### PR TITLE
fix(promql): preserve native histograms through label_replace

### DIFF
--- a/internal/api/prom/handler_chdb_histogram_valued_test.go
+++ b/internal/api/prom/handler_chdb_histogram_valued_test.go
@@ -234,6 +234,12 @@ func TestQuery_HistogramValued_ChDB(t *testing.T) {
 			want:       wireHistogram{Count: "30", Sum: "15", Buckets: latestBuckets},
 		},
 		{
+			name:       "label_replace bare selector",
+			query:      `label_replace(latency_exp_hist, "service_copy", "$1-copy", "service", "(.*)")`,
+			wantMetric: map[string]string{"__name__": "latency_exp_hist", "service": "api", "service_copy": "api-copy"},
+			want:       wireHistogram{Count: "30", Sum: "15", Buckets: latestBuckets},
+		},
+		{
 			// An ungrouped sum() reduces ACROSS series, so it publishes
 			// no labels at all. One series in, so the bucket ladder is
 			// unchanged.
@@ -252,6 +258,12 @@ func TestQuery_HistogramValued_ChDB(t *testing.T) {
 			want:       wireHistogram{Count: "30", Sum: "15", Buckets: latestBuckets},
 		},
 		{
+			name:       "label_replace sum by",
+			query:      `label_replace(sum by (service) (latency_exp_hist), "service_copy", "$1-copy", "service", "(.*)")`,
+			wantMetric: map[string]string{"service": "api", "service_copy": "api-copy"},
+			want:       wireHistogram{Count: "30", Sum: "15", Buckets: latestBuckets},
+		},
+		{
 			// The hand-worked expectation from
 			// exp_histogram_rate.txtar: every field scaled by
 			// 1.25/300 = 1/240. Count 24/240 = 0.1, Sum 12/240 =
@@ -261,6 +273,18 @@ func TestQuery_HistogramValued_ChDB(t *testing.T) {
 			name:       "rate",
 			query:      "rate(latency_exp_hist[5m])",
 			wantMetric: map[string]string{"service": "api"},
+			want: wireHistogram{
+				Count: "0.1", Sum: "0.05",
+				Buckets: [][4]any{
+					{float64(0), "1", "2", "0.05"},
+					{float64(0), "2", "4", "0.05"},
+				},
+			},
+		},
+		{
+			name:       "label_replace rate",
+			query:      `label_replace(rate(latency_exp_hist[5m]), "service_copy", "$1-copy", "service", "(.*)")`,
+			wantMetric: map[string]string{"service": "api", "service_copy": "api-copy"},
 			want: wireHistogram{
 				Count: "0.1", Sum: "0.05",
 				Buckets: [][4]any{
@@ -285,6 +309,28 @@ func TestQuery_HistogramValued_ChDB(t *testing.T) {
 			assertBuckets(t, got.Buckets, tc.want.Buckets)
 		})
 	}
+}
+
+// TestQuery_HistogramValuedLabelReplaceCollision_ChDB pins the error half
+// of label_replace's contract. Rewriting the only distinguishing label of
+// two histogram series onto one value must abort instead of merging or
+// publishing duplicate label sets.
+func TestQuery_HistogramValuedLabelReplaceCollision_ChDB(t *testing.T) {
+	c := chclienttest.NewChDB(t)
+	c.Seed(t, histValuedSeed+`
+INSERT INTO otel_metrics_exponential_histogram VALUES
+    ('latency_exp_hist', map('service', 'web'), toDateTime64('2025-12-31 23:59:01', 9),  4,  2.0, 0, 1, 0, [1, 2], 0, []),
+    ('latency_exp_hist', map('service', 'web'), toDateTime64('2026-01-01 00:00:01', 9), 20, 10.0, 0, 1, 0, [9, 10], 0, []);`)
+	h := prom.New(c, schema.DefaultOTelMetrics(), nil)
+	mux := http.NewServeMux()
+	h.Mount(mux)
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+
+	const query = `label_replace(latency_exp_hist, "service", "same", "service", ".*")`
+	status, body := getBody(t, fmt.Sprintf("%s/api/v1/query?query=%s&time=%s",
+		srv.URL, url.QueryEscape(query), histValuedEvalTime.Format(time.RFC3339)))
+	assertDuplicateLabelsetRejected(t, body, status, query)
 }
 
 // assertBuckets compares the decoded bucket tuples element by element.
@@ -448,7 +494,7 @@ func TestQueryRange_HistogramValued_ChDB(t *testing.T) {
 	// values are exp_histogram_rate.txtar's hand-worked ones unchanged.
 	stamp := histValuedEvalTime.Format(time.RFC3339)
 	reqURL := fmt.Sprintf("%s/api/v1/query_range?query=%s&start=%s&end=%s&step=60",
-		srv.URL, url.QueryEscape("rate(latency_exp_hist[5m])"), stamp, stamp)
+		srv.URL, url.QueryEscape(`label_replace(rate(latency_exp_hist[5m]), "service_copy", "$1-copy", "service", "(.*)")`), stamp, stamp)
 
 	resp, err := http.Get(reqURL) //nolint:noctx // test-local request against httptest
 	if err != nil {
@@ -487,7 +533,7 @@ func TestQueryRange_HistogramValued_ChDB(t *testing.T) {
 	if len(series.Values) != 0 {
 		t.Errorf("range query returned BOTH values and histograms: %v", series.Values)
 	}
-	assertMetric(t, series.Metric, map[string]string{"service": "api"})
+	assertMetric(t, series.Metric, map[string]string{"service": "api", "service_copy": "api-copy"})
 
 	// Each entry is [timestamp, {count, sum, buckets}].
 	point, ok := series.Histograms[0].([]any)

--- a/internal/promql/exp_histogram_reject_test.go
+++ b/internal/promql/exp_histogram_reject_test.go
@@ -69,7 +69,6 @@ func TestLower_ExpHistogram_UnsupportedShapesRejectExplicitly(t *testing.T) {
 		{name: "max aggregation", query: `max(latency_exp_hist)`},
 		{name: "stddev aggregation", query: `stddev(latency_exp_hist)`},
 		{name: "stdvar aggregation", query: `stdvar(latency_exp_hist)`},
-		{name: "label_replace", query: `label_replace(latency_exp_hist, "a", "b", "service", "(.*)")`},
 		{name: "abs", query: `abs(latency_exp_hist)`},
 		{name: "topk", query: `topk(3, latency_exp_hist)`},
 		{name: "raw range vector", query: `latency_exp_hist[5m]`},
@@ -82,7 +81,6 @@ func TestLower_ExpHistogram_UnsupportedShapesRejectExplicitly(t *testing.T) {
 		{name: "sum over rate", query: `sum(rate(latency_exp_hist[5m]))`},
 		{name: "sum over increase", query: `sum(increase(latency_exp_hist[5m]))`},
 		{name: "sum of sum", query: `sum(sum(latency_exp_hist))`},
-		{name: "sum under label_replace", query: `label_replace(sum(latency_exp_hist), "a", "b", "service", "(.*)")`},
 		{name: "sum under topk", query: `topk(3, sum by (service) (latency_exp_hist))`},
 		{name: "sum under abs", query: `abs(sum(latency_exp_hist))`},
 
@@ -93,7 +91,6 @@ func TestLower_ExpHistogram_UnsupportedShapesRejectExplicitly(t *testing.T) {
 		// across-series merge stacked on top of the window reduction, so
 		// answering it with the window reduction alone would silently drop
 		// the sum.
-		{name: "rate under label_replace", query: `label_replace(rate(latency_exp_hist[5m]), "a", "b", "service", "(.*)")`},
 		{name: "rate under abs", query: `abs(rate(latency_exp_hist[5m]))`},
 		{name: "rate under topk", query: `topk(3, rate(latency_exp_hist[5m]))`},
 		{name: "rate under avg", query: `avg(rate(latency_exp_hist[5m]))`},
@@ -134,6 +131,78 @@ func TestLower_ExpHistogram_UnsupportedShapesRejectExplicitly(t *testing.T) {
 			}
 			if !strings.Contains(err.Error(), "exponential histogram") {
 				t.Fatalf("Lower(%q): error %q does not explain the exp-histogram shape mismatch", tc.query, err.Error())
+			}
+		})
+	}
+}
+
+// TestLower_ExpHistogram_LabelReplaceIsHistogramValued pins issue #2219:
+// label_replace changes only labels, so it must preserve the histogram
+// payload and the root HistogramRowShape for every supported
+// histogram-valued operand. The guarded Aggregate is part of the contract:
+// without it a non-injective rewrite could publish two series with the same
+// output label set, which reference Prometheus rejects.
+func TestLower_ExpHistogram_LabelReplaceIsHistogramValued(t *testing.T) {
+	t.Parallel()
+
+	s := schema.DefaultOTelMetrics()
+	p := parser.NewParser(parser.Options{EnableExperimentalFunctions: true})
+	start := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	end := start.Add(time.Hour)
+
+	for _, tc := range []struct {
+		name  string
+		query string
+		lower func(parser.Expr) (chplan.Node, error)
+	}{
+		{
+			name:  "bare instant",
+			query: `label_replace(latency_exp_hist, "copy", "$1-copy", "service", "(.*)")`,
+			lower: func(e parser.Expr) (chplan.Node, error) {
+				return promql.LowerAt(context.Background(), e, s, end, end)
+			},
+		},
+		{
+			name:  "sum instant",
+			query: `label_replace(sum by (service) (latency_exp_hist), "copy", "$1-copy", "service", "(.*)")`,
+			lower: func(e parser.Expr) (chplan.Node, error) {
+				return promql.LowerAt(context.Background(), e, s, end, end)
+			},
+		},
+		{
+			name:  "rate range",
+			query: `label_replace(rate(latency_exp_hist[5m]), "copy", "$1-copy", "service", "(.*)")`,
+			lower: func(e parser.Expr) (chplan.Node, error) {
+				return promql.LowerAtRange(context.Background(), e, s, start, end, time.Minute)
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			expr, err := p.ParseExpr(tc.query)
+			if err != nil {
+				t.Fatalf("ParseExpr(%q): %v", tc.query, err)
+			}
+			plan, err := tc.lower(expr)
+			if err != nil {
+				t.Fatalf("Lower(%q): %v", tc.query, err)
+			}
+			if shape := chplan.RowShapeOf(plan); shape != chplan.HistogramRowShape {
+				t.Fatalf("RowShapeOf(lower(%q)) = %s, want %s", tc.query, shape, chplan.HistogramRowShape)
+			}
+			hp, ok := plan.(*chplan.HistogramProjection)
+			if !ok {
+				t.Fatalf("lower(%q) root = %T, want *chplan.HistogramProjection", tc.query, plan)
+			}
+			guard, ok := hp.Input.(*chplan.Aggregate)
+			if !ok {
+				t.Fatalf("lower(%q) HistogramProjection.Input = %T, want duplicate-labelset *chplan.Aggregate", tc.query, hp.Input)
+			}
+			if guard.Having == nil {
+				t.Fatalf("lower(%q) duplicate-labelset Aggregate has nil Having", tc.query)
+			}
+			if len(guard.AggFuncs) != 10 {
+				t.Fatalf("lower(%q) guard carries %d aggregates, want Value plus nine histogram fields", tc.query, len(guard.AggFuncs))
 			}
 		})
 	}

--- a/internal/promql/histogram_native_label_replace.go
+++ b/internal/promql/histogram_native_label_replace.go
@@ -1,0 +1,133 @@
+package promql
+
+import (
+	"fmt"
+
+	"github.com/prometheus/prometheus/promql/parser"
+
+	"github.com/tsouza/cerberus/internal/chplan"
+	"github.com/tsouza/cerberus/internal/schema"
+)
+
+// labelReplaceOverExpHistogram recognizes label_replace around one of the
+// native-histogram shapes whose result is histogram-valued. Reference
+// Prometheus rewrites only the series labels and leaves the float or histogram
+// sample payload untouched (promql/functions.go: evalLabelReplace).
+func labelReplaceOverExpHistogram(expr parser.Expr, s schema.Metrics, ctx lowerCtx) (*parser.Call, bool) {
+	call, ok := peelWrappers(expr).(*parser.Call)
+	if !ok || call.Func.Name != "label_replace" || len(call.Args) != 5 {
+		return nil, false
+	}
+	return call, isExpHistogramValuedShape(call.Args[0], s, ctx)
+}
+
+func lowerLabelReplaceOverExpHistogram(call *parser.Call, s schema.Metrics, ctx lowerCtx) (chplan.Node, error) {
+	attrs, err := labelReplaceAttributes(call, s)
+	if err != nil {
+		return nil, err
+	}
+
+	inner, err := lowerExpHistogramValuedShape(call.Args[0], s, ctx)
+	if err != nil {
+		return nil, err
+	}
+	hp, ok := inner.(*chplan.HistogramProjection)
+	if !ok {
+		return nil, fmt.Errorf("promql: internal invariant violated: exp-histogram label_replace input is %T, want *chplan.HistogramProjection", inner)
+	}
+	return rewriteHistogramProjectionAttributes(hp, attrs, s), nil
+}
+
+// lowerExpHistogramValuedShape lowers the closed set recognized by
+// isExpHistogramValuedShape. Keeping the recognizer and dispatcher paired
+// prevents a newly admitted shape from silently falling back to scalar
+// lowering and dropping its histogram payload.
+func lowerExpHistogramValuedShape(expr parser.Expr, s schema.Metrics, ctx lowerCtx) (chplan.Node, error) {
+	if vs, ok := bareExpHistogramSelector(expr, s, ctx); ok {
+		return lowerExpHistogramBare(vs, s, ctx)
+	}
+	if agg, vs, ok := sumOrAvgOverExpHistogram(expr, s, ctx); ok {
+		return lowerExpHistogramSumOrAvg(agg, vs, s, ctx)
+	}
+	if shape, ok := rateOverExpHistogram(expr, s, ctx); ok {
+		return lowerExpHistogramRate(shape, s, ctx)
+	}
+	return nil, fmt.Errorf("promql: internal invariant violated: expression is not a known histogram-valued shape: %v", expr)
+}
+
+// rewriteHistogramProjectionAttributes applies a label rewrite without
+// converting a histogram row into an ordinary Value-shaped row. The inner
+// HistogramProjection first gives the payload stable output aliases; a
+// Project rewrites Attributes while forwarding all thirteen columns; the
+// Aggregate enforces Prometheus's duplicate-labelset rule per evaluation
+// step and carries the nine histogram fields through; the outer
+// HistogramProjection restores HistogramRowShape for the wire decoder.
+func rewriteHistogramProjectionAttributes(hp *chplan.HistogramProjection, attrs chplan.Expr, s schema.Metrics) *chplan.HistogramProjection {
+	projections := []chplan.Projection{
+		{Expr: &chplan.ColumnRef{Name: s.MetricNameColumn}},
+		{Expr: attrs, Alias: s.AttributesColumn},
+		{Expr: &chplan.ColumnRef{Name: s.TimestampColumn}},
+		{Expr: &chplan.ColumnRef{Name: s.ValueColumn}},
+	}
+	for _, name := range histogramProjectionOutputColumns() {
+		projections = append(projections, chplan.Projection{Expr: &chplan.ColumnRef{Name: name}})
+	}
+	rewritten := &chplan.Project{Input: hp, Projections: projections}
+
+	aggs := []chplan.AggFunc{
+		{Fn: chplan.FnAny, Args: []chplan.Expr{&chplan.ColumnRef{Name: s.ValueColumn}}, Alias: s.ValueColumn},
+	}
+	for _, name := range histogramProjectionOutputColumns() {
+		aggs = append(aggs, chplan.AggFunc{
+			Fn: chplan.FnAny, Args: []chplan.Expr{&chplan.ColumnRef{Name: name}}, Alias: name,
+		})
+	}
+	guarded := &chplan.Aggregate{
+		Input: rewritten,
+		GroupBy: []chplan.Expr{
+			&chplan.ColumnRef{Name: s.MetricNameColumn},
+			&chplan.ColumnRef{Name: s.AttributesColumn},
+			&chplan.ColumnRef{Name: s.TimestampColumn},
+		},
+		GroupByAliases: []string{s.MetricNameColumn, s.AttributesColumn, s.TimestampColumn},
+		AggFuncs:       aggs,
+		Having:         duplicateLabelsetRowCountGuardExpr(),
+	}
+
+	return &chplan.HistogramProjection{
+		Input:                      guarded,
+		CountColumn:                chplan.HistogramCountColumn,
+		SumColumn:                  chplan.HistogramSumColumn,
+		ScaleColumn:                chplan.HistogramScaleColumn,
+		ZeroThresholdColumn:        chplan.HistogramZeroThresholdColumn,
+		ZeroCountColumn:            chplan.HistogramZeroCountColumn,
+		PositiveOffsetColumn:       chplan.HistogramPositiveOffsetColumn,
+		PositiveBucketCountsColumn: chplan.HistogramPositiveBucketCountsColumn,
+		NegativeOffsetColumn:       chplan.HistogramNegativeOffsetColumn,
+		NegativeBucketCountsColumn: chplan.HistogramNegativeBucketCountsColumn,
+		GroupBy: []chplan.Expr{
+			&chplan.ColumnRef{Name: s.MetricNameColumn},
+			&chplan.ColumnRef{Name: s.AttributesColumn},
+			&chplan.ColumnRef{Name: s.TimestampColumn},
+			&chplan.ColumnRef{Name: s.ValueColumn},
+		},
+		GroupByAliases:   []string{s.MetricNameColumn, s.AttributesColumn, s.TimestampColumn, s.ValueColumn},
+		MetricNameColumn: s.MetricNameColumn,
+		AttributesColumn: s.AttributesColumn,
+		TimestampColumn:  s.TimestampColumn,
+	}
+}
+
+func histogramProjectionOutputColumns() []string {
+	return []string{
+		chplan.HistogramCountColumn,
+		chplan.HistogramSumColumn,
+		chplan.HistogramScaleColumn,
+		chplan.HistogramZeroThresholdColumn,
+		chplan.HistogramZeroCountColumn,
+		chplan.HistogramPositiveOffsetColumn,
+		chplan.HistogramPositiveBucketCountsColumn,
+		chplan.HistogramNegativeOffsetColumn,
+		chplan.HistogramNegativeBucketCountsColumn,
+	}
+}

--- a/internal/promql/label_fns.go
+++ b/internal/promql/label_fns.go
@@ -22,6 +22,22 @@ import (
 // every code path — so we re-assert the StringLiteral shape here with
 // clear errors instead of panicking on a bad cast.
 func lowerLabelReplace(c *parser.Call, s schema.Metrics, ctx lowerCtx) (chplan.Node, error) {
+	attrs, err := labelReplaceAttributes(c, s)
+	if err != nil {
+		return nil, err
+	}
+
+	inner, err := lower(c.Args[0], s, ctx)
+	if err != nil {
+		return nil, err
+	}
+	return guardLabelRewriteCollision(projectAttributesOverInner(inner, s, attrs), s), nil
+}
+
+// labelReplaceAttributes validates label_replace's static arguments and
+// returns the Attributes expression shared by the ordinary sample lowering
+// and the histogram-valued root lowering.
+func labelReplaceAttributes(c *parser.Call, s schema.Metrics) (chplan.Expr, error) {
 	if len(c.Args) != 5 {
 		return nil, fmt.Errorf("promql: label_replace expects 5 arguments, got %d", len(c.Args))
 	}
@@ -47,10 +63,6 @@ func lowerLabelReplace(c *parser.Call, s schema.Metrics, ctx lowerCtx) (chplan.N
 		return nil, fmt.Errorf("promql: label_replace: %w", err)
 	}
 
-	inner, err := lower(c.Args[0], s, ctx)
-	if err != nil {
-		return nil, err
-	}
 	attrs := &chplan.LabelReplace{
 		Map:              &chplan.ColumnRef{Name: s.AttributesColumn},
 		Dst:              dst,
@@ -61,7 +73,7 @@ func lowerLabelReplace(c *parser.Call, s schema.Metrics, ctx lowerCtx) (chplan.N
 		Regex:            regex,
 		EmptyReplacement: qlcommon.EmptyCapturesReplacement(replacement),
 	}
-	return guardLabelRewriteCollision(projectAttributesOverInner(inner, s, attrs), s), nil
+	return attrs, nil
 }
 
 // lowerLabelJoin lowers

--- a/internal/promql/lower.go
+++ b/internal/promql/lower.go
@@ -173,15 +173,16 @@ func LowerMetadataRange(ctx context.Context, expr parser.Expr, s schema.Metrics,
 // exponential (native) histogram that return a HISTOGRAM-VALUED sample —
 // a bare selector, `sum`/`avg` `[by/without] (<selector>)`, and
 // `rate`/`increase` over a range-vector selector — plus scalar binary
-// operations that either preserve that histogram value or drop it as an
-// incompatible sample. Their answers have a wire representation only when
-// the shape IS the whole query.
+// operations that preserve or drop that value and histogram-aware wrappers
+// such as label_replace that preserve the payload. Their answers have a wire
+// representation only when the histogram-valued shape (possibly under such
+// a wrapper) is the whole query.
 //
 // The distinction cannot be made inside [lowerVectorSelector], because the
 // selector in `sum(m_exp_hist)` and the selector in `m_exp_hist` arrive
 // there identically — same node, same instant-mode context. Most consumers
-// PromQL can wrap around a selector (arithmetic, `label_replace`, a
-// range-vector function, every reducer other than `sum`) read a `Value`
+// PromQL can wrap around a selector (arithmetic, a range-vector function,
+// every reducer other than `sum`) read a `Value`
 // column that a histogram row does not publish, so answering the nested
 // shape with a histogram projection would either fail in ClickHouse with
 // code 47 or, worse, silently reduce the placeholder Value. Deciding
@@ -196,6 +197,8 @@ func LowerMetadataRange(ctx context.Context, expr parser.Expr, s schema.Metrics,
 // [bareExpHistogramSelector], [sumOrAvgOverExpHistogram] and
 // [rateOverExpHistogram] recognise disjoint root node types (a selector, an
 // aggregation, a range-vector call), so none can shadow another.
+// Histogram-preserving wrappers dispatch before them because their operand
+// is one of those payload shapes.
 // [rateOverExpHistogram] additionally refuses an aggregation WRAPPER, so
 // `sum(rate(...))` — which needs both reductions — matches neither it nor
 // [sumOrAvgOverExpHistogram] and stays rejected. The scaling scalar-binop
@@ -207,6 +210,9 @@ func LowerMetadataRange(ctx context.Context, expr parser.Expr, s schema.Metrics,
 // expression, consumes no Value column, and already has its own
 // full-range bare-selector path.
 func lowerRoot(expr parser.Expr, s schema.Metrics, ctx lowerCtx) (chplan.Node, error) {
+	if call, ok := labelReplaceOverExpHistogram(expr, s, ctx); ok {
+		return lowerLabelReplaceOverExpHistogram(call, s, ctx)
+	}
 	if vs, ok := bareExpHistogramSelector(expr, s, ctx); ok {
 		return lowerExpHistogramBare(vs, s, ctx)
 	}

--- a/test/rejection-parity/catalogue/internal__promql__histogram_native_label_replace.go.json
+++ b/test/rejection-parity/catalogue/internal__promql__histogram_native_label_replace.go.json
@@ -1,0 +1,53 @@
+{
+  "entries": [
+    {
+      "head": "promql",
+      "site": "internal/promql/histogram_native_label_replace.go:lowerExpHistogramValuedShape#f5fecb3d",
+      "message": "promql: internal invariant violated: expression is not a known histogram-valued shape: %v",
+      "class": "internal",
+      "rationale": "lowerExpHistogramValuedShape is called only after labelReplaceOverExpHistogram proved isExpHistogramValuedShape, and the recognizer and dispatcher enumerate the same bareExpHistogramSelector, sumOrAvgOverExpHistogram, and rateOverExpHistogram shapes",
+      "evidence": {
+        "guard": [
+          "past returning if vs, ok := bareExpHistogramSelector(expr, s, ctx); ok",
+          "past returning if agg, vs, ok := sumOrAvgOverExpHistogram(expr, s, ctx); ok",
+          "past returning if shape, ok := rateOverExpHistogram(expr, s, ctx); ok"
+        ],
+        "callers": [
+          "lowerLabelReplaceOverExpHistogram"
+        ],
+        "cited": [
+          "bareExpHistogramSelector",
+          "isExpHistogramValuedShape",
+          "labelReplaceOverExpHistogram",
+          "lowerExpHistogramValuedShape",
+          "rateOverExpHistogram",
+          "sumOrAvgOverExpHistogram"
+        ]
+      }
+    },
+    {
+      "head": "promql",
+      "site": "internal/promql/histogram_native_label_replace.go:lowerLabelReplaceOverExpHistogram#3e91de20",
+      "message": "promql: internal invariant violated: exp-histogram label_replace input is %T, want *chplan.HistogramProjection",
+      "class": "internal",
+      "rationale": "lowerLabelReplaceOverExpHistogram receives only the three isExpHistogramValuedShape variants, whose lowerExpHistogramBare, lowerExpHistogramSumOrAvg, and lowerExpHistogramRate lowerings all cap their result with HistogramProjection",
+      "evidence": {
+        "guard": [
+          "past returning if err != nil",
+          "past returning if err != nil",
+          "if !ok"
+        ],
+        "callers": [
+          "lowerRoot"
+        ],
+        "cited": [
+          "isExpHistogramValuedShape",
+          "lowerExpHistogramBare",
+          "lowerExpHistogramRate",
+          "lowerExpHistogramSumOrAvg",
+          "lowerLabelReplaceOverExpHistogram"
+        ]
+      }
+    }
+  ]
+}

--- a/test/rejection-parity/catalogue/internal__promql__label_fns.go.json
+++ b/test/rejection-parity/catalogue/internal__promql__label_fns.go.json
@@ -2,6 +2,50 @@
   "entries": [
     {
       "head": "promql",
+      "site": "internal/promql/label_fns.go:labelReplaceAttributes#8c37a823",
+      "message": "promql: label_replace expects 5 arguments, got %d",
+      "class": "internal",
+      "rationale": "parser-enforced arity: label_replace requires exactly five arguments; labelReplaceAttributes is called only after lowerCall or labelReplaceOverExpHistogram has identified that parser Call",
+      "evidence": {
+        "guard": [
+          "if len(c.Args) != 5"
+        ],
+        "callers": [
+          "lowerLabelReplace",
+          "lowerLabelReplaceOverExpHistogram"
+        ],
+        "cited": [
+          "labelReplaceAttributes",
+          "labelReplaceOverExpHistogram",
+          "lowerCall"
+        ]
+      }
+    },
+    {
+      "head": "promql",
+      "site": "internal/promql/label_fns.go:labelReplaceAttributes#d11e3df4",
+      "message": "promql: label_replace: %w",
+      "class": "divergence",
+      "trigger_query": "label_replace(up, \"d\", \"$dup\", \"src\", \"(?:(?P\u003cdup\u003ea?)|y)*(?P\u003cdup\u003eb)\")",
+      "tracking_issue": 1956,
+      "evidence": {
+        "guard": [
+          "past returning if len(c.Args) != 5",
+          "past returning if err != nil",
+          "past returning if err != nil",
+          "past returning if err != nil",
+          "past returning if err != nil",
+          "if err != nil"
+        ],
+        "callers": [
+          "lowerLabelReplace",
+          "lowerLabelReplaceOverExpHistogram"
+        ]
+      },
+      "since": "2026-08-05"
+    },
+    {
+      "head": "promql",
       "site": "internal/promql/label_fns.go:lowerLabelJoin#c71ab88a",
       "message": "promql: label_join expects at least 3 arguments (v, dst, separator[, src…]), got %d",
       "class": "internal",
@@ -17,43 +61,6 @@
     },
     {
       "head": "promql",
-      "site": "internal/promql/label_fns.go:lowerLabelReplace#8c37a823",
-      "message": "promql: label_replace expects 5 arguments, got %d",
-      "class": "internal",
-      "rationale": "parser-enforced arity: label_replace requires exactly five arguments",
-      "evidence": {
-        "guard": [
-          "if len(c.Args) != 5"
-        ],
-        "callers": [
-          "lowerCall"
-        ]
-      }
-    },
-    {
-      "head": "promql",
-      "site": "internal/promql/label_fns.go:lowerLabelReplace#d11e3df4",
-      "message": "promql: label_replace: %w",
-      "class": "divergence",
-      "trigger_query": "label_replace(up, \"d\", \"$dup\", \"src\", \"(?:(?P\u003cdup\u003ea?)|y)*(?P\u003cdup\u003eb)\")",
-      "tracking_issue": 1956,
-      "evidence": {
-        "guard": [
-          "past returning if len(c.Args) != 5",
-          "past returning if err != nil",
-          "past returning if err != nil",
-          "past returning if err != nil",
-          "past returning if err != nil",
-          "if err != nil"
-        ],
-        "callers": [
-          "lowerCall"
-        ]
-      },
-      "since": "2026-08-05"
-    },
-    {
-      "head": "promql",
       "site": "internal/promql/label_fns.go:stringArg#4c3f7595",
       "message": "promql: %s(%s) requires a string literal, got %T",
       "class": "internal",
@@ -63,9 +70,9 @@
           "if !ok"
         ],
         "callers": [
+          "labelReplaceAttributes",
           "lowerHistogramQuantiles",
           "lowerLabelJoin",
-          "lowerLabelReplace",
           "lowerSortByLabel"
         ]
       }

--- a/test/rejection-parity/catalogue/internal__promql__lower.go.json
+++ b/test/rejection-parity/catalogue/internal__promql__lower.go.json
@@ -76,8 +76,8 @@
       "site": "internal/promql/lower.go:expHistogramSelectorRouting#71e3ce4e",
       "message": "promql: %q is an exponential histogram metric; only a bare %q selector, sum()/avg()/count() over one, rate()/increase()/resets()/changes() over one, histogram_quantile(), histogram_count(), histogram_sum(), and the %q/%q companion selectors are supported",
       "class": "divergence",
-      "trigger_query": "label_replace(demo_latency_exp_hist, \"copy\", \"$1\", \"instance\", \"(.*)\")",
-      "tracking_issue": 2219,
+      "trigger_query": "abs(demo_latency_exp_hist)",
+      "tracking_issue": 2221,
       "evidence": {
         "guard": [
           "past returning if bare, col, hasCompanion := s.HistogramCompanionColumn(metricName); hasCompanion \u0026\u0026 s.IsExpHistogramMetric(bare) \u0026\u0026 s.ExpHistogramTable != \"\"",


### PR DESCRIPTION
Closes #2219.

## Summary

- route `label_replace` over supported native-histogram-valued shapes through a histogram-aware root lowering
- preserve all nine histogram payload columns while rewriting labels
- enforce duplicate-labelset rejection per evaluation step before restoring the histogram wire shape
- cover instant/range payload preservation and non-injective collision rejection with chDB

## Validation

- targeted race PromQL lowering tests
- `just test-chdb`
- `just update-golden migration parity solver promql chsql codegen cardinality`
- `go test -count=1 ./test/rejection-parity`
- `node .github/scripts/doc-counts.mjs`
- `git diff --check`

Follow-up #2221 tracks the independently verified remaining float-only-function wrong rejection at the shared selector-routing site.