### PR TITLE
test(migration): seed `up` and query staleness in the MIG-17 hotspot corpus

### DIFF
--- a/docs/migration-testing.md
+++ b/docs/migration-testing.md
@@ -219,6 +219,28 @@ rather than dependent on the exporter's start-time behaviour; the seeder then
 polls for all six `otel_*` tables against a hard deadline before it writes a
 single fixture row. Nothing in the seeder creates a table.
 
+**The semantic hotspots are declared, never incidental.** Three fields in the
+declaration exist purely so MIG-17's corpus has a real divergence to fail on.
+`restarts` zeroes a named counter series' running total mid-window, so
+`rate()` / `increase()` cross a genuine pod-restart reset rather than a
+monotonic climb. `scrape_health.down` makes a named service's `up` report 0 for
+a contiguous run of samples and then recover, which is the firing edge and the
+resolve edge `up == 0` selects. `scrape_health.stops` ends one service's `up`
+early, so that series has to disappear from BOTH backends exactly one instant
+lookback after its last sample — the TSDB stale-marker versus ClickHouse gap
+model section 5 requires cerberus to match rather than tolerate. Nothing
+synthesises `up`: on both sides it is an ordinary gauge that has to be written
+to be queryable, so an archetype that declares no `scrape_health` block has no
+`up` at all and a staleness query against it would compare two empty answers.
+
+Each shape is inert unless two files that cannot see each other agree — the
+declaration has to inject it inside the queried window, and the committed
+corpus has to select the very series it was injected into.
+`test/regression/migration_tier1_test.go` holds them together offline: it fails
+when a declared shape lands where no replayed step reads it (an outage between
+two steps, a disappearance edge off the step grid), and when the corpus stops
+naming the series a shape was injected into.
+
 The fixture carries exactly one deliberate asymmetry between the two sides:
 reference Prometheus additionally receives `seed.PreIngestWindow` of gauge
 history ending one sample step BELOW the first ClickHouse row, on the fixture's

--- a/test/e2e/migration/archetypes/three-signal/expected/tier1.json
+++ b/test/e2e/migration/archetypes/three-signal/expected/tier1.json
@@ -1,14 +1,14 @@
 {
   "log_streams": 9,
   "log_records": 1089,
-  "prom_series": 48,
+  "prom_series": 51,
   "traces": 60,
   "traces_per_service": 20,
   "spans": 237,
   "samples_per_series": 121,
   "verify_steps": 21,
   "series": {
-    "gauge": 6,
+    "gauge": 9,
     "sum": 6,
     "histogram": 6
   },

--- a/test/e2e/migration/archetypes/three-signal/seed/fixture.json
+++ b/test/e2e/migration/archetypes/three-signal/seed/fixture.json
@@ -11,5 +11,13 @@
   "spans_per_trace": [3, 4, 5],
   "restarts": {
     "payments|500": [60]
+  },
+  "scrape_health": {
+    "down": {
+      "payments": [44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59]
+    },
+    "stops": {
+      "search": 88
+    }
   }
 }

