### PR TITLE
feat(solver): make the UnionAll/RangeWindowNative spine re-anchorable for route B

### DIFF
--- a/docs/solver.md
+++ b/docs/solver.md
@@ -39,12 +39,26 @@ The signals, each gathered in the one pass:
    sends the whole plan to route A. A new node defaults to route A until its
    marker is proven.
 2. **Routable spine family.** Re-anchoring rewrites the grid carried by the
-   `RangeWindow` matrix family and the `RangeLWR` bare-selector
+   `RangeWindow` matrix family, the `RangeWindowNative` ClickHouse-native
+   `timeSeries*ToGrid` family, and the `RangeLWR` bare-selector
    last-with-respect-to family. Every other grid carrier —
-   `RangeWindowNative`, `RangeWindowResample`, `RangeBucketFanout`, `StepGrid`,
-   `AbsentOverTime` — carries its own eval grid that re-anchoring clones
-   verbatim, so a plan whose spine bound-carrier is one of those fails closed to
-   route A (every shard would otherwise emit stale bounds).
+   `RangeWindowResample`, `RangeBucketFanout`, `StepGrid`, `AbsentOverTime` —
+   carries its own eval grid that re-anchoring clones verbatim, so a plan whose
+   spine bound-carrier is one of those fails closed to route A (every shard
+   would otherwise emit stale bounds).
+
+   `UnionAll` carries no grid of its own and re-anchors every arm onto the same
+   sub-grid, so a mixed spine — `UnionAll{RangeWindowNative, RangeWindow}`, the
+   shape a cumulative/delta temporality split emits — slices as a unit. All arms
+   move together or none does: the arms are concatenated positionally, so a
+   shard that re-gridded one and shared another verbatim would compose the
+   shared arm's full-grid answer `K` times over.
+
+   The three re-anchorable kinds are exactly the kinds the slicer's `unpinSpine`
+   zeroes and exactly the kinds `carrierGeometryOf` marks re-anchorable. A kind
+   that re-anchoring learns but `unpinSpine` does not stays pinned at the full
+   request grid, so every slice aborts with a grid mismatch and the plan falls
+   back to route A while still classifying as routable.
 
    Measurement is separate from admissibility: the signal walk records the cost
    grid of **every** carrier kind, routable or not, because the corpus needs to
@@ -107,10 +121,22 @@ The signals, each gathered in the one pass:
 When every signal passes, the plan is **eligible**. The cost grid then decides
 whether slicing is worthwhile:
 
-- `F` = max `Range/Step` (or `Lookback/Step`) over windowed nodes.
+- `F` = max per-sample intermediate-row count over windowed nodes: `Range/Step`
+  (or `Lookback/Step`) for a carrier that materialises the `(sample, anchor)`
+  matrix, and `1` for the native `timeSeries*ToGrid` family, which reads each
+  sample exactly once into a per-series grid array whatever its window width is.
+  `F` is the memory proxy the auto gate reads, so reporting `Range/Step` for a
+  native carrier would shard a flat-memory single-pass statement `K` ways and
+  pay `K` scans for a matrix that is never built. A native carrier is still
+  fully sliceable — it simply does not clear `MinFanout` on its own, so it
+  routes when a fan-out sibling arm prices the plan or when the threshold-free
+  `Eligible` seam (the failure-driven route memo, which fires on a real route-A
+  resource failure) asks for it.
 - `N` = `OuterRange/Step + 1`, the outer anchor count.
 - `D` = cumulative spine lookback (Σ `Range` down nested matrix windows + leaf
-  `RangeLWR.Lookback`).
+  `RangeLWR.Lookback`). Unlike `F`, `D` is unaffected by which emitter reads the
+  window: it measures per-slice SCAN redundancy, and a native carrier's shard
+  widens its input by `Offset + Range` exactly as a fan-out carrier's does.
 - `K = clamp(floor(N / MinAnchorsPerSlice), 2, min(MaxK, floor(OuterRange /
   max(D, Step))))`.
 
@@ -209,8 +235,8 @@ emptied. `D` is the cumulative spine lookback recovered by walking the spine.
 request grid (the grid-prediction guard already verified it sits exactly
 there). To re-grid each slice onto a sub-window, the slicer first builds one
 spine-unpinned, copy-on-write view (`unpinSpine`): the windowed-spine bounds
-(`RangeWindow` / `RangeLWR` `Start`, `End`, and the matrix `OuterRange`) are
-zeroed. This is safe because signal 5 already proved every spine node sits on
+(`RangeWindow` / `RangeWindowNative` / `RangeLWR` `Start`, `End`, and the matrix
+`OuterRange`) are zeroed. This is safe because signal 5 already proved every spine node sits on
 the predicted grid, so the zeroed information is exactly what the re-anchor
 recomputes. `unpinSpine` clones ONLY the spine-path nodes it zeroes (and their
 ancestors back to the root, the `O(spine-depth)` chain) and SHARES every
@@ -241,7 +267,11 @@ returned to the handler:
 2. **Emit first.** All `K` shard SQLs are emitted before any cursor opens, so
    an emit failure aborts with zero CH work. A belt-and-braces assertion
    rejects any shard SQL string still containing a `now64(` call despite the
