### PR TITLE
chore(perf): migrate label_replace_negative_sibling_probe to the per-table baseline shape

### DIFF
--- a/test/perf/solver-decision-baseline/label_replace_negative_sibling_probe/fanout.json
+++ b/test/perf/solver-decision-baseline/label_replace_negative_sibling_probe/fanout.json
@@ -1,5 +1,6 @@
 {
-  "query": "label_replace_negative_sibling_probe",
+  "query": "label_replace_negative_sibling_probe/fanout",
+  "lowering": "fanout",
   "routed": true,
   "k": 8,
   "reason": "routed",

--- a/test/perf/solver-decision-baseline/label_replace_negative_sibling_probe/native.json
+++ b/test/perf/solver-decision-baseline/label_replace_negative_sibling_probe/native.json
@@ -1,0 +1,11 @@
+{
+  "query": "label_replace_negative_sibling_probe/native",
+  "lowering": "native",
+  "routed": false,
+  "k": 0,
+  "reason": "not-sliceable",
+  "n_anchors": 241,
+  "fanout": 1,
+  "cumulative_d": "5m0s",
+  "outer_range": "1h0m0s"
+}


### PR DESCRIPTION
## Summary

`test/perf/solver-decision-baseline/label_replace_negative_sibling_probe.json` landed on main as a flat single-record file (added alongside #1956's negative-sibling-probe support), predating #2160's migration of the solver-decision-baseline corpus to a `fanout.json`/`native.json` pair per query.

The stray flat file makes the corpus internally inconsistent (2 distinct field sets across shards), which `TestGeneratedBaselineStructuralGuardWired` only surfaces under GitHub's ephemeral PR-merge checkout — every open PR that merges main into its own branch inherits the inconsistency at CI time, even though each branch's own literal tip is individually self-consistent. Confirmed on two independent PRs (#2159, #2165) hitting the identical failure after merging main.

Fixing it here, on main, stops every other branch from having to carry the same one-off fix.

## Verification

- `just update-golden solver` — clean regeneration, only this one record changed shape.
- `go test -tags chdb -run '^TestGeneratedBaselineStructuralGuardWired$|^TestSolverDecisionRatchet$' ./test/regression/... ./test/perf/...` — both green.