### PR TITLE
test(spec): strict-scan LogQL wire projections

### DIFF
--- a/internal/testsql/logs_seed_ddl.go
+++ b/internal/testsql/logs_seed_ddl.go
@@ -1,0 +1,105 @@
+package testsql
+
+import "strings"
+
+// logsTableName is schema.DefaultOTelLogs().LogsTable, mirrored here so this
+// build-tag-free seed helper stays independent of internal/schema.
+const logsTableName = "otel_logs"
+
+// logsBackfilledColumns are the default OTel-CH columns the production
+// LogQL log-stream wire projection reads regardless of the fixture's own raw
+// pre-wrap SQL. Spec seeds deliberately declare only the columns their raw
+// lowering touches, so strict-scan's post-ProjectSamples reconstruction needs
+// these defaults added before it can exercise the real cursor shape.
+var logsBackfilledColumns = []backfilledColumn{
+	{name: "Timestamp", ddl: "Timestamp DateTime64(9) DEFAULT toDateTime64(0, 9)"},
+	{name: "Body", ddl: "Body String DEFAULT ''"},
+	{name: "SeverityText", ddl: "SeverityText LowCardinality(String) DEFAULT ''"},
+	{name: "ResourceAttributes", ddl: "ResourceAttributes Map(String, String) DEFAULT map()"},
+	{name: "LogAttributes", ddl: "LogAttributes Map(String, String) DEFAULT map()"},
+}
+
+// BackfillLogsColumns adds the production columns needed by LogQL's
+// post-ProjectSamples log-row projection and preserves positional INSERTs by
+// rewriting them with their original explicit column list.
+func BackfillLogsColumns(stmts []string) []string {
+	cols := map[string][]string{}
+	out := make([]string, 0, len(stmts))
+	for _, stmt := range stmts {
+		if table, colNames, body, ok := parseLogsCreate(stmt); ok {
+			cols[table] = colNames
+			out = append(out, body)
+			continue
+		}
+		if rewritten, ok := rewriteBackfilledInsert(stmt, cols); ok {
+			out = append(out, rewritten)
+			continue
+		}
+		out = append(out, stmt)
+	}
+	return out
+}
+
+func parseLogsCreate(stmt string) (table string, colNames []string, rewritten string, ok bool) {
+	trimmed := stripLeadingNoise(stmt)
+	prefix := stmt[:len(stmt)-len(trimmed)]
+	rest, ok := createTableTail(trimmed)
+	if !ok {
+		return "", nil, "", false
+	}
+	name := strings.ToLower(strings.TrimSpace(firstToken(rest)))
+	if name != logsTableName {
+		return "", nil, "", false
+	}
+	open := strings.IndexByte(trimmed, '(')
+	if open < 0 {
+		return "", nil, "", false
+	}
+	closeParen := matchParen(trimmed, open)
+	if closeParen < 0 {
+		return "", nil, "", false
+	}
+	defs := splitTopLevelCommas(trimmed[open+1 : closeParen])
+	declared := make(map[string]bool, len(defs))
+	names := make([]string, 0, len(defs))
+	normalizedDefs := make([]string, len(defs))
+	changed := false
+	for i, d := range defs {
+		normalized := normalizeLogsColumnDef(d)
+		if normalized != d {
+			changed = true
+		}
+		normalizedDefs[i] = normalized
+		column := firstToken(strings.TrimSpace(normalized))
+		if column != "" {
+			declared[column] = true
+			names = append(names, column)
+		}
+	}
+	missing := make([]string, 0, len(logsBackfilledColumns))
+	for _, column := range logsBackfilledColumns {
+		if !declared[column.name] {
+			missing = append(missing, " "+column.ddl)
+		}
+	}
+	if len(missing) == 0 && !changed {
+		return "", nil, "", false
+	}
+	newDefs := append(append(make([]string, 0, len(normalizedDefs)+len(missing)), normalizedDefs...), missing...)
+	rewritten = prefix + trimmed[:open+1] + strings.Join(newDefs, ",") + trimmed[closeParen:]
+	return name, names, rewritten, true
+}
+
+// normalizeLogsColumnDef replaces fixture-only MATERIALIZED definitions on
+// columns the production log-row wrap reads with DEFAULT. ClickHouse excludes
+// MATERIALIZED columns from SELECT *, while production's real otel_logs schema
+// exposes these columns normally. DEFAULT preserves the fixture's derived
+// value but keeps it visible to the reconstructed outer projection.
+func normalizeLogsColumnDef(def string) string {
+	switch firstToken(strings.TrimSpace(def)) {
+	case "Timestamp", "Body", "SeverityText", "ResourceAttributes", "LogAttributes":
+		return strings.Replace(def, " MATERIALIZED ", " DEFAULT ", 1)
+	default:
+		return def
+	}
+}

