### PR TITLE
docs: align engine and PREWHERE documentation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,8 +52,8 @@ Where a change belongs, by the question it answers:
 - **"The plan IR cannot express this"** → `internal/chplan/` (`Scan`, `Filter`, `Project`,
   `Aggregate`, `RangeWindow`, `Limit`, and the `Expr` tree). Shared by all three heads.
 - **"The plan is correct but slow"** → `internal/optimizer/`, a rule-based fixpoint driver with a
-  Pattern API and an analyzer/optimizer rule split (transposes, PREWHERE promotion, late
-  materialisation).
+  Pattern API and an analyzer/optimizer rule split (transposes, projection pushdown). Emitter-side
+  optimizations such as PREWHERE promotion and late materialisation live in `internal/chsql/`.
 - **"The SQL is wrong"** → `internal/chsql/`, the plan → ClickHouse SQL emitter. Typed Frags only
   (invariant 10).
 - **"The HTTP response shape is wrong"** → `internal/api/prom/`, `internal/api/loki/`,

--- a/docs/engine.md
+++ b/docs/engine.md
@@ -1,25 +1,25 @@
 # Engine
 
 The query engine — `internal/engine/` — is the shared pipeline that
-turns an upstream query (PromQL / LogQL / TraceQL) into a
+turns an upstream language query (PromQL / LogQL / TraceQL) into a
 ClickHouse result. The three HTTP heads (Prometheus, Loki, Tempo)
-each plug in as a `Lang` adapter; the engine owns the parse →
-optimize → emit → execute loop and the telemetry around it.
+each plug in as a `Lang` adapter; for those query routes the engine owns
+the parse → optimize → emit → execute loop and the telemetry around it.
 
 ## Overview
 
-Cerberus has one shared query pipeline, not three. Each query
+Cerberus has one shared language-query pipeline, not three. Each query
 language has its own parser and its own response shape, but the
 work in the middle — lowering to the shared plan IR, optimizing,
 emitting ClickHouse SQL, executing against the driver — is
-identical. The engine extracts that middle so the heads stay thin:
+identical. The engine extracts that middle so those routes stay thin:
 HTTP dispatch + per-language adapter wiring + response shaping.
 
 ```text
    HTTP request
         │
         ▼
-   handler (api/{prom,loki,tempo})
+   query handler (api/{prom,loki,tempo})
         │
         │  builds Lang adapter
         ▼
@@ -41,16 +41,28 @@ adapters live next to (or inside) the head they serve:
 `internal/api/prom/lang.go`, `internal/logql/lang.go`,
 `internal/api/tempo/lang.go`.
 
+Not every upstream endpoint is a language query or returns the canonical
+sample row shape. Metadata, discovery, live-tail, and enrichment endpoints
+compose typed SQL in `internal/api` and use dedicated client decoders; those
+intentional paths are listed under [API-owned SQL paths](#api-owned-sql-paths).
+
 ## The Engine + Lang contract
 
-The engine is two types and one interface.
+The contract centers on `Engine`, the `Lang` interface, per-query `Meta`,
+and the result types.
 
 ### `Engine`
 
 ```go
 type Engine struct {
-    Optimizer *optimizer.Driver
-    Client    Querier
+    Optimizer       *optimizer.Driver
+    Client          Querier
+    Solver          *solver.Solver
+    Settings        SettingsRules
+    liveSettings    atomic.Pointer[SettingsRules]
+    QueryObserver   QueryObserver
+    MaxQuerySamples int64
+    RouteMemo       *routememo.Memo
 }
 ```
 
@@ -62,6 +74,16 @@ type Engine struct {
   `CursorQuerier` interface, the engine's `QueryCursor` /
   `QueryPlanCursor` entry points open a streaming cursor instead
   of draining rows into a slice. Required.
+- `Solver` optionally classifies PromQL plans and executes the sharded
+  route; `nil` keeps every request on the single-statement route.
+- `Settings` holds plan-gated ClickHouse settings. `liveSettings` is the
+  atomic replacement installed by `SetSettings` after capability changes.
+- `QueryObserver` optionally records dispatches and outcomes for the
+  asynchronous query-log performance corpus.
+- `MaxQuerySamples` rejects oversized subquery anchor grids before
+  dispatch; `0` disables that plan-side gate.
+- `RouteMemo` optionally remembers resource-failure routing outcomes and
+  can steer a later eligible PromQL request to route B.
 
 One Engine instance is constructed per HTTP head in
 `cmd/cerberus/main.go` and lives for the lifetime of the process.
@@ -108,6 +130,7 @@ type Meta struct {
     IsMetric      bool
     IsTraceByID   bool
     ResponseShape string
+    Guards        []Guard
     Extra         map[string]any
 }
 ```
