### PR TITLE
feat(dash): break the cerberus error rate down by status class and failure reason

### DIFF
--- a/docs/observability.md
+++ b/docs/observability.md
@@ -304,6 +304,22 @@ for a code outside them). Alert on
 `cerberus_queries_total{cerberus_status_class="5xx"}` for "cerberus is
 broken" and leave `4xx` to a separate, lower-urgency rule.
 
+Both labels reach the surface on the provisioned Cerberus dashboard,
+which carries an "Errors by status class" panel
+(`sum by (cerberus_status_class) (rate(cerberus_queries_total{result="error"}[5m]))`)
+beside an "Errors by failure reason" panel over
+`cerberus_error_reason`. The pair is what the plain "Error rate by
+language" panel above them cannot answer: that panel says a head is
+failing, these two say whether the caller or the gateway is at fault
+and which failure mode is behind it. The dashboard ships in three
+hand-maintained copies — the k3d source at
+`test/e2e/grafana/dashboards/cerberus.json`, the ConfigMap literal in
+`test/e2e/k3s/grafana-dashboards.yaml` that the k3d stack actually
+serves, and the compose copy at
+`test/e2e/grafana/compose/dashboards/cerberus.json` — held in lockstep
+by `test/regression/grafana_dashboard_copy_parity_test.go`, so a panel
+added to one is a failure until it is added to all three.
+
 #### Duration buckets
 
 The duration ladders are explicit (the SDK default is

--- a/test/e2e/grafana/compose/dashboards/cerberus.json
+++ b/test/e2e/grafana/compose/dashboards/cerberus.json
@@ -469,6 +469,188 @@
     },
     {
       "datasource": {
+        "type": "prometheus",
+        "uid": "cerberus-prometheus"
+      },
+      "description": "Error rate split by HTTP status family — the cerberus_status_class label on cerberus_queries_total, filtered to result=error. Separates a caller-side 4xx spike (queries cerberus cannot answer as written) from a 5xx spike (cerberus failed to answer something valid). Alert on 5xx; 4xx belongs to a lower-urgency rule.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 30,
+            "gradientMode": "opacity",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "normal"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 12,
+        "x": 0,
+        "y": 24
+      },
+      "id": 6,
+      "options": {
+        "legend": {
+          "calcs": ["mean", "max", "lastNotNull"],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "cerberus-prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sum by (cerberus_status_class) (rate(cerberus_queries_total{result=\"error\"}[5m]))",
+          "legendFormat": "{{cerberus_status_class}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Errors by status class",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "cerberus-prometheus"
+      },
+      "description": "Error rate split by the closed cerberus_error_reason enum on cerberus_queries_total — bad_request, backend_unavailable, resource_exhausted, timeout, internal. Names WHY the errors in the status-class panel happened; internal is the page-worthy one. Admission-control rejections are absent by construction: the limiter sits outside the query pipeline and reports on the Admission rejections panel instead.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 30,
+            "gradientMode": "opacity",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "normal"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 12,
+        "x": 12,
+        "y": 24
+      },
+      "id": 8,
+      "options": {
+        "legend": {
+          "calcs": ["mean", "max", "lastNotNull"],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "cerberus-prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sum by (cerberus_error_reason) (rate(cerberus_queries_total{result=\"error\"}[5m]))",
+          "legendFormat": "{{cerberus_error_reason}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Errors by failure reason",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
         "type": "tempo",
         "uid": "cerberus-tempo"
       },

--- a/test/e2e/grafana/dashboards/cerberus.json
+++ b/test/e2e/grafana/dashboards/cerberus.json
@@ -469,6 +469,188 @@
     },
     {
       "datasource": {
+        "type": "prometheus",
+        "uid": "cerberus-prometheus"
+      },
+      "description": "Error rate split by HTTP status family — the cerberus_status_class label on cerberus_queries_total, filtered to result=error. Separates a caller-side 4xx spike (queries cerberus cannot answer as written) from a 5xx spike (cerberus failed to answer something valid). Alert on 5xx; 4xx belongs to a lower-urgency rule.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 30,
+            "gradientMode": "opacity",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "normal"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 12,
+        "x": 0,
+        "y": 24
+      },
+      "id": 6,
+      "options": {
+        "legend": {
+          "calcs": ["mean", "max", "lastNotNull"],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "cerberus-prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sum by (cerberus_status_class) (rate(cerberus_queries_total{result=\"error\"}[5m]))",
+          "legendFormat": "{{cerberus_status_class}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Errors by status class",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "cerberus-prometheus"
+      },
+      "description": "Error rate split by the closed cerberus_error_reason enum on cerberus_queries_total — bad_request, backend_unavailable, resource_exhausted, timeout, internal. Names WHY the errors in the status-class panel happened; internal is the page-worthy one. Admission-control rejections are absent by construction: the limiter sits outside the query pipeline and reports on the Admission rejections panel instead.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 30,
+            "gradientMode": "opacity",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "normal"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 12,
+        "x": 12,
+        "y": 24
+      },
+      "id": 8,
+      "options": {
+        "legend": {
+          "calcs": ["mean", "max", "lastNotNull"],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "cerberus-prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sum by (cerberus_error_reason) (rate(cerberus_queries_total{result=\"error\"}[5m]))",
+          "legendFormat": "{{cerberus_error_reason}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Errors by failure reason",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
         "type": "tempo",
         "uid": "cerberus-tempo"
       },

--- a/test/e2e/k3s/grafana-dashboards.yaml
+++ b/test/e2e/k3s/grafana-dashboards.yaml
@@ -505,6 +505,188 @@ data:
         },
         {
           "datasource": {
+            "type": "prometheus",
+            "uid": "cerberus-prometheus"
+          },
+          "description": "Error rate split by HTTP status family — the cerberus_status_class label on cerberus_queries_total, filtered to result=error. Separates a caller-side 4xx spike (queries cerberus cannot answer as written) from a 5xx spike (cerberus failed to answer something valid). Alert on 5xx; 4xx belongs to a lower-urgency rule.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 30,
+                "gradientMode": "opacity",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "lineInterpolation": "linear",
+                "lineWidth": 2,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "never",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "normal"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  }
+                ]
+              },
+              "unit": "reqps"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 10,
+            "w": 12,
+            "x": 0,
+            "y": 24
+          },
+          "id": 6,
+          "options": {
+            "legend": {
+              "calcs": ["mean", "max", "lastNotNull"],
+              "displayMode": "table",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "desc"
+            }
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "cerberus-prometheus"
+              },
+              "editorMode": "code",
+              "expr": "sum by (cerberus_status_class) (rate(cerberus_queries_total{result=\"error\"}[5m]))",
+              "legendFormat": "{{cerberus_status_class}}",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Errors by status class",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "cerberus-prometheus"
+          },
+          "description": "Error rate split by the closed cerberus_error_reason enum on cerberus_queries_total — bad_request, backend_unavailable, resource_exhausted, timeout, internal. Names WHY the errors in the status-class panel happened; internal is the page-worthy one. Admission-control rejections are absent by construction: the limiter sits outside the query pipeline and reports on the Admission rejections panel instead.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 30,
+                "gradientMode": "opacity",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "lineInterpolation": "linear",
+                "lineWidth": 2,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "never",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "normal"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  }
+                ]
+              },
+              "unit": "reqps"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 10,
+            "w": 12,
+            "x": 12,
+            "y": 24
+          },
+          "id": 8,
+          "options": {
+            "legend": {
+              "calcs": ["mean", "max", "lastNotNull"],
+              "displayMode": "table",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "desc"
+            }
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "cerberus-prometheus"
+              },
+              "editorMode": "code",
+              "expr": "sum by (cerberus_error_reason) (rate(cerberus_queries_total{result=\"error\"}[5m]))",
+              "legendFormat": "{{cerberus_error_reason}}",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Errors by failure reason",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
             "type": "tempo",
             "uid": "cerberus-tempo"
           },