--- a/internal/testsql/logs_seed_ddl_test.go
+++ b/internal/testsql/logs_seed_ddl_test.go
@@ -1,0 +1,52 @@
+package testsql
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestBackfillLogsColumns_AddsWireProjectionColumns(t *testing.T) {
+	ddl := "CREATE TABLE otel_logs (\n" +
+		"    Timestamp DateTime64(9),\n" +
+		"    Body String,\n" +
+		"    ResourceAttributes Map(String, String)\n" +
+		") ENGINE = Memory"
+	insert := "INSERT INTO otel_logs VALUES (now64(9), 'line', map('job', 'api'))"
+	got := BackfillLogsColumns([]string{ddl, insert})
+	if len(got) != 2 {
+		t.Fatalf("BackfillLogsColumns returned %d statements, want 2", len(got))
+	}
+	for _, column := range []string{"SeverityText LowCardinality(String)", "LogAttributes Map(String, String)"} {
+		if !strings.Contains(got[0], column) {
+			t.Errorf("backfilled DDL missing %q:\n%s", column, got[0])
+		}
+	}
+	if !strings.Contains(got[1], "INSERT INTO otel_logs (Timestamp, Body, ResourceAttributes) VALUES") {
+		t.Errorf("positional INSERT did not retain the original column list:\n%s", got[1])
+	}
+}
+
+func TestBackfillLogsColumns_NormalizesWireColumnsToDefault(t *testing.T) {
+	ddl := "CREATE TABLE otel_logs (\n" +
+		"    Body String,\n" +
+		"    ResourceAttributes Map(String, String) MATERIALIZED map('job', 'api')\n" +
+		") ENGINE = Memory"
+	got := BackfillLogsColumns([]string{ddl})
+	if len(got) != 1 {
+		t.Fatalf("BackfillLogsColumns returned %d statements, want 1", len(got))
+	}
+	if strings.Contains(got[0], "ResourceAttributes Map(String, String) MATERIALIZED") {
+		t.Fatalf("wire-read column remained MATERIALIZED and invisible to SELECT *:\n%s", got[0])
+	}
+	if !strings.Contains(got[0], "ResourceAttributes Map(String, String) DEFAULT map('job', 'api')") {
+		t.Fatalf("wire-read column did not preserve its expression as DEFAULT:\n%s", got[0])
+	}
+}
+
+func TestBackfillLogsColumns_LeavesOtherTablesUntouched(t *testing.T) {
+	ddl := "CREATE TABLE helper (Timestamp DateTime64(9)) ENGINE = Memory"
+	got := BackfillLogsColumns([]string{ddl})
+	if len(got) != 1 || got[0] != ddl {
+		t.Fatalf("BackfillLogsColumns(helper) = %q, want unchanged %q", got, ddl)
+	}
+}

