### PR TITLE
fix(api/tempo): honour the q narrowing filter on the tag-value routes

### DIFF
--- a/compatibility/parity-baseline.json
+++ b/compatibility/parity-baseline.json
@@ -1145,8 +1145,8 @@
       ]
     },
     "tempo": {
-      "passed": 78,
-      "total": 78,
+      "passed": 82,
+      "total": 82,
       "cases": [
         "metrics_instant | metrics_avg_over_time_instant",
         "metrics_instant | metrics_count_over_time_instant",
@@ -1208,9 +1208,13 @@
         "search | spansets_select_nested_set",
         "search | status_eq_error",
         "search | status_not_nil",
+        "tag_values_v1 | tag_values_v1_query_ignored",
         "tag_values_v1 | tag_values_v1_service_name",
         "tag_values_v2 | tag_values_v2_deployment_env",
+        "tag_values_v2 | tag_values_v2_intrinsic_scoped_by_query",
+        "tag_values_v2 | tag_values_v2_scoped_by_query",
         "tag_values_v2 | tag_values_v2_service_name",
+        "tag_values_v2 | tag_values_v2_span_attr_scoped_by_query",
         "tag_values_v2 | tag_values_v2_unknown_tag_empty",
         "tags_v1 | tags_v1_all",
         "tags_v1 | tags_v1_malformed_query",
@@ -1229,8 +1233,8 @@
       ]
     },
     "tempo-grpc": {
-      "passed": 76,
-      "total": 76,
+      "passed": 80,
+      "total": 80,
       "cases": [
         "metrics_instant | metrics_avg_over_time_instant",
         "metrics_instant | metrics_count_over_time_instant",
@@ -1292,9 +1296,13 @@
         "search | spansets_select_nested_set",
         "search | status_eq_error",
         "search | status_not_nil",
+        "tag_values_v1 | tag_values_v1_query_ignored",
         "tag_values_v1 | tag_values_v1_service_name",
         "tag_values_v2 | tag_values_v2_deployment_env",
+        "tag_values_v2 | tag_values_v2_intrinsic_scoped_by_query",
+        "tag_values_v2 | tag_values_v2_scoped_by_query",
         "tag_values_v2 | tag_values_v2_service_name",
+        "tag_values_v2 | tag_values_v2_span_attr_scoped_by_query",
         "tag_values_v2 | tag_values_v2_unknown_tag_empty",
         "tags_v1 | tags_v1_all",
         "tags_v1 | tags_v1_malformed_query",

--- a/compatibility/tempo/driver/corpus.go
+++ b/compatibility/tempo/driver/corpus.go
@@ -6,10 +6,13 @@
 //
 //	-- name --                  short identifier, used in the report
 //	-- query --                 the TraceQL expression (search / metrics
-//	                            endpoints). On tags_v1 / tags_v2 it is
-//	                            optional and rides as the `q` narrowing
-//	                            parameter, which restricts the answer to the
-//	                            keys the selected spans carry.
+//	                            endpoints). On all four tag-discovery
+//	                            endpoints it is optional and rides as the `q`
+//	                            narrowing parameter, which restricts the
+//	                            answer to the keys (tags_*) or values
+//	                            (tag_values_*) the selected spans carry.
+//	                            Only the V2 routes honour it — see
+//	                            validateTagAssertions.
 //	-- endpoint --              one of: search | search_recent | traces |
 //	                            traces_v2 | tags_v1 | tags_v2 |
 //	                            tag_values_v1 | tag_values_v2 |
@@ -43,8 +46,9 @@
 //	-- expected_values --       newline-separated subset that must appear in
 //	                            the response list (tag-names or tag-values)
 //	-- expected_absent_values --newline-separated set that must NOT appear in
-//	                            the tag-names list — the strict-subset half of
-//	                            a `q`-scoped tags_v2 case (tags_v1 ignores `q`,
+//	                            the tag-names / tag-values list — the
+//	                            strict-subset half of a `q`-scoped tags_v2 or
+//	                            tag_values_v2 case (the V1 routes ignore `q`,
 //	                            so a V1 case asserts the wide answer instead)
 //	-- expected_scopes --       newline-separated subset of scope names
 //	                            (resource / span / intrinsic) that must
@@ -211,14 +215,15 @@ type CorpusCase struct {
 	ExpectedValues []string
 
 	// ExpectedAbsentValues is the mirror of ExpectedValues: every entry
-	// must be MISSING from the tag-names list. It exists so a `q`-scoped
-	// tags_v2 case can assert the scoped key set is a STRICT subset of
-	// the unscoped one — an expected_values-only case passes just as well
-	// when `q` is ignored entirely, because the keys it names are in the
-	// unfiltered answer too. A tags_v1 case never carries one: V1 has no
-	// `q` to honour, so its scoped answer IS the unscoped one and the
-	// assertion that catches a regression there is the presence of the
-	// keys a narrowing route would have dropped. Empty disables.
+	// must be MISSING from the tag-names or tag-values list. It exists so
+	// a `q`-scoped tags_v2 / tag_values_v2 case can assert the scoped set
+	// is a STRICT subset of the unscoped one — an expected_values-only
+	// case passes just as well when `q` is ignored entirely, because the
+	// entries it names are in the unfiltered answer too. A V1 case never
+	// carries one: V1 has no `q` to honour, so its scoped answer IS the
+	// unscoped one and the assertion that catches a regression there is
+	// the presence of the entries a narrowing route would have dropped.
+	// Empty disables.
 	ExpectedAbsentValues []string
 
 	// ExpectedScopes is a subset-must-be-present assertion for the
@@ -549,7 +554,7 @@ func validateCase(cur CorpusCase, ord int) (CorpusCase, error) {
 	if cur.Scope != "" && cur.Endpoint != "tags_v2" {
 		return cur, fmt.Errorf("case %q: -- scope -- is only valid for endpoint=tags_v2 (got %s)", cur.Name, cur.Endpoint)
 	}
-	if err := validateTagNameAssertions(cur); err != nil {
+	if err := validateTagAssertions(cur); err != nil {
 		return cur, err
 	}
 	if cur.Spss != 0 && cur.Endpoint != "search" {
@@ -570,39 +575,63 @@ func validateCase(cur CorpusCase, ord int) (CorpusCase, error) {
 	return cur, nil
 }
 
-// validateTagNameAssertions keeps a tag-names case honest about what it
+// narrowingTagEndpoint reports whether the endpoint is a tag-discovery
+// route that HONOURS the `q` narrowing parameter — the two V2 routes.
+// Both the name and the value pair split the same way, and upstream's
+// own code is why: only the V2 executors run ExtractConditionGroups over
+// the request query, while the V1 ones reach storage with a bare scope
+// (names) or a bare tag name (values) and no slot for a filter.
+func narrowingTagEndpoint(ep string) bool {
+	return ep == "tags_v2" || ep == "tag_values_v2"
+}
+
+// unfilteredTagEndpoint reports whether the endpoint is a tag-discovery
+// route that IGNORES `q` — the two V1 routes.
+func unfilteredTagEndpoint(ep string) bool {
+	return ep == "tags_v1" || ep == "tag_values_v1"
+}
+
+// validateTagAssertions keeps a tag-discovery case honest about what it
 // claims the route does with the assertions it carries. Every rule here is
 // about the same failure: a case that passes whether or not the behaviour
 // under test happened.
-func validateTagNameAssertions(cur CorpusCase) error {
-	// expected_absent_values is only read by assertTagsCase, so allowing
-	// it anywhere else would let a case carry an assertion that never
-	// runs — a green that proves nothing.
-	if len(cur.ExpectedAbsentValues) != 0 && cur.Endpoint != "tags_v1" && cur.Endpoint != "tags_v2" {
-		return fmt.Errorf("case %q: -- expected_absent_values -- is only valid for endpoint=tags_v1 / tags_v2 (got %s)", cur.Name, cur.Endpoint)
+//
+// The rules are stated over the endpoint's `q` CONTRACT rather than over
+// endpoint names one at a time, so the name and value pairs cannot drift
+// apart — the value routes were originally left out of the narrowing fix
+// entirely (#1932), and a per-name rule set is exactly what let that gap
+// sit undetected: the loader rejected the strict-subset assertion on the
+// value endpoints, so no case could have caught the missing filter.
+func validateTagAssertions(cur CorpusCase) error {
+	// expected_absent_values is only read by assertTagsCase /
+	// assertTagValuesCase, so allowing it anywhere else would let a case
+	// carry an assertion that never runs — a green that proves nothing.
+	if len(cur.ExpectedAbsentValues) != 0 && !isTagEndpoint(cur.Endpoint) {
+		return fmt.Errorf("case %q: -- expected_absent_values -- is only valid for endpoint=tags_v1 / tags_v2 / tag_values_v1 / tag_values_v2 (got %s)", cur.Name, cur.Endpoint)
 	}
-	// `q` on a tag-names route means opposite things on the two versions,
-	// and a case that sends one has to say which it is testing.
+	// `q` on a tag-discovery route means opposite things on the two
+	// versions, and a case that sends one has to say which it is testing.
 	//
-	// On tags_v2 the parameter narrows, and the only reason to send one is
-	// to get a SMALLER key set back: without an expected_absent_values the
+	// On a V2 route the parameter narrows, and the only reason to send one
+	// is to get a SMALLER set back: without an expected_absent_values the
 	// case passes identically when `q` is dropped on the floor, which is
 	// the bug the parameter exists to fix.
-	if cur.Query != "" && cur.Endpoint == "tags_v2" && len(cur.ExpectedAbsentValues) == 0 {
-		return fmt.Errorf("case %q: endpoint=tags_v2 with a -- query -- requires -- expected_absent_values -- (a key the unscoped answer carries and the scoped one must not), otherwise the case cannot tell a honoured `q` from an ignored one", cur.Name)
+	if cur.Query != "" && narrowingTagEndpoint(cur.Endpoint) && len(cur.ExpectedAbsentValues) == 0 {
+		return fmt.Errorf("case %q: endpoint=%s with a -- query -- requires -- expected_absent_values -- (an entry the unscoped answer carries and the scoped one must not), otherwise the case cannot tell a honoured `q` from an ignored one", cur.Name, cur.Endpoint)
 	}
-	// tags_v1 does not take `q` — upstream's V1 route drops it and answers
-	// the whole window (LiveStore.SearchTags forwards only the scope into
-	// SearchTagsV2). So a V1 case sending one asserts the OPPOSITE: the
-	// keys the query does not select are still there. Requiring
-	// expected_values and refusing expected_absent_values keeps a case
-	// from re-encoding the narrowing premise on the route that has none.
-	if cur.Query != "" && cur.Endpoint == "tags_v1" {
+	// A V1 route does not take `q` — upstream drops it and answers the
+	// whole window (LiveStore.SearchTags forwards only the scope into
+	// SearchTagsV2; the V1 values executors take a bare tag name). So a V1
+	// case sending one asserts the OPPOSITE: the entries the query does not
+	// select are still there. Requiring expected_values and refusing
+	// expected_absent_values keeps a case from re-encoding the narrowing
+	// premise on the route that has none.
+	if cur.Query != "" && unfilteredTagEndpoint(cur.Endpoint) {
 		if len(cur.ExpectedAbsentValues) != 0 {
-			return fmt.Errorf("case %q: endpoint=tags_v1 with a -- query -- cannot carry -- expected_absent_values -- (V1 ignores `q` and answers the unscoped key set)", cur.Name)
+			return fmt.Errorf("case %q: endpoint=%s with a -- query -- cannot carry -- expected_absent_values -- (V1 ignores `q` and answers the unscoped set)", cur.Name, cur.Endpoint)
 		}
 		if len(cur.ExpectedValues) == 0 {
-			return fmt.Errorf("case %q: endpoint=tags_v1 with a -- query -- requires -- expected_values -- (a key only the spans the query does NOT select carry), otherwise the case cannot tell an ignored `q` from an honoured one", cur.Name)
+			return fmt.Errorf("case %q: endpoint=%s with a -- query -- requires -- expected_values -- (an entry only the spans the query does NOT select carry), otherwise the case cannot tell an ignored `q` from an honoured one", cur.Name, cur.Endpoint)
 		}
 	}
 	return nil
@@ -670,9 +699,9 @@ func hasBodyShapeAssertion(cur CorpusCase) bool {
 }
 
 // isTagEndpoint reports whether the given endpoint is one of the four
-// tag / tag-values endpoints. None of them REQUIRES a TraceQL query:
-// tag_values_v1 / tag_values_v2 have no query slot at all, and on
-// tags_v1 / tags_v2 the query is the optional `q` narrowing filter.
+// tag / tag-values endpoints. None of them REQUIRES a TraceQL query: on
+// all four the query is the optional `q` narrowing filter, honoured on
+// the V2 halves and ignored on the V1 halves.
 func isTagEndpoint(ep string) bool {
 	switch ep {
 	case "tags_v1", "tags_v2", "tag_values_v1", "tag_values_v2":

--- a/compatibility/tempo/driver/corpus/smoke.txtar
+++ b/compatibility/tempo/driver/corpus/smoke.txtar
@@ -1026,6 +1026,126 @@ tag_values_v2
 -- expected_max_values --
 0
 
+# --- `q` narrowing on the tag-VALUES routes (#1932) ---
+# The value half of the same autocomplete `q` the tags_v2 cases above
+# pin. Grafana's value dropdown is what these routes back, so the
+# unfiltered answer is both the widest set and the least relevant one:
+# every value the key takes anywhere in the window rather than the
+# values it takes on the spans the user's half-typed query selects.
+#
+# Every V2 case here carries an -- expected_absent_values -- because
+# that is the ONLY assertion that can tell a honoured `q` from an
+# ignored one: an expected_values-only case passes just as well against
+# the unfiltered list, since those values are in it too. The loader
+# enforces that (corpus.go's validateTagAssertions).
+#
+# The three V2 cases below are one per CH lookup shape, because the
+# narrowing conjunct lands in a different place in each: the resource
+# map and the span map both go through the dynamic-attribute
+# arrayJoin subquery (where the conjunct joins the INNER query, the
+# one that still has the span row in scope), while an intrinsic goes
+# through the flat DISTINCT-column projection.
+
+-- name --
+tag_values_v2_scoped_by_query
+-- endpoint --
+tag_values_v2
+# Auto-scope leading-dot form, resolving into ResourceAttributes where
+# the seeder writes service.name (same rationale as
+# tag_values_v2_service_name above). Unfiltered this key takes all four
+# seeded service names; under a query that selects one service's spans
+# it must take exactly one.
+-- tag_name --
+.service.name
+-- query --
+{ resource.service.name = "checkout" }
+-- expected_min_values --
+1
+-- expected_max_values --
+50
+-- expected_values --
+checkout
+-- expected_absent_values --
+payments
+search
+shipping
+
+-- name --
+tag_values_v2_span_attr_scoped_by_query
+-- endpoint --
+tag_values_v2
+# The span-attribute map, one lookup shape over from the case above.
+# The seeder gives every trace 2..4 children carrying child.index
+# "0".."3", so the unfiltered value set is those four; a query pinning
+# the attribute to one of them must leave exactly that one.
+-- tag_name --
+.child.index
+-- query --
+{ span.child.index = "0" }
+-- expected_min_values --
+1
+-- expected_max_values --
+50
+-- expected_values --
+0
+-- expected_absent_values --
+1
+2
+3
+
+-- name --
+tag_values_v2_intrinsic_scoped_by_query
+-- endpoint --
+tag_values_v2
+# The intrinsic branch: `name` reads the dedicated span-name column
+# rather than an attribute map, so it exercises the OTHER values-SQL
+# shape (a flat DISTINCT projection, no arrayJoin subquery to push the
+# conjunct into). The seeder names every root "GET /api/<svc>/<idx>"
+# and every child "<svc>.child.<n>", so a per-service query partitions
+# the span-name space cleanly.
+-- tag_name --
+name
+-- query --
+{ resource.service.name = "checkout" }
+-- expected_min_values --
+1
+-- expected_max_values --
+500
+-- expected_values --
+GET /api/checkout/0
+checkout.child.0
+-- expected_absent_values --
+GET /api/payments/0
+payments.child.0
+
+-- name --
+tag_values_v1_query_ignored
+-- endpoint --
+tag_values_v1
+# The V1 half of the asymmetry, and the reason the loader refuses an
+# -- expected_absent_values -- here: upstream parses `q` on this route
+# and even re-emits it onto the sub-requests, but every V1 executor
+# reaches storage with a bare tag name and no slot for a filter
+# (modules/livestore/instance_search.go's SearchTagValues calls
+# block.SearchTagValues(ctx, tagName, ...); the backend-block leg gets
+# there via tempodb the same way). So V1 answers the whole window's
+# value set whatever `q` says, and the assertion IS that the values
+# only the spans this query does NOT select carry are still present.
+-- tag_name --
+service.name
+-- query --
+{ resource.service.name = "checkout" }
+-- expected_min_values --
+1
+-- expected_max_values --
+50
+-- expected_values --
+checkout
+payments
+search
+shipping
+
+
 # --- Nil comparisons (Traces Drilldown breakdown shapes) ---
 # Grafana Traces Drilldown appends `&& <groupBy> != nil` to EVERY
 # breakdown query, so nil comparisons on intrinsics are a load-bearing

--- a/compatibility/tempo/driver/corpus_test.go
+++ b/compatibility/tempo/driver/corpus_test.go
@@ -693,6 +693,52 @@ search
 -- expected_absent_values --
 child.index
 `,
+		// The same four guards on the tag-VALUES pair (#1932). They are
+		// stated over the endpoint's `q` contract, not over endpoint
+		// names, so the value routes inherit them rather than being a
+		// second place the rules could rot.
+		"tag values v2 query without absent values": `-- name --
+q_values_no_absent
+-- endpoint --
+tag_values_v2
+-- tag_name --
+.service.name
+-- query --
+{ resource.service.name = "checkout" }
+-- expected_values --
+checkout
+`,
+		"tag values v1 query with absent values": `-- name --
+q_values_v1_absent
+-- endpoint --
+tag_values_v1
+-- tag_name --
+service.name
+-- query --
+{ resource.service.name = "checkout" }
+-- expected_values --
+checkout
+-- expected_absent_values --
+payments
+`,
+		"tag values v1 query without expected values": `-- name --
+q_values_v1_bare
+-- endpoint --
+tag_values_v1
+-- tag_name --
+service.name
+-- query --
+{ resource.service.name = "checkout" }
+`,
+		"absent values on a metrics endpoint": `-- name --
+absent_on_metrics
+-- endpoint --
+metrics_instant
+-- query --
+{ span.http.method = "GET" } | rate()
+-- expected_absent_values --
+child.index
+`,
 	} {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
@@ -754,6 +800,71 @@ child.index
 		t.Errorf("v1 expected_absent_values = %v", v1[0].ExpectedAbsentValues)
 	}
 	if !slices.Contains(v1[0].ExpectedValues, "child.index") {
+		t.Errorf("v1 expected_values = %v", v1[0].ExpectedValues)
+	}
+}
+
+// TestParseCorpus_TagValuesQueryShapes is the positive control on the
+// tag-VALUES pair: the two shapes the corpus uses parse, and the
+// strict-subset assertion the loader used to refuse outright on these
+// endpoints now lands on the case (#1932).
+//
+// That refusal is why the missing filter went unnoticed for as long as
+// it did — the value routes ignored `q` entirely, and the one assertion
+// that could have said so was a parse error, so no corpus case could
+// have been written to fail.
+func TestParseCorpus_TagValuesQueryShapes(t *testing.T) {
+	t.Parallel()
+	const v2Src = `-- name --
+q_scoped_values_v2
+-- endpoint --
+tag_values_v2
+-- tag_name --
+.service.name
+-- query --
+{ resource.service.name = "checkout" }
+-- expected_values --
+checkout
+-- expected_absent_values --
+payments
+`
+	const v1Src = `-- name --
+q_ignored_values_v1
+-- endpoint --
+tag_values_v1
+-- tag_name --
+service.name
+-- query --
+{ resource.service.name = "checkout" }
+-- expected_values --
+checkout
+payments
+`
+	v2, err := parseCorpus(strings.NewReader(v2Src), "t.txtar")
+	if err != nil {
+		t.Fatalf("parseCorpus v2: %v", err)
+	}
+	if len(v2) != 1 {
+		t.Fatalf("v2 case count: want 1, got %d", len(v2))
+	}
+	if v2[0].Query != `{ resource.service.name = "checkout" }` {
+		t.Errorf("v2 query = %q", v2[0].Query)
+	}
+	if len(v2[0].ExpectedAbsentValues) != 1 || v2[0].ExpectedAbsentValues[0] != "payments" {
+		t.Errorf("v2 expected_absent_values = %v", v2[0].ExpectedAbsentValues)
+	}
+
+	v1, err := parseCorpus(strings.NewReader(v1Src), "t.txtar")
+	if err != nil {
+		t.Fatalf("parseCorpus v1: %v", err)
+	}
+	if len(v1) != 1 {
+		t.Fatalf("v1 case count: want 1, got %d", len(v1))
+	}
+	if len(v1[0].ExpectedAbsentValues) != 0 {
+		t.Errorf("v1 expected_absent_values = %v", v1[0].ExpectedAbsentValues)
+	}
+	if !slices.Contains(v1[0].ExpectedValues, "payments") {
 		t.Errorf("v1 expected_values = %v", v1[0].ExpectedValues)
 	}
 }

--- a/compatibility/tempo/driver/diff.go
+++ b/compatibility/tempo/driver/diff.go
@@ -471,12 +471,19 @@ func compareForEndpoint(tc CorpusCase, tempoBody, cerbBody []byte) (Diff, error)
 	}
 }
 
-// setTagQuery sends a tag-name case's optional TraceQL query as the `q`
-// narrowing parameter. Both backends accept it on /api/search/tags and
-// /api/v2/search/tags, where it restricts the answer to the keys carried
-// by the spans the query selects; a case with no -- query -- section
-// sends no `q` at all and gets the unfiltered key set, which is what
-// every tag case did before the parameter was wired.
+// setTagQuery sends a tag-discovery case's optional TraceQL query as the
+// `q` narrowing parameter. Both backends accept it on all four discovery
+// routes — /api/search/tags, /api/v2/search/tags, and the two
+// /api/[v2/]search/tag/{name}/values siblings — where it restricts the
+// answer to the keys (or values) carried by the spans the query selects;
+// a case with no -- query -- section sends no `q` at all and gets the
+// unfiltered set, which is what every tag case did before the parameter
+// was wired.
+//
+// Sending it is not the same as it being honoured: /api/search/tags
+// answers the unfiltered key set whatever `q` says (see
+// validateTagAssertions in corpus.go), and the corpus expresses that
+// asymmetry per case rather than by withholding the parameter.
 func setTagQuery(q url.Values, tc CorpusCase) {
 	if tc.Query != "" {
 		q.Set("q", tc.Query)
@@ -543,10 +550,12 @@ func buildURL(base string, tc CorpusCase, backend string, startTS, endTS time.Ti
 		u.Path += "/api/search/tag/" + tc.TagName + "/values"
 		q.Set("start", fmt.Sprintf("%d", startTS.Unix()))
 		q.Set("end", fmt.Sprintf("%d", endTS.Unix()))
+		setTagQuery(q, tc)
 	case "tag_values_v2":
 		u.Path += "/api/v2/search/tag/" + tc.TagName + "/values"
 		q.Set("start", fmt.Sprintf("%d", startTS.Unix()))
 		q.Set("end", fmt.Sprintf("%d", endTS.Unix()))
+		setTagQuery(q, tc)
 	case "metrics_range":
 		u.Path += "/api/metrics/query_range"
 		q.Set("q", tc.Query)

--- a/compatibility/tempo/driver/differ.go
+++ b/compatibility/tempo/driver/differ.go
@@ -662,7 +662,10 @@ func assertTagsCase(tc CorpusCase, body []byte, backendLabel string) ([]DiffReas
 }
 
 // assertTagValuesCase applies the tag-values assertions: min/max list
-// cardinality + expected-values subset.
+// cardinality, expected-values subset, and expected-absent-values
+// disjointness — the strict-subset half of a `q`-scoped case, which is
+// the only assertion that can tell a honoured `q` from an ignored one
+// (#1932).
 func assertTagValuesCase(tc CorpusCase, body []byte, backendLabel string) ([]DiffReason, error) {
 	v2 := tc.Endpoint == "tag_values_v2"
 	values, _, err := decodeTagValues(body, v2)
@@ -689,6 +692,18 @@ func assertTagValuesCase(tc CorpusCase, body []byte, backendLabel string) ([]Dif
 				reasons = append(reasons, DiffReason{
 					Kind:   "assertion",
 					Detail: fmt.Sprintf("%s: expected tag value %q in response (tag_name=%q)", backendLabel, want, tc.TagName),
+				})
+			}
+		}
+	}
+	if len(tc.ExpectedAbsentValues) > 0 {
+		seen := stringSet(values)
+		for _, unwanted := range tc.ExpectedAbsentValues {
+			if seen[unwanted] {
+				reasons = append(reasons, DiffReason{
+					Kind: "assertion",
+					Detail: fmt.Sprintf("%s: tag value %q must be absent from the response (tag_name=%q, q=%q)",
+						backendLabel, unwanted, tc.TagName, tc.Query),
 				})
 			}
 		}

--- a/compatibility/tempo/driver/differ_test.go
+++ b/compatibility/tempo/driver/differ_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bytes"
 	"math"
+	"slices"
 	"strings"
 	"testing"
 )
@@ -791,6 +792,54 @@ func TestAssertCase_TagsAbsentValues(t *testing.T) {
 	}
 	if !strings.Contains(reasons[0].Detail, "child.index") {
 		t.Errorf("reason does not name the leaked key: %s", reasons[0].Detail)
+	}
+}
+
+// TestAssertCase_TagValuesAbsentValues is the same strict-subset test
+// one route over, on the tag-VALUES pair (#1932). It is a separate
+// assertion path — assertTagValuesCase decodes a flat value list (V1)
+// or typed {type,value} objects (V2), not the scope-partitioned
+// envelope assertTagsCase reads — so the tags test above does not cover
+// it, and until this landed the value routes had no graded way to say a
+// `q` was honoured.
+func TestAssertCase_TagValuesAbsentValues(t *testing.T) {
+	t.Parallel()
+	tc := CorpusCase{
+		Name:                 "x",
+		Endpoint:             "tag_values_v2",
+		TagName:              ".service.name",
+		Query:                `{ resource.service.name = "checkout" }`,
+		ExpectedValues:       []string{"checkout"},
+		ExpectedAbsentValues: []string{"payments", "shipping"},
+	}
+
+	scoped := []byte(`{"tagValues":[{"type":"string","value":"checkout"}]}`)
+	reasons, err := AssertCase(tc, scoped, "tempo")
+	if err != nil {
+		t.Fatalf("AssertCase (scoped): %v", err)
+	}
+	if len(reasons) != 0 {
+		t.Fatalf("scoped answer should pass, got %+v", reasons)
+	}
+
+	// The same case against a backend that ignored `q` and answered the
+	// window-wide value set: both absent values are present, so it must
+	// fail once per leaked value.
+	unscoped := []byte(`{"tagValues":[` +
+		`{"type":"string","value":"checkout"},` +
+		`{"type":"string","value":"payments"},` +
+		`{"type":"string","value":"shipping"}]}`)
+	reasons, err = AssertCase(tc, unscoped, "tempo")
+	if err != nil {
+		t.Fatalf("AssertCase (unscoped): %v", err)
+	}
+	if len(reasons) != 2 {
+		t.Fatalf("unscoped answer should fail on both leaked values, got %+v", reasons)
+	}
+	for _, want := range []string{"payments", "shipping"} {
+		if !slices.ContainsFunc(reasons, func(r DiffReason) bool { return strings.Contains(r.Detail, want) }) {
+			t.Errorf("no reason names the leaked value %q: %+v", want, reasons)
+		}
 	}
 }
 

--- a/compatibility/tempo/driver/grpc_diff.go
+++ b/compatibility/tempo/driver/grpc_diff.go
@@ -512,6 +512,7 @@ func fetchGRPCTagsV2(ctx context.Context, client tempopb.StreamingQuerierClient,
 func fetchGRPCTagValuesV1(ctx context.Context, client tempopb.StreamingQuerierClient, tc CorpusCase, opts caseOpts) ([]byte, error) {
 	req := &tempopb.SearchTagValuesRequest{
 		TagName: tc.TagName,
+		Query:   tc.Query,
 		Start:   unixSeconds32(opts.startTS),
 		End:     unixSeconds32(opts.endTS),
 	}
@@ -538,6 +539,7 @@ func fetchGRPCTagValuesV1(ctx context.Context, client tempopb.StreamingQuerierCl
 func fetchGRPCTagValuesV2(ctx context.Context, client tempopb.StreamingQuerierClient, tc CorpusCase, opts caseOpts) ([]byte, error) {
 	req := &tempopb.SearchTagValuesRequest{
 		TagName: tc.TagName,
+		Query:   tc.Query,
 		Start:   unixSeconds32(opts.startTS),
 		End:     unixSeconds32(opts.endTS),
 	}

--- a/internal/api/tempo/grpc/tags.go
+++ b/internal/api/tempo/grpc/tags.go
@@ -10,7 +10,6 @@ import (
 	"google.golang.org/grpc/status"
 
 	"github.com/tsouza/cerberus/internal/api/tempo"
-	"github.com/tsouza/cerberus/internal/chclient"
 )
 
 // This file implements the four tag-list StreamingQuerier RPCs:
@@ -125,7 +124,11 @@ func (s *Service) SearchTagsV2(req *tempopb.SearchTagsRequest, stream tempopb.St
 // scoped names (`resource.x` / `span.x`) route to one attribute
 // map; auto-scope names (`.x`, bare dotted) union both maps. Empty
 // values are filtered out (the arrayJoin([]) shape can synthesise
-// them for rows where only one map carries the key).
+// them for rows where only one map carries the key). The request
+// Query is ignored here, as it is on the HTTP twin and in upstream
+// Tempo: a narrowing query belongs to the V2 route, and every V1
+// executor upstream takes a bare tag name with nowhere to put a filter
+// (see TagsRoute in internal/api/tempo/search_tags_filter.go).
 func (s *Service) SearchTagValues(req *tempopb.SearchTagValuesRequest, stream tempopb.StreamingQuerier_SearchTagValuesServer) error {
 	if s.Handler == nil {
 		return status.Error(codes.Internal, "tempo gRPC service not wired to handler")
@@ -134,7 +137,9 @@ func (s *Service) SearchTagValues(req *tempopb.SearchTagValuesRequest, stream te
 	if name == "" {
 		return status.Error(codes.InvalidArgument, "missing tag name")
 	}
-	values, _, err := s.lookupTagValues(stream.Context(), name, req.GetStart(), req.GetEnd())
+	values, _, err := s.lookupTagValues(
+		stream.Context(), name, tempo.TagValuesRouteV1, req.GetQuery(), req.GetStart(), req.GetEnd(),
+	)
 	if err != nil {
 		return err
 	}
@@ -148,6 +153,12 @@ func (s *Service) SearchTagValues(req *tempopb.SearchTagValuesRequest, stream te
 // ("duration" / "status" / "kind"), dynamic attributes report
 // "string" (cerberus stores SpanAttributes/ResourceAttributes as
 // CH Map(String, String)).
+//
+// This is the value-side route that honours a non-empty request
+// Query: it narrows the value set to the values the requested key
+// takes on the spans that TraceQL query selects — the gRPC spelling
+// of the HTTP `q` parameter, and the completion Grafana's value
+// dropdown actually wants.
 func (s *Service) SearchTagValuesV2(req *tempopb.SearchTagValuesRequest, stream tempopb.StreamingQuerier_SearchTagValuesV2Server) error {
 	if s.Handler == nil {
 		return status.Error(codes.Internal, "tempo gRPC service not wired to handler")
@@ -156,7 +167,9 @@ func (s *Service) SearchTagValuesV2(req *tempopb.SearchTagValuesRequest, stream 
 	if name == "" {
 		return status.Error(codes.InvalidArgument, "missing tag name")
 	}
-	values, typ, err := s.lookupTagValues(stream.Context(), name, req.GetStart(), req.GetEnd())
+	values, typ, err := s.lookupTagValues(
+		stream.Context(), name, tempo.TagValuesRouteV2, req.GetQuery(), req.GetStart(), req.GetEnd(),
+	)
 	if err != nil {
 		return err
 	}
@@ -172,7 +185,16 @@ func (s *Service) SearchTagValuesV2(req *tempopb.SearchTagValuesRequest, stream 
 // SearchTagValues and SearchTagValuesV2. The returned error is
 // already a *grpc/status error (mapped to InvalidArgument /
 // Internal) so callers can return it as-is.
-func (s *Service) lookupTagValues(ctx context.Context, name string, startSec, endSec uint32) (values []string, valueType string, err error) {
+//
+// route + query carry the request's optional TraceQL narrowing filter
+// down to the CH lookup, which is where route decides whether the query
+// is honoured at all (tempo.TagsRoute in
+// internal/api/tempo/search_tags_filter.go). Threading them through here
+// rather than at the two call sites is what keeps the RPCs from drifting
+// apart on what a `q` means.
+func (s *Service) lookupTagValues(
+	ctx context.Context, name string, route tempo.TagsRoute, query string, startSec, endSec uint32,
+) (values []string, valueType string, err error) {
 	resolved, parseErr := s.Handler.ResolveTagName(name)
 	// resolveTagName returns a non-nil error only on a parser-
 	// rejected bare dotted form. V1 historically accepted that; the
@@ -185,7 +207,7 @@ func (s *Service) lookupTagValues(ctx context.Context, name string, startSec, en
 		return nil, "", status.Error(codes.InvalidArgument, "unresolved tag name")
 	}
 	start, end := tempoTagsBounds(startSec, endSec)
-	vals, typ, err := s.Handler.FetchTagValues(ctx, resolved, start, end)
+	vals, typ, err := s.Handler.FetchTagValues(ctx, resolved, route, query, start, end)
 	if err != nil {
 		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
 			// Let the gRPC transport propagate the cancellation
@@ -193,7 +215,13 @@ func (s *Service) lookupTagValues(ctx context.Context, name string, startSec, en
 			// would mask it as a server fault.
 			return nil, "", err
 		}
-		return nil, "", status.Error(codes.Internal, chclient.SafeMessage(err))
+		// The shared classification, not a blanket Internal: with a
+		// narrowing query in the pipeline a caller can now be at fault
+		// here (an unparseable or non-row-shaped `q` is ErrClassParse /
+		// ErrClassLower → InvalidArgument), and collapsing that onto
+		// Internal would tell Grafana the backend broke rather than that
+		// the query did. A CH-side failure still classifies to Internal.
+		return nil, "", grpcStatusFor(err)
 	}
 	return vals, typ, nil
 }

--- a/internal/api/tempo/grpc/tags_test.go
+++ b/internal/api/tempo/grpc/tags_test.go
@@ -706,3 +706,142 @@ func assertTagsNarrowed(t *testing.T, got []string, unfiltered string) {
 		t.Errorf("narrowed answer dropped http.method: %v", got)
 	}
 }
+
+// The value-side narrowing fixture the three tests below share. The tag
+// is the leading-dot auto-scope form, so the lookup takes the
+// dynamic-attribute branch; the fake answers the lookup carrying the
+// extra attribute-map conjunct with a strictly smaller value set, so an
+// RPC that ignored Query surfaces the wider fallback and fails.
+const (
+	tagValuesTagName         = ".child.index"
+	tagValuesNarrowedValue   = "0"
+	tagValuesUnfilteredValue = "3"
+)
+
+func narrowedTagValuesBySQL() map[string][]string {
+	return map[string][]string{"`SpanAttributes`[?] = ?": {tagValuesNarrowedValue}}
+}
+
+// TestSearchTagValuesV2_QueryNarrows pins the gRPC half of #1932:
+// SearchTagValuesRequest.Query is the proto spelling of the HTTP `?q=`
+// parameter on the value routes, and the V2 values RPC must push it into
+// the same value lookup its HTTP twin does. Before this the field was
+// never read at all — the RPC answered the whole window's value set for
+// every Query, which is the widest and least useful answer Grafana's
+// value dropdown could get.
+func TestSearchTagValuesV2_QueryNarrows(t *testing.T) {
+	t.Parallel()
+
+	q := &fakeQuerier{
+		strings:      []string{tagValuesNarrowedValue, tagValuesUnfilteredValue},
+		stringsBySQL: narrowedTagValuesBySQL(),
+	}
+	client := newTagsTestServer(t, q)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	t.Cleanup(cancel)
+	stream, err := client.SearchTagValuesV2(ctx, &tempopb.SearchTagValuesRequest{
+		TagName: tagValuesTagName,
+		Query:   tagsNarrowingQuery,
+	})
+	if err != nil {
+		t.Fatalf("open SearchTagValuesV2 stream: %v", err)
+	}
+	frames, err := recvAll[tempopb.SearchTagValuesV2Response](t, stream)
+	if err != nil {
+		t.Fatalf("recvAll: %v", err)
+	}
+	var got []string
+	for _, f := range frames {
+		for _, v := range f.GetTagValues() {
+			got = append(got, v.GetValue())
+		}
+	}
+	assertTagValuesNarrowed(t, got)
+}
+
+// TestSearchTagValuesV1_QueryIgnored is the V1 counterpart, and the fact
+// that keeps the gRPC surface in parity with reference Tempo: the V1
+// values RPC does not take a narrowing query. Upstream parses Query for
+// both value routes and even re-emits it onto the sub-requests, but every
+// V1 executor reaches storage with a bare tag name and no slot for a
+// filter, so a V1 caller gets the whole window's values back whatever
+// Query says — including a Query that would not parse, which is answered
+// rather than rejected. Both shapes are driven here because an RPC that
+// validated Query without applying it would pass the narrowing half
+// alone.
+func TestSearchTagValuesV1_QueryIgnored(t *testing.T) {
+	t.Parallel()
+
+	for name, query := range map[string]string{
+		"narrowing": tagsNarrowingQuery,
+		"malformed": "{{{",
+	} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			q := &fakeQuerier{
+				strings:      []string{tagValuesNarrowedValue, tagValuesUnfilteredValue},
+				stringsBySQL: narrowedTagValuesBySQL(),
+			}
+			client := newTagsTestServer(t, q)
+			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			t.Cleanup(cancel)
+			stream, err := client.SearchTagValues(ctx, &tempopb.SearchTagValuesRequest{
+				TagName: tagValuesTagName,
+				Query:   query,
+			})
+			if err != nil {
+				t.Fatalf("open SearchTagValues stream: %v", err)
+			}
+			frames, err := recvAll[tempopb.SearchTagValuesResponse](t, stream)
+			if err != nil {
+				t.Fatalf("recvAll: %v", err)
+			}
+			var got []string
+			for _, f := range frames {
+				got = append(got, f.GetTagValues()...)
+			}
+			if !slices.Contains(got, tagValuesUnfilteredValue) {
+				t.Errorf("V1 narrowed its answer on Query=%q: %v", query, got)
+			}
+		})
+	}
+}
+
+// TestSearchTagValuesV2_MalformedQuery_GRPCStatus pins the rejection
+// code. An unparseable Query is caller error, and the shared
+// classification (tempo.ClassifyErr → grpcStatusFor) renders that as
+// InvalidArgument — the same fact the HTTP V2 values route answers 400
+// for. Before Query was read at all, every failure behind the values
+// lookup collapsed onto codes.Internal, which told Grafana the backend
+// had broken rather than that the query had.
+func TestSearchTagValuesV2_MalformedQuery_GRPCStatus(t *testing.T) {
+	t.Parallel()
+
+	client := newTagsTestServer(t, &fakeQuerier{})
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	t.Cleanup(cancel)
+	stream, err := client.SearchTagValuesV2(ctx, &tempopb.SearchTagValuesRequest{
+		TagName: tagValuesTagName,
+		Query:   "{{{",
+	})
+	if err != nil {
+		t.Fatalf("open SearchTagValuesV2 stream: %v", err)
+	}
+	_, err = stream.Recv()
+	assertCode(t, err, codes.InvalidArgument)
+}
+
+// assertTagValuesNarrowed asserts the narrowed value survived and the
+// value only the unfiltered lookup reports did not.
+func assertTagValuesNarrowed(t *testing.T, got []string) {
+	t.Helper()
+	if len(got) == 0 {
+		t.Fatal("no values returned")
+	}
+	if slices.Contains(got, tagValuesUnfilteredValue) {
+		t.Errorf("value %q the query does not select leaked into the answer: %v", tagValuesUnfilteredValue, got)
+	}
+	if !slices.Contains(got, tagValuesNarrowedValue) {
+		t.Errorf("narrowed answer dropped %q: %v", tagValuesNarrowedValue, got)
+	}
+}

--- a/internal/api/tempo/grpc_exports.go
+++ b/internal/api/tempo/grpc_exports.go
@@ -133,16 +133,34 @@ func (h *Handler) ResolveTagName(name string) (ResolvedTagName, error) {
 // SpanAttributes / ResourceAttributes map(s). Returns the sorted,
 // de-duplicated value list plus the Tempo V2 type label (see
 // intrinsicType — "string" for dynamic attributes).
-func (h *Handler) FetchTagValues(ctx context.Context, r ResolvedTagName, start, end time.Time) (values []string, valueType string, err error) {
+//
+// query is the caller's optional TraceQL narrowing filter — the `q` URL
+// parameter on the HTTP routes, SearchTagValuesRequest.Query over gRPC —
+// and route says which tag-value route is asking, which is what decides
+// whether the query is honoured at all. Both go through the same
+// tagQueryFilter the tag-NAME routes use, so a `q` selects the same spans
+// on every discovery route and on both transports. An empty (or
+// route-discarded) query yields a nil filter, and a nil filter appends no
+// clause: the lookup renders exactly the SQL it did before `q` existed.
+// A `q` that cannot be parsed, lowered, or reduced to a span-row
+// predicate comes back as a classified error (ClassifyErr →
+// InvalidArgument).
+func (h *Handler) FetchTagValues(
+	ctx context.Context, r ResolvedTagName, route TagsRoute, query string, start, end time.Time,
+) (values []string, valueType string, err error) {
+	filter, err := h.tagQueryFilter(ctx, route, query, start, end)
+	if err != nil {
+		return nil, "", err
+	}
 	var (
 		sqlStr string
 		args   []any
 	)
 	if r.IsIntrinsic {
-		sqlStr, args = buildIntrinsicValuesSQL(h.Schema, r.IntrinsicCol, start, end)
+		sqlStr, args = buildIntrinsicValuesSQL(h.Schema, r.IntrinsicCol, filter, start, end)
 		valueType = intrinsicType(r.IntrinsicName)
 	} else {
-		sqlStr, args = buildAttributeValuesSQL(h.Schema, r.Key, r.mapScope, start, end)
+		sqlStr, args = buildAttributeValuesSQL(h.Schema, r.Key, r.mapScope, filter, start, end)
 		valueType = "string"
 	}
 	raw, err := h.Client.QueryStrings(ctx, sqlStr, args...)

--- a/internal/api/tempo/search_tag_values.go
+++ b/internal/api/tempo/search_tag_values.go
@@ -63,15 +63,26 @@ func intrinsicColumn(name string, s schema.Traces) (string, bool) {
 // path; if it matches an intrinsic the handler queries the dedicated
 // column, otherwise it unions SpanAttributes[name] and
 // ResourceAttributes[name] (a key can live in either map).
+//
+// The `q` narrowing parameter is a V2 parameter and this route ignores
+// it, as upstream does — a V1 request answers the whole window's value
+// set whatever `q` says, including a malformed one (see the route
+// contract in search_tags_filter.go).
 func (h *Handler) handleSearchTagValues(w http.ResponseWriter, r *http.Request) {
-	h.respondTagValues(w, r, false)
+	h.respondTagValues(w, r, TagValuesRouteV1)
 }
 
 // handleSearchTagValuesV2 implements
 // `GET /api/v2/search/tag/{name}/values`. Same data as V1, wrapped per
 // Tempo V2's typed envelope.
+//
+// This is the value-side route that takes the optional `q` parameter: it
+// narrows the answer to the values the requested key takes on the spans a
+// TraceQL query selects, which is what backs Grafana's value-completion
+// dropdown. It contributes one more conjunct to the lookup's WHERE;
+// absent, the SQL is unchanged (see search_tags_filter.go).
 func (h *Handler) handleSearchTagValuesV2(w http.ResponseWriter, r *http.Request) {
-	h.respondTagValues(w, r, true)
+	h.respondTagValues(w, r, TagValuesRouteV2)
 }
 
 // respondTagValues is the shared core of V1 + V2.
@@ -96,7 +107,7 @@ func (h *Handler) handleSearchTagValuesV2(w http.ResponseWriter, r *http.Request
 // resolveTagName runs the parse once; callers downstream switch on
 // whether it landed on an intrinsic column or a map lookup, and which
 // scope the map lookup targets.
-func (h *Handler) respondTagValues(w http.ResponseWriter, r *http.Request, v2 bool) {
+func (h *Handler) respondTagValues(w http.ResponseWriter, r *http.Request, route TagsRoute) {
 	name := r.PathValue("name")
 	if name == "" {
 		writeError(w, http.StatusBadRequest, "", "", errors.New("missing tag name"))
@@ -112,6 +123,17 @@ func (h *Handler) respondTagValues(w http.ResponseWriter, r *http.Request, v2 bo
 	// fact table (same map-explosion failure as /search/tags).
 	start, end = BoundDiscoveryWindow(start, end)
 
+	// The optional `?q=` narrowing filter — the same one the tag-NAME
+	// routes take, resolved through the same tagQueryFilter so a `q`
+	// selects the same spans wherever it is sent. It is read after the
+	// window so a request that gets both wrong reports the window first,
+	// matching upstream's parameter order.
+	filter, err := h.tagQueryFilter(r.Context(), route, r.URL.Query().Get("q"), start, end)
+	if err != nil {
+		writeError(w, tagsErrStatus(err), "", "", err)
+		return
+	}
+
 	resolved, _ := resolveTagName(name, h.Schema)
 	var (
 		sqlStr   string
@@ -119,10 +141,10 @@ func (h *Handler) respondTagValues(w http.ResponseWriter, r *http.Request, v2 bo
 		valueTyp string
 	)
 	if resolved.IsIntrinsic {
-		sqlStr, args = buildIntrinsicValuesSQL(h.Schema, resolved.IntrinsicCol, start, end)
+		sqlStr, args = buildIntrinsicValuesSQL(h.Schema, resolved.IntrinsicCol, filter, start, end)
 		valueTyp = intrinsicType(resolved.IntrinsicName)
 	} else {
-		sqlStr, args = buildAttributeValuesSQL(h.Schema, resolved.Key, resolved.MapScope, start, end)
+		sqlStr, args = buildAttributeValuesSQL(h.Schema, resolved.Key, resolved.MapScope, filter, start, end)
 		valueTyp = "string"
 	}
 	h.Logger.Debug("cerberus tempo /search/tag/values",
@@ -141,7 +163,7 @@ func (h *Handler) respondTagValues(w http.ResponseWriter, r *http.Request, v2 bo
 	}
 	values = sortedUnique(values)
 
-	if v2 {
+	if route == TagValuesRouteV2 {
 		out := make([]TagValueV2, 0, len(values))
 		for _, v := range values {
 			out = append(out, TagValueV2{Type: valueTyp, Value: v})
@@ -163,7 +185,11 @@ func (h *Handler) respondTagValues(w http.ResponseWriter, r *http.Request, v2 bo
 // (no-op) and numeric / enum columns (Duration, StatusCode) uniformly,
 // so the chclient.QueryStrings binder is happy regardless of the
 // underlying type.
-func buildIntrinsicValuesSQL(s schema.Traces, col string, start, end time.Time) (string, []any) {
+//
+// `filter` is the optional `?q=` span-row predicate (see
+// search_tags_filter.go); a nil filter appends no clause, so a request
+// without `q` renders exactly the SQL it always did.
+func buildIntrinsicValuesSQL(s schema.Traces, col string, filter chsql.Frag, start, end time.Time) (string, []any) {
 	sb := chsql.NewQuery().
 		Select(distinctToStringFrag(col)).
 		From(chsql.Col(s.SpansTable))
@@ -172,6 +198,9 @@ func buildIntrinsicValuesSQL(s schema.Traces, col string, start, end time.Time) 
 	}
 	if !end.IsZero() {
 		sb.Where(tempoTimeLteFrag(s.TimestampColumn, end))
+	}
+	if filter != nil {
+		sb.Where(filter)
 	}
 	return sb.Build()
 }
@@ -204,7 +233,13 @@ func buildIntrinsicValuesSQL(s schema.Traces, col string, start, end time.Time) 
 //	    WHERE mapContains(`<col>`, ?) [AND time bounds]
 //	)
 //	WHERE v != ''
-func buildAttributeValuesSQL(s schema.Traces, name string, scope attrMapScope, start, end time.Time) (string, []any) {
+//
+// `filter` is the optional `?q=` span-row predicate (see
+// search_tags_filter.go). It joins the INNER query's conjuncts, not the
+// outer one: it is a predicate over the span row, and the outer SELECT
+// sees only the exploded value column `v`. A nil filter appends no
+// clause, so a request without `q` renders exactly the SQL it always did.
+func buildAttributeValuesSQL(s schema.Traces, name string, scope attrMapScope, filter chsql.Frag, start, end time.Time) (string, []any) {
 	var (
 		selFrag   chsql.Frag
 		whereFrag chsql.Frag
@@ -229,6 +264,9 @@ func buildAttributeValuesSQL(s schema.Traces, name string, scope attrMapScope, s
 	}
 	if !end.IsZero() {
 		inner.Where(tempoTimeLteFrag(s.TimestampColumn, end))
+	}
+	if filter != nil {
+		inner.Where(filter)
 	}
 
 	outer := chsql.NewQuery().

--- a/internal/api/tempo/search_tag_values_filter_test.go
+++ b/internal/api/tempo/search_tag_values_filter_test.go
@@ -1,0 +1,375 @@
+package tempo_test
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/tsouza/cerberus/internal/api/tempo"
+)
+
+// This file pins the optional `?q=<TraceQL>` narrowing filter on the
+// tag-VALUE discovery routes (#1932), and the asymmetry between them:
+// like the tag-NAME pair, `q` is a V2 parameter.
+//
+// The value routes back the VALUE half of Grafana's tag autocomplete —
+// the dropdown the user is mid-way through completing — which is where
+// the unfiltered answer is both the largest set and the least useful
+// one: every value the key takes anywhere in the window, rather than the
+// values it takes on the spans the query already selects. The name
+// routes learned to narrow in #1820; the value routes were not in that
+// change's scope and kept answering the whole window.
+//
+// V1 answers that window-wide value set by design, and upstream is
+// unusually explicit about it: `q` is parsed for BOTH value routes by
+// one shared parser and even re-emitted onto the sub-requests, so it
+// physically reaches the queriers on V1 — and then dies at every leaf,
+// because each V1 executor takes a bare tag name with no slot for a
+// filter. Only the V2 executors extract condition groups from the query.
+// The V1 half of the tables below asserts exactly that.
+
+// The two tag-VALUE routes, named because the tests below split on which
+// one honours `q`. Each carries a `%s` for the {name} path segment.
+const (
+	tagValuesRouteV1Path = "/api/search/tag/%s/values"
+	tagValuesRouteV2Path = "/api/v2/search/tag/%s/values"
+)
+
+// tagValuesRoutes is the single enumeration of the tag-VALUE routes. A
+// third one added without joining this list is a missing row.
+var tagValuesRoutes = []string{tagValuesRouteV1Path, tagValuesRouteV2Path}
+
+// The tag whose values every case below enumerates, and the narrowing
+// query. `.child.index` is the leading-dot auto-scope form, so the
+// lookup takes the dynamic-attribute branch (the arrayJoin subquery over
+// both maps) — the shape where the narrowing conjunct has to land in the
+// INNER query to be able to see the span row at all.
+const (
+	tagValuesKey   = ".child.index"
+	tagValuesQuery = `{ span.http.method = "GET" }`
+	// tagValuesIntrinsicKey takes the OTHER values-SQL branch: a
+	// dedicated column read by a flat DISTINCT projection, with no
+	// subquery for the conjunct to land inside.
+	tagValuesIntrinsicKey = "name"
+	// tagValuesConjunct is the rendered shape of tagValuesQuery's
+	// predicate. It appears in the lookup SQL only when the filter was
+	// applied: the unfiltered dynamic-attribute SQL reads the same map
+	// column, but as a subscript in the projection and inside
+	// mapContains, never as an equality.
+	tagValuesConjunct = "`SpanAttributes`[?] = ?"
+	// tagValuesOuterWhere is the outer query's empty-value filter. The
+	// narrowing conjunct must appear BEFORE it, which is what proves it
+	// landed in the inner query rather than being applied to the already
+	// exploded value column.
+	tagValuesOuterWhere = "`v` != ?"
+)
+
+// tagValuesURL builds the request for one route. A `hasQ` of false omits
+// the parameter entirely, which is the "behaviour before `q` existed"
+// case. The window is the shared tagsFilter* pair from
+// search_tags_filter_test.go: explicit bounds keep two renders of the
+// same request byte-comparable, which the identical-SQL assertions need.
+func tagValuesURL(route, name, q string, hasQ bool) string {
+	vals := url.Values{}
+	vals.Set("start", strconv.FormatInt(tagsFilterStart.Unix(), 10))
+	vals.Set("end", strconv.FormatInt(tagsFilterEnd.Unix(), 10))
+	if hasQ {
+		vals.Set("q", q)
+	}
+	return strings.Replace(route, "%s", url.PathEscape(name), 1) + "?" + vals.Encode()
+}
+
+// tagValuesLookup drives one route and reports the status, the response
+// body, and the last SQL + args the handler sent to ClickHouse. A
+// tag-values request issues exactly one CH query, so lastSQL is
+// unambiguous without any scope narrowing.
+func tagValuesLookup(t *testing.T, name, q string, hasQ bool, route string, byS map[string][]string) (int, string, string, []any) {
+	t.Helper()
+	stub := &stubQuerier{strings: []string{"0"}, stringsBySQL: byS}
+	srv := newServer(stub, "v1.0.0-test")
+	t.Cleanup(srv.Close)
+
+	resp, err := http.Get(srv.URL + tagValuesURL(route, name, q, hasQ))
+	if err != nil {
+		t.Fatalf("GET %s: %v", route, err)
+	}
+	defer resp.Body.Close()
+	return resp.StatusCode, readBody(t, resp), stub.lastSQL, stub.lastArgs
+}
+
+// TestSearchTagValuesQuery_NarrowsLookupSQL is the #1932 regression on
+// the dynamic-attribute branch: a `q` must reach the value lookup as one
+// more WHERE conjunct over the same window, inside the subquery that
+// still has the span row in scope, with its operand values bound as
+// parameters rather than spliced into the SQL text.
+func TestSearchTagValuesQuery_NarrowsLookupSQL(t *testing.T) {
+	t.Parallel()
+
+	base, _, baseSQL, baseArgs := tagValuesLookup(t, tagValuesKey, "", false, tagValuesRouteV2Path, nil)
+	if base != http.StatusOK {
+		t.Fatalf("unfiltered lookup: status=%d", base)
+	}
+	status, body, gotSQL, gotArgs := tagValuesLookup(t, tagValuesKey, tagValuesQuery, true, tagValuesRouteV2Path, nil)
+	if status != http.StatusOK {
+		t.Fatalf("filtered lookup: status=%d body=%s", status, body)
+	}
+
+	// The unfiltered lookup reads the same map column, so the assertion
+	// has to be that the EQUALITY appeared — not merely the column.
+	if strings.Contains(baseSQL, tagValuesConjunct) {
+		t.Fatalf("unfiltered SQL already carries the narrowing conjunct, the test proves nothing: %s", baseSQL)
+	}
+	if !strings.Contains(gotSQL, tagValuesConjunct) {
+		t.Fatalf("narrowed SQL does not read the span attribute map as a predicate\n  base: %s\n   got: %s", baseSQL, gotSQL)
+	}
+	// Inside the inner query, not the outer one: the outer SELECT sees
+	// only the exploded value column `v`, so a conjunct applied there
+	// could not reference a span attribute at all.
+	conjunctAt := strings.Index(gotSQL, tagValuesConjunct)
+	outerAt := strings.Index(gotSQL, tagValuesOuterWhere)
+	if outerAt < 0 {
+		t.Fatalf("outer empty-value filter missing from the lookup: %s", gotSQL)
+	}
+	if conjunctAt > outerAt {
+		t.Errorf("narrowing conjunct landed in the OUTER query, where the span row is out of scope: %s", gotSQL)
+	}
+	// The filter is appended to the window conjuncts, never a
+	// replacement for them.
+	if got, want := strings.Count(gotSQL, "`Timestamp`"), strings.Count(baseSQL, "`Timestamp`"); got != want {
+		t.Errorf("window conjuncts changed: %d vs %d\n  base: %s\n   got: %s", got, want, baseSQL, gotSQL)
+	}
+	// The literal rides as a bound parameter (invariant 10: no SQL
+	// text carries user values).
+	if strings.Contains(gotSQL, "GET") {
+		t.Errorf("query literal spliced into SQL text: %s", gotSQL)
+	}
+	if !argsBind(gotArgs, "http.method", "GET") {
+		t.Errorf("args do not bind the attribute key and value: %v (base args %v)", gotArgs, baseArgs)
+	}
+}
+
+// TestSearchTagValuesQuery_NarrowsIntrinsicLookupSQL covers the other
+// values-SQL branch. An intrinsic reads a dedicated column through a flat
+// DISTINCT projection — there is no subquery — so the conjunct lands as a
+// trailing AND on the one query. Asserting the prefix pins both facts at
+// once: the window survives, and nothing else moved.
+func TestSearchTagValuesQuery_NarrowsIntrinsicLookupSQL(t *testing.T) {
+	t.Parallel()
+
+	_, _, baseSQL, _ := tagValuesLookup(t, tagValuesIntrinsicKey, "", false, tagValuesRouteV2Path, nil)
+	status, body, gotSQL, gotArgs := tagValuesLookup(
+		t, tagValuesIntrinsicKey, tagValuesQuery, true, tagValuesRouteV2Path, nil,
+	)
+	if status != http.StatusOK {
+		t.Fatalf("filtered lookup: status=%d body=%s", status, body)
+	}
+	if !strings.HasPrefix(gotSQL, baseSQL+" AND ") {
+		t.Fatalf("narrowed SQL is not the unfiltered SQL plus one conjunct\n  base: %s\n   got: %s", baseSQL, gotSQL)
+	}
+	extra := strings.TrimPrefix(gotSQL, baseSQL+" AND ")
+	if !strings.Contains(extra, "`SpanAttributes`") {
+		t.Errorf("added conjunct does not read the span attribute map: %s", extra)
+	}
+	if strings.Contains(gotSQL, "GET") {
+		t.Errorf("query literal spliced into SQL text: %s", gotSQL)
+	}
+	if !argsBind(gotArgs, "http.method", "GET") {
+		t.Errorf("args do not bind the attribute key and value: %v", gotArgs)
+	}
+}
+
+// TestSearchTagValuesQuery_NarrowsTheAnswer drives the narrowing end to
+// end: the stub answers the narrowed lookup with a strictly smaller value
+// set than the unfiltered one, and the assertion is that the RESPONSE —
+// not just the SQL — carries the smaller set. This is the in-process twin
+// of the compatibility corpus case tag_values_v2_scoped_by_query, which
+// pins the same subset relation against reference Tempo.
+func TestSearchTagValuesQuery_NarrowsTheAnswer(t *testing.T) {
+	t.Parallel()
+
+	// Keyed on the conjunct only the filtered lookup carries.
+	narrowed := map[string][]string{tagValuesConjunct: {"0"}}
+	// Carried by spans `{ span.http.method = "GET" }` does not select.
+	const unfiltered = "3"
+
+	stub := &stubQuerier{strings: []string{"0", unfiltered}, stringsBySQL: narrowed}
+	srv := newServer(stub, "v1.0.0-test")
+	t.Cleanup(srv.Close)
+
+	resp, err := http.Get(srv.URL + tagValuesURL(tagValuesRouteV2Path, tagValuesKey, tagValuesQuery, true))
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer resp.Body.Close()
+	got := decodeTagValues(t, tagValuesRouteV2Path, resp)
+	if len(got) == 0 {
+		t.Fatal("no values returned")
+	}
+	if !contains(got, "0") {
+		t.Errorf("narrowed answer dropped the selected value: %v", got)
+	}
+	if contains(got, unfiltered) {
+		t.Errorf("value %q the query does not select leaked into the answer: %v", unfiltered, got)
+	}
+}
+
+// TestSearchTagValuesV1Query_Ignored is the parity fact the V2 tests
+// above cannot state: V1 does not take `q`, so every shape of it — one
+// that would narrow, one that cannot be parsed, one that lowers to
+// something no row predicate describes — answers 200 with the same value
+// set and the same SQL a request without `q` gets.
+//
+// This is the compatibility corpus case tag_values_v1_query_ignored in
+// miniature: reference Tempo answers `{ span.http.method = "GET" }` on
+// the V1 values route with the whole window's values, including the ones
+// carried only by spans that query does not select.
+func TestSearchTagValuesV1Query_Ignored(t *testing.T) {
+	t.Parallel()
+
+	// Answered only when the lookup carries the narrowing conjunct, so a
+	// V1 route that pushed `q` down would return this shorter set.
+	narrowed := map[string][]string{tagValuesConjunct: {"0"}}
+	// Carried by spans `{ span.http.method = "GET" }` does not select.
+	const unfiltered = "3"
+
+	baseStatus, baseBody, baseSQL, _ := tagValuesLookup(t, tagValuesKey, "", false, tagValuesRouteV1Path, narrowed)
+	if baseStatus != http.StatusOK {
+		t.Fatalf("unfiltered lookup: status=%d body=%s", baseStatus, baseBody)
+	}
+
+	for name, query := range map[string]string{
+		"narrowing":        tagValuesQuery,
+		"malformed":        "{{{",
+		"metrics pipeline": `{} | rate()`,
+		"structural":       `{ span.a = 1 } >> { span.b = 2 }`,
+	} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			stub := &stubQuerier{strings: []string{"0", unfiltered}, stringsBySQL: narrowed}
+			srv := newServer(stub, "v1.0.0-test")
+			t.Cleanup(srv.Close)
+
+			resp, err := http.Get(srv.URL + tagValuesURL(tagValuesRouteV1Path, tagValuesKey, query, true))
+			if err != nil {
+				t.Fatalf("GET: %v", err)
+			}
+			defer resp.Body.Close()
+			if resp.StatusCode != http.StatusOK {
+				t.Fatalf("status: want 200, got %d body=%s", resp.StatusCode, readBody(t, resp))
+			}
+			got := decodeTagValues(t, tagValuesRouteV1Path, resp)
+			if !contains(got, unfiltered) {
+				t.Errorf("V1 narrowed its answer on q=%q: %v", query, got)
+			}
+			if stub.lastSQL != baseSQL {
+				t.Errorf("V1 q=%q changed the SQL\n  base: %s\n   got: %s", query, baseSQL, stub.lastSQL)
+			}
+		})
+	}
+}
+
+// TestSearchTagValuesQuery_AbsentRendersIdenticalSQL is the other half of
+// the contract: `q` is opt-in, so a request that omits it — and a request
+// that sends it empty, which is what Grafana does before the user has
+// typed anything — must render byte-identical SQL to the pre-#1932
+// handler. A filter that leaked a no-op `AND 1` would change part pruning
+// on a table this endpoint already has to be careful with. Both value-SQL
+// branches are driven, because they append the conjunct in different
+// places and could each grow a different no-op.
+func TestSearchTagValuesQuery_AbsentRendersIdenticalSQL(t *testing.T) {
+	t.Parallel()
+
+	for _, route := range tagValuesRoutes {
+		for _, key := range []string{tagValuesKey, tagValuesIntrinsicKey} {
+			t.Run(route+" "+key, func(t *testing.T) {
+				t.Parallel()
+				_, _, absentSQL, absentArgs := tagValuesLookup(t, key, "", false, route, nil)
+				_, _, emptySQL, emptyArgs := tagValuesLookup(t, key, "", true, route, nil)
+				if emptySQL != absentSQL {
+					t.Errorf("empty q changed the SQL\n  absent: %s\n   empty: %s", absentSQL, emptySQL)
+				}
+				if len(emptyArgs) != len(absentArgs) {
+					t.Errorf("empty q changed the bound args: %v vs %v", emptyArgs, absentArgs)
+				}
+			})
+		}
+	}
+}
+
+// TestSearchTagValuesQuery_Malformed pins the parse rejection. `q` is
+// TraceQL, so an unparseable one is a 400 carrying the same parse-stage
+// message /api/search answers for the identical input — one
+// classification, every route (errclass.go). V1 has no `q` to reject and
+// is covered by TestSearchTagValuesV1Query_Ignored instead.
+func TestSearchTagValuesQuery_Malformed(t *testing.T) {
+	t.Parallel()
+
+	status, body, sql, _ := tagValuesLookup(t, tagValuesKey, "{{{", true, tagValuesRouteV2Path, nil)
+	if status != http.StatusBadRequest {
+		t.Fatalf("status: want 400, got %d body=%s", status, body)
+	}
+	if !strings.Contains(body, "parse") {
+		t.Errorf("body does not name the parse stage: %s", body)
+	}
+	if sql != "" {
+		t.Errorf("a rejected q still hit ClickHouse: %s", sql)
+	}
+}
+
+// TestSearchTagValuesQuery_NonRowShapeRejected covers the queries that
+// parse and lower but whose matching spans are defined by a join or an
+// aggregate rather than a predicate over one row. There is no conjunct to
+// push into a value lookup for those, and answering the unfiltered value
+// set would be a silently WIDER answer than the caller asked for — so
+// they are refused with a 422 that names why. V2 only: V1 promises the
+// unfiltered set to begin with, so there is nothing to refuse.
+func TestSearchTagValuesQuery_NonRowShapeRejected(t *testing.T) {
+	t.Parallel()
+
+	for name, query := range map[string]string{
+		"metrics pipeline": `{} | rate()`,
+		"structural":       `{ span.a = 1 } >> { span.b = 2 }`,
+	} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			status, body, sql, _ := tagValuesLookup(t, tagValuesKey, query, true, tagValuesRouteV2Path, nil)
+			if status != http.StatusUnprocessableEntity {
+				t.Fatalf("status: want 422, got %d body=%s", status, body)
+			}
+			if !strings.Contains(body, "row predicate") {
+				t.Errorf("body does not explain the shape requirement: %s", body)
+			}
+			if sql != "" {
+				t.Errorf("a rejected q still hit ClickHouse: %s", sql)
+			}
+		})
+	}
+}
+
+// decodeTagValues flattens either envelope onto the value list, so the
+// route tables above can assert on both with one comparison.
+func decodeTagValues(t *testing.T, route string, resp *http.Response) []string {
+	t.Helper()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("%s: status=%d", route, resp.StatusCode)
+	}
+	if strings.Contains(route, "/v2/") {
+		var body tempo.SearchTagValuesResponseV2
+		if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+			t.Fatalf("decode V2: %v", err)
+		}
+		out := make([]string, 0, len(body.TagValues))
+		for _, v := range body.TagValues {
+			out = append(out, v.Value)
+		}
+		return out
+	}
+	var body tempo.SearchTagValuesResponse
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		t.Fatalf("decode V1: %v", err)
+	}
+	return body.TagValues
+}

--- a/internal/api/tempo/search_tags_filter.go
+++ b/internal/api/tempo/search_tags_filter.go
@@ -12,9 +12,11 @@ import (
 )
 
 // This file implements the optional `q=<TraceQL>` narrowing filter on the
-// tag-NAME discovery routes, and owns the one respect in which those two
-// routes differ: `q` belongs to V2 (`/api/v2/search/tags`) and not to V1
-// (`/api/search/tags`).
+// tag discovery routes — both the tag-NAME pair (`/api/search/tags`,
+// `/api/v2/search/tags`) and the tag-VALUE pair
+// (`/api/search/tag/{name}/values`, `/api/v2/search/tag/{name}/values`) —
+// and owns the one respect in which each pair's two halves differ: `q`
+// belongs to V2 and not to V1.
 //
 // Grafana's tag autocomplete sends `q` as soon as the user has typed any
 // part of a query: the point is to offer the keys that exist on the spans
@@ -23,9 +25,17 @@ import (
 // autocomplete list was wider than the data it was completing against
 // (#1820).
 //
-// That is a V2 parameter. Upstream Tempo's API reference lists `q` under
-// "Search tags V2" only, and its V1 route drops it on the floor rather
-// than rejecting it: modules/livestore/live_store.go's SearchTags forwards
+// The value routes are where that gap bites hardest, and they were left
+// out of #1820's fix (#1932). They back the VALUE half of the same
+// dropdown — the completion the user is mid-way through typing — so the
+// unfiltered answer there is both the largest set and the least relevant
+// one: every value the key takes anywhere in the window, rather than the
+// values it takes on the spans the query already selects.
+//
+// That is a V2 parameter on both pairs. On the name side, upstream
+// Tempo's API reference lists `q` under "Search tags V2" only, and the V1
+// name route drops it on the floor rather than
+// rejecting it: modules/livestore/live_store.go's SearchTags forwards
 // nothing but req.Scope into instance.SearchTagsV2, so the empty query
 // yields no condition groups and every block answers with the unfiltered
 // b.SearchTags. The same call also zeroes Start/End, and includeBlock
@@ -34,17 +44,22 @@ import (
 // malformed — its `q` was. Matching that is why V1 here neither parses nor
 // validates the parameter.
 //
-// The narrowing is a predicate over the SPAN ROW, which is what makes it
-// composable with the per-scope key projections: each scope bucket already
+// The narrowing is a predicate over the SPAN ROW, which is what makes one
+// filter serve every discovery lookup. Each tag-name scope bucket already
 // runs `SELECT DISTINCT <keys-of-column> FROM <spans> WHERE <window>`, and
-// `q` contributes one more conjunct to that WHERE. Nothing else about the
-// lookup changes, so a request without `q` renders byte-identical SQL.
+// each tag-value lookup runs the same shape over one key's values, so `q`
+// contributes one more conjunct to that WHERE in both cases. On the
+// dynamic-attribute value lookup — whose outer SELECT sees only the
+// exploded value column — the conjunct joins the INNER query, the one
+// that still has the span row in scope. Nothing else about any lookup
+// changes, so a request without `q` renders byte-identical SQL.
 
-// TagsRoute names which of the two tag-name routes a lookup answers.
-// The routes differ in exactly one respect — whether `q` is part of
-// their contract — and TagsRoute.narrowingQuery is the single place that
-// difference is expressed, so the HTTP and gRPC surfaces cannot drift on
-// it. Exported because the gRPC tag services select the route too.
+// TagsRoute names which of the four tag-discovery routes a lookup
+// answers. The routes differ in exactly one respect — whether `q` is
+// part of their contract — and TagsRoute.narrowingQuery is the single
+// place that difference is expressed, so the HTTP and gRPC surfaces
+// cannot drift on it, and neither can the name and value halves.
+// Exported because the gRPC tag services select the route too.
 type TagsRoute uint8
 
 const (
@@ -54,14 +69,39 @@ const (
 	// TagsRouteV2 is `/api/v2/search/tags` and its gRPC twin
 	// SearchTagsV2, the route that documents and honours `q`.
 	TagsRouteV2
+	// TagValuesRouteV1 is `/api/search/tag/{name}/values` and its gRPC
+	// twin SearchTagValues. Like TagsRouteV1 it carries no narrowing
+	// query.
+	TagValuesRouteV1
+	// TagValuesRouteV2 is `/api/v2/search/tag/{name}/values` and its
+	// gRPC twin SearchTagValuesV2 — the value-side route that documents
+	// and honours `q`.
+	TagValuesRouteV2
 )
 
-// narrowingQuery returns the TraceQL query this route filters its key
-// lookups by, given whatever the client sent. On V2 that is the client's
-// query verbatim; on V1 it is always empty, because `q` is not part of
-// the V1 contract and upstream ignores it there.
+// narrowingQuery returns the TraceQL query this route filters its
+// lookups by, given whatever the client sent. On the two V2 routes that
+// is the client's query verbatim; on the two V1 routes it is always
+// empty, because `q` is not part of the V1 contract and upstream ignores
+// it there.
+//
+// The value side is asymmetric for the same reason the name side is, and
+// upstream's own code is where that shows: `q` is parsed for both value
+// routes by one shared parser (pkg/api/search_tags.go's
+// parseSearchTagValuesRequest — its enforceTraceQL flag validates the
+// TAG NAME, not the query) and even re-emitted onto the sub-requests, so
+// it physically reaches the queriers on V1. It then dies at every leaf.
+// The V1 executors take a bare tag name and have nowhere to put a
+// filter — modules/livestore/instance_search.go's SearchTagValues calls
+// block.SearchTagValues(ctx, tagName, …), and the backend-block leg in
+// modules/querier/querier.go reaches tempodb's block.SearchTagValues the
+// same way — while only the V2 executors run
+// traceql.ExtractConditionGroups(req.Query, …) and take the filtered
+// ExecuteTagValues path. Upstream's API reference documents `q` under
+// "Search tag values V2" only, and matching that is why V1 here never
+// reaches the parser.
 func (rt TagsRoute) narrowingQuery(raw string) string {
-	if rt == TagsRouteV2 {
+	if rt == TagsRouteV2 || rt == TagValuesRouteV2 {
 		return raw
 	}
 	return ""
@@ -71,15 +111,18 @@ func (rt TagsRoute) narrowingQuery(raw string) string {
 // but does not reduce to a predicate over a single span row". Structural
 // (`{...} >> {...}`), multi-spanset and metrics-pipeline queries lower to
 // plan shapes whose matching spans are defined by a join or an aggregate,
-// not by a row predicate, so there is no conjunct to push into the key
-// lookups. Answering the unfiltered key set for those would be a silently
-// wrong answer — wider than the query asked for — so they are rejected.
-var errTagQueryShape = errors.New("traceql: tag-name filtering needs a query that selects spans by a row predicate")
+// not by a row predicate, so there is no conjunct to push into the key or
+// value lookups. Answering the unfiltered set for those would be a
+// silently wrong answer — wider than the query asked for — so they are
+// rejected.
+var errTagQueryShape = errors.New("traceql: tag discovery filtering needs a query that selects spans by a row predicate")
 
 // tagQueryFilter turns the raw `q` query parameter into the extra WHERE
-// conjunct the per-scope key lookups run under. An empty `q` — and any `q`
-// at all on the V1 route, which does not take one — yields a nil Frag, and
-// a nil Frag adds no clause, so those requests are unchanged down to the
+// conjunct a discovery lookup runs under — the per-scope key lookups on
+// the name routes, the per-key value lookups on the value routes. An
+// empty `q` — and any `q` at all on a V1 route, which does not take
+// one — yields a nil Frag, and a nil Frag adds no clause, so those
+// requests are unchanged down to the
 // rendered SQL. Routing the parameter through TagsRoute here rather than at
 // the call sites is what keeps a V1 caller from ever reaching the parser:
 // upstream answers a malformed V1 `q` with a 200 and the unfiltered key


### PR DESCRIPTION
## What

`GET /api/search/tag/{name}/values`, `GET /api/v2/search/tag/{name}/values` and their gRPC twins
(`SearchTagValues` / `SearchTagValuesV2`) dropped the `q` TraceQL filter on the floor. #1929 taught
the tag-NAME routes to narrow their answer to the spans a row-predicate selects; the sibling value
routes were not in that change's scope.

That is the endpoint backing Grafana's value-completion dropdown, which makes it the case where the
unfiltered answer is both the largest set and the least relevant one: every value the key takes
anywhere in the window, rather than the values it takes on the spans the user's half-typed query
already selects.

## How

The narrowing **reuses `search_tags_filter.go` wholesale** rather than growing a second copy.
`TagsRoute` gains `TagValuesRouteV1` / `TagValuesRouteV2`, so the one "does this route honour `q`"
decision still lives in a single `narrowingQuery` switch and the name and value halves cannot drift.

The filter threads through `respondTagValues` and `FetchTagValues` into **both** values-SQL shapes:

- the intrinsic column's flat `DISTINCT` projection takes it as a trailing conjunct;
- the dynamic-attribute `arrayJoin` subquery takes it on the **INNER** query — the one that still has
  the span row in scope, since the outer `SELECT` sees only the exploded value column `v`.

The values RPCs also stop collapsing every failure onto `codes.Internal`. With a query in the
pipeline the caller can now be at fault, so they route through the shared `grpcStatusFor`
classification: `InvalidArgument` for a bad `q`, `Internal` still for a CH failure.

## V1 keeps ignoring `q`, and that is upstream-faithful

Traced in the vendored Tempo rather than assumed. Upstream parses `q` for **both** value routes
through one shared parser (`pkg/api/search_tags.go:341` — its `enforceTraceQL` flag validates the
tag NAME, not the query) and even re-emits it onto the sub-requests, so it physically reaches the
queriers on V1. It then dies at every leaf: each V1 executor takes a bare tag name with no slot for
a filter (`modules/livestore/instance_search.go:419` calls `block.SearchTagValues(ctx, tagName, …)`;
the backend-block leg reaches tempodb the same way via `modules/querier/querier.go:757`), while only
the V2 executors run `traceql.ExtractConditionGroups(req.Query, …)` and take the filtered
`ExecuteTagValues` path (`instance_search.go:511`, `querier.go:827`).

## Compat corpus

The loader used to **reject** `expected_absent_values` on the value endpoints outright, which is why
nothing could have caught this gap: the one assertion able to tell a honoured `q` from an ignored one
was a parse error there. Its rules are now stated over the endpoint's `q` *contract* rather than over
endpoint names, so both pairs inherit them, and four new cases ride it — one per values-SQL shape on
V2 (resource map, span map, intrinsic column) plus the V1 case asserting the wide answer.

## Verification

Both directions of the new behaviour were mutation-checked, not just observed green:

- forcing `filter = nil` in `respondTagValues` fails `TestSearchTagValuesQuery_NarrowsLookupSQL`,
  `…_NarrowsIntrinsicLookupSQL` and `…_NarrowsTheAnswer`;
- making `narrowingQuery` return the raw query for every route fails
  `TestSearchTagValuesV1Query_Ignored` (and `TestSearchTagsV1Query_Ignored`);
- making it return `""` for every route fails `TestSearchTagValuesV2_QueryNarrows` and
  `TestSearchTagValuesV2_MalformedQuery_GRPCStatus`.

The narrowing is asserted at three levels: the rendered SQL (conjunct present, inside the inner
query, window conjuncts intact, literal bound as a parameter and never spliced), the HTTP response
(strict subset), and the gRPC response. `…_AbsentRendersIdenticalSQL` pins the other half of the
contract — a request with no `q`, and one with an empty `q`, render byte-identical SQL on both
routes and both SQL shapes.

`./internal/api/tempo/...` and `./compatibility/tempo/driver/` pass. `just migration-golden`
regenerates identically (the shard is implied only because `./cmd/cerberus/` closes over
`internal/api/tempo`), so no golden moved. `forbid-sql-raw` and `forbid-skip` are clean.

The compat/tempo lane needs a real ClickHouse + real Tempo and is settled in CI.

Closes #1932
