### PR TITLE
docs(readme): add the Artifact Hub badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ _Keep Grafana, alerting, and your CLI tooling. Swap the backend._
 [![License: Apache 2.0](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](LICENSE)
 [![Go Reference](https://pkg.go.dev/badge/github.com/tsouza/cerberus.svg)](https://pkg.go.dev/github.com/tsouza/cerberus)
 [![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/tsouza/cerberus)
+[![Artifact Hub](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/cerberus)](https://artifacthub.io/packages/search?repo=cerberus)
 
 [![PromQL compat](https://img.shields.io/endpoint?url=https%3A%2F%2Fraw.githubusercontent.com%2Ftsouza%2Fcerberus%2Fcompat-scores%2Fbadges%2Fprometheus.json)](https://github.com/tsouza/cerberus/actions/workflows/compatibility.yml)
 [![LogQL compat](https://img.shields.io/endpoint?url=https%3A%2F%2Fraw.githubusercontent.com%2Ftsouza%2Fcerberus%2Fcompat-scores%2Fbadges%2Floki.json)](https://github.com/tsouza/cerberus/actions/workflows/compatibility.yml)


### PR DESCRIPTION
## Summary

- Adds the Artifact Hub badge to the README header, alongside the existing License/Go Reference/DeepWiki badges.
- The badge resolves now that the cerberus OCI chart repository is registered and ownership-verified on Artifact Hub (#1503, PR #2079).

## Test plan

- [x] Confirmed `https://artifacthub.io/badge/repository/cerberus` returns HTTP 200 with a valid badge payload.