### PR TITLE
fix(api/tempo): charge compare()'s synthesised sample grid against the query budget

### DIFF
--- a/cmd/cerberus/main.go
+++ b/cmd/cerberus/main.go
@@ -192,6 +192,13 @@ func mountAPIHeads(
 		tempoHandler.Limiter = limiters.tempo
 		tempoHandler.StructuralTwoPhase = cfg.TempoStructuralTwoPhase
 		tempoHandler.Engine.Settings = settingsRules(cfg, optSet)
+		// The per-query sample budget the ENGINE-level bounds read. The cursor
+		// enforces the same ceiling on rows it drains from ClickHouse, but the
+		// engine's own gates (requireSubquerySampleBudget, and compare()'s
+		// synthesised-grid budget) read it from here — left at zero they are
+		// silently inert, which is how a compare() grid 108x over the configured
+		// budget was still served.
+		tempoHandler.Engine.MaxQuerySamples = tempoClient.MaxQuerySamples()
 		tempoHandler.Mount(traceMux)
 		engines = append(engines, tempoHandler.Engine)
 

--- a/internal/api/tempo/metrics_query_range_compare.go
+++ b/internal/api/tempo/metrics_query_range_compare.go
@@ -156,12 +156,67 @@ type compareSeriesState struct {
 	total  float64
 }
 
+// requireCompareGridBudget fail-closes a compare() whose ZERO-FILLED wire grid
+// would exceed the per-query sample budget (Config.MaxQuerySamples).
+//
+// compare() is the one metrics shape whose result size is not bounded by
+// anything upstream of it. Every other shape hands ClickHouse's rows straight
+// to the wire, so the Go-side result drain (chclient.SampleBudget /
+// Config.MaxQuerySamples) charges each sample as it is read and aborts a
+// runaway mid-drain. compare() instead SYNTHESISES its grid after the drain:
+// postProcessCompare folds a SPARSE row stream (only the anchors that carry
+// data) into a DENSE series x anchor matrix, zero-filling every gap. The rows
+// actually read from CH can therefore be a handful while the emitted matrix is
+// six orders of magnitude larger — so the drain budget never sees the samples
+// it is supposed to bound, and neither does the CH-side max_memory_usage cap
+// (the query is cheap; the expansion happens here, on the Go heap).
+//
+// The other two bounds miss it for the same structural reason:
+// format.MaxResolutionPoints caps the anchor axis ALONE (11000) and
+// requireSubquerySampleBudget deliberately counts one series' grid rather than
+// anchors x series, documenting that the cardinality axis "is bounded elsewhere
+// ... the result-drain SampleBudget". For compare() that elsewhere does not
+// exist. This restores it: the product series x anchors IS the sample count the
+// response will carry, so it is charged before a single MetricsSample is
+// allocated.
+//
+// Rejecting (rather than truncating) matches every peer bound: the caller gets
+// the same chclient.ErrTooManySamples that a drained overrun raises, which
+// ClassifyErr maps to the same resource-exhausted 422 on both the HTTP and gRPC
+// surfaces. Truncating would instead answer a comparison with a silently
+// partial baseline, which is worse than an honest refusal.
+//
+// maxSamples <= 0 disables the budget, matching the cursor's and the subquery
+// gate's semantics so the bound stays inert in tests that do not wire it.
+// The comparison is written as a division rather than `series*anchors > max`
+// so no input can overflow it into a wrapped negative that slips under the
+// budget. Today's operands cannot reach that (anchors is already capped at
+// format.MaxResolutionPoints upstream), so this is defence against a future
+// caller with a wider grid, not a live hazard. For positive operands
+// `anchors > max/series` (integer division) is exactly equivalent to
+// `series*anchors > max`.
+func requireCompareGridBudget(seriesCount, anchorCount int, maxSamples int64) error {
+	if maxSamples <= 0 || seriesCount <= 0 || anchorCount <= 0 {
+		return nil
+	}
+	if int64(anchorCount) > maxSamples/int64(seriesCount) {
+		return &chclient.TooManySamplesError{Limit: maxSamples}
+	}
+	return nil
+}
+
 // postProcessCompare folds the raw (cohort, attr, val, anchor, count)
 // row stream into the wire series set — the cerberus-side equivalent
 // of upstream Tempo's BaselineAggregator.Results. `anchors` is the
 // full matrix grid (every series zero-fills across it); `topN` is the
 // per-(cohort, attribute) value cap.
-func postProcessCompare(samples []chclient.Sample, topN int, anchors []time.Time) []MetricsSeries {
+//
+// `maxSamples` bounds the zero-filled series x anchor product this builds; see
+// requireCompareGridBudget for why this is the only place that product can be
+// charged. A crossing returns chclient.ErrTooManySamples and no series.
+func postProcessCompare(
+	samples []chclient.Sample, topN int, anchors []time.Time, maxSamples int64,
+) ([]MetricsSeries, error) {
 	type cohortAttr struct {
 		meta string // baseline | selection
 		attr string
@@ -201,6 +256,25 @@ func postProcessCompare(samples []chclient.Sample, topN int, anchors []time.Time
 			totals[ca] = tm
 		}
 		tm[ns] += s.Value
+	}
+
+	// Charge the grid BEFORE building it. The emitted series set is one series
+	// per surviving (cohort, attr, val) plus one totals series per
+	// (cohort, attr), and every one of them zero-fills across every anchor —
+	// so this product is exactly the sample count the response would carry.
+	// Counting it here needs no sorting and allocates nothing, which is the
+	// point: an over-budget compare() is refused before the matrix exists on
+	// the heap, not after.
+	emitted := len(totals)
+	for _, vm := range values {
+		n := len(vm)
+		if topN > 0 && n > topN {
+			n = topN
+		}
+		emitted += n
+	}
+	if err := requireCompareGridBudget(emitted, len(anchors), maxSamples); err != nil {
+		return nil, err
 	}
 
 	gridSamples := func(counts map[int64]float64) []MetricsSample {
@@ -282,7 +356,7 @@ func postProcessCompare(samples []chclient.Sample, topN int, anchors []time.Time
 		addSeries(totalMeta(ca.meta), ca.attr, compareNilLabelValue, totals[ca])
 	}
 
-	return series
+	return series, nil
 }
 
 // execCompareRange runs the matrix-shape pipeline for a lowered
@@ -324,7 +398,12 @@ func (h *Handler) execCompareRange(
 		"start", start, "end", end, "step", step,
 		"sql", res.SQL, "args", telemetry.SanitizeArgsForLog(res.Args))
 
-	series := postProcessCompare(res.Samples, cmp.TopN, compareAnchorGrid(start, end, step))
+	series, err := postProcessCompare(
+		res.Samples, cmp.TopN, compareAnchorGrid(start, end, step), h.Engine.MaxQuerySamples,
+	)
+	if err != nil {
+		return nil, nil, err
+	}
 	return series, res.Headers, nil
 }
 

--- a/internal/api/tempo/metrics_query_range_compare_test.go
+++ b/internal/api/tempo/metrics_query_range_compare_test.go
@@ -2,8 +2,10 @@ package tempo_test
 
 import (
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/url"
+	"strconv"
 	"testing"
 	"time"
 
@@ -48,7 +50,12 @@ func TestPostProcessCompare_Semantics(t *testing.T) {
 		compareRow("1", "name", "a", t1, 4),
 	}
 
-	series := tempo.PostProcessCompareForTest(samples, 2, anchors)
+	// 0 disables the grid budget, so this case keeps asserting the fold
+	// semantics alone (the budget has its own boundary test below).
+	series, err := tempo.PostProcessCompareForTest(samples, 2, anchors, 0)
+	if err != nil {
+		t.Fatalf("postProcessCompare: %v", err)
+	}
 
 	type key struct{ meta, attr, val string }
 	got := map[key][]float64{}
@@ -234,4 +241,119 @@ func TestMetricsQueryInstant_Compare(t *testing.T) {
 	if byMeta["baseline_total"] != 5 || byMeta["selection_total"] != 2 {
 		t.Errorf("instant totals = %v, want baseline_total=5 selection_total=2", byMeta)
 	}
+}
+
+// TestPostProcessCompare_GridBudget is the regression pin for the compare()
+// sample-budget bypass.
+//
+// compare() is the only metrics shape that SYNTHESISES its samples instead of
+// forwarding ClickHouse's rows, so the Go-side result drain — the thing that
+// enforces MaxQuerySamples for every other shape — never sees them. Measured on
+// a live compose stack before the fix: a 15 m window at Grafana's auto-step
+// drained a handful of sparse rows and emitted 540,300 samples against a
+// configured 5,000-sample budget (108x) as a 21.6 MB HTTP 200. The budget has to
+// be charged on the emitted product, which is what these cases pin.
+func TestPostProcessCompare_GridBudget(t *testing.T) {
+	t.Parallel()
+
+	t0 := time.Date(2026, 5, 12, 10, 1, 0, 0, time.UTC)
+
+	// One attribute with one value yields exactly two series: the value series
+	// and its totals series. Emitted samples are therefore 2 x len(anchors).
+	const seriesPerAttr = 2
+	rows := []chclient.Sample{compareRow("0", "name", "a", t0, 1)}
+
+	anchorsOf := func(n int) []time.Time {
+		out := make([]time.Time, n)
+		for i := range out {
+			out[i] = t0.Add(time.Duration(i) * time.Minute)
+		}
+		return out
+	}
+
+	t.Run("at the cap is served", func(t *testing.T) {
+		t.Parallel()
+		const anchors = 50
+		series, err := tempo.PostProcessCompareForTest(
+			rows, 0, anchorsOf(anchors), seriesPerAttr*anchors,
+		)
+		if err != nil {
+			t.Fatalf("a grid exactly at the budget must be served, got: %v", err)
+		}
+		got := 0
+		for _, s := range series {
+			got += len(s.Samples)
+		}
+		if got != seriesPerAttr*anchors {
+			t.Fatalf("emitted %d samples, want %d — the case no longer sits ON the cap, "+
+				"so the boundary it claims to pin is untested", got, seriesPerAttr*anchors)
+		}
+	})
+
+	t.Run("one sample over the cap is refused", func(t *testing.T) {
+		t.Parallel()
+		const anchors = 50
+		_, err := tempo.PostProcessCompareForTest(
+			rows, 0, anchorsOf(anchors), seriesPerAttr*anchors-1,
+		)
+		if err == nil {
+			t.Fatal("a grid one sample over the budget was served")
+		}
+		if !errors.Is(err, chclient.ErrTooManySamples) {
+			t.Fatalf("over-budget compare must raise ErrTooManySamples so ClassifyErr "+
+				"answers 422 (not a 500); got %v", err)
+		}
+	})
+
+	t.Run("a sparse drain cannot buy an unbounded grid", func(t *testing.T) {
+		t.Parallel()
+		// THE bug: one input row, a dense output grid. Every bound upstream of
+		// this point sees a single cheap row — the CH memory cap, the drain
+		// budget and format.MaxResolutionPoints all pass — so if the product is
+		// not charged here it is never charged at all.
+		const anchors = 10_000
+		if seriesPerAttr*anchors <= len(rows) {
+			t.Fatal("test setup is wrong: the emitted grid must dwarf the drained rows")
+		}
+		_, err := tempo.PostProcessCompareForTest(rows, 0, anchorsOf(anchors), 5_000)
+		if err == nil {
+			t.Fatalf("%d drained row(s) synthesised a %d-sample grid under a 5,000-sample "+
+				"budget without rejection — the drain-side budget cannot see synthesised "+
+				"samples, so this path is unbounded", len(rows), seriesPerAttr*anchors)
+		}
+		if !errors.Is(err, chclient.ErrTooManySamples) {
+			t.Fatalf("want ErrTooManySamples, got %v", err)
+		}
+	})
+
+	t.Run("many series over few anchors is charged on the product", func(t *testing.T) {
+		t.Parallel()
+		// The mirror of the sparse-drain case: the anchor axis is small (well
+		// inside format.MaxResolutionPoints) and the CARDINALITY axis is what
+		// runs away. Neither axis alone is over any threshold — only the
+		// product is, which is the whole point of charging it here.
+		manyVals := make([]chclient.Sample, 0, 4096)
+		for i := range 4096 {
+			manyVals = append(manyVals,
+				compareRow("0", "name", "v"+strconv.Itoa(i), t0, 1))
+		}
+		const anchors = 100
+		_, err := tempo.PostProcessCompareForTest(manyVals, 0, anchorsOf(anchors), 100_000)
+		if err == nil {
+			t.Fatalf("4096 values over %d anchors (~%d samples) was served under a "+
+				"100,000-sample budget", anchors, 4097*anchors)
+		}
+		if !errors.Is(err, chclient.ErrTooManySamples) {
+			t.Fatalf("want ErrTooManySamples, got %v", err)
+		}
+	})
+
+	t.Run("a non-positive budget stays inert", func(t *testing.T) {
+		t.Parallel()
+		// Matches the cursor's and requireSubquerySampleBudget's semantics, so a
+		// handler that never wired a budget keeps serving.
+		if _, err := tempo.PostProcessCompareForTest(rows, 0, anchorsOf(10_000), 0); err != nil {
+			t.Fatalf("maxSamples<=0 must disable the budget, got: %v", err)
+		}
+	})
 }

--- a/internal/engine/resource_bound_classification_test.go
+++ b/internal/engine/resource_bound_classification_test.go
@@ -64,7 +64,7 @@ var resourceBoundClassification = map[string]struct {
 	"Aggregate":                {boundRuntimeNet, "axis 4: GROUP BY cardinality; external-aggregation spill + max_memory_usage; output bounded by the result drain SampleBudget"},
 	"MetricsAggregate":         {boundRuntimeNet, "axis 4: TraceQL metrics GROUP BY; spill + max_memory_usage"},
 	"MetricsSecondStage":       {boundRuntimeNet, "axis 4/7: second-stage metrics reduction over the bounded first stage"},
-	"MetricsCompare":           {boundRuntimeNet, "axis 7: compare() arithmetic over the scan-bounded input"},
+	"MetricsCompare":           {boundGated, "axis 4/7: compare() arithmetic over the scan-bounded input, PLUS the zero-filled series x anchor grid it synthesises after the drain — gated by requireCompareGridBudget, the only place that product can be charged (the result-drain SampleBudget never sees a synthesised sample)"},
 	"MetricsHistogramOverTime": {boundRuntimeNet, "axis 4/7: per-bucket histogram over the bounded window"},
 	"CrossJoin":                {boundRuntimeNet, "axis 4: row product; current callers (absent lowering) feed it a single-row side; max_memory_usage"},
 	"InfoJoin":                 {boundRuntimeNet, "axis 4: info-metric enrichment join; spill + max_memory_usage"},

--- a/test/e2e/grafana/compose/dashboards/showcase-traceql.json
+++ b/test/e2e/grafana/compose/dashboards/showcase-traceql.json
@@ -2055,8 +2055,7 @@
      },
      "query": "{ } | rate()",
      "queryType": "traceql",
-     "refId": "A",
-     "step": "15s"
+     "refId": "A"
     },
     {
      "datasource": {
@@ -2065,8 +2064,7 @@
      },
      "query": "{ } | rate() by (resource.service.name)",
      "queryType": "traceql",
-     "refId": "B",
-     "step": "15s"
+     "refId": "B"
     }
    ],
    "title": "rate() \u2014 bare and by()",
@@ -2154,8 +2152,7 @@
      },
      "query": "{ } | count_over_time()",
      "queryType": "traceql",
