### PR TITLE
test(migrateverify): avoid released ports for unreachable backends

### DIFF
--- a/compatibility/loki/cmd/loki-compliance-tester/compare_test.go
+++ b/compatibility/loki/cmd/loki-compliance-tester/compare_test.go
@@ -367,17 +367,29 @@ func TestDoQuery_NonOKCarriesStatusAndTruncatedBody(t *testing.T) {
 // than surfacing as a zero-value result that would read as "empty".
 func TestDoQuery_UnreachableHost(t *testing.T) {
 	t.Parallel()
-	srv := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
-	addr := srv.URL
-	srv.Close() // nothing listens on this port any more
+	addr := unreachableBackendURL()
+	u, err := url.Parse(addr)
+	if err != nil {
+		t.Fatalf("parse unreachable backend URL: %v", err)
+	}
+	if u.Scheme != "http" || u.Hostname() != "backend.invalid" || u.Port() != "" {
+		t.Fatalf("unreachable backend URL = %q, want http://backend.invalid without a port", u)
+	}
 
-	_, err := doQuery(&http.Client{Timeout: 2 * time.Second}, addr+"/loki/api/v1/query_range", url.Values{})
+	_, err = doQuery(&http.Client{Timeout: 2 * time.Second}, addr+"/loki/api/v1/query_range", url.Values{})
 	if err == nil {
-		t.Fatal("doQuery against a closed listener returned no error")
+		t.Fatal("doQuery against an unreachable host returned no error")
 	}
 	if !strings.Contains(err.Error(), "http call") {
 		t.Fatalf("error %q should be the wrapped transport failure", err.Error())
 	}
+}
+
+// unreachableBackendURL uses the RFC 2606 reserved .invalid TLD so the
+// transport-error test never depends on a released ephemeral port staying
+// unclaimed by another parallel test listener.
+func unreachableBackendURL() string {
+	return "http://backend.invalid"
 }
 
 // TestCompareAll_ExpansionErrorsBypassTheWire — a case that failed to

--- a/internal/migrateverify/verify_lanes_test.go
+++ b/internal/migrateverify/verify_lanes_test.go
@@ -522,7 +522,7 @@ func TestVerify_TransportErrorRedactsCredentialsAllDialects(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.head, func(t *testing.T) {
-			addr := strings.TrimPrefix(deadBackendURL(t), "http://")
+			addr := strings.TrimPrefix(unreachableBackendURL(), "http://")
 			badURL := "http://" + user + ":" + pass + "@" + addr
 			lanes := map[string]Lane{tc.head: {
 				Ref:      NewHTTPBackend(badURL, WithDialect(tc.dialect)),

--- a/internal/migrateverify/verify_test.go
+++ b/internal/migrateverify/verify_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"reflect"
 	"strings"
 	"testing"
@@ -369,15 +370,21 @@ func nonMatrixServer(t *testing.T) *httptest.Server {
 	return srv
 }
 
-// deadBackendURL returns the URL of an httptest server that has already been
-// closed, so any request against it fails at the transport layer (connection
-// refused) — a deterministic way to exercise the transport-error branches.
-func deadBackendURL(t *testing.T) string {
-	t.Helper()
-	srv := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
-	u := srv.URL
-	srv.Close()
-	return u
+// unreachableBackendURL returns a URL whose host can never resolve. RFC 2606
+// reserves .invalid, so another test listener cannot make this backend
+// reachable by reusing a released ephemeral port.
+func unreachableBackendURL() string {
+	return "http://backend.invalid"
+}
+
+func TestUnreachableBackendURLUsesReservedHostWithoutPort(t *testing.T) {
+	u, err := url.Parse(unreachableBackendURL())
+	if err != nil {
+		t.Fatalf("parse unreachable backend URL: %v", err)
+	}
+	if u.Scheme != "http" || u.Hostname() != "backend.invalid" || u.Port() != "" {
+		t.Fatalf("unreachable backend URL = %q, want http://backend.invalid without a port", u)
+	}
 }
 
 // TestVerify_Cerberus200NonMatrix: cerberus answers 200 but with a non-matrix
@@ -427,7 +434,7 @@ func TestVerify_ReferenceTransportError(t *testing.T) {
 	cerBody := map[string]string{
 		"q": matrix(seriesSpec{labels: map[string]string{"job": "a"}, points: []pointSpec{{1_700_000_000, "1"}}}),
 	}
-	ref := NewHTTPBackend(deadBackendURL(t))
+	ref := NewHTTPBackend(unreachableBackendURL())
 	cer := NewHTTPBackend(matrixServer(t, cerBody).URL)
 	rep := Verify(context.Background(), Corpus{Queries: []Query{promQuery("q", "s")}}, promLanes(ref, cer), testParams())
 	res := rep.Results[0]
@@ -447,7 +454,7 @@ func TestVerify_CerberusTransportError(t *testing.T) {
 		"q": matrix(seriesSpec{labels: map[string]string{"job": "a"}, points: []pointSpec{{1_700_000_000, "1"}}}),
 	}
 	ref := NewHTTPBackend(matrixServer(t, refBody).URL)
-	cer := NewHTTPBackend(deadBackendURL(t))
+	cer := NewHTTPBackend(unreachableBackendURL())
 	rep := Verify(context.Background(), Corpus{Queries: []Query{promQuery("q", "s")}}, promLanes(ref, cer), testParams())
 	res := rep.Results[0]
 	if res.Verdict != VerdictError {
@@ -468,7 +475,7 @@ func TestVerify_TransportErrorRedactsCredentials(t *testing.T) {
 		user = "s3cr3t-token"
 		pass = "hunter2-pw"
 	)
-	addr := strings.TrimPrefix(deadBackendURL(t), "http://")
+	addr := strings.TrimPrefix(unreachableBackendURL(), "http://")
 	badURL := "http://" + user + ":" + pass + "@" + addr
 
 	cerBody := map[string]string{


### PR DESCRIPTION
Fixes #2078

## What changed

- replace closed httptest listeners with RFC 2606 `.invalid` backend URLs in migrateverify transport-error tests
- apply the same deterministic unreachable host to the parallel Loki compliance test
- pin the unreachable URL to a reserved hostname with no port so ephemeral-port reuse cannot return

## Root cause

The tests closed an httptest listener and reused its released ephemeral port as an unreachable backend. A later parallel listener could receive that port and invert the transport-error assertion.

## Validation

- `go test -race -count=1 -run '^(TestUnreachableBackendURLUsesReservedHostWithoutPort|TestVerify_ReferenceTransportError|TestVerify_CerberusTransportError|TestVerify_TransportErrorRedactsCredentials|TestVerify_TransportErrorRedactsCredentialsAllDialects)$' ./internal/migrateverify`\n- `go test -race -count=1 -run '^TestDoQuery_UnreachableHost$' ./cmd/loki-compliance-tester` (from `compatibility/loki`)\n- `git diff --check`