### PR TITLE
fix(ci): resolve downloaded golden patches from workspace

### DIFF
--- a/.github/scripts/manual-golden-update.mjs
+++ b/.github/scripts/manual-golden-update.mjs
@@ -284,7 +284,10 @@ function assertTargetUnmoved(root, branch, targetSha) {
 
 function applyAndPush(env) {
   const targetRoot = required(env, 'TARGET_ROOT');
-  const patchRoot = required(env, 'PATCH_ROOT');
+  // `git -C target apply <patch>` resolves a relative patch after changing to
+  // target. Resolve the artifact root against the controller workspace first,
+  // so a sibling `patches/` download remains reachable from the target clone.
+  const patchRoot = path.resolve(required(env, 'PATCH_ROOT'));
   const branch = validateBranch(required(env, 'BRANCH'), required(env, 'DEFAULT_BRANCH'));
   const targetSha = required(env, 'TARGET_SHA');
   const selected = parseShards(required(env, 'SHARDS_INPUT'));

--- a/.github/scripts/manual-golden-update.test.mjs
+++ b/.github/scripts/manual-golden-update.test.mjs
@@ -180,11 +180,14 @@ test('two independently generated shard patches publish as one commit', () => {
     git(publish, ['checkout', '-q', '--detach', targetSha]);
     const outputs = path.join(root, 'outputs');
     command('node', [SCRIPT], {
+      cwd: root,
       env: {
         ...process.env,
         MODE: 'apply-push',
-        TARGET_ROOT: publish,
-        PATCH_ROOT: patches,
+        // Match Actions: the controller, sibling target checkout, and artifact
+        // directory are all workspace-relative.
+        TARGET_ROOT: 'publish',
+        PATCH_ROOT: 'patches',
         BRANCH: 'agent/topic',
         DEFAULT_BRANCH: 'main',
         SHARDS_INPUT: 'promql logql',


### PR DESCRIPTION
## Summary

- resolve the downloaded patch artifact root before invoking Git with a separate target working directory
- exercise the exact workspace-relative controller, target, and patches layout used by Actions

## Root cause

The controller passed a workspace-relative patch path to `git -C target apply`. Git resolved that path after changing into the target checkout, so the sibling downloaded artifact directory could not be found.

## Validation

- `node --test .github/scripts/manual-golden-update.test.mjs` (7/7 passed)
- the integration case publishes two independently generated shard patches as one commit using relative `target` and `patches` directories