### PR TITLE
fix(e2e): seed metrics crawl at its canonical route

### DIFF
--- a/test/e2e/playwright/crawl/stacks.ts
+++ b/test/e2e/playwright/crawl/stacks.ts
@@ -180,9 +180,8 @@ const DRILLDOWN_APP_SEEDS: ReadonlyArray<string> = DRILLDOWN_APPS.map(
 
 /**
  * Lean interaction roots shared by both stacks: the three drilldown
- * app entry surfaces (canonical keys — the metrics app's /trail seed
- * redirects to /drilldown but stays KEYED by the harvested /trail
- * path). The drilldown apps are where the interaction gap class
+ * app entry surfaces (canonical keys). The drilldown apps are where
+ * the interaction gap class
  * lives — the 2026-06-10 maintainer find (Traces Drilldown
  * groupBy=kind → nil-comparison 422) was a state only an interaction
  * reaches.
@@ -190,7 +189,7 @@ const DRILLDOWN_APP_SEEDS: ReadonlyArray<string> = DRILLDOWN_APPS.map(
 const DRILLDOWN_LEAN_INTERACTION_ROOTS: ReadonlyArray<string> = [
   '/a/grafana-exploretraces-app/explore',
   '/a/grafana-lokiexplore-app/explore',
-  '/a/grafana-metricsdrilldown-app/trail',
+  '/a/grafana-metricsdrilldown-app/drilldown',
 ];
 
 // ---------------------------------------------------------------------------

--- a/test/e2e/playwright/helpers.spec.ts
+++ b/test/e2e/playwright/helpers.spec.ts
@@ -487,6 +487,7 @@ test('iterateDrilldownApps returns the apps the pinned Grafana ships', () => {
     'grafana-lokiexplore-app',
     'grafana-exploretraces-app',
   ]);
+  expect(apps[0]?.root).toBe('/a/grafana-metricsdrilldown-app/drilldown');
   // Returned array must be a fresh copy — mutating it must not
   // contaminate the module-level constant.
   apps.pop();

--- a/test/e2e/playwright/helpers/drilldown.ts
+++ b/test/e2e/playwright/helpers/drilldown.ts
@@ -70,7 +70,7 @@ export type DrilldownApp = {
 export const DRILLDOWN_APPS: ReadonlyArray<DrilldownApp> = [
   {
     id: 'grafana-metricsdrilldown-app',
-    root: '/a/grafana-metricsdrilldown-app/trail',
+    root: '/a/grafana-metricsdrilldown-app/drilldown',
     label: 'Explore Metrics',
   },
   {


### PR DESCRIPTION
## Summary

Use Metrics Drilldown’s canonical `/drilldown` route as the lean crawl seed and interaction root instead of the legacy `/trail` redirect. This keeps the interaction-discovered `/drilldown?metric={metric}` state on the same crawl shard that drives the metric selector.

The late compose crawl merge on #2165 showed `/trail` owned by shard 1 while `/drilldown` was owned by shard 2. Shard 1 discovered the route but could not audit it, and shard 2 never drove the cross-owner interaction. The native-histogram changes in #2165 were unrelated; the keyboard metric-selection fix included from main exposed the stale seed by making the interaction commit reliably.

## Validation

- `npx playwright test helpers.spec.ts --grep "iterateDrilldownApps returns the apps"`
- `node --test .github/scripts/merge-crawl-slices.test.mjs`

## CI Proof

The non-required `compose-crawl-merge` job must pass and visit both pinned Metrics Drilldown lean surfaces before merge.

Closes #2170