### PR TITLE
fix(e2e): concentrate the api-service log seed onto one drain cluster

### DIFF
--- a/internal/api/loki/patterns_e2e_seed_volume_internal_test.go
+++ b/internal/api/loki/patterns_e2e_seed_volume_internal_test.go
@@ -1,0 +1,90 @@
+package loki
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/tsouza/cerberus/internal/chclient"
+)
+
+// TestMinePatternsClearsE2ESeedFloor pins the class of regression that
+// broke the "dashboard" e2e gate for 12+ hours after #2205 added the
+// minimumPatternVolume floor (mirroring upstream Loki's minClusterSize):
+// the rolling e2e seed (test/e2e/seed/cmd/seed/main.go's insertLogsSQL)
+// generates otel_logs rows for {service_name="api"} that, once the
+// rolling re-seeder (`just e2e-seed-rolling`, 30 s ticks) has accumulated
+// a realistic handful of ticks, must produce at least one drain cluster
+// whose volume clears minimumPatternVolume — otherwise the
+// /loki/api/v1/patterns e2e assertion
+// (test/e2e/playwright/loki_ux.spec.ts:152, "patterns: the /patterns
+// endpoint extracts drain clusters from log bodies") sees
+// body.data.length == 0 on every run, deterministically, forever: the
+// pre-fix seed split ~14 api rows/tick evenly across 5 body templates and
+// up to 2 severity levels (minePatterns trains one drain.Miner per
+// level), which tops out around 3 lines/tick/cluster and never clears
+// the 30-line floor even after the rolling re-seeder's full ~587 s
+// retention window (test/e2e/seed/cmd/seed/stale.go's logsStaleMargin).
+//
+// This test mirrors insertLogsSQL's row-generation formula in Go — the
+// SQL is the source of truth; keep the two in sync:
+//
+//	service  = ['api', 'frontend', 'db'][number % 3]
+//	severity = multiIf(number % 3 = 0, 'WARN', number % 5 = 0, 'ERROR', 'INFO')
+//	body     = multiIf(number % 3 = 0, 'handled request', ...) + " id=" + number
+//
+// api rows (number % 3 == 0) are pinned to one severity + one body
+// template, so every api row lands in the SAME drain cluster instead of
+// splitting across templates/levels.
+func TestMinePatternsClearsE2ESeedFloor(t *testing.T) {
+	t.Parallel()
+
+	const (
+		tickInterval = 30 * time.Second // e2e-seed-rolling's --re-seed-interval
+		rowsPerTick  = 40               // insertLogsSQL: FROM numbers(40)
+		cadence      = 15 * time.Second // insertLogsSQL: (number - 20) * 15 SECOND
+
+		// realisticDwellTicks is a conservative lower bound on how many
+		// rolling re-seed ticks land before the dashboard e2e's
+		// Playwright patterns spec fires: `just e2e-run`'s full Go spec
+		// suite against the live stack runs between `e2e-seed-rolling`
+		// start and the Playwright step, comfortably clearing several
+		// ticks in every observed run.
+		realisticDwellTicks = 6
+	)
+
+	now := time.Now()
+	start := now.Add(-5 * time.Minute) // last5MinWindow() in loki_ux.spec.ts
+	end := now
+
+	var lines []chclient.TimestampedLine
+	for tick := 0; tick < realisticDwellTicks; tick++ {
+		tickNow := now.Add(-time.Duration(tick) * tickInterval)
+		for n := 0; n < rowsPerTick; n++ {
+			if n%3 != 0 {
+				continue // insertLogsSQL: arrayElement(['api','frontend','db'], number%3+1) != 'api'
+			}
+			ts := tickNow.Add(time.Duration(n-20) * cadence)
+			if ts.Before(start) || ts.After(end) {
+				continue
+			}
+			lines = append(lines, chclient.TimestampedLine{
+				Timestamp: ts,
+				Severity:  "WARN", // insertLogsSQL: multiIf(number % 3 = 0, 'WARN', ...)
+				Body:      fmt.Sprintf("handled request id=%d", n),
+			})
+		}
+	}
+
+	got := minePatterns(lines, start, end, minimumPatternSampleResolution)
+	if len(got) == 0 {
+		t.Fatalf("0 clusters after %d re-seed ticks (%d api lines in the query window) — "+
+			"the e2e seed fixture no longer clears minimumPatternVolume=%d; "+
+			"see test/e2e/seed/cmd/seed/main.go's insertLogsSQL",
+			realisticDwellTicks, len(lines), minimumPatternVolume)
+	}
+	if v := patternTestVolume(got[0]); v < minimumPatternVolume {
+		t.Fatalf("best cluster volume=%d want >= minimumPatternVolume=%d after %d re-seed ticks",
+			v, minimumPatternVolume, realisticDwellTicks)
+	}
+}