--- a/test/e2e/migration/archetypes/three-signal/seed/verify-hotspots.json
+++ b/test/e2e/migration/archetypes/three-signal/seed/verify-hotspots.json
@@ -32,6 +32,24 @@
       "lang": "promql"
     },
     {
+      "expr": "up == 0",
+      "source": "manual:test/e2e/migration/archetypes/three-signal/seed/verify-hotspots.json/staleness scrape failed",
+      "kind": "panel",
+      "lang": "promql"
+    },
+    {
+      "expr": "up{service_name=\"search\"}",
+      "source": "manual:test/e2e/migration/archetypes/three-signal/seed/verify-hotspots.json/staleness target vanished",
+      "kind": "panel",
+      "lang": "promql"
+    },
+    {
+      "expr": "absent_over_time(up{service_name=\"search\"}[5m])",
+      "source": "manual:test/e2e/migration/archetypes/three-signal/seed/verify-hotspots.json/staleness absent over time",
+      "kind": "panel",
+      "lang": "promql"
+    },
+    {
       "expr": "histogram_quantile(0.95, sum by (le) (rate(cerberus_migration_request_duration_seconds_bucket[5m])))",
       "source": "manual:test/e2e/migration/archetypes/three-signal/seed/verify-hotspots.json/histogram quantile",
       "kind": "panel",

--- a/test/e2e/migration/seed/drift.go
+++ b/test/e2e/migration/seed/drift.go
@@ -78,20 +78,29 @@ func DriftRowCount(ctx context.Context, conn driver.Conn) (uint64, error) {
 //
 // It returns the per-instant values it injected, so the caller can assert the
 // exact post-injection reading rather than merely "something changed".
-func InjectGaugeDrift(ctx context.Context, conn driver.Conn, f Fixture, service string) (map[int64]float64, error) {
+// The metric is named by the CALLER rather than read off whichever series the
+// scan happened to land on last. The gauge table carries more than one family
+// — the declared gauge metric, any churn dimension, and the scrape-health `up`
+// series — so inferring it would inject drift into an arbitrary one of them
+// while the caller's query, and its expectation, name another. The injection
+// would land, the query would not see it, and a negative control that cannot
+// see its own corruption reports the lane is blind when it is not.
+func InjectGaugeDrift(
+	ctx context.Context, conn driver.Conn, f Fixture, metricName, service string,
+) (map[int64]float64, error) {
 	base := map[int64]float64{}
-	var metricName string
+	var found bool
 	for _, s := range f.Gauge {
-		if s.Attributes[serviceNameLabel] != service {
+		if s.MetricName != metricName || s.Attributes[serviceNameLabel] != service {
 			continue
 		}
-		metricName = s.MetricName
+		found = true
 		for _, sample := range s.Samples {
 			base[sample.Time.UnixMilli()] += sample.Value
 		}
 	}
-	if metricName == "" {
-		return nil, fmt.Errorf("fixture holds no gauge series for service %q", service)
+	if !found {
+		return nil, fmt.Errorf("fixture holds no %s series for service %q", metricName, service)
 	}
 
 	injected := make(map[int64]float64, len(base))

--- a/test/e2e/migration/seed/fixture.go
+++ b/test/e2e/migration/seed/fixture.go
@@ -69,11 +69,50 @@ type Declaration struct {
 	// (service, status) counter series, the sample INDEX at which that
 	// series' running total resets to zero before continuing to climb — the
 	// shape rate()/increase() must survive across a real pod restart. The map
-	// key is "<service>|<status>" (restartKeySeparator joins them); a key
-	// naming a combination outside the declared cross join is simply never
-	// looked up. Absent or empty leaves buildCounter's counters purely
-	// monotonic — exactly today's behaviour.
+	// key is "<service>|<status>" (restartKeySeparator joins them). Absent or
+	// empty leaves buildCounter's counters purely monotonic.
+	//
+	// Every key must name a combination the declared cross join actually
+	// produces, and every index must address a real sample; both are rejected
+	// rather than silently ignored. A key that resolves to nothing declares a
+	// reset the fixture never injects, which leaves the corpus query written
+	// against it asserting reset handling over a series that never resets —
+	// coverage that reads as present and proves nothing.
 	Restarts map[string][]int `json:"restarts,omitempty"`
+
+	// ScrapeHealth optionally declares the fixture's `up` series: Prometheus's
+	// own per-target scrape-health gauge, and the handle every staleness query
+	// in a hotspot corpus is written against. Nothing synthesises `up` — on
+	// both sides of the diff it is an ordinary gauge that has to be written to
+	// be queryable — so an archetype that wants target-down semantics
+	// exercised has to declare them here. Absent, the fixture emits no `up` at
+	// all and every archetype that does not declare it is byte-for-byte
+	// unaffected.
+	ScrapeHealth *ScrapeHealth `json:"scrape_health,omitempty"`
+}
+
+// ScrapeHealth declares the two target-down shapes a migration has to survive.
+// They are NOT the same shape and they do not share an expected answer, which
+// is exactly why a corpus needs both:
+//
+//   - Down — the target is still there and still being scraped, but the scrape
+//     FAILED. `up` is present and reports 0. `up == 0` selects precisely those
+//     samples, and the return to 1 afterwards is the resolve edge.
+//   - Stops — the target is GONE. `up` carries no sample at all past that
+//     index, so neither backend holds a value and the expected answer is
+//     governed purely by the instant-selector lookback: the series stays
+//     visible for the lookback delta past its last sample and then disappears.
+//     That is the TSDB stale-marker versus ClickHouse gap model
+//     docs/migration-testing.md section 5 requires cerberus to MATCH rather
+//     than tolerate.
+type ScrapeHealth struct {
+	// Down maps a declared service to the sample indices at which its scrape
+	// failed. A service naming no entry is scraped successfully throughout.
+	Down map[string][]int `json:"down,omitempty"`
+	// Stops maps a declared service to the LAST sample index its target is
+	// scraped at; the series carries no sample after it. A service naming no
+	// entry is scraped for the whole window.
+	Stops map[string]int `json:"stops,omitempty"`
 }
 
 // LoadDeclaration reads and validates an archetype's fixture declaration. A
@@ -139,7 +178,79 @@ func (d Declaration) validate() error {
 	if d.ChurnCardinality < 0 {
 		return fmt.Errorf("churn_cardinality is %d, want a non-negative count", d.ChurnCardinality)
 	}
+	if err := d.validateRestartKeys(); err != nil {
+		return err
+	}
+	return d.validateScrapeHealthServices()
+}
+
+// contains reports whether a declared list holds a value. The lists are three
+// to six entries long, so a linear scan is the whole of it.
+func contains(list []string, want string) bool {
+	for _, v := range list {
+		if v == want {
+			return true
+		}
+	}
+	return false
+}
+
+// validateRestartKeys rejects a Restarts key that names a series the declared
+// cross join never produces. Ignoring such a key silently is what turns a
+// declared counter reset into no reset at all while the corpus query written
+// against it keeps passing, which is the failure mode this whole family of
+// declarations exists to make impossible.
+func (d Declaration) validateRestartKeys() error {
+	for key := range d.Restarts {
+		service, status, ok := strings.Cut(key, restartKeySeparator)
+		if !ok {
+			return fmt.Errorf("restarts key %q is not %q-joined; want \"<service>%s<http_status_code>\"",
+				key, restartKeySeparator, restartKeySeparator)
+		}
+		if !contains(d.Services, service) {
+			return fmt.Errorf("restarts key %q names service %q, which is not in services %v", key, service, d.Services)
+		}
+		if !contains(d.StatusCodes, status) {
+			return fmt.Errorf("restarts key %q names status code %q, which is not in http_status_codes %v",
+				key, status, d.StatusCodes)
+		}
+	}
 	return nil
+}
+
+// validateScrapeHealthServices rejects a scrape-health entry naming a service
+// the declaration does not carry, for the same reason: a typo would leave the
+// `up` series uniformly healthy and every staleness query in the corpus
+// comparing two empty answers.
+func (d Declaration) validateScrapeHealthServices() error {
+	if d.ScrapeHealth == nil {
+		return nil
+	}
+	for _, m := range []struct {
+		field    string
+		services []string
+	}{
+		{"scrape_health.down", mapKeys(d.ScrapeHealth.Down)},
+		{"scrape_health.stops", mapKeys(d.ScrapeHealth.Stops)},
+	} {
+		for _, service := range m.services {
+			if !contains(d.Services, service) {
+				return fmt.Errorf("%s names service %q, which is not in services %v", m.field, service, d.Services)
+			}
+		}
+	}
+	return nil
+}
+
+// mapKeys returns a map's keys in sorted order, so a validation failure names
+// the same offending entry on every run.
+func mapKeys[V any](m map[string]V) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	sort.Strings(out)
+	return out
 }
 
 // Fixture-window geometry. The fixture's SHAPE is byte-identical on every run;
@@ -503,11 +614,17 @@ func Build(d Declaration, w Window) (Fixture, error) {
 
 	rng := rand.New(rand.NewSource(seedValue)) //nolint:gosec // fixture determinism, not cryptography
 	times := w.SampleTimes()
+	if err := d.validateSampleIndices(len(times)); err != nil {
+		return Fixture{}, err
+	}
 
 	traces := buildTraces(d, w, rng)
 	fixture := Fixture{
-		Window:     w,
-		Gauge:      append(buildGauge(d, times, rng), buildChurn(d, times)...),
+		Window: w,
+		// The scrape-health family lands in the gauge table because that is
+		// what `up` is; appending it last keeps every previously declared
+		// gauge series at the index it already had.
+		Gauge:      append(append(buildGauge(d, times, rng), buildChurn(d, times)...), buildScrapeHealth(d, times)...),
 		Counter:    buildCounter(d, times, rng),
 		Histogram:  buildHistogram(d, times),
 		LogStreams: buildLogStreams(d, times, traces),
@@ -590,11 +707,60 @@ func restartIndices(d Declaration, service, status string) map[int]bool {
 	if !ok {
 		return nil
 	}
+	return indexSet(indices)
+}
+
+// indexSet turns a declared list of sample indices into a membership set. A
+// nil or empty list yields a nil map, and indexing a nil map is safe and
+// always reports false, so an undeclared series stays exactly as it was.
+func indexSet(indices []int) map[int]bool {
+	if len(indices) == 0 {
+		return nil
+	}
 	set := make(map[int]bool, len(indices))
 	for _, idx := range indices {
 		set[idx] = true
 	}
 	return set
+}
+
+// validateSampleIndices rejects every declared sample index that does not
+// address a real sample of the built window. LoadDeclaration cannot do this —
+// how many samples a fixture holds is a property of the WINDOW, not of the
+// declaration — so it runs from Build, where both are in hand. An index past
+// the end would otherwise inject nothing at all, and an injection that does
+// nothing is indistinguishable from coverage right up until it is relied on.
+func (d Declaration) validateSampleIndices(sampleCount int) error {
+	inRange := func(field string, idx int) error {
+		if idx < 0 || idx >= sampleCount {
+			return fmt.Errorf("%s declares sample index %d, but the fixture window holds %d samples (0..%d)",
+				field, idx, sampleCount, sampleCount-1)
+		}
+		return nil
+	}
+	for _, key := range mapKeys(d.Restarts) {
+		for _, idx := range d.Restarts[key] {
+			if err := inRange(fmt.Sprintf("restarts[%q]", key), idx); err != nil {
+				return err
+			}
+		}
+	}
+	if d.ScrapeHealth == nil {
+		return nil
+	}
+	for _, service := range mapKeys(d.ScrapeHealth.Down) {
+		for _, idx := range d.ScrapeHealth.Down[service] {
+			if err := inRange(fmt.Sprintf("scrape_health.down[%q]", service), idx); err != nil {
+				return err
+			}
+		}
+	}
+	for _, service := range mapKeys(d.ScrapeHealth.Stops) {
+		if err := inRange(fmt.Sprintf("scrape_health.stops[%q]", service), d.ScrapeHealth.Stops[service]); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 // churnSeriesValue is the constant sample value every churn series carries.
@@ -627,6 +793,57 @@ func buildChurn(d Declaration, times []time.Time) []MetricSeries {
 				d.ChurnLabel:     fmt.Sprintf("%s-%03d", d.ChurnLabel, i),
 			},
 			Samples: samples,
+		})
+	}
+	return out
+}
+
+// The scrape-health family. `up` is Prometheus's own reserved per-target
+// health gauge, so its name is fixed rather than archetype-configurable, and
+// the two values below are the only two Prometheus itself ever writes into it.
+const (
+	// ScrapeHealthMetric is exported so a corpus-shape assertion names the
+	// series through the package that writes it rather than restating "up".
+	ScrapeHealthMetric = "up"
+	scrapeSucceeded    = 1.0
+	scrapeFailed       = 0.0
+)
+
+// buildScrapeHealth returns one `up` series per declared service, in declared
+// order, carrying only the service label — `up` is per-target, so crossing it
+// with the status codes would invent targets the fixture does not model.
+//
+// Like buildChurn it draws no random values and consumes no RNG state, so its
+// presence never perturbs buildCounter/buildHistogram/buildLogStreams/
+// buildTraces' draws, and adding it to an archetype leaves every other series
+// in that archetype byte-for-byte unchanged.
+func buildScrapeHealth(d Declaration, times []time.Time) []MetricSeries {
+	if d.ScrapeHealth == nil {
+		return nil
+	}
+	out := make([]MetricSeries, 0, len(d.Services))
+	for _, svc := range d.Services {
+		down := indexSet(d.ScrapeHealth.Down[svc])
+		last := len(times) - 1
+		if stop, ok := d.ScrapeHealth.Stops[svc]; ok {
+			last = stop
+		}
+		samples := make([]Sample, 0, last+1)
+		for i, t := range times {
+			if i > last {
+				break
+			}
+			value := scrapeSucceeded
+			if down[i] {
+				value = scrapeFailed
+			}
+			samples = append(samples, Sample{Time: t, Value: value})
+		}
+		out = append(out, MetricSeries{
+			MetricName:  ScrapeHealthMetric,
+			ServiceName: svc,
+			Attributes:  map[string]string{serviceNameLabel: svc},
+			Samples:     samples,
 		})
 	}
 	return out

--- a/test/e2e/migration/seed/manifest.go
+++ b/test/e2e/migration/seed/manifest.go
@@ -29,14 +29,21 @@ type Manifest struct {
 	// rather than restated by hand. A parity assertion that compares a side
 	// against one of these is comparing against a declared value, not against
 	// the other side's length.
-	Streams          int         `json:"streams"`
-	LogRecords       int         `json:"log_records"`
-	Series           SeriesCount `json:"series"`
-	PromSeries       int         `json:"prom_series"`
-	Traces           int         `json:"traces"`
-	Spans            int         `json:"spans"`
-	SamplesPerSeries int         `json:"samples_per_series"`
-	VerifySteps      int         `json:"verify_steps"`
+	Streams    int         `json:"streams"`
+	LogRecords int         `json:"log_records"`
+	Series     SeriesCount `json:"series"`
+	// GaugeMetricSeries is how many series the DECLARED gauge metric alone
+	// carries. Series.Gauge counts the whole gauge TABLE, which also holds any
+	// churn dimension and the scrape-health `up` family, so it is the wrong
+	// number to hold a metric-SCOPED probe to: a scenario that reads
+	// `GaugeMetric` and then compares against Series.Gauge is counting series
+	// its own WHERE clause excluded. Every such probe reads this instead.
+	GaugeMetricSeries int `json:"gauge_metric_series"`
+	PromSeries        int `json:"prom_series"`
+	Traces            int `json:"traces"`
+	Spans             int `json:"spans"`
+	SamplesPerSeries  int `json:"samples_per_series"`
+	VerifySteps       int `json:"verify_steps"`
 
 	// The incumbent-only history: what reference Prometheus holds STRICTLY
 	// before SeedStart, which is where ClickHouse's own ingest starts. These
@@ -69,19 +76,20 @@ type SeriesCount struct {
 // the substrate does not hold.
 func NewManifest(d Declaration, f Fixture) Manifest {
 	return Manifest{
-		AnchorEnd:        f.Window.AnchorEnd,
-		SeedStart:        f.Window.SeedStart,
-		VerifyStart:      f.Window.VerifyStart,
-		VerifyEnd:        f.Window.VerifyEnd,
-		Step:             f.Window.Step.String(),
-		Streams:          len(f.LogStreams),
-		LogRecords:       f.LogRecordCount(),
-		Series:           SeriesCount{Gauge: len(f.Gauge), Sum: len(f.Counter), Histogram: len(f.Histogram)},
-		PromSeries:       f.PromSeriesCount(),
-		Traces:           len(f.Traces),
-		Spans:            f.SpanCount(),
-		SamplesPerSeries: len(f.Window.SampleTimes()),
-		VerifySteps:      len(f.Window.VerifySteps()),
+		AnchorEnd:         f.Window.AnchorEnd,
+		SeedStart:         f.Window.SeedStart,
+		VerifyStart:       f.Window.VerifyStart,
+		VerifyEnd:         f.Window.VerifyEnd,
+		Step:              f.Window.Step.String(),
+		Streams:           len(f.LogStreams),
+		LogRecords:        f.LogRecordCount(),
+		Series:            SeriesCount{Gauge: len(f.Gauge), Sum: len(f.Counter), Histogram: len(f.Histogram)},
+		GaugeMetricSeries: countSeriesNamed(f.Gauge, d.GaugeMetric),
+		PromSeries:        f.PromSeriesCount(),
+		Traces:            len(f.Traces),
+		Spans:             f.SpanCount(),
+		SamplesPerSeries:  len(f.Window.SampleTimes()),
+		VerifySteps:       len(f.Window.VerifySteps()),
 
 		PreIngestStart:            f.Window.PreIngestStart(),
 		PreIngestSeries:           len(f.PromPreIngestSeries()),
@@ -92,6 +100,17 @@ func NewManifest(d Declaration, f Fixture) Manifest {
 		HistogramMetric: d.HistogramMetric,
 		LogJob:          d.LogJob,
 	}
+}
+
+// countSeriesNamed counts the series carrying one metric name.
+func countSeriesNamed(list []MetricSeries, name string) int {
+	var n int
+	for _, s := range list {
+		if s.MetricName == name {
+			n++
+		}
+	}
+	return n
 }
 
 // manifestFileMode is the mode the manifest is written with: readable by the

--- a/test/e2e/migration/steps/then_cutover.go
+++ b/test/e2e/migration/steps/then_cutover.go
@@ -383,10 +383,14 @@ func (w *World) givenIngestStart() error {
 		if m.GaugeMetric == "" {
 			return fmt.Errorf("archetype %s: the seeder's manifest names no gauge metric; the scenario has nothing to probe", a)
 		}
-		if m.Series.Gauge <= 0 || m.SamplesPerSeries <= 0 {
-			return fmt.Errorf("archetype %s: the seeder declared %d gauge series over %d samples each; "+
+		// The probe below is SCOPED to GaugeMetric, so every count it is held
+		// to is that metric's own — never Series.Gauge, which counts the whole
+		// gauge table including the churn dimension and the scrape-health `up`
+		// family that this census's WHERE clause excludes.
+		if m.GaugeMetricSeries <= 0 || m.SamplesPerSeries <= 0 {
+			return fmt.Errorf("archetype %s: the seeder declared %d %s series over %d samples each; "+
 				"there is no positive cardinality for cerberus's answer to be held to",
-				a, m.Series.Gauge, m.SamplesPerSeries)
+				a, m.GaugeMetricSeries, m.GaugeMetric, m.SamplesPerSeries)
 		}
 		if m.PreIngestSeries <= 0 || m.PreIngestSamplesPerSeries <= 0 {
 			return fmt.Errorf("archetype %s: the seeder left the incumbent %d series of %d samples before ingest-start; "+
@@ -410,9 +414,12 @@ func (w *World) givenIngestStart() error {
 			// One ClickHouse row per declared series per declared sample; both
 			// factors are checked positive immediately above, so the widening
 			// carries no sign surprise.
-			wantRowsAtOrAfter: uint64(m.Series.Gauge) * uint64(m.SamplesPerSeries),
-			wantSeries:        m.Series.Gauge,
-			wantIncumbentPre:  m.PreIngestSeries,
+			wantRowsAtOrAfter: uint64(m.GaugeMetricSeries) * uint64(m.SamplesPerSeries),
+			wantSeries:        m.GaugeMetricSeries,
+			// The incumbent's pre-ingest history covers every gauge series,
+			// but this probe reads GaugeMetric alone, so it can only answer
+			// with that metric's share of it.
+			wantIncumbentPre: m.GaugeMetricSeries,
 		}
 	}
 	return nil

--- a/test/e2e/migration/steps/then_tenant_isolation.go
+++ b/test/e2e/migration/steps/then_tenant_isolation.go
@@ -600,12 +600,18 @@ func (w *World) thenUnderBudgetReadComplete() error {
 	if !ok {
 		return fmt.Errorf("archetype %s's manifest was never loaded", w.tenant.archetype)
 	}
-	if manifest.Series.Gauge == 0 {
-		return fmt.Errorf("archetype %s's manifest declares no gauge series; the read would be vacuous", w.tenant.archetype)
+	// The in-budget read is scoped to GaugeMetric, so it is held to that
+	// metric's own cardinality. Series.Gauge counts the whole gauge table —
+	// the churn dimension and the scrape-health `up` family included — and
+	// holding a metric-scoped read to it fails by demanding series the read
+	// never selected.
+	if manifest.GaugeMetricSeries == 0 {
+		return fmt.Errorf("archetype %s's manifest declares no %s series; the read would be vacuous",
+			w.tenant.archetype, manifest.GaugeMetric)
 	}
-	if w.tenant.underBudgetSeries != manifest.Series.Gauge {
-		return fmt.Errorf("the in-budget read returned %d series, want the %d gauge series the manifest declares",
-			w.tenant.underBudgetSeries, manifest.Series.Gauge)
+	if w.tenant.underBudgetSeries != manifest.GaugeMetricSeries {
+		return fmt.Errorf("the in-budget read returned %d series, want the %d %s series the manifest declares",
+			w.tenant.underBudgetSeries, manifest.GaugeMetricSeries, manifest.GaugeMetric)
 	}
 	decl, err := w.tenantDeclaration()
 	if err != nil {

--- a/test/e2e/migration/tier1_parity_test.go
+++ b/test/e2e/migration/tier1_parity_test.go
@@ -298,9 +298,26 @@ type metricParityCase struct {
 	carriesName bool
 }
 
+// seriesNamed selects the fixture series carrying one metric name. A metric
+// TABLE is not a metric FAMILY: the gauge table holds the declared gauge
+// metric, any churn dimension, and the scrape-health `up` series at once, so
+// an oracle for a query scoped to one of them has to be scoped the same way.
+// Aggregating the whole table instead produces groups the query never returns
+// — and, worse, groups the query's `by` clause has no label for.
+func seriesNamed(list []seed.MetricSeries, name string) []seed.MetricSeries {
+	out := make([]seed.MetricSeries, 0, len(list))
+	for _, s := range list {
+		if s.MetricName == name {
+			out = append(out, s)
+		}
+	}
+	return out
+}
+
 func metricParityCases(tc tier1Context) []metricParityCase {
-	counter := func(f seed.Fixture) []seed.MetricSeries { return f.Counter }
-	gauge := func(f seed.Fixture) []seed.MetricSeries { return f.Gauge }
+	d := tc.declaration
+	counter := func(f seed.Fixture) []seed.MetricSeries { return seriesNamed(f.Counter, d.CounterMetric) }
+	gauge := func(f seed.Fixture) []seed.MetricSeries { return seriesNamed(f.Gauge, d.GaugeMetric) }
 	histogramCount := func(f seed.Fixture) []seed.MetricSeries {
 		out := make([]seed.MetricSeries, 0, len(f.Histogram))
 		for _, h := range f.Histogram {
@@ -315,7 +332,6 @@ func metricParityCases(tc tier1Context) []metricParityCase {
 		}
 		return out
 	}
-	d := tc.declaration
 	return []metricParityCase{
 		{
 			// Raw series: proves the two sides carry the same SERIES IDENTITY,
@@ -814,7 +830,7 @@ func assertDriftIsObserved(t *testing.T, ctx context.Context, tc tier1Context) {
 	// the post-injection expectation is a declared value rather than whatever
 	// the backend happened to return a moment ago.
 	base := gaugeOracleForService(tc, service)
-	injected, err := seed.InjectGaugeDrift(ctx, conn, tc.fixture, service)
+	injected, err := seed.InjectGaugeDrift(ctx, conn, tc.fixture, tc.declaration.GaugeMetric, service)
 	if err != nil {
 		t.Fatalf("inject reference drift: %v", err)
 	}
@@ -892,7 +908,7 @@ func assertStepGridComplete(t *testing.T, side, service string, series promMatri
 func gaugeOracleForService(tc tier1Context, service string) map[int64]float64 {
 	out := map[int64]float64{}
 	for _, s := range tc.fixture.Gauge {
-		if s.Attributes["service_name"] != service {
+		if s.MetricName != tc.declaration.GaugeMetric || s.Attributes["service_name"] != service {
 			continue
 		}
 		for _, sample := range s.Samples {

--- a/test/regression/migration_tier1_test.go
+++ b/test/regression/migration_tier1_test.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"sort"
 	"strconv"
 	"strings"
 	"testing"
@@ -16,6 +17,7 @@ import (
 	"gopkg.in/yaml.v3"
 
 	"github.com/tsouza/cerberus/internal/config"
+	"github.com/tsouza/cerberus/internal/qlcommon"
 
 	"github.com/tsouza/cerberus/test/e2e/migration/lib"
 	"github.com/tsouza/cerberus/test/e2e/migration/seed"
@@ -936,6 +938,19 @@ type tier1Declaration struct {
 	HistogramBounds  []float64 `json:"histogram_bounds"`
 	TracesPerService int       `json:"traces_per_service"`
 	SpansPerTrace    []int     `json:"spans_per_trace"`
+	// The three declarations that move a count off the service × status cross
+	// join, or that inject a shape a hotspot query is written against. The
+	// count pins and the corpus-shape pin below read them.
+	ChurnCardinality int                `json:"churn_cardinality"`
+	ScrapeHealth     *tier1ScrapeHealth `json:"scrape_health"`
+}
+
+// tier1ScrapeHealth is the archetype's declared `up` shape: which services
+// report a failed scrape at which sample indices, and which service's target
+// stops being scraped altogether.
+type tier1ScrapeHealth struct {
+	Down  map[string][]int `json:"down"`
+	Stops map[string]int   `json:"stops"`
 }
 
 // tier1Expected is the subset of the archetype's pinned expectations these pins
@@ -996,7 +1011,17 @@ func TestMigrationTier1ExpectationsFollowTheDeclaration(t *testing.T) {
 	// A classic-histogram series expands on the reference side into one
 	// cumulative bucket per explicit bound, a +Inf bucket, a _count and a _sum.
 	histogramPromSeries := metricSeries * (len(decl.HistogramBounds) + 3)
-	promSeries := metricSeries*2 + histogramPromSeries
+	// `up` is per-TARGET, so a declared scrape-health block adds exactly one
+	// gauge series per service — never a service × status cross. Declaring it
+	// is what moves the gauge count off the cross-join figure, and pinning the
+	// distinction here is what stops a future cross-joined `up` (three times
+	// the targets the fixture models) landing unnoticed.
+	scrapeHealthSeries := 0
+	if decl.ScrapeHealth != nil {
+		scrapeHealthSeries = len(decl.Services)
+	}
+	gaugeSeries := metricSeries + decl.ChurnCardinality + scrapeHealthSeries
+	promSeries := gaugeSeries + metricSeries + histogramPromSeries
 
 	// The window geometry has two definitions — the Go consts in seed/fixture.go
 	// and these pinned counts — and they are bound HERE. Without this, a change
@@ -1012,7 +1037,7 @@ func TestMigrationTier1ExpectationsFollowTheDeclaration(t *testing.T) {
 	}{
 		{"samples per series", expected.SamplesPerSeries, len(window.SampleTimes())},
 		{"verify steps", expected.VerifySteps, len(window.VerifySteps())},
-		{"gauge series", expected.Series.Gauge, metricSeries},
+		{"gauge series", expected.Series.Gauge, gaugeSeries},
 		{"sum series", expected.Series.Sum, metricSeries},
 		{"histogram series", expected.Series.Histogram, metricSeries},
 		{"log streams", expected.LogStreams, logStreams},
@@ -1160,6 +1185,305 @@ func TestMigrationTier1QueriesNameTheFixture(t *testing.T) {
 			t.Fatalf("%s query %q names no fixture metric (%v). A query that does not name one can "+
 				"reach the ClickHouse-only schema warm-up rows, which have no reference-side "+
 				"counterpart.", tier1ExpectedPath, q.Query, fixtureMetrics)
+		}
+	}
+}
+
+// The semantic-hotspot corpus MIG-17 replays, and the fixture shapes its PASS
+// cell claims it exercises.
+const tier1HotspotCorpusPath = tier1ArchetypeDir + "/seed/verify-hotspots.json"
+
+// Label keys the fixture writes its metric attributes under. They restate
+// seed's own unexported constants, and deliberately so: a rename there moves
+// the fixture AND the committed corpus, and this pin then fails by not finding
+// the series it went looking for rather than by silently matching nothing.
+const (
+	tier1ServiceLabel    = "service_name"
+	tier1StatusCodeLabel = "http_status_code"
+)
+
+// tier1Corpus is the committed verify-corpus shape.
+type tier1Corpus struct {
+	Queries []struct {
+		Expr string `json:"expr"`
+	} `json:"queries"`
+}
+
+// TestMigrationTier1HotspotCorpusSelectsItsSeededHotspots is the anti-hollow
+// pin for MIG-17's PASS cell (docs/migration-testing.md section 6), which
+// names counter-reset handling and `up==0` / stale-versus-gap staleness as
+// what the scenario proves.
+//
+// Both claims are only true if TWO independent files agree, and neither file
+// can see the other: the archetype's data declaration has to INJECT the shape
+// inside the queried window, and the committed hotspot corpus has to SELECT
+// the very series it was injected into. Break either half and MIG-17 still
+// goes green — a corpus query scoped to a series that never resets compares
+// two identical monotonic answers, and a staleness query against a metric
+// nothing seeds compares two empty ones. That is the exact failure #1542
+// records, so it is pinned here, offline, on the required lane rather than
+// left to a scheduled Docker run to notice.
+func TestMigrationTier1HotspotCorpusSelectsItsSeededHotspots(t *testing.T) {
+	t.Parallel()
+
+	decl, err := seed.LoadDeclaration(tier1DeclPath)
+	if err != nil {
+		t.Fatalf("load %s: %v", tier1DeclPath, err)
+	}
+	window := seed.NewWindow(time.Now())
+	fixture, err := seed.Build(decl, window)
+	if err != nil {
+		t.Fatalf("build the fixture from %s: %v", tier1DeclPath, err)
+	}
+	exprs := readTier1HotspotExprs(t)
+
+	assertTier1CounterResetHotspot(t, decl, fixture, window, exprs)
+	assertTier1ScrapeFailureHotspot(t, decl, fixture, window, exprs)
+	assertTier1TargetVanishedHotspot(t, decl, fixture, window, exprs)
+}
+
+// readTier1HotspotExprs reads the committed hotspot corpus's expressions.
+func readTier1HotspotExprs(t *testing.T) []string {
+	t.Helper()
+	buf, err := os.ReadFile(tier1HotspotCorpusPath)
+	if err != nil {
+		t.Fatalf("read %s: %v", tier1HotspotCorpusPath, err)
+	}
+	var corpus tier1Corpus
+	if err := json.Unmarshal(buf, &corpus); err != nil {
+		t.Fatalf("parse %s: %v", tier1HotspotCorpusPath, err)
+	}
+	if len(corpus.Queries) == 0 {
+		t.Fatalf("%s declares no query at all", tier1HotspotCorpusPath)
+	}
+	out := make([]string, 0, len(corpus.Queries))
+	for _, q := range corpus.Queries {
+		out = append(out, q.Expr)
+	}
+	return out
+}
+
+// tier1CorpusSelects reports whether any corpus expression carries every one
+// of the given fragments — the test's definition of "this corpus query is
+// scoped to that series".
+func tier1CorpusSelects(exprs []string, fragments ...string) bool {
+	for _, expr := range exprs {
+		all := true
+		for _, f := range fragments {
+			if !strings.Contains(expr, f) {
+				all = false
+				break
+			}
+		}
+		if all {
+			return true
+		}
+	}
+	return false
+}
+
+// tier1FindSeries returns the fixture series carrying exactly the given metric
+// name and attribute values.
+func tier1FindSeries(list []seed.MetricSeries, metric string, attrs map[string]string) (seed.MetricSeries, bool) {
+	for _, s := range list {
+		if s.MetricName != metric {
+			continue
+		}
+		match := true
+		for k, v := range attrs {
+			if s.Attributes[k] != v {
+				match = false
+				break
+			}
+		}
+		if match {
+			return s, true
+		}
+	}
+	return seed.MetricSeries{}, false
+}
+
+// tier1VerifySteps returns the instants the parity lane actually queries, as a
+// set. A seeded shape that falls BETWEEN two steps is never read, so every
+// assertion below is stated against this set rather than against the sample
+// grid.
+func tier1VerifySteps(w seed.Window) map[time.Time]bool {
+	out := map[time.Time]bool{}
+	for _, t := range w.VerifySteps() {
+		out[t] = true
+	}
+	return out
+}
+
+// tier1SortedKeys returns a map's keys in sorted order so a failure names the
+// same entry on every run.
+func tier1SortedKeys[V any](m map[string]V) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// assertTier1CounterResetHotspot pins the counter-reset half: the declared
+// restart lands on a real drop in a real series, at an instant the lane
+// queries, and the corpus carries a query scoped to that exact series.
+func assertTier1CounterResetHotspot(
+	t *testing.T, decl seed.Declaration, f seed.Fixture, w seed.Window, exprs []string,
+) {
+	t.Helper()
+	if len(decl.Restarts) == 0 {
+		t.Fatalf("%s declares no counter restart, so MIG-17's counter-reset claim rests on a fixture whose "+
+			"counters are purely monotonic and rate()/increase() never cross a reset", tier1DeclPath)
+	}
+	steps := tier1VerifySteps(w)
+	times := w.SampleTimes()
+	for _, key := range tier1SortedKeys(decl.Restarts) {
+		service, status, _ := strings.Cut(key, "|")
+		series, ok := tier1FindSeries(f.Counter, decl.CounterMetric, map[string]string{
+			tier1ServiceLabel: service, tier1StatusCodeLabel: status,
+		})
+		if !ok {
+			t.Fatalf("%s declares restart %q but the fixture carries no %s series for %s/%s",
+				tier1DeclPath, key, decl.CounterMetric, service, status)
+		}
+		for _, idx := range decl.Restarts[key] {
+			if idx == 0 {
+				t.Fatalf("%s restarts %q at sample 0; a reset at the very first sample has no preceding "+
+					"value to fall from, so no rate() window can observe it", tier1DeclPath, key)
+			}
+			if series.Samples[idx].Value >= series.Samples[idx-1].Value {
+				t.Fatalf("%s restarts %q at sample %d, but the series goes %g -> %g there; the counter "+
+					"never actually falls, so reset handling is not exercised",
+					tier1DeclPath, key, idx, series.Samples[idx-1].Value, series.Samples[idx].Value)
+			}
+			at := times[idx]
+			if !at.After(w.VerifyStart) || !at.Before(w.VerifyEnd) {
+				t.Fatalf("%s restarts %q at %s, outside the queried interval (%s, %s); no replayed step's "+
+					"range window spans it", tier1DeclPath, key, at, w.VerifyStart, w.VerifyEnd)
+			}
+			if !steps[at] {
+				t.Fatalf("%s restarts %q at %s, which is not one of the %d instants the lane queries",
+					tier1DeclPath, key, at, len(steps))
+			}
+		}
+		if !tier1CorpusSelects(exprs, decl.CounterMetric,
+			tier1ServiceLabel+`="`+service+`"`, tier1StatusCodeLabel+`="`+status+`"`) {
+			t.Fatalf("%s carries no query scoped to the restarting series %s{%s=%q,%s=%q}. Without one, the "+
+				"reset is only ever swept up by an unscoped aggregate, and any reset coverage is incidental "+
+				"— it would evaporate the moment the seed changed.",
+				tier1HotspotCorpusPath, decl.CounterMetric, tier1ServiceLabel, service, tier1StatusCodeLabel, status)
+		}
+	}
+}
+
+// assertTier1ScrapeFailureHotspot pins the `up==0` half: a declared scrape
+// failure is visible at instants the lane queries, it RESOLVES back to a
+// healthy scrape inside the same window, and the corpus carries the `up == 0`
+// query that selects it.
+func assertTier1ScrapeFailureHotspot(
+	t *testing.T, decl seed.Declaration, f seed.Fixture, w seed.Window, exprs []string,
+) {
+	t.Helper()
+	if decl.ScrapeHealth == nil || len(decl.ScrapeHealth.Down) == 0 {
+		t.Fatalf("%s declares no failed scrape, so MIG-17's `up==0` claim would compare two empty answers",
+			tier1DeclPath)
+	}
+	if !tier1CorpusSelects(exprs, seed.ScrapeHealthMetric, "== 0") {
+		t.Fatalf("%s carries no `%s == 0` query, which is the expression MIG-17's PASS cell names by hand",
+			tier1HotspotCorpusPath, seed.ScrapeHealthMetric)
+	}
+	steps := tier1VerifySteps(w)
+	for _, service := range tier1SortedKeys(decl.ScrapeHealth.Down) {
+		series, ok := tier1FindSeries(f.Gauge, seed.ScrapeHealthMetric, map[string]string{tier1ServiceLabel: service})
+		if !ok {
+			t.Fatalf("%s declares a failed scrape for %q but the fixture carries no %s series for it",
+				tier1DeclPath, service, seed.ScrapeHealthMetric)
+		}
+		var failedAt, resolvedAfter int
+		var lastFailure time.Time
+		for _, sample := range series.Samples {
+			if !steps[sample.Time] {
+				continue
+			}
+			if sample.Value == 0 {
+				failedAt++
+				lastFailure = sample.Time
+				resolvedAfter = 0
+				continue
+			}
+			if !lastFailure.IsZero() {
+				resolvedAfter++
+			}
+		}
+		if failedAt == 0 {
+			t.Fatalf("%s declares a failed scrape for %q, but no queried step reads a zero: the outage falls "+
+				"entirely between steps and `%s == 0` returns nothing on either side",
+				tier1DeclPath, service, seed.ScrapeHealthMetric)
+		}
+		if resolvedAfter == 0 {
+			t.Fatalf("%s leaves %q scrape-failed through the end of the queried window, so the resolve edge "+
+				"MIG-17's PASS cell names is never crossed", tier1DeclPath, service)
+		}
+	}
+}
+
+// assertTier1TargetVanishedHotspot pins the stale-versus-gap half: a declared
+// target really does stop being scraped, its disappearance edge — the last
+// sample plus the instant lookback, which is where BOTH backends must drop the
+// series — lands exactly on an instant the lane queries, and the corpus reads
+// that series both bare and through absent_over_time.
+//
+// The edge is pinned ON a step rather than merely inside the window on
+// purpose. The lookback interval is left-open on both sides, so a sample
+// exactly `lookback` old is already gone; a step landing anywhere else would
+// leave the boundary itself unread and the comparison would pass on either
+// convention.
+func assertTier1TargetVanishedHotspot(
+	t *testing.T, decl seed.Declaration, f seed.Fixture, w seed.Window, exprs []string,
+) {
+	t.Helper()
+	if decl.ScrapeHealth == nil || len(decl.ScrapeHealth.Stops) == 0 {
+		t.Fatalf("%s declares no vanishing target, so MIG-17's stale-marker-versus-gap claim rests on a "+
+			"fixture in which every series runs to the end of the window", tier1DeclPath)
+	}
+	steps := tier1VerifySteps(w)
+	for _, service := range tier1SortedKeys(decl.ScrapeHealth.Stops) {
+		series, ok := tier1FindSeries(f.Gauge, seed.ScrapeHealthMetric, map[string]string{tier1ServiceLabel: service})
+		if !ok {
+			t.Fatalf("%s stops scraping %q but the fixture carries no %s series for it",
+				tier1DeclPath, service, seed.ScrapeHealthMetric)
+		}
+		if len(series.Samples) == 0 {
+			t.Fatalf("%s leaves %q with no %s sample at all", tier1DeclPath, service, seed.ScrapeHealthMetric)
+		}
+		last := series.Samples[len(series.Samples)-1].Time
+		if !last.Before(w.VerifyEnd) {
+			t.Fatalf("%s stops scraping %q at %s, at or after the last queried instant %s; the series never "+
+				"disappears inside the compared window", tier1DeclPath, service, last, w.VerifyEnd)
+		}
+		vanishes := last.Add(qlcommon.InstantLookback)
+		if !steps[vanishes] {
+			t.Fatalf("%s stops scraping %q at %s, so the series disappears at %s — which is not one of the "+
+				"instants the lane queries. Move the stop index so the edge lands on a step; a boundary no "+
+				"step reads is a boundary neither backend is held to.",
+				tier1DeclPath, service, last, vanishes)
+		}
+		if !vanishes.Before(w.VerifyEnd) {
+			t.Fatalf("%s stops scraping %q so late that the disappearance at %s is the last queried instant "+
+				"%s or beyond; no step reads the series in its absence",
+				tier1DeclPath, service, vanishes, w.VerifyEnd)
+		}
+		scope := tier1ServiceLabel + `="` + service + `"`
+		for _, shape := range []struct{ what, fragment string }{
+			{"a bare selector, which reads the instant-lookback edge", seed.ScrapeHealthMetric + "{" + scope + "}"},
+			{"absent_over_time, which reads the same edge through a range window", "absent_over_time"},
+		} {
+			if !tier1CorpusSelects(exprs, seed.ScrapeHealthMetric, scope, shape.fragment) {
+				t.Fatalf("%s carries no query reading the vanished target %q through %s",
+					tier1HotspotCorpusPath, service, shape.what)
+			}
 		}
 	}
 }

--- a/test/regression/migration_tier1_test.go
+++ b/test/regression/migration_tier1_test.go
@@ -1052,6 +1052,36 @@ func TestMigrationTier1ExpectationsFollowTheDeclaration(t *testing.T) {
 		}
 	}
 
+	// The gauge TABLE and the declared gauge FAMILY are two different counts
+	// the moment an archetype declares a churn dimension or a scrape-health
+	// block, and every metric-scoped probe (MIG-15's in-budget read, MIG-23's
+	// boundary census) is held to the family. Publishing them as one number is
+	// how those scenarios came to demand series their own WHERE clause
+	// excluded, so the split is pinned rather than left to a live run.
+	full, err := seed.LoadDeclaration(tier1DeclPath)
+	if err != nil {
+		t.Fatalf("load %s: %v", tier1DeclPath, err)
+	}
+	fixture, err := seed.Build(full, window)
+	if err != nil {
+		t.Fatalf("build the fixture from %s: %v", tier1DeclPath, err)
+	}
+	m := seed.NewManifest(full, fixture)
+	if m.GaugeMetricSeries != metricSeries {
+		t.Fatalf("the manifest publishes %d %s series but the declaration implies %d",
+			m.GaugeMetricSeries, full.GaugeMetric, metricSeries)
+	}
+	if m.Series.Gauge != gaugeSeries {
+		t.Fatalf("the manifest publishes %d gauge-table series but the declaration implies %d",
+			m.Series.Gauge, gaugeSeries)
+	}
+	if full.ScrapeHealth != nil && m.GaugeMetricSeries >= m.Series.Gauge {
+		t.Fatalf("%s declares a scrape-health block, but the manifest's gauge-metric count (%d) does not "+
+			"sit strictly below the gauge-table count (%d); the two have collapsed back into one number "+
+			"and a metric-scoped probe held to the table count would demand series it never selected",
+			tier1DeclPath, m.GaugeMetricSeries, m.Series.Gauge)
+	}
+
 	if expected.Spans <= expected.Traces {
 		t.Fatalf("%s declares %d spans across %d traces; every trace holds at least %d spans, so the "+
 			"span count cannot be that low", tier1ExpectedPath, expected.Spans, expected.Traces,


### PR DESCRIPTION
MIG-17's §6 PASS cell names `up==0` and the stale-marker-versus-gap edge as
what the semantic-hotspot corpus proves. Nothing seeded an `up` series at all —
cerberus does not synthesise it, so both sides of the differential compared two
empty answers and a staleness regression passed MIG-17 green.

#1662 closed the counter-reset half of the issue. This closes the staleness
half, and resolves the sub-point that issue left open.

## The open sub-point, resolved

`cerberus_migration_requests_total` **is** a restarting series — `payments|500`
resets at sample index 60, declared by #1662. The `rate`/`increase` pair scoped
to that series is real coverage, not incidental. What was still missing is that
nothing *held* it that way: the declaration and the corpus could drift apart
silently. They no longer can.

## What was added

The three-signal declaration gains a `scrape_health` block, and the fixture
builds an `up` series per service from it:

- `down` — `payments` scrape-fails for a contiguous run of samples across the
  pod restart that already zeroed its counter, then recovers. That is the
  firing edge and the resolve edge `up == 0` selects.
- `stops` — `search`'s target stops being scraped at sample 88, chosen so the
  disappearance (last sample + the 5m instant lookback) lands *exactly* on a
  replayed step. The lookback interval is left-open at both ends, so a sample
  exactly `lookback` old is already gone; a step landing anywhere else would
  leave the boundary unread and the comparison would pass on either convention.

Three corpus queries read it: `up == 0`, a bare `up{service_name="search"}`
across the instant-lookback edge, and `absent_over_time(...)` across the same
edge through a range window.

`up` is written to both sides — an ordinary gauge in `otel_metrics_gauge` and an
ordinary remote-write series — so the fixture's one deliberate asymmetry is
still the pre-ingest history, unchanged.

## The pin that stops it rotting

`TestMigrationTier1HotspotCorpusSelectsItsSeededHotspots` holds the two files
together offline, on the required lane. Each shape is inert unless the
declaration injects it *inside the queried window* and the corpus selects *the
very series it was injected into* — and neither file can see the other.

Proven to go red, each with its own message, by five injected regressions:

| injected regression | assertion that fired |
| --- | --- |
| drop the `up == 0` corpus query | corpus carries no `up == 0` query |
| move the vanish edge off a queried step (`stops` 88 → 89) | disappearance at an instant no step reads |
| shrink the outage to fall entirely between steps | no queried step reads a zero |
| remove `stops` | no vanishing target declared |
| unscope the corpus's restarting-series queries | no query scoped to the restarting series |

Also hardened, same root cause: a `restarts` key naming a series outside the
declared cross join, or any declared sample index past the end of the window, is
now rejected instead of silently injecting nothing.

## Seeding a second gauge family broke three latent assumptions

The gauge TABLE stopped being a single metric FAMILY, and five consumers were
inferring the family from the table. Each now names the metric it means:

- the tier-1 parity oracle aggregated every gauge series into a query scoped to
  one metric (9 groups where the query returns 6);
- `gaugeOracleForService` summed across families;
- `InjectGaugeDrift` took its metric name from whichever series the scan landed
  on last, so the **negative control injected drift into `up`** while asserting
  against the queue-depth query — it reported the lane blind when it was not;
- MIG-15's in-budget read and MIG-23's boundary census compared a
  metric-scoped answer against `manifest.Series.Gauge`.

The manifest now publishes `gauge_metric_series` next to the table count, and an
offline pin keeps the two distinct whenever an archetype declares a second gauge
family.

## Counts and pins

Gauge series 6 → 9 and prom series 48 → 51 in the archetype's hand-authored
`expected/tier1.json`. The regression derivation computes the gauge count as
`cross-join + churn + scrape-health` rather than restating the cross join, so
`up` cannot silently become status-crossed (three times the targets the fixture
models).

The MIG-17 PASS cell needed no edit — it already named exactly these queries,
and the corpus has now caught up to it — so `pass-assertions.pin.json` is
unchanged. `MODE=verify` reports 30/30 scenarios, 0 violations.

## Live verification

Full tier-1 lane, from a clean seed: **18 scenarios, 18 passed; 147 steps**,
plus the substrate + parity suite. Both `ok`.

Per-query evidence from `migrate verify` against the live dual-backend stack —
every entry `match`, none comparing zero units. Sample counts over the 21
replayed steps, identical on reference Prometheus v3.11.3 and cerberus:

| expression | steps returned |
| --- | --- |
| `up == 0` | 4 / 21 (the outage, both edges inside the window) |
| `up{service_name="search"}` | 17 / 21 (present, then gone at the lookback edge) |
| `absent_over_time(up{service_name="search"}[5m])` | 4 / 21 (the exact complement) |

**The lane goes red on a real engine regression.** Widening
`qlcommon.InstantLookback` from 5m to 10m and rebuilding the server, MIG-17
failed with:

> archetype three-signal: 1 quer(y/ies) diverged: … /staleness target vanished
> (`up{service_name="search"}`): reference has no sample at this step

Reverted, rebuilt, green again. Before this PR the same regression passed
MIG-17 — nothing queried `up`.

Closes #1542
