### PR TITLE
fix(test): close the chDB session at exit so -race chdb suites stop segfaulting

### DIFF
--- a/.go-arch-lint.yml
+++ b/.go-arch-lint.yml
@@ -34,6 +34,13 @@
 #     api-health      — readiness probe.
 #     schema-ddl      — OTel-CH DDL helpers (config consumes; isolated).
 #     chclienttest    — chclient test helpers.
+#     chdbsession     — process-exit half of libchdb's session lifecycle for
+#                       chdb-tagged TEST binaries. A test package's TestMain
+#                       closes the cached chdb-go session before os.Exit so
+#                       the C++ destructors `-race`'s racefini runs do not
+#                       tear a live embedded ClickHouse down (#1971). Depends
+#                       on nothing but chdb-go, and is a no-op leaf in the
+#                       default (non-chdb) build.
 #     chsqltest       — the chDB harness internal/chsql's round-trip tests
 #                       share: an isolated database per test plus the metric
 #                       seed-DDL renderer. Depends on nothing; it sits outside
@@ -151,6 +158,7 @@ components:
   # the CH driver. Declared explicitly with its own deps block instead.
   api-reqctx:     { in: api/reqctx }
   chclienttest:   { in: chclienttest }
+  chdbsession:    { in: chdbsession }
   chsqltest:      { in: chsqltest }
   sealedscan:     { in: sealedscan }
   testsql:        { in: testsql }
@@ -219,6 +227,7 @@ commonComponents:
   - api-health
   - api-info
   - chclienttest
+  - chdbsession
   - chsqltest
   - qlcommon
   - chopt

--- a/docs/test-strategy.md
+++ b/docs/test-strategy.md
@@ -306,6 +306,49 @@ does round-trip, so the marker cannot decay into a blanket exemption. No
 fixture currently needs it — the pinned chDB substrate clears every floor
 the corpus exercises.
 
+#### The chdb lane and the race detector
+
+Every chdb-tagged test binary loads libchdb.so — an embedded ClickHouse —
+with `dlopen`, and chdb-go caches ONE process-wide session for the life of
+the process. Its driver's `(*conn).Close` is a no-op, so `db.Close()` does
+not shut the native engine down; nothing on the Go side ever does.
+
+That asymmetry is invisible to a plain `go test`, because Go's `os.Exit`
+reaches the `exit_group` syscall directly and libchdb's C++ static
+destructors never run. It is NOT invisible under `-race`: `os.Exit` first
+calls `runtime_beforeExit` → `runtime.racefini` → `__tsan_fini`, which — per
+the Go runtime's own comment on `racefini` — "will run C atexit functions
+and C++ destructors". Those destructors then tore libchdb down while its
+engine was still live, and the process died with
+
+```text
+SIGSEGV: segmentation violation
+runtime.racefini()
+os.runtime_beforeExit(0x0)
+os.Exit(0x0)
+```
+
+at a constant offset inside `libchdb.so`, **after** every test in the binary
+had already passed — turning a suite in which nothing failed into a failed
+lane. `os.Exit(0x0)` in that trace is the tell: the exit code was zero.
+
+`internal/chdbsession.CloseForExit` closes the cached session before the
+binary exits, so those destructors run against an already-shut-down engine.
+It is per-package by necessity — `TestMain` is the only process-exit seam Go
+offers and it is declared per package — so
+`test/regression/chdb_race_exit_test.go` is the ratchet: it walks the tree
+for chdb-tagged test files and fails any package whose `TestMain` does not
+call it. Without that gate a newly added chdb-tagged package would silently
+reintroduce the crash.
+
+The `chdb` CI job still runs without `-race`, for cost rather than
+correctness. Measured over the four `internal/api` packages, `-race` costs
+between 1.5x (`prom`, 131s → 201s — it is already the long pole) and 5x
+(`tempo/grpc`, 0.4s → 2.1s) in wall clock. The difference now is that a
+developer or agent CAN run
+`go test -race -tags chdb ./...` to chase a suspected data race in
+chdb-tagged code, which before was structurally impossible.
+
 ### Layer 6d — Function-surface parity ledger
 
 Layers 6a-c prove that an *accepted* query returns the right rows. Layer

--- a/internal/api/loki/testmain_test.go
+++ b/internal/api/loki/testmain_test.go
@@ -1,0 +1,19 @@
+package loki_test
+
+import (
+	"os"
+	"testing"
+
+	"github.com/tsouza/cerberus/internal/chdbsession"
+)
+
+// TestMain exists to shut the process-wide chDB session down before the
+// test binary exits. Under `-race`, os.Exit runs runtime.racefini, which
+// runs libchdb's C++ static destructors against a still-live embedded
+// ClickHouse and segfaults AFTER every test has passed (#1971).
+// chdbsession.CloseForExit is a no-op in the default, non-chdb build.
+func TestMain(m *testing.M) {
+	code := m.Run()
+	chdbsession.CloseForExit()
+	os.Exit(code)
+}

--- a/internal/api/prom/pipeline_spans_test.go
+++ b/internal/api/prom/pipeline_spans_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/tsouza/cerberus/internal/api/prom"
 	"github.com/tsouza/cerberus/internal/cerbtrace"
 	"github.com/tsouza/cerberus/internal/chclient"
+	"github.com/tsouza/cerberus/internal/chdbsession"
 	"github.com/tsouza/cerberus/internal/schema"
 )
 
@@ -54,7 +55,13 @@ func TestMain(m *testing.M) {
 		sdktrace.WithSampler(sdktrace.AlwaysSample()),
 	)
 	otel.SetTracerProvider(tp)
