### PR TITLE
test(parity): enrol classic histogram quantile fixtures

### DIFF
--- a/docs/specs/issue-1986-classic-histogram-count.md
+++ b/docs/specs/issue-1986-classic-histogram-count.md
@@ -1,0 +1,57 @@
+# Spec: #1986 classic histogram count parity
+
+Status: implemented and regenerated; verification pending focused chDB checks.
+
+## Problem
+
+Classic-histogram fixtures may omit physical `Count` because Cerberus derives the
+total from `BucketCounts`. The seed DDL supplies the absent column as zero, but
+the parity reader used that zero for Prometheus's `_count` and `le="+Inf"`
+series. The reference therefore received different data from Cerberus.
+
+## Scope
+
+- Derive a classic histogram's count from its bucket counts only when the fixture
+  did not declare `Count`.
+- Preserve a declared count verbatim, including an inconsistent one, so the
+  parity check can expose it.
+- Enrol only classic-histogram fixtures proven to pass the live reference check.
+
+## Audit And Rationale
+
+The original issue's five input-model gaps have already been materially reduced:
+gauge and sum rows, projection columns, resource labels, metric-name
+normalisation, classic histograms, native histogram values, and `@ start()` /
+`@ end()` evaluation are represented by the current parity layer. The remaining
+work is no longer one shared reader omission: it is native-histogram edge
+semantics, DELTA-temporality values that vanilla Prometheus cannot represent,
+non-sample API shapes, and individual real value/count/label disagreements.
+
+This batch is the smallest remaining common root cause in the classic-histogram
+residue. A minimal seed omits `Count`; the test DDL backfill supplies zero only
+for INSERT arity, while Cerberus derives the total from `BucketCounts`. Passing
+that synthetic zero to Prometheus makes the oracle evaluate different input.
+Deriving only an omitted count corrects the oracle input without concealing a
+fixture that explicitly declares an inconsistent count.
+
+## Task List
+
+1. Complete: derive the omitted classic count in the parity input translator and
+   cover both derived and declared-count paths.
+2. Complete: enrol four passing classic-histogram quantile fixtures and raise the
+   global parity floor from 578 to 582.
+3. Complete: regenerate the required shards; the generated diff contains only
+   the four intended PromQL parity declarations.
+This batch does not close #1986. The parent issue remains the tracker for every
+residual class below until its definition of done is met.
+
+4. Follow-up, real disagreements rather than enrolment omissions:
+   `histogram_quantile_avg_by_le`,
+   `histogram_quantile_sum_by_le`, and `histogram_quantile_with_filter` differ
+   by final-bit float values; `histogram_quantile_classic_duplicate_bounds`,
+   `histogram_quantile_classic_latest_sample`, and
+   `histogram_quantile_classic_multi_series` have material wrong values.
+5. Follow-up, separately audit the native-histogram semantic residue,
+   structurally non-sample metadata/exemplar/duplicate-labelset fixtures, and
+   the two DELTA-temporality counter fixtures. Each must either enrol or gain a
+   named mechanical comparison contract before #1986 can close.

