### PR TITLE
fix(api/loki): close the WebSocket instead of refusing /tail's handshake at the cap

### DIFF
--- a/docs/operations.md
+++ b/docs/operations.md
@@ -664,12 +664,14 @@ requests" says nothing about how many unbounded-duration streams the
 replica should carry. Set `CERBERUS_ADMIT_TAIL=0` to opt out of the tail
 cap as well, or `CERBERUS_ADMIT_DISABLED=true` to opt out of both.
 
-A tail refused by the tail cap is refused at the HTTP upgrade — `503` +
-`Retry-After: 1`, before the connection becomes a WebSocket — rather than
-upgraded and then closed with a close frame the way reference Loki
-answers its own `querier.max-concurrent-tail-requests`. Issue
-[#2048](https://github.com/tsouza/cerberus/issues/2048) tracks aligning
-the two, since a WebSocket client does not read the `Retry-After` header.
+A tail refused by the tail cap upgrades to a WebSocket first and is then
+closed with a `1013` (`Try Again Later`) close frame, the same shape
+reference Loki answers its own `querier.max-concurrent-tail-requests`
+with — every other admitted route refuses at the HTTP upgrade instead
+(`503` + `Retry-After: 1`), but a WebSocket client has no way to read an
+HTTP header once the handshake has already gone through, so `/tail`'s
+rejection has to live at the WebSocket layer to be actionable
+(issue [#2048](https://github.com/tsouza/cerberus/issues/2048)).
 
 `CERBERUS_ADMIT_DISABLED=true` removes admission control entirely, on
 every budget at once — useful for local development where artificial caps

--- a/internal/api/loki/conformance_test.go
+++ b/internal/api/loki/conformance_test.go
@@ -1170,6 +1170,47 @@ func tailDialStatus(t *testing.T, srv *httptest.Server, query string) int {
 	return resp.StatusCode
 }
 
+// tailDialCapClose dials /tail expecting the handshake to SUCCEED (the
+// tail-cap rejection happens after Upgrade, per issue #2048) and returns
+// the close code and reason text the server sends. Fails the test outright
+// if the handshake itself is refused, or if the connection is torn down
+// some way other than a close frame (a bare read error, or no close at all
+// before the deadline) — either would mean the rejection regressed back
+// to a refused handshake, or stopped signalling the client at all.
+func tailDialCapClose(t *testing.T, srv *httptest.Server, query string) (code int, reason string) {
+	t.Helper()
+	u, err := url.Parse(srv.URL)
+	if err != nil {
+		t.Fatalf("parse server URL: %v", err)
+	}
+	u.Scheme = "ws"
+	u.Path = "/loki/api/v1/tail"
+	u.RawQuery = "query=" + url.QueryEscape(query)
+
+	conn, resp, err := websocket.DefaultDialer.Dial(u.String(), nil)
+	if err != nil {
+		status := -1
+		if resp != nil {
+			status = resp.StatusCode
+		}
+		t.Fatalf("dial %s: handshake refused (status=%d, err=%v) — the tail-cap rejection must "+
+			"upgrade first and close after, not refuse the handshake", u.String(), status, err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusSwitchingProtocols {
+		t.Fatalf("dial %s: handshake status %d, want 101", u.String(), resp.StatusCode)
+	}
+	defer conn.Close()
+
+	_ = conn.SetReadDeadline(time.Now().Add(5 * time.Second))
+	_, _, err = conn.ReadMessage()
+	var closeErr *websocket.CloseError
+	if !errors.As(err, &closeErr) {
+		t.Fatalf("ReadMessage after tail-cap rejection = %v, want a *websocket.CloseError", err)
+	}
+	return closeErr.Code, closeErr.Text
+}
+
 // TestConformance_LokiFullTailBudgetLeavesQueriesAdmitted is the
 // regression pin for issue #1482 — the reason /tail has a budget of its
 // own at all.
@@ -1208,9 +1249,12 @@ func TestConformance_LokiFullTailBudgetLeavesQueriesAdmitted(t *testing.T) {
 	_ = dialTail(t, srv, `{job="api"}`)
 
 	// Corroborate that the tail budget really is full — otherwise the
-	// assertions below would pass trivially on an unoccupied budget.
-	if got := tailDialStatus(t, srv, `{job="api"}`); got != http.StatusServiceUnavailable {
-		t.Fatalf("second /tail dial: status %d, want 503 — the live session did not occupy the tail budget, so this test proves nothing", got)
+	// assertions below would pass trivially on an unoccupied budget. The
+	// rejection upgrades first (issue #2048) and closes with
+	// tailCapCloseCode rather than refusing the handshake.
+	if code, _ := tailDialCapClose(t, srv, `{job="api"}`); code != websocket.CloseTryAgainLater {
+		t.Fatalf("second /tail dial: close code %d, want %d (CloseTryAgainLater) — the live "+
+			"session did not occupy the tail budget, so this test proves nothing", code, websocket.CloseTryAgainLater)
 	}
 
 	// Every short-lived route, twice over the request cap, all serial so
@@ -1257,10 +1301,13 @@ func TestConformance_LokiFullTailBudgetLeavesQueriesAdmitted(t *testing.T) {
 // exempt it. A separate budget that never rejects would be an unbounded
 // resource wearing a cap's name.
 //
-// The rejection rides the same admit.Middleware contract as every other
-// route — HTTP 503 + Retry-After, written BEFORE the WebSocket upgrade,
-// so the client sees an ordinary refused handshake rather than an
-// upgraded-then-severed connection.
+// The rejection does NOT ride admit.Middleware the way every other route's
+// does: /tail upgrades to a WebSocket FIRST and the handler acquires
+// TailLimiter itself, so a full budget reaches the client as a close frame
+// on an already-101'd connection, not a refused handshake (issue #2048 —
+// a refused handshake gives a WebSocket client no distinguishable "retry"
+// signal, the same shape it gets from a missing endpoint or a broken
+// proxy).
 func TestConformance_LokiTailRejectedAtTailCap(t *testing.T) {
 	t.Parallel()
 
@@ -1273,8 +1320,12 @@ func TestConformance_LokiTailRejectedAtTailCap(t *testing.T) {
 
 	srv := newSplitBudgetServer(t, admit.New("loki", 4), tailLimiter)
 
-	if got := tailDialStatus(t, srv, `{job="api"}`); got != http.StatusServiceUnavailable {
-		t.Fatalf("/tail at cap: status %d, want 503", got)
+	code, reason := tailDialCapClose(t, srv, `{job="api"}`)
+	if code != websocket.CloseTryAgainLater {
+		t.Fatalf("/tail at cap: close code %d, want %d (CloseTryAgainLater)", code, websocket.CloseTryAgainLater)
+	}
+	if reason != loki.TailCapCloseReason {
+		t.Errorf("/tail at cap: close reason %q, want %q", reason, loki.TailCapCloseReason)
 	}
 }
 

--- a/internal/api/loki/export_test.go
+++ b/internal/api/loki/export_test.go
@@ -20,3 +20,9 @@ package loki
 func (h *Handler) SetOnQueryRangeDrain(fn func(int64)) {
 	h.onQueryRangeDrain = fn
 }
+
+// TailCapCloseReason exposes the /tail tail-budget-saturated close-frame
+// reason text (issue #2048) to package loki_test, so a conformance test
+// can assert the exact wording without hand-duplicating it — a drifted
+// copy would pass even after the production string changed.
+const TailCapCloseReason = tailCapCloseReason

--- a/internal/api/loki/handler.go
+++ b/internal/api/loki/handler.go
@@ -91,6 +91,10 @@ type Handler struct {
 	// every subsequent Loki request on the replica 503s until a tail
 	// client disconnects — issue #1482. Two budgets means a full tail
 	// budget costs ordinary queries nothing.
+	//
+	// Unlike every other route, /tail does NOT front this limiter with
+	// admit.Middleware — see handleTail's doc comment (issue #2048) for
+	// why the acquire has to happen after the WebSocket upgrade instead.
 	TailLimiter *admit.Limiter
 
 	// Version is the cerberus build identifier surfaced via
@@ -170,7 +174,7 @@ func (h *Handler) Mount(mux *http.ServeMux) {
 	}
 	// register mounts an ordinary, short-lived Loki route on the shared
 	// request budget (CERBERUS_ADMIT_LOKI). /tail is the one route that
-	// does NOT go through here — it takes TailLimiter instead.
+	// does NOT go through here — see the mount comment on it below.
 	register := func(pattern string, hf http.HandlerFunc) {
 		registerWith(h.Limiter, pattern, hf)
 	}
@@ -197,11 +201,23 @@ func (h *Handler) Mount(mux *http.ServeMux) {
 	register("GET /loki/api/v1/patterns", h.handlePatterns)
 	register("POST /loki/api/v1/patterns", h.handlePatterns)
 	// /tail is WebSocket-upgrade only; no POST counterpart in upstream Loki.
-	// It is the ONE route mounted on TailLimiter rather than Limiter: its
-	// slot is held for the session's whole lifetime, so it must not be
+	// Its slot is held for the session's whole lifetime, so it must not be
 	// drawn from the budget the millisecond-scale routes above share (see
-	// the TailLimiter field doc and issue #1482).
-	registerWith(h.TailLimiter, "GET /loki/api/v1/tail", h.handleTail)
+	// the TailLimiter field doc and issue #1482) — that much matches every
+	// other route's registerWith call.
+	//
+	// What does NOT match is going through registerWith's admit.Middleware:
+	// that middleware acquires (or refuses) the slot BEFORE next runs, i.e.
+	// before the WebSocket handshake, so a refusal reaches the client as a
+	// 503 that never became a WebSocket at all. Reference Loki upgrades
+	// FIRST and enforces its tail limit inside the handler, so a rejection
+	// reaches an already-101'd client as a close frame — a shape a
+	// WebSocket client can actually act on, where an HTTP 503 on the
+	// handshake is invisible to WebSocket-level close handling (issue
+	// #2048). handleTail therefore acquires TailLimiter itself, after
+	// Upgrade succeeds; mounting it bypasses registerWith so the standard
+	// admission wrapper cannot double-gate the same budget beforehand.
+	mux.Handle("GET /loki/api/v1/tail", telemetry.QueryMiddleware("logql", panicEnvelope, http.HandlerFunc(h.handleTail)))
 	// Format-query + build-info probes. Grafana's Loki datasource hits
 	// /status/buildinfo on every page load to gate feature flags
 	// (LogQL editor capabilities, label-browser presence) and uses

--- a/internal/api/loki/tail.go
+++ b/internal/api/loki/tail.go
@@ -101,6 +101,19 @@ type droppedEntryStream struct {
 // 4xx errors are returned BEFORE the WebSocket upgrade so misuse looks
 // like an ordinary HTTP bad-request rather than a confusing websocket-
 // handshake-then-close failure.
+//
+// The tail-CAP rejection is the deliberate exception: it is checked AFTER
+// the upgrade, by acquiring h.TailLimiter's slot once the handshake has
+// already succeeded, and a refusal is delivered as a close frame
+// (tailCapCloseCode) rather than an HTTP status. Reference Loki's own
+// tail limit works the same way (its querier acquires the slot inside
+// the already-upgraded handler and the rejection reaches the client as a
+// close frame — see pkg/querier/tail/http.go upstream). Gating the cap
+// before Upgrade, as every other route's admit.Middleware does, would
+// refuse the handshake outright — indistinguishable, at the WebSocket
+// layer, from hitting a missing endpoint or a broken proxy, and a
+// WebSocket client has no HTTP-status-level "retry" signal to act on
+// (issue #2048).
 func (h *Handler) handleTail(w http.ResponseWriter, r *http.Request) {
 	q := r.URL.Query().Get("query")
 	if q == "" {
@@ -160,6 +173,17 @@ func (h *Handler) handleTail(w http.ResponseWriter, r *http.Request) {
 			h.Logger.Warn("cerberus loki tail: websocket close failed", "err", err)
 		}
 	}()
+
+	// The tail budget is acquired HERE, after the upgrade — see the
+	// handleTail doc comment for why. A nil TailLimiter (the "tailing is
+	// unadmitted" configuration) always grants, matching Acquire's own
+	// nil-receiver contract.
+	release, ok := h.TailLimiter.Acquire(r.Context())
+	if !ok {
+		writeTailCapClose(conn, h.tailWriteTimeout())
+		return
+	}
+	defer release()
 
 	tx, err := postProcessExtract(expr)
 	if err != nil {
@@ -302,6 +326,37 @@ func writeTailChunk(conn *websocket.Conn, streams []Stream, writeTimeout time.Du
 		Streams:        streams,
 		DroppedEntries: []droppedEntryStream{},
 	})
+}
+
+// tailCapCloseCode is the WebSocket close code sent when the tail budget
+// is saturated. 1013 ("Try Again Later", RFC 6455 §7.4.1) is the code the
+// spec reserves for exactly this — a server temporarily unable to service
+// the request that would likely accept it later — as opposed to 1008
+// ("Policy Violation") or 1011 ("Internal Error"), neither of which
+// invites a retry.
+const tailCapCloseCode = websocket.CloseTryAgainLater
+
+// tailCapCloseReason is the close-frame reason text. Kept well under the
+// 123-byte RFC 6455 control-frame payload limit and phrased like
+// admit.Middleware's own "admission control: server saturated" 503 body,
+// so an operator grepping logs on either side of the upgrade sees the
+// same vocabulary for the same condition.
+const tailCapCloseReason = "admission control: tail budget saturated"
+
+// writeTailCapClose sends the close frame for a tail request that lost
+// the race for a TailLimiter slot. The connection is already an upgraded
+// WebSocket at this point (handleTail calls this only after Upgrade
+// succeeds), so this is the ONLY way to signal the rejection — an HTTP
+// status is no longer available once the handshake completed. The error
+// is intentionally discarded: the caller's deferred conn.Close() tears
+// the connection down regardless, and a write failing because the peer
+// already vanished is not a fault worth logging.
+func writeTailCapClose(conn *websocket.Conn, writeTimeout time.Duration) {
+	_ = conn.WriteControl(
+		websocket.CloseMessage,
+		websocket.FormatCloseMessage(tailCapCloseCode, tailCapCloseReason),
+		time.Now().Add(writeTimeout),
+	)
 }
 
 // buildTailSQL constructs the per-tick polling SELECT. The shape is:


### PR DESCRIPTION
## Summary

- `/tail` was the one Loki route mounted behind `admit.Middleware`, which acquires (or refuses) the admission slot BEFORE the handler runs — so a saturated tail budget refused the HTTP upgrade itself (503 + `Retry-After: 1`). A WebSocket client never reads that header once the handshake fails, so the rejection was indistinguishable from a missing endpoint or a broken proxy.
- Reference Loki upgrades first and enforces its own `querier.max-concurrent-tail-requests` cap inside the already-connected handler, delivering a close frame instead. This PR mirrors that:
  - `/tail` now mounts without `admit.Middleware` (`internal/api/loki/handler.go`).
  - `handleTail` acquires `h.TailLimiter` itself right after `Upgrade` succeeds, and on rejection writes a `1013` (`Try Again Later`) close frame with a short reason (`internal/api/loki/tail.go`).
  - The rejection still ticks `cerberus_admit_rejected_total{budget="tail"}` — that accounting lives inside `Limiter.Acquire` itself, which both paths call.

## Test plan

- [x] `go test -race ./internal/api/loki/...` — full package suite green, including the two conformance tests (`TestConformance_LokiTailRejectedAtTailCap`, `TestConformance_LokiFullTailBudgetLeavesQueriesAdmitted`) updated to dial through to `101` and assert the close code/reason instead of expecting a refused handshake.
- [x] Added a close-reason assertion via a new exported test-only alias (`export_test.go`) so the reason text can't silently drift from what the test pins.
- [x] `go build ./...`, `go vet ./...`
- [x] `node .github/scripts/forbid-skip.mjs` (`CHECK=all`), `node .github/scripts/forbid-sql-raw.mjs`
- [x] `gofumpt -l` / `goimports -l` clean on touched Go files; `markdownlint-cli2 docs/operations.md` clean
- [x] Updated `docs/operations.md`'s tail-admission section, which previously described the refused-handshake behavior as deliberate and contrasted it with reference Loki's close-frame approach as something cerberus explicitly did NOT do.

Closes #2048

