### PR TITLE
fix(ci): isolate main pushes from scheduled deep tests

### DIFF
--- a/.github/scripts/main-coalescing.mjs
+++ b/.github/scripts/main-coalescing.mjs
@@ -3,10 +3,11 @@
 // GitHub evaluates workflow concurrency before any job can run, so the policy
 // has two halves: the exact expressions enrolled workflows carry and this
 // executable model that proves which event/ref pairs those expressions may
-// cancel. Only a push or scheduled run bound to refs/heads/main is replaceable.
-// Pull requests, merge groups, manual qualification, reusable-workflow calls,
-// maintenance branches, tags, releases, and unknown inputs receive a unique
-// run group and can never cancel one another.
+// cancel. Main pushes and equivalent scheduled runs are replaceable within
+// separate mode groups, so a routine push can never erase deeper nightly
+// evidence. Pull requests, merge groups, manual qualification,
+// reusable-workflow calls, maintenance branches, tags, releases, and unknown
+// inputs receive a unique run group and can never cancel one another.
 //
 // MODE=check (default) reads CI_LANE_REGISTRY (default .github/ci-lanes.json),
 // checks every enrolled workflow, and rejects registry/workflow drift.
@@ -27,13 +28,13 @@ export const MAIN_REF = 'refs/heads/main';
 export const LATEST_MAIN_SUFFIX = 'latest-main';
 
 export const GROUP_EXPRESSION =
-  "${{ github.workflow }}-${{ ((github.event_name == 'push' || github.event_name == 'schedule') && github.ref == 'refs/heads/main') && 'latest-main' || github.run_id }}";
+  "${{ github.workflow }}-${{ (github.event_name == 'push' && github.ref == 'refs/heads/main') && 'latest-main-push' || (github.event_name == 'schedule' && github.ref == 'refs/heads/main' && github.event.schedule != '') && format('latest-main-schedule-{0}', github.event.schedule) || github.run_id }}";
 export const CANCEL_EXPRESSION =
-  "${{ (github.event_name == 'push' || github.event_name == 'schedule') && github.ref == 'refs/heads/main' }}";
+  "${{ (github.event_name == 'push' && github.ref == 'refs/heads/main') || (github.event_name == 'schedule' && github.ref == 'refs/heads/main' && github.event.schedule != '') }}";
 
 // These workflows contain replaceable deep-main, soak, or scheduled test work.
