### PR TITLE
fix(rejection-parity): re-file the exp-histogram scalar-binop divergence tracking issue

### DIFF
--- a/test/rejection-parity/catalogue/internal__promql__lower.go.json
+++ b/test/rejection-parity/catalogue/internal__promql__lower.go.json
@@ -77,7 +77,7 @@
       "message": "promql: %q is an exponential histogram metric; only a bare %q selector, sum()/avg()/count() over one, rate()/increase()/resets()/changes() over one, histogram_quantile(), histogram_count(), histogram_sum(), and the %q/%q companion selectors are supported",
       "class": "divergence",
       "trigger_query": "demo_latency_exp_hist + 1",
-      "tracking_issue": 2087,
+      "tracking_issue": 2189,
       "evidence": {
         "guard": [
           "past returning if bare, col, hasCompanion := s.HistogramCompanionColumn(metricName); hasCompanion \u0026\u0026 s.IsExpHistogramMetric(bare) \u0026\u0026 s.ExpHistogramTable != \"\"",


### PR DESCRIPTION
## Summary

`test/rejection-parity/catalogue/internal__promql__lower.go.json`'s `internal/promql/lower.go:expHistogramSelectorRouting` entry (`class: "divergence"`) cited `tracking_issue: 2087` — but #2087 is the exact issue PR #2179 ("feat(promql): answer scalar `*` and `/` over a native-histogram sample") itself closed by fixing the `*`/`/` half of it, leaving the entry citing a dead issue. This tripped the required `rejection-parity-divergence-liveness` check on every open PR.

- Verified both `trigger_query` (`demo_latency_exp_hist + 1`) and `class` (`divergence`) are still accurate as-is, not stale:
  - `internal/promql/exp_histogram_reject_test.go`'s `"parenthesised scalar arithmetic"` case (`(latency_exp_hist) + 1`) still pins this exact rejection today.
  - `internal/promql/histogram_native_scalar_binop.go`'s own doc comment confirms only `*`/`/` are answered; `+`/`-`/`^`/`%`/comparisons over an exp-histogram-valued shape still fall through to `expHistogramSelectorRouting`'s rejection.
  - The pinned Prometheus fork's `vectorElemBinop` (`promql/engine.go`), for `hlhs != nil && hrhs == nil` + `ADD`, returns `keep=false` with an info annotation rather than an error — i.e. reference answers `200` (empty result) where cerberus rejects with `422`. `test/rejection-parity`'s differential harness classifies purely by status-code class, so this remains a live divergence.
  - `TestRejectionTriggersExerciseSites` confirms the trigger query actually reaches this site and reproduces the exact catalogued message.
- Filed #2189 to track the residual gap (#2087 explicitly scoped `+`/`-`/`^`/`%`/comparisons out of its own "done when" and was closed without a separate follow-up picking that up) and re-pointed `tracking_issue` at it.
- Regenerated via `CERBERUS_UPDATE_INVENTORY=1 go test ./test/rejection-parity/...` — the diff is exactly the one `tracking_issue` line; no other shard or entry drifted.
- Grepped `test/rejection-parity/catalogue/*.json` for `1772`/`2087`: no other entry cites either as a live `tracking_issue` (two `class: "internal"` rationales in `internal__promql__binary.go.json` mention #2087 in prose, which is fine — not a liveness-checked field).

## Test plan

- [x] `go test -run '^TestCatalogueIsRegenerable$' ./test/rejection-parity/...` — PASS
- [x] `go test -run '^TestRejectionTriggersExerciseSites$' ./test/rejection-parity/...` — PASS (site reached, message matches)
- [x] `go test -run '^TestCatalogueEntriesAreClassified$' ./test/rejection-parity/...` — PASS
- [x] `go test -run '^TestDivergenceEntriesRespectAgeCap$|^TestDivergenceCeilingRatchet$' ./test/rejection-parity/...` — PASS
- [x] `.github/scripts/rejection-parity-divergence-liveness.mjs` run locally against the live GitHub API (`GITHUB_TOKEN=$(gh auth token)`) — **0 violations**, all 3 divergence entries cite an open tracking issue.

Related: #2189 (new, tracks the remaining `+`/`-`/`^`/`%`/comparison scalar-binop gap over an exp-histogram sample — not closed by this PR, which only fixes the catalogue bookkeeping).