--- a/test/spec/logqlwrap/logqlwrap.go
+++ b/test/spec/logqlwrap/logqlwrap.go
@@ -1,0 +1,87 @@
+// Package logqlwrap reconstructs the production LogQL wire projection for
+// spec fixtures whose recorded SQL is captured before Lang.ProjectSamples.
+package logqlwrap
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/tsouza/cerberus/internal/chplan"
+	"github.com/tsouza/cerberus/internal/chsql"
+	"github.com/tsouza/cerberus/internal/logql"
+	"github.com/tsouza/cerberus/internal/schema"
+	"github.com/tsouza/cerberus/test/spec"
+)
+
+// ReconstructLogStreamWrap reconstructs the post-ProjectSamples SQL that the
+// production Loki handler sends to ClickHouse for a log-stream fixture.
+//
+// Layer 2a records LogQL SQL before the engine applies ProjectSamples, so a
+// log-stream fixture normally contains a bare SELECT * and never exercises
+// the production cursor's (Line, Attributes, TimeUnix[, Metadata]) scan. This
+// helper runs the same Lang.Parse + Lang.ProjectSamples pair as production and
+// emits the resulting wire projection. Metric queries return ok=false because
+// their recorded SQL already carries the matrix shape strict-scan exercises.
+func ReconstructLogStreamWrap(c *spec.Case) (sqlStr string, args []any, ok bool, err error) {
+	plan, ok, err := ReconstructLogStreamWrapPlan(c)
+	if err != nil || !ok {
+		return "", nil, ok, err
+	}
+	sqlStr, args, err = chsql.Emit(context.Background(), plan)
+	if err != nil {
+		return "", nil, false, fmt.Errorf("chsql.Emit(wrapped): %w", err)
+	}
+	return sqlStr, args, true, nil
+}
+
+// ReconstructLogStreamWrapPlan is ReconstructLogStreamWrap's plan-level twin.
+// It returns ok=false for non-LogQL fixtures and LogQL metric queries.
+func ReconstructLogStreamWrapPlan(c *spec.Case) (plan chplan.Node, ok bool, err error) {
+	query, hasQuery := c.Section("query.logql")
+	if !hasQuery {
+		return nil, false, nil
+	}
+	start, end, step, err := readWindowSections(c)
+	if err != nil {
+		return nil, false, err
+	}
+
+	lang := &logql.Lang{
+		Schema: schema.DefaultOTelLogs(),
+		Start:  start,
+		End:    end,
+		Step:   step,
+	}
+	rawPlan, meta, err := lang.Parse(context.Background(), strings.TrimSpace(query))
+	if err != nil {
+		return nil, false, fmt.Errorf("logql lower (wrap reconstruction): %w", err)
+	}
+	if meta.IsMetric {
+		return nil, false, nil
+	}
+	return lang.ProjectSamples(rawPlan, meta), true, nil
+}
+
+func readWindowSections(c *spec.Case) (start, end time.Time, step time.Duration, err error) {
+	if v, ok := c.Section("start"); ok && strings.TrimSpace(v) != "" {
+		start, err = time.Parse(time.RFC3339Nano, strings.TrimSpace(v))
+		if err != nil {
+			return time.Time{}, time.Time{}, 0, fmt.Errorf("bad start %q: %w", v, err)
+		}
+	}
+	if v, ok := c.Section("end"); ok && strings.TrimSpace(v) != "" {
+		end, err = time.Parse(time.RFC3339Nano, strings.TrimSpace(v))
+		if err != nil {
+			return time.Time{}, time.Time{}, 0, fmt.Errorf("bad end %q: %w", v, err)
+		}
+	}
+	if v, ok := c.Section("step"); ok && strings.TrimSpace(v) != "" {
+		step, err = time.ParseDuration(strings.TrimSpace(v))
+		if err != nil {
+			return time.Time{}, time.Time{}, 0, fmt.Errorf("bad step %q: %w", v, err)
+		}
+	}
+	return start, end, step, nil
+}

