### PR TITLE
fix(ci): bound and shard the chDB round-trip legs so promql stops racing go test's default

### DIFF
--- a/.github/scripts/README.md
+++ b/.github/scripts/README.md
@@ -1332,6 +1332,37 @@ the pinned numbers cannot drift away from what the crawl actually asks for.
   - Exit: `0` when every shard passed or the lane was correctly
     short-circuited, `1` otherwise.
 
+- **`chdb-roundtrip.mjs`** — `chdb.yml`, the `roundtrip (<ql>)` matrix job. Runs
+  one head's chDB-executing TXTAR walk: `./test/spec/<ql>/` (pre-optimizer) and
+  `./internal/<ql>/` (post-optimizer plus the reference-engine parity). It
+  replaces a bare `go test` line for two reasons that line could not express.
+  First, an explicit per-process `-timeout`: without one every leg runs under
+  `go test`'s own DEFAULT 10-minute watchdog, which is applied per test BINARY
+  and is entirely independent of the job's `timeout-minutes`. The promql leg
+  had been finishing inside 550-600s of that 600s budget for weeks and then
+  crossed it, failing a PR on a walk that was still making forward progress —
+  the timeout panic named a subtest one second old, at fixture 475 of 582.
+  Second, a fan-out: the promql corpus is 582 fixtures against logql's 189 and
+  traceql's 222, so its leg takes ~700s where the other two heads' whole jobs
+  finish in under 180s, and that gap widens with every fixture merged. The walk
+  cannot be parallelised in-process (chdb-go caches ONE session per process and
+  the fixtures share it — #1987, #2096), so promql is split across three
+  processes over the SAME `SPEC_SHARD_INDEX` / `SPEC_SHARD_COUNT` partition
+  `just update-golden` already fans out on (`lib/golden-shards.mjs`,
+  `test/spec/shard.go`). Unlike `perf-guards`, the split is INSIDE the job, so
+  no context is renamed and branch protection is untouched. A build-only
+  `-run=^$` pass runs first, because Go's build cache dedupes stored output
+  rather than concurrent work and three legs would otherwise compile the same
+  two binaries at once on a cold runner. `chdb-roundtrip.test.mjs` is the
+  `node --test` guard (run on `ci.yml`'s scripts lane); its load-bearing
+  assertion reads `chdb.yml` and requires the per-process timeout to stay
+  strictly BELOW the job's `timeout-minutes`, because only `go test`'s own alarm
+  prints the goroutine dump that names a wedged libchdb frame — a runner kill
+  prints nothing.
+  - Env: `QL` (`promql` | `logql` | `traceql`), `TAGS` (the leg's build tags),
+    `GO` (test seam; default `go`).
+  - Exit: `0` when every leg passed, `1` on a failed leg or bad input.
+
 - **`migration-e2e.mjs`** — `ci.yml`'s `lint` job (`MODE=verify`) and
   `migration-e2e.yml` (all four modes). The Layer-14 migration lane's
   coverage ratchet, tier-matrix emitter, scenario runner and lane roll-up.

--- a/.github/scripts/chdb-roundtrip.mjs
+++ b/.github/scripts/chdb-roundtrip.mjs
@@ -1,0 +1,238 @@
+// chdb-roundtrip.mjs — runs one head's `roundtrip (<ql>)` leg of chdb.yml:
+// the chDB-executing TXTAR walk over `./test/spec/<ql>/` (pre-optimizer,
+// TestRoundTripChDB) and `./internal/<ql>/` (post-optimizer RunRoundTripSQL +
+// the reference-engine RunParity, TestLower).
+//
+// Why this is a script rather than the one-line `go test` it replaces
+// ---------------------------------------------------------------------------
+// Two facts about that `go test` were invisible in YAML and cost a red lane:
+//
+//   1. NO EXPLICIT `-timeout`. `go test` applies its own DEFAULT 10-minute
+//      watchdog PER TEST BINARY, entirely independently of the job's
+//      `timeout-minutes: 20`. The promql leg had been finishing in 550-600s of
+//      that 600s budget for weeks (job wall-clock 648-683s on main), so it was
+//      one slow runner away from failing — and then did, on run
+//      31710525983: `FAIL github.com/tsouza/cerberus/internal/promql 600.049s`,
+//      with the panic's own header naming a subtest that had been running for
+//      ONE SECOND. That is a walk still making forward progress when the
+//      alarm fired, not a hang: it had reached fixture 475 of 582 and needed
+//      roughly 735s. The lane was measuring the watchdog, not the code.
+//
+//   2. ONE PROCESS. The promql corpus is 582 fixtures against logql's 189 and
+//      traceql's 222, and the internal/<ql> walk is the expensive half of the
+//      two (it seeds chDB, executes the post-optimizer SQL, and answers the
+//      parity-enrolled fixtures with a real Prometheus TSDB engine). The leg's
+//      wall-clock therefore grows with every fixture merged, and raising a
+//      number would only move the next failure out by a few months.
+//
+// Both are fixed here rather than in YAML because the fix is a fan-out with a
+// failure-propagation contract, which is exactly the "non-trivial step logic"
+// invariant 15 keeps out of workflow files.
+//
+// The partition is the one that already exists: spec.ShardFromEnv
+// (test/spec/shard.go) reads SPEC_SHARD_INDEX / SPEC_SHARD_COUNT, and both
+// walks this leg runs honour it. `just update-golden promql` fans the
+// round-trip generator out over the same pair
+// (.github/scripts/lib/golden-shards.mjs), where it was MEASURED at 629s in
+// one process against 231s at four legs.
+//
+// Env:
+//   QL       head name — `promql` | `logql` | `traceql`. Required.
+//   TAGS     go build tags for the leg (`chdb`, or the AGPL-oracle triple for
+//            logql/traceql). Required.
+//   GO       go executable; default `go`. Test seam.
+//
+// Exit: 0 when every leg passed; 1 on a failed leg, a bad QL, or a missing env.
+//
+// node: builtins only — no npm deps, no setup-node needed.
+
+import process from 'node:process';
+import { spawn } from 'node:child_process';
+import { error, notice, log, group } from './lib/gh.mjs';
+
+/**
+ * How many PROCESSES each head's leg fans out to.
+ *
+ * A GitHub-hosted `ubuntu-latest` runner has 4 cores, and each leg runs its two
+ * packages with `-p 1` (below), so the fan-out count IS the number of test
+ * binaries competing for those cores — no hidden second multiplier.
+ *
+ * promql is the only head that needs one. Its leg takes ~700s where logql's and
+ * traceql's whole JOBS — checkout, toolchain, libchdb install and all — finish
+ * in 173-181s, so those two have an order of magnitude of headroom and a
+ * fan-out would buy them nothing but N-times-repeated compilation of the
+ * non-corpus tests in the same packages.
+ *
+ * Three rather than four for promql, because chDB threads WITHIN a single query
+ * as well: a leg already uses more than one core, so a fan-out matching the core
+ * count oversubscribes rather than spreads. That is the same effect measured on
+ * the update-golden fan-out, where 8 legs on an 8-core box (252s) came out
+ * WORSE than 4 (231s) — the useful margin is over the serial walk, not at the
+ * top of the range. Three legs leave a core for the runner's own work and still
+ * cut the walk to roughly a third.
+ */
+const FANOUT = {
+  promql: 3,
+  logql: 1,
+  traceql: 1,
+};
+
+/**
+ * The per-process `go test -timeout`, in minutes.
+ *
+ * It has one job the job-level `timeout-minutes` cannot do: when a walk really
+ * does wedge in a libchdb downcall, `go test`'s own alarm panics with the full
+ * goroutine dump that names the wedged frame — the artefact #2096 was diagnosed
+ * from. A runner-level kill produces no such dump, so this bound MUST stay
+ * strictly below chdb.yml's `timeout-minutes`, and
+ * chdb-roundtrip.test.mjs asserts that ordering against the workflow file.
+ *
+ * Twelve minutes is ~5x the ~250s a fanned-out promql leg should take and ~2x
+ * the ~700s an UNFANNED leg takes today, so it stays a hang detector rather
+ * than a throughput ceiling even if the fan-out is reduced to 1, while leaving
+ * the 20-minute job cap several minutes of room to publish the dump.
+ */
+export const GO_TEST_TIMEOUT_MINUTES = 12;
+
+/** The env pair spec.ShardFromEnv reads. Contract with test/spec/shard.go. */
+const SPEC_SHARD_INDEX_ENV = 'SPEC_SHARD_INDEX';
+const SPEC_SHARD_COUNT_ENV = 'SPEC_SHARD_COUNT';
+
+/** Heads this lane knows how to run. */
+export const HEADS = Object.keys(FANOUT);
+
+/**
+ * The commands one head's leg runs, fan-out expanded.
+ *
+ * A fan-out of 1 declares NO shard env at all rather than `1/1`: half a
+ * declared partition is an error on the Go side, and a whole-corpus leg should
+ * reach spec.WalkShard through the same unset-means-everything path a
+ * hand-typed `go test` does.
+ *
+ * `-p 1` runs the leg's two packages one after the other inside the leg instead
+ * of concurrently, so N legs mean exactly N test binaries. Without it `go test`
+ * would run both packages of every leg at once and the real concurrency would
+ * be 2N — double what the fan-out count says, and past the core count.
+ */
+export function legCommands({ ql, tags, go = 'go' }) {
+  const fanOut = FANOUT[ql];
+  const argv = [
+    go,
+    'test',
+    '-tags',
+    tags,
+    '-count=1',
+    '-p',
+    '1',
+    `-timeout=${GO_TEST_TIMEOUT_MINUTES}m`,
+    `./test/spec/${ql}/...`,
+    `./internal/${ql}/...`,
+  ];
+  if (fanOut <= 1) return [{ name: ql, argv, env: {} }];
+  return Array.from({ length: fanOut }, (_, i) => ({
+    name: `${ql} ${i + 1}/${fanOut}`,
+    argv,
+    env: {
+      [SPEC_SHARD_INDEX_ENV]: String(i + 1),
+      [SPEC_SHARD_COUNT_ENV]: String(fanOut),
+    },
+  }));
+}
+
+/**
+ * The build-only pass that runs BEFORE a fan-out, never as part of it.
+ *
+ * `-run=^$` matches no test, so this compiles and links both of the head's test
+ * binaries and executes nothing. Without it every leg of a fan-out starts by
+ * compiling the SAME two binaries at the same time: Go's build cache dedupes
+ * the stored output, not the concurrent work, so N legs on a cold runner cache
+ * do the whole ~75s compile N times over the same cores before any fixture
+ * runs. Paying it once, serially, hands every leg a warm cache.
+ *
+ * A fan-out of 1 needs none of this — its single leg IS the one compile.
+ */
+export function warmupCommand({ ql, tags, go = 'go' }) {
+  if (FANOUT[ql] <= 1) return null;
+  return {
+    name: `${ql} build`,
+    argv: [go, 'test', '-tags', tags, '-count=1', '-p', '1', '-run=^$', `./test/spec/${ql}/...`, `./internal/${ql}/...`],
+    env: {},
+  };
+}
+
+/**
+ * Runs one leg to completion, buffering its output.
+ *
+ * Buffered rather than inherited because concurrent legs interleave line by
+ * line otherwise, and a `go test` failure is a multi-line block (the fixture
+ * name, the got/want diff, or a goroutine dump) that is unreadable once two
+ * legs shuffle into each other. Every leg's buffer is printed whole, in leg
+ * order, after the run — including the `-timeout` panic dump, which arrives in
+ * the buffer because the bound above always fires before the job cap.
+ */
+function runLeg(leg) {
+  return new Promise((resolve) => {
+    const [cmd, ...args] = leg.argv;
+    const child = spawn(cmd, args, {
+      env: { ...process.env, ...leg.env },
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+    let out = '';
+    child.stdout.on('data', (d) => {
+      out += d;
+    });
+    child.stderr.on('data', (d) => {
+      out += d;
+    });
+    child.on('error', (err) => resolve({ leg, code: 1, out: `${out}\nspawn ${cmd}: ${err.message}` }));
+    child.on('close', (code) => resolve({ leg, code: code ?? 1, out }));
+  });
+}
+
+async function main() {
+  const ql = process.env.QL ?? '';
+  const tags = process.env.TAGS ?? '';
+  if (!HEADS.includes(ql)) {
+    error(`QL must be one of ${HEADS.join(', ')} (got ${JSON.stringify(ql)})`);
+    process.exit(1);
+  }
+  if (tags === '') {
+    error('TAGS is required — the leg would compile without the chdb driver and walk nothing');
+    process.exit(1);
+  }
+
+  const go = process.env.GO ?? 'go';
+  const legs = legCommands({ ql, tags, go });
+  notice(`roundtrip ${ql}: ${legs.length} leg(s), ${GO_TEST_TIMEOUT_MINUTES}m per-process timeout`);
+
+  const started = Date.now();
+
+  const warmup = warmupCommand({ ql, tags, go });
+  if (warmup) {
+    const built = await runLeg(warmup);
+    if (built.code !== 0) {
+      group(`${warmup.name} (exit ${built.code})`, () => log(built.out.trimEnd()));
+      error(`roundtrip ${ql}: the leg binaries did not build`);
+      process.exit(1);
+    }
+  }
+
+  const results = await Promise.all(legs.map(runLeg));
+  const elapsedSeconds = Math.round((Date.now() - started) / 1000);
+
+  for (const r of results) {
+    group(`${r.leg.name} (exit ${r.code})`, () => log(r.out.trimEnd()));
+  }
+
+  const failed = results.filter((r) => r.code !== 0);
+  if (failed.length > 0) {
+    error(`roundtrip ${ql}: ${failed.length} of ${results.length} leg(s) failed after ${elapsedSeconds}s`);
+    process.exit(1);
+  }
+  notice(`roundtrip ${ql}: ${results.length} leg(s) passed in ${elapsedSeconds}s`);
+}
+
+// Import-safe: the tests import legCommands without running a leg.
+if (process.argv[1] && process.argv[1].endsWith('chdb-roundtrip.mjs')) {
+  await main();
+}

--- a/.github/scripts/chdb-roundtrip.test.mjs
+++ b/.github/scripts/chdb-roundtrip.test.mjs
@@ -1,0 +1,126 @@
+// chdb-roundtrip.test.mjs — node:test guard for the `roundtrip (<ql>)` leg
+// runner's two load-bearing properties: the per-process `go test -timeout`
+// exists and stays diagnosable, and the fan-out is a real partition.
+//
+// Runs on the cheap `check` lane (`node --test`), so a regression here fails in
+// milliseconds rather than 20 minutes into a chDB job.
+//
+// The timeout ordering assertion reads chdb.yml itself rather than restating
+// its number, because the property being pinned is a RELATION between two files:
+// `go test`'s own alarm has to fire BEFORE the runner kills the job, or the
+// goroutine dump that names the wedged frame is never printed. That dump is the
+// whole reason #2096 was diagnosable at all.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { legCommands, warmupCommand, GO_TEST_TIMEOUT_MINUTES, HEADS } from './chdb-roundtrip.mjs';
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const workflow = readFileSync(path.join(here, '..', 'workflows', 'chdb.yml'), 'utf8');
+
+/** The `timeout-minutes:` of the roundtrip job, read out of chdb.yml. */
+function roundtripJobTimeoutMinutes() {
+  const job = workflow.slice(workflow.indexOf('\n  roundtrip:'));
+  const m = /^\s{4}timeout-minutes:\s*(\d+)/m.exec(job);
+  assert.ok(m, 'chdb.yml: the roundtrip job declares no timeout-minutes');
+  return Number(m[1]);
+}
+
+test('every leg declares an explicit go test -timeout (the #2096/#2094 regression)', () => {
+  for (const ql of HEADS) {
+    for (const leg of legCommands({ ql, tags: 'chdb' })) {
+      assert.ok(
+        leg.argv.some((a) => a.startsWith('-timeout=')),
+        `${leg.name}: no -timeout — the leg would run under go test's invisible 10m default`,
+      );
+    }
+  }
+});
+
+test('the per-process timeout stays strictly below the job cap, so the dump is printed', () => {
+  const jobCap = roundtripJobTimeoutMinutes();
+  assert.ok(
+    GO_TEST_TIMEOUT_MINUTES < jobCap,
+    `go test -timeout=${GO_TEST_TIMEOUT_MINUTES}m must be < the roundtrip job's ` +
+      `timeout-minutes: ${jobCap}; at or above it the runner kills the job first and the ` +
+      'goroutine dump that names the wedged frame is lost',
+  );
+});
+
+test('a fanned-out head partitions 1..N and declares both env variables', () => {
+  const legs = legCommands({ ql: 'promql', tags: 'chdb' });
+  assert.ok(legs.length > 1, 'promql is the head the fan-out exists for');
+  const indices = legs.map((l) => Number(l.env.SPEC_SHARD_INDEX));
+  assert.deepEqual(
+    indices,
+    legs.map((_, i) => i + 1),
+    'indices must be contiguous and 1-based: an index outside [1, N] names a slice ' +
+      'that does not exist, so that leg walks nothing and still exits 0',
+  );
+  for (const leg of legs) {
+    assert.equal(leg.env.SPEC_SHARD_COUNT, String(legs.length));
+  }
+});
+
+test('an unfanned head declares NO shard env rather than 1/1', () => {
+  for (const ql of HEADS.filter((h) => legCommands({ ql: h, tags: 'chdb' }).length === 1)) {
+    const [leg] = legCommands({ ql, tags: 'chdb' });
+    assert.deepEqual(
+      leg.env,
+      {},
+      `${ql}: a whole-corpus leg must reach spec.WalkShard through the unset-means-everything ` +
+        'path, not through a half-declared partition',
+    );
+  }
+});
+
+test('each leg runs both packages of its head, and only its own head', () => {
+  for (const ql of HEADS) {
+    for (const leg of legCommands({ ql, tags: 'chdb' })) {
+      assert.ok(leg.argv.includes(`./test/spec/${ql}/...`), `${leg.name}: missing the pre-optimizer walk`);
+      assert.ok(leg.argv.includes(`./internal/${ql}/...`), `${leg.name}: missing the post-optimizer walk`);
+      for (const other of HEADS.filter((h) => h !== ql)) {
+        assert.ok(
+          !leg.argv.some((a) => a.includes(`/${other}/`)),
+          `${leg.name}: walks ${other}, which its own matrix leg already covers`,
+        );
+      }
+    }
+  }
+});
+
+test('legs run one package at a time, so N legs mean N test binaries', () => {
+  const legs = legCommands({ ql: 'promql', tags: 'chdb' });
+  for (const leg of legs) {
+    const p = leg.argv.indexOf('-p');
+    assert.ok(p >= 0 && leg.argv[p + 1] === '1', `${leg.name}: without -p 1 the real concurrency is 2N`);
+  }
+});
+
+test('a fanned-out head warms the build cache, and the warm-up runs NO test', () => {
+  const warmup = warmupCommand({ ql: 'promql', tags: 'chdb' });
+  assert.ok(warmup, 'a fan-out without a warm-up compiles the same binaries once per leg');
+  assert.ok(
+    warmup.argv.includes('-run=^$'),
+    'the warm-up must match no test — it exists to compile, not to walk a slice of the corpus',
+  );
+  assert.deepEqual(warmup.env, {}, 'the warm-up owns no corpus slice');
+});
+
+test('an unfanned head has no warm-up: its single leg IS the compile', () => {
+  for (const ql of HEADS.filter((h) => legCommands({ ql: h, tags: 'chdb' }).length === 1)) {
+    assert.equal(warmupCommand({ ql, tags: 'chdb' }), null);
+  }
+});
+
+test('the build tags reach the go command verbatim', () => {
+  const tags = 'chdb,agpl_oracle,chdb_agpl_oracle';
+  for (const leg of legCommands({ ql: 'logql', tags })) {
+    const i = leg.argv.indexOf('-tags');
+    assert.ok(i >= 0 && leg.argv[i + 1] === tags, `${leg.name}: build tags dropped`);
+  }
+});

--- a/.github/workflows/chdb.yml
+++ b/.github/workflows/chdb.yml
@@ -303,9 +303,19 @@ jobs:
       # ./internal/<ql>/ additionally runs RunParity for every fixture
       # carrying a `parity:` section — the reference-engine comparison
       # that has no GOLDEN_UPDATE branch at all (test/spec/parity.go).
+      #
+      # The `go test` invocation lives in chdb-roundtrip.mjs, not here,
+      # because it needs two things a `run:` line cannot carry: an explicit
+      # per-process `-timeout` (without one every leg silently runs under
+      # go test's own 10-minute default, which the promql leg outgrew — see
+      # the script's header) and, for promql, a fan-out over the
+      # SPEC_SHARD_* partition with a failure-propagation contract.
       - name: Run TXTAR round-trip (${{ matrix.ql }})
         if: needs.changes.outputs.docs_only != 'true'
-        run: go test -tags ${{ matrix.tags }} -count=1 ./test/spec/${{ matrix.ql }}/... ./internal/${{ matrix.ql }}/...
+        env:
+          QL: ${{ matrix.ql }}
+          TAGS: ${{ matrix.tags }}
+        run: node .github/scripts/chdb-roundtrip.mjs
 
   # `perf-guards` runs the chDB-tagged deterministic perf-regression
   # ASSERTIONS under test/perf/ — the load-bearing fix for task #73.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -715,6 +715,17 @@ jobs:
       - name: Assert the perf-guards shard roll-up cannot report a hollow green
         run: node --test .github/scripts/perf-guards-aggregate.test.mjs
 
+      # The `roundtrip (<ql>)` leg runner. Two of its properties are invisible
+      # in the chDB lane itself until they fail 10-20 minutes in: that every leg
+      # declares an explicit `go test -timeout` (without one the leg runs under
+      # go test's own 10-minute default, which the promql corpus outgrew — the
+      # #2094 red lane), and that the bound stays strictly BELOW the job's
+      # `timeout-minutes`, so a genuine wedge is reported by go test's goroutine
+      # dump rather than by a runner kill that prints nothing. Pure in-process
+      # test over the module plus a read of chdb.yml, ~250ms.
+      - name: Assert the chDB round-trip legs are bounded and diagnosable
+        run: node --test .github/scripts/chdb-roundtrip.test.mjs
+
       # The subprocess helper every script above runs its commands through.
       # capture() names the spawnSync options it forwards rather than spreading
       # `opts`, so an unsupported key used to vanish without a word — and a

--- a/internal/promql/lower_test.go
+++ b/internal/promql/lower_test.go
@@ -60,7 +60,29 @@ func TestLower(t *testing.T) {
 	rangeStart := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
 	rangeEnd := rangeStart.Add(5 * time.Minute)
 
-	spec.Walk(t, fixtureDir, func(t *testing.T, c *spec.Case) {
+	// The slice of the corpus this PROCESS owns. With SPEC_SHARD_INDEX /
+	// SPEC_SHARD_COUNT unset — a hand-typed `go test ./internal/promql/`, or
+	// `just update-golden promql`, whose TestLower generator declares no
+	// fan-out because it writes the `-- sql --` that the round-trip generator
+	// then executes — that slice is the whole corpus and this walks exactly
+	// what it always did.
+	//
+	// CI's `roundtrip (promql)` leg DOES set the pair, because under the
+	// `chdb` tag this walk additionally executes every fixture's post-optimizer
+	// SQL (RunRoundTripSQL) and answers the parity-enrolled ones with a real
+	// Prometheus engine (RunParity) — the single longest chDB-executing walk
+	// in the repo, and one that grows with every fixture added. Spreading it
+	// over several PROCESSES is the only parallelism it can take: the subtests
+	// share chdb-go's package-level session singleton, which spec.OpenChDB
+	// isolates fixtures against by switching DATABASE rather than by tearing
+	// down, so a t.Parallel() here would race two goroutines against those
+	// CREATE/USE/DROP DATABASE statements. See spec.WalkShard's doc comment.
+	shard, err := spec.ShardFromEnv()
+	if err != nil {
+		t.Fatalf("lowering corpus shard: %v", err)
+	}
+
+	spec.WalkShard(t, fixtureDir, shard, func(t *testing.T, c *spec.Case) {
 		// Fixtures prefixed `exemplars_` are owned by the chsql
 		// exemplars emitter harness under
 		// internal/chsql/query_exemplars_spec_test.go — they record

--- a/test/spec/promql/fixture_isolation_chdb_test.go
+++ b/test/spec/promql/fixture_isolation_chdb_test.go
@@ -4,14 +4,17 @@
 package promql_spec_test
 
 import (
+	"os"
 	"os/exec"
 	"strings"
 	"testing"
+
+	"github.com/tsouza/cerberus/test/spec"
 )
 
 // isolationSample names a handful of round-trip fixtures whose only path
-// to a green result, before #1987's per-fixture chDB session reset
-// (test/spec/runner_chdb.go's resetChDBSession), was reading a SIBLING
+// to a green result, before #1987's per-fixture chDB isolation
+// (test/spec/runner_chdb.go's OpenChDB), was reading a SIBLING
 // fixture's leftover table in the process-shared chDB session:
 //
 //   - regex_name_matcher_underscored_matches_dotted and
@@ -56,11 +59,12 @@ var isolationSample = []string{
 // invariant 5 mandates reproducing a red check — rather than just calling
 // spec.RunRoundTrip in-process, because the whole point is to prove each
 // fixture is self-sufficient in a process where NO sibling fixture has
-// run first and left tables behind. Once the chDB session is genuinely
-// isolated per fixture (this repo's fix), running a fixture alone and
-// running it as part of the full TestRoundTripChDB walk mean the same
-// thing; a regression that reintroduces cross-fixture leakage (dropping
-// resetChDBSession, or a fixture's seed drifting out of
+// run first and left tables behind. Once each fixture is genuinely
+// isolated (this repo's fix: spec.OpenChDB gives every fixture its own
+// DATABASE on the shared session), running a fixture alone and running it
+// as part of the full TestRoundTripChDB walk mean the same thing; a
+// regression that reintroduces cross-fixture leakage (dropping that
+// per-fixture database, or a fixture's seed drifting out of
 // self-sufficiency) breaks exactly the isolated invocation this test
 // drives, even though the whole-package walk would stay green.
 func TestFixtureIsolation_SampleRunsAlone(t *testing.T) {
@@ -69,6 +73,7 @@ func TestFixtureIsolation_SampleRunsAlone(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			pattern := "^TestRoundTripChDB$/^" + name + "$"
 			cmd := exec.Command("go", "test", "-tags", "chdb", "-count=1", "-v", "-run", pattern, ".")
+			cmd.Env = withoutCorpusShard(os.Environ())
 			out, err := cmd.CombinedOutput()
 			if err != nil {
 				t.Fatalf(
@@ -88,5 +93,51 @@ func TestFixtureIsolation_SampleRunsAlone(t *testing.T) {
 				t.Fatalf("fixture %s: -run %q matched no subtest (typo'd name?), output:\n%s", name, pattern, out)
 			}
 		})
+	}
+}
+
+// withoutCorpusShard strips SPEC_SHARD_INDEX / SPEC_SHARD_COUNT from an
+// environment.
+//
+// The nested `go test` above names ONE fixture and needs the whole corpus
+// available to find it. Inherited unchanged, a parent that owns a corpus SLICE
+// — CI's fanned-out `roundtrip (promql)` leg
+// (.github/scripts/chdb-roundtrip.mjs) — hands the child its own partition,
+// spec.WalkShard filters the named fixture out for two legs in three, and the
+// child reports "matched no subtest" for a fixture that is not missing at all.
+// The partition belongs to the walk that declared it, not to a subprocess
+// asking a different question.
+func withoutCorpusShard(env []string) []string {
+	out := make([]string, 0, len(env))
+	for _, kv := range env {
+		if strings.HasPrefix(kv, spec.ShardIndexEnv+"=") || strings.HasPrefix(kv, spec.ShardCountEnv+"=") {
+			continue
+		}
+		out = append(out, kv)
+	}
+	return out
+}
+
+// TestWithoutCorpusShard pins the strip itself, because its failure mode is
+// the quiet one: with the pair still in the child's environment the nested
+// run reports a MISSING FIXTURE, which reads as a corpus problem rather than
+// as an inherited partition, and the real message is lost.
+func TestWithoutCorpusShard(t *testing.T) {
+	t.Parallel()
+
+	got := withoutCorpusShard([]string{
+		"PATH=/usr/bin",
+		spec.ShardIndexEnv + "=2",
+		"GODEBUG=asyncpreemptoff=1",
+		spec.ShardCountEnv + "=3",
+	})
+	want := []string{"PATH=/usr/bin", "GODEBUG=asyncpreemptoff=1"}
+	if len(got) != len(want) {
+		t.Fatalf("withoutCorpusShard() = %q, want %q", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("withoutCorpusShard() = %q, want %q", got, want)
+		}
 	}
 }

--- a/test/spec/promql/roundtrip_chdb_test.go
+++ b/test/spec/promql/roundtrip_chdb_test.go
@@ -23,16 +23,17 @@ import (
 // TestRoundTripChDB walks the slice of the PromQL corpus this process owns.
 //
 // With SPEC_SHARD_INDEX / SPEC_SHARD_COUNT unset — a hand-typed
-// `go test -tags chdb ./test/spec/promql/`, or CI's `roundtrip (promql)` job —
-// that slice is the whole corpus and this behaves exactly as it did before the
-// partition existed. `just update-golden promql` sets the pair and fans the
-// generator out across several processes instead
-// (.github/scripts/lib/golden-shards.mjs), because this walk is the single
-// longest step in that recipe and it cannot be parallelised in-process: the
-// subtests share chdb-go's package-level session singleton, which
-// spec.resetChDBSession deliberately tears down and rebuilds between fixtures
-// for cross-fixture isolation (#1987), so a t.Parallel() here would race two
-// goroutines against that teardown. A separate process has its own singleton.
+// `go test -tags chdb ./test/spec/promql/` — that slice is the whole corpus
+// and this behaves exactly as it did before the partition existed. Both
+// `just update-golden promql` (.github/scripts/lib/golden-shards.mjs) and CI's
+// `roundtrip (promql)` leg (.github/scripts/chdb-roundtrip.mjs) set the pair
+// and fan the walk out across several processes instead, because it is the
+// longest step of each and it cannot be parallelised in-process: the subtests
+// share chdb-go's package-level session singleton, which spec.OpenChDB
+// isolates fixtures against by switching DATABASE on that one session
+// (#1987, #2096), so a t.Parallel() here would race two goroutines against
+// those CREATE/USE/DROP DATABASE statements. A separate process has its own
+// singleton.
 func TestRoundTripChDB(t *testing.T) {
 	t.Parallel()
 

--- a/test/spec/runner_chdb.go
+++ b/test/spec/runner_chdb.go
@@ -286,10 +286,10 @@ func isolatedChDBDatabaseName(testName string) string {
 // Idempotency within one fixture: a single fixture's seed can run
 // through this more than once in the same session — RunRoundTrip
 // (pre-optimizer) and RunRoundTripSQL/RunParity (post-optimizer /
-// reference-engine) all reseed the same `seed:` text against whatever
-// session OpenChDB most recently produced, and [resetChDBSession] only
-// tears that session down at the END of the fixture's subtest, not
-// between these calls. The applier promotes bare `CREATE TABLE` to
+// reference-engine) all reseed the same `seed:` text into the isolated
+// DATABASE [OpenChDB] created for the fixture, which it caches for the
+// whole subtest and drops only at the END of it, not between these
+// calls. The applier promotes bare `CREATE TABLE` to
 // `CREATE OR REPLACE TABLE` so a second pass over the same seed within
 // one fixture doesn't trip TABLE_ALREADY_EXISTS. Fixture authors who
 // want strict CH semantics can opt out by writing


### PR DESCRIPTION
## What happened

`roundtrip (promql)` failed on #2094 with `FAIL github.com/tsouza/cerberus/internal/promql 600.049s`
([run 31710525983](https://github.com/tsouza/cerberus/actions/runs/31710525983/job/94482253705)).
That 600s is **`go test`'s own DEFAULT watchdog**, applied per test BINARY and entirely independent
of the job's `timeout-minutes: 20`. This workflow never overrode it.

## It was not a hang

Three pieces of evidence, all from the failing run itself:

1. The panic's own header names the in-flight subtest as **one second old**
   (`TestLower/subquery_last_over_time_rate_inner_no_name (1s)`) — forward progress at the moment
   the alarm fired.
2. That fixture is **#475 of 582** in sorted order, so the walk needed roughly **735s** of a 600s
   budget.
3. The same job logged `ok github.com/tsouza/cerberus/test/spec/promql 399.975s` — the sibling
   package passed, concurrently, on the same cores.

And it had been marginal for weeks, not just on #2094: `roundtrip (promql)` on `main` runs
**648-683s** of job wall-clock with a **423-704s** run-to-run spread. Every run was one slow runner
away from red.

## The fix

**An explicit per-process `-timeout`, and a fan-out.**

The promql corpus is 582 fixtures against logql's 189 and traceql's 222, and `./internal/<ql>/` is
the expensive half of the leg — it seeds chDB, executes the post-optimizer SQL, and answers the
parity-enrolled fixtures with a real Prometheus TSDB engine. Its leg takes ~700s where the other two
heads' whole jobs finish under 180s, and that gap widens with every fixture merged, so raising a
number alone would only move the next failure out by a few months.

The walk cannot be parallelised in-process (the fixtures share chdb-go's per-process session —
#1987, #2096), so promql is split across three processes over the **same** `SPEC_SHARD_INDEX` /
`SPEC_SHARD_COUNT` partition `just update-golden` already fans out on. The split is **inside** the
job, so no status-check context is renamed and branch protection is untouched.

### Measured

On a 4-core mask, which reproduces the runner's ratio closely (`test/spec/promql` 347s local against
400s in CI):

| | one process | three legs |
|---|---|---|
| `internal/promql` | 515s | 165-190s per leg |
| whole lane wall-clock | 515s+ | 344s |

Every process now sits at ~25% of its bound instead of ~100% of it.

## A real bug the fan-out surfaced

`TestFixtureIsolation_SampleRunsAlone` shells out to a nested `go test` naming ONE fixture, and that
child **inherited the parent's `SPEC_SHARD_*`**. Two legs in three then could not find the fixture
they named and reported "matched no subtest" — an inherited partition wearing a missing-fixture
costume. The child's environment now has the pair stripped, with a unit test pinning it, because the
failure mode is a misleading message rather than a crash.

## Guard

`chdb-roundtrip.test.mjs` runs on the cheap `check` lane. Its load-bearing assertion reads
`chdb.yml` and requires the per-process bound to stay strictly **below** the job's
`timeout-minutes`: only `go test`'s own alarm prints the goroutine dump that names a wedged libchdb
frame — the artefact #2096 was diagnosed from — and a runner kill prints nothing.

Also corrects three comments still describing `resetChDBSession`, which #2097 removed in favour of
per-fixture `DATABASE` isolation.

## Validation

Local: the three legs pass green end-to-end under the real script (344s, exit 0), and the nine
`node --test` assertions pass. This PR's own `roundtrip (promql)` check is the CI-side proof, since
the failure being fixed is specific to the runner's resource profile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)