### PR TITLE
fix(perf): count all union arms in cardinality scans

### DIFF
--- a/test/perf/cardinality-baseline/logql/variants_sum_by_and_count.json
+++ b/test/perf/cardinality-baseline/logql/variants_sum_by_and_count.json
@@ -1,7 +1,7 @@
 {
   "fixture": "logql/variants_sum_by_and_count",
-  "fan_factor": 1,
-  "scan_rows": 3,
+  "fan_factor": 0.5,
+  "scan_rows": 6,
   "peak_intermediate": 3,
   "has_cross_join": false,
   "has_array_join": false,

--- a/test/perf/cardinality-baseline/metadata/series_no_bounds.json
+++ b/test/perf/cardinality-baseline/metadata/series_no_bounds.json
@@ -1,8 +1,8 @@
 {
   "fixture": "metadata/series_no_bounds",
-  "fan_factor": 1,
-  "scan_rows": 12,
-  "peak_intermediate": 12,
+  "fan_factor": 0.4,
+  "scan_rows": 600,
+  "peak_intermediate": 240,
   "has_cross_join": false,
   "has_array_join": true,
   "has_recursive_cte": false,

--- a/test/perf/cardinality-baseline/promql/info_ignore_split_unpinned_base.json
+++ b/test/perf/cardinality-baseline/promql/info_ignore_split_unpinned_base.json
@@ -1,7 +1,7 @@
 {
   "fixture": "promql/info_ignore_split_unpinned_base",
-  "fan_factor": 1,
-  "scan_rows": 2,
+  "fan_factor": 0.5,
+  "scan_rows": 4,
   "peak_intermediate": 2,
   "has_cross_join": false,
   "has_array_join": true,

--- a/test/perf/cardinality-baseline/promql/label_replace_over_native_rate_range_step.json
+++ b/test/perf/cardinality-baseline/promql/label_replace_over_native_rate_range_step.json
@@ -1,7 +1,7 @@
 {
   "fixture": "promql/label_replace_over_native_rate_range_step",
-  "fan_factor": 1,
-  "scan_rows": 18,
+  "fan_factor": 0.75,
+  "scan_rows": 24,
   "peak_intermediate": 18,
   "has_cross_join": false,
   "has_array_join": true,

--- a/test/perf/cardinality-baseline/promql/native_rate_join_range_step.json
+++ b/test/perf/cardinality-baseline/promql/native_rate_join_range_step.json
@@ -1,8 +1,8 @@
 {
   "fixture": "promql/native_rate_join_range_step",
-  "fan_factor": 1,
-  "scan_rows": 5,
-  "peak_intermediate": 5,
+  "fan_factor": 0.5,
+  "scan_rows": 12,
+  "peak_intermediate": 6,
   "has_cross_join": false,
   "has_array_join": true,
   "has_recursive_cte": false,

--- a/test/perf/cardinality-baseline/promql/native_rate_range_step.json
+++ b/test/perf/cardinality-baseline/promql/native_rate_range_step.json
@@ -1,7 +1,7 @@
 {
   "fixture": "promql/native_rate_range_step",
-  "fan_factor": 1,
-  "scan_rows": 18,
+  "fan_factor": 0.75,
+  "scan_rows": 24,
   "peak_intermediate": 18,
   "has_cross_join": false,
   "has_array_join": true,

--- a/test/perf/cardinality-baseline/promql/native_rate_recollapse_collision.json
+++ b/test/perf/cardinality-baseline/promql/native_rate_recollapse_collision.json
@@ -1,7 +1,7 @@
 {
   "fixture": "promql/native_rate_recollapse_collision",
-  "fan_factor": 1,
-  "scan_rows": 9,
+  "fan_factor": 0.75,
+  "scan_rows": 12,
   "peak_intermediate": 9,
   "has_cross_join": false,
   "has_array_join": true,

--- a/test/perf/cardinality-baseline/promql/native_rate_recollapse_collision_two_level.json
+++ b/test/perf/cardinality-baseline/promql/native_rate_recollapse_collision_two_level.json
@@ -1,7 +1,7 @@
 {
   "fixture": "promql/native_rate_recollapse_collision_two_level",
-  "fan_factor": 1,
-  "scan_rows": 9,
+  "fan_factor": 0.75,
+  "scan_rows": 12,
   "peak_intermediate": 9,
   "has_cross_join": false,
   "has_array_join": true,

--- a/test/perf/cardinality-baseline/promql/native_rate_recollapse_metric_name_isolation.json
+++ b/test/perf/cardinality-baseline/promql/native_rate_recollapse_metric_name_isolation.json
@@ -1,7 +1,7 @@
 {
   "fixture": "promql/native_rate_recollapse_metric_name_isolation",
-  "fan_factor": 1,
-  "scan_rows": 9,
+  "fan_factor": 0.75,
+  "scan_rows": 12,
   "peak_intermediate": 9,
   "has_cross_join": false,
   "has_array_join": true,

--- a/test/perf/cardinality-baseline/promql/native_rate_recollapse_range_step.json
+++ b/test/perf/cardinality-baseline/promql/native_rate_recollapse_range_step.json
@@ -1,7 +1,7 @@
 {
   "fixture": "promql/native_rate_recollapse_range_step",
-  "fan_factor": 1,
-  "scan_rows": 18,
+  "fan_factor": 0.75,
+  "scan_rows": 24,
   "peak_intermediate": 18,
   "has_cross_join": false,
   "has_array_join": true,

--- a/test/perf/cardinality-baseline/promql/native_rate_temporality_cumulative.json
+++ b/test/perf/cardinality-baseline/promql/native_rate_temporality_cumulative.json
@@ -1,7 +1,7 @@
 {
   "fixture": "promql/native_rate_temporality_cumulative",
-  "fan_factor": 1,
-  "scan_rows": 9,
+  "fan_factor": 0.75,
+  "scan_rows": 12,
   "peak_intermediate": 9,
   "has_cross_join": false,
   "has_array_join": true,

--- a/test/perf/cardinality-baseline/promql/native_rate_temporality_delta.json
+++ b/test/perf/cardinality-baseline/promql/native_rate_temporality_delta.json
@@ -1,8 +1,8 @@
 {
   "fixture": "promql/native_rate_temporality_delta",
-  "fan_factor": 1,
-  "scan_rows": 9,
-  "peak_intermediate": 9,
+  "fan_factor": 2.9166666666666665,
+  "scan_rows": 12,
+  "peak_intermediate": 35,
   "has_cross_join": false,
   "has_array_join": true,
   "has_recursive_cte": false,

--- a/test/perf/cardinality-baseline/promql/native_rate_temporality_mixed.json
+++ b/test/perf/cardinality-baseline/promql/native_rate_temporality_mixed.json
@@ -1,8 +1,8 @@
 {
   "fixture": "promql/native_rate_temporality_mixed",
-  "fan_factor": 1,
-  "scan_rows": 18,
-  "peak_intermediate": 18,
+  "fan_factor": 1.4583333333333333,
+  "scan_rows": 24,
+  "peak_intermediate": 35,
   "has_cross_join": false,
   "has_array_join": true,
   "has_recursive_cte": false,

--- a/test/perf/cardinality-baseline/promql/no_name_matcher_reaches_histogram_tables.json
+++ b/test/perf/cardinality-baseline/promql/no_name_matcher_reaches_histogram_tables.json
@@ -1,7 +1,7 @@
 {
   "fixture": "promql/no_name_matcher_reaches_histogram_tables",
-  "fan_factor": 1,
-  "scan_rows": 5,
+  "fan_factor": 1.25,
+  "scan_rows": 4,
   "peak_intermediate": 5,
   "has_cross_join": false,
   "has_array_join": true,

--- a/test/perf/cardinality-baseline/promql/regex_name_matcher_scans_exp_histogram_table.json
+++ b/test/perf/cardinality-baseline/promql/regex_name_matcher_scans_exp_histogram_table.json
@@ -1,7 +1,7 @@
 {
   "fixture": "promql/regex_name_matcher_scans_exp_histogram_table",
-  "fan_factor": 1,
-  "scan_rows": 6,
+  "fan_factor": 1.2,
+  "scan_rows": 5,
   "peak_intermediate": 6,
   "has_cross_join": false,
   "has_array_join": true,

--- a/test/perf/cardinality-baseline/promql/subquery_last_over_time_histogram_fanout_name.json
+++ b/test/perf/cardinality-baseline/promql/subquery_last_over_time_histogram_fanout_name.json
@@ -1,7 +1,7 @@
 {
   "fixture": "promql/subquery_last_over_time_histogram_fanout_name",
-  "fan_factor": 3,
-  "scan_rows": 8,
+  "fan_factor": 4,
+  "scan_rows": 6,
   "peak_intermediate": 24,
   "has_cross_join": false,
   "has_array_join": true,

--- a/test/perf/cardinality-baseline/traceql/set_union_mixed_granularity.json
+++ b/test/perf/cardinality-baseline/traceql/set_union_mixed_granularity.json
@@ -1,7 +1,7 @@
 {
   "fixture": "traceql/set_union_mixed_granularity",
-  "fan_factor": 1,
-  "scan_rows": 3,
+  "fan_factor": 0.75,
+  "scan_rows": 4,
   "peak_intermediate": 3,
   "has_cross_join": false,
   "has_array_join": false,

--- a/test/perf/cardinality-baseline/traceql/structural_union_child.json
+++ b/test/perf/cardinality-baseline/traceql/structural_union_child.json
@@ -1,7 +1,7 @@
 {
   "fixture": "traceql/structural_union_child",
-  "fan_factor": 1,
-  "scan_rows": 2,
+  "fan_factor": 0.5,
+  "scan_rows": 4,
   "peak_intermediate": 2,
   "has_cross_join": false,
   "has_array_join": false,

--- a/test/perf/cardinality-baseline/traceql/structural_union_child_dup_key_order.json
+++ b/test/perf/cardinality-baseline/traceql/structural_union_child_dup_key_order.json
@@ -1,7 +1,7 @@
 {
   "fixture": "traceql/structural_union_child_dup_key_order",
-  "fan_factor": 1,
-  "scan_rows": 8,
+  "fan_factor": 2,
+  "scan_rows": 4,
   "peak_intermediate": 8,
   "has_cross_join": false,
   "has_array_join": false,

--- a/test/perf/cardinality-baseline/traceql/structural_union_descendant.json
+++ b/test/perf/cardinality-baseline/traceql/structural_union_descendant.json
@@ -1,7 +1,7 @@
 {
   "fixture": "traceql/structural_union_descendant",
   "fan_factor": null,
-  "scan_rows": 2,
+  "scan_rows": 3,
   "peak_intermediate": 2,
   "has_cross_join": false,
   "has_array_join": false,

--- a/test/perf/cardinality-baseline/traceql/structural_union_sibling.json
+++ b/test/perf/cardinality-baseline/traceql/structural_union_sibling.json
@@ -1,7 +1,7 @@
 {
   "fixture": "traceql/structural_union_sibling",
-  "fan_factor": 1,
-  "scan_rows": 2,
+  "fan_factor": 0.5,
+  "scan_rows": 4,
   "peak_intermediate": 2,
   "has_cross_join": false,
   "has_array_join": false,

--- a/test/perf/cardinality-baseline/traceql/structural_union_sibling_dup_key_order.json
+++ b/test/perf/cardinality-baseline/traceql/structural_union_sibling_dup_key_order.json
@@ -1,7 +1,7 @@
 {
   "fixture": "traceql/structural_union_sibling_dup_key_order",
-  "fan_factor": 1,
-  "scan_rows": 8,
+  "fan_factor": 2,
+  "scan_rows": 4,
   "peak_intermediate": 8,
   "has_cross_join": false,
   "has_array_join": false,

--- a/test/perf/cardinality-baseline/traceql/structure_tab_no_nested_set_select.json
+++ b/test/perf/cardinality-baseline/traceql/structure_tab_no_nested_set_select.json
@@ -1,7 +1,7 @@
 {
   "fixture": "traceql/structure_tab_no_nested_set_select",
   "fan_factor": null,
-  "scan_rows": 10,
+  "scan_rows": 13,
   "peak_intermediate": 10,
   "has_cross_join": false,
   "has_array_join": false,

--- a/test/perf/cardinality-baseline/traceql/structure_tab_no_union_select_parent.json
+++ b/test/perf/cardinality-baseline/traceql/structure_tab_no_union_select_parent.json
@@ -1,7 +1,7 @@
 {
   "fixture": "traceql/structure_tab_no_union_select_parent",
   "fan_factor": null,
-  "scan_rows": 6,
+  "scan_rows": 8,
   "peak_intermediate": 6,
   "has_cross_join": false,
   "has_array_join": true,

--- a/test/perf/cardinality-baseline/traceql/structure_tab_signal_kind_server_select_parent.json
+++ b/test/perf/cardinality-baseline/traceql/structure_tab_signal_kind_server_select_parent.json
@@ -1,7 +1,7 @@
 {
   "fixture": "traceql/structure_tab_signal_kind_server_select_parent",
   "fan_factor": null,
-  "scan_rows": 8,
+  "scan_rows": 9,
   "peak_intermediate": 8,
   "has_cross_join": false,
   "has_array_join": true,

--- a/test/perf/cardinality-baseline/traceql/structure_tab_signal_true_select_left.json
+++ b/test/perf/cardinality-baseline/traceql/structure_tab_signal_true_select_left.json
@@ -1,7 +1,7 @@
 {
   "fixture": "traceql/structure_tab_signal_true_select_left",
   "fan_factor": null,
-  "scan_rows": 10,
+  "scan_rows": 13,
   "peak_intermediate": 10,
   "has_cross_join": false,
   "has_array_join": true,

--- a/test/perf/cardinality-baseline/traceql/structure_tab_signal_true_select_parent.json
+++ b/test/perf/cardinality-baseline/traceql/structure_tab_signal_true_select_parent.json
@@ -1,7 +1,7 @@
 {
   "fixture": "traceql/structure_tab_signal_true_select_parent",
   "fan_factor": null,
-  "scan_rows": 10,
+  "scan_rows": 13,
   "peak_intermediate": 10,
   "has_cross_join": false,
   "has_array_join": true,

--- a/test/perf/cardinality-baseline/traceql/structure_tab_signal_true_select_status_parent.json
+++ b/test/perf/cardinality-baseline/traceql/structure_tab_signal_true_select_status_parent.json
@@ -1,7 +1,7 @@
 {
   "fixture": "traceql/structure_tab_signal_true_select_status_parent",
   "fan_factor": null,
-  "scan_rows": 10,
+  "scan_rows": 13,
   "peak_intermediate": 10,
   "has_cross_join": false,
   "has_array_join": true,

--- a/test/perf/profile/profile.go
+++ b/test/perf/profile/profile.go
@@ -66,9 +66,10 @@ type Record struct {
 	// test/spec/.
 	Fixture string `json:"fixture"`
 
-	// ScanRows is the row count of the deepest (leaf) FROM-source
-	// subquery level — the rows actually read off the seeded tables
-	// before any fan-out stage. The fan-out denominator.
+	// ScanRows is the sum of the deepest (leaf) FROM-source subquery level
+	// in every scan pipeline — the rows actually read off the seeded tables
+	// before any fan-out stage. A UNION ALL contributes one leaf per arm.
+	// The fan-out denominator.
 	ScanRows int64 `json:"scan_rows"`
 
 	// PeakIntermediate is the maximum count() over every non-aggregating
@@ -293,17 +294,17 @@ func (p *Profiler) ProfileFixture(fixtureID string, prep *spec.PreparedRoundTrip
 	// through — see that function's doc for why a RECURSIVE CTE is
 	// handled separately, below, from the structural EXPLAIN flag
 	// instead.
-	levels, descentReasons := levelsWithReasons(query)
-	rec.UncountableReasons = append(rec.UncountableReasons, descentReasons...)
+	decomposition := decomposeQuery(query, 0)
+	rec.UncountableReasons = append(rec.UncountableReasons, decomposition.reasons...)
 	if rec.HasRecursiveCTE {
 		rec.UncountableReasons = append(rec.UncountableReasons, recursiveCTEUncountableReason)
 	}
 
-	rec.Levels = make([]LevelCount, 0, len(levels))
+	rec.Levels = make([]LevelCount, 0, len(decomposition.levels))
 	var peak int64
 	var peakBytes uint64
-	for depth, lvl := range levels {
-		c, br, err := p.scalarCount(lvl)
+	for _, level := range decomposition.levels {
+		c, br, err := p.scalarCount(level.query)
 		if err != nil {
 			// A level that can't be counted in isolation (e.g. it
 			// references a name only in scope at an outer level) is
@@ -313,10 +314,16 @@ func (p *Profiler) ProfileFixture(fixtureID string, prep *spec.PreparedRoundTrip
 			// stage's contribution to PeakIntermediate is unknown rather
 			// than silently treated as zero.
 			rec.UncountableReasons = append(rec.UncountableReasons,
-				fmt.Sprintf("depth %d: count() failed in isolation: %v", depth, err))
+				fmt.Sprintf("depth %d: count() failed in isolation: %v", level.depth, err))
 			continue
 		}
-		rec.Levels = append(rec.Levels, LevelCount{Depth: depth, Count: c})
+		rec.Levels = append(rec.Levels, LevelCount{Depth: level.depth, Count: c})
+		if level.depth == 0 {
+			rec.ResultRows = c
+		}
+		if level.scanSource {
+			rec.ScanRows += c
+		}
 		if c > peak {
 			peak = c
 		}
@@ -326,13 +333,6 @@ func (p *Profiler) ProfileFixture(fixtureID string, prep *spec.PreparedRoundTrip
 	}
 	rec.PeakIntermediate = peak
 	rec.PeakBytesRead = peakBytes
-
-	// scan_rows is the deepest level we could count (the leaf FROM
-	// source). result_rows is the outermost (depth 0).
-	if len(rec.Levels) > 0 {
-		rec.ScanRows = rec.Levels[len(rec.Levels)-1].Count
-		rec.ResultRows = rec.Levels[0].Count
-	}
 
 	rec.UncountableLevels = len(rec.UncountableReasons)
 	// FanFactor stays nil whenever any level was opaque: a fabricated

--- a/test/perf/profile/sql.go
+++ b/test/perf/profile/sql.go
@@ -36,19 +36,19 @@ func planHasRecursiveCTE(plan string) bool {
 // level, OUTERMOST FIRST, so callers can run `count() FROM (<level>)` per
 // level to build the intermediate-cardinality decomposition. Depth 0 is
 // the full query; each subsequent entry strips one layer of `SELECT ...
-// FROM (<inner>) ...` nesting, descending the leftmost FROM-source chain
-// down to the leaf scan.
+// FROM (<inner>) ...` nesting, descending through every UNION ALL arm and
+// down to each leaf scan.
 //
-// Only the LEFTMOST FROM source is descended at each level — the common
+// The LEFTMOST FROM source is descended at each ordinary level — the common
 // fan-out shape in cerberus's emitted SQL is a straight nest of
 // `SELECT ... FROM (SELECT ... FROM (... merge(...)))`, where each layer
 // is the Project / Aggregate / Filter / RangeWindow stage wrapping the
 // one below. A CROSS JOIN / ARRAY JOIN widens the row set WITHIN a level
 // (so its inflated count shows up as that level's count()), which is
-// exactly what we want the per-level count to capture. Branch subqueries
-// (UNION arms, join RHS, scalar/IN subqueries) are not separately
-// descended — the level's own count() already reflects their contribution
-// to that level's row set.
+// exactly what we want the per-level count to capture. UNION ALL is the
+// exception: each arm is a separate scan pipeline, so every arm is descended
+// and its leaf is marked as a scan source. Join RHS and scalar/IN subqueries
+// remain represented only by the level's own count.
 //
 // A WITH-prefixed query (CTE chain, recursive or set-op CSE) is kept
 // intact at depth 0 and not descended, because its inner SELECTs
@@ -82,6 +82,22 @@ func fromSourceLevels(query string) []string {
 	return levels
 }
 
+// queryLevel is one independently countable pipeline level. scanSource marks
+// the leaf of one scan pipeline; a UNION ALL therefore has one scan source per
+// arm, and ProfileFixture sums their counts for its ScanRows denominator.
+type queryLevel struct {
+	query      string
+	depth      int
+	scanSource bool
+}
+
+type queryDecomposition struct {
+	levels  []queryLevel
+	reasons []string
+}
+
+const maxFromSourceDepth = 64
+
 // levelsWithReasons walks the same leftmost FROM-source chain
 // [fromSourceLevels] documents, and ADDITIONALLY reports, as
 // uncountableReasons, every point where the descent had to stop because
@@ -111,44 +127,154 @@ func fromSourceLevels(query string) []string {
 // [subqueryFrag]-family emitters splice into a WITH clause, and once
 // spliced there this function cannot see through it.
 func levelsWithReasons(query string) ([]string, []string) {
+	decomposition := decomposeQuery(query, 0)
+	levels := make([]string, 0, len(decomposition.levels))
+	for _, level := range decomposition.levels {
+		levels = append(levels, level.query)
+	}
+	return levels, decomposition.reasons
+}
+
+func decomposeQuery(query string, depth int) queryDecomposition {
 	query = strings.TrimSpace(query)
-	levels := []string{query}
+	decomposition := queryDecomposition{
+		levels: []queryLevel{{query: query, depth: depth}},
+	}
+	if depth >= maxFromSourceDepth {
+		decomposition.levels[0].scanSource = true
+		return decomposition
+	}
 
 	// A RECURSIVE top-level query: 1 level, no reason (see doc above —
 	// ProfileFixture's HasRecursiveCTE-driven reason covers it).
 	if hasWithRecursivePrefix(query) {
-		return levels, nil
+		decomposition.levels[0].scanSource = true
+		return decomposition
 	}
 	// A non-recursive WITH-prefixed top-level query: 1 level, and a
 	// reason — descending into the CTE bodies would reference
 	// out-of-scope CTE names.
 	if hasWithPrefix(query) {
-		return levels, []string{uncountableCTEReason(0)}
+		decomposition.levels[0].scanSource = true
+		decomposition.reasons = []string{uncountableCTEReason(depth)}
+		return decomposition
 	}
 
-	cur := query
-	// Bound the descent so a pathological input can't loop unboundedly.
-	for i := 0; i < 64; i++ {
-		inner, ok := leftmostFromSubquery(cur)
-		if !ok {
-			break
+	if arms := splitTopLevelUnionAll(query); len(arms) > 1 {
+		for _, arm := range arms {
+			armDecomposition := decomposeQuery(trimEnclosingParens(arm), depth+1)
+			decomposition.levels = append(decomposition.levels, armDecomposition.levels...)
+			decomposition.reasons = append(decomposition.reasons, armDecomposition.reasons...)
 		}
-		inner = strings.TrimSpace(inner)
-		if inner == "" || strings.EqualFold(inner, cur) {
-			break
-		}
-		if hasWithRecursivePrefix(inner) {
-			// Same rationale as the top-level case: no reason here, the
-			// HasRecursiveCTE flag covers it exactly once.
-			break
-		}
-		if hasWithPrefix(inner) {
-			return levels, []string{uncountableCTEReason(len(levels))}
-		}
-		levels = append(levels, inner)
-		cur = inner
+		return decomposition
 	}
-	return levels, nil
+
+	inner, ok := leftmostFromSubquery(query)
+	if !ok {
+		decomposition.levels[0].scanSource = true
+		return decomposition
+	}
+	inner = strings.TrimSpace(inner)
+	if inner == "" || strings.EqualFold(inner, query) {
+		decomposition.levels[0].scanSource = true
+		return decomposition
+	}
+	if hasWithRecursivePrefix(inner) {
+		// Same rationale as the top-level case: no reason here, the
+		// HasRecursiveCTE flag covers it exactly once.
+		decomposition.levels[0].scanSource = true
+		return decomposition
+	}
+	if hasWithPrefix(inner) {
+		decomposition.levels[0].scanSource = true
+		decomposition.reasons = []string{uncountableCTEReason(depth + 1)}
+		return decomposition
+	}
+
+	innerDecomposition := decomposeQuery(inner, depth+1)
+	decomposition.levels = append(decomposition.levels, innerDecomposition.levels...)
+	decomposition.reasons = append(decomposition.reasons, innerDecomposition.reasons...)
+	return decomposition
+}
+
+// splitTopLevelUnionAll splits a UNION ALL chain only at depth zero and
+// outside string literals. A one-element result means query is not a top-level
+// UNION ALL. Cerberus emits UNION arms parenthesised, but accepting bare SELECT
+// arms as well keeps the decomposition faithful to valid ClickHouse SQL.
+func splitTopLevelUnionAll(query string) []string {
+	var arms []string
+	start := 0
+	depth := 0
+	inString := false
+	for i := 0; i < len(query); i++ {
+		if inString {
+			switch query[i] {
+			case '\\':
+				i++
+			case '\'':
+				if i+1 < len(query) && query[i+1] == '\'' {
+					i++
+				} else {
+					inString = false
+				}
+			}
+			continue
+		}
+		switch query[i] {
+		case '\'':
+			inString = true
+		case '(':
+			depth++
+		case ')':
+			if depth > 0 {
+				depth--
+			}
+		default:
+			if depth != 0 || !sqlWordAt(query, i, "UNION") {
+				continue
+			}
+			allStart := skipSQLSpace(query, i+len("UNION"))
+			if !sqlWordAt(query, allStart, "ALL") {
+				continue
+			}
+			arms = append(arms, strings.TrimSpace(query[start:i]))
+			i = allStart + len("ALL") - 1
+			start = i + 1
+		}
+	}
+	if len(arms) == 0 {
+		return []string{query}
+	}
+	return append(arms, strings.TrimSpace(query[start:]))
+}
+
+func sqlWordAt(query string, start int, word string) bool {
+	end := start + len(word)
+	if start < 0 || end > len(query) || !strings.EqualFold(query[start:end], word) {
+		return false
+	}
+	return (start == 0 || !isSQLWordByte(query[start-1])) &&
+		(end == len(query) || !isSQLWordByte(query[end]))
+}
+
+func isSQLWordByte(b byte) bool {
+	return b == '_' || b >= '0' && b <= '9' || b >= 'A' && b <= 'Z' || b >= 'a' && b <= 'z'
+}
+
+func skipSQLSpace(query string, start int) int {
+	for start < len(query) && strings.ContainsRune(" \t\n\r", rune(query[start])) {
+		start++
+	}
+	return start
+}
+
+func trimEnclosingParens(query string) string {
+	query = strings.TrimSpace(query)
+	inner, ok := balancedParen(query)
+	if !ok || len(query) != len(inner)+2 {
+		return query
+	}
+	return strings.TrimSpace(inner)
 }
 
 // uncountableCTEReason renders the human-readable line recorded in

--- a/test/perf/profile/sql_test.go
+++ b/test/perf/profile/sql_test.go
@@ -97,6 +97,17 @@ func TestFromSourceLevels(t *testing.T) {
 			query: "SELECT x FROM (WITH c AS (SELECT 1) SELECT n AS x FROM c)",
 			want:  []string{"SELECT x FROM (WITH c AS (SELECT 1) SELECT n AS x FROM c)"},
 		},
+		{
+			name:  "descends every UNION ALL arm",
+			query: "SELECT x FROM (SELECT a AS x FROM (SELECT a FROM left_t) UNION ALL SELECT b AS x FROM right_t)",
+			want: []string{
+				"SELECT x FROM (SELECT a AS x FROM (SELECT a FROM left_t) UNION ALL SELECT b AS x FROM right_t)",
+				"SELECT a AS x FROM (SELECT a FROM left_t) UNION ALL SELECT b AS x FROM right_t",
+				"SELECT a AS x FROM (SELECT a FROM left_t)",
+				"SELECT a FROM left_t",
+				"SELECT b AS x FROM right_t",
+			},
+		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
@@ -105,6 +116,29 @@ func TestFromSourceLevels(t *testing.T) {
 				t.Errorf("fromSourceLevels mismatch\n got = %#v\nwant = %#v", got, tc.want)
 			}
 		})
+	}
+}
+
+func TestDecomposeQueryMarksEveryUnionLeafAsScanSource(t *testing.T) {
+	query := "SELECT x FROM (SELECT a AS x FROM (SELECT a FROM left_t) UNION ALL SELECT b AS x FROM right_t)"
+	got := decomposeQuery(query, 0)
+	var scanSources []string
+	for _, level := range got.levels {
+		if level.scanSource {
+			scanSources = append(scanSources, level.query)
+		}
+	}
+	want := []string{"SELECT a FROM left_t", "SELECT b AS x FROM right_t"}
+	if !reflect.DeepEqual(scanSources, want) {
+		t.Errorf("scan sources mismatch\n got = %#v\nwant = %#v", scanSources, want)
+	}
+}
+
+func TestSplitTopLevelUnionAllShieldsNestedAndQuotedTokens(t *testing.T) {
+	query := "SELECT 'UNION ALL' AS s FROM (SELECT 1 UNION ALL SELECT 2) UNION ALL SELECT 3"
+	want := []string{"SELECT 'UNION ALL' AS s FROM (SELECT 1 UNION ALL SELECT 2)", "SELECT 3"}
+	if got := splitTopLevelUnionAll(query); !reflect.DeepEqual(got, want) {
+		t.Errorf("splitTopLevelUnionAll mismatch\n got = %#v\nwant = %#v", got, want)
 	}
 }
 

--- a/test/perf/profile/union_all_pipeline_test.go
+++ b/test/perf/profile/union_all_pipeline_test.go
@@ -1,0 +1,50 @@
+//go:build chdb
+
+package profile
+
+import "testing"
+
+// TestProfileFixture_UnionAllPipelineSumsArmScans reproduces issue #2051:
+// each UNION arm has its own nested pipeline, but the old leftmost descent
+// reaches only the first arm's leaf and records a hollow denominator of two.
+func TestProfileFixture_UnionAllPipelineSumsArmScans(t *testing.T) {
+	const body = `-- seed --
+CREATE TABLE pipeline_union_left (a UInt64) ENGINE = MergeTree ORDER BY a;
+INSERT INTO pipeline_union_left VALUES (1), (2);
+CREATE TABLE pipeline_union_right (a UInt64) ENGINE = MergeTree ORDER BY a;
+INSERT INTO pipeline_union_right VALUES (3), (4), (5);
+-- expected_rows --
+[]
+-- sql --
+SELECT a FROM (
+  SELECT a FROM (SELECT a FROM pipeline_union_left)
+  UNION ALL
+  SELECT a FROM (SELECT a FROM pipeline_union_right)
+)
+`
+	prep := writeFixture(t, body)
+
+	p, err := NewProfiler()
+	if err != nil {
+		t.Fatalf("NewProfiler: %v", err)
+	}
+	defer p.Close()
+
+	rec := p.ProfileFixture("test/union_all_pipeline", prep)
+	if rec.Err != "" {
+		t.Fatalf("unexpected profile error: %s", rec.Err)
+	}
+	if rec.ScanRows != 5 {
+		t.Errorf("ScanRows = %d, want 5 (2 left-arm rows + 3 right-arm rows)", rec.ScanRows)
+	}
+	if rec.ResultRows != 5 || rec.PeakIntermediate != 5 {
+		t.Errorf("(ResultRows, PeakIntermediate) = (%d, %d), want (5, 5)",
+			rec.ResultRows, rec.PeakIntermediate)
+	}
+	if rec.UncountableLevels != 0 {
+		t.Errorf("UncountableLevels = %d, want 0: %v", rec.UncountableLevels, rec.UncountableReasons)
+	}
+	if rec.FanFactor == nil || *rec.FanFactor != 1 {
+		t.Errorf("FanFactor = %v, want measured 1.0", rec.FanFactor)
+	}
+}


### PR DESCRIPTION
Fixes #2051.

The cardinality profiler now decomposes every top-level `UNION ALL` arm as a sibling pipeline, retains each arm’s real nesting depth, and sums every arm leaf into `scan_rows`. This prevents the first arm from becoming a hollow denominator for the whole query.

The regression uses two nested arms with 2 and 3 rows and asserts `scan_rows=5`. The canonical cardinality baseline was regenerated, updating 28 UNION-bearing fixtures.

Validation:
- exact nested-arm chDB regression and decomposition unit tests
- `just update-golden cardinality` (8/8 legs plus seal)
- generated baseline structural guard (11/11)
- `git diff --check`