### PR TITLE
perf(chclient): decline the columnar decode before dispatch on a declared non-matrix shape

### DIFF
--- a/internal/chclient/columnar.go
+++ b/internal/chclient/columnar.go
@@ -89,6 +89,13 @@ var histogramMatrixColumns = [...]string{
 // string) is treated as "unknown, defer to the structural test" so this gate
 // can be adopted incrementally without silently disabling the columnar
 // decode for not-yet-migrated callers.
+//
+// Because it is a statement of caller INTENT rather than an observation of the
+// result, it is readable before the dial: queryCursorColumnar declines on a
+// declared non-matrix shape BEFORE acquirePool, so the fallback costs one
+// physical execution rather than two (#2043). bindColumns re-checks it on the
+// first result block, which is where a caller whose ctx never reached this
+// package still gets the structural test.
 const ResponseShapeMatrix = "prom-matrix"
 
 // responseShapeCtxKey is the context key WithResponseShape and
@@ -219,6 +226,22 @@ func chPoolOptions(cfg Config) chpool.Options {
 // with err nil. A non-nil err is a real failure already classified + recorded
 // against the breaker, exactly as the row path's QueryCursor open failure.
 func (d columnarDecoder) queryCursorColumnar(c *Client, ctx context.Context, sql string, args ...any) (Cursor, bool, error) {
+	// A caller that has DECLARED a non-matrix ResponseShape has already told us
+	// this query is not the prom query_range matrix, and it said so on the ctx —
+	// before any dial. Decline here, where the verdict is free, rather than in
+	// bindColumns, where the identical verdict arrives only after pool.Do has
+	// run the query to its first result block: the row fallback then re-dispatches
+	// it in full under a fresh query_id, so a late decline costs TWO physical
+	// executions for every LogQL / Tempo query an operator who opted into
+	// columnar_result_decode runs (#2043). An absent shape ("") stays "unknown,
+	// defer to the structural test", exactly as bindColumns treats it, so a
+	// not-yet-threaded caller is unaffected. bindColumns keeps this same check as
+	// the defense-in-depth it was added as (#1429); this only stops the dispatch
+	// its verdict was always going to waste.
+	if shape := ResponseShapeFromContext(ctx); shape != "" && shape != ResponseShapeMatrix {
+		return nil, false, nil
+	}
+
 	// Bind the positional `?` args into the raw SQL body ch-go sends. An
 	// unbindable arg type (outside the matrix path's closed string/int/float
 	// set) defers to the row path BEFORE any dial or breaker touch — the

--- a/internal/chclient/columnar_early_decline_test.go
+++ b/internal/chclient/columnar_early_decline_test.go
@@ -1,0 +1,174 @@
+package chclient
+
+import (
+	"context"
+	"net"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/ClickHouse/clickhouse-go/v2/lib/driver"
+)
+
+// columnar_early_decline_test.go — the dispatch-count pin for #2043.
+//
+// The columnar matrix decode declines every non-matrix shape, and a decline
+// routes the query down the row path under a FRESH query_id — a second
+// physical execution. The caller-declared ResponseShape is on the ctx before
+// any dial, so a declared non-matrix shape must be declined BEFORE the ch-go
+// pool is touched: the fallback then costs one execution, not two.
+//
+// These tests count both dispatch surfaces independently — the row path's
+// driver.Conn.Query calls and the columnar path's TCP connections to the
+// (fake) ClickHouse address — so "exactly one dispatch" is asserted as a
+// behaviour rather than inferred from control flow.
+
+// earlyDeclineFixtureRows is the row count the fake row-path conn answers
+// with: enough to prove the fallback cursor actually decoded the result set,
+// small enough to drain inline.
+const earlyDeclineFixtureRows = 3
+
+// countingConn is a driver.Conn fake that counts row-path dispatches — one
+// per Query call — and answers each with a fixed-size generated result set.
+type countingConn struct {
+	chaosConn
+	queries atomic.Int64
+}
+
+func (c *countingConn) Query(context.Context, string, ...any) (driver.Rows, error) {
+	c.queries.Add(1)
+	return newGenRows(earlyDeclineFixtureRows), nil
+}
+
+// dialCounter is a TCP listener standing in for the ClickHouse address the
+// columnar ch-go pool dials. It counts every accepted connection and closes
+// it immediately: the columnar path's handshake then fails, but the count has
+// already recorded that a dispatch was attempted — which is the whole point.
+type dialCounter struct {
+	ln    net.Listener
+	dials atomic.Int64
+}
+
+func newDialCounter(t *testing.T) *dialCounter {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	d := &dialCounter{ln: ln}
+	go func() {
+		for {
+			conn, err := ln.Accept()
+			if err != nil {
+				return
+			}
+			d.dials.Add(1)
+			_ = conn.Close()
+		}
+	}()
+	t.Cleanup(func() { _ = ln.Close() })
+	return d
+}
+
+func (d *dialCounter) addr() string { return d.ln.Addr().String() }
+
+// newCountingColumnarClient wires a Client whose decode strategy is the
+// columnar one — row fallback on a counting driver.Conn, columnar pool
+// pointed at the counting listener — so a test can attribute every dispatch
+// to exactly one of the two paths.
+func newCountingColumnarClient(t *testing.T, dc *dialCounter) (*Client, *countingConn, columnarDecoder) {
+	t.Helper()
+	conn := &countingConn{}
+	client := newWithConn(conn)
+	dec := columnarDecoder{
+		matrix: newColumnarMatrixDecoder(Config{
+			Addr:        dc.addr(),
+			DialTimeout: columnarEarlyDeclineDialTimeout,
+		}),
+		fallback: rowDecoder{},
+	}
+	client.cursorDecoder = dec
+	t.Cleanup(dec.close)
+	return client, conn, dec
+}
+
+// columnarEarlyDeclineDialTimeout bounds the positive control's dial against
+// a listener that answers no ClickHouse handshake, so a failed dial fails the
+// test quickly instead of parking on the platform default.
+const columnarEarlyDeclineDialTimeout = 2 * time.Second
+
+// TestColumnarDecode_NonMatrixShapeDispatchesExactlyOnce is the #2043
+// regression pin: a query whose caller declared a non-matrix ResponseShape
+// (here Loki's log-stream shape) must reach ClickHouse EXACTLY ONCE, on the
+// row path. Before the fix the columnar path dispatched first and only then
+// consulted the declared shape in bindColumns, so the same query executed
+// twice — once columnar, once again under a fresh query_id on the fallback.
+func TestColumnarDecode_NonMatrixShapeDispatchesExactlyOnce(t *testing.T) {
+	t.Parallel()
+
+	dc := newDialCounter(t)
+	client, conn, dec := newCountingColumnarClient(t, dc)
+
+	ctx := WithResponseShape(context.Background(), "loki-streams")
+	cursor, err := client.QueryCursor(ctx, "SELECT Line, Attributes, TimeUnix, Metadata FROM logs")
+	// The dial count is read first so a regression reports the defect (a
+	// dispatch the declared shape had already ruled out) rather than the
+	// transport error that dispatch happens to surface.
+	if got := dc.dials.Load(); got != 0 {
+		t.Fatalf("columnar path opened %d connection(s) to ClickHouse for a declared non-matrix shape, want 0 — the ResponseShape gate is being evaluated AFTER the dispatch it was meant to prevent (#2043)", got)
+	}
+	if err != nil {
+		t.Fatalf("QueryCursor: %v", err)
+	}
+	defer func() { _ = cursor.Close() }()
+
+	// The row fallback still answers the query correctly — the fix removes a
+	// wasted execution, it does not change the result.
+	drained := 0
+	for cursor.Next() {
+		if got := cursor.Sample().MetricName; got != "up" {
+			t.Fatalf("row-fallback Sample().MetricName = %q, want %q", got, "up")
+		}
+		drained++
+	}
+	if err := cursor.Err(); err != nil {
+		t.Fatalf("cursor.Err: %v", err)
+	}
+	if drained != earlyDeclineFixtureRows {
+		t.Fatalf("row fallback drained %d rows, want %d", drained, earlyDeclineFixtureRows)
+	}
+
+	if got := conn.queries.Load(); got != 1 {
+		t.Fatalf("row path dispatched %d quer(ies), want exactly 1", got)
+	}
+	if dec.matrix.pool != nil {
+		t.Fatal("columnar ch-go pool was acquired for a declared non-matrix shape — the decline must happen before acquirePool")
+	}
+}
+
+// TestColumnarDecode_MatrixShapeStillDispatchesColumnar is the positive
+// control for the counter above: with the matrix ResponseShape declared, the
+// columnar path DOES engage and dial, so the zero-dial assertion in the
+// non-matrix test is a real observation and not a harness that can never see
+// a columnar dispatch at all. The dial's handshake fails (the listener speaks
+// no ClickHouse protocol) — the dispatch attempt is what is being pinned.
+func TestColumnarDecode_MatrixShapeStillDispatchesColumnar(t *testing.T) {
+	t.Parallel()
+
+	dc := newDialCounter(t)
+	client, _, _ := newCountingColumnarClient(t, dc)
+
+	ctx, cancel := context.WithTimeout(context.Background(), columnarEarlyDeclineDialTimeout)
+	defer cancel()
+	ctx = WithResponseShape(ctx, ResponseShapeMatrix)
+	cursor, err := client.QueryCursor(ctx, "SELECT MetricName, Attributes, TimeUnix, Value FROM metrics")
+	if cursor != nil {
+		_ = cursor.Close()
+	}
+	if err == nil {
+		t.Fatal("QueryCursor against a listener that speaks no ClickHouse protocol returned no error")
+	}
+	if got := dc.dials.Load(); got < 1 {
+		t.Fatalf("columnar path opened %d connection(s) for the declared matrix shape, want at least 1 — the harness cannot observe a columnar dispatch, so the non-matrix zero-dial assertion would be vacuous", got)
+	}
+}

--- a/internal/chclient/decoder.go
+++ b/internal/chclient/decoder.go
@@ -156,6 +156,12 @@ type columnarDecoder struct {
 // physical execution re-keys, so the corpus reconciler's join key still matches
 // the primary attempt's terminal query_log row, and cancellation (ctx-based)
 // is unaffected by the id string.
+//
+// When the columnar attempt declined BEFORE dispatching — the declared
+// non-matrix ResponseShape gate at the top of queryCursorColumnar (#2043) —
+// there is no in-flight query to collide with and the re-key is merely
+// redundant, never wrong: the row path is then this query's one and only
+// physical execution, under an id nothing else has used.
 func (d columnarDecoder) decode(c *Client, ctx context.Context, sql string, args ...any) (Cursor, error) {
 	cur, ok, err := d.queryCursorColumnar(c, ctx, sql, args...)
 	if err != nil {


### PR DESCRIPTION
## What

`columnarDecoder` knew a query was not the prom `query_range` matrix *before* it dialled, but only acted on that knowledge *after* it had already dispatched: the caller-declared `ResponseShape` was read off the ctx at `columnarCursor` construction time, `pool.Do` ran the query, and only then did `bindColumns` decline on the first result block. The decline routes the query down the row path under a fresh `query_id` — a second physical execution.

`internal/engine/engine.go` threads `chclient.WithResponseShape(execCtx, meta.ResponseShape)` on every engine-driven query, so `loki-streams`, `loki-matrix` and the Tempo shapes all declined, and each one paid a full wasted dispatch first.

This adds the early decline at the top of `queryCursorColumnar`, mirroring the `bindArgs` early return directly below it: an explicitly declared shape that is not `ResponseShapeMatrix` returns to the row path **before** `acquirePool` / `pool.Do`. An absent shape (`""`) still means "unknown, defer to the structural test", so a not-yet-threaded caller is unaffected.

The `bindColumns` check is **unchanged** and stays exactly as the defence-in-depth it was added as (#1429) — the diff on `columnar.go` is 23 insertions and zero deletions.

## Why it is safe

No wrong answers either way: the row fallback returns the correct result. Blast radius is bounded to operators who opted into `columnar_result_decode` (the one `chopt` feature `auto` deliberately skips). For them, this halves the physical executions of every LogQL and Tempo query.

## Verification

`internal/chclient/columnar_early_decline_test.go` counts both dispatch surfaces independently — the row path's `driver.Conn.Query` calls (a counting `driver.Conn` fake via the existing `newWithConn` seam) and the columnar path's TCP connections to the address its ch-go pool dials (a counting listener). With a `loki-streams` ctx it asserts **zero** columnar dials, **exactly one** row dispatch, an un-acquired columnar pool, and a fully-decoded fallback result set. Reverting the fix locally makes it fail with `columnar path opened 1 connection(s) to ClickHouse for a declared non-matrix shape, want 0`.

A positive control (`TestColumnarDecode_MatrixShapeStillDispatchesColumnar`) asserts the matrix shape *does* dial the counting listener, so the zero-dial assertion cannot degrade into a harness that could never observe a columnar dispatch at all.

`go test -race ./internal/chclient/` passes.

Closes #2043

🤖 Generated with [Claude Code](https://claude.com/claude-code)