### PR TITLE
fix(coverage): fail closed on package test errors

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -441,16 +441,14 @@ bench:
 # list to maintain or forget.
 coverage:
     @echo "==> default-tag coverage"
-    # `|| true` tolerates partial failures (e.g. `main` packages that
-    # require the `covdata` tool on toolchains that ship without it).
-    # The cover.out profile is still written for every package that
-    # compiled, which is all production code in internal/**.
+    # Both coverage runs fail closed. The repository pins one supported Go
+    # toolchain, which includes covdata; a partial profile produced after any
+    # package test failure is not evidence and must never reach the floor gate.
     # 40m, not the 25m this lane used before -coverpkg: the heaviest binary
     # (test/perf) took 933s of that budget on CI while instrumenting only its
     # own package, and instrumenting every package into it measured 1266s
-    # locally. A binary that overruns is swallowed by the `|| true` above and
-    # silently drops its whole contribution from the profile, which shows up
-    # later as an unexplained floor failure rather than as a timeout.
+    # locally. A binary that overruns fails here and names the timeout directly
+    # instead of silently dropping its whole contribution from the profile.
     # The awk trims go test's echo of the -coverpkg list back to what the
     # bare `./...` form used to print. An explicit list of every package is
     # ~5 KiB, repeated on EVERY package's result line, which buries the
@@ -459,7 +457,7 @@ coverage:
     # everything on stderr pass through untouched. `fflush()` keeps the pipe
     # line-buffered — a block-buffered filter would show nothing at all until
     # a 4 KiB chunk fills, which on a lane this long reads as a hung job.
-    go test -timeout 40m -coverpkg="$(go list ./... | paste -sd, -)" -coverprofile=cover.out ./... | awk '{ sub(/of statements in github\.com\/.*/, "of statements"); print; fflush() }' || true
+    go test -timeout 40m -coverpkg="$(go list ./... | paste -sd, -)" -coverprofile=cover.out ./... | awk '{ sub(/of statements in github\.com\/.*/, "of statements"); print; fflush() }'
     @test -s cover.out
     # Fold each lane as soon as it is written. -coverpkg makes EVERY test
     # binary emit a row for every block it linked, so a raw lane profile is
@@ -470,7 +468,7 @@ coverage:
     @{ echo "mode: set"; awk 'FNR==1{next} { k=$1" "$2; if (!(k in m) || $3>m[k]) m[k]=$3 } END { for (k in m) print k, m[k] }' cover.out | sort; } > cover-folded.out && mv cover-folded.out cover.out
     @if [ -e /usr/local/lib/libchdb.so ]; then \
         echo "==> chdb-tagged coverage"; \
-        go test -timeout 40m -tags chdb,agpl_oracle,chdb_agpl_oracle -coverpkg="$(go list -tags chdb,agpl_oracle,chdb_agpl_oracle ./... | paste -sd, -)" -coverprofile=cover-chdb.out ./... | awk '{ sub(/of statements in github\.com\/.*/, "of statements"); print; fflush() }' || true; \
+        go test -timeout 40m -tags chdb,agpl_oracle,chdb_agpl_oracle -coverpkg="$(go list -tags chdb,agpl_oracle,chdb_agpl_oracle ./... | paste -sd, -)" -coverprofile=cover-chdb.out ./... | awk '{ sub(/of statements in github\.com\/.*/, "of statements"); print; fflush() }'; \
         { echo "mode: set"; \
           awk 'FNR==1{next} { k=$1" "$2; if (!(k in m) || $3>m[k]) m[k]=$3 } END { for (k in m) print k, m[k] }' cover-chdb.out | sort; \
         } > cover-folded.out && mv cover-folded.out cover-chdb.out; \

--- a/test/regression/coverage_recipe_fail_closed_test.go
+++ b/test/regression/coverage_recipe_fail_closed_test.go
@@ -1,0 +1,37 @@
+package regression
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+// TestCoverageRecipeFailsClosedOnGoTestFailure pins the coverage profile to a
+// successful test run. Before #2089, both go test pipelines ended in `|| true`,
+// so an entire package could fail while its partial profile still reached the
+// floor comparison as apparently valid evidence.
+func TestCoverageRecipeFailsClosedOnGoTestFailure(t *testing.T) {
+	t.Parallel()
+
+	buf, err := os.ReadFile("../../Justfile")
+	if err != nil {
+		t.Fatalf("read Justfile: %v", err)
+	}
+	justfile := string(buf)
+	start := strings.Index(justfile, "\ncoverage:\n")
+	end := strings.Index(justfile, "\nupdate-coverage-floor:")
+	if start < 0 || end < 0 || end <= start {
+		t.Fatalf("cannot isolate the coverage recipe in Justfile")
+	}
+	recipe := justfile[start:end]
+
+	if got := strings.Count(recipe, "go test -timeout"); got != 2 {
+		t.Fatalf("coverage recipe carries %d go test runs, want default and chdb-tagged runs", got)
+	}
+	if strings.Contains(recipe, "|| true") {
+		t.Fatalf("coverage recipe tolerates a failed command with `|| true`; a partial profile is not valid evidence")
+	}
+	if !strings.Contains(justfile, `set shell := ["bash", "-eu", "-o", "pipefail", "-c"]`) {
+		t.Fatalf("Justfile shell does not enable pipefail; a failed go test before the output-filter pipe would be hidden")
+	}
+}


### PR DESCRIPTION
## Summary

- remove the broad success override from both default-tag and chDB-tagged coverage test pipelines
- pin the coverage recipe to bash pipefail and reject any future `|| true` that could turn a partial profile into apparently valid floor evidence

Fixes #2089

## Test plan

- [x] `go test -race -run ^TestCoverageRecipeFailsClosedOnGoTestFailure$ ./test/regression/`
- [x] `git diff --check`
- [ ] CI green

## Notes for reviewers

The chDB coverage lane already gained the required LogQL oracle tags in #2151. This closes the independent failure-propagation half of the issue.