--- a/test/regression/grafana_dashboard_copy_parity_test.go
+++ b/test/regression/grafana_dashboard_copy_parity_test.go
@@ -1,0 +1,328 @@
+package regression
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"reflect"
+	"sort"
+	"strings"
+	"testing"
+)
+
+// The cerberus self-observability dashboard exists in three places, and every
+// one of them is hand-maintained:
+//
+//   - test/e2e/grafana/dashboards/cerberus.json — the k3d editable copy.
+//   - test/e2e/k3s/grafana-dashboards.yaml — the k3d DEPLOYED copy, the same
+//     JSON embedded as a ConfigMap literal. This is what Grafana serves in the
+//     k3d stack; the file above is never mounted.
+//   - test/e2e/grafana/compose/dashboards/cerberus.json — the compose copy,
+//     mounted straight into Grafana by docker-compose.yml.
+//
+// Nothing generated any of them and nothing copies one to another, so the three
+// drift silently and asymmetrically. The failure mode is specifically quiet:
+// iterate-all-dashboards.spec.ts probes panel expressions read FROM DISK while
+// the browser renders what the stack actually SERVES, so a panel added to the
+// editable copy but not to the ConfigMap passes its own probe against a
+// dashboard that does not contain it. An operator on k3d then sees a board that
+// is missing the panel CI just declared green.
+//
+// These tests are the gate that comment asks for.
+const (
+	dashboardK3dPath     = "../../test/e2e/grafana/dashboards/cerberus.json"
+	dashboardComposePath = "../../test/e2e/grafana/compose/dashboards/cerberus.json"
+	dashboardConfigMap   = "../../test/e2e/k3s/grafana-dashboards.yaml"
+
+	// configMapJSONKey is the ConfigMap data key whose block scalar holds the
+	// dashboard, and configMapJSONIndent is the block's indentation. A YAML
+	// block scalar under a `data:` mapping is indented one level past the key,
+	// which at this file's two-space step is four columns.
+	configMapJSONKey    = "cerberus.json: |"
+	configMapJSONIndent = "    "
+
+	// maxReportedDiffs bounds the failure message. A drifted pair usually
+	// differs in one panel; printing every path in a wholesale rewrite would
+	// bury the first, actionable one.
+	maxReportedDiffs = 10
+)
+
+// TestK3dDashboardConfigMapMatchesItsSourceFile pins the k3d editable copy
+// against the ConfigMap literal that is actually deployed. The relationship is
+// byte-for-byte: the ConfigMap block is the source file with every line
+// indented by configMapJSONIndent, which is what makes the drift mechanically
+// checkable rather than a review convention.
+func TestK3dDashboardConfigMapMatchesItsSourceFile(t *testing.T) {
+	t.Parallel()
+
+	source, err := os.ReadFile(dashboardK3dPath)
+	if err != nil {
+		t.Fatalf("read dashboard source %s: %v", dashboardK3dPath, err)
+	}
+	raw, err := os.ReadFile(dashboardConfigMap)
+	if err != nil {
+		t.Fatalf("read ConfigMap %s: %v", dashboardConfigMap, err)
+	}
+
+	embedded, err := configMapEmbeddedDashboard(string(raw))
+	if err != nil {
+		t.Fatalf("extract %s from %s: %v", configMapJSONKey, dashboardConfigMap, err)
+	}
+
+	if embedded == string(source) {
+		return
+	}
+
+	// Report at the JSON level when both sides parse — a panel-level path is
+	// far more actionable than a line number into an indented blob — and fall
+	// back to the byte verdict when one side is not valid JSON.
+	var srcDoc, embDoc any
+	srcErr := json.Unmarshal(source, &srcDoc)
+	embErr := json.Unmarshal([]byte(embedded), &embDoc)
+	if srcErr == nil && embErr == nil {
+		if diffs := jsonDiffPaths("", srcDoc, embDoc); len(diffs) > 0 {
+			t.Errorf("%s is out of sync with %s at %d path(s):\n  - %s\n"+
+				"The ConfigMap is the copy k3d actually serves. Re-embed the source file: "+
+				"indent every line of %s by %d spaces and replace the `%s` block.",
+				dashboardConfigMap, dashboardK3dPath, len(diffs),
+				strings.Join(diffs, "\n  - "),
+				dashboardK3dPath, len(configMapJSONIndent), configMapJSONKey)
+			return
+		}
+	}
+
+	t.Errorf("%s and %s carry the same JSON but differ byte-for-byte (formatting drift).\n"+
+		"The ConfigMap block must be the source file indented by %d spaces, so the two stay diffable. "+
+		"Re-embed the source file into the `%s` block.",
+		dashboardConfigMap, dashboardK3dPath, len(configMapJSONIndent), configMapJSONKey)
+}
+
+// TestComposeAndK3dDashboardsCarryTheSamePanels pins the two mounted copies
+// against each other. They are deliberately NOT byte-identical: each carries a
+// `description` naming the data its own stack ships, and that is the only
+// divergence the split justifies. Everything an operator reads — the panel set,
+// their ids, titles, expressions, units and grid positions — has to be the
+// same board on both substrates, or "it works on compose" stops meaning
+// anything about k3d.
+func TestComposeAndK3dDashboardsCarryTheSamePanels(t *testing.T) {
+	t.Parallel()
+
+	k3d := readDashboardBody(t, dashboardK3dPath)
+	compose := readDashboardBody(t, dashboardComposePath)
+
+	// The per-stack description is the sanctioned difference; assert it is
+	// actually present on both rather than deleting a key that silently is not
+	// there, which would let a dropped description pass as parity.
+	for path, doc := range map[string]map[string]any{
+		dashboardK3dPath:     k3d,
+		dashboardComposePath: compose,
+	} {
+		desc, ok := doc["description"].(string)
+		if !ok || strings.TrimSpace(desc) == "" {
+			t.Fatalf("%s has no top-level description; the per-stack description is the one "+
+				"sanctioned difference between the two copies and must exist on both", path)
+		}
+		delete(doc, "description")
+	}
+
+	if reflect.DeepEqual(k3d, compose) {
+		return
+	}
+	diffs := jsonDiffPaths("", k3d, compose)
+	t.Errorf("%s and %s diverge at %d path(s) outside the sanctioned `description`:\n  - %s\n"+
+		"Both stacks provision the same board; a panel added to one must be added to the other "+
+		"(and re-embedded into %s).",
+		dashboardK3dPath, dashboardComposePath, len(diffs),
+		strings.Join(diffs, "\n  - "), dashboardConfigMap)
+}
+
+func readDashboardBody(t *testing.T, path string) map[string]any {
+	t.Helper()
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read dashboard %s: %v", path, err)
+	}
+	var doc map[string]any
+	if err := json.Unmarshal(raw, &doc); err != nil {
+		t.Fatalf("parse dashboard %s: %v", path, err)
+	}
+	return doc
+}
+
+// configMapEmbeddedDashboard returns the dashboard JSON carried by the
+// configMapJSONKey block scalar, with the block indentation stripped. It errors
+// rather than returning a partial document when the block is absent or a line
+// is under-indented, so a restructured ConfigMap fails loudly instead of
+// silently comparing an empty string.
+func configMapEmbeddedDashboard(yaml string) (string, error) {
+	lines := strings.Split(yaml, "\n")
+	start := -1
+	for i, line := range lines {
+		if strings.TrimSpace(line) == configMapJSONKey {
+			start = i + 1
+			break
+		}
+	}
+	if start < 0 {
+		return "", fmt.Errorf("no `%s` block found", configMapJSONKey)
+	}
+
+	body := lines[start:]
+	// A block scalar ends at the first line indented less than the block, or at
+	// end of file. Trailing blank lines belong to the file, not the scalar.
+	end := len(body)
+	for i, line := range body {
+		if line == "" {
+			continue
+		}
+		if !strings.HasPrefix(line, configMapJSONIndent) {
+			end = i
+			break
+		}
+	}
+	body = body[:end]
+	for len(body) > 0 && body[len(body)-1] == "" {
+		body = body[:len(body)-1]
+	}
+	if len(body) == 0 {
+		return "", fmt.Errorf("`%s` block is empty", configMapJSONKey)
+	}
+
+	out := make([]string, len(body))
+	for i, line := range body {
+		out[i] = strings.TrimPrefix(line, configMapJSONIndent)
+	}
+	return strings.Join(out, "\n") + "\n", nil
+}
+
+// jsonDiffPaths walks two decoded JSON documents in lockstep and returns the
+// paths at which they differ, capped at maxReportedDiffs. Paths are dotted for
+// object keys and bracketed for array indices, and a panel's own `id` is
+// appended to its index so the caller reads "panels[6] (id=8)" rather than an
+// ordinal they would have to count out by hand.
+func jsonDiffPaths(path string, a, b any) []string {
+	var out []string
+	appendDiff := func(p, msg string) {
+		if len(out) < maxReportedDiffs {
+			out = append(out, fmt.Sprintf("%s: %s", pathOrRoot(p), msg))
+		}
+	}
+
+	switch av := a.(type) {
+	case map[string]any:
+		bv, ok := b.(map[string]any)
+		if !ok {
+			appendDiff(path, fmt.Sprintf("object on one side, %s on the other", jsonKind(b)))
+			return out
+		}
+		keys := make([]string, 0, len(av)+len(bv))
+		seen := make(map[string]bool, len(av)+len(bv))
+		for k := range av {
+			keys, seen[k] = append(keys, k), true
+		}
+		for k := range bv {
+			if !seen[k] {
+				keys = append(keys, k)
+			}
+		}
+		sort.Strings(keys)
+		for _, k := range keys {
+			ae, aok := av[k]
+			be, bok := bv[k]
+			switch {
+			case aok && !bok:
+				appendDiff(joinPath(path, k), "present on the first, missing on the second")
+			case !aok && bok:
+				appendDiff(joinPath(path, k), "missing on the first, present on the second")
+			default:
+				out = appendCapped(out, jsonDiffPaths(joinPath(path, k), ae, be))
+			}
+			if len(out) >= maxReportedDiffs {
+				return out
+			}
+		}
+		return out
+
+	case []any:
+		bv, ok := b.([]any)
+		if !ok {
+			appendDiff(path, fmt.Sprintf("array on one side, %s on the other", jsonKind(b)))
+			return out
+		}
+		if len(av) != len(bv) {
+			appendDiff(path, fmt.Sprintf("%d element(s) vs %d", len(av), len(bv)))
+			return out
+		}
+		for i := range av {
+			out = appendCapped(out, jsonDiffPaths(indexPath(path, i, av[i]), av[i], bv[i]))
+			if len(out) >= maxReportedDiffs {
+				return out
+			}
+		}
+		return out
+
+	default:
+		if !reflect.DeepEqual(a, b) {
+			appendDiff(path, fmt.Sprintf("%s vs %s", jsonScalar(a), jsonScalar(b)))
+		}
+		return out
+	}
+}
+
+func appendCapped(dst, src []string) []string {
+	for _, s := range src {
+		if len(dst) >= maxReportedDiffs {
+			return dst
+		}
+		dst = append(dst, s)
+	}
+	return dst
+}
+
+func joinPath(path, key string) string {
+	if path == "" {
+		return key
+	}
+	return path + "." + key
+}
+
+// indexPath labels an array element by its position, plus the element's own
+// `id` when it carries one — the dashboards' panel arrays are id-keyed, and the
+// id is what a reader searches the JSON for.
+func indexPath(path string, i int, elem any) string {
+	label := fmt.Sprintf("%s[%d]", path, i)
+	if obj, ok := elem.(map[string]any); ok {
+		if id, ok := obj["id"]; ok {
+			label += fmt.Sprintf(" (id=%s)", jsonScalar(id))
+		}
+	}
+	return label
+}
+
+func pathOrRoot(path string) string {
+	if path == "" {
+		return "<root>"
+	}
+	return path
+}
+
+func jsonKind(v any) string {
+	switch v.(type) {
+	case map[string]any:
+		return "object"
+	case []any:
+		return "array"
+	case nil:
+		return "null"
+	default:
+		return "scalar"
+	}
+}
+
+func jsonScalar(v any) string {
+	b, err := json.Marshal(v)
+	if err != nil {
+		return fmt.Sprintf("%v", v)
+	}
+	return string(b)
+}


