### PR TITLE
refactor: collapse mirrored production dispatch onto one classifier, and gate it

### DIFF
--- a/.go-arch-lint.yml
+++ b/.go-arch-lint.yml
@@ -161,6 +161,7 @@ components:
   chdbsession:    { in: chdbsession }
   chsqltest:      { in: chsqltest }
   sealedscan:     { in: sealedscan }
+  dispatchscan:   { in: dispatchscan }
   testsql:        { in: testsql }
   qlcommon:       { in: qlcommon }
   # Clean-room in-house Drain log-template miner (replaces the AGPL
@@ -237,6 +238,13 @@ commonComponents:
   # construction. It imports nothing but the standard library and knows
   # nothing about cerberus, which keeps it a true leaf.
   - sealedscan
+  # dispatchscan is sealedscan's production-side sibling: it derives, from
+  # Go source, the arm sets production code dispatches over the shared IR
+  # (the bool classifiers over a sealed interface, and the string
+  # vocabulary an emitter switch accepts). The mirrored-dispatch ratchet
+  # consumes it. Like sealedscan it imports nothing but the standard
+  # library and knows nothing about cerberus, so it is a true leaf.
+  - dispatchscan
 
 deps:
   # chplan is the foundation. No internal dependencies declared — entries

--- a/internal/api/tempo/metrics_pipeline.go
+++ b/internal/api/tempo/metrics_pipeline.go
@@ -124,6 +124,36 @@ type metricsPipeline struct {
 	compare   *chplan.MetricsCompare
 }
 
+// unwrapMetricsRoot returns the T carried at the plan root, or directly
+// under a single Filter wrapper (kept for forward-compat with a future
+// scalar-filter stage). It reports ok=false for any other shape — the
+// trigger for classifyMetricsPipeline's "not a metrics pipeline"
+// rejection.
+//
+// This is the ONE unwrapper for that question. It was three — one per
+// pipeline kind, each a verbatim copy of the same two-arm switch with
+// only the target type changed, and each carrying a docstring asserting
+// it mirrored the other two's "forward-compat posture". Three copies of
+// one walk is three chances to peel a different set of wrappers: the
+// shape they walk is a property of the PLAN spine, not of the node at
+// the bottom of it, so a wrapper that becomes peelable becomes peelable
+// for every kind at once. Teaching that to one copy and not the others
+// is what left `| topk(N)` rejected as "not a metrics-pipeline
+// expression" until the handler learned to peel MetricsSecondStage
+// (see TestMetricsQueryRange_TopKSecondStage).
+func unwrapMetricsRoot[T chplan.Node](plan chplan.Node) (T, bool) {
+	if v, ok := plan.(T); ok {
+		return v, true
+	}
+	if f, ok := plan.(*chplan.Filter); ok {
+		if inner, ok := f.Input.(T); ok {
+			return inner, true
+		}
+	}
+	var zero T
+	return zero, false
+}
+
 // classifyMetricsPipeline peels the second-stage chain off a lowered plan
 // and identifies the metrics pipeline underneath it. surface and query only
 // shape the rejection: they name the endpoint the caller used and echo the
