### PR TITLE
fix(deploy): register the cerberus OCI chart on Artifact Hub

### DIFF
--- a/deploy/helm/cerberus/artifacthub-repo.yml
+++ b/deploy/helm/cerberus/artifacthub-repo.yml
@@ -6,10 +6,10 @@
 #     --config /dev/null:application/vnd.cncf.artifacthub.config.v1+yaml \
 #     artifacthub-repo.yml:application/vnd.cncf.artifacthub.repository-metadata.layer.v1.yaml
 #
-# repositoryID is the UUID Artifact Hub issues when the OCI repo
-# (oci://ghcr.io/tsouza/cerberus/charts/cerberus) is registered. Fill it in
-# after registration; until then AH cannot verify ownership.
-repositoryID: ""
+# repositoryID is the UUID Artifact Hub issued when the OCI repo
+# (oci://ghcr.io/tsouza/cerberus/charts/cerberus) was registered under the
+# tsouza account, confirming AH can verify ownership of the published chart.
+repositoryID: "fbc1f47f-a94d-49ba-b78e-0c2289139c20"
 owners:
   - name: tsouza
     email: tcostasouza@gmail.com


### PR DESCRIPTION
## Summary

- Registers `oci://ghcr.io/tsouza/cerberus/charts/cerberus` on Artifact Hub via the API (`repository_id: fbc1f47f-a94d-49ba-b78e-0c2289139c20`, `user_alias: tsouza`).
- Fills in `deploy/helm/cerberus/artifacthub-repo.yml`'s `repositoryID`, so the existing `Push Artifact Hub metadata` release step (`.github/workflows/release.yml:767-768`, `chart-publish.mjs ah-metadata`) publishes an ownership-verified metadata artifact on the next release.

Without this, Artifact Hub cannot confirm the publisher owns the chart it already discovered and is tracking/scanning — no "Verified Publisher" badge, no ownership link back to the repo.

## Test plan

- [x] Confirmed via `curl https://artifacthub.io/api/v1/repositories/search?name=cerberus` that the repository now exists with the expected `url`, `user_alias: tsouza`, and a live `digest`/`last_tracking_ts`/`last_scanning_ts`.
- [x] Confirmed `chart-publish.mjs`'s `ah-metadata` subcommand reads exactly this file (`artifacthub-repo.yml:202`), so the next release run republishes it with the filled-in ID.

Closes #1503