### PR TITLE
fix(api/loki): give /tail its own admission budget so tails cannot starve queries

### DIFF
--- a/.github/scripts/chart-render-assert.mjs
+++ b/.github/scripts/chart-render-assert.mjs
@@ -140,4 +140,24 @@ function count(haystack, needle) {
   check(negRejected, 'admit.tempo negative rejected (minimum:0 enforced)')
 }
 
+// --- 8. admit.tail is its own env knob, independent of admit.loki ------------
+// The Loki /tail WebSocket holds its admission slot until the client
+// disconnects, so it draws on CERBERUS_ADMIT_TAIL rather than the shared
+// CERBERUS_ADMIT_LOKI request budget. A chart that dropped the key, or aliased
+// it back onto admit.loki, would silently restore the starvation the split
+// exists to prevent.
+{
+  const out = tpl(['--set', 'admit.tail=4', '--set', 'admit.loki=128', '-s', 'templates/configmap-env.yaml'])
+  check(out.includes('CERBERUS_ADMIT_TAIL: "4"'), 'admit.tail integer cap renders as CERBERUS_ADMIT_TAIL="4"')
+  check(out.includes('CERBERUS_ADMIT_LOKI: "128"'), 'admit.tail does not disturb CERBERUS_ADMIT_LOKI')
+
+  let negRejected = false
+  try {
+    tpl(['--set', 'admit.tail=-1', '-s', 'templates/configmap-env.yaml'])
+  } catch {
+    negRejected = true
+  }
+  check(negRejected, 'admit.tail negative rejected (minimum:0 enforced)')
+}
+
 process.exit(ok ? 0 : 1)

--- a/cmd/cerberus/admit_tail_budget_test.go
+++ b/cmd/cerberus/admit_tail_budget_test.go
@@ -1,0 +1,151 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/tsouza/cerberus/internal/api/admit"
+	"github.com/tsouza/cerberus/internal/chopt"
+	"github.com/tsouza/cerberus/internal/config"
+	"github.com/tsouza/cerberus/internal/schema"
+)
+
+// admitTestConfig is the minimal Config the limiter + Loki-handler
+// bootstrap reads: the four admission caps plus the log schema the
+// handler is built against.
+func admitTestConfig(a config.AdmitConfig) config.Config {
+	return config.Config{
+		Admit: a,
+		Logs:  schema.DefaultOTelLogs(),
+	}
+}
+
+// TestNewAdmitLimiters_TailIsItsOwnBudget pins the process-level half of
+// the fix for issue #1482: CERBERUS_ADMIT_TAIL must produce a limiter
+// that is a DIFFERENT semaphore from the Loki request budget, not a
+// second reference to it and not a nil that silently falls back.
+//
+// The whole starvation bug is one shared semaphore, so pointer identity
+// is the property worth asserting here — a wiring that aliased the two
+// would satisfy every cap-arithmetic assertion in the package while
+// reproducing the bug exactly.
+func TestNewAdmitLimiters_TailIsItsOwnBudget(t *testing.T) {
+	cfg := admitTestConfig(config.AdmitConfig{
+		Prom:  config.DefaultAdmitProm,
+		Loki:  config.DefaultAdmitLoki,
+		Tempo: config.DefaultAdmitTempo,
+		Tail:  config.DefaultAdmitTail,
+	})
+
+	limiters := newAdmitLimiters(cfg, quietLogger())
+
+	if limiters.lokiTail == nil {
+		t.Fatal("lokiTail limiter is nil — CERBERUS_ADMIT_TAIL built no budget, leaving /tail unadmitted")
+	}
+	if limiters.loki == nil {
+		t.Fatal("loki limiter is nil")
+	}
+	if limiters.lokiTail == limiters.loki {
+		t.Fatal("lokiTail and loki are the same *admit.Limiter — one semaphore means tails still starve queries (#1482)")
+	}
+	if got := limiters.lokiTail.Budget(); got != admit.BudgetTail {
+		t.Errorf("lokiTail.Budget() = %q, want %q", got, admit.BudgetTail)
+	}
+	if got := limiters.loki.Budget(); got != admit.BudgetRequest {
+		t.Errorf("loki.Budget() = %q, want %q", got, admit.BudgetRequest)
+	}
+	// Both budgets belong to the Loki head, so the existing per-head
+	// telemetry keeps resolving; only `budget` tells them apart.
+	if got := limiters.lokiTail.Head(); got != "loki" {
+		t.Errorf("lokiTail.Head() = %q, want \"loki\"", got)
+	}
+}
+
+// TestNewAdmitLimiters_TailCapIsIndependentOfLokiCap pins that the two
+// caps are read from their own config fields. A tail cap derived from
+// (or clamped to) the Loki cap would make CERBERUS_ADMIT_TAIL cosmetic.
+func TestNewAdmitLimiters_TailCapIsIndependentOfLokiCap(t *testing.T) {
+	// Tail budget 1, Loki request budget 2. Drain the tail budget; the
+	// request budget must still hand out both of its slots.
+	limiters := newAdmitLimiters(admitTestConfig(config.AdmitConfig{
+		Loki: 2,
+		Tail: 1,
+	}), quietLogger())
+
+	rel, ok := limiters.lokiTail.Acquire(t.Context())
+	if !ok {
+		t.Fatal("tail acquire 1: want ok")
+	}
+	defer rel()
+	if _, ok := limiters.lokiTail.Acquire(t.Context()); ok {
+		t.Fatal("tail acquire 2: want reject — the tail cap of 1 is not being applied")
+	}
+
+	for i := range 2 {
+		relQ, ok := limiters.loki.Acquire(t.Context())
+		if !ok {
+			t.Fatalf("loki acquire %d with the tail budget drained: want ok (#1482)", i)
+		}
+		defer relQ()
+	}
+}
+
+// TestNewAdmitLimiters_DisabledNilsEveryBudget pins that the master
+// switch reaches the new budget too. A CERBERUS_ADMIT_DISABLED=true
+// process that still built a tail limiter would cap live-tailing on a
+// deployment that asked for no admission control at all.
+func TestNewAdmitLimiters_DisabledNilsEveryBudget(t *testing.T) {
+	limiters := newAdmitLimiters(admitTestConfig(config.AdmitConfig{
+		Disabled: true,
+		Prom:     config.DefaultAdmitProm,
+		Loki:     config.DefaultAdmitLoki,
+		Tempo:    config.DefaultAdmitTempo,
+		Tail:     config.DefaultAdmitTail,
+	}), quietLogger())
+
+	if limiters != (admitLimiters{}) {
+		t.Fatalf("CERBERUS_ADMIT_DISABLED=true must nil every budget, got %+v", limiters)
+	}
+}
+
+// TestNewAdmitLimiters_ZeroTailCapMeansUnadmitted pins the "0 ==
+// unlimited" convention on the new knob, matching every other admission
+// cap: CERBERUS_ADMIT_TAIL=0 (or `false`) builds no tail limiter, so
+// /tail mounts pass-through rather than being capped at zero — which
+// would reject every tail and break Live-tailing outright.
+func TestNewAdmitLimiters_ZeroTailCapMeansUnadmitted(t *testing.T) {
+	limiters := newAdmitLimiters(admitTestConfig(config.AdmitConfig{
+		Loki: config.DefaultAdmitLoki,
+		Tail: 0,
+	}), quietLogger())
+
+	if limiters.lokiTail != nil {
+		t.Fatalf("tail cap 0 must build no limiter (unlimited), got %+v", limiters.lokiTail)
+	}
+	if limiters.loki == nil {
+		t.Fatal("an unlimited tail budget must not disable the Loki request budget")
+	}
+}
+
+// TestNewLokiHandler_WiresBothBudgets closes the loop from the limiters
+// to the handler fields the Loki mux reads. newAdmitLimiters can build
+// two perfectly distinct budgets and the bug still returns if the
+// handler receives the request limiter in both slots.
+func TestNewLokiHandler_WiresBothBudgets(t *testing.T) {
+	cfg := admitTestConfig(config.AdmitConfig{
+		Loki: config.DefaultAdmitLoki,
+		Tail: config.DefaultAdmitTail,
+	})
+	limiters := newAdmitLimiters(cfg, quietLogger())
+
+	h := newLokiHandler(lazyClient(t), cfg, chopt.EnabledSet{}, limiters.loki, limiters.lokiTail, quietLogger())
+
+	if h.Limiter != limiters.loki {
+		t.Errorf("Handler.Limiter = %p, want the loki request budget %p", h.Limiter, limiters.loki)
+	}
+	if h.TailLimiter != limiters.lokiTail {
+		t.Errorf("Handler.TailLimiter = %p, want the tail budget %p", h.TailLimiter, limiters.lokiTail)
+	}
+	if h.TailLimiter == h.Limiter {
+		t.Error("Handler.TailLimiter aliases Handler.Limiter — /tail would draw on the query budget again (#1482)")
+	}
+}

--- a/cmd/cerberus/admit_tail_budget_test.go
+++ b/cmd/cerberus/admit_tail_budget_test.go
@@ -1,7 +1,13 @@
 package main
 
 import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
 	"testing"
+
+	"github.com/gorilla/websocket"
 
 	"github.com/tsouza/cerberus/internal/api/admit"
 	"github.com/tsouza/cerberus/internal/chopt"
@@ -137,7 +143,7 @@ func TestNewLokiHandler_WiresBothBudgets(t *testing.T) {
 	})
 	limiters := newAdmitLimiters(cfg, quietLogger())
 
-	h := newLokiHandler(lazyClient(t), cfg, chopt.EnabledSet{}, limiters.loki, limiters.lokiTail, quietLogger())
+	h := newLokiHandler(lazyClient(t), cfg, chopt.EnabledSet{}, limiters, quietLogger())
 
 	if h.Limiter != limiters.loki {
 		t.Errorf("Handler.Limiter = %p, want the loki request budget %p", h.Limiter, limiters.loki)
@@ -147,5 +153,82 @@ func TestNewLokiHandler_WiresBothBudgets(t *testing.T) {
 	}
 	if h.TailLimiter == h.Limiter {
 		t.Error("Handler.TailLimiter aliases Handler.Limiter — /tail would draw on the query budget again (#1482)")
+	}
+}
+
+// TestMountAPIHeads_TailAndQueryBudgetsAreWiredEndToEnd is the only test
+// that exercises the WHOLE wiring chain the way the process does it:
+// config caps → newAdmitLimiters → mountAPIHeads → newLokiHandler →
+// loki.Handler.Mount → the real ServeMux → HTTP.
+//
+// Every other test in this file inspects one link. That leaves the
+// composition itself unpinned, and the composition is where issue #1482
+// actually lived: each part was individually reasonable, and the bug was
+// which budget the /tail pattern got mounted on. A wiring that fed the
+// request limiter to both fields — or swapped them — would satisfy the
+// per-link tests and fail here.
+//
+// The caps are deliberately asymmetric and both exhausted-by-one: hold
+// the single Loki request slot and the ordinary route must 503 while the
+// tail upgrade must still reach 101. Swap the two budgets anywhere along
+// the chain and the two assertions trade places.
+func TestMountAPIHeads_TailAndQueryBudgetsAreWiredEndToEnd(t *testing.T) {
+	t.Setenv("CERBERUS_ENABLED_HEADS", "loki")
+	t.Setenv("CERBERUS_ADMIT_LOKI", "1")
+	t.Setenv("CERBERUS_ADMIT_TAIL", "1")
+
+	cfg, err := config.FromEnv()
+	if err != nil {
+		t.Fatalf("config.FromEnv: %v", err)
+	}
+	logger := quietLogger()
+	limiters := newAdmitLimiters(cfg, logger)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	mux := http.NewServeMux()
+	if _, err := mountAPIHeads(ctx, mux, lazyClient(t), cfg, chopt.EnabledSet{}, limiters, logger); err != nil {
+		t.Fatalf("mountAPIHeads: %v", err)
+	}
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+
+	// Occupy the entire Loki REQUEST budget.
+	rel, ok := limiters.loki.Acquire(t.Context())
+	if !ok {
+		t.Fatal("setup: the loki request budget must start free")
+	}
+	defer rel()
+
+	resp, err := http.Get(srv.URL + `/loki/api/v1/labels`)
+	if err != nil {
+		t.Fatalf("GET /labels: %v", err)
+	}
+	status := resp.StatusCode
+	resp.Body.Close()
+	if status != http.StatusServiceUnavailable {
+		t.Fatalf("GET /labels with the request budget held: status %d, want 503 — the ordinary routes are not on limiters.loki", status)
+	}
+
+	// The tail budget is untouched, so the upgrade succeeds. The
+	// unreachable ClickHouse behind it only affects what the session
+	// streams AFTER the handshake, which is not what this asserts.
+	u, err := url.Parse(srv.URL)
+	if err != nil {
+		t.Fatalf("parse server URL: %v", err)
+	}
+	u.Scheme = "ws"
+	u.Path = "/loki/api/v1/tail"
+	u.RawQuery = "query=" + url.QueryEscape(`{job="api"}`)
+	conn, wsResp, err := websocket.DefaultDialer.Dial(u.String(), nil)
+	if conn != nil {
+		t.Cleanup(func() { _ = conn.Close() })
+	}
+	if wsResp == nil {
+		t.Fatalf("dial /tail: no handshake response (err=%v)", err)
+	}
+	defer wsResp.Body.Close()
+	if wsResp.StatusCode != http.StatusSwitchingProtocols {
+		t.Fatalf("dial /tail with only the REQUEST budget held: status %d, want 101 — /tail is drawing on the wrong budget (#1482)", wsResp.StatusCode)
 	}
 }

--- a/cmd/cerberus/chopt_reprobe_test.go
+++ b/cmd/cerberus/chopt_reprobe_test.go
@@ -176,12 +176,12 @@ func mountedConsumers(t *testing.T, enabledHeads string) chOptConsumers {
 	cfg.ClickHouse.Addr = unreachableAddr(t)
 
 	logger := quietLogger()
-	promLimiter, lokiLimiter, tempoLimiter := newAdmitLimiters(cfg, logger)
+	limiters := newAdmitLimiters(cfg, logger)
 	ctx, cancel := context.WithCancel(context.Background())
 	t.Cleanup(cancel)
 
 	heads, err := mountAPIHeads(ctx, http.NewServeMux(), lazyClient(t), cfg, chopt.EnabledSet{},
-		promLimiter, lokiLimiter, tempoLimiter, logger)
+		limiters, logger)
 	if err != nil {
 		t.Fatalf("mountAPIHeads: %v", err)
 	}

