### PR TITLE
perf(ci): scope PR mutation testing to changed lines

### DIFF
--- a/.github/scripts/README.md
+++ b/.github/scripts/README.md
@@ -844,6 +844,20 @@ contract failure.
     or a bad `MODE`.
   - Tests: `node --test .github/scripts/mutation-matrix.test.mjs` (run by the
     `forbid-skip` job).
+- **`mutation-run.mjs`** — `mutation.yml`, the `gremlins unleash` step. Owns the
+  changed-line/full decision and the argv gremlins actually receives, so a
+  missing or malformed report field can never read as a cheap successful
+  phase. A non-empty `DIFF_REF` first invokes gremlins' native merge-base
+  `--diff` filter; if that report executed zero mutants (a comment-only or
+  otherwise mutation-free edit), it deletes the report and reruns the phase in
+  full rather than letting a hollow incremental run report green.
+  - Env: `SCOPE`, `REPORT`, `MUTANT_TIMEOUT_MAX` (required); `WORKERS`,
+    `EXCLUDE_FILES`, `DIFF_REF` (optional).
+  - Exit: `0` when the final report executed at least one mutant; `1` on a bad
+    env value, a pre-existing report at `REPORT`, a gremlins invocation
+    failure, or zero mutants surviving the full fallback.
+  - Tests: `node --test .github/scripts/mutation-run.test.mjs` (run by the
+    `forbid-skip` job).
 - **`release-version-gate.mjs`** — `release.yml`, the `gate` job (app side).
   The publish-on-merge pipeline ships when a validated `release/*` PR is MERGED
   to main (not on a raw pushed tag — that trigger is retired). On the resulting

--- a/.github/scripts/mutation-matrix.mjs
+++ b/.github/scripts/mutation-matrix.mjs
@@ -55,7 +55,7 @@ import { execFileSync } from 'node:child_process';
 import { readFileSync, readdirSync, statSync } from 'node:fs';
 import { join } from 'node:path';
 
-import { error, log, notice, setOutput } from './lib/gh.mjs';
+import { error, git, log, notice, setOutput } from './lib/gh.mjs';
 import { changedPaths, matchesAny, normalise, runsFullLane, underPrefix } from './lib/scope-gate.mjs';
 import { HARNESS_PATHS, MUTATION_PRODUCTION_GLOBS, PHASES } from './mutation-phases.mjs';
 
@@ -454,6 +454,62 @@ export function selectPhases({
   };
 }
 
+// changedLineProjection returns the exact merge-base ref and per-path added-line
+// counts used by gremlins' native `--diff` filter. A malformed or unavailable
+// projection is null: callers must run the selected phase in full.
+export function changedLineProjection({ baseSha, headSha, runGit = git }) {
+  const base = String(baseSha ?? '').trim();
+  const head = String(headSha ?? '').trim();
+  if (!/^[0-9a-f]{7,64}$/i.test(base) || !/^[0-9a-f]{7,64}$/i.test(head)) return null;
+
+  const mergeBase = runGit(['merge-base', base, head]);
+  const ref = String(mergeBase?.stdout ?? '').trim();
+  if (mergeBase?.status !== 0 || !/^[0-9a-f]{40,64}$/i.test(ref)) return null;
+
+  // `--no-renames` makes the NUL-delimited numstat grammar one fixed record
+  // shape. A rename with content becomes delete + add, which safely treats the
+  // new file as entirely changed rather than under-selecting its mutants.
+  const diff = runGit(['diff', '--numstat', '-z', '--no-renames', ref, head]);
+  if (diff?.status !== 0) return null;
+  const additions = new Map();
+  for (const record of String(diff.stdout ?? '').split('\0')) {
+    if (record === '') continue;
+    const fields = record.split('\t');
+    if (fields.length !== 3 || fields[2] === '') return null;
+    const [added, deleted, path] = fields;
+    if ((added !== '-' && !/^[0-9]+$/.test(added)) || (deleted !== '-' && !/^[0-9]+$/.test(deleted))) {
+      return null;
+    }
+    additions.set(normalise(path), added === '-' ? null : Number(added));
+  }
+  return { ref, additions };
+}
+
+function mutableProductionGo(path) {
+  return path.endsWith('.go') && !path.endsWith('_test.go');
+}
+
+// addChangedLineRefs chooses incremental mutation independently per phase. A
+// phase is incremental only when every changed path that selected it is a
+// production Go file with at least one added line. Test, fixture, binary,
+// harness, delete-only, and unknown changes deliberately keep the full phase:
+// each can change the efficacy of mutants outside the edited lines.
+export function addChangedLineRefs({ phases, changed, projection }) {
+  return phases.map((phase) => {
+    if (!(changed instanceof Set) || projection === null) return { ...phase, diff_ref: '' };
+    const claimed = [...changed].filter((path) => phaseClaims(phase, path));
+    const incremental =
+      claimed.length > 0 &&
+      claimed.every(
+        (path) =>
+          mutableProductionGo(path) &&
+          Number.isSafeInteger(projection.additions.get(normalise(path))) &&
+          projection.additions.get(normalise(path)) > 0,
+      );
+    return { ...phase, diff_ref: incremental ? projection.ref : '' };
+  });
+}
+
 // ---------------------------------------------------------------------------
 // driver
 // ---------------------------------------------------------------------------
