### PR TITLE
fix(engine): declare the response shape on every route-B solver dispatch

### DIFF
--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -1184,6 +1184,30 @@ func (e *Engine) classify(plan chplan.Node, lang Lang) (*solver.Decision, bool) 
 	return e.Solver.Classify(plan, rm)
 }
 
+// routeBExecCtx builds the ctx EVERY route-B dispatch hands to
+// solver.Executor.Execute — the four of them: executeRouted, its streaming
+// sibling executeRoutedCursor, the route-memo hit and the A->B retry. Two
+// values ride it, and both are per-dispatch facts rather than ctx lineage, so
+// this is derived from the arguments at the dispatch site rather than assumed
+// to be already present on the caller's ctx (the retry paths run on a ctx the
+// HANDLER supplies at drain time, which carries neither):
+//
+//   - the head's progress recorder, as route A's dispatch does; and
+//   - the adapter's declared response shape, so the shard cursors the Executor
+//     opens through internal/solver's own CursorQuerier get the SAME
+//     defense-in-depth AND-gate dispatchRouteACursor gives route A (#1429):
+//     chclient's columnar matrix decode confirms the caller INTENDS the matrix
+//     shape on top of its structural name/type test (#1753).
+//
+// The Executor takes no ResponseShape parameter — ctx is the only channel —
+// and stamping it here rather than inside internal/solver is what keeps the
+// declaration a property of the adapter's Meta, exactly as on route A. It
+// survives to each shard's QueryCursor by ordinary ctx nesting; internal/
+// solver's response_shape_wiring_test.go pins that arrival.
+func routeBExecCtx(ctx context.Context, langName, responseShape string) context.Context {
+	return chclient.WithResponseShape(chclient.WithProgressFor(ctx, langName), responseShape)
+}
+
 // executeRouted runs the dormant route-B path: it dispatches the K shard
 // cursors through the Solver's Executor and drains the composed cursor into
 // the eager Result slice. It is NEVER reached under Mode=single (classify