--- a/test/regression/parity_contract_test.go
+++ b/test/regression/parity_contract_test.go
@@ -171,7 +171,7 @@ func TestParityEnrolmentFloor(t *testing.T) {
 
 	// parityEnrolmentFloor is the number of fixtures currently carrying a
 	// `parity:` section. It ratchets UP only.
-	const parityEnrolmentFloor = 578
+	const parityEnrolmentFloor = 582
 
 	enrolled := 0
 	for _, dir := range parityFixtureDirs(t) {

--- a/test/spec/parity_chdb.go
+++ b/test/spec/parity_chdb.go
@@ -883,6 +883,7 @@ func readSeededClassicHistograms(
 	}
 	defer func() { _ = rows.Close() }()
 
+	countDeclared := hasColumn(seedCols, colCount)
 	for rows.Next() {
 		var name, attrsJSON, resAttrsJSON, serviceName, countsJSON, boundsJSON string
 		var tsMillis int64
@@ -917,6 +918,12 @@ func readSeededClassicHistograms(
 					"overflow bucket", name, len(counts), len(bounds),
 			)
 		}
+		if !countDeclared {
+			// Cerberus derives a classic histogram's total from its per-bucket
+			// counts when the physical Count column is absent. The seed DDL
+			// backfill is zero only to keep INSERT arity valid, not data.
+			count = totalClassicHistogramObservations(counts)
+		}
 
 		cumulative := 0.0
 		for i, bound := range bounds {
@@ -938,6 +945,14 @@ func readSeededClassicHistograms(
 		}
 	}
 	return rows.Err()
+}
+
+func totalClassicHistogramObservations(counts []float64) float64 {
+	total := 0.0
+	for _, count := range counts {
+		total += count
+	}
+	return total
 }
 
 // formatBucketBound renders a bucket boundary the way the `le` label

--- a/test/spec/parity_columns_chdb_test.go
+++ b/test/spec/parity_columns_chdb_test.go
@@ -269,10 +269,7 @@ func TestResourceAttributesProjectionFallsBackWhenUnseeded(t *testing.T) {
 // a reference answer that disagrees with cerberus for a reason that is
 // the translator's fault rather than the lowering's.
 func TestReadSeededClassicHistograms(t *testing.T) {
-	chdbEngineMu.Lock()
-	defer chdbEngineMu.Unlock()
-
-	const seed = `CREATE TABLE otel_metrics_histogram (
+	const declaredCountSeed = `CREATE TABLE otel_metrics_histogram (
     MetricName String,
     Attributes Map(String, String),
     TimeUnix DateTime64(9),
@@ -282,45 +279,70 @@ func TestReadSeededClassicHistograms(t *testing.T) {
     ExplicitBounds Array(Float64)
 ) ENGINE = MergeTree ORDER BY (MetricName, Attributes, TimeUnix);
 INSERT INTO otel_metrics_histogram VALUES
-    ('lat', map('service', 'api'), toDateTime64('2026-01-01 00:00:00', 9), 21, 10.0, [1, 2, 3, 4, 5, 6], [1.0, 2.0, 3.0, 4.0, 5.0]);`
+	    ('lat', map('service', 'api'), toDateTime64('2026-01-01 00:00:00', 9), 19, 10.0, [1, 2, 3, 4, 5, 6], [1.0, 2.0, 3.0, 4.0, 5.0]);`
+	const omittedCountSeed = `CREATE TABLE otel_metrics_histogram (
+    MetricName String,
+    Attributes Map(String, String),
+    TimeUnix DateTime64(9),
+    Sum Float64,
+    BucketCounts Array(UInt64),
+    ExplicitBounds Array(Float64)
+) ENGINE = MergeTree ORDER BY (MetricName, Attributes, TimeUnix);
+INSERT INTO otel_metrics_histogram VALUES
+    ('lat', map('service', 'api'), toDateTime64('2026-01-01 00:00:00', 9), 10.0, [1, 2, 3, 4, 5, 6], [1.0, 2.0, 3.0, 4.0, 5.0]);`
 
-	db := OpenChDB(t)
-	ApplySeed(t, db, seed)
+	for _, tc := range []struct {
+		name  string
+		seed  string
+		count float64
+	}{
+		{name: "declared count is preserved", seed: declaredCountSeed, count: 19},
+		{name: "omitted count is derived from buckets", seed: omittedCountSeed, count: 21},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			chdbEngineMu.Lock()
+			defer chdbEngineMu.Unlock()
 
-	byKey := map[string]*oracle.Series{}
-	nameRestorer := newMetricNameRestorer()
-	if err := readSeededClassicHistograms(db, &RoundTripSections{Seed: seed}, nil, byKey, &nameRestorer); err != nil {
-		t.Fatalf("readSeededClassicHistograms: %v", err)
-	}
+			db := OpenChDB(t)
+			ApplySeed(t, db, tc.seed)
 
-	// Per-bucket counts [1 2 3 4 5 6] accumulate to [1 3 6 10 15], and the
-	// overflow bucket is the total Count.
-	want := map[string]float64{
-		`__name__=lat_bucket,le=1,service=api`:    1,
-		`__name__=lat_bucket,le=2,service=api`:    3,
-		`__name__=lat_bucket,le=3,service=api`:    6,
-		`__name__=lat_bucket,le=4,service=api`:    10,
-		`__name__=lat_bucket,le=5,service=api`:    15,
-		`__name__=lat_bucket,le=+Inf,service=api`: 21,
-		`__name__=lat_count,service=api`:          21,
-		`__name__=lat_sum,service=api`:            10,
-	}
-	if len(byKey) != len(want) {
-		t.Fatalf("read %d series, want %d: %v", len(byKey), len(want), byKey)
-	}
-	for key, wantValue := range want {
-		s, ok := byKey[key]
-		if !ok {
-			t.Errorf("series %s was not reconstructed", key)
-			continue
-		}
-		if len(s.Points) != 1 {
-			t.Errorf("series %s has %d points, want 1", key, len(s.Points))
-			continue
-		}
-		if !oracle.EqualValues(s.Points[0].Value, wantValue) {
-			t.Errorf("series %s = %v, want %v", key, s.Points[0].Value, wantValue)
-		}
+			byKey := map[string]*oracle.Series{}
+			nameRestorer := newMetricNameRestorer()
+			if err := readSeededClassicHistograms(
+				db, &RoundTripSections{Seed: tc.seed}, nil, byKey, &nameRestorer,
+			); err != nil {
+				t.Fatalf("readSeededClassicHistograms: %v", err)
+			}
+
+			// Per-bucket counts [1 2 3 4 5 6] accumulate to [1 3 6 10 15].
+			want := map[string]float64{
+				`__name__=lat_bucket,le=1,service=api`:    1,
+				`__name__=lat_bucket,le=2,service=api`:    3,
+				`__name__=lat_bucket,le=3,service=api`:    6,
+				`__name__=lat_bucket,le=4,service=api`:    10,
+				`__name__=lat_bucket,le=5,service=api`:    15,
+				`__name__=lat_bucket,le=+Inf,service=api`: tc.count,
+				`__name__=lat_count,service=api`:          tc.count,
+				`__name__=lat_sum,service=api`:            10,
+			}
+			if len(byKey) != len(want) {
+				t.Fatalf("read %d series, want %d: %v", len(byKey), len(want), byKey)
+			}
+			for key, wantValue := range want {
+				s, ok := byKey[key]
+				if !ok {
+					t.Errorf("series %s was not reconstructed", key)
+					continue
+				}
+				if len(s.Points) != 1 {
+					t.Errorf("series %s has %d points, want 1", key, len(s.Points))
+					continue
+				}
+				if !oracle.EqualValues(s.Points[0].Value, wantValue) {
+					t.Errorf("series %s = %v, want %v", key, s.Points[0].Value, wantValue)
+				}
+			}
+		})
 	}
 }
 

--- a/test/spec/promql/histogram_quantile_agg_no_range_wrapper.txtar
+++ b/test/spec/promql/histogram_quantile_agg_no_range_wrapper.txtar
@@ -1,5 +1,9 @@
 -- query.promql --
 histogram_quantile(0.5, sum by(le)(http_server_request_duration_bucket))
+-- parity --
+oracle: prometheus
+endpoint: /api/v1/query
+scope: full
 -- seed --
 CREATE TABLE otel_metrics_histogram (
     MetricName String,

--- a/test/spec/promql/histogram_quantile_classic_negative_bound_upper_rank.txtar
+++ b/test/spec/promql/histogram_quantile_classic_negative_bound_upper_rank.txtar
@@ -9,6 +9,10 @@
 # across (0, 5] : 0 + (5-0) * (5.6-5)/(6-5) = 3.
 -- query.promql --
 histogram_quantile(0.8, http_server_request_duration_bucket)
+-- parity --
+oracle: prometheus
+endpoint: /api/v1/query
+scope: full
 -- seed --
 CREATE TABLE otel_metrics_histogram (
     MetricName String,

--- a/test/spec/promql/histogram_quantile_classic_plateau_overflow.txtar
+++ b/test/spec/promql/histogram_quantile_classic_plateau_overflow.txtar
@@ -14,6 +14,10 @@
 
 -- query.promql --
 histogram_quantile(0.8, http_server_request_duration_bucket)
+-- parity --
+oracle: prometheus
+endpoint: /api/v1/query
+scope: full
 -- seed --
 CREATE TABLE otel_metrics_histogram (
     MetricName String,

--- a/test/spec/promql/histogram_quantile_classic_zero_count_plateau.txtar
+++ b/test/spec/promql/histogram_quantile_classic_zero_count_plateau.txtar
@@ -21,6 +21,10 @@
 
 -- query.promql --
 histogram_quantile(0.4, http_server_request_duration_bucket)
+-- parity --
+oracle: prometheus
+endpoint: /api/v1/query
+scope: full
 -- seed --
 CREATE TABLE otel_metrics_histogram (
     MetricName String,


### PR DESCRIPTION
Refs #1986

## Summary

Derives omitted classic histogram counts for the independent parity input and enrols four classic histogram quantile fixtures.

## Test plan

- Focused parity reader and floor tests
- PromQL parity fixture execution
- Generated artifact review

The parent epic remains open for its named residual classes.