@@ -135,15 +165,15 @@ type metricsPipeline struct {
 func classifyMetricsPipeline(plan chplan.Node, surface metricsSurface, query string) (metricsPipeline, error) {
 	stages, inner := peelMetricsSecondStages(plan)
 	p := metricsPipeline{Inner: inner, Stages: stages}
-	if m, ok := unwrapMetricsAggregate(inner); ok {
+	if m, ok := unwrapMetricsRoot[*chplan.MetricsAggregate](inner); ok {
 		p.kind, p.scalar = metricsPipelineScalar, m
 		return p, nil
 	}
-	if m, ok := unwrapMetricsHistogram(inner); ok {
+	if m, ok := unwrapMetricsRoot[*chplan.MetricsHistogramOverTime](inner); ok {
 		p.kind, p.histogram = metricsPipelineHistogram, m
 		return p, nil
 	}
-	if m, ok := unwrapMetricsCompare(inner); ok {
+	if m, ok := unwrapMetricsRoot[*chplan.MetricsCompare](inner); ok {
 		p.kind, p.compare = metricsPipelineCompare, m
 		return p, nil
 	}

--- a/internal/api/tempo/metrics_query_range.go
+++ b/internal/api/tempo/metrics_query_range.go
@@ -347,10 +347,6 @@ func parseMetricsStep(raw string) (time.Duration, error) {
 	return d, nil
 }
 
-// unwrapMetricsAggregate returns the MetricsAggregate at the plan root
-// (or directly under a single Filter wrapper, kept for forward-compat
-// with a future scalar-filter stage). Returns ok=false for any other
-// shape — the trigger for the handler's "not a metrics query" 400.
 // peelMetricsSecondStages splits a lowered metrics plan into its
 // MetricsSecondStage chain (outermost first — the order the lowering
 // wrapped them, i.e. reverse source order) and the inner aggregate
@@ -384,18 +380,6 @@ func applyMetricsSecondStages(node chplan.Node, stages []*chplan.MetricsSecondSt
 		node = &ss
 	}
 	return node
-}
-
-func unwrapMetricsAggregate(plan chplan.Node) (*chplan.MetricsAggregate, bool) {
-	switch v := plan.(type) {
-	case *chplan.MetricsAggregate:
-		return v, true
-	case *chplan.Filter:
-		if inner, ok := v.Input.(*chplan.MetricsAggregate); ok {
-			return inner, true
-		}
-	}
-	return nil, false
 }
 
 // tempoMetricNameLabel mirrors the Prometheus-style `__name__` label

--- a/internal/api/tempo/metrics_query_range_compare.go
+++ b/internal/api/tempo/metrics_query_range_compare.go
@@ -64,21 +64,6 @@ const (
 	compareRowValLabel  = "__val"
 )
 
-// unwrapMetricsCompare returns the MetricsCompare at the plan root (or
-// directly under a single Filter wrapper — mirroring
-// unwrapMetricsAggregate's forward-compat posture).
-func unwrapMetricsCompare(plan chplan.Node) (*chplan.MetricsCompare, bool) {
-	switch v := plan.(type) {
-	case *chplan.MetricsCompare:
-		return v, true
-	case *chplan.Filter:
-		if inner, ok := v.Input.(*chplan.MetricsCompare); ok {
-			return inner, true
-		}
-	}
-	return nil, false
-}
-
 // wrapCompareForSample wraps the matrix-shape RangeWindow with the
 // Sample projection the engine's row decoder expects. The cohort flag,
 // attribute name and attribute value ride the Attributes map under the

--- a/internal/api/tempo/metrics_query_range_histogram.go
+++ b/internal/api/tempo/metrics_query_range_histogram.go
@@ -28,21 +28,6 @@ import (
 // are placeholders"), so cerberus ships the empty `Exemplars: []`
 // envelope — the same shape every series gets before attachment.
 
-// unwrapMetricsHistogram returns the MetricsHistogramOverTime at the
-// plan root (or directly under a single Filter wrapper — mirroring
-// unwrapMetricsAggregate's forward-compat posture).
-func unwrapMetricsHistogram(plan chplan.Node) (*chplan.MetricsHistogramOverTime, bool) {
-	switch v := plan.(type) {
-	case *chplan.MetricsHistogramOverTime:
-		return v, true
-	case *chplan.Filter:
-		if inner, ok := v.Input.(*chplan.MetricsHistogramOverTime); ok {
-			return inner, true
-		}
-	}
-	return nil, false
-}
-
 // histogramLabelNames mirrors metricsLabelNames for the histogram node:
 // the user-facing group-by label names (display-name → alias →
 // "group_<i>" fallback chain) with `__bucket` appended — every

--- a/internal/api/tempo/metrics_recursive_window_test.go
+++ b/internal/api/tempo/metrics_recursive_window_test.go
@@ -70,7 +70,7 @@ func lowerMetricsWithWindow(t *testing.T, query string, start, end time.Time) ch
 func wrapMetricsMatrix(t *testing.T, plan chplan.Node, start, end time.Time) chplan.Node {
 	t.Helper()
 	stages, inner := peelMetricsSecondStages(plan)
-	metrics, ok := unwrapMetricsAggregate(inner)
+	metrics, ok := unwrapMetricsRoot[*chplan.MetricsAggregate](inner)
 	if !ok {
 		t.Fatalf("plan is not a metrics aggregate: %T", inner)
 	}

--- a/internal/chplan/range_window_funcs.go
+++ b/internal/chplan/range_window_funcs.go
@@ -1,0 +1,125 @@
+package chplan
+
+import "sort"
+
+// rangeWindowSurfaces records which query-language surfaces can reach a
+// range-window reducer from source. A reducer the emitter supports is not
+// automatically nameable in every head: `log_rate` exists only for LogQL's
+// `rate()` over a log stream, and admitting it to PromQL would accept a
+// function reference no PromQL parser produces.
+type rangeWindowSurfaces struct {
+	// promQL reports whether a PromQL query can name the reducer at
+	// source — i.e. whether the PromQL head may lower a call to it, and
+	// so whether it may carry a subquery argument.
+	promQL bool
+}
+
+// rangeWindowFuncs is the vocabulary of [RangeWindow].Func values: every
+// name the SQL emitter dispatches on, with the surfaces that can reach it.
+//
+// This is the ONE definition of that vocabulary. It was two — the
+// emitter's dispatch in internal/chsql and a hand-written `rangeVectorFn`
+// set in internal/promql that gated whether a function accepts a subquery
+// argument — with a docstring on each pointing at the other and asserting
+// they agreed. They describe one fact: which reducer names the windowed-
+// array emitters handle in both instant and matrix (OuterRange > 0)
+// modes. Two hand-maintained answers to one question drift silently, and
+// the drift is invisible in both directions: a name in the emitter but
+// not the PromQL set rejects a query the SQL could have served, and a
+// name in the PromQL set but not the emitter lowers a plan that fails at
+// emit time with ErrUnsupported instead of a parse-time rejection.
+//
+// The emitter's own name→emit-method dispatch cannot live here — its
+// arms bind to unexported chsql methods, so they are not a value any
+// package can read — and it stays a switch in internal/chsql. The
+// TestRangeWindowVocabularyIsDerived ratchet re-derives that switch's arm
+// set from source (internal/dispatchscan) and diffs it against this
+// vocabulary, in both directions. The PromQL head has no set of its own
+// at all: it derives its gate from [IsPromQLRangeWindowFunc].
+//
+// Membership notes, carried from the set this replaced:
+//
+//   - predict_linear / holt_winters / quantile_over_time carry extra
+//     scalar arguments beyond the subquery itself; the PromQL head
+//     threads them onto the RangeWindow the same way its non-subquery
+//     lowerers do (#1456).
+//   - `double_exponential_smoothing` is absent deliberately. It is a
+//     PromQL SOURCE spelling, not an IR name: the head canonicalises it
+//     to `holt_winters` before the name reaches the IR, so a second entry
+//     here would be a second name for one reducer rather than a second
+//     reducer.
+//   - first_over_time sits beside last_over_time because the two are the
+//     `__name__`-preserving pair: admitting one over a subquery but not
+//     the other would make the name contract unobservable for half of it.
+//   - present_over_time and mad_over_time are plain reducers in the
+//     emitter's shared `emitRangeWindowOverTime` case, carry no extra
+//     scalar, and already lower over a bare matrix selector. Withholding
+//     them would reject `mad_over_time(m[5m:1m])` while accepting
+//     `mad_over_time(m[5m])` — a split reference Prometheus does not
+//     make.
+//   - The four ts_of_*_over_time reducers route through
+//     `emitRangeWindowTsOfOverTime`, which reduces the per-anchor window
+//     array exactly as `emitRangeWindowOverTime` does and is likewise
+//     agnostic about whether the rows underneath came from a matrix
+//     selector or a subquery's anchor grid.
+//
+// A reducer that lowers to its OWN node shape rather than to a
+// RangeWindow — absent_over_time, which becomes an AbsentOverTime — is
+// not in this vocabulary at all, and the heads reject a subquery argument
+// to it through their generic "does not accept a subquery argument" path.
+var rangeWindowFuncs = map[string]rangeWindowSurfaces{
+	"rate":     {promQL: true},
+	"irate":    {promQL: true},
+	"increase": {promQL: true},
+	"delta":    {promQL: true},
+	"idelta":   {promQL: true},
+	"deriv":    {promQL: true},
+	"resets":   {promQL: true},
+
+	"changes":               {promQL: true},
+	"sum_over_time":         {promQL: true},
+	"avg_over_time":         {promQL: true},
+	"min_over_time":         {promQL: true},
+	"max_over_time":         {promQL: true},
+	"count_over_time":       {promQL: true},
+	"first_over_time":       {promQL: true},
+	"last_over_time":        {promQL: true},
+	"stddev_over_time":      {promQL: true},
+	"stdvar_over_time":      {promQL: true},
+	"present_over_time":     {promQL: true},
+	"mad_over_time":         {promQL: true},
+	"ts_of_first_over_time": {promQL: true},
+	"ts_of_last_over_time":  {promQL: true},
+	"ts_of_max_over_time":   {promQL: true},
+	"ts_of_min_over_time":   {promQL: true},
+	"predict_linear":        {promQL: true},
+	"holt_winters":          {promQL: true},
+	"quantile_over_time":    {promQL: true},
+	// LogQL's `rate()` over a log stream. No PromQL parser produces the
+	// name, so the PromQL head must not accept it.
+	"log_rate": {promQL: false},
+}
+
+// IsPromQLRangeWindowFunc reports whether name is a [RangeWindow].Func
+// the emitter reduces as a range-vector windowed array AND a PromQL query
+// can name at source.
+//
+// The name is the IR name: a caller holding a PromQL source spelling
+// canonicalises it first (the `double_exponential_smoothing` →
+// `holt_winters` rewrite the upstream parser's spelling forces).
+func IsPromQLRangeWindowFunc(name string) bool {
+	return rangeWindowFuncs[name].promQL
+}
+
+// RangeWindowFuncNames returns every [RangeWindow].Func in the
+// vocabulary, sorted. The SQL emitter's dispatch ratchet diffs its own
+// table against this, so a reducer added to one side and not the other
+// fails rather than silently splitting the vocabulary in two.
+func RangeWindowFuncNames() []string {
+	out := make([]string, 0, len(rangeWindowFuncs))
+	for name := range rangeWindowFuncs {
+		out = append(out, name)
+	}
+	sort.Strings(out)
+	return out
+}

--- a/internal/dispatchscan/dispatchscan.go
+++ b/internal/dispatchscan/dispatchscan.go
@@ -1,0 +1,400 @@
+// Package dispatchscan derives, from Go source, the arm sets of the
+// dispatches PRODUCTION code performs over the shared plan IR.
+//
+// It is the production-side sibling of internal/sealedscan. sealedscan
+// answers "which types are in this sealed set"; dispatchscan answers
+// "which of them does this piece of code actually branch on". Both exist
+// for the same reason: a hand-maintained restatement of a fact the source
+// already determines drifts, and it drifts silently, because the
+// restatement's existence implies a check that nobody is running.
+//
+// Two shapes are derived, one per defect the ratchets built on this
+// package police.
+//
+//   - [Classifiers] finds the bool-returning classifier: a function whose
+//     answer about an IR node is computed by a type switch over a sealed
+//     interface. Two of those in different packages, under one name, are
+//     one question with two answers — the shape #1504 recorded, where
+//     internal/api/prom hand-mirrored a 3-kind classifier while
+//     internal/chsql covered 5 for the same question and a docstring on
+//     each asserted they agreed.
+//
+//   - [SwitchArms] finds the vocabulary a dispatch accepts: the string
+//     cases of an expression switch. A head that gates on the same
+//     vocabulary from a hand-written set cannot be diffed against the
+//     dispatch any other way, because the dispatch's arms bind to
+//     unexported methods and so are not a value any test can read.
+//
+// It parses declarations only, so it reads a package directory with
+// go/parser rather than loading it with golang.org/x/tools/go/packages,
+// for the same reason sealedscan does: nothing here needs types, build
+// tag resolution or import graphs.
+//
+// The consequence of parsing rather than type-checking is that an
+// interface is identified by its written name — `chplan.Node` at a use
+// site, `Node` inside package chplan — rather than by identity. An import
+// renamed with an alias therefore reads as a different interface and is
+// skipped, which is the conservative direction: the scan under-reports
+// rather than binding two unrelated interfaces together because they
+// share a short name (`Expr` names a different interface in chplan, in
+// lsyntax and in the TraceQL AST).
+package dispatchscan
+
+import (
+	"fmt"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+)
+
+// Classifier is one bool-returning shape classifier: a function that
+// answers a yes/no question about an IR node by switching on the node's
+// dynamic type.
+type Classifier struct {
+	// Package is the name of the package declaring the function.
+	Package string
+	// Func is the function's name.
+	Func string
+	// Interface is the qualified name of the sealed interface switched
+	// over, as written at the switch: "chplan.Node".
+	Interface string
+	// File is the path of the file declaring the function.
+	File string
+	// Line is the line of the function declaration.
+	Line int
+	// Arms holds the sorted type names the switch branches on, as
+	// written: ["*chplan.Filter", "*chplan.Project"].
+	Arms []string
+}
+
+// Classifiers returns every classifier declared in the package rooted at
+// dir whose type switch is over one of the interfaces named in sealed —
+// a set of qualified names ("chplan.Node"), as [QualifyInterface] builds
+// them.
+//
+// A function qualifies when it returns only bool, takes a parameter typed
+// as one of those interfaces, and switches on that parameter's dynamic
+// type. Those three together are what make it a restatement of a
+// classification rather than an ordinary walk: the answer is a property
+// of the node kind alone, so two of them must agree by construction.
+//
+// A walk that returns a plan, a column set or an error is deliberately
+// out of scope even when it switches on the same interface. Those differ
+// legitimately between callers — a rewrite rule handles the nodes it
+// rewrites — and folding them in would flag most of the optimizer.
+func Classifiers(dir string, sealed map[string]bool) ([]Classifier, error) {
+	files, pkg, err := parseDir(dir)
+	if err != nil {
+		return nil, err
+	}
+	var out []Classifier
+	for _, pf := range files {
+		for _, decl := range pf.file.Decls {
+			fd, ok := decl.(*ast.FuncDecl)
+			if !ok || fd.Body == nil || !returnsOnlyBool(fd.Type) {
+				continue
+			}
+			params := ifaceParams(fd.Type, pkg, sealed)
+			if len(params) == 0 {
+				continue
+			}
+			out = append(out, classifiersIn(fd, params, pkg, pf)...)
+		}
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].File != out[j].File {
+			return out[i].File < out[j].File
+		}
+		return out[i].Line < out[j].Line
+	})
+	return out, nil
+}
+
+// QualifyInterface renders the qualified name Classifiers keys on for an
+// interface named iface declared in package pkg.
+func QualifyInterface(pkg, iface string) string {
+	return pkg + "." + iface
+}
+
+// PackageName returns the name of the package rooted at dir, which a
+// caller needs to qualify the interfaces declared there. It differs from
+// the directory's base name often enough to be worth reading rather than
+// assuming.
+//
+// It returns "" with no error for a directory holding no non-test Go
+// source: a caller walking a tree meets those, and they declare nothing
+// to qualify.
+func PackageName(dir string) (string, error) {
+	_, pkg, err := parseDir(dir)
+	return pkg, err
+}
+
+// classifiersIn collects one Classifier per type switch in fd that
+// switches on a parameter of sealed-interface type.
+func classifiersIn(fd *ast.FuncDecl, params map[string]string, pkg string, pf parsedFile) []Classifier {
+	var out []Classifier
+	ast.Inspect(fd.Body, func(n ast.Node) bool {
+		sw, ok := n.(*ast.TypeSwitchStmt)
+		if !ok {
+			return true
+		}
+		iface, ok := params[typeSwitchSubject(sw)]
+		if !ok {
+			return true
+		}
+		arms := typeSwitchArms(sw)
+		if len(arms) == 0 {
+			return true
+		}
+		pos := pf.fset.Position(fd.Pos())
+		out = append(out, Classifier{
+			Package:   pkg,
+			Func:      fd.Name.Name,
+			Interface: iface,
+			File:      pf.path,
+			Line:      pos.Line,
+			Arms:      arms,
+		})
+		return true
+	})
+	return out
+}
+
+// SwitchArms returns the sorted, deduplicated string-literal cases of the
+// expression switch inside the function named fn in the package rooted at
+// dir — the vocabulary that dispatch accepts.
+//
+// It requires the function to hold exactly one switch whose cases are all
+// string literals, and returns an error otherwise. That strictness is the
+// vacuity guard: a ratchet that silently derives an empty vocabulary
+// passes forever while asserting nothing, so a dispatch reshaped past
+// what this recognises must fail loudly and be re-read rather than
+// degrade to a no-op.
+func SwitchArms(dir, fn string) ([]string, error) {
+	files, _, err := parseDir(dir)
+	if err != nil {
+		return nil, err
+	}
+	for _, pf := range files {
+		for _, decl := range pf.file.Decls {
+			fd, ok := decl.(*ast.FuncDecl)
+			if !ok || fd.Body == nil || fd.Name.Name != fn {
+				continue
+			}
+			return stringSwitchArms(fd, dir, fn)
+		}
+	}
+	return nil, fmt.Errorf("dispatchscan: no function %s in %s — the scan lost its grip on "+
+		"the source shape, so every ratchet built on it is vacuous", fn, dir)
+}
+
+// stringSwitchArms extracts the string cases of fd's single expression
+// switch.
+func stringSwitchArms(fd *ast.FuncDecl, dir, fn string) ([]string, error) {
+	var switches []*ast.SwitchStmt
+	ast.Inspect(fd.Body, func(n ast.Node) bool {
+		if sw, ok := n.(*ast.SwitchStmt); ok {
+			switches = append(switches, sw)
+		}
+		return true
+	})
+	if len(switches) != 1 {
+		return nil, fmt.Errorf("dispatchscan: %s in %s holds %d expression switches, want "+
+			"exactly 1 — the dispatch was reshaped, so re-read it rather than trusting a "+
+			"vocabulary derived from the wrong one", fn, dir, len(switches))
+	}
+	seen := map[string]bool{}
+	var arms []string
+	for _, stmt := range switches[0].Body.List {
+		clause, ok := stmt.(*ast.CaseClause)
+		if !ok {
+			continue
+		}
+		for _, expr := range clause.List {
+			lit, ok := expr.(*ast.BasicLit)
+			if !ok || lit.Kind != token.STRING {
+				return nil, fmt.Errorf("dispatchscan: %s in %s switches on a non-string case "+
+					"%s — the dispatch is not a vocabulary this scan can derive", fn, dir,
+					exprName(expr))
+			}
+			name, err := strconv.Unquote(lit.Value)
+			if err != nil {
+				return nil, fmt.Errorf("dispatchscan: %s in %s: unquote case %s: %w",
+					fn, dir, lit.Value, err)
+			}
+			if seen[name] {
+				continue
+			}
+			seen[name] = true
+			arms = append(arms, name)
+		}
+	}
+	if len(arms) == 0 {
+		return nil, fmt.Errorf("dispatchscan: %s in %s has no string cases — the scan lost "+
+			"its grip on the source shape, so every ratchet built on it is vacuous", fn, dir)
+	}
+	sort.Strings(arms)
+	return arms, nil
+}
+
+// parsedFile is one parsed non-test source file and where it came from.
+type parsedFile struct {
+	path string
+	file *ast.File
+	fset *token.FileSet
+}
+
+// parseDir parses the package's non-test sources, returning them with the
+// package name. Test files are excluded: a dispatch is a production
+// declaration, and a test-only classifier would be reported as a mirror
+// of the production one it exists to verify.
+func parseDir(dir string) ([]parsedFile, string, error) {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return nil, "", fmt.Errorf("dispatchscan: read package directory: %w", err)
+	}
+	fset := token.NewFileSet()
+	var out []parsedFile
+	var pkg string
+	for _, entry := range entries {
+		name := entry.Name()
+		if entry.IsDir() || !strings.HasSuffix(name, ".go") || strings.HasSuffix(name, "_test.go") {
+			continue
+		}
+		path := filepath.Join(dir, name)
+		file, perr := parser.ParseFile(fset, path, nil, 0)
+		if perr != nil {
+			return nil, "", fmt.Errorf("dispatchscan: parse %s: %w", name, perr)
+		}
+		pkg = file.Name.Name
+		out = append(out, parsedFile{path: path, file: file, fset: fset})
+	}
+	return out, pkg, nil
+}
+
+// returnsOnlyBool reports whether every result of ft is a bare bool. A
+// classifier answers yes or no and nothing else: a function also
+// returning the node it found is an unwrapper, whose arms legitimately
+// differ per caller.
+func returnsOnlyBool(ft *ast.FuncType) bool {
+	if ft.Results == nil || len(ft.Results.List) == 0 {
+		return false
+	}
+	for _, r := range ft.Results.List {
+		id, ok := r.Type.(*ast.Ident)
+		if !ok || id.Name != "bool" {
+			return false
+		}
+	}
+	return true
+}
+
+// ifaceParams maps each parameter name whose declared type is one of the
+// sealed interfaces to that interface's qualified name.
+func ifaceParams(ft *ast.FuncType, pkg string, sealed map[string]bool) map[string]string {
+	if ft.Params == nil {
+		return nil
+	}
+	out := map[string]string{}
+	for _, p := range ft.Params.List {
+		qualified, ok := qualifiedTypeName(p.Type, pkg)
+		if !ok || !sealed[qualified] {
+			continue
+		}
+		for _, name := range p.Names {
+			out[name.Name] = qualified
+		}
+	}
+	return out
+}
+
+// qualifiedTypeName renders a parameter's type as a qualified name,
+// treating a bare identifier as local to pkg.
+func qualifiedTypeName(expr ast.Expr, pkg string) (string, bool) {
+	switch v := expr.(type) {
+	case *ast.Ident:
+		return QualifyInterface(pkg, v.Name), true
+	case *ast.SelectorExpr:
+		id, ok := v.X.(*ast.Ident)
+		if !ok {
+			return "", false
+		}
+		return QualifyInterface(id.Name, v.Sel.Name), true
+	}
+	return "", false
+}
+
+// typeSwitchSubject returns the name of the identifier a type switch
+// switches on, or "" for a subject this scan does not recognise.
+func typeSwitchSubject(sw *ast.TypeSwitchStmt) string {
+	var subject ast.Expr
+	switch assign := sw.Assign.(type) {
+	case *ast.AssignStmt:
+		if len(assign.Rhs) == 1 {
+			if ta, ok := assign.Rhs[0].(*ast.TypeAssertExpr); ok {
+				subject = ta.X
+			}
+		}
+	case *ast.ExprStmt:
+		if ta, ok := assign.X.(*ast.TypeAssertExpr); ok {
+			subject = ta.X
+		}
+	}
+	if id, ok := subject.(*ast.Ident); ok {
+		return id.Name
+	}
+	return ""
+}
+
+// typeSwitchArms returns the sorted type names a type switch branches on.
+// The `nil` case and the default clause carry no type name and are
+// skipped: neither says anything about which node kinds the classifier
+// covers.
+func typeSwitchArms(sw *ast.TypeSwitchStmt) []string {
+	seen := map[string]bool{}
+	var arms []string
+	for _, stmt := range sw.Body.List {
+		clause, ok := stmt.(*ast.CaseClause)
+		if !ok {
+			continue
+		}
+		for _, expr := range clause.List {
+			name := exprName(expr)
+			if name == "" || name == "nil" || seen[name] {
+				continue
+			}
+			seen[name] = true
+			arms = append(arms, name)
+		}
+	}
+	sort.Strings(arms)
+	return arms
+}
+
+// exprName renders a type expression as its written name, unwrapping a
+// pointer. It returns "" for a shape this scan does not recognise, so the
+// caller skips it rather than recording a bogus arm.
+func exprName(expr ast.Expr) string {
+	switch v := expr.(type) {
+	case *ast.Ident:
+		return v.Name
+	case *ast.StarExpr:
+		inner := exprName(v.X)
+		if inner == "" {
+			return ""
+		}
+		return "*" + inner
+	case *ast.SelectorExpr:
+		outer := exprName(v.X)
+		if outer == "" {
+			return ""
+		}
+		return outer + "." + v.Sel.Name
+	}
+	return ""
+}

--- a/internal/dispatchscan/dispatchscan_test.go
+++ b/internal/dispatchscan/dispatchscan_test.go
@@ -1,0 +1,146 @@
+package dispatchscan_test
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/tsouza/cerberus/internal/dispatchscan"
+)
+
+// fixtureDir is the package the scan reads. It holds every shape the
+// scan must recognise beside the near-misses it must not, so a scan that
+// stops recognising and a scan that starts over-recognising both fail
+// here.
+var fixtureDir = filepath.Join("testdata", "dispatchpkg")
+
+// sealedFixture names the fixture's sealed interface the way a caller
+// walking the tree would qualify it.
+func sealedFixture(t *testing.T) map[string]bool {
+	t.Helper()
+	pkg, err := dispatchscan.PackageName(fixtureDir)
+	if err != nil {
+		t.Fatalf("PackageName: %v", err)
+	}
+	if pkg != "dispatchpkg" {
+		t.Fatalf("PackageName = %q, want dispatchpkg", pkg)
+	}
+	return map[string]bool{dispatchscan.QualifyInterface(pkg, "Node"): true}
+}
+
+func TestClassifiers(t *testing.T) {
+	t.Parallel()
+
+	found, err := dispatchscan.Classifiers(fixtureDir, sealedFixture(t))
+	if err != nil {
+		t.Fatalf("Classifiers: %v", err)
+	}
+
+	got := map[string][]string{}
+	for _, c := range found {
+		if c.Interface != "dispatchpkg.Node" {
+			t.Errorf("%s: Interface = %q, want dispatchpkg.Node", c.Func, c.Interface)
+		}
+		if c.Package != "dispatchpkg" {
+			t.Errorf("%s: Package = %q, want dispatchpkg", c.Func, c.Package)
+		}
+		if c.Line == 0 || !strings.HasSuffix(c.File, "pkg.go") {
+			t.Errorf("%s: File/Line = %s:%d, want a position in pkg.go", c.Func, c.File, c.Line)
+		}
+		got[c.Func] = c.Arms
+	}
+
+	// The two classifier shapes, with the `nil` case dropped from the
+	// arms: it names no node kind, so it says nothing about coverage.
+	wantArms := map[string][]string{
+		"isDerived":  {"*Filter", "*Scan"},
+		"keyedTwice": {"*Project"},
+	}
+	for fn, want := range wantArms {
+		arms, ok := got[fn]
+		if !ok {
+			t.Errorf("%s was not recognised as a classifier", fn)
+			continue
+		}
+		if strings.Join(arms, ",") != strings.Join(want, ",") {
+			t.Errorf("%s: arms = %v, want %v", fn, arms, want)
+		}
+	}
+
+	// The near-misses. Each is a function the rule must stay away from,
+	// and each fails for a different reason.
+	for _, fn := range []string{"unwrap", "isEmpty", "switchesOnLocal"} {
+		if _, ok := got[fn]; ok {
+			t.Errorf("%s was recognised as a classifier, but it is a near-miss the scan "+
+				"must not read", fn)
+		}
+	}
+}
+
+// TestClassifiersIgnoresUnsealedInterfaces pins that the sealed set is
+// what bounds the scan. Passing an empty set must find nothing rather
+// than every type switch in the package.
+func TestClassifiersIgnoresUnsealedInterfaces(t *testing.T) {
+	t.Parallel()
+
+	found, err := dispatchscan.Classifiers(fixtureDir, map[string]bool{})
+	if err != nil {
+		t.Fatalf("Classifiers: %v", err)
+	}
+	if len(found) != 0 {
+		t.Errorf("Classifiers over an empty sealed set found %d classifiers, want 0", len(found))
+	}
+}
+
+func TestSwitchArms(t *testing.T) {
+	t.Parallel()
+
+	arms, err := dispatchscan.SwitchArms(fixtureDir, "dispatchVocabulary")
+	if err != nil {
+		t.Fatalf("SwitchArms: %v", err)
+	}
+	// Sorted and deduplicated: the fixture names "rate" twice and lists
+	// two names in one clause.
+	want := "irate,rate,sum_over_time"
+	if got := strings.Join(arms, ","); got != want {
+		t.Errorf("SwitchArms = %q, want %q", got, want)
+	}
+}
+
+// TestSwitchArmsRefusesShapesItCannotDerive pins the vacuity guards. Each
+// case is a dispatch this scan must NOT report an answer for, because a
+// silently empty or half-read vocabulary makes every ratchet built on it
+// pass while asserting nothing.
+func TestSwitchArmsRefusesShapesItCannotDerive(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		fn     string
+		reason string
+	}{
+		{fn: "noSuchFunction", reason: "the function is gone"},
+		{fn: "twoSwitches", reason: "the dispatch was reshaped into several switches"},
+		{fn: "intSwitch", reason: "the cases are not a string vocabulary"},
+		{fn: "noSwitch", reason: "the switch is gone"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.fn, func(t *testing.T) {
+			t.Parallel()
+			if _, err := dispatchscan.SwitchArms(fixtureDir, tc.fn); err == nil {
+				t.Errorf("SwitchArms(%s) returned no error, but %s — a ratchet built on it "+
+					"would pass while asserting nothing", tc.fn, tc.reason)
+			}
+		})
+	}
+}
+
+func TestScanErrorsOnMissingDirectory(t *testing.T) {
+	t.Parallel()
+
+	if _, err := dispatchscan.Classifiers(filepath.Join("testdata", "nope"), nil); err == nil {
+		t.Error("Classifiers on a missing directory returned no error")
+	}
+	if _, err := dispatchscan.PackageName(filepath.Join("testdata", "nope")); err == nil {
+		t.Error("PackageName on a missing directory returned no error")
+	}
+}

--- a/internal/dispatchscan/testdata/dispatchpkg/pkg.go
+++ b/internal/dispatchscan/testdata/dispatchpkg/pkg.go
@@ -1,0 +1,123 @@
+// Package dispatchpkg is the fixture the dispatchscan tests read. It
+// holds one sealed interface, the classifier shapes the scan must
+// recognise, the near-misses it must not, and the dispatch shapes
+// SwitchArms accepts and refuses.
+package dispatchpkg
+
+// Node is sealed by an unexported niladic marker, as every IR interface
+// in this repository is.
+type Node interface {
+	planNode()
+}
+
+type Scan struct{}
+
+type Filter struct{ Input Node }
+
+type Project struct{ Input Node }
+
+func (*Scan) planNode()    {}
+func (*Filter) planNode()  {}
+func (*Project) planNode() {}
+
+// isDerived is the shape the scan must find: bool result, sealed
+// interface parameter, type switch on that parameter.
+func isDerived(n Node) bool {
+	switch v := n.(type) {
+	case *Scan:
+		return false
+	case *Filter:
+		return isDerived(v.Input)
+	case nil:
+		return false
+	}
+	return false
+}
+
+// keyedTwice returns two bools, which is still an answer and nothing
+// else, so it counts.
+func keyedTwice(n Node) (bool, bool) {
+	switch n.(type) {
+	case *Project:
+		return true, true
+	}
+	return false, false
+}
+
+// unwrap returns a node, so it is an unwrapper rather than a
+// classification: its arms legitimately differ per caller.
+func unwrap(n Node) (*Filter, bool) {
+	switch v := n.(type) {
+	case *Filter:
+		return v, true
+	}
+	return nil, false
+}
+
+// isEmpty takes no sealed interface at all.
+func isEmpty(s string) bool {
+	return s == ""
+}
+
+// switchesOnLocal switches on a local rather than on the parameter.
+// Without type information the scan cannot confirm the local still holds
+// the sealed value, so it under-reports here rather than recording arms
+// it cannot attribute — the conservative direction.
+func switchesOnLocal(n Node) bool {
+	inner := innerOf(n)
+	switch inner.(type) {
+	case *Scan:
+		return true
+	}
+	return false
+}
+
+// innerOf peels one wrapper, returning a node rather than an answer.
+func innerOf(n Node) Node {
+	if f, ok := n.(*Filter); ok {
+		return f.Input
+	}
+	return n
+}
+
+// dispatchVocabulary is the string-switch shape SwitchArms derives.
+func dispatchVocabulary(name string) int {
+	switch name {
+	case "rate", "irate":
+		return 1
+	case "sum_over_time":
+		return 2
+	case "rate":
+		return 3
+	default:
+		return 0
+	}
+}
+
+// twoSwitches holds more than one expression switch, which SwitchArms
+// must refuse rather than guess between.
+func twoSwitches(a, b string) int {
+	switch a {
+	case "x":
+		return 1
+	}
+	switch b {
+	case "y":
+		return 2
+	}
+	return 0
+}
+
+// intSwitch dispatches on non-string cases, which is not a vocabulary.
+func intSwitch(n int) bool {
+	switch n {
+	case 1:
+		return true
+	}
+	return false
+}
+
+// noSwitch holds no expression switch at all.
+func noSwitch(n int) int {
+	return n + 1
+}

--- a/internal/logql/binary.go
+++ b/internal/logql/binary.go
@@ -438,7 +438,7 @@ func logSampleColumns(inner chplan.Node, s schema.Logs) logSampleShape {
 			hasNativeTime: true,
 		}
 	}