### PR DESCRIPTION
## Why

`cerberus_queries_total` has carried `cerberus.status_class` and `cerberus.error_reason` since the
failure classification landed, and until now nothing read either one. The Cerberus board collapsed
every failure into a single `result="error"` ratio, so a bad-query spike and a ClickHouse outage
rendered as the same line — the operator saw the number they would have seen before the
classification existed, and separating the two meant hand-writing PromQL.

## What

Two panels, filling the empty grid band between "Admission rejections" and the trace table:

| Panel | Expression | Answers |
| ----- | ---------- | ------- |
| Errors by status class | `sum by (cerberus_status_class) (rate(cerberus_queries_total{result="error"}[5m]))` | Whose fault — 4xx is a caller sending queries cerberus cannot answer, 5xx is cerberus failing to answer valid ones |
| Errors by failure reason | `sum by (cerberus_error_reason) (rate(cerberus_queries_total{result="error"}[5m]))` | Which failure mode — `bad_request` / `backend_unavailable` / `resource_exhausted` / `timeout` / `internal` |

Both reuse the existing "Admission rejections" panel's shape exactly (stacked `reqps` timeseries,
`palette-classic`, table legend with mean/max/last), so they read as part of the board.

Neither carries a `cerberus.expect` declaration — this is an ops-family dashboard, so both take the
default `nonempty` contract and `iterate-all-dashboards` asserts they return data. They do:
`generateSelfTraffic` already fires deliberately malformed queries at all three heads, which is what
populates the `4xx` / `bad_request` buckets.

