### PR TITLE
fix(promql): honour a subquery's @ pin in absent()[range:step] lowering

### DIFF
--- a/internal/promql/subquery.go
+++ b/internal/promql/subquery.go
@@ -1496,6 +1496,11 @@ const subqueryStalenessLookback = instantLookback
 // lowering's documented global-emptiness posture, fanned across the
 // grid via lowerAbsent's StepGrid range mode.
 //
+// An `@`-pinned subquery (`absent(v)[5m:1m] @ <ts>`) evaluates its own
+// [pin-Range, pin] window once, overriding range mode wherever the two
+// disagree — the same precedence subqueryGridCtx applies to every other
+// subquery inner shape (#2071).
+//
 // A zero eval anchor (plain Lower() without LowerAt* threading) cannot
 // materialise the grid's literal timestamps; the wire handlers always
 // thread eval times, so the guard is unreachable via HTTP.
@@ -1509,17 +1514,31 @@ func lowerSubqueryOverAbsent(
 	if ctx.end.IsZero() {
 		return nil, fmt.Errorf("promql: subquery over absent() requires query eval-time context (use LowerAt)")
 	}
-	// Range mode fans one absence indicator per outer anchor, so the grid
-	// reaches back a full subquery range before the QUERY start — the
-	// leading anchors otherwise have no inner anchors to reduce. Instant
-	// eval has no query start and reaches back from the eval timestamp.
-	// (ctx.end is non-zero here by the guard above, so this is exactly
-	// ctx.rangeMode().)
-	gridStart := ctx.end.Add(-sub.Range)
-	if ctx.rangeMode() {
-		gridStart = ctx.start.Add(-sub.Range)
+	anchor, err := subqueryAnchor(sub, ctx)
+	if err != nil {
+		return nil, err
 	}
-	gridEnd := ctx.end
+	// An `@`-pinned subquery (`@ <ts>` / `@ start()` / `@ end()`) evaluates
+	// its OWN window once, at the pin, overriding range mode wherever the
+	// two disagree — mirrors subqueryGridCtx's precedence for every other
+	// subquery inner shape. Absent no `@` pin: range mode fans one absence
+	// indicator per outer anchor, so the grid reaches back a full subquery
+	// range before the QUERY start — the leading anchors otherwise have no
+	// inner anchors to reduce. Instant eval has no query start and reaches
+	// back from the eval timestamp. (ctx.end is non-zero here by the guard
+	// above, so the unpinned range check is exactly ctx.rangeMode().)
+	var gridStart, gridEnd time.Time
+	switch {
+	case subqueryPinned(sub) && !anchor.End.IsZero():
+		gridEnd = anchor.End
+		gridStart = anchor.End.Add(-sub.Range)
+	case ctx.rangeMode():
+		gridEnd = ctx.end
+		gridStart = ctx.start.Add(-sub.Range)
+	default:
+		gridEnd = ctx.end
+		gridStart = ctx.end.Add(-sub.Range)
+	}
 
 	// The SUBQUERY's own `offset` shifts WHICH instants it evaluates, so
 	// the whole anchor grid moves back with it — and the emitted anchor
@@ -1537,10 +1556,6 @@ func lowerSubqueryOverAbsent(
 	// selects inner anchors BY their timestamps and already applies the
 	// same offset to its own window — using both applies the shift twice
 	// and the two anchor ranges come out disjoint (empty result).
-	anchor, err := subqueryAnchor(sub, ctx)
-	if err != nil {
-		return nil, err
-	}
 	gridStart = gridStart.Add(-anchor.Offset)
 	gridEnd = gridEnd.Add(-anchor.Offset)
 

--- a/internal/promql/subquery_grid_test.go
+++ b/internal/promql/subquery_grid_test.go
@@ -316,27 +316,50 @@ func TestWidenSubquerySpineSkipsInstantWindows(t *testing.T) {
 // In range mode the grid has to reach back a full subquery range before
 // the QUERY start, or the leading outer anchors have no inner anchors to
 // reduce and the series silently begins late; instant eval has no query
-// start and reaches back from the eval timestamp instead.
+// start and reaches back from the eval timestamp instead. An `@` pin
+// overrides both: the subquery evaluates its own [pin-Range, pin] window
+// regardless of the surrounding query's mode (#2071 — lowerSubqueryOverAbsent
+// used to ignore the pin entirely and always fall back to the query's own
+// window).
 func TestSubqueryOverAbsentGridCoversEveryOuterAnchor(t *testing.T) {
 	t.Parallel()
 
 	const query = `absent(up)[5m:1m]`
 	const subRange = 5 * time.Minute
 
+	// Deliberately far from both query bounds, so a grid that ignored the
+	// pin would land on visibly different anchors.
+	pin := time.Date(2026, time.January, 1, 0, 0, 0, 0, time.UTC)
+	pinMillis := pin.UnixMilli()
+
 	cases := []struct {
-		name string
-		ctx  lowerCtx
-		want time.Time
+		name      string
+		pinAt     *int64
+		ctx       lowerCtx
+		wantStart time.Time
+		wantEnd   time.Time
 	}{
 		{
-			name: "range mode reaches back from the query start",
-			ctx:  lowerCtx{start: gridTestQueryStart, end: gridTestQueryEnd, step: gridTestQueryStep},
-			want: gridTestQueryStart.Add(-subRange),
+			name:      "range mode reaches back from the query start",
+			ctx:       lowerCtx{start: gridTestQueryStart, end: gridTestQueryEnd, step: gridTestQueryStep},
+			wantStart: gridTestQueryStart.Add(-subRange),
+			wantEnd:   gridTestQueryEnd,
 		},
 		{
-			name: "instant eval reaches back from the eval timestamp",
-			ctx:  lowerCtx{end: gridTestQueryEnd},
-			want: gridTestQueryEnd.Add(-subRange),
+			name:      "instant eval reaches back from the eval timestamp",
+			ctx:       lowerCtx{end: gridTestQueryEnd},
+			wantStart: gridTestQueryEnd.Add(-subRange),
+			wantEnd:   gridTestQueryEnd,
+		},
+		{
+			// A `@` pin overrides the range-mode window entirely: the
+			// subquery evaluates its own [pin-Range, pin], not the outer
+			// query's [start, end].
+			name:      "@ pin wins over the range-mode window",
+			pinAt:     &pinMillis,
+			ctx:       lowerCtx{start: gridTestQueryStart, end: gridTestQueryEnd, step: gridTestQueryStep},
+			wantStart: pin.Add(-subRange),
+			wantEnd:   pin,
 		},
 	}
 
@@ -344,9 +367,13 @@ func TestSubqueryOverAbsentGridCoversEveryOuterAnchor(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
+			sub := parseSubquery(t, query)
+			if tc.pinAt != nil {
+				sub.Timestamp = tc.pinAt
+			}
 			ctx := tc.ctx
 			ctx.lowerers = RangeLowerers{}.withDefaults()
-			plan, err := lowerSubquery(parseSubquery(t, query), schema.DefaultOTelMetrics(), ctx)
+			plan, err := lowerSubquery(sub, schema.DefaultOTelMetrics(), ctx)
 			if err != nil {
 				t.Fatalf("lowerSubquery(%q): %v", query, err)
 			}
@@ -358,11 +385,11 @@ func TestSubqueryOverAbsentGridCoversEveryOuterAnchor(t *testing.T) {
 			if !ok {
 				t.Fatalf("lowered %q over %T, want *chplan.AbsentOverTime", query, project.Input)
 			}
-			if !absent.Start.Equal(tc.want) {
-				t.Errorf("AbsentOverTime.Start = %s, want %s", absent.Start, tc.want)
+			if !absent.Start.Equal(tc.wantStart) {
+				t.Errorf("AbsentOverTime.Start = %s, want %s", absent.Start, tc.wantStart)
 			}
-			if !absent.End.Equal(tc.ctx.end) {
-				t.Errorf("AbsentOverTime.End = %s, want %s", absent.End, tc.ctx.end)
+			if !absent.End.Equal(tc.wantEnd) {
+				t.Errorf("AbsentOverTime.End = %s, want %s", absent.End, tc.wantEnd)
 			}
 		})
 	}

--- a/test/perf/cardinality-baseline/promql/subquery_absent_at_pin.json
+++ b/test/perf/cardinality-baseline/promql/subquery_absent_at_pin.json
@@ -1,0 +1,11 @@
+{
+  "fixture": "promql/subquery_absent_at_pin",
+  "fan_factor": 1,
+  "scan_rows": 6,
+  "peak_intermediate": 6,
+  "has_cross_join": true,
+  "has_array_join": true,
+  "has_recursive_cte": false,
+  "max_recursion_depth": 0,
+  "uncountable_levels": 0
+}

--- a/test/perf/solver-decision-baseline/subquery_absent_at_pin/fanout.json
+++ b/test/perf/solver-decision-baseline/subquery_absent_at_pin/fanout.json
@@ -1,0 +1,11 @@
+{
+  "query": "subquery_absent_at_pin/fanout",
+  "lowering": "fanout",
+  "routed": false,
+  "k": 0,
+  "reason": "not-sliceable",
+  "n_anchors": 241,
+  "fanout": 5,
+  "cumulative_d": "10m0s",
+  "outer_range": "1h0m0s"
+}

--- a/test/perf/solver-decision-baseline/subquery_absent_at_pin/native.json
+++ b/test/perf/solver-decision-baseline/subquery_absent_at_pin/native.json
@@ -1,0 +1,11 @@
+{
+  "query": "subquery_absent_at_pin/native",
+  "lowering": "native",
+  "routed": false,
+  "k": 0,
+  "reason": "not-sliceable",
+  "n_anchors": 241,
+  "fanout": 5,
+  "cumulative_d": "10m0s",
+  "outer_range": "1h0m0s"
+}

--- a/test/regression/parity_contract_test.go
+++ b/test/regression/parity_contract_test.go
@@ -171,7 +171,7 @@ func TestParityEnrolmentFloor(t *testing.T) {
 
 	// parityEnrolmentFloor is the number of fixtures currently carrying a
 	// `parity:` section. It ratchets UP only.
-	const parityEnrolmentFloor = 604
+	const parityEnrolmentFloor = 605
 
 	enrolled := 0
 	for _, dir := range parityFixtureDirs(t) {

--- a/test/spec/promql/subquery_absent_at_pin.txtar
+++ b/test/spec/promql/subquery_absent_at_pin.txtar
@@ -1,0 +1,66 @@
+# `max_over_time(absent(<v>)[5m:1m] @ <ts>)` under query_range. The `@`
+# pin fixes the subquery's own evaluation window at `<ts>` — reference
+# Prometheus checks the SAME pinned window `(23:08:20, 23:13:20]` at every
+# outer step and broadcasts one verdict.
+#
+# The seed has NO sample anywhere near the pin, but DOES have one inside
+# the request's own `range_step` window (2026-01-01 00:00:00 .. 00:05:00).
+# Before #2071's fix, `lowerSubqueryOverAbsent` never consulted the pin
+# and anchored the grid on the request's own window instead — finding the
+# unrelated sample there and (wrongly) reporting the series present. The
+# correct, pinned answer is `absent = 1`, broadcast across every step.
+
+-- query.promql --
+max_over_time(absent(demo_metric)[5m:1m] @ 1700000000)
+-- parity --
+oracle: prometheus
+endpoint: /api/v1/query_range
+scope: full
+-- range_step --
+60s
+-- seed --
+CREATE TABLE otel_metrics_gauge (
+    MetricName String,
+    Attributes Map(String, String),
+    TimeUnix DateTime64(9),
+    Value Float64
+) ENGINE = MergeTree ORDER BY (MetricName, Attributes, TimeUnix);
+-- Sample sits inside the REQUEST's own [start,end] window, nowhere near
+-- the `@` pin (2023-11-14 22:13:20 UTC) — proves the lowering must read
+-- the pin rather than the request window.
+INSERT INTO otel_metrics_gauge VALUES
+    ('demo_metric', map('job', 'api'), toDateTime64('2026-01-01 00:02:00', 9), 5);
+-- expected_rows --
+[
+  [{}, "2026-01-01T00:00:00Z", "2026-01-01T00:00:00Z", 1],
+  [{}, "2026-01-01T00:01:00Z", "2026-01-01T00:01:00Z", 1],
+  [{}, "2026-01-01T00:02:00Z", "2026-01-01T00:02:00Z", 1],
+  [{}, "2026-01-01T00:03:00Z", "2026-01-01T00:03:00Z", 1],
+  [{}, "2026-01-01T00:04:00Z", "2026-01-01T00:04:00Z", 1],
+  [{}, "2026-01-01T00:05:00Z", "2026-01-01T00:05:00Z", 1]
+]
+-- args --
+[0] string = ""
+[1] string = "Map(String,String)"
+[2] float64 = 1
+[3] string = "service.name"
+[4] string = "service_name"
+[5] string = "service.name"
+[6] string = "service_name"
+[7] string = ""
+[8] string = "service_name"
+[9] string = "demo_metric"
+[10] string = "demo.metric"
+[11] string = "demo/metric"
+-- chplan --
+Project [Attributes AS Attributes, anchor_ts AS anchor_ts, anchor_ts AS TimeUnix, Value AS Value]
+  CrossJoin
+    StepGrid start=2026-01-01T00:00:00.000000000Z end=2026-01-01T00:05:00.000000000Z step=1m0s
+    RangeWindow func=max_over_time range=5m0s step=0s ts=anchor_ts value=Value groupBy=[Attributes] start=0001-01-01T00:00:00Z end=2023-11-14T22:13:20Z
+      Project [Attributes AS Attributes, TimeUnix AS anchor_ts, Value AS Value]
+        AbsentOverTime range=5m0s step=1m0s ts=TimeUnix value=Value name=MetricName attrs=Attributes start=2023-11-14T22:08:20Z end=2023-11-14T22:13:20Z
+          Project [MetricName AS MetricName, mapSort(mapConcat(mapUpdate(mapFromArrays(arrayMap(k -> replaceRegexpAll(k, "[^a-zA-Z0-9_]", "_"), mapKeys(mapFilter((k, v) -> (k NOT IN ("service.name", "service_name")), ResourceAttributes))), mapValues(mapFilter((k, v) -> (k NOT IN ("service.name", "service_name")), ResourceAttributes))), mapFromArrays(arrayMap(k -> replaceRegexpAll(k, "[^a-zA-Z0-9_]", "_"), mapKeys(Attributes)), mapValues(Attributes))), mapFilter((k, v) -> (v != ""), map("service_name", toString(ServiceName))))) AS Attributes, TimeUnix AS TimeUnix, Value AS Value]
+            Filter predicate=(MetricName IN ("demo_metric", "demo.metric", "demo/metric"))
+              Scan(merge(otel_metrics_gauge|otel_metrics_sum))
+-- sql --
+SELECT `Attributes` AS `Attributes`, `anchor_ts` AS `anchor_ts`, `anchor_ts` AS `TimeUnix`, `Value` AS `Value` FROM (SELECT * FROM (SELECT arrayJoin(arrayMap(i -> toDateTime64('2026-01-01 00:00:00.000000000', 9) + toIntervalNanosecond(i * 60000000000), range(0, 6))) AS `anchor_ts`) AS L CROSS JOIN (SELECT `Attributes`, max(`Value`) AS `Value` FROM (SELECT `Attributes` AS `Attributes`, `TimeUnix` AS `anchor_ts`, `Value` AS `Value` FROM (SELECT ? AS `MetricName`, CAST(map(), ?) AS `Attributes`, anchor_ts AS `TimeUnix`, toFloat64(?) AS `Value` FROM (SELECT anchor_ts FROM (SELECT arrayJoin(arrayMap(i -> toDateTime64('2023-11-14 22:08:20.000000000', 9) + toIntervalNanosecond(i * 60000000000), range(0, 6))) AS `anchor_ts` FROM (SELECT 1)) WHERE anchor_ts NOT IN ((SELECT arrayJoin(arrayMap(i -> toDateTime64('2023-11-14 22:08:20.000000000', 9) + toIntervalNanosecond(i * 60000000000), range(greatest(0, intDiv(dateDiff('nanosecond', toDateTime64('2023-11-14 22:08:20.000000000', 9), `TimeUnix`) - 1, toInt64(60000000000)) - (modulo(dateDiff('nanosecond', toDateTime64('2023-11-14 22:08:20.000000000', 9), `TimeUnix`) - 1, toInt64(60000000000)) < 0) + 1), least(6, intDiv(dateDiff('nanosecond', toDateTime64('2023-11-14 22:08:20.000000000', 9), `TimeUnix`) + 299999999999, toInt64(60000000000)) - (modulo(dateDiff('nanosecond', toDateTime64('2023-11-14 22:08:20.000000000', 9), `TimeUnix`) + 299999999999, toInt64(60000000000)) < 0) + 1)))) AS `anchor_ts` FROM (SELECT `MetricName` AS `MetricName`, mapSort(mapConcat(mapUpdate(mapFromArrays(arrayMap(k -> replaceRegexpAll(k, '[^a-zA-Z0-9_]', '_'), mapKeys(mapFilter((k, v) -> (k NOT IN (?, ?)), `ResourceAttributes`))), mapValues(mapFilter((k, v) -> (k NOT IN (?, ?)), `ResourceAttributes`))), mapFromArrays(arrayMap(k -> replaceRegexpAll(k, '[^a-zA-Z0-9_]', '_'), mapKeys(`Attributes`)), mapValues(`Attributes`))), mapFilter((k, v) -> (v != ?), map(?, toString(`ServiceName`))))) AS `Attributes`, `TimeUnix` AS `TimeUnix`, `Value` AS `Value` FROM (SELECT * FROM merge(currentDatabase(), '^(otel_metrics_gauge|otel_metrics_sum)$') WHERE (`MetricName` IN (?, ?, ?)))) WHERE `TimeUnix` > toDateTime64('2023-11-14 22:08:20.000000000', 9) - toIntervalNanosecond(300000000000) AND `TimeUnix` <= toDateTime64('2023-11-14 22:13:20.000000000', 9)))))) WHERE `anchor_ts` > toDateTime64('2023-11-14 22:13:20.000000000', 9) - toIntervalNanosecond(300000000000) AND `anchor_ts` <= toDateTime64('2023-11-14 22:13:20.000000000', 9) GROUP BY `Attributes`) AS R)


### PR DESCRIPTION
## Summary

- `lowerSubqueryOverAbsent` (the lowering for `absent(<selector>)[<range>:<step>]`, typically nested under an outer reducer like `max_over_time`) built its anchor grid from the surrounding `lowerCtx` alone and never consulted the subquery's own `@` modifier — `subqueryPinned(sub)` / `anchor.End` were not read at that site.
- An `@`-pinned absent subquery (`absent(v)[5m:1m] @ T`) therefore evaluated the *request's own* window instead of the pinned one, while every sibling subquery lowering (`subqueryGridCtx`, `lowerAbsentOverTimeOverSubquery`) already handled the pin correctly.
- Fix mirrors `subqueryGridCtx`'s precedence: an `@` pin (`anchor.End`, from `subqueryPinned(sub)`) wins over range mode wherever the two disagree; unpinned range/instant behaviour is unchanged.

## Root cause

`widenSubquerySpine` — the mechanism the enclosing `max_over_time(...)` wrapper uses to re-narrow an inner subquery's window to the pinned instant — only walks `RangeWindow` / `Project` / `Aggregate` / `TopK` / `Filter` nodes. It has no case for `*chplan.AbsentOverTime`, so for the absent-subquery shape `lowerSubqueryOverAbsent`'s own grid computation is the *sole* source of truth for the window, both standalone and when wrapped by an outer reducer. Since that function never read the pin, the bug reproduced in both shapes.

## Fix

`lowerSubqueryOverAbsent` now computes `subqueryAnchor` first, then picks the grid with the same three-way precedence `subqueryGridCtx` already uses: `subqueryPinned(sub) && !anchor.End.IsZero()` → pinned window `[anchor.End-Range, anchor.End]`; else `ctx.rangeMode()` → request window; else the instant-eval fallback. The subquery's own `offset` shift is applied afterward, unchanged.

## Testing (TDD)

- Added `test/spec/promql/subquery_absent_at_pin.txtar`: `max_over_time(absent(demo_metric)[5m:1m] @ 1700000000)` under `query_range`, seeded with a sample that sits inside the *request's* window but nowhere near the pin. Carries a `-- parity --` section (`oracle: prometheus`), so it is checked against the real upstream Prometheus engine, not just self-consistency. Confirmed the fixture fails against the pre-fix code (reference returns 6 broadcast `1`s, buggy cerberus returned `[]`) and passes with the fix.
- Extended `TestSubqueryOverAbsentGridCoversEveryOuterAnchor` in `internal/promql/subquery_grid_test.go` with an `"@ pin wins over the range-mode window"` case, mirroring the existing precedent test for `subqueryGridCtx`. Verified it fails without the fix (`AbsentOverTime.Start`/`.End` land on the query's own window rather than the pin) and passes with it.
- Regenerated goldens via `just update-golden migration parity solver promql chsql codegen cardinality` (the full set the branch's diff implies is stale, per invariant 9's coverage check) — the only regenerated artefact is the new fixture itself; nothing else in the corpus drifted.
- `go build ./...`, `go vet ./internal/promql/...`, `go test -race ./internal/promql/...`, and `node .github/scripts/forbid-sql-raw.mjs` all clean.

Closes #2071

🤖 Generated with [Claude Code](https://claude.com/claude-code)