### PR TITLE
fix(e2e): de-gate k3d crawl coverage

### DIFF
--- a/.github/scripts/assert-crawl-terminal.mjs
+++ b/.github/scripts/assert-crawl-terminal.mjs
@@ -64,6 +64,7 @@ export function classifyCrawlOutcome({
   hasInformational,
   crawlResult,
   depth,
+  crawlExpected = 'true',
 }) {
   // The lane short-circuits on a change the compose stack cannot see. That is
   // benign ONLY on the same two facts the required aggregate checks: the scope
@@ -89,6 +90,13 @@ export function classifyCrawlOutcome({
     return {
       ok: false,
       message: `compose-smoke-setup did not succeed (${setupResult}) — the crawl matrix was never planned.`,
+    };
+  }
+
+  if (crawlExpected !== 'true') {
+    return {
+      ok: true,
+      message: 'this event does not dispatch the crawl coverage matrix.',
     };
   }
 
@@ -147,6 +155,7 @@ function main() {
     hasInformational: process.env.HAS_INFORMATIONAL ?? '',
     crawlResult: process.env.CRAWL_SHARD_RESULT ?? '',
     depth: process.env.SWEEP_DEPTH ?? 'lean',
+    crawlExpected: process.env.CRAWL_EXPECTED ?? 'true',
   });
   if (verdict.ok) {
     notice(`crawl-terminal: ${verdict.message}`);

--- a/.github/scripts/assert-crawl-terminal.test.mjs
+++ b/.github/scripts/assert-crawl-terminal.test.mjs
@@ -58,6 +58,18 @@ test('a planner that stopped emitting a crawl matrix at all fails', () => {
   assert.match(verdict.message, /silently stopped existing/);
 });
 
+test('an event without a scheduled crawl short-circuits cleanly', () => {
+  const verdict = classifyCrawlOutcome({
+    scopeResult: 'success',
+    setupResult: 'success',
+    hasInformational: 'false',
+    crawlResult: 'skipped',
+    depth: 'lean',
+    crawlExpected: 'false',
+  });
+  assert.equal(verdict.ok, true);
+});
+
 test('an out-of-scope change short-circuits cleanly — but only on a scope job that decided', () => {
   const outOfScope = classifyCrawlOutcome({
     scopeResult: 'success',

--- a/.github/scripts/dashboard-matrix.mjs
+++ b/.github/scripts/dashboard-matrix.mjs
@@ -339,6 +339,17 @@ export function buildMatrix(includeCrawl, includeSplit, regeneratesK3DInventory 
   return include;
 }
 
+// buildMatrices keeps the required smoke topology checks and the slow crawl
+// coverage sweep in distinct GitHub matrices. A matrix has one aggregate result,
+// so this split is what lets the dashboard release gate ignore crawl failures.
+export function buildMatrices(includeCrawl, includeSplit, regeneratesK3DInventory = false) {
+  const include = buildMatrix(includeCrawl, includeSplit, regeneratesK3DInventory);
+  return {
+    required: include.filter((entry) => entry.crawlStack !== CRAWL_STACK_K3D),
+    informational: include.filter((entry) => entry.crawlStack === CRAWL_STACK_K3D),
+  };
+}
+
 function emit() {
   const discovered = discover();
   assertCoverageOrExit(discovered);
@@ -353,23 +364,25 @@ function emit() {
   const includeSplit = process.env.INCLUDE_SPLIT === 'true';
   const regeneratesK3DInventory =
     process.env.UPDATE_CRAWL_INVENTORY === 'k3d' || process.env.UPDATE_CRAWL_INVENTORY === 'both';
-  const include = buildMatrix(includeCrawl, includeSplit, regeneratesK3DInventory);
-  setOutput('matrix', JSON.stringify({ include }));
-  setOutput('shard_names', JSON.stringify(include.map((e) => e.name)));
+  const { required, informational } = buildMatrices(includeCrawl, includeSplit, regeneratesK3DInventory);
+  setOutput('matrix', JSON.stringify({ include: required }));
+  setOutput('matrix_informational', JSON.stringify({ include: informational }));
+  setOutput('has_informational', informational.length > 0 ? 'true' : 'false');
+  setOutput('shard_names', JSON.stringify(required.map((e) => e.name)));
   appendStepSummary(
     [
       '### dashboard (k3d) shard matrix',
       '',
       '| shard | mode | specs | CRAWL_STACK | Go e2e | timeout (min) |',
       '| --- | --- | --- | --- | --- | --- |',
-      ...include.map(
+      ...[...required, ...informational].map(
         (e) =>
           `| \`${e.name}\` | ${e.mode} | ${e.specs.split(' ').filter(Boolean).length} | ${e.crawlStack || '(none)'} | ${e.runGoE2E ? 'yes' : 'no'} | ${e.timeoutMinutes} |`,
       ),
     ].join('\n'),
   );
   log(
-    `dashboard-matrix: emitted ${include.length}-entry matrix` +
+    `dashboard-matrix: emitted ${required.length}-entry required matrix and ${informational.length}-entry informational matrix` +
       (includeCrawl ? '.' : ' (smoke-only; crawl shard runs on schedule/dispatch).'),
   );
   process.exit(0);

--- a/.github/scripts/dashboard-matrix.test.mjs
+++ b/.github/scripts/dashboard-matrix.test.mjs
@@ -21,6 +21,7 @@ import {
   collectViolations,
   SHARDS,
   buildMatrix,
+  buildMatrices,
   MODE_MONOLITH,
   MODE_SPLIT,
   SPLIT_ONLY_SPECS,
@@ -174,6 +175,14 @@ test('buildMatrix: inventory regeneration emits one unsharded crawl writer', () 
     [[0, 1]],
     'a regeneration must have one writer rather than slice artifacts to merge',
   );
+});
+
+test('buildMatrices: crawl is informational while every smoke entry remains required', () => {
+  const { required, informational } = buildMatrices(true, true);
+  assert.ok(required.length > 0, 'the required matrix must retain smoke coverage');
+  assert.equal(informational.length, CRAWL_FRONTIER_SHARD_COUNT);
+  assert.ok(required.every((entry) => entry.crawlStack !== CRAWL_STACK_K3D));
+  assert.ok(informational.every((entry) => entry.crawlStack === CRAWL_STACK_K3D));
 });
 
 test('buildMatrix: every emitted entry has a non-empty spec list and a filename-safe name', () => {

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -974,6 +974,8 @@ jobs:
     timeout-minutes: 5
     outputs:
       matrix: ${{ steps.emit.outputs.matrix }}
+      matrix_informational: ${{ steps.emit.outputs.matrix_informational }}
+      has_informational: ${{ steps.emit.outputs.has_informational }}
     steps:
       - uses: actions/checkout@v7
 
@@ -1049,7 +1051,7 @@ jobs:
       # expensive step below is gated on RUN_SHARD, which is false for the crawl
       # shard on a push event. The smoke shards always run.
       RUN_SHARD: ${{ matrix.crawlStack != 'k3d' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || startsWith(github.head_ref, 'release/') }}
-    steps:
+    steps: &dashboard_shard_steps
       - uses: actions/checkout@v7
 
       # ---- free runner disk BEFORE k3d + the stack boot (infra-flake fix) ----
@@ -1416,11 +1418,50 @@ jobs:
         if: always() && env.RUN_SHARD == 'true'
         run: just e2e-down
 
+  # The crawl uses the same k3d setup and Playwright steps as smoke, but its
+  # matrix is deliberately separate: its coverage failures cannot block the
+  # release-required dashboard aggregate.
+  dashboard-shard-info:
+    name: dashboard-shard-info
+    needs: dashboard-setup
+    if: needs.dashboard-setup.outputs.has_informational == 'true'
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJSON(needs.dashboard-setup.outputs.matrix_informational) }}
+    timeout-minutes: ${{ matrix.timeoutMinutes }}
+    concurrency:
+      group: e2e-dashboard-info-${{ github.ref }}-${{ matrix.name }}
+      cancel-in-progress: false
+    env:
+      RUN_SHARD: 'true'
+    steps: *dashboard_shard_steps
+
+  # This reader remains informational, but makes a cancelled or skipped k3d
+  # crawl visible rather than allowing the coverage lane to go silently hollow.
+  dashboard-crawl-terminal:
+    name: dashboard-crawl-terminal
+    needs: [dashboard-setup, dashboard-shard-info]
+    if: always()
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v7
+      - name: assert the k3d surface crawl reached a verdict
+        run: node .github/scripts/assert-crawl-terminal.mjs
+        env:
+          SCOPE_RESULT: success
+          SETUP_RESULT: ${{ needs.dashboard-setup.result }}
+          HAS_INFORMATIONAL: ${{ needs.dashboard-setup.outputs.has_informational }}
+          CRAWL_EXPECTED: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || startsWith(github.head_ref, 'release/') }}
+          CRAWL_SHARD_RESULT: ${{ needs.dashboard-shard-info.result }}
+          SWEEP_DEPTH: full
+
   dashboard-crawl-merge:
     name: dashboard-crawl-merge
-    needs: [dashboard-setup, dashboard-shard]
+    needs: [dashboard-setup, dashboard-shard-info]
     if: >-
-      always() && needs.dashboard-shard.result == 'success' &&
+      always() && needs.dashboard-shard-info.result == 'success' &&
       (github.event_name == 'schedule' || startsWith(github.head_ref, 'release/') ||
       (github.event_name == 'workflow_dispatch' &&
       inputs.update_crawl_inventory != 'k3d' && inputs.update_crawl_inventory != 'both'))
@@ -1431,7 +1472,6 @@ jobs:
         with:
           pattern: crawl-slice-k3d-*
           path: crawl-slices
-          merge-multiple: true
       - name: Merge k3d crawl slices and assert inventory
         env:
           CRAWL_SLICE_DIR: crawl-slices
@@ -1452,7 +1492,7 @@ jobs:
   # where dashboard-setup does not run).
   dashboard:
     name: dashboard
-    needs: [dashboard-setup, dashboard-shard, dashboard-crawl-merge]
+    needs: [dashboard-setup, dashboard-shard]
     if: always()
     runs-on: ubuntu-latest
     timeout-minutes: 5
@@ -1461,7 +1501,6 @@ jobs:
         run: |
           echo "setup  = ${{ needs.dashboard-setup.result }}"
            echo "shards = ${{ needs.dashboard-shard.result }}"
-           echo "crawl merge = ${{ needs.dashboard-crawl-merge.result }}"
           # If setup was skipped (docs-only PR, or a non-PR/push/schedule/
           # dispatch path), there is nothing to aggregate — report green
           # without work. On a code PR setup runs, so this branch does not fire
@@ -1483,16 +1522,6 @@ jobs:
            if [ "${{ needs.dashboard-shard.result }}" != "success" ]; then
             echo "::error::one or more dashboard shards failed/cancelled (rolled-up: ${{ needs.dashboard-shard.result }})."
              exit 1
-           fi
-           if [ "${{ github.event_name }}" = "schedule" ] || \
-              [ "${{ github.event_name }}" = "pull_request" ] || \
-              { [ "${{ github.event_name }}" = "workflow_dispatch" ] && \
-                [ "${{ inputs.update_crawl_inventory }}" != "k3d" ] && \
-                [ "${{ inputs.update_crawl_inventory }}" != "both" ]; }; then
-             if [ "${{ needs.dashboard-crawl-merge.result }}" != "success" ]; then
-               echo "::error::dashboard crawl slice merge did not succeed (${{ needs.dashboard-crawl-merge.result }})."
-               exit 1
-             fi
            fi
            echo "all dashboard shards passed."
 


### PR DESCRIPTION
## Summary

- split k3d dashboard smoke and crawl entries into required and informational matrices
- keep the release-required `dashboard` aggregate dependent only on smoke shards
- add an informational k3d crawl terminality reader and retain crawl slice merging

## Validation

- `node --test .github/scripts/dashboard-matrix.test.mjs .github/scripts/assert-crawl-terminal.test.mjs`
- `just lint-actions`

Closes #2010
