### PR TITLE
fix(e2e): seed current database span system attribute

### DIFF
--- a/test/e2e/playwright/compose_grafana_smoke.spec.ts
+++ b/test/e2e/playwright/compose_grafana_smoke.spec.ts
@@ -95,6 +95,62 @@ test.beforeAll(async ({ request }) => {
   await awaitSeedFixtureSignal(request);
 });
 
+test('compose: Trace Drilldown Database calls reaches its post-histogram query', async ({
+  request,
+}) => {
+  // grafana-exploretraces-app v2.1.0 defines Database calls as
+  // `span.db.system.name != ""`. Its duration view first runs the histogram
+  // query, derives latencyThreshold from the returned buckets, then retries
+  // the raw search with a concrete `duration > <threshold>` predicate.
+  // Keep all three stages load-bearing: a legacy-only db.system seed makes
+  // the selector and histogram empty, so latencyThreshold never resolves.
+  const baseURL = process.env.GRAFANA_BASE_URL ?? 'http://localhost:3000';
+  const tempoProxy =
+    `${baseURL}/api/datasources/proxy/uid/cerberus-tempo/api`;
+  const primarySignal = 'span.db.system.name != ""';
+  const direct = await request.get(
+    `${tempoProxy}/search?q=${encodeURIComponent(`{ ${primarySignal} }`)}`,
+  );
+  expect(direct.status(), 'Database calls primary signal search').toBe(200);
+  const directBody = await direct.json();
+  expect(
+    directBody.traces?.length ?? 0,
+    'seeded database spans match db.system.name',
+  ).toBeGreaterThan(0);
+
+  const end = Math.floor(Date.now() / 1000);
+  const histogramParams = new URLSearchParams({
+    q: `{ ${primarySignal} && true } | histogram_over_time(duration) with(sample=true)`,
+    start: String(end - 3600),
+    end: String(end),
+    step: '60s',
+  });
+  const histogram = await request.get(
+    `${tempoProxy}/metrics/query_range?${histogramParams.toString()}`,
+  );
+  expect(histogram.status(), 'Database calls duration histogram').toBe(200);
+  const histogramBody = await histogram.json();
+  expect(
+    histogramBody.series?.length ?? 0,
+    'histogram resolves a latency threshold',
+  ).toBeGreaterThan(0);
+
+  // A concrete threshold is the settled query shape emitted after the
+  // histogram. The app's separate empty-threshold initial query remains an
+  // upstream bug (grafana/traces-drilldown#850 / cerberus#2009); this test
+  // neither sends nor tolerates that malformed request.
+  const settledQuery = `{ ${primarySignal} && true && duration > 1ms }`;
+  const settled = await request.get(
+    `${tempoProxy}/search?q=${encodeURIComponent(settledQuery)}`,
+  );
+  expect(settled.status(), 'settled Database calls duration search').toBe(200);
+  const settledBody = await settled.json();
+  expect(
+    settledBody.traces?.length ?? 0,
+    'post-histogram query matches seeded spans',
+  ).toBeGreaterThan(0);
+});
+
 test('compose: home, drilldown app, and every provisioned dashboard load without datasource errors', async ({
   page,
   request,

--- a/test/e2e/playwright/tempo_ux.spec.ts
+++ b/test/e2e/playwright/tempo_ux.spec.ts
@@ -15,7 +15,7 @@ import { test, expect } from '@playwright/test';
  *   Trace 3 (a0…003): api → db              (cron.refresh / cache.refresh)
  *
  * Span attributes seeded: http.method, http.status_code, db.system,
- * cron.name. Resource attribute: service.name.
+ * db.system.name, cron.name. Resource attribute: service.name.
  */
 
 const tempoProxy = '/api/datasources/proxy/uid/cerberus-tempo/api';

--- a/test/e2e/seed/cmd/seed/main.go
+++ b/test/e2e/seed/cmd/seed/main.go
@@ -499,9 +499,9 @@ VALUES
   (now64(9) - INTERVAL 9 SECOND,  'a0000000000000000000000000000001', '0000000000000002', '0000000000000001', 'GET /api/users',   'Client', 'api',      map('service.name', 'api'),      map('http.method', 'GET',  'http.status_code', '200'),  80000000, 'Ok'),
   (now64(9) - INTERVAL 20 SECOND, 'a0000000000000000000000000000002', '0000000000000003', '',                 'POST /checkout',   'Server', 'frontend', map('service.name', 'frontend'), map('http.method', 'POST', 'http.status_code', '500'), 600000000, 'Error'),
   (now64(9) - INTERVAL 19 SECOND, 'a0000000000000000000000000000002', '0000000000000004', '0000000000000003', 'POST /api/order',  'Client', 'api',      map('service.name', 'api'),      map('http.method', 'POST', 'http.status_code', '500'), 450000000, 'Error'),
-  (now64(9) - INTERVAL 19 SECOND, 'a0000000000000000000000000000002', '0000000000000005', '0000000000000004', 'orders.insert',    'Client', 'db',       map('service.name', 'db'),       map('db.system',   'postgres'),                            300000000, 'Error'),
+  (now64(9) - INTERVAL 19 SECOND, 'a0000000000000000000000000000002', '0000000000000005', '0000000000000004', 'orders.insert',    'Client', 'db',       map('service.name', 'db'),       map('db.system', 'postgres', 'db.system.name', 'postgres'), 300000000, 'Error'),
   (now64(9) - INTERVAL 30 SECOND, 'a0000000000000000000000000000003', '0000000000000006', '',                 'cron.refresh',     'Server', 'api',      map('service.name', 'api'),      map('cron.name',   'refresh'),                              90000000, 'Ok'),
-  (now64(9) - INTERVAL 29 SECOND, 'a0000000000000000000000000000003', '0000000000000007', '0000000000000006', 'cache.refresh',    'Client', 'db',       map('service.name', 'db'),       map('db.system',   'redis'),                                40000000, 'Ok')`
+  (now64(9) - INTERVAL 29 SECOND, 'a0000000000000000000000000000003', '0000000000000007', '0000000000000006', 'cache.refresh',    'Client', 'db',       map('service.name', 'db'),       map('db.system', 'redis', 'db.system.name', 'redis'),       40000000, 'Ok')`
 
 	// Showcase-PromQL seed shapes (PR feat/showcase-promql). The
 	// showcase-promql dashboard's feature panels need data shapes the

--- a/test/e2e/seed/cmd/seed/showcase_traceql.go
+++ b/test/e2e/seed/cmd/seed/showcase_traceql.go
@@ -76,7 +76,7 @@ VALUES
   (now64(9) - INTERVAL 38 SECOND, 'b0000000000000000000000000000001', 'b000000000000104', 'b000000000000102',
    'orders.insert', 'Client', 'db', map('service.name', 'db'),
    'showcase-instrumentation', '1.2.3',
-   map('db.system', 'postgres', 'payload_bytes', '64'),
+   map('db.system', 'postgres', 'db.system.name', 'postgres', 'payload_bytes', '64'),
    50000000, 'Ok', '', [], [], [], [], [], [], []),
   (now64(9) - INTERVAL 37 SECOND, 'b0000000000000000000000000000001', 'b000000000000105', 'b000000000000103',
    'charge-retry', 'Internal', 'payments', map('service.name', 'payments'),
@@ -105,7 +105,7 @@ VALUES
   (now64(9) - INTERVAL 22 SECOND, 'b0000000000000000000000000000002', 'b000000000000204', 'b000000000000203',
    'orders.update', 'Client', 'db', map('service.name', 'db'),
    'showcase-instrumentation', '1.2.3',
-   map('db.system', 'postgres', 'payload_bytes', '96'),
+   map('db.system', 'postgres', 'db.system.name', 'postgres', 'payload_bytes', '96'),
    40000000, 'Ok', '', [], [], [], [], [], [], [])`
 
 // deleteStaleShowcaseTracesSQL drops the *previous* ticks' showcase

--- a/test/regression/seed_test.go
+++ b/test/regression/seed_test.go
@@ -188,6 +188,48 @@ func TestTracesSeedHasFrontendAndApiServices(t *testing.T) {
 	}
 }
 
+// TestDatabaseSpanSeedsCarryBothSystemKeys pins the two contracts the E2E
+// database spans serve. Grafana Traces Drilldown v2.1.0's Database calls
+// primary signal queries span.db.system.name, while older compatibility probes
+// still consume the legacy db.system key. Every seeded database map must carry
+// both keys with the same value so adding the current semantic-convention key
+// cannot silently erase the legacy coverage (issue #2195).
+func TestDatabaseSpanSeedsCarryBothSystemKeys(t *testing.T) {
+	t.Parallel()
+
+	for _, path := range []string{seedSource, showcaseTraceSeedSource} {
+		buf, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatalf("read %s: %v", path, err)
+		}
+		assertDBSystemNameCompanions(t, path, string(buf))
+	}
+}
+
+func assertDBSystemNameCompanions(t *testing.T, path, content string) {
+	t.Helper()
+
+	mapRE := regexp.MustCompile(`map\(([^)]*'db\.system'[^)]*)\)`)
+	legacyRE := regexp.MustCompile(`'db\.system'\s*,\s*'([^']+)'`)
+	currentRE := regexp.MustCompile(`'db\.system\.name'\s*,\s*'([^']+)'`)
+	maps := mapRE.FindAllStringSubmatch(content, -1)
+	if len(maps) == 0 {
+		t.Fatalf("%s: no seeded db.system maps found", path)
+	}
+	for _, match := range maps {
+		legacy := legacyRE.FindStringSubmatch(match[1])
+		current := currentRE.FindStringSubmatch(match[1])
+		switch {
+		case len(legacy) == 0:
+			t.Errorf("%s: database attribute map lost legacy db.system: map(%s)", path, match[1])
+		case len(current) == 0:
+			t.Errorf("%s: db.system=%q has no db.system.name companion for the Trace Drilldown Database calls signal: map(%s)", path, legacy[1], match[1])
+		case legacy[1] != current[1]:
+			t.Errorf("%s: db.system=%q and db.system.name=%q disagree in map(%s)", path, legacy[1], current[1], match[1])
+		}
+	}
+}
+
 // showcaseTraceSeedSource is the Go file holding the showcase-traceql
 // rolling re-seed (INSERT + stale-row DELETE) for the b0... trace range.
 const showcaseTraceSeedSource = "../e2e/seed/cmd/seed/showcase_traceql.go"


### PR DESCRIPTION
Closes #2195

## What changed

- seed `db.system.name` alongside the intentionally preserved `db.system` value on every database span
- add a regression ratchet requiring both keys to remain present and equal
- add a compose-smoke flow covering the Traces Drilldown Database calls selector, duration histogram, and concrete post-histogram duration query

## Why

Grafana Traces Drilldown v2.1.0 defines Database calls with `span.db.system.name != ""`. The existing fixtures only supplied the legacy `db.system`, leaving that signal empty and preventing the duration flow from reaching its settled query.

The malformed initial empty-threshold query remains tracked upstream in grafana/traces-drilldown#850 and locally in #2009; this change neither suppresses nor tolerates it.

## Validation

- `go test -race -count=1 -run '^TestDatabaseSpanSeedsCarryBothSystemKeys$' ./test/regression`
- `go test -race -count=1 ./test/e2e/seed/cmd/seed`
- `node .github/scripts/compose-smoke-matrix.mjs`
- `git diff --check`