-     "refId": "A",
-     "step": "15s"
+     "refId": "A"
     },
     {
      "datasource": {
@@ -2164,8 +2161,7 @@
      },
      "query": "{ } | count_over_time() by (name)",
      "queryType": "traceql",
-     "refId": "B",
-     "step": "15s"
+     "refId": "B"
     }
    ],
    "title": "count_over_time()",
@@ -2253,8 +2249,7 @@
      },
      "query": "{ } | min_over_time(duration)",
      "queryType": "traceql",
-     "refId": "A",
-     "step": "15s"
+     "refId": "A"
     },
     {
      "datasource": {
@@ -2263,8 +2258,7 @@
      },
      "query": "{ } | max_over_time(duration)",
      "queryType": "traceql",
-     "refId": "B",
-     "step": "15s"
+     "refId": "B"
     },
     {
      "datasource": {
@@ -2273,8 +2267,7 @@
      },
      "query": "{ } | avg_over_time(duration)",
      "queryType": "traceql",
-     "refId": "C",
-     "step": "15s"
+     "refId": "C"
     }
    ],
    "title": "min / max / avg over time (duration)",
@@ -2362,8 +2355,7 @@
      },
      "query": "{ } | sum_over_time(.payload_bytes)",
      "queryType": "traceql",
-     "refId": "A",
-     "step": "15s"
+     "refId": "A"
     }
    ],
    "title": "sum_over_time over a numeric attribute",