@@ -1203,7 +1227,7 @@ func (e *Engine) executeRouted(
 	execT := telemetry.ObserveStage(telemetry.StageExecute, lang.Name())
 	start := time.Now()
 	cursor, info, err := e.Solver.Executor.Execute(
-		chclient.WithProgressFor(ctx, lang.Name()), lang.Name(), decision, chclient.SampleBudgetFromContext(ctx),
+		routeBExecCtx(ctx, lang.Name(), meta.ResponseShape), lang.Name(), decision, chclient.SampleBudgetFromContext(ctx),
 	)
 	if err != nil {
 		execT.Done(ctx)
@@ -1402,7 +1426,7 @@ func (e *Engine) QueryPlanCursor(ctx context.Context, lang Lang, plan chplan.Nod
 	// back to the ordinary route-A dispatch below exactly as if this had
 	// never run (Major-2's symmetric fallback).
 	budget := chclient.SampleBudgetFromContext(ctx)
-	if cur, info, usedDecision, key, ok := e.tryRouteMemoHit(chclient.WithProgressFor(ctx, lang.Name()), lang.Name(), plan, decision, budget); ok {
+	if cur, info, usedDecision, key, ok := e.tryRouteMemoHit(ctx, lang.Name(), meta.ResponseShape, plan, decision, budget); ok {
 		result := e.buildRoutedCursorResult(meta, plan, lang.Name(), usedDecision, cur, info, "memo-hit")
 		result.Retry = func(retryCtx context.Context, drainErr error) (CursorResult, bool) {
 			// The verdict already existed before this dispatch (that is
@@ -1436,8 +1460,7 @@ func (e *Engine) QueryPlanCursor(ctx context.Context, lang Lang, plan chplan.Nod
 		// this returns a routed CursorResult from route B instead; on
 		// failure (including "retry does not apply here") the original
 		// route-A error is what surfaces, unchanged.
-		execCtx := chclient.WithProgressFor(ctx, lang.Name())
-		if cur, info, usedDecision, observeFn, retried := e.retryOnRouteAResourceFailure(execCtx, lang.Name(), plan, decision, budget, err); retried {
+		if cur, info, usedDecision, observeFn, retried := e.retryOnRouteAResourceFailure(ctx, lang.Name(), meta.ResponseShape, plan, decision, budget, err); retried {
 			retryResult := e.buildRoutedCursorResult(meta, plan, lang.Name(), usedDecision, cur, info, "retry")
 			retryResult.ObserveDrainOutcome = observeFn
 			return retryResult, nil
@@ -1457,7 +1480,7 @@ func (e *Engine) QueryPlanCursor(ctx context.Context, lang Lang, plan chplan.Nod
 	// declines).
 	if e.routeMemoActive() && decision != nil {
 		result.Retry = func(retryCtx context.Context, drainErr error) (CursorResult, bool) {
-			cur, info, usedDecision, observeFn, retried := e.retryOnRouteAResourceFailure(retryCtx, lang.Name(), plan, decision, budget, drainErr)
+			cur, info, usedDecision, observeFn, retried := e.retryOnRouteAResourceFailure(retryCtx, lang.Name(), meta.ResponseShape, plan, decision, budget, drainErr)
 			if !retried {
 				return CursorResult{}, false
 			}
@@ -1674,7 +1697,7 @@ func (e *Engine) executeRoutedCursor(
 	}
 	execT := telemetry.ObserveStage(telemetry.StageExecute, lang.Name())
 	cursor, info, err := e.Solver.Executor.Execute(
-		chclient.WithProgressFor(ctx, lang.Name()), lang.Name(), decision, chclient.SampleBudgetFromContext(ctx),
+		routeBExecCtx(ctx, lang.Name(), meta.ResponseShape), lang.Name(), decision, chclient.SampleBudgetFromContext(ctx),
 	)
 	execT.Done(ctx)
 	if err != nil {

--- a/internal/engine/route_b_response_shape_wiring_test.go
+++ b/internal/engine/route_b_response_shape_wiring_test.go
@@ -1,0 +1,251 @@
+package engine
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	"github.com/tsouza/cerberus/internal/chclient"
+	"github.com/tsouza/cerberus/internal/routememo"
+	"github.com/tsouza/cerberus/internal/solver"
+)
+
+// routeBMismatchedResponseShape is a deliberately NON-matrix declaration —
+// the Loki log-stream pivot key an adapter really does set
+// (internal/logql/lang.go). chclient's bindColumns declines the columnar
+// matrix decode for exactly this input, so threading it verbatim to the
+// shards is what gives route B a gate that can actually DECLINE rather than
+// one that only ever waves matrix queries through.
+const routeBMismatchedResponseShape = "loki-streams"
+
+// shapeCapturingSolverClient is a solver.CursorQuerier that records the
+// ResponseShape each shard's dispatch ctx carried at the moment
+// internal/solver opened that shard's cursor — the exact value
+// chclient.columnarCursor reads to decide whether the columnar matrix decode
+// may engage.
+type shapeCapturingSolverClient struct {
+	rows int
+
+	mu     sync.Mutex
+	shapes []string
+}
+
+func (c *shapeCapturingSolverClient) QueryCursor(ctx context.Context, _ string, _ ...any) (chclient.Cursor, error) {
+	c.mu.Lock()
+	c.shapes = append(c.shapes, chclient.ResponseShapeFromContext(ctx))
+	c.mu.Unlock()
+	return &fakeMemoWiringCursor{remaining: c.rows}, nil
+}
+
+func (c *shapeCapturingSolverClient) MaxQueryMemoryBytes() int64 { return 0 }
+
+func (c *shapeCapturingSolverClient) observed() []string {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return append([]string(nil), c.shapes...)
+}
+
+// assertEveryShardDeclared pins that the fan-out really happened (wantShards
+// cursors opened — an assertion over an empty slice would pass vacuously) and
+// that EVERY shard presented want to its CursorQuerier.
+func assertEveryShardDeclared(t *testing.T, c *shapeCapturingSolverClient, wantShards int, want string) {
+	t.Helper()
+	got := c.observed()
+	if len(got) != wantShards {
+		t.Fatalf("shard cursor opens = %d, want %d — the dispatch did not fan out, so the shape assertion would be vacuous",
+			len(got), wantShards)
+	}
+	for shard, shape := range got {
+		if shape != want {
+			t.Errorf("shard %d: ResponseShapeFromContext(dispatch ctx) = %q, want %q — Meta.ResponseShape never reached this route-B shard",
+				shard, shape, want)
+		}
+	}
+}
+
+// routeBDispatch names one of the FOUR call sites that hand a ctx to
+// solver.Executor.Execute. Each builds its own Engine around the capturing
+// client, drives its own dispatch to a complete drain (so every shard has
+// certainly opened), and reports how many shards it fanned out to.
+type routeBDispatch struct {
+	name     string
+	dispatch func(t *testing.T, cq *shapeCapturingSolverClient, meta Meta) int
+}
+
+func routeBDispatches() []routeBDispatch {
+	return []routeBDispatch{
+		{
+			// The eager route-B path: QueryPlan's fan-out, drained into a
+			// Result by the engine itself.
+			name: "executeRouted",
+			dispatch: func(t *testing.T, cq *shapeCapturingSolverClient, meta Meta) int {
+				t.Helper()
+				eng := newRoutedCorpusEngine(t, cq, nil)
+				plan := memoWiringEligiblePlan()
+				d := routedDecision(t, eng, plan)
+				if _, err := eng.executeRouted(context.Background(), routedCorpusLang{}, meta, plan, d); err != nil {
+					t.Fatalf("executeRouted: %v", err)
+				}
+				return len(d.Slices)
+			},
+		},
+		{
+			// The streaming sibling: the caller owns the drain.
+			name: "executeRoutedCursor",
+			dispatch: func(t *testing.T, cq *shapeCapturingSolverClient, meta Meta) int {
+				t.Helper()
+				eng := newRoutedCorpusEngine(t, cq, nil)
+				plan := memoWiringEligiblePlan()
+				d := routedDecision(t, eng, plan)
+				cr, err := eng.executeRoutedCursor(context.Background(), routedCorpusLang{}, meta, plan, d)
+				if err != nil {
+					t.Fatalf("executeRoutedCursor: %v", err)
+				}
+				drainRouteBCursor(t, cr.Cursor)
+				return len(d.Slices)
+			},
+		},
+		{
+			// The failure-driven route memo's hit path: a live PreferB
+			// verdict routes B without route A running at all.
+			name: "tryRouteMemoHit",
+			dispatch: func(t *testing.T, cq *shapeCapturingSolverClient, meta Meta) int {
+				t.Helper()
+				eng, memo := newMemoWiringEngine(t, cq)
+				plan := memoWiringEligiblePlan()
+				seed := memoWiringNotRoutedDecision(t)
+				d := eng.deriveRouteMemoDispatch(plan, seed, memoWiringGridEnd.Add(2*memoWiringGridStep))
+				if !d.eligible {
+					t.Fatalf("fixture plan must be structurally eligible")
+				}
+				memo.Observe(d.key, routememo.RouteB, routememo.OutcomeSuccess)
+
+				cur, _, usedDecision, _, ok := eng.tryRouteMemoHit(
+					context.Background(), solver.LangPromQL, meta.ResponseShape, plan, seed, nil,
+				)
+				if !ok {
+					t.Fatal("tryRouteMemoHit did not dispatch on a live PreferB verdict")
+				}
+				drainRouteBCursor(t, cur)
+				return len(usedDecision.Slices)
+			},
+		},
+		{
+			// The A->B retry: route A failed on resource exhaustion, so this
+			// probe dispatches B instead. It runs on the ctx the CALLER hands
+			// in at retry time, which is why the shape has to be re-declared
+			// from Meta rather than inherited from the original dispatch.
+			name: "retryOnRouteAResourceFailure",
+			dispatch: func(t *testing.T, cq *shapeCapturingSolverClient, meta Meta) int {
+				t.Helper()
+				eng, _ := newMemoWiringEngine(t, cq)
+				plan := memoWiringEligiblePlan()
+				seed := memoWiringNotRoutedDecision(t)
+
+				// A single route-A resource failure never earns a probe: the
+				// memo demands minCorroboratingFailures consecutive failures
+				// on the same key first, so the dispatch under test is the
+				// SECOND call (see
+				// TestRetryOnRouteAResourceFailure_ProbesAfterCorroboration).
+				if _, _, _, _, retried := eng.retryOnRouteAResourceFailure(
+					context.Background(), solver.LangPromQL, meta.ResponseShape, plan, seed, nil,
+					chclient.ErrMemoryLimitExceeded,
+				); retried {
+					t.Fatal("probed on the FIRST route-A resource failure — fixture no longer matches the memo's corroboration rule")
+				}
+
+				cur, _, usedDecision, observeFn, retried := eng.retryOnRouteAResourceFailure(
+					context.Background(), solver.LangPromQL, meta.ResponseShape, plan, seed, nil,
+					chclient.ErrMemoryLimitExceeded,
+				)
+				if !retried {
+					t.Fatal("retryOnRouteAResourceFailure did not probe route B after a resource failure")
+				}
+				drainRouteBCursor(t, cur)
+				observeFn(nil)
+				return len(usedDecision.Slices)
+			},
+		},
+	}
+}
+
+// drainRouteBCursor drains and closes a composed route-B cursor, failing on
+// any drain error — a dispatch that aborted mid-drain would leave some shards
+// unopened and make the per-shard assertions vacuous.
+func drainRouteBCursor(t *testing.T, cur chclient.Cursor) {
+	t.Helper()
+	for cur.Next() {
+	}
+	if err := cur.Err(); err != nil {
+		t.Fatalf("drain: %v", err)
+	}
+	if err := cur.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+}
+
+// TestRouteBDispatch_ThreadsResponseShapeToEveryShard is the route-B half of
+// #1429's defense-in-depth, which #1429 itself wired only into route A's
+// dispatchRouteACursor: internal/solver owns a structurally separate
+// CursorQuerier, and a cursor opened through it used to present
+// ResponseShapeFromContext(ctx) == "" — the "unknown, defer to the structural
+// test alone" safety valve — no matter what the adapter declared (#1753).
+//
+// It runs over ALL FOUR sites that dispatch through solver.Executor.Execute,
+// because "route B" is not one call site: a memo hit and an A->B retry open
+// route-B cursors on ctxs that never passed through executeRouted(Cursor) at
+// all. Adding a fifth dispatch without stamping the shape is what this table
+// exists to catch.
+func TestRouteBDispatch_ThreadsResponseShapeToEveryShard(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range routeBDispatches() {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			cq := &shapeCapturingSolverClient{rows: 1}
+			shards := tc.dispatch(t, cq, Meta{IsMetric: true, ResponseShape: chclient.ResponseShapeMatrix})
+			assertEveryShardDeclared(t, cq, shards, chclient.ResponseShapeMatrix)
+		})
+	}
+}
+
+// TestRouteBDispatch_MismatchedResponseShapeReachesEveryShard is what proves
+// the AND-gate can actually FIRE on route B rather than merely riding along:
+// a declaration that does NOT match the matrix shape is the single input
+// chclient.bindColumns tests to REFUSE the columnar decode
+// (chclient/columnar_shape_test.go pins that half). Were the value dropped
+// anywhere between Meta and the shard's QueryCursor, the shards would present
+// "" and the gate would fall back to the structural name/type check alone —
+// passing a matrix-shaped-by-coincidence projection straight through, the
+// exact collision class #1429 exists to close.
+func TestRouteBDispatch_MismatchedResponseShapeReachesEveryShard(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range routeBDispatches() {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			cq := &shapeCapturingSolverClient{rows: 1}
+			shards := tc.dispatch(t, cq, Meta{IsMetric: true, ResponseShape: routeBMismatchedResponseShape})
+			assertEveryShardDeclared(t, cq, shards, routeBMismatchedResponseShape)
+		})
+	}
+}
+
+// TestRouteBDispatch_UnsetResponseShapeStaysEmpty is the negative pairing to
+// both tests above, mirroring route A's own pin: an adapter that never
+// declared a shape must leave every shard ctx observably EMPTY. "" is
+// chclient's incremental-adoption valve, so inventing a value here would
+// silently change which projections the columnar decode accepts for every
+// not-yet-migrated caller.
+func TestRouteBDispatch_UnsetResponseShapeStaysEmpty(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range routeBDispatches() {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			cq := &shapeCapturingSolverClient{rows: 1}
+			shards := tc.dispatch(t, cq, Meta{IsMetric: true})
+			assertEveryShardDeclared(t, cq, shards, "")
+		})
+	}
+}

--- a/internal/engine/route_memo_wiring.go
+++ b/internal/engine/route_memo_wiring.go
@@ -128,9 +128,14 @@ func recordRouteMemoPressureActive(m *routememo.Memo) {
 // Major-2's symmetric fallback: on ANY route-B drain failure, Observe the
 // failure and fall back to route A, exactly as if this function had never
 // been called).
+// responseShape is the dispatching adapter's engine.Meta.ResponseShape,
+// threaded as a value (like langName) rather than read off ctx because this
+// is a route-B dispatch and routeBExecCtx owns stamping it — see that
+// function for why every Execute call site declares the shape itself.
 func (e *Engine) tryRouteMemoHit(
 	ctx context.Context,
 	langName string,
+	responseShape string,
 	plan chplan.Node,
 	seedDecision *solver.Decision,
 	budget *chclient.SampleBudget,
@@ -169,7 +174,9 @@ func (e *Engine) tryRouteMemoHit(
 	dispatchDone := telemetry.ObserveRoutedDispatchInflight(ctx)
 	defer dispatchDone()
 
-	cur, execInfo, err := e.Solver.Executor.Execute(ctx, langName, d.decision, budget)
+	cur, execInfo, err := e.Solver.Executor.Execute(
+		routeBExecCtx(ctx, langName, responseShape), langName, d.decision, budget,
+	)
 	if err != nil {
 		// A pre-flight failure (breaker/emit/gate/now64) classifies
 		// NoEvidence by construction — Observe is a documented no-op for it,
@@ -200,9 +207,15 @@ func (e *Engine) tryRouteMemoHit(
 // true. Skipping it silently drops the one observation this probe exists to
 // make, leaving the Key permanently Unknown no matter how many times route A
 // goes on failing it.
+// responseShape is the dispatching adapter's engine.Meta.ResponseShape,
+// threaded for the same reason as on tryRouteMemoHit: this dispatch opens
+// route-B cursors, so it declares the shape through routeBExecCtx. It matters
+// most HERE — the retry runs on a ctx the handler supplies at drain time,
+// which carries nothing the original dispatch stamped.
 func (e *Engine) retryOnRouteAResourceFailure(
 	ctx context.Context,
 	langName string,
+	responseShape string,
 	plan chplan.Node,
 	seedDecision *solver.Decision,
 	budget *chclient.SampleBudget,
@@ -271,7 +284,9 @@ func (e *Engine) retryOnRouteAResourceFailure(
 	}
 	dispatchDone := telemetry.ObserveRoutedDispatchInflight(ctx)
 
-	cur, execInfo, dispatchErr := e.Solver.Executor.Execute(ctx, langName, d.decision, budget)
+	cur, execInfo, dispatchErr := e.Solver.Executor.Execute(
+		routeBExecCtx(ctx, langName, responseShape), langName, d.decision, budget,
+	)
 	if dispatchErr != nil {
 		// A pre-flight failure classifies NoEvidence by construction —
 		// Observe is a documented no-op for it. The probe token is released

--- a/internal/engine/route_memo_wiring_test.go
+++ b/internal/engine/route_memo_wiring_test.go
@@ -20,6 +20,13 @@ import (
 
 // --- fixtures shared by every test in this file --------------------------
 
+// memoWiringResponseShape is the engine.Meta.ResponseShape every dispatch in
+// this file declares. The fixtures are matrix RangeWindow plans, so the
+// production value an adapter would declare for them is the prom matrix shape
+// — the value routeBExecCtx stamps onto the ctx the Executor receives, which
+// response_shape_wiring_test.go asserts on directly.
+const memoWiringResponseShape = chclient.ResponseShapeMatrix
+
 var (
 	memoWiringGridStart = time.Date(2026, 6, 13, 0, 0, 0, 0, time.UTC)
 	memoWiringGridStep  = 15 * time.Second
@@ -326,7 +333,7 @@ func TestTryRouteMemoHit_RecordsDeclineReasons(t *testing.T) {
 		eng, _ := newMemoWiringEngine(t, cq)
 		seed := memoWiringNotRoutedDecision(t)
 		before := routeMemoHitSkippedByReason(t, reader)[telemetry.RouteMemoDeclineNotEligible]
-		if _, _, _, _, ok := eng.tryRouteMemoHit(t.Context(), "promql", memoWiringIneligiblePlan(), seed, nil); ok {
+		if _, _, _, _, ok := eng.tryRouteMemoHit(t.Context(), "promql", memoWiringResponseShape, memoWiringIneligiblePlan(), seed, nil); ok {
 			t.Fatal("tryRouteMemoHit dispatched despite a structurally ineligible plan")
 		}
 		after := routeMemoHitSkippedByReason(t, reader)[telemetry.RouteMemoDeclineNotEligible]
@@ -361,7 +368,7 @@ func TestTryRouteMemoHit_RecordsDeclineReasons(t *testing.T) {
 			GroupBy:         []chplan.Expr{&chplan.ColumnRef{Name: "Attributes"}},
 		}
 		before := routeMemoHitSkippedByReason(t, reader)[telemetry.RouteMemoDeclineNotFresh]
-		if _, _, _, _, ok := eng.tryRouteMemoHit(t.Context(), "promql", notFreshPlan, seed, nil); ok {
+		if _, _, _, _, ok := eng.tryRouteMemoHit(t.Context(), "promql", memoWiringResponseShape, notFreshPlan, seed, nil); ok {
 			t.Fatal("tryRouteMemoHit dispatched on a request whose End has not aged past the live-edge margin")
 		}
 		after := routeMemoHitSkippedByReason(t, reader)[telemetry.RouteMemoDeclineNotFresh]
@@ -379,7 +386,7 @@ func TestTryRouteMemoHit_RecordsDeclineReasons(t *testing.T) {
 		seed := memoWiringNotRoutedDecision(t)
 		before := routeMemoHitSkippedByReason(t, reader)[telemetry.RouteMemoDeclineNoPreferB]
 		// Fresh memo: Lookup(k) reports Unknown, not PreferB.
-		if _, _, _, _, ok := eng.tryRouteMemoHit(t.Context(), "promql", plan, seed, nil); ok {
+		if _, _, _, _, ok := eng.tryRouteMemoHit(t.Context(), "promql", memoWiringResponseShape, plan, seed, nil); ok {
 			t.Fatal("tryRouteMemoHit dispatched with no recorded verdict")
 		}
 		after := routeMemoHitSkippedByReason(t, reader)[telemetry.RouteMemoDeclineNoPreferB]
@@ -398,7 +405,7 @@ func TestTryRouteMemoHit_RecordsDeclineReasons(t *testing.T) {
 		memo.Observe(d.key, routememo.RouteB, routememo.OutcomeSuccess)
 		memo.SetNowForTest(func() time.Time { return fixedNow.Add(20 * time.Minute) }) // past re-validation midpoint
 		before := routeMemoHitSkippedByReason(t, reader)[telemetry.RouteMemoDeclineStale]
-		if _, _, _, _, ok := eng.tryRouteMemoHit(t.Context(), "promql", plan, seed, nil); ok {
+		if _, _, _, _, ok := eng.tryRouteMemoHit(t.Context(), "promql", memoWiringResponseShape, plan, seed, nil); ok {
 			t.Fatal("tryRouteMemoHit dispatched on a STALE PreferB verdict")
 		}
 		after := routeMemoHitSkippedByReason(t, reader)[telemetry.RouteMemoDeclineStale]
@@ -414,7 +421,7 @@ func TestTryRouteMemoHit_RecordsDeclineReasons(t *testing.T) {
 		d := eng.deriveRouteMemoDispatch(plan, seed, memoWiringGridEnd.Add(2*memoWiringGridStep))
 		memo.Observe(d.key, routememo.RouteB, routememo.OutcomeSuccess)
 		before := routeMemoHitSkippedByReason(t, reader)[telemetry.RouteMemoDeclineBreakerOpen]
-		if _, _, _, _, ok := eng.tryRouteMemoHit(t.Context(), "promql", plan, seed, nil); ok {
+		if _, _, _, _, ok := eng.tryRouteMemoHit(t.Context(), "promql", memoWiringResponseShape, plan, seed, nil); ok {
 			t.Fatal("tryRouteMemoHit dispatched with the breaker OPEN")
 		}
 		after := routeMemoHitSkippedByReason(t, reader)[telemetry.RouteMemoDeclineBreakerOpen]
@@ -437,7 +444,7 @@ func TestTryRouteMemoHit_RecordsDeclineReasons(t *testing.T) {
 			}
 		}
 		before := routeMemoHitSkippedByReason(t, reader)[telemetry.RouteMemoDeclineNoDispatchToken]
-		if _, _, _, _, ok := eng.tryRouteMemoHit(t.Context(), "promql", plan, seed, nil); ok {
+		if _, _, _, _, ok := eng.tryRouteMemoHit(t.Context(), "promql", memoWiringResponseShape, plan, seed, nil); ok {
 			t.Fatal("tryRouteMemoHit dispatched despite an exhausted admission semaphore")
 		}
 		after := routeMemoHitSkippedByReason(t, reader)[telemetry.RouteMemoDeclineNoDispatchToken]
@@ -464,7 +471,7 @@ func TestRetryOnRouteAResourceFailure_RecordsProbeDeclineReasons(t *testing.T) {
 		// First resource failure on a fresh Unknown key: corroboration=1,
 		// below minCorroboratingFailures — ObserveRouteAFailureAndMaybeBeginProbe
 		// itself refuses, for a reason OTHER than cluster-wide pressure.
-		if _, _, _, _, retried := eng.retryOnRouteAResourceFailure(t.Context(), "promql", plan, seed, nil, chclient.ErrMemoryLimitExceeded); retried {
+		if _, _, _, _, retried := eng.retryOnRouteAResourceFailure(t.Context(), "promql", memoWiringResponseShape, plan, seed, nil, chclient.ErrMemoryLimitExceeded); retried {
 			t.Fatal("retried on the first route-A resource failure")
 		}
 		after := routeMemoHitSkippedByReason(t, reader)[telemetry.RouteMemoDeclineProbeNotAdmitted]
@@ -495,7 +502,7 @@ func TestRetryOnRouteAResourceFailure_RecordsProbeDeclineReasons(t *testing.T) {
 			t.Fatalf("fixture failed to establish UnderPressure()==true")
 		}
 		before := routeMemoHitSkippedByReason(t, reader)[telemetry.RouteMemoDeclineUnderPressure]
-		if _, _, _, _, retried := eng.retryOnRouteAResourceFailure(t.Context(), "promql", plan, seed, nil, chclient.ErrMemoryLimitExceeded); retried {
+		if _, _, _, _, retried := eng.retryOnRouteAResourceFailure(t.Context(), "promql", memoWiringResponseShape, plan, seed, nil, chclient.ErrMemoryLimitExceeded); retried {
 			t.Fatal("retried while the memo is under cluster-wide pressure")
 		}
 		after := routeMemoHitSkippedByReason(t, reader)[telemetry.RouteMemoDeclineUnderPressure]
@@ -526,7 +533,7 @@ func TestRetryOnRouteAResourceFailure_RoutedDispatchInflight(t *testing.T) {
 	}
 
 	// corroboration=1: below threshold, no dispatch, no inflight movement.
-	if _, _, _, _, retried := eng.retryOnRouteAResourceFailure(ctx, "promql", plan, seed, nil, chclient.ErrMemoryLimitExceeded); retried {
+	if _, _, _, _, retried := eng.retryOnRouteAResourceFailure(ctx, "promql", memoWiringResponseShape, plan, seed, nil, chclient.ErrMemoryLimitExceeded); retried {
 		t.Fatal("retried on the first route-A resource failure")
 	}
 	if got := routedDispatchInflightValue(t, reader); got != 0 {
@@ -534,7 +541,7 @@ func TestRetryOnRouteAResourceFailure_RoutedDispatchInflight(t *testing.T) {
 	}
 
 	// corroboration=2: probe admitted, dispatch begins.
-	_, _, _, observeFn, retried := eng.retryOnRouteAResourceFailure(ctx, "promql", plan, seed, nil, chclient.ErrMemoryLimitExceeded)
+	_, _, _, observeFn, retried := eng.retryOnRouteAResourceFailure(ctx, "promql", memoWiringResponseShape, plan, seed, nil, chclient.ErrMemoryLimitExceeded)
 	if !retried {
 		t.Fatal("did not retry on the 2nd consecutive route-A resource failure")
 	}
@@ -563,7 +570,7 @@ func TestRouteABSuccessTotal(t *testing.T) {
 		eng, _ := newMemoWiringEngine(t, cq)
 		seed := memoWiringNotRoutedDecision(t)
 		before := routeABSuccessByRoute(t, reader)[telemetry.RouteChoiceA]
-		if _, _, _, _, retried := eng.retryOnRouteAResourceFailure(t.Context(), "promql", plan, seed, nil, nil); retried {
+		if _, _, _, _, retried := eng.retryOnRouteAResourceFailure(t.Context(), "promql", memoWiringResponseShape, plan, seed, nil, nil); retried {
 			t.Fatal("a Success classification must never itself trigger a retry dispatch")
 		}
 		after := routeABSuccessByRoute(t, reader)[telemetry.RouteChoiceA]
@@ -577,10 +584,10 @@ func TestRouteABSuccessTotal(t *testing.T) {
 		eng, _ := newMemoWiringEngine(t, cq)
 		seed := memoWiringNotRoutedDecision(t)
 		ctx := t.Context()
-		if _, _, _, _, retried := eng.retryOnRouteAResourceFailure(ctx, "promql", plan, seed, nil, chclient.ErrMemoryLimitExceeded); retried {
+		if _, _, _, _, retried := eng.retryOnRouteAResourceFailure(ctx, "promql", memoWiringResponseShape, plan, seed, nil, chclient.ErrMemoryLimitExceeded); retried {
 			t.Fatal("retried on the first route-A resource failure")
 		}
-		_, _, _, observeFn, retried := eng.retryOnRouteAResourceFailure(ctx, "promql", plan, seed, nil, chclient.ErrMemoryLimitExceeded)
+		_, _, _, observeFn, retried := eng.retryOnRouteAResourceFailure(ctx, "promql", memoWiringResponseShape, plan, seed, nil, chclient.ErrMemoryLimitExceeded)
 		if !retried {
 			t.Fatal("did not retry on the 2nd consecutive route-A resource failure")
 		}
@@ -656,7 +663,7 @@ func TestTryRouteMemoHit_DispatchesOnLivePreferBVerdict(t *testing.T) {
 	}
 	memo.Observe(d.key, routememo.RouteB, routememo.OutcomeSuccess)
 
-	cur, info, usedDecision, gotKey, ok := eng.tryRouteMemoHit(context.Background(), "promql", plan, seed, nil)
+	cur, info, usedDecision, gotKey, ok := eng.tryRouteMemoHit(context.Background(), "promql", memoWiringResponseShape, plan, seed, nil)
 	if !ok {
 		t.Fatal("tryRouteMemoHit did not dispatch on a live PreferB verdict")
 	}
@@ -686,7 +693,7 @@ func TestTryRouteMemoHit_UnknownKeyNeverDispatches(t *testing.T) {
 	plan := memoWiringEligiblePlan()
 	seed := memoWiringNotRoutedDecision(t)
 
-	_, _, _, _, ok := eng.tryRouteMemoHit(context.Background(), "promql", plan, seed, nil)
+	_, _, _, _, ok := eng.tryRouteMemoHit(context.Background(), "promql", memoWiringResponseShape, plan, seed, nil)
 	if ok {
 		t.Fatal("tryRouteMemoHit dispatched for an Unknown key — must never memo-hit without a recorded verdict")
 	}
@@ -716,7 +723,7 @@ func TestTryRouteMemoHit_StaleVerdictFallsBackToCaller(t *testing.T) {
 	// crossing the TTL itself.
 	memo.SetNowForTest(func() time.Time { return fixedNow.Add(20 * time.Minute) })
 
-	_, _, _, _, ok := eng.tryRouteMemoHit(context.Background(), "promql", plan, seed, nil)
+	_, _, _, _, ok := eng.tryRouteMemoHit(context.Background(), "promql", memoWiringResponseShape, plan, seed, nil)
 	if ok {
 		t.Fatal("tryRouteMemoHit dispatched on a STALE PreferB verdict — must fall through to route A instead")
 	}
@@ -761,7 +768,7 @@ func TestTryRouteMemoHit_PreFlightFailureFallsBackToRouteA(t *testing.T) {
 	d := eng.deriveRouteMemoDispatch(plan, seed, fixedNow)
 	memo.Observe(d.key, routememo.RouteB, routememo.OutcomeSuccess)
 
-	cur, info, usedDecision, _, ok := eng.tryRouteMemoHit(context.Background(), "promql", plan, seed, nil)
+	cur, info, usedDecision, _, ok := eng.tryRouteMemoHit(context.Background(), "promql", memoWiringResponseShape, plan, seed, nil)
 	if ok {
 		t.Fatal("tryRouteMemoHit reported dispatched=true despite a pre-flight emit failure")
 	}
@@ -801,7 +808,7 @@ func TestTryRouteMemoHit_MidDrainResourceFailure_ObserveViaClassify(t *testing.T
 	d := eng.deriveRouteMemoDispatch(plan, seed, fixedNow)
 	memo.Observe(d.key, routememo.RouteB, routememo.OutcomeSuccess)
 
-	cur, _, _, gotKey, ok := eng.tryRouteMemoHit(context.Background(), "promql", plan, seed, nil)
+	cur, _, _, gotKey, ok := eng.tryRouteMemoHit(context.Background(), "promql", memoWiringResponseShape, plan, seed, nil)
 	if !ok {
 		t.Fatal("tryRouteMemoHit must dispatch (Execute's synchronous return has no visibility into a per-shard open error)")
 	}
@@ -837,7 +844,7 @@ func TestRetryOnRouteAResourceFailure_ProbesAfterCorroboration(t *testing.T) {
 
 	// First resource failure: corroboration=1, below the threshold — must
 	// NOT retry.
-	_, _, _, _, retried := eng.retryOnRouteAResourceFailure(ctx, "promql", plan, seed, nil, chclient.ErrMemoryLimitExceeded)
+	_, _, _, _, retried := eng.retryOnRouteAResourceFailure(ctx, "promql", memoWiringResponseShape, plan, seed, nil, chclient.ErrMemoryLimitExceeded)
 	if retried {
 		t.Fatal("retried on the FIRST route-A resource failure — corroboration requires more than one")
 	}
@@ -848,7 +855,7 @@ func TestRetryOnRouteAResourceFailure_ProbesAfterCorroboration(t *testing.T) {
 	// Second consecutive resource failure, same key, no intervening
 	// success: corroboration=2 (the default minCorroboratingFailures) —
 	// NOW a probe is admitted and route B dispatches.
-	cur, info, usedDecision, observeFn, retried := eng.retryOnRouteAResourceFailure(ctx, "promql", plan, seed, nil, chclient.ErrMemoryLimitExceeded)
+	cur, info, usedDecision, observeFn, retried := eng.retryOnRouteAResourceFailure(ctx, "promql", memoWiringResponseShape, plan, seed, nil, chclient.ErrMemoryLimitExceeded)
 	if !retried {
 		t.Fatal("did not retry on the 2nd consecutive route-A resource failure")
 	}
@@ -891,7 +898,7 @@ func TestRetryOnRouteAResourceFailure_NonResourceErrorNeverRetried(t *testing.T)
 
 	timeoutErr := &solver.SolverTimeoutError{Timeout: "60s"}
 	for i := 0; i < 5; i++ {
-		_, _, _, _, retried := eng.retryOnRouteAResourceFailure(ctx, "promql", plan, seed, nil, timeoutErr)
+		_, _, _, _, retried := eng.retryOnRouteAResourceFailure(ctx, "promql", memoWiringResponseShape, plan, seed, nil, timeoutErr)
 		if retried {
 			t.Fatalf("iteration %d: retried on a NoEvidence-class error (solver timeout)", i)
 		}
@@ -914,7 +921,7 @@ func TestRetryOnRouteAResourceFailure_ClientGoneNeverRetried(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 
-	_, _, _, _, retried := eng.retryOnRouteAResourceFailure(ctx, "promql", plan, seed, nil, chclient.ErrMemoryLimitExceeded)
+	_, _, _, _, retried := eng.retryOnRouteAResourceFailure(ctx, "promql", memoWiringResponseShape, plan, seed, nil, chclient.ErrMemoryLimitExceeded)
 	if retried {
 		t.Fatal("retried on a cancelled context — no client is there to receive the retry's answer")
 	}
@@ -936,10 +943,10 @@ func TestRouteMemoWiring_InactiveWhenRouteMemoNil(t *testing.T) {
 	plan := memoWiringEligiblePlan()
 	seed := memoWiringNotRoutedDecision(t)
 
-	if _, _, _, _, ok := eng.tryRouteMemoHit(context.Background(), "promql", plan, seed, nil); ok {
+	if _, _, _, _, ok := eng.tryRouteMemoHit(context.Background(), "promql", memoWiringResponseShape, plan, seed, nil); ok {
 		t.Fatal("tryRouteMemoHit dispatched with RouteMemo nil")
 	}
-	if _, _, _, _, ok := eng.retryOnRouteAResourceFailure(context.Background(), "promql", plan, seed, nil, chclient.ErrMemoryLimitExceeded); ok {
+	if _, _, _, _, ok := eng.retryOnRouteAResourceFailure(context.Background(), "promql", memoWiringResponseShape, plan, seed, nil, chclient.ErrMemoryLimitExceeded); ok {
 		t.Fatal("retryOnRouteAResourceFailure dispatched with RouteMemo nil")
 	}
 	if cq.opens.Load() != 0 {

--- a/internal/solver/executor.go
+++ b/internal/solver/executor.go
@@ -414,6 +414,15 @@ func (sc *shardCursor) runShard(
 	if perShardMemoryBytes > 0 {
 		pctx = chclient.WithQuerySetting(pctx, "max_memory_usage", perShardMemoryBytes)
 	}
+	// The caller's declared response shape (chclient.WithResponseShape, stamped
+	// by the engine at every route-B dispatch) is deliberately NOT re-stamped
+	// here: unlike the progress recorder (one mutable recorder per ctx key —
+	// sharing corrupts the histograms) and the query_id (one per shard, a
+	// shared id is CH error 216), it is an immutable, request-scoped string
+	// every shard must present identically, so it rides gctx down here by
+	// ordinary ctx nesting. Rebuilding a shard ctx from a bare Background would
+	// silently drop it and hollow out chclient's columnar AND-gate on route B —
+	// response_shape_wiring_test.go pins that it arrives at every shard.
 
 	// This shard's own cancel handle. The cursor is opened on qctx and torn
 	// down by THIS goroutine, so chclient.CloseCursor can drain the remaining

--- a/internal/solver/response_shape_wiring_test.go
+++ b/internal/solver/response_shape_wiring_test.go
@@ -1,0 +1,122 @@
+package solver
+
+import (
+	"context"
+	"testing"
+
+	"github.com/tsouza/cerberus/internal/chclient"
+)
+
+// routeBMismatchedResponseShape is a response shape that is NOT
+// chclient.ResponseShapeMatrix — the Loki log-stream pivot key an adapter
+// really does declare (internal/logql/lang.go). chclient's bindColumns
+// declines the columnar matrix decode for exactly this input
+// (chclient/columnar_shape_test.go pins that half), so a test that proves
+// this value reaches a shard's QueryCursor ctx proves the AND-gate has the
+// input it needs to fire on route B.
+const routeBMismatchedResponseShape = "loki-streams"
+
+// responseShapeOfShards reads back the ResponseShape each shard's
+// QueryCursor call actually observed on its own ctx, failing the test if any
+// shard never opened a cursor at all (which would make an "every shard
+// carries the shape" assertion vacuously true).
+func responseShapeOfShards(t *testing.T, q *fakeQuerier, k int) []string {
+	t.Helper()
+	q.mu.Lock()
+	defer q.mu.Unlock()
+	shapes := make([]string, k)
+	for shard := 0; shard < k; shard++ {
+		shardCtx, ok := q.ctxByShard[shard]
+		if !ok {
+			t.Fatalf("shard %d never opened a cursor — nothing to assert about its ctx", shard)
+		}
+		shapes[shard] = chclient.ResponseShapeFromContext(shardCtx)
+	}
+	return shapes
+}
+
+// runShardsWithResponseShape dispatches a k-shard routed Decision through a
+// real Executor whose ctx carries shape (when non-empty), drains the composed
+// cursor to completion so every shard has certainly opened, and returns the
+// per-shard observed shapes.
+func runShardsWithResponseShape(t *testing.T, shape string, k int) []string {
+	t.Helper()
+
+	q := newFakeQuerier(2)
+	cfg := testCfg()
+	cfg.Parallel = k // kEff == k, so all k shards really do open a cursor
+	x := newExec(q, newFakeEmitter(), cfg, 32, newFakeBreaker(BreakerClosed), nil)
+
+	ctx := context.Background()
+	if shape != "" {
+		ctx = chclient.WithResponseShape(ctx, shape)
+	}
+	cur, _, err := x.Execute(ctx, "promql", makeDecision(k), nil)
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	defer cur.Close()
+	if _, err := drainAll(cur); err != nil {
+		t.Fatalf("drain: %v", err)
+	}
+	return responseShapeOfShards(t, q, k)
+}
+
+// TestExecute_ResponseShapeReachesEveryShardCursor is the route-B half of
+// #1429's defense-in-depth wiring (#1753). The engine stamps the adapter's
+// declared ResponseShape onto the ctx it hands Execute; Execute derives a
+// cancel-cause ctx, a breaker-dedup ctx and an errgroup ctx from it, and
+// runShard then re-stamps a per-shard progress recorder, query_id, sample
+// budget and memory setting onto its own derived ctx. This pins that the
+// declared shape survives that whole chain to EVERY shard's QueryCursor —
+// the ordinary-ctx-nesting claim the fix rests on, which is precisely what a
+// future refactor rebuilding a shard ctx from scratch would silently break.
+func TestExecute_ResponseShapeReachesEveryShardCursor(t *testing.T) {
+	t.Parallel()
+
+	const k = 4
+	for shard, got := range runShardsWithResponseShape(t, chclient.ResponseShapeMatrix, k) {
+		if got != chclient.ResponseShapeMatrix {
+			t.Errorf("shard %d: ResponseShapeFromContext(shard ctx) = %q, want %q — the engine's declared shape never reached this shard's CursorQuerier",
+				shard, got, chclient.ResponseShapeMatrix)
+		}
+	}
+}
+
+// TestExecute_MismatchedResponseShapeReachesEveryShardCursor is the pin that
+// the AND-gate can actually FIRE on route B, not merely that a matching shape
+// rides along harmlessly: a non-matrix declaration must arrive at every
+// shard's QueryCursor ctx VERBATIM, since that is the single input
+// chclient.bindColumns tests to decline the columnar matrix decode. If the
+// value were dropped anywhere in the Execute -> errgroup -> runShard chain
+// the shards would present "" instead, which the gate reads as "unknown,
+// defer to the structural test alone" — the exact hollow-gate outcome #1753
+// exists to close.
+func TestExecute_MismatchedResponseShapeReachesEveryShardCursor(t *testing.T) {
+	t.Parallel()
+
+	const k = 3
+	for shard, got := range runShardsWithResponseShape(t, routeBMismatchedResponseShape, k) {
+		if got != routeBMismatchedResponseShape {
+			t.Errorf("shard %d: ResponseShapeFromContext(shard ctx) = %q, want %q — a mismatched shape must reach the gate, or route B's AND-gate can never decline",
+				shard, got, routeBMismatchedResponseShape)
+		}
+	}
+}
+
+// TestExecute_UnsetResponseShapeStaysEmptyOnEveryShard is the negative
+// pairing: a caller that never declared a shape must leave every shard ctx
+// observably EMPTY, never a stale or defaulted value. "" is chclient's
+// incremental-adoption safety valve ("unknown, defer to the structural check
+// alone"), so inventing a value here would change what the columnar decode
+// accepts for not-yet-migrated callers.
+func TestExecute_UnsetResponseShapeStaysEmptyOnEveryShard(t *testing.T) {
+	t.Parallel()
+
+	const k = 2
+	for shard, got := range runShardsWithResponseShape(t, "", k) {
+		if got != "" {
+			t.Errorf("shard %d: ResponseShapeFromContext(shard ctx) = %q, want \"\" for a caller that never declared a shape", shard, got)
+		}
+	}
+}


### PR DESCRIPTION
## What

#1429 added `engine.Meta.ResponseShape` as a second, independent check ANDed on top of `chclient/columnar.go`'s structural name/type test in `bindColumns()` — a caller must both look like the matrix shape and declare it before the columnar decode engages. That wiring reached only route A (`Engine.dispatchRouteACursor`). `internal/solver` owns a structurally separate `CursorQuerier`, so every cursor opened through the solver-routed path presented `ResponseShapeFromContext(ctx) == ""` — the "unknown, defer to the structural test alone" incremental-adoption valve — and route B got none of the added defense-in-depth.

## How

Tracing the dispatch chain turned up **four** `Solver.Executor.Execute` call sites, not the two the issue named:

| site | path |
| --- | --- |
| `engine.go` `executeRouted` | eager route B |
| `engine.go` `executeRoutedCursor` | streaming route B |
| `route_memo_wiring.go` `tryRouteMemoHit` | live PreferB verdict routes B directly |
| `route_memo_wiring.go` `retryOnRouteAResourceFailure` | A->B retry probe |

All four now build their Execute ctx through a single `routeBExecCtx(ctx, langName, responseShape)`, which stamps the head's progress recorder plus `chclient.WithResponseShape`. The two memo helpers take the shape as a value alongside `langName` rather than reading it off ctx, because the retry paths run on a ctx the **handler** supplies at drain time that carries nothing the original dispatch stamped — and because a value argument cannot be silently forgotten at a call site.

`ctx` is the only channel `Executor.Execute` offers, so the solver reads it back where it already is: the shape reaches each shard's `QueryCursor` by ordinary ctx nesting through `Execute` -> cancel-cause ctx -> breaker-dedup ctx -> errgroup ctx -> `runShard`. Unlike the per-shard progress recorder (one mutable recorder per ctx key) and the per-shard `query_id` (a shared id is CH error 216), an immutable request-scoped string needs no re-stamp — that asymmetry is now documented in `runShard` and pinned by a test rather than assumed.

## Tests

Two new files, both tabled so they cover the dispatch paths rather than one representative:

- `internal/engine/route_b_response_shape_wiring_test.go` — runs all **four** dispatch sites x three declarations (matrix / mismatched / unset), asserting the value every shard's `CursorQuerier` observed, and failing loudly if the dispatch did not actually fan out (so no assertion passes vacuously).
- `internal/solver/response_shape_wiring_test.go` — pins the ctx-nesting claim the fix rests on: the declared shape survives `Execute` -> errgroup -> `runShard` to every shard.

The mismatched-shape cases are what prove the AND-gate can actually **fire** on route B rather than merely riding along: a non-matrix declaration is the single input `bindColumns` tests to refuse the columnar decode (`chclient/columnar_shape_test.go` pins that half), so it must arrive verbatim — a dropped value would present `""` and silently fall back to the structural check alone.

Both directions were mutation-checked, not assumed: removing the stamp from `routeBExecCtx` fails all eight matrix/mismatch subtests, and stripping the shape in `runShard` fails the solver pins.

Closes #1753