### PR TITLE
fix(e2e): pin Metrics Drilldown's legacy /trail redirector as a seed

### DIFF
--- a/test/e2e/playwright/crawl/grafana-surface-inventory.compose.json
+++ b/test/e2e/playwright/crawl/grafana-surface-inventory.compose.json
@@ -823,6 +823,10 @@
       "lean": false
     },
     {
+      "url": "/a/grafana-metricsdrilldown-app/trail",
+      "lean": true
+    },
+    {
       "url": "/a/grafana-pyroscope-app/explore",
       "lean": false
     },

--- a/test/e2e/playwright/crawl/stacks.ts
+++ b/test/e2e/playwright/crawl/stacks.ts
@@ -169,22 +169,45 @@ const CERBERUS_DATASOURCES: ReadonlyArray<ExpectedDatasource> = [
 ];
 
 /**
+ * Metrics Drilldown's legacy `/trail` route: a real, still-live
+ * client redirector into `/drilldown` (verified live against
+ * grafana-metricsdrilldown-app 2.3.1 on grafana/grafana:12.2.9 —
+ * `/trail` navigates through `/trail/drilldown` and settles on
+ * `/drilldown`, the identical entry state `/drilldown` itself
+ * renders). It keeps its own pinned inventory row deliberately: the
+ * app dropping or breaking the alias is a real regression, and
+ * nothing else in the crawl visits the bare `/trail` path once
+ * `/drilldown` is the seed. It must stay a plain SEED, never an
+ * interaction root (see DRILLDOWN_LEAN_INTERACTION_ROOTS below) —
+ * driving controls from `/trail` drives them against the
+ * ALREADY-REDIRECTED `/drilldown` page, so every gesture's
+ * post-navigation URL canonicalizes to `/drilldown`, not `/trail`,
+ * misclassifying every in-place `/trail` state as a cross-owner
+ * `/drilldown` discovery instead (#2170 / #2174).
+ */
+const METRICS_DRILLDOWN_LEGACY_TRAIL_SEED =
+  '/a/grafana-metricsdrilldown-app/trail';
+
+/**
  * The lean representative set both stacks use today: one entry route
  * per first-party drilldown app (the catalogue in
- * helpers/drilldown.ts). Concrete paths — they may pin var-* state
+ * helpers/drilldown.ts), plus the metrics app's legacy `/trail`
+ * redirector seed above. Concrete paths — they may pin var-* state
  * the app needs on a cold context.
  */
-const DRILLDOWN_APP_SEEDS: ReadonlyArray<string> = DRILLDOWN_APPS.map(
-  (app) => app.root,
-);
+const DRILLDOWN_APP_SEEDS: ReadonlyArray<string> = [
+  ...DRILLDOWN_APPS.map((app) => app.root),
+  METRICS_DRILLDOWN_LEGACY_TRAIL_SEED,
+];
 
 /**
  * Lean interaction roots shared by both stacks: the three drilldown
  * app entry surfaces (canonical keys). The drilldown apps are where
- * the interaction gap class
- * lives — the 2026-06-10 maintainer find (Traces Drilldown
- * groupBy=kind → nil-comparison 422) was a state only an interaction
- * reaches.
+ * the interaction gap class lives — the 2026-06-10 maintainer find
+ * (Traces Drilldown groupBy=kind → nil-comparison 422) was a state
+ * only an interaction reaches. Metrics Drilldown's entry here is
+ * `/drilldown`, never the legacy `/trail` seed above — see that
+ * constant's doc for why driving `/trail`'s controls cannot work.
  */
 const DRILLDOWN_LEAN_INTERACTION_ROOTS: ReadonlyArray<string> = [
   '/a/grafana-exploretraces-app/explore',


### PR DESCRIPTION
## Summary

The compose crawl's merged-inventory ratchet flags `/a/grafana-metricsdrilldown-app/trail` as visited-but-not-pinned while claiming its pinned `.../drilldown/trail` sibling was NOT visited. Both symptoms have the same root cause: `/trail` is a real, still-live client redirector into `/drilldown` (verified against grafana-metricsdrilldown-app 2.3.1 on grafana/grafana:12.2.9 — navigating `/trail` bounces through `/trail/drilldown` and settles on `/drilldown`, the same entry state `/drilldown` itself renders). Because the crawl only records the URL a page settles on, driving `/trail` was always reporting back as a `/drilldown` visit and never satisfying `/trail`'s own pinned row.

## Fix

- `test/e2e/playwright/crawl/stacks.ts`: pin `/a/grafana-metricsdrilldown-app/trail` as its own SEED (`METRICS_DRILLDOWN_LEGACY_TRAIL_SEED`), added to `DRILLDOWN_APP_SEEDS`. It stays a plain seed and is explicitly excluded from `DRILLDOWN_LEAN_INTERACTION_ROOTS`: driving controls from `/trail` would drive them against the already-redirected `/drilldown` page, misclassifying every in-place `/trail` state as a cross-owner `/drilldown` discovery instead.
- `test/e2e/playwright/crawl/grafana-surface-inventory.compose.json`: re-pinned the `/trail` row (regenerated via `CERBERUS_UPDATE_INVENTORY=1 SWEEP_DEPTH=full CRAWL_STACK=compose npx playwright test crawl/crawl.spec.ts`, run 3 times to converge past this exact discovery/redirect race).

## Test plan

- [x] `npx tsc --noEmit` clean on `test/e2e/playwright`.
- [x] Full-depth compose crawl regeneration run (3x, converged).
- [ ] CI's `compose-crawl-merge` gate (cannot be settled locally per invariant 5 — needs the compose stack).

Closes #2170