@@ -128,6 +151,8 @@ the plan alone:
   `"tempo-trace"`, …). The engine does not read it; it is
   threaded through `Result` so the response formatter does not
   have to re-derive it.
+- `Guards` — ordered value-domain checks that the engine emits and
+  executes before the main query. The first violation rejects the request.
 - `Extra` — adapter-specific bag for per-language knobs that ride
   through `Meta` without bloating the type (the LogQL adapter
   uses it to carry the parsed `syntax.Expr` to the handler).
@@ -144,14 +169,15 @@ type Result struct {
     PlanNodeCount int
     Headers       map[string]string
     Meta          Meta
+    Inspected     int64
 }
 ```
 
 - `Samples` is the decoded row stream. Handlers pivot it into the
   upstream wire shape.
 - `SQL` + `Args` are surfaced for debug logging.
-- `Strategy` is a free-form label for the execution path taken —
-  empty in the default path; see [Extension points](#extension-points).
+- `Strategy` is the canonical execution-family label: `"native"` for
+  language queries and `"trace-by-id"` for that Tempo short-circuit.
 - `CHMillis` is the wall-clock time spent in `Client.Query`,
   exposed through the `X-Cerberus-CH-Millis` response header.
 - `PlanNodeCount` is the optimised plan's node count, exposed
@@ -161,6 +187,8 @@ type Result struct {
   of `http.ResponseWriter`.
 - `Meta` is the same `Meta` the adapter returned, threaded
   through so the response pivot can switch on it.
+- `Inspected` is the number of rows drained from ClickHouse on the eager
+  path. Streaming callers read the corresponding count from the cursor.
 
 A streaming sibling — `CursorResult` — mirrors this shape but
 carries a `chclient.Cursor` instead of a `[]Sample` slice. The
@@ -168,7 +196,7 @@ caller is responsible for `cursor.Close()`.
 
 ## Request lifecycle
 
-A typical request flows through the following stages:
+A typical parsed language-query request flows through the following stages:
 
 1. **HTTP dispatch.** The per-API handler (`internal/api/prom`,
    `internal/api/loki`, `internal/api/tempo`) parses the HTTP
@@ -188,13 +216,16 @@ A typical request flows through the following stages:
 4. **Inside the engine:**
    1. `lang.Parse` runs the head's parser and lowers to
       `chplan`. Opens `parse` + `lower` spans.
-   2. `lang.ProjectSamples` wraps the plan into the canonical
+   2. The engine executes any `Meta.Guards` before the main statement.
+   3. `lang.ProjectSamples` wraps the plan into the canonical
       `Sample` row shape.
-   3. The optimizer runs (skipped when `Meta.IsTraceByID` is
+   4. The optimizer runs (skipped when `Meta.IsTraceByID` is
       set). Opens an `optimize` span.
-   4. `chsql.Emit` materialises the plan into parameterised
+   5. The optional solver classifies the optimized plan and may select
+      the sharded route.
+   6. `chsql.Emit` materialises the plan into parameterised
       ClickHouse SQL. Opens an `emit` span.
-   5. `Client.Query` executes the SQL. Opens an `execute` span;
+   7. `Client.Query` executes the SQL. Opens an `execute` span;
       records wall-clock time into `Result.CHMillis`.
 5. **Result.** The engine returns a `Result` (or `CursorResult`)
    with the decoded samples and the metadata the handler needs
@@ -211,6 +242,31 @@ error types — `parseStageError` in the Prom adapter,
 `*httperr.Error` in the LogQL adapter — ride through the wrap
 so the handler can map them to the right HTTP status without
 losing the cause.
+
+## API-owned SQL paths
+
+The engine is the common path when an endpoint starts from a language query
+or plan and consumes canonical `Sample` rows. Some upstream APIs need a
+different row decoder, combine several generated statements, or perform a
+side query around the main result. Those handlers use the same typed `chsql`
+surface and `chclient`, but intentionally do not force the work through
+`Engine.Query`:
+
+- **Prometheus:** `internal/api/prom/metadata.go` builds the catalog and
+  series fan-in queries; `internal/api/prom/exemplars.go` emits the
+  endpoint's dedicated exemplar rows.
+- **Loki:** under `internal/api/loki`, `labels.go`, `label_values.go`,
+  `series.go`, `index_stats.go`, `index_volume.go`, `detected_labels.go`,
+  `detected_fields.go`, and `patterns.go` build metadata or sampled-row
+  shapes; `tail.go` builds each bounded poll in the live WebSocket loop.
+- **Tempo:** under `internal/api/tempo`, `search_tags.go` and
+  `search_tag_values.go` build tag discovery; `root_lookup.go` and
+  `structural_two_phase.go` emit follow-up or narrow phase plans;
+  `metrics_exec.go` emits the optional exemplar side query.
+
+These are API-layer orchestration paths, not alternate query-language
+pipelines. Main PromQL, LogQL, and TraceQL query execution still converges on
+the engine.
 
 ## Pipeline stages in depth
 
@@ -466,8 +522,10 @@ source of truth is the upstream OTel-CH exporter via the
 [`tsouza/opentelemetry-collector-contrib:cerberus-ddl`](https://github.com/tsouza/opentelemetry-collector-contrib/tree/cerberus-ddl)
 fork — cerberus consumes the same DDL templates the production
 exporter emits, so a deployment where the exporter writes and cerberus
-reads sees one schema across both sides. A thin YAML override config
-supports SigNoz schemas and custom column layouts.
+reads sees one schema across both sides. Runtime YAML and environment
+overrides cover the five metrics table names, the logs and spans table names,
+the traces timestamp-lookup toggle, and the Prometheus resource-label list.
+They do not provide a SigNoz preset or arbitrary column-name mapping.
 
 ## Adding a new query head
 
@@ -509,7 +567,7 @@ response. The contract is:
 | ----------------------- | ----------------------- | ---------------------------------------------------------------------------------------- |
 | `X-Cerberus-CH-Millis`  | `Result.CHMillis`       | Wall-clock milliseconds spent inside `Client.Query` (the ClickHouse roundtrip).          |
 | `X-Cerberus-Plan-Nodes` | `Result.PlanNodeCount`  | Node count of the optimised plan that produced the executed SQL.                         |
-| `X-Cerberus-Strategy`   | `Result.Strategy`       | Free-form label identifying the execution path. Empty in the default direct-table path.  |
+| `X-Cerberus-Strategy`   | `Result.Strategy`       | Execution-family label: `native` or `trace-by-id`.                                       |
 
 Handlers stamp these headers from `Result` (or via the chclient
 millisecond counter where a per-request middleware is in play).
@@ -533,20 +591,12 @@ the same way.
 
 ## Extension points
 
-The engine has two designed-in extension points beyond the `Lang`
-interface.
-
-### Strategy switch
-
-`Result.Strategy` is a free-form label that names the execution
-path taken. The default path leaves it empty. An optimizer rule
-that rewrites the plan to read from a materialised view, a
-pre-aggregated table, or any other alternative storage can stamp
-the strategy by setting it on a marker node the engine reads back
-after the optimizer pass. This is the seat for future
-fallback-evaluator work — adding a new strategy means writing the
-rule that detects when it applies and the label that identifies
-it, without touching the engine's loop.
+Beyond `Lang`, the engine has three optional runtime seams. `Solver` and
+`RouteMemo` own route classification, sharded execution, and failure-driven
+route selection. `Settings` plus `SetSettings` apply plan-gated ClickHouse
+settings and permit an atomic capability refresh. `QueryObserver` receives
+dispatch and outcome events for the performance corpus. Their nil or zero
+values preserve the ordinary single-statement path.
 
 ### OTel hooks
 
@@ -582,15 +632,18 @@ A short list, because the engine's narrow scope is deliberate:
 
 - **Not a query plan cache.** Plans are recomputed per request.
   The engine has no LRU, no memoisation, no plan store.
-- **Not a result cache.** Result rows are streamed straight from
-  the ClickHouse driver to the handler. Cerberus is a gateway,
-  not a memoisation layer.
+- **Not a result cache.** Cursor routes stream rows to the handler; eager
+  routes drain rows into the per-request `Result.Samples` slice. Neither
+  retains results beyond that request.
 - **Not a router.** URL → endpoint dispatch stays in the
   handlers; the engine sees a request only after the handler has
   decided which entry point to call.
+- **Not the owner of every ClickHouse statement.** It owns the shared
+  language-query pipeline. Endpoint-specific metadata, discovery, live-tail,
+  and enrichment statements remain in the API packages listed above.
 - **Not a translator of wire formats.** The handler formats
-  `Result.Samples` into the upstream wire shape; the engine never
-  touches `http.ResponseWriter`.
+  engine results or dedicated endpoint rows into the upstream wire shape;
+  the engine never touches `http.ResponseWriter`.
 - **Not a streaming subquery reducer.** A PromQL subquery
   `<reducer>_over_time(<inner>[range:step])` materialises
   `range/step + 1` anchor rows per series before collapsing them,

--- a/internal/chplan/rewrite_children_exhaustive_test.go
+++ b/internal/chplan/rewrite_children_exhaustive_test.go
@@ -13,8 +13,8 @@ import (
 // Driver uses to walk a chplan tree bottom-up. Every concrete Node
 // type needs an arm that recurses into its Children(); any type that falls
 // through to the default `return n, false` becomes an OPAQUE LEAF and
-// silently DISABLES every optimizer rule (predicate pushdown, PREWHERE,
-// projection-pushdown, MV substitution, constant-fold) on its whole
+// silently DISABLES every optimizer rule (predicate pushdown,
+// projection-pushdown, constant-fold) on its whole
 // subtree. That is exactly the perf bug this test guards against
 // reintroducing: the walk was previously total for only 11 of the 26 node
 // types, so e.g. the TraceQL MetricsAggregate subtree was never optimized.

--- a/internal/chsql/builder.go
+++ b/internal/chsql/builder.go
@@ -19,8 +19,8 @@ import (
 // primitives the emitter uses, plus a handful of CH-specific helpers
 // (MapAt, MapKeys, MapFilterExcept, Now64, SubtractNanos,
 // DateTime64Lit, Lambda, ParamAgg) and a QueryBuilder with first-class
-// PREWHERE, JOIN, and WITH RECURSIVE slots so the optimizer rules can
-// compose SQL fragments without re-parsing rendered strings.
+// PREWHERE, JOIN, and WITH RECURSIVE slots so emitters and endpoint-specific
+// callers can compose SQL fragments without re-parsing rendered strings.
 //
 // The zero value is ready to use.
 type Builder struct {
@@ -2344,11 +2344,10 @@ type cteClause struct {
 //
 // PREWHERE is a first-class slot, distinct from WHERE. ClickHouse
 // evaluates PREWHERE before WHERE on the primary-key columns,
-// pruning rows before the full row read; the optimizer's PREWHERE
-// promotion rule moves predicates from WHERE → PREWHERE when the
-// predicate only references sort-key columns. Modelling PREWHERE separately
-// here means those rewrites are slot-level operations rather than
-// string rewrites on rendered SQL.
+// pruning rows before the full row read; the chsql emitter's Filter(Scan)
+// path promotes eligible predicates from WHERE → PREWHERE. Modelling
+// PREWHERE separately here makes that partition a slot-level operation
+// rather than a string rewrite on rendered SQL.
 //
 // JOIN clauses live in the joins slot, rendered in order between
 // FROM and PREWHERE. Each entry holds a JoinKind, a source Frag (the

--- a/internal/chsql/metrics_compare_test.go
+++ b/internal/chsql/metrics_compare_test.go
@@ -150,7 +150,7 @@ func TestEmitRangeWindowCompare_JoinScanPushdown(t *testing.T) {
 	// aggregate's inputs rather than filtering its output. This non-root shape
 	// has no direct Timestamp bound, so the scan itself is NOT pruned (that is
 	// #1214's lossless tradeoff; only the root-scoped arm prunes).
-	// PREWHERE promotion (internal/optimizer)
+	// PREWHERE promotion in the chsql emitter
 	// splits the two conjuncts of the Filter across PREWHERE/WHERE rather
 	// than AND-ing them into one clause; either placement still lands the
 	// seed inside the scan, below the GROUP BY. The seed's own bound

--- a/internal/logql/lang.go
+++ b/internal/logql/lang.go
@@ -375,9 +375,9 @@ func parseExprTraced(ctx context.Context, query string) (syntax.Expr, error) {
 // Rationale: cerberus is a query gateway, not an index-scoped store.
 // Upstream Loki's rejection exists because its chunk index is keyed by
 // label set and a match-all matcher would force a full-store fan-out;
-// cerberus translates to a ClickHouse WHERE predicate that the CH
-// optimiser already prunes (PREWHERE / MV substitution / sparse-index
-// skip), so a `{service_name=~".*"}` query is well-defined and lowers
+// cerberus translates to a ClickHouse predicate that can use emitted
+// PREWHERE and sparse-index pruning, so a `{service_name=~".*"}` query
+// is well-defined and lowers
 // to `match(ResourceAttributes['service_name'], '.*')` — equivalent to
 // `service_name!=""` on rows where the label is present, plus the
 // rows where it's absent (RA[missing] = ” in CH; `match(”, '.*')`

--- a/internal/optimizer/constant_fold.go
+++ b/internal/optimizer/constant_fold.go
@@ -10,9 +10,8 @@ import "github.com/tsouza/cerberus/internal/chplan"
 // This is the **semantic / must-run** flavour of constant folding
 // (DataFusion `AnalyzerRule` shape — see analyzer.go). Downstream
 // rules assume that pure-literal subtrees have already collapsed to a
-// single Lit: a
-// PREWHERE-promotion rule that distinguishes `WHERE false` from
-// `WHERE 1=0` would silently miss the latter without this pass.
+// single Lit: the chsql emitter's PREWHERE partitioning would otherwise
+// distinguish `WHERE false` from the equivalent `WHERE 1=0` shape.
 //
 // Folding runs recursively across each expression tree before the
 // result is compared with the original — so a single Apply call can

--- a/internal/optimizer/decision_pins_test.go
+++ b/internal/optimizer/decision_pins_test.go
@@ -8,9 +8,10 @@ package optimizer_test
 // ProjectionPushdown: each checks passthrough columns / column sets to
 // decide whether the rewrite is semantics-preserving.
 //
-// PREWHERE promotion and late-materialisation are not wired as
-// distinct named rules. Their semantic deputies in v1 are the
-// FilterRangeWindowTranspose + ProjectionPushdown rules; pin those.
+// PREWHERE promotion lives in the chsql emitter rather than a named
+// optimizer rule; FilterRangeWindowTranspose can expose a predicate to
+// that emitter path. ProjectionPushdown is late materialisation's
+// plan-side deputy. Pin those two optimizer decisions here.
 //
 // Each test asserts on the *plan shape* the rule produces — not on
 // raw SQL — so a future emitter tweak (changing inner aliases, for

--- a/internal/optimizer/doc.go
+++ b/internal/optimizer/doc.go
@@ -82,9 +82,9 @@
 //     stacked *above* an Aggregate down beneath it. No current lowering
 //     emits `Filter(Aggregate(…))` with a bare group-key predicate —
 //     PromQL `sum by (job) (m{job="x"})` lowers the `job="x"` matcher
-//     into the scan PREWHERE, not above the aggregate. The rule is
-//     retained so a future lowering that *does* surface a group-key
-//     filter above an aggregate is handled correctly without a
+//     into a Filter directly above the scan, not above the aggregate.
+//     The rule is retained so a future lowering that *does* surface a
+//     group-key filter above an aggregate is handled correctly without a
 //     re-derivation. Its unit + rule-interaction tests pin the
 //     behaviour; the cost of keeping it is a no-op pattern probe per
 //     fixpoint iteration.

--- a/internal/optimizer/filter_aggregate_transpose.go
+++ b/internal/optimizer/filter_aggregate_transpose.go
@@ -9,10 +9,10 @@ import "github.com/tsouza/cerberus/internal/chplan"
 // SPECULATIVE: 0 fires on the current test/spec corpus (measured with
 // the total optimizer walk from #812). No live lowering emits a
 // group-key label filter stacked *above* an Aggregate — PromQL
-// `sum by (job) (m{job="x"})` lowers the `job="x"` matcher into the
-// scan PREWHERE, never above the aggregate. The rule is kept as cheap
-// correctness insurance: a future lowering that *does* surface such a
-// shape is then handled without re-derivation. Do not count it as an
+// `sum by (job) (m{job="x"})` lowers the `job="x"` matcher into a Filter
+// directly above the scan, never above the aggregate. The rule is kept
+// as cheap correctness insurance: a future lowering that *does* surface
+// such a shape is then handled without re-derivation. Do not count it as an
 // active optimization. See doc.go for the corpus-wide fire census.
 //
 // Lineage: Calcite's `FilterAggregateTransposeRule` — see
@@ -21,8 +21,8 @@ import "github.com/tsouza/cerberus/internal/chplan"
 // predicate over the Aggregate result is equivalent to the same
 // predicate applied to the rows feeding the Aggregate. Pushing it
 // underneath dramatically shrinks the rows the GROUP BY has to chew
-// through, and exposes the predicate to PREWHERE promotion once it
-// reaches the Scan.
+// through, and exposes the predicate to the chsql emitter's PREWHERE
+// promotion once it reaches the Scan.
 //
 // Safety. The Filter sees two flavours of output column on the
 // Aggregate: the group-by keys (`Aggregate.GroupBy`, optionally renamed

--- a/internal/optimizer/filter_range_window_transpose.go
+++ b/internal/optimizer/filter_range_window_transpose.go
@@ -19,7 +19,8 @@ import "github.com/tsouza/cerberus/internal/chplan"
 // applied to the per-sample rows feeding the window. Pushing it
 // underneath shrinks the rows the windowed-array idiom has to
 // `groupArray` / `arraySort` / `arrayFilter` through, and exposes the
-// predicate to PREWHERE promotion once it reaches the Scan.
+// predicate to the chsql emitter's PREWHERE promotion once it reaches
+// the Scan.
 //
 // Safety. The Filter sees three flavours of column on the
 // RangeWindow's output:

--- a/internal/promql/histogram_quantile_range.go
+++ b/internal/promql/histogram_quantile_range.go
@@ -779,7 +779,7 @@ func buildHistogramBucketFanout(
 ) chplan.Node {
 	// Scan-side metric-bounded Filter: apply label matchers so the
 	// fan-out reads a metric-bounded row set; this is the
-	// PREWHERE-eligible shape the optimizer keeps fast.
+	// PREWHERE-eligible shape the chsql emitter keeps fast.
 	var rawSide chplan.Node = scan
 	if pred != nil {
 		rawSide = &chplan.Filter{Input: scan, Predicate: pred}

--- a/internal/promql/lower.go
+++ b/internal/promql/lower.go
@@ -680,7 +680,7 @@ func lowerVectorSelector(v *parser.VectorSelector, s schema.Metrics, ctx lowerCt
 	// `sum by (service_name) (rate({__name__=~".+"}[5m]))`.
 	// The Project lands between the Scan/Filter and the per-mode
 	// wraps so PREWHERE-eligible matchers stay on the raw Scan
-	// (the optimizer's promotion path is untouched).
+	// (the chsql emitter's promotion path is untouched).
 	//
 	// Order-of-operations for `pred`: when the augmenting Project
 	// kicks in it preserves only the canonical Sample quadruple
@@ -696,7 +696,7 @@ func lowerVectorSelector(v *parser.VectorSelector, s schema.Metrics, ctx lowerCt
 	// The fix sinks `pred` to a Filter immediately above the raw
 	// scan-side input BEFORE augmenting — at that layer every raw
 	// column (including ServiceName) is still in scope and the
-	// optimizer's PREWHERE promotion path still sees the matcher
+	// chsql emitter's PREWHERE promotion path still sees the matcher
 	// Filter directly above the Scan. The downstream wrappers then
 	// receive `pred=nil` and only attach the LWR / staleness time
 	// bounds (which reference TimeUnix, preserved by the augment).
@@ -1895,7 +1895,7 @@ func rawLabelValueExpr(s schema.Metrics, promLabel string) chplan.Expr {
 // produce a single candidate — keep the legacy single-comparison
 // emit, byte-stable with the pre-fan-out fixtures. The InList is
 // `isCheapPredicate`-shaped (InList over ColumnRef / LitString), so
-// the optimizer's PREWHERE promotion treats it exactly like the
+// the chsql emitter's PREWHERE promotion treats it exactly like the
 // single equality it replaces.
 // promMetricNormalizePattern is the SQL-side mirror of
 // [format.OTelToPromMetric]: every byte outside the Prom metric-name
@@ -1971,7 +1971,7 @@ func metricNamePredicateOn(m *labels.Matcher, s schema.Metrics, nameExpr func() 
 	// (code 62, "Max query size exceeded") on the metrics-explorer broad
 	// probe. An IN tuple renders the column once + N `?` placeholders —
 	// compact text, constant parser depth — regardless of N. InList is
-	// classified cheap + PREWHERE-promotable by the optimizer (see
+	// classified cheap + PREWHERE-promotable by the chsql emitter (see
 	// internal/chsql/prewhere.go), so this preserves the
 	// granule-prune posture the single-equality emit had.
 	list := make([]chplan.Expr, len(candidates))

--- a/internal/schema/doc.go
+++ b/internal/schema/doc.go
@@ -1,7 +1,4 @@
 // Package schema holds the default OpenTelemetry ClickHouse Exporter schema
-// constants and the override-config types that let users point cerberus at
-// SigNoz, custom column layouts, or alternative table names.
-//
-// Default schema + override config land in seed PR5 alongside the PromQL
-// vertical slice.
+// descriptions and the runtime overrides for metrics, logs, and traces table
+// names.
 package schema

--- a/test/property/gen/logql.go
+++ b/test/property/gen/logql.go
@@ -220,7 +220,7 @@ func drawBody(t *rapid.T, id string) string {
 //
 // `CREATE OR REPLACE TABLE` keeps re-runs inside the same chDB
 // process idempotent. MergeTree (not Memory) matches the metrics-
-// side rationale: the optimizer's PREWHERE promotion fires
+// side rationale: the chsql emitter's PREWHERE promotion fires
 // unconditionally and chDB's Memory engine refuses PREWHERE.
 //
 // The DDL must declare every column the LogQL lowering can reference

--- a/test/property/gen/metrics.go
+++ b/test/property/gen/metrics.go
@@ -155,10 +155,9 @@ func drawPoints(t *rapid.T, id string) []property.Point {
 // `CREATE OR REPLACE TABLE` keeps re-runs inside the same chDB process
 // idempotent (chdb-go shares one catalog across sessions in v1.11.0).
 //
-// MergeTree (not Memory) is the chosen engine because cerberus's
-// optimizer emits PREWHERE clauses on aggregate-over-filter shapes
-// (the promotion rule fires unconditionally), and chDB's Memory
-// engine returns ILLEGAL_PREWHERE on those queries. MergeTree
+// MergeTree (not Memory) is the chosen engine because cerberus's chsql
+// emitter emits PREWHERE clauses on aggregate-over-filter shapes, and
+// chDB's Memory engine returns ILLEGAL_PREWHERE on those queries. MergeTree
 // supports PREWHERE the way every real cerberus deployment does, so
 // the property test matches what production CH does. ORDER BY
 // (MetricName, TimeUnix) gives the table a sort key without forcing

--- a/test/property/gen/traceql.go
+++ b/test/property/gen/traceql.go
@@ -136,8 +136,7 @@ const (
 //   - "__status__"      → the CH-stored status literal (Ok/Error/Unset)
 //
 // MergeTree is the chosen engine (matches PromQL property test
-// rationale: Memory engine refuses PREWHERE the cerberus optimizer
-// emits).
+// rationale: Memory engine refuses PREWHERE the chsql emitter emits).
 func TraceQLDataset() *rapid.Generator[property.Dataset] {
 	return rapid.Custom(func(t *rapid.T) property.Dataset {
 		numTraces := rapid.IntRange(1, traceQLMaxTraces).Draw(t, "numTraces")


### PR DESCRIPTION
## Summary

- attribute PREWHERE promotion to the chsql emitter across code comments and contributor guidance
- narrow schema claims to the table and resource-label overrides exposed at runtime
- document the current Engine and Meta fields plus intentional API-owned SQL paths

## Validation

- `npm exec --yes -- markdownlint-cli2@v0.18.1 docs/engine.md CLAUDE.md`
- `git diff --check`
- repository pre-commit and pre-push hooks

Closes #2059