@@ -526,8 +582,19 @@ function main() {
   }
   if (gaps.length > 0) process.exit(1);
 
+  const projection =
+    changed === null
+      ? null
+      : changedLineProjection({
+          baseSha: process.env.BASE_SHA,
+          headSha: process.env.HEAD_SHA,
+        });
+  const matrixPhases = addChangedLineRefs({ phases, changed, projection });
+  const incrementalCount = matrixPhases.filter((phase) => phase.diff_ref !== '').length;
+
   notice(
-    `mutation-matrix: running ${phases.length}/${PHASES.length} phases — ${reason}` +
+    `mutation-matrix: running ${phases.length}/${PHASES.length} phases — ${reason}; ` +
+      `${incrementalCount} changed-line, ${matrixPhases.length - incrementalCount} full` +
       (phases.length > 0 ? ` (${phases.map((p) => p.phase).join(', ')})` : ''),
   );
 
@@ -537,7 +604,7 @@ function main() {
   // a job-level `if:` cannot introspect a matrix: without it, a SKIPPED `mutate`
   // is indistinguishable to the aggregator from a selection that was legitimately
   // empty — which is precisely the ambiguity this lane is being fixed to remove.
-  setOutput('matrix', JSON.stringify({ include: phases }));
+  setOutput('matrix', JSON.stringify({ include: matrixPhases }));
   setOutput('has_phases', String(phases.length > 0));
 }
 

