### PR TITLE
feat(promql): answer avg() over an exponential histogram

### DIFF
--- a/internal/promql/exp_histogram_avg_test.go
+++ b/internal/promql/exp_histogram_avg_test.go
@@ -1,0 +1,284 @@
+package promql_test
+
+import (
+	"context"
+	"slices"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/prometheus/prometheus/promql/parser"
+
+	"github.com/tsouza/cerberus/internal/chplan"
+	"github.com/tsouza/cerberus/internal/chsql"
+	"github.com/tsouza/cerberus/internal/promql"
+	"github.com/tsouza/cerberus/internal/schema"
+)
+
+// TestLower_ExpHistogram_AvgIsHistogramValued pins the fifth
+// histogram-VALUED lowering: `avg [by/without] (<exp-histogram
+// selector>)` is answerable, and the answer is a
+// chplan.HistogramProjection publishing the same thirteen-column
+// contract as the bare, `sum()` and `rate()` siblings.
+//
+// Like `sum()`, the quartet's first slot must be an EMPTY literal:
+// reference PromQL drops `__name__` from every aggregation result.
+func TestLower_ExpHistogram_AvgIsHistogramValued(t *testing.T) {
+	t.Parallel()
+
+	s := schema.DefaultOTelMetrics()
+	p := parser.NewParser(parser.Options{EnableExperimentalFunctions: true})
+	start := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	end := start.Add(time.Hour)
+
+	cases := []struct {
+		name  string
+		query string
+		lower func(parser.Expr) (chplan.Node, error)
+	}{
+		{
+			name:  "instant",
+			query: `avg(latency_exp_hist)`,
+			lower: func(e parser.Expr) (chplan.Node, error) {
+				return promql.LowerAt(context.Background(), e, s, end, end)
+			},
+		},
+		{
+			name:  "instant by",
+			query: `avg by (service) (latency_exp_hist)`,
+			lower: func(e parser.Expr) (chplan.Node, error) {
+				return promql.LowerAt(context.Background(), e, s, end, end)
+			},
+		},
+		{
+			name:  "instant without",
+			query: `avg without (pod) (latency_exp_hist{service="api"})`,
+			lower: func(e parser.Expr) (chplan.Node, error) {
+				return promql.LowerAt(context.Background(), e, s, end, end)
+			},
+		},
+		{
+			name:  "parenthesised",
+			query: `(avg(latency_exp_hist))`,
+			lower: func(e parser.Expr) (chplan.Node, error) {
+				return promql.LowerAt(context.Background(), e, s, end, end)
+			},
+		},
+		{
+			name:  "range",
+			query: `avg by (service) (latency_exp_hist)`,
+			lower: func(e parser.Expr) (chplan.Node, error) {
+				return promql.LowerAtRange(context.Background(), e, s, start, end, 30*time.Second)
+			},
+		},
+		{
+			name:  "range with absolute @ pin",
+			query: `avg(latency_exp_hist @ 1767225600)`,
+			lower: func(e parser.Expr) (chplan.Node, error) {
+				return promql.LowerAtRange(context.Background(), e, s, start, end, 30*time.Second)
+			},
+		},
+	}
+
+	wantAliases := []string{
+		s.MetricNameColumn, s.AttributesColumn, s.TimestampColumn, s.ValueColumn,
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			expr, err := p.ParseExpr(tc.query)
+			if err != nil {
+				t.Fatalf("ParseExpr(%q): %v", tc.query, err)
+			}
+			plan, err := tc.lower(expr)
+			if err != nil {
+				t.Fatalf("lower(%q): unexpected error: %v", tc.query, err)
+			}
+			if shape := chplan.RowShapeOf(plan); shape != chplan.HistogramRowShape {
+				t.Fatalf("lower(%q): plan root publishes %s, want histogram", tc.query, shape)
+			}
+			hp, ok := plan.(*chplan.HistogramProjection)
+			if !ok {
+				t.Fatalf("lower(%q): plan root is %T, want *chplan.HistogramProjection", tc.query, plan)
+			}
+			if !slices.Equal(hp.GroupByAliases, wantAliases) {
+				t.Fatalf("lower(%q): leading output aliases = %v, want %v", tc.query, hp.GroupByAliases, wantAliases)
+			}
+			name, ok := hp.GroupBy[0].(*chplan.LitString)
+			if !ok || name.V != "" {
+				t.Fatalf("lower(%q): __name__ projection is %#v, want an empty literal — "+
+					"an aggregation result carries no metric name", tc.query, hp.GroupBy[0])
+			}
+		})
+	}
+}
+
+// TestLower_ExpHistogram_AvgDividesOnlyTheCountFields is the correctness
+// assertion this lowering lives or dies by, and it asserts in BOTH
+// directions.
+//
+// Reference's FloatHistogram.Div scales exactly five fields — ZeroCount,
+// Count, Sum and the two signed bucket ladders — and leaves Scale, the
+// zero threshold and both bucket OFFSETS alone. Those four describe
+// where the buckets sit on the value axis rather than how much fell into
+// them, so dividing any of them would slide the distribution sideways
+// instead of averaging it.
+//
+// A plan that divided all nine would still publish thirteen well-typed
+// columns in contract order, still decode, and still pass every
+// structural check in this file's sibling test — and would answer with a
+// silently wrong distribution. So the negative half (four fields
+// untouched) is the half that actually catches the bug, and `sum()` is
+// checked alongside as the control: the SAME merge with NO division
+// anywhere.
+func TestLower_ExpHistogram_AvgDividesOnlyTheCountFields(t *testing.T) {
+	t.Parallel()
+
+	p := parser.NewParser(parser.Options{EnableExperimentalFunctions: true})
+	at := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+
+	// reshapeProjections returns the merged row's projections — the
+	// Project directly beneath the histogram cap, where the division (if
+	// any) is applied.
+	reshapeProjections := func(t *testing.T, s schema.Metrics, query string) map[string]chplan.Expr {
+		t.Helper()
+		expr, err := p.ParseExpr(query)
+		if err != nil {
+			t.Fatalf("ParseExpr(%q): %v", query, err)
+		}
+		plan, err := promql.LowerAt(context.Background(), expr, s, at, at)
+		if err != nil {
+			t.Fatalf("LowerAt(%q): %v", query, err)
+		}
+		hp, ok := plan.(*chplan.HistogramProjection)
+		if !ok {
+			t.Fatalf("lower(%q): plan root is %T, want *chplan.HistogramProjection", query, plan)
+		}
+		reshape, ok := hp.Input.(*chplan.Project)
+		if !ok {
+			t.Fatalf("lower(%q): projection input is %T, want *chplan.Project", query, hp.Input)
+		}
+		byAlias := make(map[string]chplan.Expr, len(reshape.Projections))
+		for _, proj := range reshape.Projections {
+			byAlias[proj.Alias] = proj.Expr
+		}
+		return byAlias
+	}
+
+	// dividesBySeriesCount reports whether e is a division by the group's
+	// member count, looking through the per-bucket arrayMap the two
+	// ladders are scaled through.
+	dividesBySeriesCount := func(e chplan.Expr) bool {
+		if call, ok := e.(*chplan.FuncCall); ok && call.Name == "arrayMap" && len(call.Args) == 2 {
+			lambda, ok := call.Args[0].(*chplan.Lambda)
+			if !ok {
+				return false
+			}
+			e = lambda.Body
+		}
+		div, ok := e.(*chplan.Binary)
+		if !ok || div.Op != chplan.OpDiv {
+			return false
+		}
+		ref, ok := div.Right.(*chplan.ColumnRef)
+		return ok && ref.Name == "_hq_group_series_count"
+	}
+
+	// The default OTel schema does not persist a zero threshold (see
+	// schema.DefaultOTelMetrics), so the merge never publishes that
+	// column and an assertion about it there would be vacuous. The
+	// second schema sets one, which is what makes the "ZeroThreshold is
+	// NOT divided" half of this test a real assertion rather than a
+	// lookup that silently finds nothing.
+	withZeroThreshold := schema.DefaultOTelMetrics()
+	withZeroThreshold.ZeroThresholdColumn = "ZeroThreshold"
+
+	for _, s := range []schema.Metrics{schema.DefaultOTelMetrics(), withZeroThreshold} {
+		scaled := []string{
+			s.CountColumn, s.SumColumn, s.ZeroCountColumn,
+			s.PositiveBucketCountsColumn, s.NegativeBucketCountsColumn,
+		}
+		untouched := []string{
+			s.ScaleColumn, s.PositiveOffsetColumn, s.NegativeOffsetColumn,
+		}
+		if s.ZeroThresholdColumn != "" {
+			untouched = append(untouched, s.ZeroThresholdColumn)
+		}
+
+		avgProjs := reshapeProjections(t, s, `avg by (service) (latency_exp_hist)`)
+		for _, alias := range scaled {
+			proj, ok := avgProjs[alias]
+			if !ok {
+				t.Fatalf("avg publishes no %q projection", alias)
+			}
+			if !dividesBySeriesCount(proj) {
+				t.Fatalf("avg does NOT divide %q by the group's member count (%#v) — "+
+					"reference's FloatHistogram.Div scales every count-bearing field", alias, proj)
+			}
+		}
+		for _, alias := range untouched {
+			proj, ok := avgProjs[alias]
+			if !ok {
+				t.Fatalf("avg publishes no %q projection", alias)
+			}
+			if dividesBySeriesCount(proj) {
+				t.Fatalf("avg divides %q, which reference's FloatHistogram.Div leaves ALONE — "+
+					"that field is a bucket POSITION, not a count; scaling it moves the "+
+					"distribution instead of averaging it", alias)
+			}
+		}
+
+		// The control: the same merge under `sum()` divides nothing at all.
+		sumProjs := reshapeProjections(t, s, `sum by (service) (latency_exp_hist)`)
+		for _, alias := range append(append([]string{}, scaled...), untouched...) {
+			proj, ok := sumProjs[alias]
+			if !ok {
+				t.Fatalf("sum publishes no %q projection", alias)
+			}
+			if dividesBySeriesCount(proj) {
+				t.Fatalf("sum divides %q by the group's member count — that is avg's "+
+					"arithmetic leaking onto the shared merge", alias)
+			}
+		}
+	}
+}
+
+// TestLower_ExpHistogram_AvgMergesBucketLadders pins that `avg()` reaches
+// the SAME shared native-histogram merge `sum()` does — the scale-fold +
+// offset-align + zero-pad mirroring FloatHistogram.Add — rather than
+// reducing the histogram columns some other way.
+//
+// Without this, an `avg()` that carried ONE member series' ladder
+// straight through and divided it by the member count would still
+// publish a well-formed, plausibly-scaled histogram.
+func TestLower_ExpHistogram_AvgMergesBucketLadders(t *testing.T) {
+	t.Parallel()
+
+	s := schema.DefaultOTelMetrics()
+	p := parser.NewParser(parser.Options{EnableExperimentalFunctions: true})
+	expr, err := p.ParseExpr(`avg by (service) (latency_exp_hist)`)
+	if err != nil {
+		t.Fatalf("ParseExpr: %v", err)
+	}
+	at := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	plan, err := promql.LowerAt(context.Background(), expr, s, at, at)
+	if err != nil {
+		t.Fatalf("LowerAt: %v", err)
+	}
+	sql, _, err := chsql.Emit(context.Background(), plan)
+	if err != nil {
+		t.Fatalf("Emit: %v", err)
+	}
+	for _, want := range []string{
+		"min(`" + s.ScaleColumn + "`)",
+		"sum(`" + s.CountColumn + "`) AS `" + s.CountColumn + "`",
+		"sum(`" + s.SumColumn + "`) AS `" + s.SumColumn + "`",
+		"sum(`" + s.ZeroCountColumn + "`) AS `" + s.ZeroCountColumn + "`",
+		"bitShiftRight",
+	} {
+		if !strings.Contains(sql, want) {
+			t.Fatalf("emitted SQL does not reach the shared native-histogram merge: missing %q\n%s", want, sql)
+		}
+	}
+}