## The three-copy gate

The board ships in three hand-maintained copies, and only a YAML comment asked anyone to keep them
together:

- `test/e2e/grafana/dashboards/cerberus.json` — the k3d editable copy
- `test/e2e/k3s/grafana-dashboards.yaml` — the ConfigMap literal the k3d stack actually serves
- `test/e2e/grafana/compose/dashboards/cerberus.json` — the compose copy

That split is quiet by construction: `iterate-all-dashboards` probes expressions read from disk while
the browser renders what the stack serves, so a panel added to the source file but absent from the
ConfigMap passes its own probe against a board that does not contain it. All three copies get the
panels here, and `test/regression/grafana_dashboard_copy_parity_test.go` now holds them in lockstep —
byte parity for the ConfigMap against its source, structural parity between the two mounted copies
with the per-stack `description` as the one sanctioned difference.

## Verification

- The new gate was checked in both directions, not just for green: injecting an expression change
  into the compose copy alone and a title change into the ConfigMap alone each produced a targeted
  failure naming the exact path (`panels[5] (id=6).targets[0].expr`, `panels[5] (id=6).title`), and
  the real tree is green.
- Both expressions were fired against a live cerberus + ClickHouse and resolve to the full taxonomy:
  `cerberus_status_class` returns `2xx` / `4xx` / `5xx` and `cerberus_error_reason` returns
  `bad_request` / `backend_unavailable`, so the panels have series to draw rather than "No data".
- `docs/observability.md` now names the dashboard consumer next to the taxonomy it documents, and
  points at the parity gate.

Closes #1466
