### PR TITLE
perf(api/prom): prune histogram arms for pinned gauges

### DIFF
--- a/internal/api/prom/handler_label_values_matched_test.go
+++ b/internal/api/prom/handler_label_values_matched_test.go
@@ -295,7 +295,10 @@ func TestLabelValues_MatchSelector_UpstreamError(t *testing.T) {
 	t.Cleanup(srv.Close)
 
 	resp, err := http.Get(srv.URL + "/api/v1/label/job/values?" +
-		"match%5B%5D=up")
+		// The explicit counter suffix bypasses bare-histogram classification,
+		// so the injected error still comes from the matched-value query this
+		// regression is intended to cover.
+		"match%5B%5D=requests_total")
 	if err != nil {
 		t.Fatalf("GET: %v", err)
 	}

--- a/internal/api/prom/handler_labels_histogram_test.go
+++ b/internal/api/prom/handler_labels_histogram_test.go
@@ -24,6 +24,7 @@ type labelKeysStub struct {
 	// values slice. Default (no key matches) returns an empty slice so
 	// the union flows through without picking up phantom labels.
 	resultsBySQLContains map[string][]string
+	histogramBases       []string
 	sqls                 []string
 	// samples mirror stubQuerier's behaviour for the /series surface;
 	// the executeInstant path runs the matcher through QueryCursor, so
@@ -51,6 +52,14 @@ func (s *labelKeysStub) QueryStrings(_ context.Context, sql string, _ ...any) ([
 	s.recordSQL(sql)
 	s.mu.Lock()
 	defer s.mu.Unlock()
+	// The histogram-base catalogue projects only MetricName/TimeUnix. Matched
+	// label-name/value arms necessarily carry Attributes, so this distinguishes
+	// the classification lookup from the data query without matching SQL text
+	// that the test does not own.
+	if strings.Contains(sql, "otel_metrics_histogram") &&
+		strings.Contains(sql, "MetricName") && !strings.Contains(sql, "Attributes") {
+		return s.histogramBases, nil
+	}
 	for needle, vals := range s.resultsBySQLContains {
 		if strings.Contains(sql, needle) {
 			return vals, nil
@@ -117,6 +126,7 @@ func TestLabels_HistogramBareName_FansOutCompanions(t *testing.T) {
 	// + `cerberus_ql` to mimic the histogram's stored label keys;
 	// the gauge-targeted base arm returns nothing.
 	stub := &labelKeysStub{
+		histogramBases: []string{"cerberus_clickhouse_bytes_read"},
 		resultsBySQLContains: map[string][]string{
 			"otel_metrics_histogram": {"le", "cerberus_ql"},
 		},
@@ -172,6 +182,7 @@ func TestLabelValues_HistogramBareName_FansOutCompanions(t *testing.T) {
 	t.Parallel()
 
 	stub := &labelKeysStub{
+		histogramBases: []string{"cerberus_clickhouse_bytes_read"},
 		resultsBySQLContains: map[string][]string{
 			"otel_metrics_histogram": {"0.5", "1", "+Inf"},
 		},

--- a/internal/api/prom/handler_metadata_fanin_test.go
+++ b/internal/api/prom/handler_metadata_fanin_test.go
@@ -63,6 +63,9 @@ type faninRecordingQuerier struct {
 	// per-candidate label sets — exactly what the per-candidate reference
 	// path would have returned.
 	sampleFor map[string][]chclient.Sample
+	// stringResults answers the histogram-base catalogue lookup used to
+	// classify equality-pinned metric names before building /series arms.
+	stringResults []string
 
 	querySQLs   []string
 	stringsSQLs []string
@@ -92,7 +95,7 @@ func (q *faninRecordingQuerier) QueryCursor(_ context.Context, sql string, args 
 func (q *faninRecordingQuerier) QueryStrings(_ context.Context, sql string, args ...any) ([]string, error) {
 	q.stringsSQLs = append(q.stringsSQLs, sql)
 	q.stringsArgs = append(q.stringsArgs, args)
-	return nil, nil
+	return q.stringResults, nil
 }
 
 func (q *faninRecordingQuerier) QueryLabelSets(_ context.Context, _ string, _ ...any) ([]map[string]string, error) {
@@ -343,7 +346,7 @@ func assertBoundedFanout(t *testing.T, endpoint string, n int, sqls []string, ar
 // round-trip.
 func TestHandleSeries_TypicalChipIsOneRoundTrip(t *testing.T) {
 	t.Parallel()
-	q := &faninRecordingQuerier{}
+	q := &faninRecordingQuerier{stringResults: []string{"http_server_request_duration"}}
 	srv := faninServer(q)
 	defer srv.Close()
 
@@ -363,6 +366,76 @@ func TestHandleSeries_TypicalChipIsOneRoundTrip(t *testing.T) {
 	if rt := len(q.querySQLs); rt != 1 {
 		t.Fatalf("typical histogram-base chip issued %d /series round-trips, want exactly "+
 			"1 (the fan-in win); SQLs:\n%s", rt, strings.Join(q.querySQLs, "\n---\n"))
+	}
+	if len(q.stringsSQLs) != 1 {
+		t.Fatalf("histogram-base catalogue lookups = %d, want 1", len(q.stringsSQLs))
+	}
+	if sql := q.querySQLs[0]; !strings.Contains(sql, schema.DefaultOTelMetrics().HistogramTable) ||
+		!strings.Contains(sql, "arrayJoin") {
+		t.Fatalf("catalogued histogram base lost its histogram bucket arm:\n%s", sql)
+	}
+}
+
+// TestHandleSeries_PinnedGaugePrunesHistogramCompanionArms reproduces #2085:
+// Grafana Metrics Drilldown asks /series for one equality-pinned gauge name,
+// but the pre-fix matcher expansion treated every bare name as a possible
+// classic-histogram base. That produced base, _bucket, _count, and _sum
+// variants; their table routing then pulled the histogram bucket ladder and
+// repeated gauge/sum scans into one large UNION ALL.
+//
+// The histogram catalogue is empty in this fixture, proving the pinned name is
+// not a classic-histogram base. The resulting data query must therefore retain
+// only the unavoidable unknown-kind gauge+sum pair: one merged scan naming
+// each table once, with no UNION ALL, histogram, or arrayJoin arm.
+func TestHandleSeries_PinnedGaugePrunesHistogramCompanionArms(t *testing.T) {
+	t.Parallel()
+
+	q := &faninRecordingQuerier{}
+	srv := faninServer(q)
+	defer srv.Close()
+
+	form := url.Values{}
+	form.Add("match[]", `{__name__="system_network_conntrack_max"}`)
+	resp, err := http.PostForm(srv.URL+"/api/v1/series", form)
+	if err != nil {
+		t.Fatalf("POST /series: %v", err)
+	}
+	body := readBody(t, resp)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status=%d body=%s", resp.StatusCode, body)
+	}
+	if got := len(q.stringsSQLs); got != 1 {
+		t.Errorf("histogram-base catalogue lookups = %d, want 1", got)
+	} else {
+		catalogueSQL := q.stringsSQLs[0]
+		metrics := schema.DefaultOTelMetrics()
+		if !strings.Contains(catalogueSQL, metrics.HistogramTable) {
+			t.Errorf("histogram-base catalogue lookup missed %s:\n%s", metrics.HistogramTable, catalogueSQL)
+		}
+		if !strings.Contains(catalogueSQL, "HAVING") || !strings.Contains(catalogueSQL, "max(") {
+			t.Errorf("histogram-base catalogue lookup is not bounded by the now-anchored max timestamp:\n%s", catalogueSQL)
+		}
+	}
+	if got := len(q.querySQLs); got != 1 {
+		t.Fatalf("/series data queries = %d, want 1", got)
+	}
+
+	sql := q.querySQLs[0]
+	metrics := schema.DefaultOTelMetrics()
+	if got := strings.Count(sql, metrics.GaugeTable); got != 1 {
+		t.Errorf("gauge-table arms = %d, want 1\nSQL: %s", got, sql)
+	}
+	if got := strings.Count(sql, metrics.SumTable); got != 1 {
+		t.Errorf("sum-table arms = %d, want 1\nSQL: %s", got, sql)
+	}
+	if strings.Contains(sql, metrics.HistogramTable) {
+		t.Errorf("pinned gauge query retained a histogram arm\nSQL: %s", sql)
+	}
+	if strings.Contains(sql, "arrayJoin") {
+		t.Errorf("pinned gauge query retained the histogram bucket ladder\nSQL: %s", sql)
+	}
+	if got := strings.Count(sql, "UNION ALL"); got != 0 {
+		t.Errorf("UNION ALL boundaries = %d, want 0 for one merged gauge+sum scan\nSQL: %s", got, sql)
 	}
 }
 

--- a/internal/api/prom/metadata.go
+++ b/internal/api/prom/metadata.go
@@ -1284,11 +1284,22 @@ func (h *Handler) catalogMatcherSQL(
 // metadata surface and the query path answer with exactly the same set.
 // Both families are pinned, in both directions, by
 // internal/api/prom/handler_chdb_series_storage_spelling_test.go.
-func expandSeriesMatchers(parser promparser.Parser, matchers []string, s schema.Metrics) []string {
+func expandSeriesMatchers(
+	parser promparser.Parser,
+	matchers []string,
+	s schema.Metrics,
+	histogramBases map[string]struct{},
+) []string {
 	seen := make(map[string]struct{})
 	out := make([]string, 0, len(matchers))
 	for _, m := range matchers {
-		for _, variant := range expandBareHistogramMatcher(parser, m, s) {
+		variants := []string{m}
+		if base, ok := bareHistogramBaseName(parser, m); ok {
+			if _, isHistogram := histogramBases[base]; isHistogram {
+				variants = expandBareHistogramMatcher(parser, m, s)
+			}
+		}
+		for _, variant := range variants {
 			if _, dup := seen[variant]; dup {
 				continue
 			}
@@ -1301,19 +1312,21 @@ func expandSeriesMatchers(parser promparser.Parser, matchers []string, s schema.
 
 // expandMetadataMatchers is the single matcher fan-out every matched metadata
 // surface (/series, /labels, /label/<name>/values) runs. It layers the
-// name-shape expansion that needs no data (the classic-histogram companions,
-// see [expandSeriesMatchers]) with the one that
-// does: a `__name__` matcher that is NOT pinned to an equality — a regex or a
+// catalogue-gated classic-histogram companion expansion (see
+// [expandSeriesMatchers]) with unpinned-name resolution: a `__name__` matcher
+// that is NOT pinned to an equality — a regex or a
 // negated regex — cannot be resolved against the stored MetricName column,
 // because the histogram-derived names it speaks about exist only as synthetic
 // companions of a stored base name (see regex_name_histogram.go).
 //
-// For those selectors the base names present in the window are enumerated once
-// — [Handler.histogramBaseNames], the same enumeration the `__name__` catalog
-// answers from, so both surfaces agree on which families exist — and each
-// synthetic name the matcher accepts is appended as an equality-pinned variant.
-// Selectors whose name is already pinned skip the enumeration entirely, so the
-// common metric-picker shapes issue no extra query.
+// The base names present in the window are enumerated once whenever resolution
+// needs them — for an unpinned selector, or for a bare equality-pinned name that
+// might be a classic-histogram base. This is the same enumeration the `__name__`
+// catalog answers from, so both surfaces agree on which families exist. A bare
+// pinned name expands to its synthetic companions only when that set contains
+// the base; ordinary gauges and counters keep one matcher variant instead of
+// paying for the histogram bucket/count/sum arms. Already-suffixed equality
+// matchers need no enumeration because their table routing is explicit.
 //
 // Only the caller's own matchers are classified, never the expanded variants:
 // the two expansions above fire exclusively on equality-pinned names, so a
@@ -1325,27 +1338,39 @@ func expandSeriesMatchers(parser promparser.Parser, matchers []string, s schema.
 func (h *Handler) expandMetadataMatchers(
 	ctx context.Context, matchers []string, start, end time.Time, nowAnchored bool,
 ) ([]string, error) {
-	variants := expandSeriesMatchers(h.parser, matchers, h.Schema)
-
 	type unpinned struct {
 		nameMatchers []*labels.Matcher
 		other        []*labels.Matcher
 	}
 	var needResolution []unpinned
+	needsHistogramBases := false
 	for _, matcher := range matchers {
+		if _, ok := bareHistogramBaseName(h.parser, matcher); ok {
+			needsHistogramBases = true
+		}
 		nameMatchers, other, ok := unpinnedMetricNameMatchers(h.parser, matcher)
 		if !ok {
 			continue
 		}
 		needResolution = append(needResolution, unpinned{nameMatchers: nameMatchers, other: other})
 	}
+
+	var bases []string
+	if needsHistogramBases || len(needResolution) > 0 {
+		var err error
+		bases, err = h.histogramBaseNames(ctx, start, end, nowAnchored)
+		if err != nil {
+			return nil, err
+		}
+	}
+	histogramBases := make(map[string]struct{}, len(bases))
+	for _, base := range bases {
+		histogramBases[base] = struct{}{}
+	}
+	variants := expandSeriesMatchers(h.parser, matchers, h.Schema, histogramBases)
+
 	if len(needResolution) == 0 {
 		return variants, nil
-	}
-
-	bases, err := h.histogramBaseNames(ctx, start, end, nowAnchored)
-	if err != nil {
-		return nil, err
 	}
 	if len(bases) == 0 {
 		return variants, nil

--- a/internal/api/prom/regex_name_histogram_test.go
+++ b/internal/api/prom/regex_name_histogram_test.go
@@ -242,18 +242,17 @@ func (q *recordingQuerier) QueryExemplars(context.Context, string, ...any) ([]ch
 	return nil, nil
 }
 
-// TestExpandMetadataMatchers_PinnedNameIssuesNoEnumeration pins the cost of the
-// common case: a selector whose `__name__` is already pinned to an equality
-// needs no name set, so the metadata path must not issue the base-name
-// enumeration at all.
-func TestExpandMetadataMatchers_PinnedNameIssuesNoEnumeration(t *testing.T) {
+// TestExpandMetadataMatchers_PinnedCompanionIssuesNoEnumeration pins the
+// explicit-suffix fast path: a `_total` selector cannot denote a bare classic
+// histogram base, so its table routing needs no histogram-name catalogue.
+func TestExpandMetadataMatchers_PinnedCompanionIssuesNoEnumeration(t *testing.T) {
 	t.Parallel()
 
 	q := &recordingQuerier{strings: []string{"synth_latency_seconds"}}
 	h := New(q, schema.DefaultOTelMetrics(), nil)
 	start, end := metadataTestWindow()
 
-	if _, err := h.expandMetadataMatchers(context.Background(), []string{`{__name__="up"}`}, start, end, false); err != nil {
+	if _, err := h.expandMetadataMatchers(context.Background(), []string{`{__name__="requests_total"}`}, start, end, false); err != nil {
 		t.Fatalf("expandMetadataMatchers: %v", err)
 	}
 	if len(q.sql) != 0 {

--- a/test/perf/cardinality-baseline/metadata/series_no_bounds.json
+++ b/test/perf/cardinality-baseline/metadata/series_no_bounds.json
@@ -1,10 +1,10 @@
 {
   "fixture": "metadata/series_no_bounds",
-  "fan_factor": 0.4,
-  "scan_rows": 600,
+  "fan_factor": 1,
+  "scan_rows": 240,
   "peak_intermediate": 240,
   "has_cross_join": false,
-  "has_array_join": true,
+  "has_array_join": false,
   "has_recursive_cte": false,
   "max_recursion_depth": 0,
   "uncountable_levels": 0

--- a/test/perf/metadata-query-size-baseline.json
+++ b/test/perf/metadata-query-size-baseline.json
@@ -1,5 +1,5 @@
 {
-  "bound_bytes_per_selector_bound": 37755,
-  "bound_bytes_per_selector_floor": 22653,
-  "combined_queries_bound": 6
+  "bound_bytes_per_selector_bound": 5525,
+  "bound_bytes_per_selector_floor": 3315,
+  "combined_queries_bound": 3
 }

--- a/test/perf/series_fanout_chdb_test.go
+++ b/test/perf/series_fanout_chdb_test.go
@@ -26,9 +26,10 @@
 // with a rendered-size guard keeping every query under CH's max_query_size).
 // This harness drives the real in-process Prom handler against a chDB
 // session via a round-trip-counting Querier decorator and now asserts the
-// post-fan-in invariant: a typical histogram-shaped request issues EXACTLY
-// ONE round-trip. It also runs the equivalent single combined query
-// directly to size the wall-clock win the fan-in delivers.
+// post-fan-in invariant: a typical histogram-shaped request issues exactly
+// one bounded histogram-catalog lookup and exactly one metrics query. It also
+// runs the equivalent single combined metrics query directly to size the
+// wall-clock win the fan-in delivers.
 package perf
 
 import (
@@ -38,6 +39,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"slices"
 	"sync"
 	"testing"
 	"time"
@@ -231,6 +233,23 @@ func TestSeriesFanout_ChDB(t *testing.T) {
 	t.Logf("end-to-end handler wall:     %v", totalWall.Round(time.Microsecond))
 	t.Logf("mean per-trip:               %v", (chSum / time.Duration(max1(n))).Round(time.Microsecond))
 
+	// --- ASSERTION: fan-in shipped — one catalog probe + one metrics query ---
+	//
+	// Pinned-name routing first asks the bounded histogram catalog whether the
+	// name is a real histogram base, then uses that answer to choose the arm
+	// family. The lookup is intentionally separate from the sample query; the
+	// fan-in invariant is that every selected sample arm still collapses into
+	// ONE combined Query call below the K=128 cap. Checking the method sequence
+	// keeps a second sample query from hiding behind the expected catalog cost.
+	wantMethods := []string{"QueryStrings", "Query"}
+	if !slices.Equal(methods, wantMethods) {
+		t.Fatalf("/series fan-in regression: ClickHouse method sequence = %v, want %v. "+
+			"A pinned histogram-shaped matcher must issue one bounded histogram-catalog "+
+			"lookup followed by one combined metrics query; extra Query calls mean the "+
+			"sample-arm fan-out regressed.", methods, wantMethods)
+	}
+	metricsQueryWall := perOp[1]
+
 	// --- Projected batched cost: one OR-joined combined query ---------
 	//
 	// Model the task #71 refactor: instead of N sequential instant queries,
@@ -276,30 +295,12 @@ SELECT DISTINCT MetricName, Attributes FROM (
 	}
 
 	t.Logf("--- projected batched (single combined query) ---")
-	t.Logf("combined-query round-trips:  1  (was %d)", n)
+	t.Logf("combined-query round-trips:  1  (handler metrics queries: 1)")
 	t.Logf("combined-query best wall:    %v", best.Round(time.Microsecond))
-	if chSum > 0 {
-		t.Logf("CH-time delta:               %v (fan-out)  ->  %v (combined)  =  %.1fx",
-			chSum.Round(time.Microsecond), best.Round(time.Microsecond),
-			float64(chSum)/float64(best))
-	}
-
-	// --- ASSERTION: fan-in shipped — typical request is ONE round-trip ---
-	//
-	// The /series fan-in batching (task #71) landed on main: the
-	// nested matcher fan-out now collapses into ONE combined UNION-ALL
-	// query (chunked to ⌈N/K⌉ only past the K=128 arm cap). The matcher
-	// above (`{__name__="http_server_request_duration"}`) fans out to its
-	// H (classic-histogram companion) variants — far below the cap — so the batched handler issues EXACTLY ONE CH
-	// round-trip. This is the deterministic post-fan-in guard: a regression
-	// that re-introduced the per-variant loop (or otherwise un-batched the
-	// fan-out) would inflate n back above 1 and trip here.
-	if n != 1 {
-		t.Fatalf("/series fan-in regression: a typical histogram-shaped match[] request "+
-			"issued %d ClickHouse round-trips, want exactly 1. The fan-in batching (task "+
-			"#71) collapses the variant fan-out into one combined UNION-ALL query for "+
-			"any request below the K=128 arm cap; an n>1 here means the per-variant loop "+
-			"regressed or the combined query was split when it should not have been.", n)
+	if metricsQueryWall > 0 {
+		t.Logf("metrics-query CH-time delta: %v (handler)  ->  %v (direct)  =  %.1fx",
+			metricsQueryWall.Round(time.Microsecond), best.Round(time.Microsecond),
+			float64(metricsQueryWall)/float64(best))
 	}
 }
 


### PR DESCRIPTION
## Summary

- classify bare equality-pinned metadata matchers against the bounded classic-histogram catalogue
- expand `_bucket`, `_count`, and `_sum` companions only for bases present in that catalogue
- keep explicit companion/counter suffixes on their zero-lookup fast path
- pin both sides structurally: gauges use one merged gauge+sum scan, while real histograms retain their bucket ladder

## Root cause and impact

Every bare pinned metric name was treated as a possible classic-histogram base. A plain gauge therefore expanded into four matcher variants whose table routing produced repeated gauge, sum, and histogram scans, including `arrayJoin` over the bucket ladder. Grafana Metrics Drilldown pays this cost for each metric tile.

The handler now reuses the bounded histogram-base enumeration already used by regex metadata matching. Plain gauges avoid the histogram arms; actual histogram bases preserve the existing companion surface.

Fixes #2085.

## Validation

- `go test -race ./internal/api/prom/`
- targeted pinned-gauge and histogram-control API regressions
- `node .github/scripts/forbid-sql-raw.mjs`
- `git diff --check`