-// A schedule and a push on main intentionally share one group per workflow, so
-// the newest run is the only one allowed to consume the deep-test budget.
+// Main pushes share one group per workflow. Scheduled runs share a group only
+// with the same workflow and exact cron expression.
 export const COALESCED_WORKFLOWS = Object.freeze([
   '.github/workflows/agpl-oracle.yml',
   '.github/workflows/chdb.yml',
@@ -79,17 +80,29 @@ export const QUICKSTART_CANCEL_EXPRESSION =
 export function coalescingDecision({
   eventName,
   ref,
+  schedule,
   workflow = 'workflow',
   runId = 'run',
 } = {}) {
   const event = String(eventName ?? '');
   const boundRef = String(ref ?? '');
-  const replaceable =
-    (event === 'push' || event === 'schedule') && boundRef === MAIN_REF;
+  const cron = String(schedule ?? '').trim();
+  const mainPush = event === 'push' && boundRef === MAIN_REF;
+  const equivalentSchedule =
+    event === 'schedule' && boundRef === MAIN_REF && cron !== '';
+  const groupKey = mainPush
+    ? `${LATEST_MAIN_SUFFIX}-push`
+    : equivalentSchedule
+      ? `${LATEST_MAIN_SUFFIX}-schedule-${cron}`
+      : runId;
   return Object.freeze({
-    cancelInProgress: replaceable,
-    group: `${workflow}-${replaceable ? LATEST_MAIN_SUFFIX : runId}`,
-    reason: replaceable ? 'latest_main' : 'distinct_run',
+    cancelInProgress: mainPush || equivalentSchedule,
+    group: `${workflow}-${groupKey}`,
+    reason: mainPush
+      ? 'latest_main_push'
+      : equivalentSchedule
+        ? 'equivalent_schedule'
+        : 'distinct_run',
   });
 }
 
@@ -177,12 +190,12 @@ export function validateEnrolledWorkflow(workflow, workflowText) {
   }
   if (concurrency.group !== GROUP_EXPRESSION) {
     problems.push(
-      `${workflow}: concurrency group is ${JSON.stringify(concurrency.group)}, want the canonical latest-main/unique-run expression`,
+      `${workflow}: concurrency group is ${JSON.stringify(concurrency.group)}, want the canonical main-push/equivalent-schedule/unique-run expression`,
     );
   }
   if (concurrency.cancelInProgress !== CANCEL_EXPRESSION) {
     problems.push(
-      `${workflow}: cancel-in-progress is ${JSON.stringify(concurrency.cancelInProgress)}, want the canonical main-push/schedule-only expression`,
+      `${workflow}: cancel-in-progress is ${JSON.stringify(concurrency.cancelInProgress)}, want the canonical main-push/equivalent-schedule-only expression`,
     );
   }
 

--- a/.github/scripts/main-coalescing.test.mjs
+++ b/.github/scripts/main-coalescing.test.mjs
@@ -17,22 +17,50 @@ import {
   validateQuickstartWorkflow,
 } from './main-coalescing.mjs';
 
-const decision = (eventName, ref, runId = '17') =>
-  coalescingDecision({ eventName, ref, workflow: 'deep', runId });
+const decision = (eventName, ref, runId = '17', schedule = '') =>
+  coalescingDecision({
+    eventName,
+    ref,
+    workflow: 'deep',
+    runId,
+    schedule,
+  });
 
-test('only main push and main schedule share the replaceable group', () => {
-  for (const eventName of ['push', 'schedule']) {
-    assert.deepEqual(decision(eventName, MAIN_REF), {
-      cancelInProgress: true,
-      group: 'deep-latest-main',
-      reason: 'latest_main',
-    });
-  }
-
+test('main pushes replace only main pushes', () => {
+  assert.deepEqual(decision('push', MAIN_REF), {
+    cancelInProgress: true,
+    group: 'deep-latest-main-push',
+    reason: 'latest_main_push',
+  });
   assert.equal(
     decision('push', MAIN_REF, 'old').group,
-    decision('schedule', MAIN_REF, 'new').group,
+    decision('push', MAIN_REF, 'new').group,
   );
+});
+
+test('scheduled runs replace only the same scheduled mode', () => {
+  const nightly = '17 3 * * *';
+  assert.deepEqual(decision('schedule', MAIN_REF, '17', nightly), {
+    cancelInProgress: true,
+    group: `deep-latest-main-schedule-${nightly}`,
+    reason: 'equivalent_schedule',
+  });
+  assert.equal(
+    decision('schedule', MAIN_REF, 'old', nightly).group,
+    decision('schedule', MAIN_REF, 'new', nightly).group,
+  );
+  assert.notEqual(
+    decision('schedule', MAIN_REF, 'old', nightly).group,
+    decision('schedule', MAIN_REF, 'new', '45 4 * * *').group,
+  );
+});
+
+test('a main push cannot cancel nightly-only evidence', () => {
+  const push = decision('push', MAIN_REF, 'push');
+  const nightly = decision('schedule', MAIN_REF, 'nightly', '17 3 * * *');
+  assert.equal(push.cancelInProgress, true);
+  assert.equal(nightly.cancelInProgress, true);
+  assert.notEqual(push.group, nightly.group);
 });
 
 test('PR, queue, qualification, maintenance, release, and unknown events never cancel', () => {
@@ -77,11 +105,19 @@ test('push and schedule fail safe to distinct groups on every non-main ref', () 
       '',
       undefined,
     ]) {
-      const verdict = decision(eventName, ref);
+      const verdict = decision(eventName, ref, '17', '17 3 * * *');
       assert.equal(verdict.cancelInProgress, false, `${eventName} ${ref}`);
       assert.equal(verdict.group, 'deep-17', `${eventName} ${ref}`);
     }
   }
+});
+
+test('a malformed schedule without its declared cron fails safe to a unique group', () => {
+  const first = decision('schedule', MAIN_REF, '101');
+  const second = decision('schedule', MAIN_REF, '102');
+  assert.equal(first.cancelInProgress, false);
+  assert.equal(second.cancelInProgress, false);
+  assert.notEqual(first.group, second.group);
 });
 
 test('structural parser reads only the top-level concurrency mapping', () => {

--- a/.github/workflows/agpl-oracle.yml
+++ b/.github/workflows/agpl-oracle.yml
@@ -83,10 +83,10 @@ permissions:
   contents: read
 
 concurrency:
-  # A newer deep run may replace only push/schedule work on main. Every PR,
-  # queue, dispatch, maintenance, and unknown event gets its own run-id group.
-  group: ${{ github.workflow }}-${{ ((github.event_name == 'push' || github.event_name == 'schedule') && github.ref == 'refs/heads/main') && 'latest-main' || github.run_id }}
-  cancel-in-progress: ${{ (github.event_name == 'push' || github.event_name == 'schedule') && github.ref == 'refs/heads/main' }}
+  # Main pushes replace only older main pushes; matching cron schedules replace
+  # only that scheduled mode. Every other event gets its own run-id group.
+  group: ${{ github.workflow }}-${{ (github.event_name == 'push' && github.ref == 'refs/heads/main') && 'latest-main-push' || (github.event_name == 'schedule' && github.ref == 'refs/heads/main' && github.event.schedule != '') && format('latest-main-schedule-{0}', github.event.schedule) || github.run_id }}
+  cancel-in-progress: ${{ (github.event_name == 'push' && github.ref == 'refs/heads/main') || (github.event_name == 'schedule' && github.ref == 'refs/heads/main' && github.event.schedule != '') }}
 
 jobs:
   # Docs-only short-circuit — see chdb.yml for the full rationale. The

--- a/.github/workflows/chdb.yml
+++ b/.github/workflows/chdb.yml
@@ -75,10 +75,10 @@ permissions:
   contents: read
 
 concurrency:
-  # A newer deep run may replace only push/schedule work on main. Every PR,
-  # queue, dispatch, maintenance, and unknown event gets its own run-id group.
-  group: ${{ github.workflow }}-${{ ((github.event_name == 'push' || github.event_name == 'schedule') && github.ref == 'refs/heads/main') && 'latest-main' || github.run_id }}
-  cancel-in-progress: ${{ (github.event_name == 'push' || github.event_name == 'schedule') && github.ref == 'refs/heads/main' }}
+  # Main pushes replace only older main pushes; matching cron schedules replace
+  # only that scheduled mode. Every other event gets its own run-id group.
+  group: ${{ github.workflow }}-${{ (github.event_name == 'push' && github.ref == 'refs/heads/main') && 'latest-main-push' || (github.event_name == 'schedule' && github.ref == 'refs/heads/main' && github.event.schedule != '') && format('latest-main-schedule-{0}', github.event.schedule) || github.run_id }}
+  cancel-in-progress: ${{ (github.event_name == 'push' && github.ref == 'refs/heads/main') || (github.event_name == 'schedule' && github.ref == 'refs/heads/main' && github.event.schedule != '') }}
 
 jobs:
   # See `.github/workflows/ci.yml` for the rationale + filter convention.

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -49,10 +49,10 @@ permissions:
   security-events: write
 
 concurrency:
-  # A newer deep run may replace only push/schedule work on main. In particular,
-  # PR and merge-group evidence is unique and can never be cancelled here.
-  group: ${{ github.workflow }}-${{ ((github.event_name == 'push' || github.event_name == 'schedule') && github.ref == 'refs/heads/main') && 'latest-main' || github.run_id }}
-  cancel-in-progress: ${{ (github.event_name == 'push' || github.event_name == 'schedule') && github.ref == 'refs/heads/main' }}
+  # Main pushes and matching cron schedules replace only their own modes. PR
+  # and merge-group evidence is unique and can never be cancelled here.
+  group: ${{ github.workflow }}-${{ (github.event_name == 'push' && github.ref == 'refs/heads/main') && 'latest-main-push' || (github.event_name == 'schedule' && github.ref == 'refs/heads/main' && github.event.schedule != '') && format('latest-main-schedule-{0}', github.event.schedule) || github.run_id }}
+  cancel-in-progress: ${{ (github.event_name == 'push' && github.ref == 'refs/heads/main') || (github.event_name == 'schedule' && github.ref == 'refs/heads/main' && github.event.schedule != '') }}
 
 jobs:
   analyze:

--- a/.github/workflows/compatibility.yml
+++ b/.github/workflows/compatibility.yml
@@ -96,10 +96,10 @@ permissions:
   packages: read
 
 concurrency:
-  # A newer deep run may replace only push/schedule work on main. Release-head
-  # PRs, merge groups, dispatches, and maintenance pushes remain distinct.
-  group: ${{ github.workflow }}-${{ ((github.event_name == 'push' || github.event_name == 'schedule') && github.ref == 'refs/heads/main') && 'latest-main' || github.run_id }}
-  cancel-in-progress: ${{ (github.event_name == 'push' || github.event_name == 'schedule') && github.ref == 'refs/heads/main' }}
+  # Main pushes and matching cron schedules replace only their own modes.
+  # Release-head PRs, queue, dispatch, and maintenance remain distinct.
+  group: ${{ github.workflow }}-${{ (github.event_name == 'push' && github.ref == 'refs/heads/main') && 'latest-main-push' || (github.event_name == 'schedule' && github.ref == 'refs/heads/main' && github.event.schedule != '') && format('latest-main-schedule-{0}', github.event.schedule) || github.run_id }}
+  cancel-in-progress: ${{ (github.event_name == 'push' && github.ref == 'refs/heads/main') || (github.event_name == 'schedule' && github.ref == 'refs/heads/main' && github.event.schedule != '') }}
 
 jobs:
   # See `.github/workflows/ci.yml` for the rationale + filter convention.

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -41,10 +41,10 @@ permissions:
   contents: read
 
 concurrency:
-  # A newer measured run may replace only push/schedule work on main. PR,
-  # queue, dispatch, and maintenance evidence is unique and never cancelled.
-  group: ${{ github.workflow }}-${{ ((github.event_name == 'push' || github.event_name == 'schedule') && github.ref == 'refs/heads/main') && 'latest-main' || github.run_id }}
-  cancel-in-progress: ${{ (github.event_name == 'push' || github.event_name == 'schedule') && github.ref == 'refs/heads/main' }}
+  # Main pushes and matching cron schedules replace only their own modes. PR,
+  # queue, dispatch, and maintenance evidence stays unique and uncancelled.
+  group: ${{ github.workflow }}-${{ (github.event_name == 'push' && github.ref == 'refs/heads/main') && 'latest-main-push' || (github.event_name == 'schedule' && github.ref == 'refs/heads/main' && github.event.schedule != '') && format('latest-main-schedule-{0}', github.event.schedule) || github.run_id }}
+  cancel-in-progress: ${{ (github.event_name == 'push' && github.ref == 'refs/heads/main') || (github.event_name == 'schedule' && github.ref == 'refs/heads/main' && github.event.schedule != '') }}
 
 jobs:
   coverage:

--- a/.github/workflows/migration-e2e.yml
+++ b/.github/workflows/migration-e2e.yml
@@ -84,11 +84,11 @@ permissions:
   packages: read
 
 concurrency:
-  # Only replaceable source-tree push/schedule work on main shares a group.
-  # Artifact workflow calls, dispatches, and maintenance qualification use a
-  # unique run-id group and can neither queue behind nor cancel source work.
-  group: ${{ github.workflow }}-${{ ((github.event_name == 'push' || github.event_name == 'schedule') && github.ref == 'refs/heads/main') && 'latest-main' || github.run_id }}
-  cancel-in-progress: ${{ (github.event_name == 'push' || github.event_name == 'schedule') && github.ref == 'refs/heads/main' }}
+  # Main pushes and matching cron schedules replace only their own modes.
+  # Artifact calls, dispatches, and maintenance qualification use a unique
+  # run-id group and can neither queue behind nor cancel source work.
+  group: ${{ github.workflow }}-${{ (github.event_name == 'push' && github.ref == 'refs/heads/main') && 'latest-main-push' || (github.event_name == 'schedule' && github.ref == 'refs/heads/main' && github.event.schedule != '') && format('latest-main-schedule-{0}', github.event.schedule) || github.run_id }}
+  cancel-in-progress: ${{ (github.event_name == 'push' && github.ref == 'refs/heads/main') || (github.event_name == 'schedule' && github.ref == 'refs/heads/main' && github.event.schedule != '') }}
 
 jobs:
   # Enumerate the Gherkin features, hold them to the 26-story anchor, and

--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -45,10 +45,10 @@ permissions:
   contents: read
 
 concurrency:
-  # Full main/nightly sweeps are replaceable. Scoped PR/queue evidence and
-  # manual or release-head qualification always receive unique run-id groups.
-  group: ${{ github.workflow }}-${{ ((github.event_name == 'push' || github.event_name == 'schedule') && github.ref == 'refs/heads/main') && 'latest-main' || github.run_id }}
-  cancel-in-progress: ${{ (github.event_name == 'push' || github.event_name == 'schedule') && github.ref == 'refs/heads/main' }}
+  # Main pushes and the exact nightly cron replace only their own modes. Scoped
+  # PR/queue and manual or release-head qualification remain unique.
+  group: ${{ github.workflow }}-${{ (github.event_name == 'push' && github.ref == 'refs/heads/main') && 'latest-main-push' || (github.event_name == 'schedule' && github.ref == 'refs/heads/main' && github.event.schedule != '') && format('latest-main-schedule-{0}', github.event.schedule) || github.run_id }}
+  cancel-in-progress: ${{ (github.event_name == 'push' && github.ref == 'refs/heads/main') || (github.event_name == 'schedule' && github.ref == 'refs/heads/main' && github.event.schedule != '') }}
 
 jobs:
   # select — decide WHICH phases this event runs, and emit them as the `mutate`

--- a/.github/workflows/perf-benchmark.yml
+++ b/.github/workflows/perf-benchmark.yml
@@ -56,8 +56,8 @@ permissions:
 concurrency:
   # The weekly run is replaceable only while bound to main. PR measurements and
   # explicit manual qualification always receive a unique run-id group.
-  group: ${{ github.workflow }}-${{ ((github.event_name == 'push' || github.event_name == 'schedule') && github.ref == 'refs/heads/main') && 'latest-main' || github.run_id }}
-  cancel-in-progress: ${{ (github.event_name == 'push' || github.event_name == 'schedule') && github.ref == 'refs/heads/main' }}
+  group: ${{ github.workflow }}-${{ (github.event_name == 'push' && github.ref == 'refs/heads/main') && 'latest-main-push' || (github.event_name == 'schedule' && github.ref == 'refs/heads/main' && github.event.schedule != '') && format('latest-main-schedule-{0}', github.event.schedule) || github.run_id }}
+  cancel-in-progress: ${{ (github.event_name == 'push' && github.ref == 'refs/heads/main') || (github.event_name == 'schedule' && github.ref == 'refs/heads/main' && github.event.schedule != '') }}
 
 jobs:
   bench:

--- a/.github/workflows/perf-profile.yml
+++ b/.github/workflows/perf-profile.yml
@@ -56,10 +56,10 @@ permissions:
   contents: read
 
 concurrency:
-  # A newer deep run may replace only push/schedule work on main. Release-head
-  # PRs, dispatches, and maintenance pushes remain distinct qualification.
-  group: ${{ github.workflow }}-${{ ((github.event_name == 'push' || github.event_name == 'schedule') && github.ref == 'refs/heads/main') && 'latest-main' || github.run_id }}
-  cancel-in-progress: ${{ (github.event_name == 'push' || github.event_name == 'schedule') && github.ref == 'refs/heads/main' }}
+  # Main pushes and matching cron schedules replace only their own modes.
+  # Release-head PRs, dispatches, and maintenance pushes remain distinct.
+  group: ${{ github.workflow }}-${{ (github.event_name == 'push' && github.ref == 'refs/heads/main') && 'latest-main-push' || (github.event_name == 'schedule' && github.ref == 'refs/heads/main' && github.event.schedule != '') && format('latest-main-schedule-{0}', github.event.schedule) || github.run_id }}
+  cancel-in-progress: ${{ (github.event_name == 'push' && github.ref == 'refs/heads/main') || (github.event_name == 'schedule' && github.ref == 'refs/heads/main' && github.event.schedule != '') }}
 
 jobs:
   profile:

--- a/.github/workflows/property.yml
+++ b/.github/workflows/property.yml
@@ -79,10 +79,10 @@ permissions:
   contents: read
 
 concurrency:
-  # A newer deep run may replace only push/schedule work on main. PR, queue,
-  # dispatch, and maintenance evidence is unique and never cancelled.
-  group: ${{ github.workflow }}-${{ ((github.event_name == 'push' || github.event_name == 'schedule') && github.ref == 'refs/heads/main') && 'latest-main' || github.run_id }}
-  cancel-in-progress: ${{ (github.event_name == 'push' || github.event_name == 'schedule') && github.ref == 'refs/heads/main' }}
+  # Main pushes and matching cron schedules replace only their own modes. PR,
+  # queue, dispatch, and maintenance evidence stays unique and uncancelled.
+  group: ${{ github.workflow }}-${{ (github.event_name == 'push' && github.ref == 'refs/heads/main') && 'latest-main-push' || (github.event_name == 'schedule' && github.ref == 'refs/heads/main' && github.event.schedule != '') && format('latest-main-schedule-{0}', github.event.schedule) || github.run_id }}
+  cancel-in-progress: ${{ (github.event_name == 'push' && github.ref == 'refs/heads/main') || (github.event_name == 'schedule' && github.ref == 'refs/heads/main' && github.event.schedule != '') }}
 
 jobs:
   property:

--- a/.github/workflows/schema-integration.yml
+++ b/.github/workflows/schema-integration.yml
@@ -43,10 +43,10 @@ permissions:
   packages: read
 
 concurrency:
-  # A newer deep run may replace only push/schedule work on main. PR and manual
-  # qualification runs receive a unique run-id group and cannot be cancelled.
-  group: ${{ github.workflow }}-${{ ((github.event_name == 'push' || github.event_name == 'schedule') && github.ref == 'refs/heads/main') && 'latest-main' || github.run_id }}
-  cancel-in-progress: ${{ (github.event_name == 'push' || github.event_name == 'schedule') && github.ref == 'refs/heads/main' }}
+  # Main pushes and matching cron schedules replace only their own modes. PR
+  # and manual qualification remain unique and cannot be cancelled.
+  group: ${{ github.workflow }}-${{ (github.event_name == 'push' && github.ref == 'refs/heads/main') && 'latest-main-push' || (github.event_name == 'schedule' && github.ref == 'refs/heads/main' && github.event.schedule != '') && format('latest-main-schedule-{0}', github.event.schedule) || github.run_id }}
+  cancel-in-progress: ${{ (github.event_name == 'push' && github.ref == 'refs/heads/main') || (github.event_name == 'schedule' && github.ref == 'refs/heads/main' && github.event.schedule != '') }}
 
 jobs:
   # Docs-only PRs short-circuit the Docker work. See ci.yml / chdb.yml for the

--- a/.github/workflows/strict-scan.yml
+++ b/.github/workflows/strict-scan.yml
@@ -49,10 +49,10 @@ permissions:
   packages: read
 
 concurrency:
-  # A newer deep run may replace only push/schedule work on main. PR, queue,
-  # dispatch, and maintenance evidence is unique and never cancelled.
-  group: ${{ github.workflow }}-${{ ((github.event_name == 'push' || github.event_name == 'schedule') && github.ref == 'refs/heads/main') && 'latest-main' || github.run_id }}
-  cancel-in-progress: ${{ (github.event_name == 'push' || github.event_name == 'schedule') && github.ref == 'refs/heads/main' }}
+  # Main pushes and matching cron schedules replace only their own modes. PR,
+  # queue, dispatch, and maintenance evidence stays unique and uncancelled.
+  group: ${{ github.workflow }}-${{ (github.event_name == 'push' && github.ref == 'refs/heads/main') && 'latest-main-push' || (github.event_name == 'schedule' && github.ref == 'refs/heads/main' && github.event.schedule != '') && format('latest-main-schedule-{0}', github.event.schedule) || github.run_id }}
+  cancel-in-progress: ${{ (github.event_name == 'push' && github.ref == 'refs/heads/main') || (github.event_name == 'schedule' && github.ref == 'refs/heads/main' && github.event.schedule != '') }}
 
 jobs:
   # Docs-only PRs short-circuit the Docker work. See ci.yml / chdb.yml for the

--- a/docs/test-strategy.md
+++ b/docs/test-strategy.md
@@ -90,10 +90,12 @@ not wired as a branch-protection gate (typically because it needs the chDB
 substrate, a Docker stack, or a soak streak before promotion).
 
 Replaceable deep-test workflows coalesce only a `push` or `schedule` run whose
-ref is exactly `refs/heads/main`; both event types share that workflow's
-`latest-main` group. Every pull request, merge group, manual dispatch,
-reusable-workflow call, maintenance branch, tag, release event, and unknown
-event/ref pair receives a unique run-id group. The exhaustive E2E workflow,
+ref is exactly `refs/heads/main`. Main pushes share one `latest-main-push`
+group; scheduled runs key their group by the exact cron expression. A routine
+push therefore cannot erase nightly-only coverage, and two differently scoped
+schedules cannot erase each other. Every pull request, merge group, manual
+dispatch, reusable-workflow call, maintenance branch, tag, release event, and
+unknown event/ref pair receives a unique run-id group. The exhaustive E2E workflow,
 the required `quickstart`, post-merge generated-artifact drift, core gates,
 publication, stateful mirroring, and monitors are explicit negative controls.
 `.github/scripts/main-coalescing.mjs` binds the enrolled workflow expressions

--- a/test/regression/merge_queue_test.go
+++ b/test/regression/merge_queue_test.go
@@ -127,7 +127,7 @@ var queueSafeCancelInProgress = regexp.MustCompile(
 	`^\$\{\{\s*github\.event_name\s*==\s*'([a-z_]+)'\s*\}\}$`,
 )
 
-const latestMainCancelInProgress = "${{ (github.event_name == 'push' || github.event_name == 'schedule') && github.ref == 'refs/heads/main' }}"
+const replaceableMainModeCancelInProgress = "${{ (github.event_name == 'push' && github.ref == 'refs/heads/main') || (github.event_name == 'schedule' && github.ref == 'refs/heads/main' && github.event.schedule != '') }}"
 
 // cancelInProgressIsQueueSafe reports whether a `cancel-in-progress:` value can
 // never be true on a `merge_group` run.
@@ -135,7 +135,7 @@ func cancelInProgressIsQueueSafe(value string) bool {
 	if value == "false" {
 		return true
 	}
-	if value == latestMainCancelInProgress {
+	if value == replaceableMainModeCancelInProgress {
 		return true
 	}
 	m := queueSafeCancelInProgress.FindStringSubmatch(value)


### PR DESCRIPTION
## Summary

- Splits the shared `latest-main` concurrency group into two disjoint modes: `latest-main-push` for `push` events on `refs/heads/main`, and `latest-main-schedule-<cron>` (keyed by the exact `github.event.schedule` cron string) for scheduled runs on `refs/heads/main`.
- Previously a routine push to main and a scheduled nightly/weekly deep-test run on the same workflow shared one `latest-main` group with `cancel-in-progress: true`, so a push could cancel an in-progress nightly deep-test run mid-flight (and vice versa), silently erasing evidence the schedule exists to produce.
- Applies the same group/cancel-in-progress expression update across all 12 coalesced deep-test workflows (agpl-oracle, chdb, codeql, compatibility, coverage, migration-e2e, mutation, perf-benchmark, perf-profile, property, schema-integration, strict-scan), plus the shared model in `.github/scripts/main-coalescing.mjs`, its test suite, `docs/test-strategy.md`, and the queue-safety regression in `test/regression/merge_queue_test.go`.
- A schedule event with an unexpectedly empty `github.event.schedule` fails safe to a unique run-id group (never coalesced) rather than accidentally sharing a group.

Part of #2230.

## Test plan

- [x] `node --test .github/scripts/main-coalescing.test.mjs` — all 12 cases pass, including the registry/workflow drift check (`the checked-in registry and every enrolled workflow match the policy`).
- [x] `go test -run '^TestMergeGroupRunsAreNeverCancelledByConcurrency$|^TestEveryRequiredContextPostsOnTheMergeGroup$' ./test/regression/...` — pass.
- [x] `actionlint` over all 12 changed workflow files — clean.
- [x] `markdownlint-cli2 docs/test-strategy.md` — clean.
- [x] `gofmt -l` / `gofumpt -l` on the changed Go test file — clean.
- [ ] CI will run the full required-check matrix on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)