--- a/test/spec/logqlwrap/logqlwrap_test.go
+++ b/test/spec/logqlwrap/logqlwrap_test.go
@@ -1,0 +1,69 @@
+package logqlwrap
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/tsouza/cerberus/internal/chplan"
+	"github.com/tsouza/cerberus/test/spec"
+)
+
+func TestReconstructLogStreamWrapPlan(t *testing.T) {
+	c := loadCase(t, "-- query.logql --\n{job=\"api\"} |= \"error\"\n")
+	plan, ok, err := ReconstructLogStreamWrapPlan(c)
+	if err != nil {
+		t.Fatalf("ReconstructLogStreamWrapPlan: %v", err)
+	}
+	if !ok {
+		t.Fatal("ReconstructLogStreamWrapPlan declined a log-stream query")
+	}
+	project, ok := plan.(*chplan.Project)
+	if !ok {
+		t.Fatalf("wrapped plan = %T, want *chplan.Project", plan)
+	}
+	want := []string{"Line", "Attributes", "TimeUnix", "Metadata"}
+	if len(project.Projections) != len(want) {
+		t.Fatalf("projection width = %d, want %d", len(project.Projections), len(want))
+	}
+	for i, projection := range project.Projections {
+		if projection.Alias != want[i] {
+			t.Errorf("projection[%d] alias = %q, want %q", i, projection.Alias, want[i])
+		}
+	}
+}
+
+func TestReconstructLogStreamWrapDeclinesMetricQueries(t *testing.T) {
+	c := loadCase(t, "-- query.logql --\nrate({job=\"api\"}[5m])\n")
+	if _, _, ok, err := ReconstructLogStreamWrap(c); err != nil || ok {
+		t.Fatalf("ReconstructLogStreamWrap(metric) = ok %v, err %v; want false, nil", ok, err)
+	}
+}
+
+func TestReconstructLogStreamWrapThreadsFixtureWindow(t *testing.T) {
+	c := loadCase(t, "-- query.logql --\n{job=\"api\"}\n-- start --\n2026-01-01T00:00:00Z\n-- end --\n2026-01-01T00:05:00Z\n")
+	sqlStr, _, ok, err := ReconstructLogStreamWrap(c)
+	if err != nil {
+		t.Fatalf("ReconstructLogStreamWrap: %v", err)
+	}
+	if !ok {
+		t.Fatal("ReconstructLogStreamWrap declined a log-stream query")
+	}
+	if !strings.Contains(sqlStr, "`Timestamp` >=") || !strings.Contains(sqlStr, "`Timestamp` <=") {
+		t.Fatalf("wrapped SQL omitted the fixture window:\n%s", sqlStr)
+	}
+}
+
+func loadCase(t *testing.T, body string) *spec.Case {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "case.txtar")
+	if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+	c, err := spec.Load(path)
+	if err != nil {
+		t.Fatalf("spec.Load: %v", err)
+	}
+	return c
+}

