### PR TITLE
test(compat/loki): drive patterns with a live fixture

### DIFF
--- a/compatibility/loki/README.md
+++ b/compatibility/loki/README.md
@@ -28,7 +28,7 @@ compatibility/loki/
   cerberus-queries/               cerberus-owned ADDITIVE query corpus (see below)
   upstream-skip-baseline.txt      pinned set of upstream `skip: true` keys (sanity rail; see "Upstream-skip baseline")
   dataset_metadata.json           pinned dataset metadata for ${SELECTOR}/${LABEL_*}
-  reports/                        diff driver output (gitignored)
+  reports/                        diff output + live fixture handshake (gitignored)
   cmd/
     seed/                         deterministic OTel-shape log seeder
     loki-compliance-tester/       cerberus-owned diff driver
@@ -162,6 +162,25 @@ that lives OUTSIDE the AGPL `upstream/` boundary:
   snapshot untouched: it is upstream's code, unused only in the subset
   cerberus vendors, and the bump procedure below re-copies `metadata.go`
   verbatim, so deleting it locally would be undone at the next bump.
+
+The `/patterns` differential does not use `dataset_metadata.json`.
+Reference Loki serves recent patterns from a wall-clock-retained in-memory
+ingester, so the static corpus anchor cannot provide a sound fixture. The
+seeder therefore dual-writes one dedicated current-time stream and atomically
+publishes its selector, exact query window, and per-level input volumes to
+`reports/live-patterns-metadata.json`. The stream stays outside
+`serviceConfigs` and the template resolver, so it cannot perturb corpus case
+selection. The range driver refuses a missing, malformed, future, or stale
+handshake before issuing any differential request.
+
+The four `/patterns` result rows grade only the portable contract: success
+envelope with non-empty data, exact seeded level vocabulary and coverage,
+two-integer positive sample tuples inside the advertised window, and returned
+volume in `(0, seeded]` for every level on each backend. Pattern text and
+cluster identity are intentionally not compared: upstream's Drain miner and
+Cerberus's clean-room miner are different implementations, and upstream's
+cluster floor/cap are not endpoint semantics Cerberus can soundly mirror by
+comparing templates.
 
 ## Detected-fields differential pass
 