@@ -2451,8 +2443,7 @@
      },
      "query": "{ } | quantile_over_time(duration, .5, .9, .99)",
      "queryType": "traceql",
-     "refId": "A",
-     "step": "15s"
+     "refId": "A"
     }
    ],
    "title": "quantile_over_time multi-phi",
@@ -2540,8 +2531,7 @@
      },
      "query": "{ } | histogram_over_time(duration)",
      "queryType": "traceql",
-     "refId": "A",
-     "step": "15s"
+     "refId": "A"
     }
    ],
    "title": "histogram_over_time",
@@ -2629,8 +2619,7 @@
      },
      "query": "{ } | rate() with (exemplars = true)",
      "queryType": "traceql",
-     "refId": "A",
-     "step": "15s"
+     "refId": "A"
     }
    ],
    "title": "Hints: with(exemplars = true)",
@@ -2718,8 +2707,7 @@
      },
      "query": "{ } | rate() by (name) | topk(3)",
      "queryType": "traceql",
-     "refId": "A",
-     "step": "15s"
+     "refId": "A"
     },
     {
      "datasource": {
@@ -2728,8 +2716,7 @@
      },
      "query": "{ } | rate() by (name) | bottomk(3)",
      "queryType": "traceql",
-     "refId": "B",
-     "step": "15s"
+     "refId": "B"
     }
    ],
    "title": "Second stage: topk / bottomk",