-	os.Exit(m.Run())
+	code := m.Run()
+	// Shut the process-wide chDB session down before os.Exit, or a -race
+	// build of this package's chdb-tagged tests segfaults inside libchdb
+	// during runtime.racefini once every test has already passed (#1971).
+	// No-op in the default, non-chdb build.
+	chdbsession.CloseForExit()
+	os.Exit(code)
 }
 
 // TestPipelineSpans_FiveStageChain asserts that a single /api/v1/query

--- a/internal/api/tempo/grpc/testmain_test.go
+++ b/internal/api/tempo/grpc/testmain_test.go
@@ -1,0 +1,19 @@
+package grpc_test
+
+import (
+	"os"
+	"testing"
+
+	"github.com/tsouza/cerberus/internal/chdbsession"
+)
+
+// TestMain exists to shut the process-wide chDB session down before the
+// test binary exits. Under `-race`, os.Exit runs runtime.racefini, which
+// runs libchdb's C++ static destructors against a still-live embedded
+// ClickHouse and segfaults AFTER every test has passed (#1971).
+// chdbsession.CloseForExit is a no-op in the default, non-chdb build.
+func TestMain(m *testing.M) {
+	code := m.Run()
+	chdbsession.CloseForExit()
+	os.Exit(code)
+}

--- a/internal/api/tempo/testmain_test.go
+++ b/internal/api/tempo/testmain_test.go
@@ -1,0 +1,19 @@
+package tempo_test
+
+import (
+	"os"
+	"testing"
+
+	"github.com/tsouza/cerberus/internal/chdbsession"
+)
+
+// TestMain exists to shut the process-wide chDB session down before the
+// test binary exits. Under `-race`, os.Exit runs runtime.racefini, which
+// runs libchdb's C++ static destructors against a still-live embedded
+// ClickHouse and segfaults AFTER every test has passed (#1971).
+// chdbsession.CloseForExit is a no-op in the default, non-chdb build.
+func TestMain(m *testing.M) {
+	code := m.Run()
+	chdbsession.CloseForExit()
+	os.Exit(code)
+}

--- a/internal/chclient/execute_span_test.go
+++ b/internal/chclient/execute_span_test.go
@@ -12,6 +12,7 @@ import (
 	"go.opentelemetry.io/otel/trace"
 
 	"github.com/tsouza/cerberus/internal/cerbtrace"
+	"github.com/tsouza/cerberus/internal/chdbsession"
 )
 
 // executeSpanExporter is the package-wide in-memory exporter installed
@@ -26,7 +27,13 @@ func TestMain(m *testing.M) {
 		sdktrace.WithSampler(sdktrace.AlwaysSample()),
 	)
 	otel.SetTracerProvider(tp)
-	os.Exit(m.Run())
+	code := m.Run()
+	// Shut the process-wide chDB session down before os.Exit, or a -race
+	// build of this package's chdb-tagged probe segfaults inside libchdb
+	// during runtime.racefini once every test has already passed (#1971).
+	// No-op in the default, non-chdb build.
+	chdbsession.CloseForExit()
+	os.Exit(code)
 }
 
 // TestStartExecuteSpan_Attributes pins the attribute contract on the

--- a/internal/chclienttest/testmain_test.go
+++ b/internal/chclienttest/testmain_test.go
@@ -1,0 +1,19 @@
+package chclienttest_test
+
+import (
+	"os"
+	"testing"
+
+	"github.com/tsouza/cerberus/internal/chdbsession"
+)
+
+// TestMain shuts the process-wide chDB session down before this binary
+// exits. Under `-race`, os.Exit runs runtime.racefini, which runs libchdb's
+// C++ static destructors against a still-live embedded ClickHouse and
+// segfaults AFTER every test has already passed (#1971).
+// chdbsession.CloseForExit is a no-op in the default, non-chdb build.
+func TestMain(m *testing.M) {
+	code := m.Run()
+	chdbsession.CloseForExit()
+	os.Exit(code)
+}

--- a/internal/chdbsession/close_chdb.go
+++ b/internal/chdbsession/close_chdb.go
@@ -1,0 +1,51 @@
+//go:build chdb
+
+package chdbsession
+
+import (
+	"sync"
+
+	"github.com/chdb-io/chdb-go/chdb"
+)
+
+// closeOnce guards against a TestMain that calls CloseForExit on more than
+// one path. chdb.Session.Close drops chdb-go's cached globalSession and
+// removes the session's temp directory, so a second call would build a
+// BRAND NEW session (see below) purely to tear it down again.
+var closeOnce sync.Once
+
+// CloseForExit shuts the process-wide chDB session down. Call it from a
+// test package's TestMain, after m.Run has returned and before os.Exit:
+//
+//	func TestMain(m *testing.M) {
+//		code := m.Run()
+//		chdbsession.CloseForExit()
+//		os.Exit(code)
+//	}
+//
+// Without it, a `-race` build of a chdb-tagged test binary segfaults inside
+// libchdb.so during runtime.racefini — after the suite has already passed.
+// The package doc has the full mechanism.
+//
+// It must run AFTER the last test: closing the session invalidates every
+// *sql.DB in the binary, and chdb-go would silently mint a replacement
+// session (with an empty temp directory) for the next query.
+//
+// chdb-go exposes no "is there a session?" predicate — chdb.NewSession
+// returns the cached globalSession when one exists and CREATES one when
+// none does. So in the rare case of a chdb-tagged binary that ran no chDB
+// test at all (`go test -tags chdb -run TestSomethingElse`), this opens a
+// session just to close it. That costs one chdb_connect and one temp
+// directory at process exit and is the price of not reaching into
+// chdb-go's unexported package state, which invariant 11 forbids.
+func CloseForExit() {
+	closeOnce.Do(func() {
+		session, err := chdb.NewSession()
+		// A session that cannot even be opened has no native state to tear
+		// down, which is precisely the state CloseForExit wants to reach.
+		if err != nil || session == nil {
+			return
+		}
+		session.Close()
+	})
+}

