### PR TITLE
ci: add evidence-backed shadow merge fence

### DIFF
--- a/.github/actions/ci-native-part/action.yml
+++ b/.github/actions/ci-native-part/action.yml
@@ -1,0 +1,30 @@
+name: emit CI lane native part
+description: Publish a completion-bound native evidence part for one registered producer
+
+inputs:
+  id:
+    description: Registry native part ID
+    required: true
+  seed:
+    description: Exact seed used by a seeded producer lane
+    required: false
+    default: ''
+
+runs:
+  using: composite
+  steps:
+    - name: emit the completion-bound native case
+      shell: bash
+      env:
+        CI_NATIVE_PART_ID: ${{ inputs.id }}
+        CI_NATIVE_PART_OUTPUT: .ci-native/${{ inputs.id }}/cases.json
+        CI_NATIVE_SEED: ${{ inputs.seed }}
+      run: node .github/scripts/ci-lane-native-part.mjs
+
+    - name: upload the attempt-qualified native part
+      uses: actions/upload-artifact@v7
+      with:
+        name: ci-native-part-${{ inputs.id }}-${{ github.run_attempt }}
+        path: .ci-native/${{ inputs.id }}/cases.json
+        if-no-files-found: error
+        retention-days: 14

--- a/.github/ci-lanes.json
+++ b/.github/ci-lanes.json
@@ -537,7 +537,7 @@
       "description": "Test-only differential oracles behind the AGPL quarantine boundary.",
       "owner": {
         "workflow": ".github/workflows/agpl-oracle.yml",
-        "jobs": ["changes", "agpl-oracle"],
+        "jobs": ["changes", "agpl-oracle", "native-evidence"],
         "producer_jobs": [],
         "context_job": "agpl-oracle"
       },
@@ -585,7 +585,7 @@
       "description": "Helm lint, generated documentation, render, and schema validation.",
       "owner": {
         "workflow": ".github/workflows/chart-ci.yml",
-        "jobs": ["chart-validate"],
+        "jobs": ["chart-validate", "native-evidence"],
         "producer_jobs": [],
         "context_job": "chart-validate"
       },
@@ -626,7 +626,7 @@
       "description": "Exotic LogQL integration corpus executed through chDB and the AGPL oracle.",
       "owner": {
         "workflow": ".github/workflows/chdb.yml",
-        "jobs": ["integration-logql"],
+        "jobs": ["integration-logql", "native-evidence"],
         "producer_jobs": [],
         "context_job": "integration-logql"
       },
@@ -661,7 +661,7 @@
       "description": "Exotic PromQL integration corpus executed through chDB.",
       "owner": {
         "workflow": ".github/workflows/chdb.yml",
-        "jobs": ["integration-promql"],
+        "jobs": ["integration-promql", "native-evidence"],
         "producer_jobs": [],
         "context_job": "integration-promql"
       },
@@ -696,7 +696,7 @@
       "description": "Exotic TraceQL integration corpus executed through chDB.",
       "owner": {
         "workflow": ".github/workflows/chdb.yml",
-        "jobs": ["integration-traceql"],
+        "jobs": ["integration-traceql", "native-evidence"],
         "producer_jobs": [],
         "context_job": "integration-traceql"
       },
@@ -731,8 +731,8 @@
       "description": "Sharded cardinality, scale-wall, and compute fan-out ratchets.",
       "owner": {
         "workflow": ".github/workflows/chdb.yml",
-        "jobs": ["perf-guards-shard", "perf-guards"],
-        "producer_jobs": ["perf-guards"],
+        "jobs": ["perf-guards-shard", "perf-guards", "native-evidence"],
+        "producer_jobs": ["perf-guards-shard"],
         "context_job": "perf-guards"
       },
       "executions": ["default"],
@@ -762,7 +762,7 @@
       "description": "chDB build, driver sanity, and handler execution tests.",
       "owner": {
         "workflow": ".github/workflows/chdb.yml",
-        "jobs": ["changes", "chdb-build", "probe"],
+        "jobs": ["changes", "chdb-build", "probe", "native-evidence"],
         "producer_jobs": [],
         "context_job": "probe"
       },
@@ -797,7 +797,7 @@
       "description": "LogQL TXTAR SQL executed against seeded chDB rows.",
       "owner": {
         "workflow": ".github/workflows/chdb.yml",
-        "jobs": ["roundtrip"],
+        "jobs": ["roundtrip", "native-evidence"],
         "producer_jobs": [],
         "context_job": "roundtrip"
       },
@@ -832,7 +832,7 @@
       "description": "PromQL TXTAR SQL executed against seeded chDB rows.",
       "owner": {
         "workflow": ".github/workflows/chdb.yml",
-        "jobs": ["roundtrip"],
+        "jobs": ["roundtrip", "native-evidence"],
         "producer_jobs": [],
         "context_job": "roundtrip"
       },
@@ -867,7 +867,7 @@
       "description": "TraceQL TXTAR SQL executed against seeded chDB rows.",
       "owner": {
         "workflow": ".github/workflows/chdb.yml",
-        "jobs": ["roundtrip"],
+        "jobs": ["roundtrip", "native-evidence"],
         "producer_jobs": [],
         "context_job": "roundtrip"
       },
@@ -902,7 +902,7 @@
       "description": "Real-ClickHouse strict decoding, resource-bound, schema, and teardown differentials.",
       "owner": {
         "workflow": ".github/workflows/strict-scan.yml",
-        "jobs": ["changes", "strict-scan"],
+        "jobs": ["changes", "strict-scan", "native-evidence"],
         "producer_jobs": [],
         "context_job": "strict-scan"
       },
@@ -943,7 +943,7 @@
       "description": "Production dependency graph remains free of AGPL packages.",
       "owner": {
         "workflow": ".github/workflows/ci.yml",
-        "jobs": ["agpl-clean"],
+        "jobs": ["agpl-clean", "native-evidence"],
         "producer_jobs": [],
         "context_job": "agpl-clean"
       },
@@ -974,7 +974,7 @@
       "description": "Focused deterministic sleep-injection assertions under the production chaos build tag.",
       "owner": {
         "workflow": ".github/workflows/ci.yml",
-        "jobs": ["check-test", "check"],
+        "jobs": ["check-test", "check", "native-evidence"],
         "producer_jobs": ["check-test"],
         "context_job": "check"
       },
@@ -1011,7 +1011,7 @@
       "description": "Race-detected default-tag tests, build, tagged vet, oracle module, and module-tidy drift.",
       "owner": {
         "workflow": ".github/workflows/ci.yml",
-        "jobs": ["changes", "check-test", "check-build", "check"],
+        "jobs": ["changes", "check-test", "check-build", "check", "native-evidence"],
         "producer_jobs": ["changes", "check-test", "check-build"],
         "context_job": "check"
       },
@@ -1071,7 +1071,7 @@
       "description": "Behavioural anti-skip, anti-escape-hatch, and CI harness integrity scans.",
       "owner": {
         "workflow": ".github/workflows/ci.yml",
-        "jobs": ["forbid-skip"],
+        "jobs": ["forbid-skip", "native-evidence"],
         "producer_jobs": [],
         "context_job": "forbid-skip"
       },
@@ -1102,7 +1102,7 @@
       "description": "Repository-local markdown link integrity.",
       "owner": {
         "workflow": ".github/workflows/ci.yml",
-        "jobs": ["link-check"],
+        "jobs": ["link-check", "native-evidence"],
         "producer_jobs": [],
         "context_job": "link-check"
       },
@@ -1133,7 +1133,7 @@
       "description": "Go, architecture, Actions, commits, markdown, TypeScript, and generated-doc linting.",
       "owner": {
         "workflow": ".github/workflows/ci.yml",
-        "jobs": ["lint"],
+        "jobs": ["lint", "native-evidence"],
         "producer_jobs": [],
         "context_job": "lint"
       },
@@ -1164,7 +1164,7 @@
       "description": "Compatibility workflow's duplicated compile and discipline pre-gate.",
       "owner": {
         "workflow": ".github/workflows/compatibility.yml",
-        "jobs": ["changes", "gate"],
+        "jobs": ["changes", "gate", "native-evidence"],
         "producer_jobs": [],
         "context_job": "gate"
       },
@@ -1195,7 +1195,7 @@
       "description": "LogQL differential against Loki plus exact parity-ratchet roster.",
       "owner": {
         "workflow": ".github/workflows/compatibility.yml",
-        "jobs": ["loki"],
+        "jobs": ["loki", "native-evidence"],
         "producer_jobs": [],
         "context_job": "loki"
       },
@@ -1234,7 +1234,7 @@
       "description": "PromQL differential against Prometheus plus exact parity-ratchet roster.",
       "owner": {
         "workflow": ".github/workflows/compatibility.yml",
-        "jobs": ["prometheus"],
+        "jobs": ["prometheus", "native-evidence"],
         "producer_jobs": [],
         "context_job": "prometheus"
       },
@@ -1273,7 +1273,7 @@
       "description": "PromQL differential against the minimum supported ClickHouse version.",
       "owner": {
         "workflow": ".github/workflows/compatibility.yml",
-        "jobs": ["prometheus-floor"],
+        "jobs": ["prometheus-floor", "native-evidence"],
         "producer_jobs": [],
         "context_job": "prometheus-floor"
       },
@@ -1312,7 +1312,7 @@
       "description": "Forced solver route B must remain byte-identical to route A against Prometheus.",
       "owner": {
         "workflow": ".github/workflows/compatibility.yml",
-        "jobs": ["prometheus-forced-route"],
+        "jobs": ["prometheus-forced-route", "native-evidence"],
         "producer_jobs": [],
         "context_job": "prometheus-forced-route"
       },
@@ -1347,7 +1347,7 @@
       "description": "Flag-on live Prometheus function-surface completeness probe.",
       "owner": {
         "workflow": ".github/workflows/compatibility.yml",
-        "jobs": ["promql-surface"],
+        "jobs": ["promql-surface", "native-evidence"],
         "producer_jobs": [],
         "context_job": "promql-surface"
       },
@@ -1382,7 +1382,7 @@
       "description": "TraceQL HTTP and gRPC differentials against Tempo plus exact parity rosters.",
       "owner": {
         "workflow": ".github/workflows/compatibility.yml",
-        "jobs": ["tempo"],
+        "jobs": ["tempo", "native-evidence"],
         "producer_jobs": [],
         "context_job": "tempo"
       },
@@ -1421,7 +1421,7 @@
       "description": "Configuration registry, environment documentation, and generated defaults stay aligned.",
       "owner": {
         "workflow": ".github/workflows/config-docs.yml",
-        "jobs": ["config-docs"],
+        "jobs": ["config-docs", "native-evidence"],
         "producer_jobs": [],
         "context_job": "config-docs"
       },
@@ -1495,7 +1495,7 @@
       "description": "Bundled ClickHouse plus MinIO object-storage placement and query smoke.",
       "owner": {
         "workflow": ".github/workflows/e2e.yml",
-        "jobs": ["bwc-minio"],
+        "jobs": ["bwc-minio", "native-evidence"],
         "producer_jobs": [],
         "context_job": "bwc-minio"
       },
@@ -1526,7 +1526,7 @@
       "description": "Live k3d fault injection over the gateway and its dependencies.",
       "owner": {
         "workflow": ".github/workflows/e2e.yml",
-        "jobs": ["chaos"],
+        "jobs": ["chaos", "native-evidence"],
         "producer_jobs": [],
         "context_job": "chaos"
       },
@@ -1562,7 +1562,7 @@
           "compose-crawl-merge",
           "crawl-terminal"
         ],
-        "producer_jobs": ["crawl-terminal"],
+        "producer_jobs": ["compose-smoke-shard-info"],
         "context_job": "crawl-terminal"
       },
       "executions": ["default"],
@@ -1622,7 +1622,7 @@
           "compose-smoke-shard",
           "compose-smoke"
         ],
-        "producer_jobs": ["compose-smoke"],
+        "producer_jobs": ["compose-smoke-scope", "compose-smoke-setup", "compose-smoke-shard"],
         "context_job": "compose-smoke"
       },
       "executions": ["default"],
@@ -1676,8 +1676,8 @@
       "description": "k3d, real telemetry, Go E2E, Grafana Playwright, and restart gate.",
       "owner": {
         "workflow": ".github/workflows/e2e.yml",
-        "jobs": ["dashboard-setup", "dashboard-shard", "dashboard"],
-        "producer_jobs": ["dashboard"],
+        "jobs": ["dashboard-setup", "dashboard-shard", "dashboard", "native-evidence"],
+        "producer_jobs": ["dashboard-setup", "dashboard-shard"],
         "context_job": "dashboard"
       },
       "executions": ["default"],
@@ -1712,7 +1712,7 @@
           "dashboard-crawl-terminal",
           "dashboard-crawl-merge"
         ],
-        "producer_jobs": ["dashboard-crawl-terminal"],
+        "producer_jobs": ["dashboard-shard-info"],
         "context_job": "dashboard-crawl-terminal"
       },
       "executions": ["default"],
@@ -1746,7 +1746,7 @@
       "description": "Required one-stack proof of the repository-root README quickstart.",
       "owner": {
         "workflow": ".github/workflows/quickstart.yml",
-        "jobs": ["select", "run", "quickstart"],
+        "jobs": ["select", "run", "quickstart", "native-evidence"],
         "producer_jobs": ["select", "run"],
         "context_job": "quickstart"
       },
@@ -1800,7 +1800,7 @@
       "description": "Gateway reaches health within the startup threshold against ClickHouse.",
       "owner": {
         "workflow": ".github/workflows/e2e.yml",
-        "jobs": ["startup-bench"],
+        "jobs": ["startup-bench", "native-evidence"],
         "producer_jobs": [],
         "context_job": "startup-bench"
       },
@@ -1866,7 +1866,7 @@
       "description": "Every work-deferral marker is bound to an open repository issue.",
       "owner": {
         "workflow": ".github/workflows/forbid-deferral.yml",
-        "jobs": ["forbid-deferral"],
+        "jobs": ["forbid-deferral", "native-evidence"],
         "producer_jobs": [],
         "context_job": "forbid-deferral"
       },
@@ -1901,7 +1901,7 @@
       "description": "Pull request descriptions carry meaningful review context.",
       "owner": {
         "workflow": ".github/workflows/pr-hygiene.yml",
-        "jobs": ["pr-body"],
+        "jobs": ["pr-body", "native-evidence"],
         "producer_jobs": [],
         "context_job": "pr-body"
       },
@@ -1971,7 +1971,8 @@
           "migration-tier0",
           "migration-tier1",
           "migration-tier2",
-          "migration-aggregate"
+          "migration-aggregate",
+          "native-evidence"
         ],
         "producer_jobs": [
           "migration-setup",
@@ -2055,7 +2056,7 @@
       "description": "Corpus-wide deterministic compute fan-out profile.",
       "owner": {
         "workflow": ".github/workflows/perf-profile.yml",
-        "jobs": ["profile"],
+        "jobs": ["profile", "native-evidence"],
         "producer_jobs": [],
         "context_job": "profile"
       },
@@ -2086,7 +2087,7 @@
       "description": "Ordinary-PR structural enrollment of every production package in a positive floor.",
       "owner": {
         "workflow": ".github/workflows/coverage.yml",
-        "jobs": ["coverage"],
+        "jobs": ["coverage", "native-evidence"],
         "producer_jobs": [],
         "context_job": "coverage"
       },
@@ -2117,7 +2118,7 @@
       "description": "Merged default-tag and chDB profiles held to per-package floors; absent on ordinary PRs.",
       "owner": {
         "workflow": ".github/workflows/coverage.yml",
-        "jobs": ["coverage"],
+        "jobs": ["coverage", "native-evidence"],
         "producer_jobs": [],
         "context_job": "coverage"
       },
@@ -2164,8 +2165,8 @@
       "description": "Impact-selected gremlins package phases rolled into one efficacy gate.",
       "owner": {
         "workflow": ".github/workflows/mutation.yml",
-        "jobs": ["select", "mutate", "mutation"],
-        "producer_jobs": ["mutation"],
+        "jobs": ["select", "mutate", "mutation", "native-evidence"],
+        "producer_jobs": ["select", "mutate"],
         "context_job": "mutation"
       },
       "executions": ["default"],
@@ -2221,7 +2222,7 @@
       "description": "Regenerate every golden shard implied by the landed merge and fail on drift.",
       "owner": {
         "workflow": ".github/workflows/post-merge-drift.yml",
-        "jobs": ["drift"],
+        "jobs": ["drift", "native-evidence"],
         "producer_jobs": [],
         "context_job": "drift"
       },
@@ -2256,7 +2257,7 @@
       "description": "Rapid PromQL, LogQL, and TraceQL oracle properties; required context is a no-op on ordinary PRs.",
       "owner": {
         "workflow": ".github/workflows/property.yml",
-        "jobs": ["property"],
+        "jobs": ["property", "native-evidence"],
         "producer_jobs": [],
         "context_job": "property"
       },
@@ -2369,7 +2370,7 @@
       "description": "Auto-create and schema DDL integration against a real ClickHouse server.",
       "owner": {
         "workflow": ".github/workflows/schema-integration.yml",
-        "jobs": ["changes", "schema-ddl"],
+        "jobs": ["changes", "schema-ddl", "native-evidence"],
         "producer_jobs": [],
         "context_job": "schema-ddl"
       },
@@ -2408,8 +2409,8 @@
       "description": "Advanced-setup CodeQL scan and umbrella findings gate.",
       "owner": {
         "workflow": ".github/workflows/codeql.yml",
-        "jobs": ["analyze", "CodeQL"],
-        "producer_jobs": ["CodeQL"],
+        "jobs": ["analyze", "CodeQL", "native-evidence"],
+        "producer_jobs": ["analyze"],
         "context_job": "CodeQL"
       },
       "executions": ["default"],

--- a/.github/ci-lanes.json
+++ b/.github/ci-lanes.json
@@ -19,7 +19,494 @@
   },
   "native_evidence": {
     "schema_version": 1,
-    "parts": []
+    "parts": [
+      {
+        "id": "agpl.oracle.agpl-oracle.source",
+        "lane_id": "agpl.oracle",
+        "execution_id": "default",
+        "invocation_mode": "source_tree",
+        "producer_job": "agpl-oracle",
+        "parser": "case-json-v1",
+        "entry": "cases.json"
+      },
+      {
+        "id": "chart.validate.chart-validate.source",
+        "lane_id": "chart.validate",
+        "execution_id": "default",
+        "invocation_mode": "source_tree",
+        "producer_job": "chart-validate",
+        "parser": "case-json-v1",
+        "entry": "cases.json"
+      },
+      {
+        "id": "chdb.integration-logql.integration-logql.source",
+        "lane_id": "chdb.integration-logql",
+        "execution_id": "default",
+        "invocation_mode": "source_tree",
+        "producer_job": "integration-logql",
+        "parser": "case-json-v1",
+        "entry": "cases.json"
+      },
+      {
+        "id": "chdb.integration-promql.integration-promql.source",
+        "lane_id": "chdb.integration-promql",
+        "execution_id": "default",
+        "invocation_mode": "source_tree",
+        "producer_job": "integration-promql",
+        "parser": "case-json-v1",
+        "entry": "cases.json"
+      },
+      {
+        "id": "chdb.integration-traceql.integration-traceql.source",
+        "lane_id": "chdb.integration-traceql",
+        "execution_id": "default",
+        "invocation_mode": "source_tree",
+        "producer_job": "integration-traceql",
+        "parser": "case-json-v1",
+        "entry": "cases.json"
+      },
+      {
+        "id": "chdb.perf-guards.perf-guards.source",
+        "lane_id": "chdb.perf-guards",
+        "execution_id": "default",
+        "invocation_mode": "source_tree",
+        "producer_job": "perf-guards",
+        "parser": "case-json-v1",
+        "entry": "cases.json"
+      },
+      {
+        "id": "chdb.probe.probe.source",
+        "lane_id": "chdb.probe",
+        "execution_id": "default",
+        "invocation_mode": "source_tree",
+        "producer_job": "probe",
+        "parser": "case-json-v1",
+        "entry": "cases.json"
+      },
+      {
+        "id": "chdb.roundtrip-logql.roundtrip.source",
+        "lane_id": "chdb.roundtrip-logql",
+        "execution_id": "default",
+        "invocation_mode": "source_tree",
+        "producer_job": "roundtrip",
+        "parser": "case-json-v1",
+        "entry": "cases.json"
+      },
+      {
+        "id": "chdb.roundtrip-promql.roundtrip.source",
+        "lane_id": "chdb.roundtrip-promql",
+        "execution_id": "default",
+        "invocation_mode": "source_tree",
+        "producer_job": "roundtrip",
+        "parser": "case-json-v1",
+        "entry": "cases.json"
+      },
+      {
+        "id": "chdb.roundtrip-traceql.roundtrip.source",
+        "lane_id": "chdb.roundtrip-traceql",
+        "execution_id": "default",
+        "invocation_mode": "source_tree",
+        "producer_job": "roundtrip",
+        "parser": "case-json-v1",
+        "entry": "cases.json"
+      },
+      {
+        "id": "chdb.strict-scan.strict-scan.source",
+        "lane_id": "chdb.strict-scan",
+        "execution_id": "default",
+        "invocation_mode": "source_tree",
+        "producer_job": "strict-scan",
+        "parser": "case-json-v1",
+        "entry": "cases.json"
+      },
+      {
+        "id": "ci.agpl-clean.agpl-clean.source",
+        "lane_id": "ci.agpl-clean",
+        "execution_id": "default",
+        "invocation_mode": "source_tree",
+        "producer_job": "agpl-clean",
+        "parser": "case-json-v1",
+        "entry": "cases.json"
+      },
+      {
+        "id": "ci.chaos-sleep.check-test.source",
+        "lane_id": "ci.chaos-sleep",
+        "execution_id": "default",
+        "invocation_mode": "source_tree",
+        "producer_job": "check-test",
+        "parser": "case-json-v1",
+        "entry": "cases.json"
+      },
+      {
+        "id": "ci.check.changes.source",
+        "lane_id": "ci.check",
+        "execution_id": "default",
+        "invocation_mode": "source_tree",
+        "producer_job": "changes",
+        "parser": "case-json-v1",
+        "entry": "cases.json"
+      },
+      {
+        "id": "ci.check.check-build.source",
+        "lane_id": "ci.check",
+        "execution_id": "default",
+        "invocation_mode": "source_tree",
+        "producer_job": "check-build",
+        "parser": "case-json-v1",
+        "entry": "cases.json"
+      },
+      {
+        "id": "ci.check.check-test.source",
+        "lane_id": "ci.check",
+        "execution_id": "default",
+        "invocation_mode": "source_tree",
+        "producer_job": "check-test",
+        "parser": "case-json-v1",
+        "entry": "cases.json"
+      },
+      {
+        "id": "ci.forbid-skip.forbid-skip.source",
+        "lane_id": "ci.forbid-skip",
+        "execution_id": "default",
+        "invocation_mode": "source_tree",
+        "producer_job": "forbid-skip",
+        "parser": "case-json-v1",
+        "entry": "cases.json"
+      },
+      {
+        "id": "ci.link-check.link-check.source",
+        "lane_id": "ci.link-check",
+        "execution_id": "default",
+        "invocation_mode": "source_tree",
+        "producer_job": "link-check",
+        "parser": "case-json-v1",
+        "entry": "cases.json"
+      },
+      {
+        "id": "ci.lint.lint.source",
+        "lane_id": "ci.lint",
+        "execution_id": "default",
+        "invocation_mode": "source_tree",
+        "producer_job": "lint",
+        "parser": "case-json-v1",
+        "entry": "cases.json"
+      },
+      {
+        "id": "compatibility.gate.gate.source",
+        "lane_id": "compatibility.gate",
+        "execution_id": "default",
+        "invocation_mode": "source_tree",
+        "producer_job": "gate",
+        "parser": "case-json-v1",
+        "entry": "cases.json"
+      },
+      {
+        "id": "compatibility.loki.loki.source",
+        "lane_id": "compatibility.loki",
+        "execution_id": "default",
+        "invocation_mode": "source_tree",
+        "producer_job": "loki",
+        "parser": "case-json-v1",
+        "entry": "cases.json"
+      },
+      {
+        "id": "compatibility.prometheus-floor.prometheus-floor.source",
+        "lane_id": "compatibility.prometheus-floor",
+        "execution_id": "default",
+        "invocation_mode": "source_tree",
+        "producer_job": "prometheus-floor",
+        "parser": "case-json-v1",
+        "entry": "cases.json"
+      },
+      {
+        "id": "compatibility.prometheus-forced-route.prometheus-forced-route.source",
+        "lane_id": "compatibility.prometheus-forced-route",
+        "execution_id": "default",
+        "invocation_mode": "source_tree",
+        "producer_job": "prometheus-forced-route",
+        "parser": "case-json-v1",
+        "entry": "cases.json"
+      },
+      {
+        "id": "compatibility.prometheus.prometheus.source",
+        "lane_id": "compatibility.prometheus",
+        "execution_id": "default",
+        "invocation_mode": "source_tree",
+        "producer_job": "prometheus",
+        "parser": "case-json-v1",
+        "entry": "cases.json"
+      },
+      {
+        "id": "compatibility.promql-surface.promql-surface.source",
+        "lane_id": "compatibility.promql-surface",
+        "execution_id": "default",
+        "invocation_mode": "source_tree",
+        "producer_job": "promql-surface",
+        "parser": "case-json-v1",
+        "entry": "cases.json"
+      },
+      {
+        "id": "compatibility.tempo.tempo.source",
+        "lane_id": "compatibility.tempo",
+        "execution_id": "default",
+        "invocation_mode": "source_tree",
+        "producer_job": "tempo",
+        "parser": "case-json-v1",
+        "entry": "cases.json"
+      },
+      {
+        "id": "docs.config-drift.config-docs.source",
+        "lane_id": "docs.config-drift",
+        "execution_id": "default",
+        "invocation_mode": "source_tree",
+        "producer_job": "config-docs",
+        "parser": "case-json-v1",
+        "entry": "cases.json"
+      },
+      {
+        "id": "e2e.bwc-minio.bwc-minio.source",
+        "lane_id": "e2e.bwc-minio",
+        "execution_id": "default",
+        "invocation_mode": "source_tree",
+        "producer_job": "bwc-minio",
+        "parser": "case-json-v1",
+        "entry": "cases.json"
+      },
+      {
+        "id": "e2e.chaos.chaos.source",
+        "lane_id": "e2e.chaos",
+        "execution_id": "default",
+        "invocation_mode": "source_tree",
+        "producer_job": "chaos",
+        "parser": "case-json-v1",
+        "entry": "cases.json"
+      },
+      {
+        "id": "e2e.compose-crawl.crawl-terminal.source",
+        "lane_id": "e2e.compose-crawl",
+        "execution_id": "default",
+        "invocation_mode": "source_tree",
+        "producer_job": "crawl-terminal",
+        "parser": "case-json-v1",
+        "entry": "cases.json"
+      },
+      {
+        "id": "e2e.compose-smoke.compose-smoke.source",
+        "lane_id": "e2e.compose-smoke",
+        "execution_id": "default",
+        "invocation_mode": "source_tree",
+        "producer_job": "compose-smoke",
+        "parser": "case-json-v1",
+        "entry": "cases.json"
+      },
+      {
+        "id": "e2e.dashboard-crawl.dashboard-crawl-terminal.source",
+        "lane_id": "e2e.dashboard-crawl",
+        "execution_id": "default",
+        "invocation_mode": "source_tree",
+        "producer_job": "dashboard-crawl-terminal",
+        "parser": "case-json-v1",
+        "entry": "cases.json"
+      },
+      {
+        "id": "e2e.dashboard.dashboard.source",
+        "lane_id": "e2e.dashboard",
+        "execution_id": "default",
+        "invocation_mode": "source_tree",
+        "producer_job": "dashboard",
+        "parser": "case-json-v1",
+        "entry": "cases.json"
+      },
+      {
+        "id": "e2e.quickstart.run.source",
+        "lane_id": "e2e.quickstart",
+        "execution_id": "default",
+        "invocation_mode": "source_tree",
+        "producer_job": "run",
+        "parser": "case-json-v1",
+        "entry": "cases.json"
+      },
+      {
+        "id": "e2e.quickstart.select.source",
+        "lane_id": "e2e.quickstart",
+        "execution_id": "default",
+        "invocation_mode": "source_tree",
+        "producer_job": "select",
+        "parser": "case-json-v1",
+        "entry": "cases.json"
+      },
+      {
+        "id": "e2e.startup-bench.startup-bench.source",
+        "lane_id": "e2e.startup-bench",
+        "execution_id": "default",
+        "invocation_mode": "source_tree",
+        "producer_job": "startup-bench",
+        "parser": "case-json-v1",
+        "entry": "cases.json"
+      },
+      {
+        "id": "governance.forbid-deferral.forbid-deferral.source",
+        "lane_id": "governance.forbid-deferral",
+        "execution_id": "default",
+        "invocation_mode": "source_tree",
+        "producer_job": "forbid-deferral",
+        "parser": "case-json-v1",
+        "entry": "cases.json"
+      },
+      {
+        "id": "governance.pr-body.pr-body.source",
+        "lane_id": "governance.pr-body",
+        "execution_id": "default",
+        "invocation_mode": "source_tree",
+        "producer_job": "pr-body",
+        "parser": "case-json-v1",
+        "entry": "cases.json"
+      },
+      {
+        "id": "migration.e2e.migration-setup.artifact",
+        "lane_id": "migration.e2e",
+        "execution_id": "default",
+        "invocation_mode": "candidate_artifact",
+        "producer_job": "migration-setup",
+        "parser": "case-json-v1",
+        "entry": "cases.json"
+      },
+      {
+        "id": "migration.e2e.migration-tier0.artifact",
+        "lane_id": "migration.e2e",
+        "execution_id": "default",
+        "invocation_mode": "candidate_artifact",
+        "producer_job": "migration-tier0",
+        "parser": "case-json-v1",
+        "entry": "cases.json"
+      },
+      {
+        "id": "migration.e2e.migration-tier1.artifact",
+        "lane_id": "migration.e2e",
+        "execution_id": "default",
+        "invocation_mode": "candidate_artifact",
+        "producer_job": "migration-tier1",
+        "parser": "case-json-v1",
+        "entry": "cases.json"
+      },
+      {
+        "id": "migration.e2e.migration-tier2.artifact",
+        "lane_id": "migration.e2e",
+        "execution_id": "default",
+        "invocation_mode": "candidate_artifact",
+        "producer_job": "migration-tier2",
+        "parser": "case-json-v1",
+        "entry": "cases.json"
+      },
+      {
+        "id": "migration.e2e.migration-setup.source",
+        "lane_id": "migration.e2e",
+        "execution_id": "default",
+        "invocation_mode": "source_tree",
+        "producer_job": "migration-setup",
+        "parser": "case-json-v1",
+        "entry": "cases.json"
+      },
+      {
+        "id": "migration.e2e.migration-tier0.source",
+        "lane_id": "migration.e2e",
+        "execution_id": "default",
+        "invocation_mode": "source_tree",
+        "producer_job": "migration-tier0",
+        "parser": "case-json-v1",
+        "entry": "cases.json"
+      },
+      {
+        "id": "migration.e2e.migration-tier1.source",
+        "lane_id": "migration.e2e",
+        "execution_id": "default",
+        "invocation_mode": "source_tree",
+        "producer_job": "migration-tier1",
+        "parser": "case-json-v1",
+        "entry": "cases.json"
+      },
+      {
+        "id": "migration.e2e.migration-tier2.source",
+        "lane_id": "migration.e2e",
+        "execution_id": "default",
+        "invocation_mode": "source_tree",
+        "producer_job": "migration-tier2",
+        "parser": "case-json-v1",
+        "entry": "cases.json"
+      },
+      {
+        "id": "performance.profile.profile.source",
+        "lane_id": "performance.profile",
+        "execution_id": "default",
+        "invocation_mode": "source_tree",
+        "producer_job": "profile",
+        "parser": "case-json-v1",
+        "entry": "cases.json"
+      },
+      {
+        "id": "quality.coverage-enrollment.coverage.source",
+        "lane_id": "quality.coverage-enrollment",
+        "execution_id": "default",
+        "invocation_mode": "source_tree",
+        "producer_job": "coverage",
+        "parser": "case-json-v1",
+        "entry": "cases.json"
+      },
+      {
+        "id": "quality.coverage-measured.coverage.source",
+        "lane_id": "quality.coverage-measured",
+        "execution_id": "default",
+        "invocation_mode": "source_tree",
+        "producer_job": "coverage",
+        "parser": "case-json-v1",
+        "entry": "cases.json"
+      },
+      {
+        "id": "quality.mutation.mutation.source",
+        "lane_id": "quality.mutation",
+        "execution_id": "default",
+        "invocation_mode": "source_tree",
+        "producer_job": "mutation",
+        "parser": "case-json-v1",
+        "entry": "cases.json"
+      },
+      {
+        "id": "quality.post-merge-drift.drift.source",
+        "lane_id": "quality.post-merge-drift",
+        "execution_id": "default",
+        "invocation_mode": "source_tree",
+        "producer_job": "drift",
+        "parser": "case-json-v1",
+        "entry": "cases.json"
+      },
+      {
+        "id": "quality.property.property.source",
+        "lane_id": "quality.property",
+        "execution_id": "default",
+        "invocation_mode": "source_tree",
+        "producer_job": "property",
+        "parser": "case-json-v1",
+        "entry": "cases.json"
+      },
+      {
+        "id": "schema.ddl.schema-ddl.source",
+        "lane_id": "schema.ddl",
+        "execution_id": "default",
+        "invocation_mode": "source_tree",
+        "producer_job": "schema-ddl",
+        "parser": "case-json-v1",
+        "entry": "cases.json"
+      },
+      {
+        "id": "security.codeql.codeql.source",
+        "lane_id": "security.codeql",
+        "execution_id": "default",
+        "invocation_mode": "source_tree",
+        "producer_job": "CodeQL",
+        "parser": "case-json-v1",
+        "entry": "cases.json"
+      }
+    ]
   },
   "layers": [
     { "id": "1", "name": "Parser smoke / AST-shape pinning" },
@@ -245,7 +732,7 @@
       "owner": {
         "workflow": ".github/workflows/chdb.yml",
         "jobs": ["perf-guards-shard", "perf-guards"],
-        "producer_jobs": ["perf-guards-shard"],
+        "producer_jobs": ["perf-guards"],
         "context_job": "perf-guards"
       },
       "executions": ["default"],
@@ -1075,7 +1562,7 @@
           "compose-crawl-merge",
           "crawl-terminal"
         ],
-        "producer_jobs": ["compose-smoke-shard-info"],
+        "producer_jobs": ["crawl-terminal"],
         "context_job": "crawl-terminal"
       },
       "executions": ["default"],
@@ -1135,11 +1622,7 @@
           "compose-smoke-shard",
           "compose-smoke"
         ],
-        "producer_jobs": [
-          "compose-smoke-scope",
-          "compose-smoke-setup",
-          "compose-smoke-shard"
-        ],
+        "producer_jobs": ["compose-smoke"],
         "context_job": "compose-smoke"
       },
       "executions": ["default"],
@@ -1194,7 +1677,7 @@
       "owner": {
         "workflow": ".github/workflows/e2e.yml",
         "jobs": ["dashboard-setup", "dashboard-shard", "dashboard"],
-        "producer_jobs": ["dashboard-setup", "dashboard-shard"],
+        "producer_jobs": ["dashboard"],
         "context_job": "dashboard"
       },
       "executions": ["default"],
@@ -1229,7 +1712,7 @@
           "dashboard-crawl-terminal",
           "dashboard-crawl-merge"
         ],
-        "producer_jobs": ["dashboard-shard-info"],
+        "producer_jobs": ["dashboard-crawl-terminal"],
         "context_job": "dashboard-crawl-terminal"
       },
       "executions": ["default"],
@@ -1682,7 +2165,7 @@
       "owner": {
         "workflow": ".github/workflows/mutation.yml",
         "jobs": ["select", "mutate", "mutation"],
-        "producer_jobs": ["select", "mutate"],
+        "producer_jobs": ["mutation"],
         "context_job": "mutation"
       },
       "executions": ["default"],
@@ -1926,7 +2409,7 @@
       "owner": {
         "workflow": ".github/workflows/codeql.yml",
         "jobs": ["analyze", "CodeQL"],
-        "producer_jobs": ["analyze"],
+        "producer_jobs": ["CodeQL"],
         "context_job": "CodeQL"
       },
       "executions": ["default"],

--- a/.github/ci-lanes.json
+++ b/.github/ci-lanes.json
@@ -1,7 +1,7 @@
 {
   "schema_version": 1,
   "selection_schema_version": 1,
-  "report_schema_version": 1,
+  "report_schema_version": 2,
   "rollout": "shadow",
   "impact_selection": {
     "known_nonimpact_globs": [
@@ -87,7 +87,7 @@
       "timeout_minutes": 15,
       "slo_minutes": 15,
       "accountable_owner": "query-quality",
-      "report_schema_version": 1
+      "report_schema_version": 2
     },
     {
       "id": "chart.validate",
@@ -128,7 +128,7 @@
       "timeout_minutes": 30,
       "slo_minutes": 12,
       "accountable_owner": "release-engineering",
-      "report_schema_version": 1
+      "report_schema_version": 2
     },
     {
       "id": "chdb.integration-logql",
@@ -163,7 +163,7 @@
       "timeout_minutes": 20,
       "slo_minutes": 20,
       "accountable_owner": "query-quality",
-      "report_schema_version": 1
+      "report_schema_version": 2
     },
     {
       "id": "chdb.integration-promql",
@@ -198,7 +198,7 @@
       "timeout_minutes": 20,
       "slo_minutes": 20,
       "accountable_owner": "query-quality",
-      "report_schema_version": 1
+      "report_schema_version": 2
     },
     {
       "id": "chdb.integration-traceql",
@@ -233,7 +233,7 @@
       "timeout_minutes": 20,
       "slo_minutes": 20,
       "accountable_owner": "query-quality",
-      "report_schema_version": 1
+      "report_schema_version": 2
     },
     {
       "id": "chdb.perf-guards",
@@ -264,7 +264,7 @@
       "timeout_minutes": 30,
       "slo_minutes": 20,
       "accountable_owner": "query-quality",
-      "report_schema_version": 1
+      "report_schema_version": 2
     },
     {
       "id": "chdb.probe",
@@ -299,7 +299,7 @@
       "timeout_minutes": 15,
       "slo_minutes": 15,
       "accountable_owner": "query-quality",
-      "report_schema_version": 1
+      "report_schema_version": 2
     },
     {
       "id": "chdb.roundtrip-logql",
@@ -334,7 +334,7 @@
       "timeout_minutes": 20,
       "slo_minutes": 20,
       "accountable_owner": "query-quality",
-      "report_schema_version": 1
+      "report_schema_version": 2
     },
     {
       "id": "chdb.roundtrip-promql",
@@ -369,7 +369,7 @@
       "timeout_minutes": 20,
       "slo_minutes": 20,
       "accountable_owner": "query-quality",
-      "report_schema_version": 1
+      "report_schema_version": 2
     },
     {
       "id": "chdb.roundtrip-traceql",
@@ -404,7 +404,7 @@
       "timeout_minutes": 20,
       "slo_minutes": 20,
       "accountable_owner": "query-quality",
-      "report_schema_version": 1
+      "report_schema_version": 2
     },
     {
       "id": "chdb.strict-scan",
@@ -445,7 +445,7 @@
       "timeout_minutes": 20,
       "slo_minutes": 20,
       "accountable_owner": "query-quality",
-      "report_schema_version": 1
+      "report_schema_version": 2
     },
     {
       "id": "ci.agpl-clean",
@@ -476,7 +476,7 @@
       "timeout_minutes": 20,
       "slo_minutes": 8,
       "accountable_owner": "security",
-      "report_schema_version": 1
+      "report_schema_version": 2
     },
     {
       "id": "ci.chaos-sleep",
@@ -513,7 +513,7 @@
       "timeout_minutes": 20,
       "slo_minutes": 8,
       "accountable_owner": "quality-platform",
-      "report_schema_version": 1
+      "report_schema_version": 2
     },
     {
       "id": "ci.check",
@@ -573,7 +573,7 @@
       "timeout_minutes": 20,
       "slo_minutes": 10,
       "accountable_owner": "quality-platform",
-      "report_schema_version": 1
+      "report_schema_version": 2
     },
     {
       "id": "ci.forbid-skip",
@@ -604,7 +604,7 @@
       "timeout_minutes": 30,
       "slo_minutes": 12,
       "accountable_owner": "quality-platform",
-      "report_schema_version": 1
+      "report_schema_version": 2
     },
     {
       "id": "ci.link-check",
@@ -635,7 +635,7 @@
       "timeout_minutes": 20,
       "slo_minutes": 8,
       "accountable_owner": "quality-platform",
-      "report_schema_version": 1
+      "report_schema_version": 2
     },
     {
       "id": "ci.lint",
@@ -666,7 +666,7 @@
       "timeout_minutes": 60,
       "slo_minutes": 20,
       "accountable_owner": "quality-platform",
-      "report_schema_version": 1
+      "report_schema_version": 2
     },
     {
       "id": "compatibility.gate",
@@ -697,7 +697,7 @@
       "timeout_minutes": 10,
       "slo_minutes": 8,
       "accountable_owner": "quality-platform",
-      "report_schema_version": 1
+      "report_schema_version": 2
     },
     {
       "id": "compatibility.loki",
@@ -736,7 +736,7 @@
       "timeout_minutes": 30,
       "slo_minutes": 20,
       "accountable_owner": "query-quality",
-      "report_schema_version": 1
+      "report_schema_version": 2
     },
     {
       "id": "compatibility.prometheus",
@@ -775,7 +775,7 @@
       "timeout_minutes": 30,
       "slo_minutes": 20,
       "accountable_owner": "query-quality",
-      "report_schema_version": 1
+      "report_schema_version": 2
     },
     {
       "id": "compatibility.prometheus-floor",
@@ -814,7 +814,7 @@
       "timeout_minutes": 30,
       "slo_minutes": 20,
       "accountable_owner": "query-quality",
-      "report_schema_version": 1
+      "report_schema_version": 2
     },
     {
       "id": "compatibility.prometheus-forced-route",
@@ -849,7 +849,7 @@
       "timeout_minutes": 30,
       "slo_minutes": 20,
       "accountable_owner": "query-quality",
-      "report_schema_version": 1
+      "report_schema_version": 2
     },
     {
       "id": "compatibility.promql-surface",
@@ -884,7 +884,7 @@
       "timeout_minutes": 15,
       "slo_minutes": 15,
       "accountable_owner": "query-quality",
-      "report_schema_version": 1
+      "report_schema_version": 2
     },
     {
       "id": "compatibility.tempo",
@@ -923,7 +923,7 @@
       "timeout_minutes": 30,
       "slo_minutes": 20,
       "accountable_owner": "query-quality",
-      "report_schema_version": 1
+      "report_schema_version": 2
     },
     {
       "id": "docs.config-drift",
@@ -962,7 +962,7 @@
       "timeout_minutes": 20,
       "slo_minutes": 10,
       "accountable_owner": "quality-platform",
-      "report_schema_version": 1
+      "report_schema_version": 2
     },
     {
       "id": "docs.external-links",
@@ -997,7 +997,7 @@
       "timeout_minutes": 30,
       "slo_minutes": 30,
       "accountable_owner": "quality-platform",
-      "report_schema_version": 1
+      "report_schema_version": 2
     },
     {
       "id": "e2e.bwc-minio",
@@ -1028,7 +1028,7 @@
       "timeout_minutes": 40,
       "slo_minutes": 40,
       "accountable_owner": "system-quality",
-      "report_schema_version": 1
+      "report_schema_version": 2
     },
     {
       "id": "e2e.chaos",
@@ -1059,7 +1059,7 @@
       "timeout_minutes": 40,
       "slo_minutes": 40,
       "accountable_owner": "system-quality",
-      "report_schema_version": 1
+      "report_schema_version": 2
     },
     {
       "id": "e2e.compose-crawl",
@@ -1118,7 +1118,7 @@
       "timeout_minutes": 120,
       "slo_minutes": 20,
       "accountable_owner": "system-quality",
-      "report_schema_version": 1
+      "report_schema_version": 2
     },
     {
       "id": "e2e.compose-smoke",
@@ -1182,7 +1182,7 @@
       "timeout_minutes": 120,
       "slo_minutes": 20,
       "accountable_owner": "system-quality",
-      "report_schema_version": 1
+      "report_schema_version": 2
     },
     {
       "id": "e2e.dashboard",
@@ -1213,7 +1213,7 @@
       "timeout_minutes": 120,
       "slo_minutes": 120,
       "accountable_owner": "system-quality",
-      "report_schema_version": 1
+      "report_schema_version": 2
     },
     {
       "id": "e2e.dashboard-crawl",
@@ -1252,7 +1252,7 @@
       "timeout_minutes": 120,
       "slo_minutes": 120,
       "accountable_owner": "system-quality",
-      "report_schema_version": 1
+      "report_schema_version": 2
     },
     {
       "id": "e2e.quickstart",
@@ -1306,7 +1306,7 @@
       "timeout_minutes": 25,
       "slo_minutes": 20,
       "accountable_owner": "system-quality",
-      "report_schema_version": 1
+      "report_schema_version": 2
     },
     {
       "id": "e2e.startup-bench",
@@ -1341,7 +1341,7 @@
       "timeout_minutes": 10,
       "slo_minutes": 10,
       "accountable_owner": "system-quality",
-      "report_schema_version": 1
+      "report_schema_version": 2
     },
     {
       "id": "governance.chaos-applicability",
@@ -1372,7 +1372,7 @@
       "timeout_minutes": 10,
       "slo_minutes": 10,
       "accountable_owner": "quality-platform",
-      "report_schema_version": 1
+      "report_schema_version": 2
     },
     {
       "id": "governance.forbid-deferral",
@@ -1407,7 +1407,7 @@
       "timeout_minutes": 10,
       "slo_minutes": 5,
       "accountable_owner": "quality-platform",
-      "report_schema_version": 1
+      "report_schema_version": 2
     },
     {
       "id": "governance.pr-body",
@@ -1438,7 +1438,7 @@
       "timeout_minutes": 5,
       "slo_minutes": 5,
       "accountable_owner": "quality-platform",
-      "report_schema_version": 1
+      "report_schema_version": 2
     },
     {
       "id": "governance.release-gate-drift",
@@ -1472,7 +1472,7 @@
       "timeout_minutes": 10,
       "slo_minutes": 10,
       "accountable_owner": "release-engineering",
-      "report_schema_version": 1
+      "report_schema_version": 2
     },
     {
       "id": "migration.e2e",
@@ -1518,7 +1518,7 @@
       "timeout_minutes": 120,
       "slo_minutes": 120,
       "accountable_owner": "release-engineering",
-      "report_schema_version": 1
+      "report_schema_version": 2
     },
     {
       "id": "performance.benchmark",
@@ -1561,7 +1561,7 @@
       "timeout_minutes": 60,
       "slo_minutes": 20,
       "accountable_owner": "query-quality",
-      "report_schema_version": 1
+      "report_schema_version": 2
     },
     {
       "id": "performance.profile",
@@ -1592,7 +1592,7 @@
       "timeout_minutes": 30,
       "slo_minutes": 30,
       "accountable_owner": "query-quality",
-      "report_schema_version": 1
+      "report_schema_version": 2
     },
     {
       "id": "quality.coverage-enrollment",
@@ -1623,7 +1623,7 @@
       "timeout_minutes": 60,
       "slo_minutes": 10,
       "accountable_owner": "quality-platform",
-      "report_schema_version": 1
+      "report_schema_version": 2
     },
     {
       "id": "quality.coverage-measured",
@@ -1670,7 +1670,7 @@
       "timeout_minutes": 60,
       "slo_minutes": 60,
       "accountable_owner": "quality-platform",
-      "report_schema_version": 1
+      "report_schema_version": 2
     },
     {
       "id": "quality.mutation",
@@ -1727,7 +1727,7 @@
       "timeout_minutes": 90,
       "slo_minutes": 20,
       "accountable_owner": "query-quality",
-      "report_schema_version": 1
+      "report_schema_version": 2
     },
     {
       "id": "quality.post-merge-drift",
@@ -1762,7 +1762,7 @@
       "timeout_minutes": 45,
       "slo_minutes": 45,
       "accountable_owner": "quality-platform",
-      "report_schema_version": 1
+      "report_schema_version": 2
     },
     {
       "id": "quality.property",
@@ -1802,7 +1802,7 @@
       "timeout_minutes": 30,
       "slo_minutes": 30,
       "accountable_owner": "query-quality",
-      "report_schema_version": 1
+      "report_schema_version": 2
     },
     {
       "id": "release.brew-migration",
@@ -1840,7 +1840,7 @@
       "timeout_minutes": 60,
       "slo_minutes": 60,
       "accountable_owner": "release-engineering",
-      "report_schema_version": 1
+      "report_schema_version": 2
     },
     {
       "id": "release.brew-verify",
@@ -1875,7 +1875,7 @@
       "timeout_minutes": 60,
       "slo_minutes": 60,
       "accountable_owner": "release-engineering",
-      "report_schema_version": 1
+      "report_schema_version": 2
     },
     {
       "id": "schema.ddl",
@@ -1914,7 +1914,7 @@
       "timeout_minutes": 25,
       "slo_minutes": 20,
       "accountable_owner": "system-quality",
-      "report_schema_version": 1
+      "report_schema_version": 2
     },
     {
       "id": "security.codeql",
@@ -1945,7 +1945,7 @@
       "timeout_minutes": 30,
       "slo_minutes": 20,
       "accountable_owner": "security",
-      "report_schema_version": 1
+      "report_schema_version": 2
     }
   ],
   "non_lane_workflows": [
@@ -1954,10 +1954,18 @@
       "reason": "automation"
     },
     {
+      "workflow": ".github/workflows/ci-native-evidence.yml",
+      "reason": "infrastructure"
+    },
+    {
       "workflow": ".github/workflows/dependabot-tidy-nested-modules.yml",
       "reason": "dependency_maintenance"
     },
     { "workflow": ".github/workflows/issue-label.yml", "reason": "labeling" },
+    {
+      "workflow": ".github/workflows/merge-fence.yml",
+      "reason": "infrastructure"
+    },
     {
       "workflow": ".github/workflows/mirror-images.yml",
       "reason": "infrastructure"

--- a/.github/ci-lanes.json
+++ b/.github/ci-lanes.json
@@ -17,6 +17,10 @@
       "docs/**"
     ]
   },
+  "native_evidence": {
+    "schema_version": 1,
+    "parts": []
+  },
   "layers": [
     { "id": "1", "name": "Parser smoke / AST-shape pinning" },
     { "id": "2a", "name": "chplan IR snapshots in TXTAR" },

--- a/.github/scripts/ci-lane-contract.mjs
+++ b/.github/scripts/ci-lane-contract.mjs
@@ -1373,14 +1373,22 @@ export function validateRegistry(document, { root = process.cwd() } = {}) {
   for (const [laneID, jobs] of nativeJobsByLane) {
     const lane = lanesByID.get(laneID);
     const actual = [...jobs].sort();
-    const declared = [
-      ...(lane.owner.producer_jobs.length > 0
-        ? lane.owner.producer_jobs
-        : [lane.owner.context_job]),
-    ].sort();
-    if (JSON.stringify(actual) !== JSON.stringify(declared)) {
+    // owner.producer_jobs names the upstream jobs a fail-closed AGGREGATE
+    // context observes (test/regression/ci_lane_registry_test.go), which is a
+    // separate claim from where evidence is actually UPLOADED from. The two
+    // coincide when every producer can safely call ci-native-part, but a
+    // matrix/sharded producer cannot: its artifact name
+    // (ci-native-part-<id>-<run_attempt>) is shared across shards, so a
+    // fan-out job never emits its own part and the aggregate context job
+    // emits on its behalf instead. Allowing either — actual producers
+    // restricted to {context_job} ∪ producer_jobs — accepts both shapes
+    // while still rejecting a part uploaded by a job this lane never claims.
+    const allowed = new Set([lane.owner.context_job, ...lane.owner.producer_jobs]);
+    const unclaimed = actual.filter((job) => !allowed.has(job));
+    if (unclaimed.length > 0) {
       problems.push(
-        `registry lane ${laneID} owner.producer_jobs must exactly match native part producers ${JSON.stringify(actual)}`,
+        `registry lane ${laneID} native part producers ${JSON.stringify(unclaimed)} are neither ` +
+          `owner.context_job nor listed in owner.producer_jobs`,
       );
     }
     const invocationModes = [];

--- a/.github/scripts/ci-lane-contract.mjs
+++ b/.github/scripts/ci-lane-contract.mjs
@@ -732,6 +732,55 @@ function workflowJobCommands(root, workflow, jobs) {
   return commands;
 }
 
+function workflowJobBlock(root, workflow, jobID) {
+  if (
+    typeof workflow !== "string" ||
+    typeof jobID !== "string" ||
+    !existsSync(resolve(root, workflow))
+  ) {
+    return "";
+  }
+  const lines = readFileSync(resolve(root, workflow), "utf8").split("\n");
+  const jobsIndex = lines.findIndex((line) => /^\s*jobs:\s*(?:#.*)?$/.test(line));
+  if (jobsIndex === -1) return "";
+  const jobsIndent = /^\s*/.exec(lines[jobsIndex])[0].length;
+  const jobIndent = jobsIndent + 2;
+  let start = -1;
+  for (let i = jobsIndex + 1; i < lines.length; i += 1) {
+    const line = lines[i];
+    if (line.trim() === "" || line.trim().startsWith("#")) continue;
+    const indent = /^\s*/.exec(line)[0].length;
+    if (indent <= jobsIndent) break;
+    const job = /^\s*([A-Za-z_][A-Za-z0-9_-]*):\s*(?:#.*)?$/.exec(line);
+    if (indent !== jobIndent || !job) continue;
+    if (start !== -1) return lines.slice(start, i).join("\n");
+    if (job[1] === jobID) start = i;
+  }
+  return start === -1 ? "" : lines.slice(start).join("\n");
+}
+
+function producerJobEnrollsNativePart(root, workflow, jobID, partID) {
+  const block = workflowJobBlock(root, workflow, jobID);
+  if (block === "") return false;
+  const escapedID = partID.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const enrollment = new RegExp(
+    `uses:\\s*\\./\\.github/actions/ci-native-part(?:/action\\.yml)?\\s*` +
+      `[\\s\\S]{0,500}?\\n\\s*with:\\s*[\\s\\S]{0,300}?\\n\\s*id:\\s*['\"]?${escapedID}['\"]?\\s*(?:#.*)?$`,
+    "m",
+  );
+  return enrollment.test(block);
+}
+
+function workflowCallsNativeEvidence(root, workflow) {
+  if (typeof workflow !== "string" || !existsSync(resolve(root, workflow))) {
+    return false;
+  }
+  const contents = readFileSync(resolve(root, workflow), "utf8");
+  return /uses:\s*\.\/\.github\/workflows\/ci-native-evidence\.yml(?:\s|$)/m.test(
+    contents,
+  );
+}
+
 function normalizedCommand(value) {
   return value.trim().replace(/\s+/g, " ");
 }
@@ -1263,6 +1312,7 @@ export function validateRegistry(document, { root = process.cwd() } = {}) {
 
   const nativeJobsByLane = new Map();
   const nativeExecutions = new Set();
+  const nativeWorkflows = new Set();
   for (let i = 0; i < nativeParts.length; i += 1) {
     const part = nativeParts[i];
     const at = `registry.native_evidence.parts[${i}]`;
@@ -1282,6 +1332,18 @@ export function validateRegistry(document, { root = process.cwd() } = {}) {
       );
     }
     if (
+      !producerJobEnrollsNativePart(
+        root,
+        lane.owner.workflow,
+        part.producer_job,
+        part.id,
+      )
+    ) {
+      problems.push(
+        `${at} is not uploaded by ${lane.owner.workflow} job ${part.producer_job}`,
+      );
+    }
+    if (
       part.invocation_mode === "source_tree" &&
       !lane.applicability.source
     ) {
@@ -1296,14 +1358,26 @@ export function validateRegistry(document, { root = process.cwd() } = {}) {
     const jobs = nativeJobsByLane.get(lane.id) ?? new Set();
     jobs.add(part.producer_job);
     nativeJobsByLane.set(lane.id, jobs);
+    nativeWorkflows.add(lane.owner.workflow);
     nativeExecutions.add(
       `${lane.id}/${part.execution_id}/${part.invocation_mode}`,
     );
   }
+  for (const workflow of [...nativeWorkflows].sort()) {
+    if (!workflowCallsNativeEvidence(root, workflow)) {
+      problems.push(
+        `${workflow} owns native parts but does not call ci-native-evidence.yml`,
+      );
+    }
+  }
   for (const [laneID, jobs] of nativeJobsByLane) {
     const lane = lanesByID.get(laneID);
     const actual = [...jobs].sort();
-    const declared = [...lane.owner.producer_jobs].sort();
+    const declared = [
+      ...(lane.owner.producer_jobs.length > 0
+        ? lane.owner.producer_jobs
+        : [lane.owner.context_job]),
+    ].sort();
     if (JSON.stringify(actual) !== JSON.stringify(declared)) {
       problems.push(
         `registry lane ${laneID} owner.producer_jobs must exactly match native part producers ${JSON.stringify(actual)}`,

--- a/.github/scripts/ci-lane-contract.mjs
+++ b/.github/scripts/ci-lane-contract.mjs
@@ -61,6 +61,14 @@ import { fileURLToPath } from "node:url";
 export const REGISTRY_SCHEMA_VERSION = 1;
 export const SELECTION_SCHEMA_VERSION = 1;
 export const REPORT_SCHEMA_VERSION = 2;
+export const NATIVE_PART_SCHEMA_VERSION = 1;
+export const NATIVE_PART_PARSERS = Object.freeze([
+  "case-json-v1",
+  "compat-cases-json-v1",
+  "go-test-json-v1",
+  "junit-xml-v1",
+  "node-tap-v1",
+]);
 export const DEFAULT_REGISTRY_PATH = ".github/ci-lanes.json";
 export const MERGE_P95_SLO_MINUTES = 20;
 export const RELEASE_QUALIFICATION_SLO_MINUTES = 120;
@@ -119,12 +127,23 @@ const TOP_KEYS = new Set([
   "report_schema_version",
   "rollout",
   "impact_selection",
+  "native_evidence",
   "layers",
   "lanes",
   "non_lane_workflows",
 ]);
 const LAYER_KEYS = new Set(["id", "name"]);
 const IMPACT_SELECTION_KEYS = new Set(["known_nonimpact_globs"]);
+const NATIVE_EVIDENCE_KEYS = new Set(["schema_version", "parts"]);
+const NATIVE_PART_KEYS = new Set([
+  "id",
+  "lane_id",
+  "execution_id",
+  "invocation_mode",
+  "producer_job",
+  "parser",
+  "entry",
+]);
 const LANE_KEYS = new Set([
   "id",
   "description",
@@ -161,6 +180,8 @@ const CONTEXT_KEYS = new Set(["match", "name", "protected"]);
 const APPLICABILITY_KEYS = new Set(["source", "artifact"]);
 const SELECTOR_POLICY_KEYS = new Set(["unknown_paths", "failure"]);
 const NON_LANE_KEYS = new Set(["workflow", "reason"]);
+const NATIVE_PART_ID_RE = /^[a-z0-9][a-z0-9.-]*$/;
+const NATIVE_PART_ENTRY_RE = /^(?!\/)(?!.*(?:^|\/)\.\.(?:\/|$))[A-Za-z0-9_.-]+(?:\/[A-Za-z0-9_.-]+)*$/;
 
 const PURPOSES = new Set([
   "correctness",
@@ -344,6 +365,7 @@ const TRUSTED_ARTIFACT_KEYS = new Set([
 const TRUSTED_ARTIFACT_ENTRY_KEYS = new Set([
   "lane_id",
   "execution_id",
+  "invocation_mode",
   "sha256",
 ]);
 // Pull-request Actions runs expose the branch-head SHA through the REST API,
@@ -877,6 +899,71 @@ export function validateRegistry(document, { root = process.cwd() } = {}) {
     }
   }
 
+  const nativeParts = [];
+  if (
+    exactObject(
+      document.native_evidence,
+      NATIVE_EVIDENCE_KEYS,
+      "registry.native_evidence",
+      problems,
+    )
+  ) {
+    if (document.native_evidence.schema_version !== NATIVE_PART_SCHEMA_VERSION) {
+      problems.push(
+        `registry.native_evidence.schema_version must be ${NATIVE_PART_SCHEMA_VERSION}`,
+      );
+    }
+    if (!Array.isArray(document.native_evidence.parts)) {
+      problems.push("registry.native_evidence.parts must be an array");
+    } else {
+      let previousIdentity = "";
+      const partIDs = new Set();
+      for (let i = 0; i < document.native_evidence.parts.length; i += 1) {
+        const part = document.native_evidence.parts[i];
+        const at = `registry.native_evidence.parts[${i}]`;
+        if (!exactObject(part, NATIVE_PART_KEYS, at, problems)) continue;
+        stringValue(part.id, `${at}.id`, problems, {
+          pattern: NATIVE_PART_ID_RE,
+        });
+        stringValue(part.lane_id, `${at}.lane_id`, problems, {
+          pattern: LANE_ID_RE,
+        });
+        stringValue(part.execution_id, `${at}.execution_id`, problems, {
+          pattern: EXECUTION_ID_RE,
+        });
+        enumValue(
+          part.invocation_mode,
+          INVOCATION_MODES,
+          `${at}.invocation_mode`,
+          problems,
+        );
+        stringValue(part.producer_job, `${at}.producer_job`, problems, {
+          pattern: WORKFLOW_JOB_ID_RE,
+        });
+        enumValue(
+          part.parser,
+          new Set(NATIVE_PART_PARSERS),
+          `${at}.parser`,
+          problems,
+        );
+        stringValue(part.entry, `${at}.entry`, problems, {
+          pattern: NATIVE_PART_ENTRY_RE,
+        });
+        if (partIDs.has(part.id)) problems.push(`${at}.id duplicates ${part.id}`);
+        partIDs.add(part.id);
+        const identity =
+          `${part.lane_id}/${part.execution_id}/${part.invocation_mode}/${part.id}`;
+        if (previousIdentity !== "" && identity.localeCompare(previousIdentity) <= 0) {
+          problems.push(
+            `${at} identity ${identity} is not strictly sorted after ${previousIdentity}`,
+          );
+        }
+        previousIdentity = identity;
+        nativeParts.push(part);
+      }
+    }
+  }
+
   if (!Array.isArray(document.layers)) {
     problems.push("registry.layers must be an array");
   } else {
@@ -899,6 +986,7 @@ export function validateRegistry(document, { root = process.cwd() } = {}) {
   const knownLayers = new Set(CANONICAL_LAYERS);
   const coveredLayers = new Set();
   const laneIDs = new Set();
+  const lanesByID = new Map();
   const protectedContexts = new Set();
   const recipeCommands = justRecipeCommands(root);
   const recipes = new Set(recipeCommands.keys());
@@ -922,6 +1010,7 @@ export function validateRegistry(document, { root = process.cwd() } = {}) {
           );
         }
         laneIDs.add(lane.id);
+        lanesByID.set(lane.id, lane);
         previousID = lane.id;
       }
       stringValue(lane.description, `${at}.description`, problems);
@@ -953,11 +1042,6 @@ export function validateRegistry(document, { root = process.cwd() } = {}) {
             ) {
               problems.push(
                 `${at}.owner.producer_jobs contains ${job}, which is not in owner.jobs`,
-              );
-            }
-            if (job === lane.owner.context_job) {
-              problems.push(
-                `${at}.owner.producer_jobs must exclude the context_job ${job}`,
               );
             }
           }
@@ -1177,6 +1261,69 @@ export function validateRegistry(document, { root = process.cwd() } = {}) {
     }
   }
 
+  const nativeJobsByLane = new Map();
+  const nativeExecutions = new Set();
+  for (let i = 0; i < nativeParts.length; i += 1) {
+    const part = nativeParts[i];
+    const at = `registry.native_evidence.parts[${i}]`;
+    const lane = lanesByID.get(part.lane_id);
+    if (!lane) {
+      problems.push(`${at}.lane_id names unknown lane ${part.lane_id}`);
+      continue;
+    }
+    if (!lane.executions.includes(part.execution_id)) {
+      problems.push(
+        `${at}.execution_id ${part.execution_id} is not registered by lane ${lane.id}`,
+      );
+    }
+    if (!lane.owner.jobs.includes(part.producer_job)) {
+      problems.push(
+        `${at}.producer_job ${part.producer_job} is not owned by lane ${lane.id}`,
+      );
+    }
+    if (
+      part.invocation_mode === "source_tree" &&
+      !lane.applicability.source
+    ) {
+      problems.push(`${at}.invocation_mode belongs to a non-source lane`);
+    }
+    if (
+      part.invocation_mode === "candidate_artifact" &&
+      !lane.applicability.artifact
+    ) {
+      problems.push(`${at}.invocation_mode belongs to a non-artifact lane`);
+    }
+    const jobs = nativeJobsByLane.get(lane.id) ?? new Set();
+    jobs.add(part.producer_job);
+    nativeJobsByLane.set(lane.id, jobs);
+    nativeExecutions.add(
+      `${lane.id}/${part.execution_id}/${part.invocation_mode}`,
+    );
+  }
+  for (const [laneID, jobs] of nativeJobsByLane) {
+    const lane = lanesByID.get(laneID);
+    const actual = [...jobs].sort();
+    const declared = [...lane.owner.producer_jobs].sort();
+    if (JSON.stringify(actual) !== JSON.stringify(declared)) {
+      problems.push(
+        `registry lane ${laneID} owner.producer_jobs must exactly match native part producers ${JSON.stringify(actual)}`,
+      );
+    }
+    const invocationModes = [];
+    if (lane.applicability.source) invocationModes.push("source_tree");
+    if (lane.applicability.artifact) invocationModes.push("candidate_artifact");
+    for (const executionID of lane.executions) {
+      for (const invocationMode of invocationModes) {
+        if (nativeExecutions.has(`${laneID}/${executionID}/${invocationMode}`)) {
+          continue;
+        }
+        problems.push(
+          `registry lane ${laneID}/${executionID}/${invocationMode} has native parts for another invocation but none for this invocation`,
+        );
+      }
+    }
+  }
+
   validateCanonicalHeadOracleFloors(
     document.lanes,
     root,
@@ -1321,6 +1468,17 @@ export function nativeArtifactName(workflow, run) {
     .replace(/\.ya?ml$/, "")
     .replace(/[^A-Za-z0-9_.-]+/g, "-");
   return `ci-native-${basename}-${run.id}-${run.attempt}`;
+}
+
+export function nativePartArtifactName(partID, runAttempt) {
+  const id = String(partID ?? "").trim();
+  const attempt = String(runAttempt ?? "").trim();
+  if (!NATIVE_PART_ID_RE.test(id) || !/^[1-9][0-9]*$/.test(attempt)) {
+    throw new ContractError("invalid CI lane native part artifact", [
+      "part id and run attempt must be canonical",
+    ]);
+  }
+  return `ci-native-part-${id}-${attempt}`;
 }
 
 function validateDigest(value, path, problems, { required = false } = {}) {
@@ -1878,7 +2036,8 @@ export function validateReport(document, registry) {
           `report.producer.artifact.name must be ${expectedArtifactName}`,
         );
       }
-      const expectedEntry = `${document.lane_id}/${document.execution_id}`;
+      const expectedEntry =
+        `${document.lane_id}/${document.execution_id}/${document.invocation?.mode}`;
       if (document.producer.artifact.entry !== expectedEntry) {
         problems.push(
           `report.producer.artifact.entry must be ${expectedEntry}`,
@@ -2119,10 +2278,15 @@ export function validateProducerManifest(document, registry) {
       knownJobs.get(lane.owner.workflow).add(job);
     if (!knownEntries.has(lane.owner.workflow))
       knownEntries.set(lane.owner.workflow, new Set());
+    const modes = [];
+    if (lane.applicability.source) modes.push("source_tree");
+    if (lane.applicability.artifact) modes.push("candidate_artifact");
     for (const executionID of lane.executions) {
-      knownEntries
-        .get(lane.owner.workflow)
-        .add(`${lane.id}/${executionID}`);
+      for (const mode of modes) {
+        knownEntries
+          .get(lane.owner.workflow)
+          .add(`${lane.id}/${executionID}/${mode}`);
+      }
     }
   }
   if (!Array.isArray(document.producers)) {
@@ -2173,7 +2337,8 @@ export function validateProducerManifest(document, registry) {
       if (!Array.isArray(producer.jobs) || producer.jobs.length === 0) {
         problems.push(`${at}.jobs must be a non-empty array`);
       } else {
-        const jobs = new Set();
+        const jobExecutions = new Set();
+        const jobDatabaseIDs = new Set();
         for (let j = 0; j < producer.jobs.length; j += 1) {
           const job = producer.jobs[j];
           const jobAt = `${at}.jobs[${j}]`;
@@ -2186,12 +2351,19 @@ export function validateProducerManifest(document, registry) {
           ) {
             problems.push(`${jobAt}.job is not registered for the workflow`);
           }
-          if (jobs.has(job.job)) problems.push(`${jobAt}.job is duplicated`);
-          jobs.add(job.job);
           stringValue(job.name, `${jobAt}.name`, problems);
           stringValue(job.database_id, `${jobAt}.database_id`, problems, {
             pattern: RUN_ID_RE,
           });
+          const jobExecution = `${job.job}/${job.name}`;
+          if (jobExecutions.has(jobExecution)) {
+            problems.push(`${jobAt} duplicates job execution ${jobExecution}`);
+          }
+          if (jobDatabaseIDs.has(job.database_id)) {
+            problems.push(`${jobAt}.database_id is duplicated`);
+          }
+          jobExecutions.add(jobExecution);
+          jobDatabaseIDs.add(job.database_id);
           enumValue(
             job.conclusion,
             JOB_CONCLUSIONS,
@@ -2248,10 +2420,17 @@ export function validateProducerManifest(document, registry) {
                 problems,
                 { pattern: EXECUTION_ID_RE },
               );
+              enumValue(
+                entry.invocation_mode,
+                INVOCATION_MODES,
+                `${entryAt}.invocation_mode`,
+                problems,
+              );
               stringValue(entry.sha256, `${entryAt}.sha256`, problems, {
                 pattern: SHA256_RE,
               });
-              const identity = `${entry.lane_id}/${entry.execution_id}`;
+              const identity =
+                `${entry.lane_id}/${entry.execution_id}/${entry.invocation_mode}`;
               if (entries.has(identity)) {
                 problems.push(`${entryAt} duplicates native entry ${identity}`);
               }
@@ -2279,13 +2458,16 @@ export function validateProducerManifest(document, registry) {
 }
 
 function reportIdentity(report) {
-  return `${report.lane_id}/${report.execution_id}`;
+  return `${report.lane_id}/${report.execution_id}/${report.invocation.mode}`;
 }
 
-function expectedInvocationMode(lane, posture) {
-  if (posture === "release" && lane.applicability.artifact)
-    return "candidate_artifact";
-  return "source_tree";
+function expectedInvocationModes(lane, posture) {
+  const modes = [];
+  if (lane.applicability.source) modes.push("source_tree");
+  if (posture === "release" && lane.applicability.artifact) {
+    modes.push("candidate_artifact");
+  }
+  return modes;
 }
 
 function validateQualificationExpectations(expected, registry, selection) {
@@ -2449,11 +2631,15 @@ export function validateReportSet({
   for (const item of selection.lanes) {
     if (item.disposition !== "selected") continue;
     expectedWorkflows.add(lanesByID.get(item.lane_id).owner.workflow);
+    const lane = lanesByID.get(item.lane_id);
     for (const execution of item.executions) {
-      expectedReports.set(`${item.lane_id}/${execution}`, {
-        lane: lanesByID.get(item.lane_id),
-        execution,
-      });
+      for (const mode of expectedInvocationModes(lane, selection.posture)) {
+        expectedReports.set(`${item.lane_id}/${execution}/${mode}`, {
+          lane,
+          execution,
+          mode,
+        });
+      }
     }
   }
 
@@ -2553,10 +2739,10 @@ export function validateReportSet({
         `${identity}: correlation_nonce does not match the current qualification`,
       );
     }
-    const mode = expectedInvocationMode(lane, selection.posture);
-    if (report.invocation.mode !== mode) {
+    const mode = report.invocation.mode;
+    if (expectedReports.get(identity)?.mode !== mode) {
       problems.push(
-        `${identity}: invocation mode ${report.invocation.mode} must be ${mode}`,
+        `${identity}: invocation mode ${mode} is not selected for this lane execution`,
       );
     }
     if (
@@ -2603,23 +2789,28 @@ export function validateReportSet({
         `${identity}: producer run identity does not match the trusted workflow run`,
       );
     }
-    const context = trusted.jobs.find(
+    const jobCandidates = trusted.jobs.filter(
       (job) => job.job === report.producer.job,
     );
-    if (!context) {
+    const contexts = jobCandidates.filter((job) => {
+      return lane.context.match === "exact"
+        ? job.name === lane.context.name
+        : job.name.startsWith(lane.context.name);
+    });
+    if (jobCandidates.length === 0) {
       problems.push(
         `${identity}: trusted context job ${report.producer.job} is missing`,
       );
+    } else if (contexts.length === 0) {
+      problems.push(
+        `${identity}: trusted context check name ${jobCandidates[0].name} does not match ${lane.context.name}`,
+      );
+    } else if (contexts.length > 1) {
+      problems.push(
+        `${identity}: trusted context job ${report.producer.job} is ambiguous`,
+      );
     } else {
-      const contextNameMatches =
-        lane.context.match === "exact"
-          ? context.name === lane.context.name
-          : context.name.startsWith(lane.context.name);
-      if (!contextNameMatches) {
-        problems.push(
-          `${identity}: trusted context check name ${context.name} does not match ${lane.context.name}`,
-        );
-      }
+      const [context] = contexts;
       if (context.conclusion !== "success") {
         problems.push(
           `${identity}: trusted context job ${report.producer.job} is ${context.conclusion}`,
@@ -2644,7 +2835,8 @@ export function validateReportSet({
       const entry = artifact.entries.find(
         (candidate) =>
           candidate.lane_id === report.lane_id &&
-          candidate.execution_id === report.execution_id,
+          candidate.execution_id === report.execution_id &&
+          candidate.invocation_mode === report.invocation.mode,
       );
       if (!entry) {
         problems.push(

--- a/.github/scripts/ci-lane-contract.mjs
+++ b/.github/scripts/ci-lane-contract.mjs
@@ -18,18 +18,24 @@
 // Env (reports):
 //   CI_LANE_SELECTION     selection manifest path (required)
 //   CI_LANE_REPORT_DIR    recursively-read report directory (required)
-//   CI_LANE_JOB_RESULTS_JSON
-//                         JSON object keyed by <workflow>#<job>. Each value is
-//                         {conclusion, run_id, run_attempt}. This is trusted
-//                         workflow `needs` state, not report-artifact content.
+//   CI_LANE_PRODUCER_MANIFEST
+//                         trusted API-built producer-manifest path (required)
 //   CI_LANE_POSTURE     merge | main | release
 //   CI_EXPECT_SHA         exact source commit selected for qualification
 //   CI_EXPECT_TREE        exact Git tree selected for qualification
+//   CI_EXPECT_CORRELATION_NONCE per-qualification 64-hex correlation value
 //   CI_EXPECT_CANDIDATE_DIGEST
 //                         sha256 digest; required when a selected lane applies
 //                         to an artifact
 //   CI_EXPECT_RUN_ID      selection/qualification workflow run id
 //   CI_EXPECT_RUN_ATTEMPT selection/qualification workflow attempt
+//   CI_EXPECT_SELECTION_SHA256 exact selection-manifest SHA-256
+//   CI_EXPECT_EVENT_KIND  workflow event used for producer-run discovery
+//   CI_EXPECT_PR_NUMBER   PR number; required only for pull_request
+//   CI_EXPECT_EVENT_HEAD_SHA API workflow-run head SHA
+//   CI_EXPECT_EVENT_BASE_SHA event base SHA; required for PR/merge group
+//   CI_EXPECT_PROJECTED_SHA exact projected checkout SHA
+//   CI_EXPECT_REPOSITORY  exact owner/repository slug from trusted context
 //   CI_EXPECT_BASE_SHA    merge base commit; required for merge qualification
 //   CI_EXPECT_CHANGED_PATHS_JSON
 //                         canonical compact changed-path JSON array; required
@@ -40,6 +46,7 @@
 // non-zero on every malformed, missing, stale, skipped, neutral, cancelled,
 // mismatched, or zero-execution state.
 
+import { createHash } from "node:crypto";
 import process from "node:process";
 import {
   appendFileSync,
@@ -53,7 +60,7 @@ import { fileURLToPath } from "node:url";
 
 export const REGISTRY_SCHEMA_VERSION = 1;
 export const SELECTION_SCHEMA_VERSION = 1;
-export const REPORT_SCHEMA_VERSION = 1;
+export const REPORT_SCHEMA_VERSION = 2;
 export const DEFAULT_REGISTRY_PATH = ".github/ci-lanes.json";
 export const MERGE_P95_SLO_MINUTES = 20;
 export const RELEASE_QUALIFICATION_SLO_MINUTES = 120;
@@ -244,6 +251,7 @@ const SELECTION_KEYS = new Set([
   "posture",
   "source",
   "candidate_digest",
+  "correlation_nonce",
   "run",
   "selector",
   "lanes",
@@ -272,13 +280,22 @@ const REPORT_KEYS = new Set([
   "posture",
   "source",
   "candidate_digest",
-  "run",
+  "correlation_nonce",
+  "selection_ref",
   "producer",
   "invocation",
   "evidence",
   "conclusion",
 ]);
-const PRODUCER_KEYS = new Set(["workflow", "job"]);
+const SELECTION_REF_KEYS = new Set(["run", "manifest_sha256"]);
+const PRODUCER_KEYS = new Set(["workflow", "job", "run", "artifact"]);
+const PRODUCER_ARTIFACT_KEYS = new Set([
+  "id",
+  "name",
+  "sha256",
+  "entry",
+  "entry_sha256",
+]);
 const INVOCATION_KEYS = new Set([
   "mode",
   "recipe",
@@ -295,14 +312,62 @@ const EVIDENCE_KEYS = new Set([
   "seed",
   "corpus_id",
 ]);
-const JOB_RESULT_KEYS = new Set(["conclusion", "run_id", "run_attempt"]);
+const PRODUCER_MANIFEST_KEYS = new Set([
+  "schema_version",
+  "correlation_nonce",
+  "selection_ref",
+  "producers",
+]);
+const TRUSTED_PRODUCER_KEYS = new Set([
+  "workflow",
+  "run",
+  "source",
+  "correlation_nonce",
+  "event",
+  "repository",
+  "conclusion",
+  "jobs",
+  "artifacts",
+]);
+const TRUSTED_JOB_KEYS = new Set([
+  "job",
+  "name",
+  "database_id",
+  "conclusion",
+]);
+const TRUSTED_ARTIFACT_KEYS = new Set([
+  "id",
+  "name",
+  "sha256",
+  "entries",
+]);
+const TRUSTED_ARTIFACT_ENTRY_KEYS = new Set([
+  "lane_id",
+  "execution_id",
+  "sha256",
+]);
+// Pull-request Actions runs expose the branch-head SHA through the REST API,
+// while checkout uses the projected merge commit. Keep both identities: run
+// discovery binds the event head/base/PR tuple; native evidence binds the
+// projected commit and tree. Equating the two rejects honest PR evidence.
+const EVENT_IDENTITY_KEYS = new Set([
+  "kind",
+  "pr_number",
+  "event_head_sha",
+  "event_base_sha",
+  "projected_sha",
+]);
 const QUALIFICATION_EXPECTATION_KEYS = new Set([
   "posture",
   "sha",
   "tree",
   "candidateDigest",
+  "correlationNonce",
   "runID",
   "runAttempt",
+  "selectionManifestSHA256",
+  "eventIdentity",
+  "repository",
   "baseSHA",
   "changedPaths",
 ]);
@@ -313,6 +378,16 @@ const WORKFLOW_JOB_ID_RE = /^[A-Za-z_][A-Za-z0-9_-]*$/;
 const SHA_RE = /^(?:[0-9a-f]{40}|[0-9a-f]{64})$/;
 const DIGEST_RE = /^sha256:[0-9a-f]{64}$/;
 const RUN_ID_RE = /^[1-9][0-9]*$/;
+const SHA256_RE = /^[0-9a-f]{64}$/;
+const CORRELATION_NONCE_RE = /^[0-9a-f]{64}$/;
+const REPOSITORY_RE = /^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/;
+const EVENT_KINDS = new Set([
+  "merge_group",
+  "pull_request",
+  "push",
+  "schedule",
+  "workflow_dispatch",
+]);
 const DOMAIN_RE = /^[a-z0-9][a-z0-9-]*$/;
 const UNSUPPORTED_GLOB_META_RE = /[?\[\]{}]/;
 
@@ -521,7 +596,7 @@ function validateRepositoryGlob(root, value, path, problems) {
   }
 }
 
-function validateChangedPaths(value, path, problems) {
+export function validateChangedPaths(value, path, problems) {
   if (!stringArray(value, path, problems, { allowEmpty: true })) return false;
   for (let i = 0; i < value.length; i += 1) {
     canonicalRepositoryPath(value[i], `${path}[${i}]`, problems);
@@ -1180,6 +1255,74 @@ function validateRun(run, path, problems) {
   integerValue(run.attempt, `${path}.attempt`, problems, { min: 1 });
 }
 
+function validateSelectionRef(value, path, problems) {
+  if (!exactObject(value, SELECTION_REF_KEYS, path, problems)) return;
+  validateRun(value.run, `${path}.run`, problems);
+  stringValue(value.manifest_sha256, `${path}.manifest_sha256`, problems, {
+    pattern: SHA256_RE,
+  });
+}
+
+function validateArtifact(value, keys, path, problems) {
+  if (!exactObject(value, keys, path, problems)) return;
+  stringValue(value.id, `${path}.id`, problems, { pattern: RUN_ID_RE });
+  stringValue(value.name, `${path}.name`, problems);
+  stringValue(value.sha256, `${path}.sha256`, problems, {
+    pattern: SHA256_RE,
+  });
+}
+
+export function selectionManifestSHA256(document) {
+  return createHash("sha256")
+    .update(`${JSON.stringify(document, null, 2)}\n`)
+    .digest("hex");
+}
+
+function canonicalJSONValue(value) {
+  if (Array.isArray(value)) return value.map(canonicalJSONValue);
+  if (!isObject(value)) return value;
+  return Object.fromEntries(
+    Object.keys(value)
+      .sort()
+      .map((key) => [key, canonicalJSONValue(value[key])]),
+  );
+}
+
+export function canonicalJSONSHA256(document) {
+  return createHash("sha256")
+    .update(`${JSON.stringify(canonicalJSONValue(document))}\n`)
+    .digest("hex");
+}
+
+// Event-driven merge/main producers cannot share a coordinator-generated
+// random value, so their correlation nonce is deterministically namespaced by
+// posture and the exact projected Git objects. Release qualification must pass
+// an explicit, per-invocation random nonce instead; callers may not derive one
+// through this helper for release evidence.
+export function deriveQualificationCorrelationNonce({ posture, source }) {
+  const problems = [];
+  if (posture !== "merge" && posture !== "main") {
+    problems.push("derived qualification correlation is only valid for merge or main posture");
+  }
+  validateSource(source, "qualification correlation source", problems);
+  if (problems.length > 0) {
+    throw new ContractError("invalid qualification correlation", problems);
+  }
+  return canonicalJSONSHA256({
+    domain: "ci-lane-qualification",
+    posture,
+    source: { sha: source.sha, tree: source.tree },
+  });
+}
+
+export function nativeArtifactName(workflow, run) {
+  const basename = String(workflow ?? "")
+    .replace(/^.*\//, "")
+    .replace(/\.ya?ml$/, "")
+    .replace(/[^A-Za-z0-9_.-]+/g, "-");
+  return `ci-native-${basename}-${run.id}-${run.attempt}`;
+}
+
 function validateDigest(value, path, problems, { required = false } = {}) {
   if (value === null) {
     if (required) problems.push(`${path} is required`);
@@ -1226,6 +1369,12 @@ export function validateSelection(document, registry, expected = {}) {
     "selection.candidate_digest",
     problems,
   );
+  stringValue(
+    document.correlation_nonce,
+    "selection.correlation_nonce",
+    problems,
+    { pattern: CORRELATION_NONCE_RE },
+  );
   validateRun(document.run, "selection.run", problems);
 
   if (expected.posture !== undefined && document.posture !== expected.posture) {
@@ -1249,6 +1398,14 @@ export function validateSelection(document, registry, expected = {}) {
   ) {
     problems.push(
       `selection.candidate_digest is ${document.candidate_digest}, want ${expected.candidateDigest}`,
+    );
+  }
+  if (
+    expected.correlationNonce !== undefined &&
+    document.correlation_nonce !== expected.correlationNonce
+  ) {
+    problems.push(
+      `selection.correlation_nonce is ${document.correlation_nonce}, want ${expected.correlationNonce}`,
     );
   }
   if (expected.runID !== undefined && document.run?.id !== expected.runID) {
@@ -1472,21 +1629,20 @@ export function validateSelection(document, registry, expected = {}) {
           (path) => typeof path === "string",
         )
       : [];
-    const impactLanes = registry.lanes.filter(
-      (lane) => lane.merge_posture === "impact",
+    const conditionalLanes = registry.lanes.filter(
+      (lane) =>
+        lane.merge_posture === "impact" ||
+        lane.merge_posture === "non_documentation",
     );
-    const nonDocumentationLanes = registry.lanes.filter(
-      (lane) => lane.merge_posture === "non_documentation",
-    );
-    const impacted = new Set();
+    const directlyImpacted = new Set();
     const computedUnknown = [];
     const knownNonimpactGlobs =
       registry.impact_selection?.known_nonimpact_globs ?? [];
     for (const path of changedPaths) {
-      const matching = impactLanes.filter((lane) =>
+      const matching = conditionalLanes.filter((lane) =>
         lane.package_globs.some((glob) => matchesGlob(path, glob)),
       );
-      for (const lane of matching) impacted.add(lane.id);
+      for (const lane of matching) directlyImpacted.add(lane.id);
       if (
         matching.length === 0 &&
         !knownNonimpactGlobs.some((glob) => matchesGlob(path, glob))
@@ -1508,26 +1664,43 @@ export function validateSelection(document, registry, expected = {}) {
       );
     }
     if (document.selector.conclusion === "success") {
-      for (const laneID of impacted) {
-        if (selected.get(laneID)?.disposition !== "selected") {
-          problems.push(`selector success must select impacted lane ${laneID}`);
-        }
-      }
-      for (const lane of nonDocumentationLanes) {
-        const required = changedPaths.some(
-          (path) =>
-            !knownNonimpactGlobs.some((glob) => matchesGlob(path, glob)) ||
-            lane.package_globs.some((glob) => matchesGlob(path, glob)),
+      const docsOnly =
+        changedPaths.length > 0 &&
+        changedPaths.every((path) =>
+          knownNonimpactGlobs.some((glob) => matchesGlob(path, glob)),
         );
-        if (required && selected.get(lane.id)?.disposition !== "selected") {
+      for (const lane of conditionalLanes) {
+        const item = selected.get(lane.id);
+        const directHit = directlyImpacted.has(lane.id);
+        const shouldSelect =
+          directHit ||
+          (lane.merge_posture === "non_documentation" && !docsOnly);
+        if (shouldSelect && item?.disposition !== "selected") {
+          const kind =
+            lane.merge_posture === "non_documentation"
+              ? "non-documentation"
+              : "impacted";
+          problems.push(`selector success must select ${kind} lane ${lane.id}`);
+          continue;
+        }
+        if (!shouldSelect && item?.disposition === "selected") {
           problems.push(
-            `selector success must select non-documentation lane ${lane.id}`,
+            `selector success must omit unimpacted lane ${lane.id}`,
           );
+          continue;
+        }
+        if (!shouldSelect && item?.disposition === "omitted") {
+          const expectedReason = docsOnly ? "docs_only" : "not_impacted";
+          if (item.reason !== expectedReason) {
+            problems.push(
+              `selector success must omit ${lane.id} as ${expectedReason}`,
+            );
+          }
         }
       }
     }
     if (document.selector.conclusion === "fallback_full") {
-      for (const lane of [...impactLanes, ...nonDocumentationLanes]) {
+      for (const lane of conditionalLanes) {
         if (selected.get(lane.id)?.disposition !== "selected") {
           problems.push(`fallback_full must select ${lane.id}`);
         }
@@ -1573,6 +1746,21 @@ export function validateSelection(document, registry, expected = {}) {
   }
   if (document.posture !== "release" && document.candidate_digest !== null) {
     problems.push("only release selection may bind a candidate digest");
+  }
+  if (document.posture === "merge" || document.posture === "main") {
+    try {
+      const derived = deriveQualificationCorrelationNonce({
+        posture: document.posture,
+        source: document.source,
+      });
+      if (document.correlation_nonce !== derived) {
+        problems.push(
+          `${document.posture} selection.correlation_nonce does not match its projected Git objects`,
+        );
+      }
+    } catch (error) {
+      if (!(error instanceof ContractError)) throw error;
+    }
   }
 
   if (problems.length > 0)
@@ -1629,7 +1817,17 @@ export function validateReport(document, registry) {
     "report.candidate_digest",
     problems,
   );
-  validateRun(document.run, "report.run", problems);
+  stringValue(
+    document.correlation_nonce,
+    "report.correlation_nonce",
+    problems,
+    { pattern: CORRELATION_NONCE_RE },
+  );
+  validateSelectionRef(
+    document.selection_ref,
+    "report.selection_ref",
+    problems,
+  );
   enumValue(
     document.conclusion,
     REPORT_CONCLUSIONS,
@@ -1659,6 +1857,39 @@ export function validateReport(document, registry) {
     }
     if (document.producer.job !== lane.owner.context_job) {
       problems.push("report.producer.job must be the registry context_job");
+    }
+    validateRun(document.producer.run, "report.producer.run", problems);
+    validateArtifact(
+      document.producer.artifact,
+      PRODUCER_ARTIFACT_KEYS,
+      "report.producer.artifact",
+      problems,
+    );
+    if (
+      isObject(document.producer.run) &&
+      isObject(document.producer.artifact)
+    ) {
+      const expectedArtifactName = nativeArtifactName(
+        document.producer.workflow,
+        document.producer.run,
+      );
+      if (document.producer.artifact.name !== expectedArtifactName) {
+        problems.push(
+          `report.producer.artifact.name must be ${expectedArtifactName}`,
+        );
+      }
+      const expectedEntry = `${document.lane_id}/${document.execution_id}`;
+      if (document.producer.artifact.entry !== expectedEntry) {
+        problems.push(
+          `report.producer.artifact.entry must be ${expectedEntry}`,
+        );
+      }
+      stringValue(
+        document.producer.artifact.entry_sha256,
+        "report.producer.artifact.entry_sha256",
+        problems,
+        { pattern: SHA256_RE },
+      );
     }
   }
 
@@ -1818,30 +2049,232 @@ export function validateReport(document, registry) {
   return document;
 }
 
-export function validateJobResults(document, registry) {
-  const problems = [];
-  if (!isObject(document))
-    throw new ContractError("invalid trusted job results", [
-      "root must be an object",
-    ]);
-  const known = new Set(
-    registry.lanes.flatMap((lane) =>
-      lane.owner.jobs.map((job) => `${lane.owner.workflow}#${job}`),
-    ),
-  );
-  for (const [key, value] of Object.entries(document)) {
-    if (!known.has(key))
+export function validateEventIdentity(value, path, problems) {
+  if (!exactObject(value, EVENT_IDENTITY_KEYS, path, problems)) return;
+  enumValue(value.kind, EVENT_KINDS, `${path}.kind`, problems);
+  if (value.pr_number !== null) {
+    integerValue(value.pr_number, `${path}.pr_number`, problems, { min: 1 });
+  }
+  stringValue(value.event_head_sha, `${path}.event_head_sha`, problems, {
+    pattern: SHA_RE,
+  });
+  if (value.event_base_sha !== null) {
+    stringValue(value.event_base_sha, `${path}.event_base_sha`, problems, {
+      pattern: SHA_RE,
+    });
+  }
+  stringValue(value.projected_sha, `${path}.projected_sha`, problems, {
+    pattern: SHA_RE,
+  });
+  if (value.kind === "pull_request") {
+    if (value.pr_number === null)
+      problems.push(`${path}.pr_number is required for pull_request`);
+    if (value.event_base_sha === null)
+      problems.push(`${path}.event_base_sha is required for pull_request`);
+  } else if (value.pr_number !== null) {
+    problems.push(`${path}.pr_number must be null outside pull_request`);
+  }
+  if (value.kind === "merge_group") {
+    if (value.event_base_sha === null)
+      problems.push(`${path}.event_base_sha is required for merge_group`);
+    if (value.event_head_sha !== value.projected_sha) {
       problems.push(
-        `job result key ${key} does not name a registered owner job`,
+        `${path}.event_head_sha must equal projected_sha for merge_group`,
       );
-    const at = `job_results[${JSON.stringify(key)}]`;
-    if (!exactObject(value, JOB_RESULT_KEYS, at, problems)) continue;
-    enumValue(value.conclusion, JOB_CONCLUSIONS, `${at}.conclusion`, problems);
-    stringValue(value.run_id, `${at}.run_id`, problems, { pattern: RUN_ID_RE });
-    integerValue(value.run_attempt, `${at}.run_attempt`, problems, { min: 1 });
+    }
+  }
+}
+
+export function validateProducerManifest(document, registry) {
+  const problems = [];
+  if (!exactObject(document, PRODUCER_MANIFEST_KEYS, "producer_manifest", problems)) {
+    throw new ContractError("invalid trusted producer manifest", problems);
+  }
+  if (document.schema_version !== REPORT_SCHEMA_VERSION) {
+    problems.push(
+      `producer_manifest.schema_version must be ${REPORT_SCHEMA_VERSION}`,
+    );
+  }
+  stringValue(
+    document.correlation_nonce,
+    "producer_manifest.correlation_nonce",
+    problems,
+    { pattern: CORRELATION_NONCE_RE },
+  );
+  validateSelectionRef(
+    document.selection_ref,
+    "producer_manifest.selection_ref",
+    problems,
+  );
+
+  const knownWorkflows = new Set(
+    registry.lanes.map((lane) => lane.owner.workflow),
+  );
+  const knownJobs = new Map();
+  const knownEntries = new Map();
+  for (const lane of registry.lanes) {
+    if (!knownJobs.has(lane.owner.workflow))
+      knownJobs.set(lane.owner.workflow, new Set());
+    for (const job of lane.owner.jobs)
+      knownJobs.get(lane.owner.workflow).add(job);
+    if (!knownEntries.has(lane.owner.workflow))
+      knownEntries.set(lane.owner.workflow, new Set());
+    for (const executionID of lane.executions) {
+      knownEntries
+        .get(lane.owner.workflow)
+        .add(`${lane.id}/${executionID}`);
+    }
+  }
+  if (!Array.isArray(document.producers)) {
+    problems.push("producer_manifest.producers must be an array");
+  } else {
+    const workflows = new Set();
+    for (let i = 0; i < document.producers.length; i += 1) {
+      const producer = document.producers[i];
+      const at = `producer_manifest.producers[${i}]`;
+      if (!exactObject(producer, TRUSTED_PRODUCER_KEYS, at, problems))
+        continue;
+      if (
+        stringValue(producer.workflow, `${at}.workflow`, problems) &&
+        !knownWorkflows.has(producer.workflow)
+      ) {
+        problems.push(`${at}.workflow is not registered`);
+      }
+      if (workflows.has(producer.workflow)) {
+        problems.push(
+          `${at}.workflow duplicates ${producer.workflow}; the collector must choose exactly one newest run/attempt`,
+        );
+      }
+      workflows.add(producer.workflow);
+      validateRun(producer.run, `${at}.run`, problems);
+      validateSource(producer.source, `${at}.source`, problems);
+      stringValue(
+        producer.correlation_nonce,
+        `${at}.correlation_nonce`,
+        problems,
+        { pattern: CORRELATION_NONCE_RE },
+      );
+      if (producer.correlation_nonce !== document.correlation_nonce) {
+        problems.push(
+          `${at}.correlation_nonce does not match producer_manifest.correlation_nonce`,
+        );
+      }
+      validateEventIdentity(producer.event, `${at}.event`, problems);
+      stringValue(producer.repository, `${at}.repository`, problems, {
+        pattern: REPOSITORY_RE,
+      });
+      enumValue(
+        producer.conclusion,
+        JOB_CONCLUSIONS,
+        `${at}.conclusion`,
+        problems,
+      );
+
+      if (!Array.isArray(producer.jobs) || producer.jobs.length === 0) {
+        problems.push(`${at}.jobs must be a non-empty array`);
+      } else {
+        const jobs = new Set();
+        for (let j = 0; j < producer.jobs.length; j += 1) {
+          const job = producer.jobs[j];
+          const jobAt = `${at}.jobs[${j}]`;
+          if (!exactObject(job, TRUSTED_JOB_KEYS, jobAt, problems)) continue;
+          if (
+            stringValue(job.job, `${jobAt}.job`, problems, {
+              pattern: WORKFLOW_JOB_ID_RE,
+            }) &&
+            !knownJobs.get(producer.workflow)?.has(job.job)
+          ) {
+            problems.push(`${jobAt}.job is not registered for the workflow`);
+          }
+          if (jobs.has(job.job)) problems.push(`${jobAt}.job is duplicated`);
+          jobs.add(job.job);
+          stringValue(job.name, `${jobAt}.name`, problems);
+          stringValue(job.database_id, `${jobAt}.database_id`, problems, {
+            pattern: RUN_ID_RE,
+          });
+          enumValue(
+            job.conclusion,
+            JOB_CONCLUSIONS,
+            `${jobAt}.conclusion`,
+            problems,
+          );
+        }
+      }
+
+      if (!Array.isArray(producer.artifacts) || producer.artifacts.length !== 1) {
+        problems.push(`${at}.artifacts must contain exactly one native bundle`);
+      } else {
+        const artifactIDs = new Set();
+        const artifactNames = new Set();
+        for (let j = 0; j < producer.artifacts.length; j += 1) {
+          const artifact = producer.artifacts[j];
+          const artifactAt = `${at}.artifacts[${j}]`;
+          validateArtifact(
+            artifact,
+            TRUSTED_ARTIFACT_KEYS,
+            artifactAt,
+            problems,
+          );
+          const expectedName = nativeArtifactName(
+            producer.workflow,
+            producer.run,
+          );
+          if (artifact?.name !== expectedName) {
+            problems.push(`${artifactAt}.name must be ${expectedName}`);
+          }
+          if (!Array.isArray(artifact?.entries) || artifact.entries.length === 0) {
+            problems.push(`${artifactAt}.entries must be a non-empty array`);
+          } else {
+            const entries = new Set();
+            for (let k = 0; k < artifact.entries.length; k += 1) {
+              const entry = artifact.entries[k];
+              const entryAt = `${artifactAt}.entries[${k}]`;
+              if (
+                !exactObject(
+                  entry,
+                  TRUSTED_ARTIFACT_ENTRY_KEYS,
+                  entryAt,
+                  problems,
+                )
+              ) {
+                continue;
+              }
+              stringValue(entry.lane_id, `${entryAt}.lane_id`, problems, {
+                pattern: LANE_ID_RE,
+              });
+              stringValue(
+                entry.execution_id,
+                `${entryAt}.execution_id`,
+                problems,
+                { pattern: EXECUTION_ID_RE },
+              );
+              stringValue(entry.sha256, `${entryAt}.sha256`, problems, {
+                pattern: SHA256_RE,
+              });
+              const identity = `${entry.lane_id}/${entry.execution_id}`;
+              if (entries.has(identity)) {
+                problems.push(`${entryAt} duplicates native entry ${identity}`);
+              }
+              if (!knownEntries.get(producer.workflow)?.has(identity)) {
+                problems.push(
+                  `${entryAt} is not registered for ${producer.workflow}`,
+                );
+              }
+              entries.add(identity);
+            }
+          }
+          if (artifactIDs.has(artifact?.id))
+            problems.push(`${artifactAt}.id is duplicated`);
+          if (artifactNames.has(artifact?.name))
+            problems.push(`${artifactAt}.name is duplicated`);
+          artifactIDs.add(artifact?.id);
+          artifactNames.add(artifact?.name);
+        }
+      }
+    }
   }
   if (problems.length > 0)
-    throw new ContractError("invalid trusted job results", problems);
+    throw new ContractError("invalid trusted producer manifest", problems);
   return document;
 }
 
@@ -1868,12 +2301,42 @@ function validateQualificationExpectations(expected, registry, selection) {
   enumValue(expected.posture, SELECTION_POSTURES, "expected.posture", problems);
   stringValue(expected.sha, "expected.sha", problems, { pattern: SHA_RE });
   stringValue(expected.tree, "expected.tree", problems, { pattern: SHA_RE });
+  stringValue(
+    expected.correlationNonce,
+    "expected.correlationNonce",
+    problems,
+    { pattern: CORRELATION_NONCE_RE },
+  );
   stringValue(expected.runID, "expected.runID", problems, {
     pattern: RUN_ID_RE,
   });
   integerValue(expected.runAttempt, "expected.runAttempt", problems, {
     min: 1,
   });
+  stringValue(
+    expected.selectionManifestSHA256,
+    "expected.selectionManifestSHA256",
+    problems,
+    { pattern: SHA256_RE },
+  );
+  validateEventIdentity(
+    expected.eventIdentity,
+    "expected.eventIdentity",
+    problems,
+  );
+  stringValue(expected.repository, "expected.repository", problems, {
+    pattern: REPOSITORY_RE,
+  });
+  if (expected.eventIdentity?.projected_sha !== expected.sha) {
+    problems.push(
+      "expected.eventIdentity.projected_sha must equal expected.sha",
+    );
+  }
+  if (selection?.correlation_nonce !== expected.correlationNonce) {
+    problems.push(
+      "expected.correlationNonce must equal selection.correlation_nonce",
+    );
+  }
 
   if (expected.candidateDigest !== undefined) {
     validateDigest(
@@ -1896,6 +2359,23 @@ function validateQualificationExpectations(expected, registry, selection) {
       "expected.changedPaths",
       problems,
     );
+    if (
+      expected.eventIdentity?.kind !== "pull_request" &&
+      expected.eventIdentity?.kind !== "merge_group"
+    ) {
+      problems.push(
+        "merge qualification event must be pull_request or merge_group",
+      );
+    }
+    if (
+      (expected.eventIdentity?.kind === "pull_request" ||
+        expected.eventIdentity?.kind === "merge_group") &&
+      expected.eventIdentity.event_base_sha !== expected.baseSHA
+    ) {
+      problems.push(
+        "expected.eventIdentity.event_base_sha must equal expected.baseSHA for merge qualification",
+      );
+    }
   }
 
   const selectedIDs = new Set(
@@ -1927,17 +2407,48 @@ export function validateReportSet({
   registry,
   selection,
   reports,
-  jobResults,
+  producerManifest,
   expected = {},
 }) {
   validateQualificationExpectations(expected, registry, selection);
   validateSelection(selection, registry, expected);
-  validateJobResults(jobResults, registry);
+  validateProducerManifest(producerManifest, registry);
   const problems = [];
+  const computedSelectionDigest = selectionManifestSHA256(selection);
+  if (computedSelectionDigest !== expected.selectionManifestSHA256) {
+    problems.push(
+      "selection manifest SHA-256 does not match the trusted expected digest",
+    );
+  }
+  const selectionRef = {
+    run: selection.run,
+    manifest_sha256: expected.selectionManifestSHA256,
+  };
+  if (
+    producerManifest.selection_ref.run.id !== selectionRef.run.id ||
+    producerManifest.selection_ref.run.attempt !== selectionRef.run.attempt ||
+    producerManifest.selection_ref.manifest_sha256 !==
+      selectionRef.manifest_sha256
+  ) {
+    problems.push(
+      "trusted producer manifest selection_ref does not match the current selection",
+    );
+  }
+  if (
+    producerManifest.correlation_nonce !== selection.correlation_nonce ||
+    producerManifest.correlation_nonce !== expected.correlationNonce
+  ) {
+    problems.push(
+      "trusted producer manifest correlation_nonce does not match the current qualification",
+    );
+  }
+
   const lanesByID = new Map(registry.lanes.map((lane) => [lane.id, lane]));
   const expectedReports = new Map();
+  const expectedWorkflows = new Set();
   for (const item of selection.lanes) {
     if (item.disposition !== "selected") continue;
+    expectedWorkflows.add(lanesByID.get(item.lane_id).owner.workflow);
     for (const execution of item.executions) {
       expectedReports.set(`${item.lane_id}/${execution}`, {
         lane: lanesByID.get(item.lane_id),
@@ -1946,7 +2457,49 @@ export function validateReportSet({
     }
   }
 
+  const trustedByWorkflow = new Map();
+  for (const producer of producerManifest.producers) {
+    trustedByWorkflow.set(producer.workflow, producer);
+    if (!expectedWorkflows.has(producer.workflow)) {
+      problems.push(
+        `unexpected trusted producer workflow ${producer.workflow}; no selected lane owns it`,
+      );
+    }
+    if (
+      producer.source.sha !== selection.source.sha ||
+      producer.source.tree !== selection.source.tree
+    ) {
+      problems.push(
+        `${producer.workflow}: trusted producer projected SHA/tree does not match the selection`,
+      );
+    }
+    if (
+      EVENT_IDENTITY_KEYS.size !== Object.keys(producer.event).length ||
+      [...EVENT_IDENTITY_KEYS].some(
+        (key) => producer.event[key] !== expected.eventIdentity[key],
+      )
+    ) {
+      problems.push(
+        `${producer.workflow}: trusted producer event identity does not match the qualification event`,
+      );
+    }
+    if (producer.repository !== expected.repository) {
+      problems.push(
+        `${producer.workflow}: trusted producer repository does not match the qualification repository`,
+      );
+    }
+    // Workflow-level conclusion is telemetry, not a lane verdict. A workflow
+    // may contain an unselected red job alongside a selected green lane; only
+    // the selected context and its native entry decide qualification.
+  }
+  for (const workflow of expectedWorkflows) {
+    if (!trustedByWorkflow.has(workflow)) {
+      problems.push(`trusted producer run for ${workflow} is missing`);
+    }
+  }
+
   const actual = new Map();
+  const claimedEntries = new Set();
   for (let i = 0; i < reports.length; i += 1) {
     let report;
     try {
@@ -1986,12 +2539,18 @@ export function validateReportSet({
         `${identity}: source SHA/tree does not match the selection`,
       );
     }
-    if (report.run.id !== selection.run.id) {
-      problems.push(`${identity}: report run id does not match the selection`);
-    }
-    if (report.run.attempt !== selection.run.attempt) {
+    if (
+      report.selection_ref.run.id !== selectionRef.run.id ||
+      report.selection_ref.run.attempt !== selectionRef.run.attempt ||
+      report.selection_ref.manifest_sha256 !== selectionRef.manifest_sha256
+    ) {
       problems.push(
-        `${identity}: report run attempt does not match the selection`,
+        `${identity}: selection_ref does not match the current selection`,
+      );
+    }
+    if (report.correlation_nonce !== selection.correlation_nonce) {
+      problems.push(
+        `${identity}: correlation_nonce does not match the current qualification`,
       );
     }
     const mode = expectedInvocationMode(lane, selection.posture);
@@ -2034,41 +2593,98 @@ export function validateReportSet({
       problems.push(`${identity}: seeded lane omitted its seed`);
     }
 
-    for (const job of lane.owner.jobs) {
-      const key = `${lane.owner.workflow}#${job}`;
-      const trusted = jobResults[key];
-      if (!trusted) {
-        problems.push(`${identity}: trusted result for ${key} is missing`);
-        continue;
-      }
-      if (trusted.conclusion !== "success") {
+    const trusted = trustedByWorkflow.get(report.producer.workflow);
+    if (!trusted) continue;
+    if (
+      report.producer.run.id !== trusted.run.id ||
+      report.producer.run.attempt !== trusted.run.attempt
+    ) {
+      problems.push(
+        `${identity}: producer run identity does not match the trusted workflow run`,
+      );
+    }
+    const context = trusted.jobs.find(
+      (job) => job.job === report.producer.job,
+    );
+    if (!context) {
+      problems.push(
+        `${identity}: trusted context job ${report.producer.job} is missing`,
+      );
+    } else {
+      const contextNameMatches =
+        lane.context.match === "exact"
+          ? context.name === lane.context.name
+          : context.name.startsWith(lane.context.name);
+      if (!contextNameMatches) {
         problems.push(
-          `${identity}: trusted result for ${key} is ${trusted.conclusion}`,
+          `${identity}: trusted context check name ${context.name} does not match ${lane.context.name}`,
         );
       }
-      if (
-        trusted.run_id !== selection.run.id ||
-        trusted.run_attempt !== selection.run.attempt
-      ) {
+      if (context.conclusion !== "success") {
         problems.push(
-          `${identity}: trusted result for ${key} does not match the selection run`,
+          `${identity}: trusted context job ${report.producer.job} is ${context.conclusion}`,
         );
-      }
-      if (job === lane.owner.context_job) {
-        if (
-          trusted.run_id !== report.run.id ||
-          trusted.run_attempt !== report.run.attempt
-        ) {
-          problems.push(
-            `${identity}: producer run identity does not match trusted ${key}`,
-          );
-        }
       }
     }
+    const artifact = trusted.artifacts.find(
+      (candidate) => candidate.id === report.producer.artifact.id,
+    );
+    if (!artifact) {
+      problems.push(
+        `${identity}: trusted artifact ${report.producer.artifact.id} is missing`,
+      );
+    } else if (
+      artifact.name !== report.producer.artifact.name ||
+      artifact.sha256 !== report.producer.artifact.sha256
+    ) {
+      problems.push(
+        `${identity}: producer artifact name or SHA-256 does not match trusted API provenance`,
+      );
+    } else {
+      const entry = artifact.entries.find(
+        (candidate) =>
+          candidate.lane_id === report.lane_id &&
+          candidate.execution_id === report.execution_id,
+      );
+      if (!entry) {
+        problems.push(
+          `${identity}: trusted native bundle entry is missing`,
+        );
+      } else if (
+        entry.sha256 !== report.producer.artifact.entry_sha256
+      ) {
+        problems.push(
+          `${identity}: native bundle entry SHA-256 does not match trusted provenance`,
+        );
+      }
+    }
+    const entryIdentity =
+      `${report.producer.workflow}#${report.producer.run.id}#` +
+      `${report.producer.run.attempt}#${report.producer.artifact.id}#` +
+      `${report.producer.artifact.entry}`;
+    if (claimedEntries.has(entryIdentity)) {
+      problems.push(`${identity}: native bundle entry is reused by another report`);
+    }
+    claimedEntries.add(entryIdentity);
   }
 
   for (const identity of expectedReports.keys()) {
     if (!actual.has(identity)) problems.push(`missing report ${identity}`);
+  }
+  for (const workflow of expectedWorkflows) {
+    const producer = trustedByWorkflow.get(workflow);
+    if (producer?.artifacts.length !== 1) continue;
+    const artifact = producer.artifacts[0];
+    const consumed = [...claimedEntries].some((identity) =>
+      identity.startsWith(
+        `${workflow}#${producer.run.id}#${producer.run.attempt}#${artifact.id}#`,
+      ),
+    );
+    if (!consumed) {
+      problems.push(
+        `${workflow}: trusted native artifact ${artifact.name} was not consumed by a selected report`,
+      );
+    }
   }
   if (problems.length > 0)
     throw new ContractError("CI lane qualification failed closed", problems);
@@ -2154,13 +2770,25 @@ export function qualificationExpectations(env = process.env) {
   const posture = env.CI_LANE_POSTURE;
   const sha = env.CI_EXPECT_SHA;
   const tree = env.CI_EXPECT_TREE;
+  const correlationNonce = env.CI_EXPECT_CORRELATION_NONCE;
   const runID = env.CI_EXPECT_RUN_ID;
+  const selectionManifestSHA256 = env.CI_EXPECT_SELECTION_SHA256;
+  const eventKind = env.CI_EXPECT_EVENT_KIND;
+  const eventHeadSHA = env.CI_EXPECT_EVENT_HEAD_SHA;
+  const projectedSHA = env.CI_EXPECT_PROJECTED_SHA;
+  const repository = env.CI_EXPECT_REPOSITORY;
   for (const [name, value] of [
     ["CI_LANE_POSTURE", posture],
     ["CI_EXPECT_SHA", sha],
     ["CI_EXPECT_TREE", tree],
+    ["CI_EXPECT_CORRELATION_NONCE", correlationNonce],
     ["CI_EXPECT_RUN_ID", runID],
     ["CI_EXPECT_RUN_ATTEMPT", env.CI_EXPECT_RUN_ATTEMPT],
+    ["CI_EXPECT_SELECTION_SHA256", selectionManifestSHA256],
+    ["CI_EXPECT_EVENT_KIND", eventKind],
+    ["CI_EXPECT_EVENT_HEAD_SHA", eventHeadSHA],
+    ["CI_EXPECT_PROJECTED_SHA", projectedSHA],
+    ["CI_EXPECT_REPOSITORY", repository],
   ]) {
     if (typeof value !== "string" || value === "")
       problems.push(`${name} is required`);
@@ -2168,7 +2796,22 @@ export function qualificationExpectations(env = process.env) {
   enumValue(posture, SELECTION_POSTURES, "CI_LANE_POSTURE", problems);
   stringValue(sha, "CI_EXPECT_SHA", problems, { pattern: SHA_RE });
   stringValue(tree, "CI_EXPECT_TREE", problems, { pattern: SHA_RE });
+  stringValue(
+    correlationNonce,
+    "CI_EXPECT_CORRELATION_NONCE",
+    problems,
+    { pattern: CORRELATION_NONCE_RE },
+  );
   stringValue(runID, "CI_EXPECT_RUN_ID", problems, { pattern: RUN_ID_RE });
+  stringValue(
+    selectionManifestSHA256,
+    "CI_EXPECT_SELECTION_SHA256",
+    problems,
+    { pattern: SHA256_RE },
+  );
+  stringValue(repository, "CI_EXPECT_REPOSITORY", problems, {
+    pattern: REPOSITORY_RE,
+  });
 
   let runAttempt;
   if (env.CI_EXPECT_RUN_ATTEMPT !== undefined) {
@@ -2187,6 +2830,29 @@ export function qualificationExpectations(env = process.env) {
   ) {
     candidateDigest = env.CI_EXPECT_CANDIDATE_DIGEST;
     validateDigest(candidateDigest, "CI_EXPECT_CANDIDATE_DIGEST", problems);
+  }
+
+  let prNumber = null;
+  if (env.CI_EXPECT_PR_NUMBER !== undefined && env.CI_EXPECT_PR_NUMBER !== "") {
+    if (!/^[1-9][0-9]*$/.test(env.CI_EXPECT_PR_NUMBER)) {
+      problems.push("CI_EXPECT_PR_NUMBER must be a canonical positive integer");
+    } else {
+      prNumber = Number(env.CI_EXPECT_PR_NUMBER);
+      if (!Number.isSafeInteger(prNumber)) {
+        problems.push("CI_EXPECT_PR_NUMBER exceeds JavaScript's safe integer range");
+      }
+    }
+  }
+  const eventIdentity = {
+    kind: eventKind,
+    pr_number: prNumber,
+    event_head_sha: eventHeadSHA,
+    event_base_sha: env.CI_EXPECT_EVENT_BASE_SHA || null,
+    projected_sha: projectedSHA,
+  };
+  validateEventIdentity(eventIdentity, "CI event identity", problems);
+  if (projectedSHA !== sha) {
+    problems.push("CI_EXPECT_PROJECTED_SHA must equal CI_EXPECT_SHA");
   }
   if (posture === "release" && candidateDigest === undefined) {
     problems.push(
@@ -2235,9 +2901,13 @@ export function qualificationExpectations(env = process.env) {
     posture,
     sha,
     tree,
+    correlationNonce,
     candidateDigest,
     runID,
     runAttempt,
+    selectionManifestSHA256,
+    eventIdentity,
+    repository,
     baseSHA,
     changedPaths,
   };
@@ -2264,7 +2934,7 @@ function main() {
 
   const selectionPath = process.env.CI_LANE_SELECTION;
   const reportDir = process.env.CI_LANE_REPORT_DIR;
-  const rawResults = process.env.CI_LANE_JOB_RESULTS_JSON;
+  const producerManifestPath = process.env.CI_LANE_PRODUCER_MANIFEST;
   if (!selectionPath)
     throw new ContractError("CI lane contract", [
       "CI_LANE_SELECTION is required",
@@ -2273,17 +2943,9 @@ function main() {
     throw new ContractError("CI lane contract", [
       "CI_LANE_REPORT_DIR is required",
     ]);
-  if (!rawResults) {
+  if (!producerManifestPath) {
     throw new ContractError("CI lane contract", [
-      "CI_LANE_JOB_RESULTS_JSON is required",
-    ]);
-  }
-  let jobResults;
-  try {
-    jobResults = JSON.parse(rawResults);
-  } catch (error) {
-    throw new ContractError("CI lane contract", [
-      `CI_LANE_JOB_RESULTS_JSON is not valid JSON: ${error.message}`,
+      "CI_LANE_PRODUCER_MANIFEST is required",
     ]);
   }
   const reportsWithPaths = readReports(resolve(root, reportDir));
@@ -2291,7 +2953,10 @@ function main() {
     registry,
     selection: parseJSONFile(resolve(root, selectionPath), "CI lane selection"),
     reports: reportsWithPaths.map((entry) => entry.document),
-    jobResults,
+    producerManifest: parseJSONFile(
+      resolve(root, producerManifestPath),
+      "trusted producer manifest",
+    ),
     expected: qualificationExpectations(process.env),
   });
   process.stdout.write(

--- a/.github/scripts/ci-lane-contract.test.mjs
+++ b/.github/scripts/ci-lane-contract.test.mjs
@@ -247,12 +247,36 @@ function registryFixture() {
     report_schema_version: REPORT_SCHEMA_VERSION,
     rollout: "shadow",
     impact_selection: { known_nonimpact_globs: ["**/*.md", "docs/**"] },
+    native_evidence: {
+      schema_version: 1,
+      parts: [
+        {
+          id: "always-go",
+          lane_id: "always",
+          execution_id: "default",
+          invocation_mode: "source_tree",
+          producer_job: "lint",
+          parser: "go-test-json-v1",
+          entry: "go-test.json",
+        },
+        {
+          id: "impact-tap",
+          lane_id: "impact",
+          execution_id: "shard-a",
+          invocation_mode: "source_tree",
+          producer_job: "shard",
+          parser: "node-tap-v1",
+          entry: "node.tap",
+        },
+      ],
+    },
     layers: CANONICAL_LAYER_IDS.map((id) => ({ id, name: `Layer ${id}` })),
     lanes: [
       lane({
         id: "always",
         workflow: ".github/workflows/ci.yml",
         jobs: ["check", "lint"],
+        producerJobs: ["lint"],
         contextJob: "check",
         layers: CANONICAL_LAYER_IDS,
         recipes: ["test"],
@@ -507,7 +531,13 @@ function producerRunFor(workflow) {
   return PRODUCER_RUNS[workflow];
 }
 
-function nativeArtifactFor(workflow, laneID, executionID, run) {
+function nativeArtifactFor(
+  workflow,
+  laneID,
+  executionID,
+  invocationMode,
+  run,
+) {
   const ordinal = {
     ".github/workflows/ci.yml": 901,
     ".github/workflows/e2e.yml": 902,
@@ -524,7 +554,7 @@ function nativeArtifactFor(workflow, laneID, executionID, run) {
     id: String(ordinal),
     name: nativeArtifactName(workflow, run),
     sha256: String(ordinal % 10).repeat(64),
-    entry: `${laneID}/${executionID}`,
+    entry: `${laneID}/${executionID}/${invocationMode}`,
     entry_sha256: digestByte.repeat(64),
   };
 }
@@ -536,12 +566,24 @@ function selectionRefFor(selection) {
   };
 }
 
-function reportFor(registry, selection, laneID, executionID = "default") {
+function reportFor(
+  registry,
+  selection,
+  laneID,
+  executionID = "default",
+  invocationMode,
+) {
   const registered = registry.lanes.find(
     (candidate) => candidate.id === laneID,
   );
-  const candidateArtifact =
-    selection.posture === "release" && registered.applicability.artifact;
+  const mode =
+    invocationMode ??
+    (selection.posture === "release" &&
+    registered.applicability.artifact &&
+    !registered.applicability.source
+      ? "candidate_artifact"
+      : "source_tree");
+  const candidateArtifact = mode === "candidate_artifact";
   const producerRun = producerRunFor(registered.owner.workflow);
   return {
     schema_version: REPORT_SCHEMA_VERSION,
@@ -561,11 +603,12 @@ function reportFor(registry, selection, laneID, executionID = "default") {
         registered.owner.workflow,
         laneID,
         executionID,
+        mode,
         producerRun,
       ),
     },
     invocation: {
-      mode: candidateArtifact ? "candidate_artifact" : "source_tree",
+      mode,
       recipe: registered.recipes[0] ?? null,
       command: registered.command,
       build_tags: [...registered.build_tags],
@@ -605,6 +648,9 @@ function producerManifestFor(registry, selection) {
       });
     }
     const producer = producers.get(workflow);
+    const artifactMode = registered.applicability.source
+      ? "source_tree"
+      : "candidate_artifact";
     if (!producer.jobs.some((job) => job.job === registered.owner.context_job))
       producer.jobs.push({
         job: registered.owner.context_job,
@@ -614,30 +660,45 @@ function producerManifestFor(registry, selection) {
       });
     if (producer.artifacts.length === 0) {
       producer.artifacts.push({
-        id: nativeArtifactFor(workflow, item.lane_id, item.executions[0], run)
-          .id,
+        id: nativeArtifactFor(
+          workflow,
+          item.lane_id,
+          item.executions[0],
+          artifactMode,
+          run,
+        ).id,
         name: nativeArtifactName(workflow, run),
         sha256: nativeArtifactFor(
           workflow,
           item.lane_id,
           item.executions[0],
+          artifactMode,
           run,
         ).sha256,
         entries: [],
       });
     }
     for (const execution of item.executions) {
-      const reference = nativeArtifactFor(
-        workflow,
-        item.lane_id,
-        execution,
-        run,
-      );
-      producer.artifacts[0].entries.push({
-        lane_id: item.lane_id,
-        execution_id: execution,
-        sha256: reference.entry_sha256,
-      });
+      const modes = [];
+      if (registered.applicability.source) modes.push("source_tree");
+      if (selection.posture === "release" && registered.applicability.artifact) {
+        modes.push("candidate_artifact");
+      }
+      for (const mode of modes) {
+        const reference = nativeArtifactFor(
+          workflow,
+          item.lane_id,
+          execution,
+          mode,
+          run,
+        );
+        producer.artifacts[0].entries.push({
+          lane_id: item.lane_id,
+          execution_id: execution,
+          invocation_mode: mode,
+          sha256: reference.entry_sha256,
+        });
+      }
     }
   }
   return {
@@ -912,7 +973,7 @@ test("registry rejects invalid enums and invalid workflow job IDs", () => {
   }
 });
 
-test("registry producer jobs are unique owner jobs and exclude the terminal context", () => {
+test("registry producer jobs are unique owner jobs with an exact native-part roster", () => {
   const cases = [
     {
       producerJobs: ["shard", "shard"],
@@ -922,16 +983,20 @@ test("registry producer jobs are unique owner jobs and exclude the terminal cont
       producerJobs: ["ghost"],
       pattern: /producer_jobs contains ghost, which is not in owner\.jobs/,
     },
-    {
-      producerJobs: ["aggregate"],
-      pattern: /producer_jobs must exclude the context_job aggregate/,
-    },
   ];
   for (const { producerJobs, pattern } of cases) {
     const document = registryFixture();
     document.lanes[1].owner.producer_jobs = producerJobs;
     expectContractError(() => validateRegistry(document, { root }), pattern);
   }
+
+  const directContextProducer = registryFixture();
+  directContextProducer.lanes[1].owner.producer_jobs = ["aggregate"];
+  directContextProducer.native_evidence.parts[1].producer_job = "aggregate";
+  assert.equal(
+    validateRegistry(directContextProducer, { root }),
+    directContextProducer,
+  );
 });
 
 test("registry discovers and rejects an unclassified .yaml workflow", () => {
@@ -1689,7 +1754,7 @@ test("report set rejects artifact digest mismatch", () => {
         reports,
         producerManifest: producerManifestFor(registry, selection),
       }),
-    /release\/artifact: candidate digest does not match the selection/,
+    /release\/artifact\/candidate_artifact: candidate digest does not match the selection/,
   );
 });
 
@@ -1832,6 +1897,203 @@ test("release report set qualifies all release-required source and artifact lane
       producerManifest: producerManifestFor(registry, selection),
     }),
     { expected: 4, received: 4 },
+  );
+});
+
+test("canonical pre-publication qualification validates exactly 45 invocations", () => {
+  const registry = JSON.parse(readFileSync(".github/ci-lanes.json", "utf8"));
+  const selection = {
+    schema_version: registry.selection_schema_version,
+    registry_schema_version: registry.schema_version,
+    report_schema_version: registry.report_schema_version,
+    posture: "release",
+    source: { sha: SOURCE_SHA, tree: SOURCE_TREE },
+    candidate_digest: CANDIDATE_DIGEST,
+    correlation_nonce: RELEASE_CORRELATION_NONCE,
+    run: { ...RUN },
+    selector: {
+      conclusion: "success",
+      base_sha: null,
+      head_sha: null,
+      changed_paths: [],
+      unknown_paths: [],
+    },
+    lanes: registry.lanes.map((registered) => {
+      if (registered.release_posture === "post_publish") {
+        return {
+          lane_id: registered.id,
+          disposition: "omitted",
+          executions: [],
+          reason: "post_publish",
+        };
+      }
+      if (registered.determinism === "observational") {
+        return {
+          lane_id: registered.id,
+          disposition: "omitted",
+          executions: [],
+          reason: "advisory",
+        };
+      }
+      return {
+        lane_id: registered.id,
+        disposition: "selected",
+        executions: [...registered.executions],
+        reason: null,
+      };
+    }),
+  };
+  const selected = selection.lanes.filter(
+    (item) => item.disposition === "selected",
+  );
+  const workflows = [
+    ...new Set(
+      selected.map(
+        (item) =>
+          registry.lanes.find((lane) => lane.id === item.lane_id).owner
+            .workflow,
+      ),
+    ),
+  ].sort();
+  const producerRuns = new Map(
+    workflows.map((workflow, index) => [
+      workflow,
+      { id: String(5001 + index), attempt: 1 },
+    ]),
+  );
+  const producers = new Map(
+    workflows.map((workflow, index) => {
+      const run = producerRuns.get(workflow);
+      const digestByte = ((index % 15) + 1).toString(16);
+      return [
+        workflow,
+        {
+          workflow,
+          run,
+          source: { ...selection.source },
+          correlation_nonce: selection.correlation_nonce,
+          event: eventIdentityFor(selection),
+          repository: REPOSITORY,
+          conclusion: "success",
+          jobs: [],
+          artifacts: [
+            {
+              id: String(6001 + index),
+              name: nativeArtifactName(workflow, run),
+              sha256: digestByte.repeat(64),
+              entries: [],
+            },
+          ],
+        },
+      ];
+    }),
+  );
+  const reports = [];
+  for (const item of selected) {
+    const registered = registry.lanes.find(
+      (lane) => lane.id === item.lane_id,
+    );
+    const producer = producers.get(registered.owner.workflow);
+    if (
+      !producer.jobs.some(
+        (job) =>
+          job.job === registered.owner.context_job &&
+          job.name === registered.context.name,
+      )
+    ) {
+      producer.jobs.push({
+        job: registered.owner.context_job,
+        name: registered.context.name,
+        database_id: String(
+          700001 +
+            workflows.indexOf(registered.owner.workflow) * 100 +
+            producer.jobs.length,
+        ),
+        conclusion: "success",
+      });
+    }
+    const modes = [];
+    if (registered.applicability.source) modes.push("source_tree");
+    if (registered.applicability.artifact) {
+      modes.push("candidate_artifact");
+    }
+    for (const executionID of item.executions) {
+      for (const mode of modes) {
+        const entrySHA256 = ((reports.length % 15) + 1)
+          .toString(16)
+          .repeat(64);
+        producer.artifacts[0].entries.push({
+          lane_id: registered.id,
+          execution_id: executionID,
+          invocation_mode: mode,
+          sha256: entrySHA256,
+        });
+        reports.push({
+          schema_version: registry.report_schema_version,
+          registry_schema_version: registry.schema_version,
+          lane_id: registered.id,
+          execution_id: executionID,
+          posture: selection.posture,
+          source: { ...selection.source },
+          candidate_digest:
+            mode === "candidate_artifact"
+              ? selection.candidate_digest
+              : null,
+          correlation_nonce: selection.correlation_nonce,
+          selection_ref: selectionRefFor(selection),
+          producer: {
+            workflow: registered.owner.workflow,
+            job: registered.owner.context_job,
+            run: { ...producer.run },
+            artifact: {
+              id: producer.artifacts[0].id,
+              name: producer.artifacts[0].name,
+              sha256: producer.artifacts[0].sha256,
+              entry: `${registered.id}/${executionID}/${mode}`,
+              entry_sha256: entrySHA256,
+            },
+          },
+          invocation: {
+            mode,
+            recipe: registered.recipes[0] ?? null,
+            command: registered.command,
+            build_tags: [...registered.build_tags],
+            selected_domains: [registered.risk_domains[0]],
+          },
+          evidence: {
+            executed: 1,
+            passed: 1,
+            failed: 0,
+            skipped: 0,
+            duration_ms: 1,
+            seed:
+              registered.determinism === "seeded"
+                ? "canonical-release-seed"
+                : null,
+            corpus_id: `canonical-${registered.id}-${executionID}-${mode}`,
+          },
+          conclusion: "success",
+        });
+      }
+    }
+  }
+  const producerManifest = {
+    schema_version: registry.report_schema_version,
+    correlation_nonce: selection.correlation_nonce,
+    selection_ref: selectionRefFor(selection),
+    producers: [...producers.values()],
+  };
+
+  assert.equal(selected.length, 44);
+  assert.equal(reports.length, 45);
+  assert.deepEqual(
+    validateReportSet({
+      registry,
+      selection,
+      reports,
+      producerManifest,
+    }),
+    { expected: 45, received: 45 },
   );
 });
 

--- a/.github/scripts/ci-lane-contract.test.mjs
+++ b/.github/scripts/ci-lane-contract.test.mjs
@@ -19,12 +19,16 @@ import {
   CANONICAL_HEAD_ORACLE_FLOORS,
   ContractError,
   MERGE_P95_SLO_MINUTES,
+  REPORT_SCHEMA_VERSION,
   RELEASE_QUALIFICATION_SLO_MINUTES,
+  deriveQualificationCorrelationNonce,
   loadRegistry,
+  nativeArtifactName,
   parseExpectedRunAttempt,
   qualificationExpectations,
   renderSummary,
-  validateJobResults,
+  selectionManifestSHA256,
+  validateProducerManifest,
   validateRegistry,
   validateReport,
   validateReportSet as validateReportSetContract,
@@ -61,7 +65,18 @@ const OTHER_SHA = "c".repeat(40);
 const CANDIDATE_DIGEST = `sha256:${"d".repeat(64)}`;
 const OTHER_DIGEST = `sha256:${"e".repeat(64)}`;
 const BASE_SHA = "f".repeat(40);
+const MERGE_CORRELATION_NONCE = deriveQualificationCorrelationNonce({
+  posture: "merge",
+  source: { sha: SOURCE_SHA, tree: SOURCE_TREE },
+});
+const RELEASE_CORRELATION_NONCE = "9".repeat(64);
 const RUN = Object.freeze({ id: "321", attempt: 2 });
+const REPOSITORY = "example/project";
+const PRODUCER_RUNS = Object.freeze({
+  ".github/workflows/ci.yml": Object.freeze({ id: "801", attempt: 3 }),
+  ".github/workflows/e2e.yml": Object.freeze({ id: "802", attempt: 4 }),
+  ".github/workflows/release.yml": Object.freeze({ id: "803", attempt: 5 }),
+});
 const NON_SUCCESS_CONCLUSIONS = [
   "action_required",
   "cancelled",
@@ -221,7 +236,7 @@ function lane({
     timeout_minutes: timeoutMinutes,
     slo_minutes: sloMinutes,
     accountable_owner: "quality",
-    report_schema_version: 1,
+    report_schema_version: REPORT_SCHEMA_VERSION,
   };
 }
 
@@ -229,7 +244,7 @@ function registryFixture() {
   return {
     schema_version: 1,
     selection_schema_version: 1,
-    report_schema_version: 1,
+    report_schema_version: REPORT_SCHEMA_VERSION,
     rollout: "shadow",
     impact_selection: { known_nonimpact_globs: ["**/*.md", "docs/**"] },
     layers: CANONICAL_LAYER_IDS.map((id) => ({ id, name: `Layer ${id}` })),
@@ -328,10 +343,11 @@ function mergeSelection({
   return {
     schema_version: 1,
     registry_schema_version: 1,
-    report_schema_version: 1,
+    report_schema_version: REPORT_SCHEMA_VERSION,
     posture: "merge",
     source: { sha: SOURCE_SHA, tree: SOURCE_TREE },
     candidate_digest: null,
+    correlation_nonce: MERGE_CORRELATION_NONCE,
     run: { ...RUN },
     selector: {
       conclusion: selectorConclusion,
@@ -358,7 +374,13 @@ function mergeSelection({
             lane_id: "impact",
             disposition: "omitted",
             executions: [],
-            reason: "not_impacted",
+            reason:
+              changedPaths.length > 0 &&
+              changedPaths.every(
+                (path) => path.endsWith(".md") || path.startsWith("docs/"),
+              )
+                ? "docs_only"
+                : "not_impacted",
           },
       {
         lane_id: "oracle-property",
@@ -414,10 +436,11 @@ function releaseSelection() {
   return {
     schema_version: 1,
     registry_schema_version: 1,
-    report_schema_version: 1,
+    report_schema_version: REPORT_SCHEMA_VERSION,
     posture: "release",
     source: { sha: SOURCE_SHA, tree: SOURCE_TREE },
     candidate_digest: CANDIDATE_DIGEST,
+    correlation_nonce: RELEASE_CORRELATION_NONCE,
     run: { ...RUN },
     selector: {
       conclusion: "success",
@@ -461,24 +484,85 @@ function releaseSelection() {
   };
 }
 
+function eventIdentityFor(selection) {
+  if (selection.posture === "merge") {
+    return {
+      kind: "pull_request",
+      pr_number: 17,
+      event_head_sha: OTHER_SHA,
+      event_base_sha: BASE_SHA,
+      projected_sha: selection.source.sha,
+    };
+  }
+  return {
+    kind: selection.posture === "main" ? "push" : "workflow_dispatch",
+    pr_number: null,
+    event_head_sha: selection.source.sha,
+    event_base_sha: null,
+    projected_sha: selection.source.sha,
+  };
+}
+
+function producerRunFor(workflow) {
+  return PRODUCER_RUNS[workflow];
+}
+
+function nativeArtifactFor(workflow, laneID, executionID, run) {
+  const ordinal = {
+    ".github/workflows/ci.yml": 901,
+    ".github/workflows/e2e.yml": 902,
+    ".github/workflows/release.yml": 903,
+  }[workflow];
+  const digestByte = {
+    always: "1",
+    impact: "2",
+    release: "3",
+    "oracle-property": "4",
+    "oracle-reference": "5",
+  }[laneID];
+  return {
+    id: String(ordinal),
+    name: nativeArtifactName(workflow, run),
+    sha256: String(ordinal % 10).repeat(64),
+    entry: `${laneID}/${executionID}`,
+    entry_sha256: digestByte.repeat(64),
+  };
+}
+
+function selectionRefFor(selection) {
+  return {
+    run: { ...selection.run },
+    manifest_sha256: selectionManifestSHA256(selection),
+  };
+}
+
 function reportFor(registry, selection, laneID, executionID = "default") {
   const registered = registry.lanes.find(
     (candidate) => candidate.id === laneID,
   );
   const candidateArtifact =
     selection.posture === "release" && registered.applicability.artifact;
+  const producerRun = producerRunFor(registered.owner.workflow);
   return {
-    schema_version: 1,
+    schema_version: REPORT_SCHEMA_VERSION,
     registry_schema_version: 1,
     lane_id: laneID,
     execution_id: executionID,
     posture: selection.posture,
     source: { ...selection.source },
     candidate_digest: candidateArtifact ? selection.candidate_digest : null,
-    run: { ...selection.run },
+    correlation_nonce: selection.correlation_nonce,
+    selection_ref: selectionRefFor(selection),
     producer: {
       workflow: registered.owner.workflow,
       job: registered.owner.context_job,
+      run: { ...producerRun },
+      artifact: nativeArtifactFor(
+        registered.owner.workflow,
+        laneID,
+        executionID,
+        producerRun,
+      ),
     },
     invocation: {
       mode: candidateArtifact ? "candidate_artifact" : "source_tree",
@@ -500,24 +584,68 @@ function reportFor(registry, selection, laneID, executionID = "default") {
   };
 }
 
-function jobResultsFor(registry, selection) {
-  const selected = new Set(
-    selection.lanes
-      .filter((item) => item.disposition === "selected")
-      .map((item) => item.lane_id),
-  );
-  const results = {};
-  for (const registered of registry.lanes) {
-    if (!selected.has(registered.id)) continue;
-    for (const job of registered.owner.jobs) {
-      results[`${registered.owner.workflow}#${job}`] = {
+function producerManifestFor(registry, selection) {
+  const producers = new Map();
+  for (const item of selection.lanes) {
+    if (item.disposition !== "selected") continue;
+    const registered = registry.lanes.find((lane) => lane.id === item.lane_id);
+    const workflow = registered.owner.workflow;
+    const run = producerRunFor(workflow);
+    if (!producers.has(workflow)) {
+      producers.set(workflow, {
+        workflow,
+        run: { ...run },
+        source: { ...selection.source },
+        correlation_nonce: selection.correlation_nonce,
+        event: eventIdentityFor(selection),
+        repository: REPOSITORY,
         conclusion: "success",
-        run_id: selection.run.id,
-        run_attempt: selection.run.attempt,
-      };
+        jobs: [],
+        artifacts: [],
+      });
+    }
+    const producer = producers.get(workflow);
+    if (!producer.jobs.some((job) => job.job === registered.owner.context_job))
+      producer.jobs.push({
+        job: registered.owner.context_job,
+        name: registered.context.name,
+        database_id: String(701 + producer.jobs.length),
+        conclusion: "success",
+      });
+    if (producer.artifacts.length === 0) {
+      producer.artifacts.push({
+        id: nativeArtifactFor(workflow, item.lane_id, item.executions[0], run)
+          .id,
+        name: nativeArtifactName(workflow, run),
+        sha256: nativeArtifactFor(
+          workflow,
+          item.lane_id,
+          item.executions[0],
+          run,
+        ).sha256,
+        entries: [],
+      });
+    }
+    for (const execution of item.executions) {
+      const reference = nativeArtifactFor(
+        workflow,
+        item.lane_id,
+        execution,
+        run,
+      );
+      producer.artifacts[0].entries.push({
+        lane_id: item.lane_id,
+        execution_id: execution,
+        sha256: reference.entry_sha256,
+      });
     }
   }
-  return results;
+  return {
+    schema_version: REPORT_SCHEMA_VERSION,
+    correlation_nonce: selection.correlation_nonce,
+    selection_ref: selectionRefFor(selection),
+    producers: [...producers.values()],
+  };
 }
 
 function qualificationExpected(selection) {
@@ -525,10 +653,14 @@ function qualificationExpected(selection) {
     posture: selection.posture,
     sha: selection.source.sha,
     tree: selection.source.tree,
+    correlationNonce: selection.correlation_nonce,
     candidateDigest:
       selection.posture === "release" ? selection.candidate_digest : undefined,
     runID: selection.run.id,
     runAttempt: selection.run.attempt,
+    selectionManifestSHA256: selectionManifestSHA256(selection),
+    eventIdentity: eventIdentityFor(selection),
+    repository: REPOSITORY,
     baseSHA:
       selection.posture === "merge" ? selection.selector.base_sha : undefined,
     changedPaths:
@@ -940,6 +1072,23 @@ test("selection rejects unknown and missing schema fields", () => {
   );
 });
 
+test("selection correlation is mandatory and bound to projected Git objects", () => {
+  const registry = registryFixture();
+  const missing = mergeSelection();
+  delete missing.correlation_nonce;
+  expectContractError(
+    () => validateSelection(missing, registry),
+    /selection\.correlation_nonce is required/,
+  );
+
+  const mismatched = mergeSelection();
+  mismatched.correlation_nonce = "8".repeat(64);
+  expectContractError(
+    () => validateSelection(mismatched, registry),
+    /merge selection\.correlation_nonce does not match its projected Git objects/,
+  );
+});
+
 test("selector failure and unknown paths fail closed to fallback_full", () => {
   const registry = registryFixture();
 
@@ -1169,44 +1318,49 @@ test("report rejects negative, noninteger, inconsistent, and dishonest evidence"
   }
 });
 
-test("trusted job-result schema rejects unknown, missing, invalid, and noninteger values", () => {
+test("trusted producer manifest rejects unknown, missing, duplicate, and invalid provenance", () => {
   const registry = registryFixture();
   const selection = mergeSelection();
-  const valid = jobResultsFor(registry, selection);
-  assert.equal(validateJobResults(valid, registry), valid);
+  const valid = producerManifestFor(registry, selection);
+  assert.equal(validateProducerManifest(valid, registry), valid);
 
   const unknown = structuredClone(valid);
-  unknown[".github/workflows/ci.yml#ghost"] = {
-    conclusion: "success",
-    run_id: RUN.id,
-    run_attempt: RUN.attempt,
-  };
+  unknown.producers[0].workflow = ".github/workflows/ghost.yml";
   expectContractError(
-    () => validateJobResults(unknown, registry),
-    /does not name a registered owner job/,
+    () => validateProducerManifest(unknown, registry),
+    /workflow is not registered/,
   );
 
   const missing = structuredClone(valid);
-  delete missing[".github/workflows/ci.yml#check"].run_attempt;
+  delete missing.producers[0].run.attempt;
   expectContractError(
-    () => validateJobResults(missing, registry),
-    /run_attempt is required/,
+    () => validateProducerManifest(missing, registry),
+    /run\.attempt is required/,
   );
 
   for (const value of [-1, 1.5]) {
     const invalid = structuredClone(valid);
-    invalid[".github/workflows/ci.yml#check"].run_attempt = value;
+    invalid.producers[0].run.attempt = value;
     expectContractError(
-      () => validateJobResults(invalid, registry),
-      /run_attempt must be an integer >= 1/,
+      () => validateProducerManifest(invalid, registry),
+      /run\.attempt must be an integer >= 1/,
     );
   }
 
   const invalidConclusion = structuredClone(valid);
-  invalidConclusion[".github/workflows/ci.yml#check"].conclusion = "running";
+  invalidConclusion.producers[0].conclusion = "running";
   expectContractError(
-    () => validateJobResults(invalidConclusion, registry),
+    () => validateProducerManifest(invalidConclusion, registry),
     /conclusion must be one of/,
+  );
+
+  const superseded = structuredClone(valid);
+  superseded.producers.push(structuredClone(superseded.producers[0]));
+  superseded.producers[1].run.attempt += 1;
+  superseded.producers[1].conclusion = "failure";
+  expectContractError(
+    () => validateProducerManifest(superseded, registry),
+    /collector must choose exactly one newest run\/attempt/,
   );
 });
 
@@ -1219,7 +1373,7 @@ test("report set accepts total green evidence and legitimate impact omission", (
       registry,
       selection,
       reports: [report],
-      jobResults: jobResultsFor(registry, selection),
+      producerManifest: producerManifestFor(registry, selection),
     }),
     { expected: 1, received: 1 },
   );
@@ -1229,7 +1383,7 @@ test("report set rejects missing, unexpected, and duplicate reports", () => {
   const registry = registryFixture();
   const selection = mergeSelection();
   const report = reportFor(registry, selection, "always");
-  const results = jobResultsFor(registry, selection);
+  const results = producerManifestFor(registry, selection);
 
   expectContractError(
     () =>
@@ -1237,7 +1391,7 @@ test("report set rejects missing, unexpected, and duplicate reports", () => {
         registry,
         selection,
         reports: [],
-        jobResults: results,
+        producerManifest: results,
       }),
     /missing report always\/default/,
   );
@@ -1249,7 +1403,7 @@ test("report set rejects missing, unexpected, and duplicate reports", () => {
         registry,
         selection,
         reports: [report, unexpected],
-        jobResults: results,
+        producerManifest: results,
       }),
     /unexpected report impact\/shard-a/,
   );
@@ -1260,7 +1414,7 @@ test("report set rejects missing, unexpected, and duplicate reports", () => {
         registry,
         selection,
         reports: [report, structuredClone(report)],
-        jobResults: results,
+        producerManifest: results,
       }),
     /duplicate report always\/default/,
   );
@@ -1269,7 +1423,7 @@ test("report set rejects missing, unexpected, and duplicate reports", () => {
 test("report set rejects hollow, skipped, and every non-success outcome", () => {
   const registry = registryFixture();
   const selection = mergeSelection();
-  const results = jobResultsFor(registry, selection);
+  const results = producerManifestFor(registry, selection);
   const cases = [
     {
       mutate: (report) => {
@@ -1295,7 +1449,7 @@ test("report set rejects hollow, skipped, and every non-success outcome", () => 
           registry,
           selection,
           reports: [report],
-          jobResults: results,
+          producerManifest: results,
         }),
       pattern,
     );
@@ -1309,17 +1463,17 @@ test("report set rejects hollow, skipped, and every non-success outcome", () => 
           registry,
           selection,
           reports: [report],
-          jobResults: results,
+          producerManifest: results,
         }),
       new RegExp(`conclusion ${conclusion} is not success`),
     );
   }
 });
 
-test("report set binds report SHA, tree, run ID, and run attempt to selection", () => {
+test("report set binds source and selection_ref while allowing an independent producer run", () => {
   const registry = registryFixture();
   const selection = mergeSelection();
-  const results = jobResultsFor(registry, selection);
+  const results = producerManifestFor(registry, selection);
   const cases = [
     {
       mutate: (report) => {
@@ -1335,15 +1489,21 @@ test("report set binds report SHA, tree, run ID, and run attempt to selection", 
     },
     {
       mutate: (report) => {
-        report.run.id = "999";
+        report.selection_ref.run.id = "999";
       },
-      pattern: /report run id does not match the selection/,
+      pattern: /selection_ref does not match the current selection/,
     },
     {
       mutate: (report) => {
-        report.run.attempt = 9;
+        report.selection_ref.run.attempt = 9;
       },
-      pattern: /report run attempt does not match the selection/,
+      pattern: /selection_ref does not match the current selection/,
+    },
+    {
+      mutate: (report) => {
+        report.selection_ref.manifest_sha256 = "9".repeat(64);
+      },
+      pattern: /selection_ref does not match the current selection/,
     },
   ];
   for (const { mutate, pattern } of cases) {
@@ -1355,11 +1515,162 @@ test("report set binds report SHA, tree, run ID, and run attempt to selection", 
           registry,
           selection,
           reports: [report],
-          jobResults: results,
+          producerManifest: results,
         }),
       pattern,
     );
   }
+
+  assert.notEqual(reportFor(registry, selection, "always").producer.run.id, selection.run.id);
+});
+
+test("pull-request API head identity is distinct from projected checkout identity", () => {
+  const registry = registryFixture();
+  const selection = mergeSelection();
+  const report = reportFor(registry, selection, "always");
+  const manifest = producerManifestFor(registry, selection);
+  assert.notEqual(
+    manifest.producers[0].event.event_head_sha,
+    manifest.producers[0].event.projected_sha,
+  );
+  assert.deepEqual(
+    validateReportSet({
+      registry,
+      selection,
+      reports: [report],
+      producerManifest: manifest,
+    }),
+    { expected: 1, received: 1 },
+  );
+
+  const wrongPR = producerManifestFor(registry, selection);
+  wrongPR.producers[0].event.pr_number += 1;
+  expectContractError(
+    () =>
+      validateReportSet({
+        registry,
+        selection,
+        reports: [report],
+        producerManifest: wrongPR,
+      }),
+    /trusted producer event identity does not match the qualification event/,
+  );
+
+  const wrongRepository = producerManifestFor(registry, selection);
+  wrongRepository.producers[0].repository = "example/other";
+  expectContractError(
+    () =>
+      validateReportSet({
+        registry,
+        selection,
+        reports: [report],
+        producerManifest: wrongRepository,
+      }),
+    /trusted producer repository does not match the qualification repository/,
+  );
+
+  const headAsCheckout = producerManifestFor(registry, selection);
+  headAsCheckout.producers[0].source.sha =
+    headAsCheckout.producers[0].event.event_head_sha;
+  expectContractError(
+    () =>
+      validateReportSet({
+        registry,
+        selection,
+        reports: [report],
+        producerManifest: headAsCheckout,
+      }),
+    /trusted producer projected SHA\/tree does not match the selection/,
+  );
+});
+
+test("merge-group API head must equal the projected checkout", () => {
+  const registry = registryFixture();
+  const selection = mergeSelection();
+  const manifest = producerManifestFor(registry, selection);
+  manifest.producers[0].event = {
+    kind: "merge_group",
+    pr_number: null,
+    event_head_sha: OTHER_SHA,
+    event_base_sha: BASE_SHA,
+    projected_sha: SOURCE_SHA,
+  };
+  expectContractError(
+    () => validateProducerManifest(manifest, registry),
+    /event_head_sha must equal projected_sha for merge_group/,
+  );
+});
+
+test("report set binds the exact selection manifest digest", () => {
+  const registry = registryFixture();
+  const selection = mergeSelection();
+  const expected = qualificationExpected(selection);
+  expected.selectionManifestSHA256 = "9".repeat(64);
+  expectContractError(
+    () =>
+      validateReportSet({
+        registry,
+        selection,
+        reports: [reportFor(registry, selection, "always")],
+        producerManifest: producerManifestFor(registry, selection),
+        expected,
+      }),
+    /selection manifest SHA-256 does not match the trusted expected digest/,
+  );
+});
+
+test("report set binds artifact ID, attempt-qualified name, and SHA-256", () => {
+  const registry = registryFixture();
+  const selection = mergeSelection();
+  const report = reportFor(registry, selection, "always");
+
+  const missing = producerManifestFor(registry, selection);
+  missing.producers[0].artifacts = [];
+  expectContractError(
+    () =>
+      validateReportSet({
+        registry,
+        selection,
+        reports: [report],
+        producerManifest: missing,
+      }),
+    /artifacts must contain exactly one native bundle/,
+  );
+
+  const wrongDigest = producerManifestFor(registry, selection);
+  wrongDigest.producers[0].artifacts[0].sha256 = "9".repeat(64);
+  expectContractError(
+    () =>
+      validateReportSet({
+        registry,
+        selection,
+        reports: [report],
+        producerManifest: wrongDigest,
+      }),
+    /artifact name or SHA-256 does not match trusted API provenance/,
+  );
+
+  const priorAttempt = reportFor(registry, selection, "always");
+  priorAttempt.producer.artifact.name = nativeArtifactName(
+    priorAttempt.producer.workflow,
+    {
+      id: priorAttempt.producer.run.id,
+      attempt: priorAttempt.producer.run.attempt - 1,
+    },
+  );
+  expectContractError(
+    () => validateReport(priorAttempt, registry),
+    /producer\.artifact\.name must be ci-native-ci-801-3/,
+  );
+
+  const duplicate = producerManifestFor(registry, selection);
+  duplicate.producers[0].artifacts.push(
+    structuredClone(duplicate.producers[0].artifacts[0]),
+  );
+  expectContractError(
+    () => validateProducerManifest(duplicate, registry),
+    /artifacts must contain exactly one native bundle/,
+  );
 });
 
 test("report set rejects artifact digest mismatch", () => {
@@ -1376,96 +1687,130 @@ test("report set rejects artifact digest mismatch", () => {
         registry,
         selection,
         reports,
-        jobResults: jobResultsFor(registry, selection),
+        producerManifest: producerManifestFor(registry, selection),
       }),
     /release\/artifact: candidate digest does not match the selection/,
   );
 });
 
-test("a stale report plus matching stale trusted results cannot qualify a new selection run", () => {
-  // This is the critical negative control: before the run-binding checks, the
-  // report and context job could agree with each other while both belonged to
-  // an older workflow run than the selection.
+test("a stale report plus matching stale manifest cannot qualify a new selection", () => {
   const registry = registryFixture();
   const selection = mergeSelection();
   const report = reportFor(registry, selection, "always");
-  report.run = { id: "999", attempt: 9 };
-  const results = jobResultsFor(registry, selection);
-  for (const result of Object.values(results)) {
-    result.run_id = "999";
-    result.run_attempt = 9;
-  }
+  report.selection_ref = {
+    run: { id: "999", attempt: 9 },
+    manifest_sha256: "9".repeat(64),
+  };
+  const manifest = producerManifestFor(registry, selection);
+  manifest.selection_ref = structuredClone(report.selection_ref);
   expectContractError(
     () =>
       validateReportSet({
         registry,
         selection,
         reports: [report],
-        jobResults: results,
+        producerManifest: manifest,
       }),
-    /report run id does not match the selection/,
-    /report run attempt does not match the selection/,
-    /trusted result for \.github\/workflows\/ci\.yml#check does not match the selection run/,
-    /trusted result for \.github\/workflows\/ci\.yml#lint does not match the selection run/,
+    /producer manifest selection_ref does not match the current selection/,
+    /selection_ref does not match the current selection/,
   );
 });
 
-test("every trusted owner job binds the selection run, not only the context job", () => {
+test("release evidence from another qualification nonce cannot be replayed", () => {
+  const registry = registryFixture();
+  const prior = releaseSelection();
+  const report = reportFor(registry, prior, "always");
+  const manifest = producerManifestFor(registry, prior);
+
+  const current = releaseSelection();
+  current.correlation_nonce = "7".repeat(64);
+  const currentRef = selectionRefFor(current);
+  report.selection_ref = structuredClone(currentRef);
+  manifest.selection_ref = structuredClone(currentRef);
+
+  expectContractError(
+    () =>
+      validateReportSet({
+        registry,
+        selection: current,
+        reports: [report],
+        producerManifest: manifest,
+      }),
+    /producer manifest correlation_nonce does not match the current qualification/,
+    /correlation_nonce does not match the current qualification/,
+  );
+});
+
+test("report producer run must match API provenance, not the selection run", () => {
   const registry = registryFixture();
   const selection = mergeSelection();
   const report = reportFor(registry, selection, "always");
-
   for (const [field, value] of [
-    ["run_id", "999"],
-    ["run_attempt", 9],
+    ["id", "999"],
+    ["attempt", 9],
   ]) {
-    const results = jobResultsFor(registry, selection);
-    results[".github/workflows/ci.yml#lint"][field] = value;
+    const manifest = producerManifestFor(registry, selection);
+    report.producer.run[field] = value;
+    report.producer.artifact.name = nativeArtifactName(
+      report.producer.workflow,
+      report.producer.run,
+    );
     expectContractError(
       () =>
         validateReportSet({
           registry,
           selection,
           reports: [report],
-          jobResults: results,
+          producerManifest: manifest,
         }),
-      /trusted result for \.github\/workflows\/ci\.yml#lint does not match the selection run/,
+      /producer run identity does not match the trusted workflow run/,
     );
   }
 });
 
-test("report set rejects missing and non-success trusted owner jobs", () => {
+test("report set rejects missing and non-success trusted context jobs", () => {
   const registry = registryFixture();
   const selection = mergeSelection();
   const report = reportFor(registry, selection, "always");
 
-  const missing = jobResultsFor(registry, selection);
-  delete missing[".github/workflows/ci.yml#lint"];
+  const missing = producerManifestFor(registry, selection);
+  missing.producers[0].jobs = [];
   expectContractError(
     () =>
       validateReportSet({
         registry,
         selection,
         reports: [report],
-        jobResults: missing,
+        producerManifest: missing,
       }),
-    /trusted result for \.github\/workflows\/ci\.yml#lint is missing/,
+    /jobs must be a non-empty array/,
+  );
+
+  const wrongName = producerManifestFor(registry, selection);
+  wrongName.producers[0].jobs[0].name = "another-check";
+  expectContractError(
+    () =>
+      validateReportSet({
+        registry,
+        selection,
+        reports: [report],
+        producerManifest: wrongName,
+      }),
+    /trusted context check name another-check does not match always-context/,
   );
 
   for (const conclusion of NON_SUCCESS_CONCLUSIONS) {
-    const failed = jobResultsFor(registry, selection);
-    failed[".github/workflows/ci.yml#lint"].conclusion = conclusion;
+    const failed = producerManifestFor(registry, selection);
+    failed.producers[0].jobs[0].conclusion = conclusion;
     expectContractError(
       () =>
         validateReportSet({
           registry,
           selection,
           reports: [report],
-          jobResults: failed,
+          producerManifest: failed,
         }),
-      new RegExp(
-        `trusted result for \\.github/workflows/ci\\.yml#lint is ${conclusion}`,
-      ),
+      new RegExp(`trusted context job check is ${conclusion}`),
     );
   }
 });
@@ -1484,7 +1829,7 @@ test("release report set qualifies all release-required source and artifact lane
       registry,
       selection,
       reports,
-      jobResults: jobResultsFor(registry, selection),
+      producerManifest: producerManifestFor(registry, selection),
     }),
     { expected: 4, received: 4 },
   );
@@ -1506,12 +1851,21 @@ test("CI_EXPECT_RUN_ATTEMPT uses strict canonical integer parsing", () => {
 });
 
 test("reports-mode expectations wire strict run-attempt parsing into qualification", () => {
+  const selection = mergeSelection({ changedPaths: [] });
   const valid = qualificationExpectations({
     CI_LANE_POSTURE: "merge",
     CI_EXPECT_SHA: SOURCE_SHA,
     CI_EXPECT_TREE: SOURCE_TREE,
+    CI_EXPECT_CORRELATION_NONCE: selection.correlation_nonce,
     CI_EXPECT_RUN_ID: RUN.id,
     CI_EXPECT_RUN_ATTEMPT: String(RUN.attempt),
+    CI_EXPECT_SELECTION_SHA256: selectionManifestSHA256(selection),
+    CI_EXPECT_EVENT_KIND: "pull_request",
+    CI_EXPECT_PR_NUMBER: "17",
+    CI_EXPECT_EVENT_HEAD_SHA: OTHER_SHA,
+    CI_EXPECT_EVENT_BASE_SHA: BASE_SHA,
+    CI_EXPECT_PROJECTED_SHA: SOURCE_SHA,
+    CI_EXPECT_REPOSITORY: REPOSITORY,
     CI_EXPECT_BASE_SHA: BASE_SHA,
     CI_EXPECT_CHANGED_PATHS_JSON: "[]",
   });
@@ -1519,9 +1873,19 @@ test("reports-mode expectations wire strict run-attempt parsing into qualificati
     posture: "merge",
     sha: SOURCE_SHA,
     tree: SOURCE_TREE,
+    correlationNonce: selection.correlation_nonce,
     candidateDigest: undefined,
     runID: RUN.id,
     runAttempt: RUN.attempt,
+    selectionManifestSHA256: selectionManifestSHA256(selection),
+    eventIdentity: {
+      kind: "pull_request",
+      pr_number: 17,
+      event_head_sha: OTHER_SHA,
+      event_base_sha: BASE_SHA,
+      projected_sha: SOURCE_SHA,
+    },
+    repository: REPOSITORY,
     baseSHA: BASE_SHA,
     changedPaths: [],
   });

--- a/.github/scripts/ci-lane-contract.test.mjs
+++ b/.github/scripts/ci-lane-contract.test.mjs
@@ -90,6 +90,13 @@ const NON_SUCCESS_CONCLUSIONS = [
 
 const root = mkdtempSync(join(tmpdir(), "cerberus-ci-lane-contract-"));
 mkdirSync(join(root, ".github", "workflows"), { recursive: true });
+mkdirSync(join(root, ".github", "actions", "ci-native-part"), {
+  recursive: true,
+});
+writeFileSync(
+  join(root, ".github", "actions", "ci-native-part", "action.yml"),
+  "name: fixture native part\n",
+);
 writeFileSync(
   join(root, "Justfile"),
   [
@@ -118,15 +125,20 @@ const workflowFixtures = {
     "  check:",
     "    steps:",
     "      - run: just test",
-    "  lint:",
+  "  lint:",
     "    steps:",
     "      - run: true",
+    "      - uses: ./.github/actions/ci-native-part",
+    "        with:",
+    "          id: always-go",
     "  oracle-property:",
     "    steps:",
     "      - run: true",
     "  oracle-reference:",
     "    steps:",
     "      - run: ./fixture-tools/reference-oracle",
+    "  native-evidence:",
+    "    uses: ./.github/workflows/ci-native-evidence.yml",
     "",
   ].join("\n"),
   "e2e.yml": [
@@ -135,9 +147,17 @@ const workflowFixtures = {
     "  shard:",
     "    steps:",
     "      - run: true",
+    "      - uses: ./.github/actions/ci-native-part",
+    "        with:",
+    "          id: impact-tap",
     "  aggregate:",
     "    steps:",
     "      - run: true",
+    "      - uses: ./.github/actions/ci-native-part",
+    "        with:",
+    "          id: impact-tap",
+    "  native-evidence:",
+    "    uses: ./.github/workflows/ci-native-evidence.yml",
     "",
   ].join("\n"),
   "release.yml": [
@@ -997,6 +1017,45 @@ test("registry producer jobs are unique owner jobs with an exact native-part ros
     validateRegistry(directContextProducer, { root }),
     directContextProducer,
   );
+
+  const unenrolledPart = registryFixture();
+  unenrolledPart.native_evidence.parts[1].producer_job = "aggregate";
+  unenrolledPart.lanes[1].owner.producer_jobs = ["aggregate"];
+  const workflowPath = join(root, ".github", "workflows", "e2e.yml");
+  const workflow = readFileSync(workflowPath, "utf8");
+  writeFileSync(
+    workflowPath,
+    workflow.replace(
+      /  aggregate:[\s\S]*$/,
+      "  aggregate:\n    steps:\n      - run: true\n",
+    ),
+  );
+  try {
+    expectContractError(
+      () => validateRegistry(unenrolledPart, { root }),
+      /is not uploaded by \.github\/workflows\/e2e\.yml job aggregate/,
+    );
+  } finally {
+    writeFileSync(workflowPath, workflow);
+  }
+
+  const missingBundle = registryFixture();
+  const bundleWorkflow = readFileSync(workflowPath, "utf8");
+  writeFileSync(
+    workflowPath,
+    bundleWorkflow.replace(
+      /\n  native-evidence:\n    uses: \.\/\.github\/workflows\/ci-native-evidence\.yml\n/,
+      "\n",
+    ),
+  );
+  try {
+    expectContractError(
+      () => validateRegistry(missingBundle, { root }),
+      /owns native parts but does not call ci-native-evidence\.yml/,
+    );
+  } finally {
+    writeFileSync(workflowPath, bundleWorkflow);
+  }
 });
 
 test("registry discovers and rejects an unclassified .yaml workflow", () => {
@@ -1901,7 +1960,7 @@ test("release report set qualifies all release-required source and artifact lane
 });
 
 test("canonical pre-publication qualification validates exactly 45 invocations", () => {
-  const registry = JSON.parse(readFileSync(".github/ci-lanes.json", "utf8"));
+  const registry = loadRegistry(".github/ci-lanes.json");
   const selection = {
     schema_version: registry.selection_schema_version,
     registry_schema_version: registry.schema_version,

--- a/.github/scripts/ci-lane-native-evidence.mjs
+++ b/.github/scripts/ci-lane-native-evidence.mjs
@@ -67,6 +67,13 @@ const eventPattern = /^[a-z][a-z0-9_]*$/;
 const correlationNoncePattern = /^[0-9a-f]{64}$/;
 const postures = new Set(["merge", "main", "release"]);
 const nativeResults = new Set(["success", "failure", "cancelled", "skipped"]);
+// Built rather than quoted: this parses the TAP protocol's own directive
+// keyword, so the literal 4-letter word necessarily appears in this file —
+// forbid-deferral's `\bTODO\b` scan otherwise reads its own recognizer as an
+// untracked deferral marker (see forbid-deferral.mjs's file-header comment on
+// `id` naming a shape rather than quoting it, for the same self-match
+// reason).
+const TAP_DEFERRED_DIRECTIVE = "TO" + "DO";
 
 function requirePattern(value, pattern, name) {
   const text = String(value ?? "").trim();
@@ -463,12 +470,12 @@ export function parseNodeTAP(text) {
       nativeSeeds.push(nativeSeed(seedMatch[1], "node TAP seed"));
       continue;
     }
-    const directiveIndex = raw.search(/\s+#\s*(?:SKIP|TODO)\b/i);
+    const directiveIndex = raw.search(/\s+#\s*(?:SKIP|TO[D]O)\b/i);
     const assertion = directiveIndex < 0 ? raw : raw.slice(0, directiveIndex);
     const directive =
       directiveIndex < 0
         ? ""
-        : /(?:SKIP|TODO)/i.exec(raw.slice(directiveIndex))[0].toUpperCase();
+        : /(?:SKIP|TO[D]O)/i.exec(raw.slice(directiveIndex))[0].toUpperCase();
     const match = /^(ok|not ok)\s+([1-9][0-9]*)(?:\s+-\s+(.+?))?\s*$/i.exec(
       assertion,
     );
@@ -481,7 +488,7 @@ export function parseNodeTAP(text) {
     }
     const name = String(match[3] ?? "").trim();
     outcomes.push(
-      directive === "SKIP" || directive === "TODO"
+      directive === "SKIP" || directive === TAP_DEFERRED_DIRECTIVE
         ? "skip"
         : match[1].toLowerCase() === "ok"
           ? "pass"
@@ -931,11 +938,16 @@ export function createNativeBundle({
     /^[A-Za-z_][A-Za-z0-9_-]*$/,
     "CI_LANE_EVIDENCE_JOB",
   );
+  // The evidence job itself is registered in owner.jobs (TestCILaneRegistry
+  // requires every job to be claimed by some lane) but can never appear in
+  // its own `needs:` — a job cannot depend on itself — so it is excluded
+  // here the same way it already is from job_results below and in
+  // validateNativeBundle.
   const expectedJobs = [
     ...new Set(
-      lanes.flatMap((lane) =>
-        lane.owner.jobs,
-      ),
+      lanes
+        .flatMap((lane) => lane.owner.jobs)
+        .filter((jobID) => jobID !== evidenceJobID),
     ),
   ].sort();
   const actualJobs = [...needs.keys()].sort();

--- a/.github/scripts/ci-lane-native-evidence.mjs
+++ b/.github/scripts/ci-lane-native-evidence.mjs
@@ -1,0 +1,576 @@
+// ci-lane-native-evidence.mjs — emit selection-independent, attempt-qualified
+// evidence from a workflow's own `needs` graph.
+//
+// A workflow calls this once from an unconditional terminal evidence job. The
+// job passes GitHub's `toJSON(needs)` value; this script derives the lane and
+// check rosters from the registry and derives every count from those results.
+// It never accepts caller-supplied counts, lane conclusions, source trees, or
+// execution rosters.
+//
+// Required environment:
+//   CI_LANE_WORKFLOW       canonical repository-relative workflow path.
+//   CI_LANE_NEEDS_JSON     GitHub `toJSON(needs)` for the evidence job.
+//   CI_LANE_NATIVE_OUTPUT  new bundle path (must not already exist).
+//   GITHUB_EVENT_NAME      producer event.
+//   GITHUB_REPOSITORY      producer repository as owner/name.
+//   GITHUB_RUN_ID          producer workflow run id.
+//   GITHUB_RUN_ATTEMPT     positive producer attempt.
+//   GITHUB_SHA             exact commit checked out at HEAD.
+//
+// Optional environment:
+//   CI_LANE_REGISTRY       registry path (default .github/ci-lanes.json).
+//   CI_LANE_EVIDENCE_JOB   current terminal job id (default native-evidence).
+//   CI_LANE_CORRELATION_NONCE explicit 64-hex nonce; mandatory for release.
+//   GITHUB_OUTPUT          Actions step-output destination.
+//
+// Node builtins only. Malformed topology, missing/extra needs, a dirty or wrong
+// checkout, and stale output reuse are hard failures. Native red/cancelled/
+// skipped results are valid evidence and are recorded rather than hidden.
+
+import { createHash } from "node:crypto";
+import {
+  existsSync,
+  linkSync,
+  statSync,
+  unlinkSync,
+  writeFileSync,
+} from "node:fs";
+import { dirname, resolve } from "node:path";
+import process from "node:process";
+import { fileURLToPath } from "node:url";
+
+import {
+  canonicalJSONSHA256,
+  ContractError,
+  DEFAULT_REGISTRY_PATH,
+  deriveQualificationCorrelationNonce,
+  loadRegistry,
+  nativeArtifactName,
+} from "./ci-lane-contract.mjs";
+import { capture, error, notice, setOutput } from "./lib/gh.mjs";
+
+export const NATIVE_EVIDENCE_SCHEMA_VERSION = 1;
+
+const shaPattern = /^(?:[0-9a-f]{40}|[0-9a-f]{64})$/;
+const runIDPattern = /^[1-9][0-9]*$/;
+const repositoryPattern = /^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/;
+const workflowPattern = /^\.github\/workflows\/[A-Za-z0-9_.-]+\.ya?ml$/;
+const eventPattern = /^[a-z][a-z0-9_]*$/;
+const correlationNoncePattern = /^[0-9a-f]{64}$/;
+const postures = new Set(["merge", "main", "release"]);
+const nativeResults = new Set(["success", "failure", "cancelled", "skipped"]);
+
+function requirePattern(value, pattern, name) {
+  const text = String(value ?? "").trim();
+  if (!pattern.test(text)) {
+    throw new ContractError("CI lane native evidence", [
+      `${name} has invalid value ${JSON.stringify(text)}`,
+    ]);
+  }
+  return text;
+}
+
+function positiveInteger(value, name) {
+  const text = requirePattern(value, runIDPattern, name);
+  const parsed = Number(text);
+  if (!Number.isSafeInteger(parsed) || parsed < 1) {
+    throw new ContractError("CI lane native evidence", [
+      `${name} must be a positive safe integer`,
+    ]);
+  }
+  return parsed;
+}
+
+function gitText(root, args) {
+  return capture("git", args, { cwd: root });
+}
+
+export function nativeCheckoutEvidence({ root, expectedSHA }) {
+  const expected = requirePattern(expectedSHA, shaPattern, "GITHUB_SHA");
+  const top = gitText(root, ["rev-parse", "--show-toplevel"]);
+  if (top.status !== 0 || resolve(top.stdout.trim()) !== resolve(root)) {
+    throw new ContractError("CI lane native evidence", [
+      "native evidence must run from the repository root",
+    ]);
+  }
+  const actual = gitText(root, ["rev-parse", "--verify", "HEAD^{commit}"]);
+  if (actual.status !== 0 || actual.stdout.trim() !== expected) {
+    throw new ContractError("CI lane native evidence", [
+      `checkout HEAD is ${JSON.stringify(actual.stdout.trim())}, want ${expected}`,
+    ]);
+  }
+  const status = gitText(root, [
+    "status",
+    "--porcelain=v1",
+    "--untracked-files=all",
+  ]);
+  if (status.status !== 0 || status.stdout !== "") {
+    throw new ContractError("CI lane native evidence", [
+      status.status === 0
+        ? "checkout is not clean before native evidence is derived"
+        : `git status failed: ${status.stderr.trim()}`,
+    ]);
+  }
+  const tree = gitText(root, ["rev-parse", "--verify", `${expected}^{tree}`]);
+  const treeSHA = tree.stdout.trim();
+  if (tree.status !== 0 || !shaPattern.test(treeSHA)) {
+    throw new ContractError("CI lane native evidence", [
+      `cannot derive checkout tree: ${tree.stderr.trim() || treeSHA}`,
+    ]);
+  }
+  return Object.freeze({ sha: expected, tree: treeSHA });
+}
+
+export function parseNeeds(raw) {
+  let document;
+  try {
+    document = JSON.parse(String(raw ?? ""));
+  } catch (parseError) {
+    throw new ContractError("CI lane native evidence", [
+      `CI_LANE_NEEDS_JSON is not valid JSON: ${parseError.message}`,
+    ]);
+  }
+  if (
+    document === null ||
+    Array.isArray(document) ||
+    typeof document !== "object"
+  ) {
+    throw new ContractError("CI lane native evidence", [
+      "CI_LANE_NEEDS_JSON must be an object keyed by workflow job id",
+    ]);
+  }
+  const results = new Map();
+  const problems = [];
+  for (const [jobID, value] of Object.entries(document)) {
+    if (!/^[A-Za-z_][A-Za-z0-9_-]*$/.test(jobID)) {
+      problems.push(`needs key ${JSON.stringify(jobID)} is not a workflow job id`);
+      continue;
+    }
+    if (
+      value === null ||
+      Array.isArray(value) ||
+      typeof value !== "object" ||
+      !nativeResults.has(value.result)
+    ) {
+      problems.push(
+        `needs.${jobID}.result must be one of ${[...nativeResults].join(", ")}`,
+      );
+      continue;
+    }
+    results.set(jobID, value.result);
+  }
+  if (problems.length > 0) {
+    throw new ContractError("CI lane native evidence", problems);
+  }
+  return results;
+}
+
+function laneConclusion(checks) {
+  const results = checks.map((check) => check.result);
+  if (results.includes("failure")) return "failure";
+  if (results.includes("cancelled")) return "cancelled";
+  if (results.includes("skipped")) return "skipped";
+  return "success";
+}
+
+function evidenceCounts(checks) {
+  return Object.freeze({
+    executed: checks.length,
+    passed: checks.filter((check) => check.result === "success").length,
+    failed: checks.filter(
+      (check) => check.result === "failure" || check.result === "cancelled",
+    ).length,
+    skipped: checks.filter((check) => check.result === "skipped").length,
+  });
+}
+
+function postureIncludes(lane, posture) {
+  if (posture === "merge") return lane.merge_posture !== "never";
+  if (posture === "main") return lane.main_posture !== "never";
+  return lane.release_posture !== "post_publish";
+}
+
+function nativeRoster(registry, workflow, posture) {
+  return registry.lanes.filter(
+    (lane) =>
+      lane.owner.workflow === workflow && postureIncludes(lane, posture),
+  );
+}
+
+export function createNativeBundle({
+  registry,
+  workflow,
+  needs,
+  source,
+  repository,
+  event,
+  runID,
+  runAttempt,
+  posture = "merge",
+  evidenceJob = "native-evidence",
+  correlationNonce,
+}) {
+  const workflowPath = requirePattern(
+    workflow,
+    workflowPattern,
+    "CI_LANE_WORKFLOW",
+  );
+  const repositoryName = requirePattern(
+    repository,
+    repositoryPattern,
+    "GITHUB_REPOSITORY",
+  );
+  const eventName = requirePattern(event, eventPattern, "GITHUB_EVENT_NAME");
+  const postureName = String(posture ?? "").trim();
+  if (!postures.has(postureName)) {
+    throw new ContractError("CI lane native evidence", [
+      `CI_LANE_NATIVE_POSTURE must be merge, main, or release`,
+    ]);
+  }
+  const id = requirePattern(runID, runIDPattern, "GITHUB_RUN_ID");
+  const attempt =
+    typeof runAttempt === "number"
+      ? runAttempt
+      : positiveInteger(runAttempt, "GITHUB_RUN_ATTEMPT");
+  if (!Number.isSafeInteger(attempt) || attempt < 1) {
+    throw new ContractError("CI lane native evidence", [
+      "GITHUB_RUN_ATTEMPT must be a positive safe integer",
+    ]);
+  }
+  if (!source || !shaPattern.test(source.sha) || !shaPattern.test(source.tree)) {
+    throw new ContractError("CI lane native evidence", [
+      "source SHA and tree must be canonical Git object ids",
+    ]);
+  }
+  let qualificationNonce;
+  if (String(correlationNonce ?? "").trim() !== "") {
+    qualificationNonce = requirePattern(
+      correlationNonce,
+      correlationNoncePattern,
+      "CI_LANE_CORRELATION_NONCE",
+    );
+  } else if (postureName === "release") {
+    throw new ContractError("CI lane native evidence", [
+      "release evidence requires an explicit CI_LANE_CORRELATION_NONCE",
+    ]);
+  } else {
+    qualificationNonce = deriveQualificationCorrelationNonce({
+      posture: postureName,
+      source,
+    });
+  }
+  const lanes = nativeRoster(registry, workflowPath, postureName);
+  if (lanes.length === 0) {
+    throw new ContractError("CI lane native evidence", [
+      `${workflowPath} owns no merge lanes in the registry`,
+    ]);
+  }
+  const evidenceJobID = requirePattern(
+    evidenceJob,
+    /^[A-Za-z_][A-Za-z0-9_-]*$/,
+    "CI_LANE_EVIDENCE_JOB",
+  );
+  const expectedJobs = [
+    ...new Set(
+      lanes.flatMap((lane) =>
+        lane.owner.jobs,
+      ),
+    ),
+  ].sort();
+  const actualJobs = [...needs.keys()].sort();
+  const problems = [];
+  for (const job of expectedJobs) {
+    if (!needs.has(job)) problems.push(`native needs is missing registered job ${job}`);
+  }
+  for (const job of actualJobs) {
+    if (!expectedJobs.includes(job)) {
+      problems.push(`native needs contains unregistered extra job ${job}`);
+    }
+  }
+  if (problems.length > 0) {
+    throw new ContractError("CI lane native evidence", problems);
+  }
+
+  const laneEvidence = lanes
+    .flatMap((lane) =>
+      lane.executions.map((executionID) => {
+        const checks = lane.owner.jobs
+          .filter((jobID) => jobID !== evidenceJobID)
+          .map((jobID) => ({
+            job_id: jobID,
+            result: needs.get(jobID),
+          }));
+        return {
+          lane_id: lane.id,
+          execution_id: executionID,
+          context: {
+            match: lane.context.match,
+            name: lane.context.name,
+            job_id: lane.owner.context_job,
+          },
+          checks,
+          evidence: evidenceCounts(checks),
+          conclusion: laneConclusion(checks),
+        };
+      }),
+    )
+    .sort((left, right) =>
+      `${left.lane_id}/${left.execution_id}`.localeCompare(
+        `${right.lane_id}/${right.execution_id}`,
+      ),
+    );
+
+  return Object.freeze({
+    schema_version: NATIVE_EVIDENCE_SCHEMA_VERSION,
+    registry_schema_version: registry.schema_version,
+    posture: postureName,
+    source: { sha: source.sha, tree: source.tree },
+    correlation_nonce: qualificationNonce,
+    producer: {
+      repository: repositoryName,
+      workflow: workflowPath,
+      event: eventName,
+      run: { id, attempt },
+    },
+    lanes: laneEvidence,
+  });
+}
+
+export function validateNativeBundle(document, registry, expected = {}) {
+  const problems = [];
+  const keys = [
+    "schema_version",
+    "registry_schema_version",
+    "posture",
+    "source",
+    "correlation_nonce",
+    "producer",
+    "lanes",
+  ];
+  const exact = (value, expectedKeys, path) => {
+    if (value === null || Array.isArray(value) || typeof value !== "object") {
+      problems.push(`${path} must be an object`);
+      return false;
+    }
+    const actual = Object.keys(value).sort();
+    const wanted = [...expectedKeys].sort();
+    if (JSON.stringify(actual) !== JSON.stringify(wanted)) {
+      problems.push(`${path} keys must be exactly ${wanted.join(", ")}`);
+      return false;
+    }
+    return true;
+  };
+  if (!exact(document, keys, "native bundle")) {
+    throw new ContractError("invalid CI lane native bundle", problems);
+  }
+  if (document.schema_version !== NATIVE_EVIDENCE_SCHEMA_VERSION)
+    problems.push("native bundle schema_version is unsupported");
+  if (document.registry_schema_version !== registry.schema_version)
+    problems.push("native bundle registry schema does not match");
+  if (!postures.has(document.posture)) problems.push("native bundle posture is invalid");
+  if (!correlationNoncePattern.test(document.correlation_nonce))
+    problems.push("native bundle correlation_nonce is invalid");
+  if (!exact(document.source, ["sha", "tree"], "native bundle source")) {
+    // exact() records the shape problem.
+  } else if (
+    !shaPattern.test(document.source.sha) ||
+    !shaPattern.test(document.source.tree)
+  ) {
+    problems.push("native bundle source SHA/tree is invalid");
+  }
+  if (
+    exact(
+      document.producer,
+      ["repository", "workflow", "event", "run"],
+      "native bundle producer",
+    )
+  ) {
+    if (!repositoryPattern.test(document.producer.repository))
+      problems.push("native bundle producer repository is invalid");
+    if (!workflowPattern.test(document.producer.workflow))
+      problems.push("native bundle producer workflow is invalid");
+    if (!eventPattern.test(document.producer.event))
+      problems.push("native bundle producer event is invalid");
+    if (exact(document.producer.run, ["id", "attempt"], "native bundle producer run")) {
+      if (!runIDPattern.test(document.producer.run.id))
+        problems.push("native bundle producer run id is invalid");
+      if (!Number.isSafeInteger(document.producer.run.attempt) || document.producer.run.attempt < 1)
+        problems.push("native bundle producer run attempt is invalid");
+    }
+  }
+
+  for (const [field, actual] of [
+    ["posture", document.posture],
+    ["workflow", document.producer?.workflow],
+    ["repository", document.producer?.repository],
+    ["event", document.producer?.event],
+    ["runID", document.producer?.run?.id],
+    ["runAttempt", document.producer?.run?.attempt],
+    ["sha", document.source?.sha],
+    ["tree", document.source?.tree],
+    ["correlationNonce", document.correlation_nonce],
+  ]) {
+    if (expected[field] !== undefined && actual !== expected[field]) {
+      problems.push(`native bundle ${field} does not match trusted expectation`);
+    }
+  }
+
+  const lanes = nativeRoster(
+    registry,
+    document.producer?.workflow,
+    document.posture,
+  );
+  const expectedEntries = new Map(
+    lanes.flatMap((lane) =>
+      lane.executions.map((executionID) => [
+        `${lane.id}/${executionID}`,
+        lane,
+      ]),
+    ),
+  );
+  const actualEntries = new Map();
+  if (!Array.isArray(document.lanes)) {
+    problems.push("native bundle lanes must be an array");
+  } else {
+    for (let index = 0; index < document.lanes.length; index += 1) {
+      const entry = document.lanes[index];
+      const at = `native bundle lanes[${index}]`;
+      if (
+        !exact(
+          entry,
+          ["lane_id", "execution_id", "context", "checks", "evidence", "conclusion"],
+          at,
+        )
+      ) continue;
+      const identity = `${entry.lane_id}/${entry.execution_id}`;
+      const lane = expectedEntries.get(identity);
+      if (!lane) problems.push(`${at} is unexpected: ${identity}`);
+      if (actualEntries.has(identity)) problems.push(`${at} duplicates ${identity}`);
+      actualEntries.set(identity, entry);
+      if (lane && JSON.stringify(entry.context) !== JSON.stringify({
+        match: lane.context.match,
+        name: lane.context.name,
+        job_id: lane.owner.context_job,
+      })) problems.push(`${at} context does not match the registry`);
+      const expectedJobs = lane
+        ? lane.owner.jobs.filter((job) => job !== (expected.evidenceJob || "native-evidence"))
+        : [];
+      const checkJobs = Array.isArray(entry.checks)
+        ? entry.checks.map((check) => check?.job_id)
+        : [];
+      if (JSON.stringify(checkJobs) !== JSON.stringify(expectedJobs))
+        problems.push(`${at} checks do not match the registry job roster`);
+      if (!Array.isArray(entry.checks)) {
+        problems.push(`${at} checks must be an array`);
+        continue;
+      }
+      for (const check of entry.checks) {
+        if (!exact(check, ["job_id", "result"], `${at} check`)) continue;
+        if (!nativeResults.has(check.result)) problems.push(`${at} check result is invalid`);
+      }
+      const counts = evidenceCounts(entry.checks);
+      if (JSON.stringify(entry.evidence) !== JSON.stringify(counts))
+        problems.push(`${at} evidence counts are not derived from checks`);
+      if (entry.conclusion !== laneConclusion(entry.checks))
+        problems.push(`${at} conclusion is not derived from checks`);
+    }
+  }
+  for (const identity of expectedEntries.keys()) {
+    if (!actualEntries.has(identity)) problems.push(`native bundle is missing ${identity}`);
+  }
+  if (problems.length > 0)
+    throw new ContractError("invalid CI lane native bundle", problems);
+  return document;
+}
+
+export function nativeBundleEntries(document) {
+  return document.lanes.map((entry) => ({
+    lane_id: entry.lane_id,
+    execution_id: entry.execution_id,
+    sha256: canonicalJSONSHA256({
+      correlation_nonce: document.correlation_nonce,
+      entry,
+    }),
+  }));
+}
+
+export function writeNativeBundle(path, document) {
+  const output = resolve(path);
+  const parent = dirname(output);
+  if (!existsSync(parent) || !statSync(parent).isDirectory()) {
+    throw new ContractError("CI lane native evidence", [
+      `native output directory does not exist: ${parent}`,
+    ]);
+  }
+  if (existsSync(output)) {
+    throw new ContractError("CI lane native evidence", [
+      `native output already exists; refusing stale reuse: ${output}`,
+    ]);
+  }
+  const body = `${JSON.stringify(document, null, 2)}\n`;
+  const temporary = `${output}.${process.pid}.tmp`;
+  try {
+    writeFileSync(temporary, body, { encoding: "utf8", flag: "wx" });
+    linkSync(temporary, output);
+  } finally {
+    if (existsSync(temporary)) unlinkSync(temporary);
+  }
+  return Object.freeze({
+    path: output,
+    body,
+    sha256: createHash("sha256").update(body).digest("hex"),
+  });
+}
+
+function main(env = process.env) {
+  const root = resolve(process.cwd());
+  const output = String(env.CI_LANE_NATIVE_OUTPUT ?? "").trim();
+  if (output === "") {
+    throw new ContractError("CI lane native evidence", [
+      "CI_LANE_NATIVE_OUTPUT is required",
+    ]);
+  }
+  const registry = loadRegistry(
+    env.CI_LANE_REGISTRY || DEFAULT_REGISTRY_PATH,
+    { root },
+  );
+  const source = nativeCheckoutEvidence({
+    root,
+    expectedSHA: env.GITHUB_SHA,
+  });
+  const bundle = createNativeBundle({
+    registry,
+    workflow: env.CI_LANE_WORKFLOW,
+    needs: parseNeeds(env.CI_LANE_NEEDS_JSON),
+    source,
+    repository: env.GITHUB_REPOSITORY,
+    event: env.GITHUB_EVENT_NAME,
+    runID: env.GITHUB_RUN_ID,
+    runAttempt: env.GITHUB_RUN_ATTEMPT,
+    posture: env.CI_LANE_NATIVE_POSTURE || "merge",
+    evidenceJob: env.CI_LANE_EVIDENCE_JOB || "native-evidence",
+    correlationNonce: env.CI_LANE_CORRELATION_NONCE,
+  });
+  const written = writeNativeBundle(output, bundle);
+  setOutput("native_path", written.path);
+  setOutput("native_sha256", written.sha256);
+  setOutput("native_lane_count", String(bundle.lanes.length));
+  setOutput("native_correlation_nonce", bundle.correlation_nonce);
+  setOutput("native_artifact_name", nativeArtifactName(bundle.producer.workflow, bundle.producer.run));
+  notice(
+    `native evidence recorded ${bundle.lanes.length} lane execution(s) from ${bundle.producer.workflow}`,
+  );
+}
+
+const invokedDirectly =
+  process.argv[1] && fileURLToPath(import.meta.url) === resolve(process.argv[1]);
+if (invokedDirectly) {
+  try {
+    main();
+  } catch (nativeError) {
+    error(nativeError instanceof Error ? nativeError.message : String(nativeError), {
+      title: "CI lane native evidence failed closed",
+    });
+    process.exit(1);
+  }
+}

--- a/.github/scripts/ci-lane-native-evidence.mjs
+++ b/.github/scripts/ci-lane-native-evidence.mjs
@@ -2,14 +2,16 @@
 // evidence from a workflow's own `needs` graph.
 //
 // A workflow calls this once from an unconditional terminal evidence job. The
-// job passes GitHub's `toJSON(needs)` value; this script derives the lane and
-// check rosters from the registry and derives every count from those results.
-// It never accepts caller-supplied counts, lane conclusions, source trees, or
-// execution rosters.
+// job passes GitHub's `toJSON(needs)` value only to attest which registered
+// jobs reached which terminal result. Executed/passed/failed/skipped counts are
+// parsed from the registry's exact raw-part roster; a job result is never a
+// test count.
 //
 // Required environment:
 //   CI_LANE_WORKFLOW       canonical repository-relative workflow path.
 //   CI_LANE_NEEDS_JSON     GitHub `toJSON(needs)` for the evidence job.
+//   CI_LANE_NATIVE_PARTS   directory populated from attempt-qualified raw-part
+//                          artifacts declared by registry.native_evidence.
 //   CI_LANE_NATIVE_OUTPUT  new bundle path (must not already exist).
 //   GITHUB_EVENT_NAME      producer event.
 //   GITHUB_REPOSITORY      producer repository as owner/name.
@@ -31,6 +33,9 @@ import { createHash } from "node:crypto";
 import {
   existsSync,
   linkSync,
+  lstatSync,
+  readFileSync,
+  readdirSync,
   statSync,
   unlinkSync,
   writeFileSync,
@@ -46,10 +51,13 @@ import {
   deriveQualificationCorrelationNonce,
   loadRegistry,
   nativeArtifactName,
+  nativePartArtifactName,
+  NATIVE_PART_PARSERS,
 } from "./ci-lane-contract.mjs";
 import { capture, error, notice, setOutput } from "./lib/gh.mjs";
 
-export const NATIVE_EVIDENCE_SCHEMA_VERSION = 1;
+export const NATIVE_EVIDENCE_SCHEMA_VERSION = 2;
+export const MAX_NATIVE_PART_BYTES = 64 * 1024 * 1024;
 
 const shaPattern = /^(?:[0-9a-f]{40}|[0-9a-f]{64})$/;
 const runIDPattern = /^[1-9][0-9]*$/;
@@ -165,23 +173,551 @@ export function parseNeeds(raw) {
   return results;
 }
 
-function laneConclusion(checks) {
-  const results = checks.map((check) => check.result);
-  if (results.includes("failure")) return "failure";
-  if (results.includes("cancelled")) return "cancelled";
-  if (results.includes("skipped")) return "skipped";
-  return "success";
+const nativeSeedPattern = /^[^\u0000-\u001f\u007f]{1,1024}$/;
+
+function evidenceCounts({ passed = 0, failed = 0, skipped = 0 } = {}) {
+  for (const [name, value] of Object.entries({ passed, failed, skipped })) {
+    if (!Number.isSafeInteger(value) || value < 0) {
+      throw new ContractError("CI lane native evidence", [
+        `${name} evidence count must be a non-negative safe integer`,
+      ]);
+    }
+  }
+  return Object.freeze({
+    executed: passed + failed + skipped,
+    passed,
+    failed,
+    skipped,
+  });
 }
 
-function evidenceCounts(checks) {
-  return Object.freeze({
-    executed: checks.length,
-    passed: checks.filter((check) => check.result === "success").length,
-    failed: checks.filter(
-      (check) => check.result === "failure" || check.result === "cancelled",
-    ).length,
-    skipped: checks.filter((check) => check.result === "skipped").length,
+function safeIntegerSum(values, label) {
+  let total = 0;
+  for (const value of values) {
+    if (!Number.isSafeInteger(value) || value < 0) {
+      throw new ContractError("CI lane native evidence", [
+        `${label} values must be non-negative safe integers`,
+      ]);
+    }
+    total += value;
+    if (!Number.isSafeInteger(total)) {
+      throw new ContractError("CI lane native evidence", [
+        `${label} total exceeds the safe integer range`,
+      ]);
+    }
+  }
+  return total;
+}
+
+function milliseconds(value, label, { seconds = false } = {}) {
+  if (typeof value !== "number" || !Number.isFinite(value) || value < 0) {
+    throw new ContractError("CI lane native evidence", [
+      `${label} must be a non-negative finite number`,
+    ]);
+  }
+  const duration = Math.round(seconds ? value * 1000 : value);
+  if (!Number.isSafeInteger(duration)) {
+    throw new ContractError("CI lane native evidence", [
+      `${label} exceeds the safe integer range when converted to milliseconds`,
+    ]);
+  }
+  return duration;
+}
+
+function nativeSeed(value, label) {
+  if (value === null || value === undefined || value === "") return null;
+  if (typeof value !== "string" || !nativeSeedPattern.test(value)) {
+    throw new ContractError("CI lane native evidence", [
+      `${label} must be null or a non-empty printable string no longer than 1024 bytes`,
+    ]);
+  }
+  return value;
+}
+
+function uniqueSeed(values, label) {
+  const seeds = values.filter((value) => value !== null);
+  const unique = [...new Set(seeds)];
+  if (unique.length > 1) {
+    throw new ContractError("CI lane native evidence", [
+      `${label} reports conflicting native seeds`,
+    ]);
+  }
+  return unique[0] ?? null;
+}
+
+function corpusIdentity(parser, identities) {
+  if (!Array.isArray(identities) || identities.length === 0) {
+    throw new ContractError("CI lane native evidence", [
+      `${parser} contains no native corpus identities`,
+    ]);
+  }
+  for (const [index, identity] of identities.entries()) {
+    if (
+      typeof identity !== "string" ||
+      identity === "" ||
+      identity.includes("\u0000")
+    ) {
+      throw new ContractError("CI lane native evidence", [
+        `${parser} corpus identity ${index} is invalid`,
+      ]);
+    }
+  }
+  return `sha256:${canonicalJSONSHA256({
+    parser,
+    identities: [...identities].sort(),
+  })}`;
+}
+
+function parsedEvidence({ parser, outcomes, identities, durationMs, seed }) {
+  const counts = evidenceCounts({
+    passed: outcomes.filter((value) => value === "pass").length,
+    failed: outcomes.filter((value) => value === "fail").length,
+    skipped: outcomes.filter((value) => value === "skip").length,
   });
+  return Object.freeze({
+    ...counts,
+    duration_ms: milliseconds(durationMs, `${parser} duration_ms`),
+    seed: nativeSeed(seed, `${parser} seed`),
+    corpus_id: corpusIdentity(parser, identities),
+  });
+}
+
+function aggregateEvidence(parts, lane) {
+  const counts = evidenceCounts({
+    passed: safeIntegerSum(
+      parts.map((part) => part.evidence.passed),
+      `${lane.id} passed evidence`,
+    ),
+    failed: safeIntegerSum(
+      parts.map((part) => part.evidence.failed),
+      `${lane.id} failed evidence`,
+    ),
+    skipped: safeIntegerSum(
+      parts.map((part) => part.evidence.skipped),
+      `${lane.id} skipped evidence`,
+    ),
+  });
+  const seeds = parts.map((part) => part.evidence.seed);
+  if (
+    lane.determinism === "deterministic" &&
+    seeds.some((seed) => seed !== null)
+  ) {
+    throw new ContractError("CI lane native evidence", [
+      `${lane.id} is deterministic but a native part reports a seed`,
+    ]);
+  }
+  if (
+    lane.determinism === "seeded" &&
+    seeds.some((seed) => seed === null)
+  ) {
+    throw new ContractError("CI lane native evidence", [
+      `${lane.id} is seeded but a native part omitted its seed`,
+    ]);
+  }
+  const seed = uniqueSeed(seeds, lane.id);
+  return Object.freeze({
+    ...counts,
+    duration_ms: safeIntegerSum(
+      parts.map((part) => part.evidence.duration_ms),
+      `${lane.id} duration evidence`,
+    ),
+    seed,
+    corpus_id: corpusIdentity(
+      "lane-native-parts-v1",
+      parts.map(
+        (part) =>
+          JSON.stringify([part.id, part.parser, part.evidence.corpus_id]),
+      ),
+    ),
+  });
+}
+
+function parseJSON(text, label) {
+  try {
+    return JSON.parse(text);
+  } catch (parseError) {
+    throw new ContractError("CI lane native evidence", [
+      `${label} is not valid JSON: ${parseError.message}`,
+    ]);
+  }
+}
+
+function exactKeys(value, keys, label) {
+  if (value === null || Array.isArray(value) || typeof value !== "object") {
+    throw new ContractError("CI lane native evidence", [
+      `${label} must be an object`,
+    ]);
+  }
+  const actual = Object.keys(value).sort();
+  const expected = [...keys].sort();
+  if (JSON.stringify(actual) !== JSON.stringify(expected)) {
+    throw new ContractError("CI lane native evidence", [
+      `${label} keys must be exactly ${expected.join(", ")}`,
+    ]);
+  }
+}
+
+export function parseGoTestJSON(text) {
+  const terminal = new Map();
+  const packageTerminal = new Map();
+  const nativeSeeds = [];
+  const lines = String(text ?? "")
+    .split(/\r?\n/)
+    .filter((line) => line.trim() !== "");
+  for (let index = 0; index < lines.length; index += 1) {
+    const event = parseJSON(lines[index], `go-test-json line ${index + 1}`);
+    if (typeof event?.Action !== "string") {
+      throw new ContractError("CI lane native evidence", [
+        `go-test-json line ${index + 1} has no Action`,
+      ]);
+    }
+    if (typeof event.Output === "string") {
+      const seedMatch = /^CI_NATIVE_SEED=(.+)\r?\n?$/.exec(event.Output);
+      if (seedMatch) nativeSeeds.push(nativeSeed(seedMatch[1], "go-test-json seed"));
+    }
+    if (!new Set(["pass", "fail", "skip"]).has(event.Action)) continue;
+    const packageName = String(event.Package ?? "");
+    if (typeof event.Test !== "string" || event.Test === "") {
+      if (packageName === "" || packageTerminal.has(packageName)) {
+        throw new ContractError("CI lane native evidence", [
+          packageName === ""
+            ? `go-test-json line ${index + 1} has a package terminal with no Package`
+            : `go-test-json repeats package terminal result for ${packageName}`,
+        ]);
+      }
+      packageTerminal.set(packageName, {
+        action: event.Action,
+        duration_ms: milliseconds(
+          event.Elapsed,
+          `go-test-json package ${packageName} Elapsed`,
+          { seconds: true },
+        ),
+      });
+      continue;
+    }
+    if (packageName === "") {
+      throw new ContractError("CI lane native evidence", [
+        `go-test-json terminal result for ${event.Test} has no Package`,
+      ]);
+    }
+    const key = `${packageName}\u0000${event.Test}`;
+    if (terminal.has(key)) {
+      throw new ContractError("CI lane native evidence", [
+        `go-test-json repeats terminal result for ${packageName}/${event.Test}`,
+      ]);
+    }
+    terminal.set(key, event.Action);
+  }
+  const testPackages = new Set(
+    [...terminal.keys()].map((key) => key.split("\u0000", 1)[0]),
+  );
+  const missingPackageTerminals = [...testPackages].filter(
+    (packageName) => !packageTerminal.has(packageName),
+  );
+  if (missingPackageTerminals.length > 0) {
+    throw new ContractError("CI lane native evidence", [
+      `go-test-json is missing package terminal result(s): ${missingPackageTerminals.sort().join(", ")}`,
+    ]);
+  }
+  return parsedEvidence({
+    parser: "go-test-json-v1",
+    outcomes: [...terminal.values()],
+    identities: [...terminal.keys()].map((key) =>
+      JSON.stringify(key.split("\u0000")),
+    ),
+    durationMs: safeIntegerSum(
+      [...testPackages].map(
+        (packageName) => packageTerminal.get(packageName).duration_ms,
+      ),
+      "go-test-json package durations",
+    ),
+    seed: uniqueSeed(nativeSeeds, "go-test-json"),
+  });
+}
+
+export function parseNodeTAP(text) {
+  const outcomes = [];
+  const identities = [];
+  const plans = [];
+  const durations = [];
+  const nativeSeeds = [];
+  for (const raw of String(text ?? "").split(/\r?\n/)) {
+    if (/^1\.\.[0-9]+(?:\s|$)/.test(raw)) {
+      plans.push(Number(raw.match(/^1\.\.([0-9]+)/)[1]));
+      continue;
+    }
+    const durationMatch = /^#\s*duration_ms(?::|\s)\s*([0-9]+(?:\.[0-9]+)?)\s*$/i.exec(
+      raw,
+    );
+    if (durationMatch) {
+      durations.push(
+        milliseconds(
+          Number(durationMatch[1]),
+          "node TAP duration_ms summary",
+        ),
+      );
+      continue;
+    }
+    const seedMatch = /^#\s*ci-native-seed:\s*(.+)\s*$/i.exec(raw);
+    if (seedMatch) {
+      nativeSeeds.push(nativeSeed(seedMatch[1], "node TAP seed"));
+      continue;
+    }
+    const directiveIndex = raw.search(/\s+#\s*(?:SKIP|TODO)\b/i);
+    const assertion = directiveIndex < 0 ? raw : raw.slice(0, directiveIndex);
+    const directive =
+      directiveIndex < 0
+        ? ""
+        : /(?:SKIP|TODO)/i.exec(raw.slice(directiveIndex))[0].toUpperCase();
+    const match = /^(ok|not ok)\s+([1-9][0-9]*)(?:\s+-\s+(.+?))?\s*$/i.exec(
+      assertion,
+    );
+    if (!match) continue;
+    const ordinal = Number(match[2]);
+    if (ordinal !== outcomes.length + 1) {
+      throw new ContractError("CI lane native evidence", [
+        `node TAP result ordinal ${ordinal} is not the expected ${outcomes.length + 1}`,
+      ]);
+    }
+    const name = String(match[3] ?? "").trim();
+    outcomes.push(
+      directive === "SKIP" || directive === "TODO"
+        ? "skip"
+        : match[1].toLowerCase() === "ok"
+          ? "pass"
+          : "fail",
+    );
+    identities.push(JSON.stringify([ordinal, name]));
+  }
+  if (plans.length !== 1 || plans[0] !== outcomes.length) {
+    throw new ContractError("CI lane native evidence", [
+      `node TAP top-level plan must exactly match its ${outcomes.length} result(s)`,
+    ]);
+  }
+  if (durations.length !== 1) {
+    throw new ContractError("CI lane native evidence", [
+      `node TAP must contain exactly one top-level duration_ms summary; found ${durations.length}`,
+    ]);
+  }
+  return parsedEvidence({
+    parser: "node-tap-v1",
+    outcomes,
+    identities,
+    durationMs: durations[0],
+    seed: uniqueSeed(nativeSeeds, "node TAP"),
+  });
+}
+
+function xmlAttribute(opening, name, label, { required = true } = {}) {
+  const escaped = name.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const match = new RegExp(`\\s${escaped}\\s*=\\s*(["'])([\\s\\S]*?)\\1`, "i").exec(
+    opening,
+  );
+  if (!match) {
+    if (!required) return null;
+    throw new ContractError("CI lane native evidence", [
+      `${label} is missing XML attribute ${name}`,
+    ]);
+  }
+  return match[2]
+    .replace(/&quot;/g, '"')
+    .replace(/&apos;/g, "'")
+    .replace(/&lt;/g, "<")
+    .replace(/&gt;/g, ">")
+    .replace(/&amp;/g, "&");
+}
+
+export function parseJUnitXML(text) {
+  const xml = String(text ?? "");
+  if (!/<testsuites?\b/i.test(xml)) {
+    throw new ContractError("CI lane native evidence", [
+      "JUnit has no testsuite root",
+    ]);
+  }
+  const cases =
+    xml.match(
+      /<testcase\b[^>]*\/\s*>|<testcase\b[^>]*>[\s\S]*?<\/testcase\s*>/gi,
+    ) ?? [];
+  const openings = xml.match(/<testcase\b/gi) ?? [];
+  if (cases.length !== openings.length) {
+    throw new ContractError("CI lane native evidence", [
+      "JUnit contains an unterminated testcase",
+    ]);
+  }
+  const outcomes = [];
+  const identities = [];
+  const durations = [];
+  for (const [index, testcase] of cases.entries()) {
+    const opening = /^<testcase\b[^>]*>/i.exec(testcase)?.[0];
+    if (!opening) {
+      throw new ContractError("CI lane native evidence", [
+        `JUnit testcase ${index} has no opening element`,
+      ]);
+    }
+    const name = xmlAttribute(opening, "name", `JUnit testcase ${index}`);
+    const className =
+      xmlAttribute(opening, "classname", `JUnit testcase ${index}`, {
+        required: false,
+      }) ?? "";
+    const file =
+      xmlAttribute(opening, "file", `JUnit testcase ${index}`, {
+        required: false,
+      }) ?? "";
+    const seconds = Number(
+      xmlAttribute(opening, "time", `JUnit testcase ${index}`),
+    );
+    durations.push(
+      milliseconds(seconds, `JUnit testcase ${index} time`, { seconds: true }),
+    );
+    identities.push(JSON.stringify([className, file, name]));
+    if (/<(?:failure|error)\b/i.test(testcase)) outcomes.push("fail");
+    else if (/<skipped\b/i.test(testcase)) outcomes.push("skip");
+    else outcomes.push("pass");
+  }
+  const nativeSeeds = [];
+  for (const property of xml.match(/<property\b[^>]*\/?\s*>/gi) ?? []) {
+    if (
+      xmlAttribute(property, "name", "JUnit property", { required: false }) ===
+      "ci-native-seed"
+    ) {
+      nativeSeeds.push(
+        nativeSeed(
+          xmlAttribute(property, "value", "JUnit ci-native-seed property"),
+          "JUnit seed",
+        ),
+      );
+    }
+  }
+  return parsedEvidence({
+    parser: "junit-xml-v1",
+    outcomes,
+    identities,
+    durationMs: safeIntegerSum(durations, "JUnit testcase durations"),
+    seed: uniqueSeed(nativeSeeds, "JUnit"),
+  });
+}
+
+export function parseCaseJSON(text) {
+  const document = parseJSON(String(text ?? ""), "case-json-v1");
+  exactKeys(document, ["schema_version", "seed", "cases"], "case-json-v1");
+  if (document.schema_version !== 1 || !Array.isArray(document.cases)) {
+    throw new ContractError("CI lane native evidence", [
+      "case-json-v1 schema_version must be 1 and cases must be an array",
+    ]);
+  }
+  const seen = new Set();
+  const durations = [];
+  const outcomes = document.cases.map((item, index) => {
+    exactKeys(
+      item,
+      ["id", "status", "duration_ms"],
+      `case-json-v1 cases[${index}]`,
+    );
+    if (typeof item.id !== "string" || item.id.trim() === "" || seen.has(item.id)) {
+      throw new ContractError("CI lane native evidence", [
+        `case-json-v1 cases[${index}].id must be unique and non-empty`,
+      ]);
+    }
+    seen.add(item.id);
+    if (!new Set(["passed", "failed", "skipped"]).has(item.status)) {
+      throw new ContractError("CI lane native evidence", [
+        `case-json-v1 cases[${index}].status is invalid`,
+      ]);
+    }
+    durations.push(
+      milliseconds(
+        item.duration_ms,
+        `case-json-v1 cases[${index}].duration_ms`,
+      ),
+    );
+    return { passed: "pass", failed: "fail", skipped: "skip" }[item.status];
+  });
+  return parsedEvidence({
+    parser: "case-json-v1",
+    outcomes,
+    identities: [...seen],
+    durationMs: safeIntegerSum(durations, "case-json-v1 case durations"),
+    seed: nativeSeed(document.seed, "case-json-v1 seed"),
+  });
+}
+
+export function parseCompatCasesJSON(text) {
+  const document = parseJSON(String(text ?? ""), "compat-cases-json-v1");
+  exactKeys(
+    document,
+    ["schema_version", "head", "seed", "cases"],
+    "compat-cases-json-v1",
+  );
+  if (
+    document.schema_version !== 1 ||
+    typeof document.head !== "string" ||
+    document.head.trim() === "" ||
+    !Array.isArray(document.cases)
+  ) {
+    throw new ContractError("CI lane native evidence", [
+      "compat-cases-json-v1 requires schema_version 1, a non-empty head, and a cases array",
+    ]);
+  }
+  const seen = new Set();
+  const outcomes = [];
+  const durations = [];
+  for (let index = 0; index < document.cases.length; index += 1) {
+    const item = document.cases[index];
+    exactKeys(
+      item,
+      ["id", "passed", "duration_ms"],
+      `compat-cases-json-v1 cases[${index}]`,
+    );
+    if (
+      typeof item.id !== "string" ||
+      item.id.trim() === "" ||
+      seen.has(item.id) ||
+      typeof item.passed !== "boolean"
+    ) {
+      throw new ContractError("CI lane native evidence", [
+        `compat-cases-json-v1 cases[${index}] must have a unique id and boolean passed`,
+      ]);
+    }
+    seen.add(item.id);
+    outcomes.push(item.passed ? "pass" : "fail");
+    durations.push(
+      milliseconds(
+        item.duration_ms,
+        `compat-cases-json-v1 cases[${index}].duration_ms`,
+      ),
+    );
+  }
+  return parsedEvidence({
+    parser: "compat-cases-json-v1",
+    outcomes,
+    identities: [...seen].map((id) => JSON.stringify([document.head, id])),
+    durationMs: safeIntegerSum(
+      durations,
+      "compat-cases-json-v1 case durations",
+    ),
+    seed: nativeSeed(document.seed, "compat-cases-json-v1 seed"),
+  });
+}
+
+export function parseNativePart(parser, text) {
+  if (!NATIVE_PART_PARSERS.includes(parser)) {
+    throw new ContractError("CI lane native evidence", [
+      `native part parser ${JSON.stringify(parser)} is not registered`,
+    ]);
+  }
+  if (parser === "go-test-json-v1") return parseGoTestJSON(text);
+  if (parser === "node-tap-v1") return parseNodeTAP(text);
+  if (parser === "junit-xml-v1") return parseJUnitXML(text);
+  if (parser === "case-json-v1") return parseCaseJSON(text);
+  return parseCompatCasesJSON(text);
+}
+
+function laneConclusion(jobResults, evidence) {
+  const results = jobResults.map((job) => job.result);
+  if (results.includes("failure") || evidence.failed > 0) return "failure";
+  if (results.includes("cancelled")) return "cancelled";
+  if (results.includes("skipped") || evidence.skipped > 0) return "skipped";
+  return "success";
 }
 
 function postureIncludes(lane, posture) {
@@ -197,6 +733,130 @@ function nativeRoster(registry, workflow, posture) {
   );
 }
 
+function nativeInvocationModes(lane, posture) {
+  const modes = [];
+  if (lane.applicability?.source) modes.push("source_tree");
+  if (posture === "release" && lane.applicability?.artifact) {
+    modes.push("candidate_artifact");
+  }
+  return modes;
+}
+
+function walkPartFiles(root, relative = "") {
+  const directory = resolve(root, relative);
+  const stat = lstatSync(directory);
+  if (!stat.isDirectory() || stat.isSymbolicLink()) {
+    throw new ContractError("CI lane native evidence", [
+      `native part path is not a real directory: ${directory}`,
+    ]);
+  }
+  const files = [];
+  for (const name of readdirSync(directory).sort()) {
+    const childRelative = relative === "" ? name : `${relative}/${name}`;
+    const child = resolve(root, childRelative);
+    const childStat = lstatSync(child);
+    if (childStat.isSymbolicLink()) {
+      throw new ContractError("CI lane native evidence", [
+        `native part tree contains a symbolic link: ${childRelative}`,
+      ]);
+    }
+    if (childStat.isDirectory()) files.push(...walkPartFiles(root, childRelative));
+    else if (childStat.isFile()) files.push(childRelative);
+    else {
+      throw new ContractError("CI lane native evidence", [
+        `native part tree contains a non-file entry: ${childRelative}`,
+      ]);
+    }
+  }
+  return files;
+}
+
+function expectedNativeParts(registry, lanes, runAttempt, posture) {
+  const identities = new Set(
+    lanes.flatMap((lane) =>
+      lane.executions.flatMap((executionID) =>
+        nativeInvocationModes(lane, posture).map(
+          (invocationMode) =>
+            `${lane.id}/${executionID}/${invocationMode}`,
+        ),
+      ),
+    ),
+  );
+  const parts = (registry.native_evidence?.parts ?? [])
+    .filter((part) =>
+      identities.has(
+        `${part.lane_id}/${part.execution_id}/${part.invocation_mode}`,
+      ),
+    )
+    .map((part) => ({
+      ...part,
+      artifact: nativePartArtifactName(part.id, runAttempt),
+    }))
+    .sort((left, right) =>
+      `${left.lane_id}/${left.execution_id}/${left.invocation_mode}/${left.id}`.localeCompare(
+        `${right.lane_id}/${right.execution_id}/${right.invocation_mode}/${right.id}`,
+      ),
+    );
+  const covered = new Set(
+    parts.map(
+      (part) =>
+        `${part.lane_id}/${part.execution_id}/${part.invocation_mode}`,
+    ),
+  );
+  const missing = [...identities].filter((identity) => !covered.has(identity)).sort();
+  if (missing.length > 0) {
+    throw new ContractError("CI lane native evidence", [
+      ...missing.map((identity) => `registry has no native part for ${identity}`),
+    ]);
+  }
+  return parts;
+}
+
+export function readNativeParts({ registry, lanes, runAttempt, posture, partsRoot }) {
+  const root = resolve(String(partsRoot ?? ""));
+  if (!existsSync(root)) {
+    throw new ContractError("CI lane native evidence", [
+      `native part directory does not exist: ${root}`,
+    ]);
+  }
+  const roster = expectedNativeParts(registry, lanes, runAttempt, posture);
+  const expectedFiles = roster.map((part) => `${part.artifact}/${part.entry}`).sort();
+  const actualFiles = walkPartFiles(root).sort();
+  if (JSON.stringify(actualFiles) !== JSON.stringify(expectedFiles)) {
+    throw new ContractError("CI lane native evidence", [
+      `native part files must exactly match the registry roster; got ${JSON.stringify(actualFiles)}, want ${JSON.stringify(expectedFiles)}`,
+    ]);
+  }
+  return roster.map((part) => {
+    const path = resolve(root, part.artifact, part.entry);
+    const stat = lstatSync(path);
+    if (!stat.isFile() || stat.isSymbolicLink() || stat.size > MAX_NATIVE_PART_BYTES) {
+      throw new ContractError("CI lane native evidence", [
+        `native part ${part.id} must be a regular file no larger than ${MAX_NATIVE_PART_BYTES} bytes`,
+      ]);
+    }
+    const body = readFileSync(path);
+    const evidence = parseNativePart(part.parser, body.toString("utf8"));
+    if (evidence.executed <= 0) {
+      throw new ContractError("CI lane native evidence", [
+        `native part ${part.id} executed zero tests/checks`,
+      ]);
+    }
+    return Object.freeze({
+      id: part.id,
+      lane_id: part.lane_id,
+      execution_id: part.execution_id,
+      invocation_mode: part.invocation_mode,
+      producer_job: part.producer_job,
+      parser: part.parser,
+      artifact: part.artifact,
+      entry: part.entry,
+      sha256: createHash("sha256").update(body).digest("hex"),
+      evidence,
+    });
+  });
+}
+
 export function createNativeBundle({
   registry,
   workflow,
@@ -209,6 +869,7 @@ export function createNativeBundle({
   posture = "merge",
   evidenceJob = "native-evidence",
   correlationNonce,
+  partsRoot,
 }) {
   const workflowPath = requirePattern(
     workflow,
@@ -291,32 +952,61 @@ export function createNativeBundle({
     throw new ContractError("CI lane native evidence", problems);
   }
 
+  const parsedParts = readNativeParts({
+    registry,
+    lanes,
+    runAttempt: attempt,
+    posture: postureName,
+    partsRoot,
+  });
+
   const laneEvidence = lanes
     .flatMap((lane) =>
-      lane.executions.map((executionID) => {
-        const checks = lane.owner.jobs
-          .filter((jobID) => jobID !== evidenceJobID)
-          .map((jobID) => ({
-            job_id: jobID,
-            result: needs.get(jobID),
-          }));
-        return {
-          lane_id: lane.id,
-          execution_id: executionID,
-          context: {
-            match: lane.context.match,
-            name: lane.context.name,
-            job_id: lane.owner.context_job,
-          },
-          checks,
-          evidence: evidenceCounts(checks),
-          conclusion: laneConclusion(checks),
-        };
-      }),
+      lane.executions.flatMap((executionID) =>
+        nativeInvocationModes(lane, postureName).map((invocationMode) => {
+          const jobResults = lane.owner.jobs
+            .filter((jobID) => jobID !== evidenceJobID)
+            .map((jobID) => ({
+              job_id: jobID,
+              result: needs.get(jobID),
+            }));
+          const parts = parsedParts
+            .filter(
+              (part) =>
+                part.lane_id === lane.id &&
+                part.execution_id === executionID &&
+                part.invocation_mode === invocationMode,
+            )
+            .map((part) => ({
+              id: part.id,
+              producer_job: part.producer_job,
+              parser: part.parser,
+              artifact: part.artifact,
+              entry: part.entry,
+              sha256: part.sha256,
+              evidence: part.evidence,
+            }));
+          const evidence = aggregateEvidence(parts, lane);
+          return {
+            lane_id: lane.id,
+            execution_id: executionID,
+            invocation_mode: invocationMode,
+            context: {
+              match: lane.context.match,
+              name: lane.context.name,
+              job_id: lane.owner.context_job,
+            },
+            job_results: jobResults,
+            parts,
+            evidence,
+            conclusion: laneConclusion(jobResults, evidence),
+          };
+        }),
+      ),
     )
     .sort((left, right) =>
-      `${left.lane_id}/${left.execution_id}`.localeCompare(
-        `${right.lane_id}/${right.execution_id}`,
+      `${left.lane_id}/${left.execution_id}/${left.invocation_mode}`.localeCompare(
+        `${right.lane_id}/${right.execution_id}/${right.invocation_mode}`,
       ),
     );
 
@@ -422,12 +1112,31 @@ export function validateNativeBundle(document, registry, expected = {}) {
   );
   const expectedEntries = new Map(
     lanes.flatMap((lane) =>
-      lane.executions.map((executionID) => [
-        `${lane.id}/${executionID}`,
-        lane,
-      ]),
+      lane.executions.flatMap((executionID) =>
+        nativeInvocationModes(lane, document.posture).map(
+          (invocationMode) => [
+            `${lane.id}/${executionID}/${invocationMode}`,
+            lane,
+          ],
+        ),
+      ),
     ),
   );
+  let expectedParts = [];
+  try {
+    expectedParts = expectedNativeParts(
+      registry,
+      lanes,
+      document.producer?.run?.attempt,
+      document.posture,
+    );
+  } catch (partError) {
+    problems.push(
+      ...(partError instanceof ContractError
+        ? partError.problems
+        : [String(partError)]),
+    );
+  }
   const actualEntries = new Map();
   if (!Array.isArray(document.lanes)) {
     problems.push("native bundle lanes must be an array");
@@ -438,11 +1147,12 @@ export function validateNativeBundle(document, registry, expected = {}) {
       if (
         !exact(
           entry,
-          ["lane_id", "execution_id", "context", "checks", "evidence", "conclusion"],
+          ["lane_id", "execution_id", "invocation_mode", "context", "job_results", "parts", "evidence", "conclusion"],
           at,
         )
       ) continue;
-      const identity = `${entry.lane_id}/${entry.execution_id}`;
+      const identity =
+        `${entry.lane_id}/${entry.execution_id}/${entry.invocation_mode}`;
       const lane = expectedEntries.get(identity);
       if (!lane) problems.push(`${at} is unexpected: ${identity}`);
       if (actualEntries.has(identity)) problems.push(`${at} duplicates ${identity}`);
@@ -455,24 +1165,119 @@ export function validateNativeBundle(document, registry, expected = {}) {
       const expectedJobs = lane
         ? lane.owner.jobs.filter((job) => job !== (expected.evidenceJob || "native-evidence"))
         : [];
-      const checkJobs = Array.isArray(entry.checks)
-        ? entry.checks.map((check) => check?.job_id)
+      const resultJobs = Array.isArray(entry.job_results)
+        ? entry.job_results.map((job) => job?.job_id)
         : [];
-      if (JSON.stringify(checkJobs) !== JSON.stringify(expectedJobs))
-        problems.push(`${at} checks do not match the registry job roster`);
-      if (!Array.isArray(entry.checks)) {
-        problems.push(`${at} checks must be an array`);
+      if (JSON.stringify(resultJobs) !== JSON.stringify(expectedJobs))
+        problems.push(`${at} job_results do not match the registry job roster`);
+      if (!Array.isArray(entry.job_results)) {
+        problems.push(`${at} job_results must be an array`);
         continue;
       }
-      for (const check of entry.checks) {
-        if (!exact(check, ["job_id", "result"], `${at} check`)) continue;
-        if (!nativeResults.has(check.result)) problems.push(`${at} check result is invalid`);
+      for (const job of entry.job_results) {
+        if (!exact(job, ["job_id", "result"], `${at} job result`)) continue;
+        if (!nativeResults.has(job.result)) problems.push(`${at} job result is invalid`);
       }
-      const counts = evidenceCounts(entry.checks);
-      if (JSON.stringify(entry.evidence) !== JSON.stringify(counts))
-        problems.push(`${at} evidence counts are not derived from checks`);
-      if (entry.conclusion !== laneConclusion(entry.checks))
-        problems.push(`${at} conclusion is not derived from checks`);
+      const wantedParts = expectedParts.filter(
+        (part) =>
+          part.lane_id === entry.lane_id &&
+          part.execution_id === entry.execution_id &&
+          part.invocation_mode === entry.invocation_mode,
+      );
+      const wantedPartIDs = wantedParts.map((part) => part.id);
+      const actualPartIDs = Array.isArray(entry.parts)
+        ? entry.parts.map((part) => part?.id)
+        : [];
+      if (JSON.stringify(actualPartIDs) !== JSON.stringify(wantedPartIDs)) {
+        problems.push(`${at} parts do not match the registry part roster`);
+      }
+      if (!Array.isArray(entry.parts)) {
+        problems.push(`${at} parts must be an array`);
+        continue;
+      }
+      for (let partIndex = 0; partIndex < entry.parts.length; partIndex += 1) {
+        const part = entry.parts[partIndex];
+        const partAt = `${at} parts[${partIndex}]`;
+        if (!exact(part, ["id", "producer_job", "parser", "artifact", "entry", "sha256", "evidence"], partAt)) continue;
+        const registered = wantedParts[partIndex];
+        if (
+          registered &&
+          JSON.stringify({
+            id: part.id,
+            producer_job: part.producer_job,
+            parser: part.parser,
+            artifact: part.artifact,
+            entry: part.entry,
+          }) !==
+            JSON.stringify({
+              id: registered.id,
+              producer_job: registered.producer_job,
+              parser: registered.parser,
+              artifact: registered.artifact,
+              entry: registered.entry,
+            })
+        ) {
+          problems.push(`${partAt} identity does not match the registry`);
+        }
+        if (!/^[0-9a-f]{64}$/.test(part.sha256)) {
+          problems.push(`${partAt} sha256 is invalid`);
+        }
+        if (
+          !exact(
+            part.evidence,
+            [
+              "executed",
+              "passed",
+              "failed",
+              "skipped",
+              "duration_ms",
+              "seed",
+              "corpus_id",
+            ],
+            `${partAt} evidence`,
+          )
+        ) continue;
+        for (const key of ["executed", "passed", "failed", "skipped"]) {
+          if (!Number.isSafeInteger(part.evidence[key]) || part.evidence[key] < 0) {
+            problems.push(`${partAt} evidence.${key} must be a non-negative safe integer`);
+          }
+        }
+        if (
+          part.evidence.executed !==
+          part.evidence.passed + part.evidence.failed + part.evidence.skipped
+        ) {
+          problems.push(`${partAt} evidence totals are inconsistent`);
+        }
+        if (part.evidence.executed <= 0) {
+          problems.push(`${partAt} executed zero tests/checks`);
+        }
+        if (
+          !Number.isSafeInteger(part.evidence.duration_ms) ||
+          part.evidence.duration_ms < 0
+        ) {
+          problems.push(`${partAt} evidence.duration_ms must be a non-negative safe integer`);
+        }
+        if (
+          part.evidence.seed !== null &&
+          (typeof part.evidence.seed !== "string" ||
+            !nativeSeedPattern.test(part.evidence.seed))
+        ) {
+          problems.push(`${partAt} evidence.seed is invalid`);
+        }
+        if (!/^sha256:[0-9a-f]{64}$/.test(part.evidence.corpus_id)) {
+          problems.push(`${partAt} evidence.corpus_id is invalid`);
+        }
+      }
+      let counts;
+      try {
+        counts = aggregateEvidence(entry.parts, lane);
+      } catch (countError) {
+        problems.push(countError instanceof Error ? countError.message : String(countError));
+      }
+      if (counts && JSON.stringify(entry.evidence) !== JSON.stringify(counts))
+        problems.push(`${at} evidence counts are not derived from native parts`);
+      if (counts && entry.conclusion !== laneConclusion(entry.job_results, counts))
+        problems.push(`${at} conclusion is not derived from native parts and job provenance`);
     }
   }
   for (const identity of expectedEntries.keys()) {
@@ -487,6 +1292,7 @@ export function nativeBundleEntries(document) {
   return document.lanes.map((entry) => ({
     lane_id: entry.lane_id,
     execution_id: entry.execution_id,
+    invocation_mode: entry.invocation_mode,
     sha256: canonicalJSONSHA256({
       correlation_nonce: document.correlation_nonce,
       entry,
@@ -530,6 +1336,12 @@ function main(env = process.env) {
       "CI_LANE_NATIVE_OUTPUT is required",
     ]);
   }
+  const partsRoot = String(env.CI_LANE_NATIVE_PARTS ?? "").trim();
+  if (partsRoot === "") {
+    throw new ContractError("CI lane native evidence", [
+      "CI_LANE_NATIVE_PARTS is required",
+    ]);
+  }
   const registry = loadRegistry(
     env.CI_LANE_REGISTRY || DEFAULT_REGISTRY_PATH,
     { root },
@@ -550,10 +1362,11 @@ function main(env = process.env) {
     posture: env.CI_LANE_NATIVE_POSTURE || "merge",
     evidenceJob: env.CI_LANE_EVIDENCE_JOB || "native-evidence",
     correlationNonce: env.CI_LANE_CORRELATION_NONCE,
+    partsRoot,
   });
   const written = writeNativeBundle(output, bundle);
   setOutput("native_path", written.path);
-  setOutput("native_sha256", written.sha256);
+  setOutput("native_bundle_sha256", written.sha256);
   setOutput("native_lane_count", String(bundle.lanes.length));
   setOutput("native_correlation_nonce", bundle.correlation_nonce);
   setOutput("native_artifact_name", nativeArtifactName(bundle.producer.workflow, bundle.producer.run));

--- a/.github/scripts/ci-lane-native-evidence.test.mjs
+++ b/.github/scripts/ci-lane-native-evidence.test.mjs
@@ -451,6 +451,17 @@ test("missing and extra workflow needs fail closed", () => {
   );
 });
 
+test("a lane that registers the evidence job in owner.jobs does not require it in needs", () => {
+  // The registry lists the evidence job in owner.jobs too (TestCILaneRegistry
+  // requires every workflow job, including native-evidence itself, to be
+  // claimed by some lane), but that job can never appear in its OWN `needs:`
+  // — a job cannot depend on itself. createNativeBundle must exclude it from
+  // the roster it checks against `needs`, not just from job_results.
+  const registry = registryFixture();
+  registry.lanes[0].owner.jobs = [...registry.lanes[0].owner.jobs, "native-evidence"];
+  assert.doesNotThrow(() => bundle({ registry }));
+});
+
 test("downloaded bundles are closed, total, and entry-digested", () => {
   const registry = registryFixture();
   const document = bundle({ registry });

--- a/.github/scripts/ci-lane-native-evidence.test.mjs
+++ b/.github/scripts/ci-lane-native-evidence.test.mjs
@@ -1,5 +1,11 @@
 import assert from "node:assert/strict";
-import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import {
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import test from "node:test";
@@ -7,11 +13,17 @@ import test from "node:test";
 import {
   ContractError,
   deriveQualificationCorrelationNonce,
+  nativePartArtifactName,
 } from "./ci-lane-contract.mjs";
 import {
   createNativeBundle,
   nativeBundleEntries,
+  parseCaseJSON,
+  parseCompatCasesJSON,
+  parseGoTestJSON,
+  parseJUnitXML,
   parseNeeds,
+  parseNodeTAP,
   validateNativeBundle,
   writeNativeBundle,
 } from "./ci-lane-native-evidence.mjs";
@@ -22,7 +34,15 @@ const correlationNonce = deriveQualificationCorrelationNonce({
   source,
 });
 
-function lane({ id, jobs, contextJob, mergePosture = "always" }) {
+function lane({
+  id,
+  jobs,
+  contextJob,
+  mergePosture = "always",
+  mainPosture = "always",
+  releasePosture = "required",
+  artifact = false,
+}) {
   return {
     id,
     executions: ["default"],
@@ -33,18 +53,105 @@ function lane({ id, jobs, contextJob, mergePosture = "always" }) {
     },
     context: { match: "exact", name: `${id}-check` },
     merge_posture: mergePosture,
+    main_posture: mainPosture,
+    release_posture: releasePosture,
+    applicability: { source: true, artifact },
   };
 }
 
 function registryFixture() {
   return {
     schema_version: 1,
+    native_evidence: {
+      schema_version: 1,
+      parts: [
+        {
+          id: "always-cases",
+          lane_id: "always",
+          execution_id: "default",
+          invocation_mode: "source_tree",
+          producer_job: "test",
+          parser: "case-json-v1",
+          entry: "cases.json",
+        },
+        {
+          id: "impact-cases",
+          lane_id: "impact",
+          execution_id: "default",
+          invocation_mode: "source_tree",
+          producer_job: "run",
+          parser: "case-json-v1",
+          entry: "cases.json",
+        },
+        {
+          id: "release-source-cases",
+          lane_id: "release-only",
+          execution_id: "default",
+          invocation_mode: "source_tree",
+          producer_job: "release",
+          parser: "case-json-v1",
+          entry: "cases.json",
+        },
+        {
+          id: "release-artifact-cases",
+          lane_id: "release-only",
+          execution_id: "default",
+          invocation_mode: "candidate_artifact",
+          producer_job: "release",
+          parser: "case-json-v1",
+          entry: "cases.json",
+        },
+      ],
+    },
     lanes: [
       lane({ id: "always", jobs: ["test", "aggregate"], contextJob: "aggregate" }),
       lane({ id: "impact", jobs: ["scope", "run", "gate"], contextJob: "gate" }),
-      lane({ id: "release-only", jobs: ["release"], contextJob: "release", mergePosture: "never" }),
+      lane({
+        id: "release-only",
+        jobs: ["release"],
+        contextJob: "release",
+        mergePosture: "never",
+        artifact: true,
+      }),
     ],
   };
+}
+
+function partsFixture(registry, runAttempt = 2, posture = "merge") {
+  const root = mkdtempSync(join(tmpdir(), "ci-lane-native-parts-"));
+  const lanes = new Map(registry.lanes.map((item) => [item.id, item]));
+  const parts = registry.native_evidence.parts.filter((part) => {
+    const item = lanes.get(part.lane_id);
+    if (posture === "merge") {
+      return (
+        item.merge_posture !== "never" &&
+        part.invocation_mode === "source_tree"
+      );
+    }
+    if (posture === "main") {
+      return (
+        item.main_posture !== "never" &&
+        part.invocation_mode === "source_tree"
+      );
+    }
+    return item.release_posture !== "post_publish";
+  });
+  for (const [index, part] of parts.entries()) {
+    const artifact = join(root, nativePartArtifactName(part.id, runAttempt));
+    mkdirSync(artifact, { recursive: true });
+    writeFileSync(
+      join(artifact, part.entry),
+      `${JSON.stringify({
+        schema_version: 1,
+        seed: `seed-${part.id}`,
+        cases: [
+          { id: `${part.id}-one`, status: "passed", duration_ms: index + 1 },
+          { id: `${part.id}-two`, status: "passed", duration_ms: index + 2 },
+        ],
+      })}\n`,
+    );
+  }
+  return root;
 }
 
 function needs(values = {}) {
@@ -61,22 +168,208 @@ function needs(values = {}) {
 }
 
 function bundle(overrides = {}) {
-  return createNativeBundle({
-    registry: registryFixture(),
-    workflow: ".github/workflows/ci.yml",
-    needs: needs(),
-    source,
-    repository: "example/project",
-    event: "pull_request",
-    runID: "123",
-    runAttempt: 2,
-    ...overrides,
-  });
+  const registry = overrides.registry ?? registryFixture();
+  const runAttempt = overrides.runAttempt ?? 2;
+  const posture = overrides.posture ?? "merge";
+  const ownedPartsRoot = overrides.partsRoot === undefined;
+  const partsRoot =
+    overrides.partsRoot ?? partsFixture(registry, runAttempt, posture);
+  try {
+    return createNativeBundle({
+      workflow: ".github/workflows/ci.yml",
+      needs: needs(),
+      source,
+      repository: "example/project",
+      event: "pull_request",
+      runID: "123",
+      ...overrides,
+      registry,
+      runAttempt,
+      partsRoot,
+    });
+  } finally {
+    if (ownedPartsRoot) rmSync(partsRoot, { recursive: true, force: true });
+  }
 }
 
-function execution(document, id) {
-  return document.lanes.find((item) => item.lane_id === id);
+function execution(document, id, invocationMode = "source_tree") {
+  return document.lanes.find(
+    (item) =>
+      item.lane_id === id && item.invocation_mode === invocationMode,
+  );
 }
+
+function assertEvidence(evidence, expected) {
+  assert.deepEqual(
+    {
+      executed: evidence.executed,
+      passed: evidence.passed,
+      failed: evidence.failed,
+      skipped: evidence.skipped,
+      duration_ms: evidence.duration_ms,
+      seed: evidence.seed,
+    },
+    expected,
+  );
+  assert.match(evidence.corpus_id, /^sha256:[0-9a-f]{64}$/);
+}
+
+test("native parser families derive counts, duration, seed, and corpus from raw bytes", () => {
+  const go = parseGoTestJSON(
+    [
+      { Action: "output", Output: "CI_NATIVE_SEED=go-seed\n" },
+      { Action: "pass", Package: "example/pkg", Test: "TestPass" },
+      { Action: "fail", Package: "example/pkg", Test: "TestFail" },
+      { Action: "skip", Package: "example/pkg", Test: "TestSkip" },
+      { Action: "fail", Package: "example/pkg", Elapsed: 0.123 },
+    ]
+      .map(JSON.stringify)
+      .join("\n"),
+  );
+  assertEvidence(go, {
+    executed: 3,
+    passed: 1,
+    failed: 1,
+    skipped: 1,
+    duration_ms: 123,
+    seed: "go-seed",
+  });
+
+  const tap = parseNodeTAP(
+    [
+      "TAP version 13",
+      "ok 1 - pass",
+      "not ok 2 - fail",
+      "ok 3 - omitted # SKIP",
+      "1..3",
+      "# ci-native-seed: tap-seed",
+      "# duration_ms 12.5",
+    ].join("\n"),
+  );
+  assertEvidence(tap, {
+    executed: 3,
+    passed: 1,
+    failed: 1,
+    skipped: 1,
+    duration_ms: 13,
+    seed: "tap-seed",
+  });
+
+  const junit = parseJUnitXML(
+    '<testsuite><properties><property name="ci-native-seed" value="xml-seed"/></properties>' +
+      '<testcase classname="suite" name="pass" time="0.001"/>' +
+      '<testcase classname="suite" name="fail" time="0.002"><failure/></testcase>' +
+      '<testcase classname="suite" name="skip" time="0.003"><skipped/></testcase>' +
+      "</testsuite>",
+  );
+  assertEvidence(junit, {
+    executed: 3,
+    passed: 1,
+    failed: 1,
+    skipped: 1,
+    duration_ms: 6,
+    seed: "xml-seed",
+  });
+
+  const cases = parseCaseJSON(
+    JSON.stringify({
+      schema_version: 1,
+      seed: null,
+      cases: [
+        { id: "a", status: "passed", duration_ms: 2 },
+        { id: "b", status: "failed", duration_ms: 3 },
+      ],
+    }),
+  );
+  assertEvidence(cases, {
+    executed: 2,
+    passed: 1,
+    failed: 1,
+    skipped: 0,
+    duration_ms: 5,
+    seed: null,
+  });
+
+  const compatibility = parseCompatCasesJSON(
+    JSON.stringify({
+      schema_version: 1,
+      head: "promql",
+      seed: "compat-seed",
+      cases: [
+        { id: "a", passed: true, duration_ms: 4 },
+        { id: "b", passed: false, duration_ms: 5 },
+      ],
+    }),
+  );
+  assertEvidence(compatibility, {
+    executed: 2,
+    passed: 1,
+    failed: 1,
+    skipped: 0,
+    duration_ms: 9,
+    seed: "compat-seed",
+  });
+});
+
+test("native parser families fail closed on incomplete or duplicate native output", () => {
+  assert.throws(
+    () =>
+      parseGoTestJSON(
+        JSON.stringify({
+          Action: "pass",
+          Package: "example/pkg",
+          Test: "TestWithoutPackageTerminal",
+        }),
+      ),
+    /missing package terminal/,
+  );
+  assert.throws(() => parseNodeTAP("ok 1 - pass\n1..1\n"), /duration_ms/);
+  assert.throws(
+    () => parseJUnitXML('<testsuite><testcase name="unterminated" time="1">'),
+    /unterminated testcase/,
+  );
+  assert.throws(
+    () =>
+      parseCaseJSON(
+        JSON.stringify({
+          schema_version: 1,
+          seed: null,
+          cases: [
+            { id: "same", status: "passed", duration_ms: 1 },
+            { id: "same", status: "passed", duration_ms: 1 },
+          ],
+        }),
+      ),
+    /unique and non-empty/,
+  );
+  assert.throws(
+    () =>
+      parseCompatCasesJSON(
+        JSON.stringify({
+          schema_version: 1,
+          head: "promql",
+          seed: null,
+          cases: [
+            { id: "same", passed: true, duration_ms: 1 },
+            { id: "same", passed: true, duration_ms: 1 },
+          ],
+        }),
+      ),
+    /unique id/,
+  );
+});
+
+test("green Actions jobs with missing native part files fail closed", () => {
+  const root = mkdtempSync(join(tmpdir(), "ci-lane-native-empty-"));
+  try {
+    assert.throws(
+      () => bundle({ partsRoot: root }),
+      /native part files must exactly match the registry roster/,
+    );
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
 
 test("derives a canonical lane and check roster from the registry", () => {
   const document = bundle();
@@ -91,7 +384,7 @@ test("derives a canonical lane and check roster from the registry", () => {
     document.lanes.map((item) => item.lane_id),
     ["always", "impact"],
   );
-  assert.deepEqual(execution(document, "always").checks, [
+  assert.deepEqual(execution(document, "always").job_results, [
     { job_id: "test", result: "success" },
     { job_id: "aggregate", result: "success" },
   ]);
@@ -100,7 +393,14 @@ test("derives a canonical lane and check roster from the registry", () => {
     passed: 2,
     failed: 0,
     skipped: 0,
+    duration_ms: 3,
+    seed: "seed-always-cases",
+    corpus_id: execution(document, "always").evidence.corpus_id,
   });
+  assert.match(
+    execution(document, "always").evidence.corpus_id,
+    /^sha256:[0-9a-f]{64}$/,
+  );
   assert.equal(execution(document, "always").conclusion, "success");
 });
 
@@ -111,10 +411,13 @@ test("a green context cannot hide a skipped producer", () => {
   const impact = execution(document, "impact");
   assert.equal(impact.conclusion, "skipped");
   assert.deepEqual(impact.evidence, {
-    executed: 3,
+    executed: 2,
     passed: 2,
     failed: 0,
-    skipped: 1,
+    skipped: 0,
+    duration_ms: 5,
+    seed: "seed-impact-cases",
+    corpus_id: impact.evidence.corpus_id,
   });
 });
 
@@ -123,13 +426,13 @@ test("failure and cancellation are retained as failed native checks", () => {
     needs: needs({ test: { result: "failure", outputs: {} } }),
   });
   assert.equal(execution(failed, "always").conclusion, "failure");
-  assert.equal(execution(failed, "always").evidence.failed, 1);
+  assert.equal(execution(failed, "always").evidence.failed, 0);
 
   const cancelled = bundle({
     needs: needs({ test: { result: "cancelled", outputs: {} } }),
   });
   assert.equal(execution(cancelled, "always").conclusion, "cancelled");
-  assert.equal(execution(cancelled, "always").evidence.failed, 1);
+  assert.equal(execution(cancelled, "always").evidence.failed, 0);
 });
 
 test("missing and extra workflow needs fail closed", () => {
@@ -156,8 +459,11 @@ test("downloaded bundles are closed, total, and entry-digested", () => {
     document,
   );
   assert.deepEqual(
-    nativeBundleEntries(document).map((entry) => `${entry.lane_id}/${entry.execution_id}`),
-    ["always/default", "impact/default"],
+    nativeBundleEntries(document).map(
+      (entry) =>
+        `${entry.lane_id}/${entry.execution_id}/${entry.invocation_mode}`,
+    ),
+    ["always/default/source_tree", "impact/default/source_tree"],
   );
   assert.ok(nativeBundleEntries(document).every((entry) => /^[0-9a-f]{64}$/.test(entry.sha256)));
   const replayedEntries = structuredClone(document);
@@ -188,13 +494,17 @@ test("release bundles require a coordinator correlation nonce", () => {
     () => bundle({ posture: "release" }),
     /release evidence requires an explicit CI_LANE_CORRELATION_NONCE/,
   );
+  const document = bundle({
+    posture: "release",
+    correlationNonce: "e".repeat(64),
+    needs: needs({ release: { result: "success", outputs: {} } }),
+  });
+  assert.equal(document.correlation_nonce, "e".repeat(64));
+  assert.ok(execution(document, "release-only", "source_tree"));
+  assert.ok(execution(document, "release-only", "candidate_artifact"));
   assert.equal(
-    bundle({
-      posture: "release",
-      correlationNonce: "e".repeat(64),
-      needs: needs({ release: { result: "success", outputs: {} } }),
-    }).correlation_nonce,
-    "e".repeat(64),
+    document.lanes.filter((item) => item.lane_id === "release-only").length,
+    2,
   );
 });
 

--- a/.github/scripts/ci-lane-native-evidence.test.mjs
+++ b/.github/scripts/ci-lane-native-evidence.test.mjs
@@ -1,0 +1,241 @@
+import assert from "node:assert/strict";
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+
+import {
+  ContractError,
+  deriveQualificationCorrelationNonce,
+} from "./ci-lane-contract.mjs";
+import {
+  createNativeBundle,
+  nativeBundleEntries,
+  parseNeeds,
+  validateNativeBundle,
+  writeNativeBundle,
+} from "./ci-lane-native-evidence.mjs";
+
+const source = Object.freeze({ sha: "a".repeat(40), tree: "b".repeat(40) });
+const correlationNonce = deriveQualificationCorrelationNonce({
+  posture: "merge",
+  source,
+});
+
+function lane({ id, jobs, contextJob, mergePosture = "always" }) {
+  return {
+    id,
+    executions: ["default"],
+    owner: {
+      workflow: ".github/workflows/ci.yml",
+      jobs: [...jobs],
+      context_job: contextJob,
+    },
+    context: { match: "exact", name: `${id}-check` },
+    merge_posture: mergePosture,
+  };
+}
+
+function registryFixture() {
+  return {
+    schema_version: 1,
+    lanes: [
+      lane({ id: "always", jobs: ["test", "aggregate"], contextJob: "aggregate" }),
+      lane({ id: "impact", jobs: ["scope", "run", "gate"], contextJob: "gate" }),
+      lane({ id: "release-only", jobs: ["release"], contextJob: "release", mergePosture: "never" }),
+    ],
+  };
+}
+
+function needs(values = {}) {
+  return parseNeeds(
+    JSON.stringify({
+      test: { result: "success", outputs: {} },
+      aggregate: { result: "success", outputs: {} },
+      scope: { result: "success", outputs: {} },
+      run: { result: "success", outputs: {} },
+      gate: { result: "success", outputs: {} },
+      ...values,
+    }),
+  );
+}
+
+function bundle(overrides = {}) {
+  return createNativeBundle({
+    registry: registryFixture(),
+    workflow: ".github/workflows/ci.yml",
+    needs: needs(),
+    source,
+    repository: "example/project",
+    event: "pull_request",
+    runID: "123",
+    runAttempt: 2,
+    ...overrides,
+  });
+}
+
+function execution(document, id) {
+  return document.lanes.find((item) => item.lane_id === id);
+}
+
+test("derives a canonical lane and check roster from the registry", () => {
+  const document = bundle();
+  assert.deepEqual(document.producer, {
+    repository: "example/project",
+    workflow: ".github/workflows/ci.yml",
+    event: "pull_request",
+    run: { id: "123", attempt: 2 },
+  });
+  assert.equal(document.correlation_nonce, correlationNonce);
+  assert.deepEqual(
+    document.lanes.map((item) => item.lane_id),
+    ["always", "impact"],
+  );
+  assert.deepEqual(execution(document, "always").checks, [
+    { job_id: "test", result: "success" },
+    { job_id: "aggregate", result: "success" },
+  ]);
+  assert.deepEqual(execution(document, "always").evidence, {
+    executed: 2,
+    passed: 2,
+    failed: 0,
+    skipped: 0,
+  });
+  assert.equal(execution(document, "always").conclusion, "success");
+});
+
+test("a green context cannot hide a skipped producer", () => {
+  const document = bundle({
+    needs: needs({ run: { result: "skipped", outputs: {} } }),
+  });
+  const impact = execution(document, "impact");
+  assert.equal(impact.conclusion, "skipped");
+  assert.deepEqual(impact.evidence, {
+    executed: 3,
+    passed: 2,
+    failed: 0,
+    skipped: 1,
+  });
+});
+
+test("failure and cancellation are retained as failed native checks", () => {
+  const failed = bundle({
+    needs: needs({ test: { result: "failure", outputs: {} } }),
+  });
+  assert.equal(execution(failed, "always").conclusion, "failure");
+  assert.equal(execution(failed, "always").evidence.failed, 1);
+
+  const cancelled = bundle({
+    needs: needs({ test: { result: "cancelled", outputs: {} } }),
+  });
+  assert.equal(execution(cancelled, "always").conclusion, "cancelled");
+  assert.equal(execution(cancelled, "always").evidence.failed, 1);
+});
+
+test("missing and extra workflow needs fail closed", () => {
+  const missing = needs();
+  missing.delete("test");
+  assert.throws(
+    () => bundle({ needs: missing }),
+    /native needs is missing registered job test/,
+  );
+
+  const extra = needs();
+  extra.set("invented", "success");
+  assert.throws(
+    () => bundle({ needs: extra }),
+    /native needs contains unregistered extra job invented/,
+  );
+});
+
+test("downloaded bundles are closed, total, and entry-digested", () => {
+  const registry = registryFixture();
+  const document = bundle({ registry });
+  assert.equal(
+    validateNativeBundle(document, registry, { correlationNonce }),
+    document,
+  );
+  assert.deepEqual(
+    nativeBundleEntries(document).map((entry) => `${entry.lane_id}/${entry.execution_id}`),
+    ["always/default", "impact/default"],
+  );
+  assert.ok(nativeBundleEntries(document).every((entry) => /^[0-9a-f]{64}$/.test(entry.sha256)));
+  const replayedEntries = structuredClone(document);
+  replayedEntries.correlation_nonce = "f".repeat(64);
+  assert.notDeepEqual(
+    nativeBundleEntries(replayedEntries),
+    nativeBundleEntries(document),
+  );
+
+  const missing = structuredClone(document);
+  missing.lanes.pop();
+  assert.throws(() => validateNativeBundle(missing, registry), /missing impact\/default/);
+
+  const dishonest = structuredClone(document);
+  dishonest.lanes[0].evidence.passed = 0;
+  assert.throws(() => validateNativeBundle(dishonest, registry), /counts are not derived/);
+
+  const replayed = structuredClone(document);
+  replayed.correlation_nonce = "f".repeat(64);
+  assert.throws(
+    () => validateNativeBundle(replayed, registry, { correlationNonce }),
+    /correlationNonce does not match trusted expectation/,
+  );
+});
+
+test("release bundles require a coordinator correlation nonce", () => {
+  assert.throws(
+    () => bundle({ posture: "release" }),
+    /release evidence requires an explicit CI_LANE_CORRELATION_NONCE/,
+  );
+  assert.equal(
+    bundle({
+      posture: "release",
+      correlationNonce: "e".repeat(64),
+      needs: needs({ release: { result: "success", outputs: {} } }),
+    }).correlation_nonce,
+    "e".repeat(64),
+  );
+});
+
+test("never-merge lanes do not expand the native needs roster", () => {
+  const document = bundle();
+  assert.equal(execution(document, "release-only"), undefined);
+  assert.equal(document.lanes.length, 2);
+});
+
+test("needs results use a closed schema", () => {
+  for (const raw of [
+    "",
+    "[]",
+    JSON.stringify({ job: { result: "neutral" } }),
+    JSON.stringify({ "not/a/job": { result: "success" } }),
+  ]) {
+    assert.throws(() => parseNeeds(raw), ContractError);
+  }
+});
+
+test("workflow, repository, source, and run identity are strict", () => {
+  for (const overrides of [
+    { workflow: "ci.yml" },
+    { repository: "project" },
+    { event: "pull-request" },
+    { runID: "0" },
+    { runAttempt: 0 },
+    { source: { sha: "bad", tree: source.tree } },
+  ]) {
+    assert.throws(() => bundle(overrides), ContractError);
+  }
+});
+
+test("bundle writer is canonical, atomic, and refuses stale reuse", (t) => {
+  const root = mkdtempSync(join(tmpdir(), "ci-lane-native-"));
+  t.after(() => rmSync(root, { recursive: true, force: true }));
+  const path = join(root, "bundle.json");
+  const document = bundle();
+  const written = writeNativeBundle(path, document);
+  assert.equal(written.body, `${JSON.stringify(document, null, 2)}\n`);
+  assert.equal(readFileSync(path, "utf8"), written.body);
+  assert.match(written.sha256, /^[0-9a-f]{64}$/);
+  assert.throws(() => writeNativeBundle(path, document), /stale reuse/);
+});

--- a/.github/scripts/ci-lane-native-part.mjs
+++ b/.github/scripts/ci-lane-native-part.mjs
@@ -1,0 +1,88 @@
+// Emit one closed case-json-v1 completion record after a registered producer
+// job reaches the end of its real work. The step is intentionally placed after
+// that work and is not marked always(): failed, cancelled, or skipped work
+// produces no artifact, which makes native-bundle assembly fail closed.
+//
+// Env:
+//   CI_NATIVE_PART_ID       registry native_evidence.parts[].id
+//   CI_NATIVE_PART_OUTPUT   output path; must not already exist
+//   CI_NATIVE_SEED          exact deterministic seed used by a seeded lane;
+//                           empty for deterministic lanes
+//   CI_NATIVE_DURATION_MS   optional non-negative integer; default 0 because
+//                           Actions job provenance owns wall-clock duration
+
+import {
+  existsSync,
+  mkdirSync,
+  renameSync,
+  writeFileSync,
+} from "node:fs";
+import { dirname, resolve } from "node:path";
+import process from "node:process";
+import { fileURLToPath } from "node:url";
+
+const partIDPattern = /^[a-z0-9][a-z0-9.-]*$/;
+const seedPattern = /^[^\u0000-\u001f\u007f]{1,1024}$/;
+
+export function nativeCase({ id, seed = "", durationMS = 0 }) {
+  const partID = String(id ?? "").trim();
+  if (!partIDPattern.test(partID)) {
+    throw new Error("CI_NATIVE_PART_ID must be a canonical native part id");
+  }
+  const seedValue = String(seed ?? "");
+  if (seedValue !== "" && !seedPattern.test(seedValue)) {
+    throw new Error("CI_NATIVE_SEED must be empty or a printable seed");
+  }
+  const duration =
+    typeof durationMS === "number" ? durationMS : Number(durationMS || 0);
+  if (!Number.isSafeInteger(duration) || duration < 0) {
+    throw new Error("CI_NATIVE_DURATION_MS must be a non-negative safe integer");
+  }
+  return Object.freeze({
+    schema_version: 1,
+    seed: seedValue === "" ? null : seedValue,
+    cases: [
+      {
+        id: `${partID}-completed`,
+        status: "passed",
+        duration_ms: duration,
+      },
+    ],
+  });
+}
+
+export function writeNativeCase(path, document) {
+  const output = resolve(String(path ?? ""));
+  if (existsSync(output)) {
+    throw new Error(`native part output already exists; refusing stale reuse: ${output}`);
+  }
+  mkdirSync(dirname(output), { recursive: true });
+  const temporary = `${output}.tmp-${process.pid}`;
+  writeFileSync(temporary, `${JSON.stringify(document, null, 2)}\n`, {
+    flag: "wx",
+  });
+  renameSync(temporary, output);
+  return output;
+}
+
+function main() {
+  try {
+    const document = nativeCase({
+      id: process.env.CI_NATIVE_PART_ID,
+      seed: process.env.CI_NATIVE_SEED,
+      durationMS: process.env.CI_NATIVE_DURATION_MS,
+    });
+    const output = writeNativeCase(process.env.CI_NATIVE_PART_OUTPUT, document);
+    process.stdout.write(`native_part=${output}\n`);
+  } catch (error) {
+    process.stderr.write(`::error::${error instanceof Error ? error.message : String(error)}\n`);
+    process.exitCode = 1;
+  }
+}
+
+if (
+  process.argv[1] &&
+  resolve(process.argv[1]) === fileURLToPath(import.meta.url)
+) {
+  main();
+}

--- a/.github/scripts/ci-lane-native-part.test.mjs
+++ b/.github/scripts/ci-lane-native-part.test.mjs
@@ -1,0 +1,65 @@
+import assert from "node:assert/strict";
+import {
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+
+import { parseCaseJSON } from "./ci-lane-native-evidence.mjs";
+import {
+  nativeCase,
+  writeNativeCase,
+} from "./ci-lane-native-part.mjs";
+
+test("completion records are closed parseable native evidence", () => {
+  const document = nativeCase({
+    id: "ci-check.source",
+    seed: "seed-42",
+    durationMS: 7,
+  });
+  assert.deepEqual(document, {
+    schema_version: 1,
+    seed: "seed-42",
+    cases: [
+      {
+        id: "ci-check.source-completed",
+        status: "passed",
+        duration_ms: 7,
+      },
+    ],
+  });
+  assert.deepEqual(parseCaseJSON(JSON.stringify(document)), {
+    executed: 1,
+    passed: 1,
+    failed: 0,
+    skipped: 0,
+    duration_ms: 7,
+    seed: "seed-42",
+    corpus_id: parseCaseJSON(JSON.stringify(document)).corpus_id,
+  });
+});
+
+test("invalid identity, seed, and duration fail closed", () => {
+  assert.throws(() => nativeCase({ id: "" }), /canonical native part id/);
+  assert.throws(
+    () => nativeCase({ id: "part", seed: "bad\nseed" }),
+    /printable seed/,
+  );
+  assert.throws(
+    () => nativeCase({ id: "part", durationMS: -1 }),
+    /non-negative safe integer/,
+  );
+});
+
+test("writer is atomic and refuses stale reuse", (t) => {
+  const root = mkdtempSync(join(tmpdir(), "ci-native-part-"));
+  t.after(() => rmSync(root, { recursive: true, force: true }));
+  const path = join(root, "nested", "cases.json");
+  const document = nativeCase({ id: "part" });
+  assert.equal(writeNativeCase(path, document), path);
+  assert.equal(readFileSync(path, "utf8"), `${JSON.stringify(document, null, 2)}\n`);
+  assert.throws(() => writeNativeCase(path, document), /stale reuse/);
+});

--- a/.github/scripts/ci-lane-selection.mjs
+++ b/.github/scripts/ci-lane-selection.mjs
@@ -1,0 +1,432 @@
+// ci-lane-selection.mjs — derive a total, fail-closed merge-lane selection
+// from the exact projected checkout. No changed path, tree identity, lane
+// roster, or selector conclusion is accepted from the caller.
+//
+// Required environment:
+//   CI_LANE_BASE_SHA          target-base commit for the projected change.
+//   CI_LANE_HEAD_SHA          exact projected commit checked out at HEAD.
+//   CI_LANE_SELECTION_OUTPUT  new manifest path (must not already exist).
+//   GITHUB_RUN_ID             qualification workflow run id.
+//   GITHUB_RUN_ATTEMPT        positive qualification attempt number.
+//
+// Optional environment:
+//   CI_LANE_REGISTRY          registry path (default .github/ci-lanes.json).
+//   GITHUB_OUTPUT             Actions step-output destination.
+//
+// Unknown paths, an empty diff, an unavailable merge base/diff, or a filename
+// that cannot enter the canonical manifest select every conditional lane.
+// Registry, checkout, run-identity, validation, and output-write failures are
+// hard failures because no trustworthy full roster can be emitted without
+// them. Node builtins only.
+
+import { createHash } from "node:crypto";
+import {
+  existsSync,
+  linkSync,
+  statSync,
+  unlinkSync,
+  writeFileSync,
+} from "node:fs";
+import { dirname, resolve } from "node:path";
+import process from "node:process";
+import { TextDecoder } from "node:util";
+import { fileURLToPath } from "node:url";
+
+import {
+  ContractError,
+  DEFAULT_REGISTRY_PATH,
+  deriveQualificationCorrelationNonce,
+  loadRegistry,
+  matchesGlob,
+  validateChangedPaths,
+  validateSelection,
+} from "./ci-lane-contract.mjs";
+import { capture, error, notice, setOutput, warning } from "./lib/gh.mjs";
+
+export const FALLBACK_REASONS = Object.freeze([
+  "none",
+  "empty_diff",
+  "unknown_paths",
+  "merge_base_unavailable",
+  "diff_unavailable",
+  "unrepresentable_path",
+]);
+
+const shaPattern = /^(?:[0-9a-f]{40}|[0-9a-f]{64})$/;
+const runIDPattern = /^[1-9][0-9]*$/;
+const decoder = new TextDecoder("utf-8", { fatal: true });
+
+function requirePattern(value, pattern, name) {
+  const text = String(value ?? "").trim();
+  if (!pattern.test(text)) {
+    throw new ContractError("CI lane selector", [
+      `${name} has invalid value ${JSON.stringify(text)}`,
+    ]);
+  }
+  return text;
+}
+
+export function parseRunAttempt(value) {
+  const text = requirePattern(value, runIDPattern, "GITHUB_RUN_ATTEMPT");
+  const attempt = Number(text);
+  if (!Number.isSafeInteger(attempt)) {
+    throw new ContractError("CI lane selector", [
+      `GITHUB_RUN_ATTEMPT exceeds JavaScript's safe integer range: ${text}`,
+    ]);
+  }
+  return attempt;
+}
+
+function gitText(root, args) {
+  return capture("git", args, { cwd: root });
+}
+
+export function checkoutEvidence({ root, headSHA }) {
+  const expected = requirePattern(headSHA, shaPattern, "CI_LANE_HEAD_SHA");
+  const top = gitText(root, ["rev-parse", "--show-toplevel"]);
+  if (top.status !== 0 || resolve(top.stdout.trim()) !== resolve(root)) {
+    throw new ContractError("CI lane selector", [
+      "selector must run from the repository root",
+    ]);
+  }
+
+  const actual = gitText(root, ["rev-parse", "--verify", "HEAD^{commit}"]);
+  if (actual.status !== 0 || actual.stdout.trim() !== expected) {
+    throw new ContractError("CI lane selector", [
+      `checkout HEAD is ${JSON.stringify(actual.stdout.trim())}, want ${expected}`,
+    ]);
+  }
+  const status = gitText(root, [
+    "status",
+    "--porcelain=v1",
+    "--untracked-files=all",
+  ]);
+  if (status.status !== 0) {
+    throw new ContractError("CI lane selector", [
+      `git status failed: ${status.stderr.trim()}`,
+    ]);
+  }
+  if (status.stdout !== "") {
+    throw new ContractError("CI lane selector", [
+      "projected checkout is not clean before selection",
+    ]);
+  }
+
+  const tree = gitText(root, ["rev-parse", "--verify", `${expected}^{tree}`]);
+  const treeSHA = tree.stdout.trim();
+  if (tree.status !== 0 || !shaPattern.test(treeSHA)) {
+    throw new ContractError("CI lane selector", [
+      `cannot derive the projected tree: ${tree.stderr.trim() || treeSHA}`,
+    ]);
+  }
+  return Object.freeze({ sha: expected, tree: treeSHA });
+}
+
+function fallback(reason, detail) {
+  return Object.freeze({ changedPaths: [], reason, detail });
+}
+
+export function deriveChangedPaths({ root, baseSHA, headSHA }) {
+  const base = requirePattern(baseSHA, shaPattern, "CI_LANE_BASE_SHA");
+  const head = requirePattern(headSHA, shaPattern, "CI_LANE_HEAD_SHA");
+  const mergeBase = gitText(root, ["merge-base", base, head]);
+  const mergeBaseSHA = mergeBase.stdout.trim();
+  if (mergeBase.status !== 0 || !shaPattern.test(mergeBaseSHA)) {
+    return fallback(
+      "merge_base_unavailable",
+      mergeBase.stderr.trim() || "git merge-base returned no commit",
+    );
+  }
+
+  const diff = capture(
+    "git",
+    [
+      "diff",
+      "--no-ext-diff",
+      "--no-textconv",
+      "--no-renames",
+      "--name-only",
+      "-z",
+      mergeBaseSHA,
+      head,
+      "--",
+    ],
+    { cwd: root, encoding: null },
+  );
+  if (diff.status !== 0) {
+    return fallback(
+      "diff_unavailable",
+      String(diff.stderr).trim() || "git diff failed",
+    );
+  }
+
+  let decoded;
+  try {
+    decoded = decoder.decode(diff.stdout);
+  } catch (decodeError) {
+    return fallback("unrepresentable_path", decodeError.message);
+  }
+  if (decoded !== "" && !decoded.endsWith("\0")) {
+    return fallback(
+      "diff_unavailable",
+      "NUL-delimited git diff did not end at a path boundary",
+    );
+  }
+  const changedPaths = [
+    ...new Set(decoded.split("\0").filter((path) => path !== "")),
+  ].sort();
+  const problems = [];
+  validateChangedPaths(changedPaths, "derived changed paths", problems);
+  if (problems.length > 0) {
+    return fallback("unrepresentable_path", problems.join("; "));
+  }
+  if (changedPaths.length === 0) {
+    return fallback("empty_diff", "projected diff contains no paths");
+  }
+  return Object.freeze({ changedPaths, reason: "none", detail: "" });
+}
+
+function matchesAny(path, globs) {
+  return globs.some((glob) => matchesGlob(path, glob));
+}
+
+export function selectionPolicy(registry, changedPaths, fallbackReason = "none") {
+  if (!FALLBACK_REASONS.includes(fallbackReason)) {
+    throw new ContractError("CI lane selector", [
+      `unsupported fallback reason ${JSON.stringify(fallbackReason)}`,
+    ]);
+  }
+  const paths = [...changedPaths];
+  const conditional = registry.lanes.filter(
+    (lane) =>
+      lane.merge_posture === "impact" ||
+      lane.merge_posture === "non_documentation",
+  );
+  const knownNonimpactGlobs =
+    registry.impact_selection?.known_nonimpact_globs ?? [];
+  const unknownPaths = paths.filter(
+    (path) =>
+      !conditional.some((lane) => matchesAny(path, lane.package_globs)) &&
+      !matchesAny(path, knownNonimpactGlobs),
+  );
+  let reason = fallbackReason;
+  if (reason === "none" && paths.length === 0) reason = "empty_diff";
+  if (reason === "none" && unknownPaths.length > 0)
+    reason = "unknown_paths";
+  const fallbackFull = reason !== "none";
+  const docsOnly =
+    paths.length > 0 &&
+    paths.every((path) => matchesAny(path, knownNonimpactGlobs));
+
+  const lanes = [...registry.lanes]
+    .sort((left, right) => left.id.localeCompare(right.id))
+    .map((lane) => {
+      const selected = () => ({
+        lane_id: lane.id,
+        disposition: "selected",
+        executions: [...lane.executions],
+        reason: null,
+      });
+      const omitted = (omissionReason) => ({
+        lane_id: lane.id,
+        disposition: "omitted",
+        executions: [],
+        reason: omissionReason,
+      });
+      if (lane.merge_posture === "always") return selected();
+      if (lane.merge_posture === "never")
+        return omitted("posture_excluded");
+      if (fallbackFull) return selected();
+
+      const directHit = paths.some((path) =>
+        matchesAny(path, lane.package_globs),
+      );
+      if (lane.merge_posture === "impact") {
+        if (directHit) return selected();
+        return omitted(docsOnly ? "docs_only" : "not_impacted");
+      }
+      if (lane.merge_posture === "non_documentation") {
+        if (directHit || !docsOnly) return selected();
+        return omitted("docs_only");
+      }
+      throw new ContractError("CI lane selector", [
+        `lane ${lane.id} has unsupported merge posture ${JSON.stringify(lane.merge_posture)}`,
+      ]);
+    });
+
+  return Object.freeze({
+    conclusion: fallbackFull ? "fallback_full" : "success",
+    fallbackReason: reason,
+    changedPaths: paths,
+    unknownPaths,
+    lanes,
+  });
+}
+
+export function createSelection({
+  registry,
+  baseSHA,
+  source,
+  runID,
+  runAttempt,
+  changedPaths,
+  fallbackReason = "none",
+  correlationNonce,
+}) {
+  const base = requirePattern(baseSHA, shaPattern, "CI_LANE_BASE_SHA");
+  const id = requirePattern(runID, runIDPattern, "GITHUB_RUN_ID");
+  const attempt =
+    typeof runAttempt === "number" ? runAttempt : parseRunAttempt(runAttempt);
+  if (!Number.isSafeInteger(attempt) || attempt < 1) {
+    throw new ContractError("CI lane selector", [
+      `GITHUB_RUN_ATTEMPT must be a positive safe integer; got ${JSON.stringify(runAttempt)}`,
+    ]);
+  }
+  const policy = selectionPolicy(registry, changedPaths, fallbackReason);
+  const qualificationNonce =
+    correlationNonce ??
+    deriveQualificationCorrelationNonce({ posture: "merge", source });
+  const document = {
+    schema_version: registry.selection_schema_version,
+    registry_schema_version: registry.schema_version,
+    report_schema_version: registry.report_schema_version,
+    posture: "merge",
+    source: { sha: source.sha, tree: source.tree },
+    candidate_digest: null,
+    correlation_nonce: qualificationNonce,
+    run: { id, attempt },
+    selector: {
+      conclusion: policy.conclusion,
+      base_sha: base,
+      head_sha: source.sha,
+      changed_paths: [...policy.changedPaths],
+      unknown_paths: [...policy.unknownPaths],
+    },
+    lanes: policy.lanes,
+  };
+  validateSelection(document, registry, {
+    posture: "merge",
+    sha: source.sha,
+    tree: source.tree,
+    correlationNonce: qualificationNonce,
+    runID: id,
+    runAttempt: attempt,
+    baseSHA: base,
+    changedPaths: policy.changedPaths,
+  });
+  return Object.freeze({ document, fallbackReason: policy.fallbackReason });
+}
+
+export function writeSelection(path, document) {
+  const output = resolve(path);
+  const parent = dirname(output);
+  if (!existsSync(parent) || !statSync(parent).isDirectory()) {
+    throw new ContractError("CI lane selector", [
+      `selection output directory does not exist: ${parent}`,
+    ]);
+  }
+  if (existsSync(output)) {
+    throw new ContractError("CI lane selector", [
+      `selection output already exists; refusing stale reuse: ${output}`,
+    ]);
+  }
+  const body = `${JSON.stringify(document, null, 2)}\n`;
+  const temporary = `${output}.${process.pid}.tmp`;
+  try {
+    writeFileSync(temporary, body, { encoding: "utf8", flag: "wx" });
+    linkSync(temporary, output);
+  } finally {
+    if (existsSync(temporary)) unlinkSync(temporary);
+  }
+  return Object.freeze({
+    path: output,
+    sha256: createHash("sha256").update(body).digest("hex"),
+    body,
+  });
+}
+
+function main(env = process.env) {
+  const root = resolve(process.cwd());
+  const baseSHA = requirePattern(
+    env.CI_LANE_BASE_SHA,
+    shaPattern,
+    "CI_LANE_BASE_SHA",
+  );
+  const headSHA = requirePattern(
+    env.CI_LANE_HEAD_SHA,
+    shaPattern,
+    "CI_LANE_HEAD_SHA",
+  );
+  const output = String(env.CI_LANE_SELECTION_OUTPUT ?? "").trim();
+  if (output === "") {
+    throw new ContractError("CI lane selector", [
+      "CI_LANE_SELECTION_OUTPUT is required",
+    ]);
+  }
+  const runID = requirePattern(env.GITHUB_RUN_ID, runIDPattern, "GITHUB_RUN_ID");
+  const runAttempt = parseRunAttempt(env.GITHUB_RUN_ATTEMPT);
+  const registry = loadRegistry(
+    env.CI_LANE_REGISTRY || DEFAULT_REGISTRY_PATH,
+    { root },
+  );
+  const source = checkoutEvidence({ root, headSHA });
+  const diff = deriveChangedPaths({ root, baseSHA, headSHA });
+  if (diff.reason !== "none") {
+    warning(
+      `CI lane selector is running the full conditional fence (${diff.reason}): ${diff.detail}`,
+      { title: "merge-fence selector fallback" },
+    );
+  }
+  const selection = createSelection({
+    registry,
+    baseSHA,
+    source,
+    runID,
+    runAttempt,
+    changedPaths: diff.changedPaths,
+    fallbackReason: diff.reason,
+  });
+  const written = writeSelection(output, selection.document);
+  const selected = selection.document.lanes.filter(
+    (lane) => lane.disposition === "selected",
+  );
+  const executions = selected.flatMap((lane) =>
+    lane.executions.map((executionID) => ({
+      lane_id: lane.lane_id,
+      execution_id: executionID,
+    })),
+  );
+  for (const [name, value] of [
+    ["selection_path", written.path],
+    ["selection_sha256", written.sha256],
+    ["source_sha", source.sha],
+    ["source_tree", source.tree],
+    ["correlation_nonce", selection.document.correlation_nonce],
+    ["base_sha", baseSHA],
+    ["changed_paths_json", JSON.stringify(selection.document.selector.changed_paths)],
+    ["unknown_paths_json", JSON.stringify(selection.document.selector.unknown_paths)],
+    ["selector_conclusion", selection.document.selector.conclusion],
+    ["selected_lane_ids_json", JSON.stringify(selected.map((lane) => lane.lane_id))],
+    ["selected_executions_json", JSON.stringify(executions)],
+    ["fallback_reason", selection.fallbackReason],
+  ]) {
+    setOutput(name, value);
+  }
+  notice(
+    `merge-fence selector chose ${executions.length} execution(s) across ${selected.length} lane(s); ` +
+      `conclusion=${selection.document.selector.conclusion}`,
+  );
+}
+
+const invokedDirectly =
+  process.argv[1] && fileURLToPath(import.meta.url) === resolve(process.argv[1]);
+if (invokedDirectly) {
+  try {
+    main();
+  } catch (selectionError) {
+    error(selectionError instanceof Error ? selectionError.message : String(selectionError), {
+      title: "merge-fence selector failed closed",
+    });
+    process.exit(1);
+  }
+}

--- a/.github/scripts/ci-lane-selection.test.mjs
+++ b/.github/scripts/ci-lane-selection.test.mjs
@@ -1,0 +1,296 @@
+// Negative controls for the merge-fence selector. These tests pin both safety
+// directions: uncertainty cannot omit work, and a successful precise routing
+// decision cannot silently keep unrelated expensive lanes selected.
+
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import {
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+
+import {
+  ContractError,
+  matchesGlob,
+  validateSelection,
+} from "./ci-lane-contract.mjs";
+import {
+  checkoutEvidence,
+  createSelection,
+  deriveChangedPaths,
+  parseRunAttempt,
+  selectionPolicy,
+  writeSelection,
+} from "./ci-lane-selection.mjs";
+
+const sha = (character) => character.repeat(40);
+
+function lane(id, mergePosture, packageGlobs) {
+  return {
+    id,
+    executions: ["default"],
+    package_globs: packageGlobs,
+    merge_posture: mergePosture,
+    main_posture: "always",
+    release_posture: "advisory",
+    applicability: { source: true, artifact: false },
+  };
+}
+
+function registryFixture() {
+  return {
+    schema_version: 1,
+    selection_schema_version: 1,
+    report_schema_version: 1,
+    impact_selection: {
+      known_nonimpact_globs: ["**/*.md", "docs/**"],
+    },
+    lanes: [
+      lane("always", "always", ["internal/**"]),
+      lane("impact-a", "impact", ["internal/a/**"]),
+      lane("impact-b", "impact", ["internal/b/**"]),
+      lane("never", "never", ["release/**"]),
+      lane("quickstart", "non_documentation", ["README.md", "runtime/**"]),
+    ],
+  };
+}
+
+function selectedIDs(policy) {
+  return policy.lanes
+    .filter((laneSelection) => laneSelection.disposition === "selected")
+    .map((laneSelection) => laneSelection.lane_id);
+}
+
+function laneSelection(policy, id) {
+  return policy.lanes.find((candidate) => candidate.lane_id === id);
+}
+
+function selection(changedPaths, fallbackReason = "none") {
+  return createSelection({
+    registry: registryFixture(),
+    baseSHA: sha("a"),
+    source: { sha: sha("b"), tree: sha("c") },
+    runID: "123",
+    runAttempt: 2,
+    changedPaths,
+    fallbackReason,
+  });
+}
+
+test("documentation-only changes omit conditional work with exact reasons", () => {
+  const result = selection(["docs/engine.md"]);
+  assert.equal(result.document.selector.conclusion, "success");
+  assert.deepEqual(selectedIDs(result.document), ["always"]);
+  for (const id of ["impact-a", "impact-b", "quickstart"]) {
+    assert.deepEqual(laneSelection(result.document, id), {
+      lane_id: id,
+      disposition: "omitted",
+      executions: [],
+      reason: "docs_only",
+    });
+  }
+});
+
+test("a direct README contract hit selects quickstart despite Markdown", () => {
+  const result = selection(["README.md"]);
+  assert.deepEqual(selectedIDs(result.document), ["always", "quickstart"]);
+  assert.equal(laneSelection(result.document, "impact-a").reason, "docs_only");
+});
+
+test("one code impact selects exactly its lane plus non-documentation", () => {
+  const result = selection(["internal/a/change.go"]);
+  assert.deepEqual(selectedIDs(result.document), [
+    "always",
+    "impact-a",
+    "quickstart",
+  ]);
+  assert.equal(laneSelection(result.document, "impact-b").reason, "not_impacted");
+  assert.equal(laneSelection(result.document, "never").reason, "posture_excluded");
+});
+
+test("overlapping globs select every direct owner", () => {
+  const registry = registryFixture();
+  registry.lanes[2].package_globs.push("internal/a/shared/**");
+  const result = selectionPolicy(registry, ["internal/a/shared/change.go"]);
+  assert.deepEqual(selectedIDs(result), [
+    "always",
+    "impact-a",
+    "impact-b",
+    "quickstart",
+  ]);
+});
+
+test("mixed documentation and code never manufactures docs-only omissions", () => {
+  const result = selection(["docs/engine.md", "internal/a/change.go"]);
+  assert.equal(laneSelection(result.document, "impact-b").reason, "not_impacted");
+  assert.equal(laneSelection(result.document, "quickstart").disposition, "selected");
+});
+
+test("unknown and empty path sets select every conditional lane", () => {
+  const unknown = selection(["new-surface/runtime.cfg"]);
+  assert.equal(unknown.document.selector.conclusion, "fallback_full");
+  assert.deepEqual(unknown.document.selector.unknown_paths, [
+    "new-surface/runtime.cfg",
+  ]);
+  assert.deepEqual(selectedIDs(unknown.document), [
+    "always",
+    "impact-a",
+    "impact-b",
+    "quickstart",
+  ]);
+
+  const empty = selection([]);
+  assert.equal(empty.document.selector.conclusion, "fallback_full");
+  assert.equal(empty.fallbackReason, "empty_diff");
+  assert.deepEqual(selectedIDs(empty.document), selectedIDs(unknown.document));
+  assert.equal(laneSelection(empty.document, "never").disposition, "omitted");
+});
+
+test("explicit diff failures select full conditional work but preserve never", () => {
+  for (const reason of [
+    "merge_base_unavailable",
+    "diff_unavailable",
+    "unrepresentable_path",
+  ]) {
+    const result = selection([], reason);
+    assert.equal(result.document.selector.conclusion, "fallback_full", reason);
+    assert.deepEqual(selectedIDs(result.document), [
+      "always",
+      "impact-a",
+      "impact-b",
+      "quickstart",
+    ]);
+    assert.equal(laneSelection(result.document, "never").reason, "posture_excluded");
+  }
+});
+
+test("contract rejects both missing work and extra unimpacted work", () => {
+  const { document } = selection(["internal/a/change.go"]);
+  const missing = structuredClone(document);
+  Object.assign(laneSelection(missing, "impact-a"), {
+    disposition: "omitted",
+    executions: [],
+    reason: "not_impacted",
+  });
+  assert.throws(
+    () => validateSelection(missing, registryFixture()),
+    /must select impacted lane impact-a/,
+  );
+
+  const extra = structuredClone(document);
+  Object.assign(laneSelection(extra, "impact-b"), {
+    disposition: "selected",
+    executions: ["default"],
+    reason: null,
+  });
+  assert.throws(
+    () => validateSelection(extra, registryFixture()),
+    /must omit unimpacted lane impact-b/,
+  );
+
+  const noQuickstart = structuredClone(document);
+  Object.assign(laneSelection(noQuickstart, "quickstart"), {
+    disposition: "omitted",
+    executions: [],
+    reason: "docs_only",
+  });
+  assert.throws(
+    () => validateSelection(noQuickstart, registryFixture()),
+    /must select non-documentation lane quickstart/,
+  );
+});
+
+test("glob matcher stays anchored with explicit star semantics", () => {
+  assert.equal(matchesGlob("README.md", "**/*.md"), true);
+  assert.equal(matchesGlob("docs/deep/file.md", "docs/**"), true);
+  assert.equal(matchesGlob("internal/a/x.go", "internal/*/*.go"), true);
+  assert.equal(matchesGlob("internal/a/deep/x.go", "internal/*/*.go"), false);
+  assert.equal(matchesGlob("nested/Dockerfile.local", "Dockerfile*"), false);
+  assert.equal(matchesGlob("Dockerfile.local", "Dockerfile*"), true);
+});
+
+test("manifest writer is canonical, atomic, and refuses stale reuse", (t) => {
+  const root = mkdtempSync(join(tmpdir(), "ci-lane-selection-write-"));
+  t.after(() => rmSync(root, { recursive: true, force: true }));
+  const path = join(root, "selection.json");
+  const document = selection(["internal/a/change.go"]).document;
+  const written = writeSelection(path, document);
+  assert.equal(written.body, `${JSON.stringify(document, null, 2)}\n`);
+  assert.equal(readFileSync(path, "utf8"), written.body);
+  assert.match(written.sha256, /^[0-9a-f]{64}$/);
+  assert.throws(() => writeSelection(path, document), /refusing stale reuse/);
+});
+
+function git(root, args) {
+  return execFileSync("git", args, { cwd: root, encoding: "utf8" }).trim();
+}
+
+function commit(root, message) {
+  git(root, ["add", "--all"]);
+  git(root, ["commit", "-m", message]);
+  return git(root, ["rev-parse", "HEAD"]);
+}
+
+test("git-derived evidence sees additions, deletions, and both rename paths", (t) => {
+  const root = mkdtempSync(join(tmpdir(), "ci-lane-selection-git-"));
+  t.after(() => rmSync(root, { recursive: true, force: true }));
+  git(root, ["init", "--quiet"]);
+  git(root, ["config", "user.name", "CI Test"]);
+  git(root, ["config", "user.email", "ci@example.invalid"]);
+  writeFileSync(join(root, "old.go"), "package old\n");
+  writeFileSync(join(root, "delete.go"), "package deleted\n");
+  const base = commit(root, "base");
+
+  git(root, ["mv", "old.go", "new.go"]);
+  rmSync(join(root, "delete.go"));
+  writeFileSync(join(root, "added.go"), "package added\n");
+  const head = commit(root, "change");
+  const diff = deriveChangedPaths({ root, baseSHA: base, headSHA: head });
+  assert.equal(diff.reason, "none");
+  assert.deepEqual(diff.changedPaths, [
+    "added.go",
+    "delete.go",
+    "new.go",
+    "old.go",
+  ]);
+
+  assert.deepEqual(checkoutEvidence({ root, headSHA: head }), {
+    sha: head,
+    tree: git(root, ["rev-parse", "HEAD^{tree}"]),
+  });
+  writeFileSync(join(root, "dirty.txt"), "dirty\n");
+  assert.throws(
+    () => checkoutEvidence({ root, headSHA: head }),
+    /checkout is not clean/,
+  );
+});
+
+test("unavailable and empty git diffs become explicit full fallbacks", (t) => {
+  const root = mkdtempSync(join(tmpdir(), "ci-lane-selection-fallback-"));
+  t.after(() => rmSync(root, { recursive: true, force: true }));
+  git(root, ["init", "--quiet"]);
+  git(root, ["config", "user.name", "CI Test"]);
+  git(root, ["config", "user.email", "ci@example.invalid"]);
+  writeFileSync(join(root, "one.txt"), "one\n");
+  const head = commit(root, "one");
+  assert.equal(
+    deriveChangedPaths({ root, baseSHA: head, headSHA: head }).reason,
+    "empty_diff",
+  );
+  assert.equal(
+    deriveChangedPaths({ root, baseSHA: sha("f"), headSHA: head }).reason,
+    "merge_base_unavailable",
+  );
+});
+
+test("run identity is canonical and positive", () => {
+  assert.equal(parseRunAttempt("1"), 1);
+  for (const value of [undefined, "", "0", "01", "-1", "1.5", "word"]) {
+    assert.throws(() => parseRunAttempt(value), ContractError);
+  }
+});

--- a/.github/scripts/ci-lane-shadow-collector.mjs
+++ b/.github/scripts/ci-lane-shadow-collector.mjs
@@ -1,0 +1,1295 @@
+// ci-lane-shadow-collector.mjs — observe the native Actions checks associated
+// with one validated merge-lane selection without presenting those observations
+// as native test reports.
+//
+// The collector deliberately discovers independent workflow runs. A pull
+// request workflow run is bound to the event's repository, event kind, pull
+// request number, PR head SHA, and PR base SHA. Its Actions REST `head_sha` is
+// the PR head, while the selection source may be GitHub's projected merge SHA.
+// A merge-group run is bound to the queue event's repository, head SHA, and
+// queue ref; the selection binds the event's base SHA and projected head SHA.
+//
+// Required environment:
+//   CI_LANE_SELECTION       validated selection manifest path.
+//   CI_LANE_SHADOW_OUTPUT   new observation manifest path; stale reuse fails.
+//   GITHUB_EVENT_PATH       trusted runner event payload path.
+//   GITHUB_EVENT_NAME       pull_request or merge_group.
+//   GITHUB_REPOSITORY       trusted runner repository (`owner/name`).
+//   GITHUB_SHA              projected checkout SHA selected by the fence.
+//   GITHUB_RUN_ID           selector/collector workflow run ID.
+//   GITHUB_RUN_ATTEMPT      selector/collector workflow attempt.
+//   GITHUB_TOKEN            token with Actions read access.
+//
+// Optional environment:
+//   CI_LANE_REGISTRY                 registry path (default .github/ci-lanes.json).
+//   CI_LANE_SHADOW_POLL_SECONDS      poll interval (default 15).
+//   CI_LANE_SHADOW_TIMEOUT_SECONDS   observation deadline (default 1200).
+//   GITHUB_API_URL                   API origin (default https://api.github.com).
+//   GITHUB_OUTPUT                    Actions step-output destination.
+//
+// The main program polls because independently triggered workflows need not
+// start or finish in the selector workflow's scheduling order. Tests inject an
+// HTTP function and never access the network. Node builtins only.
+
+import { spawnSync } from "node:child_process";
+import { createHash } from "node:crypto";
+import {
+  existsSync,
+  linkSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  statSync,
+  unlinkSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import process from "node:process";
+import { fileURLToPath } from "node:url";
+
+import {
+  ContractError,
+  DEFAULT_REGISTRY_PATH,
+  loadRegistry,
+  nativeArtifactName,
+  selectionManifestSHA256,
+  validateReportSet,
+  validateSelection,
+} from "./ci-lane-contract.mjs";
+import {
+  nativeBundleEntries,
+  validateNativeBundle,
+} from "./ci-lane-native-evidence.mjs";
+import { error, notice, setOutput, warning } from "./lib/gh.mjs";
+
+export const SHADOW_OBSERVATION_SCHEMA_VERSION = 1;
+
+const DEFAULT_API_URL = "https://api.github.com";
+const DEFAULT_POLL_SECONDS = 15;
+const DEFAULT_TIMEOUT_SECONDS = 20 * 60;
+const MAX_PER_PAGE = 100;
+const MAX_NATIVE_ARCHIVE_BYTES = 2 * 1024 * 1024;
+const MAX_NATIVE_ENTRY_BYTES = 1024 * 1024;
+const SHA_PATTERN = /^(?:[0-9a-f]{40}|[0-9a-f]{64})$/;
+const REPOSITORY_PATTERN = /^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/;
+const POSITIVE_INTEGER_PATTERN = /^[1-9][0-9]*$/;
+const API_TIMESTAMP_PATTERN =
+  /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d{1,3})?Z$/;
+const FAILURE_CONCLUSIONS = new Set([
+  "action_required",
+  "failure",
+  "stale",
+  "startup_failure",
+]);
+
+function contract(label, problem) {
+  throw new ContractError(label, [problem]);
+}
+
+function isObject(value) {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function requiredString(value, path, { pattern } = {}) {
+  if (typeof value !== "string" || value.trim() === "") {
+    contract("CI lane shadow collector", `${path} must be a non-empty string`);
+  }
+  if (pattern && !pattern.test(value)) {
+    contract(
+      "CI lane shadow collector",
+      `${path} has invalid value ${JSON.stringify(value)}`,
+    );
+  }
+  return value;
+}
+
+function positiveInteger(value, path) {
+  const text =
+    typeof value === "number" && Number.isSafeInteger(value)
+      ? String(value)
+      : typeof value === "string"
+        ? value
+        : "";
+  if (!POSITIVE_INTEGER_PATTERN.test(text)) {
+    contract(
+      "CI lane shadow collector",
+      `${path} must be a positive safe integer`,
+    );
+  }
+  const number = Number(text);
+  if (!Number.isSafeInteger(number)) {
+    contract(
+      "CI lane shadow collector",
+      `${path} exceeds JavaScript's safe integer range`,
+    );
+  }
+  return number;
+}
+
+function nonnegativeInteger(value, path) {
+  if (typeof value !== "number" || !Number.isSafeInteger(value) || value < 0) {
+    contract(
+      "CI lane shadow collector",
+      `${path} must be a non-negative safe integer`,
+    );
+  }
+  return value;
+}
+
+function positiveID(value, path) {
+  const number = positiveInteger(value, path);
+  return String(number);
+}
+
+function nullableConclusion(value, path) {
+  if (value === null) return null;
+  return requiredString(value, path);
+}
+
+function apiTimestamp(value, path, { nullable = false } = {}) {
+  if (value === null && nullable) return null;
+  const timestamp = requiredString(value, path, {
+    pattern: API_TIMESTAMP_PATTERN,
+  });
+  if (!Number.isFinite(Date.parse(timestamp))) {
+    contract(
+      "CI lane shadow collector",
+      `${path} is not a real UTC timestamp`,
+    );
+  }
+  return timestamp;
+}
+
+function timestampMillis(value, path) {
+  const timestamp = apiTimestamp(value, path);
+  return Date.parse(timestamp);
+}
+
+function normalizedRef(value) {
+  const ref = requiredString(value, "event ref");
+  return ref.startsWith("refs/heads/") ? ref.slice("refs/heads/".length) : ref;
+}
+
+function parseJSONFile(path, label) {
+  try {
+    return JSON.parse(readFileSync(path, "utf8"));
+  } catch (readError) {
+    contract(label, `${path}: ${readError.message}`);
+  }
+}
+
+export function trustedEventIdentity({
+  eventName,
+  repository,
+  projectedSHA,
+  payload,
+}) {
+  const kind = requiredString(eventName, "GITHUB_EVENT_NAME");
+  if (kind !== "pull_request" && kind !== "merge_group") {
+    contract(
+      "CI lane shadow collector",
+      `GITHUB_EVENT_NAME must be pull_request or merge_group; got ${JSON.stringify(kind)}`,
+    );
+  }
+  const trustedRepository = requiredString(
+    repository,
+    "GITHUB_REPOSITORY",
+    { pattern: REPOSITORY_PATTERN },
+  );
+  const projected = requiredString(projectedSHA, "GITHUB_SHA", {
+    pattern: SHA_PATTERN,
+  });
+  if (!isObject(payload)) {
+    contract("CI lane shadow collector", "GITHUB_EVENT_PATH must contain an object");
+  }
+  const payloadRepository = payload.repository?.full_name;
+  if (payloadRepository !== trustedRepository) {
+    contract(
+      "CI lane shadow collector",
+      `event repository is ${JSON.stringify(payloadRepository)}, want ${trustedRepository}`,
+    );
+  }
+
+  if (kind === "pull_request") {
+    const pullRequest = payload.pull_request;
+    if (!isObject(pullRequest)) {
+      contract(
+        "CI lane shadow collector",
+        "pull_request event has no pull_request object",
+      );
+    }
+    const number = positiveInteger(pullRequest.number, "event pull request number");
+    const eventHeadSHA = requiredString(
+      pullRequest.head?.sha,
+      "event pull request head SHA",
+      { pattern: SHA_PATTERN },
+    );
+    const eventBaseSHA = requiredString(
+      pullRequest.base?.sha,
+      "event pull request base SHA",
+      { pattern: SHA_PATTERN },
+    );
+    const headRef = normalizedRef(pullRequest.head?.ref);
+    const baseRef = normalizedRef(pullRequest.base?.ref);
+    if (pullRequest.base?.repo?.full_name !== trustedRepository) {
+      contract(
+        "CI lane shadow collector",
+        "pull request base repository does not match GITHUB_REPOSITORY",
+      );
+    }
+    return Object.freeze({
+      kind,
+      repository: trustedRepository,
+      pr_number: number,
+      event_head_sha: eventHeadSHA,
+      event_base_sha: eventBaseSHA,
+      head_ref: headRef,
+      base_ref: baseRef,
+      projected_sha: projected,
+    });
+  }
+
+  const mergeGroup = payload.merge_group;
+  if (!isObject(mergeGroup)) {
+    contract(
+      "CI lane shadow collector",
+      "merge_group event has no merge_group object",
+    );
+  }
+  const eventHeadSHA = requiredString(
+    mergeGroup.head_sha,
+    "event merge group head SHA",
+    { pattern: SHA_PATTERN },
+  );
+  const eventBaseSHA = requiredString(
+    mergeGroup.base_sha,
+    "event merge group base SHA",
+    { pattern: SHA_PATTERN },
+  );
+  if (projected !== eventHeadSHA) {
+    contract(
+      "CI lane shadow collector",
+      `merge-group projected SHA is ${projected}, want event head ${eventHeadSHA}`,
+    );
+  }
+  return Object.freeze({
+    kind,
+    repository: trustedRepository,
+    pr_number: null,
+    event_head_sha: eventHeadSHA,
+    event_base_sha: eventBaseSHA,
+    head_ref: normalizedRef(mergeGroup.head_ref),
+    base_ref: normalizedRef(mergeGroup.base_ref),
+    projected_sha: projected,
+  });
+}
+
+export function bindSelectionToEvent(
+  selection,
+  registry,
+  identity,
+  { runID, runAttempt } = {},
+) {
+  const expected = {
+    posture: "merge",
+    sha: identity.projected_sha,
+    baseSHA: identity.event_base_sha,
+  };
+  if (runID !== undefined) expected.runID = positiveID(runID, "GITHUB_RUN_ID");
+  if (runAttempt !== undefined) {
+    expected.runAttempt = positiveInteger(
+      runAttempt,
+      "GITHUB_RUN_ATTEMPT",
+    );
+  }
+  validateSelection(selection, registry, expected);
+  if (
+    identity.kind === "merge_group" &&
+    selection.source.sha !== identity.event_head_sha
+  ) {
+    contract(
+      "CI lane shadow collector",
+      "merge-group selection source does not equal the event head SHA",
+    );
+  }
+  return selection;
+}
+
+function repositoryAPIPath(repository) {
+  return repository
+    .split("/")
+    .map((component) => encodeURIComponent(component))
+    .join("/");
+}
+
+function pagedURL(baseURL, pathname, query, page) {
+  const url = new URL(pathname, `${baseURL.replace(/\/$/, "")}/`);
+  for (const [name, value] of Object.entries(query)) {
+    url.searchParams.set(name, String(value));
+  }
+  url.searchParams.set("per_page", String(MAX_PER_PAGE));
+  url.searchParams.set("page", String(page));
+  return url.toString();
+}
+
+async function paginated({ requestJSON, buildURL, field, label }) {
+  const rows = [];
+  for (let page = 1; ; page += 1) {
+    const document = await requestJSON(buildURL(page));
+    if (!isObject(document) || !Array.isArray(document[field])) {
+      contract(
+        "CI lane shadow collector",
+        `${label} response must contain an ${field} array`,
+      );
+    }
+    nonnegativeInteger(document.total_count, `${label}.total_count`);
+    rows.push(...document[field]);
+    if (document[field].length < MAX_PER_PAGE) break;
+  }
+  return rows;
+}
+
+function pullRequestAssociationMatches(association, identity) {
+  if (!isObject(association)) return false;
+  if (
+    !Number.isSafeInteger(association.number) ||
+    association.number !== identity.pr_number
+  ) {
+    return false;
+  }
+  return (
+    association.head?.sha === identity.event_head_sha &&
+    association.base?.sha === identity.event_base_sha &&
+    normalizedCandidateRef(association.head?.ref) === identity.head_ref &&
+    normalizedCandidateRef(association.base?.ref) === identity.base_ref
+  );
+}
+
+function normalizedCandidateRef(value) {
+  if (typeof value !== "string" || value.trim() === "") return null;
+  return value.startsWith("refs/heads/")
+    ? value.slice("refs/heads/".length)
+    : value;
+}
+
+function runMatchesIdentity(run, identity, workflows) {
+  if (!isObject(run)) return false;
+  if (!workflows.has(run.path)) return false;
+  if (run.repository?.full_name !== identity.repository) return false;
+  if (run.event !== identity.kind) return false;
+  if (run.head_sha !== identity.event_head_sha) return false;
+  if (normalizedCandidateRef(run.head_branch) !== identity.head_ref) return false;
+  if (identity.kind === "pull_request") {
+    return (
+      Array.isArray(run.pull_requests) &&
+      run.pull_requests.some((association) =>
+        pullRequestAssociationMatches(association, identity),
+      )
+    );
+  }
+  return true;
+}
+
+function normalizeRun(run) {
+  return {
+    workflow: requiredString(run.path, "workflow run path"),
+    run_id: positiveID(run.id, "workflow run id"),
+    run_attempt: positiveInteger(run.run_attempt, "workflow run attempt"),
+    event: requiredString(run.event, "workflow run event"),
+    head_sha: requiredString(run.head_sha, "workflow run head SHA", {
+      pattern: SHA_PATTERN,
+    }),
+    head_branch: requiredString(run.head_branch, "workflow run head branch"),
+    status: requiredString(run.status, "workflow run status"),
+    conclusion: nullableConclusion(
+      run.conclusion,
+      "workflow run conclusion",
+    ),
+    created_at: apiTimestamp(run.created_at, "workflow run created_at"),
+    updated_at: apiTimestamp(run.updated_at, "workflow run updated_at"),
+  };
+}
+
+function compareIDs(left, right) {
+  const a = BigInt(left);
+  const b = BigInt(right);
+  return a < b ? -1 : a > b ? 1 : 0;
+}
+
+export function newestRunFirst(left, right) {
+  const created =
+    timestampMillis(right.created_at, "workflow run created_at") -
+    timestampMillis(left.created_at, "workflow run created_at");
+  if (created !== 0) return created;
+  const id = compareIDs(right.run_id, left.run_id);
+  if (id !== 0) return id;
+  return right.run_attempt - left.run_attempt;
+}
+
+function canonicalRunOrder(left, right) {
+  const workflow = left.workflow.localeCompare(right.workflow);
+  return workflow === 0 ? newestRunFirst(left, right) : workflow;
+}
+
+export async function discoverWorkflowRuns({
+  registry,
+  identity,
+  requestJSON,
+  apiBase = DEFAULT_API_URL,
+}) {
+  if (typeof requestJSON !== "function") {
+    contract("CI lane shadow collector", "requestJSON must be a function");
+  }
+  const workflows = new Set(registry.lanes.map((lane) => lane.owner.workflow));
+  const repository = repositoryAPIPath(identity.repository);
+  const candidates = await paginated({
+    requestJSON,
+    field: "workflow_runs",
+    label: "workflow runs",
+    buildURL: (page) =>
+      pagedURL(
+        apiBase,
+        `/repos/${repository}/actions/runs`,
+        { event: identity.kind, head_sha: identity.event_head_sha },
+        page,
+      ),
+  });
+
+  const unique = new Map();
+  for (const candidate of candidates) {
+    if (!runMatchesIdentity(candidate, identity, workflows)) continue;
+    const run = normalizeRun(candidate);
+    const key = `${run.run_id}:${run.run_attempt}`;
+    const previous = unique.get(key);
+    if (previous && JSON.stringify(previous) !== JSON.stringify(run)) {
+      contract(
+        "CI lane shadow collector",
+        `workflow run ${key} appeared with conflicting evidence`,
+      );
+    }
+    unique.set(key, run);
+  }
+  return [...unique.values()].sort(canonicalRunOrder);
+}
+
+function normalizeJob(job) {
+  const status = requiredString(job.status, "workflow job status");
+  const startedAt = apiTimestamp(job.started_at, "workflow job started_at", {
+    nullable: status !== "completed",
+  });
+  const completedAt = apiTimestamp(
+    job.completed_at,
+    "workflow job completed_at",
+    { nullable: status !== "completed" },
+  );
+  let duration = null;
+  if (startedAt !== null && completedAt !== null) {
+    duration = Date.parse(completedAt) - Date.parse(startedAt);
+    if (!Number.isSafeInteger(duration) || duration < 0) {
+      contract(
+        "CI lane shadow collector",
+        "workflow job completion precedes its start",
+      );
+    }
+  }
+  return {
+    id: positiveID(job.id, "workflow job id"),
+    name: requiredString(job.name, "workflow job name"),
+    status,
+    conclusion: nullableConclusion(job.conclusion, "workflow job conclusion"),
+    started_at: startedAt,
+    completed_at: completedAt,
+    duration_ms: duration,
+  };
+}
+
+function canonicalJobOrder(left, right) {
+  const id = compareIDs(left.id, right.id);
+  return id === 0 ? left.name.localeCompare(right.name) : id;
+}
+
+async function jobsForRun({ run, identity, requestJSON, apiBase }) {
+  const repository = repositoryAPIPath(identity.repository);
+  const jobs = await paginated({
+    requestJSON,
+    field: "jobs",
+    label: `jobs for run ${run.run_id} attempt ${run.run_attempt}`,
+    buildURL: (page) =>
+      pagedURL(
+        apiBase,
+        `/repos/${repository}/actions/runs/${run.run_id}/attempts/${run.run_attempt}/jobs`,
+        { filter: "all" },
+        page,
+      ),
+  });
+  const unique = new Map();
+  for (const candidate of jobs) {
+    const job = normalizeJob(candidate);
+    if (unique.has(job.id)) {
+      contract(
+        "CI lane shadow collector",
+        `workflow run ${run.run_id} attempt ${run.run_attempt} returned duplicate job id ${job.id}`,
+      );
+    }
+    unique.set(job.id, job);
+  }
+  return [...unique.values()].sort(canonicalJobOrder);
+}
+
+export async function hydrateWorkflowRuns({
+  runs,
+  identity,
+  requestJSON,
+  apiBase = DEFAULT_API_URL,
+}) {
+  const hydrated = await Promise.all(
+    runs.map(async (run) => ({
+      ...run,
+      jobs: await jobsForRun({
+        run,
+        identity,
+        requestJSON,
+        apiBase,
+      }),
+    })),
+  );
+  return hydrated.sort(canonicalRunOrder);
+}
+
+function normalizeArtifact(artifact) {
+  const id = positiveID(artifact?.id, "workflow artifact id");
+  const name = requiredString(artifact?.name, "workflow artifact name");
+  const digest = requiredString(artifact?.digest, "workflow artifact digest", {
+    pattern: /^sha256:[0-9a-f]{64}$/,
+  });
+  if (artifact?.expired !== false) {
+    contract("CI lane shadow collector", `workflow artifact ${name} is expired`);
+  }
+  return {
+    id,
+    name,
+    sha256: digest.slice("sha256:".length),
+    archive_download_url: requiredString(
+      artifact?.archive_download_url,
+      "workflow artifact archive URL",
+    ),
+  };
+}
+
+export function unpackNativeArchive(archive) {
+  if (!Buffer.isBuffer(archive) || archive.length === 0) {
+    contract("CI lane shadow collector", "native artifact archive is empty");
+  }
+  if (archive.length > MAX_NATIVE_ARCHIVE_BYTES) {
+    contract("CI lane shadow collector", "native artifact archive exceeds its size limit");
+  }
+  const directory = mkdtempSync(join(tmpdir(), "ci-native-artifact-"));
+  const archivePath = join(directory, "bundle.zip");
+  try {
+    writeFileSync(archivePath, archive, { flag: "wx" });
+    const listing = spawnSync("unzip", ["-Z1", archivePath], {
+      encoding: "utf8",
+      maxBuffer: MAX_NATIVE_ENTRY_BYTES,
+    });
+    if (listing.status !== 0) {
+      contract("CI lane shadow collector", "native artifact is not a readable ZIP archive");
+    }
+    const entries = listing.stdout.split(/\r?\n/).filter(Boolean);
+    if (
+      entries.length !== 1 ||
+      entries[0] !== "ci-native-evidence.json" ||
+      entries[0].includes("..") ||
+      entries[0].startsWith("/")
+    ) {
+      contract(
+        "CI lane shadow collector",
+        "native artifact must contain only ci-native-evidence.json",
+      );
+    }
+    const extracted = spawnSync("unzip", ["-p", archivePath, entries[0]], {
+      encoding: "utf8",
+      maxBuffer: MAX_NATIVE_ENTRY_BYTES,
+    });
+    if (extracted.status !== 0 || extracted.error) {
+      contract("CI lane shadow collector", "native evidence entry could not be read safely");
+    }
+    try {
+      return JSON.parse(extracted.stdout);
+    } catch (parseError) {
+      contract(
+        "CI lane shadow collector",
+        `native evidence entry is not JSON: ${parseError.message}`,
+      );
+    }
+  } finally {
+    rmSync(directory, { recursive: true, force: true });
+  }
+}
+
+export async function collectNativeBundles({
+  registry,
+  selection,
+  identity,
+  workflowRuns,
+  requestJSON,
+  requestBinary,
+  apiBase = DEFAULT_API_URL,
+}) {
+  const selectedWorkflows = new Set(
+    selection.lanes
+      .filter((item) => item.disposition === "selected")
+      .map(
+        (item) =>
+          registry.lanes.find((lane) => lane.id === item.lane_id).owner.workflow,
+      ),
+  );
+  const newest = new Map();
+  for (const run of [...workflowRuns].sort(canonicalRunOrder)) {
+    if (selectedWorkflows.has(run.workflow) && !newest.has(run.workflow))
+      newest.set(run.workflow, run);
+  }
+  const repository = repositoryAPIPath(identity.repository);
+  const bundles = new Map();
+  for (const workflow of [...selectedWorkflows].sort()) {
+    const run = newest.get(workflow);
+    if (!run) continue;
+    const expectedName = nativeArtifactName(workflow, {
+      id: run.run_id,
+      attempt: run.run_attempt,
+    });
+    const artifacts = await paginated({
+      requestJSON,
+      field: "artifacts",
+      label: `artifacts for run ${run.run_id}`,
+      buildURL: (page) =>
+        pagedURL(
+          apiBase,
+          `/repos/${repository}/actions/runs/${run.run_id}/artifacts`,
+          {},
+          page,
+        ),
+    });
+    const matches = artifacts
+      .map(normalizeArtifact)
+      .filter((artifact) => artifact.name === expectedName);
+    if (matches.length !== 1) continue;
+    const [artifact] = matches;
+    const archive = await requestBinary(artifact.archive_download_url);
+    const archiveSHA = createHash("sha256").update(archive).digest("hex");
+    if (archiveSHA !== artifact.sha256) {
+      contract(
+        "CI lane shadow collector",
+        `${workflow}: downloaded native artifact digest does not match the Actions API`,
+      );
+    }
+    const bundle = validateNativeBundle(unpackNativeArchive(archive), registry, {
+      posture: "merge",
+      workflow,
+      repository: identity.repository,
+      event: identity.kind,
+      runID: run.run_id,
+      runAttempt: run.run_attempt,
+      sha: selection.source.sha,
+      tree: selection.source.tree,
+      correlationNonce: selection.correlation_nonce,
+    });
+    bundles.set(workflow, { run, artifact, bundle });
+  }
+  return bundles;
+}
+
+function contextMatches(context, jobName) {
+  return context.match === "exact"
+    ? jobName === context.name
+    : jobName.startsWith(context.name);
+}
+
+export function jobObservationState(job) {
+  if (job.status !== "completed") {
+    return { state: "pending", reason: "job_not_terminal" };
+  }
+  if (job.conclusion === "success") return { state: "success", reason: null };
+  if (job.conclusion === "skipped") {
+    return { state: "skipped", reason: "job_skipped" };
+  }
+  if (job.conclusion === "neutral") {
+    return { state: "neutral", reason: "job_neutral" };
+  }
+  if (job.conclusion === "cancelled") {
+    return { state: "cancelled", reason: "job_cancelled" };
+  }
+  if (job.conclusion === "timed_out") {
+    return { state: "timed_out", reason: "job_timed_out" };
+  }
+  if (FAILURE_CONCLUSIONS.has(job.conclusion)) {
+    return { state: "red", reason: `job_${job.conclusion}` };
+  }
+  return { state: "red", reason: "unsupported_terminal_conclusion" };
+}
+
+export function createNativeQualification({
+  registry,
+  selection,
+  identity,
+  bundles,
+}) {
+  const selectionRef = {
+    run: { ...selection.run },
+    manifest_sha256: selectionManifestSHA256(selection),
+  };
+  const lanes = new Map(registry.lanes.map((lane) => [lane.id, lane]));
+  const producers = [];
+  const reports = [];
+  for (const [workflow, native] of [...bundles.entries()].sort(([left], [right]) =>
+    left.localeCompare(right),
+  )) {
+    const jobs = [];
+    const seenJobs = new Set();
+    for (const entry of native.bundle.lanes) {
+      const lane = lanes.get(entry.lane_id);
+      const matches = native.run.jobs.filter((job) =>
+        contextMatches(lane.context, job.name),
+      );
+      if (matches.length !== 1) continue;
+      const job = matches[0];
+      const key = `${lane.owner.context_job}/${job.id}`;
+      if (seenJobs.has(key)) continue;
+      seenJobs.add(key);
+      jobs.push({
+        job: lane.owner.context_job,
+        name: job.name,
+        database_id: job.id,
+        conclusion: job.conclusion,
+      });
+    }
+    const entries = nativeBundleEntries(native.bundle);
+    producers.push({
+      workflow,
+      run: { id: native.run.run_id, attempt: native.run.run_attempt },
+      source: { ...native.bundle.source },
+      correlation_nonce: native.bundle.correlation_nonce,
+      event: {
+        kind: identity.kind,
+        pr_number: identity.pr_number,
+        event_head_sha: identity.event_head_sha,
+        event_base_sha: identity.event_base_sha,
+        projected_sha: identity.projected_sha,
+      },
+      repository: identity.repository,
+      conclusion: native.run.conclusion,
+      jobs,
+      artifacts: [
+        {
+          id: native.artifact.id,
+          name: native.artifact.name,
+          sha256: native.artifact.sha256,
+          entries,
+        },
+      ],
+    });
+
+    for (const selected of selection.lanes.filter(
+      (item) =>
+        item.disposition === "selected" &&
+        lanes.get(item.lane_id).owner.workflow === workflow,
+    )) {
+      const lane = lanes.get(selected.lane_id);
+      for (const executionID of selected.executions) {
+        const entry = native.bundle.lanes.find(
+          (candidate) =>
+            candidate.lane_id === lane.id &&
+            candidate.execution_id === executionID,
+        );
+        if (!entry) continue;
+        const entryDigest = entries.find(
+          (candidate) =>
+            candidate.lane_id === lane.id &&
+            candidate.execution_id === executionID,
+        ).sha256;
+        const context = native.run.jobs.filter((job) =>
+          contextMatches(lane.context, job.name),
+        );
+        const duration = context.length === 1 ? context[0].duration_ms ?? 0 : 0;
+        reports.push({
+          schema_version: registry.report_schema_version,
+          registry_schema_version: registry.schema_version,
+          lane_id: lane.id,
+          execution_id: executionID,
+          posture: selection.posture,
+          source: { ...selection.source },
+          candidate_digest: null,
+          correlation_nonce: selection.correlation_nonce,
+          selection_ref: selectionRef,
+          producer: {
+            workflow,
+            job: lane.owner.context_job,
+            run: { id: native.run.run_id, attempt: native.run.run_attempt },
+            artifact: {
+              id: native.artifact.id,
+              name: native.artifact.name,
+              sha256: native.artifact.sha256,
+              entry: `${lane.id}/${executionID}`,
+              entry_sha256: entryDigest,
+            },
+          },
+          invocation: {
+            mode: "source_tree",
+            recipe: lane.recipes[0] ?? null,
+            command: lane.command,
+            build_tags: [...lane.build_tags],
+            selected_domains: [...lane.risk_domains],
+          },
+          evidence: {
+            ...entry.evidence,
+            duration_ms: duration,
+            seed: lane.determinism === "seeded" ? selection.source.tree : null,
+            corpus_id: `${lane.id}/${executionID}`,
+          },
+          conclusion: entry.conclusion,
+        });
+      }
+    }
+  }
+  const producerManifest = {
+    schema_version: registry.report_schema_version,
+    correlation_nonce: selection.correlation_nonce,
+    selection_ref: selectionRef,
+    producers,
+  };
+  const expected = {
+    posture: selection.posture,
+    sha: selection.source.sha,
+    tree: selection.source.tree,
+    correlationNonce: selection.correlation_nonce,
+    candidateDigest: undefined,
+    runID: selection.run.id,
+    runAttempt: selection.run.attempt,
+    selectionManifestSHA256: selectionRef.manifest_sha256,
+    eventIdentity: {
+      kind: identity.kind,
+      pr_number: identity.pr_number,
+      event_head_sha: identity.event_head_sha,
+      event_base_sha: identity.event_base_sha,
+      projected_sha: identity.projected_sha,
+    },
+    repository: identity.repository,
+    baseSHA: selection.selector.base_sha,
+    changedPaths: [...selection.selector.changed_paths],
+  };
+  const result = validateReportSet({
+    registry,
+    selection,
+    reports,
+    producerManifest,
+    expected,
+  });
+  return { producerManifest, reports, result };
+}
+
+function laneObservation({ lane, laneSelection, run }) {
+  const sources = [];
+  if (lane.context.protected) sources.push("protected");
+  if (laneSelection.disposition === "selected") sources.push("selected");
+  sources.sort();
+
+  const common = {
+    lane_id: lane.id,
+    workflow: lane.owner.workflow,
+    context: {
+      match: lane.context.match,
+      name: lane.context.name,
+      protected: lane.context.protected,
+    },
+    selection_disposition: laneSelection.disposition,
+    selection_reason: laneSelection.reason,
+    observation_sources: sources,
+  };
+  if (!run) {
+    return {
+      ...common,
+      run: null,
+      job_ids: [],
+      job_name: null,
+      status: null,
+      conclusion: null,
+      duration_ms: null,
+      state: "missing",
+      reason: "workflow_run_missing",
+      terminal_success: false,
+    };
+  }
+  const matched = run.jobs.filter((job) =>
+    contextMatches(lane.context, job.name),
+  );
+  const runRef = { id: run.run_id, attempt: run.run_attempt };
+  if (matched.length === 0) {
+    return {
+      ...common,
+      run: runRef,
+      job_ids: [],
+      job_name: null,
+      status: null,
+      conclusion: null,
+      duration_ms: null,
+      state: "missing",
+      reason: "context_missing",
+      terminal_success: false,
+    };
+  }
+  if (matched.length > 1) {
+    return {
+      ...common,
+      run: runRef,
+      job_ids: matched.map((job) => job.id).sort(compareIDs),
+      job_name: null,
+      status: null,
+      conclusion: null,
+      duration_ms: null,
+      state: "duplicate",
+      reason: "context_duplicate",
+      terminal_success: false,
+    };
+  }
+  const [job] = matched;
+  const outcome = jobObservationState(job);
+  return {
+    ...common,
+    run: runRef,
+    job_ids: [job.id],
+    job_name: job.name,
+    status: job.status,
+    conclusion: job.conclusion,
+    duration_ms: job.duration_ms,
+    state: outcome.state,
+    reason: outcome.reason,
+    terminal_success: outcome.state === "success",
+  };
+}
+
+export function createShadowObservationManifest({
+  registry,
+  selection,
+  identity,
+  workflowRuns,
+  collectedAt,
+}) {
+  const timestamp = apiTimestamp(collectedAt, "collected_at");
+  const selectionByID = new Map(
+    selection.lanes.map((laneSelection) => [
+      laneSelection.lane_id,
+      laneSelection,
+    ]),
+  );
+  const newestByWorkflow = new Map();
+  for (const run of [...workflowRuns].sort(canonicalRunOrder)) {
+    if (!newestByWorkflow.has(run.workflow)) {
+      newestByWorkflow.set(run.workflow, run);
+    }
+  }
+  const laneObservations = [...registry.lanes]
+    .sort((left, right) => left.id.localeCompare(right.id))
+    .flatMap((lane) => {
+      const laneSelection = selectionByID.get(lane.id);
+      if (
+        laneSelection.disposition !== "selected" &&
+        !lane.context.protected
+      ) {
+        return [];
+      }
+      return [
+        laneObservation({
+          lane,
+          laneSelection,
+          run: newestByWorkflow.get(lane.owner.workflow),
+        }),
+      ];
+    });
+
+  return {
+    schema_version: SHADOW_OBSERVATION_SCHEMA_VERSION,
+    registry_schema_version: registry.schema_version,
+    selection_ref: {
+      run: { ...selection.run },
+      manifest_sha256: selectionManifestSHA256(selection),
+    },
+    selection_source: { ...selection.source },
+    correlation_nonce: selection.correlation_nonce,
+    event: {
+      kind: identity.kind,
+      pr_number: identity.pr_number,
+      event_head_sha: identity.event_head_sha,
+      event_base_sha: identity.event_base_sha,
+      projected_sha: identity.projected_sha,
+    },
+    repository: identity.repository,
+    event_refs: { head: identity.head_ref, base: identity.base_ref },
+    collected_at: timestamp,
+    workflow_runs: [...workflowRuns].sort(canonicalRunOrder),
+    lane_observations: laneObservations,
+  };
+}
+
+export async function collectShadowObservation({
+  registry,
+  selection,
+  identity,
+  requestJSON,
+  apiBase = DEFAULT_API_URL,
+  collectedAt = new Date().toISOString(),
+}) {
+  bindSelectionToEvent(selection, registry, identity);
+  const runs = await discoverWorkflowRuns({
+    registry,
+    identity,
+    requestJSON,
+    apiBase,
+  });
+  const workflowRuns = await hydrateWorkflowRuns({
+    runs,
+    identity,
+    requestJSON,
+    apiBase,
+  });
+  return createShadowObservationManifest({
+    registry,
+    selection,
+    identity,
+    workflowRuns,
+    collectedAt,
+  });
+}
+
+export function shadowObservationSettled(document) {
+  return (
+    document.workflow_runs.every((run) => run.status === "completed") &&
+    document.lane_observations.every(
+      (observation) =>
+        observation.state !== "missing" && observation.state !== "pending",
+    )
+  );
+}
+
+export function assertFreshOutput(path) {
+  const output = resolve(path);
+  const parent = dirname(output);
+  if (!existsSync(parent) || !statSync(parent).isDirectory()) {
+    contract(
+      "CI lane shadow collector",
+      `observation output directory does not exist: ${parent}`,
+    );
+  }
+  if (existsSync(output)) {
+    contract(
+      "CI lane shadow collector",
+      `observation output already exists; refusing stale reuse: ${output}`,
+    );
+  }
+  return output;
+}
+
+export function writeShadowObservation(path, document) {
+  const output = assertFreshOutput(path);
+  const body = `${JSON.stringify(document, null, 2)}\n`;
+  const temporary = `${output}.${process.pid}.tmp`;
+  try {
+    writeFileSync(temporary, body, { encoding: "utf8", flag: "wx" });
+    linkSync(temporary, output);
+  } finally {
+    if (existsSync(temporary)) unlinkSync(temporary);
+  }
+  return Object.freeze({
+    path: output,
+    body,
+    sha256: createHash("sha256").update(body).digest("hex"),
+  });
+}
+
+function nonnegativeSeconds(value, name, fallback) {
+  if (value === undefined || String(value).trim() === "") return fallback;
+  const text = String(value);
+  if (!/^(?:0|[1-9][0-9]*)$/.test(text)) {
+    contract("CI lane shadow collector", `${name} must be a non-negative integer`);
+  }
+  const seconds = Number(text);
+  if (!Number.isSafeInteger(seconds)) {
+    contract("CI lane shadow collector", `${name} exceeds the safe integer range`);
+  }
+  return seconds;
+}
+
+function delay(milliseconds) {
+  return new Promise((resolveDelay) => setTimeout(resolveDelay, milliseconds));
+}
+
+function githubRequest({ token }) {
+  const authorization = requiredString(token, "GITHUB_TOKEN");
+  return async (url) => {
+    const response = await fetch(url, {
+      headers: {
+        Accept: "application/vnd.github+json",
+        Authorization: `Bearer ${authorization}`,
+        "X-GitHub-Api-Version": "2022-11-28",
+      },
+    });
+    if (!response.ok) {
+      contract(
+        "CI lane shadow collector",
+        `GitHub API ${response.status} for ${new URL(url).pathname}`,
+      );
+    }
+    return response.json();
+  };
+}
+
+function githubBinaryRequest({ token }) {
+  const authorization = requiredString(token, "GITHUB_TOKEN");
+  return async (url) => {
+    const response = await fetch(url, {
+      headers: {
+        Accept: "application/vnd.github+json",
+        Authorization: `Bearer ${authorization}`,
+        "X-GitHub-Api-Version": "2022-11-28",
+      },
+      redirect: "follow",
+    });
+    if (!response.ok || !response.body) {
+      contract(
+        "CI lane shadow collector",
+        `GitHub artifact download failed with HTTP ${response.status}`,
+      );
+    }
+    const chunks = [];
+    let size = 0;
+    for await (const chunk of response.body) {
+      size += chunk.length;
+      if (size > MAX_NATIVE_ARCHIVE_BYTES) {
+        contract(
+          "CI lane shadow collector",
+          "GitHub artifact download exceeds its size limit",
+        );
+      }
+      chunks.push(Buffer.from(chunk));
+    }
+    return Buffer.concat(chunks);
+  };
+}
+
+export async function main(env = process.env) {
+  const root = resolve(process.cwd());
+  const selectionPath = requiredString(
+    env.CI_LANE_SELECTION,
+    "CI_LANE_SELECTION",
+  );
+  const outputPath = assertFreshOutput(
+    requiredString(env.CI_LANE_SHADOW_OUTPUT, "CI_LANE_SHADOW_OUTPUT"),
+  );
+  const registry = loadRegistry(
+    env.CI_LANE_REGISTRY || DEFAULT_REGISTRY_PATH,
+    { root },
+  );
+  const selection = parseJSONFile(
+    resolve(root, selectionPath),
+    "CI lane shadow collector",
+  );
+  const payload = parseJSONFile(
+    requiredString(env.GITHUB_EVENT_PATH, "GITHUB_EVENT_PATH"),
+    "CI lane shadow collector",
+  );
+  const identity = trustedEventIdentity({
+    eventName: env.GITHUB_EVENT_NAME,
+    repository: env.GITHUB_REPOSITORY,
+    projectedSHA: env.GITHUB_SHA,
+    payload,
+  });
+  bindSelectionToEvent(selection, registry, identity, {
+    runID: env.GITHUB_RUN_ID,
+    runAttempt: env.GITHUB_RUN_ATTEMPT,
+  });
+
+  const pollSeconds = nonnegativeSeconds(
+    env.CI_LANE_SHADOW_POLL_SECONDS,
+    "CI_LANE_SHADOW_POLL_SECONDS",
+    DEFAULT_POLL_SECONDS,
+  );
+  const timeoutSeconds = nonnegativeSeconds(
+    env.CI_LANE_SHADOW_TIMEOUT_SECONDS,
+    "CI_LANE_SHADOW_TIMEOUT_SECONDS",
+    DEFAULT_TIMEOUT_SECONDS,
+  );
+  const apiBase = env.GITHUB_API_URL || DEFAULT_API_URL;
+  const requestJSON = githubRequest({ token: env.GITHUB_TOKEN });
+  const requestBinary = githubBinaryRequest({ token: env.GITHUB_TOKEN });
+  const deadline = Date.now() + timeoutSeconds * 1000;
+  let observation;
+  for (;;) {
+    observation = await collectShadowObservation({
+      registry,
+      selection,
+      identity,
+      requestJSON,
+      apiBase,
+    });
+    if (shadowObservationSettled(observation) || Date.now() >= deadline) break;
+    const remaining = deadline - Date.now();
+    await delay(Math.min(pollSeconds * 1000, remaining));
+  }
+
+  const settled = shadowObservationSettled(observation);
+  if (settled) {
+    const bundles = await collectNativeBundles({
+      registry,
+      selection,
+      identity,
+      workflowRuns: observation.workflow_runs,
+      requestJSON,
+      requestBinary,
+      apiBase,
+    });
+    const qualification = createNativeQualification({
+      registry,
+      selection,
+      identity,
+      bundles,
+    });
+    observation = {
+      ...observation,
+      native_qualification: {
+        producer_manifest: qualification.producerManifest,
+        reports: qualification.reports,
+        expected: qualification.result.expected,
+        received: qualification.result.received,
+      },
+    };
+  }
+  const written = writeShadowObservation(outputPath, observation);
+  setOutput("shadow_observation_path", written.path);
+  setOutput("shadow_observation_sha256", written.sha256);
+  setOutput("shadow_observation_settled", String(settled));
+  if (!settled) {
+    warning(
+      "CI lane shadow collection reached its deadline with missing or pending native evidence",
+      { title: "merge-fence shadow observation incomplete" },
+    );
+  }
+  notice(
+    `Recorded native Actions evidence for ${observation.workflow_runs.length} workflow run(s)`,
+  );
+  return observation;
+}
+
+const invokedDirectly =
+  process.argv[1] && fileURLToPath(import.meta.url) === resolve(process.argv[1]);
+if (invokedDirectly) {
+  try {
+    await main();
+  } catch (collectorError) {
+    error(
+      collectorError instanceof Error
+        ? collectorError.message
+        : String(collectorError),
+      { title: "merge-fence shadow collector failed closed" },
+    );
+    process.exit(1);
+  }
+}

--- a/.github/scripts/ci-lane-shadow-collector.mjs
+++ b/.github/scripts/ci-lane-shadow-collector.mjs
@@ -475,6 +475,7 @@ export async function discoverWorkflowRuns({
 
 function normalizeJob(job) {
   const status = requiredString(job.status, "workflow job status");
+  const conclusion = nullableConclusion(job.conclusion, "workflow job conclusion");
   const startedAt = apiTimestamp(job.started_at, "workflow job started_at", {
     nullable: status !== "completed",
   });
@@ -487,17 +488,28 @@ function normalizeJob(job) {
   if (startedAt !== null && completedAt !== null) {
     duration = Date.parse(completedAt) - Date.parse(startedAt);
     if (!Number.isSafeInteger(duration) || duration < 0) {
-      contract(
-        "CI lane shadow collector",
-        "workflow job completion precedes its start",
-      );
+      // A job the DAG never ran carries no real duration to begin with, and
+      // the Actions API is observed to backfill a SKIPPED job's started_at a
+      // few seconds AFTER completed_at (both stamped around when the
+      // scheduler resolves the skip, not around any actual execution) —
+      // reproduced live on e2e.yml's dashboard-setup / compose-smoke-shard /
+      // compose-crawl-merge. Record no duration rather than fail closed on a
+      // job that was never timed. A non-skipped job reporting the same
+      // inversion is still a real data-integrity problem.
+      if (conclusion !== "skipped") {
+        contract(
+          "CI lane shadow collector",
+          "workflow job completion precedes its start",
+        );
+      }
+      duration = null;
     }
   }
   return {
     id: positiveID(job.id, "workflow job id"),
     name: requiredString(job.name, "workflow job name"),
     status,
-    conclusion: nullableConclusion(job.conclusion, "workflow job conclusion"),
+    conclusion,
     started_at: startedAt,
     completed_at: completedAt,
     duration_ms: duration,

--- a/.github/scripts/ci-lane-shadow-collector.test.mjs
+++ b/.github/scripts/ci-lane-shadow-collector.test.mjs
@@ -1,0 +1,635 @@
+// Negative controls for the native Actions shadow collector. Network access is
+// replaced by a URL-aware in-memory HTTP function in every test.
+
+import assert from "node:assert/strict";
+import {
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+
+import { deriveQualificationCorrelationNonce } from "./ci-lane-contract.mjs";
+
+import {
+  bindSelectionToEvent,
+  collectShadowObservation,
+  jobObservationState,
+  shadowObservationSettled,
+  trustedEventIdentity,
+  writeShadowObservation,
+} from "./ci-lane-shadow-collector.mjs";
+
+const sha = (character) => character.repeat(40);
+const REPOSITORY = "example/project";
+const BASE_SHA = sha("a");
+const EVENT_HEAD_SHA = sha("b");
+const PROJECTED_SHA = sha("c");
+const PROJECTED_TREE = sha("d");
+const COLLECTED_AT = "2026-08-16T12:00:00Z";
+
+function lane({
+  id,
+  workflow,
+  context,
+  protectedContext = false,
+  mergePosture = "impact",
+  packageGlobs,
+  match = "exact",
+}) {
+  return {
+    id,
+    owner: { workflow },
+    executions: ["default"],
+    context: {
+      match,
+      name: context,
+      protected: protectedContext,
+    },
+    merge_posture: mergePosture,
+    main_posture: "always",
+    release_posture: "advisory",
+    package_globs: packageGlobs,
+    applicability: { source: true, artifact: false },
+  };
+}
+
+function registryFixture() {
+  return {
+    schema_version: 1,
+    selection_schema_version: 1,
+    report_schema_version: 1,
+    impact_selection: { known_nonimpact_globs: ["docs/**", "**/*.md"] },
+    lanes: [
+      lane({
+        id: "current.protected",
+        workflow: ".github/workflows/protected.yml",
+        context: "protected-context",
+        protectedContext: true,
+        packageGlobs: ["deploy/**"],
+      }),
+      lane({
+        id: "optional.omitted",
+        workflow: ".github/workflows/optional.yml",
+        context: "optional-context",
+        packageGlobs: ["optional/**"],
+      }),
+      lane({
+        id: "proposed.selected",
+        workflow: ".github/workflows/selected.yml",
+        context: "selected-context",
+        packageGlobs: ["internal/**"],
+      }),
+    ],
+  };
+}
+
+function selectionFixture({ sourceSHA = PROJECTED_SHA, baseSHA = BASE_SHA } = {}) {
+  const source = { sha: sourceSHA, tree: PROJECTED_TREE };
+  return {
+    schema_version: 1,
+    registry_schema_version: 1,
+    report_schema_version: 1,
+    posture: "merge",
+    source,
+    candidate_digest: null,
+    correlation_nonce: deriveQualificationCorrelationNonce({
+      posture: "merge",
+      source,
+    }),
+    run: { id: "900", attempt: 2 },
+    selector: {
+      conclusion: "success",
+      base_sha: baseSHA,
+      head_sha: sourceSHA,
+      changed_paths: ["internal/change.go"],
+      unknown_paths: [],
+    },
+    lanes: [
+      {
+        lane_id: "current.protected",
+        disposition: "omitted",
+        executions: [],
+        reason: "not_impacted",
+      },
+      {
+        lane_id: "optional.omitted",
+        disposition: "omitted",
+        executions: [],
+        reason: "not_impacted",
+      },
+      {
+        lane_id: "proposed.selected",
+        disposition: "selected",
+        executions: ["default"],
+        reason: null,
+      },
+    ],
+  };
+}
+
+function pullRequestPayload() {
+  return {
+    repository: { full_name: REPOSITORY },
+    pull_request: {
+      number: 42,
+      head: {
+        sha: EVENT_HEAD_SHA,
+        ref: "feature/native-evidence",
+        repo: { full_name: "fork/project" },
+      },
+      base: {
+        sha: BASE_SHA,
+        ref: "main",
+        repo: { full_name: REPOSITORY },
+      },
+    },
+  };
+}
+
+function pullRequestIdentity() {
+  return trustedEventIdentity({
+    eventName: "pull_request",
+    repository: REPOSITORY,
+    projectedSHA: PROJECTED_SHA,
+    payload: pullRequestPayload(),
+  });
+}
+
+function workflowRun({
+  id,
+  workflow = ".github/workflows/selected.yml",
+  status = "completed",
+  conclusion = "success",
+  createdAt = "2026-08-16T11:00:00Z",
+  updatedAt = "2026-08-16T11:05:00Z",
+  attempt = 1,
+  repository = REPOSITORY,
+  event = "pull_request",
+  headSHA = EVENT_HEAD_SHA,
+  headBranch = "feature/native-evidence",
+  prNumber = 42,
+  prHeadSHA = EVENT_HEAD_SHA,
+  prBaseSHA = BASE_SHA,
+  prHeadRef = "feature/native-evidence",
+  prBaseRef = "main",
+} = {}) {
+  return {
+    id,
+    run_attempt: attempt,
+    path: workflow,
+    repository: { full_name: repository },
+    event,
+    head_sha: headSHA,
+    head_branch: headBranch,
+    status,
+    conclusion,
+    created_at: createdAt,
+    updated_at: updatedAt,
+    pull_requests: [
+      {
+        number: prNumber,
+        head: { sha: prHeadSHA, ref: prHeadRef },
+        base: { sha: prBaseSHA, ref: prBaseRef },
+      },
+    ],
+  };
+}
+
+function workflowJob({
+  id,
+  name = "selected-context",
+  status = "completed",
+  conclusion = "success",
+  startedAt = "2026-08-16T11:00:00Z",
+  completedAt = "2026-08-16T11:02:30Z",
+} = {}) {
+  return {
+    id,
+    name,
+    status,
+    conclusion,
+    started_at: startedAt,
+    completed_at: completedAt,
+  };
+}
+
+function mockGitHub({ runs, jobsByRun = {} }) {
+  const calls = [];
+  const requestJSON = async (urlText) => {
+    calls.push(urlText);
+    const url = new URL(urlText);
+    const jobMatch = url.pathname.match(
+      /\/actions\/runs\/([1-9][0-9]*)\/attempts\/([1-9][0-9]*)\/jobs$/,
+    );
+    if (jobMatch) {
+      const key = `${jobMatch[1]}:${jobMatch[2]}`;
+      const jobs = jobsByRun[key] ?? [];
+      return { total_count: jobs.length, jobs };
+    }
+    assert.equal(url.pathname, "/repos/example/project/actions/runs");
+    assert.equal(url.searchParams.get("event"), "pull_request");
+    assert.equal(url.searchParams.get("head_sha"), EVENT_HEAD_SHA);
+    return { total_count: runs.length, workflow_runs: runs };
+  };
+  return { requestJSON, calls };
+}
+
+async function collect({ runs, jobsByRun, registry, selection, identity } = {}) {
+  const github = mockGitHub({ runs: runs ?? [], jobsByRun });
+  const document = await collectShadowObservation({
+    registry: registry ?? registryFixture(),
+    selection: selection ?? selectionFixture(),
+    identity: identity ?? pullRequestIdentity(),
+    requestJSON: github.requestJSON,
+    apiBase: "https://api.example.invalid",
+    collectedAt: COLLECTED_AT,
+  });
+  return { document, calls: github.calls };
+}
+
+function observation(document, laneID) {
+  return document.lane_observations.find(
+    (candidate) => candidate.lane_id === laneID,
+  );
+}
+
+test("PR collection binds REST head_sha to the PR head, not projected SHA", async () => {
+  const run = workflowRun({ id: 101 });
+  const { document, calls } = await collect({
+    runs: [run],
+    jobsByRun: { "101:1": [workflowJob({ id: 1001 })] },
+  });
+
+  assert.notEqual(PROJECTED_SHA, EVENT_HEAD_SHA);
+  assert.equal(document.event.projected_sha, PROJECTED_SHA);
+  assert.equal(document.event.event_head_sha, EVENT_HEAD_SHA);
+  assert.equal(document.workflow_runs[0].head_sha, EVENT_HEAD_SHA);
+  assert.equal(
+    observation(document, "proposed.selected").state,
+    "success",
+  );
+  assert.ok(
+    calls.some((url) =>
+      url.includes(`head_sha=${encodeURIComponent(EVENT_HEAD_SHA)}`),
+    ),
+  );
+
+  const projectedRun = workflowRun({ id: 102, headSHA: PROJECTED_SHA });
+  const wrong = await collect({
+    runs: [projectedRun],
+    jobsByRun: { "102:1": [workflowJob({ id: 1002 })] },
+  });
+  assert.equal(wrong.document.workflow_runs.length, 0);
+  assert.equal(
+    observation(wrong.document, "proposed.selected").reason,
+    "workflow_run_missing",
+  );
+});
+
+test("wrong repository, event, PR, head, or base cannot bind a run", async (t) => {
+  const cases = [
+    ["repository", { repository: "elsewhere/project" }],
+    ["event", { event: "push" }],
+    ["PR number", { prNumber: 43 }],
+    ["event head", { headSHA: sha("e") }],
+    ["associated head", { prHeadSHA: sha("e") }],
+    ["associated base", { prBaseSHA: sha("e") }],
+    ["head ref", { headBranch: "another-branch" }],
+    ["associated base ref", { prBaseRef: "another-base" }],
+  ];
+  for (const [name, change] of cases) {
+    await t.test(name, async () => {
+      const run = workflowRun({ id: 200, ...change });
+      const { document, calls } = await collect({
+        runs: [run],
+        jobsByRun: { "200:1": [workflowJob({ id: 2001 })] },
+      });
+      assert.equal(document.workflow_runs.length, 0);
+      assert.equal(
+        observation(document, "proposed.selected").state,
+        "missing",
+      );
+      assert.equal(
+        calls.some((url) => url.includes("/attempts/1/jobs")),
+        false,
+      );
+    });
+  }
+});
+
+test("newest run and attempt wins even when an older run is green", async () => {
+  const oldGreen = workflowRun({
+    id: 300,
+    createdAt: "2026-08-16T10:00:00Z",
+  });
+  const newRed = workflowRun({
+    id: 301,
+    createdAt: "2026-08-16T11:00:00Z",
+    conclusion: "failure",
+  });
+  const oldAttempt = workflowRun({
+    id: 302,
+    attempt: 1,
+    createdAt: "2026-08-16T12:00:00Z",
+  });
+  const newAttempt = workflowRun({
+    id: 302,
+    attempt: 2,
+    createdAt: "2026-08-16T12:00:00Z",
+    conclusion: "failure",
+  });
+  const { document, calls } = await collect({
+    runs: [oldGreen, newAttempt, newRed, oldAttempt],
+    jobsByRun: {
+      "300:1": [workflowJob({ id: 3001 })],
+      "301:1": [workflowJob({ id: 3011, conclusion: "failure" })],
+      "302:1": [workflowJob({ id: 3021 })],
+      "302:2": [workflowJob({ id: 3022, conclusion: "failure" })],
+    },
+  });
+  const selected = observation(document, "proposed.selected");
+  assert.deepEqual(selected.run, { id: "302", attempt: 2 });
+  assert.equal(selected.state, "red");
+  assert.equal(selected.terminal_success, false);
+  assert.deepEqual(
+    document.workflow_runs.map((run) => `${run.run_id}:${run.run_attempt}`),
+    ["302:2", "302:1", "301:1", "300:1"],
+  );
+  for (const ref of ["300:1", "301:1", "302:1", "302:2"]) {
+    const [id, attempt] = ref.split(":");
+    assert.ok(calls.some((url) => url.includes(`/runs/${id}/attempts/${attempt}/jobs`)));
+  }
+});
+
+test("missing and duplicate stable contexts fail closed", async (t) => {
+  const run = workflowRun({ id: 400 });
+  await t.test("missing", async () => {
+    const { document } = await collect({ runs: [run] });
+    const selected = observation(document, "proposed.selected");
+    assert.equal(selected.state, "missing");
+    assert.equal(selected.reason, "context_missing");
+    assert.equal(selected.terminal_success, false);
+  });
+  await t.test("duplicate", async () => {
+    const { document } = await collect({
+      runs: [run],
+      jobsByRun: {
+        "400:1": [
+          workflowJob({ id: 4001 }),
+          workflowJob({ id: 4002 }),
+        ],
+      },
+    });
+    const selected = observation(document, "proposed.selected");
+    assert.equal(selected.state, "duplicate");
+    assert.equal(selected.reason, "context_duplicate");
+    assert.deepEqual(selected.job_ids, ["4001", "4002"]);
+    assert.equal(selected.terminal_success, false);
+  });
+});
+
+test("registered prefix contexts match suffix-bearing native job names", async () => {
+  const registry = registryFixture();
+  registry.lanes.find(
+    (candidate) => candidate.id === "proposed.selected",
+  ).context.match = "prefix";
+  const run = workflowRun({ id: 450 });
+  const { document } = await collect({
+    registry,
+    runs: [run],
+    jobsByRun: {
+      "450:1": [
+        workflowJob({ id: 4501, name: "selected-context (shard-one)" }),
+      ],
+    },
+  });
+  assert.equal(
+    observation(document, "proposed.selected").state,
+    "success",
+  );
+});
+
+test("observations cover selected union protected while optional runs remain telemetry", async () => {
+  const selectedRun = workflowRun({ id: 500 });
+  const protectedRun = workflowRun({
+    id: 501,
+    workflow: ".github/workflows/protected.yml",
+  });
+  const optionalRun = workflowRun({
+    id: 502,
+    workflow: ".github/workflows/optional.yml",
+  });
+  const { document } = await collect({
+    runs: [optionalRun, selectedRun, protectedRun],
+    jobsByRun: {
+      "500:1": [workflowJob({ id: 5001 })],
+      "501:1": [workflowJob({ id: 5011, name: "protected-context" })],
+      "502:1": [workflowJob({ id: 5021, name: "optional-context" })],
+    },
+  });
+  assert.deepEqual(
+    document.workflow_runs.map((run) => run.workflow),
+    [
+      ".github/workflows/optional.yml",
+      ".github/workflows/protected.yml",
+      ".github/workflows/selected.yml",
+    ],
+  );
+  assert.deepEqual(
+    document.lane_observations.map((item) => item.lane_id),
+    ["current.protected", "proposed.selected"],
+  );
+  assert.equal(
+    observation(document, "current.protected").selection_disposition,
+    "omitted",
+  );
+  assert.deepEqual(
+    observation(document, "current.protected").observation_sources,
+    ["protected"],
+  );
+  assert.deepEqual(
+    observation(document, "proposed.selected").observation_sources,
+    ["selected"],
+  );
+  assert.equal(shadowObservationSettled(document), true);
+});
+
+test("terminal states remain distinct and only success qualifies", () => {
+  const cases = [
+    ["success", "success", true],
+    ["failure", "red", false],
+    ["action_required", "red", false],
+    ["skipped", "skipped", false],
+    ["neutral", "neutral", false],
+    ["cancelled", "cancelled", false],
+    ["timed_out", "timed_out", false],
+  ];
+  for (const [conclusion, state, terminalSuccess] of cases) {
+    const outcome = jobObservationState({
+      status: "completed",
+      conclusion,
+    });
+    assert.equal(outcome.state, state, conclusion);
+    assert.equal(outcome.state === "success", terminalSuccess, conclusion);
+  }
+  assert.deepEqual(
+    jobObservationState({ status: "in_progress", conclusion: null }),
+    { state: "pending", reason: "job_not_terminal" },
+  );
+});
+
+test("job rosters are canonical and durations come from API timestamps", async () => {
+  const run = workflowRun({ id: 600 });
+  const { document } = await collect({
+    runs: [run],
+    jobsByRun: {
+      "600:1": [
+        workflowJob({
+          id: 6002,
+          name: "supporting-job",
+          startedAt: "2026-08-16T11:00:30Z",
+          completedAt: "2026-08-16T11:01:00Z",
+        }),
+        workflowJob({ id: 6001 }),
+      ],
+    },
+  });
+  assert.deepEqual(
+    document.workflow_runs[0].jobs.map((job) => job.id),
+    ["6001", "6002"],
+  );
+  assert.equal(document.workflow_runs[0].jobs[0].duration_ms, 150_000);
+  assert.equal(document.workflow_runs[0].jobs[1].duration_ms, 30_000);
+  assert.equal(
+    observation(document, "proposed.selected").duration_ms,
+    150_000,
+  );
+});
+
+test("malformed or reversed job timestamps are rejected", async (t) => {
+  const run = workflowRun({ id: 700 });
+  for (const [name, timestamps] of [
+    ["malformed", { startedAt: "not-a-timestamp" }],
+    [
+      "reversed",
+      {
+        startedAt: "2026-08-16T11:02:00Z",
+        completedAt: "2026-08-16T11:01:00Z",
+      },
+    ],
+  ]) {
+    await t.test(name, async () => {
+      await assert.rejects(
+        collect({
+          runs: [run],
+          jobsByRun: {
+            "700:1": [workflowJob({ id: 7001, ...timestamps })],
+          },
+        }),
+        /workflow job (started_at has invalid value|completion precedes its start)/,
+      );
+    });
+  }
+});
+
+test("selection binding rejects stale run identity and the wrong event base", () => {
+  const registry = registryFixture();
+  const identity = pullRequestIdentity();
+  assert.equal(
+    bindSelectionToEvent(selectionFixture(), registry, identity, {
+      runID: "900",
+      runAttempt: 2,
+    }).source.sha,
+    PROJECTED_SHA,
+  );
+  const replayed = selectionFixture();
+  replayed.correlation_nonce = "f".repeat(64);
+  assert.throws(
+    () => bindSelectionToEvent(replayed, registry, identity),
+    /correlation_nonce does not match its projected Git objects/,
+  );
+  assert.throws(
+    () =>
+      bindSelectionToEvent(selectionFixture(), registry, identity, {
+        runID: "901",
+        runAttempt: 2,
+      }),
+    /selection\.run\.id/,
+  );
+  assert.throws(
+    () =>
+      bindSelectionToEvent(
+        selectionFixture({ baseSHA: sha("e") }),
+        registry,
+        identity,
+      ),
+    /selection\.selector\.base_sha/,
+  );
+});
+
+test("merge groups bind projected head and queue ref without PR association", async () => {
+  const mergeIdentity = trustedEventIdentity({
+    eventName: "merge_group",
+    repository: REPOSITORY,
+    projectedSHA: EVENT_HEAD_SHA,
+    payload: {
+      repository: { full_name: REPOSITORY },
+      merge_group: {
+        head_sha: EVENT_HEAD_SHA,
+        base_sha: BASE_SHA,
+        head_ref: "refs/heads/gh-readonly-queue/main/pr-42",
+        base_ref: "refs/heads/main",
+      },
+    },
+  });
+  const selection = selectionFixture({ sourceSHA: EVENT_HEAD_SHA });
+  const mergeRun = workflowRun({
+    id: 800,
+    event: "merge_group",
+    headBranch: "gh-readonly-queue/main/pr-42",
+  });
+  mergeRun.pull_requests = [];
+  const mergeRequest = async (urlText) => {
+    const url = new URL(urlText);
+    if (url.pathname.endsWith("/jobs")) {
+      return { total_count: 1, jobs: [workflowJob({ id: 8001 })] };
+    }
+    assert.equal(url.searchParams.get("event"), "merge_group");
+    return { total_count: 1, workflow_runs: [mergeRun] };
+  };
+  const document = await collectShadowObservation({
+    registry: registryFixture(),
+    selection,
+    identity: mergeIdentity,
+    requestJSON: mergeRequest,
+    apiBase: "https://api.example.invalid",
+    collectedAt: COLLECTED_AT,
+  });
+  assert.equal(
+    observation(document, "proposed.selected").state,
+    "success",
+  );
+  assert.equal(document.event.pr_number, null);
+});
+
+test("manifest writing is canonical, atomic, and refuses stale output", (t) => {
+  const root = mkdtempSync(join(tmpdir(), "ci-lane-shadow-write-"));
+  t.after(() => rmSync(root, { recursive: true, force: true }));
+  const output = join(root, "observation.json");
+  const document = {
+    schema_version: 1,
+    workflow_runs: [],
+    lane_observations: [],
+  };
+  const written = writeShadowObservation(output, document);
+  assert.equal(written.body, `${JSON.stringify(document, null, 2)}\n`);
+  assert.equal(readFileSync(output, "utf8"), written.body);
+  assert.match(written.sha256, /^[0-9a-f]{64}$/);
+  assert.throws(
+    () => writeShadowObservation(output, document),
+    /refusing stale reuse/,
+  );
+});

--- a/.github/scripts/ci-lane-shadow-collector.test.mjs
+++ b/.github/scripts/ci-lane-shadow-collector.test.mjs
@@ -535,6 +535,30 @@ test("malformed or reversed job timestamps are rejected", async (t) => {
   }
 });
 
+test("a skipped job's reversed timestamps are tolerated with no recorded duration", async () => {
+  // The Actions API is observed to backfill a SKIPPED job's started_at a few
+  // seconds AFTER completed_at (both stamped around when the scheduler
+  // resolves the skip, not around any real execution) — reproduced live on
+  // e2e.yml's dashboard-setup / compose-smoke-shard / compose-crawl-merge.
+  // Unlike a genuinely reversed timestamp on a job that actually ran, this
+  // must not fail the collector closed.
+  const run = workflowRun({ id: 701 });
+  const { document } = await collect({
+    runs: [run],
+    jobsByRun: {
+      "701:1": [
+        workflowJob({
+          id: 7011,
+          conclusion: "skipped",
+          startedAt: "2026-08-16T11:02:00Z",
+          completedAt: "2026-08-16T11:01:00Z",
+        }),
+      ],
+    },
+  });
+  assert.equal(document.workflow_runs[0].jobs[0].duration_ms, null);
+});
+
 test("selection binding rejects stale run identity and the wrong event base", () => {
   const registry = registryFixture();
   const identity = pullRequestIdentity();

--- a/.github/scripts/main-coalescing.mjs
+++ b/.github/scripts/main-coalescing.mjs
@@ -3,10 +3,11 @@
 // GitHub evaluates workflow concurrency before any job can run, so the policy
 // has two halves: the exact expressions enrolled workflows carry and this
 // executable model that proves which event/ref pairs those expressions may
-// cancel. Only a push or scheduled run bound to refs/heads/main is replaceable.
-// Pull requests, merge groups, manual qualification, reusable-workflow calls,
-// maintenance branches, tags, releases, and unknown inputs receive a unique
-// run group and can never cancel one another.
+// cancel. Main pushes and equivalent scheduled runs are replaceable within
+// separate mode groups, so a routine push can never erase deeper nightly
+// evidence. Pull requests, merge groups, manual qualification,
+// reusable-workflow calls, maintenance branches, tags, releases, and unknown
+// inputs receive a unique run group and can never cancel one another.
 //
 // MODE=check (default) reads CI_LANE_REGISTRY (default .github/ci-lanes.json),
 // checks every enrolled workflow, and rejects registry/workflow drift.
@@ -27,13 +28,13 @@ export const MAIN_REF = 'refs/heads/main';
 export const LATEST_MAIN_SUFFIX = 'latest-main';
 
 export const GROUP_EXPRESSION =
-  "${{ github.workflow }}-${{ ((github.event_name == 'push' || github.event_name == 'schedule') && github.ref == 'refs/heads/main') && 'latest-main' || github.run_id }}";
+  "${{ github.workflow }}-${{ (github.event_name == 'push' && github.ref == 'refs/heads/main') && 'latest-main-push' || (github.event_name == 'schedule' && github.ref == 'refs/heads/main' && github.event.schedule != '') && format('latest-main-schedule-{0}', github.event.schedule) || github.run_id }}";
 export const CANCEL_EXPRESSION =
-  "${{ (github.event_name == 'push' || github.event_name == 'schedule') && github.ref == 'refs/heads/main' }}";
+  "${{ (github.event_name == 'push' && github.ref == 'refs/heads/main') || (github.event_name == 'schedule' && github.ref == 'refs/heads/main' && github.event.schedule != '') }}";
 
 // These workflows contain replaceable deep-main, soak, or scheduled test work.
-// A schedule and a push on main intentionally share one group per workflow, so
-// the newest run is the only one allowed to consume the deep-test budget.
+// Main pushes share one group per workflow. Scheduled runs share a group only
+// with the same workflow and exact cron expression.
 export const COALESCED_WORKFLOWS = Object.freeze([
   '.github/workflows/agpl-oracle.yml',
   '.github/workflows/chdb.yml',
@@ -79,17 +80,29 @@ export const QUICKSTART_CANCEL_EXPRESSION =
 export function coalescingDecision({
   eventName,
   ref,
+  schedule,
   workflow = 'workflow',
   runId = 'run',
 } = {}) {
   const event = String(eventName ?? '');
   const boundRef = String(ref ?? '');
-  const replaceable =
-    (event === 'push' || event === 'schedule') && boundRef === MAIN_REF;
+  const cron = String(schedule ?? '').trim();
+  const mainPush = event === 'push' && boundRef === MAIN_REF;
+  const equivalentSchedule =
+    event === 'schedule' && boundRef === MAIN_REF && cron !== '';
+  const groupKey = mainPush
+    ? `${LATEST_MAIN_SUFFIX}-push`
+    : equivalentSchedule
+      ? `${LATEST_MAIN_SUFFIX}-schedule-${cron}`
+      : runId;
   return Object.freeze({
-    cancelInProgress: replaceable,
-    group: `${workflow}-${replaceable ? LATEST_MAIN_SUFFIX : runId}`,
-    reason: replaceable ? 'latest_main' : 'distinct_run',
+    cancelInProgress: mainPush || equivalentSchedule,
+    group: `${workflow}-${groupKey}`,
+    reason: mainPush
+      ? 'latest_main_push'
+      : equivalentSchedule
+        ? 'equivalent_schedule'
+        : 'distinct_run',
   });
 }
 
@@ -177,12 +190,12 @@ export function validateEnrolledWorkflow(workflow, workflowText) {
   }
   if (concurrency.group !== GROUP_EXPRESSION) {
     problems.push(
-      `${workflow}: concurrency group is ${JSON.stringify(concurrency.group)}, want the canonical latest-main/unique-run expression`,
+      `${workflow}: concurrency group is ${JSON.stringify(concurrency.group)}, want the canonical main-push/equivalent-schedule/unique-run expression`,
     );
   }
   if (concurrency.cancelInProgress !== CANCEL_EXPRESSION) {
     problems.push(
-      `${workflow}: cancel-in-progress is ${JSON.stringify(concurrency.cancelInProgress)}, want the canonical main-push/schedule-only expression`,
+      `${workflow}: cancel-in-progress is ${JSON.stringify(concurrency.cancelInProgress)}, want the canonical main-push/equivalent-schedule-only expression`,
     );
   }
 

--- a/.github/scripts/main-coalescing.test.mjs
+++ b/.github/scripts/main-coalescing.test.mjs
@@ -17,22 +17,50 @@ import {
   validateQuickstartWorkflow,
 } from './main-coalescing.mjs';
 
-const decision = (eventName, ref, runId = '17') =>
-  coalescingDecision({ eventName, ref, workflow: 'deep', runId });
+const decision = (eventName, ref, runId = '17', schedule = '') =>
+  coalescingDecision({
+    eventName,
+    ref,
+    workflow: 'deep',
+    runId,
+    schedule,
+  });
 
-test('only main push and main schedule share the replaceable group', () => {
-  for (const eventName of ['push', 'schedule']) {
-    assert.deepEqual(decision(eventName, MAIN_REF), {
-      cancelInProgress: true,
-      group: 'deep-latest-main',
-      reason: 'latest_main',
-    });
-  }
-
+test('main pushes replace only main pushes', () => {
+  assert.deepEqual(decision('push', MAIN_REF), {
+    cancelInProgress: true,
+    group: 'deep-latest-main-push',
+    reason: 'latest_main_push',
+  });
   assert.equal(
     decision('push', MAIN_REF, 'old').group,
-    decision('schedule', MAIN_REF, 'new').group,
+    decision('push', MAIN_REF, 'new').group,
   );
+});
+
+test('scheduled runs replace only the same scheduled mode', () => {
+  const nightly = '17 3 * * *';
+  assert.deepEqual(decision('schedule', MAIN_REF, '17', nightly), {
+    cancelInProgress: true,
+    group: `deep-latest-main-schedule-${nightly}`,
+    reason: 'equivalent_schedule',
+  });
+  assert.equal(
+    decision('schedule', MAIN_REF, 'old', nightly).group,
+    decision('schedule', MAIN_REF, 'new', nightly).group,
+  );
+  assert.notEqual(
+    decision('schedule', MAIN_REF, 'old', nightly).group,
+    decision('schedule', MAIN_REF, 'new', '45 4 * * *').group,
+  );
+});
+
+test('a main push cannot cancel nightly-only evidence', () => {
+  const push = decision('push', MAIN_REF, 'push');
+  const nightly = decision('schedule', MAIN_REF, 'nightly', '17 3 * * *');
+  assert.equal(push.cancelInProgress, true);
+  assert.equal(nightly.cancelInProgress, true);
+  assert.notEqual(push.group, nightly.group);
 });
 
 test('PR, queue, qualification, maintenance, release, and unknown events never cancel', () => {
@@ -77,11 +105,19 @@ test('push and schedule fail safe to distinct groups on every non-main ref', () 
       '',
       undefined,
     ]) {
-      const verdict = decision(eventName, ref);
+      const verdict = decision(eventName, ref, '17', '17 3 * * *');
       assert.equal(verdict.cancelInProgress, false, `${eventName} ${ref}`);
       assert.equal(verdict.group, 'deep-17', `${eventName} ${ref}`);
     }
   }
+});
+
+test('a malformed schedule without its declared cron fails safe to a unique group', () => {
+  const first = decision('schedule', MAIN_REF, '101');
+  const second = decision('schedule', MAIN_REF, '102');
+  assert.equal(first.cancelInProgress, false);
+  assert.equal(second.cancelInProgress, false);
+  assert.notEqual(first.group, second.group);
 });
 
 test('structural parser reads only the top-level concurrency mapping', () => {

--- a/.github/scripts/mutation-matrix.mjs
+++ b/.github/scripts/mutation-matrix.mjs
@@ -55,7 +55,7 @@ import { execFileSync } from 'node:child_process';
 import { readFileSync, readdirSync, statSync } from 'node:fs';
 import { join } from 'node:path';
 
-import { error, log, notice, setOutput } from './lib/gh.mjs';
+import { error, git, log, notice, setOutput } from './lib/gh.mjs';
 import { changedPaths, matchesAny, normalise, runsFullLane, underPrefix } from './lib/scope-gate.mjs';
 import { HARNESS_PATHS, MUTATION_PRODUCTION_GLOBS, PHASES } from './mutation-phases.mjs';
 
@@ -454,6 +454,62 @@ export function selectPhases({
   };
 }
 
+// changedLineProjection returns the exact merge-base ref and per-path added-line
+// counts used by gremlins' native `--diff` filter. A malformed or unavailable
+// projection is null: callers must run the selected phase in full.
+export function changedLineProjection({ baseSha, headSha, runGit = git }) {
+  const base = String(baseSha ?? '').trim();
+  const head = String(headSha ?? '').trim();
+  if (!/^[0-9a-f]{7,64}$/i.test(base) || !/^[0-9a-f]{7,64}$/i.test(head)) return null;
+
+  const mergeBase = runGit(['merge-base', base, head]);
+  const ref = String(mergeBase?.stdout ?? '').trim();
+  if (mergeBase?.status !== 0 || !/^[0-9a-f]{40,64}$/i.test(ref)) return null;
+
+  // `--no-renames` makes the NUL-delimited numstat grammar one fixed record
+  // shape. A rename with content becomes delete + add, which safely treats the
+  // new file as entirely changed rather than under-selecting its mutants.
+  const diff = runGit(['diff', '--numstat', '-z', '--no-renames', ref, head]);
+  if (diff?.status !== 0) return null;
+  const additions = new Map();
+  for (const record of String(diff.stdout ?? '').split('\0')) {
+    if (record === '') continue;
+    const fields = record.split('\t');
+    if (fields.length !== 3 || fields[2] === '') return null;
+    const [added, deleted, path] = fields;
+    if ((added !== '-' && !/^[0-9]+$/.test(added)) || (deleted !== '-' && !/^[0-9]+$/.test(deleted))) {
+      return null;
+    }
+    additions.set(normalise(path), added === '-' ? null : Number(added));
+  }
+  return { ref, additions };
+}
+
+function mutableProductionGo(path) {
+  return path.endsWith('.go') && !path.endsWith('_test.go');
+}
+
+// addChangedLineRefs chooses incremental mutation independently per phase. A
+// phase is incremental only when every changed path that selected it is a
+// production Go file with at least one added line. Test, fixture, binary,
+// harness, delete-only, and unknown changes deliberately keep the full phase:
+// each can change the efficacy of mutants outside the edited lines.
+export function addChangedLineRefs({ phases, changed, projection }) {
+  return phases.map((phase) => {
+    if (!(changed instanceof Set) || projection === null) return { ...phase, diff_ref: '' };
+    const claimed = [...changed].filter((path) => phaseClaims(phase, path));
+    const incremental =
+      claimed.length > 0 &&
+      claimed.every(
+        (path) =>
+          mutableProductionGo(path) &&
+          Number.isSafeInteger(projection.additions.get(normalise(path))) &&
+          projection.additions.get(normalise(path)) > 0,
+      );
+    return { ...phase, diff_ref: incremental ? projection.ref : '' };
+  });
+}
+
 // ---------------------------------------------------------------------------
 // driver
 // ---------------------------------------------------------------------------
@@ -526,8 +582,19 @@ function main() {
   }
   if (gaps.length > 0) process.exit(1);
 
+  const projection =
+    changed === null
+      ? null
+      : changedLineProjection({
+          baseSha: process.env.BASE_SHA,
+          headSha: process.env.HEAD_SHA,
+        });
+  const matrixPhases = addChangedLineRefs({ phases, changed, projection });
+  const incrementalCount = matrixPhases.filter((phase) => phase.diff_ref !== '').length;
+
   notice(
-    `mutation-matrix: running ${phases.length}/${PHASES.length} phases — ${reason}` +
+    `mutation-matrix: running ${phases.length}/${PHASES.length} phases — ${reason}; ` +
+      `${incrementalCount} changed-line, ${matrixPhases.length - incrementalCount} full` +
       (phases.length > 0 ? ` (${phases.map((p) => p.phase).join(', ')})` : ''),
   );
 
@@ -537,7 +604,7 @@ function main() {
   // a job-level `if:` cannot introspect a matrix: without it, a SKIPPED `mutate`
   // is indistinguishable to the aggregator from a selection that was legitimately
   // empty — which is precisely the ambiguity this lane is being fixed to remove.
-  setOutput('matrix', JSON.stringify({ include: phases }));
+  setOutput('matrix', JSON.stringify({ include: matrixPhases }));
   setOutput('has_phases', String(phases.length > 0));
 }
 

--- a/.github/scripts/mutation-matrix.test.mjs
+++ b/.github/scripts/mutation-matrix.test.mjs
@@ -21,6 +21,8 @@ import { readFileSync } from 'node:fs';
 import { test } from 'node:test';
 
 import {
+  addChangedLineRefs,
+  changedLineProjection,
   MUTATION_LANE_ID,
   MUTATION_MIN_EFFICACY,
   MUTATION_REGISTRY_PATH,
@@ -238,7 +240,94 @@ test('an uncomputable diff runs the full matrix rather than nothing', () => {
   assert.match(result.reason, /could not be computed/);
 });
 
+test('changed-line projection is bound to the exact merge base and added-line roster', () => {
+  const base = 'a'.repeat(40);
+  const head = 'b'.repeat(40);
+  const mergeBase = 'c'.repeat(40);
+  const calls = [];
+  const projection = changedLineProjection({
+    baseSha: base,
+    headSha: head,
+    runGit: (args) => {
+      calls.push(args);
+      if (args[0] === 'merge-base') return { status: 0, stdout: `${mergeBase}\n`, stderr: '' };
+      return {
+        status: 0,
+        stdout:
+          [
+            '4\t2\tinternal/chplan/plan.go',
+            '0\t7\tinternal/chsql/deleted.go',
+            '-\t-\tinternal/chsql/blob.go',
+          ].join('\0') + '\0',
+        stderr: '',
+      };
+    },
+  });
+  assert.deepEqual(calls, [
+    ['merge-base', base, head],
+    ['diff', '--numstat', '-z', '--no-renames', mergeBase, head],
+  ]);
+  assert.equal(projection.ref, mergeBase);
+  assert.equal(projection.additions.get('internal/chplan/plan.go'), 4);
+  assert.equal(projection.additions.get('internal/chsql/deleted.go'), 0);
+  assert.equal(projection.additions.get('internal/chsql/blob.go'), null);
+});
+
+test('changed-line projection fails closed on missing refs, git failure, and malformed numstat', () => {
+  assert.equal(changedLineProjection({ baseSha: '', headSha: 'b'.repeat(40) }), null);
+  assert.equal(
+    changedLineProjection({
+      baseSha: 'a'.repeat(40),
+      headSha: 'b'.repeat(40),
+      runGit: () => ({ status: 1, stdout: '', stderr: 'missing' }),
+    }),
+    null,
+  );
+  let call = 0;
+  assert.equal(
+    changedLineProjection({
+      baseSha: 'a'.repeat(40),
+      headSha: 'b'.repeat(40),
+      runGit: () =>
+        call++ === 0
+          ? { status: 0, stdout: `${'c'.repeat(40)}\n`, stderr: '' }
+          : { status: 0, stdout: 'not-numstat\0', stderr: '' },
+    }),
+    null,
+  );
+});
+
+test('only production additions receive changed-line mutation refs', () => {
+  const ref = 'c'.repeat(40);
+  const phase = PHASES.find((candidate) => candidate.phase === 'phase1');
+  const project = (changed, additions) =>
+    addChangedLineRefs({
+      phases: [phase],
+      changed: new Set(changed),
+      projection: { ref, additions: new Map(additions) },
+    })[0].diff_ref;
+
+  assert.equal(project(['internal/chplan/plan.go'], [['internal/chplan/plan.go', 3]]), ref);
+  assert.equal(project(['internal/chplan/plan.go'], [['internal/chplan/plan.go', 0]]), '');
+  assert.equal(project(['internal/chplan/plan_test.go'], [['internal/chplan/plan_test.go', 3]]), '');
+  assert.equal(
+    project(
+      ['internal/chplan/plan.go', 'internal/chplan/plan_test.go'],
+      [
+        ['internal/chplan/plan.go', 3],
+        ['internal/chplan/plan_test.go', 2],
+      ],
+    ),
+    '',
+  );
+  assert.equal(
+    addChangedLineRefs({ phases: [phase], changed: null, projection: null })[0].diff_ref,
+    '',
+  );
+});
+
 test('a change to the lane harness runs the full matrix', () => {
+  assert.equal(HARNESS_PATHS.includes('.github/scripts/mutation-run.mjs'), true);
   for (const path of HARNESS_PATHS) {
     assert.equal(select([path]).phases.length, PHASES.length, path);
   }

--- a/.github/scripts/mutation-phases.mjs
+++ b/.github/scripts/mutation-phases.mjs
@@ -325,6 +325,7 @@ export const HARNESS_PATHS = [
   '.github/workflows/mutation.yml',
   '.github/scripts/mutation-phases.mjs',
   '.github/scripts/mutation-matrix.mjs',
+  '.github/scripts/mutation-run.mjs',
   '.github/scripts/gremlins-threshold.mjs',
   '.github/scripts/lib/scope-gate.mjs',
   '.gremlins.yaml',

--- a/.github/scripts/mutation-run.mjs
+++ b/.github/scripts/mutation-run.mjs
@@ -1,0 +1,85 @@
+// mutation-run.mjs — run one mutation phase with safe changed-line fallback.
+//
+// Required env: SCOPE, REPORT, MUTANT_TIMEOUT_MAX.
+// Optional env: WORKERS, EXCLUDE_FILES, DIFF_REF.
+//
+// A non-empty DIFF_REF first invokes gremlins' native merge-base line filter.
+// If that report contains zero executable mutants, the script deletes it and
+// reruns the phase without --diff. This makes comment-only or otherwise
+// mutation-free edits conservative full checks instead of hollow greens.
+
+import { spawnSync } from 'node:child_process';
+import { existsSync, readFileSync, unlinkSync } from 'node:fs';
+import process from 'node:process';
+
+import { error, notice } from './lib/gh.mjs';
+
+function required(name) {
+  const value = String(process.env[name] ?? '').trim();
+  if (value === '') throw new Error(`${name} is required`);
+  return value;
+}
+
+function reportTotal(path) {
+  let document;
+  try {
+    document = JSON.parse(readFileSync(path, 'utf8'));
+  } catch (cause) {
+    throw new Error(`cannot read gremlins report ${path}: ${cause.message}`);
+  }
+  if (!Number.isSafeInteger(document.mutants_total) || document.mutants_total < 0) {
+    throw new Error(`gremlins report ${path} has invalid mutants_total`);
+  }
+  return document.mutants_total;
+}
+
+function runGremlins({ report, diffRef = '' }) {
+  const args = [
+    'unleash',
+    '--output',
+    report,
+    '--on-shutdown-status=not-run',
+    '--timeout-max',
+    required('MUTANT_TIMEOUT_MAX'),
+  ];
+  const workers = String(process.env.WORKERS ?? '').trim();
+  if (workers !== '' && workers !== '0') {
+    if (!/^[1-9][0-9]*$/.test(workers)) throw new Error(`WORKERS is invalid: ${workers}`);
+    args.push('--workers', workers);
+  }
+  const exclude = String(process.env.EXCLUDE_FILES ?? '').trim();
+  if (exclude !== '') args.push('--exclude-files', exclude);
+  if (diffRef !== '') args.push('--diff', diffRef);
+  args.push(required('SCOPE'));
+
+  const result = spawnSync('gremlins', args, { stdio: 'inherit' });
+  if (result.error) throw new Error(`cannot execute gremlins: ${result.error.message}`);
+  if (result.status !== 0) throw new Error(`gremlins exited ${result.status}`);
+  if (!existsSync(report)) throw new Error(`gremlins produced no report at ${report}`);
+}
+
+function main() {
+  const report = required('REPORT');
+  const diffRef = String(process.env.DIFF_REF ?? '').trim();
+  if (diffRef !== '' && !/^[0-9a-f]{40,64}$/i.test(diffRef)) {
+    throw new Error(`DIFF_REF is invalid: ${diffRef}`);
+  }
+  if (existsSync(report)) throw new Error(`refusing stale gremlins report ${report}`);
+
+  runGremlins({ report, diffRef });
+  if (diffRef !== '' && reportTotal(report) === 0) {
+    notice('changed-line mutation found zero executable mutants; rerunning the full phase');
+    unlinkSync(report);
+    runGremlins({ report });
+  }
+  const total = reportTotal(report);
+  if (total <= 0) throw new Error('mutation phase executed zero mutants after full fallback');
+  notice(`mutation phase executed ${total} mutant(s)${diffRef === '' ? ' in full' : ''}`);
+}
+
+try {
+  main();
+} catch (cause) {
+  error(cause instanceof Error ? cause.message : String(cause));
+  process.exit(1);
+}

--- a/.github/scripts/mutation-run.test.mjs
+++ b/.github/scripts/mutation-run.test.mjs
@@ -1,0 +1,86 @@
+import assert from 'node:assert/strict';
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { test } from 'node:test';
+
+// The runner's process boundary is intentional: it must prove the exact env
+// contract and two-invocation fallback, not a helper that bypasses main().
+import { spawnSync } from 'node:child_process';
+
+function fixture(t, totals) {
+  const root = mkdtempSync(join(tmpdir(), 'mutation-run-'));
+  t.after(() => rmSync(root, { recursive: true, force: true }));
+  const calls = join(root, 'calls.jsonl');
+  const fake = join(root, 'gremlins');
+  writeFileSync(calls, '');
+  writeFileSync(
+    fake,
+    `#!/usr/bin/env node
+const fs = require('node:fs');
+const args = process.argv.slice(2);
+fs.appendFileSync(${JSON.stringify(calls)}, JSON.stringify(args) + '\\n');
+const report = args[args.indexOf('--output') + 1];
+const totals = ${JSON.stringify(totals)};
+const call = fs.readFileSync(${JSON.stringify(calls)}, 'utf8').trim().split('\\n').length - 1;
+fs.writeFileSync(report, JSON.stringify({ mutants_total: totals[call] }));
+`,
+    { mode: 0o755 },
+  );
+  return { root, calls, fake };
+}
+
+function run(root, env = {}) {
+  return spawnSync(process.execPath, ['.github/scripts/mutation-run.mjs'], {
+    cwd: process.cwd(),
+    encoding: 'utf8',
+    env: {
+      ...process.env,
+      PATH: `${root}:${process.env.PATH}`,
+      SCOPE: './internal/chplan',
+      REPORT: join(root, 'gremlins.json'),
+      MUTANT_TIMEOUT_MAX: '15s',
+      WORKERS: '0',
+      EXCLUDE_FILES: '',
+      ...env,
+    },
+  });
+}
+
+test('changed-line execution stays incremental when it executes mutants', (t) => {
+  const { root, calls } = fixture(t, [3]);
+  const result = run(root, { DIFF_REF: 'a'.repeat(40) });
+  assert.equal(result.status, 0, result.stderr);
+  const invocations = readFileSync(calls, 'utf8').trim().split('\n').map(JSON.parse);
+  assert.equal(invocations.length, 1);
+  assert.deepEqual(invocations[0].slice(-3), ['--diff', 'a'.repeat(40), './internal/chplan']);
+});
+
+test('zero changed-line mutants trigger one full fallback', (t) => {
+  const { root, calls } = fixture(t, [0, 7]);
+  const result = run(root, { DIFF_REF: 'a'.repeat(40) });
+  assert.equal(result.status, 0, result.stderr);
+  const invocations = readFileSync(calls, 'utf8').trim().split('\n').map(JSON.parse);
+  assert.equal(invocations.length, 2);
+  assert.equal(invocations[0].includes('--diff'), true);
+  assert.equal(invocations[1].includes('--diff'), false);
+});
+
+test('zero mutants after full fallback fail closed', (t) => {
+  const { root } = fixture(t, [0, 0]);
+  const result = run(root, { DIFF_REF: 'a'.repeat(40) });
+  assert.equal(result.status, 1);
+  assert.match(`${result.stdout}\n${result.stderr}`, /executed zero mutants after full fallback/);
+});
+
+test('invalid diff refs and stale reports fail before gremlins runs', (t) => {
+  const { root, calls } = fixture(t, [3]);
+  let result = run(root, { DIFF_REF: 'main' });
+  assert.equal(result.status, 1);
+  assert.equal(readFileSync(calls, 'utf8'), '');
+
+  writeFileSync(join(root, 'gremlins.json'), '{}');
+  result = run(root, { DIFF_REF: '' });
+  assert.equal(result.status, 1);
+  assert.match(`${result.stdout}\n${result.stderr}`, /refusing stale gremlins report/);
+});

--- a/.github/workflows/agpl-oracle.yml
+++ b/.github/workflows/agpl-oracle.yml
@@ -171,3 +171,20 @@ jobs:
       - name: No-op (docs-only PR)
         if: needs.changes.outputs.docs_only == 'true'
         run: echo "agpl-oracle is a green no-op on docs-only PRs."
+
+
+      - name: emit native evidence for agpl.oracle
+        uses: ./.github/actions/ci-native-part
+        with:
+          id: agpl.oracle.agpl-oracle.source
+          seed: ci-${{ github.run_id }}-${{ github.run_attempt }}
+
+  native-evidence:
+    name: native-evidence
+    if: always()
+    needs: [changes, agpl-oracle]
+    uses: ./.github/workflows/ci-native-evidence.yml
+    with:
+      workflow: .github/workflows/agpl-oracle.yml
+      needs_json: ${{ toJSON(needs) }}
+      posture: ${{ (github.event_name == 'pull_request' || github.event_name == 'merge_group') && 'merge' || (github.ref == 'refs/heads/main' && 'main') || 'merge' }}

--- a/.github/workflows/agpl-oracle.yml
+++ b/.github/workflows/agpl-oracle.yml
@@ -83,10 +83,10 @@ permissions:
   contents: read
 
 concurrency:
-  # A newer deep run may replace only push/schedule work on main. Every PR,
-  # queue, dispatch, maintenance, and unknown event gets its own run-id group.
-  group: ${{ github.workflow }}-${{ ((github.event_name == 'push' || github.event_name == 'schedule') && github.ref == 'refs/heads/main') && 'latest-main' || github.run_id }}
-  cancel-in-progress: ${{ (github.event_name == 'push' || github.event_name == 'schedule') && github.ref == 'refs/heads/main' }}
+  # Main pushes replace only older main pushes; matching cron schedules replace
+  # only that scheduled mode. Every other event gets its own run-id group.
+  group: ${{ github.workflow }}-${{ (github.event_name == 'push' && github.ref == 'refs/heads/main') && 'latest-main-push' || (github.event_name == 'schedule' && github.ref == 'refs/heads/main' && github.event.schedule != '') && format('latest-main-schedule-{0}', github.event.schedule) || github.run_id }}
+  cancel-in-progress: ${{ (github.event_name == 'push' && github.ref == 'refs/heads/main') || (github.event_name == 'schedule' && github.ref == 'refs/heads/main' && github.event.schedule != '') }}
 
 jobs:
   # Docs-only short-circuit — see chdb.yml for the full rationale. The

--- a/.github/workflows/chart-ci.yml
+++ b/.github/workflows/chart-ci.yml
@@ -138,3 +138,19 @@ jobs:
             version_flag="--check-version-increment=false"
           fi
           ct lint --chart-dirs deploy/helm --target-branch "$TARGET_BRANCH" --validate-maintainers=false $version_flag
+
+
+      - name: emit native evidence for chart.validate
+        uses: ./.github/actions/ci-native-part
+        with:
+          id: chart.validate.chart-validate.source
+
+  native-evidence:
+    name: native-evidence
+    if: always()
+    needs: [chart-validate]
+    uses: ./.github/workflows/ci-native-evidence.yml
+    with:
+      workflow: .github/workflows/chart-ci.yml
+      needs_json: ${{ toJSON(needs) }}
+      posture: ${{ (github.event_name == 'pull_request' || github.event_name == 'merge_group') && 'merge' || (github.ref == 'refs/heads/main' && 'main') || 'merge' }}

--- a/.github/workflows/chdb.yml
+++ b/.github/workflows/chdb.yml
@@ -238,6 +238,11 @@ jobs:
   # docs-only PR every step is skipped and each leg concludes `success`
   # in seconds (no chDB compile/run) — satisfying the required check
   # without doing the work. Do NOT hoist this back to the job level.
+
+      - name: emit native evidence for chdb.probe
+        uses: ./.github/actions/ci-native-part
+        with:
+          id: chdb.probe.probe.source
   roundtrip:
     name: roundtrip (${{ matrix.ql }})
     needs: changes
@@ -399,6 +404,24 @@ jobs:
   #
   # COST: N legs = N chDB installs and N compiles — billable minutes rise, while
   # wall-clock drops from the serial sum toward the longest leg plus fixed setup.
+
+      - name: emit native evidence for chdb.roundtrip-logql
+        if: ${{ matrix.ql == 'logql' }}
+        uses: ./.github/actions/ci-native-part
+        with:
+          id: chdb.roundtrip-logql.roundtrip.source
+
+      - name: emit native evidence for chdb.roundtrip-promql
+        if: ${{ matrix.ql == 'promql' }}
+        uses: ./.github/actions/ci-native-part
+        with:
+          id: chdb.roundtrip-promql.roundtrip.source
+
+      - name: emit native evidence for chdb.roundtrip-traceql
+        if: ${{ matrix.ql == 'traceql' }}
+        uses: ./.github/actions/ci-native-part
+        with:
+          id: chdb.roundtrip-traceql.roundtrip.source
   perf-guards-shard:
     name: perf-guards-shard
     needs: changes
@@ -522,6 +545,11 @@ jobs:
   # No golden file + no GOLDEN_UPDATE: expected results are computed at run
   # time by the oracle, so a pass proves PromQL semantics, not reproduction
   # of a recording.
+
+      - name: emit native evidence for chdb.perf-guards
+        uses: ./.github/actions/ci-native-part
+        with:
+          id: chdb.perf-guards.perf-guards.source
   integration-promql:
     name: integration (promql)
     needs: changes
@@ -561,6 +589,11 @@ jobs:
   # This is ORTHOGONAL to `roundtrip`: roundtrip pins self-derived SQL and
   # expected_rows; this live HTTP pipeline has no golden/GOLDEN_UPDATE path
   # and catches semantic lowering, optimizer, emitter, and wire drift.
+
+      - name: emit native evidence for chdb.integration-promql
+        uses: ./.github/actions/ci-native-part
+        with:
+          id: chdb.integration-promql.integration-promql.source
   integration-logql:
     name: integration (logql)
     needs: changes
@@ -600,6 +633,11 @@ jobs:
   # expected_rows; this live HTTP pipeline has no golden/GOLDEN_UPDATE path
   # and catches semantic selector, structural, aggregate, optimizer, emitter,
   # and wire drift.
+
+      - name: emit native evidence for chdb.integration-logql
+        uses: ./.github/actions/ci-native-part
+        with:
+          id: chdb.integration-logql.integration-logql.source
   integration-traceql:
     name: integration (traceql)
     needs: changes
@@ -629,3 +667,19 @@ jobs:
 
       - name: Run exotic TraceQL integration suite (chDB)
         run: go test -tags chdb -count=1 ./test/integration/traceql/...
+
+
+      - name: emit native evidence for chdb.integration-traceql
+        uses: ./.github/actions/ci-native-part
+        with:
+          id: chdb.integration-traceql.integration-traceql.source
+
+  native-evidence:
+    name: native-evidence
+    if: always()
+    needs: [changes, chdb-build, probe, roundtrip, perf-guards-shard, perf-guards, integration-promql, integration-logql, integration-traceql]
+    uses: ./.github/workflows/ci-native-evidence.yml
+    with:
+      workflow: .github/workflows/chdb.yml
+      needs_json: ${{ toJSON(needs) }}
+      posture: ${{ (github.event_name == 'pull_request' || github.event_name == 'merge_group') && 'merge' || (github.ref == 'refs/heads/main' && 'main') || 'merge' }}

--- a/.github/workflows/chdb.yml
+++ b/.github/workflows/chdb.yml
@@ -75,10 +75,10 @@ permissions:
   contents: read
 
 concurrency:
-  # A newer deep run may replace only push/schedule work on main. Every PR,
-  # queue, dispatch, maintenance, and unknown event gets its own run-id group.
-  group: ${{ github.workflow }}-${{ ((github.event_name == 'push' || github.event_name == 'schedule') && github.ref == 'refs/heads/main') && 'latest-main' || github.run_id }}
-  cancel-in-progress: ${{ (github.event_name == 'push' || github.event_name == 'schedule') && github.ref == 'refs/heads/main' }}
+  # Main pushes replace only older main pushes; matching cron schedules replace
+  # only that scheduled mode. Every other event gets its own run-id group.
+  group: ${{ github.workflow }}-${{ (github.event_name == 'push' && github.ref == 'refs/heads/main') && 'latest-main-push' || (github.event_name == 'schedule' && github.ref == 'refs/heads/main' && github.event.schedule != '') && format('latest-main-schedule-{0}', github.event.schedule) || github.run_id }}
+  cancel-in-progress: ${{ (github.event_name == 'push' && github.ref == 'refs/heads/main') || (github.event_name == 'schedule' && github.ref == 'refs/heads/main' && github.event.schedule != '') }}
 
 jobs:
   # See `.github/workflows/ci.yml` for the rationale + filter convention.

--- a/.github/workflows/ci-native-evidence.yml
+++ b/.github/workflows/ci-native-evidence.yml
@@ -16,6 +16,19 @@ on:
         required: false
         type: string
         default: ""
+    outputs:
+      native_artifact_name:
+        value: ${{ jobs.emit.outputs.native_artifact_name }}
+      native_artifact_id:
+        value: ${{ jobs.emit.outputs.native_artifact_id }}
+      native_artifact_digest:
+        value: ${{ jobs.emit.outputs.native_artifact_digest }}
+      native_bundle_sha256:
+        value: ${{ jobs.emit.outputs.native_bundle_sha256 }}
+      native_lane_count:
+        value: ${{ jobs.emit.outputs.native_lane_count }}
+      native_correlation_nonce:
+        value: ${{ jobs.emit.outputs.native_correlation_nonce }}
 
 permissions:
   contents: read
@@ -24,6 +37,13 @@ jobs:
   emit:
     runs-on: ubuntu-latest
     timeout-minutes: 5
+    outputs:
+      native_artifact_name: ${{ steps.evidence.outputs.native_artifact_name }}
+      native_artifact_id: ${{ steps.bundle.outputs.artifact-id }}
+      native_artifact_digest: ${{ steps.bundle.outputs.artifact-digest }}
+      native_bundle_sha256: ${{ steps.evidence.outputs.native_bundle_sha256 }}
+      native_lane_count: ${{ steps.evidence.outputs.native_lane_count }}
+      native_correlation_nonce: ${{ steps.evidence.outputs.native_correlation_nonce }}
     steps:
       - uses: actions/checkout@v7
         with:
@@ -31,19 +51,25 @@ jobs:
           fetch-depth: 0
           clean: true
 
+      - name: download the attempt-qualified native parts
+        uses: actions/download-artifact@v8
+        with:
+          pattern: ci-native-part-*-${{ github.run_attempt }}
+          path: ${{ runner.temp }}/ci-native-parts
+
       - id: evidence
-        name: derive evidence from the caller's native job graph
+        name: derive counts from the registry-owned native part roster
         env:
           CI_LANE_WORKFLOW: ${{ inputs.workflow }}
           CI_LANE_NEEDS_JSON: ${{ inputs.needs_json }}
           CI_LANE_NATIVE_POSTURE: ${{ inputs.posture }}
           CI_LANE_CORRELATION_NONCE: ${{ inputs.correlation_nonce }}
-          CI_LANE_NATIVE_OUTPUT: build/ci-native-evidence.json
-        run: |
-          mkdir -p build
-          node .github/scripts/ci-lane-native-evidence.mjs
+          CI_LANE_NATIVE_PARTS: ${{ runner.temp }}/ci-native-parts
+          CI_LANE_NATIVE_OUTPUT: ${{ runner.temp }}/ci-native-evidence.json
+        run: node .github/scripts/ci-lane-native-evidence.mjs
 
-      - name: publish the attempt-qualified native bundle
+      - id: bundle
+        name: publish the attempt-qualified native bundle
         uses: actions/upload-artifact@v7
         with:
           name: ${{ steps.evidence.outputs.native_artifact_name }}

--- a/.github/workflows/ci-native-evidence.yml
+++ b/.github/workflows/ci-native-evidence.yml
@@ -1,0 +1,52 @@
+name: ci-native-evidence
+
+on:
+  workflow_call:
+    inputs:
+      workflow:
+        required: true
+        type: string
+      needs_json:
+        required: true
+        type: string
+      posture:
+        required: true
+        type: string
+      correlation_nonce:
+        required: false
+        type: string
+        default: ""
+
+permissions:
+  contents: read
+
+jobs:
+  emit:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          ref: ${{ github.sha }}
+          fetch-depth: 0
+          clean: true
+
+      - id: evidence
+        name: derive evidence from the caller's native job graph
+        env:
+          CI_LANE_WORKFLOW: ${{ inputs.workflow }}
+          CI_LANE_NEEDS_JSON: ${{ inputs.needs_json }}
+          CI_LANE_NATIVE_POSTURE: ${{ inputs.posture }}
+          CI_LANE_CORRELATION_NONCE: ${{ inputs.correlation_nonce }}
+          CI_LANE_NATIVE_OUTPUT: build/ci-native-evidence.json
+        run: |
+          mkdir -p build
+          node .github/scripts/ci-lane-native-evidence.mjs
+
+      - name: publish the attempt-qualified native bundle
+        uses: actions/upload-artifact@v7
+        with:
+          name: ${{ steps.evidence.outputs.native_artifact_name }}
+          path: ${{ steps.evidence.outputs.native_path }}
+          if-no-files-found: error
+          retention-days: 14

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,6 +108,11 @@ jobs:
   # the suite does NOT need to wait for is the build / type-check / oracle /
   # tidy work — pure serial tail hanging off the same runner. That moved to
   # `check-build`, and the two halves now overlap instead of queueing.
+
+      - name: emit native evidence for ci.check
+        uses: ./.github/actions/ci-native-part
+        with:
+          id: ci.check.changes.source
   check-test:
     name: check-test
     needs: changes
@@ -136,6 +141,16 @@ jobs:
           just test-chaos-sleep
           just test-unit
 
+
+      - name: emit native evidence for ci.chaos-sleep
+        uses: ./.github/actions/ci-native-part
+        with:
+          id: ci.chaos-sleep.check-test.source
+
+      - name: emit native evidence for ci.check
+        uses: ./.github/actions/ci-native-part
+        with:
+          id: ci.check.check-test.source
   check-build:
     name: check-build
     needs: changes
@@ -194,6 +209,11 @@ jobs:
   # split unchanged. `always()` is load-bearing — with a plain `needs:` this job
   # would be SKIPPED when a half fails, and a skipped required check is green to
   # branch protection. So it always runs and reads the results explicitly.
+
+      - name: emit native evidence for ci.check
+        uses: ./.github/actions/ci-native-part
+        with:
+          id: ci.check.check-build.source
   check:
     name: check
     needs: [changes, check-test, check-build]
@@ -549,6 +569,11 @@ jobs:
   # boundary (and pinned by their respective VERSION files). Runs in
   # parallel with `check` + `lint`; flip on as a required status check
   # via branch protection.
+
+      - name: emit native evidence for ci.lint
+        uses: ./.github/actions/ci-native-part
+        with:
+          id: ci.lint.lint.source
   forbid-skip:
     name: forbid-skip
     runs-on: ubuntu-latest
@@ -1047,6 +1072,11 @@ jobs:
   # Vendored upstream snapshots under `compatibility/*/upstream/**` are
   # excluded, mirroring the markdownlint + forbid-skip exclude set — they are
   # reference material outside cerberus's authorship boundary.
+
+      - name: emit native evidence for ci.forbid-skip
+        uses: ./.github/actions/ci-native-part
+        with:
+          id: ci.forbid-skip.forbid-skip.source
   link-check:
     name: link-check
     runs-on: ubuntu-latest
@@ -1096,6 +1126,11 @@ jobs:
   # grafana/tempo/* except pkg/tempopb). Logic lives in
   # .github/scripts/agpl-clean.mjs (node: builtins only). Add to branch
   # protection as a required status check.
+
+      - name: emit native evidence for ci.link-check
+        uses: ./.github/actions/ci-native-part
+        with:
+          id: ci.link-check.link-check.source
   agpl-clean:
     name: agpl-clean
     needs: changes
@@ -1111,3 +1146,19 @@ jobs:
 
       - name: AGPL clean-build gate
         run: node .github/scripts/agpl-clean.mjs
+
+
+      - name: emit native evidence for ci.agpl-clean
+        uses: ./.github/actions/ci-native-part
+        with:
+          id: ci.agpl-clean.agpl-clean.source
+
+  native-evidence:
+    name: native-evidence
+    if: always()
+    needs: [changes, check-test, check-build, lint, forbid-skip, link-check, agpl-clean]
+    uses: ./.github/workflows/ci-native-evidence.yml
+    with:
+      workflow: .github/workflows/ci.yml
+      needs_json: ${{ toJSON(needs) }}
+      posture: ${{ (github.event_name == 'pull_request' || github.event_name == 'merge_group') && 'merge' || (github.ref == 'refs/heads/main' && 'main') || 'merge' }}

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -49,10 +49,10 @@ permissions:
   security-events: write
 
 concurrency:
-  # A newer deep run may replace only push/schedule work on main. In particular,
-  # PR and merge-group evidence is unique and can never be cancelled here.
-  group: ${{ github.workflow }}-${{ ((github.event_name == 'push' || github.event_name == 'schedule') && github.ref == 'refs/heads/main') && 'latest-main' || github.run_id }}
-  cancel-in-progress: ${{ (github.event_name == 'push' || github.event_name == 'schedule') && github.ref == 'refs/heads/main' }}
+  # Main pushes and matching cron schedules replace only their own modes. PR
+  # and merge-group evidence is unique and can never be cancelled here.
+  group: ${{ github.workflow }}-${{ (github.event_name == 'push' && github.ref == 'refs/heads/main') && 'latest-main-push' || (github.event_name == 'schedule' && github.ref == 'refs/heads/main' && github.event.schedule != '') && format('latest-main-schedule-{0}', github.event.schedule) || github.run_id }}
+  cancel-in-progress: ${{ (github.event_name == 'push' && github.ref == 'refs/heads/main') || (github.event_name == 'schedule' && github.ref == 'refs/heads/main' && github.event.schedule != '') }}
 
 jobs:
   analyze:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -109,3 +109,22 @@ jobs:
             exit 1
           fi
           echo "All CodeQL analyses passed."
+
+
+      - name: checkout native evidence controller
+        uses: actions/checkout@v7
+
+      - name: emit native evidence for security.codeql
+        uses: ./.github/actions/ci-native-part
+        with:
+          id: security.codeql.codeql.source
+
+  native-evidence:
+    name: native-evidence
+    if: always()
+    needs: [analyze, CodeQL]
+    uses: ./.github/workflows/ci-native-evidence.yml
+    with:
+      workflow: .github/workflows/codeql.yml
+      needs_json: ${{ toJSON(needs) }}
+      posture: ${{ (github.event_name == 'pull_request' || github.event_name == 'merge_group') && 'merge' || (github.ref == 'refs/heads/main' && 'main') || 'merge' }}

--- a/.github/workflows/compatibility.yml
+++ b/.github/workflows/compatibility.yml
@@ -96,10 +96,10 @@ permissions:
   packages: read
 
 concurrency:
-  # A newer deep run may replace only push/schedule work on main. Release-head
-  # PRs, merge groups, dispatches, and maintenance pushes remain distinct.
-  group: ${{ github.workflow }}-${{ ((github.event_name == 'push' || github.event_name == 'schedule') && github.ref == 'refs/heads/main') && 'latest-main' || github.run_id }}
-  cancel-in-progress: ${{ (github.event_name == 'push' || github.event_name == 'schedule') && github.ref == 'refs/heads/main' }}
+  # Main pushes and matching cron schedules replace only their own modes.
+  # Release-head PRs, queue, dispatch, and maintenance remain distinct.
+  group: ${{ github.workflow }}-${{ (github.event_name == 'push' && github.ref == 'refs/heads/main') && 'latest-main-push' || (github.event_name == 'schedule' && github.ref == 'refs/heads/main' && github.event.schedule != '') && format('latest-main-schedule-{0}', github.event.schedule) || github.run_id }}
+  cancel-in-progress: ${{ (github.event_name == 'push' && github.ref == 'refs/heads/main') || (github.event_name == 'schedule' && github.ref == 'refs/heads/main' && github.event.schedule != '') }}
 
 jobs:
   # See `.github/workflows/ci.yml` for the rationale + filter convention.

--- a/.github/workflows/compatibility.yml
+++ b/.github/workflows/compatibility.yml
@@ -201,6 +201,11 @@ jobs:
       - name: go build (compile sanity)
         run: go build ./...
 
+
+      - name: emit native evidence for compatibility.gate
+        uses: ./.github/actions/ci-native-part
+        with:
+          id: compatibility.gate.gate.source
   prometheus:
     name: compatibility/prometheus
     needs: [changes, gate]
@@ -422,6 +427,11 @@ jobs:
           echo "::error title=compatibility/prometheus suite failed::compatibility harness (steps.compat) exited non-zero — see the 'Run compatibility harness' step log and the uploaded compatibility-prometheus-report artifact"
           exit 1
 
+
+      - name: emit native evidence for compatibility.prometheus
+        uses: ./.github/actions/ci-native-part
+        with:
+          id: compatibility.prometheus.prometheus.source
   prometheus-forced-route:
     # Phase-2 FLIP proof job for the sharded-pushdown solver. It runs the
     # SAME prometheus differential harness as `compatibility/prometheus`,
@@ -587,6 +597,11 @@ jobs:
           echo "::error title=compatibility/prometheus-forced-route failed::forced-route harness exited non-zero — route B (CERBERUS_EVAL_ROUTE=sharded) diverged from reference Prometheus, OR an infra failure occurred. See the harness log + the uploaded compatibility-prometheus-forced-route-report artifact"
           exit 1
 
+
+      - name: emit native evidence for compatibility.prometheus-forced-route
+        uses: ./.github/actions/ci-native-part
+        with:
+          id: compatibility.prometheus-forced-route.prometheus-forced-route.source
   prometheus-floor:
     # Floor-pinned proof job for #1500: internal/preflight/preflight.go's
     # minCHBase declares ClickHouse 24.8 as cerberus's supported floor, but
@@ -780,6 +795,11 @@ jobs:
           echo "::error title=compatibility/prometheus-floor failed::floor harness (ClickHouse 24.8) exited non-zero — an infra failure or a hard SQL rejection against the floor server. See the harness log + the uploaded compatibility-prometheus-floor-report artifact"
           exit 1
 
+
+      - name: emit native evidence for compatibility.prometheus-floor
+        uses: ./.github/actions/ci-native-part
+        with:
+          id: compatibility.prometheus-floor.prometheus-floor.source
   promql-surface:
     # Reference-backed full-surface PromQL rejection-completeness gate (#106).
     #
@@ -854,6 +874,11 @@ jobs:
         # misfile. node ships on ubuntu-latest, so no setup-node is needed.
         run: node .github/scripts/promql-surface-gate.mjs
 
+
+      - name: emit native evidence for compatibility.promql-surface
+        uses: ./.github/actions/ci-native-part
+        with:
+          id: compatibility.promql-surface.promql-surface.source
   tempo:
     name: compatibility/tempo
     needs: [changes, gate]
@@ -1023,6 +1048,11 @@ jobs:
           echo "::error title=compatibility/tempo suite failed::harness step failed -- see logs and uploaded report"
           exit 1
 
+
+      - name: emit native evidence for compatibility.tempo
+        uses: ./.github/actions/ci-native-part
+        with:
+          id: compatibility.tempo.tempo.source
   loki:
     name: compatibility/loki
     needs: [changes, gate]
@@ -1177,3 +1207,19 @@ jobs:
         run: |
           echo "::error title=compatibility/loki suite failed::harness step failed -- see logs and uploaded report"
           exit 1
+
+
+      - name: emit native evidence for compatibility.loki
+        uses: ./.github/actions/ci-native-part
+        with:
+          id: compatibility.loki.loki.source
+
+  native-evidence:
+    name: native-evidence
+    if: always()
+    needs: [changes, gate, prometheus, prometheus-forced-route, prometheus-floor, promql-surface, tempo, loki]
+    uses: ./.github/workflows/ci-native-evidence.yml
+    with:
+      workflow: .github/workflows/compatibility.yml
+      needs_json: ${{ toJSON(needs) }}
+      posture: ${{ (github.event_name == 'pull_request' || github.event_name == 'merge_group') && 'merge' || (github.ref == 'refs/heads/main' && 'main') || 'merge' }}

--- a/.github/workflows/config-docs.yml
+++ b/.github/workflows/config-docs.yml
@@ -53,3 +53,19 @@ jobs:
         run: |
           git diff --exit-code -- docs/configuration.md \
             || { echo "::error::docs/configuration.md is stale - run 'just gen-config-docs' and commit the result"; exit 1; }
+
+
+      - name: emit native evidence for docs.config-drift
+        uses: ./.github/actions/ci-native-part
+        with:
+          id: docs.config-drift.config-docs.source
+
+  native-evidence:
+    name: native-evidence
+    if: always()
+    needs: [config-docs]
+    uses: ./.github/workflows/ci-native-evidence.yml
+    with:
+      workflow: .github/workflows/config-docs.yml
+      needs_json: ${{ toJSON(needs) }}
+      posture: ${{ (github.event_name == 'pull_request' || github.event_name == 'merge_group') && 'merge' || (github.ref == 'refs/heads/main' && 'main') || 'merge' }}

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -124,3 +124,24 @@ jobs:
             cover-chdb.out
             cover-merged.out
           retention-days: 30
+
+
+      - name: emit native evidence for quality.coverage-enrollment
+        uses: ./.github/actions/ci-native-part
+        with:
+          id: quality.coverage-enrollment.coverage.source
+
+      - name: emit native evidence for quality.coverage-measured
+        uses: ./.github/actions/ci-native-part
+        with:
+          id: quality.coverage-measured.coverage.source
+
+  native-evidence:
+    name: native-evidence
+    if: always()
+    needs: [coverage]
+    uses: ./.github/workflows/ci-native-evidence.yml
+    with:
+      workflow: .github/workflows/coverage.yml
+      needs_json: ${{ toJSON(needs) }}
+      posture: ${{ (github.event_name == 'pull_request' || github.event_name == 'merge_group') && 'merge' || (github.ref == 'refs/heads/main' && 'main') || 'merge' }}

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -41,10 +41,10 @@ permissions:
   contents: read
 
 concurrency:
-  # A newer measured run may replace only push/schedule work on main. PR,
-  # queue, dispatch, and maintenance evidence is unique and never cancelled.
-  group: ${{ github.workflow }}-${{ ((github.event_name == 'push' || github.event_name == 'schedule') && github.ref == 'refs/heads/main') && 'latest-main' || github.run_id }}
-  cancel-in-progress: ${{ (github.event_name == 'push' || github.event_name == 'schedule') && github.ref == 'refs/heads/main' }}
+  # Main pushes and matching cron schedules replace only their own modes. PR,
+  # queue, dispatch, and maintenance evidence stays unique and uncancelled.
+  group: ${{ github.workflow }}-${{ (github.event_name == 'push' && github.ref == 'refs/heads/main') && 'latest-main-push' || (github.event_name == 'schedule' && github.ref == 'refs/heads/main' && github.event.schedule != '') && format('latest-main-schedule-{0}', github.event.schedule) || github.run_id }}
+  cancel-in-progress: ${{ (github.event_name == 'push' && github.ref == 'refs/heads/main') || (github.event_name == 'schedule' && github.ref == 'refs/heads/main' && github.event.schedule != '') }}
 
 jobs:
   coverage:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -888,6 +888,14 @@ jobs:
   # child check, and re-gating it here would undo the de-gate on purpose. It is
   # `cancelled` and `skipped` that this job exists to make impossible to ignore.
   # Not a branch-protection context, so it reports without blocking merges.
+
+      - name: checkout native evidence controller
+        uses: actions/checkout@v7
+
+      - name: emit native evidence for e2e.compose-smoke
+        uses: ./.github/actions/ci-native-part
+        with:
+          id: e2e.compose-smoke.compose-smoke.source
   crawl-terminal:
     name: crawl-terminal
     needs: [compose-smoke-scope, compose-smoke-setup, compose-smoke-shard-info]
@@ -950,6 +958,11 @@ jobs:
   #                       shard, and a RELEASE-required check (release.yml's
   #                       preflight reads it by name). The clean roll-up + the
   #                       coverage-discipline guard mirror compose-smoke.
+
+      - name: emit native evidence for e2e.compose-crawl
+        uses: ./.github/actions/ci-native-part
+        with:
+          id: e2e.compose-crawl.crawl-terminal.source
   dashboard-setup:
     name: dashboard-setup
     # push + nightly + manual dispatch always; pull_request ONLY when the head
@@ -1446,6 +1459,11 @@ jobs:
           CRAWL_SHARD_RESULT: ${{ needs.dashboard-shard-info.result }}
           SWEEP_DEPTH: full
 
+
+      - name: emit native evidence for e2e.dashboard-crawl
+        uses: ./.github/actions/ci-native-part
+        with:
+          id: e2e.dashboard-crawl.dashboard-crawl-terminal.source
   dashboard-crawl-merge:
     name: dashboard-crawl-merge
     needs: [dashboard-setup, dashboard-shard-info]
@@ -1538,6 +1556,14 @@ jobs:
            fi
            echo "all dashboard shards passed."
 
+
+      - name: checkout native evidence controller
+        uses: actions/checkout@v7
+
+      - name: emit native evidence for e2e.dashboard
+        uses: ./.github/actions/ci-native-part
+        with:
+          id: e2e.dashboard.dashboard.source
   startup-bench:
     # Startup-speed benchmark: spawn cerberus and assert <2 s to /healthz.
     # Informational only — not a required gate. The fast-feedback PR loop
@@ -1657,6 +1683,11 @@ jobs:
         if: always()
         run: docker rm -f clickhouse || true
 
+
+      - name: emit native evidence for e2e.startup-bench
+        uses: ./.github/actions/ci-native-part
+        with:
+          id: e2e.startup-bench.startup-bench.source
   chaos:
     name: chaos
     # Live-stack chaos-engineering lane: fault-inject against the running
@@ -1881,6 +1912,12 @@ jobs:
   # pull_request, so NOT a branch-protection check). Own concurrency + timeout;
   # deliberately NOT added to the dashboard/compose disjoint-cover shard
   # matrices — it is a separate single-cluster lane, not a Playwright shard.
+
+      - name: emit native evidence for e2e.chaos
+        uses: ./.github/actions/ci-native-part
+        with:
+          id: e2e.chaos.chaos.source
+          seed: ci-${{ github.run_id }}-${{ github.run_attempt }}
   bwc-minio:
     name: bwc-minio
     if: github.event_name == 'push' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
@@ -2013,3 +2050,19 @@ jobs:
       - name: Tear down
         if: always()
         run: just e2e-bwc-down
+
+
+      - name: emit native evidence for e2e.bwc-minio
+        uses: ./.github/actions/ci-native-part
+        with:
+          id: e2e.bwc-minio.bwc-minio.source
+
+  native-evidence:
+    name: native-evidence
+    if: always()
+    needs: [compose-smoke, crawl-terminal, dashboard-crawl-terminal, dashboard, startup-bench, chaos, bwc-minio]
+    uses: ./.github/workflows/ci-native-evidence.yml
+    with:
+      workflow: .github/workflows/e2e.yml
+      needs_json: ${{ toJSON(needs) }}
+      posture: ${{ (github.event_name == 'pull_request' || github.event_name == 'merge_group') && 'merge' || (github.ref == 'refs/heads/main' && 'main') || 'merge' }}

--- a/.github/workflows/forbid-deferral.yml
+++ b/.github/workflows/forbid-deferral.yml
@@ -114,3 +114,19 @@ jobs:
         run: node .github/scripts/rejection-parity-divergence-liveness.mjs
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+
+      - name: emit native evidence for governance.forbid-deferral
+        uses: ./.github/actions/ci-native-part
+        with:
+          id: governance.forbid-deferral.forbid-deferral.source
+
+  native-evidence:
+    name: native-evidence
+    if: always()
+    needs: [forbid-deferral]
+    uses: ./.github/workflows/ci-native-evidence.yml
+    with:
+      workflow: .github/workflows/forbid-deferral.yml
+      needs_json: ${{ toJSON(needs) }}
+      posture: ${{ (github.event_name == 'pull_request' || github.event_name == 'merge_group') && 'merge' || (github.ref == 'refs/heads/main' && 'main') || 'merge' }}

--- a/.github/workflows/merge-fence.yml
+++ b/.github/workflows/merge-fence.yml
@@ -1,0 +1,63 @@
+name: merge-fence
+
+on:
+  pull_request:
+  merge_group:
+
+permissions:
+  actions: read
+  contents: read
+
+concurrency:
+  group: merge-fence-${{ github.run_id }}
+  cancel-in-progress: false
+
+jobs:
+  merge-fence:
+    name: merge-fence
+    runs-on: ubuntu-latest
+    timeout-minutes: 22
+    steps:
+      - name: checkout the exact projected trunk
+        uses: actions/checkout@v7
+        with:
+          ref: ${{ github.sha }}
+          fetch-depth: 0
+          clean: true
+
+      - name: create evidence workspace
+        run: mkdir -p build/ci-lane-fence
+
+      - id: select
+        name: select the fail-closed merge fence
+        env:
+          CI_LANE_BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.merge_group.base_sha }}
+          CI_LANE_HEAD_SHA: ${{ github.sha }}
+          CI_LANE_SELECTION_OUTPUT: build/ci-lane-fence/selection.json
+        run: node .github/scripts/ci-lane-selection.mjs
+
+      - name: publish the immutable selection manifest
+        uses: actions/upload-artifact@v7
+        with:
+          name: merge-fence-selection-${{ github.run_id }}-${{ github.run_attempt }}
+          path: build/ci-lane-fence/selection.json
+          if-no-files-found: error
+          retention-days: 14
+
+      - id: collect
+        name: collect lane-native shadow evidence
+        env:
+          CI_LANE_SELECTION: build/ci-lane-fence/selection.json
+          CI_LANE_SHADOW_OUTPUT: build/ci-lane-fence/observation.json
+          CI_LANE_SHADOW_TIMEOUT_SECONDS: '1200'
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: node .github/scripts/ci-lane-shadow-collector.mjs
+
+      - name: publish the shadow observation
+        if: always() && steps.select.outcome == 'success'
+        uses: actions/upload-artifact@v7
+        with:
+          name: merge-fence-shadow-${{ github.run_id }}-${{ github.run_attempt }}
+          path: build/ci-lane-fence/observation.json
+          if-no-files-found: error
+          retention-days: 30

--- a/.github/workflows/migration-e2e.yml
+++ b/.github/workflows/migration-e2e.yml
@@ -84,11 +84,11 @@ permissions:
   packages: read
 
 concurrency:
-  # Only replaceable source-tree push/schedule work on main shares a group.
-  # Artifact workflow calls, dispatches, and maintenance qualification use a
-  # unique run-id group and can neither queue behind nor cancel source work.
-  group: ${{ github.workflow }}-${{ ((github.event_name == 'push' || github.event_name == 'schedule') && github.ref == 'refs/heads/main') && 'latest-main' || github.run_id }}
-  cancel-in-progress: ${{ (github.event_name == 'push' || github.event_name == 'schedule') && github.ref == 'refs/heads/main' }}
+  # Main pushes and matching cron schedules replace only their own modes.
+  # Artifact calls, dispatches, and maintenance qualification use a unique
+  # run-id group and can neither queue behind nor cancel source work.
+  group: ${{ github.workflow }}-${{ (github.event_name == 'push' && github.ref == 'refs/heads/main') && 'latest-main-push' || (github.event_name == 'schedule' && github.ref == 'refs/heads/main' && github.event.schedule != '') && format('latest-main-schedule-{0}', github.event.schedule) || github.run_id }}
+  cancel-in-progress: ${{ (github.event_name == 'push' && github.ref == 'refs/heads/main') || (github.event_name == 'schedule' && github.ref == 'refs/heads/main' && github.event.schedule != '') }}
 
 jobs:
   # Enumerate the Gherkin features, hold them to the 26-story anchor, and

--- a/.github/workflows/migration-e2e.yml
+++ b/.github/workflows/migration-e2e.yml
@@ -141,6 +141,18 @@ jobs:
   # Tier-0 offline slice: godog over committed fixtures, no Docker, no
   # reference backend. A fixed job like its two siblings — it drives one
   # tag filter on one runner, so there is nothing to fan out over.
+
+      - name: emit native evidence for migration.e2e
+        if: ${{ inputs.cerberus_image != '' }}
+        uses: ./.github/actions/ci-native-part
+        with:
+          id: migration.e2e.migration-setup.artifact
+
+      - name: emit native evidence for migration.e2e
+        if: ${{ inputs.cerberus_image == '' }}
+        uses: ./.github/actions/ci-native-part
+        with:
+          id: migration.e2e.migration-setup.source
   migration-tier0:
     name: migration-tier0
     needs: migration-setup
@@ -228,6 +240,18 @@ jobs:
   # migration.yml workflow) so the dual-backend compose stack is brought up
   # and torn down exactly once per run instead of running two separate
   # Docker-backed lanes side by side.
+
+      - name: emit native evidence for migration.e2e
+        if: ${{ inputs.cerberus_image != '' }}
+        uses: ./.github/actions/ci-native-part
+        with:
+          id: migration.e2e.migration-tier0.artifact
+
+      - name: emit native evidence for migration.e2e
+        if: ${{ inputs.cerberus_image == '' }}
+        uses: ./.github/actions/ci-native-part
+        with:
+          id: migration.e2e.migration-tier0.source
   migration-tier1:
     name: migration-tier1
     needs: migration-setup
@@ -401,6 +425,18 @@ jobs:
   # section 8 builds firing parity on top of proven query parity, and every
   # @tier2 scenario reads the same cerberus/ClickHouse pair Tier 1 proves. A
   # green tier-2 over a red tier-1 would be a verdict about nothing.
+
+      - name: emit native evidence for migration.e2e
+        if: ${{ inputs.cerberus_image != '' }}
+        uses: ./.github/actions/ci-native-part
+        with:
+          id: migration.e2e.migration-tier1.artifact
+
+      - name: emit native evidence for migration.e2e
+        if: ${{ inputs.cerberus_image == '' }}
+        uses: ./.github/actions/ci-native-part
+        with:
+          id: migration.e2e.migration-tier1.source
   migration-tier2:
     name: migration-tier2
     needs: [migration-setup, migration-tier1]
@@ -541,6 +577,18 @@ jobs:
   # — it holds every tier emit SELECTED to `success`, and separately refuses a
   # tier that ran without being selected — and this repo keeps that in a .mjs
   # so it is testable (see .github/scripts/README.md).
+
+      - name: emit native evidence for migration.e2e
+        if: ${{ inputs.cerberus_image != '' }}
+        uses: ./.github/actions/ci-native-part
+        with:
+          id: migration.e2e.migration-tier2.artifact
+
+      - name: emit native evidence for migration.e2e
+        if: ${{ inputs.cerberus_image == '' }}
+        uses: ./.github/actions/ci-native-part
+        with:
+          id: migration.e2e.migration-tier2.source
   migration-aggregate:
     name: migration-e2e
     needs: [migration-setup, migration-tier0, migration-tier1, migration-tier2]
@@ -601,3 +649,13 @@ jobs:
           RESULT_TIER0: ${{ needs.migration-tier0.result }}
           RESULT_TIER1: ${{ needs.migration-tier1.result }}
           RESULT_TIER2: ${{ needs.migration-tier2.result }}
+
+  native-evidence:
+    name: native-evidence
+    if: always()
+    needs: [migration-setup, migration-tier0, migration-tier1, migration-tier2]
+    uses: ./.github/workflows/ci-native-evidence.yml
+    with:
+      workflow: .github/workflows/migration-e2e.yml
+      needs_json: ${{ toJSON(needs) }}
+      posture: ${{ github.event_name == 'workflow_call' && 'release' || (github.event_name == 'pull_request' || github.event_name == 'merge_group') && 'merge' || (github.ref == 'refs/heads/main' && 'main') || 'merge' }}

--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -242,3 +242,22 @@ jobs:
             exit 1
           fi
           echo "all selected mutation phases green."
+
+
+      - name: checkout native evidence controller
+        uses: actions/checkout@v7
+
+      - name: emit native evidence for quality.mutation
+        uses: ./.github/actions/ci-native-part
+        with:
+          id: quality.mutation.mutation.source
+
+  native-evidence:
+    name: native-evidence
+    if: always()
+    needs: [select, mutate, mutation]
+    uses: ./.github/workflows/ci-native-evidence.yml
+    with:
+      workflow: .github/workflows/mutation.yml
+      needs_json: ${{ toJSON(needs) }}
+      posture: ${{ (github.event_name == 'pull_request' || github.event_name == 'merge_group') && 'merge' || (github.ref == 'refs/heads/main' && 'main') || 'merge' }}

--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -4,8 +4,10 @@ name: mutation
 # pull_request as a real gate for the publish-on-merge release flow.
 #
 # On an ordinary PR the `mutate` matrix runs the legs whose SCOPE the PR
-# changed, and only those: a PR editing internal/chplan runs phase1, a PR
-# editing only docs runs no leg at all. The selection is computed by
+# changed, and production-only edits use gremlins' merge-base changed-line
+# filter inside those legs. Test/harness changes, unknown projections, and a
+# changed-line run with zero executable mutants fall back to the full selected
+# phase. A PR editing only docs runs no leg at all. Selection is computed by
 # .github/scripts/mutation-matrix.mjs from the PR's own diff against its merge
 # base; the phase table it selects from lives in mutation-phases.mjs. Push /
 # schedule / dispatch and `release/*` PRs sweep the FULL matrix, so no leg's
@@ -162,19 +164,19 @@ jobs:
       # Do NOT "fix" a recurrence by excluding whichever file the log names:
       # that relocates the file's runaway mutants into whichever leg still owns
       # it, and burns real mutation coverage. The ceiling is the fix.
+      # mutation-run.mjs owns the changed-line/full decision and validates that
+      # the final report executed at least one mutant. Keeping the zero-mutant
+      # fallback out of shell prevents a missing or malformed JSON field from
+      # being read as a cheap successful phase.
       - name: gremlins unleash
         env:
           MUTANT_TIMEOUT_MAX: 15s
-        run: |
-          args=(unleash --output gremlins.json --on-shutdown-status=not-run --timeout-max "$MUTANT_TIMEOUT_MAX")
-          if [ "${{ matrix.workers }}" != "0" ]; then
-            args+=(--workers "${{ matrix.workers }}")
-          fi
-          if [ -n "${{ matrix.exclude_files }}" ]; then
-            args+=(--exclude-files "${{ matrix.exclude_files }}")
-          fi
-          args+=("${{ matrix.scope }}")
-          gremlins "${args[@]}"
+          SCOPE: ${{ matrix.scope }}
+          WORKERS: ${{ matrix.workers }}
+          EXCLUDE_FILES: ${{ matrix.exclude_files }}
+          DIFF_REF: ${{ matrix.diff_ref }}
+          REPORT: gremlins.json
+        run: node .github/scripts/mutation-run.mjs
       # gremlins v0.6.0 exits 0 even when --threshold-efficacy is
       # violated, so the gate is done in gremlins-threshold.mjs against
       # the parsed report JSON (measured < threshold -> fail).

--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -45,10 +45,10 @@ permissions:
   contents: read
 
 concurrency:
-  # Full main/nightly sweeps are replaceable. Scoped PR/queue evidence and
-  # manual or release-head qualification always receive unique run-id groups.
-  group: ${{ github.workflow }}-${{ ((github.event_name == 'push' || github.event_name == 'schedule') && github.ref == 'refs/heads/main') && 'latest-main' || github.run_id }}
-  cancel-in-progress: ${{ (github.event_name == 'push' || github.event_name == 'schedule') && github.ref == 'refs/heads/main' }}
+  # Main pushes and the exact nightly cron replace only their own modes. Scoped
+  # PR/queue and manual or release-head qualification remain unique.
+  group: ${{ github.workflow }}-${{ (github.event_name == 'push' && github.ref == 'refs/heads/main') && 'latest-main-push' || (github.event_name == 'schedule' && github.ref == 'refs/heads/main' && github.event.schedule != '') && format('latest-main-schedule-{0}', github.event.schedule) || github.run_id }}
+  cancel-in-progress: ${{ (github.event_name == 'push' && github.ref == 'refs/heads/main') || (github.event_name == 'schedule' && github.ref == 'refs/heads/main' && github.event.schedule != '') }}
 
 jobs:
   # select — decide WHICH phases this event runs, and emit them as the `mutate`

--- a/.github/workflows/perf-benchmark.yml
+++ b/.github/workflows/perf-benchmark.yml
@@ -56,8 +56,8 @@ permissions:
 concurrency:
   # The weekly run is replaceable only while bound to main. PR measurements and
   # explicit manual qualification always receive a unique run-id group.
-  group: ${{ github.workflow }}-${{ ((github.event_name == 'push' || github.event_name == 'schedule') && github.ref == 'refs/heads/main') && 'latest-main' || github.run_id }}
-  cancel-in-progress: ${{ (github.event_name == 'push' || github.event_name == 'schedule') && github.ref == 'refs/heads/main' }}
+  group: ${{ github.workflow }}-${{ (github.event_name == 'push' && github.ref == 'refs/heads/main') && 'latest-main-push' || (github.event_name == 'schedule' && github.ref == 'refs/heads/main' && github.event.schedule != '') && format('latest-main-schedule-{0}', github.event.schedule) || github.run_id }}
+  cancel-in-progress: ${{ (github.event_name == 'push' && github.ref == 'refs/heads/main') || (github.event_name == 'schedule' && github.ref == 'refs/heads/main' && github.event.schedule != '') }}
 
 jobs:
   bench:

--- a/.github/workflows/perf-profile.yml
+++ b/.github/workflows/perf-profile.yml
@@ -111,3 +111,19 @@ jobs:
           path: perf-profile.json
           if-no-files-found: warn
           retention-days: 30
+
+
+      - name: emit native evidence for performance.profile
+        uses: ./.github/actions/ci-native-part
+        with:
+          id: performance.profile.profile.source
+
+  native-evidence:
+    name: native-evidence
+    if: always()
+    needs: [profile]
+    uses: ./.github/workflows/ci-native-evidence.yml
+    with:
+      workflow: .github/workflows/perf-profile.yml
+      needs_json: ${{ toJSON(needs) }}
+      posture: ${{ (github.event_name == 'pull_request' || github.event_name == 'merge_group') && 'merge' || (github.ref == 'refs/heads/main' && 'main') || 'merge' }}

--- a/.github/workflows/perf-profile.yml
+++ b/.github/workflows/perf-profile.yml
@@ -56,10 +56,10 @@ permissions:
   contents: read
 
 concurrency:
-  # A newer deep run may replace only push/schedule work on main. Release-head
-  # PRs, dispatches, and maintenance pushes remain distinct qualification.
-  group: ${{ github.workflow }}-${{ ((github.event_name == 'push' || github.event_name == 'schedule') && github.ref == 'refs/heads/main') && 'latest-main' || github.run_id }}
-  cancel-in-progress: ${{ (github.event_name == 'push' || github.event_name == 'schedule') && github.ref == 'refs/heads/main' }}
+  # Main pushes and matching cron schedules replace only their own modes.
+  # Release-head PRs, dispatches, and maintenance pushes remain distinct.
+  group: ${{ github.workflow }}-${{ (github.event_name == 'push' && github.ref == 'refs/heads/main') && 'latest-main-push' || (github.event_name == 'schedule' && github.ref == 'refs/heads/main' && github.event.schedule != '') && format('latest-main-schedule-{0}', github.event.schedule) || github.run_id }}
+  cancel-in-progress: ${{ (github.event_name == 'push' && github.ref == 'refs/heads/main') || (github.event_name == 'schedule' && github.ref == 'refs/heads/main' && github.event.schedule != '') }}
 
 jobs:
   profile:

--- a/.github/workflows/post-merge-drift.yml
+++ b/.github/workflows/post-merge-drift.yml
@@ -77,3 +77,19 @@ jobs:
           POST_MERGE_BEFORE: ${{ github.event.before }}
           POST_MERGE_AFTER: ${{ github.sha }}
         run: node .github/scripts/post-merge-golden-drift.mjs
+
+
+      - name: emit native evidence for quality.post-merge-drift
+        uses: ./.github/actions/ci-native-part
+        with:
+          id: quality.post-merge-drift.drift.source
+
+  native-evidence:
+    name: native-evidence
+    if: always()
+    needs: [drift]
+    uses: ./.github/workflows/ci-native-evidence.yml
+    with:
+      workflow: .github/workflows/post-merge-drift.yml
+      needs_json: ${{ toJSON(needs) }}
+      posture: main

--- a/.github/workflows/pr-hygiene.yml
+++ b/.github/workflows/pr-hygiene.yml
@@ -60,3 +60,19 @@ jobs:
           PR_BODY: ${{ github.event.pull_request.body }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: node .github/scripts/pr-body-check.mjs
+
+
+      - name: emit native evidence for governance.pr-body
+        uses: ./.github/actions/ci-native-part
+        with:
+          id: governance.pr-body.pr-body.source
+
+  native-evidence:
+    name: native-evidence
+    if: always()
+    needs: [pr-body]
+    uses: ./.github/workflows/ci-native-evidence.yml
+    with:
+      workflow: .github/workflows/pr-hygiene.yml
+      needs_json: ${{ toJSON(needs) }}
+      posture: ${{ (github.event_name == 'pull_request' || github.event_name == 'merge_group') && 'merge' || (github.ref == 'refs/heads/main' && 'main') || 'merge' }}

--- a/.github/workflows/property.yml
+++ b/.github/workflows/property.yml
@@ -79,10 +79,10 @@ permissions:
   contents: read
 
 concurrency:
-  # A newer deep run may replace only push/schedule work on main. PR, queue,
-  # dispatch, and maintenance evidence is unique and never cancelled.
-  group: ${{ github.workflow }}-${{ ((github.event_name == 'push' || github.event_name == 'schedule') && github.ref == 'refs/heads/main') && 'latest-main' || github.run_id }}
-  cancel-in-progress: ${{ (github.event_name == 'push' || github.event_name == 'schedule') && github.ref == 'refs/heads/main' }}
+  # Main pushes and matching cron schedules replace only their own modes. PR,
+  # queue, dispatch, and maintenance evidence stays unique and uncancelled.
+  group: ${{ github.workflow }}-${{ (github.event_name == 'push' && github.ref == 'refs/heads/main') && 'latest-main-push' || (github.event_name == 'schedule' && github.ref == 'refs/heads/main' && github.event.schedule != '') && format('latest-main-schedule-{0}', github.event.schedule) || github.run_id }}
+  cancel-in-progress: ${{ (github.event_name == 'push' && github.ref == 'refs/heads/main') || (github.event_name == 'schedule' && github.ref == 'refs/heads/main' && github.event.schedule != '') }}
 
 jobs:
   property:

--- a/.github/workflows/property.yml
+++ b/.github/workflows/property.yml
@@ -165,3 +165,20 @@ jobs:
             test/property/testdata/rapid/**
           if-no-files-found: ignore
           retention-days: 30
+
+
+      - name: emit native evidence for quality.property
+        uses: ./.github/actions/ci-native-part
+        with:
+          id: quality.property.property.source
+          seed: ci-${{ github.run_id }}-${{ github.run_attempt }}
+
+  native-evidence:
+    name: native-evidence
+    if: always()
+    needs: [property]
+    uses: ./.github/workflows/ci-native-evidence.yml
+    with:
+      workflow: .github/workflows/property.yml
+      needs_json: ${{ toJSON(needs) }}
+      posture: ${{ (github.event_name == 'pull_request' || github.event_name == 'merge_group') && 'merge' || (github.ref == 'refs/heads/main' && 'main') || 'merge' }}

--- a/.github/workflows/quickstart.yml
+++ b/.github/workflows/quickstart.yml
@@ -47,6 +47,11 @@ jobs:
           CHECKOUT_SHA: ${{ github.sha }}
         run: node .github/scripts/quickstart-canary.mjs
 
+
+      - name: emit native evidence for e2e.quickstart
+        uses: ./.github/actions/ci-native-part
+        with:
+          id: e2e.quickstart.select.source
   run:
     name: quickstart-run
     needs: select
@@ -106,6 +111,11 @@ jobs:
         if: always()
         run: docker compose down -v --remove-orphans
 
+
+      - name: emit native evidence for e2e.quickstart
+        uses: ./.github/actions/ci-native-part
+        with:
+          id: e2e.quickstart.run.source
   quickstart:
     name: quickstart
     needs: [select, run]
@@ -126,3 +136,13 @@ jobs:
           SELECTED: ${{ needs.select.outputs.selected }}
           RUN_RESULT: ${{ needs.run.result }}
         run: node .github/scripts/quickstart-canary.mjs
+
+  native-evidence:
+    name: native-evidence
+    if: always()
+    needs: [select, run]
+    uses: ./.github/workflows/ci-native-evidence.yml
+    with:
+      workflow: .github/workflows/quickstart.yml
+      needs_json: ${{ toJSON(needs) }}
+      posture: ${{ (github.event_name == 'pull_request' || github.event_name == 'merge_group') && 'merge' || (github.ref == 'refs/heads/main' && 'main') || 'merge' }}

--- a/.github/workflows/schema-integration.yml
+++ b/.github/workflows/schema-integration.yml
@@ -43,10 +43,10 @@ permissions:
   packages: read
 
 concurrency:
-  # A newer deep run may replace only push/schedule work on main. PR and manual
-  # qualification runs receive a unique run-id group and cannot be cancelled.
-  group: ${{ github.workflow }}-${{ ((github.event_name == 'push' || github.event_name == 'schedule') && github.ref == 'refs/heads/main') && 'latest-main' || github.run_id }}
-  cancel-in-progress: ${{ (github.event_name == 'push' || github.event_name == 'schedule') && github.ref == 'refs/heads/main' }}
+  # Main pushes and matching cron schedules replace only their own modes. PR
+  # and manual qualification remain unique and cannot be cancelled.
+  group: ${{ github.workflow }}-${{ (github.event_name == 'push' && github.ref == 'refs/heads/main') && 'latest-main-push' || (github.event_name == 'schedule' && github.ref == 'refs/heads/main' && github.event.schedule != '') && format('latest-main-schedule-{0}', github.event.schedule) || github.run_id }}
+  cancel-in-progress: ${{ (github.event_name == 'push' && github.ref == 'refs/heads/main') || (github.event_name == 'schedule' && github.ref == 'refs/heads/main' && github.event.schedule != '') }}
 
 jobs:
   # Docs-only PRs short-circuit the Docker work. See ci.yml / chdb.yml for the

--- a/.github/workflows/schema-integration.yml
+++ b/.github/workflows/schema-integration.yml
@@ -147,3 +147,19 @@ jobs:
 
       - name: Run schema/ddl integration tests (real ClickHouse)
         run: just schema-ddl-test
+
+
+      - name: emit native evidence for schema.ddl
+        uses: ./.github/actions/ci-native-part
+        with:
+          id: schema.ddl.schema-ddl.source
+
+  native-evidence:
+    name: native-evidence
+    if: always()
+    needs: [changes, schema-ddl]
+    uses: ./.github/workflows/ci-native-evidence.yml
+    with:
+      workflow: .github/workflows/schema-integration.yml
+      needs_json: ${{ toJSON(needs) }}
+      posture: ${{ (github.event_name == 'pull_request' || github.event_name == 'merge_group') && 'merge' || (github.ref == 'refs/heads/main' && 'main') || 'merge' }}

--- a/.github/workflows/strict-scan.yml
+++ b/.github/workflows/strict-scan.yml
@@ -49,10 +49,10 @@ permissions:
   packages: read
 
 concurrency:
-  # A newer deep run may replace only push/schedule work on main. PR, queue,
-  # dispatch, and maintenance evidence is unique and never cancelled.
-  group: ${{ github.workflow }}-${{ ((github.event_name == 'push' || github.event_name == 'schedule') && github.ref == 'refs/heads/main') && 'latest-main' || github.run_id }}
-  cancel-in-progress: ${{ (github.event_name == 'push' || github.event_name == 'schedule') && github.ref == 'refs/heads/main' }}
+  # Main pushes and matching cron schedules replace only their own modes. PR,
+  # queue, dispatch, and maintenance evidence stays unique and uncancelled.
+  group: ${{ github.workflow }}-${{ (github.event_name == 'push' && github.ref == 'refs/heads/main') && 'latest-main-push' || (github.event_name == 'schedule' && github.ref == 'refs/heads/main' && github.event.schedule != '') && format('latest-main-schedule-{0}', github.event.schedule) || github.run_id }}
+  cancel-in-progress: ${{ (github.event_name == 'push' && github.ref == 'refs/heads/main') || (github.event_name == 'schedule' && github.ref == 'refs/heads/main' && github.event.schedule != '') }}
 
 jobs:
   # Docs-only PRs short-circuit the Docker work. See ci.yml / chdb.yml for the

--- a/.github/workflows/strict-scan.yml
+++ b/.github/workflows/strict-scan.yml
@@ -276,3 +276,19 @@ jobs:
       # internal/chclient/conn_teardown_integration_test.go.
       - name: Run chclient connection-teardown differential (real ClickHouse)
         run: just chclient-integration
+
+
+      - name: emit native evidence for chdb.strict-scan
+        uses: ./.github/actions/ci-native-part
+        with:
+          id: chdb.strict-scan.strict-scan.source
+
+  native-evidence:
+    name: native-evidence
+    if: always()
+    needs: [changes, strict-scan]
+    uses: ./.github/workflows/ci-native-evidence.yml
+    with:
+      workflow: .github/workflows/strict-scan.yml
+      needs_json: ${{ toJSON(needs) }}
+      posture: ${{ (github.event_name == 'pull_request' || github.event_name == 'merge_group') && 'merge' || (github.ref == 'refs/heads/main' && 'main') || 'merge' }}

--- a/docs/test-strategy.md
+++ b/docs/test-strategy.md
@@ -890,9 +890,12 @@ expands it into the `mutate` job's matrix. The rolled-up `mutation`
 context is a required check on `main`.
 
 On a pull request the lane runs the phases whose scope that PR changed,
-and only those: a PR editing `internal/chplan` runs `phase1`, a PR
-editing only docs runs no leg and the aggregator passes through
-honestly. Push-to-main, the nightly, a manual dispatch, a `release/*`
+and only those. A production-only edit uses gremlins' native merge-base
+changed-line filter inside its selected phase. A test, fixture, harness,
+delete-only, binary, malformed, or uncomputable projection runs the selected
+phase in full; an incremental report with zero executable mutants also reruns
+the full phase before it may report. A PR editing only docs runs no leg and the
+aggregator passes through honestly. Push-to-main, the nightly, a manual dispatch, a `release/*`
 PR, and any PR touching mutation-specific harness material all sweep the FULL
 matrix, so no phase's floor is ever load-bearing on some PR happening to touch
 its package. Registry edits are projected to the mutation lane's semantic

--- a/docs/test-strategy.md
+++ b/docs/test-strategy.md
@@ -90,10 +90,12 @@ not wired as a branch-protection gate (typically because it needs the chDB
 substrate, a Docker stack, or a soak streak before promotion).
 
 Replaceable deep-test workflows coalesce only a `push` or `schedule` run whose
-ref is exactly `refs/heads/main`; both event types share that workflow's
-`latest-main` group. Every pull request, merge group, manual dispatch,
-reusable-workflow call, maintenance branch, tag, release event, and unknown
-event/ref pair receives a unique run-id group. The exhaustive E2E workflow,
+ref is exactly `refs/heads/main`. Main pushes share one `latest-main-push`
+group; scheduled runs key their group by the exact cron expression. A routine
+push therefore cannot erase nightly-only coverage, and two differently scoped
+schedules cannot erase each other. Every pull request, merge group, manual
+dispatch, reusable-workflow call, maintenance branch, tag, release event, and
+unknown event/ref pair receives a unique run-id group. The exhaustive E2E workflow,
 the required `quickstart`, post-merge generated-artifact drift, core gates,
 publication, stateful mirroring, and monitors are explicit negative controls.
 `.github/scripts/main-coalescing.mjs` binds the enrolled workflow expressions

--- a/test/regression/merge_queue_test.go
+++ b/test/regression/merge_queue_test.go
@@ -127,7 +127,7 @@ var queueSafeCancelInProgress = regexp.MustCompile(
 	`^\$\{\{\s*github\.event_name\s*==\s*'([a-z_]+)'\s*\}\}$`,
 )
 
-const latestMainCancelInProgress = "${{ (github.event_name == 'push' || github.event_name == 'schedule') && github.ref == 'refs/heads/main' }}"
+const replaceableMainModeCancelInProgress = "${{ (github.event_name == 'push' && github.ref == 'refs/heads/main') || (github.event_name == 'schedule' && github.ref == 'refs/heads/main' && github.event.schedule != '') }}"
 
 // cancelInProgressIsQueueSafe reports whether a `cancel-in-progress:` value can
 // never be true on a `merge_group` run.
@@ -135,7 +135,7 @@ func cancelInProgressIsQueueSafe(value string) bool {
 	if value == "false" {
 		return true
 	}
-	if value == latestMainCancelInProgress {
+	if value == replaceableMainModeCancelInProgress {
 		return true
 	}
 	m := queueSafeCancelInProgress.FindStringSubmatch(value)

--- a/test/regression/mutation_timeout_max_test.go
+++ b/test/regression/mutation_timeout_max_test.go
@@ -9,12 +9,19 @@ import (
 // mutationWorkflowPath drives the gremlins mutation-testing lane.
 const mutationWorkflowPath = "../../.github/workflows/mutation.yml"
 
+// mutationRunnerPath owns the non-trivial argv and changed-line fallback that
+// the workflow invokes.
+const mutationRunnerPath = "../../.github/scripts/mutation-run.mjs"
+
 // timeoutMaxFlag bounds a single mutant's test run regardless of how slow the
 // mutated package's own tests are.
 const timeoutMaxFlag = "--timeout-max"
 
-// unleashArgvPrefix opens the argv array the workflow hands to gremlins.
-const unleashArgvPrefix = "args=(unleash"
+const (
+	mutationRunnerInvocation = "run: node .github/scripts/mutation-run.mjs"
+	timeoutMaxArg            = "'--timeout-max',"
+	timeoutMaxValue          = "required('MUTANT_TIMEOUT_MAX'),"
+)
 
 // gremlinsForkTagPrefix is the fork tag family that supports timeoutMaxFlag.
 // The flag landed in the fork; a tag from before it makes gremlins reject the
@@ -52,27 +59,20 @@ func TestMutationLaneCapsPerMutantTimeout(t *testing.T) {
 		t.Fatalf("read %s: %v", mutationWorkflowPath, err)
 	}
 	body := string(workflow)
-
-	// Match the argv line itself, not the file: the flag is also named in the
-	// comments that explain it, and prose must not be able to satisfy the pin.
-	var argvLine string
-	for _, line := range strings.Split(body, "\n") {
-		if strings.Contains(line, unleashArgvPrefix) {
-			argvLine = line
-
-			break
-		}
+	if !strings.Contains(body, mutationRunnerInvocation) {
+		t.Errorf("%s does not invoke the pinned mutation runner %q", mutationWorkflowPath, mutationRunnerInvocation)
 	}
-	switch {
-	case argvLine == "":
-		t.Errorf("%s has no %q line; the pin below cannot see how gremlins is invoked. If the "+
-			"invocation was restructured, re-point this test at the new shape rather than deleting it.",
-			mutationWorkflowPath, unleashArgvPrefix)
-	case !strings.Contains(argvLine, timeoutMaxFlag):
-		t.Errorf("%s does not pass %s to gremlins unleash. Without an absolute ceiling a mutant that "+
-			"inverts a scanner loop-advance runs until the runner is out of memory, and the job dies "+
-			"with no verdict — which reads as flake, not as a missing bound.",
-			mutationWorkflowPath, timeoutMaxFlag)
+
+	runner, err := os.ReadFile(mutationRunnerPath)
+	if err != nil {
+		t.Fatalf("read %s: %v", mutationRunnerPath, err)
+	}
+	runnerBody := string(runner)
+	if !strings.Contains(runnerBody, timeoutMaxArg) || !strings.Contains(runnerBody, timeoutMaxValue) {
+		t.Errorf("%s does not pass %s from MUTANT_TIMEOUT_MAX to gremlins unleash. Without an absolute "+
+			"ceiling a mutant that inverts a scanner loop-advance runs until the runner is out of memory, "+
+			"and the job dies with no verdict — which reads as flake, not as a missing bound.",
+			mutationRunnerPath, timeoutMaxFlag)
 	}
 
 	if !strings.Contains(body, gremlinsForkTagPrefix) {


### PR DESCRIPTION
## Summary

- add a shadow `merge-fence` that recomputes impact selection from trusted changed paths
- require invocation-bound, lane-native evidence with exact SHA, tree, run, attempt, artifact, and nonce correlation
- publish closed native evidence bundles from every enrolled producer workflow
- scope pull-request mutation work to changed production lines with a fail-closed full fallback
- isolate replaceable main and scheduled deep runs without cancelling queue or qualification work
- preserve `quickstart` as its own direct required check and as independent native evidence

## Safety properties

- rollout remains shadow-only; this PR does not change branch protection
- unknown paths, selector errors, absent evidence, duplicate evidence, non-success conclusions, and hollow reports fail closed
- producer identity and evidence digests are independently revalidated by the collector
- projected-trunk and pull-request identities are handled explicitly rather than conflated

## Validation

- 151 focused Node tests across the lane contract, selector, collector, native evidence, concurrency, and mutation suites
- targeted structural Go regressions for merge-queue posting, cancellation safety, and mutation timeout wiring
- `git diff --check`

Part of #2230