### PR TITLE
fix(e2e): preserve compose crawl slices

### DIFF
--- a/.github/scripts/merge-crawl-slices.mjs
+++ b/.github/scripts/merge-crawl-slices.mjs
@@ -95,15 +95,19 @@ export function mergeSlices(slices, { stack, depth, inventory, exclusions, inven
   return { visited, discovered, violations };
 }
 
+export function readSlices(dir) {
+  return readdirSync(dir, { recursive: true })
+    .filter((name) => name.endsWith('.json'))
+    .map((name) => JSON.parse(readFileSync(join(dir, name), 'utf8')));
+}
+
 function main() {
   const dir = process.env.CRAWL_SLICE_DIR;
   const stack = process.env.CRAWL_STACK;
   if (!dir || !stack) {
     throw new Error('CRAWL_SLICE_DIR and CRAWL_STACK are required');
   }
-  const slices = readdirSync(dir)
-    .filter((name) => name.endsWith('.json'))
-    .map((name) => JSON.parse(readFileSync(join(dir, name), 'utf8')));
+  const slices = readSlices(dir);
   const depth = process.env.SWEEP_DEPTH ?? slices[0]?.depth;
   if (depth !== 'lean' && depth !== 'full') {
     throw new Error('crawl slices must declare SWEEP_DEPTH=lean|full');

--- a/.github/scripts/merge-crawl-slices.test.mjs
+++ b/.github/scripts/merge-crawl-slices.test.mjs
@@ -1,7 +1,10 @@
 import assert from 'node:assert/strict';
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import { test } from 'node:test';
 
-import { mergeSlices, owner } from './merge-crawl-slices.mjs';
+import { mergeSlices, owner, readSlices } from './merge-crawl-slices.mjs';
 
 const stack = 'compose';
 const shardCount = 2;
@@ -33,6 +36,20 @@ test('owner keeps URL-encoded interaction states with their source route', () =>
   const inPlaceState = `${interactionURL}#tabs[Favorites|All]=All`;
   assert.equal(owner(interactionURL, shardCount), owner(source, shardCount));
   assert.equal(owner(inPlaceState, shardCount), owner(source, shardCount));
+});
+
+test('readSlices preserves same-named slices from separate artifacts', () => {
+  const dir = mkdtempSync(join(tmpdir(), 'crawl-slices-'));
+  try {
+    for (const index of [0, 1]) {
+      const artifact = join(dir, `crawl-slice-compose-${index}`);
+      mkdirSync(artifact);
+      writeFileSync(join(artifact, 'crawl-slice.json'), JSON.stringify({ index }));
+    }
+    assert.deepEqual(readSlices(dir), [{ index: 0 }, { index: 1 }]);
+  } finally {
+    rmSync(dir, { force: true, recursive: true });
+  }
 });
 
 test('mergeSlices accepts a total, owned shard cover', () => {

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -805,7 +805,6 @@ jobs:
         with:
           pattern: crawl-slice-compose-*
           path: crawl-slices
-          merge-multiple: true
       - name: Merge compose crawl slices and assert inventory
         env:
           CRAWL_SLICE_DIR: crawl-slices


### PR DESCRIPTION
## Summary

Keep each downloaded artifact in its own directory and recursively load crawl slices, preventing same-named files from overwriting one another.

## Verification

- node --test .github/scripts/merge-crawl-slices.test.mjs

Fixes #2153.