### PR TITLE
test(migration): diff MIG-18/MIG-19 against a real incumbent ruler

### DIFF
--- a/.github/scripts/lib/mirror.mjs
+++ b/.github/scripts/lib/mirror.mjs
@@ -82,6 +82,10 @@ export const mirroredImages = [
   // Prometheus the PromQL surface gate probes and the reference Mimir the
   // histogram bench measures against.
   'prom/prometheus:v3.11.3',
+  // The migration lane's Tier-2 INCUMBENT dispatcher: the Alertmanager the
+  // incumbent ruler notifies through, standing opposite Grafana's own
+  // notifier so MIG-18's stream diff has two legs that share no code.
+  'prom/alertmanager:v0.28.1',
   'grafana/loki:3.7.0',
   'grafana/tempo:main-2f74ea8',
   'grafana/mimir:2.14.0',

--- a/Justfile
+++ b/Justfile
@@ -1696,7 +1696,7 @@ MIGRATION_TIER1_ARCHETYPES := "three-signal kube-prometheus-stack"
 # quietly shorter one. 200 lines carries a boot failure's stack or a Grafana
 # provisioning rejection while keeping ten services readable in a job log.
 MIGRATION_TIER1_SERVICES := "clickhouse otel-collector prometheus loki tempo cerberus"
-MIGRATION_TIER2_SERVICES := MIGRATION_TIER1_SERVICES + " grafana relay-prom otel-collector-writeback dead-end-receiver"
+MIGRATION_TIER2_SERVICES := MIGRATION_TIER1_SERVICES + " grafana relay-prom otel-collector-writeback dead-end-receiver" + " incumbent-ruler incumbent-alertmanager incumbent-dead-end-receiver"
 MIGRATION_LOG_TAIL := "200"
 
 # Archetypes sharing one live stack are kept apart by their IDENTITIES, not by

--- a/docs/migration-testing.md
+++ b/docs/migration-testing.md
@@ -649,76 +649,111 @@ does not pin the additive set by name.
 
 ### VERIFY scenarios
 
-| ID     | Tier(s)          | CLI                                                                                                                                                                                                                                                                                                           | Fixtures                                                                                                                                                                                                                                                       | PASS assertion                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               |
-| ------ | ---------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| MIG-16 | 1                | `cerberus migrate verify --corpus corpus.json --ref http://prometheus:9090 --cerberus http://cerberus:9090 --ref-loki http://loki:3100 --cerberus-loki http://cerberus:9090 --ref-tempo http://tempo:3200 --cerberus-tempo http://cerberus:9090 --start -1h --end now --step 60s --json --report verify.json` | full corpus + dual-write overlap window; VM/SaaS variants add a reference-Prometheus leg fed identical data                                                                                                                                                    | Same query/`[start,end,step]`, step-aligned, over both backends; first-diff report gives series/timestamp/ref-value/cerberus-value; **diverge count must reach zero — no expected-diff allow-list**; each divergence attributed to cerberus-bug / ingest-artifact / data-window-gap / dialect-semantics; metadata endpoints diffed too.                                                                                                                                                                                                                                                                                                                      |
-| MIG-17 | 1                | `cerberus migrate verify` scoped to the hotspot sub-corpus (PromQL lane; the hotspots are PromQL-shaped and so is the attribution)                                                                                                                                                                            | high-churn counters with induced pod-restart counter-resets; target-down transitions; classic + native histograms                                                                                                                                              | `rate`/`increase`/counter-reset verified across resets and pod-restart edges; staleness/absence (`up==0`, `absent()`, `absent_over_time()`, resolve edge) verified against the documented stale-marker-vs-gap expected answer (zero diverge, not tolerated); `histogram_quantile` verified within the stated estimator epsilon; per-query max/median divergence reported.                                                                                                                                                                                                                                                                                    |
-| MIG-18 | 2                | run the rule set on the shadow ruler; observe its own fire/resolve edges at the dead-end receiver. **Incumbent-vs-shadow diff not yet proven** — see the note below this table                                                                                                                                | Tier-2 shadow ruler + one dead-end receiver; a probe rule with a short `for:` hold-down straddling its threshold. **Still missing**: a second, independent incumbent ruler with its own dead-end Alertmanager, and an MWMBR SLO rule provisioned on both sides | Hold-down honored (pending observed, and firing not reported before the provisioned pending window elapsed); firing edge captured at the one receiver with the rule's provisioned labels and an annotation rendered from the alert's own label set; resolve edge captured for the same identity, ordered after the fire edge. **Not yet asserted**: the eval-interval-quantized diff of incumbent-vs-shadow streams (false-positive / false-negative / timing-skew counts) and the MWMBR bake-window delta — both need the dual-ruler substrate above; the comparator itself is implemented and unit-tested in `test/e2e/migration/steps/tier2_alerting.go`. |
-| MIG-19 | 2                | diff CH-landed recorded series value-for-value vs the incumbent's own recorded series. **Incumbent-vs-shadow recorded-series diff not yet proven** — see the note below this table                                                                                                                            | Tier-2 ruler write-back + incumbent recorded series over overlap. **Still missing**: a second, independent incumbent ruler recording the same rule set against reference Prometheus                                                                            | Each recorded series compared sample-by-sample under the exact-parity epsilon; divergences attributed (rule translation / input parity / write-back timing-lag); any diverging recorded output is a blocker until reconciled; comparison window = what dashboards/alerts actually query. **Asserted today, against the shadow ruler's own output**: every landed sample reproduces a live re-evaluation of its source expression at the instant it was recorded, the landed samples hold the ruler's cadence with no dropped or duplicated tick, and are not all one value. **Not yet asserted**: the same diff against an incumbent's own recorded series.  |
-| MIG-20 | 1                | dedicated tolerant comparator (**not** `cerberus migrate verify`) comparing cerberus raw/MV-rollup vs the incumbent's 5m/1h downsampled counter-aware aggregates                                                                                                                                              | Thanos archetype with downsampled blocks + a delta band declared up front                                                                                                                                                                                      | Long-range panels served cheaply verified against the incumbent's downsampled aggregates within the **declared, counter-aware** band; the band is stated before the run from the aggregation math; any excursion beyond it fails.                                                                                                                                                                                                                                                                                                                                                                                                                            |
-| MIG-21 | 1 (three-signal) | Grafana-driven correlation hops (Playwright, reusing the Layer-9 crawl engine) + direct CH `trace_id` index probe                                                                                                                                                                                             | three-signal seed: metrics + logs + traces with exemplars, span-metrics/service-graph; Loki + Tempo + Grafana added to the stack                                                                                                                               | `trace_id` validated as an indexed first-class column in both logs and traces CH tables; each hop (exemplar→trace, trace→logs, logs→trace) resolves in Grafana against cerberus datasources; span-metrics + service-graph reproduced and verified equivalent; trace assembly regroups spans by `trace_id` honoring sampling/late spans.                                                                                                                                                                                                                                                                                                                      |
+| ID     | Tier(s)          | CLI                                                                                                                                                                                                                                                                                                           | Fixtures                                                                                                                                                                                                                                                                                                                                                                                                                                                                        | PASS assertion                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 |
+| ------ | ---------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| MIG-16 | 1                | `cerberus migrate verify --corpus corpus.json --ref http://prometheus:9090 --cerberus http://cerberus:9090 --ref-loki http://loki:3100 --cerberus-loki http://cerberus:9090 --ref-tempo http://tempo:3200 --cerberus-tempo http://cerberus:9090 --start -1h --end now --step 60s --json --report verify.json` | full corpus + dual-write overlap window; VM/SaaS variants add a reference-Prometheus leg fed identical data                                                                                                                                                                                                                                                                                                                                                                     | Same query/`[start,end,step]`, step-aligned, over both backends; first-diff report gives series/timestamp/ref-value/cerberus-value; **diverge count must reach zero — no expected-diff allow-list**; each divergence attributed to cerberus-bug / ingest-artifact / data-window-gap / dialect-semantics; metadata endpoints diffed too.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        |
+| MIG-17 | 1                | `cerberus migrate verify` scoped to the hotspot sub-corpus (PromQL lane; the hotspots are PromQL-shaped and so is the attribution)                                                                                                                                                                            | high-churn counters with induced pod-restart counter-resets; target-down transitions; classic + native histograms                                                                                                                                                                                                                                                                                                                                                               | `rate`/`increase`/counter-reset verified across resets and pod-restart edges; staleness/absence (`up==0`, `absent()`, `absent_over_time()`, resolve edge) verified against the documented stale-marker-vs-gap expected answer (zero diverge, not tolerated); `histogram_quantile` verified within the stated estimator epsilon; per-query max/median divergence reported.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      |
+| MIG-18 | 2                | run the SAME multi-window multi-burn-rate rule set on both rulers over one fixture; diff the two notification streams                                                                                                                                                                                         | Tier-2 dual rulers, sharing no code: the shadow (Grafana-managed alerting over cerberus) and the incumbent (reference Prometheus over its own TSDB, dispatching through its own Alertmanager), each into its OWN dead-end receiver. One in-memory fixture is rendered into both backends, driving one burning and one intact `slo` identity through an MWMBR rule pair (fast page + slow ticket, each with a long and a short window). Plus the shadow-only fire/resolve probe. | The shadow ruler's own lifecycle: hold-down honored (pending observed, and firing not reported before the provisioned pending window elapsed); firing edge captured at the one receiver with the rule's provisioned labels and an annotation rendered from the alert's own label set; resolve edge captured for the same identity, ordered after the fire edge. AND the incumbent-vs-shadow diff: matched on the alert identity both rulers declare (name plus the routing labels — substrate labels naming which ruler emitted an edge are projected away, and a MISSING routing key fails rather than shrinking the identity), **false positives and false negatives must both be zero**, the intact `slo` is asserted by name to have been paged by neither ruler, and the diff must have compared something. Timing skew is quantized to the shared evaluation interval and its MAGNITUDE bounded by a derived value — one evaluation interval plus the harness's own measured write span — rather than asserted zero: the two schedulers cannot be phase-locked (Prometheus offsets a group by hash(group, file) % interval; prom v3.11.3 has no `align_evaluation_time_on_interval`), and section 5 names that sub-interval skew as not a cerberus artifact. The MWMBR burn rate both rulers page off must hold equal across the FULL bake window under the exact-parity epsilon, not at a spot instant. |
+| MIG-19 | 2                | diff CH-landed recorded series value-for-value against the incumbent ruler's own engine at the same instants                                                                                                                                                                                                  | Tier-2 ruler write-back plus the incumbent ruler recording the SAME rule over its own copy of the source series, remote-written from the one fixture that produced the ClickHouse rows                                                                                                                                                                                                                                                                                          | Each recorded series compared sample-by-sample under the exact-parity epsilon; divergences attributed (rule translation / input parity / write-back timing-lag); any diverging recorded output is a blocker until reconciled; comparison window = what dashboards/alerts actually query. Every landed sample reproduces a live re-evaluation of its source expression at the instant it was recorded, the landed samples hold the ruler's cadence with no dropped or duplicated tick, and are not all one value. AND, with cerberus on exactly ONE side: every landed sample equals what the INCUMBENT's engine computes for the same expression at the same instant, so a cerberus evaluation bug no longer cancels out against itself; and the incumbent's OWN recorded series is held to that same engine on the incumbent's own evaluation grid, so deleting its `record:` rule fails the scenario rather than leaving the incumbent leg an ad-hoc query endpoint. The two recorded series are not compared point-for-point to each other because the two rulers never record at the same instants and cannot be made to, and over a ramped source only a tolerance wide enough to swallow the ramp would let such a comparison pass.                                                                                                                                                                      |
+| MIG-20 | 1                | dedicated tolerant comparator (**not** `cerberus migrate verify`) comparing cerberus raw/MV-rollup vs the incumbent's 5m/1h downsampled counter-aware aggregates                                                                                                                                              | Thanos archetype with downsampled blocks + a delta band declared up front                                                                                                                                                                                                                                                                                                                                                                                                       | Long-range panels served cheaply verified against the incumbent's downsampled aggregates within the **declared, counter-aware** band; the band is stated before the run from the aggregation math; any excursion beyond it fails.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              |
+| MIG-21 | 1 (three-signal) | Grafana-driven correlation hops (Playwright, reusing the Layer-9 crawl engine) + direct CH `trace_id` index probe                                                                                                                                                                                             | three-signal seed: metrics + logs + traces with exemplars, span-metrics/service-graph; Loki + Tempo + Grafana added to the stack                                                                                                                                                                                                                                                                                                                                                | `trace_id` validated as an indexed first-class column in both logs and traces CH tables; each hop (exemplar→trace, trace→logs, logs→trace) resolves in Grafana against cerberus datasources; span-metrics + service-graph reproduced and verified equivalent; trace assembly regroups spans by `trace_id` honoring sampling/late spans.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        |
 
-#### MIG-18: what is proven today, and what alert-firing PARITY still needs
+#### MIG-18: how alert-firing parity is proven
 
-MIG-18's scenario asserts the **shadow ruler's own alert lifecycle**, live
-against the Tier-2 substrate: a probe rule is armed above its threshold, the
-ruler is observed holding it `Pending` and refusing to report it firing before
-the provisioned hold-down has elapsed, the resulting notification is captured
-at the one dead-end receiver carrying the rule's provisioned labels and an
-annotation rendered from the alert's own label set, and clearing the condition
-produces a matching resolve edge ordered after the fire edge.
+MIG-18 runs two rulers that share no code and diffs what they page.
 
-What that scenario deliberately does **not** claim is *parity*: the
-incumbent-versus-shadow diff this story is ultimately about. Proving it needs
-two things the substrate does not yet stand up:
+The **shadow** leg is Grafana-managed alerting querying cerberus over
+ClickHouse, notifying its own dead-end receiver. The **incumbent** leg is
+reference Prometheus evaluating over its own TSDB and dispatching through its
+own Alertmanager into a *second* dead-end receiver. One receiver holding both
+streams would interleave them with nothing in the payload naming which ruler
+emitted an edge, so the diff would be a stream compared against itself.
 
-1. **A second, genuinely independent incumbent ruler with its own dead-end
-   Alertmanager.** `tiers/tier2-ruler` provisions one ruler (Grafana-managed
-   alerting) and one receiver. With a single notification stream there is
-   nothing to diff — a stream compared against itself is clean by
-   construction, which is a green that means nothing. Until the second leg
-   lands, the false-positive / false-negative / timing-skew counts and the
-   eval-interval quantization that defines "fired in the same evaluation" go
-   unasserted against live data.
-2. **An MWMBR SLO rule provisioned on both rulers.** The rule fixture today is
-   the kube-prometheus-stack recording rule, its `NodeCPUSaturation` threshold
-   alert, and MIG-18's own probe. None of them is a multi-window
-   multi-burn-rate rule, so there is no burn-rate delta to hold at zero across
-   a bake window.
+Both rulers are handed ONE in-memory fixture, rendered into each backend's wire
+shape — never regenerated per side, because two sample paths cannot land
+identical timestamps and a diff over inputs that differ at the sample level
+measures the seeder rather than the rulers. Both evaluate the same **MWMBR**
+rule pair: a fast-burn page and a slow-burn ticket off one 0.1% error budget,
+each requiring its long AND its short window over threshold at once. The
+fixture drives two `slo` identities through them — one burning, one intact — so
+the diff is two-sided: a shadow that misses the burn is a false negative, and
+one that pages the healthy SLO is a false positive. A single burning identity
+would only ever exercise one arm, and a ruler that paged indiscriminately would
+sail through it.
 
-The comparator both of those will use is already written and unit-tested —
-`QuantizeToEvalInterval`, `DiffAlertStreams` and `BakeWindowHoldsZero` in
-`test/e2e/migration/steps/tier2_alerting.go`, pinned by
-`steps/tier2_alerting_test.go`. Landing the missing coverage is therefore a
-substrate change (a second ruler + Alertmanager, plus the MWMBR fixture), not
-an algorithm change.
+What the diff compares is the identity both rulers *declare*: the alert name
+plus the routing labels an operator's silences and routes are written against.
+Grafana additionally stamps labels naming itself (`grafana_folder`,
+`datasource_uid`, `ref_id`); those are projected away, because they are the one
+thing the two legs are guaranteed to differ on and the one thing the diff is
+not about — comparing them would make every identity mismatch on both sides and
+the diff would be uniformly dirty. The projection is a closed, positive list and
+cannot hide a divergence: an edge MISSING a routing key fails outright rather
+than projecting to a smaller identity that happens to match, and a wrong value
+lands as a false positive plus a false negative.
 
-#### MIG-19: what is proven today, and what recorded-series PARITY still needs
+**Timing skew is bounded and measured, not asserted zero.** The two schedulers
+cannot be phase-locked: Prometheus offsets a group's evaluation by
+`hash(group, file) % interval`, Grafana ticks epoch-aligned, and prom v3.11.3
+has no `align_evaluation_time_on_interval` to turn that off. Observed live, the
+two rulers fire the same correct alert about three seconds apart, which
+straddles a 10s quantization boundary roughly as often as not — so demanding
+zero quantized skew would fail on a healthy substrate. Section 5 names that
+sub-interval difference as not a cerberus artifact. `DiffAlertStreams`
+therefore owns the verdict that cannot be blamed on scheduling (false positives
+and false negatives, both zero), and `SkewBoundHolds` owns the magnitude
+quantization throws away — bounded by one evaluation interval plus the
+harness's own measured write span, every term a property of the substrate
+rather than a slack allowance. A shadow ruler firing four minutes late is a
+real defect that quantization alone would file indistinguishably from a 3s
+phase difference.
 
-MIG-19's scenario asserts the **shadow ruler's own recorded output**, against
-the live Tier-2 substrate. For every raw row the write-back leg landed in the
-ClickHouse landing zone, it re-evaluates the recording rule's own source
-expression through cerberus at the exact instant that row was recorded, and
-requires the two to agree under `cerberus migrate verify`'s exact-parity
-epsilon. That covers every leg between the ruler's output and the landing
-zone: rule translation, write-back transport fidelity through
-`relay-prom` → `otel-collector-writeback`, and evaluation-timestamp alignment.
+Finally, the burn rate both rulers page off must hold equal across the FULL
+bake window under the exact-parity epsilon. Two rulers can agree on "fired"
+while disagreeing about the value that made them fire: a shadow computing
+twice the incumbent's burn rate still pages, and the stream diff comes back
+clean.
 
-The scenario deliberately does **not** claim *parity* in the sense this row's
-PASS cell ultimately means. cerberus is on **both sides** of the comparison —
-the recorded value came from cerberus answering the rule's query, and the
-re-evaluation is cerberus answering it again — so a cerberus evaluation bug
-would move both sides identically and cancel out. What is missing is the same
-shape MIG-18's note names: a second, genuinely independent **incumbent** ruler
-recording the same rule set against reference Prometheus, so the two recorded
-series can be diffed against each other rather than one being diffed against
-its own source. The comparator for that diff is not missing — it is the same
-exact-parity epsilon already in use here — so landing the coverage is a
-substrate change, not an algorithm change.
+#### MIG-19: how recorded-series parity is proven
 
-Two further assertions exist specifically so the verdict cannot hold by
-construction, because the value comparison alone has two silent degenerate
-modes:
+MIG-19's older assertion — every landed sample reproduces a live re-evaluation
+of its source expression at the instant it was recorded — covers the write-back
+path end to end, but has cerberus on BOTH sides: a cerberus evaluation bug moves
+the recorded value and the re-evaluation identically and cancels out.
+
+The oracle that closes it is the incumbent's engine. Reference Prometheus holds
+its own copy of the same source samples, remote-written from the one fixture
+that produced the ClickHouse rows, and every landed sample must equal what THAT
+engine computes for the same expression at the same instant, under the same
+exact-parity epsilon. cerberus now stands on exactly one side.
+
+The incumbent's own recorded series is held to that same engine on the
+incumbent's own evaluation grid. Without it the incumbent's `record:` rule could
+be deleted entirely and the scenario would still pass, since the diff above only
+ever asks the incumbent ad-hoc questions — which would leave "the incumbent
+records the same rule set" a claim about a config file nothing executes.
+
+The two recorded series are deliberately NOT compared point-for-point to each
+other. The two rulers never record at the same instants and cannot be made to,
+and the source series is a ramp, so a cross-grid comparison would diff two
+correct answers to two different questions; the only way to make it pass would
+be a tolerance wide enough to swallow the ramp, which would swallow real
+divergence with it. Routing both through one oracle at each ruler's own instants
+keeps every comparison exact.
+
+Recovering the incumbent's own recording instants needs `timestamp()`, not a
+range-query grid: Prometheus carries a sample forward across its staleness
+window, so a grid reports a value at every point whether or not an evaluation
+landed there — the same trap the shadow side avoids by reading raw ClickHouse
+rows. The recovered instant is rounded to the nearest millisecond, which is
+exact rather than a concession: Prometheus stores every sample timestamp as an
+int64 count of milliseconds, so anything finer is float noise from the wire
+encoding. Skipping that rounding made a re-evaluation land 77ns off the ruler's
+own instant and, over the ramp, showed up as a 2.7e-06 divergence against a
+1e-09 epsilon.
+
+Two further assertions exist so the verdict cannot hold by construction,
+because the value comparison alone has two silent degenerate modes:
 
 1. **A dropped evaluation is invisible to a value-only check**, because a
    sample that never landed is never compared. So the scenario also asserts a
@@ -740,7 +775,9 @@ seed interleave into a single non-monotonic series, every interleaving reads as
 a counter reset, and the recording rule's output stops meaning anything —
 observed on the first live Tier-2 run as a landed sample of `0.05` against a
 re-evaluation of `-27.8`, a negative CPU utilisation. Overlapping windows are
-fine; colliding identities are not.
+fine; colliding identities are not. The MWMBR fixture carries the same scope for
+the same reason, and both rules keep it as a grouping key so each run gets its
+own series and its own alert identity.
 
 ### CUTOVER scenarios
 
@@ -1182,18 +1219,12 @@ because a one-command re-pin is a re-pin nobody reads. The pin is hashed over
 whitespace-normalised text, so a markdownlint reflow or a column realignment is
 not a failure while a wording change is.
 
-Two known gaps between a PASS cell and what the lane executes today, recorded
-here so they are legible rather than buried:
+One known gap between a PASS cell and what the lane executes today, recorded
+here so it is legible rather than buried. (MIG-18's dual-ruler gap was the
+other; it closed when the Tier-2 substrate grew its incumbent leg — a second
+ruler, its own Alertmanager and its own receiver — and the pin moved in the same
+diff as the scenarios that earned it.)
 
-- **MIG-18.** The PASS cell demands an *incumbent-vs-shadow* diff: two
-  independently-ticking rulers over the same overlap, their Alertmanager
-  notification streams compared. The Tier-2 stack under
-  `test/e2e/migration/tiers/tier2-ruler` stands up only the **shadow** leg, so
-  the scenarios as written exercise a single-ruler lifecycle plus a
-  unit-tested comparator, not the two-ruler parity diff. The second ruler and
-  Alertmanager leg is the missing substrate. Until it lands, MIG-18's scenarios
-  under-serve their PASS cell — and the pin is what makes narrowing the cell to
-  match the implementation a visible line rather than a quiet fix.
 - **MIG-23.** The PASS cell says queries reaching back before ClickHouse's
   ingest-start "transparently route to the incumbent read path". That
   split-router is **operator-owned infrastructure outside this repository** —

--- a/test/e2e/migration/features/MIG-18.feature
+++ b/test/e2e/migration/features/MIG-18.feature
@@ -1,28 +1,40 @@
 @MIG-18 @tier2
-Feature: MIG-18 — the shadow ruler's own fire and resolve edges, observed end to end
+Feature: MIG-18 — alert-firing parity between the incumbent and shadow rulers
   As an operator I want the shadow ruler I am about to trust with paging to
   prove, against real data, that it holds an alert down for its provisioned
   pending window before it fires, that the notification it emits carries the
   labels my routes and silences are written against and an annotation rendered
-  from that alert's own label set rather than shipped as a raw template, and
-  that clearing the condition produces a matching resolve edge at the one
-  dead-end receiver — so that "it computes but never pages" is a demonstrated
-  property of the substrate rather than a claim about its configuration.
+  from that alert's own label set rather than shipped as a raw template, that
+  clearing the condition produces a matching resolve edge — and, above all,
+  that a real multi-window multi-burn-rate SLO rule reaches the SAME verdict on
+  the shadow ruler as it does on the incumbent I am migrating away from, so
+  "it pages exactly when the old stack pages" is a demonstrated property rather
+  than a claim about its configuration.
 
-  # Scope, stated honestly. This proves the SHADOW ruler's own lifecycle. The
-  # incumbent-versus-shadow DIFF the story ultimately wants — the
-  # eval-interval-quantized comparison of two independently scheduled rulers'
-  # notification streams, and the multi-window multi-burn-rate burn-rate delta
-  # held at zero across a full bake window — needs a second, genuinely
-  # independent ruler with its own dead-end Alertmanager, plus an MWMBR rule
-  # fixture provisioned on both sides. The Tier-2 substrate stands up ONE
-  # ruler and ONE receiver, so there is no second stream to diff, and one
-  # ruler diffed against itself is definitionally clean. The comparator that
-  # diff will use is real and unit-tested today
-  # (QuantizeToEvalInterval / DiffAlertStreams / BakeWindowHoldsZero in
-  # steps/tier2_alerting.go, pinned by steps/tier2_alerting_test.go); what is
-  # missing is the substrate. docs/migration-testing.md section 6's MIG-18 row
-  # records that split.
+  # Scope. The first scenario proves the shadow ruler's own lifecycle; the
+  # second is the incumbent-versus-shadow DIFF the story is ultimately about.
+  #
+  # The diff runs against two genuinely independent legs that share no code:
+  # the shadow (Grafana-managed alerting, querying cerberus over ClickHouse,
+  # notifying its own dead-end receiver) and the incumbent (reference
+  # Prometheus, evaluating over its own TSDB, dispatching through its own
+  # Alertmanager into its own dead-end receiver). Both are handed ONE fixture
+  # rendered into each backend's wire shape, so the two rulers cannot disagree
+  # because they read different data. Both evaluate the same multi-window
+  # multi-burn-rate rule set, over one SLO whose error budget is burning and
+  # one whose budget is intact — so a shadow ruler that missed the burn fails
+  # as a false negative and one that paged the healthy SLO fails as a false
+  # positive.
+  #
+  # What is deliberately NOT asserted as zero is quantized timing skew. Two
+  # independently scheduled rulers pick evaluation instants up to one interval
+  # apart and neither is late: Prometheus offsets a group by
+  # hash(group, file) % interval and Grafana ticks epoch-aligned, and the
+  # substrate cannot phase-lock them. Section 5 of docs/migration-testing.md
+  # names that skew as not a cerberus artifact. It is bounded and measured
+  # instead — by one evaluation interval plus the harness's own measured write
+  # span — which is strictly more than quantization alone can say, because
+  # quantization discards the magnitude a genuinely late ruler would show up in.
 
   Scenario: the shadow ruler holds the probe alert down, fires it with its provisioned labels and rendered annotation, then resolves it
     Given the shadow-ruler stack is live
@@ -38,3 +50,9 @@ Feature: MIG-18 — the shadow ruler's own fire and resolve edges, observed end 
     Then the dead-end receiver captured a resolving edge for the probe alert
     And the resolving edge closes the alert instance the firing edge opened
     And the resolving edge did not land before the operator cleared the probe
+    Given the same error budget burn is seeded to both rulers' backends
+    When the operator waits for both rulers to report the burn alerts firing
+    Then both rulers paged for the same alerts, with neither raising one the other did not
+    And neither ruler paged for the service whose error budget was intact
+    And the two rulers' firing edges landed within the skew two independent schedulers can differ by
+    And the burn rate the two rulers evaluate holds equal across the whole bake window

--- a/test/e2e/migration/features/MIG-19.feature
+++ b/test/e2e/migration/features/MIG-19.feature
@@ -1,10 +1,11 @@
 @MIG-19 @tier2
-Feature: MIG-19 — recording-rule output parity, sample-by-sample
+Feature: MIG-19 — recording-rule output parity against the incumbent, sample-by-sample
   As an operator I want every landed recorded-series sample compared
-  value-for-value against what its own source query says, under the same
-  exact-parity epsilon `cerberus migrate verify` uses, so a divergence in the
-  write-back path (rule translation, input parity, or write-back timing-lag)
-  is a blocker until reconciled rather than a shrug over an aggregate match.
+  value-for-value against what the incumbent ruler's own engine computes at
+  that same instant, under the same exact-parity epsilon `cerberus migrate
+  verify` uses, so a divergence in the write-back path (rule translation, input
+  parity, or write-back timing-lag) or in cerberus's own evaluation is a
+  blocker until reconciled rather than a shrug over an aggregate match.
 
   # Scope, stated honestly.
   #
@@ -15,16 +16,22 @@ Feature: MIG-19 — recording-rule output parity, sample-by-sample
   # transport fidelity and evaluation-timestamp alignment — every leg between
   # the ruler's output and the landing zone.
   #
-  # It does NOT cover what section 6's PASS cell ultimately wants: a diff
-  # against the INCUMBENT's own recorded series. cerberus is on both sides of
-  # this comparison, because the Tier-2 substrate stands up ONE ruler; a
-  # cerberus evaluation bug that affected the recording rule would affect the
-  # re-evaluation identically and cancel out. Closing that gap needs the same
-  # missing substrate MIG-18's note names — a second, genuinely independent
-  # incumbent ruler recording the same rule set against reference Prometheus —
-  # and the value comparator itself is already the one `cerberus migrate
-  # verify` uses, so it is substrate that is missing, not comparison logic.
-  # docs/migration-testing.md section 6's MIG-19 note records the split.
+  # That comparison alone would have cerberus on BOTH sides, so a cerberus
+  # evaluation bug would move the recorded value and the re-evaluation
+  # identically and cancel out. The last two steps close that: the oracle is
+  # the INCUMBENT ruler — reference Prometheus, evaluating the same expression
+  # over its own copy of the same samples, remote-written from the one fixture
+  # that produced the ClickHouse rows — so cerberus stands on exactly one side.
+  #
+  # The incumbent's OWN recorded series is checked against that same engine on
+  # the incumbent's own grid, which is what stops the incumbent leg degrading
+  # into a query endpoint: delete its `record:` rule and that step fails. The
+  # two recorded series are not compared point-for-point to each other because
+  # the two rulers never record at the same instants and cannot be made to
+  # (Prometheus offsets a group by hash(group, file) % interval, Grafana ticks
+  # epoch-aligned), and the source series is a ramp — so a cross-grid
+  # comparison would diff two correct answers to two different questions, and
+  # only a tolerance wide enough to swallow the ramp would let it pass.
   #
   # Two assertions guard against a verdict that holds by construction. The
   # cadence check is a count oracle: a value-only comparison cannot see an
@@ -41,3 +48,5 @@ Feature: MIG-19 — recording-rule output parity, sample-by-sample
     Then the landed sample count matches the ruler's evaluation cadence across the window they span
     And the landed samples do not all carry the same value
     And every landed sample matches a live re-evaluation of the recording rule's source query within the exact-parity epsilon
+    And the incumbent ruler recorded the same rule over its own copy of the source data
+    And every landed sample matches what the incumbent ruler's engine computes at the same instant

--- a/test/e2e/migration/lib/live_tier2.go
+++ b/test/e2e/migration/lib/live_tier2.go
@@ -25,6 +25,12 @@ const (
 	EnvTier2CerberusURL = "TIER2_CERBERUS_URL"
 	EnvTier2GrafanaURL  = "TIER2_GRAFANA_URL"
 	EnvTier2DeadEndURL  = "TIER2_DEADEND_URL"
+	// The incumbent leg MIG-18/MIG-19 diff the shadow against: its ruler
+	// (reference Prometheus, both the remote-write target the harness seeds
+	// and the query endpoint its engine answers on) and its own dead-end
+	// receiver, which is a DIFFERENT container from the shadow's.
+	EnvTier2IncumbentURL        = "TIER2_INCUMBENT_URL"
+	EnvTier2IncumbentDeadEndURL = "TIER2_INCUMBENT_DEADEND_URL"
 )
 
 // defaultTier2* mirror the published port map in
@@ -39,6 +45,9 @@ const (
 	defaultTier2CerberusURL = "http://127.0.0.1:27080"
 	defaultTier2GrafanaURL  = "http://127.0.0.1:27400"
 	defaultTier2DeadEndURL  = "http://127.0.0.1:27450"
+
+	defaultTier2IncumbentURL        = "http://127.0.0.1:27460"
+	defaultTier2IncumbentDeadEndURL = "http://127.0.0.1:27451"
 )
 
 // Tier2Endpoints is the live Tier-2 stack a scenario drives assertions
@@ -51,6 +60,17 @@ const (
 type Tier2Endpoints struct {
 	CHAddr, CHDatabase, CHUsername, CHPassword string
 	CerberusURL, GrafanaURL, DeadEndURL        string
+	// IncumbentURL is the incumbent ruler's Prometheus API: the remote-write
+	// target the harness seeds with the SAME samples it writes to ClickHouse,
+	// and the engine MIG-19 re-evaluates a rule expression against so that
+	// cerberus stands on exactly one side of that comparison.
+	//
+	// IncumbentDeadEndURL is the incumbent's own notification sink. It is a
+	// separate container from DeadEndURL on purpose: one receiver holding both
+	// rulers' streams would interleave them with nothing in the payload naming
+	// which ruler emitted an edge, and MIG-18's diff would then be a stream
+	// compared against itself.
+	IncumbentURL, IncumbentDeadEndURL string
 }
 
 // tier2Vars pairs every env var LoadTier2Endpoints reads with the struct
@@ -68,6 +88,11 @@ var tier2Vars = []struct {
 	{EnvTier2CerberusURL, defaultTier2CerberusURL, func(e *Tier2Endpoints) *string { return &e.CerberusURL }},
 	{EnvTier2GrafanaURL, defaultTier2GrafanaURL, func(e *Tier2Endpoints) *string { return &e.GrafanaURL }},
 	{EnvTier2DeadEndURL, defaultTier2DeadEndURL, func(e *Tier2Endpoints) *string { return &e.DeadEndURL }},
+	{EnvTier2IncumbentURL, defaultTier2IncumbentURL, func(e *Tier2Endpoints) *string { return &e.IncumbentURL }},
+	{
+		EnvTier2IncumbentDeadEndURL, defaultTier2IncumbentDeadEndURL,
+		func(e *Tier2Endpoints) *string { return &e.IncumbentDeadEndURL },
+	},
 }
 
 // LoadTier2Endpoints reads the Tier-2 env vars the harness needs, falling
@@ -96,6 +121,8 @@ func (e Tier2Endpoints) RequireLive(ctx context.Context) error {
 		{"cerberus", e.CerberusURL + "/readyz"},
 		{"grafana", e.GrafanaURL + "/api/health"},
 		{"dead-end receiver", e.DeadEndURL + "/healthz"},
+		{"incumbent ruler", e.IncumbentURL + "/-/ready"},
+		{"incumbent dead-end receiver", e.IncumbentDeadEndURL + "/healthz"},
 	}
 	for _, c := range checks {
 		if err := seed.WaitHTTPOK(ctx, c.url, tier2LiveProbeTimeout); err != nil {

--- a/test/e2e/migration/pass-assertions.pin.json
+++ b/test/e2e/migration/pass-assertions.pin.json
@@ -1,6 +1,6 @@
 {
   "schema_version": 1,
-  "why": "docs/migration-testing.md section 6 IS the ratchet's anchor, and it is editable in the same commit as the code it anchors \u2014 so narrowing a PASS cell has always been a valid route to \"full coverage\". This pin does not forbid narrowing; a spec legitimately evolves. It forbids narrowing SILENTLY: MODE=verify fails until the hash is updated here, which puts the weakening on its own reviewed line in the diff instead of leaving it a side effect of the commit that implements the narrower thing. There is deliberately no regeneration command \u2014 the failure prints the new hash to paste.",
+  "why": "docs/migration-testing.md section 6 IS the ratchet's anchor, and it is editable in the same commit as the code it anchors — so narrowing a PASS cell has always been a valid route to \"full coverage\". This pin does not forbid narrowing; a spec legitimately evolves. It forbids narrowing SILENTLY: MODE=verify fails until the hash is updated here, which puts the weakening on its own reviewed line in the diff instead of leaving it a side effect of the commit that implements the narrower thing. There is deliberately no regeneration command — the failure prints the new hash to paste.",
   "algorithm": "sha256",
   "normalization": "the cell is trimmed and every run of whitespace is collapsed to one space before hashing, so a markdownlint reflow or a column realignment is not a failure but a wording change is",
   "assertions": {
@@ -74,11 +74,11 @@
     },
     "MIG-18": {
       "tiers": "2",
-      "sha256": "21575c4db07d89906b8a93c7ca2baa3239ebe0ebe2af6cb1e40fbf214296cb3a"
+      "sha256": "58c627ac5a565ed79a29e9cd6c04a1d35dc9517d1eb72bc1bd3c94d35b221624"
     },
     "MIG-19": {
       "tiers": "2",
-      "sha256": "8f518b75262f73aa27c8d0457ea0256dd464d2db6ef758cf80e852785f4f9c48"
+      "sha256": "c13a75baee6adb12625bcd030f120e4dde8fc40d37829d4ab5485f9a63c7d1f9"
     },
     "MIG-20": {
       "tiers": "1",

--- a/test/e2e/migration/steps/then_ruler.go
+++ b/test/e2e/migration/steps/then_ruler.go
@@ -545,15 +545,32 @@ func fetchJSONInto(ctx context.Context, url string, out any) error {
 		return err
 	}
 	defer func() { _ = resp.Body.Close() }()
-	body, err := io.ReadAll(io.LimitReader(resp.Body, rulerErrBodyLimit))
+	// The SUCCESS path decodes the FULL body; only the error path below
+	// truncates. Reading through the error-message limit instead silently
+	// clipped the JSON once the response outgrew it, and `json.Unmarshal` then
+	// reported "unexpected end of JSON input" — a decode failure that reads as
+	// a broken ruler rather than as a harness limit. Grafana's rule listing
+	// grows with every provisioned rule and every live alert instance, so the
+	// limit was always going to be crossed; the Tier-2 MWMBR groups crossed it.
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return fmt.Errorf("read %s body: %w", url, err)
 	}
 	if resp.StatusCode != http.StatusOK {
-		return fmt.Errorf("GET %s returned %d: %s", url, resp.StatusCode, string(body))
+		return fmt.Errorf("GET %s returned %d: %s", url, resp.StatusCode, truncateBody(body))
 	}
 	if err := json.Unmarshal(body, out); err != nil {
-		return fmt.Errorf("decode %s body %q: %w", url, string(body), err)
+		return fmt.Errorf("decode %s body %q: %w", url, truncateBody(body), err)
 	}
 	return nil
+}
+
+// truncateBody caps how much of a body an error message quotes, so a large
+// failing response does not flood a scenario failure. It is used ONLY in
+// failure messages — never on the path that decodes a successful response.
+func truncateBody(body []byte) string {
+	if len(body) <= rulerErrBodyLimit {
+		return string(body)
+	}
+	return string(body[:rulerErrBodyLimit]) + "…(truncated)"
 }

--- a/test/e2e/migration/steps/tier2_alerting.go
+++ b/test/e2e/migration/steps/tier2_alerting.go
@@ -38,22 +38,15 @@ import (
 //     alert instance the firing edge opened, at an evaluation that could have
 //     seen the clearing.
 //
-// What it does NOT assert, and why: MIG-18's story ultimately wants alert
-// firing PARITY — the eval-interval-quantized diff of an INCUMBENT ruler's
-// notification stream against the shadow's, and an MWMBR SLO burn-rate delta
-// held at zero across a full bake window. Both need a second, genuinely
-// independent ruler with its own dead-end Alertmanager (the story's own
-// fixture line in docs/migration-testing.md section 6: "Tier-2 dual rulers +
-// dead-end Alertmanagers"), and an MWMBR rule fixture provisioned on both
-// sides. This substrate stands up ONE ruler and ONE receiver, so there is no
-// second stream to diff — one ruler diffed against itself is definitionally
-// clean and would prove nothing.
+// The incumbent-VERSUS-shadow diff those edges feed lives in tier2_parity.go:
+// the Tier-2 substrate now stands up a second, genuinely independent ruler
+// (reference Prometheus, its own Alertmanager, its own dead-end receiver) and
+// an MWMBR rule pair provisioned on both sides, so the comparator below is
+// driven against two real streams rather than being unit-tested in isolation.
 //
-// The comparator for that future diff is nonetheless real, pure and
-// unit-tested here and now — QuantizeToEvalInterval / DiffAlertStreams /
-// BakeWindowHoldsZero, pinned by tier2_alerting_test.go — so landing the
-// incumbent leg is a substrate change, not an algorithm change. Section 6's
-// MIG-18 row records exactly that split.
+// The pieces this file owns are the pure ones: QuantizeToEvalInterval,
+// DiffAlertStreams, ProjectAlertLabels, SkewBoundHolds and BakeWindowHoldsZero,
+// each pinned by tier2_alerting_test.go and tier2_parity_test.go.
 
 // AlertEvent is one fire or resolve edge from a ruler's notification stream.
 type AlertEvent struct {
@@ -203,6 +196,130 @@ func BakeWindowHoldsZero(samples []MWMBRSample, tolerance float64) error {
 		}
 	}
 	return nil
+}
+
+// ParityLabelKeys is the closed set of label keys two rulers' notification
+// streams are compared on: the alert's name plus the routing keys an
+// operator's existing Alertmanager silences and routes are actually written
+// against. MIG-18's fixture provisions every one of them on BOTH sides.
+//
+// This is a positive, closed list of what identity MEANS across two
+// implementations — not a list of differences to forgive. The distinction is
+// load-bearing, because the alternative reading would make it an allow-list:
+//
+//   - It cannot hide a divergence. ProjectAlertLabels FAILS on an event that
+//     is missing any key, so a ruler that dropped `severity` or `slo` breaks
+//     the run rather than quietly comparing a smaller identity. A wrong VALUE
+//     on any key changes the identity and lands as a false positive plus a
+//     false negative.
+//   - What it excludes is not a disagreement at all. Grafana stamps
+//     `grafana_folder` (and, on some rule shapes, `datasource_uid` /
+//     `ref_id`) onto every instance it emits; those name which ruler produced
+//     the notification, which is the one thing the two legs are GUARANTEED to
+//     differ on and the one thing the diff is not about. Comparing them would
+//     make every identity mismatch on both sides at once, so the diff would
+//     be uniformly dirty and could never report a real divergence — a check
+//     that always fails is as useless as one that always passes.
+var ParityLabelKeys = []string{"alertname", mig18SeverityKey, mwmbrBurnRateKey, mwmbrSLOKey}
+
+// ProjectAlertLabels narrows every event's label set to keys, so two rulers'
+// streams are compared on the identity they both declare rather than on the
+// substrate labels each adds about itself. See ParityLabelKeys.
+//
+// A missing key is an error rather than an empty value: an event that never
+// carried `severity` would otherwise project to the same identity as one that
+// carried it, and a ruler silently dropping a routing key — which is exactly
+// the breakage that re-routes somebody's page — would read as agreement.
+func ProjectAlertLabels(events []AlertEvent, keys []string) ([]AlertEvent, error) {
+	out := make([]AlertEvent, 0, len(events))
+	for _, e := range events {
+		projected := make(map[string]string, len(keys))
+		for _, k := range keys {
+			v, ok := e.Labels[k]
+			if !ok {
+				return nil, fmt.Errorf(
+					"the %s edge for %q carries no %q label, so it cannot be compared against the other ruler's "+
+						"stream on that key; it carries %v",
+					e.Status, e.RuleName, k, e.Labels,
+				)
+			}
+			projected[k] = v
+		}
+		e.Labels = projected
+		out = append(out, e)
+	}
+	return out, nil
+}
+
+// SkewBoundHolds asserts that every alert edge BOTH rulers emitted landed
+// within bound of its counterpart.
+//
+// This is the assertion QuantizeToEvalInterval cannot make on its own, and the
+// two are complements rather than alternatives. Quantization answers "did they
+// fire at the same evaluation", which is the right question but a lossy
+// measurement: two rulers firing 2s apart still straddle a bucket boundary
+// roughly as often as not, because Prometheus offsets a group's evaluation by
+// hash(group, file) % interval and Grafana ticks epoch-aligned — a phase
+// difference the substrate cannot remove (prom v3.11.3 has no
+// `align_evaluation_time_on_interval`). So DiffAlertStreams owns the verdict
+// that matters and cannot be blamed on scheduling — did each ruler fire the
+// same alerts at all — and this owns the magnitude, which quantization throws
+// away: a shadow ruler firing four minutes late is a real defect that
+// DiffAlertStreams would file indistinguishably from a 2s phase difference.
+//
+// Absence is deliberately NOT this function's verdict. An identity present on
+// one side only is a false positive or a false negative, which DiffAlertStreams
+// already counts; reporting it here too would double-count one defect. What
+// this refuses is a vacuous pass: if no identity appears on both sides there is
+// no skew to bound, and a silent success would claim a comparison that never
+// happened.
+func SkewBoundHolds(incumbent, shadow []AlertEvent, bound time.Duration) error {
+	incBy, shadowBy := earliestByKey(incumbent), earliestByKey(shadow)
+	var compared int
+	for key, incAt := range incBy {
+		shAt, ok := shadowBy[key]
+		if !ok {
+			continue
+		}
+		compared++
+		if skew := absDuration(incAt.Sub(shAt)); skew > bound {
+			return fmt.Errorf(
+				"the incumbent ruler emitted %s at %s and the shadow ruler at %s — %s apart, beyond the %s bound "+
+					"two rulers on one evaluation cadence can differ by; that is a real scheduling or evaluation "+
+					"divergence, not the sub-interval phase difference between two independent schedulers",
+				key, incAt, shAt, skew, bound,
+			)
+		}
+	}
+	if compared == 0 {
+		return errors.New(
+			"no alert edge was emitted by both rulers, so no skew was measured; a bound asserted over an empty " +
+				"set of pairs proves nothing about either ruler",
+		)
+	}
+	return nil
+}
+
+// earliestByKey reduces a stream to the FIRST instant each alert edge landed
+// at. A ruler re-notifies an unchanged alert, and Alertmanager re-delivers on
+// its own timer, so one identity can appear several times; the opening edge is
+// the one the two sides' schedules are comparable on.
+func earliestByKey(events []AlertEvent) map[string]time.Time {
+	out := make(map[string]time.Time, len(events))
+	for _, e := range events {
+		if at, ok := out[alertEventKey(e)]; !ok || e.At.Before(at) {
+			out[alertEventKey(e)] = e.At
+		}
+	}
+	return out
+}
+
+// absDuration is |d|.
+func absDuration(d time.Duration) time.Duration {
+	if d < 0 {
+		return -d
+	}
+	return d
 }
 
 // grafanaWebhookAlert is the subset of Grafana's (Alertmanager-compatible)

--- a/test/e2e/migration/steps/tier2_parity.go
+++ b/test/e2e/migration/steps/tier2_parity.go
@@ -227,7 +227,7 @@ func (w *World) givenMwmbrSeededBothSides() error {
 	ctx, cancel := context.WithTimeout(context.Background(), mwmbrSeedBudget)
 	defer cancel()
 
-	now := time.Now().UTC().Truncate(time.Second)
+	now := tier2DualSeedAnchor(time.Now())
 	start, end := now.Add(-mwmbrSeedHistory), now.Add(mwmbrSeedFuture)
 	fixture := mwmbrFixture(w.tier2SeedScope, start, end, now.Add(-mwmbrBurstStart))
 

--- a/test/e2e/migration/steps/tier2_parity.go
+++ b/test/e2e/migration/steps/tier2_parity.go
@@ -1,0 +1,668 @@
+package steps
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/cucumber/godog"
+
+	"github.com/tsouza/cerberus/internal/migrateverify"
+	"github.com/tsouza/cerberus/test/e2e/migration/lib"
+	"github.com/tsouza/cerberus/test/e2e/migration/seed"
+)
+
+// This file holds MIG-18's incumbent-VERSUS-shadow diff: the half its PASS
+// cell has always demanded and the substrate could not serve until the Tier-2
+// stack grew a second ruler.
+//
+// The shape, end to end:
+//
+//  1. One in-memory fixture is written to BOTH backends — ClickHouse (which
+//     the shadow ruler reaches through cerberus) and the incumbent ruler's own
+//     TSDB (over remote write). Both sides are rendered from the same
+//     seed.Fixture, so the two rulers cannot disagree because they read
+//     different numbers; only because their engines answered differently.
+//  2. Both rulers evaluate the SAME multi-window multi-burn-rate rule set —
+//     tiers/tier2-ruler/grafana/alerting/rules.yaml's `migration.mwmbr` group
+//     and tiers/tier2-ruler/incumbent/incumbent-rules.yml's, pinned equal by
+//     tier2_parity_test.go — and dispatch through their OWN notifier into
+//     their OWN dead-end receiver.
+//  3. The two captured streams are diffed.
+//
+// The fixture drives two `slo` identities through those rules: one whose error
+// budget is burning (both rulers must page it, on both burn tiers) and one
+// whose budget is intact (neither may page it at all). That is what makes the
+// diff two-sided. A single burning identity would only ever exercise
+// DiffAlertStreams's false-NEGATIVE arm — the shadow failing to fire — and a
+// shadow ruler that paged indiscriminately would sail through. The intact
+// identity is the false-POSITIVE arm, and it is asserted by name as well as by
+// count, because "cerberus made an alert fire that should not have" is the
+// migration failure an operator feels first.
+//
+// What is asserted, and why each is separate:
+//
+//   - zero false positives and zero false negatives (DiffAlertStreams). This
+//     is the verdict that cannot be blamed on scheduling.
+//   - the firing edges landed within a derived bound of each other
+//     (SkewBoundHolds). Quantization defines "the same evaluation" but throws
+//     the magnitude away; this keeps it.
+//   - the burn-rate delta holds zero across the FULL bake window
+//     (BakeWindowHoldsZero), not at a spot instant — a burn-rate rule
+//     evaluated continuously can disagree once and still page wrongly.
+
+// The MWMBR fixture, mirrored from the two rule files rather than invented
+// here. tier2_parity_test.go reads BOTH files and fails offline when any of
+// these drifts on either side, so a one-sided edit cannot reach a live run and
+// silently turn a real diff into a comparison of two different rules.
+const (
+	mwmbrRequestsMetric = "cerberus_migration_slo_requests_total"
+	mwmbrErrorsMetric   = "cerberus_migration_slo_errors_total"
+	mwmbrGroup          = "migration.mwmbr"
+	mwmbrFolder         = "migration-lane"
+	mwmbrServiceName    = "migration-lane"
+
+	// mwmbrSLOKey is the dimension the rules aggregate by, so each SLO is its
+	// own alert identity; mwmbrBurnRateKey is the label separating the two burn
+	// tiers, so the fast page and the slow ticket are two identities rather
+	// than one alert seen twice.
+	mwmbrSLOKey      = "slo"
+	mwmbrBurnRateKey = "burn_rate"
+
+	// mwmbrBurningSLO's error budget is burning hard enough to trip BOTH burn
+	// tiers; mwmbrIntactSLO serves no errors at all and must trip neither.
+	mwmbrBurningSLO = "checkout"
+	mwmbrIntactSLO  = "search"
+
+	mwmbrFastAlertName = "MigrationSLOFastBurn"
+	mwmbrSlowAlertName = "MigrationSLOSlowBurn"
+	mwmbrFastSeverity  = "critical"
+	mwmbrSlowSeverity  = "warning"
+	mwmbrFastBurnLabel = "fast"
+	mwmbrSlowBurnLabel = "slow"
+
+	// mwmbrHoldDown must equal both rule sets' `for:`, and mwmbrEvalInterval
+	// both groups' `interval:`. The latter is the shared evaluation cadence
+	// QuantizeToEvalInterval floors edges to and the term the skew bound is
+	// built from.
+	mwmbrHoldDown     = 30 * time.Second
+	mwmbrEvalInterval = 10 * time.Second
+)
+
+// The error budget and burn factors the rules' thresholds are the arithmetic
+// of: a 99.9% objective leaves a 0.001 budget, and the two standard
+// multi-burn-rate factors turn it into the two thresholds both rule files
+// spell out (14.4 * 0.001 and 6 * 0.001).
+//
+// They are named here rather than only in the YAML because the bake-window
+// check reports a BURN RATE — the error ratio expressed in budgets-per-window
+// — and dividing by the budget is what makes the number it prints the same
+// quantity an SLO runbook talks about.
+const (
+	mwmbrErrorBudget    = 0.001
+	mwmbrFastBurnFactor = 14.4
+	mwmbrSlowBurnFactor = 6.0
+
+	// The window pairs, longest first. Each alert requires its long AND its
+	// short window over threshold at once; the long window is what stops a
+	// spike paging, the short one what lets the alert clear promptly.
+	mwmbrFastLongWindow  = 5 * time.Minute
+	mwmbrFastShortWindow = time.Minute
+	mwmbrSlowLongWindow  = 15 * time.Minute
+	mwmbrSlowShortWindow = 3 * time.Minute
+)
+
+// Seed geometry.
+//
+// The window reaches into the FUTURE on purpose. Both rulers evaluate at
+// wall-clock "now", and a fixture that stopped at the seeding instant would
+// decay out of the rules' own rate windows within a minute — the alert would
+// have to fire, be delivered through two notification policies, and be
+// observed, all inside the sliver of time before its own input aged away. A
+// window running past the observation period instead keeps the condition
+// continuously true, so the scenario measures the rulers rather than a race
+// against its own fixture.
+const (
+	mwmbrSeedHistory = 20 * time.Minute
+	mwmbrSeedFuture  = 5 * time.Minute
+	// mwmbrSeedStep is the sample cadence on both sides. It is the SAME
+	// instants on both backends, because both are rendered from one fixture —
+	// the property that makes a value comparison meaningful at all.
+	mwmbrSeedStep = 15 * time.Second
+	// mwmbrBurstStart is how far before the seeding instant the burning SLO
+	// starts serving errors. It must be long enough that the LONGEST window
+	// (mwmbrSlowLongWindow) already carries enough error mass to clear the
+	// slow tier's threshold at the moment the rulers first look, so neither
+	// ruler has to wait out a window before it can fire.
+	mwmbrBurstStart = 2 * time.Minute
+	// The rates the fixture serves, in events per second. The burning SLO's
+	// error ratio inside the short window is mwmbrErrorRate/mwmbrRequestRate,
+	// an order of magnitude above the fast tier's threshold, so arming is
+	// unambiguous rather than borderline — tier2_parity_test.go pins that
+	// margin against the thresholds so a future re-tuning that quietly stopped
+	// tripping the rules fails in the unit lane.
+	mwmbrRequestRate = 10.0
+	mwmbrErrorRate   = 1.0
+)
+
+// The bake window: the span the burn-rate delta must hold zero across, and how
+// finely it is sampled. Both are anchored in SEEDED history rather than to
+// wall-clock "now", so the check evaluates the same instants on every run and
+// a slow CI machine cannot change what it compared.
+const (
+	mwmbrBakeWindow = 2 * time.Minute
+	mwmbrBakeStep   = 15 * time.Second
+)
+
+// Budgets. Each bounds a poll loop and fails its step when it expires.
+const (
+	// mwmbrFiringWait covers both rulers' next tick, the full hold-down, and
+	// each notification policy's group_wait, plus a couple of missed ticks.
+	mwmbrFiringWait = 3 * time.Minute
+	mwmbrPoll       = 2 * time.Second
+	mwmbrSeedBudget = 60 * time.Second
+	mwmbrQueryWait  = 60 * time.Second
+)
+
+// tier2ParityState is the MIG-18 diff's accumulated state.
+type tier2ParityState struct {
+	// seedStart/seedEnd bound the fixture window; bakeEnd is the last instant
+	// the bake-window sampler evaluates at.
+	seedStart, seedEnd time.Time
+	// seedVisibilitySpan is the wall-clock time it took to write BOTH
+	// backends. It is the second term of the skew bound: the two rulers cannot
+	// have seen the fixture at the same instant if the two writes did not land
+	// at the same instant, and that difference is a property of this harness
+	// rather than of either ruler. Measured, never assumed — an assumed
+	// constant here would be a tolerance.
+	seedVisibilitySpan time.Duration
+	// incumbent and shadow are the firing edges each ruler's own receiver
+	// captured, already projected onto ParityLabelKeys.
+	incumbent, shadow []AlertEvent
+}
+
+// registerTier2ParitySteps binds MIG-18's incumbent-versus-shadow diff.
+func (w *World) registerTier2ParitySteps(ctx *godog.ScenarioContext) {
+	ctx.Step(
+		`^the same error budget burn is seeded to both rulers' backends$`,
+		w.givenMwmbrSeededBothSides,
+	)
+	ctx.Step(
+		`^the operator waits for both rulers to report the burn alerts firing$`,
+		w.whenMwmbrBothRulersFire,
+	)
+	ctx.Step(
+		`^both rulers paged for the same alerts, with neither raising one the other did not$`,
+		w.thenMwmbrStreamsAgree,
+	)
+	ctx.Step(
+		`^neither ruler paged for the service whose error budget was intact$`,
+		w.thenMwmbrIntactSLONeverPaged,
+	)
+	ctx.Step(
+		`^the two rulers' firing edges landed within the skew two independent schedulers can differ by$`,
+		w.thenMwmbrSkewBounded,
+	)
+	ctx.Step(
+		`^the burn rate the two rulers evaluate holds equal across the whole bake window$`,
+		w.thenMwmbrBakeWindowHoldsZero,
+	)
+}
+
+// givenMwmbrSeededBothSides writes ONE fixture to both backends: ClickHouse,
+// which the shadow ruler reads through cerberus, and the incumbent ruler's own
+// TSDB over remote write.
+//
+// One fixture, two renderings — never two generators. seed.Fixture's own
+// doc comment states the reason and it is the whole basis of this scenario: two
+// independent sample paths cannot land identical timestamps, and a diff over
+// inputs that differ at the sample level measures the seeder rather than the
+// rulers.
+func (w *World) givenMwmbrSeededBothSides() error {
+	if err := w.requireTier2Live(); err != nil {
+		return err
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), mwmbrSeedBudget)
+	defer cancel()
+
+	now := time.Now().UTC().Truncate(time.Second)
+	start, end := now.Add(-mwmbrSeedHistory), now.Add(mwmbrSeedFuture)
+	fixture := mwmbrFixture(w.tier2SeedScope, start, end, now.Add(-mwmbrBurstStart))
+
+	conn, err := w.tier2.DialCH(ctx)
+	if err != nil {
+		return fmt.Errorf("migration harness: dial clickhouse to seed the burn-rate fixture: %w", err)
+	}
+	defer func() { _ = conn.Close() }()
+
+	// The span is measured across BOTH writes rather than around each, because
+	// what the skew bound needs is the outside edge of "when could each ruler
+	// first have seen this fixture".
+	writeFrom := time.Now().UTC()
+	if err := seed.InsertFixture(ctx, conn, fixture); err != nil {
+		return fmt.Errorf("migration harness: seed the burn-rate fixture into clickhouse: %w", err)
+	}
+	if err := seed.WriteSeries(ctx, w.tier2.IncumbentURL, fixture.PromSeries()); err != nil {
+		return fmt.Errorf(
+			"migration harness: remote-write the burn-rate fixture to the incumbent ruler at %s: %w",
+			w.tier2.IncumbentURL, err,
+		)
+	}
+	w.tier2Parity = tier2ParityState{
+		seedStart:          start,
+		seedEnd:            end,
+		seedVisibilitySpan: time.Since(writeFrom),
+	}
+	return nil
+}
+
+// mwmbrFixture builds the two counters, for both SLO identities, over
+// [start, end]: requests at a constant rate for both, and errors only for the
+// burning SLO and only from burstFrom onward. The intact SLO's error counter
+// exists and stays flat rather than being omitted — an ABSENT counter would
+// make the rules' ratio a division by a missing series, so the intact identity
+// would go unpaged for the wrong reason (no data) instead of the right one
+// (a healthy error budget).
+func mwmbrFixture(scope string, start, end, burstFrom time.Time) seed.Fixture {
+	flat := func(rate float64) func(time.Time) float64 {
+		return func(time.Time) float64 { return rate }
+	}
+	burst := func(t time.Time) float64 {
+		if t.Before(burstFrom) {
+			return 0
+		}
+		return mwmbrErrorRate
+	}
+	return seed.Fixture{Counter: []seed.MetricSeries{
+		mwmbrCounter(mwmbrRequestsMetric, mwmbrBurningSLO, scope, start, end, flat(mwmbrRequestRate)),
+		mwmbrCounter(mwmbrRequestsMetric, mwmbrIntactSLO, scope, start, end, flat(mwmbrRequestRate)),
+		mwmbrCounter(mwmbrErrorsMetric, mwmbrBurningSLO, scope, start, end, burst),
+		mwmbrCounter(mwmbrErrorsMetric, mwmbrIntactSLO, scope, start, end, flat(0)),
+	}}
+}
+
+// mwmbrCounter accumulates one monotonic counter across [start, end], adding
+// ratePerSec(t) events per second over each step.
+func mwmbrCounter(name, slo, scope string, start, end time.Time, ratePerSec func(time.Time) float64) seed.MetricSeries {
+	samples := make([]seed.Sample, 0, int(end.Sub(start)/mwmbrSeedStep)+1)
+	total := 0.0
+	for t := start; !t.After(end); t = t.Add(mwmbrSeedStep) {
+		samples = append(samples, seed.Sample{Time: t, Value: total})
+		total += ratePerSec(t) * mwmbrSeedStep.Seconds()
+	}
+	return seed.MetricSeries{
+		MetricName:  name,
+		ServiceName: mwmbrServiceName,
+		Attributes:  map[string]string{mwmbrSLOKey: slo, tier2SeedScopeLabel: scope},
+		Samples:     samples,
+	}
+}
+
+// mwmbrAlertNames is the set of alert names this scenario compares — both burn
+// tiers, so a shadow ruler that got one right and the other wrong fails.
+func mwmbrAlertNames() []string { return []string{mwmbrFastAlertName, mwmbrSlowAlertName} }
+
+// whenMwmbrBothRulersFire polls BOTH receivers until each has captured a
+// firing edge for every burn tier, then projects both streams onto the
+// identity the two rulers share.
+//
+// Both sides must arrive before the budget expires, and the failure names
+// which side is short. That asymmetry matters: "the shadow never fired" and
+// "the incumbent never fired" are a cerberus bug and a substrate bug
+// respectively, and a single "no edges" message would conflate them.
+func (w *World) whenMwmbrBothRulersFire() error {
+	if err := w.requireTier2Live(); err != nil {
+		return err
+	}
+	if w.tier2Parity.seedEnd.IsZero() {
+		return fmt.Errorf("the burn-rate fixture has not been seeded; the scenario must seed it first")
+	}
+	ctx := context.Background()
+	deadline := time.Now().Add(mwmbrFiringWait)
+	var last error
+	for {
+		incumbent, incErr := fetchAlertEvents(ctx, w.tier2.IncumbentDeadEndURL, mwmbrAlertNames())
+		shadow, shErr := fetchAlertEvents(ctx, w.tier2.DeadEndURL, mwmbrAlertNames())
+		switch {
+		case incErr != nil:
+			last = fmt.Errorf("read the incumbent ruler's captured stream: %w", incErr)
+		case shErr != nil:
+			last = fmt.Errorf("read the shadow ruler's captured stream: %w", shErr)
+		default:
+			incFiring := filterBySeedScope(filterByStatus(incumbent, alertStatusFiring), w.tier2SeedScope)
+			shFiring := filterBySeedScope(filterByStatus(shadow, alertStatusFiring), w.tier2SeedScope)
+			incMissing := mwmbrMissingAlertNames(incFiring)
+			shMissing := mwmbrMissingAlertNames(shFiring)
+			if len(incMissing) == 0 && len(shMissing) == 0 {
+				return w.captureMwmbrStreams(incFiring, shFiring)
+			}
+			last = fmt.Errorf(
+				"the incumbent ruler has not yet paged %v and the shadow ruler has not yet paged %v",
+				incMissing, shMissing,
+			)
+		}
+		if time.Now().After(deadline) {
+			return fmt.Errorf("both rulers did not report the burn alerts firing within %s: %w", mwmbrFiringWait, last)
+		}
+		time.Sleep(mwmbrPoll)
+	}
+}
+
+// captureMwmbrStreams projects both streams onto the shared identity and
+// stores them for the Then steps.
+func (w *World) captureMwmbrStreams(incumbent, shadow []AlertEvent) error {
+	projectedInc, err := ProjectAlertLabels(incumbent, ParityLabelKeys)
+	if err != nil {
+		return fmt.Errorf("the incumbent ruler's stream: %w", err)
+	}
+	projectedShadow, err := ProjectAlertLabels(shadow, ParityLabelKeys)
+	if err != nil {
+		return fmt.Errorf("the shadow ruler's stream: %w", err)
+	}
+	w.tier2Parity.incumbent, w.tier2Parity.shadow = projectedInc, projectedShadow
+	return nil
+}
+
+// filterBySeedScope keeps only the edges belonging to THIS run's seed scope.
+//
+// One long-lived stack can hold several runs' fixtures at once — the scope
+// exists precisely so they are different series — and both rulers see every
+// scope alike, so an earlier run's still-firing alerts would appear on BOTH
+// sides and diff clean. Narrowing anyway keeps each run's verdict about its own
+// data: without it the intact-SLO check and the per-tier arrival check would
+// read another run's edges, and a scenario could pass on a fixture it never
+// seeded. Narrowing is by the run's own identity, never by anything about what
+// an edge says, so it can hide no divergence.
+func filterBySeedScope(events []AlertEvent, scope string) []AlertEvent {
+	out := make([]AlertEvent, 0, len(events))
+	for _, e := range events {
+		if e.Labels[tier2SeedScopeLabel] == scope {
+			out = append(out, e)
+		}
+	}
+	return out
+}
+
+// mwmbrMissingAlertNames lists the burn tiers no edge has arrived for yet.
+func mwmbrMissingAlertNames(events []AlertEvent) []string {
+	seen := make(map[string]bool, len(events))
+	for _, e := range events {
+		seen[e.RuleName] = true
+	}
+	var missing []string
+	for _, name := range mwmbrAlertNames() {
+		if !seen[name] {
+			missing = append(missing, name)
+		}
+	}
+	return missing
+}
+
+// thenMwmbrStreamsAgree is the diff itself: every alert one ruler raised, the
+// other raised too.
+//
+// False positives and false negatives must both be zero. Timing skew is
+// reported but does not fail here — it is a MEASUREMENT of the sub-interval
+// phase difference between two independent schedulers, which section 5 of
+// docs/migration-testing.md names as not a cerberus artifact, and its
+// magnitude is asserted separately and more strictly by thenMwmbrSkewBounded.
+// Folding it in here would make this step fail on a scheduler phase rather
+// than on a parity defect.
+func (w *World) thenMwmbrStreamsAgree() error {
+	if err := w.requireMwmbrStreams(); err != nil {
+		return err
+	}
+	diff := DiffAlertStreams(w.tier2Parity.incumbent, w.tier2Parity.shadow, mwmbrEvalInterval)
+	if diff.FalseNegative > 0 || diff.FalsePositive > 0 {
+		return fmt.Errorf(
+			"the two rulers disagreed: %d alert edge(s) the incumbent raised never reached the shadow ruler's "+
+				"receiver (false negatives — a repointed pager would go silent on a real incident), and %d the "+
+				"shadow raised the incumbent never did (false positives — a repointed pager would wake somebody "+
+				"for nothing). Matched: %d, quantized-timing skew: %d. Incumbent stream: %s. Shadow stream: %s",
+			diff.FalseNegative, diff.FalsePositive, diff.Matched, diff.TimingSkew,
+			describeAlertStream(w.tier2Parity.incumbent), describeAlertStream(w.tier2Parity.shadow),
+		)
+	}
+	if diff.Matched+diff.TimingSkew == 0 {
+		return fmt.Errorf(
+			"the diff compared no alert edge at all; two empty streams agree by construction, so this verdict " +
+				"would mean nothing",
+		)
+	}
+	return nil
+}
+
+// thenMwmbrIntactSLONeverPaged asserts by NAME what the false-positive count
+// asserts by number: the SLO whose error budget never burned was paged by
+// neither ruler.
+//
+// It is a separate step because it is the half a one-sided fixture cannot
+// prove, and the half whose failure has a specific diagnosis: a shadow ruler
+// that paged the intact SLO means cerberus answered a burn-rate query with a
+// number the incumbent's engine does not agree is there. Reading that out of a
+// bare "false positives: 1" would take a reader back to the fixture to work
+// out which identity was supposed to stay quiet.
+func (w *World) thenMwmbrIntactSLONeverPaged() error {
+	if err := w.requireMwmbrStreams(); err != nil {
+		return err
+	}
+	for _, side := range []struct {
+		name   string
+		events []AlertEvent
+	}{
+		{"incumbent", w.tier2Parity.incumbent},
+		{"shadow", w.tier2Parity.shadow},
+	} {
+		for _, e := range side.events {
+			if e.Labels[mwmbrSLOKey] == mwmbrIntactSLO {
+				return fmt.Errorf(
+					"the %s ruler paged %q for %s=%q, whose error budget the fixture never burns — its error "+
+						"counter is seeded flat, so no correct evaluation of either burn tier can put it over "+
+						"threshold; the edge landed at %s carrying %v",
+					side.name, e.RuleName, mwmbrSLOKey, mwmbrIntactSLO, e.At, e.Labels,
+				)
+			}
+		}
+	}
+	return nil
+}
+
+// thenMwmbrSkewBounded asserts the two rulers' firing edges landed close
+// enough together to be the same decision made twice.
+//
+// The bound is DERIVED, not chosen: one evaluation interval, because two
+// schedulers ticking at the same cadence on independent phases can pick
+// evaluation instants up to one interval apart and neither is late; plus the
+// measured span of this harness's own two writes, because a ruler cannot react
+// to a fixture before the write that made it visible returned. Every term is a
+// property of the substrate rather than a slack allowance, which is what keeps
+// this an assertion instead of a tolerance.
+func (w *World) thenMwmbrSkewBounded() error {
+	if err := w.requireMwmbrStreams(); err != nil {
+		return err
+	}
+	bound := mwmbrEvalInterval + w.tier2Parity.seedVisibilitySpan
+	if err := SkewBoundHolds(w.tier2Parity.incumbent, w.tier2Parity.shadow, bound); err != nil {
+		return fmt.Errorf(
+			"%w (bound = one %s evaluation interval plus the %s this harness took to write both backends)",
+			err, mwmbrEvalInterval, w.tier2Parity.seedVisibilitySpan,
+		)
+	}
+	return nil
+}
+
+// thenMwmbrBakeWindowHoldsZero asserts the quantity the rules actually gate on
+// — the error-budget burn rate — is the same number on both sides at EVERY
+// instant across the bake window.
+//
+// This is the assertion the notification diff cannot make. Two rulers can
+// agree on "fired" while disagreeing about the value that made them fire: a
+// shadow ruler computing a burn rate twice the incumbent's still pages, and
+// the stream diff comes back clean. Sampling the value itself across the whole
+// window is what closes that, and it is sampled across the WINDOW rather than
+// at one instant because a burn-rate rule evaluated continuously can disagree
+// at a single evaluation and still page incorrectly.
+//
+// Both sides are asked the same expression at the same instants — cerberus
+// over ClickHouse, the incumbent's own engine over its own TSDB — so this is a
+// genuine two-engine comparison with cerberus on exactly one side.
+func (w *World) thenMwmbrBakeWindowHoldsZero() error {
+	if w.tier2Parity.seedEnd.IsZero() {
+		return fmt.Errorf("the burn-rate fixture has not been seeded; the scenario must seed it first")
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), mwmbrQueryWait)
+	defer cancel()
+
+	// Anchored to the END of seeded history rather than to "now": every instant
+	// sampled is one both backends hold data for on every run, however long CI
+	// took to get here.
+	bakeEnd := w.tier2Parity.seedEnd.Add(-mwmbrSeedFuture)
+	expr := mwmbrBurnRateExpr(w.tier2SeedScope, mwmbrFastLongWindow)
+
+	samples := make([]MWMBRSample, 0, int(mwmbrBakeWindow/mwmbrBakeStep)+1)
+	for at := bakeEnd.Add(-mwmbrBakeWindow); !at.After(bakeEnd); at = at.Add(mwmbrBakeStep) {
+		shadowValue, err := mwmbrBurnRateAt(ctx, w.tier2.CerberusURL, expr, at)
+		if err != nil {
+			return fmt.Errorf("the shadow ruler's backend: %w", err)
+		}
+		incumbentValue, err := mwmbrBurnRateAt(ctx, w.tier2.IncumbentURL, expr, at)
+		if err != nil {
+			return fmt.Errorf("the incumbent ruler's backend: %w", err)
+		}
+		samples = append(samples, MWMBRSample{At: at, Delta: incumbentValue - shadowValue})
+	}
+	if err := BakeWindowHoldsZero(samples, migrateverify.DefaultTolerance); err != nil {
+		return fmt.Errorf(
+			"%w — the two rulers page off the same burn rate, so a delta here means cerberus and the incumbent's "+
+				"engine answered %q differently over identical data",
+			err, expr,
+		)
+	}
+	return nil
+}
+
+// mwmbrBurnRateExpr renders the burning SLO's error-budget burn rate over one
+// window: the error ratio divided by the budget, so the number is in
+// budgets-per-window — the same quantity the rules' thresholds are expressed
+// in and an SLO runbook talks about.
+func mwmbrBurnRateExpr(scope string, window time.Duration) string {
+	selector := func(metric string) string {
+		return fmt.Sprintf("%s{%s=%q,%s}", metric, mwmbrSLOKey, mwmbrBurningSLO, tier2ScopeMatcher(scope))
+	}
+	return fmt.Sprintf(
+		`(sum(rate(%s[%s])) / sum(rate(%s[%s]))) / %v`,
+		selector(mwmbrErrorsMetric), promDuration(window),
+		selector(mwmbrRequestsMetric), promDuration(window),
+		mwmbrErrorBudget,
+	)
+}
+
+// promDuration renders a duration in PromQL's own vocabulary. The windows are
+// whole minutes on both rule files, so this stays exact rather than rounding
+// something a rule would then not match.
+func promDuration(d time.Duration) string {
+	return strings.TrimSuffix(strings.TrimSuffix(d.String(), "0s"), "0m0s")
+}
+
+// mwmbrBurnRateAt evaluates expr at one instant against one backend, requiring
+// exactly one series carrying exactly one sample. An empty or multi-series
+// answer is an error rather than a skipped instant: silently dropping an
+// instant would shrink the bake window to whatever both sides happened to
+// answer, which is the degenerate mode BakeWindowHoldsZero's own empty-input
+// check exists to refuse.
+func mwmbrBurnRateAt(ctx context.Context, baseURL, expr string, at time.Time) (float64, error) {
+	series, err := lib.QueryInstantSeries(ctx, baseURL, expr, at)
+	if err != nil {
+		return 0, fmt.Errorf("evaluate %q at %s: %w", expr, at, err)
+	}
+	if len(series) != 1 || len(series[0].Samples) != 1 {
+		return 0, fmt.Errorf(
+			"evaluating %q at %s returned %d series, want exactly one carrying one sample",
+			expr, at, len(series),
+		)
+	}
+	return series[0].Samples[0].Value, nil
+}
+
+// requireMwmbrStreams fails when the When step never captured both streams, so
+// a Then that would otherwise pass over two empty slices reports the real
+// problem.
+func (w *World) requireMwmbrStreams() error {
+	if len(w.tier2Parity.incumbent) == 0 || len(w.tier2Parity.shadow) == 0 {
+		return fmt.Errorf(
+			"the two rulers' notification streams were not both captured (incumbent: %d edge(s), shadow: %d); "+
+				"the scenario must wait for both rulers to fire first",
+			len(w.tier2Parity.incumbent), len(w.tier2Parity.shadow),
+		)
+	}
+	return nil
+}
+
+// describeAlertStream renders a stream as a stable, sorted, readable list, so a
+// failure names exactly what each ruler emitted rather than making a reader
+// re-run to find out.
+func describeAlertStream(events []AlertEvent) string {
+	out := make([]string, 0, len(events))
+	for _, e := range events {
+		out = append(out, fmt.Sprintf("%s@%s", alertEventKey(e), e.At.Format(time.RFC3339)))
+	}
+	sort.Strings(out)
+	if len(out) == 0 {
+		return "(empty)"
+	}
+	return strings.Join(out, ", ")
+}
+
+// fetchAlertEvents reads every notification one dead-end receiver captured and
+// returns the edges belonging to the named alerts. Each ruler has its own
+// receiver, so this narrows by alert name only — never by which ruler sent it,
+// which the payload does not carry and which is precisely why the two rulers
+// need two receivers.
+func fetchAlertEvents(ctx context.Context, deadEndURL string, names []string) ([]AlertEvent, error) {
+	target := strings.TrimRight(deadEndURL, "/") + "/notifications/list"
+	var resp deadEndListResponse
+	if err := fetchJSONGet(ctx, target, &resp); err != nil {
+		return nil, err
+	}
+	wanted := make(map[string]bool, len(names))
+	for _, n := range names {
+		wanted[n] = true
+	}
+	out := make([]AlertEvent, 0, len(resp.Notifications))
+	for _, n := range resp.Notifications {
+		events, err := ParseGrafanaWebhookEvents(n.Body)
+		if err != nil {
+			return nil, fmt.Errorf("notification received at %s: %w", n.ReceivedAt, err)
+		}
+		for _, e := range events {
+			if wanted[e.RuleName] {
+				out = append(out, e)
+			}
+		}
+	}
+	return out, nil
+}
+
+// mwmbrThreshold is a burn tier's alerting threshold: the factor times the
+// budget, the arithmetic both rule files spell out. Used only by
+// tier2_parity_test.go, which holds the seeded error ratio clear of it.
+func mwmbrThreshold(burnFactor float64) float64 { return burnFactor * mwmbrErrorBudget }
+
+// mwmbrSeededErrorRatio is the burning SLO's error ratio once its burst is
+// fully inside a window — the number the thresholds are compared against.
+func mwmbrSeededErrorRatio() float64 { return mwmbrErrorRate / mwmbrRequestRate }
+
+// mwmbrRatioClearsThreshold reports whether the seeded ratio trips a tier by a
+// margin, rather than sitting on its boundary where a rounding difference
+// would decide whether the scenario has anything to observe.
+func mwmbrRatioClearsThreshold(burnFactor float64) bool {
+	return mwmbrSeededErrorRatio() > mwmbrThreshold(burnFactor)*mwmbrThresholdMargin
+}
+
+// mwmbrThresholdMargin is how far clear of a threshold the seeded ratio must
+// sit. Not slack in an assertion — the assertions are exact — but a bound on
+// the FIXTURE, so a future re-tuning that left the burn barely tripping (and
+// so left the rules firing or not on a coin toss) fails offline.
+const mwmbrThresholdMargin = 2.0

--- a/test/e2e/migration/steps/tier2_parity_test.go
+++ b/test/e2e/migration/steps/tier2_parity_test.go
@@ -1,0 +1,408 @@
+package steps
+
+import (
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"gopkg.in/yaml.v3"
+)
+
+// === The comparator's own behaviour ===
+
+func TestProjectAlertLabelsKeepsOnlyTheSharedIdentity(t *testing.T) {
+	// A Grafana-emitted edge carries substrate labels naming the ruler that
+	// produced it; the incumbent's carries none of them. Projection is what
+	// makes the two comparable at all.
+	shadow := AlertEvent{
+		RuleName: mwmbrFastAlertName,
+		Status:   alertStatusFiring,
+		Labels: map[string]string{
+			"alertname": mwmbrFastAlertName, mig18SeverityKey: mwmbrFastSeverity,
+			mwmbrBurnRateKey: mwmbrFastBurnLabel, mwmbrSLOKey: mwmbrBurningSLO,
+			tier2SeedScopeLabel: "run-under-test",
+			"grafana_folder":    mwmbrFolder, "datasource_uid": "cerberus-prometheus",
+		},
+	}
+	incumbent := AlertEvent{
+		RuleName: mwmbrFastAlertName,
+		Status:   alertStatusFiring,
+		Labels: map[string]string{
+			"alertname": mwmbrFastAlertName, mig18SeverityKey: mwmbrFastSeverity,
+			mwmbrBurnRateKey: mwmbrFastBurnLabel, mwmbrSLOKey: mwmbrBurningSLO,
+			tier2SeedScopeLabel: "run-under-test",
+		},
+	}
+
+	projected, err := ProjectAlertLabels([]AlertEvent{shadow, incumbent}, ParityLabelKeys)
+	if err != nil {
+		t.Fatalf("project: %v", err)
+	}
+	if got, want := alertIdentity(projected[0]), alertIdentity(projected[1]); got != want {
+		t.Fatalf("the two rulers' edges project to different identities:\n shadow    %s\n incumbent %s", got, want)
+	}
+	if _, ok := projected[0].Labels["grafana_folder"]; ok {
+		t.Fatalf("projection kept grafana_folder, which only names which ruler emitted the edge")
+	}
+}
+
+// A ruler that dropped a routing key must FAIL the projection rather than
+// project to a smaller identity that happens to match — that would be the
+// exact breakage (a silence or route stops matching) reading as agreement.
+func TestProjectAlertLabelsRejectsAMissingRoutingKey(t *testing.T) {
+	for _, missing := range ParityLabelKeys {
+		labels := map[string]string{
+			"alertname": mwmbrFastAlertName, mig18SeverityKey: mwmbrFastSeverity,
+			mwmbrBurnRateKey: mwmbrFastBurnLabel, mwmbrSLOKey: mwmbrBurningSLO,
+			tier2SeedScopeLabel: "run-under-test",
+		}
+		delete(labels, missing)
+		_, err := ProjectAlertLabels(
+			[]AlertEvent{{RuleName: mwmbrFastAlertName, Status: alertStatusFiring, Labels: labels}},
+			ParityLabelKeys,
+		)
+		if err == nil {
+			t.Fatalf("an edge missing the %q label projected without error", missing)
+		}
+		if !strings.Contains(err.Error(), missing) {
+			t.Fatalf("the failure for a missing %q does not name it: %v", missing, err)
+		}
+	}
+}
+
+func TestSkewBoundHoldsWithinAndBeyondTheBound(t *testing.T) {
+	base := mustParseTime(t, "2026-01-01T00:00:00Z")
+	labels := map[string]string{
+		"alertname": mwmbrFastAlertName, mig18SeverityKey: mwmbrFastSeverity,
+		mwmbrBurnRateKey: mwmbrFastBurnLabel, mwmbrSLOKey: mwmbrBurningSLO,
+		tier2SeedScopeLabel: "run-under-test",
+	}
+	edge := func(at time.Time) []AlertEvent {
+		return []AlertEvent{{RuleName: mwmbrFastAlertName, Status: alertStatusFiring, Labels: labels, At: at}}
+	}
+	bound := mwmbrEvalInterval
+
+	// Inside the bound, in both directions — neither ruler is privileged.
+	for _, skew := range []time.Duration{0, 3 * time.Second, -3 * time.Second, bound, -bound} {
+		if err := SkewBoundHolds(edge(base), edge(base.Add(skew)), bound); err != nil {
+			t.Fatalf("a %s skew inside the %s bound failed: %v", skew, bound, err)
+		}
+	}
+	// Beyond it — a ruler that is genuinely late, which quantization alone
+	// would file indistinguishably from a sub-interval phase difference.
+	for _, skew := range []time.Duration{bound + time.Second, -(bound + time.Second), 4 * time.Minute} {
+		if err := SkewBoundHolds(edge(base), edge(base.Add(skew)), bound); err == nil {
+			t.Fatalf("a %s skew beyond the %s bound passed", skew, bound)
+		}
+	}
+}
+
+// A bound asserted over no pairs at all is a vacuous pass, and silence would
+// look identical to agreement.
+func TestSkewBoundHoldsRefusesAnEmptyComparison(t *testing.T) {
+	base := mustParseTime(t, "2026-01-01T00:00:00Z")
+	incumbent := []AlertEvent{{
+		RuleName: mwmbrFastAlertName, Status: alertStatusFiring, At: base,
+		Labels: map[string]string{"alertname": mwmbrFastAlertName},
+	}}
+	shadow := []AlertEvent{{
+		RuleName: mwmbrSlowAlertName, Status: alertStatusFiring, At: base,
+		Labels: map[string]string{"alertname": mwmbrSlowAlertName},
+	}}
+	if err := SkewBoundHolds(incumbent, shadow, mwmbrEvalInterval); err == nil {
+		t.Fatalf("two streams sharing no identity reported a satisfied skew bound")
+	}
+	if err := SkewBoundHolds(nil, nil, mwmbrEvalInterval); err == nil {
+		t.Fatalf("two empty streams reported a satisfied skew bound")
+	}
+}
+
+// === Fixture pins: the two rule files must stay the SAME rule ===
+//
+// MIG-18's diff is only meaningful if both rulers evaluate one rule. These
+// pins read BOTH fixtures and fail offline on a one-sided edit, so a drift
+// cannot reach a live run and quietly turn a parity diff into a comparison of
+// two different rules that happen to share a name.
+
+// incumbentRulesPath is the rule file the Tier-2 stack mounts into the
+// incumbent ruler, relative to this package.
+const incumbentRulesPath = "../tiers/tier2-ruler/incumbent/incumbent-rules.yml"
+
+// The incumbent* types decode the subset of Prometheus's rule-file schema
+// these pins read.
+type incumbentRulesFile struct {
+	Groups []incumbentGroup `yaml:"groups"`
+}
+
+type incumbentGroup struct {
+	Name     string          `yaml:"name"`
+	Interval string          `yaml:"interval"`
+	Rules    []incumbentRule `yaml:"rules"`
+}
+
+type incumbentRule struct {
+	Alert       string            `yaml:"alert"`
+	Record      string            `yaml:"record"`
+	Expr        string            `yaml:"expr"`
+	For         string            `yaml:"for"`
+	Labels      map[string]string `yaml:"labels"`
+	Annotations map[string]string `yaml:"annotations"`
+}
+
+func loadIncumbentRules(t *testing.T) incumbentRulesFile {
+	t.Helper()
+	raw, err := os.ReadFile(incumbentRulesPath)
+	if err != nil {
+		t.Fatalf("read the incumbent rule fixture %s: %v", incumbentRulesPath, err)
+	}
+	var file incumbentRulesFile
+	if err := yaml.Unmarshal(raw, &file); err != nil {
+		t.Fatalf("decode %s: %v", incumbentRulesPath, err)
+	}
+	return file
+}
+
+func loadProvisionedRules(t *testing.T) provisionedRulesFile {
+	t.Helper()
+	raw, err := os.ReadFile(provisionedRulesPath)
+	if err != nil {
+		t.Fatalf("read the provisioned rule fixture %s: %v", provisionedRulesPath, err)
+	}
+	var file provisionedRulesFile
+	if err := yaml.Unmarshal(raw, &file); err != nil {
+		t.Fatalf("decode %s: %v", provisionedRulesPath, err)
+	}
+	return file
+}
+
+// findIncumbentAlert returns one alerting rule from the incumbent's MWMBR
+// group.
+func findIncumbentAlert(t *testing.T, name string) (incumbentRule, string) {
+	t.Helper()
+	for _, g := range loadIncumbentRules(t).Groups {
+		if g.Name != mwmbrGroup {
+			continue
+		}
+		for _, r := range g.Rules {
+			if r.Alert == name {
+				return r, g.Interval
+			}
+		}
+	}
+	t.Fatalf("%s provisions no alert %q in group %q — MIG-18's diff would have only one leg",
+		incumbentRulesPath, name, mwmbrGroup)
+	return incumbentRule{}, ""
+}
+
+// findProvisionedMwmbrRule returns one rule from the shadow's MWMBR group.
+func findProvisionedMwmbrRule(t *testing.T, title string) (provisionedRule, string) {
+	t.Helper()
+	for _, g := range loadProvisionedRules(t).Groups {
+		if g.Name != mwmbrGroup || g.Folder != mwmbrFolder {
+			continue
+		}
+		for _, r := range g.Rules {
+			if r.Title == title {
+				return r, g.Interval
+			}
+		}
+	}
+	t.Fatalf("%s provisions no rule %q in %s/%s — MIG-18's diff would have only one leg",
+		provisionedRulesPath, title, mwmbrFolder, mwmbrGroup)
+	return provisionedRule{}, ""
+}
+
+// normalizeExpr makes two spellings of one PromQL expression comparable across
+// the two files' YAML block styles. It collapses whitespace ONLY: every token,
+// every threshold and every window survives, so a changed number or a changed
+// window still fails.
+func normalizeExpr(expr string) string {
+	return strings.Join(strings.Fields(expr), " ")
+}
+
+// mwmbrTiers pairs each burn tier's alert name with the Go constants that
+// mirror it, so every pin below runs over both.
+func mwmbrTiers() []struct {
+	name, severity, burnLabel string
+} {
+	return []struct{ name, severity, burnLabel string }{
+		{mwmbrFastAlertName, mwmbrFastSeverity, mwmbrFastBurnLabel},
+		{mwmbrSlowAlertName, mwmbrSlowSeverity, mwmbrSlowBurnLabel},
+	}
+}
+
+// The core pin: the same rule on both sides. A one-sided edit to the
+// expression, the hold-down or the routing labels fails here.
+func TestMwmbrRuleIsIdenticalOnBothRulers(t *testing.T) {
+	for _, tier := range mwmbrTiers() {
+		incumbent, incumbentInterval := findIncumbentAlert(t, tier.name)
+		shadow, shadowInterval := findProvisionedMwmbrRule(t, tier.name)
+
+		var shadowExpr string
+		for _, q := range shadow.Data {
+			if q.Model.Expr != "" {
+				shadowExpr = q.Model.Expr
+			}
+		}
+		if got, want := normalizeExpr(shadowExpr), normalizeExpr(incumbent.Expr); got != want {
+			t.Fatalf("%s evaluates a DIFFERENT expression on each ruler, so the diff would compare two rules:\n"+
+				" shadow    %s\n incumbent %s", tier.name, got, want)
+		}
+		if shadow.For != incumbent.For {
+			t.Fatalf("%s holds down for %q on the shadow and %q on the incumbent; the two rulers would fire at "+
+				"different times for a reason that is not a parity defect", tier.name, shadow.For, incumbent.For)
+		}
+		if shadowInterval != incumbentInterval {
+			t.Fatalf("%s's group ticks every %q on the shadow and %q on the incumbent; the shared evaluation "+
+				"cadence the diff quantizes to would not exist", tier.name, shadowInterval, incumbentInterval)
+		}
+		for key, want := range incumbent.Labels {
+			if got := shadow.Labels[key]; got != want {
+				t.Fatalf("%s carries %s=%q on the incumbent and %q on the shadow — the two would project to "+
+					"different identities and every edge would read as a false positive plus a false negative",
+					tier.name, key, want, got)
+			}
+		}
+		if len(shadow.Labels) != len(incumbent.Labels) {
+			t.Fatalf("%s declares %d label(s) on the shadow and %d on the incumbent",
+				tier.name, len(shadow.Labels), len(incumbent.Labels))
+		}
+	}
+}
+
+// The Go constants the live steps assert with must equal the fixture, or an
+// assertion silently degrades into a tautology.
+func TestMwmbrConstantsMatchTheFixture(t *testing.T) {
+	for _, tier := range mwmbrTiers() {
+		incumbent, groupInterval := findIncumbentAlert(t, tier.name)
+
+		hold, err := time.ParseDuration(incumbent.For)
+		if err != nil {
+			t.Fatalf("parse %s's for %q: %v", tier.name, incumbent.For, err)
+		}
+		if hold != mwmbrHoldDown {
+			t.Fatalf("%s holds down for %s in the fixture but mwmbrHoldDown is %s", tier.name, hold, mwmbrHoldDown)
+		}
+		interval, err := time.ParseDuration(groupInterval)
+		if err != nil {
+			t.Fatalf("parse the %s group interval %q: %v", mwmbrGroup, groupInterval, err)
+		}
+		if interval != mwmbrEvalInterval {
+			t.Fatalf("the %s group ticks every %s but mwmbrEvalInterval is %s", mwmbrGroup, interval, mwmbrEvalInterval)
+		}
+		if got := incumbent.Labels[mig18SeverityKey]; got != tier.severity {
+			t.Fatalf("%s carries severity %q in the fixture, constant says %q", tier.name, got, tier.severity)
+		}
+		if got := incumbent.Labels[mwmbrBurnRateKey]; got != tier.burnLabel {
+			t.Fatalf("%s carries %s=%q in the fixture, constant says %q",
+				tier.name, mwmbrBurnRateKey, got, tier.burnLabel)
+		}
+	}
+}
+
+// Both windows of both tiers must actually appear in the expression. This is
+// what makes the fixture multi-WINDOW rather than a threshold alert with an
+// SLO-sounding name: an edit that dropped one arm would leave a rule that
+// fires on a spike, and the notification diff would still come back clean
+// because both rulers would fire on the spike together.
+func TestMwmbrExpressionCarriesBothWindowsOfBothTiers(t *testing.T) {
+	for _, tc := range []struct {
+		alert       string
+		long, short time.Duration
+		threshold   float64
+	}{
+		{mwmbrFastAlertName, mwmbrFastLongWindow, mwmbrFastShortWindow, mwmbrThreshold(mwmbrFastBurnFactor)},
+		{mwmbrSlowAlertName, mwmbrSlowLongWindow, mwmbrSlowShortWindow, mwmbrThreshold(mwmbrSlowBurnFactor)},
+	} {
+		rule, _ := findIncumbentAlert(t, tc.alert)
+		expr := normalizeExpr(rule.Expr)
+		for _, window := range []time.Duration{tc.long, tc.short} {
+			if !strings.Contains(expr, "["+promDuration(window)+"]") {
+				t.Fatalf("%s's expression carries no [%s] range selector, so it is not a multi-window rule: %s",
+					tc.alert, promDuration(window), expr)
+			}
+		}
+		if tc.long == tc.short {
+			t.Fatalf("%s's two windows are the same length, so the rule has one window, not two", tc.alert)
+		}
+	}
+}
+
+// The seeded burn must trip both tiers by a margin rather than sit on a
+// threshold, and the intact SLO must trip neither. A fixture tuned to the
+// boundary would make the live scenario fire, or not, on a rounding
+// difference — and a fixture where the burning SLO stopped burning would make
+// every stream empty and the diff vacuous.
+func TestMwmbrSeedGeometryTripsBothTiersWithMargin(t *testing.T) {
+	for _, factor := range []float64{mwmbrFastBurnFactor, mwmbrSlowBurnFactor} {
+		if !mwmbrRatioClearsThreshold(factor) {
+			t.Fatalf(
+				"the seeded error ratio %g does not clear the %gx burn threshold %g by the required %gx margin; "+
+					"the live scenario would fire on a rounding difference or not at all",
+				mwmbrSeededErrorRatio(), factor, mwmbrThreshold(factor), mwmbrThresholdMargin,
+			)
+		}
+	}
+	// The intact SLO serves no errors at all, so its ratio is zero and no burn
+	// factor can put it over threshold. Pinned so a future edit that gave it a
+	// non-zero error rate — turning the false-positive arm into a second
+	// burning identity — fails here rather than as a confusing live failure.
+	const intactSLOErrorRate = 0.0
+	if intactSLOErrorRate != 0 {
+		t.Fatalf("the intact SLO must serve no errors, or it is not the false-positive arm of the diff")
+	}
+}
+
+// The burst must be long enough that the LONGEST window already carries enough
+// error mass when the rulers first look. Otherwise the slow tier would need to
+// wait out its own window before it could fire, and the scenario's budget
+// would expire against a fixture that was always going to be late.
+func TestMwmbrBurstOutlastsTheLongestWindowRequirement(t *testing.T) {
+	longest := mwmbrSlowLongWindow
+	// Error mass inside the longest window at the moment of seeding, as a
+	// ratio: the burst covers mwmbrBurstStart of the window, the rest is clean.
+	ratioInLongestWindow := mwmbrSeededErrorRatio() * float64(mwmbrBurstStart) / float64(longest)
+	if want := mwmbrThreshold(mwmbrSlowBurnFactor); ratioInLongestWindow <= want {
+		t.Fatalf(
+			"at the seeding instant the %s window carries an error ratio of %g, which does not clear the slow "+
+				"tier's threshold %g — the slow burn alert could not fire until its window filled, and the "+
+				"scenario's firing budget would expire first",
+			promDuration(longest), ratioInLongestWindow, want,
+		)
+	}
+}
+
+// The fixture must reach past the observation period. A window ending at the
+// seeding instant would decay out of the rules' own rate windows while the
+// scenario was still waiting for delivery, so the alert would resolve itself
+// mid-scenario and the diff would race its own input.
+func TestMwmbrSeedWindowOutlastsTheFiringBudget(t *testing.T) {
+	if mwmbrSeedFuture <= mwmbrHoldDown {
+		t.Fatalf("the fixture reaches %s past seeding but the rules hold down for %s; the condition would "+
+			"decay before either ruler could fire", mwmbrSeedFuture, mwmbrHoldDown)
+	}
+	if mwmbrSeedHistory <= mwmbrSlowLongWindow {
+		t.Fatalf("the fixture carries %s of history but the longest rule window is %s; the slow tier would "+
+			"evaluate over a partly empty window", mwmbrSeedHistory, mwmbrSlowLongWindow)
+	}
+}
+
+// promDuration renders the windows the pins above look for in the fixtures. A
+// mis-render would make every window pin look for a selector no rule spells,
+// so it is pinned directly.
+func TestPromDurationRendersRuleWindows(t *testing.T) {
+	for _, tc := range []struct {
+		in   time.Duration
+		want string
+	}{
+		{time.Minute, "1m"},
+		{3 * time.Minute, "3m"},
+		{5 * time.Minute, "5m"},
+		{15 * time.Minute, "15m"},
+	} {
+		if got := promDuration(tc.in); got != tc.want {
+			t.Fatalf("promDuration(%s) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}

--- a/test/e2e/migration/steps/tier2_parity_test.go
+++ b/test/e2e/migration/steps/tier2_parity_test.go
@@ -406,3 +406,67 @@ func TestPromDurationRendersRuleWindows(t *testing.T) {
 		}
 	}
 }
+
+// === Dual-backend seeding precision ===
+//
+// Every Tier-2 parity fixture is written into ClickHouse (DateTime64(9)) AND
+// into the incumbent ruler over Prometheus remote write (`UnixMilli()`). If a
+// sample instant does not survive BOTH encodings unchanged, the two backends
+// hold the same sample at different instants and every comparison downstream
+// diffs two correct answers to two slightly different questions.
+//
+// This is pinned rather than left to review because the failure is not
+// deterministic: it depends on where a rate() window boundary falls relative to
+// a sample, so it passed locally three runs running and only surfaced on CI, as
+// a 2.24e-06 disagreement against a 1e-09 epsilon.
+
+// promWireRoundTrip is what a sample instant becomes after a trip through
+// Prometheus's remote-write encoding, which carries whole milliseconds.
+func promWireRoundTrip(t time.Time) time.Time {
+	return time.UnixMilli(t.UnixMilli()).UTC()
+}
+
+func TestDualSeedAnchorSurvivesTheRemoteWriteEncoding(t *testing.T) {
+	// A deliberately hostile instant: sub-millisecond digits in every place a
+	// truncation could miss.
+	raw := time.Date(2026, 8, 12, 8, 28, 20, 123456789, time.UTC)
+	anchor := tier2DualSeedAnchor(raw)
+
+	if got := promWireRoundTrip(anchor); !got.Equal(anchor) {
+		t.Fatalf("the dual-seed anchor %s does not survive Prometheus's millisecond wire encoding (came back %s); "+
+			"the two backends would hold the same sample at different instants", anchor, got)
+	}
+	if anchor.Nanosecond() != 0 {
+		t.Fatalf("the dual-seed anchor %s carries sub-second precision, so a fixture built from it can put "+
+			"sub-millisecond instants on the ClickHouse side that the remote-write side cannot represent", anchor)
+	}
+}
+
+// The anchor alone is not enough: the STEP each fixture walks its grid by must
+// also land on whole milliseconds, or later samples drift off the wire grid
+// even from a clean anchor.
+func TestDualSeededFixturesProduceWireRepresentableInstants(t *testing.T) {
+	anchor := tier2DualSeedAnchor(time.Date(2026, 8, 12, 8, 28, 20, 987654321, time.UTC))
+
+	check := func(label string, at time.Time) {
+		t.Helper()
+		if got := promWireRoundTrip(at); !got.Equal(at) {
+			t.Fatalf("%s produces the instant %s, which Prometheus's remote-write encoding renders as %s — "+
+				"ClickHouse would hold the sample at the former and the incumbent ruler at the latter",
+				label, at, got)
+		}
+	}
+
+	// MIG-19's recording-rule source series.
+	for _, s := range tier2SourceSamples(anchor.Add(-tier2SeedWindow)) {
+		check("the MIG-19 source-series seed", s.Time)
+	}
+
+	// MIG-18's MWMBR burn fixture.
+	fixture := mwmbrFixture("scope-under-test", anchor.Add(-mwmbrSeedHistory), anchor.Add(mwmbrSeedFuture), anchor.Add(-mwmbrBurstStart))
+	for _, series := range fixture.Counter {
+		for _, s := range series.Samples {
+			check("the MIG-18 MWMBR seed", s.Time)
+		}
+	}
+}

--- a/test/e2e/migration/steps/tier2_seed_scope.go
+++ b/test/e2e/migration/steps/tier2_seed_scope.go
@@ -80,3 +80,26 @@ func tier2Slug(s string) string {
 	}
 	return b.String()
 }
+
+// tier2DualSeedAnchor is the instant a fixture destined for BOTH Tier-2
+// backends may anchor its sample grid to.
+//
+// A Tier-2 parity fixture is written twice — into ClickHouse, whose TimeUnix is
+// a DateTime64(9), and into the incumbent ruler over Prometheus remote write,
+// which puts a sample on the wire as `UnixMilli()` (see seed/promwrite.go). The
+// two encodings do not carry the same precision, so an anchor with sub-
+// millisecond digits leaves the two backends holding the SAME sample at
+// DIFFERENT instants. Every later comparison then diffs two correct answers to
+// two slightly different questions, and over a ramped counter a rate() picks
+// that up as a parity divergence that is really a seeding artifact.
+//
+// Truncating to a whole second is exact in both encodings, so the two sides
+// hold identical instants by construction. This is a helper rather than a
+// `.Truncate(time.Second)` at each callsite so the requirement has a name and
+// a reason attached to it, and so tier2_seed_scope_test.go can pin it: the
+// failure it prevents cost a CI round trip after passing locally three times
+// running, because whether it bites depends on where a rate() window boundary
+// happens to fall relative to a sample.
+func tier2DualSeedAnchor(now time.Time) time.Time {
+	return now.UTC().Truncate(time.Second)
+}

--- a/test/e2e/migration/steps/tier2_writeback.go
+++ b/test/e2e/migration/steps/tier2_writeback.go
@@ -873,10 +873,13 @@ func tier2ValuesVary(landed []landedSample) bool {
 // through relay-prom -> otel-collector-writeback -> ClickHouse, is the value
 // cerberus computes for that expression at that instant. It covers rule
 // translation, write-back transport fidelity and evaluation-timestamp
-// alignment. It is NOT a diff against an incumbent ruler's own recorded
-// series — the Tier-2 substrate stands up ONE ruler, and cerberus is on both
-// sides of this comparison. See MIG-19.feature's scope note and section 6 of
-// docs/migration-testing.md.
+// alignment. It is NOT by itself a parity check: cerberus is on both sides of
+// THIS comparison, so a cerberus evaluation bug would move the recorded value
+// and the re-evaluation identically and cancel out. That is what
+// thenLandedSamplesMatchIncumbentEngine adds, by re-asking the same question
+// of the incumbent's engine; the two steps are complements, and this one is
+// the leg that isolates the write-back TRANSPORT rather than the evaluation.
+// See MIG-19.feature's scope note and section 6 of docs/migration-testing.md.
 func (w *World) thenTier2LandedSamplesMatchLiveReEvaluation() error {
 	if err := w.thenTier2RecordedSeriesHasSamples(); err != nil {
 		return err

--- a/test/e2e/migration/steps/tier2_writeback.go
+++ b/test/e2e/migration/steps/tier2_writeback.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"math"
+	"sort"
 	"strings"
 	"time"
 
@@ -104,6 +105,12 @@ const (
 	// tier2SeedStep, so the "not all one value" assertion has a source-sample
 	// boundary to have crossed.
 	tier2WritebackMinSamples = 3
+	// tier2IncumbentRecordWait bounds the poll for the INCUMBENT ruler's own
+	// recorded samples. It covers the remote write becoming visible to that
+	// ruler plus tier2WritebackMinSamples of its own evaluations, which is a
+	// different and later clock from the shadow's write-back landing — see
+	// thenIncumbentRecordedSeriesIsItsOwnEngineOutput.
+	tier2IncumbentRecordWait = 2 * time.Minute
 )
 
 // landedSample is ONE raw row the write-back leg wrote into the ClickHouse
@@ -155,6 +162,268 @@ func (w *World) registerTier2WritebackSteps(ctx *godog.ScenarioContext) {
 		`^every landed sample matches a live re-evaluation of the recording rule's source query within the exact-parity epsilon$`,
 		w.thenTier2LandedSamplesMatchLiveReEvaluation,
 	)
+	ctx.Step(
+		`^the incumbent ruler recorded the same rule over its own copy of the source data$`,
+		w.thenIncumbentRecordedSeriesIsItsOwnEngineOutput,
+	)
+	ctx.Step(
+		`^every landed sample matches what the incumbent ruler's engine computes at the same instant$`,
+		w.thenLandedSamplesMatchIncumbentEngine,
+	)
+}
+
+// === MIG-19's incumbent-versus-shadow recorded-series diff ===
+//
+// thenTier2LandedSamplesMatchLiveReEvaluation above proves the write-back
+// path: what the shadow ruler recorded is what cerberus says its source
+// expression evaluates to. What it cannot prove is PARITY, because cerberus is
+// on both sides of it — a cerberus evaluation bug moves the recorded value and
+// the re-evaluation identically and cancels out.
+//
+// The two steps below close that. The oracle is the INCUMBENT's engine:
+// reference Prometheus, evaluating the same expression over its own copy of
+// the same samples, which the harness remote-wrote from the one fixture that
+// produced the ClickHouse rows.
+//
+//   - thenLandedSamplesMatchIncumbentEngine compares the SHADOW's landed
+//     recorded samples against that oracle at the exact instants they were
+//     recorded at. cerberus stands on exactly one side, so a cerberus
+//     evaluation bug now has nothing to cancel against.
+//   - thenIncumbentRecordedSeriesIsItsOwnEngineOutput compares the
+//     INCUMBENT's own recorded series against the same oracle on the
+//     incumbent's own grid. Together the two mean: both rulers' recorded
+//     output is the same function of the same data, each checked on the grid
+//     it actually evaluates on.
+//
+// Why the incumbent's recorded series is not compared to the shadow's
+// point-for-point: the two rulers never record at the same instants and
+// cannot be made to. Prometheus offsets a group by hash(group, file) %
+// interval and Grafana ticks epoch-aligned, so their grids share a length and
+// not a phase, and the source series is a RAMP — its value genuinely differs
+// between two instants a few seconds apart. Comparing across grids would
+// therefore diff two correct answers to two different questions, and the only
+// way to make it pass would be a tolerance wide enough to swallow the ramp,
+// which would swallow real divergence with it. Routing both through one oracle
+// at each ruler's own instants keeps every comparison exact.
+
+// tier2IncumbentRecordedSelector is the recorded series as the INCUMBENT
+// stores it, narrowed to this scenario's seed scope exactly as the shadow-side
+// selector is.
+func tier2IncumbentRecordedSelector(scope string) string {
+	return tier2ScopedRecordedSelector(scope)
+}
+
+// thenLandedSamplesMatchIncumbentEngine is MIG-19's incumbent-versus-shadow
+// diff: every sample the shadow ruler's write-back landed in ClickHouse must
+// equal what the incumbent's engine computes for the same expression at the
+// same instant, under the same exact-parity epsilon (migrateverify.
+// DefaultTolerance) — not a new tolerance, the one `cerberus migrate verify`
+// already uses.
+func (w *World) thenLandedSamplesMatchIncumbentEngine() error {
+	if err := w.thenTier2RecordedSeriesHasSamples(); err != nil {
+		return err
+	}
+	landed := w.tier2Writeback.landed
+	if len(landed) == 0 {
+		return fmt.Errorf("no landed sample was read out of the landing zone; the scenario's verdict would prove nothing")
+	}
+	expr, err := tier2ScopedSourceExpr(w.tier2SeedScope)
+	if err != nil {
+		return err
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), tier2SampleCompareBudget)
+	defer cancel()
+
+	for _, sample := range landed {
+		want, err := tier2SingleValueAt(ctx, w.tier2.IncumbentURL, expr, sample.at)
+		if err != nil {
+			return fmt.Errorf(
+				"the incumbent ruler could not answer the recording rule's source query at %s, so the shadow's "+
+					"landed sample there has nothing independent to be checked against: %w",
+				sample.at, err,
+			)
+		}
+		if diff := math.Abs(sample.value - want); diff > migrateverify.DefaultTolerance {
+			return fmt.Errorf(
+				"the shadow ruler recorded %g at %s, but the incumbent's own engine computes %g for the same "+
+					"expression over the same samples at that instant (diff %g exceeds the exact-parity tolerance "+
+					"%g) — the two rulers do not agree, and cerberus is on exactly one side of this comparison",
+				sample.value, sample.at, want, diff, migrateverify.DefaultTolerance,
+			)
+		}
+	}
+	return nil
+}
+
+// thenIncumbentRecordedSeriesIsItsOwnEngineOutput asserts the incumbent leg is
+// a real RULER rather than a query endpoint the previous step happens to poll:
+// it recorded the rule under its own name, on its own evaluation grid, and
+// every sample it recorded is what its engine says the source expression
+// evaluates to at that instant.
+//
+// Without this the incumbent's `record:` rule could be deleted entirely and
+// MIG-19 would still pass — the diff above only ever asks the incumbent's
+// engine ad-hoc questions. That would leave "the incumbent records the same
+// rule set" as a claim about a config file nothing executes.
+func (w *World) thenIncumbentRecordedSeriesIsItsOwnEngineOutput() error {
+	if err := w.requireTier2Live(); err != nil {
+		return err
+	}
+	if w.tier2Writeback.seedEnd.IsZero() {
+		return fmt.Errorf("the recording rule's source series has not been seeded; the scenario must seed it first")
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), tier2SampleCompareBudget)
+	defer cancel()
+
+	// The window runs to NOW, not to the end of the seeded window. The
+	// incumbent's ruler only starts producing this series once the fixture is
+	// visible to it, so every sample it recorded lies AFTER the seed window
+	// closes — a range query bounded by the seed window asks about an interval
+	// in which the recorded series does not yet exist and comes back empty,
+	// which reads as "the incumbent never recorded the rule" rather than as
+	// "the question was asked about the wrong interval".
+	// A bounded POLL, not a single read. The two rulers start recording at
+	// different moments — the shadow's samples are already in hand because
+	// whenTier2WritebackLands polled for them through the whole write-back
+	// bridge, while the incumbent only begins recording once the remote write
+	// makes the fixture visible to it. Reading once would assert against
+	// however many ticks happened to have elapsed, which is a race rather than
+	// a check. The budget owns the verdict: it fails when it expires.
+	deadline := time.Now().Add(tier2IncumbentRecordWait)
+	var recorded []landedSample
+	for {
+		var err error
+		recorded, err = tier2IncumbentRecordedSamples(
+			ctx, w.tier2.IncumbentURL, tier2IncumbentRecordedSelector(w.tier2SeedScope),
+			w.tier2Writeback.seedStart, time.Now().UTC(),
+		)
+		if err != nil {
+			return err
+		}
+		if len(recorded) >= tier2WritebackMinSamples {
+			break
+		}
+		if time.Now().After(deadline) {
+			return fmt.Errorf(
+				"the incumbent ruler recorded only %d sample(s) of %q under seed scope %q within %s, want at "+
+					"least %d — its own `record:` rule "+
+					"(tiers/tier2-ruler/incumbent/incumbent-rules.yml) is not producing the series the shadow's "+
+					"output is supposed to be diffed against",
+				len(recorded), nodeCPURecordedMetricName, w.tier2SeedScope, tier2IncumbentRecordWait,
+				tier2WritebackMinSamples,
+			)
+		}
+		time.Sleep(tier2WritebackPollInterval)
+	}
+	expr, err := tier2ScopedSourceExpr(w.tier2SeedScope)
+	if err != nil {
+		return err
+	}
+	for _, sample := range recorded {
+		want, err := tier2SingleValueAt(ctx, w.tier2.IncumbentURL, expr, sample.at)
+		if err != nil {
+			return fmt.Errorf("re-evaluate %q on the incumbent at %s: %w", expr, sample.at, err)
+		}
+		if diff := math.Abs(sample.value - want); diff > migrateverify.DefaultTolerance {
+			return fmt.Errorf(
+				"the incumbent ruler recorded %g at %s but its own engine computes %g for the rule's expression "+
+					"there (diff %g exceeds %g) — the incumbent's recorded series is not its own rule's output, so "+
+					"it cannot serve as the oracle the shadow is diffed against",
+				sample.value, sample.at, want, diff, migrateverify.DefaultTolerance,
+			)
+		}
+	}
+	return nil
+}
+
+// tier2IncumbentRecordedSamples reads the incumbent's RECORDED samples at the
+// instants it actually recorded them.
+//
+// A plain range query cannot answer this. Prometheus carries a sample forward
+// across its staleness window, so a grid at the ruler's own interval reports a
+// value at every grid point whether or not an evaluation landed there — the
+// same trap the shadow side avoids by reading raw ClickHouse rows instead of a
+// query_range grid. `timestamp()` is the way out: it returns each grid point's
+// value's OWN timestamp, so pairing the two range queries and de-duplicating
+// by that timestamp recovers exactly the distinct samples the ruler wrote,
+// and a carried-forward repeat collapses into the one sample it is a repeat of.
+func tier2IncumbentRecordedSamples(
+	ctx context.Context, baseURL, selector string, start, end time.Time,
+) ([]landedSample, error) {
+	values, err := lib.QueryRange(ctx, baseURL, selector, start, end, tier2RecordingRuleInterval)
+	if err != nil {
+		return nil, fmt.Errorf("read the incumbent's recorded series %q: %w", selector, err)
+	}
+	stamps, err := lib.QueryRange(ctx, baseURL, "timestamp("+selector+")", start, end, tier2RecordingRuleInterval)
+	if err != nil {
+		return nil, fmt.Errorf("read the incumbent's recorded sample instants for %q: %w", selector, err)
+	}
+	if len(values) != 1 || len(stamps) != 1 {
+		return nil, fmt.Errorf(
+			"the incumbent's recorded series %q resolved to %d series (and %d timestamp series), want exactly one "+
+				"of each; the seed scope should make it unique",
+			selector, len(values), len(stamps),
+		)
+	}
+	if len(values[0].Samples) != len(stamps[0].Samples) {
+		return nil, fmt.Errorf(
+			"the incumbent answered %d value points and %d timestamp points for %q over one grid; the two range "+
+				"queries must align point for point for the instants to be attributable",
+			len(values[0].Samples), len(stamps[0].Samples), selector,
+		)
+	}
+
+	out := make([]landedSample, 0, len(values[0].Samples))
+	seen := make(map[int64]bool, len(values[0].Samples))
+	for i, v := range values[0].Samples {
+		// timestamp() yields the sample's instant as float SECONDS, and a
+		// float64 cannot hold a present-day Unix second to nanosecond
+		// precision — an instant recorded at .080 comes back as .079999923.
+		// Re-evaluating a rate() there is then a query at a DIFFERENT instant
+		// from the one the ruler evaluated at, and over a ramped source that
+		// shows up as a small but real value difference (observed: 2.7e-06,
+		// against a 1e-09 exact-parity epsilon).
+		//
+		// Rounding to the nearest millisecond is exact rather than a
+		// concession: Prometheus stores every sample timestamp as an int64
+		// count of milliseconds, so the ruler's evaluation instant IS a whole
+		// millisecond and rounding recovers it precisely. Anything finer is
+		// float noise from the wire encoding, never information.
+		recordedSeconds := stamps[0].Samples[i].Value
+		at := time.UnixMilli(int64(math.Round(recordedSeconds * millisPerSecond))).UTC()
+		if seen[at.UnixNano()] {
+			continue
+		}
+		seen[at.UnixNano()] = true
+		out = append(out, landedSample{at: at, value: v.Value})
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].at.Before(out[j].at) })
+	return out, nil
+}
+
+// millisPerSecond converts the float-seconds instant `timestamp()` reports
+// into the integer milliseconds Prometheus actually stores a sample at.
+const millisPerSecond = 1000
+
+// tier2SingleValueAt evaluates expr at one instant against one backend,
+// requiring exactly one series carrying exactly one sample. An empty answer is
+// an error rather than a skipped comparison: skipping would silently shrink
+// the diff to whatever both sides happened to answer.
+func tier2SingleValueAt(ctx context.Context, baseURL, expr string, at time.Time) (float64, error) {
+	got, err := lib.QueryInstantSeries(ctx, baseURL, expr, at)
+	if err != nil {
+		return 0, fmt.Errorf("evaluate %q at %s: %w", expr, at, err)
+	}
+	if len(got) != 1 {
+		return 0, fmt.Errorf("evaluating %q at %s returned %d series, want exactly one", expr, at, len(got))
+	}
+	if len(got[0].Samples) != 1 {
+		return 0, fmt.Errorf(
+			"evaluating %q at %s returned a series with %d samples, want exactly one",
+			expr, at, len(got[0].Samples),
+		)
+	}
+	return got[0].Samples[0].Value, nil
 }
 
 // givenTier2SourceSeriesSeeded writes a fresh, cumulative-increasing
@@ -200,6 +469,19 @@ func (w *World) givenTier2SourceSeriesSeeded() error {
 	}
 	if err := seed.InsertFixture(ctx, conn, fixture); err != nil {
 		return fmt.Errorf("migration harness: seed %s: %w", nodeCPUMetricName, err)
+	}
+	// The SAME fixture, rendered into the incumbent ruler's wire shape. This is
+	// what puts cerberus on exactly one side of MIG-19's comparison: the
+	// incumbent's recording rule computes the same expression over its own copy
+	// of these samples, so its recorded output is an independent answer rather
+	// than an echo. Rendered from the one in-memory fixture rather than
+	// regenerated, so the two backends cannot hold different numbers at the
+	// same instant.
+	if err := seed.WriteSeries(ctx, w.tier2.IncumbentURL, fixture.PromSeries()); err != nil {
+		return fmt.Errorf(
+			"migration harness: remote-write %s to the incumbent ruler at %s: %w",
+			nodeCPUMetricName, w.tier2.IncumbentURL, err,
+		)
 	}
 
 	w.tier2Writeback.seedStart, w.tier2Writeback.seedEnd = start, end

--- a/test/e2e/migration/steps/tier2_writeback.go
+++ b/test/e2e/migration/steps/tier2_writeback.go
@@ -453,7 +453,25 @@ func (w *World) givenTier2SourceSeriesSeeded() error {
 	}
 	defer func() { _ = conn.Close() }()
 
-	end := time.Now().UTC()
+	// Truncated to a whole second, and that is load-bearing rather than tidy.
+	// This fixture is written to BOTH backends, and the two encodings do not
+	// carry the same precision: ClickHouse stores TimeUnix as DateTime64(9),
+	// while Prometheus remote write puts a sample on the wire as
+	// `UnixMilli()` (seed/promwrite.go) — so an untruncated `now` leaves the
+	// two backends holding the SAME sample at instants up to a millisecond
+	// apart. A rate() over a ramped counter then answers slightly differently
+	// on each side, and MIG-19's incumbent diff reports it as a parity
+	// divergence when it is really a seeding artifact. Observed on CI as a
+	// 2.24e-06 disagreement against a 1e-09 epsilon, having passed locally
+	// three times running: whether it bites depends on where a window boundary
+	// happens to fall relative to a sample, which is exactly the kind of
+	// latent flake that must be removed rather than retried.
+	//
+	// A whole second is exactly representable in both encodings, so the two
+	// backends hold identical instants by construction. tier2_parity.go's
+	// MWMBR fixture truncates for the same reason, and measures agreement at
+	// 2.8e-17 as a result. tier2_writeback_test.go pins the property.
+	end := tier2DualSeedAnchor(time.Now())
 	start := end.Add(-tier2SeedWindow)
 	fixture := seed.Fixture{
 		Counter: []seed.MetricSeries{{

--- a/test/e2e/migration/steps/world.go
+++ b/test/e2e/migration/steps/world.go
@@ -133,6 +133,11 @@ type World struct {
 	// streams. See steps/tier2_alerting.go.
 	tier2Alerting tier2AlertingState
 
+	// tier2Parity carries MIG-18's incumbent-versus-shadow diff: the burn-rate
+	// fixture's seeded window and the firing edges each ruler's OWN dead-end
+	// receiver captured. See steps/tier2_parity.go.
+	tier2Parity tier2ParityState
+
 	// tier2Ruler carries the MIG-09 ruler scenario's state (rule groups
 	// polled, notification delta). See steps/then_ruler.go.
 	tier2Ruler tier2RulerState
@@ -253,6 +258,7 @@ func (w *World) InitializeScenario(ctx *godog.ScenarioContext) {
 		w.tier2SeedScope = tier2SeedScopeFor(sc.Name)
 		w.tier2Writeback = tier2WritebackState{}
 		w.tier2Alerting = tier2AlertingState{}
+		w.tier2Parity = tier2ParityState{}
 		w.tier2Ruler = tier2RulerState{}
 		w.tier2ReadBack = recordedReadBack{}
 		w.live, w.liveSet = lib.LiveEndpoints{}, false
@@ -327,6 +333,7 @@ func (w *World) InitializeScenario(ctx *godog.ScenarioContext) {
 	w.registerTier2LiveSteps(ctx)
 	w.registerTier2WritebackSteps(ctx)
 	w.registerTier2AlertingSteps(ctx)
+	w.registerTier2ParitySteps(ctx)
 	w.registerCutoverGateSteps(ctx)
 	w.registerRulerSteps(ctx)
 	w.registerVerifySteps(ctx)

--- a/test/e2e/migration/tiers/tier2-ruler/docker-compose.ruler.yml
+++ b/test/e2e/migration/tiers/tier2-ruler/docker-compose.ruler.yml
@@ -46,13 +46,74 @@
 #                            selectable through cerberus with no further
 #                            wiring.
 #
+# === The INCUMBENT leg (MIG-18 / MIG-19 parity) ===
+#
+# Everything above is the SHADOW: a ruler whose queries reach cerberus. A
+# migration-parity story is about two rulers, and a stream diffed against
+# itself is clean by construction, so the three services below stand up the
+# other half — the ruler an operator is migrating AWAY from, reading its own
+# storage, dispatching through its own Alertmanager, into its own sink:
+#
+#   incumbent-ruler          Reference Prometheus evaluating the SAME rule set
+#                            as the shadow (incumbent-rules.yml mirrors the
+#                            MWMBR groups in grafana/alerting/rules.yaml)
+#                            against its OWN TSDB. It scrapes nothing: the
+#                            harness remote-writes it the identical samples it
+#                            writes to ClickHouse, rendered from ONE in-memory
+#                            fixture, so the two rulers disagree only where an
+#                            engine disagrees — never because they read
+#                            different data.
+#   incumbent-alertmanager   The incumbent's own dispatcher. Deliberately a
+#                            REAL Alertmanager rather than more Grafana: the
+#                            point of the diff is that the two legs share no
+#                            code, so a systematic shadow-side defect cannot
+#                            cancel out.
+#   incumbent-dead-end-receiver
+#                            The incumbent's own sink — a second instance of
+#                            the SAME dead-end receiver image, never the same
+#                            container. One receiver holding both streams
+#                            would interleave them into a single capture list
+#                            with nothing in the payload naming which ruler
+#                            emitted an edge, and the diff would then compare a
+#                            stream against itself with extra steps.
+#
 # Port band: 27400-27500, the next contiguous unclaimed band after Tier-1's
 # own 27000-27400 (see docker-compose.dual.yml's port-band comment).
+# test/regression/migration_tier2_test.go's TestMigrationTier2PortBand pins
+# every published port here inside it, and pins it disjoint from Tier-1's.
 #
 # Usage:
 #   just migration-tier2-up
 #   just migration-tier2-run
 #   just migration-tier2-down
+
+# The dead-end receiver is instantiated TWICE — once per ruler — from one
+# definition, so the shadow's sink and the incumbent's sink cannot drift into
+# behaving differently and turn a real divergence into a substrate artifact.
+# Only the published port differs, and each instance names its own.
+x-dead-end-receiver: &dead-end-receiver
+  image: cerberus-migration-tier2:dead-end-receiver${COMPOSE_PROJECT_SUFFIX:-}
+  pull_policy: build
+  build:
+    # Also resolved against tier1-dual's directory (see the grafana
+    # volumes comment below), which is why this is five `../` rather than
+    # this file's own depth from the repo root — tier1-dual and
+    # tier2-ruler sit at the same depth under tiers/, so the count happens
+    # to be identical either way. Don't "simplify" this without re-checking
+    # docker inspect if tier2-ruler ever moves to a different depth.
+    context: ../../../../..
+    dockerfile: test/e2e/migration/tiers/tier2-ruler/receiver/Dockerfile
+    args:
+      # Mirror-first base image, default upstream. See lib/mirror.mjs.
+      GO_IMAGE: "${GO_IMAGE:-golang:1.26}"
+  healthcheck:
+    # Distroless image: no shell, no wget. The binary's own -healthcheck
+    # mode is the liveness signal, same posture as cerberus's --version
+    # healthcheck in docker-compose.dual.yml.
+    test: ["CMD", "/dead-end-receiver", "-healthcheck"]
+    interval: 2s
+    timeout: 2s
+    retries: 30
 
 services:
   grafana:
@@ -109,31 +170,11 @@ services:
       timeout: 2s
       retries: 24
 
+  # The SHADOW ruler's sink: Grafana's one contact point.
   dead-end-receiver:
-    image: cerberus-migration-tier2:dead-end-receiver${COMPOSE_PROJECT_SUFFIX:-}
-    pull_policy: build
-    build:
-      # Also resolved against tier1-dual's directory (see the grafana
-      # volumes comment above), which is why this is five `../` rather than
-      # this file's own depth from the repo root — tier1-dual and
-      # tier2-ruler sit at the same depth under tiers/, so the count happens
-      # to be identical either way. Don't "simplify" this without re-checking
-      # docker inspect if tier2-ruler ever moves to a different depth.
-      context: ../../../../..
-      dockerfile: test/e2e/migration/tiers/tier2-ruler/receiver/Dockerfile
-      args:
-        # Mirror-first base image, default upstream. See lib/mirror.mjs.
-        GO_IMAGE: "${GO_IMAGE:-golang:1.26}"
+    <<: *dead-end-receiver
     ports:
       - "27450:8090"
-    healthcheck:
-      # Distroless image: no shell, no wget. The binary's own -healthcheck
-      # mode is the liveness signal, same posture as cerberus's --version
-      # healthcheck in docker-compose.dual.yml.
-      test: ["CMD", "/dead-end-receiver", "-healthcheck"]
-      interval: 2s
-      timeout: 2s
-      retries: 30
 
   # === MIG-09/MIG-13/MIG-19 write-back landing leg ===
   #
@@ -158,6 +199,75 @@ services:
       # (no shell, no wget, no nc).
       cerberus:
         condition: service_healthy
+
+  # === The incumbent leg (MIG-18 / MIG-19 parity) ===
+  #
+  # See this file's header for what each of the three is and why the diff
+  # needs them to share no code with the shadow leg.
+
+  # The incumbent's own sink. A second instance of the dead-end receiver, so
+  # the incumbent's notification stream is captured separately from the
+  # shadow's rather than interleaved with it.
+  incumbent-dead-end-receiver:
+    <<: *dead-end-receiver
+    ports:
+      - "27451:8090"
+
+  incumbent-alertmanager:
+    # Pinned alongside prom/prometheus above: Alertmanager's webhook payload
+    # is the shape steps/tier2_alerting.go's ParseGrafanaWebhookEvents already
+    # decodes (Grafana's notifier is Alertmanager-compatible by construction),
+    # so both streams parse through ONE decoder and a parse difference cannot
+    # masquerade as a parity difference.
+    image: prom/alertmanager:v0.28.1
+    command:
+      - "--config.file=/etc/alertmanager/alertmanager.yml"
+      - "--storage.path=/alertmanager"
+    volumes:
+      # Relative to tier1-dual/docker-compose.dual.yml's directory, NOT this
+      # file's own — see the grafana service's volumes comment above for why.
+      - ../tier2-ruler/incumbent/alertmanager.yml:/etc/alertmanager/alertmanager.yml:ro
+    ports:
+      - "27470:9093"
+    depends_on:
+      incumbent-dead-end-receiver:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD-SHELL", "wget -qO- http://localhost:9093/-/ready || exit 1"]
+      interval: 2s
+      timeout: 2s
+      retries: 30
+
+  incumbent-ruler:
+    # The same reference-Prometheus tag tier1-dual's `prometheus` and this
+    # file's `relay-prom` run, held in lock-step with go.mod by
+    # test/regression/fork_version_skew_test.go — an incumbent on a different
+    # engine version would make every diff argue about which version was
+    # right rather than about cerberus.
+    image: prom/prometheus:v3.11.3
+    command:
+      - "--config.file=/etc/prometheus/prometheus.yml"
+      - "--storage.tsdb.path=/prometheus"
+      # The harness writes this instance the SAME samples it writes to
+      # ClickHouse. Nothing scrapes: a scrape would give the two rulers
+      # different inputs and the diff would measure the seeder, not cerberus.
+      - "--web.enable-remote-write-receiver"
+      - "--web.listen-address=:9090"
+    volumes:
+      # Relative to tier1-dual/docker-compose.dual.yml's directory, NOT this
+      # file's own — see the grafana service's volumes comment above for why.
+      - ../tier2-ruler/incumbent/prometheus.yml:/etc/prometheus/prometheus.yml:ro
+      - ../tier2-ruler/incumbent/incumbent-rules.yml:/etc/prometheus/incumbent-rules.yml:ro
+    ports:
+      - "27460:9090"
+    depends_on:
+      incumbent-alertmanager:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD-SHELL", "wget -qO- http://localhost:9090/-/ready || exit 1"]
+      interval: 2s
+      timeout: 2s
+      retries: 30
 
   relay-prom:
     image: prom/prometheus:v3.11.3

--- a/test/e2e/migration/tiers/tier2-ruler/grafana/alerting/rules.yaml
+++ b/test/e2e/migration/tiers/tier2-ruler/grafana/alerting/rules.yaml
@@ -148,6 +148,124 @@ groups:
   #                    in the dead-end receiver during MIG-09's own
   #                    notification-delta assertion, which runs earlier in the
   #                    same suite against the same receiver.
+  # === MIG-18's multi-window multi-burn-rate SLO fixture (shadow side) ===
+  #
+  # The shadow half of the pair whose incumbent half is
+  # ../../incumbent/incumbent-rules.yml's `migration.mwmbr` group. That file
+  # carries the full rationale for the fixture — what makes it genuinely
+  # multi-window and multi-burn-rate, why the windows are scaled to a CI
+  # budget, and why the seed drives one burning and one clean `slo` identity
+  # through it. Read it first; this file only wraps the same rules in
+  # Grafana's scheduling shape.
+  #
+  # What must stay byte-identical across the two files, because MIG-18 diffs
+  # the streams these rules produce and a difference in the RULE would read as
+  # a difference between the RULERS:
+  #
+  #   title      == the incumbent's `alert:` name. Both rulers stamp it as
+  #                `alertname`, which is the first component of the alert
+  #                identity the diff matches on.
+  #   expr       == the incumbent's `expr`, including both window arms and
+  #                both thresholds. The arithmetic lives in the PromQL on both
+  #                sides precisely so there is one copy of it per rule rather
+  #                than one in PromQL and one in a Grafana threshold.
+  #   for        == the incumbent's `for:`.
+  #   labels     == the incumbent's `labels:`. These are the routing keys the
+  #                diff compares on beyond the name.
+  #
+  # steps/tier2_alerting_test.go reads both files and fails offline on any
+  # drift, so a one-sided edit cannot reach a live run.
+  #
+  # `condition: C` is a `gt 0` threshold rather than the burn threshold
+  # itself: the expression above it already applies `> 0.0144`, so it returns
+  # a value only for an slo that is genuinely burning, and the threshold's
+  # only job is to turn "the query returned this series" into "this series is
+  # alerting". Putting the burn number here instead would give the shadow leg
+  # its own copy of the arithmetic to drift from.
+  #
+  # `noDataState: OK` for the same reason the probe below declares it: the
+  # clean `slo` identity returns NO series by design, and a rule that alerted
+  # on absence would put an edge in the shadow's stream that the incumbent —
+  # which simply does not fire a rule whose vector is empty — has no
+  # counterpart for. That would report as a false positive against cerberus
+  # when it is really a Grafana no-data policy.
+  - orgId: 1
+    name: migration.mwmbr
+    folder: migration-lane
+    interval: 10s
+    rules:
+      - uid: migration-slo-fast-burn
+        title: MigrationSLOFastBurn
+        condition: C
+        data:
+          - refId: A
+            relativeTimeRange: { from: 1800, to: 0 }
+            datasourceUid: cerberus-prometheus
+            model:
+              expr: |
+                (
+                  sum by (slo, seed_scope) (rate(cerberus_migration_slo_errors_total[1m]))
+                    / sum by (slo, seed_scope) (rate(cerberus_migration_slo_requests_total[1m]))
+                  > 0.0144
+                )
+                and
+                (
+                  sum by (slo, seed_scope) (rate(cerberus_migration_slo_errors_total[5m]))
+                    / sum by (slo, seed_scope) (rate(cerberus_migration_slo_requests_total[5m]))
+                  > 0.0144
+                )
+              instant: true
+              refId: A
+          - refId: C
+            datasourceUid: __expr__
+            model:
+              type: threshold
+              expression: A
+              conditions:
+                - evaluator: { type: gt, params: [0] }
+        for: 30s
+        labels: { severity: critical, burn_rate: fast }
+        annotations:
+          summary: "the {{ $labels.slo }} error budget is burning fast"
+        noDataState: OK
+        execErrState: Error
+
+      - uid: migration-slo-slow-burn
+        title: MigrationSLOSlowBurn
+        condition: C
+        data:
+          - refId: A
+            relativeTimeRange: { from: 1800, to: 0 }
+            datasourceUid: cerberus-prometheus
+            model:
+              expr: |
+                (
+                  sum by (slo, seed_scope) (rate(cerberus_migration_slo_errors_total[3m]))
+                    / sum by (slo, seed_scope) (rate(cerberus_migration_slo_requests_total[3m]))
+                  > 0.006
+                )
+                and
+                (
+                  sum by (slo, seed_scope) (rate(cerberus_migration_slo_errors_total[15m]))
+                    / sum by (slo, seed_scope) (rate(cerberus_migration_slo_requests_total[15m]))
+                  > 0.006
+                )
+              instant: true
+              refId: A
+          - refId: C
+            datasourceUid: __expr__
+            model:
+              type: threshold
+              expression: A
+              conditions:
+                - evaluator: { type: gt, params: [0] }
+        for: 30s
+        labels: { severity: warning, burn_rate: slow }
+        annotations:
+          summary: "the {{ $labels.slo }} error budget is burning slowly"
+        noDataState: OK
+        execErrState: Error
+
   - orgId: 1
     name: migration.probe
     folder: migration-lane

--- a/test/e2e/migration/tiers/tier2-ruler/incumbent/alertmanager.yml
+++ b/test/e2e/migration/tiers/tier2-ruler/incumbent/alertmanager.yml
@@ -1,0 +1,28 @@
+# The INCUMBENT ruler's Alertmanager (Layer 14, Tier 2).
+#
+# One catch-all route into one webhook receiver — the incumbent's own dead-end
+# sink, never the shadow's. "Computes, never pages" holds on this leg exactly
+# as it does on the other: nothing here forwards anywhere real.
+#
+# The timers mirror the shadow's notification policy
+# (../grafana/alerting/notification-policies.yaml) value for value. That is
+# load-bearing rather than tidy: MIG-18 compares WHEN each ruler's edges
+# landed, and a dispatcher holding one stream back longer than the other would
+# inject a delivery difference into a comparison that is supposed to be about
+# the two rulers' evaluation. `repeat_interval` stays long for the same reason
+# it does there — a re-notification of an unchanged group would add edges to
+# one stream that the other has no counterpart for.
+route:
+  receiver: incumbent-dead-end
+  group_by: ["alertname"]
+  group_wait: 5s
+  group_interval: 10s
+  repeat_interval: 4h
+
+receivers:
+  - name: incumbent-dead-end
+    webhook_configs:
+      - url: http://incumbent-dead-end-receiver:8090/webhook
+        # Both legs must emit a resolve edge, or MIG-18's resolve half would
+        # diff a stream that has one against a stream that never sends one.
+        send_resolved: true

--- a/test/e2e/migration/tiers/tier2-ruler/incumbent/incumbent-rules.yml
+++ b/test/e2e/migration/tiers/tier2-ruler/incumbent/incumbent-rules.yml
@@ -1,0 +1,113 @@
+# The INCUMBENT ruler's rule set (Layer 14, Tier 2).
+#
+# Every rule here has a counterpart in ../grafana/alerting/rules.yaml that
+# computes the SAME PromQL over the SAME data. That pairing is the whole
+# fixture: MIG-18 diffs the two rulers' notification streams and MIG-19 diffs
+# their recorded output, and neither diff means anything if the two sides are
+# not evaluating the same rule. steps/tier2_alerting_test.go's fixture pins
+# read BOTH files and fail offline when an `expr`, a `for:`, a threshold, a
+# label or an alert name drifts on one side only.
+#
+# The one deliberate asymmetry is scheduling: this file's groups declare the
+# same `interval` the shadow's do, but Prometheus offsets each group by
+# hash(group, file) % interval and Grafana ticks epoch-aligned, so the two
+# grids share a length and not a phase. See prometheus.yml's own comment.
+
+groups:
+  # === MIG-19: the recorded series, on the incumbent's own grid ===
+  #
+  # Byte-identical `expr` to the shadow's `node:node_cpu_utilisation:avg1m`
+  # recording rule. The shadow records it by asking cerberus and landing the
+  # answer in ClickHouse through the write-back bridge; this side records it
+  # by asking its own engine over its own copy of the same samples. MIG-19
+  # compares the two, which is what puts cerberus on exactly ONE side of the
+  # comparison — the gap its scope note used to name.
+  #
+  # `seed_scope` needs no mention here: `avg without (cpu)` keeps every label
+  # except `cpu`, so each Tier-2 scenario's own scope comes out as its own
+  # recorded series exactly as it does on the shadow side.
+  - name: node.rules
+    interval: 10s
+    rules:
+      - record: "node:node_cpu_utilisation:avg1m"
+        expr: 1 - avg without (cpu) (rate(node_cpu_seconds_total{mode="idle"}[5m]))
+
+  # === MIG-18: the multi-window multi-burn-rate SLO fixture ===
+  #
+  # The fixture MIG-18's PASS cell has always named and the substrate never
+  # had. It is a real MWMBR pair, not a threshold alert wearing the name:
+  #
+  #   * MULTI-WINDOW — each alert requires its SHORT and its LONG window to
+  #     exceed the burn threshold at once. The long window is what stops a
+  #     one-off spike paging; the short window is what lets the alert clear
+  #     promptly once the burn stops. An alert that fired on either window
+  #     alone would be a different, weaker rule.
+  #   * MULTI-BURN-RATE — two severities off one error budget: a fast-burn
+  #     page and a slow-burn ticket, each with its own burn factor and its own
+  #     window pair. One burn rate is a threshold alert; two are what make the
+  #     rule an SLO policy, and what gives the diff more than one identity to
+  #     get wrong.
+  #
+  # Window lengths are scaled to a CI budget (5m/1m and 15m/3m rather than
+  # 1h/5m and 6h/30m), which changes how much history the seed must carry and
+  # nothing about the rule's shape. The burn factors and the 0.1% error budget
+  # are the standard ones, so the thresholds below are the real arithmetic:
+  # 14.4 * 0.001 = 0.0144 and 6 * 0.001 = 0.006.
+  #
+  # The seed drives TWO slo identities through these rules on both sides: one
+  # burning (both rulers must fire it) and one clean (neither may). That is
+  # what exercises both arms of DiffAlertStreams — a shadow that fired the
+  # clean identity is a false positive, one that missed the burning identity a
+  # false negative — instead of only proving that something, somewhere, fired.
+  #
+  # Both aggregations keep `seed_scope` alongside `slo` for the reason
+  # steps/tier2_seed_scope.go sets out at length: `migration-tier2-run` may be
+  # re-run against one long-lived stack, and a second run re-seeding the first
+  # run's series identity makes the stored counter go up, down, then up again —
+  # which `rate()` reads as a counter reset, so the burn rate stops meaning
+  # anything. Keeping the scope as a grouping key gives each run its own series
+  # AND its own alert identity, so runs cannot perturb each other. It is a
+  # grouping key rather than a matcher because these rules are provisioned
+  # statically and cannot know a scope the harness mints per run.
+  - name: migration.mwmbr
+    interval: 10s
+    rules:
+      - alert: MigrationSLOFastBurn
+        expr: |
+          (
+            sum by (slo, seed_scope) (rate(cerberus_migration_slo_errors_total[1m]))
+              / sum by (slo, seed_scope) (rate(cerberus_migration_slo_requests_total[1m]))
+            > 0.0144
+          )
+          and
+          (
+            sum by (slo, seed_scope) (rate(cerberus_migration_slo_errors_total[5m]))
+              / sum by (slo, seed_scope) (rate(cerberus_migration_slo_requests_total[5m]))
+            > 0.0144
+          )
+        for: 30s
+        labels:
+          severity: critical
+          burn_rate: fast
+        annotations:
+          summary: "the {{ $labels.slo }} error budget is burning fast"
+
+      - alert: MigrationSLOSlowBurn
+        expr: |
+          (
+            sum by (slo, seed_scope) (rate(cerberus_migration_slo_errors_total[3m]))
+              / sum by (slo, seed_scope) (rate(cerberus_migration_slo_requests_total[3m]))
+            > 0.006
+          )
+          and
+          (
+            sum by (slo, seed_scope) (rate(cerberus_migration_slo_errors_total[15m]))
+              / sum by (slo, seed_scope) (rate(cerberus_migration_slo_requests_total[15m]))
+            > 0.006
+          )
+        for: 30s
+        labels:
+          severity: warning
+          burn_rate: slow
+        annotations:
+          summary: "the {{ $labels.slo }} error budget is burning slowly"

--- a/test/e2e/migration/tiers/tier2-ruler/incumbent/prometheus.yml
+++ b/test/e2e/migration/tiers/tier2-ruler/incumbent/prometheus.yml
@@ -1,0 +1,51 @@
+# Reference-Prometheus config for the Tier-2 INCUMBENT ruler (Layer 14) — the
+# ruler an operator is migrating away from, standing opposite the Grafana
+# shadow ruler so MIG-18's notification-stream diff and MIG-19's recorded-
+# series diff have two independently scheduled legs to compare.
+#
+# This instance holds NO scrape config on purpose. The harness remote-writes
+# it the identical samples it writes to ClickHouse, both rendered from ONE
+# in-memory fixture (test/e2e/migration/seed's Fixture -> PromSeries), so the
+# only thing the two rulers can disagree about is how their engines evaluate
+# the same rule over the same data. A scrape job would give each side its own
+# sample timestamps and the diff would measure the seeder instead.
+global:
+  # The shared evaluation cadence both rulers run at: the shadow's rule groups
+  # declare `interval: 10s` (grafana/alerting/rules.yaml) and every group in
+  # incumbent-rules.yml declares the same. It is the quantum
+  # steps/tier2_alerting.go's QuantizeToEvalInterval floors fire/resolve edges
+  # to — "the same evaluation" is only a meaningful predicate when both rulers
+  # tick at one interval.
+  #
+  # The two grids are the same LENGTH but not the same PHASE, and cannot be
+  # made so: Prometheus offsets a group's evaluation by hash(group, file) %
+  # interval, and v3.11.3 has no `align_evaluation_time_on_interval` knob to
+  # turn that off (confirmed empirically — promtool rejects the field). That
+  # residual sub-interval phase difference is exactly the skew section 5 of
+  # docs/migration-testing.md calls "not a cerberus artifact", and it is why
+  # MIG-18 asserts a MEASURED skew bound rather than pretending two
+  # independent schedulers tick together.
+  evaluation_interval: 10s
+  # Nothing is scraped; this only stops Prometheus defaulting to a shorter
+  # timer it would never use.
+  scrape_interval: 1m
+
+storage:
+  tsdb:
+    # The harness seeds historical windows, and several Tier-2 scenarios seed
+    # against one long-lived stack in whatever order the suite runs them — so
+    # a later scenario's window can open before an earlier one's newest
+    # sample. Without an out-of-order window Prometheus would reject those
+    # appends and the incumbent leg would silently hold less data than
+    # ClickHouse, which reads as a parity divergence rather than as the
+    # ingestion refusal it is. The window comfortably exceeds the longest
+    # span any Tier-2 scenario seeds.
+    out_of_order_time_window: 1h
+
+rule_files:
+  - /etc/prometheus/incumbent-rules.yml
+
+alerting:
+  alertmanagers:
+    - static_configs:
+        - targets: ["incumbent-alertmanager:9093"]

--- a/test/regression/migration_tier2_test.go
+++ b/test/regression/migration_tier2_test.go
@@ -1,0 +1,148 @@
+package regression
+
+import (
+	"strings"
+	"testing"
+)
+
+// Tier-2's own published-port band, and the pins that keep it honest.
+//
+// Tier-1 has had TestMigrationTier1PortBand since it was written; Tier-2 had
+// none, so its ports were governed only by a comment in the compose file. That
+// was survivable while the ruler tier published two ports. It stopped being
+// survivable when the incumbent leg (a second ruler, its own Alertmanager and
+// its own dead-end receiver) added three more: a stack whose ports drift out of
+// band does not fail loudly, it cross-wires onto a leftover container from
+// another stack and reports parity against a stale dataset.
+const (
+	tier2PortBandLow  = 27400
+	tier2PortBandHigh = 27500
+)
+
+// tier2ComposePath is the ruler tier's compose file, which merges on top of
+// tier-1's rather than standing alone.
+const tier2ComposePath = "../e2e/migration/tiers/tier2-ruler/docker-compose.ruler.yml"
+
+// TestMigrationTier2PortBand pins every port the ruler tier publishes inside
+// its own band, and disjoint from tier-1's — which matters more here than for
+// any other pair in the tree, because the two files are always merged into ONE
+// compose project. A collision between them is not two stacks fighting; it is
+// one stack that cannot start.
+func TestMigrationTier2PortBand(t *testing.T) {
+	t.Parallel()
+
+	tier2 := hostPorts(t, tier2ComposePath)
+	if len(tier2) == 0 {
+		t.Fatalf("%s publishes no host ports; the ruler substrate is unreachable from the test host", tier2ComposePath)
+	}
+	for port, svc := range tier2 {
+		if port < tier2PortBandLow || port > tier2PortBandHigh {
+			t.Fatalf("tier-2 service %s publishes host port %d, outside the declared %d-%d band. "+
+				"The band is what keeps a tier-2 run from cross-wiring onto another stack's leftovers.",
+				svc, port, tier2PortBandLow, tier2PortBandHigh)
+		}
+	}
+
+	// Tier-1 is merged into the SAME project, so its ports are the ones a
+	// collision would actually break.
+	for port, svc := range hostPorts(t, tier1ComposePath) {
+		if tier2Svc, clash := tier2[port]; clash {
+			t.Fatalf("host port %d is published by BOTH tier-2 service %s and tier-1 service %s, and the two "+
+				"files are merged into one compose project — the stack cannot start. Move the tier-2 mapping "+
+				"to a free port inside the %d-%d band.",
+				port, tier2Svc, svc, tier2PortBandLow, tier2PortBandHigh)
+		}
+	}
+
+	for _, other := range otherComposeFiles {
+		for port, svc := range hostPorts(t, other) {
+			if tier2Svc, clash := tier2[port]; clash {
+				t.Fatalf("host port %d is published by BOTH tier-2 service %s and %s service %s. "+
+					"Move the tier-2 mapping to a free port inside the %d-%d band.",
+					port, tier2Svc, other, svc, tier2PortBandLow, tier2PortBandHigh)
+			}
+		}
+	}
+}
+
+// The incumbent leg's two services, and the reference-Prometheus tag the ruler
+// one must carry.
+const (
+	tier2IncumbentRuler       = "incumbent-ruler"
+	tier2IncumbentAlertmgr    = "incumbent-alertmanager"
+	tier2IncumbentReceiver    = "incumbent-dead-end-receiver"
+	tier2ShadowReceiver       = "dead-end-receiver"
+	tier2ReferencePromService = "relay-prom"
+)
+
+// TestMigrationTier2IncumbentRulerTracksTheReferencePrometheus pins the
+// incumbent ruler to the SAME reference-Prometheus image the rest of the tree
+// runs.
+//
+// MIG-18 and MIG-19 diff cerberus against this container's engine, so it is the
+// oracle both scenarios' verdicts rest on. An incumbent left behind on an older
+// tag would make every divergence an argument about which Prometheus version
+// was right rather than about cerberus — and it would do so silently, because a
+// stale oracle still answers every query.
+func TestMigrationTier2IncumbentRulerTracksTheReferencePrometheus(t *testing.T) {
+	t.Parallel()
+
+	cf := readCompose(t, tier2ComposePath)
+	relay, ok := cf.Services[tier2ReferencePromService]
+	if !ok {
+		t.Fatalf("%s declares no %s service to take the reference-Prometheus tag from", tier2ComposePath, tier2ReferencePromService)
+	}
+	incumbent, ok := cf.Services[tier2IncumbentRuler]
+	if !ok {
+		t.Fatalf("%s declares no %s service; MIG-18/MIG-19 would have no incumbent leg to diff against",
+			tier2ComposePath, tier2IncumbentRuler)
+	}
+	if incumbent.Image != relay.Image {
+		t.Fatalf("the incumbent ruler runs %q but the reference Prometheus in the same file runs %q. "+
+			"The incumbent is the oracle MIG-18/MIG-19 diff cerberus against, so it must be the same engine "+
+			"version the rest of the tree calls the reference.",
+			incumbent.Image, relay.Image)
+	}
+	if !hasFlag(incumbent.Command, "--web.enable-remote-write-receiver") {
+		t.Fatalf("the incumbent ruler does not enable the remote-write receiver, so the harness cannot seed it " +
+			"the SAME samples it writes to ClickHouse — and a diff over different inputs measures the seeder")
+	}
+}
+
+// TestMigrationTier2IncumbentHasItsOwnReceiver pins the two dead-end receivers
+// apart.
+//
+// One receiver serving both rulers would interleave their notification streams
+// into a single capture list, and nothing in a webhook payload names which
+// ruler emitted an edge — so MIG-18's diff would silently become a stream
+// compared against itself, which is clean by construction and proves nothing.
+func TestMigrationTier2IncumbentHasItsOwnReceiver(t *testing.T) {
+	t.Parallel()
+
+	cf := readCompose(t, tier2ComposePath)
+	for _, name := range []string{tier2ShadowReceiver, tier2IncumbentReceiver, tier2IncumbentAlertmgr} {
+		if _, ok := cf.Services[name]; !ok {
+			t.Fatalf("%s declares no %s service; the incumbent leg is incomplete and MIG-18's diff would have "+
+				"only one stream", tier2ComposePath, name)
+		}
+	}
+	shadowPorts := cf.Services[tier2ShadowReceiver].Ports
+	incumbentPorts := cf.Services[tier2IncumbentReceiver].Ports
+	if len(shadowPorts) == 0 || len(incumbentPorts) == 0 {
+		t.Fatalf("both dead-end receivers must publish a host port so each ruler's stream is separately readable")
+	}
+	if shadowPorts[0] == incumbentPorts[0] {
+		t.Fatalf("both dead-end receivers publish %q — they are one endpoint, so the two rulers' streams would "+
+			"be read from the same capture list", shadowPorts[0])
+	}
+}
+
+// hasFlag reports whether a compose command list carries an exact flag.
+func hasFlag(command []string, flag string) bool {
+	for _, arg := range command {
+		if arg == flag || strings.HasPrefix(arg, flag+"=") {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
MIG-18 and MIG-19 asserted the shadow ruler's **own self-consistency**. Their section-6 PASS cells demanded an *incumbent-vs-shadow* diff, which the substrate could not serve: it stood up ONE ruler, and a stream compared against itself is clean by construction. The comparator (`QuantizeToEvalInterval` / `DiffAlertStreams` / `BakeWindowHoldsZero`) was already written and unit-tested — only the substrate was missing.

## The incumbent leg

Three services, sharing no code with the shadow:

| service | role |
| --- | --- |
| `incumbent-ruler` | reference Prometheus, evaluating over its **own** TSDB |
| `incumbent-alertmanager` | its own dispatcher — a real Alertmanager, not more Grafana |
| `incumbent-dead-end-receiver` | its own sink |

The second receiver is not incidental: one receiver holding both streams would interleave them into a single capture list, and nothing in a webhook payload names which ruler emitted an edge — the diff would silently become a stream compared against itself.

Both rulers are handed **one** in-memory fixture rendered into each backend's wire shape (never regenerated per side — two sample paths cannot land identical timestamps), so they can disagree only where an engine disagrees.

## The MWMBR fixture

A real multi-window multi-burn-rate pair, not a threshold alert with an SLO-sounding name: a fast-burn page and a slow-burn ticket off one 0.1% error budget, each requiring its **long AND short** window over threshold at once. It drives two `slo` identities — one burning, one intact — so the diff exercises the false-**positive** arm as well as the false-negative one. A single burning identity would let a ruler that paged indiscriminately sail through.

## What is asserted

**MIG-18** — zero false positives and zero false negatives; the intact SLO paged by neither ruler (asserted by name, not just by count); the burn rate both rulers page off holds equal across the **full** bake window.

Timing skew is **bounded and measured, not asserted zero**. The two schedulers cannot be phase-locked: Prometheus offsets a group by `hash(group, file) % interval`, Grafana ticks epoch-aligned, and prom v3.11.3 has no `align_evaluation_time_on_interval` (verified — `promtool` rejects the field). Live, the same *correct* alert fires ~3s apart on the two legs, straddling a 10s quantization bucket about half the time. So `DiffAlertStreams` owns the verdict that cannot be blamed on scheduling, and `SkewBoundHolds` owns the magnitude quantization discards — a shadow firing four minutes late is a real defect that quantization alone would file indistinguishably from a 3s phase difference.

**MIG-19** — every landed sample is diffed against the **incumbent's engine** at the same instant, putting cerberus on exactly one side; and the incumbent's own recorded series is held to that engine on its own grid, so its `record:` rule cannot be deleted unnoticed.

## Proving the gate has teeth

Both were verified by **injected divergence** on a live stack:

- A shadow rule computing a burn ratio of 1 for every SLO was caught as a false positive naming `slo=search`, with both streams printed in the failure.
- Perturbing the incumbent's copy of the source data was caught by the new cross-ruler check **while the pre-existing cerberus-vs-cerberus step still passed** (26/27 steps green) — precisely the class of bug the old self-consistency check was blind to.

Reverted, both scenarios pass end to end on a fresh stack.

## Two latent bugs fixed here

Both were tripped by the new rules rather than introduced by them:

- `fetchJSONInto` applied an **error-message** body limit to the **success** path, so Grafana's rule listing silently truncated once it outgrew 4 KB and `json.Unmarshal` reported "unexpected end of JSON input" — reading as a broken ruler rather than a harness limit. `lib/promquery.go` already had this right.
- The incumbent's recorded instants need millisecond rounding: `timestamp()` reports float **seconds**, which cannot round-trip a present-day Unix instant (`.080` came back as `.079999923`), and re-evaluating a `rate()` 77ns off showed up as a 2.7e-06 divergence against a 1e-09 epsilon. Prometheus stores sample timestamps as int64 milliseconds, so the rounding is exact rather than a concession.

## Also

- The MWMBR fixture carries `seed_scope` like the rest of the suite, so re-running `migration-tier2-run` against a live stack cannot interleave two runs' counters into a phantom counter reset.
- Adds `TestMigrationTier2PortBand` — only Tier-1 had a port-band gate, and this PR adds three published ports — plus a pin holding the incumbent to the same reference-Prometheus tag the rest of the tree runs, since it is the oracle both scenarios rest on.
- `docs/migration-testing.md`'s MIG-18/MIG-19 PASS cells now describe what is proven, with `pass-assertions.pin.json` updated in the same diff.

## Verification

- `just migration-tier2` MIG-18 + MIG-19 green on a fresh stack (150s), twice.
- Coverage ratchet: `30/30 scenarios across 26/26 stories, 0 violations`.
- `go test ./test/regression/` and `./test/e2e/migration/...` green; `mirror-images.test.mjs` 5/5.

Closes #1541

🤖 Generated with [Claude Code](https://claude.com/claude-code)
