### PR TITLE
fix(logql): give log streams their own scan shape instead of a padding column

### DIFF
--- a/docs/engine.md
+++ b/docs/engine.md
@@ -92,11 +92,14 @@ type Lang interface {
   TimeUnix, Value)`. Each head's per-shape switch
   (canonical / derived / structural-join) lives in the adapter,
   not in the engine. The shape is *positional*: the Loki
-  log-stream projection reuses the same four/five-column scan with
-  a log line in the first, String-typed column (aliased
-  `logql.LogLineColumn`) and a placeholder in the Float64 one, and
-  `chclient.DecodeLogRows` decodes that row into the named
-  `chclient.LogRow` the streams pivot consumes.
+  log-stream projection is `(Line, Attributes, TimeUnix)`, plus a
+  trailing `Metadata` column on a schema that carries structured
+  metadata. It puts the log line in the first, String-typed column
+  (aliased `logql.LogLineColumn`) and carries no numeric column at
+  all, because a log stream has no value to report. The cursor
+  recognises the shape by that leading alias and binds a scan with
+  no float destination; `chclient.DecodeLogRows` then decodes the
+  row into the named `chclient.LogRow` the streams pivot consumes.
 
 ### `Meta`
 

--- a/internal/api/loki/tail.go
+++ b/internal/api/loki/tail.go
@@ -307,17 +307,19 @@ func writeTailChunk(conn *websocket.Conn, streams []Stream, writeTimeout time.Du
 // buildTailSQL constructs the per-tick polling SELECT. The shape is:
 //
 //	SELECT `Body` AS Line, `ResourceAttributes` AS Attributes,
-//	       `Timestamp` AS TimeUnix, toFloat64(0) AS Value
+//	       `Timestamp` AS TimeUnix
 //	FROM `otel_logs`
 //	WHERE <matchers> AND `Timestamp` >= <cursor> AND `Timestamp` <= <end>
 //	ORDER BY `Timestamp` ASC
 //	LIMIT <n>
 //
 // That is the log-stream projection shape [logql.LogLineColumn] names:
-// the line takes the positional row's first, String-typed column and the
-// Float64 column takes a placeholder, and chclient.DecodeLogRows decodes
-// the row into chclient.LogRow. All identifiers and time-range bounds
-// flow through chsql.QueryBuilder — no fmt.Sprintf-on-SQL.
+// the line takes the positional row's first, String-typed column, and
+// there is no numeric column at all — a log stream has no value, so the
+// cursor recognises the leading alias and binds no float destination
+// (issue #1430). chclient.DecodeLogRows decodes the row into
+// chclient.LogRow. All identifiers and time-range bounds flow through
+// chsql.QueryBuilder — no fmt.Sprintf-on-SQL.
 //
 // Rows are sorted ascending so the runTailLoop cursor-advance logic
 // picks the genuinely latest sample. Without ORDER BY the LIMIT could
@@ -330,7 +332,6 @@ func buildTailSQL(s schema.Logs, matchers []*labels.Matcher, cursor, end time.Ti
 			chsql.As(chsql.Col(s.BodyColumn), logql.LogLineColumn),
 			chsql.As(chsql.Col(s.ResourceAttributesColumn), "Attributes"),
 			chsql.As(chsql.Col(s.TimestampColumn), "TimeUnix"),
-			chsql.As(toFloat64Zero(), "Value"),
 		).
 		From(chsql.Col(s.LogsTable))
 
@@ -348,15 +349,6 @@ func buildTailSQL(s schema.Logs, matchers []*labels.Matcher, cursor, end time.Ti
 
 	sqlStr, args := sb.Build()
 	return sqlStr, args, nil
-}
-
-// toFloat64Zero is the chsql.Frag for `toFloat64(0)` — used as the
-// placeholder Value column so the positional row scanner reads a
-// stable Float64 instead of CH's UInt8 default for a bare literal `0`.
-// Composed via the typed Call constructor wrapping a Lit(0) argument;
-// the 0 binds as a positional `?` and CH coerces it inside toFloat64.
-func toFloat64Zero() chsql.Frag {
-	return chsql.Call("toFloat64", chsql.Lit(0))
 }
 
 // parseTailDelayFor reads the optional `delay_for` query param.

--- a/internal/api/loki/tail_test.go
+++ b/internal/api/loki/tail_test.go
@@ -292,12 +292,25 @@ func TestTail_SQLShape(t *testing.T) {
 		"`Body` AS `Line`",
 		"`ResourceAttributes` AS `Attributes`",
 		"`Timestamp` AS `TimeUnix`",
-		"toFloat64(?) AS `Value`",
 		"ORDER BY `Timestamp`",
 		"LIMIT 100",
 	} {
 		if !strings.Contains(sqlStr, frag) {
 			t.Errorf("expected SQL to contain %q, got %q", frag, sqlStr)
+		}
+	}
+	// The tail projection is the log-stream shape: line, labels, timestamp
+	// and nothing else. It carries no numeric column, because a log stream
+	// has no value — the cursor recognises the leading `Line` alias and
+	// binds no float destination (issue #1430). Pinning the ABSENCE keeps a
+	// placeholder from creeping back in under any alias.
+	for _, frag := range []string{
+		"toFloat64(",
+		"AS `Value`",
+	} {
+		if strings.Contains(sqlStr, frag) {
+			t.Errorf("tail SQL must not contain %q — the log-stream projection carries "+
+				"no numeric placeholder column (issue #1430); got %q", frag, sqlStr)
 		}
 	}
 }

--- a/internal/chclient/client.go
+++ b/internal/chclient/client.go
@@ -1187,8 +1187,10 @@ type Sample struct {
 	Labels     map[string]string
 	Timestamp  time.Time
 	// Value is the projection's fourth, Float64 column: the metric value.
-	// A log-stream projection has no numeric value and binds a constant
-	// placeholder here; [DecodeLogRows] drops it.
+	// A log-stream projection has no numeric value, so it projects no
+	// fourth column at all and the log-row scan binds no destination for
+	// this field — it stays zero on that path, and [DecodeLogRows] has no
+	// slot for it (issue #1430).
 	Value float64
 	// SeriesID is a stable, per-cursor identity for the interned Labels
 	// map: every Sample whose Labels alias the same interned instance
@@ -1209,11 +1211,12 @@ type Sample struct {
 	SeriesID uint32
 	// Metadata carries per-row structured metadata for Loki log-stream
 	// queries — the OTel-CH LogAttributes map surfaced as the third
-	// element of Loki's `[ts, line, {metadata}]` value tuple. It is
-	// populated only when the projection emits a fifth `Metadata` column
-	// (the log-stream path), and stays nil for every metric query and
-	// for the prom / tempo heads, whose four-column projections leave the
-	// shared cursor's 4-column scan path untouched.
+	// element of Loki's `[ts, line, {metadata}]` value tuple. Structured
+	// metadata is a log-stream concept: it is populated only on the
+	// log-row layout that emits a trailing `Metadata` column, and stays
+	// nil for every metric query and for the prom / tempo heads, whose
+	// four-column projections leave the shared cursor's sample-shaped scan
+	// path untouched.
 	Metadata map[string]string
 	// Histogram carries a decoded OTel exponential (native) histogram
 	// value — the shape a histogram-VALUED PromQL result (`rate()`,

--- a/internal/chclient/columnar.go
+++ b/internal/chclient/columnar.go
@@ -39,8 +39,9 @@ import (
 // matrixColumns is the four-column projection the prom `query_range` matrix
 // pivot drains: MetricName, the Attributes Map(String,String), TimeUnix, and
 // Value, in that order. The columnar path engages ONLY when a result block's
-// shape matches this exactly; any other shape (the five-column Loki log-stream
-// projection, the metadata endpoints) falls back to the row path.
+// shape matches this exactly; any other shape (the Loki log-stream
+// projection, which leads with `Line` and carries no Value column at all, or
+// the metadata endpoints) falls back to the row path.
 //
 // This is a name/type collision test, not a proof of intent: a future
 // projection that happens to reuse these four names and types (e.g. a
@@ -411,8 +412,9 @@ type timeColumn interface {
 }
 
 // bindColumns type-asserts the Auto-inferred result columns into the matrix
-// shape. A mismatch (wrong count, wrong names, wrong types — e.g. the
-// five-column Loki projection) reports false so the caller falls back.
+// shape. A mismatch (wrong count, wrong names, wrong types — e.g. the Loki
+// log-stream projection, whose first column is `Line`) reports false so the
+// caller falls back.
 //
 // This ANDs two independent checks (#1429): the structural name/type test
 // below, unchanged, PLUS — when the caller declared a ResponseShape — a
@@ -426,8 +428,10 @@ func (d *columnarCursor) bindColumns() (matrixCols, bool) {
 		return matrixCols{}, false
 	}
 	// Two column counts are the matrix shape: the base four, and the base
-	// four plus the nine histogram columns. Anything else (the five-column
-	// Loki log-stream projection, the metadata endpoints) falls back.
+	// four plus the nine histogram columns. Anything else falls back. The
+	// log-stream projection can share the base COUNT (Line, Attributes,
+	// TimeUnix, Metadata is four wide), so it is the per-column name test
+	// below — not the count — that declines it.
 	histogramShaped := false
 	switch len(d.results) {
 	case len(matrixColumns):

--- a/internal/chclient/cursor.go
+++ b/internal/chclient/cursor.go
@@ -184,44 +184,105 @@ type rowsCursor struct {
 	// path that also calls Close).
 	closeOnce sync.Once
 	closeErr  error
-	// metadataProbed latches the one-time column-shape probe (see
-	// [rowsCursor.scanRow]). hasMetadata records whether the projection
-	// carries a fifth `Metadata` column — the Loki log-stream path — so
-	// the scan binds five destinations (…, &metadata) instead of four.
-	// Every metric query and the prom / tempo heads project four columns,
-	// leaving hasMetadata false and the scan byte-identical to before.
-	metadataProbed bool
-	hasMetadata    bool
-	// histogramProbed / hasHistogram are the histogram-shaped sibling of
-	// metadataProbed / hasMetadata: hasHistogram records whether the
-	// projection carries the nine trailing Histogram*Column columns a
-	// chplan.HistogramProjection subquery publishes (see issue #1926),
-	// so the scan binds thirteen destinations (the base four plus the
-	// nine histogram fields) instead of four.
-	//
-	// hasHistogram latches true for the histogram-VALUED PromQL shapes —
-	// a bare exp-histogram selector, `sum()` over one, and
-	// `rate()`/`increase()` over one — and stays false, leaving the scan
-	// byte-identical to before, on every other query. Only this
-	// ROW-based cursor is no longer alone in reading those nine columns:
-	// the columnar sibling in columnar.go binds the SAME thirteen (see
-	// histogramMatrixColumns), so a histogram query keeps the columnar
-	// fast path instead of being re-dispatched to ClickHouse in full by
-	// columnarDecoder.decode's row fallback (issue #1967).
-	histogramProbed bool
-	hasHistogram    bool
+	// shapeProbed latches the one-time column-shape probe and shape holds
+	// its verdict — the positional layout every row of this result set
+	// carries. driver.Rows.Columns() is a result-set-wide property, so the
+	// decision is taken on the first row and reused for the whole stream.
+	// See [rowShape] for the layouts and [probeRowShape] for how each is
+	// recognised.
+	shapeProbed bool
+	shape       rowShape
 }
 
+// rowShape is the positional column layout a result set carries. The scan
+// [rowsCursor.Next] runs is positional, so the shape IS the decode
+// contract: it selects both how MANY destinations are bound and what each
+// one means.
+//
+// Every head emits one of these. The sample-shaped layouts lead with
+// `MetricName` and carry a numeric `Value`; the log-row layouts lead with
+// [logLineColumn] and carry no numeric column at all, because a log stream
+// has no value to report.
+type rowShape uint8
+
+const (
+	// shapeSample is the canonical four-column metric row —
+	// (MetricName, Attributes, TimeUnix, Value) — that every PromQL and
+	// TraceQL query, and every LogQL METRIC query, projects. It is the
+	// default: an unrecognised column layout decodes as this shape, which
+	// is what every path did before the probe existed.
+	shapeSample rowShape = iota
+	// shapeSampleHistogram is shapeSample plus the nine trailing
+	// Histogram*Column columns a chplan.HistogramProjection subquery
+	// publishes (issue #1926), so the scan binds thirteen destinations.
+	// It latches for the histogram-VALUED PromQL shapes — a bare
+	// exp-histogram selector, `sum()` over one, and `rate()`/`increase()`
+	// over one. This ROW-based cursor is not alone in reading those nine
+	// columns: the columnar sibling in columnar.go binds the SAME thirteen
+	// (see histogramMatrixColumns), so a histogram query keeps the
+	// columnar fast path instead of being re-dispatched to ClickHouse in
+	// full by columnarDecoder.decode's row fallback (issue #1967).
+	shapeSampleHistogram
+	// shapeLogRow is the Loki log-stream row — (Line, Attributes,
+	// TimeUnix) — which binds THREE destinations and no float at all.
+	// A log line has no numeric value, so the projection emits no Value
+	// column and [Sample.Value] stays zero on this path (issue #1430).
+	shapeLogRow
+	// shapeLogRowMetadata is shapeLogRow plus the trailing
+	// [metadataColumn]: (Line, Attributes, TimeUnix, Metadata). It is the
+	// shape a log-stream query against a schema WITH a structured-metadata
+	// column emits.
+	shapeLogRowMetadata
+)
+
 // metadataColumn is the projection alias the Loki log-stream path appends
-// as a fifth column to carry per-row structured metadata (the OTel-CH
+// as a TRAILING column to carry per-row structured metadata (the OTel-CH
 // LogAttributes map) into [Sample.Metadata]. The shared cursor probes the
 // result-set columns for this name once and adapts its positional scan.
+//
+// Structured metadata is a log-stream concept: it rides only on the
+// [shapeLogRowMetadata] layout, never on a sample row. No head projects a
+// metric result with metadata attached, so there is no such layout to
+// decode.
 const metadataColumn = "Metadata"
+
+// logLineColumn is the FIRST projection alias a Loki log-stream query
+// binds its log line to (the literal internal/logql.LogLineColumn emits).
+// It is the marker [probeRowShape] keys the log-row layouts off: a log
+// stream has no numeric value, so its projection is
+// (Line, Attributes, TimeUnix[, Metadata]) with NO Value column, versus
+// the (MetricName, Attributes, TimeUnix, Value[, …]) every metric query on
+// all three heads emits.
+//
+// chclient may not import logql (see .go-arch-lint.yml: chclient declares
+// no internal dependencies), so this string is duplicated by convention
+// rather than imported — the same pairing metadataColumn and
+// histogramLastColumn already have with their emitter-side aliases.
+// Changing logql.LogLineColumn requires changing this literal too;
+// TestLogLineColumn_MatchesCursorProbeLiteral in internal/logql pins
+// the pair.
+const logLineColumn = "Line"
+
+// logRowColumns is the width of the bare [shapeLogRow] projection —
+// (Line, Attributes, TimeUnix) — and logRowMetadataColumns the width of
+// its [shapeLogRowMetadata] sibling, which appends [metadataColumn].
+// The probe matches on the exact width as well as the alias names so a
+// wider projection that merely happens to lead with `Line` is never
+// mistaken for a log row.
+const (
+	logRowColumns         = 3
+	logRowMetadataColumns = 4
+)
+
+// sampleColumns is the width of the canonical [shapeSample] projection:
+// (MetricName, Attributes, TimeUnix, Value).
+const sampleColumns = 4
 
 // histogramColumnCount is the number of trailing columns a
 // chplan.HistogramProjection subquery appends after the base four —
 // the nine Histogram*Column output aliases. The scan binds
-// 4+histogramColumnCount destinations when hasHistogram latches true.
+// sampleColumns+histogramColumnCount destinations when the probe
+// resolves [shapeSampleHistogram].
 const histogramColumnCount = 9
 
 // histogramLastColumn is the LAST of the nine Histogram*Column aliases
@@ -237,6 +298,39 @@ const histogramColumnCount = 9
 // internal/logql/lang.go emits. Changing chplan.HistogramNegativeBucketCountsColumn
 // requires changing this literal too.
 const histogramLastColumn = "HistogramNegativeBucketCounts"
+
+// probeRowShape resolves a result set's positional layout from its column
+// names. cols is driver.Rows.Columns() — the emitter's output aliases, in
+// projection order.
+//
+// The log-row layouts are recognised by their FIRST alias
+// ([logLineColumn]) together with an exact width, because they are the two
+// layouts with no numeric column: matching on width alone would confuse
+// (Line, Attributes, TimeUnix, Metadata) with the four-column sample
+// shape, and matching on the leading alias alone would misread any wider
+// projection that happened to lead with `Line`. The sample-shaped
+// extensions are recognised by their trailing alias, as they always have
+// been, plus the width the scan they select actually binds — the two are
+// the same statement, and pairing them keeps a merely-similar projection
+// from selecting a scan wider than its result set.
+//
+// An unrecognised layout resolves to [shapeSample], the four-destination
+// scan every path ran before any probe existed.
+func probeRowShape(cols []string) rowShape {
+	if len(cols) == 0 {
+		return shapeSample
+	}
+	last := cols[len(cols)-1]
+	switch {
+	case len(cols) == logRowColumns && cols[0] == logLineColumn:
+		return shapeLogRow
+	case len(cols) == logRowMetadataColumns && cols[0] == logLineColumn && last == metadataColumn:
+		return shapeLogRowMetadata
+	case len(cols) == sampleColumns+histogramColumnCount && last == histogramLastColumn:
+		return shapeSampleHistogram
+	}
+	return shapeSample
+}
 
 // Next advances the cursor to the next row. Returns false when the
 // stream is exhausted or when a decode error occurred; in the error case
@@ -260,34 +354,24 @@ func (c *rowsCursor) Next() bool {
 	}
 	var s Sample
 	var labels map[string]string
-	// metadataJSON receives the fifth `Metadata` column when present: the
-	// log-stream projection renders the filtered LogAttributes map via
+	// metadataJSON receives the trailing `Metadata` column when present:
+	// the log-stream projection renders the filtered LogAttributes map via
 	// `toJSONString(...)`, so it scans as a plain `String` (a JSON object)
 	// rather than a raw `Map(String, String)`. A native Map column scans
 	// on prod ClickHouse but NOT under the chDB probe lane (chdb-go's
 	// Parquet driver can't cast a Map — see chdb_probe_test.go); the JSON
 	// string scans cleanly on both, and is json.Unmarshal'd back below.
 	var metadataJSON string
-	// Probe the result-set shape once: the Loki log-stream projection
-	// appends a fifth `Metadata` column, a chplan.HistogramProjection
-	// subquery appends nine Histogram*Column columns (issue #1926 —
-	// taken by the histogram-valued PromQL shapes, see hasHistogram),
-	// every other path projects four.
-	// driver.Rows.Columns() is stable across the stream, so latch the
-	// decision on the first row and bind the scan accordingly.
-	if !c.metadataProbed {
-		cols := c.rows.Columns()
-		c.hasMetadata = len(cols) > 0 && cols[len(cols)-1] == metadataColumn
-		c.metadataProbed = true
-	}
-	if !c.histogramProbed {
-		cols := c.rows.Columns()
-		c.hasHistogram = len(cols) > 0 && cols[len(cols)-1] == histogramLastColumn
-		c.histogramProbed = true
+	// Probe the result-set shape once. driver.Rows.Columns() is stable
+	// across the stream, so latch the decision on the first row and bind
+	// the scan accordingly for every row after it.
+	if !c.shapeProbed {
+		c.shape = probeRowShape(c.rows.Columns())
+		c.shapeProbed = true
 	}
 	var hv HistogramValue
-	switch {
-	case c.hasHistogram:
+	switch c.shape {
+	case shapeSampleHistogram:
 		if err := c.rows.Scan(
 			&s.MetricName, &labels, &s.Timestamp, &s.Value,
 			&hv.Count, &hv.Sum, &hv.Scale, &hv.ZeroThreshold, &hv.ZeroCount,
@@ -298,8 +382,19 @@ func (c *rowsCursor) Next() bool {
 			return false
 		}
 		s.Histogram = &hv
-	case c.hasMetadata:
-		if err := c.rows.Scan(&s.MetricName, &labels, &s.Timestamp, &s.Value, &metadataJSON); err != nil {
+	// The two log-row layouts bind NO numeric destination: a log stream has
+	// no value, so the projection carries no Value column and s.Value stays
+	// zero. The line lands in s.MetricName — the positional row's first,
+	// String-typed slot, which a metric query fills with the metric name —
+	// and [DecodeLogRows] is the single place that positional knowledge
+	// becomes the named [LogRow] fields consumers read.
+	case shapeLogRow:
+		if err := c.rows.Scan(&s.MetricName, &labels, &s.Timestamp); err != nil {
+			c.err = fmt.Errorf("chclient: scan: %w", err)
+			return false
+		}
+	case shapeLogRowMetadata:
+		if err := c.rows.Scan(&s.MetricName, &labels, &s.Timestamp, &metadataJSON); err != nil {
 			c.err = fmt.Errorf("chclient: scan: %w", err)
 			return false
 		}
@@ -344,11 +439,12 @@ func (c *rowsCursor) Next() bool {
 	}
 	// Per-row structured metadata is genuinely distinct per log line
 	// (durations, byte counts, query ids), so it is NOT interned — unlike
-	// the series-identity Labels map. The fifth column arrives as a JSON
+	// the series-identity Labels map. The trailing column arrives as a JSON
 	// object string (`toJSONString` of the filtered LogAttributes map);
 	// decode it back to a map. An empty / `{}` payload leaves Metadata
 	// nil, so [StreamValue.MarshalJSON] falls back to the two-element
-	// `[ts, line]` tuple. Left nil entirely on the four-column path.
+	// `[ts, line]` tuple. Left nil entirely on the layouts that carry no
+	// [metadataColumn].
 	if metadata := decodeMetadataJSON(metadataJSON); len(metadata) > 0 {
 		s.Metadata = metadata
 	}
@@ -471,9 +567,12 @@ func (c *rowsCursor) Close() error {
 }
 
 // QueryCursor runs sql with positional args and returns a forward-only
-// Cursor over the result set. The SQL must project (MetricName,
-// Attributes, TimeUnix, Value) in that order — Scan binds positionally,
-// matching Client.Query.
+// Cursor over the result set. The SQL must project one of the layouts
+// [rowShape] enumerates — (MetricName, Attributes, TimeUnix, Value) and
+// its metadata / histogram extensions, or the log-stream
+// (Line, Attributes, TimeUnix[, Metadata]) — because Scan binds
+// positionally, matching Client.Query. [probeRowShape] resolves which
+// from the result-set column names.
 //
 // Compared to Query, QueryCursor keeps only one Sample resident in
 // process memory at a time, which is the only way to keep RAM bounded

--- a/internal/chclient/cursor_logrow_test.go
+++ b/internal/chclient/cursor_logrow_test.go
@@ -1,0 +1,319 @@
+package chclient
+
+import (
+	"reflect"
+	"testing"
+	"time"
+)
+
+// cursor_logrow_test.go — issue #1430.
+//
+// A log stream has no numeric value. Before #1430 the Loki log-stream
+// projection still emitted a `toFloat64(0) AS Value` column so the row was as
+// wide as the cursor's fixed positional scan. These tests pin the decode side
+// of its removal: the cursor recognises the two log-row layouts from their
+// column names and binds a scan with NO numeric destination, while every
+// sample-shaped layout keeps binding exactly the destinations it always did.
+
+// logRowProjectionColumns / logRowMetadataProjectionColumns are the two
+// column layouts a Loki log-stream query publishes: the bare row, and the row
+// plus the trailing structured-metadata column a schema with an
+// AttributesColumn adds. They mirror the aliases internal/logql/lang.go
+// emits — chclient may not import logql (.go-arch-lint.yml), so the names are
+// duplicated by value here exactly as histogramProjectionColumns duplicates
+// chplan's.
+var (
+	logRowProjectionColumns         = []string{"Line", "Attributes", "TimeUnix"}
+	logRowMetadataProjectionColumns = []string{"Line", "Attributes", "TimeUnix", "Metadata"}
+)
+
+// sampleProjectionColumns is the canonical four-column metric row every
+// PromQL / TraceQL query and every LogQL metric query publishes.
+var sampleProjectionColumns = []string{"MetricName", "Attributes", "TimeUnix", "Value"}
+
+// sampleMetadataProjectionColumns is sampleProjectionColumns plus a trailing
+// Metadata column — a layout NO head emits: structured metadata is a
+// log-stream concept, so it rides on a log row or not at all. It appears here
+// only as a negative case, pinning that the probe does not invent a decode
+// for it.
+var sampleMetadataProjectionColumns = []string{"MetricName", "Attributes", "TimeUnix", "Value", "Metadata"}
+
+// TestProbeRowShape pins the whole classification table, including the two
+// collisions that make the log-row layouts non-obvious to recognise:
+//
+//   - (Line, Attributes, TimeUnix, Metadata) is exactly as WIDE as the
+//     four-column sample layout, so width alone cannot tell them apart;
+//   - a wider projection that merely leads with `Line` is not a log row, so
+//     the leading alias alone cannot either.
+//
+// Both signals together are what the probe requires.
+func TestProbeRowShape(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		cols []string
+		want rowShape
+	}{
+		{"bare log row", logRowProjectionColumns, shapeLogRow},
+		{"log row with structured metadata", logRowMetadataProjectionColumns, shapeLogRowMetadata},
+		{"sample row", sampleProjectionColumns, shapeSample},
+		{"histogram row", histogramProjectionColumns, shapeSampleHistogram},
+		// No columns at all: nothing to key off, so the default
+		// four-destination scan — the behaviour every path had before any
+		// probe existed. fakeRows leaves Columns() nil in the pre-existing
+		// sample-shaped tests, which is exactly this case.
+		{"no columns reported", nil, shapeSample},
+		// Leads with `Line` but is not three or four wide: not a log row.
+		// Falls through to the sample-shaped tests, which do not match
+		// either, so it decodes as the default.
+		{
+			"wider projection leading with Line",
+			[]string{"Line", "Attributes", "TimeUnix", "Value", "Extra"},
+			shapeSample,
+		},
+		// Four wide and ends in Metadata, but does NOT lead with `Line`.
+		// This is no layout any head emits: the real sample+metadata shape
+		// is FIVE wide (MetricName, Attributes, TimeUnix, Value, Metadata).
+		// Classifying it as shapeSampleMetadata on the trailing name alone
+		// would select a five-destination scan against a four-column
+		// result set, so the probe pairs the trailing alias with the width
+		// the scan actually binds and lets this fall back to the default.
+		{
+			"four wide ending in Metadata but leading with MetricName",
+			[]string{"MetricName", "Attributes", "TimeUnix", "Metadata"},
+			shapeSample,
+		},
+		// A sample row with a trailing Metadata column: no head emits this,
+		// because structured metadata is a log-stream concept. The probe
+		// must not invent a five-destination decode for it — it falls back
+		// to the default, and a result set that really did arrive in this
+		// shape would fail loudly on scan arity rather than silently
+		// mis-binding.
+		{
+			"five wide sample layout with metadata",
+			sampleMetadataProjectionColumns,
+			shapeSample,
+		},
+		// Three wide but leading with something else: not a log row.
+		{"three wide not leading with Line", []string{"MetricName", "Attributes", "TimeUnix"}, shapeSample},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			t.Parallel()
+			if got := probeRowShape(c.cols); got != c.want {
+				t.Errorf("probeRowShape(%v) = %d, want %d", c.cols, got, c.want)
+			}
+		})
+	}
+}
+
+// TestRowsCursor_DecodesLogRowWithoutValueColumn pins the three-column
+// log-stream decode end to end: the line, the stream labels and the timestamp
+// all round-trip, no numeric destination is bound (fakeRows.Scan errors on a
+// destination count it does not recognise, so a four-destination scan against
+// this three-column result set fails the test rather than silently reading a
+// float), and Sample.Value stays zero.
+func TestRowsCursor_DecodesLogRowWithoutValueColumn(t *testing.T) {
+	t.Parallel()
+
+	ts := time.Date(2026, 8, 9, 10, 30, 0, 0, time.UTC)
+	labels := map[string]string{"service_name": "api", "detected_level": "error"}
+	rows := &fakeRows{
+		columns: logRowProjectionColumns,
+		samples: []Sample{{
+			// The line rides in the positional row's first, String-typed
+			// slot — the one a metric query fills with the metric name.
+			MetricName: `level=error msg="upstream timeout" duration=1.2s`,
+			Labels:     labels,
+			Timestamp:  ts,
+		}},
+	}
+	cursor := &rowsCursor{rows: rows}
+
+	if !cursor.Next() {
+		t.Fatalf("Next: want true, cursor.Err() = %v", cursor.Err())
+	}
+	got := cursor.Sample()
+	if err := cursor.Err(); err != nil {
+		t.Fatalf("Err: %v", err)
+	}
+	if got.MetricName != `level=error msg="upstream timeout" duration=1.2s` {
+		t.Errorf("line: got %q, want the projected log body", got.MetricName)
+	}
+	if !reflect.DeepEqual(got.Labels, labels) {
+		t.Errorf("labels: got %v, want %v", got.Labels, labels)
+	}
+	if !got.Timestamp.Equal(ts) {
+		t.Errorf("timestamp: got %v, want %v", got.Timestamp, ts)
+	}
+	if got.Value != 0 {
+		t.Errorf("Value: got %v, want 0 — the log-row scan binds no numeric "+
+			"destination, so this field is never written (issue #1430)", got.Value)
+	}
+	if got.Metadata != nil {
+		t.Errorf("Metadata: got %v, want nil on the bare three-column layout", got.Metadata)
+	}
+	if cursor.Next() {
+		t.Fatal("Next should return false after the single row")
+	}
+}
+
+// TestRowsCursor_DecodesLogRowWithMetadata pins the four-column sibling: the
+// trailing Metadata column decodes into Sample.Metadata, and — the part that
+// makes this layout worth its own test — the fourth destination is the
+// metadata String, NOT the numeric Value. This is the layout that collides in
+// width with the sample shape, so getting it wrong would bind a *float64
+// where a JSON String arrives.
+func TestRowsCursor_DecodesLogRowWithMetadata(t *testing.T) {
+	t.Parallel()
+
+	ts := time.Date(2026, 8, 9, 10, 31, 0, 0, time.UTC)
+	labels := map[string]string{"service_name": "api"}
+	metadata := map[string]string{"duration": "1.2s", "query_id": "abc-123"}
+	rows := &fakeRows{
+		columns: logRowMetadataProjectionColumns,
+		samples: []Sample{{
+			MetricName: "request completed",
+			Labels:     labels,
+			Timestamp:  ts,
+			Metadata:   metadata,
+		}},
+	}
+	cursor := &rowsCursor{rows: rows}
+
+	if !cursor.Next() {
+		t.Fatalf("Next: want true, cursor.Err() = %v", cursor.Err())
+	}
+	got := cursor.Sample()
+	if err := cursor.Err(); err != nil {
+		t.Fatalf("Err: %v", err)
+	}
+	if got.MetricName != "request completed" {
+		t.Errorf("line: got %q, want %q", got.MetricName, "request completed")
+	}
+	if !reflect.DeepEqual(got.Labels, labels) {
+		t.Errorf("labels: got %v, want %v", got.Labels, labels)
+	}
+	if !got.Timestamp.Equal(ts) {
+		t.Errorf("timestamp: got %v, want %v", got.Timestamp, ts)
+	}
+	if !reflect.DeepEqual(got.Metadata, metadata) {
+		t.Errorf("metadata: got %v, want %v", got.Metadata, metadata)
+	}
+	if got.Value != 0 {
+		t.Errorf("Value: got %v, want 0 — the log-row scan binds no numeric "+
+			"destination even on the four-wide layout (issue #1430)", got.Value)
+	}
+}
+
+// TestRowsCursor_LogRowDecodeRoundTripsToLogRow pins the seam this whole
+// change exists to keep honest: the positional Sample the cursor produces for
+// a log-stream result set decodes into the named [LogRow] fields, and LogRow
+// carries no numeric field for the removed column to reappear in.
+func TestRowsCursor_LogRowDecodeRoundTripsToLogRow(t *testing.T) {
+	t.Parallel()
+
+	ts := time.Date(2026, 8, 9, 10, 32, 0, 0, time.UTC)
+	rows := &fakeRows{
+		columns: logRowMetadataProjectionColumns,
+		samples: []Sample{
+			{
+				MetricName: "first line",
+				Labels:     map[string]string{"service_name": "api"},
+				Timestamp:  ts,
+				Metadata:   map[string]string{"bytes": "512"},
+			},
+			{
+				MetricName: "second line",
+				Labels:     map[string]string{"service_name": "api"},
+				Timestamp:  ts.Add(time.Second),
+			},
+		},
+	}
+	cursor := &rowsCursor{rows: rows}
+
+	var drained []Sample
+	for cursor.Next() {
+		drained = append(drained, cursor.Sample())
+	}
+	if err := cursor.Err(); err != nil {
+		t.Fatalf("Err: %v", err)
+	}
+
+	logRows := DecodeLogRows(drained)
+	if len(logRows) != 2 {
+		t.Fatalf("DecodeLogRows returned %d rows, want 2", len(logRows))
+	}
+	if logRows[0].Line != "first line" || logRows[1].Line != "second line" {
+		t.Errorf("lines: got %q / %q, want %q / %q",
+			logRows[0].Line, logRows[1].Line, "first line", "second line")
+	}
+	if !reflect.DeepEqual(logRows[0].Metadata, map[string]string{"bytes": "512"}) {
+		t.Errorf("row 0 metadata: got %v, want map[bytes:512]", logRows[0].Metadata)
+	}
+	if logRows[1].Metadata != nil {
+		t.Errorf("row 1 metadata: got %v, want nil (empty metadata map)", logRows[1].Metadata)
+	}
+	// Both rows share one interned label map — the log path keeps the same
+	// per-series interning the sample path has, so a long log drain retains
+	// one map per stream rather than one per line.
+	if logRows[0].Labels == nil || !reflect.DeepEqual(logRows[0].Labels, logRows[1].Labels) {
+		t.Errorf("labels: got %v / %v, want both rows to carry the same stream identity",
+			logRows[0].Labels, logRows[1].Labels)
+	}
+	if drained[0].SeriesID != drained[1].SeriesID {
+		t.Errorf("SeriesID: got %d / %d, want both rows interned to one series",
+			drained[0].SeriesID, drained[1].SeriesID)
+	}
+}
+
+// TestRowsCursor_SampleShapesBindTheValueColumn is the control: the layouts
+// that DO carry a numeric value must still bind it. It is the guard against
+// the log-row branch widening to swallow a shape it does not own — the exact
+// failure mode that would silently zero every metric result.
+func TestRowsCursor_SampleShapesBindTheValueColumn(t *testing.T) {
+	t.Parallel()
+
+	ts := time.Date(2026, 8, 9, 10, 33, 0, 0, time.UTC)
+	cases := []struct {
+		name    string
+		columns []string
+		want    float64
+	}{
+		{"four-column sample", sampleProjectionColumns, 42.5},
+		// Columns() unreported — the shape every pre-probe path decoded as.
+		{"no columns reported", nil, 3.5},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			t.Parallel()
+
+			rows := &fakeRows{
+				columns: c.columns,
+				samples: []Sample{{
+					MetricName: "up",
+					Labels:     map[string]string{"job": "api"},
+					Timestamp:  ts,
+					Value:      c.want,
+				}},
+			}
+			cursor := &rowsCursor{rows: rows}
+
+			if !cursor.Next() {
+				t.Fatalf("Next: want true, cursor.Err() = %v", cursor.Err())
+			}
+			got := cursor.Sample()
+			if err := cursor.Err(); err != nil {
+				t.Fatalf("Err: %v", err)
+			}
+			if got.Value != c.want {
+				t.Errorf("Value: got %v, want %v — the sample-shaped layouts must keep "+
+					"binding their numeric column", got.Value, c.want)
+			}
+			if got.MetricName != "up" {
+				t.Errorf("MetricName: got %q, want %q", got.MetricName, "up")
+			}
+		})
+	}
+}

--- a/internal/chclient/cursor_test.go
+++ b/internal/chclient/cursor_test.go
@@ -1,6 +1,7 @@
 package chclient
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"reflect"
@@ -43,35 +44,77 @@ func (r *fakeRows) Next() bool {
 // mismatching.
 const wantHistogramDest = 4 + histogramColumnCount
 
+// scanLeadingThree binds the (String, label map, timestamp) prefix every
+// layout shares, whatever follows it.
+func scanLeadingThree(dest []any, s Sample) {
+	if p, ok := dest[0].(*string); ok {
+		*p = s.MetricName
+	}
+	if p, ok := dest[1].(*map[string]string); ok {
+		*p = s.Labels
+	}
+	if p, ok := dest[2].(*time.Time); ok {
+		*p = s.Timestamp
+	}
+}
+
+// scanMetadataJSON binds a trailing metadata destination the way the server
+// delivers it: the `Metadata` column is a `toJSONString(<Map>)` payload, so
+// it arrives as a JSON-object String the cursor unmarshals back into a map.
+func scanMetadataJSON(dst any, s Sample) error {
+	p, ok := dst.(*string)
+	if !ok {
+		return fmt.Errorf("fakeRows.Scan: metadata destination is %T, want *string", dst)
+	}
+	if s.Metadata == nil {
+		*p = ""
+		return nil
+	}
+	encoded, err := json.Marshal(s.Metadata)
+	if err != nil {
+		return fmt.Errorf("fakeRows.Scan: marshal metadata fixture: %w", err)
+	}
+	*p = string(encoded)
+	return nil
+}
+
+// isFloatDest reports whether d is the *float64 destination the SAMPLE
+// layouts bind in position 4. It is what disambiguates the two four-wide
+// layouts: the sample shape's fourth column is the numeric Value, the
+// log+metadata shape's fourth is the metadata String. Keying on the bound
+// TYPE rather than on the production probe's verdict keeps the fake an
+// independent check — a probe that mis-classified a shape would bind the
+// wrong destinations here and fail, rather than being rubber-stamped.
+func isFloatDest(d any) bool {
+	_, ok := d.(*float64)
+	return ok
+}
+
 func (r *fakeRows) Scan(dest ...any) error {
 	if r.scanErr != nil {
 		return r.scanErr
 	}
 	s := r.samples[r.idx-1]
-	switch len(dest) {
-	case 4:
-		if p, ok := dest[0].(*string); ok {
-			*p = s.MetricName
+	switch {
+	// (Line, Attributes, TimeUnix) — the log-stream layout, which binds no
+	// numeric destination at all (issue #1430).
+	case len(dest) == logRowColumns:
+		scanLeadingThree(dest, s)
+	// (Line, Attributes, TimeUnix, Metadata) — the log-stream layout with
+	// structured metadata. Same width as the sample layout, told apart by
+	// the fourth destination's type.
+	case len(dest) == logRowMetadataColumns && !isFloatDest(dest[3]):
+		scanLeadingThree(dest, s)
+		if err := scanMetadataJSON(dest[3], s); err != nil {
+			return err
 		}
-		if p, ok := dest[1].(*map[string]string); ok {
-			*p = s.Labels
-		}
-		if p, ok := dest[2].(*time.Time); ok {
-			*p = s.Timestamp
-		}
+	case len(dest) == sampleColumns:
+		scanLeadingThree(dest, s)
 		if p, ok := dest[3].(*float64); ok {
 			*p = s.Value
 		}
-	case wantHistogramDest:
-		if p, ok := dest[0].(*string); ok {
-			*p = s.MetricName
-		}
-		if p, ok := dest[1].(*map[string]string); ok {
-			*p = s.Labels
-		}
-		if p, ok := dest[2].(*time.Time); ok {
-			*p = s.Timestamp
-		}
+	case len(dest) == wantHistogramDest:
+		scanLeadingThree(dest, s)
 		if p, ok := dest[3].(*float64); ok {
 			*p = s.Value
 		}
@@ -107,7 +150,8 @@ func (r *fakeRows) Scan(dest ...any) error {
 			*p = hv.NegativeBucketCounts
 		}
 	default:
-		return fmt.Errorf("fakeRows.Scan: want 4 or %d destinations, got %d", wantHistogramDest, len(dest))
+		return fmt.Errorf("fakeRows.Scan: want %d, %d or %d destinations, got %d",
+			logRowColumns, sampleColumns, wantHistogramDest, len(dest))
 	}
 	return nil
 }

--- a/internal/chclient/logrow.go
+++ b/internal/chclient/logrow.go
@@ -4,13 +4,14 @@ import "time"
 
 // logrow.go — the log-stream row decode.
 //
-// [Sample] is the POSITIONAL row of the four/five-column projection every
-// head's SQL emits: the scan binds column 1 into a String, column 2 into the
-// label map, column 3 into a timestamp, column 4 into a float, and the
-// optional fifth column into per-row metadata. What column 1 MEANS is
-// per-query: a metric query projects the metric name into it, a log-stream
-// query projects the log line (a log line is a String, so it cannot ride in
-// the Float64 slot the metric value occupies).
+// [Sample] is the POSITIONAL row of whichever projection a head's SQL
+// emits: the scan binds column 1 into a String, column 2 into the label map,
+// column 3 into a timestamp, and — on the sample-shaped layouts only —
+// column 4 into a float, with an optional trailing column for per-row
+// metadata. What column 1 MEANS is per-query: a metric query projects the
+// metric name into it, a log-stream query projects the log line (a log line
+// is a String, so it cannot ride in the Float64 slot the metric value
+// occupies).
 //
 // [LogRow] is the semantic row for the log-stream shape, and
 // [DecodeLogRows] is the single place that positional knowledge is turned
@@ -41,11 +42,12 @@ type LogRow struct {
 // DecodeLogRows decodes a log-stream result set into the named [LogRow]
 // shape. The rows it takes are the positional [Sample] rows the shared
 // cursor produced for a log-stream projection — `(<line>, Attributes,
-// TimeUnix, Value[, Metadata])`.
+// TimeUnix[, Metadata])`.
 //
-// The projection's Value column is a constant placeholder: it exists only so
-// the log-stream shape is as wide as the positional scan the shared cursor
-// runs, and carries no log-stream meaning. Decoding drops it.
+// That projection carries no numeric column: a log stream has no value to
+// report, so the cursor's log-row scan binds no float destination and
+// [Sample.Value] is zero on every row here. [LogRow] has no slot for it by
+// construction.
 //
 // A nil or empty input returns nil. Labels and Metadata are carried over by
 // reference — Labels is the cursor's interned per-series map, so the

--- a/internal/chclienttest/client.go
+++ b/internal/chclienttest/client.go
@@ -41,6 +41,24 @@ const histogramLastColumn = "HistogramNegativeBucketCounts"
 // appends after the base four.
 const histogramColumnCount = 9
 
+// logLineColumn is the FIRST projection alias a Loki log-stream query
+// binds its log line to, and logRowColumns / logRowMetadataColumns are
+// the two widths that shape comes in: (Line, Attributes, TimeUnix) and
+// the same plus a trailing metadataColumn. They mirror the production
+// rowsCursor's probe constants so this double binds the same
+// no-numeric-destination scan off the result-set column shape.
+//
+// A log stream has no numeric value, so the log-row layouts project no
+// Value column at all (issue #1430) — matching on the leading alias AND
+// the exact width is what keeps the four-wide log+metadata layout from
+// being read as the four-wide sample layout.
+const logLineColumn = "Line"
+
+const (
+	logRowColumns         = 3
+	logRowMetadataColumns = 4
+)
+
 // Client is a chDB-backed implementation of the Querier interface each
 // handler defines (api/prom.Querier, api/loki.Querier, api/tempo.Querier).
 // All three are subsets of *chclient.Client's surface, so a single struct
@@ -247,9 +265,10 @@ func (c *Client) prepareQuery(query string) string {
 // Query satisfies the *chclient.Client.Query surface — it runs sql
 // with positional args and decodes each row into a chclient.Sample.
 // The SQL must project (MetricName, Attributes, TimeUnix, Value) in
-// that order; the Attributes column is rewritten to toJSONString(…)
-// before the round-trip and JSON-decoded back to a map[string]string
-// on the Go side.
+// that order, or the Loki log-stream shape (Line, Attributes,
+// TimeUnix[, Metadata]), which carries no Value column; the Attributes
+// column is rewritten to toJSONString(…) before the round-trip and
+// JSON-decoded back to a map[string]string on the Go side.
 func (c *Client) Query(ctx context.Context, query string, args ...any) ([]chclient.Sample, error) {
 	if c.err != nil {
 		return nil, c.err
@@ -261,18 +280,27 @@ func (c *Client) Query(ctx context.Context, query string, args ...any) ([]chclie
 	}
 	defer func() { _ = rows.Close() }()
 
-	// Mirror the production rowsCursor metadata probe: the Loki log-stream
-	// projection appends a fifth `Metadata` column (a `toJSONString(<Map>)`
-	// JSON-object String), every other path projects four. Bind the scan
-	// to the column shape so the four-column metric / prom / tempo paths
-	// stay a four-destination scan and the log-stream path picks up the
-	// structured-metadata string.
+	// Mirror the production rowsCursor shape probe: the Loki log-stream
+	// projection leads with `Line` and carries no Value column, optionally
+	// appending a trailing `Metadata` column (a `toJSONString(<Map>)`
+	// JSON-object String); every metric path projects the base four. Bind
+	// the scan to the column shape so the four-column metric / prom /
+	// tempo paths stay a four-destination scan and the log-stream path
+	// binds no float.
 	cols, err := rows.Columns()
 	if err != nil {
 		return nil, fmt.Errorf("chclienttest: columns: %w", err)
 	}
 	hasMetadata := len(cols) > 0 && cols[len(cols)-1] == metadataColumn
 	hasHistogram := len(cols) > 0 && cols[len(cols)-1] == histogramLastColumn
+	// The log-row layouts bind no numeric destination at all. Recognise
+	// them by the leading alias plus the exact width, exactly as the
+	// production probeRowShape does, so the four-wide log+metadata layout
+	// is never mistaken for the four-wide sample layout. Structured
+	// metadata rides only on a log row — no head projects a metric result
+	// with metadata attached.
+	isLogRow := len(cols) == logRowColumns && cols[0] == logLineColumn
+	isLogRowMetadata := len(cols) == logRowMetadataColumns && cols[0] == logLineColumn && hasMetadata
 
 	var out []chclient.Sample
 	for rows.Next() {
@@ -306,8 +334,15 @@ func (c *Client) Query(ctx context.Context, query string, args ...any) ([]chclie
 				return nil, err
 			}
 			hv = decoded
-		case hasMetadata:
-			if err := rows.Scan(&name, &attrsJSON, &ts, &value, &metadataJSON); err != nil {
+		// The log-row arms come BEFORE hasMetadata: a log+metadata result
+		// satisfies both predicates, and only the log-row arm binds the
+		// correct destination count (no float).
+		case isLogRow:
+			if err := rows.Scan(&name, &attrsJSON, &ts); err != nil {
+				return nil, fmt.Errorf("chclienttest: scan: %w", err)
+			}
+		case isLogRowMetadata:
+			if err := rows.Scan(&name, &attrsJSON, &ts, &metadataJSON); err != nil {
 				return nil, fmt.Errorf("chclienttest: scan: %w", err)
 			}
 		default:

--- a/internal/logql/lang.go
+++ b/internal/logql/lang.go
@@ -125,6 +125,13 @@ func (l *Lang) Parse(ctx context.Context, query string) (chplan.Node, engine.Met
 // projects the metric name into. chclient.DecodeLogRows decodes that row
 // into chclient.LogRow, whose Line field is what the Loki streams pivot
 // reads.
+//
+// It is also the MARKER the cursor's shape probe keys the log-row scan
+// off: a result set leading with this alias carries no numeric column, so
+// the cursor binds no float destination. chclient may not import logql
+// (.go-arch-lint.yml), so it mirrors this literal in its own unexported
+// logLineColumn const; TestLogLineColumn_MatchesCursorProbeLiteral pins
+// the pair.
 const LogLineColumn = "Line"
 
 // ProjectSamples wraps plan with the projection that reshapes the
@@ -133,7 +140,8 @@ const LogLineColumn = "Line"
 // (mirrors the promql side's anchor trick to keep matrix step-grid
 // bucketing from dropping the only row); log queries project the log
 // Body under [LogLineColumn], since a log line is a String and the
-// positional row's fourth column is a float64.
+// sample shape's fourth column is a float64 — a log stream has no
+// numeric value, so its projection carries no fourth column at all.
 func (l *Lang) ProjectSamples(plan chplan.Node, meta engine.Meta) chplan.Node {
 	s := l.Schema
 	if meta.IsMetric {
@@ -223,10 +231,13 @@ func (l *Lang) ProjectSamples(plan chplan.Node, meta engine.Meta) chplan.Node {
 		}
 	}
 	// Log-stream query: the positional row the chclient cursor scans is
-	// (<String>, Attributes, TimeUnix, <Float64>). A log line is a String,
+	// (<String>, Attributes, TimeUnix[, Metadata]). A log line is a String,
 	// so it takes the first column — the slot a metric query fills with the
-	// metric name — under the [LogLineColumn] alias, and the Float64 slot
-	// takes a 0.0 placeholder to keep the row as wide as the scan.
+	// metric name — under the [LogLineColumn] alias, and there is NO fourth
+	// Float64 column: a log stream has no numeric value, so projecting a
+	// placeholder would be width every log query pays for and then discards
+	// (issue #1430). The chclient cursor recognises the shape by this
+	// leading alias and binds a scan with no numeric destination.
 	// chclient.DecodeLogRows turns that row into the named
 	// chclient.LogRow the Loki streams pivot consumes.
 	//
@@ -284,11 +295,6 @@ func (l *Lang) ProjectSamples(plan chplan.Node, meta engine.Meta) chplan.Node {
 		{Expr: lineExpr, Alias: LogLineColumn},
 		{Expr: attrsExpr, Alias: "Attributes"},
 		{Expr: &chplan.ColumnRef{Name: s.TimestampColumn}, Alias: "TimeUnix"},
-		// LitFloat is wrapped centrally in toFloat64(?) by
-		// internal/chsql/Builder.Expr; without that pin CH would
-		// narrow the bare `0` placeholder to UInt8 and clickhouse-go's
-		// Sample Scan would reject UInt8 → *float64.
-		{Expr: &chplan.LitFloat{V: 0}, Alias: "Value"},
 	}
 	// Surface the OTel-CH LogAttributes map as Loki structured metadata —
 	// the third element of each `[ts, line, {metadata}]` value tuple. The
@@ -297,11 +303,11 @@ func (l *Lang) ProjectSamples(plan chplan.Node, meta engine.Meta) chplan.Node {
 	// the genuinely per-line keys (duration / bytes / query_id / …) ride
 	// here instead, which is exactly the shape Grafana's Logs Drilldown
 	// reads to render clean, well-formed columns. The chclient cursor
-	// detects this fifth `Metadata` column and binds a five-destination
-	// scan; the four-column metric / prom / tempo paths are untouched.
-	// Schemas without a structured-metadata column (AttributesColumn == "")
-	// skip the projection entirely, falling back to the prior four-column
-	// shape byte-for-byte.
+	// detects this trailing `Metadata` column and binds a four-destination
+	// log-row scan; the four-column metric / prom / tempo paths are
+	// untouched. Schemas without a structured-metadata column
+	// (AttributesColumn == "") skip the projection entirely, leaving the
+	// bare three-column log-row shape.
 	if s.AttributesColumn != "" {
 		projections = append(projections, chplan.Projection{
 			Expr:  structuredMetadataExpr(s),

--- a/internal/logql/lang_test.go
+++ b/internal/logql/lang_test.go
@@ -416,10 +416,12 @@ func TestProjectSamples_LogQuerySurfacesDetectedLevelWhenReferenced(t *testing.T
 		t.Fatalf("ProjectSamples returned %T, want *chplan.Project", wrapped)
 	}
 	// The default OTel-logs schema carries a structured-metadata column,
-	// so the wire projection adds a fifth `Metadata` slot surfacing the
+	// so the wire projection adds a trailing `Metadata` slot surfacing the
 	// per-line LogAttributes map (Loki's `[ts, line, {metadata}]` tuple).
-	if len(proj.Projections) != 5 {
-		t.Fatalf("got %d projections, want 5 (Line, Attributes, TimeUnix, Value, Metadata)",
+	// Four slots, not five: a log stream has no numeric value, so there is
+	// no Value column (issue #1430).
+	if len(proj.Projections) != 4 {
+		t.Fatalf("got %d projections, want 4 (Line, Attributes, TimeUnix, Metadata)",
 			len(proj.Projections))
 	}
 	// The line slot is the positional row's first, String-typed column,
@@ -438,7 +440,7 @@ func TestProjectSamples_LogQuerySurfacesDetectedLevelWhenReferenced(t *testing.T
 		t.Fatalf("line slot ColumnRef.Name: got %q, want %q (schema's BodyColumn)",
 			lineRef.Name, s.BodyColumn)
 	}
-	metaSlot := proj.Projections[4]
+	metaSlot := proj.Projections[3]
 	if metaSlot.Alias != "Metadata" {
 		t.Fatalf("metadata slot alias: got %q, want %q", metaSlot.Alias, "Metadata")
 	}

--- a/internal/logql/log_row_shape_test.go
+++ b/internal/logql/log_row_shape_test.go
@@ -1,0 +1,203 @@
+package logql_test
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/tsouza/cerberus/internal/chplan"
+	"github.com/tsouza/cerberus/internal/chsql"
+	"github.com/tsouza/cerberus/internal/engine"
+	"github.com/tsouza/cerberus/internal/logql"
+	syntax "github.com/tsouza/cerberus/internal/logql/lsyntax"
+	"github.com/tsouza/cerberus/internal/schema"
+)
+
+// log_row_shape_test.go — issue #1430.
+//
+// A log stream has no numeric value. Before #1430 the log-stream projection
+// still emitted a fourth `toFloat64(0) AS Value` column, purely so the row
+// was as wide as the shared cursor's fixed positional scan; every log query
+// paid for that column on the wire and then discarded it.
+//
+// These tests pin the shape from the emitter side: the plan-level projection
+// list, the alias order, and the SQL text ClickHouse actually receives.
+
+// logStreamProjection lowers q's log-stream wire projection through the same
+// Lang.ProjectSamples call engine.QueryPlan makes.
+func logStreamProjection(t *testing.T, q string, s schema.Logs) *chplan.Project {
+	t.Helper()
+
+	expr, err := syntax.ParseExpr(q)
+	if err != nil {
+		t.Fatalf("ParseExpr(%q): %v", q, err)
+	}
+	l := &logql.Lang{Schema: s}
+	wrapped := l.ProjectSamples(&chplan.Scan{Table: s.LogsTable}, engine.Meta{
+		IsMetric: false,
+		Extra:    map[string]any{"expr": expr},
+	})
+	proj, ok := wrapped.(*chplan.Project)
+	if !ok {
+		t.Fatalf("ProjectSamples(%q) returned %T, want *chplan.Project", q, wrapped)
+	}
+	return proj
+}
+
+// projectionAliases is the projection's alias list in emission order — the
+// positional contract the chclient cursor's scan binds against.
+func projectionAliases(proj *chplan.Project) []string {
+	out := make([]string, len(proj.Projections))
+	for i, p := range proj.Projections {
+		out[i] = p.Alias
+	}
+	return out
+}
+
+// TestLogStreamProjection_HasNoValueColumn pins the alias list of both
+// log-stream layouts: the four-wide (Line, Attributes, TimeUnix, Metadata)
+// shape a schema WITH a structured-metadata column emits, and the three-wide
+// (Line, Attributes, TimeUnix) shape a schema without one emits. Neither
+// carries a `Value` alias.
+//
+// The `Value` assertion is the issue-#1430 regression checkpoint: it fails
+// the moment a placeholder column is reintroduced anywhere in the log-stream
+// projection, regardless of which expression produces it.
+func TestLogStreamProjection_HasNoValueColumn(t *testing.T) {
+	t.Parallel()
+
+	withMetadata := schema.DefaultOTelLogs()
+	noMetadata := schema.DefaultOTelLogs()
+	// A schema whose structured-metadata column is blank skips the Metadata
+	// projection entirely, leaving the bare three-column log row.
+	noMetadata.AttributesColumn = ""
+
+	cases := []struct {
+		name string
+		s    schema.Logs
+		want []string
+	}{
+		{
+			name: "structured-metadata schema",
+			s:    withMetadata,
+			want: []string{logql.LogLineColumn, "Attributes", "TimeUnix", "Metadata"},
+		},
+		{
+			name: "schema without a structured-metadata column",
+			s:    noMetadata,
+			want: []string{logql.LogLineColumn, "Attributes", "TimeUnix"},
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			t.Parallel()
+
+			proj := logStreamProjection(t, `{job="api"}`, c.s)
+			got := projectionAliases(proj)
+			if len(got) != len(c.want) {
+				t.Fatalf("projection aliases = %v (%d slots), want %v (%d slots)",
+					got, len(got), c.want, len(c.want))
+			}
+			for i := range c.want {
+				if got[i] != c.want[i] {
+					t.Errorf("projection alias[%d] = %q, want %q (full list %v)", i, got[i], c.want[i], got)
+				}
+			}
+			for i, alias := range got {
+				if alias == "Value" {
+					t.Errorf("projection slot %d aliases %q: a log stream has no numeric "+
+						"value, so the log-stream projection must carry no Value column "+
+						"at all — the placeholder issue #1430 removed (full list %v)",
+						i, alias, got)
+				}
+			}
+		})
+	}
+}
+
+// TestLogStreamProjection_NoPlaceholderLiteralInPlan pins the plan-level
+// half: no slot of a log-stream projection is a bare numeric literal. The
+// removed placeholder was a *chplan.LitFloat{V: 0}, and a literal in this
+// projection means the emitter is manufacturing data rather than projecting
+// it.
+func TestLogStreamProjection_NoPlaceholderLiteralInPlan(t *testing.T) {
+	t.Parallel()
+
+	for _, q := range []string{
+		`{job="api"}`,
+		`{job="api"} |= "error"`,
+		`{job="api"} | logfmt`,
+		`{job="api"} | unpack`,
+	} {
+		t.Run(q, func(t *testing.T) {
+			t.Parallel()
+
+			proj := logStreamProjection(t, q, schema.DefaultOTelLogs())
+			for i, p := range proj.Projections {
+				switch p.Expr.(type) {
+				case *chplan.LitFloat, *chplan.LitInt:
+					t.Errorf("projection slot %d (alias %q) is a numeric literal %T — "+
+						"the log-stream shape carries no synthesised numeric column "+
+						"(issue #1430)", i, p.Alias, p.Expr)
+				}
+			}
+		})
+	}
+}
+
+// TestLogStreamSQL_OmitsToFloat64Placeholder pins the same property one layer
+// down, in the SQL text ClickHouse receives: the emitted SELECT list neither
+// aliases a `Value` column nor wraps anything in the `toFloat64(?)` the
+// placeholder literal used to render as.
+//
+// Pinning the SQL as well as the plan matters because the placeholder was
+// invisible at the plan level as anything but a literal — it acquired its
+// toFloat64 wrap centrally in the chsql builder, so a plan-only assertion
+// would not have described what actually went over the wire.
+func TestLogStreamSQL_OmitsToFloat64Placeholder(t *testing.T) {
+	t.Parallel()
+
+	proj := logStreamProjection(t, `{job="api"}`, schema.DefaultOTelLogs())
+	sqlStr, _, err := chsql.Emit(context.Background(), proj)
+	if err != nil {
+		t.Fatalf("chsql.Emit: %v", err)
+	}
+	// Everything before the FROM is the projection list; a `Value` alias
+	// anywhere else in the statement (an inner scope, a WHERE) is not this
+	// test's business.
+	selectList := sqlStr
+	if idx := strings.Index(sqlStr, " FROM "); idx > 0 {
+		selectList = sqlStr[:idx]
+	}
+	if strings.Contains(selectList, "AS `Value`") {
+		t.Errorf("log-stream SELECT list aliases a `Value` column — the placeholder "+
+			"issue #1430 removed:\n%s", sqlStr)
+	}
+	if strings.Contains(selectList, "toFloat64(") {
+		t.Errorf("log-stream SELECT list still contains a toFloat64 wrap — the shape "+
+			"the placeholder literal rendered as (issue #1430):\n%s", sqlStr)
+	}
+}
+
+// TestLogLineColumn_MatchesCursorProbeLiteral pins the emitter side of the
+// cross-package pairing the chclient cursor depends on: chclient may not
+// import logql (.go-arch-lint.yml gives it no internal dependencies), so it
+// duplicates this alias in its own unexported logLineColumn const and keys
+// its no-numeric-destination log-row scan off it.
+//
+// Renaming LogLineColumn without changing that literal would not fail to
+// compile — the cursor would simply stop recognising log rows and fall back
+// to the four-destination sample scan against a three-column result set,
+// surfacing as a scan error on every log query. This assertion turns that
+// into a compile-time-adjacent failure at the source of the rename.
+func TestLogLineColumn_MatchesCursorProbeLiteral(t *testing.T) {
+	t.Parallel()
+
+	const cursorProbeLiteral = "Line" // internal/chclient/cursor.go: logLineColumn
+	if logql.LogLineColumn != cursorProbeLiteral {
+		t.Errorf("logql.LogLineColumn = %q, but internal/chclient/cursor.go's logLineColumn "+
+			"probe constant is %q — the cursor keys its log-row scan off this alias and "+
+			"cannot import logql to read it, so the two literals must be changed together",
+			logql.LogLineColumn, cursorProbeLiteral)
+	}
+}

--- a/test/spec/strictscan_integration_test.go
+++ b/test/spec/strictscan_integration_test.go
@@ -39,8 +39,7 @@
 //     columns — NOT the chDB `toJSONString` Map-wrap that masks the divergence)
 //     through `chclient.Client.QueryCursor`, which scans positionally into the
 //     EXACT destination types the production matrix decoder uses
-//     (`MetricName string`, `map[string]string`, `time.Time`, `float64`; plus a
-//     5th `Metadata` String for the Loki log-stream path);
+//     (`MetricName string`, `map[string]string`, `time.Time`, `float64`);
 //  4. drains the cursor and asserts NO scan-type error.
 //
 // Step 3 is the load-bearing one: QueryCursor's rowsCursor.Next() runs the very
@@ -49,9 +48,13 @@
 // here exactly as it would in prod — the failure the chDB lane swallows.
 //
 // SCOPE: the three query heads' round-trip fixtures (the metric/range/vector-
-// join emitters where Value-typed columns live are all under promql; logql and
-// traceql exercise the Map + log-stream + trace projections). The optimizer
-// lane has no round-trip fixtures. Args are taken verbatim from each fixture's
+// join emitters where Value-typed columns live are all under promql; logql
+// and traceql exercise the Map and trace projections). The optimizer lane has
+// no round-trip fixtures. LogQL's LOG-STREAM wire projection is not in scope
+// here — Layer 2a records its SQL before ProjectSamples, so a log fixture's
+// `-- sql --` is a bare `SELECT *` that classifies as non-matrix; the real-CH
+// coverage for that shape is the compat-logql differential. See issue #2044
+// for closing the gap the way #1635 closed TraceQL's. Args are taken verbatim from each fixture's
 // `-- args --` block, so no synthetic placeholder binding is needed — EXCEPT
 // for TraceQL search-shaped fixtures, where traceqlWrapForStrictScan discards
 // the fixture's own `-- sql --` / `-- args --` and re-derives both (see its
@@ -159,22 +162,24 @@ const (
 	// strict-scanned through the production cursor.
 	caseRan caseOutcome = iota
 	// caseNonMatrix: the fixture's SQL is not the (MetricName, Attributes,
-	// TimeUnix, Value [, Metadata]) matrix shape the production cursor
-	// decodes — it belongs to a different decoder (label values, Tempo
-	// search rows, index stats, …) and is out of this lane's scope.
+	// TimeUnix, Value) matrix shape the production cursor decodes — it
+	// belongs to a different decoder (label values, Tempo search rows,
+	// index stats, …) and is out of this lane's scope.
 	caseNonMatrix
 )
 
 // matrixColumns is the exact column projection the production matrix cursor
 // (chclient.rowsCursor) binds positionally. A fixture whose emitted SQL
-// produces these columns (optionally + a trailing "Metadata" String for the
-// Loki log-stream path) is in scope; anything else belongs to a different
+// produces these columns is in scope; anything else belongs to a different
 // production decoder and is skipped.
+//
+// There is no metadata-suffixed variant of this shape: structured metadata
+// rides only on the Loki log-stream row (Line, Attributes, TimeUnix
+// [, Metadata]), which carries no Value column and which no fixture's
+// recorded SQL produces — Layer 2a captures logql SQL BEFORE
+// ProjectSamples, so a log fixture's `-- sql --` is a bare `SELECT *` and
+// is skipped as non-matrix here. See issue #2044.
 var matrixColumns = []string{"MetricName", "Attributes", "TimeUnix", "Value"}
-
-// metadataColumn is the optional 5th column the Loki log-stream projection
-// appends (mirrors chclient's metadataColumn const).
-const metadataColumn = "Metadata"
 
 // runStrictScanCase seeds the fixture's tables, probes the emitted SQL's
 // result column shape, and — only when that shape is the production matrix
@@ -276,7 +281,7 @@ func traceqlWrapForStrictScan(t *testing.T, c *spec.Case, rt *spec.RoundTripSect
 
 // isMatrixShape runs the query, reads the result column names, and reports
 // whether they are the production matrix projection (MetricName, Attributes,
-// TimeUnix, Value) optionally followed by a Metadata column. The probe drains
+// TimeUnix, Value). The probe drains
 // no rows — Columns() is populated as soon as the query is open — so it is
 // cheap. A non-nil error means the server rejected the query at open time.
 func isMatrixShape(ctx context.Context, client *chclient.Client, query string, args []any) (bool, error) {
@@ -287,16 +292,13 @@ func isMatrixShape(ctx context.Context, client *chclient.Client, query string, a
 	defer func() { _ = rows.Close() }()
 
 	cols := rows.Columns()
-	if len(cols) != len(matrixColumns) && len(cols) != len(matrixColumns)+1 {
+	if len(cols) != len(matrixColumns) {
 		return false, nil
 	}
 	for i, want := range matrixColumns {
 		if cols[i] != want {
 			return false, nil
 		}
-	}
-	if len(cols) == len(matrixColumns)+1 && cols[len(matrixColumns)] != metadataColumn {
-		return false, nil
 	}
 	return true, nil
 }


### PR DESCRIPTION
A log stream has no numeric value, yet the LogQL log-stream projection emitted a `toFloat64(0) AS Value` column on every log query. It carried no meaning: it existed only so the row was as wide as `rowsCursor.Next`'s fixed 4-or-5-destination positional scan, and the decode dropped it immediately. Every log query paid for the column on the wire and then discarded it.

This is the remaining half of the defect #1426 started on. #1426 removed the *smuggle* — the log body riding in a field named `MetricName` — and gave the decode a named `chclient.LogRow`. What was left was the shape itself: still a metric-sample shape wearing log-stream data.

## What changed

**The cursor learns the log-row shape** rather than the data being padded to fit the scan. The two parallel probe bool pairs (`metadataProbed`/`hasMetadata`, `histogramProbed`/`hasHistogram`) collapse into one latched `rowShape` resolved by `probeRowShape`, which recognises four layouts:

| shape | columns | destinations |
|---|---|---|
| `shapeSample` | `MetricName, Attributes, TimeUnix, Value` | 4 |
| `shapeSampleHistogram` | + the nine `Histogram*Column` aliases | 13 |
| `shapeLogRow` | `Line, Attributes, TimeUnix` | **3, no float** |
| `shapeLogRowMetadata` | `Line, Attributes, TimeUnix, Metadata` | **4, no float** |

The two sample-shaped layouts decode exactly as before. The log-row arms bind no numeric destination at all, so `Sample.Value` is never written on that path — and `LogRow`, which never had a slot for it, is unaffected.

**The two emitters stop projecting the placeholder**: `internal/logql/lang.go`'s log-stream branch and `internal/api/loki/tail.go`'s `buildTailSQL` (whose `toFloat64Zero()` helper is deleted).

## Recognising the shape

The log layouts are keyed on their leading `Line` alias **and** an exact width, because neither signal suffices alone:

- the four-wide log+metadata layout is exactly as wide as the sample layout, so width alone would confuse them;
- a wider projection that merely leads with `Line` is not a log row, so the leading alias alone would misread it.

Each sample-shaped layout's trailing-alias test is likewise now paired with the width the scan it selects actually binds, so a merely-similar projection can no longer select a scan wider than its result set.

## One layout retired

That pairing makes a dead layout visible. Structured metadata is a log-stream concept, and the log-stream row is now its own shape — so `(MetricName, Attributes, TimeUnix, Value, Metadata)` is emitted by nothing. Its five-destination scan arm is removed from the production cursor, the chDB test double and the strict-scan lane's classifier, rather than kept as speculative generality. A result set arriving in that shape now fails loudly on scan arity instead of silently selecting a wider bind.

The columnar decoder needs no behavioural change — it declines on the first column name, `Line` never being `MetricName` — but its comments described the log shape as five-column and its count check as what declines it, and neither is true any more.

## Tests

- `probeRowShape` table covering every layout **and both collision cases**: a four-wide layout ending in `Metadata` that leads with `MetricName`, and a wider projection that leads with `Line`. Neither is read as what it resembles.
- End-to-end log-row decode with and without metadata, asserting the line/labels/timestamp round-trip, that `Value` stays zero, and — via `fakeRows` erroring on an unrecognised destination count — that no float destination is bound at all.
- A `DecodeLogRows` round-trip over a multi-row drain, pinning that per-series label interning still holds on the log path.
- A control test proving the sample-shaped layouts still bind their `Value`. This is the guard against the log-row branch widening to swallow a shape it does not own — the failure mode that would silently zero every metric result.
- Emitter-side pins that no log-stream projection carries a `Value` alias, a numeric literal, or a `toFloat64` wrap, for both the metadata and no-metadata schema shapes; plus the tail SQL's absence assertions.
- A cross-package pin that `logql.LogLineColumn` still equals the literal the cursor's probe duplicates — `chclient` cannot import `logql`, so a rename would otherwise silently stop the cursor recognising log rows.

`internal/logql/lang_test.go`'s existing five-slot assertion moves to four. That is the one existing test this changes, and it is the assertion this PR exists to change.

**Verified against chDB end to end**: the Loki handler suite's 223 tests pass, including `TestQuery_Streams_StructuredMetadata`, which drives the four-wide log+metadata layout through the real engine. Prom, Tempo, PromQL, TraceQL and the regression meta-tests pass untouched.

No golden churn: Layer 2a records logql SQL before `ProjectSamples`, so the wire projection appears in no fixture.

## Found, not fixed here

Both verified at their own `file:line` and filed:

- **#2043** — the columnar decoder dispatches to ClickHouse *before* its `ResponseShape` gate can decline, so under the opt-in `columnar_result_decode` feature every non-matrix query (all LogQL and Tempo shapes) executes twice. The gate's input is on the ctx before the dial; only its evaluation is late.
- **#2044** — strict-scan never sees LogQL's log-stream wire projection, the LogQL half of the gap #1635 closed for TraceQL. Real-ClickHouse coverage for the shape today is the compat-logql differential.

Closes #1430