--- a/internal/chdbsession/close_nochdb.go
+++ b/internal/chdbsession/close_nochdb.go
@@ -1,0 +1,9 @@
+//go:build !chdb
+
+package chdbsession
+
+// CloseForExit does nothing in the default build: without the `chdb` build
+// tag the binary never links libchdb, so there is no native session to shut
+// down. The no-op exists so an UNTAGGED TestMain — the only TestMain a
+// package is allowed to declare — can call CloseForExit unconditionally.
+func CloseForExit() {}

--- a/internal/chdbsession/doc.go
+++ b/internal/chdbsession/doc.go
@@ -1,0 +1,31 @@
+// Package chdbsession owns the process-exit half of libchdb's session
+// lifecycle for chdb-tagged TEST binaries.
+//
+// libchdb is an embedded ClickHouse loaded into the test process with
+// dlopen. chdb-go caches ONE process-wide `*chdb.Session` (its package-level
+// `globalSession`) and hands it to every `sql.Open("chdb", "")` in the
+// binary, and the driver's own `(*conn).Close` is a no-op — so nothing on
+// the Go side ever shuts the native engine down. The session, its
+// connection and ClickHouse's background thread pools stay live until the
+// process exits.
+//
+// That is fine for a plain `go test` run, because Go's `os.Exit` reaches
+// the `exit_group` syscall directly and libchdb's C++ static destructors
+// never run. It is NOT fine under `-race`: `os.Exit` first calls
+// `runtime_beforeExit` → `runtime.racefini` → `__tsan_fini`, which — per
+// the Go runtime's own comment on race.go's racefini — "will run C atexit
+// functions and C++ destructors". Those destructors then tear libchdb down
+// while its engine is still live, and the process dies with SIGSEGV inside
+// libchdb.so AFTER every test has already passed, turning a green suite
+// into a failed lane (issue #1971).
+//
+// [CloseForExit] supplies the missing half: it closes the cached session
+// before the test binary exits, so the C++ destructors that `__tsan_fini`
+// triggers run against an engine that has already been shut down cleanly.
+// Wire it into a package's TestMain — see [CloseForExit]'s example — and
+// that package's chdb-tagged tests become `-race`-safe.
+//
+// The non-chdb build of this package is a no-op, so an untagged TestMain
+// can call [CloseForExit] unconditionally without dragging libchdb into
+// the default CGO_ENABLED=0 lane.
+package chdbsession

--- a/internal/chsql/testmain_test.go
+++ b/internal/chsql/testmain_test.go
@@ -1,0 +1,19 @@
+package chsql_test
+
+import (
+	"os"
+	"testing"
+
+	"github.com/tsouza/cerberus/internal/chdbsession"
+)
+
+// TestMain shuts the process-wide chDB session down before this binary
+// exits. Under `-race`, os.Exit runs runtime.racefini, which runs libchdb's
+// C++ static destructors against a still-live embedded ClickHouse and
+// segfaults AFTER every test has already passed (#1971).
+// chdbsession.CloseForExit is a no-op in the default, non-chdb build.
+func TestMain(m *testing.M) {
+	code := m.Run()
+	chdbsession.CloseForExit()
+	os.Exit(code)
+}

--- a/internal/logql/testmain_test.go
+++ b/internal/logql/testmain_test.go
@@ -1,0 +1,19 @@
+package logql_test
+
+import (
+	"os"
+	"testing"
+
+	"github.com/tsouza/cerberus/internal/chdbsession"
+)
+
+// TestMain shuts the process-wide chDB session down before this binary
+// exits. Under `-race`, os.Exit runs runtime.racefini, which runs libchdb's
+// C++ static destructors against a still-live embedded ClickHouse and
+// segfaults AFTER every test has already passed (#1971).
+// chdbsession.CloseForExit is a no-op in the default, non-chdb build.
+func TestMain(m *testing.M) {
+	code := m.Run()
+	chdbsession.CloseForExit()
+	os.Exit(code)
+}

--- a/internal/optcorpus/testmain_test.go
+++ b/internal/optcorpus/testmain_test.go
@@ -1,0 +1,19 @@
+package optcorpus
+
+import (
+	"os"
+	"testing"
+
+	"github.com/tsouza/cerberus/internal/chdbsession"
+)
+
+// TestMain shuts the process-wide chDB session down before this binary
+// exits. Under `-race`, os.Exit runs runtime.racefini, which runs libchdb's
+// C++ static destructors against a still-live embedded ClickHouse and
+// segfaults AFTER every test has already passed (#1971).
+// chdbsession.CloseForExit is a no-op in the default, non-chdb build.
+func TestMain(m *testing.M) {
+	code := m.Run()
+	chdbsession.CloseForExit()
+	os.Exit(code)
+}

--- a/internal/optimizer/testmain_test.go
+++ b/internal/optimizer/testmain_test.go
@@ -1,0 +1,19 @@
+package optimizer_test
+
+import (
+	"os"
+	"testing"
+
+	"github.com/tsouza/cerberus/internal/chdbsession"
+)
+
+// TestMain shuts the process-wide chDB session down before this binary
+// exits. Under `-race`, os.Exit runs runtime.racefini, which runs libchdb's
+// C++ static destructors against a still-live embedded ClickHouse and
+// segfaults AFTER every test has already passed (#1971).
+// chdbsession.CloseForExit is a no-op in the default, non-chdb build.
+func TestMain(m *testing.M) {
+	code := m.Run()
+	chdbsession.CloseForExit()
+	os.Exit(code)
+}

