### PR TITLE
perf(traceql): read the spans table once for a bare-selector spanset intersect

### DIFF
--- a/docs/performance.md
+++ b/docs/performance.md
@@ -132,6 +132,22 @@ The typed emitter is CH-native, not ANSI-ish:
 - **`PREWHERE` promotion** fuses `Filter(Scan)` and partitions conjuncts into a
   sort-prefix bucket / skip-index bucket / rest, promoting cheap predicates
   that touch no wide column so CH evaluates them before reading wide columns.
+- **Single-pass spanset intersect** — TraceQL `&&` is a trace-level
+  conjunction over a span-level union, and the portable spelling of it names
+  each arm as a `WITH` CTE referenced three times. A non-recursive CTE is a
+  textual substitution, so ClickHouse re-reads the spans table per use site:
+  four leaf passes for two arms, seven for three. Where every arm is a filter
+  chain over one shared scan with a pure row predicate, the emitter collapses
+  the whole chain to one pass, gating traces with
+  `QUALIFY max(<p>) OVER (PARTITION BY TraceId)`. `QUALIFY` filters on the
+  window value without projecting it, so the statement keeps its bare
+  `SELECT *` column set. Shared conjuncts are factored out of the arms'
+  disjunction first — otherwise a windowed query's request bounds would
+  vanish into one opaque `OR` and lose partition pruning, making the single
+  pass a full-retention scan. Arms whose membership is decided by a subplan
+  rather than by the row — a parenthesised sub-pipeline ending in a spanset
+  aggregate — keep the CTE shape, because no per-row predicate reproduces a
+  per-trace aggregate.
 - **Streaming `clickhouse-go/v2` cursor** — bounded RSS, no full row buffer on
   the hot path.
 
@@ -214,8 +230,9 @@ ceiling only tightens when a maintainer re-runs
 **fan_factor is nullable, and null is never a free pass.** The profiler's
 per-subquery `count()` decomposition only descends the leftmost `FROM`
 source; it stops on a `WITH`-prefixed subquery (a CTE reference or a
-pre-rendered subquery splice — the `&&` `SetIntersect` shape in
-`internal/chsql/set_op.go` is the current example) and, structurally via
+pre-rendered subquery splice — the union-gated `&&` `SetIntersect` fallback
+in `internal/chsql/set_op.go` is the current example, reached only by the
+arm shapes the single-pass window gate cannot fuse) and, structurally via
 `EXPLAIN`, on any `RECURSIVE` CTE step. Before #1519 those stages silently
 flattened to `fan_factor = 1.00` — the profiler reported "no fan-out" on
 exactly the constructs it exists to catch. `profile.Record.FanFactor` is

