### PR TITLE
perf(spec): reuse round-trip work in parity

### DIFF
--- a/internal/logql/lower_test.go
+++ b/internal/logql/lower_test.go
@@ -94,7 +94,7 @@ func TestLower(t *testing.T) {
 		if err != nil {
 			t.Fatalf("Emit(optimized plan): %v", err)
 		}
-		spec.RunRoundTripSQL(t, c, optSQL, optArgs)
+		roundTripResult := spec.RunRoundTripSQL(t, c, optSQL, optArgs)
 
 		// A fixture carrying a `parity:` section is additionally answered
 		// by the REAL upstream Loki engine over the same seeded data, and
@@ -105,7 +105,7 @@ func TestLower(t *testing.T) {
 		// test/spec/parity.go for why the fixture stores the parity
 		// CONTRACT and not the parity ANSWER.
 		parityStart, parityEnd, parityStep := parityWindow(start, end, step)
-		spec.RunParity(t, c, spec.ParityEval{Start: parityStart, End: parityEnd, Step: parityStep})
+		spec.RunParity(t, c, spec.ParityEval{Start: parityStart, End: parityEnd, Step: parityStep}, roundTripResult)
 	})
 }
 

--- a/internal/promql/lower_test.go
+++ b/internal/promql/lower_test.go
@@ -186,7 +186,7 @@ func TestLower(t *testing.T) {
 		if err != nil {
 			t.Fatalf("Emit(optimized plan): %v", err)
 		}
-		spec.RunRoundTripSQL(t, c, optSQL, optArgs)
+		roundTripResult := spec.RunRoundTripSQL(t, c, optSQL, optArgs)
 
 		// A fixture carrying a `parity:` section is additionally answered
 		// by the REAL upstream Prometheus engine over the same seeded
@@ -214,7 +214,7 @@ func TestLower(t *testing.T) {
 			}
 			parityStart, parityEnd, parityStep = rangeStart, rangeEnd, d
 		}
-		spec.RunParity(t, c, spec.ParityEval{Start: parityStart, End: parityEnd, Step: parityStep})
+		spec.RunParity(t, c, spec.ParityEval{Start: parityStart, End: parityEnd, Step: parityStep}, roundTripResult)
 	})
 }
 

--- a/internal/traceql/lower_test.go
+++ b/internal/traceql/lower_test.go
@@ -109,7 +109,7 @@ func TestLower(t *testing.T) {
 		if err != nil {
 			t.Fatalf("Emit(optimized plan): %v", err)
 		}
-		spec.RunRoundTripSQL(t, c, optSQL, optArgs)
+		roundTripResult := spec.RunRoundTripSQL(t, c, optSQL, optArgs)
 
 		// A fixture carrying a `parity:` section is additionally checked
 		// against the REAL upstream Tempo engine — including its own
@@ -123,7 +123,7 @@ func TestLower(t *testing.T) {
 		// The zero ParityEval is the honest value here: a spanset query
 		// selects spans rather than sampling a time series, so no
 		// evaluation instant or step participates in the comparison.
-		spec.RunParity(t, c, spec.ParityEval{})
+		spec.RunParity(t, c, spec.ParityEval{}, roundTripResult)
 	})
 }
 