--- a/internal/promql/testmain_test.go
+++ b/internal/promql/testmain_test.go
@@ -1,0 +1,19 @@
+package promql_test
+
+import (
+	"os"
+	"testing"
+
+	"github.com/tsouza/cerberus/internal/chdbsession"
+)
+
+// TestMain shuts the process-wide chDB session down before this binary
+// exits. Under `-race`, os.Exit runs runtime.racefini, which runs libchdb's
+// C++ static destructors against a still-live embedded ClickHouse and
+// segfaults AFTER every test has already passed (#1971).
+// chdbsession.CloseForExit is a no-op in the default, non-chdb build.
+func TestMain(m *testing.M) {
+	code := m.Run()
+	chdbsession.CloseForExit()
+	os.Exit(code)
+}

--- a/internal/routerrules/testmain_test.go
+++ b/internal/routerrules/testmain_test.go
@@ -1,0 +1,19 @@
+package routerrules
+
+import (
+	"os"
+	"testing"
+
+	"github.com/tsouza/cerberus/internal/chdbsession"
+)
+
+// TestMain shuts the process-wide chDB session down before this binary
+// exits. Under `-race`, os.Exit runs runtime.racefini, which runs libchdb's
+// C++ static destructors against a still-live embedded ClickHouse and
+// segfaults AFTER every test has already passed (#1971).
+// chdbsession.CloseForExit is a no-op in the default, non-chdb build.
+func TestMain(m *testing.M) {
+	code := m.Run()
+	chdbsession.CloseForExit()
+	os.Exit(code)
+}

--- a/internal/schema/ddl/testmain_test.go
+++ b/internal/schema/ddl/testmain_test.go
@@ -1,0 +1,19 @@
+package ddl_test
+
+import (
+	"os"
+	"testing"
+
+	"github.com/tsouza/cerberus/internal/chdbsession"
+)
+
+// TestMain shuts the process-wide chDB session down before this binary
+// exits. Under `-race`, os.Exit runs runtime.racefini, which runs libchdb's
+// C++ static destructors against a still-live embedded ClickHouse and
+// segfaults AFTER every test has already passed (#1971).
+// chdbsession.CloseForExit is a no-op in the default, non-chdb build.
+func TestMain(m *testing.M) {
+	code := m.Run()
+	chdbsession.CloseForExit()
+	os.Exit(code)
+}

