### PR TITLE
fix(test): pin the cardinality fan-out's test names so a rename cannot no-op it

### DIFF
--- a/.github/scripts/cardinality-baseline-update.mjs
+++ b/.github/scripts/cardinality-baseline-update.mjs
@@ -79,6 +79,13 @@ import { runAllTagged } from './lib/spawn-tagged.mjs';
  * exactly one leg at any N, so N legs at count N always cover the tree, whatever
  * N the tree was last written at. Matching is what keeps the balance floor
  * measured at a split somebody actually runs.
+ *
+ * What this asks of the host is N concurrent in-process ClickHouse engines —
+ * each leg stands up its own chdb session, where the serial pass stood up one.
+ * A host too small for that loses a leg to the OOM killer, which fails loudly
+ * and is safe to recover from: a leg only ever rewrites its own slice, so
+ * re-running the recipe is idempotent. CARDINALITY_BASELINE_FANOUT is the lever
+ * for a smaller machine.
  */
 const BASELINE_FANOUT = 8;
 

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -228,7 +228,8 @@ other 7/8 as removed fixtures and leave a tree that still parses.
 `baselineShards.writeShard` scopes the prune to the leg's own slice — a leg
 deletes a stale file only when the file's key hashes to the leg's index — so leg
 `i` can only touch paths leg `i` is also the only writer of, and N legs at count
-N reproduce the serial pass byte for byte.
+N reproduce the serial pass byte for byte, modulo the empty directories a leg
+deliberately leaves behind (git tracks files, so those never reach the artefact).
 `just update-cardinality-baseline` therefore fans the profile pass out across the
 same 8 legs, through `.github/scripts/cardinality-baseline-update.mjs`, and
 closes with a step that re-derives the corpus roster from a TXTAR walk and

