### PR TITLE
test(chdb): add LogQL and TraceQL semantic integration lanes

### DIFF
--- a/.github/workflows/chdb.yml
+++ b/.github/workflows/chdb.yml
@@ -549,3 +549,81 @@ jobs:
 
       - name: Run exotic PromQL integration suite (chDB)
         run: go test -tags chdb -count=1 ./test/integration/promql/...
+
+  # `integration-logql` is the LogQL sibling of integration-promql. It
+  # seeds ONE rich, fixed OTel logs fixture, mounts the real loki.Handler,
+  # and compares the stream rows for every category-matrix query with the
+  # independent property oracle. The oracle's Loki parser dependency stays
+  # test-only behind the established three-tag AGPL quarantine.
+  #
+  # This is ORTHOGONAL to `roundtrip`: roundtrip pins self-derived SQL and
+  # expected_rows; this live HTTP pipeline has no golden/GOLDEN_UPDATE path
+  # and catches semantic lowering, optimizer, emitter, and wire drift.
+  integration-logql:
+    name: integration (logql)
+    needs: changes
+    if: needs.changes.outputs.docs_only != 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-go@v7
+        with:
+          go-version-file: 'go.mod'
+          cache: true
+
+      - uses: taiki-e/install-action@6c6fd71fe4fb72c3697d269963d0e15df8adedad  # v2.85.10
+        with:
+          tool: just
+
+      - name: Cache libchdb.so
+        uses: actions/cache@v6
+        with:
+          path: /usr/local/lib/libchdb.so
+          key: libchdb-${{ runner.os }}-${{ runner.arch }}-v26.5.0
+
+      - name: Install libchdb.so
+        run: just chdb-install
+
+      - name: Run exotic LogQL integration suite (chDB)
+        run: go test -tags chdb,agpl_oracle,chdb_agpl_oracle -count=1 ./test/integration/logql/...
+
+  # `integration-traceql` is the TraceQL sibling of integration-promql.
+  # It seeds ONE rich, fixed OTel traces fixture with real parent chains,
+  # mounts the real tempo.Handler, and compares every category-matrix query
+  # with the independent from-scratch TraceQL property oracle.
+  #
+  # This is ORTHOGONAL to `roundtrip`: roundtrip pins self-derived SQL and
+  # expected_rows; this live HTTP pipeline has no golden/GOLDEN_UPDATE path
+  # and catches semantic selector, structural, aggregate, optimizer, emitter,
+  # and wire drift.
+  integration-traceql:
+    name: integration (traceql)
+    needs: changes
+    if: needs.changes.outputs.docs_only != 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-go@v7
+        with:
+          go-version-file: 'go.mod'
+          cache: true
+
+      - uses: taiki-e/install-action@6c6fd71fe4fb72c3697d269963d0e15df8adedad  # v2.85.10
+        with:
+          tool: just
+
+      - name: Cache libchdb.so
+        uses: actions/cache@v6
+        with:
+          path: /usr/local/lib/libchdb.so
+          key: libchdb-${{ runner.os }}-${{ runner.arch }}-v26.5.0
+
+      - name: Install libchdb.so
+        run: just chdb-install
+
+      - name: Run exotic TraceQL integration suite (chDB)
+        run: go test -tags chdb -count=1 ./test/integration/traceql/...

