### PR TITLE
fix(loki): tokenize structured pattern lines by field

### DIFF
--- a/internal/api/loki/patterns.go
+++ b/internal/api/loki/patterns.go
@@ -146,12 +146,12 @@ func buildPatternsSQL(s schema.Logs, matchers []*labels.Matcher, start, end time
 // encodes that as `data:[]`, matching upstream Loki.
 //
 // The miner is the in-house clean-room Drain implementation
-// (internal/drain), which tokenises on whitespace and treats
-// digit-bearing tokens as variables — generic enough for arbitrary log
-// lines without a per-format tokeniser gate. Each level bucket gets its
-// own drain.Miner instance (confirmed independent — a Miner owns its own
-// token tree and cluster slice, no shared state), so lines never mix
-// templates across levels.
+// (internal/drain), which tokenises JSON/logfmt at field boundaries,
+// falls back to whitespace for ordinary text, and treats digit-bearing
+// tokens as variables. Each level bucket gets its own drain.Miner
+// instance (confirmed independent — a Miner owns its own token tree and
+// cluster slice, no shared state), so lines never mix templates across
+// levels.
 func minePatterns(lines []chclient.TimestampedLine) []Pattern {
 	miners := make(map[string]*drain.Miner)
 	levels := make([]string, 0)

--- a/internal/api/loki/patterns_test.go
+++ b/internal/api/loki/patterns_test.go
@@ -2,6 +2,7 @@ package loki_test
 
 import (
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"strings"
 	"testing"
@@ -10,6 +11,62 @@ import (
 	"github.com/tsouza/cerberus/internal/api/loki"
 	"github.com/tsouza/cerberus/internal/chclient"
 )
+
+// TestPatterns_CompactJSONCollapsesBySchema pins #2080 at the HTTP boundary:
+// distinct compact-JSON lines with one schema must produce one useful pattern,
+// not one response row per input line.
+func TestPatterns_CompactJSONCollapsesBySchema(t *testing.T) {
+	t.Parallel()
+
+	base := time.Date(2026, 5, 11, 0, 0, 0, 0, time.UTC)
+	const lineCount = 32
+	lines := make([]chclient.TimestampedLine, 0, lineCount)
+	for i := 0; i < lineCount; i++ {
+		ts := base.Add(time.Duration(i) * time.Minute)
+		lines = append(lines, chclient.TimestampedLine{
+			Timestamp: ts,
+			Body: fmt.Sprintf(
+				`{"level":"info","ts":%q,"msg":"HTTP request","method":"GET","path":"/api/users/%d","status":200,"latency_ms":%d}`,
+				ts.Format(time.RFC3339), i, 10+i,
+			),
+			Severity: "INFO",
+		})
+	}
+
+	srv := newServer(&stubQuerier{tsLines: lines})
+	t.Cleanup(srv.Close)
+	resp, err := http.Get(srv.URL +
+		`/loki/api/v1/patterns?query=%7Bservice_name%3D%22web-server%22%7D&start=1778457600&end=1778544000`)
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status=%d", resp.StatusCode)
+	}
+
+	var out patternsResponse
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(out.Data) != 1 {
+		t.Fatalf("compact JSON produced %d patterns for %d schema-identical lines, want 1: %+v", len(out.Data), lineCount, out.Data)
+	}
+	if got := patternSampleTotal(out.Data[0]); got != lineCount {
+		t.Fatalf("pattern sample total = %d, want %d", got, lineCount)
+	}
+	if !strings.Contains(out.Data[0].Pattern, `"method"`) || !strings.Contains(out.Data[0].Pattern, `"GET"`) || !strings.Contains(out.Data[0].Pattern, "<_>") {
+		t.Fatalf("pattern does not preserve JSON schema/literals and variables: %q", out.Data[0].Pattern)
+	}
+}
+
+func patternSampleTotal(pattern loki.Pattern) int64 {
+	var total int64
+	for _, sample := range pattern.Samples {
+		total += sample[1]
+	}
+	return total
+}
 
 type patternsResponse struct {
 	Status string         `json:"status"`

--- a/internal/drain/drain.go
+++ b/internal/drain/drain.go
@@ -12,8 +12,8 @@
 //
 // Algorithm recap (paper §3):
 //
-//   - Preprocessing: each log message is split into tokens on
-//     whitespace.
+//   - Preprocessing: structured JSON/logfmt messages are split into
+//     field-level tokens; ordinary text is split on whitespace.
 //   - Step 1 — search by length: the first tree layer buckets messages
 //     by their token count, on the premise that messages from the same
 //     template usually share a length.
@@ -32,6 +32,7 @@
 package drain
 
 import (
+	"encoding/json"
 	"sort"
 	"strconv"
 	"strings"
@@ -181,7 +182,7 @@ func New(cfg Config) *Miner {
 // epoch) into the tree, creating or updating a cluster. Empty lines are
 // ignored.
 func (m *Miner) Train(line string, tsNano int64) {
-	tokens := strings.Fields(line)
+	tokens := tokenize(line)
 	if len(tokens) == 0 {
 		return
 	}
@@ -194,6 +195,140 @@ func (m *Miner) Train(line string, tsNano int64) {
 	m.addCluster(cl)
 	cl.observe(tsNano)
 	m.all = append(m.all, cl)
+}
+
+// tokenize selects a field-aware tokenisation for structured log lines and
+// falls back to Drain's whitespace tokenisation for ordinary text. Keeping
+// keys, separators, and values in separate positions gives the similarity
+// stage stable schema tokens while allowing values to generalise.
+func tokenize(line string) []string {
+	if tokens, ok := tokenizeJSON(line); ok {
+		return tokens
+	}
+	if tokens, ok := tokenizeLogfmt(line); ok {
+		return tokens
+	}
+	return strings.Fields(line)
+}
+
+// tokenizeJSON lexes a valid JSON object or array without interpreting its
+// values. Raw string and number spellings stay intact, while structural
+// punctuation becomes its own token. This preserves field order in the
+// rendered pattern and, critically, prevents a compact document from becoming
+// one indivisible token.
+func tokenizeJSON(line string) ([]string, bool) {
+	trimmed := strings.TrimSpace(line)
+	if len(trimmed) == 0 || (trimmed[0] != '{' && trimmed[0] != '[') || !json.Valid([]byte(trimmed)) {
+		return nil, false
+	}
+
+	tokens := make([]string, 0)
+	for i := 0; i < len(trimmed); {
+		switch trimmed[i] {
+		case ' ', '\t', '\r', '\n':
+			i++
+		case '{', '}', '[', ']', ':', ',':
+			tokens = append(tokens, trimmed[i:i+1])
+			i++
+		case '"':
+			start := i
+			i++
+			for i < len(trimmed) {
+				if trimmed[i] == '\\' {
+					i += 2
+					continue
+				}
+				i++
+				if trimmed[i-1] == '"' {
+					break
+				}
+			}
+			tokens = append(tokens, trimmed[start:i])
+		default:
+			start := i
+			for i < len(trimmed) && !isJSONDelimiter(trimmed[i]) {
+				i++
+			}
+			tokens = append(tokens, trimmed[start:i])
+		}
+	}
+	return tokens, true
+}
+
+func isJSONDelimiter(b byte) bool {
+	switch b {
+	case ' ', '\t', '\r', '\n', '{', '}', '[', ']', ':', ',':
+		return true
+	default:
+		return false
+	}
+}
+
+// tokenizeLogfmt splits a line made entirely of key=value fields, respecting
+// whitespace and escaped quotes inside quoted values. A line with any bare
+// field is ordinary text and falls back to strings.Fields, so messages such as
+// "GET /path status=200" keep their existing Drain behavior.
+func tokenizeLogfmt(line string) ([]string, bool) {
+	var tokens []string
+	for i := 0; i < len(line); {
+		for i < len(line) && isLogfmtSpace(line[i]) {
+			i++
+		}
+		if i == len(line) {
+			break
+		}
+
+		start := i
+		quoted := false
+		for i < len(line) {
+			switch line[i] {
+			case '\\':
+				if quoted && i+1 < len(line) {
+					i += 2
+					continue
+				}
+			case '"':
+				quoted = !quoted
+			case ' ', '\t', '\r', '\n':
+				if !quoted {
+					goto fieldDone
+				}
+			}
+			i++
+		}
+
+	fieldDone:
+		if quoted {
+			return nil, false
+		}
+		field := line[start:i]
+		eq := strings.IndexByte(field, '=')
+		if eq <= 0 || !validLogfmtKey(field[:eq]) {
+			return nil, false
+		}
+		tokens = append(tokens, field[:eq], "=", field[eq+1:])
+	}
+	return tokens, len(tokens) != 0
+}
+
+func isLogfmtSpace(b byte) bool {
+	switch b {
+	case ' ', '\t', '\r', '\n':
+		return true
+	default:
+		return false
+	}
+}
+
+func validLogfmtKey(key string) bool {
+	for i := 0; i < len(key); i++ {
+		b := key[i]
+		if (b >= 'a' && b <= 'z') || (b >= 'A' && b <= 'Z') || b == '_' || b == '.' || b == '-' || (i > 0 && b >= '0' && b <= '9') {
+			continue
+		}
+		return false
+	}
+	return true
 }
 
 // Clusters returns every discovered cluster in creation order. The

--- a/internal/drain/drain_test.go
+++ b/internal/drain/drain_test.go
@@ -1,11 +1,71 @@
 package drain_test
 
 import (
+	"fmt"
 	"testing"
 	"time"
 
 	"github.com/tsouza/cerberus/internal/drain"
 )
+
+// TestDrain_CompactJSONCollapsesBySchema pins #2080: compact JSON has no
+// whitespace, so treating the whole line as one token creates one cluster per
+// observation. Field-aware tokenisation must expose the stable schema and
+// literals to Drain while allowing timestamps, paths, and measurements to
+// generalise.
+func TestDrain_CompactJSONCollapsesBySchema(t *testing.T) {
+	t.Parallel()
+	d := drain.New(drain.DefaultConfig())
+	base := time.Date(2026, 5, 11, 0, 0, 0, 0, time.UTC)
+	const lineCount = 32
+	for i := 0; i < lineCount; i++ {
+		line := fmt.Sprintf(
+			`{"level":"info","ts":%q,"msg":"HTTP request","method":"GET","path":"/api/users/%d","status":200,"latency_ms":%d}`,
+			base.Add(time.Duration(i)*time.Minute).Format(time.RFC3339), i, 10+i,
+		)
+		d.Train(line, base.Add(time.Duration(i)*time.Minute).UnixNano())
+	}
+
+	clusters := d.Clusters()
+	if len(clusters) != 1 {
+		t.Fatalf("compact JSON produced %d clusters for %d schema-identical lines, want 1", len(clusters), lineCount)
+	}
+	if got := clusters[0].Count(); got != lineCount {
+		t.Fatalf("cluster count = %d, want %d", got, lineCount)
+	}
+	for _, want := range []string{`"method"`, `"GET"`, "<_>"} {
+		if !contains(clusters[0].String(), want) {
+			t.Fatalf("template %q does not preserve %q", clusters[0].String(), want)
+		}
+	}
+}
+
+// TestDrain_LogfmtKeepsQuotedFields pins the structured fallback: quoted
+// values containing whitespace remain one field value, while variable values
+// generalise independently from their stable keys.
+func TestDrain_LogfmtKeepsQuotedFields(t *testing.T) {
+	t.Parallel()
+	d := drain.New(drain.DefaultConfig())
+	base := time.Date(2026, 5, 11, 0, 0, 0, 0, time.UTC)
+	for i := 0; i < 8; i++ {
+		line := fmt.Sprintf(
+			`level=info ts=%q msg="HTTP request" method=GET path=/api/users/%d status=200`,
+			base.Add(time.Duration(i)*time.Minute).Format(time.RFC3339), i,
+		)
+		d.Train(line, base.Add(time.Duration(i)*time.Minute).UnixNano())
+	}
+
+	clusters := d.Clusters()
+	if len(clusters) != 1 {
+		t.Fatalf("logfmt produced %d clusters, want 1", len(clusters))
+	}
+	template := clusters[0].String()
+	for _, want := range []string{`level = info`, `msg = "HTTP request"`, `method = GET`, "<_>"} {
+		if !contains(template, want) {
+			t.Fatalf("template %q does not preserve %q", template, want)
+		}
+	}
+}
 
 // findCluster returns the first cluster whose template contains every
 // given substring, or nil.


### PR DESCRIPTION
Closes #2080

## What changed

- tokenizes valid JSON objects/arrays into structural field-level tokens before Drain clustering
- tokenizes complete logfmt lines into key/separator/value tokens while preserving quoted values
- keeps whitespace tokenization as the fallback for ordinary text
- adds miner-level and `/loki/api/v1/patterns` regressions proving 32 compact-JSON lines sharing one schema collapse to one pattern

## Root cause

`Miner.Train` always used `strings.Fields`. A compact JSON document contains no whitespace, so each full line became one token. Distinct timestamps and values therefore had zero token similarity and created one cluster per line.

The new tokenizers are a clean-room implementation using only the Go standard library and cerberus code; no upstream AGPL implementation is linked or copied.

## Validation

- `go test -race ./internal/drain/ ./internal/logql/logpattern/ ./internal/api/loki/`
- targeted pre-fix regression reproduced 32 clusters for 32 schema-identical lines; the fixed miner and HTTP endpoint both return one cluster/pattern
