### PR TITLE
perf(traceql): fold phase-B trace-id restriction into the inverse closure anchor

### DIFF
--- a/internal/chsql/structural_join.go
+++ b/internal/chsql/structural_join.go
@@ -882,11 +882,16 @@ func (e *emitter) buildStructuralInverseClosure(j *chplan.StructuralJoin, rightS
 	//
 	// The seed carries the request-window bound for the same reason the
 	// canonical closure's does: this anchor is a recursive-CTE arm, so nothing
-	// outside the CTE prunes its `(<R>) AS _seed` scan (#1942). The trace-id
-	// restriction is deliberately NOT folded here — the inverse closure projects
-	// only `_depth > 0` rows, which come from the step arm alone, and the step
-	// already restricts them (structuralStepWhere), so phase B stays a faithful
-	// top-N subset without it.
+	// outside the CTE prunes its `(<R>) AS _seed` scan (#1942). It also carries
+	// the two-phase trace-id restriction (structuralAnchorNodeBounds), shared
+	// with the canonical closure's anchor: #2104 found this seed omitted it,
+	// which does not change the RESULT — the inverse closure projects only
+	// `_depth > 0` rows, which come from the step arm alone, and the step
+	// already restricts them (structuralStepWhere), so phase B stayed a
+	// faithful top-N subset either way — but it does mean the seed scan read
+	// every windowed trace on the R side instead of granule-pruning to the
+	// top-N literals via idx_trace_id, exactly the amplification phase B
+	// exists to avoid.
 	anchor := NewQuery().
 		Select(
 			Distinct(Col(j.TraceIDColumn)),
@@ -895,7 +900,7 @@ func (e *emitter) buildStructuralInverseClosure(j *chplan.StructuralJoin, rightS
 			verbatim("0 AS _depth"),
 		).
 		From(aliasedFrag(rightSub, "_seed")).
-		Where(structuralAnchorWindowFrags(j)...)
+		Where(structuralAnchorNodeBounds(j)...)
 
 	stepOn := And(spanIDPairFrag("t", j.TraceIDColumn, "c", j.TraceIDColumn), stepRel)
 	stepFrom, err := e.fromSpansScan(table, memoryStreamingBound())
@@ -960,12 +965,14 @@ func structuralStepWhere(j *chplan.StructuralJoin) []Frag {
 
 // structuralAnchorWhere builds the WHERE conjuncts for a recursive closure's
 // anchor seed: the candidate prefilter (both sides selective — restrict seeds
-// to traces present on the OTHER side too), the two-phase trace-id restriction
-// (phase B — restrict seeds to the top-N traces), and the request-window
-// partition-prune bound (structuralAnchorWindowFrags). The first two key on the
-// seed's TraceId; all three are pure pruning bounds, and a plan that sets none
-// gets an empty slice so the anchor stays byte-identical. otherSideSub is the
-// closure's other-side subquery Frag (R for the canonical closure).
+// to traces present on the OTHER side too) plus the node-only bounds every
+// anchor gets (structuralAnchorNodeBounds — the two-phase trace-id restriction
+// and the request-window partition-prune bound). The prefilter is
+// canonical-closure-only: the inverse closure's seed IS the other side
+// already, so intersecting it with itself would be a no-op at best. All are
+// pure pruning bounds, and a plan that sets none gets an empty slice so the
+// anchor stays byte-identical. otherSideSub is the closure's other-side
+// subquery Frag (R for the canonical closure).
 func structuralAnchorWhere(j *chplan.StructuralJoin, otherSideSub Frag) []Frag {
 	var conds []Frag
 	if j.CandidatePrefilter {
@@ -974,6 +981,22 @@ func structuralAnchorWhere(j *chplan.StructuralJoin, otherSideSub Frag) []Frag {
 			structuralCandidateTraceSubquery(otherSideSub, j.TraceIDColumn),
 		))
 	}
+	return append(conds, structuralAnchorNodeBounds(j)...)
+}
+
+// structuralAnchorNodeBounds builds the WHERE conjuncts every recursive
+// closure anchor gets regardless of projection direction: the two-phase
+// trace-id restriction (phase B — restrict the seed to the top-N traces via
+// idx_trace_id) and the request-window partition-prune bound
+// (structuralAnchorWindowFrags). Shared by the canonical closure's anchor
+// (through structuralAnchorWhere, which additionally folds the
+// CandidatePrefilter) and the inverse closure's anchor
+// (buildStructuralInverseClosure) — #2104 found the inverse anchor built its
+// own window-only WHERE by hand and never folded the restriction, so its seed
+// scan read every windowed trace on the R side instead of granule-pruning to
+// the top-N literals, exactly the read amplification phase B exists to avoid.
+func structuralAnchorNodeBounds(j *chplan.StructuralJoin) []Frag {
+	var conds []Frag
 	if len(j.TraceIDRestriction) > 0 {
 		conds = append(conds, inStringLiteralsFrag(Col(j.TraceIDColumn), j.TraceIDRestriction))
 	}

--- a/internal/chsql/structural_join_anchor_mutation_test.go
+++ b/internal/chsql/structural_join_anchor_mutation_test.go
@@ -85,3 +85,62 @@ func TestEmitStructuralRecursive_UnrestrictedAnchorHasNoSeedWhere(t *testing.T) 
 		t.Fatalf("plan set no pruning bound, yet the anchor seed carries a WHERE:\n%s", sql)
 	}
 }
+
+// structuralUnionClosurePlan returns a union recursive (`&>>`) StructuralJoin
+// — the shape whose L-projection arm renders through
+// buildStructuralInverseClosure's inverse closure, alongside the canonical
+// one the R-projection arm uses.
+func structuralUnionClosurePlan() *chplan.StructuralJoin {
+	plan := structuralClosurePlan()
+	plan.Op = chplan.StructuralUnionDescendant
+	return plan
+}
+
+// TestEmitStructuralRecursive_InverseAnchorCarriesTraceIDRestriction pins the
+// #2104 fix: the INVERSE closure's anchor seed (buildStructuralInverseClosure,
+// `_struct_closure_inv_*`) must fold the two-phase phase-B trace-id
+// restriction, exactly as the canonical closure's anchor does
+// (TestEmitStructuralRecursive_AnchorCarriesTraceIDRestriction). Before the
+// fix the inverse anchor carried only the request-window bound, so its seed
+// scan read every windowed trace on the R side instead of granule-pruning to
+// the top-N literals via idx_trace_id — a correct-but-amplified read, not a
+// wrong result (the closure only ever projects `_depth > 0` rows, which the
+// step arm's own restriction already confines to the top-N set).
+func TestEmitStructuralRecursive_InverseAnchorCarriesTraceIDRestriction(t *testing.T) {
+	t.Parallel()
+
+	plan := structuralUnionClosurePlan()
+	plan.TraceIDRestriction = []string{"aabb", "ccdd"}
+
+	sql, _, err := chsql.Emit(context.Background(), plan)
+	if err != nil {
+		t.Fatalf("Emit: %v", err)
+	}
+	if !strings.Contains(sql, "_struct_closure_inv_") {
+		t.Fatalf("union recursive op did not render an inverse closure CTE:\n%s", sql)
+	}
+	if !strings.Contains(sql, "AS _seed WHERE `TraceId` IN ('aabb', 'ccdd')") {
+		t.Fatalf("trace-id restriction missing from the inverse closure's anchor seed:\n%s", sql)
+	}
+}
+
+// TestEmitStructuralRecursive_InverseAnchorUnrestrictedHasNoSeedWhere mirrors
+// TestEmitStructuralRecursive_UnrestrictedAnchorHasNoSeedWhere for the inverse
+// closure: a plan that sets no phase-B restriction (the single-query path,
+// not phase B of the two-phase search) must render the inverse anchor with no
+// seed WHERE, so the assertion above cannot be satisfied by an emitter that
+// always splices one in.
+func TestEmitStructuralRecursive_InverseAnchorUnrestrictedHasNoSeedWhere(t *testing.T) {
+	t.Parallel()
+
+	sql, _, err := chsql.Emit(context.Background(), structuralUnionClosurePlan())
+	if err != nil {
+		t.Fatalf("Emit: %v", err)
+	}
+	if !strings.Contains(sql, "_struct_closure_inv_") {
+		t.Fatalf("union recursive op did not render an inverse closure CTE:\n%s", sql)
+	}
+	if strings.Contains(sql, "AS _seed WHERE") {
+		t.Fatalf("plan set no pruning bound, yet the inverse anchor seed carries a WHERE:\n%s", sql)
+	}
+}


### PR DESCRIPTION
## Summary

Issue #2104: phase B of the two-phase structural fetch stamps `TraceIDRestriction` onto a `StructuralJoin` so every physical spans scan reads only the top-N traces phase A ranked. The canonical closure's anchor folds it (`structuralAnchorWhere`); the union recursive (`&>>`/`&<<`) **inverse** closure's anchor (`buildStructuralInverseClosure`) built its own window-only WHERE by hand and never folded it, so that anchor's seed scan read every windowed trace on the R side instead of granule-pruning to the top-N literals via `idx_trace_id` — exactly the read amplification phase B exists to avoid.

This is a **read-amplification bug, not a correctness one**: the inverse closure only ever projects `_depth > 0` rows, which come from the step arm alone, and the step arm already restricts them (`structuralStepWhere`) — `TestSearch_UnionTwoPhase_Parity_ChDB` legitimately passed before this fix and still passes after it.

## Fix

Extracts `structuralAnchorNodeBounds` (trace-id restriction + window) as the bound both anchors share:
- The canonical anchor keeps going through `structuralAnchorWhere`, which now composes the canonical-only candidate prefilter with `structuralAnchorNodeBounds` (same emitted SQL — byte-identical, just refactored).
- The inverse anchor (`buildStructuralInverseClosure`) now calls `structuralAnchorNodeBounds` directly instead of the window-only `structuralAnchorWindowFrags`, so it picks up the trace-id restriction fold for the first time.

## Verification

- New tests in `internal/chsql/structural_join_anchor_mutation_test.go`, mirroring the existing canonical-anchor mutation-kill tests:
  - `TestEmitStructuralRecursive_InverseAnchorCarriesTraceIDRestriction` — a union recursive (`&>>`) plan with `TraceIDRestriction` set renders the restriction into the inverse closure's `_seed WHERE`.
  - `TestEmitStructuralRecursive_InverseAnchorUnrestrictedHasNoSeedWhere` — the complement: no restriction set means no seed WHERE, so the assertion above can't be satisfied by an emitter that always splices one in.
- `go test -race ./internal/chsql/...` — all pass.
- `go test -tags chdb ./internal/chsql/... ./internal/api/tempo/...` — all pass, including `TestSearch_UnionTwoPhase_Parity_ChDB` (the phase-B correctness parity test) unchanged.
- `go test -tags chdb ./test/spec/traceql/... -run TestRoundTripChDB` — all 100+ TraceQL spec fixtures pass unchanged; none of them set `TraceIDRestriction` (it's an API-layer phase-B stamp, not something the spec-level lowering exercises), so this is a zero-diff refactor for every existing golden — no `just update-golden` regeneration needed.
- `node .github/scripts/forbid-sql-raw.mjs` — clean.
- `gofumpt -extra` / `goimports -local` — clean.

Closes #2104