--- a/test/integration/logql/exotic_test.go
+++ b/test/integration/logql/exotic_test.go
@@ -1,0 +1,135 @@
+//go:build chdb_agpl_oracle
+
+package logql
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"sort"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/tsouza/cerberus/internal/api/loki"
+	"github.com/tsouza/cerberus/internal/chclienttest"
+	"github.com/tsouza/cerberus/internal/schema"
+	"github.com/tsouza/cerberus/test/property"
+	oraclelogql "github.com/tsouza/cerberus/test/property/oracle/logql"
+	"github.com/tsouza/cerberus/test/spec/wire"
+)
+
+// TestExoticLogQL is the chDB-backed LogQL semantic integration suite.
+//
+// It seeds one rich fixed OTel logs fixture into an ephemeral chDB session,
+// mounts the real loki.Handler, and runs every ExoticMatrix query through
+// both cerberus's parse -> lower -> optimize -> emit -> execute HTTP pipeline
+// and the independent from-scratch property oracle. CompareOutcomes checks
+// the resulting stream-row multiset exactly.
+//
+// This is orthogonal to LogQL roundtrip: roundtrip pins self-derived SQL and
+// expected_rows, while this suite computes its expected answer at runtime
+// without GOLDEN_UPDATE and therefore catches semantic pipeline drift.
+func TestExoticLogQL(t *testing.T) {
+	ddl, model := RichSeed()
+	cli := chclienttest.NewChDB(t)
+	cli.Seed(t, ddl)
+
+	handler := loki.New(cli, schema.DefaultOTelLogs(), nil)
+	mux := http.NewServeMux()
+	handler.Mount(mux)
+	server := httptest.NewServer(mux)
+	t.Cleanup(server.Close)
+
+	dataset := property.Dataset{DDL: ddl, Logs: model}
+	for _, tc := range ExoticMatrix {
+		t.Run(tc.name, func(t *testing.T) {
+			query := property.Query{String: tc.logql, EvalTs: seedAnchor.Add(time.Hour).Unix()}
+			want := oraclelogql.Evaluate(dataset, query)
+			if want.Err != nil {
+				t.Fatalf("matrix contains unsupported oracle query %q: %v", query.String, want.Err)
+			}
+			got := runRange(t.Context(), server.URL, query)
+			if diff := property.CompareOutcomes(want, got); diff != "" {
+				t.Fatalf("exotic drift\n--- query ---\n%s\n--- diff (want=oracle got=cerberus) ---\n%s", query.String, diff)
+			}
+		})
+	}
+}
+
+func runRange(ctx context.Context, baseURL string, query property.Query) property.Outcome {
+	start := seedAnchor.Add(-time.Minute).Unix()
+	end := seedAnchor.Add(time.Hour).Unix()
+	url := fmt.Sprintf("%s/loki/api/v1/query_range?query=%s&start=%d&end=%d&step=60", baseURL, wire.EscapeQuery(query.String, ""), start, end)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return property.Outcome{Err: fmt.Errorf("build request: %w", err)}
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return property.Outcome{Err: fmt.Errorf("query roundtrip: %w", err)}
+	}
+	defer func() { _ = resp.Body.Close() }()
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return property.Outcome{Err: fmt.Errorf("read body: %w", err)}
+	}
+	var parsed struct {
+		Status    string `json:"status"`
+		ErrorType string `json:"errorType"`
+		Error     string `json:"error"`
+		Data      struct {
+			ResultType string        `json:"resultType"`
+			Result     []loki.Stream `json:"result"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(body, &parsed); err != nil {
+		return property.Outcome{Err: fmt.Errorf("decode body: %w; status=%d body=%s", err, resp.StatusCode, body)}
+	}
+	if parsed.Status != "success" {
+		return property.Outcome{Err: fmt.Errorf("cerberus returned status=%q errorType=%q err=%q", parsed.Status, parsed.ErrorType, parsed.Error)}
+	}
+	if parsed.Data.ResultType != "streams" {
+		return property.Outcome{Err: fmt.Errorf("cerberus returned resultType=%q, want streams", parsed.Data.ResultType)}
+	}
+	out := property.Outcome{Rows: make([]property.OutcomeRow, 0, len(modelRows(parsed.Data.Result)))}
+	for _, stream := range parsed.Data.Result {
+		for _, value := range stream.Values {
+			timestamp, err := strconv.ParseInt(value.Timestamp, 10, 64)
+			if err != nil {
+				return property.Outcome{Err: fmt.Errorf("parse timestamp %q: %w", value.Timestamp, err)}
+			}
+			out.Rows = append(out.Rows, property.OutcomeRow{
+				Labels:      cloneLabels(stream.Stream),
+				TimestampMs: timestamp / int64(time.Millisecond),
+				Line:        value.Line,
+			})
+		}
+	}
+	sort.Slice(out.Rows, func(i, j int) bool {
+		if out.Rows[i].TimestampMs != out.Rows[j].TimestampMs {
+			return out.Rows[i].TimestampMs < out.Rows[j].TimestampMs
+		}
+		return out.Rows[i].Line < out.Rows[j].Line
+	})
+	return out
+}
+
+func modelRows(streams []loki.Stream) []loki.StreamValue {
+	var rows []loki.StreamValue
+	for _, stream := range streams {
+		rows = append(rows, stream.Values...)
+	}
+	return rows
+}
+
+func cloneLabels(in map[string]string) map[string]string {
+	out := make(map[string]string, len(in))
+	for key, value := range in {
+		out[key] = value
+	}
+	return out
+}

--- a/test/integration/logql/matrix.go
+++ b/test/integration/logql/matrix.go
@@ -1,0 +1,44 @@
+//go:build chdb_agpl_oracle
+
+package logql
+
+type exoticCase struct {
+	name  string
+	logql string
+}
+
+// ExoticMatrix covers every stream-query family the independent LogQL
+// oracle evaluates. Metric queries and parser stages absent from that oracle
+// are deliberately not represented as both-erroring pseudo-coverage.
+var ExoticMatrix = []exoticCase{
+	// CAT1: stream label selection, including missing-label semantics.
+	{name: "cat1/selector_equal", logql: `{job="api"}`},
+	{name: "cat1/selector_not_equal", logql: `{service_name=~".+",job!="api"}`},
+	{name: "cat1/selector_regex", logql: `{service_name=~"auth|billing"}`},
+	{name: "cat1/selector_not_regex", logql: `{job=~".+",service_name!~"checkout"}`},
+	{name: "cat1/selector_conjunction", logql: `{job="api",service_name="auth"}`},
+	{name: "cat1/selector_empty", logql: `{job="missing"}`},
+
+	// CAT2: positive, negative, regex, and chained line filters.
+	{name: "cat2/contains", logql: `{job="api"} |= "retry"`},
+	{name: "cat2/not_contains", logql: `{job="api"} != "retry"`},
+	{name: "cat2/regex", logql: `{job="api"} |~ "(timeout|error)"`},
+	{name: "cat2/not_regex", logql: `{job="api"} !~ "timeout"`},
+	{name: "cat2/chained", logql: `{job="api"} |= "retry" != "billing"`},
+
+	// CAT3: post-pipeline stream identity mutation.
+	{name: "cat3/label_format_job", logql: `{job="api"} | label_format workload=job`},
+	{name: "cat3/label_format_service", logql: `{service_name="auth"} | label_format service=service_name`},
+
+	// CAT4: IP filter single address, CIDR, range, and negation.
+	{name: "cat4/ip_single", logql: `{job="api"} |= ip("10.1.2.3")`},
+	{name: "cat4/ip_cidr", logql: `{job="api"} |= ip("10.0.0.0/8")`},
+	{name: "cat4/ip_range", logql: `{job="api"} |= ip("192.168.0.1-192.168.1.255")`},
+	{name: "cat4/ip_not", logql: `{job="api"} != ip("10.0.0.0/8")`},
+
+	// CAT5: pattern filters with leading/trailing captures and negation.
+	{name: "cat5/pattern_surrounded", logql: `{job="api"} |> "<_>timeout<_>"`},
+	{name: "cat5/pattern_prefix", logql: `{job="api"} |> "auth<_>"`},
+	{name: "cat5/pattern_suffix", logql: `{job="api"} |> "<_>retry"`},
+	{name: "cat5/pattern_not", logql: `{job="api"} !> "<_>timeout<_>"`},
+}

--- a/test/integration/logql/seed.go
+++ b/test/integration/logql/seed.go
@@ -18,14 +18,28 @@ var seedAnchor = time.Date(2026, 5, 13, 12, 0, 0, 0, time.UTC)
 // matrix category has both accepting and rejecting records.
 func RichSeed() (string, *property.LogsModel) {
 	records := []property.LogRecord{
-		logRecord(0, "INFO", "request ok cache hit 10.1.2.3", labels("job", "api", "service_name", "checkout"), labels("trace.id", "t-1")),
-		logRecord(1, "WARN", "request timeout retry 10.200.0.9", labels("job", "api", "service_name", "checkout"), labels("level", "ERR", "trace.id", "t-2")),
-		logRecord(2, "ERROR", "auth error retry 192.168.1.5", labels("job", "api", "service_name", "auth"), labels("detected_level", "Warn", "tenant", "blue")),
-		logRecord(3, "DEBUG", "cache miss ok 172.16.0.1", labels("job", "web", "service_name", "checkout"), labels("log.level", "debug", "tenant", "green")),
-		logRecord(4, "", "billing error timeout 8.8.8.8", labels("job", "batch", "service_name", "billing"), labels("severity", "critical")),
-		logRecord(5, "INFO", "request ok cache miss", labels("job", "web", "service_name", "auth"), nil),
-		logRecord(6, "ERROR", "auth timeout from 10.1.2.3 retry", labels("job", "api", "service_name", "auth"), labels("severity_text", "fatal", "tenant", "blue")),
-		logRecord(7, "", "worker heartbeat ok", labels("job", "batch", "service_name", "billing"), nil),
+		logRecord(0, "INFO", "request ok cache hit 10.1.2.3",
+			map[string]string{"job": "api", "service_name": "checkout"},
+			map[string]string{"trace.id": "t-1"}),
+		logRecord(1, "WARN", "request timeout retry 10.200.0.9",
+			map[string]string{"job": "api", "service_name": "checkout"},
+			map[string]string{"level": "ERR", "trace.id": "t-2"}),
+		logRecord(2, "ERROR", "auth error retry 192.168.1.5",
+			map[string]string{"job": "api", "service_name": "auth"},
+			map[string]string{"detected_level": "Warn", "tenant": "blue"}),
+		logRecord(3, "DEBUG", "cache miss ok 172.16.0.1",
+			map[string]string{"job": "web", "service_name": "checkout"},
+			map[string]string{"log.level": "debug", "tenant": "green"}),
+		logRecord(4, "", "billing error timeout 8.8.8.8",
+			map[string]string{"job": "batch", "service_name": "billing"},
+			map[string]string{"severity": "critical"}),
+		logRecord(5, "INFO", "request ok cache miss",
+			map[string]string{"job": "web", "service_name": "auth"}, nil),
+		logRecord(6, "ERROR", "auth timeout from 10.1.2.3 retry",
+			map[string]string{"job": "api", "service_name": "auth"},
+			map[string]string{"severity_text": "fatal", "tenant": "blue"}),
+		logRecord(7, "", "worker heartbeat ok",
+			map[string]string{"job": "batch", "service_name": "billing"}, nil),
 	}
 	return renderDDL(records), &property.LogsModel{Records: records}
 }
@@ -38,14 +52,6 @@ func logRecord(step int, severity, body string, resource, attrs map[string]strin
 		LogAttributes:      attrs,
 		TimestampNanos:     seedAnchor.Add(time.Duration(step) * 15 * time.Second).UnixNano(),
 	}
-}
-
-func labels(kv ...string) map[string]string {
-	out := make(map[string]string, len(kv)/2)
-	for i := 0; i < len(kv); i += 2 {
-		out[kv[i]] = kv[i+1]
-	}
-	return out
 }
 
 func renderDDL(records []property.LogRecord) string {

--- a/test/integration/logql/seed.go
+++ b/test/integration/logql/seed.go
@@ -1,0 +1,116 @@
+//go:build chdb_agpl_oracle
+
+package logql
+
+import (
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/tsouza/cerberus/test/property"
+)
+
+var seedAnchor = time.Date(2026, 5, 13, 12, 0, 0, 0, time.UTC)
+
+// RichSeed returns one deterministic OTel logs fixture and its independent
+// in-memory mirror. The rows intentionally overlap on stream labels while
+// varying bodies, structured metadata, severity, and IP tokens so every
+// matrix category has both accepting and rejecting records.
+func RichSeed() (string, *property.LogsModel) {
+	records := []property.LogRecord{
+		logRecord(0, "INFO", "request ok cache hit 10.1.2.3", labels("job", "api", "service_name", "checkout"), labels("trace.id", "t-1")),
+		logRecord(1, "WARN", "request timeout retry 10.200.0.9", labels("job", "api", "service_name", "checkout"), labels("level", "ERR", "trace.id", "t-2")),
+		logRecord(2, "ERROR", "auth error retry 192.168.1.5", labels("job", "api", "service_name", "auth"), labels("detected_level", "Warn", "tenant", "blue")),
+		logRecord(3, "DEBUG", "cache miss ok 172.16.0.1", labels("job", "web", "service_name", "checkout"), labels("log.level", "debug", "tenant", "green")),
+		logRecord(4, "", "billing error timeout 8.8.8.8", labels("job", "batch", "service_name", "billing"), labels("severity", "critical")),
+		logRecord(5, "INFO", "request ok cache miss", labels("job", "web", "service_name", "auth"), nil),
+		logRecord(6, "ERROR", "auth timeout from 10.1.2.3 retry", labels("job", "api", "service_name", "auth"), labels("severity_text", "fatal", "tenant", "blue")),
+		logRecord(7, "", "worker heartbeat ok", labels("job", "batch", "service_name", "billing"), nil),
+	}
+	return renderDDL(records), &property.LogsModel{Records: records}
+}
+
+func logRecord(step int, severity, body string, resource, attrs map[string]string) property.LogRecord {
+	return property.LogRecord{
+		Body:               body,
+		SeverityText:       severity,
+		ResourceAttributes: resource,
+		LogAttributes:      attrs,
+		TimestampNanos:     seedAnchor.Add(time.Duration(step) * 15 * time.Second).UnixNano(),
+	}
+}
+
+func labels(kv ...string) map[string]string {
+	out := make(map[string]string, len(kv)/2)
+	for i := 0; i < len(kv); i += 2 {
+		out[kv[i]] = kv[i+1]
+	}
+	return out
+}
+
+func renderDDL(records []property.LogRecord) string {
+	var b strings.Builder
+	b.WriteString(`CREATE OR REPLACE TABLE otel_logs (
+    Timestamp DateTime64(9),
+    SeverityText LowCardinality(String),
+    SeverityNumber UInt8 DEFAULT 0,
+    Body String,
+    ResourceAttributes Map(LowCardinality(String), String),
+    LogAttributes Map(String, String),
+    ServiceName LowCardinality(String) DEFAULT '',
+    ScopeName String DEFAULT '',
+    ScopeVersion String DEFAULT '',
+    EventName LowCardinality(String) DEFAULT '',
+    TraceId String DEFAULT '',
+    SpanId String DEFAULT '',
+    TraceFlags UInt8 DEFAULT 0
+) ENGINE = MergeTree ORDER BY Timestamp;
+INSERT INTO otel_logs (Timestamp, SeverityText, Body, ResourceAttributes, LogAttributes) VALUES `)
+	for i, record := range records {
+		if i > 0 {
+			b.WriteString(", ")
+		}
+		b.WriteString("(toDateTime64('")
+		b.WriteString(time.Unix(0, record.TimestampNanos).UTC().Format("2006-01-02 15:04:05.000"))
+		b.WriteString("', 9), '")
+		b.WriteString(escapeSQL(record.SeverityText))
+		b.WriteString("', '")
+		b.WriteString(escapeSQL(record.Body))
+		b.WriteString("', ")
+		b.WriteString(renderMap(record.ResourceAttributes))
+		b.WriteString(", ")
+		b.WriteString(renderMap(record.LogAttributes))
+		b.WriteByte(')')
+	}
+	b.WriteString(";\n")
+	return b.String()
+}
+
+func renderMap(values map[string]string) string {
+	if len(values) == 0 {
+		return "map()"
+	}
+	keys := make([]string, 0, len(values))
+	for key := range values {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	var b strings.Builder
+	b.WriteString("map(")
+	for i, key := range keys {
+		if i > 0 {
+			b.WriteString(", ")
+		}
+		b.WriteByte('\'')
+		b.WriteString(escapeSQL(key))
+		b.WriteString("', '")
+		b.WriteString(escapeSQL(values[key]))
+		b.WriteByte('\'')
+	}
+	b.WriteByte(')')
+	return b.String()
+}
+
+func escapeSQL(value string) string {
+	return strings.ReplaceAll(value, "'", "''")
+}

--- a/test/integration/logql/testmain_test.go
+++ b/test/integration/logql/testmain_test.go
@@ -1,0 +1,16 @@
+package logql
+
+import (
+	"os"
+	"testing"
+
+	"github.com/tsouza/cerberus/internal/chdbsession"
+)
+
+// TestMain closes the process-wide chDB session before the Go runtime tears
+// down libchdb's C++ statics. See test/integration/promql/testmain_test.go.
+func TestMain(m *testing.M) {
+	code := m.Run()
+	chdbsession.CloseForExit()
+	os.Exit(code)
+}

--- a/test/integration/traceql/exotic_test.go
+++ b/test/integration/traceql/exotic_test.go
@@ -1,0 +1,97 @@
+//go:build chdb
+
+package traceql
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/tsouza/cerberus/internal/api/tempo"
+	"github.com/tsouza/cerberus/internal/chclienttest"
+	"github.com/tsouza/cerberus/internal/schema"
+	"github.com/tsouza/cerberus/test/property"
+	oracletraceql "github.com/tsouza/cerberus/test/property/oracle/traceql"
+	"github.com/tsouza/cerberus/test/spec/wire"
+)
+
+const searchWindowMargin = time.Hour
+
+// TestExoticTraceQL is the chDB-backed TraceQL semantic integration suite.
+//
+// It seeds one rich fixed OTel traces fixture into an ephemeral chDB session,
+// mounts the real tempo.Handler, and runs every ExoticMatrix query through
+// both cerberus's parse -> lower -> optimize -> emit -> execute HTTP pipeline
+// and the independent from-scratch property oracle. CompareOutcomes checks
+// the resulting inspected-span multiset exactly.
+//
+// This is orthogonal to TraceQL roundtrip: roundtrip pins self-derived SQL and
+// expected_rows, while this suite computes its expected answer at runtime
+// without GOLDEN_UPDATE and therefore catches semantic pipeline drift.
+func TestExoticTraceQL(t *testing.T) {
+	ddl, model := RichSeed()
+	cli := chclienttest.NewChDB(t)
+	cli.Seed(t, ddl)
+
+	handler := tempo.New(cli, schema.DefaultOTelTraces(), "v1.0.0-integration", nil)
+	mux := http.NewServeMux()
+	handler.Mount(mux)
+	server := httptest.NewServer(mux)
+	t.Cleanup(server.Close)
+
+	dataset := property.Dataset{DDL: ddl, Metrics: model}
+	for _, tc := range ExoticMatrix {
+		t.Run(tc.name, func(t *testing.T) {
+			query := property.Query{String: tc.traceql, EvalTs: seedAnchor.Add(searchWindowMargin).Unix()}
+			want := oracletraceql.Evaluate(dataset, query)
+			if want.Err != nil {
+				t.Fatalf("matrix contains unsupported oracle query %q: %v", query.String, want.Err)
+			}
+			got := runSearch(t.Context(), server.URL, query)
+			if diff := property.CompareOutcomes(want, got); diff != "" {
+				t.Fatalf("exotic drift\n--- query ---\n%s\n--- diff (want=oracle got=cerberus) ---\n%s", query.String, diff)
+			}
+		})
+	}
+}
+
+func runSearch(ctx context.Context, baseURL string, query property.Query) property.Outcome {
+	start := seedAnchor.Add(-searchWindowMargin).Unix()
+	end := seedAnchor.Add(searchWindowMargin).Unix()
+	url := fmt.Sprintf("%s/api/search?q=%s&start=%d&end=%d", baseURL, wire.EscapeQuery(query.String, ""), start, end)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return property.Outcome{Err: fmt.Errorf("build request: %w", err)}
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return property.Outcome{Err: fmt.Errorf("query roundtrip: %w", err)}
+	}
+	defer func() { _ = resp.Body.Close() }()
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return property.Outcome{Err: fmt.Errorf("read body: %w", err)}
+	}
+	if resp.StatusCode != http.StatusOK {
+		return property.Outcome{Err: fmt.Errorf("cerberus returned status=%d body=%s", resp.StatusCode, body)}
+	}
+	var parsed tempo.SearchResponse
+	if err := json.Unmarshal(body, &parsed); err != nil {
+		return property.Outcome{Err: fmt.Errorf("decode body: %w; status=%d body=%s", err, resp.StatusCode, body)}
+	}
+	inspectedSpans, err := strconv.Atoi(resp.Header.Get(tempo.HeaderInspectedSpans))
+	if err != nil {
+		return property.Outcome{Err: fmt.Errorf("%s header %q: %w", tempo.HeaderInspectedSpans, resp.Header.Get(tempo.HeaderInspectedSpans), err)}
+	}
+	rows := make([]property.OutcomeRow, 0, inspectedSpans)
+	for range inspectedSpans {
+		rows = append(rows, property.OutcomeRow{Labels: map[string]string{}})
+	}
+	return property.Outcome{Rows: rows}
+}

--- a/test/integration/traceql/matrix.go
+++ b/test/integration/traceql/matrix.go
@@ -1,0 +1,50 @@
+//go:build chdb
+
+package traceql
+
+type exoticCase struct {
+	name    string
+	traceql string
+}
+
+// ExoticMatrix covers every query family the independent TraceQL oracle
+// evaluates, with explicit empty and boundary cases alongside positive ones.
+var ExoticMatrix = []exoticCase{
+	// CAT1: resource and span attribute selectors.
+	{name: "cat1/service", traceql: `{ resource.service.name = "api" }`},
+	{name: "cat1/cluster", traceql: `{ resource.cluster = "east" }`},
+	{name: "cat1/span_method", traceql: `{ span.http.method = "POST" }`},
+	{name: "cat1/empty", traceql: `{ resource.service.name = "missing" }`},
+
+	// CAT2: matcher variants and conjunction.
+	{name: "cat2/regex", traceql: `{ resource.service.name =~ "a.*" }`},
+	{name: "cat2/not_regex", traceql: `{ resource.service.name !~ "web" }`},
+	{name: "cat2/not_equal", traceql: `{ resource.cluster != "west" }`},
+	{name: "cat2/conjunction", traceql: `{ resource.service.name = "api" && status = error }`},
+
+	// CAT3: intrinsic filters and exact boundaries.
+	{name: "cat3/duration_gt", traceql: `{ duration > 50ms }`},
+	{name: "cat3/duration_equal", traceql: `{ duration = 120ms }`},
+	{name: "cat3/status", traceql: `{ status = error }`},
+	{name: "cat3/status_not", traceql: `{ status != unset }`},
+	{name: "cat3/name", traceql: `{ name = "GET /checkout/0" }`},
+
+	// CAT4: immediate-child versus any-depth descendant semantics.
+	{name: "cat4/child", traceql: `{ resource.service.name = "api" } > { resource.service.name = "web" }`},
+	{name: "cat4/descendant", traceql: `{ resource.service.name = "api" } >> { resource.service.name = "batch" }`},
+	{name: "cat4/structural_empty", traceql: `{ resource.service.name = "batch" } > { resource.service.name = "api" }`},
+
+	// CAT5: trace-scoped count filters, including equality and ceiling.
+	{name: "cat5/count_gt", traceql: `{ resource.service.name = "api" } | count() > 1`},
+	{name: "cat5/count_equal", traceql: `{ resource.service.name = "web" } | count() = 2`},
+	{name: "cat5/count_empty", traceql: `{ resource.service.name = "api" } | count() > 3`},
+
+	// CAT6: duration reducers across the matching spans of each trace.
+	{name: "cat6/avg", traceql: `{ resource.service.name = "api" } | avg(duration) > 100ms`},
+	{name: "cat6/min", traceql: `{ resource.service.name = "web" } | min(duration) = 10ms`},
+	{name: "cat6/max", traceql: `{ resource.service.name = "web" } | max(duration) >= 120ms`},
+	{name: "cat6/sum", traceql: `{ resource.service.name = "batch" } | sum(duration) >= 300ms`},
+
+	// CAT7: projection preserves the selected spanset cardinality.
+	{name: "cat7/select", traceql: `{ resource.service.name = "api" } | select(span.http.method)`},
+}

--- a/test/integration/traceql/seed.go
+++ b/test/integration/traceql/seed.go
@@ -1,0 +1,137 @@
+//go:build chdb
+
+package traceql
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/tsouza/cerberus/test/property"
+)
+
+var seedAnchor = time.Date(2026, 5, 13, 12, 0, 0, 0, time.UTC)
+
+const rootParentID = "0000000000000000"
+
+type spanSeed struct {
+	traceID    string
+	spanID     string
+	parentID   string
+	service    string
+	cluster    string
+	httpMethod string
+	name       string
+	startTime  time.Time
+	durationNs int64
+	statusCode string
+}
+
+// RichSeed returns a fixed OTel traces fixture with three traces and multiple
+// parent chains. Its service, cluster, method, duration, and status spread
+// gives selectors and per-trace aggregations non-trivial positive, negative,
+// and boundary answers; the chains make child and descendant differ.
+func RichSeed() (string, *property.MetricsModel) {
+	spans := []spanSeed{
+		span(0, "11111111111111111111111111111111", "1111111111111111", rootParentID, "api", "east", "GET", "GET /checkout/0", 10, "Ok"),
+		span(1, "11111111111111111111111111111111", "1111111111111112", "1111111111111111", "web", "east", "POST", "POST /checkout/1", 120, "Error"),
+		span(2, "11111111111111111111111111111111", "1111111111111113", "1111111111111112", "batch", "west", "PUT", "PUT /worker/2", 300, "Unset"),
+		span(3, "22222222222222222222222222222222", "2222222222222221", rootParentID, "api", "west", "POST", "POST /auth/3", 50, "Error"),
+		span(4, "22222222222222222222222222222222", "2222222222222222", "2222222222222221", "api", "west", "GET", "GET /auth/4", 300, "Ok"),
+		span(5, "33333333333333333333333333333333", "3333333333333331", rootParentID, "web", "east", "PUT", "PUT /billing/5", 120, "Unset"),
+		span(6, "33333333333333333333333333333333", "3333333333333332", "3333333333333331", "batch", "east", "GET", "GET /billing/6", 50, "Error"),
+		span(7, "33333333333333333333333333333333", "3333333333333333", "3333333333333332", "web", "west", "POST", "POST /billing/7", 10, "Ok"),
+	}
+	return renderDDL(spans), spansModel(spans)
+}
+
+func span(step int, traceID, spanID, parentID, service, cluster, method, name string, durationMs int64, status string) spanSeed {
+	return spanSeed{
+		traceID: traceID, spanID: spanID, parentID: parentID,
+		service: service, cluster: cluster, httpMethod: method, name: name,
+		startTime:  seedAnchor.Add(time.Duration(step) * time.Second),
+		durationNs: durationMs * int64(time.Millisecond), statusCode: status,
+	}
+}
+
+func spansModel(spans []spanSeed) *property.MetricsModel {
+	series := make([]property.SeriesData, 0, len(spans))
+	for _, item := range spans {
+		series = append(series, property.SeriesData{
+			MetricName: item.name,
+			Labels: map[string]string{
+				"resource.service.name": item.service,
+				"resource.cluster":      item.cluster,
+				"span.http.method":      item.httpMethod,
+				"__name__":              item.name,
+				"__traceID__":           item.traceID,
+				"__spanID__":            item.spanID,
+				"__parentSpanID__":      item.parentID,
+				"__duration_ns__":       fmt.Sprintf("%d", item.durationNs),
+				"__status__":            item.statusCode,
+			},
+			Points: []property.Point{{TimestampMs: item.startTime.UnixMilli(), Value: float64(item.durationNs)}},
+		})
+	}
+	return &property.MetricsModel{Series: series}
+}
+
+func renderDDL(spans []spanSeed) string {
+	var b strings.Builder
+	b.WriteString(`CREATE OR REPLACE TABLE otel_traces (
+    Timestamp DateTime64(9),
+    TraceId String,
+    SpanId String,
+    ParentSpanId String,
+    SpanName String,
+    SpanKind LowCardinality(String),
+    ServiceName LowCardinality(String),
+    ResourceAttributes Map(String, String),
+    SpanAttributes Map(String, String),
+    Duration Int64,
+    StatusCode LowCardinality(String),
+    StatusMessage String,
+    ScopeName String,
+    ScopeVersion String
+) ENGINE = MergeTree ORDER BY (Timestamp, TraceId);
+INSERT INTO otel_traces VALUES `)
+	for i, item := range spans {
+		if i > 0 {
+			b.WriteString(", ")
+		}
+		fmt.Fprintf(&b, "(toDateTime64('%s', 9), %s, %s, %s, %s, 'Internal', %s, %s, %s, %d, %s, '', '', '')",
+			item.startTime.UTC().Format("2006-01-02 15:04:05.000"),
+			quoteSQL(item.traceID), quoteSQL(item.spanID), quoteSQL(item.parentID),
+			quoteSQL(item.name), quoteSQL(item.service),
+			renderMap(map[string]string{"service.name": item.service, "cluster": item.cluster}),
+			renderMap(map[string]string{"http.method": item.httpMethod}),
+			item.durationNs, quoteSQL(item.statusCode))
+	}
+	b.WriteString(";\n")
+	return b.String()
+}
+
+func renderMap(values map[string]string) string {
+	keys := make([]string, 0, len(values))
+	for key := range values {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	var b strings.Builder
+	b.WriteString("map(")
+	for i, key := range keys {
+		if i > 0 {
+			b.WriteString(", ")
+		}
+		b.WriteString(quoteSQL(key))
+		b.WriteString(", ")
+		b.WriteString(quoteSQL(values[key]))
+	}
+	b.WriteByte(')')
+	return b.String()
+}
+
+func quoteSQL(value string) string {
+	return "'" + strings.ReplaceAll(strings.ReplaceAll(value, "\\", "\\\\"), "'", "\\'") + "'"
+}

--- a/test/integration/traceql/testmain_test.go
+++ b/test/integration/traceql/testmain_test.go
@@ -1,0 +1,16 @@
+package traceql
+
+import (
+	"os"
+	"testing"
+
+	"github.com/tsouza/cerberus/internal/chdbsession"
+)
+
+// TestMain closes the process-wide chDB session before the Go runtime tears
+// down libchdb's C++ statics. See test/integration/promql/testmain_test.go.
+func TestMain(m *testing.M) {
+	code := m.Run()
+	chdbsession.CloseForExit()
+	os.Exit(code)
+}

--- a/test/regression/agpl_oracle_tag_set_test.go
+++ b/test/regression/agpl_oracle_tag_set_test.go
@@ -47,14 +47,15 @@ var agplOracleLanes = []agplOracleLane{
 		},
 	},
 	{
-		// The TraceQL parity runner needs the reference engine AND the
-		// chDB session that holds the seeded spans, so it runs on the
-		// chDB lane's traceql leg rather than in the tag's own lane.
+		// The TraceQL parity runner and fixed LogQL integration suite need
+		// their reference oracles AND a chDB session, so they run in the
+		// chDB workflow rather than in the tag's own lane.
 		workflow: ".github/workflows/chdb.yml",
 		tags:     "chdb,agpl_oracle,chdb_agpl_oracle",
 		scopes: []string{
 			"test/spec/",
 			"internal/traceql/",
+			"test/integration/logql/",
 		},
 	},
 }


### PR DESCRIPTION
## Summary

- add fixed, rich LogQL and TraceQL chDB integration datasets and category matrices
- drive the real Loki and Tempo HTTP handlers against independent property oracles
- add dedicated `integration (logql)` and `integration (traceql)` CI jobs
- preserve the LogQL oracle's established test-only AGPL tag quarantine

## Why

The LogQL and TraceQL heads had round-trip coverage but lacked PromQL's live-pipeline semantic pairing. These suites compute expected outcomes at runtime, so SQL/golden self-consistency cannot hide lowering, optimizer, emitter, or wire drift.

## Validation

- `go test -tags chdb -count=1 -run '^TestExoticTraceQL$' ./test/integration/traceql/...`
- `go test -tags chdb,agpl_oracle,chdb_agpl_oracle -count=1 -run '^TestExoticLogQL$' ./test/integration/logql/...`
- `go test -count=1 -run '^TestAGPLOracleTagSetCoverage$' ./test/regression`
- `just lint-actions`
- `git diff --check`

Closes #2162
