### PR TITLE
refactor(chplan): seal api and chsql function symbols

### DIFF
--- a/internal/api/tempo/handler.go
+++ b/internal/api/tempo/handler.go
@@ -502,7 +502,7 @@ func tsScanBound(tsCol string, op chplan.BinaryOp, t time.Time) chplan.Expr {
 		Op:   op,
 		Left: &chplan.ColumnRef{Name: tsCol},
 		Right: &chplan.FuncCall{
-			Name: "fromUnixTimestamp64Nano",
+			Fn:   chplan.FnFromUnixNanos,
 			Args: []chplan.Expr{&chplan.LitInt{V: t.UnixNano()}},
 		},
 	}
@@ -1079,7 +1079,7 @@ func wrapWithSampleProjection(plan chplan.Node, s schema.Traces, meta engine.Met
 			{Expr: &chplan.LitString{V: ""}, Alias: "MetricName"},
 			{Expr: emptyAttrsMap(), Alias: "Attributes"},
 			{Expr: chplan.NowNano(), Alias: "TimeUnix"},
-			{Expr: &chplan.FuncCall{Name: "toFloat64", Args: []chplan.Expr{&chplan.ColumnRef{Name: "Value"}}}, Alias: "Value"},
+			{Expr: &chplan.FuncCall{Fn: chplan.FnToFloat64, Args: []chplan.Expr{&chplan.ColumnRef{Name: "Value"}}}, Alias: "Value"},
 		}}
 	case isProjectShape(plan):
 		// `| select(...)` lowering produces Project(Filter?(Scan)) —
@@ -1145,8 +1145,8 @@ func sampleProjectionsWithSelected(s schema.Traces, selectedKVs []chplan.Expr) [
 		stripLeadingHexZeros(s.SpanIDColumn),
 	}
 	mapArgs = append(mapArgs, selectedKVs...)