--- a/test/perf/baseline_shards_roundtrip_test.go
+++ b/test/perf/baseline_shards_roundtrip_test.go
@@ -319,9 +319,15 @@ func TestBaselineShardsShardedWriteRefusesForeignRecords(t *testing.T) {
 //
 // Both trees start from a stale roster, so the comparison covers pruning as well
 // as writing — the half a "sharded regeneration" gets wrong is the half that
-// deletes. Running the legs as real goroutines rather than in sequence is what
-// puts the concurrent walk (a sibling unlinking its own file mid-walk) under the
-// race detector instead of leaving it to the first real regeneration.
+// deletes.
+//
+// The legs run as real goroutines rather than in sequence to exercise the
+// FILESYSTEM interleaving they meet in production: concurrent MkdirAll, WriteFile,
+// Remove and WalkDir against one tree. That is the part `-race` cannot speak to —
+// the legs share no mutable Go state (the store is a value with no field written,
+// and each leg owns its own index of errs), so the detector has nothing to
+// instrument here. Sequencing them would leave the interleaving untested until
+// the first real regeneration.
 func TestBaselineShardsShardedWriteMatchesTheWholeCorpusWrite(t *testing.T) {
 	t.Parallel()
 
@@ -370,6 +376,52 @@ func TestBaselineShardsShardedWriteMatchesTheWholeCorpusWrite(t *testing.T) {
 		if _, ok := want[path]; !ok {
 			t.Errorf("%s is in the sharded tree and not in the serial one — a leg failed to prune it", path)
 		}
+	}
+}
+
+// TestBaselineShardsShardedWriteOwnsFilesAtUnEXPECTEDDepths pins the totality
+// the fan-out's completeness rests on.
+//
+// A leg prunes a stale file only when it OWNS the file's key, so the argument
+// that N legs together clear every stale file needs the partition to be total
+// over whatever keys are on disk — not merely over the keys a generator would
+// produce. `spec.ShardOf` hashes an arbitrary string, so a file at the wrong
+// depth (a leftover from a tree whose shape changed, or a hand-dropped file) is
+// still owned by exactly one leg. Were it owned by NONE, it would survive every
+// sharded regeneration while a whole-corpus one removed it — a stale row the
+// ratchet keeps honouring, visible only when somebody happened to run unsharded.
+func TestBaselineShardsShardedWriteOwnsFilesAtUnexpectedDepths(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	s := probeShards(dir, 2)
+	corpus := probeCorpus(8)
+	s.mustWrite(t, probes(corpus...))
+
+	// Depth 1 in a depth-2 tree: no key the generator emits maps here.
+	stray := filepath.Join(dir, "stray.json")
+	if err := os.WriteFile(stray, []byte("{}\n"), shardFilePerm); err != nil {
+		t.Fatalf("plant stray shard: %v", err)
+	}
+
+	removedBy := 0
+	for i := range probeShardCount {
+		leg := spec.Shard{Index: i + 1, Count: probeShardCount}
+		if err := s.writeShard(spec.FilterShardMap(leg, probes(corpus...)), leg); err != nil {
+			t.Fatalf("leg %d of %d failed: %v", i+1, probeShardCount, err)
+		}
+		if _, err := os.Stat(stray); os.IsNotExist(err) && removedBy == 0 {
+			removedBy = i + 1
+		}
+	}
+
+	if removedBy == 0 {
+		t.Errorf("a stray shard at an unexpected depth survived all %d legs — it is owned by no leg, "+
+			"so no sharded regeneration can ever remove it", probeShardCount)
+	}
+	if want := spec.ShardOf(keyFor("stray.json"), probeShardCount); removedBy != want {
+		t.Errorf("the stray was removed by leg %d, but its key is owned by leg %d — prune is not "+
+			"scoping by the same partition the corpus is split on", removedBy, want)
 	}
 }
 

--- a/test/perf/baseline_shards_test.go
+++ b/test/perf/baseline_shards_test.go
@@ -220,20 +220,19 @@ func (s baselineShards[T]) write(entries map[string]T) error {
 // writer of. Legs therefore touch disjoint path sets and never race for a file,
 // and the union of N legs at count N is byte-for-byte the single whole-corpus
 // pass — every key on disk belongs to exactly one leg, so every stale file is
-// some leg's to remove.
+// some leg's to remove. "Every key" is literal rather than approximate:
+// [spec.ShardOf] is total over strings, so even a file at an unexpected depth,
+// whose key no generator would produce, is still owned by exactly one leg and
+// pruned by it. Nothing on disk can end up owned by nobody.
 //
 // Without that scoping a leg's prune walks the whole tree and deletes the other
 // N-1 legs' rows as "no longer in the corpus" — the hazard that made a sharded
 // regeneration impossible, and the reason the ratchet's update path used to
 // refuse a partial corpus outright.
 //
-// Two smaller concessions to running beside live siblings, both no-ops when the
-// shard is whole:
+// One concession to running beside live siblings, a no-op when the shard is
+// whole:
 //
-//   - the walk tolerates an entry that vanishes under it, because a sibling
-//     pruning ITS OWN stale file can remove a path between this leg's readdir
-//     and its lstat. A path that disappeared is by construction not this leg's
-//     to prune — only its owner deletes it — so skipping it loses nothing.
 //   - empty directories are left alone. Removing one races a sibling that is
 //     between MkdirAll and WriteFile inside it, and an empty directory is not
 //     part of the artefact anyway: git tracks files, so an empty directory left
@@ -301,15 +300,15 @@ func (s baselineShards[T]) prune(want map[string]struct{}, shard spec.Shard) err
 	var stale []string
 	var dirs []string
 
+	// A file a sibling leg unlinks mid-walk needs no tolerance here:
+	// [filepath.WalkDir] surfaces an error from exactly two places — the
+	// os.Lstat of the ROOT, and an os.ReadDir of a directory — and os.ReadDir
+	// already drops an entry that disappeared between the readdir and the stat.
+	// Swallowing fs.ErrNotExist at this callback would therefore not cover the
+	// concurrent case at all; the only thing it could reach is a missing tree
+	// root, which must fail loudly rather than prune nothing and exit 0.
 	err := filepath.WalkDir(s.dir, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
-			// A sibling leg pruning its own stale file can unlink a path
-			// between this walk's readdir and its lstat. Only the owning leg
-			// deletes a path, so one that vanished was never this leg's.
-			if !shard.IsWhole() && errors.Is(err, fs.ErrNotExist) {
-				return nil
-			}
-
 			return err
 		}
 		if d.IsDir() {

--- a/test/perf/cardinality_ratchet_test.go
+++ b/test/perf/cardinality_ratchet_test.go
@@ -374,8 +374,8 @@ func TestCardinalityRatchet(t *testing.T) {
 	}
 	for _, id := range removed {
 		t.Errorf("baseline fixture %q no longer in the corpus (%v) — run `just update-cardinality-baseline` "+
-			"to drop the stale row. Regeneration is always whole-corpus, so run it without "+
-			"%s/%s set.", id, shard, profile.ShardIndexEnv, profile.ShardCountEnv)
+			"to drop the stale row. The recipe fans out and sets %s/%s itself, one value per leg; "+
+			"nothing needs setting by hand.", id, shard, profile.ShardIndexEnv, profile.ShardCountEnv)
 	}
 
 	// Per-fixture upward-regression ratchet over the matched set.

--- a/test/perf/profile/metadata.go
+++ b/test/perf/profile/metadata.go
@@ -283,10 +283,17 @@ type metadataFixture struct {
 	args  []any
 }
 
-// captureMetadataFixtures drives the three windowless metadata endpoints
-// named in issue #1530 and returns the dominant captured SQL statement for
-// each, paired with a fixture id under the "metadata/" namespace (parallel
-// to the "<head>/<name>" TXTAR ids ProfileCorpus uses).
+// metadataFixtureSpecs is the roster of the three windowless metadata endpoints
+// named in issue #1530: the fixture id each is recorded under — in the
+// "metadata/" namespace, parallel to the "<head>/<name>" TXTAR ids ProfileCorpus
+// uses — and the request that produces it.
+//
+// It is a package-level var rather than a local inside
+// [captureMetadataFixtures] so the ids can be read without standing an HTTP
+// handler up and profiling it ([MetadataFixtureIDs]). The baseline's
+// completeness check needs to know which rows the tree must hold, which is a
+// question about names — deriving those names by running the profiler would make
+// the cheap check as expensive as the thing it checks.
 //
 //   - metadata/series_no_bounds — GET /api/v1/series?match[]=up. Requires
 //     match[] (the endpoint 400s without one — internal/api/prom/metadata.go's
@@ -301,21 +308,6 @@ type metadataFixture struct {
 //   - metadata/label_values_no_bounds — GET /api/v1/label/job/values. No
 //     match[], no bounds: the catalog-wide label-value enumeration
 //     (unionLabelValuesSQL) for an ordinary Attributes-map key.
-//
-// Each capture takes the LAST recorded statement: the single-matcher /
-// single-arm fast paths these requests hit (metadataUpMetric has no
-// dotted/underscored form to expand, and the resource arm is disabled)
-// issue exactly one statement, so "last" is simply "the" statement; taking
-// the last rather than indexing [0] keeps this robust if a future matcher
-// expansion adds a leading catalog lookup ahead of the sample query.
-// metadataFixtureSpecs is the ROSTER half of the three fixtures above: the id
-// each one is recorded under and the request that produces it.
-//
-// It is a package-level var rather than a local so the ids can be read without
-// standing an HTTP handler up and profiling it ([MetadataFixtureIDs]). The
-// baseline's completeness check needs to know which rows the tree must hold,
-// which is a question about names — deriving those names by running the
-// profiler would make the cheap check as expensive as the thing it checks.
 var metadataFixtureSpecs = []struct {
 	id   string
 	path string
@@ -338,6 +330,16 @@ func MetadataFixtureIDs() []string {
 	return out
 }
 
+// captureMetadataFixtures drives every endpoint in [metadataFixtureSpecs] and
+// returns the dominant captured SQL statement for each, paired with its
+// fixture id.
+//
+// Each capture takes the LAST recorded statement: the single-matcher /
+// single-arm fast paths these requests hit (metadataUpMetric has no
+// dotted/underscored form to expand, and the resource arm is disabled)
+// issue exactly one statement, so "last" is simply "the" statement; taking
+// the last rather than indexing [0] keeps this robust if a future matcher
+// expansion adds a leading catalog lookup ahead of the sample query.
 func captureMetadataFixtures() []metadataFixture {
 	specs := metadataFixtureSpecs
 	out := make([]metadataFixture, 0, len(specs))

--- a/test/regression/cardinality_baseline_fanout_test.go
+++ b/test/regression/cardinality_baseline_fanout_test.go
@@ -46,6 +46,12 @@ const cardinalitySealTest = "TestCardinalityBaselineCoversTheCorpus"
 // cardinalityRatchetTest is the profiling step every leg runs.
 const cardinalityRatchetTest = "TestCardinalityRatchet"
 
+// cardinalityRatchetSourcePath holds both of those test functions. The plan
+// names them as `-run` REGEXES, and `go test -run '^NoSuchTest$'` prints "no
+// tests to run" and exits 0 — so the names have to be pinned against the source
+// that defines them, not only against the plan text that mentions them.
+const cardinalityRatchetSourcePath = "../perf/cardinality_ratchet_test.go"
+
 // cardinalityUpdatePlan asks the runner for the ordered regeneration plan it
 // would execute. One line per step: `<label> <ENV=v>... <command>`.
 //
@@ -57,7 +63,12 @@ func cardinalityUpdatePlan(t *testing.T) []string {
 
 	cmd := exec.Command("node", cardinalityUpdateModule)
 	cmd.Dir = repoRootFromRegression
-	cmd.Env = append(os.Environ(), "CARDINALITY_UPDATE_PRINT_PLAN=1")
+	// CARDINALITY_BASELINE_FANOUT is cleared, not merely left unset: it is a
+	// documented override, so a developer who exported it to measure the split
+	// on their own machine would otherwise see this pin fail against a leg count
+	// nobody committed. An empty value falls through the runner's `if (!raw)`
+	// back to the compiled-in default, which is the number under test.
+	cmd.Env = append(os.Environ(), "CARDINALITY_UPDATE_PRINT_PLAN=1", "CARDINALITY_BASELINE_FANOUT=")
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		var exitErr *exec.ExitError
@@ -205,6 +216,36 @@ func TestCardinalityBaselinePlanSealsTheFanOut(t *testing.T) {
 	if len(legs) > 0 && sealAt < lastLegAt {
 		t.Errorf("the seal runs at plan step %d, before the last profiling leg at step %d. It would "+
 			"then assert the PREVIOUS regeneration's tree.\n%s", sealAt, lastLegAt, strings.Join(plan, "\n"))
+	}
+}
+
+// TestCardinalityPlanNamesTestsThatExist closes the gap between the plan's
+// `-run` regexes and the Go functions they are supposed to select.
+//
+// `go test -run '^NoSuchTest$' ./pkg/` prints "no tests to run" and exits **0**.
+// Every other assertion in this file matches those names against the plan TEXT,
+// which a rename satisfies on both sides at once, so on its own the pin cannot
+// see the failure it most needs to:
+//
+//   - rename the seal and the closing step passes vacuously — the fan-out keeps
+//     its only check that a leg never ran, in name only.
+//   - rename the ratchet and all N legs no-op, the seal then passes over the
+//     untouched (still-matching) tree, and `just update-cardinality-baseline`
+//     becomes a complete no-op that exits 0 and prints an empty diff — which
+//     reads exactly like "no drift".
+//
+// Both are the repo's hollow-green class: a lane that reports success while
+// measuring nothing.
+func TestCardinalityPlanNamesTestsThatExist(t *testing.T) {
+	t.Parallel()
+
+	src := readFileString(t, cardinalityRatchetSourcePath)
+	for _, name := range []string{cardinalityRatchetTest, cardinalitySealTest} {
+		if !strings.Contains(src, "func "+name+"(") {
+			t.Errorf("the regeneration plan selects %q with `go test -run`, but %s defines no such "+
+				"function. `-run` matching nothing exits 0 after running nothing, so this renames a "+
+				"step into a no-op that still reports success.", name, cardinalityRatchetSourcePath)
+		}
 	}
 }
 


### PR DESCRIPTION
## What

Review follow-ups to #2123, which sharded the cardinality baseline's write path so `just update-cardinality-baseline` fans out. The mechanism itself held up under review — the partition mapping, the `N=1` no-op claim and the seal's roster derivation all verified — but the review found one **hollow-green** gap and three smaller defects in the surface around it. Fixing them here rather than leaving them on `main`.

## The hollow-green gap

The regeneration plan selects its steps with `go test -run` **regexes**, and `go test -run '^NoSuchTest$'` prints `no tests to run` and exits **0**. Every assertion pinning those names matched them against the plan *text* — which a rename satisfies on both sides at once. So:

- rename the seal → the closing step passes vacuously, and the fan-out keeps its only check that a leg never ran **in name only**;
- rename the ratchet → all 8 legs no-op, the seal then passes over the untouched (still-matching) tree, and the whole recipe exits 0 printing an empty diff — which reads exactly like *"no drift"*.

`TestCardinalityPlanNamesTestsThatExist` now matches both names against the source that defines them.

**Verified it can fail** rather than assuming it: renaming `TestCardinalityBaselineCoversTheCorpus` makes it red with the intended message, restoring the name makes it green again.

## The neutralized guard

The prune walk's `fs.ErrNotExist` tolerance was itself a guard that could not fire, and it is removed. `filepath.WalkDir` surfaces an error from exactly two places — the `os.Lstat` of the **root**, and an `os.ReadDir` — and `os.ReadDir` already drops an entry that disappeared between its readdir and its stat. So the branch could never cover the concurrent case its comment described; the only thing it could reach was a **missing tree root**, which it turned into a leg that pruned nothing and exited 0. The comment now records why no tolerance is needed, so it does not get re-added.

## The rest

- **Stale guidance in a live gating failure.** The removed-fixture message still told maintainers *"Regeneration is always whole-corpus, so run it without `PERF_SHARD_INDEX`/`PERF_SHARD_COUNT` set"* — the sentence #2123 made false, in the message a maintainer reads when the gate fires. It now says the recipe sets them itself.
- **Detached godoc.** Hoisting the metadata roster out of `captureMetadataFixtures` left that function's doc comment contiguous with the new var, so godoc attributed it to `metadataFixtureSpecs` — a var documented as a function that "returns the dominant captured SQL statement" — and left the function undocumented. Split so each half sits on what it describes.
- **The plan pin inherited the environment.** `CARDINALITY_BASELINE_FANOUT` is a documented override for measuring the split on a differently shaped machine; a developer who exported it made `TestCardinalityFanOutMatchesTheGoPartition` fail against a leg count nobody committed. The pin now clears it explicitly, which the README already claimed it did.
- **Two comments that overclaimed.** The concurrency test said running the legs as goroutines puts the walk "under the race detector" — but the legs share no mutable Go state, so `-race` has nothing to instrument; its real value is the *filesystem* interleaving, which is now what it says. And `docs/performance.md` asserted "byte for byte" without the empty-directory qualification the code documents.
- **A memory note on the fan-out constant.** 8 legs means 8 concurrent in-process ClickHouse engines where the serial pass stood up one; a host too small loses a leg to the OOM killer, which is loud and idempotent to recover from.

## New coverage

`TestBaselineShardsShardedWriteOwnsFilesAtUnexpectedDepths` pins the **totality** the completeness argument rests on. A leg prunes only keys it owns, so "N legs together clear every stale file" needs the partition to be total over whatever is *on disk*, not just over keys a generator would emit. `spec.ShardOf` hashes an arbitrary string, so a file at the wrong depth is still owned by exactly one leg — were it owned by none, it would survive every sharded regeneration while a whole-corpus one removed it, i.e. a stale row visible only when somebody happened to run unsharded.

## Verification

- `go test -race -run TestBaselineShards ./test/perf/` — green.
- `go test -run 'TestCardinality|TestPerfGuards|TestGoldenUpdate' ./test/regression/` — green.
- The new pin proven to fail on a rename and pass on restore.

No change to the write semantics themselves, so `test/perf/cardinality-baseline/` is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