--- a/internal/chsql/builder.go
+++ b/internal/chsql/builder.go
@@ -2259,6 +2259,7 @@ type QueryBuilder struct {
 	prewhere   []Frag
 	groupBy    []Frag
 	having     []Frag
+	qualify    []Frag
 	orderBy    []orderKey
 	limit      int64
 	hasLimit   bool
@@ -2426,6 +2427,27 @@ func (s *QueryBuilder) GroupBy(keys ...Frag) *QueryBuilder {
 // `WHERE TimeUnix >= ?` on the same column cannot.
 func (s *QueryBuilder) Having(conds ...Frag) *QueryBuilder {
 	s.having = append(s.having, conds...)
+	return s
+}
+
+// Qualify appends a post-window predicate (multiple conditions are
+// AND-joined). QUALIFY is to window functions what HAVING is to
+// aggregates: it filters on the value of a `… OVER (…)` expression,
+// which WHERE cannot do because window functions are evaluated after
+// WHERE.
+//
+// Its value over the equivalent `SELECT *, <win> AS g FROM … WHERE g`
+// rewrite is that the window column never enters the projection, so the
+// result keeps the input's exact column set and the caller needs no
+// `* EXCEPT (g)` to strip it back off. That is what lets the `&&`
+// single-pass trace gate (set_op.go) keep `SELECT *` over the bare spans
+// table — the shape whose column set every downstream consumer, and the
+// spec harness's star expansion, already understand.
+//
+// Renders after HAVING and before ORDER BY, matching ClickHouse's clause
+// order.
+func (s *QueryBuilder) Qualify(conds ...Frag) *QueryBuilder {
+	s.qualify = append(s.qualify, conds...)
 	return s
 }
 
@@ -2635,6 +2657,10 @@ func (s *QueryBuilder) writeInto(b *Builder) {
 	if len(s.having) > 0 {
 		b.sb.WriteString(" HAVING ")
 		And(s.having...)(b)
+	}
+	if len(s.qualify) > 0 {
+		b.sb.WriteString(" QUALIFY ")
+		And(s.qualify...)(b)
 	}
 	if len(s.orderBy) > 0 {
 		b.sb.WriteString(" ORDER BY ")

--- a/internal/chsql/emit_node.go
+++ b/internal/chsql/emit_node.go
@@ -85,8 +85,21 @@ func (e *emitter) splice(b *Builder) error {
 }
 
 func (e *emitter) emitScan(s *chplan.Scan) error {
-	if err := validateScanShape(s); err != nil {
+	sb, err := scanQuery(s)
+	if err != nil {
 		return err
+	}
+	return e.emitSelect(sb)
+}
+
+// scanQuery assembles the bare `SELECT [cols] FROM <table>` QueryBuilder
+// for a predicate-less Scan, returned unrendered so a caller can hang
+// further slots off it — the unfiltered-arm case of the `&&` single-pass
+// gate (set_op.go), where every arm matches every span and there is no
+// disjunction to restrict the scan by.
+func scanQuery(s *chplan.Scan) (*QueryBuilder, error) {
+	if err := validateScanShape(s); err != nil {
+		return nil, err
 	}
 	sb := NewQuery().From(scanTableFrag(s))
 	// An empty Columns slice appends nothing to the SELECT list, which
@@ -98,7 +111,7 @@ func (e *emitter) emitScan(s *chplan.Scan) error {
 		cols = append(cols, Col(c))
 	}
 	sb.Select(cols...)
-	return e.emitSelect(sb)
+	return sb, nil
 }
 
 // validateScanShape enforces the mutual exclusion between Scan.Table and
@@ -380,8 +393,27 @@ func (e *emitter) emitFilter(f *chplan.Filter) error {
 // promotion always activates in that case when the table shape has
 // wide columns registered.
 func (e *emitter) emitFilterScan(f *chplan.Filter, scan *chplan.Scan) error {
-	if err := validateScanShape(scan); err != nil {
+	sb, err := filterScanQuery(f, scan)
+	if err != nil {
 		return err
+	}
+	return e.emitSelect(sb)
+}
+
+// filterScanQuery assembles the Filter-directly-above-Scan QueryBuilder
+// that emitFilterScan renders, returning it unrendered so a caller that
+// needs to hang further slots off the same single-table SELECT can do so
+// without losing the PREWHERE split.
+//
+// The `&&` single-pass trace gate (set_op.go's fusedIntersectQuery) is
+// that caller: it drives the arms' disjunction through here so the fused
+// scan keeps the same granule-skipping PREWHERE promotion each arm's own
+// Filter(Scan) would have received, then adds its QUALIFY window gate.
+// Sharing the assembly is what keeps the fast path from silently trading
+// four cheap PREWHERE-pruned reads for one unpruned one.
+func filterScanQuery(f *chplan.Filter, scan *chplan.Scan) (*QueryBuilder, error) {
+	if err := validateScanShape(scan); err != nil {
+		return nil, err
 	}
 	// For a UnionTables scan every member table shares the metric-row
 	// shape (the cerberus-created metrics tables all order by
@@ -431,7 +463,7 @@ func (e *emitter) emitFilterScan(f *chplan.Filter, scan *chplan.Scan) error {
 	if len(whereExprs) > 0 {
 		sb.Where(conjunctionFrag(whereExprs))
 	}
-	return e.emitSelect(sb)
+	return sb, nil
 }
 
 // conjunctionFrag returns a Frag that renders exprs joined with " AND ".

--- a/internal/chsql/emit_node_goldens_test.go
+++ b/internal/chsql/emit_node_goldens_test.go
@@ -300,40 +300,182 @@ func TestEmitNode_Aggregate_PropagatesChildError(t *testing.T) {
 // TestEmitNode_SetOperation_Intersect pins TraceQL's `A && B` semantics:
 // both arms must match the same trace, but the result is the identity-deduped
 // span-level union of those arms. Tempo uses this shape for both `&&` and
-// `||`; `&&` differs only by the two trace-cohort predicates.
+// `||`; `&&` differs only by the trace gate.
+//
+// It also pins the DECISION BOUNDARY between the two shapes that gate
+// (see chsql.fusableIntersect):
+//
+//   - Arms that are Filter-chains over one shared Scan with pure row
+//     predicates fuse into ONE pass — `WHERE <p1> OR <p2> QUALIFY
+//     max(<p1>) OVER (PARTITION BY TraceId) AND …` — costing one leaf
+//     read of the spans table.
+//   - Every other arm shape keeps the union-gated `_setand_{l,r}_<n>` CTE
+//     pair, which is correct but re-reads the table per use site.
+//
+// The negative cases are the load-bearing half. A sub-pipeline arm is
+// STRUCTURALLY a Filter chain over the shared Scan, so an emitter that
+// swapped shapes on structure alone would fuse it and return wrong rows:
+// its membership test is a per-trace aggregate that no per-row predicate
+// can reproduce. These cases fail on exactly that mistake.
 func TestEmitNode_SetOperation_Intersect(t *testing.T) {
 	t.Parallel()
 
-	plan := &chplan.SetOperation{
-		Left:          &chplan.Scan{Table: "otel_traces"},
-		Right:         &chplan.Scan{Table: "otel_traces"},
-		Op:            chplan.SetIntersect,
-		TraceIDColumn: "TraceId",
-		SpanIDColumn:  "SpanId",
-	}
-	sql, args, err := chsql.Emit(context.Background(), plan)
-	if err != nil {
-		t.Fatalf("Emit: %v", err)
-	}
-	// Verify the structural shape: arm CTEs, UNION ALL, trace gate, and
-	// identity deduplication.
-	for _, frag := range []string{
-		"WITH _setand_l_1 AS",
-		"_setand_r_1 AS",
-		"UNION ALL",
-		"`TraceId` IN (SELECT `TraceId` FROM _setand_l_1)",
-		"`TraceId` IN (SELECT `TraceId` FROM _setand_r_1)",
-		"LIMIT 1 BY `TraceId`, `SpanId`",
-	} {
-		if !strings.Contains(sql, frag) {
-			t.Errorf("SetIntersect SQL missing fragment %q; got %q", frag, sql)
+	scan := func() *chplan.Scan { return &chplan.Scan{Table: "otel_traces"} }
+	filtered := func(col, val string) chplan.Node {
+		return &chplan.Filter{
+			Input:     scan(),
+			Predicate: &chplan.Binary{Op: chplan.OpEq, Left: &chplan.ColumnRef{Name: col}, Right: &chplan.LitString{V: val}},
 		}
 	}
-	if strings.Contains(sql, "INNER JOIN") {
-		t.Errorf("SetIntersect must union distinct spans from matching traces, not intersect span identities: %q", sql)
+	intersect := func(l, r chplan.Node) *chplan.SetOperation {
+		return &chplan.SetOperation{
+			Left: l, Right: r, Op: chplan.SetIntersect,
+			TraceIDColumn: "TraceId", SpanIDColumn: "SpanId",
+		}
 	}
-	if args != nil {
-		t.Errorf("Args = %v; want nil (no `?` in this shape)", args)
+	// A parenthesised sub-pipeline arm: the span rows under a per-trace
+	// aggregate cohort, exactly what test/spec/traceql's
+	// spanset_pipeline_intersect fixture lowers to.
+	subPipelineArm := func() chplan.Node {
+		return &chplan.Filter{
+			Input: filtered("SpanName", "left"),
+			Predicate: &chplan.InSubquery{
+				Left: &chplan.ColumnRef{Name: "TraceId"},
+				Subquery: &chplan.Aggregate{
+					Input:          scan(),
+					GroupBy:        []chplan.Expr{&chplan.ColumnRef{Name: "TraceId"}},
+					GroupByAliases: []string{"TraceId"},
+				},
+			},
+		}
+	}
+
+	const (
+		fusedGateLeft  = "QUALIFY max((`SpanName` = ?)) OVER (PARTITION BY `TraceId`)"
+		fusedGateRight = "max((`Duration` = ?)) OVER (PARTITION BY `TraceId`)"
+		armCTELeft     = "WITH _setand_l_1 AS"
+		armCTERight    = "_setand_r_1 AS"
+		identityDedup  = "LIMIT 1 BY `TraceId`, `SpanId`"
+	)
+
+	cases := []struct {
+		name    string
+		plan    *chplan.SetOperation
+		want    []string
+		notWant []string
+	}{
+		{
+			// The issue-#1519 case: two bare selectors over one table.
+			name: "bare selector arms fuse to a single pass",
+			plan: intersect(filtered("SpanName", "left"), filtered("Duration", "5")),
+			want: []string{
+				"SELECT * FROM `otel_traces`",
+				"WHERE ((`SpanName` = ?) OR (`Duration` = ?))",
+				fusedGateLeft,
+				fusedGateRight,
+				identityDedup,
+			},
+			notWant: []string{armCTELeft, armCTERight, "UNION ALL", "_setand_"},
+		},
+		{
+			// `{} && {}` — both arms match every span, so the disjunction
+			// is a tautology and every trace already satisfies both gates.
+			name: "unfiltered arms need neither restriction nor gate",
+			plan: intersect(scan(), scan()),
+			want: []string{"SELECT * FROM `otel_traces`", identityDedup},
+			notWant: []string{
+				armCTELeft, "UNION ALL", "QUALIFY", "WHERE",
+			},
+		},
+		{
+			// `A && B && C` arrives left-nested; all three arms fuse into
+			// ONE pass with three gate terms rather than nesting a second
+			// union-gated statement inside the first.
+			name: "nested intersect chain flattens into one pass",
+			plan: intersect(
+				intersect(filtered("SpanName", "left"), filtered("Duration", "5")),
+				filtered("StatusCode", "Error"),
+			),
+			want: []string{
+				"WHERE (((`SpanName` = ?) OR (`Duration` = ?)) OR (`StatusCode` = ?))",
+				fusedGateLeft,
+				fusedGateRight,
+				"max((`StatusCode` = ?)) OVER (PARTITION BY `TraceId`)",
+			},
+			notWant: []string{"_setand_", "UNION ALL"},
+		},
+		{
+			// THE correctness boundary: structurally a Filter chain over
+			// the shared Scan, semantically a per-trace aggregate.
+			name:    "sub-pipeline arm keeps the union-gated shape",
+			plan:    intersect(subPipelineArm(), filtered("Duration", "5")),
+			want:    []string{armCTELeft, armCTERight, "UNION ALL", "`TraceId` IN (SELECT `TraceId` FROM _setand_l_1)", identityDedup},
+			notWant: []string{"QUALIFY"},
+		},
+		{
+			// A BoundedTraceScope is an Expr LEAF, so a Node-only walk
+			// never sees it — but the emitter re-derives a top-N spans
+			// subquery from it, so fusing would hide a second table read
+			// behind a shape advertising one pass.
+			name: "bounded-trace-scope arm keeps the union-gated shape",
+			plan: intersect(
+				&chplan.Filter{Input: scan(), Predicate: &chplan.BoundedTraceScope{
+					SpansTable: "otel_traces", TraceIDColumn: "TraceId",
+					ParentSpanIDColumn: "ParentSpanId", TimestampColumn: "Timestamp", TraceLimit: 20,
+				}},
+				filtered("Duration", "5"),
+			),
+			want:    []string{armCTELeft, armCTERight, identityDedup},
+			notWant: []string{"QUALIFY"},
+		},
+		{
+			// Different tables are not one shared pass, however similar
+			// the arm shapes look.
+			name: "arms over different tables keep the union-gated shape",
+			plan: intersect(
+				&chplan.Filter{Input: &chplan.Scan{Table: "otel_traces"}, Predicate: &chplan.ColumnRef{Name: "A"}},
+				&chplan.Filter{Input: &chplan.Scan{Table: "otel_traces_other"}, Predicate: &chplan.ColumnRef{Name: "B"}},
+			),
+			want:    []string{armCTELeft, armCTERight, identityDedup},
+			notWant: []string{"QUALIFY"},
+		},
+		{
+			// A nested `||` is a different operator; flattening it into
+			// the conjunctive gate would turn "either arm" into "both".
+			name: "nested union arm keeps the union-gated shape",
+			plan: intersect(
+				&chplan.SetOperation{
+					Left: filtered("SpanName", "left"), Right: filtered("Duration", "5"),
+					Op: chplan.SetUnion, TraceIDColumn: "TraceId", SpanIDColumn: "SpanId",
+				},
+				filtered("StatusCode", "Error"),
+			),
+			want:    []string{armCTELeft, armCTERight, identityDedup},
+			notWant: []string{"QUALIFY"},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			sql, _, err := chsql.Emit(context.Background(), tc.plan)
+			if err != nil {
+				t.Fatalf("Emit: %v", err)
+			}
+			for _, frag := range tc.want {
+				if !strings.Contains(sql, frag) {
+					t.Errorf("SetIntersect SQL missing fragment %q; got %q", frag, sql)
+				}
+			}
+			for _, frag := range tc.notWant {
+				if strings.Contains(sql, frag) {
+					t.Errorf("SetIntersect SQL must not contain %q; got %q", frag, sql)
+				}
+			}
+			if strings.Contains(sql, "INNER JOIN") {
+				t.Errorf("SetIntersect must union distinct spans from matching traces, not intersect span identities: %q", sql)
+			}
+		})
 	}
 }
 

--- a/internal/chsql/set_op.go
+++ b/internal/chsql/set_op.go
@@ -16,13 +16,22 @@ import (
 // magic 1.
 const unionDedupLimitPerIdentity = 1
 
-// The `&&` arm CTE names. Each arm subplan is materialised once under
-// these names and referenced three times (its UNION-ALL leg plus both
-// trace-cohort IN subqueries); inlining instead would re-render the
-// whole subplan three times per nesting level, so `A && B && C && D`
-// would grow the emitted text exponentially. The `<n>` suffix comes
-// from emitter.nextCTESeq so a nested `&&` never shadows its parent's
-// arm names in the outer CH scope.
+// The `&&` arm CTE names. Each arm subplan is NAMED once under these
+// names and referenced three times (its UNION-ALL leg plus both
+// trace-cohort IN subqueries). Naming it keeps the emitted TEXT linear —
+// inlining would re-render the whole subplan three times per nesting
+// level, so `A && B && C && D` would grow the SQL exponentially — but it
+// does NOT make ClickHouse read the arm once. A non-recursive `WITH` is
+// a textual substitution: CH re-evaluates every use site independently
+// (the same property nested_set_annotate.go documents), so a two-arm
+// `&&` over bare selectors costs FOUR leaf reads of the spans table and
+// a three-arm chain costs seven — measured, not inferred.
+//
+// That cost is why these names are now the FALLBACK shape rather than
+// the only one; see fusableIntersect for the single-pass gate that
+// replaces them wherever the arms admit it. The `<n>` suffix comes from
+// emitter.nextCTESeq so a nested `&&` never shadows its parent's arm
+// names in the outer CH scope.
 const (
 	intersectLeftArmCTEPrefix  = "_setand_l_"
 	intersectRightArmCTEPrefix = "_setand_r_"
@@ -92,6 +101,16 @@ func (e *emitter) emitSetOperation(s *chplan.SetOperation) error {
 		return fmt.Errorf("%w: SetOperation column names unset", ErrUnsupported)
 	}
 
+	// Fast path first, BEFORE the arms are rendered: rendering an arm
+	// advances the shared CTE counter, so probing fusibility afterwards
+	// would leave gaps in the `_setand_*_<n>` numbering of whatever the
+	// fallback then emits.
+	if s.Op == chplan.SetIntersect {
+		if scan, arms, ok := fusableIntersect(s); ok {
+			return e.emitFusedIntersect(s, scan, arms)
+		}
+	}
+
 	leftFrag, err := e.subqueryFrag(s.Left)
 	if err != nil {
 		return err
@@ -146,4 +165,320 @@ func intersectQuery(s *chplan.SetOperation, leftFrag, rightFrag Frag, seq int) *
 		Where(armTraceCohort(leftCTE), armTraceCohort(rightCTE)).
 		Limit(unionDedupLimitPerIdentity).
 		LimitBy(Col(s.TraceIDColumn), Col(s.SpanIDColumn))
+}
+
+// fusableIntersect decides whether an `&&` tree can be served by the
+// single-pass window gate instead of the union-gated CTE shape, and if
+// so returns the one Scan every arm reads plus the arms' predicates in
+// left-to-right order.
+//
+// THE DECISION. The gate rewrites "traces where every arm matched at
+// least one span, carrying every span any arm matched" from a union of
+// separately-evaluated arms into ONE pass over the shared table:
+//
+//	SELECT * FROM <spans>
+//	WHERE  (<p1>) OR (<p2>) …            -- the span-level union
+//	QUALIFY max(<p1>) OVER (PARTITION BY <TraceId>)
+//	   AND  max(<p2>) OVER (PARTITION BY <TraceId>) …   -- the trace gate
+//	LIMIT 1 BY <TraceId>, <SpanId>
+//
+// That is only a faithful rewrite when each arm is a ROW PREDICATE over
+// the same rows — every arm must reduce to "this span matches <p>", so
+// that `max(<p>) OVER (PARTITION BY TraceId)` reproduces Tempo's
+// `len(side) > 0` per-trace test, and so that restricting the scan to
+// the disjunction cannot hide a row an arm needed (a row satisfying <p1>
+// always satisfies `<p1> OR <p2>`).
+//
+// An arm qualifies iff it is a chain of Filters bottoming out in a Scan
+// (conjoined into one predicate), the Scan is Equal to every other arm's,
+// and the predicate is gate-safe (see gateSafePredicate).
+//
+// WHAT DOES NOT QUALIFY, and why the choice is load-bearing rather than
+// cosmetic. `spanset_pipeline_intersect`'s arms —
+// `({…} | count() > 0) && ({…} | count() > 0)` — lower to
+// `Filter(TraceId IN {Aggregate pipeline}) → Filter(<selector>) → Scan`.
+// Structurally that IS a Filter chain over the shared Scan, so a purely
+// structural test would fuse it; the result would be WRONG, because the
+// arm's membership is decided by a per-trace aggregate over the arm's own
+// row set, which no per-row predicate — and therefore no `max(<p>) OVER`
+// — can reproduce. gateSafePredicate's "no nested plan" rule is exactly
+// the line between the two cases.
+//
+// Nested `&&` flattens: `A && B && C` arrives as
+// SetOperation(SetOperation(A, B), C) and fuses to a single pass over all
+// three arms, since "(A && B) matched this trace" is precisely "A matched
+// and B matched" and its spans are A's ∪ B's. A chain that is only partly
+// fusable falls back at the level that fails and still fuses below it,
+// because the fallback renders its arms through the ordinary recursive
+// emit.
+func fusableIntersect(s *chplan.SetOperation) (*chplan.Scan, []chplan.Expr, bool) {
+	var scan *chplan.Scan
+	var arms []chplan.Expr
+	if !collectIntersectArms(s, s, &scan, &arms) {
+		return nil, nil, false
+	}
+	return scan, arms, true
+}
+
+// collectIntersectArms walks the `&&` chain rooted at root, appending one
+// predicate per leaf arm and pinning the single Scan they must share.
+// Reports false the moment any arm disqualifies.
+func collectIntersectArms(n chplan.Node, root *chplan.SetOperation, scan **chplan.Scan, arms *[]chplan.Expr) bool {
+	if inner, ok := n.(*chplan.SetOperation); ok {
+		// Only an `&&` on the SAME identity key flattens. A nested `||`
+		// is a different operator, and a nested `&&` keyed on a different
+		// (TraceId, SpanId) pair is a spanset granularity change the gate
+		// must not paper over.
+		if inner.Op != chplan.SetIntersect ||
+			inner.TraceIDColumn != root.TraceIDColumn ||
+			inner.SpanIDColumn != root.SpanIDColumn {
+			return false
+		}
+		return collectIntersectArms(inner.Left, root, scan, arms) &&
+			collectIntersectArms(inner.Right, root, scan, arms)
+	}
+	pred, armScan, ok := filterChainOverScan(n)
+	if !ok || !gateSafePredicate(pred) {
+		return false
+	}
+	if *scan == nil {
+		*scan = armScan
+	} else if !(*scan).Equal(armScan) {
+		return false
+	}
+	*arms = append(*arms, pred)
+	return true
+}
+
+// filterChainOverScan peels a chain of Filters off a Scan and returns the
+// conjunction of their predicates (nil for a bare, unfiltered Scan — an
+// arm that matches every span). Reports false for any other node shape.
+func filterChainOverScan(n chplan.Node) (chplan.Expr, *chplan.Scan, bool) {
+	var preds []chplan.Expr
+	for {
+		switch v := n.(type) {
+		case *chplan.Filter:
+			// Collected outermost-first; reversed below so the rendered
+			// conjunction reads innermost-first, the order the arm's own
+			// Filter(Scan) emit would have produced. A predicate-less
+			// Filter restricts nothing and contributes no conjunct — it
+			// must not reach the AND chain, where a nil operand would
+			// render as an empty token.
+			if v.Predicate != nil {
+				preds = append(preds, v.Predicate)
+			}
+			n = v.Input
+		case *chplan.Scan:
+			for i, j := 0, len(preds)-1; i < j; i, j = i+1, j-1 {
+				preds[i], preds[j] = preds[j], preds[i]
+			}
+			return conjoinExprs(preds), v, true
+		default:
+			return nil, nil, false
+		}
+	}
+}
+
+// conjoinExprs folds preds into a single left-associated AND expression.
+// Empty returns nil, the "no predicate at all" signal.
+func conjoinExprs(preds []chplan.Expr) chplan.Expr {
+	if len(preds) == 0 {
+		return nil
+	}
+	out := preds[0]
+	for _, p := range preds[1:] {
+		out = &chplan.Binary{Op: chplan.OpAnd, Left: out, Right: p}
+	}
+	return out
+}
+
+// gateSafePredicate reports whether pred is a pure row predicate — one
+// whose truth for a span depends on that span's own columns and nothing
+// else — which is the precondition for `max(pred) OVER (PARTITION BY
+// TraceId)` to mean "some span of this trace matched this arm".
+//
+// Two things disqualify, both because they smuggle a whole table read
+// into what looks like a scalar test:
+//
+//   - A nested plan (chplan.InSubquery / chplan.ScalarSubquery). This is
+//     the sub-pipeline arm of fusableIntersect's godoc: the arm's real
+//     membership test lives in that subplan, not in the row.
+//   - A BoundedTraceScope. It is an Expr LEAF, so the Node walk never
+//     sees it, but the emitter re-derives a top-N trace subquery from it
+//     at emit time — fusing one would keep a second read of the spans
+//     table alive behind a shape that advertises a single pass.
+//
+// A nil predicate (unfiltered Scan arm) is trivially gate-safe.
+func gateSafePredicate(pred chplan.Expr) bool {
+	if pred == nil {
+		return true
+	}
+	safe := true
+	chplan.InspectExprNodes(pred, func(e chplan.Expr) bool {
+		if _, ok := e.(*chplan.BoundedTraceScope); ok {
+			safe = false
+		}
+		return safe
+	}, func(chplan.Node) { safe = false })
+	return safe
+}
+
+// emitFusedIntersect renders the single-pass window gate described in
+// fusableIntersect's godoc.
+//
+// The arms' disjunction rides filterScanQuery, the same assembly an arm's
+// own Filter(Scan) would have used, so the fused scan keeps PREWHERE
+// granule pruning rather than trading four pruned reads for one unpruned
+// one. Each arm predicate is therefore rendered twice — once in the
+// WHERE/PREWHERE disjunction, once inside its `max(…) OVER (…)` gate —
+// and binds its `?` args twice; that is the price of never materialising
+// the predicate as a column.
+//
+// Not materialising it is the point. The obvious alternative, projecting
+// `max(…) OVER (…) AS g` and filtering on `g`, forces the outer SELECT to
+// strip the synthetic column back off with `* EXCEPT (g)`, which changes
+// the statement's projection shape for every downstream consumer. QUALIFY
+// filters on the window value while leaving the projection a bare
+// `SELECT *` over the spans table — the same column set the arm CTEs
+// produce today.
+//
+// The trace gate is `max(<pred>)`, not `countIf(<pred>) > 0`, so a
+// Nullable predicate stays correct by CH's own three-valued rules: an arm
+// whose predicate is NULL on every span of a trace yields a NULL gate,
+// and `WHERE NULL` drops the row exactly as the arm's own
+// `TraceId IN (<cohort>)` would have.
+//
+// Row ORDER differs from the fallback shape: the union emits all of the
+// left arm then all of the right, while one pass emits table order. Both
+// are unordered results feeding the same `LIMIT 1 BY` span-identity dedup
+// — TraceQL's own contract fixes the SET of spans, never their order.
+func (e *emitter) emitFusedIntersect(s *chplan.SetOperation, scan *chplan.Scan, arms []chplan.Expr) error {
+	common, residuals := splitCommonConjuncts(arms)
+	conds := append([]chplan.Expr(nil), common...)
+	if disj := disjoinArms(residuals); disj != nil {
+		conds = append(conds, disj)
+	}
+
+	var (
+		sb  *QueryBuilder
+		err error
+	)
+	if len(conds) > 0 {
+		sb, err = filterScanQuery(&chplan.Filter{Input: scan, Predicate: conjoinExprs(conds)}, scan)
+	} else {
+		// Every arm matches every span, so there is nothing to restrict
+		// the scan by.
+		sb, err = scanQuery(scan)
+	}
+	if err != nil {
+		return err
+	}
+	for _, pred := range residuals {
+		if pred == nil {
+			// The arm is fully implied by the shared conjuncts every
+			// surviving row already satisfies, so its gate is constantly
+			// true — including the unfiltered-arm case.
+			continue
+		}
+		sb.Qualify(Window(
+			Call("max", func(b *Builder) { _ = b.Expr(pred) }),
+			[]Frag{Col(s.TraceIDColumn)},
+			nil,
+		))
+	}
+	sb.Limit(unionDedupLimitPerIdentity).
+		LimitBy(Col(s.TraceIDColumn), Col(s.SpanIDColumn))
+	return e.emitSelect(sb)
+}
+
+// splitCommonConjuncts factors the conjuncts every arm shares out of the
+// arms' predicates, returning them plus each arm's residual (nil when an
+// arm is wholly implied by the shared set).
+//
+// This is what keeps the fused scan as cheap as the arms it replaces. A
+// windowed TraceQL query — the shape Grafana actually sends — puts the
+// SAME request-window bounds on every arm, so the unfactored disjunction
+// would be `(<p1> AND <window>) OR (<p2> AND <window>)`: ONE opaque
+// conjunct, from which partitionPrewhere can promote nothing and CH can
+// prune no `toDate(Timestamp)` partition. Factored, the restriction is
+// `<window> AND (<p1> OR <p2>)` and the window conjuncts reach PREWHERE
+// exactly as they do on an arm's own Filter(Scan). Without this the fast
+// path would trade four partition-pruned reads for one full-retention
+// scan and be a REGRESSION on the production path, not a win.
+//
+// Dropping the shared conjuncts from the gate terms is sound for the same
+// reason it is safe to drop them from the disjunction: every row the
+// window function sees has already passed them, so on that row set
+// `<residual> AND <common>` and `<residual>` agree, and therefore so do
+// their per-partition maxima.
+func splitCommonConjuncts(arms []chplan.Expr) (common, residuals []chplan.Expr) {
+	residuals = make([]chplan.Expr, len(arms))
+	perArm := make([][]chplan.Expr, len(arms))
+	for i, pred := range arms {
+		if pred == nil {
+			// An unfiltered arm shares nothing, so nothing is common to
+			// ALL arms; every arm keeps its own predicate whole.
+			return nil, arms
+		}
+		perArm[i] = flattenAnd(pred)
+	}
+	if len(perArm) == 0 {
+		return nil, residuals
+	}
+
+	shared := make([]bool, len(perArm[0]))
+	for i, c := range perArm[0] {
+		shared[i] = true
+		for _, other := range perArm[1:] {
+			if !containsExpr(other, c) {
+				shared[i] = false
+				break
+			}
+		}
+		if shared[i] {
+			common = append(common, c)
+		}
+	}
+	if len(common) == 0 {
+		return nil, arms
+	}
+	for i, conjuncts := range perArm {
+		var rest []chplan.Expr
+		for _, c := range conjuncts {
+			if !containsExpr(common, c) {
+				rest = append(rest, c)
+			}
+		}
+		residuals[i] = conjoinExprs(rest)
+	}
+	return common, residuals
+}
+
+// containsExpr reports whether list holds an expression equal to want.
+func containsExpr(list []chplan.Expr, want chplan.Expr) bool {
+	for _, e := range list {
+		if e.Equal(want) {
+			return true
+		}
+	}
+	return false
+}
+
+// disjoinArms folds the arms' predicates into the span-level union's
+// restriction. A nil arm predicate makes the whole disjunction a
+// tautology, so the result is nil and the caller emits no restriction at
+// all rather than a redundant `… OR true`.
+func disjoinArms(arms []chplan.Expr) chplan.Expr {
+	var out chplan.Expr
+	for _, pred := range arms {
+		if pred == nil {
+			return nil
+		}
+		if out == nil {
+			out = pred
+			continue
+		}
+		out = &chplan.Binary{Op: chplan.OpOr, Left: out, Right: pred}
+	}
+	return out
 }

--- a/test/perf/cardinality-baseline/traceql/edge_set_intersect_3.json
+++ b/test/perf/cardinality-baseline/traceql/edge_set_intersect_3.json
@@ -1,11 +1,11 @@
 {
   "fixture": "traceql/edge_set_intersect_3",
-  "fan_factor": null,
+  "fan_factor": 1,
   "scan_rows": 1,
   "peak_intermediate": 1,
   "has_cross_join": false,
   "has_array_join": false,
   "has_recursive_cte": false,
   "max_recursion_depth": 0,
-  "uncountable_levels": 1
+  "uncountable_levels": 0
 }

--- a/test/perf/cardinality-baseline/traceql/set_intersect_simple.json
+++ b/test/perf/cardinality-baseline/traceql/set_intersect_simple.json
@@ -1,11 +1,11 @@
 {
   "fixture": "traceql/set_intersect_simple",
-  "fan_factor": null,
+  "fan_factor": 1,
   "scan_rows": 4,
   "peak_intermediate": 4,
   "has_cross_join": false,
   "has_array_join": false,
   "has_recursive_cte": false,
   "max_recursion_depth": 0,
-  "uncountable_levels": 1
+  "uncountable_levels": 0
 }

--- a/test/perf/cardinality-baseline/traceql/spanset_and_distinct_spans.json
+++ b/test/perf/cardinality-baseline/traceql/spanset_and_distinct_spans.json
@@ -1,11 +1,11 @@
 {
   "fixture": "traceql/spanset_and_distinct_spans",
-  "fan_factor": null,
+  "fan_factor": 1,
   "scan_rows": 2,
   "peak_intermediate": 2,
   "has_cross_join": false,
   "has_array_join": false,
   "has_recursive_cte": false,
   "max_recursion_depth": 0,
-  "uncountable_levels": 1
+  "uncountable_levels": 0
 }

--- a/test/perf/set_intersect_single_pass_chdb_test.go
+++ b/test/perf/set_intersect_single_pass_chdb_test.go
@@ -1,0 +1,333 @@
+//go:build chdb
+
+// Regression guard for the TraceQL spanset-intersect (`A && B`) leaf-pass
+// blowup (issue #1519).
+//
+// # The cost
+//
+// `&&` names each arm as a non-recursive `WITH _setand_{l,r}_<n>` CTE and
+// references it three times — its UNION-ALL leg plus both trace-cohort
+// `TraceId IN (…)` subqueries. A non-recursive CTE is a TEXTUAL
+// substitution, not a materialisation: ClickHouse re-evaluates every use
+// site, so a two-arm `&&` over bare selectors reads `otel_traces` — the
+// largest table cerberus touches — FOUR times, and `A && B && C` reads it
+// SEVEN times, all for a result one pass can produce.
+//
+// # The fix (chsql.fusableIntersect / emitFusedIntersect)
+//
+// Where every arm is a Filter chain over one shared Scan with a pure row
+// predicate, the whole chain collapses to
+//
+//	SELECT * FROM otel_traces
+//	WHERE <shared conjuncts> AND (<r1> OR <r2> …)
+//	QUALIFY max(<r1>) OVER (PARTITION BY TraceId) AND max(<r2>) OVER (…)
+//	LIMIT 1 BY TraceId, SpanId
+//
+// — one leaf pass. QUALIFY filters on the window value without projecting
+// it, so the statement keeps the bare `SELECT *` column set.
+//
+// # This guard
+//
+//	PRONG 1 (correctness): the emitted `&&` returns exactly the span set
+//	Tempo's semantics demand — the identity-deduped span-level UNION of both
+//	arms, restricted to traces where BOTH arms matched at least one span.
+//	The oracle is the union-gated shape this change replaces, written out
+//	literally, so the two independent formulations must agree on a seed
+//	built to separate them (a trace matching only one arm, and a trace whose
+//	two arms match DIFFERENT spans — the case a span-level intersection
+//	would wrongly return empty for).
+//
+//	PRONG 2 (cost): the fusable shapes must read exactly the seed's row
+//	count out of otel_traces — one pass over the table — two-arm and
+//	three-arm alike.
+//
+//	PRONG 3 (the decision boundary, pinned the other way): the sub-pipeline
+//	shape `({…} | count() > 0) && ({…} | count() > 0)` must STILL read the
+//	table more than once, because its arms' membership is a per-trace
+//	aggregate no per-row `max(<p>) OVER (…)` can reproduce. Without this
+//	prong the guard would rubber-stamp an emitter that fused everything
+//	unconditionally — which is a correctness bug, not merely a slower one.
+//	Sensitivity has to be pinned in BOTH directions or the pin is decorative.
+//
+// Build-tagged chdb; rides the perf-guards job.
+package perf
+
+import (
+	"context"
+	"database/sql"
+	"strings"
+	"testing"
+
+	"github.com/tsouza/cerberus/internal/chsql"
+	"github.com/tsouza/cerberus/internal/schema"
+	"github.com/tsouza/cerberus/internal/traceql"
+	traceqlast "github.com/tsouza/cerberus/internal/traceql/ast"
+)
+
+// setIntersectDDL is the minimal spans shape the `&&` gate reads: the
+// identity key it dedups on plus the two attribute sources the arms
+// select over. MergeTree (not Memory) because PREWHERE promotion and the
+// EXPLAIN leaf-read node names are MergeTree-specific.
+const setIntersectDDL = `CREATE TABLE otel_traces (
+    TraceId String, SpanId String, ParentSpanId String, SpanName String,
+    SpanKind String, Duration Int64, Timestamp DateTime64(9),
+    StatusCode String, StatusMessage String, ScopeName String, ScopeVersion String,
+    SpanAttributes Map(String,String), ResourceAttributes Map(String,String)
+) ENGINE = MergeTree() ORDER BY (TraceId, SpanId);`
+
+// setIntersectSeed separates the shapes rather than merely exercising them.
+//
+//	t1 — arm A matches s1 only, arm B matches s2 only. `&&` must return
+//	     BOTH spans: it is a TRACE-level conjunction over a SPAN-level
+//	     union, so a span-level intersection (which returns nothing here)
+//	     is the wrong answer.
+//	t2 — arm A matches, arm B does not. The whole trace must drop.
+//	t3 — arm B matches, arm A does not. The whole trace must drop.
+const setIntersectSeed = `INSERT INTO otel_traces
+    (TraceId, SpanId, ParentSpanId, SpanName, SpanKind, Duration, Timestamp, StatusCode, ResourceAttributes)
+VALUES
+    ('t1','s1','','sp','Client', 100, toDateTime64('2026-05-01 10:00:00',9), 'Ok', map('service.name','a')),
+    ('t1','s2','','sp','Client',9000, toDateTime64('2026-05-01 10:00:01',9), 'Ok', map('service.name','z')),
+    ('t2','s3','','sp','Client', 100, toDateTime64('2026-05-01 10:00:02',9), 'Ok', map('service.name','a')),
+    ('t3','s4','','sp','Client',9000, toDateTime64('2026-05-01 10:00:03',9), 'Ok', map('service.name','z'));`
+
+// setIntersectQL is the two-arm bare-selector query issue #1519 measured:
+// arm A selects on a resource attribute, arm B on duration.
+const setIntersectQL = `{ resource.service.name = "a" } && { duration > 1000 }`
+
+// setIntersectQL3 is the same shape one arm deeper. `A && B && C` arrives
+// left-nested and must flatten into the SAME single pass, not nest a
+// second union-gated statement inside the first.
+const setIntersectQL3 = `{ resource.service.name = "a" } && { duration > 1000 } && { status = ok }`
+
+// setIntersectPipelineQL is the shape that must NOT fuse: both operands are
+// parenthesised sub-pipelines ending in a spanset aggregate.
+const setIntersectPipelineQL = `({ resource.service.name = "a" } | count() > 0) && ({ duration > 1000 } | count() > 0)`
+
+// unionGatedOracle is the shape emitFusedIntersect replaces, written out
+// by hand as an independent formulation of the same Tempo semantics: both
+// arms' rows unioned, deduped on span identity, gated on the trace
+// appearing in BOTH arms.
+const unionGatedOracle = "WITH " +
+	"l AS (SELECT * FROM otel_traces WHERE ResourceAttributes['service.name'] = 'a'), " +
+	"r AS (SELECT * FROM otel_traces WHERE Duration > 1000) " +
+	"SELECT TraceId, SpanId FROM ((SELECT * FROM l) UNION ALL (SELECT * FROM r)) " +
+	"WHERE TraceId IN (SELECT TraceId FROM l) AND TraceId IN (SELECT TraceId FROM r) " +
+	"LIMIT 1 BY TraceId, SpanId"
+
+// setIntersectSeedRows is the number of spans setIntersectSeed inserts.
+// The fused shape must read exactly this many rows out of otel_traces —
+// one pass over the table — whatever the arm count.
+const setIntersectSeedRows = 4
+
+func openSetIntersectDB(t *testing.T) *sql.DB {
+	t.Helper()
+	db, err := sql.Open("chdb", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	if err := db.Ping(); err != nil {
+		t.Fatal(err)
+	}
+	return db
+}
+
+func setIntersectExec(t *testing.T, db *sql.DB, s string) {
+	t.Helper()
+	if _, err := db.Exec(s); err != nil {
+		t.Fatalf("exec: %v\n%s", err, s)
+	}
+}
+
+func setIntersectSeedDB(t *testing.T, db *sql.DB) {
+	t.Helper()
+	setIntersectExec(t, db, "CREATE DATABASE IF NOT EXISTS default")
+	setIntersectExec(t, db, "DROP TABLE IF EXISTS otel_traces")
+	setIntersectExec(t, db, setIntersectDDL)
+	setIntersectExec(t, db, setIntersectSeed)
+}
+
+// emitTraceQL lowers ql through the real parse -> lower -> emit chain, so
+// the SQL under measurement is the SQL cerberus ships.
+func emitTraceQL(t *testing.T, ql string) (string, []any) {
+	t.Helper()
+	expr, err := traceqlast.Parse(ql)
+	if err != nil {
+		t.Fatalf("parse %q: %v", ql, err)
+	}
+	plan, err := traceql.Lower(context.Background(), expr, schema.DefaultOTelTraces())
+	if err != nil {
+		t.Fatalf("lower %q: %v", ql, err)
+	}
+	sqlText, args, err := chsql.Emit(context.Background(), plan)
+	if err != nil {
+		t.Fatalf("emit %q: %v", ql, err)
+	}
+	return stripTrailingSemi(sqlText), args
+}
+
+// rowsReadFromSpansTable returns ClickHouse's own estimate of how many
+// rows the statement reads out of otel_traces, summed across every access
+// of the table. Divided by the seed's row count it IS the scan
+// amplification: one pass reads the table once, the union-gated shape
+// reads it once per use site.
+//
+// Rows read, not plan nodes. Node-counting looked equivalent and is not:
+// on MergeTree, `EXPLAIN PLAN` renders the `CreatingSets` step for the
+// two `TraceId IN (…)` cohort subqueries WITHOUT its child plans, so the
+// two set-building reads are invisible and a node count reports 2 for a
+// shape that genuinely reads the table 4 times (the Memory engine, whose
+// EXPLAIN does expand them, shows all 4). EXPLAIN ESTIMATE inherits the
+// same blind spot, so the FALLBACK figure here is a LOWER BOUND on its
+// true cost — which is harmless, because every assertion below wants the
+// fallback to be bigger and the fused shape to be exactly one pass.
+func rowsReadFromSpansTable(t *testing.T, db *sql.DB, sqlText string, args []any) int64 {
+	t.Helper()
+	rows, err := db.Query("EXPLAIN ESTIMATE "+sqlText, args...)
+	if err != nil {
+		t.Fatalf("EXPLAIN ESTIMATE failed: %v\nSQL: %s", err, sqlText)
+	}
+	defer func() { _ = rows.Close() }()
+	var total int64
+	seen := 0
+	for rows.Next() {
+		var database, table string
+		var parts, estRows, marks int64
+		if err := rows.Scan(&database, &table, &parts, &estRows, &marks); err != nil {
+			t.Fatalf("scan EXPLAIN ESTIMATE row: %v", err)
+		}
+		if table != "otel_traces" {
+			continue
+		}
+		seen++
+		total += estRows
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatalf("EXPLAIN ESTIMATE rows: %v", err)
+	}
+	if seen == 0 {
+		t.Fatalf("EXPLAIN ESTIMATE reported no read of otel_traces — the plan shape changed "+
+			"and this guard is no longer measuring scan amplification.\nSQL: %s", sqlText)
+	}
+	t.Logf("rows read from otel_traces = %d (seed holds %d) for\n  SQL: %s",
+		total, setIntersectSeedRows, sqlText)
+	return total
+}
+
+func spanIdentities(t *testing.T, db *sql.DB, sqlText string, args []any) []string {
+	t.Helper()
+	rows, err := db.Query("SELECT TraceId, SpanId FROM ("+sqlText+") ORDER BY TraceId, SpanId", args...)
+	if err != nil {
+		t.Fatalf("query failed: %v\nSQL: %s", err, sqlText)
+	}
+	defer func() { _ = rows.Close() }()
+	var out []string
+	for rows.Next() {
+		var tid, sid string
+		if err := rows.Scan(&tid, &sid); err != nil {
+			t.Fatalf("scan: %v", err)
+		}
+		out = append(out, tid+"/"+sid)
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatalf("rows: %v", err)
+	}
+	return out
+}
+
+// TestSetIntersect_SinglePass_MatchesUnionGatedSemantics is PRONG 1: the
+// fused single-pass gate and the union-gated shape it replaces must select
+// the same spans, on a seed built to catch the ways a rewrite of `&&` goes
+// wrong (dropping the trace whose arms matched different spans, or keeping
+// a trace only one arm matched).
+func TestSetIntersect_SinglePass_MatchesUnionGatedSemantics(t *testing.T) {
+	db := openSetIntersectDB(t)
+	setIntersectSeedDB(t, db)
+
+	sqlText, args := emitTraceQL(t, setIntersectQL)
+	got := spanIdentities(t, db, sqlText, args)
+
+	// Wrapped rather than suffixed: ORDER BY cannot follow `LIMIT n BY`.
+	oracleRows, err := db.Query("SELECT TraceId, SpanId FROM (" + unionGatedOracle + ") ORDER BY TraceId, SpanId")
+	if err != nil {
+		t.Fatalf("oracle query failed: %v", err)
+	}
+	defer func() { _ = oracleRows.Close() }()
+	var want []string
+	for oracleRows.Next() {
+		var tid, sid string
+		if err := oracleRows.Scan(&tid, &sid); err != nil {
+			t.Fatalf("oracle scan: %v", err)
+		}
+		want = append(want, tid+"/"+sid)
+	}
+
+	// t1's two spans and nothing else: arm A matched s1, arm B matched s2,
+	// so the trace passes the gate and contributes BOTH spans.
+	if strings.Join(want, ",") != "t1/s1,t1/s2" {
+		t.Fatalf("oracle itself returned %v, want [t1/s1 t1/s2] — the seed no longer "+
+			"separates the shapes and PRONG 1 would pass vacuously", want)
+	}
+	if strings.Join(got, ",") != strings.Join(want, ",") {
+		t.Errorf("single-pass `&&` selected %v; the union-gated shape it replaces selects %v.\nSQL: %s",
+			got, want, sqlText)
+	}
+}
+
+// TestSetIntersect_SinglePass_LeafReads is PRONG 2 + PRONG 3: the fusable
+// shapes cost one pass, and the sub-pipeline shape — which must keep the
+// costlier but correct union-gated form — still costs more than one.
+func TestSetIntersect_SinglePass_LeafReads(t *testing.T) {
+	db := openSetIntersectDB(t)
+	setIntersectSeedDB(t, db)
+
+	t.Run("two-arm bare selectors fuse to one pass", func(t *testing.T) {
+		sqlText, args := emitTraceQL(t, setIntersectQL)
+		if !strings.Contains(sqlText, "QUALIFY") {
+			t.Fatalf("`&&` over two bare selectors did not emit the single-pass QUALIFY "+
+				"gate at all — the rows-read assertion below would be measuring the wrong "+
+				"shape.\nSQL: %s", sqlText)
+		}
+		if n := rowsReadFromSpansTable(t, db, sqlText, args); n != setIntersectSeedRows {
+			t.Errorf("`&&` over two bare selectors reads %d rows of otel_traces, want %d "+
+				"(exactly one pass over the %d-row seed). The union-gated CTE shape reads it "+
+				"at least twice — anything above %d means the single-pass QUALIFY gate stopped "+
+				"firing (see chsql.fusableIntersect).\nSQL: %s",
+				n, setIntersectSeedRows, setIntersectSeedRows, setIntersectSeedRows, sqlText)
+		}
+	})
+
+	t.Run("three-arm chain flattens to one pass", func(t *testing.T) {
+		sqlText, args := emitTraceQL(t, setIntersectQL3)
+		if n := rowsReadFromSpansTable(t, db, sqlText, args); n != setIntersectSeedRows {
+			t.Errorf("`A && B && C` reads %d rows of otel_traces, want %d (one pass over the "+
+				"%d-row seed). The nested union-gated shape reads it once per arm — anything "+
+				"above %d means the chain stopped flattening.\nSQL: %s",
+				n, setIntersectSeedRows, setIntersectSeedRows, setIntersectSeedRows, sqlText)
+		}
+	})
+
+	// The boundary, pinned the other way. This subtest FAILING is the
+	// signal that the emitter began fusing sub-pipeline arms — which
+	// returns wrong rows, since a per-trace aggregate is not a row
+	// predicate. It is deliberately an assertion about the shape being
+	// MORE expensive, and that is the correct expectation here.
+	t.Run("sub-pipeline arms keep the union-gated shape", func(t *testing.T) {
+		sqlText, args := emitTraceQL(t, setIntersectPipelineQL)
+		if !strings.Contains(sqlText, "_setand_l_") {
+			t.Errorf("sub-pipeline `&&` no longer emits the union-gated arm CTEs. Its arms' "+
+				"membership is a per-trace aggregate, which no `max(<p>) OVER (PARTITION BY "+
+				"TraceId)` can reproduce, so fusing it returns WRONG rows.\nSQL: %s", sqlText)
+		}
+		if strings.Contains(sqlText, "QUALIFY") {
+			t.Errorf("sub-pipeline `&&` emitted the single-pass QUALIFY gate; see above — "+
+				"this shape must not fuse.\nSQL: %s", sqlText)
+		}
+		if n := rowsReadFromSpansTable(t, db, sqlText, args); n <= setIntersectSeedRows {
+			t.Errorf("sub-pipeline `&&` reads %d rows of otel_traces; want more than %d. "+
+				"A single pass here means the shape fused after all.\nSQL: %s",
+				n, setIntersectSeedRows, sqlText)
+		}
+	})
+}

--- a/test/spec/traceql/compound_and_windowed.txtar
+++ b/test/spec/traceql/compound_and_windowed.txtar
@@ -10,16 +10,18 @@ and no Timestamp predicate was emitted at all.
 -- query.traceql --
 { resource.service.name = "a" } && { span.http.status_code = 500 }
 -- sql --
-WITH _setand_l_1 AS (SELECT * FROM `otel_traces` WHERE (`Timestamp` >= fromUnixTimestamp64Nano(?)) AND (`Timestamp` <= fromUnixTimestamp64Nano(?)) AND (`ResourceAttributes`[?] = ?)), _setand_r_1 AS (SELECT * FROM `otel_traces` WHERE (`Timestamp` >= fromUnixTimestamp64Nano(?)) AND (`Timestamp` <= fromUnixTimestamp64Nano(?)) AND (toFloat64OrNull(`SpanAttributes`[?]) = ?)) SELECT * FROM ((SELECT * FROM _setand_l_1) UNION ALL (SELECT * FROM _setand_r_1)) WHERE `TraceId` IN (SELECT `TraceId` FROM _setand_l_1) AND `TraceId` IN (SELECT `TraceId` FROM _setand_r_1) LIMIT 1 BY `TraceId`, `SpanId`
+SELECT * FROM `otel_traces` WHERE (`Timestamp` >= fromUnixTimestamp64Nano(?)) AND (`Timestamp` <= fromUnixTimestamp64Nano(?)) AND ((`ResourceAttributes`[?] = ?) OR (toFloat64OrNull(`SpanAttributes`[?]) = ?)) QUALIFY max((`ResourceAttributes`[?] = ?)) OVER (PARTITION BY `TraceId`) AND max((toFloat64OrNull(`SpanAttributes`[?]) = ?)) OVER (PARTITION BY `TraceId`) LIMIT 1 BY `TraceId`, `SpanId`
 -- args --
 [0] int64 = 1782571392000000000
 [1] int64 = 1782573192000000000
 [2] string = "service.name"
 [3] string = "a"
-[4] int64 = 1782571392000000000
-[5] int64 = 1782573192000000000
-[6] string = "http.status_code"
-[7] int64 = 500
+[4] string = "http.status_code"
+[5] int64 = 500
+[6] string = "service.name"
+[7] string = "a"
+[8] string = "http.status_code"
+[9] int64 = 500
 -- chplan --
 SetOperation op=&&
   Filter predicate=((ResourceAttributes["service.name"] = "a") AND ((Timestamp >= fromUnixTimestamp64Nano(1782571392000000000)) AND (Timestamp <= fromUnixTimestamp64Nano(1782573192000000000))))

--- a/test/spec/traceql/edge_set_intersect_3.txtar
+++ b/test/spec/traceql/edge_set_intersect_3.txtar
@@ -5,8 +5,12 @@
 [1] string = "a"
 [2] int64 = 1000000000
 [3] string = "Error"
+[4] string = "service.name"
+[5] string = "a"
+[6] int64 = 1000000000
+[7] string = "Error"
 -- sql --
-WITH _setand_l_2 AS (WITH _setand_l_1 AS (SELECT * FROM `otel_traces` WHERE (`ResourceAttributes`[?] = ?)), _setand_r_1 AS (SELECT * FROM `otel_traces` WHERE (`Duration` > ?)) SELECT * FROM ((SELECT * FROM _setand_l_1) UNION ALL (SELECT * FROM _setand_r_1)) WHERE `TraceId` IN (SELECT `TraceId` FROM _setand_l_1) AND `TraceId` IN (SELECT `TraceId` FROM _setand_r_1) LIMIT 1 BY `TraceId`, `SpanId`), _setand_r_2 AS (SELECT * FROM `otel_traces` WHERE (`StatusCode` = ?)) SELECT * FROM ((SELECT * FROM _setand_l_2) UNION ALL (SELECT * FROM _setand_r_2)) WHERE `TraceId` IN (SELECT `TraceId` FROM _setand_l_2) AND `TraceId` IN (SELECT `TraceId` FROM _setand_r_2) LIMIT 1 BY `TraceId`, `SpanId`
+SELECT * FROM `otel_traces` WHERE (((`ResourceAttributes`[?] = ?) OR (`Duration` > ?)) OR (`StatusCode` = ?)) QUALIFY max((`ResourceAttributes`[?] = ?)) OVER (PARTITION BY `TraceId`) AND max((`Duration` > ?)) OVER (PARTITION BY `TraceId`) AND max((`StatusCode` = ?)) OVER (PARTITION BY `TraceId`) LIMIT 1 BY `TraceId`, `SpanId`
 -- seed --
 CREATE TABLE otel_traces (
     TraceId String,

--- a/test/spec/traceql/set_intersect_simple.txtar
+++ b/test/spec/traceql/set_intersect_simple.txtar
@@ -1,11 +1,14 @@
 -- query.traceql --
 { resource.service.name = "a" } && { duration > 1s }
 -- sql --
-WITH _setand_l_1 AS (SELECT * FROM `otel_traces` WHERE (`ResourceAttributes`[?] = ?)), _setand_r_1 AS (SELECT * FROM `otel_traces` WHERE (`Duration` > ?)) SELECT * FROM ((SELECT * FROM _setand_l_1) UNION ALL (SELECT * FROM _setand_r_1)) WHERE `TraceId` IN (SELECT `TraceId` FROM _setand_l_1) AND `TraceId` IN (SELECT `TraceId` FROM _setand_r_1) LIMIT 1 BY `TraceId`, `SpanId`
+SELECT * FROM `otel_traces` WHERE ((`ResourceAttributes`[?] = ?) OR (`Duration` > ?)) QUALIFY max((`ResourceAttributes`[?] = ?)) OVER (PARTITION BY `TraceId`) AND max((`Duration` > ?)) OVER (PARTITION BY `TraceId`) LIMIT 1 BY `TraceId`, `SpanId`
 -- args --
 [0] string = "service.name"
 [1] string = "a"
 [2] int64 = 1000000000
+[3] string = "service.name"
+[4] string = "a"
+[5] int64 = 1000000000
 -- seed --
 CREATE TABLE otel_traces (
     TraceId String,

--- a/test/spec/traceql/spanset_and_distinct_spans.txtar
+++ b/test/spec/traceql/spanset_and_distinct_spans.txtar
@@ -3,8 +3,10 @@
 -- args --
 [0] string = "left"
 [1] string = "right"
+[2] string = "left"
+[3] string = "right"
 -- sql --
-WITH _setand_l_1 AS (SELECT * FROM `otel_traces` WHERE (`SpanName` = ?)), _setand_r_1 AS (SELECT * FROM `otel_traces` WHERE (`SpanName` = ?)) SELECT * FROM ((SELECT * FROM _setand_l_1) UNION ALL (SELECT * FROM _setand_r_1)) WHERE `TraceId` IN (SELECT `TraceId` FROM _setand_l_1) AND `TraceId` IN (SELECT `TraceId` FROM _setand_r_1) LIMIT 1 BY `TraceId`, `SpanId`
+SELECT * FROM `otel_traces` WHERE ((`SpanName` = ?) OR (`SpanName` = ?)) QUALIFY max((`SpanName` = ?)) OVER (PARTITION BY `TraceId`) AND max((`SpanName` = ?)) OVER (PARTITION BY `TraceId`) LIMIT 1 BY `TraceId`, `SpanId`
 -- seed --
 CREATE TABLE otel_traces (
     TraceId String,

--- a/test/spec/traceql/structural_descendant_of_intersect.txtar
+++ b/test/spec/traceql/structural_descendant_of_intersect.txtar
@@ -6,14 +6,18 @@
 -- query.traceql --
 ({ resource.service.name = "a" } && { resource.service.name = "b" }) >> { resource.service.name = "c" }
 -- sql --
-SELECT R.`TraceId` AS `TraceId`, R.`SpanId` AS `SpanId`, R.`ParentSpanId` AS `ParentSpanId`, R.`SpanName` AS `SpanName`, R.`Duration` AS `Duration`, R.`Timestamp` AS `Timestamp`, R.`ResourceAttributes` AS `ResourceAttributes`, R.`SpanAttributes` AS `SpanAttributes`, R.`StatusCode` AS `StatusCode`, R.`StatusMessage` AS `StatusMessage`, R.`SpanKind` AS `SpanKind`, R.`ScopeName` AS `ScopeName`, R.`ScopeVersion` AS `ScopeVersion` FROM (WITH RECURSIVE _struct_closure_2 AS (SELECT DISTINCT `TraceId`, `SpanId`, `ParentSpanId`, 0 AS _depth FROM (WITH _setand_l_1 AS (SELECT * FROM `otel_traces` WHERE (`ResourceAttributes`[?] = ?)), _setand_r_1 AS (SELECT * FROM `otel_traces` WHERE (`ResourceAttributes`[?] = ?)) SELECT * FROM ((SELECT * FROM _setand_l_1) UNION ALL (SELECT * FROM _setand_r_1)) WHERE `TraceId` IN (SELECT `TraceId` FROM _setand_l_1) AND `TraceId` IN (SELECT `TraceId` FROM _setand_r_1) LIMIT 1 BY `TraceId`, `SpanId`) AS _seed UNION ALL SELECT DISTINCT t.`TraceId`, t.`SpanId`, t.`ParentSpanId`, c._depth + 1 FROM `otel_traces` AS t INNER JOIN _struct_closure_2 AS c ON t.`TraceId` = c.`TraceId` AND t.`ParentSpanId` = c.`SpanId` WHERE c._depth < 128) SELECT DISTINCT `TraceId`, `SpanId` FROM _struct_closure_2 WHERE _depth > 0) AS L INNER JOIN (SELECT * FROM `otel_traces` WHERE (`ResourceAttributes`[?] = ?)) AS R ON L.`TraceId` = R.`TraceId` AND L.`SpanId` = R.`SpanId`
+SELECT R.`TraceId` AS `TraceId`, R.`SpanId` AS `SpanId`, R.`ParentSpanId` AS `ParentSpanId`, R.`SpanName` AS `SpanName`, R.`Duration` AS `Duration`, R.`Timestamp` AS `Timestamp`, R.`ResourceAttributes` AS `ResourceAttributes`, R.`SpanAttributes` AS `SpanAttributes`, R.`StatusCode` AS `StatusCode`, R.`StatusMessage` AS `StatusMessage`, R.`SpanKind` AS `SpanKind`, R.`ScopeName` AS `ScopeName`, R.`ScopeVersion` AS `ScopeVersion` FROM (WITH RECURSIVE _struct_closure_1 AS (SELECT DISTINCT `TraceId`, `SpanId`, `ParentSpanId`, 0 AS _depth FROM (SELECT * FROM `otel_traces` WHERE ((`ResourceAttributes`[?] = ?) OR (`ResourceAttributes`[?] = ?)) QUALIFY max((`ResourceAttributes`[?] = ?)) OVER (PARTITION BY `TraceId`) AND max((`ResourceAttributes`[?] = ?)) OVER (PARTITION BY `TraceId`) LIMIT 1 BY `TraceId`, `SpanId`) AS _seed UNION ALL SELECT DISTINCT t.`TraceId`, t.`SpanId`, t.`ParentSpanId`, c._depth + 1 FROM `otel_traces` AS t INNER JOIN _struct_closure_1 AS c ON t.`TraceId` = c.`TraceId` AND t.`ParentSpanId` = c.`SpanId` WHERE c._depth < 128) SELECT DISTINCT `TraceId`, `SpanId` FROM _struct_closure_1 WHERE _depth > 0) AS L INNER JOIN (SELECT * FROM `otel_traces` WHERE (`ResourceAttributes`[?] = ?)) AS R ON L.`TraceId` = R.`TraceId` AND L.`SpanId` = R.`SpanId`
 -- args --
 [0] string = "service.name"
 [1] string = "a"
 [2] string = "service.name"
 [3] string = "b"
 [4] string = "service.name"
-[5] string = "c"
+[5] string = "a"
+[6] string = "service.name"
+[7] string = "b"
+[8] string = "service.name"
+[9] string = "c"
 -- seed --
 CREATE TABLE otel_traces (
     TraceId String,


### PR DESCRIPTION
TraceQL `A && B` named each arm as a non-recursive `WITH _setand_{l,r}_<n>` CTE and referenced it three times — its UNION-ALL leg plus both trace-cohort `TraceId IN (…)` subqueries. A non-recursive CTE is a **textual substitution, not a materialisation**: ClickHouse re-evaluates every use site, so two arms read `otel_traces` four times and `A && B && C` read it seven, for a result one pass produces.

`set_op.go`'s own comment asserted the opposite ("materialised once … referenced three times"), directly contradicting the note in `nested_set_annotate.go`. That comment is corrected here, since the misconception is why the cost went unnoticed.

## The new shape

Where every arm is a filter chain over ONE shared `Scan` with a pure row predicate, the whole chain collapses to a single pass:

```sql
SELECT * FROM otel_traces
WHERE <shared conjuncts> AND (<r1> OR <r2> …)
QUALIFY max(<r1>) OVER (PARTITION BY TraceId) AND max(<r2>) OVER (…)
LIMIT 1 BY TraceId, SpanId
```

`QUALIFY` filters on the window value **without projecting it**, so the statement keeps its bare `SELECT *` column set and needs no `* EXCEPT (…)` to strip a synthetic gate column back off. That matters beyond tidiness: the projected-column spelling would have changed the statement's shape for every downstream consumer and for the spec harness's star expansion.

## The decision boundary — it chooses, it does not swap

`fusableIntersect` flattens the `&&` chain and takes the fast path only when every leaf arm is a filter chain bottoming out in one `Equal` `Scan` with a **gate-safe** predicate: no nested plan (`InSubquery` / `ScalarSubquery`), no `BoundedTraceScope`.

The predicate rule, not the tree structure, is the load-bearing line. `spanset_pipeline_intersect`'s arms — `({…} | count() > 0) && (…)` — lower to `Filter(TraceId IN {Aggregate pipeline}) → Filter(<selector>) → Scan`, which **is** structurally a filter chain over the shared scan. A structural test alone would fuse it and return wrong rows, because its membership is a per-trace aggregate no per-row `max(<p>) OVER (…)` can reproduce. `BoundedTraceScope` is excluded for a related reason: it is an `Expr` *leaf*, so a Node-only walk never sees it, yet the emitter re-derives a top-N spans subquery from it — fusing one would hide a second table read behind a shape advertising a single pass.

Also excluded: arms over different `Scan`s, and a nested `||` (flattening it into the conjunctive gate would turn "either arm" into "both"). A partly-fusable chain falls back only at the level that fails and still fuses below it.

`A && B && C` arrives left-nested and flattens into one pass, since "(A && B) matched this trace" is exactly "A matched and B matched" and its spans are A's ∪ B's.

## Common-conjunct factoring is required, not a nicety

`(p1 ∧ W) ∨ (p2 ∧ W)` is factored to `W ∧ (p1 ∨ p2)`. Without it, the windowed shape Grafana actually sends collapses to one opaque `OR` conjunct from which no `Timestamp` bound reaches PREWHERE — trading four partition-pruned reads for one full-retention scan, a **regression** rather than a win. Dropping the shared conjuncts from the gate terms is sound because every row the window sees has already passed them.

## Measured

chDB 26.5, through the real parse → lower → emit chain:

| shape | before | after |
| --- | --- | --- |
| `A && B` bare selectors | 4 leaf passes | **1** |
| `A && B && C` | 7 leaf passes | **1** |
| sub-pipeline `&&` | unchanged | unchanged |

The 4 and 7 are full-plan counts on the Memory engine, reproducing the issue's own measurement. On MergeTree, `EXPLAIN ESTIMATE` reports 2x / 3x the table versus 1x after — a *lower bound*, because MergeTree's EXPLAIN does not expand the `CreatingSets` cohort subqueries.

## The ratchet regains sight of the shape

The three fusable fixtures flip from a null `fan_factor` to an honestly measured one, because the construct that blinded the profiler is **gone**, not because the metric was taught to guess:

```
set_intersect_simple        fan_factor null -> 1, uncountable_levels 1 -> 0
spanset_and_distinct_spans            null -> 1,                    1 -> 0
edge_set_intersect_3                  null -> 1,                    1 -> 0
```

`spanset_pipeline_intersect` correctly stays null (keeps the CTE); `structural_descendant_of_intersect` stays null for an unrelated reason (`has_recursive_cte`).

(The measurement half of #1519 — `fan_factor` reporting `null` + `uncountable_levels` instead of a fabricated `1.00` — already shipped in #1713. This PR is the emitter half.)

## Tests

- `TestEmitNode_SetOperation_Intersect` is now a 7-case decision-boundary table. Four cases are negatives that fail on an unconditional swap: sub-pipeline arm, `BoundedTraceScope` arm, different tables, nested `||`.
- New `test/perf/set_intersect_single_pass_chdb_test.go`, three prongs: correctness against the union-gated shape as an independent oracle on a seed built to separate them (including the trace whose two arms match *different* spans, which a span-level intersection would wrongly drop); cost pinned at exactly one pass; and the boundary pinned **the other way**, so an emitter that fused everything fails rather than rubber-stamping.
- **Absorption demo**: disabling `fusableIntersect` turns the guard red — two-arm reports "did not emit the single-pass QUALIFY gate", three-arm reports 12 rows read vs 4. Restored and re-verified.
- **No `-- expected_rows --` cell moved in any regenerated fixture** — the fused shape is result-identical on every executable spec fixture, and `spanset_pipeline_intersect.txtar` is untouched.

## Notes

Emitter, not optimizer: `chplan` has no window/`QUALIFY` node, and the union+CTE gate was already an emitter-side realization choice rather than a plan node. Keeping it there leaves the plan tree byte-identical, which is why the production `RequireSpansScansBounded` chokepoint — a plan-tree gate — is unaffected. `emitFilterScan` / `emitScan` were split into builder-returning helpers so the fused scan reuses the identical PREWHERE promotion each arm's own `Filter(Scan)` received; the regenerated promql/logql/chsql/optimizer/codegen shards showed zero churn, confirming that refactor is behaviour-neutral.

Closes #1519