@@ -2817,8 +2804,7 @@
      },
      "query": "{ } | rate() by (name) > 0.0001",
      "queryType": "traceql",
-     "refId": "A",
-     "step": "15s"
+     "refId": "A"
     }
    ],
    "title": "Second stage: threshold filter",
@@ -3690,8 +3676,7 @@
        },
        "query": "{ } | compare({ status = error })",
        "queryType": "traceql",
-       "refId": "A",
-       "step": "15s"
+       "refId": "A"
       }
      ],
      "title": "compare() \u2014 baseline vs selection",


### PR DESCRIPTION
## What this turned out to be

The issue's headline — "no density bound exists on the Tempo metrics path" — is
refuted, as the issue's own follow-up comment says. The anchor-count cap is
there on both surfaces (`metrics_query_range.go:270`, `grpc_exports.go:206`),
with boundary tests in `grpc_metrics_range_bounds_test.go`. It also would not
have helped: a 15 m window at Grafana's ~600 ms auto-step is 1,800 anchors,
far under the 11,000 ceiling.

The workaround's stated cause is gone too. I booted the compose stack and drove
all 15 pinned targets at a 0.5 s step: every one returns 200, the slowest in
320 ms. The per-query memory rejection the pin was added to dodge does not
reproduce on `main`.

