### PR TITLE
fix(crawl): partition frontier ownership across shards

### DIFF
--- a/.github/scripts/compose-smoke-matrix.mjs
+++ b/.github/scripts/compose-smoke-matrix.mjs
@@ -89,6 +89,7 @@ const NONCRAWL_SHARD_TIMEOUT_LEAN_MIN = 45;
 // decide which shard outcomes gate it. Emitted from a single source of truth so
 // the de-gate can't drift from the partition.
 const GATE_EXCLUDED_SHARDS = ['shard-crawl'];
+export const CRAWL_FRONTIER_SHARD_COUNT = 3;
 
 // ---------------------------------------------------------------------------
 // The wall-clock-balanced partition of the compose-smoke spec set.
@@ -260,6 +261,14 @@ const shardEntry = (s, opts) => ({
   timeoutMinutes: shardTimeoutMinutes(s.name, opts),
 });
 
+export const crawlShardEntries = (s, opts) =>
+  Array.from({ length: opts.regeneratesComposeInventory ? 1 : CRAWL_FRONTIER_SHARD_COUNT }, (_, crawlShardIndex) => ({
+    ...shardEntry(s, opts),
+    name: `${s.name}-${crawlShardIndex}`,
+    crawlShardIndex,
+    crawlShardCount: opts.regeneratesComposeInventory ? 1 : CRAWL_FRONTIER_SHARD_COUNT,
+  }));
+
 const isGateExcluded = (name) => GATE_EXCLUDED_SHARDS.includes(name);
 
 function emit() {
@@ -289,7 +298,7 @@ function emit() {
   const informational = SHARDS.filter((s) => isGateExcluded(s.name));
 
   setOutput('matrix', JSON.stringify({ include: required.map((s) => shardEntry(s, depthOpts)) }));
-  setOutput('matrix_informational', JSON.stringify({ include: informational.map((s) => shardEntry(s, depthOpts)) }));
+  setOutput('matrix_informational', JSON.stringify({ include: informational.flatMap((s) => crawlShardEntries(s, depthOpts)) }));
   setOutput('has_informational', informational.length > 0 ? 'true' : 'false');
   setOutput('shard_names', JSON.stringify(SHARDS.map((s) => s.name)));
   setOutput('gate_excluded', JSON.stringify(GATE_EXCLUDED_SHARDS));

--- a/.github/scripts/compose-smoke-matrix.test.mjs
+++ b/.github/scripts/compose-smoke-matrix.test.mjs
@@ -20,6 +20,9 @@ import {
   collectViolations,
   shardSweepDepth,
   shardTimeoutMinutes,
+  CRAWL_FRONTIER_SHARD_COUNT,
+  crawlShardEntries,
+  SHARDS,
 } from './compose-smoke-matrix.mjs';
 import {
   CRAWL_SHARD_TIMEOUT_FULL_MIN,
@@ -117,4 +120,20 @@ test('every shard ceiling outlives the spec budget at its own depth', () => {
       `crawl ceiling must follow its own sweep depth (${depth})`,
     );
   }
+});
+
+test('the crawl frontier count is a positive matrix fan-out', () => {
+  assert.ok(Number.isInteger(CRAWL_FRONTIER_SHARD_COUNT));
+  assert.ok(CRAWL_FRONTIER_SHARD_COUNT > 1);
+});
+
+test('inventory regeneration emits one unsharded compose crawl writer', () => {
+  const crawl = SHARDS.find((shard) => shard.name === CRAWL_SHARD);
+  assert.ok(crawl, 'the crawl shard must exist');
+  assert.deepEqual(
+    crawlShardEntries(crawl, { isSchedule: false, regeneratesComposeInventory: true }).map(
+      (entry) => [entry.crawlShardIndex, entry.crawlShardCount],
+    ),
+    [[0, 1]],
+  );
 });

--- a/.github/scripts/crawl-frontier-workflow.test.mjs
+++ b/.github/scripts/crawl-frontier-workflow.test.mjs
@@ -1,0 +1,39 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { test } from 'node:test';
+
+const workflow = readFileSync(resolve('.github/workflows/e2e.yml'), 'utf8');
+
+test('dashboard release status needs and rejects the crawl-slice merge', () => {
+  assert.match(
+    workflow,
+    /dashboard:\n    name: dashboard\n    needs: \[dashboard-setup, dashboard-shard, dashboard-crawl-merge\]/,
+  );
+  assert.match(
+    workflow,
+    /dashboard crawl slice merge did not succeed \(\$\{\{ needs\.dashboard-crawl-merge\.result \}\}\)/,
+  );
+});
+
+test('release PRs run the crawl matrix and its merge', () => {
+  assert.match(
+    workflow,
+    /RUN_SHARD: \$\{\{ matrix\.crawlStack != 'k3d' \|\| github\.event_name == 'schedule' \|\| github\.event_name == 'workflow_dispatch' \|\| startsWith\(github\.head_ref, 'release\/'\) \}\}/,
+  );
+  assert.match(
+    workflow,
+    /github\.event_name == 'schedule' \|\| startsWith\(github\.head_ref, 'release\/'\) \|\|\n      \(github\.event_name == 'workflow_dispatch'/,
+  );
+});
+
+test('ordinary dispatches merge slices while k3d regeneration remains unsharded', () => {
+  assert.match(
+    workflow,
+    /github\.event_name == 'workflow_dispatch' &&\n      inputs\.update_crawl_inventory != 'k3d' && inputs\.update_crawl_inventory != 'both'/,
+  );
+  assert.match(
+    workflow,
+    /matrix\.crawlShardCount > 1/,
+  );
+});

--- a/.github/scripts/dashboard-matrix.mjs
+++ b/.github/scripts/dashboard-matrix.mjs
@@ -12,28 +12,11 @@
 // against the single k3d Grafana, followed — on schedule/dispatch only — by the
 // k3d crawl trio (crawl/crawl.spec.ts + dsquery + lints) at SWEEP_DEPTH=full.
 //
-// The dominant cost is crawl/crawl.spec.ts: a SINGLE async BFS `test()` that
-// walks every reachable Grafana surface — the ~50min long pole at
-// SWEEP_DEPTH=full. It is indivisible by Playwright's native `--shard` (which
-// splits at `test()` granularity, so a one-test spec stays whole) AND by
-// spec-file sharding (it is one file, one test). The only parallelism this PR
-// buys is LOGICAL and COARSE: split the non-crawl smoke specs across N k3d
-// clusters running concurrently, and put the crawl trio on its OWN dedicated
-// k3d cluster so the ~50min crawl runs CONCURRENTLY with the smoke shards
-// instead of serially after them. Wall-clock drops from
-// (smoke serial + crawl) toward max(crawl ~50min, slowest smoke shard).
-//
-// What this manifest does NOT do (the follow-up): it does not split the crawl
-// BFS frontier itself. Beating the ~50min floor needs the crawl engine to
-// PARTITION its discovered frontier across shards (a CRAWL_SHARD_INDEX /
-// CRAWL_SHARD_COUNT contract that deterministically assigns each discovered
-// surface to a shard, with each shard emitting its visited slice and a final
-// job merging + asserting the union against the pinned inventory). That is a
-// deep change to the 1383-line BFS + the inventory ratchet (lib.ts diffInventory
-// asserts the WHOLE visited set) — tracked as tsouza/cerberus#2005, unblocked
-// now that the k3d inventory is bootstrapped (grafana-surface-inventory.k3d.json,
-// tsouza/cerberus#1539) but not yet designed or built. This manifest is the
-// safe, coarse win that lands first.
+// The crawl remains one Playwright test, so native --shard cannot split it.
+// Its CRAWL_SHARD_INDEX / CRAWL_SHARD_COUNT contract instead fans the expensive
+// oracle and interaction work over isolated clusters. Every shard retains link
+// discovery, writes its owned visited slice, and dashboard-crawl-merge applies
+// the inventory ratchet once over their union.
 //
 // k3d cost/flake trade-off: a k3d cluster is heavy (~3-5min bring-up) and flaky
 // (telemetrygen / otel-collector-gateway readiness BackOff). A matrix of N
@@ -92,6 +75,7 @@ const CRAWL_STACK_NONE = '';
 // lane exists to do the exhaustive sweep). Named because the crawl shard's job
 // timeout is derived from the spec budget AT THIS DEPTH.
 const CRAWL_SHARD_SWEEP_DEPTH = 'full';
+export const CRAWL_FRONTIER_SHARD_COUNT = 3;
 
 // Chart deployment topologies the smoke lane exercises (E2E_MODE in `just
 // e2e-up`). The SAME Grafana/Playwright smoke runs against both: `monolith`
@@ -310,7 +294,7 @@ function verify() {
 //
 // Each entry's `name` encodes the mode (e.g. shard-smoke-a-monolith) so the
 // matrix keys, concurrency group, and artifact names stay unique.
-export function buildMatrix(includeCrawl, includeSplit) {
+export function buildMatrix(includeCrawl, includeSplit, regeneratesK3DInventory = false) {
   const include = [];
   // Split mode doubles the k3d boot count (the setup-bound long pole) for one
   // unique spec (split_isolation), so per-PR it's cost + flake with little
@@ -321,14 +305,19 @@ export function buildMatrix(includeCrawl, includeSplit) {
     if (s.crawlStack === CRAWL_STACK_K3D) {
       // Crawl: monolith-only, dispatched only when crawl is included.
       if (!includeCrawl) continue;
-      include.push({
-        name: `${s.name}-${MODE_MONOLITH}`,
-        mode: MODE_MONOLITH,
-        specs: s.specs.join(' '),
-        crawlStack: s.crawlStack,
-        runGoE2E: s.runGoE2E,
-        timeoutMinutes: shardTimeoutMinutes(s),
-      });
+      const crawlShardCount = regeneratesK3DInventory ? 1 : CRAWL_FRONTIER_SHARD_COUNT;
+      for (let crawlShardIndex = 0; crawlShardIndex < crawlShardCount; crawlShardIndex++) {
+        include.push({
+          name: `${s.name}-${crawlShardIndex}-${MODE_MONOLITH}`,
+          mode: MODE_MONOLITH,
+          specs: s.specs.join(' '),
+          crawlStack: s.crawlStack,
+          crawlShardIndex,
+          crawlShardCount,
+          runGoE2E: s.runGoE2E,
+          timeoutMinutes: shardTimeoutMinutes(s),
+        });
+      }
       continue;
     }
     // Smoke shard: one entry per enabled mode.
@@ -362,7 +351,9 @@ function emit() {
   // dispatched on those events.
   const includeCrawl = process.env.INCLUDE_CRAWL === 'true';
   const includeSplit = process.env.INCLUDE_SPLIT === 'true';
-  const include = buildMatrix(includeCrawl, includeSplit);
+  const regeneratesK3DInventory =
+    process.env.UPDATE_CRAWL_INVENTORY === 'k3d' || process.env.UPDATE_CRAWL_INVENTORY === 'both';
+  const include = buildMatrix(includeCrawl, includeSplit, regeneratesK3DInventory);
   setOutput('matrix', JSON.stringify({ include }));
   setOutput('shard_names', JSON.stringify(include.map((e) => e.name)));
   appendStepSummary(

--- a/.github/scripts/dashboard-matrix.test.mjs
+++ b/.github/scripts/dashboard-matrix.test.mjs
@@ -25,6 +25,7 @@ import {
   MODE_SPLIT,
   SPLIT_ONLY_SPECS,
   CRAWL_STACK_K3D,
+  CRAWL_FRONTIER_SHARD_COUNT,
 } from './dashboard-matrix.mjs';
 
 test('live tree: SHARDS ∪ EXCLUDED is a total, disjoint cover (no violations)', () => {
@@ -159,8 +160,20 @@ test('buildMatrix: the crawl shard runs once, monolith-only, and only when crawl
   );
   const withCrawl = buildMatrix(true);
   const crawlEntries = withCrawl.filter((e) => e.crawlStack === CRAWL_STACK_K3D);
-  assert.equal(crawlEntries.length, 1, 'crawl must be dispatched exactly once when included');
-  assert.equal(crawlEntries[0].mode, MODE_MONOLITH, 'the crawl shard is monolith-only');
+  assert.equal(crawlEntries.length, CRAWL_FRONTIER_SHARD_COUNT, 'crawl must dispatch every frontier shard');
+  assert.deepEqual(crawlEntries.map((entry) => entry.crawlShardIndex).sort(), [...Array(CRAWL_FRONTIER_SHARD_COUNT).keys()]);
+  assert.ok(crawlEntries.every((entry) => entry.mode === MODE_MONOLITH), 'crawl shards are monolith-only');
+});
+
+test('buildMatrix: inventory regeneration emits one unsharded crawl writer', () => {
+  const crawlEntries = buildMatrix(true, true, true).filter(
+    (entry) => entry.crawlStack === CRAWL_STACK_K3D,
+  );
+  assert.deepEqual(
+    crawlEntries.map((entry) => [entry.crawlShardIndex, entry.crawlShardCount]),
+    [[0, 1]],
+    'a regeneration must have one writer rather than slice artifacts to merge',
+  );
 });
 
 test('buildMatrix: every emitted entry has a non-empty spec list and a filename-safe name', () => {

--- a/.github/scripts/merge-crawl-slices.mjs
+++ b/.github/scripts/merge-crawl-slices.mjs
@@ -1,0 +1,134 @@
+// merge-crawl-slices.mjs — merge isolated crawl shard artifacts and apply the
+// inventory ratchet once. Env: CRAWL_SLICE_DIR, CRAWL_STACK, SWEEP_DEPTH.
+
+import { readdirSync, readFileSync } from 'node:fs';
+import { join, resolve } from 'node:path';
+import process from 'node:process';
+
+const inventoryFilename = (stack) => `grafana-surface-inventory.${stack}.json`;
+
+export function owner(canonical, count) {
+  const base = canonical.split('#', 1)[0].split('?', 1)[0];
+  let hash = 0;
+  for (let i = 0; i < base.length; i++) hash = (hash * 31 + base.charCodeAt(i)) >>> 0;
+  return hash % count;
+}
+
+export function mergeSlices(slices, { stack, depth, inventory, exclusions, inventoryFilename }) {
+  const filename = inventoryFilename ?? `grafana-surface-inventory.${stack}.json`;
+  if (!Array.isArray(inventory.surfaces)) {
+    throw new Error(`loadInventory: ${filename} has no surfaces[] array`);
+  }
+  if (inventory.stack !== stack) {
+    throw new Error(
+      `loadInventory: ${filename} pins stack ${JSON.stringify(inventory.stack)} ` +
+        `but the active config is ${JSON.stringify(stack)} — the config points at the wrong file`,
+    );
+  }
+  const exclusionsFilename = `grafana-surface-exclusions.${stack}.json`;
+  if (!Array.isArray(exclusions.exclusions)) {
+    throw new Error(`loadExclusions: ${exclusionsFilename} has no exclusions[] array`);
+  }
+  if (slices.length === 0) throw new Error('crawl slice merge received no slice artifacts');
+  const count = slices[0].shard?.count;
+  if (!Number.isInteger(count) || count < 1) throw new Error('crawl slice has an invalid shard count');
+  const indexes = new Set();
+  const visited = new Set();
+  const discovered = new Set();
+  for (const slice of slices) {
+    if (slice.stack !== stack || slice.depth !== depth || slice.shard?.count !== count) {
+      throw new Error('crawl slice metadata does not match the merge invocation');
+    }
+    const index = slice.shard.index;
+    if (!Number.isInteger(index) || index < 0 || index >= count || indexes.has(index)) {
+      throw new Error(`crawl slices do not form a unique shard cover at index ${index}`);
+    }
+    indexes.add(index);
+    for (const url of slice.visited ?? []) {
+      if (owner(url, count) !== index) throw new Error(`crawl slice ${index} contains unowned state ${url}`);
+      visited.add(url);
+    }
+    for (const url of slice.discovered ?? []) discovered.add(url);
+  }
+  if (indexes.size !== count) throw new Error(`crawl slices cover ${indexes.size} of ${count} shards`);
+
+  const excluded = new Set();
+  const violations = [];
+  for (const exclusion of exclusions.exclusions) {
+    if (!exclusion.rationale || exclusion.rationale.trim() === '') {
+      violations.push(
+        `exclusion ${JSON.stringify(exclusion.url)} has no rationale — every exclusion must document why the surface is genuinely uncrawlable`,
+      );
+    }
+    if (excluded.has(exclusion.url)) {
+      violations.push(`exclusion ${JSON.stringify(exclusion.url)} is listed twice`);
+    }
+    excluded.add(exclusion.url);
+  }
+  const expected = new Set(
+    inventory.surfaces
+      .filter((surface) => depth === 'full' || surface.lean)
+      .map((surface) => surface.url),
+  );
+  for (const surface of inventory.surfaces) {
+    if (excluded.has(surface.url)) {
+      violations.push(
+        `surface ${JSON.stringify(surface.url)} is in BOTH the inventory and the exclusions file — a crawled surface cannot be excluded (stale exclusion)`,
+      );
+    }
+  }
+  const ratcheted = new Set([...visited, ...discovered]);
+  for (const url of [...ratcheted].sort()) {
+    if (!expected.has(url)) {
+      violations.push(
+        `NEW surface ${JSON.stringify(url)} visited but not pinned in ${filename} — coverage grew; regenerate deliberately with CERBERUS_UPDATE_INVENTORY=1 SWEEP_DEPTH=full CRAWL_STACK=${stack}`,
+      );
+    }
+  }
+  for (const url of [...expected].sort()) {
+    if (!visited.has(url)) {
+      violations.push(
+        `pinned surface ${JSON.stringify(url)} (${depth} set) was NOT visited — coverage shrank; fix the crawl/stack regression, never delete the row to make this pass`,
+      );
+    }
+  }
+  return { visited, discovered, violations };
+}
+
+function main() {
+  const dir = process.env.CRAWL_SLICE_DIR;
+  const stack = process.env.CRAWL_STACK;
+  if (!dir || !stack) {
+    throw new Error('CRAWL_SLICE_DIR and CRAWL_STACK are required');
+  }
+  const slices = readdirSync(dir)
+    .filter((name) => name.endsWith('.json'))
+    .map((name) => JSON.parse(readFileSync(join(dir, name), 'utf8')));
+  const depth = process.env.SWEEP_DEPTH ?? slices[0]?.depth;
+  if (depth !== 'lean' && depth !== 'full') {
+    throw new Error('crawl slices must declare SWEEP_DEPTH=lean|full');
+  }
+  const crawlDir = resolve('test/e2e/playwright/crawl');
+  const inventory = JSON.parse(readFileSync(join(crawlDir, inventoryFilename(stack)), 'utf8'));
+  const exclusions = JSON.parse(readFileSync(join(crawlDir, `grafana-surface-exclusions.${stack}.json`), 'utf8'));
+  const result = mergeSlices(slices, {
+    stack,
+    depth,
+    inventory,
+    exclusions,
+    inventoryFilename: inventoryFilename(stack),
+  });
+  if (result.violations.length > 0) {
+    throw new Error(`surface-inventory ratchet violated:\n  - ${result.violations.join('\n  - ')}`);
+  }
+  console.log(`crawl slice merge: ${result.visited.size} audited states from ${slices.length} shards`);
+}
+
+if (process.argv[1] && import.meta.url === new URL(`file://${process.argv[1]}`).href) {
+  try {
+    main();
+  } catch (error) {
+    console.error(error.message);
+    process.exit(1);
+  }
+}

--- a/.github/scripts/merge-crawl-slices.test.mjs
+++ b/.github/scripts/merge-crawl-slices.test.mjs
@@ -1,0 +1,132 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+
+import { mergeSlices, owner } from './merge-crawl-slices.mjs';
+
+const stack = 'compose';
+const shardCount = 2;
+const otherOwnerURL = (url) => {
+  const wanted = 1 - owner(url, shardCount);
+  for (let suffix = 0; ; suffix++) {
+    const candidate = `/surface-${suffix}`;
+    if (owner(candidate, shardCount) === wanted) return candidate;
+  }
+};
+const sameOwnerURL = (url) => {
+  const wanted = owner(url, shardCount);
+  for (let suffix = 0; ; suffix++) {
+    const candidate = `/same-owner-${suffix}`;
+    if (owner(candidate, shardCount) === wanted) return candidate;
+  }
+};
+const shard = (index, visited, discovered = visited) => ({
+  stack,
+  depth: 'full',
+  shard: { index, count: 2 },
+  visited,
+  discovered,
+});
+
+test('owner keeps URL-encoded interaction states with their source route', () => {
+  const source = '/a/grafana-exploretraces-app/explore';
+  const interactionURL = `${source}?actionView=traceList&var-primarySignal=kind=server`;
+  const inPlaceState = `${interactionURL}#tabs[Favorites|All]=All`;
+  assert.equal(owner(interactionURL, shardCount), owner(source, shardCount));
+  assert.equal(owner(inPlaceState, shardCount), owner(source, shardCount));
+});
+
+test('mergeSlices accepts a total, owned shard cover', () => {
+  const one = '/one';
+  const two = `${otherOwnerURL(one)}#state=x`;
+  const inventory = { stack, surfaces: [{ url: one, lean: true }, { url: two, lean: false }] };
+  const slices = [shard(owner(one, shardCount), [one]), shard(owner(two, shardCount), [two])];
+  assert.deepEqual(
+    mergeSlices(slices, { stack, depth: 'full', inventory, exclusions: { exclusions: [] } }).violations,
+    [],
+  );
+});
+
+test('mergeSlices rejects missing owners and coverage growth', () => {
+  assert.throws(
+    () => mergeSlices([shard(0, [])], { stack, depth: 'full', inventory: { stack, surfaces: [] }, exclusions: { exclusions: [] } }),
+    /cover 1 of 2/,
+  );
+  const first = '/one';
+  const second = `${otherOwnerURL(first)}#state=x`;
+  const inventory = { stack, surfaces: [{ url: first, lean: true }, { url: second, lean: false }] };
+  const newURL = sameOwnerURL(first);
+  const slices = [shard(owner(first, shardCount), [first, newURL]), shard(owner(second, shardCount), [second])];
+  assert.match(
+    mergeSlices(slices, { stack, depth: 'full', inventory, exclusions: { exclusions: [] } }).violations.join('\n'),
+    /NEW surface/,
+  );
+});
+
+test('mergeSlices ratchets audited interaction states, not only discovered URLs', () => {
+  const first = '/one';
+  const second = `${otherOwnerURL(first)}#state=x`;
+  const inventory = { stack, surfaces: [{ url: first, lean: true }, { url: second, lean: false }] };
+  const slices = [
+    shard(owner(first, shardCount), [first, '/one#control=value'], [first]),
+    shard(owner(second, shardCount), [second]),
+  ];
+  const result = mergeSlices(slices, {
+    stack,
+    depth: 'full',
+    inventory,
+    exclusions: { exclusions: [] },
+  });
+  assert.match(result.violations.join('\n'), /NEW surface "\/one#control=value" visited but not pinned/);
+});
+
+test('mergeSlices preserves every exclusion violation diffInventory reports', () => {
+  const first = '/one';
+  const second = `${otherOwnerURL(first)}#state=x`;
+  const inventory = { stack, surfaces: [{ url: first, lean: true }, { url: second, lean: false }] };
+  const slices = [shard(owner(first, shardCount), [first]), shard(owner(second, shardCount), [second])];
+  const result = mergeSlices(slices, {
+    stack,
+    depth: 'full',
+    inventory,
+    exclusions: {
+      exclusions: [
+        { url: first, rationale: '' },
+        { url: first, rationale: 'duplicate stale exclusion' },
+      ],
+    },
+  });
+  assert.match(result.violations.join('\n'), /has no rationale/);
+  assert.match(result.violations.join('\n'), /is listed twice/);
+  assert.match(result.violations.join('\n'), /is in BOTH the inventory and the exclusions file/);
+});
+
+test('mergeSlices reports cross-owner discovery as inventory growth', () => {
+  const first = '/one';
+  const second = `${otherOwnerURL(first)}#state=x`;
+  const crossOwner = otherOwnerURL(first);
+  const inventory = { stack, surfaces: [{ url: first, lean: true }, { url: second, lean: false }] };
+  const result = mergeSlices(
+    [
+      shard(owner(first, shardCount), [first], [first, crossOwner]),
+      shard(owner(second, shardCount), [second]),
+    ],
+    { stack, depth: 'full', inventory, exclusions: { exclusions: [] } },
+  );
+  assert.match(result.violations.join('\n'), new RegExp(`NEW surface ${JSON.stringify(crossOwner)}`));
+});
+
+test('mergeSlices validates inventory and exclusion files like crawl/lib.ts', () => {
+  const slices = [shard(0, []), shard(1, [])];
+  assert.throws(
+    () => mergeSlices(slices, { stack, depth: 'full', inventory: { stack }, exclusions: { exclusions: [] } }),
+    /has no surfaces\[\] array/,
+  );
+  assert.throws(
+    () => mergeSlices(slices, { stack, depth: 'full', inventory: { stack: 'k3d', surfaces: [] }, exclusions: { exclusions: [] } }),
+    /pins stack "k3d" but the active config is "compose"/,
+  );
+  assert.throws(
+    () => mergeSlices(slices, { stack, depth: 'full', inventory: { stack, surfaces: [] }, exclusions: {} }),
+    /has no exclusions\[\] array/,
+  );
+});

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -706,6 +706,9 @@ jobs:
           CERBERUS_URL: http://localhost:8080
           SWEEP_DEPTH: ${{ matrix.sweepDepth }}
           CRAWL_STACK: compose
+          CRAWL_SHARD_INDEX: ${{ matrix.crawlShardIndex }}
+          CRAWL_SHARD_COUNT: ${{ matrix.crawlShardCount }}
+          CRAWL_SLICE_PATH: crawl-slice.json
           # Regen path for grafana-surface-inventory.compose.json — the
           # compose-stack equivalent of the k3d dashboard-shard's
           # CERBERUS_UPDATE_INVENTORY (tsouza/cerberus#1826). Only this shard
@@ -718,6 +721,15 @@ jobs:
               '1' || ''
             }}
         run: npx playwright test ${{ matrix.specs }} --reporter=list,html
+
+      - name: Upload compose crawl slice
+        if: always() && matrix.crawlShardCount > 1
+        uses: actions/upload-artifact@v7
+        with:
+          name: crawl-slice-compose-${{ matrix.crawlShardIndex }}
+          path: test/e2e/playwright/crawl-slice.json
+          if-no-files-found: error
+          retention-days: 7
 
       # Bootstrap/regen path for
       # test/e2e/playwright/crawl/grafana-surface-inventory.compose.json —
@@ -778,6 +790,27 @@ jobs:
       - name: teardown
         if: always()
         run: docker compose down -v --remove-orphans
+
+  compose-crawl-merge:
+    name: compose-crawl-merge
+    needs: [compose-smoke-setup, compose-smoke-shard-info]
+    if: >-
+      needs.compose-smoke-setup.outputs.has_informational == 'true' &&
+      (github.event_name != 'workflow_dispatch' ||
+      (inputs.update_crawl_inventory != 'compose' && inputs.update_crawl_inventory != 'both'))
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/download-artifact@v8
+        with:
+          pattern: crawl-slice-compose-*
+          path: crawl-slices
+          merge-multiple: true
+      - name: Merge compose crawl slices and assert inventory
+        env:
+          CRAWL_SLICE_DIR: crawl-slices
+          CRAWL_STACK: compose
+        run: node .github/scripts/merge-crawl-slices.mjs
 
   # The AGGREGATOR — named EXACTLY `compose-smoke` because that is the name
   # release.yml's preflight looks for in RELEASE_REQUIRED_CHECKS. The matrix
@@ -897,13 +930,9 @@ jobs:
   # runs serially after the smoke set. Wall-clock drops from
   # (smoke serial + crawl) toward max(crawl ~50min, slowest smoke shard).
   #
-  # Beating the 50min floor itself needs the crawl ENGINE to partition its
-  # discovered BFS frontier across shards (a CRAWL_SHARD_INDEX/COUNT contract +
-  # a final union-merge-and-assert against the pinned inventory). That is a deep
-  # change to the 1383-line BFS + the inventory ratchet — tracked as
-  # tsouza/cerberus#2005, unblocked now that the k3d inventory is bootstrapped
-  # (tsouza/cerberus#1539) but not yet designed or built. This sharding is the
-  # safe coarse win that lands first.
+   # The crawl engine partitions its owned audit frontier with
+   # CRAWL_SHARD_INDEX/COUNT. Each shard uploads a slice and dashboard-crawl-merge
+   # asserts their union against the pinned inventory.
   #
   # k3d cost: a cluster is heavy (~3-5min bring-up), and a matrix of N clusters
   # multiplies that cost, so the shard count is kept at 3 — two smoke shards +
@@ -982,6 +1011,7 @@ jobs:
           # shipped in v1.4.0 precisely because the release commit's checks
           # never ran split; this closes that hole.)
           INCLUDE_SPLIT: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || startsWith(github.head_ref, 'release/') }}
+          UPDATE_CRAWL_INVENTORY: ${{ inputs.update_crawl_inventory }}
 
   dashboard-shard:
     name: dashboard-shard
@@ -1019,7 +1049,7 @@ jobs:
       # job. On push-to-main the crawl shard is a near-instant green no-op: every
       # expensive step below is gated on RUN_SHARD, which is false for the crawl
       # shard on a push event. The smoke shards always run.
-      RUN_SHARD: ${{ matrix.crawlStack != 'k3d' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}
+      RUN_SHARD: ${{ matrix.crawlStack != 'k3d' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || startsWith(github.head_ref, 'release/') }}
     steps:
       - uses: actions/checkout@v7
 
@@ -1216,6 +1246,9 @@ jobs:
           CERBERUS_URL: http://localhost:8080
           CRAWL_STACK: ${{ matrix.crawlStack }}
           SWEEP_DEPTH: full
+          CRAWL_SHARD_INDEX: ${{ matrix.crawlShardIndex }}
+          CRAWL_SHARD_COUNT: ${{ matrix.crawlShardCount }}
+          CRAWL_SLICE_PATH: crawl-slice.json
           CERBERUS_UPDATE_INVENTORY: >-
             ${{
               github.event_name == 'workflow_dispatch' &&
@@ -1223,6 +1256,15 @@ jobs:
               '1' || ''
             }}
         run: npx playwright test ${{ matrix.specs }} --reporter=list,html
+
+      - name: Upload k3d crawl slice
+        if: always() && matrix.crawlStack == 'k3d' && matrix.crawlShardCount > 1
+        uses: actions/upload-artifact@v7
+        with:
+          name: crawl-slice-k3d-${{ matrix.crawlShardIndex }}
+          path: test/e2e/playwright/crawl-slice.json
+          if-no-files-found: error
+          retention-days: 7
 
       - name: Upload regenerated k3d crawl inventory
         if: >-
@@ -1375,6 +1417,29 @@ jobs:
         if: always() && env.RUN_SHARD == 'true'
         run: just e2e-down
 
+  dashboard-crawl-merge:
+    name: dashboard-crawl-merge
+    needs: [dashboard-setup, dashboard-shard]
+    if: >-
+      always() && needs.dashboard-shard.result == 'success' &&
+      (github.event_name == 'schedule' || startsWith(github.head_ref, 'release/') ||
+      (github.event_name == 'workflow_dispatch' &&
+      inputs.update_crawl_inventory != 'k3d' && inputs.update_crawl_inventory != 'both'))
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/download-artifact@v8
+        with:
+          pattern: crawl-slice-k3d-*
+          path: crawl-slices
+          merge-multiple: true
+      - name: Merge k3d crawl slices and assert inventory
+        env:
+          CRAWL_SLICE_DIR: crawl-slices
+          CRAWL_STACK: k3d
+          SWEEP_DEPTH: full
+        run: node .github/scripts/merge-crawl-slices.mjs
+
   # The AGGREGATOR — a single clean pass/fail over every dashboard shard. The
   # lane runs on a `release/*` PR (a smoke-only matrix; see dashboard-setup),
   # and `dashboard` is named in release.yml's RELEASE_REQUIRED_CHECKS, exactly
@@ -1388,7 +1453,7 @@ jobs:
   # where dashboard-setup does not run).
   dashboard:
     name: dashboard
-    needs: [dashboard-setup, dashboard-shard]
+    needs: [dashboard-setup, dashboard-shard, dashboard-crawl-merge]
     if: always()
     runs-on: ubuntu-latest
     timeout-minutes: 5
@@ -1396,7 +1461,8 @@ jobs:
       - name: gate on every shard
         run: |
           echo "setup  = ${{ needs.dashboard-setup.result }}"
-          echo "shards = ${{ needs.dashboard-shard.result }}"
+           echo "shards = ${{ needs.dashboard-shard.result }}"
+           echo "crawl merge = ${{ needs.dashboard-crawl-merge.result }}"
           # If setup was skipped (docs-only PR, or a non-PR/push/schedule/
           # dispatch path), there is nothing to aggregate — report green
           # without work. On a code PR setup runs, so this branch does not fire
@@ -1415,11 +1481,21 @@ jobs:
             echo "::error::dashboard-setup did not succeed (${{ needs.dashboard-setup.result }})."
             exit 1
           fi
-          if [ "${{ needs.dashboard-shard.result }}" != "success" ]; then
+           if [ "${{ needs.dashboard-shard.result }}" != "success" ]; then
             echo "::error::one or more dashboard shards failed/cancelled (rolled-up: ${{ needs.dashboard-shard.result }})."
-            exit 1
-          fi
-          echo "all dashboard shards passed."
+             exit 1
+           fi
+           if [ "${{ github.event_name }}" = "schedule" ] || \
+              [ "${{ github.event_name }}" = "pull_request" ] || \
+              { [ "${{ github.event_name }}" = "workflow_dispatch" ] && \
+                [ "${{ inputs.update_crawl_inventory }}" != "k3d" ] && \
+                [ "${{ inputs.update_crawl_inventory }}" != "both" ]; }; then
+             if [ "${{ needs.dashboard-crawl-merge.result }}" != "success" ]; then
+               echo "::error::dashboard crawl slice merge did not succeed (${{ needs.dashboard-crawl-merge.result }})."
+               exit 1
+             fi
+           fi
+           echo "all dashboard shards passed."
 
   startup-bench:
     # Startup-speed benchmark: spawn cerberus and assert <2 s to /healthz.

--- a/docs/specs/crawl-frontier-partitioning.md
+++ b/docs/specs/crawl-frontier-partitioning.md
@@ -1,0 +1,67 @@
+# Spec: Crawl frontier partitioning
+
+Tracks issue #2005.
+
+## Problem
+
+`crawl/crawl.spec.ts` contains one BFS test which visits and interaction-sweeps every Grafana
+surface. Both `.github/scripts/compose-smoke-matrix.mjs` and
+`.github/scripts/dashboard-matrix.mjs` put that test in one `shard-crawl` entry, so it remains the
+full-depth wall-clock long pole.
+
+## Scope
+
+Included: deterministic `CRAWL_SHARD_INDEX` / `CRAWL_SHARD_COUNT` validation and ownership; a
+per-shard visited-slice artifact; a merge-and-ratchet command; and compose and k3d matrix wiring.
+
+Excluded: changing the crawler's canonicalization, page or interaction oracles, inventory format,
+or the crawl's release-gate posture.
+
+## Design
+
+The committed inventory is the common seed frontier. Each shard owns a canonical surface when a
+stable UTF-16 hash of its route path (the part before `?` or `#`) modulo the shard count equals its
+zero-based index. URL-encoded and in-place interaction states therefore remain with the page that
+can drive them, so the owning shard also audits every interaction result it discovers.
+
+Every shard still performs discovery from its owned pages. It emits only the states it audited plus
+the canonical links it discovered. The final merge unions audited slices and discovered canonicals,
+then runs the existing inventory comparison against the union. A discovered surface absent from the
+inventory consequently fails as growth even when its deterministic owner was not able to receive it
+within the isolated CI job. This is necessary because GitHub matrix jobs cannot exchange a live BFS
+frontier; the next deliberate inventory update makes the new surface a seed and assigns it normally.
+
+Unsharded execution remains the one-shard contract (`index=0`, `count=1`) and preserves the
+existing direct inventory regeneration path. Sharded runs never write the inventory directly; the
+merge command is the sole writer and requires full depth.
+
+The two matrix manifests create the same number of crawl entries, pass their index/count to the
+Playwright process, upload uniquely named slice artifacts, and run one merge job after all crawl
+entries complete. The merge job downloads every required slice, verifies matching stack/depth/count
+metadata and a total, disjoint ownership cover, then applies `diffInventory` to their union.
+
+## Verification
+
+- Playwright unit pins in `crawl.spec.ts` cover valid and invalid shard contracts, deterministic
+  assignment, base-surface co-location, and the merge ratchet's growth and shrink detection.
+- Node tests for each matrix pin the emitted crawl shard count, contiguous indexes, and index/count
+  environment wiring.
+- The merge command is covered with fixture slice files through `node --test`.
+- `actionlint` and the Node test files are executable locally. A real compose and k3d scheduled or
+  dispatch run is CI-only evidence for artifact transfer and live crawl timing.
+
+## Risks
+
+- A newly discovered surface assigned to another shard is reported as coverage growth in the current
+  run but is not audited until it is present in the common inventory on a later run. The merge fails
+  loudly, so this cannot become a silent coverage gap.
+- More crawl shards multiply stack startup and browser resource use. The shard count is kept as one
+  named constant per substrate and is pinned by matrix tests.
+
+## Task List
+
+1. Add and test the deterministic crawl shard contract and slice serialization. Verification: focused
+   Playwright crawl unit tests.
+2. Add and test the slice merge and inventory-ratchet command. Verification: focused Node tests.
+3. Fan out compose and k3d crawl matrices, pass the contract, publish slices, and merge them.
+   Verification: matrix tests and `actionlint`.

--- a/docs/test-strategy.md
+++ b/docs/test-strategy.md
@@ -957,18 +957,11 @@ the aggregator job literally named `compose-smoke` needs the matrix
 and gates on it so the required-check context still appears). Specs
 are **discovered** (`git ls-files`), so a newly added `*.spec.ts` is a
 hard CI failure until it is either assigned to a shard or named in the
-exclude list — never a silent no-run. `crawl/crawl` rides its own
-shard with only light companions because its single BFS `test()` is
-the ~50min `SWEEP_DEPTH=full` long pole and cannot be split — the
-nightly lane's wall-clock is therefore ≈ max(crawl shard) rather than
-the serial sum behind it. *Documented follow-up (tsouza/cerberus#2005):*
-the k3d `dashboard` job also runs the crawl (`CRAWL_STACK=k3d`)
-unfiltered + its own crawl trio, on its own dedicated shard mirroring
-this one — neither substrate splits the BFS frontier itself; splitting
-the `crawl/crawl` BFS `test()` (a `CRAWL_SHARD_INDEX`/`COUNT` contract
-partitioning the frontier, plus a merge-and-assert step against the
-pinned inventory) is the only path below the ~50min full-depth floor
-and is a crawl-engine change, not a workflow one.
+exclude list — never a silent no-run. `crawl/crawl` uses a
+`CRAWL_SHARD_INDEX`/`COUNT` contract: every crawl shard retains BFS
+discovery, audits its deterministic owned slice, and uploads that slice
+for one merge-and-ratchet step against the pinned inventory. The k3d
+`dashboard` job uses the same contract with `CRAWL_STACK=k3d`.
 
 **The surface-inventory ratchet.**
 `crawl/grafana-surface-inventory.<stack>.json` pins each stack's

--- a/test/e2e/playwright/crawl/crawl.spec.ts
+++ b/test/e2e/playwright/crawl/crawl.spec.ts
@@ -129,6 +129,8 @@ import {
   byCodepoint,
   canonicalTarget,
   canonicalizeURL,
+  belongsToCrawlShard,
+  crawlShard,
   collectVisibleAlertBanners,
   diffInventory,
   expandSiblingTabs,
@@ -382,6 +384,62 @@ test.describe('crawl: canonicalization pins', () => {
         `stack ${name}: committed inventory doc matches the config's inventoryDoc`,
       ).toBe(cfg.inventoryDoc);
     }
+  });
+
+  test('crawl shard contract is total, deterministic, and keeps interaction states with their page', () => {
+    expect(crawlShard({})).toEqual({ index: 0, count: 1 });
+    expect(crawlShard({ CRAWL_SHARD_INDEX: '2', CRAWL_SHARD_COUNT: '3' })).toEqual({
+      index: 2,
+      count: 3,
+    });
+    expect(() => crawlShard({ CRAWL_SHARD_INDEX: '0' })).toThrow(/requires both/);
+    expect(() => crawlShard({ CRAWL_SHARD_INDEX: '3', CRAWL_SHARD_COUNT: '3' })).toThrow(
+      /outside/,
+    );
+    for (const [index, count] of [
+      ['-1', '3'],
+      ['1.5', '3'],
+      ['1e2', '3'],
+      ['Infinity', '3'],
+      ['9007199254740992', '3'],
+      ['0', '0'],
+      ['0', '1.5'],
+      ['0', 'Infinity'],
+      ['0', '9007199254740992'],
+    ]) {
+      expect(() =>
+        crawlShard({ CRAWL_SHARD_INDEX: index, CRAWL_SHARD_COUNT: count }),
+      ).toThrow(/requires/);
+    }
+
+    const states = [
+      '/',
+      '/d/example',
+      '/d/example#radio[mode]=detail',
+      '/a/grafana-exploretraces-app/explore?var-groupBy={var-groupBy}',
+    ];
+    for (const state of states) {
+      const owners = [0, 1, 2].filter((index) =>
+        belongsToCrawlShard(state, { index, count: 3 }),
+      );
+      expect(owners, `${state} must have exactly one owner`).toHaveLength(1);
+    }
+    expect(
+      belongsToCrawlShard('/d/example', { index: 0, count: 3 }),
+    ).toBe(
+      belongsToCrawlShard('/d/example#radio[mode]=detail', {
+        index: 0,
+        count: 3,
+      }),
+    );
+    expect(
+      belongsToCrawlShard('/d/example', { index: 0, count: 3 }),
+    ).toBe(
+      belongsToCrawlShard('/d/example?var-mode=detail', {
+        index: 0,
+        count: 3,
+      }),
+    );
   });
 
   test('canonical keys are path-only — volatile and session-state params are stripped', () => {
@@ -1624,13 +1682,16 @@ test('crawl: BFS over every reachable Grafana surface with universal oracles + i
 }, testInfo) => {
   const stack = activeStack();
   const depth = sweepDepth();
+  const shard = crawlShard();
   // Budget: lean ≈ 10 pages × ~6s + 30s seed + the representative
   // interaction sweep over the 3 drilldown roots (~3 min); full ≈
   // cap pages + the exhaustive interaction sweep (a fresh navigation
   // per planned gesture).
   testInfo.setTimeout(depth === 'full' ? 75 * 60_000 : 14 * 60_000);
   // eslint-disable-next-line no-console
-  console.log(`crawl stack: ${stack.name} — ${describeSweepDepth(depth)}`);
+  console.log(
+    `crawl stack: ${stack.name} — ${describeSweepDepth(depth)} (shard ${shard.index + 1}/${shard.count})`,
+  );
 
   const baseURL =
     process.env.GRAFANA_URL ??
@@ -1737,6 +1798,7 @@ test('crawl: BFS over every reachable Grafana surface with universal oracles + i
 
   const pageCap = depth === 'full' ? stack.pageCapFull : stack.pageCapLean;
   const visited = new Map<string, string>(); // canonical → concrete navigated
+  const audited = new Map<string, string>(); // states owned by this shard
   // In-place interaction states (`<canonical>#<control>=<value>`) →
   // concrete URL the gesture ran against. Kept separate from
   // `visited` because they are gestures on an already-counted page,
@@ -1766,13 +1828,16 @@ test('crawl: BFS over every reachable Grafana surface with universal oracles + i
 
       visited.set(entry.canonical, entry.concrete);
 
+      const ownsSurface = belongsToCrawlShard(entry.canonical, shard);
       const { harvested, pageFailures } = await visitAndAudit(
         lease,
         baseURL,
         entry,
         declaredNoData,
         declaredErrorExprs,
+        ownsSurface,
       );
+      if (ownsSurface) audited.set(entry.canonical, entry.concrete);
       failures.push(...pageFailures);
 
       // Lean visits the seed set + the nav links harvested from the
@@ -1816,7 +1881,7 @@ test('crawl: BFS over every reachable Grafana surface with universal oracles + i
       // the pairwise bound: surfaces pinning ≥2 structural params are
       // terminal (planInteractions returns an empty plan for them).
       const isLeanRoot = stack.leanInteractionRoots.includes(entry.canonical);
-      if (depth === 'full' || isLeanRoot) {
+      if (ownsSurface && (depth === 'full' || isLeanRoot)) {
         const sweep = await sweepInteractions(
           lease,
           baseURL,
@@ -1829,6 +1894,7 @@ test('crawl: BFS over every reachable Grafana surface with universal oracles + i
         failures.push(...sweep.failures);
         for (const [stateKey, state] of sweep.inPlaceStates) {
           inPlaceVisited.set(stateKey, state.concrete);
+          audited.set(stateKey, state.concrete);
           if (isLeanRoot && state.leanRepresentative) leanSet.add(stateKey);
         }
         // Same fold as the link-harvest loop above: several driven
@@ -1873,7 +1939,7 @@ test('crawl: BFS over every reachable Grafana surface with universal oracles + i
   // interaction states (`<canonical>#<control>=<value>` notation) —
   // both pin into the same inventory ratchet.
   const auditedStates = new Map<string, string>([
-    ...visited,
+    ...audited,
     ...inPlaceVisited,
   ]);
 
@@ -1895,6 +1961,7 @@ test('crawl: BFS over every reachable Grafana surface with universal oracles + i
   // run still fails loudly on the failures right below.
   // -------------------------------------------------------------------------
   if (process.env.CERBERUS_UPDATE_INVENTORY) {
+    expect(shard.count, 'inventory regeneration must run unsharded').toBe(1);
     expect(
       depth,
       'inventory regeneration requires the exhaustive crawl: rerun with SWEEP_DEPTH=full',
@@ -1924,6 +1991,18 @@ test('crawl: BFS over every reachable Grafana surface with universal oracles + i
   }
 
   if (process.env.CERBERUS_UPDATE_INVENTORY) return;
+
+  if (shard.count > 1) {
+    const slicePath = process.env.CRAWL_SLICE_PATH;
+    if (slicePath === undefined || slicePath === '') {
+      throw new Error('sharded crawl requires CRAWL_SLICE_PATH for the merge job');
+    }
+    writeFileSync(
+      slicePath,
+      `${JSON.stringify({ stack: stack.name, depth, shard, visited: [...auditedStates.keys()].sort(), discovered: [...visited.keys()].sort() }, null, 2)}\n`,
+    );
+    return;
+  }
 
   // Bootstrap guard before the diff: an EMPTY committed inventory
   // means the stack was registered but never crawled exhaustively —
@@ -2228,6 +2307,7 @@ async function visitAndAudit(
   entry: QueueEntry,
   declaredNoData: ReadonlyMap<string, Set<string>>,
   declaredErrorExprs: ReadonlyMap<string, Set<string>>,
+  audit: boolean,
 ): Promise<{ harvested: string[]; pageFailures: CrawlFailure[] }> {
   const pageFailures: CrawlFailure[] = [];
   const fail: FailFn = (rule, detail) =>
@@ -2241,27 +2321,31 @@ async function visitAndAudit(
   );
 
   const page = await lease.acquire();
-  const { messages: consoleErrors, stop: stopConsole } =
-    await captureConsoleErrors(page);
-  const wire = startWireCapture(page, baseURL);
+  const capture = audit ? await captureConsoleErrors(page) : undefined;
+  const wire = audit ? startWireCapture(page, baseURL) : undefined;
 
   let harvested: string[] = [];
   try {
     lease.noteNavigation();
     await gotoCold(page, `${baseURL}${entry.concrete}`);
-    await tolerateRepaintFlicker(page, { settleMs: 600, timeoutMs: 45_000 });
+    if (audit) {
+      await tolerateRepaintFlicker(page, { settleMs: 600, timeoutMs: 45_000 });
+    }
 
     harvested = await harvestLinks(page);
 
-    await evaluateDomOracles(page, contracts, entry.concrete, fail);
+    if (audit) {
+      await evaluateDomOracles(page, contracts, entry.concrete, fail);
+    }
   } catch (err) {
     fail(
       'navigation-threw',
       `goto(${entry.concrete}) threw: ${(err as Error).message}`,
     );
   } finally {
-    stopConsole();
+    capture?.stop();
   }
+  if (wire === undefined || capture === undefined) return { harvested, pageFailures };
   await wire.stop();
   const reconciledInitRace = evaluateWireOracles(wire.captured, contracts, fail);
 
@@ -2270,7 +2354,7 @@ async function visitAndAudit(
   // for the escalation path if a Grafana bump ever makes a real filter
   // unavoidable).
   const reportableErrors = resolveInitRaceConsoleTwins(
-    consoleErrors,
+    capture.messages,
     reconciledInitRace,
   );
   if (reportableErrors.length > 0) {

--- a/test/e2e/playwright/crawl/lib.ts
+++ b/test/e2e/playwright/crawl/lib.ts
@@ -858,6 +858,70 @@ export function byCodepoint(a: string, b: string): number {
   return a > b ? 1 : 0;
 }
 
+/** A zero-based, total partition of a crawl's base surface keys. */
+export type CrawlShard = {
+  index: number;
+  count: number;
+};
+
+const UNSHARDED_CRAWL: CrawlShard = { index: 0, count: 1 };
+
+/**
+ * Read the crawl's optional matrix contract. Both variables are required when
+ * either is set: accepting one silently turns a typo into an incomplete crawl.
+ */
+export function crawlShard(env = process.env): CrawlShard {
+  const index = env.CRAWL_SHARD_INDEX;
+  const count = env.CRAWL_SHARD_COUNT;
+  if (index === undefined && count === undefined) return UNSHARDED_CRAWL;
+  if (index === undefined || count === undefined) {
+    throw new Error(
+      'crawl sharding requires both CRAWL_SHARD_INDEX and CRAWL_SHARD_COUNT',
+    );
+  }
+  if (!/^\d+$/.test(index) || !/^[1-9]\d*$/.test(count)) {
+    throw new Error(
+      `crawl sharding requires a non-negative integer index and positive integer count; got index=${JSON.stringify(index)} count=${JSON.stringify(count)}`,
+    );
+  }
+  const shard = { index: Number(index), count: Number(count) };
+  if (
+    !Number.isSafeInteger(shard.index) ||
+    !Number.isSafeInteger(shard.count) ||
+    shard.index < 0 ||
+    shard.count < 1
+  ) {
+    throw new Error(
+      `crawl sharding requires safe integers with a non-negative index and positive count; got index=${JSON.stringify(index)} count=${JSON.stringify(count)}`,
+    );
+  }
+  if (shard.index >= shard.count) {
+    throw new Error(
+      `crawl sharding index ${shard.index} is outside [0, ${shard.count})`,
+    );
+  }
+  return shard;
+}
+
+/**
+ * Interaction URLs change a page's query state, not its route. Hashing only
+ * the canonical path keeps every URL-encoded interaction with the source page
+ * that discovered it, so the same shard both drives the control and audits its
+ * navigable result. In-place states are covered by the same rule.
+ */
+export function crawlShardOwner(canonical: string, count: number): number {
+  const base = canonical.split('#', 1)[0]?.split('?', 1)[0] ?? canonical;
+  let hash = 0;
+  for (let i = 0; i < base.length; i++) {
+    hash = (hash * 31 + base.charCodeAt(i)) >>> 0;
+  }
+  return hash % count;
+}
+
+export function belongsToCrawlShard(canonical: string, shard: CrawlShard): boolean {
+  return crawlShardOwner(canonical, shard.count) === shard.index;
+}
+
 /**
  * Fold a batch of {canonical, concrete} candidates down to ONE
  * concrete representative per canonical — a PURE function of the


### PR DESCRIPTION
Closes #2005

## Summary

Partitions crawl audit and interaction ownership deterministically, merges complete shard artifacts, and preserves release-gating inventory ratchets.

## Test plan

- Crawl merge and matrix tests
- Workflow dependency tests
- actionlint

CI supplies live compose and k3d artifact-transfer evidence.