--- a/test/spec/parity_chdb.go
+++ b/test/spec/parity_chdb.go
@@ -124,7 +124,7 @@ var lokiParityEvaluator func(
 // with no runner compiled into this lane is a FATAL error, never a silent
 // pass: a fixture that believes it is enrolled and is not would be the
 // hollow green the whole mechanism exists to prevent.
-func RunParity(t *testing.T, c *Case, eval ParityEval) {
+func RunParity(t *testing.T, c *Case, eval ParityEval, roundTrip RoundTripResult) {
 	t.Helper()
 
 	p, enrolled, err := LoadParity(c)
@@ -144,6 +144,13 @@ func RunParity(t *testing.T, c *Case, eval ParityEval) {
 			"fixture %s carries a `parity:` section but no executable round-trip. "+
 				"The parity check reads the seeded rows back out of chDB, so it needs the same "+
 				"`seed:` + `expected_rows:` opt-in RunRoundTrip needs.", c.Name,
+		)
+	}
+	if !roundTrip.seeded || roundTrip.fixtureName != c.Name {
+		t.Fatalf(
+			"fixture %s: parity requires the successful RunRoundTripSQL result for the same fixture; "+
+				"got fixture %q (seeded=%t)",
+			c.Name, roundTrip.fixtureName, roundTrip.seeded,
 		)
 	}
 
@@ -170,7 +177,6 @@ func RunParity(t *testing.T, c *Case, eval ParityEval) {
 	defer chdbEngineMu.Unlock()
 
 	db := OpenChDB(t)
-	ApplySeed(t, db, rt.Seed)
 
 	q := parityQuery{
 		Expr:  resolveAtModifiers(strings.TrimSpace(query), eval.Start, eval.End, eval.Step),
@@ -200,9 +206,9 @@ func RunParity(t *testing.T, c *Case, eval ParityEval) {
 		t.Fatalf("fixture %s: %v", c.Name, err)
 	}
 
-	cols, err := parityProjectionColumns(db, rt)
-	if err != nil {
-		t.Fatalf("fixture %s: %v", c.Name, err)
+	cols := roundTrip.projectionColumns
+	if len(cols) == 0 {
+		t.Fatalf("fixture %s: RunRoundTripSQL returned no driver projection columns", c.Name)
 	}
 	sc, err := locateSampleColumns(cols)
 	if err != nil {
@@ -821,43 +827,6 @@ func (r metricNameRestorer) record(labels map[string]string, name string) error 
 
 // compareAgainstReference is the assertion itself. See
 // [comparesTimestamps] for which axes participate and why.
-// parityProjectionColumns returns the column names of the projection that
-// produced this fixture's `expected_rows:`.
-//
-// The names come from the DRIVER, by running the fixture's own pinned
-// `sql:` section against the already-seeded session and asking the result
-// for its columns. The alternative — parsing the outer SELECT's aliases
-// out of the SQL text — would be a second, hand-written answer to a
-// question the driver already answers exactly, and the two would
-// eventually disagree on some projection nobody thought to test.
-//
-// Nothing about the comparison becomes self-referential: only the column
-// LABELLING is learned here. Every value still comes from the pinned
-// `expected_rows:`, which is the artefact regeneration can corrupt and
-// therefore the artefact the reference engine must be checked against.
-func parityProjectionColumns(db *sql.DB, rt *RoundTripSections) ([]string, error) {
-	query, args := substituteNow64(rt.SQL, rt.Args)
-	query = testsql.ExpandStarProjection(query, testsql.SeedTableColumns(rt.Seed))
-	query = testsql.RewriteMapProjections(query)
-	query = testsql.NestMapOrderBy(query)
-	query = testsql.NestMapWhere(query)
-
-	rows, err := db.Query(query, args...)
-	if err != nil {
-		return nil, fmt.Errorf("re-run the fixture's own sql to read its projection: %w", err)
-	}
-	defer func() { _ = rows.Close() }()
-
-	// rows.Columns() returns names without instantiating the driver's
-	// column-type table, so it sidesteps the Map rows.ColumnTypes()
-	// panic the round-trip runner documents.
-	cols, err := rows.Columns()
-	if err != nil {
-		return nil, fmt.Errorf("read the projection's column names: %w", err)
-	}
-	return cols, nil
-}
-
 func compareAgainstReference(
 	t *testing.T, c *Case, p *Parity, rt *RoundTripSections, sc sampleColumns,
 	got []referenceSample, compareTimestamps bool, query string,

--- a/test/spec/parity_nochdb.go
+++ b/test/spec/parity_nochdb.go
@@ -20,7 +20,7 @@ import (
 
 // RunParity is a no-op when the `chdb` build tag is not set. The real
 // implementation lives in parity_chdb.go.
-func RunParity(t *testing.T, c *Case, eval ParityEval) {
+func RunParity(t *testing.T, c *Case, eval ParityEval, roundTrip RoundTripResult) {
 	t.Helper()
-	_, _, _ = c, eval, t
+	_, _, _, _ = c, eval, roundTrip, t
 }

--- a/test/spec/parity_reuse_chdb_test.go
+++ b/test/spec/parity_reuse_chdb_test.go
@@ -1,0 +1,78 @@
+//go:build chdb
+
+package spec
+
+import (
+	"os"
+	"path/filepath"
+	"slices"
+	"testing"
+	"time"
+)
+
+const parityReuseQuery = `SELECT '' AS MetricName, CAST(map(), 'Map(String, String)') AS Attributes, toDateTime64('2026-01-01 00:00:01', 9) AS TimeUnix, toFloat64(pi()) AS Value FROM (SELECT 1)`
+
+func TestRunParityReusesRoundTripWork(t *testing.T) {
+	eval := ParityEval{Start: time.Date(2026, 1, 1, 0, 0, 1, 0, time.UTC)}
+
+	t.Run("seed is not applied twice", func(t *testing.T) {
+		// ApplySeed deliberately does not rewrite CREATE VIEW. A second seed
+		// pass would therefore fail with VIEW_ALREADY_EXISTS, making this a
+		// behavioural pin that parity consumes the database RunRoundTripSQL
+		// already populated instead of relying on seed idempotency.
+		c := loadParityReuseFixture(
+			t,
+			"CREATE VIEW parity_seed_once AS SELECT 1;",
+			parityReuseQuery,
+		)
+		result := RunRoundTripSQL(t, c, parityReuseQuery, nil)
+		RunParity(t, c, eval, result)
+	})
+
+	t.Run("projection columns come from the completed round trip", func(t *testing.T) {
+		// The fixture's pinned SQL is intentionally executable only as an
+		// alarm: the optimized caller-supplied query below produces the same
+		// pinned values and column labels. Parity must use the driver columns
+		// carried by its RoundTripResult; re-executing this section merely to
+		// call rows.Columns would trip throwIf.
+		pinnedAlarm := `SELECT throwIf(1, 'projection SQL was re-executed') AS MetricName, CAST(map(), 'Map(String, String)') AS Attributes, toDateTime64('2026-01-01 00:00:01', 9) AS TimeUnix, toFloat64(pi()) AS Value FROM (SELECT 1)`
+		c := loadParityReuseFixture(t, "", pinnedAlarm)
+		result := RunRoundTripSQL(t, c, parityReuseQuery, nil)
+		wantColumns := []string{"MetricName", "Attributes", "TimeUnix", "Value"}
+		if !slices.Equal(result.projectionColumns, wantColumns) {
+			t.Fatalf("RunRoundTripSQL columns = %v, want %v", result.projectionColumns, wantColumns)
+		}
+		RunParity(t, c, eval, result)
+	})
+}
+
+func loadParityReuseFixture(t *testing.T, extraSeed, pinnedSQL string) *Case {
+	t.Helper()
+	body := `-- query.promql --
+pi()
+-- parity --
+oracle: prometheus
+endpoint: /api/v1/query
+scope: full
+-- seed --
+CREATE TABLE otel_metrics_gauge (
+    MetricName String,
+    Attributes Map(String, String),
+    TimeUnix DateTime64(9),
+    Value Float64
+) ENGINE = MergeTree ORDER BY (MetricName, Attributes, TimeUnix);
+` + extraSeed + `
+-- expected_rows --
+[["", {}, "2026-01-01T00:00:01Z", 3.141592653589793]]
+-- sql --
+` + pinnedSQL + "\n"
+	path := filepath.Join(t.TempDir(), "parity_reuse.txtar")
+	if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+	c, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	return c
+}

--- a/test/spec/parity_tempo_chdb_agpl_oracle.go
+++ b/test/spec/parity_tempo_chdb_agpl_oracle.go
@@ -55,7 +55,6 @@ func runTempoParity(t *testing.T, c *Case, p *Parity, rt *RoundTripSections) {
 	defer chdbEngineMu.Unlock()
 
 	db := OpenChDB(t)
-	ApplySeed(t, db, rt.Seed)
 
 	spans, err := readSeededSpans(db)
 	if err != nil {

--- a/test/spec/roundtrip.go
+++ b/test/spec/roundtrip.go
@@ -99,6 +99,18 @@ type RoundTripSections struct {
 	expectedRowsPresent bool
 }
 
+// RoundTripResult is the opaque handoff from [RunRoundTripSQL] to
+// [RunParity]. A successful post-optimizer round trip proves two facts parity
+// otherwise used to rediscover expensively: this fixture's isolated database
+// has already been seeded, and the driver has already reported the result
+// projection's column names. Its fields stay private so callers can only pass
+// the result through; they cannot fabricate a weaker parity input.
+type RoundTripResult struct {
+	fixtureName       string
+	projectionColumns []string
+	seeded            bool
+}
+
 // IsRoundTrip reports whether the fixture opted into the
 // seed+expected_rows assertion path. An explicit `expected_rows: []`
 // counts as opt-in.

--- a/test/spec/runner_chdb.go
+++ b/test/spec/runner_chdb.go
@@ -109,9 +109,9 @@ var chdbSessionSettingsApplied bool
 
 // chdbActiveDatabases maps a fixture subtest's t.Name() to the isolated
 // database OpenChDB already created for it, so a fixture that calls
-// OpenChDB more than once (RunRoundTrip, then RunRoundTripSQL, then
-// RunParity -- test/spec/parity_chdb.go's RunParity opens its own chDB
-// session too) pays ONE CREATE DATABASE / DROP DATABASE cycle for the
+// OpenChDB more than once (RunRoundTripSQL, then RunParity --
+// test/spec/parity_chdb.go's RunParity opens its own chDB session too)
+// pays ONE CREATE DATABASE / DROP DATABASE cycle for the
 // whole fixture rather than one per call. Every call still re-issues USE,
 // which is a single, cheap statement, so a later call is never left
 // pointing at a database an earlier call's cleanup already dropped out
@@ -283,17 +283,14 @@ func isolatedChDBDatabaseName(testName string) string {
 // and exec's each piece. Statements wrapped in single-quoted strings
 // keep their semicolons literal (handled by a tiny state machine).
 //
-// Idempotency within one fixture: a single fixture's seed can run
-// through this more than once in the same session — RunRoundTrip
-// (pre-optimizer) and RunRoundTripSQL/RunParity (post-optimizer /
-// reference-engine) all reseed the same `seed:` text into the isolated
-// DATABASE [OpenChDB] created for the fixture, which it caches for the
-// whole subtest and drops only at the END of it, not between these
-// calls. The applier promotes bare `CREATE TABLE` to
-// `CREATE OR REPLACE TABLE` so a second pass over the same seed within
-// one fixture doesn't trip TABLE_ALREADY_EXISTS. Fixture authors who
-// want strict CH semantics can opt out by writing
-// `CREATE OR REPLACE TABLE` / `CREATE TABLE IF NOT EXISTS` themselves.
+// The applier remains idempotent for direct harness callers: it promotes bare
+// `CREATE TABLE` to `CREATE OR REPLACE TABLE` so a repeated application inside
+// one fixture does not trip TABLE_ALREADY_EXISTS. The normal parity path does
+// not rely on that tolerance: [RunRoundTripSQL] applies the seed once and
+// returns a [RoundTripResult] proving it, then [RunParity] reuses the same
+// isolated database. Fixture authors who want strict CH semantics can opt out
+// by writing `CREATE OR REPLACE TABLE` / `CREATE TABLE IF NOT EXISTS`
+// themselves.
 func ApplySeed(t *testing.T, db *sql.DB, seed string) {
 	t.Helper()
 	stmts := testsql.BackfillMetricsColumns(testsql.SplitStatements(seed))
@@ -364,7 +361,7 @@ func RunRoundTrip(t *testing.T, c *Case, opts ...RoundTripOption) {
 
 	// expected_rows is ground truth for the pre-optimizer SQL above, so a
 	// mismatch here is safe to fold into GOLDEN_UPDATE.
-	runRoundTripSQL(t, c, rt, sql, args, true)
+	_ = runRoundTripSQL(t, c, rt, sql, args, true)
 }
 
 // RunRoundTripSQL is [RunRoundTrip]'s post-optimizer twin: it executes a
@@ -386,21 +383,22 @@ func RunRoundTrip(t *testing.T, c *Case, opts ...RoundTripOption) {
 // execution that RunRoundTrip captures; this function only ever compares
 // against it.
 //
-// A no-op for fixtures that never opted into round-trip execution, same
-// as RunRoundTrip.
-func RunRoundTripSQL(t *testing.T, c *Case, sql string, args []any) {
+// On success it returns the opaque seed/projection handoff [RunParity]
+// consumes. A fixture that never opted into round-trip execution returns the
+// zero result, just as RunRoundTrip is a no-op for it.
+func RunRoundTripSQL(t *testing.T, c *Case, sql string, args []any) RoundTripResult {
 	t.Helper()
 	rt, err := LoadRoundTrip(c)
 	if err != nil {
 		t.Fatalf("LoadRoundTrip: %v", err)
 	}
 	if !rt.IsRoundTrip() {
-		return
+		return RoundTripResult{}
 	}
 	if strings.TrimSpace(sql) == "" {
 		t.Fatalf("fixture %s: optimized SQL is empty", c.Name)
 	}
-	runRoundTripSQL(t, c, rt, sql, args, false)
+	return runRoundTripSQL(t, c, rt, sql, args, false)
 }
 
 // runRoundTripSQL is the shared chDB-execution core both RunRoundTrip and
@@ -411,7 +409,14 @@ func RunRoundTripSQL(t *testing.T, c *Case, sql string, args []any) {
 // or fails outright (RunRoundTripSQL, the post-optimizer check — a
 // mismatch there must never silently become the new "expected", since
 // that would launder a real optimizer bug into a passing golden).
-func runRoundTripSQL(t *testing.T, c *Case, rt *RoundTripSections, sql string, args []any, allowGoldenUpdate bool) {
+func runRoundTripSQL(
+	t *testing.T,
+	c *Case,
+	rt *RoundTripSections,
+	sql string,
+	args []any,
+	allowGoldenUpdate bool,
+) RoundTripResult {
 	t.Helper()
 
 	// Acquire the process-global chDB engine lock for the FULL engine
@@ -448,6 +453,21 @@ func runRoundTripSQL(t *testing.T, c *Case, rt *RoundTripSections, sql string, a
 			query, queryArgs, err)
 	}
 	defer func() { _ = rows.Close() }()
+	// Read the projection names from the same driver result parity values use.
+	// rows.Columns avoids the Map-sensitive ColumnTypes path and costs no extra
+	// execution: the driver already has this metadata for the open result set.
+	cols, err := rows.Columns()
+	if err != nil {
+		t.Fatalf("rows.Columns: %v", err)
+	}
+	if len(cols) == 0 {
+		t.Fatalf("fixture %s: driver returned an empty SELECT projection", c.Name)
+	}
+	result := RoundTripResult{
+		fixtureName:       c.Name,
+		projectionColumns: append([]string(nil), cols...),
+		seeded:            true,
+	}
 
 	if colCount == 0 {
 		// Wildcard outer projection (`SELECT R.* FROM ...`): the
@@ -455,14 +475,7 @@ func runRoundTripSQL(t *testing.T, c *Case, rt *RoundTripSections, sql string, a
 		// Columns()` returns names without instantiating the
 		// driver's column-type table, so it sidesteps the Map
 		// `rows.ColumnTypes()` panic.
-		cols, cerr := rows.Columns()
-		if cerr != nil {
-			t.Fatalf("rows.Columns: %v", cerr)
-		}
 		colCount = len(cols)
-		if colCount == 0 {
-			t.Fatalf("fixture %s: cannot determine SELECT projection count from sql", c.Name)
-		}
 	}
 
 	got := make([][]any, 0, len(rt.ExpectedRows))
@@ -516,11 +529,12 @@ func runRoundTripSQL(t *testing.T, c *Case, rt *RoundTripSections, sql string, a
 			Match(t, c, map[string]string{
 				"expected_rows": formatExpectedRows(gotNorm),
 			})
-			return
+			return result
 		}
 		t.Fatalf("round-trip mismatch (fixture %s)\n got = %s\nwant = %s",
 			c.Name, mustJSON(gotNorm), mustJSON(want))
 	}
+	return result
 }
 
 // formatExpectedRows renders a row set in the canonical TXTAR

--- a/test/spec/runner_nochdb.go
+++ b/test/spec/runner_nochdb.go
@@ -24,11 +24,12 @@ func RunRoundTrip(t *testing.T, c *Case, opts ...RoundTripOption) {
 
 // RunRoundTripSQL is a no-op when the `chdb` build tag is not set. The
 // real implementation lives in runner_chdb.go.
-func RunRoundTripSQL(t *testing.T, c *Case, sql string, args []any) {
+func RunRoundTripSQL(t *testing.T, c *Case, sql string, args []any) RoundTripResult {
 	t.Helper()
 	// Intentionally empty — seed: / expected_rows: are inert without
 	// the chdb build tag.
 	_ = c
 	_ = sql
 	_ = args
+	return RoundTripResult{}
 }


### PR DESCRIPTION
## Summary

- return an opaque same-fixture handoff from `RunRoundTripSQL`
- reuse its already-seeded isolated chDB database in `RunParity`
- carry driver-reported projection column names into parity instead of re-executing fixture SQL
- fail closed if parity receives no successful handoff or one from another fixture
- cover Prometheus, Loki, and Tempo parity paths

## Root cause and impact

Each parity-enrolled fixture applied its byte-identical seed again immediately after the post-optimizer round trip. PromQL and LogQL parity then executed the fixture SQL a second time solely to call `rows.Columns()`, discarding all rows. This repeated native chDB work in the longest corpus lane.

`RunRoundTripSQL` already owns the seeded database and open driver result. It now captures the column labels from that result and returns an opaque token. `RunParity` reopens the same isolated database only to read seeded inputs for the reference engine, while every compared value still comes from the fixture's pinned `expected_rows`.

Fixes #2101.

## Validation

- exact chDB regression for single seed application and no projection re-execution
- real parity-enrolled PromQL fixture: `pi_constant`
- real parity-enrolled LogQL fixture: `binop_vv_compare_filter`
- real parity-enrolled TraceQL fixture: `edge_sibling_with_attrs`
- no-tag PromQL/LogQL/TraceQL/spec compile
- chDB and AGPL-oracle tagged compiles
- `node .github/scripts/forbid-sql-raw.mjs`
- `git diff --check`