--- a/internal/solver/stress_test.go
+++ b/internal/solver/stress_test.go
@@ -2,6 +2,8 @@ package solver
 
 import (
 	"context"
+	"fmt"
+	"os"
 	"sync"
 	"testing"
 	"time"
@@ -11,6 +13,7 @@ import (
 	"go.uber.org/goleak"
 
 	"github.com/tsouza/cerberus/internal/chclient"
+	"github.com/tsouza/cerberus/internal/chdbsession"
 )
 
 // TestMain wraps the package's tests in a goleak verifier so every producer
@@ -18,13 +21,27 @@ import (
 // shard-kill-mid-drain and timeout scenarios. A leaked producer (e.g. one
 // blocked forever on a channel send because it didn't select on gctx.Done)
 // fails the whole package here.
+//
+// This spells goleak.VerifyTestMain's body out rather than calling it,
+// because that helper calls os.Exit itself and so leaves no seam for the
+// chDB session shutdown that has to happen before the process exits — under
+// `-race`, os.Exit runs runtime.racefini, which runs libchdb's C++ static
+// destructors against a still-live embedded ClickHouse and segfaults AFTER
+// every test has already passed (#1971). goleak.Find carries the retry
+// backoff, so the leak check itself is unchanged.
 func TestMain(m *testing.M) {
-	goleak.VerifyTestMain(
-		m,
+	code := m.Run()
+	if err := goleak.Find(
 		// The OTel global meter provider may keep background goroutines; the
 		// solver itself spawns none beyond its per-request producers.
 		goleak.IgnoreTopFunction("go.opentelemetry.io/otel/sdk/metric.(*PeriodicReader).run"),
-	)
+	); err != nil && code == 0 {
+		fmt.Fprintf(os.Stderr, "goleak: %v\n", err)
+		code = 1
+	}
+	// No-op in the default, non-chdb build.
+	chdbsession.CloseForExit()
+	os.Exit(code)
 }
 
 // TestDeadlockHammer is the required deadlock-hammer stress lane

--- a/test/consumer-corpus/testmain_test.go
+++ b/test/consumer-corpus/testmain_test.go
@@ -1,0 +1,19 @@
+package consumercorpus
+
+import (
+	"os"
+	"testing"
+
+	"github.com/tsouza/cerberus/internal/chdbsession"
+)
+
+// TestMain shuts the process-wide chDB session down before this binary
+// exits. Under `-race`, os.Exit runs runtime.racefini, which runs libchdb's
+// C++ static destructors against a still-live embedded ClickHouse and
+// segfaults AFTER every test has already passed (#1971).
+// chdbsession.CloseForExit is a no-op in the default, non-chdb build.
+func TestMain(m *testing.M) {
+	code := m.Run()
+	chdbsession.CloseForExit()
+	os.Exit(code)
+}

--- a/test/integration/promql/testmain_test.go
+++ b/test/integration/promql/testmain_test.go
@@ -1,0 +1,19 @@
+package promql
+
+import (
+	"os"
+	"testing"
+
+	"github.com/tsouza/cerberus/internal/chdbsession"
+)
+
+// TestMain shuts the process-wide chDB session down before this binary
+// exits. Under `-race`, os.Exit runs runtime.racefini, which runs libchdb's
+// C++ static destructors against a still-live embedded ClickHouse and
+// segfaults AFTER every test has already passed (#1971).
+// chdbsession.CloseForExit is a no-op in the default, non-chdb build.
+func TestMain(m *testing.M) {
+	code := m.Run()
+	chdbsession.CloseForExit()
+	os.Exit(code)
+}

--- a/test/perf/profile/testmain_test.go
+++ b/test/perf/profile/testmain_test.go
@@ -1,0 +1,19 @@
+package profile
+
+import (
+	"os"
+	"testing"
+
+	"github.com/tsouza/cerberus/internal/chdbsession"
+)
+
+// TestMain shuts the process-wide chDB session down before this binary
+// exits. Under `-race`, os.Exit runs runtime.racefini, which runs libchdb's
+// C++ static destructors against a still-live embedded ClickHouse and
+// segfaults AFTER every test has already passed (#1971).
+// chdbsession.CloseForExit is a no-op in the default, non-chdb build.
+func TestMain(m *testing.M) {
+	code := m.Run()
+	chdbsession.CloseForExit()
+	os.Exit(code)
+}

--- a/test/perf/scaling/testmain_test.go
+++ b/test/perf/scaling/testmain_test.go
@@ -1,0 +1,19 @@
+package scaling
+
+import (
+	"os"
+	"testing"
+
+	"github.com/tsouza/cerberus/internal/chdbsession"
+)
+
+// TestMain shuts the process-wide chDB session down before this binary
+// exits. Under `-race`, os.Exit runs runtime.racefini, which runs libchdb's
+// C++ static destructors against a still-live embedded ClickHouse and
+// segfaults AFTER every test has already passed (#1971).
+// chdbsession.CloseForExit is a no-op in the default, non-chdb build.
+func TestMain(m *testing.M) {
+	code := m.Run()
+	chdbsession.CloseForExit()
+	os.Exit(code)
+}

--- a/test/perf/testmain_test.go
+++ b/test/perf/testmain_test.go
@@ -1,0 +1,19 @@
+package perf
+
+import (
+	"os"
+	"testing"
+
+	"github.com/tsouza/cerberus/internal/chdbsession"
+)
+
+// TestMain shuts the process-wide chDB session down before this binary
+// exits. Under `-race`, os.Exit runs runtime.racefini, which runs libchdb's
+// C++ static destructors against a still-live embedded ClickHouse and
+// segfaults AFTER every test has already passed (#1971).
+// chdbsession.CloseForExit is a no-op in the default, non-chdb build.
+func TestMain(m *testing.M) {
+	code := m.Run()
+	chdbsession.CloseForExit()
+	os.Exit(code)
+}

--- a/test/property/testmain_test.go
+++ b/test/property/testmain_test.go
@@ -1,0 +1,19 @@
+package property_test
+
+import (
+	"os"
+	"testing"
+
+	"github.com/tsouza/cerberus/internal/chdbsession"
+)
+
+// TestMain shuts the process-wide chDB session down before this binary
+// exits. Under `-race`, os.Exit runs runtime.racefini, which runs libchdb's
+// C++ static destructors against a still-live embedded ClickHouse and
+// segfaults AFTER every test has already passed (#1971).
+// chdbsession.CloseForExit is a no-op in the default, non-chdb build.
+func TestMain(m *testing.M) {
+	code := m.Run()
+	chdbsession.CloseForExit()
+	os.Exit(code)
+}

--- a/test/regression/chdb_race_exit_test.go
+++ b/test/regression/chdb_race_exit_test.go
@@ -1,0 +1,213 @@
+package regression
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+// This pins #1971: a `-race` build of ANY chdb-tagged test binary died with
+// SIGSEGV inside libchdb.so during runtime.racefini, at process exit, after
+// every test in the binary had already passed — so a suite in which nothing
+// failed reported the lane as failed.
+//
+// The mechanism is a teardown-ordering contract nobody was holding up.
+// libchdb is an embedded ClickHouse dlopen'd into the test process; chdb-go
+// caches ONE process-wide session and its driver's (*conn).Close is a no-op,
+// so the native engine is still live when the process exits. A plain
+// `go test` never notices, because Go's os.Exit reaches exit_group directly
+// and libchdb's C++ static destructors never run. Under `-race`, os.Exit
+// first calls runtime_beforeExit -> runtime.racefini -> __tsan_fini, which
+// (per the Go runtime's own comment on racefini) "will run C atexit
+// functions and C++ destructors" — tearing libchdb down while its engine
+// still runs.
+//
+// internal/chdbsession.CloseForExit closes the session first, so those
+// destructors run against an already-shut-down engine. It only works if
+// every chdb-tagged test package actually CALLS it from its TestMain, and
+// TestMain is per-package by language design — there is no single root to
+// fix. This test is that root: it makes the per-package wiring a checked
+// property instead of a convention a new package can silently skip.
+
+const (
+	// chdbSessionSelector / chdbSessionFunc name the wiring this test
+	// enforces: a `chdbsession.CloseForExit()` call inside TestMain.
+	chdbSessionSelector = "chdbsession"
+	chdbSessionFunc     = "CloseForExit"
+
+	// chdbSessionImplFile defines CloseForExit for the chdb build. The scan
+	// below proves nothing if the helper it points every package at has been
+	// deleted or renamed, so its presence is asserted separately.
+	chdbSessionImplFile = "../../internal/chdbsession/close_chdb.go"
+
+	// minChDBTestPackages is a floor under the discovered package set. The
+	// walk is the only thing standing between a new chdb-tagged package and
+	// a silently unwired TestMain, so a walk that suddenly finds almost
+	// nothing — a moved tree, a broken filter — must fail loudly rather than
+	// pass by finding no work to do. The real count was 25 when this landed;
+	// the floor sits below that so ordinary churn does not trip it.
+	minChDBTestPackages = 15
+)
+
+// chdbBuildTagRE matches a `//go:build` line that names the chdb tag. It is
+// only ever applied to the text BEFORE a file's package clause, which is
+// where build constraints must live — that also keeps this test file, whose
+// own source contains the pattern below the package clause, from matching
+// itself.
+var chdbBuildTagRE = regexp.MustCompile(`(?m)^//go:build\b[^\n]*\bchdb\b`)
+
+// TestChDBTaggedPackagesCloseSessionOnExit asserts that every package with a
+// chdb-tagged test file declares a TestMain that calls
+// chdbsession.CloseForExit.
+func TestChDBTaggedPackagesCloseSessionOnExit(t *testing.T) {
+	t.Parallel()
+
+	// Vacuity guard: the wiring this test enforces is worthless if the
+	// helper every TestMain calls no longer exists.
+	impl, err := os.ReadFile(chdbSessionImplFile)
+	if err != nil {
+		t.Fatalf("read %s: %v\nthis is the helper every chdb-tagged TestMain calls; without it "+
+			"the per-package scan below enforces a call to nothing", chdbSessionImplFile, err)
+	}
+	if !strings.Contains(string(impl), "func "+chdbSessionFunc+"(") {
+		t.Fatalf("%s no longer defines %s — the scan below would enforce a call to a function "+
+			"that does not exist", chdbSessionImplFile, chdbSessionFunc)
+	}
+
+	pkgDirs := chdbTaggedPackageDirs(t)
+	if len(pkgDirs) < minChDBTestPackages {
+		t.Fatalf("found only %d chdb-tagged test packages (floor %d) — the walk is not finding "+
+			"the tree it is supposed to police, so a green result here proves nothing",
+			len(pkgDirs), minChDBTestPackages)
+	}
+
+	for _, dir := range pkgDirs {
+		if wired, err := packageTestMainClosesSession(dir); err != nil {
+			t.Errorf("%s: %v", dir, err)
+		} else if !wired {
+			t.Errorf("%s has chdb-tagged tests but no TestMain calling %s.%s.\n"+
+				"Under -race this package's test binary segfaults inside libchdb during "+
+				"runtime.racefini at process exit, AFTER its tests pass (#1971). Add:\n\n"+
+				"\tfunc TestMain(m *testing.M) {\n"+
+				"\t\tcode := m.Run()\n"+
+				"\t\t%s.%s()\n"+
+				"\t\tos.Exit(code)\n"+
+				"\t}\n",
+				dir, chdbSessionSelector, chdbSessionFunc, chdbSessionSelector, chdbSessionFunc)
+		}
+	}
+}
+
+// chdbTaggedPackageDirs walks the repo for _test.go files carrying the chdb
+// build tag and returns their directories, deduplicated and sorted.
+func chdbTaggedPackageDirs(t *testing.T) []string {
+	t.Helper()
+
+	seen := map[string]bool{}
+	for _, tree := range []string{"internal", "test"} {
+		root := filepath.Join(repoRootFromRegression, tree)
+		err := filepath.WalkDir(root, func(path string, d os.DirEntry, err error) error {
+			if err != nil {
+				return err
+			}
+			if d.IsDir() || !strings.HasSuffix(path, "_test.go") {
+				return nil
+			}
+			body, readErr := os.ReadFile(path)
+			if readErr != nil {
+				return readErr
+			}
+			if hasChDBBuildTag(string(body)) {
+				seen[filepath.Dir(path)] = true
+			}
+			return nil
+		})
+		if err != nil {
+			t.Fatalf("walk %s: %v", root, err)
+		}
+	}
+
+	dirs := make([]string, 0, len(seen))
+	for d := range seen {
+		dirs = append(dirs, d)
+	}
+	sortStrings(dirs)
+	return dirs
+}
+
+// hasChDBBuildTag reports whether src carries a `//go:build` constraint
+// naming chdb. Only the header — everything before the package clause — is
+// considered, since that is the only place a build constraint is honoured.
+func hasChDBBuildTag(src string) bool {
+	header := src
+	if idx := strings.Index(src, "\npackage "); idx >= 0 {
+		header = src[:idx]
+	}
+	return chdbBuildTagRE.MatchString(header)
+}
+
+// packageTestMainClosesSession reports whether any _test.go file in dir
+// declares a TestMain whose body calls chdbsession.CloseForExit.
+func packageTestMainClosesSession(dir string) (bool, error) {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return false, err
+	}
+	fset := token.NewFileSet()
+	for _, e := range entries {
+		if e.IsDir() || !strings.HasSuffix(e.Name(), "_test.go") {
+			continue
+		}
+		file, parseErr := parser.ParseFile(fset, filepath.Join(dir, e.Name()), nil, 0)
+		if parseErr != nil {
+			return false, parseErr
+		}
+		for _, decl := range file.Decls {
+			fn, ok := decl.(*ast.FuncDecl)
+			if !ok || fn.Name.Name != "TestMain" || fn.Recv != nil || fn.Body == nil {
+				continue
+			}
+			if callsCloseForExit(fn.Body) {
+				return true, nil
+			}
+		}
+	}
+	return false, nil
+}
+
+// callsCloseForExit reports whether body contains a chdbsession.CloseForExit
+// call.
+func callsCloseForExit(body *ast.BlockStmt) bool {
+	found := false
+	ast.Inspect(body, func(n ast.Node) bool {
+		call, ok := n.(*ast.CallExpr)
+		if !ok {
+			return true
+		}
+		sel, ok := call.Fun.(*ast.SelectorExpr)
+		if !ok || sel.Sel.Name != chdbSessionFunc {
+			return true
+		}
+		if ident, ok := sel.X.(*ast.Ident); ok && ident.Name == chdbSessionSelector {
+			found = true
+			return false
+		}
+		return true
+	})
+	return found
+}
+
+// sortStrings keeps the failure output stable without pulling sort into the
+// call site.
+func sortStrings(s []string) {
+	for i := 1; i < len(s); i++ {
+		for j := i; j > 0 && s[j] < s[j-1]; j-- {
+			s[j], s[j-1] = s[j-1], s[j]
+		}
+	}
+}

--- a/test/regression/testmain_test.go
+++ b/test/regression/testmain_test.go
@@ -1,0 +1,19 @@
+package regression
+
+import (
+	"os"
+	"testing"
+
+	"github.com/tsouza/cerberus/internal/chdbsession"
+)
+
+// TestMain shuts the process-wide chDB session down before this binary
+// exits. Under `-race`, os.Exit runs runtime.racefini, which runs libchdb's
+// C++ static destructors against a still-live embedded ClickHouse and
+// segfaults AFTER every test has already passed (#1971).
+// chdbsession.CloseForExit is a no-op in the default, non-chdb build.
+func TestMain(m *testing.M) {
+	code := m.Run()
+	chdbsession.CloseForExit()
+	os.Exit(code)
+}

--- a/test/spec/logql/testmain_test.go
+++ b/test/spec/logql/testmain_test.go
@@ -1,0 +1,19 @@
+package logql_spec_test
+
+import (
+	"os"
+	"testing"
+
+	"github.com/tsouza/cerberus/internal/chdbsession"
+)
+
+// TestMain shuts the process-wide chDB session down before this binary
+// exits. Under `-race`, os.Exit runs runtime.racefini, which runs libchdb's
+// C++ static destructors against a still-live embedded ClickHouse and
+// segfaults AFTER every test has already passed (#1971).
+// chdbsession.CloseForExit is a no-op in the default, non-chdb build.
+func TestMain(m *testing.M) {
+	code := m.Run()
+	chdbsession.CloseForExit()
+	os.Exit(code)
+}

--- a/test/spec/promql/testmain_test.go
+++ b/test/spec/promql/testmain_test.go
@@ -1,0 +1,19 @@
+package promql_spec_test
+
+import (
+	"os"
+	"testing"
+
+	"github.com/tsouza/cerberus/internal/chdbsession"
+)
+
+// TestMain shuts the process-wide chDB session down before this binary
+// exits. Under `-race`, os.Exit runs runtime.racefini, which runs libchdb's
+// C++ static destructors against a still-live embedded ClickHouse and
+// segfaults AFTER every test has already passed (#1971).
+// chdbsession.CloseForExit is a no-op in the default, non-chdb build.
+func TestMain(m *testing.M) {
+	code := m.Run()
+	chdbsession.CloseForExit()
+	os.Exit(code)
+}

--- a/test/spec/testmain_test.go
+++ b/test/spec/testmain_test.go
@@ -1,0 +1,19 @@
+package spec_test
+
+import (
+	"os"
+	"testing"
+
+	"github.com/tsouza/cerberus/internal/chdbsession"
+)
+
+// TestMain shuts the process-wide chDB session down before this binary
+// exits. Under `-race`, os.Exit runs runtime.racefini, which runs libchdb's
+// C++ static destructors against a still-live embedded ClickHouse and
+// segfaults AFTER every test has already passed (#1971).
+// chdbsession.CloseForExit is a no-op in the default, non-chdb build.
+func TestMain(m *testing.M) {
+	code := m.Run()
+	chdbsession.CloseForExit()
+	os.Exit(code)
+}

--- a/test/spec/traceql/testmain_test.go
+++ b/test/spec/traceql/testmain_test.go
@@ -1,0 +1,19 @@
+package traceql_spec_test
+
+import (
+	"os"
+	"testing"
+
+	"github.com/tsouza/cerberus/internal/chdbsession"
+)
+
+// TestMain shuts the process-wide chDB session down before this binary
+// exits. Under `-race`, os.Exit runs runtime.racefini, which runs libchdb's
+// C++ static destructors against a still-live embedded ClickHouse and
+// segfaults AFTER every test has already passed (#1971).
+// chdbsession.CloseForExit is a no-op in the default, non-chdb build.
+func TestMain(m *testing.M) {
+	code := m.Run()
+	chdbsession.CloseForExit()
+	os.Exit(code)
+}


### PR DESCRIPTION
## What

Makes `go test -race -tags chdb ./...` exit clean. Before this, a `-race` build of any
chdb-tagged test binary died with `SIGSEGV` inside `runtime.racefini()` at process exit —
**after** every test in the binary had already passed — so a suite in which nothing failed
reported the lane as failed.

This is the first of issue #1971's two allowed outcomes (a real fix), not the second
(a documented `-race` exemption).

## Root cause

A teardown-ordering contract nobody was holding up.

libchdb is an embedded ClickHouse `dlopen`'d into the test process. chdb-go caches ONE
process-wide session (`chdb.NewSession` returns its package-level `globalSession`), and the
driver's `(*conn).Close` is **a no-op** — so `db.Close()` never shuts the native engine down,
and nothing else does either. The engine, its connection and ClickHouse's background thread
pools are still live when the process exits.

A plain `go test` never notices: Go's `os.Exit` reaches the `exit_group` syscall directly, so
libchdb's C++ static destructors never run. Under `-race` it is different — `os.Exit` first
calls `runtime_beforeExit` → `runtime.racefini` → `__tsan_fini`, which, per the Go runtime's
own comment on `racefini` (`runtime/race.go:504`):

> `__tsan_fini` will run C atexit functions and C++ destructors, which can theoretically call
> back into Go.

Those destructors tear libchdb down while its engine is still running, and the process
segfaults. `os.Exit(0x0)` in the trace is the tell — the exit code was zero.

Note this is **not** the `chdb_connect` signal-handler hazard from #2096/#2097. That one is
already guarded upstream in chdb-go v1.12.0, and `internal/api/...` calls `chdb_connect`
exactly **once** per test binary anyway, because the driver's no-op `Close` means the cached
`globalSession` is never torn down and rebuilt. Different mechanism, different fix.

## Evidence

A standalone reproducer (chdb session + MergeTree tables + inserts + queries, then exit)
isolates the axis exactly:

| variant                                            | racefini crashes |
| -------------------------------------------------- | ---------------- |
| no `-race`, `os.Exit`                                | 0/5              |
| `-race`, `os.Exit`                                   | **5/5**          |
| `-race`, `syscall.Exit` (skips `racefini`)           | 0/5              |
| `-race`, `os.Exit` after closing the chDB session    | 0/5              |

The faulting PC resolves to a **constant offset inside `libchdb.so`'s executable segment**
(`0x16d819e6`) across every reproduction, confirmed by matching each crash's `PC=` against
that process's own `/proc/self/maps`. The three crashes seen in the wild — including the one
in the issue report — all share their low 24 bits (`0xd82a1a`), the fingerprint of one
offset in one `dlopen`'d library at different ASLR bases. libchdb is stripped, so no function
name is recoverable.

On the real repro command from the issue, `go test -race -tags chdb -timeout 300s -count=1
./internal/api/...`:

- **before:** 3/3 runs crashed, two packages per run (`internal/api/prom` and
  `internal/api/tempo`), each after `PASS`.
- **after:** 6/6 runs crash-free, 5/6 fully green. The one non-green run was a 300s
  timeout on `internal/api/prom`, caused by my own concurrent test load while it ran —
  `prom` needs ~200s under `-race` against a 300s limit, and every subsequent quiet run
  passed with `prom` at 200.8s `ok`.

## What changed

- **`internal/chdbsession`** (new): `CloseForExit()` closes the cached chDB session so the
  C++ destructors `racefini` triggers run against an already-shut-down engine. The non-chdb
  build is a no-op, so an untagged `TestMain` can call it unconditionally without dragging
  libchdb into the default `CGO_ENABLED=0` lane.
- **`TestMain` wiring** in all 25 packages that carry chdb-tagged test files. `TestMain` is
  the only process-exit seam Go offers and it is declared per package, so there is no single
  root to fix. `internal/solver`'s existing `TestMain` spells `goleak.VerifyTestMain`'s body
  out rather than calling it, because that helper calls `os.Exit` itself and leaves no seam
  after `m.Run()`; `goleak.Find` carries the retry backoff, so the leak check is unchanged.
- **`test/regression/chdb_race_exit_test.go`** (the ratchet): walks the tree for chdb-tagged
  test files and fails any package whose `TestMain` does not call `CloseForExit`. Without it
  a newly added chdb-tagged package silently reintroduces the crash. It carries two vacuity
  guards — the helper must still exist and define `CloseForExit`, and the walk must find at
  least 15 packages — so a broken scan fails loudly instead of passing by finding no work.
  Verified to bite: deleting one package's `TestMain` fails it with an actionable message.
- **`docs/test-strategy.md`**: the mechanism, the crash signature, and why the `chdb` CI job
  still runs without `-race` (cost, not correctness — measured at 1.5x for `prom`, which is
  already the long pole, up to 5x for `tempo/grpc`). The point is that `-race` + chdb is now
  *possible* for anyone chasing a suspected data race in chdb-tagged code, which it
  structurally was not before.
- **`.go-arch-lint.yml`**: declares the new package (invariant 16).

## Testing

- The issue's exact repro command, repeated runs: **3/3 crashing before, 0/6 after**.
- The ratchet's negative test — delete one package's `TestMain`, watch it fail with the
  actionable message, restore, watch it pass.
- `go vet -tags chdb ./...` clean over the whole tree (covers all 22 generated `TestMain`
  files, and proves no package ended up with two).
- `go test -race` on the untagged build of the packages whose existing `TestMain` this
  restructures — `internal/solver`, `internal/chclient` — plus `test/regression` and
  `test/spec`: all `ok`.

## One upstream note

chdb-go v1.12.0's `Session.Close()` calls `s.conn.Close()` and then, for a temp-dir session,
`Cleanup()` — which calls `s.conn.Close()` again. `connection.Close()` never nils `c.conn`,
so the same `chdb_connection*` reaches `chdb_close_conn` twice.

This PR calls `Close()` anyway, because it is the correct public API for "shut this session
down" and the alternative (`Cleanup()`, which happens to close exactly once) would couple us
to upstream's internal control flow and unconditionally delete a non-temp session directory.
The double call is empirically harmless — `chdb.h` documents `chdb_close_conn` as handling
"connection shutdown and cleanup", and 20/20 dedicated stress runs plus every process exit in
the verification above came back clean. Recording it here so the choice is on the record
rather than rediscovered later.

Closes #1971