--- a/test/spec/strictscan_logql_integration_test.go
+++ b/test/spec/strictscan_logql_integration_test.go
@@ -1,0 +1,111 @@
+//go:build integration
+
+package spec_test
+
+import (
+	"context"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/tsouza/cerberus/internal/chclient"
+	"github.com/tsouza/cerberus/internal/testsql"
+	"github.com/tsouza/cerberus/test/spec"
+	"github.com/tsouza/cerberus/test/spec/logqlwrap"
+)
+
+// TestStrictScanDifferentialLogStreams closes the LogQL half of the
+// pre-wrap fixture gap: Layer 2a records a log-stream query as SELECT *, while
+// production applies ProjectSamples and sends (Line, Attributes, TimeUnix[,
+// Metadata]) to ClickHouse. Its TestStrictScanDifferential prefix means the
+// canonical `just strict-scan-test` recipe runs this sibling under the same
+// real-ClickHouse required check.
+func TestStrictScanDifferentialLogStreams(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Minute)
+	defer cancel()
+
+	client := newStrictScanClient(ctx, t)
+	dir := filepath.Join(repoRootFromTest(t), "test", "spec", "logql")
+	var ran, skippedMetric, skippedNonRoundTrip int
+	spec.Walk(t, dir, func(t *testing.T, c *spec.Case) {
+		rt, err := spec.LoadRoundTrip(c)
+		if err != nil {
+			t.Fatalf("LoadRoundTrip: %v", err)
+		}
+		if !rt.IsRoundTrip() || strings.TrimSpace(rt.SQL) == "" {
+			skippedNonRoundTrip++
+			return
+		}
+
+		sqlStr, args, ok, err := logqlwrap.ReconstructLogStreamWrap(c)
+		if err != nil {
+			t.Fatalf("reconstruct production log-stream wrap: %v", err)
+		}
+		if !ok {
+			skippedMetric++
+			return
+		}
+		rt.SQL, rt.Args = sqlStr, args
+		applyStrictScanLogSeed(ctx, t, client, rt.Seed)
+		query, queryArgs := spec.SubstituteNow64(rt.SQL, rt.Args)
+
+		logRow, err := isLogRowShape(ctx, client, query, queryArgs)
+		if err != nil {
+			t.Fatalf("query open failed against real ClickHouse:\n--- sql ---\n%s\n--- err ---\n%v", query, err)
+		}
+		if !logRow {
+			t.Fatalf("reconstructed production LogQL SQL did not expose (Line, Attributes, TimeUnix[, Metadata]):\n%s", query)
+		}
+
+		cur, err := client.QueryCursor(ctx, query, queryArgs...)
+		if err != nil {
+			t.Fatalf("QueryCursor (open) failed:\n--- sql ---\n%s\n--- err ---\n%v", query, err)
+		}
+		defer func() { _ = cur.Close() }()
+		for cur.Next() {
+			_ = cur.Sample()
+		}
+		if err := cur.Err(); err != nil {
+			if isStrictScanError(err) {
+				t.Fatalf("STRICT-SCAN TYPE ERROR — LogQL wire projection cannot be decoded by the production cursor:\n--- sql ---\n%s\n--- err ---\n%v", query, err)
+			}
+			t.Fatalf("cursor drain failed:\n--- sql ---\n%s\n--- err ---\n%v", query, err)
+		}
+		ran++
+	})
+
+	if ran == 0 {
+		t.Fatalf("strict-scan differential ran zero reconstructed LogQL log-stream fixtures (metric=%d, non-round-trip=%d) — reconstruction or corpus selection is broken", skippedMetric, skippedNonRoundTrip)
+	}
+	t.Logf("strict-scan differential: strict-scanned %d reconstructed LogQL log-stream fixtures against real ClickHouse (%d metric + %d non-round-trip skipped)", ran, skippedMetric, skippedNonRoundTrip)
+}
+
+func isLogRowShape(ctx context.Context, client *chclient.Client, query string, args []any) (bool, error) {
+	rows, err := client.Conn().Query(ctx, query, args...)
+	if err != nil {
+		return false, err
+	}
+	defer func() { _ = rows.Close() }()
+
+	cols := rows.Columns()
+	if len(cols) == 3 {
+		return cols[0] == "Line" && cols[1] == "Attributes" && cols[2] == "TimeUnix", nil
+	}
+	return len(cols) == 4 && cols[0] == "Line" && cols[1] == "Attributes" && cols[2] == "TimeUnix" && cols[3] == "Metadata", nil
+}
+
+func applyStrictScanLogSeed(ctx context.Context, t *testing.T, client *chclient.Client, seed string) {
+	t.Helper()
+	stmts := testsql.BackfillLogsColumns(testsql.SplitStatements(seed))
+	for _, stmt := range stmts {
+		stmt = strings.TrimSpace(stmt)
+		if stmt == "" {
+			continue
+		}
+		stmt = testsql.PromoteCreateTable(stmt)
+		if err := client.Exec(ctx, stmt); err != nil {
+			t.Fatalf("seed exec failed:\n--- stmt ---\n%s\n--- err ---\n%v", stmt, err)
+		}
+	}
+}


### PR DESCRIPTION
Closes #2044

Reconstructs the post-ProjectSamples LogQL stream projection for strict-scan fixtures so the real ClickHouse lane exercises the production `(Line, Attributes, TimeUnix[, Metadata])` cursor layout.

Adds fixture-seed backfill for the default log columns the wire projection reads. Fixture-only `MATERIALIZED` definitions are normalized to `DEFAULT`, preserving their derived values while keeping them visible through the inner `SELECT *` used by the production wrap.

Validation:
- `go test -run "^TestBackfillLogsColumns_" ./internal/testsql`
- `go test -run "^TestReconstructLogStreamWrap" ./test/spec/logqlwrap`
- `just strict-scan-test`