### PR TITLE
fix(e2e): select Grafana metrics without Tooltip crash

### DIFF
--- a/test/e2e/playwright/crawl/crawl.spec.ts
+++ b/test/e2e/playwright/crawl/crawl.spec.ts
@@ -151,10 +151,12 @@ import {
   type SurfaceInventory,
 } from './lib.js';
 import {
+  comboboxSelectionGesture,
   declaredVocabulary,
   discoverControls,
   driveInteraction,
   interactionStateKey,
+  keyboardMenuOptionSequence,
   planInteractions,
   representativeOption,
   settleAdhocFilterBar,
@@ -247,6 +249,9 @@ function makePageLease(browser: Browser): PageLease {
  * render settle that follows is bounded separately.
  */
 const NAVIGATION_TIMEOUT_MS = 90_000;
+
+/** Focused metric-select regression budget, including two Grafana settles. */
+const METRIC_SELECT_REGRESSION_TIMEOUT_MS = 2 * 60_000;
 
 /**
  * Navigate with the SAME cold app state every time.
@@ -1044,6 +1049,24 @@ test.describe('crawl: canonicalization pins', () => {
     );
   });
 
+  test('metric-select commits its exact representative through the keyboard path', () => {
+    const key = 'select[metric select]';
+    const liveOrder = ['zulu_metric', 'alpha_metric', 'mike_metric'];
+    const representative = representativeOption(liveOrder);
+
+    expect(comboboxSelectionGesture(key)).toBe('keyboard');
+    expect(comboboxSelectionGesture('select[Select label]')).toBe('pointer');
+    expect(representative).toBe('alpha_metric');
+    expect(keyboardMenuOptionSequence(liveOrder, key, representative)).toEqual([
+      'Home',
+      'ArrowDown',
+      'Enter',
+    ]);
+    expect(() =>
+      keyboardMenuOptionSequence(liveOrder, key, 'missing_metric'),
+    ).toThrow(/option "missing_metric" is absent from the settled dropdown/);
+  });
+
   test('the inventory order is a function of the URLs, not of the host locale', () => {
     // Surface keys are mostly punctuation — `#`, `?`, `=`, `{`, `"`,
     // `-` — and a collating comparison ranks punctuation at a lower
@@ -1670,6 +1693,61 @@ test.describe('crawl: wire-capture body reads are bounded', () => {
       /target page closed/,
     );
   });
+});
+
+test('crawl: Prometheus metric-select representative commits without React #185', async ({
+  page,
+}, testInfo) => {
+  testInfo.setTimeout(METRIC_SELECT_REGRESSION_TIMEOUT_MS);
+  const stack = activeStack();
+  const baseURL =
+    process.env.GRAFANA_URL ??
+    process.env.GRAFANA_BASE_URL ??
+    stack.defaultGrafanaURL;
+  const capture = await captureConsoleErrors(page);
+
+  await page.goto(`${baseURL}/explore`, {
+    waitUntil: 'domcontentloaded',
+    timeout: NAVIGATION_TIMEOUT_MS,
+  });
+  await tolerateRepaintFlicker(page, { settleMs: 600, timeoutMs: 45_000 });
+
+  const control = (await discoverControls(page)).find(
+    (candidate) => candidate.key === 'select[metric select]',
+  );
+  expect(
+    control,
+    'Prometheus Explore exposes the metric-select combobox',
+  ).toBeDefined();
+  const planned = planInteractions([control!], 0);
+  expect(
+    planned,
+    'metric-select has one deterministic representative',
+  ).toHaveLength(1);
+
+  await driveInteraction(page, planned[0]!);
+  await tolerateRepaintFlicker(page, { settleMs: 600, timeoutMs: 45_000 });
+
+  const selected = (await discoverControls(page)).find(
+    (candidate) => candidate.key === control!.key,
+  );
+  expect(
+    selected,
+    'metric-select survives and remains discoverable after commit',
+  ).toBeDefined();
+  expect(selected!.options[selected!.selectedIndex]).toBe(planned[0]!.option);
+
+  capture.stop();
+  expect(
+    capture.messages,
+    'metric-select commit logs no browser errors',
+  ).toEqual([]);
+  const bodyText = await page.locator('body').innerText();
+  for (const pattern of PAGE_CRASH_PATTERNS) {
+    expect(bodyText, `page body has no crash signature ${pattern}`).not.toMatch(
+      pattern,
+    );
+  }
 });
 
 // ---------------------------------------------------------------------------

--- a/test/e2e/playwright/crawl/interactions.ts
+++ b/test/e2e/playwright/crawl/interactions.ts
@@ -1326,6 +1326,17 @@ async function clickMenuOption(
   option: string,
 ): Promise<void> {
   const labels = await readSettledMenuOptions(page);
+  const index = settledMenuOptionIndex(labels, controlKey, option);
+  await openMenuOptions(page)
+    .nth(index)
+    .click({ timeout: CONTROL_CLICK_TIMEOUT_MS });
+}
+
+function settledMenuOptionIndex(
+  labels: ReadonlyArray<string>,
+  controlKey: string,
+  option: string,
+): number {
   const index = labels.indexOf(option);
   if (index < 0) {
     throw new Error(
@@ -1334,9 +1345,33 @@ async function clickMenuOption(
         `between discovery and driving`,
     );
   }
-  await openMenuOptions(page)
-    .nth(index)
-    .click({ timeout: CONTROL_CLICK_TIMEOUT_MS });
+  return index;
+}
+
+/**
+ * Key sequence that activates one exact option from an open Grafana Combobox
+ * menu. Home fixes the starting highlight at index zero regardless of what
+ * pointer-open pre-highlighted; ArrowDown then advances through the freshly
+ * settled live order.
+ */
+export function keyboardMenuOptionSequence(
+  labels: ReadonlyArray<string>,
+  controlKey: string,
+  option: string,
+): string[] {
+  const index = settledMenuOptionIndex(labels, controlKey, option);
+  return ['Home', ...Array.from({ length: index }, () => 'ArrowDown'), 'Enter'];
+}
+
+async function pressMenuOption(
+  page: Page,
+  controlKey: string,
+  option: string,
+): Promise<void> {
+  const labels = await readSettledMenuOptions(page);
+  for (const key of keyboardMenuOptionSequence(labels, controlKey, option)) {
+    await page.keyboard.press(key);
+  }
 }
 
 /**
@@ -1495,6 +1530,20 @@ export async function discoverControls(
 // ---------------------------------------------------------------------------
 
 /**
+ * Grafana 12.2.9's Prometheus metric combobox has a Tooltip-wrapped sibling
+ * whose pointer-commit ref churn loops through floating-ui's unguarded
+ * setDomReference state setter (grafana/grafana#130469). Keyboard commit
+ * reaches the same Combobox onChange and query state without entering that
+ * Tooltip path. Keep every other combobox pointer-driven so the exception is
+ * no broader than the upstream defect.
+ */
+export function comboboxSelectionGesture(
+  controlKey: string,
+): 'keyboard' | 'pointer' {
+  return controlKey === 'select[metric select]' ? 'keyboard' : 'pointer';
+}
+
+/**
  * Re-find a combobox on the freshly navigated page by its discovery
  * KEY, not its discovery-time element hint: downshift inputs are
  * addressed by React useId-derived ids that need not survive a
@@ -1650,7 +1699,11 @@ export async function driveInteraction(
     case 'combobox': {
       const input = await relocateCombobox(page, settled, control);
       await input.click({ timeout: CONTROL_CLICK_TIMEOUT_MS });
-      await clickMenuOption(page, control.key, option);
+      if (comboboxSelectionGesture(control.key) === 'keyboard') {
+        await pressMenuOption(page, control.key, option);
+      } else {
+        await clickMenuOption(page, control.key, option);
+      }
       return;
     }
     case 'adhoc-filter': {


### PR DESCRIPTION
## Summary

- commit Grafana Explore's `select[metric select]` representative through the keyboard path that reaches the same Combobox `onChange`
- anchor keyboard navigation with `Home` and advance through the freshly settled option order so the exact deterministic representative is selected
- retain pointer activation for every other combobox and retain the existing console-error, crash-banner, and inventory oracles

## Root cause

Grafana 12.2.9's pointer commit reattaches the `Open metrics explorer` button's Tooltip ref. `Tooltip.tsx` calls floating-ui's unguarded `setDomReference` state setter during that ref attach, producing a render/ref-attach loop until React throws error #185. Keyboard commit applies the same metric selection without that pointer-only Tooltip ref churn.

Cerberus's `/api/v1/label/__name__/values` and `/api/v1/metadata` responses are valid Prometheus shapes. The issue's browser interception experiments reproduce the crash with empty metadata, short metadata, and one synthetic metric, ruling out Cerberus payload content, option count, and virtualization. This change therefore belongs in the crawl interaction source rather than the Prometheus API or an exclusion/expected-failure file. Upstream source tracking is grafana/grafana#130469.

## Verification

- `CRAWL_STACK=compose npx playwright test crawl/crawl.spec.ts --grep "metric-select commits its exact representative through the keyboard path"`
- isolated Compose project `cerberus-56c1e80f`, then `CRAWL_STACK=compose GRAFANA_URL=http://localhost:3000 CERBERUS_URL=http://localhost:8080 npx playwright test crawl/crawl.spec.ts --grep "Prometheus metric-select representative commits without React #185"`
- live regression verifies the planned metric is selected, the control survives rediscovery, no console error is logged, and no page crash signature renders
- no generated inventory or exclusion artifact changed

Closes #2007