-	reservedMap := &chplan.FuncCall{Name: "map", Args: mapArgs}
-	mergedAttrs := &chplan.FuncCall{Name: "mapConcat", Args: []chplan.Expr{
+	reservedMap := &chplan.FuncCall{Fn: chplan.FnMap, Args: mapArgs}
+	mergedAttrs := &chplan.FuncCall{Fn: chplan.FnMapMerge, Args: []chplan.Expr{
 		&chplan.ColumnRef{Name: s.ResourceAttributesColumn},
 		reservedMap,
 	}}
@@ -1158,7 +1158,7 @@ func sampleProjectionsWithSelected(s schema.Traces, selectedKVs []chplan.Expr) [
 		// is float64 and clickhouse-go's Scan refuses Int64→float64 without
 		// a cast. toFloat64 keeps the wire shape lossless within the
 		// 53-bit mantissa range (a 100-day duration in ns still fits).
-		{Expr: &chplan.FuncCall{Name: "toFloat64", Args: []chplan.Expr{&chplan.ColumnRef{Name: s.DurationColumn}}}, Alias: "Value"},
+		{Expr: &chplan.FuncCall{Fn: chplan.FnToFloat64, Args: []chplan.Expr{&chplan.ColumnRef{Name: s.DurationColumn}}}, Alias: "Value"},
 	}
 }
 
@@ -1207,7 +1207,7 @@ func selectedAttrKVPairs(p *chplan.Project, s schema.Traces) []chplan.Expr {
 // selectedAttrKVPairs for the rationale per shape).
 func classifySelectedProjection(pr chplan.Projection, s schema.Traces) (string, chplan.Expr, bool) {
 	toStr := func(e chplan.Expr) chplan.Expr {
-		return &chplan.FuncCall{Name: "toString", Args: []chplan.Expr{e}}
+		return &chplan.FuncCall{Fn: chplan.FnToString, Args: []chplan.Expr{e}}
 	}
 	switch e := pr.Expr.(type) {
 	case *chplan.ColumnRef:
@@ -1218,7 +1218,7 @@ func classifySelectedProjection(pr chplan.Projection, s schema.Traces) (string, 
 			return searchKeySelName, toStr(e), true
 		case s.StatusCodeColumn, s.SpanKindColumn:
 			return searchKeySelStrPrefix + pr.Alias,
-				toStr(&chplan.FuncCall{Name: "lower", Args: []chplan.Expr{e}}), true
+				toStr(&chplan.FuncCall{Fn: chplan.FnLower, Args: []chplan.Expr{e}}), true
 		case s.StatusMessageColumn, s.ScopeNameColumn, s.ScopeVersionColumn:
 			return searchKeySelStrPrefix + pr.Alias, toStr(e), true
 		}
@@ -1245,7 +1245,7 @@ func classifySelectedProjection(pr chplan.Projection, s schema.Traces) (string, 
 // for parity with the historical descendant/ancestor split, but both
 // arms now emit identical projections.
 func rQualifiedSampleProjections(s schema.Traces) []chplan.Projection {
-	reservedMap := &chplan.FuncCall{Name: "map", Args: []chplan.Expr{
+	reservedMap := &chplan.FuncCall{Fn: chplan.FnMap, Args: []chplan.Expr{
 		&chplan.LitString{V: searchKeyTraceID},
 		stripLeadingHexZeros(s.TraceIDColumn),
 		&chplan.LitString{V: searchKeyParentSpanID},
@@ -1253,7 +1253,7 @@ func rQualifiedSampleProjections(s schema.Traces) []chplan.Projection {
 		&chplan.LitString{V: searchKeySpanID},
 		stripLeadingHexZeros(s.SpanIDColumn),
 	}}
-	mergedAttrs := &chplan.FuncCall{Name: "mapConcat", Args: []chplan.Expr{
+	mergedAttrs := &chplan.FuncCall{Fn: chplan.FnMapMerge, Args: []chplan.Expr{
 		&chplan.ColumnRef{Name: s.ResourceAttributesColumn},
 		reservedMap,
 	}}
@@ -1261,7 +1261,7 @@ func rQualifiedSampleProjections(s schema.Traces) []chplan.Projection {
 		{Expr: &chplan.ColumnRef{Name: s.SpanNameColumn}, Alias: "MetricName"},
 		{Expr: mergedAttrs, Alias: "Attributes"},
 		{Expr: &chplan.ColumnRef{Name: s.TimestampColumn}, Alias: "TimeUnix"},
-		{Expr: &chplan.FuncCall{Name: "toFloat64", Args: []chplan.Expr{&chplan.ColumnRef{Name: s.DurationColumn}}}, Alias: "Value"},
+		{Expr: &chplan.FuncCall{Fn: chplan.FnToFloat64, Args: []chplan.Expr{&chplan.ColumnRef{Name: s.DurationColumn}}}, Alias: "Value"},
 	}
 }
 
@@ -1292,31 +1292,31 @@ func traceByIDProjections(s schema.Traces) []chplan.Projection {
 		// SpanKind / StatusCode are LowCardinality(String); cast to
 		// String so the mapConcat homogeneous-value-type requirement
 		// is met across the merged Map(String,String).
-		&chplan.FuncCall{Name: "toString", Args: []chplan.Expr{&chplan.ColumnRef{Name: s.SpanKindColumn}}},
+		&chplan.FuncCall{Fn: chplan.FnToString, Args: []chplan.Expr{&chplan.ColumnRef{Name: s.SpanKindColumn}}},
 		&chplan.LitString{V: traceByIDKeyStatusCode},
-		&chplan.FuncCall{Name: "toString", Args: []chplan.Expr{&chplan.ColumnRef{Name: s.StatusCodeColumn}}},
+		&chplan.FuncCall{Fn: chplan.FnToString, Args: []chplan.Expr{&chplan.ColumnRef{Name: s.StatusCodeColumn}}},
 		&chplan.LitString{V: traceByIDKeyScopeName},
 		// ScopeName / ScopeVersion are String in the upstream OTel-CH
 		// traces DDL, but custom schemas may declare them
 		// LowCardinality(String); toString keeps the map() literal's
 		// value type homogeneous either way (same rationale as
 		// SpanKind / StatusCode above).
-		&chplan.FuncCall{Name: "toString", Args: []chplan.Expr{&chplan.ColumnRef{Name: s.ScopeNameColumn}}},
+		&chplan.FuncCall{Fn: chplan.FnToString, Args: []chplan.Expr{&chplan.ColumnRef{Name: s.ScopeNameColumn}}},
 		&chplan.LitString{V: traceByIDKeyScopeVersion},
-		&chplan.FuncCall{Name: "toString", Args: []chplan.Expr{&chplan.ColumnRef{Name: s.ScopeVersionColumn}}},
+		&chplan.FuncCall{Fn: chplan.FnToString, Args: []chplan.Expr{&chplan.ColumnRef{Name: s.ScopeVersionColumn}}},
 		&chplan.LitString{V: traceByIDKeySpanAttrsJSON},
 		// CH `toJSONString(<Map>)` renders a JSON object like
 		// {"http.method":"GET","http.status_code":"200"}. The Go
 		// handler json-decodes it back into a Go map[string]string.
-		&chplan.FuncCall{Name: "toJSONString", Args: []chplan.Expr{&chplan.ColumnRef{Name: s.AttributesColumn}}},
+		&chplan.FuncCall{Fn: chplan.FnToJSONString, Args: []chplan.Expr{&chplan.ColumnRef{Name: s.AttributesColumn}}},
 	}
-	metaMap := &chplan.FuncCall{Name: "map", Args: metaKVPairs}
+	metaMap := &chplan.FuncCall{Fn: chplan.FnMap, Args: metaKVPairs}
 
 	// Final Attributes = mapConcat(ResourceAttributes, metaMap).
 	// Resource attribute keys (service.*, k8s.*, host.*, ...) never
 	// collide with the __cerberus_* reserved keys so no precedence
 	// surprises.
-	mergedAttrs := &chplan.FuncCall{Name: "mapConcat", Args: []chplan.Expr{
+	mergedAttrs := &chplan.FuncCall{Fn: chplan.FnMapMerge, Args: []chplan.Expr{
 		&chplan.ColumnRef{Name: s.ResourceAttributesColumn},
 		metaMap,
 	}}
@@ -1325,7 +1325,7 @@ func traceByIDProjections(s schema.Traces) []chplan.Projection {
 		{Expr: &chplan.ColumnRef{Name: s.SpanNameColumn}, Alias: "MetricName"},
 		{Expr: mergedAttrs, Alias: "Attributes"},
 		{Expr: &chplan.ColumnRef{Name: s.TimestampColumn}, Alias: "TimeUnix"},
-		{Expr: &chplan.FuncCall{Name: "toFloat64", Args: []chplan.Expr{&chplan.ColumnRef{Name: s.DurationColumn}}}, Alias: "Value"},
+		{Expr: &chplan.FuncCall{Fn: chplan.FnToFloat64, Args: []chplan.Expr{&chplan.ColumnRef{Name: s.DurationColumn}}}, Alias: "Value"},
 	}
 }
 
@@ -1336,9 +1336,9 @@ func traceByIDProjections(s schema.Traces) []chplan.Projection {
 // the rendered SQL has the same shape across the three QL surfaces.
 func emptyAttrsMap() chplan.Expr {
 	return &chplan.FuncCall{
-		Name: "CAST",
+		Fn: chplan.FnCast,
 		Args: []chplan.Expr{
-			&chplan.FuncCall{Name: "map", Args: nil},
+			&chplan.FuncCall{Fn: chplan.FnMap, Args: nil},
 			&chplan.LitString{V: "Map(String,String)"},
 		},
 	}
@@ -1555,7 +1555,7 @@ func spansetAggregateSampleProjections() []chplan.Projection {
 		Left:  &chplan.ColumnRef{Name: "TraceEndNs"},
 		Right: &chplan.ColumnRef{Name: "TraceStartNs"},
 	}
-	traceIDMap := &chplan.FuncCall{Name: "map", Args: []chplan.Expr{
+	traceIDMap := &chplan.FuncCall{Fn: chplan.FnMap, Args: []chplan.Expr{
 		&chplan.LitString{V: searchKeyTraceID},
 		stripLeadingHexZeros("TraceId"),
 		&chplan.LitString{V: searchKeyParentSpanID},
@@ -1563,9 +1563,9 @@ func spansetAggregateSampleProjections() []chplan.Projection {
 		&chplan.LitString{V: searchKeyTraceDurationNs},
 		// toString keeps the merged Map(String,String) homogeneous;
 		// the shaper parses the int back out on the Go side.
-		&chplan.FuncCall{Name: "toString", Args: []chplan.Expr{traceDurationNs}},
+		&chplan.FuncCall{Fn: chplan.FnToString, Args: []chplan.Expr{traceDurationNs}},
 	}}
-	mergedAttrs := &chplan.FuncCall{Name: "mapConcat", Args: []chplan.Expr{
+	mergedAttrs := &chplan.FuncCall{Fn: chplan.FnMapMerge, Args: []chplan.Expr{
 		&chplan.ColumnRef{Name: "ResourceAttrs"},
 		traceIDMap,
 	}}
@@ -1573,7 +1573,7 @@ func spansetAggregateSampleProjections() []chplan.Projection {
 		{Expr: &chplan.ColumnRef{Name: "MetricName"}, Alias: "MetricName"},
 		{Expr: mergedAttrs, Alias: "Attributes"},
 		{Expr: &chplan.ColumnRef{Name: "TimeUnix"}, Alias: "TimeUnix"},
-		{Expr: &chplan.FuncCall{Name: "toFloat64", Args: []chplan.Expr{&chplan.ColumnRef{Name: "Value"}}}, Alias: "Value"},
+		{Expr: &chplan.FuncCall{Fn: chplan.FnToFloat64, Args: []chplan.Expr{&chplan.ColumnRef{Name: "Value"}}}, Alias: "Value"},
 	}
 }
 

--- a/internal/api/tempo/metrics_phi_label_test.go
+++ b/internal/api/tempo/metrics_phi_label_test.go
@@ -133,7 +133,7 @@ func TestWrapMetricsForSample_QuantileAttrsIncludeBucket(t *testing.T) {
 	}
 	attrsExpr := proj.Projections[1].Expr
 	call, ok := attrsExpr.(*chplan.FuncCall)
-	if !ok || call.Name != "map" {
+	if !ok || call.Fn != chplan.FnMap {
 		t.Fatalf("Attributes expr = %T (%v), want *chplan.FuncCall(map)", attrsExpr, attrsExpr)
 	}
 
@@ -146,7 +146,7 @@ func TestWrapMetricsForSample_QuantileAttrsIncludeBucket(t *testing.T) {
 		if lit, ok := arg.(*chplan.LitString); ok && lit.V == "__bucket" {
 			foundBucketKey = true
 			if i+1 < len(call.Args) {
-				if fc, ok := call.Args[i+1].(*chplan.FuncCall); ok && fc.Name == "toString" {
+				if fc, ok := call.Args[i+1].(*chplan.FuncCall); ok && fc.Fn == chplan.FnToString {
 					if len(fc.Args) == 1 {
 						if col, ok := fc.Args[0].(*chplan.ColumnRef); ok && col.Name == "__bucket" {
 							foundBucketCol = true
@@ -249,7 +249,7 @@ func TestWrapMetricsForSample_UngroupedQuantileSurfacesBucket(t *testing.T) {
 		t.Errorf("Attributes map[0] (key) = %v, want LitString{__bucket}", call.Args[0])
 	}
 	val, ok := call.Args[1].(*chplan.FuncCall)
-	if !ok || val.Name != "toString" {
+	if !ok || val.Fn != chplan.FnToString {
 		t.Errorf("Attributes map[1] (value) = %v, want toString(...) call", call.Args[1])
 	}
 
@@ -384,7 +384,7 @@ func TestWrapMetricsForSample_DisplayNameKeysAttributesMap(t *testing.T) {
 		t.Fatalf("project has %d projections, want >= 2", len(proj.Projections))
 	}
 	call, ok := proj.Projections[1].Expr.(*chplan.FuncCall)
-	if !ok || call.Name != "map" {
+	if !ok || call.Fn != chplan.FnMap {
 		t.Fatalf("Attributes expr = %T (%v), want *chplan.FuncCall(map)", proj.Projections[1].Expr, proj.Projections[1].Expr)
 	}
 	if len(call.Args) < 2 {
@@ -401,7 +401,7 @@ func TestWrapMetricsForSample_DisplayNameKeysAttributesMap(t *testing.T) {
 	// And the VALUE side wraps toString around the SQL-side alias, not
 	// the display name.
 	valueCall, ok := call.Args[1].(*chplan.FuncCall)
-	if !ok || valueCall.Name != "toString" {
+	if !ok || valueCall.Fn != chplan.FnToString {
 		t.Fatalf("map arg[1] = %T (%v), want toString(<alias>)", call.Args[1], call.Args[1])
 	}
 	if len(valueCall.Args) != 1 {
@@ -464,7 +464,7 @@ func TestWrapMetricsForSample_UngroupedAttachesMetricName(t *testing.T) {
 				t.Fatalf("project has %d projections, want >= 2", len(proj.Projections))
 			}
 			call, ok := proj.Projections[1].Expr.(*chplan.FuncCall)
-			if !ok || call.Name != "map" {
+			if !ok || call.Fn != chplan.FnMap {
 				t.Fatalf("Attributes expr = %T (%v), want *chplan.FuncCall(map)", proj.Projections[1].Expr, proj.Projections[1].Expr)
 			}
 			if len(call.Args) != 2 {

--- a/internal/api/tempo/metrics_query_range.go
+++ b/internal/api/tempo/metrics_query_range.go
@@ -489,7 +489,7 @@ func wrapMetricsForSample(inner chplan.Node, m *chplan.MetricsAggregate) chplan.
 				args,
 				&chplan.LitString{V: labelNames[i]},
 				&chplan.FuncCall{
-					Name: "toString",
+					Fn:   chplan.FnToString,
 					Args: []chplan.Expr{&chplan.ColumnRef{Name: attrAliases[i]}},
 				},
 			)
@@ -498,11 +498,11 @@ func wrapMetricsForSample(inner chplan.Node, m *chplan.MetricsAggregate) chplan.
 			args,
 			&chplan.LitString{V: tempoQuantileBucketLabel},
 			&chplan.FuncCall{
-				Name: "toString",
+				Fn:   chplan.FnToString,
 				Args: []chplan.Expr{&chplan.ColumnRef{Name: tempoQuantileBucketLabel}},
 			},
 		)
-		attrs = &chplan.FuncCall{Name: "map", Args: args}
+		attrs = &chplan.FuncCall{Fn: chplan.FnMap, Args: args}
 	case len(m.GroupBy) == 0:
 		// Ungrouped non-quantile: emit Tempo's UngroupedAggregator-style
 		// `{__name__="<op>"}` label so the response series is keyed by
@@ -511,7 +511,7 @@ func wrapMetricsForSample(inner chplan.Node, m *chplan.MetricsAggregate) chplan.
 		// count_over_time / avg_over_time / ...), matching the upstream
 		// wire form LabelsFromArgs(labels.MetricName, op.String()).
 		attrs = &chplan.FuncCall{
-			Name: "map",
+			Fn: chplan.FnMap,
 			Args: []chplan.Expr{
 				&chplan.LitString{V: tempoMetricNameLabel},
 				&chplan.LitString{V: m.Op.String()},
@@ -524,12 +524,12 @@ func wrapMetricsForSample(inner chplan.Node, m *chplan.MetricsAggregate) chplan.
 				args,
 				&chplan.LitString{V: labelNames[i]},
 				&chplan.FuncCall{
-					Name: "toString",
+					Fn:   chplan.FnToString,
 					Args: []chplan.Expr{&chplan.ColumnRef{Name: attrAliases[i]}},
 				},
 			)
 		}
-		attrs = &chplan.FuncCall{Name: "map", Args: args}
+		attrs = &chplan.FuncCall{Fn: chplan.FnMap, Args: args}
 	}
 
 	return &chplan.Project{

--- a/internal/api/tempo/metrics_query_range_compare.go
+++ b/internal/api/tempo/metrics_query_range_compare.go
@@ -72,14 +72,14 @@ const (
 func wrapCompareForSample(rw *chplan.RangeWindow, m *chplan.MetricsCompare) chplan.Node {
 	selAlias, attrAlias, valAlias, valueAlias := compareAliases(m)
 	attrs := &chplan.FuncCall{
-		Name: "map",
+		Fn: chplan.FnMap,
 		Args: []chplan.Expr{
 			&chplan.LitString{V: compareRowSelLabel},
-			&chplan.FuncCall{Name: "toString", Args: []chplan.Expr{&chplan.ColumnRef{Name: selAlias}}},
+			&chplan.FuncCall{Fn: chplan.FnToString, Args: []chplan.Expr{&chplan.ColumnRef{Name: selAlias}}},
 			&chplan.LitString{V: compareRowAttrLabel},
-			&chplan.FuncCall{Name: "toString", Args: []chplan.Expr{&chplan.ColumnRef{Name: attrAlias}}},
+			&chplan.FuncCall{Fn: chplan.FnToString, Args: []chplan.Expr{&chplan.ColumnRef{Name: attrAlias}}},
 			&chplan.LitString{V: compareRowValLabel},
-			&chplan.FuncCall{Name: "toString", Args: []chplan.Expr{&chplan.ColumnRef{Name: valAlias}}},
+			&chplan.FuncCall{Fn: chplan.FnToString, Args: []chplan.Expr{&chplan.ColumnRef{Name: valAlias}}},
 		},
 	}
 	return &chplan.Project{

--- a/internal/api/tempo/metrics_query_range_histogram.go
+++ b/internal/api/tempo/metrics_query_range_histogram.go
@@ -63,7 +63,7 @@ func wrapHistogramForSample(rw *chplan.RangeWindow, m *chplan.MetricsHistogramOv
 			args,
 			&chplan.LitString{V: labelNames[i]},
 			&chplan.FuncCall{
-				Name: "toString",
+				Fn:   chplan.FnToString,
 				Args: []chplan.Expr{&chplan.ColumnRef{Name: attrAliases[i]}},
 			},
 		)
@@ -72,7 +72,7 @@ func wrapHistogramForSample(rw *chplan.RangeWindow, m *chplan.MetricsHistogramOv
 		args,
 		&chplan.LitString{V: tempoQuantileBucketLabel},
 		&chplan.FuncCall{
-			Name: "toString",
+			Fn:   chplan.FnToString,
 			Args: []chplan.Expr{&chplan.ColumnRef{Name: m.BucketAlias}},
 		},
 	)
@@ -81,7 +81,7 @@ func wrapHistogramForSample(rw *chplan.RangeWindow, m *chplan.MetricsHistogramOv
 		Input: rw,
 		Projections: []chplan.Projection{
 			{Expr: &chplan.LitString{V: ""}, Alias: "MetricName"},
-			{Expr: &chplan.FuncCall{Name: "map", Args: args}, Alias: "Attributes"},
+			{Expr: &chplan.FuncCall{Fn: chplan.FnMap, Args: args}, Alias: "Attributes"},
 			{Expr: &chplan.ColumnRef{Name: "anchor_ts"}, Alias: "TimeUnix"},
 			{Expr: &chplan.ColumnRef{Name: m.ValueAlias}, Alias: "Value"},
 		},

--- a/internal/api/tempo/root_lookup.go
+++ b/internal/api/tempo/root_lookup.go
@@ -185,7 +185,7 @@ func buildRootLookupPlan(s schema.Traces, traceIDs []string) chplan.Node {
 
 	// argMinIf(SpanName, Timestamp, rootCond) AS RootSpanName.
 	aggSpanName := chplan.AggFunc{
-		Name: "argMinIf",
+		Fn: chplan.FnArgMinIf,
 		Args: []chplan.Expr{
 			&chplan.ColumnRef{Name: s.SpanNameColumn},
 			&chplan.ColumnRef{Name: s.TimestampColumn},
@@ -195,7 +195,7 @@ func buildRootLookupPlan(s schema.Traces, traceIDs []string) chplan.Node {
 	}
 	// argMinIf(ResourceAttributes['service.name'], Timestamp, rootCond) AS RootSvc.
 	aggSvc := chplan.AggFunc{
-		Name: "argMinIf",
+		Fn: chplan.FnArgMinIf,
 		Args: []chplan.Expr{
 			&chplan.MapAccess{
 				Map: &chplan.ColumnRef{Name: s.ResourceAttributesColumn},
@@ -212,10 +212,10 @@ func buildRootLookupPlan(s schema.Traces, traceIDs []string) chplan.Node {
 	// plain integer (DateTime64 lacks a typed interval subtraction
 	// in the chplan IR).
 	aggTraceStart := chplan.AggFunc{
-		Name: "min",
+		Fn: chplan.FnMin,
 		Args: []chplan.Expr{
 			&chplan.FuncCall{
-				Name: "toUnixTimestamp64Nano",
+				Fn:   chplan.FnToUnixNanos,
 				Args: []chplan.Expr{&chplan.ColumnRef{Name: s.TimestampColumn}},
 			},
 		},
@@ -226,16 +226,16 @@ func buildRootLookupPlan(s schema.Traces, traceIDs []string) chplan.Node {
 	// keeps the sum Int64 so subtracting TraceStartNs (Int64) yields
 	// a signed integer CH doesn't refuse to subtract.
 	aggTraceEnd := chplan.AggFunc{
-		Name: "max",
+		Fn: chplan.FnMax,
 		Args: []chplan.Expr{
 			&chplan.Binary{
 				Op: chplan.OpAdd,
 				Left: &chplan.FuncCall{
-					Name: "toUnixTimestamp64Nano",
+					Fn:   chplan.FnToUnixNanos,
 					Args: []chplan.Expr{&chplan.ColumnRef{Name: s.TimestampColumn}},
 				},
 				Right: &chplan.FuncCall{
-					Name: "toInt64",
+					Fn:   chplan.FnToInt64,
 					Args: []chplan.Expr{&chplan.ColumnRef{Name: s.DurationColumn}},
 				},
 			},
@@ -256,7 +256,7 @@ func buildRootLookupPlan(s schema.Traces, traceIDs []string) chplan.Node {
 	// produced by the Aggregate by bare name works because Aggregate
 	// emits `<expr> AS <alias>` + `<func> AS <alias>` in the SELECT
 	// list.
-	attrsMap := &chplan.FuncCall{Name: "map", Args: []chplan.Expr{
+	attrsMap := &chplan.FuncCall{Fn: chplan.FnMap, Args: []chplan.Expr{
 		&chplan.LitString{V: searchKeyTraceID},
 		stripLeadingHexZeros("TraceId"),
 		&chplan.LitString{V: "service.name"},
@@ -273,7 +273,7 @@ func buildRootLookupPlan(s schema.Traces, traceIDs []string) chplan.Node {
 			{Expr: &chplan.ColumnRef{Name: "RootSpanName"}, Alias: "MetricName"},
 			{Expr: attrsMap, Alias: "Attributes"},
 			{Expr: chplan.NowNano(), Alias: "TimeUnix"},
-			{Expr: &chplan.FuncCall{Name: "toFloat64", Args: []chplan.Expr{traceDurationNs}}, Alias: "Value"},
+			{Expr: &chplan.FuncCall{Fn: chplan.FnToFloat64, Args: []chplan.Expr{traceDurationNs}}, Alias: "Value"},
 		},
 	}
 }

--- a/internal/api/tempo/structural_two_phase.go
+++ b/internal/api/tempo/structural_two_phase.go
@@ -200,7 +200,7 @@ func buildStructuralPhaseAPlan(sj *chplan.StructuralJoin, s schema.Traces, limit
 		GroupBy:        []chplan.Expr{&chplan.ColumnRef{Name: s.TraceIDColumn}},
 		GroupByAliases: []string{s.TraceIDColumn},
 		AggFuncs: []chplan.AggFunc{{
-			Name:  "min",
+			Fn:    chplan.FnMin,
 			Args:  []chplan.Expr{&chplan.ColumnRef{Name: s.TimestampColumn}},
 			Alias: phaseARankTsAlias,
 		}},

--- a/internal/chplan/fn.go
+++ b/internal/chplan/fn.go
@@ -549,6 +549,10 @@ const (
 	// CH's interpolated estimate.
 	FnQuantile Fn = "quantile"
 
+	// quantiles(phi1, phi2, ...)(x) aggregate — every requested percentile of x
+	// in the group as an Array(Float64), in parameter order.
+	FnQuantiles Fn = "quantiles"
+
 	// stddevPop(x) aggregate — the population standard deviation of x in the
 	// group.
 	FnStddevPop Fn = "stddevPop"

--- a/internal/chsql/builder.go
+++ b/internal/chsql/builder.go
@@ -665,7 +665,7 @@ func anchoredRegexPattern(v chplan.Expr) chplan.Expr {
 		return &chplan.LitString{V: anchorPrefix + lit.V + anchorSuffix}
 	}
 	return &chplan.FuncCall{
-		Name: "concat",
+		Fn: chplan.FnConcat,
 		Args: []chplan.Expr{
 			&chplan.LitString{V: anchorPrefix},
 			v,

--- a/internal/chsql/fnspelling.go
+++ b/internal/chsql/fnspelling.go
@@ -198,6 +198,7 @@ var fnSpellings = map[chplan.Fn]fnSpelling{
 	chplan.FnMax:        {Name: "max"},
 	chplan.FnMin:        {Name: "min"},
 	chplan.FnQuantile:   {Name: "quantile"},
+	chplan.FnQuantiles:  {Name: "quantiles"},
 	chplan.FnStddevPop:  {Name: "stddevPop"},
 	chplan.FnSum:        {Name: "sum"},
 	chplan.FnUniqExact:  {Name: "uniqExact"},

--- a/internal/chsql/histogram_over_time.go
+++ b/internal/chsql/histogram_over_time.go
@@ -67,7 +67,7 @@ func (e *emitter) emitMetricsHistogramOverTime(m *chplan.MetricsHistogramOverTim
 		valueAlias = "Value"
 	}
 	countFunc := chplan.AggFunc{
-		Name:  "count",
+		Fn:    chplan.FnCount,
 		Args:  []chplan.Expr{&chplan.LitInt{V: 1}},
 		Alias: valueAlias,
 	}

--- a/internal/chsql/metrics_compare.go
+++ b/internal/chsql/metrics_compare.go
@@ -364,7 +364,7 @@ func windowRootLookupTraceIDSeed(root chplan.Node, traceIDCol string, seed chpla
 func tsBoundExprs(tsCol string, startNano, endNano int64) (lo, hi chplan.Expr) {
 	fromNano := func(nano int64) chplan.Expr {
 		return &chplan.FuncCall{
-			Name: "fromUnixTimestamp64Nano",
+			Fn:   chplan.FnFromUnixNanos,
 			Args: []chplan.Expr{&chplan.LitInt{V: nano}},
 		}
 	}
@@ -570,7 +570,7 @@ func compareCountValueFrag() Frag {
 	return Call(
 		"toFloat64",
 		func(b *Builder) {
-			_ = b.Expr(&chplan.FuncCall{Name: "count", Args: []chplan.Expr{&chplan.LitInt{V: 1}}})
+			_ = b.Expr(&chplan.FuncCall{Fn: chplan.FnCount, Args: []chplan.Expr{&chplan.LitInt{V: 1}}})
 		},
 	)
 }

--- a/internal/chsql/range_lwr.go
+++ b/internal/chsql/range_lwr.go
@@ -142,7 +142,7 @@ func (e *emitter) emitRangeLWR(r *chplan.RangeLWR) error {
 	collapse.Select(Col("anchor_ts"))
 	collapse.Select(RawAs(
 		aggFuncFrag(chplan.AggFunc{
-			Name: "argMax",
+			Fn: chplan.FnArgMax,
 			Args: []chplan.Expr{
 				&chplan.ColumnRef{Name: r.ValueCol},
 				&chplan.ColumnRef{Name: r.TimestampCol},
@@ -162,7 +162,7 @@ func (e *emitter) emitRangeLWR(r *chplan.RangeLWR) error {
 	if r.SampleTimestamp {
 		collapse.Select(RawAs(
 			aggFuncFrag(chplan.AggFunc{
-				Name: "max",
+				Fn:   chplan.FnMax,
 				Args: []chplan.Expr{&chplan.ColumnRef{Name: r.TimestampCol}},
 			}),
 			chplan.RangeLWRSampleTimestampColumn,

--- a/internal/chsql/range_window.go
+++ b/internal/chsql/range_window.go
@@ -64,10 +64,10 @@ func (e *emitter) emitMetricsAggregate(m *chplan.MetricsAggregate) error {
 		// Inner SELECT: project the `quantiles(p1, p2, ...)(Attr)`
 		// Array(Float64) under an internal alias; the outer SELECT
 		// fans it out via arrayJoin + tupleElement.
-		af := chplan.AggFunc{Name: name, Params: params, Args: args, Alias: ""}
+		af := chplan.AggFunc{Fn: name, Params: params, Args: args, Alias: ""}
 		sb.Select(RawAs(aggFuncFrag(af), "qs_array"))
 	} else {
-		af := chplan.AggFunc{Name: name, Params: params, Args: args, Alias: m.ValueAlias}
+		af := chplan.AggFunc{Fn: name, Params: params, Args: args, Alias: m.ValueAlias}
 		sb.Select(aggFuncFrag(af))
 	}
 	// An empty GroupBy appends no keys (GroupBy is a no-op on an empty
@@ -114,34 +114,34 @@ func (e *emitter) emitMetricsAggregate(m *chplan.MetricsAggregate) error {
 // happens in the wrapping emitter (emitMetricsAggregate /
 // emitRangeWindowMetrics), not here.
 func metricsAggregateCH(m *chplan.MetricsAggregate) (
-	name string,
+	fn chplan.Fn,
 	params []chplan.Expr,
 	args []chplan.Expr,
 	err error,
 ) {
 	switch m.Op {
 	case chplan.MetricsOpRate, chplan.MetricsOpCountOverTime:
-		return "count", nil, []chplan.Expr{&chplan.LitInt{V: 1}}, nil
+		return chplan.FnCount, nil, []chplan.Expr{&chplan.LitInt{V: 1}}, nil
 	case chplan.MetricsOpSumOverTime:
 		if m.Attr == nil {
 			return "", nil, nil, fmt.Errorf("%w: %s requires Attr", ErrUnsupported, m.Op)
 		}
-		return "sum", nil, []chplan.Expr{m.Attr}, nil
+		return chplan.FnSum, nil, []chplan.Expr{m.Attr}, nil
 	case chplan.MetricsOpAvgOverTime:
 		if m.Attr == nil {
 			return "", nil, nil, fmt.Errorf("%w: %s requires Attr", ErrUnsupported, m.Op)
 		}
-		return "avg", nil, []chplan.Expr{m.Attr}, nil
+		return chplan.FnAvg, nil, []chplan.Expr{m.Attr}, nil
 	case chplan.MetricsOpMinOverTime:
 		if m.Attr == nil {
 			return "", nil, nil, fmt.Errorf("%w: %s requires Attr", ErrUnsupported, m.Op)
 		}
-		return "min", nil, []chplan.Expr{m.Attr}, nil
+		return chplan.FnMin, nil, []chplan.Expr{m.Attr}, nil
 	case chplan.MetricsOpMaxOverTime:
 		if m.Attr == nil {
 			return "", nil, nil, fmt.Errorf("%w: %s requires Attr", ErrUnsupported, m.Op)
 		}
-		return "max", nil, []chplan.Expr{m.Attr}, nil
+		return chplan.FnMax, nil, []chplan.Expr{m.Attr}, nil
 	case chplan.MetricsOpQuantileOverTime:
 		if m.Attr == nil {
 			return "", nil, nil, fmt.Errorf("%w: %s requires Attr", ErrUnsupported, m.Op)
@@ -150,7 +150,7 @@ func metricsAggregateCH(m *chplan.MetricsAggregate) (
 			return "", nil, nil, fmt.Errorf("%w: MetricsAggregate quantile requires at least 1 quantile", ErrUnsupported)
 		}
 		if len(m.Quantiles) == 1 {
-			return "quantile", []chplan.Expr{&chplan.LitFloat{V: m.Quantiles[0]}}, []chplan.Expr{m.Attr}, nil
+			return chplan.FnQuantile, []chplan.Expr{&chplan.LitFloat{V: m.Quantiles[0]}}, []chplan.Expr{m.Attr}, nil
 		}
 		// Multi-phi: emit `quantiles(p1, p2, ...)(Attr)` which returns
 		// an Array(Float64) of size N. The wrapping emitter (bare or
@@ -160,7 +160,7 @@ func metricsAggregateCH(m *chplan.MetricsAggregate) (
 		for i, q := range m.Quantiles {
 			ps[i] = &chplan.LitFloat{V: q}
 		}
-		return "quantiles", ps, []chplan.Expr{m.Attr}, nil
+		return chplan.FnQuantiles, ps, []chplan.Expr{m.Attr}, nil
 	}
 	return "", nil, nil, fmt.Errorf("%w: MetricsAggregate op %s", ErrUnsupported, m.Op)
 }
@@ -999,7 +999,7 @@ func (e *emitter) emitRangeWindowMetrics(r *chplan.RangeWindow, m *chplan.Metric
 	if m.Op == chplan.MetricsOpQuantileOverTime {
 		return e.emitRangeWindowMetricsQuantileBuckets(r, m)
 	}
-	chName, params, args, err := metricsAggregateCH(m)
+	fn, params, args, err := metricsAggregateCH(m)
 	if err != nil {
 		return err
 	}
@@ -1125,7 +1125,7 @@ func (e *emitter) emitRangeWindowMetrics(r *chplan.RangeWindow, m *chplan.Metric
 	if zeroFill {
 		outerSb.Select(As(metricsSumWeightReducerFrag(m.Op, rangeSeconds), m.ValueAlias))
 	} else {
-		outerSb.Select(As(metricsReducerFrag(m.Op, chName, params, args, rangeSeconds), m.ValueAlias))
+		outerSb.Select(As(metricsReducerFrag(m.Op, fn, params, args, rangeSeconds), m.ValueAlias))
 	}
 
 	// GROUP BY group aliases + anchor_ts.
@@ -2114,28 +2114,19 @@ func windowValsFrag() Frag {
 // UInt64 to *float64 is unsupported`. The rate case keeps the cast as
 // well even though `count() / N` already promotes to Float64 in CH —
 // the uniform wrap is cheaper to reason about than a per-op exception.
-func metricsReducerFrag(op chplan.MetricsOp, chName string, params, args []chplan.Expr, rangeSeconds float64) Frag {
+func metricsReducerFrag(op chplan.MetricsOp, fn chplan.Fn, params, args []chplan.Expr, rangeSeconds float64) Frag {
 	// Translate Attr operand to a metric_arg reference (the alias the
 	// inner SELECT projects under) for *_over_time cases.
-	argFrags := make([]func(b *Builder), 0, len(args))
-	for range args {
-		argFrags = append(argFrags, func(b *Builder) { b.Ident("metric_arg") })
+	aggArgs := make([]chplan.Expr, len(args))
+	for i := range args {
+		aggArgs[i] = &chplan.ColumnRef{Name: "metric_arg"}
 	}
 	if op == chplan.MetricsOpRate || op == chplan.MetricsOpCountOverTime {
 		// args is [LitInt{1}] — pass through verbatim so we emit count(?).
-		argFrags = argFrags[:0]
-		for _, a := range args {
-			expr := a
-			argFrags = append(argFrags, func(b *Builder) { _ = b.Expr(expr) })
-		}
-	}
-	paramFrags := make([]func(b *Builder), 0, len(params))
-	for _, p := range params {
-		expr := p
-		paramFrags = append(paramFrags, func(b *Builder) { _ = b.Expr(expr) })
+		aggArgs = args
 	}
 
-	agg := Call("toFloat64", func(b *Builder) { b.ParamAgg(chName, paramFrags, argFrags) })
+	agg := Call("toFloat64", aggFuncFrag(chplan.AggFunc{Fn: fn, Params: params, Args: aggArgs}))
 	switch op {
 	case chplan.MetricsOpRate:
 		return Div(agg, InlineLit(rangeSeconds))

--- a/test/spec/chplan_print.go
+++ b/test/spec/chplan_print.go
@@ -922,6 +922,7 @@ var fnGoNames = map[chplan.Fn]string{
 	chplan.FnMax:                             "FnMax",
 	chplan.FnMin:                             "FnMin",
 	chplan.FnQuantile:                        "FnQuantile",
+	chplan.FnQuantiles:                       "FnQuantiles",
 	chplan.FnStddevPop:                       "FnStddevPop",
 	chplan.FnSum:                             "FnSum",
 	chplan.FnUniqExact:                       "FnUniqExact",


### PR DESCRIPTION
Fixes #2184
Part of #2060

## What changed

- convert production `internal/api` and `internal/chsql` `FuncCall`/`AggFunc` construction sites from raw ClickHouse `Name` strings to sealed `chplan.Fn` symbols
- make the variable-driven metrics aggregate mapping return `chplan.Fn` end to end, without casting raw strings
- add the missing `FnQuantiles` vocabulary entry and ClickHouse spelling required by the existing multi-quantile path
- update Tempo structural assertions to pin symbolic identity

## Why

These remaining internal construction sites bypassed the sealed function vocabulary introduced by #2060. The multi-quantile path also exposed a real vocabulary gap: `quantiles` had no declared symbol, so converting it safely required a first-class `FnQuantiles` entry rather than an unchecked cast.

## Compatibility

The canonical ten-shard `just update-golden` run completed with zero artifact diff. Emitted SQL, `expected_rows`, and existing recorded IR are byte-identical.

## Validation

- focused `internal/chsql` sealed-vocabulary and emitter regressions under `-race`
- focused `internal/api/tempo` search, metrics, histogram, compare, and multi-quantile regressions under `-race`
- `just update-golden migration parity solver promql logql traceql chsql optimizer codegen cardinality`
- `node .github/scripts/forbid-sql-raw.mjs`
- raw-name inventory: zero production `FuncCall`/`AggFunc` `Name:` literals in `internal/api` and `internal/chsql` (dual-mode identity copying remains intact)