### PR TITLE
fix(promql): drop native histograms in float-only functions

### DIFF
--- a/compatibility/parity-baseline.json
+++ b/compatibility/parity-baseline.json
@@ -3,8 +3,8 @@
   "_contract": "Per head: 'cases' is the exact, sorted roster of corpus case IDs, every one of which agreed with the reference backend; 'passed' and 'total' are the human-facing counts the README and docs cite, and the ratchet asserts passed == total == cases.length so they cannot drift from the roster. The baseline records FULL parity for every head — this file has no shape for recording a divergence as acceptable, because a diff against a reference backend is a bug to fix at the source. When the corpus legitimately changes, replace the head's entry in the SAME PR, taking the roster from the run's compat-cases.json artefact rather than hand-editing it.",
   "heads": {
     "prometheus": {
-      "passed": 938,
-      "total": 938,
+      "passed": 939,
+      "total": 939,
       "cases": [
         "\"a string literal\"",
         "(1 * 2 + 4 / 6 - (10%7)^2) != demo_memory_usage_bytes",
@@ -77,6 +77,7 @@
         "Inf",
         "NaN",
         "abs(-demo_memory_usage_bytes)",
+        "abs(demo_latency_exp_hist)",
         "abs(demo_memory_usage_bytes)",
         "absent(demo_memory_usage_bytes + demo_memory_usage_bytes)",
         "absent(demo_memory_usage_bytes)",

--- a/compatibility/prometheus/cerberus-test-queries.yml
+++ b/compatibility/prometheus/cerberus-test-queries.yml
@@ -590,6 +590,8 @@ test_cases:
   # powers of two; the two seeded instances carry different positive
   # offsets and different bucket shapes, so a series mix-up cannot pass.
   #
+  # Float-only functions accept native histograms but drop those samples.
+  - query: 'abs(demo_latency_exp_hist)'
   # Value functions: Count / Sum / Sum÷Count, then the bucket-midpoint
   # variance estimate (geometric midpoints for standard exponential
   # buckets) in both its stddev and stdvar spellings.

--- a/internal/api/prom/handler_chdb_histogram_valued_test.go
+++ b/internal/api/prom/handler_chdb_histogram_valued_test.go
@@ -333,6 +333,79 @@ INSERT INTO otel_metrics_exponential_histogram VALUES
 	assertDuplicateLabelsetRejected(t, body, status, query)
 }
 
+// TestQuery_FloatOnlyFunctionDropsNativeHistogram_ChDB pins the HTTP contract
+// behind issue #2221. The same handler session carries one native histogram
+// and one ordinary float series: abs() must accept both, drop the histogram
+// sample, and continue transforming the representable float sample normally.
+// OTel-CH stores the two sample kinds in different physical tables, so a
+// single logical series containing both kinds is not representable; exercising
+// both routes in one session is the closest storage-faithful mixed control.
+func TestQuery_FloatOnlyFunctionDropsNativeHistogram_ChDB(t *testing.T) {
+	stamp := histValuedEvalTime.Format("2006-01-02 15:04:05.000000000")
+	seed := gaugeDDL + histValuedSeed + fmt.Sprintf(`
+INSERT INTO otel_metrics_gauge VALUES
+    ('temperature', map('service', 'api'), toDateTime64('%s', 9), -4.0);`, stamp)
+	srv, _ := newChDBServer(t, seed)
+
+	cases := []struct {
+		query     string
+		wantCount int
+		wantValue string
+	}{
+		{query: "abs(latency_exp_hist)", wantCount: 0},
+		{query: "abs(temperature)", wantCount: 1, wantValue: "4"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.query, func(t *testing.T) {
+			reqURL := fmt.Sprintf("%s/api/v1/query?query=%s&time=%s",
+				srv.URL, url.QueryEscape(tc.query), histValuedEvalTime.Format(time.RFC3339))
+			resp, err := http.Get(reqURL) //nolint:noctx // test-local request against httptest
+			if err != nil {
+				t.Fatalf("GET /api/v1/query: %v", err)
+			}
+			defer func() { _ = resp.Body.Close() }()
+
+			var body struct {
+				Status string `json:"status"`
+				Data   struct {
+					ResultType string `json:"resultType"`
+					Result     []struct {
+						Value []json.RawMessage `json:"value"`
+					} `json:"result"`
+				} `json:"data"`
+				ErrorType string `json:"errorType"`
+				Error     string `json:"error"`
+			}
+			if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+				t.Fatalf("decode response: %v", err)
+			}
+			if resp.StatusCode != http.StatusOK || body.Status != "success" {
+				t.Fatalf("status=%d body.status=%q errorType=%q error=%q",
+					resp.StatusCode, body.Status, body.ErrorType, body.Error)
+			}
+			if body.Data.ResultType != "vector" {
+				t.Fatalf("resultType = %q, want vector", body.Data.ResultType)
+			}
+			if len(body.Data.Result) != tc.wantCount {
+				t.Fatalf("result count = %d, want %d", len(body.Data.Result), tc.wantCount)
+			}
+			if tc.wantCount == 0 {
+				return
+			}
+			if len(body.Data.Result[0].Value) != 2 {
+				t.Fatalf("value pair = %s, want [timestamp, value]", body.Data.Result[0].Value)
+			}
+			var gotValue string
+			if err := json.Unmarshal(body.Data.Result[0].Value[1], &gotValue); err != nil {
+				t.Fatalf("decode sample value: %v", err)
+			}
+			if gotValue != tc.wantValue {
+				t.Fatalf("sample value = %q, want %q", gotValue, tc.wantValue)
+			}
+		})
+	}
+}
+
 // assertBuckets compares the decoded bucket tuples element by element.
 func assertBuckets(t *testing.T, got, want [][4]any) {
 	t.Helper()

--- a/internal/chplan/row_shape.go
+++ b/internal/chplan/row_shape.go
@@ -96,13 +96,11 @@ const (
 	//
 	// Three lowerings build this node today (internal/promql's
 	// histogram_native_bare.go, histogram_native_sum.go and
-	// histogram_native_rate.go), but no forwarder is reached with it:
-	// each is dispatched only at the ROOT of a query, and every shape
-	// that would wrap one — `label_replace(...)`, `abs(...)`, scalar
-	// arithmetic — is still refused by expHistogramSelectorRouting. The
-	// forwarders are unreachable by that guard rather than adapted, so
-	// teaching them this shape remains a prerequisite for lifting it
-	// (issue #1967).
+	// histogram_native_rate.go). Generic forwarders still cannot consume
+	// it: label transforms and scalar arithmetic are refused by
+	// expHistogramSelectorRouting. Float-only functions are the deliberate
+	// exception: they drop every histogram sample and re-project an empty
+	// canonical float shape without invoking the generic forwarder.
 	HistogramRowShape
 )
 

--- a/internal/promql/exp_histogram_reject_test.go
+++ b/internal/promql/exp_histogram_reject_test.go
@@ -23,8 +23,9 @@ import (
 // (TestLower_ExpHistogram_BareSelectorIsHistogramValued), `sum()` over
 // one and its `avg()` twin (TestLower_ExpHistogram_SumIsHistogramValued,
 // TestLower_ExpHistogram_AvgIsHistogramValued) and `rate()` /
-// `increase()` over one
-// (TestLower_ExpHistogram_RateIsHistogramValued) — must fail lowering
+// `increase()` over one (TestLower_ExpHistogram_RateIsHistogramValued),
+// and float-only functions, which accept and drop histogram samples
+// (issue #2221) — must fail lowering
 // with a clear error, never silently resolve against the Gauge/Sum tables
 // and return an empty-but-200 result. Before the fix, TablesFor never
 // yielded ExpHistogramTable for these shapes, so cerberus quietly scanned
@@ -58,7 +59,6 @@ func TestLower_ExpHistogram_UnsupportedShapesRejectExplicitly(t *testing.T) {
 		{name: "irate", query: `irate(latency_exp_hist[5m])`},
 		{name: "sum_over_time", query: `sum_over_time(latency_exp_hist[5m])`},
 		{name: "absent_over_time", query: `absent_over_time(latency_exp_hist[5m])`},
-		{name: "abs", query: `abs(latency_exp_hist)`},
 		{name: "raw range vector", query: `latency_exp_hist[5m]`},
 		{name: "subquery", query: `max_over_time(latency_exp_hist[5m:1m])`},
 
@@ -70,7 +70,6 @@ func TestLower_ExpHistogram_UnsupportedShapesRejectExplicitly(t *testing.T) {
 		{name: "sum over increase", query: `sum(increase(latency_exp_hist[5m]))`},
 		{name: "sum of sum", query: `sum(sum(latency_exp_hist))`},
 		{name: "sum under topk", query: `topk(3, sum by (service) (latency_exp_hist))`},
-		{name: "sum under abs", query: `abs(sum(latency_exp_hist))`},
 
 		// `rate()` / `increase()` over a range-vector selector ARE answered
 		// (see TestLower_ExpHistogram_RateIsHistogramValued). These are the
@@ -79,7 +78,6 @@ func TestLower_ExpHistogram_UnsupportedShapesRejectExplicitly(t *testing.T) {
 		// across-series merge stacked on top of the window reduction, so
 		// answering it with the window reduction alone would silently drop
 		// the sum.
-		{name: "rate under abs", query: `abs(rate(latency_exp_hist[5m]))`},
 		{name: "rate under topk", query: `topk(3, rate(latency_exp_hist[5m]))`},
 		{name: "rate under avg", query: `avg(rate(latency_exp_hist[5m]))`},
 		{name: "rate over subquery", query: `rate(latency_exp_hist[5m:1m])`},

--- a/internal/promql/histogram_native_bare.go
+++ b/internal/promql/histogram_native_bare.go
@@ -18,10 +18,11 @@ import (
 // histogram_sum), which is why [expHistogramSelectorRouting] rejects the
 // bare shape wherever it is NOT the whole query: a consumer that reads a
 // `Value` column the histogram row shape does not carry would silently
-// reduce the placeholder value. Such shapes keep their explicit
-// rejection until each grows its own histogram-AWARE lowering — the one
-// that exists so far is `sum()`, in histogram_native_sum.go, which
-// consumes the bucket ladders rather than a Value (issue #1967).
+// reduce the placeholder value. Such shapes keep their explicit rejection
+// until each grows its own histogram-AWARE lowering. The consumers that do
+// exist either consume the bucket ladders (`sum()`, in
+// histogram_native_sum.go) or deliberately drop histogram samples (the
+// float-only functions, in histogram_native_float_fn.go).
 //
 // The plan shape mirrors the native-quantile siblings in
 // histogram_quantile.go / histogram_quantile_range.go rung for rung —
@@ -54,10 +55,11 @@ const histogramSampleValuePlaceholder = 0.0
 // an exp-histogram metric, i.e. the one shape this file answers.
 //
 // It is deliberately asked only of the ROOT of a query (see [lowerRoot]).
-// A selector nested under anything else — a reducer, a range-vector
-// function, arithmetic, `label_replace` — reaches lowerVectorSelector
-// instead and is rejected there, because its consumer reads a `Value`
-// column a histogram row does not publish.
+// A selector nested under an unrecognised consumer — a reducer, a
+// range-vector function, arithmetic, `label_replace` — reaches
+// lowerVectorSelector instead and is rejected there, because its consumer
+// reads a `Value` column a histogram row does not publish. Histogram-aware
+// consumers recognise the selector before that recursive descent.
 //
 // Metadata enumeration (/series, /labels) is excluded: it consumes only
 // MetricName + Attributes and has its own full-range lowering, which

--- a/internal/promql/histogram_native_float_fn.go
+++ b/internal/promql/histogram_native_float_fn.go
@@ -1,0 +1,58 @@
+package promql
+
+import (
+	"github.com/prometheus/prometheus/promql/parser"
+
+	"github.com/tsouza/cerberus/internal/chplan"
+	"github.com/tsouza/cerberus/internal/schema"
+)
+
+// lowerExpHistogramValuedShape recognises and lowers every expression shape
+// whose result consists exclusively of native-histogram samples. Keeping the
+// recogniser and lowering paired prevents consumers from reimplementing the
+// root dispatch and accidentally admitting a shape they cannot actually lower.
+func lowerExpHistogramValuedShape(expr parser.Expr, s schema.Metrics, ctx lowerCtx) (chplan.Node, bool, error) {
+	if vs, ok := bareExpHistogramSelector(expr, s, ctx); ok {
+		plan, err := lowerExpHistogramBare(vs, s, ctx)
+		return plan, true, err
+	}
+	if agg, vs, ok := sumOrAvgOverExpHistogram(expr, s, ctx); ok {
+		plan, err := lowerExpHistogramSumOrAvg(agg, vs, s, ctx)
+		return plan, true, err
+	}
+	if shape, ok := rateOverExpHistogram(expr, s, ctx); ok {
+		plan, err := lowerExpHistogramRate(shape, s, ctx)
+		return plan, true, err
+	}
+	if histSide, op, scale, ok := expHistogramScalarBinop(expr, s, ctx); ok {
+		plan, err := lowerExpHistogramScalarBinop(histSide, op, scale, s, ctx, false)
+		return plan, true, err
+	}
+	return nil, false, nil
+}
+
+// dropExpHistogramSamples converts a histogram-valued plan into the canonical
+// float-sample row shape while selecting no rows. Prometheus's float-only
+// functions accept native histograms but simpleFloatFunc omits every sample
+// whose H field is set. Cerberus knows these inputs are histogram-only, so the
+// exact result is an empty float vector rather than a lowering error.
+//
+// The projection deliberately sits above the false filter. HistogramProjection
+// publishes the canonical quartet followed by its histogram columns; selecting
+// only the quartet here makes the result's schema float-valued even when no row
+// reaches the wire, and the literal Value avoids treating the histogram
+// projection's compatibility placeholder as a real sample.
+func dropExpHistogramSamples(input chplan.Node, s schema.Metrics) chplan.Node {
+	return &chplan.Project{
+		Input: &chplan.Filter{
+			Input:     input,
+			Predicate: &chplan.LitBool{V: false},
+		},
+		Projections: []chplan.Projection{
+			{Expr: &chplan.LitString{V: ""}, Alias: s.MetricNameColumn},
+			{Expr: &chplan.ColumnRef{Name: s.AttributesColumn}, Alias: s.AttributesColumn},
+			{Expr: &chplan.ColumnRef{Name: s.TimestampColumn}, Alias: s.TimestampColumn},
+			{Expr: &chplan.LitFloat{V: 0}, Alias: s.ValueColumn},
+		},
+	}
+}

--- a/internal/promql/histogram_native_float_fn_test.go
+++ b/internal/promql/histogram_native_float_fn_test.go
@@ -1,0 +1,114 @@
+package promql_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/prometheus/prometheus/promql/parser"
+
+	"github.com/tsouza/cerberus/internal/chplan"
+	"github.com/tsouza/cerberus/internal/promql"
+	"github.com/tsouza/cerberus/internal/schema"
+)
+
+func TestLower_ExpHistogram_FloatOnlyFunctionsDropSamples(t *testing.T) {
+	t.Parallel()
+
+	s := schema.DefaultOTelMetrics()
+	p := parser.NewParser(parser.Options{EnableExperimentalFunctions: true})
+	at := time.Date(2026, 1, 1, 0, 0, 1, 0, time.UTC)
+
+	queries := []string{
+		`abs(latency_exp_hist)`,
+		`ceil(latency_exp_hist)`,
+		`floor(latency_exp_hist)`,
+		`round(latency_exp_hist)`,
+		`round(latency_exp_hist, 0.1)`,
+		`sqrt(latency_exp_hist)`,
+		`exp(latency_exp_hist)`,
+		`ln(latency_exp_hist)`,
+		`log2(latency_exp_hist)`,
+		`log10(latency_exp_hist)`,
+		`sgn(latency_exp_hist)`,
+		`acos(latency_exp_hist)`,
+		`acosh(latency_exp_hist)`,
+		`asin(latency_exp_hist)`,
+		`asinh(latency_exp_hist)`,
+		`atan(latency_exp_hist)`,
+		`atanh(latency_exp_hist)`,
+		`cos(latency_exp_hist)`,
+		`cosh(latency_exp_hist)`,
+		`sin(latency_exp_hist)`,
+		`sinh(latency_exp_hist)`,
+		`tan(latency_exp_hist)`,
+		`tanh(latency_exp_hist)`,
+		`deg(latency_exp_hist)`,
+		`rad(latency_exp_hist)`,
+
+		// The consumer sees histogram-valued results, not only selectors.
+		`abs(sum(latency_exp_hist))`,
+		`abs(rate(latency_exp_hist[5m]))`,
+		`abs(latency_exp_hist * 2)`,
+	}
+
+	for _, query := range queries {
+		query := query
+		t.Run(query, func(t *testing.T) {
+			t.Parallel()
+
+			expr, err := p.ParseExpr(query)
+			if err != nil {
+				t.Fatalf("ParseExpr(%q): %v", query, err)
+			}
+			plan, err := promql.LowerAt(context.Background(), expr, s, at, at)
+			if err != nil {
+				t.Fatalf("LowerAt(%q): %v", query, err)
+			}
+			assertEmptyFloatProjection(t, plan)
+		})
+	}
+}
+
+func TestLower_ExpHistogram_FloatOnlyFunctionRangeDropsSamples(t *testing.T) {
+	t.Parallel()
+
+	s := schema.DefaultOTelMetrics()
+	p := parser.NewParser(parser.Options{})
+	expr, err := p.ParseExpr(`abs(latency_exp_hist)`)
+	if err != nil {
+		t.Fatalf("ParseExpr: %v", err)
+	}
+	start := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	plan, err := promql.LowerAtRange(context.Background(), expr, s, start, start.Add(time.Minute), 15*time.Second)
+	if err != nil {
+		t.Fatalf("LowerAtRange: %v", err)
+	}
+	assertEmptyFloatProjection(t, plan)
+}
+
+func assertEmptyFloatProjection(t *testing.T, plan chplan.Node) {
+	t.Helper()
+
+	if shape := chplan.RowShapeOf(plan); shape != chplan.SampleRowShape {
+		t.Fatalf("plan publishes %s, want sample", shape)
+	}
+	project, ok := plan.(*chplan.Project)
+	if !ok {
+		t.Fatalf("plan root = %T, want *chplan.Project", plan)
+	}
+	if len(project.Projections) != 4 {
+		t.Fatalf("projection count = %d, want canonical sample quartet", len(project.Projections))
+	}
+	filter, ok := project.Input.(*chplan.Filter)
+	if !ok {
+		t.Fatalf("project input = %T, want *chplan.Filter", project.Input)
+	}
+	predicate, ok := filter.Predicate.(*chplan.LitBool)
+	if !ok || predicate.V {
+		t.Fatalf("filter predicate = %#v, want LitBool{false}", filter.Predicate)
+	}
+	if shape := chplan.RowShapeOf(filter.Input); shape != chplan.HistogramRowShape {
+		t.Fatalf("filtered input publishes %s, want histogram", shape)
+	}
+}

--- a/internal/promql/histogram_native_label_replace.go
+++ b/internal/promql/histogram_native_label_replace.go
@@ -27,32 +27,18 @@ func lowerLabelReplaceOverExpHistogram(call *parser.Call, s schema.Metrics, ctx 
 		return nil, err
 	}
 
-	inner, err := lowerExpHistogramValuedShape(call.Args[0], s, ctx)
+	inner, ok, err := lowerExpHistogramValuedShape(call.Args[0], s, ctx)
 	if err != nil {
 		return nil, err
+	}
+	if !ok {
+		return nil, fmt.Errorf("promql: internal invariant violated: expression is not a known histogram-valued shape: %v", call.Args[0])
 	}
 	hp, ok := inner.(*chplan.HistogramProjection)
 	if !ok {
 		return nil, fmt.Errorf("promql: internal invariant violated: exp-histogram label_replace input is %T, want *chplan.HistogramProjection", inner)
 	}
 	return rewriteHistogramProjectionAttributes(hp, attrs, s), nil
-}
-
-// lowerExpHistogramValuedShape lowers the closed set recognized by
-// isExpHistogramValuedShape. Keeping the recognizer and dispatcher paired
-// prevents a newly admitted shape from silently falling back to scalar
-// lowering and dropping its histogram payload.
-func lowerExpHistogramValuedShape(expr parser.Expr, s schema.Metrics, ctx lowerCtx) (chplan.Node, error) {
-	if vs, ok := bareExpHistogramSelector(expr, s, ctx); ok {
-		return lowerExpHistogramBare(vs, s, ctx)
-	}
-	if agg, vs, ok := sumOrAvgOverExpHistogram(expr, s, ctx); ok {
-		return lowerExpHistogramSumOrAvg(agg, vs, s, ctx)
-	}
-	if shape, ok := rateOverExpHistogram(expr, s, ctx); ok {
-		return lowerExpHistogramRate(shape, s, ctx)
-	}
-	return nil, fmt.Errorf("promql: internal invariant violated: expression is not a known histogram-valued shape: %v", expr)
 }
 
 // rewriteHistogramProjectionAttributes applies a label rewrite without

--- a/internal/promql/instant_fns.go
+++ b/internal/promql/instant_fns.go
@@ -59,6 +59,12 @@ func lowerInstantFn(c *parser.Call, s schema.Metrics, chFn chplan.Fn, ctx lowerC
 	switch c.Func.Name {
 	case "round":
 		if len(c.Args) == 2 {
+			if hist, ok, err := lowerExpHistogramValuedShape(c.Args[0], s, ctx); ok {
+				if err != nil {
+					return nil, err
+				}
+				return dropExpHistogramSamples(hist, s), nil
+			}
 			return lowerRoundToNearest(c, s, ctx)
 		}
 	}
@@ -66,6 +72,12 @@ func lowerInstantFn(c *parser.Call, s schema.Metrics, chFn chplan.Fn, ctx lowerC
 	if len(c.Args) != 1 {
 		return nil, fmt.Errorf("promql: %s with %d arguments is unsupported (instant math fns are unary)",
 			c.Func.Name, len(c.Args))
+	}
+	if hist, ok, err := lowerExpHistogramValuedShape(c.Args[0], s, ctx); ok {
+		if err != nil {
+			return nil, err
+		}
+		return dropExpHistogramSamples(hist, s), nil
 	}
 
 	inner, err := lower(c.Args[0], s, ctx)

--- a/internal/promql/lower.go
+++ b/internal/promql/lower.go
@@ -213,14 +213,8 @@ func lowerRoot(expr parser.Expr, s schema.Metrics, ctx lowerCtx) (chplan.Node, e
 	if call, ok := labelReplaceOverExpHistogram(expr, s, ctx); ok {
 		return lowerLabelReplaceOverExpHistogram(call, s, ctx)
 	}
-	if vs, ok := bareExpHistogramSelector(expr, s, ctx); ok {
-		return lowerExpHistogramBare(vs, s, ctx)
-	}
-	if agg, vs, ok := sumOrAvgOverExpHistogram(expr, s, ctx); ok {
-		return lowerExpHistogramSumOrAvg(agg, vs, s, ctx)
-	}
-	if shape, ok := rateOverExpHistogram(expr, s, ctx); ok {
-		return lowerExpHistogramRate(shape, s, ctx)
+	if plan, ok, err := lowerExpHistogramValuedShape(expr, s, ctx); ok {
+		return plan, err
 	}
 	if shape, ok := resetsOrChangesOverExpHistogram(expr, s, ctx); ok {
 		return lowerExpHistogramResetsOrChanges(shape, s, ctx)
@@ -230,9 +224,6 @@ func lowerRoot(expr parser.Expr, s schema.Metrics, ctx lowerCtx) (chplan.Node, e
 	}
 	if agg, vs, ok := droppingAggregationOverExpHistogram(expr, s, ctx); ok {
 		return lowerExpHistogramDroppingAggregation(agg, vs, s, ctx)
-	}
-	if histSide, op, scale, ok := expHistogramScalarBinop(expr, s, ctx); ok {
-		return lowerExpHistogramScalarBinop(histSide, op, scale, s, ctx, false)
 	}
 	if histSide, ok := expHistogramDroppingScalarBinop(expr, s, ctx); ok {
 		return lowerExpHistogramScalarBinop(histSide, "", nil, s, ctx, true)
@@ -461,8 +452,9 @@ func lowerHistogramSelectorInput(
 // answers with a chplan.HistogramProjection before the recursive descent
 // that leads to lowerVectorSelector ever starts. That is the whole of the
 // narrowing — the selector nested under anything ELSE still arrives here
-// and is still rejected, because nothing above it can consume a histogram
-// row. Each exempt shape earns its exemption by not reading a Value:
+// and is still rejected unless that consumer explicitly drops histogram
+// samples, as the float-only functions do. Each histogram-valued shape earns
+// its exemption by not reading a Value:
 // `sum()` adds the bucket ladders themselves (`avg()` divides that sum
 // by the group's member count), and `rate`/`increase` difference them
 // across time. `sum(rate(...))`, which stacks the two

--- a/test/rejection-parity/catalogue/internal__promql__histogram_native_label_replace.go.json
+++ b/test/rejection-parity/catalogue/internal__promql__histogram_native_label_replace.go.json
@@ -2,35 +2,37 @@
   "entries": [
     {
       "head": "promql",
-      "site": "internal/promql/histogram_native_label_replace.go:lowerExpHistogramValuedShape#f5fecb3d",
-      "message": "promql: internal invariant violated: expression is not a known histogram-valued shape: %v",
+      "site": "internal/promql/histogram_native_label_replace.go:lowerLabelReplaceOverExpHistogram#3e91de20",
+      "message": "promql: internal invariant violated: exp-histogram label_replace input is %T, want *chplan.HistogramProjection",
       "class": "internal",
-      "rationale": "lowerExpHistogramValuedShape is called only after labelReplaceOverExpHistogram proved isExpHistogramValuedShape, and the recognizer and dispatcher enumerate the same bareExpHistogramSelector, sumOrAvgOverExpHistogram, and rateOverExpHistogram shapes",
+      "rationale": "lowerLabelReplaceOverExpHistogram is called only after labelReplaceOverExpHistogram proved isExpHistogramValuedShape, and the three shapes that recognizer admits are lowered by lowerExpHistogramValuedShape through lowerExpHistogramBare, lowerExpHistogramSumOrAvg, or lowerExpHistogramRate, each of which caps its result with HistogramProjection",
       "evidence": {
         "guard": [
-          "past returning if vs, ok := bareExpHistogramSelector(expr, s, ctx); ok",
-          "past returning if agg, vs, ok := sumOrAvgOverExpHistogram(expr, s, ctx); ok",
-          "past returning if shape, ok := rateOverExpHistogram(expr, s, ctx); ok"
+          "past returning if err != nil",
+          "past returning if err != nil",
+          "past returning if !ok",
+          "if !ok"
         ],
         "callers": [
-          "lowerLabelReplaceOverExpHistogram"
+          "lowerRoot"
         ],
         "cited": [
-          "bareExpHistogramSelector",
           "isExpHistogramValuedShape",
           "labelReplaceOverExpHistogram",
+          "lowerExpHistogramBare",
+          "lowerExpHistogramRate",
+          "lowerExpHistogramSumOrAvg",
           "lowerExpHistogramValuedShape",
-          "rateOverExpHistogram",
-          "sumOrAvgOverExpHistogram"
+          "lowerLabelReplaceOverExpHistogram"
         ]
       }
     },
     {
       "head": "promql",
-      "site": "internal/promql/histogram_native_label_replace.go:lowerLabelReplaceOverExpHistogram#3e91de20",
-      "message": "promql: internal invariant violated: exp-histogram label_replace input is %T, want *chplan.HistogramProjection",
+      "site": "internal/promql/histogram_native_label_replace.go:lowerLabelReplaceOverExpHistogram#f5fecb3d",
+      "message": "promql: internal invariant violated: expression is not a known histogram-valued shape: %v",
       "class": "internal",
-      "rationale": "lowerLabelReplaceOverExpHistogram receives only the three isExpHistogramValuedShape variants, whose lowerExpHistogramBare, lowerExpHistogramSumOrAvg, and lowerExpHistogramRate lowerings all cap their result with HistogramProjection",
+      "rationale": "lowerLabelReplaceOverExpHistogram is called only after labelReplaceOverExpHistogram proved isExpHistogramValuedShape, and that recognizer's bareExpHistogramSelector, sumOrAvgOverExpHistogram, and rateOverExpHistogram shapes are the first three cases lowerExpHistogramValuedShape accepts, so the matched operand cannot reach the unmatched fallback",
       "evidence": {
         "guard": [
           "past returning if err != nil",
@@ -41,11 +43,13 @@
           "lowerRoot"
         ],
         "cited": [
+          "bareExpHistogramSelector",
           "isExpHistogramValuedShape",
-          "lowerExpHistogramBare",
-          "lowerExpHistogramRate",
-          "lowerExpHistogramSumOrAvg",
-          "lowerLabelReplaceOverExpHistogram"
+          "labelReplaceOverExpHistogram",
+          "lowerExpHistogramValuedShape",
+          "lowerLabelReplaceOverExpHistogram",
+          "rateOverExpHistogram",
+          "sumOrAvgOverExpHistogram"
         ]
       }
     }

--- a/test/rejection-parity/catalogue/internal__promql__histogram_native_scalar_binop.go.json
+++ b/test/rejection-parity/catalogue/internal__promql__histogram_native_scalar_binop.go.json
@@ -5,13 +5,14 @@
       "site": "internal/promql/histogram_native_scalar_binop.go:lowerExpHistogramScalarBinop#03401a30",
       "message": "promql: internal invariant violated: exp-histogram lowering did not cap with *chplan.HistogramProjection, got %T",
       "class": "internal",
-      "rationale": "defensive type assertion: lowerExpHistogramBare, lowerExpHistogramSumOrAvg and lowerExpHistogramRate — the only three functions this switch calls — each cap their returned plan with a *chplan.HistogramProjection by construction (nativeHistogramProjection / aggregatedHistogramProjection), so the type assertion below this guard never fails for a lowerRoot-reachable query. It guards against a future change to one of those three lowerings dropping the cap.",
+      "rationale": "defensive type assertion: lowerExpHistogramBare, lowerExpHistogramSumOrAvg and lowerExpHistogramRate — the only three functions this switch calls through lowerExpHistogramValuedShape or lowerRoot — each cap their returned plan with a *chplan.HistogramProjection by construction (nativeHistogramProjection / aggregatedHistogramProjection), so the type assertion below this guard never fails for a reachable query. It guards against a future change to one of those three lowerings dropping the cap.",
       "evidence": {
         "guard": [
           "past returning if err != nil",
           "if !ok"
         ],
         "callers": [
+          "lowerExpHistogramValuedShape",
           "lowerRoot"
         ],
         "cited": [
@@ -19,6 +20,7 @@
           "lowerExpHistogramBare",
           "lowerExpHistogramRate",
           "lowerExpHistogramSumOrAvg",
+          "lowerExpHistogramValuedShape",
           "lowerRoot",
           "nativeHistogramProjection"
         ]
@@ -29,7 +31,7 @@
       "site": "internal/promql/histogram_native_scalar_binop.go:lowerExpHistogramScalarBinop#d112d97a",
       "message": "promql: internal invariant violated: exp-histogram scalar-binop matched no known histogram-valued shape for %v",
       "class": "internal",
-      "rationale": "defensive fallback: expHistogramScalarBinop and expHistogramDroppingScalarBinop only ever name histSide after isExpHistogramValuedShape confirmed it matches bareExpHistogramSelector, sumOrAvgOverExpHistogram or rateOverExpHistogram, so this switch's three arms are exhaustive for every histSide lowerRoot passes in. It guards against the recognizers and this switch drifting apart if a fourth shape is ever added to one without the others.",
+      "rationale": "defensive fallback: expHistogramScalarBinop reaches this function through lowerExpHistogramValuedShape and expHistogramDroppingScalarBinop reaches it through lowerRoot; both only name histSide after isExpHistogramValuedShape confirmed it matches bareExpHistogramSelector, sumOrAvgOverExpHistogram or rateOverExpHistogram, so this switch's three arms are exhaustive. It guards against either recognizer and this switch drifting apart if a fourth shape is added to one without the others.",
       "evidence": {
         "guard": [
           "default of switch over [case func() bool { _, ok := bareExpHistogramSelector(histSide, s, ctx); return ok }(); default]",
@@ -37,6 +39,7 @@
           "else of if shape, ok := rateOverExpHistogram(histSide, s, ctx); ok"
         ],
         "callers": [
+          "lowerExpHistogramValuedShape",
           "lowerRoot"
         ],
         "cited": [
@@ -44,6 +47,7 @@
           "expHistogramDroppingScalarBinop",
           "expHistogramScalarBinop",
           "isExpHistogramValuedShape",
+          "lowerExpHistogramValuedShape",
           "lowerRoot",
           "rateOverExpHistogram",
           "sumOrAvgOverExpHistogram"

--- a/test/rejection-parity/catalogue/internal__promql__lower.go.json
+++ b/test/rejection-parity/catalogue/internal__promql__lower.go.json
@@ -76,8 +76,8 @@
       "site": "internal/promql/lower.go:expHistogramSelectorRouting#71e3ce4e",
       "message": "promql: %q is an exponential histogram metric; only a bare %q selector, sum()/avg()/count() over one, rate()/increase()/resets()/changes() over one, histogram_quantile(), histogram_count(), histogram_sum(), and the %q/%q companion selectors are supported",
       "class": "divergence",
-      "trigger_query": "min(demo_latency_exp_hist)",
-      "tracking_issue": 2223,
+      "trigger_query": "delta(demo_latency_exp_hist[5m])",
+      "tracking_issue": 2224,
       "evidence": {
         "guard": [
           "past returning if bare, col, hasCompanion := s.HistogramCompanionColumn(metricName); hasCompanion \u0026\u0026 s.IsExpHistogramMetric(bare) \u0026\u0026 s.ExpHistogramTable != \"\"",

--- a/test/rejection-parity/catalogue/internal__promql__lower.go.json
+++ b/test/rejection-parity/catalogue/internal__promql__lower.go.json
@@ -76,8 +76,8 @@
       "site": "internal/promql/lower.go:expHistogramSelectorRouting#71e3ce4e",
       "message": "promql: %q is an exponential histogram metric; only a bare %q selector, sum()/avg()/count() over one, rate()/increase()/resets()/changes() over one, histogram_quantile(), histogram_count(), histogram_sum(), and the %q/%q companion selectors are supported",
       "class": "divergence",
-      "trigger_query": "abs(demo_latency_exp_hist)",
-      "tracking_issue": 2221,
+      "trigger_query": "min(demo_latency_exp_hist)",
+      "tracking_issue": 2223,
       "evidence": {
         "guard": [
           "past returning if bare, col, hasCompanion := s.HistogramCompanionColumn(metricName); hasCompanion \u0026\u0026 s.IsExpHistogramMetric(bare) \u0026\u0026 s.ExpHistogramTable != \"\"",


### PR DESCRIPTION
Closes #2221.

## Summary

- recognize native-histogram-valued operands for PromQL float-only instant functions
- return the canonical empty float vector for histogram-only inputs, matching Prometheus sample-dropping behavior
- preserve ordinary float-function evaluation and histogram scalar-binop dispatch
- cover bare, aggregated, range-derived, and value-preserving scalar-binop histogram shapes

## Root cause

Float-only functions descended through ordinary scalar lowering, so a native-histogram selector reached the shared unsupported-selector guard even though Prometheus accepts the query and omits histogram samples.

## Validation

- targeted race PromQL lowering tests, including the merged `label_replace` paths
- targeted chDB HTTP tests for histogram dropping and ordinary float output
- canonical `just update-golden migration parity solver promql logql traceql chsql optimizer codegen cardinality`
- canonical check-only shard coverage sweep
- rejection-parity update and non-update verification
- `git diff --check`
- zero-result `git grep -in fnspelling HEAD`

The routing-site divergence trigger now points to verified open follow-up #2223.