--- a/compatibility/loki/cmd/loki-compliance-tester/main.go
+++ b/compatibility/loki/cmd/loki-compliance-tester/main.go
@@ -88,6 +88,7 @@ type flags struct {
 	corpusDir          string
 	cerberusQueriesDir string
 	metadataDir        string
+	livePatternsPath   string
 	reportPath         string
 	scorePath          string
 	casesPath          string
@@ -108,6 +109,7 @@ func parseFlags() flags {
 	flag.StringVar(&f.corpusDir, "corpus", "./queries", "Path to the vendored bench/queries/ directory (suite subdirs: fast/, regression/, exhaustive/)")
 	flag.StringVar(&f.cerberusQueriesDir, "cerberus-queries", "./cerberus-queries", "Path to the cerberus-owned additive query directory (same suite subdirs: fast/, regression/, exhaustive/); merged into the corpus loaded from -corpus. Never edits the AGPL vendor snapshot.")
 	flag.StringVar(&f.metadataDir, "metadata-dir", ".", "Directory containing dataset_metadata.json")
+	flag.StringVar(&f.livePatternsPath, "live-patterns-metadata", "", "Path to the seeder's now-anchored /patterns fixture handshake (required for range runs)")
 	flag.StringVar(&f.reportPath, "report", "", "Report output path; empty writes to stdout")
 	flag.StringVar(&f.scorePath, "score", "", "shields.io endpoint-badge score JSON output path; empty means do not write")
 	flag.StringVar(&f.casesPath, "cases", "", "per-case parity roster JSON output path; empty means do not write")
@@ -150,6 +152,9 @@ func run() error {
 		return errors.New("both -addr-1 and -addr-2 must be set")
 	}
 	isInstant := f.rangeType == "instant"
+	if !isInstant && f.livePatternsPath == "" {
+		return errors.New("-live-patterns-metadata is required for range runs")
+	}
 
 	// Sanity rail (task #269): when -skip-baseline is set, partition
 	// the full corpus into runnable + upstream-skipped, then diff the
@@ -182,6 +187,10 @@ func run() error {
 	// results join the same report + score pipeline as the corpus
 	// cases — no separate bucket, no allow-list.
 	if !isInstant {
+		livePatterns, err := readLivePatternsMetadata(f.livePatternsPath, time.Now().UTC())
+		if err != nil {
+			return fmt.Errorf("load live patterns metadata: %w", err)
+		}
 		metadata, err := bench.LoadMetadata(f.metadataDir)
 		if err != nil {
 			return fmt.Errorf("LoadMetadata(%s) for detected-fields pass: %w", f.metadataDir, err)
@@ -212,6 +221,13 @@ func run() error {
 		// #1435 / #1593 / #1484 / #1626 describe on the Tempo side. See
 		// status_parity.go.
 		results = append(results, compareStatusParityAll(httpClient, f)...)
+
+		// /patterns is backed by a wall-clock-retained pattern ingester in
+		// reference Loki, so it consumes the separate live fixture described
+		// by the seeder handshake rather than dataset_metadata.json's static
+		// corpus. Only stable protocol axes are graded; pattern strings and
+		// cluster identities are deliberately outside the comparison.
+		results = append(results, compareLivePatterns(httpClient, f, livePatterns)...)
 	}
 
 	report := Report{

--- a/compatibility/loki/cmd/loki-compliance-tester/patterns_live.go
+++ b/compatibility/loki/cmd/loki-compliance-tester/patterns_live.go
@@ -68,7 +68,7 @@ func livePatternsAxes() []livePatternsAxis {
 }
 
 func readLivePatternsMetadata(path string, now time.Time) (livePatternsMetadata, error) {
-	payload, err := os.ReadFile(path)
+	payload, err := os.ReadFile(path) //nolint:gosec // operator-supplied handshake path; offline harness input
 	if err != nil {
 		return livePatternsMetadata{}, err
 	}

--- a/compatibility/loki/cmd/loki-compliance-tester/patterns_live.go
+++ b/compatibility/loki/cmd/loki-compliance-tester/patterns_live.go
@@ -1,0 +1,313 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"slices"
+	"sort"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+)
+
+const (
+	livePatternsSource          = "cerberus/patterns-live"
+	livePatternsMetadataVersion = 1
+	livePatternsMetadataMaxAge  = 15 * time.Minute
+	livePatternsWindowMaxSpan   = 10 * time.Minute
+	livePatternsStep            = 10 * time.Second
+	livePatternsBodyLimit       = 16 << 20
+)
+
+type livePatternsMetadata struct {
+	Version        int            `json:"version"`
+	Selector       string         `json:"selector"`
+	Start          time.Time      `json:"start"`
+	End            time.Time      `json:"end"`
+	CreatedAt      time.Time      `json:"created_at"`
+	EntriesByLevel map[string]int `json:"entries_by_level"`
+}
+
+type patternWire struct {
+	Level   string            `json:"level"`
+	Samples []json.RawMessage `json:"samples"`
+}
+
+type patternsWire struct {
+	Status string
+	Data   []patternWire
+}
+
+type patternsObservation struct {
+	envelopeErr string
+	encodingErr string
+	levels      []string
+	volume      map[string]int64
+}
+
+type livePatternsAxis struct {
+	kind        string
+	description string
+}
+
+func livePatternsAxes() []livePatternsAxis {
+	return []livePatternsAxis{
+		{kind: "patterns_envelope", description: "live /patterns success envelope and non-empty data"},
+		{kind: "patterns_levels", description: "live /patterns level vocabulary and coverage"},
+		{kind: "patterns_samples", description: "live /patterns sample tuple encoding"},
+		{kind: "patterns_volume", description: "live /patterns per-level volume bound"},
+	}
+}
+
+func readLivePatternsMetadata(path string, now time.Time) (livePatternsMetadata, error) {
+	payload, err := os.ReadFile(path)
+	if err != nil {
+		return livePatternsMetadata{}, err
+	}
+	decoder := json.NewDecoder(bytes.NewReader(payload))
+	decoder.DisallowUnknownFields()
+	var metadata livePatternsMetadata
+	if err := decoder.Decode(&metadata); err != nil {
+		return livePatternsMetadata{}, fmt.Errorf("decode: %w", err)
+	}
+	if err := decoder.Decode(&struct{}{}); !errors.Is(err, io.EOF) {
+		return livePatternsMetadata{}, errors.New("metadata contains trailing JSON")
+	}
+	if err := validateLivePatternsMetadata(metadata, now.UTC()); err != nil {
+		return livePatternsMetadata{}, err
+	}
+	return metadata, nil
+}
+
+func validateLivePatternsMetadata(metadata livePatternsMetadata, now time.Time) error {
+	if metadata.Version != livePatternsMetadataVersion {
+		return fmt.Errorf("version=%d, want %d", metadata.Version, livePatternsMetadataVersion)
+	}
+	if metadata.Selector == "" {
+		return errors.New("selector is empty")
+	}
+	if !metadata.Start.Before(metadata.End) {
+		return fmt.Errorf("invalid window: start=%s end=%s", metadata.Start, metadata.End)
+	}
+	if span := metadata.End.Sub(metadata.Start); span > livePatternsWindowMaxSpan {
+		return fmt.Errorf("window span=%s exceeds %s", span, livePatternsWindowMaxSpan)
+	}
+	if metadata.CreatedAt.Before(metadata.End) {
+		return fmt.Errorf("created_at=%s precedes window end=%s", metadata.CreatedAt, metadata.End)
+	}
+	if metadata.CreatedAt.After(now) {
+		return fmt.Errorf("created_at=%s is in the future relative to %s", metadata.CreatedAt, now)
+	}
+	if age := now.Sub(metadata.CreatedAt); age > livePatternsMetadataMaxAge {
+		return fmt.Errorf("metadata age=%s exceeds %s", age, livePatternsMetadataMaxAge)
+	}
+	if len(metadata.EntriesByLevel) == 0 {
+		return errors.New("entries_by_level is empty")
+	}
+	for level, count := range metadata.EntriesByLevel {
+		if level == "" || level != strings.ToLower(level) || count <= 0 {
+			return fmt.Errorf("invalid level volume %q=%d", level, count)
+		}
+	}
+	return nil
+}
+
+func compareLivePatterns(c *http.Client, f flags, metadata livePatternsMetadata) []Result {
+	type fetched struct {
+		observation patternsObservation
+		err         error
+	}
+	out := make([]fetched, 2)
+	var wg sync.WaitGroup
+	wg.Add(2)
+	for idx, addr := range []string{f.addr1, f.addr2} {
+		idx, addr := idx, addr
+		go func() {
+			defer wg.Done()
+			wire, err := fetchLivePatterns(c, addr, metadata)
+			if err != nil {
+				out[idx].err = err
+				return
+			}
+			out[idx].observation = observeLivePatterns(wire, metadata)
+		}()
+	}
+	wg.Wait()
+
+	results := make([]Result, 0, len(livePatternsAxes()))
+	for _, axis := range livePatternsAxes() {
+		result := Result{TestCase: TestCase{
+			Query:       metadata.Selector,
+			Source:      livePatternsSource,
+			Description: axis.description,
+			Kind:        axis.kind,
+			Direction:   "n/a",
+			Start:       metadata.Start.Format(time.RFC3339Nano),
+			End:         metadata.End.Format(time.RFC3339Nano),
+			Step:        livePatternsStep.String(),
+		}}
+		switch {
+		case out[0].err != nil:
+			result.UnexpectedFailure = fmt.Sprintf("reference (-addr-1) failed: %v", out[0].err)
+		case out[1].err != nil:
+			result.UnexpectedFailure = fmt.Sprintf("test endpoint (-addr-2) failed: %v", out[1].err)
+		default:
+			result.Diff = compareLivePatternsAxis(axis.kind, out[0].observation, out[1].observation, metadata)
+		}
+		results = append(results, result)
+	}
+	return results
+}
+
+func fetchLivePatterns(c *http.Client, baseURL string, metadata livePatternsMetadata) (patternsWire, error) {
+	params := url.Values{}
+	params.Set("query", metadata.Selector)
+	params.Set("start", strconv.FormatInt(metadata.Start.UnixNano(), 10))
+	params.Set("end", strconv.FormatInt(metadata.End.UnixNano(), 10))
+	params.Set("step", livePatternsStep.String())
+	endpoint := strings.TrimRight(baseURL, "/") + "/loki/api/v1/patterns?" + params.Encode()
+	ctx, cancel := context.WithTimeout(context.Background(), c.Timeout)
+	defer cancel()
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
+	if err != nil {
+		return patternsWire{}, fmt.Errorf("new request: %w", err)
+	}
+	resp, err := c.Do(req)
+	if err != nil {
+		return patternsWire{}, fmt.Errorf("http call: %w", err)
+	}
+	defer resp.Body.Close()
+	body, err := io.ReadAll(io.LimitReader(resp.Body, livePatternsBodyLimit))
+	if err != nil {
+		return patternsWire{}, fmt.Errorf("read body: %w", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		return patternsWire{}, fmt.Errorf("status=%d body=%s", resp.StatusCode, errorBodySnippet(string(body)))
+	}
+	return decodePatternsWire(body), nil
+}
+
+func decodePatternsWire(body []byte) patternsWire {
+	var raw struct {
+		Status json.RawMessage `json:"status"`
+		Data   json.RawMessage `json:"data"`
+	}
+	if err := json.Unmarshal(body, &raw); err != nil {
+		return patternsWire{Status: "decode error: " + err.Error()}
+	}
+	var status string
+	if len(raw.Status) == 0 {
+		status = "missing"
+	} else if err := json.Unmarshal(raw.Status, &status); err != nil {
+		status = "invalid: " + err.Error()
+	}
+	if len(raw.Data) == 0 || bytes.Equal(raw.Data, []byte("null")) {
+		return patternsWire{Status: status}
+	}
+	var data []patternWire
+	if err := json.Unmarshal(raw.Data, &data); err != nil {
+		return patternsWire{Status: status, Data: []patternWire{{Level: "__data_decode_error__" + err.Error()}}}
+	}
+	return patternsWire{Status: status, Data: data}
+}
+
+func observeLivePatterns(wire patternsWire, metadata livePatternsMetadata) patternsObservation {
+	observation := patternsObservation{volume: make(map[string]int64)}
+	if wire.Status != "success" {
+		observation.envelopeErr = fmt.Sprintf("status field=%q", wire.Status)
+	} else if len(wire.Data) == 0 {
+		observation.envelopeErr = "data is missing, null, or empty"
+	}
+	levelSet := make(map[string]struct{})
+	for patternIndex, pattern := range wire.Data {
+		levelSet[pattern.Level] = struct{}{}
+		for sampleIndex, raw := range pattern.Samples {
+			var tuple []int64
+			if err := json.Unmarshal(raw, &tuple); err != nil {
+				observation.encodingErr = fmt.Sprintf("pattern[%d].samples[%d] is not an integer tuple: %v", patternIndex, sampleIndex, err)
+				continue
+			}
+			if len(tuple) != 2 {
+				observation.encodingErr = fmt.Sprintf("pattern[%d].samples[%d] has %d elements, want 2", patternIndex, sampleIndex, len(tuple))
+				continue
+			}
+			ts, count := tuple[0], tuple[1]
+			if ts < metadata.Start.Unix() || ts > metadata.End.Unix() {
+				observation.encodingErr = fmt.Sprintf("pattern[%d].samples[%d] timestamp=%d outside [%d,%d]", patternIndex, sampleIndex, ts, metadata.Start.Unix(), metadata.End.Unix())
+			}
+			if count <= 0 {
+				observation.encodingErr = fmt.Sprintf("pattern[%d].samples[%d] count=%d, want positive", patternIndex, sampleIndex, count)
+				continue
+			}
+			observation.volume[pattern.Level] += count
+		}
+	}
+	observation.levels = make([]string, 0, len(levelSet))
+	for level := range levelSet {
+		observation.levels = append(observation.levels, level)
+	}
+	sort.Strings(observation.levels)
+	return observation
+}
+
+func compareLivePatternsAxis(kind string, reference, test patternsObservation, metadata livePatternsMetadata) string {
+	switch kind {
+	case "patterns_envelope":
+		return sideErrors("envelope", reference.envelopeErr, test.envelopeErr)
+	case "patterns_levels":
+		expected := make([]string, 0, len(metadata.EntriesByLevel))
+		for level := range metadata.EntriesByLevel {
+			expected = append(expected, level)
+		}
+		sort.Strings(expected)
+		return sideSliceDiff("levels", expected, reference.levels, test.levels)
+	case "patterns_samples":
+		return sideErrors("sample encoding", reference.encodingErr, test.encodingErr)
+	case "patterns_volume":
+		for _, side := range []struct {
+			name   string
+			volume map[string]int64
+		}{
+			{name: "reference", volume: reference.volume},
+			{name: "test endpoint", volume: test.volume},
+		} {
+			for level, seeded := range metadata.EntriesByLevel {
+				got := side.volume[level]
+				if got <= 0 || got > int64(seeded) {
+					return fmt.Sprintf("%s level=%q volume=%d outside (0,%d]", side.name, level, got, seeded)
+				}
+			}
+		}
+		return ""
+	default:
+		return "unknown live patterns axis " + kind
+	}
+}
+
+func sideErrors(axis, reference, test string) string {
+	switch {
+	case reference != "" && test != "":
+		return fmt.Sprintf("%s: reference=%s; test endpoint=%s", axis, reference, test)
+	case reference != "":
+		return fmt.Sprintf("%s: reference=%s", axis, reference)
+	case test != "":
+		return fmt.Sprintf("%s: test endpoint=%s", axis, test)
+	default:
+		return ""
+	}
+}
+
+func sideSliceDiff(axis string, expected, reference, test []string) string {
+	if slices.Equal(reference, expected) && slices.Equal(test, expected) {
+		return ""
+	}
+	return fmt.Sprintf("%s: expected=%v reference=%v test endpoint=%v", axis, expected, reference, test)
+}

--- a/compatibility/loki/cmd/loki-compliance-tester/patterns_live_test.go
+++ b/compatibility/loki/cmd/loki-compliance-tester/patterns_live_test.go
@@ -1,0 +1,154 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func livePatternsTestMetadata() livePatternsMetadata {
+	end := time.Date(2026, 8, 15, 12, 0, 0, 0, time.UTC)
+	return livePatternsMetadata{
+		Version:        livePatternsMetadataVersion,
+		Selector:       `{service_name="cerberus-patterns-live"}`,
+		Start:          end.Add(-2 * time.Minute),
+		End:            end,
+		CreatedAt:      end,
+		EntriesByLevel: map[string]int{"error": 40, "info": 40, "warn": 40},
+	}
+}
+
+func TestReadLivePatternsMetadata_RejectsStaleAndMalformedHandshakes(t *testing.T) {
+	t.Parallel()
+	metadata := livePatternsTestMetadata()
+	write := func(t *testing.T, value any, suffix string) string {
+		t.Helper()
+		payload, err := json.Marshal(value)
+		if err != nil {
+			t.Fatalf("Marshal: %v", err)
+		}
+		path := filepath.Join(t.TempDir(), "live.json")
+		if err := os.WriteFile(path, append(payload, suffix...), 0o600); err != nil {
+			t.Fatalf("WriteFile: %v", err)
+		}
+		return path
+	}
+
+	if got, err := readLivePatternsMetadata(write(t, metadata, "\n"), metadata.CreatedAt.Add(time.Minute)); err != nil {
+		t.Fatalf("valid metadata rejected: %v", err)
+	} else if got.Selector != metadata.Selector {
+		t.Fatalf("selector=%q, want %q", got.Selector, metadata.Selector)
+	}
+
+	staleNow := metadata.CreatedAt.Add(livePatternsMetadataMaxAge + time.Second)
+	if _, err := readLivePatternsMetadata(write(t, metadata, ""), staleNow); err == nil || !strings.Contains(err.Error(), "metadata age") {
+		t.Fatalf("stale metadata error=%v, want age diagnostic", err)
+	}
+	if _, err := readLivePatternsMetadata(write(t, metadata, " {}"), metadata.CreatedAt); err == nil || !strings.Contains(err.Error(), "trailing JSON") {
+		t.Fatalf("trailing JSON error=%v", err)
+	}
+	withUnknown := map[string]any{
+		"version": metadata.Version, "selector": metadata.Selector, "start": metadata.Start,
+		"end": metadata.End, "created_at": metadata.CreatedAt, "entries_by_level": metadata.EntriesByLevel,
+		"unrecognised": true,
+	}
+	if _, err := readLivePatternsMetadata(write(t, withUnknown, ""), metadata.CreatedAt); err == nil || !strings.Contains(err.Error(), "unknown field") {
+		t.Fatalf("unknown-field error=%v", err)
+	}
+}
+
+func TestCompareLivePatterns_GradesOnlyStableAxes(t *testing.T) {
+	t.Parallel()
+	metadata := livePatternsTestMetadata()
+	reference := livePatternsServer(t, metadata, `{
+  "status":"success",
+  "data":[
+    {"pattern":"upstream alpha <*> beta","level":"info","samples":[[%d,20],[%d,15]]},
+    {"pattern":"upstream error","level":"error","samples":[[%d,31]]},
+    {"pattern":"upstream warn","level":"warn","samples":[[%d,40]]}
+  ]
+}`)
+	testEndpoint := livePatternsServer(t, metadata, `{
+  "status":"success",
+  "data":[
+    {"pattern":"clean room cluster one","level":"warn","samples":[[%d,20],[%d,15]]},
+    {"pattern":"clean room cluster two","level":"info","samples":[[%d,40]]},
+    {"pattern":"clean room cluster three","level":"error","samples":[[%d,30]]}
+  ]
+}`)
+
+	results := compareLivePatterns(&http.Client{Timeout: 5 * time.Second}, flags{addr1: reference.URL, addr2: testEndpoint.URL}, metadata)
+	if len(results) != len(livePatternsAxes()) {
+		t.Fatalf("results=%d, want %d", len(results), len(livePatternsAxes()))
+	}
+	for _, result := range results {
+		if !result.success() {
+			t.Fatalf("stable-axis comparison failed for %s: %+v", result.TestCase.Kind, result)
+		}
+		if result.TestCase.Source != livePatternsSource || result.TestCase.Query != metadata.Selector {
+			t.Fatalf("case envelope=%+v", result.TestCase)
+		}
+	}
+}
+
+func TestCompareLivePatterns_ReportsPerLevelOvercount(t *testing.T) {
+	t.Parallel()
+	metadata := livePatternsTestMetadata()
+	tooLarge := `{"status":"success","data":[` +
+		`{"pattern":"a","level":"error","samples":[[%d,41]]},` +
+		`{"pattern":"b","level":"info","samples":[[%d,20],[%d,20]]},` +
+		`{"pattern":"c","level":"warn","samples":[[%d,40]]}]}`
+	reference := livePatternsServer(t, metadata, tooLarge)
+	testEndpoint := livePatternsServer(t, metadata, tooLarge)
+	results := compareLivePatterns(&http.Client{Timeout: 5 * time.Second}, flags{addr1: reference.URL, addr2: testEndpoint.URL}, metadata)
+
+	for _, result := range results {
+		if result.TestCase.Kind == "patterns_volume" {
+			if !strings.Contains(result.Diff, `level="error" volume=41 outside (0,40]`) {
+				t.Fatalf("volume diff=%q", result.Diff)
+			}
+			return
+		}
+	}
+	t.Fatal("patterns_volume result missing")
+}
+
+func TestObserveLivePatterns_RejectsNonIntegerSampleEncoding(t *testing.T) {
+	t.Parallel()
+	metadata := livePatternsTestMetadata()
+	wire := decodePatternsWire([]byte(`{"status":"success","data":[{"level":"info","samples":[[1.5,2]]}]}`))
+	observation := observeLivePatterns(wire, metadata)
+	if !strings.Contains(observation.encodingErr, "not an integer tuple") {
+		t.Fatalf("encoding error=%q", observation.encodingErr)
+	}
+}
+
+func livePatternsServer(t *testing.T, metadata livePatternsMetadata, bodyFormat string) *httptest.Server {
+	t.Helper()
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/loki/api/v1/patterns" {
+			http.NotFound(w, r)
+			return
+		}
+		if got := r.URL.Query().Get("query"); got != metadata.Selector {
+			t.Errorf("query=%q, want %q", got, metadata.Selector)
+		}
+		if got := r.URL.Query().Get("start"); got != fmt.Sprint(metadata.Start.UnixNano()) {
+			t.Errorf("start=%q, want %d", got, metadata.Start.UnixNano())
+		}
+		if got := r.URL.Query().Get("end"); got != fmt.Sprint(metadata.End.UnixNano()) {
+			t.Errorf("end=%q, want %d", got, metadata.End.UnixNano())
+		}
+		ts := metadata.Start.Add(time.Minute).Unix()
+		_, _ = fmt.Fprintf(w, bodyFormat, ts, ts+10, ts+20, ts+30)
+	})
+	server := httptest.NewServer(handler)
+	t.Cleanup(server.Close)
+	return server
+}

--- a/compatibility/loki/cmd/seed/live_patterns.go
+++ b/compatibility/loki/cmd/seed/live_patterns.go
@@ -105,7 +105,7 @@ func writeLivePatternsMetadata(path string, metadata livePatternsMetadata) error
 	payload = append(payload, '\n')
 
 	dir := filepath.Dir(path)
-	if err := os.MkdirAll(dir, 0o755); err != nil {
+	if err := os.MkdirAll(dir, 0o750); err != nil {
 		return fmt.Errorf("mkdir %s: %w", dir, err)
 	}
 	tmp, err := os.CreateTemp(dir, ".live-patterns-*.json")

--- a/compatibility/loki/cmd/seed/live_patterns.go
+++ b/compatibility/loki/cmd/seed/live_patterns.go
@@ -1,0 +1,234 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"time"
+)
+
+const (
+	livePatternsService         = "cerberus-patterns-live"
+	livePatternsEntriesPerLevel = 40
+	livePatternsEntryInterval   = time.Second
+	livePatternsFixtureAge      = 2 * time.Minute
+	livePatternsPollInterval    = 250 * time.Millisecond
+	livePatternsProbeTimeout    = 30 * time.Second
+	livePatternsMetadataVersion = 1
+)
+
+var livePatternsLevels = []string{"ERROR", "INFO", "WARN"}
+
+type livePatternsMetadata struct {
+	Version        int            `json:"version"`
+	Selector       string         `json:"selector"`
+	Start          time.Time      `json:"start"`
+	End            time.Time      `json:"end"`
+	CreatedAt      time.Time      `json:"created_at"`
+	EntriesByLevel map[string]int `json:"entries_by_level"`
+}
+
+type livePatternsFixture struct {
+	stream   stream
+	metadata livePatternsMetadata
+}
+
+func buildLivePatternsFixture(now time.Time) livePatternsFixture {
+	now = now.UTC().Truncate(time.Second)
+	start := now.Add(-livePatternsFixtureAge)
+	entryCount := len(livePatternsLevels) * livePatternsEntriesPerLevel
+	entries := make([]entry, 0, entryCount)
+	counts := make(map[string]int, len(livePatternsLevels))
+	for i := 0; i < entryCount; i++ {
+		level := livePatternsLevels[i%len(livePatternsLevels)]
+		entries = append(entries, entry{
+			ts:    start.Add(time.Duration(i) * livePatternsEntryInterval),
+			level: level,
+			line:  "live patterns fixture processed request",
+		})
+		counts[strings.ToLower(level)]++
+	}
+
+	config := serviceConfig{
+		Name:        livePatternsService,
+		ServiceName: livePatternsService,
+		Format:      "unstructured",
+		Cluster:     "live-patterns",
+		Namespace:   "compatibility",
+		Pod:         "live-patterns-0",
+		Container:   "seeder",
+	}
+	return livePatternsFixture{
+		stream: stream{
+			config: config,
+			labels: map[string]string{
+				"cluster":      config.Cluster,
+				"namespace":    config.Namespace,
+				"service":      config.Name,
+				"service_name": config.ServiceName,
+				"pod":          config.Pod,
+				"container":    config.Container,
+				"env":          "production",
+				"region":       "us-east-1",
+				"datacenter":   "dc1",
+			},
+			entries: entries,
+		},
+		metadata: livePatternsMetadata{
+			Version:        livePatternsMetadataVersion,
+			Selector:       `{service_name="` + livePatternsService + `"}`,
+			Start:          start,
+			End:            now,
+			CreatedAt:      now,
+			EntriesByLevel: counts,
+		},
+	}
+}
+
+func writeLivePatternsMetadata(path string, metadata livePatternsMetadata) error {
+	if err := validateLivePatternsMetadata(metadata); err != nil {
+		return err
+	}
+	payload, err := json.MarshalIndent(metadata, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal: %w", err)
+	}
+	payload = append(payload, '\n')
+
+	dir := filepath.Dir(path)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return fmt.Errorf("mkdir %s: %w", dir, err)
+	}
+	tmp, err := os.CreateTemp(dir, ".live-patterns-*.json")
+	if err != nil {
+		return fmt.Errorf("create temp file: %w", err)
+	}
+	tmpPath := tmp.Name()
+	defer func() { _ = os.Remove(tmpPath) }()
+	if err := tmp.Chmod(0o600); err != nil {
+		_ = tmp.Close()
+		return fmt.Errorf("chmod temp file: %w", err)
+	}
+	if _, err := tmp.Write(payload); err != nil {
+		_ = tmp.Close()
+		return fmt.Errorf("write temp file: %w", err)
+	}
+	if err := tmp.Sync(); err != nil {
+		_ = tmp.Close()
+		return fmt.Errorf("sync temp file: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		return fmt.Errorf("close temp file: %w", err)
+	}
+	if err := os.Rename(tmpPath, path); err != nil {
+		return fmt.Errorf("rename metadata into place: %w", err)
+	}
+	return nil
+}
+
+func validateLivePatternsMetadata(metadata livePatternsMetadata) error {
+	if metadata.Version != livePatternsMetadataVersion {
+		return fmt.Errorf("version=%d, want %d", metadata.Version, livePatternsMetadataVersion)
+	}
+	if metadata.Selector == "" {
+		return errors.New("selector is empty")
+	}
+	if !metadata.Start.Before(metadata.End) {
+		return fmt.Errorf("invalid window: start=%s end=%s", metadata.Start, metadata.End)
+	}
+	if metadata.CreatedAt.IsZero() {
+		return errors.New("created_at is zero")
+	}
+	if len(metadata.EntriesByLevel) == 0 {
+		return errors.New("entries_by_level is empty")
+	}
+	for level, count := range metadata.EntriesByLevel {
+		if level == "" || count <= 0 {
+			return fmt.Errorf("invalid level volume %q=%d", level, count)
+		}
+	}
+	return nil
+}
+
+func waitLivePatternsBoth(ctx context.Context, lokiURL, cerberusURL string, metadata livePatternsMetadata, logger *slog.Logger) error {
+	for _, target := range []struct {
+		name string
+		url  string
+	}{
+		{name: "loki", url: lokiURL},
+		{name: "cerberus", url: cerberusURL},
+	} {
+		if err := waitLivePatternsNonEmpty(ctx, target.url, metadata); err != nil {
+			return fmt.Errorf("%s: %w", target.name, err)
+		}
+		logger.Info("live /patterns fixture visible", "target", target.name)
+	}
+	return nil
+}
+
+func waitLivePatternsNonEmpty(ctx context.Context, baseURL string, metadata livePatternsMetadata) error {
+	deadline := time.Now().Add(livePatternsProbeTimeout)
+	var lastErr error
+	for {
+		lastErr = probeLivePatterns(ctx, baseURL, metadata)
+		if lastErr == nil {
+			return nil
+		}
+		if time.Now().After(deadline) {
+			return fmt.Errorf("timed out waiting for non-empty /patterns: %w", lastErr)
+		}
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(livePatternsPollInterval):
+		}
+	}
+}
+
+func probeLivePatterns(ctx context.Context, baseURL string, metadata livePatternsMetadata) error {
+	params := url.Values{}
+	params.Set("query", metadata.Selector)
+	params.Set("start", strconv.FormatInt(metadata.Start.UnixNano(), 10))
+	params.Set("end", strconv.FormatInt(metadata.End.UnixNano(), 10))
+	params.Set("step", "10s")
+	endpoint := strings.TrimRight(baseURL, "/") + "/loki/api/v1/patterns?" + params.Encode()
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
+	if err != nil {
+		return fmt.Errorf("new request: %w", err)
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("request: %w", err)
+	}
+	defer resp.Body.Close()
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
+	if err != nil {
+		return fmt.Errorf("read response: %w", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("status=%d body=%s", resp.StatusCode, strings.TrimSpace(string(body)))
+	}
+	var envelope struct {
+		Status string            `json:"status"`
+		Data   []json.RawMessage `json:"data"`
+	}
+	if err := json.Unmarshal(body, &envelope); err != nil {
+		return fmt.Errorf("decode response: %w", err)
+	}
+	if envelope.Status != "success" {
+		return fmt.Errorf("status field=%q", envelope.Status)
+	}
+	if len(envelope.Data) == 0 {
+		return errors.New("data is empty")
+	}
+	return nil
+}

--- a/compatibility/loki/cmd/seed/live_patterns_test.go
+++ b/compatibility/loki/cmd/seed/live_patterns_test.go
@@ -1,0 +1,71 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+	"time"
+)
+
+func TestBuildLivePatternsFixture_UsesOneInjectedClock(t *testing.T) {
+	t.Parallel()
+	now := time.Date(2026, 8, 15, 12, 34, 56, 789, time.UTC)
+	fixture := buildLivePatternsFixture(now)
+
+	if fixture.stream.config.ServiceName != livePatternsService {
+		t.Fatalf("service_name=%q, want %q", fixture.stream.config.ServiceName, livePatternsService)
+	}
+	for _, config := range serviceConfigs {
+		if config.ServiceName == livePatternsService {
+			t.Fatalf("live service leaked into static serviceConfigs: %+v", config)
+		}
+	}
+	wantEntries := len(livePatternsLevels) * livePatternsEntriesPerLevel
+	if got := len(fixture.stream.entries); got != wantEntries {
+		t.Fatalf("entries=%d, want %d", got, wantEntries)
+	}
+	wantCreatedAt := now.Truncate(time.Second)
+	if !fixture.metadata.CreatedAt.Equal(wantCreatedAt) || !fixture.metadata.End.Equal(wantCreatedAt) {
+		t.Fatalf("metadata clock=(created=%s end=%s), want both %s", fixture.metadata.CreatedAt, fixture.metadata.End, wantCreatedAt)
+	}
+	if !fixture.stream.entries[0].ts.Equal(fixture.metadata.Start) {
+		t.Fatalf("first timestamp=%s, metadata start=%s", fixture.stream.entries[0].ts, fixture.metadata.Start)
+	}
+	last := fixture.stream.entries[len(fixture.stream.entries)-1].ts
+	if !last.Before(fixture.metadata.End) {
+		t.Fatalf("last timestamp=%s must be before window end=%s", last, fixture.metadata.End)
+	}
+	wantCounts := map[string]int{"error": 40, "info": 40, "warn": 40}
+	if !reflect.DeepEqual(fixture.metadata.EntriesByLevel, wantCounts) {
+		t.Fatalf("entries_by_level=%v, want %v", fixture.metadata.EntriesByLevel, wantCounts)
+	}
+}
+
+func TestWriteLivePatternsMetadata_ReplacesCompleteJSON(t *testing.T) {
+	t.Parallel()
+	path := filepath.Join(t.TempDir(), "nested", "live-patterns.json")
+	metadata := buildLivePatternsFixture(time.Date(2026, 8, 15, 12, 0, 0, 0, time.UTC)).metadata
+	if err := writeLivePatternsMetadata(path, metadata); err != nil {
+		t.Fatalf("writeLivePatternsMetadata: %v", err)
+	}
+	payload, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	var got livePatternsMetadata
+	if err := json.Unmarshal(payload, &got); err != nil {
+		t.Fatalf("metadata is not complete JSON: %v\n%s", err, payload)
+	}
+	if !reflect.DeepEqual(got, metadata) {
+		t.Fatalf("metadata=%+v, want %+v", got, metadata)
+	}
+	matches, err := filepath.Glob(filepath.Join(filepath.Dir(path), ".live-patterns-*.json"))
+	if err != nil {
+		t.Fatalf("Glob: %v", err)
+	}
+	if len(matches) != 0 {
+		t.Fatalf("temporary metadata files remain after rename: %v", matches)
+	}
+}

--- a/compatibility/loki/cmd/seed/main.go
+++ b/compatibility/loki/cmd/seed/main.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"flag"
 	"fmt"
 	"io"
@@ -169,9 +170,13 @@ func run(logger *slog.Logger) error {
 		password = flag.String("password", envOr("CERBERUS_CH_PASSWORD", "cerberus"), "ClickHouse password")
 		lokiURL  = flag.String("loki-url", envOr("LOKI_URL", "http://localhost:23100"), "Reference Loki base URL")
 		cerbURL  = flag.String("cerberus-url", envOr("CERBERUS_URL", "http://localhost:29092"), "cerberus LogQL base URL")
+		livePath = flag.String("live-patterns-metadata", envOr("LIVE_PATTERNS_METADATA", ""), "Path for the now-anchored /patterns fixture handshake (required)")
 		timeout  = flag.Duration("timeout", 4*time.Minute, "overall dial + push + verify timeout")
 	)
 	flag.Parse()
+	if *livePath == "" {
+		return errors.New("-live-patterns-metadata is required")
+	}
 
 	ctx, cancel := context.WithTimeout(context.Background(), *timeout)
 	defer cancel()
@@ -206,7 +211,8 @@ func run(logger *slog.Logger) error {
 		return fmt.Errorf("parse anchor: %w", err)
 	}
 
-	streams := buildStreams(start)
+	fixture := buildLivePatternsFixture(time.Now().UTC())
+	streams := append(buildStreams(start), fixture.stream)
 	totalEntries := 0
 	for _, s := range streams {
 		totalEntries += len(s.entries)
@@ -272,11 +278,20 @@ func run(logger *slog.Logger) error {
 		return fmt.Errorf("verify: %w", err)
 	}
 
+	logger.Info("waiting for live /patterns fixture on both targets", "selector", fixture.metadata.Selector)
+	if err := waitLivePatternsBoth(ctx, *lokiURL, *cerbURL, fixture.metadata, logger); err != nil {
+		return fmt.Errorf("verify live patterns: %w", err)
+	}
+	if err := writeLivePatternsMetadata(*livePath, fixture.metadata); err != nil {
+		return fmt.Errorf("write live patterns metadata: %w", err)
+	}
+
 	logger.Info("sample log line", "line", streams[0].entries[0].line)
 	logger.Info(
 		"seed done",
 		"streams", len(streams),
 		"total_entries", totalEntries,
+		"live_patterns_metadata", *livePath,
 	)
 	return nil
 }

--- a/compatibility/loki/loki-config.yaml
+++ b/compatibility/loki/loki-config.yaml
@@ -83,6 +83,14 @@ ingester:
   wal:
     disk_full_threshold: 0
 
+# /patterns is served from a separate, in-memory pattern ingester. The
+# compatibility seeder writes a small wall-clock-anchored stream for this
+# endpoint; the large deterministic corpus remains fixed at its historical
+# anchor and is intentionally unsuitable for the pattern ingester's retention
+# window.
+pattern_ingester:
+  enabled: true
+
 ruler:
   alertmanager_url: http://localhost:9093
 

--- a/compatibility/loki/scripts/run-loki-compatibility.sh
+++ b/compatibility/loki/scripts/run-loki-compatibility.sh
@@ -51,6 +51,10 @@
 #                       reports/compat-cases.json). The per-case
 #                       (identity, agreed) roster the parity ratchet
 #                       gates on; see compatibility/internal/score.
+#   LIVE_PATTERNS_METADATA
+#                       Seeder/tester handshake for the now-anchored
+#                       /patterns fixture (default:
+#                       reports/live-patterns-metadata.json).
 #   DRIVER_TIMEOUT      Per-request HTTP timeout (default: 30s).
 #   DRIVER_TOLERANCE    -tolerance flag (default: 1e-5; matches upstream).
 #   DRIVER_RANGE_TYPE   -range-type flag (default: range; 'instant' also valid).
@@ -79,6 +83,7 @@ export COMPOSE_PROJECT_SUFFIX
 REPORT=${DRIVER_REPORT:-"$ROOT_DIR/reports/diff.json"}
 SCORE=${DRIVER_SCORE:-"$ROOT_DIR/reports/compat-score.json"}
 CASES=${DRIVER_CASES:-"$ROOT_DIR/reports/compat-cases.json"}
+LIVE_PATTERNS_METADATA=${LIVE_PATTERNS_METADATA:-"$ROOT_DIR/reports/live-patterns-metadata.json"}
 TIMEOUT=${DRIVER_TIMEOUT:-30s}
 TOLERANCE=${DRIVER_TOLERANCE:-1e-5}
 RANGE_TYPE=${DRIVER_RANGE_TYPE:-range}
@@ -126,7 +131,8 @@ node "$REPO_ROOT/.github/scripts/build-with-registry-retry.mjs" \
     docker compose up -d --build --wait clickhouse loki cerberus
 
 echo "==> running seeder (go run ./cmd/seed)"
-(cd "$REPO_ROOT" && go run ./compatibility/loki/cmd/seed/)
+(cd "$REPO_ROOT" && go run ./compatibility/loki/cmd/seed/ \
+    -live-patterns-metadata="$LIVE_PATTERNS_METADATA")
 
 if [ -n "${DRIVER_SKIP:-}" ]; then
     echo "==> DRIVER_SKIP set — finishing after smoke"
@@ -164,6 +170,7 @@ set +e
     -corpus="$ROOT_DIR/upstream/loki-bench/queries" \
     -cerberus-queries="$ROOT_DIR/cerberus-queries" \
     -metadata-dir="$ROOT_DIR" \
+    -live-patterns-metadata="$LIVE_PATTERNS_METADATA" \
     -skip-baseline="$SKIP_BASELINE" \
     -report="$REPORT" \
     -score="$SCORE" \

--- a/compatibility/parity-baseline.json
+++ b/compatibility/parity-baseline.json
@@ -938,9 +938,13 @@
       ]
     },
     "loki": {
-      "passed": 218,
-      "total": 218,
+      "passed": 222,
+      "total": 222,
       "cases": [
+        "cerberus/patterns-live | patterns_envelope | range | n/a | {service_name=\"cerberus-patterns-live\"} | step=10s | live /patterns success envelope and non-empty data",
+        "cerberus/patterns-live | patterns_levels | range | n/a | {service_name=\"cerberus-patterns-live\"} | step=10s | live /patterns level vocabulary and coverage",
+        "cerberus/patterns-live | patterns_samples | range | n/a | {service_name=\"cerberus-patterns-live\"} | step=10s | live /patterns sample tuple encoding",
+        "cerberus/patterns-live | patterns_volume | range | n/a | {service_name=\"cerberus-patterns-live\"} | step=10s | live /patterns per-level volume bound",
         "cerberus/status-parity | status_parity | range | n/a |  | missing query parameter on /query_range",
         "cerberus/status-parity | status_parity | range | n/a | { | syntactically invalid LogQL (unbalanced selector) on /query_range",
         "cerberus/wrong-rejection-burndown | log | range | BACKWARD | {cluster=\"cluster-0\", container=\"container-0\", datacenter=\"dc1\", env=\"production\", namespace=\"namespace-0\", pod=\"pod-0\", region=\"us-east-1\", service=\"web-server\", service_name=\"web-server\"} != ip(\"255.255.255.255\") | ip line filter negated: single-IP",


### PR DESCRIPTION
Closes #2082

## What changed

- seed a dedicated wall-clock-anchored log stream into both reference Loki and Cerberus
- publish an atomic seeder/tester JSON handshake carrying the selector, exact query window, creation time, and per-level volume bounds
- enable Loki's in-memory pattern ingester and wait until the fixture is visible on both backends
- add four differential cases covering the stable `/patterns` contract: success envelope, level vocabulary, integer sample tuples, and per-level volume bounds
- keep pattern templates and cluster identity outside the comparison because Loki's AGPL drain implementation and Cerberus's clean-room miner intentionally cluster differently
- generate the Loki parity roster from the successful run, increasing it from 218 to 222 passing cases

## Why

The historical compatibility fixture is calendar-anchored, but reference Loki prunes `/patterns` data relative to wall-clock time. A static-fixture differential therefore always observed an empty reference response and could not catch regressions such as #1434. The live stream is isolated from `dataset_metadata.json`, so existing corpus selectors and cases are unchanged.

## Validation

- `go test -race -count=1 ./compatibility/loki/cmd/loki-compliance-tester ./compatibility/loki/cmd/seed`
- `DRIVER_PARALLELISM=4 just compat-logql` — 222/222 cases passed against reference Loki
- `HEAD=loki SCORE=compatibility/loki/reports/compat-score.json CASES=compatibility/loki/reports/compat-cases.json node .github/scripts/compat-ratchet.mjs`
- `git diff --check`