--- a/.github/scripts/mutation-matrix.test.mjs
+++ b/.github/scripts/mutation-matrix.test.mjs
@@ -21,6 +21,8 @@ import { readFileSync } from 'node:fs';
 import { test } from 'node:test';
 
 import {
+  addChangedLineRefs,
+  changedLineProjection,
   MUTATION_LANE_ID,
   MUTATION_MIN_EFFICACY,
   MUTATION_REGISTRY_PATH,
@@ -238,7 +240,94 @@ test('an uncomputable diff runs the full matrix rather than nothing', () => {
   assert.match(result.reason, /could not be computed/);
 });
 
+test('changed-line projection is bound to the exact merge base and added-line roster', () => {
+  const base = 'a'.repeat(40);
+  const head = 'b'.repeat(40);
+  const mergeBase = 'c'.repeat(40);
+  const calls = [];
+  const projection = changedLineProjection({
+    baseSha: base,
+    headSha: head,
+    runGit: (args) => {
+      calls.push(args);
+      if (args[0] === 'merge-base') return { status: 0, stdout: `${mergeBase}\n`, stderr: '' };
+      return {
+        status: 0,
+        stdout:
+          [
+            '4\t2\tinternal/chplan/plan.go',
+            '0\t7\tinternal/chsql/deleted.go',
+            '-\t-\tinternal/chsql/blob.go',
+          ].join('\0') + '\0',
+        stderr: '',
+      };
+    },
+  });
+  assert.deepEqual(calls, [
+    ['merge-base', base, head],
+    ['diff', '--numstat', '-z', '--no-renames', mergeBase, head],
+  ]);
+  assert.equal(projection.ref, mergeBase);
+  assert.equal(projection.additions.get('internal/chplan/plan.go'), 4);
+  assert.equal(projection.additions.get('internal/chsql/deleted.go'), 0);
+  assert.equal(projection.additions.get('internal/chsql/blob.go'), null);
+});
+
+test('changed-line projection fails closed on missing refs, git failure, and malformed numstat', () => {
+  assert.equal(changedLineProjection({ baseSha: '', headSha: 'b'.repeat(40) }), null);
+  assert.equal(
+    changedLineProjection({
+      baseSha: 'a'.repeat(40),
+      headSha: 'b'.repeat(40),
+      runGit: () => ({ status: 1, stdout: '', stderr: 'missing' }),
+    }),
+    null,
+  );
+  let call = 0;
+  assert.equal(
+    changedLineProjection({
+      baseSha: 'a'.repeat(40),
+      headSha: 'b'.repeat(40),
+      runGit: () =>
+        call++ === 0
+          ? { status: 0, stdout: `${'c'.repeat(40)}\n`, stderr: '' }
+          : { status: 0, stdout: 'not-numstat\0', stderr: '' },
+    }),
+    null,
+  );
+});
+
+test('only production additions receive changed-line mutation refs', () => {
+  const ref = 'c'.repeat(40);
+  const phase = PHASES.find((candidate) => candidate.phase === 'phase1');
+  const project = (changed, additions) =>
+    addChangedLineRefs({
+      phases: [phase],
+      changed: new Set(changed),
+      projection: { ref, additions: new Map(additions) },
+    })[0].diff_ref;
+
+  assert.equal(project(['internal/chplan/plan.go'], [['internal/chplan/plan.go', 3]]), ref);
+  assert.equal(project(['internal/chplan/plan.go'], [['internal/chplan/plan.go', 0]]), '');
+  assert.equal(project(['internal/chplan/plan_test.go'], [['internal/chplan/plan_test.go', 3]]), '');
+  assert.equal(
+    project(
+      ['internal/chplan/plan.go', 'internal/chplan/plan_test.go'],
+      [
+        ['internal/chplan/plan.go', 3],
+        ['internal/chplan/plan_test.go', 2],
+      ],
+    ),
+    '',
+  );
+  assert.equal(
+    addChangedLineRefs({ phases: [phase], changed: null, projection: null })[0].diff_ref,
+    '',
+  );
+});
+
 test('a change to the lane harness runs the full matrix', () => {
+  assert.equal(HARNESS_PATHS.includes('.github/scripts/mutation-run.mjs'), true);
   for (const path of HARNESS_PATHS) {
     assert.equal(select([path]).phases.length, PHASES.length, path);
   }

--- a/.github/scripts/mutation-phases.mjs
+++ b/.github/scripts/mutation-phases.mjs
@@ -325,6 +325,7 @@ export const HARNESS_PATHS = [
   '.github/workflows/mutation.yml',
   '.github/scripts/mutation-phases.mjs',
   '.github/scripts/mutation-matrix.mjs',
+  '.github/scripts/mutation-run.mjs',
   '.github/scripts/gremlins-threshold.mjs',
   '.github/scripts/lib/scope-gate.mjs',
   '.gremlins.yaml',

--- a/.github/scripts/mutation-run.mjs
+++ b/.github/scripts/mutation-run.mjs
@@ -1,0 +1,85 @@
+// mutation-run.mjs — run one mutation phase with safe changed-line fallback.
+//
+// Required env: SCOPE, REPORT, MUTANT_TIMEOUT_MAX.
+// Optional env: WORKERS, EXCLUDE_FILES, DIFF_REF.
+//
+// A non-empty DIFF_REF first invokes gremlins' native merge-base line filter.
+// If that report contains zero executable mutants, the script deletes it and
+// reruns the phase without --diff. This makes comment-only or otherwise
+// mutation-free edits conservative full checks instead of hollow greens.
+
+import { spawnSync } from 'node:child_process';
+import { existsSync, readFileSync, unlinkSync } from 'node:fs';
+import process from 'node:process';
+
+import { error, notice } from './lib/gh.mjs';
+
+function required(name) {
+  const value = String(process.env[name] ?? '').trim();
+  if (value === '') throw new Error(`${name} is required`);
+  return value;
+}
+
+function reportTotal(path) {
+  let document;
+  try {
+    document = JSON.parse(readFileSync(path, 'utf8'));
+  } catch (cause) {
+    throw new Error(`cannot read gremlins report ${path}: ${cause.message}`);
+  }
+  if (!Number.isSafeInteger(document.mutants_total) || document.mutants_total < 0) {
+    throw new Error(`gremlins report ${path} has invalid mutants_total`);
+  }
+  return document.mutants_total;
+}
+
+function runGremlins({ report, diffRef = '' }) {
+  const args = [
+    'unleash',
+    '--output',
+    report,
+    '--on-shutdown-status=not-run',
+    '--timeout-max',
+    required('MUTANT_TIMEOUT_MAX'),
+  ];
+  const workers = String(process.env.WORKERS ?? '').trim();
+  if (workers !== '' && workers !== '0') {
+    if (!/^[1-9][0-9]*$/.test(workers)) throw new Error(`WORKERS is invalid: ${workers}`);
+    args.push('--workers', workers);
+  }
+  const exclude = String(process.env.EXCLUDE_FILES ?? '').trim();
+  if (exclude !== '') args.push('--exclude-files', exclude);
+  if (diffRef !== '') args.push('--diff', diffRef);
+  args.push(required('SCOPE'));
+
+  const result = spawnSync('gremlins', args, { stdio: 'inherit' });
+  if (result.error) throw new Error(`cannot execute gremlins: ${result.error.message}`);
+  if (result.status !== 0) throw new Error(`gremlins exited ${result.status}`);
+  if (!existsSync(report)) throw new Error(`gremlins produced no report at ${report}`);
+}
+
+function main() {
+  const report = required('REPORT');
+  const diffRef = String(process.env.DIFF_REF ?? '').trim();
+  if (diffRef !== '' && !/^[0-9a-f]{40,64}$/i.test(diffRef)) {
+    throw new Error(`DIFF_REF is invalid: ${diffRef}`);
+  }
+  if (existsSync(report)) throw new Error(`refusing stale gremlins report ${report}`);
+
+  runGremlins({ report, diffRef });
+  if (diffRef !== '' && reportTotal(report) === 0) {
+    notice('changed-line mutation found zero executable mutants; rerunning the full phase');
+    unlinkSync(report);
+    runGremlins({ report });
+  }
+  const total = reportTotal(report);
+  if (total <= 0) throw new Error('mutation phase executed zero mutants after full fallback');
+  notice(`mutation phase executed ${total} mutant(s)${diffRef === '' ? ' in full' : ''}`);
+}
+
+try {
+  main();
+} catch (cause) {
+  error(cause instanceof Error ? cause.message : String(cause));
+  process.exit(1);
+}

--- a/.github/scripts/mutation-run.test.mjs
+++ b/.github/scripts/mutation-run.test.mjs
@@ -1,0 +1,86 @@
+import assert from 'node:assert/strict';
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { test } from 'node:test';
+
+// The runner's process boundary is intentional: it must prove the exact env
+// contract and two-invocation fallback, not a helper that bypasses main().
+import { spawnSync } from 'node:child_process';
+
+function fixture(t, totals) {
+  const root = mkdtempSync(join(tmpdir(), 'mutation-run-'));
+  t.after(() => rmSync(root, { recursive: true, force: true }));
+  const calls = join(root, 'calls.jsonl');
+  const fake = join(root, 'gremlins');
+  writeFileSync(calls, '');
+  writeFileSync(
+    fake,
+    `#!/usr/bin/env node
+const fs = require('node:fs');
+const args = process.argv.slice(2);
+fs.appendFileSync(${JSON.stringify(calls)}, JSON.stringify(args) + '\\n');
+const report = args[args.indexOf('--output') + 1];
+const totals = ${JSON.stringify(totals)};
+const call = fs.readFileSync(${JSON.stringify(calls)}, 'utf8').trim().split('\\n').length - 1;
+fs.writeFileSync(report, JSON.stringify({ mutants_total: totals[call] }));
+`,
+    { mode: 0o755 },
+  );
+  return { root, calls, fake };
+}
+
+function run(root, env = {}) {
+  return spawnSync(process.execPath, ['.github/scripts/mutation-run.mjs'], {
+    cwd: process.cwd(),
+    encoding: 'utf8',
+    env: {
+      ...process.env,
+      PATH: `${root}:${process.env.PATH}`,
+      SCOPE: './internal/chplan',
+      REPORT: join(root, 'gremlins.json'),
+      MUTANT_TIMEOUT_MAX: '15s',
+      WORKERS: '0',
+      EXCLUDE_FILES: '',
+      ...env,
+    },
+  });
+}
+
+test('changed-line execution stays incremental when it executes mutants', (t) => {
+  const { root, calls } = fixture(t, [3]);
+  const result = run(root, { DIFF_REF: 'a'.repeat(40) });
+  assert.equal(result.status, 0, result.stderr);
+  const invocations = readFileSync(calls, 'utf8').trim().split('\n').map(JSON.parse);
+  assert.equal(invocations.length, 1);
+  assert.deepEqual(invocations[0].slice(-3), ['--diff', 'a'.repeat(40), './internal/chplan']);
+});
+
+test('zero changed-line mutants trigger one full fallback', (t) => {
+  const { root, calls } = fixture(t, [0, 7]);
+  const result = run(root, { DIFF_REF: 'a'.repeat(40) });
+  assert.equal(result.status, 0, result.stderr);
+  const invocations = readFileSync(calls, 'utf8').trim().split('\n').map(JSON.parse);
+  assert.equal(invocations.length, 2);
+  assert.equal(invocations[0].includes('--diff'), true);
+  assert.equal(invocations[1].includes('--diff'), false);
+});
+
+test('zero mutants after full fallback fail closed', (t) => {
+  const { root } = fixture(t, [0, 0]);
+  const result = run(root, { DIFF_REF: 'a'.repeat(40) });
+  assert.equal(result.status, 1);
+  assert.match(`${result.stdout}\n${result.stderr}`, /executed zero mutants after full fallback/);
+});
+
+test('invalid diff refs and stale reports fail before gremlins runs', (t) => {
+  const { root, calls } = fixture(t, [3]);
+  let result = run(root, { DIFF_REF: 'main' });
+  assert.equal(result.status, 1);
+  assert.equal(readFileSync(calls, 'utf8'), '');
+
+  writeFileSync(join(root, 'gremlins.json'), '{}');
+  result = run(root, { DIFF_REF: '' });
+  assert.equal(result.status, 1);
+  assert.match(`${result.stdout}\n${result.stderr}`, /refusing stale gremlins report/);
+});

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -820,6 +820,14 @@ jobs:
       - name: Assert the mutation phase selector scopes correctly
         run: node --test .github/scripts/mutation-matrix.test.mjs
 
+      # The runner half of the same lane: the env contract gremlins actually
+      # receives, and the two-invocation changed-line/full fallback. A bug here
+      # is the same class of silent failure as the selector's — a phase that
+      # LOOKS like it ran (exit 0) after actually executing zero mutants, which
+      # is exactly what the zero-mutant fallback exists to prevent.
+      - name: Assert the mutation runner's env contract and fallback
+        run: node --test .github/scripts/mutation-run.test.mjs
+
       # Whether a job that pulls an image logged in first. An anonymous pull is
       # not an error: it succeeds until the shared per-runner-IP quota happens to
       # be spent, and then reads as flake — which is how #1572 fixed the class by

--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -4,8 +4,10 @@ name: mutation
 # pull_request as a real gate for the publish-on-merge release flow.
 #
 # On an ordinary PR the `mutate` matrix runs the legs whose SCOPE the PR
-# changed, and only those: a PR editing internal/chplan runs phase1, a PR
-# editing only docs runs no leg at all. The selection is computed by
+# changed, and production-only edits use gremlins' merge-base changed-line
+# filter inside those legs. Test/harness changes, unknown projections, and a
+# changed-line run with zero executable mutants fall back to the full selected
+# phase. A PR editing only docs runs no leg at all. Selection is computed by
 # .github/scripts/mutation-matrix.mjs from the PR's own diff against its merge
 # base; the phase table it selects from lives in mutation-phases.mjs. Push /
 # schedule / dispatch and `release/*` PRs sweep the FULL matrix, so no leg's
@@ -162,19 +164,19 @@ jobs:
       # Do NOT "fix" a recurrence by excluding whichever file the log names:
       # that relocates the file's runaway mutants into whichever leg still owns
       # it, and burns real mutation coverage. The ceiling is the fix.
+      # mutation-run.mjs owns the changed-line/full decision and validates that
+      # the final report executed at least one mutant. Keeping the zero-mutant
+      # fallback out of shell prevents a missing or malformed JSON field from
+      # being read as a cheap successful phase.
       - name: gremlins unleash
         env:
           MUTANT_TIMEOUT_MAX: 15s
-        run: |
-          args=(unleash --output gremlins.json --on-shutdown-status=not-run --timeout-max "$MUTANT_TIMEOUT_MAX")
-          if [ "${{ matrix.workers }}" != "0" ]; then
-            args+=(--workers "${{ matrix.workers }}")
-          fi
-          if [ -n "${{ matrix.exclude_files }}" ]; then
-            args+=(--exclude-files "${{ matrix.exclude_files }}")
-          fi
-          args+=("${{ matrix.scope }}")
-          gremlins "${args[@]}"
+          SCOPE: ${{ matrix.scope }}
+          WORKERS: ${{ matrix.workers }}
+          EXCLUDE_FILES: ${{ matrix.exclude_files }}
+          DIFF_REF: ${{ matrix.diff_ref }}
+          REPORT: gremlins.json
+        run: node .github/scripts/mutation-run.mjs
       # gremlins v0.6.0 exits 0 even when --threshold-efficacy is
       # violated, so the gate is done in gremlins-threshold.mjs against
       # the parsed report JSON (measured < threshold -> fail).

--- a/docs/test-strategy.md
+++ b/docs/test-strategy.md
@@ -887,9 +887,12 @@ expands it into the `mutate` job's matrix. The rolled-up `mutation`
 context is a required check on `main`.
 
 On a pull request the lane runs the phases whose scope that PR changed,
-and only those: a PR editing `internal/chplan` runs `phase1`, a PR
-editing only docs runs no leg and the aggregator passes through
-honestly. Push-to-main, the nightly, a manual dispatch, a `release/*`
+and only those. A production-only edit uses gremlins' native merge-base
+changed-line filter inside its selected phase. A test, fixture, harness,
+delete-only, binary, malformed, or uncomputable projection runs the selected
+phase in full; an incremental report with zero executable mutants also reruns
+the full phase before it may report. A PR editing only docs runs no leg and the
+aggregator passes through honestly. Push-to-main, the nightly, a manual dispatch, a `release/*`
 PR, and any PR touching mutation-specific harness material all sweep the FULL
 matrix, so no phase's floor is ever load-bearing on some PR happening to touch
 its package. Registry edits are projected to the mutation lane's semantic

--- a/test/regression/mutation_timeout_max_test.go
+++ b/test/regression/mutation_timeout_max_test.go
@@ -9,12 +9,19 @@ import (
 // mutationWorkflowPath drives the gremlins mutation-testing lane.
 const mutationWorkflowPath = "../../.github/workflows/mutation.yml"
 
+// mutationRunnerPath owns the non-trivial argv and changed-line fallback that
+// the workflow invokes.
+const mutationRunnerPath = "../../.github/scripts/mutation-run.mjs"
+
 // timeoutMaxFlag bounds a single mutant's test run regardless of how slow the
 // mutated package's own tests are.
 const timeoutMaxFlag = "--timeout-max"
 
-// unleashArgvPrefix opens the argv array the workflow hands to gremlins.
-const unleashArgvPrefix = "args=(unleash"
+const (
+	mutationRunnerInvocation = "run: node .github/scripts/mutation-run.mjs"
+	timeoutMaxArg            = "'--timeout-max',"
+	timeoutMaxValue          = "required('MUTANT_TIMEOUT_MAX'),"
+)
 
 // gremlinsForkTagPrefix is the fork tag family that supports timeoutMaxFlag.
 // The flag landed in the fork; a tag from before it makes gremlins reject the
@@ -52,27 +59,20 @@ func TestMutationLaneCapsPerMutantTimeout(t *testing.T) {
 		t.Fatalf("read %s: %v", mutationWorkflowPath, err)
 	}
 	body := string(workflow)
-
-	// Match the argv line itself, not the file: the flag is also named in the
-	// comments that explain it, and prose must not be able to satisfy the pin.
-	var argvLine string
-	for _, line := range strings.Split(body, "\n") {
-		if strings.Contains(line, unleashArgvPrefix) {
-			argvLine = line
-
-			break
-		}
+	if !strings.Contains(body, mutationRunnerInvocation) {
+		t.Errorf("%s does not invoke the pinned mutation runner %q", mutationWorkflowPath, mutationRunnerInvocation)
 	}
-	switch {
-	case argvLine == "":
-		t.Errorf("%s has no %q line; the pin below cannot see how gremlins is invoked. If the "+
-			"invocation was restructured, re-point this test at the new shape rather than deleting it.",
-			mutationWorkflowPath, unleashArgvPrefix)
-	case !strings.Contains(argvLine, timeoutMaxFlag):
-		t.Errorf("%s does not pass %s to gremlins unleash. Without an absolute ceiling a mutant that "+
-			"inverts a scanner loop-advance runs until the runner is out of memory, and the job dies "+
-			"with no verdict — which reads as flake, not as a missing bound.",
-			mutationWorkflowPath, timeoutMaxFlag)
+
+	runner, err := os.ReadFile(mutationRunnerPath)
+	if err != nil {
+		t.Fatalf("read %s: %v", mutationRunnerPath, err)
+	}
+	runnerBody := string(runner)
+	if !strings.Contains(runnerBody, timeoutMaxArg) || !strings.Contains(runnerBody, timeoutMaxValue) {
+		t.Errorf("%s does not pass %s from MUTANT_TIMEOUT_MAX to gremlins unleash. Without an absolute "+
+			"ceiling a mutant that inverts a scanner loop-advance runs until the runner is out of memory, "+
+			"and the job dies with no verdict — which reads as flake, not as a missing bound.",
+			mutationRunnerPath, timeoutMaxFlag)
 	}
 
 	if !strings.Contains(body, gremlinsForkTagPrefix) {


### PR DESCRIPTION
## Summary

- Scope the `mutation` lane's per-phase gremlins runs to changed lines: a phase whose selecting diff is entirely production Go additions (no test, fixture, harness, delete-only, or unknown-projection paths) now runs gremlins' native merge-base `--diff` filter instead of the full package.
- Extract the `gremlins unleash` invocation out of inline workflow shell into `.github/scripts/mutation-run.mjs`, which owns the env contract and a safety fallback: if a changed-line run executes zero mutants (e.g. a comment-only edit), it deletes that report and reruns the phase in full rather than letting a hollow incremental run report green.
- Update `test/regression/mutation_timeout_max_test.go` to pin `--timeout-max` against the new runner script instead of the retired inline `args=(unleash ...)` shell line.
- Wire the new `mutation-run.test.mjs` into the `forbid-skip` job in `ci.yml` and document `mutation-run.mjs` in `.github/scripts/README.md`, matching every other script in that directory — the original commit shipped the test file without wiring it into CI, which would have made a regression in the runner's env contract or its zero-mutant fallback pass silently.

## Test plan

- [x] `node --check` on every changed/added `.mjs` file
- [x] `node --test .github/scripts/mutation-matrix.test.mjs` (34/34 pass)
- [x] `node --test .github/scripts/mutation-run.test.mjs` (4/4 pass)
- [x] `go test -run '^TestMutationLaneCapsPerMutantTimeout$' ./test/regression/...`
- [x] `actionlint .github/workflows/mutation.yml .github/workflows/ci.yml`
- [x] `npx markdownlint-cli2 docs/test-strategy.md .github/scripts/README.md`
- [x] `node .github/scripts/doc-refs.mjs` (all cited paths exist)
- [x] `CHECK=all node .github/scripts/forbid-skip.mjs`
- [ ] CI: full `mutation`, `lint`, `test`, and `forbid-skip` gates (this PR's own trigger)

## Notes for reviewers

`lint`, `strict-scan`, the compat lanes, and `e2e`/`compose-smoke` cannot be settled locally per
this repo's standing rule; they'll report on this PR's own CI run. Everything else above was run
narrowed to the changed files before pushing.

Part of #2230
