### PR TITLE
perf(ci): size each cardinality-baseline leg's GOMAXPROCS to its share

### DIFF
--- a/.github/scripts/cardinality-baseline-update.mjs
+++ b/.github/scripts/cardinality-baseline-update.mjs
@@ -53,11 +53,18 @@
 //   CARDINALITY_UPDATE_PRINT_PLAN   (optional) `1` prints the ordered plan
 //                                   (`<label> <ENV=v>... <command>` per line)
 //                                   and exits without regenerating anything.
+//   GOMAXPROCS                      (optional) overrides the per-leg default
+//                                   of `hostCores / fanOut` (see
+//                                   perLegGOMAXPROCS) — set this yourself only
+//                                   if you deliberately want every leg
+//                                   scheduling against the full core count
+//                                   again.
 //
 // Exits 1 on a missing libchdb.so, on any leg failing, or on the seal step
 // reporting a tree that does not match the corpus.
 
 import { existsSync } from 'node:fs';
+import os from 'node:os';
 import process from 'node:process';
 
 import { error, log } from './lib/gh.mjs';
@@ -124,6 +131,29 @@ function goTest(run, timeout) {
 }
 
 /**
+ * Per-leg GOMAXPROCS: the host's core count divided evenly across the N
+ * concurrent legs, floored at 1.
+ *
+ * Each leg is a separate `go test` process, and the Go runtime defaults an
+ * unset GOMAXPROCS to the FULL host core count regardless of how many
+ * sibling processes are already competing for it. N legs left at that
+ * default therefore each try to schedule as if they owned every core, which
+ * oversubscribes an N-core-or-smaller host by a factor of N — measured on an
+ * 8-core dev box running the default 8-way fan-out as ~50% CPU utilisation
+ * per leg instead of ~100%, roughly doubling wall time. Dividing the core
+ * count up front is what the fan-out itself already assumes (`count` legs
+ * partitioning `count`-ways), so this just makes the scheduler's per-process
+ * budget agree with that assumption instead of over-committing it.
+ *
+ * A caller that has deliberately set GOMAXPROCS in its own environment (a
+ * CI runner tuned for a different oversubscription strategy, say) is left
+ * alone — this only fills the gap the Go runtime's own default leaves.
+ */
+function perLegGOMAXPROCS(count) {
+  return String(Math.max(1, Math.floor(os.cpus().length / count)));
+}
+
+/**
  * The regeneration plan: N profiling legs over disjoint slices, then the seal.
  *
  * The leg INDEX is 1-based and the legs are contiguous 1..N, because that is
@@ -132,6 +162,7 @@ function goTest(run, timeout) {
  * should have owned is owned by nobody — and every leg still exits 0.
  */
 function plan(count, timeout) {
+  const gomaxprocs = process.env.GOMAXPROCS || perLegGOMAXPROCS(count);
   const legs = Array.from({ length: count }, (_, i) => ({
     label: `cardinality[${i + 1}/${count}]`,
     argv: goTest(RATCHET_TEST, timeout),
@@ -139,6 +170,7 @@ function plan(count, timeout) {
       [UPDATE_ENV]: '1',
       [PERF_SHARD_INDEX_ENV]: String(i + 1),
       [PERF_SHARD_COUNT_ENV]: String(count),
+      GOMAXPROCS: gomaxprocs,
     },
   }));
 


### PR DESCRIPTION
## Summary

Every `update-cardinality-baseline` leg is a separate `go test -tags chdb` process, and an unset `GOMAXPROCS` defaults to the FULL host core count regardless of how many sibling legs are already scheduled. N legs left at that default each try to schedule as if they owned every core — an N-way self-inflicted oversubscription on any host with N cores or fewer.

Caught live on an 8-core dev box: `ps`/`uptime` during a real 8-way cardinality regeneration showed load average ~20, each leg getting roughly 50% CPU instead of ~100%, and heavy swap usage — the fan-out's own concurrency was fighting itself for cores.

## Fix

`cardinality-baseline-update.mjs`'s `plan()` now divides the host's core count by the leg count (`os.cpus().length / count`, floored at 1) and passes it as each leg's `GOMAXPROCS`, unless the caller has already set `GOMAXPROCS` explicitly (respected as-is). This makes the scheduler's per-process budget agree with what the fan-out itself already assumes: `count` legs partitioning `count` ways.

CI runners have a different core/leg ratio than this dev box, so this is a general fix, not dev-machine-specific tuning — the computation is host-relative, not a hardcoded constant.

## Test plan

- [x] `CARDINALITY_UPDATE_PRINT_PLAN=1 node .github/scripts/cardinality-baseline-update.mjs` — confirmed `GOMAXPROCS=1` appears on each of the 8 leg lines on this 8-core box (8 cores / 8 legs = 1), and the seal step is unaffected.
- [x] `go test -run '^TestCardinalityBaselineFansOutTheProfilePass$|^TestCardinalityBaselinePlanSealsTheFanOut$' ./test/regression/...` — both pass; the extra `GOMAXPROCS=N` field doesn't disturb the existing field-based plan-line assertions.
- [ ] CI green (not independently re-running the full ~20min cardinality regeneration locally per invariant 5 — the print-plan + regression-test coverage above is the narrowed local repro for this script-level change).