-   static gate.
+   static gate. The dispatch context carries the same plan-shape-gated
+   ClickHouse settings a route-A statement would get — notably
+   `allow_experimental_time_series_aggregate_functions=1` when a shard plan
+   carries a `timeSeries*ToGrid` node, without which every shard answers code
+   63 rather than degrading.
 3. **Two-stage weighted admission (degrade, don't reject).** The handler has
    already charged weight 1; the Executor asks for `(P-1)` additional admission
    units. On a partial or zero grant it clamps effective parallelism to

--- a/internal/chplan/range_window_native.go
+++ b/internal/chplan/range_window_native.go
@@ -148,6 +148,27 @@ func (*RangeWindowNative) planNode() {}
 
 func (r *RangeWindowNative) Children() []Node { return []Node{r.Input} }
 
+// InputWindow returns the bounds the INPUT relation must cover for this node
+// to answer every anchor in [start, end]. Each anchor reduces the samples in
+// `(anchor - Offset - Range, anchor - Offset]`, so the oldest anchor reaches
+// back Offset+Range past start; Offset enters with its sign, so a forward
+// (negative) offset widens by less.
+//
+// It is the SINGLE owner of that arithmetic for this node kind — the twin of
+// [RangeWindow.InputWindow] — read by every pass that has to predict, widen or
+// re-anchor the inner spine (the solver's signal walk, [ReanchorRange]). Three
+// independent copies of `start.Add(-Offset-Range)` is exactly how the #1464
+// class of bug (one pass widening by Range and another by Offset+Range) gets
+// reintroduced: the two then disagree about the inner grid, the grid-prediction
+// guard reads a divergence that is not there, and a routable plan silently
+// falls back to route A.
+func (r *RangeWindowNative) InputWindow(start, end time.Time) (time.Time, time.Time) {
+	if r.Step <= 0 {
+		return start, end
+	}
+	return start.Add(-r.Offset - r.Range), end
+}
+
 func (r *RangeWindowNative) Equal(other Node) bool {
 	o, ok := other.(*RangeWindowNative)
 	if !ok {

--- a/internal/chplan/reanchor.go
+++ b/internal/chplan/reanchor.go
@@ -73,6 +73,16 @@ var ErrReanchorGridMismatch = errors.New("chplan: windowed node bounds do not ma
 // verbatim (the original pointer, not a copy) — it is below the spine and
 // does not move in time.
 //
+// RangeWindowNative (the ClickHouse-native timeSeries<fn>ToGrid lowering of
+// the same window semantics) re-anchors exactly like the matrix RangeWindow —
+// re-grid (Start, End), widen the input spine by Offset+Range via
+// RangeWindowNative.InputWindow — with the grid-prediction guard in its
+// two-bound (no OuterRange field) form. UnionAll carries no grid of its own
+// and re-anchors EVERY arm onto the same [start, end], which is what lets a
+// mixed `UnionAll{RangeWindowNative, RangeWindow}` spine slice: the arms are
+// concatenated positionally, so all of them must move together or the shards
+// double-count the arm that did not.
+//
 // RangeLWR (the bare-selector last-with-respect-to leaf, the deriv / idelta /
 // irate / instant-LWR / negative-offset families) re-anchors the same way:
 // matrix-grid RangeLWRs (Step > 0) re-grid their (Start, End) and recurse into
@@ -117,6 +127,73 @@ func reanchor(n Node, start, end time.Time) (Node, error) {
 		}
 		c.Input = input
 		return &c, nil
+	case *RangeWindowNative:
+		// The ClickHouse-native timeSeries<fn>ToGrid lowering of the SAME
+		// window semantics the RangeWindow arm above re-grids: the aggregate
+		// is handed (Start, End, Step, Range) and evaluates grid point i from
+		// the samples in `(anchor_i - Offset - Range, anchor_i - Offset]`. So
+		// re-anchoring is the same two moves — re-grid (Start, End), widen the
+		// input spine by Offset+Range — and the same discipline applies: the
+		// grid is filled only when the node is either unpinned (the slicer's
+		// UnpinSpine shape) or already sits exactly on the predicted grid, and
+		// an @-pinned divergence routes A via ErrReanchorGridMismatch.
+		//
+		// The one structural difference from the RangeWindow arm is that this
+		// node carries no OuterRange field — its grid span IS End-Start — so
+		// the guard is checkPredictedGridNative, the RangeLWR-shaped two-bound
+		// form rather than the three-bound one.
+		if v.Step <= 0 {
+			// No anchor grid to re-grid. The lowering only builds this node in
+			// range mode, so this is unreachable from a real plan; keeping the
+			// arm symmetric with RangeWindow / RangeLWR means a hand-built or
+			// future instant shape terminates the walk instead of being
+			// re-gridded onto bounds it has no anchors for.
+			return v, nil
+		}
+		if err := checkPredictedGridNative(v, start, end); err != nil {
+			return nil, err
+		}
+		// Clone only this spine node; GroupBy / Recollapse / Scalars are
+		// off-grid immutable, so share the original slice headers.
+		c := *v
+		c.Start = start
+		c.End = end
+		inStart, inEnd := v.InputWindow(start, end)
+		input, err := reanchor(v.Input, inStart, inEnd)
+		if err != nil {
+			return nil, err
+		}
+		c.Input = input
+		return &c, nil
+	case *UnionAll:
+		// A UNION ALL of independent windowed spines. It carries NO grid and
+		// NO lookback of its own: every arm already evaluates over the request
+		// grid and each does its own -Offset-Range widening, so re-anchor every
+		// arm onto the SAME [start, end] the union was asked for — exactly the
+		// VectorJoin arm's shape, generalised from two fixed sides to N.
+		//
+		// Re-anchoring EVERY arm is what makes the union re-anchorable at all:
+		// the arms are concatenated positionally, so a shard that re-gridded
+		// one arm and shared another verbatim would emit one sub-grid's rows
+		// beside the full grid's, and the K-way composition would double-count
+		// every anchor of the shared arm. An @-pinned or grid-divergent arm
+		// surfaces ErrReanchorGridMismatch from the recursion and aborts the
+		// whole re-anchor to route A.
+		//
+		// A union whose arms carry no grid at all (the classic-histogram
+		// companion-suffix routing, where the UnionAll sits BENEATH the
+		// windowed node) recurses into arms that all hit the share-verbatim
+		// default, so this arm allocates a new Inputs slice and returns an
+		// Equal tree — the same cost the Project / Filter arms already pay.
+		inputs := make([]Node, len(v.Inputs))
+		for i, in := range v.Inputs {
+			arm, err := reanchor(in, start, end)
+			if err != nil {
+				return nil, err
+			}
+			inputs[i] = arm
+		}
+		return &UnionAll{Inputs: inputs}, nil
 	case *RangeLWR:
 		// The bare-selector last-with-respect-to leaf. Its eval grid is
 		// [Start, End] spaced by Step; each anchor reduces the most-recent
@@ -282,6 +359,27 @@ func epochFloor(t time.Time, step time.Duration) time.Time {
 		floor--
 	}
 	return time.Unix(0, floor*stepNS).UTC()
+}
+
+// checkPredictedGridNative is checkPredictedGrid for a RangeWindowNative. Like
+// the RangeLWR form, the node carries no OuterRange field — its grid span IS
+// End-Start — so the predicted grid is just [predStart, predEnd]. Either the
+// bounds are unpinned (zero Start and End — the slicer's UnpinSpine shape,
+// filled by the re-anchor) or they already sit exactly on the predicted grid.
+// Anything else — most importantly an @-pinned End diverging from the predicted
+// grid — is rejected so the solver routes A.
+func checkPredictedGridNative(r *RangeWindowNative, predStart, predEnd time.Time) error {
+	if r.Start.IsZero() && r.End.IsZero() {
+		return nil
+	}
+	if r.Start.Equal(predStart) && r.End.Equal(predEnd) {
+		return nil
+	}
+	return fmt.Errorf("%w: RangeWindowNative bounds (Start=%v End=%v) "+
+		"do not match predicted grid (Start=%v End=%v) — an @-pinned or non-grid anchor",
+		ErrReanchorGridMismatch,
+		r.Start, r.End,
+		predStart, predEnd)
 }
 
 // checkPredictedGridLWR is checkPredictedGrid for a RangeLWR. The LWR carries

--- a/internal/chplan/reanchor.go
+++ b/internal/chplan/reanchor.go
@@ -99,150 +99,13 @@ func ReanchorRange(n Node, start, end time.Time) (Node, error) {
 func reanchor(n Node, start, end time.Time) (Node, error) {
 	switch v := n.(type) {
 	case *RangeWindow:
-		// Instant-shape RangeWindows resolve a single anchor themselves and
-		// terminate the walk (mirrors widenSubquerySpine's Step <= 0 guard).
-		if v.Step <= 0 {
-			// Instant-shape window: not re-gridded, share verbatim.
-			return v, nil
-		}
-		if err := checkPredictedGrid(v, start, end); err != nil {
-			return nil, err
-		}
-		// Clone only this spine node; GroupBy / Scalars / ScalarExprs are
-		// off-grid immutable, so share the original slice headers (the shard
-		// re-grids Start/End/OuterRange only — it never mutates these).
-		c := *v
-		c.Start = start
-		c.End = end
-		c.OuterRange = end.Sub(start)
-		// Each of this window's anchors looks back Offset+Range (the window
-		// is [End-Offset-Range, End-Offset], see the RangeWindow doc comment
-		// above); widen the input spine by that much via the single shared
-		// owner of this arithmetic so the inner grid covers every anchor's
-		// window.
-		inStart, inEnd := v.InputWindow(start, end)
-		input, err := reanchor(v.Input, inStart, inEnd)
-		if err != nil {
-			return nil, err
-		}
-		c.Input = input
-		return &c, nil
+		return reanchorRangeWindow(v, start, end)
 	case *RangeWindowNative:
-		// The ClickHouse-native timeSeries<fn>ToGrid lowering of the SAME
-		// window semantics the RangeWindow arm above re-grids: the aggregate
-		// is handed (Start, End, Step, Range) and evaluates grid point i from
-		// the samples in `(anchor_i - Offset - Range, anchor_i - Offset]`. So
-		// re-anchoring is the same two moves — re-grid (Start, End), widen the
-		// input spine by Offset+Range — and the same discipline applies: the
-		// grid is filled only when the node is either unpinned (the slicer's
-		// UnpinSpine shape) or already sits exactly on the predicted grid, and
-		// an @-pinned divergence routes A via ErrReanchorGridMismatch.
-		//
-		// The one structural difference from the RangeWindow arm is that this
-		// node carries no OuterRange field — its grid span IS End-Start — so
-		// the guard is checkPredictedGridNative, the RangeLWR-shaped two-bound
-		// form rather than the three-bound one.
-		if v.Step <= 0 {
-			// No anchor grid to re-grid. The lowering only builds this node in
-			// range mode, so this is unreachable from a real plan; keeping the
-			// arm symmetric with RangeWindow / RangeLWR means a hand-built or
-			// future instant shape terminates the walk instead of being
-			// re-gridded onto bounds it has no anchors for.
-			return v, nil
-		}
-		if err := checkPredictedGridNative(v, start, end); err != nil {
-			return nil, err
-		}
-		// Clone only this spine node; GroupBy / Recollapse / Scalars are
-		// off-grid immutable, so share the original slice headers.
-		c := *v
-		c.Start = start
-		c.End = end
-		inStart, inEnd := v.InputWindow(start, end)
-		input, err := reanchor(v.Input, inStart, inEnd)
-		if err != nil {
-			return nil, err
-		}
-		c.Input = input
-		return &c, nil
+		return reanchorRangeWindowNative(v, start, end)
 	case *UnionAll:
-		// A UNION ALL of independent windowed spines. It carries NO grid and
-		// NO lookback of its own: every arm already evaluates over the request
-		// grid and each does its own -Offset-Range widening, so re-anchor every
-		// arm onto the SAME [start, end] the union was asked for — exactly the
-		// VectorJoin arm's shape, generalised from two fixed sides to N.
-		//
-		// Re-anchoring EVERY arm is what makes the union re-anchorable at all:
-		// the arms are concatenated positionally, so a shard that re-gridded
-		// one arm and shared another verbatim would emit one sub-grid's rows
-		// beside the full grid's, and the K-way composition would double-count
-		// every anchor of the shared arm. An @-pinned or grid-divergent arm
-		// surfaces ErrReanchorGridMismatch from the recursion and aborts the
-		// whole re-anchor to route A.
-		//
-		// A union whose arms carry no grid at all (the classic-histogram
-		// companion-suffix routing, where the UnionAll sits BENEATH the
-		// windowed node) recurses into arms that all hit the share-verbatim
-		// default, so this arm allocates a new Inputs slice and returns an
-		// Equal tree — the same cost the Project / Filter arms already pay.
-		inputs := make([]Node, len(v.Inputs))
-		for i, in := range v.Inputs {
-			arm, err := reanchor(in, start, end)
-			if err != nil {
-				return nil, err
-			}
-			inputs[i] = arm
-		}
-		return &UnionAll{Inputs: inputs}, nil
+		return reanchorUnionAll(v, start, end)
 	case *RangeLWR:
-		// The bare-selector last-with-respect-to leaf. Its eval grid is
-		// [Start, End] spaced by Step; each anchor reduces the most-recent
-		// sample in its offset-aware staleness window
-		// `(anchor - Offset - Lookback, anchor - Offset]`. The per-(series,
-		// anchor) value depends only on that window's membership, not on the
-		// scan lower bound — it is registered slice-invariant — so re-anchoring
-		// to a sub-grid yields exactly the rows route A would have produced for
-		// those anchors. Same no-mutate + grid-prediction discipline as
-		// the RangeWindow arm: the grid is filled only when the node is either
-		// unpinned (the slicer's unpinSpine shape) or already sits exactly on
-		// the predicted grid; an @-pinned divergence routes A via
-		// ErrReanchorGridMismatch.
-		if v.Step <= 0 {
-			// No anchor grid to re-grid (an instant-shape LWR); share verbatim.
-			return v, nil
-		}
-		if err := checkPredictedGridLWR(v, start, end); err != nil {
-			return nil, err
-		}
-		c := *v
-		if v.StepAlign {
-			// Epoch-aligned subquery inner (see RangeLWR.StepAlign): the
-			// unsliced query would have evaluated this grid at absolute-epoch
-			// (phase 0) anchors, independent of [start, end]. epochFloor's
-			// residue from phase 0 does not depend on what offset produced
-			// its input, so re-deriving the floor directly from this shard's
-			// own predicted bounds reproduces the SAME phase every shard
-			// would use — keeping every shard commensurate with the others
-			// and with the unsliced grid.
-			c.End = epochFloor(end, v.Step)
-			c.Start = epochFloor(start, v.Step).Add(v.Step)
-			if c.Start.After(c.End) {
-				c.Start = c.End
-			}
-		} else {
-			c.Start = start
-			c.End = end
-		}
-		// The membership window looks back Offset+Lookback from each anchor;
-		// widen the input spine by that much so every anchor finds its samples.
-		// Offset enters with its sign (a negative offset shifts the window
-		// forward), mirroring the solver-owned sign-aware scan floor.
-		input, err := reanchor(v.Input, c.Start.Add(-v.Offset-v.Lookback), c.End)
-		if err != nil {
-			return nil, err
-		}
-		c.Input = input
-		return &c, nil
+		return reanchorRangeLWR(v, start, end)
 	case *Project:
 		input, err := reanchor(v.Input, start, end)
 		if err != nil {
@@ -278,34 +141,7 @@ func reanchor(n Node, start, end time.Time) (Node, error) {
 		// Predicate is off-grid immutable: share.
 		return &Filter{Input: input, Predicate: v.Predicate}, nil
 	case *VectorJoin:
-		// A step-aligned vector-vector join carries NO own anchor grid and NO
-		// lookback: each arm is an independent windowed spine that already
-		// evaluates over the request grid, and the join step-aligns the two on
-		// the per-anchor TimestampColumn. Re-anchor BOTH arms onto the SAME
-		// [start, end] the join was asked for (no widening — the arms' own
-		// RangeWindow / RangeLWR nodes do their -Range / -Lookback widening),
-		// then copy-on-write the join node, re-filling the two arms and sharing
-		// the immutable modifier fields (Op / Match / Card / Include /
-		// ReturnBool / StepAligned) + the four column names verbatim. An
-		// @-pinned or grid-divergent arm surfaces ErrReanchorGridMismatch from
-		// the recursion, aborting the whole re-anchor to route A. The
-		// instant-mode (!StepAligned) join is kept off this path by the
-		// planner's sawInstantVectorJoin fail-closed guard (its emitter
-		// synthesizes the join-side timestamp with now64(9), a wall-clock that
-		// diverges across shards); registration is by node kind, so the guard —
-		// not this case — is what excludes it.
-		left, err := reanchor(v.Left, start, end)
-		if err != nil {
-			return nil, err
-		}
-		right, err := reanchor(v.Right, start, end)
-		if err != nil {
-			return nil, err
-		}
-		c := *v
-		c.Left = left
-		c.Right = right
-		return &c, nil
+		return reanchorVectorJoin(v, start, end)
 	default:
 		// Off the windowed spine: SHARE the immutable subtree verbatim. The
 		// off-spine subtree is byte-identical across all K shards (it does not
@@ -318,6 +154,193 @@ func reanchor(n Node, start, end time.Time) (Node, error) {
 		// clone it first or it will corrupt sibling shards.
 		return n, nil
 	}
+}
+
+// reanchorRangeWindow re-grids the fan-out matrix window: fill (Start, End,
+// OuterRange) from the requested grid, then recurse into the input spine widened
+// by RangeWindow.InputWindow (Offset+Range of lookback) so every anchor finds
+// the samples its window covers.
+//
+// Instant-shape RangeWindows resolve a single anchor themselves and terminate
+// the walk (mirrors widenSubquerySpine's Step <= 0 guard).
+func reanchorRangeWindow(v *RangeWindow, start, end time.Time) (Node, error) {
+	if v.Step <= 0 {
+		// Instant-shape window: not re-gridded, share verbatim.
+		return v, nil
+	}
+	if err := checkPredictedGrid(v, start, end); err != nil {
+		return nil, err
+	}
+	// Clone only this spine node; GroupBy / Scalars / ScalarExprs are off-grid
+	// immutable, so share the original slice headers (the shard re-grids
+	// Start/End/OuterRange only — it never mutates these).
+	c := *v
+	c.Start = start
+	c.End = end
+	c.OuterRange = end.Sub(start)
+	// Each of this window's anchors looks back Offset+Range (the window is
+	// [End-Offset-Range, End-Offset], see the RangeWindow doc comment); widen
+	// the input spine by that much via the single shared owner of this
+	// arithmetic so the inner grid covers every anchor's window.
+	inStart, inEnd := v.InputWindow(start, end)
+	input, err := reanchor(v.Input, inStart, inEnd)
+	if err != nil {
+		return nil, err
+	}
+	c.Input = input
+	return &c, nil
+}
+
+// reanchorRangeWindowNative re-grids the ClickHouse-native timeSeries<fn>ToGrid
+// lowering of the SAME window semantics reanchorRangeWindow handles: the
+// aggregate is handed (Start, End, Step, Range) and evaluates grid point i from
+// the samples in `(anchor_i - Offset - Range, anchor_i - Offset]`. So
+// re-anchoring is the same two moves — re-grid (Start, End), widen the input
+// spine by Offset+Range — and the same discipline applies: the grid is filled
+// only when the node is either unpinned (the slicer's UnpinSpine shape) or
+// already sits exactly on the predicted grid, and an @-pinned divergence routes
+// A via ErrReanchorGridMismatch.
+//
+// The one structural difference from the fan-out arm is that this node carries
+// no OuterRange field — its grid span IS End-Start — so the guard is
+// checkPredictedGridNative, the RangeLWR-shaped two-bound form rather than the
+// three-bound one.
+func reanchorRangeWindowNative(v *RangeWindowNative, start, end time.Time) (Node, error) {
+	if v.Step <= 0 {
+		// No anchor grid to re-grid. The lowering only builds this node in range
+		// mode, so this is unreachable from a real plan; keeping the arm
+		// symmetric with RangeWindow / RangeLWR means a hand-built or later
+		// instant shape terminates the walk instead of being re-gridded onto
+		// bounds it has no anchors for.
+		return v, nil
+	}
+	if err := checkPredictedGridNative(v, start, end); err != nil {
+		return nil, err
+	}
+	// Clone only this spine node; GroupBy / Recollapse / Scalars are off-grid
+	// immutable, so share the original slice headers.
+	c := *v
+	c.Start = start
+	c.End = end
+	inStart, inEnd := v.InputWindow(start, end)
+	input, err := reanchor(v.Input, inStart, inEnd)
+	if err != nil {
+		return nil, err
+	}
+	c.Input = input
+	return &c, nil
+}
+
+// reanchorUnionAll re-anchors a UNION ALL of independent windowed spines. It
+// carries NO grid and NO lookback of its own: every arm already evaluates over
+// the request grid and each does its own -Offset-Range widening, so every arm
+// re-anchors onto the SAME [start, end] the union was asked for — exactly
+// reanchorVectorJoin's shape, generalised from two fixed sides to N.
+//
+// Re-anchoring EVERY arm is what makes the union re-anchorable at all: the arms
+// are concatenated positionally, so a shard that re-gridded one arm and shared
+// another verbatim would emit one sub-grid's rows beside the full grid's, and
+// the K-way composition would double-count every anchor of the shared arm. An
+// @-pinned or grid-divergent arm surfaces ErrReanchorGridMismatch from the
+// recursion and aborts the whole re-anchor to route A.
+//
+// A union whose arms carry no grid at all (the classic-histogram
+// companion-suffix routing, where the UnionAll sits BENEATH the windowed node)
+// recurses into arms that all hit the share-verbatim default, so this allocates
+// a new Inputs slice and returns an Equal tree — the same cost the Project /
+// Filter arms already pay.
+func reanchorUnionAll(v *UnionAll, start, end time.Time) (Node, error) {
+	inputs := make([]Node, len(v.Inputs))
+	for i, in := range v.Inputs {
+		arm, err := reanchor(in, start, end)
+		if err != nil {
+			return nil, err
+		}
+		inputs[i] = arm
+	}
+	return &UnionAll{Inputs: inputs}, nil
+}
+
+// reanchorRangeLWR re-grids the bare-selector last-with-respect-to leaf. Its
+// eval grid is [Start, End] spaced by Step; each anchor reduces the most-recent
+// sample in its offset-aware staleness window
+// `(anchor - Offset - Lookback, anchor - Offset]`. The per-(series, anchor)
+// value depends only on that window's membership, not on the scan lower bound —
+// it is registered slice-invariant — so re-anchoring to a sub-grid yields
+// exactly the rows route A would have produced for those anchors. Same
+// no-mutate + grid-prediction discipline as the RangeWindow arm: the grid is
+// filled only when the node is either unpinned (the slicer's UnpinSpine shape)
+// or already sits exactly on the predicted grid; an @-pinned divergence routes A
+// via ErrReanchorGridMismatch.
+func reanchorRangeLWR(v *RangeLWR, start, end time.Time) (Node, error) {
+	if v.Step <= 0 {
+		// No anchor grid to re-grid (an instant-shape LWR); share verbatim.
+		return v, nil
+	}
+	if err := checkPredictedGridLWR(v, start, end); err != nil {
+		return nil, err
+	}
+	c := *v
+	if v.StepAlign {
+		// Epoch-aligned subquery inner (see RangeLWR.StepAlign): the
+		// unsliced query would have evaluated this grid at absolute-epoch
+		// (phase 0) anchors, independent of [start, end]. epochFloor's
+		// residue from phase 0 does not depend on what offset produced
+		// its input, so re-deriving the floor directly from this shard's
+		// own predicted bounds reproduces the SAME phase every shard
+		// would use — keeping every shard commensurate with the others
+		// and with the unsliced grid.
+		c.End = epochFloor(end, v.Step)
+		c.Start = epochFloor(start, v.Step).Add(v.Step)
+		if c.Start.After(c.End) {
+			c.Start = c.End
+		}
+	} else {
+		c.Start = start
+		c.End = end
+	}
+	// The membership window looks back Offset+Lookback from each anchor;
+	// widen the input spine by that much so every anchor finds its samples.
+	// Offset enters with its sign (a negative offset shifts the window
+	// forward), mirroring the solver-owned sign-aware scan floor.
+	input, err := reanchor(v.Input, c.Start.Add(-v.Offset-v.Lookback), c.End)
+	if err != nil {
+		return nil, err
+	}
+	c.Input = input
+	return &c, nil
+}
+
+// reanchorVectorJoin re-anchors a step-aligned vector-vector join. It carries
+// NO own anchor grid and NO lookback: each arm is an independent windowed spine
+// that already evaluates over the request grid, and the join step-aligns the two
+// on the per-anchor TimestampColumn. BOTH arms re-anchor onto the SAME
+// [start, end] the join was asked for (no widening — the arms' own RangeWindow /
+// RangeLWR nodes do their -Range / -Lookback widening), then the join node is
+// copy-on-written, re-filling the two arms and sharing the immutable modifier
+// fields (Op / Match / Card / Include / ReturnBool / StepAligned) + the four
+// column names verbatim. An @-pinned or grid-divergent arm surfaces
+// ErrReanchorGridMismatch from the recursion, aborting the whole re-anchor to
+// route A.
+//
+// The instant-mode (!StepAligned) join is kept off this path by the planner's
+// sawInstantVectorJoin fail-closed guard (its emitter synthesizes the join-side
+// timestamp with now64(9), a wall-clock that diverges across shards);
+// registration is by node kind, so that guard — not this function — is what
+// excludes it.
+func reanchorVectorJoin(v *VectorJoin, start, end time.Time) (Node, error) {
+	left, err := reanchor(v.Left, start, end)
+	if err != nil {
+		return nil, err
+	}
+	right, err := reanchor(v.Right, start, end)
+	if err != nil {
+		return nil, err
+	}
+	c := *v
+	c.Left = left
+	c.Right = right
+	return &c, nil
 }
 
 // checkPredictedGrid asserts a matrix RangeWindow's current bounds match

--- a/internal/chplan/reanchor_native_union_test.go
+++ b/internal/chplan/reanchor_native_union_test.go
@@ -1,0 +1,288 @@
+package chplan_test
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/tsouza/cerberus/internal/chplan"
+)
+
+// nativeNode builds a RangeWindowNative over a leaf scan for the given grid +
+// offset — the ClickHouse-native timeSeries<fn>ToGrid shape ReanchorRange
+// re-grids (issue #2117).
+func nativeNode(start, end time.Time, step, rang, offset time.Duration) *chplan.RangeWindowNative {
+	return &chplan.RangeWindowNative{
+		Input:           &chplan.Scan{Table: "metrics", Columns: []string{"Value", "TimeUnix"}},
+		Func:            "rate",
+		Range:           rang,
+		Step:            step,
+		Start:           start,
+		End:             end,
+		Offset:          offset,
+		TimestampColumn: "TimeUnix",
+		ValueColumn:     "Value",
+		GroupBy:         []chplan.Expr{&chplan.ColumnRef{Name: "Attributes"}},
+	}
+}
+
+// nativeOverWindow builds a RangeWindowNative whose Input is a matrix
+// RangeWindow, so the widening the native arm applies to its inner spine is
+// OBSERVABLE: the inner window's re-anchored Start is the only place
+// Offset+Range shows up.
+func nativeOverWindow(step, rang, offset time.Duration) *chplan.RangeWindowNative {
+	n := nativeNode(time.Time{}, time.Time{}, step, rang, offset)
+	n.Input = matrixWindow(time.Minute, step, 0)
+	return n
+}
+
+// TestReanchorRange_NativeReGrids asserts an unpinned RangeWindowNative is
+// re-anchored onto the requested sub-grid, that its non-grid fields survive,
+// and that the input tree is left byte-identical (copy-not-mutate).
+func TestReanchorRange_NativeReGrids(t *testing.T) {
+	t.Parallel()
+	for _, tc := range []struct {
+		name   string
+		offset time.Duration
+	}{
+		{"zero offset", 0},
+		{"negative offset", -5 * time.Minute},
+		{"positive offset", time.Hour},
+	} {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			const rang = 5 * time.Minute
+			in := nativeNode(time.Time{}, time.Time{}, time.Minute, rang, tc.offset)
+			snapshot := chplan.CloneNode(in)
+
+			subStart := time.Unix(1600, 0).UTC()
+			subEnd := time.Unix(4000, 0).UTC()
+
+			out, err := chplan.ReanchorRange(in, subStart, subEnd)
+			if err != nil {
+				t.Fatalf("ReanchorRange: %v", err)
+			}
+			r := out.(*chplan.RangeWindowNative)
+			if !r.Start.Equal(subStart) || !r.End.Equal(subEnd) {
+				t.Fatalf("re-anchored bounds wrong: Start=%v End=%v", r.Start, r.End)
+			}
+			if r.Range != rang || r.Offset != tc.offset || r.Step != time.Minute || r.Func != "rate" {
+				t.Fatalf("re-anchor lost a non-grid field: %+v", r)
+			}
+			if !in.Equal(snapshot) {
+				t.Fatal("ReanchorRange mutated its RangeWindowNative input")
+			}
+		})
+	}
+}
+
+// TestReanchorRange_NativeWidensInputSpine asserts the native arm widens its
+// INPUT by Offset+Range — the arithmetic RangeWindowNative.InputWindow owns and
+// the solver's signal walk predicts. A shard whose inner spine is not widened
+// starts its scan at the shard's own oldest anchor, so that anchor's window is
+// missing every sample older than it and the shard's first grid points are
+// wrong (or absent) in a way no full-grid test can see.
+func TestReanchorRange_NativeWidensInputSpine(t *testing.T) {
+	t.Parallel()
+	for _, tc := range []struct {
+		name   string
+		offset time.Duration
+	}{
+		{"zero offset", 0},
+		{"negative offset", -3 * time.Minute},
+		{"positive offset", 30 * time.Minute},
+	} {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			const rang = 5 * time.Minute
+			in := nativeOverWindow(time.Minute, rang, tc.offset)
+
+			start := time.Unix(10_000, 0).UTC()
+			end := time.Unix(20_000, 0).UTC()
+			out, err := chplan.ReanchorRange(in, start, end)
+			if err != nil {
+				t.Fatalf("ReanchorRange: %v", err)
+			}
+			inner := out.(*chplan.RangeWindowNative).Input.(*chplan.RangeWindow)
+
+			wantStart, wantEnd := in.InputWindow(start, end)
+			if !inner.Start.Equal(wantStart) || !inner.End.Equal(wantEnd) {
+				t.Fatalf("inner spine at [%v,%v], want InputWindow [%v,%v]",
+					inner.Start, inner.End, wantStart, wantEnd)
+			}
+			// Non-vacuity: the widening really moved the inner start.
+			if wantStart.Equal(start) {
+				t.Fatalf("InputWindow returned the unwidened start for offset=%s range=%s; "+
+					"the assertion above would hold for a node that widened by nothing",
+					tc.offset, rang)
+			}
+		})
+	}
+}
+
+// TestReanchorRange_NativeAcceptsAlreadyGridded: a RangeWindowNative already
+// sitting exactly on the predicted grid re-anchors without error — the shape a
+// top-level range-mode rate() carries before UnpinSpine touches it.
+func TestReanchorRange_NativeAcceptsAlreadyGridded(t *testing.T) {
+	t.Parallel()
+	start := time.Unix(1000, 0).UTC()
+	end := time.Unix(4600, 0).UTC()
+	in := nativeNode(start, end, time.Minute, 5*time.Minute, 0)
+	out, err := chplan.ReanchorRange(in, start, end)
+	if err != nil {
+		t.Fatalf("already-gridded RangeWindowNative should re-anchor cleanly, got %v", err)
+	}
+	r := out.(*chplan.RangeWindowNative)
+	if !r.Start.Equal(start) || !r.End.Equal(end) {
+		t.Fatalf("bounds drifted: %v %v", r.Start, r.End)
+	}
+}
+
+// TestReanchorRange_NativeRejectsAtPin: a RangeWindowNative whose bounds
+// diverge from the predicted grid (an @-pinned anchor) is rejected, so the
+// solver aborts the Decision to route A rather than emit shards that silently
+// disagree with @ semantics.
+func TestReanchorRange_NativeRejectsAtPin(t *testing.T) {
+	t.Parallel()
+	in := nativeNode(time.Unix(9999-3600, 0).UTC(), time.Unix(9999, 0).UTC(), time.Minute, 5*time.Minute, 0)
+	_, err := chplan.ReanchorRange(in, time.Unix(1000, 0).UTC(), time.Unix(4600, 0).UTC())
+	if !errors.Is(err, chplan.ErrReanchorGridMismatch) {
+		t.Fatalf("expected ErrReanchorGridMismatch for an @-pinned RangeWindowNative, got %v", err)
+	}
+}
+
+// TestReanchorRange_NativeSpineNodeIsCloned: the COW contract on the native
+// spine node. The re-gridded node is a fresh clone, so re-gridding one shard
+// never moves another's (or the input's) grid.
+func TestReanchorRange_NativeSpineNodeIsCloned(t *testing.T) {
+	t.Parallel()
+	in := nativeNode(time.Time{}, time.Time{}, time.Minute, 5*time.Minute, -5*time.Minute)
+	snapshot := chplan.CloneNode(in)
+
+	out, err := chplan.ReanchorRange(in, time.Unix(1000, 0).UTC(), time.Unix(4600, 0).UTC())
+	if err != nil {
+		t.Fatalf("ReanchorRange: %v", err)
+	}
+	r := out.(*chplan.RangeWindowNative)
+	if r == in {
+		t.Fatal("ReanchorRange returned the same RangeWindowNative pointer (spine must be cloned)")
+	}
+	r.Start = time.Unix(0, 0).UTC()
+	r.End = time.Unix(1, 0).UTC()
+	r.Offset = 999 * time.Hour
+
+	if !in.Equal(snapshot) {
+		t.Fatal("re-gridding the cloned native spine node leaked into the input")
+	}
+	if r.Input != in.Input {
+		t.Fatal("off-spine Input was copied; COW requires it be shared")
+	}
+}
+
+// TestReanchorRange_UnionAllReAnchorsEveryArm is the pin for the mixed spine
+// issue #2117 exists to unblock: `UnionAll{RangeWindowNative, RangeWindow}`.
+//
+// Both arms must land on the SAME re-anchored grid. The arms are concatenated
+// positionally, so a shard that re-gridded one and shared the other verbatim
+// would emit one sub-grid's rows beside the full grid's, and the K-way
+// composition would double-count every anchor of the arm that did not move —
+// silently, since both arms still project the same column shape.
+func TestReanchorRange_UnionAllReAnchorsEveryArm(t *testing.T) {
+	t.Parallel()
+
+	native := nativeNode(time.Time{}, time.Time{}, time.Minute, 5*time.Minute, 0)
+	fanout := matrixWindow(5*time.Minute, time.Minute, 0)
+	in := &chplan.UnionAll{Inputs: []chplan.Node{native, fanout}}
+	snapshot := chplan.CloneNode(in)
+
+	start := time.Unix(1000, 0).UTC()
+	end := time.Unix(4600, 0).UTC()
+
+	out, err := chplan.ReanchorRange(in, start, end)
+	if err != nil {
+		t.Fatalf("ReanchorRange: %v", err)
+	}
+	u, ok := out.(*chplan.UnionAll)
+	if !ok {
+		t.Fatalf("ReanchorRange returned %T, want *chplan.UnionAll", out)
+	}
+	if len(u.Inputs) != len(in.Inputs) {
+		t.Fatalf("arm count changed: %d -> %d", len(in.Inputs), len(u.Inputs))
+	}
+
+	gotNative := u.Inputs[0].(*chplan.RangeWindowNative)
+	if !gotNative.Start.Equal(start) || !gotNative.End.Equal(end) {
+		t.Errorf("native arm at [%v,%v], want [%v,%v]", gotNative.Start, gotNative.End, start, end)
+	}
+	gotFanout := u.Inputs[1].(*chplan.RangeWindow)
+	if !gotFanout.Start.Equal(start) || !gotFanout.End.Equal(end) {
+		t.Errorf("fan-out arm at [%v,%v], want [%v,%v]", gotFanout.Start, gotFanout.End, start, end)
+	}
+	if gotFanout.OuterRange != end.Sub(start) {
+		t.Errorf("fan-out arm OuterRange = %s, want %s", gotFanout.OuterRange, end.Sub(start))
+	}
+
+	if !in.Equal(snapshot) {
+		t.Fatal("ReanchorRange mutated its UnionAll input")
+	}
+	if u == in {
+		t.Fatal("ReanchorRange returned the same UnionAll pointer (the arm slice must be fresh)")
+	}
+}
+
+// TestReanchorRange_UnionAllPropagatesArmMismatch: a single @-pinned arm aborts
+// the whole re-anchor. Re-anchoring the other arms and dropping this one would
+// produce a shard set whose union is missing that arm's rows entirely.
+func TestReanchorRange_UnionAllPropagatesArmMismatch(t *testing.T) {
+	t.Parallel()
+
+	pinned := nativeNode(time.Unix(9999-3600, 0).UTC(), time.Unix(9999, 0).UTC(),
+		time.Minute, 5*time.Minute, 0)
+	in := &chplan.UnionAll{Inputs: []chplan.Node{
+		matrixWindow(5*time.Minute, time.Minute, 0),
+		pinned,
+	}}
+
+	_, err := chplan.ReanchorRange(in, time.Unix(1000, 0).UTC(), time.Unix(4600, 0).UTC())
+	if !errors.Is(err, chplan.ErrReanchorGridMismatch) {
+		t.Fatalf("expected ErrReanchorGridMismatch from the @-pinned arm, got %v", err)
+	}
+}
+
+// TestReanchorRange_UnionAllBelowSpineIsUnchanged pins the pre-existing shape
+// this arm must not disturb: the classic-histogram companion-suffix routing
+// puts the UnionAll BENEATH the windowed node, over arms that carry no grid at
+// all. Those arms hit the share-verbatim default, so the re-anchored tree must
+// be Equal to the input with the window's grid filled and nothing else moved.
+func TestReanchorRange_UnionAllBelowSpineIsUnchanged(t *testing.T) {
+	t.Parallel()
+
+	armA := &chplan.Scan{Table: "otel_metrics_sum", Columns: []string{"Value", "TimeUnix"}}
+	armB := &chplan.Scan{Table: "otel_metrics_histogram", Columns: []string{"Value", "TimeUnix"}}
+	union := &chplan.UnionAll{Inputs: []chplan.Node{armA, armB}}
+	in := matrixWindow(5*time.Minute, time.Minute, 0)
+	in.Input = union
+	snapshot := chplan.CloneNode(in)
+
+	start := time.Unix(1000, 0).UTC()
+	end := time.Unix(4600, 0).UTC()
+	out, err := chplan.ReanchorRange(in, start, end)
+	if err != nil {
+		t.Fatalf("ReanchorRange: %v", err)
+	}
+
+	gotUnion := out.(*chplan.RangeWindow).Input.(*chplan.UnionAll)
+	if !gotUnion.Equal(union) {
+		t.Fatal("a grid-free UnionAll below the spine was altered by re-anchoring")
+	}
+	if gotUnion.Inputs[0] != chplan.Node(armA) || gotUnion.Inputs[1] != chplan.Node(armB) {
+		t.Fatal("grid-free UnionAll arms were copied; they must be shared verbatim")
+	}
+	if !in.Equal(snapshot) {
+		t.Fatal("ReanchorRange mutated its input")
+	}
+}

--- a/internal/chplan/sliceinvariant.go
+++ b/internal/chplan/sliceinvariant.go
@@ -48,6 +48,23 @@ func IsSliceInvariant(n Node) bool {
 //     bounded sample-fan-out families: each (series, anchor) value is the
 //     reduce of exactly that anchor's `(anchor - Offset - Range, anchor -
 //     Offset]` window membership, independent of the scan lower bound.
+//   - RangeWindowNative — the ClickHouse-native timeSeries<fn>ToGrid lowering
+//     of the SAME window semantics. The aggregate is handed (start, end, step,
+//     window) and evaluates grid point i from exactly the samples inside
+//     `(anchor_i - Offset - Range, anchor_i - Offset]`, so its per-(series,
+//     anchor) value is scan-lower-bound-independent for the identical reason
+//     the fan-out arm's is — the criterion above, not a resemblance argument.
+//     Note what is NOT being claimed: the aggregate's INTERNAL evaluation is
+//     order-dependent (extrapolatedRate walks the window's samples in time
+//     order and reads the first/last pair), but that order is a property of
+//     the window's own membership, which slicing does not touch. The hazard
+//     this registry exists to police is a value seeded at the SCAN's first row
+//     (lagInFrame), and the aggregate reads no such seed: every shard hands it
+//     a scan widened by Offset+Range past that shard's oldest anchor, so each
+//     grid point sees the same sample multiset it saw unsliced. Measured
+//     against the fan-out arm on a 500k-row / 5000-series seed across three
+//     temporality mixes: identical cell key sets, zero missing and zero extra
+//     cells (issue #2117).
 //   - StepGrid — emits the anchor grid itself; a sub-grid is a subset.
 //   - UnionAll — slice-invariant iff every arm is (checked structurally by
 //     the whole-plan walk, since each arm is itself visited).
@@ -71,8 +88,9 @@ func IsSliceInvariant(n Node) bool {
 //     each is its own PR.
 //
 // Extension point. Phase-3 node families (TopK as per-anchor LIMIT K BY,
-// VectorSetOp, HistogramQuantile{,Native}, AbsentOverTime, the metrics_*
-// TraceQL family, nested spines under the lcm clamp) are DELIBERATELY ABSENT:
+// VectorSetOp, HistogramQuantile{,Native}, AbsentOverTime, RangeWindowResample,
+// the metrics_* TraceQL family, nested spines under the lcm clamp) are
+// DELIBERATELY ABSENT:
 // each enters this registry only with its own slice-invariance proof + the
 // reset-at-seam fixture family, one node family per PR. To register a kind,
 // argue its per-(series, anchor) output is scan-lower-bound-independent, add
@@ -85,6 +103,7 @@ var sliceInvariantKinds = func() map[reflect.Type]struct{} {
 		&Project{},
 		&Aggregate{},
 		&RangeWindow{},
+		&RangeWindowNative{},
 		&RangeLWR{},
 		&RangeBucketFanout{},
 		&StepGrid{},

--- a/internal/chplan/sliceinvariant_test.go
+++ b/internal/chplan/sliceinvariant_test.go
@@ -19,6 +19,7 @@ func sliceInvariantRegisteredKinds() []chplan.Node {
 		&chplan.Project{},
 		&chplan.Aggregate{},
 		&chplan.RangeWindow{},
+		&chplan.RangeWindowNative{},
 		&chplan.RangeLWR{},
 		&chplan.RangeBucketFanout{},
 		&chplan.StepGrid{},
@@ -81,14 +82,16 @@ func TestIsSliceInvariant_UnregisteredKinds(t *testing.T) {
 	// fail-closed guard. VectorSetOp / NaryVectorSetOp are deliberately
 	// default-denied: set-op family nodes (and/or/unless), absent from
 	// sliceInvariantKinds until their own slice-invariance proof + §Parity
-	// lanes land. RangeWindowNative is also default-denied: the experimental
-	// native-rate node is never routed by the solver (ReanchorRange does not
-	// re-grid it), so it fails closed to route A — exactly the safe default for
-	// an opt-in node. InfoJoin is a join-family node whose Info arm is a
-	// point-in-time label lookup, not a sliced row stream, so it stays
-	// default-denied. RangeWindowResample (a re-gridding range node) and
-	// SearchTraceLimit (a per-trace cap) are likewise default-denied — neither
-	// is a simple sliced row stream. HistogramProjection is default-denied
+	// lanes land. RangeWindowNative is now REGISTERED (issue #2117): the
+	// timeSeries*ToGrid aggregate evaluates grid point i from exactly the
+	// samples in that anchor's own window, which is the registry's criterion,
+	// and chplan.ReanchorRange re-grids it so a routed plan really is
+	// partitioned rather than repeated. InfoJoin is a join-family node whose
+	// Info arm is a point-in-time label lookup, not a sliced row stream, so it
+	// stays default-denied. RangeWindowResample (a re-gridding range node whose
+	// grid ReanchorRange does not yet re-anchor) and SearchTraceLimit (a
+	// per-trace cap) are likewise default-denied — neither is a simple sliced
+	// row stream. HistogramProjection is default-denied
 	// too: like HistogramQuantileNative, it aggregates bucket columns per
 	// group from its input rather than passing a sliced row stream through
 	// unchanged, and no lowering builds it yet regardless.

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -1213,8 +1213,45 @@ func (e *Engine) classify(plan chplan.Node, lang Lang) (*solver.Decision, bool) 
 // declaration a property of the adapter's Meta, exactly as on route A. It
 // survives to each shard's QueryCursor by ordinary ctx nesting; internal/
 // solver's response_shape_wiring_test.go pins that arrival.
-func routeBExecCtx(ctx context.Context, langName, responseShape string) context.Context {
-	return chclient.WithResponseShape(chclient.WithProgressFor(ctx, langName), responseShape)
+//
+// It also carries route A's per-plan ts-grid rule across to route B: a shard
+// whose plan contains a node from the experimental timeSeries*ToGrid family
+// needs `allow_experimental_time_series_aggregate_functions=1` exactly as a
+// route-A statement does, and ClickHouse answers code 63 ("aggregate function
+// ... is experimental and disabled by default") on every shard without it. The
+// rule reads the DECISION's own shard plans rather than the pre-slice plan
+// because those are the trees the Executor emits; they are re-anchored copies
+// of the same spine, so the two agree, and reading what is emitted is what
+// keeps them agreeing.
+//
+// This became reachable when RangeWindowNative entered the routable spine
+// family (issue #2117). Before that every ts-grid-carrying plan was refused as
+// not-sliceable — by the slice-invariance registry on the main spine and by the
+// same registry inside walkScalarInterior for an Expr-embedded one — so no
+// route-B dispatch could carry the family at all.
+func routeBExecCtx(ctx context.Context, langName, responseShape string, decision *solver.Decision) context.Context {
+	ctx = chclient.WithResponseShape(chclient.WithProgressFor(ctx, langName), responseShape)
+	if decisionHasTSGridNative(decision) {
+		ctx = chclient.WithTSGridSetting(ctx)
+	}
+	return ctx
+}
+
+// decisionHasTSGridNative reports whether ANY shard plan of decision carries a
+// node from the experimental timeSeries*ToGrid family. One shard is enough: the
+// setting rides the shared dispatch ctx, and every shard of a routed plan is a
+// re-anchored copy of the same spine, so the family is present in all of them or
+// in none.
+func decisionHasTSGridNative(decision *solver.Decision) bool {
+	if decision == nil {
+		return false
+	}
+	for _, s := range decision.Slices {
+		if planHasTSGridNative(s.Plan) {
+			return true
+		}
+	}
+	return false
 }
 
 // executeRouted runs the dormant route-B path: it dispatches the K shard
@@ -1236,7 +1273,7 @@ func (e *Engine) executeRouted(
 	execT := telemetry.ObserveStage(telemetry.StageExecute, lang.Name())
 	start := time.Now()
 	cursor, info, err := e.Solver.Executor.Execute(
-		routeBExecCtx(ctx, lang.Name(), meta.ResponseShape), lang.Name(), decision, chclient.SampleBudgetFromContext(ctx),
+		routeBExecCtx(ctx, lang.Name(), meta.ResponseShape, decision), lang.Name(), decision, chclient.SampleBudgetFromContext(ctx),
 	)
 	if err != nil {
 		execT.Done(ctx)
@@ -1706,7 +1743,7 @@ func (e *Engine) executeRoutedCursor(
 	}
 	execT := telemetry.ObserveStage(telemetry.StageExecute, lang.Name())
 	cursor, info, err := e.Solver.Executor.Execute(
-		routeBExecCtx(ctx, lang.Name(), meta.ResponseShape), lang.Name(), decision, chclient.SampleBudgetFromContext(ctx),
+		routeBExecCtx(ctx, lang.Name(), meta.ResponseShape, decision), lang.Name(), decision, chclient.SampleBudgetFromContext(ctx),
 	)
 	execT.Done(ctx)
 	if err != nil {

--- a/internal/engine/route_b_tsgrid_setting_test.go
+++ b/internal/engine/route_b_tsgrid_setting_test.go
@@ -1,0 +1,151 @@
+package engine
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/tsouza/cerberus/internal/chclient"
+	"github.com/tsouza/cerberus/internal/chplan"
+	"github.com/tsouza/cerberus/internal/solver"
+)
+
+// tsGridRouteBGrid is the shard grid the fixtures below sit on. The bounds are
+// arbitrary — nothing in this file reads them back — but they are pinned so a
+// shard plan is a realistic re-anchored node rather than a zero-valued one.
+var (
+	tsGridRouteBStart = time.Date(2026, 6, 13, 0, 0, 0, 0, time.UTC)
+	tsGridRouteBEnd   = tsGridRouteBStart.Add(30 * time.Minute)
+	tsGridRouteBStep  = 15 * time.Second
+)
+
+// tsGridRouteBDecision builds a two-shard routed Decision whose shard plans are
+// each `wrap(<leaf>)`. It stands in for what the Planner hands the Executor: the
+// setting rule must read THESE trees, since they are what gets emitted.
+func tsGridRouteBDecision(wrap func() chplan.Node) *solver.Decision {
+	return &solver.Decision{
+		Strategy: solver.StrategyShardedTimeslice,
+		K:        2,
+		Reason:   solver.ReasonRouted,
+		Slices: []solver.Slice{
+			{Index: 0, Start: tsGridRouteBStart, End: tsGridRouteBEnd, Plan: wrap()},
+			{Index: 1, Start: tsGridRouteBStart, End: tsGridRouteBEnd, Plan: wrap()},
+		},
+	}
+}
+
+func tsGridRouteBNativeShard() chplan.Node {
+	return &chplan.Aggregate{
+		Input: &chplan.RangeWindowNative{
+			Input:           &chplan.Scan{Table: "otel_metrics_sum"},
+			Func:            "rate",
+			Range:           5 * time.Minute,
+			Step:            tsGridRouteBStep,
+			Start:           tsGridRouteBStart,
+			End:             tsGridRouteBEnd,
+			TimestampColumn: "TimeUnix",
+			ValueColumn:     "Value",
+		},
+		AggFuncs: []chplan.AggFunc{{Name: "sum", Args: []chplan.Expr{&chplan.ColumnRef{Name: "Value"}}}},
+	}
+}
+
+func tsGridRouteBFanoutShard() chplan.Node {
+	return &chplan.Aggregate{
+		Input: &chplan.RangeWindow{
+			Input:           &chplan.Scan{Table: "otel_metrics_sum"},
+			Func:            "rate",
+			Range:           5 * time.Minute,
+			Step:            tsGridRouteBStep,
+			OuterRange:      tsGridRouteBEnd.Sub(tsGridRouteBStart),
+			Start:           tsGridRouteBStart,
+			End:             tsGridRouteBEnd,
+			TimestampColumn: "TimeUnix",
+			ValueColumn:     "Value",
+		},
+		AggFuncs: []chplan.AggFunc{{Name: "sum", Args: []chplan.Expr{&chplan.ColumnRef{Name: "Value"}}}},
+	}
+}
+
+// TestRouteBExecCtx_StampsTSGridSettingForNativeShards pins that route B
+// carries route A's per-plan experimental-aggregate rule.
+//
+// `timeSeries*ToGrid` is an experimental ClickHouse aggregate: without
+// `allow_experimental_time_series_aggregate_functions=1` the server answers code
+// 63 on EVERY shard, so a routed native plan fails outright rather than
+// degrading. Route A stamps it in execContext; route B's dispatch ctx is built
+// somewhere else entirely, and until RangeWindowNative joined the routable spine
+// family (issue #2117) no route-B dispatch could carry the family, so the two
+// paths were never both required to know the rule.
+//
+// The three cases are the three shapes that matter, and each fails differently
+// if the rule is wrong: the native shard (missing setting -> code 63), the
+// Expr-embedded interior (the WalkDeep case chplan.Walk cannot see, which the
+// scalar-anchor-compatibility check now admits into a ROUTED plan), and the
+// plain fan-out shard (a stray experimental setting on an unrelated query,
+// which can itself error on an older server).
+func TestRouteBExecCtx_StampsTSGridSettingForNativeShards(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name  string
+		wrap  func() chplan.Node
+		stamp bool
+	}{
+		{name: "native shard spine", wrap: tsGridRouteBNativeShard, stamp: true},
+		{
+			// The ts-grid node hangs off an Expr slot (a per-step scalar
+			// parameter's ScalarSubquery), which chplan.Walk does not follow.
+			// planHasTSGridNative uses WalkDeep precisely for this.
+			name: "native only inside a scalar interior",
+			wrap: func() chplan.Node {
+				return &chplan.Filter{
+					Input: tsGridRouteBFanoutShard(),
+					Predicate: &chplan.Binary{
+						Op:    chplan.OpGt,
+						Left:  &chplan.ColumnRef{Name: "Value"},
+						Right: &chplan.ScalarSubquery{Input: tsGridRouteBNativeShard()},
+					},
+				}
+			},
+			stamp: true,
+		},
+		{name: "fan-out shard spine", wrap: tsGridRouteBFanoutShard, stamp: false},
+	} {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			ctx := routeBExecCtx(context.Background(), "promql",
+				chclient.ResponseShapeMatrix, tsGridRouteBDecision(tc.wrap))
+
+			settings := chclient.QuerySettingsFromContext(ctx)
+			_, got := settings[chclient.SettingExperimentalTSGridAggregate]
+			if got != tc.stamp {
+				t.Fatalf("%s present = %v, want %v — a missing setting makes every shard "+
+					"answer ClickHouse code 63; a stray one rides a query that does not need it",
+					chclient.SettingExperimentalTSGridAggregate, got, tc.stamp)
+			}
+
+			// The pre-existing route-B ctx values must survive the addition:
+			// the AND-gate for the columnar matrix decode reads the response
+			// shape off this same ctx.
+			if shape := chclient.ResponseShapeFromContext(ctx); shape != chclient.ResponseShapeMatrix {
+				t.Errorf("ResponseShape = %q, want %q", shape, chclient.ResponseShapeMatrix)
+			}
+		})
+	}
+}
+
+// TestRouteBExecCtx_NilDecisionStampsNothing pins the degenerate input. A nil
+// Decision reaches this seam only from a wiring bug, and inventing an
+// experimental setting for a dispatch nobody classified would put the knob on a
+// query that may not tolerate it.
+func TestRouteBExecCtx_NilDecisionStampsNothing(t *testing.T) {
+	t.Parallel()
+
+	ctx := routeBExecCtx(context.Background(), "promql", chclient.ResponseShapeMatrix, nil)
+	if settings := chclient.QuerySettingsFromContext(ctx); len(settings) != 0 {
+		t.Fatalf("nil decision stamped settings %v", settings)
+	}
+}

--- a/internal/engine/route_memo_wiring.go
+++ b/internal/engine/route_memo_wiring.go
@@ -175,7 +175,7 @@ func (e *Engine) tryRouteMemoHit(
 	defer dispatchDone()
 
 	cur, execInfo, err := e.Solver.Executor.Execute(
-		routeBExecCtx(ctx, langName, responseShape), langName, d.decision, budget,
+		routeBExecCtx(ctx, langName, responseShape, d.decision), langName, d.decision, budget,
 	)
 	if err != nil {
 		// A pre-flight failure (breaker/emit/gate/now64) classifies
@@ -285,7 +285,7 @@ func (e *Engine) retryOnRouteAResourceFailure(
 	dispatchDone := telemetry.ObserveRoutedDispatchInflight(ctx)
 
 	cur, execInfo, dispatchErr := e.Solver.Executor.Execute(
-		routeBExecCtx(ctx, langName, responseShape), langName, d.decision, budget,
+		routeBExecCtx(ctx, langName, responseShape, d.decision), langName, d.decision, budget,
 	)
 	if dispatchErr != nil {
 		// A pre-flight failure classifies NoEvidence by construction —

--- a/internal/solver/carrier_geometry_test.go
+++ b/internal/solver/carrier_geometry_test.go
@@ -40,7 +40,11 @@ type carrierCase struct {
 	plan func() chplan.Node
 	// wantD is the cumulative per-anchor lookback the extractor must record.
 	wantD time.Duration
-	// wantFanout is wantD / gridStep.
+	// wantFanout is the per-sample intermediate-row count the extractor must
+	// record: wantD / gridStep for a carrier that materialises the
+	// (sample, anchor) matrix, and singlePassFanout for the native
+	// timeSeries*ToGrid family, which reads each sample exactly once whatever
+	// its window width is (carrierGeometry.singlePass).
 	wantFanout int64
 	// reanchorable says whether chplan.ReanchorRange re-grids this kind. It is
 	// the ONLY thing that decides whether the plan may be sliced; every row
@@ -97,6 +101,14 @@ func carrierCases() []carrierCase {
 			// The regression this whole table exists for: a natively-lowered
 			// rate() is the plan's ONLY carrier, so an extractor blind to it
 			// records nothing at all.
+			//
+			// It is re-anchorable (chplan.ReanchorRange re-grids it, the
+			// slicer's UnpinSpine zeroes it) and single-pass: the aggregate
+			// materialises no (sample, anchor) matrix, so its fan-out is
+			// singlePassFanout, NOT geomNativeRange/gridStep. That pairing is
+			// the whole point — sliceable when the evidence says slice, and
+			// below MinFanout on its own so ModeAuto does not shard a
+			// flat-memory statement for a memory problem it does not have.
 			kind: "RangeWindowNative",
 			plan: func() chplan.Node {
 				return &chplan.RangeWindowNative{
@@ -112,10 +124,16 @@ func carrierCases() []carrierCase {
 				}
 			},
 			wantD:        geomNativeRange,
-			wantFanout:   int64(geomNativeRange / gridStep),
-			reanchorable: false,
+			wantFanout:   singlePassFanout,
+			reanchorable: true,
 		},
 		{
+			// The other member of the native timeSeries*ToGrid family, and the
+			// reason singlePass is a property of the EMITTER family rather than
+			// a per-kind special case: it builds no (sample, anchor) matrix
+			// either, so its fan-out is singlePassFanout for exactly the same
+			// reason. It is not re-anchored, so that answer is telemetry only —
+			// the row is refused by the reanchorable fail-close whatever its F.
 			kind: "RangeWindowResample",
 			plan: func() chplan.Node {
 				return &chplan.RangeWindowResample{
@@ -131,7 +149,7 @@ func carrierCases() []carrierCase {
 				}
 			},
 			wantD:        geomResampleLookback,
-			wantFanout:   int64(geomResampleLookback / gridStep),
+			wantFanout:   singlePassFanout,
 			reanchorable: false,
 		},
 		{
@@ -367,23 +385,13 @@ func TestCarrierGeometryOf_UnclassifiableCarrierFailsClosed(t *testing.T) {
 	}
 }
 
-// TestCarrierGeometry_NativeIsMeasuredButNeverSliceable is the correctness pin
-// for the exact hazard widening extraction creates: making the solver SEE a
-// carrier must not make the slicer TAKE it.
-//
-// The subject is the shape the whole defect was found on — a natively-lowered
-// rate() whose RangeWindowNative is the plan's only grid carrier. Before the
-// fix it extracted nothing; after it, the Decision carries a real cost grid.
-// Both halves are asserted together, because either one alone is satisfiable by
-// a wrong change: extracting nothing still "never slices", and registering the
-// node slice-invariant would extract features while shipping wrong answers
-// (ReanchorRange clones the node verbatim, so every shard would evaluate the
-// ORIGINAL full grid and the merged result would be the query repeated K times
-// rather than partitioned).
-func TestCarrierGeometry_NativeIsMeasuredButNeverSliceable(t *testing.T) {
-	t.Parallel()
+// nativeCarrierPlan builds the dominant natively-lowered shape —
+// `sum(rate(m[3m]))` with the rate on the timeSeriesRateToGrid path — whose
+// RangeWindowNative is the plan's ONLY grid carrier. It is the subject of the
+// three native pins below, built from the table row so the two cannot drift.
+func nativeCarrierPlan(t *testing.T) (plan, native chplan.Node) {
+	t.Helper()
 
-	var native chplan.Node
 	for _, tc := range carrierCases() {
 		if tc.kind == "RangeWindowNative" {
 			native = tc.plan()
@@ -392,40 +400,163 @@ func TestCarrierGeometry_NativeIsMeasuredButNeverSliceable(t *testing.T) {
 	if native == nil {
 		t.Fatal("carrierCases lost its RangeWindowNative row; this pin has no subject")
 	}
-
-	// The dominant real shape: sum(rate(...)) with the rate lowered natively.
-	plan := &chplan.Aggregate{
+	return &chplan.Aggregate{
 		Input:    native,
 		AggFuncs: []chplan.AggFunc{{Name: "sum", Args: []chplan.Expr{&chplan.ColumnRef{Name: "Value"}}}},
-	}
+	}, native
+}
+
+// TestCarrierGeometry_NativeIsMeasuredAndSliceable pins BOTH halves of the
+// natively-lowered spine's classification, which are independently wrong-able.
+//
+// Measurement half: the plan's only carrier is the RangeWindowNative, so an
+// extractor blind to it records an all-zero cost grid — the regression the
+// seven-kind table exists for, restated here on the real sum(rate(...)) shape.
+//
+// Slicing half: the node IS re-anchorable (issue #2117 — chplan.ReanchorRange
+// re-grids it, the slicer's UnpinSpine zeroes it, and it is registered
+// slice-invariant), so the threshold-free Eligible seam routes it. That seam is
+// the failure-driven route memo's, which fires on a REAL route-A resource
+// failure rather than on a cost proxy — precisely the evidence that justifies
+// paying K scans for a native plan.
+//
+// Both are asserted together because either alone is satisfiable by a wrong
+// change: a node that is never sliceable "passes" any measurement assertion,
+// and a node sliced without ReanchorRange knowing its grid would hand every
+// shard the ORIGINAL full-grid bounds and merge the query repeated K times.
+func TestCarrierGeometry_NativeIsMeasuredAndSliceable(t *testing.T) {
+	t.Parallel()
+
+	plan, native := nativeCarrierPlan(t)
 
 	start, end, step := GridOf(plan)
 	meta := RequestMeta{Lang: LangPromQL, Start: start, End: end, Step: step}
 
 	// Measurement half.
-	d, routed := (&Planner{Cfg: autoCfg()}).Plan(plan, meta)
+	d, _ := (&Planner{Cfg: autoCfg()}).Plan(plan, meta)
 	if d.NAnchors == 0 || d.OuterRange == 0 || d.CumulativeD == 0 || d.Fanout == 0 {
 		t.Errorf("natively-lowered rate() extracted N=%d OuterRange=%s D=%s F=%d — an all-zero "+
 			"cost grid is the extractor blindness this pin exists to catch",
 			d.NAnchors, d.OuterRange, d.CumulativeD, d.Fanout)
 	}
 
-	// Correctness half, at both public seams. Eligible deliberately bypasses
-	// the cost thresholds, so it is the stricter of the two.
-	if routed {
-		t.Errorf("Plan routed a RangeWindowNative spine (K=%d)", d.K)
+	// Slicing half, at the threshold-free seam.
+	ed, eligible := (&Planner{Cfg: autoCfg()}).Eligible(plan, meta)
+	if !eligible {
+		t.Fatalf("Eligible refused a RangeWindowNative spine (reason=%q) — ReanchorRange re-grids "+
+			"this kind, so a plan that carries nothing else must be sliceable", ed.Reason)
 	}
-	if ed, eligible := (&Planner{Cfg: autoCfg()}).Eligible(plan, meta); eligible {
-		t.Errorf("Eligible routed a RangeWindowNative spine (K=%d) — the threshold-free seam is "+
-			"where an over-wide extraction shows up first", ed.K)
+	if ed.K < 2 {
+		t.Errorf("Eligible routed with K=%d; a route is K >= 2 by definition", ed.K)
 	}
 
-	// And the structural backstop underneath both: the node is NOT registered
-	// slice-invariant, and must stay that way until ReanchorRange learns its
-	// grid. A change that "fixes" this test by registering it is the bug.
-	if chplan.IsSliceInvariant(native) {
-		t.Error("RangeWindowNative is registered slice-invariant, but chplan.ReanchorRange has no " +
-			"arm for it — every shard would emit the original full-grid bounds")
+	// And the structural backstop underneath both: the node IS registered
+	// slice-invariant. A change that drops the registration while keeping the
+	// ReanchorRange arm leaves the plan refused for a reason that reads like a
+	// cost judgement.
+	if !chplan.IsSliceInvariant(native) {
+		t.Error("RangeWindowNative is not registered slice-invariant, so gate (1) refuses every " +
+			"plan carrying one and the ReanchorRange arm is unreachable")
+	}
+}
+
+// TestCarrierGeometry_NativeShardsPartitionTheGrid is the semantic half of the
+// slicing pin above: being ALLOWED to slice is worthless unless the shards
+// actually tile the original anchor grid.
+//
+// It reads the re-anchored RangeWindowNative out of every produced shard and
+// asserts the shards' anchor sets are pairwise disjoint and union to the
+// unsliced grid exactly, and that each shard's node carries that shard's own
+// bounds. The failure this catches is the specific one UnpinSpine's missing arm
+// would have produced: a node left pinned at the full grid re-anchors to the
+// same [Start, End] in every shard, so the union is the whole grid K times over.
+func TestCarrierGeometry_NativeShardsPartitionTheGrid(t *testing.T) {
+	t.Parallel()
+
+	plan, _ := nativeCarrierPlan(t)
+	start, end, step := GridOf(plan)
+	meta := RequestMeta{Lang: LangPromQL, Start: start, End: end, Step: step}
+
+	d, eligible := (&Planner{Cfg: autoCfg()}).Eligible(plan, meta)
+	if !eligible {
+		t.Fatalf("Eligible refused the native spine (reason=%q); this pin has no shards to read",
+			d.Reason)
+	}
+
+	seen := map[int64]int{}
+	for _, s := range d.Slices {
+		var found *chplan.RangeWindowNative
+		chplan.Walk(s.Plan, func(n chplan.Node) bool {
+			if rw, ok := n.(*chplan.RangeWindowNative); ok {
+				found = rw
+				return false
+			}
+			return true
+		})
+		if found == nil {
+			t.Fatalf("shard %d carries no RangeWindowNative; the slicer lost the spine node", s.Index)
+		}
+		if !found.Start.Equal(s.Start) || !found.End.Equal(s.End) {
+			t.Fatalf("shard %d node bounds [%v,%v] != shard bounds [%v,%v] — the node was shared "+
+				"verbatim instead of re-anchored", s.Index, found.Start, found.End, s.Start, s.End)
+		}
+		for a := found.End; !a.Before(found.Start); a = a.Add(-step) {
+			seen[a.UnixNano()]++
+		}
+	}
+
+	orig := originalAnchors(start, end, step)
+	if len(seen) != len(orig) {
+		t.Fatalf("shard anchor union has %d anchors, original grid has %d", len(seen), len(orig))
+	}
+	for _, a := range orig {
+		switch seen[a.UnixNano()] {
+		case 1:
+		case 0:
+			t.Fatalf("original anchor %v is in no shard", a)
+		default:
+			t.Fatalf("anchor %v appears in %d shards (not disjoint)", a, seen[a.UnixNano()])
+		}
+	}
+}
+
+// TestCarrierGeometry_NativeDoesNotRouteOnCostAlone is the resolution of issue
+// #2117's open sub-question, pinned as behaviour.
+//
+// Making the native spine sliceable must NOT make ModeAuto shard it. The native
+// aggregate materialises no (sample, anchor) matrix — its state is one grid
+// array per SERIES — so sharding it K ways pays K scans of an Offset+Range
+// overlapping window for a memory problem the statement does not have. Its
+// fan-out is therefore singlePassFanout, which is below the default MinFanout,
+// so ModeAuto declines on COST (below-threshold) while every correctness gate
+// passes. Reporting Range/Step here — the answer before #2117 — flips this
+// query to routed and is exactly the regression the sub-question named.
+func TestCarrierGeometry_NativeDoesNotRouteOnCostAlone(t *testing.T) {
+	t.Parallel()
+
+	plan, _ := nativeCarrierPlan(t)
+	start, end, step := GridOf(plan)
+	meta := RequestMeta{Lang: LangPromQL, Start: start, End: end, Step: step}
+
+	cfg := autoCfg()
+	if cfg.MinFanout <= int(singlePassFanout) {
+		t.Fatalf("MinFanout=%d <= singlePassFanout=%d; a single-pass carrier would clear the gate "+
+			"on cost and this pin is vacuous", cfg.MinFanout, singlePassFanout)
+	}
+
+	d, routed := (&Planner{Cfg: cfg}).Plan(plan, meta)
+	if routed {
+		t.Fatalf("ModeAuto sharded a single-pass native spine (K=%d) — K scans bought for a "+
+			"matrix that is never built", d.K)
+	}
+	if d.Reason != ReasonBelowThreshold {
+		t.Errorf("reason = %q, want %q — the native spine is refused by the COST gate, not by a "+
+			"correctness gate; any other token means a structural refusal crept back in",
+			d.Reason, ReasonBelowThreshold)
+	}
+	if d.Fanout != singlePassFanout {
+		t.Errorf("Fanout = %d, want %d — a single-pass grid aggregate reads each sample once "+
+			"whatever its window width is", d.Fanout, singlePassFanout)
 	}
 }
 

--- a/internal/solver/native_union_route_test.go
+++ b/internal/solver/native_union_route_test.go
@@ -1,0 +1,441 @@
+package solver
+
+import (
+	"testing"
+	"time"
+
+	"github.com/tsouza/cerberus/internal/chplan"
+)
+
+// unionArmRange is the [range] both arms of the mixed-union fixture carry. With
+// gridStep = 15s it gives the fan-out arm F = 20, which clears the default
+// MinFanout (16) — so the union routes on THAT arm's fan-out while the native
+// arm contributes singlePassFanout. Naming it makes the "which arm cleared the
+// gate" question answerable from the fixture rather than from arithmetic in a
+// reader's head.
+const unionArmRange = 5 * time.Minute
+
+// nativeUnionPlan builds the plan shape issue #2117 exists to make routable:
+// `sum(<UnionAll{RangeWindowNative, RangeWindow}>)` — the CUMULATIVE/DELTA
+// temporality split, where the cumulative half lowers to the ClickHouse-native
+// timeSeriesRateToGrid aggregate and the delta half stays on the arrayJoin
+// fan-out. Both arms sit on the same request grid and project the same
+// positional column shape, which is what makes the UNION ALL well-formed.
+func nativeUnionPlan() chplan.Node {
+	native := &chplan.RangeWindowNative{
+		Input:           leafScan(),
+		Func:            "rate",
+		Range:           unionArmRange,
+		Step:            gridStep,
+		Start:           gridStart,
+		End:             gridEnd,
+		TimestampColumn: "TimeUnix",
+		ValueColumn:     "Value",
+		GroupBy:         []chplan.Expr{&chplan.ColumnRef{Name: "Attributes"}},
+	}
+	fanout := &chplan.RangeWindow{
+		Input:           leafScan(),
+		Func:            "rate",
+		Range:           unionArmRange,
+		Step:            gridStep,
+		OuterRange:      gridEnd.Sub(gridStart),
+		Start:           gridStart,
+		End:             gridEnd,
+		TimestampColumn: "TimeUnix",
+		ValueColumn:     "Value",
+		GroupBy:         []chplan.Expr{&chplan.ColumnRef{Name: "Attributes"}},
+	}
+	return &chplan.Aggregate{
+		Input:    &chplan.UnionAll{Inputs: []chplan.Node{native, fanout}},
+		AggFuncs: []chplan.AggFunc{{Name: "sum", Args: []chplan.Expr{&chplan.ColumnRef{Name: "Value"}}}},
+	}
+}
+
+// TestPlan_NativeUnionSpineRoutes is the end-to-end pin for issue #2117: the
+// mixed `UnionAll{RangeWindowNative, RangeWindow}` spine routes B under
+// ModeAuto.
+//
+// Before #2117 it was refused twice over — RangeWindowNative was absent from
+// chplan's slice-invariance registry (gate 1) AND marked non-re-anchorable
+// (gate 1b) — so shipping the CUMULATIVE/DELTA split would have turned a
+// previously-routable counter panel into a not-sliceable rejection for any
+// all-delta deployment.
+//
+// The routing decision rests on the FAN-OUT arm's F (the native arm reports
+// singlePassFanout, below MinFanout), which is exactly right: the union's
+// memory pressure is the fan-out arm's matrix, and slicing the grid is what
+// bounds it.
+func TestPlan_NativeUnionSpineRoutes(t *testing.T) {
+	t.Parallel()
+
+	plan := nativeUnionPlan()
+	snapshot := chplan.CloneNode(plan)
+
+	d, routed := (&Planner{Cfg: autoCfg()}).Plan(plan, oomMeta())
+	if !routed {
+		t.Fatalf("the mixed native/fan-out union must route; got reason=%q", d.Reason)
+	}
+	if d.Reason != ReasonRouted {
+		t.Errorf("reason = %q, want %q", d.Reason, ReasonRouted)
+	}
+	if d.K < 2 {
+		t.Errorf("K = %d; a route is K >= 2 by definition", d.K)
+	}
+	if want := int64(unionArmRange / gridStep); d.Fanout != want {
+		t.Errorf("Fanout = %d, want %d — maxFanout is a MAX over carriers, so the fan-out arm's "+
+			"matrix is what the union is priced on", d.Fanout, want)
+	}
+	if !plan.Equal(snapshot) {
+		t.Error("classification mutated the input plan")
+	}
+}
+
+// TestPlan_NativeUnionShardsMoveBothArms is the correctness half of the pin
+// above: routing the union is only sound if EVERY arm moves onto the shard's
+// grid.
+//
+// The arms are concatenated positionally, so an arm left at the full request
+// grid would contribute its whole answer to every shard — the composed result
+// is then that arm's rows K times over, beside the other arm's correctly
+// partitioned rows. Nothing downstream can detect that: both arms still project
+// the same column shape, so the union parses, executes and returns plausible
+// numbers.
+//
+// It fails on any of the three independent seams this change had to widen:
+// chplan.ReanchorRange's UnionAll arm, its RangeWindowNative arm, and the
+// slicer's UnpinSpine (which must zero the native node's bounds, or every slice
+// aborts with ErrReanchorGridMismatch and sliceAndDecide silently falls back to
+// route A).
+func TestPlan_NativeUnionShardsMoveBothArms(t *testing.T) {
+	t.Parallel()
+
+	plan := nativeUnionPlan()
+	d, routed := (&Planner{Cfg: autoCfg()}).Plan(plan, oomMeta())
+	if !routed {
+		t.Fatalf("the mixed union must route; got reason=%q", d.Reason)
+	}
+
+	nativeSeen := map[int64]int{}
+	fanoutSeen := map[int64]int{}
+	for _, s := range d.Slices {
+		var (
+			native *chplan.RangeWindowNative
+			fanout *chplan.RangeWindow
+		)
+		chplan.Walk(s.Plan, func(n chplan.Node) bool {
+			switch v := n.(type) {
+			case *chplan.RangeWindowNative:
+				native = v
+			case *chplan.RangeWindow:
+				fanout = v
+			}
+			return true
+		})
+		if native == nil || fanout == nil {
+			t.Fatalf("shard %d lost an arm (native=%v fanout=%v)", s.Index, native != nil, fanout != nil)
+		}
+		if !native.Start.Equal(s.Start) || !native.End.Equal(s.End) {
+			t.Fatalf("shard %d native arm at [%v,%v], want the shard grid [%v,%v]",
+				s.Index, native.Start, native.End, s.Start, s.End)
+		}
+		if !fanout.Start.Equal(s.Start) || !fanout.End.Equal(s.End) {
+			t.Fatalf("shard %d fan-out arm at [%v,%v], want the shard grid [%v,%v]",
+				s.Index, fanout.Start, fanout.End, s.Start, s.End)
+		}
+		if fanout.OuterRange != s.End.Sub(s.Start) {
+			t.Fatalf("shard %d fan-out arm OuterRange = %s, want %s",
+				s.Index, fanout.OuterRange, s.End.Sub(s.Start))
+		}
+		for a := s.End; !a.Before(s.Start); a = a.Add(-gridStep) {
+			nativeSeen[a.UnixNano()]++
+			fanoutSeen[a.UnixNano()]++
+		}
+	}
+
+	orig := originalAnchors(gridStart, gridEnd, gridStep)
+	for name, seen := range map[string]map[int64]int{"native": nativeSeen, "fan-out": fanoutSeen} {
+		if len(seen) != len(orig) {
+			t.Errorf("%s arm covers %d anchors, original grid has %d", name, len(seen), len(orig))
+		}
+		for _, a := range orig {
+			if c := seen[a.UnixNano()]; c != 1 {
+				t.Errorf("%s arm: anchor %v covered %d times, want exactly 1", name, a, c)
+			}
+		}
+	}
+}
+
+// nativeSpinePlan builds `<wrap>(RangeWindowNative)` on the canonical grid —
+// the pure-native shape, with the wrapper chosen by the caller so both of
+// UnpinSpine's two structurally different routes to the same node are covered.
+func nativeSpinePlan(wrap func(chplan.Node) chplan.Node) chplan.Node {
+	return wrap(&chplan.RangeWindowNative{
+		Input:           leafScan(),
+		Func:            "rate",
+		Range:           unionArmRange,
+		Step:            gridStep,
+		Start:           gridStart,
+		End:             gridEnd,
+		TimestampColumn: "TimeUnix",
+		ValueColumn:     "Value",
+		GroupBy:         []chplan.Expr{&chplan.ColumnRef{Name: "Attributes"}},
+	})
+}
+
+// TestUnpinSpine_ZeroesNativeBounds pins the slicer half on its own, because
+// the failure it guards is INVISIBLE at the Decision seam: a native node left
+// pinned makes every ReanchorRange call return ErrReanchorGridMismatch, which
+// sliceAndDecide converts into a not-sliceable route-A Decision. The plan then
+// looks like one the solver declined on structure rather than one whose slicer
+// is broken, and no route-B assertion anywhere would notice.
+//
+// The three fixtures are the three structurally different ways UnpinSpine
+// reaches the node, and they exercise DIFFERENT code:
+//
+//   - under a Project: the copy-on-write spine walk (unpinSpineCOW's own
+//     RangeWindowNative arm);
+//   - under an Aggregate, and inside the mixed union: the off-spine
+//     descend-and-clone fallback (subtreeHasZeroableSpine must SEE the node,
+//     then zeroSpineInPlace must zero it).
+//
+// A change that teaches only one of those paths passes the other fixtures, so
+// covering one shape would leave half the slicer unpinned.
+func TestUnpinSpine_ZeroesNativeBounds(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name string
+		plan func() chplan.Node
+	}{
+		{
+			name: "project-spine",
+			plan: func() chplan.Node {
+				return nativeSpinePlan(func(n chplan.Node) chplan.Node {
+					return &chplan.Project{
+						Input:       n,
+						Projections: []chplan.Projection{{Expr: &chplan.ColumnRef{Name: "Value"}, Alias: "Value"}},
+					}
+				})
+			},
+		},
+		{
+			name: "aggregate-root",
+			plan: func() chplan.Node {
+				return nativeSpinePlan(func(n chplan.Node) chplan.Node {
+					return &chplan.Aggregate{
+						Input:    n,
+						AggFuncs: []chplan.AggFunc{{Name: "sum", Args: []chplan.Expr{&chplan.ColumnRef{Name: "Value"}}}},
+					}
+				})
+			},
+		},
+		{name: "mixed-union", plan: nativeUnionPlan},
+	} {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			plan := tc.plan()
+			snapshot := chplan.CloneNode(plan)
+
+			base := UnpinSpine(plan)
+
+			found := 0
+			chplan.Walk(base, func(n chplan.Node) bool {
+				v, ok := n.(*chplan.RangeWindowNative)
+				if !ok {
+					return true
+				}
+				found++
+				if !v.Start.IsZero() || !v.End.IsZero() {
+					t.Errorf("UnpinSpine left the native node pinned at [%v,%v]; ReanchorRange "+
+						"only fills an unpinned or already-on-target node, so every slice "+
+						"would abort", v.Start, v.End)
+				}
+				return true
+			})
+			if found != 1 {
+				t.Fatalf("expected exactly 1 RangeWindowNative in the unpinned view, found %d", found)
+			}
+			if !plan.Equal(snapshot) {
+				t.Error("UnpinSpine mutated the caller's plan")
+			}
+		})
+	}
+}
+
+// TestPlan_NativeGridGuardsRefuse pins the bound-pinning and grid-prediction
+// gates the native spine acquired the moment it became routable (issue #2117).
+//
+// Before it was routable these checks were unnecessary — a node that never
+// slices cannot slice onto wrong bounds — so they are entirely new surface, and
+// their failure mode is the worst kind: an @-pinned node re-anchored onto the
+// request grid answers a DIFFERENT query than the one asked, silently and with
+// plausible numbers.
+//
+// Each fixture below is refused by exactly one gate, and the reason token is
+// asserted rather than just the route bit: a refusal that lands on the right
+// answer via the wrong gate is a gate that will stop working when its neighbour
+// moves.
+func TestPlan_NativeGridGuardsRefuse(t *testing.T) {
+	t.Parallel()
+
+	native := func(mut func(*chplan.RangeWindowNative)) chplan.Node {
+		n := &chplan.RangeWindowNative{
+			Input:           leafScan(),
+			Func:            "rate",
+			Range:           unionArmRange,
+			Step:            gridStep,
+			Start:           gridStart,
+			End:             gridEnd,
+			TimestampColumn: "TimeUnix",
+			ValueColumn:     "Value",
+			GroupBy:         []chplan.Expr{&chplan.ColumnRef{Name: "Attributes"}},
+		}
+		mut(n)
+		return n
+	}
+
+	for _, tc := range []struct {
+		name       string
+		plan       chplan.Node
+		wantReason string
+	}{
+		{
+			// The @-modifier shape: bounds pinned somewhere the request grid
+			// does not predict. Re-anchoring would move them onto the request
+			// grid and answer the un-pinned query.
+			name: "at-pinned bounds diverge from the request grid",
+			plan: native(func(n *chplan.RangeWindowNative) {
+				n.Start = gridStart.Add(-24 * time.Hour)
+				n.End = gridEnd.Add(-24 * time.Hour)
+			}),
+			wantReason: ReasonGridMismatch,
+		},
+		{
+			// No lowering emits an unpinned native node; if one appeared, its
+			// grid is whatever the re-anchor invents, which is not a query
+			// anybody asked for.
+			name: "both bounds unpinned",
+			plan: native(func(n *chplan.RangeWindowNative) {
+				n.Start = time.Time{}
+				n.End = time.Time{}
+			}),
+			wantReason: ReasonInstant,
+		},
+		{
+			name: "half-pinned bounds",
+			plan: native(func(n *chplan.RangeWindowNative) {
+				n.Start = time.Time{}
+			}),
+			wantReason: ReasonInstant,
+		},
+		{
+			// Nested one level under a routable spine: the grid predicted there
+			// is widened by the outer window's Range, so a native node pinned at
+			// the OUTER grid does not sit where its own depth predicts.
+			name:       "nested under a routable window",
+			plan:       geomRoutableSpine(native(func(*chplan.RangeWindowNative) {})),
+			wantReason: ReasonGridMismatch,
+		},
+	} {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			d, routed := (&Planner{Cfg: autoCfg()}).Plan(tc.plan, oomMeta())
+			if routed {
+				t.Fatalf("plan routed B (K=%d); a native node off the predicted grid must not be "+
+					"re-anchored onto it", d.K)
+			}
+			if d.Reason != tc.wantReason {
+				t.Errorf("reason = %q, want %q", d.Reason, tc.wantReason)
+			}
+			// Eligible bypasses the cost thresholds, so it is the stricter seam:
+			// a refusal that only holds because the plan was too cheap to shard
+			// is not a correctness gate.
+			if ed, eligible := (&Planner{Cfg: autoCfg()}).Eligible(tc.plan, oomMeta()); eligible {
+				t.Errorf("Eligible routed the plan (K=%d) — the threshold-free seam is where a "+
+					"missing correctness gate shows up first", ed.K)
+			}
+		})
+	}
+}
+
+// nestedNativeStep is the inner native grid's own resolution in the
+// commensurability fixture below, chosen so that it does NOT divide the
+// quantum the slicer emits for the outer grid (m = ceil(241/8) = 31 anchors,
+// 465s) — the whole point being that the shard boundary would move the inner
+// grid's phase.
+const nestedNativeStep = 7 * time.Second
+
+// nestedNativeRange is the inner native window's [range]. It is distinct from
+// the outer spine's own range so a cumulative-D assertion can tell the two
+// contributions apart.
+const nestedNativeRange = time.Minute
+
+// nestedNativeSpine builds a routable outer RangeWindow over a native inner
+// grid pinned EXACTLY where that depth predicts, at the given inner resolution.
+// It is the only shape that reaches the native arm's end-phase bookkeeping: a
+// nested native node whose bounds diverge at all is refused by the
+// grid-prediction gate long before the quantum is considered.
+func nestedNativeSpine(innerStep time.Duration) chplan.Node {
+	outer := geomRoutableSpine(nil)
+	outer.Input = &chplan.RangeWindowNative{
+		Input:           leafScan(),
+		Func:            "rate",
+		Range:           nestedNativeRange,
+		Step:            innerStep,
+		Start:           gridStart.Add(-geomOuterSpineRange),
+		End:             gridEnd,
+		TimestampColumn: "TimeUnix",
+		ValueColumn:     "Value",
+		GroupBy:         []chplan.Expr{&chplan.ColumnRef{Name: "Attributes"}},
+	}
+	return outer
+}
+
+// TestPlan_NestedNativeGridConstrainsTheSliceQuantum pins the last gate the
+// native spine needed once it became routable: a NESTED native grid is
+// generated from the node's own bounds with no epoch snap, so shifting a shard
+// boundary by a non-multiple of that grid's resolution moves its phase and the
+// per-shard anchor set stops being a subset of the unsliced one.
+//
+// The two fixtures differ ONLY in the inner resolution, so the refusal cannot
+// be resting on anything else in the shape: at a resolution that divides the
+// emitted quantum the same plan routes, and at one that does not it is refused
+// as incommensurate.
+func TestPlan_NestedNativeGridConstrainsTheSliceQuantum(t *testing.T) {
+	t.Parallel()
+
+	t.Run("incommensurate inner resolution is refused", func(t *testing.T) {
+		t.Parallel()
+
+		plan := nestedNativeSpine(nestedNativeStep)
+		d, eligible := (&Planner{Cfg: autoCfg()}).Eligible(plan, oomMeta())
+		if eligible {
+			t.Fatalf("a nested native grid at %s routed under a %s quantum (K=%d); the shard "+
+				"boundary moves its phase", nestedNativeStep, gridStep, d.K)
+		}
+		if d.Reason != ReasonIncommensurate {
+			t.Errorf("reason = %q, want %q — any other token means the plan was refused by a "+
+				"different gate and the quantum check is untested", d.Reason, ReasonIncommensurate)
+		}
+	})
+
+	t.Run("commensurate inner resolution routes", func(t *testing.T) {
+		t.Parallel()
+
+		plan := nestedNativeSpine(gridStep)
+		d, eligible := (&Planner{Cfg: autoCfg()}).Eligible(plan, oomMeta())
+		if !eligible {
+			t.Fatalf("the control shape must route, else the refusal above proves nothing about "+
+				"the inner resolution; reason=%q", d.Reason)
+		}
+		if want := geomOuterSpineRange + nestedNativeRange; d.CumulativeD != want {
+			t.Errorf("CumulativeD = %s, want %s — the nested native node was never measured, so "+
+				"the walk did not reach it and neither fixture says anything about it",
+				d.CumulativeD, want)
+		}
+	})
+}

--- a/internal/solver/planner.go
+++ b/internal/solver/planner.go
@@ -461,24 +461,7 @@ func (p *Planner) walkNode(n chplan.Node, predStart, predEnd time.Time, predStep
 		return
 
 	case *chplan.RangeWindowNative:
-		// The ClickHouse-native `timeSeries<fn>ToGrid` lowering of
-		// rate(m[Range]) and its siblings. It owns a full eval grid, so on a
-		// purely natively-lowered plan it is the ONLY carrier and the sole
-		// source of that plan's n_anchors / outer_range / cumulative_d.
-		p.recordGridCarrier(v, depth, sig)
-		p.checkRangeWindowNativeGrid(v, predStart, predEnd, depth, sig)
-		for _, e := range v.GroupBy {
-			p.walkExpr(e, predStart, predEnd, v.Step, sig)
-		}
-		for _, pr := range v.Recollapse {
-			p.walkExpr(pr.Expr, predStart, predEnd, v.Step, sig)
-		}
-		// Recurse into the inner spine widened via the single shared owner of
-		// this arithmetic (mirrors ReanchorRange) so the grid this predicts for
-		// the child matches what re-anchoring actually produces — including the
-		// Offset term (#1464).
-		inStart, inEnd := v.InputWindow(predStart, predEnd)
-		p.walkNode(v.Input, inStart, inEnd, v.Step, depth+1, sig)
+		p.walkRangeWindowNative(v, predStart, predEnd, depth, sig)
 		return
 
 	case *chplan.RangeWindowResample:
@@ -609,6 +592,33 @@ func (p *Planner) walkNode(n chplan.Node, predStart, predEnd time.Time, predStep
 	for _, c := range n.Children() {
 		p.walkNode(c, predStart, predEnd, predStep, depth, sig)
 	}
+}
+
+// walkRangeWindowNative sweeps the ClickHouse-native `timeSeries<fn>ToGrid`
+// lowering of rate(m[Range]) and its siblings. The node owns a full eval grid,
+// so on a purely natively-lowered plan it is the ONLY carrier and the sole
+// source of that plan's n_anchors / outer_range / cumulative_d.
+//
+// Its GroupBy and Recollapse exprs are evaluated at THIS node's own level and
+// cadence, so an embedded ScalarSubquery / InSubquery is checked against
+// (predStart, predEnd, v.Step) rather than against the widened inner-spine
+// bounds the recursion below descends into — the same rule the fan-out
+// RangeWindow arm applies to its own exprs.
+func (p *Planner) walkRangeWindowNative(v *chplan.RangeWindowNative, predStart, predEnd time.Time, depth int, sig *signals) {
+	p.recordGridCarrier(v, depth, sig)
+	p.checkRangeWindowNativeGrid(v, predStart, predEnd, depth, sig)
+	for _, e := range v.GroupBy {
+		p.walkExpr(e, predStart, predEnd, v.Step, sig)
+	}
+	for _, pr := range v.Recollapse {
+		p.walkExpr(pr.Expr, predStart, predEnd, v.Step, sig)
+	}
+	// Recurse into the inner spine widened via the single shared owner of this
+	// arithmetic (mirrors chplan.ReanchorRange) so the grid this predicts for
+	// the child matches what re-anchoring actually produces — including the
+	// Offset term (#1464).
+	inStart, inEnd := v.InputWindow(predStart, predEnd)
+	p.walkNode(v.Input, inStart, inEnd, v.Step, depth+1, sig)
 }
 
 // carrierGeometry is the measurement-only projection of one

--- a/internal/solver/planner.go
+++ b/internal/solver/planner.go
@@ -218,16 +218,16 @@ func (p *Planner) classify(plan chplan.Node, meta RequestMeta) (sig signals, dec
 		return sig, notRouted(ReasonNotSliceable).withGrid(sig, meta), 0, false
 	}
 	// (1b) Routable-spine restriction: the routable spine families are the
-	// RangeWindow matrix family and the RangeLWR bare-selector
-	// last-with-respect-to family — ReanchorRange re-grids both. Every other
-	// [chplan.GridCarrier] kind (RangeWindowNative, RangeWindowResample,
-	// RangeBucketFanout, StepGrid, AbsentOverTime) has its grid CloneNode'd
-	// verbatim, so each shard would emit the original full-grid bounds; they
-	// fail closed to route A. Note the asymmetry this gate exists to preserve:
-	// the extractor MEASURES all seven kinds so the corpus can see what a
-	// refused plan costs, while only the two re-anchored families may be
-	// SLICED. Admitting a kind here means teaching ReanchorRange its grid
-	// first, not widening carrierGeometryOf.
+	// RangeWindow matrix family, the RangeWindowNative timeSeries*ToGrid family
+	// and the RangeLWR bare-selector last-with-respect-to family — ReanchorRange
+	// re-grids all three. Every other [chplan.GridCarrier] kind
+	// (RangeWindowResample, RangeBucketFanout, StepGrid, AbsentOverTime) has its
+	// grid CloneNode'd verbatim, so each shard would emit the original full-grid
+	// bounds; they fail closed to route A. Note the asymmetry this gate exists
+	// to preserve: the extractor MEASURES all seven kinds so the corpus can see
+	// what a refused plan costs, while only the re-anchored families may be
+	// SLICED. Admitting a kind here means teaching ReanchorRange (and the
+	// slicer's UnpinSpine) its grid first, not widening carrierGeometryOf.
 	if sig.sawNonRangeWindowSpine {
 		return sig, notRouted(ReasonNotSliceable).withGrid(sig, meta), 0, false
 	}
@@ -361,12 +361,17 @@ type signals struct {
 	// ReanchorRange does NOT re-anchor — every [chplan.GridCarrier] kind
 	// outside the routable set, which ReanchorRange CloneNode's verbatim (so
 	// every shard would emit stale bounds). The routable set is the
-	// RangeWindow matrix family plus the RangeLWR bare-selector family: both
-	// are re-gridded by ReanchorRange and zeroed/re-filled by UnpinSpine, so
-	// neither sets this flag. RangeWindowNative / RangeWindowResample /
-	// RangeBucketFanout / StepGrid / AbsentOverTime fail closed to route A
-	// until ReanchorRange learns their grids — see carrierGeometry.reanchorable,
-	// which is the single place that decision is recorded.
+	// RangeWindow matrix family, the RangeWindowNative timeSeries*ToGrid family
+	// and the RangeLWR bare-selector family: all three are re-gridded by
+	// ReanchorRange and zeroed/re-filled by UnpinSpine, so none of them sets
+	// this flag. RangeWindowResample / RangeBucketFanout / StepGrid /
+	// AbsentOverTime fail closed to route A until ReanchorRange learns their
+	// grids — see carrierGeometry.reanchorable, which is the single place that
+	// decision is recorded.
+	//
+	// The name is historical: the routable set was once the RangeWindow family
+	// alone. It reads "saw a carrier outside the re-anchorable set", which is
+	// what carrierGeometry.reanchorable answers.
 	sawNonRangeWindowSpine bool
 
 	// sawGridCarrier records that the walk found at least one
@@ -456,25 +461,24 @@ func (p *Planner) walkNode(n chplan.Node, predStart, predEnd time.Time, predStep
 		return
 
 	case *chplan.RangeWindowNative:
-		// The ClickHouse-native `timeSeriesRateToGrid` lowering of
-		// rate(m[Range]). It owns a full eval grid, so it is the ONLY carrier
-		// in a natively-lowered plan and the sole source of that plan's
-		// n_anchors / outer_range / cumulative_d. Its bounds are pinned by
-		// construction (range mode only), so no bound-pinning gate applies;
-		// recordGridCarrier's reanchorable check is what keeps it on route A.
+		// The ClickHouse-native `timeSeries<fn>ToGrid` lowering of
+		// rate(m[Range]) and its siblings. It owns a full eval grid, so on a
+		// purely natively-lowered plan it is the ONLY carrier and the sole
+		// source of that plan's n_anchors / outer_range / cumulative_d.
 		p.recordGridCarrier(v, depth, sig)
+		p.checkRangeWindowNativeGrid(v, predStart, predEnd, depth, sig)
 		for _, e := range v.GroupBy {
 			p.walkExpr(e, predStart, predEnd, v.Step, sig)
 		}
 		for _, pr := range v.Recollapse {
 			p.walkExpr(pr.Expr, predStart, predEnd, v.Step, sig)
 		}
-		// Each anchor reduces the samples in `(anchor - Offset - Range,
-		// anchor - Offset]`, so the inner spine reaches back Offset+Range —
-		// the same widening RangeWindow.InputWindow owns for the arm above
-		// (#1464). Offset enters with its sign, so a forward (negative)
-		// offset widens by less.
-		p.walkNode(v.Input, predStart.Add(-v.Offset-v.Range), predEnd, v.Step, depth+1, sig)
+		// Recurse into the inner spine widened via the single shared owner of
+		// this arithmetic (mirrors ReanchorRange) so the grid this predicts for
+		// the child matches what re-anchoring actually produces — including the
+		// Offset term (#1464).
+		inStart, inEnd := v.InputWindow(predStart, predEnd)
+		p.walkNode(v.Input, inStart, inEnd, v.Step, depth+1, sig)
 		return
 
 	case *chplan.RangeWindowResample:
@@ -635,10 +639,12 @@ type carrierGeometry struct {
 	// in here for consistency with that arithmetic; the two answer different
 	// questions and conflating them is wrong in both features this feeds:
 	//
-	//   - F = lookback/Step is how many samples ONE anchor reduces. Shifting
-	//     a window does not change how many samples it holds, and F gates
-	//     routing under ModeAuto, so folding Offset in would route plans on
-	//     a sample count nobody reads.
+	//   - F = lookback/Step is how many (sample, anchor) pairs the carrier
+	//     MATERIALISES per sample. Shifting a window does not change how many
+	//     samples it holds, and F gates routing under ModeAuto, so folding
+	//     Offset in would route plans on a sample count nobody reads. (For a
+	//     singlePass carrier this derivation does not apply at all — see that
+	//     field.)
 	//   - D = Σ lookback drives the high-D floor, which measures per-slice
 	//     REDUNDANCY: a slice narrower than D re-reads more than it computes,
 	//     because ADJACENT slices' input windows overlap by exactly the
@@ -653,13 +659,57 @@ type carrierGeometry struct {
 	// offset-bearing carrier kind at once.
 	lookback time.Duration
 
+	// singlePass reports that the carrier's emitter reduces each raw sample
+	// EXACTLY ONCE, in one streaming aggregate pass, and never materialises the
+	// (sample, anchor) matrix. It is the native timeSeries*ToGrid family: the
+	// aggregate is handed (start, end, step, window) and fills a per-series
+	// grid array in a single C++ walk of the samples.
+	//
+	// It exists because `lookback` answers TWO questions that coincide for the
+	// fan-out family and diverge for the native one:
+	//
+	//   - D (Σ lookback) is per-slice SCAN redundancy: adjacent slices' input
+	//     windows overlap by exactly the window span, whichever emitter reads
+	//     them. A native carrier's shard widens its scan by Offset+Range
+	//     exactly as the fan-out arm's does (chplan.RangeWindowNative.
+	//     InputWindow), so its D is its Range and this field does NOT touch it.
+	//   - F is the MEMORY proxy the ModeAuto gate reads: peak intermediate rows
+	//     per raw row, which is what slicing the anchor grid K ways divides by
+	//     K. The fan-out arm arrayJoins each sample across the lookback/Step
+	//     anchors it covers, so its F is lookback/Step. The native aggregate
+	//     builds no such intermediate — its state is one Array(Nullable(Float64))
+	//     of N grid points per SERIES — so it materialises one row per sample and
+	//     its F is singlePassFanout, flat in the window width.
+	//
+	// Reporting lookback/Step for a native carrier would claim a matrix that is
+	// never built, and ModeAuto would shard a flat-memory single-pass statement
+	// K ways — paying K scans of an Offset+Range-overlapping window for a memory
+	// problem the statement does not have. Reporting singlePassFanout keeps the
+	// native carrier below MinFanout on its own (so ModeAuto declines on cost),
+	// while leaving it fully SLICEABLE: a mixed UnionAll whose other arm IS a
+	// fan-out still routes on that arm's F (maxFanout is a max over carriers),
+	// and the threshold-free Eligible seam — the failure-driven route memo,
+	// which fires on a real route-A resource failure rather than on a cost proxy
+	// — still slices a pure-native plan when the evidence says route A could not
+	// hold it.
+	singlePass bool
+
 	// reanchorable reports whether [chplan.ReanchorRange] re-grids this kind.
 	// This is a CORRECTNESS bit, not a measurement one: a carrier
 	// ReanchorRange clones verbatim hands every shard the original full-grid
 	// bounds, so a live grid on such a kind must fail the plan closed to
-	// route A. Exactly the RangeWindow and RangeLWR families are re-gridded.
+	// route A. Exactly the RangeWindow, RangeWindowNative and RangeLWR
+	// families are re-gridded.
 	reanchorable bool
 }
+
+// singlePassFanout is the fan-out a carrier contributes when its emitter reads
+// each raw sample exactly once and materialises no (sample, anchor) matrix: one
+// intermediate row per sample, i.e. no amplification at all. It is the F of the
+// native timeSeries*ToGrid family (carrierGeometry.singlePass), and 1 rather
+// than 0 because the samples ARE read — a zero would say the carrier touches no
+// data, which is StepGrid's answer, not this family's.
+const singlePassFanout = int64(1)
 
 // carrierGeometryOf derives the measurement geometry of one grid carrier,
 // enumerating every [chplan.GridCarrier] implementation.
@@ -692,14 +742,29 @@ func carrierGeometryOf(gc chplan.GridCarrier) (carrierGeometry, bool) {
 		// timeSeries<fn>ToGrid: the whole rate(m[Range]) collapses into one
 		// ClickHouse aggregate, so this node ALONE carries the grid of a
 		// natively-lowered plan — it is the sole source of that plan's
-		// n_anchors / outer_range / cumulative_d. ReanchorRange has no arm
-		// for it, so it stays route A.
-		return carrierGeometry{outerRange: v.End.Sub(v.Start), lookback: v.Range, reanchorable: false}, true
+		// n_anchors / outer_range / cumulative_d. ReanchorRange re-grids it
+		// (and UnpinSpine zeroes it), so it is sliceable; its per-anchor
+		// lookback is the window Range, and it materialises no (sample, anchor)
+		// matrix, so its fan-out is singlePassFanout rather than Range/Step.
+		return carrierGeometry{
+			outerRange:   v.End.Sub(v.Start),
+			lookback:     v.Range,
+			singlePass:   true,
+			reanchorable: true,
+		}, true
 
 	case *chplan.RangeWindowResample:
 		// timeSeriesResampleToGridWithStaleness: the native sibling of
-		// RangeLWR, with the staleness horizon as its per-anchor depth.
-		return carrierGeometry{outerRange: v.End.Sub(v.Start), lookback: v.Lookback, reanchorable: false}, true
+		// RangeLWR, with the staleness horizon as its per-anchor depth. Same
+		// single-pass grid aggregate as RangeWindowNative, so the same fan-out
+		// answer; it is NOT re-anchored, so the flag is telemetry-only here
+		// until ReanchorRange grows an arm for it.
+		return carrierGeometry{
+			outerRange:   v.End.Sub(v.Start),
+			lookback:     v.Lookback,
+			singlePass:   true,
+			reanchorable: false,
+		}, true
 
 	case *chplan.RangeBucketFanout:
 		// The array-aggregate fan-out behind the histogram families. Its
@@ -766,10 +831,22 @@ func (p *Planner) recordGridCarrier(gc chplan.GridCarrier, depth int, sig *signa
 	}
 
 	if step > 0 {
-		if fan := int64(geom.lookback / step); fan > sig.maxFanout {
+		// F is the per-sample intermediate-row count, so it is derived from the
+		// window width ONLY for a carrier that materialises the (sample, anchor)
+		// matrix. A single-pass grid aggregate reads each sample once whatever
+		// its window width is; see carrierGeometry.singlePass.
+		fan := singlePassFanout
+		if !geom.singlePass {
+			fan = int64(geom.lookback / step)
+		}
+		if fan > sig.maxFanout {
 			sig.maxFanout = fan
 		}
 	}
+	// D is per-slice SCAN redundancy, which is the window SPAN regardless of
+	// which emitter reads it — a single-pass carrier's shard widens its input
+	// by Offset+Range exactly as a fan-out carrier's does, so singlePass does
+	// not enter here.
 	sig.cumulativeD += geom.lookback
 
 	if depth == 0 && geom.outerRange > 0 && step > 0 {
@@ -855,6 +932,53 @@ func (p *Planner) checkRangeLWRGrid(v *chplan.RangeLWR, predStart, predEnd time.
 	if depth > 0 && v.Step > 0 && !v.StepAlign {
 		sig.endPhasedResolutions = append(sig.endPhasedResolutions, v.Step)
 	}
+}
+
+// checkRangeWindowNativeGrid runs the bound-pinning and grid-prediction gates
+// for the native timeSeries*ToGrid family. It mirrors checkRangeWindowGrid with
+// the one structural difference the node imposes: no separate OuterRange field,
+// so the predicted span is End-Start directly (the RangeLWR form of the same
+// equality).
+//
+// The node is pinned in range mode by construction, so in a plan built by the
+// lowering neither the unpinned nor the half-pinned branch can fire. They are
+// here because this gate is what stands between an @-pinned anchor and a shard
+// set that silently disagrees with @ semantics: before this node was routable
+// the check was unnecessary, and "the lowering cannot produce that shape today"
+// is not a property the slicer may rest correctness on.
+func (p *Planner) checkRangeWindowNativeGrid(v *chplan.RangeWindowNative, predStart, predEnd time.Time, depth int, sig *signals) {
+	startZero := v.Start.IsZero()
+	endZero := v.End.IsZero()
+	switch {
+	case startZero && endZero:
+		// Fully unpinned. ReanchorRange fills this shape, but no lowering emits
+		// it for this node kind, so it is a plan whose grid nothing pinned:
+		// refuse rather than invent one.
+		sig.sawUnpinnedBound = true
+	case startZero != endZero:
+		// Half-pinned: malformed.
+		sig.sawUnpinnedBound = true
+	default:
+		if !rangeWindowNativeGridMatches(v, predStart, predEnd) {
+			sig.sawGridMismatch = true
+		}
+	}
+
+	// (5) Nested-grid phase for the slice-quantum check. The node's anchor axis
+	// is `timeSeriesRange(Start, End, Step)` with no epoch snap — there is no
+	// StepAlign carve-out on this kind — so a NESTED one's phase moves with the
+	// shard's bounds exactly as a non-StepAlign'd nested RangeWindow's does, and
+	// it constrains the slice quantum the same way.
+	if depth > 0 && v.Step > 0 {
+		sig.endPhasedResolutions = append(sig.endPhasedResolutions, v.Step)
+	}
+}
+
+// rangeWindowNativeGridMatches is rangeWindowGridMatches for a
+// RangeWindowNative: it carries no separate OuterRange field, so the predicted
+// span is End-Start directly.
+func rangeWindowNativeGridMatches(v *chplan.RangeWindowNative, predStart, predEnd time.Time) bool {
+	return v.Start.Equal(predStart) && v.End.Equal(predEnd)
 }
 
 // rangeWindowGridMatches reports whether v's own (Start, End, OuterRange)
@@ -1048,10 +1172,14 @@ func (p *Planner) checkScalarHeavy(inner chplan.Node, predStart, predEnd time.Ti
 // of its bounds: it is excluded from the routable spine family on the MAIN
 // spine too (signal 1b, carrierGeometry.reanchorable), and this package has
 // no argument that makes it safe here that it does not already have there.
-// RangeWindowNative, RangeWindowResample and AbsentOverTime are absent from
+// RangeWindowResample and AbsentOverTime are absent from
 // chplan.IsSliceInvariant's registry, so one appearing inside an interior
 // already fails the whole plan via walkScalarInterior's slice-invariance
-// sweep before this function's answer can matter. StepGrid IS registered
+// sweep before this function's answer can matter. RangeWindowNative IS
+// registered (issue #2117), so that sweep no longer covers it and this function
+// answers for it directly — under the same equality the fan-out RangeWindow
+// gets, since a full-span native grid replicated K× is exactly as wide a scan
+// as a full-span fan-out one. StepGrid IS registered
 // slice-invariant and falls through the switch below to the generic
 // Children() walk unchecked — deliberately: it is the bare, data-free anchor
 // axis behind `time()` / `vector(scalar)` / the zero-arg date functions, it
@@ -1076,6 +1204,22 @@ func scalarInteriorAnchorCompatible(n chplan.Node, predStart, predEnd time.Time,
 			return false
 		}
 		return scalarInteriorAnchorCompatible(v.Input, predStart.Add(-v.Offset-v.Lookback), predEnd, predStep)
+	case *chplan.RangeWindowNative:
+		// The native timeSeries*ToGrid family, held to the SAME equality as the
+		// fan-out RangeWindow above — in its two-bound form, since the node has
+		// no OuterRange field. This arm became load-bearing the moment the node
+		// entered chplan.IsSliceInvariant's registry (issue #2117): before that,
+		// walkScalarInterior's slice-invariance sweep refused any plan whose
+		// interior carried one, so the switch never had to answer. Now the
+		// sweep is silent and the generic Children() fall-through below would
+		// admit a native interior as CHEAP whatever its bounds — replicating a
+		// full-span single-pass grid aggregate K times, which is exactly the
+		// unboundedly-wide interior the gate exists to keep on route A.
+		if v.Step <= 0 || v.Step != predStep || !rangeWindowNativeGridMatches(v, predStart, predEnd) {
+			return false
+		}
+		inStart, inEnd := v.InputWindow(predStart, predEnd)
+		return scalarInteriorAnchorCompatible(v.Input, inStart, inEnd, predStep)
 	case *chplan.RangeBucketFanout:
 		return false
 	}

--- a/internal/solver/planner_test.go
+++ b/internal/solver/planner_test.go
@@ -617,6 +617,44 @@ func TestPlan_ScalarAnchorCompatibleRoutes(t *testing.T) {
 	}
 }
 
+// TestPlan_ScalarNativeAnchorCompatibleRoutes is the positive counterpart for
+// the native arm of the anchor-compatibility check: a native timeSeries*ToGrid
+// interior sitting EXACTLY on the grid AND cadence predicted where it is
+// embedded is bounded to one value per outer anchor, so it is admitted and the
+// plan routes.
+//
+// Without it the negative rows below would be satisfied by an arm that refuses
+// EVERY native interior, which is a different (and needlessly narrow) policy
+// than the one the fan-out family gets.
+func TestPlan_ScalarNativeAnchorCompatibleRoutes(t *testing.T) {
+	t.Parallel()
+	anchoredInner := &chplan.RangeWindowNative{
+		Input:           leafScan(),
+		Func:            "rate",
+		Range:           5 * time.Minute,
+		Step:            gridStep,
+		Start:           gridStart,
+		End:             gridEnd,
+		TimestampColumn: "TimeUnix",
+		ValueColumn:     "Value",
+	}
+	plan := &chplan.Filter{
+		Input: oomWindow().(*chplan.Aggregate),
+		Predicate: &chplan.Binary{
+			Op:    chplan.OpGt,
+			Left:  &chplan.ColumnRef{Name: "Value"},
+			Right: &chplan.ScalarSubquery{Input: anchoredInner},
+		},
+	}
+	d, routed := (&Planner{Cfg: autoCfg()}).Plan(plan, oomMeta())
+	if !routed {
+		t.Fatalf("an anchor-compatible native scalar interior must route; reason=%q", d.Reason)
+	}
+	if d.Reason != ReasonRouted {
+		t.Fatalf("reason = %q, want %q", d.Reason, ReasonRouted)
+	}
+}
+
 // TestPlan_ScalarAnchorIncompatibleRejected is the negative table for the
 // anchor-compatibility carve-out: each case builds a windowed interior that
 // resembles TestPlan_ScalarAnchorCompatibleRoutes's admitted shape in every
@@ -663,6 +701,40 @@ func TestPlan_ScalarAnchorIncompatibleRejected(t *testing.T) {
 				AttributesCol: "Attributes",
 				TimestampCol:  "TimeUnix",
 				ValueCol:      "Value",
+			},
+		},
+		{
+			// A native timeSeries*ToGrid interior whose span is independent of
+			// the outer grid. It is registered slice-invariant (issue #2117), so
+			// walkScalarInterior's sweep no longer refuses it and
+			// scalarInteriorAnchorCompatible's own arm is the only thing between
+			// this and replicating a 30-day single-pass grid aggregate K times.
+			name: "RangeWindowNative, span diverges",
+			inner: &chplan.RangeWindowNative{
+				Input:           leafScan(),
+				Func:            "rate",
+				Range:           5 * time.Minute,
+				Step:            gridStep,
+				Start:           gridStart.Add(-30 * 24 * time.Hour),
+				End:             gridEnd.Add(-30 * 24 * time.Hour),
+				TimestampColumn: "TimeUnix",
+				ValueColumn:     "Value",
+			},
+		},
+		{
+			// The same native interior on the outer grid's exact span but at a
+			// coarser cadence: not provably one value per OUTER anchor, so it
+			// stays heavy for the same reason the fan-out row above does.
+			name: "RangeWindowNative, grid matches, step diverges",
+			inner: &chplan.RangeWindowNative{
+				Input:           leafScan(),
+				Func:            "rate",
+				Range:           5 * time.Minute,
+				Step:            time.Minute,
+				Start:           gridStart,
+				End:             gridEnd,
+				TimestampColumn: "TimeUnix",
+				ValueColumn:     "Value",
 			},
 		},
 		{

--- a/internal/solver/slicer.go
+++ b/internal/solver/slicer.go
@@ -134,9 +134,16 @@ func (p *Planner) slice(plan chplan.Node, meta RequestMeta, k int) ([]Slice, err
 }
 
 // UnpinSpine returns a copy-on-write view of plan whose windowed-spine bounds
-// (RangeWindow / RangeLWR Start, End, and the matrix OuterRange) are zeroed,
-// so ReanchorRange treats every spine node as the unpinned subquery-inner
-// shape and fills each slice's grid in.
+// (RangeWindow / RangeWindowNative / RangeLWR Start, End, and the matrix
+// OuterRange) are zeroed, so ReanchorRange treats every spine node as the
+// unpinned subquery-inner shape and fills each slice's grid in.
+//
+// The set of kinds zeroed here is exactly the set chplan.ReanchorRange
+// re-grids, which is exactly the set carrierGeometryOf marks reanchorable.
+// The three must move together: a kind ReanchorRange learned but this function
+// did not stays pinned at the full request grid, and every slice then fails
+// ErrReanchorGridMismatch — which sliceAndDecide converts into a silent
+// fall back to route A, so the plan classifies as routable and never routes.
 //
 // The original plan is never mutated. UnpinSpine clones ONLY the spine-path
 // nodes it actually zeroes (and their ancestors back to the root, the
@@ -195,6 +202,22 @@ func unpinSpineCOW(n chplan.Node) (chplan.Node, bool) {
 		c := *v
 		c.Input = input
 		return &c, true
+	case *chplan.RangeWindowNative:
+		// The native timeSeries<fn>ToGrid spine node. It is pinned at the full
+		// request grid by construction (the lowering only builds it in range
+		// mode), and chplan.ReanchorRange re-grids it — so it must be zeroed
+		// here for the same reason the matrix RangeWindow is: ReanchorRange
+		// only fills a node that is unpinned or already on the target grid, and
+		// a slice's grid is a SUB-window of the one this node carries. Leaving
+		// it pinned makes every slice fail ErrReanchorGridMismatch, which
+		// sliceAndDecide turns into a silent fall back to route A — the plan
+		// would look routable and never actually route.
+		input, _ := unpinSpineCOW(v.Input)
+		c := *v
+		c.Start = time.Time{}
+		c.End = time.Time{}
+		c.Input = input
+		return &c, true
 	case *chplan.RangeLWR:
 		input, _ := unpinSpineCOW(v.Input)
 		c := *v
@@ -248,7 +271,15 @@ func descendOffSpine(n chplan.Node) (chplan.Node, bool) {
 // subtreeHasZeroableSpine reports whether the subtree rooted at n (descending
 // only through Node children, never through Expr-embedded ScalarSubquery
 // interiors -- which UnpinSpine never zeroed) contains a windowed node whose
-// grid UnpinSpine would zero: any RangeLWR, or a matrix RangeWindow (Step > 0).
+// grid UnpinSpine would zero: any RangeLWR, or a matrix RangeWindow /
+// RangeWindowNative (Step > 0).
+//
+// It must name exactly the kinds unpinSpineCOW zeroes. A kind zeroed there but
+// missing here is invisible to the off-spine probe, so a subtree carrying only
+// that kind is shared verbatim and reaches ReanchorRange still pinned at the
+// full grid -- the ErrReanchorGridMismatch / silent-route-A failure the arms
+// themselves describe. The mixed `UnionAll{RangeWindowNative, RangeWindow}`
+// spine is precisely a subtree reached this way.
 func subtreeHasZeroableSpine(n chplan.Node) bool {
 	found := false
 	chplan.Walk(n, func(node chplan.Node) bool {
@@ -256,6 +287,10 @@ func subtreeHasZeroableSpine(n chplan.Node) bool {
 		case *chplan.RangeLWR:
 			found = true
 		case *chplan.RangeWindow:
+			if v.Step > 0 {
+				found = true
+			}
+		case *chplan.RangeWindowNative:
 			if v.Step > 0 {
 				found = true
 			}
@@ -276,6 +311,13 @@ func zeroSpineInPlace(n chplan.Node) {
 			v.Start = time.Time{}
 			v.End = time.Time{}
 			v.OuterRange = 0
+		}
+		zeroSpineInPlace(v.Input)
+		return
+	case *chplan.RangeWindowNative:
+		if v.Step > 0 {
+			v.Start = time.Time{}
+			v.End = time.Time{}
 		}
 		zeroSpineInPlace(v.Input)
 		return


### PR DESCRIPTION
Closes #2117

## What was wrong

A plan carrying a `chplan.RangeWindowNative` was refused by the solver twice over: the node was
absent from chplan's slice-invariance registry, and `solver.carrierGeometryOf` marked it
`reanchorable: false` because `chplan.ReanchorRange` had no arm for it.

A `UnionAll{RangeWindowNative, RangeWindow}` — the plan shape #2114's CUMULATIVE/DELTA temporality
split needs to emit — trips both gates. Shipping that split without this would have turned the
canonical `sum(rate(e2e_http_requests_total[5m]))` counter panel from `routed K=8` into
`not-sliceable` for any all-delta deployment: a correctness-preserving 5x speedup for the majority
traded against a hard routing failure for a minority.

## Plan IR

- **`sliceInvariantKinds` gains `RangeWindowNative`.** The `timeSeries*ToGrid` aggregate is handed
  `(start, end, step, window)` and evaluates grid point *i* from exactly the samples in
  `(anchor_i - Offset - Range, anchor_i - Offset]` — the registry's stated criterion, not a
  resemblance argument. What is *not* being claimed: the aggregate's internal evaluation is
  order-dependent (`extrapolatedRate` reads the window's first/last pair), but that order is a
  property of the window's own membership, which slicing does not touch. The hazard the registry
  polices is a value seeded at the *scan's* first row (`lagInFrame`), and this aggregate reads no
  such seed.

- **`ReanchorRange` gains a `*RangeWindowNative` arm** — re-grid `Start`/`End`, widen the input spine
  via the new `RangeWindowNative.InputWindow`, behind a two-bound grid-prediction guard
  (`checkPredictedGridNative`, the `RangeLWR`-shaped form, since the node has no `OuterRange` field).

- **`ReanchorRange` gains a `*UnionAll` arm** that re-anchors *every* arm onto the same sub-grid. The
  arms are concatenated positionally, so all of them must move together — a shard that re-gridded one
  and shared another verbatim would compose the shared arm's full-grid answer K times over, silently,
  since both arms still project the same column shape.

## Slicer and planner

Three seams had to widen together, and each fails differently:

- **`UnpinSpine`** zeroes the native node's bounds on all three of its routes to that node (the
  copy-on-write spine walk, the off-spine `subtreeHasZeroableSpine` probe, and the `zeroSpineInPlace`
  fallback). Without any one of them the node reaches `ReanchorRange` still pinned at the full request
  grid, every slice returns `ErrReanchorGridMismatch`, and `sliceAndDecide` converts that into a
  *silent* fall back to route A — the plan classifies as routable and never routes.

- **The native carrier's bound-pinning, grid-prediction and nested-grid-phase gates now run**
  (`checkRangeWindowNativeGrid`). This is entirely new surface: before the node was routable, an
  @-pinned anchor could not be sliced onto wrong bounds because it could not be sliced at all.

- **`scalarInteriorAnchorCompatible` gains a native arm.** Registering the node slice-invariant
  silenced `walkScalarInterior`'s sweep, which was the only thing standing between a full-span
  single-pass grid aggregate in a `ScalarSubquery` interior and being replicated K times. It is now
  held to the same grid-and-cadence equality the fan-out `RangeWindow` gets.

## The open sub-question, resolved: a native carrier's fan-out is 1

`carrierGeometry.lookback` was answering two questions that coincide for the fan-out family and
diverge for the native one. They are now split:

- **D stays the window span for every carrier.** D is per-slice *scan* redundancy — adjacent slices'
  input windows overlap by exactly the window span, whichever emitter reads them — and a native
  shard widens its input by `Offset+Range` exactly as a fan-out shard does. `singlePass` does not
  touch it, so the high-D floor and the K clamp are unchanged.

- **F becomes `singlePassFanout` (1) for the native `timeSeries*ToGrid` family.** F is the *memory*
  proxy the ModeAuto gate reads: peak intermediate rows per raw row, which is what slicing the anchor
  grid K ways divides by K. The fan-out arm `arrayJoin`s each sample across the `lookback/Step`
  anchors it covers; the native aggregate builds no such intermediate — its state is one
  `Array(Nullable(Float64))` of N grid points per *series*. Reporting `Range/Step` would claim a
  matrix that is never built, and ModeAuto would shard a flat-memory single-pass statement K ways,
  paying K overlapping scans for a memory problem it does not have.

The pairing is the point: a pure-native plan is **fully sliceable** but stays route A on **cost**
(`F=1 < MinFanout=16`, `reason=below-threshold` — a cost gate, not a correctness one), while

- a mixed `UnionAll{native, fan-out}` routes on the fan-out arm's `F=20`, since `maxFanout` is a max
  over carriers — exactly #2114's shape; and
- the threshold-free `Eligible` seam — the failure-driven route memo, which fires on a *real* route-A
  resource failure rather than on a cost proxy — still slices a pure-native plan when the evidence
  says route A could not hold it.

`RangeWindowResample` is marked `singlePass` too. It is the same native emitter family and the same
argument applies verbatim; marking one and not its sibling would leave the field's own definition
false for half the family it describes. It is not re-anchorable, so this changes no routing decision
— only the recorded corpus feature, which becomes honest.

## Engine: route B never stamped the experimental setting

Found while verifying the above. `routeBExecCtx` did not apply route A's per-plan ts-grid rule, so a
routed plan carrying a `timeSeries*ToGrid` node would have had ClickHouse answer code 63
(`aggregate function ... is experimental and disabled by default`) on **every** shard rather than
degrading. That was unreachable while no ts-grid plan could route — the slice-invariance registry
refused them on the main spine *and* inside `walkScalarInterior` — and this PR makes it reachable
three ways at once (`ModeSharded`, which is what `compatibility/prometheus-forced-route` runs; the
route memo; and a mixed union under ModeAuto). Fixed in the same change, reading the Decision's own
shard plans since those are the trees the Executor emits.

## Verification

**Semantic correctness of the new arms** — every added behaviour was checked by mutating the
production code and confirming a test goes red. Eight mutants, all caught:

| mutant | caught by |
| --- | --- |
| `ReanchorRange` native arm inert (share verbatim) | 6 chplan tests |
| `ReanchorRange` UnionAll arm inert | 2 chplan tests |
| native arm skips `InputWindow` widening | `TestReanchorRange_NativeWidensInputSpine` (3 offsets) |
| `unpinSpineCOW` native arm does not zero | `TestUnpinSpine_ZeroesNativeBounds/project-spine` |
| `subtreeHasZeroableSpine` blind to native | 3 solver tests |
| `zeroSpineInPlace` blind to native | 5 solver tests |
| native `singlePass` reverted to `false` | 3 solver tests |
| native grid-prediction guard removed | `TestPlan_NativeGridGuardsRefuse` (2 rows) |
| native pinning guard removed | `TestPlan_NativeGridGuardsRefuse/half-pinned` |
| nested-native end-phase not recorded | `TestPlan_NestedNativeGridConstrainsTheSliceQuantum` |
| `scalarInteriorAnchorCompatible` native arm removed | 2 rows of the negative table |
| route-B ts-grid stamp removed | 2 rows of the engine table |

Beyond kind-level assertions, `TestPlan_NativeUnionShardsMoveBothArms` and
`TestCarrierGeometry_NativeShardsPartitionTheGrid` read the re-anchored node out of every produced
shard and assert the shards' anchor sets are pairwise disjoint and union to the unsliced grid
exactly — the property that distinguishes a partitioned answer from the same answer K times.

**Behaviour preservation.** `just update-golden all` regenerates **every** shard (promql, logql,
traceql, chsql, optimizer, codegen, migration, parity, solver, cardinality) with a **zero-byte diff**:
no emitted SQL, plan snapshot, chDB roundtrip, migration golden, parity ledger or cardinality profile
moves. The whole untagged suite (`./internal/...` + `./test/...`) is green.

**The solver decision baseline.** Zero decisions changed — and that green is hollow for a structural
reason worth stating rather than glossing. The ratchet's `classifyCorpus` lowers through
`promql.LowerAtRange`, whose zero `LowerOpts` resolves to the **all-fan-out** strategy table, so the
lane never classifies a native plan at all. Measured over the corpus it classifies: 590 fixtures,
283 `RangeWindow`, 33 `UnionAll`, **0** `RangeWindowNative`, **0** `RangeWindowResample` — while
`ts_grid_range` is `AutoSelect: true` above CH 25.9, i.e. the production default. Filed as #2120.

The 33 `UnionAll` fixtures were audited individually rather than trusted to the aggregate: three of
them put a `UnionAll` above a live grid carrier (`histogram_quantiles_classic_multi_phi`,
`histogram_quantiles_native_multi_phi`, `info_ignore_split_unpinned_base`) and all three are
`not-sliceable` before and after, refused by a non-slice-invariant node or a non-re-anchorable
carrier. So no plan in the corpus reaches the new `UnionAll` arm today, and the widening changes no
live behaviour.

## Scope boundary

This PR does **not** ship #2114's CUMULATIVE/DELTA UNION split. It touches neither
`nativeTSGridMatrixNode`'s `rw.TemporalityColumn != ""` refusal nor any emitter. #2114 is now
unblocked as its own follow-on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