--- a/test/e2e/playwright/loki_ux.spec.ts
+++ b/test/e2e/playwright/loki_ux.spec.ts
@@ -9,11 +9,16 @@ import { test, expect } from '@playwright/test';
  * link, histogram, ...) by hitting the cerberus-loki datasource proxy.
  *
  * Seed shape (test/e2e/seed/cmd/seed/main.go):
- *   • otel_logs: 120 rows spaced 15 s apart spanning a 30-minute window
- *     centred on the seed timestamp, three services (api / frontend /
- *     db). SeverityNumber cycles {17, 13, 9} and SeverityText cycles
- *     {ERROR, WARN, INFO}. Body has the form "<message> id=<n>" —
- *     useful as a line-filter substring target.
+ *   • otel_logs: 40 rows spaced 15 s apart spanning a 10-minute window
+ *     centred on the (re-anchored) seed timestamp, three services
+ *     (api / frontend / db). frontend/db rows cycle SeverityNumber
+ *     {17, 13, 9} / SeverityText {ERROR, WARN, INFO} across 5 message
+ *     templates; api rows are pinned to a single severity (WARN) and
+ *     message template ("handled request") so the rolling re-seeder
+ *     accumulates enough same-template/same-level volume for the
+ *     patterns test below to clear /loki/api/v1/patterns'
+ *     minimumPatternVolume floor. Body has the form "<message> id=<n>"
+ *     — useful as a line-filter substring target.
  */
 
 const lokiProxy = '/api/datasources/proxy/uid/cerberus-loki/loki/api/v1';
