### PR TITLE
fix(e2e): swap gh run download for actions/download-artifact in crawl merges

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -799,12 +799,29 @@ jobs:
       (github.event_name != 'workflow_dispatch' ||
       (inputs.update_crawl_inventory != 'compose' && inputs.update_crawl_inventory != 'both'))
     runs-on: ubuntu-latest
+    # actions: read (on top of the workflow-level contents: read) is what
+    # `gh run download` below needs — job-level permissions REPLACE the
+    # workflow-level block for this job rather than adding to it, so
+    # contents: read has to be restated.
+    permissions:
+      contents: read
+      actions: read
     steps:
       - uses: actions/checkout@v7
-      - uses: actions/download-artifact@v8
-        with:
-          pattern: crawl-slice-compose-*
-          path: crawl-slices
+      # `gh run download`, not `actions/download-artifact@v8`: the latter
+      # verifies each artifact's SHA256 against the upload-time manifest
+      # through the actions/toolkit artifact client, which has an
+      # intermittent `digest-mismatch` false positive against the Actions
+      # v4 backend — observed on PRs #2147, #2155 and #2156, each with a
+      # fresh digest every run, so it is the download verification that is
+      # flaky rather than the uploaded bytes. `gh run download` fetches the
+      # same artifacts through the REST API instead, sidestepping that
+      # client entirely — the workaround upstream issue threads for
+      # actions/download-artifact's digest verification converge on.
+      - name: Download compose crawl slices
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh run download ${{ github.run_id }} --pattern 'crawl-slice-compose-*' --dir crawl-slices
       - name: Merge compose crawl slices and assert inventory
         env:
           CRAWL_SLICE_DIR: crawl-slices
@@ -1425,13 +1442,36 @@ jobs:
       (github.event_name == 'workflow_dispatch' &&
       inputs.update_crawl_inventory != 'k3d' && inputs.update_crawl_inventory != 'both'))
     runs-on: ubuntu-latest
+    # actions: read (on top of the workflow-level contents: read) is what
+    # `gh run download` below needs — job-level permissions REPLACE the
+    # workflow-level block for this job rather than adding to it, so
+    # contents: read has to be restated.
+    permissions:
+      contents: read
+      actions: read
     steps:
       - uses: actions/checkout@v7
-      - uses: actions/download-artifact@v8
-        with:
-          pattern: crawl-slice-k3d-*
-          path: crawl-slices
-          merge-multiple: true
+      # `gh run download`, not `actions/download-artifact@v8`: the latter
+      # verifies each artifact's SHA256 against the upload-time manifest
+      # through the actions/toolkit artifact client, which has an
+      # intermittent `digest-mismatch` false positive against the Actions
+      # v4 backend — observed on PRs #2147, #2155 and #2156, each with a
+      # fresh digest every run, so it is the download verification that is
+      # flaky rather than the uploaded bytes. `gh run download` fetches the
+      # same artifacts through the REST API instead, sidestepping that
+      # client entirely — the workaround upstream issue threads for
+      # actions/download-artifact's digest verification converge on.
+      # `gh run download` always extracts each artifact under its own
+      # subdirectory (it has no `merge-multiple` equivalent), unlike the
+      # toolkit downloader above with that flag set. That is fine here:
+      # `readSlices` in merge-crawl-slices.mjs walks CRAWL_SLICE_DIR
+      # recursively, so the per-artifact subdirectories are found either
+      # way — matching how the compose job's own download (never using
+      # `merge-multiple`) already works.
+      - name: Download k3d crawl slices
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh run download ${{ github.run_id }} --pattern 'crawl-slice-k3d-*' --dir crawl-slices
       - name: Merge k3d crawl slices and assert inventory
         env:
           CRAWL_SLICE_DIR: crawl-slices


### PR DESCRIPTION
## Summary

`actions/download-artifact@v8` intermittently fails the `crawl-slice-compose-*` /
`crawl-slice-k3d-*` downloads with a `digest-mismatch` against the Actions v4
backend — observed on PRs #2147, #2155 and #2156, each with a fresh digest every
run, so it's the download-side verification that's flaky, not the uploaded
bytes. This swaps both `compose-crawl-merge` and `dashboard-crawl-merge` to
`gh run download`, which fetches artifacts through the REST API instead of the
toolkit's artifact client, sidestepping that verification path entirely.

Neither job is a required check (both are the de-gated, informational crawl-
coverage lane — see the `compose-smoke` / `dashboard` aggregator comments in
`e2e.yml`), so this isn't a release gate, but it's been red on every open PR.

## Verification

- `actionlint` (matches `just lint-actions`): clean.
- Job-level `permissions: actions: read` added (workflow-level only grants
  `contents: read` / `packages: read`, and job-level permissions replace
  rather than extend that block) — required for `gh run download`.
- `merge-crawl-slices.mjs`'s `readSlices` already walks its input directory
  recursively, so `gh run download`'s per-artifact-subdirectory layout (it has
  no `merge-multiple` equivalent) is picked up the same way the compose job's
  existing non-flattened download already is.