### PR TITLE
feat(qlcommon): probe capture participation to widen label_replace's shared-name guard

### DIFF
--- a/internal/chplan/clone.go
+++ b/internal/chplan/clone.go
@@ -485,9 +485,9 @@ func cloneStrings(in []string) []string {
 }
 
 // cloneLabelReplaceSegments copies a replacement decomposition. Each
-// element carries its own Fallbacks slice, so the backing arrays are
-// copied too — a shallow copy would leave the clone aliasing the
-// original's index lists.
+// element carries its own Fallbacks and Probes slices, so the backing
+// arrays are copied too — a shallow copy would leave the clone aliasing
+// the original's index lists.
 func cloneLabelReplaceSegments(in []LabelReplaceSegment) []LabelReplaceSegment {
 	if in == nil {
 		return nil
@@ -496,6 +496,7 @@ func cloneLabelReplaceSegments(in []LabelReplaceSegment) []LabelReplaceSegment {
 	copy(out, in)
 	for i := range out {
 		out[i].Fallbacks = cloneInts(in[i].Fallbacks)
+		out[i].Probes = cloneInts(in[i].Probes)
 	}
 	return out
 }

--- a/internal/chplan/label_replace.go
+++ b/internal/chplan/label_replace.go
@@ -64,6 +64,15 @@ type LabelReplace struct {
 	Src              string
 	Regex            string
 	EmptyReplacement string
+	// ProbedRegex, when non-empty, is the pattern the emitter must feed
+	// `extractGroups` in place of Regex: the same pattern with synthetic
+	// capture groups added so that a group whose own capture cannot report
+	// whether it TOOK PART in the match has a neighbour that can. It
+	// matches exactly the strings Regex matches — the added groups only
+	// observe — but it numbers capture groups differently, so every index
+	// in Segments is in ITS numbering, not Regex's. Regex still drives the
+	// `match(...)` test, where the numbering is immaterial.
+	ProbedRegex string
 	// Segments, when non-empty, replaces Replacement as the description
 	// of the substituted value. See LabelReplaceSegment.
 	Segments []LabelReplaceSegment
@@ -104,6 +113,15 @@ type LabelReplaceSegment struct {
 	// participant capturing the empty string with a later listed group
 	// capturing text — see qlcommon's captureGroups.expressibleCarriers.
 	Fallbacks []int
+	// Probes holds, for each searched carrier — Group followed by
+	// Fallbacks, one element apiece and in that order — the capture group
+	// whose NON-EMPTINESS reports that the carrier took part in the match.
+	// It is empty when every carrier's own capture reports that, which is
+	// the case whenever no carrier is nullable-and-skippable; the emitter
+	// then searches the carriers themselves. When it is populated the
+	// indices refer to [LabelReplace.ProbedRegex], whose synthetic groups
+	// exist precisely to be read here.
+	Probes []int
 	// Group is the capture-group index to substitute, or [NoCaptureGroup]
 	// when this segment is literal text.
 	Group int
@@ -111,6 +129,14 @@ type LabelReplaceSegment struct {
 
 // Equal reports whether two segments describe the same contribution.
 func (s LabelReplaceSegment) Equal(o LabelReplaceSegment) bool {
+	if len(s.Probes) != len(o.Probes) {
+		return false
+	}
+	for i := range s.Probes {
+		if s.Probes[i] != o.Probes[i] {
+			return false
+		}
+	}
 	if len(s.Fallbacks) != len(o.Fallbacks) {
 		return false
 	}

--- a/internal/chplan/label_replace.go
+++ b/internal/chplan/label_replace.go
@@ -167,6 +167,7 @@ func (l *LabelReplace) Equal(other Expr) bool {
 		l.Replacement == o.Replacement &&
 		l.Src == o.Src &&
 		l.Regex == o.Regex &&
+		l.ProbedRegex == o.ProbedRegex &&
 		l.EmptyReplacement == o.EmptyReplacement &&
 		l.Map.Equal(o.Map)
 }

--- a/internal/chsql/builder.go
+++ b/internal/chsql/builder.go
@@ -1108,21 +1108,52 @@ func (b *Builder) labelReplaceSegment(l *chplan.LabelReplace, seg chplan.LabelRe
 			srcErr = err
 		}
 	})
+	extract := labelReplaceExtractRegex(l, anchored)
 	if len(seg.Fallbacks) == 0 {
-		captureGroupAt(src, anchored, seg.Group)(b)
+		captureGroupAt(src, extract, seg.Group)(b)
 		return srcErr
 	}
 	candidates := make([]Frag, 0, 1+len(seg.Fallbacks))
-	candidates = append(candidates, captureGroupAt(src, anchored, seg.Group))
+	candidates = append(candidates, captureGroupAt(src, extract, seg.Group))
 	for _, idx := range seg.Fallbacks {
-		candidates = append(candidates, captureGroupAt(src, anchored, idx))
+		candidates = append(candidates, captureGroupAt(src, extract, idx))
+	}
+	if len(seg.Probes) == 0 {
+		Call(
+			"arrayFirst",
+			Lambda1(labelReplaceCandidateParam, Neq(BareIdent(labelReplaceCandidateParam), Lit(""))),
+			Array(candidates...),
+		)(b)
+		return srcErr
+	}
+	// A probed carrier is one whose own capture cannot say whether it took
+	// part in the match, so the test and the answer read different groups.
+	// `arrayFirst` over TWO arrays is exactly that shape: the predicate
+	// runs over the participation array, and the element returned is the
+	// one at the same position of the value array.
+	witnesses := make([]Frag, 0, len(seg.Probes))
+	for _, idx := range seg.Probes {
+		witnesses = append(witnesses, captureGroupAt(src, extract, idx))
 	}
 	Call(
 		"arrayFirst",
-		Lambda1(labelReplaceCandidateParam, Neq(BareIdent(labelReplaceCandidateParam), Lit(""))),
+		Lambda2(labelReplaceCandidateParam, labelReplaceWitnessParam,
+			Neq(BareIdent(labelReplaceWitnessParam), Lit(""))),
 		Array(candidates...),
+		Array(witnesses...),
 	)(b)
 	return srcErr
+}
+
+// labelReplaceExtractRegex is the pattern the `extractGroups` calls read.
+// It is the plan's probed rewrite when it has one — whose synthetic
+// groups the segment indices are numbered against — and the plain
+// anchored regex otherwise.
+func labelReplaceExtractRegex(l *chplan.LabelReplace, anchored string) string {
+	if l.ProbedRegex == "" {
+		return anchored
+	}
+	return anchorLabelReplaceRegex(l.ProbedRegex)
 }
 
 // labelReplaceCandidateParam is the lambda parameter naming one
@@ -1130,6 +1161,13 @@ func (b *Builder) labelReplaceSegment(l *chplan.LabelReplace, seg chplan.LabelRe
 // labelReplaceSegment emits. It is emitter-chosen and never collides with
 // a column: CH resolves a lambda parameter ahead of any outer name.
 const labelReplaceCandidateParam = "x"
+
+// labelReplaceWitnessParam is the second lambda parameter of the
+// two-array `arrayFirst` search, naming the capture whose non-emptiness
+// reports that the candidate beside it took part in the match. Like
+// labelReplaceCandidateParam it is emitter-chosen, and CH resolves a
+// lambda parameter ahead of any outer name.
+const labelReplaceWitnessParam = "p"
 
 // captureGroupAt returns a Frag for one capture group's value:
 // `extractGroups(<src>, <anchored>)[<group>]`.

--- a/internal/chsql/label_replace_probe_chdb_test.go
+++ b/internal/chsql/label_replace_probe_chdb_test.go
@@ -1,0 +1,107 @@
+//go:build chdb
+
+// chDB-backed proof that the probe rewrite is right in ClickHouse and not
+// only in Go.
+//
+// Every other test of this feature reasons about `extractGroups` through
+// Go's `regexp`, which is a model of ClickHouse's regex engine rather than
+// ClickHouse itself. The two agree on re2 semantics, but the emitted form
+// — `arrayFirst` over TWO arrays, whose predicate runs over the second and
+// whose result comes from the first — is a ClickHouse function contract,
+// not a Go one. If CH returned the element of the array the predicate ran
+// over, every Go-side differential would still pass while the label on the
+// wire carried the probe's text instead of the carrier's.
+//
+// So this runs the SQL the emitter really produces, against the values
+// ClickHouse really computes, and compares to Go's `ExpandString` — the
+// engine reference Prometheus and reference Loki both define
+// `label_replace` in terms of.
+package chsql
+
+import (
+	"regexp"
+	"testing"
+
+	"github.com/tsouza/cerberus/internal/chplan"
+	"github.com/tsouza/cerberus/internal/chsqltest"
+)
+
+func TestLabelReplaceProbedSelection_ChDB(t *testing.T) {
+	db := chsqltest.OpenIsolatedChDB(t)
+
+	cases := []struct {
+		name    string
+		regex   string
+		probed  string
+		segment chplan.LabelReplaceSegment
+		srcs    []string
+	}{
+		{
+			// The witness issue #1956 was narrowed to. On "xb" the
+			// optional branch takes part and captures nothing, so the
+			// answer is "" — which a search over the carriers' own
+			// captures would get wrong by answering "b".
+			name:    "quest_body_probe",
+			regex:   `(?:x(?P<dup>a?))?(?P<dup>b)`,
+			probed:  `(?:(?P<cerberusprobe0>x(?P<dup>a?)))?(?P<dup>b)`,
+			segment: chplan.LabelReplaceSegment{Group: 2, Fallbacks: []int{3}, Probes: []int{1, 3}},
+			srcs:    []string{"xb", "b", "xab"},
+		},
+		{
+			// Only the branch holding the carrier is probed, so the probe
+			// must stay silent on matches that take the other branch.
+			name:    "alternation_branch_probe",
+			regex:   `(?:x(?P<dup>a?)|y(?P<dup>b))?(?P<dup>c)`,
+			probed:  `(?:(?P<cerberusprobe0>x(?P<dup>a?))|y(?P<dup>b))?(?P<dup>c)`,
+			segment: chplan.LabelReplaceSegment{Group: 2, Fallbacks: []int{3, 4}, Probes: []int{1, 3, 4}},
+			srcs:    []string{"xc", "xac", "ybc", "c"},
+		},
+		{
+			// Two probes in one pattern: each must answer for its own
+			// carrier and not for the other's.
+			name:    "two_probes",
+			regex:   `(?:x(?P<dup>a?))?(?:y(?P<dup>b?))?(?P<dup>c)`,
+			probed:  `(?:(?P<cerberusprobe0>x(?P<dup>a?)))?(?:(?P<cerberusprobe1>y(?P<dup>b?)))?(?P<dup>c)`,
+			segment: chplan.LabelReplaceSegment{Group: 2, Fallbacks: []int{4, 5}, Probes: []int{1, 3, 5}},
+			srcs:    []string{"xyc", "yc", "c", "xaybc", "xybc", "xc"},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			sql, args := renderExpr(t, &chplan.LabelReplace{
+				Map:              attrsMap(),
+				Dst:              "dst",
+				Src:              "src",
+				Regex:            tc.regex,
+				ProbedRegex:      tc.probed,
+				EmptyReplacement: "",
+				Segments:         []chplan.LabelReplaceSegment{tc.segment},
+			})
+			// The emitted expression rewrites the whole Attributes map, so
+			// the assertion reads the destination label back out of it.
+			// mapFilter drops an empty value, and a missing key reads as
+			// the empty string, which is the same observable.
+			query := "SELECT (" + sql + ")[?] FROM (SELECT map(?, ?) AS Attributes)"
+
+			oracle := regexp.MustCompile("^(?s:" + tc.regex + ")$")
+			for _, src := range tc.srcs {
+				match := oracle.FindStringSubmatchIndex(src)
+				if match == nil {
+					t.Fatalf("regex %q does not match %q — the oracle needs a match", tc.regex, src)
+				}
+				want := string(oracle.ExpandString(nil, "$dup", src, match))
+
+				bound := append(append([]any{}, args...), "dst", "src", src)
+				var got string
+				if err := db.QueryRow(query, bound...).Scan(&got); err != nil {
+					t.Fatalf("regex %q src %q: %v\n--- sql ---\n%s", tc.regex, src, err, query)
+				}
+				if got != want {
+					t.Errorf("regex %q src %q: ClickHouse answered %q, Go's ExpandString gives %q",
+						tc.regex, src, got, want)
+				}
+			}
+		})
+	}
+}

--- a/internal/chsql/label_rewrite_mutation_test.go
+++ b/internal/chsql/label_rewrite_mutation_test.go
@@ -239,3 +239,55 @@ func TestMutation_ExprLabelJoin_MapErrorPropagates(t *testing.T) {
 		t.Fatalf("LabelJoin with an unrenderable Map must return ErrUnsupported, got %v", err)
 	}
 }
+
+// TestMutation_ExprLabelReplace_ProbedCarrierForm pins the shape a
+// selection takes when a carrier's own capture cannot report whether it
+// took part in the match: `arrayFirst` over TWO arrays, testing the
+// participation array and answering from the value array, over the
+// REWRITTEN regex whose synthetic groups the probes index.
+//
+// Both halves are assertions. Emitting the single-array form would test
+// the carrier's own capture and answer with a later carrier's text on
+// exactly the rows the rewrite exists for; emitting the original regex
+// would index groups that the rewrite renumbered, silently reading the
+// wrong ones.
+//
+// Kills labelReplaceSegment's `len(seg.Probes) == 0` guard and
+// labelReplaceExtractRegex's `l.ProbedRegex == ""` guard.
+func TestMutation_ExprLabelReplace_ProbedCarrierForm(t *testing.T) {
+	t.Parallel()
+
+	sql, args := renderExpr(t, &chplan.LabelReplace{
+		Map:              attrsMap(),
+		Dst:              "dst",
+		Src:              "src",
+		Regex:            `(?:x(?P<dup>a?))?(?P<dup>b)`,
+		ProbedRegex:      `(?:(?P<cerberusprobe0>x(?P<dup>a?)))?(?P<dup>b)`,
+		EmptyReplacement: "",
+		Segments: []chplan.LabelReplaceSegment{
+			{Group: 2, Fallbacks: []int{3}, Probes: []int{1, 3}},
+		},
+	})
+
+	const probed = `^(?s:(?:(?P<cerberusprobe0>x(?P<dup>a?)))?(?P<dup>b))$`
+	assertRender(
+		t, sql, args,
+		"mapFilter((k, v) -> v != '', if(match(`Attributes`[?], ?), "+
+			"mapUpdate(`Attributes`, map(?, if(empty(`Attributes`[?]), ?, "+
+			"concat(arrayFirst((x, p) -> p != ?, ["+
+			"extractGroups(`Attributes`[?], ?)[?], "+
+			"extractGroups(`Attributes`[?], ?)[?]], ["+
+			"extractGroups(`Attributes`[?], ?)[?], "+
+			"extractGroups(`Attributes`[?], ?)[?]]))))), `Attributes`))",
+		[]any{
+			// The match() test keeps the ORIGINAL regex: it accepts the
+			// same strings, and no numbering is read off it.
+			"src", "^(?s:(?:x(?P<dup>a?))?(?P<dup>b))$", "dst", "src", "",
+			"",
+			"src", probed, int64(2),
+			"src", probed, int64(3),
+			"src", probed, int64(1),
+			"src", probed, int64(3),
+		},
+	)
+}

--- a/internal/logql/label_fns.go
+++ b/internal/logql/label_fns.go
@@ -63,6 +63,7 @@ func lowerLabelReplace(e *syntax.LabelReplaceExpr, s schema.Logs, lc lowerCtx) (
 		Dst:              e.Dst,
 		Replacement:      chRepl.Template,
 		Segments:         chRepl.Segments,
+		ProbedRegex:      chRepl.ProbedRegex,
 		Src:              e.Src,
 		Regex:            e.Regex,
 		EmptyReplacement: qlcommon.EmptyCapturesReplacement(e.Replacement),

--- a/internal/logql/label_fns_test.go
+++ b/internal/logql/label_fns_test.go
@@ -23,11 +23,15 @@ func TestLowerLabelReplace_RejectsInexpressibleBackref(t *testing.T) {
 	// captures text: Go's ExpandString stops at the first participant and
 	// expands to its empty capture, and `extractGroups` renders "took part
 	// matching empty" exactly like "took no part", so SQL cannot observe
-	// which. On `host="xb"` reference Loki answers `service=""` where a
-	// first-non-empty search would answer `service="b"`. Issue #1956
-	// tracks the residue.
+	// which. On `host="b"` reference Loki answers `service=""` where the
+	// emitted search would answer `service="b"`.
+	//
+	// The carrier here is alone in a nullable alternation branch, so
+	// nothing above it is guaranteed to be consumed and no probe can stand
+	// in for its participation — the case a probe rewrite cannot reach.
+	// Issue #1956 tracks that residue.
 	const q = `label_replace(sum by (host) (count_over_time({app="a"}[5m])), ` +
-		`"service", "$dup", "host", "(?:x(?P<dup>a?))?(?P<dup>b)")`
+		`"service", "$dup", "host", "(?:(?P<dup>a?)|y)(?P<dup>b)")`
 
 	expr, err := syntax.ParseExpr(q)
 	if err != nil {
@@ -63,6 +67,9 @@ func TestLowerLabelReplace_AcceptsSharedCaptureName(t *testing.T) {
 		// A nullable carrier every match must pass through: Go always
 		// stops at it, so the search truncates there.
 		{"nullable_carrier_on_the_mandatory_spine", `(?P<dup>a?)(?P<dup>b)`},
+		// A nullable carrier a match can skip, cleared by rewriting the
+		// regex to probe the mandatory text in the quest's body.
+		{"nullable_skippable_carrier_with_a_probeable_ancestor", `(?:x(?P<dup>a?))?(?P<dup>b)`},
 	}
 
 	for _, tc := range cases {

--- a/internal/promql/label_fns.go
+++ b/internal/promql/label_fns.go
@@ -56,6 +56,7 @@ func lowerLabelReplace(c *parser.Call, s schema.Metrics, ctx lowerCtx) (chplan.N
 		Dst:              dst,
 		Replacement:      chRepl.Template,
 		Segments:         chRepl.Segments,
+		ProbedRegex:      chRepl.ProbedRegex,
 		Src:              src,
 		Regex:            regex,
 		EmptyReplacement: qlcommon.EmptyCapturesReplacement(replacement),

--- a/internal/promql/label_fns_test.go
+++ b/internal/promql/label_fns_test.go
@@ -22,14 +22,21 @@ import (
 // and emit a plan whose destination label silently holds the wrong text.
 //
 // The regex below is the smallest shape that really is unobservable, and
-// it carries its own proof: on `host="xb"` the optional branch takes part
-// and `dup` captures nothing, so Prometheus answers `service=""`, while a
-// first-non-empty search over the two carriers answers `service="b"`.
-// Issue #1956 tracks the residue this pins.
+// it carries its own proof: on `host="b"` the alternation takes its empty
+// first branch, so `dup` takes part capturing nothing and Prometheus
+// answers `service=""`, while the emitted search answers `service="b"`.
+//
+// A carrier under a quest is NOT enough on its own any more — where the
+// carrier has an ancestor that cannot match empty, cerberus rewrites the
+// regex to probe it and lowers the query, which
+// TestLowerLabelReplace_AcceptsSharedCaptureName covers. What is left is a
+// carrier alone in a nullable branch, with nothing above it guaranteed to
+// be consumed. Issue #1956 tracks that residue, and
+// ClickHouse/ClickHouse#114733 tracks the upstream gap behind it.
 func TestLowerLabelReplace_RejectsInexpressibleBackref(t *testing.T) {
 	t.Parallel()
 
-	const q = `label_replace(temperature, "service", "$dup", "host", "(?:x(?P<dup>a?))?(?P<dup>b)")`
+	const q = `label_replace(temperature, "service", "$dup", "host", "(?:(?P<dup>a?)|y)(?P<dup>b)")`
 
 	expr, err := parser.NewParser(parser.Options{}).ParseExpr(q)
 	if err != nil {
@@ -80,6 +87,15 @@ func TestLowerLabelReplace_AcceptsSharedCaptureName(t *testing.T) {
 			// carrier is unreachable.
 			"nullable_carrier_on_the_mandatory_spine",
 			`label_replace(temperature, "service", "$dup", "host", "(?P<dup>a?)(?P<dup>b)")`,
+		},
+		{
+			// A nullable carrier a match CAN skip, which no static fact
+			// clears: the quest's body holds mandatory text, so cerberus
+			// rewrites the regex to capture that text and reads the
+			// carrier's participation off it. This shape was rejected
+			// until probes existed.
+			"nullable_skippable_carrier_with_a_probeable_ancestor",
+			`label_replace(temperature, "service", "$dup", "host", "(?:x(?P<dup>a?))?(?P<dup>b)")`,
 		},
 	}
 

--- a/internal/qlcommon/capture_participation_test.go
+++ b/internal/qlcommon/capture_participation_test.go
@@ -244,6 +244,19 @@ var participationArrangements = []participationArrangement{
 	{template: "(?:C1{2}|C2)", carriers: 2, alwaysExpressible: true},
 	{template: "(?:C1|C2){2}", carriers: 2},
 
+	// A branch with LITERAL text of its own is what gives a carrier
+	// inside it a non-nullable ancestor to probe, so these are the
+	// arrangements the probe rewrite actually turns on — and, under a
+	// repetition, the ones where one match can enter both branches and a
+	// probe has to keep answering for its own carrier only.
+	{template: "(?:xC1|C2)*", carriers: 2},
+	{template: "(?:xC1|C2)+", carriers: 2},
+	{template: "(?:xC1|C2)?", carriers: 2},
+	{template: "(?:xC1|yC2)*", carriers: 2},
+	{template: "(?:xC1)?(?:yC2)?", carriers: 2},
+	{template: "(?:xC1)*(?:yC2)*", carriers: 2},
+	{template: "(?:x(?:yC1))?C2", carriers: 2},
+
 	// Three carriers. The first four put a carrier in an alternation
 	// branch alongside a THIRD that sits outside it, which is the shape
 	// where clearing a carrier against only its immediate successor is not
@@ -258,6 +271,9 @@ var participationArrangements = []participationArrangement{
 	{template: "(?:C1)?C2(?:C3)?", carriers: 3},
 	{template: "(?:C1|C2|C3)*", carriers: 3},
 	{template: "(?:xC1)?(?:C2|C3)", carriers: 3},
+	{template: "(?:xC1|C2)*C3", carriers: 3},
+	{template: "(?:xC1)?(?:yC2)?C3", carriers: 3},
+	{template: "C1(?:xC2|yC3)?", carriers: 3},
 }
 
 // participationCorpus expands every arrangement against every combination
@@ -342,7 +358,7 @@ func TestExpressibleCarriersAgreeWithExpandString(t *testing.T) {
 	inputs := stringsUpTo("abxy", 3)
 
 	corpus := participationCorpus()
-	accepted := 0
+	accepted, probed := 0, 0
 	for _, regex := range corpus {
 		re, err := regexp.Compile(anchorRegex(regex))
 		if err != nil {
@@ -354,6 +370,9 @@ func TestExpressibleCarriersAgreeWithExpandString(t *testing.T) {
 			continue
 		}
 		accepted++
+		if got.ProbedRegex != "" {
+			probed++
+		}
 
 		for _, src := range inputs {
 			match := re.FindStringSubmatchIndex(src)
@@ -361,7 +380,7 @@ func TestExpressibleCarriersAgreeWithExpandString(t *testing.T) {
 				continue
 			}
 			want := string(re.ExpandString(nil, "$dup", src, match))
-			evaluated := evaluateReplacement(got, src, re.FindStringSubmatch(src))
+			evaluated := evaluateReplacement(got, regex, src)
 			if evaluated != want {
 				t.Fatalf("regex %q src %q: %+v evaluates to %q; "+
 					"Go's ExpandString gives %q",
@@ -381,8 +400,20 @@ func TestExpressibleCarriersAgreeWithExpandString(t *testing.T) {
 			"the differential proves nothing about a guard that rejects everything",
 			accepted, len(corpus), floor)
 	}
-	t.Logf("shared-capture-name corpus: %d regexes, %d accepted, %d inputs each",
-		len(corpus), accepted, len(inputs))
+	// The probe rewrite must actually FIRE. Every regex it turns on is one
+	// the static facts alone reject, so a change that silently stopped
+	// planning probes would leave the loop above passing on a strictly
+	// smaller set — green, and having quietly given the capability back.
+	// The two counts also report the narrowing itself: acceptance without
+	// a rewrite is exactly what the guard admitted before probes existed,
+	// because the rewrite only ever adds.
+	if probed == 0 {
+		t.Error("no corpus regex was accepted through a probe rewrite — the rewrite is inert, " +
+			"and the shapes it exists to express are being rejected again")
+	}
+	t.Logf("shared-capture-name corpus: %d regexes, %d accepted (%d without a probe rewrite, "+
+		"%d only because of one), %d inputs each",
+		len(corpus), accepted, accepted-probed, probed, len(inputs))
 }
 
 // stringsUpTo returns every string over alphabet with length 0..maxLen.

--- a/internal/qlcommon/capture_probe.go
+++ b/internal/qlcommon/capture_probe.go
@@ -179,12 +179,26 @@ func planCaptureProbes(regex string, need []int) (captureProbePlan, bool) {
 }
 
 // stripAnchors removes the wrapper [anchorRegex] added.
+//
+// The two halves are derived from [anchorRegex] rather than written out
+// again, because the emitter already carries its own copy of that
+// spelling and a third one would be a third thing to keep in step.
 func stripAnchors(anchored string) (string, bool) {
-	const prefix, suffix = "^(?s:", ")$"
+	prefix, suffix := anchorWrapper()
 	if !strings.HasPrefix(anchored, prefix) || !strings.HasSuffix(anchored, suffix) {
 		return "", false
 	}
 	return anchored[len(prefix) : len(anchored)-len(suffix)], true
+}
+
+// anchorWrapper returns the text [anchorRegex] puts before and after a
+// pattern, by asking it to wrap a marker no regex source can contain and
+// reading the halves off either side.
+func anchorWrapper() (prefix, suffix string) {
+	const marker = "\x00"
+	wrapped := anchorRegex(marker)
+	at := strings.Index(wrapped, marker)
+	return wrapped[:at], wrapped[at+len(marker):]
 }
 
 // readBackPlan verifies the rewrite against the compiler and derives the
@@ -256,6 +270,9 @@ func insertProbes(src string, spans map[int]sourceSpan) (string, map[int]string,
 	probeNames := map[int]string{}
 	var edits []edit
 	for _, carrier := range carriers {
+		if !nestsCleanly(spans[carrier], spans, carriers) {
+			return "", nil, false
+		}
 		span := spans[carrier]
 		name, seen := named[span]
 		if !seen {
@@ -302,6 +319,29 @@ func insertProbes(src string, spans map[int]sourceSpan) (string, map[int]string,
 	}
 	out.WriteString(src[prev:])
 	return out.String(), probeNames, true
+}
+
+// nestsCleanly reports whether span is either nested inside or disjoint
+// from every other span in the set.
+//
+// Parentheses can only bracket a set of ranges that nests — the edits are
+// applied in one forward pass, so a pair that merely OVERLAPS would emit
+// its four delimiters in an order that brackets two DIFFERENT ranges than
+// the ones asked for, and the result would still compile. Ancestor walks
+// only ever produce nesting sets, so this never fires in practice; it is
+// here because "wrapped a span nobody chose" is the one failure this file
+// cannot detect after the fact.
+func nestsCleanly(span sourceSpan, spans map[int]sourceSpan, carriers []int) bool {
+	for _, carrier := range carriers {
+		other := spans[carrier]
+		disjoint := span.end <= other.start || other.end <= span.start
+		nested := (span.start <= other.start && other.end <= span.end) ||
+			(other.start <= span.start && span.end <= other.end)
+		if !disjoint && !nested {
+			return false
+		}
+	}
+	return true
 }
 
 // probeSpanFor finds the span whose emptiness answers for the capture

--- a/internal/qlcommon/capture_probe.go
+++ b/internal/qlcommon/capture_probe.go
@@ -251,8 +251,11 @@ type sourceSpan struct{ start, end int }
 // insertProbes wraps each distinct span in a named capture group,
 // returning the rewritten source and the probe name serving each carrier.
 //
-// Two carriers under one ancestor resolve to the same span and share a
-// single probe, which keeps the rewrite as small as the question needs.
+// The spans nest, so the rewrite is one walk of the source with a stack of
+// the spans currently open: a `)` is always owed to the innermost of them.
+// Emitting from the structure rather than from a sorted list of loose
+// delimiters is what makes "which probe wraps which span" a property of
+// the walk instead of of a comparator.
 func insertProbes(src string, spans map[int]sourceSpan) (string, map[int]string, bool) {
 	carriers := make([]int, 0, len(spans))
 	for carrier := range spans {
@@ -260,88 +263,63 @@ func insertProbes(src string, spans map[int]sourceSpan) (string, map[int]string,
 	}
 	sort.Ints(carriers)
 
-	type edit struct {
-		at   int
-		open bool
-		span sourceSpan
-		name string
-	}
+	// One probe per DISTINCT span: two carriers under one ancestor resolve
+	// to the same span and share a probe, which keeps the rewrite as small
+	// as the question needs.
 	named := map[sourceSpan]string{}
 	probeNames := map[int]string{}
-	var edits []edit
+	var ordered []sourceSpan
 	for _, carrier := range carriers {
-		if !nestsCleanly(spans[carrier], spans, carriers) {
-			return "", nil, false
-		}
 		span := spans[carrier]
-		name, seen := named[span]
-		if !seen {
-			name = probeNamePrefix + strconv.Itoa(len(named))
-			named[span] = name
-			edits = append(edits,
-				edit{at: span.start, open: true, span: span, name: name},
-				edit{at: span.end, open: false, span: span, name: name})
+		if _, seen := named[span]; !seen {
+			named[span] = probeNamePrefix + strconv.Itoa(len(named))
+			ordered = append(ordered, span)
 		}
-		probeNames[carrier] = name
+		probeNames[carrier] = named[span]
 	}
-	// Spans nest, so at a shared offset the wider one must open first and
-	// close last for the inserted parentheses to nest the same way.
-	sort.SliceStable(edits, func(i, j int) bool {
-		a, b := edits[i], edits[j]
-		if a.at != b.at {
-			return a.at < b.at
+
+	// Outermost first at a shared start, so nested spans open in the order
+	// their parentheses have to nest.
+	sort.SliceStable(ordered, func(i, j int) bool {
+		if ordered[i].start != ordered[j].start {
+			return ordered[i].start < ordered[j].start
 		}
-		if a.open != b.open {
-			return !a.open
-		}
-		wa, wb := a.span.end-a.span.start, b.span.end-b.span.start
-		if a.open {
-			return wa > wb
-		}
-		return wa < wb
+		return ordered[i].end > ordered[j].end
 	})
 
+	// Walk the source once, opening every span that starts here and closing
+	// every one that ends here. The open spans form a stack because they
+	// nest, so the innermost — the one on top — is always the one to close.
 	var out strings.Builder
-	prev := 0
-	for _, e := range edits {
-		if e.at < prev || e.at > len(src) {
-			return "", nil, false
-		}
-		out.WriteString(src[prev:e.at])
-		if e.open {
-			out.WriteString("(?P<")
-			out.WriteString(e.name)
-			out.WriteString(">")
-		} else {
+	var open []sourceSpan
+	next := 0
+	for i := 0; i <= len(src); i++ {
+		for len(open) > 0 && open[len(open)-1].end == i {
 			out.WriteString(")")
+			open = open[:len(open)-1]
 		}
-		prev = e.at
+		for next < len(ordered) && ordered[next].start == i {
+			out.WriteString("(?P<")
+			out.WriteString(named[ordered[next]])
+			out.WriteString(">")
+			open = append(open, ordered[next])
+			next++
+		}
+		if i < len(src) {
+			out.WriteByte(src[i])
+		}
 	}
-	out.WriteString(src[prev:])
+	// Every span must have been both opened and closed by the walk. That
+	// single check is the whole validation: a span reaching outside the
+	// source never opens or never closes, and a pair that overlaps without
+	// nesting leaves the stack holding one of them when its partner
+	// closes. Checking the spans separately beforehand would restate the
+	// same conditions in a form that could drift from what the walk
+	// actually does.
+	if len(open) != 0 || next != len(ordered) {
+		return "", nil, false
+	}
 	return out.String(), probeNames, true
-}
-
-// nestsCleanly reports whether span is either nested inside or disjoint
-// from every other span in the set.
-//
-// Parentheses can only bracket a set of ranges that nests — the edits are
-// applied in one forward pass, so a pair that merely OVERLAPS would emit
-// its four delimiters in an order that brackets two DIFFERENT ranges than
-// the ones asked for, and the result would still compile. Ancestor walks
-// only ever produce nesting sets, so this never fires in practice; it is
-// here because "wrapped a span nobody chose" is the one failure this file
-// cannot detect after the fact.
-func nestsCleanly(span sourceSpan, spans map[int]sourceSpan, carriers []int) bool {
-	for _, carrier := range carriers {
-		other := spans[carrier]
-		disjoint := span.end <= other.start || other.end <= span.start
-		nested := (span.start <= other.start && other.end <= span.end) ||
-			(other.start <= span.start && span.end <= other.end)
-		if !disjoint && !nested {
-			return false
-		}
-	}
-	return true
 }
 
 // probeSpanFor finds the span whose emptiness answers for the capture

--- a/internal/qlcommon/capture_probe.go
+++ b/internal/qlcommon/capture_probe.go
@@ -1,0 +1,385 @@
+package qlcommon
+
+import (
+	"regexp"
+	"regexp/syntax"
+	"sort"
+	"strconv"
+	"strings"
+)
+
+// This file recovers, for a capture group whose own capture cannot report
+// it, the one bit `extractGroups` throws away: whether the group TOOK
+// PART in the match.
+//
+// The bit is unobservable only because every group cerberus can read is
+// nullable — a group that took part capturing nothing renders as `''`,
+// exactly like one that took no part. But nullability is a property of
+// the group's SUBPATTERN, not of the position it occupies, and cerberus
+// gets to choose which subpatterns it reads. So rather than reason harder
+// about the groups the user wrote, this rewrites the REGEX to add a group
+// whose emptiness answers the question directly.
+//
+// Walk up from the carrier to the nearest enclosing span that
+//
+//  1. cannot match the empty string, and
+//  2. every match of which must pass through the carrier,
+//
+// and wrap that span in a fresh capture group — a PROBE. (1) makes the
+// probe non-empty whenever it takes part, and (2) makes it take part
+// exactly when the carrier does. Its non-emptiness is therefore the
+// carrier's participation bit, and the selection over like-named groups
+// becomes a search whose test reads the probe while its answer reads the
+// carrier:
+//
+//	`(?:x(?P<dup>a?))?(?P<dup>b)`
+//
+// becomes
+//
+//	`(?:(?P<cerberusprobe0>x(?P<dup>a?)))?(?P<dup>b)`
+//
+// and on `xb` the probe captures `x` while the carrier captures nothing,
+// so the search stops at the carrier and answers `''` — which is what
+// Go's ExpandString answers, and what a first-non-empty search over the
+// carriers alone gets wrong by answering `b`.
+//
+// (2) is checked against the span's OWN parse rather than the whole
+// regex's: within `x(?P<dup>a?)` the carrier sits on the mandatory spine,
+// even though within the whole pattern it does not. That is precisely the
+// question a probe answers, so the sub-parse is the right frame.
+//
+// Two facts make the walk terminate correctly. Going outwards makes (1)
+// easier to satisfy — a wider span holds more mandatory text — and (2)
+// harder, since a wider span can take in an alternation or a quantifier
+// the carrier sits under. (2) is also MONOTONE: once a span puts a
+// skippable node above the carrier, so does every wider span. So the walk
+// stops at the first span that fails (2), and takes the first that
+// satisfies both.
+//
+// What this does not reach is a carrier with no such span at all —
+// typically one alone in an alternation branch, where the branch is
+// nullable and the alternation above it is what the carrier can be
+// skipped by. Issue #1956 tracks the remainder.
+//
+// The spans are located by scanning the regex SOURCE, because
+// `regexp/syntax` records no byte offsets: its parse tree cannot say
+// where a node came from, and reconstructing a source string from a
+// mutated tree would stake a user's query semantics on `Regexp.String()`
+// round-tripping. Scanning instead means the rewritten regex is the
+// user's own text with two bytes inserted, and every judgement about a
+// span is made by handing the SUBSTRING back to `regexp/syntax` — so the
+// parse tree stays the authority on meaning and the scanner only ever
+// answers "which bytes".
+
+// probeNamePrefix names the capture groups this file inserts. The
+// rewritten regex is handed back to `regexp.Compile`, so the probes are
+// readable off `SubexpNames` by name — which is what lets
+// [planCaptureProbes] verify its own rewrite rather than trust its
+// arithmetic.
+const probeNamePrefix = "cerberusprobe"
+
+// captureProbePlan is a regex rewritten to expose participation, together
+// with the index translation the rewrite forces.
+type captureProbePlan struct {
+	// regex is the rewritten pattern, unanchored, in the same spelling
+	// the caller passed in.
+	regex string
+	// toProbed maps a capture-group index in the ORIGINAL regex to the
+	// index the same group holds in regex. Index 0 (the whole match) maps
+	// to itself.
+	toProbed []int
+	// probeOf maps an original carrier index to the probe group whose
+	// non-emptiness reports that carrier's participation. Keyed by the
+	// ORIGINAL index; the value is in the PROBED numbering.
+	probeOf map[int]int
+}
+
+// probedIndex translates a capture-group index from the original regex's
+// numbering into the rewritten one. The zero plan — no rewrite — leaves
+// every index alone, so callers need not branch on whether one happened.
+func (p captureProbePlan) probedIndex(original int) int {
+	if original < 0 || original >= len(p.toProbed) {
+		return original
+	}
+	return p.toProbed[original]
+}
+
+// planCaptureProbes rewrites regex so that each capture group named in
+// need gains a probe, and reports ok=false when NONE of them has a
+// probeable span — a rewrite that answers nothing is only index churn.
+//
+// A carrier with no probeable span is left out of the plan rather than
+// sinking it, because the carriers of one shared NAME are decided
+// together but different names are decided apart: one name's
+// unanswerable carrier must not cost another name the answer it earned.
+// The caller reads [captureProbePlan.probeOf] per carrier and keeps its
+// rejection for whichever names remain unanswered.
+//
+// need holds capture-group indices in regex's own numbering.
+func planCaptureProbes(regex string, need []int) (captureProbePlan, bool) {
+	if len(need) == 0 {
+		return captureProbePlan{}, false
+	}
+	anchored := anchorRegex(regex)
+	original, err := regexp.Compile(anchored)
+	if err != nil {
+		return captureProbePlan{}, false
+	}
+	// A pattern that already carries a probe name would make the rewrite
+	// unreadable back off SubexpNames, so decline rather than guess.
+	for _, name := range original.SubexpNames() {
+		if strings.HasPrefix(name, probeNamePrefix) {
+			return captureProbePlan{}, false
+		}
+	}
+	groups, ok := scanSourceGroups(anchored)
+	if !ok {
+		return captureProbePlan{}, false
+	}
+	byCapture := map[int]int{}
+	for i, g := range groups {
+		if g.capturing {
+			byCapture[g.capIndex] = i
+		}
+	}
+
+	spans := map[int]sourceSpan{}
+	for _, carrier := range need {
+		at, known := byCapture[carrier]
+		if !known {
+			continue
+		}
+		if span, ok := probeSpanFor(anchored, groups, at); ok {
+			spans[carrier] = span
+		}
+	}
+	if len(spans) == 0 {
+		return captureProbePlan{}, false
+	}
+
+	probed, probeNames, ok := insertProbes(anchored, spans)
+	if !ok {
+		return captureProbePlan{}, false
+	}
+	plan, ok := readBackPlan(original, probed, probeNames)
+	if !ok {
+		return captureProbePlan{}, false
+	}
+	// The probes all sit inside the anchoring wrapper, so stripping it
+	// returns the rewrite to the caller's own spelling — and a wrapper
+	// that did not survive means the rewrite landed somewhere this code
+	// did not intend, which is a reason to decline rather than to trim
+	// harder.
+	body, ok := stripAnchors(plan.regex)
+	if !ok {
+		return captureProbePlan{}, false
+	}
+	plan.regex = body
+	return plan, true
+}
+
+// stripAnchors removes the wrapper [anchorRegex] added.
+func stripAnchors(anchored string) (string, bool) {
+	const prefix, suffix = "^(?s:", ")$"
+	if !strings.HasPrefix(anchored, prefix) || !strings.HasSuffix(anchored, suffix) {
+		return "", false
+	}
+	return anchored[len(prefix) : len(anchored)-len(suffix)], true
+}
+
+// readBackPlan verifies the rewrite against the compiler and derives the
+// index translation from it.
+//
+// This is the rewrite's own proof of work. The scanner computed byte
+// offsets; rather than trust them, the probed pattern is compiled and its
+// capture-group NAMES are compared against the original's. Deleting the
+// probe names from the rewritten vector must reproduce the original
+// vector exactly — same length, same names, same order. A probe inserted
+// at a boundary that does not bracket what it was meant to therefore
+// fails here instead of silently answering for the wrong span.
+func readBackPlan(original *regexp.Regexp, probed string, probeNames map[int]string) (captureProbePlan, bool) {
+	compiled, err := regexp.Compile(probed)
+	if err != nil {
+		return captureProbePlan{}, false
+	}
+	names := compiled.SubexpNames()
+	plan := captureProbePlan{regex: probed, probeOf: map[int]int{}}
+	probeIndex := map[string]int{}
+	for i, name := range names {
+		if strings.HasPrefix(name, probeNamePrefix) {
+			probeIndex[name] = i
+			continue
+		}
+		plan.toProbed = append(plan.toProbed, i)
+	}
+	originalNames := original.SubexpNames()
+	if len(plan.toProbed) != len(originalNames) {
+		return captureProbePlan{}, false
+	}
+	for i, at := range plan.toProbed {
+		if names[at] != originalNames[i] {
+			return captureProbePlan{}, false
+		}
+	}
+	for carrier, name := range probeNames {
+		at, known := probeIndex[name]
+		if !known {
+			return captureProbePlan{}, false
+		}
+		plan.probeOf[carrier] = at
+	}
+	return plan, true
+}
+
+// sourceSpan is a half-open byte range of a regex source.
+type sourceSpan struct{ start, end int }
+
+// insertProbes wraps each distinct span in a named capture group,
+// returning the rewritten source and the probe name serving each carrier.
+//
+// Two carriers under one ancestor resolve to the same span and share a
+// single probe, which keeps the rewrite as small as the question needs.
+func insertProbes(src string, spans map[int]sourceSpan) (string, map[int]string, bool) {
+	carriers := make([]int, 0, len(spans))
+	for carrier := range spans {
+		carriers = append(carriers, carrier)
+	}
+	sort.Ints(carriers)
+
+	type edit struct {
+		at   int
+		open bool
+		span sourceSpan
+		name string
+	}
+	named := map[sourceSpan]string{}
+	probeNames := map[int]string{}
+	var edits []edit
+	for _, carrier := range carriers {
+		span := spans[carrier]
+		name, seen := named[span]
+		if !seen {
+			name = probeNamePrefix + strconv.Itoa(len(named))
+			named[span] = name
+			edits = append(edits,
+				edit{at: span.start, open: true, span: span, name: name},
+				edit{at: span.end, open: false, span: span, name: name})
+		}
+		probeNames[carrier] = name
+	}
+	// Spans nest, so at a shared offset the wider one must open first and
+	// close last for the inserted parentheses to nest the same way.
+	sort.SliceStable(edits, func(i, j int) bool {
+		a, b := edits[i], edits[j]
+		if a.at != b.at {
+			return a.at < b.at
+		}
+		if a.open != b.open {
+			return !a.open
+		}
+		wa, wb := a.span.end-a.span.start, b.span.end-b.span.start
+		if a.open {
+			return wa > wb
+		}
+		return wa < wb
+	})
+
+	var out strings.Builder
+	prev := 0
+	for _, e := range edits {
+		if e.at < prev || e.at > len(src) {
+			return "", nil, false
+		}
+		out.WriteString(src[prev:e.at])
+		if e.open {
+			out.WriteString("(?P<")
+			out.WriteString(e.name)
+			out.WriteString(">")
+		} else {
+			out.WriteString(")")
+		}
+		prev = e.at
+	}
+	out.WriteString(src[prev:])
+	return out.String(), probeNames, true
+}
+
+// probeSpanFor finds the span whose emptiness answers for the capture
+// group at groups[at], or reports that no span does.
+//
+// The ladder is walked innermost-first, and the two tests are applied in
+// the order their monotonicity demands: failing "every match of the span
+// passes through the carrier" ends the walk, because no wider span can
+// restore it, while failing "the span cannot match empty" only moves the
+// walk outwards, where more mandatory text may make it hold.
+func probeSpanFor(src string, groups []sourceGroup, at int) (sourceSpan, bool) {
+	carrierOpen := groups[at].open
+	for _, span := range candidateSpans(groups, at) {
+		body := src[span.start:span.end]
+		parsed, err := syntax.Parse(body, syntax.Perl)
+		if err != nil {
+			return sourceSpan{}, false
+		}
+		shape, known := captureShapes(body)[captureOrdinalIn(groups, span, carrierOpen)]
+		if !known || !shape.unconditional {
+			return sourceSpan{}, false
+		}
+		if !matchesEmpty(parsed) {
+			return span, true
+		}
+	}
+	return sourceSpan{}, false
+}
+
+// captureOrdinalIn reports the capture-group number the group opening at
+// carrierOpen holds within span, which is what a parse of the span alone
+// numbers it. Go numbers capture groups by the position of their opening
+// parenthesis, so this counts openings.
+func captureOrdinalIn(groups []sourceGroup, span sourceSpan, carrierOpen int) int {
+	ordinal := 0
+	for _, g := range groups {
+		if g.capturing && g.open >= span.start && g.open <= carrierOpen {
+			ordinal++
+		}
+	}
+	return ordinal
+}
+
+// candidateSpans returns the ancestor spans to try for the group at
+// groups[at], innermost first.
+//
+// Each enclosing group contributes two: the single alternation BRANCH
+// holding the carrier, then the group's whole body. The branch comes
+// first because it is the tighter frame — inside `(?:xA|y)` the branch
+// `xA` puts the carrier on a mandatory spine that the full body, an
+// alternation, does not.
+func candidateSpans(groups []sourceGroup, at int) []sourceSpan {
+	var out []sourceSpan
+	child := at
+	for parent := groups[at].parent; parent >= 0; parent = groups[parent].parent {
+		g := groups[parent]
+		if branch, split := branchContaining(g, groups[child].open); split {
+			out = append(out, branch)
+		}
+		out = append(out, sourceSpan{start: g.bodyStart, end: g.bodyEnd})
+		child = parent
+	}
+	return out
+}
+
+// branchContaining returns the top-level alternation branch of g's body
+// that holds the group opening at offset, and whether g's body is an
+// alternation at all.
+func branchContaining(g sourceGroup, offset int) (sourceSpan, bool) {
+	if len(g.alternations) == 0 {
+		return sourceSpan{}, false
+	}
+	start := g.bodyStart
+	for _, bar := range g.alternations {
+		if offset < bar {
+			return sourceSpan{start: start, end: bar}, true
+		}
+		start = bar + 1
+	}
+	return sourceSpan{start: start, end: g.bodyEnd}, true
+}

--- a/internal/qlcommon/capture_probe.go
+++ b/internal/qlcommon/capture_probe.go
@@ -290,10 +290,17 @@ func insertProbes(src string, spans map[int]sourceSpan) (string, map[int]string,
 	// Walk the source once, opening every span that starts here and closing
 	// every one that ends here. The open spans form a stack because they
 	// nest, so the innermost — the one on top — is always the one to close.
+	//
+	// The walk visits POSITIONS, of which there is one more than there are
+	// bytes: a span ending at the very end of the source closes at the
+	// position after the last byte. Hence the break in the middle rather
+	// than a bound on the loop — a `for i := 0; i <= len(src)` header would
+	// be an index bound that deliberately disagrees with the indexing
+	// inside it, which is the shape a real off-by-one hides in.
 	var out strings.Builder
 	var open []sourceSpan
 	next := 0
-	for i := 0; i <= len(src); i++ {
+	for i := 0; ; i++ {
 		for len(open) > 0 && open[len(open)-1].end == i {
 			out.WriteString(")")
 			open = open[:len(open)-1]
@@ -305,9 +312,10 @@ func insertProbes(src string, spans map[int]sourceSpan) (string, map[int]string,
 			open = append(open, ordered[next])
 			next++
 		}
-		if i < len(src) {
-			out.WriteByte(src[i])
+		if i == len(src) {
+			break
 		}
+		out.WriteByte(src[i])
 	}
 	// Every span must have been both opened and closed by the walk. That
 	// single check is the whole validation: a span reaching outside the

--- a/internal/qlcommon/capture_probe_boundary_test.go
+++ b/internal/qlcommon/capture_probe_boundary_test.go
@@ -44,6 +44,9 @@ var scannerSyntaxCorpus = []string{
 	`([\]()])`,
 	`([[:alpha:]])`,
 	`([[:^alpha:]])`,
+	`([[:alpha:]()])`,
+	`x[[:digit:]](a)`,
+	`[[:alpha:]][[:digit:]](a)`,
 	`([a[b])`,
 	`([-a])`,
 	`([a-])`,
@@ -297,14 +300,17 @@ func TestCandidateSpansReachTheWholePattern(t *testing.T) {
 func TestProbedIndexTranslatesOnlyRealGroups(t *testing.T) {
 	t.Parallel()
 
-	plan := captureProbePlan{toProbed: []int{0, 2, 3}}
+	// The whole-match entry is deliberately not 0: a table that mapped it
+	// to itself would make the range check's lower bound unobservable,
+	// since returning the argument and returning the entry would agree.
+	plan := captureProbePlan{toProbed: []int{5, 2, 3}}
 
 	cases := []struct {
 		name     string
 		original int
 		want     int
 	}{
-		{"whole_match", 0, 0},
+		{"whole_match", 0, 5},
 		{"first_group", 1, 2},
 		{"last_group", 2, 3},
 		{"one_past_the_table", 3, 3},
@@ -384,6 +390,49 @@ func TestInsertProbesRejectsSpansItCannotWrap(t *testing.T) {
 		}
 	})
 
+	t.Run("a_span_entirely_past_the_source", func(t *testing.T) {
+		t.Parallel()
+		// This one never opens at all, where the case above opens and
+		// never closes — the two halves of the walk's postcondition.
+		if _, _, ok := insertProbes(source, map[int]sourceSpan{
+			1: {start: len(source) + 4, end: len(source) + 8},
+		}); ok {
+			t.Error("insertProbes accepted a span lying entirely past the source")
+		}
+	})
+
+	t.Run("spans_that_touch_without_overlapping", func(t *testing.T) {
+		t.Parallel()
+		// One span ending exactly where the next begins is disjoint, not
+		// overlapping, and both can be wrapped. This is the input that
+		// separates "ends before the other starts" from "ends at or
+		// before" — the bound the nesting test turns on.
+		got, names, ok := insertProbes(source, map[int]sourceSpan{
+			1: {start: 0, end: 6},
+			2: {start: 6, end: 12},
+		})
+		if !ok {
+			t.Fatal("insertProbes declined two spans that merely touch; neither contains the " +
+				"other and neither overlaps it, so both are wrappable")
+		}
+		if len(names) != 2 {
+			t.Errorf("insertProbes named %d probes, want 2", len(names))
+		}
+		assertProbed(t, got, `(?P<`+probeNamePrefix+`0>(?:xa))(?P<`+probeNamePrefix+`1>(?:yb))`)
+	})
+
+	t.Run("a_span_nested_inside_another_sharing_an_end", func(t *testing.T) {
+		t.Parallel()
+		got, _, ok := insertProbes(source, map[int]sourceSpan{
+			1: {start: 0, end: 12},
+			2: {start: 6, end: 12},
+		})
+		if !ok {
+			t.Fatal("insertProbes declined a span nested inside another that shares its end")
+		}
+		assertProbed(t, got, `(?P<`+probeNamePrefix+`0>(?:xa)(?P<`+probeNamePrefix+`1>(?:yb)))`)
+	})
+
 	t.Run("overlapping_spans", func(t *testing.T) {
 		t.Parallel()
 		if _, _, ok := insertProbes(source, map[int]sourceSpan{
@@ -408,15 +457,27 @@ func TestInsertProbesRejectsSpansItCannotWrap(t *testing.T) {
 		if len(names) != 2 {
 			t.Errorf("insertProbes named %d probes, want 2", len(names))
 		}
-		compiled, err := regexp.Compile(got)
-		if err != nil {
-			t.Fatalf("insertProbes produced %q, which does not compile: %v", got, err)
-		}
-		if compiled.NumSubexp() != 2 {
-			t.Errorf("insertProbes produced %q with %d groups, want 2",
-				got, compiled.NumSubexp())
-		}
+		// The WIDER span must open first. Both open at the same offset, so
+		// only the delimiter order decides which probe wraps which span —
+		// and a swap still compiles, still has two groups, and answers for
+		// the wrong one.
+		assertProbed(t, got, `(?P<`+probeNamePrefix+`0>(?P<`+probeNamePrefix+`1>(?:xa))(?:yb))`)
 	})
+}
+
+// assertProbed compares a rewritten pattern against the exact expected
+// text and checks it still compiles. The exact text matters: several
+// orderings of the same delimiters produce a pattern that compiles and has
+// the right group count while bracketing the wrong spans.
+func assertProbed(t *testing.T, got, want string) {
+	t.Helper()
+
+	if got != want {
+		t.Errorf("insertProbes produced\n  %s\nwant\n  %s", got, want)
+	}
+	if _, err := regexp.Compile(got); err != nil {
+		t.Errorf("insertProbes produced %q, which does not compile: %v", got, err)
+	}
 }
 
 // TestPlanCaptureProbesSkipsUnknownCarriers pins that a carrier index the

--- a/internal/qlcommon/capture_probe_boundary_test.go
+++ b/internal/qlcommon/capture_probe_boundary_test.go
@@ -1,0 +1,469 @@
+package qlcommon
+
+import (
+	"regexp"
+	"strings"
+	"testing"
+)
+
+// scannerSyntaxCorpus is a regex source per branch of the source scanner:
+// each escape form, each character-class edge, each group spelling, each
+// quantifier, and nestings of them. It is the input to
+// [TestEveryScannedSpanSurvivesProbeInsertion], which is what turns these
+// from strings into assertions about byte offsets.
+var scannerSyntaxCorpus = []string{
+	`(a)`,
+	`(?:a)`,
+	`(?P<n>a)`,
+	`(?<n>a)`,
+	`x(a)y`,
+	`(a)(b)(c)`,
+	`((a)(b))`,
+	`(?:(a)|(b))`,
+	`(a|b)`,
+	`(a|b|c)`,
+	`((?:a|b)c)`,
+	`(?:x(a)|y(b)|z(c))`,
+
+	// Escapes: the next byte is covered whatever it is, so none of these
+	// parentheses or brackets open anything.
+	`(\(a\))`,
+	`(\[a\])`,
+	`(\\)`,
+	`(\\\\)`,
+	`(a\|b)`,
+	`(\p{L})`,
+	`(\pL)`,
+	`(\d\w\s)`,
+
+	// Character classes: a leading `]` is a member, `^` may precede it, a
+	// POSIX name carries its own `]`, and an escape inside covers a byte.
+	`([()])`,
+	`([]()])`,
+	`([^]()])`,
+	`([\]()])`,
+	`([[:alpha:]])`,
+	`([[:^alpha:]])`,
+	`([a[b])`,
+	`([-a])`,
+	`([a-])`,
+	`([a-z])`,
+	`([^a-z])`,
+	`x([|])y(a)`,
+
+	// Quantifiers after a group must not be swallowed into its span.
+	`(?:(a))?`,
+	`(?:(a))*`,
+	`(?:(a))+`,
+	`(?:(a)){2,3}`,
+	`(a+?)`,
+	`(a*?b)`,
+	`(a{2,3})`,
+
+	// `\Q…\E` quotes its contents, so parentheses inside it are literal
+	// text and must not be counted as groups — including an unterminated
+	// run, which quotes the rest of the pattern.
+	`\Q(x)\E(a)`,
+	`\Q(?P<n>q)\E(a)`,
+	`\Q(\E(a)`,
+	`\Q[\E(a)`,
+	`(a)\Q(y`,
+	`\Q\E(a)`,
+
+	// Scoped flag groups are self-contained and stay scannable.
+	`((?i:a))`,
+	`(?i:(a))`,
+	`(?is:(a)|b)`,
+	`(?i-s:(a))`,
+}
+
+// TestEveryScannedSpanSurvivesProbeInsertion is the scanner's real
+// assertion. Every other test of it checks a span against a substring the
+// test itself wrote down; this one checks the span against the Go regexp
+// COMPILER, by doing to it exactly what the rewrite does — inserting a
+// capture group at its two ends — and requiring the result to be a
+// pattern that still compiles, still matches the same strings, and still
+// captures the same text into every group the source wrote.
+//
+// That is what makes an off-by-one visible. A boundary that is one byte
+// out lands a parenthesis inside a character class, between a group and
+// its quantifier, or in the middle of an escape — and the pattern either
+// stops compiling or quietly changes meaning, both of which fail here.
+// Asserting the spans as substrings cannot catch the second.
+func TestEveryScannedSpanSurvivesProbeInsertion(t *testing.T) {
+	t.Parallel()
+
+	inputs := stringsUpTo("abxyz", 3)
+	spans := 0
+
+	for _, source := range scannerSyntaxCorpus {
+		original, err := regexp.Compile(source)
+		if err != nil {
+			t.Fatalf("corpus regex %q does not compile: %v", source, err)
+		}
+		groups, ok := scanSourceGroups(source)
+		if !ok {
+			t.Fatalf("scanSourceGroups(%q) declined; every corpus entry is meant to scan", source)
+		}
+		if got, want := countCapturing(groups), original.NumSubexp(); got != want {
+			t.Errorf("scanSourceGroups(%q) found %d capturing group(s), the compiler reports %d",
+				source, got, want)
+		}
+
+		for at, g := range groups {
+			if at == wholePatternGroup {
+				continue
+			}
+			spans++
+			probed := source[:g.bodyStart] + "(?P<" + probeNamePrefix + "0>" +
+				source[g.bodyStart:g.bodyEnd] + ")" + source[g.bodyEnd:]
+
+			rewritten, err := regexp.Compile(probed)
+			if err != nil {
+				t.Errorf("scanSourceGroups(%q) group %d spans [%d,%d); wrapping it gives %q, "+
+					"which does not compile: %v", source, at, g.bodyStart, g.bodyEnd, probed, err)
+				continue
+			}
+			assertSameLanguage(t, source, probed, original, rewritten, inputs)
+		}
+	}
+
+	if spans == 0 {
+		t.Fatal("no span was checked — this test would pass vacuously")
+	}
+	t.Logf("probe insertion validated %d scanned spans over %d sources",
+		spans, len(scannerSyntaxCorpus))
+}
+
+// assertSameLanguage requires two patterns to accept the same strings and
+// to capture the same text into every group of the first.
+func assertSameLanguage(t *testing.T, source, probed string, original, rewritten *regexp.Regexp, inputs []string) {
+	t.Helper()
+
+	var positions []int
+	for at, name := range rewritten.SubexpNames() {
+		if !strings.HasPrefix(name, probeNamePrefix) {
+			positions = append(positions, at)
+		}
+	}
+	if len(positions) != len(original.SubexpNames()) {
+		t.Errorf("wrapping %q into %q changed the capture-group count", source, probed)
+		return
+	}
+
+	for _, src := range inputs {
+		before := original.FindStringSubmatchIndex(src)
+		after := rewritten.FindStringSubmatchIndex(src)
+		if (before == nil) != (after == nil) {
+			t.Errorf("wrapping %q into %q changed whether %q matches", source, probed, src)
+			return
+		}
+		if before == nil {
+			continue
+		}
+		for group, mapped := range positions {
+			if before[2*group] != after[2*mapped] || before[2*group+1] != after[2*mapped+1] {
+				t.Errorf("wrapping %q into %q moved capture group %d on input %q",
+					source, probed, group, src)
+				return
+			}
+		}
+	}
+}
+
+func countCapturing(groups []sourceGroup) int {
+	n := 0
+	for _, g := range groups {
+		if g.capturing {
+			n++
+		}
+	}
+	return n
+}
+
+// TestScanSourceGroupsWholePatternGroup pins the virtual group standing
+// for the entire pattern. It is what gives a group at the top level a
+// parent to walk up to, so a walk that skipped it would silently stop
+// looking one level early.
+func TestScanSourceGroupsWholePatternGroup(t *testing.T) {
+	t.Parallel()
+
+	const source = `x(?P<dup>a?)y`
+	groups, ok := scanSourceGroups(source)
+	if !ok {
+		t.Fatalf("scanSourceGroups(%q) declined", source)
+	}
+	root := groups[wholePatternGroup]
+	if root.open != -1 {
+		t.Errorf("whole-pattern group opens at %d, want -1 — it stands for a group that is "+
+			"not written in the source", root.open)
+	}
+	if root.bodyStart != 0 || root.bodyEnd != len(source) {
+		t.Errorf("whole-pattern group spans [%d,%d), want [0,%d)",
+			root.bodyStart, root.bodyEnd, len(source))
+	}
+	if root.parent != -1 {
+		t.Errorf("whole-pattern group has parent %d, want -1", root.parent)
+	}
+	if root.capturing {
+		t.Error("whole-pattern group reports as capturing; it corresponds to no capture index")
+	}
+}
+
+// TestBranchContainingSplitsEveryBranch pins the branch boundaries a probe
+// is placed at. The first branch starts at the body, the last ends at it,
+// and a middle branch is bounded by the two bars around it — each of which
+// is an offset the rewrite inserts a parenthesis at.
+func TestBranchContainingSplitsEveryBranch(t *testing.T) {
+	t.Parallel()
+
+	const source = `(?:aa|bb|cc)`
+	groups, ok := scanSourceGroups(source)
+	if !ok {
+		t.Fatalf("scanSourceGroups(%q) declined", source)
+	}
+	g := groups[1]
+
+	cases := []struct {
+		name   string
+		offset int
+		want   string
+	}{
+		{"first_branch", strings.Index(source, "aa"), "aa"},
+		{"middle_branch", strings.Index(source, "bb"), "bb"},
+		{"last_branch", strings.Index(source, "cc"), "cc"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			span, split := branchContaining(g, tc.offset)
+			if !split {
+				t.Fatalf("branchContaining reported no alternation for %q", source)
+			}
+			if got := source[span.start:span.end]; got != tc.want {
+				t.Errorf("branchContaining(offset %d) = %q, want %q", tc.offset, got, tc.want)
+			}
+		})
+	}
+
+	t.Run("no_alternation", func(t *testing.T) {
+		t.Parallel()
+		plain, ok := scanSourceGroups(`(?:ab)`)
+		if !ok {
+			t.Fatal("scanSourceGroups declined")
+		}
+		if _, split := branchContaining(plain[1], 3); split {
+			t.Error("branchContaining reported an alternation in a body that has none, which " +
+				"would make the rewrite probe a branch boundary that does not exist")
+		}
+	})
+}
+
+// TestCandidateSpansReachTheWholePattern pins that the ladder walks all
+// the way to the virtual whole-pattern group. A walk that stopped at the
+// last WRITTEN group would never offer the outermost span, so a carrier
+// whose only non-nullable ancestor is the pattern itself would be refused.
+func TestCandidateSpansReachTheWholePattern(t *testing.T) {
+	t.Parallel()
+
+	const source = `x(?P<dup>a?)`
+	groups, ok := scanSourceGroups(source)
+	if !ok {
+		t.Fatalf("scanSourceGroups(%q) declined", source)
+	}
+	at := 0
+	for i, g := range groups {
+		if g.capturing {
+			at = i
+		}
+	}
+	spans := candidateSpans(groups, at)
+	if len(spans) == 0 {
+		t.Fatal("candidateSpans returned nothing for a top-level group; its parent is the " +
+			"whole-pattern group, which the walk must still visit")
+	}
+	last := spans[len(spans)-1]
+	if last.start != 0 || last.end != len(source) {
+		t.Errorf("outermost candidate spans [%d,%d), want the whole pattern [0,%d)",
+			last.start, last.end, len(source))
+	}
+}
+
+// TestProbedIndexTranslatesOnlyRealGroups pins the index translation's
+// edges. Index 0 is the whole match and must translate like any other;
+// anything past the table is not a group the rewrite knows about and must
+// come back untouched, which is what keeps an out-of-range reference
+// resolving to nothing rather than to a group it never named.
+func TestProbedIndexTranslatesOnlyRealGroups(t *testing.T) {
+	t.Parallel()
+
+	plan := captureProbePlan{toProbed: []int{0, 2, 3}}
+
+	cases := []struct {
+		name     string
+		original int
+		want     int
+	}{
+		{"whole_match", 0, 0},
+		{"first_group", 1, 2},
+		{"last_group", 2, 3},
+		{"one_past_the_table", 3, 3},
+		{"far_past_the_table", 99, 99},
+		{"negative", -1, -1},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if got := plan.probedIndex(tc.original); got != tc.want {
+				t.Errorf("probedIndex(%d) = %d, want %d", tc.original, got, tc.want)
+			}
+		})
+	}
+
+	t.Run("the_zero_plan_is_the_identity", func(t *testing.T) {
+		t.Parallel()
+		var none captureProbePlan
+		for _, original := range []int{0, 1, 9} {
+			if got := none.probedIndex(original); got != original {
+				t.Errorf("probedIndex(%d) on a plan with no rewrite = %d, want %d",
+					original, got, original)
+			}
+		}
+	})
+}
+
+// TestStripAnchorsRequiresBothEnds pins that the wrapper is only removed
+// when it is really there. A rewrite that lost its anchoring would be
+// handed back to the caller as an unanchored pattern and then anchored
+// again by the emitter, so the two halves are checked separately.
+func TestStripAnchorsRequiresBothEnds(t *testing.T) {
+	t.Parallel()
+
+	if body, ok := stripAnchors(anchorRegex(`a(b)`)); !ok || body != `a(b)` {
+		t.Errorf("stripAnchors(%q) = (%q, %v), want (%q, true)",
+			anchorRegex(`a(b)`), body, ok, `a(b)`)
+	}
+	for _, name := range []string{`^(?s:a(b)`, `a(b))$`, `a(b)`, ``} {
+		if _, ok := stripAnchors(name); ok {
+			t.Errorf("stripAnchors(%q) succeeded; want a decline, because the wrapper it is "+
+				"meant to remove is not present", name)
+		}
+	}
+}
+
+// TestInsertProbesRejectsSpansItCannotWrap pins the fail-closed arm of the
+// insertion. The edits are applied in one forward pass, so a span reaching
+// past the source, or one overlapping another without nesting inside it,
+// would splice parentheses into text already written — producing a pattern
+// that may still compile while bracketing something nobody chose.
+func TestInsertProbesRejectsSpansItCannotWrap(t *testing.T) {
+	t.Parallel()
+
+	const source = `(?:xa)(?:yb)`
+
+	t.Run("a_span_reaching_past_the_source", func(t *testing.T) {
+		t.Parallel()
+		if _, _, ok := insertProbes(source, map[int]sourceSpan{
+			1: {start: 3, end: len(source) + 1},
+		}); ok {
+			t.Error("insertProbes accepted a span reaching past the source")
+		}
+	})
+
+	t.Run("a_span_ending_exactly_at_the_source_end", func(t *testing.T) {
+		t.Parallel()
+		got, _, ok := insertProbes(source, map[int]sourceSpan{
+			1: {start: 0, end: len(source)},
+		})
+		if !ok {
+			t.Fatal("insertProbes declined a span covering the whole source, which is a " +
+				"perfectly wrappable one")
+		}
+		if _, err := regexp.Compile(got); err != nil {
+			t.Errorf("insertProbes produced %q, which does not compile: %v", got, err)
+		}
+	})
+
+	t.Run("overlapping_spans", func(t *testing.T) {
+		t.Parallel()
+		if _, _, ok := insertProbes(source, map[int]sourceSpan{
+			1: {start: 0, end: 8},
+			2: {start: 4, end: 12},
+		}); ok {
+			t.Error("insertProbes accepted two spans that overlap without nesting; the " +
+				"parentheses it would insert cannot bracket both")
+		}
+	})
+
+	t.Run("nested_spans_sharing_a_start", func(t *testing.T) {
+		t.Parallel()
+		got, names, ok := insertProbes(source, map[int]sourceSpan{
+			1: {start: 0, end: len(source)},
+			2: {start: 0, end: 6},
+		})
+		if !ok {
+			t.Fatal("insertProbes declined two properly nested spans that share a start; the " +
+				"wider one simply opens first")
+		}
+		if len(names) != 2 {
+			t.Errorf("insertProbes named %d probes, want 2", len(names))
+		}
+		compiled, err := regexp.Compile(got)
+		if err != nil {
+			t.Fatalf("insertProbes produced %q, which does not compile: %v", got, err)
+		}
+		if compiled.NumSubexp() != 2 {
+			t.Errorf("insertProbes produced %q with %d groups, want 2",
+				got, compiled.NumSubexp())
+		}
+	})
+}
+
+// TestPlanCaptureProbesSkipsUnknownCarriers pins that a carrier index the
+// scanner has no group for is stepped over rather than ending the plan.
+// The needy list is a union across every shared name, so one unusable
+// entry must not cost the others their rewrite.
+func TestPlanCaptureProbesSkipsUnknownCarriers(t *testing.T) {
+	t.Parallel()
+
+	const regex = `(?:x(?P<dup>a?))?(?P<dup>b)`
+	plan, ok := planCaptureProbes(regex, []int{99, 1})
+	if !ok {
+		t.Fatal("planCaptureProbes gave up after an index it could not place; the carriers " +
+			"it CAN place must still be planned")
+	}
+	if _, planned := plan.probeOf[1]; !planned {
+		t.Errorf("planCaptureProbes(%q) planned no probe for carrier 1: %+v", regex, plan)
+	}
+	if _, planned := plan.probeOf[99]; planned {
+		t.Error("planCaptureProbes planned a probe for a carrier index that names no group")
+	}
+}
+
+// TestCarriersNeedingProbesIgnoresUnsharedNames pins that a name only one
+// group carries contributes nothing to the plan, and — because the walk is
+// over every name in the pattern — that meeting such a name does not stop
+// the walk before it reaches a shared one that does need probes.
+func TestCarriersNeedingProbesIgnoresUnsharedNames(t *testing.T) {
+	t.Parallel()
+
+	// `alone` sorts before `dup`, so a walk that stopped at the first
+	// unshared name would never reach the carriers that need probes.
+	const regex = `(?P<alone>q?)(?:x(?P<dup>a?))?(?P<dup>b)`
+	groups := newCaptureGroups(regex, withCaptureProbes)
+
+	needy := groups.carriersNeedingProbes()
+	if len(needy) == 0 {
+		t.Fatal("carriersNeedingProbes found nothing; the shared name in this pattern has a " +
+			"carrier no static fact clears")
+	}
+	for _, idx := range needy {
+		if idx == 1 {
+			t.Error("carriersNeedingProbes listed the group carrying the unshared name; a " +
+				"name only one group carries is never ambiguous")
+		}
+	}
+	if groups.probe.regex == "" {
+		t.Error("no rewrite was planned, so the unshared name ended the walk early")
+	}
+}

--- a/internal/qlcommon/capture_probe_test.go
+++ b/internal/qlcommon/capture_probe_test.go
@@ -443,3 +443,75 @@ func TestProbeRewriteDeclinesInlineFlagSettings(t *testing.T) {
 		}
 	})
 }
+
+// TestReplacementToCHRewritesOnlyWhenTheRewriteIsTheReason pins that a
+// rewrite never happens where it buys nothing — which is a correctness
+// requirement, not tidiness.
+//
+// A rewrite renumbers every capture group. The `replaceRegexpOne`
+// substitution string is applied against the regex `match(...)` ran, which
+// is the ORIGINAL one, so a template built from rewritten indices points
+// at the wrong groups: for `(?:x(?P<dup>a?))?(?P<dup>b)` the reference
+// `$1` would render as `\2` and substitute the text of `(?P<dup>b)`. That
+// is a silently wrong label value on the wire — the failure mode issue
+// #1490 reported — rather than a loud one.
+//
+// Two guarantees keep it out of reach, and both are asserted here: a
+// template that resolves without a rewrite never gets one, and a
+// decomposition that DID get one never takes the substitution-string form.
+func TestReplacementToCHRewritesOnlyWhenTheRewriteIsTheReason(t *testing.T) {
+	t.Parallel()
+
+	// The regex carries a shared name whose carriers would need probes,
+	// so a resolution that planned them eagerly would rewrite for every
+	// template below — none of which reference that name.
+	const regex = `(?:x(?P<dup>a?))?(?P<dup>b)`
+
+	t.Run("a_reference_that_needs_no_probe_keeps_the_original_numbering", func(t *testing.T) {
+		t.Parallel()
+
+		inputs := []string{"xab", "b", "xb"}
+		oracle := regexp.MustCompile(anchorRegex(regex))
+
+		for _, repl := range []string{"$1", "$2", "v=$1", "$1-$2", "plain"} {
+			got, err := ReplacementToCH(repl, regex)
+			if err != nil {
+				t.Fatalf("ReplacementToCH(%q, %q): unexpected error: %v", repl, regex, err)
+			}
+			if got.ProbedRegex != "" {
+				t.Errorf("ReplacementToCH(%q, %q) rewrote the regex to %q; the template "+
+					"references no shared name, so the rewrite renumbers groups for nothing",
+					repl, regex, got.ProbedRegex)
+			}
+			for _, src := range inputs {
+				match := oracle.FindStringSubmatchIndex(src)
+				if match == nil {
+					continue
+				}
+				want := string(oracle.ExpandString(nil, repl, src, match))
+				if evaluated := evaluateReplacement(got, regex, src); evaluated != want {
+					t.Errorf("ReplacementToCH(%q, %q) on %q evaluates to %q; Go's "+
+						"ExpandString gives %q", repl, regex, src, evaluated, want)
+				}
+			}
+		}
+	})
+
+	t.Run("a_rewritten_decomposition_never_takes_the_template_form", func(t *testing.T) {
+		t.Parallel()
+
+		got, err := ReplacementToCH("$dup", regex)
+		if err != nil {
+			t.Fatalf("ReplacementToCH(%q): unexpected error: %v", regex, err)
+		}
+		if got.ProbedRegex == "" {
+			t.Fatal("the shared-name reference did not produce a rewrite, so this test no " +
+				"longer covers what it claims to")
+		}
+		if got.Template != "" {
+			t.Errorf("ReplacementToCH(%q) returned the substitution-string form %q alongside a "+
+				"rewrite; that string is applied against the ORIGINAL regex, so its backrefs "+
+				"would point at the wrong groups", regex, got.Template)
+		}
+	})
+}

--- a/internal/qlcommon/capture_probe_test.go
+++ b/internal/qlcommon/capture_probe_test.go
@@ -1,0 +1,445 @@
+package qlcommon
+
+import (
+	"regexp"
+	"regexp/syntax"
+	"strings"
+	"testing"
+
+	"github.com/tsouza/cerberus/internal/chplan"
+)
+
+// TestReplacementToCHProbesCarrierParticipation pins the rewrite itself:
+// which span each probe wraps, and which group ends up answering for which
+// carrier. The differentials prove the ANSWERS are right; this pins the
+// MECHANISM, so a rewrite that happened to reach the same answers by
+// probing a different span would still be visible in review.
+//
+// Every regex here was rejected outright before probes existed.
+func TestReplacementToCHProbesCarrierParticipation(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name       string
+		regex      string
+		wantProbed string
+		wantSegs   []chplan.LabelReplaceSegment
+	}{
+		{
+			// The witness issue #1956 was narrowed to. Carrier 1 is
+			// nullable and sits under a quest, but the quest's body holds
+			// a mandatory "x", so wrapping the body reports whether the
+			// quest was entered — which is whether carrier 1 took part.
+			name:       "quest_body_with_mandatory_text",
+			regex:      `(?:x(?P<dup>a?))?(?P<dup>b)`,
+			wantProbed: `(?:(?P<cerberusprobe0>x(?P<dup>a?)))?(?P<dup>b)`,
+			wantSegs: []chplan.LabelReplaceSegment{
+				{Group: 2, Fallbacks: []int{3}, Probes: []int{1, 3}},
+			},
+		},
+		{
+			// A star rather than a quest. The probe reports the LAST pass,
+			// and so does the carrier, so "took part at all" still agrees.
+			name:       "star_body_with_mandatory_text",
+			regex:      `(?:x(?P<dup>a?))*(?P<dup>b)`,
+			wantProbed: `(?:(?P<cerberusprobe0>x(?P<dup>a?)))*(?P<dup>b)`,
+			wantSegs: []chplan.LabelReplaceSegment{
+				{Group: 2, Fallbacks: []int{3}, Probes: []int{1, 3}},
+			},
+		},
+		{
+			// The mandatory text is an outer group's, not the carrier's
+			// own parent's, so the walk has to climb past a nullable span
+			// before it finds one that answers.
+			name:       "mandatory_text_an_ancestor_out",
+			regex:      `(?:(?:(?P<dup>a?))x)?(?P<dup>b)`,
+			wantProbed: `(?:(?P<cerberusprobe0>(?:(?P<dup>a?))x))?(?P<dup>b)`,
+			wantSegs: []chplan.LabelReplaceSegment{
+				{Group: 2, Fallbacks: []int{3}, Probes: []int{1, 3}},
+			},
+		},
+		{
+			// Only the BRANCH holding the carrier may be probed: the whole
+			// alternation body would put a skippable node above it.
+			name:       "alternation_branch_with_mandatory_text",
+			regex:      `(?:x(?P<dup>a?)|y(?P<dup>b))?(?P<dup>c)`,
+			wantProbed: `(?:(?P<cerberusprobe0>x(?P<dup>a?))|y(?P<dup>b))?(?P<dup>c)`,
+			wantSegs: []chplan.LabelReplaceSegment{
+				// Carrier 2 is non-nullable, so it answers for itself;
+				// only carrier 1 needed a probe.
+				{Group: 2, Fallbacks: []int{3, 4}, Probes: []int{1, 3, 4}},
+			},
+		},
+		{
+			// Two independent carriers each get their own probe, and the
+			// numbering they report is the REWRITTEN one throughout.
+			name:       "two_carriers_two_probes",
+			regex:      `(?:x(?P<dup>a?))?(?:y(?P<dup>b?))?(?P<dup>c)`,
+			wantProbed: `(?:(?P<cerberusprobe0>x(?P<dup>a?)))?(?:(?P<cerberusprobe1>y(?P<dup>b?)))?(?P<dup>c)`,
+			wantSegs: []chplan.LabelReplaceSegment{
+				{Group: 2, Fallbacks: []int{4, 5}, Probes: []int{1, 3, 5}},
+			},
+		},
+		{
+			// The ambiguity sits at carrier 2; carrier 1 is non-nullable
+			// and keeps answering for itself.
+			name:       "probe_after_a_clear_first_carrier",
+			regex:      `(?P<dup>a)|(?:x(?P<dup>b?))?(?P<dup>c)`,
+			wantProbed: `(?P<dup>a)|(?:(?P<cerberusprobe0>x(?P<dup>b?)))?(?P<dup>c)`,
+			wantSegs: []chplan.LabelReplaceSegment{
+				{Group: 1, Fallbacks: []int{3, 4}, Probes: []int{1, 2, 4}},
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := ReplacementToCH("$dup", tc.regex)
+			if err != nil {
+				t.Fatalf("ReplacementToCH(%q): unexpected error: %v", tc.regex, err)
+			}
+			if got.ProbedRegex != tc.wantProbed {
+				t.Fatalf("ReplacementToCH(%q).ProbedRegex = %q, want %q",
+					tc.regex, got.ProbedRegex, tc.wantProbed)
+			}
+			if len(got.Segments) != len(tc.wantSegs) {
+				t.Fatalf("ReplacementToCH(%q): got %d segments %+v, want %d",
+					tc.regex, len(got.Segments), got.Segments, len(tc.wantSegs))
+			}
+			for i := range tc.wantSegs {
+				if !got.Segments[i].Equal(tc.wantSegs[i]) {
+					t.Fatalf("ReplacementToCH(%q): segment %d = %+v, want %+v",
+						tc.regex, i, got.Segments[i], tc.wantSegs[i])
+				}
+			}
+		})
+	}
+}
+
+// TestProbeRewritePreservesMatching is the safety property the whole
+// rewrite rests on, and the one a differential over ANSWERS cannot reach:
+// the pattern cerberus sends to ClickHouse must accept exactly the strings
+// the user's pattern accepts, and must capture exactly the same text into
+// every group the user wrote.
+//
+// A rewrite that quietly changed the language would still agree with
+// ExpandString on the inputs both happen to match, and would silently drop
+// or admit rows on the ones they disagree about. So this compares the two
+// compiled patterns SPAN BY SPAN over every corpus regex the rewrite fires
+// on, rather than comparing the label value they produce.
+func TestProbeRewritePreservesMatching(t *testing.T) {
+	t.Parallel()
+
+	inputs := stringsUpTo("abxy", 3)
+	rewritten := 0
+
+	for _, regex := range participationCorpus() {
+		got, err := ReplacementToCH("$dup", regex)
+		if err != nil || got.ProbedRegex == "" {
+			continue
+		}
+		rewritten++
+
+		original := regexp.MustCompile(anchorRegex(regex))
+		probed := regexp.MustCompile(anchorRegex(got.ProbedRegex))
+		positions := originalGroupPositions(t, original, probed, regex)
+
+		for _, src := range inputs {
+			before := original.FindStringSubmatchIndex(src)
+			after := probed.FindStringSubmatchIndex(src)
+			if (before == nil) != (after == nil) {
+				t.Fatalf("regex %q rewritten to %q: %q matches %v before and %v after — "+
+					"the rewrite changed which strings the pattern accepts",
+					regex, got.ProbedRegex, src, before != nil, after != nil)
+			}
+			if before == nil {
+				continue
+			}
+			for group, at := range positions {
+				if before[2*group] != after[2*at] || before[2*group+1] != after[2*at+1] {
+					t.Fatalf("regex %q rewritten to %q: on %q capture group %d spans "+
+						"[%d,%d) before and [%d,%d) after — the rewrite moved a capture",
+						regex, got.ProbedRegex, src, group,
+						before[2*group], before[2*group+1], after[2*at], after[2*at+1])
+				}
+			}
+		}
+	}
+
+	if rewritten == 0 {
+		t.Fatal("no corpus regex was rewritten — this test would pass vacuously")
+	}
+	t.Logf("probe rewrite preserved matching on %d corpus regexes, %d inputs each",
+		rewritten, len(inputs))
+}
+
+// originalGroupPositions maps each of the original pattern's capture-group
+// indices to the index the same group holds in the rewritten one.
+func originalGroupPositions(t *testing.T, original, probed *regexp.Regexp, regex string) []int {
+	t.Helper()
+
+	var positions []int
+	for at, name := range probed.SubexpNames() {
+		if strings.HasPrefix(name, probeNamePrefix) {
+			continue
+		}
+		positions = append(positions, at)
+	}
+	if want := len(original.SubexpNames()); len(positions) != want {
+		t.Fatalf("regex %q: rewritten pattern has %d non-probe groups, want %d",
+			regex, len(positions), want)
+	}
+	return positions
+}
+
+// TestProbeSpanInvariantsHold checks the two properties every chosen probe
+// span must have, directly, on every span the corpus makes the planner
+// choose. The differentials show the answers come out right; this shows
+// they come out right for the stated REASON, so a span that happened to
+// work on the corpus but violated the invariant would be caught here
+// rather than by whichever query first fell outside the corpus.
+func TestProbeSpanInvariantsHold(t *testing.T) {
+	t.Parallel()
+
+	checked := 0
+	for _, regex := range participationCorpus() {
+		anchored := anchorRegex(regex)
+		groups, ok := scanSourceGroups(anchored)
+		if !ok {
+			continue
+		}
+		for _, g := range groups {
+			if !g.capturing {
+				continue
+			}
+			span, ok := probeSpanFor(anchored, groups, groupIndexOf(groups, g.capIndex))
+			if !ok {
+				continue
+			}
+			checked++
+			body := anchored[span.start:span.end]
+			parsed, err := syntax.Parse(body, syntax.Perl)
+			if err != nil {
+				t.Fatalf("regex %q: probe span %q does not parse: %v", regex, body, err)
+			}
+			if matchesEmpty(parsed) {
+				t.Fatalf("regex %q: probe span %q can match the empty string, so its "+
+					"emptiness cannot report participation", regex, body)
+			}
+			shape, known := captureShapes(body)[captureOrdinalIn(groups, span, g.open)]
+			if !known || !shape.unconditional {
+				t.Fatalf("regex %q: probe span %q does not pass through capture group %d on "+
+					"every match, so entering it does not imply the carrier took part",
+					regex, body, g.capIndex)
+			}
+		}
+	}
+	if checked == 0 {
+		t.Fatal("no probe span was chosen over the corpus — this test would pass vacuously")
+	}
+	t.Logf("probe span invariants held for %d chosen spans", checked)
+}
+
+func groupIndexOf(groups []sourceGroup, capIndex int) int {
+	for i, g := range groups {
+		if g.capturing && g.capIndex == capIndex {
+			return i
+		}
+	}
+	return 0
+}
+
+// TestWeakenedProbeChoiceIsCaughtByTheCorpus is the adversarial pass over
+// this file's own reasoning. Each subtest reproduces the planner with one
+// of its two span tests removed, and requires the corpus to produce a
+// concrete disagreement with Go — so the corpus is known to be sensitive
+// to each test individually, rather than merely passing while both hold.
+//
+// Without this, a corpus that happened to contain no regex distinguishing
+// "the nearest ancestor" from "the nearest NON-NULLABLE ancestor" would
+// give the same green, and the narrower reasoning would be unsupported.
+func TestWeakenedProbeChoiceIsCaughtByTheCorpus(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		// weakened picks a probe span with one invariant dropped.
+		weakened func(src string, groups []sourceGroup, at int) (sourceSpan, bool)
+	}{
+		{
+			// Probing the nearest ancestor whatever it is: a nullable span
+			// reports empty even when it was entered, so a carrier that
+			// took part reads as absent.
+			name: "ignores_that_the_span_must_not_match_empty",
+			weakened: func(_ string, groups []sourceGroup, at int) (sourceSpan, bool) {
+				spans := candidateSpans(groups, at)
+				if len(spans) == 0 {
+					return sourceSpan{}, false
+				}
+				return spans[0], true
+			},
+		},
+		{
+			// Probing the nearest non-nullable ancestor without requiring
+			// every match of it to reach the carrier: the span can then be
+			// entered by a match that skips the carrier, so a carrier that
+			// took no part reads as present.
+			name: "ignores_that_every_match_must_reach_the_carrier",
+			weakened: func(src string, groups []sourceGroup, at int) (sourceSpan, bool) {
+				for _, span := range candidateSpans(groups, at) {
+					parsed, err := syntax.Parse(src[span.start:span.end], syntax.Perl)
+					if err != nil {
+						return sourceSpan{}, false
+					}
+					if !matchesEmpty(parsed) {
+						return span, true
+					}
+				}
+				return sourceSpan{}, false
+			},
+		},
+	}
+
+	inputs := stringsUpTo("abxy", 3)
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			for _, regex := range participationCorpus() {
+				if witness := weakenedProbeDisagreement(regex, tc.weakened, inputs); witness != "" {
+					t.Logf("corpus catches the weakening: %s", witness)
+					return
+				}
+			}
+			t.Error("no corpus regex disagreed with Go once this span test was dropped — " +
+				"the corpus cannot tell the planner's reasoning from a weaker one, so the " +
+				"differentials are not evidence for it")
+		})
+	}
+}
+
+// weakenedProbeDisagreement builds the plan a weakened span choice would
+// produce and returns the first input on which it answers differently from
+// Go's ExpandString, or "" when it never does.
+func weakenedProbeDisagreement(
+	regex string,
+	spanFor func(src string, groups []sourceGroup, at int) (sourceSpan, bool),
+	inputs []string,
+) string {
+	anchored := anchorRegex(regex)
+	original, err := regexp.Compile(anchored)
+	if err != nil {
+		return ""
+	}
+	groups, ok := scanSourceGroups(anchored)
+	if !ok {
+		return ""
+	}
+
+	shapes := captureShapes(anchored)
+	g := captureGroups{count: original.NumSubexp(), shapes: shapes, byName: map[string][]int{}}
+	for i, name := range original.SubexpNames() {
+		if name != "" {
+			g.byName[name] = append(g.byName[name], i)
+		}
+	}
+	carriers := g.byName["dup"]
+	if len(carriers) < 2 {
+		return ""
+	}
+
+	spans := map[int]sourceSpan{}
+	for _, carrier := range g.unclearedCarriers(carriers) {
+		span, ok := spanFor(anchored, groups, groupIndexOf(groups, carrier))
+		if !ok {
+			return ""
+		}
+		spans[carrier] = span
+	}
+	if len(spans) == 0 {
+		return ""
+	}
+	probed, probeNames, ok := insertProbes(anchored, spans)
+	if !ok {
+		return ""
+	}
+	plan, ok := readBackPlan(original, probed, probeNames)
+	if !ok {
+		return ""
+	}
+	g.probe = plan
+	searched, probes, _, ok := g.expressibleCarriers(carriers)
+	if !ok {
+		return ""
+	}
+
+	compiled, err := regexp.Compile(plan.regex)
+	if err != nil {
+		return ""
+	}
+	segment := chplan.LabelReplaceSegment{Group: searched[0], Fallbacks: searched[1:], Probes: probes}
+	for _, src := range inputs {
+		match := original.FindStringSubmatchIndex(src)
+		if match == nil {
+			continue
+		}
+		want := string(original.ExpandString(nil, "$dup", src, match))
+		got := evaluateSegments([]chplan.LabelReplaceSegment{segment}, src, compiled.FindStringSubmatch(src))
+		if got != want {
+			return "regex " + regex + " rewritten to " + plan.regex +
+				" answers " + got + " on input " + src + " where Go answers " + want
+		}
+	}
+	return ""
+}
+
+// TestProbeRewriteDeclinesInlineFlagSettings pins the one construct that
+// would let the rewrite change what the user's pattern MEANS rather than
+// merely how its groups are numbered.
+//
+// A bare `(?i)` applies to the end of the group enclosing it, crossing
+// alternation branches. Wrapping a branch in a probe group confines it to
+// that branch, so a pattern that matched "B" through the leaked flag stops
+// matching it. The first half of this test demonstrates that hazard
+// directly — it is the reason for the decline, stated as something that
+// runs — and the second half pins that cerberus keeps its rejection rather
+// than emitting the rewrite.
+func TestProbeRewriteDeclinesInlineFlagSettings(t *testing.T) {
+	t.Parallel()
+
+	t.Run("wrapping_a_branch_would_confine_the_setting", func(t *testing.T) {
+		t.Parallel()
+
+		leaked := regexp.MustCompile(anchorRegex(`(?:(?i)a(?P<dup>x?)|b)`))
+		confined := regexp.MustCompile(anchorRegex(`(?:(?P<probe>(?i)a(?P<dup>x?))|b)`))
+
+		if !leaked.MatchString("B") {
+			t.Fatal(`"B" does not match the un-wrapped pattern — the premise of this test is that ` +
+				`the inline (?i) reaches the second branch`)
+		}
+		if confined.MatchString("B") {
+			t.Fatal(`"B" still matches once the first branch is wrapped — the hazard this ` +
+				`decline exists for has gone away, and the decline should be revisited`)
+		}
+	})
+
+	t.Run("cerberus_keeps_the_rejection", func(t *testing.T) {
+		t.Parallel()
+
+		for _, regex := range []string{
+			`(?:(?i)x(?P<dup>a?)|y)(?P<dup>b)`,
+			`(?i)(?:x(?P<dup>a?))?(?P<dup>b)`,
+			`(?:x(?P<dup>a?)(?i))?(?P<dup>b)`,
+		} {
+			got, err := ReplacementToCH("$dup", regex)
+			if err == nil {
+				t.Errorf("ReplacementToCH(%q) produced %+v; want the rejection kept, because "+
+					"no rewrite of a pattern carrying a bare inline flag setting is known to "+
+					"preserve its language", regex, got)
+			}
+		}
+	})
+}

--- a/internal/qlcommon/label_replace.go
+++ b/internal/qlcommon/label_replace.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"regexp"
 	"regexp/syntax"
+	"sort"
 	"strconv"
 	"strings"
 	"unicode"
@@ -98,7 +99,7 @@ const unresolvedGroup = -1
 // (very-much-reachable) cold path where the regex doesn't match
 // anything.
 func ReplacementToCH(repl, regex string) (CHReplacement, error) {
-	segments, err := ReplacementSegments(repl, regex)
+	segments, probed, err := ReplacementSegments(repl, regex)
 	if err != nil {
 		return CHReplacement{}, err
 	}
@@ -109,7 +110,7 @@ func ReplacementToCH(repl, regex string) (CHReplacement, error) {
 		// `replaceRegexpOne` substitution string, and both are expressible
 		// over the `extractGroups` decomposition.
 		if seg.Group > maxCHBackref || len(seg.Fallbacks) > 0 {
-			return CHReplacement{Segments: segments}, nil
+			return CHReplacement{Segments: segments, ProbedRegex: probed}, nil
 		}
 	}
 	return CHReplacement{Template: renderCHTemplate(segments)}, nil
@@ -124,6 +125,15 @@ func ReplacementToCH(repl, regex string) (CHReplacement, error) {
 type CHReplacement struct {
 	// Template is the `replaceRegexpOne` substitution string.
 	Template string
+	// ProbedRegex, when non-empty, is the regex the emitter must feed
+	// `extractGroups` in place of the one the query named: the same
+	// pattern with synthetic capture groups added so that a carrier whose
+	// own capture cannot report whether it took part in the match has one
+	// that can. It matches the same strings as the original — the added
+	// groups only observe — but it NUMBERS groups differently, so every
+	// index in Segments is already in its numbering and the two must be
+	// read together. See [planCaptureProbes].
+	ProbedRegex string
 	// Segments is the literal-run / capture-group decomposition the
 	// emitter renders as a `concat` over `extractGroups`. A segment's
 	// Literal is the DECODED text — `$$` has already collapsed to `$`,
@@ -145,7 +155,7 @@ type CHReplacement struct {
 // References that bind to nothing — an index past the regex's group
 // count, a name no group carries — contribute nothing at all, exactly as
 // Go's `ExpandString` substitutes the empty string for them.
-func ReplacementSegments(repl, regex string) ([]chplan.LabelReplaceSegment, error) {
+func ReplacementSegments(repl, regex string) ([]chplan.LabelReplaceSegment, string, error) {
 	groups := newCaptureGroups(regex)
 
 	var segments []chplan.LabelReplaceSegment
@@ -171,19 +181,20 @@ func ReplacementSegments(repl, regex string) ([]chplan.LabelReplaceSegment, erro
 	for i := 0; i < len(repl); {
 		ref, step, err := replacementStep(&literal, repl, i, groups)
 		if err != nil {
-			return nil, err
+			return nil, "", err
 		}
 		if ref.group != unresolvedGroup {
 			flush()
 			segments = append(segments, chplan.LabelReplaceSegment{
 				Group:     ref.group,
 				Fallbacks: ref.fallbacks,
+				Probes:    ref.probes,
 			})
 		}
 		i += step
 	}
 	flush()
-	return segments, nil
+	return segments, groups.probe.regex, nil
 }
 
 // renderCHTemplate folds a decomposition back into a `replaceRegexpOne`
@@ -233,6 +244,11 @@ type captureGroups struct {
 	// unparseable or unclassifiable regex keeps the rejection rather than
 	// risking a wrong answer.
 	shapes map[int]captureShape
+	// probe is the regex rewritten to expose the participation of
+	// carriers whose own capture cannot report it, together with the
+	// index translation that rewrite forces. Its `regex` is empty when no
+	// carrier needed a probe, which leaves every index below untouched.
+	probe captureProbePlan
 }
 
 // newCaptureGroups compiles regex for its capture-group metadata.
@@ -267,7 +283,70 @@ func newCaptureGroups(regex string) captureGroups {
 		}
 		g.byName[name] = append(g.byName[name], i)
 	}
+	if needy := g.carriersNeedingProbes(); len(needy) > 0 {
+		// A failed plan leaves the zero value, which reads as "no probes"
+		// everywhere below and keeps the rejection those carriers had.
+		g.probe, _ = planCaptureProbes(regex, needy)
+	}
 	return g
+}
+
+// carriersNeedingProbes lists every capture group that shares its name,
+// survives the truncation, and can neither be cleared by non-nullability
+// nor by exclusivity — the carriers for which the emitted search would
+// otherwise have to guess. The list is the input to the regex rewrite;
+// planning is separate from deciding, because one rewrite serves every
+// shared name in the pattern at once.
+//
+// The result is sorted so a pattern always rewrites the same way, which
+// keeps the emitted SQL — and the goldens pinning it — stable.
+func (g captureGroups) carriersNeedingProbes() []int {
+	seen := map[int]bool{}
+	for _, carriers := range g.byName {
+		if len(carriers) < 2 {
+			continue
+		}
+		for _, idx := range g.unclearedCarriers(carriers) {
+			seen[idx] = true
+		}
+	}
+	out := make([]int, 0, len(seen))
+	for idx := range seen {
+		out = append(out, idx)
+	}
+	sort.Ints(out)
+	return out
+}
+
+// unclearedCarriers reports which of one name's carriers the static facts
+// alone cannot clear, over the same truncated prefix
+// [captureGroups.expressibleCarriers] searches.
+func (g captureGroups) unclearedCarriers(carriers []int) []int {
+	searched := carriers[:g.searchableEnd(carriers):g.searchableEnd(carriers)]
+	var out []int
+	for i, idx := range searched {
+		shape, known := g.shapes[idx]
+		if !known {
+			continue
+		}
+		if !shape.nullable || g.exclusiveOfAll(shape, searched[i+1:]) {
+			continue
+		}
+		out = append(out, idx)
+	}
+	return out
+}
+
+// searchableEnd is how many of carriers the search may look through:
+// everything up to and including the first one every match must pass
+// through, since Go's own scan can never walk past that one either.
+func (g captureGroups) searchableEnd(carriers []int) int {
+	for i, idx := range carriers {
+		if g.shapes[idx].unconditional {
+			return i + 1
+		}
+	}
+	return len(carriers)
 }
 
 // anchorRegex anchors a `label_replace` regex to a full-string match, the
@@ -370,6 +449,13 @@ type resolvedRef struct {
 	// [captureGroups.expressibleCarriers] for why that reproduces Go's
 	// choice exactly.
 	fallbacks []int
+	// probes holds, for each searched carrier — `group` followed by
+	// `fallbacks`, so one element apiece and in that order — the capture
+	// group whose NON-EMPTINESS reports that carrier took part in the
+	// match. It is empty when no carrier needed one, in which case every
+	// carrier's own capture reports its participation and the search is
+	// the plain non-empty one. See [planCaptureProbes].
+	probes []int
 }
 
 // resolve maps one extracted reference to the capture group(s) it points
@@ -427,10 +513,10 @@ func (g captureGroups) resolve(ref templateRef) (resolvedRef, error) {
 		// A numbered reference past the regex's group count binds to
 		// nothing, which is the empty string — not an error.
 		if ref.num <= g.count {
-			out.group = ref.num
+			out.group = g.probe.probedIndex(ref.num)
 		}
 	case len(carriers) > 1:
-		searched, ambiguous, ok := g.expressibleCarriers(carriers)
+		searched, probes, ambiguous, ok := g.expressibleCarriers(carriers)
 		if !ok {
 			return resolvedRef{}, fmt.Errorf(
 				"references capture-group name %q, which %d capture groups share, "+
@@ -443,9 +529,9 @@ func (g captureGroups) resolve(ref templateRef) (resolvedRef, error) {
 				ref.name, len(carriers), ambiguous,
 			)
 		}
-		out.group, out.fallbacks = searched[0], searched[1:]
+		out.group, out.fallbacks, out.probes = searched[0], searched[1:], probes
 	case len(carriers) == 1:
-		out.group = carriers[0]
+		out.group = g.probe.probedIndex(carriers[0])
 	}
 	return out, nil
 }
@@ -478,26 +564,42 @@ func (g captureGroups) resolve(ref templateRef) (resolvedRef, error) {
 // A carrier the parse-tree walk could not classify has no shape recorded,
 // which reads as nullable and exclusive of nothing, so an unrecognised
 // regex keeps the rejection.
-func (g captureGroups) expressibleCarriers(carriers []int) ([]int, int, bool) {
-	end := len(carriers)
-	for i, idx := range carriers {
-		if g.shapes[idx].unconditional {
-			end = i + 1
-			break
-		}
-	}
+func (g captureGroups) expressibleCarriers(carriers []int) ([]int, []int, int, bool) {
+	end := g.searchableEnd(carriers)
 	searched := carriers[:end:end]
+
+	probes := make([]int, len(searched))
+	anyProbe := false
 	for i, idx := range searched {
 		shape, known := g.shapes[idx]
-		if known && !shape.nullable {
+		if !known {
+			return nil, nil, idx, false
+		}
+		// By default a carrier reports its own participation, which is
+		// what makes the emitted search the plain non-empty one.
+		probes[i] = g.probe.probedIndex(idx)
+		if !shape.nullable || g.exclusiveOfAll(shape, searched[i+1:]) {
 			continue
 		}
-		if known && g.exclusiveOfAll(shape, searched[i+1:]) {
-			continue
+		at, probed := g.probe.probeOf[idx]
+		if !probed {
+			return nil, nil, idx, false
 		}
-		return nil, idx, false
+		probes[i] = at
+		anyProbe = true
 	}
-	return searched, 0, true
+	if !anyProbe {
+		probes = nil
+	}
+
+	// Every index leaves in the rewritten regex's numbering, which is the
+	// one the emitter's `extractGroups` reads. Without a rewrite the
+	// translation is the identity.
+	out := make([]int, len(searched))
+	for i, idx := range searched {
+		out[i] = g.probe.probedIndex(idx)
+	}
+	return out, probes, 0, true
 }
 
 // exclusiveOfAll reports whether shape's group can never take part in the

--- a/internal/qlcommon/label_replace.go
+++ b/internal/qlcommon/label_replace.go
@@ -326,10 +326,12 @@ func newCaptureGroups(regex string, probes captureProbeUse) captureGroups {
 		}
 		g.byName[name] = append(g.byName[name], i)
 	}
-	if needy := g.carriersNeedingProbes(); probes == withCaptureProbes && len(needy) > 0 {
-		// A failed plan leaves the zero value, which reads as "no probes"
-		// everywhere below and keeps the rejection those carriers had.
-		g.probe, _ = planCaptureProbes(regex, needy)
+	if probes == withCaptureProbes {
+		// A failed plan — including the empty request a pattern with no
+		// shared name makes — leaves the zero value, which reads as "no
+		// probes" everywhere below and keeps the rejection those carriers
+		// had.
+		g.probe, _ = planCaptureProbes(regex, g.carriersNeedingProbes())
 	}
 	return g
 }

--- a/internal/qlcommon/label_replace.go
+++ b/internal/qlcommon/label_replace.go
@@ -99,21 +99,51 @@ const unresolvedGroup = -1
 // (very-much-reachable) cold path where the regex doesn't match
 // anything.
 func ReplacementToCH(repl, regex string) (CHReplacement, error) {
-	segments, probed, err := ReplacementSegments(repl, regex)
-	if err != nil {
-		return CHReplacement{}, err
+	// Resolve WITHOUT a regex rewrite first. Everything that was already
+	// expressible then stays byte-for-byte what it was, and — more than a
+	// courtesy — no reference keeps its original numbering by accident:
+	// a rewrite renumbers every capture group, so a pattern that gains one
+	// it did not need would silently move what `$1` points at.
+	segments, err := replacementSegments(repl, regex, withoutCaptureProbes)
+	if err == nil {
+		return chReplacement(segments, ""), nil
+	}
+	// Only the shared-carrier ambiguity is worth a second attempt, and
+	// only it can be cleared by one. Any other failure reproduces
+	// identically below, so the error the caller sees is the probed pass's
+	// — the one that names the carrier no probe could answer for.
+	probedSegments, probed, probedErr := replacementSegmentsProbed(repl, regex)
+	if probedErr != nil {
+		return CHReplacement{}, probedErr
+	}
+	return chReplacement(probedSegments, probed), nil
+}
+
+// chReplacement picks the output form a decomposition takes.
+//
+// A group above ClickHouse's `\9` ceiling has no `\N` spelling, and a
+// reference to a name several groups share is a SELECTION among indices
+// rather than one index — neither fits a `replaceRegexpOne` substitution
+// string, and both are expressible over the `extractGroups`
+// decomposition.
+//
+// A probe rewrite forces the same choice whatever the indices look like.
+// The substitution string is applied against the regex `match(...)` ran,
+// which is the ORIGINAL one, while every index in a rewritten
+// decomposition is numbered against the REWRITTEN pattern — so a template
+// built from those indices would point at the wrong groups. The
+// `extractGroups` form is the one that reads the rewritten pattern, so it
+// is the only form a rewrite may take.
+func chReplacement(segments []chplan.LabelReplaceSegment, probed string) CHReplacement {
+	if probed != "" {
+		return CHReplacement{Segments: segments, ProbedRegex: probed}
 	}
 	for _, seg := range segments {
-		// A group above CH's `\9` ceiling has no `\N` spelling, and a
-		// reference to a name several groups share is a SELECTION among
-		// indices rather than one index — neither fits a
-		// `replaceRegexpOne` substitution string, and both are expressible
-		// over the `extractGroups` decomposition.
 		if seg.Group > maxCHBackref || len(seg.Fallbacks) > 0 {
-			return CHReplacement{Segments: segments, ProbedRegex: probed}, nil
+			return CHReplacement{Segments: segments}
 		}
 	}
-	return CHReplacement{Template: renderCHTemplate(segments)}, nil
+	return CHReplacement{Template: renderCHTemplate(segments)}
 }
 
 // CHReplacement is the ClickHouse-side form of a Go replacement template.
@@ -156,8 +186,39 @@ type CHReplacement struct {
 // count, a name no group carries — contribute nothing at all, exactly as
 // Go's `ExpandString` substitutes the empty string for them.
 func ReplacementSegments(repl, regex string) ([]chplan.LabelReplaceSegment, string, error) {
-	groups := newCaptureGroups(regex)
+	if segments, err := replacementSegments(repl, regex, withoutCaptureProbes); err == nil {
+		return segments, "", nil
+	}
+	return replacementSegmentsProbed(repl, regex)
+}
 
+// captureProbeUse says whether a resolution may rewrite the regex to
+// expose capture participation. The two passes are separate because a
+// rewrite renumbers every group, so it must not happen where it buys
+// nothing.
+type captureProbeUse bool
+
+const (
+	withoutCaptureProbes captureProbeUse = false
+	withCaptureProbes    captureProbeUse = true
+)
+
+// replacementSegmentsProbed resolves with a rewrite permitted, returning
+// the rewritten regex alongside the decomposition.
+func replacementSegmentsProbed(repl, regex string) ([]chplan.LabelReplaceSegment, string, error) {
+	groups := newCaptureGroups(regex, withCaptureProbes)
+	segments, err := resolveSegments(repl, groups)
+	if err != nil {
+		return nil, "", err
+	}
+	return segments, groups.probe.regex, nil
+}
+
+func replacementSegments(repl, regex string, probes captureProbeUse) ([]chplan.LabelReplaceSegment, error) {
+	return resolveSegments(repl, newCaptureGroups(regex, probes))
+}
+
+func resolveSegments(repl string, groups captureGroups) ([]chplan.LabelReplaceSegment, error) {
 	var segments []chplan.LabelReplaceSegment
 	var literal strings.Builder
 	flush := func() {
@@ -181,7 +242,7 @@ func ReplacementSegments(repl, regex string) ([]chplan.LabelReplaceSegment, stri
 	for i := 0; i < len(repl); {
 		ref, step, err := replacementStep(&literal, repl, i, groups)
 		if err != nil {
-			return nil, "", err
+			return nil, err
 		}
 		if ref.group != unresolvedGroup {
 			flush()
@@ -194,7 +255,7 @@ func ReplacementSegments(repl, regex string) ([]chplan.LabelReplaceSegment, stri
 		i += step
 	}
 	flush()
-	return segments, groups.probe.regex, nil
+	return segments, nil
 }
 
 // renderCHTemplate folds a decomposition back into a `replaceRegexpOne`
@@ -258,7 +319,7 @@ type captureGroups struct {
 // is allowed through and CH's own parse stage surfaces the regex error
 // to the client — the same fallback the pre-name-resolution version of
 // this file used.
-func newCaptureGroups(regex string) captureGroups {
+func newCaptureGroups(regex string, probes captureProbeUse) captureGroups {
 	// Anchored to mirror the SQL emitter and reference Prometheus
 	// (promql/functions.go: `"^(?s:" + regexStr + ")$"`), including the
 	// non-capturing `(?s:...)` wrapper: without it, `^...$` binds only to
@@ -283,7 +344,7 @@ func newCaptureGroups(regex string) captureGroups {
 		}
 		g.byName[name] = append(g.byName[name], i)
 	}
-	if needy := g.carriersNeedingProbes(); len(needy) > 0 {
+	if needy := g.carriersNeedingProbes(); probes == withCaptureProbes && len(needy) > 0 {
 		// A failed plan leaves the zero value, which reads as "no probes"
 		// everywhere below and keeps the rejection those carriers had.
 		g.probe, _ = planCaptureProbes(regex, needy)

--- a/internal/qlcommon/label_replace.go
+++ b/internal/qlcommon/label_replace.go
@@ -99,24 +99,11 @@ const unresolvedGroup = -1
 // (very-much-reachable) cold path where the regex doesn't match
 // anything.
 func ReplacementToCH(repl, regex string) (CHReplacement, error) {
-	// Resolve WITHOUT a regex rewrite first. Everything that was already
-	// expressible then stays byte-for-byte what it was, and — more than a
-	// courtesy — no reference keeps its original numbering by accident:
-	// a rewrite renumbers every capture group, so a pattern that gains one
-	// it did not need would silently move what `$1` points at.
-	segments, err := replacementSegments(repl, regex, withoutCaptureProbes)
-	if err == nil {
-		return chReplacement(segments, ""), nil
+	segments, probed, err := ReplacementSegments(repl, regex)
+	if err != nil {
+		return CHReplacement{}, err
 	}
-	// Only the shared-carrier ambiguity is worth a second attempt, and
-	// only it can be cleared by one. Any other failure reproduces
-	// identically below, so the error the caller sees is the probed pass's
-	// — the one that names the carrier no probe could answer for.
-	probedSegments, probed, probedErr := replacementSegmentsProbed(repl, regex)
-	if probedErr != nil {
-		return CHReplacement{}, probedErr
-	}
-	return chReplacement(probedSegments, probed), nil
+	return chReplacement(segments, probed), nil
 }
 
 // chReplacement picks the output form a decomposition takes.
@@ -186,10 +173,20 @@ type CHReplacement struct {
 // count, a name no group carries — contribute nothing at all, exactly as
 // Go's `ExpandString` substitutes the empty string for them.
 func ReplacementSegments(repl, regex string) ([]chplan.LabelReplaceSegment, string, error) {
-	if segments, err := replacementSegments(repl, regex, withoutCaptureProbes); err == nil {
+	// Unrewritten first: everything already expressible stays exactly what
+	// it was, and no reference is renumbered by a rewrite it did not need.
+	// Only the shared-carrier ambiguity can be cleared by one, and any
+	// other failure reproduces identically on the second pass, so the
+	// error a caller sees is always the probed pass's.
+	if segments, err := resolveSegments(repl, newCaptureGroups(regex, withoutCaptureProbes)); err == nil {
 		return segments, "", nil
 	}
-	return replacementSegmentsProbed(repl, regex)
+	groups := newCaptureGroups(regex, withCaptureProbes)
+	segments, err := resolveSegments(repl, groups)
+	if err != nil {
+		return nil, "", err
+	}
+	return segments, groups.probe.regex, nil
 }
 
 // captureProbeUse says whether a resolution may rewrite the regex to
@@ -202,21 +199,6 @@ const (
 	withoutCaptureProbes captureProbeUse = false
 	withCaptureProbes    captureProbeUse = true
 )
-
-// replacementSegmentsProbed resolves with a rewrite permitted, returning
-// the rewritten regex alongside the decomposition.
-func replacementSegmentsProbed(repl, regex string) ([]chplan.LabelReplaceSegment, string, error) {
-	groups := newCaptureGroups(regex, withCaptureProbes)
-	segments, err := resolveSegments(repl, groups)
-	if err != nil {
-		return nil, "", err
-	}
-	return segments, groups.probe.regex, nil
-}
-
-func replacementSegments(repl, regex string, probes captureProbeUse) ([]chplan.LabelReplaceSegment, error) {
-	return resolveSegments(repl, newCaptureGroups(regex, probes))
-}
 
 func resolveSegments(repl string, groups captureGroups) ([]chplan.LabelReplaceSegment, error) {
 	var segments []chplan.LabelReplaceSegment
@@ -359,11 +341,20 @@ func newCaptureGroups(regex string, probes captureProbeUse) captureGroups {
 // planning is separate from deciding, because one rewrite serves every
 // shared name in the pattern at once.
 //
-// The result is sorted so a pattern always rewrites the same way, which
-// keeps the emitted SQL — and the goldens pinning it — stable.
+// The walk over names is ordered as well as the result. The accumulated
+// set already made the output order-independent, so this is defence
+// rather than a fix: it keeps the traversal itself reproducible, which is
+// what a reader stepping through a rewrite needs.
 func (g captureGroups) carriersNeedingProbes() []int {
+	names := make([]string, 0, len(g.byName))
+	for name := range g.byName {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
 	seen := map[int]bool{}
-	for _, carriers := range g.byName {
+	for _, name := range names {
+		carriers := g.byName[name]
 		if len(carriers) < 2 {
 			continue
 		}

--- a/internal/qlcommon/label_replace_anchor_test.go
+++ b/internal/qlcommon/label_replace_anchor_test.go
@@ -106,7 +106,7 @@ func TestAnchorRegexIsNonCapturing(t *testing.T) {
 func TestNewCaptureGroupsIndicesSurviveAnchorWrap(t *testing.T) {
 	t.Parallel()
 
-	g := newCaptureGroups(`(a)(b)|(c)`)
+	g := newCaptureGroups(`(a)(b)|(c)`, withoutCaptureProbes)
 
 	const wantCount = 3
 	if g.count != wantCount {

--- a/internal/qlcommon/label_replace_segments_test.go
+++ b/internal/qlcommon/label_replace_segments_test.go
@@ -289,16 +289,19 @@ func TestSharedCaptureNameSegmentsAgreeWithExpandString(t *testing.T) {
 			if err != nil {
 				t.Fatalf("ReplacementToCH(%q, %q): unexpected error: %v", tc.repl, tc.regex, err)
 			}
-			re := regexp.MustCompile("^" + tc.regex + "$")
+			// The oracle must anchor the way reference Prometheus and the
+			// emitter do. A bare `^…$` binds only to the outer arms of a
+			// top-level alternation, which makes a different set of
+			// carriers take part than the query would really see.
+			re := regexp.MustCompile(anchorRegex(tc.regex))
 			for _, src := range tc.srcs {
 				match := re.FindStringSubmatchIndex(src)
 				if match == nil {
 					t.Fatalf("regex %q does not match %q — the oracle needs a match", tc.regex, src)
 				}
 				want := string(re.ExpandString(nil, tc.repl, src, match))
-				groups := re.FindStringSubmatch(src)
 
-				evaluated := evaluateReplacement(got, src, groups)
+				evaluated := evaluateReplacement(got, tc.regex, src)
 				if evaluated != want {
 					t.Fatalf("regex %q repl %q src %q: %+v evaluates to %q; "+
 						"Go's ExpandString gives %q",
@@ -314,11 +317,24 @@ func TestSharedCaptureNameSegmentsAgreeWithExpandString(t *testing.T) {
 // the `extractGroups` decomposition collapses to a `replaceRegexpOne`
 // substitution string (or the other way round). Exactly one of the two
 // fields is ever populated — see [CHReplacement].
-func evaluateReplacement(repl CHReplacement, src string, groups []string) string {
-	if repl.Template == "" {
-		return evaluateSegments(repl.Segments, src, groups)
+func evaluateReplacement(repl CHReplacement, regex, src string) string {
+	if repl.Template != "" {
+		return evaluateCHTemplate(repl.Template, regexGroups(regex, src))
 	}
-	return evaluateCHTemplate(repl.Template, groups)
+	// A decomposition whose indices were renumbered by a probe rewrite is
+	// only meaningful against the rewritten pattern's own capture groups,
+	// so the evaluator reads the same regex the emitter would.
+	extract := regex
+	if repl.ProbedRegex != "" {
+		extract = repl.ProbedRegex
+	}
+	return evaluateSegments(repl.Segments, src, regexGroups(extract, src))
+}
+
+// regexGroups returns the capture-group texts an anchored match of regex
+// against src yields, which is what `extractGroups` returns in SQL.
+func regexGroups(regex, src string) []string {
+	return regexp.MustCompile(anchorRegex(regex)).FindStringSubmatch(src)
 }
 
 // evaluateCHTemplate renders a `replaceRegexpOne` substitution string the
@@ -367,10 +383,16 @@ func evaluateSegments(segments []chplan.LabelReplaceSegment, src string, groups 
 			out += groups[seg.Group]
 			continue
 		}
-		// arrayFirst(x -> x != '', [...]) — and the empty string when no
+		// arrayFirst over the carriers, testing each one's WITNESS — its
+		// own capture, or the probe group standing in for it — and
+		// answering with the carrier beside it. The empty string when no
 		// candidate qualifies, which adds nothing.
-		for _, idx := range append([]int{seg.Group}, seg.Fallbacks...) {
-			if groups[idx] != "" {
+		for i, idx := range append([]int{seg.Group}, seg.Fallbacks...) {
+			witness := idx
+			if i < len(seg.Probes) {
+				witness = seg.Probes[i]
+			}
+			if groups[witness] != "" {
 				out += groups[idx]
 				break
 			}

--- a/internal/qlcommon/label_replace_test.go
+++ b/internal/qlcommon/label_replace_test.go
@@ -150,26 +150,38 @@ func TestReplacementToCH(t *testing.T) {
 	}
 }
 
-// TestReplacementToCHRejectsInexpressibleBackrefs pins the one shape that
-// Go's ExpandString resolves to a real capture but no ClickHouse
-// expression can reproduce: a name several capture groups share where the
-// first carrier to TAKE PART in a match can capture the EMPTY STRING while
-// a LATER carrier in that same match captures text. ExpandString stops at
-// the first participant and expands to its empty capture; the emitted
-// `arrayFirst(x -> x != ”, …)` search skips it and answers with the later
-// carrier instead. Participation is what would separate the two, and it is
-// not observable from SQL — `extractGroups` reports a group that did not
-// participate and a group that matched the empty string identically, as
-// `”`.
+// TestReplacementToCHRejectsInexpressibleBackrefs pins what is left of
+// the one shape Go's ExpandString resolves to a real capture but no
+// ClickHouse expression can reproduce: a name several capture groups share
+// where the first carrier to TAKE PART in a match can capture the EMPTY
+// STRING while a LATER carrier in that same match captures text.
+// ExpandString stops at the first participant and expands to its empty
+// capture; a search that tests each carrier's own capture for non-emptiness
+// skips it and answers with the later carrier instead.
+//
+// Participation is not observable from SQL — `extractGroups` reports a
+// group that did not participate and a group that matched the empty string
+// identically, as `”` (ClickHouse/ClickHouse#114733 tracks that upstream).
+// But it IS observable indirectly wherever the carrier has an ancestor that
+// cannot match empty and that no optional node separates from it: probing
+// that ancestor turns participation back into non-emptiness, and
+// [planCaptureProbes] rewrites the regex to read it. So a carrier under a
+// quest is no longer rejected merely for being under one — see
+// TestReplacementToCHProbesCarrierParticipation.
+//
+// What remains is a carrier with no such ancestor ANYWHERE above it: one
+// alone in a branch, or alone under a quest, where every enclosing span up
+// to the node that can skip it is itself nullable. Nothing in the pattern
+// is then guaranteed to be consumed when the carrier takes part, so no
+// group's emptiness can stand in for its participation.
 //
 // Nullability alone does NOT put a carrier in this position, which is why
 // every case below carries a concrete WITNESS: an input string on which
-// Go's answer and the first-non-empty search really do differ. A case
-// without one would be pinning an over-rejection rather than the
-// divergence — the trap the previous revision of this test fell into, when
-// all four of its regexes turned out to be expressible after all. The
-// shapes that are expressible are covered by
-// TestSharedCaptureNameSegmentsAgreeWithExpandString and
+// Go's answer and the emitted search really do differ. A case without one
+// would be pinning an over-rejection rather than the divergence — the trap
+// an earlier revision of this test fell into, when all four of its regexes
+// turned out to be expressible after all. The shapes that ARE expressible
+// are covered by TestSharedCaptureNameSegmentsAgreeWithExpandString and
 // TestExpressibleCarriersAgreeWithExpandString.
 //
 // It used to be emitted as literal template text — a 200 carrying a label
@@ -186,48 +198,38 @@ func TestReplacementToCHRejectsInexpressibleBackrefs(t *testing.T) {
 		wantErrs []string
 	}{
 		{
-			// Carrier 1 sits under a quest, so a match can skip it
-			// entirely, and it is nullable, so a match can also enter it
-			// and capture nothing. Witness "xb": Go answers "" (carrier 1
-			// took part, matching empty after the "x"), first-non-empty
-			// answers "b".
-			"nullable_carrier_a_match_can_skip",
-			"$dup",
-			`(?:x(?P<dup>a?))?(?P<dup>b)`,
-			[]string{`"dup"`, "2 capture groups", "empty string", "capture group 1"},
-		},
-		{
-			// The alternation around carrier 1 is itself mandatory, so
-			// being in a branch of it excludes carrier 1 from nothing —
-			// carrier 2 sits outside the alternation and takes part
-			// alongside it. Witness "b": Go answers "", first-non-empty
-			// answers "b".
-			"nullable_carrier_in_a_co_occurring_branch",
+			// Carrier 1 is alone in a branch of a mandatory alternation.
+			// The branch is nullable, so there is nothing in it to probe,
+			// and the alternation above it is exactly what lets a match
+			// skip the carrier — so no wider span can answer either.
+			// Witness "b": Go answers "" (the empty branch took part),
+			// the emitted search answers "b".
+			"nullable_carrier_alone_in_a_co_occurring_branch",
 			"$dup",
 			`(?:(?P<dup>a?)|y)(?P<dup>b)`,
 			[]string{`"dup"`, "2 capture groups", "empty string", "capture group 1"},
 		},
 		{
-			// The ambiguity is not always at the FIRST carrier. Carrier 1
-			// is non-nullable and therefore clear; carrier 2 is the one
-			// whose participation cannot be read back. Witness "xc": Go
-			// answers "", first-non-empty answers "c".
-			"ambiguity_after_a_clear_first_carrier",
+			// The same hole under a quest rather than an alternation:
+			// carrier 1 is the entire body of the optional group, so the
+			// only span that could be probed is the carrier itself, and
+			// it is nullable. Witness "b": greedy matching enters the
+			// quest and captures nothing, so Go answers "" while the
+			// emitted search answers "b".
+			"nullable_carrier_alone_under_a_quest",
 			"$dup",
-			`(?P<dup>a)|(?:x(?P<dup>b?))?(?P<dup>c)`,
-			[]string{`"dup"`, "3 capture groups", "empty string", "capture group 2"},
+			`(?:(?P<dup>a?))?(?P<dup>b)`,
+			[]string{`"dup"`, "2 capture groups", "empty string", "capture group 1"},
 		},
 		{
-			// Two carriers in different branches of one alternation
-			// normally exclude each other, but a repetition AROUND the
-			// alternation re-enters it, so one match takes both branches.
-			// Witness "bbbx": the last pass takes the first branch and
-			// captures nothing while an earlier pass captured "b", so Go
-			// answers "" and first-non-empty answers "b".
-			"repetition_re_enters_the_alternation",
+			// The ambiguity is not always at the FIRST carrier. Carrier 1
+			// is non-nullable and therefore clear; carrier 2 is the one
+			// with no probeable ancestor. Witness "x": Go answers "",
+			// the emitted search answers "x".
+			"unprobeable_carrier_after_a_clear_first_carrier",
 			"$dup",
-			`(?:x(?P<dup>a?)|(?P<dup>b))*`,
-			[]string{`"dup"`, "2 capture groups", "empty string", "capture group 1"},
+			`(?P<dup>a)|(?:(?P<dup>b?)|y)(?P<dup>x)`,
+			[]string{`"dup"`, "3 capture groups", "empty string", "capture group 2"},
 		},
 	}
 	for _, tc := range cases {

--- a/internal/qlcommon/regex_source_scan.go
+++ b/internal/qlcommon/regex_source_scan.go
@@ -88,14 +88,9 @@ func scanSourceGroups(src string) ([]sourceGroup, bool) {
 			groups[innermost].alternations = append(groups[innermost].alternations, i)
 			i++
 		case '(':
-			bodyStart, capturing, opens, ok := classifyGroupOpen(src, i)
+			bodyStart, capturing, ok := classifyGroupOpen(src, i)
 			if !ok {
 				return nil, false
-			}
-			if !opens {
-				// A `(?flags)` setting opens nothing; it just ends.
-				i = bodyStart
-				continue
 			}
 			g := sourceGroup{
 				open:      i,
@@ -200,42 +195,39 @@ const groupFlagBytes = "imsU-"
 // The scoped spelling `(?flags:…)` is a group of its own and carries its
 // setting with it wherever it is wrapped, so it stays allowed.
 //
-// opens=false is therefore reserved for nothing at present; the return
-// stays in the signature because the `)` arm is what recognises the
+// Every group this returns therefore opens one, which is why there is no
+// "opened nothing" outcome: the `)` arm exists only to recognise the
 // setting in order to refuse it.
-func classifyGroupOpen(src string, i int) (bodyStart int, capturing, opens, ok bool) {
+func classifyGroupOpen(src string, i int) (bodyStart int, capturing, ok bool) {
 	if i+1 >= len(src) || src[i+1] != '?' {
-		return i + 1, true, true, true
+		return i + 1, true, true
 	}
 	j := i + 2
 	if j >= len(src) {
-		return 0, false, false, false
+		return 0, false, false
 	}
 	// `(?P<name>…)` and its `(?<name>…)` spelling both capture.
 	if src[j] == 'P' || src[j] == '<' {
 		if src[j] == 'P' {
 			j++
 			if j >= len(src) || src[j] != '<' {
-				return 0, false, false, false
+				return 0, false, false
 			}
 		}
 		end := strings.IndexByte(src[j+1:], '>')
 		if end < 0 {
-			return 0, false, false, false
+			return 0, false, false
 		}
-		return j + 1 + end + 1, true, true, true
+		return j + 1 + end + 1, true, true
 	}
 	for j < len(src) && strings.IndexByte(groupFlagBytes, src[j]) >= 0 {
 		j++
 	}
 	if j >= len(src) {
-		return 0, false, false, false
+		return 0, false, false
 	}
-	switch src[j] {
-	case ':':
-		return j + 1, false, true, true
-	case ')':
-		return 0, false, false, false
+	if src[j] == ':' {
+		return j + 1, false, true
 	}
-	return 0, false, false, false
+	return 0, false, false
 }

--- a/internal/qlcommon/regex_source_scan.go
+++ b/internal/qlcommon/regex_source_scan.go
@@ -66,6 +66,16 @@ func scanSourceGroups(src string) ([]sourceGroup, bool) {
 			if i+1 >= len(src) {
 				return nil, false
 			}
+			if src[i+1] == 'Q' {
+				// `\Q…\E` quotes everything up to the `\E`, or to the end
+				// of the pattern when there is none. Reading two bytes and
+				// carrying on would scan the QUOTED text as pattern, so a
+				// `(` inside it would be counted as a group — shifting every
+				// later capture index and pointing the rewrite at literal
+				// text.
+				i = endOfQuotedRun(src, i)
+				continue
+			}
 			i += 2
 		case '[':
 			end, ok := skipCharClass(src, i)
@@ -157,6 +167,16 @@ func skipCharClass(src string, i int) (int, bool) {
 		}
 	}
 	return 0, false
+}
+
+// endOfQuotedRun returns the offset just past the `\Q…\E` run starting at
+// src[i], which the caller has established is the `\` of a `\Q`. An
+// unterminated run quotes the rest of the pattern.
+func endOfQuotedRun(src string, i int) int {
+	if end := strings.Index(src[i+2:], `\E`); end >= 0 {
+		return i + 2 + end + 2
+	}
+	return len(src)
 }
 
 // groupFlagBytes are the inline-flag letters Go accepts between `(?` and

--- a/internal/qlcommon/regex_source_scan.go
+++ b/internal/qlcommon/regex_source_scan.go
@@ -1,0 +1,221 @@
+package qlcommon
+
+import "strings"
+
+// This file answers "which bytes" about a regex source, and nothing about
+// what those bytes mean.
+//
+// `regexp/syntax` records no byte offsets — its nodes cannot say where in
+// the source they came from — so a rewrite that has to insert text at a
+// particular structural position cannot get the position from the parse
+// tree. The alternative, mutating the tree and serialising it back with
+// `Regexp.String()`, would rest a user's query semantics on that
+// printer's round-tripping. Scanning the source instead keeps the rewrite
+// to an insertion into the user's own text, and leaves every question of
+// MEANING to `regexp/syntax`, which [probeSpanFor] asks by handing back
+// the substring a span names.
+//
+// The scanner is deliberately partial. It recognises the group syntax Go
+// accepts and nothing else, and every construct it cannot classify makes
+// it decline outright rather than guess an offset. Declining costs the
+// caller a rewrite it might have earned; a wrong offset would bracket the
+// wrong span and answer a different question than the one asked.
+
+// sourceGroup is one parenthesised group of a regex source.
+type sourceGroup struct {
+	// open is the offset of the group's `(`, or -1 for the virtual group
+	// standing for the whole pattern.
+	open int
+	// bodyStart is the offset just past the group's opening syntax —
+	// after `(`, `(?:`, or `(?P<name>`.
+	bodyStart int
+	// bodyEnd is the offset of the group's `)`, or len(src) for the
+	// virtual whole-pattern group.
+	bodyEnd int
+	// capturing distinguishes `(…)` and `(?P<name>…)` from `(?:…)`.
+	capturing bool
+	// capIndex is the group's 1-based capture number, matching what
+	// `Regexp.SubexpNames` reports; 0 when the group does not capture.
+	capIndex int
+	// parent indexes the enclosing group, or -1 for the virtual one.
+	parent int
+	// alternations holds the offsets of the `|` bytes at the TOP level of
+	// this group's body — the ones that split it into branches. A `|`
+	// inside a nested group belongs to that group instead.
+	alternations []int
+}
+
+// wholePatternGroup is the index of the virtual group standing for the
+// entire pattern, which gives a group at the top level a parent to walk
+// up to.
+const wholePatternGroup = 0
+
+// scanSourceGroups locates every group in src, reporting ok=false for any
+// pattern whose group syntax this does not fully recognise — including an
+// unbalanced one, which Go's own parser would reject anyway.
+func scanSourceGroups(src string) ([]sourceGroup, bool) {
+	groups := []sourceGroup{{open: -1, bodyStart: 0, bodyEnd: len(src), parent: -1}}
+	open := []int{wholePatternGroup}
+	captures := 0
+
+	for i := 0; i < len(src); {
+		switch src[i] {
+		case '\\':
+			// An escape covers the next byte whatever it is, so a `\(`
+			// never opens a group and a `\[` never opens a class.
+			if i+1 >= len(src) {
+				return nil, false
+			}
+			i += 2
+		case '[':
+			end, ok := skipCharClass(src, i)
+			if !ok {
+				return nil, false
+			}
+			i = end
+		case '|':
+			innermost := open[len(open)-1]
+			groups[innermost].alternations = append(groups[innermost].alternations, i)
+			i++
+		case '(':
+			bodyStart, capturing, opens, ok := classifyGroupOpen(src, i)
+			if !ok {
+				return nil, false
+			}
+			if !opens {
+				// A `(?flags)` setting opens nothing; it just ends.
+				i = bodyStart
+				continue
+			}
+			g := sourceGroup{
+				open:      i,
+				bodyStart: bodyStart,
+				capturing: capturing,
+				parent:    open[len(open)-1],
+			}
+			if capturing {
+				captures++
+				g.capIndex = captures
+			}
+			groups = append(groups, g)
+			open = append(open, len(groups)-1)
+			i = bodyStart
+		case ')':
+			if len(open) == 1 {
+				return nil, false
+			}
+			groups[open[len(open)-1]].bodyEnd = i
+			open = open[:len(open)-1]
+			i++
+		default:
+			i++
+		}
+	}
+	if len(open) != 1 {
+		return nil, false
+	}
+	return groups, true
+}
+
+// skipCharClass returns the offset just past the character class opening
+// at src[i], which the caller has established is a `[`.
+//
+// The leading-`]` rule matters: in `[]a]` and `[^]a]` the first `]` is a
+// member rather than the terminator, so treating it as the end would let
+// the rest of the class — parentheses included — be scanned as pattern.
+func skipCharClass(src string, i int) (int, bool) {
+	j := i + 1
+	if j < len(src) && src[j] == '^' {
+		j++
+	}
+	if j < len(src) && src[j] == ']' {
+		j++
+	}
+	for j < len(src) {
+		switch src[j] {
+		case '\\':
+			if j+1 >= len(src) {
+				return 0, false
+			}
+			j += 2
+		case '[':
+			// A POSIX name such as `[:alpha:]` nests inside the class and
+			// carries its own `]`, which is not the class's terminator.
+			if j+1 < len(src) && src[j+1] == ':' {
+				end := strings.Index(src[j+2:], ":]")
+				if end < 0 {
+					return 0, false
+				}
+				j += 2 + end + 2
+				continue
+			}
+			j++
+		case ']':
+			return j + 1, true
+		default:
+			j++
+		}
+	}
+	return 0, false
+}
+
+// groupFlagBytes are the inline-flag letters Go accepts between `(?` and
+// the `:` or `)` that ends the flag list.
+const groupFlagBytes = "imsU-"
+
+// classifyGroupOpen reads the group opening at src[i], which the caller
+// has established is a `(`.
+//
+// A bare `(?flags)` SETTING makes the whole scan decline, which is not
+// fussiness but the one construct that would make an inserted group
+// change the pattern's meaning. Such a setting applies from where it
+// appears to the end of the group enclosing it, CROSSING alternation
+// branches: in `(?:(?i)a|b)` the `(?i)` reaches the `b` as well, so the
+// pattern matches "B". Wrapping the first branch in a probe group —
+// `(?:(?P<probe>(?i)a)|b)` — confines the setting to that branch, and
+// "B" stops matching. The rewrite would then be reading capture groups
+// out of a pattern that accepts a different language than the query
+// asked for, which no amount of index bookkeeping can put right.
+//
+// The scoped spelling `(?flags:…)` is a group of its own and carries its
+// setting with it wherever it is wrapped, so it stays allowed.
+//
+// opens=false is therefore reserved for nothing at present; the return
+// stays in the signature because the `)` arm is what recognises the
+// setting in order to refuse it.
+func classifyGroupOpen(src string, i int) (bodyStart int, capturing, opens, ok bool) {
+	if i+1 >= len(src) || src[i+1] != '?' {
+		return i + 1, true, true, true
+	}
+	j := i + 2
+	if j >= len(src) {
+		return 0, false, false, false
+	}
+	// `(?P<name>…)` and its `(?<name>…)` spelling both capture.
+	if src[j] == 'P' || src[j] == '<' {
+		if src[j] == 'P' {
+			j++
+			if j >= len(src) || src[j] != '<' {
+				return 0, false, false, false
+			}
+		}
+		end := strings.IndexByte(src[j+1:], '>')
+		if end < 0 {
+			return 0, false, false, false
+		}
+		return j + 1 + end + 1, true, true, true
+	}
+	for j < len(src) && strings.IndexByte(groupFlagBytes, src[j]) >= 0 {
+		j++
+	}
+	if j >= len(src) {
+		return 0, false, false, false
+	}
+	switch src[j] {
+	case ':':
+		return j + 1, false, true, true
+	case ')':
+		return 0, false, false, false
+	}
+	return 0, false, false, false
+}

--- a/internal/qlcommon/regex_source_scan_test.go
+++ b/internal/qlcommon/regex_source_scan_test.go
@@ -28,6 +28,11 @@ func TestScanSourceGroupsLocatesGroups(t *testing.T) {
 		{"non_capturing", `a(?:b)c`, []string{"b"}, []int{0}},
 		{"named", `a(?P<n>b)c`, []string{"b"}, []int{1}},
 		{"named_short_spelling", `a(?<n>b)c`, []string{"b"}, []int{1}},
+		// An empty name is still a group opening as far as offsets go —
+		// the `>` is found at distance zero, which is the boundary between
+		// "found it" and "there is none". Whether Go's own parser then
+		// accepts the name is its business, not the scanner's.
+		{"empty_group_name", `(?P<>a)`, []string{"a"}, []int{1}},
 		{"nested", `((a)(b))`, []string{"(a)(b)", "a", "b"}, []int{1, 2, 3}},
 		{"mixed_capturing_and_not", `(?:(a))`, []string{"(a)", "a"}, []int{0, 1}},
 
@@ -109,6 +114,20 @@ func TestScanSourceGroupsDeclines(t *testing.T) {
 		{"bare_flag_setting", `(?i)(a)`},
 		{"bare_flag_setting_with_minus", `(?i-s)(a)`},
 		{"bare_flag_setting_inside_a_group", `(?:(?i)a|b)`},
+
+		// Each of these ends exactly where a guard is about to read the
+		// next byte. They are the inputs that tell a bound that stops one
+		// short from one that reads past the end.
+		{"lone_open_paren", `(`},
+		{"lone_backslash", `\`},
+		{"lone_class_open", `[`},
+		{"class_open_then_negation", `[^`},
+		{"class_open_then_negated_bracket", `[^]`},
+		{"truncated_named_prefix", `(?P`},
+		{"class_ending_in_a_bracket", `[a[`},
+		{"truncated_posix_open", `[[:`},
+		{"truncated_posix_name", `[[:alpha`},
+		{"class_ending_in_an_escape", `[a\`},
 	}
 
 	for _, tc := range cases {

--- a/internal/qlcommon/regex_source_scan_test.go
+++ b/internal/qlcommon/regex_source_scan_test.go
@@ -1,0 +1,157 @@
+package qlcommon
+
+import "testing"
+
+// TestScanSourceGroupsLocatesGroups pins the offsets the rewrite inserts
+// at. Every case is a source whose group boundaries a naive
+// paren-counting scan would get wrong — an escaped parenthesis, a
+// parenthesis inside a character class, a class whose first member is the
+// `]` that would otherwise close it, a POSIX name carrying its own `]`,
+// and the `(?…)` spellings Go accepts.
+//
+// A wrong offset here does not fail loudly: it brackets a different span,
+// and the probe then answers a different question than the one asked. So
+// the assertion is on the exact substring each group's body spans.
+func TestScanSourceGroupsLocatesGroups(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		src  string
+		// bodies is the body substring of each group, in source order.
+		bodies []string
+		// captures is the capture index of each group, 0 when it does not
+		// capture.
+		captures []int
+	}{
+		{"plain_group", `a(b)c`, []string{"b"}, []int{1}},
+		{"non_capturing", `a(?:b)c`, []string{"b"}, []int{0}},
+		{"named", `a(?P<n>b)c`, []string{"b"}, []int{1}},
+		{"named_short_spelling", `a(?<n>b)c`, []string{"b"}, []int{1}},
+		{"nested", `((a)(b))`, []string{"(a)(b)", "a", "b"}, []int{1, 2, 3}},
+		{"mixed_capturing_and_not", `(?:(a))`, []string{"(a)", "a"}, []int{0, 1}},
+
+		// An escaped parenthesis is literal text, not a group.
+		{"escaped_parens", `\((a)\)`, []string{"a"}, []int{1}},
+		{"escaped_backslash_then_group", `\\(a)`, []string{"a"}, []int{1}},
+
+		// Parentheses inside a character class are members of it.
+		{"parens_in_a_class", `[()](a)`, []string{"a"}, []int{1}},
+		{"leading_bracket_member", `[]()](a)`, []string{"a"}, []int{1}},
+		{"negated_leading_bracket_member", `[^]()](a)`, []string{"a"}, []int{1}},
+		{"posix_class", `[[:alpha:]](a)`, []string{"a"}, []int{1}},
+		{"escaped_bracket_in_a_class", `[\]()](a)`, []string{"a"}, []int{1}},
+
+		// A SCOPED flag group carries its setting with it, so wrapping it
+		// cannot move where the setting applies.
+		{"flag_group", `(?i:a)(b)`, []string{"a", "b"}, []int{0, 1}},
+		{"flag_group_with_minus", `(?i-s:a)(b)`, []string{"a", "b"}, []int{0, 1}},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			groups, ok := scanSourceGroups(tc.src)
+			if !ok {
+				t.Fatalf("scanSourceGroups(%q) declined; want it to scan", tc.src)
+			}
+			// Element 0 is the virtual whole-pattern group.
+			real := groups[1:]
+			if len(real) != len(tc.bodies) {
+				t.Fatalf("scanSourceGroups(%q) found %d groups, want %d: %+v",
+					tc.src, len(real), len(tc.bodies), real)
+			}
+			for i, g := range real {
+				if body := tc.src[g.bodyStart:g.bodyEnd]; body != tc.bodies[i] {
+					t.Errorf("scanSourceGroups(%q) group %d spans %q, want %q",
+						tc.src, i, body, tc.bodies[i])
+				}
+				if g.capIndex != tc.captures[i] {
+					t.Errorf("scanSourceGroups(%q) group %d has capture index %d, want %d",
+						tc.src, i, g.capIndex, tc.captures[i])
+				}
+			}
+		})
+	}
+}
+
+// TestScanSourceGroupsDeclines pins the conservatism the rewrite's
+// soundness rests on. The scanner computes byte offsets that another
+// function then inserts parentheses at, so a construct it cannot classify
+// must make it decline outright — guessing an offset would bracket a span
+// nobody chose, and the probe would answer for the wrong thing while
+// still compiling.
+func TestScanSourceGroupsDeclines(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		src  string
+	}{
+		{"unclosed_group", `(a`},
+		{"unopened_group", `a)`},
+		{"trailing_backslash", `a\`},
+		{"unterminated_class", `[abc`},
+		{"unterminated_posix_class", `[[:alpha`},
+		{"trailing_backslash_in_a_class", `[a\`},
+		{"truncated_named_group", `(?P<n`},
+		{"truncated_short_named_group", `(?<n`},
+		{"named_group_without_bracket", `(?Pn>a)`},
+		{"unknown_group_construct", `(?=a)`},
+		{"truncated_flag_group", `(?i`},
+		{"bare_question_group", `(?`},
+
+		// A bare flag SETTING reaches to the end of its enclosing group,
+		// across alternation branches. Wrapping a branch would confine it
+		// and change which strings the pattern accepts, so a pattern
+		// carrying one is never rewritten.
+		{"bare_flag_setting", `(?i)(a)`},
+		{"bare_flag_setting_with_minus", `(?i-s)(a)`},
+		{"bare_flag_setting_inside_a_group", `(?:(?i)a|b)`},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if _, ok := scanSourceGroups(tc.src); ok {
+				t.Errorf("scanSourceGroups(%q) scanned it; want a decline, because an offset "+
+					"guessed for a construct this does not model would silently bracket the "+
+					"wrong span", tc.src)
+			}
+		})
+	}
+}
+
+// TestPlanCaptureProbesDeclines pins the planner's own fail-closed paths:
+// a pattern it cannot rewrite must yield no plan rather than a partial
+// one, because every index in a decomposition is numbered against the
+// rewrite and a half-applied one would renumber without answering.
+func TestPlanCaptureProbesDeclines(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name  string
+		regex string
+		need  []int
+	}{
+		{"nothing_to_probe", `(?P<dup>a)|(?P<dup>b)`, nil},
+		{"carrier_with_no_probeable_ancestor", `(?:(?P<dup>a?)|y)(?P<dup>b)`, []int{1}},
+		{"carrier_alone_under_a_quest", `(?:(?P<dup>a?))?(?P<dup>b)`, []int{1}},
+		{"unparseable_regex", `(?P<dup>a`, []int{1}},
+		{"index_past_the_group_count", `(?P<dup>a?)(?P<dup>b)`, []int{9}},
+		// A pattern already carrying a probe name would make the rewrite
+		// unreadable back off SubexpNames.
+		{"probe_name_collision", `(?:x(?P<` + probeNamePrefix + `9>a?))?(?P<dup>b)`, []int{1}},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if plan, ok := planCaptureProbes(tc.regex, tc.need); ok {
+				t.Errorf("planCaptureProbes(%q, %v) planned %+v; want a decline",
+					tc.regex, tc.need, plan)
+			}
+		})
+	}
+}

--- a/test/perf/cardinality-baseline/logql/label_replace_probed_shared_capture_name.json
+++ b/test/perf/cardinality-baseline/logql/label_replace_probed_shared_capture_name.json
@@ -1,0 +1,11 @@
+{
+  "fixture": "logql/label_replace_probed_shared_capture_name",
+  "fan_factor": 1,
+  "scan_rows": 3,
+  "peak_intermediate": 3,
+  "has_cross_join": false,
+  "has_array_join": false,
+  "has_recursive_cte": false,
+  "max_recursion_depth": 0,
+  "uncountable_levels": 0
+}

--- a/test/perf/cardinality-baseline/promql/label_replace_probed_shared_capture_name.json
+++ b/test/perf/cardinality-baseline/promql/label_replace_probed_shared_capture_name.json
@@ -1,0 +1,11 @@
+{
+  "fixture": "promql/label_replace_probed_shared_capture_name",
+  "fan_factor": 1,
+  "scan_rows": 3,
+  "peak_intermediate": 3,
+  "has_cross_join": false,
+  "has_array_join": false,
+  "has_recursive_cte": false,
+  "max_recursion_depth": 0,
+  "uncountable_levels": 0
+}

--- a/test/perf/solver-decision-baseline/label_replace_probed_shared_capture_name.json
+++ b/test/perf/solver-decision-baseline/label_replace_probed_shared_capture_name.json
@@ -1,0 +1,10 @@
+{
+  "query": "label_replace_probed_shared_capture_name",
+  "routed": true,
+  "k": 8,
+  "reason": "routed",
+  "n_anchors": 241,
+  "fanout": 20,
+  "cumulative_d": "5m0s",
+  "outer_range": "1h0m0s"
+}

--- a/test/regression/parity_contract_test.go
+++ b/test/regression/parity_contract_test.go
@@ -171,7 +171,7 @@ func TestParityEnrolmentFloor(t *testing.T) {
 
 	// parityEnrolmentFloor is the number of fixtures currently carrying a
 	// `parity:` section. It ratchets UP only.
-	const parityEnrolmentFloor = 560
+	const parityEnrolmentFloor = 562
 
 	enrolled := 0
 	for _, dir := range parityFixtureDirs(t) {

--- a/test/rejection-parity/catalogue/internal__logql__label_fns.go.json
+++ b/test/rejection-parity/catalogue/internal__logql__label_fns.go.json
@@ -5,7 +5,7 @@
       "site": "internal/logql/label_fns.go:lowerLabelReplace#8cd9f67b",
       "message": "logql: label_replace: %w",
       "class": "divergence",
-      "trigger_query": "label_replace(rate({app=\"x\"}[5m]), \"d\", \"$dup\", \"src\", \"(?:x(?P\u003cdup\u003ea?))?(?P\u003cdup\u003eb)\")",
+      "trigger_query": "label_replace(rate({app=\"x\"}[5m]), \"d\", \"$dup\", \"src\", \"(?:(?P\u003cdup\u003ea?)|y)(?P\u003cdup\u003eb)\")",
       "tracking_issue": 1956,
       "evidence": {
         "guard": [

--- a/test/rejection-parity/catalogue/internal__promql__label_fns.go.json
+++ b/test/rejection-parity/catalogue/internal__promql__label_fns.go.json
@@ -35,7 +35,7 @@
       "site": "internal/promql/label_fns.go:lowerLabelReplace#d11e3df4",
       "message": "promql: label_replace: %w",
       "class": "divergence",
-      "trigger_query": "label_replace(up, \"d\", \"$dup\", \"src\", \"(?:x(?P\u003cdup\u003ea?))?(?P\u003cdup\u003eb)\")",
+      "trigger_query": "label_replace(up, \"d\", \"$dup\", \"src\", \"(?:(?P\u003cdup\u003ea?)|y)(?P\u003cdup\u003eb)\")",
       "tracking_issue": 1956,
       "evidence": {
         "guard": [

--- a/test/spec/chplan_print.go
+++ b/test/spec/chplan_print.go
@@ -637,8 +637,9 @@ func printExpr(e chplan.Expr) string {
 	case *chplan.MapWithoutEmptyValues:
 		return fmt.Sprintf("mapWithoutEmpty(%s)", printExpr(v.Map))
 	case *chplan.LabelReplace:
-		return fmt.Sprintf("labelReplace(%s, dst=%q, replacement=%q, src=%q, regex=%q, emptyReplacement=%q%s)",
+		return fmt.Sprintf("labelReplace(%s, dst=%q, replacement=%q, src=%q, regex=%q, emptyReplacement=%q%s%s)",
 			printExpr(v.Map), v.Dst, v.Replacement, v.Src, v.Regex, v.EmptyReplacement,
+			printLabelReplaceProbedRegex(v.ProbedRegex),
 			printLabelReplaceSegments(v.Segments))
 	case *chplan.LabelJoin:
 		return fmt.Sprintf("labelJoin(%s, dst=%q, separator=%q, srcs=[%s])",
@@ -793,7 +794,21 @@ func formatGroupByEntry(expr, alias, display string) string {
 //
 // A shared-name reference prints as its carrier indices joined by `|`
 // (`$1|$2`), the "first of these with a non-empty capture" selection
-// chplan.LabelReplaceSegment.Fallbacks describes.
+// chplan.LabelReplaceSegment.Fallbacks describes. A carrier whose
+// participation is read off a synthetic probe group instead of its own
+// capture prints that group after an `@` (`$2@$1`), so a golden pins WHICH
+// group answers for each carrier and not merely that some probe exists.
+// printLabelReplaceProbedRegex renders the rewritten pattern the emitter
+// reads capture groups out of, and nothing at all when there is none — so
+// every fixture whose regex needed no probe keeps its golden line
+// unchanged.
+func printLabelReplaceProbedRegex(probed string) string {
+	if probed == "" {
+		return ""
+	}
+	return fmt.Sprintf(", probedRegex=%q", probed)
+}
+
 func printLabelReplaceSegments(segments []chplan.LabelReplaceSegment) string {
 	if len(segments) == 0 {
 		return ""
@@ -804,9 +819,14 @@ func printLabelReplaceSegments(segments []chplan.LabelReplaceSegment) string {
 			parts = append(parts, fmt.Sprintf("%q", seg.Literal))
 			continue
 		}
-		indices := []string{fmt.Sprintf("$%d", seg.Group)}
-		for _, idx := range seg.Fallbacks {
-			indices = append(indices, fmt.Sprintf("$%d", idx))
+		carriers := append([]int{seg.Group}, seg.Fallbacks...)
+		indices := make([]string, 0, len(carriers))
+		for i, carrier := range carriers {
+			at := fmt.Sprintf("$%d", carrier)
+			if i < len(seg.Probes) && seg.Probes[i] != carrier {
+				at += fmt.Sprintf("@$%d", seg.Probes[i])
+			}
+			indices = append(indices, at)
 		}
 		parts = append(parts, strings.Join(indices, "|"))
 	}

--- a/test/spec/chplan_print.go
+++ b/test/spec/chplan_print.go
@@ -786,6 +786,17 @@ func formatGroupByEntry(expr, alias, display string) string {
 	}
 }
 
+// printLabelReplaceProbedRegex renders the rewritten pattern the emitter
+// reads capture groups out of, and nothing at all when there is none — so
+// every fixture whose regex needed no probe keeps its golden line
+// unchanged.
+func printLabelReplaceProbedRegex(probed string) string {
+	if probed == "" {
+		return ""
+	}
+	return fmt.Sprintf(", probedRegex=%q", probed)
+}
+
 // printLabelReplaceSegments renders the replacement decomposition a
 // label_replace carries when its template references a capture group
 // above ClickHouse's `\9` substitution ceiling, or a name several capture
@@ -798,17 +809,6 @@ func formatGroupByEntry(expr, alias, display string) string {
 // participation is read off a synthetic probe group instead of its own
 // capture prints that group after an `@` (`$2@$1`), so a golden pins WHICH
 // group answers for each carrier and not merely that some probe exists.
-// printLabelReplaceProbedRegex renders the rewritten pattern the emitter
-// reads capture groups out of, and nothing at all when there is none — so
-// every fixture whose regex needed no probe keeps its golden line
-// unchanged.
-func printLabelReplaceProbedRegex(probed string) string {
-	if probed == "" {
-		return ""
-	}
-	return fmt.Sprintf(", probedRegex=%q", probed)
-}
-
 func printLabelReplaceSegments(segments []chplan.LabelReplaceSegment) string {
 	if len(segments) == 0 {
 		return ""

--- a/test/spec/logql/label_replace_probed_shared_capture_name.txtar
+++ b/test/spec/logql/label_replace_probed_shared_capture_name.txtar
@@ -1,0 +1,369 @@
+# A capture-group NAME two groups carry where the first carrier is
+# NULLABLE and a match can SKIP it entirely — the shape that was rejected
+# outright until cerberus learned to rewrite the regex.
+#
+# Go's ExpandString resolves `$dup` to the first carrier that TOOK PART in
+# the row's match, and ClickHouse's `extractGroups` cannot report
+# participation: a group that took no part and a group that took part
+# matching the empty string are both `''`. The other two fixtures for this
+# name escape that by never letting the ambiguity arise — every carrier
+# non-empty (label_replace_shared_capture_name.txtar), or the carriers in
+# exclusive alternation branches
+# (label_replace_nullable_shared_capture_name.txtar). Here it really does
+# arise, and is answered anyway.
+#
+# The two middle rows are the entire point, because their capture arrays
+# are IDENTICAL and their correct answers are not:
+#
+#   - `web--77` enters the optional group — "web-" and the trailing "-"
+#     both matched — and `dup` captured NOTHING between them. Group one
+#     TOOK PART, so ExpandString expands `$dup` to `""` and Prometheus
+#     answers `service="svc-"`.
+#   - `77` never enters the optional group at all, so group one took no
+#     part and `$dup` resolves to group two: `service="svc-77"`.
+#
+# `extractGroups` returns `['', '77']` for BOTH. No search over those two
+# values can answer `svc-` for one and `svc-77` for the other, which is
+# why a first-non-empty search gets `web--77` wrong.
+#
+# The rewrite makes the difference readable. `(?:web-(?P<dup>[a-z]*)-)?`
+# has a body that cannot match empty, so wrapping it in a synthetic group
+# gives a capture that is non-empty exactly when the optional group was
+# entered — which is exactly when carrier one took part. The emitted
+# search reads that group and answers with the carrier beside it, which is
+# what `probedRegex` and the `$2@$1` segment below record.
+#
+# `web-alpha-77` is the ordinary case, and `77` the skipped one, so all
+# three branches of the search are exercised. Issue #1956 tracks the
+# residue this does NOT reach: a carrier with no such body to wrap.
+
+-- query.logql --
+label_replace(sum by (host) (count_over_time({job="api"}[5m])), "service", "svc-$dup", "host", "(?:web-(?P<dup>[a-z]*)-)?(?P<dup>[0-9]+)")
+-- parity --
+oracle: loki
+endpoint: /api/v1/query
+scope: full
+-- seed --
+CREATE TABLE otel_logs (
+    Timestamp DateTime64(9),
+    Body String,
+    SeverityText LowCardinality(String) DEFAULT '',
+    ResourceAttributes Map(String, String),
+    LogAttributes Map(String, String)
+) ENGINE = Memory;
+INSERT INTO otel_logs (Timestamp, Body, ResourceAttributes) VALUES
+    (toDateTime64('2026-01-01 00:00:00', 9), 'a', map('job', 'api', 'host', 'web-alpha-77')),
+    (toDateTime64('2026-01-01 00:00:00', 9), 'b', map('job', 'api', 'host', 'web--77')),
+    (toDateTime64('2026-01-01 00:00:00', 9), 'c', map('job', 'api', 'host', '77'));
+-- expected_rows --
+[
+  ["", {"host": "77", "service": "svc-77"}, "2026-01-01T00:00:01Z", 1],
+  ["", {"host": "web--77", "service": "svc-"}, "2026-01-01T00:00:01Z", 1],
+  ["", {"host": "web-alpha-77", "service": "svc-alpha"}, "2026-01-01T00:00:01Z", 1]
+]
+-- args --
+[0] string = "host"
+[1] string = "^(?s:(?:web-(?P<dup>[a-z]*)-)?(?P<dup>[0-9]+))$"
+[2] string = "service"
+[3] string = "host"
+[4] string = "svc-"
+[5] string = "svc-"
+[6] string = ""
+[7] string = "host"
+[8] string = "^(?s:(?:(?P<cerberusprobe0>web-(?P<dup>[a-z]*)-))?(?P<dup>[0-9]+))$"
+[9] int64 = 2
+[10] string = "host"
+[11] string = "^(?s:(?:(?P<cerberusprobe0>web-(?P<dup>[a-z]*)-))?(?P<dup>[0-9]+))$"
+[12] int64 = 3
+[13] string = "host"
+[14] string = "^(?s:(?:(?P<cerberusprobe0>web-(?P<dup>[a-z]*)-))?(?P<dup>[0-9]+))$"
+[15] int64 = 1
+[16] string = "host"
+[17] string = "^(?s:(?:(?P<cerberusprobe0>web-(?P<dup>[a-z]*)-))?(?P<dup>[0-9]+))$"
+[18] int64 = 3
+[19] string = ""
+[20] string = "host"
+[21] int64 = 9
+[22] string = "host"
+[23] string = ""
+[24] string = "detected_level"
+[25] string = "detected_level"
+[26] string = ""
+[27] string = "detected_level"
+[28] string = "level"
+[29] string = ""
+[30] string = "level"
+[31] string = "log.level"
+[32] string = ""
+[33] string = "log.level"
+[34] string = "severity"
+[35] string = ""
+[36] string = "severity"
+[37] string = "severity_text"
+[38] string = ""
+[39] string = "severity_text"
+[40] string = ""
+[41] string = "unknown"
+[42] string = "detected_level"
+[43] string = ""
+[44] string = "detected_level"
+[45] string = "level"
+[46] string = ""
+[47] string = "level"
+[48] string = "log.level"
+[49] string = ""
+[50] string = "log.level"
+[51] string = "severity"
+[52] string = ""
+[53] string = "severity"
+[54] string = "severity_text"
+[55] string = ""
+[56] string = "severity_text"
+[57] string = "trace"
+[58] string = "detected_level"
+[59] string = ""
+[60] string = "detected_level"
+[61] string = "level"
+[62] string = ""
+[63] string = "level"
+[64] string = "log.level"
+[65] string = ""
+[66] string = "log.level"
+[67] string = "severity"
+[68] string = ""
+[69] string = "severity"
+[70] string = "severity_text"
+[71] string = ""
+[72] string = "severity_text"
+[73] string = "trc"
+[74] string = "trace"
+[75] string = "detected_level"
+[76] string = ""
+[77] string = "detected_level"
+[78] string = "level"
+[79] string = ""
+[80] string = "level"
+[81] string = "log.level"
+[82] string = ""
+[83] string = "log.level"
+[84] string = "severity"
+[85] string = ""
+[86] string = "severity"
+[87] string = "severity_text"
+[88] string = ""
+[89] string = "severity_text"
+[90] string = "debug"
+[91] string = "detected_level"
+[92] string = ""
+[93] string = "detected_level"
+[94] string = "level"
+[95] string = ""
+[96] string = "level"
+[97] string = "log.level"
+[98] string = ""
+[99] string = "log.level"
+[100] string = "severity"
+[101] string = ""
+[102] string = "severity"
+[103] string = "severity_text"
+[104] string = ""
+[105] string = "severity_text"
+[106] string = "dbg"
+[107] string = "debug"
+[108] string = "detected_level"
+[109] string = ""
+[110] string = "detected_level"
+[111] string = "level"
+[112] string = ""
+[113] string = "level"
+[114] string = "log.level"
+[115] string = ""
+[116] string = "log.level"
+[117] string = "severity"
+[118] string = ""
+[119] string = "severity"
+[120] string = "severity_text"
+[121] string = ""
+[122] string = "severity_text"
+[123] string = "info"
+[124] string = "detected_level"
+[125] string = ""
+[126] string = "detected_level"
+[127] string = "level"
+[128] string = ""
+[129] string = "level"
+[130] string = "log.level"
+[131] string = ""
+[132] string = "log.level"
+[133] string = "severity"
+[134] string = ""
+[135] string = "severity"
+[136] string = "severity_text"
+[137] string = ""
+[138] string = "severity_text"
+[139] string = "inf"
+[140] string = "detected_level"
+[141] string = ""
+[142] string = "detected_level"
+[143] string = "level"
+[144] string = ""
+[145] string = "level"
+[146] string = "log.level"
+[147] string = ""
+[148] string = "log.level"
+[149] string = "severity"
+[150] string = ""
+[151] string = "severity"
+[152] string = "severity_text"
+[153] string = ""
+[154] string = "severity_text"
+[155] string = "information"
+[156] string = "info"
+[157] string = "detected_level"
+[158] string = ""
+[159] string = "detected_level"
+[160] string = "level"
+[161] string = ""
+[162] string = "level"
+[163] string = "log.level"
+[164] string = ""
+[165] string = "log.level"
+[166] string = "severity"
+[167] string = ""
+[168] string = "severity"
+[169] string = "severity_text"
+[170] string = ""
+[171] string = "severity_text"
+[172] string = "warn"
+[173] string = "detected_level"
+[174] string = ""
+[175] string = "detected_level"
+[176] string = "level"
+[177] string = ""
+[178] string = "level"
+[179] string = "log.level"
+[180] string = ""
+[181] string = "log.level"
+[182] string = "severity"
+[183] string = ""
+[184] string = "severity"
+[185] string = "severity_text"
+[186] string = ""
+[187] string = "severity_text"
+[188] string = "wrn"
+[189] string = "detected_level"
+[190] string = ""
+[191] string = "detected_level"
+[192] string = "level"
+[193] string = ""
+[194] string = "level"
+[195] string = "log.level"
+[196] string = ""
+[197] string = "log.level"
+[198] string = "severity"
+[199] string = ""
+[200] string = "severity"
+[201] string = "severity_text"
+[202] string = ""
+[203] string = "severity_text"
+[204] string = "warning"
+[205] string = "warn"
+[206] string = "detected_level"
+[207] string = ""
+[208] string = "detected_level"
+[209] string = "level"
+[210] string = ""
+[211] string = "level"
+[212] string = "log.level"
+[213] string = ""
+[214] string = "log.level"
+[215] string = "severity"
+[216] string = ""
+[217] string = "severity"
+[218] string = "severity_text"
+[219] string = ""
+[220] string = "severity_text"
+[221] string = "error"
+[222] string = "detected_level"
+[223] string = ""
+[224] string = "detected_level"
+[225] string = "level"
+[226] string = ""
+[227] string = "level"
+[228] string = "log.level"
+[229] string = ""
+[230] string = "log.level"
+[231] string = "severity"
+[232] string = ""
+[233] string = "severity"
+[234] string = "severity_text"
+[235] string = ""
+[236] string = "severity_text"
+[237] string = "err"
+[238] string = "error"
+[239] string = "detected_level"
+[240] string = ""
+[241] string = "detected_level"
+[242] string = "level"
+[243] string = ""
+[244] string = "level"
+[245] string = "log.level"
+[246] string = ""
+[247] string = "log.level"
+[248] string = "severity"
+[249] string = ""
+[250] string = "severity"
+[251] string = "severity_text"
+[252] string = ""
+[253] string = "severity_text"
+[254] string = "critical"
+[255] string = "critical"
+[256] string = "detected_level"
+[257] string = ""
+[258] string = "detected_level"
+[259] string = "level"
+[260] string = ""
+[261] string = "level"
+[262] string = "log.level"
+[263] string = ""
+[264] string = "log.level"
+[265] string = "severity"
+[266] string = ""
+[267] string = "severity"
+[268] string = "severity_text"
+[269] string = ""
+[270] string = "severity_text"
+[271] string = "fatal"
+[272] string = "fatal"
+[273] string = "detected_level"
+[274] string = ""
+[275] string = "detected_level"
+[276] string = "level"
+[277] string = ""
+[278] string = "level"
+[279] string = "log.level"
+[280] string = ""
+[281] string = "log.level"
+[282] string = "severity"
+[283] string = ""
+[284] string = "severity"
+[285] string = "severity_text"
+[286] string = ""
+[287] string = "severity_text"
+[288] string = "host"
+[289] string = "host"
+[290] string = "host"
+[291] string = "host"
+[292] int64 = 1
+[293] string = "job"
+[294] string = "api"
+-- chplan --
+Project [MetricName AS MetricName, labelReplace(Attributes, dst="service", replacement="", src="host", regex="(?:web-(?P<dup>[a-z]*)-)?(?P<dup>[0-9]+)", emptyReplacement="svc-", probedRegex="(?:(?P<cerberusprobe0>web-(?P<dup>[a-z]*)-))?(?P<dup>[0-9]+)", segments=["svc-", $2@$1|$3]) AS Attributes, TimeUnix AS TimeUnix, Value AS Value]
+  Project ["" AS MetricName, map("host", gkey_0) AS Attributes, now64(9) AS TimeUnix, Value AS Value]
+    Aggregate groupBy=[ResourceAttributes["host"] AS gkey_0] funcs=[sum(Value) AS Value]
+      RangeWindow func=count_over_time range=5m0s step=0s ts=Timestamp value=Value groupBy=[ResourceAttributes]
+        Project [mapSort(mapConcat(ResourceAttributes, mapFilter((k, v) -> (v != ""), map("detected_level", multiIf((lower(multiIf((LogAttributes["detected_level"] != ""), LogAttributes["detected_level"], (LogAttributes["level"] != ""), LogAttributes["level"], (LogAttributes["log.level"] != ""), LogAttributes["log.level"], (LogAttributes["severity"] != ""), LogAttributes["severity"], (LogAttributes["severity_text"] != ""), LogAttributes["severity_text"], SeverityText)) = ""), "unknown", ((lower(multiIf((LogAttributes["detected_level"] != ""), LogAttributes["detected_level"], (LogAttributes["level"] != ""), LogAttributes["level"], (LogAttributes["log.level"] != ""), LogAttributes["log.level"], (LogAttributes["severity"] != ""), LogAttributes["severity"], (LogAttributes["severity_text"] != ""), LogAttributes["severity_text"], SeverityText)) = "trace") OR (lower(multiIf((LogAttributes["detected_level"] != ""), LogAttributes["detected_level"], (LogAttributes["level"] != ""), LogAttributes["level"], (LogAttributes["log.level"] != ""), LogAttributes["log.level"], (LogAttributes["severity"] != ""), LogAttributes["severity"], (LogAttributes["severity_text"] != ""), LogAttributes["severity_text"], SeverityText)) = "trc")), "trace", ((lower(multiIf((LogAttributes["detected_level"] != ""), LogAttributes["detected_level"], (LogAttributes["level"] != ""), LogAttributes["level"], (LogAttributes["log.level"] != ""), LogAttributes["log.level"], (LogAttributes["severity"] != ""), LogAttributes["severity"], (LogAttributes["severity_text"] != ""), LogAttributes["severity_text"], SeverityText)) = "debug") OR (lower(multiIf((LogAttributes["detected_level"] != ""), LogAttributes["detected_level"], (LogAttributes["level"] != ""), LogAttributes["level"], (LogAttributes["log.level"] != ""), LogAttributes["log.level"], (LogAttributes["severity"] != ""), LogAttributes["severity"], (LogAttributes["severity_text"] != ""), LogAttributes["severity_text"], SeverityText)) = "dbg")), "debug", (((lower(multiIf((LogAttributes["detected_level"] != ""), LogAttributes["detected_level"], (LogAttributes["level"] != ""), LogAttributes["level"], (LogAttributes["log.level"] != ""), LogAttributes["log.level"], (LogAttributes["severity"] != ""), LogAttributes["severity"], (LogAttributes["severity_text"] != ""), LogAttributes["severity_text"], SeverityText)) = "info") OR (lower(multiIf((LogAttributes["detected_level"] != ""), LogAttributes["detected_level"], (LogAttributes["level"] != ""), LogAttributes["level"], (LogAttributes["log.level"] != ""), LogAttributes["log.level"], (LogAttributes["severity"] != ""), LogAttributes["severity"], (LogAttributes["severity_text"] != ""), LogAttributes["severity_text"], SeverityText)) = "inf")) OR (lower(multiIf((LogAttributes["detected_level"] != ""), LogAttributes["detected_level"], (LogAttributes["level"] != ""), LogAttributes["level"], (LogAttributes["log.level"] != ""), LogAttributes["log.level"], (LogAttributes["severity"] != ""), LogAttributes["severity"], (LogAttributes["severity_text"] != ""), LogAttributes["severity_text"], SeverityText)) = "information")), "info", (((lower(multiIf((LogAttributes["detected_level"] != ""), LogAttributes["detected_level"], (LogAttributes["level"] != ""), LogAttributes["level"], (LogAttributes["log.level"] != ""), LogAttributes["log.level"], (LogAttributes["severity"] != ""), LogAttributes["severity"], (LogAttributes["severity_text"] != ""), LogAttributes["severity_text"], SeverityText)) = "warn") OR (lower(multiIf((LogAttributes["detected_level"] != ""), LogAttributes["detected_level"], (LogAttributes["level"] != ""), LogAttributes["level"], (LogAttributes["log.level"] != ""), LogAttributes["log.level"], (LogAttributes["severity"] != ""), LogAttributes["severity"], (LogAttributes["severity_text"] != ""), LogAttributes["severity_text"], SeverityText)) = "wrn")) OR (lower(multiIf((LogAttributes["detected_level"] != ""), LogAttributes["detected_level"], (LogAttributes["level"] != ""), LogAttributes["level"], (LogAttributes["log.level"] != ""), LogAttributes["log.level"], (LogAttributes["severity"] != ""), LogAttributes["severity"], (LogAttributes["severity_text"] != ""), LogAttributes["severity_text"], SeverityText)) = "warning")), "warn", ((lower(multiIf((LogAttributes["detected_level"] != ""), LogAttributes["detected_level"], (LogAttributes["level"] != ""), LogAttributes["level"], (LogAttributes["log.level"] != ""), LogAttributes["log.level"], (LogAttributes["severity"] != ""), LogAttributes["severity"], (LogAttributes["severity_text"] != ""), LogAttributes["severity_text"], SeverityText)) = "error") OR (lower(multiIf((LogAttributes["detected_level"] != ""), LogAttributes["detected_level"], (LogAttributes["level"] != ""), LogAttributes["level"], (LogAttributes["log.level"] != ""), LogAttributes["log.level"], (LogAttributes["severity"] != ""), LogAttributes["severity"], (LogAttributes["severity_text"] != ""), LogAttributes["severity_text"], SeverityText)) = "err")), "error", (lower(multiIf((LogAttributes["detected_level"] != ""), LogAttributes["detected_level"], (LogAttributes["level"] != ""), LogAttributes["level"], (LogAttributes["log.level"] != ""), LogAttributes["log.level"], (LogAttributes["severity"] != ""), LogAttributes["severity"], (LogAttributes["severity_text"] != ""), LogAttributes["severity_text"], SeverityText)) = "critical"), "critical", (lower(multiIf((LogAttributes["detected_level"] != ""), LogAttributes["detected_level"], (LogAttributes["level"] != ""), LogAttributes["level"], (LogAttributes["log.level"] != ""), LogAttributes["log.level"], (LogAttributes["severity"] != ""), LogAttributes["severity"], (LogAttributes["severity_text"] != ""), LogAttributes["severity_text"], SeverityText)) = "fatal"), "fatal", lower(multiIf((LogAttributes["detected_level"] != ""), LogAttributes["detected_level"], (LogAttributes["level"] != ""), LogAttributes["level"], (LogAttributes["log.level"] != ""), LogAttributes["log.level"], (LogAttributes["severity"] != ""), LogAttributes["severity"], (LogAttributes["severity_text"] != ""), LogAttributes["severity_text"], SeverityText))), "host", if(mapContains(LogAttributes, "host"), LogAttributes["host"], ResourceAttributes["host"]))))) AS ResourceAttributes, Timestamp, 1 AS Value]
+          Filter predicate=(ResourceAttributes["job"] = "api")
+            Scan(otel_logs)
+-- sql --
+SELECT `MetricName` AS `MetricName`, mapFilter((k, v) -> v != '', if(match(`Attributes`[?], ?), mapUpdate(`Attributes`, map(?, if(empty(`Attributes`[?]), ?, concat(?, arrayFirst((x, p) -> p != ?, [extractGroups(`Attributes`[?], ?)[?], extractGroups(`Attributes`[?], ?)[?]], [extractGroups(`Attributes`[?], ?)[?], extractGroups(`Attributes`[?], ?)[?]]))))), `Attributes`)) AS `Attributes`, `TimeUnix` AS `TimeUnix`, `Value` AS `Value` FROM (SELECT ? AS `MetricName`, map(?, `gkey_0`) AS `Attributes`, now64(?) AS `TimeUnix`, `Value` AS `Value` FROM (SELECT `ResourceAttributes`[?] AS `gkey_0`, sum(`Value`) AS `Value` FROM (SELECT `ResourceAttributes`, toFloat64(count()) AS `Value` FROM (SELECT mapSort(mapConcat(`ResourceAttributes`, mapFilter((k, v) -> (v != ?), map(?, multiIf((lower(multiIf((`LogAttributes`[?] != ?), `LogAttributes`[?], (`LogAttributes`[?] != ?), `LogAttributes`[?], (`LogAttributes`[?] != ?), `LogAttributes`[?], (`LogAttributes`[?] != ?), `LogAttributes`[?], (`LogAttributes`[?] != ?), `LogAttributes`[?], `SeverityText`)) = ?), ?, ((lower(multiIf((`LogAttributes`[?] != ?), `LogAttributes`[?], (`LogAttributes`[?] != ?), `LogAttributes`[?], (`LogAttributes`[?] != ?), `LogAttributes`[?], (`LogAttributes`[?] != ?), `LogAttributes`[?], (`LogAttributes`[?] != ?), `LogAttributes`[?], `SeverityText`)) = ?) OR (lower(multiIf((`LogAttributes`[?] != ?), `LogAttributes`[?], (`LogAttributes`[?] != ?), `LogAttributes`[?], (`LogAttributes`[?] != ?), `LogAttributes`[?], (`LogAttributes`[?] != ?), `LogAttributes`[?], (`LogAttributes`[?] != ?), `LogAttributes`[?], `SeverityText`)) = ?)), ?, ((lower(multiIf((`LogAttributes`[?] != ?), `LogAttributes`[?], (`LogAttributes`[?] != ?), `LogAttributes`[?], (`LogAttributes`[?] != ?), `LogAttributes`[?], (`LogAttributes`[?] != ?), `LogAttributes`[?], (`LogAttributes`[?] != ?), `LogAttributes`[?], `SeverityText`)) = ?) OR (lower(multiIf((`LogAttributes`[?] != ?), `LogAttributes`[?], (`LogAttributes`[?] != ?), `LogAttributes`[?], (`LogAttributes`[?] != ?), `LogAttributes`[?], (`LogAttributes`[?] != ?), `LogAttributes`[?], (`LogAttributes`[?] != ?), `LogAttributes`[?], `SeverityText`)) = ?)), ?, (((lower(multiIf((`LogAttributes`[?] != ?), `LogAttributes`[?], (`LogAttributes`[?] != ?), `LogAttributes`[?], (`LogAttributes`[?] != ?), `LogAttributes`[?], (`LogAttributes`[?] != ?), `LogAttributes`[?], (`LogAttributes`[?] != ?), `LogAttributes`[?], `SeverityText`)) = ?) OR (lower(multiIf((`LogAttributes`[?] != ?), `LogAttributes`[?], (`LogAttributes`[?] != ?), `LogAttributes`[?], (`LogAttributes`[?] != ?), `LogAttributes`[?], (`LogAttributes`[?] != ?), `LogAttributes`[?], (`LogAttributes`[?] != ?), `LogAttributes`[?], `SeverityText`)) = ?)) OR (lower(multiIf((`LogAttributes`[?] != ?), `LogAttributes`[?], (`LogAttributes`[?] != ?), `LogAttributes`[?], (`LogAttributes`[?] != ?), `LogAttributes`[?], (`LogAttributes`[?] != ?), `LogAttributes`[?], (`LogAttributes`[?] != ?), `LogAttributes`[?], `SeverityText`)) = ?)), ?, (((lower(multiIf((`LogAttributes`[?] != ?), `LogAttributes`[?], (`LogAttributes`[?] != ?), `LogAttributes`[?], (`LogAttributes`[?] != ?), `LogAttributes`[?], (`LogAttributes`[?] != ?), `LogAttributes`[?], (`LogAttributes`[?] != ?), `LogAttributes`[?], `SeverityText`)) = ?) OR (lower(multiIf((`LogAttributes`[?] != ?), `LogAttributes`[?], (`LogAttributes`[?] != ?), `LogAttributes`[?], (`LogAttributes`[?] != ?), `LogAttributes`[?], (`LogAttributes`[?] != ?), `LogAttributes`[?], (`LogAttributes`[?] != ?), `LogAttributes`[?], `SeverityText`)) = ?)) OR (lower(multiIf((`LogAttributes`[?] != ?), `LogAttributes`[?], (`LogAttributes`[?] != ?), `LogAttributes`[?], (`LogAttributes`[?] != ?), `LogAttributes`[?], (`LogAttributes`[?] != ?), `LogAttributes`[?], (`LogAttributes`[?] != ?), `LogAttributes`[?], `SeverityText`)) = ?)), ?, ((lower(multiIf((`LogAttributes`[?] != ?), `LogAttributes`[?], (`LogAttributes`[?] != ?), `LogAttributes`[?], (`LogAttributes`[?] != ?), `LogAttributes`[?], (`LogAttributes`[?] != ?), `LogAttributes`[?], (`LogAttributes`[?] != ?), `LogAttributes`[?], `SeverityText`)) = ?) OR (lower(multiIf((`LogAttributes`[?] != ?), `LogAttributes`[?], (`LogAttributes`[?] != ?), `LogAttributes`[?], (`LogAttributes`[?] != ?), `LogAttributes`[?], (`LogAttributes`[?] != ?), `LogAttributes`[?], (`LogAttributes`[?] != ?), `LogAttributes`[?], `SeverityText`)) = ?)), ?, (lower(multiIf((`LogAttributes`[?] != ?), `LogAttributes`[?], (`LogAttributes`[?] != ?), `LogAttributes`[?], (`LogAttributes`[?] != ?), `LogAttributes`[?], (`LogAttributes`[?] != ?), `LogAttributes`[?], (`LogAttributes`[?] != ?), `LogAttributes`[?], `SeverityText`)) = ?), ?, (lower(multiIf((`LogAttributes`[?] != ?), `LogAttributes`[?], (`LogAttributes`[?] != ?), `LogAttributes`[?], (`LogAttributes`[?] != ?), `LogAttributes`[?], (`LogAttributes`[?] != ?), `LogAttributes`[?], (`LogAttributes`[?] != ?), `LogAttributes`[?], `SeverityText`)) = ?), ?, lower(multiIf((`LogAttributes`[?] != ?), `LogAttributes`[?], (`LogAttributes`[?] != ?), `LogAttributes`[?], (`LogAttributes`[?] != ?), `LogAttributes`[?], (`LogAttributes`[?] != ?), `LogAttributes`[?], (`LogAttributes`[?] != ?), `LogAttributes`[?], `SeverityText`))), ?, if(mapContains(`LogAttributes`, ?), `LogAttributes`[?], `ResourceAttributes`[?]))))) AS `ResourceAttributes`, `Timestamp`, ? AS `Value` FROM (SELECT * FROM `otel_logs` WHERE (`ResourceAttributes`[?] = ?))) WHERE `Timestamp` > now64(9) - toIntervalNanosecond(300000000000) AND `Timestamp` <= now64(9) GROUP BY `ResourceAttributes`) GROUP BY `gkey_0`))

--- a/test/spec/promql/label_replace_probed_shared_capture_name.txtar
+++ b/test/spec/promql/label_replace_probed_shared_capture_name.txtar
@@ -1,0 +1,108 @@
+# A capture-group NAME two groups carry where the first carrier is
+# NULLABLE and a match can SKIP it entirely — the shape that was rejected
+# outright until cerberus learned to rewrite the regex.
+#
+# Go's ExpandString resolves `$dup` to the first carrier that TOOK PART in
+# the row's match, and ClickHouse's `extractGroups` cannot report
+# participation: a group that took no part and a group that took part
+# matching the empty string are both `''`. The other two fixtures for this
+# name escape that by never letting the ambiguity arise — every carrier
+# non-empty (label_replace_shared_capture_name.txtar), or the carriers in
+# exclusive alternation branches
+# (label_replace_nullable_shared_capture_name.txtar). Here it really does
+# arise, and is answered anyway.
+#
+# The two middle rows are the entire point, because their capture arrays
+# are IDENTICAL and their correct answers are not:
+#
+#   - `web--77` enters the optional group — "web-" and the trailing "-"
+#     both matched — and `dup` captured NOTHING between them. Group one
+#     TOOK PART, so ExpandString expands `$dup` to `""` and Prometheus
+#     answers `service="svc-"`.
+#   - `77` never enters the optional group at all, so group one took no
+#     part and `$dup` resolves to group two: `service="svc-77"`.
+#
+# `extractGroups` returns `['', '77']` for BOTH. No search over those two
+# values can answer `svc-` for one and `svc-77` for the other, which is
+# why a first-non-empty search gets `web--77` wrong.
+#
+# The rewrite makes the difference readable. `(?:web-(?P<dup>[a-z]*)-)?`
+# has a body that cannot match empty, so wrapping it in a synthetic group
+# gives a capture that is non-empty exactly when the optional group was
+# entered — which is exactly when carrier one took part. The emitted
+# search reads that group and answers with the carrier beside it, which is
+# what `probedRegex` and the `$2@$1` segment below record.
+#
+# `web-alpha-77` is the ordinary case, and `77` the skipped one, so all
+# three branches of the search are exercised. Issue #1956 tracks the
+# residue this does NOT reach: a carrier with no such body to wrap.
+
+-- query.promql --
+label_replace(temperature, "service", "svc-$dup", "host", "(?:web-(?P<dup>[a-z]*)-)?(?P<dup>[0-9]+)")
+-- parity --
+oracle: prometheus
+endpoint: /api/v1/query
+scope: full
+-- seed --
+CREATE TABLE otel_metrics_gauge (
+    MetricName String,
+    Attributes Map(String, String),
+    TimeUnix DateTime64(9),
+    Value Float64
+) ENGINE = MergeTree ORDER BY (MetricName, Attributes, TimeUnix);
+INSERT INTO otel_metrics_gauge VALUES
+    ('temperature', map('host', 'web-alpha-77'), toDateTime64('2026-01-01 00:00:00', 9), 22.5),
+    ('temperature', map('host', 'web--77'), toDateTime64('2026-01-01 00:00:00', 9), 21.5),
+    ('temperature', map('host', '77'), toDateTime64('2026-01-01 00:00:00', 9), 19.5);
+-- expected_rows --
+[
+  ["temperature", {"host": "77", "service": "svc-77"}, "2026-01-01T00:00:00Z", 19.5],
+  ["temperature", {"host": "web--77", "service": "svc-"}, "2026-01-01T00:00:00Z", 21.5],
+  ["temperature", {"host": "web-alpha-77", "service": "svc-alpha"}, "2026-01-01T00:00:00Z", 22.5]
+]
+-- args --
+[0] string = "host"
+[1] string = "^(?s:(?:web-(?P<dup>[a-z]*)-)?(?P<dup>[0-9]+))$"
+[2] string = "service"
+[3] string = "host"
+[4] string = "svc-"
+[5] string = "svc-"
+[6] string = ""
+[7] string = "host"
+[8] string = "^(?s:(?:(?P<cerberusprobe0>web-(?P<dup>[a-z]*)-))?(?P<dup>[0-9]+))$"
+[9] int64 = 2
+[10] string = "host"
+[11] string = "^(?s:(?:(?P<cerberusprobe0>web-(?P<dup>[a-z]*)-))?(?P<dup>[0-9]+))$"
+[12] int64 = 3
+[13] string = "host"
+[14] string = "^(?s:(?:(?P<cerberusprobe0>web-(?P<dup>[a-z]*)-))?(?P<dup>[0-9]+))$"
+[15] int64 = 1
+[16] string = "host"
+[17] string = "^(?s:(?:(?P<cerberusprobe0>web-(?P<dup>[a-z]*)-))?(?P<dup>[0-9]+))$"
+[18] int64 = 3
+[19] string = "service.name"
+[20] string = "service_name"
+[21] string = "service.name"
+[22] string = "service_name"
+[23] string = ""
+[24] string = "service_name"
+[25] string = "temperature"
+[26] string = "2026-01-01 00:00:01.000000000"
+[27] int64 = 9
+[28] string = "2026-01-01 00:00:01.000000000"
+[29] int64 = 9
+[30] int64 = 300000000000
+[31] int64 = 1
+[32] int64 = 0
+-- chplan --
+Project [MetricName, Attributes, TimeUnix, Value]
+  Aggregate groupBy=[Attributes AS Attributes, MetricName AS MetricName] funcs=[any(Value) AS Value, any(TimeUnix) AS TimeUnix] having=(throwIf((count() > 1), "vector cannot contain metrics with the same labelset") = 0)
+    Project [MetricName, labelReplace(Attributes, dst="service", replacement="", src="host", regex="(?:web-(?P<dup>[a-z]*)-)?(?P<dup>[0-9]+)", emptyReplacement="svc-", probedRegex="(?:(?P<cerberusprobe0>web-(?P<dup>[a-z]*)-))?(?P<dup>[0-9]+)", segments=["svc-", $2@$1|$3]) AS Attributes, TimeUnix, Value]
+      Project [MetricName AS MetricName, Attributes AS Attributes, lwr_ts AS TimeUnix, lwr_value AS Value]
+        Aggregate groupBy=[MetricName AS MetricName, Attributes AS Attributes] funcs=[max(TimeUnix) AS lwr_ts, argMax(Value, TimeUnix) AS lwr_value]
+          Filter predicate=((TimeUnix <= toDateTime64("2026-01-01 00:00:01.000000000", 9)) AND (TimeUnix > (toDateTime64("2026-01-01 00:00:01.000000000", 9) - toIntervalNanosecond(300000000000))))
+            Project [MetricName AS MetricName, mapSort(mapConcat(mapUpdate(mapFromArrays(arrayMap(k -> replaceRegexpAll(k, "[^a-zA-Z0-9_]", "_"), mapKeys(mapFilter((k, v) -> (k NOT IN ("service.name", "service_name")), ResourceAttributes))), mapValues(mapFilter((k, v) -> (k NOT IN ("service.name", "service_name")), ResourceAttributes))), mapFromArrays(arrayMap(k -> replaceRegexpAll(k, "[^a-zA-Z0-9_]", "_"), mapKeys(Attributes)), mapValues(Attributes))), mapFilter((k, v) -> (v != ""), map("service_name", toString(ServiceName))))) AS Attributes, TimeUnix AS TimeUnix, Value AS Value]
+              Filter predicate=(MetricName = "temperature")
+                Scan(merge(otel_metrics_gauge|otel_metrics_sum))
+-- sql --
+SELECT `MetricName`, `Attributes`, `TimeUnix`, `Value` FROM (SELECT `Attributes` AS `Attributes`, `MetricName` AS `MetricName`, any(`Value`) AS `Value`, any(`TimeUnix`) AS `TimeUnix` FROM (SELECT `MetricName`, mapFilter((k, v) -> v != '', if(match(`Attributes`[?], ?), mapUpdate(`Attributes`, map(?, if(empty(`Attributes`[?]), ?, concat(?, arrayFirst((x, p) -> p != ?, [extractGroups(`Attributes`[?], ?)[?], extractGroups(`Attributes`[?], ?)[?]], [extractGroups(`Attributes`[?], ?)[?], extractGroups(`Attributes`[?], ?)[?]]))))), `Attributes`)) AS `Attributes`, `TimeUnix`, `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, `lwr_ts` AS `TimeUnix`, `lwr_value` AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, max(`TimeUnix`) AS `lwr_ts`, argMax(`Value`, `TimeUnix`) AS `lwr_value` FROM (SELECT * FROM (SELECT `MetricName` AS `MetricName`, mapSort(mapConcat(mapUpdate(mapFromArrays(arrayMap(k -> replaceRegexpAll(k, '[^a-zA-Z0-9_]', '_'), mapKeys(mapFilter((k, v) -> (k NOT IN (?, ?)), `ResourceAttributes`))), mapValues(mapFilter((k, v) -> (k NOT IN (?, ?)), `ResourceAttributes`))), mapFromArrays(arrayMap(k -> replaceRegexpAll(k, '[^a-zA-Z0-9_]', '_'), mapKeys(`Attributes`)), mapValues(`Attributes`))), mapFilter((k, v) -> (v != ?), map(?, toString(`ServiceName`))))) AS `Attributes`, `TimeUnix` AS `TimeUnix`, `Value` AS `Value` FROM (SELECT * FROM merge(currentDatabase(), '^(otel_metrics_gauge|otel_metrics_sum)$') PREWHERE (`MetricName` = ?))) WHERE ((`TimeUnix` <= toDateTime64(?, ?)) AND (`TimeUnix` > (toDateTime64(?, ?) - toIntervalNanosecond(?))))) GROUP BY `MetricName`, `Attributes`))) GROUP BY `Attributes`, `MetricName` HAVING (throwIf((count() > ?), 'vector cannot contain metrics with the same labelset') = ?))


### PR DESCRIPTION
## What

`label_replace` rejected every shared-capture-name shape whose answer turned on
whether a group **took part** in the match. This recovers most of them by
rewriting the regex instead of reasoning harder about it.

Go's `ExpandString` expands `$name` to the first carrier that took part.
ClickHouse's `extractGroups` renders "took part matching empty" and "took no
part" identically as `''`, so participation is not readable back — and a
first-non-empty search answers with the wrong carrier on exactly the rows where
the two differ.

The bit is recoverable structurally. Walk up from the carrier to the nearest
span that (a) cannot match the empty string and (b) every match of which passes
through the carrier, and wrap that span in a synthetic capture group. It takes
part exactly when the carrier does, and being non-nullable it is non-empty
exactly when it takes part — so its emptiness **is** the participation bit:

```
(?:x(?P<dup>a?))?(?P<dup>b)
(?:(?P<cerberusprobe0>x(?P<dup>a?)))?(?P<dup>b)
```

The selection emits as `arrayFirst((x, p) -> p != '', [values], [probes])`: the
predicate reads the participation array, the answer comes from the value array.

## Acceptance delta

Exhaustive shared-capture-name corpus, extended here with the literal-bearing
alternation shapes the rewrite turns on. Same methodology as #2116 — every
accepted regex is checked against Go's `ExpandString` on every input over the
alphabet, exactly, with no tolerance.

| | regexes | accepted | share |
|---|---:|---:|---:|
| before | 11907 | 6912 | 58.0% |
| after | 11907 | 8417 | 70.7% |

1505 regexes are accepted **only** because of a probe rewrite, and a test fails
if that count is ever zero — a change that silently stopped planning probes
would otherwise stay green while handing the capability back.

## Why the rewrite is safe

Locating spans needs byte offsets, which `regexp/syntax` does not record. Rather
than mutate a parse tree and serialise it back through `Regexp.String()` — which
would stake a user's query semantics on that printer — the spans are found by
scanning the **source**, and every judgement about a span is made by handing the
substring back to `regexp/syntax`. The parse tree stays the authority on
meaning; the scanner only ever answers "which bytes", and fails closed on
anything it does not model.

Evidence, beyond the answer differential:

- **Language preservation**, span by span: for all 1505 rewritten regexes, the
  rewritten pattern matches the same strings and captures the same text into
  every group the user wrote. An answer differential cannot reach this — a
  rewrite that changed the language would still agree on the inputs both happen
  to match, while silently dropping or admitting rows on the rest.
- **Span invariants**, checked directly on all 19066 spans the corpus makes the
  planner choose, so they hold for the stated reason rather than by luck.
- **Adversarial pass**: each of the two span tests is dropped in turn and the
  corpus is required to produce a concrete disagreement with Go. Both do, so the
  corpus is known to be sensitive to each individually.
- **Real ClickHouse execution** of the emitted SQL. The two-array `arrayFirst`
  contract — predicate over the second array, result from the first — is a CH
  one that no Go-side differential reaches; if CH returned the element the
  predicate ran over, every other test here would still pass.

## End-to-end coverage

Both heads gain a seeded, parity-enrolled fixture
(`label_replace_probed_shared_capture_name.txtar`, `oracle: prometheus` /
`oracle: loki`), so the rewritten shape is differentialled against the reference
backends rather than only against cerberus's own output. It is also what makes
the golden printer's `probedRegex=` and `$2@$1` cells reachable — they were dead
in the corpus otherwise.

The fixture is chosen for one property: hosts `web--77` and `77` produce
**identical** capture arrays `['', '77']` and different correct answers
(`svc-` and `svc-77`). No search over those two values can be right for both,
which is precisely what the probe fixes, and precisely what a fixture asserting
only "the query answers" would miss.

## Hazards found and closed

**Inline flag rescoping.** A bare `(?flags)` setting applies to the end of its enclosing group,
**crossing alternation branches**. Wrapping one branch confines it, so
`(?:(?i)a|b)` matches `"B"` before a rewrite and not after — a genuine language
change. Patterns carrying one are never rewritten, and the hazard is pinned as a
running test so any future relaxation has to confront it. The scoped `(?flags:…)`
spelling carries its setting with it and stays allowed.

**Probe renumbering reaching the template path.** A rewrite renumbers every
group, while `replaceRegexpOne`'s substitution string is applied against the
ORIGINAL regex — so `$1` rendered as `\2` and substituted the wrong group's
text. Resolution now runs unrewritten first and only retries with a rewrite when
that fails, and a rewritten decomposition can never take the substitution-string
form. Both halves are asserted.

**`\Q…\E` mis-scanned.** The quoted run was read as a two-byte escape and its
contents scanned as pattern, so a parenthesis inside literal text was counted as
a capture group — a fail-open in a component whose contract is to decline rather
than guess.

**Overlapping spans silently re-nested.** `insertProbes` applied its edits in one
forward pass, so a pair of spans that merely overlapped bracketed two different
ranges than the ones asked for. Spans must now be pairwise nested or disjoint.

## What stays rejected

A carrier with no such span anywhere above it — alone in a nullable alternation
branch, or alone under a quest — where nothing is guaranteed to be consumed when
it takes part. The head tests and both rejection-parity catalogue triggers move
to `(?:(?P<dup>a?)|y)(?P<dup>b)`, which is that shape, and each still carries a
concrete divergence witness.

This narrows #1956; that issue stays open and now records the two further
mechanisms I measured against the remainder. Upstream,
ClickHouse/ClickHouse#114733 tracks the `extractGroups` gap that would remove the
need for any of this — filed as part of this work, with no existing duplicate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
