### PR TITLE
fix(optimizer): collapse pushdown column enumerators, fix Having/Temporality drops

### DIFF
--- a/internal/optimizer/projection_pushdown.go
+++ b/internal/optimizer/projection_pushdown.go
@@ -33,11 +33,13 @@ import (
 // RangeWindow — sitting directly over Scan or Filter(Scan):
 //
 //  3. `Aggregate(Scan)` / `Aggregate(Filter(Scan))` — narrow the Scan to
-//     the union of the columns the Aggregate's GroupBy keys and AggFunc
-//     params/args read, plus the Filter predicate's columns when present.
+//     the union of the columns the Aggregate's GroupBy keys, AggFunc
+//     params/args, and Having predicate read, plus the Filter predicate's
+//     columns when present.
 //  4. `RangeWindow(Scan)` / `RangeWindow(Filter(Scan))` — narrow the Scan
 //     to the union of TimestampColumn + ValueColumn (the per-sample pair
-//     the windowed-array idiom reads), the GroupBy + ScalarExprs column
+//     the windowed-array idiom reads), TemporalityColumn when set, each
+//     fused Variants arm's ValueColumn, the GroupBy + ScalarExprs column
 //     refs, plus the Filter predicate's columns when present.
 //  5. `RangeWindowNative(Scan)` / `RangeWindowNative(Filter(Scan))` — the
 //     experimental ClickHouse-native `timeSeriesRateToGrid` lowering.
@@ -230,32 +232,68 @@ func cloneStageOverInput(stage, newInput chplan.Node) chplan.Node {
 }
 
 // aggregateColumns returns the sorted, deduped set of base columns an
-// Aggregate's own emit reads: the union of every GroupBy key expression
-// and every AggFunc's Params + Args. emitAggregate (chsql/emit_node.go)
-// selects exactly these — GroupBy in the SELECT/GROUP BY, AggFuncs as the
-// reducers — so this is the complete set the narrowed Scan must carry.
+// Aggregate's own emit reads: the union of every GroupBy key expression,
+// every AggFunc's Params + Args, and Having. emitAggregate
+// (chsql/emit_node.go) renders exactly these — GroupBy in the
+// SELECT/GROUP BY, AggFuncs as the reducers, Having as a real SQL HAVING
+// evaluated against the same row shape — so this is the complete set the
+// narrowed Scan must carry.
+//
+// Having matters even though it never rides as a GroupBy key or an
+// AggFunc arg: duplicateLabelsetGuardExpr (internal/promql/lower.go)
+// plants `throwIf(uniqExact(MetricName) > 1, …) = 0` as an Aggregate's
+// Having specifically because MetricName is NOT a GroupBy key for that
+// shape (the guard exists to detect distinct names colliding under one
+// dropped-name group) — so a narrowed Scan that only unions GroupBy +
+// AggFuncs strips MetricName out from under a HAVING clause that
+// references it, and ClickHouse fails outer-scope resolution with error
+// 47 (UNKNOWN_IDENTIFIER).
 func aggregateColumns(a *chplan.Aggregate) []string {
-	seen := map[string]struct{}{}
-	collect := collectColumn(seen)
-	for _, g := range a.GroupBy {
-		walkExpr(g, collect)
-	}
-	for _, af := range a.AggFuncs {
-		for _, p := range af.Params {
-			walkExpr(p, collect)
-		}
-		for _, ar := range af.Args {
-			walkExpr(ar, collect)
-		}
-	}
-	return sortedColumnSet(seen)
+	var roots []chplan.Expr
+	roots = append(roots, a.GroupBy...)
+	roots = append(roots, aggFuncExprs(a.AggFuncs)...)
+	roots = append(roots, a.Having)
+	return stageColumns(nil, roots...)
 }
 
 // rangeWindowColumns returns the sorted, deduped set of base columns a
 // RangeWindow's row-shape emit reads: the bare-string TimestampColumn +
 // ValueColumn (the per-sample pair the windowed-array idiom consumes —
-// added literally, they are plain column names, not Exprs), plus the
-// column refs walked out of GroupBy and ScalarExprs.
+// added literally, they are plain column names, not Exprs), TemporalityColumn
+// when set, each fused Variants arm's ValueColumn, plus the column refs
+// walked out of GroupBy and ScalarExprs.
+//
+// TemporalityColumn matters even though the doc on that field frames it as
+// an opt-in extra: whenever it is non-empty, emitWindowedArrayExtrapolated
+// (chsql/range_window.go) reads `any(<TemporalityColumn>)` off Input inside
+// the same innermost SELECT this pushdown narrows, unconditionally — so
+// omitting it here narrows the Scan out from under a column the emit still
+// references, and ClickHouse fails outer-scope resolution with error 47
+// (UNKNOWN_IDENTIFIER). The default OTel-CH lowering never exposes the gap
+// because augmentSelectorAttributes (internal/promql/lower.go) wraps the
+// selector in a Project that carries TemporalityColumn whenever the schema
+// sets both ResourceAttributesColumn and AggregationTemporalityColumn — a
+// Project input applyStageScan declines outright. A schema that clears
+// ResourceAttributesColumn (and has no dedicated top-level-column overlay)
+// makes that Project a no-op that augmentSelectorAttributes skips
+// (isBareAttributesRef, internal/promql/resource_attributes.go), so a
+// `rate()` / `increase()` over an unambiguous Sum/Histogram-table selector
+// on such a schema reaches this function with a bare Filter(Scan) Input and
+// TemporalityColumn still set — the gap is live, not merely hypothetical.
+//
+// The fused Variants arms matter for the same reason each stage's own
+// per-arm value column matters everywhere else in this file: LogQL's
+// `variants(...)` construct (internal/logql/variants.go) fuses several
+// range-function arms into one window, each naming its own ValueColumn,
+// and the emitter (chsql/range_window_variants.go) reads every arm's
+// column directly off Input. Today every LogQL fused Input arrives wrapped
+// in a Project, which applyStageScan declines — so, like TemporalityColumn
+// above, this is currently reached through a Project gate that keeps the
+// omission latent rather than live. Collecting it here anyway keeps this
+// function a complete, self-contained description of "every base column
+// RangeWindow's own emit reads off Input", so the day a lowering emits a
+// fused window directly over Scan/Filter(Scan), or applyStageScan grows a
+// Project arm, the pushdown already narrows correctly instead of 502ing.
 //
 // Only the row-shape (PromQL / LogQL) RangeWindow over Scan / Filter(Scan)
 // reaches this: the Apply switch routes a RangeWindow whose Input is a
@@ -264,21 +302,14 @@ func aggregateColumns(a *chplan.Aggregate) []string {
 // — to applyRangeWindowOverMetricsAggregate instead, since that shape needs
 // to WIDEN an already-narrowed Scan rather than narrow one directly.
 func rangeWindowColumns(r *chplan.RangeWindow) []string {
-	seen := map[string]struct{}{}
-	if r.TimestampColumn != "" {
-		seen[r.TimestampColumn] = struct{}{}
+	bare := []string{r.TimestampColumn, r.ValueColumn, r.TemporalityColumn}
+	for _, v := range r.Variants {
+		bare = append(bare, v.ValueColumn)
 	}
-	if r.ValueColumn != "" {
-		seen[r.ValueColumn] = struct{}{}
-	}
-	collect := collectColumn(seen)
-	for _, g := range r.GroupBy {
-		walkExpr(g, collect)
-	}
-	for _, s := range r.ScalarExprs {
-		walkExpr(s, collect)
-	}
-	return sortedColumnSet(seen)
+	var roots []chplan.Expr
+	roots = append(roots, r.GroupBy...)
+	roots = append(roots, r.ScalarExprs...)
+	return stageColumns(bare, roots...)
 }
 
 // applyRangeWindowOverMetricsAggregate handles the TraceQL matrix shape
@@ -391,21 +422,11 @@ func widenScanColumns(scan *chplan.Scan, extraCol string) (*chplan.Scan, bool) {
 // invariant-relaxation away from re-opening the #860/#861 dropped-column
 // class. Both ship.
 func nativeRangeWindowColumns(r *chplan.RangeWindowNative) []string {
-	seen := map[string]struct{}{}
-	if r.TimestampColumn != "" {
-		seen[r.TimestampColumn] = struct{}{}
-	}
-	if r.ValueColumn != "" {
-		seen[r.ValueColumn] = struct{}{}
-	}
-	collect := collectColumn(seen)
-	for _, g := range r.GroupBy {
-		walkExpr(g, collect)
-	}
-	for _, p := range r.Recollapse {
-		walkExpr(p.Expr, collect)
-	}
-	return sortedColumnSet(seen)
+	bare := []string{r.TimestampColumn, r.ValueColumn}
+	var roots []chplan.Expr
+	roots = append(roots, r.GroupBy...)
+	roots = append(roots, projectionExprs(r.Recollapse)...)
+	return stageColumns(bare, roots...)
 }
 
 // resampleRangeWindowColumns returns the sorted, deduped set of base columns a
@@ -424,13 +445,7 @@ func nativeRangeWindowColumns(r *chplan.RangeWindowNative) []string {
 // columns — 502s the query at runtime, so the enumeration must match the emit's
 // reads exactly (the same #860/#861 failure class the native-rate path guards).
 func resampleRangeWindowColumns(r *chplan.RangeWindowResample) []string {
-	seen := map[string]struct{}{}
-	for _, c := range []string{r.MetricNameCol, r.AttributesCol, r.TimestampCol, r.ValueCol} {
-		if c != "" {
-			seen[c] = struct{}{}
-		}
-	}
-	return sortedColumnSet(seen)
+	return stageColumns([]string{r.MetricNameCol, r.AttributesCol, r.TimestampCol, r.ValueCol})
 }
 
 // rangeBucketFanoutColumns returns the sorted, deduped set of base columns
@@ -442,23 +457,10 @@ func resampleRangeWindowColumns(r *chplan.RangeWindowResample) []string {
 // columns, and each AggFunc's Params + Args — so narrowing the Scan to
 // exactly that union is safe.
 func rangeBucketFanoutColumns(r *chplan.RangeBucketFanout) []string {
-	seen := map[string]struct{}{}
-	if r.TimestampCol != "" {
-		seen[r.TimestampCol] = struct{}{}
-	}
-	collect := collectColumn(seen)
-	for _, g := range r.GroupBy {
-		walkExpr(g, collect)
-	}
-	for _, af := range r.AggFuncs {
-		for _, p := range af.Params {
-			walkExpr(p, collect)
-		}
-		for _, a := range af.Args {
-			walkExpr(a, collect)
-		}
-	}
-	return sortedColumnSet(seen)
+	var roots []chplan.Expr
+	roots = append(roots, r.GroupBy...)
+	roots = append(roots, aggFuncExprs(r.AggFuncs)...)
+	return stageColumns([]string{r.TimestampCol}, roots...)
 }
 
 // rangeLWRColumns returns the sorted, deduped set of base columns a
@@ -466,13 +468,7 @@ func rangeBucketFanoutColumns(r *chplan.RangeBucketFanout) []string {
 // four named columns — MetricNameCol, AttributesCol, TimestampCol,
 // ValueCol (mirrors resampleRangeWindowColumns).
 func rangeLWRColumns(r *chplan.RangeLWR) []string {
-	seen := map[string]struct{}{}
-	for _, c := range []string{r.MetricNameCol, r.AttributesCol, r.TimestampCol, r.ValueCol} {
-		if c != "" {
-			seen[c] = struct{}{}
-		}
-	}
-	return sortedColumnSet(seen)
+	return stageColumns([]string{r.MetricNameCol, r.AttributesCol, r.TimestampCol, r.ValueCol})
 }
 
 // metricsAggregateColumns returns the sorted, deduped set of base columns
@@ -484,13 +480,10 @@ func rangeLWRColumns(r *chplan.RangeLWR) []string {
 // enumerate it; applyRangeWindowOverMetricsAggregate widens the Scan this
 // rule narrows to include it once the RangeWindow's own Apply case runs.
 func metricsAggregateColumns(m *chplan.MetricsAggregate) []string {
-	seen := map[string]struct{}{}
-	collect := collectColumn(seen)
-	for _, g := range m.GroupBy {
-		walkExpr(g, collect)
-	}
-	walkExpr(m.Attr, collect)
-	return sortedColumnSet(seen)
+	var roots []chplan.Expr
+	roots = append(roots, m.GroupBy...)
+	roots = append(roots, m.Attr)
+	return stageColumns(nil, roots...)
 }
 
 // histogramQuantileColumns returns the sorted, deduped set of base columns
@@ -501,23 +494,62 @@ func metricsAggregateColumns(m *chplan.MetricsAggregate) []string {
 // build the Sample contract Project ABOVE this node. PhiExpr is likewise
 // excluded — it is a self-contained ScalarSubquery over a SEPARATE plan.
 func histogramQuantileColumns(h *chplan.HistogramQuantile) []string {
+	return stageColumns([]string{h.BucketCountsColumn, h.ExplicitBoundsColumn}, h.GroupBy...)
+}
+
+// stageColumns is the one derivation every *Columns enumerator above
+// funnels through: "the set of base-relation column names this node's own
+// emit reads off its input" is always bare column names (`bare`, empty
+// entries skipped) union the ColumnRef leaves reachable from a set of
+// expression roots (`roots`), sorted and deduped so the narrowed Scan's
+// Columns is reproducible across runs. Before this helper existed the
+// eight enumerators repeated this shape by hand — two of them
+// (resampleRangeWindowColumns / rangeLWRColumns) with byte-identical
+// bodies modulo the receiver type — which is exactly how aggregateColumns
+// silently omitted Having and rangeWindowColumns silently omitted
+// TemporalityColumn and the fused Variants arms: a field added to a plan
+// node was eight places to remember, not one.
+func stageColumns(bare []string, roots ...chplan.Expr) []string {
 	seen := map[string]struct{}{}
-	if h.BucketCountsColumn != "" {
-		seen[h.BucketCountsColumn] = struct{}{}
-	}
-	if h.ExplicitBoundsColumn != "" {
-		seen[h.ExplicitBoundsColumn] = struct{}{}
+	for _, c := range bare {
+		if c != "" {
+			seen[c] = struct{}{}
+		}
 	}
 	collect := collectColumn(seen)
-	for _, g := range h.GroupBy {
-		walkExpr(g, collect)
+	for _, r := range roots {
+		walkExpr(r, collect)
 	}
 	return sortedColumnSet(seen)
 }
 
+// aggFuncExprs flattens an AggFunc list's Params + Args, in order, into one
+// Expr slice for feeding to stageColumns. Shared by aggregateColumns and
+// rangeBucketFanoutColumns, whose AggFunc loops were character-for-character
+// identical modulo the loop variable name.
+func aggFuncExprs(fns []chplan.AggFunc) []chplan.Expr {
+	var out []chplan.Expr
+	for _, af := range fns {
+		out = append(out, af.Params...)
+		out = append(out, af.Args...)
+	}
+	return out
+}
+
+// projectionExprs flattens a Projection list's Expr fields, in order, into
+// one Expr slice for feeding to stageColumns.
+func projectionExprs(projs []chplan.Projection) []chplan.Expr {
+	out := make([]chplan.Expr, 0, len(projs))
+	for _, p := range projs {
+		out = append(out, p.Expr)
+	}
+	return out
+}
+
 // sortedColumnSet flattens a column-name set into a sorted, deduped slice.
-// Shared by aggregateColumns / rangeWindowColumns so the narrowed Scan's
-// Columns is reproducible across runs.
+// The single sink every column-collecting function in this file — stageColumns,
+// predicateColumns, referencedColumns — funnels through, so the narrowed
+// Scan's Columns is reproducible across runs.
 func sortedColumnSet(seen map[string]struct{}) []string {
 	out := make([]string, 0, len(seen))
 	for name := range seen {
@@ -572,14 +604,7 @@ func applyProjectFilterScan(p *chplan.Project, f *chplan.Filter) (chplan.Node, b
 // refs (joins, not in scope here) are not expected on a Filter directly
 // over a Scan.
 func predicateColumns(e chplan.Expr) []string {
-	seen := map[string]struct{}{}
-	walkExpr(e, collectColumn(seen))
-	out := make([]string, 0, len(seen))
-	for name := range seen {
-		out = append(out, name)
-	}
-	sort.Strings(out)
-	return out
+	return stageColumns(nil, e)
 }
 
 // collectColumn returns a walkExpr visitor that records every column
@@ -631,16 +656,7 @@ func unionSortedColumns(a, b []string) []string {
 // referencedColumns returns the set of ColumnRef names referenced anywhere
 // in projs, deduped and sorted for deterministic emission.
 func referencedColumns(projs []chplan.Projection) []string {
-	seen := map[string]struct{}{}
-	for _, p := range projs {
-		walkExpr(p.Expr, collectColumn(seen))
-	}
-	out := make([]string, 0, len(seen))
-	for name := range seen {
-		out = append(out, name)
-	}
-	sort.Strings(out)
-	return out
+	return stageColumns(nil, projectionExprs(projs)...)
 }
 
 // walkExpr visits e and every Expr reachable from it. Every chplan

--- a/internal/optimizer/projection_pushdown_test.go
+++ b/internal/optimizer/projection_pushdown_test.go
@@ -110,3 +110,141 @@ func TestNativeRangeWindowColumns_Recollapse(t *testing.T) {
 		})
 	}
 }
+
+// TestRangeWindowColumns_Temporality pins the #2127 fix: rangeWindowColumns
+// must include TemporalityColumn whenever it is set, because
+// emitWindowedArrayExtrapolated (chsql/range_window.go) reads
+// `any(<TemporalityColumn>)` off the same Input this pushdown narrows,
+// unconditionally. Reached in production by a `rate()` / `increase()` over
+// a schema that clears ResourceAttributesColumn (and has no dedicated
+// top-level-column overlay) with AggregationTemporalityColumn set: on such
+// a schema augmentSelectorAttributes (internal/promql/lower.go) skips the
+// Project wrap that would otherwise carry TemporalityColumn, so the
+// RangeWindow's Input is a bare Filter(Scan) with TemporalityColumn still
+// populated — exactly the shape applyStageScan narrows directly.
+func TestRangeWindowColumns_Temporality(t *testing.T) {
+	t.Parallel()
+
+	r := &chplan.RangeWindow{
+		Input:             &chplan.Scan{Table: "otel_metrics_sum"},
+		Func:              "rate",
+		TimestampColumn:   "TimeUnix",
+		ValueColumn:       "Value",
+		TemporalityColumn: "AggregationTemporality",
+		GroupBy:           []chplan.Expr{&chplan.ColumnRef{Name: "Attributes"}},
+	}
+	want := []string{"AggregationTemporality", "Attributes", "TimeUnix", "Value"}
+	if got := rangeWindowColumns(r); !reflect.DeepEqual(got, want) {
+		t.Errorf("rangeWindowColumns() = %v, want %v", got, want)
+	}
+}
+
+// TestRangeWindowColumns_TemporalityReachesNarrowedScan proves the gap end
+// to end through the rule itself, not just the enumerator: applying
+// ProjectionPushdown to `RangeWindow(Filter(Scan))` with TemporalityColumn
+// set must leave AggregationTemporality in the narrowed Scan.Columns.
+// Before the #2127 fix this narrowed the Scan to {Attributes, TimeUnix,
+// Value}, dropping AggregationTemporality out from under the emitter and
+// 502ing with UNKNOWN_IDENTIFIER.
+func TestRangeWindowColumns_TemporalityReachesNarrowedScan(t *testing.T) {
+	t.Parallel()
+
+	scan := &chplan.Scan{Table: "otel_metrics_sum"}
+	filter := &chplan.Filter{
+		Input:     scan,
+		Predicate: &chplan.Binary{Op: chplan.OpEq, Left: &chplan.ColumnRef{Name: "MetricName"}, Right: &chplan.InlineString{V: "x"}},
+	}
+	r := &chplan.RangeWindow{
+		Input:             filter,
+		Func:              "rate",
+		TimestampColumn:   "TimeUnix",
+		ValueColumn:       "Value",
+		TemporalityColumn: "AggregationTemporality",
+		GroupBy:           []chplan.Expr{&chplan.ColumnRef{Name: "Attributes"}},
+	}
+
+	got, changed := (ProjectionPushdown{}).Apply(r)
+	if !changed {
+		t.Fatalf("ProjectionPushdown.Apply() reported no change")
+	}
+	rewritten, ok := got.(*chplan.RangeWindow)
+	if !ok {
+		t.Fatalf("ProjectionPushdown.Apply() returned %T, want *chplan.RangeWindow", got)
+	}
+	rewrittenFilter, ok := rewritten.Input.(*chplan.Filter)
+	if !ok {
+		t.Fatalf("rewritten RangeWindow.Input = %T, want *chplan.Filter", rewritten.Input)
+	}
+	rewrittenScan, ok := rewrittenFilter.Input.(*chplan.Scan)
+	if !ok {
+		t.Fatalf("rewritten Filter.Input = %T, want *chplan.Scan", rewrittenFilter.Input)
+	}
+
+	want := []string{"AggregationTemporality", "Attributes", "MetricName", "TimeUnix", "Value"}
+	if !reflect.DeepEqual(rewrittenScan.Columns, want) {
+		t.Errorf("narrowed Scan.Columns = %v, want %v", rewrittenScan.Columns, want)
+	}
+}
+
+// TestRangeWindowColumns_Variants pins the second #2127 latent gap: a fused
+// multi-arm RangeWindow (LogQL's variants(...)) must contribute every arm's
+// own ValueColumn, since range_window_variants.go reads each arm's column
+// directly off Input. Currently reached only through a Project gate
+// applyStageScan declines, but the enumerator itself must still be a
+// complete description of what the emit reads.
+func TestRangeWindowColumns_Variants(t *testing.T) {
+	t.Parallel()
+
+	r := &chplan.RangeWindow{
+		Input:           &chplan.Scan{Table: "logs"},
+		TimestampColumn: "TimeUnix",
+		GroupBy:         []chplan.Expr{&chplan.ColumnRef{Name: "Attributes"}},
+		Variants: []chplan.RangeWindowVariant{
+			{Func: "count_over_time", ValueColumn: "CountValue", Label: "0"},
+			{Func: "bytes_over_time", ValueColumn: "BytesValue", Label: "1"},
+		},
+		VariantColumn: "__variant__",
+	}
+	want := []string{"Attributes", "BytesValue", "CountValue", "TimeUnix"}
+	if got := rangeWindowColumns(r); !reflect.DeepEqual(got, want) {
+		t.Errorf("rangeWindowColumns() = %v, want %v", got, want)
+	}
+}
+
+// TestAggregateColumns_Having pins the third #2127 latent gap:
+// aggregateColumns must include the columns Having references, since
+// emitAggregate (chsql/emit_node.go) renders Having as a real SQL HAVING
+// clause evaluated against the same narrowed row shape. Mirrors
+// duplicateLabelsetGuardExpr's shape (internal/promql/lower.go): a
+// `throwIf(uniqExact(MetricName) > 1, …) = 0` guard where MetricName is
+// deliberately absent from both GroupBy and AggFuncs.
+func TestAggregateColumns_Having(t *testing.T) {
+	t.Parallel()
+
+	a := &chplan.Aggregate{
+		Input:   &chplan.Scan{Table: "otel_metrics_gauge"},
+		GroupBy: []chplan.Expr{&chplan.ColumnRef{Name: "Attributes"}},
+		AggFuncs: []chplan.AggFunc{
+			{Name: "any", Args: []chplan.Expr{&chplan.ColumnRef{Name: "Value"}}, Alias: "Value"},
+		},
+		Having: &chplan.Binary{
+			Op: chplan.OpEq,
+			Left: &chplan.FuncCall{
+				Name: "throwIf",
+				Args: []chplan.Expr{
+					&chplan.Binary{
+						Op:    chplan.OpGt,
+						Left:  &chplan.FuncCall{Name: "uniqExact", Args: []chplan.Expr{&chplan.ColumnRef{Name: "MetricName"}}},
+						Right: &chplan.LitInt{V: 1},
+					},
+					&chplan.InlineString{V: "duplicate labelset"},
+				},
+			},
+			Right: &chplan.LitInt{V: 0},
+		},
+	}
+	want := []string{"Attributes", "MetricName", "Value"}
+	if got := aggregateColumns(a); !reflect.DeepEqual(got, want) {
+		t.Errorf("aggregateColumns() = %v, want %v", got, want)
+	}
+}


### PR DESCRIPTION
## Summary

Issue #2127 named eight nearly-identical `*Columns` helpers in `internal/optimizer/projection_pushdown.go`, each deriving "the base columns this stage node's own emit reads off its input" by hand. That duplication is exactly how two real omissions crept in:

- `aggregateColumns` never walked `Aggregate.Having`, so a narrowed Scan could drop a column the HAVING clause references. Verified live: `duplicateLabelsetGuardExpr` (`internal/promql/lower.go:3023`) plants `throwIf(uniqExact(MetricName) > 1, …) = 0` as an `Aggregate.Having` specifically because `MetricName` is *not* a GroupBy key for that shape — so it rode in via neither GroupBy nor AggFuncs, and the old enumerator silently missed it.
- `rangeWindowColumns` never included `RangeWindow.TemporalityColumn` or a fused `Variants` arm's `ValueColumn`. Verified reachable: `augmentSelectorAttributes` (`internal/promql/lower.go:1051`) only wraps the selector in a Project carrying `TemporalityColumn` when the schema sets `ResourceAttributesColumn`; when a schema clears it (and has no dedicated top-level-column overlay), `isBareAttributesRef` makes that Project a no-op the wrap skips (`internal/promql/resource_attributes.go:408`), so a `rate()`/`increase()` selector reaches `ProjectionPushdown` with a bare `Filter(Scan)` Input and `TemporalityColumn` still set.

Both are real `UNKNOWN_IDENTIFIER` 502s waiting to fire once the narrowed Scan actually drops the column the emitter still reads at `internal/chsql/range_window.go` / `internal/chsql/emit_node.go:556`.

## Changes

- Collapses all eight enumerators (`aggregateColumns`, `rangeWindowColumns`, `nativeRangeWindowColumns`, `resampleRangeWindowColumns`, `rangeBucketFanoutColumns`, `rangeLWRColumns`, `metricsAggregateColumns`, `histogramQuantileColumns`) onto one shared `stageColumns(bare []string, roots ...chplan.Expr) []string` derivation, plus two small flattening helpers (`aggFuncExprs`, `projectionExprs`) that kill the two byte-identical bodies the issue called out (`resampleRangeWindowColumns`/`rangeLWRColumns`, and the `AggFunc` loop duplicated between `aggregateColumns`/`rangeBucketFanoutColumns`).
- `predicateColumns` / `referencedColumns`, which each re-implemented `sortedColumnSet`'s body inline instead of calling it, now funnel through the same `stageColumns` helper — `sortedColumnSet` has exactly one call site shape left.
- Fixes the two latent gaps as part of the wiring: `aggregateColumns` now walks `Having`; `rangeWindowColumns` now includes `TemporalityColumn` and every `Variants` arm's `ValueColumn`.
- Updates the `ProjectionPushdown` doc comment's shape (3)/(4) summaries to match.

## Verification

- New unit tests directly on the enumerators/rule, mirroring the existing `TestNativeRangeWindowColumns_Recollapse` style:
  - `TestRangeWindowColumns_Temporality` — `TemporalityColumn` is included when set.
  - `TestRangeWindowColumns_TemporalityReachesNarrowedScan` — applies `ProjectionPushdown.Apply` end to end over `RangeWindow(Filter(Scan))` and asserts the narrowed `Scan.Columns` still carries `AggregationTemporality`.
  - `TestRangeWindowColumns_Variants` — a fused-arm `RangeWindow` contributes every arm's `ValueColumn`.
  - `TestAggregateColumns_Having` — an `Aggregate` with a `Having` referencing a column absent from GroupBy/AggFuncs (mirroring `duplicateLabelsetGuardExpr`'s exact shape) includes that column.
- `go test ./internal/optimizer/...` (race-enabled) — all pass, including the existing `TestOptimizer` txtar-fixture suite (19 subtests) with no fixture drift, so no `just update-golden optimizer` run was needed.
- `gofumpt -extra` / `goimports -local` — clean.

Closes #2127