--- a/cmd/cerberus/enabled_heads_test.go
+++ b/cmd/cerberus/enabled_heads_test.go
@@ -53,14 +53,14 @@ func buildHeadsTestServer(t *testing.T, enabledHeads string) *httptest.Server {
 
 	logger := slog.New(slog.NewTextHandler(httptestDiscard{}, &slog.HandlerOptions{Level: slog.LevelError}))
 
-	prom, loki, tempo := newAdmitLimiters(cfg, logger)
+	limiters := newAdmitLimiters(cfg, logger)
 	traceMux := http.NewServeMux()
 	// mountAPIHeads owns lifecycle goroutines (the optcorpus reconciler when
 	// enabled), all bound to this ctx. Cancel it on cleanup so nothing leaks
 	// past the test.
 	ctx, cancel := context.WithCancel(context.Background())
 	t.Cleanup(cancel)
-	if _, err := mountAPIHeads(ctx, traceMux, client, cfg, chopt.EnabledSet{}, prom, loki, tempo, logger); err != nil {
+	if _, err := mountAPIHeads(ctx, traceMux, client, cfg, chopt.EnabledSet{}, limiters, logger); err != nil {
 		t.Fatalf("mountAPIHeads: %v", err)
 	}
 

--- a/cmd/cerberus/main.go
+++ b/cmd/cerberus/main.go
@@ -180,7 +180,7 @@ func mountAPIHeads(
 
 	if cfg.HeadEnabled(config.HeadLoki) {
 		lokiClient := client.ForHead(chclient.HeadLoki)
-		lokiHandler := newLokiHandler(lokiClient, cfg, optSet, limiters.loki, limiters.lokiTail, logger)
+		lokiHandler := newLokiHandler(lokiClient, cfg, optSet, limiters, logger)
 		lokiHandler.Mount(traceMux)
 		engines = append(engines, lokiHandler.Engine)
 	}
@@ -827,14 +827,18 @@ func nativeRangeLowerers(optSet chopt.EnabledSet) promql.RangeLowerers {
 // Extracted (mirroring newPromHandler) so run's bootstrap stays within its
 // maintainability budget as the optimization suite adds wiring.
 //
-// The head takes TWO limiters: `limiter` (CERBERUS_ADMIT_LOKI) fronts every
-// short-lived route, and `tailLimiter` (CERBERUS_ADMIT_TAIL) fronts only the
-// long-lived /tail WebSocket. They must be distinct instances — see
-// loki.Handler.TailLimiter and issue #1482.
-func newLokiHandler(client *chclient.Client, cfg config.Config, optSet chopt.EnabledSet, limiter, tailLimiter *admit.Limiter, logger *slog.Logger) *loki.Handler {
+// The head draws on TWO of the process's admission budgets: limiters.loki
+// (CERBERUS_ADMIT_LOKI) fronts every short-lived route, and limiters.lokiTail
+// (CERBERUS_ADMIT_TAIL) fronts only the long-lived /tail WebSocket. It takes
+// the whole admitLimiters rather than the two pointers positionally for the
+// reason that type exists: two same-typed *admit.Limiter parameters transpose
+// silently at the callsite, and transposing THESE two mounts /tail on the
+// request budget and every ordinary route on the tail budget — a subtler
+// #1482. Selecting the fields by name here makes that untypeable.
+func newLokiHandler(client *chclient.Client, cfg config.Config, optSet chopt.EnabledSet, limiters admitLimiters, logger *slog.Logger) *loki.Handler {
 	h := loki.New(client, cfg.Logs, logger.With("api", "loki"))
-	h.Limiter = limiter
-	h.TailLimiter = tailLimiter
+	h.Limiter = limiters.loki
+	h.TailLimiter = limiters.lokiTail
 	h.Version = Version
 	h.QueryTimeout = cfg.ClickHouse.QueryTimeout
 	h.TailWriteTimeout = cfg.LokiTailWriteTimeout

--- a/cmd/cerberus/main.go
+++ b/cmd/cerberus/main.go
@@ -65,28 +65,61 @@ func isVersionFlag(args []string) bool {
 	return false
 }
 
-// newAdmitLimiters builds the per-head admission-control limiters. When
+// admitLimiters carries the admission budgets this process fronts its
+// routes with. Prom / loki / tempo are the per-head request budgets;
+// lokiTail is the Loki head's SECOND budget, a distinct semaphore that
+// bounds only the long-lived /tail WebSocket. A nil field means that
+// budget is unadmitted (cap 0, or the master switch off) and the
+// middleware degrades to a pass-through wrapper.
+//
+// Grouped in a struct rather than returned as a tuple because the set is
+// no longer one-per-head: heads and budgets are different axes, and a
+// positional 4-tuple of same-typed pointers is exactly the shape where a
+// mis-ordered argument compiles and silently mounts /tail on the query
+// budget — the bug this type exists to prevent.
+type admitLimiters struct {
+	prom     *admit.Limiter
+	loki     *admit.Limiter
+	tempo    *admit.Limiter
+	lokiTail *admit.Limiter
+}
+
+// newAdmitLimiters builds the admission-control limiters. When
 // CERBERUS_ADMIT_DISABLED=true every limiter is nil and the middleware
-// short-circuits to a pass-through wrapper. Otherwise each per-head cap
-// CERBERUS_ADMIT_{PROM,LOKI,TEMPO} sizes its limiter directly (resolved by
-// config.admitFromEnv from an explicit integer or a true/false alias).
-// admit.New returns nil for a non-positive cap, so a disabled head and a
-// zero cap collapse to the same pass-through path.
-func newAdmitLimiters(cfg config.Config, logger *slog.Logger) (*admit.Limiter, *admit.Limiter, *admit.Limiter) {
+// short-circuits to a pass-through wrapper. Otherwise each cap
+// CERBERUS_ADMIT_{PROM,LOKI,TEMPO,TAIL} sizes its limiter directly
+// (resolved by config.admitFromEnv from an explicit integer or a
+// true/false alias). admit.New / admit.NewTail return nil for a
+// non-positive cap, so a disabled head and a zero cap collapse to the
+// same pass-through path.
+//
+// CERBERUS_ADMIT_TAIL builds its own limiter through admit.NewTail — NOT
+// a second reference to the Loki one. A /tail session occupies its slot
+// until the client disconnects, so pointing both at one semaphore lets
+// live-tail occupancy starve every ordinary Loki route on the replica
+// (issue #1482).
+func newAdmitLimiters(cfg config.Config, logger *slog.Logger) admitLimiters {
 	if cfg.Admit.Disabled {
 		logger.Info("admission control disabled (CERBERUS_ADMIT_DISABLED=true)")
-		return nil, nil, nil
+		return admitLimiters{}
 	}
 	promCap := cfg.Admit.Prom
 	lokiCap := cfg.Admit.Loki
 	tempoCap := cfg.Admit.Tempo
+	tailCap := cfg.Admit.Tail
 	logger.Info(
 		"admission control enabled",
 		"prom", promCap,
 		"loki", lokiCap,
 		"tempo", tempoCap,
+		"loki_tail", tailCap,
 	)
-	return admit.New("prom", promCap), admit.New("loki", lokiCap), admit.New("tempo", tempoCap)
+	return admitLimiters{
+		prom:     admit.New("prom", promCap),
+		loki:     admit.New("loki", lokiCap),
+		tempo:    admit.New("tempo", tempoCap),
+		lokiTail: admit.NewTail("loki", tailCap),
+	}
 }
 
 // apiHeads carries what run() needs back from mountAPIHeads: the Tempo gRPC
@@ -118,7 +151,7 @@ func mountAPIHeads(
 	client *chclient.Client,
 	cfg config.Config,
 	optSet chopt.EnabledSet,
-	promLimiter, lokiLimiter, tempoLimiter *admit.Limiter,
+	limiters admitLimiters,
 	logger *slog.Logger,
 ) (apiHeads, error) {
 	// engines accumulates the engines actually built so the corpus reconciler
@@ -136,18 +169,18 @@ func mountAPIHeads(
 		// built from it, so when prom is disabled neither the view nor the
 		// solver exists.
 		promClient := client.ForHead(chclient.HeadProm)
-		evalSolver, err := buildSolver(logger, cfg.ClickHouse, promClient, promLimiter)
+		evalSolver, err := buildSolver(logger, cfg.ClickHouse, promClient, limiters.prom)
 		if err != nil {
 			return apiHeads{}, fmt.Errorf("configure solver: %w", err)
 		}
-		promHandler = newPromHandler(promClient, cfg, optSet, evalSolver, promLimiter, logger)
+		promHandler = newPromHandler(promClient, cfg, optSet, evalSolver, limiters.prom, logger)
 		promHandler.Mount(traceMux)
 		engines = append(engines, promHandler.Engine)
 	}
 
 	if cfg.HeadEnabled(config.HeadLoki) {
 		lokiClient := client.ForHead(chclient.HeadLoki)
-		lokiHandler := newLokiHandler(lokiClient, cfg, optSet, lokiLimiter, logger)
+		lokiHandler := newLokiHandler(lokiClient, cfg, optSet, limiters.loki, limiters.lokiTail, logger)
 		lokiHandler.Mount(traceMux)
 		engines = append(engines, lokiHandler.Engine)
 	}
@@ -156,7 +189,7 @@ func mountAPIHeads(
 	if cfg.HeadEnabled(config.HeadTempo) {
 		tempoClient := client.ForHead(chclient.HeadTempo)
 		tempoHandler := tempo.New(tempoClient, cfg.Traces, Version, logger.With("api", "tempo"))
-		tempoHandler.Limiter = tempoLimiter
+		tempoHandler.Limiter = limiters.tempo
 		tempoHandler.StructuralTwoPhase = cfg.TempoStructuralTwoPhase
 		tempoHandler.Engine.Settings = settingsRules(cfg, optSet)
 		tempoHandler.Mount(traceMux)
@@ -166,7 +199,7 @@ func mountAPIHeads(
 		// + schema + admit limiter so the streaming RPC bodies and the HTTP
 		// handlers run the same parse + lower + emit pipeline. Built only when
 		// tempo is enabled; nil otherwise.
-		tempoGRPCService := tempogrpc.NewService(tempoHandler, tempoLimiter, logger.With("api", "tempo-grpc"))
+		tempoGRPCService := tempogrpc.NewService(tempoHandler, limiters.tempo, logger.With("api", "tempo-grpc"))
 		grpcServer = tempogrpc.NewServer(tempoGRPCService)
 	}
 
@@ -447,8 +480,8 @@ func run() error {
 		return err
 	}
 
-	// Build per-head admission-control limiters (see newAdmitLimiters).
-	promLimiter, lokiLimiter, tempoLimiter := newAdmitLimiters(cfg, logger)
+	// Build the admission-control limiters (see newAdmitLimiters).
+	limiters := newAdmitLimiters(cfg, logger)
 
 	// The trace mux carries the three Prom/Loki/Tempo APIs and is
 	// wrapped with otelhttp so every request becomes a server span.
@@ -488,7 +521,7 @@ func run() error {
 	// (one process = one OOM kills all heads today). The Tempo gRPC server is
 	// likewise nil when tempo is off. /healthz + /readyz are mounted below,
 	// unconditionally, in every mode.
-	heads, err := mountAPIHeads(ctx, traceMux, client, cfg, optSet, promLimiter, lokiLimiter, tempoLimiter, logger)
+	heads, err := mountAPIHeads(ctx, traceMux, client, cfg, optSet, limiters, logger)
 	if err != nil {
 		return err
 	}
@@ -789,13 +822,19 @@ func nativeRangeLowerers(optSet chopt.EnabledSet) promql.RangeLowerers {
 	return l
 }
 
-// newLokiHandler builds the Loki head's handler with its limiter, version,
+// newLokiHandler builds the Loki head's handler with its limiters, version,
 // timeouts, and the resolved per-query optimization SettingsRules wired in.
 // Extracted (mirroring newPromHandler) so run's bootstrap stays within its
 // maintainability budget as the optimization suite adds wiring.
-func newLokiHandler(client *chclient.Client, cfg config.Config, optSet chopt.EnabledSet, limiter *admit.Limiter, logger *slog.Logger) *loki.Handler {
+//
+// The head takes TWO limiters: `limiter` (CERBERUS_ADMIT_LOKI) fronts every
+// short-lived route, and `tailLimiter` (CERBERUS_ADMIT_TAIL) fronts only the
+// long-lived /tail WebSocket. They must be distinct instances — see
+// loki.Handler.TailLimiter and issue #1482.
+func newLokiHandler(client *chclient.Client, cfg config.Config, optSet chopt.EnabledSet, limiter, tailLimiter *admit.Limiter, logger *slog.Logger) *loki.Handler {
 	h := loki.New(client, cfg.Logs, logger.With("api", "loki"))
 	h.Limiter = limiter
+	h.TailLimiter = tailLimiter
 	h.Version = Version
 	h.QueryTimeout = cfg.ClickHouse.QueryTimeout
 	h.TailWriteTimeout = cfg.LokiTailWriteTimeout

--- a/cmd/cerberus/prom_metadata_lookback_test.go
+++ b/cmd/cerberus/prom_metadata_lookback_test.go
@@ -48,8 +48,8 @@ func newPromHandlerForTest(t *testing.T) *promHandlerUnderTest {
 	t.Cleanup(func() { _ = client.Close() })
 
 	logger := slog.New(slog.NewTextHandler(httptestDiscard{}, &slog.HandlerOptions{Level: slog.LevelError}))
-	promLimiter, _, _ := newAdmitLimiters(cfg, logger)
-	h := newPromHandler(client, cfg, chopt.EnabledSet{}, nil, promLimiter, logger)
+	limiters := newAdmitLimiters(cfg, logger)
+	h := newPromHandler(client, cfg, chopt.EnabledSet{}, nil, limiters.prom, logger)
 	return &promHandlerUnderTest{cfg: cfg, lookback: h.MetadataLookback}
 }
 

--- a/cmd/cerberus/solver_no_background_loop_test.go
+++ b/cmd/cerberus/solver_no_background_loop_test.go
@@ -62,7 +62,7 @@ func TestMountAPIHeads_PromStartsNoBackgroundLoop(t *testing.T) {
 	t.Cleanup(func() { _ = client.Close() })
 
 	logger := slog.New(slog.NewTextHandler(httptestDiscard{}, &slog.HandlerOptions{Level: slog.LevelError}))
-	prom, loki, tempo := newAdmitLimiters(cfg, logger)
+	limiters := newAdmitLimiters(cfg, logger)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	t.Cleanup(cancel)
@@ -75,7 +75,7 @@ func TestMountAPIHeads_PromStartsNoBackgroundLoop(t *testing.T) {
 		goleak.IgnoreCurrent(),
 	}
 
-	if _, err := mountAPIHeads(ctx, http.NewServeMux(), client, cfg, chopt.EnabledSet{}, prom, loki, tempo, logger); err != nil {
+	if _, err := mountAPIHeads(ctx, http.NewServeMux(), client, cfg, chopt.EnabledSet{}, limiters, logger); err != nil {
 		t.Fatalf("mountAPIHeads: %v", err)
 	}
 

--- a/deploy/helm/cerberus/README.md
+++ b/deploy/helm/cerberus/README.md
@@ -212,9 +212,10 @@ Kubernetes: `>=1.23.0-0`
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| admit.disabled | bool | `false` | Disable admission entirely on every head (CERBERUS_ADMIT_DISABLED). |
-| admit.loki | bool | `true` | Loki API in-flight cap (CERBERUS_ADMIT_LOKI): integer cap, or true (default cap 64) / false (unlimited). |
+| admit.disabled | bool | `false` | Disable admission entirely on every budget (CERBERUS_ADMIT_DISABLED). |
+| admit.loki | bool | `true` | Loki API in-flight cap, every route EXCEPT /tail (CERBERUS_ADMIT_LOKI): integer cap, or true (default cap 64) / false (unlimited). |
 | admit.prom | bool | `true` | Prom API in-flight cap (CERBERUS_ADMIT_PROM): integer cap, or true (default cap 64) / false (unlimited). |
+| admit.tail | bool | `true` | Concurrent Loki /tail WebSocket sessions, on its own budget (CERBERUS_ADMIT_TAIL): integer cap, or true (default cap 16) / false (unlimited). |
 | admit.tempo | bool | `true` | Tempo API in-flight cap (CERBERUS_ADMIT_TEMPO): integer cap, or true (default cap 32) / false (unlimited). |
 | affinity | object | `{}` | Affinity. Composed UNDER `affinityPresets` below — any field set here wins; the presets only inject podAffinity terms. |
 | affinityPresets | object | `{"colocateWithClickHouse":{"enabled":false,"mode":"preferred","podSelector":{"matchLabels":{"app.kubernetes.io/name":"clickhouse"}},"topologyKey":"kubernetes.io/hostname"}}` | Scheduling affinity presets (a convenience over hand-writing raw affinity). Composed over `affinity` above. |

--- a/deploy/helm/cerberus/templates/_helpers.tpl
+++ b/deploy/helm/cerberus/templates/_helpers.tpl
@@ -286,6 +286,7 @@ CERBERUS_AUTO_CREATE_DATABASE: {{ if kindIs "invalid" .Values.autoCreate.databas
 CERBERUS_ADMIT_PROM: {{ .Values.admit.prom | quote }}
 CERBERUS_ADMIT_LOKI: {{ .Values.admit.loki | quote }}
 CERBERUS_ADMIT_TEMPO: {{ .Values.admit.tempo | quote }}
+CERBERUS_ADMIT_TAIL: {{ .Values.admit.tail | quote }}
 CERBERUS_ADMIT_DISABLED: {{ .Values.admit.disabled | quote }}
 {{- if .Values.requirementsCheck }}
 CERBERUS_REQUIREMENTS_CHECK: "true"

--- a/deploy/helm/cerberus/values.schema.json
+++ b/deploy/helm/cerberus/values.schema.json
@@ -200,6 +200,7 @@
         "prom": { "type": ["boolean", "integer"], "minimum": 0 },
         "loki": { "type": ["boolean", "integer"], "minimum": 0 },
         "tempo": { "type": ["boolean", "integer"], "minimum": 0 },
+        "tail": { "type": ["boolean", "integer"], "minimum": 0 },
         "disabled": { "type": "boolean" }
       }
     },

--- a/deploy/helm/cerberus/values.yaml
+++ b/deploy/helm/cerberus/values.yaml
@@ -363,20 +363,26 @@ autoCreate:
   # database yet). An explicit `false` always WINS — even under bundled.
   database: null
 
-# Per-head admission control (in-flight concurrency caps). prom / loki / tempo
-# each accept EITHER an explicit integer cap OR a boolean: `true` enables the
-# head at its conservative default cap (64 / 64 / 32), `false` (or `0`) leaves
-# the head unlimited, and a positive integer (e.g. `2`) pins an exact cap.
-# `disabled: true` is the master switch that removes admission control on every
-# head at once.
+# Admission control (concurrency caps). prom / loki / tempo / tail each accept
+# EITHER an explicit integer cap OR a boolean: `true` enables that budget at its
+# conservative default cap (64 / 64 / 32 / 16), `false` (or `0`) leaves it
+# unlimited, and a positive integer (e.g. `2`) pins an exact cap. `disabled:
+# true` is the master switch that removes admission control everywhere at once.
+#
+# `tail` is a SEPARATE budget from `loki`, not a sub-cap of it: a /tail
+# WebSocket holds its slot until the client disconnects, so drawn from the same
+# pool as the millisecond-scale routes, live-tail sessions would ratchet the
+# Loki head to zero free slots and 503 every query on the replica.
 admit:
   # -- Prom API in-flight cap (CERBERUS_ADMIT_PROM): integer cap, or true (default cap 64) / false (unlimited).
   prom: true
-  # -- Loki API in-flight cap (CERBERUS_ADMIT_LOKI): integer cap, or true (default cap 64) / false (unlimited).
+  # -- Loki API in-flight cap, every route EXCEPT /tail (CERBERUS_ADMIT_LOKI): integer cap, or true (default cap 64) / false (unlimited).
   loki: true
   # -- Tempo API in-flight cap (CERBERUS_ADMIT_TEMPO): integer cap, or true (default cap 32) / false (unlimited).
   tempo: true
-  # -- Disable admission entirely on every head (CERBERUS_ADMIT_DISABLED).
+  # -- Concurrent Loki /tail WebSocket sessions, on its own budget (CERBERUS_ADMIT_TAIL): integer cap, or true (default cap 16) / false (unlimited).
+  tail: true
+  # -- Disable admission entirely on every budget (CERBERUS_ADMIT_DISABLED).
   disabled: false
 
 otlp:

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -282,13 +282,13 @@ integer pins an exact cap. A negative or unparseable value is rejected at
 startup. `CERBERUS_ADMIT_DISABLED` is a separate master switch that turns every
 budget off at once.
 
-| Variable                  | Config file      | Type        | Default | Description                                                                                                                                                     |
-| ------------------------- | ---------------- | ----------- | ------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `CERBERUS_ADMIT_DISABLED` | `admit.disabled` | bool        | `false` | Disable admission control entirely on every head (handy for local development).                                                                                 |
-| `CERBERUS_ADMIT_PROM`     | `admit.prom`     | int \| bool | `64`    | Prom API in-flight cap. Integer caps the head; `true` = default cap 64; `false`/`0` = unlimited.                                                                |
-| `CERBERUS_ADMIT_LOKI`     | `admit.loki`     | int \| bool | `64`    | Loki API in-flight cap. Integer caps the head; `true` = default cap 64; `false`/`0` = unlimited.                                                                |
-| `CERBERUS_ADMIT_TEMPO`    | `admit.tempo`    | int \| bool | `32`    | Tempo API in-flight cap. Integer caps the head; `true` = default cap 32; `false`/`0` = unlimited.                                                               |
-| `CERBERUS_ADMIT_TAIL`     | `admit.tail`     | int \| bool | `16`    | Concurrent Loki `/tail` WebSocket sessions, on a budget SEPARATE from `CERBERUS_ADMIT_LOKI`. Integer caps it; `true` = default cap 16; `false`/`0` = unlimited. |
+| Variable                  | Config file      | Type        | Default | Description                                                                                                                                                       |
+| ------------------------- | ---------------- | ----------- | ------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `CERBERUS_ADMIT_DISABLED` | `admit.disabled` | bool        | `false` | Disable admission control entirely, on every budget at once (handy for local development).                                                                        |
+| `CERBERUS_ADMIT_PROM`     | `admit.prom`     | int \| bool | `64`    | Prom API in-flight cap. Integer caps the head; `true` = default cap 64; `false`/`0` = unlimited.                                                                  |
+| `CERBERUS_ADMIT_LOKI`     | `admit.loki`     | int \| bool | `64`    | Loki API in-flight cap, covering every route EXCEPT `/tail` (see `CERBERUS_ADMIT_TAIL`). Integer caps the head; `true` = default cap 64; `false`/`0` = unlimited. |
+| `CERBERUS_ADMIT_TEMPO`    | `admit.tempo`    | int \| bool | `32`    | Tempo API in-flight cap. Integer caps the head; `true` = default cap 32; `false`/`0` = unlimited.                                                                 |
+| `CERBERUS_ADMIT_TAIL`     | `admit.tail`     | int \| bool | `16`    | Concurrent Loki `/tail` WebSocket sessions, on a budget SEPARATE from `CERBERUS_ADMIT_LOKI`. Integer caps it; `true` = default cap 16; `false`/`0` = unlimited.   |
 
 ## Logging
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -267,19 +267,28 @@ simultaneous in-flight requests. Requests above the cap are rejected with HTTP
 of overload. Tempo's cap is half of Prom / Loki because trace queries are
 typically the heaviest per-call.
 
-`CERBERUS_ADMIT_{PROM,LOKI,TEMPO}` each accept **either** a non-negative
-integer cap **or** a boolean alias: `true` enables the head at its conservative
-default cap, `false` (or `0`) leaves that head unlimited, and a positive
+The Loki head's `/tail` WebSocket draws on its OWN budget,
+`CERBERUS_ADMIT_TAIL`, because it bounds a different quantity: an ordinary
+request holds its slot for milliseconds, whereas a tail holds one from the
+WebSocket upgrade until the client disconnects. Sharing one semaphore would
+let idle Live-tail panels ratchet the Loki head to zero free slots and 503
+every query on the replica, so the two budgets are sized and exhausted
+independently.
+
+`CERBERUS_ADMIT_{PROM,LOKI,TEMPO,TAIL}` each accept **either** a non-negative
+integer cap **or** a boolean alias: `true` enables that budget at its
+conservative default cap, `false` (or `0`) leaves it unlimited, and a positive
 integer pins an exact cap. A negative or unparseable value is rejected at
 startup. `CERBERUS_ADMIT_DISABLED` is a separate master switch that turns every
-head off at once.
+budget off at once.
 
-| Variable                  | Config file      | Type        | Default | Description                                                                                       |
-| ------------------------- | ---------------- | ----------- | ------- | ------------------------------------------------------------------------------------------------- |
-| `CERBERUS_ADMIT_DISABLED` | `admit.disabled` | bool        | `false` | Disable admission control entirely on every head (handy for local development).                   |
-| `CERBERUS_ADMIT_PROM`     | `admit.prom`     | int \| bool | `64`    | Prom API in-flight cap. Integer caps the head; `true` = default cap 64; `false`/`0` = unlimited.  |
-| `CERBERUS_ADMIT_LOKI`     | `admit.loki`     | int \| bool | `64`    | Loki API in-flight cap. Integer caps the head; `true` = default cap 64; `false`/`0` = unlimited.  |
-| `CERBERUS_ADMIT_TEMPO`    | `admit.tempo`    | int \| bool | `32`    | Tempo API in-flight cap. Integer caps the head; `true` = default cap 32; `false`/`0` = unlimited. |
+| Variable                  | Config file      | Type        | Default | Description                                                                                                                                                     |
+| ------------------------- | ---------------- | ----------- | ------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `CERBERUS_ADMIT_DISABLED` | `admit.disabled` | bool        | `false` | Disable admission control entirely on every head (handy for local development).                                                                                 |
+| `CERBERUS_ADMIT_PROM`     | `admit.prom`     | int \| bool | `64`    | Prom API in-flight cap. Integer caps the head; `true` = default cap 64; `false`/`0` = unlimited.                                                                |
+| `CERBERUS_ADMIT_LOKI`     | `admit.loki`     | int \| bool | `64`    | Loki API in-flight cap. Integer caps the head; `true` = default cap 64; `false`/`0` = unlimited.                                                                |
+| `CERBERUS_ADMIT_TEMPO`    | `admit.tempo`    | int \| bool | `32`    | Tempo API in-flight cap. Integer caps the head; `true` = default cap 32; `false`/`0` = unlimited.                                                               |
+| `CERBERUS_ADMIT_TAIL`     | `admit.tail`     | int \| bool | `16`    | Concurrent Loki `/tail` WebSocket sessions, on a budget SEPARATE from `CERBERUS_ADMIT_LOKI`. Integer caps it; `true` = default cap 16; `false`/`0` = unlimited. |
 
 ## Logging
 

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -656,6 +656,21 @@ demand exceeds `CERBERUS_ADMIT_TAIL`; sustained `budget="request"`
 rejections on `cerberus_ql="logql"` are ordinary query saturation and are
 now unaffected by how many tails are open.
 
+The tail budget is independent of `CERBERUS_ADMIT_LOKI` in both
+directions, including when that knob is off: a replica running
+`CERBERUS_ADMIT_LOKI=0` (unlimited Loki requests) still admits at most
+`CERBERUS_ADMIT_TAIL` concurrent tail sessions, because "unlimited
+requests" says nothing about how many unbounded-duration streams the
+replica should carry. Set `CERBERUS_ADMIT_TAIL=0` to opt out of the tail
+cap as well, or `CERBERUS_ADMIT_DISABLED=true` to opt out of both.
+
+A tail refused by the tail cap is refused at the HTTP upgrade — `503` +
+`Retry-After: 1`, before the connection becomes a WebSocket — rather than
+upgraded and then closed with a close frame the way reference Loki
+answers its own `querier.max-concurrent-tail-requests`. Issue
+[#2048](https://github.com/tsouza/cerberus/issues/2048) tracks aligning
+the two, since a WebSocket client does not read the `Retry-After` header.
+
 `CERBERUS_ADMIT_DISABLED=true` removes admission control entirely, on
 every budget at once — useful for local development where artificial caps
 mask real concurrency bugs.

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -604,21 +604,61 @@ pool serves them from a shared connection set.
 
 ### Per-handler concurrency caps (admission control)
 
-Cerberus's `internal/api/admit` package fronts each of the three API
-heads with a counted semaphore that caps simultaneous in-flight
-requests. Caps are env-driven via `CERBERUS_ADMIT_PROM` /
-`CERBERUS_ADMIT_LOKI` / `CERBERUS_ADMIT_TEMPO` (defaults: 64 / 64 / 32
-— Tempo is half because trace queries are typically the heaviest
-per-call). Each accepts an explicit integer cap or a boolean alias
-(`true` = the default cap, `false`/`0` = that head unlimited), so a plain
-chart bool and a precise operator cap both work. Requests above the cap
-are rejected with HTTP 503 +
-`Retry-After: 1` so well-behaved clients back off and ClickHouse stays
-out of overload.
+Cerberus's `internal/api/admit` package fronts its routes with counted
+semaphores. Each accepts an explicit integer cap or a boolean alias
+(`true` = the default cap, `false`/`0` = unlimited), so a plain chart
+bool and a precise operator cap both work. An occupant above the cap is
+rejected with HTTP 503 + `Retry-After: 1` so well-behaved clients back
+off and ClickHouse stays out of overload.
 
-`CERBERUS_ADMIT_DISABLED=true` removes admission control entirely —
-useful for local development where artificial caps mask real
-concurrency bugs.
+There are **four** budgets, and they are not four heads — they are three
+request budgets plus one for long-lived streams:
+
+| Knob                   | Default | Bounds                              | A slot is held for                                   |
+| ---------------------- | ------- | ----------------------------------- | ---------------------------------------------------- |
+| `CERBERUS_ADMIT_PROM`  | 64      | every Prom route                    | the request (milliseconds)                           |
+| `CERBERUS_ADMIT_LOKI`  | 64      | every Loki route **except** `/tail` | the request (milliseconds)                           |
+| `CERBERUS_ADMIT_TEMPO` | 32      | every Tempo route (HTTP + gRPC)     | the request (milliseconds)                           |
+| `CERBERUS_ADMIT_TAIL`  | 16      | `GET /loki/api/v1/tail` only        | **the whole session — until the client disconnects** |
+
+Tempo's cap is half of Prom / Loki because trace queries (search +
+tag-value scans + per-trace span fetches) are the heaviest per-call.
+
+The tail budget is separate because it bounds a different quantity. The
+three request budgets cap *concurrency*: slots churn in milliseconds, so
+a cap of 64 sustains far more than 64 queries per second. The tail
+budget caps *concurrent live-tail sessions*: a `/tail` slot is taken at
+the WebSocket upgrade and returned only when the client disconnects,
+which is minutes or hours later — nothing reclaims it in between, and
+`CERBERUS_HTTP_WRITE_TIMEOUT` defaults to unlimited precisely so a tail
+can stream indefinitely. Read the tail cap as "how many Grafana Live-tail
+panels may point at one replica at once", and size it against the
+per-session steady load: each tail re-queries ClickHouse about once a
+second, so the cap is also tailing's background query rate per replica.
+
+Sizing them separately is what keeps the two from interfering. Were
+`/tail` drawn from the Loki request budget, `CERBERUS_ADMIT_LOKI`
+concurrent Live-tail sessions would occupy every Loki slot indefinitely
+and every subsequent `/query`, `/query_range`, `/labels`, `/series`,
+`/patterns` and Drilldown probe on that replica would 503 until a tail
+client disconnected. Occupancy would only ratchet one way, and the
+symptom — "the Loki datasource is down", on a healthy pod with no
+elevated CPU — points nowhere near the cause. Exhausting the tail budget
+now costs ordinary Loki queries nothing: the two semaphores are
+independent, and a saturated tail budget rejects only new `/tail`
+upgrades.
+
+To tell which budget rejected a request, group the rejection counter by
+the `budget` label: `sum by (cerberus_ql, budget, reason)
+(rate(cerberus_admit_rejected_total[5m]))` splits `budget="request"` from
+`budget="tail"`. Sustained `budget="tail"` rejections mean live-tail
+demand exceeds `CERBERUS_ADMIT_TAIL`; sustained `budget="request"`
+rejections on `cerberus_ql="logql"` are ordinary query saturation and are
+now unaffected by how many tails are open.
+
+`CERBERUS_ADMIT_DISABLED=true` removes admission control entirely, on
+every budget at once — useful for local development where artificial caps
+mask real concurrency bugs.
 
 ### Kubernetes HorizontalPodAutoscaler
 

--- a/internal/api/admit/admit.go
+++ b/internal/api/admit/admit.go
@@ -14,6 +14,15 @@
 // failing fast on the slow few rather than degrading service for
 // everyone.
 //
+// A head can own MORE THAN ONE budget, because a semaphore counts
+// requests rather than occupancy-time and those two quantities only
+// coincide while every occupant is short-lived. The Loki head's
+// `/tail` WebSocket holds its slot from the upgrade until the client
+// disconnects — minutes or hours — so it gets its own [NewTail]
+// limiter (`CERBERUS_ADMIT_TAIL`) rather than drawing on the
+// millisecond-scale request budget every other Loki route shares. See
+// docs/operations.md § "Per-handler concurrency caps".
+//
 // The limiter is opt-out (`CERBERUS_ADMIT_DISABLED=true`) for local /
 // dev workflows where artificial caps get in the way; in production
 // it should always be on.
@@ -48,6 +57,26 @@ const meterName = "github.com/tsouza/cerberus/internal/api/admit"
 // panel resolves consistently across both metric sources.
 const attrQL = attribute.Key("cerberus.ql")
 
+// attrBudget labels the rejection counter with WHICH of a head's
+// admission budgets ran out. A head can front more than one semaphore
+// (see the package doc): without this dimension a saturated long-lived
+// budget and a saturated request budget are indistinguishable on the
+// wire, and the operator-visible symptom of both is the same 503 — the
+// exact ambiguity issue #1482 reports as "the Loki datasource is down"
+// with a healthy pod. Grouping by it is additive for existing
+// dashboards: `sum by (cerberus_ql, reason)` still resolves, it just
+// sums the budgets back together.
+const attrBudget = attribute.Key("budget")
+
+// BudgetRequest is the budget every short-lived HTTP request and gRPC
+// stream draws on — the one [New] builds. BudgetTail is the separate
+// long-lived-stream budget [NewTail] builds, held for the whole
+// lifetime of a Loki `/tail` WebSocket.
+const (
+	BudgetRequest = "request"
+	BudgetTail    = "tail"
+)
+
 // attrReason labels the rejection counter with the rejection cause.
 // The limiter currently has exactly one rejection path: the weighted
 // semaphore was at its cap when Acquire ran. Future paths (e.g.,
@@ -58,7 +87,7 @@ const attrReason = attribute.Key("reason")
 // ReasonCapExceeded is emitted on the reason attribute when Acquire
 // is called while the limiter's semaphore is saturated. It's the only
 // rejection path the limiter has today, and newWithProvider
-// pre-registers its (cerberus.ql, reason) stream at 0 when the
+// pre-registers its (cerberus.ql, budget, reason) stream at 0 when the
 // Limiter is constructed — see the zero-init note there. Future
 // reason values must be pre-registered the same way so dashboards
 // see a 0-valued series instead of "No data" on healthy replicas.
@@ -97,13 +126,14 @@ func headToQL(head string) string {
 type Limiter struct {
 	head     string
 	ql       string
+	budget   string
 	sem      *semaphore.Weighted
 	rejected metric.Int64Counter
 }
 
-// New constructs a Limiter for head with the given cap. head is the
-// API identifier ("prom" / "loki" / "tempo") used to label the
-// rejection counter; cap is the maximum number of concurrent
+// New constructs a [BudgetRequest] Limiter for head with the given cap.
+// head is the API identifier ("prom" / "loki" / "tempo") used to label
+// the rejection counter; cap is the maximum number of concurrent
 // in-flight requests. A cap of 0 or less returns nil — the caller
 // treats that as "admission control disabled for this head", which
 // makes config wiring symmetric across the enabled / disabled cases.
@@ -113,14 +143,34 @@ type Limiter struct {
 // (via cmd/cerberus/main.go) before building limiters so the counter
 // flows to the configured OTLP exporter.
 func New(head string, cap int) *Limiter {
-	return newWithProvider(head, cap, otel.GetMeterProvider())
+	return newWithProvider(head, BudgetRequest, cap, otel.GetMeterProvider())
 }
 
-// newWithProvider is the test seam New() funnels through. Lets unit
-// tests construct a Limiter whose rejected counter targets a manual
-// reader without racing with parallel tests that use the global
+// NewTail constructs the [BudgetTail] Limiter for head — the separate
+// budget that bounds long-lived streaming routes, today only the Loki
+// head's `/tail` WebSocket. It is a DIFFERENT semaphore from the one
+// [New] returns for the same head, so a replica whose tail budget is
+// fully occupied still admits ordinary queries at full request cap.
+//
+// Sizing it separately is the point, not a convenience: a tail slot is
+// released at client disconnect (the handler streams until then, and
+// CERBERUS_HTTP_WRITE_TIMEOUT defaults to unlimited precisely so it
+// can), so tail occupancy ratchets one way over a session's lifetime
+// where request occupancy churns in milliseconds. Sharing one
+// semaphore between the two lets N idle browser tabs permanently
+// consume a budget sized for query concurrency.
+//
+// Cap semantics, the nil-for-non-positive sentinel, and the
+// MeterProvider note are identical to [New].
+func NewTail(head string, cap int) *Limiter {
+	return newWithProvider(head, BudgetTail, cap, otel.GetMeterProvider())
+}
+
+// newWithProvider is the test seam New() and NewTail() funnel through.
+// Lets unit tests construct a Limiter whose rejected counter targets a
+// manual reader without racing with parallel tests that use the global
 // provider.
-func newWithProvider(head string, cap int, mp metric.MeterProvider) *Limiter {
+func newWithProvider(head, budget string, cap int, mp metric.MeterProvider) *Limiter {
 	if cap <= 0 {
 		return nil
 	}
@@ -130,7 +180,7 @@ func newWithProvider(head string, cap int, mp metric.MeterProvider) *Limiter {
 		metric.WithDescription(
 			"Requests rejected by the per-handler concurrency cap. "+
 				"Labels: cerberus.ql (promql / logql / traceql), "+
-				"reason (cap_exceeded).",
+				"budget (request / tail), reason (cap_exceeded).",
 		),
 		metric.WithUnit("{request}"),
 	)
@@ -153,11 +203,13 @@ func newWithProvider(head string, cap int, mp metric.MeterProvider) *Limiter {
 	// from process start, so rate() resolves to 0 per head.
 	rejected.Add(context.Background(), 0, metric.WithAttributes(
 		attrQL.String(ql),
+		attrBudget.String(budget),
 		attrReason.String(ReasonCapExceeded),
 	))
 	return &Limiter{
 		head:     head,
 		ql:       ql,
+		budget:   budget,
 		sem:      semaphore.NewWeighted(int64(cap)),
 		rejected: rejected,
 	}
@@ -176,6 +228,7 @@ func (l *Limiter) Acquire(ctx context.Context) (release func(), ok bool) {
 	if !l.sem.TryAcquire(1) {
 		l.rejected.Add(ctx, 1, metric.WithAttributes(
 			attrQL.String(l.ql),
+			attrBudget.String(l.budget),
 			attrReason.String(ReasonCapExceeded),
 		))
 		return func() {}, false
@@ -267,6 +320,18 @@ func (l *Limiter) Head() string {
 		return ""
 	}
 	return l.head
+}
+
+// Budget returns which of its head's admission budgets this Limiter
+// bounds — [BudgetRequest] or [BudgetTail]. A nil receiver (admission
+// disabled) returns "". Callers use it to assert a route was wired to
+// the budget it was meant to draw on, and to attribute a rejection log
+// line to the right cap.
+func (l *Limiter) Budget() string {
+	if l == nil {
+		return ""
+	}
+	return l.budget
 }
 
 // StreamInterceptor returns a grpc.StreamServerInterceptor that

--- a/internal/api/admit/admit.go
+++ b/internal/api/admit/admit.go
@@ -324,9 +324,9 @@ func (l *Limiter) Head() string {
 
 // Budget returns which of its head's admission budgets this Limiter
 // bounds — [BudgetRequest] or [BudgetTail]. A nil receiver (admission
-// disabled) returns "". Callers use it to assert a route was wired to
-// the budget it was meant to draw on, and to attribute a rejection log
-// line to the right cap.
+// disabled) returns "". It exists so a caller can assert a route was
+// wired to the budget it was meant to draw on: the two are the same
+// type, so nothing else distinguishes them at a callsite.
 func (l *Limiter) Budget() string {
 	if l == nil {
 		return ""

--- a/internal/api/admit/admit_test.go
+++ b/internal/api/admit/admit_test.go
@@ -304,12 +304,17 @@ func TestRejectedCounter(t *testing.T) {
 
 // rejectedStreams collects every cerberus_admit_rejected_total data
 // point from a manual-reader snapshot, keyed by its
-// "<cerberus.ql>/<reason>" attribute pair. Returning a map (rather
-// than a flat sum) lets callers assert both the per-stream value and
-// the *number* of distinct streams — the dashboard's
-// `sum by (cerberus_ql, reason)` panel renders one series per key,
-// so a stray second stream with mismatched attributes is itself a
+// "<cerberus.ql>/<budget>/<reason>" attribute triple. Returning a map
+// (rather than a flat sum) lets callers assert both the per-stream
+// value and the *number* of distinct streams — the dashboard's
+// `sum by (cerberus_ql, budget, reason)` panel renders one series per
+// key, so a stray extra stream with mismatched attributes is itself a
 // bug worth failing on.
+//
+// budget is part of the key, not merely asserted present: a head can
+// front more than one semaphore (request vs the Loki /tail budget) and
+// keying without it would silently collide their two streams into one
+// "duplicate" failure while a real duplicate went unnoticed.
 func rejectedStreams(t *testing.T, reader *metric.ManualReader) map[string]int64 {
 	t.Helper()
 	var rm metricdata.ResourceMetrics
@@ -334,11 +339,15 @@ func rejectedStreams(t *testing.T, reader *metric.ManualReader) map[string]int64
 				if !ok {
 					t.Fatalf("rejected_total data point missing cerberus.ql attribute: %v", dp.Attributes.ToSlice())
 				}
+				budget, ok := dp.Attributes.Value("budget")
+				if !ok {
+					t.Fatalf("rejected_total data point missing budget attribute: %v", dp.Attributes.ToSlice())
+				}
 				reason, ok := dp.Attributes.Value("reason")
 				if !ok {
 					t.Fatalf("rejected_total data point missing reason attribute: %v", dp.Attributes.ToSlice())
 				}
-				key := ql.AsString() + "/" + reason.AsString()
+				key := ql.AsString() + "/" + budget.AsString() + "/" + reason.AsString()
 				if _, dup := streams[key]; dup {
 					t.Fatalf("rejected_total: duplicate stream for %q in one collection", key)
 				}
@@ -362,27 +371,116 @@ func TestRejectedCounterZeroInitializedAtConstruction(t *testing.T) {
 	reader := metric.NewManualReader()
 	mp := metric.NewMeterProvider(metric.WithReader(reader))
 
-	// Construct all three heads; never call Acquire.
+	// Construct all three heads plus the Loki tail budget — every
+	// limiter a full cerberus process builds; never call Acquire.
 	for _, head := range []string{"prom", "loki", "tempo"} {
 		if l := admit.NewWithProvider(head, 4, mp); l == nil {
 			t.Fatalf("NewWithProvider(%q): want limiter, got nil", head)
 		}
 	}
+	if l := admit.NewTailWithProvider("loki", 4, mp); l == nil {
+		t.Fatalf("NewTailWithProvider(loki): want limiter, got nil")
+	}
 
 	streams := rejectedStreams(t, reader)
-	if len(streams) != 3 {
-		t.Fatalf("want exactly 3 zero-init streams, got %d: %v", len(streams), streams)
+	want := []string{
+		"promql/" + admit.BudgetRequest,
+		"logql/" + admit.BudgetRequest,
+		"traceql/" + admit.BudgetRequest,
+		// The tail budget keeps cerberus.ql=logql — it is the same head,
+		// so the existing per-head dashboards keep resolving — and is
+		// told apart by budget alone.
+		"logql/" + admit.BudgetTail,
 	}
-	for _, ql := range []string{"promql", "logql", "traceql"} {
-		key := ql + "/" + admit.ReasonCapExceeded
+	if len(streams) != len(want) {
+		t.Fatalf("want exactly %d zero-init streams, got %d: %v", len(want), len(streams), streams)
+	}
+	for _, prefix := range want {
+		key := prefix + "/" + admit.ReasonCapExceeded
 		got, ok := streams[key]
 		if !ok {
-			t.Errorf("missing zero-init stream %q (panel would show No data for this head)", key)
+			t.Errorf("missing zero-init stream %q (panel would show No data for this budget)", key)
 			continue
 		}
 		if got != 0 {
 			t.Errorf("stream %q: want 0 before any rejection, got %d", key, got)
 		}
+	}
+}
+
+// TestTailBudgetIsIndependentOfRequestBudget pins the semaphore-level
+// guarantee the Loki head's /tail split rests on: two limiters built for
+// the SAME head share no capacity. Saturating one must leave the other
+// at full capacity, in both directions — the request budget is what
+// ordinary Loki queries draw on, and issue #1482 is precisely what
+// happens when a long-lived tail can consume it.
+func TestTailBudgetIsIndependentOfRequestBudget(t *testing.T) {
+	t.Parallel()
+
+	const cap = 2
+	requests := admit.New("loki", cap)
+	tail := admit.NewTail("loki", cap)
+
+	// Drain the tail budget completely.
+	for i := 0; i < cap; i++ {
+		rel, ok := tail.Acquire(t.Context())
+		if !ok {
+			t.Fatalf("tail acquire %d: want ok", i)
+		}
+		defer rel()
+	}
+	if _, ok := tail.Acquire(t.Context()); ok {
+		t.Fatalf("tail acquire past cap: want reject")
+	}
+
+	// The request budget is untouched: still admits its full cap.
+	for i := 0; i < cap; i++ {
+		rel, ok := requests.Acquire(t.Context())
+		if !ok {
+			t.Fatalf("request acquire %d with the tail budget drained: want ok (#1482)", i)
+		}
+		defer rel()
+	}
+	// ...and enforces its own cap independently.
+	if _, ok := requests.Acquire(t.Context()); ok {
+		t.Fatalf("request acquire past cap: want reject")
+	}
+}
+
+// TestTailRejectionCarriesTailBudgetLabel pins the operator-facing half
+// of the split: a rejection from the tail budget must be attributable to
+// it. Without the budget label a starved tail budget and a saturated
+// request budget are the same 503 on the same cerberus.ql=logql stream,
+// with no way to tell which cap to raise.
+func TestTailRejectionCarriesTailBudgetLabel(t *testing.T) {
+	t.Parallel()
+
+	reader := metric.NewManualReader()
+	mp := metric.NewMeterProvider(metric.WithReader(reader))
+
+	tail := admit.NewTailWithProvider("loki", 1, mp)
+	rel, ok := tail.Acquire(t.Context())
+	if !ok {
+		t.Fatalf("acquire 1: want ok")
+	}
+	defer rel()
+	if _, ok := tail.Acquire(t.Context()); ok {
+		t.Fatalf("acquire 2: want reject")
+	}
+
+	streams := rejectedStreams(t, reader)
+	if len(streams) != 1 {
+		t.Fatalf("want exactly 1 stream (zero-init and hot path must share attributes), got %d: %v", len(streams), streams)
+	}
+	key := "logql/" + admit.BudgetTail + "/" + admit.ReasonCapExceeded
+	if got := streams[key]; got != 1 {
+		t.Fatalf("stream %q: want 1 after one tail rejection, got %d: %v", key, got, streams)
+	}
+	if got := tail.Budget(); got != admit.BudgetTail {
+		t.Errorf("Budget() = %q, want %q", got, admit.BudgetTail)
+	}
+	if got := tail.Head(); got != "loki" {
+		t.Errorf("Head() = %q, want %q — the tail budget belongs to the Loki head", got, "loki")
 	}
 }
 
@@ -411,7 +509,7 @@ func TestRejectedCounterZeroInitSharesStreamWithHotPath(t *testing.T) {
 	if len(streams) != 1 {
 		t.Fatalf("want exactly 1 stream (zero-init and hot path must share attributes), got %d: %v", len(streams), streams)
 	}
-	key := "promql/" + admit.ReasonCapExceeded
+	key := "promql/" + admit.BudgetRequest + "/" + admit.ReasonCapExceeded
 	if got := streams[key]; got != 1 {
 		t.Fatalf("stream %q: want 1 after one rejection, got %d", key, got)
 	}

--- a/internal/api/admit/export_test.go
+++ b/internal/api/admit/export_test.go
@@ -4,7 +4,15 @@ import "go.opentelemetry.io/otel/metric"
 
 // NewWithProvider exposes the unexported constructor for tests that
 // need to point the rejection counter at a manual reader without
-// touching the OTel global (which other parallel tests share).
+// touching the OTel global (which other parallel tests share). Builds
+// the head's BudgetRequest limiter, mirroring New.
 func NewWithProvider(head string, cap int, mp metric.MeterProvider) *Limiter {
-	return newWithProvider(head, cap, mp)
+	return newWithProvider(head, BudgetRequest, cap, mp)
+}
+
+// NewTailWithProvider is the NewTail counterpart of NewWithProvider:
+// the head's BudgetTail limiter, with its rejection counter aimed at
+// the caller's manual reader.
+func NewTailWithProvider(head string, cap int, mp metric.MeterProvider) *Limiter {
+	return newWithProvider(head, BudgetTail, cap, mp)
 }

--- a/internal/api/admit/topup_test.go
+++ b/internal/api/admit/topup_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func newTestLimiter(cap int) *Limiter {
-	return newWithProvider("prom", cap, sdkmetric.NewMeterProvider())
+	return newWithProvider("prom", BudgetRequest, cap, sdkmetric.NewMeterProvider())
 }
 
 // TestTryAcquireTopUp_FullGrant — when the semaphore has headroom the top-up

--- a/internal/api/loki/conformance_test.go
+++ b/internal/api/loki/conformance_test.go
@@ -1123,6 +1123,212 @@ func TestConformance_LokiAdmitIndependentFromOthers(t *testing.T) {
 	}
 }
 
+// newSplitBudgetServer mounts a Loki handler whose two admission
+// budgets are wired to the caller's limiters — `limiter` for every
+// short-lived route, `tailLimiter` for /tail alone — over a querier
+// that serves both the ordinary query path and the tail poll loop.
+// Returns the live server; the caller closes nothing (t.Cleanup does).
+func newSplitBudgetServer(t *testing.T, limiter, tailLimiter *admit.Limiter) *httptest.Server {
+	t.Helper()
+	h := loki.New(&tailStubQuerier{
+		chunks: [][]chclient.Sample{{{
+			MetricName: "x",
+			Labels:     map[string]string{"job": "api"},
+		}}},
+	}, schema.DefaultOTelLogs(), nil)
+	h.Limiter = limiter
+	h.TailLimiter = tailLimiter
+	mux := http.NewServeMux()
+	h.Mount(mux)
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+// tailDialStatus dials /tail and reports the HTTP status of the
+// handshake response, closing whatever it got. Unlike dialTail it does
+// NOT fail the test on a refused upgrade — a refusal is the outcome
+// under test here.
+func tailDialStatus(t *testing.T, srv *httptest.Server, query string) int {
+	t.Helper()
+	u, err := url.Parse(srv.URL)
+	if err != nil {
+		t.Fatalf("parse server URL: %v", err)
+	}
+	u.Scheme = "ws"
+	u.Path = "/loki/api/v1/tail"
+	u.RawQuery = "query=" + url.QueryEscape(query)
+
+	conn, resp, err := websocket.DefaultDialer.Dial(u.String(), nil)
+	if conn != nil {
+		_ = conn.Close()
+	}
+	if resp == nil {
+		t.Fatalf("dial %s: no handshake response (err=%v)", u.String(), err)
+	}
+	defer resp.Body.Close()
+	return resp.StatusCode
+}
+
+// TestConformance_LokiFullTailBudgetLeavesQueriesAdmitted is the
+// regression pin for issue #1482 — the reason /tail has a budget of its
+// own at all.
+//
+// /tail holds its admission slot from the WebSocket upgrade until the
+// client disconnects, which is unbounded (CERBERUS_HTTP_WRITE_TIMEOUT
+// defaults to 0 precisely so a tail can stream indefinitely). While the
+// tail budget and the request budget were one semaphore, N live-tail
+// sessions permanently occupied N of the Loki head's slots and every
+// subsequent /query, /query_range, /labels, /series and /patterns on that
+// replica 503'd until a tail client disconnected — a starvation that only
+// ever ratcheted one way.
+//
+// So: saturate the tail budget completely, then drive the ordinary routes
+// to their OWN full capacity. Every one must be admitted. Sizing the tail
+// budget at 1 and the request budget at 2 makes the pre-fix behaviour
+// impossible to pass: a shared semaphore of either size would be fully
+// consumed by the held tail slot and reject the very first query.
+func TestConformance_LokiFullTailBudgetLeavesQueriesAdmitted(t *testing.T) {
+	t.Parallel()
+
+	const requestCap = 2
+	tailLimiter := admit.NewTail("loki", 1)
+	limiter := admit.New("loki", requestCap)
+
+	// Occupy the ENTIRE tail budget and never give it back, exactly as a
+	// live Grafana tail panel does.
+	rel, ok := tailLimiter.Acquire(context.Background())
+	if !ok {
+		t.Fatalf("setup: tail budget must start free")
+	}
+	defer rel()
+
+	srv := newSplitBudgetServer(t, limiter, tailLimiter)
+
+	// Every short-lived route, twice over the request cap, all serial so
+	// each slot is released before the next acquire. A single 503 here is
+	// the bug.
+	paths := []string{
+		`/loki/api/v1/query?query=%7Bjob%3D%22api%22%7D`,
+		`/loki/api/v1/labels`,
+		`/loki/api/v1/series?match%5B%5D=%7Bjob%3D%22api%22%7D`,
+		`/loki/api/v1/index/stats?query=%7Bjob%3D%22api%22%7D`,
+	}
+	for round := 0; round < requestCap*2; round++ {
+		for _, p := range paths {
+			resp, err := http.Get(srv.URL + p)
+			if err != nil {
+				t.Fatalf("round %d GET %s: %v", round, p, err)
+			}
+			status := resp.StatusCode
+			resp.Body.Close()
+			if status == http.StatusServiceUnavailable {
+				t.Fatalf("round %d GET %s: 503 — a saturated tail budget must not reject ordinary Loki requests (#1482)", round, p)
+			}
+			if status != http.StatusOK {
+				t.Fatalf("round %d GET %s: status %d, want 200", round, p, status)
+			}
+		}
+	}
+
+	// And the two budgets are genuinely separate objects, not one
+	// semaphore reached through two fields.
+	if limiter == tailLimiter {
+		t.Fatalf("request and tail budgets must be distinct limiters")
+	}
+	if got := tailLimiter.Budget(); got != admit.BudgetTail {
+		t.Errorf("tail limiter budget = %q, want %q", got, admit.BudgetTail)
+	}
+	if got := limiter.Budget(); got != admit.BudgetRequest {
+		t.Errorf("request limiter budget = %q, want %q", got, admit.BudgetRequest)
+	}
+}
+
+// TestConformance_LokiTailRejectedAtTailCap is the other half of the
+// split: giving /tail its own budget must actually BOUND tailing, not
+// exempt it. A separate budget that never rejects would be an unbounded
+// resource wearing a cap's name.
+//
+// The rejection rides the same admit.Middleware contract as every other
+// route — HTTP 503 + Retry-After, written BEFORE the WebSocket upgrade,
+// so the client sees an ordinary refused handshake rather than an
+// upgraded-then-severed connection.
+func TestConformance_LokiTailRejectedAtTailCap(t *testing.T) {
+	t.Parallel()
+
+	tailLimiter := admit.NewTail("loki", 1)
+	rel, ok := tailLimiter.Acquire(context.Background())
+	if !ok {
+		t.Fatalf("setup: tail budget must start free")
+	}
+	defer rel()
+
+	srv := newSplitBudgetServer(t, admit.New("loki", 4), tailLimiter)
+
+	if got := tailDialStatus(t, srv, `{job="api"}`); got != http.StatusServiceUnavailable {
+		t.Fatalf("/tail at cap: status %d, want 503", got)
+	}
+}
+
+// TestConformance_LokiFullQueryBudgetLeavesTailAdmitted closes the
+// symmetry. Query saturation is a transient, self-clearing condition
+// (slots churn in milliseconds); a live-tail session that a burst of
+// queries can refuse would drop Grafana's Live panel for the duration of
+// an unrelated load spike. With the budgets split, a full REQUEST budget
+// leaves the tail upgrade untouched.
+func TestConformance_LokiFullQueryBudgetLeavesTailAdmitted(t *testing.T) {
+	t.Parallel()
+
+	limiter := admit.New("loki", 1)
+	rel, ok := limiter.Acquire(context.Background())
+	if !ok {
+		t.Fatalf("setup: request budget must start free")
+	}
+	defer rel()
+
+	srv := newSplitBudgetServer(t, limiter, admit.NewTail("loki", 1))
+
+	// The request budget really is exhausted...
+	resp, err := http.Get(srv.URL + `/loki/api/v1/query?query=%7Bjob%3D%22api%22%7D`)
+	if err != nil {
+		t.Fatalf("GET /query: %v", err)
+	}
+	status := resp.StatusCode
+	resp.Body.Close()
+	if status != http.StatusServiceUnavailable {
+		t.Fatalf("GET /query with the request budget held: status %d, want 503", status)
+	}
+
+	// ...and /tail upgrades anyway, on its own budget.
+	if got := tailDialStatus(t, srv, `{job="api"}`); got != http.StatusSwitchingProtocols {
+		t.Fatalf("/tail with only the REQUEST budget exhausted: status %d, want 101", got)
+	}
+}
+
+// TestConformance_LokiTailUnadmittedWithoutTailLimiter pins the nil
+// sentinel for the new field: a Handler carrying a request limiter but
+// no TailLimiter leaves /tail unadmitted rather than silently falling
+// back to the request budget. Falling back would re-create #1482 in
+// any deployment that set only CERBERUS_ADMIT_LOKI, so the pass-through
+// is the deliberate behaviour — the same "cap 0 means unlimited"
+// convention Limiter itself follows.
+func TestConformance_LokiTailUnadmittedWithoutTailLimiter(t *testing.T) {
+	t.Parallel()
+
+	limiter := admit.New("loki", 1)
+	rel, ok := limiter.Acquire(context.Background())
+	if !ok {
+		t.Fatalf("setup: request budget must start free")
+	}
+	defer rel()
+
+	srv := newSplitBudgetServer(t, limiter, nil)
+
+	if got := tailDialStatus(t, srv, `{job="api"}`); got != http.StatusSwitchingProtocols {
+		t.Fatalf("/tail with a nil TailLimiter: status %d, want 101 (unadmitted)", got)
+	}
+}
+
 // TestConformance_LokiGrafanaMsTimestamps_ResourcesProxy is the
 // request-level pin for #194 on the Loki side. Grafana 11.x's Loki
 // datasource sends 13-digit ms `start` / `end` timestamps over

--- a/internal/api/loki/conformance_test.go
+++ b/internal/api/loki/conformance_test.go
@@ -1183,11 +1183,17 @@ func tailDialStatus(t *testing.T, srv *httptest.Server, query string) int {
 // replica 503'd until a tail client disconnected — a starvation that only
 // ever ratcheted one way.
 //
-// So: saturate the tail budget completely, then drive the ordinary routes
-// to their OWN full capacity. Every one must be admitted. Sizing the tail
-// budget at 1 and the request budget at 2 makes the pre-fix behaviour
-// impossible to pass: a shared semaphore of either size would be fully
-// consumed by the held tail slot and reject the very first query.
+// So: saturate the tail budget with a REAL, live /tail session — dialled
+// through the mux, holding its slot through the admission middleware
+// exactly as a Grafana Live-tail panel does — and then drive the ordinary
+// routes to their OWN full capacity. Every one must be admitted.
+//
+// Occupying the budget by dialling rather than by calling Acquire on the
+// limiter is what makes this test see the MOUNT as well as the budgets:
+// were /tail re-mounted on the request limiter, the live session would
+// consume a request slot and the query loop below would 503 — which is
+// precisely the pre-fix behaviour. Sizing the tail budget at 1 and the
+// request budget at 2 leaves no room for that to pass by luck.
 func TestConformance_LokiFullTailBudgetLeavesQueriesAdmitted(t *testing.T) {
 	t.Parallel()
 
@@ -1195,15 +1201,17 @@ func TestConformance_LokiFullTailBudgetLeavesQueriesAdmitted(t *testing.T) {
 	tailLimiter := admit.NewTail("loki", 1)
 	limiter := admit.New("loki", requestCap)
 
-	// Occupy the ENTIRE tail budget and never give it back, exactly as a
-	// live Grafana tail panel does.
-	rel, ok := tailLimiter.Acquire(context.Background())
-	if !ok {
-		t.Fatalf("setup: tail budget must start free")
-	}
-	defer rel()
-
 	srv := newSplitBudgetServer(t, limiter, tailLimiter)
+
+	// A live tail session takes the one tail slot and keeps it for the
+	// rest of the test (the conn closes on cleanup).
+	_ = dialTail(t, srv, `{job="api"}`)
+
+	// Corroborate that the tail budget really is full — otherwise the
+	// assertions below would pass trivially on an unoccupied budget.
+	if got := tailDialStatus(t, srv, `{job="api"}`); got != http.StatusServiceUnavailable {
+		t.Fatalf("second /tail dial: status %d, want 503 — the live session did not occupy the tail budget, so this test proves nothing", got)
+	}
 
 	// Every short-lived route, twice over the request cap, all serial so
 	// each slot is released before the next acquire. A single 503 here is

--- a/internal/api/loki/handler.go
+++ b/internal/api/loki/handler.go
@@ -71,8 +71,27 @@ type Handler struct {
 	Lang *logql.Lang
 
 	// Limiter caps in-flight Loki API requests. nil disables the
-	// admission middleware. Wired from CERBERUS_ADMIT_LOKI.
+	// admission middleware. Wired from CERBERUS_ADMIT_LOKI. It fronts
+	// every route EXCEPT /tail — see TailLimiter.
 	Limiter *admit.Limiter
+
+	// TailLimiter caps concurrent /tail WebSocket sessions. nil leaves
+	// tailing unadmitted. Wired from CERBERUS_ADMIT_TAIL, and it is a
+	// DIFFERENT *admit.Limiter instance than Limiter — that separation is
+	// the whole point of the field.
+	//
+	// A semaphore counts requests, but the quantity worth bounding is
+	// occupancy-time, and the two only agree while every occupant is
+	// short-lived. /tail's occupants are not: the handler holds its slot
+	// from the WebSocket upgrade until the client disconnects (which is
+	// why CERBERUS_HTTP_WRITE_TIMEOUT defaults to unlimited — nothing
+	// else reclaims it). Fronted by the same semaphore as /query and the
+	// metadata routes, N idle Grafana Live-tail panels permanently
+	// occupy N of the Loki head's slots, occupancy ratchets one way, and
+	// every subsequent Loki request on the replica 503s until a tail
+	// client disconnects — issue #1482. Two budgets means a full tail
+	// budget costs ordinary queries nothing.
+	TailLimiter *admit.Limiter
 
 	// Version is the cerberus build identifier surfaced via
 	// `/loki/api/v1/status/buildinfo`. Wired from cmd/cerberus's
@@ -141,12 +160,19 @@ func (h *Handler) Mount(mux *http.ServeMux) {
 	// long-lived tail counts as one query for the purposes of total
 	// volume bookkeeping; its duration will skew toward the long tail
 	// of the histogram, which is what dashboards want to see anyway.
+	// registerWith mounts one pattern behind a CHOSEN admission budget.
+	// admit.Middleware (outer) → telemetry.QueryMiddleware (inner) —
+	// rejections are accounted on cerberus.admit.rejected_total, not on
+	// cerberus.queries.*. See prom.Handler.Mount for the full layering
+	// note.
+	registerWith := func(limiter *admit.Limiter, pattern string, hf http.HandlerFunc) {
+		mux.Handle(pattern, limiter.Middleware(1, telemetry.QueryMiddleware("logql", panicEnvelope, hf)))
+	}
+	// register mounts an ordinary, short-lived Loki route on the shared
+	// request budget (CERBERUS_ADMIT_LOKI). /tail is the one route that
+	// does NOT go through here — it takes TailLimiter instead.
 	register := func(pattern string, hf http.HandlerFunc) {
-		// admit.Middleware (outer) → telemetry.QueryMiddleware (inner)
-		// — rejections are accounted on cerberus.admit.rejected_total,
-		// not on cerberus.queries.*. See prom.Handler.Mount for the
-		// full layering note.
-		mux.Handle(pattern, h.Limiter.Middleware(1, telemetry.QueryMiddleware("logql", panicEnvelope, hf)))
+		registerWith(h.Limiter, pattern, hf)
 	}
 	register("GET /loki/api/v1/query", h.handleQuery)
 	register("POST /loki/api/v1/query", h.handleQuery)
@@ -171,7 +197,11 @@ func (h *Handler) Mount(mux *http.ServeMux) {
 	register("GET /loki/api/v1/patterns", h.handlePatterns)
 	register("POST /loki/api/v1/patterns", h.handlePatterns)
 	// /tail is WebSocket-upgrade only; no POST counterpart in upstream Loki.
-	register("GET /loki/api/v1/tail", h.handleTail)
+	// It is the ONE route mounted on TailLimiter rather than Limiter: its
+	// slot is held for the session's whole lifetime, so it must not be
+	// drawn from the budget the millisecond-scale routes above share (see
+	// the TailLimiter field doc and issue #1482).
+	registerWith(h.TailLimiter, "GET /loki/api/v1/tail", h.handleTail)
 	// Format-query + build-info probes. Grafana's Loki datasource hits
 	// /status/buildinfo on every page load to gate feature flags
 	// (LogQL editor capabilities, label-browser presence) and uses

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1203,11 +1203,7 @@ func newDefaults() *viper.Viper {
 	v.SetDefault(envOTLPHeaders, defaultOTLPHeaders)
 	v.SetDefault(envOTLPTimeout, defaultOTLPTimeout.String())
 	v.SetDefault(envOTLPExportInterval, defaultOTLPExportInterval.String())
-	v.SetDefault(envAdmitDisabled, defaultAdmitDisabled)
-	v.SetDefault(envAdmitProm, DefaultAdmitProm)
-	v.SetDefault(envAdmitLoki, DefaultAdmitLoki)
-	v.SetDefault(envAdmitTempo, DefaultAdmitTempo)
-	v.SetDefault(envAdmitTail, DefaultAdmitTail)
+	setAdmitDefaults(v)
 	v.SetDefault(envEnabledHeads, defaultEnabledHeads)
 	return v
 }
@@ -1224,6 +1220,21 @@ func setCHOptDefaults(v *viper.Viper) {
 	v.SetDefault(envCHOptCorpusSinkPath, defaultCHOptCorpusSinkPath)
 	v.SetDefault(envCHOptCorpusRing, defaultCHOptCorpusRing)
 	v.SetDefault(envCHOptCorpusSinkMode, defaultCHOptCorpusSinkMode)
+}
+
+// setAdmitDefaults seeds the CERBERUS_ADMIT_* defaults: the master
+// off-switch plus the four admission budgets. Extracted from newDefaults
+// for the same reason setCHOptDefaults was — the budgets are one
+// coherent family (three per-head request caps and the Loki /tail cap
+// that bounds occupancy rather than throughput), and grouping them keeps
+// newDefaults a flat list of unrelated knobs instead of growing a
+// sub-block every time the family does.
+func setAdmitDefaults(v *viper.Viper) {
+	v.SetDefault(envAdmitDisabled, defaultAdmitDisabled)
+	v.SetDefault(envAdmitProm, DefaultAdmitProm)
+	v.SetDefault(envAdmitLoki, DefaultAdmitLoki)
+	v.SetDefault(envAdmitTempo, DefaultAdmitTempo)
+	v.SetDefault(envAdmitTail, DefaultAdmitTail)
 }
 
 // Built-in defaults, kept as named constants so newLoader's SetDefault

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -440,14 +440,15 @@ type SchemaProvisioning struct {
 // AdmitConfig holds the per-handler admission-control concurrency caps.
 //
 // CERBERUS_ADMIT_{PROM,LOKI,TEMPO} set the per-head in-flight concurrency
-// cap. Each accepts EITHER an explicit non-negative integer cap OR a
-// boolean spelling, so one knob serves both an operator pinning an exact
-// cap and the Helm chart rendering a plain YAML bool:
+// cap and CERBERUS_ADMIT_TAIL sets the Loki head's separate long-lived
+// `/tail` budget. Each accepts EITHER an explicit non-negative integer cap
+// OR a boolean spelling, so one knob serves both an operator pinning an
+// exact cap and the Helm chart rendering a plain YAML bool:
 //
-//   - a positive integer N -> cap the head at N concurrent requests
-//   - "true"  / "t"        -> enable at the head's conservative default
-//     cap (DefaultAdmitProm / Loki / Tempo)
-//   - "false" / "f" / "0"  -> no limiter for that head (unlimited)
+//   - a positive integer N -> cap at N concurrent occupants
+//   - "true"  / "t"        -> enable at the conservative default cap
+//     (DefaultAdmitProm / Loki / Tempo / Tail)
+//   - "false" / "f" / "0"  -> no limiter there (unlimited)
 //   - a negative or otherwise unparseable value -> rejected (fail fast)
 //
 // "1"/"0" are read as the integer caps 1 and 0 (and 0 == unlimited), so
@@ -479,6 +480,19 @@ type AdmitConfig struct {
 	// head unlimited. Default DefaultAdmitTempo (CERBERUS_ADMIT_TEMPO
 	// unset or "true").
 	Tempo int
+
+	// Tail caps simultaneous Loki `/tail` WebSocket sessions, on a
+	// semaphore SEPARATE from Loki. 0 leaves tailing unlimited. Default
+	// DefaultAdmitTail (CERBERUS_ADMIT_TAIL unset or "true").
+	//
+	// It is its own knob because it bounds a different quantity than the
+	// others do. Loki / Prom / Tempo bound requests that occupy a slot for
+	// milliseconds; a `/tail` session holds its slot from the WebSocket
+	// upgrade until the client disconnects, which is why
+	// CERBERUS_HTTP_WRITE_TIMEOUT defaults to unlimited. Drawn from one
+	// pool, tail occupancy ratchets one way and eventually starves every
+	// ordinary Loki route on the replica — issue #1482.
+	Tail int
 }
 
 // HTTPServerConfig holds the cerberus HTTP server's net/http timeout knobs
@@ -656,6 +670,7 @@ const (
 	envAdmitProm               = "CERBERUS_ADMIT_PROM"
 	envAdmitLoki               = "CERBERUS_ADMIT_LOKI"
 	envAdmitTempo              = "CERBERUS_ADMIT_TEMPO"
+	envAdmitTail               = "CERBERUS_ADMIT_TAIL"
 	envEnabledHeads            = "CERBERUS_ENABLED_HEADS"
 )
 
@@ -770,6 +785,8 @@ const configFileBaseName = "cerberus"
 //	CERBERUS_ADMIT_PROM            default "64"  (Prom cap; int N, or true/false)
 //	CERBERUS_ADMIT_LOKI            default "64"  (Loki cap; int N, or true/false)
 //	CERBERUS_ADMIT_TEMPO           default "32"  (Tempo cap; int N, or true/false)
+//	CERBERUS_ADMIT_TAIL            default "16"  (Loki /tail cap, a budget
+//	    SEPARATE from CERBERUS_ADMIT_LOKI; int N, or true/false)
 //	CERBERUS_ENABLED_HEADS         default "prom,loki,tempo" — comma-separated
 //	    subset of query heads this process serves. Unset = all three (full
 //	    backward compatibility). A subset (e.g. "prom") skips building AND
@@ -1039,6 +1056,7 @@ var allEnvKeys = []string{
 	envAdmitProm,
 	envAdmitLoki,
 	envAdmitTempo,
+	envAdmitTail,
 	envEnabledHeads,
 }
 
@@ -1189,6 +1207,7 @@ func newDefaults() *viper.Viper {
 	v.SetDefault(envAdmitProm, DefaultAdmitProm)
 	v.SetDefault(envAdmitLoki, DefaultAdmitLoki)
 	v.SetDefault(envAdmitTempo, DefaultAdmitTempo)
+	v.SetDefault(envAdmitTail, DefaultAdmitTail)
 	v.SetDefault(envEnabledHeads, defaultEnabledHeads)
 	return v
 }
@@ -1589,16 +1608,39 @@ const (
 	DefaultAdmitTempo = 32
 )
 
+// DefaultAdmitTail is the cap for the Loki head's SEPARATE `/tail`
+// budget (CERBERUS_ADMIT_TAIL unset or "true"). It is a quarter of
+// DefaultAdmitLoki for two reasons that both follow from what a tail
+// slot actually costs:
+//
+//   - Duration. A tail holds its slot from the WebSocket upgrade to the
+//     client disconnect, so the cap is a ceiling on CONCURRENT LIVE-TAIL
+//     SESSIONS per replica, not on request throughput. Sixteen open
+//     Grafana Live-tail panels against one replica is a generous ceiling
+//     for an interactive debugging workflow; a fleet that genuinely needs
+//     more raises the knob or adds replicas.
+//   - Steady load. Each session re-queries ClickHouse on the
+//     internal/api/loki tail poll cadence (one second), so the cap is
+//     also the steady background query rate tailing imposes — bounded
+//     here at 16 q/s per replica, where the Loki request budget's 64
+//     would be four times that and never idle.
+//
+// It is deliberately NOT DefaultAdmitLoki: sizing the two budgets equally
+// would restore the "tails can consume a query-sized budget" arithmetic
+// this knob exists to break, and it is deliberately not 0, which would
+// read as "unlimited" and leave tail occupancy unbounded.
+const DefaultAdmitTail = 16
+
 // admitFromEnv reads CERBERUS_ADMIT_* knobs from the viper loader.
 // CERBERUS_ADMIT_DISABLED is a plain bool (getBool). The per-head
-// CERBERUS_ADMIT_{PROM,LOKI,TEMPO} are concurrency caps read through
-// getAdmitCap, which accepts an explicit non-negative integer OR a
-// boolean spelling: "true" -> the head's default cap, "false"/"0" ->
-// unlimited, a positive N -> cap N, negative/garbage -> rejected. This
-// keeps the 1/0/true/false ergonomics the Helm chart relies on while
-// still letting an operator pin an exact cap (e.g. 2). Unset values fall
-// back to the registered per-head defaults (DefaultAdmitProm / Loki /
-// Tempo).
+// CERBERUS_ADMIT_{PROM,LOKI,TEMPO} plus the Loki-tail-specific
+// CERBERUS_ADMIT_TAIL are concurrency caps read through getAdmitCap,
+// which accepts an explicit non-negative integer OR a boolean spelling:
+// "true" -> that budget's default cap, "false"/"0" -> unlimited, a
+// positive N -> cap N, negative/garbage -> rejected. This keeps the
+// 1/0/true/false ergonomics the Helm chart relies on while still letting
+// an operator pin an exact cap (e.g. 2). Unset values fall back to the
+// registered defaults (DefaultAdmitProm / Loki / Tempo / Tail).
 func admitFromEnv(v *viper.Viper) (AdmitConfig, error) {
 	disabled, err := getBool(v, envAdmitDisabled)
 	if err != nil {
@@ -1616,11 +1658,16 @@ func admitFromEnv(v *viper.Viper) (AdmitConfig, error) {
 	if err != nil {
 		return AdmitConfig{}, err
 	}
+	tail, err := getAdmitCap(v, envAdmitTail, DefaultAdmitTail)
+	if err != nil {
+		return AdmitConfig{}, err
+	}
 	return AdmitConfig{
 		Disabled: disabled,
 		Prom:     prom,
 		Loki:     loki,
 		Tempo:    tempo,
+		Tail:     tail,
 	}, nil
 }
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -385,6 +385,7 @@ func TestFromEnv_Admit_Defaults(t *testing.T) {
 	t.Setenv("CERBERUS_ADMIT_PROM", "")
 	t.Setenv("CERBERUS_ADMIT_LOKI", "")
 	t.Setenv("CERBERUS_ADMIT_TEMPO", "")
+	t.Setenv("CERBERUS_ADMIT_TAIL", "")
 	cfg, err := FromEnv()
 	if err != nil {
 		t.Fatalf("FromEnv: %v", err)
@@ -401,6 +402,22 @@ func TestFromEnv_Admit_Defaults(t *testing.T) {
 	if cfg.Admit.Tempo != DefaultAdmitTempo {
 		t.Errorf("Admit.Tempo = %d; want %d (default cap)", cfg.Admit.Tempo, DefaultAdmitTempo)
 	}
+	// The tail budget defaults ON at its own, smaller cap. Two failure
+	// modes matter more than the exact number: 0 would read as
+	// "unlimited" and leave live-tail occupancy unbounded, and
+	// DefaultAdmitLoki would make the two budgets interchangeable in
+	// size and re-open the arithmetic of #1482 for anyone who reasons
+	// about totals.
+	if cfg.Admit.Tail != DefaultAdmitTail {
+		t.Errorf("Admit.Tail = %d; want %d (default cap)", cfg.Admit.Tail, DefaultAdmitTail)
+	}
+	if DefaultAdmitTail <= 0 {
+		t.Errorf("DefaultAdmitTail = %d; must be positive — 0 means unlimited tailing", DefaultAdmitTail)
+	}
+	if DefaultAdmitTail >= DefaultAdmitLoki {
+		t.Errorf("DefaultAdmitTail = %d; want a budget strictly smaller than DefaultAdmitLoki (%d)",
+			DefaultAdmitTail, DefaultAdmitLoki)
+	}
 }
 
 // TestFromEnv_Admit_Overrides confirms env-var overrides flow through.
@@ -412,6 +429,7 @@ func TestFromEnv_Admit_Overrides(t *testing.T) {
 	t.Setenv("CERBERUS_ADMIT_PROM", "false")
 	t.Setenv("CERBERUS_ADMIT_LOKI", "0")
 	t.Setenv("CERBERUS_ADMIT_TEMPO", "true")
+	t.Setenv("CERBERUS_ADMIT_TAIL", "3")
 	cfg, err := FromEnv()
 	if err != nil {
 		t.Fatalf("FromEnv: %v", err)
@@ -427,6 +445,12 @@ func TestFromEnv_Admit_Overrides(t *testing.T) {
 	}
 	if cfg.Admit.Tempo != DefaultAdmitTempo {
 		t.Errorf("Admit.Tempo = %d; want %d (\"true\" = default cap)", cfg.Admit.Tempo, DefaultAdmitTempo)
+	}
+	// CERBERUS_ADMIT_TAIL resolves on its own, unaffected by the Loki
+	// knob sitting at 0 right beside it — the two are separate budgets,
+	// not a cap and a sub-cap.
+	if cfg.Admit.Tail != 3 {
+		t.Errorf("Admit.Tail = %d; want 3 (explicit integer cap)", cfg.Admit.Tail)
 	}
 }
 
@@ -477,6 +501,55 @@ func TestFromEnv_Admit_RejectsGarbage(t *testing.T) {
 			t.Setenv("CERBERUS_ADMIT_PROM", raw)
 			if _, err := FromEnv(); err == nil {
 				t.Fatalf("FromEnv with CERBERUS_ADMIT_PROM=%q: want error, got nil", raw)
+			}
+		})
+	}
+}
+
+// TestFromEnv_AdmitTail_AcceptsIntOrBool pins CERBERUS_ADMIT_TAIL to the
+// same int-or-bool contract as the per-head caps, and pins the two
+// properties an operator relies on: setting it never disturbs
+// CERBERUS_ADMIT_LOKI, and a garbage or negative value fails startup
+// rather than silently resolving to something permissive. A tail budget
+// that quietly parsed to 0 would be indistinguishable from "unlimited",
+// which is the state issue #1482 describes.
+func TestFromEnv_AdmitTail_AcceptsIntOrBool(t *testing.T) {
+	for _, tc := range []struct {
+		raw  string
+		want int
+	}{
+		{"true", DefaultAdmitTail},
+		{"t", DefaultAdmitTail},
+		{"TRUE", DefaultAdmitTail},
+		{"false", 0},
+		{"f", 0},
+		{"0", 0},
+		{"1", 1},
+		{"8", 8},
+	} {
+		t.Run(tc.raw, func(t *testing.T) {
+			t.Setenv("CERBERUS_ADMIT_TAIL", tc.raw)
+			t.Setenv("CERBERUS_ADMIT_LOKI", "50")
+			cfg, err := FromEnv()
+			if err != nil {
+				t.Fatalf("FromEnv with CERBERUS_ADMIT_TAIL=%q: unexpected error %v", tc.raw, err)
+			}
+			if cfg.Admit.Tail != tc.want {
+				t.Errorf("Admit.Tail = %d; want %d for %q", cfg.Admit.Tail, tc.want, tc.raw)
+			}
+			if cfg.Admit.Loki != 50 {
+				t.Errorf("Admit.Loki = %d; want 50 — CERBERUS_ADMIT_TAIL must not disturb the Loki request budget", cfg.Admit.Loki)
+			}
+		})
+	}
+}
+
+func TestFromEnv_AdmitTail_RejectsGarbage(t *testing.T) {
+	for _, raw := range []string{"maybe", "-1", "1.5", "2x"} {
+		t.Run(raw, func(t *testing.T) {
+			t.Setenv("CERBERUS_ADMIT_TAIL", raw)
+			if _, err := FromEnv(); err == nil {
+				t.Fatalf("FromEnv with CERBERUS_ADMIT_TAIL=%q: want error, got nil", raw)
 			}
 		})
 	}

--- a/internal/config/envdocs.go
+++ b/internal/config/envdocs.go
@@ -271,9 +271,9 @@ var envDocs = []EnvDoc{
 	{envCHBreakerOpenIntrvl, "duration", "Circuit breaker", "OPEN-state backoff before the breaker admits a single HALF-OPEN probe, and the `Retry-After` a breaker-open 503 advertises. Must be > 0."},
 
 	// --- Admission control ---
-	{envAdmitDisabled, "bool", "Admission control", "Disable admission control entirely on every head (handy for local development)."},
+	{envAdmitDisabled, "bool", "Admission control", "Disable admission control entirely, on every budget at once (handy for local development)."},
 	{envAdmitProm, "int | bool", "Admission control", "Prom API in-flight cap. Integer caps the head; `true` = default cap 64; `false`/`0` = unlimited."},
-	{envAdmitLoki, "int | bool", "Admission control", "Loki API in-flight cap. Integer caps the head; `true` = default cap 64; `false`/`0` = unlimited."},
+	{envAdmitLoki, "int | bool", "Admission control", "Loki API in-flight cap, covering every route EXCEPT `/tail` (see `CERBERUS_ADMIT_TAIL`). Integer caps the head; `true` = default cap 64; `false`/`0` = unlimited."},
 	{envAdmitTempo, "int | bool", "Admission control", "Tempo API in-flight cap. Integer caps the head; `true` = default cap 32; `false`/`0` = unlimited."},
 	{envAdmitTail, "int | bool", "Admission control", "Concurrent Loki `/tail` WebSocket sessions, on a budget SEPARATE from `CERBERUS_ADMIT_LOKI`. Integer caps it; `true` = default cap 16; `false`/`0` = unlimited."},
 

--- a/internal/config/envdocs.go
+++ b/internal/config/envdocs.go
@@ -129,12 +129,19 @@ var envDocGroups = []envDocGroup{
 			"503 + `Retry-After: 1` so well-behaved clients back off and ClickHouse stays out\n" +
 			"of overload. Tempo's cap is half of Prom / Loki because trace queries are\n" +
 			"typically the heaviest per-call.\n\n" +
-			"`CERBERUS_ADMIT_{PROM,LOKI,TEMPO}` each accept **either** a non-negative\n" +
-			"integer cap **or** a boolean alias: `true` enables the head at its conservative\n" +
-			"default cap, `false` (or `0`) leaves that head unlimited, and a positive\n" +
+			"The Loki head's `/tail` WebSocket draws on its OWN budget,\n" +
+			"`CERBERUS_ADMIT_TAIL`, because it bounds a different quantity: an ordinary\n" +
+			"request holds its slot for milliseconds, whereas a tail holds one from the\n" +
+			"WebSocket upgrade until the client disconnects. Sharing one semaphore would\n" +
+			"let idle Live-tail panels ratchet the Loki head to zero free slots and 503\n" +
+			"every query on the replica, so the two budgets are sized and exhausted\n" +
+			"independently.\n\n" +
+			"`CERBERUS_ADMIT_{PROM,LOKI,TEMPO,TAIL}` each accept **either** a non-negative\n" +
+			"integer cap **or** a boolean alias: `true` enables that budget at its\n" +
+			"conservative default cap, `false` (or `0`) leaves it unlimited, and a positive\n" +
 			"integer pins an exact cap. A negative or unparseable value is rejected at\n" +
 			"startup. `CERBERUS_ADMIT_DISABLED` is a separate master switch that turns every\n" +
-			"head off at once.",
+			"budget off at once.",
 	},
 	{
 		Name:  "Logging",
@@ -268,6 +275,7 @@ var envDocs = []EnvDoc{
 	{envAdmitProm, "int | bool", "Admission control", "Prom API in-flight cap. Integer caps the head; `true` = default cap 64; `false`/`0` = unlimited."},
 	{envAdmitLoki, "int | bool", "Admission control", "Loki API in-flight cap. Integer caps the head; `true` = default cap 64; `false`/`0` = unlimited."},
 	{envAdmitTempo, "int | bool", "Admission control", "Tempo API in-flight cap. Integer caps the head; `true` = default cap 32; `false`/`0` = unlimited."},
+	{envAdmitTail, "int | bool", "Admission control", "Concurrent Loki `/tail` WebSocket sessions, on a budget SEPARATE from `CERBERUS_ADMIT_LOKI`. Integer caps it; `true` = default cap 16; `false`/`0` = unlimited."},
 
 	// --- Logging ---
 	{envLogFormat, "string", "Logging", "slog handler kind: `text` (human-readable) or `json` (aggregators)."},

--- a/internal/config/matrix_test.go
+++ b/internal/config/matrix_test.go
@@ -597,6 +597,12 @@ func TestFromEnv_AdmitFalsyDisablesHead(t *testing.T) {
 	if cfg.Admit.Prom != DefaultAdmitProm || cfg.Admit.Tempo != DefaultAdmitTempo {
 		t.Errorf("disabling loki must not touch prom/tempo: prom=%d tempo=%d", cfg.Admit.Prom, cfg.Admit.Tempo)
 	}
+	// Nor the tail budget: /tail is a separate semaphore, so unlimiting
+	// the Loki request budget says nothing about how many concurrent
+	// live-tail sessions the replica accepts.
+	if cfg.Admit.Tail != DefaultAdmitTail {
+		t.Errorf("disabling the loki request budget must not touch the tail budget: tail=%d, want %d", cfg.Admit.Tail, DefaultAdmitTail)
+	}
 }
 
 // TestFromEnv_AdmitIntegerCap pins the explicit-integer cap path the e2e

--- a/internal/config/nested.go
+++ b/internal/config/nested.go
@@ -146,6 +146,7 @@ var bindings = []binding{
 	{"admit.prom", envAdmitProm, bindScalar},
 	{"admit.loki", envAdmitLoki, bindScalar},
 	{"admit.tempo", envAdmitTempo, bindScalar},
+	{"admit.tail", envAdmitTail, bindScalar},
 	{"admit.disabled", envAdmitDisabled, bindScalar},
 
 	// Generated DDL. The chart reaches its long tail through a generic

--- a/internal/config/viper_test.go
+++ b/internal/config/viper_test.go
@@ -111,6 +111,9 @@ func TestFromEnv_ViperDefaults_NoEnv(t *testing.T) {
 	if cfg.Admit.Tempo != DefaultAdmitTempo {
 		t.Errorf("Admit.Tempo = %d; want %d (default cap)", cfg.Admit.Tempo, DefaultAdmitTempo)
 	}
+	if cfg.Admit.Tail != DefaultAdmitTail {
+		t.Errorf("Admit.Tail = %d; want %d (default cap)", cfg.Admit.Tail, DefaultAdmitTail)
+	}
 }
 
 // TestFromEnv_ViperEnvBeatsDefault asserts a CERBERUS_<VAR> override

--- a/test/e2e/grafana/compose/dashboards/cerberus.json
+++ b/test/e2e/grafana/compose/dashboards/cerberus.json
@@ -381,7 +381,7 @@
         "type": "prometheus",
         "uid": "cerberus-prometheus"
       },
-      "description": "Admission-control rejections per second, per head. Backed by cerberus_admit_rejected_total — declarative until the admission middleware exports it.",
+      "description": "Admission-control rejections per second, split by head and by admission budget (request vs the Loki /tail budget). Backed by cerberus_admit_rejected_total — declarative until the admission middleware exports it.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -458,8 +458,8 @@
             "uid": "cerberus-prometheus"
           },
           "editorMode": "code",
-          "expr": "sum by (cerberus_ql, reason) (rate(cerberus_admit_rejected_total[5m]))",
-          "legendFormat": "{{cerberus_ql}} / {{reason}}",
+          "expr": "sum by (cerberus_ql, budget, reason) (rate(cerberus_admit_rejected_total[5m]))",
+          "legendFormat": "{{cerberus_ql}} / {{budget}} / {{reason}}",
           "range": true,
           "refId": "A"
         }

--- a/test/e2e/grafana/dashboards/cerberus.json
+++ b/test/e2e/grafana/dashboards/cerberus.json
@@ -381,7 +381,7 @@
         "type": "prometheus",
         "uid": "cerberus-prometheus"
       },
-      "description": "Admission-control rejections per second, per head. Backed by cerberus_admit_rejected_total — declarative until the admission middleware exports it.",
+      "description": "Admission-control rejections per second, split by head and by admission budget (request vs the Loki /tail budget). Backed by cerberus_admit_rejected_total — declarative until the admission middleware exports it.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -458,8 +458,8 @@
             "uid": "cerberus-prometheus"
           },
           "editorMode": "code",
-          "expr": "sum by (cerberus_ql, reason) (rate(cerberus_admit_rejected_total[5m]))",
-          "legendFormat": "{{cerberus_ql}} / {{reason}}",
+          "expr": "sum by (cerberus_ql, budget, reason) (rate(cerberus_admit_rejected_total[5m]))",
+          "legendFormat": "{{cerberus_ql}} / {{budget}} / {{reason}}",
           "range": true,
           "refId": "A"
         }

--- a/test/e2e/k3s/grafana-dashboards.yaml
+++ b/test/e2e/k3s/grafana-dashboards.yaml
@@ -417,7 +417,7 @@ data:
             "type": "prometheus",
             "uid": "cerberus-prometheus"
           },
-          "description": "Admission-control rejections per second, per head. Backed by cerberus_admit_rejected_total — declarative until the admission middleware exports it.",
+          "description": "Admission-control rejections per second, split by head and by admission budget (request vs the Loki /tail budget). Backed by cerberus_admit_rejected_total — declarative until the admission middleware exports it.",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -494,8 +494,8 @@ data:
                 "uid": "cerberus-prometheus"
               },
               "editorMode": "code",
-              "expr": "sum by (cerberus_ql, reason) (rate(cerberus_admit_rejected_total[5m]))",
-              "legendFormat": "{{cerberus_ql}} / {{reason}}",
+              "expr": "sum by (cerberus_ql, budget, reason) (rate(cerberus_admit_rejected_total[5m]))",
+              "legendFormat": "{{cerberus_ql}} / {{budget}} / {{reason}}",
               "range": true,
               "refId": "A"
             }

--- a/test/e2e/playwright/helpers/sweep.ts
+++ b/test/e2e/playwright/helpers/sweep.ts
@@ -26,7 +26,10 @@
  * per head — so the per-head admit semaphores in
  * internal/api/admit saturate and cerberus ticks
  * `cerberus_admit_rejected_total{reason="cap_exceeded"}` on every
- * (cerberus_ql, reason) bucket. Without the burst the cerberus-self
+ * (cerberus_ql, budget, reason) bucket the burst can reach — the
+ * three heads' budget="request" streams. The Loki budget="tail"
+ * stream is zero-initialised at construction, so the panel renders a
+ * flat 0 for it rather than dropping the series. Without the burst the cerberus-self
  * "Admission rejections" panel has nothing to graph and the sweep's
  * empty-result guard fires.
  *
@@ -50,7 +53,7 @@ const DEFAULT_CERBERUS_URL = 'http://localhost:8080';
 // it should grow its own burst phase below).
 //
 // Without this phase the cerberus-self "Admission rejections" panel
-// (sum by (cerberus_ql, reason) (rate(cerberus_admit_rejected_total[5m])))
+// (sum by (cerberus_ql, budget, reason) (rate(cerberus_admit_rejected_total[5m])))
 // stays empty over the warmup window — healthy compose traffic never
 // approaches the cap.
 const ADMIT_BURST_CONCURRENCY = 128;


### PR DESCRIPTION
## The bug

The Loki head fronted every route with one admission semaphore, `/tail` included:

```go
mux.Handle(pattern, h.Limiter.Middleware(1, telemetry.QueryMiddleware("logql", panicEnvelope, hf)))
```

A semaphore counts requests, but the quantity worth bounding is occupancy-time, and the two agree
only while every occupant is short-lived. A tail's is not: `admit.Middleware` acquires before
`next.ServeHTTP` and releases via `defer`, which for `/tail` fires at client disconnect — and
`CERBERUS_HTTP_WRITE_TIMEOUT` defaults to `0`/unlimited *precisely so* a tail can stream
indefinitely, so nothing reclaims the slot in between.

At defaults (`CERBERUS_ADMIT_LOKI=64`), 64 Grafana Live-tail panels permanently occupied the entire
Loki budget and every subsequent Loki request on the replica — `/query`, `/query_range`, `/labels`,
`/series`, `/patterns`, the Drilldown probes — was rejected with `503 + Retry-After: 1` until a tail
client disconnected. Occupancy only ratcheted one way. The symptom ("the Loki datasource is down",
healthy pod, no elevated CPU, `cerberus_admit_rejected_total` climbing) points nowhere near the
cause, and the documented remedy — raise the cap, add replicas — does not address the shape.

## The mechanism

**Two budgets, not one cap and a sub-cap.**

- `admit.NewTail(head, cap)` builds a limiter carrying `BudgetTail`; `admit.New` keeps
  `BudgetRequest`. Same head, different semaphore.
- `loki.Handler` gains `TailLimiter`. `Mount` grows a `registerWith(limiter, pattern, hf)` seam;
  every short-lived route still goes through `h.Limiter`, and `GET /loki/api/v1/tail` — the one
  route — goes through `h.TailLimiter`.
- `CERBERUS_ADMIT_TAIL` (`internal/config`) sizes it, on the same int-or-bool contract as the
  per-head caps: integer cap, `true` = the default, `false`/`0` = unlimited, negative/garbage
  rejected at startup. `CERBERUS_ADMIT_DISABLED` still nils every budget at once.
- `cmd/cerberus`'s three-tuple of limiters becomes an `admitLimiters` struct. Four same-typed
  pointers returned positionally is exactly the shape where a mis-ordered argument compiles and
  silently remounts `/tail` on the query budget.

The budgets are independent in **both** directions. A full tail budget costs ordinary queries
nothing (the bug); and a query burst can no longer refuse a Live-tail upgrade, which matters because
query saturation is transient and self-clearing while dropping a Live panel is not.

## Why 16

`DefaultAdmitTail = 16`, a quarter of `DefaultAdmitLoki`, chosen from what a tail slot actually
costs rather than by analogy:

- **Duration.** The cap is a ceiling on *concurrent live-tail sessions per replica*, not on request
  throughput — 16 open Live-tail panels against one replica is generous for an interactive debugging
  workflow.
- **Steady load.** Each session re-queries ClickHouse on the one-second tail poll cadence, so the cap
  is also tailing's steady background query rate: 16 q/s per replica.

Not `0` (reads as "unlimited" — the state the issue describes). Not `DefaultAdmitLoki` (equal sizing
restores the arithmetic the split exists to break). `TestFromEnv_Admit_Defaults` asserts both bounds
directly, so a future edit to the number cannot silently cross either.

## Diagnosability

`cerberus_admit_rejected_total` gains a `budget` label (`request` / `tail`), zero-initialised at
construction like the existing streams so a healthy replica exports a flat 0 rather than "No data".
The issue calls out that the bug presents with "no way to tell which" — now
`sum by (cerberus_ql, budget, reason)` splits them. Additive for existing consumers: the current
`sum by (cerberus_ql, reason)` panels keep resolving, they just sum the budgets back together. The
three cerberus-self dashboard copies group by it.

## Tests

The route-mounting tests were verified non-vacuous by mutation — remounting `/tail` on `h.Limiter`
turns three of them red (`101` where `503` is wanted, and `503` twice where `101` is wanted).

- `internal/api/loki` — a fully saturated tail budget leaves every short-lived route admitted at full
  request capacity (the regression pin); `/tail` is genuinely bounded by its own cap; a saturated
  *request* budget leaves the tail upgrade untouched; a nil `TailLimiter` is pass-through, not a
  fallback to the request budget.
- `internal/api/admit` — two limiters on the same head share no capacity in either direction; a tail
  rejection carries `budget="tail"` on the same stream its zero-init registered; the zero-init test
  now covers all four budgets a real process builds.
- `internal/config` — `CERBERUS_ADMIT_TAIL` parses int-or-bool, rejects garbage, never disturbs
  `CERBERUS_ADMIT_LOKI`, and defaults positive-and-below-Loki.
- `cmd/cerberus` — the process wires two *distinct* limiters through to the handler's two fields
  (pointer identity, since an alias would satisfy every cap-arithmetic assertion while reproducing
  the bug).
- `.github/scripts/chart-render-assert.mjs` — `admit.tail` renders its own env key without disturbing
  `admit.loki`, and rejects a negative cap.

Existing Prom/Loki/Tempo admission tests are unchanged in behaviour.

## Also updated

`docs/operations.md` now distinguishes short-lived request slots from the tail budget in a table and
states plainly that a tail holds its slot until client disconnect — it previously described all caps
as "simultaneous in-flight requests" with no such warning. Helm chart (`values.yaml`,
`values.schema.json`, `_helpers.tpl`, regenerated `README.md`) and the code-generated
`docs/configuration.md` carry the new knob.

Verified locally: `internal/api/admit`, `internal/api/loki`, `internal/config` and `cmd/cerberus`
race-tested green; `go vet ./...` clean; `helm lint` and `chart-render-assert.mjs` pass;
markdownlint clean on both touched docs.


## Found while building this, not fixed here

[#2048](https://github.com/tsouza/cerberus/issues/2048) — a `/tail` refused by admission control is
refused at the HTTP upgrade (`503` + `Retry-After: 1`), where reference Loki upgrades first and
delivers its `querier.max-concurrent-tail-requests` rejection as a close frame on the established
connection (verified at `grafana/loki/v3@v3.7.1 pkg/querier/tail/http.go:49,69` and
`pkg/querier/tail/querier.go:164-168`). A WebSocket client does not read `Retry-After`, so the one
actionable field is dropped by its intended reader. This predates the split — `/tail` was already
behind the admission middleware — but the dedicated default makes the rejection reachable sooner, so
it is filed rather than left implicit. Fixing it means moving the tail acquire inside `handleTail`
after the upgrade, which is a different change in a different layer. `docs/operations.md` records the
current shape and points at the issue.

Closes #1482

🤖 Generated with [Claude Code](https://claude.com/claude-code)