--- a/internal/promql/exp_histogram_reject_test.go
+++ b/internal/promql/exp_histogram_reject_test.go
@@ -21,7 +21,8 @@ import (
 // `_count` / `_sum` companion selectors, and the three top-level
 // histogram-VALUED shapes issue #1967 answers — a BARE selector
 // (TestLower_ExpHistogram_BareSelectorIsHistogramValued), `sum()` over
-// one (TestLower_ExpHistogram_SumIsHistogramValued) and `rate()` /
+// one and its `avg()` twin (TestLower_ExpHistogram_SumIsHistogramValued,
+// TestLower_ExpHistogram_AvgIsHistogramValued) and `rate()` /
 // `increase()` over one
 // (TestLower_ExpHistogram_RateIsHistogramValued) — must fail lowering
 // with a clear error, never silently resolve against the Gauge/Sum tables
@@ -36,6 +37,13 @@ import (
 // does read a `Value` column the histogram row shape never publishes, or
 // hands `sum()` an aggregand that is not a bare selector. They stay
 // rejected until each grows its own histogram-aware lowering.
+//
+// `min` / `max` / `count` / `topk` stay here for a DIFFERENT reason from
+// the rest, and it is not "nobody has written the lowering yet":
+// reference Prometheus DROPS native-histogram samples from those
+// aggregations with an annotation, so there is no merged distribution to
+// publish (see [expHistogramAggOpIsMergeable], which admits only `sum`
+// and `avg` for exactly this reason).
 func TestLower_ExpHistogram_UnsupportedShapesRejectExplicitly(t *testing.T) {
 	t.Parallel()
 
@@ -52,7 +60,6 @@ func TestLower_ExpHistogram_UnsupportedShapesRejectExplicitly(t *testing.T) {
 		{name: "irate", query: `irate(latency_exp_hist[5m])`},
 		{name: "sum_over_time", query: `sum_over_time(latency_exp_hist[5m])`},
 		{name: "absent_over_time", query: `absent_over_time(latency_exp_hist[5m])`},
-		{name: "avg aggregation", query: `avg(latency_exp_hist)`},
 		{name: "min aggregation", query: `min(latency_exp_hist)`},
 		{name: "max aggregation", query: `max(latency_exp_hist)`},
 		{name: "count aggregation", query: `count(latency_exp_hist)`},

--- a/internal/promql/histogram_native_avg.go
+++ b/internal/promql/histogram_native_avg.go
@@ -1,0 +1,154 @@
+package promql
+
+import (
+	"github.com/prometheus/prometheus/promql/parser"
+
+	"github.com/tsouza/cerberus/internal/chplan"
+	"github.com/tsouza/cerberus/internal/schema"
+)
+
+// histogram_native_avg.go lowers `avg [by/without] (<selector>)` over an
+// OTel exponential (native) histogram — the fifth histogram-VALUED
+// lowering, after the bare selector, `sum()` and `rate()`/`increase()`.
+//
+// Reference Prometheus answers `avg()` over native-histogram samples
+// with a native histogram: promql's aggregation accumulates an
+// incremental mean of the group's FloatHistograms and publishes it. The
+// incremental form exists purely for floating-point accuracy over long
+// groups — the VALUE it converges on is the group's summed distribution
+// divided by the number of contributing samples, which is what this
+// lowering computes directly.
+//
+// So `avg()` is `sum()` plus one division, and this file is deliberately
+// only that division: [sumOrAvgOverExpHistogram] recognises both
+// aggregations and [expHistogramGroupMerge] builds the identical merge
+// for both, so the two can never drift apart in the arithmetic that
+// reconciles bucket ladders. Sharing the merge is the whole point of the
+// split — a second, parallel merge would be a second place for the
+// scale-fold to go wrong.
+//
+// WHICH fields the division touches is the load-bearing detail, and it
+// is not "all of them". Reference divides a FloatHistogram by a scalar
+// in `FloatHistogram.Div`:
+//
+//	h.ZeroCount /= scalar
+//	h.Count     /= scalar
+//	h.Sum       /= scalar
+//	for i := range h.PositiveBuckets { h.PositiveBuckets[i] /= scalar }
+//	for i := range h.NegativeBuckets { h.NegativeBuckets[i] /= scalar }
+//
+// — the five COUNT-bearing fields, and nothing else. Scale, the zero
+// threshold and both bucket offsets describe where the buckets SIT on
+// the value axis, not how much fell into them; scaling any of them would
+// silently move the distribution rather than average it. That is the
+// most plausible way to ship a wrong answer here, because a plan that
+// divided the offsets too would still publish thirteen well-typed
+// columns and still decode — so [TestLower_ExpHistogram_AvgDividesOnlyTheCountFields]
+// pins the split in both directions.
+//
+// The divisor is the group's SERIES count, counted at the same across-
+// series stage that merges the ladders: each row reaching that stage is
+// one series' single resolved sample (the per-series stage below it
+// already collapsed each series to its newest in-window reading), so
+// `count()` there is exactly reference's `group.groupCount` — the number
+// of samples that went into the mean.
+//
+// Fractional bucket counts are the visible consequence and are correct:
+// averaging three histograms whose bucket holds 1, 1 and 2 observations
+// publishes 1.333. Issue #2037 pinned the nine histogram output columns
+// as Float64 / Array(Float64) / Int32 precisely so a fractional ladder
+// decodes end to end, which is why this lowering needs no decode-path
+// work of its own.
+
+// expHistogramGroupSeriesCountAlias is the across-series stage's member
+// count — the divisor `avg()` scales the merged distribution by.
+//
+// It shares the `_hq_` prefix, and the collision argument, of the merge
+// aliases in histogram_quantile.go: user labels cannot produce it.
+const expHistogramGroupSeriesCountAlias = "_hq_group_series_count"
+
+// expHistogramGroupSeriesCountAgg counts the rows entering the
+// across-series merge, i.e. the number of series contributing a sample
+// to the group.
+//
+// It is collected for `avg()` only — see [expHistogramGroupMergeAggs].
+// `sum()` never reads it, and emitting it there would change a shipped
+// lowering's SQL to carry a column nothing consumes.
+func expHistogramGroupSeriesCountAgg() chplan.AggFunc {
+	return chplan.AggFunc{
+		Name:  "count",
+		Args:  []chplan.Expr{},
+		Alias: expHistogramGroupSeriesCountAlias,
+	}
+}
+
+// expHistogramAvgScaleProjections divides the merged row's five
+// count-bearing fields by the group's series count, leaving every
+// position-bearing field untouched.
+//
+// It rewrites [expHistogramGroupMergeProjections]'s output rather than
+// re-deriving it, so `avg()` publishes exactly the columns `sum()`
+// publishes, in exactly the same order — the thirteen-column contract
+// chplan.HistogramProjection and chclient's positional row cursor both
+// depend on.
+//
+// The two count-bearing SHAPES need different arithmetic: Count, Sum and
+// ZeroCount are scalars and divide directly, while the two bucket
+// ladders are arrays and divide element-wise through `arrayMap`.
+func expHistogramAvgScaleProjections(projs []chplan.Projection, s schema.Metrics) []chplan.Projection {
+	scaled := make([]chplan.Projection, len(projs))
+	for i, p := range projs {
+		switch p.Alias {
+		case s.CountColumn, s.SumColumn, s.ZeroCountColumn:
+			scaled[i] = chplan.Projection{Expr: expHistogramAvgDivide(p.Expr), Alias: p.Alias}
+		case s.PositiveBucketCountsColumn, s.NegativeBucketCountsColumn:
+			scaled[i] = chplan.Projection{Expr: expHistogramAvgDivideLadder(p.Expr), Alias: p.Alias}
+		default:
+			// Scale, ZeroThreshold and both bucket offsets: position, not
+			// count. Reference's Div leaves all four alone.
+			scaled[i] = p
+		}
+	}
+	return scaled
+}
+
+// expHistogramAvgDivide divides one scalar field by the group's series
+// count.
+func expHistogramAvgDivide(e chplan.Expr) chplan.Expr {
+	return &chplan.Binary{
+		Op:    chplan.OpDiv,
+		Left:  e,
+		Right: &chplan.ColumnRef{Name: expHistogramGroupSeriesCountAlias},
+	}
+}
+
+// expHistogramAvgDivideLadder divides every bucket of one merged ladder
+// by the group's series count, element-wise.
+//
+// The merged ladder is already dense over the merged scale — the
+// across-series merge emits one entry per index in the merged range — so
+// an element-wise map is the whole of reference's
+// `for i := range h.PositiveBuckets { h.PositiveBuckets[i] /= scalar }`.
+func expHistogramAvgDivideLadder(e chplan.Expr) chplan.Expr {
+	const paramBucket = "b"
+	return &chplan.FuncCall{
+		Name: "arrayMap",
+		Args: []chplan.Expr{
+			&chplan.Lambda{
+				Params: []string{paramBucket},
+				// BareIdent, not ColumnRef: a lambda parameter is bound by
+				// the lambda, not read off a row, and every other
+				// exp-histogram bucket expression in this package spells it
+				// that way (see expHistogramBucketRowContribExpr).
+				Body: expHistogramAvgDivide(&chplan.BareIdent{Name: paramBucket}),
+			},
+			e,
+		},
+	}
+}
+
+// expHistogramGroupIsAvg reports whether an aggregation this file's
+// sibling recognised is the `avg` half of the pair.
+func expHistogramGroupIsAvg(agg *parser.AggregateExpr) bool {
+	return agg.Op == parser.AVG
+}

--- a/internal/promql/histogram_native_rate.go
+++ b/internal/promql/histogram_native_rate.go
@@ -118,7 +118,7 @@ const (
 // selector>[range])` or the `increase` twin — the two shapes this file
 // answers — returning the matched [histogramAggShape].
 //
-// Like [bareExpHistogramSelector] and [sumOverExpHistogram] it is asked
+// Like [bareExpHistogramSelector] and [sumOrAvgOverExpHistogram] it is asked
 // only of the ROOT of a query (see [lowerRoot]), and for the same reason:
 // the answer is a histogram row, which only the wire can consume.
 // `rate(m_exp_hist[5m]) * 2` or `label_replace(rate(m_exp_hist[5m]), ...)`

--- a/internal/promql/histogram_native_sum.go
+++ b/internal/promql/histogram_native_sum.go
@@ -13,6 +13,10 @@ import (
 // in histogram_native_bare.go) to cap a plan with a
 // [chplan.HistogramProjection].
 //
+// It also hosts the MERGE that `avg()` reuses: histogram_native_avg.go
+// adds one division on top of the row this file builds, and shares this
+// file's recognizer. Everything below about the merge applies to both.
+//
 // Reference Prometheus answers `sum()` over native-histogram samples
 // with a native histogram, not a float: promql's aggregation walks the
 // group calling `histogram.FloatHistogram.Add` on each member, so the
@@ -42,7 +46,7 @@ import (
 //	HistogramProjection [MetricName='', Attributes, now64(9), Value=0, <nine histogram columns>]
 //	  Project [Attributes (rebuilt from gkeys), merged Scale / ZeroCount /
 //	           ZeroThreshold / {Pos,Neg}{Offset,BucketCounts}, Count, Sum]
-//	    Aggregate groupBy=[<user by/without labels>] funcs=<expHistogramSumMergeAggs>
+//	    Aggregate groupBy=[<user by/without labels>] funcs=<expHistogramGroupMergeAggs>
 //	      Aggregate groupBy=[series identity] funcs=<nativeExpHistValuedLatestAggs>  ← per series
 //	        Filter <matchers> AND <staleness window>
 //	          Scan(otel_metrics_exponential_histogram)
@@ -55,8 +59,14 @@ import (
 // distributions ACROSS series. Collapsing them into one grouping would
 // add a series' own consecutive scrapes to each other.
 
-// sumOverExpHistogram reports whether expr is `sum [by/without] (<bare
-// exp-histogram selector>)` — the one shape this file answers.
+// sumOrAvgOverExpHistogram reports whether expr is `sum [by/without]
+// (<bare exp-histogram selector>)` or its `avg` twin — the two shapes
+// this file answers.
+//
+// The two share one recognizer because they share one merge: `avg()` is
+// this file's merge divided by the group's series count, and
+// histogram_native_avg.go adds only that division. Recognising them
+// apart would let the shapes they accept drift.
 //
 // Like [bareExpHistogramSelector] it is asked only of the ROOT of a
 // query (see [lowerRoot]), and for the same reason: the answer is a
@@ -68,15 +78,15 @@ import (
 // m_exp_hist[5m]))` does not: its aggregand is a range-vector function
 // with its own histogram-valued lowering to grow (issue #1967), and
 // admitting it here would silently drop the rate.
-func sumOverExpHistogram(expr parser.Expr, s schema.Metrics, ctx lowerCtx) (*parser.AggregateExpr, *parser.VectorSelector, bool) {
+func sumOrAvgOverExpHistogram(expr parser.Expr, s schema.Metrics, ctx lowerCtx) (*parser.AggregateExpr, *parser.VectorSelector, bool) {
 	if s.ExpHistogramTable == "" || ctx.metadataFullRange {
 		return nil, nil, false
 	}
 	agg, ok := unwrapAggregateExpr(expr)
-	// Param is nil for every SUM the parser produces (only the topk /
-	// bottomk / quantile / count_values family carries one); the check
-	// states the assumption rather than relying on it.
-	if !ok || agg.Op != parser.SUM || agg.Param != nil {
+	// Param is nil for every SUM and AVG the parser produces (only the
+	// topk / bottomk / quantile / count_values family carries one); the
+	// check states the assumption rather than relying on it.
+	if !ok || !expHistogramAggOpIsMergeable(agg.Op) || agg.Param != nil {
 		return nil, nil, false
 	}
 	vs, ok := unwrapVectorSelector(agg.Expr)
@@ -108,15 +118,15 @@ func unwrapAggregateExpr(e parser.Expr) (*parser.AggregateExpr, bool) {
 	}
 }
 
-// lowerExpHistogramSum lowers the `sum()` shape across the three
+// lowerExpHistogramSumOrAvg lowers the `sum()` / `avg()` shape across the three
 // evaluation shapes [rangeGridShapeFor] distinguishes, the same three
 // the bare sibling handles — see [lowerExpHistogramBare] for what each
 // one means.
-func lowerExpHistogramSum(agg *parser.AggregateExpr, vs *parser.VectorSelector, s schema.Metrics, ctx lowerCtx) (chplan.Node, error) {
+func lowerExpHistogramSumOrAvg(agg *parser.AggregateExpr, vs *parser.VectorSelector, s schema.Metrics, ctx lowerCtx) (chplan.Node, error) {
 	if shape := rangeGridShapeFor(vs, ctx); shape == gridFanout {
-		return lowerExpHistogramSumRange(agg, vs, s, ctx), nil
+		return lowerExpHistogramSumOrAvgRange(agg, vs, s, ctx), nil
 	} else if shape == gridBroadcast {
-		merged, err := expHistogramSumMergedInstant(agg, vs, s, ctx)
+		merged, err := expHistogramGroupMergedInstant(agg, vs, s, ctx)
 		if err != nil {
 			return nil, err
 		}
@@ -132,19 +142,19 @@ func lowerExpHistogramSum(agg *parser.AggregateExpr, vs *parser.VectorSelector, 
 			s,
 		), nil
 	}
-	merged, err := expHistogramSumMergedInstant(agg, vs, s, ctx)
+	merged, err := expHistogramGroupMergedInstant(agg, vs, s, ctx)
 	if err != nil {
 		return nil, err
 	}
 	return aggregatedHistogramProjection(merged, chplan.NowNano(), s), nil
 }
 
-// expHistogramSumMergedInstant builds the instant-mode subtree beneath
+// expHistogramGroupMergedInstant builds the instant-mode subtree beneath
 // the histogram projection: the filtered scan collapsed to the newest
 // in-window sample per series, then merged across series by the user's
 // grouping. Its output is one row per output series carrying the merged
 // distribution under the schema's own column names.
-func expHistogramSumMergedInstant(agg *parser.AggregateExpr, vs *parser.VectorSelector, s schema.Metrics, ctx lowerCtx) (chplan.Node, error) {
+func expHistogramGroupMergedInstant(agg *parser.AggregateExpr, vs *parser.VectorSelector, s schema.Metrics, ctx lowerCtx) (chplan.Node, error) {
 	scan := &chplan.Scan{Table: s.ExpHistogramTable}
 	pred := buildPredicate(vs.LabelMatchers, s)
 	pred, err := andInstantWindow(pred, vs, s.TimestampColumn, ctx)
@@ -156,10 +166,10 @@ func expHistogramSumMergedInstant(agg *parser.AggregateExpr, vs *parser.VectorSe
 		input = &chplan.Filter{Input: scan, Predicate: pred}
 	}
 	perSeries := latestSampleAgg(input, nativeExpHistValuedLatestAggs(s), s)
-	return expHistogramSumMerge(perSeries, nil, agg, s), nil
+	return expHistogramGroupMerge(perSeries, nil, agg, s), nil
 }
 
-// lowerExpHistogramSumRange is the query_range shape. Stage 1 is the
+// lowerExpHistogramSumOrAvgRange is the query_range shape. Stage 1 is the
 // per-anchor [chplan.RangeBucketFanout] the bare range path builds — one
 // staleness window per step anchor, keyed on SERIES identity — and stage
 // 2 is the across-series merge within each anchor, exactly as
@@ -170,7 +180,7 @@ func expHistogramSumMergedInstant(agg *parser.AggregateExpr, vs *parser.VectorSe
 // reference PromQL means: `sum by(service)` over three pods must take
 // each pod's own newest sample and add the three, not take one newest
 // sample per service.
-func lowerExpHistogramSumRange(agg *parser.AggregateExpr, vs *parser.VectorSelector, s schema.Metrics, ctx lowerCtx) chplan.Node {
+func lowerExpHistogramSumOrAvgRange(agg *parser.AggregateExpr, vs *parser.VectorSelector, s schema.Metrics, ctx lowerCtx) chplan.Node {
 	scan := &chplan.Scan{Table: s.ExpHistogramTable}
 	pred := buildPredicate(vs.LabelMatchers, s)
 	perSeries := buildHistogramBucketFanout(
@@ -179,10 +189,10 @@ func lowerExpHistogramSumRange(agg *parser.AggregateExpr, vs *parser.VectorSelec
 		nativeExpHistValuedLatestAggs(s), s, ctx,
 	)
 	anchor := &chplan.ColumnRef{Name: stepGridAnchorColumn}
-	return aggregatedHistogramProjection(expHistogramSumMerge(perSeries, anchor, agg, s), anchor, s)
+	return aggregatedHistogramProjection(expHistogramGroupMerge(perSeries, anchor, agg, s), anchor, s)
 }
 
-// expHistogramSumMerge is the across-SERIES stage: it adds the per-series
+// expHistogramGroupMerge is the across-SERIES stage: it adds the per-series
 // distributions perSeries hands up, grouped by the user's `by/without`
 // clause, and reshapes the result back into the exp-histogram row
 // contract under the schema's own column names.
@@ -197,7 +207,7 @@ func lowerExpHistogramSumRange(agg *parser.AggregateExpr, vs *parser.VectorSelec
 // in scope above stage 1 — the same binding [histogramAggGroupBy]'s doc
 // describes for the quantile paths, and the reason they must not be
 // re-wrapped in [canonicalGroupKeyExpr].
-func expHistogramSumMerge(perSeries chplan.Node, anchor *chplan.ColumnRef, agg *parser.AggregateExpr, s schema.Metrics) chplan.Node {
+func expHistogramGroupMerge(perSeries chplan.Node, anchor *chplan.ColumnRef, agg *parser.AggregateExpr, s schema.Metrics) chplan.Node {
 	groupBy, groupByAliases, attrsRebuild := histogramAggGroupBy(
 		agg, &chplan.ColumnRef{Name: s.AttributesColumn}, s,
 	)
@@ -211,15 +221,25 @@ func expHistogramSumMerge(perSeries chplan.Node, anchor *chplan.ColumnRef, agg *
 		Input:              perSeries,
 		GroupBy:            groupBy,
 		GroupByAliases:     groupByAliases,
-		AggFuncs:           expHistogramSumMergeAggs(s),
+		AggFuncs:           expHistogramGroupMergeAggs(agg, s),
 		DropEmptyOnNoGroup: true,
 	}
 	projs = append(projs, chplan.Projection{Expr: attrsRebuild, Alias: s.AttributesColumn})
-	projs = append(projs, expHistogramSumMergeProjections(s)...)
+	fields := expHistogramGroupMergeProjections(s)
+	if expHistogramGroupIsAvg(agg) {
+		// The ONE place the two aggregations differ. Everything below this
+		// line — the scale fold, the offset alignment, the zero padding —
+		// is identical for `sum` and `avg`, which is why the division
+		// wraps the merged row here rather than reaching into the shared
+		// merge. See histogram_native_avg.go for which fields it touches
+		// and why the other four must not be touched.
+		fields = expHistogramAvgScaleProjections(fields, s)
+	}
+	projs = append(projs, fields...)
 	return &chplan.Project{Input: merged, Projections: projs}
 }
 
-// expHistogramSumMergeAggs is [expHistogramMergeAggs] — the shared
+// expHistogramGroupMergeAggs is [expHistogramMergeAggs] — the shared
 // scale-fold + offset-align + zero-pad collection, the arithmetic of
 // FloatHistogram.Add — widened by the two whole-histogram scalars a
 // histogram-VALUED answer must also publish.
@@ -228,21 +248,28 @@ func expHistogramSumMerge(perSeries chplan.Node, anchor *chplan.ColumnRef, agg *
 // count and total observed value, and neither depends on bucket
 // alignment. `sum(<col>) AS <col>` reuses the source column's own name,
 // the same aliasing expHistogramMergeAggs already applies to ZeroCount.
-func expHistogramSumMergeAggs(s schema.Metrics) []chplan.AggFunc {
-	return append(
-		[]chplan.AggFunc{
-			{Name: "sum", Args: []chplan.Expr{&chplan.ColumnRef{Name: s.CountColumn}}, Alias: s.CountColumn},
-			{Name: "sum", Args: []chplan.Expr{&chplan.ColumnRef{Name: s.SumColumn}}, Alias: s.SumColumn},
-		},
-		expHistogramMergeAggs(s)...,
-	)
+// `avg()` additionally collects the group's member count, the divisor it
+// scales the merged distribution by (see
+// [expHistogramGroupSeriesCountAgg]). `sum()` does NOT collect it: it
+// has no use for the column, and adding one to a shipped lowering's
+// emitted SQL would cost a counter per group and churn its goldens for
+// nothing.
+func expHistogramGroupMergeAggs(agg *parser.AggregateExpr, s schema.Metrics) []chplan.AggFunc {
+	aggs := []chplan.AggFunc{
+		{Name: "sum", Args: []chplan.Expr{&chplan.ColumnRef{Name: s.CountColumn}}, Alias: s.CountColumn},
+		{Name: "sum", Args: []chplan.Expr{&chplan.ColumnRef{Name: s.SumColumn}}, Alias: s.SumColumn},
+	}
+	if expHistogramGroupIsAvg(agg) {
+		aggs = append(aggs, expHistogramGroupSeriesCountAgg())
+	}
+	return append(aggs, expHistogramMergeAggs(s)...)
 }
 
-// expHistogramSumMergeProjections is [expHistogramMergeProjections] plus
+// expHistogramGroupMergeProjections is [expHistogramMergeProjections] plus
 // the Count / Sum pass-through, so the reshaped row carries all nine
 // fields [chplan.HistogramProjection] reads by name rather than the
 // seven the quantile kernel needs.
-func expHistogramSumMergeProjections(s schema.Metrics) []chplan.Projection {
+func expHistogramGroupMergeProjections(s schema.Metrics) []chplan.Projection {
 	return append(
 		[]chplan.Projection{
 			{Expr: &chplan.ColumnRef{Name: s.CountColumn}, Alias: s.CountColumn},

--- a/internal/promql/lower.go
+++ b/internal/promql/lower.go
@@ -171,7 +171,7 @@ func LowerMetadataRange(ctx context.Context, expr parser.Expr, s schema.Metrics,
 // lowerRoot lowers the ROOT of a query expression. It is [lower] plus the
 // dispatches that can only be decided at the root: the shapes over an
 // exponential (native) histogram that return a HISTOGRAM-VALUED sample —
-// a bare selector, `sum [by/without] (<selector>)`, and
+// a bare selector, `sum`/`avg` `[by/without] (<selector>)`, and
 // `rate`/`increase` over a range-vector selector — whose answer has a
 // wire representation only when the shape IS the whole query.
 //
@@ -191,11 +191,11 @@ func LowerMetadataRange(ctx context.Context, expr parser.Expr, s schema.Metrics,
 //
 // The three dispatches are ordered but not mutually exclusive in
 // principle, and the order is arbitrary: [bareExpHistogramSelector],
-// [sumOverExpHistogram] and [rateOverExpHistogram] recognise disjoint
+// [sumOrAvgOverExpHistogram] and [rateOverExpHistogram] recognise disjoint
 // root node types (a selector, an aggregation, a range-vector call), so
 // none can shadow another. [rateOverExpHistogram] additionally refuses an
 // aggregation WRAPPER, so `sum(rate(...))` — which needs both reductions
-// — matches neither it nor [sumOverExpHistogram] and stays rejected.
+// — matches neither it nor [sumOrAvgOverExpHistogram] and stays rejected.
 //
 // Metadata lowering ([LowerMetadataRange]) deliberately does NOT route
 // through here: it enumerates series and labels rather than evaluating an
@@ -205,8 +205,8 @@ func lowerRoot(expr parser.Expr, s schema.Metrics, ctx lowerCtx) (chplan.Node, e
 	if vs, ok := bareExpHistogramSelector(expr, s, ctx); ok {
 		return lowerExpHistogramBare(vs, s, ctx)
 	}
-	if agg, vs, ok := sumOverExpHistogram(expr, s, ctx); ok {
-		return lowerExpHistogramSum(agg, vs, s, ctx)
+	if agg, vs, ok := sumOrAvgOverExpHistogram(expr, s, ctx); ok {
+		return lowerExpHistogramSumOrAvg(agg, vs, s, ctx)
 	}
 	if shape, ok := rateOverExpHistogram(expr, s, ctx); ok {
 		return lowerExpHistogramRate(shape, s, ctx)
@@ -418,7 +418,7 @@ func lowerHistogramSelectorInput(
 //
 // When ok is true and err is non-nil, every other shape over a pinned
 // exp-histogram selector — one wrapped in
-// resets()/changes()/avg()/arithmetic/etc. — has no scalar
+// resets()/changes()/min()/arithmetic/etc. — has no scalar
 // Value column to read: the exp-histogram row shape (Sum/Count/Scale/
 // PositiveCounts/NegativeCounts) is disjoint from the Sample contract
 // these functions reduce over. histogram_quantile()/histogram_count()/
@@ -429,16 +429,17 @@ func lowerHistogramSelectorInput(
 // err rejects it explicitly rather than silently matching zero rows
 // against the Gauge/Sum tables.
 //
-// Three shapes no longer reach here at all: a BARE selector, `sum
-// [by/without] (<selector>)`, and `rate`/`increase` over a range-vector
-// selector. All three return a histogram-valued sample, which [lowerRoot]
+// Three shapes no longer reach here at all: a BARE selector, `sum` or
+// `avg` `[by/without] (<selector>)`, and `rate`/`increase` over a
+// range-vector selector. All three return a histogram-valued sample, which [lowerRoot]
 // answers with a chplan.HistogramProjection before the recursive descent
 // that leads to lowerVectorSelector ever starts. That is the whole of the
 // narrowing — the selector nested under anything ELSE still arrives here
 // and is still rejected, because nothing above it can consume a histogram
 // row. Each exempt shape earns its exemption by not reading a Value:
-// `sum()` adds the bucket ladders themselves, and `rate`/`increase`
-// difference them across time. `sum(rate(...))`, which stacks the two
+// `sum()` adds the bucket ladders themselves (`avg()` divides that sum
+// by the group's member count), and `rate`/`increase` difference them
+// across time. `sum(rate(...))`, which stacks the two
 // reductions, is answered by neither and still arrives here.
 //
 // Metadata enumeration (/series, /labels — ctx.metadataFullRange) is
@@ -455,7 +456,7 @@ func expHistogramSelectorRouting(metricName string, s schema.Metrics, ctx lowerC
 	if s.IsExpHistogramMetric(metricName) && !ctx.metadataFullRange {
 		return nil, nil, "", "", true, fmt.Errorf(
 			"promql: %q is an exponential histogram metric; only a bare %q selector, "+
-				"sum() over one, rate()/increase() over one, histogram_quantile(), "+
+				"sum()/avg() over one, rate()/increase() over one, histogram_quantile(), "+
 				"histogram_count(), histogram_sum(), and the %q/%q companion selectors "+
 				"are supported",
 			metricName, metricName, metricName+"_count", metricName+"_sum",

--- a/test/perf/cardinality-baseline/promql/exp_histogram_avg.json
+++ b/test/perf/cardinality-baseline/promql/exp_histogram_avg.json
@@ -1,0 +1,11 @@
+{
+  "fixture": "promql/exp_histogram_avg",
+  "fan_factor": 1,
+  "scan_rows": 2,
+  "peak_intermediate": 2,
+  "has_cross_join": false,
+  "has_array_join": false,
+  "has_recursive_cte": false,
+  "max_recursion_depth": 0,
+  "uncountable_levels": 0
+}

--- a/test/perf/cardinality-baseline/promql/exp_histogram_avg_by.json
+++ b/test/perf/cardinality-baseline/promql/exp_histogram_avg_by.json
@@ -1,0 +1,11 @@
+{
+  "fixture": "promql/exp_histogram_avg_by",
+  "fan_factor": 1,
+  "scan_rows": 3,
+  "peak_intermediate": 3,
+  "has_cross_join": false,
+  "has_array_join": false,
+  "has_recursive_cte": false,
+  "max_recursion_depth": 0,
+  "uncountable_levels": 0
+}

--- a/test/perf/solver-decision-baseline/exp_histogram_avg.json
+++ b/test/perf/solver-decision-baseline/exp_histogram_avg.json
@@ -1,0 +1,10 @@
+{
+  "query": "exp_histogram_avg",
+  "routed": false,
+  "k": 0,
+  "reason": "not-sliceable",
+  "n_anchors": 241,
+  "fanout": 20,
+  "cumulative_d": "5m0s",
+  "outer_range": "1h0m0s"
+}

--- a/test/perf/solver-decision-baseline/exp_histogram_avg_by.json
+++ b/test/perf/solver-decision-baseline/exp_histogram_avg_by.json
@@ -1,0 +1,10 @@
+{
+  "query": "exp_histogram_avg_by",
+  "routed": false,
+  "k": 0,
+  "reason": "not-sliceable",
+  "n_anchors": 241,
+  "fanout": 20,
+  "cumulative_d": "5m0s",
+  "outer_range": "1h0m0s"
+}

--- a/test/regression/parity_contract_test.go
+++ b/test/regression/parity_contract_test.go
@@ -171,7 +171,7 @@ func TestParityEnrolmentFloor(t *testing.T) {
 
 	// parityEnrolmentFloor is the number of fixtures currently carrying a
 	// `parity:` section. It ratchets UP only.
-	const parityEnrolmentFloor = 545
+	const parityEnrolmentFloor = 547
 
 	enrolled := 0
 	for _, dir := range parityFixtureDirs(t) {

--- a/test/rejection-parity/catalogue/internal__promql__lower.go.json
+++ b/test/rejection-parity/catalogue/internal__promql__lower.go.json
@@ -73,10 +73,10 @@
     },
     {
       "head": "promql",
-      "site": "internal/promql/lower.go:expHistogramSelectorRouting#609f45fd",
-      "message": "promql: %q is an exponential histogram metric; only a bare %q selector, sum() over one, rate()/increase() over one, histogram_quantile(), histogram_count(), histogram_sum(), and the %q/%q companion selectors are supported",
+      "site": "internal/promql/lower.go:expHistogramSelectorRouting#4ba854ed",
+      "message": "promql: %q is an exponential histogram metric; only a bare %q selector, sum()/avg() over one, rate()/increase() over one, histogram_quantile(), histogram_count(), histogram_sum(), and the %q/%q companion selectors are supported",
       "class": "divergence",
-      "trigger_query": "avg(demo_latency_exp_hist)",
+      "trigger_query": "resets(demo_latency_exp_hist[5m])",
       "tracking_issue": 1772,
       "evidence": {
         "guard": [

--- a/test/spec/promql/exp_histogram_avg.txtar
+++ b/test/spec/promql/exp_histogram_avg.txtar
@@ -1,0 +1,114 @@
+-- query.promql --
+avg(http_server_duration_exp_hist)
+-- parity --
+oracle: prometheus
+endpoint: /api/v1/query
+scope: full
+-- seed --
+CREATE TABLE otel_metrics_exponential_histogram (
+    MetricName String,
+    Attributes Map(String, String),
+    TimeUnix DateTime64(9),
+    Count UInt64,
+    Sum Float64,
+    Scale Int32,
+    ZeroCount UInt64,
+    PositiveOffset Int32,
+    PositiveBucketCounts Array(UInt64),
+    NegativeOffset Int32,
+    NegativeBucketCounts Array(UInt64)
+) ENGINE = MergeTree ORDER BY (MetricName, Attributes, TimeUnix);
+-- DELIBERATELY the same two series as exp_histogram_sum.txtar, so this
+-- fixture reads as that one's control: `avg()` IS that merge divided by
+-- the group's member count, and every number below is the sum fixture's
+-- halved. Two series at the SAME Scale but DIFFERENT PositiveOffsets, so
+-- the merge still has to offset-align before it can add.
+--
+-- merged offset = min(0, 1)               = 0
+-- merged span   = max(0+3-1, 1+2-1) - 0+1 = 3
+--   idx 0: api 1 +  web —  = 1
+--   idx 1: api 2 +  web 4  = 6
+--   idx 2: api 3 +  web 5  = 8
+-- summed PositiveBucketCounts = [1, 6, 8]; the group has 2 members, so
+-- avg publishes [0.5, 3, 4] at PositiveOffset 0, Scale 0.
+--
+-- The FRACTIONAL bucket counts are the point of this fixture, not an
+-- accident: reference's FloatHistogram.Div divides every count-bearing
+-- field, and averaging integer counts is exactly where fractions first
+-- appear on a histogram-valued answer.
+--
+-- The three whole-histogram scalars divide alike: Count (6+9)/2 = 7.5,
+-- Sum (42.5+10.5)/2 = 26.5, ZeroCount (1+2)/2 = 1.5. PositiveOffset and
+-- Scale are bucket POSITIONS and are NOT divided — halving them would
+-- slide the distribution instead of averaging it.
+--
+-- `avg()` drops __name__ and (with no by/without clause) every label, so
+-- the output series is ["", {}].
+INSERT INTO otel_metrics_exponential_histogram VALUES
+    ('http_server_duration_exp_hist', map('service', 'api'), toDateTime64('2026-01-01 00:00:00', 9), 6, 42.5, 0, 1, 0, [1, 2, 3], 0, []),
+    ('http_server_duration_exp_hist', map('service', 'web'), toDateTime64('2026-01-01 00:00:00', 9), 9, 10.5, 0, 2, 1, [4, 5],    0, []);
+-- expected_rows --
+[
+  ["", {}, "2026-01-01T00:00:01Z", 0, 7.5, 26.5, 0, 0, 1.5, 0, [0.5,3,4], 0, []]
+]
+-- args --
+[0] string = ""
+[1] int64 = 9
+[2] float64 = 0
+[3] string = "Map(String,String)"
+[4] int64 = 1
+[5] int64 = 0
+[6] int64 = 0
+[7] int64 = 1
+[8] int64 = 1
+[9] int64 = 1
+[10] int64 = 0
+[11] int64 = 0
+[12] int64 = 1
+[13] int64 = 1
+[14] string = "service.name"
+[15] string = "service_name"
+[16] string = "service.name"
+[17] string = "service_name"
+[18] string = ""
+[19] string = "service_name"
+[20] string = "http_server_duration_exp_hist"
+[21] string = "http.server.duration.exp.hist"
+[22] string = "http.server.duration.exp/hist"
+[23] string = "http.server.duration.exp_hist"
+[24] string = "http.server.duration/exp/hist"
+[25] string = "http.server.duration/exp_hist"
+[26] string = "http.server.duration_exp.hist"
+[27] string = "http.server.duration_exp_hist"
+[28] string = "http.server/duration/exp/hist"
+[29] string = "http.server/duration/exp_hist"
+[30] string = "http.server/duration_exp_hist"
+[31] string = "http.server_duration.exp.hist"
+[32] string = "http.server_duration.exp_hist"
+[33] string = "http.server_duration_exp.hist"
+[34] string = "http.server_duration_exp_hist"
+[35] string = "http/server/duration/exp/hist"
+[36] string = "http/server/duration/exp_hist"
+[37] string = "http/server/duration_exp_hist"
+[38] string = "http/server_duration_exp_hist"
+[39] string = "http_server.duration.exp.hist"
+[40] string = "http_server.duration.exp_hist"
+[41] string = "http_server.duration_exp.hist"
+[42] string = "http_server.duration_exp_hist"
+[43] string = "http_server_duration.exp.hist"
+[44] string = "http_server_duration.exp_hist"
+[45] string = "http_server_duration_exp.hist"
+[46] string = "2026-01-01 00:00:01.000000000"
+[47] int64 = 9
+[48] string = "2026-01-01 00:00:01.000000000"
+[49] int64 = 9
+[50] int64 = 300000000000
+-- chplan --
+HistogramProjection project=["" AS MetricName, Attributes AS Attributes, now64(9) AS TimeUnix, 0 AS Value]
+  Project [CAST(map(), "Map(String,String)") AS Attributes, (Count / _hq_group_series_count) AS Count, (Sum / _hq_group_series_count) AS Sum, _hq_merged_scale AS Scale, (ZeroCount / _hq_group_series_count) AS ZeroCount, arrayMin(arrayMap((s, off) -> bitShiftRight(off, (s - _hq_merged_scale)), _hq_scales, _hq_pos_offsets)) AS PositiveOffset, arrayMap(b -> (b / _hq_group_series_count), arrayMap(t -> arraySum(arrayMap((s, off, arr) -> arraySum(arrayMap(j -> if((bitShiftRight((off + (j - 1)), (s - _hq_merged_scale)) = (arrayMin(arrayMap((sm, om) -> bitShiftRight(om, (sm - _hq_merged_scale)), _hq_scales, _hq_pos_offsets)) + t)), arr[j], 0), arrayEnumerate(arr))), _hq_scales, _hq_pos_offsets, _hq_pos_buckets)), range(toUInt64(greatest(0, ((arrayMax(arrayMap((sm, om, am) -> bitShiftRight((om + (length(am) - 1)), (sm - _hq_merged_scale)), _hq_scales, _hq_pos_offsets, _hq_pos_buckets)) - arrayMin(arrayMap((sm, om) -> bitShiftRight(om, (sm - _hq_merged_scale)), _hq_scales, _hq_pos_offsets))) + 1)))))) AS PositiveBucketCounts, arrayMin(arrayMap((s, off) -> bitShiftRight(off, (s - _hq_merged_scale)), _hq_scales, _hq_neg_offsets)) AS NegativeOffset, arrayMap(b -> (b / _hq_group_series_count), arrayMap(t -> arraySum(arrayMap((s, off, arr) -> arraySum(arrayMap(j -> if((bitShiftRight((off + (j - 1)), (s - _hq_merged_scale)) = (arrayMin(arrayMap((sm, om) -> bitShiftRight(om, (sm - _hq_merged_scale)), _hq_scales, _hq_neg_offsets)) + t)), arr[j], 0), arrayEnumerate(arr))), _hq_scales, _hq_neg_offsets, _hq_neg_buckets)), range(toUInt64(greatest(0, ((arrayMax(arrayMap((sm, om, am) -> bitShiftRight((om + (length(am) - 1)), (sm - _hq_merged_scale)), _hq_scales, _hq_neg_offsets, _hq_neg_buckets)) - arrayMin(arrayMap((sm, om) -> bitShiftRight(om, (sm - _hq_merged_scale)), _hq_scales, _hq_neg_offsets))) + 1)))))) AS NegativeBucketCounts]
+    Aggregate groupBy=[] funcs=[sum(Count) AS Count, sum(Sum) AS Sum, count() AS _hq_group_series_count, min(Scale) AS _hq_merged_scale, sum(ZeroCount) AS ZeroCount, groupArray(Scale) AS _hq_scales, groupArray(PositiveOffset) AS _hq_pos_offsets, groupArray(PositiveBucketCounts) AS _hq_pos_buckets, groupArray(NegativeOffset) AS _hq_neg_offsets, groupArray(NegativeBucketCounts) AS _hq_neg_buckets]
+      Aggregate groupBy=[mapSort(mapConcat(mapUpdate(mapFromArrays(arrayMap(k -> replaceRegexpAll(k, "[^a-zA-Z0-9_]", "_"), mapKeys(mapFilter((k, v) -> (k NOT IN ("service.name", "service_name")), ResourceAttributes))), mapValues(mapFilter((k, v) -> (k NOT IN ("service.name", "service_name")), ResourceAttributes))), mapFromArrays(arrayMap(k -> replaceRegexpAll(k, "[^a-zA-Z0-9_]", "_"), mapKeys(Attributes)), mapValues(Attributes))), mapFilter((k, v) -> (v != ""), map("service_name", toString(ServiceName))))) AS Attributes] funcs=[argMax(Count, TimeUnix) AS Count, argMax(Sum, TimeUnix) AS Sum, argMax(Scale, TimeUnix) AS Scale, argMax(ZeroCount, TimeUnix) AS ZeroCount, argMax(PositiveOffset, TimeUnix) AS PositiveOffset, argMax(PositiveBucketCounts, TimeUnix) AS PositiveBucketCounts, argMax(NegativeOffset, TimeUnix) AS NegativeOffset, argMax(NegativeBucketCounts, TimeUnix) AS NegativeBucketCounts]
+        Filter predicate=(((MetricName IN ("http_server_duration_exp_hist", "http.server.duration.exp.hist", "http.server.duration.exp/hist", "http.server.duration.exp_hist", "http.server.duration/exp/hist", "http.server.duration/exp_hist", "http.server.duration_exp.hist", "http.server.duration_exp_hist", "http.server/duration/exp/hist", "http.server/duration/exp_hist", "http.server/duration_exp_hist", "http.server_duration.exp.hist", "http.server_duration.exp_hist", "http.server_duration_exp.hist", "http.server_duration_exp_hist", "http/server/duration/exp/hist", "http/server/duration/exp_hist", "http/server/duration_exp_hist", "http/server_duration_exp_hist", "http_server.duration.exp.hist", "http_server.duration.exp_hist", "http_server.duration_exp.hist", "http_server.duration_exp_hist", "http_server_duration.exp.hist", "http_server_duration.exp_hist", "http_server_duration_exp.hist")) AND (TimeUnix <= toDateTime64("2026-01-01 00:00:01.000000000", 9))) AND (TimeUnix > (toDateTime64("2026-01-01 00:00:01.000000000", 9) - toIntervalNanosecond(300000000000))))
+          Scan(otel_metrics_exponential_histogram)
+-- sql --
+SELECT ? AS `MetricName`, `Attributes` AS `Attributes`, now64(?) AS `TimeUnix`, toFloat64(?) AS `Value`, toFloat64(`Count`) AS `HistogramCount`, toFloat64(`Sum`) AS `HistogramSum`, toInt32(`Scale`) AS `HistogramScale`, toFloat64(0.) AS `HistogramZeroThreshold`, toFloat64(`ZeroCount`) AS `HistogramZeroCount`, toInt32(`PositiveOffset`) AS `HistogramPositiveOffset`, arrayMap(x -> toFloat64(x), `PositiveBucketCounts`) AS `HistogramPositiveBucketCounts`, toInt32(`NegativeOffset`) AS `HistogramNegativeOffset`, arrayMap(x -> toFloat64(x), `NegativeBucketCounts`) AS `HistogramNegativeBucketCounts` FROM (SELECT CAST(map(), ?) AS `Attributes`, (`Count` / `_hq_group_series_count`) AS `Count`, (`Sum` / `_hq_group_series_count`) AS `Sum`, `_hq_merged_scale` AS `Scale`, (`ZeroCount` / `_hq_group_series_count`) AS `ZeroCount`, arrayMin(arrayMap((s, off) -> bitShiftRight(off, (s - `_hq_merged_scale`)), `_hq_scales`, `_hq_pos_offsets`)) AS `PositiveOffset`, arrayMap(b -> (b / `_hq_group_series_count`), arrayMap(t -> arraySum(arrayMap((s, off, arr) -> arraySum(arrayMap(j -> if((bitShiftRight((off + (j - ?)), (s - `_hq_merged_scale`)) = (arrayMin(arrayMap((sm, om) -> bitShiftRight(om, (sm - `_hq_merged_scale`)), `_hq_scales`, `_hq_pos_offsets`)) + t)), arr[j], ?), arrayEnumerate(arr))), `_hq_scales`, `_hq_pos_offsets`, `_hq_pos_buckets`)), range(toUInt64(greatest(?, ((arrayMax(arrayMap((sm, om, am) -> bitShiftRight((om + (length(am) - ?)), (sm - `_hq_merged_scale`)), `_hq_scales`, `_hq_pos_offsets`, `_hq_pos_buckets`)) - arrayMin(arrayMap((sm, om) -> bitShiftRight(om, (sm - `_hq_merged_scale`)), `_hq_scales`, `_hq_pos_offsets`))) + ?)))))) AS `PositiveBucketCounts`, arrayMin(arrayMap((s, off) -> bitShiftRight(off, (s - `_hq_merged_scale`)), `_hq_scales`, `_hq_neg_offsets`)) AS `NegativeOffset`, arrayMap(b -> (b / `_hq_group_series_count`), arrayMap(t -> arraySum(arrayMap((s, off, arr) -> arraySum(arrayMap(j -> if((bitShiftRight((off + (j - ?)), (s - `_hq_merged_scale`)) = (arrayMin(arrayMap((sm, om) -> bitShiftRight(om, (sm - `_hq_merged_scale`)), `_hq_scales`, `_hq_neg_offsets`)) + t)), arr[j], ?), arrayEnumerate(arr))), `_hq_scales`, `_hq_neg_offsets`, `_hq_neg_buckets`)), range(toUInt64(greatest(?, ((arrayMax(arrayMap((sm, om, am) -> bitShiftRight((om + (length(am) - ?)), (sm - `_hq_merged_scale`)), `_hq_scales`, `_hq_neg_offsets`, `_hq_neg_buckets`)) - arrayMin(arrayMap((sm, om) -> bitShiftRight(om, (sm - `_hq_merged_scale`)), `_hq_scales`, `_hq_neg_offsets`))) + ?)))))) AS `NegativeBucketCounts` FROM (SELECT `Count`, `Sum`, `_hq_group_series_count`, `_hq_merged_scale`, `ZeroCount`, `_hq_scales`, `_hq_pos_offsets`, `_hq_pos_buckets`, `_hq_neg_offsets`, `_hq_neg_buckets` FROM (SELECT sum(`Count`) AS `Count`, sum(`Sum`) AS `Sum`, toFloat64(count()) AS `_hq_group_series_count`, min(`Scale`) AS `_hq_merged_scale`, sum(`ZeroCount`) AS `ZeroCount`, groupArray(`Scale`) AS `_hq_scales`, groupArray(`PositiveOffset`) AS `_hq_pos_offsets`, groupArray(`PositiveBucketCounts`) AS `_hq_pos_buckets`, groupArray(`NegativeOffset`) AS `_hq_neg_offsets`, groupArray(`NegativeBucketCounts`) AS `_hq_neg_buckets`, count() AS `_cerb_n` FROM (SELECT mapSort(mapConcat(mapUpdate(mapFromArrays(arrayMap(k -> replaceRegexpAll(k, '[^a-zA-Z0-9_]', '_'), mapKeys(mapFilter((k, v) -> (k NOT IN (?, ?)), `ResourceAttributes`))), mapValues(mapFilter((k, v) -> (k NOT IN (?, ?)), `ResourceAttributes`))), mapFromArrays(arrayMap(k -> replaceRegexpAll(k, '[^a-zA-Z0-9_]', '_'), mapKeys(`Attributes`)), mapValues(`Attributes`))), mapFilter((k, v) -> (v != ?), map(?, toString(`ServiceName`))))) AS `Attributes`, argMax(`Count`, `TimeUnix`) AS `Count`, argMax(`Sum`, `TimeUnix`) AS `Sum`, argMax(`Scale`, `TimeUnix`) AS `Scale`, argMax(`ZeroCount`, `TimeUnix`) AS `ZeroCount`, argMax(`PositiveOffset`, `TimeUnix`) AS `PositiveOffset`, argMax(`PositiveBucketCounts`, `TimeUnix`) AS `PositiveBucketCounts`, argMax(`NegativeOffset`, `TimeUnix`) AS `NegativeOffset`, argMax(`NegativeBucketCounts`, `TimeUnix`) AS `NegativeBucketCounts` FROM (SELECT * FROM `otel_metrics_exponential_histogram` PREWHERE (`MetricName` IN (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)) WHERE (`TimeUnix` <= toDateTime64(?, ?)) AND (`TimeUnix` > (toDateTime64(?, ?) - toIntervalNanosecond(?)))) GROUP BY `Attributes`)) WHERE `_cerb_n` > 0))

--- a/test/spec/promql/exp_histogram_avg_by.txtar
+++ b/test/spec/promql/exp_histogram_avg_by.txtar
@@ -1,0 +1,111 @@
+-- query.promql --
+avg by (service) (http_server_duration_exp_hist)
+-- parity --
+oracle: prometheus
+endpoint: /api/v1/query
+scope: full
+-- seed --
+CREATE TABLE otel_metrics_exponential_histogram (
+    MetricName String,
+    Attributes Map(String, String),
+    TimeUnix DateTime64(9),
+    Count UInt64,
+    Sum Float64,
+    Scale Int32,
+    ZeroCount UInt64,
+    PositiveOffset Int32,
+    PositiveBucketCounts Array(UInt64),
+    NegativeOffset Int32,
+    NegativeBucketCounts Array(UInt64)
+) ENGINE = MergeTree ORDER BY (MetricName, Attributes, TimeUnix);
+-- The same three series as exp_histogram_sum_by.txtar, and the reason
+-- this fixture exists rather than just the ungrouped one: the two groups
+-- have DIFFERENT member counts, so the divisor has to be computed PER
+-- GROUP. A lowering that divided by one global series count would get
+-- `api` right and `web` wrong, and a lowering that forgot to divide at
+-- all would get `web` right and `api` wrong — so between them the two
+-- output rows pin the divisor from both sides.
+--
+--   {service=api}: 2 members. [1,1] + [2,1] = [3,2], Count 2+3 = 5,
+--                  Sum 1+2 = 3 → /2 → [1.5,1], Count 2.5, Sum 1.5
+--   {service=web}: 1 member.  [4] = [4], Count 4, Sum 3
+--                  → /1 → UNCHANGED
+--
+-- `web` passing through untouched is the load-bearing half: dividing a
+-- one-member group by anything other than 1 would show up here and
+-- nowhere else in this fixture family.
+--
+-- Both output offsets stay 0 and are NOT divided — an offset is a bucket
+-- position, not a count. `pod` is dropped by the grouping, and __name__
+-- by the aggregation.
+INSERT INTO otel_metrics_exponential_histogram VALUES
+    ('http_server_duration_exp_hist', map('service', 'api', 'pod', 'a'), toDateTime64('2026-01-01 00:00:00', 9), 2, 1.0, 0, 0, 0, [1, 1], 0, []),
+    ('http_server_duration_exp_hist', map('service', 'api', 'pod', 'b'), toDateTime64('2026-01-01 00:00:00', 9), 3, 2.0, 0, 0, 0, [2, 1], 0, []),
+    ('http_server_duration_exp_hist', map('service', 'web', 'pod', 'c'), toDateTime64('2026-01-01 00:00:00', 9), 4, 3.0, 0, 0, 0, [4],    0, []);
+-- expected_rows --
+[
+  ["", {"service": "api"}, "2026-01-01T00:00:01Z", 0, 2.5, 1.5, 0, 0, 0, 0, [1.5,1], 0, []],
+  ["", {"service": "web"}, "2026-01-01T00:00:01Z", 0, 4, 3, 0, 0, 0, 0, [4], 0, []]
+]
+-- args --
+[0] string = ""
+[1] int64 = 9
+[2] float64 = 0
+[3] string = "service"
+[4] int64 = 1
+[5] int64 = 0
+[6] int64 = 0
+[7] int64 = 1
+[8] int64 = 1
+[9] int64 = 1
+[10] int64 = 0
+[11] int64 = 0
+[12] int64 = 1
+[13] int64 = 1
+[14] string = "service"
+[15] string = "service.name"
+[16] string = "service_name"
+[17] string = "service.name"
+[18] string = "service_name"
+[19] string = ""
+[20] string = "service_name"
+[21] string = "http_server_duration_exp_hist"
+[22] string = "http.server.duration.exp.hist"
+[23] string = "http.server.duration.exp/hist"
+[24] string = "http.server.duration.exp_hist"
+[25] string = "http.server.duration/exp/hist"
+[26] string = "http.server.duration/exp_hist"
+[27] string = "http.server.duration_exp.hist"
+[28] string = "http.server.duration_exp_hist"
+[29] string = "http.server/duration/exp/hist"
+[30] string = "http.server/duration/exp_hist"
+[31] string = "http.server/duration_exp_hist"
+[32] string = "http.server_duration.exp.hist"
+[33] string = "http.server_duration.exp_hist"
+[34] string = "http.server_duration_exp.hist"
+[35] string = "http.server_duration_exp_hist"
+[36] string = "http/server/duration/exp/hist"
+[37] string = "http/server/duration/exp_hist"
+[38] string = "http/server/duration_exp_hist"
+[39] string = "http/server_duration_exp_hist"
+[40] string = "http_server.duration.exp.hist"
+[41] string = "http_server.duration.exp_hist"
+[42] string = "http_server.duration_exp.hist"
+[43] string = "http_server.duration_exp_hist"
+[44] string = "http_server_duration.exp.hist"
+[45] string = "http_server_duration.exp_hist"
+[46] string = "http_server_duration_exp.hist"
+[47] string = "2026-01-01 00:00:01.000000000"
+[48] int64 = 9
+[49] string = "2026-01-01 00:00:01.000000000"
+[50] int64 = 9
+[51] int64 = 300000000000
+-- chplan --
+HistogramProjection project=["" AS MetricName, Attributes AS Attributes, now64(9) AS TimeUnix, 0 AS Value]
+  Project [map("service", gkey_0) AS Attributes, (Count / _hq_group_series_count) AS Count, (Sum / _hq_group_series_count) AS Sum, _hq_merged_scale AS Scale, (ZeroCount / _hq_group_series_count) AS ZeroCount, arrayMin(arrayMap((s, off) -> bitShiftRight(off, (s - _hq_merged_scale)), _hq_scales, _hq_pos_offsets)) AS PositiveOffset, arrayMap(b -> (b / _hq_group_series_count), arrayMap(t -> arraySum(arrayMap((s, off, arr) -> arraySum(arrayMap(j -> if((bitShiftRight((off + (j - 1)), (s - _hq_merged_scale)) = (arrayMin(arrayMap((sm, om) -> bitShiftRight(om, (sm - _hq_merged_scale)), _hq_scales, _hq_pos_offsets)) + t)), arr[j], 0), arrayEnumerate(arr))), _hq_scales, _hq_pos_offsets, _hq_pos_buckets)), range(toUInt64(greatest(0, ((arrayMax(arrayMap((sm, om, am) -> bitShiftRight((om + (length(am) - 1)), (sm - _hq_merged_scale)), _hq_scales, _hq_pos_offsets, _hq_pos_buckets)) - arrayMin(arrayMap((sm, om) -> bitShiftRight(om, (sm - _hq_merged_scale)), _hq_scales, _hq_pos_offsets))) + 1)))))) AS PositiveBucketCounts, arrayMin(arrayMap((s, off) -> bitShiftRight(off, (s - _hq_merged_scale)), _hq_scales, _hq_neg_offsets)) AS NegativeOffset, arrayMap(b -> (b / _hq_group_series_count), arrayMap(t -> arraySum(arrayMap((s, off, arr) -> arraySum(arrayMap(j -> if((bitShiftRight((off + (j - 1)), (s - _hq_merged_scale)) = (arrayMin(arrayMap((sm, om) -> bitShiftRight(om, (sm - _hq_merged_scale)), _hq_scales, _hq_neg_offsets)) + t)), arr[j], 0), arrayEnumerate(arr))), _hq_scales, _hq_neg_offsets, _hq_neg_buckets)), range(toUInt64(greatest(0, ((arrayMax(arrayMap((sm, om, am) -> bitShiftRight((om + (length(am) - 1)), (sm - _hq_merged_scale)), _hq_scales, _hq_neg_offsets, _hq_neg_buckets)) - arrayMin(arrayMap((sm, om) -> bitShiftRight(om, (sm - _hq_merged_scale)), _hq_scales, _hq_neg_offsets))) + 1)))))) AS NegativeBucketCounts]
+    Aggregate groupBy=[Attributes["service"] AS gkey_0] funcs=[sum(Count) AS Count, sum(Sum) AS Sum, count() AS _hq_group_series_count, min(Scale) AS _hq_merged_scale, sum(ZeroCount) AS ZeroCount, groupArray(Scale) AS _hq_scales, groupArray(PositiveOffset) AS _hq_pos_offsets, groupArray(PositiveBucketCounts) AS _hq_pos_buckets, groupArray(NegativeOffset) AS _hq_neg_offsets, groupArray(NegativeBucketCounts) AS _hq_neg_buckets]
+      Aggregate groupBy=[mapSort(mapConcat(mapUpdate(mapFromArrays(arrayMap(k -> replaceRegexpAll(k, "[^a-zA-Z0-9_]", "_"), mapKeys(mapFilter((k, v) -> (k NOT IN ("service.name", "service_name")), ResourceAttributes))), mapValues(mapFilter((k, v) -> (k NOT IN ("service.name", "service_name")), ResourceAttributes))), mapFromArrays(arrayMap(k -> replaceRegexpAll(k, "[^a-zA-Z0-9_]", "_"), mapKeys(Attributes)), mapValues(Attributes))), mapFilter((k, v) -> (v != ""), map("service_name", toString(ServiceName))))) AS Attributes] funcs=[argMax(Count, TimeUnix) AS Count, argMax(Sum, TimeUnix) AS Sum, argMax(Scale, TimeUnix) AS Scale, argMax(ZeroCount, TimeUnix) AS ZeroCount, argMax(PositiveOffset, TimeUnix) AS PositiveOffset, argMax(PositiveBucketCounts, TimeUnix) AS PositiveBucketCounts, argMax(NegativeOffset, TimeUnix) AS NegativeOffset, argMax(NegativeBucketCounts, TimeUnix) AS NegativeBucketCounts]
+        Filter predicate=(((MetricName IN ("http_server_duration_exp_hist", "http.server.duration.exp.hist", "http.server.duration.exp/hist", "http.server.duration.exp_hist", "http.server.duration/exp/hist", "http.server.duration/exp_hist", "http.server.duration_exp.hist", "http.server.duration_exp_hist", "http.server/duration/exp/hist", "http.server/duration/exp_hist", "http.server/duration_exp_hist", "http.server_duration.exp.hist", "http.server_duration.exp_hist", "http.server_duration_exp.hist", "http.server_duration_exp_hist", "http/server/duration/exp/hist", "http/server/duration/exp_hist", "http/server/duration_exp_hist", "http/server_duration_exp_hist", "http_server.duration.exp.hist", "http_server.duration.exp_hist", "http_server.duration_exp.hist", "http_server.duration_exp_hist", "http_server_duration.exp.hist", "http_server_duration.exp_hist", "http_server_duration_exp.hist")) AND (TimeUnix <= toDateTime64("2026-01-01 00:00:01.000000000", 9))) AND (TimeUnix > (toDateTime64("2026-01-01 00:00:01.000000000", 9) - toIntervalNanosecond(300000000000))))
+          Scan(otel_metrics_exponential_histogram)
+-- sql --
+SELECT ? AS `MetricName`, `Attributes` AS `Attributes`, now64(?) AS `TimeUnix`, toFloat64(?) AS `Value`, toFloat64(`Count`) AS `HistogramCount`, toFloat64(`Sum`) AS `HistogramSum`, toInt32(`Scale`) AS `HistogramScale`, toFloat64(0.) AS `HistogramZeroThreshold`, toFloat64(`ZeroCount`) AS `HistogramZeroCount`, toInt32(`PositiveOffset`) AS `HistogramPositiveOffset`, arrayMap(x -> toFloat64(x), `PositiveBucketCounts`) AS `HistogramPositiveBucketCounts`, toInt32(`NegativeOffset`) AS `HistogramNegativeOffset`, arrayMap(x -> toFloat64(x), `NegativeBucketCounts`) AS `HistogramNegativeBucketCounts` FROM (SELECT map(?, `gkey_0`) AS `Attributes`, (`Count` / `_hq_group_series_count`) AS `Count`, (`Sum` / `_hq_group_series_count`) AS `Sum`, `_hq_merged_scale` AS `Scale`, (`ZeroCount` / `_hq_group_series_count`) AS `ZeroCount`, arrayMin(arrayMap((s, off) -> bitShiftRight(off, (s - `_hq_merged_scale`)), `_hq_scales`, `_hq_pos_offsets`)) AS `PositiveOffset`, arrayMap(b -> (b / `_hq_group_series_count`), arrayMap(t -> arraySum(arrayMap((s, off, arr) -> arraySum(arrayMap(j -> if((bitShiftRight((off + (j - ?)), (s - `_hq_merged_scale`)) = (arrayMin(arrayMap((sm, om) -> bitShiftRight(om, (sm - `_hq_merged_scale`)), `_hq_scales`, `_hq_pos_offsets`)) + t)), arr[j], ?), arrayEnumerate(arr))), `_hq_scales`, `_hq_pos_offsets`, `_hq_pos_buckets`)), range(toUInt64(greatest(?, ((arrayMax(arrayMap((sm, om, am) -> bitShiftRight((om + (length(am) - ?)), (sm - `_hq_merged_scale`)), `_hq_scales`, `_hq_pos_offsets`, `_hq_pos_buckets`)) - arrayMin(arrayMap((sm, om) -> bitShiftRight(om, (sm - `_hq_merged_scale`)), `_hq_scales`, `_hq_pos_offsets`))) + ?)))))) AS `PositiveBucketCounts`, arrayMin(arrayMap((s, off) -> bitShiftRight(off, (s - `_hq_merged_scale`)), `_hq_scales`, `_hq_neg_offsets`)) AS `NegativeOffset`, arrayMap(b -> (b / `_hq_group_series_count`), arrayMap(t -> arraySum(arrayMap((s, off, arr) -> arraySum(arrayMap(j -> if((bitShiftRight((off + (j - ?)), (s - `_hq_merged_scale`)) = (arrayMin(arrayMap((sm, om) -> bitShiftRight(om, (sm - `_hq_merged_scale`)), `_hq_scales`, `_hq_neg_offsets`)) + t)), arr[j], ?), arrayEnumerate(arr))), `_hq_scales`, `_hq_neg_offsets`, `_hq_neg_buckets`)), range(toUInt64(greatest(?, ((arrayMax(arrayMap((sm, om, am) -> bitShiftRight((om + (length(am) - ?)), (sm - `_hq_merged_scale`)), `_hq_scales`, `_hq_neg_offsets`, `_hq_neg_buckets`)) - arrayMin(arrayMap((sm, om) -> bitShiftRight(om, (sm - `_hq_merged_scale`)), `_hq_scales`, `_hq_neg_offsets`))) + ?)))))) AS `NegativeBucketCounts` FROM (SELECT `Attributes`[?] AS `gkey_0`, sum(`Count`) AS `Count`, sum(`Sum`) AS `Sum`, toFloat64(count()) AS `_hq_group_series_count`, min(`Scale`) AS `_hq_merged_scale`, sum(`ZeroCount`) AS `ZeroCount`, groupArray(`Scale`) AS `_hq_scales`, groupArray(`PositiveOffset`) AS `_hq_pos_offsets`, groupArray(`PositiveBucketCounts`) AS `_hq_pos_buckets`, groupArray(`NegativeOffset`) AS `_hq_neg_offsets`, groupArray(`NegativeBucketCounts`) AS `_hq_neg_buckets` FROM (SELECT mapSort(mapConcat(mapUpdate(mapFromArrays(arrayMap(k -> replaceRegexpAll(k, '[^a-zA-Z0-9_]', '_'), mapKeys(mapFilter((k, v) -> (k NOT IN (?, ?)), `ResourceAttributes`))), mapValues(mapFilter((k, v) -> (k NOT IN (?, ?)), `ResourceAttributes`))), mapFromArrays(arrayMap(k -> replaceRegexpAll(k, '[^a-zA-Z0-9_]', '_'), mapKeys(`Attributes`)), mapValues(`Attributes`))), mapFilter((k, v) -> (v != ?), map(?, toString(`ServiceName`))))) AS `Attributes`, argMax(`Count`, `TimeUnix`) AS `Count`, argMax(`Sum`, `TimeUnix`) AS `Sum`, argMax(`Scale`, `TimeUnix`) AS `Scale`, argMax(`ZeroCount`, `TimeUnix`) AS `ZeroCount`, argMax(`PositiveOffset`, `TimeUnix`) AS `PositiveOffset`, argMax(`PositiveBucketCounts`, `TimeUnix`) AS `PositiveBucketCounts`, argMax(`NegativeOffset`, `TimeUnix`) AS `NegativeOffset`, argMax(`NegativeBucketCounts`, `TimeUnix`) AS `NegativeBucketCounts` FROM (SELECT * FROM `otel_metrics_exponential_histogram` PREWHERE (`MetricName` IN (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)) WHERE (`TimeUnix` <= toDateTime64(?, ?)) AND (`TimeUnix` > (toDateTime64(?, ?) - toIntervalNanosecond(?)))) GROUP BY `Attributes`) GROUP BY `gkey_0`))


### PR DESCRIPTION
Answers `avg [by/without] (<exponential histogram selector>)`, the fifth histogram-valued PromQL lowering after the bare selector, `sum()` and `rate()`/`increase()`.

This addresses part of #1772. It deliberately carries **no closing keyword** — #1772 tracks a class of rejected shapes and three of them are still rejected after this. See "What is still rejected" below and the comment posted on the issue.

## What reference does

`avg()` over native-histogram samples is histogram-valued: the aggregation accumulates an incremental mean of the group's `FloatHistogram`s. The incremental form exists for floating-point accuracy over long groups; the value it converges on is the summed distribution divided by the number of contributing samples.

So `avg()` is `sum()` plus one division, and it is wired as exactly that — one recognizer and one merge now serve both aggregations, so the scale-fold / offset-align / zero-pad arithmetic cannot drift between them, and `histogram_native_avg.go` adds only the scaling.

## The part that is easy to get wrong

Reference's `FloatHistogram.Div` scales **five** fields and no others:

```go
h.ZeroCount /= scalar
h.Count     /= scalar
h.Sum       /= scalar
for i := range h.PositiveBuckets { h.PositiveBuckets[i] /= scalar }
for i := range h.NegativeBuckets { h.NegativeBuckets[i] /= scalar }
```

`Scale`, the zero threshold and both bucket **offsets** are untouched: they describe where the buckets sit on the value axis, not how much fell into them. A plan that divided those too would still publish thirteen well-typed columns in contract order, still decode, and still pass every structural check — while answering with a distribution slid sideways.

So `TestLower_ExpHistogram_AvgDividesOnlyTheCountFields` asserts in both directions, with `sum()` alongside as the no-division control. Both halves were verified against mutants: divide `Scale` too and it fails; forget the bucket ladders and it fails.

Because the default OTel schema does not persist a zero threshold, that column is not published at all there — so the test also runs against a schema that does set it, rather than leaving that assertion looking present while finding nothing.

## Fixtures

Two spec fixtures, both sharing their seed with the `sum()` sibling so the division reads as the only difference. `exp_histogram_avg_by.txtar` carries the assertion the ungrouped one cannot: its two groups have **different member counts** (2 and 1), so a global rather than per-group divisor gets `web` wrong, while a missing divisor gets `api` wrong. Both pass the chDB roundtrip against hand-worked expectations.

The fractional bucket counts (`[0.5, 3, 4]`) are the point rather than an artefact: averaging integer counts is where fractions first reach a histogram-valued answer, which #2037's typed output columns made decodable.

## Blast radius

`sum()`'s emitted SQL is byte-identical to before — the member-count aggregate is collected only for `avg()`, so a shipped lowering does not grow a column nothing reads. The only regenerated tracked artefact is the catalogue entry; the new fixtures bring their own solver and cardinality baselines.

## The divergence entry: retargeted, not deleted

The entry's site key is a SHA of the rejection message, which now names `avg()`, so the key relocated `#609f45fd` → `#4ba854ed` and lost its curation. Re-curated at `resets(demo_latency_exp_hist[5m])` — a trigger cerberus still rejects and reference still answers — with `tracking_issue` and `since` preserved.

Deleting it would have ratcheted the divergence ceiling 3 → 2 for free, which is tempting, but it would also have hidden a divergence that is still real. Retargeting keeps it visible; the ceiling stays 3 and `docs/coverage.md` is unchanged.

## What is still rejected, and why

Verified against the pinned parser fork rather than assumed:

| Shape | Reference | Status |
|---|---|---|
| `resets()`, `changes()`, `count()` | **answers**, float-valued | still rejected — stays under #1772, which the catalogue entry now points at via `resets()` |
| `h * 2`, `h / 2` | **answers**, histogram-valued (`Mul`/`Div`) | still rejected — filed as #2087, structurally distinct (needs a new `BinaryExpr` root dispatch) |
| `h + 1`, `h - 1` | drops the sample with an `IncompatibleTypesInBinOp` annotation | not a "reference answers" divergence |
| `min`, `max`, `stddev`, `stdvar`, `quantile` | drops histogram samples with a `HistogramIgnoredInAggregation` annotation | not a divergence — an empty result is the reference answer, which is why `expHistogramAggOpIsMergeable` admits only `sum` and `avg` |

`resets()` / `changes()` / `count()` are not filed separately on purpose: they are the same class #1772 already names — float-valued reductions over exp-histogram samples — and filing three more leaves of a known class would be noise. #2087 is filed because it is a different class.
