### PR TITLE
fix(cmd/cerberus): wire MaxQuerySamples into the Loki head's engine

### DIFF
--- a/cmd/cerberus/loki_max_query_samples_test.go
+++ b/cmd/cerberus/loki_max_query_samples_test.go
@@ -1,0 +1,103 @@
+package main
+
+import (
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/tsouza/cerberus/internal/chclient"
+	"github.com/tsouza/cerberus/internal/chopt"
+	"github.com/tsouza/cerberus/internal/config"
+	"github.com/tsouza/cerberus/internal/schema"
+)
+
+// lokiMaxQuerySamplesWant is deliberately unlike every default in play (0
+// in a bare chclient.Config, and 0 was exactly what the Loki head's
+// engine carried before this fix), so a wiring that reaches the handler
+// can only have come from the client this test built.
+const lokiMaxQuerySamplesWant = 12345
+
+// newLokiClientWithSamples builds a client that never dials (chclient.New
+// only validates options) carrying the given MaxQuerySamples.
+func newLokiClientWithSamples(t *testing.T, maxSamples int64) *chclient.Client {
+	t.Helper()
+	client, err := chclient.New(chclient.Config{
+		Addr:            unreachableAddr(t),
+		Database:        "otel",
+		DialTimeout:     time.Second,
+		MaxOpenConns:    10,
+		MaxIdleConns:    5,
+		MaxQuerySamples: maxSamples,
+	})
+	if err != nil {
+		t.Fatalf("chclient.New: %v", err)
+	}
+	t.Cleanup(func() { _ = client.Close() })
+	return client
+}
+
+// TestNewLokiHandler_WiresMaxQuerySamples pins the fix for issue #2055:
+// newLokiHandler must carry the client's configured MaxQuerySamples onto
+// Handler.Engine, the same way newPromHandler already does (main.go,
+// "MaxQuerySamples: client.MaxQuerySamples()"). Left at the zero-value
+// engine.Engine literal's default, requireSubquerySampleBudget
+// (internal/engine/anchor_budget.go) fail-opens — `maxSamples <= 0`
+// returns nil before it ever looks at the plan — so the plan-time
+// anchor-grid gate silently never fires on the Loki head.
+func TestNewLokiHandler_WiresMaxQuerySamples(t *testing.T) {
+	client := newLokiClientWithSamples(t, lokiMaxQuerySamplesWant)
+	cfg := config.Config{Logs: schema.DefaultOTelLogs()}
+	limiters := newAdmitLimiters(cfg, quietLogger())
+
+	h := newLokiHandler(client, cfg, chopt.EnabledSet{}, limiters, quietLogger())
+
+	if h.Engine == nil {
+		t.Fatal("Handler.Engine is nil")
+	}
+	if h.Engine.MaxQuerySamples != lokiMaxQuerySamplesWant {
+		t.Fatalf("Handler.Engine.MaxQuerySamples = %d, want %d — the Loki head's plan-time "+
+			"anchor-grid budget gate fail-opens on every subquery until this is wired",
+			h.Engine.MaxQuerySamples, lokiMaxQuerySamplesWant)
+	}
+}
+
+// TestMountAPIHeads_EveryBuiltEngineCarriesMaxQuerySamples is the
+// suggested-check half of issue #2055's fix: a regression test asserting
+// every built head's engine carries a positive MaxQuerySamples closes the
+// CLASS of "this head's engine silently fail-opens the sample-budget
+// gate" rather than pinning only the Loki leg. Runs all three heads
+// through the real mountAPIHeads wiring, off one client whose
+// MaxQuerySamples is positive, and requires every engine it hands to the
+// optimization-corpus consumer set to have inherited that value.
+func TestMountAPIHeads_EveryBuiltEngineCarriesMaxQuerySamples(t *testing.T) {
+	client := newLokiClientWithSamples(t, lokiMaxQuerySamplesWant)
+	cfg := config.Config{
+		Logs:   schema.DefaultOTelLogs(),
+		Schema: schema.DefaultOTelMetrics(),
+		Traces: schema.DefaultOTelTraces(),
+		EnabledHeads: config.EnabledHeads{
+			config.HeadProm:  {},
+			config.HeadLoki:  {},
+			config.HeadTempo: {},
+		},
+	}
+	logger := quietLogger()
+	limiters := newAdmitLimiters(cfg, logger)
+
+	heads, err := mountAPIHeads(t.Context(), http.NewServeMux(), client, cfg, chopt.EnabledSet{}, limiters, logger)
+	if err != nil {
+		t.Fatalf("mountAPIHeads: %v", err)
+	}
+
+	engines := heads.consumers.engines
+	if len(engines) != 3 {
+		t.Fatalf("mountAPIHeads built %d engine(s) with all three heads enabled, want 3", len(engines))
+	}
+	for i, eng := range engines {
+		if eng.MaxQuerySamples != lokiMaxQuerySamplesWant {
+			t.Errorf("engine %d: MaxQuerySamples = %d, want %d — this head's plan-time "+
+				"anchor-grid budget gate fail-opens on every subquery until this is wired",
+				i, eng.MaxQuerySamples, lokiMaxQuerySamplesWant)
+		}
+	}
+}

