### PR TITLE
fix(loki): bound patterns and honor step

### DIFF
--- a/internal/api/loki/conformance_test.go
+++ b/internal/api/loki/conformance_test.go
@@ -636,20 +636,19 @@ func TestConformance_LokiPatternsBasic(t *testing.T) {
 	t.Parallel()
 
 	base := time.Date(2026, 5, 14, 12, 0, 0, 0, time.UTC)
-	// 5 canned (Timestamp, Body) rows feeding the stub Querier — drain
-	// folds them into >=1 clusters when the handler trains on them.
+	// Enough canned rows to meet upstream's retained-pattern volume floor;
+	// drain folds them into one cluster when the handler trains on them.
 	// Drain rejects lines with fewer than 4 tokens, so each body
 	// includes at least four space-separated chunks (path, status,
 	// latency suffix) to satisfy the minimum.
-	q := &stubQuerier{
-		tsLines: []chclient.TimestampedLine{
-			{Timestamp: base, Body: "GET /api/foo/1 status=200 latency=5ms"},
-			{Timestamp: base.Add(1 * time.Second), Body: "GET /api/foo/2 status=200 latency=7ms"},
-			{Timestamp: base.Add(2 * time.Second), Body: "GET /api/foo/3 status=200 latency=4ms"},
-			{Timestamp: base.Add(3 * time.Second), Body: "GET /api/foo/4 status=200 latency=11ms"},
-			{Timestamp: base.Add(4 * time.Second), Body: "GET /api/foo/5 status=200 latency=9ms"},
-		},
+	lines := make([]chclient.TimestampedLine, 0, retainedPatternVolumeFloor)
+	for i := 0; i < retainedPatternVolumeFloor; i++ {
+		lines = append(lines, chclient.TimestampedLine{
+			Timestamp: base.Add(time.Duration(i) * time.Second),
+			Body:      "GET /api/foo/1 status=200 latency=5ms",
+		})
 	}
+	q := &stubQuerier{tsLines: lines}
 	srv := newServer(q)
 	t.Cleanup(srv.Close)
 
@@ -681,7 +680,8 @@ func TestConformance_LokiPatternsBasic(t *testing.T) {
 		t.Fatalf("expected non-nil Data slice (JSON []); got nil — body=%s", body)
 	}
 	if len(env.Data) < 1 {
-		t.Fatalf("expected >=1 cluster after 5 trained lines; got %d — body=%s",
+		t.Fatalf("expected >=1 cluster after %d trained lines; got %d — body=%s",
+			retainedPatternVolumeFloor,
 			len(env.Data), body)
 	}
 	// Per-element pins: each Pattern decodes with the

--- a/internal/api/loki/patterns.go
+++ b/internal/api/loki/patterns.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/prometheus/prometheus/model/labels"
 
+	"github.com/tsouza/cerberus/internal/api/format"
 	"github.com/tsouza/cerberus/internal/chclient"
 	"github.com/tsouza/cerberus/internal/chsql"
 	"github.com/tsouza/cerberus/internal/drain"
@@ -21,7 +22,23 @@ import (
 // supplied. Mirrors detected_fields' default — drain's
 // `MaxAllowedLineLength` already bounds per-line cost; this caps the
 // number of lines.
-const defaultPatternsLineLimit = 1000
+const (
+	defaultPatternsLineLimit = 1000
+
+	// minimumPatternVolume mirrors upstream Loki's minClusterSize: a
+	// template must account for at least this many log lines before it is
+	// useful enough to return to the pattern panel.
+	minimumPatternVolume = 30
+
+	// maximumPatternSeries mirrors upstream Loki's maxPatterns response
+	// bound. The volume sort below makes the retained series the most
+	// significant templates, rather than the first ones alphabetically.
+	maximumPatternSeries = 300
+
+	// minimumPatternSampleResolution is both the default when the request
+	// omits step and the execution floor upstream applies to smaller steps.
+	minimumPatternSampleResolution = 10 * time.Second
+)
 
 // Pattern is one detected log-line template plus its time-bucketed
 // sample counts. The upstream Loki contract (verified against
@@ -83,6 +100,11 @@ func (h *Handler) handlePatterns(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusBadRequest, ErrBadData, err)
 		return
 	}
+	step, err := parsePatternsStep(r.FormValue("step"), start, end)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, ErrBadData, err)
+		return
+	}
 
 	sqlStr, args, err := buildPatternsSQL(h.Schema, matchers, start, end, lineLimit)
 	if err != nil {
@@ -98,7 +120,7 @@ func (h *Handler) handlePatterns(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	patterns := minePatterns(lines)
+	patterns := minePatterns(lines, step)
 
 	writeJSON(w, http.StatusOK, Response{
 		Status: "success",
@@ -152,21 +174,28 @@ func buildPatternsSQL(s schema.Logs, matchers []*labels.Matcher, start, end time
 // instance (confirmed independent — a Miner owns its own token tree and
 // cluster slice, no shared state), so lines never mix templates across
 // levels.
-func minePatterns(lines []chclient.TimestampedLine) []Pattern {
+func minePatterns(lines []chclient.TimestampedLine, step time.Duration) []Pattern {
+	type patternWithVolume struct {
+		pattern Pattern
+		volume  int64
+	}
+
 	miners := make(map[string]*drain.Miner)
 	levels := make([]string, 0)
 	for _, line := range lines {
 		level := logql.NormalizeDetectedLevel(line.Severity)
 		m, ok := miners[level]
 		if !ok {
-			m = drain.New(drain.DefaultConfig())
+			cfg := drain.DefaultConfig()
+			cfg.SampleResolution = step
+			m = drain.New(cfg)
 			miners[level] = m
 			levels = append(levels, level)
 		}
 		m.Train(line.Body, line.Timestamp.UnixNano())
 	}
 
-	out := make([]Pattern, 0)
+	weighted := make([]patternWithVolume, 0)
 	for _, level := range levels {
 		for _, c := range miners[level].Clusters() {
 			if c == nil {
@@ -176,25 +205,56 @@ func minePatterns(lines []chclient.TimestampedLine) []Pattern {
 			if s == "" {
 				continue
 			}
-			out = append(out, Pattern{
-				Pattern: s,
-				Level:   level,
-				Samples: projectSamples(c.Samples()),
+			if c.Count() < minimumPatternVolume {
+				continue
+			}
+			weighted = append(weighted, patternWithVolume{
+				pattern: Pattern{
+					Pattern: s,
+					Level:   level,
+					Samples: projectSamples(c.Samples()),
+				},
+				volume: c.Count(),
 			})
 		}
 	}
-	// Stable response order — drain's Clusters() return order follows
-	// LRU cache traversal, which is not deterministic across runs.
-	// Sorting by (pattern, level) lets Grafana / tests pin on the wire
-	// shape without flake; the level tiebreak matters now that the same
-	// pattern string can recur across two different level buckets.
-	sort.Slice(out, func(i, j int) bool {
-		if out[i].Pattern != out[j].Pattern {
-			return out[i].Pattern < out[j].Pattern
+	// Upstream retains the most significant patterns: sort by descending
+	// total volume before applying its hard series cap. Pattern and level
+	// are deterministic tie-breaks for equal-volume clusters.
+	sort.SliceStable(weighted, func(i, j int) bool {
+		if weighted[i].volume != weighted[j].volume {
+			return weighted[i].volume > weighted[j].volume
 		}
-		return out[i].Level < out[j].Level
+		if weighted[i].pattern.Pattern != weighted[j].pattern.Pattern {
+			return weighted[i].pattern.Pattern < weighted[j].pattern.Pattern
+		}
+		return weighted[i].pattern.Level < weighted[j].pattern.Level
 	})
+	if len(weighted) > maximumPatternSeries {
+		weighted = weighted[:maximumPatternSeries]
+	}
+	out := make([]Pattern, len(weighted))
+	for i := range weighted {
+		out[i] = weighted[i].pattern
+	}
 	return out
+}
+
+func parsePatternsStep(raw string, start, end time.Time) (time.Duration, error) {
+	if raw == "" {
+		return minimumPatternSampleResolution, nil
+	}
+	step, err := format.ParseDuration(raw)
+	if err != nil || step <= 0 {
+		return 0, errors.New("invalid 'step' parameter")
+	}
+	if end.Sub(start)/step > format.MaxResolutionPoints {
+		return 0, errors.New(format.ResolutionCapMessage)
+	}
+	if step < minimumPatternSampleResolution {
+		return minimumPatternSampleResolution, nil
+	}
+	return step, nil
 }
 
 // projectSamples converts the in-house drain cluster samples

--- a/internal/api/loki/patterns.go
+++ b/internal/api/loki/patterns.go
@@ -120,7 +120,7 @@ func (h *Handler) handlePatterns(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	patterns := minePatterns(lines, step)
+	patterns := minePatterns(lines, start, end, step)
 
 	writeJSON(w, http.StatusOK, Response{
 		Status: "success",
@@ -174,7 +174,7 @@ func buildPatternsSQL(s schema.Logs, matchers []*labels.Matcher, start, end time
 // instance (confirmed independent — a Miner owns its own token tree and
 // cluster slice, no shared state), so lines never mix templates across
 // levels.
-func minePatterns(lines []chclient.TimestampedLine, step time.Duration) []Pattern {
+func minePatterns(lines []chclient.TimestampedLine, start, end time.Time, step time.Duration) []Pattern {
 	type patternWithVolume struct {
 		pattern Pattern
 		volume  int64
@@ -205,16 +205,18 @@ func minePatterns(lines []chclient.TimestampedLine, step time.Duration) []Patter
 			if s == "" {
 				continue
 			}
-			if c.Count() < minimumPatternVolume {
+			samples := projectSamples(c.Samples(), start, end)
+			volume := sampleVolume(samples)
+			if volume < minimumPatternVolume {
 				continue
 			}
 			weighted = append(weighted, patternWithVolume{
 				pattern: Pattern{
 					Pattern: s,
 					Level:   level,
-					Samples: projectSamples(c.Samples()),
+					Samples: samples,
 				},
-				volume: c.Count(),
+				volume: volume,
 			})
 		}
 	}
@@ -259,15 +261,31 @@ func parsePatternsStep(raw string, start, end time.Time) (time.Duration, error) 
 
 // projectSamples converts the in-house drain cluster samples
 // (TimestampUnixSec, Count) onto the upstream wire shape
-// `[][unix_seconds, count]`. Samples already arrive ascending by
-// timestamp (drain.Cluster.Samples sorts), and the resolution is whole
+// `[][unix_seconds, count]`. Drain aligns buckets to the Unix grid, so an
+// unaligned request start can put the first bucket's timestamp before the
+// query window even though its rows were in-window. Upstream drops that
+// partial pre-start bucket; apply the same [start,end] timestamp filter
+// before the volume floor is evaluated. Samples already arrive ascending
+// by timestamp (drain.Cluster.Samples sorts), and the resolution is whole
 // seconds, matching upstream's `WriteQueryPatternsResponseJSON`, which
 // emits `sample.Timestamp.Unix()`.
-func projectSamples(samples []drain.Sample) [][2]int64 {
+func projectSamples(samples []drain.Sample, start, end time.Time) [][2]int64 {
 	out := make([][2]int64, 0, len(samples))
 	for _, s := range samples {
+		stamp := time.Unix(s.TimestampUnixSec, 0)
+		if stamp.Before(start) || stamp.After(end) {
+			continue
+		}
 		out = append(out, [2]int64{s.TimestampUnixSec, s.Count})
 	}
 	sort.Slice(out, func(i, j int) bool { return out[i][0] < out[j][0] })
 	return out
+}
+
+func sampleVolume(samples [][2]int64) int64 {
+	var total int64
+	for _, sample := range samples {
+		total += sample[1]
+	}
+	return total
 }

--- a/internal/api/loki/patterns_chdb_test.go
+++ b/internal/api/loki/patterns_chdb_test.go
@@ -67,15 +67,12 @@ func newChDBPatternsServer(t *testing.T, ddl string) (*httptest.Server, *chclien
 	return srv, c
 }
 
-// TestPatterns_ChDB_DrainRoundtrip seeds otel_logs with 10 lines across
-// three pattern shapes, exercises the handler end-to-end through chDB,
+// TestPatterns_ChDB_DrainRoundtrip seeds otel_logs with one pattern at
+// upstream's volume floor, exercises the handler end-to-end through chDB,
 // and asserts the response carries:
-//   - at least one cluster (drain folds the lines into >=1 templates;
-//     the seed is shaped to produce exactly 3 token-skeletons but drain
-//     may merge based on SimTh — the lower bound is robust),
-//   - sum of samples[*][1] across all clusters == 10 (every trained
-//     line accounts for one count, none dropped by the limiter — drain's
-//     DefaultConfig.MaxClusters is 300, far above three),
+//   - one retained cluster (all rows share one token skeleton),
+//   - sum of samples[*][1] across all clusters == 30 (every trained
+//     line accounts for one count),
 //   - at least one cluster contains both "GET" and "200" (the dominant
 //     shape), exercising the structural-not-exact assertion strategy
 //     from plan §4,
@@ -91,38 +88,25 @@ func TestPatterns_ChDB_DrainRoundtrip(t *testing.T) {
 	base := time.Date(2026, 5, 14, 12, 0, 0, 0, time.UTC)
 	const tsFmt = "2006-01-02 15:04:05.000"
 
-	// Three pattern shapes. Drain rejects lines with fewer than 4
-	// tokens, so each body carries at least four space-separated chunks
-	// (verb, path, status, latency suffix) to clear the threshold.
+	// One pattern shape at upstream's 30-line retention floor. Drain
+	// rejects lines with fewer than 4 tokens, so each body carries at
+	// least four space-separated chunks (verb, path, status, latency
+	// suffix) to clear the threshold.
 	//
-	//   - 5x "GET /api/foo/<N> status=200 latency=<L>ms" — drain folds
-	//     into a single template
-	//   - 3x "GET /api/bar/<M> status=200 latency=<L>ms" — drain folds
-	//     into a single template (may merge with foo at coarser
-	//     `LogClusterDepth` settings)
-	//   - 2x "POST /bar status=500 latency=<L>ms" — drain folds into
-	//     a single template
-	//
-	// Total: 10 lines, expected >=1 cluster (seed is engineered to
-	// yield up to 3; drain's punctuation tokeniser may merge based on
-	// SimTh — the lower-bound assertion is robust).
-	seedRows := []struct {
+	// All rows use "GET /api/foo/<N> status=200 latency=<L>ms", which
+	// drain folds into a single retained template.
+	seedRows := make([]struct {
 		dt   time.Duration
 		body string
-	}{
-		// GET /api/foo/<N> ... — 5 variants.
-		{0 * time.Second, "GET /api/foo/1 status=200 latency=5ms"},
-		{1 * time.Second, "GET /api/foo/2 status=200 latency=7ms"},
-		{2 * time.Second, "GET /api/foo/3 status=200 latency=4ms"},
-		{3 * time.Second, "GET /api/foo/4 status=200 latency=11ms"},
-		{4 * time.Second, "GET /api/foo/5 status=200 latency=9ms"},
-		// GET /api/bar/<M> ... — 3 variants.
-		{5 * time.Second, "GET /api/bar/10 status=200 latency=12ms"},
-		{6 * time.Second, "GET /api/bar/20 status=200 latency=8ms"},
-		{7 * time.Second, "GET /api/bar/30 status=200 latency=6ms"},
-		// POST /bar ... — 2 lines, varied latency.
-		{8 * time.Second, "POST /bar status=500 latency=22ms"},
-		{9 * time.Second, "POST /bar status=500 latency=18ms"},
+	}, 0, retainedPatternVolumeFloor)
+	for i := 0; i < retainedPatternVolumeFloor; i++ {
+		seedRows = append(seedRows, struct {
+			dt   time.Duration
+			body string
+		}{
+			dt:   time.Duration(i) * time.Second,
+			body: fmt.Sprintf("GET /api/foo/%d status=200 latency=%dms", i, i+1),
+		})
 	}
 
 	var inserts strings.Builder
@@ -144,7 +128,7 @@ func TestPatterns_ChDB_DrainRoundtrip(t *testing.T) {
 	startUnix := base.Add(-1 * time.Minute).Unix()
 	endUnix := base.Add(1 * time.Minute).Unix()
 	url := fmt.Sprintf(
-		`%s/loki/api/v1/patterns?query=%%7Bjob%%3D%%22api%%22%%7D&start=%d&end=%d&line_limit=20`,
+		`%s/loki/api/v1/patterns?query=%%7Bjob%%3D%%22api%%22%%7D&start=%d&end=%d&line_limit=30`,
 		srv.URL, startUnix, endUnix,
 	)
 	resp, err := http.Get(url)
@@ -167,33 +151,30 @@ func TestPatterns_ChDB_DrainRoundtrip(t *testing.T) {
 		t.Fatalf("status=%q want success", out.Status)
 	}
 
-	// Plan §4 assertion: cluster count is >=1. The seed is shaped to
-	// yield exactly 3 (one per token skeleton); drain's punctuation
-	// tokeniser may split or merge differently across upstream bumps,
-	// so the assertion is the lower bound — anything below 1 means
-	// the SQL did not retrieve any rows or drain failed to train.
+	// The 30 structurally equivalent rows meet the retention floor, so
+	// anything below one cluster means the SQL did not retrieve them or
+	// drain failed to train.
 	if len(out.Data) < 1 {
-		t.Fatalf("expected >=1 cluster after training 10 lines; got %d: %+v",
+		t.Fatalf("expected >=1 cluster after training %d lines; got %d: %+v",
+			retainedPatternVolumeFloor,
 			len(out.Data), out.Data)
 	}
 
 	// Plan §4 assertion: sum of samples[*][1] across all clusters ==
-	// 10 (every trained line accounts for one count, none dropped by
-	// the limiter — DefaultConfig.MaxClusters is 300, far above 3).
+	// 30 (every trained line accounts for one count).
 	var totalCount int64
 	for _, p := range out.Data {
 		for _, s := range p.Samples {
 			totalCount += s[1]
 		}
 	}
-	if totalCount != 10 {
-		t.Errorf("expected sample-count sum == 10 (one per trained line); got %d across %d clusters",
-			totalCount, len(out.Data))
+	if totalCount != retainedPatternVolumeFloor {
+		t.Errorf("expected sample-count sum == %d (one per trained line); got %d across %d clusters",
+			retainedPatternVolumeFloor, totalCount, len(out.Data))
 	}
 
 	// Plan §4 assertion: at least one cluster contains the literal
-	// tokens "GET" and "200" (the dominant 8-line shape across foo
-	// and bar). Structural assertion — drain's `<_>` placeholder may
+	// tokens "GET" and "200". Structural assertion — drain's `<_>` placeholder may
 	// land anywhere between the verbs/codes.
 	var foundGET bool
 	for _, p := range out.Data {

--- a/internal/api/loki/patterns_semantics_internal_test.go
+++ b/internal/api/loki/patterns_semantics_internal_test.go
@@ -20,7 +20,7 @@ func TestMinePatternsVolumeFloor(t *testing.T) {
 	lines := repeatedPatternLines(base, "rare alpha quiet path", belowFloorCount)
 	lines = append(lines, repeatedPatternLines(base, "common beta loud route", atFloorCount)...)
 
-	got := minePatterns(lines, minimumPatternSampleResolution)
+	got := minePatterns(lines, base, base.Add(time.Minute), minimumPatternSampleResolution)
 	if len(got) != 1 {
 		t.Fatalf("patterns=%d want 1: %+v", len(got), got)
 	}
@@ -48,7 +48,7 @@ func TestMinePatternsVolumeSortAndSeriesCap(t *testing.T) {
 		}
 	}
 
-	got := minePatterns(lines, minimumPatternSampleResolution)
+	got := minePatterns(lines, base, base.Add(time.Minute), minimumPatternSampleResolution)
 	if len(got) != maximumPatternSeries {
 		t.Fatalf("patterns=%d want hard cap %d", len(got), maximumPatternSeries)
 	}
@@ -80,7 +80,7 @@ func TestMinePatternsUsesRequestedStep(t *testing.T) {
 		})
 	}
 
-	got := minePatterns(lines, requestedStep)
+	got := minePatterns(lines, base, base.Add(30*time.Second), requestedStep)
 	if len(got) != 1 {
 		t.Fatalf("patterns=%d want 1: %+v", len(got), got)
 	}

--- a/internal/api/loki/patterns_semantics_internal_test.go
+++ b/internal/api/loki/patterns_semantics_internal_test.go
@@ -1,0 +1,172 @@
+package loki
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/tsouza/cerberus/internal/api/format"
+	"github.com/tsouza/cerberus/internal/chclient"
+)
+
+func TestMinePatternsVolumeFloor(t *testing.T) {
+	t.Parallel()
+
+	const (
+		belowFloorCount = minimumPatternVolume - 1
+		atFloorCount    = minimumPatternVolume
+	)
+	base := time.Unix(0, 0).UTC()
+	lines := repeatedPatternLines(base, "rare alpha quiet path", belowFloorCount)
+	lines = append(lines, repeatedPatternLines(base, "common beta loud route", atFloorCount)...)
+
+	got := minePatterns(lines, minimumPatternSampleResolution)
+	if len(got) != 1 {
+		t.Fatalf("patterns=%d want 1: %+v", len(got), got)
+	}
+	if got[0].Pattern != "common beta loud route" {
+		t.Fatalf("retained pattern=%q want the cluster at the volume floor", got[0].Pattern)
+	}
+	if volume := patternTestVolume(got[0]); volume != atFloorCount {
+		t.Fatalf("retained volume=%d want %d", volume, atFloorCount)
+	}
+}
+
+func TestMinePatternsVolumeSortAndSeriesCap(t *testing.T) {
+	t.Parallel()
+
+	const candidateSeries = maximumPatternSeries + 1
+	base := time.Unix(0, 0).UTC()
+	lines := make([]chclient.TimestampedLine, 0, candidateSeries*minimumPatternVolume+1)
+	var highestVolumePattern string
+	for i := 0; i < candidateSeries; i++ {
+		body := distinctPatternBody(i)
+		lines = append(lines, repeatedPatternLines(base, body, minimumPatternVolume)...)
+		if i == candidateSeries-1 {
+			highestVolumePattern = body
+			lines = append(lines, chclient.TimestampedLine{Timestamp: base, Body: body, Severity: "INFO"})
+		}
+	}
+
+	got := minePatterns(lines, minimumPatternSampleResolution)
+	if len(got) != maximumPatternSeries {
+		t.Fatalf("patterns=%d want hard cap %d", len(got), maximumPatternSeries)
+	}
+	if got[0].Pattern != highestVolumePattern {
+		t.Fatalf("first pattern=%q want highest-volume %q", got[0].Pattern, highestVolumePattern)
+	}
+	if volume := patternTestVolume(got[0]); volume != minimumPatternVolume+1 {
+		t.Fatalf("first volume=%d want %d", volume, minimumPatternVolume+1)
+	}
+	for i := 1; i < len(got); i++ {
+		if patternTestVolume(got[i-1]) < patternTestVolume(got[i]) {
+			t.Fatalf("patterns not volume-descending at %d: %d < %d", i,
+				patternTestVolume(got[i-1]), patternTestVolume(got[i]))
+		}
+	}
+}
+
+func TestMinePatternsUsesRequestedStep(t *testing.T) {
+	t.Parallel()
+
+	const requestedStep = 15 * time.Second
+	base := time.Unix(0, 0).UTC()
+	lines := make([]chclient.TimestampedLine, 0, minimumPatternVolume)
+	for i := 0; i < minimumPatternVolume; i++ {
+		lines = append(lines, chclient.TimestampedLine{
+			Timestamp: base.Add(time.Duration(i) * time.Second),
+			Body:      "common beta loud route",
+			Severity:  "INFO",
+		})
+	}
+
+	got := minePatterns(lines, requestedStep)
+	if len(got) != 1 {
+		t.Fatalf("patterns=%d want 1: %+v", len(got), got)
+	}
+	want := [][2]int64{{0, 15}, {15, 15}}
+	if len(got[0].Samples) != len(want) {
+		t.Fatalf("samples=%v want %v", got[0].Samples, want)
+	}
+	for i := range want {
+		if got[0].Samples[i] != want[i] {
+			t.Fatalf("sample[%d]=%v want %v", i, got[0].Samples[i], want[i])
+		}
+	}
+}
+
+func TestParsePatternsStep(t *testing.T) {
+	t.Parallel()
+
+	start := time.Unix(0, 0).UTC()
+	end := start.Add(time.Hour)
+	for _, tc := range []struct {
+		name string
+		raw  string
+		want time.Duration
+	}{
+		{name: "absent defaults to drain resolution", want: minimumPatternSampleResolution},
+		{name: "sub-floor step uses execution floor", raw: "5s", want: minimumPatternSampleResolution},
+		{name: "plain seconds", raw: "15", want: 15 * time.Second},
+		{name: "duration", raw: "1m", want: time.Minute},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := parsePatternsStep(tc.raw, start, end)
+			if err != nil {
+				t.Fatalf("parsePatternsStep(%q): %v", tc.raw, err)
+			}
+			if got != tc.want {
+				t.Fatalf("step=%s want %s", got, tc.want)
+			}
+		})
+	}
+
+	for _, raw := range []string{"0", "-1", "invalid"} {
+		if _, err := parsePatternsStep(raw, start, end); err == nil {
+			t.Errorf("parsePatternsStep(%q) succeeded; want error", raw)
+		}
+	}
+	overCapEnd := start.Add((format.MaxResolutionPoints + 1) * time.Second)
+	if _, err := parsePatternsStep("1s", start, overCapEnd); err == nil {
+		t.Error("step exceeding the resolution cap succeeded; want error")
+	}
+}
+
+func repeatedPatternLines(base time.Time, body string, count int) []chclient.TimestampedLine {
+	lines := make([]chclient.TimestampedLine, count)
+	for i := range lines {
+		lines[i] = chclient.TimestampedLine{
+			Timestamp: base.Add(time.Duration(i) * time.Second),
+			Body:      body,
+			Severity:  "INFO",
+		}
+	}
+	return lines
+}
+
+func distinctPatternBody(n int) string {
+	id := alphabeticPatternID(n)
+	return strings.Join([]string{"alpha" + id, "beta" + id, "gamma" + id, "delta" + id}, " ")
+}
+
+func alphabeticPatternID(n int) string {
+	const alphabet = "abcdefghijklmnopqrstuvwxyz"
+	var reversed [3]byte
+	pos := len(reversed)
+	for {
+		pos--
+		reversed[pos] = alphabet[n%len(alphabet)]
+		n = n/len(alphabet) - 1
+		if n < 0 {
+			return string(reversed[pos:])
+		}
+	}
+}
+
+func patternTestVolume(pattern Pattern) int64 {
+	var total int64
+	for _, sample := range pattern.Samples {
+		total += sample[1]
+	}
+	return total
+}

--- a/internal/api/loki/patterns_test.go
+++ b/internal/api/loki/patterns_test.go
@@ -242,6 +242,64 @@ func TestPatterns_UsesRequestedStep(t *testing.T) {
 	}
 }
 
+func TestPatterns_DropsPartialPreStartBucket(t *testing.T) {
+	t.Parallel()
+
+	const (
+		requestStartUnix = int64(1786836195)
+		requestEndUnix   = int64(1786836315)
+		firstFullBucket  = int64(1786836200)
+	)
+	lines := []chclient.TimestampedLine{{
+		Timestamp: time.Unix(requestStartUnix+2, 0).UTC(),
+		Body:      "live warning request failed",
+		Severity:  "WARN",
+	}}
+	for offset := int64(0); offset < 4; offset++ {
+		lines = append(lines, chclient.TimestampedLine{
+			Timestamp: time.Unix(firstFullBucket+offset, 0).UTC(),
+			Body:      "live warning request failed",
+			Severity:  "WARN",
+		})
+	}
+	for i := 4; i < retainedPatternVolumeFloor; i++ {
+		lines = append(lines, chclient.TimestampedLine{
+			Timestamp: time.Unix(firstFullBucket+10, 0).UTC(),
+			Body:      "live warning request failed",
+			Severity:  "WARN",
+		})
+	}
+
+	srv := newServer(&stubQuerier{tsLines: lines})
+	t.Cleanup(srv.Close)
+	resp, err := http.Get(srv.URL +
+		`/loki/api/v1/patterns?query=%7Bservice_name%3D%22cerberus-patterns-live%22%7D` +
+		`&start=1786836195&end=1786836315&step=10s`)
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status=%d", resp.StatusCode)
+	}
+
+	var out patternsResponse
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(out.Data) != 1 {
+		t.Fatalf("patterns=%d want 1: %+v", len(out.Data), out.Data)
+	}
+	if got := out.Data[0].Samples[0]; got != [2]int64{firstFullBucket, 4} {
+		t.Fatalf("first sample=%v want [%d 4]; partial pre-start bucket was not dropped", got, firstFullBucket)
+	}
+	for _, sample := range out.Data[0].Samples {
+		if sample[0] < requestStartUnix || sample[0] > requestEndUnix {
+			t.Fatalf("sample %v outside request window [%d,%d]", sample, requestStartUnix, requestEndUnix)
+		}
+	}
+}
+
 // TestPatterns_BucketsByDetectedLevel feeds the handler two structurally
 // identical templates at different severities and asserts the handler
 // emits two DISTINCT clusters, one per level — pattern mining must not

--- a/internal/api/loki/patterns_test.go
+++ b/internal/api/loki/patterns_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -73,6 +74,8 @@ type patternsResponse struct {
 	Data   []loki.Pattern `json:"data"`
 }
 
+const retainedPatternVolumeFloor = 30
+
 // TestPatterns_EmptyPeekWindow — when the peek SQL returns zero rows the
 // drain miner emits no clusters and the handler returns the empty-data
 // envelope. Grafana renders this gracefully (the panel just shows "no
@@ -117,14 +120,15 @@ func TestPatterns_DrainExtractsCommonTemplate(t *testing.T) {
 	t.Parallel()
 
 	base := time.Date(2026, 5, 14, 12, 0, 0, 0, time.UTC)
-	q := &stubQuerier{
-		tsLines: []chclient.TimestampedLine{
-			{Timestamp: base, Body: "GET /api/users/1 status=200 latency=5ms", Severity: "INFO"},
-			{Timestamp: base.Add(1 * time.Second), Body: "GET /api/users/2 status=200 latency=7ms", Severity: "INFO"},
-			{Timestamp: base.Add(2 * time.Second), Body: "GET /api/users/42 status=200 latency=4ms", Severity: "INFO"},
-			{Timestamp: base.Add(3 * time.Second), Body: "GET /api/users/1337 status=200 latency=11ms", Severity: "INFO"},
-		},
+	lines := make([]chclient.TimestampedLine, 0, retainedPatternVolumeFloor)
+	for i := 0; i < retainedPatternVolumeFloor; i++ {
+		lines = append(lines, chclient.TimestampedLine{
+			Timestamp: base.Add(time.Duration(i) * time.Second),
+			Body:      "GET /api/users/" + strconv.Itoa(i) + " status=200 latency=" + strconv.Itoa(i+1) + "ms",
+			Severity:  "INFO",
+		})
 	}
+	q := &stubQuerier{tsLines: lines}
 
 	srv := newServer(q)
 	t.Cleanup(srv.Close)
@@ -172,13 +176,13 @@ func TestPatterns_DrainExtractsCommonTemplate(t *testing.T) {
 	}
 	// Per upstream WriteQueryPatternsResponseJSON: each sample is
 	// [unix_seconds, count]. Sum of counts across all samples for this
-	// cluster must equal the number of trained lines (4).
+	// cluster must equal the number of trained lines.
 	var total int64
 	for _, s := range hit.Samples {
 		total += s[1]
 	}
-	if total != 4 {
-		t.Errorf("expected sample count sum of 4 (one per trained line); got %d", total)
+	if total != retainedPatternVolumeFloor {
+		t.Errorf("expected sample count sum of %d (one per trained line); got %d", retainedPatternVolumeFloor, total)
 	}
 	// Sample timestamps are unix SECONDS (not ms / ns). 2026-05-14T12:00:00 UTC = 1778760000.
 	const baseUnix = 1778760000
@@ -195,6 +199,49 @@ func TestPatterns_DrainExtractsCommonTemplate(t *testing.T) {
 	}
 }
 
+func TestPatterns_UsesRequestedStep(t *testing.T) {
+	t.Parallel()
+
+	base := time.Unix(0, 0).UTC()
+	lines := make([]chclient.TimestampedLine, 0, retainedPatternVolumeFloor)
+	for i := 0; i < retainedPatternVolumeFloor; i++ {
+		lines = append(lines, chclient.TimestampedLine{
+			Timestamp: base.Add(time.Duration(i) * time.Second),
+			Body:      "GET /api/users/42 status=200 latency=5ms",
+			Severity:  "INFO",
+		})
+	}
+	srv := newServer(&stubQuerier{tsLines: lines})
+	t.Cleanup(srv.Close)
+
+	resp, err := http.Get(srv.URL +
+		`/loki/api/v1/patterns?query=%7Bjob%3D%22api%22%7D&start=0&end=30&step=15s`)
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status=%d", resp.StatusCode)
+	}
+
+	var out patternsResponse
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(out.Data) != 1 {
+		t.Fatalf("patterns=%d want 1: %+v", len(out.Data), out.Data)
+	}
+	want := [][2]int64{{0, 15}, {15, 15}}
+	if len(out.Data[0].Samples) != len(want) {
+		t.Fatalf("samples=%v want %v", out.Data[0].Samples, want)
+	}
+	for i := range want {
+		if out.Data[0].Samples[i] != want[i] {
+			t.Fatalf("sample[%d]=%v want %v", i, out.Data[0].Samples[i], want[i])
+		}
+	}
+}
+
 // TestPatterns_BucketsByDetectedLevel feeds the handler two structurally
 // identical templates at different severities and asserts the handler
 // emits two DISTINCT clusters, one per level — pattern mining must not
@@ -205,13 +252,15 @@ func TestPatterns_BucketsByDetectedLevel(t *testing.T) {
 	t.Parallel()
 
 	base := time.Date(2026, 5, 14, 12, 0, 0, 0, time.UTC)
-	q := &stubQuerier{
-		tsLines: []chclient.TimestampedLine{
-			{Timestamp: base, Body: "connection reset by peer", Severity: "ERROR"},
-			{Timestamp: base.Add(1 * time.Second), Body: "connection reset by peer", Severity: "err"},
-			{Timestamp: base.Add(2 * time.Second), Body: "connection reset by peer", Severity: "WARN"},
-		},
+	lines := make([]chclient.TimestampedLine, 0, 2*retainedPatternVolumeFloor)
+	for i := 0; i < retainedPatternVolumeFloor; i++ {
+		lines = append(
+			lines,
+			chclient.TimestampedLine{Timestamp: base.Add(time.Duration(i) * time.Second), Body: "connection reset by peer", Severity: "ERROR"},
+			chclient.TimestampedLine{Timestamp: base.Add(time.Duration(i) * time.Second), Body: "connection reset by peer", Severity: "WARN"},
+		)
 	}
+	q := &stubQuerier{tsLines: lines}
 
 	srv := newServer(q)
 	t.Cleanup(srv.Close)
@@ -239,15 +288,14 @@ func TestPatterns_BucketsByDetectedLevel(t *testing.T) {
 		}
 		byLevel[p.Level] += total
 	}
-	// The two "ERROR"/"err" lines normalize to the same "error" bucket
-	// (two samples); the "WARN" line is its own "warn" bucket (one
-	// sample) — never merged with the error-level cluster despite an
+	// Both severity buckets meet the upstream volume floor and remain
+	// separate — never merged despite an
 	// identical line body.
-	if byLevel["error"] != 2 {
-		t.Errorf("expected 2 samples in level=error, got %d (byLevel=%+v)", byLevel["error"], byLevel)
+	if byLevel["error"] != retainedPatternVolumeFloor {
+		t.Errorf("expected %d samples in level=error, got %d (byLevel=%+v)", retainedPatternVolumeFloor, byLevel["error"], byLevel)
 	}
-	if byLevel["warn"] != 1 {
-		t.Errorf("expected 1 sample in level=warn, got %d (byLevel=%+v)", byLevel["warn"], byLevel)
+	if byLevel["warn"] != retainedPatternVolumeFloor {
+		t.Errorf("expected %d samples in level=warn, got %d (byLevel=%+v)", retainedPatternVolumeFloor, byLevel["warn"], byLevel)
 	}
 	if _, ok := byLevel[""]; ok {
 		t.Errorf("expected no empty-level cluster, got byLevel=%+v", byLevel)
@@ -322,6 +370,8 @@ func TestPatterns_BadInput(t *testing.T) {
 		{"bad start", `/loki/api/v1/patterns?query=%7Bjob%3D%22api%22%7D&start=banana&end=2`},
 		{"bad line_limit", `/loki/api/v1/patterns?query=%7Bjob%3D%22api%22%7D&start=1&end=2&line_limit=banana`},
 		{"non-positive line_limit", `/loki/api/v1/patterns?query=%7Bjob%3D%22api%22%7D&start=1&end=2&line_limit=0`},
+		{"bad step", `/loki/api/v1/patterns?query=%7Bjob%3D%22api%22%7D&start=1&end=2&step=banana`},
+		{"non-positive step", `/loki/api/v1/patterns?query=%7Bjob%3D%22api%22%7D&start=1&end=2&step=0`},
 	}
 	for _, tc := range cases {
 		tc := tc


### PR DESCRIPTION
Closes #2081.

## What changed

- honor `/loki/api/v1/patterns?step=` with Loki-compatible parsing, the 10-second execution floor, and the 11,000-point request guard
- drop aligned sample buckets whose timestamp falls before an unaligned request start, matching live Loki behavior
- prune clusters below 30 in-window observations
- sort retained clusters by descending volume and cap the response at 300 series
- preserve deterministic pattern/level tie-breaking

## Validation

- focused Loki handler and mining tests under `-race`, including the live unaligned-start regression
- focused chDB `/patterns` roundtrip and empty-window tests
- repository pre-commit and pre-push gates