What the measurement *did* surface is the real bug, and it is the product axis
the follow-up comment asked for.

## The bug

`compare()` is the only Tempo metrics shape whose result size no bound reaches.
Every other shape forwards ClickHouse's rows to the wire, so the Go-side result
drain charges each sample as it is read and aborts a runaway mid-drain.
`compare()` instead **synthesises** its grid *after* the drain:
`postProcessCompare` folds a sparse row stream (only anchors carrying data) into
a dense series x anchor matrix, zero-filling every gap.

So the drain budget never sees the samples it is supposed to bound, and neither
does `max_memory_usage` — the query is cheap; the expansion happens on the Go
heap. Measured on the stack with `CERBERUS_QUERY_MAX_SAMPLES=5000`:

| query | result |
| --- | --- |
| `{ } \| rate() by (name)` | 422, budget enforced |
| `{ } \| compare({ status = error })` | **200, 21.6 MB, 540,300 samples — 108x the budget** |

The three neighbouring bounds miss it structurally: `format.MaxResolutionPoints`
caps the anchor axis alone; `requireSubquerySampleBudget` deliberately counts one
series' grid rather than anchors x series, documenting that the cardinality axis
"is bounded elsewhere ... the result-drain SampleBudget"; and for `compare()`
that elsewhere does not exist.