-	if isMatrixRangeWindow(inner) {
+	if bottomsOutAtMatrixRangeWindow(inner) {
 		return logSampleShape{
 			metricName:    &chplan.LitString{V: ""},
 			attrsCol:      s.ResourceAttributesColumn,

--- a/internal/logql/lang.go
+++ b/internal/logql/lang.go
@@ -213,7 +213,7 @@ func (l *Lang) ProjectSamples(plan chplan.Node, meta engine.Meta) chplan.Node {
 		switch {
 		case isVectorAggregateSampleShape(plan):
 			tsExpr = &chplan.ColumnRef{Name: "TimeUnix"}
-		case isMatrixRangeWindow(plan):
+		case bottomsOutAtMatrixRangeWindow(plan):
 			tsExpr = &chplan.ColumnRef{Name: "anchor_ts"}
 		case !l.End.IsZero():
 			tsExpr = timeLiteralExpr(l.End)

--- a/internal/logql/lower_internal_test.go
+++ b/internal/logql/lower_internal_test.go
@@ -274,7 +274,7 @@ func TestWithMatcherWindowExtension(t *testing.T) {
 }
 
 // TestIsMatrixRangeWindowBoundary pins the `v.OuterRange > 0` boundary
-// in [isMatrixRangeWindow]. A CONDITIONALS_BOUNDARY mutant flips `> 0`
+// in [bottomsOutAtMatrixRangeWindow]. A CONDITIONALS_BOUNDARY mutant flips `> 0`
 // to `>= 0`, which would classify a zero-OuterRange instant RangeWindow
 // as a matrix node. The caller — vector-aggregation lowering — would
 // then add a non-existent `anchor_ts` column to the GROUP BY and the
@@ -304,8 +304,8 @@ func TestIsMatrixRangeWindowBoundary(t *testing.T) {
 			t.Parallel()
 
 			rw := &chplan.RangeWindow{OuterRange: tc.outerRange}
-			if got := isMatrixRangeWindow(rw); got != tc.want {
-				t.Fatalf("isMatrixRangeWindow(OuterRange=%v) = %v, want %v (%s)", tc.outerRange, got, tc.want, tc.description)
+			if got := bottomsOutAtMatrixRangeWindow(rw); got != tc.want {
+				t.Fatalf("bottomsOutAtMatrixRangeWindow(OuterRange=%v) = %v, want %v (%s)", tc.outerRange, got, tc.want, tc.description)
 			}
 		})
 	}
@@ -338,8 +338,8 @@ func TestIsMatrixRangeWindowWalksWrappers(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			if got := isMatrixRangeWindow(tc.node); got != tc.want {
-				t.Fatalf("isMatrixRangeWindow(%s) = %v, want %v", tc.name, got, tc.want)
+			if got := bottomsOutAtMatrixRangeWindow(tc.node); got != tc.want {
+				t.Fatalf("bottomsOutAtMatrixRangeWindow(%s) = %v, want %v", tc.name, got, tc.want)
 			}
 		})
 	}

--- a/internal/logql/range_aggregation.go
+++ b/internal/logql/range_aggregation.go
@@ -540,7 +540,7 @@ func andFilter(inner chplan.Node, extra chplan.Expr) chplan.Node {
 // #310 and the e2e-failures it surfaced.
 const rangeAggSynthValueColumn = "Value"
 
-// isMatrixRangeWindow reports whether plan's root (walking past
+// bottomsOutAtMatrixRangeWindow reports whether plan's root (walking past
 // value-rewrite Projects / Filters / Aggregates that preserve the inner
 // matrix shape) bottoms out at a matrix-shape RangeWindow — one emitting
 // N rows per series across [Start, End] spaced by Step, exposing
@@ -551,18 +551,36 @@ const rangeAggSynthValueColumn = "Value"
 // nested aggregations (`max(avg by (level) (matrix))`) recognise the
 // matrix shape — the inner Aggregate carries its own per-anchor bucket
 // (re-aliased to TimeUnix by the wrap Project), and the outer
-// aggregation must re-bucket on it. Mirrors prom's isMatrixRangeWindow
-// in internal/api/prom/handler.go.
-func isMatrixRangeWindow(plan chplan.Node) bool {
+// aggregation must re-bucket on it.
+//
+// It is NOT the PromQL head's bottomsOutAtMatrixRangeWindow, which it used to claim
+// to mirror while answering a different question with a different arm
+// set. The two differ deliberately, in both directions:
+//
+//   - PromQL crosses an Aggregate only when it keys on an alias of
+//     `anchor_ts` (chplan.AggregatePreservesMatrixGrid), because its
+//     caller goes on to READ `anchor_ts` off the output scope and a
+//     grid-folding `sum by (…)` never exposes it. This one crosses any
+//     Aggregate, because its callers ask only whether a per-anchor bucket
+//     exists SOMEWHERE below and then resolve its name separately
+//     ([matrixBucketColumn]) — LogQL's nested shape re-aliases the bucket
+//     to `TimeUnix`, which is exactly the alias PromQL's guard rejects.
+//   - PromQL also answers true for a RangeWindowNative. Nothing here can
+//     see one: the native timeSeries*ToGrid nodes are built only by
+//     internal/promql, so an arm for them would be unreachable.
+//
+// Naming the two the same invited the copy that #2031 records: a reader
+// who assumes one question fixes one copy and leaves the other.
+func bottomsOutAtMatrixRangeWindow(plan chplan.Node) bool {
 	switch v := plan.(type) {
 	case *chplan.RangeWindow:
 		return v.OuterRange > 0
 	case *chplan.Project:
-		return isMatrixRangeWindow(v.Input)
+		return bottomsOutAtMatrixRangeWindow(v.Input)
 	case *chplan.Filter:
-		return isMatrixRangeWindow(v.Input)
+		return bottomsOutAtMatrixRangeWindow(v.Input)
 	case *chplan.Aggregate:
-		return isMatrixRangeWindow(v.Input)
+		return bottomsOutAtMatrixRangeWindow(v.Input)
 	}
 	return false
 }
@@ -583,7 +601,7 @@ func isMatrixRangeWindow(plan chplan.Node) bool {
 //     their bucket reference is `TimeUnix`, not `anchor_ts` (which is no
 //     longer in scope past the inner Aggregate's projection).
 //
-// Callers are expected to gate on [isMatrixRangeWindow] first.
+// Callers are expected to gate on [bottomsOutAtMatrixRangeWindow] first.
 func matrixBucketColumn(plan chplan.Node) string {
 	switch v := plan.(type) {
 	case *chplan.Aggregate:

--- a/internal/logql/range_aggregation_test.go
+++ b/internal/logql/range_aggregation_test.go
@@ -196,8 +196,8 @@ func TestLowerRangeAggregationMatrixShapeUnwrap(t *testing.T) {
 			if !rw.End.Equal(end) {
 				t.Errorf("%q: End = %v, want %v", tc.query, rw.End, end)
 			}
-			if !isMatrixRangeWindow(rw) {
-				t.Errorf("%q: isMatrixRangeWindow(rw) = false, want true", tc.query)
+			if !bottomsOutAtMatrixRangeWindow(rw) {
+				t.Errorf("%q: bottomsOutAtMatrixRangeWindow(rw) = false, want true", tc.query)
 			}
 
 			// Emit the SQL and confirm the per-anchor matrix scaffold
@@ -339,7 +339,7 @@ func TestLowerRangeAggregationUnwrapStripsTargetFromIdentity(t *testing.T) {
 }
 
 // TestIsMatrixRangeWindowWalksNestedAggregation pins the
-// nested-aggregation traversal in [isMatrixRangeWindow]: the helper
+// nested-aggregation traversal in [bottomsOutAtMatrixRangeWindow]: the helper
 // MUST walk through `*chplan.Aggregate` so the outer
 // `lowerVectorAggregation` recognises `max(avg by (level)
 // (avg_over_time(...)))` and friends as matrix-shape inputs. The
@@ -365,14 +365,14 @@ func TestIsMatrixRangeWindowWalksNestedAggregation(t *testing.T) {
 	agg := &chplan.Aggregate{Input: rw, GroupBy: []chplan.Expr{&chplan.ColumnRef{Name: "anchor_ts"}}, GroupByAliases: []string{"bucket_ts"}}
 	proj := &chplan.Project{Input: agg, Projections: []chplan.Projection{{Expr: &chplan.ColumnRef{Name: "bucket_ts"}, Alias: "TimeUnix"}}}
 
-	if !isMatrixRangeWindow(proj) {
-		t.Errorf("isMatrixRangeWindow(Project(Aggregate(RangeWindow))) = false, want true — nested-aggregation matrix shape lost")
+	if !bottomsOutAtMatrixRangeWindow(proj) {
+		t.Errorf("bottomsOutAtMatrixRangeWindow(Project(Aggregate(RangeWindow))) = false, want true — nested-aggregation matrix shape lost")
 	}
-	if !isMatrixRangeWindow(agg) {
-		t.Errorf("isMatrixRangeWindow(Aggregate(RangeWindow)) = false, want true — Aggregate case missing from helper")
+	if !bottomsOutAtMatrixRangeWindow(agg) {
+		t.Errorf("bottomsOutAtMatrixRangeWindow(Aggregate(RangeWindow)) = false, want true — Aggregate case missing from helper")
 	}
-	if !isMatrixRangeWindow(rw) {
-		t.Errorf("isMatrixRangeWindow(RangeWindow{OuterRange>0}) = false, want true — base case regressed")
+	if !bottomsOutAtMatrixRangeWindow(rw) {
+		t.Errorf("bottomsOutAtMatrixRangeWindow(RangeWindow{OuterRange>0}) = false, want true — base case regressed")
 	}
 
 	// matrixBucketColumn must dispatch on plan depth: a bare RangeWindow
@@ -391,7 +391,7 @@ func TestIsMatrixRangeWindowWalksNestedAggregation(t *testing.T) {
 }
 
 // TestLowerVectorAggregationNestedMatrixBucketsOnTimeUnix pins the
-// downstream effect of [isMatrixRangeWindow] + [matrixBucketColumn]:
+// downstream effect of [bottomsOutAtMatrixRangeWindow] + [matrixBucketColumn]:
 // when the outer aggregation lowers
 // `max(avg by (level) (avg_over_time(...)))` in range mode, the
 // emitted SQL MUST GROUP BY `TimeUnix` (not `anchor_ts`, which is no

--- a/internal/logql/vector_aggregation.go
+++ b/internal/logql/vector_aggregation.go
@@ -74,7 +74,7 @@ func lowerVectorAggregation(e *syntax.VectorAggregationExpr, s schema.Logs, lc l
 	// (`max(avg by (level) (avg_over_time(...)))`) bucket correctly
 	// instead of collapsing the whole matrix into one row.
 	const bucketAlias = "bucket_ts"
-	rangeBucketed := lc.rangeMode() && isMatrixRangeWindow(input)
+	rangeBucketed := lc.rangeMode() && bottomsOutAtMatrixRangeWindow(input)
 	if rangeBucketed {
 		bucketCol := matrixBucketColumn(input)
 		groupBy = append(groupBy, &chplan.ColumnRef{Name: bucketCol})

--- a/internal/logql/vector_aggregation_test.go
+++ b/internal/logql/vector_aggregation_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 // TestLowerVectorAggregationRangeBucketedGate pins the
-// `lc.rangeMode() && isMatrixRangeWindow(input)` gate inside
+// `lc.rangeMode() && bottomsOutAtMatrixRangeWindow(input)` gate inside
 // [lowerVectorAggregation]. The flag controls whether the per-anchor
 // bucket column is added to the Aggregate's GROUP BY so per-step rows
 // survive the aggregation collapse.
@@ -29,7 +29,7 @@ import (
 // Pin the first case via `sum by (job) (vector(1))` lowered under
 // [LowerAtRange]. `vector(...)` lowers to a Project over `chplan.OneRow`
 // (see [lowerVector] / [syntheticLogScalar]) — a truly non-matrix
-// shape that `isMatrixRangeWindow` will reject regardless of how
+// shape that `bottomsOutAtMatrixRangeWindow` will reject regardless of how
 // many Aggregate / Project / Filter layers it walks through. The
 // original lowering keeps the outer Aggregate at one GroupBy
 // expression (the `by (job)` map-access); the mutant prepends the
@@ -46,7 +46,7 @@ func TestLowerVectorAggregationRangeBucketedGate(t *testing.T) {
 	s := schema.DefaultOTelLogs()
 
 	// Non-matrix inner: `vector(1)` lowers to Project(OneRow), which
-	// bottoms out at a non-matrix node. `isMatrixRangeWindow` returns
+	// bottoms out at a non-matrix node. `bottomsOutAtMatrixRangeWindow` returns
 	// false; the original keeps rangeBucketed=false; the mutant turns
 	// it on.
 	query := `sum by (job) (vector(1))`

--- a/internal/promql/subquery.go
+++ b/internal/promql/subquery.go
@@ -333,7 +333,8 @@ func lowerSubqueryOverCall(
 	// instead (issue #1866).
 	//
 	// `absent_over_time` is the one range-vector function deliberately
-	// outside [rangeVectorFn] — it lowers to its own chplan.AbsentOverTime
+	// outside the range-window vocabulary ([chplan.IsPromQLRangeWindowFunc])
+	// — it lowers to its own chplan.AbsentOverTime
 	// node rather than a RangeWindow — and it takes the same exit: the
 	// reducer path used to build a RangeWindow the emitter has no case
 	// for, which failed at emit time with `unsupported: range function
@@ -341,7 +342,7 @@ func lowerSubqueryOverCall(
 	// "does not accept a subquery argument" for the nested subquery form
 	// (issue #1867). Routing through lowerCall reaches the dedicated
 	// absent lowerings for BOTH argument shapes.
-	if _, isReducer := rangeVectorFn[call.Func.Name]; !isReducer {
+	if !chplan.IsPromQLRangeWindowFunc(canonicalRangeWindowFunc(call.Func.Name)) {
 		return lowerSubqueryOverInstantCall(sub, call, step, s, ctx)
 	}
 	arity, matrixArg := subqueryInnerRangeFnShape(call.Func.Name)
@@ -686,7 +687,7 @@ func lowerOuterRangeFnOverSubquery(
 	if outer.Func.Name == "absent_over_time" {
 		return lowerAbsentOverTimeOverSubquery(outer, sub, s, ctx)
 	}
-	if _, ok := rangeVectorFn[outer.Func.Name]; !ok {
+	if !chplan.IsPromQLRangeWindowFunc(canonicalRangeWindowFunc(outer.Func.Name)) {
 		return nil, fmt.Errorf("promql: %s does not accept a subquery argument", outer.Func.Name)
 	}
 
@@ -1152,8 +1153,12 @@ func projectCarriesMetricName(p *chplan.Project, s schema.Metrics) bool {
 // holt_winters / double_exponential_smoothing need this: the upstream
 // parser only recognises the `double_exponential_smoothing` spelling
 // (the legacy `holt_winters` name was removed upstream and is rejected
-// at parse time), but the emitter's switch — and rangeVectorFn below —
-// key on the IR's "holt_winters" name regardless of source spelling.
+// at parse time), but the emitter's dispatch — and the shared vocabulary
+// [chplan.IsPromQLRangeWindowFunc] reads — key on the IR's "holt_winters"
+// name regardless of source spelling. Every gate that asks whether a
+// function is a range-vector reducer canonicalises through here first, so
+// the vocabulary carries one entry per reducer rather than one per
+// spelling.
 func canonicalRangeWindowFunc(name string) string {
 	if name == "double_exponential_smoothing" {
 		return "holt_winters"
@@ -1288,77 +1293,6 @@ func widenSubquerySpine(n chplan.Node, start, end time.Time) {
 	case *chplan.Filter:
 		widenSubquerySpine(v.Input, start, end)
 	}
-}
-
-// rangeVectorFn is the set of PromQL functions cerberus's emitter
-// handles as range-vector reducers — i.e. every RangeWindow.Func the
-// windowed-array emitters support in both instant and matrix
-// (OuterRange > 0) modes. Subquery-argument lowering only fires for
-// these. predict_linear / holt_winters / quantile_over_time carry extra
-// scalar arguments beyond the subquery itself; threadOuterRangeFnScalars
-// (called from lowerOuterRangeFnOverSubquery for the outer reducer and
-// from lowerSubqueryOverRangeFnCall for the subquery inner) threads them
-// onto the RangeWindow the same way range_fns.go's non-subquery lowerers
-// do (#1456).
-// Both "holt_winters" and "double_exponential_smoothing" are listed even
-// though the upstream parser only ever produces the latter today — same
-// forward-compat rationale as lowerRangeVectorCall's two-spelling case.
-//
-// "first_over_time" sits here beside "last_over_time" because the two are
-// the `__name__`-preserving pair (rangeFnPreservesName): admitting one
-// over a subquery but not the other would make the name contract
-// unobservable for half of it. Both route through the emitter's shared
-// `emitRangeWindowOverTime` case, so the matrix and instant shapes are the
-// same code path `last_over_time` already exercises.
-//
-// "present_over_time" and "mad_over_time" are admitted on the same
-// grounds: both are plain reducers in the emitter's shared
-// `emitRangeWindowOverTime` case (internal/chsql/range_window.go), both
-// already lower over a bare matrix selector through
-// lowerRangeVectorCall's generic tail, and neither carries an extra
-// scalar argument. Withholding them here would reject
-// `mad_over_time(m[5m:1m])` while accepting `mad_over_time(m[5m])` — a
-// split reference Prometheus does not make. The generic "does not
-// accept a subquery argument" message stays for reducers with no
-// RangeWindow lowering at all (e.g. absent_over_time, which lowers to
-// its own node shape).
-// The four `ts_of_*_over_time` reducers sit here for the same reason:
-// they route through the emitter's `emitRangeWindowTsOfOverTime` case,
-// which — like `emitRangeWindowOverTime` — reduces the per-anchor window
-// array and is agnostic about whether the rows underneath came from a
-// matrix selector or from a subquery's anchor grid. They differ from
-// `first_over_time` / `last_over_time` only in projecting the winning
-// sample's timestamp instead of its value, and they drop `__name__`
-// (rangeFnPreservesName returns false for them), matching reference
-// Prometheus.
-var rangeVectorFn = map[string]struct{}{
-	"rate":                         {},
-	"irate":                        {},
-	"increase":                     {},
-	"delta":                        {},
-	"idelta":                       {},
-	"deriv":                        {},
-	"resets":                       {},
-	"changes":                      {},
-	"sum_over_time":                {},
-	"avg_over_time":                {},
-	"min_over_time":                {},
-	"max_over_time":                {},
-	"count_over_time":              {},
-	"first_over_time":              {},
-	"last_over_time":               {},
-	"stddev_over_time":             {},
-	"stdvar_over_time":             {},
-	"present_over_time":            {},
-	"mad_over_time":                {},
-	"ts_of_first_over_time":        {},
-	"ts_of_last_over_time":         {},
-	"ts_of_max_over_time":          {},
-	"ts_of_min_over_time":          {},
-	"predict_linear":               {},
-	"holt_winters":                 {},
-	"double_exponential_smoothing": {},
-	"quantile_over_time":           {},
 }
 
 // instantTransformFns is the set of sample-preserving instant-vector
@@ -2609,7 +2543,7 @@ func lowerSubqueryOverCallSubquery(
 	s schema.Metrics,
 	ctx lowerCtx,
 ) (chplan.Node, error) {
-	if _, ok := rangeVectorFn[call.Func.Name]; !ok {
+	if !chplan.IsPromQLRangeWindowFunc(canonicalRangeWindowFunc(call.Func.Name)) {
 		return nil, fmt.Errorf("promql: %s does not accept a subquery argument", call.Func.Name)
 	}
 	if err := requirePositiveInnerRange(innerSub); err != nil {

--- a/test/regression/mirrored_dispatch_test.go
+++ b/test/regression/mirrored_dispatch_test.go
@@ -1,0 +1,379 @@
+package regression
+
+// Class-closing ratchet for the PRODUCTION half of the "declared
+// duplicate of a derivable fact" family (#2031).
+//
+// sealed_marker_derivation_test.go closes the TEST half: a number or a
+// hand list restating a sealed set, in a `_test.go`, matched against the
+// markers declared beside it. Its own scope note names what it cannot
+// see — "a dispatch mirrored between two PRODUCTION files" — which is the
+// shape #1504 actually recorded: internal/api/prom hand-mirrored a 3-kind
+// derived-shape classifier while internal/chsql covered 5 for the same
+// question, with a docstring on each asserting they agreed. That one was
+// closed by unifying on chplan.IsDerivedShape, but by unification, not by
+// a gate, so nothing stopped it coming back.
+//
+// Two rules run here, one per shape the production mirror takes.
+//
+//	Rule C — TWO CLASSIFIERS, ONE NAME. A bool-returning function that
+//	answers a question about an IR node by switching on the node's
+//	dynamic type is a classification. Two of them over the same sealed
+//	interface, in different packages, under the same name, are one
+//	question with two answers, and the answers drift: the copy is made
+//	by copying, so it starts identical and then only one side learns
+//	about a new node kind.
+//
+//	Rule D — TWO VOCABULARIES, ONE DISPATCH. Where a head gates on the
+//	set of names a dispatch accepts, the gate and the dispatch must be
+//	re-derived from each other rather than both hand-written. The
+//	emitter's arms bind to unexported methods, so the arm set is not a
+//	value any test can read — it is derived from source
+//	(internal/dispatchscan) and diffed against the vocabulary the head
+//	reads.
+//
+// SCOPE, stated plainly. Rule C matches on the NAME, not on the arm
+// sets, and that is a deliberate narrowing rather than the whole target.
+// The arm-set formulations were measured against this tree first: "two
+// classifiers over one interface whose arms differ" and "…whose arms are
+// in a subset relation" flag 18 pairs today, essentially all of them
+// legitimate — chsql.isCheapPredicate and traceql.isNumericExpr share an
+// arm set the way any two predicates over one IR do, and a gate that
+// fires on those would be a gate nobody can keep green. Name identity
+// flagged exactly one pair, and that pair was a real mirror whose
+// docstring said so ("Mirrors prom's isMatrixRangeWindow"). The rule
+// therefore catches the copy that keeps its name, which is what a copy
+// does; it does not claim to catch a mirror written from scratch under a
+// different name. Its remedy is the honest pair: collapse the two onto
+// one classifier the way IsDerivedShape was, or — when they answer
+// genuinely different questions, as the PromQL and LogQL matrix walks
+// turned out to — name them for the questions they answer, so the next
+// reader is not invited to fix one by copying the other.
+
+import (
+	"fmt"
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/tsouza/cerberus/internal/chplan"
+	"github.com/tsouza/cerberus/internal/dispatchscan"
+	"github.com/tsouza/cerberus/internal/sealedscan"
+)
+
+// internalRoot is the tree Rule C walks. Production dispatch over the
+// shared IR lives under internal/; cmd/ wires it together and declares no
+// classifiers.
+const internalRoot = repoRoot + "/internal"
+
+// rangeWindowEmitDir and rangeWindowEmitFunc name the dispatch Rule D
+// re-derives: the SQL emitter's range-window switch, whose arms are the
+// reducer names the windowed-array emitters handle.
+const (
+	rangeWindowEmitDir  = repoRoot + "/internal/chsql"
+	rangeWindowEmitFunc = "emitRangeWindow"
+)
+
+// TestProductionDispatchIsNotMirrored is Rule C over the live tree.
+func TestProductionDispatchIsNotMirrored(t *testing.T) {
+	t.Parallel()
+
+	dirs := goPackageDirs(t, internalRoot)
+	sealed := sealedInterfaces(t, dirs)
+	if len(sealed) == 0 {
+		t.Fatal("found no sealed marker interfaces under internal/ — the scan lost its " +
+			"grip on the source shape, so this ratchet is vacuous")
+	}
+
+	var all []dispatchscan.Classifier
+	for _, dir := range dirs {
+		found, err := dispatchscan.Classifiers(dir, sealed)
+		if err != nil {
+			t.Fatalf("scan %s: %v", dir, err)
+		}
+		all = append(all, found...)
+	}
+	if len(all) == 0 {
+		t.Fatal("found no bool classifiers over any sealed interface — the scan lost its " +
+			"grip on the source shape, so this ratchet is vacuous")
+	}
+
+	for _, v := range mirroredClassifiers(all) {
+		t.Errorf("%s:%d: %s", v.path, v.line, v.msg)
+	}
+}
+
+// TestRangeWindowVocabularyIsDerived is Rule D over the live tree.
+//
+// The PromQL head gates whether a function accepts a subquery argument on
+// chplan's range-window vocabulary. That gate was a hand-written
+// `rangeVectorFn` set in internal/promql, pointing at the emitter's
+// switch and asserting it agreed with it; the emitter's switch pointed
+// back. Neither could see the other, so the vocabulary was two facts.
+func TestRangeWindowVocabularyIsDerived(t *testing.T) {
+	t.Parallel()
+
+	emitted, err := dispatchscan.SwitchArms(rangeWindowEmitDir, rangeWindowEmitFunc)
+	if err != nil {
+		t.Fatalf("derive the emitter's range-window arms: %v", err)
+	}
+	vocabulary := chplan.RangeWindowFuncNames()
+	if len(vocabulary) == 0 {
+		t.Fatal("chplan.RangeWindowFuncNames is empty — the ratchet would pass while " +
+			"asserting nothing")
+	}
+
+	inVocabulary := make(map[string]bool, len(vocabulary))
+	for _, name := range vocabulary {
+		inVocabulary[name] = true
+	}
+	emits := make(map[string]bool, len(emitted))
+	for _, name := range emitted {
+		emits[name] = true
+	}
+	for _, name := range vocabulary {
+		if !emits[name] {
+			t.Errorf("chplan's range-window vocabulary names %q but %s has no arm for it: "+
+				"a head lowers a plan carrying it and the emit then fails with ErrUnsupported "+
+				"instead of the query being rejected at lowering", name, rangeWindowEmitFunc)
+		}
+	}
+	for _, name := range emitted {
+		if !inVocabulary[name] {
+			t.Errorf("%s emits range function %q but chplan's vocabulary omits it: no head "+
+				"can build a plan that reaches the arm, and the PromQL subquery gate — which "+
+				"derives from that vocabulary — rejects a query the SQL could have served",
+				rangeWindowEmitFunc, name)
+		}
+	}
+}
+
+// mirroredClassifiers implements Rule C: classifiers over one sealed
+// interface, sharing a name, declared in more than one package.
+//
+// The name is compared case-insensitively so that an exported copy of an
+// unexported classifier is not a way around it.
+//
+// It RETURNS findings rather than reporting through *testing.T for the
+// same reason the sealed-marker rules do: a scan-and-assert-nothing gate
+// whose detector has no positive test goes green either because the tree
+// is clean or because the detector broke, and nothing distinguishes the
+// two. TestMirroredDispatchRules_FireOnTheDefectShapes drives it against
+// fixtures that hold the defect.
+func mirroredClassifiers(all []dispatchscan.Classifier) []finding {
+	type key struct{ iface, name string }
+	groups := map[key][]dispatchscan.Classifier{}
+	for _, c := range all {
+		k := key{iface: c.Interface, name: strings.ToLower(c.Func)}
+		groups[k] = append(groups[k], c)
+	}
+
+	var out []finding
+	for k, group := range groups {
+		pkgs := map[string]bool{}
+		for _, c := range group {
+			pkgs[c.Package] = true
+		}
+		if len(pkgs) < 2 {
+			continue
+		}
+		for _, c := range group {
+			out = append(out, finding{
+				path: c.File,
+				line: c.Line,
+				msg: fmt.Sprintf(
+					"%s.%s classifies %s here, and %s does the same under the same name (%s). "+
+						"Two classifiers over one sealed interface are one question with two "+
+						"answers: collapse them onto a single classifier in the interface's own "+
+						"package the way chplan.IsDerivedShape was, or — if they answer "+
+						"different questions — name them for the questions they answer so the "+
+						"next reader does not fix one by copying the other",
+					c.Package, c.Func, k.iface, strings.Join(otherPackages(group, c.Package), ", "),
+					k.name,
+				),
+			})
+		}
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].path != out[j].path {
+			return out[i].path < out[j].path
+		}
+		return out[i].line < out[j].line
+	})
+	return out
+}
+
+// otherPackages names the sorted packages in group other than self.
+func otherPackages(group []dispatchscan.Classifier, self string) []string {
+	seen := map[string]bool{}
+	var out []string
+	for _, c := range group {
+		if c.Package == self || seen[c.Package] {
+			continue
+		}
+		seen[c.Package] = true
+		out = append(out, c.Package+"."+c.Func)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// sealedInterfaces derives the qualified names of every sealed marker
+// interface declared under the given directories.
+func sealedInterfaces(t *testing.T, dirs []string) map[string]bool {
+	t.Helper()
+	out := map[string]bool{}
+	for _, dir := range dirs {
+		markers, err := sealedscan.Markers(dir)
+		if err != nil {
+			t.Fatalf("scan %s: %v", dir, err)
+		}
+		if len(markers) == 0 {
+			continue
+		}
+		pkg, err := dispatchscan.PackageName(dir)
+		if err != nil {
+			t.Fatalf("package name for %s: %v", dir, err)
+		}
+		for _, m := range markers {
+			out[dispatchscan.QualifyInterface(pkg, m.Interface)] = true
+		}
+	}
+	return out
+}
+
+// TestMirroredDispatchRules_FireOnTheDefectShapes is the guard on the
+// guard. Each fixture tree under testdata holds the defect its rule must
+// catch alongside the near-misses it must NOT catch, and the expectation
+// is the exact set of flagged lines — so a rule that stops detecting, and
+// a rule that starts over-detecting, both fail here.
+func TestMirroredDispatchRules_FireOnTheDefectShapes(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		dir string
+		// positive says the fixture holds at least one line the rule
+		// must flag. Without it a fixture whose classifiers were all
+		// deleted would expect nothing, match a rule that detects
+		// nothing, and pass — the dead-rule case this test prevents.
+		positive bool
+	}{
+		// One classifier copied into a second package under its own
+		// name, having already drifted by an arm — beside the local
+		// helper that shares the name but not the interface.
+		{dir: "mirrored", positive: true},
+		// The same two packages classifying the same interface under
+		// names that state their different questions, plus a same-named
+		// pair that returns a node rather than a bool (an unwrapper,
+		// whose arms legitimately differ per caller) and a same-named
+		// pair inside ONE package.
+		{dir: "distinct"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.dir, func(t *testing.T) {
+			t.Parallel()
+
+			root := filepath.Join("testdata", "mirroreddispatch", tc.dir)
+			dirs := goPackageDirs(t, root)
+			if len(dirs) < 2 {
+				t.Fatalf("fixture %s holds %d package directories, want at least 2 — a "+
+					"cross-package rule cannot be exercised by one package", root, len(dirs))
+			}
+			sealed := sealedInterfaces(t, dirs)
+			if len(sealed) == 0 {
+				t.Fatalf("fixture %s declares no sealed interface, so there is nothing to "+
+					"classify", root)
+			}
+
+			var all []dispatchscan.Classifier
+			for _, dir := range dirs {
+				found, err := dispatchscan.Classifiers(dir, sealed)
+				if err != nil {
+					t.Fatalf("scan %s: %v", dir, err)
+				}
+				all = append(all, found...)
+			}
+			if len(all) == 0 {
+				t.Fatalf("fixture %s holds no classifiers, so the rule has nothing to "+
+					"read", root)
+			}
+
+			gotLines := []int{}
+			for _, v := range mirroredClassifiers(all) {
+				gotLines = append(gotLines, v.line)
+			}
+			sort.Ints(gotLines)
+			want := markedSourceLines(t, root)
+			if tc.positive != (len(want) > 0) {
+				t.Fatalf("fixture %s marks %d lines with %s, but positive=%v — the fixture "+
+					"no longer states the case it is named for", root, len(want), wantMarker,
+					tc.positive)
+			}
+			if !sameInts(gotLines, want) {
+				t.Errorf("fixture %s: rule flagged lines %v, want %v (the lines marked %s)",
+					root, gotLines, want, wantMarker)
+			}
+		})
+	}
+}
+
+// TestDispatchScanVacuityGuards pins that the derivations fail loudly
+// rather than returning an empty answer when they lose their grip on the
+// source shape. A ratchet whose scan silently finds nothing passes
+// forever while asserting nothing, which is the defect this whole file
+// exists to prevent — so the guards themselves need a test.
+func TestDispatchScanVacuityGuards(t *testing.T) {
+	t.Parallel()
+
+	if _, err := dispatchscan.SwitchArms(rangeWindowEmitDir, "noSuchDispatchFunction"); err == nil {
+		t.Error("SwitchArms found no such function and returned no error — a ratchet built " +
+			"on it would derive an empty vocabulary and pass while asserting nothing")
+	}
+	// A function with no expression switch at all: the derivation must
+	// refuse rather than report an empty arm set.
+	if _, err := dispatchscan.SwitchArms(repoRoot+"/internal/chplan", "RangeWindowFuncNames"); err == nil {
+		t.Error("SwitchArms accepted a function holding no expression switch and returned " +
+			"no error — the dispatch it is aimed at could be reshaped away unnoticed")
+	}
+}
+
+// markedSourceLines returns the sorted fixture lines marked with
+// wantMarker across a fixture TREE's non-test Go files.
+//
+// It is the production-shaped sibling of wantMarkedLines, which reads
+// `_test.go` files in one directory: these fixtures are production
+// dispatch spread over several packages, and dispatchscan deliberately
+// ignores test files.
+func markedSourceLines(t *testing.T, root string) []int {
+	t.Helper()
+	lines := []int{}
+	err := filepath.WalkDir(root, func(path string, d os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() || !strings.HasSuffix(path, ".go") || strings.HasSuffix(path, "_test.go") {
+			return nil
+		}
+		fset := token.NewFileSet()
+		file, perr := parser.ParseFile(fset, path, nil, parser.ParseComments)
+		if perr != nil {
+			return fmt.Errorf("parse %s: %w", path, perr)
+		}
+		for _, group := range file.Comments {
+			for _, c := range group.List {
+				if strings.TrimSpace(c.Text) == wantMarker {
+					lines = append(lines, fset.Position(c.Pos()).Line)
+				}
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walk %s: %v", root, err)
+	}
+	sort.Ints(lines)
+	return lines
+}

--- a/test/regression/testdata/mirroreddispatch/distinct/alpha/alpha.go
+++ b/test/regression/testdata/mirroreddispatch/distinct/alpha/alpha.go
@@ -1,0 +1,48 @@
+// Package alpha classifies the same interface as beta, under a name that
+// states its own question. Nothing here is flagged.
+package alpha
+
+import "ir"
+
+// exposesAnchorColumn asks whether the anchor column is readable off the
+// output scope — the question its own caller needs.
+//
+//lint:ignore U1000 fixture
+func exposesAnchorColumn(n ir.Node) bool {
+	switch v := n.(type) {
+	case *ir.Window:
+		return v.Outer > 0
+	case *ir.NativeWindow:
+		return true
+	case *ir.Filter:
+		return exposesAnchorColumn(v.Input)
+	}
+	return false
+}
+
+// unwrapWindow shares its name with beta's, but returns a node rather
+// than only a bool: an unwrapper's arms legitimately differ per caller,
+// so it is out of the rule's scope.
+//
+//lint:ignore U1000 fixture
+func unwrapWindow(n ir.Node) (*ir.Window, bool) {
+	switch v := n.(type) {
+	case *ir.Window:
+		return v, true
+	case *ir.Filter:
+		return unwrapWindow(v.Input)
+	}
+	return nil, false
+}
+
+// isLeaf and the isLeaf in this same file's sibling below share a name
+// within ONE package, which is not a cross-package mirror.
+//
+//lint:ignore U1000 fixture
+func isLeaf(n ir.Node) bool {
+	switch n.(type) {
+	case *ir.Scan:
+		return true
+	}
+	return false
+}

--- a/test/regression/testdata/mirroreddispatch/distinct/beta/beta.go
+++ b/test/regression/testdata/mirroreddispatch/distinct/beta/beta.go
@@ -1,0 +1,33 @@
+// Package beta asks a different question about the same interface, and
+// says so in its name.
+package beta
+
+import "ir"
+
+// bottomsOutAtWindow asks only whether a window exists somewhere below,
+// crossing any re-keying node, because its caller resolves the column
+// name separately.
+//
+//lint:ignore U1000 fixture
+func bottomsOutAtWindow(n ir.Node) bool {
+	switch v := n.(type) {
+	case *ir.Window:
+		return v.Outer > 0
+	case *ir.Filter:
+		return bottomsOutAtWindow(v.Input)
+	case *ir.Project:
+		return bottomsOutAtWindow(v.Input)
+	}
+	return false
+}
+
+//lint:ignore U1000 fixture
+func unwrapWindow(n ir.Node) (*ir.Window, bool) {
+	switch v := n.(type) {
+	case *ir.Window:
+		return v, true
+	case *ir.Project:
+		return unwrapWindow(v.Input)
+	}
+	return nil, false
+}

--- a/test/regression/testdata/mirroreddispatch/distinct/ir/ir.go
+++ b/test/regression/testdata/mirroreddispatch/distinct/ir/ir.go
@@ -1,0 +1,24 @@
+// Package ir stands in for chplan: a sealed node interface with several
+// kinds, closed by an unexported niladic marker.
+package ir
+
+// Node is the sealed interface the classifiers below switch over.
+type Node interface {
+	planNode()
+}
+
+type Scan struct{}
+
+type Filter struct{ Input Node }
+
+type Project struct{ Input Node }
+
+type Window struct{ Outer int }
+
+type NativeWindow struct{}
+
+func (*Scan) planNode()         {}
+func (*Filter) planNode()       {}
+func (*Project) planNode()      {}
+func (*Window) planNode()       {}
+func (*NativeWindow) planNode() {}

--- a/test/regression/testdata/mirroreddispatch/mirrored/alpha/alpha.go
+++ b/test/regression/testdata/mirroreddispatch/mirrored/alpha/alpha.go
@@ -1,0 +1,20 @@
+// Package alpha holds the original classifier.
+package alpha
+
+import "ir"
+
+// isMatrixShape is the complete answer: it knows about the native window
+// kind, and it stops at a Project that re-keys the rows.
+//
+//lint:ignore U1000 fixture
+func isMatrixShape(n ir.Node) bool { // WANT
+	switch v := n.(type) {
+	case *ir.Window:
+		return v.Outer > 0
+	case *ir.NativeWindow:
+		return true
+	case *ir.Filter:
+		return isMatrixShape(v.Input)
+	}
+	return false
+}

--- a/test/regression/testdata/mirroreddispatch/mirrored/beta/beta.go
+++ b/test/regression/testdata/mirroreddispatch/mirrored/beta/beta.go
@@ -1,0 +1,30 @@
+// Package beta holds the copy, made by copying and then drifted: it never
+// learned about the native window kind.
+package beta
+
+import "ir"
+
+//lint:ignore U1000 fixture
+func isMatrixShape(n ir.Node) bool { // WANT
+	switch v := n.(type) {
+	case *ir.Window:
+		return v.Outer > 0
+	case *ir.Filter:
+		return isMatrixShape(v.Input)
+	}
+	return false
+}
+
+// isCheap shares no name with anything in alpha, and classifies the same
+// interface. Different questions are allowed to differ.
+//
+//lint:ignore U1000 fixture
+func isCheap(n ir.Node) bool {
+	switch n.(type) {
+	case *ir.Scan:
+		return true
+	case *ir.Project:
+		return false
+	}
+	return false
+}

--- a/test/regression/testdata/mirroreddispatch/mirrored/ir/ir.go
+++ b/test/regression/testdata/mirroreddispatch/mirrored/ir/ir.go
@@ -1,0 +1,24 @@
+// Package ir stands in for chplan: a sealed node interface with several
+// kinds, closed by an unexported niladic marker.
+package ir
+
+// Node is the sealed interface the classifiers below switch over.
+type Node interface {
+	planNode()
+}
+
+type Scan struct{}
+
+type Filter struct{ Input Node }
+
+type Project struct{ Input Node }
+
+type Window struct{ Outer int }
+
+type NativeWindow struct{}
+
+func (*Scan) planNode()         {}
+func (*Filter) planNode()       {}
+func (*Project) planNode()      {}
+func (*Window) planNode()       {}
+func (*NativeWindow) planNode() {}

--- a/test/rejection-parity/catalogue/internal__promql__subquery.go.json
+++ b/test/rejection-parity/catalogue/internal__promql__subquery.go.json
@@ -38,16 +38,17 @@
       "site": "internal/promql/subquery.go:lowerOuterRangeFnOverSubquery#b8fba661",
       "message": "promql: %s does not accept a subquery argument",
       "class": "internal",
-      "rationale": "unreachable: every PromQL function taking a range-vector argument is either a member of rangeVectorFn or is absent_over_time, which the arm above this guard routes to lowerAbsentOverTimeOverSubquery, so no parseable query reaches it",
+      "rationale": "unreachable: a PromQL function that takes a range-vector argument is either a member of the shared range-window vocabulary (chplan.IsPromQLRangeWindowFunc, consulted through canonicalRangeWindowFunc so the double_exponential_smoothing source spelling resolves to its IR name) or absent_over_time, and the arm directly above this guard routes absent_over_time to lowerAbsentOverTimeOverSubquery, so no parseable query reaches it",
       "evidence": {
         "guard": [
           "past returning if outer.Func.Name == \"absent_over_time\"",
-          "if _, ok := rangeVectorFn[outer.Func.Name]; !ok"
+          "if !chplan.IsPromQLRangeWindowFunc(canonicalRangeWindowFunc(outer.Func.Name))"
         ],
         "callers": [
           "lowerCall"
         ],
         "cited": [
+          "canonicalRangeWindowFunc",
           "lowerAbsentOverTimeOverSubquery"
         ]
       }
@@ -175,12 +176,12 @@
       "site": "internal/promql/subquery.go:lowerSubqueryOverCall#9b8454a6",
       "message": "promql: subquery inner %s expects exactly %d argument(s), got %d",
       "class": "internal",
-      "rationale": "the rangeVectorFn membership gate above this check routes every non-reducer call to lowerSubqueryOverInstantCall, so only rangeVectorFn members reach it, and subqueryInnerRangeFnShape reports each of their true PromQL arities; none of them is variadic, so the upstream parser has already rejected any call whose argument count differs before lowering begins",
+      "rationale": "the range-window vocabulary gate above (chplan.IsPromQLRangeWindowFunc) routes a non-reducer call to lowerSubqueryOverInstantCall, so only vocabulary members reach this check, and subqueryInnerRangeFnShape reports each member's true PromQL arity; none of them is variadic, so the upstream parser has already rejected any call whose argument count differs before lowering begins",
       "evidence": {
         "guard": [
           "past returning if isInstantTransformCall(call) \u0026\u0026 subqueryInstantSafe(call)",
           "past returning if call.Func.Name == \"absent\"",
-          "past returning if _, isReducer := rangeVectorFn[call.Func.Name]; !isReducer",
+          "past returning if !chplan.IsPromQLRangeWindowFunc(canonicalRangeWindowFunc(call.Func.Name))",
           "if len(call.Args) != arity"
         ],
         "callers": [
@@ -198,12 +199,12 @@
       "site": "internal/promql/subquery.go:lowerSubqueryOverCall#a2b5a42c",
       "message": "promql: subquery inner %s must wrap a MatrixSelector, got %T",
       "class": "internal",
-      "rationale": "matrixArgExpr is peelWrappers(call.Args[matrixArg]) (#1896); the parser only ever gives this argument position a Matrix-typed expression (a MatrixSelector or a SubqueryExpr, optionally wrapped in ParenExpr/StepInvariantExpr), and peeling strips every such wrapper, so after peeling matrixArgExpr can only be a MatrixSelector or a SubqueryExpr -- this assertion cannot fail on any parseable query.",
+      "rationale": "matrixArgExpr is peelWrappers(call.Args[matrixArg]) (#1896); the parser only ever gives this argument position a Matrix-typed expression (a MatrixSelector or a SubqueryExpr, optionally wrapped in ParenExpr/StepInvariantExpr), and peeling strips every such wrapper, so after peeling matrixArgExpr can only be a MatrixSelector or a SubqueryExpr -- this assertion cannot fail on any parseable query",
       "evidence": {
         "guard": [
           "past returning if isInstantTransformCall(call) \u0026\u0026 subqueryInstantSafe(call)",
           "past returning if call.Func.Name == \"absent\"",
-          "past returning if _, isReducer := rangeVectorFn[call.Func.Name]; !isReducer",
+          "past returning if !chplan.IsPromQLRangeWindowFunc(canonicalRangeWindowFunc(call.Func.Name))",
           "past returning if len(call.Args) != arity",
           "past returning if innerSub, ok := matrixArgExpr.(*parser.SubqueryExpr); ok",
           "if !ok"
@@ -222,12 +223,12 @@
       "site": "internal/promql/subquery.go:lowerSubqueryOverCall#df8fa0f7",
       "message": "promql: subquery inner matrix selector must wrap a VectorSelector, got %T",
       "class": "internal",
-      "rationale": "the parser only ever builds a MatrixSelector around a VectorSelector, so the inner assertion cannot fail on any parseable query.",
+      "rationale": "the parser only ever builds a MatrixSelector around a VectorSelector, so the inner assertion cannot fail on any parseable query",
       "evidence": {
         "guard": [
           "past returning if isInstantTransformCall(call) \u0026\u0026 subqueryInstantSafe(call)",
           "past returning if call.Func.Name == \"absent\"",
-          "past returning if _, isReducer := rangeVectorFn[call.Func.Name]; !isReducer",
+          "past returning if !chplan.IsPromQLRangeWindowFunc(canonicalRangeWindowFunc(call.Func.Name))",
           "past returning if len(call.Args) != arity",
           "past returning if innerSub, ok := matrixArgExpr.(*parser.SubqueryExpr); ok",
           "past returning if !ok",
@@ -244,10 +245,10 @@
       "site": "internal/promql/subquery.go:lowerSubqueryOverCallSubquery#b8fba661",
       "message": "promql: %s does not accept a subquery argument",
       "class": "internal",
-      "rationale": "lowerSubqueryOverCall is the only caller and dispatches here only after its own rangeVectorFn membership gate has admitted the call, so the name is already in the map by the time this check runs",
+      "rationale": "lowerSubqueryOverCall is the only caller and dispatches here only after its own range-window vocabulary gate has admitted the call, so chplan.IsPromQLRangeWindowFunc has already answered true for the same canonicalised name by the time this check runs",
       "evidence": {
         "guard": [
-          "if _, ok := rangeVectorFn[call.Func.Name]; !ok"
+          "if !chplan.IsPromQLRangeWindowFunc(canonicalRangeWindowFunc(call.Func.Name))"
         ],
         "callers": [
           "lowerSubqueryOverCall"


### PR DESCRIPTION
`#1504` recorded a dispatch hand-mirrored between two production files: `internal/api/prom` covered 3 node kinds while `internal/chsql` covered 5 for the same question, with a docstring on each asserting they agreed. It was closed by unifying on `chplan.IsDerivedShape` — by unification, not by a gate. `#2031` named three live instances of the same shape and asked for a ratchet.

## What changed

**Tempo — three unwrappers → one.** `unwrapMetricsAggregate` / `unwrapMetricsHistogram` / `unwrapMetricsCompare` were verbatim copies of one two-arm switch with only the target type changed, each asserting in its docstring that it mirrored the others' "forward-compat posture". Which wrappers to peel is a property of the plan *spine*, not of the node at the bottom of it, so a wrapper that becomes peelable becomes peelable for every kind at once. They collapse onto one generic `unwrapMetricsRoot[T]`. Teaching one copy and not the others is what left `| topk(N)` rejected until the handler learned to peel `MetricsSecondStage`.

**PromQL — two vocabularies → one.** The head gated subquery arguments on a hand-written `rangeVectorFn` set that pointed at the emitter's switch and asserted it agreed; the emitter's switch pointed back. The vocabulary now lives once, in `chplan`, with the surfaces that reach each reducer.

The two sets **did** agree before this change — verified, not assumed — modulo two deliberate differences the one table now records rather than leaves implicit:

| name | emitter | old `rangeVectorFn` | why |
|---|---|---|---|
| `log_rate` | yes | no | LogQL-only; no PromQL parser produces the name |
| `double_exponential_smoothing` | no | yes | a PromQL *source spelling* the head canonicalises to `holt_winters`, not a second reducer |

**LogQL — a fourth instance, found by the new scan.** `logql.isMatrixRangeWindow` and `prom.isMatrixRangeWindow` shared a name over `chplan.Node`, and the LogQL docstring said "Mirrors prom's isMatrixRangeWindow". They had drifted twice. On inspection they answer *different questions*, so this is a rename, not a force-unification:

- PromQL crosses an `Aggregate` only when it keys on an alias of `anchor_ts`, because its caller then **reads** `anchor_ts` off the output scope. LogQL crosses any `Aggregate`, because its callers ask only whether a bucket exists *somewhere* below and resolve its name separately — and LogQL's nested shape re-aliases the bucket to `TimeUnix`, exactly the alias PromQL's guard rejects.
- PromQL answers true for a `RangeWindowNative`. LogQL can never see one: those nodes are built only by `internal/promql` (verified).

Renamed to `bottomsOutAtMatrixRangeWindow`, with the false "mirrors" claim replaced by a statement of how the two differ in both directions. No behaviour change.

## The ratchet

`internal/dispatchscan` derives, from Go source, the arm sets production code dispatches over the IR — the production-side sibling of `internal/sealedscan`, following its conventions (parse-only, non-test sources, loud vacuity guards). Two rules in `test/regression/mirrored_dispatch_test.go` consume it.

**Rule C — two classifiers, one name.** Fails when two bool-returning type-switch classifiers over one sealed interface are declared in different packages under the same name.

The issue's own phrasing ("arm sets differ, where one is reachable from the other's callers") was measured against this tree before being narrowed. Both arm-set formulations are unusable here:

| formulation | pairs flagged today |
|---|---|
| arms differ | 18 |
| arms in a subset relation | 18 |
| **same name** | **1** |

Almost all 18 are legitimate — `chsql.isCheapPredicate` and `traceql.isNumericExpr` share an arm set the way any two predicates over one IR do — and a gate nobody can keep green becomes a rubber stamp. Name identity flagged exactly one pair, and it was a real mirror that said so in its own docstring. The rule therefore catches the copy that keeps its name, which is what a copy does; it does not claim to catch a mirror written from scratch under a different name, and the file says so. Its remedy is the honest pair: collapse onto one classifier, or name them for the different questions they answer.

**Rule D — two vocabularies, one dispatch.** Re-derives the emitter's `emitRangeWindow` arms from source and diffs them against `chplan.RangeWindowFuncNames()` in both directions. The emitter's arms bind to unexported methods, so the arm set is not a value any test can read; a runtime table is impossible here because a package-level table of those method expressions is an initialization cycle (the emitter is recursive).

### Not vacuous

Both rules return findings rather than reporting through `*testing.T`, so fixtures drive them — a rule that stops detecting and one that starts over-detecting both fail. Beyond the fixtures, each rule was mutation-tested against the **real** defect:

- restoring `logql.isMatrixRangeWindow` → Rule C fails, naming both `internal/api/prom/handler.go:1377` and `internal/logql/range_aggregation.go:574`;
- dropping `resets` from the vocabulary → Rule D fails naming `resets`;
- adding a `phantom_over_time` arm to the emitter → Rule D fails naming `phantom_over_time`.

`dispatchscan`'s own guards are tested too: a missing function, a reshaped dispatch with two switches, non-string cases, and no switch at all each return an error rather than an empty answer.

## Found, verified, not fixed here

The third instance `#2031` named — `projection_pushdown.go`'s column enumerators — turned out to be a different shape and is filed separately as #2127. There are **eight**, not four, and they are one derivation ("the base-relation columns this node's emit reads off its input") wearing two coats, because chplan stores column identity as bare strings on some nodes and `Expr` trees on others. `resampleRangeWindowColumns` and `rangeLWRColumns` are byte-identical modulo receiver. The scan also found that `rangeWindowColumns` omits `TemporalityColumn` while the emitter selects `Col(r.TemporalityColumn)` off the same relation — a latent CH-error-47 path. Rule C cannot see any of it: these are parallel field lists, not type switches, and widening the rule to reach them is what produces the 18-pair false-positive set above.

Refs #2031
