### PR TITLE
ci(codeql): exclude non-production Go binaries from extraction

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -1,0 +1,30 @@
+# CodeQL analysis scope for cerberus.
+#
+# paths-ignore removes files from EXTRACTION, not just from result reporting —
+# an ignored file can never appear as a source, sink, or intermediate step in
+# any query, in any language. This is deliberately narrower than "exclude
+# everything under test/" or "exclude everything under compatibility/": it
+# targets only the standalone Go binaries that never link into cmd/cerberus
+# (test-harness servers, differential-compliance testers, corpus seeders).
+# Table-driven _test.go files, Playwright specs, and .github/scripts/*.mjs
+# stay in scope — they are real CI-facing code, not synthetic fixtures.
+#
+# Why this exists: alerts #121/#122 (go/reflected-xss, dismissed 2026-08-13)
+# were a false flow between a standalone package-main test binary under
+# test/e2e/ and unrelated production middleware in cmd/cerberus's own build —
+# two binaries with no shared call graph, merged only because CodeQL's Go
+# whole-database analysis matches sources/sinks by interface satisfaction
+# (io.Writer) rather than real reachability across separate binaries. See
+# project memory project_codeql_xss_cross_binary_fp for the full trace.
+name: "cerberus CodeQL config"
+
+queries:
+  - uses: security-and-quality
+
+paths-ignore:
+  # Differential-compliance testers, corpus seeders, and other Go tooling
+  # under compatibility/ — CI-only, never built into cmd/cerberus.
+  - compatibility/**/*.go
+  # e2e/migration test-harness binaries (seeders, scenario drivers, the
+  # dead-end-receiver webhook sink) — CI-only, never built into cmd/cerberus.
+  - test/e2e/**/*.go

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -78,8 +78,11 @@ jobs:
         uses: github/codeql-action/init@v4
         with:
           languages: ${{ matrix.language }}
-          # Default query suite mirrors what default setup was running.
-          queries: security-and-quality
+          # config-file carries both the query suite (still security-and-quality,
+          # matching what default setup ran) and paths-ignore, which excludes
+          # standalone non-production Go binaries from extraction — see the
+          # config file's own header comment for why.
+          config-file: ./.github/codeql/codeql-config.yml
 
       - name: Autobuild
         uses: github/codeql-action/autobuild@v4


### PR DESCRIPTION
## Summary

- Adds `.github/codeql/codeql-config.yml` with `paths-ignore: [compatibility/**/*.go, test/e2e/**/*.go]`, and points `codeql.yml`'s init step at it via `config-file`.
- `paths-ignore` removes files from CodeQL **extraction**, not just result reporting — an excluded file can never appear as a source, sink, or intermediate step in any query.

## Why

Alerts #121/#122 (`go/reflected-xss`, dismissed 2026-08-13) were a false flow between `test/e2e/migration/tiers/tier2-ruler/receiver/main.go` — a standalone `package main` test-harness webhook receiver that never links into `cmd/cerberus` — and unrelated production middleware. CodeQL's Go whole-database analysis merged the two purely via `io.Writer` interface satisfaction, not real cross-binary reachability.

`compatibility/**/*.go` and `test/e2e/**/*.go` hold exactly this class of code: standalone differential-compliance testers, corpus seeders, and scenario drivers that are CI-only and never reach the shipped binary. Excluding them removes this false-positive class at the root rather than dismissing each instance as it recurs. Table-driven `_test.go` files elsewhere, Playwright specs, and `.github/scripts/*.mjs` stay in scope — only these two non-production Go trees are excluded.

## Test plan

- [x] `just lint-actions` (actionlint) passes on the modified workflow
- [x] Confirmed `test/regression/merge_queue_test.go`'s `CodeQL` context assertions are unaffected (they check `merge_group` presence and the umbrella job name, not query/config-file content)
- [x] Confirmed no `.py` or non-`node_modules` `.mjs`/`.ts` files live under the excluded `**/*.go` globs, so the `javascript-typescript`/`python`/`actions` language matrix legs are unaffected
- [ ] CI's own `CodeQL` check on this PR is the real validation that the config is well-formed and the languages still analyze successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)