## The fix

`requireCompareGridBudget` charges `series x anchors` before a single
`MetricsSample` is allocated, raising the same `chclient.ErrTooManySamples` a
drained overrun raises — so `ClassifyErr` answers the same 422 on the HTTP and
gRPC surfaces. It rejects rather than truncates, matching every peer bound; a
truncated `compare()` would answer with a silently partial baseline.

The gate needed a budget to read, which exposed a second gap: **the Tempo head's
engine never wired `MaxQuerySamples`** — only the prom head did — so every
engine-level bound on that head, `requireSubquerySampleBudget` included, was
silently inert. `main.go` now wires it from the head's own client. Without this
the new gate is a no-op, which is exactly what the first stack run showed.

The Loki head has the identical wiring gap. It is filed as #2055 rather than
fixed here, because wiring it activates a dormant gate on LogQL shapes that need
their own validation.

## The showcase

All 15 `"step": "15s"` pins are dropped, so the dashboard exercises Grafana's
real auto-step. There is only one copy of this dashboard — no k3d ConfigMap
sibling — so nothing else needed syncing.

Verified in a browser against the stack: Grafana now sends no explicit step
(choosing its own interval), every metrics panel renders data, and **0 panels
report an error**. Response volume across the dashboard's TraceQL requests goes
188 KB -> 404 KB, which is the honest cost of the real shape.

## Verification

- Live repro before/after on a compose stack isolated on its own port range.
- `requireCompareGridBudget` boundary tests: at the cap serves, one sample over
  refuses, a 1-row drain synthesising a 20,000-sample grid refuses, cardinality
  runaway over few anchors refuses, non-positive budget stays inert. Confirmed
  they fail against the unfixed code, so they are not vacuous.
- `MetricsCompare`'s row in the resource-bound classification moves from
  `boundRuntimeNet` to `boundGated` and names the new gate, so the taxonomy
  stops claiming a bound that was not there.

Closes #1526