--- a/cmd/cerberus/main.go
+++ b/cmd/cerberus/main.go
@@ -850,6 +850,11 @@ func newLokiHandler(client *chclient.Client, cfg config.Config, optSet chopt.Ena
 	h.QueryTimeout = cfg.ClickHouse.QueryTimeout
 	h.TailWriteTimeout = cfg.LokiTailWriteTimeout
 	h.Engine.Settings = settingsRules(cfg, optSet)
+	// The prom head wires this (line ~713 above); the Loki head never did,
+	// so requireSubquerySampleBudget's plan-time anchor-grid gate
+	// (internal/engine/anchor_budget.go) fail-opened on every LogQL
+	// subquery — issue #2055.
+	h.Engine.MaxQuerySamples = client.MaxQuerySamples()
 	return h
 }
 


### PR DESCRIPTION
## Summary

- `newLokiHandler` (`cmd/cerberus/main.go`) never assigned `Engine.MaxQuerySamples`, unlike `newPromHandler` and the Tempo wiring in `mountAPIHeads`. `requireSubquerySampleBudget` (`internal/engine/anchor_budget.go`) fail-opens when `maxSamples <= 0`, so the plan-time anchor-grid sample-budget gate silently never fired on the Loki head. The cursor-level drain budget (`chclient.Config.MaxQuerySamples`) was unaffected — this is specifically the plan-time gate that exists because the drain-side budget sees ~1 row/series for an instant reducer and never trips.
- One-line fix: `h.Engine.MaxQuerySamples = client.MaxQuerySamples()` in `newLokiHandler`, mirroring the prom/tempo wiring.

## Validated the activation is safe under defaults

Per the issue's own caveat ("this ACTIVATES a dormant gate... needs its own validation"), I checked whether any currently-servable LogQL query would start being rejected:

- LogQL's grammar has no nested-subquery shape — `RangeAggregationExpr.Left` is always a raw `LogRangeExpr` over a log selector, never another `RangeAggregationExpr` — so `subqueryAnchorLoad`'s multiplicative nesting path can never trigger for any LogQL query.
- The only shape that can set `NumAnchors` for LogQL is the plain `query_range` outer step grid, which `internal/api/loki/handler.go` already caps at `format.MaxResolutionPoints` (11000) before lowering ever runs.
- `CERBERUS_QUERY_MAX_SAMPLES` defaults to 5,000,000 — twelve orders of magnitude above 11000.

So under the default configuration, no LogQL query can trip the newly-activated gate; it only bites an operator who has deliberately lowered the sample budget below 11000, which is exactly the protective rejection the gate exists to give.

## Test plan

- [x] Added `TestNewLokiHandler_WiresMaxQuerySamples` (focused, mirrors `prom_metadata_lookback_test.go`'s style).
- [x] Added `TestMountAPIHeads_EveryBuiltEngineCarriesMaxQuerySamples` — the suggested-check from the issue itself, run through the real `mountAPIHeads` wiring with all three heads enabled, closing the class rather than just the Loki leg.
- [x] Verified both tests actually catch the regression: temporarily neutralized the fix locally, confirmed both fail with the exact "MaxQuerySamples = 0, want 12345" message, then restored the fix and confirmed green.
- [x] `go test -race ./cmd/cerberus/...`, `go test ./internal/engine/... ./internal/logql/... ./internal/api/loki/...` — all green.
- [x] `go build ./...`, `go vet ./cmd/...`
- [x] `node .github/scripts/forbid-skip.mjs` (`CHECK=all`), `node .github/scripts/forbid-sql-raw.mjs`
- [x] `gofumpt -l` / `goimports -l` clean

Closes #2055