@@ -160,9 +165,12 @@ test.describe('Loki UX — Logs panel flows', () => {
     //      {"pattern":"...","level":"","samples":[[ts_seconds, count], ...]},
     //      ...
     //   ]}
-    // The seed body cycles five distinct templates with a varying
-    // `id=<n>` suffix, so drain produces at least one cluster for the
-    // `{service_name="api"}` selector.
+    // Every `{service_name="api"}` row shares one body template
+    // ("handled request", varying only the `id=<n>` suffix) and one
+    // severity (WARN), so the rolling re-seeder's accumulated volume
+    // for that single drain cluster clears the handler's
+    // minimumPatternVolume floor (internal/api/loki/patterns.go)
+    // within a handful of re-seed ticks, well before this spec runs.
     const { start, end } = last5MinWindow();
     const q = encodeURIComponent('{service_name="api"}');
     const url = `${lokiProxy}/patterns?query=${q}&start=${start * 1e9}&end=${end * 1e9}`;

--- a/test/e2e/seed/cmd/seed/main.go
+++ b/test/e2e/seed/cmd/seed/main.go
@@ -463,6 +463,24 @@ FROM numbers(600)`
 	// (5 m staleness lookback, see internal/api/loki/handler.go:235)
 	// finds ≥1 row inside the lookback regardless of suite drift.
 	//
+	// `service_name="api"` rows (number % 3 = 0, ~14 of the 40) are
+	// pinned to a SINGLE body template ("handled request") and a
+	// SINGLE severity (WARN) — frontend/db keep the original 5-template
+	// / mixed-severity variety. This is load-bearing for
+	// /loki/api/v1/patterns (internal/api/loki/patterns.go): drain
+	// trains one Miner per detected level (minePatterns), and
+	// minimumPatternVolume requires ≥30 lines in one cluster before
+	// it's retained. Splitting api's ~14 rows/tick evenly across 5
+	// templates x up to 2 severities (the pre-fix shape) tops out
+	// around 3 lines/tick per cluster — never clears the floor even
+	// after the rolling re-seeder's full ~587 s retention window
+	// (test/e2e/seed/cmd/seed/stale.go's logsStaleMargin). Concentrating
+	// every api row onto one template+level instead gives that cluster
+	// ~14 lines/tick, clearing the floor within a handful of re-seed
+	// ticks — see internal/api/loki's
+	// TestMinePatternsClearsE2ESeedFloor, which mirrors this exact
+	// formula and pins the regression. Keep the two in sync.
+	//
 	// The column list deliberately omits `TimestampTime`: upstream's
 	// clickhouseexporter removed the column from the logs DDL in
 	// v0.150.0. Before the fork bump to the v0.152 templates, which
@@ -481,11 +499,14 @@ SELECT
     now64(9) + INTERVAL ((number - 20) * 15) SECOND AS ts,
     lpad(toString(number % 4), 32, '0'),
     lpad(toString(number % 4), 16, '0'),
-    multiIf(number % 5 = 0, 'ERROR', number % 3 = 0, 'WARN', 'INFO'),
-    multiIf(number % 5 = 0, 17, number % 3 = 0, 13, 9),
+    multiIf(number % 3 = 0, 'WARN', number % 5 = 0, 'ERROR', 'INFO'),
+    multiIf(number % 3 = 0, 13, number % 5 = 0, 17, 9),
     arrayElement(['api', 'frontend', 'db'], number % 3 + 1),
     concat(
-        arrayElement(['handled request', 'connection refused', 'slow query', 'cache hit', 'auth failed'], number % 5 + 1),
+        multiIf(
+            number % 3 = 0, 'handled request',
+            arrayElement(['connection refused', 'slow query', 'cache hit', 'auth failed'], number % 4 + 1)
+        ),
         ' id=', toString(number)
     ),
     map('service_name', arrayElement(['api', 'frontend', 'db'], number % 3 + 1)),


### PR DESCRIPTION
## Summary

The `dashboard` e2e Playwright suite's `/loki/api/v1/patterns` assertion (`test/e2e/playwright/loki_ux.spec.ts:152`, "patterns: the /patterns endpoint extracts drain clusters from log bodies") has returned `body.data.length == 0` on every run since `main` picked up #2205, which added `minimumPatternVolume = 30` to `internal/api/loki/patterns.go` — a floor mirroring upstream Loki's `minClusterSize`. That floor is correct product behaviour and is already covered by dedicated chDB/unit tests (`patterns_chdb_test.go`, `patterns_semantics_internal_test.go`). The regression is entirely on the e2e fixture side.

**Root cause**: `insertLogsSQL` (`test/e2e/seed/cmd/seed/main.go`) split each `{service_name="api"}` rolling re-seed tick's ~14 rows evenly across 5 body templates and, because `minePatterns` trains one `drain.Miner` per detected severity level, further split across up to 2 severities. That topped out around 3 lines/tick per drain cluster — verified via a Go-side simulation and confirmed by real chDB execution of the pre-fix formula — which never clears the 30-line floor even after the rolling re-seeder's full ~587s retention window (`test/e2e/seed/cmd/seed/stale.go`'s `logsStaleMargin`). The failure was deterministic, not a flake: the pre-fix formula mathematically cannot reach 30 for this fixture shape regardless of dwell time.

## Fix

Pin every `service_name="api"` row to a single body template (`"handled request"`) and a single severity (`WARN`) — `frontend`/`db` rows keep the original 5-template / mixed-severity variety, which no other test depends on for `api` specifically. This concentrates all ~14 api rows/tick into one drain cluster, clearing the floor within a handful of re-seed ticks (validated below), well inside the dwell time between `just e2e-seed-rolling` starting and the Playwright `patterns` spec running (`e2e-wait-otel` + the full `just e2e-run` Go spec suite run in between).

Also fixed a stale doc comment at the top of `loki_ux.spec.ts` that still described a since-abandoned 120-row/30-minute seed shape.

## Verification

- New white-box regression test `internal/api/loki/patterns_e2e_seed_volume_internal_test.go` (`TestMinePatternsClearsE2ESeedFloor`) mirrors the seed formula in Go, simulates a realistic 6-tick rolling-reseed accumulation, and calls the real (unexported) `minePatterns` to assert the resulting best cluster clears `minimumPatternVolume`. This is the layer that would have caught the regression at CI-speed instead of an e2e cluster — it fails against the pre-fix (uneven split) formula even at 20 simulated ticks (10 minutes), and passes against the fix at 5-6 ticks (2.5-3 minutes).
- Verified the modified `insertLogsSQL` against **real chDB execution** (not just Go-side reasoning): confirmed 14 `api` rows per tick, 100% using the `"handled request"` template at `WARN` severity.
- `go test -race ./internal/api/loki/...` — pass.
- `go test ./test/e2e/seed/cmd/seed/...` (untagged tests) — pass, unaffected.
- `go build ./...` — clean.

## Test plan

- [x] `go test -race ./internal/api/loki/...`
- [x] `go test ./test/e2e/seed/cmd/seed/...`
- [x] Real chDB execution of the modified `insertLogsSQL`
- [ ] CI `dashboard` e2e lane goes green (this is precisely the gate this PR fixes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)