### PR TITLE
perf(logql): fuse variants sharing a value expression

### DIFF
--- a/internal/chplan/range_window.go
+++ b/internal/chplan/range_window.go
@@ -245,17 +245,17 @@ type RangeWindow struct {
 // function to evaluate, the per-sample value column it reads, and the label
 // stamped into RangeWindow.VariantColumn on the rows it produces.
 //
-// Every arm reduces the SAME window membership — the arms differ only in
-// which per-row value column they read and which reducer they apply — so the
-// emitter builds one sorted (timestamp, value₀, …, valueₙ₋₁) array per
-// (series, anchor) and reduces it once per arm.
+// Every arm reduces the SAME window membership. Arms may share a per-row
+// value column when they apply different reducers to the same expression, so
+// the emitter builds one sorted (timestamp, distinct-value₀, …) array per
+// (series, anchor) and maps each arm to its value slot before reducing it.
 type RangeWindowVariant struct {
 	// Func is the range function, from the same vocabulary as
 	// RangeWindow.Func.
 	Func string
 
-	// ValueColumn names this arm's per-sample value column on Input.
-	// Distinct per arm — that is the whole point of the fused shape.
+	// ValueColumn names this arm's per-sample value column on Input. Multiple
+	// arms may name one column when they reduce the same value expression.
 	ValueColumn string
 
 	// Label is the value stamped into RangeWindow.VariantColumn for the

--- a/internal/chsql/range_window_variants.go
+++ b/internal/chsql/range_window_variants.go
@@ -27,16 +27,16 @@ import (
 //	SELECT <series>, [anchor_ts, <tsCol>,] `Value`, `__variant__`
 //	FROM (
 //	  SELECT <series>, [anchor_ts,] window_vals_0, …, window_vals_{N-1}
-//	  FROM ( … one groupArray of (ts, v_0, …, v_{N-1}) per (series[, anchor]) … )
+//	  FROM ( … one groupArray of (ts, distinct_v_0, …) per (series[, anchor]) … )
 //	)
 //	ARRAY JOIN [<reduce_0>, …, <reduce_{N-1}>] AS `Value`,
 //	           [<label_0>, …, <label_{N-1}>] AS `__variant__`
 //	WHERE length(window_pairs) >= 1
 //
 // Result-equivalence (not byte-equivalence) to the per-arm shape is the
-// contract, and it holds arm by arm: arm i's values array is
-// `arrayMap(p -> p.{i+2}, arraySort(p -> (p.1, p.{i+2}), window_pairs))`,
-// which is element-for-element the `arrayMap(p -> p.2,
+// contract, and it holds arm by arm: arm i maps to its distinct-value slot s
+// and reads `arrayMap(p -> p.{s+2}, arraySort(p -> (p.1, p.{s+2}),
+// window_pairs))`, which is element-for-element the `arrayMap(p -> p.2,
 // arraySort(groupArray((ts, v_i))))` the unfused arm builds — same
 // membership (one shared window predicate), same ordering key (ts, then that
 // arm's own value), and ties under that key hold equal v_i so the projected
@@ -95,20 +95,10 @@ func checkFusedVariants(r *chplan.RangeWindow) error {
 	if r.TemporalityColumn != "" {
 		return fmt.Errorf("%w: fused RangeWindow with a temporality column", ErrUnsupported)
 	}
-	seen := make(map[string]struct{}, len(r.Variants))
 	for i, v := range r.Variants {
 		if v.ValueColumn == "" {
 			return fmt.Errorf("%w: fused RangeWindow arm %d has no ValueColumn", ErrUnsupported, i)
 		}
-		if _, dup := seen[v.ValueColumn]; dup {
-			// Two arms reading one column would make the groupArray
-			// tuple ambiguous about which slot belongs to which arm.
-			return fmt.Errorf(
-				"%w: fused RangeWindow arms share ValueColumn %q",
-				ErrUnsupported, v.ValueColumn,
-			)
-		}
-		seen[v.ValueColumn] = struct{}{}
 	}
 	return nil
 }
@@ -131,10 +121,10 @@ func (e *emitter) emitRangeWindowVariants(r *chplan.RangeWindow) error {
 }
 
 // groupArrayVariantTupleFrag renders
-// `arraySort(groupArray((<tsCol>, <valCols...>)))` — the shared per-window
-// sample array carrying every arm's value alongside the timestamp, so one
-// grouped pass feeds all N reducers. The single-arm groupArrayPairFrag is the
-// N=1 case of this shape.
+// `arraySort(groupArray((<tsCol>, <distinctValCols...>)))` — the shared
+// per-window sample array carrying every distinct value alongside the
+// timestamp, so one grouped pass feeds all N reducers. The single-arm
+// groupArrayPairFrag is the N=1 case of this shape.
 func groupArrayVariantTupleFrag(tsCol string, valCols []string) Frag {
 	parts := make([]Frag, 0, len(valCols)+1)
 	parts = append(parts, Col(tsCol))
@@ -144,22 +134,21 @@ func groupArrayVariantTupleFrag(tsCol string, valCols []string) Frag {
 	return Call("arraySort", Call("groupArray", Tuple(parts...)))
 }
 
-// variantValsFrag renders arm i's values array out of the shared
+// variantValsFrag renders one value slot's array out of the shared
 // `window_pairs` tuple array:
 //
-//	arrayMap(p -> tupleElement(p, <i+2>),
-//	         arraySort(p -> (tupleElement(p, 1), tupleElement(p, <i+2>)),
+//	arrayMap(p -> tupleElement(p, <slot+2>),
+//	         arraySort(p -> (tupleElement(p, 1), tupleElement(p, <slot+2>)),
 //	                   window_pairs))
 //
 // The re-sort is what makes the arm equivalent to its unfused self: the
-// single-arm path sorts (ts, value) PAIRS, so arm i's ordering key is
-// (ts, v_i) rather than the shared tuple's (ts, v_0, v_1, …). Re-keying per
-// arm reproduces that ordering exactly, which matters for the order-sensitive
-// reducers (first_over_time / last_over_time read the array's ends).
-func variantValsFrag(pairs Frag, i int) Frag {
-	// +2: tuple slot 1 is the timestamp, so arm i's value is slot i+2.
+// single-arm path sorts (ts, value) PAIRS. Re-keying on the selected value
+// slot reproduces that ordering exactly, including when several arms share
+// the slot, which matters for first_over_time / last_over_time.
+func variantValsFrag(pairs Frag, valueSlot int) Frag {
+	// +2: tuple slot 1 is the timestamp, so value slot i is tuple slot i+2.
 	const firstValueSlot = 2
-	slot := int64(i + firstValueSlot)
+	slot := int64(valueSlot + firstValueSlot)
 	valOf := func(p Frag) Frag { return Call("tupleElement", p, InlineLit(slot)) }
 	tsOf := func(p Frag) Frag { return Call("tupleElement", p, InlineLit(int64(1))) }
 	sorted := Call(
@@ -185,21 +174,33 @@ func variantArmValueFrags(r *chplan.RangeWindow) ([]Frag, error) {
 	return out, nil
 }
 
-// variantArmValueColumns lists the arms' per-sample value columns in arm
-// order — the order the shared groupArray tuple's slots follow.
-func variantArmValueColumns(r *chplan.RangeWindow) []string {
+// fusedVariantValueLayout deduplicates per-sample value columns in first-use
+// order and maps every arm to its tuple slot. This is the many-to-one seam
+// that lets max_over_time and min_over_time share one projected value.
+func fusedVariantValueLayout(r *chplan.RangeWindow) ([]string, []int) {
 	cols := make([]string, 0, len(r.Variants))
+	slots := make([]int, 0, len(r.Variants))
+	seen := make(map[string]int, len(r.Variants))
 	for _, v := range r.Variants {
-		cols = append(cols, v.ValueColumn)
+		slot, ok := seen[v.ValueColumn]
+		if !ok {
+			slot = len(cols)
+			seen[v.ValueColumn] = slot
+			cols = append(cols, v.ValueColumn)
+		}
+		slots = append(slots, slot)
 	}
-	return cols
+	return cols, slots
 }
 
 // selectVariantVals projects one `window_vals_<i>` alias per arm off the
 // shared `window_pairs` tuple array.
-func selectVariantVals(q *QueryBuilder, r *chplan.RangeWindow) {
+func selectVariantVals(q *QueryBuilder, r *chplan.RangeWindow, armSlots []int) {
 	for i := range r.Variants {
-		q.Select(As(variantValsFrag(BareIdent("window_pairs"), i), variantWindowValsAlias(i)))
+		q.Select(As(
+			variantValsFrag(BareIdent("window_pairs"), armSlots[i]),
+			variantWindowValsAlias(i),
+		))
 	}
 }
 
@@ -235,12 +236,13 @@ func (e *emitter) emitRangeWindowVariantsInstant(r *chplan.RangeWindow) error {
 	if err != nil {
 		return err
 	}
+	valueColumns, armSlots := fusedVariantValueLayout(r)
 
-	// Innermost SELECT — one sorted (ts, v_0, …, v_{N-1}) array per series.
+	// Innermost SELECT — one sorted (ts, distinct_v_0, …) array per series.
 	innermost := NewQuery()
 	innermost.Select(groupFrags...)
 	innermost.Select(As(
-		groupArrayVariantTupleFrag(r.TimestampColumn, variantArmValueColumns(r)),
+		groupArrayVariantTupleFrag(r.TimestampColumn, valueColumns),
 		"series_array",
 	))
 	innerSub, err := e.subqueryFrag(r.Input)
@@ -266,7 +268,7 @@ func (e *emitter) emitRangeWindowVariantsInstant(r *chplan.RangeWindow) error {
 	mid := NewQuery().From(innerMid.Frag())
 	mid.Select(groupFrags...)
 	mid.Select(Col("window_pairs"))
-	selectVariantVals(mid, r)
+	selectVariantVals(mid, r, armSlots)
 
 	// Outer SELECT — reduce once per arm and unpivot.
 	outer := NewQuery().From(mid.Frag())
@@ -299,6 +301,7 @@ func (e *emitter) emitRangeWindowVariantsMatrix(r *chplan.RangeWindow) error {
 	if err != nil {
 		return err
 	}
+	valueColumns, armSlots := fusedVariantValueLayout(r)
 	innerSub, err := e.subqueryFrag(r.Input)
 	if err != nil {
 		return err
@@ -306,11 +309,11 @@ func (e *emitter) emitRangeWindowVariantsMatrix(r *chplan.RangeWindow) error {
 	innerSub, srcTs := fanoutTsSource(innerSub, r.TimestampColumn)
 
 	// Sample-fanout SELECT — one row per (sample, covered anchor), carrying
-	// every arm's value so the regroup can build one shared tuple array.
+	// every distinct value so the regroup can build one shared tuple array.
 	fanout := NewQuery().From(innerSub)
 	fanout.Select(groupFrags...)
 	fanout.Select(Col(srcTs))
-	for _, c := range variantArmValueColumns(r) {
+	for _, c := range valueColumns {
 		fanout.Select(Col(c))
 	}
 	fanout.Select(As(
@@ -324,7 +327,7 @@ func (e *emitter) emitRangeWindowVariantsMatrix(r *chplan.RangeWindow) error {
 	regroup.Select(groupFrags...)
 	regroup.Select(Col("anchor_ts"))
 	regroup.Select(As(
-		groupArrayVariantTupleFrag(srcTs, variantArmValueColumns(r)),
+		groupArrayVariantTupleFrag(srcTs, valueColumns),
 		"window_pairs",
 	))
 	regroupKeys := make([]Frag, 0, len(groupFrags)+1)
@@ -337,7 +340,7 @@ func (e *emitter) emitRangeWindowVariantsMatrix(r *chplan.RangeWindow) error {
 	mid.Select(groupFrags...)
 	mid.Select(Col("anchor_ts"))
 	mid.Select(Col("window_pairs"))
-	selectVariantVals(mid, r)
+	selectVariantVals(mid, r, armSlots)
 
 	// Outer SELECT — reduce once per arm and unpivot. anchor_ts is also
 	// surfaced under the schema timestamp column so a wrapping Aggregate's

--- a/internal/chsql/range_window_variants_test.go
+++ b/internal/chsql/range_window_variants_test.go
@@ -3,6 +3,7 @@ package chsql
 import (
 	"context"
 	"errors"
+	"slices"
 	"strings"
 	"testing"
 	"time"
@@ -158,9 +159,6 @@ func TestEmitFusedVariantsRejectsIllFormed(t *testing.T) {
 		"no timestamp column": func(r *chplan.RangeWindow) {
 			r.TimestampColumn = ""
 		},
-		"arms share a value column": func(r *chplan.RangeWindow) {
-			r.Variants[1].ValueColumn = r.Variants[0].ValueColumn
-		},
 		"arm with no value column": func(r *chplan.RangeWindow) {
 			r.Variants[1].ValueColumn = ""
 		},
@@ -180,6 +178,31 @@ func TestEmitFusedVariantsRejectsIllFormed(t *testing.T) {
 		if _, _, err := Emit(context.Background(), r); !errors.Is(err, ErrUnsupported) {
 			t.Errorf("%s: got err %v, want ErrUnsupported", name, err)
 		}
+	}
+}
+
+// TestFusedVariantValueLayout pins the arm-to-slot many-to-one mapping. The
+// tuple carries each input value column once, while reducers retain arm order
+// and may read the same slot.
+func TestFusedVariantValueLayout(t *testing.T) {
+	t.Parallel()
+	r := fusedTestWindow()
+	r.Variants[1].ValueColumn = "Value_0"
+	r.Variants = append(r.Variants, chplan.RangeWindowVariant{
+		Func: "min_over_time", ValueColumn: "Value_1", Label: "2",
+	})
+
+	columns, slots := fusedVariantValueLayout(r)
+	wantColumns := []string{"Value_0", "Value_1"}
+	wantSlots := []int{0, 0, 1}
+	if !slices.Equal(columns, wantColumns) {
+		t.Errorf("value columns = %v, want %v", columns, wantColumns)
+	}
+	if !slices.Equal(slots, wantSlots) {
+		t.Errorf("arm slots = %v, want %v", slots, wantSlots)
+	}
+	if _, _, err := Emit(context.Background(), r); err != nil {
+		t.Fatalf("Emit shared-value fused window: %v", err)
 	}
 }
 

--- a/internal/logql/variants.go
+++ b/internal/logql/variants.go
@@ -109,12 +109,11 @@ func lowerMultiVariant(e *syntax.MultiVariantExpr, s schema.Logs, lc lowerCtx) (
 	return &chplan.UnionAll{Inputs: arms}, nil
 }
 
-// variantArmValueColumn names the per-sample value column the fused window
-// reads for arm i. The unfused arms all project their value under the one
-// [rangeAggSynthValueColumn] alias; fusing them into a single row means each
-// needs its own column, so they are re-aliased by index.
-func variantArmValueColumn(i int) string {
-	return fmt.Sprintf("%s_%d", rangeAggSynthValueColumn, i)
+// variantValueSlotColumn names one DISTINCT per-sample value column the fused
+// window reads. Several arms may point at the same slot when they apply
+// different reducers to the same value expression.
+func variantValueSlotColumn(slot int) string {
+	return fmt.Sprintf("%s_%d", rangeAggSynthValueColumn, slot)
 }
 
 // variantLabelFor renders the `__variant__` value for arm i — its zero-based
@@ -340,14 +339,28 @@ func fuseVariantArms(arms []chplan.Node) (*chplan.RangeWindow, bool) {
 	}
 
 	// Shared input Project: every projection but the value one verbatim from
-	// arm 0, then each arm's own value expression under its own alias.
+	// arm 0, then each DISTINCT value expression under its own slot alias.
+	// Multiple arms can read one slot when they differ only in the reducer.
 	base := projects[0]
+	valueRepresentatives := make([]chplan.Projection, 0, len(projects))
+	armValueColumns := make([]string, 0, len(projects))
+	for _, p := range projects {
+		value := p.Projections[valueIdx]
+		slot := slices.IndexFunc(valueRepresentatives, func(existing chplan.Projection) bool {
+			return projectionEqual(existing, value)
+		})
+		if slot < 0 {
+			slot = len(valueRepresentatives)
+			valueRepresentatives = append(valueRepresentatives, value)
+		}
+		armValueColumns = append(armValueColumns, variantValueSlotColumn(slot))
+	}
 	var shared []chplan.Projection
 	shared = append(shared, base.Projections[:valueIdx]...)
-	for i, p := range projects {
+	for slot, p := range valueRepresentatives {
 		shared = append(shared, chplan.Projection{
-			Expr:  p.Projections[valueIdx].Expr,
-			Alias: variantArmValueColumn(i),
+			Expr:  p.Expr,
+			Alias: variantValueSlotColumn(slot),
 		})
 	}
 	shared = append(shared, base.Projections[valueIdx+1:]...)
@@ -363,18 +376,18 @@ func fuseVariantArms(arms []chplan.Node) (*chplan.RangeWindow, bool) {
 	for i, w := range windows {
 		fused.Variants = append(fused.Variants, chplan.RangeWindowVariant{
 			Func:        w.Func,
-			ValueColumn: variantArmValueColumn(i),
+			ValueColumn: armValueColumns[i],
 			Label:       variantLabelFor(i),
 		})
 	}
 	return &fused, true
 }
 
-// sharedValueProjectionIndex locates the ONE projection position at which the
-// arms' input Projects differ — the per-sample value expression. It reports
-// ok=false unless every Project has the same projection list length, differs
-// at exactly one position, and that position is the [rangeAggSynthValueColumn]
-// alias in every arm.
+// sharedValueProjectionIndex locates the per-sample value projection. It
+// reports ok=false unless every Project has the same projection list length,
+// differs at no more than one position, and the selected position is the
+// [rangeAggSynthValueColumn] alias in every arm. Zero differing positions is
+// the shared-value case: the arms apply different reducers to one value slot.
 //
 // Requiring the differing position to be the value alias is what keeps the
 // fusion sound: two arms differing in their IDENTITY projection describe
@@ -400,17 +413,20 @@ func sharedValueProjectionIndex(projects []*chplan.Project) (int, bool) {
 		valueIdx = i
 	}
 	if valueIdx < 0 {
-		// Every projection agrees, so the arms read the identical per-sample
-		// value and differ only in the reducer applied to it — as in
-		// `variants(max_over_time({app="foo"} | unwrap latency [5m]),
-		// min_over_time({app="foo"} | unwrap latency [5m]))`. That is a real
-		// query, and it IS fusible: the arms would share one value column
-		// rather than getting one each. This lowering does not build that
-		// shape — every arm here names its own column, and the emitter
-		// rejects two arms pointing at one — so the query keeps the per-arm
-		// plan and its scan per arm. Widening the arm-to-column mapping to
-		// many-to-one is issue #2050.
-		return 0, false
+		// Every projection agrees. Locate the one canonical value alias so
+		// the fused Project can expose it once and point every arm at it.
+		for i, p := range base.Projections {
+			if p.Alias != rangeAggSynthValueColumn {
+				continue
+			}
+			if valueIdx >= 0 {
+				return 0, false
+			}
+			valueIdx = i
+		}
+		if valueIdx < 0 {
+			return 0, false
+		}
 	}
 	for _, p := range projects {
 		if p.Projections[valueIdx].Alias != rangeAggSynthValueColumn {

--- a/internal/logql/variants_fusion_chdb_test.go
+++ b/internal/logql/variants_fusion_chdb_test.go
@@ -106,6 +106,47 @@ func TestFusedUngroupedVariantsEmptyInput(t *testing.T) {
 	}
 }
 
+// TestFusedVariantsSharedValueColumn executes two different reducers over one
+// projected value slot. It catches an arm-index/tuple-index mapping bug that
+// SQL text alone cannot: arm 1 must read slot 0 rather than a nonexistent
+// second value tuple element.
+func TestFusedVariantsSharedValueColumn(t *testing.T) {
+	value := &chplan.FuncCall{
+		Fn: chplan.FnToFloat64,
+		Args: []chplan.Expr{&chplan.FuncCall{
+			Fn:   chplan.FnLength,
+			Args: []chplan.Expr{&chplan.ColumnRef{Name: "Body"}},
+		}},
+	}
+	rw := &chplan.RangeWindow{
+		Input: &chplan.Project{
+			Input: &chplan.Scan{Table: "otel_logs"},
+			Projections: []chplan.Projection{
+				{Expr: &chplan.ColumnRef{Name: "ResourceAttributes"}, Alias: "ResourceAttributes"},
+				{Expr: &chplan.ColumnRef{Name: "Timestamp"}},
+				{Expr: value, Alias: "Value_0"},
+			},
+		},
+		Range:              5 * time.Minute,
+		TimestampColumn:    "Timestamp",
+		ValueColumn:        "Value",
+		VariantColumn:      "__variant__",
+		GroupBy:            []chplan.Expr{&chplan.ColumnRef{Name: "ResourceAttributes"}},
+		InstantScanBounded: true,
+		Variants: []chplan.RangeWindowVariant{
+			{Func: "max_over_time", ValueColumn: "Value_0", Label: "0"},
+			{Func: "min_over_time", ValueColumn: "Value_0", Label: "1"},
+		},
+	}
+	got := runVariantPlan(t, rw, variantsFusionSeedRows, "`__variant__`, `Value`")
+	want := map[string]float64{"0": 4, "1": 2}
+	for variant, wantValue := range want {
+		if got[variant] != wantValue {
+			t.Errorf("__variant__=%q value = %v, want %v", variant, got[variant], wantValue)
+		}
+	}
+}
+
 // runFusedVariantsQuery lowers query, asserts it actually fused (a test that
 // silently fell back to the per-arm shape would pass while covering nothing),
 // executes it over a freshly seeded chDB session, and returns the value per

--- a/internal/logql/variants_fusion_internal_test.go
+++ b/internal/logql/variants_fusion_internal_test.go
@@ -136,8 +136,6 @@ func TestFuseVariantArms_RefusesDivergentArms(t *testing.T) {
 			b.Input.(*chplan.Project).Projections[1].Expr = &chplan.ColumnRef{Name: "Other"}
 			return []chplan.Node{countArm(), b}
 		}(),
-		// The arms compute the same value: nothing to fan out.
-		"identical arms": {countArm(), countArm()},
 		// A function the fused emitter does not reduce over the values
 		// array keeps the whole query on the per-arm path.
 		"unfusible function": func() []chplan.Node {
@@ -197,8 +195,40 @@ func TestFuseVariantArms_FusesThreeArms(t *testing.T) {
 		if v.Label != variantLabelFor(i) {
 			t.Errorf("arm %d label = %q, want %q", i, v.Label, variantLabelFor(i))
 		}
-		if v.ValueColumn != variantArmValueColumn(i) {
-			t.Errorf("arm %d value column = %q, want %q", i, v.ValueColumn, variantArmValueColumn(i))
+		if v.ValueColumn != variantValueSlotColumn(i) {
+			t.Errorf("arm %d value column = %q, want %q", i, v.ValueColumn, variantValueSlotColumn(i))
+		}
+	}
+}
+
+// TestFuseVariantArms_FusesSharedValues pins the many-to-one value layout:
+// arms that differ only in their reducer share one projected value slot, and
+// a third distinct expression gets the next slot without disturbing arm
+// labels or order.
+func TestFuseVariantArms_FusesSharedValues(t *testing.T) {
+	t.Parallel()
+	sharedValue := &chplan.ColumnRef{Name: "latency"}
+	arms := []chplan.Node{
+		variantArm("max_over_time", sharedValue, "otel_logs"),
+		variantArm("min_over_time", sharedValue, "otel_logs"),
+		bytesArm(),
+	}
+	fused, ok := fuseVariantArms(arms)
+	if !ok {
+		t.Fatal("shared-value arms were not fused")
+	}
+	proj := fused.Input.(*chplan.Project)
+	if len(proj.Projections) != 4 {
+		t.Fatalf("shared Project has %d projections, want 4 (2 shared + 2 distinct values)",
+			len(proj.Projections))
+	}
+	wantColumns := []string{"Value_0", "Value_0", "Value_1"}
+	for i, want := range wantColumns {
+		if got := fused.Variants[i].ValueColumn; got != want {
+			t.Errorf("arm %d value column = %q, want %q", i, got, want)
+		}
+		if got := fused.Variants[i].Label; got != variantLabelFor(i) {
+			t.Errorf("arm %d label = %q, want %q", i, got, variantLabelFor(i))
 		}
 	}
 }

--- a/internal/logql/variants_test.go
+++ b/internal/logql/variants_test.go
@@ -56,6 +56,15 @@ func TestLowerMultiVariant(t *testing.T) {
 			wantFused: true,
 		},
 		{
+			// Both reducers read the same unwrapped value. They must share
+			// one value slot rather than falling back to two table scans.
+			name:      "shared value expression",
+			query:     `variants(max_over_time({app="foo"} | unwrap latency [5m]), min_over_time({app="foo"} | unwrap latency [5m])) of ({app="foo"}[5m])`,
+			wantArms:  2,
+			wantTags:  []string{"0", "1"},
+			wantFused: true,
+		},
+		{
 			// The `of (...)` arm is a hint, not a constraint: the parser
 			// accepts arms whose selectors differ from it and from each
 			// other, and those genuinely read two streams.


### PR DESCRIPTION
Closes #2050

## Summary
- deduplicate fused variants value projections into distinct slots
- map multiple reducer arms onto one shared value slot in both instant and matrix emitters
- cover lowering, SQL layout, and real chDB value semantics

## Verification
- `go test -timeout 15m -race -run Test(LowerMultiVariant|FuseVariantArms_|EmitFusedVariants) ./internal/logql ./internal/chsql`
- `go test -timeout 15m -race -run ^TestFusedVariantValueLayout$ ./internal/chsql`
- `go test -timeout 10m -tags chdb -count=1 -run ^TestFusedVariantsSharedValueColumn$ ./internal/logql`
- `node .github/scripts/forbid-sql-raw.mjs`