### PR TITLE
fix(ci): log in to the GHCR mirror first and survive a Docker Hub outage

### DIFF
--- a/.github/scripts/README.md
+++ b/.github/scripts/README.md
@@ -20,7 +20,10 @@ Each module:
 `lib/gh.mjs` is the shared helper library: workflow-command emitters
 (`error` / `notice` / `warning` / `group`), `capture` / `exec` / `git`
 wrappers around `node:child_process`, a `lsFiles` `git ls-files -z`
-wrapper, plus `appendStepSummary` / `setOutput` for the runner files.
+wrapper, plus `appendStepSummary` / `setOutput` / `exportEnv` for the runner
+files. `setOutput` and `exportEnv` differ by consumer, not by mechanism: a step
+output has to be named by whoever reads it, while `$GITHUB_ENV` carries a
+decision that changes how the REST of the job behaves and has no single reader.
 
 `lib/shard-coverage.mjs` holds the Playwright spec-partition rules the two
 e2e shard-matrix modules share — `discoverSpecs()` (the tracked spec
@@ -69,6 +72,33 @@ Docker Hub failures was spending the anonymous per-IP quota (issue #1565).
 the mirrored copy and `docker tag`s it to the upstream name, so the caller asks
 for the upstream ref and the local daemon ends up holding something
 indistinguishable from an upstream pull. A miss is a fallback, not a failure.
+
+**Mirror-only mode** is the exception to that last sentence, and the one shape in
+which a mirror miss is fatal. A registry can also be UNREACHABLE, which is
+neither a refusal nor an answer: when `registry-login.mjs` exhausts its retries
+on a `transient` verdict against **Docker Hub**, it exports
+`CERBERUS_REGISTRY_MIRROR_ONLY=1` through `$GITHUB_ENV` and exits 0 instead of
+failing the job — a Docker Hub outage is precisely what the mirror was built to
+survive, and killing the job there fails a lane whose every image is sitting in a
+registry nothing has contacted (issue #1933). In that mode `pullImageWithRetry`
+**removes** the Docker Hub fallback rather than deprioritising it: a mirror miss
+is a hard error naming the image, and `buildBaseImageRef` returns `null` so a
+build is never started against a `FROM` that cannot resolve. The alternative —
+`continue-on-error: true` on the login — is a regression rather than a fix,
+because an unauthenticated job does not fail, it degrades to the shared anonymous
+Docker Hub quota and reads as flake on the day that quota runs out. Two jobs opt
+out with `ON_TRANSPORT_FAULT: fail`: `mirror-images.yml` READS the inventory from
+Docker Hub and `release.yml` PUSHES to it, and a mirror cannot stand in for
+either. The mode is never entered on a `rate-limit` or `credential` verdict, and
+never on a login to any registry but Docker Hub.
+
+Because every login is a hard gate, the ORDER of the two logins decides whether
+an outage is survivable, so the `ghcr.io` login runs FIRST in every job — the
+primary path authenticated ahead of the fallback. `assert-image-jobs-authenticate.mjs`'s
+R5 pins that, and `test/regression/mirror_only_downgrade_test.go` measures the
+property the whole mirror rests on: with Docker Hub unreachable, a job whose
+images are all mirrored runs to completion, and one whose image is not mirrored
+fails loudly rather than pulling anonymously.
 
 `lib/mirror.mjs` is that mirror's inventory and its upstream→mirror mapping —
 `mirrorRegistry`, `mirroredImages`, `mirroredRef(ref)`. It exists because
@@ -1616,6 +1646,11 @@ the pinned numbers cannot drift away from what the crawl actually asks for.
     that pulls images — is excluded because `node --test` imports a module and
     runs its tests rather than its CLI, which is a fact about the command and
     holds for every module.
+  - Presence is not order. R5 requires the `ghcr.io` login to run BEFORE the
+    Docker Hub one where a job has both: every login is a hard gate, so
+    authenticating the fallback ahead of the primary path is what let a Docker
+    Hub outage kill `compatibility/promql-surface` before the mirror holding
+    every image it needed was contacted (run 31148765992, issue #1933).
   - Env: `WORKFLOW_DIR` (optional; default `.github/workflows`), `REPO_ROOT`
     (optional; default the working directory).
   - Exit: `0` when every acquiring job is authenticated, `1` on a violation, on
@@ -1652,7 +1687,7 @@ the pinned numbers cannot drift away from what the crawl actually asks for.
     mirrored. "The copy command exited 0" and "a consumer can resolve this ref"
     are different claims, and the difference is invisible downstream: an
     unresolvable mirror is a miss, and a miss falls back to Docker Hub.
-- **`registry-login.mjs`** — `mirror-images.yml`, both login steps. `docker
+- **`registry-login.mjs`** — every login step in every workflow. `docker
   login` under the same retry policy every other registry interaction here has.
   It exists because `docker/login-action` has no retry input and the workflow
   died on its first real run (30724446834) with `context deadline exceeded` on
@@ -1665,16 +1700,33 @@ the pinned numbers cannot drift away from what the crawl actually asks for.
   immediately (wrong on attempt 1 is wrong on attempt 5), a transport fault
   retries, anything else is fatal rather than retried five times and read as
   flake.
+  - A spent TRANSPORT-fault budget on **Docker Hub** does not fail the job: it
+    exports `CERBERUS_REGISTRY_MIRROR_ONLY=1` through `$GITHUB_ENV` and exits 0,
+    downgrading the job to mirror-only (see the registry-policy section above).
+    That is a narrowing, not a tolerance — a quota refusal and a rejected
+    credential still fail on the first attempt, a login to any other registry
+    still fails outright, and every later acquisition either comes from the
+    mirror or fails loudly naming the image it wanted.
   - Env: `REGISTRY` (blank/unset means Docker Hub, matching `docker login`'s own
     default), `USERNAME` (required), `PASSWORD` (required; passed on stdin,
     never argv, so it cannot reach a process listing),
     `REGISTRY_LOGIN_BACKOFF_STEP_SECONDS` (optional; default `2` — attempt N
-    waits N × step).
-  - Exit: `0` on a successful login, `1` on any class that is not retried and on
-    a transport fault that outlived every attempt.
+    waits N × step), `ON_TRANSPORT_FAULT` (optional; `mirror-only` by default,
+    `fail` for the two jobs Docker Hub is not a fallback for — an unrecognised
+    value exits rather than silently taking the permissive branch), `GITHUB_ENV`
+    (runner-provided; the channel the mirror-only flag is exported through).
+  - Exit: `0` on a successful login and on a Docker Hub transport fault that
+    downgraded the job; `1` on any class that is not retried, on a transport
+    fault that outlived every attempt without downgrading, and on an
+    `ON_TRANSPORT_FAULT` value that is neither of the two.
   - Gated by `registry-login.test.mjs` on the required `check` lane, which pins
     the ORDER rather than the patterns: three of the four classes can match the
-    same output, and each wrong order fails silently in its own way.
+    same output, and each wrong order fails silently in its own way. It also
+    pins the downgrade by DENYING each of its three conditions in turn, because
+    the risk is a downgrade that happens where it must not. The end-to-end half
+    is `test/regression/mirror_only_downgrade_test.go`, which drives this script
+    and `pull-images.mjs` in sequence against a stub `docker` that answers every
+    Docker Hub call with the outage's own error text.
 
 - **`golden-update.mjs`** — no workflow. This one is invoked by
   `just update-golden <shard>...`, the local regeneration recipe, and it is

--- a/.github/scripts/README.md
+++ b/.github/scripts/README.md
@@ -81,15 +81,23 @@ on a `transient` verdict against **Docker Hub**, it exports
 failing the job — a Docker Hub outage is precisely what the mirror was built to
 survive, and killing the job there fails a lane whose every image is sitting in a
 registry nothing has contacted (issue #1933). In that mode `pullImageWithRetry`
-**removes** the Docker Hub fallback rather than deprioritising it: a mirror miss
-is a hard error naming the image, and `buildBaseImageRef` returns `null` so a
-build is never started against a `FROM` that cannot resolve. The alternative —
+**removes** the Docker Hub fallback rather than deprioritising it: a Docker Hub
+ref the mirror cannot serve is a hard error naming the image, and
+`buildBaseImageRef` returns `null` so a build is never started against a `FROM`
+that cannot resolve. The mode constrains **Docker Hub acquisitions only** — a
+ref on a registry Docker Hub does not meter (`ghcr.io/…/telemetrygen`, the
+released `ghcr.io/tsouza/cerberus` image, `gcr.io/distroless/*`) is reached over
+a path the outage cannot touch and is acquired exactly as always. Keying that
+refusal off `mirroredRef(...) === null` would conflate "the mirror has no copy
+of this" with "this never needed one" and take down the very e2e and migration
+lanes the mode exists to save. The alternative —
 `continue-on-error: true` on the login — is a regression rather than a fix,
 because an unauthenticated job does not fail, it degrades to the shared anonymous
 Docker Hub quota and reads as flake on the day that quota runs out. Two jobs opt
 out with `ON_TRANSPORT_FAULT: fail`: `mirror-images.yml` READS the inventory from
 Docker Hub and `release.yml` PUSHES to it, and a mirror cannot stand in for
-either. The mode is never entered on a `rate-limit` or `credential` verdict, and
+either — R6 pins that boundary in both directions, keyed on registry write
+permission rather than on a job name. The mode is never entered on a `rate-limit` or `credential` verdict, and
 never on a login to any registry but Docker Hub.
 
 Because every login is a hard gate, the ORDER of the two logins decides whether
@@ -1651,6 +1659,11 @@ the pinned numbers cannot drift away from what the crawl actually asks for.
     authenticating the fallback ahead of the primary path is what let a Docker
     Hub outage kill `compatibility/promql-surface` before the mirror holding
     every image it needed was contacted (run 31148765992, issue #1933).
+  - R6 requires `ON_TRANSPORT_FAULT: fail` on a Docker Hub login exactly when
+    the job holds registry **write** permission, and forbids it otherwise. The
+    permission is what separates a producer from a consumer: a job writing to a
+    registry cannot be served by a mirror, and one only reading from it must not
+    quietly opt itself back out of surviving an outage.
   - Env: `WORKFLOW_DIR` (optional; default `.github/workflows`), `REPO_ROOT`
     (optional; default the working directory).
   - Exit: `0` when every acquiring job is authenticated, `1` on a violation, on

--- a/.github/scripts/assert-image-jobs-authenticate.mjs
+++ b/.github/scripts/assert-image-jobs-authenticate.mjs
@@ -23,6 +23,14 @@
 //       PRIVATE GHCR mirror before Docker Hub) has a ghcr.io login. Without it
 //       the mirror is unreadable and every acquisition silently degrades to the
 //       anonymous Docker Hub quota the mirror exists to stop spending.
+//   R5  A job with both logins runs the ghcr.io one FIRST. Presence is not
+//       order, and the order is what decides whether an outage is survivable:
+//       every login is a hard gate, so authenticating the FALLBACK registry
+//       ahead of the PRIMARY one means a Docker Hub outage kills the job before
+//       the mirror it exists to fall back TO has been contacted at all. That is
+//       exactly how `compatibility/promql-surface` went red without running a
+//       single query (run 31148765992, issue #1933) while every image it needed
+//       sat in the mirror.
 //
 // THERE IS NO ALLOW-LIST, and that is the substance of the module rather than a
 // stylistic preference. The obvious way to write this gate is a regex for
@@ -1060,6 +1068,24 @@ export function violationsFor(jobId, findings) {
     );
   }
 
+  // R5 — the ghcr.io login runs BEFORE the Docker Hub one.
+  //
+  // Read off the position in `logins`, which the resolver fills in step order,
+  // so the rule is about the workflow's actual sequence rather than about a
+  // field a step could set wrongly. Both must be present for the question to
+  // mean anything: a job with one login has no order to get wrong, and R2 / R3
+  // above are what decide whether the missing one was required.
+  const mirrorAt = findings.logins.findIndex((l) => registryHost(l.registry) === mirrorHost);
+  const hubAt = findings.logins.findIndex((l) => dockerHubRegistries.has(registryHost(l.registry)));
+  if (mirrorAt !== -1 && hubAt !== -1 && hubAt < mirrorAt) {
+    out.push(
+      `${jobId}: logs in to Docker Hub before ${mirrorHost} — the FALLBACK registry is authenticated ahead ` +
+        'of the PRIMARY one. Every login is a hard gate, so in that order a Docker Hub outage fails the job ' +
+        'before the mirror it exists to fall back to has been contacted at all. Move the ' +
+        `${mirrorHost} login above the Docker Hub one.`,
+    );
+  }
+
   // R4 — the acquisitions must run ON the authenticated, mirror-first path, not
   // merely alongside a login step.
   //
@@ -1131,7 +1157,9 @@ function main() {
 
   log(`scanned ${results.length} jobs; ${acquiring.length} acquire at least one image`);
   for (const { id, findings } of acquiring) {
-    const logins = findings.logins.map((l) => l.registry || 'docker.io').sort().join(' + ') || 'NONE';
+    // In STEP order, not sorted: R5 is a rule about the sequence, so a log that
+    // sorted it would print the same line for a passing job and a failing one.
+    const logins = findings.logins.map((l) => l.registry || 'docker.io').join(' then ') || 'NONE';
     log(`  ${id} — ${[...new Set(findings.acquisitions)].join(', ')} | logins: ${logins}`);
   }
 

--- a/.github/scripts/assert-image-jobs-authenticate.mjs
+++ b/.github/scripts/assert-image-jobs-authenticate.mjs
@@ -31,6 +31,14 @@
 //       exactly how `compatibility/promql-surface` went red without running a
 //       single query (run 31148765992, issue #1933) while every image it needed
 //       sat in the mirror.
+//   R6  A Docker Hub login carries `ON_TRANSPORT_FAULT: fail` exactly when its
+//       job holds registry WRITE permission. The mirror-only downgrade lets a
+//       CONSUMER carry on without Docker Hub because the mirror can serve it;
+//       for a PRODUCER — the job mirroring Docker Hub's inventory, the job
+//       publishing a release beside it — no mirror can substitute, and carrying
+//       on turns a clean early failure into work half-done. Asked in both
+//       directions, because a producer that lost the opt-out and a consumer
+//       that gained one are both silent.
 //
 // THERE IS NO ALLOW-LIST, and that is the substance of the module rather than a
 // stylistic preference. The obvious way to write this gate is a regex for
@@ -90,6 +98,19 @@ const dockerHubRegistries = new Set(['', 'docker.io', 'index.docker.io', 'regist
 // lib/mirror.mjs's default `mirrorRegistry` rather than restated, so a mirror
 // that moves cannot leave the gate asserting a login to the old host.
 const mirrorHost = 'ghcr.io';
+
+// The env var `registry-login.mjs` reads its transport-fault policy from, and
+// the value that opts a login OUT of the mirror-only downgrade. Spelled to match
+// that module; R6 below is the rule that keeps the two workflows which need the
+// opt-out from losing it silently.
+const onTransportFaultVar = 'ON_TRANSPORT_FAULT';
+const onTransportFaultFail = 'fail';
+
+// The registry permission that marks a job as a PRODUCER rather than a
+// consumer. A job granted write access to a package registry is there to put
+// artefacts INTO one — mirroring Docker Hub's inventory, or publishing a release
+// beside it — and a mirror cannot stand in for a registry a job is writing to.
+const producerPackagesPermission = 'write';
 
 // The two names a step uses for "this checkout". Both are the repository root
 // on a runner, so binding them to it is what lets
@@ -226,14 +247,16 @@ function splitSteps(stepsBlock) {
   return steps;
 }
 
-// parseWorkflow — { env, jobs: [{ name, env, steps }] }.
+// parseWorkflow — { env, permissions, jobs: [{ name, env, permissions, steps }] }.
 export function parseWorkflow(text) {
   const lines = text.split('\n');
   const jobsIdx = findKey(lines, 'jobs', 0);
-  if (jobsIdx === -1) return { env: {}, jobs: [] };
+  if (jobsIdx === -1) return { env: {}, permissions: {}, jobs: [] };
 
   const topEnvIdx = findKey(lines, 'env', 0);
   const workflowEnv = topEnvIdx === -1 ? {} : mappingAt(lines.slice(topEnvIdx), 'env');
+  const topPermIdx = findKey(lines, 'permissions', 0);
+  const workflowPermissions = topPermIdx === -1 ? {} : mappingAt(lines.slice(topPermIdx), 'permissions');
 
   const jobsBlock = blockUnder(lines, jobsIdx);
   const jobIndent = minIndent(jobsBlock);
@@ -254,10 +277,19 @@ export function parseWorkflow(text) {
 
   return {
     env: workflowEnv,
+    permissions: workflowPermissions,
     jobs: jobs.map((job) => {
       const stepsIdx = findKey(job.lines, 'steps', minIndent(job.lines));
       const steps = stepsIdx === -1 ? [] : splitSteps(blockUnder(job.lines, stepsIdx));
-      return { name: job.name, env: mappingAt(job.lines, 'env'), steps };
+      return {
+        name: job.name,
+        env: mappingAt(job.lines, 'env'),
+        // A job's own `permissions:` REPLACES the workflow's rather than
+        // merging with it, which is GitHub's rule and the reason this is
+        // resolved per job rather than unioned.
+        permissions: mappingAt(job.lines, 'permissions'),
+        steps,
+      };
     }),
   };
 }
@@ -637,6 +669,9 @@ function newFindings() {
     composePolicyFiles: new Set(),
     composeMaterialised: [],
     mirrorWrites: 0,
+    // R6's bookkeeping: does this job hold registry WRITE permission, i.e. is
+    // it a producer rather than a consumer of images?
+    producesPackages: false,
   };
 }
 
@@ -757,7 +792,13 @@ class Resolver {
     const rest = argv.slice(1).filter((t) => t !== '');
     const sub = rest.find((t) => !t.startsWith('-'));
     if (sub === 'login') {
-      findings.logins.push({ registry: loginRegistry(rest.slice(rest.indexOf('login') + 1), scope) });
+      // The transport-fault policy is read off the SCOPE rather than the argv,
+      // because `registry-login.mjs` takes it from the environment — which is
+      // the step's own `env:` block, already folded into the scope by `step`.
+      findings.logins.push({
+        registry: loginRegistry(rest.slice(rest.indexOf('login') + 1), scope),
+        onTransportFault: (scope[onTransportFaultVar] ?? '').trim(),
+      });
       return;
     }
     if (sub === 'pull') {
@@ -1075,6 +1116,43 @@ export function violationsFor(jobId, findings) {
   // field a step could set wrongly. Both must be present for the question to
   // mean anything: a job with one login has no order to get wrong, and R2 / R3
   // above are what decide whether the missing one was required.
+  const hubLogins = findings.logins.filter((l) => dockerHubRegistries.has(registryHost(l.registry)));
+
+  // R6 — a Docker Hub login opts out of the mirror-only downgrade exactly when
+  // its job PRODUCES into a registry.
+  //
+  // The downgrade lets a job carry on without Docker Hub because the mirror can
+  // serve it. That reasoning holds for a consumer and inverts for a producer:
+  // `mirror-images.yml` READS the inventory from Docker Hub to populate the
+  // mirror, and `release.yml` PUSHES half of an atomic dual-registry release to
+  // it. Neither can be served by a mirror, and letting either continue turns a
+  // clean early failure into work half-done — a release whose GHCR half is
+  // published and whose Docker Hub half is not.
+  //
+  // Keyed on the registry WRITE permission rather than on a job name, so it is a
+  // fact about what the job is allowed to do. Asked in BOTH directions: a
+  // producer that lost the opt-out fails here, and so does a consumer that
+  // acquired one — the second is how a lane quietly opts itself back out of the
+  // very resilience this change exists to give it.
+  for (const login of hubLogins) {
+    const optedOut = login.onTransportFault === onTransportFaultFail;
+    if (findings.producesPackages && !optedOut) {
+      out.push(
+        `${jobId}: writes to a package registry but its Docker Hub login omits ` +
+          `\`${onTransportFaultVar}: ${onTransportFaultFail}\` — a producer cannot be served by the mirror, ` +
+          'so downgrading it would let the job continue past a registry it must have and finish its work ' +
+          'half-done',
+      );
+    }
+    if (!findings.producesPackages && optedOut) {
+      out.push(
+        `${jobId}: only consumes images, yet its Docker Hub login sets ` +
+          `\`${onTransportFaultVar}: ${onTransportFaultFail}\` — that opts the job out of mirror-only mode, ` +
+          'so a Docker Hub outage kills it again even though the mirror holds every image it needs',
+      );
+    }
+  }
+
   const mirrorAt = findings.logins.findIndex((l) => registryHost(l.registry) === mirrorHost);
   const hubAt = findings.logins.findIndex((l) => dockerHubRegistries.has(registryHost(l.registry)));
   if (mirrorAt !== -1 && hubAt !== -1 && hubAt < mirrorAt) {
@@ -1131,10 +1209,14 @@ export function scan({ root = process.cwd(), workflowDir = '.github/workflows' }
   const results = [];
   for (const file of readdirSync(dir).sort()) {
     if (!/\.ya?ml$/.test(file)) continue;
-    const { env, jobs } = parseWorkflow(readFileSync(join(dir, file), 'utf8'));
+    const { env, permissions, jobs } = parseWorkflow(readFileSync(join(dir, file), 'utf8'));
     for (const job of jobs) {
       const findings = newFindings();
       const scope = { ...repoRootVars, ...env, ...job.env };
+      // A job's own `permissions:` block replaces the workflow's; only when it
+      // declares none does the workflow-level grant apply.
+      const effective = Object.keys(job.permissions).length > 0 ? job.permissions : permissions;
+      findings.producesPackages = (effective.packages ?? '').trim() === producerPackagesPermission;
       for (const step of job.steps) resolver.step(step, scope, findings);
       results.push({ id: `${file}:${job.name}`, findings });
     }

--- a/.github/scripts/assert-image-jobs-authenticate.test.mjs
+++ b/.github/scripts/assert-image-jobs-authenticate.test.mjs
@@ -101,6 +101,19 @@ function withoutStep(title) {
   };
 }
 
+// A job that pulls through the shared policy, so R3 is the rule under test and
+// the only variable is how its one login names a registry.
+const jobLoggingInTo = (registry) => ({
+  acquisitions: ['pullImageWithRetry'],
+  logins: [{ registry }],
+  viaSharedPolicy: true,
+  refs: new Set(),
+  unresolved: [],
+  composePolicyFiles: new Set(),
+  composeMaterialised: [],
+  mirrorWrites: 0,
+});
+
 // ---------------------------------------------------------------------------
 // The tree, as it stands.
 // ---------------------------------------------------------------------------
@@ -274,6 +287,42 @@ test('R5 fires when the Docker Hub login runs before the ghcr.io one', () => {
   );
 });
 
+// ---------------------------------------------------------------------------
+// R6 — the mirror-only downgrade is opted out of exactly where a mirror cannot
+// stand in for Docker Hub, and nowhere else.
+//
+// Both directions are negative controls because both are silent. A producer
+// that lost its opt-out carries on past a registry it must have and finishes
+// half its work — `release.yml` publishing its GHCR half and not its Docker Hub
+// half. A consumer that gained one is back to dying on an outage the mirror was
+// built to survive, which is issue #1933 reintroduced one line at a time.
+// ---------------------------------------------------------------------------
+
+test('R6 fires when a job that writes to a registry loses its opt-out', () => {
+  const results = scanWith('mirror-images.yml', (text) =>
+    text.replace(/^\s*ON_TRANSPORT_FAULT: fail\n/m, ''),
+  );
+  const id = 'mirror-images.yml:mirror';
+  const violations = violationsFor(id, findingsFor(id, results));
+  assert.ok(
+    violations.some((m) => m.includes('writes to a package registry but its Docker Hub login omits')),
+    `expected an R6 producer violation, got ${JSON.stringify(violations)}`,
+  );
+});
+
+test('R6 fires when a consuming job opts itself out of mirror-only mode', () => {
+  // The e2e specimen: adding the opt-out to its Docker Hub login is the exact
+  // one-line edit that would quietly undo this change for that lane.
+  const results = scanWith('e2e.yml', (text) =>
+    text.replace(/(\n(\s+)USERNAME: tsouza\n)/, `$1$2ON_TRANSPORT_FAULT: fail\n`),
+  );
+  const violations = results.flatMap((r) => violationsFor(r.id, r.findings));
+  assert.ok(
+    violations.some((m) => m.includes('only consumes images, yet its Docker Hub login sets')),
+    `expected an R6 consumer violation, got ${JSON.stringify(violations)}`,
+  );
+});
+
 test('R5 is silent when a job has only one login to order', () => {
   // A job with one login has no order to get wrong, and R2 / R3 are what decide
   // whether the absent one was required. A rule that fired here would report a
@@ -373,19 +422,6 @@ test('the job that writes the mirror is not required to read through it', () => 
 // match misses spellings `docker login` itself accepts. Each case below goes red
 // on the pre-fix comparison, which is the only reason they are worth having.
 // ---------------------------------------------------------------------------
-
-// A job that pulls through the shared policy, so R3 is the rule under test and
-// the only variable is how its one login names a registry.
-const jobLoggingInTo = (registry) => ({
-  acquisitions: ['pullImageWithRetry'],
-  logins: [{ registry }],
-  viaSharedPolicy: true,
-  refs: new Set(),
-  unresolved: [],
-  composePolicyFiles: new Set(),
-  composeMaterialised: [],
-  mirrorWrites: 0,
-});
 
 test('a login to a host that merely starts with ghcr.io is not a mirror login', () => {
   // `startsWith` accepted this; a hostname compare does not. Somebody else owns

--- a/.github/scripts/assert-image-jobs-authenticate.test.mjs
+++ b/.github/scripts/assert-image-jobs-authenticate.test.mjs
@@ -218,6 +218,70 @@ test('R3 fires when a job pulling through the mirror has no ghcr.io login', () =
   assert.match(violations[0], /no ghcr\.io login/);
 });
 
+// ---------------------------------------------------------------------------
+// R5 — presence is not order.
+//
+// `compatibility/promql-surface` went red on run 31148765992 without running a
+// single query: the Docker Hub login exhausted its retries on `context deadline
+// exceeded`, and because it sat AHEAD of the ghcr.io login the job died before
+// the mirror holding every image it needed was ever contacted. Both logins were
+// present the whole time, so R1–R3 passed on that job on that run — which is
+// what makes the order a separate rule rather than a stylistic one.
+// ---------------------------------------------------------------------------
+
+// swapLoginOrder — put the Docker Hub login back ahead of the mirror login, the
+// pre-#1933 shape, by moving the mirror step to just after the Hub step. Only
+// the pair in the specimen job is touched, so the rest of the file stays clean.
+function swapLoginOrder(text) {
+  const lines = text.split('\n');
+  const stepAt = (title, from) => {
+    const i = lines.findIndex((l, n) => n >= from && l.trim() === `- name: ${title}`);
+    assert.notEqual(i, -1, `no step titled "${title}" from line ${from}`);
+    const indent = lines[i].length - lines[i].trimStart().length;
+    let end = i + 1;
+    while (end < lines.length) {
+      const l = lines[end];
+      if (l.trim().startsWith('- ') && l.length - l.trimStart().length === indent) break;
+      end++;
+    }
+    while (end - 1 > i && lines[end - 1].trim() === '') end--;
+    return [i, end];
+  };
+  // The specimen's own pair: find the mirror login that precedes its Hub login.
+  const bench = lines.findIndex((l) => l.trim() === 'startup-bench:');
+  assert.notEqual(bench, -1, 'startup-bench did not appear in e2e.yml');
+  const [mTop, mEnd] = stepAt('Log in to the image mirror (GHCR)', bench);
+  const [hTop, hEnd] = stepAt('Log in to Docker Hub', mEnd);
+  const mirror = lines.slice(mTop, mEnd);
+  const hub = lines.slice(hTop, hEnd);
+  return [...lines.slice(0, mTop), ...hub, ...lines.slice(mEnd, hTop), ...mirror, ...lines.slice(hEnd)].join('\n');
+}
+
+test('R5 fires when the Docker Hub login runs before the ghcr.io one', () => {
+  const results = scanWith('e2e.yml', swapLoginOrder);
+  const findings = findingsFor(specimenJob, results);
+  const violations = violationsFor(specimenJob, findings);
+  assert.ok(
+    violations.some((m) => m.includes('logs in to Docker Hub before ghcr.io')),
+    `expected an R5 ordering violation, got ${JSON.stringify(violations)}`,
+  );
+  // And for the ORDER alone: both logins are still there, so no presence rule
+  // may fire. Without this the test would pass on a doctoring that deleted one.
+  assert.equal(findings.logins.length, 2, 'the doctored job must still have both logins');
+  assert.ok(
+    !violations.some((m) => m.includes('no Docker Hub login') || m.includes('no ghcr.io login')),
+    `only the ordering rule should fire, got ${JSON.stringify(violations)}`,
+  );
+});
+
+test('R5 is silent when a job has only one login to order', () => {
+  // A job with one login has no order to get wrong, and R2 / R3 are what decide
+  // whether the absent one was required. A rule that fired here would report a
+  // second violation for every job the presence rules already caught.
+  const oneLogin = { ...jobLoggingInTo('ghcr.io'), refs: new Set() };
+  assert.deepEqual(violationsFor('some:job', oneLogin), []);
+});
+
 test('removing the acquisition removes the requirement, not the other way round', () => {
   // The rules key off acquiring, so a job that stops pulling stops being
   // judged — otherwise every login step in the repo would be load-bearing

--- a/.github/scripts/build-with-registry-retry.mjs
+++ b/.github/scripts/build-with-registry-retry.mjs
@@ -153,9 +153,17 @@ if (command.length === 0) {
 // `build.args` of each service, and the Justfile's direct builds pass
 // `--build-arg GO_IMAGE` with no value, which is docker's own "take it from the
 // environment" form. Neither needs this module to know which build sites exist.
+//
+// A null answer means mirror-only mode and a base image the mirror cannot
+// serve, i.e. there is no ref this build could resolve at all. The command is
+// not started: `buildBaseImageRef` has already said which image and why, and
+// running the build anyway would bury that under a BuildKit timeout against the
+// registry the job has already established it cannot reach.
 for (const [argName, upstreamRef] of Object.entries(buildBaseImageArgs)) {
   if ((process.env[argName] ?? '') !== '') continue;
-  process.env[argName] = buildBaseImageRef(upstreamRef);
+  const ref = buildBaseImageRef(upstreamRef);
+  if (ref === null) process.exit(1);
+  process.env[argName] = ref;
 }
 
 const backoffStepSeconds = readBackoffStepSeconds('IMAGE_BUILD_RETRY_BACKOFF_SECONDS', defaultBackoffStepSeconds);

--- a/.github/scripts/lib/gh.mjs
+++ b/.github/scripts/lib/gh.mjs
@@ -14,6 +14,7 @@
 //     honouring include globs + `:!:`-style pathspec excludes.
 //   - appendStepSummary(): append markdown to $GITHUB_STEP_SUMMARY.
 //   - setOutput(): append `name=value` to $GITHUB_OUTPUT.
+//   - exportEnv(): append `NAME=value` to $GITHUB_ENV.
 
 import { spawnSync } from 'node:child_process';
 import { appendFileSync } from 'node:fs';
@@ -203,4 +204,26 @@ export function setOutput(name, value) {
     return;
   }
   appendFileSync(file, `${line}\n`);
+}
+
+// exportEnv() — append `NAME=value` pairs to $GITHUB_ENV, the runner's channel
+// for state that must reach EVERY later step of the same job.
+//
+// The distinction from setOutput() is the consumer, not the mechanism: a step
+// output has to be named by whoever reads it (`steps.<id>.outputs.<name>`), so
+// it fits a value one later step consumes deliberately. A decision that changes
+// how the REST of the job behaves — a resolved plan, a degraded registry mode —
+// has no such single reader, and threading it through every step's `env:` is
+// the per-leg shape that goes stale the moment a step is added.
+//
+// Logged rather than written when the variable is absent, so a local run says
+// what it would have exported instead of silently doing nothing.
+export function exportEnv(entries) {
+  const block = entries.map(([name, value]) => `${name}=${value}`).join('\n');
+  const file = process.env.GITHUB_ENV;
+  if (!file) {
+    log(`[no $GITHUB_ENV in env; the following would have been exported]\n${block}`);
+    return;
+  }
+  appendFileSync(file, `${block}\n`);
 }

--- a/.github/scripts/lib/mirror.mjs
+++ b/.github/scripts/lib/mirror.mjs
@@ -50,6 +50,7 @@
 //   mirrorRegistry         the GHCR namespace mirrored copies live under.
 //   mirroredImages         every upstream ref cerberus's CI pulls.
 //   mirroredRef(ref)       the mirrored ref for an inventoried image, else null.
+//   isDockerHubRef(ref)    is this ref metered by Docker Hub at all?
 
 import process from 'node:process';
 
@@ -152,7 +153,13 @@ const inventory = new Set(mirroredImages);
 // a port (`localhost:5000`). This is the same rule the docker CLI applies, and
 // it is why `minio/mc` resolves to Docker Hub while `gcr.io/distroless/static`
 // does not.
-function isDockerHubRef(ref) {
+//
+// Exported because "is this ref metered by Docker Hub" is a question with two
+// callers and one right answer. `mirroredRef` asks it to decide whether a copy
+// could exist; `pullImageWithRetry` asks it to decide whether a Docker Hub
+// outage is even relevant to an acquisition. Answering it twice is how those
+// two drift.
+export function isDockerHubRef(ref) {
   const slash = ref.indexOf('/');
   if (slash === -1) return true; // a bare name is a Docker Hub `library/` image
   const first = ref.slice(0, slash);

--- a/.github/scripts/lib/registry.mjs
+++ b/.github/scripts/lib/registry.mjs
@@ -48,12 +48,38 @@
 //                                          runner can read it, else upstream.
 //                                          A `FROM` cannot be served from the
 //                                          daemon, so it needs the ref itself.
+//   mirrorOnlyEnvVar / mirrorOnlyEnvValue  the job-scoped flag saying Docker Hub
+//                                          is unreachable for this job.
+//   mirrorOnly(env)                        is this job in that mode?
 //
 // The best answer to a quota is not to draw on it. `pullImageWithRetry` reaches
 // for `lib/mirror.mjs`'s GHCR copy first and re-tags it to the upstream name,
 // so the retry policy below is what protects the FALLBACK rather than the
 // common case. See that module for why a mirror beats authenticating each pull
 // path in turn.
+//
+// MIRROR-ONLY MODE. There is a third thing a registry can do, distinct from
+// both refusing and answering: it can be UNREACHABLE. `registry-login.mjs`
+// exhausts its retries on a transport fault, and until #1933 that killed the
+// job — a Docker Hub outage taking down a lane whose every image sits in a GHCR
+// mirror that was never contacted. So a login that ends that way records
+// mirror-only mode for the rest of the job instead, and every acquisition below
+// reads it.
+//
+// What the mode changes is one thing only: the Docker Hub fallback is REMOVED,
+// not deprioritised. A mirror miss becomes a hard error naming the image. That
+// is the half worth stating twice, because the obvious cheap version of this
+// feature — letting the login be advisory — degrades a job to the shared
+// ANONYMOUS Docker Hub quota, which is the silent failure the login gate
+// (`assert-image-jobs-authenticate.mjs`, R2/R3) exists to make impossible. A
+// job that cannot be served by the mirror must fail loudly and say which image
+// it was.
+//
+// The mode is entered ONLY on a transport fault. A quota refusal
+// (`rate-limit`) or a rejected credential still fails on the first attempt: the
+// first is a counter that mirror-only mode cannot decrement and the second is a
+// secret that is simply wrong, and neither is a reason to run a job in a
+// degraded mode.
 
 import process from 'node:process';
 
@@ -130,6 +156,48 @@ export function rateLimitDiagnosis(subject) {
   );
 }
 
+// The environment variable carrying mirror-only mode from the login step that
+// decided it to every acquisition later in the same job, and the one value that
+// turns it on.
+//
+// $GITHUB_ENV is the channel because the decision has JOB scope: it is made
+// once, by one step, and every subsequent step has to honour it — including the
+// ones that reach an acquisition three hops down a Justfile recipe, which no
+// step-output plumbing would reach without an edit per lane. The name is
+// prefixed so it cannot collide with a variable a tool being tested reads.
+export const mirrorOnlyEnvVar = 'CERBERUS_REGISTRY_MIRROR_ONLY';
+export const mirrorOnlyEnvValue = '1';
+
+// mirrorOnly — is this process running under a job that lost Docker Hub?
+//
+// Read at call time rather than at module load, and against an environment the
+// caller may pass, so the mode is a property of the run rather than of the
+// import order. Any value other than the one above is off: a half-set variable
+// must not put a job into a degraded mode by accident.
+export function mirrorOnly(env = process.env) {
+  return String(env[mirrorOnlyEnvVar] ?? '').trim() === mirrorOnlyEnvValue;
+}
+
+// mirrorOnlyDiagnosis — the one explanation for "this job is mirror-only and
+// the mirror could not serve `subject`".
+//
+// It names the image because that is the only actionable fact: the fix is to
+// add that ref to `mirroredImages` in lib/mirror.mjs and let `mirror-images.yml`
+// copy it. It says what did NOT happen because the alternative — reaching for
+// Docker Hub anonymously — is the failure that would have been silent, and a
+// reader who does not know it was deliberately declined will go looking for the
+// pull that never happened.
+export function mirrorOnlyDiagnosis(image, consequence = '') {
+  const because = consequence === '' ? '' : ` — ${consequence}`;
+  return (
+    `${image} is not available from the GHCR mirror, and this job is running mirror-only because Docker Hub ` +
+    'was unreachable when it logged in. The upstream pull was NOT attempted: an anonymous Docker Hub pull is ' +
+    'the silent degradation the mirror and the login gate exist to remove, so this fails instead' +
+    `${because}. The fix is to add the image to \`mirroredImages\` in .github/scripts/lib/mirror.mjs so ` +
+    '`mirror-images.yml` copies it, and to check that this job logs in to ghcr.io before it acquires anything.'
+  );
+}
+
 // The failure signatures that mean "the registry / network said no", as
 // distinct from "the build said no" and from "the registry said not-so-fast".
 // Every entry is a fault in fetching bytes over the wire, never a compiler,
@@ -200,11 +268,17 @@ function acquireFromMirror(image) {
   const mirror = mirroredRef(image);
   if (mirror === null) return false;
 
+  // What a miss means depends on the mode, so the sentence is built from it
+  // rather than asserting a fallback that mirror-only mode has removed. A
+  // notice promising a Docker Hub pull that never happens is worse than no
+  // notice: it sends the next reader looking for a pull in the log.
+  const next = mirrorOnly() ? 'and this job is mirror-only, so the acquisition fails' : 'falling back to Docker Hub';
+
   log(`    docker pull ${mirror} (mirror of ${image})`);
   const pull = capture('docker', ['pull', mirror]);
   if (pull.status !== 0) {
     notice(
-      `${mirror} could not be pulled, falling back to ${image} on Docker Hub. The mirror is stale or the ` +
+      `${mirror} could not be pulled, ${next}. The mirror is stale or the ` +
         `package is not public; \`mirror-images.mjs\` is what fixes that.\n${pull.stderr.trim()}`,
     );
     return false;
@@ -212,9 +286,7 @@ function acquireFromMirror(image) {
 
   const tag = capture('docker', ['tag', mirror, image]);
   if (tag.status !== 0) {
-    notice(
-      `pulled ${mirror} but could not tag it as ${image}, falling back to Docker Hub.\n${tag.stderr.trim()}`,
-    );
+    notice(`pulled ${mirror} but could not tag it as ${image}, ${next}.\n${tag.stderr.trim()}`);
     return false;
   }
 
@@ -240,12 +312,33 @@ function acquireFromMirror(image) {
 // working — a fork's runner authenticates to ghcr.io as itself and cannot read
 // this repo's private packages, so it probes, misses, and builds from Docker
 // Hub exactly as it did before the mirror existed.
+//
+// Under mirror-only mode that reasoning inverts, because its premise is gone:
+// the upstream ref is NOT reachable. Returning it would hand BuildKit a `FROM`
+// against a registry this job has already established it cannot talk to, and
+// the failure would arrive minutes later as a build timeout naming neither the
+// mirror nor the outage. So the miss returns null — "there is no ref that can
+// serve this build" — and the caller reports it before spending the time.
 export function buildBaseImageRef(image) {
   const mirror = mirroredRef(image);
-  if (mirror === null) return image;
+  if (mirror === null) {
+    if (mirrorOnly()) {
+      error(mirrorOnlyDiagnosis(image, 'the build has no base image to resolve its `FROM` against'));
+      return null;
+    }
+    return image;
+  }
 
   const probe = capture('docker', ['buildx', 'imagetools', 'inspect', mirror]);
   if (probe.status !== 0) {
+    if (mirrorOnly()) {
+      error(
+        `${mirror} is not resolvable from this runner and this job is mirror-only because Docker Hub was ` +
+          `unreachable when it logged in, so there is no ref a build can resolve ${image} from. Check that ` +
+          `this job logs in to ghcr.io before it builds.\n${probe.stderr.trim()}`,
+      );
+      return null;
+    }
     notice(
       `${mirror} is not resolvable from this runner, so the build resolves ${image} from Docker Hub. ` +
         'That spends the anonymous quota this mirror exists to stop spending; `mirror-images.mjs` is ' +
@@ -274,6 +367,11 @@ export function buildBaseImageRef(image) {
 //   consequence         clause naming what breaks when the budget is spent,
 //                       appended to the exhaustion error.
 //
+// Under mirror-only mode the upstream loop below is not entered at all: the
+// mirror either serves the image or the acquisition fails naming it. See the
+// module header for why a fallback to an ANONYMOUS Docker Hub pull is the one
+// outcome that must not be available here.
+//
 // Returns true when the image is in the local daemon, false otherwise.
 export function pullImageWithRetry(image, options = {}) {
   const {
@@ -283,6 +381,21 @@ export function pullImageWithRetry(image, options = {}) {
   } = options;
 
   if (acquireFromMirror(image)) return true;
+
+  if (mirrorOnly()) {
+    // Asked before the mode, exactly as it is inside the loop: a copy already
+    // in the daemon satisfies this caller's postcondition no matter which
+    // registry is reachable, and no pull is needed to honour it.
+    if (acceptLocalCopy && presentLocally(image)) {
+      notice(
+        `${image} could not be acquired from the mirror, but it is already in the local daemon — ` +
+          'the caller accepts the local copy.',
+      );
+      return true;
+    }
+    error(mirrorOnlyDiagnosis(image, consequence));
+    return false;
+  }
 
   for (let attempt = 1; attempt <= registryAttempts; attempt++) {
     log(`    docker pull ${image} (attempt ${attempt}/${registryAttempts})`);

--- a/.github/scripts/lib/registry.mjs
+++ b/.github/scripts/lib/registry.mjs
@@ -84,7 +84,7 @@
 import process from 'node:process';
 
 import { capture, error, log, notice } from './gh.mjs';
-import { mirroredRef } from './mirror.mjs';
+import { isDockerHubRef, mirroredRef } from './mirror.mjs';
 
 // Five attempts with a linear backoff: long enough to ride out a registry blip
 // or a transport fault, short enough that a genuinely unreachable registry
@@ -176,6 +176,27 @@ export const mirrorOnlyEnvValue = '1';
 // must not put a job into a degraded mode by accident.
 export function mirrorOnly(env = process.env) {
   return String(env[mirrorOnlyEnvVar] ?? '').trim() === mirrorOnlyEnvValue;
+}
+
+// blockedByMirrorOnly — is `image` an acquisition this mode must refuse?
+//
+// Mirror-only mode exists because DOCKER HUB is unreachable, so it may only
+// constrain acquisitions that would have gone to Docker Hub. A ref naming any
+// other registry — `ghcr.io/open-telemetry/…/telemetrygen`, the released
+// `ghcr.io/tsouza/cerberus` image the migration lanes extract a binary from,
+// `gcr.io/distroless/*` — is reached over a path the outage does not touch, on
+// credentials the job already holds. Refusing those would take down the very
+// e2e and migration lanes this mode is supposed to save, and it would do it
+// with a message prescribing an impossible fix: adding a `ghcr.io/…` ref to
+// `mirroredImages` cannot help, because `mirroredRef` declines a non-Docker-Hub
+// ref by design and lib/mirror.mjs deliberately keeps unmetered registries out
+// of the inventory.
+//
+// So the question is asked in two parts rather than read off `mirroredRef`
+// returning null, which conflates "the mirror has no copy of this" with "this
+// never needed one".
+function blockedByMirrorOnly(image) {
+  return isDockerHubRef(image);
 }
 
 // mirrorOnlyDiagnosis — the one explanation for "this job is mirror-only and
@@ -322,7 +343,11 @@ function acquireFromMirror(image) {
 export function buildBaseImageRef(image) {
   const mirror = mirroredRef(image);
   if (mirror === null) {
-    if (mirrorOnly()) {
+    // Same narrowing as the pull path: a base image on a registry Docker Hub
+    // does not meter (`gcr.io/distroless/*`) resolves exactly as it always did,
+    // because the outage this mode reacts to cannot touch it. Only an
+    // unmirrored DOCKER HUB base image leaves a build with no resolvable ref.
+    if (mirrorOnly() && blockedByMirrorOnly(image)) {
       error(mirrorOnlyDiagnosis(image, 'the build has no base image to resolve its `FROM` against'));
       return null;
     }
@@ -382,7 +407,7 @@ export function pullImageWithRetry(image, options = {}) {
 
   if (acquireFromMirror(image)) return true;
 
-  if (mirrorOnly()) {
+  if (mirrorOnly() && blockedByMirrorOnly(image)) {
     // Asked before the mode, exactly as it is inside the loop: a copy already
     // in the daemon satisfies this caller's postcondition no matter which
     // registry is reachable, and no pull is needed to honour it.

--- a/.github/scripts/migration-artifact.mjs
+++ b/.github/scripts/migration-artifact.mjs
@@ -44,11 +44,11 @@
 // build / pull / extraction, or a `--version` probe that does not report
 // exactly the expected stamp.
 
-import { appendFileSync, mkdirSync, chmodSync } from 'node:fs';
+import { mkdirSync, chmodSync } from 'node:fs';
 import path from 'node:path';
 import process from 'node:process';
 
-import { capture, error, notice, log } from './lib/gh.mjs';
+import { capture, error, exportEnv, notice } from './lib/gh.mjs';
 import { pullImageWithRetry } from './lib/registry.mjs';
 
 // SOURCE_BUILD_VERSION is what `go build ./cmd/cerberus` with no ldflags
@@ -208,16 +208,6 @@ function probeVersion(binary, plan) {
     process.exit(1);
   }
   return lines[0];
-}
-
-function exportEnv(entries) {
-  const file = process.env.GITHUB_ENV;
-  const block = entries.map(([k, v]) => `${k}=${v}`).join('\n');
-  if (!file) {
-    log(`[no $GITHUB_ENV in env; resolved plan follows]\n${block}`);
-    return;
-  }
-  appendFileSync(file, `${block}\n`);
 }
 
 function main() {

--- a/.github/scripts/registry-login.mjs
+++ b/.github/scripts/registry-login.mjs
@@ -30,6 +30,28 @@
 // password that is wrong on attempt 1 is wrong on attempt 5, and retrying it
 // only turns a clear error into a slow one.
 //
+// WHAT A SPENT TRANSIENT BUDGET MEANS (issue #1933). Exhausting the retries on
+// a `transient` verdict is an honest report that this runner cannot reach the
+// registry — and for DOCKER HUB that is precisely the condition the GHCR mirror
+// was built to survive. Killing the job there fails a lane whose every image is
+// in a registry nobody even contacted. So a Docker Hub login that ends this way
+// downgrades the job to MIRROR-ONLY mode (lib/registry.mjs) rather than failing:
+// it records the mode in $GITHUB_ENV and exits 0, and every later acquisition
+// serves itself from the mirror or fails LOUDLY naming the image it wanted.
+//
+// Three boundaries make that a narrowing rather than a tolerance:
+//
+//   * only the `transient` verdict downgrades. A quota refusal and a rejected
+//     credential still fail on the first attempt, as before.
+//   * only DOCKER HUB downgrades. A ghcr.io login that cannot reach ghcr.io has
+//     nothing to fall back TO — mirror-only mode there would mean "acquire
+//     everything from the registry we just failed to reach", so it fails.
+//   * the downgrade is never silence. `continue-on-error: true` on this step
+//     would have been the cheap version and is the regression it looks like a
+//     fix for: an unauthenticated job does not fail, it degrades to the shared
+//     anonymous Docker Hub quota and reads as flake on the day that quota runs
+//     out. Mirror-only mode REMOVES the Docker Hub path instead of demoting it.
+//
 // ENV CONTRACT
 //   REGISTRY  — registry host to log in to. Blank/unset means Docker Hub, which
 //               is what `docker login` itself does with no host argument.
@@ -37,14 +59,23 @@
 //   PASSWORD  — required; passed on stdin, never as argv, so it cannot leak
 //               into a process listing.
 //   REGISTRY_LOGIN_BACKOFF_STEP_SECONDS — optional; attempt N waits N × step.
+//   ON_TRANSPORT_FAULT — optional; `mirror-only` (default) or `fail`. What an
+//               exhausted TRANSPORT-fault budget does on a Docker Hub login.
+//               `fail` is for the two jobs Docker Hub is not a fallback for:
+//               `mirror-images.yml` READS the inventory from it, and
+//               `release.yml` PUSHES to it. Neither can be served by a mirror,
+//               so for them an unreachable Docker Hub is a genuine dead end.
+//   GITHUB_ENV — runner file the mirror-only flag is exported through.
 
 import process from 'node:process';
 import { pathToFileURL } from 'node:url';
 
-import { capture, error, log, notice } from './lib/gh.mjs';
+import { capture, error, exportEnv, log, notice } from './lib/gh.mjs';
 import {
   isRegistryRateLimit,
   isTransientRegistryFailure,
+  mirrorOnlyEnvValue,
+  mirrorOnlyEnvVar,
   rateLimitDiagnosis,
   readBackoffStepSeconds,
   registryAttempts,
@@ -90,6 +121,46 @@ export function classifyLoginFailure(text) {
   return 'fatal';
 }
 
+// The two answers to "what does an exhausted transport-fault budget do", and the
+// variable that carries the choice. Spelled as named constants because the whole
+// difference between a lane that survives a Docker Hub outage and one that dies
+// on it is which of these two strings a step did not have to say.
+export const onTransportFaultVar = 'ON_TRANSPORT_FAULT';
+export const onTransportFaultMirrorOnly = 'mirror-only';
+export const onTransportFaultFail = 'fail';
+
+// Docker Hub under every name `docker login` accepts for it. The empty string is
+// the ordinary one — `docker login` with no host argument targets Docker Hub —
+// and the rest are here so a step that spells the host out does not silently
+// lose the downgrade it never knew it had.
+const dockerHubRegistries = new Set(['', 'docker.io', 'index.docker.io', 'registry-1.docker.io']);
+
+export function isDockerHubLogin(registry) {
+  return dockerHubRegistries.has(String(registry ?? '').trim().toLowerCase());
+}
+
+// downgradeToMirrorOnly — the whole downgrade decision as one pure function, for
+// the same reason `classifyLoginFailure` is one: the value of the rule is in the
+// conjunction, and a conjunction spread across an if-chain in `main` is testable
+// only by spawning docker against a registry that is really down.
+//
+// All three conditions are load-bearing and none is a default:
+//   verdict === 'transient'  — the registry is UNREACHABLE, as opposed to
+//                              refusing us (quota) or rejecting us (credential).
+//                              Only unreachability is what a mirror substitutes
+//                              for.
+//   Docker Hub               — the mirror stands in for Docker Hub and nothing
+//                              else. A mirror-only mode entered because the
+//                              MIRROR is unreachable is a contradiction.
+//   not opted out            — `fail` is how the two jobs that genuinely need
+//                              Docker Hub (mirroring it, publishing to it) say
+//                              a mirror cannot serve them.
+export function downgradeToMirrorOnly({ registry, verdict, onTransportFault }) {
+  if (verdict !== 'transient') return false;
+  if (!isDockerHubLogin(registry)) return false;
+  return onTransportFault !== onTransportFaultFail;
+}
+
 function requiredEnv(name) {
   const value = process.env[name];
   if (value === undefined || value === '') {
@@ -99,8 +170,38 @@ function requiredEnv(name) {
   return value;
 }
 
+// readOnTransportFault — the validated policy for this step.
+//
+// An unrecognised value exits rather than falling back to the default. The
+// default is the PERMISSIVE branch, so a typo (`ON_TRANSPORT_FAULT: fial`)
+// would silently re-enable the downgrade on exactly the two jobs that spelled
+// it out to switch it off — and the symptom would be a release that carried on
+// after losing its push registry.
+function readOnTransportFault(registry) {
+  const raw = (process.env[onTransportFaultVar] ?? '').trim();
+  if (raw === '') return onTransportFaultMirrorOnly;
+  if (raw !== onTransportFaultMirrorOnly && raw !== onTransportFaultFail) {
+    error(
+      `${onTransportFaultVar} must be \`${onTransportFaultMirrorOnly}\` or \`${onTransportFaultFail}\`, ` +
+        `got ${JSON.stringify(raw)}.`,
+    );
+    process.exit(1);
+  }
+  if (raw === onTransportFaultMirrorOnly && !isDockerHubLogin(registry)) {
+    error(
+      `${onTransportFaultVar}=${onTransportFaultMirrorOnly} is set on a login to ${registry}, which is not ` +
+        'Docker Hub. Mirror-only mode means "acquire everything from the GHCR mirror", so it can only stand ' +
+        'in for Docker Hub — asking for it here would mean falling back to the registry this step just ' +
+        'failed to reach.',
+    );
+    process.exit(1);
+  }
+  return raw;
+}
+
 function main() {
   const registry = (process.env.REGISTRY ?? '').trim();
+  const onTransportFault = readOnTransportFault(registry);
   const username = requiredEnv('USERNAME');
   const password = requiredEnv('PASSWORD');
   // Docker Hub is the no-host form of the command, matching `docker login`'s
@@ -144,6 +245,17 @@ function main() {
       process.exit(1);
     }
     if (attempt === registryAttempts) {
+      if (downgradeToMirrorOnly({ registry, verdict, onTransportFault })) {
+        exportEnv([[mirrorOnlyEnvVar, mirrorOnlyEnvValue]]);
+        notice(
+          `Logging in to ${subject} failed ${registryAttempts} times with a transport fault, so this job ` +
+            'continues in MIRROR-ONLY mode: every image is acquired from the GHCR mirror, and an image the ' +
+            'mirror cannot serve fails the job naming itself rather than being pulled anonymously from the ' +
+            'registry that is down. This is not a quota, and it is not a green light for an unauthenticated ' +
+            'pull. See the command output above.',
+        );
+        return;
+      }
       error(
         `Logging in to ${subject} failed ${registryAttempts} times with a transport fault. The registry is ` +
           'not reachable from this runner; this is not a quota. See the command output above.',

--- a/.github/scripts/registry-login.test.mjs
+++ b/.github/scripts/registry-login.test.mjs
@@ -17,7 +17,13 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
 
-import { classifyLoginFailure } from './registry-login.mjs';
+import {
+  classifyLoginFailure,
+  downgradeToMirrorOnly,
+  isDockerHubLogin,
+  onTransportFaultFail,
+  onTransportFaultMirrorOnly,
+} from './registry-login.mjs';
 
 // The output that killed the mirror workflow's first real run: the /v2/
 // handshake timed out before anything was pulled.
@@ -68,4 +74,61 @@ test('an error off every list is fatal rather than retried', () => {
   assert.equal(classifyLoginFailure('docker: command not found'), 'fatal');
   assert.equal(classifyLoginFailure(''), 'fatal');
   assert.equal(classifyLoginFailure(undefined), 'fatal');
+});
+
+// ---------------------------------------------------------------------------
+// The downgrade to mirror-only (issue #1933).
+//
+// A spent transport-fault budget on DOCKER HUB is the one failure the GHCR
+// mirror was built to survive, and until #1933 it was the one that guaranteed
+// the lane could not run: `compatibility/promql-surface` died on run
+// 31148765992 without issuing a query, while every image it needed sat in a
+// mirror nothing had contacted. So the verdict that used to end the job now
+// downgrades it — for that verdict, on that registry, unless the step opted out.
+//
+// Each of the three conditions is tested by DENYING it, because the risk here is
+// not a downgrade that fails to happen (that is the old, visible behaviour) but
+// one that happens where it must not: a job that carries on without the registry
+// it was going to publish to, or one that "falls back" to the registry it just
+// failed to reach.
+// ---------------------------------------------------------------------------
+
+const hubTransient = { registry: '', verdict: 'transient', onTransportFault: onTransportFaultMirrorOnly };
+
+test('an unreachable Docker Hub downgrades the job instead of killing it', () => {
+  assert.equal(downgradeToMirrorOnly(hubTransient), true);
+  // The default is the downgrade: a consuming job says nothing at all, which is
+  // what keeps a NEW image-acquiring lane from having to know the rule exists.
+  assert.equal(downgradeToMirrorOnly({ ...hubTransient, onTransportFault: '' }), true);
+});
+
+test('only a transport fault downgrades — a quota or a bad credential still fails', () => {
+  // A mirror cannot decrement a rolling quota window and cannot fix a wrong
+  // password. Downgrading on either would run the job in a degraded mode for a
+  // reason the degradation does not address, and hide a plain misconfiguration
+  // behind an image-not-mirrored error five steps later.
+  for (const verdict of ['rate-limit', 'credential', 'fatal']) {
+    assert.equal(downgradeToMirrorOnly({ ...hubTransient, verdict }), false, `${verdict} must not downgrade`);
+  }
+});
+
+test('only Docker Hub downgrades — a mirror that is down cannot stand in for itself', () => {
+  // "Acquire everything from the GHCR mirror" is not a recovery from "ghcr.io is
+  // unreachable"; it is the same failure with a longer path to it.
+  assert.equal(downgradeToMirrorOnly({ ...hubTransient, registry: 'ghcr.io' }), false);
+  // Every spelling `docker login` accepts for Docker Hub still downgrades, so a
+  // step that names the host does not silently lose the behaviour.
+  for (const spelling of ['docker.io', 'index.docker.io', 'registry-1.docker.io', 'DOCKER.IO', ' ']) {
+    assert.equal(isDockerHubLogin(spelling), true, `${JSON.stringify(spelling)} is Docker Hub`);
+    assert.equal(downgradeToMirrorOnly({ ...hubTransient, registry: spelling }), true);
+  }
+  assert.equal(isDockerHubLogin('ghcr.io'), false);
+});
+
+test('a step that publishes to Docker Hub opts out and still fails', () => {
+  // `release.yml` pushes half of an atomic dual-registry release to Docker Hub
+  // and `mirror-images.yml` READS the inventory from it. For both, Docker Hub is
+  // the thing itself rather than a fallback, so continuing without it would
+  // report success over work that did not happen.
+  assert.equal(downgradeToMirrorOnly({ ...hubTransient, onTransportFault: onTransportFaultFail }), false);
 });

--- a/.github/workflows/compatibility.yml
+++ b/.github/workflows/compatibility.yml
@@ -21,6 +21,9 @@ name: compatibility
 # Registry logins are deliberately NOT an Action: `docker/login-action` has no
 # retry input, and a login that fails on a handshake blip fails the whole job
 # before it pulls anything. They run `.github/scripts/registry-login.mjs`.
+# The GHCR mirror login comes FIRST in every job: it is the primary acquisition
+# path, and a Docker Hub outage that outlasts the retries downgrades the job to
+# mirror-only rather than killing it (issue #1933).
 #
 # Each job ALSO:
 #   - appends the head's compat percent / passed-over-total to
@@ -250,29 +253,41 @@ jobs:
         with:
           tool: just
 
+      # Cerberus's own copy of every upstream image this job pulls lives in a
+      # PRIVATE GHCR namespace, and `pullImageWithRetry` reaches for it before
+      # Docker Hub. That reach works only once this step has written ghcr.io
+      # credentials; without it the pull falls back to the shared anonymous
+      # Docker Hub quota. See .github/scripts/lib/mirror.mjs.
+      #
+      # FIRST, ahead of the Docker Hub login below, because this is the PRIMARY
+      # acquisition path and that one is the fallback. Authenticating the
+      # fallback first is what let a Docker Hub outage kill this job before the
+      # mirror it exists to fall back TO was ever contacted (issue #1933).
+      - name: Log in to the image mirror (GHCR)
+        env:
+          REGISTRY: ghcr.io
+          USERNAME: ${{ github.repository_owner }}
+          PASSWORD: ${{ secrets.GITHUB_TOKEN }}
+        run: node .github/scripts/registry-login.mjs
+
       # Authenticated Docker Hub pulls get a far higher rate limit than
       # anonymous pulls from shared runner IPs — two image-pull flakes
       # in one night hit this workflow (run 27241748868). Skips
       # silently when the secrets are absent (forks). The GHCR mirror
-      # login below is what removes the dependence on this limit.
+      # login above is what removes the dependence on this limit.
+      #
+      # An unreachable Docker Hub no longer takes this job down with it: the
+      # login exhausts its retries on a transport fault and downgrades the job
+      # to MIRROR-ONLY (registry-login.mjs), where every image comes from the
+      # mirror and one the mirror cannot serve fails the job naming itself
+      # rather than being pulled anonymously. A quota refusal or a rejected
+      # credential still fails here on the first attempt.
       - name: Log in to Docker Hub
         if: ${{ env.DOCKER_HUB_PAT_SET == 'true' }}
         env:
           DOCKER_HUB_PAT_SET: ${{ secrets.DOCKER_HUB_PAT != '' }}
           USERNAME: tsouza
           PASSWORD: ${{ secrets.DOCKER_HUB_PAT }}
-        run: node .github/scripts/registry-login.mjs
-
-      # Cerberus's own copy of every upstream image this job pulls lives in a
-      # PRIVATE GHCR namespace, and `pullImageWithRetry` reaches for it before
-      # Docker Hub. That reach works only once this step has written ghcr.io
-      # credentials; without it the pull falls back to the shared anonymous
-      # Docker Hub quota. See .github/scripts/lib/mirror.mjs.
-      - name: Log in to the image mirror (GHCR)
-        env:
-          REGISTRY: ghcr.io
-          USERNAME: ${{ github.repository_owner }}
-          PASSWORD: ${{ secrets.GITHUB_TOKEN }}
         run: node .github/scripts/registry-login.mjs
 
       - name: Run compatibility harness
@@ -456,24 +471,35 @@ jobs:
         with:
           tool: just
 
+      # Cerberus's own copy of every upstream image this job pulls lives in a
+      # PRIVATE GHCR namespace, and `pullImageWithRetry` reaches for it before
+      # Docker Hub. That reach works only once this step has written ghcr.io
+      # credentials; without it the pull falls back to the shared anonymous
+      # Docker Hub quota. See .github/scripts/lib/mirror.mjs.
+      #
+      # FIRST, ahead of the Docker Hub login below, because this is the PRIMARY
+      # acquisition path and that one is the fallback. Authenticating the
+      # fallback first is what let a Docker Hub outage kill this job before the
+      # mirror it exists to fall back TO was ever contacted (issue #1933).
+      - name: Log in to the image mirror (GHCR)
+        env:
+          REGISTRY: ghcr.io
+          USERNAME: ${{ github.repository_owner }}
+          PASSWORD: ${{ secrets.GITHUB_TOKEN }}
+        run: node .github/scripts/registry-login.mjs
+
+      # An unreachable Docker Hub no longer takes this job down with it: the
+      # login exhausts its retries on a transport fault and downgrades the job
+      # to MIRROR-ONLY (registry-login.mjs), where every image comes from the
+      # mirror and one the mirror cannot serve fails the job naming itself
+      # rather than being pulled anonymously. A quota refusal or a rejected
+      # credential still fails here on the first attempt.
       - name: Log in to Docker Hub
         if: ${{ env.DOCKER_HUB_PAT_SET == 'true' }}
         env:
           DOCKER_HUB_PAT_SET: ${{ secrets.DOCKER_HUB_PAT != '' }}
           USERNAME: tsouza
           PASSWORD: ${{ secrets.DOCKER_HUB_PAT }}
-        run: node .github/scripts/registry-login.mjs
-
-      # Cerberus's own copy of every upstream image this job pulls lives in a
-      # PRIVATE GHCR namespace, and `pullImageWithRetry` reaches for it before
-      # Docker Hub. That reach works only once this step has written ghcr.io
-      # credentials; without it the pull falls back to the shared anonymous
-      # Docker Hub quota. See .github/scripts/lib/mirror.mjs.
-      - name: Log in to the image mirror (GHCR)
-        env:
-          REGISTRY: ghcr.io
-          USERNAME: ${{ github.repository_owner }}
-          PASSWORD: ${{ secrets.GITHUB_TOKEN }}
         run: node .github/scripts/registry-login.mjs
 
       - name: Run forced-route compatibility harness
@@ -619,19 +645,25 @@ jobs:
         with:
           tool: just
 
+      - name: Log in to the image mirror (GHCR)
+        env:
+          REGISTRY: ghcr.io
+          USERNAME: ${{ github.repository_owner }}
+          PASSWORD: ${{ secrets.GITHUB_TOKEN }}
+        run: node .github/scripts/registry-login.mjs
+
+      # An unreachable Docker Hub no longer takes this job down with it: the
+      # login exhausts its retries on a transport fault and downgrades the job
+      # to MIRROR-ONLY (registry-login.mjs), where every image comes from the
+      # mirror and one the mirror cannot serve fails the job naming itself
+      # rather than being pulled anonymously. A quota refusal or a rejected
+      # credential still fails here on the first attempt.
       - name: Log in to Docker Hub
         if: ${{ env.DOCKER_HUB_PAT_SET == 'true' }}
         env:
           DOCKER_HUB_PAT_SET: ${{ secrets.DOCKER_HUB_PAT != '' }}
           USERNAME: tsouza
           PASSWORD: ${{ secrets.DOCKER_HUB_PAT }}
-        run: node .github/scripts/registry-login.mjs
-
-      - name: Log in to the image mirror (GHCR)
-        env:
-          REGISTRY: ghcr.io
-          USERNAME: ${{ github.repository_owner }}
-          PASSWORD: ${{ secrets.GITHUB_TOKEN }}
         run: node .github/scripts/registry-login.mjs
 
       - name: Run floor-pinned compatibility harness
@@ -776,26 +808,38 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
+      # Cerberus's own copy of every upstream image this job pulls lives in a
+      # PRIVATE GHCR namespace, and `pullImageWithRetry` reaches for it before
+      # Docker Hub. That reach works only once this step has written ghcr.io
+      # credentials; without it the pull falls back to the shared anonymous
+      # Docker Hub quota. See .github/scripts/lib/mirror.mjs.
+      #
+      # FIRST, ahead of the Docker Hub login below, because this is the PRIMARY
+      # acquisition path and that one is the fallback. Authenticating the
+      # fallback first is what let a Docker Hub outage kill this job before the
+      # mirror it exists to fall back TO was ever contacted (issue #1933).
+      - name: Log in to the image mirror (GHCR)
+        env:
+          REGISTRY: ghcr.io
+          USERNAME: ${{ github.repository_owner }}
+          PASSWORD: ${{ secrets.GITHUB_TOKEN }}
+        run: node .github/scripts/registry-login.mjs
+
       # See the prometheus job: authed Docker Hub pulls dodge the anonymous
       # rate limit shared across runner IPs; skips silently on forks.
+      #
+      # An unreachable Docker Hub no longer takes this job down with it: the
+      # login exhausts its retries on a transport fault and downgrades the job
+      # to MIRROR-ONLY (registry-login.mjs), where every image comes from the
+      # mirror and one the mirror cannot serve fails the job naming itself
+      # rather than being pulled anonymously. A quota refusal or a rejected
+      # credential still fails here on the first attempt.
       - name: Log in to Docker Hub
         if: ${{ env.DOCKER_HUB_PAT_SET == 'true' }}
         env:
           DOCKER_HUB_PAT_SET: ${{ secrets.DOCKER_HUB_PAT != '' }}
           USERNAME: tsouza
           PASSWORD: ${{ secrets.DOCKER_HUB_PAT }}
-        run: node .github/scripts/registry-login.mjs
-
-      # Cerberus's own copy of every upstream image this job pulls lives in a
-      # PRIVATE GHCR namespace, and `pullImageWithRetry` reaches for it before
-      # Docker Hub. That reach works only once this step has written ghcr.io
-      # credentials; without it the pull falls back to the shared anonymous
-      # Docker Hub quota. See .github/scripts/lib/mirror.mjs.
-      - name: Log in to the image mirror (GHCR)
-        env:
-          REGISTRY: ghcr.io
-          USERNAME: ${{ github.repository_owner }}
-          PASSWORD: ${{ secrets.GITHUB_TOKEN }}
         run: node .github/scripts/registry-login.mjs
 
       - name: Run PromQL surface-completeness gate
@@ -831,28 +875,40 @@ jobs:
       - name: Disk free (after reclaim)
         run: df -h
 
+      # Cerberus's own copy of every upstream image this job pulls lives in a
+      # PRIVATE GHCR namespace, and `pullImageWithRetry` reaches for it before
+      # Docker Hub. That reach works only once this step has written ghcr.io
+      # credentials; without it the pull falls back to the shared anonymous
+      # Docker Hub quota. See .github/scripts/lib/mirror.mjs.
+      #
+      # FIRST, ahead of the Docker Hub login below, because this is the PRIMARY
+      # acquisition path and that one is the fallback. Authenticating the
+      # fallback first is what let a Docker Hub outage kill this job before the
+      # mirror it exists to fall back TO was ever contacted (issue #1933).
+      - name: Log in to the image mirror (GHCR)
+        env:
+          REGISTRY: ghcr.io
+          USERNAME: ${{ github.repository_owner }}
+          PASSWORD: ${{ secrets.GITHUB_TOKEN }}
+        run: node .github/scripts/registry-login.mjs
+
       # See the prometheus job: authed Docker Hub pulls dodge the
       # anonymous rate limit shared across runner IPs; skips silently
       # on forks without the secrets. Ahead of the builder setup so the
       # BuildKit bootstrap image is fetched under the same credentials.
+      #
+      # An unreachable Docker Hub no longer takes this job down with it: the
+      # login exhausts its retries on a transport fault and downgrades the job
+      # to MIRROR-ONLY (registry-login.mjs), where every image comes from the
+      # mirror and one the mirror cannot serve fails the job naming itself
+      # rather than being pulled anonymously. A quota refusal or a rejected
+      # credential still fails here on the first attempt.
       - name: Log in to Docker Hub
         if: ${{ env.DOCKER_HUB_PAT_SET == 'true' }}
         env:
           DOCKER_HUB_PAT_SET: ${{ secrets.DOCKER_HUB_PAT != '' }}
           USERNAME: tsouza
           PASSWORD: ${{ secrets.DOCKER_HUB_PAT }}
-        run: node .github/scripts/registry-login.mjs
-
-      # Cerberus's own copy of every upstream image this job pulls lives in a
-      # PRIVATE GHCR namespace, and `pullImageWithRetry` reaches for it before
-      # Docker Hub. That reach works only once this step has written ghcr.io
-      # credentials; without it the pull falls back to the shared anonymous
-      # Docker Hub quota. See .github/scripts/lib/mirror.mjs.
-      - name: Log in to the image mirror (GHCR)
-        env:
-          REGISTRY: ghcr.io
-          USERNAME: ${{ github.repository_owner }}
-          PASSWORD: ${{ secrets.GITHUB_TOKEN }}
         run: node .github/scripts/registry-login.mjs
 
       # Buildx gives the Compose build cache, multi-arch support, and a
@@ -1004,28 +1060,40 @@ jobs:
           go-version-file: 'go.mod'
           cache: true
 
+      # Cerberus's own copy of every upstream image this job pulls lives in a
+      # PRIVATE GHCR namespace, and `pullImageWithRetry` reaches for it before
+      # Docker Hub. That reach works only once this step has written ghcr.io
+      # credentials; without it the pull falls back to the shared anonymous
+      # Docker Hub quota. See .github/scripts/lib/mirror.mjs.
+      #
+      # FIRST, ahead of the Docker Hub login below, because this is the PRIMARY
+      # acquisition path and that one is the fallback. Authenticating the
+      # fallback first is what let a Docker Hub outage kill this job before the
+      # mirror it exists to fall back TO was ever contacted (issue #1933).
+      - name: Log in to the image mirror (GHCR)
+        env:
+          REGISTRY: ghcr.io
+          USERNAME: ${{ github.repository_owner }}
+          PASSWORD: ${{ secrets.GITHUB_TOKEN }}
+        run: node .github/scripts/registry-login.mjs
+
       # See the prometheus job: authed Docker Hub pulls dodge the
       # anonymous rate limit shared across runner IPs; skips silently
       # on forks without the secrets. Ahead of the builder setup so the
       # BuildKit bootstrap image is fetched under the same credentials.
+      #
+      # An unreachable Docker Hub no longer takes this job down with it: the
+      # login exhausts its retries on a transport fault and downgrades the job
+      # to MIRROR-ONLY (registry-login.mjs), where every image comes from the
+      # mirror and one the mirror cannot serve fails the job naming itself
+      # rather than being pulled anonymously. A quota refusal or a rejected
+      # credential still fails here on the first attempt.
       - name: Log in to Docker Hub
         if: ${{ env.DOCKER_HUB_PAT_SET == 'true' }}
         env:
           DOCKER_HUB_PAT_SET: ${{ secrets.DOCKER_HUB_PAT != '' }}
           USERNAME: tsouza
           PASSWORD: ${{ secrets.DOCKER_HUB_PAT }}
-        run: node .github/scripts/registry-login.mjs
-
-      # Cerberus's own copy of every upstream image this job pulls lives in a
-      # PRIVATE GHCR namespace, and `pullImageWithRetry` reaches for it before
-      # Docker Hub. That reach works only once this step has written ghcr.io
-      # credentials; without it the pull falls back to the shared anonymous
-      # Docker Hub quota. See .github/scripts/lib/mirror.mjs.
-      - name: Log in to the image mirror (GHCR)
-        env:
-          REGISTRY: ghcr.io
-          USERNAME: ${{ github.repository_owner }}
-          PASSWORD: ${{ secrets.GITHUB_TOKEN }}
         run: node .github/scripts/registry-login.mjs
 
       # Buildx gives the Compose build cache + a consistent backend

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -338,30 +338,42 @@ jobs:
       - name: Disk free (after reclaim)
         run: df -h
 
+      # Cerberus's own copy of every upstream image this job pulls lives in a
+      # PRIVATE GHCR namespace, and `pullImageWithRetry` reaches for it before
+      # Docker Hub. That reach works only once this step has written ghcr.io
+      # credentials; without it the pull falls back to the shared anonymous
+      # Docker Hub quota. See .github/scripts/lib/mirror.mjs.
+      #
+      # FIRST, ahead of the Docker Hub login below, because this is the PRIMARY
+      # acquisition path and that one is the fallback. Authenticating the
+      # fallback first is what let a Docker Hub outage kill this job before the
+      # mirror it exists to fall back TO was ever contacted (issue #1933).
+      - name: Log in to the image mirror (GHCR)
+        env:
+          REGISTRY: ghcr.io
+          USERNAME: ${{ github.repository_owner }}
+          PASSWORD: ${{ secrets.GITHUB_TOKEN }}
+        run: node .github/scripts/registry-login.mjs
+
       # Authenticated Docker Hub pulls get a far higher rate limit than
       # anonymous pulls from shared runner IPs (same hardening as the
       # compatibility workflow's compose jobs). Skips silently when the
       # secrets are absent (forks); GHCR mirroring is the stronger
       # long-term fix. Ahead of the builder setup so the BuildKit
       # bootstrap image is fetched under the same credentials.
+      #
+      # An unreachable Docker Hub no longer takes this job down with it: the
+      # login exhausts its retries on a transport fault and downgrades the job
+      # to MIRROR-ONLY (registry-login.mjs), where every image comes from the
+      # mirror and one the mirror cannot serve fails the job naming itself
+      # rather than being pulled anonymously. A quota refusal or a rejected
+      # credential still fails here on the first attempt.
       - name: Log in to Docker Hub
         if: ${{ env.DOCKER_HUB_PAT_SET == 'true' }}
         env:
           DOCKER_HUB_PAT_SET: ${{ secrets.DOCKER_HUB_PAT != '' }}
           USERNAME: tsouza
           PASSWORD: ${{ secrets.DOCKER_HUB_PAT }}
-        run: node .github/scripts/registry-login.mjs
-
-      # Cerberus's own copy of every upstream image this job pulls lives in a
-      # PRIVATE GHCR namespace, and `pullImageWithRetry` reaches for it before
-      # Docker Hub. That reach works only once this step has written ghcr.io
-      # credentials; without it the pull falls back to the shared anonymous
-      # Docker Hub quota. See .github/scripts/lib/mirror.mjs.
-      - name: Log in to the image mirror (GHCR)
-        env:
-          REGISTRY: ghcr.io
-          USERNAME: ${{ github.repository_owner }}
-          PASSWORD: ${{ secrets.GITHUB_TOKEN }}
         run: node .github/scripts/registry-login.mjs
 
       - uses: ./.github/actions/setup-buildx
@@ -591,26 +603,38 @@ jobs:
       - name: Disk free (after reclaim)
         run: df -h
 
+      # Cerberus's own copy of every upstream image this job pulls lives in a
+      # PRIVATE GHCR namespace, and `pullImageWithRetry` reaches for it before
+      # Docker Hub. That reach works only once this step has written ghcr.io
+      # credentials; without it the pull falls back to the shared anonymous
+      # Docker Hub quota. See .github/scripts/lib/mirror.mjs.
+      #
+      # FIRST, ahead of the Docker Hub login below, because this is the PRIMARY
+      # acquisition path and that one is the fallback. Authenticating the
+      # fallback first is what let a Docker Hub outage kill this job before the
+      # mirror it exists to fall back TO was ever contacted (issue #1933).
+      - name: Log in to the image mirror (GHCR)
+        env:
+          REGISTRY: ghcr.io
+          USERNAME: ${{ github.repository_owner }}
+          PASSWORD: ${{ secrets.GITHUB_TOKEN }}
+        run: node .github/scripts/registry-login.mjs
+
       # Ahead of the builder setup so the BuildKit bootstrap image is
       # fetched under the same credentials.
+      #
+      # An unreachable Docker Hub no longer takes this job down with it: the
+      # login exhausts its retries on a transport fault and downgrades the job
+      # to MIRROR-ONLY (registry-login.mjs), where every image comes from the
+      # mirror and one the mirror cannot serve fails the job naming itself
+      # rather than being pulled anonymously. A quota refusal or a rejected
+      # credential still fails here on the first attempt.
       - name: Log in to Docker Hub
         if: ${{ env.DOCKER_HUB_PAT_SET == 'true' }}
         env:
           DOCKER_HUB_PAT_SET: ${{ secrets.DOCKER_HUB_PAT != '' }}
           USERNAME: tsouza
           PASSWORD: ${{ secrets.DOCKER_HUB_PAT }}
-        run: node .github/scripts/registry-login.mjs
-
-      # Cerberus's own copy of every upstream image this job pulls lives in a
-      # PRIVATE GHCR namespace, and `pullImageWithRetry` reaches for it before
-      # Docker Hub. That reach works only once this step has written ghcr.io
-      # credentials; without it the pull falls back to the shared anonymous
-      # Docker Hub quota. See .github/scripts/lib/mirror.mjs.
-      - name: Log in to the image mirror (GHCR)
-        env:
-          REGISTRY: ghcr.io
-          USERNAME: ${{ github.repository_owner }}
-          PASSWORD: ${{ secrets.GITHUB_TOKEN }}
         run: node .github/scripts/registry-login.mjs
 
       - uses: ./.github/actions/setup-buildx
@@ -1053,29 +1077,41 @@ jobs:
         run: |
           curl -sSfL https://raw.githubusercontent.com/k3d-io/k3d/main/install.sh | TAG=v5.8.3 bash
 
+      # Cerberus's own copy of every upstream image this job pulls lives in a
+      # PRIVATE GHCR namespace, and `pullImageWithRetry` reaches for it before
+      # Docker Hub. That reach works only once this step has written ghcr.io
+      # credentials; without it the pull falls back to the shared anonymous
+      # Docker Hub quota. See .github/scripts/lib/mirror.mjs.
+      #
+      # FIRST, ahead of the Docker Hub login below, because this is the PRIMARY
+      # acquisition path and that one is the fallback. Authenticating the
+      # fallback first is what let a Docker Hub outage kill this job before the
+      # mirror it exists to fall back TO was ever contacted (issue #1933).
+      - name: Log in to the image mirror (GHCR)
+        env:
+          REGISTRY: ghcr.io
+          USERNAME: ${{ github.repository_owner }}
+          PASSWORD: ${{ secrets.GITHUB_TOKEN }}
+        run: node .github/scripts/registry-login.mjs
+
       # `just e2e-up` pulls the k3s node image + every external image on
       # the HOST docker daemon (then `k3d image import`s them into the
       # cluster's containerd — see Justfile's e2e-up/_pull-retry), so this
       # login is what actually raises the pull-rate ceiling for k3d jobs,
       # exactly like the compose-smoke jobs above.
+      #
+      # An unreachable Docker Hub no longer takes this job down with it: the
+      # login exhausts its retries on a transport fault and downgrades the job
+      # to MIRROR-ONLY (registry-login.mjs), where every image comes from the
+      # mirror and one the mirror cannot serve fails the job naming itself
+      # rather than being pulled anonymously. A quota refusal or a rejected
+      # credential still fails here on the first attempt.
       - name: Log in to Docker Hub
         if: ${{ env.RUN_SHARD == 'true' && env.DOCKER_HUB_PAT_SET == 'true' }}
         env:
           DOCKER_HUB_PAT_SET: ${{ secrets.DOCKER_HUB_PAT != '' }}
           USERNAME: tsouza
           PASSWORD: ${{ secrets.DOCKER_HUB_PAT }}
-        run: node .github/scripts/registry-login.mjs
-
-      # Cerberus's own copy of every upstream image this job pulls lives in a
-      # PRIVATE GHCR namespace, and `pullImageWithRetry` reaches for it before
-      # Docker Hub. That reach works only once this step has written ghcr.io
-      # credentials; without it the pull falls back to the shared anonymous
-      # Docker Hub quota. See .github/scripts/lib/mirror.mjs.
-      - name: Log in to the image mirror (GHCR)
-        env:
-          REGISTRY: ghcr.io
-          USERNAME: ${{ github.repository_owner }}
-          PASSWORD: ${{ secrets.GITHUB_TOKEN }}
         run: node .github/scripts/registry-login.mjs
 
       - name: Bring up k3d stack
@@ -1419,29 +1455,41 @@ jobs:
         with:
           tool: just
 
+      # Cerberus's own copy of every upstream image this job pulls lives in a
+      # PRIVATE GHCR namespace, and `pullImageWithRetry` reaches for it before
+      # Docker Hub. That reach works only once this step has written ghcr.io
+      # credentials; without it the pull falls back to the shared anonymous
+      # Docker Hub quota. See .github/scripts/lib/mirror.mjs.
+      #
+      # FIRST, ahead of the Docker Hub login below, because this is the PRIMARY
+      # acquisition path and that one is the fallback. Authenticating the
+      # fallback first is what let a Docker Hub outage kill this job before the
+      # mirror it exists to fall back TO was ever contacted (issue #1933).
+      - name: Log in to the image mirror (GHCR)
+        env:
+          REGISTRY: ghcr.io
+          USERNAME: ${{ github.repository_owner }}
+          PASSWORD: ${{ secrets.GITHUB_TOKEN }}
+        run: node .github/scripts/registry-login.mjs
+
       # The mirror is reached for FIRST, but a mirror miss falls back to Docker
       # Hub — and that fallback is the anonymous shared per-runner-IP quota
       # unless this step has run. Every other image-acquiring job in this
       # workflow carries both logins; this one carried only the mirror half,
       # which is invisible for as long as the mirror keeps hitting.
+      #
+      # An unreachable Docker Hub no longer takes this job down with it: the
+      # login exhausts its retries on a transport fault and downgrades the job
+      # to MIRROR-ONLY (registry-login.mjs), where every image comes from the
+      # mirror and one the mirror cannot serve fails the job naming itself
+      # rather than being pulled anonymously. A quota refusal or a rejected
+      # credential still fails here on the first attempt.
       - name: Log in to Docker Hub
         if: ${{ env.DOCKER_HUB_PAT_SET == 'true' }}
         env:
           DOCKER_HUB_PAT_SET: ${{ secrets.DOCKER_HUB_PAT != '' }}
           USERNAME: tsouza
           PASSWORD: ${{ secrets.DOCKER_HUB_PAT }}
-        run: node .github/scripts/registry-login.mjs
-
-      # Cerberus's own copy of every upstream image this job pulls lives in a
-      # PRIVATE GHCR namespace, and `pullImageWithRetry` reaches for it before
-      # Docker Hub. That reach works only once this step has written ghcr.io
-      # credentials; without it the pull falls back to the shared anonymous
-      # Docker Hub quota. See .github/scripts/lib/mirror.mjs.
-      - name: Log in to the image mirror (GHCR)
-        env:
-          REGISTRY: ghcr.io
-          USERNAME: ${{ github.repository_owner }}
-          PASSWORD: ${{ secrets.GITHUB_TOKEN }}
         run: node .github/scripts/registry-login.mjs
 
       # `docker run` pulls a missing image itself, single-attempt: a Docker Hub
@@ -1564,29 +1612,41 @@ jobs:
         run: |
           curl -sSfL https://raw.githubusercontent.com/k3d-io/k3d/main/install.sh | TAG=v5.8.3 bash
 
+      # Cerberus's own copy of every upstream image this job pulls lives in a
+      # PRIVATE GHCR namespace, and `pullImageWithRetry` reaches for it before
+      # Docker Hub. That reach works only once this step has written ghcr.io
+      # credentials; without it the pull falls back to the shared anonymous
+      # Docker Hub quota. See .github/scripts/lib/mirror.mjs.
+      #
+      # FIRST, ahead of the Docker Hub login below, because this is the PRIMARY
+      # acquisition path and that one is the fallback. Authenticating the
+      # fallback first is what let a Docker Hub outage kill this job before the
+      # mirror it exists to fall back TO was ever contacted (issue #1933).
+      - name: Log in to the image mirror (GHCR)
+        env:
+          REGISTRY: ghcr.io
+          USERNAME: ${{ github.repository_owner }}
+          PASSWORD: ${{ secrets.GITHUB_TOKEN }}
+        run: node .github/scripts/registry-login.mjs
+
       # `just e2e-up` pulls the k3s node image + every external image on
       # the HOST docker daemon (then `k3d image import`s them into the
       # cluster's containerd — see Justfile's e2e-up/_pull-retry), so this
       # login is what actually raises the pull-rate ceiling for k3d jobs,
       # exactly like the compose-smoke jobs above.
+      #
+      # An unreachable Docker Hub no longer takes this job down with it: the
+      # login exhausts its retries on a transport fault and downgrades the job
+      # to MIRROR-ONLY (registry-login.mjs), where every image comes from the
+      # mirror and one the mirror cannot serve fails the job naming itself
+      # rather than being pulled anonymously. A quota refusal or a rejected
+      # credential still fails here on the first attempt.
       - name: Log in to Docker Hub
         if: ${{ env.DOCKER_HUB_PAT_SET == 'true' }}
         env:
           DOCKER_HUB_PAT_SET: ${{ secrets.DOCKER_HUB_PAT != '' }}
           USERNAME: tsouza
           PASSWORD: ${{ secrets.DOCKER_HUB_PAT }}
-        run: node .github/scripts/registry-login.mjs
-
-      # Cerberus's own copy of every upstream image this job pulls lives in a
-      # PRIVATE GHCR namespace, and `pullImageWithRetry` reaches for it before
-      # Docker Hub. That reach works only once this step has written ghcr.io
-      # credentials; without it the pull falls back to the shared anonymous
-      # Docker Hub quota. See .github/scripts/lib/mirror.mjs.
-      - name: Log in to the image mirror (GHCR)
-        env:
-          REGISTRY: ghcr.io
-          USERNAME: ${{ github.repository_owner }}
-          PASSWORD: ${{ secrets.GITHUB_TOKEN }}
         run: node .github/scripts/registry-login.mjs
 
       # Reuse the e2e k3d bring-up (same first steps as the dashboard job):
@@ -1760,29 +1820,41 @@ jobs:
         run: |
           curl -sSfL https://raw.githubusercontent.com/k3d-io/k3d/main/install.sh | TAG=v5.8.3 bash
 
+      # Cerberus's own copy of every upstream image this job pulls lives in a
+      # PRIVATE GHCR namespace, and `pullImageWithRetry` reaches for it before
+      # Docker Hub. That reach works only once this step has written ghcr.io
+      # credentials; without it the pull falls back to the shared anonymous
+      # Docker Hub quota. See .github/scripts/lib/mirror.mjs.
+      #
+      # FIRST, ahead of the Docker Hub login below, because this is the PRIMARY
+      # acquisition path and that one is the fallback. Authenticating the
+      # fallback first is what let a Docker Hub outage kill this job before the
+      # mirror it exists to fall back TO was ever contacted (issue #1933).
+      - name: Log in to the image mirror (GHCR)
+        env:
+          REGISTRY: ghcr.io
+          USERNAME: ${{ github.repository_owner }}
+          PASSWORD: ${{ secrets.GITHUB_TOKEN }}
+        run: node .github/scripts/registry-login.mjs
+
       # `just e2e-bwc-up` pulls the k3s node image + every external/bwc image
       # on the HOST docker daemon (then `k3d image import`s them into the
       # cluster's containerd — see Justfile's e2e-bwc-up/_pull-retry), so
       # this login is what actually raises the pull-rate ceiling here,
       # exactly like the compose-smoke jobs above.
+      #
+      # An unreachable Docker Hub no longer takes this job down with it: the
+      # login exhausts its retries on a transport fault and downgrades the job
+      # to MIRROR-ONLY (registry-login.mjs), where every image comes from the
+      # mirror and one the mirror cannot serve fails the job naming itself
+      # rather than being pulled anonymously. A quota refusal or a rejected
+      # credential still fails here on the first attempt.
       - name: Log in to Docker Hub
         if: ${{ env.DOCKER_HUB_PAT_SET == 'true' }}
         env:
           DOCKER_HUB_PAT_SET: ${{ secrets.DOCKER_HUB_PAT != '' }}
           USERNAME: tsouza
           PASSWORD: ${{ secrets.DOCKER_HUB_PAT }}
-        run: node .github/scripts/registry-login.mjs
-
-      # Cerberus's own copy of every upstream image this job pulls lives in a
-      # PRIVATE GHCR namespace, and `pullImageWithRetry` reaches for it before
-      # Docker Hub. That reach works only once this step has written ghcr.io
-      # credentials; without it the pull falls back to the shared anonymous
-      # Docker Hub quota. See .github/scripts/lib/mirror.mjs.
-      - name: Log in to the image mirror (GHCR)
-        env:
-          REGISTRY: ghcr.io
-          USERNAME: ${{ github.repository_owner }}
-          PASSWORD: ${{ secrets.GITHUB_TOKEN }}
         run: node .github/scripts/registry-login.mjs
 
       - name: Bring up k3d + MinIO + bundled-ClickHouse stack

--- a/.github/workflows/migration-e2e.yml
+++ b/.github/workflows/migration-e2e.yml
@@ -270,19 +270,6 @@ jobs:
         with:
           tool: just
 
-      # Anonymous Docker Hub pulls are rate-limited hard enough to fail a cold
-      # runner mid-`compose up` from a shared runner IP, and this stack pulls
-      # five upstream images; the other Docker-backed lanes log in first for
-      # exactly this reason. Gated on the secret being present so a fork PR
-      # degrades to anonymous rather than erroring on an empty password.
-      - name: Log in to Docker Hub
-        if: ${{ env.DOCKER_HUB_PAT_SET == 'true' }}
-        env:
-          DOCKER_HUB_PAT_SET: ${{ secrets.DOCKER_HUB_PAT != '' }}
-          USERNAME: tsouza
-          PASSWORD: ${{ secrets.DOCKER_HUB_PAT }}
-        run: node .github/scripts/registry-login.mjs
-
       # See migration-tier0's identical block: unconditional so the artifact
       # lane's GHCR pull can never silently degrade into a source build.
       - name: Log in to GHCR
@@ -290,6 +277,26 @@ jobs:
           REGISTRY: ghcr.io
           USERNAME: ${{ github.repository_owner }}
           PASSWORD: ${{ secrets.GITHUB_TOKEN }}
+        run: node .github/scripts/registry-login.mjs
+
+      # Anonymous Docker Hub pulls are rate-limited hard enough to fail a cold
+      # runner mid-`compose up` from a shared runner IP, and this stack pulls
+      # five upstream images; the other Docker-backed lanes log in first for
+      # exactly this reason. Gated on the secret being present so a fork PR
+      # degrades to anonymous rather than erroring on an empty password.
+      #
+      # An unreachable Docker Hub no longer takes this job down with it: the
+      # login exhausts its retries on a transport fault and downgrades the job
+      # to MIRROR-ONLY (registry-login.mjs), where every image comes from the
+      # mirror and one the mirror cannot serve fails the job naming itself
+      # rather than being pulled anonymously. A quota refusal or a rejected
+      # credential still fails here on the first attempt.
+      - name: Log in to Docker Hub
+        if: ${{ env.DOCKER_HUB_PAT_SET == 'true' }}
+        env:
+          DOCKER_HUB_PAT_SET: ${{ secrets.DOCKER_HUB_PAT != '' }}
+          USERNAME: tsouza
+          PASSWORD: ${{ secrets.DOCKER_HUB_PAT }}
         run: node .github/scripts/registry-login.mjs
 
       # migration-tier1 runs on a separate runner with a fresh checkout, so
@@ -430,20 +437,26 @@ jobs:
         with:
           tool: just
 
-      - name: Log in to Docker Hub
-        if: ${{ env.DOCKER_HUB_PAT_SET == 'true' }}
-        env:
-          DOCKER_HUB_PAT_SET: ${{ secrets.DOCKER_HUB_PAT != '' }}
-          USERNAME: tsouza
-          PASSWORD: ${{ secrets.DOCKER_HUB_PAT }}
-        run: node .github/scripts/registry-login.mjs
-
       # See migration-tier0's identical block.
       - name: Log in to GHCR
         env:
           REGISTRY: ghcr.io
           USERNAME: ${{ github.repository_owner }}
           PASSWORD: ${{ secrets.GITHUB_TOKEN }}
+        run: node .github/scripts/registry-login.mjs
+
+      # An unreachable Docker Hub no longer takes this job down with it: the
+      # login exhausts its retries on a transport fault and downgrades the job
+      # to MIRROR-ONLY (registry-login.mjs), where every image comes from the
+      # mirror and one the mirror cannot serve fails the job naming itself
+      # rather than being pulled anonymously. A quota refusal or a rejected
+      # credential still fails here on the first attempt.
+      - name: Log in to Docker Hub
+        if: ${{ env.DOCKER_HUB_PAT_SET == 'true' }}
+        env:
+          DOCKER_HUB_PAT_SET: ${{ secrets.DOCKER_HUB_PAT != '' }}
+          USERNAME: tsouza
+          PASSWORD: ${{ secrets.DOCKER_HUB_PAT }}
         run: node .github/scripts/registry-login.mjs
 
       - name: download migration scenarios enumeration

--- a/.github/workflows/mirror-images.yml
+++ b/.github/workflows/mirror-images.yml
@@ -63,6 +63,16 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
+      # Writing side. Retried for the same reason: an unpopulated mirror is
+      # silent at every point of use, so the handshake that enables writing to
+      # it is not a good place to be one-shot.
+      - name: Log in to GHCR
+        env:
+          REGISTRY: ghcr.io
+          USERNAME: ${{ github.repository_owner }}
+          PASSWORD: ${{ secrets.GITHUB_TOKEN }}
+        run: node .github/scripts/registry-login.mjs
+
       # Reading side. Authenticated, because copying the inventory is itself a
       # burst of manifest reads against Docker Hub — the anonymous per-IP bucket
       # is exactly what this job exists to stop spending. Skips silently when
@@ -75,22 +85,20 @@ jobs:
       # anything, so the mirror shipped inert while the PR merged green. The
       # script classifies with lib/registry.mjs, so a handshake fault retries
       # while a quota refusal still fails on the first attempt.
+      #
+      # `ON_TRANSPORT_FAULT: fail` opts OUT of the mirror-only downgrade every
+      # consuming job takes, and the reason is the direction of the copy. For a
+      # consumer, an unreachable Docker Hub is what the mirror substitutes for;
+      # for this job Docker Hub is the SOURCE, and a mirror cannot stand in for
+      # the registry it is copying from. Downgrading here would let the job
+      # carry on and report success over an inventory it never read.
       - name: Log in to Docker Hub
         if: ${{ env.DOCKER_HUB_PAT_SET == 'true' }}
         env:
           DOCKER_HUB_PAT_SET: ${{ secrets.DOCKER_HUB_PAT != '' }}
           USERNAME: tsouza
           PASSWORD: ${{ secrets.DOCKER_HUB_PAT }}
-        run: node .github/scripts/registry-login.mjs
-
-      # Writing side. Retried for the same reason: an unpopulated mirror is
-      # silent at every point of use, so the handshake that enables writing to
-      # it is not a good place to be one-shot.
-      - name: Log in to GHCR
-        env:
-          REGISTRY: ghcr.io
-          USERNAME: ${{ github.repository_owner }}
-          PASSWORD: ${{ secrets.GITHUB_TOKEN }}
+          ON_TRANSPORT_FAULT: fail
         run: node .github/scripts/registry-login.mjs
 
       - name: Mirror the inventory

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -341,10 +341,17 @@ jobs:
       # failure aborts the whole release (atomic dual-registry push).
       # Both logins sit ahead of the builder setup so the BuildKit
       # bootstrap image is fetched under the same credentials.
+      #
+      # `ON_TRANSPORT_FAULT: fail` opts OUT of the mirror-only downgrade the
+      # image-consuming jobs take. Here Docker Hub is a PUBLISH target, not a
+      # source a mirror can substitute for: continuing without it would build
+      # the release and then fail to push half of the dual-registry pair, which
+      # is the one outcome an atomic push must not produce.
       - name: Log in to Docker Hub
         env:
           USERNAME: tsouza
           PASSWORD: ${{ secrets.DOCKER_HUB_PAT }}
+          ON_TRANSPORT_FAULT: fail
         run: node .github/scripts/registry-login.mjs
 
       # `dockers_v2` builds linux/amd64 + linux/arm64 through buildx, which

--- a/.github/workflows/schema-integration.yml
+++ b/.github/workflows/schema-integration.yml
@@ -108,27 +108,39 @@ jobs:
         with:
           tool: just
 
-      # The mirror below is reached for FIRST, but a mirror miss falls back to
+      # Cerberus's own copy of every upstream image this job pulls lives in a
+      # PRIVATE GHCR namespace, and `pullImageWithRetry` reaches for it before
+      # Docker Hub. That reach works only once this step has written ghcr.io
+      # credentials; without it the pull falls back to the shared anonymous
+      # Docker Hub quota. See .github/scripts/lib/mirror.mjs.
+      #
+      # FIRST, ahead of the Docker Hub login below, because this is the PRIMARY
+      # acquisition path and that one is the fallback. Authenticating the
+      # fallback first is what let a Docker Hub outage kill this job before the
+      # mirror it exists to fall back TO was ever contacted (issue #1933).
+      - name: Log in to the image mirror (GHCR)
+        env:
+          REGISTRY: ghcr.io
+          USERNAME: ${{ github.repository_owner }}
+          PASSWORD: ${{ secrets.GITHUB_TOKEN }}
+        run: node .github/scripts/registry-login.mjs
+
+      # The mirror above is reached for FIRST, but a mirror miss falls back to
       # Docker Hub — and that fallback spends the anonymous shared
       # per-runner-IP quota unless this step has run.
+      #
+      # An unreachable Docker Hub no longer takes this job down with it: the
+      # login exhausts its retries on a transport fault and downgrades the job
+      # to MIRROR-ONLY (registry-login.mjs), where every image comes from the
+      # mirror and one the mirror cannot serve fails the job naming itself
+      # rather than being pulled anonymously. A quota refusal or a rejected
+      # credential still fails here on the first attempt.
       - name: Log in to Docker Hub
         if: ${{ env.DOCKER_HUB_PAT_SET == 'true' }}
         env:
           DOCKER_HUB_PAT_SET: ${{ secrets.DOCKER_HUB_PAT != '' }}
           USERNAME: tsouza
           PASSWORD: ${{ secrets.DOCKER_HUB_PAT }}
-        run: node .github/scripts/registry-login.mjs
-
-      # Cerberus's own copy of every upstream image this job pulls lives in a
-      # PRIVATE GHCR namespace, and `pullImageWithRetry` reaches for it before
-      # Docker Hub. That reach works only once this step has written ghcr.io
-      # credentials; without it the pull falls back to the shared anonymous
-      # Docker Hub quota. See .github/scripts/lib/mirror.mjs.
-      - name: Log in to the image mirror (GHCR)
-        env:
-          REGISTRY: ghcr.io
-          USERNAME: ${{ github.repository_owner }}
-          PASSWORD: ${{ secrets.GITHUB_TOKEN }}
         run: node .github/scripts/registry-login.mjs
 
       - name: Run schema/ddl integration tests (real ClickHouse)

--- a/.github/workflows/strict-scan.yml
+++ b/.github/workflows/strict-scan.yml
@@ -114,27 +114,39 @@ jobs:
         with:
           tool: just
 
-      # The mirror below is reached for FIRST, but a mirror miss falls back to
+      # Cerberus's own copy of every upstream image this job pulls lives in a
+      # PRIVATE GHCR namespace, and `pullImageWithRetry` reaches for it before
+      # Docker Hub. That reach works only once this step has written ghcr.io
+      # credentials; without it the pull falls back to the shared anonymous
+      # Docker Hub quota. See .github/scripts/lib/mirror.mjs.
+      #
+      # FIRST, ahead of the Docker Hub login below, because this is the PRIMARY
+      # acquisition path and that one is the fallback. Authenticating the
+      # fallback first is what let a Docker Hub outage kill this job before the
+      # mirror it exists to fall back TO was ever contacted (issue #1933).
+      - name: Log in to the image mirror (GHCR)
+        env:
+          REGISTRY: ghcr.io
+          USERNAME: ${{ github.repository_owner }}
+          PASSWORD: ${{ secrets.GITHUB_TOKEN }}
+        run: node .github/scripts/registry-login.mjs
+
+      # The mirror above is reached for FIRST, but a mirror miss falls back to
       # Docker Hub — and that fallback spends the anonymous shared
       # per-runner-IP quota unless this step has run.
+      #
+      # An unreachable Docker Hub no longer takes this job down with it: the
+      # login exhausts its retries on a transport fault and downgrades the job
+      # to MIRROR-ONLY (registry-login.mjs), where every image comes from the
+      # mirror and one the mirror cannot serve fails the job naming itself
+      # rather than being pulled anonymously. A quota refusal or a rejected
+      # credential still fails here on the first attempt.
       - name: Log in to Docker Hub
         if: ${{ env.DOCKER_HUB_PAT_SET == 'true' }}
         env:
           DOCKER_HUB_PAT_SET: ${{ secrets.DOCKER_HUB_PAT != '' }}
           USERNAME: tsouza
           PASSWORD: ${{ secrets.DOCKER_HUB_PAT }}
-        run: node .github/scripts/registry-login.mjs
-
-      # Cerberus's own copy of every upstream image this job pulls lives in a
-      # PRIVATE GHCR namespace, and `pullImageWithRetry` reaches for it before
-      # Docker Hub. That reach works only once this step has written ghcr.io
-      # credentials; without it the pull falls back to the shared anonymous
-      # Docker Hub quota. See .github/scripts/lib/mirror.mjs.
-      - name: Log in to the image mirror (GHCR)
-        env:
-          REGISTRY: ghcr.io
-          USERNAME: ${{ github.repository_owner }}
-          PASSWORD: ${{ secrets.GITHUB_TOKEN }}
         run: node .github/scripts/registry-login.mjs
 
       - name: Run strict-scan differential (real ClickHouse)

--- a/test/regression/mirror_only_downgrade_test.go
+++ b/test/regression/mirror_only_downgrade_test.go
@@ -1,0 +1,357 @@
+package regression
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+)
+
+// The GHCR mirror's whole claim is that cerberus's CI does not depend on Docker
+// Hub answering. Until issue #1933 that claim was never measured, and it was
+// false: `compatibility/promql-surface` went red on run 31148765992 without
+// issuing a single query, because the Docker Hub login exhausted its retries on
+// `context deadline exceeded` and every login is a hard gate. Each image the job
+// wanted was sitting in the mirror, which nothing had contacted.
+//
+// Two mechanisms fix that and both are asserted here, on the real scripts:
+//
+//   - `registry-login.mjs` turns a spent TRANSPORT-fault budget on Docker Hub
+//     into MIRROR-ONLY mode for the job, exported through $GITHUB_ENV.
+//   - `pullImageWithRetry` (lib/registry.mjs) in that mode serves from the
+//     mirror or fails LOUDLY naming the image. It never reaches for Docker Hub
+//     anonymously, which is the silent degradation the login gate exists to
+//     prevent and the reason `continue-on-error: true` on the login step would
+//     have been a regression rather than a fix.
+//
+// The tests drive the two halves in sequence through a stub `docker` on PATH,
+// passing the flag between them exactly as the runner does: the login step's
+// $GITHUB_ENV file is parsed and fed to the pull step's environment. That is
+// what makes the variable name load-bearing here rather than restated — a
+// rename on one side and not the other fails this test.
+
+const (
+	registryLoginModule = "../../.github/scripts/registry-login.mjs"
+	pullImagesModule    = "../../.github/scripts/pull-images.mjs"
+
+	// The output the daemon produces when it cannot reach Docker Hub at all —
+	// the verbatim line from run 31148765992. It is on `lib/registry.mjs`'s
+	// transient list and off its rate-limit list, so it is the input that
+	// produces the `transient` verdict the downgrade keys on. Using the real
+	// text rather than a synthetic one keeps this test coupled to the
+	// classifier's actual behaviour.
+	handshakeTimeout = `Error response from daemon: Get "https://registry-1.docker.io/v2/": context deadline exceeded`
+
+	// A Docker Hub ref (no registry host) that the mirror inventory does not
+	// hold, so `mirroredRef` returns null for it and mirror-only mode has
+	// nothing to serve. Deliberately not a real image: the point is the
+	// decision, and a name nobody can mirror cannot drift into the inventory.
+	unmirroredRef = "cerberus-test/not-in-the-mirror:1"
+)
+
+// dockerCall is one line of the stub's log: the verb and what it was aimed at.
+type dockerCall struct{ verb, target string }
+
+// writeStubDockerHubOutage drops a `docker` onto dir that behaves exactly as a
+// runner would during a Docker Hub outage with a healthy GHCR:
+//
+//	login <anything>   fails with the /v2/ handshake timeout, always.
+//	pull ghcr.io/...   succeeds — the mirror is up, which is the whole premise.
+//	pull <upstream>    fails the same way, and is RECORDED. Recording the
+//	                   attempt is the point: the property under test is that the
+//	                   attempt is never made, and an assertion about something
+//	                   not happening is worthless unless the harness would have
+//	                   seen it happen.
+//	tag / image        succeed / report nothing local.
+func writeStubDockerHubOutage(t *testing.T, dir, callLog string) {
+	t.Helper()
+
+	script := strings.Join([]string{
+		"#!/bin/sh",
+		"log=" + shellQuote(callLog),
+		"case \"$1\" in",
+		"  login)",
+		// The password arrives on stdin (`--password-stdin`), and a real
+		// `docker login` reads it before answering. Draining it is not cosmetic:
+		// a stub that exits first makes the parent's write race the child's
+		// death, and the EPIPE that sometimes results is classified `fatal`
+		// rather than `transient` — so the test intermittently measured a
+		// completely different code path from the one it names.
+		"    cat > /dev/null",
+		"    echo " + shellQuote("login") + " >> \"$log\"",
+		"    echo " + shellQuote(handshakeTimeout) + " >&2",
+		"    exit 1",
+		"    ;;",
+		"  pull)",
+		"    case \"$2\" in",
+		"      " + mirrorRegistryPrefix + "*)",
+		"        echo \"mirror $2\" >> \"$log\"",
+		"        exit 0",
+		"        ;;",
+		"    esac",
+		"    echo \"hub $2\" >> \"$log\"",
+		"    echo " + shellQuote(handshakeTimeout) + " >&2",
+		"    exit 1",
+		"    ;;",
+		"  tag)",
+		"    echo \"tag $3\" >> \"$log\"",
+		"    exit 0",
+		"    ;;",
+		"  image)",
+		// Nothing is cached locally, so an acquisition can only come from a
+		// registry — otherwise `acceptLocalCopy` callers would pass for the
+		// wrong reason.
+		"    exit 1",
+		"    ;;",
+		"esac",
+		"echo \"stub: unexpected docker $*\" >&2",
+		"exit 2",
+		"",
+	}, "\n")
+
+	path := filepath.Join(dir, "docker")
+	if err := os.WriteFile(path, []byte(script), 0o755); err != nil {
+		t.Fatalf("write stub docker: %v", err)
+	}
+}
+
+// readStubCalls parses the stub's log. A missing file means no call was made,
+// which is a legitimate answer rather than an error.
+func readStubCalls(t *testing.T, callLog string) []dockerCall {
+	t.Helper()
+
+	buf, err := os.ReadFile(callLog)
+	if os.IsNotExist(err) {
+		return nil
+	}
+	if err != nil {
+		t.Fatalf("read stub call log: %v", err)
+	}
+	var calls []dockerCall
+	for _, line := range strings.Split(strings.TrimSpace(string(buf)), "\n") {
+		if line == "" {
+			continue
+		}
+		verb, target, _ := strings.Cut(line, " ")
+		calls = append(calls, dockerCall{verb: verb, target: target})
+	}
+	return calls
+}
+
+func callsWithVerb(calls []dockerCall, verb string) []string {
+	var out []string
+	for _, c := range calls {
+		if c.verb == verb {
+			out = append(out, c.target)
+		}
+	}
+	sort.Strings(out)
+	return out
+}
+
+// runNode runs one of the repository's scripts against the stub PATH and returns
+// its exit status and combined output.
+func runNode(t *testing.T, module, stubDir string, env []string, args ...string) (int, string) {
+	t.Helper()
+
+	cmd := exec.Command("node", append([]string{module}, args...)...)
+	cmd.Env = append(
+		os.Environ(),
+		"PATH="+stubDir+string(os.PathListSeparator)+os.Getenv("PATH"),
+		// Zero backoff: the retry budget is what is under test, not the wait.
+		"REGISTRY_LOGIN_BACKOFF_STEP_SECONDS=0",
+		"IMAGE_PULL_BACKOFF_SECONDS=0",
+	)
+	cmd.Env = append(cmd.Env, env...)
+	out, err := cmd.CombinedOutput()
+	status := 0
+	if err != nil {
+		exit, ok := err.(*exec.ExitError)
+		if !ok {
+			t.Fatalf("run %s: %v\noutput:\n%s", module, err, out)
+		}
+		status = exit.ExitCode()
+	}
+	return status, string(out)
+}
+
+// loginUnderOutage runs the Docker Hub login against the stub and returns its
+// status, its output, and whatever it exported through $GITHUB_ENV — the
+// runner's own channel, so the exported flag reaches the next step exactly as it
+// would in a job.
+func loginUnderOutage(t *testing.T, stubDir string, env ...string) (int, string, []string) {
+	t.Helper()
+
+	githubEnv := filepath.Join(t.TempDir(), "github_env")
+	if err := os.WriteFile(githubEnv, nil, 0o600); err != nil {
+		t.Fatalf("create GITHUB_ENV file: %v", err)
+	}
+	env = append(env, "GITHUB_ENV="+githubEnv, "USERNAME=cerberus-test", "PASSWORD=not-a-real-secret")
+	status, out := runNode(t, registryLoginModule, stubDir, env)
+
+	buf, err := os.ReadFile(githubEnv)
+	if err != nil {
+		t.Fatalf("read GITHUB_ENV file: %v", err)
+	}
+	var exported []string
+	for _, line := range strings.Split(strings.TrimSpace(string(buf)), "\n") {
+		if line != "" {
+			exported = append(exported, line)
+		}
+	}
+	return status, out, exported
+}
+
+// anyMirroredImage is one ref the mirror actually holds, read from the inventory
+// rather than named here so a bump cannot leave this test pinned to a ref the
+// mirror no longer carries.
+func anyMirroredImage(t *testing.T) string {
+	t.Helper()
+
+	var refs []string
+	for ref := range mirrorInventory(t) {
+		refs = append(refs, ref)
+	}
+	sort.Strings(refs)
+	return refs[0]
+}
+
+// TestMirrorOnlyJobCompletesWithDockerHubUnreachable is the property the mirror
+// was built for and nothing measured until now: with Docker Hub unreachable, a
+// job whose images are all mirrored runs to completion.
+//
+// Both steps are the real scripts and the flag travels between them through
+// $GITHUB_ENV, so this fails if either half stops honouring the mode OR if the
+// two halves stop agreeing on how it is spelled.
+func TestMirrorOnlyJobCompletesWithDockerHubUnreachable(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	callLog := filepath.Join(dir, "calls")
+	writeStubDockerHubOutage(t, dir, callLog)
+
+	status, out, exported := loginUnderOutage(t, dir)
+	if status != 0 {
+		t.Fatalf("the Docker Hub login failed the job (exit %d) instead of downgrading it to mirror-only.\n"+
+			"An unreachable Docker Hub is exactly what the GHCR mirror exists to survive.\noutput:\n%s", status, out)
+	}
+	if len(exported) != 1 || !strings.HasPrefix(exported[0], "CERBERUS_REGISTRY_MIRROR_ONLY=") {
+		t.Fatalf("the login exported %v through $GITHUB_ENV, want the mirror-only flag. Without it every "+
+			"later step in the job carries on as if Docker Hub were reachable.\noutput:\n%s", exported, out)
+	}
+
+	image := anyMirroredImage(t)
+	status, out = runNode(t, pullImagesModule, dir, exported, image)
+	if status != 0 {
+		t.Fatalf("acquiring the mirrored image %q failed (exit %d) although the mirror served it.\noutput:\n%s",
+			image, status, out)
+	}
+
+	calls := readStubCalls(t, callLog)
+	if got := callsWithVerb(calls, "tag"); len(got) != 1 || got[0] != image {
+		t.Errorf("the mirrored copy was tagged as %v, want exactly [%s] — the caller's postcondition is the "+
+			"image present under its UPSTREAM name", got, image)
+	}
+	if got := callsWithVerb(calls, "hub"); len(got) != 0 {
+		t.Errorf("the job reached for Docker Hub (%v) while in mirror-only mode. That pull is anonymous — it "+
+			"is the silent degradation the mirror and the login gate both exist to remove.", got)
+	}
+}
+
+// TestMirrorOnlyFailsLoudlyRatherThanPullingAnonymously is the other half of the
+// same property, and the one that keeps it from being a tolerance: an image the
+// mirror cannot serve fails the job NAMING ITSELF, rather than quietly falling
+// through to the shared anonymous Docker Hub quota.
+func TestMirrorOnlyFailsLoudlyRatherThanPullingAnonymously(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	callLog := filepath.Join(dir, "calls")
+	writeStubDockerHubOutage(t, dir, callLog)
+
+	// The downgrade is this test's PREMISE, so it is asserted rather than
+	// assumed: a login that failed instead would leave `exported` empty, the
+	// pull would run in ordinary mode, and the test would go red for a reason
+	// that has nothing to do with what it is named after.
+	loginStatus, loginOut, exported := loginUnderOutage(t, dir)
+	if loginStatus != 0 || len(exported) != 1 {
+		t.Fatalf("the login exited %d exporting %v, so this test never reached mirror-only mode.\noutput:\n%s",
+			loginStatus, exported, loginOut)
+	}
+
+	status, out := runNode(t, pullImagesModule, dir, exported, unmirroredRef)
+	if status == 0 {
+		t.Fatalf("acquiring %q succeeded although the mirror does not hold it and Docker Hub is unreachable.\n"+
+			"output:\n%s", unmirroredRef, out)
+	}
+	if !strings.Contains(out, unmirroredRef) {
+		t.Errorf("the failure never named %q, so a reader cannot tell which image to mirror.\noutput:\n%s",
+			unmirroredRef, out)
+	}
+	if got := callsWithVerb(readStubCalls(t, callLog), "hub"); len(got) != 0 {
+		t.Errorf("mirror-only mode reached for Docker Hub anyway (%v) — the fallback must be REMOVED in this "+
+			"mode, not merely deprioritised.", got)
+	}
+}
+
+// TestWithoutTheDowngradeTheSameImageIsPulledFromDockerHub is the non-vacuity
+// control for both tests above. Their central assertion is that something did
+// NOT happen, which passes just as well against a stub nothing ever calls or a
+// module that crashed on startup. Here the ONLY difference is the absence of the
+// mirror-only flag, and the upstream pull the other tests forbid duly appears.
+func TestWithoutTheDowngradeTheSameImageIsPulledFromDockerHub(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	callLog := filepath.Join(dir, "calls")
+	writeStubDockerHubOutage(t, dir, callLog)
+
+	status, out := runNode(t, pullImagesModule, dir, nil, unmirroredRef)
+	if status == 0 {
+		t.Fatalf("the unmirrored image was acquired although Docker Hub is unreachable.\noutput:\n%s", out)
+	}
+	if got := callsWithVerb(readStubCalls(t, callLog), "hub"); len(got) == 0 {
+		t.Fatal("no Docker Hub pull was attempted even with mirror-only mode OFF — the stub is not observing " +
+			"the fallback at all, so the assertions that it does NOT happen prove nothing")
+	}
+}
+
+// TestOnlyDockerHubDowngrades pins the two boundaries that keep the downgrade
+// from becoming a general "carry on regardless".
+//
+// A ghcr.io login that cannot reach ghcr.io has nothing to fall back to —
+// mirror-only mode there would mean acquiring everything from the registry that
+// just failed. And a step that publishes to Docker Hub (`release.yml`) or reads
+// its inventory from it (`mirror-images.yml`) says `ON_TRANSPORT_FAULT: fail`,
+// because for those two Docker Hub is the work rather than a source a mirror can
+// stand in for.
+func TestOnlyDockerHubDowngrades(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name string
+		env  []string
+	}{
+		{name: "a login to the mirror itself", env: []string{"REGISTRY=ghcr.io"}},
+		{name: "a step that opted out", env: []string{"ON_TRANSPORT_FAULT=fail"}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			dir := t.TempDir()
+			writeStubDockerHubOutage(t, dir, filepath.Join(dir, "calls"))
+
+			status, out, exported := loginUnderOutage(t, dir, tc.env...)
+			if status == 0 {
+				t.Errorf("the login exited 0 for %s, so the job carries on without a registry no mirror can "+
+					"substitute for.\noutput:\n%s", tc.name, out)
+			}
+			if len(exported) != 0 {
+				t.Errorf("the login exported %v for %s; nothing may be exported when there is no downgrade",
+					exported, tc.name)
+			}
+		})
+	}
+}

--- a/test/regression/mirror_only_downgrade_test.go
+++ b/test/regression/mirror_only_downgrade_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"regexp"
 	"sort"
 	"strings"
 	"testing"
@@ -49,6 +50,17 @@ const (
 	// nothing to serve. Deliberately not a real image: the point is the
 	// decision, and a name nobody can mirror cannot drift into the inventory.
 	unmirroredRef = "cerberus-test/not-in-the-mirror:1"
+
+	// A ref on a registry Docker Hub does not meter, which the inventory also
+	// does not hold — and deliberately never will, because mirroring a registry
+	// that is not rate-limited would add a hop and a staleness window for no
+	// gain (see lib/mirror.mjs). `mirroredRef` returns null for it exactly as it
+	// does for `unmirroredRef`, which is why keying mirror-only mode off that
+	// null is wrong: the two refs need OPPOSITE answers.
+	//
+	// The real thing, not a placeholder: `E2E_EXTERNAL_IMAGES` in the Justfile
+	// names it, so the k3d lanes acquire it on every run.
+	unmeteredRef = "ghcr.io/open-telemetry/opentelemetry-collector-contrib/telemetrygen:v0.116.0"
 )
 
 // dockerCall is one line of the stub's log: the verb and what it was aimed at.
@@ -57,14 +69,17 @@ type dockerCall struct{ verb, target string }
 // writeStubDockerHubOutage drops a `docker` onto dir that behaves exactly as a
 // runner would during a Docker Hub outage with a healthy GHCR:
 //
-//	login <anything>   fails with the /v2/ handshake timeout, always.
-//	pull ghcr.io/...   succeeds — the mirror is up, which is the whole premise.
-//	pull <upstream>    fails the same way, and is RECORDED. Recording the
-//	                   attempt is the point: the property under test is that the
-//	                   attempt is never made, and an assertion about something
-//	                   not happening is worthless unless the harness would have
-//	                   seen it happen.
-//	tag / image        succeed / report nothing local.
+//	login <anything>     fails with the /v2/ handshake timeout, always.
+//	pull <mirror ns>/... succeeds — the mirror is up, which is the whole premise.
+//	pull <other ghcr>    succeeds, recorded as `direct`. A ref on a registry
+//	                     Docker Hub does not meter is reached over a path this
+//	                     outage cannot touch, so it must still be acquired.
+//	pull <docker hub>    fails the same way, and is recorded as `hub`. Recording
+//	                     the attempt is the point: the property under test is
+//	                     that the attempt is never made, and an assertion about
+//	                     something not happening is worthless unless the harness
+//	                     would have seen it happen.
+//	tag / image          succeed / report nothing local.
 func writeStubDockerHubOutage(t *testing.T, dir, callLog string) {
 	t.Helper()
 
@@ -86,8 +101,12 @@ func writeStubDockerHubOutage(t *testing.T, dir, callLog string) {
 		"    ;;",
 		"  pull)",
 		"    case \"$2\" in",
-		"      " + mirrorRegistryPrefix + "*)",
+		"      " + mirrorNamespace(t) + "/*)",
 		"        echo \"mirror $2\" >> \"$log\"",
+		"        exit 0",
+		"        ;;",
+		"      " + mirrorRegistryPrefix + "*)",
+		"        echo \"direct $2\" >> \"$log\"",
 		"        exit 0",
 		"        ;;",
 		"    esac",
@@ -204,6 +223,29 @@ func loginUnderOutage(t *testing.T, stubDir string, env ...string) (int, string,
 	return status, out, exported
 }
 
+// mirrorNamespaceLiteral isolates `mirrorRegistry`'s default in lib/mirror.mjs.
+var mirrorNamespaceLiteral = regexp.MustCompile(`\|\|\s*'(ghcr\.io/[^']+)'`)
+
+// mirrorNamespace is the GHCR namespace mirrored copies live under, read from
+// the module rather than restated here. The stub has to tell a pull of a
+// MIRRORED copy from a pull of some other ghcr.io image, and a hardcoded
+// namespace would silently stop distinguishing them if the mirror ever moved —
+// leaving the test green while measuring nothing.
+func mirrorNamespace(t *testing.T) string {
+	t.Helper()
+
+	src, err := os.ReadFile(mirrorModule)
+	if err != nil {
+		t.Fatalf("read %s: %v", mirrorModule, err)
+	}
+	m := mirrorNamespaceLiteral.FindStringSubmatch(string(src))
+	if m == nil {
+		t.Fatalf("%s no longer states a default `mirrorRegistry` — the stub cannot tell a mirrored pull "+
+			"from any other ghcr.io pull", mirrorModule)
+	}
+	return m[1]
+}
+
 // anyMirroredImage is one ref the mirror actually holds, read from the inventory
 // rather than named here so a bump cannot leave this test pinned to a ref the
 // mirror no longer carries.
@@ -225,6 +267,14 @@ func anyMirroredImage(t *testing.T) string {
 // Both steps are the real scripts and the flag travels between them through
 // $GITHUB_ENV, so this fails if either half stops honouring the mode OR if the
 // two halves stop agreeing on how it is spelled.
+//
+// What DISCRIMINATES here is the login half: without the downgrade it exits 1
+// and the job is over, which is issue #1933 exactly. The pull half is the
+// unchanged-behaviour leg on purpose — an inventoried image is served by
+// `acquireFromMirror` before the mode is ever consulted, so it must look
+// identical in both modes, and the assertions below say so rather than claiming
+// to exercise the mode. The pull-side behaviour that only mirror-only mode
+// produces is pinned by the two tests that follow.
 func TestMirrorOnlyJobCompletesWithDockerHubUnreachable(t *testing.T) {
 	t.Parallel()
 
@@ -293,6 +343,46 @@ func TestMirrorOnlyFailsLoudlyRatherThanPullingAnonymously(t *testing.T) {
 	if got := callsWithVerb(readStubCalls(t, callLog), "hub"); len(got) != 0 {
 		t.Errorf("mirror-only mode reached for Docker Hub anyway (%v) — the fallback must be REMOVED in this "+
 			"mode, not merely deprioritised.", got)
+	}
+}
+
+// TestMirrorOnlyStillAcquiresImagesDockerHubNeverServed is the boundary that
+// keeps the mode proportionate to the outage that caused it.
+//
+// Mirror-only mode exists because DOCKER HUB is unreachable. A ref naming any
+// other registry is fetched over a path the outage does not touch, on
+// credentials the job already holds, so it must be acquired exactly as always.
+// Refusing it would take down the lanes this mode is meant to save: the k3d e2e
+// jobs acquire `telemetrygen` from ghcr.io on every run, and the migration tiers
+// extract their binary from a `ghcr.io/tsouza/cerberus` release image.
+//
+// The bug this pins is a one-token one. `mirroredRef` returns null both for "the
+// mirror has no copy of this" and for "this never needed one", so keying the
+// refusal off that null reads the second as the first and fails an acquisition
+// that was never in danger — with a message prescribing a fix (add it to
+// `mirroredImages`) that cannot work for such a ref.
+func TestMirrorOnlyStillAcquiresImagesDockerHubNeverServed(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	callLog := filepath.Join(dir, "calls")
+	writeStubDockerHubOutage(t, dir, callLog)
+
+	loginStatus, loginOut, exported := loginUnderOutage(t, dir)
+	if loginStatus != 0 || len(exported) != 1 {
+		t.Fatalf("the login exited %d exporting %v, so this test never reached mirror-only mode.\noutput:\n%s",
+			loginStatus, exported, loginOut)
+	}
+
+	status, out := runNode(t, pullImagesModule, dir, exported, unmeteredRef)
+	if status != 0 {
+		t.Fatalf("mirror-only mode refused %q (exit %d), a ref Docker Hub does not serve and its outage cannot "+
+			"reach. The mode must constrain Docker Hub acquisitions, not every acquisition.\noutput:\n%s",
+			unmeteredRef, status, out)
+	}
+	if got := callsWithVerb(readStubCalls(t, callLog), "direct"); len(got) != 1 || got[0] != unmeteredRef {
+		t.Errorf("the unmetered ref was acquired as %v, want exactly [%s] — it must be pulled from its own "+
+			"registry rather than looked for in the mirror", got, unmeteredRef)
 	}
 }
 


### PR DESCRIPTION
Every image-acquiring job authenticated its **fallback** registry before its **primary** one. Each login is a hard gate, so an unreachable Docker Hub took down lanes whose every image was sitting in a GHCR mirror that had never been contacted — `compatibility/promql-surface` went red on run 31148765992 without issuing a single query.

`continue-on-error: true` on the login step is the cheap version and would be a regression: an unauthenticated job does not fail, it degrades to the shared **anonymous** Docker Hub quota and reads as flake on the day that quota runs out. That is the failure `assert-image-jobs-authenticate.mjs`'s R2/R3 exist to make impossible.

## Order

The `ghcr.io` login now runs first in 17 of the repo's 18 login pairs — `compatibility.yml`, `e2e.yml`, `migration-e2e.yml`, `schema-integration.yml`, `strict-scan.yml` and `mirror-images.yml`; `release.yml`'s pair was already GHCR-first. Presence was already asserted; order was not, and order is what decides whether an outage is survivable — so the gate grows **R5**, and its negative control swaps the pair back in the real workflow text and asserts the gate goes red for the ordering alone (both logins still present, no presence rule firing).

The gate's own log now prints logins in step order (`ghcr.io then docker.io`) rather than sorted, since a sorted line reads identically for a passing and a failing job.

## Mirror-only mode

A Docker Hub login that exhausts its retries on a `transient` verdict exports `CERBERUS_REGISTRY_MIRROR_ONLY=1` through `$GITHUB_ENV` and exits 0. In that mode `pullImageWithRetry` **removes** the Docker Hub fallback rather than deprioritising it: a Docker Hub ref the mirror cannot serve is a hard error naming the image, and `buildBaseImageRef` returns `null` so a build is never started against a `FROM` that cannot resolve.

The mode constrains **Docker Hub acquisitions only**. A ref on a registry Docker Hub does not meter — `ghcr.io/open-telemetry/…/telemetrygen`, the released `ghcr.io/tsouza/cerberus` image the migration tiers extract a binary from, `gcr.io/distroless/*` — is reached over a path the outage cannot touch, on credentials the job already holds, so it is acquired exactly as always. That distinction is one token wide and was wrong in the first commit: `mirroredRef` returns `null` both for "the mirror has no copy of this" and for "this never needed one", and reading the second as the first refused images that were never in danger, with a message prescribing a fix that cannot work.

Three boundaries keep the mode a narrowing rather than a tolerance:

- only a `transient` verdict downgrades — a quota refusal and a rejected credential still fail on the first attempt;
- only Docker Hub downgrades — a mirror that is unreachable cannot stand in for itself, and `ON_TRANSPORT_FAULT: mirror-only` on any other registry is rejected as a misconfiguration;
- a job that **produces** into a registry opts out with `ON_TRANSPORT_FAULT: fail`. An unrecognised value exits rather than silently taking the permissive branch, so a typo cannot re-enable the downgrade on exactly the jobs that spelled it out to switch it off.

**R6** pins that last boundary in both directions, keyed on registry **write** permission rather than on a job name — that permission is what separates a producer from a consumer. A producer that lost its opt-out fails the gate (a Docker Hub outage would otherwise let goreleaser publish its GHCR half and fail its Docker Hub half), and so does a consumer that gained one (which is #1933 reintroduced one line at a time). Both are silent failures, so both get a negative control.

The precondition that makes mirror-only viable for consuming jobs is already gated: `TestMirrorInventoryCoversEveryUpstreamImage` fails when the tree names an upstream image the inventory omits, and R4 requires every compose model to be pre-pulled through the shared policy rather than by `compose up` itself.

## The property nothing measured before

`test/regression/mirror_only_downgrade_test.go` drives the real `registry-login.mjs` and `pull-images.mjs` **in sequence** against a stub `docker` that answers every Docker Hub call with the outage's own error text, passing the flag between them through `$GITHUB_ENV` exactly as the runner does — so a rename on one side and not the other fails the test rather than being restated in prose.

- a job whose images are all mirrored **completes** with Docker Hub unreachable;
- a Docker Hub image the mirror cannot serve **fails loudly naming itself**, with no Docker Hub attempt;
- an image on a registry Docker Hub never served is **still acquired** — this one goes red on the first commit of this PR;
- a control test pins that the forbidden pull **is** observable when the mode is off, so the negative assertions are not vacuous;
- the two boundaries (a ghcr.io login, an opted-out step) still fail as before.

Also folds `migration-artifact.mjs`'s private `$GITHUB_ENV` writer into a shared `exportEnv` in `lib/gh.mjs` rather than adding a second copy beside it, and exports `isDockerHubRef` from `lib/mirror.mjs` so "is this ref metered by Docker Hub" has one answer instead of two.

## Verification

`assert-image-jobs-authenticate.mjs` reports 19/19 acquiring jobs as `ghcr.io then docker.io` with R5 and R6 active; login-step counts per workflow are identical to `HEAD` (nothing dropped or duplicated); `just lint-actions`, `doc-refs`, `doc-counts`, `repo-hygiene` (all three checks), `forbid-skip`, markdownlint, the full `test/regression` package under `-race`, and every touched `node --test` suite are green locally. Each new gate rule and each new mirror-only assertion was additionally run against the pre-fix code to confirm it goes red.

Closes #1933
