### PR TITLE
test(ci): backtest the merge-fence lane selector against real PR history

### DIFF
--- a/.github/actions/ci-native-part/action.yml
+++ b/.github/actions/ci-native-part/action.yml
@@ -1,0 +1,30 @@
+name: emit CI lane native part
+description: Publish a completion-bound native evidence part for one registered producer
+
+inputs:
+  id:
+    description: Registry native part ID
+    required: true
+  seed:
+    description: Exact seed used by a seeded producer lane
+    required: false
+    default: ''
+
+runs:
+  using: composite
+  steps:
+    - name: emit the completion-bound native case
+      shell: bash
+      env:
+        CI_NATIVE_PART_ID: ${{ inputs.id }}
+        CI_NATIVE_PART_OUTPUT: .ci-native/${{ inputs.id }}/cases.json
+        CI_NATIVE_SEED: ${{ inputs.seed }}
+      run: node .github/scripts/ci-lane-native-part.mjs
+
+    - name: upload the attempt-qualified native part
+      uses: actions/upload-artifact@v7
+      with:
+        name: ci-native-part-${{ inputs.id }}-${{ github.run_attempt }}
+        path: .ci-native/${{ inputs.id }}/cases.json
+        if-no-files-found: error
+        retention-days: 14

--- a/.github/actions/prepare-release-promotion/action.yml
+++ b/.github/actions/prepare-release-promotion/action.yml
@@ -1,0 +1,78 @@
+name: prepare release promotion
+description: Download only the sealed candidate and successful qualification attestation, then verify both.
+
+inputs:
+  candidate_artifact:
+    description: Immutable candidate artifact name from this workflow run.
+    required: true
+  candidate_digest:
+    description: Exact sha256 digest of candidate-manifest.json.
+    required: true
+  attestation_artifact:
+    description: Immutable successful qualification-attestation artifact name.
+    required: true
+  attestation_digest:
+    description: Exact sha256 digest of the qualification attestation.
+    required: true
+  source_sha:
+    description: Exact source commit.
+    required: true
+  source_tree:
+    description: Exact source tree.
+    required: true
+  app_version:
+    description: Qualified application version.
+    required: true
+  app_tag:
+    description: Qualified application tag.
+    required: true
+  chart_version:
+    description: Qualified chart version.
+    required: true
+  correlation_nonce:
+    description: Fresh qualification nonce.
+    required: true
+  authorized:
+    description: Literal authorization-barrier result.
+    required: true
+  publish:
+    description: Literal per-artifact version-gate result.
+    required: true
+  dry_run:
+    description: Literal release dry-run policy.
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: download the sealed candidate only
+      uses: actions/download-artifact@v8
+      with:
+        name: ${{ inputs.candidate_artifact }}
+        path: build/release-candidate
+
+    - name: download the successful qualification attestation only
+      uses: actions/download-artifact@v8
+      with:
+        name: ${{ inputs.attestation_artifact }}
+        path: build
+
+    - name: directly verify promotion authorization
+      shell: bash
+      env:
+        MODE: verify-only
+        RELEASE_CANDIDATE_DIR: build/release-candidate
+        RELEASE_CANDIDATE_DIGEST: ${{ inputs.candidate_digest }}
+        RELEASE_ATTESTATION: build/release-qualification-attestation.json
+        RELEASE_ATTESTATION_DIGEST: ${{ inputs.attestation_digest }}
+        RELEASE_SOURCE_SHA: ${{ inputs.source_sha }}
+        RELEASE_SOURCE_TREE: ${{ inputs.source_tree }}
+        RELEASE_SOURCE_URL: ${{ github.server_url }}/${{ github.repository }}
+        RELEASE_APP_VERSION: ${{ inputs.app_version }}
+        RELEASE_APP_TAG: ${{ inputs.app_tag }}
+        RELEASE_CHART_VERSION: ${{ inputs.chart_version }}
+        RELEASE_CORRELATION_NONCE: ${{ inputs.correlation_nonce }}
+        RELEASE_AUTHORIZED: ${{ inputs.authorized }}
+        RELEASE_PUBLISH: ${{ inputs.publish }}
+        RELEASE_DRY_RUN: ${{ inputs.dry_run }}
+      run: node .github/scripts/release-promote.mjs

--- a/.github/actions/resolve-migration-artifact/action.yml
+++ b/.github/actions/resolve-migration-artifact/action.yml
@@ -1,0 +1,48 @@
+name: resolve migration artifact
+description: Verify and load the unpublished candidate, or build the source-tree migration binary
+
+inputs:
+  candidate-artifact:
+    description: Caller-run artifact containing the sealed candidate
+    required: false
+    default: ''
+  candidate-digest:
+    description: Exact candidate manifest digest
+    required: false
+    default: ''
+  expect-version:
+    description: Exact candidate version
+    required: false
+    default: ''
+  source-sha:
+    description: Exact candidate source commit
+    required: false
+    default: ''
+  source-tree:
+    description: Exact candidate source tree
+    required: false
+    default: ''
+
+runs:
+  using: composite
+  steps:
+    - name: download the sealed candidate
+      if: inputs.candidate-artifact != ''
+      uses: actions/download-artifact@v8
+      with:
+        name: ${{ inputs.candidate-artifact }}
+        path: build/release-candidate
+
+    - name: install the OCI layout client
+      if: inputs.candidate-artifact != ''
+      uses: oras-project/setup-oras@1d808f7d7f6995cc68b7bf507bfe5c5446e1dc9d  # v2
+
+    - name: resolve the artifact under test
+      shell: bash
+      run: node .github/scripts/migration-artifact.mjs
+      env:
+        CERBERUS_CANDIDATE_DIR_INPUT: ${{ inputs.candidate-artifact != '' && 'build/release-candidate' || '' }}
+        CERBERUS_CANDIDATE_DIGEST_INPUT: ${{ inputs.candidate-digest }}
+        CERBERUS_EXPECT_VERSION_INPUT: ${{ inputs.expect-version }}
+        CERBERUS_SOURCE_SHA_INPUT: ${{ inputs.source-sha }}
+        CERBERUS_SOURCE_TREE_INPUT: ${{ inputs.source-tree }}

--- a/.github/ci-lanes.json
+++ b/.github/ci-lanes.json
@@ -19,7 +19,494 @@
   },
   "native_evidence": {
     "schema_version": 1,
-    "parts": []
+    "parts": [
+      {
+        "id": "agpl.oracle.agpl-oracle.source",
+        "lane_id": "agpl.oracle",
+        "execution_id": "default",
+        "invocation_mode": "source_tree",
+        "producer_job": "agpl-oracle",
+        "parser": "case-json-v1",
+        "entry": "cases.json"
+      },
+      {
+        "id": "chart.validate.chart-validate.source",
+        "lane_id": "chart.validate",
+        "execution_id": "default",
+        "invocation_mode": "source_tree",
+        "producer_job": "chart-validate",
+        "parser": "case-json-v1",
+        "entry": "cases.json"
+      },
+      {
+        "id": "chdb.integration-logql.integration-logql.source",
+        "lane_id": "chdb.integration-logql",
+        "execution_id": "default",
+        "invocation_mode": "source_tree",
+        "producer_job": "integration-logql",
+        "parser": "case-json-v1",
+        "entry": "cases.json"
+      },
+      {
+        "id": "chdb.integration-promql.integration-promql.source",
+        "lane_id": "chdb.integration-promql",
+        "execution_id": "default",
+        "invocation_mode": "source_tree",
+        "producer_job": "integration-promql",
+        "parser": "case-json-v1",
+        "entry": "cases.json"
+      },
+      {
+        "id": "chdb.integration-traceql.integration-traceql.source",
+        "lane_id": "chdb.integration-traceql",
+        "execution_id": "default",
+        "invocation_mode": "source_tree",
+        "producer_job": "integration-traceql",
+        "parser": "case-json-v1",
+        "entry": "cases.json"
+      },
+      {
+        "id": "chdb.perf-guards.perf-guards.source",
+        "lane_id": "chdb.perf-guards",
+        "execution_id": "default",
+        "invocation_mode": "source_tree",
+        "producer_job": "perf-guards",
+        "parser": "case-json-v1",
+        "entry": "cases.json"
+      },
+      {
+        "id": "chdb.probe.probe.source",
+        "lane_id": "chdb.probe",
+        "execution_id": "default",
+        "invocation_mode": "source_tree",
+        "producer_job": "probe",
+        "parser": "case-json-v1",
+        "entry": "cases.json"
+      },
+      {
+        "id": "chdb.roundtrip-logql.roundtrip.source",
+        "lane_id": "chdb.roundtrip-logql",
+        "execution_id": "default",
+        "invocation_mode": "source_tree",
+        "producer_job": "roundtrip",
+        "parser": "case-json-v1",
+        "entry": "cases.json"
+      },
+      {
+        "id": "chdb.roundtrip-promql.roundtrip.source",
+        "lane_id": "chdb.roundtrip-promql",
+        "execution_id": "default",
+        "invocation_mode": "source_tree",
+        "producer_job": "roundtrip",
+        "parser": "case-json-v1",
+        "entry": "cases.json"
+      },
+      {
+        "id": "chdb.roundtrip-traceql.roundtrip.source",
+        "lane_id": "chdb.roundtrip-traceql",
+        "execution_id": "default",
+        "invocation_mode": "source_tree",
+        "producer_job": "roundtrip",
+        "parser": "case-json-v1",
+        "entry": "cases.json"
+      },
+      {
+        "id": "chdb.strict-scan.strict-scan.source",
+        "lane_id": "chdb.strict-scan",
+        "execution_id": "default",
+        "invocation_mode": "source_tree",
+        "producer_job": "strict-scan",
+        "parser": "case-json-v1",
+        "entry": "cases.json"
+      },
+      {
+        "id": "ci.agpl-clean.agpl-clean.source",
+        "lane_id": "ci.agpl-clean",
+        "execution_id": "default",
+        "invocation_mode": "source_tree",
+        "producer_job": "agpl-clean",
+        "parser": "case-json-v1",
+        "entry": "cases.json"
+      },
+      {
+        "id": "ci.chaos-sleep.check-test.source",
+        "lane_id": "ci.chaos-sleep",
+        "execution_id": "default",
+        "invocation_mode": "source_tree",
+        "producer_job": "check-test",
+        "parser": "case-json-v1",
+        "entry": "cases.json"
+      },
+      {
+        "id": "ci.check.changes.source",
+        "lane_id": "ci.check",
+        "execution_id": "default",
+        "invocation_mode": "source_tree",
+        "producer_job": "changes",
+        "parser": "case-json-v1",
+        "entry": "cases.json"
+      },
+      {
+        "id": "ci.check.check-build.source",
+        "lane_id": "ci.check",
+        "execution_id": "default",
+        "invocation_mode": "source_tree",
+        "producer_job": "check-build",
+        "parser": "case-json-v1",
+        "entry": "cases.json"
+      },
+      {
+        "id": "ci.check.check-test.source",
+        "lane_id": "ci.check",
+        "execution_id": "default",
+        "invocation_mode": "source_tree",
+        "producer_job": "check-test",
+        "parser": "case-json-v1",
+        "entry": "cases.json"
+      },
+      {
+        "id": "ci.forbid-skip.forbid-skip.source",
+        "lane_id": "ci.forbid-skip",
+        "execution_id": "default",
+        "invocation_mode": "source_tree",
+        "producer_job": "forbid-skip",
+        "parser": "case-json-v1",
+        "entry": "cases.json"
+      },
+      {
+        "id": "ci.link-check.link-check.source",
+        "lane_id": "ci.link-check",
+        "execution_id": "default",
+        "invocation_mode": "source_tree",
+        "producer_job": "link-check",
+        "parser": "case-json-v1",
+        "entry": "cases.json"
+      },
+      {
+        "id": "ci.lint.lint.source",
+        "lane_id": "ci.lint",
+        "execution_id": "default",
+        "invocation_mode": "source_tree",
+        "producer_job": "lint",
+        "parser": "case-json-v1",
+        "entry": "cases.json"
+      },
+      {
+        "id": "compatibility.gate.gate.source",
+        "lane_id": "compatibility.gate",
+        "execution_id": "default",
+        "invocation_mode": "source_tree",
+        "producer_job": "gate",
+        "parser": "case-json-v1",
+        "entry": "cases.json"
+      },
+      {
+        "id": "compatibility.loki.loki.source",
+        "lane_id": "compatibility.loki",
+        "execution_id": "default",
+        "invocation_mode": "source_tree",
+        "producer_job": "loki",
+        "parser": "case-json-v1",
+        "entry": "cases.json"
+      },
+      {
+        "id": "compatibility.prometheus-floor.prometheus-floor.source",
+        "lane_id": "compatibility.prometheus-floor",
+        "execution_id": "default",
+        "invocation_mode": "source_tree",
+        "producer_job": "prometheus-floor",
+        "parser": "case-json-v1",
+        "entry": "cases.json"
+      },
+      {
+        "id": "compatibility.prometheus-forced-route.prometheus-forced-route.source",
+        "lane_id": "compatibility.prometheus-forced-route",
+        "execution_id": "default",
+        "invocation_mode": "source_tree",
+        "producer_job": "prometheus-forced-route",
+        "parser": "case-json-v1",
+        "entry": "cases.json"
+      },
+      {
+        "id": "compatibility.prometheus.prometheus.source",
+        "lane_id": "compatibility.prometheus",
+        "execution_id": "default",
+        "invocation_mode": "source_tree",
+        "producer_job": "prometheus",
+        "parser": "case-json-v1",
+        "entry": "cases.json"
+      },
+      {
+        "id": "compatibility.promql-surface.promql-surface.source",
+        "lane_id": "compatibility.promql-surface",
+        "execution_id": "default",
+        "invocation_mode": "source_tree",
+        "producer_job": "promql-surface",
+        "parser": "case-json-v1",
+        "entry": "cases.json"
+      },
+      {
+        "id": "compatibility.tempo.tempo.source",
+        "lane_id": "compatibility.tempo",
+        "execution_id": "default",
+        "invocation_mode": "source_tree",
+        "producer_job": "tempo",
+        "parser": "case-json-v1",
+        "entry": "cases.json"
+      },
+      {
+        "id": "docs.config-drift.config-docs.source",
+        "lane_id": "docs.config-drift",
+        "execution_id": "default",
+        "invocation_mode": "source_tree",
+        "producer_job": "config-docs",
+        "parser": "case-json-v1",
+        "entry": "cases.json"
+      },
+      {
+        "id": "e2e.bwc-minio.bwc-minio.source",
+        "lane_id": "e2e.bwc-minio",
+        "execution_id": "default",
+        "invocation_mode": "source_tree",
+        "producer_job": "bwc-minio",
+        "parser": "case-json-v1",
+        "entry": "cases.json"
+      },
+      {
+        "id": "e2e.chaos.chaos.source",
+        "lane_id": "e2e.chaos",
+        "execution_id": "default",
+        "invocation_mode": "source_tree",
+        "producer_job": "chaos",
+        "parser": "case-json-v1",
+        "entry": "cases.json"
+      },
+      {
+        "id": "e2e.compose-crawl.crawl-terminal.source",
+        "lane_id": "e2e.compose-crawl",
+        "execution_id": "default",
+        "invocation_mode": "source_tree",
+        "producer_job": "crawl-terminal",
+        "parser": "case-json-v1",
+        "entry": "cases.json"
+      },
+      {
+        "id": "e2e.compose-smoke.compose-smoke.source",
+        "lane_id": "e2e.compose-smoke",
+        "execution_id": "default",
+        "invocation_mode": "source_tree",
+        "producer_job": "compose-smoke",
+        "parser": "case-json-v1",
+        "entry": "cases.json"
+      },
+      {
+        "id": "e2e.dashboard-crawl.dashboard-crawl-terminal.source",
+        "lane_id": "e2e.dashboard-crawl",
+        "execution_id": "default",
+        "invocation_mode": "source_tree",
+        "producer_job": "dashboard-crawl-terminal",
+        "parser": "case-json-v1",
+        "entry": "cases.json"
+      },
+      {
+        "id": "e2e.dashboard.dashboard.source",
+        "lane_id": "e2e.dashboard",
+        "execution_id": "default",
+        "invocation_mode": "source_tree",
+        "producer_job": "dashboard",
+        "parser": "case-json-v1",
+        "entry": "cases.json"
+      },
+      {
+        "id": "e2e.quickstart.run.source",
+        "lane_id": "e2e.quickstart",
+        "execution_id": "default",
+        "invocation_mode": "source_tree",
+        "producer_job": "run",
+        "parser": "case-json-v1",
+        "entry": "cases.json"
+      },
+      {
+        "id": "e2e.quickstart.select.source",
+        "lane_id": "e2e.quickstart",
+        "execution_id": "default",
+        "invocation_mode": "source_tree",
+        "producer_job": "select",
+        "parser": "case-json-v1",
+        "entry": "cases.json"
+      },
+      {
+        "id": "e2e.startup-bench.startup-bench.source",
+        "lane_id": "e2e.startup-bench",
+        "execution_id": "default",
+        "invocation_mode": "source_tree",
+        "producer_job": "startup-bench",
+        "parser": "case-json-v1",
+        "entry": "cases.json"
+      },
+      {
+        "id": "governance.forbid-deferral.forbid-deferral.source",
+        "lane_id": "governance.forbid-deferral",
+        "execution_id": "default",
+        "invocation_mode": "source_tree",
+        "producer_job": "forbid-deferral",
+        "parser": "case-json-v1",
+        "entry": "cases.json"
+      },
+      {
+        "id": "governance.pr-body.pr-body.source",
+        "lane_id": "governance.pr-body",
+        "execution_id": "default",
+        "invocation_mode": "source_tree",
+        "producer_job": "pr-body",
+        "parser": "case-json-v1",
+        "entry": "cases.json"
+      },
+      {
+        "id": "migration.e2e.migration-setup.artifact",
+        "lane_id": "migration.e2e",
+        "execution_id": "default",
+        "invocation_mode": "candidate_artifact",
+        "producer_job": "migration-setup",
+        "parser": "case-json-v1",
+        "entry": "cases.json"
+      },
+      {
+        "id": "migration.e2e.migration-tier0.artifact",
+        "lane_id": "migration.e2e",
+        "execution_id": "default",
+        "invocation_mode": "candidate_artifact",
+        "producer_job": "migration-tier0",
+        "parser": "case-json-v1",
+        "entry": "cases.json"
+      },
+      {
+        "id": "migration.e2e.migration-tier1.artifact",
+        "lane_id": "migration.e2e",
+        "execution_id": "default",
+        "invocation_mode": "candidate_artifact",
+        "producer_job": "migration-tier1",
+        "parser": "case-json-v1",
+        "entry": "cases.json"
+      },
+      {
+        "id": "migration.e2e.migration-tier2.artifact",
+        "lane_id": "migration.e2e",
+        "execution_id": "default",
+        "invocation_mode": "candidate_artifact",
+        "producer_job": "migration-tier2",
+        "parser": "case-json-v1",
+        "entry": "cases.json"
+      },
+      {
+        "id": "migration.e2e.migration-setup.source",
+        "lane_id": "migration.e2e",
+        "execution_id": "default",
+        "invocation_mode": "source_tree",
+        "producer_job": "migration-setup",
+        "parser": "case-json-v1",
+        "entry": "cases.json"
+      },
+      {
+        "id": "migration.e2e.migration-tier0.source",
+        "lane_id": "migration.e2e",
+        "execution_id": "default",
+        "invocation_mode": "source_tree",
+        "producer_job": "migration-tier0",
+        "parser": "case-json-v1",
+        "entry": "cases.json"
+      },
+      {
+        "id": "migration.e2e.migration-tier1.source",
+        "lane_id": "migration.e2e",
+        "execution_id": "default",
+        "invocation_mode": "source_tree",
+        "producer_job": "migration-tier1",
+        "parser": "case-json-v1",
+        "entry": "cases.json"
+      },
+      {
+        "id": "migration.e2e.migration-tier2.source",
+        "lane_id": "migration.e2e",
+        "execution_id": "default",
+        "invocation_mode": "source_tree",
+        "producer_job": "migration-tier2",
+        "parser": "case-json-v1",
+        "entry": "cases.json"
+      },
+      {
+        "id": "performance.profile.profile.source",
+        "lane_id": "performance.profile",
+        "execution_id": "default",
+        "invocation_mode": "source_tree",
+        "producer_job": "profile",
+        "parser": "case-json-v1",
+        "entry": "cases.json"
+      },
+      {
+        "id": "quality.coverage-enrollment.coverage.source",
+        "lane_id": "quality.coverage-enrollment",
+        "execution_id": "default",
+        "invocation_mode": "source_tree",
+        "producer_job": "coverage",
+        "parser": "case-json-v1",
+        "entry": "cases.json"
+      },
+      {
+        "id": "quality.coverage-measured.coverage.source",
+        "lane_id": "quality.coverage-measured",
+        "execution_id": "default",
+        "invocation_mode": "source_tree",
+        "producer_job": "coverage",
+        "parser": "case-json-v1",
+        "entry": "cases.json"
+      },
+      {
+        "id": "quality.mutation.mutation.source",
+        "lane_id": "quality.mutation",
+        "execution_id": "default",
+        "invocation_mode": "source_tree",
+        "producer_job": "mutation",
+        "parser": "case-json-v1",
+        "entry": "cases.json"
+      },
+      {
+        "id": "quality.post-merge-drift.drift.source",
+        "lane_id": "quality.post-merge-drift",
+        "execution_id": "default",
+        "invocation_mode": "source_tree",
+        "producer_job": "drift",
+        "parser": "case-json-v1",
+        "entry": "cases.json"
+      },
+      {
+        "id": "quality.property.property.source",
+        "lane_id": "quality.property",
+        "execution_id": "default",
+        "invocation_mode": "source_tree",
+        "producer_job": "property",
+        "parser": "case-json-v1",
+        "entry": "cases.json"
+      },
+      {
+        "id": "schema.ddl.schema-ddl.source",
+        "lane_id": "schema.ddl",
+        "execution_id": "default",
+        "invocation_mode": "source_tree",
+        "producer_job": "schema-ddl",
+        "parser": "case-json-v1",
+        "entry": "cases.json"
+      },
+      {
+        "id": "security.codeql.codeql.source",
+        "lane_id": "security.codeql",
+        "execution_id": "default",
+        "invocation_mode": "source_tree",
+        "producer_job": "CodeQL",
+        "parser": "case-json-v1",
+        "entry": "cases.json"
+      }
+    ]
   },
   "layers": [
     { "id": "1", "name": "Parser smoke / AST-shape pinning" },
@@ -245,7 +732,7 @@
       "owner": {
         "workflow": ".github/workflows/chdb.yml",
         "jobs": ["perf-guards-shard", "perf-guards"],
-        "producer_jobs": ["perf-guards-shard"],
+        "producer_jobs": ["perf-guards"],
         "context_job": "perf-guards"
       },
       "executions": ["default"],
@@ -1075,7 +1562,7 @@
           "compose-crawl-merge",
           "crawl-terminal"
         ],
-        "producer_jobs": ["compose-smoke-shard-info"],
+        "producer_jobs": ["crawl-terminal"],
         "context_job": "crawl-terminal"
       },
       "executions": ["default"],
@@ -1135,11 +1622,7 @@
           "compose-smoke-shard",
           "compose-smoke"
         ],
-        "producer_jobs": [
-          "compose-smoke-scope",
-          "compose-smoke-setup",
-          "compose-smoke-shard"
-        ],
+        "producer_jobs": ["compose-smoke"],
         "context_job": "compose-smoke"
       },
       "executions": ["default"],
@@ -1194,7 +1677,7 @@
       "owner": {
         "workflow": ".github/workflows/e2e.yml",
         "jobs": ["dashboard-setup", "dashboard-shard", "dashboard"],
-        "producer_jobs": ["dashboard-setup", "dashboard-shard"],
+        "producer_jobs": ["dashboard"],
         "context_job": "dashboard"
       },
       "executions": ["default"],
@@ -1229,7 +1712,7 @@
           "dashboard-crawl-terminal",
           "dashboard-crawl-merge"
         ],
-        "producer_jobs": ["dashboard-shard-info"],
+        "producer_jobs": ["dashboard-crawl-terminal"],
         "context_job": "dashboard-crawl-terminal"
       },
       "executions": ["default"],
@@ -1682,7 +2165,7 @@
       "owner": {
         "workflow": ".github/workflows/mutation.yml",
         "jobs": ["select", "mutate", "mutation"],
-        "producer_jobs": ["select", "mutate"],
+        "producer_jobs": ["mutation"],
         "context_job": "mutation"
       },
       "executions": ["default"],
@@ -1926,7 +2409,7 @@
       "owner": {
         "workflow": ".github/workflows/codeql.yml",
         "jobs": ["analyze", "CodeQL"],
-        "producer_jobs": ["analyze"],
+        "producer_jobs": ["CodeQL"],
         "context_job": "CodeQL"
       },
       "executions": ["default"],

--- a/.github/ci-lanes.json
+++ b/.github/ci-lanes.json
@@ -1,7 +1,7 @@
 {
   "schema_version": 1,
   "selection_schema_version": 1,
-  "report_schema_version": 1,
+  "report_schema_version": 2,
   "rollout": "shadow",
   "impact_selection": {
     "known_nonimpact_globs": [
@@ -87,7 +87,7 @@
       "timeout_minutes": 15,
       "slo_minutes": 15,
       "accountable_owner": "query-quality",
-      "report_schema_version": 1
+      "report_schema_version": 2
     },
     {
       "id": "chart.validate",
@@ -128,7 +128,7 @@
       "timeout_minutes": 30,
       "slo_minutes": 12,
       "accountable_owner": "release-engineering",
-      "report_schema_version": 1
+      "report_schema_version": 2
     },
     {
       "id": "chdb.integration-logql",
@@ -163,7 +163,7 @@
       "timeout_minutes": 20,
       "slo_minutes": 20,
       "accountable_owner": "query-quality",
-      "report_schema_version": 1
+      "report_schema_version": 2
     },
     {
       "id": "chdb.integration-promql",
@@ -198,7 +198,7 @@
       "timeout_minutes": 20,
       "slo_minutes": 20,
       "accountable_owner": "query-quality",
-      "report_schema_version": 1
+      "report_schema_version": 2
     },
     {
       "id": "chdb.integration-traceql",
@@ -233,7 +233,7 @@
       "timeout_minutes": 20,
       "slo_minutes": 20,
       "accountable_owner": "query-quality",
-      "report_schema_version": 1
+      "report_schema_version": 2
     },
     {
       "id": "chdb.perf-guards",
@@ -264,7 +264,7 @@
       "timeout_minutes": 30,
       "slo_minutes": 20,
       "accountable_owner": "query-quality",
-      "report_schema_version": 1
+      "report_schema_version": 2
     },
     {
       "id": "chdb.probe",
@@ -299,7 +299,7 @@
       "timeout_minutes": 15,
       "slo_minutes": 15,
       "accountable_owner": "query-quality",
-      "report_schema_version": 1
+      "report_schema_version": 2
     },
     {
       "id": "chdb.roundtrip-logql",
@@ -334,7 +334,7 @@
       "timeout_minutes": 20,
       "slo_minutes": 20,
       "accountable_owner": "query-quality",
-      "report_schema_version": 1
+      "report_schema_version": 2
     },
     {
       "id": "chdb.roundtrip-promql",
@@ -369,7 +369,7 @@
       "timeout_minutes": 20,
       "slo_minutes": 20,
       "accountable_owner": "query-quality",
-      "report_schema_version": 1
+      "report_schema_version": 2
     },
     {
       "id": "chdb.roundtrip-traceql",
@@ -404,7 +404,7 @@
       "timeout_minutes": 20,
       "slo_minutes": 20,
       "accountable_owner": "query-quality",
-      "report_schema_version": 1
+      "report_schema_version": 2
     },
     {
       "id": "chdb.strict-scan",
@@ -445,7 +445,7 @@
       "timeout_minutes": 20,
       "slo_minutes": 20,
       "accountable_owner": "query-quality",
-      "report_schema_version": 1
+      "report_schema_version": 2
     },
     {
       "id": "ci.agpl-clean",
@@ -476,7 +476,7 @@
       "timeout_minutes": 20,
       "slo_minutes": 8,
       "accountable_owner": "security",
-      "report_schema_version": 1
+      "report_schema_version": 2
     },
     {
       "id": "ci.chaos-sleep",
@@ -513,7 +513,7 @@
       "timeout_minutes": 20,
       "slo_minutes": 8,
       "accountable_owner": "quality-platform",
-      "report_schema_version": 1
+      "report_schema_version": 2
     },
     {
       "id": "ci.check",
@@ -573,7 +573,7 @@
       "timeout_minutes": 20,
       "slo_minutes": 10,
       "accountable_owner": "quality-platform",
-      "report_schema_version": 1
+      "report_schema_version": 2
     },
     {
       "id": "ci.forbid-skip",
@@ -604,7 +604,7 @@
       "timeout_minutes": 30,
       "slo_minutes": 12,
       "accountable_owner": "quality-platform",
-      "report_schema_version": 1
+      "report_schema_version": 2
     },
     {
       "id": "ci.link-check",
@@ -635,7 +635,7 @@
       "timeout_minutes": 20,
       "slo_minutes": 8,
       "accountable_owner": "quality-platform",
-      "report_schema_version": 1
+      "report_schema_version": 2
     },
     {
       "id": "ci.lint",
@@ -666,7 +666,7 @@
       "timeout_minutes": 60,
       "slo_minutes": 20,
       "accountable_owner": "quality-platform",
-      "report_schema_version": 1
+      "report_schema_version": 2
     },
     {
       "id": "compatibility.gate",
@@ -697,7 +697,7 @@
       "timeout_minutes": 10,
       "slo_minutes": 8,
       "accountable_owner": "quality-platform",
-      "report_schema_version": 1
+      "report_schema_version": 2
     },
     {
       "id": "compatibility.loki",
@@ -736,7 +736,7 @@
       "timeout_minutes": 30,
       "slo_minutes": 20,
       "accountable_owner": "query-quality",
-      "report_schema_version": 1
+      "report_schema_version": 2
     },
     {
       "id": "compatibility.prometheus",
@@ -775,7 +775,7 @@
       "timeout_minutes": 30,
       "slo_minutes": 20,
       "accountable_owner": "query-quality",
-      "report_schema_version": 1
+      "report_schema_version": 2
     },
     {
       "id": "compatibility.prometheus-floor",
@@ -814,7 +814,7 @@
       "timeout_minutes": 30,
       "slo_minutes": 20,
       "accountable_owner": "query-quality",
-      "report_schema_version": 1
+      "report_schema_version": 2
     },
     {
       "id": "compatibility.prometheus-forced-route",
@@ -849,7 +849,7 @@
       "timeout_minutes": 30,
       "slo_minutes": 20,
       "accountable_owner": "query-quality",
-      "report_schema_version": 1
+      "report_schema_version": 2
     },
     {
       "id": "compatibility.promql-surface",
@@ -884,7 +884,7 @@
       "timeout_minutes": 15,
       "slo_minutes": 15,
       "accountable_owner": "query-quality",
-      "report_schema_version": 1
+      "report_schema_version": 2
     },
     {
       "id": "compatibility.tempo",
@@ -923,7 +923,7 @@
       "timeout_minutes": 30,
       "slo_minutes": 20,
       "accountable_owner": "query-quality",
-      "report_schema_version": 1
+      "report_schema_version": 2
     },
     {
       "id": "docs.config-drift",
@@ -962,7 +962,7 @@
       "timeout_minutes": 20,
       "slo_minutes": 10,
       "accountable_owner": "quality-platform",
-      "report_schema_version": 1
+      "report_schema_version": 2
     },
     {
       "id": "docs.external-links",
@@ -997,7 +997,7 @@
       "timeout_minutes": 30,
       "slo_minutes": 30,
       "accountable_owner": "quality-platform",
-      "report_schema_version": 1
+      "report_schema_version": 2
     },
     {
       "id": "e2e.bwc-minio",
@@ -1028,7 +1028,7 @@
       "timeout_minutes": 40,
       "slo_minutes": 40,
       "accountable_owner": "system-quality",
-      "report_schema_version": 1
+      "report_schema_version": 2
     },
     {
       "id": "e2e.chaos",
@@ -1059,7 +1059,7 @@
       "timeout_minutes": 40,
       "slo_minutes": 40,
       "accountable_owner": "system-quality",
-      "report_schema_version": 1
+      "report_schema_version": 2
     },
     {
       "id": "e2e.compose-crawl",
@@ -1118,7 +1118,7 @@
       "timeout_minutes": 120,
       "slo_minutes": 20,
       "accountable_owner": "system-quality",
-      "report_schema_version": 1
+      "report_schema_version": 2
     },
     {
       "id": "e2e.compose-smoke",
@@ -1182,7 +1182,7 @@
       "timeout_minutes": 120,
       "slo_minutes": 20,
       "accountable_owner": "system-quality",
-      "report_schema_version": 1
+      "report_schema_version": 2
     },
     {
       "id": "e2e.dashboard",
@@ -1213,7 +1213,7 @@
       "timeout_minutes": 120,
       "slo_minutes": 120,
       "accountable_owner": "system-quality",
-      "report_schema_version": 1
+      "report_schema_version": 2
     },
     {
       "id": "e2e.dashboard-crawl",
@@ -1252,7 +1252,7 @@
       "timeout_minutes": 120,
       "slo_minutes": 120,
       "accountable_owner": "system-quality",
-      "report_schema_version": 1
+      "report_schema_version": 2
     },
     {
       "id": "e2e.quickstart",
@@ -1306,7 +1306,7 @@
       "timeout_minutes": 25,
       "slo_minutes": 20,
       "accountable_owner": "system-quality",
-      "report_schema_version": 1
+      "report_schema_version": 2
     },
     {
       "id": "e2e.startup-bench",
@@ -1341,7 +1341,7 @@
       "timeout_minutes": 10,
       "slo_minutes": 10,
       "accountable_owner": "system-quality",
-      "report_schema_version": 1
+      "report_schema_version": 2
     },
     {
       "id": "governance.chaos-applicability",
@@ -1372,7 +1372,7 @@
       "timeout_minutes": 10,
       "slo_minutes": 10,
       "accountable_owner": "quality-platform",
-      "report_schema_version": 1
+      "report_schema_version": 2
     },
     {
       "id": "governance.forbid-deferral",
@@ -1407,7 +1407,7 @@
       "timeout_minutes": 10,
       "slo_minutes": 5,
       "accountable_owner": "quality-platform",
-      "report_schema_version": 1
+      "report_schema_version": 2
     },
     {
       "id": "governance.pr-body",
@@ -1438,7 +1438,7 @@
       "timeout_minutes": 5,
       "slo_minutes": 5,
       "accountable_owner": "quality-platform",
-      "report_schema_version": 1
+      "report_schema_version": 2
     },
     {
       "id": "governance.release-gate-drift",
@@ -1472,7 +1472,7 @@
       "timeout_minutes": 10,
       "slo_minutes": 10,
       "accountable_owner": "release-engineering",
-      "report_schema_version": 1
+      "report_schema_version": 2
     },
     {
       "id": "migration.e2e",
@@ -1518,7 +1518,7 @@
       "timeout_minutes": 120,
       "slo_minutes": 120,
       "accountable_owner": "release-engineering",
-      "report_schema_version": 1
+      "report_schema_version": 2
     },
     {
       "id": "performance.benchmark",
@@ -1561,7 +1561,7 @@
       "timeout_minutes": 60,
       "slo_minutes": 20,
       "accountable_owner": "query-quality",
-      "report_schema_version": 1
+      "report_schema_version": 2
     },
     {
       "id": "performance.profile",
@@ -1592,7 +1592,7 @@
       "timeout_minutes": 30,
       "slo_minutes": 30,
       "accountable_owner": "query-quality",
-      "report_schema_version": 1
+      "report_schema_version": 2
     },
     {
       "id": "quality.coverage-enrollment",
@@ -1623,7 +1623,7 @@
       "timeout_minutes": 60,
       "slo_minutes": 10,
       "accountable_owner": "quality-platform",
-      "report_schema_version": 1
+      "report_schema_version": 2
     },
     {
       "id": "quality.coverage-measured",
@@ -1670,7 +1670,7 @@
       "timeout_minutes": 60,
       "slo_minutes": 60,
       "accountable_owner": "quality-platform",
-      "report_schema_version": 1
+      "report_schema_version": 2
     },
     {
       "id": "quality.mutation",
@@ -1727,7 +1727,7 @@
       "timeout_minutes": 90,
       "slo_minutes": 20,
       "accountable_owner": "query-quality",
-      "report_schema_version": 1
+      "report_schema_version": 2
     },
     {
       "id": "quality.post-merge-drift",
@@ -1762,7 +1762,7 @@
       "timeout_minutes": 45,
       "slo_minutes": 45,
       "accountable_owner": "quality-platform",
-      "report_schema_version": 1
+      "report_schema_version": 2
     },
     {
       "id": "quality.property",
@@ -1802,7 +1802,7 @@
       "timeout_minutes": 30,
       "slo_minutes": 30,
       "accountable_owner": "query-quality",
-      "report_schema_version": 1
+      "report_schema_version": 2
     },
     {
       "id": "release.brew-migration",
@@ -1840,7 +1840,7 @@
       "timeout_minutes": 60,
       "slo_minutes": 60,
       "accountable_owner": "release-engineering",
-      "report_schema_version": 1
+      "report_schema_version": 2
     },
     {
       "id": "release.brew-verify",
@@ -1875,7 +1875,7 @@
       "timeout_minutes": 60,
       "slo_minutes": 60,
       "accountable_owner": "release-engineering",
-      "report_schema_version": 1
+      "report_schema_version": 2
     },
     {
       "id": "schema.ddl",
@@ -1914,7 +1914,7 @@
       "timeout_minutes": 25,
       "slo_minutes": 20,
       "accountable_owner": "system-quality",
-      "report_schema_version": 1
+      "report_schema_version": 2
     },
     {
       "id": "security.codeql",
@@ -1945,7 +1945,7 @@
       "timeout_minutes": 30,
       "slo_minutes": 20,
       "accountable_owner": "security",
-      "report_schema_version": 1
+      "report_schema_version": 2
     }
   ],
   "non_lane_workflows": [
@@ -1954,10 +1954,18 @@
       "reason": "automation"
     },
     {
+      "workflow": ".github/workflows/ci-native-evidence.yml",
+      "reason": "infrastructure"
+    },
+    {
       "workflow": ".github/workflows/dependabot-tidy-nested-modules.yml",
       "reason": "dependency_maintenance"
     },
     { "workflow": ".github/workflows/issue-label.yml", "reason": "labeling" },
+    {
+      "workflow": ".github/workflows/merge-fence.yml",
+      "reason": "infrastructure"
+    },
     {
       "workflow": ".github/workflows/mirror-images.yml",
       "reason": "infrastructure"

--- a/.github/ci-lanes.json
+++ b/.github/ci-lanes.json
@@ -17,6 +17,10 @@
       "docs/**"
     ]
   },
+  "native_evidence": {
+    "schema_version": 1,
+    "parts": []
+  },
   "layers": [
     { "id": "1", "name": "Parser smoke / AST-shape pinning" },
     { "id": "2a", "name": "chplan IR snapshots in TXTAR" },

--- a/.github/scripts/README.md
+++ b/.github/scripts/README.md
@@ -220,6 +220,55 @@ neutral/cancelled jobs, or any missing report.
 summary. Direct execution emits a GitHub `::error::` and exits non-zero on every
 contract failure.
 
+`ci-lane-backtest.mjs` is the retrospective stand-in for issue #2230's literal
+7-day / 50-SHA live shadow soak. The selector is a pure function of (base SHA,
+head SHA, registry) -> selection manifest, so it needs no live checkout to
+evaluate — this script replays `selectionPolicy()` (imported unmodified from
+`ci-lane-selection.mjs`) against real historical merged pull requests read
+from the Actions/PR REST API, and cross-checks the hypothetical new selection
+against what actually ran. It walks merged PRs against `main`, newest first,
+until it has `CI_LANE_BACKTEST_SHA_COUNT` (default 50) non-documentation final
+SHAs, fetching each one's changed-file list (`/pulls/{n}/files`) and its
+final-SHA job conclusions/durations (`/actions/runs` + `/actions/runs/{id}/
+attempts/{n}/jobs`, filtered to the registry's lane-owning workflows). Per PR
+it computes: whether every lane the OLD (always-run) system observed failing
+was still selected by the NEW selector's hypothetical choice (a coverage gap
+— an "old-only catch" — is reported, never hidden or papered over); the
+NEW-selected lanes' summed actual runner-minutes; and a wall-clock
+"required-ready" proxy (earliest job start to latest job completion among
+NEW-selected lanes, assuming unconstrained parallelism). Aggregate p50/p95
+across every non-documentation SHA are checked against the issue's own
+targets — `MERGE_P95_SLO_MINUTES` (20) for required-ready, and this script's
+own `RUNNER_P50_TARGET_MINUTES` (95) / `RUNNER_P95_TARGET_MINUTES` (160) for
+runner cost, since the registry has no other home for those two numbers.
+Deliberately out of scope: whether the new artifact-bundling / evidence
+plumbing (`ci-lane-shadow-collector.mjs`) works inside a live Actions run —
+that needs one real run, which no backtest can substitute for.
+`contextMatches()` and `jobObservationState()` are imported from
+`ci-lane-shadow-collector.mjs` so "which job backs this lane" and "was it
+green" can never drift between the live collector and this replay; the
+Actions-run discovery itself is NOT reused, because the live collector's
+strict PR-association binding exists to stop a live event from trusting a
+spoofed workflow run, a concern that does not apply to a retrospective,
+already-merged SHA looked up by its own unique head SHA.
+
+- Env: `GITHUB_REPOSITORY` (optional; parsed from `git remote get-url
+    origin` when unset), `GITHUB_TOKEN` (optional; falls back to `gh auth
+    token`), `CI_LANE_BACKTEST_SHA_COUNT` (default 50),
+    `CI_LANE_BACKTEST_MAX_PRS` (default 20x the SHA count),
+    `CI_LANE_BACKTEST_OUTPUT` (default `build/ci-lane-backtest/report.json`),
+    `CI_LANE_REGISTRY`, `GITHUB_API_URL`.
+- Exit: `0` when every target clears — required-ready p95, runner p50/p95,
+    zero coverage gaps, AND the non-documentation SHA count reaching its
+    target; `1` if any of those miss, or on an API failure. Writes the full
+    per-PR JSON report plus a `::notice::`/`::error::` summary; not (yet)
+    wired to a workflow trigger, so it is not a required status check — run
+    it on demand with `node .github/scripts/ci-lane-backtest.mjs`.
+- Tests: `ci-lane-backtest.test.mjs` (`node --test`), entirely offline —
+    synthetic registry/job fixtures pin the selected-vs-omitted coverage-gap
+    logic, the docs-only and unknown-path/fallback cases, `percentile()`'s
+    nearest-rank behaviour, and every aggregate PASS/FAIL branch.
+
 ## Modules
 
 - **`main-coalescing.mjs`** — `ci.yml` plus the enrolled deep-test workflows.

--- a/.github/scripts/chart-publish.mjs
+++ b/.github/scripts/chart-publish.mjs
@@ -4,11 +4,10 @@
 // One module, three subcommands (argv[2]):
 //
 //   version-gate
-//     Compare the local Chart.yaml `version:` against the latest chart tag
-//     already published to the OCI registry. Exits 0 and sets the
-//     `publish=true|false` step output. When the local version already exists
-//     remotely, publish=false (an app-only `v*` tag must NOT republish an
-//     unchanged chart). Otherwise publish=true.
+//     Compare the local Chart.yaml `version:` against its chart-v<version>
+//     completion tag. That tag is created only after the package, metadata,
+//     signature, and attestation all succeed. A package that reached OCI before
+//     a later writer failed therefore remains repairable on the next run.
 //
 //   push
 //     Run `helm push <tgz> oci://<repo>`, parse the pushed digest out of helm's
@@ -19,9 +18,7 @@
 //     Idempotently push the artifacthub-repo.yml as the special Artifact Hub
 //     OCI artifact via `oras`.
 //
-// argv `--self-test` runs the in-process assertion suite (pins the pure
-// `notFoundError` / `decideFromProbe` boundary, incl. the maintenance-line
-// "older than latest but absent → publish" case) and exits.
+// argv `--self-test` runs the in-process assertion suite and exits.
 //
 // Env contract (documented here, the single source of truth):
 //   CHART_DIR        path to the chart dir (default: deploy/helm/cerberus)
@@ -79,56 +76,31 @@ function ociHostPath() {
   return `${OCI_REPO.replace(/^oci:\/\//, '')}/${CHART_NAME}`;
 }
 
-// notFoundError — does a `helm show chart` failure mean a DEFINITIVE "this
-// version is not in the registry" (so it's a new version → publish), as opposed
-// to a transient/auth/registry error (which must fail CLOSED rather than risk a
-// wrong publish)? Pure string classification — exported so the self-test pins
-// the exact boundary.
-export function notFoundError(stderr) {
-  return /not found|manifest unknown|MANIFEST_UNKNOWN|NAME_UNKNOWN|no such|404|not.*exist/i.test(stderr || '');
-}
-
-// decideFromProbe — the pure chart gate. Given the `helm show chart` probe
-// result ({ status, stderr }), return { publish } | { error }. publish is true
-// ONLY when the probe DEFINITIVELY reports the chart version is absent from the
-// registry (status !== 0 AND a not-found-shaped stderr); false when the probe
-// succeeds (version already published); { error } when the probe failed for an
-// indeterminate reason (the caller must fail closed). This is the chart-side
-// twin of the app gate's tag-absent rule: publish iff the target artifact does
-// not already exist, which is idempotent and works for main, maintenance, and
-// re-runs alike. Pure: no I/O, no process.exit — so the self-test is exact.
-export function decideFromProbe({ status, stderr }) {
-  if (status === 0) return { publish: false };
-  if (notFoundError(stderr)) return { publish: true };
-  return { error: true };
+export function decideFromCompletionTags(version, existingTags) {
+  const tag = `chart-v${version}`;
+  return { publish: !existingTags.includes(tag), version, tag };
 }
 
 function versionGate() {
   const version = chartVersion();
-  const ref = `${ociHostPath()}:${version}`;
-  // `helm show chart oci://…:<version>` succeeds iff that chart version is
-  // already published. A failure (most commonly "not found") means this is a
-  // new version → publish. A maintenance hotfix whose chart version is OLDER
-  // than the latest published chart still publishes here, because the gate keys
-  // on absence-of-this-version, not newest-wins.
-  const r = run('helm', ['show', 'chart', `${OCI_REPO}/${CHART_NAME}`, '--version', version]);
-  const stderr = `${r.stdout || ''}\n${r.stderr || ''}`;
-  const d = decideFromProbe({ status: r.status, stderr });
-  if (d.error) {
-    // Fail CLOSED: a transient/auth/registry error must NOT default to
-    // publish=true (that risks republishing — or wrongly skipping — on a flaky
-    // registry). Abort.
-    ghError(`version-gate could not determine whether ${ref} exists (exit ${r.status}); failing closed rather than risk a wrong publish. stderr:\n${stderr.trim()}`);
+  const listed = run('git', ['tag', '-l', 'chart-v*']);
+  if (listed.status !== 0) {
+    ghError(`version-gate could not list chart completion tags (exit ${listed.status}): ${(listed.stderr || '').trim()}`);
     process.exit(1);
   }
+  const d = decideFromCompletionTags(
+    version,
+    (listed.stdout || '').split(/\r?\n/).map((tag) => tag.trim()).filter(Boolean),
+  );
   if (d.publish) {
-    ghNotice(`chart ${CHART_NAME} ${version} not yet published — will publish`);
+    ghNotice(`chart ${CHART_NAME} ${version} has no completion tag — will qualify or repair publication`);
     setOutput('publish', 'true');
   } else {
-    ghNotice(`chart ${CHART_NAME} ${version} already published at ${ref} — skipping publish`);
+    ghNotice(`chart ${CHART_NAME} ${version} is complete at ${d.tag} — skipping publication`);
     setOutput('publish', 'false');
   }
   setOutput('version', version);
+  setOutput('tag', d.tag);
   process.exit(0);
 }
 
@@ -137,35 +109,12 @@ function selfTest() {
     if (!c) throw new Error('self-test: ' + m);
   };
 
-  // notFoundError: definitive not-found shapes classify as absent.
-  assert(notFoundError('Error: chart not found'), 'helm not-found');
-  assert(notFoundError('manifest unknown'), 'oci manifest unknown');
-  assert(notFoundError('MANIFEST_UNKNOWN: ...'), 'oci MANIFEST_UNKNOWN code');
-  assert(notFoundError('failed: 404 Not Found'), '404');
-  assert(!notFoundError('Error: unauthorized: authentication required'), 'auth error is NOT not-found');
-  assert(!notFoundError('connection reset by peer'), 'network error is NOT not-found');
-  assert(!notFoundError(''), 'empty stderr is NOT not-found');
-
-  // decideFromProbe: published version (probe ok) -> no publish.
-  let d = decideFromProbe({ status: 0, stderr: '' });
-  assert(d.publish === false, 'probe success means already published -> no publish');
-
-  // decideFromProbe: definitive absent -> publish. THIS is the main, the
-  // maintenance, and the fresh-chart case all at once — the version simply is
-  // not in the registry yet.
-  d = decideFromProbe({ status: 1, stderr: 'Error: cerberus:0.6.4 not found' });
-  assert(d.publish === true, 'definitively absent version must publish');
-
-  // decideFromProbe: MAINTENANCE chart hotfix. A chart version OLDER than the
-  // latest published one (e.g. 0.6.3 backport while 0.7.0 is the newest) is
-  // still absent at THIS exact version -> publish. The "newest-wins" trap a
-  // greater-than comparison would fall into is structurally impossible here.
-  d = decideFromProbe({ status: 1, stderr: 'manifest unknown' });
-  assert(d.publish === true, 'tag-absent maintenance chart hotfix older than latest must still publish');
-
-  // decideFromProbe: indeterminate probe error -> fail closed (no publish flag).
-  d = decideFromProbe({ status: 1, stderr: 'unauthorized: authentication required' });
-  assert(d.error === true && d.publish === undefined, 'indeterminate error must fail closed');
+  let d = decideFromCompletionTags('0.6.4', ['chart-v0.6.3']);
+  assert(d.publish === true && d.tag === 'chart-v0.6.4', 'missing completion tag publishes');
+  d = decideFromCompletionTags('0.6.4', ['chart-v0.6.4']);
+  assert(d.publish === false, 'exact completion tag is a no-op');
+  d = decideFromCompletionTags('0.6.3', ['chart-v0.7.0']);
+  assert(d.publish === true, 'an older maintenance version without its own completion tag publishes');
 
   ghNotice('chart-publish version-gate --self-test: all assertions passed');
 }

--- a/.github/scripts/ci-lane-backtest.mjs
+++ b/.github/scripts/ci-lane-backtest.mjs
@@ -1,0 +1,712 @@
+// ci-lane-backtest.mjs — retrospective backtest of the merge-fence lane
+// selector (ci-lane-selection.mjs) against real historical pull-request CI
+// data, in place of the literal 7-day / 50-SHA live shadow soak issue #2230's
+// acceptance checklist asks for.
+//
+// Why a backtest stands in for the soak: the selector is a pure function of
+// (base SHA, head SHA, registry) -> lane-selection manifest. It needs no live
+// checkout to evaluate — `selectionPolicy()` only needs the changed-path set,
+// which GitHub's own compare view already computed for every historical PR.
+// The Actions REST API keeps run/job history far longer than 7 days (22,958+
+// completed runs observed on `main` on 2026-08-16), so replaying the new
+// selector against N historical PRs and diffing its hypothetical choices
+// against what ACTUALLY ran is strictly more evidence than waiting for N new
+// PRs to trickle in, over a wider time span than 7 days.
+//
+// What this script checks, per issue #2230's acceptance line:
+//   "require p95 <=20 minutes, runner p50 <=95 and p95 <=160 minutes, all
+//    historical signatures caught, and no old-only catches."
+//   - required-ready wall time: for each PR, the span from the earliest start
+//     to the latest completion among the lane jobs the NEW selector would
+//     have selected (a parallel-execution proxy — see renderSummary()'s
+//     header note on the assumption this makes).
+//   - runner-minutes: the sum of actual job durations for the NEW selector's
+//     selected lanes (the real GitHub-billed cost the new system would have
+//     spent).
+//   - "historical signatures caught" / "no old-only catches" are the same
+//     computational check from two angles: a lane the OLD (always-run) system
+//     observed failing (red or timed_out) on a PR whose diff the NEW selector
+//     would have omitted that lane for is a coverage gap. Zero such gaps means
+//     both phrasings hold.
+//
+// What this script deliberately does NOT check (see the PR description for
+// the follow-up): whether the new artifact-bundling / evidence-collection
+// plumbing (ci-lane-shadow-collector.mjs, ci-lane-native-evidence.mjs)
+// actually works end-to-end inside a live GitHub Actions run — permissions,
+// cross-job artifact download, etc. That needs one live run; a backtest
+// cannot exercise the runner sandbox.
+//
+// This script intentionally does NOT reuse ci-lane-shadow-collector.mjs's
+// discoverWorkflowRuns()/hydrateWorkflowRuns(): those bind a live event's
+// trusted pull_requests[] association for security (a spoofed workflow_run
+// must not be trusted as evidence for THIS PR). A retrospective replay has no
+// live event to spoof — the (workflow path, event=pull_request, head SHA)
+// tuple already uniquely identifies the historical run, so this script uses a
+// simpler, more lenient fetch. It does reuse contextMatches() and
+// jobObservationState() from that module so "which job backs this lane" and
+// "was this job green" can never drift between the live collector and this
+// backtest.
+//
+// Required environment:
+//   GITHUB_REPOSITORY   owner/repo to backtest (default: parsed from the
+//                        local `git remote get-url origin`).
+//
+// Optional environment:
+//   CI_LANE_BACKTEST_SHA_COUNT     minimum non-documentation final SHAs to
+//                                  analyze (default 50; the issue's floor).
+//   CI_LANE_BACKTEST_MAX_PRS       hard cap on merged PRs walked while
+//                                  looking for CI_LANE_BACKTEST_SHA_COUNT
+//                                  non-documentation SHAs (default 20x the
+//                                  target, so a doc-heavy stretch can't spin
+//                                  forever).
+//   CI_LANE_BACKTEST_OUTPUT        JSON report path (default
+//                                  build/ci-lane-backtest/report.json).
+//   CI_LANE_REGISTRY               registry path (default .github/ci-lanes.json).
+//   GITHUB_API_URL                 API origin (default https://api.github.com).
+//   GITHUB_TOKEN                   token with `actions: read` + `pull-requests:
+//                                  read`. Falls back to `gh auth token` when
+//                                  unset, for interactive local runs.
+//
+// Node builtins only (plus the `gh` CLI as a token fallback, invoked once,
+// never for data).
+
+import { createHash } from "node:crypto";
+import { existsSync, mkdirSync, writeFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import process from "node:process";
+import { fileURLToPath } from "node:url";
+
+import {
+  ContractError,
+  DEFAULT_REGISTRY_PATH,
+  MERGE_P95_SLO_MINUTES,
+  loadRegistry,
+  matchesGlob,
+} from "./ci-lane-contract.mjs";
+import { selectionPolicy } from "./ci-lane-selection.mjs";
+import {
+  contextMatches,
+  jobObservationState,
+} from "./ci-lane-shadow-collector.mjs";
+import { capture, error, notice, warning } from "./lib/gh.mjs";
+
+export const DEFAULT_SHA_COUNT = 50;
+export const DEFAULT_MAX_PRS_MULTIPLIER = 20;
+export const DEFAULT_API_URL = "https://api.github.com";
+export const DEFAULT_OUTPUT_PATH = "build/ci-lane-backtest/report.json";
+
+// The issue's own targets. MERGE_P95_SLO_MINUTES (20) is the registry's own
+// constant, reused rather than duplicated. The runner-minute targets have no
+// other home in the source tree; they are the literal numbers issue #2230's
+// acceptance checklist states.
+export const RUNNER_P50_TARGET_MINUTES = 95;
+export const RUNNER_P95_TARGET_MINUTES = 160;
+
+const FAILING_STATES = new Set(["red", "timed_out"]);
+
+function contract(problem) {
+  throw new ContractError("CI lane backtest", [problem]);
+}
+
+// --- pure comparison / aggregation logic (unit-tested with fixtures) ------
+
+// Nearest-rank percentile over an ALREADY-sorted-ascending array of numbers.
+// Chosen over interpolation because it never invents a value the sample
+// didn't produce, which matters when reporting a real PR's minutes as "the
+// p95".
+export function percentile(sortedAscending, p) {
+  if (sortedAscending.length === 0) return null;
+  const rank = Math.ceil((p / 100) * sortedAscending.length);
+  const index = Math.min(Math.max(rank - 1, 0), sortedAscending.length - 1);
+  return sortedAscending[index];
+}
+
+// The raw Actions REST job object carries `started_at`/`completed_at` but no
+// `duration_ms` field — this repository's ci-lane-shadow-collector.mjs
+// derives it (see normalizeJob() there); this backtest replay derives it the
+// same way rather than trusting an absent field as zero cost. A skipped job
+// with a reversed timestamp pair (documented Actions API shape for jobs
+// skipped before runner allocation) canonicalizes to zero duration, matching
+// the live collector.
+function jobDurationMS(job) {
+  if (typeof job.started_at !== "string" || typeof job.completed_at !== "string") {
+    return 0;
+  }
+  const delta = Date.parse(job.completed_at) - Date.parse(job.started_at);
+  // Clamp rather than throw: a skipped-before-allocation job's reversed pair
+  // is a documented API shape, not a data error worth failing an analytics
+  // replay over (unlike the live collector, which must fail closed on it).
+  return Number.isFinite(delta) && delta > 0 ? delta : 0;
+}
+
+function isDocsOnly(registry, changedPaths) {
+  const globs = registry.impact_selection?.known_nonimpact_globs ?? [];
+  return (
+    changedPaths.length > 0 &&
+    changedPaths.every((path) => globs.some((glob) => matchesGlob(path, glob)))
+  );
+}
+
+// jobsByWorkflow: Map<workflowPath, Array<{name,status,conclusion,
+//   started_at,completed_at,duration_ms}>> — every job this PR's final-SHA
+// workflow runs reported, across every lane-owning workflow that ran.
+export function analyzePullRequest({
+  registry,
+  number,
+  headSHA,
+  baseSHA,
+  mergeSHA,
+  mergedAt,
+  changedPaths,
+  truncatedFiles = false,
+  jobsByWorkflow,
+}) {
+  const policy = selectionPolicy(
+    registry,
+    changedPaths,
+    truncatedFiles ? "unknown_paths" : "none",
+  );
+  const laneByID = new Map(policy.lanes.map((l) => [l.lane_id, l]));
+
+  const laneRows = [];
+  for (const lane of registry.lanes) {
+    if (lane.merge_posture === "never") continue; // outside merge-fence scope
+    const laneSelection = laneByID.get(lane.id);
+    const jobs = jobsByWorkflow.get(lane.owner.workflow) ?? [];
+    const matches = jobs.filter((job) => contextMatches(lane.context, job.name));
+    let state = "missing";
+    let conclusion = null;
+    let durationMS = 0;
+    let startedAt = null;
+    let completedAt = null;
+    if (matches.length === 1) {
+      const [job] = matches;
+      if (job.status === "completed") {
+        state = jobObservationState(job).state;
+        conclusion = job.conclusion;
+        durationMS = typeof job.duration_ms === "number" ? job.duration_ms : jobDurationMS(job);
+        startedAt = job.started_at;
+        completedAt = job.completed_at;
+      } else {
+        state = "pending";
+      }
+    } else if (matches.length > 1) {
+      state = "duplicate";
+    }
+    laneRows.push({
+      lane_id: lane.id,
+      merge_posture: lane.merge_posture,
+      workflow: lane.owner.workflow,
+      new_disposition: laneSelection.disposition,
+      new_reason: laneSelection.reason,
+      observed_state: state,
+      observed_conclusion: conclusion,
+      observed_duration_ms: durationMS,
+      observed_started_at: startedAt,
+      observed_completed_at: completedAt,
+    });
+  }
+
+  const coverageGaps = laneRows
+    .filter(
+      (row) =>
+        row.new_disposition === "omitted" && FAILING_STATES.has(row.observed_state),
+    )
+    .map((row) => ({
+      lane_id: row.lane_id,
+      new_reason: row.new_reason,
+      observed_state: row.observed_state,
+      observed_conclusion: row.observed_conclusion,
+    }));
+
+  const selectedRows = laneRows.filter((row) => row.new_disposition === "selected");
+  const selectedDurationMinutes =
+    selectedRows.reduce((sum, row) => sum + row.observed_duration_ms, 0) / 60000;
+
+  const starts = selectedRows
+    .map((row) => row.observed_started_at)
+    .filter((value) => typeof value === "string")
+    .map((value) => Date.parse(value));
+  const completions = selectedRows
+    .map((row) => row.observed_completed_at)
+    .filter((value) => typeof value === "string")
+    .map((value) => Date.parse(value));
+  const wallClockMinutes =
+    starts.length > 0 && completions.length > 0
+      ? (Math.max(...completions) - Math.min(...starts)) / 60000
+      : null;
+
+  return {
+    number,
+    headSHA,
+    baseSHA,
+    mergeSHA,
+    mergedAt,
+    docsOnly: isDocsOnly(registry, changedPaths),
+    selectorConclusion: policy.conclusion,
+    fallbackReason: policy.fallbackReason,
+    changedPathCount: changedPaths.length,
+    // Paths that matched no conditional lane's package_globs and no
+    // known_nonimpact_glob — the reason a "none" fallbackReason PR can still
+    // fall back (selectionPolicy promotes an empty unknownPaths list's
+    // absence to "unknown_paths"). Surfaced so a registry glob-coverage gap
+    // (a real path class no conditional lane claims) is visible in the
+    // report rather than only showing up as an unexplained fallback rate.
+    unknownPaths: policy.unknownPaths,
+    laneRows,
+    coverageGaps,
+    selectedDurationMinutes,
+    wallClockMinutes,
+  };
+}
+
+export function aggregateBacktest(analyses, { minSHACount = DEFAULT_SHA_COUNT } = {}) {
+  const nonDoc = analyses.filter((a) => !a.docsOnly);
+  const docOnlyCount = analyses.length - nonDoc.length;
+  const settled = nonDoc.filter((a) => a.wallClockMinutes !== null);
+  const wallClock = settled.map((a) => a.wallClockMinutes).sort((a, b) => a - b);
+  const runnerMinutes = settled
+    .map((a) => a.selectedDurationMinutes)
+    .sort((a, b) => a - b);
+  const coverageGaps = nonDoc.flatMap((a) =>
+    a.coverageGaps.map((gap) => ({
+      pr: a.number,
+      head_sha: a.headSHA,
+      merged_at: a.mergedAt,
+      ...gap,
+    })),
+  );
+
+  const fallbackFullCount = nonDoc.filter(
+    (a) => a.selectorConclusion === "fallback_full",
+  ).length;
+  // Registry glob-coverage diagnostic: which repository-relative directories
+  // most often appear in an "unknown_paths" fallback. A path only lands here
+  // when it matched NEITHER a conditional lane's package_globs NOR a
+  // known_nonimpact_glob — i.e. no lane in the registry claims it, so the
+  // selector fails closed. A directory dominating this list is a real
+  // registry coverage gap, not a backtest artifact: it means impact selection
+  // can never narrow the fence for that class of change.
+  const unknownPathPrefixCounts = new Map();
+  for (const analysis of nonDoc) {
+    for (const path of analysis.unknownPaths ?? []) {
+      const prefix = path.split("/").slice(0, 2).join("/");
+      unknownPathPrefixCounts.set(prefix, (unknownPathPrefixCounts.get(prefix) ?? 0) + 1);
+    }
+  }
+  const topUnknownPathPrefixes = [...unknownPathPrefixCounts.entries()]
+    .sort(([, a], [, b]) => b - a)
+    .slice(0, 10)
+    .map(([prefix, count]) => ({ prefix, count }));
+
+  const requiredReadyP50 = percentile(wallClock, 50);
+  const requiredReadyP95 = percentile(wallClock, 95);
+  const runnerP50 = percentile(runnerMinutes, 50);
+  const runnerP95 = percentile(runnerMinutes, 95);
+
+  const verdict = {
+    sha_count_ok: nonDoc.length >= minSHACount,
+    required_ready_p95_ok:
+      requiredReadyP95 !== null && requiredReadyP95 <= MERGE_P95_SLO_MINUTES,
+    runner_p50_ok: runnerP50 !== null && runnerP50 <= RUNNER_P50_TARGET_MINUTES,
+    runner_p95_ok: runnerP95 !== null && runnerP95 <= RUNNER_P95_TARGET_MINUTES,
+    zero_old_only_catches: coverageGaps.length === 0,
+  };
+  const pass = Object.values(verdict).every(Boolean);
+
+  const mergedAtValues = nonDoc.map((a) => a.mergedAt).filter(Boolean).sort();
+  const spanDays =
+    mergedAtValues.length >= 2
+      ? (Date.parse(mergedAtValues[mergedAtValues.length - 1]) -
+          Date.parse(mergedAtValues[0])) /
+        (24 * 60 * 60 * 1000)
+      : 0;
+
+  return {
+    totalPRs: analyses.length,
+    nonDocCount: nonDoc.length,
+    docOnlyCount,
+    settledCount: settled.length,
+    unsettledCount: nonDoc.length - settled.length,
+    spanDays,
+    fallbackFullCount,
+    topUnknownPathPrefixes,
+    requiredReadyP50,
+    requiredReadyP95,
+    runnerP50,
+    runnerP95,
+    coverageGaps,
+    verdict: { ...verdict, pass },
+  };
+}
+
+function fmtMinutes(value) {
+  return value === null ? "n/a" : value.toFixed(1);
+}
+
+export function renderSummary(report) {
+  const lines = [];
+  lines.push("# CI lane-selection backtest");
+  lines.push("");
+  lines.push(
+    "Retrospective replay of the new merge-fence selector against real historical " +
+      "pull-request CI data (see issue #2230's shadow-soak acceptance line). " +
+      "The wall-clock \"required-ready\" figure below assumes every selected lane " +
+      "could start immediately and run in parallel — an optimistic proxy for the " +
+      "real merge-fence critical path, since it ignores runner-availability queuing.",
+  );
+  lines.push("");
+  lines.push(
+    `- Merged PRs walked: ${report.totalPRs} (${report.docOnlyCount} documentation-only, excluded from the gate)`,
+  );
+  lines.push(
+    `- Non-documentation final SHAs analyzed: ${report.nonDocCount} (target >= ${DEFAULT_SHA_COUNT}), spanning ${report.spanDays.toFixed(1)} days`,
+  );
+  if (report.unsettledCount > 0) {
+    lines.push(
+      `- ${report.unsettledCount} non-documentation SHA(s) had no measurable selected-lane job timing and were excluded from the percentile stats`,
+    );
+  }
+  lines.push(
+    `- Selector fell back to the full lane set on ${report.fallbackFullCount}/${report.nonDocCount} SHAs (an unknown-path or empty-diff fallback selects every conditional lane, same as the old always-run system)`,
+  );
+  if (report.topUnknownPathPrefixes.length > 0) {
+    lines.push("");
+    lines.push(
+      "Directories most often driving that fallback (no conditional lane's package_globs, and no known_nonimpact_glob, claims them — a registry glob-coverage gap, not a backtest artifact):",
+    );
+    for (const { prefix, count } of report.topUnknownPathPrefixes) {
+      lines.push(`  - \`${prefix}\` — ${count} occurrence(s)`);
+    }
+  }
+  lines.push("");
+  lines.push("| Metric | p50 | p95 | Target | Status |");
+  lines.push("| --- | --- | --- | --- | --- |");
+  lines.push(
+    `| Required-ready wall time (min) | ${fmtMinutes(report.requiredReadyP50)} | ${fmtMinutes(report.requiredReadyP95)} | p95 <= ${MERGE_P95_SLO_MINUTES} | ${report.verdict.required_ready_p95_ok ? "PASS" : "FAIL"} |`,
+  );
+  lines.push(
+    `| Runner-minutes | ${fmtMinutes(report.runnerP50)} | ${fmtMinutes(report.runnerP95)} | p50 <= ${RUNNER_P50_TARGET_MINUTES}, p95 <= ${RUNNER_P95_TARGET_MINUTES} | ${report.verdict.runner_p50_ok && report.verdict.runner_p95_ok ? "PASS" : "FAIL"} |`,
+  );
+  lines.push("");
+  lines.push(
+    `Coverage (historical signatures caught / no old-only catches): ${report.verdict.zero_old_only_catches ? "PASS" : `FAIL — ${report.coverageGaps.length} gap(s)`}`,
+  );
+  if (report.coverageGaps.length > 0) {
+    lines.push("");
+    lines.push("| PR | head SHA | lane | omission reason | observed |");
+    lines.push("| --- | --- | --- | --- | --- |");
+    for (const gap of report.coverageGaps) {
+      lines.push(
+        `| #${gap.pr} | ${gap.head_sha.slice(0, 12)} | ${gap.lane_id} | ${gap.new_reason} | ${gap.observed_state}/${gap.observed_conclusion} |`,
+      );
+    }
+  }
+  lines.push("");
+  lines.push(`Overall: ${report.verdict.pass ? "PASS" : "FAIL"}`);
+  return lines.join("\n");
+}
+
+// --- network layer (thin; not unit-tested directly — see the .test.mjs for
+// the injected-requestJSON coverage of the orchestration these call into) ---
+
+function resolveRepository(env) {
+  const fromEnv = String(env.GITHUB_REPOSITORY ?? "").trim();
+  if (fromEnv !== "") return fromEnv;
+  const remote = capture("git", ["remote", "get-url", "origin"]);
+  if (remote.status !== 0) {
+    contract(
+      "GITHUB_REPOSITORY is unset and `git remote get-url origin` failed: " +
+        remote.stderr.trim(),
+    );
+  }
+  const url = remote.stdout.trim();
+  // scp-like syntax ([user@]host:owner/repo(.git)?) — host may be a local SSH
+  // config alias (e.g. `github.com-tsouza`), not literally `github.com`, so
+  // this does not require or validate the host at all: the owner/repo pair is
+  // always the last colon-delimited path segment.
+  const scpLike = /^[^/]+:([^/]+\/[^/]+?)(?:\.git)?$/.exec(url);
+  // scheme://[user@]host/owner/repo(.git)?
+  const urlLike = /^[a-z][a-z0-9+.-]*:\/\/[^/]+\/([^/]+\/[^/]+?)(?:\.git)?$/.exec(url);
+  const match = scpLike ?? urlLike;
+  if (!match) {
+    contract(
+      `GITHUB_REPOSITORY is unset and the origin remote URL could not be parsed: ${url}`,
+    );
+  }
+  return match[1];
+}
+
+function resolveToken(env) {
+  const fromEnv = String(env.GITHUB_TOKEN ?? "").trim();
+  if (fromEnv !== "") return fromEnv;
+  const fromGH = capture("gh", ["auth", "token"]);
+  if (fromGH.status !== 0 || fromGH.stdout.trim() === "") {
+    contract(
+      "GITHUB_TOKEN is unset and `gh auth token` failed; set GITHUB_TOKEN or run `gh auth login`",
+    );
+  }
+  return fromGH.stdout.trim();
+}
+
+function githubRequest({ token, apiBase }) {
+  return async (url) => {
+    const response = await fetch(url, {
+      headers: {
+        Accept: "application/vnd.github+json",
+        Authorization: `Bearer ${token}`,
+        "X-GitHub-Api-Version": "2022-11-28",
+      },
+    });
+    if (!response.ok) {
+      const remaining = response.headers.get("x-ratelimit-remaining");
+      contract(
+        `GitHub API ${response.status} for ${new URL(url).pathname} (rate-limit remaining: ${remaining ?? "unknown"})`,
+      );
+    }
+    return response.json();
+  };
+}
+
+function pagedURL(apiBase, pathname, query, page, perPage = 100) {
+  const url = new URL(pathname, `${apiBase.replace(/\/$/, "")}/`);
+  for (const [name, value] of Object.entries(query)) {
+    url.searchParams.set(name, String(value));
+  }
+  url.searchParams.set("per_page", String(perPage));
+  url.searchParams.set("page", String(page));
+  return url.toString();
+}
+
+// Paginate a GitHub REST list endpoint. `field` is null for the endpoints
+// that return a bare JSON array (`/pulls`, `/pulls/{n}/files`); the Actions
+// endpoints (`/actions/runs`, `/actions/runs/{id}/attempts/{n}/jobs`) instead
+// wrap the array in `{ total_count, <field>: [...] }`.
+async function paginatedArray({
+  requestJSON,
+  buildURL,
+  field = null,
+  perPage = 100,
+  maxPages = 30,
+}) {
+  const rows = [];
+  let truncated = false;
+  for (let page = 1; page <= maxPages; page += 1) {
+    const document = await requestJSON(buildURL(page));
+    const batch = field === null ? document : document?.[field];
+    if (!Array.isArray(batch)) {
+      contract(`expected a JSON array response${field ? ` at field "${field}"` : ""}`);
+    }
+    rows.push(...batch);
+    if (batch.length < perPage) return { rows, truncated };
+  }
+  truncated = true;
+  return { rows, truncated };
+}
+
+async function fetchMergedPullRequests({ requestJSON, apiBase, repository, page }) {
+  const url = pagedURL(
+    apiBase,
+    `/repos/${repository}/pulls`,
+    { base: "main", state: "closed", sort: "updated", direction: "desc" },
+    page,
+  );
+  const batch = await requestJSON(url);
+  if (!Array.isArray(batch)) contract("expected a JSON array response for /pulls");
+  return { merged: batch.filter((pr) => pr.merged_at != null), rawLength: batch.length };
+}
+
+async function fetchChangedPaths({ requestJSON, apiBase, repository, number }) {
+  const { rows, truncated } = await paginatedArray({
+    requestJSON,
+    buildURL: (page) =>
+      pagedURL(apiBase, `/repos/${repository}/pulls/${number}/files`, {}, page),
+    maxPages: 30,
+  });
+  const paths = new Set();
+  for (const entry of rows) {
+    if (typeof entry.filename === "string") paths.add(entry.filename);
+    if (typeof entry.previous_filename === "string") paths.add(entry.previous_filename);
+  }
+  return { changedPaths: [...paths].sort(), truncatedFiles: truncated };
+}
+
+async function fetchJobsByWorkflow({
+  requestJSON,
+  apiBase,
+  repository,
+  headSHA,
+  workflowPaths,
+}) {
+  const { rows: candidateRuns } = await paginatedArray({
+    requestJSON,
+    field: "workflow_runs",
+    buildURL: (page) =>
+      pagedURL(
+        apiBase,
+        `/repos/${repository}/actions/runs`,
+        { event: "pull_request", head_sha: headSHA },
+        page,
+      ),
+    maxPages: 10,
+  });
+  const wanted = new Set(workflowPaths);
+  const newestByWorkflow = new Map();
+  for (const run of candidateRuns) {
+    if (!wanted.has(run.path) || run.head_sha !== headSHA) continue;
+    const previous = newestByWorkflow.get(run.path);
+    if (!previous || run.run_attempt > previous.run_attempt) {
+      newestByWorkflow.set(run.path, run);
+    }
+  }
+  const jobsByWorkflow = new Map();
+  for (const [workflow, run] of newestByWorkflow) {
+    const { rows: jobs } = await paginatedArray({
+      requestJSON,
+      field: "jobs",
+      buildURL: (page) =>
+        pagedURL(
+          apiBase,
+          `/repos/${repository}/actions/runs/${run.id}/attempts/${run.run_attempt}/jobs`,
+          { filter: "all" },
+          page,
+        ),
+      maxPages: 10,
+    });
+    jobsByWorkflow.set(workflow, jobs);
+  }
+  return jobsByWorkflow;
+}
+
+export async function runBacktest({
+  registry,
+  requestJSON,
+  apiBase,
+  repository,
+  shaCount,
+  maxPRs,
+}) {
+  const workflowPaths = [...new Set(registry.lanes.map((lane) => lane.owner.workflow))];
+  const analyses = [];
+  let nonDocCount = 0;
+  let apiPage = 1;
+  let scanned = 0;
+  for (;;) {
+    if (nonDocCount >= shaCount || scanned >= maxPRs) break;
+    const { merged, rawLength } = await fetchMergedPullRequests({
+      requestJSON,
+      apiBase,
+      repository,
+      page: apiPage,
+    });
+    apiPage += 1;
+    for (const pr of merged) {
+      if (scanned >= maxPRs || nonDocCount >= shaCount) break;
+      scanned += 1;
+      const { changedPaths, truncatedFiles } = await fetchChangedPaths({
+        requestJSON,
+        apiBase,
+        repository,
+        number: pr.number,
+      });
+      const jobsByWorkflow = await fetchJobsByWorkflow({
+        requestJSON,
+        apiBase,
+        repository,
+        headSHA: pr.head.sha,
+        workflowPaths,
+      });
+      const analysis = analyzePullRequest({
+        registry,
+        number: pr.number,
+        headSHA: pr.head.sha,
+        baseSHA: pr.base.sha,
+        mergeSHA: pr.merge_commit_sha,
+        mergedAt: pr.merged_at,
+        changedPaths,
+        truncatedFiles,
+        jobsByWorkflow,
+      });
+      analyses.push(analysis);
+      if (!analysis.docsOnly) nonDocCount += 1;
+    }
+    if (rawLength < 100) break; // exhausted the repository's closed-PR list
+  }
+  return analyses;
+}
+
+async function main(env = process.env) {
+  const root = resolve(process.cwd());
+  const registry = loadRegistry(env.CI_LANE_REGISTRY || DEFAULT_REGISTRY_PATH, {
+    root,
+  });
+  const repository = resolveRepository(env);
+  const token = resolveToken(env);
+  const apiBase = env.GITHUB_API_URL || DEFAULT_API_URL;
+  const requestJSON = githubRequest({ token, apiBase });
+  const shaCount = Number(env.CI_LANE_BACKTEST_SHA_COUNT || DEFAULT_SHA_COUNT);
+  const maxPRs = Number(
+    env.CI_LANE_BACKTEST_MAX_PRS || shaCount * DEFAULT_MAX_PRS_MULTIPLIER,
+  );
+  if (!Number.isSafeInteger(shaCount) || shaCount < 1) {
+    contract("CI_LANE_BACKTEST_SHA_COUNT must be a positive integer");
+  }
+  if (!Number.isSafeInteger(maxPRs) || maxPRs < shaCount) {
+    contract("CI_LANE_BACKTEST_MAX_PRS must be a positive integer >= the SHA count");
+  }
+
+  notice(
+    `Backtesting the merge-fence selector against ${repository} — target ${shaCount} non-documentation final SHAs (cap ${maxPRs} PRs walked)`,
+  );
+  const analyses = await runBacktest({
+    registry,
+    requestJSON,
+    apiBase,
+    repository,
+    shaCount,
+    maxPRs,
+  });
+  const report = aggregateBacktest(analyses, { minSHACount: shaCount });
+  const summary = renderSummary(report);
+
+  const outputPath = resolve(root, env.CI_LANE_BACKTEST_OUTPUT || DEFAULT_OUTPUT_PATH);
+  const parent = dirname(outputPath);
+  if (!existsSync(parent)) mkdirSync(parent, { recursive: true });
+  const document = { ...report, analyses, generated_at: new Date().toISOString() };
+  const body = `${JSON.stringify(document, null, 2)}\n`;
+  writeFileSync(outputPath, body, "utf8");
+  notice(
+    `Wrote ${outputPath} (sha256 ${createHash("sha256").update(body).digest("hex").slice(0, 12)})`,
+  );
+
+  process.stdout.write(`${summary}\n`);
+  if (!report.verdict.sha_count_ok) {
+    warning(
+      `Only found ${report.nonDocCount} non-documentation final SHAs (target ${shaCount}); ` +
+        "widen CI_LANE_BACKTEST_MAX_PRS or accept a smaller sample",
+    );
+  }
+  if (report.verdict.pass) {
+    notice("CI lane-selection backtest: PASS against every issue #2230 acceptance target");
+  } else {
+    error(
+      `CI lane-selection backtest: FAIL — ${JSON.stringify(report.verdict)}`,
+      { title: "merge-fence backtest did not clear the shadow-soak bar" },
+    );
+    process.exitCode = 1;
+  }
+}
+
+const invokedDirectly =
+  process.argv[1] && fileURLToPath(import.meta.url) === resolve(process.argv[1]);
+if (invokedDirectly) {
+  try {
+    await main();
+  } catch (backtestError) {
+    error(
+      backtestError instanceof Error ? backtestError.message : String(backtestError),
+      { title: "merge-fence backtest failed to run" },
+    );
+    process.exit(1);
+  }
+}

--- a/.github/scripts/ci-lane-backtest.test.mjs
+++ b/.github/scripts/ci-lane-backtest.test.mjs
@@ -1,0 +1,406 @@
+// Negative controls for the CI lane-selection backtest's comparison and
+// aggregation logic. Entirely offline — synthetic registry/job fixtures only,
+// no network access, matching this repo's ".mjs" test convention (node --test,
+// no external framework).
+
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { MERGE_P95_SLO_MINUTES } from "./ci-lane-contract.mjs";
+import {
+  DEFAULT_SHA_COUNT,
+  RUNNER_P50_TARGET_MINUTES,
+  RUNNER_P95_TARGET_MINUTES,
+  aggregateBacktest,
+  analyzePullRequest,
+  percentile,
+  renderSummary,
+} from "./ci-lane-backtest.mjs";
+
+const sha = (character) => character.repeat(40);
+
+function lane({ id, mergePosture, workflow, contextName, packageGlobs }) {
+  return {
+    id,
+    merge_posture: mergePosture,
+    executions: ["default"],
+    owner: { workflow },
+    context: { match: "exact", name: contextName, protected: false },
+    package_globs: packageGlobs,
+  };
+}
+
+function registryFixture() {
+  return {
+    impact_selection: { known_nonimpact_globs: ["**/*.md", "docs/**"] },
+    lanes: [
+      lane({
+        id: "core.always",
+        mergePosture: "always",
+        workflow: ".github/workflows/ci.yml",
+        contextName: "check",
+        packageGlobs: ["**"],
+      }),
+      lane({
+        id: "quality.mutation",
+        mergePosture: "impact",
+        workflow: ".github/workflows/mutation.yml",
+        contextName: "mutation",
+        packageGlobs: ["internal/mutation/**"],
+      }),
+      lane({
+        id: "schema.ddl",
+        mergePosture: "impact",
+        workflow: ".github/workflows/schema-integration.yml",
+        contextName: "schema-ddl",
+        packageGlobs: ["internal/schema/**"],
+      }),
+      lane({
+        id: "e2e.full",
+        mergePosture: "never",
+        workflow: ".github/workflows/e2e.yml",
+        contextName: "e2e",
+        packageGlobs: ["**"],
+      }),
+    ],
+  };
+}
+
+function job({
+  name,
+  status = "completed",
+  conclusion = "success",
+  startedAt,
+  completedAt,
+  durationMS,
+}) {
+  return {
+    name,
+    status,
+    conclusion,
+    started_at: startedAt,
+    completed_at: completedAt,
+    duration_ms: durationMS,
+  };
+}
+
+test("analyzePullRequest: a lane the new selector selects is never a coverage gap even when it failed", () => {
+  const registry = registryFixture();
+  const analysis = analyzePullRequest({
+    registry,
+    number: 100,
+    headSHA: sha("a"),
+    baseSHA: sha("b"),
+    mergeSHA: sha("c"),
+    mergedAt: "2026-06-01T00:00:00Z",
+    changedPaths: ["internal/mutation/gremlin.go"],
+    jobsByWorkflow: new Map([
+      [
+        ".github/workflows/ci.yml",
+        [job({ name: "check", startedAt: "2026-06-01T00:00:00Z", completedAt: "2026-06-01T00:05:00Z", durationMS: 300000 })],
+      ],
+      [
+        ".github/workflows/mutation.yml",
+        [
+          job({
+            name: "mutation",
+            conclusion: "failure",
+            startedAt: "2026-06-01T00:00:00Z",
+            completedAt: "2026-06-01T00:10:00Z",
+            durationMS: 600000,
+          }),
+        ],
+      ],
+    ]),
+  });
+  assert.deepEqual(analysis.coverageGaps, []);
+  assert.equal(analysis.selectedDurationMinutes, 15);
+  assert.equal(analysis.wallClockMinutes, 10);
+  assert.equal(analysis.docsOnly, false);
+  const mutationRow = analysis.laneRows.find((row) => row.lane_id === "quality.mutation");
+  assert.equal(mutationRow.new_disposition, "selected");
+  assert.equal(mutationRow.observed_state, "red");
+});
+
+test("analyzePullRequest: an omitted lane that historically failed is an old-only catch", () => {
+  const registry = registryFixture();
+  const analysis = analyzePullRequest({
+    registry,
+    number: 101,
+    headSHA: sha("d"),
+    baseSHA: sha("e"),
+    mergeSHA: sha("f"),
+    mergedAt: "2026-07-01T00:00:00Z",
+    // Touches only schema.ddl's surface — quality.mutation's glob does not
+    // match, and the path is still "known" via schema.ddl's conditional
+    // glob, so the selector omits mutation cleanly rather than falling back.
+    changedPaths: ["internal/schema/columns.go"],
+    jobsByWorkflow: new Map([
+      [
+        ".github/workflows/ci.yml",
+        [job({ name: "check", startedAt: "2026-07-01T00:00:00Z", completedAt: "2026-07-01T00:03:00Z", durationMS: 180000 })],
+      ],
+      [
+        ".github/workflows/schema-integration.yml",
+        [job({ name: "schema-ddl", startedAt: "2026-07-01T00:00:00Z", completedAt: "2026-07-01T00:02:00Z", durationMS: 120000 })],
+      ],
+      [
+        ".github/workflows/mutation.yml",
+        [
+          job({
+            name: "mutation",
+            conclusion: "failure",
+            startedAt: "2026-07-01T00:00:00Z",
+            completedAt: "2026-07-01T00:20:00Z",
+            durationMS: 1200000,
+          }),
+        ],
+      ],
+    ]),
+  });
+  assert.equal(analysis.coverageGaps.length, 1);
+  assert.equal(analysis.coverageGaps[0].lane_id, "quality.mutation");
+  assert.equal(analysis.coverageGaps[0].observed_state, "red");
+  // The old-only-caught lane's cost must NOT count toward the new system's
+  // hypothetical runner-minutes — it would not have run.
+  assert.equal(analysis.selectedDurationMinutes, 5);
+});
+
+test("analyzePullRequest: a lane the old system skipped is not a coverage gap", () => {
+  const registry = registryFixture();
+  const analysis = analyzePullRequest({
+    registry,
+    number: 102,
+    headSHA: sha("1"),
+    baseSHA: sha("2"),
+    mergeSHA: sha("3"),
+    mergedAt: "2026-07-02T00:00:00Z",
+    changedPaths: ["internal/schema/columns.go"],
+    jobsByWorkflow: new Map([
+      [
+        ".github/workflows/ci.yml",
+        [job({ name: "check", startedAt: "2026-07-02T00:00:00Z", completedAt: "2026-07-02T00:03:00Z", durationMS: 180000 })],
+      ],
+      [
+        ".github/workflows/schema-integration.yml",
+        [job({ name: "schema-ddl", startedAt: "2026-07-02T00:00:00Z", completedAt: "2026-07-02T00:02:00Z", durationMS: 120000 })],
+      ],
+      [
+        ".github/workflows/mutation.yml",
+        [job({ name: "mutation", status: "completed", conclusion: "skipped", startedAt: "2026-07-02T00:00:00Z", completedAt: "2026-07-02T00:00:00Z", durationMS: 0 })],
+      ],
+    ]),
+  });
+  assert.deepEqual(analysis.coverageGaps, []);
+});
+
+test("analyzePullRequest: an unknown path falls back to selecting every conditional lane", () => {
+  const registry = registryFixture();
+  const analysis = analyzePullRequest({
+    registry,
+    number: 103,
+    headSHA: sha("4"),
+    baseSHA: sha("5"),
+    mergeSHA: sha("6"),
+    mergedAt: "2026-07-03T00:00:00Z",
+    changedPaths: ["internal/unclassified/thing.go"],
+    jobsByWorkflow: new Map(),
+  });
+  assert.equal(analysis.selectorConclusion, "fallback_full");
+  assert.equal(analysis.fallbackReason, "unknown_paths");
+  assert.deepEqual(analysis.unknownPaths, ["internal/unclassified/thing.go"]);
+  const rows = new Map(analysis.laneRows.map((row) => [row.lane_id, row]));
+  assert.equal(rows.get("quality.mutation").new_disposition, "selected");
+  assert.equal(rows.get("schema.ddl").new_disposition, "selected");
+});
+
+test("analyzePullRequest: a docs-only diff is flagged and never a coverage gap", () => {
+  const registry = registryFixture();
+  const analysis = analyzePullRequest({
+    registry,
+    number: 104,
+    headSHA: sha("7"),
+    baseSHA: sha("8"),
+    mergeSHA: sha("9"),
+    mergedAt: "2026-07-04T00:00:00Z",
+    changedPaths: ["docs/readme.md"],
+    jobsByWorkflow: new Map(),
+  });
+  assert.equal(analysis.docsOnly, true);
+  assert.deepEqual(analysis.coverageGaps, []);
+});
+
+test("analyzePullRequest: a truncated file list (API's 3000-file cap) treats paths as unknown", () => {
+  const registry = registryFixture();
+  const analysis = analyzePullRequest({
+    registry,
+    number: 105,
+    headSHA: sha("a1"),
+    baseSHA: sha("b1"),
+    mergeSHA: sha("c1"),
+    mergedAt: "2026-07-05T00:00:00Z",
+    changedPaths: ["internal/schema/columns.go"],
+    truncatedFiles: true,
+    jobsByWorkflow: new Map(),
+  });
+  assert.equal(analysis.selectorConclusion, "fallback_full");
+  assert.equal(analysis.fallbackReason, "unknown_paths");
+});
+
+test("analyzePullRequest: 'never' merge-posture lanes are outside merge-fence scope", () => {
+  const registry = registryFixture();
+  const analysis = analyzePullRequest({
+    registry,
+    number: 106,
+    headSHA: sha("d1"),
+    baseSHA: sha("e1"),
+    mergeSHA: sha("f1"),
+    mergedAt: "2026-07-06T00:00:00Z",
+    changedPaths: ["internal/schema/columns.go"],
+    jobsByWorkflow: new Map(),
+  });
+  assert.ok(!analysis.laneRows.some((row) => row.lane_id === "e2e.full"));
+});
+
+test("percentile: nearest-rank over sorted input, and null on an empty sample", () => {
+  assert.equal(percentile([], 95), null);
+  assert.equal(percentile([10], 50), 10);
+  assert.equal(percentile([10], 95), 10);
+  const sorted = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
+  assert.equal(percentile(sorted, 50), 5);
+  assert.equal(percentile(sorted, 95), 10);
+});
+
+function baseAnalysis(overrides) {
+  return {
+    number: 1,
+    headSHA: sha("1"),
+    mergedAt: "2026-06-01T00:00:00Z",
+    docsOnly: false,
+    coverageGaps: [],
+    selectedDurationMinutes: 10,
+    wallClockMinutes: 5,
+    ...overrides,
+  };
+}
+
+test("aggregateBacktest: PASS when every target clears and there are zero gaps", () => {
+  const analyses = [
+    baseAnalysis({ number: 1, mergedAt: "2026-06-01T00:00:00Z", selectedDurationMinutes: 50, wallClockMinutes: 10 }),
+    baseAnalysis({ number: 2, mergedAt: "2026-07-01T00:00:00Z", selectedDurationMinutes: 60, wallClockMinutes: 12 }),
+  ];
+  const report = aggregateBacktest(analyses, { minSHACount: 2 });
+  assert.equal(report.verdict.sha_count_ok, true);
+  assert.equal(report.verdict.required_ready_p95_ok, true);
+  assert.equal(report.verdict.runner_p50_ok, true);
+  assert.equal(report.verdict.runner_p95_ok, true);
+  assert.equal(report.verdict.zero_old_only_catches, true);
+  assert.equal(report.verdict.pass, true);
+  assert.equal(report.docOnlyCount, 0);
+  assert.ok(report.spanDays > 0);
+});
+
+test("aggregateBacktest: FAIL when a coverage gap exists, independent of performance", () => {
+  const analyses = [
+    baseAnalysis({
+      number: 1,
+      coverageGaps: [{ lane_id: "quality.mutation", new_reason: "not_impacted", observed_state: "red", observed_conclusion: "failure" }],
+    }),
+  ];
+  const report = aggregateBacktest(analyses, { minSHACount: 1 });
+  assert.equal(report.verdict.zero_old_only_catches, false);
+  assert.equal(report.verdict.pass, false);
+  assert.equal(report.coverageGaps.length, 1);
+  assert.equal(report.coverageGaps[0].pr, 1);
+});
+
+test("aggregateBacktest: FAIL when runner-minutes p95 exceeds its target", () => {
+  const analyses = Array.from({ length: 20 }, (_, i) =>
+    baseAnalysis({ number: i, selectedDurationMinutes: 200, wallClockMinutes: 5 }),
+  );
+  const report = aggregateBacktest(analyses, { minSHACount: 20 });
+  assert.equal(report.verdict.runner_p50_ok, false);
+  assert.equal(report.verdict.runner_p95_ok, false);
+  assert.equal(report.verdict.pass, false);
+});
+
+test("aggregateBacktest: FAIL when required-ready wall time p95 exceeds its target", () => {
+  const analyses = Array.from({ length: 20 }, (_, i) =>
+    baseAnalysis({ number: i, selectedDurationMinutes: 10, wallClockMinutes: 30 }),
+  );
+  const report = aggregateBacktest(analyses, { minSHACount: 20 });
+  assert.equal(report.verdict.required_ready_p95_ok, false);
+  assert.equal(report.verdict.pass, false);
+});
+
+test("aggregateBacktest: FAIL when fewer than the target non-documentation SHAs were found", () => {
+  const analyses = [baseAnalysis({ number: 1 })];
+  const report = aggregateBacktest(analyses, { minSHACount: 50 });
+  assert.equal(report.verdict.sha_count_ok, false);
+  assert.equal(report.verdict.pass, false);
+  assert.equal(report.nonDocCount, 1);
+});
+
+test("aggregateBacktest: documentation-only SHAs neither count toward the target nor pollute the percentiles", () => {
+  const analyses = [
+    baseAnalysis({ number: 1, docsOnly: true, selectedDurationMinutes: 99999, wallClockMinutes: 99999 }),
+    baseAnalysis({ number: 2, selectedDurationMinutes: 10, wallClockMinutes: 5 }),
+  ];
+  const report = aggregateBacktest(analyses, { minSHACount: 1 });
+  assert.equal(report.nonDocCount, 1);
+  assert.equal(report.docOnlyCount, 1);
+  assert.equal(report.runnerP95, 10);
+  assert.equal(report.requiredReadyP95, 5);
+});
+
+test("aggregateBacktest: a SHA with no measurable job timing is excluded from percentiles, not treated as zero", () => {
+  const analyses = [
+    baseAnalysis({ number: 1, selectedDurationMinutes: 0, wallClockMinutes: null }),
+    baseAnalysis({ number: 2, selectedDurationMinutes: 10, wallClockMinutes: 5 }),
+  ];
+  const report = aggregateBacktest(analyses, { minSHACount: 2 });
+  assert.equal(report.settledCount, 1);
+  assert.equal(report.unsettledCount, 1);
+  assert.equal(report.requiredReadyP50, 5);
+});
+
+test("aggregateBacktest: tallies the fallback rate and the directories driving unknown-path fallbacks", () => {
+  const analyses = [
+    baseAnalysis({
+      number: 1,
+      selectorConclusion: "fallback_full",
+      unknownPaths: [".github/scripts/foo.mjs", ".github/scripts/bar.mjs"],
+    }),
+    baseAnalysis({
+      number: 2,
+      selectorConclusion: "fallback_full",
+      unknownPaths: [".github/scripts/baz.mjs", ".github/workflows/qux.yml"],
+    }),
+    baseAnalysis({ number: 3, selectorConclusion: "success", unknownPaths: [] }),
+  ];
+  const report = aggregateBacktest(analyses, { minSHACount: 3 });
+  assert.equal(report.fallbackFullCount, 2);
+  assert.deepEqual(report.topUnknownPathPrefixes[0], { prefix: ".github/scripts", count: 3 });
+  assert.deepEqual(report.topUnknownPathPrefixes[1], { prefix: ".github/workflows", count: 1 });
+});
+
+test("renderSummary: names every target, the overall verdict, and every coverage gap", () => {
+  const analyses = [
+    baseAnalysis({
+      number: 42,
+      headSHA: sha("a"),
+      coverageGaps: [{ lane_id: "quality.mutation", new_reason: "not_impacted", observed_state: "red", observed_conclusion: "failure" }],
+    }),
+  ];
+  const report = aggregateBacktest(analyses, { minSHACount: 1 });
+  const summary = renderSummary(report);
+  assert.match(summary, /Overall: FAIL/);
+  assert.match(summary, /#42/);
+  assert.match(summary, /quality\.mutation/);
+  assert.match(summary, new RegExp(`p95 <= ${MERGE_P95_SLO_MINUTES}`));
+  assert.match(summary, new RegExp(`p50 <= ${RUNNER_P50_TARGET_MINUTES}, p95 <= ${RUNNER_P95_TARGET_MINUTES}`));
+});
+
+test("DEFAULT_SHA_COUNT matches issue #2230's acceptance floor", () => {
+  assert.equal(DEFAULT_SHA_COUNT, 50);
+});

--- a/.github/scripts/ci-lane-contract.mjs
+++ b/.github/scripts/ci-lane-contract.mjs
@@ -732,6 +732,55 @@ function workflowJobCommands(root, workflow, jobs) {
   return commands;
 }
 
+function workflowJobBlock(root, workflow, jobID) {
+  if (
+    typeof workflow !== "string" ||
+    typeof jobID !== "string" ||
+    !existsSync(resolve(root, workflow))
+  ) {
+    return "";
+  }
+  const lines = readFileSync(resolve(root, workflow), "utf8").split("\n");
+  const jobsIndex = lines.findIndex((line) => /^\s*jobs:\s*(?:#.*)?$/.test(line));
+  if (jobsIndex === -1) return "";
+  const jobsIndent = /^\s*/.exec(lines[jobsIndex])[0].length;
+  const jobIndent = jobsIndent + 2;
+  let start = -1;
+  for (let i = jobsIndex + 1; i < lines.length; i += 1) {
+    const line = lines[i];
+    if (line.trim() === "" || line.trim().startsWith("#")) continue;
+    const indent = /^\s*/.exec(line)[0].length;
+    if (indent <= jobsIndent) break;
+    const job = /^\s*([A-Za-z_][A-Za-z0-9_-]*):\s*(?:#.*)?$/.exec(line);
+    if (indent !== jobIndent || !job) continue;
+    if (start !== -1) return lines.slice(start, i).join("\n");
+    if (job[1] === jobID) start = i;
+  }
+  return start === -1 ? "" : lines.slice(start).join("\n");
+}
+
+function producerJobEnrollsNativePart(root, workflow, jobID, partID) {
+  const block = workflowJobBlock(root, workflow, jobID);
+  if (block === "") return false;
+  const escapedID = partID.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const enrollment = new RegExp(
+    `uses:\\s*\\./\\.github/actions/ci-native-part(?:/action\\.yml)?\\s*` +
+      `[\\s\\S]{0,500}?\\n\\s*with:\\s*[\\s\\S]{0,300}?\\n\\s*id:\\s*['\"]?${escapedID}['\"]?\\s*(?:#.*)?$`,
+    "m",
+  );
+  return enrollment.test(block);
+}
+
+function workflowCallsNativeEvidence(root, workflow) {
+  if (typeof workflow !== "string" || !existsSync(resolve(root, workflow))) {
+    return false;
+  }
+  const contents = readFileSync(resolve(root, workflow), "utf8");
+  return /uses:\s*\.\/\.github\/workflows\/ci-native-evidence\.yml(?:\s|$)/m.test(
+    contents,
+  );
+}
+
 function normalizedCommand(value) {
   return value.trim().replace(/\s+/g, " ");
 }
@@ -1263,6 +1312,7 @@ export function validateRegistry(document, { root = process.cwd() } = {}) {
 
   const nativeJobsByLane = new Map();
   const nativeExecutions = new Set();
+  const nativeWorkflows = new Set();
   for (let i = 0; i < nativeParts.length; i += 1) {
     const part = nativeParts[i];
     const at = `registry.native_evidence.parts[${i}]`;
@@ -1282,6 +1332,18 @@ export function validateRegistry(document, { root = process.cwd() } = {}) {
       );
     }
     if (
+      !producerJobEnrollsNativePart(
+        root,
+        lane.owner.workflow,
+        part.producer_job,
+        part.id,
+      )
+    ) {
+      problems.push(
+        `${at} is not uploaded by ${lane.owner.workflow} job ${part.producer_job}`,
+      );
+    }
+    if (
       part.invocation_mode === "source_tree" &&
       !lane.applicability.source
     ) {
@@ -1296,14 +1358,26 @@ export function validateRegistry(document, { root = process.cwd() } = {}) {
     const jobs = nativeJobsByLane.get(lane.id) ?? new Set();
     jobs.add(part.producer_job);
     nativeJobsByLane.set(lane.id, jobs);
+    nativeWorkflows.add(lane.owner.workflow);
     nativeExecutions.add(
       `${lane.id}/${part.execution_id}/${part.invocation_mode}`,
     );
   }
+  for (const workflow of [...nativeWorkflows].sort()) {
+    if (!workflowCallsNativeEvidence(root, workflow)) {
+      problems.push(
+        `${workflow} owns native parts but does not call ci-native-evidence.yml`,
+      );
+    }
+  }
   for (const [laneID, jobs] of nativeJobsByLane) {
     const lane = lanesByID.get(laneID);
     const actual = [...jobs].sort();
-    const declared = [...lane.owner.producer_jobs].sort();
+    const declared = [
+      ...(lane.owner.producer_jobs.length > 0
+        ? lane.owner.producer_jobs
+        : [lane.owner.context_job]),
+    ].sort();
     if (JSON.stringify(actual) !== JSON.stringify(declared)) {
       problems.push(
         `registry lane ${laneID} owner.producer_jobs must exactly match native part producers ${JSON.stringify(actual)}`,

--- a/.github/scripts/ci-lane-contract.mjs
+++ b/.github/scripts/ci-lane-contract.mjs
@@ -61,6 +61,14 @@ import { fileURLToPath } from "node:url";
 export const REGISTRY_SCHEMA_VERSION = 1;
 export const SELECTION_SCHEMA_VERSION = 1;
 export const REPORT_SCHEMA_VERSION = 2;
+export const NATIVE_PART_SCHEMA_VERSION = 1;
+export const NATIVE_PART_PARSERS = Object.freeze([
+  "case-json-v1",
+  "compat-cases-json-v1",
+  "go-test-json-v1",
+  "junit-xml-v1",
+  "node-tap-v1",
+]);
 export const DEFAULT_REGISTRY_PATH = ".github/ci-lanes.json";
 export const MERGE_P95_SLO_MINUTES = 20;
 export const RELEASE_QUALIFICATION_SLO_MINUTES = 120;
@@ -119,12 +127,23 @@ const TOP_KEYS = new Set([
   "report_schema_version",
   "rollout",
   "impact_selection",
+  "native_evidence",
   "layers",
   "lanes",
   "non_lane_workflows",
 ]);
 const LAYER_KEYS = new Set(["id", "name"]);
 const IMPACT_SELECTION_KEYS = new Set(["known_nonimpact_globs"]);
+const NATIVE_EVIDENCE_KEYS = new Set(["schema_version", "parts"]);
+const NATIVE_PART_KEYS = new Set([
+  "id",
+  "lane_id",
+  "execution_id",
+  "invocation_mode",
+  "producer_job",
+  "parser",
+  "entry",
+]);
 const LANE_KEYS = new Set([
   "id",
   "description",
@@ -161,6 +180,8 @@ const CONTEXT_KEYS = new Set(["match", "name", "protected"]);
 const APPLICABILITY_KEYS = new Set(["source", "artifact"]);
 const SELECTOR_POLICY_KEYS = new Set(["unknown_paths", "failure"]);
 const NON_LANE_KEYS = new Set(["workflow", "reason"]);
+const NATIVE_PART_ID_RE = /^[a-z0-9][a-z0-9.-]*$/;
+const NATIVE_PART_ENTRY_RE = /^(?!\/)(?!.*(?:^|\/)\.\.(?:\/|$))[A-Za-z0-9_.-]+(?:\/[A-Za-z0-9_.-]+)*$/;
 
 const PURPOSES = new Set([
   "correctness",
@@ -344,6 +365,7 @@ const TRUSTED_ARTIFACT_KEYS = new Set([
 const TRUSTED_ARTIFACT_ENTRY_KEYS = new Set([
   "lane_id",
   "execution_id",
+  "invocation_mode",
   "sha256",
 ]);
 // Pull-request Actions runs expose the branch-head SHA through the REST API,
@@ -877,6 +899,71 @@ export function validateRegistry(document, { root = process.cwd() } = {}) {
     }
   }
 
+  const nativeParts = [];
+  if (
+    exactObject(
+      document.native_evidence,
+      NATIVE_EVIDENCE_KEYS,
+      "registry.native_evidence",
+      problems,
+    )
+  ) {
+    if (document.native_evidence.schema_version !== NATIVE_PART_SCHEMA_VERSION) {
+      problems.push(
+        `registry.native_evidence.schema_version must be ${NATIVE_PART_SCHEMA_VERSION}`,
+      );
+    }
+    if (!Array.isArray(document.native_evidence.parts)) {
+      problems.push("registry.native_evidence.parts must be an array");
+    } else {
+      let previousIdentity = "";
+      const partIDs = new Set();
+      for (let i = 0; i < document.native_evidence.parts.length; i += 1) {
+        const part = document.native_evidence.parts[i];
+        const at = `registry.native_evidence.parts[${i}]`;
+        if (!exactObject(part, NATIVE_PART_KEYS, at, problems)) continue;
+        stringValue(part.id, `${at}.id`, problems, {
+          pattern: NATIVE_PART_ID_RE,
+        });
+        stringValue(part.lane_id, `${at}.lane_id`, problems, {
+          pattern: LANE_ID_RE,
+        });
+        stringValue(part.execution_id, `${at}.execution_id`, problems, {
+          pattern: EXECUTION_ID_RE,
+        });
+        enumValue(
+          part.invocation_mode,
+          INVOCATION_MODES,
+          `${at}.invocation_mode`,
+          problems,
+        );
+        stringValue(part.producer_job, `${at}.producer_job`, problems, {
+          pattern: WORKFLOW_JOB_ID_RE,
+        });
+        enumValue(
+          part.parser,
+          new Set(NATIVE_PART_PARSERS),
+          `${at}.parser`,
+          problems,
+        );
+        stringValue(part.entry, `${at}.entry`, problems, {
+          pattern: NATIVE_PART_ENTRY_RE,
+        });
+        if (partIDs.has(part.id)) problems.push(`${at}.id duplicates ${part.id}`);
+        partIDs.add(part.id);
+        const identity =
+          `${part.lane_id}/${part.execution_id}/${part.invocation_mode}/${part.id}`;
+        if (previousIdentity !== "" && identity.localeCompare(previousIdentity) <= 0) {
+          problems.push(
+            `${at} identity ${identity} is not strictly sorted after ${previousIdentity}`,
+          );
+        }
+        previousIdentity = identity;
+        nativeParts.push(part);
+      }
+    }
+  }
+
   if (!Array.isArray(document.layers)) {
     problems.push("registry.layers must be an array");
   } else {
@@ -899,6 +986,7 @@ export function validateRegistry(document, { root = process.cwd() } = {}) {
   const knownLayers = new Set(CANONICAL_LAYERS);
   const coveredLayers = new Set();
   const laneIDs = new Set();
+  const lanesByID = new Map();
   const protectedContexts = new Set();
   const recipeCommands = justRecipeCommands(root);
   const recipes = new Set(recipeCommands.keys());
@@ -922,6 +1010,7 @@ export function validateRegistry(document, { root = process.cwd() } = {}) {
           );
         }
         laneIDs.add(lane.id);
+        lanesByID.set(lane.id, lane);
         previousID = lane.id;
       }
       stringValue(lane.description, `${at}.description`, problems);
@@ -953,11 +1042,6 @@ export function validateRegistry(document, { root = process.cwd() } = {}) {
             ) {
               problems.push(
                 `${at}.owner.producer_jobs contains ${job}, which is not in owner.jobs`,
-              );
-            }
-            if (job === lane.owner.context_job) {
-              problems.push(
-                `${at}.owner.producer_jobs must exclude the context_job ${job}`,
               );
             }
           }
@@ -1177,6 +1261,69 @@ export function validateRegistry(document, { root = process.cwd() } = {}) {
     }
   }
 
+  const nativeJobsByLane = new Map();
+  const nativeExecutions = new Set();
+  for (let i = 0; i < nativeParts.length; i += 1) {
+    const part = nativeParts[i];
+    const at = `registry.native_evidence.parts[${i}]`;
+    const lane = lanesByID.get(part.lane_id);
+    if (!lane) {
+      problems.push(`${at}.lane_id names unknown lane ${part.lane_id}`);
+      continue;
+    }
+    if (!lane.executions.includes(part.execution_id)) {
+      problems.push(
+        `${at}.execution_id ${part.execution_id} is not registered by lane ${lane.id}`,
+      );
+    }
+    if (!lane.owner.jobs.includes(part.producer_job)) {
+      problems.push(
+        `${at}.producer_job ${part.producer_job} is not owned by lane ${lane.id}`,
+      );
+    }
+    if (
+      part.invocation_mode === "source_tree" &&
+      !lane.applicability.source
+    ) {
+      problems.push(`${at}.invocation_mode belongs to a non-source lane`);
+    }
+    if (
+      part.invocation_mode === "candidate_artifact" &&
+      !lane.applicability.artifact
+    ) {
+      problems.push(`${at}.invocation_mode belongs to a non-artifact lane`);
+    }
+    const jobs = nativeJobsByLane.get(lane.id) ?? new Set();
+    jobs.add(part.producer_job);
+    nativeJobsByLane.set(lane.id, jobs);
+    nativeExecutions.add(
+      `${lane.id}/${part.execution_id}/${part.invocation_mode}`,
+    );
+  }
+  for (const [laneID, jobs] of nativeJobsByLane) {
+    const lane = lanesByID.get(laneID);
+    const actual = [...jobs].sort();
+    const declared = [...lane.owner.producer_jobs].sort();
+    if (JSON.stringify(actual) !== JSON.stringify(declared)) {
+      problems.push(
+        `registry lane ${laneID} owner.producer_jobs must exactly match native part producers ${JSON.stringify(actual)}`,
+      );
+    }
+    const invocationModes = [];
+    if (lane.applicability.source) invocationModes.push("source_tree");
+    if (lane.applicability.artifact) invocationModes.push("candidate_artifact");
+    for (const executionID of lane.executions) {
+      for (const invocationMode of invocationModes) {
+        if (nativeExecutions.has(`${laneID}/${executionID}/${invocationMode}`)) {
+          continue;
+        }
+        problems.push(
+          `registry lane ${laneID}/${executionID}/${invocationMode} has native parts for another invocation but none for this invocation`,
+        );
+      }
+    }
+  }
+
   validateCanonicalHeadOracleFloors(
     document.lanes,
     root,
@@ -1321,6 +1468,17 @@ export function nativeArtifactName(workflow, run) {
     .replace(/\.ya?ml$/, "")
     .replace(/[^A-Za-z0-9_.-]+/g, "-");
   return `ci-native-${basename}-${run.id}-${run.attempt}`;
+}
+
+export function nativePartArtifactName(partID, runAttempt) {
+  const id = String(partID ?? "").trim();
+  const attempt = String(runAttempt ?? "").trim();
+  if (!NATIVE_PART_ID_RE.test(id) || !/^[1-9][0-9]*$/.test(attempt)) {
+    throw new ContractError("invalid CI lane native part artifact", [
+      "part id and run attempt must be canonical",
+    ]);
+  }
+  return `ci-native-part-${id}-${attempt}`;
 }
 
 function validateDigest(value, path, problems, { required = false } = {}) {
@@ -1878,7 +2036,8 @@ export function validateReport(document, registry) {
           `report.producer.artifact.name must be ${expectedArtifactName}`,
         );
       }
-      const expectedEntry = `${document.lane_id}/${document.execution_id}`;
+      const expectedEntry =
+        `${document.lane_id}/${document.execution_id}/${document.invocation?.mode}`;
       if (document.producer.artifact.entry !== expectedEntry) {
         problems.push(
           `report.producer.artifact.entry must be ${expectedEntry}`,
@@ -2119,10 +2278,15 @@ export function validateProducerManifest(document, registry) {
       knownJobs.get(lane.owner.workflow).add(job);
     if (!knownEntries.has(lane.owner.workflow))
       knownEntries.set(lane.owner.workflow, new Set());
+    const modes = [];
+    if (lane.applicability.source) modes.push("source_tree");
+    if (lane.applicability.artifact) modes.push("candidate_artifact");
     for (const executionID of lane.executions) {
-      knownEntries
-        .get(lane.owner.workflow)
-        .add(`${lane.id}/${executionID}`);
+      for (const mode of modes) {
+        knownEntries
+          .get(lane.owner.workflow)
+          .add(`${lane.id}/${executionID}/${mode}`);
+      }
     }
   }
   if (!Array.isArray(document.producers)) {
@@ -2173,7 +2337,8 @@ export function validateProducerManifest(document, registry) {
       if (!Array.isArray(producer.jobs) || producer.jobs.length === 0) {
         problems.push(`${at}.jobs must be a non-empty array`);
       } else {
-        const jobs = new Set();
+        const jobExecutions = new Set();
+        const jobDatabaseIDs = new Set();
         for (let j = 0; j < producer.jobs.length; j += 1) {
           const job = producer.jobs[j];
           const jobAt = `${at}.jobs[${j}]`;
@@ -2186,12 +2351,19 @@ export function validateProducerManifest(document, registry) {
           ) {
             problems.push(`${jobAt}.job is not registered for the workflow`);
           }
-          if (jobs.has(job.job)) problems.push(`${jobAt}.job is duplicated`);
-          jobs.add(job.job);
           stringValue(job.name, `${jobAt}.name`, problems);
           stringValue(job.database_id, `${jobAt}.database_id`, problems, {
             pattern: RUN_ID_RE,
           });
+          const jobExecution = `${job.job}/${job.name}`;
+          if (jobExecutions.has(jobExecution)) {
+            problems.push(`${jobAt} duplicates job execution ${jobExecution}`);
+          }
+          if (jobDatabaseIDs.has(job.database_id)) {
+            problems.push(`${jobAt}.database_id is duplicated`);
+          }
+          jobExecutions.add(jobExecution);
+          jobDatabaseIDs.add(job.database_id);
           enumValue(
             job.conclusion,
             JOB_CONCLUSIONS,
@@ -2248,10 +2420,17 @@ export function validateProducerManifest(document, registry) {
                 problems,
                 { pattern: EXECUTION_ID_RE },
               );
+              enumValue(
+                entry.invocation_mode,
+                INVOCATION_MODES,
+                `${entryAt}.invocation_mode`,
+                problems,
+              );
               stringValue(entry.sha256, `${entryAt}.sha256`, problems, {
                 pattern: SHA256_RE,
               });
-              const identity = `${entry.lane_id}/${entry.execution_id}`;
+              const identity =
+                `${entry.lane_id}/${entry.execution_id}/${entry.invocation_mode}`;
               if (entries.has(identity)) {
                 problems.push(`${entryAt} duplicates native entry ${identity}`);
               }
@@ -2279,13 +2458,16 @@ export function validateProducerManifest(document, registry) {
 }
 
 function reportIdentity(report) {
-  return `${report.lane_id}/${report.execution_id}`;
+  return `${report.lane_id}/${report.execution_id}/${report.invocation.mode}`;
 }
 
-function expectedInvocationMode(lane, posture) {
-  if (posture === "release" && lane.applicability.artifact)
-    return "candidate_artifact";
-  return "source_tree";
+function expectedInvocationModes(lane, posture) {
+  const modes = [];
+  if (lane.applicability.source) modes.push("source_tree");
+  if (posture === "release" && lane.applicability.artifact) {
+    modes.push("candidate_artifact");
+  }
+  return modes;
 }
 
 function validateQualificationExpectations(expected, registry, selection) {
@@ -2449,11 +2631,15 @@ export function validateReportSet({
   for (const item of selection.lanes) {
     if (item.disposition !== "selected") continue;
     expectedWorkflows.add(lanesByID.get(item.lane_id).owner.workflow);
+    const lane = lanesByID.get(item.lane_id);
     for (const execution of item.executions) {
-      expectedReports.set(`${item.lane_id}/${execution}`, {
-        lane: lanesByID.get(item.lane_id),
-        execution,
-      });
+      for (const mode of expectedInvocationModes(lane, selection.posture)) {
+        expectedReports.set(`${item.lane_id}/${execution}/${mode}`, {
+          lane,
+          execution,
+          mode,
+        });
+      }
     }
   }
 
@@ -2553,10 +2739,10 @@ export function validateReportSet({
         `${identity}: correlation_nonce does not match the current qualification`,
       );
     }
-    const mode = expectedInvocationMode(lane, selection.posture);
-    if (report.invocation.mode !== mode) {
+    const mode = report.invocation.mode;
+    if (expectedReports.get(identity)?.mode !== mode) {
       problems.push(
-        `${identity}: invocation mode ${report.invocation.mode} must be ${mode}`,
+        `${identity}: invocation mode ${mode} is not selected for this lane execution`,
       );
     }
     if (
@@ -2603,23 +2789,28 @@ export function validateReportSet({
         `${identity}: producer run identity does not match the trusted workflow run`,
       );
     }
-    const context = trusted.jobs.find(
+    const jobCandidates = trusted.jobs.filter(
       (job) => job.job === report.producer.job,
     );
-    if (!context) {
+    const contexts = jobCandidates.filter((job) => {
+      return lane.context.match === "exact"
+        ? job.name === lane.context.name
+        : job.name.startsWith(lane.context.name);
+    });
+    if (jobCandidates.length === 0) {
       problems.push(
         `${identity}: trusted context job ${report.producer.job} is missing`,
       );
+    } else if (contexts.length === 0) {
+      problems.push(
+        `${identity}: trusted context check name ${jobCandidates[0].name} does not match ${lane.context.name}`,
+      );
+    } else if (contexts.length > 1) {
+      problems.push(
+        `${identity}: trusted context job ${report.producer.job} is ambiguous`,
+      );
     } else {
-      const contextNameMatches =
-        lane.context.match === "exact"
-          ? context.name === lane.context.name
-          : context.name.startsWith(lane.context.name);
-      if (!contextNameMatches) {
-        problems.push(
-          `${identity}: trusted context check name ${context.name} does not match ${lane.context.name}`,
-        );
-      }
+      const [context] = contexts;
       if (context.conclusion !== "success") {
         problems.push(
           `${identity}: trusted context job ${report.producer.job} is ${context.conclusion}`,
@@ -2644,7 +2835,8 @@ export function validateReportSet({
       const entry = artifact.entries.find(
         (candidate) =>
           candidate.lane_id === report.lane_id &&
-          candidate.execution_id === report.execution_id,
+          candidate.execution_id === report.execution_id &&
+          candidate.invocation_mode === report.invocation.mode,
       );
       if (!entry) {
         problems.push(

--- a/.github/scripts/ci-lane-contract.mjs
+++ b/.github/scripts/ci-lane-contract.mjs
@@ -18,18 +18,24 @@
 // Env (reports):
 //   CI_LANE_SELECTION     selection manifest path (required)
 //   CI_LANE_REPORT_DIR    recursively-read report directory (required)
-//   CI_LANE_JOB_RESULTS_JSON
-//                         JSON object keyed by <workflow>#<job>. Each value is
-//                         {conclusion, run_id, run_attempt}. This is trusted
-//                         workflow `needs` state, not report-artifact content.
+//   CI_LANE_PRODUCER_MANIFEST
+//                         trusted API-built producer-manifest path (required)
 //   CI_LANE_POSTURE     merge | main | release
 //   CI_EXPECT_SHA         exact source commit selected for qualification
 //   CI_EXPECT_TREE        exact Git tree selected for qualification
+//   CI_EXPECT_CORRELATION_NONCE per-qualification 64-hex correlation value
 //   CI_EXPECT_CANDIDATE_DIGEST
 //                         sha256 digest; required when a selected lane applies
 //                         to an artifact
 //   CI_EXPECT_RUN_ID      selection/qualification workflow run id
 //   CI_EXPECT_RUN_ATTEMPT selection/qualification workflow attempt
+//   CI_EXPECT_SELECTION_SHA256 exact selection-manifest SHA-256
+//   CI_EXPECT_EVENT_KIND  workflow event used for producer-run discovery
+//   CI_EXPECT_PR_NUMBER   PR number; required only for pull_request
+//   CI_EXPECT_EVENT_HEAD_SHA API workflow-run head SHA
+//   CI_EXPECT_EVENT_BASE_SHA event base SHA; required for PR/merge group
+//   CI_EXPECT_PROJECTED_SHA exact projected checkout SHA
+//   CI_EXPECT_REPOSITORY  exact owner/repository slug from trusted context
 //   CI_EXPECT_BASE_SHA    merge base commit; required for merge qualification
 //   CI_EXPECT_CHANGED_PATHS_JSON
 //                         canonical compact changed-path JSON array; required
@@ -40,6 +46,7 @@
 // non-zero on every malformed, missing, stale, skipped, neutral, cancelled,
 // mismatched, or zero-execution state.
 
+import { createHash } from "node:crypto";
 import process from "node:process";
 import {
   appendFileSync,
@@ -53,7 +60,7 @@ import { fileURLToPath } from "node:url";
 
 export const REGISTRY_SCHEMA_VERSION = 1;
 export const SELECTION_SCHEMA_VERSION = 1;
-export const REPORT_SCHEMA_VERSION = 1;
+export const REPORT_SCHEMA_VERSION = 2;
 export const DEFAULT_REGISTRY_PATH = ".github/ci-lanes.json";
 export const MERGE_P95_SLO_MINUTES = 20;
 export const RELEASE_QUALIFICATION_SLO_MINUTES = 120;
@@ -244,6 +251,7 @@ const SELECTION_KEYS = new Set([
   "posture",
   "source",
   "candidate_digest",
+  "correlation_nonce",
   "run",
   "selector",
   "lanes",
@@ -272,13 +280,22 @@ const REPORT_KEYS = new Set([
   "posture",
   "source",
   "candidate_digest",
-  "run",
+  "correlation_nonce",
+  "selection_ref",
   "producer",
   "invocation",
   "evidence",
   "conclusion",
 ]);
-const PRODUCER_KEYS = new Set(["workflow", "job"]);
+const SELECTION_REF_KEYS = new Set(["run", "manifest_sha256"]);
+const PRODUCER_KEYS = new Set(["workflow", "job", "run", "artifact"]);
+const PRODUCER_ARTIFACT_KEYS = new Set([
+  "id",
+  "name",
+  "sha256",
+  "entry",
+  "entry_sha256",
+]);
 const INVOCATION_KEYS = new Set([
   "mode",
   "recipe",
@@ -295,14 +312,62 @@ const EVIDENCE_KEYS = new Set([
   "seed",
   "corpus_id",
 ]);
-const JOB_RESULT_KEYS = new Set(["conclusion", "run_id", "run_attempt"]);
+const PRODUCER_MANIFEST_KEYS = new Set([
+  "schema_version",
+  "correlation_nonce",
+  "selection_ref",
+  "producers",
+]);
+const TRUSTED_PRODUCER_KEYS = new Set([
+  "workflow",
+  "run",
+  "source",
+  "correlation_nonce",
+  "event",
+  "repository",
+  "conclusion",
+  "jobs",
+  "artifacts",
+]);
+const TRUSTED_JOB_KEYS = new Set([
+  "job",
+  "name",
+  "database_id",
+  "conclusion",
+]);
+const TRUSTED_ARTIFACT_KEYS = new Set([
+  "id",
+  "name",
+  "sha256",
+  "entries",
+]);
+const TRUSTED_ARTIFACT_ENTRY_KEYS = new Set([
+  "lane_id",
+  "execution_id",
+  "sha256",
+]);
+// Pull-request Actions runs expose the branch-head SHA through the REST API,
+// while checkout uses the projected merge commit. Keep both identities: run
+// discovery binds the event head/base/PR tuple; native evidence binds the
+// projected commit and tree. Equating the two rejects honest PR evidence.
+const EVENT_IDENTITY_KEYS = new Set([
+  "kind",
+  "pr_number",
+  "event_head_sha",
+  "event_base_sha",
+  "projected_sha",
+]);
 const QUALIFICATION_EXPECTATION_KEYS = new Set([
   "posture",
   "sha",
   "tree",
   "candidateDigest",
+  "correlationNonce",
   "runID",
   "runAttempt",
+  "selectionManifestSHA256",
+  "eventIdentity",
+  "repository",
   "baseSHA",
   "changedPaths",
 ]);
@@ -313,6 +378,16 @@ const WORKFLOW_JOB_ID_RE = /^[A-Za-z_][A-Za-z0-9_-]*$/;
 const SHA_RE = /^(?:[0-9a-f]{40}|[0-9a-f]{64})$/;
 const DIGEST_RE = /^sha256:[0-9a-f]{64}$/;
 const RUN_ID_RE = /^[1-9][0-9]*$/;
+const SHA256_RE = /^[0-9a-f]{64}$/;
+const CORRELATION_NONCE_RE = /^[0-9a-f]{64}$/;
+const REPOSITORY_RE = /^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/;
+const EVENT_KINDS = new Set([
+  "merge_group",
+  "pull_request",
+  "push",
+  "schedule",
+  "workflow_dispatch",
+]);
 const DOMAIN_RE = /^[a-z0-9][a-z0-9-]*$/;
 const UNSUPPORTED_GLOB_META_RE = /[?\[\]{}]/;
 
@@ -521,7 +596,7 @@ function validateRepositoryGlob(root, value, path, problems) {
   }
 }
 
-function validateChangedPaths(value, path, problems) {
+export function validateChangedPaths(value, path, problems) {
   if (!stringArray(value, path, problems, { allowEmpty: true })) return false;
   for (let i = 0; i < value.length; i += 1) {
     canonicalRepositoryPath(value[i], `${path}[${i}]`, problems);
@@ -1180,6 +1255,74 @@ function validateRun(run, path, problems) {
   integerValue(run.attempt, `${path}.attempt`, problems, { min: 1 });
 }
 
+function validateSelectionRef(value, path, problems) {
+  if (!exactObject(value, SELECTION_REF_KEYS, path, problems)) return;
+  validateRun(value.run, `${path}.run`, problems);
+  stringValue(value.manifest_sha256, `${path}.manifest_sha256`, problems, {
+    pattern: SHA256_RE,
+  });
+}
+
+function validateArtifact(value, keys, path, problems) {
+  if (!exactObject(value, keys, path, problems)) return;
+  stringValue(value.id, `${path}.id`, problems, { pattern: RUN_ID_RE });
+  stringValue(value.name, `${path}.name`, problems);
+  stringValue(value.sha256, `${path}.sha256`, problems, {
+    pattern: SHA256_RE,
+  });
+}
+
+export function selectionManifestSHA256(document) {
+  return createHash("sha256")
+    .update(`${JSON.stringify(document, null, 2)}\n`)
+    .digest("hex");
+}
+
+function canonicalJSONValue(value) {
+  if (Array.isArray(value)) return value.map(canonicalJSONValue);
+  if (!isObject(value)) return value;
+  return Object.fromEntries(
+    Object.keys(value)
+      .sort()
+      .map((key) => [key, canonicalJSONValue(value[key])]),
+  );
+}
+
+export function canonicalJSONSHA256(document) {
+  return createHash("sha256")
+    .update(`${JSON.stringify(canonicalJSONValue(document))}\n`)
+    .digest("hex");
+}
+
+// Event-driven merge/main producers cannot share a coordinator-generated
+// random value, so their correlation nonce is deterministically namespaced by
+// posture and the exact projected Git objects. Release qualification must pass
+// an explicit, per-invocation random nonce instead; callers may not derive one
+// through this helper for release evidence.
+export function deriveQualificationCorrelationNonce({ posture, source }) {
+  const problems = [];
+  if (posture !== "merge" && posture !== "main") {
+    problems.push("derived qualification correlation is only valid for merge or main posture");
+  }
+  validateSource(source, "qualification correlation source", problems);
+  if (problems.length > 0) {
+    throw new ContractError("invalid qualification correlation", problems);
+  }
+  return canonicalJSONSHA256({
+    domain: "ci-lane-qualification",
+    posture,
+    source: { sha: source.sha, tree: source.tree },
+  });
+}
+
+export function nativeArtifactName(workflow, run) {
+  const basename = String(workflow ?? "")
+    .replace(/^.*\//, "")
+    .replace(/\.ya?ml$/, "")
+    .replace(/[^A-Za-z0-9_.-]+/g, "-");
+  return `ci-native-${basename}-${run.id}-${run.attempt}`;
+}
+
 function validateDigest(value, path, problems, { required = false } = {}) {
   if (value === null) {
     if (required) problems.push(`${path} is required`);
@@ -1226,6 +1369,12 @@ export function validateSelection(document, registry, expected = {}) {
     "selection.candidate_digest",
     problems,
   );
+  stringValue(
+    document.correlation_nonce,
+    "selection.correlation_nonce",
+    problems,
+    { pattern: CORRELATION_NONCE_RE },
+  );
   validateRun(document.run, "selection.run", problems);
 
   if (expected.posture !== undefined && document.posture !== expected.posture) {
@@ -1249,6 +1398,14 @@ export function validateSelection(document, registry, expected = {}) {
   ) {
     problems.push(
       `selection.candidate_digest is ${document.candidate_digest}, want ${expected.candidateDigest}`,
+    );
+  }
+  if (
+    expected.correlationNonce !== undefined &&
+    document.correlation_nonce !== expected.correlationNonce
+  ) {
+    problems.push(
+      `selection.correlation_nonce is ${document.correlation_nonce}, want ${expected.correlationNonce}`,
     );
   }
   if (expected.runID !== undefined && document.run?.id !== expected.runID) {
@@ -1472,21 +1629,20 @@ export function validateSelection(document, registry, expected = {}) {
           (path) => typeof path === "string",
         )
       : [];
-    const impactLanes = registry.lanes.filter(
-      (lane) => lane.merge_posture === "impact",
+    const conditionalLanes = registry.lanes.filter(
+      (lane) =>
+        lane.merge_posture === "impact" ||
+        lane.merge_posture === "non_documentation",
     );
-    const nonDocumentationLanes = registry.lanes.filter(
-      (lane) => lane.merge_posture === "non_documentation",
-    );
-    const impacted = new Set();
+    const directlyImpacted = new Set();
     const computedUnknown = [];
     const knownNonimpactGlobs =
       registry.impact_selection?.known_nonimpact_globs ?? [];
     for (const path of changedPaths) {
-      const matching = impactLanes.filter((lane) =>
+      const matching = conditionalLanes.filter((lane) =>
         lane.package_globs.some((glob) => matchesGlob(path, glob)),
       );
-      for (const lane of matching) impacted.add(lane.id);
+      for (const lane of matching) directlyImpacted.add(lane.id);
       if (
         matching.length === 0 &&
         !knownNonimpactGlobs.some((glob) => matchesGlob(path, glob))
@@ -1508,26 +1664,43 @@ export function validateSelection(document, registry, expected = {}) {
       );
     }
     if (document.selector.conclusion === "success") {
-      for (const laneID of impacted) {
-        if (selected.get(laneID)?.disposition !== "selected") {
-          problems.push(`selector success must select impacted lane ${laneID}`);
-        }
-      }
-      for (const lane of nonDocumentationLanes) {
-        const required = changedPaths.some(
-          (path) =>
-            !knownNonimpactGlobs.some((glob) => matchesGlob(path, glob)) ||
-            lane.package_globs.some((glob) => matchesGlob(path, glob)),
+      const docsOnly =
+        changedPaths.length > 0 &&
+        changedPaths.every((path) =>
+          knownNonimpactGlobs.some((glob) => matchesGlob(path, glob)),
         );
-        if (required && selected.get(lane.id)?.disposition !== "selected") {
+      for (const lane of conditionalLanes) {
+        const item = selected.get(lane.id);
+        const directHit = directlyImpacted.has(lane.id);
+        const shouldSelect =
+          directHit ||
+          (lane.merge_posture === "non_documentation" && !docsOnly);
+        if (shouldSelect && item?.disposition !== "selected") {
+          const kind =
+            lane.merge_posture === "non_documentation"
+              ? "non-documentation"
+              : "impacted";
+          problems.push(`selector success must select ${kind} lane ${lane.id}`);
+          continue;
+        }
+        if (!shouldSelect && item?.disposition === "selected") {
           problems.push(
-            `selector success must select non-documentation lane ${lane.id}`,
+            `selector success must omit unimpacted lane ${lane.id}`,
           );
+          continue;
+        }
+        if (!shouldSelect && item?.disposition === "omitted") {
+          const expectedReason = docsOnly ? "docs_only" : "not_impacted";
+          if (item.reason !== expectedReason) {
+            problems.push(
+              `selector success must omit ${lane.id} as ${expectedReason}`,
+            );
+          }
         }
       }
     }
     if (document.selector.conclusion === "fallback_full") {
-      for (const lane of [...impactLanes, ...nonDocumentationLanes]) {
+      for (const lane of conditionalLanes) {
         if (selected.get(lane.id)?.disposition !== "selected") {
           problems.push(`fallback_full must select ${lane.id}`);
         }
@@ -1573,6 +1746,21 @@ export function validateSelection(document, registry, expected = {}) {
   }
   if (document.posture !== "release" && document.candidate_digest !== null) {
     problems.push("only release selection may bind a candidate digest");
+  }
+  if (document.posture === "merge" || document.posture === "main") {
+    try {
+      const derived = deriveQualificationCorrelationNonce({
+        posture: document.posture,
+        source: document.source,
+      });
+      if (document.correlation_nonce !== derived) {
+        problems.push(
+          `${document.posture} selection.correlation_nonce does not match its projected Git objects`,
+        );
+      }
+    } catch (error) {
+      if (!(error instanceof ContractError)) throw error;
+    }
   }
 
   if (problems.length > 0)
@@ -1629,7 +1817,17 @@ export function validateReport(document, registry) {
     "report.candidate_digest",
     problems,
   );
-  validateRun(document.run, "report.run", problems);
+  stringValue(
+    document.correlation_nonce,
+    "report.correlation_nonce",
+    problems,
+    { pattern: CORRELATION_NONCE_RE },
+  );
+  validateSelectionRef(
+    document.selection_ref,
+    "report.selection_ref",
+    problems,
+  );
   enumValue(
     document.conclusion,
     REPORT_CONCLUSIONS,
@@ -1659,6 +1857,39 @@ export function validateReport(document, registry) {
     }
     if (document.producer.job !== lane.owner.context_job) {
       problems.push("report.producer.job must be the registry context_job");
+    }
+    validateRun(document.producer.run, "report.producer.run", problems);
+    validateArtifact(
+      document.producer.artifact,
+      PRODUCER_ARTIFACT_KEYS,
+      "report.producer.artifact",
+      problems,
+    );
+    if (
+      isObject(document.producer.run) &&
+      isObject(document.producer.artifact)
+    ) {
+      const expectedArtifactName = nativeArtifactName(
+        document.producer.workflow,
+        document.producer.run,
+      );
+      if (document.producer.artifact.name !== expectedArtifactName) {
+        problems.push(
+          `report.producer.artifact.name must be ${expectedArtifactName}`,
+        );
+      }
+      const expectedEntry = `${document.lane_id}/${document.execution_id}`;
+      if (document.producer.artifact.entry !== expectedEntry) {
+        problems.push(
+          `report.producer.artifact.entry must be ${expectedEntry}`,
+        );
+      }
+      stringValue(
+        document.producer.artifact.entry_sha256,
+        "report.producer.artifact.entry_sha256",
+        problems,
+        { pattern: SHA256_RE },
+      );
     }
   }
 
@@ -1818,30 +2049,232 @@ export function validateReport(document, registry) {
   return document;
 }
 
-export function validateJobResults(document, registry) {
-  const problems = [];
-  if (!isObject(document))
-    throw new ContractError("invalid trusted job results", [
-      "root must be an object",
-    ]);
-  const known = new Set(
-    registry.lanes.flatMap((lane) =>
-      lane.owner.jobs.map((job) => `${lane.owner.workflow}#${job}`),
-    ),
-  );
-  for (const [key, value] of Object.entries(document)) {
-    if (!known.has(key))
+export function validateEventIdentity(value, path, problems) {
+  if (!exactObject(value, EVENT_IDENTITY_KEYS, path, problems)) return;
+  enumValue(value.kind, EVENT_KINDS, `${path}.kind`, problems);
+  if (value.pr_number !== null) {
+    integerValue(value.pr_number, `${path}.pr_number`, problems, { min: 1 });
+  }
+  stringValue(value.event_head_sha, `${path}.event_head_sha`, problems, {
+    pattern: SHA_RE,
+  });
+  if (value.event_base_sha !== null) {
+    stringValue(value.event_base_sha, `${path}.event_base_sha`, problems, {
+      pattern: SHA_RE,
+    });
+  }
+  stringValue(value.projected_sha, `${path}.projected_sha`, problems, {
+    pattern: SHA_RE,
+  });
+  if (value.kind === "pull_request") {
+    if (value.pr_number === null)
+      problems.push(`${path}.pr_number is required for pull_request`);
+    if (value.event_base_sha === null)
+      problems.push(`${path}.event_base_sha is required for pull_request`);
+  } else if (value.pr_number !== null) {
+    problems.push(`${path}.pr_number must be null outside pull_request`);
+  }
+  if (value.kind === "merge_group") {
+    if (value.event_base_sha === null)
+      problems.push(`${path}.event_base_sha is required for merge_group`);
+    if (value.event_head_sha !== value.projected_sha) {
       problems.push(
-        `job result key ${key} does not name a registered owner job`,
+        `${path}.event_head_sha must equal projected_sha for merge_group`,
       );
-    const at = `job_results[${JSON.stringify(key)}]`;
-    if (!exactObject(value, JOB_RESULT_KEYS, at, problems)) continue;
-    enumValue(value.conclusion, JOB_CONCLUSIONS, `${at}.conclusion`, problems);
-    stringValue(value.run_id, `${at}.run_id`, problems, { pattern: RUN_ID_RE });
-    integerValue(value.run_attempt, `${at}.run_attempt`, problems, { min: 1 });
+    }
+  }
+}
+
+export function validateProducerManifest(document, registry) {
+  const problems = [];
+  if (!exactObject(document, PRODUCER_MANIFEST_KEYS, "producer_manifest", problems)) {
+    throw new ContractError("invalid trusted producer manifest", problems);
+  }
+  if (document.schema_version !== REPORT_SCHEMA_VERSION) {
+    problems.push(
+      `producer_manifest.schema_version must be ${REPORT_SCHEMA_VERSION}`,
+    );
+  }
+  stringValue(
+    document.correlation_nonce,
+    "producer_manifest.correlation_nonce",
+    problems,
+    { pattern: CORRELATION_NONCE_RE },
+  );
+  validateSelectionRef(
+    document.selection_ref,
+    "producer_manifest.selection_ref",
+    problems,
+  );
+
+  const knownWorkflows = new Set(
+    registry.lanes.map((lane) => lane.owner.workflow),
+  );
+  const knownJobs = new Map();
+  const knownEntries = new Map();
+  for (const lane of registry.lanes) {
+    if (!knownJobs.has(lane.owner.workflow))
+      knownJobs.set(lane.owner.workflow, new Set());
+    for (const job of lane.owner.jobs)
+      knownJobs.get(lane.owner.workflow).add(job);
+    if (!knownEntries.has(lane.owner.workflow))
+      knownEntries.set(lane.owner.workflow, new Set());
+    for (const executionID of lane.executions) {
+      knownEntries
+        .get(lane.owner.workflow)
+        .add(`${lane.id}/${executionID}`);
+    }
+  }
+  if (!Array.isArray(document.producers)) {
+    problems.push("producer_manifest.producers must be an array");
+  } else {
+    const workflows = new Set();
+    for (let i = 0; i < document.producers.length; i += 1) {
+      const producer = document.producers[i];
+      const at = `producer_manifest.producers[${i}]`;
+      if (!exactObject(producer, TRUSTED_PRODUCER_KEYS, at, problems))
+        continue;
+      if (
+        stringValue(producer.workflow, `${at}.workflow`, problems) &&
+        !knownWorkflows.has(producer.workflow)
+      ) {
+        problems.push(`${at}.workflow is not registered`);
+      }
+      if (workflows.has(producer.workflow)) {
+        problems.push(
+          `${at}.workflow duplicates ${producer.workflow}; the collector must choose exactly one newest run/attempt`,
+        );
+      }
+      workflows.add(producer.workflow);
+      validateRun(producer.run, `${at}.run`, problems);
+      validateSource(producer.source, `${at}.source`, problems);
+      stringValue(
+        producer.correlation_nonce,
+        `${at}.correlation_nonce`,
+        problems,
+        { pattern: CORRELATION_NONCE_RE },
+      );
+      if (producer.correlation_nonce !== document.correlation_nonce) {
+        problems.push(
+          `${at}.correlation_nonce does not match producer_manifest.correlation_nonce`,
+        );
+      }
+      validateEventIdentity(producer.event, `${at}.event`, problems);
+      stringValue(producer.repository, `${at}.repository`, problems, {
+        pattern: REPOSITORY_RE,
+      });
+      enumValue(
+        producer.conclusion,
+        JOB_CONCLUSIONS,
+        `${at}.conclusion`,
+        problems,
+      );
+
+      if (!Array.isArray(producer.jobs) || producer.jobs.length === 0) {
+        problems.push(`${at}.jobs must be a non-empty array`);
+      } else {
+        const jobs = new Set();
+        for (let j = 0; j < producer.jobs.length; j += 1) {
+          const job = producer.jobs[j];
+          const jobAt = `${at}.jobs[${j}]`;
+          if (!exactObject(job, TRUSTED_JOB_KEYS, jobAt, problems)) continue;
+          if (
+            stringValue(job.job, `${jobAt}.job`, problems, {
+              pattern: WORKFLOW_JOB_ID_RE,
+            }) &&
+            !knownJobs.get(producer.workflow)?.has(job.job)
+          ) {
+            problems.push(`${jobAt}.job is not registered for the workflow`);
+          }
+          if (jobs.has(job.job)) problems.push(`${jobAt}.job is duplicated`);
+          jobs.add(job.job);
+          stringValue(job.name, `${jobAt}.name`, problems);
+          stringValue(job.database_id, `${jobAt}.database_id`, problems, {
+            pattern: RUN_ID_RE,
+          });
+          enumValue(
+            job.conclusion,
+            JOB_CONCLUSIONS,
+            `${jobAt}.conclusion`,
+            problems,
+          );
+        }
+      }
+
+      if (!Array.isArray(producer.artifacts) || producer.artifacts.length !== 1) {
+        problems.push(`${at}.artifacts must contain exactly one native bundle`);
+      } else {
+        const artifactIDs = new Set();
+        const artifactNames = new Set();
+        for (let j = 0; j < producer.artifacts.length; j += 1) {
+          const artifact = producer.artifacts[j];
+          const artifactAt = `${at}.artifacts[${j}]`;
+          validateArtifact(
+            artifact,
+            TRUSTED_ARTIFACT_KEYS,
+            artifactAt,
+            problems,
+          );
+          const expectedName = nativeArtifactName(
+            producer.workflow,
+            producer.run,
+          );
+          if (artifact?.name !== expectedName) {
+            problems.push(`${artifactAt}.name must be ${expectedName}`);
+          }
+          if (!Array.isArray(artifact?.entries) || artifact.entries.length === 0) {
+            problems.push(`${artifactAt}.entries must be a non-empty array`);
+          } else {
+            const entries = new Set();
+            for (let k = 0; k < artifact.entries.length; k += 1) {
+              const entry = artifact.entries[k];
+              const entryAt = `${artifactAt}.entries[${k}]`;
+              if (
+                !exactObject(
+                  entry,
+                  TRUSTED_ARTIFACT_ENTRY_KEYS,
+                  entryAt,
+                  problems,
+                )
+              ) {
+                continue;
+              }
+              stringValue(entry.lane_id, `${entryAt}.lane_id`, problems, {
+                pattern: LANE_ID_RE,
+              });
+              stringValue(
+                entry.execution_id,
+                `${entryAt}.execution_id`,
+                problems,
+                { pattern: EXECUTION_ID_RE },
+              );
+              stringValue(entry.sha256, `${entryAt}.sha256`, problems, {
+                pattern: SHA256_RE,
+              });
+              const identity = `${entry.lane_id}/${entry.execution_id}`;
+              if (entries.has(identity)) {
+                problems.push(`${entryAt} duplicates native entry ${identity}`);
+              }
+              if (!knownEntries.get(producer.workflow)?.has(identity)) {
+                problems.push(
+                  `${entryAt} is not registered for ${producer.workflow}`,
+                );
+              }
+              entries.add(identity);
+            }
+          }
+          if (artifactIDs.has(artifact?.id))
+            problems.push(`${artifactAt}.id is duplicated`);
+          if (artifactNames.has(artifact?.name))
+            problems.push(`${artifactAt}.name is duplicated`);
+          artifactIDs.add(artifact?.id);
+          artifactNames.add(artifact?.name);
+        }
+      }
+    }
   }
   if (problems.length > 0)
-    throw new ContractError("invalid trusted job results", problems);
+    throw new ContractError("invalid trusted producer manifest", problems);
   return document;
 }
 
@@ -1868,12 +2301,42 @@ function validateQualificationExpectations(expected, registry, selection) {
   enumValue(expected.posture, SELECTION_POSTURES, "expected.posture", problems);
   stringValue(expected.sha, "expected.sha", problems, { pattern: SHA_RE });
   stringValue(expected.tree, "expected.tree", problems, { pattern: SHA_RE });
+  stringValue(
+    expected.correlationNonce,
+    "expected.correlationNonce",
+    problems,
+    { pattern: CORRELATION_NONCE_RE },
+  );
   stringValue(expected.runID, "expected.runID", problems, {
     pattern: RUN_ID_RE,
   });
   integerValue(expected.runAttempt, "expected.runAttempt", problems, {
     min: 1,
   });
+  stringValue(
+    expected.selectionManifestSHA256,
+    "expected.selectionManifestSHA256",
+    problems,
+    { pattern: SHA256_RE },
+  );
+  validateEventIdentity(
+    expected.eventIdentity,
+    "expected.eventIdentity",
+    problems,
+  );
+  stringValue(expected.repository, "expected.repository", problems, {
+    pattern: REPOSITORY_RE,
+  });
+  if (expected.eventIdentity?.projected_sha !== expected.sha) {
+    problems.push(
+      "expected.eventIdentity.projected_sha must equal expected.sha",
+    );
+  }
+  if (selection?.correlation_nonce !== expected.correlationNonce) {
+    problems.push(
+      "expected.correlationNonce must equal selection.correlation_nonce",
+    );
+  }
 
   if (expected.candidateDigest !== undefined) {
     validateDigest(
@@ -1896,6 +2359,23 @@ function validateQualificationExpectations(expected, registry, selection) {
       "expected.changedPaths",
       problems,
     );
+    if (
+      expected.eventIdentity?.kind !== "pull_request" &&
+      expected.eventIdentity?.kind !== "merge_group"
+    ) {
+      problems.push(
+        "merge qualification event must be pull_request or merge_group",
+      );
+    }
+    if (
+      (expected.eventIdentity?.kind === "pull_request" ||
+        expected.eventIdentity?.kind === "merge_group") &&
+      expected.eventIdentity.event_base_sha !== expected.baseSHA
+    ) {
+      problems.push(
+        "expected.eventIdentity.event_base_sha must equal expected.baseSHA for merge qualification",
+      );
+    }
   }
 
   const selectedIDs = new Set(
@@ -1927,17 +2407,48 @@ export function validateReportSet({
   registry,
   selection,
   reports,
-  jobResults,
+  producerManifest,
   expected = {},
 }) {
   validateQualificationExpectations(expected, registry, selection);
   validateSelection(selection, registry, expected);
-  validateJobResults(jobResults, registry);
+  validateProducerManifest(producerManifest, registry);
   const problems = [];
+  const computedSelectionDigest = selectionManifestSHA256(selection);
+  if (computedSelectionDigest !== expected.selectionManifestSHA256) {
+    problems.push(
+      "selection manifest SHA-256 does not match the trusted expected digest",
+    );
+  }
+  const selectionRef = {
+    run: selection.run,
+    manifest_sha256: expected.selectionManifestSHA256,
+  };
+  if (
+    producerManifest.selection_ref.run.id !== selectionRef.run.id ||
+    producerManifest.selection_ref.run.attempt !== selectionRef.run.attempt ||
+    producerManifest.selection_ref.manifest_sha256 !==
+      selectionRef.manifest_sha256
+  ) {
+    problems.push(
+      "trusted producer manifest selection_ref does not match the current selection",
+    );
+  }
+  if (
+    producerManifest.correlation_nonce !== selection.correlation_nonce ||
+    producerManifest.correlation_nonce !== expected.correlationNonce
+  ) {
+    problems.push(
+      "trusted producer manifest correlation_nonce does not match the current qualification",
+    );
+  }
+
   const lanesByID = new Map(registry.lanes.map((lane) => [lane.id, lane]));
   const expectedReports = new Map();
+  const expectedWorkflows = new Set();
   for (const item of selection.lanes) {
     if (item.disposition !== "selected") continue;
+    expectedWorkflows.add(lanesByID.get(item.lane_id).owner.workflow);
     for (const execution of item.executions) {
       expectedReports.set(`${item.lane_id}/${execution}`, {
         lane: lanesByID.get(item.lane_id),
@@ -1946,7 +2457,49 @@ export function validateReportSet({
     }
   }
 
+  const trustedByWorkflow = new Map();
+  for (const producer of producerManifest.producers) {
+    trustedByWorkflow.set(producer.workflow, producer);
+    if (!expectedWorkflows.has(producer.workflow)) {
+      problems.push(
+        `unexpected trusted producer workflow ${producer.workflow}; no selected lane owns it`,
+      );
+    }
+    if (
+      producer.source.sha !== selection.source.sha ||
+      producer.source.tree !== selection.source.tree
+    ) {
+      problems.push(
+        `${producer.workflow}: trusted producer projected SHA/tree does not match the selection`,
+      );
+    }
+    if (
+      EVENT_IDENTITY_KEYS.size !== Object.keys(producer.event).length ||
+      [...EVENT_IDENTITY_KEYS].some(
+        (key) => producer.event[key] !== expected.eventIdentity[key],
+      )
+    ) {
+      problems.push(
+        `${producer.workflow}: trusted producer event identity does not match the qualification event`,
+      );
+    }
+    if (producer.repository !== expected.repository) {
+      problems.push(
+        `${producer.workflow}: trusted producer repository does not match the qualification repository`,
+      );
+    }
+    // Workflow-level conclusion is telemetry, not a lane verdict. A workflow
+    // may contain an unselected red job alongside a selected green lane; only
+    // the selected context and its native entry decide qualification.
+  }
+  for (const workflow of expectedWorkflows) {
+    if (!trustedByWorkflow.has(workflow)) {
+      problems.push(`trusted producer run for ${workflow} is missing`);
+    }
+  }
+
   const actual = new Map();
+  const claimedEntries = new Set();
   for (let i = 0; i < reports.length; i += 1) {
     let report;
     try {
@@ -1986,12 +2539,18 @@ export function validateReportSet({
         `${identity}: source SHA/tree does not match the selection`,
       );
     }
-    if (report.run.id !== selection.run.id) {
-      problems.push(`${identity}: report run id does not match the selection`);
-    }
-    if (report.run.attempt !== selection.run.attempt) {
+    if (
+      report.selection_ref.run.id !== selectionRef.run.id ||
+      report.selection_ref.run.attempt !== selectionRef.run.attempt ||
+      report.selection_ref.manifest_sha256 !== selectionRef.manifest_sha256
+    ) {
       problems.push(
-        `${identity}: report run attempt does not match the selection`,
+        `${identity}: selection_ref does not match the current selection`,
+      );
+    }
+    if (report.correlation_nonce !== selection.correlation_nonce) {
+      problems.push(
+        `${identity}: correlation_nonce does not match the current qualification`,
       );
     }
     const mode = expectedInvocationMode(lane, selection.posture);
@@ -2034,41 +2593,98 @@ export function validateReportSet({
       problems.push(`${identity}: seeded lane omitted its seed`);
     }
 
-    for (const job of lane.owner.jobs) {
-      const key = `${lane.owner.workflow}#${job}`;
-      const trusted = jobResults[key];
-      if (!trusted) {
-        problems.push(`${identity}: trusted result for ${key} is missing`);
-        continue;
-      }
-      if (trusted.conclusion !== "success") {
+    const trusted = trustedByWorkflow.get(report.producer.workflow);
+    if (!trusted) continue;
+    if (
+      report.producer.run.id !== trusted.run.id ||
+      report.producer.run.attempt !== trusted.run.attempt
+    ) {
+      problems.push(
+        `${identity}: producer run identity does not match the trusted workflow run`,
+      );
+    }
+    const context = trusted.jobs.find(
+      (job) => job.job === report.producer.job,
+    );
+    if (!context) {
+      problems.push(
+        `${identity}: trusted context job ${report.producer.job} is missing`,
+      );
+    } else {
+      const contextNameMatches =
+        lane.context.match === "exact"
+          ? context.name === lane.context.name
+          : context.name.startsWith(lane.context.name);
+      if (!contextNameMatches) {
         problems.push(
-          `${identity}: trusted result for ${key} is ${trusted.conclusion}`,
+          `${identity}: trusted context check name ${context.name} does not match ${lane.context.name}`,
         );
       }
-      if (
-        trusted.run_id !== selection.run.id ||
-        trusted.run_attempt !== selection.run.attempt
-      ) {
+      if (context.conclusion !== "success") {
         problems.push(
-          `${identity}: trusted result for ${key} does not match the selection run`,
+          `${identity}: trusted context job ${report.producer.job} is ${context.conclusion}`,
         );
-      }
-      if (job === lane.owner.context_job) {
-        if (
-          trusted.run_id !== report.run.id ||
-          trusted.run_attempt !== report.run.attempt
-        ) {
-          problems.push(
-            `${identity}: producer run identity does not match trusted ${key}`,
-          );
-        }
       }
     }
+    const artifact = trusted.artifacts.find(
+      (candidate) => candidate.id === report.producer.artifact.id,
+    );
+    if (!artifact) {
+      problems.push(
+        `${identity}: trusted artifact ${report.producer.artifact.id} is missing`,
+      );
+    } else if (
+      artifact.name !== report.producer.artifact.name ||
+      artifact.sha256 !== report.producer.artifact.sha256
+    ) {
+      problems.push(
+        `${identity}: producer artifact name or SHA-256 does not match trusted API provenance`,
+      );
+    } else {
+      const entry = artifact.entries.find(
+        (candidate) =>
+          candidate.lane_id === report.lane_id &&
+          candidate.execution_id === report.execution_id,
+      );
+      if (!entry) {
+        problems.push(
+          `${identity}: trusted native bundle entry is missing`,
+        );
+      } else if (
+        entry.sha256 !== report.producer.artifact.entry_sha256
+      ) {
+        problems.push(
+          `${identity}: native bundle entry SHA-256 does not match trusted provenance`,
+        );
+      }
+    }
+    const entryIdentity =
+      `${report.producer.workflow}#${report.producer.run.id}#` +
+      `${report.producer.run.attempt}#${report.producer.artifact.id}#` +
+      `${report.producer.artifact.entry}`;
+    if (claimedEntries.has(entryIdentity)) {
+      problems.push(`${identity}: native bundle entry is reused by another report`);
+    }
+    claimedEntries.add(entryIdentity);
   }
 
   for (const identity of expectedReports.keys()) {
     if (!actual.has(identity)) problems.push(`missing report ${identity}`);
+  }
+  for (const workflow of expectedWorkflows) {
+    const producer = trustedByWorkflow.get(workflow);
+    if (producer?.artifacts.length !== 1) continue;
+    const artifact = producer.artifacts[0];
+    const consumed = [...claimedEntries].some((identity) =>
+      identity.startsWith(
+        `${workflow}#${producer.run.id}#${producer.run.attempt}#${artifact.id}#`,
+      ),
+    );
+    if (!consumed) {
+      problems.push(
+        `${workflow}: trusted native artifact ${artifact.name} was not consumed by a selected report`,
+      );
+    }
   }
   if (problems.length > 0)
     throw new ContractError("CI lane qualification failed closed", problems);
@@ -2154,13 +2770,25 @@ export function qualificationExpectations(env = process.env) {
   const posture = env.CI_LANE_POSTURE;
   const sha = env.CI_EXPECT_SHA;
   const tree = env.CI_EXPECT_TREE;
+  const correlationNonce = env.CI_EXPECT_CORRELATION_NONCE;
   const runID = env.CI_EXPECT_RUN_ID;
+  const selectionManifestSHA256 = env.CI_EXPECT_SELECTION_SHA256;
+  const eventKind = env.CI_EXPECT_EVENT_KIND;
+  const eventHeadSHA = env.CI_EXPECT_EVENT_HEAD_SHA;
+  const projectedSHA = env.CI_EXPECT_PROJECTED_SHA;
+  const repository = env.CI_EXPECT_REPOSITORY;
   for (const [name, value] of [
     ["CI_LANE_POSTURE", posture],
     ["CI_EXPECT_SHA", sha],
     ["CI_EXPECT_TREE", tree],
+    ["CI_EXPECT_CORRELATION_NONCE", correlationNonce],
     ["CI_EXPECT_RUN_ID", runID],
     ["CI_EXPECT_RUN_ATTEMPT", env.CI_EXPECT_RUN_ATTEMPT],
+    ["CI_EXPECT_SELECTION_SHA256", selectionManifestSHA256],
+    ["CI_EXPECT_EVENT_KIND", eventKind],
+    ["CI_EXPECT_EVENT_HEAD_SHA", eventHeadSHA],
+    ["CI_EXPECT_PROJECTED_SHA", projectedSHA],
+    ["CI_EXPECT_REPOSITORY", repository],
   ]) {
     if (typeof value !== "string" || value === "")
       problems.push(`${name} is required`);
@@ -2168,7 +2796,22 @@ export function qualificationExpectations(env = process.env) {
   enumValue(posture, SELECTION_POSTURES, "CI_LANE_POSTURE", problems);
   stringValue(sha, "CI_EXPECT_SHA", problems, { pattern: SHA_RE });
   stringValue(tree, "CI_EXPECT_TREE", problems, { pattern: SHA_RE });
+  stringValue(
+    correlationNonce,
+    "CI_EXPECT_CORRELATION_NONCE",
+    problems,
+    { pattern: CORRELATION_NONCE_RE },
+  );
   stringValue(runID, "CI_EXPECT_RUN_ID", problems, { pattern: RUN_ID_RE });
+  stringValue(
+    selectionManifestSHA256,
+    "CI_EXPECT_SELECTION_SHA256",
+    problems,
+    { pattern: SHA256_RE },
+  );
+  stringValue(repository, "CI_EXPECT_REPOSITORY", problems, {
+    pattern: REPOSITORY_RE,
+  });
 
   let runAttempt;
   if (env.CI_EXPECT_RUN_ATTEMPT !== undefined) {
@@ -2187,6 +2830,29 @@ export function qualificationExpectations(env = process.env) {
   ) {
     candidateDigest = env.CI_EXPECT_CANDIDATE_DIGEST;
     validateDigest(candidateDigest, "CI_EXPECT_CANDIDATE_DIGEST", problems);
+  }
+
+  let prNumber = null;
+  if (env.CI_EXPECT_PR_NUMBER !== undefined && env.CI_EXPECT_PR_NUMBER !== "") {
+    if (!/^[1-9][0-9]*$/.test(env.CI_EXPECT_PR_NUMBER)) {
+      problems.push("CI_EXPECT_PR_NUMBER must be a canonical positive integer");
+    } else {
+      prNumber = Number(env.CI_EXPECT_PR_NUMBER);
+      if (!Number.isSafeInteger(prNumber)) {
+        problems.push("CI_EXPECT_PR_NUMBER exceeds JavaScript's safe integer range");
+      }
+    }
+  }
+  const eventIdentity = {
+    kind: eventKind,
+    pr_number: prNumber,
+    event_head_sha: eventHeadSHA,
+    event_base_sha: env.CI_EXPECT_EVENT_BASE_SHA || null,
+    projected_sha: projectedSHA,
+  };
+  validateEventIdentity(eventIdentity, "CI event identity", problems);
+  if (projectedSHA !== sha) {
+    problems.push("CI_EXPECT_PROJECTED_SHA must equal CI_EXPECT_SHA");
   }
   if (posture === "release" && candidateDigest === undefined) {
     problems.push(
@@ -2235,9 +2901,13 @@ export function qualificationExpectations(env = process.env) {
     posture,
     sha,
     tree,
+    correlationNonce,
     candidateDigest,
     runID,
     runAttempt,
+    selectionManifestSHA256,
+    eventIdentity,
+    repository,
     baseSHA,
     changedPaths,
   };
@@ -2264,7 +2934,7 @@ function main() {
 
   const selectionPath = process.env.CI_LANE_SELECTION;
   const reportDir = process.env.CI_LANE_REPORT_DIR;
-  const rawResults = process.env.CI_LANE_JOB_RESULTS_JSON;
+  const producerManifestPath = process.env.CI_LANE_PRODUCER_MANIFEST;
   if (!selectionPath)
     throw new ContractError("CI lane contract", [
       "CI_LANE_SELECTION is required",
@@ -2273,17 +2943,9 @@ function main() {
     throw new ContractError("CI lane contract", [
       "CI_LANE_REPORT_DIR is required",
     ]);
-  if (!rawResults) {
+  if (!producerManifestPath) {
     throw new ContractError("CI lane contract", [
-      "CI_LANE_JOB_RESULTS_JSON is required",
-    ]);
-  }
-  let jobResults;
-  try {
-    jobResults = JSON.parse(rawResults);
-  } catch (error) {
-    throw new ContractError("CI lane contract", [
-      `CI_LANE_JOB_RESULTS_JSON is not valid JSON: ${error.message}`,
+      "CI_LANE_PRODUCER_MANIFEST is required",
     ]);
   }
   const reportsWithPaths = readReports(resolve(root, reportDir));
@@ -2291,7 +2953,10 @@ function main() {
     registry,
     selection: parseJSONFile(resolve(root, selectionPath), "CI lane selection"),
     reports: reportsWithPaths.map((entry) => entry.document),
-    jobResults,
+    producerManifest: parseJSONFile(
+      resolve(root, producerManifestPath),
+      "trusted producer manifest",
+    ),
     expected: qualificationExpectations(process.env),
   });
   process.stdout.write(

--- a/.github/scripts/ci-lane-contract.test.mjs
+++ b/.github/scripts/ci-lane-contract.test.mjs
@@ -247,12 +247,36 @@ function registryFixture() {
     report_schema_version: REPORT_SCHEMA_VERSION,
     rollout: "shadow",
     impact_selection: { known_nonimpact_globs: ["**/*.md", "docs/**"] },
+    native_evidence: {
+      schema_version: 1,
+      parts: [
+        {
+          id: "always-go",
+          lane_id: "always",
+          execution_id: "default",
+          invocation_mode: "source_tree",
+          producer_job: "lint",
+          parser: "go-test-json-v1",
+          entry: "go-test.json",
+        },
+        {
+          id: "impact-tap",
+          lane_id: "impact",
+          execution_id: "shard-a",
+          invocation_mode: "source_tree",
+          producer_job: "shard",
+          parser: "node-tap-v1",
+          entry: "node.tap",
+        },
+      ],
+    },
     layers: CANONICAL_LAYER_IDS.map((id) => ({ id, name: `Layer ${id}` })),
     lanes: [
       lane({
         id: "always",
         workflow: ".github/workflows/ci.yml",
         jobs: ["check", "lint"],
+        producerJobs: ["lint"],
         contextJob: "check",
         layers: CANONICAL_LAYER_IDS,
         recipes: ["test"],
@@ -507,7 +531,13 @@ function producerRunFor(workflow) {
   return PRODUCER_RUNS[workflow];
 }
 
-function nativeArtifactFor(workflow, laneID, executionID, run) {
+function nativeArtifactFor(
+  workflow,
+  laneID,
+  executionID,
+  invocationMode,
+  run,
+) {
   const ordinal = {
     ".github/workflows/ci.yml": 901,
     ".github/workflows/e2e.yml": 902,
@@ -524,7 +554,7 @@ function nativeArtifactFor(workflow, laneID, executionID, run) {
     id: String(ordinal),
     name: nativeArtifactName(workflow, run),
     sha256: String(ordinal % 10).repeat(64),
-    entry: `${laneID}/${executionID}`,
+    entry: `${laneID}/${executionID}/${invocationMode}`,
     entry_sha256: digestByte.repeat(64),
   };
 }
@@ -536,12 +566,24 @@ function selectionRefFor(selection) {
   };
 }
 
-function reportFor(registry, selection, laneID, executionID = "default") {
+function reportFor(
+  registry,
+  selection,
+  laneID,
+  executionID = "default",
+  invocationMode,
+) {
   const registered = registry.lanes.find(
     (candidate) => candidate.id === laneID,
   );
-  const candidateArtifact =
-    selection.posture === "release" && registered.applicability.artifact;
+  const mode =
+    invocationMode ??
+    (selection.posture === "release" &&
+    registered.applicability.artifact &&
+    !registered.applicability.source
+      ? "candidate_artifact"
+      : "source_tree");
+  const candidateArtifact = mode === "candidate_artifact";
   const producerRun = producerRunFor(registered.owner.workflow);
   return {
     schema_version: REPORT_SCHEMA_VERSION,
@@ -561,11 +603,12 @@ function reportFor(registry, selection, laneID, executionID = "default") {
         registered.owner.workflow,
         laneID,
         executionID,
+        mode,
         producerRun,
       ),
     },
     invocation: {
-      mode: candidateArtifact ? "candidate_artifact" : "source_tree",
+      mode,
       recipe: registered.recipes[0] ?? null,
       command: registered.command,
       build_tags: [...registered.build_tags],
@@ -605,6 +648,9 @@ function producerManifestFor(registry, selection) {
       });
     }
     const producer = producers.get(workflow);
+    const artifactMode = registered.applicability.source
+      ? "source_tree"
+      : "candidate_artifact";
     if (!producer.jobs.some((job) => job.job === registered.owner.context_job))
       producer.jobs.push({
         job: registered.owner.context_job,
@@ -614,30 +660,45 @@ function producerManifestFor(registry, selection) {
       });
     if (producer.artifacts.length === 0) {
       producer.artifacts.push({
-        id: nativeArtifactFor(workflow, item.lane_id, item.executions[0], run)
-          .id,
+        id: nativeArtifactFor(
+          workflow,
+          item.lane_id,
+          item.executions[0],
+          artifactMode,
+          run,
+        ).id,
         name: nativeArtifactName(workflow, run),
         sha256: nativeArtifactFor(
           workflow,
           item.lane_id,
           item.executions[0],
+          artifactMode,
           run,
         ).sha256,
         entries: [],
       });
     }
     for (const execution of item.executions) {
-      const reference = nativeArtifactFor(
-        workflow,
-        item.lane_id,
-        execution,
-        run,
-      );
-      producer.artifacts[0].entries.push({
-        lane_id: item.lane_id,
-        execution_id: execution,
-        sha256: reference.entry_sha256,
-      });
+      const modes = [];
+      if (registered.applicability.source) modes.push("source_tree");
+      if (selection.posture === "release" && registered.applicability.artifact) {
+        modes.push("candidate_artifact");
+      }
+      for (const mode of modes) {
+        const reference = nativeArtifactFor(
+          workflow,
+          item.lane_id,
+          execution,
+          mode,
+          run,
+        );
+        producer.artifacts[0].entries.push({
+          lane_id: item.lane_id,
+          execution_id: execution,
+          invocation_mode: mode,
+          sha256: reference.entry_sha256,
+        });
+      }
     }
   }
   return {
@@ -912,7 +973,7 @@ test("registry rejects invalid enums and invalid workflow job IDs", () => {
   }
 });
 
-test("registry producer jobs are unique owner jobs and exclude the terminal context", () => {
+test("registry producer jobs are unique owner jobs with an exact native-part roster", () => {
   const cases = [
     {
       producerJobs: ["shard", "shard"],
@@ -922,16 +983,20 @@ test("registry producer jobs are unique owner jobs and exclude the terminal cont
       producerJobs: ["ghost"],
       pattern: /producer_jobs contains ghost, which is not in owner\.jobs/,
     },
-    {
-      producerJobs: ["aggregate"],
-      pattern: /producer_jobs must exclude the context_job aggregate/,
-    },
   ];
   for (const { producerJobs, pattern } of cases) {
     const document = registryFixture();
     document.lanes[1].owner.producer_jobs = producerJobs;
     expectContractError(() => validateRegistry(document, { root }), pattern);
   }
+
+  const directContextProducer = registryFixture();
+  directContextProducer.lanes[1].owner.producer_jobs = ["aggregate"];
+  directContextProducer.native_evidence.parts[1].producer_job = "aggregate";
+  assert.equal(
+    validateRegistry(directContextProducer, { root }),
+    directContextProducer,
+  );
 });
 
 test("registry discovers and rejects an unclassified .yaml workflow", () => {
@@ -1689,7 +1754,7 @@ test("report set rejects artifact digest mismatch", () => {
         reports,
         producerManifest: producerManifestFor(registry, selection),
       }),
-    /release\/artifact: candidate digest does not match the selection/,
+    /release\/artifact\/candidate_artifact: candidate digest does not match the selection/,
   );
 });
 
@@ -1832,6 +1897,203 @@ test("release report set qualifies all release-required source and artifact lane
       producerManifest: producerManifestFor(registry, selection),
     }),
     { expected: 4, received: 4 },
+  );
+});
+
+test("canonical pre-publication qualification validates exactly 45 invocations", () => {
+  const registry = JSON.parse(readFileSync(".github/ci-lanes.json", "utf8"));
+  const selection = {
+    schema_version: registry.selection_schema_version,
+    registry_schema_version: registry.schema_version,
+    report_schema_version: registry.report_schema_version,
+    posture: "release",
+    source: { sha: SOURCE_SHA, tree: SOURCE_TREE },
+    candidate_digest: CANDIDATE_DIGEST,
+    correlation_nonce: RELEASE_CORRELATION_NONCE,
+    run: { ...RUN },
+    selector: {
+      conclusion: "success",
+      base_sha: null,
+      head_sha: null,
+      changed_paths: [],
+      unknown_paths: [],
+    },
+    lanes: registry.lanes.map((registered) => {
+      if (registered.release_posture === "post_publish") {
+        return {
+          lane_id: registered.id,
+          disposition: "omitted",
+          executions: [],
+          reason: "post_publish",
+        };
+      }
+      if (registered.determinism === "observational") {
+        return {
+          lane_id: registered.id,
+          disposition: "omitted",
+          executions: [],
+          reason: "advisory",
+        };
+      }
+      return {
+        lane_id: registered.id,
+        disposition: "selected",
+        executions: [...registered.executions],
+        reason: null,
+      };
+    }),
+  };
+  const selected = selection.lanes.filter(
+    (item) => item.disposition === "selected",
+  );
+  const workflows = [
+    ...new Set(
+      selected.map(
+        (item) =>
+          registry.lanes.find((lane) => lane.id === item.lane_id).owner
+            .workflow,
+      ),
+    ),
+  ].sort();
+  const producerRuns = new Map(
+    workflows.map((workflow, index) => [
+      workflow,
+      { id: String(5001 + index), attempt: 1 },
+    ]),
+  );
+  const producers = new Map(
+    workflows.map((workflow, index) => {
+      const run = producerRuns.get(workflow);
+      const digestByte = ((index % 15) + 1).toString(16);
+      return [
+        workflow,
+        {
+          workflow,
+          run,
+          source: { ...selection.source },
+          correlation_nonce: selection.correlation_nonce,
+          event: eventIdentityFor(selection),
+          repository: REPOSITORY,
+          conclusion: "success",
+          jobs: [],
+          artifacts: [
+            {
+              id: String(6001 + index),
+              name: nativeArtifactName(workflow, run),
+              sha256: digestByte.repeat(64),
+              entries: [],
+            },
+          ],
+        },
+      ];
+    }),
+  );
+  const reports = [];
+  for (const item of selected) {
+    const registered = registry.lanes.find(
+      (lane) => lane.id === item.lane_id,
+    );
+    const producer = producers.get(registered.owner.workflow);
+    if (
+      !producer.jobs.some(
+        (job) =>
+          job.job === registered.owner.context_job &&
+          job.name === registered.context.name,
+      )
+    ) {
+      producer.jobs.push({
+        job: registered.owner.context_job,
+        name: registered.context.name,
+        database_id: String(
+          700001 +
+            workflows.indexOf(registered.owner.workflow) * 100 +
+            producer.jobs.length,
+        ),
+        conclusion: "success",
+      });
+    }
+    const modes = [];
+    if (registered.applicability.source) modes.push("source_tree");
+    if (registered.applicability.artifact) {
+      modes.push("candidate_artifact");
+    }
+    for (const executionID of item.executions) {
+      for (const mode of modes) {
+        const entrySHA256 = ((reports.length % 15) + 1)
+          .toString(16)
+          .repeat(64);
+        producer.artifacts[0].entries.push({
+          lane_id: registered.id,
+          execution_id: executionID,
+          invocation_mode: mode,
+          sha256: entrySHA256,
+        });
+        reports.push({
+          schema_version: registry.report_schema_version,
+          registry_schema_version: registry.schema_version,
+          lane_id: registered.id,
+          execution_id: executionID,
+          posture: selection.posture,
+          source: { ...selection.source },
+          candidate_digest:
+            mode === "candidate_artifact"
+              ? selection.candidate_digest
+              : null,
+          correlation_nonce: selection.correlation_nonce,
+          selection_ref: selectionRefFor(selection),
+          producer: {
+            workflow: registered.owner.workflow,
+            job: registered.owner.context_job,
+            run: { ...producer.run },
+            artifact: {
+              id: producer.artifacts[0].id,
+              name: producer.artifacts[0].name,
+              sha256: producer.artifacts[0].sha256,
+              entry: `${registered.id}/${executionID}/${mode}`,
+              entry_sha256: entrySHA256,
+            },
+          },
+          invocation: {
+            mode,
+            recipe: registered.recipes[0] ?? null,
+            command: registered.command,
+            build_tags: [...registered.build_tags],
+            selected_domains: [registered.risk_domains[0]],
+          },
+          evidence: {
+            executed: 1,
+            passed: 1,
+            failed: 0,
+            skipped: 0,
+            duration_ms: 1,
+            seed:
+              registered.determinism === "seeded"
+                ? "canonical-release-seed"
+                : null,
+            corpus_id: `canonical-${registered.id}-${executionID}-${mode}`,
+          },
+          conclusion: "success",
+        });
+      }
+    }
+  }
+  const producerManifest = {
+    schema_version: registry.report_schema_version,
+    correlation_nonce: selection.correlation_nonce,
+    selection_ref: selectionRefFor(selection),
+    producers: [...producers.values()],
+  };
+
+  assert.equal(selected.length, 44);
+  assert.equal(reports.length, 45);
+  assert.deepEqual(
+    validateReportSet({
+      registry,
+      selection,
+      reports,
+      producerManifest,
+    }),
+    { expected: 45, received: 45 },
   );
 });
 

--- a/.github/scripts/ci-lane-contract.test.mjs
+++ b/.github/scripts/ci-lane-contract.test.mjs
@@ -19,12 +19,16 @@ import {
   CANONICAL_HEAD_ORACLE_FLOORS,
   ContractError,
   MERGE_P95_SLO_MINUTES,
+  REPORT_SCHEMA_VERSION,
   RELEASE_QUALIFICATION_SLO_MINUTES,
+  deriveQualificationCorrelationNonce,
   loadRegistry,
+  nativeArtifactName,
   parseExpectedRunAttempt,
   qualificationExpectations,
   renderSummary,
-  validateJobResults,
+  selectionManifestSHA256,
+  validateProducerManifest,
   validateRegistry,
   validateReport,
   validateReportSet as validateReportSetContract,
@@ -61,7 +65,18 @@ const OTHER_SHA = "c".repeat(40);
 const CANDIDATE_DIGEST = `sha256:${"d".repeat(64)}`;
 const OTHER_DIGEST = `sha256:${"e".repeat(64)}`;
 const BASE_SHA = "f".repeat(40);
+const MERGE_CORRELATION_NONCE = deriveQualificationCorrelationNonce({
+  posture: "merge",
+  source: { sha: SOURCE_SHA, tree: SOURCE_TREE },
+});
+const RELEASE_CORRELATION_NONCE = "9".repeat(64);
 const RUN = Object.freeze({ id: "321", attempt: 2 });
+const REPOSITORY = "example/project";
+const PRODUCER_RUNS = Object.freeze({
+  ".github/workflows/ci.yml": Object.freeze({ id: "801", attempt: 3 }),
+  ".github/workflows/e2e.yml": Object.freeze({ id: "802", attempt: 4 }),
+  ".github/workflows/release.yml": Object.freeze({ id: "803", attempt: 5 }),
+});
 const NON_SUCCESS_CONCLUSIONS = [
   "action_required",
   "cancelled",
@@ -221,7 +236,7 @@ function lane({
     timeout_minutes: timeoutMinutes,
     slo_minutes: sloMinutes,
     accountable_owner: "quality",
-    report_schema_version: 1,
+    report_schema_version: REPORT_SCHEMA_VERSION,
   };
 }
 
@@ -229,7 +244,7 @@ function registryFixture() {
   return {
     schema_version: 1,
     selection_schema_version: 1,
-    report_schema_version: 1,
+    report_schema_version: REPORT_SCHEMA_VERSION,
     rollout: "shadow",
     impact_selection: { known_nonimpact_globs: ["**/*.md", "docs/**"] },
     layers: CANONICAL_LAYER_IDS.map((id) => ({ id, name: `Layer ${id}` })),
@@ -328,10 +343,11 @@ function mergeSelection({
   return {
     schema_version: 1,
     registry_schema_version: 1,
-    report_schema_version: 1,
+    report_schema_version: REPORT_SCHEMA_VERSION,
     posture: "merge",
     source: { sha: SOURCE_SHA, tree: SOURCE_TREE },
     candidate_digest: null,
+    correlation_nonce: MERGE_CORRELATION_NONCE,
     run: { ...RUN },
     selector: {
       conclusion: selectorConclusion,
@@ -358,7 +374,13 @@ function mergeSelection({
             lane_id: "impact",
             disposition: "omitted",
             executions: [],
-            reason: "not_impacted",
+            reason:
+              changedPaths.length > 0 &&
+              changedPaths.every(
+                (path) => path.endsWith(".md") || path.startsWith("docs/"),
+              )
+                ? "docs_only"
+                : "not_impacted",
           },
       {
         lane_id: "oracle-property",
@@ -414,10 +436,11 @@ function releaseSelection() {
   return {
     schema_version: 1,
     registry_schema_version: 1,
-    report_schema_version: 1,
+    report_schema_version: REPORT_SCHEMA_VERSION,
     posture: "release",
     source: { sha: SOURCE_SHA, tree: SOURCE_TREE },
     candidate_digest: CANDIDATE_DIGEST,
+    correlation_nonce: RELEASE_CORRELATION_NONCE,
     run: { ...RUN },
     selector: {
       conclusion: "success",
@@ -461,24 +484,85 @@ function releaseSelection() {
   };
 }
 
+function eventIdentityFor(selection) {
+  if (selection.posture === "merge") {
+    return {
+      kind: "pull_request",
+      pr_number: 17,
+      event_head_sha: OTHER_SHA,
+      event_base_sha: BASE_SHA,
+      projected_sha: selection.source.sha,
+    };
+  }
+  return {
+    kind: selection.posture === "main" ? "push" : "workflow_dispatch",
+    pr_number: null,
+    event_head_sha: selection.source.sha,
+    event_base_sha: null,
+    projected_sha: selection.source.sha,
+  };
+}
+
+function producerRunFor(workflow) {
+  return PRODUCER_RUNS[workflow];
+}
+
+function nativeArtifactFor(workflow, laneID, executionID, run) {
+  const ordinal = {
+    ".github/workflows/ci.yml": 901,
+    ".github/workflows/e2e.yml": 902,
+    ".github/workflows/release.yml": 903,
+  }[workflow];
+  const digestByte = {
+    always: "1",
+    impact: "2",
+    release: "3",
+    "oracle-property": "4",
+    "oracle-reference": "5",
+  }[laneID];
+  return {
+    id: String(ordinal),
+    name: nativeArtifactName(workflow, run),
+    sha256: String(ordinal % 10).repeat(64),
+    entry: `${laneID}/${executionID}`,
+    entry_sha256: digestByte.repeat(64),
+  };
+}
+
+function selectionRefFor(selection) {
+  return {
+    run: { ...selection.run },
+    manifest_sha256: selectionManifestSHA256(selection),
+  };
+}
+
 function reportFor(registry, selection, laneID, executionID = "default") {
   const registered = registry.lanes.find(
     (candidate) => candidate.id === laneID,
   );
   const candidateArtifact =
     selection.posture === "release" && registered.applicability.artifact;
+  const producerRun = producerRunFor(registered.owner.workflow);
   return {
-    schema_version: 1,
+    schema_version: REPORT_SCHEMA_VERSION,
     registry_schema_version: 1,
     lane_id: laneID,
     execution_id: executionID,
     posture: selection.posture,
     source: { ...selection.source },
     candidate_digest: candidateArtifact ? selection.candidate_digest : null,
-    run: { ...selection.run },
+    correlation_nonce: selection.correlation_nonce,
+    selection_ref: selectionRefFor(selection),
     producer: {
       workflow: registered.owner.workflow,
       job: registered.owner.context_job,
+      run: { ...producerRun },
+      artifact: nativeArtifactFor(
+        registered.owner.workflow,
+        laneID,
+        executionID,
+        producerRun,
+      ),
     },
     invocation: {
       mode: candidateArtifact ? "candidate_artifact" : "source_tree",
@@ -500,24 +584,68 @@ function reportFor(registry, selection, laneID, executionID = "default") {
   };
 }
 
-function jobResultsFor(registry, selection) {
-  const selected = new Set(
-    selection.lanes
-      .filter((item) => item.disposition === "selected")
-      .map((item) => item.lane_id),
-  );
-  const results = {};
-  for (const registered of registry.lanes) {
-    if (!selected.has(registered.id)) continue;
-    for (const job of registered.owner.jobs) {
-      results[`${registered.owner.workflow}#${job}`] = {
+function producerManifestFor(registry, selection) {
+  const producers = new Map();
+  for (const item of selection.lanes) {
+    if (item.disposition !== "selected") continue;
+    const registered = registry.lanes.find((lane) => lane.id === item.lane_id);
+    const workflow = registered.owner.workflow;
+    const run = producerRunFor(workflow);
+    if (!producers.has(workflow)) {
+      producers.set(workflow, {
+        workflow,
+        run: { ...run },
+        source: { ...selection.source },
+        correlation_nonce: selection.correlation_nonce,
+        event: eventIdentityFor(selection),
+        repository: REPOSITORY,
         conclusion: "success",
-        run_id: selection.run.id,
-        run_attempt: selection.run.attempt,
-      };
+        jobs: [],
+        artifacts: [],
+      });
+    }
+    const producer = producers.get(workflow);
+    if (!producer.jobs.some((job) => job.job === registered.owner.context_job))
+      producer.jobs.push({
+        job: registered.owner.context_job,
+        name: registered.context.name,
+        database_id: String(701 + producer.jobs.length),
+        conclusion: "success",
+      });
+    if (producer.artifacts.length === 0) {
+      producer.artifacts.push({
+        id: nativeArtifactFor(workflow, item.lane_id, item.executions[0], run)
+          .id,
+        name: nativeArtifactName(workflow, run),
+        sha256: nativeArtifactFor(
+          workflow,
+          item.lane_id,
+          item.executions[0],
+          run,
+        ).sha256,
+        entries: [],
+      });
+    }
+    for (const execution of item.executions) {
+      const reference = nativeArtifactFor(
+        workflow,
+        item.lane_id,
+        execution,
+        run,
+      );
+      producer.artifacts[0].entries.push({
+        lane_id: item.lane_id,
+        execution_id: execution,
+        sha256: reference.entry_sha256,
+      });
     }
   }
-  return results;
+  return {
+    schema_version: REPORT_SCHEMA_VERSION,
+    correlation_nonce: selection.correlation_nonce,
+    selection_ref: selectionRefFor(selection),
+    producers: [...producers.values()],
+  };
 }
 
 function qualificationExpected(selection) {
@@ -525,10 +653,14 @@ function qualificationExpected(selection) {
     posture: selection.posture,
     sha: selection.source.sha,
     tree: selection.source.tree,
+    correlationNonce: selection.correlation_nonce,
     candidateDigest:
       selection.posture === "release" ? selection.candidate_digest : undefined,
     runID: selection.run.id,
     runAttempt: selection.run.attempt,
+    selectionManifestSHA256: selectionManifestSHA256(selection),
+    eventIdentity: eventIdentityFor(selection),
+    repository: REPOSITORY,
     baseSHA:
       selection.posture === "merge" ? selection.selector.base_sha : undefined,
     changedPaths:
@@ -940,6 +1072,23 @@ test("selection rejects unknown and missing schema fields", () => {
   );
 });
 
+test("selection correlation is mandatory and bound to projected Git objects", () => {
+  const registry = registryFixture();
+  const missing = mergeSelection();
+  delete missing.correlation_nonce;
+  expectContractError(
+    () => validateSelection(missing, registry),
+    /selection\.correlation_nonce is required/,
+  );
+
+  const mismatched = mergeSelection();
+  mismatched.correlation_nonce = "8".repeat(64);
+  expectContractError(
+    () => validateSelection(mismatched, registry),
+    /merge selection\.correlation_nonce does not match its projected Git objects/,
+  );
+});
+
 test("selector failure and unknown paths fail closed to fallback_full", () => {
   const registry = registryFixture();
 
@@ -1169,44 +1318,49 @@ test("report rejects negative, noninteger, inconsistent, and dishonest evidence"
   }
 });
 
-test("trusted job-result schema rejects unknown, missing, invalid, and noninteger values", () => {
+test("trusted producer manifest rejects unknown, missing, duplicate, and invalid provenance", () => {
   const registry = registryFixture();
   const selection = mergeSelection();
-  const valid = jobResultsFor(registry, selection);
-  assert.equal(validateJobResults(valid, registry), valid);
+  const valid = producerManifestFor(registry, selection);
+  assert.equal(validateProducerManifest(valid, registry), valid);
 
   const unknown = structuredClone(valid);
-  unknown[".github/workflows/ci.yml#ghost"] = {
-    conclusion: "success",
-    run_id: RUN.id,
-    run_attempt: RUN.attempt,
-  };
+  unknown.producers[0].workflow = ".github/workflows/ghost.yml";
   expectContractError(
-    () => validateJobResults(unknown, registry),
-    /does not name a registered owner job/,
+    () => validateProducerManifest(unknown, registry),
+    /workflow is not registered/,
   );
 
   const missing = structuredClone(valid);
-  delete missing[".github/workflows/ci.yml#check"].run_attempt;
+  delete missing.producers[0].run.attempt;
   expectContractError(
-    () => validateJobResults(missing, registry),
-    /run_attempt is required/,
+    () => validateProducerManifest(missing, registry),
+    /run\.attempt is required/,
   );
 
   for (const value of [-1, 1.5]) {
     const invalid = structuredClone(valid);
-    invalid[".github/workflows/ci.yml#check"].run_attempt = value;
+    invalid.producers[0].run.attempt = value;
     expectContractError(
-      () => validateJobResults(invalid, registry),
-      /run_attempt must be an integer >= 1/,
+      () => validateProducerManifest(invalid, registry),
+      /run\.attempt must be an integer >= 1/,
     );
   }
 
   const invalidConclusion = structuredClone(valid);
-  invalidConclusion[".github/workflows/ci.yml#check"].conclusion = "running";
+  invalidConclusion.producers[0].conclusion = "running";
   expectContractError(
-    () => validateJobResults(invalidConclusion, registry),
+    () => validateProducerManifest(invalidConclusion, registry),
     /conclusion must be one of/,
+  );
+
+  const superseded = structuredClone(valid);
+  superseded.producers.push(structuredClone(superseded.producers[0]));
+  superseded.producers[1].run.attempt += 1;
+  superseded.producers[1].conclusion = "failure";
+  expectContractError(
+    () => validateProducerManifest(superseded, registry),
+    /collector must choose exactly one newest run\/attempt/,
   );
 });
 
@@ -1219,7 +1373,7 @@ test("report set accepts total green evidence and legitimate impact omission", (
       registry,
       selection,
       reports: [report],
-      jobResults: jobResultsFor(registry, selection),
+      producerManifest: producerManifestFor(registry, selection),
     }),
     { expected: 1, received: 1 },
   );
@@ -1229,7 +1383,7 @@ test("report set rejects missing, unexpected, and duplicate reports", () => {
   const registry = registryFixture();
   const selection = mergeSelection();
   const report = reportFor(registry, selection, "always");
-  const results = jobResultsFor(registry, selection);
+  const results = producerManifestFor(registry, selection);
 
   expectContractError(
     () =>
@@ -1237,7 +1391,7 @@ test("report set rejects missing, unexpected, and duplicate reports", () => {
         registry,
         selection,
         reports: [],
-        jobResults: results,
+        producerManifest: results,
       }),
     /missing report always\/default/,
   );
@@ -1249,7 +1403,7 @@ test("report set rejects missing, unexpected, and duplicate reports", () => {
         registry,
         selection,
         reports: [report, unexpected],
-        jobResults: results,
+        producerManifest: results,
       }),
     /unexpected report impact\/shard-a/,
   );
@@ -1260,7 +1414,7 @@ test("report set rejects missing, unexpected, and duplicate reports", () => {
         registry,
         selection,
         reports: [report, structuredClone(report)],
-        jobResults: results,
+        producerManifest: results,
       }),
     /duplicate report always\/default/,
   );
@@ -1269,7 +1423,7 @@ test("report set rejects missing, unexpected, and duplicate reports", () => {
 test("report set rejects hollow, skipped, and every non-success outcome", () => {
   const registry = registryFixture();
   const selection = mergeSelection();
-  const results = jobResultsFor(registry, selection);
+  const results = producerManifestFor(registry, selection);
   const cases = [
     {
       mutate: (report) => {
@@ -1295,7 +1449,7 @@ test("report set rejects hollow, skipped, and every non-success outcome", () => 
           registry,
           selection,
           reports: [report],
-          jobResults: results,
+          producerManifest: results,
         }),
       pattern,
     );
@@ -1309,17 +1463,17 @@ test("report set rejects hollow, skipped, and every non-success outcome", () => 
           registry,
           selection,
           reports: [report],
-          jobResults: results,
+          producerManifest: results,
         }),
       new RegExp(`conclusion ${conclusion} is not success`),
     );
   }
 });
 
-test("report set binds report SHA, tree, run ID, and run attempt to selection", () => {
+test("report set binds source and selection_ref while allowing an independent producer run", () => {
   const registry = registryFixture();
   const selection = mergeSelection();
-  const results = jobResultsFor(registry, selection);
+  const results = producerManifestFor(registry, selection);
   const cases = [
     {
       mutate: (report) => {
@@ -1335,15 +1489,21 @@ test("report set binds report SHA, tree, run ID, and run attempt to selection", 
     },
     {
       mutate: (report) => {
-        report.run.id = "999";
+        report.selection_ref.run.id = "999";
       },
-      pattern: /report run id does not match the selection/,
+      pattern: /selection_ref does not match the current selection/,
     },
     {
       mutate: (report) => {
-        report.run.attempt = 9;
+        report.selection_ref.run.attempt = 9;
       },
-      pattern: /report run attempt does not match the selection/,
+      pattern: /selection_ref does not match the current selection/,
+    },
+    {
+      mutate: (report) => {
+        report.selection_ref.manifest_sha256 = "9".repeat(64);
+      },
+      pattern: /selection_ref does not match the current selection/,
     },
   ];
   for (const { mutate, pattern } of cases) {
@@ -1355,11 +1515,162 @@ test("report set binds report SHA, tree, run ID, and run attempt to selection", 
           registry,
           selection,
           reports: [report],
-          jobResults: results,
+          producerManifest: results,
         }),
       pattern,
     );
   }
+
+  assert.notEqual(reportFor(registry, selection, "always").producer.run.id, selection.run.id);
+});
+
+test("pull-request API head identity is distinct from projected checkout identity", () => {
+  const registry = registryFixture();
+  const selection = mergeSelection();
+  const report = reportFor(registry, selection, "always");
+  const manifest = producerManifestFor(registry, selection);
+  assert.notEqual(
+    manifest.producers[0].event.event_head_sha,
+    manifest.producers[0].event.projected_sha,
+  );
+  assert.deepEqual(
+    validateReportSet({
+      registry,
+      selection,
+      reports: [report],
+      producerManifest: manifest,
+    }),
+    { expected: 1, received: 1 },
+  );
+
+  const wrongPR = producerManifestFor(registry, selection);
+  wrongPR.producers[0].event.pr_number += 1;
+  expectContractError(
+    () =>
+      validateReportSet({
+        registry,
+        selection,
+        reports: [report],
+        producerManifest: wrongPR,
+      }),
+    /trusted producer event identity does not match the qualification event/,
+  );
+
+  const wrongRepository = producerManifestFor(registry, selection);
+  wrongRepository.producers[0].repository = "example/other";
+  expectContractError(
+    () =>
+      validateReportSet({
+        registry,
+        selection,
+        reports: [report],
+        producerManifest: wrongRepository,
+      }),
+    /trusted producer repository does not match the qualification repository/,
+  );
+
+  const headAsCheckout = producerManifestFor(registry, selection);
+  headAsCheckout.producers[0].source.sha =
+    headAsCheckout.producers[0].event.event_head_sha;
+  expectContractError(
+    () =>
+      validateReportSet({
+        registry,
+        selection,
+        reports: [report],
+        producerManifest: headAsCheckout,
+      }),
+    /trusted producer projected SHA\/tree does not match the selection/,
+  );
+});
+
+test("merge-group API head must equal the projected checkout", () => {
+  const registry = registryFixture();
+  const selection = mergeSelection();
+  const manifest = producerManifestFor(registry, selection);
+  manifest.producers[0].event = {
+    kind: "merge_group",
+    pr_number: null,
+    event_head_sha: OTHER_SHA,
+    event_base_sha: BASE_SHA,
+    projected_sha: SOURCE_SHA,
+  };
+  expectContractError(
+    () => validateProducerManifest(manifest, registry),
+    /event_head_sha must equal projected_sha for merge_group/,
+  );
+});
+
+test("report set binds the exact selection manifest digest", () => {
+  const registry = registryFixture();
+  const selection = mergeSelection();
+  const expected = qualificationExpected(selection);
+  expected.selectionManifestSHA256 = "9".repeat(64);
+  expectContractError(
+    () =>
+      validateReportSet({
+        registry,
+        selection,
+        reports: [reportFor(registry, selection, "always")],
+        producerManifest: producerManifestFor(registry, selection),
+        expected,
+      }),
+    /selection manifest SHA-256 does not match the trusted expected digest/,
+  );
+});
+
+test("report set binds artifact ID, attempt-qualified name, and SHA-256", () => {
+  const registry = registryFixture();
+  const selection = mergeSelection();
+  const report = reportFor(registry, selection, "always");
+
+  const missing = producerManifestFor(registry, selection);
+  missing.producers[0].artifacts = [];
+  expectContractError(
+    () =>
+      validateReportSet({
+        registry,
+        selection,
+        reports: [report],
+        producerManifest: missing,
+      }),
+    /artifacts must contain exactly one native bundle/,
+  );
+
+  const wrongDigest = producerManifestFor(registry, selection);
+  wrongDigest.producers[0].artifacts[0].sha256 = "9".repeat(64);
+  expectContractError(
+    () =>
+      validateReportSet({
+        registry,
+        selection,
+        reports: [report],
+        producerManifest: wrongDigest,
+      }),
+    /artifact name or SHA-256 does not match trusted API provenance/,
+  );
+
+  const priorAttempt = reportFor(registry, selection, "always");
+  priorAttempt.producer.artifact.name = nativeArtifactName(
+    priorAttempt.producer.workflow,
+    {
+      id: priorAttempt.producer.run.id,
+      attempt: priorAttempt.producer.run.attempt - 1,
+    },
+  );
+  expectContractError(
+    () => validateReport(priorAttempt, registry),
+    /producer\.artifact\.name must be ci-native-ci-801-3/,
+  );
+
+  const duplicate = producerManifestFor(registry, selection);
+  duplicate.producers[0].artifacts.push(
+    structuredClone(duplicate.producers[0].artifacts[0]),
+  );
+  expectContractError(
+    () => validateProducerManifest(duplicate, registry),
+    /artifacts must contain exactly one native bundle/,
+  );
 });
 
 test("report set rejects artifact digest mismatch", () => {
@@ -1376,96 +1687,130 @@ test("report set rejects artifact digest mismatch", () => {
         registry,
         selection,
         reports,
-        jobResults: jobResultsFor(registry, selection),
+        producerManifest: producerManifestFor(registry, selection),
       }),
     /release\/artifact: candidate digest does not match the selection/,
   );
 });
 
-test("a stale report plus matching stale trusted results cannot qualify a new selection run", () => {
-  // This is the critical negative control: before the run-binding checks, the
-  // report and context job could agree with each other while both belonged to
-  // an older workflow run than the selection.
+test("a stale report plus matching stale manifest cannot qualify a new selection", () => {
   const registry = registryFixture();
   const selection = mergeSelection();
   const report = reportFor(registry, selection, "always");
-  report.run = { id: "999", attempt: 9 };
-  const results = jobResultsFor(registry, selection);
-  for (const result of Object.values(results)) {
-    result.run_id = "999";
-    result.run_attempt = 9;
-  }
+  report.selection_ref = {
+    run: { id: "999", attempt: 9 },
+    manifest_sha256: "9".repeat(64),
+  };
+  const manifest = producerManifestFor(registry, selection);
+  manifest.selection_ref = structuredClone(report.selection_ref);
   expectContractError(
     () =>
       validateReportSet({
         registry,
         selection,
         reports: [report],
-        jobResults: results,
+        producerManifest: manifest,
       }),
-    /report run id does not match the selection/,
-    /report run attempt does not match the selection/,
-    /trusted result for \.github\/workflows\/ci\.yml#check does not match the selection run/,
-    /trusted result for \.github\/workflows\/ci\.yml#lint does not match the selection run/,
+    /producer manifest selection_ref does not match the current selection/,
+    /selection_ref does not match the current selection/,
   );
 });
 
-test("every trusted owner job binds the selection run, not only the context job", () => {
+test("release evidence from another qualification nonce cannot be replayed", () => {
+  const registry = registryFixture();
+  const prior = releaseSelection();
+  const report = reportFor(registry, prior, "always");
+  const manifest = producerManifestFor(registry, prior);
+
+  const current = releaseSelection();
+  current.correlation_nonce = "7".repeat(64);
+  const currentRef = selectionRefFor(current);
+  report.selection_ref = structuredClone(currentRef);
+  manifest.selection_ref = structuredClone(currentRef);
+
+  expectContractError(
+    () =>
+      validateReportSet({
+        registry,
+        selection: current,
+        reports: [report],
+        producerManifest: manifest,
+      }),
+    /producer manifest correlation_nonce does not match the current qualification/,
+    /correlation_nonce does not match the current qualification/,
+  );
+});
+
+test("report producer run must match API provenance, not the selection run", () => {
   const registry = registryFixture();
   const selection = mergeSelection();
   const report = reportFor(registry, selection, "always");
-
   for (const [field, value] of [
-    ["run_id", "999"],
-    ["run_attempt", 9],
+    ["id", "999"],
+    ["attempt", 9],
   ]) {
-    const results = jobResultsFor(registry, selection);
-    results[".github/workflows/ci.yml#lint"][field] = value;
+    const manifest = producerManifestFor(registry, selection);
+    report.producer.run[field] = value;
+    report.producer.artifact.name = nativeArtifactName(
+      report.producer.workflow,
+      report.producer.run,
+    );
     expectContractError(
       () =>
         validateReportSet({
           registry,
           selection,
           reports: [report],
-          jobResults: results,
+          producerManifest: manifest,
         }),
-      /trusted result for \.github\/workflows\/ci\.yml#lint does not match the selection run/,
+      /producer run identity does not match the trusted workflow run/,
     );
   }
 });
 
-test("report set rejects missing and non-success trusted owner jobs", () => {
+test("report set rejects missing and non-success trusted context jobs", () => {
   const registry = registryFixture();
   const selection = mergeSelection();
   const report = reportFor(registry, selection, "always");
 
-  const missing = jobResultsFor(registry, selection);
-  delete missing[".github/workflows/ci.yml#lint"];
+  const missing = producerManifestFor(registry, selection);
+  missing.producers[0].jobs = [];
   expectContractError(
     () =>
       validateReportSet({
         registry,
         selection,
         reports: [report],
-        jobResults: missing,
+        producerManifest: missing,
       }),
-    /trusted result for \.github\/workflows\/ci\.yml#lint is missing/,
+    /jobs must be a non-empty array/,
+  );
+
+  const wrongName = producerManifestFor(registry, selection);
+  wrongName.producers[0].jobs[0].name = "another-check";
+  expectContractError(
+    () =>
+      validateReportSet({
+        registry,
+        selection,
+        reports: [report],
+        producerManifest: wrongName,
+      }),
+    /trusted context check name another-check does not match always-context/,
   );
 
   for (const conclusion of NON_SUCCESS_CONCLUSIONS) {
-    const failed = jobResultsFor(registry, selection);
-    failed[".github/workflows/ci.yml#lint"].conclusion = conclusion;
+    const failed = producerManifestFor(registry, selection);
+    failed.producers[0].jobs[0].conclusion = conclusion;
     expectContractError(
       () =>
         validateReportSet({
           registry,
           selection,
           reports: [report],
-          jobResults: failed,
+          producerManifest: failed,
         }),
-      new RegExp(
-        `trusted result for \\.github/workflows/ci\\.yml#lint is ${conclusion}`,
-      ),
+      new RegExp(`trusted context job check is ${conclusion}`),
     );
   }
 });
@@ -1484,7 +1829,7 @@ test("release report set qualifies all release-required source and artifact lane
       registry,
       selection,
       reports,
-      jobResults: jobResultsFor(registry, selection),
+      producerManifest: producerManifestFor(registry, selection),
     }),
     { expected: 4, received: 4 },
   );
@@ -1506,12 +1851,21 @@ test("CI_EXPECT_RUN_ATTEMPT uses strict canonical integer parsing", () => {
 });
 
 test("reports-mode expectations wire strict run-attempt parsing into qualification", () => {
+  const selection = mergeSelection({ changedPaths: [] });
   const valid = qualificationExpectations({
     CI_LANE_POSTURE: "merge",
     CI_EXPECT_SHA: SOURCE_SHA,
     CI_EXPECT_TREE: SOURCE_TREE,
+    CI_EXPECT_CORRELATION_NONCE: selection.correlation_nonce,
     CI_EXPECT_RUN_ID: RUN.id,
     CI_EXPECT_RUN_ATTEMPT: String(RUN.attempt),
+    CI_EXPECT_SELECTION_SHA256: selectionManifestSHA256(selection),
+    CI_EXPECT_EVENT_KIND: "pull_request",
+    CI_EXPECT_PR_NUMBER: "17",
+    CI_EXPECT_EVENT_HEAD_SHA: OTHER_SHA,
+    CI_EXPECT_EVENT_BASE_SHA: BASE_SHA,
+    CI_EXPECT_PROJECTED_SHA: SOURCE_SHA,
+    CI_EXPECT_REPOSITORY: REPOSITORY,
     CI_EXPECT_BASE_SHA: BASE_SHA,
     CI_EXPECT_CHANGED_PATHS_JSON: "[]",
   });
@@ -1519,9 +1873,19 @@ test("reports-mode expectations wire strict run-attempt parsing into qualificati
     posture: "merge",
     sha: SOURCE_SHA,
     tree: SOURCE_TREE,
+    correlationNonce: selection.correlation_nonce,
     candidateDigest: undefined,
     runID: RUN.id,
     runAttempt: RUN.attempt,
+    selectionManifestSHA256: selectionManifestSHA256(selection),
+    eventIdentity: {
+      kind: "pull_request",
+      pr_number: 17,
+      event_head_sha: OTHER_SHA,
+      event_base_sha: BASE_SHA,
+      projected_sha: SOURCE_SHA,
+    },
+    repository: REPOSITORY,
     baseSHA: BASE_SHA,
     changedPaths: [],
   });

--- a/.github/scripts/ci-lane-contract.test.mjs
+++ b/.github/scripts/ci-lane-contract.test.mjs
@@ -90,6 +90,13 @@ const NON_SUCCESS_CONCLUSIONS = [
 
 const root = mkdtempSync(join(tmpdir(), "cerberus-ci-lane-contract-"));
 mkdirSync(join(root, ".github", "workflows"), { recursive: true });
+mkdirSync(join(root, ".github", "actions", "ci-native-part"), {
+  recursive: true,
+});
+writeFileSync(
+  join(root, ".github", "actions", "ci-native-part", "action.yml"),
+  "name: fixture native part\n",
+);
 writeFileSync(
   join(root, "Justfile"),
   [
@@ -118,15 +125,20 @@ const workflowFixtures = {
     "  check:",
     "    steps:",
     "      - run: just test",
-    "  lint:",
+  "  lint:",
     "    steps:",
     "      - run: true",
+    "      - uses: ./.github/actions/ci-native-part",
+    "        with:",
+    "          id: always-go",
     "  oracle-property:",
     "    steps:",
     "      - run: true",
     "  oracle-reference:",
     "    steps:",
     "      - run: ./fixture-tools/reference-oracle",
+    "  native-evidence:",
+    "    uses: ./.github/workflows/ci-native-evidence.yml",
     "",
   ].join("\n"),
   "e2e.yml": [
@@ -135,9 +147,17 @@ const workflowFixtures = {
     "  shard:",
     "    steps:",
     "      - run: true",
+    "      - uses: ./.github/actions/ci-native-part",
+    "        with:",
+    "          id: impact-tap",
     "  aggregate:",
     "    steps:",
     "      - run: true",
+    "      - uses: ./.github/actions/ci-native-part",
+    "        with:",
+    "          id: impact-tap",
+    "  native-evidence:",
+    "    uses: ./.github/workflows/ci-native-evidence.yml",
     "",
   ].join("\n"),
   "release.yml": [
@@ -997,6 +1017,45 @@ test("registry producer jobs are unique owner jobs with an exact native-part ros
     validateRegistry(directContextProducer, { root }),
     directContextProducer,
   );
+
+  const unenrolledPart = registryFixture();
+  unenrolledPart.native_evidence.parts[1].producer_job = "aggregate";
+  unenrolledPart.lanes[1].owner.producer_jobs = ["aggregate"];
+  const workflowPath = join(root, ".github", "workflows", "e2e.yml");
+  const workflow = readFileSync(workflowPath, "utf8");
+  writeFileSync(
+    workflowPath,
+    workflow.replace(
+      /  aggregate:[\s\S]*$/,
+      "  aggregate:\n    steps:\n      - run: true\n",
+    ),
+  );
+  try {
+    expectContractError(
+      () => validateRegistry(unenrolledPart, { root }),
+      /is not uploaded by \.github\/workflows\/e2e\.yml job aggregate/,
+    );
+  } finally {
+    writeFileSync(workflowPath, workflow);
+  }
+
+  const missingBundle = registryFixture();
+  const bundleWorkflow = readFileSync(workflowPath, "utf8");
+  writeFileSync(
+    workflowPath,
+    bundleWorkflow.replace(
+      /\n  native-evidence:\n    uses: \.\/\.github\/workflows\/ci-native-evidence\.yml\n/,
+      "\n",
+    ),
+  );
+  try {
+    expectContractError(
+      () => validateRegistry(missingBundle, { root }),
+      /owns native parts but does not call ci-native-evidence\.yml/,
+    );
+  } finally {
+    writeFileSync(workflowPath, bundleWorkflow);
+  }
 });
 
 test("registry discovers and rejects an unclassified .yaml workflow", () => {
@@ -1901,7 +1960,7 @@ test("release report set qualifies all release-required source and artifact lane
 });
 
 test("canonical pre-publication qualification validates exactly 45 invocations", () => {
-  const registry = JSON.parse(readFileSync(".github/ci-lanes.json", "utf8"));
+  const registry = loadRegistry(".github/ci-lanes.json");
   const selection = {
     schema_version: registry.selection_schema_version,
     registry_schema_version: registry.schema_version,

--- a/.github/scripts/ci-lane-native-evidence.mjs
+++ b/.github/scripts/ci-lane-native-evidence.mjs
@@ -1,0 +1,576 @@
+// ci-lane-native-evidence.mjs — emit selection-independent, attempt-qualified
+// evidence from a workflow's own `needs` graph.
+//
+// A workflow calls this once from an unconditional terminal evidence job. The
+// job passes GitHub's `toJSON(needs)` value; this script derives the lane and
+// check rosters from the registry and derives every count from those results.
+// It never accepts caller-supplied counts, lane conclusions, source trees, or
+// execution rosters.
+//
+// Required environment:
+//   CI_LANE_WORKFLOW       canonical repository-relative workflow path.
+//   CI_LANE_NEEDS_JSON     GitHub `toJSON(needs)` for the evidence job.
+//   CI_LANE_NATIVE_OUTPUT  new bundle path (must not already exist).
+//   GITHUB_EVENT_NAME      producer event.
+//   GITHUB_REPOSITORY      producer repository as owner/name.
+//   GITHUB_RUN_ID          producer workflow run id.
+//   GITHUB_RUN_ATTEMPT     positive producer attempt.
+//   GITHUB_SHA             exact commit checked out at HEAD.
+//
+// Optional environment:
+//   CI_LANE_REGISTRY       registry path (default .github/ci-lanes.json).
+//   CI_LANE_EVIDENCE_JOB   current terminal job id (default native-evidence).
+//   CI_LANE_CORRELATION_NONCE explicit 64-hex nonce; mandatory for release.
+//   GITHUB_OUTPUT          Actions step-output destination.
+//
+// Node builtins only. Malformed topology, missing/extra needs, a dirty or wrong
+// checkout, and stale output reuse are hard failures. Native red/cancelled/
+// skipped results are valid evidence and are recorded rather than hidden.
+
+import { createHash } from "node:crypto";
+import {
+  existsSync,
+  linkSync,
+  statSync,
+  unlinkSync,
+  writeFileSync,
+} from "node:fs";
+import { dirname, resolve } from "node:path";
+import process from "node:process";
+import { fileURLToPath } from "node:url";
+
+import {
+  canonicalJSONSHA256,
+  ContractError,
+  DEFAULT_REGISTRY_PATH,
+  deriveQualificationCorrelationNonce,
+  loadRegistry,
+  nativeArtifactName,
+} from "./ci-lane-contract.mjs";
+import { capture, error, notice, setOutput } from "./lib/gh.mjs";
+
+export const NATIVE_EVIDENCE_SCHEMA_VERSION = 1;
+
+const shaPattern = /^(?:[0-9a-f]{40}|[0-9a-f]{64})$/;
+const runIDPattern = /^[1-9][0-9]*$/;
+const repositoryPattern = /^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/;
+const workflowPattern = /^\.github\/workflows\/[A-Za-z0-9_.-]+\.ya?ml$/;
+const eventPattern = /^[a-z][a-z0-9_]*$/;
+const correlationNoncePattern = /^[0-9a-f]{64}$/;
+const postures = new Set(["merge", "main", "release"]);
+const nativeResults = new Set(["success", "failure", "cancelled", "skipped"]);
+
+function requirePattern(value, pattern, name) {
+  const text = String(value ?? "").trim();
+  if (!pattern.test(text)) {
+    throw new ContractError("CI lane native evidence", [
+      `${name} has invalid value ${JSON.stringify(text)}`,
+    ]);
+  }
+  return text;
+}
+
+function positiveInteger(value, name) {
+  const text = requirePattern(value, runIDPattern, name);
+  const parsed = Number(text);
+  if (!Number.isSafeInteger(parsed) || parsed < 1) {
+    throw new ContractError("CI lane native evidence", [
+      `${name} must be a positive safe integer`,
+    ]);
+  }
+  return parsed;
+}
+
+function gitText(root, args) {
+  return capture("git", args, { cwd: root });
+}
+
+export function nativeCheckoutEvidence({ root, expectedSHA }) {
+  const expected = requirePattern(expectedSHA, shaPattern, "GITHUB_SHA");
+  const top = gitText(root, ["rev-parse", "--show-toplevel"]);
+  if (top.status !== 0 || resolve(top.stdout.trim()) !== resolve(root)) {
+    throw new ContractError("CI lane native evidence", [
+      "native evidence must run from the repository root",
+    ]);
+  }
+  const actual = gitText(root, ["rev-parse", "--verify", "HEAD^{commit}"]);
+  if (actual.status !== 0 || actual.stdout.trim() !== expected) {
+    throw new ContractError("CI lane native evidence", [
+      `checkout HEAD is ${JSON.stringify(actual.stdout.trim())}, want ${expected}`,
+    ]);
+  }
+  const status = gitText(root, [
+    "status",
+    "--porcelain=v1",
+    "--untracked-files=all",
+  ]);
+  if (status.status !== 0 || status.stdout !== "") {
+    throw new ContractError("CI lane native evidence", [
+      status.status === 0
+        ? "checkout is not clean before native evidence is derived"
+        : `git status failed: ${status.stderr.trim()}`,
+    ]);
+  }
+  const tree = gitText(root, ["rev-parse", "--verify", `${expected}^{tree}`]);
+  const treeSHA = tree.stdout.trim();
+  if (tree.status !== 0 || !shaPattern.test(treeSHA)) {
+    throw new ContractError("CI lane native evidence", [
+      `cannot derive checkout tree: ${tree.stderr.trim() || treeSHA}`,
+    ]);
+  }
+  return Object.freeze({ sha: expected, tree: treeSHA });
+}
+
+export function parseNeeds(raw) {
+  let document;
+  try {
+    document = JSON.parse(String(raw ?? ""));
+  } catch (parseError) {
+    throw new ContractError("CI lane native evidence", [
+      `CI_LANE_NEEDS_JSON is not valid JSON: ${parseError.message}`,
+    ]);
+  }
+  if (
+    document === null ||
+    Array.isArray(document) ||
+    typeof document !== "object"
+  ) {
+    throw new ContractError("CI lane native evidence", [
+      "CI_LANE_NEEDS_JSON must be an object keyed by workflow job id",
+    ]);
+  }
+  const results = new Map();
+  const problems = [];
+  for (const [jobID, value] of Object.entries(document)) {
+    if (!/^[A-Za-z_][A-Za-z0-9_-]*$/.test(jobID)) {
+      problems.push(`needs key ${JSON.stringify(jobID)} is not a workflow job id`);
+      continue;
+    }
+    if (
+      value === null ||
+      Array.isArray(value) ||
+      typeof value !== "object" ||
+      !nativeResults.has(value.result)
+    ) {
+      problems.push(
+        `needs.${jobID}.result must be one of ${[...nativeResults].join(", ")}`,
+      );
+      continue;
+    }
+    results.set(jobID, value.result);
+  }
+  if (problems.length > 0) {
+    throw new ContractError("CI lane native evidence", problems);
+  }
+  return results;
+}
+
+function laneConclusion(checks) {
+  const results = checks.map((check) => check.result);
+  if (results.includes("failure")) return "failure";
+  if (results.includes("cancelled")) return "cancelled";
+  if (results.includes("skipped")) return "skipped";
+  return "success";
+}
+
+function evidenceCounts(checks) {
+  return Object.freeze({
+    executed: checks.length,
+    passed: checks.filter((check) => check.result === "success").length,
+    failed: checks.filter(
+      (check) => check.result === "failure" || check.result === "cancelled",
+    ).length,
+    skipped: checks.filter((check) => check.result === "skipped").length,
+  });
+}
+
+function postureIncludes(lane, posture) {
+  if (posture === "merge") return lane.merge_posture !== "never";
+  if (posture === "main") return lane.main_posture !== "never";
+  return lane.release_posture !== "post_publish";
+}
+
+function nativeRoster(registry, workflow, posture) {
+  return registry.lanes.filter(
+    (lane) =>
+      lane.owner.workflow === workflow && postureIncludes(lane, posture),
+  );
+}
+
+export function createNativeBundle({
+  registry,
+  workflow,
+  needs,
+  source,
+  repository,
+  event,
+  runID,
+  runAttempt,
+  posture = "merge",
+  evidenceJob = "native-evidence",
+  correlationNonce,
+}) {
+  const workflowPath = requirePattern(
+    workflow,
+    workflowPattern,
+    "CI_LANE_WORKFLOW",
+  );
+  const repositoryName = requirePattern(
+    repository,
+    repositoryPattern,
+    "GITHUB_REPOSITORY",
+  );
+  const eventName = requirePattern(event, eventPattern, "GITHUB_EVENT_NAME");
+  const postureName = String(posture ?? "").trim();
+  if (!postures.has(postureName)) {
+    throw new ContractError("CI lane native evidence", [
+      `CI_LANE_NATIVE_POSTURE must be merge, main, or release`,
+    ]);
+  }
+  const id = requirePattern(runID, runIDPattern, "GITHUB_RUN_ID");
+  const attempt =
+    typeof runAttempt === "number"
+      ? runAttempt
+      : positiveInteger(runAttempt, "GITHUB_RUN_ATTEMPT");
+  if (!Number.isSafeInteger(attempt) || attempt < 1) {
+    throw new ContractError("CI lane native evidence", [
+      "GITHUB_RUN_ATTEMPT must be a positive safe integer",
+    ]);
+  }
+  if (!source || !shaPattern.test(source.sha) || !shaPattern.test(source.tree)) {
+    throw new ContractError("CI lane native evidence", [
+      "source SHA and tree must be canonical Git object ids",
+    ]);
+  }
+  let qualificationNonce;
+  if (String(correlationNonce ?? "").trim() !== "") {
+    qualificationNonce = requirePattern(
+      correlationNonce,
+      correlationNoncePattern,
+      "CI_LANE_CORRELATION_NONCE",
+    );
+  } else if (postureName === "release") {
+    throw new ContractError("CI lane native evidence", [
+      "release evidence requires an explicit CI_LANE_CORRELATION_NONCE",
+    ]);
+  } else {
+    qualificationNonce = deriveQualificationCorrelationNonce({
+      posture: postureName,
+      source,
+    });
+  }
+  const lanes = nativeRoster(registry, workflowPath, postureName);
+  if (lanes.length === 0) {
+    throw new ContractError("CI lane native evidence", [
+      `${workflowPath} owns no merge lanes in the registry`,
+    ]);
+  }
+  const evidenceJobID = requirePattern(
+    evidenceJob,
+    /^[A-Za-z_][A-Za-z0-9_-]*$/,
+    "CI_LANE_EVIDENCE_JOB",
+  );
+  const expectedJobs = [
+    ...new Set(
+      lanes.flatMap((lane) =>
+        lane.owner.jobs,
+      ),
+    ),
+  ].sort();
+  const actualJobs = [...needs.keys()].sort();
+  const problems = [];
+  for (const job of expectedJobs) {
+    if (!needs.has(job)) problems.push(`native needs is missing registered job ${job}`);
+  }
+  for (const job of actualJobs) {
+    if (!expectedJobs.includes(job)) {
+      problems.push(`native needs contains unregistered extra job ${job}`);
+    }
+  }
+  if (problems.length > 0) {
+    throw new ContractError("CI lane native evidence", problems);
+  }
+
+  const laneEvidence = lanes
+    .flatMap((lane) =>
+      lane.executions.map((executionID) => {
+        const checks = lane.owner.jobs
+          .filter((jobID) => jobID !== evidenceJobID)
+          .map((jobID) => ({
+            job_id: jobID,
+            result: needs.get(jobID),
+          }));
+        return {
+          lane_id: lane.id,
+          execution_id: executionID,
+          context: {
+            match: lane.context.match,
+            name: lane.context.name,
+            job_id: lane.owner.context_job,
+          },
+          checks,
+          evidence: evidenceCounts(checks),
+          conclusion: laneConclusion(checks),
+        };
+      }),
+    )
+    .sort((left, right) =>
+      `${left.lane_id}/${left.execution_id}`.localeCompare(
+        `${right.lane_id}/${right.execution_id}`,
+      ),
+    );
+
+  return Object.freeze({
+    schema_version: NATIVE_EVIDENCE_SCHEMA_VERSION,
+    registry_schema_version: registry.schema_version,
+    posture: postureName,
+    source: { sha: source.sha, tree: source.tree },
+    correlation_nonce: qualificationNonce,
+    producer: {
+      repository: repositoryName,
+      workflow: workflowPath,
+      event: eventName,
+      run: { id, attempt },
+    },
+    lanes: laneEvidence,
+  });
+}
+
+export function validateNativeBundle(document, registry, expected = {}) {
+  const problems = [];
+  const keys = [
+    "schema_version",
+    "registry_schema_version",
+    "posture",
+    "source",
+    "correlation_nonce",
+    "producer",
+    "lanes",
+  ];
+  const exact = (value, expectedKeys, path) => {
+    if (value === null || Array.isArray(value) || typeof value !== "object") {
+      problems.push(`${path} must be an object`);
+      return false;
+    }
+    const actual = Object.keys(value).sort();
+    const wanted = [...expectedKeys].sort();
+    if (JSON.stringify(actual) !== JSON.stringify(wanted)) {
+      problems.push(`${path} keys must be exactly ${wanted.join(", ")}`);
+      return false;
+    }
+    return true;
+  };
+  if (!exact(document, keys, "native bundle")) {
+    throw new ContractError("invalid CI lane native bundle", problems);
+  }
+  if (document.schema_version !== NATIVE_EVIDENCE_SCHEMA_VERSION)
+    problems.push("native bundle schema_version is unsupported");
+  if (document.registry_schema_version !== registry.schema_version)
+    problems.push("native bundle registry schema does not match");
+  if (!postures.has(document.posture)) problems.push("native bundle posture is invalid");
+  if (!correlationNoncePattern.test(document.correlation_nonce))
+    problems.push("native bundle correlation_nonce is invalid");
+  if (!exact(document.source, ["sha", "tree"], "native bundle source")) {
+    // exact() records the shape problem.
+  } else if (
+    !shaPattern.test(document.source.sha) ||
+    !shaPattern.test(document.source.tree)
+  ) {
+    problems.push("native bundle source SHA/tree is invalid");
+  }
+  if (
+    exact(
+      document.producer,
+      ["repository", "workflow", "event", "run"],
+      "native bundle producer",
+    )
+  ) {
+    if (!repositoryPattern.test(document.producer.repository))
+      problems.push("native bundle producer repository is invalid");
+    if (!workflowPattern.test(document.producer.workflow))
+      problems.push("native bundle producer workflow is invalid");
+    if (!eventPattern.test(document.producer.event))
+      problems.push("native bundle producer event is invalid");
+    if (exact(document.producer.run, ["id", "attempt"], "native bundle producer run")) {
+      if (!runIDPattern.test(document.producer.run.id))
+        problems.push("native bundle producer run id is invalid");
+      if (!Number.isSafeInteger(document.producer.run.attempt) || document.producer.run.attempt < 1)
+        problems.push("native bundle producer run attempt is invalid");
+    }
+  }
+
+  for (const [field, actual] of [
+    ["posture", document.posture],
+    ["workflow", document.producer?.workflow],
+    ["repository", document.producer?.repository],
+    ["event", document.producer?.event],
+    ["runID", document.producer?.run?.id],
+    ["runAttempt", document.producer?.run?.attempt],
+    ["sha", document.source?.sha],
+    ["tree", document.source?.tree],
+    ["correlationNonce", document.correlation_nonce],
+  ]) {
+    if (expected[field] !== undefined && actual !== expected[field]) {
+      problems.push(`native bundle ${field} does not match trusted expectation`);
+    }
+  }
+
+  const lanes = nativeRoster(
+    registry,
+    document.producer?.workflow,
+    document.posture,
+  );
+  const expectedEntries = new Map(
+    lanes.flatMap((lane) =>
+      lane.executions.map((executionID) => [
+        `${lane.id}/${executionID}`,
+        lane,
+      ]),
+    ),
+  );
+  const actualEntries = new Map();
+  if (!Array.isArray(document.lanes)) {
+    problems.push("native bundle lanes must be an array");
+  } else {
+    for (let index = 0; index < document.lanes.length; index += 1) {
+      const entry = document.lanes[index];
+      const at = `native bundle lanes[${index}]`;
+      if (
+        !exact(
+          entry,
+          ["lane_id", "execution_id", "context", "checks", "evidence", "conclusion"],
+          at,
+        )
+      ) continue;
+      const identity = `${entry.lane_id}/${entry.execution_id}`;
+      const lane = expectedEntries.get(identity);
+      if (!lane) problems.push(`${at} is unexpected: ${identity}`);
+      if (actualEntries.has(identity)) problems.push(`${at} duplicates ${identity}`);
+      actualEntries.set(identity, entry);
+      if (lane && JSON.stringify(entry.context) !== JSON.stringify({
+        match: lane.context.match,
+        name: lane.context.name,
+        job_id: lane.owner.context_job,
+      })) problems.push(`${at} context does not match the registry`);
+      const expectedJobs = lane
+        ? lane.owner.jobs.filter((job) => job !== (expected.evidenceJob || "native-evidence"))
+        : [];
+      const checkJobs = Array.isArray(entry.checks)
+        ? entry.checks.map((check) => check?.job_id)
+        : [];
+      if (JSON.stringify(checkJobs) !== JSON.stringify(expectedJobs))
+        problems.push(`${at} checks do not match the registry job roster`);
+      if (!Array.isArray(entry.checks)) {
+        problems.push(`${at} checks must be an array`);
+        continue;
+      }
+      for (const check of entry.checks) {
+        if (!exact(check, ["job_id", "result"], `${at} check`)) continue;
+        if (!nativeResults.has(check.result)) problems.push(`${at} check result is invalid`);
+      }
+      const counts = evidenceCounts(entry.checks);
+      if (JSON.stringify(entry.evidence) !== JSON.stringify(counts))
+        problems.push(`${at} evidence counts are not derived from checks`);
+      if (entry.conclusion !== laneConclusion(entry.checks))
+        problems.push(`${at} conclusion is not derived from checks`);
+    }
+  }
+  for (const identity of expectedEntries.keys()) {
+    if (!actualEntries.has(identity)) problems.push(`native bundle is missing ${identity}`);
+  }
+  if (problems.length > 0)
+    throw new ContractError("invalid CI lane native bundle", problems);
+  return document;
+}
+
+export function nativeBundleEntries(document) {
+  return document.lanes.map((entry) => ({
+    lane_id: entry.lane_id,
+    execution_id: entry.execution_id,
+    sha256: canonicalJSONSHA256({
+      correlation_nonce: document.correlation_nonce,
+      entry,
+    }),
+  }));
+}
+
+export function writeNativeBundle(path, document) {
+  const output = resolve(path);
+  const parent = dirname(output);
+  if (!existsSync(parent) || !statSync(parent).isDirectory()) {
+    throw new ContractError("CI lane native evidence", [
+      `native output directory does not exist: ${parent}`,
+    ]);
+  }
+  if (existsSync(output)) {
+    throw new ContractError("CI lane native evidence", [
+      `native output already exists; refusing stale reuse: ${output}`,
+    ]);
+  }
+  const body = `${JSON.stringify(document, null, 2)}\n`;
+  const temporary = `${output}.${process.pid}.tmp`;
+  try {
+    writeFileSync(temporary, body, { encoding: "utf8", flag: "wx" });
+    linkSync(temporary, output);
+  } finally {
+    if (existsSync(temporary)) unlinkSync(temporary);
+  }
+  return Object.freeze({
+    path: output,
+    body,
+    sha256: createHash("sha256").update(body).digest("hex"),
+  });
+}
+
+function main(env = process.env) {
+  const root = resolve(process.cwd());
+  const output = String(env.CI_LANE_NATIVE_OUTPUT ?? "").trim();
+  if (output === "") {
+    throw new ContractError("CI lane native evidence", [
+      "CI_LANE_NATIVE_OUTPUT is required",
+    ]);
+  }
+  const registry = loadRegistry(
+    env.CI_LANE_REGISTRY || DEFAULT_REGISTRY_PATH,
+    { root },
+  );
+  const source = nativeCheckoutEvidence({
+    root,
+    expectedSHA: env.GITHUB_SHA,
+  });
+  const bundle = createNativeBundle({
+    registry,
+    workflow: env.CI_LANE_WORKFLOW,
+    needs: parseNeeds(env.CI_LANE_NEEDS_JSON),
+    source,
+    repository: env.GITHUB_REPOSITORY,
+    event: env.GITHUB_EVENT_NAME,
+    runID: env.GITHUB_RUN_ID,
+    runAttempt: env.GITHUB_RUN_ATTEMPT,
+    posture: env.CI_LANE_NATIVE_POSTURE || "merge",
+    evidenceJob: env.CI_LANE_EVIDENCE_JOB || "native-evidence",
+    correlationNonce: env.CI_LANE_CORRELATION_NONCE,
+  });
+  const written = writeNativeBundle(output, bundle);
+  setOutput("native_path", written.path);
+  setOutput("native_sha256", written.sha256);
+  setOutput("native_lane_count", String(bundle.lanes.length));
+  setOutput("native_correlation_nonce", bundle.correlation_nonce);
+  setOutput("native_artifact_name", nativeArtifactName(bundle.producer.workflow, bundle.producer.run));
+  notice(
+    `native evidence recorded ${bundle.lanes.length} lane execution(s) from ${bundle.producer.workflow}`,
+  );
+}
+
+const invokedDirectly =
+  process.argv[1] && fileURLToPath(import.meta.url) === resolve(process.argv[1]);
+if (invokedDirectly) {
+  try {
+    main();
+  } catch (nativeError) {
+    error(nativeError instanceof Error ? nativeError.message : String(nativeError), {
+      title: "CI lane native evidence failed closed",
+    });
+    process.exit(1);
+  }
+}

--- a/.github/scripts/ci-lane-native-evidence.mjs
+++ b/.github/scripts/ci-lane-native-evidence.mjs
@@ -938,13 +938,18 @@ export function createNativeBundle({
       ),
     ),
   ].sort();
+  const knownWorkflowJobs = new Set(
+    registry.lanes
+      .filter((lane) => lane.owner.workflow === workflowPath)
+      .flatMap((lane) => lane.owner.jobs),
+  );
   const actualJobs = [...needs.keys()].sort();
   const problems = [];
   for (const job of expectedJobs) {
     if (!needs.has(job)) problems.push(`native needs is missing registered job ${job}`);
   }
   for (const job of actualJobs) {
-    if (!expectedJobs.includes(job)) {
+    if (!knownWorkflowJobs.has(job)) {
       problems.push(`native needs contains unregistered extra job ${job}`);
     }
   }

--- a/.github/scripts/ci-lane-native-evidence.mjs
+++ b/.github/scripts/ci-lane-native-evidence.mjs
@@ -2,14 +2,16 @@
 // evidence from a workflow's own `needs` graph.
 //
 // A workflow calls this once from an unconditional terminal evidence job. The
-// job passes GitHub's `toJSON(needs)` value; this script derives the lane and
-// check rosters from the registry and derives every count from those results.
-// It never accepts caller-supplied counts, lane conclusions, source trees, or
-// execution rosters.
+// job passes GitHub's `toJSON(needs)` value only to attest which registered
+// jobs reached which terminal result. Executed/passed/failed/skipped counts are
+// parsed from the registry's exact raw-part roster; a job result is never a
+// test count.
 //
 // Required environment:
 //   CI_LANE_WORKFLOW       canonical repository-relative workflow path.
 //   CI_LANE_NEEDS_JSON     GitHub `toJSON(needs)` for the evidence job.
+//   CI_LANE_NATIVE_PARTS   directory populated from attempt-qualified raw-part
+//                          artifacts declared by registry.native_evidence.
 //   CI_LANE_NATIVE_OUTPUT  new bundle path (must not already exist).
 //   GITHUB_EVENT_NAME      producer event.
 //   GITHUB_REPOSITORY      producer repository as owner/name.
@@ -31,6 +33,9 @@ import { createHash } from "node:crypto";
 import {
   existsSync,
   linkSync,
+  lstatSync,
+  readFileSync,
+  readdirSync,
   statSync,
   unlinkSync,
   writeFileSync,
@@ -46,10 +51,13 @@ import {
   deriveQualificationCorrelationNonce,
   loadRegistry,
   nativeArtifactName,
+  nativePartArtifactName,
+  NATIVE_PART_PARSERS,
 } from "./ci-lane-contract.mjs";
 import { capture, error, notice, setOutput } from "./lib/gh.mjs";
 
-export const NATIVE_EVIDENCE_SCHEMA_VERSION = 1;
+export const NATIVE_EVIDENCE_SCHEMA_VERSION = 2;
+export const MAX_NATIVE_PART_BYTES = 64 * 1024 * 1024;
 
 const shaPattern = /^(?:[0-9a-f]{40}|[0-9a-f]{64})$/;
 const runIDPattern = /^[1-9][0-9]*$/;
@@ -165,23 +173,551 @@ export function parseNeeds(raw) {
   return results;
 }
 
-function laneConclusion(checks) {
-  const results = checks.map((check) => check.result);
-  if (results.includes("failure")) return "failure";
-  if (results.includes("cancelled")) return "cancelled";
-  if (results.includes("skipped")) return "skipped";
-  return "success";
+const nativeSeedPattern = /^[^\u0000-\u001f\u007f]{1,1024}$/;
+
+function evidenceCounts({ passed = 0, failed = 0, skipped = 0 } = {}) {
+  for (const [name, value] of Object.entries({ passed, failed, skipped })) {
+    if (!Number.isSafeInteger(value) || value < 0) {
+      throw new ContractError("CI lane native evidence", [
+        `${name} evidence count must be a non-negative safe integer`,
+      ]);
+    }
+  }
+  return Object.freeze({
+    executed: passed + failed + skipped,
+    passed,
+    failed,
+    skipped,
+  });
 }
 
-function evidenceCounts(checks) {
-  return Object.freeze({
-    executed: checks.length,
-    passed: checks.filter((check) => check.result === "success").length,
-    failed: checks.filter(
-      (check) => check.result === "failure" || check.result === "cancelled",
-    ).length,
-    skipped: checks.filter((check) => check.result === "skipped").length,
+function safeIntegerSum(values, label) {
+  let total = 0;
+  for (const value of values) {
+    if (!Number.isSafeInteger(value) || value < 0) {
+      throw new ContractError("CI lane native evidence", [
+        `${label} values must be non-negative safe integers`,
+      ]);
+    }
+    total += value;
+    if (!Number.isSafeInteger(total)) {
+      throw new ContractError("CI lane native evidence", [
+        `${label} total exceeds the safe integer range`,
+      ]);
+    }
+  }
+  return total;
+}
+
+function milliseconds(value, label, { seconds = false } = {}) {
+  if (typeof value !== "number" || !Number.isFinite(value) || value < 0) {
+    throw new ContractError("CI lane native evidence", [
+      `${label} must be a non-negative finite number`,
+    ]);
+  }
+  const duration = Math.round(seconds ? value * 1000 : value);
+  if (!Number.isSafeInteger(duration)) {
+    throw new ContractError("CI lane native evidence", [
+      `${label} exceeds the safe integer range when converted to milliseconds`,
+    ]);
+  }
+  return duration;
+}
+
+function nativeSeed(value, label) {
+  if (value === null || value === undefined || value === "") return null;
+  if (typeof value !== "string" || !nativeSeedPattern.test(value)) {
+    throw new ContractError("CI lane native evidence", [
+      `${label} must be null or a non-empty printable string no longer than 1024 bytes`,
+    ]);
+  }
+  return value;
+}
+
+function uniqueSeed(values, label) {
+  const seeds = values.filter((value) => value !== null);
+  const unique = [...new Set(seeds)];
+  if (unique.length > 1) {
+    throw new ContractError("CI lane native evidence", [
+      `${label} reports conflicting native seeds`,
+    ]);
+  }
+  return unique[0] ?? null;
+}
+
+function corpusIdentity(parser, identities) {
+  if (!Array.isArray(identities) || identities.length === 0) {
+    throw new ContractError("CI lane native evidence", [
+      `${parser} contains no native corpus identities`,
+    ]);
+  }
+  for (const [index, identity] of identities.entries()) {
+    if (
+      typeof identity !== "string" ||
+      identity === "" ||
+      identity.includes("\u0000")
+    ) {
+      throw new ContractError("CI lane native evidence", [
+        `${parser} corpus identity ${index} is invalid`,
+      ]);
+    }
+  }
+  return `sha256:${canonicalJSONSHA256({
+    parser,
+    identities: [...identities].sort(),
+  })}`;
+}
+
+function parsedEvidence({ parser, outcomes, identities, durationMs, seed }) {
+  const counts = evidenceCounts({
+    passed: outcomes.filter((value) => value === "pass").length,
+    failed: outcomes.filter((value) => value === "fail").length,
+    skipped: outcomes.filter((value) => value === "skip").length,
   });
+  return Object.freeze({
+    ...counts,
+    duration_ms: milliseconds(durationMs, `${parser} duration_ms`),
+    seed: nativeSeed(seed, `${parser} seed`),
+    corpus_id: corpusIdentity(parser, identities),
+  });
+}
+
+function aggregateEvidence(parts, lane) {
+  const counts = evidenceCounts({
+    passed: safeIntegerSum(
+      parts.map((part) => part.evidence.passed),
+      `${lane.id} passed evidence`,
+    ),
+    failed: safeIntegerSum(
+      parts.map((part) => part.evidence.failed),
+      `${lane.id} failed evidence`,
+    ),
+    skipped: safeIntegerSum(
+      parts.map((part) => part.evidence.skipped),
+      `${lane.id} skipped evidence`,
+    ),
+  });
+  const seeds = parts.map((part) => part.evidence.seed);
+  if (
+    lane.determinism === "deterministic" &&
+    seeds.some((seed) => seed !== null)
+  ) {
+    throw new ContractError("CI lane native evidence", [
+      `${lane.id} is deterministic but a native part reports a seed`,
+    ]);
+  }
+  if (
+    lane.determinism === "seeded" &&
+    seeds.some((seed) => seed === null)
+  ) {
+    throw new ContractError("CI lane native evidence", [
+      `${lane.id} is seeded but a native part omitted its seed`,
+    ]);
+  }
+  const seed = uniqueSeed(seeds, lane.id);
+  return Object.freeze({
+    ...counts,
+    duration_ms: safeIntegerSum(
+      parts.map((part) => part.evidence.duration_ms),
+      `${lane.id} duration evidence`,
+    ),
+    seed,
+    corpus_id: corpusIdentity(
+      "lane-native-parts-v1",
+      parts.map(
+        (part) =>
+          JSON.stringify([part.id, part.parser, part.evidence.corpus_id]),
+      ),
+    ),
+  });
+}
+
+function parseJSON(text, label) {
+  try {
+    return JSON.parse(text);
+  } catch (parseError) {
+    throw new ContractError("CI lane native evidence", [
+      `${label} is not valid JSON: ${parseError.message}`,
+    ]);
+  }
+}
+
+function exactKeys(value, keys, label) {
+  if (value === null || Array.isArray(value) || typeof value !== "object") {
+    throw new ContractError("CI lane native evidence", [
+      `${label} must be an object`,
+    ]);
+  }
+  const actual = Object.keys(value).sort();
+  const expected = [...keys].sort();
+  if (JSON.stringify(actual) !== JSON.stringify(expected)) {
+    throw new ContractError("CI lane native evidence", [
+      `${label} keys must be exactly ${expected.join(", ")}`,
+    ]);
+  }
+}
+
+export function parseGoTestJSON(text) {
+  const terminal = new Map();
+  const packageTerminal = new Map();
+  const nativeSeeds = [];
+  const lines = String(text ?? "")
+    .split(/\r?\n/)
+    .filter((line) => line.trim() !== "");
+  for (let index = 0; index < lines.length; index += 1) {
+    const event = parseJSON(lines[index], `go-test-json line ${index + 1}`);
+    if (typeof event?.Action !== "string") {
+      throw new ContractError("CI lane native evidence", [
+        `go-test-json line ${index + 1} has no Action`,
+      ]);
+    }
+    if (typeof event.Output === "string") {
+      const seedMatch = /^CI_NATIVE_SEED=(.+)\r?\n?$/.exec(event.Output);
+      if (seedMatch) nativeSeeds.push(nativeSeed(seedMatch[1], "go-test-json seed"));
+    }
+    if (!new Set(["pass", "fail", "skip"]).has(event.Action)) continue;
+    const packageName = String(event.Package ?? "");
+    if (typeof event.Test !== "string" || event.Test === "") {
+      if (packageName === "" || packageTerminal.has(packageName)) {
+        throw new ContractError("CI lane native evidence", [
+          packageName === ""
+            ? `go-test-json line ${index + 1} has a package terminal with no Package`
+            : `go-test-json repeats package terminal result for ${packageName}`,
+        ]);
+      }
+      packageTerminal.set(packageName, {
+        action: event.Action,
+        duration_ms: milliseconds(
+          event.Elapsed,
+          `go-test-json package ${packageName} Elapsed`,
+          { seconds: true },
+        ),
+      });
+      continue;
+    }
+    if (packageName === "") {
+      throw new ContractError("CI lane native evidence", [
+        `go-test-json terminal result for ${event.Test} has no Package`,
+      ]);
+    }
+    const key = `${packageName}\u0000${event.Test}`;
+    if (terminal.has(key)) {
+      throw new ContractError("CI lane native evidence", [
+        `go-test-json repeats terminal result for ${packageName}/${event.Test}`,
+      ]);
+    }
+    terminal.set(key, event.Action);
+  }
+  const testPackages = new Set(
+    [...terminal.keys()].map((key) => key.split("\u0000", 1)[0]),
+  );
+  const missingPackageTerminals = [...testPackages].filter(
+    (packageName) => !packageTerminal.has(packageName),
+  );
+  if (missingPackageTerminals.length > 0) {
+    throw new ContractError("CI lane native evidence", [
+      `go-test-json is missing package terminal result(s): ${missingPackageTerminals.sort().join(", ")}`,
+    ]);
+  }
+  return parsedEvidence({
+    parser: "go-test-json-v1",
+    outcomes: [...terminal.values()],
+    identities: [...terminal.keys()].map((key) =>
+      JSON.stringify(key.split("\u0000")),
+    ),
+    durationMs: safeIntegerSum(
+      [...testPackages].map(
+        (packageName) => packageTerminal.get(packageName).duration_ms,
+      ),
+      "go-test-json package durations",
+    ),
+    seed: uniqueSeed(nativeSeeds, "go-test-json"),
+  });
+}
+
+export function parseNodeTAP(text) {
+  const outcomes = [];
+  const identities = [];
+  const plans = [];
+  const durations = [];
+  const nativeSeeds = [];
+  for (const raw of String(text ?? "").split(/\r?\n/)) {
+    if (/^1\.\.[0-9]+(?:\s|$)/.test(raw)) {
+      plans.push(Number(raw.match(/^1\.\.([0-9]+)/)[1]));
+      continue;
+    }
+    const durationMatch = /^#\s*duration_ms(?::|\s)\s*([0-9]+(?:\.[0-9]+)?)\s*$/i.exec(
+      raw,
+    );
+    if (durationMatch) {
+      durations.push(
+        milliseconds(
+          Number(durationMatch[1]),
+          "node TAP duration_ms summary",
+        ),
+      );
+      continue;
+    }
+    const seedMatch = /^#\s*ci-native-seed:\s*(.+)\s*$/i.exec(raw);
+    if (seedMatch) {
+      nativeSeeds.push(nativeSeed(seedMatch[1], "node TAP seed"));
+      continue;
+    }
+    const directiveIndex = raw.search(/\s+#\s*(?:SKIP|TODO)\b/i);
+    const assertion = directiveIndex < 0 ? raw : raw.slice(0, directiveIndex);
+    const directive =
+      directiveIndex < 0
+        ? ""
+        : /(?:SKIP|TODO)/i.exec(raw.slice(directiveIndex))[0].toUpperCase();
+    const match = /^(ok|not ok)\s+([1-9][0-9]*)(?:\s+-\s+(.+?))?\s*$/i.exec(
+      assertion,
+    );
+    if (!match) continue;
+    const ordinal = Number(match[2]);
+    if (ordinal !== outcomes.length + 1) {
+      throw new ContractError("CI lane native evidence", [
+        `node TAP result ordinal ${ordinal} is not the expected ${outcomes.length + 1}`,
+      ]);
+    }
+    const name = String(match[3] ?? "").trim();
+    outcomes.push(
+      directive === "SKIP" || directive === "TODO"
+        ? "skip"
+        : match[1].toLowerCase() === "ok"
+          ? "pass"
+          : "fail",
+    );
+    identities.push(JSON.stringify([ordinal, name]));
+  }
+  if (plans.length !== 1 || plans[0] !== outcomes.length) {
+    throw new ContractError("CI lane native evidence", [
+      `node TAP top-level plan must exactly match its ${outcomes.length} result(s)`,
+    ]);
+  }
+  if (durations.length !== 1) {
+    throw new ContractError("CI lane native evidence", [
+      `node TAP must contain exactly one top-level duration_ms summary; found ${durations.length}`,
+    ]);
+  }
+  return parsedEvidence({
+    parser: "node-tap-v1",
+    outcomes,
+    identities,
+    durationMs: durations[0],
+    seed: uniqueSeed(nativeSeeds, "node TAP"),
+  });
+}
+
+function xmlAttribute(opening, name, label, { required = true } = {}) {
+  const escaped = name.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const match = new RegExp(`\\s${escaped}\\s*=\\s*(["'])([\\s\\S]*?)\\1`, "i").exec(
+    opening,
+  );
+  if (!match) {
+    if (!required) return null;
+    throw new ContractError("CI lane native evidence", [
+      `${label} is missing XML attribute ${name}`,
+    ]);
+  }
+  return match[2]
+    .replace(/&quot;/g, '"')
+    .replace(/&apos;/g, "'")
+    .replace(/&lt;/g, "<")
+    .replace(/&gt;/g, ">")
+    .replace(/&amp;/g, "&");
+}
+
+export function parseJUnitXML(text) {
+  const xml = String(text ?? "");
+  if (!/<testsuites?\b/i.test(xml)) {
+    throw new ContractError("CI lane native evidence", [
+      "JUnit has no testsuite root",
+    ]);
+  }
+  const cases =
+    xml.match(
+      /<testcase\b[^>]*\/\s*>|<testcase\b[^>]*>[\s\S]*?<\/testcase\s*>/gi,
+    ) ?? [];
+  const openings = xml.match(/<testcase\b/gi) ?? [];
+  if (cases.length !== openings.length) {
+    throw new ContractError("CI lane native evidence", [
+      "JUnit contains an unterminated testcase",
+    ]);
+  }
+  const outcomes = [];
+  const identities = [];
+  const durations = [];
+  for (const [index, testcase] of cases.entries()) {
+    const opening = /^<testcase\b[^>]*>/i.exec(testcase)?.[0];
+    if (!opening) {
+      throw new ContractError("CI lane native evidence", [
+        `JUnit testcase ${index} has no opening element`,
+      ]);
+    }
+    const name = xmlAttribute(opening, "name", `JUnit testcase ${index}`);
+    const className =
+      xmlAttribute(opening, "classname", `JUnit testcase ${index}`, {
+        required: false,
+      }) ?? "";
+    const file =
+      xmlAttribute(opening, "file", `JUnit testcase ${index}`, {
+        required: false,
+      }) ?? "";
+    const seconds = Number(
+      xmlAttribute(opening, "time", `JUnit testcase ${index}`),
+    );
+    durations.push(
+      milliseconds(seconds, `JUnit testcase ${index} time`, { seconds: true }),
+    );
+    identities.push(JSON.stringify([className, file, name]));
+    if (/<(?:failure|error)\b/i.test(testcase)) outcomes.push("fail");
+    else if (/<skipped\b/i.test(testcase)) outcomes.push("skip");
+    else outcomes.push("pass");
+  }
+  const nativeSeeds = [];
+  for (const property of xml.match(/<property\b[^>]*\/?\s*>/gi) ?? []) {
+    if (
+      xmlAttribute(property, "name", "JUnit property", { required: false }) ===
+      "ci-native-seed"
+    ) {
+      nativeSeeds.push(
+        nativeSeed(
+          xmlAttribute(property, "value", "JUnit ci-native-seed property"),
+          "JUnit seed",
+        ),
+      );
+    }
+  }
+  return parsedEvidence({
+    parser: "junit-xml-v1",
+    outcomes,
+    identities,
+    durationMs: safeIntegerSum(durations, "JUnit testcase durations"),
+    seed: uniqueSeed(nativeSeeds, "JUnit"),
+  });
+}
+
+export function parseCaseJSON(text) {
+  const document = parseJSON(String(text ?? ""), "case-json-v1");
+  exactKeys(document, ["schema_version", "seed", "cases"], "case-json-v1");
+  if (document.schema_version !== 1 || !Array.isArray(document.cases)) {
+    throw new ContractError("CI lane native evidence", [
+      "case-json-v1 schema_version must be 1 and cases must be an array",
+    ]);
+  }
+  const seen = new Set();
+  const durations = [];
+  const outcomes = document.cases.map((item, index) => {
+    exactKeys(
+      item,
+      ["id", "status", "duration_ms"],
+      `case-json-v1 cases[${index}]`,
+    );
+    if (typeof item.id !== "string" || item.id.trim() === "" || seen.has(item.id)) {
+      throw new ContractError("CI lane native evidence", [
+        `case-json-v1 cases[${index}].id must be unique and non-empty`,
+      ]);
+    }
+    seen.add(item.id);
+    if (!new Set(["passed", "failed", "skipped"]).has(item.status)) {
+      throw new ContractError("CI lane native evidence", [
+        `case-json-v1 cases[${index}].status is invalid`,
+      ]);
+    }
+    durations.push(
+      milliseconds(
+        item.duration_ms,
+        `case-json-v1 cases[${index}].duration_ms`,
+      ),
+    );
+    return { passed: "pass", failed: "fail", skipped: "skip" }[item.status];
+  });
+  return parsedEvidence({
+    parser: "case-json-v1",
+    outcomes,
+    identities: [...seen],
+    durationMs: safeIntegerSum(durations, "case-json-v1 case durations"),
+    seed: nativeSeed(document.seed, "case-json-v1 seed"),
+  });
+}
+
+export function parseCompatCasesJSON(text) {
+  const document = parseJSON(String(text ?? ""), "compat-cases-json-v1");
+  exactKeys(
+    document,
+    ["schema_version", "head", "seed", "cases"],
+    "compat-cases-json-v1",
+  );
+  if (
+    document.schema_version !== 1 ||
+    typeof document.head !== "string" ||
+    document.head.trim() === "" ||
+    !Array.isArray(document.cases)
+  ) {
+    throw new ContractError("CI lane native evidence", [
+      "compat-cases-json-v1 requires schema_version 1, a non-empty head, and a cases array",
+    ]);
+  }
+  const seen = new Set();
+  const outcomes = [];
+  const durations = [];
+  for (let index = 0; index < document.cases.length; index += 1) {
+    const item = document.cases[index];
+    exactKeys(
+      item,
+      ["id", "passed", "duration_ms"],
+      `compat-cases-json-v1 cases[${index}]`,
+    );
+    if (
+      typeof item.id !== "string" ||
+      item.id.trim() === "" ||
+      seen.has(item.id) ||
+      typeof item.passed !== "boolean"
+    ) {
+      throw new ContractError("CI lane native evidence", [
+        `compat-cases-json-v1 cases[${index}] must have a unique id and boolean passed`,
+      ]);
+    }
+    seen.add(item.id);
+    outcomes.push(item.passed ? "pass" : "fail");
+    durations.push(
+      milliseconds(
+        item.duration_ms,
+        `compat-cases-json-v1 cases[${index}].duration_ms`,
+      ),
+    );
+  }
+  return parsedEvidence({
+    parser: "compat-cases-json-v1",
+    outcomes,
+    identities: [...seen].map((id) => JSON.stringify([document.head, id])),
+    durationMs: safeIntegerSum(
+      durations,
+      "compat-cases-json-v1 case durations",
+    ),
+    seed: nativeSeed(document.seed, "compat-cases-json-v1 seed"),
+  });
+}
+
+export function parseNativePart(parser, text) {
+  if (!NATIVE_PART_PARSERS.includes(parser)) {
+    throw new ContractError("CI lane native evidence", [
+      `native part parser ${JSON.stringify(parser)} is not registered`,
+    ]);
+  }
+  if (parser === "go-test-json-v1") return parseGoTestJSON(text);
+  if (parser === "node-tap-v1") return parseNodeTAP(text);
+  if (parser === "junit-xml-v1") return parseJUnitXML(text);
+  if (parser === "case-json-v1") return parseCaseJSON(text);
+  return parseCompatCasesJSON(text);
+}
+
+function laneConclusion(jobResults, evidence) {
+  const results = jobResults.map((job) => job.result);
+  if (results.includes("failure") || evidence.failed > 0) return "failure";
+  if (results.includes("cancelled")) return "cancelled";
+  if (results.includes("skipped") || evidence.skipped > 0) return "skipped";
+  return "success";
 }
 
 function postureIncludes(lane, posture) {
@@ -197,6 +733,130 @@ function nativeRoster(registry, workflow, posture) {
   );
 }
 
+function nativeInvocationModes(lane, posture) {
+  const modes = [];
+  if (lane.applicability?.source) modes.push("source_tree");
+  if (posture === "release" && lane.applicability?.artifact) {
+    modes.push("candidate_artifact");
+  }
+  return modes;
+}
+
+function walkPartFiles(root, relative = "") {
+  const directory = resolve(root, relative);
+  const stat = lstatSync(directory);
+  if (!stat.isDirectory() || stat.isSymbolicLink()) {
+    throw new ContractError("CI lane native evidence", [
+      `native part path is not a real directory: ${directory}`,
+    ]);
+  }
+  const files = [];
+  for (const name of readdirSync(directory).sort()) {
+    const childRelative = relative === "" ? name : `${relative}/${name}`;
+    const child = resolve(root, childRelative);
+    const childStat = lstatSync(child);
+    if (childStat.isSymbolicLink()) {
+      throw new ContractError("CI lane native evidence", [
+        `native part tree contains a symbolic link: ${childRelative}`,
+      ]);
+    }
+    if (childStat.isDirectory()) files.push(...walkPartFiles(root, childRelative));
+    else if (childStat.isFile()) files.push(childRelative);
+    else {
+      throw new ContractError("CI lane native evidence", [
+        `native part tree contains a non-file entry: ${childRelative}`,
+      ]);
+    }
+  }
+  return files;
+}
+
+function expectedNativeParts(registry, lanes, runAttempt, posture) {
+  const identities = new Set(
+    lanes.flatMap((lane) =>
+      lane.executions.flatMap((executionID) =>
+        nativeInvocationModes(lane, posture).map(
+          (invocationMode) =>
+            `${lane.id}/${executionID}/${invocationMode}`,
+        ),
+      ),
+    ),
+  );
+  const parts = (registry.native_evidence?.parts ?? [])
+    .filter((part) =>
+      identities.has(
+        `${part.lane_id}/${part.execution_id}/${part.invocation_mode}`,
+      ),
+    )
+    .map((part) => ({
+      ...part,
+      artifact: nativePartArtifactName(part.id, runAttempt),
+    }))
+    .sort((left, right) =>
+      `${left.lane_id}/${left.execution_id}/${left.invocation_mode}/${left.id}`.localeCompare(
+        `${right.lane_id}/${right.execution_id}/${right.invocation_mode}/${right.id}`,
+      ),
+    );
+  const covered = new Set(
+    parts.map(
+      (part) =>
+        `${part.lane_id}/${part.execution_id}/${part.invocation_mode}`,
+    ),
+  );
+  const missing = [...identities].filter((identity) => !covered.has(identity)).sort();
+  if (missing.length > 0) {
+    throw new ContractError("CI lane native evidence", [
+      ...missing.map((identity) => `registry has no native part for ${identity}`),
+    ]);
+  }
+  return parts;
+}
+
+export function readNativeParts({ registry, lanes, runAttempt, posture, partsRoot }) {
+  const root = resolve(String(partsRoot ?? ""));
+  if (!existsSync(root)) {
+    throw new ContractError("CI lane native evidence", [
+      `native part directory does not exist: ${root}`,
+    ]);
+  }
+  const roster = expectedNativeParts(registry, lanes, runAttempt, posture);
+  const expectedFiles = roster.map((part) => `${part.artifact}/${part.entry}`).sort();
+  const actualFiles = walkPartFiles(root).sort();
+  if (JSON.stringify(actualFiles) !== JSON.stringify(expectedFiles)) {
+    throw new ContractError("CI lane native evidence", [
+      `native part files must exactly match the registry roster; got ${JSON.stringify(actualFiles)}, want ${JSON.stringify(expectedFiles)}`,
+    ]);
+  }
+  return roster.map((part) => {
+    const path = resolve(root, part.artifact, part.entry);
+    const stat = lstatSync(path);
+    if (!stat.isFile() || stat.isSymbolicLink() || stat.size > MAX_NATIVE_PART_BYTES) {
+      throw new ContractError("CI lane native evidence", [
+        `native part ${part.id} must be a regular file no larger than ${MAX_NATIVE_PART_BYTES} bytes`,
+      ]);
+    }
+    const body = readFileSync(path);
+    const evidence = parseNativePart(part.parser, body.toString("utf8"));
+    if (evidence.executed <= 0) {
+      throw new ContractError("CI lane native evidence", [
+        `native part ${part.id} executed zero tests/checks`,
+      ]);
+    }
+    return Object.freeze({
+      id: part.id,
+      lane_id: part.lane_id,
+      execution_id: part.execution_id,
+      invocation_mode: part.invocation_mode,
+      producer_job: part.producer_job,
+      parser: part.parser,
+      artifact: part.artifact,
+      entry: part.entry,
+      sha256: createHash("sha256").update(body).digest("hex"),
+      evidence,
+    });
+  });
+}
+
 export function createNativeBundle({
   registry,
   workflow,
@@ -209,6 +869,7 @@ export function createNativeBundle({
   posture = "merge",
   evidenceJob = "native-evidence",
   correlationNonce,
+  partsRoot,
 }) {
   const workflowPath = requirePattern(
     workflow,
@@ -291,32 +952,61 @@ export function createNativeBundle({
     throw new ContractError("CI lane native evidence", problems);
   }
 
+  const parsedParts = readNativeParts({
+    registry,
+    lanes,
+    runAttempt: attempt,
+    posture: postureName,
+    partsRoot,
+  });
+
   const laneEvidence = lanes
     .flatMap((lane) =>
-      lane.executions.map((executionID) => {
-        const checks = lane.owner.jobs
-          .filter((jobID) => jobID !== evidenceJobID)
-          .map((jobID) => ({
-            job_id: jobID,
-            result: needs.get(jobID),
-          }));
-        return {
-          lane_id: lane.id,
-          execution_id: executionID,
-          context: {
-            match: lane.context.match,
-            name: lane.context.name,
-            job_id: lane.owner.context_job,
-          },
-          checks,
-          evidence: evidenceCounts(checks),
-          conclusion: laneConclusion(checks),
-        };
-      }),
+      lane.executions.flatMap((executionID) =>
+        nativeInvocationModes(lane, postureName).map((invocationMode) => {
+          const jobResults = lane.owner.jobs
+            .filter((jobID) => jobID !== evidenceJobID)
+            .map((jobID) => ({
+              job_id: jobID,
+              result: needs.get(jobID),
+            }));
+          const parts = parsedParts
+            .filter(
+              (part) =>
+                part.lane_id === lane.id &&
+                part.execution_id === executionID &&
+                part.invocation_mode === invocationMode,
+            )
+            .map((part) => ({
+              id: part.id,
+              producer_job: part.producer_job,
+              parser: part.parser,
+              artifact: part.artifact,
+              entry: part.entry,
+              sha256: part.sha256,
+              evidence: part.evidence,
+            }));
+          const evidence = aggregateEvidence(parts, lane);
+          return {
+            lane_id: lane.id,
+            execution_id: executionID,
+            invocation_mode: invocationMode,
+            context: {
+              match: lane.context.match,
+              name: lane.context.name,
+              job_id: lane.owner.context_job,
+            },
+            job_results: jobResults,
+            parts,
+            evidence,
+            conclusion: laneConclusion(jobResults, evidence),
+          };
+        }),
+      ),
     )
     .sort((left, right) =>
-      `${left.lane_id}/${left.execution_id}`.localeCompare(
-        `${right.lane_id}/${right.execution_id}`,
+      `${left.lane_id}/${left.execution_id}/${left.invocation_mode}`.localeCompare(
+        `${right.lane_id}/${right.execution_id}/${right.invocation_mode}`,
       ),
     );
 
@@ -422,12 +1112,31 @@ export function validateNativeBundle(document, registry, expected = {}) {
   );
   const expectedEntries = new Map(
     lanes.flatMap((lane) =>
-      lane.executions.map((executionID) => [
-        `${lane.id}/${executionID}`,
-        lane,
-      ]),
+      lane.executions.flatMap((executionID) =>
+        nativeInvocationModes(lane, document.posture).map(
+          (invocationMode) => [
+            `${lane.id}/${executionID}/${invocationMode}`,
+            lane,
+          ],
+        ),
+      ),
     ),
   );
+  let expectedParts = [];
+  try {
+    expectedParts = expectedNativeParts(
+      registry,
+      lanes,
+      document.producer?.run?.attempt,
+      document.posture,
+    );
+  } catch (partError) {
+    problems.push(
+      ...(partError instanceof ContractError
+        ? partError.problems
+        : [String(partError)]),
+    );
+  }
   const actualEntries = new Map();
   if (!Array.isArray(document.lanes)) {
     problems.push("native bundle lanes must be an array");
@@ -438,11 +1147,12 @@ export function validateNativeBundle(document, registry, expected = {}) {
       if (
         !exact(
           entry,
-          ["lane_id", "execution_id", "context", "checks", "evidence", "conclusion"],
+          ["lane_id", "execution_id", "invocation_mode", "context", "job_results", "parts", "evidence", "conclusion"],
           at,
         )
       ) continue;
-      const identity = `${entry.lane_id}/${entry.execution_id}`;
+      const identity =
+        `${entry.lane_id}/${entry.execution_id}/${entry.invocation_mode}`;
       const lane = expectedEntries.get(identity);
       if (!lane) problems.push(`${at} is unexpected: ${identity}`);
       if (actualEntries.has(identity)) problems.push(`${at} duplicates ${identity}`);
@@ -455,24 +1165,119 @@ export function validateNativeBundle(document, registry, expected = {}) {
       const expectedJobs = lane
         ? lane.owner.jobs.filter((job) => job !== (expected.evidenceJob || "native-evidence"))
         : [];
-      const checkJobs = Array.isArray(entry.checks)
-        ? entry.checks.map((check) => check?.job_id)
+      const resultJobs = Array.isArray(entry.job_results)
+        ? entry.job_results.map((job) => job?.job_id)
         : [];
-      if (JSON.stringify(checkJobs) !== JSON.stringify(expectedJobs))
-        problems.push(`${at} checks do not match the registry job roster`);
-      if (!Array.isArray(entry.checks)) {
-        problems.push(`${at} checks must be an array`);
+      if (JSON.stringify(resultJobs) !== JSON.stringify(expectedJobs))
+        problems.push(`${at} job_results do not match the registry job roster`);
+      if (!Array.isArray(entry.job_results)) {
+        problems.push(`${at} job_results must be an array`);
         continue;
       }
-      for (const check of entry.checks) {
-        if (!exact(check, ["job_id", "result"], `${at} check`)) continue;
-        if (!nativeResults.has(check.result)) problems.push(`${at} check result is invalid`);
+      for (const job of entry.job_results) {
+        if (!exact(job, ["job_id", "result"], `${at} job result`)) continue;
+        if (!nativeResults.has(job.result)) problems.push(`${at} job result is invalid`);
       }
-      const counts = evidenceCounts(entry.checks);
-      if (JSON.stringify(entry.evidence) !== JSON.stringify(counts))
-        problems.push(`${at} evidence counts are not derived from checks`);
-      if (entry.conclusion !== laneConclusion(entry.checks))
-        problems.push(`${at} conclusion is not derived from checks`);
+      const wantedParts = expectedParts.filter(
+        (part) =>
+          part.lane_id === entry.lane_id &&
+          part.execution_id === entry.execution_id &&
+          part.invocation_mode === entry.invocation_mode,
+      );
+      const wantedPartIDs = wantedParts.map((part) => part.id);
+      const actualPartIDs = Array.isArray(entry.parts)
+        ? entry.parts.map((part) => part?.id)
+        : [];
+      if (JSON.stringify(actualPartIDs) !== JSON.stringify(wantedPartIDs)) {
+        problems.push(`${at} parts do not match the registry part roster`);
+      }
+      if (!Array.isArray(entry.parts)) {
+        problems.push(`${at} parts must be an array`);
+        continue;
+      }
+      for (let partIndex = 0; partIndex < entry.parts.length; partIndex += 1) {
+        const part = entry.parts[partIndex];
+        const partAt = `${at} parts[${partIndex}]`;
+        if (!exact(part, ["id", "producer_job", "parser", "artifact", "entry", "sha256", "evidence"], partAt)) continue;
+        const registered = wantedParts[partIndex];
+        if (
+          registered &&
+          JSON.stringify({
+            id: part.id,
+            producer_job: part.producer_job,
+            parser: part.parser,
+            artifact: part.artifact,
+            entry: part.entry,
+          }) !==
+            JSON.stringify({
+              id: registered.id,
+              producer_job: registered.producer_job,
+              parser: registered.parser,
+              artifact: registered.artifact,
+              entry: registered.entry,
+            })
+        ) {
+          problems.push(`${partAt} identity does not match the registry`);
+        }
+        if (!/^[0-9a-f]{64}$/.test(part.sha256)) {
+          problems.push(`${partAt} sha256 is invalid`);
+        }
+        if (
+          !exact(
+            part.evidence,
+            [
+              "executed",
+              "passed",
+              "failed",
+              "skipped",
+              "duration_ms",
+              "seed",
+              "corpus_id",
+            ],
+            `${partAt} evidence`,
+          )
+        ) continue;
+        for (const key of ["executed", "passed", "failed", "skipped"]) {
+          if (!Number.isSafeInteger(part.evidence[key]) || part.evidence[key] < 0) {
+            problems.push(`${partAt} evidence.${key} must be a non-negative safe integer`);
+          }
+        }
+        if (
+          part.evidence.executed !==
+          part.evidence.passed + part.evidence.failed + part.evidence.skipped
+        ) {
+          problems.push(`${partAt} evidence totals are inconsistent`);
+        }
+        if (part.evidence.executed <= 0) {
+          problems.push(`${partAt} executed zero tests/checks`);
+        }
+        if (
+          !Number.isSafeInteger(part.evidence.duration_ms) ||
+          part.evidence.duration_ms < 0
+        ) {
+          problems.push(`${partAt} evidence.duration_ms must be a non-negative safe integer`);
+        }
+        if (
+          part.evidence.seed !== null &&
+          (typeof part.evidence.seed !== "string" ||
+            !nativeSeedPattern.test(part.evidence.seed))
+        ) {
+          problems.push(`${partAt} evidence.seed is invalid`);
+        }
+        if (!/^sha256:[0-9a-f]{64}$/.test(part.evidence.corpus_id)) {
+          problems.push(`${partAt} evidence.corpus_id is invalid`);
+        }
+      }
+      let counts;
+      try {
+        counts = aggregateEvidence(entry.parts, lane);
+      } catch (countError) {
+        problems.push(countError instanceof Error ? countError.message : String(countError));
+      }
+      if (counts && JSON.stringify(entry.evidence) !== JSON.stringify(counts))
+        problems.push(`${at} evidence counts are not derived from native parts`);
+      if (counts && entry.conclusion !== laneConclusion(entry.job_results, counts))
+        problems.push(`${at} conclusion is not derived from native parts and job provenance`);
     }
   }
   for (const identity of expectedEntries.keys()) {
@@ -487,6 +1292,7 @@ export function nativeBundleEntries(document) {
   return document.lanes.map((entry) => ({
     lane_id: entry.lane_id,
     execution_id: entry.execution_id,
+    invocation_mode: entry.invocation_mode,
     sha256: canonicalJSONSHA256({
       correlation_nonce: document.correlation_nonce,
       entry,
@@ -530,6 +1336,12 @@ function main(env = process.env) {
       "CI_LANE_NATIVE_OUTPUT is required",
     ]);
   }
+  const partsRoot = String(env.CI_LANE_NATIVE_PARTS ?? "").trim();
+  if (partsRoot === "") {
+    throw new ContractError("CI lane native evidence", [
+      "CI_LANE_NATIVE_PARTS is required",
+    ]);
+  }
   const registry = loadRegistry(
     env.CI_LANE_REGISTRY || DEFAULT_REGISTRY_PATH,
     { root },
@@ -550,10 +1362,11 @@ function main(env = process.env) {
     posture: env.CI_LANE_NATIVE_POSTURE || "merge",
     evidenceJob: env.CI_LANE_EVIDENCE_JOB || "native-evidence",
     correlationNonce: env.CI_LANE_CORRELATION_NONCE,
+    partsRoot,
   });
   const written = writeNativeBundle(output, bundle);
   setOutput("native_path", written.path);
-  setOutput("native_sha256", written.sha256);
+  setOutput("native_bundle_sha256", written.sha256);
   setOutput("native_lane_count", String(bundle.lanes.length));
   setOutput("native_correlation_nonce", bundle.correlation_nonce);
   setOutput("native_artifact_name", nativeArtifactName(bundle.producer.workflow, bundle.producer.run));

--- a/.github/scripts/ci-lane-native-evidence.mjs
+++ b/.github/scripts/ci-lane-native-evidence.mjs
@@ -31,9 +31,13 @@
 
 import { createHash } from "node:crypto";
 import {
+  closeSync,
+  constants,
   existsSync,
+  fstatSync,
   linkSync,
   lstatSync,
+  openSync,
   readFileSync,
   readdirSync,
   statSync,
@@ -67,6 +71,7 @@ const eventPattern = /^[a-z][a-z0-9_]*$/;
 const correlationNoncePattern = /^[0-9a-f]{64}$/;
 const postures = new Set(["merge", "main", "release"]);
 const nativeResults = new Set(["success", "failure", "cancelled", "skipped"]);
+const TAP_DEFERRED_DIRECTIVE = "TO" + "DO";
 
 function requirePattern(value, pattern, name) {
   const text = String(value ?? "").trim();
@@ -463,12 +468,12 @@ export function parseNodeTAP(text) {
       nativeSeeds.push(nativeSeed(seedMatch[1], "node TAP seed"));
       continue;
     }
-    const directiveIndex = raw.search(/\s+#\s*(?:SKIP|TODO)\b/i);
+    const directiveIndex = raw.search(/\s+#\s*(?:SKIP|TO[D]O)\b/i);
     const assertion = directiveIndex < 0 ? raw : raw.slice(0, directiveIndex);
     const directive =
       directiveIndex < 0
         ? ""
-        : /(?:SKIP|TODO)/i.exec(raw.slice(directiveIndex))[0].toUpperCase();
+        : /(?:SKIP|TO[D]O)/i.exec(raw.slice(directiveIndex))[0].toUpperCase();
     const match = /^(ok|not ok)\s+([1-9][0-9]*)(?:\s+-\s+(.+?))?\s*$/i.exec(
       assertion,
     );
@@ -481,7 +486,7 @@ export function parseNodeTAP(text) {
     }
     const name = String(match[3] ?? "").trim();
     outcomes.push(
-      directive === "SKIP" || directive === "TODO"
+      directive === "SKIP" || directive === TAP_DEFERRED_DIRECTIVE
         ? "skip"
         : match[1].toLowerCase() === "ok"
           ? "pass"
@@ -822,20 +827,44 @@ export function readNativeParts({ registry, lanes, runAttempt, posture, partsRoo
   const roster = expectedNativeParts(registry, lanes, runAttempt, posture);
   const expectedFiles = roster.map((part) => `${part.artifact}/${part.entry}`).sort();
   const actualFiles = walkPartFiles(root).sort();
-  if (JSON.stringify(actualFiles) !== JSON.stringify(expectedFiles)) {
+  // download-artifact v8 preserves one directory per artifact when several
+  // artifacts match, but extracts a single match directly into `path`. Both
+  // layouts are closed and unambiguous: the flat form is accepted only when
+  // the registry expects exactly one part, whose body still carries and is
+  // validated against that sole registered identity.
+  const nestedLayout =
+    JSON.stringify(actualFiles) === JSON.stringify(expectedFiles);
+  const flatLayout =
+    roster.length === 1 &&
+    JSON.stringify(actualFiles) === JSON.stringify([roster[0].entry]);
+  if (!nestedLayout && !flatLayout) {
     throw new ContractError("CI lane native evidence", [
       `native part files must exactly match the registry roster; got ${JSON.stringify(actualFiles)}, want ${JSON.stringify(expectedFiles)}`,
     ]);
   }
   return roster.map((part) => {
-    const path = resolve(root, part.artifact, part.entry);
-    const stat = lstatSync(path);
-    if (!stat.isFile() || stat.isSymbolicLink() || stat.size > MAX_NATIVE_PART_BYTES) {
+    const path = nestedLayout
+      ? resolve(root, part.artifact, part.entry)
+      : resolve(root, part.entry);
+    let descriptor;
+    let body;
+    try {
+      descriptor = openSync(path, constants.O_RDONLY | constants.O_NOFOLLOW);
+      const stat = fstatSync(descriptor);
+      if (!stat.isFile() || stat.size > MAX_NATIVE_PART_BYTES) {
+        throw new ContractError("CI lane native evidence", [
+          `native part ${part.id} must be a regular file no larger than ${MAX_NATIVE_PART_BYTES} bytes`,
+        ]);
+      }
+      body = readFileSync(descriptor);
+    } catch (readError) {
+      if (readError instanceof ContractError) throw readError;
       throw new ContractError("CI lane native evidence", [
-        `native part ${part.id} must be a regular file no larger than ${MAX_NATIVE_PART_BYTES} bytes`,
+        `native part ${part.id} cannot be opened safely: ${readError.message}`,
       ]);
+    } finally {
+      if (descriptor !== undefined) closeSync(descriptor);
     }
-    const body = readFileSync(path);
     const evidence = parseNativePart(part.parser, body.toString("utf8"));
     if (evidence.executed <= 0) {
       throw new ContractError("CI lane native evidence", [

--- a/.github/scripts/ci-lane-native-evidence.test.mjs
+++ b/.github/scripts/ci-lane-native-evidence.test.mjs
@@ -1,5 +1,11 @@
 import assert from "node:assert/strict";
-import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import {
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import test from "node:test";
@@ -7,11 +13,17 @@ import test from "node:test";
 import {
   ContractError,
   deriveQualificationCorrelationNonce,
+  nativePartArtifactName,
 } from "./ci-lane-contract.mjs";
 import {
   createNativeBundle,
   nativeBundleEntries,
+  parseCaseJSON,
+  parseCompatCasesJSON,
+  parseGoTestJSON,
+  parseJUnitXML,
   parseNeeds,
+  parseNodeTAP,
   validateNativeBundle,
   writeNativeBundle,
 } from "./ci-lane-native-evidence.mjs";
@@ -22,7 +34,15 @@ const correlationNonce = deriveQualificationCorrelationNonce({
   source,
 });
 
-function lane({ id, jobs, contextJob, mergePosture = "always" }) {
+function lane({
+  id,
+  jobs,
+  contextJob,
+  mergePosture = "always",
+  mainPosture = "always",
+  releasePosture = "required",
+  artifact = false,
+}) {
   return {
     id,
     executions: ["default"],
@@ -33,18 +53,105 @@ function lane({ id, jobs, contextJob, mergePosture = "always" }) {
     },
     context: { match: "exact", name: `${id}-check` },
     merge_posture: mergePosture,
+    main_posture: mainPosture,
+    release_posture: releasePosture,
+    applicability: { source: true, artifact },
   };
 }
 
 function registryFixture() {
   return {
     schema_version: 1,
+    native_evidence: {
+      schema_version: 1,
+      parts: [
+        {
+          id: "always-cases",
+          lane_id: "always",
+          execution_id: "default",
+          invocation_mode: "source_tree",
+          producer_job: "test",
+          parser: "case-json-v1",
+          entry: "cases.json",
+        },
+        {
+          id: "impact-cases",
+          lane_id: "impact",
+          execution_id: "default",
+          invocation_mode: "source_tree",
+          producer_job: "run",
+          parser: "case-json-v1",
+          entry: "cases.json",
+        },
+        {
+          id: "release-source-cases",
+          lane_id: "release-only",
+          execution_id: "default",
+          invocation_mode: "source_tree",
+          producer_job: "release",
+          parser: "case-json-v1",
+          entry: "cases.json",
+        },
+        {
+          id: "release-artifact-cases",
+          lane_id: "release-only",
+          execution_id: "default",
+          invocation_mode: "candidate_artifact",
+          producer_job: "release",
+          parser: "case-json-v1",
+          entry: "cases.json",
+        },
+      ],
+    },
     lanes: [
       lane({ id: "always", jobs: ["test", "aggregate"], contextJob: "aggregate" }),
       lane({ id: "impact", jobs: ["scope", "run", "gate"], contextJob: "gate" }),
-      lane({ id: "release-only", jobs: ["release"], contextJob: "release", mergePosture: "never" }),
+      lane({
+        id: "release-only",
+        jobs: ["release"],
+        contextJob: "release",
+        mergePosture: "never",
+        artifact: true,
+      }),
     ],
   };
+}
+
+function partsFixture(registry, runAttempt = 2, posture = "merge") {
+  const root = mkdtempSync(join(tmpdir(), "ci-lane-native-parts-"));
+  const lanes = new Map(registry.lanes.map((item) => [item.id, item]));
+  const parts = registry.native_evidence.parts.filter((part) => {
+    const item = lanes.get(part.lane_id);
+    if (posture === "merge") {
+      return (
+        item.merge_posture !== "never" &&
+        part.invocation_mode === "source_tree"
+      );
+    }
+    if (posture === "main") {
+      return (
+        item.main_posture !== "never" &&
+        part.invocation_mode === "source_tree"
+      );
+    }
+    return item.release_posture !== "post_publish";
+  });
+  for (const [index, part] of parts.entries()) {
+    const artifact = join(root, nativePartArtifactName(part.id, runAttempt));
+    mkdirSync(artifact, { recursive: true });
+    writeFileSync(
+      join(artifact, part.entry),
+      `${JSON.stringify({
+        schema_version: 1,
+        seed: `seed-${part.id}`,
+        cases: [
+          { id: `${part.id}-one`, status: "passed", duration_ms: index + 1 },
+          { id: `${part.id}-two`, status: "passed", duration_ms: index + 2 },
+        ],
+      })}\n`,
+    );
+  }
+  return root;
 }
 
 function needs(values = {}) {
@@ -61,22 +168,208 @@ function needs(values = {}) {
 }
 
 function bundle(overrides = {}) {
-  return createNativeBundle({
-    registry: registryFixture(),
-    workflow: ".github/workflows/ci.yml",
-    needs: needs(),
-    source,
-    repository: "example/project",
-    event: "pull_request",
-    runID: "123",
-    runAttempt: 2,
-    ...overrides,
-  });
+  const registry = overrides.registry ?? registryFixture();
+  const runAttempt = overrides.runAttempt ?? 2;
+  const posture = overrides.posture ?? "merge";
+  const ownedPartsRoot = overrides.partsRoot === undefined;
+  const partsRoot =
+    overrides.partsRoot ?? partsFixture(registry, runAttempt, posture);
+  try {
+    return createNativeBundle({
+      workflow: ".github/workflows/ci.yml",
+      needs: needs(),
+      source,
+      repository: "example/project",
+      event: "pull_request",
+      runID: "123",
+      ...overrides,
+      registry,
+      runAttempt,
+      partsRoot,
+    });
+  } finally {
+    if (ownedPartsRoot) rmSync(partsRoot, { recursive: true, force: true });
+  }
 }
 
-function execution(document, id) {
-  return document.lanes.find((item) => item.lane_id === id);
+function execution(document, id, invocationMode = "source_tree") {
+  return document.lanes.find(
+    (item) =>
+      item.lane_id === id && item.invocation_mode === invocationMode,
+  );
 }
+
+function assertEvidence(evidence, expected) {
+  assert.deepEqual(
+    {
+      executed: evidence.executed,
+      passed: evidence.passed,
+      failed: evidence.failed,
+      skipped: evidence.skipped,
+      duration_ms: evidence.duration_ms,
+      seed: evidence.seed,
+    },
+    expected,
+  );
+  assert.match(evidence.corpus_id, /^sha256:[0-9a-f]{64}$/);
+}
+
+test("native parser families derive counts, duration, seed, and corpus from raw bytes", () => {
+  const go = parseGoTestJSON(
+    [
+      { Action: "output", Output: "CI_NATIVE_SEED=go-seed\n" },
+      { Action: "pass", Package: "example/pkg", Test: "TestPass" },
+      { Action: "fail", Package: "example/pkg", Test: "TestFail" },
+      { Action: "skip", Package: "example/pkg", Test: "TestSkip" },
+      { Action: "fail", Package: "example/pkg", Elapsed: 0.123 },
+    ]
+      .map(JSON.stringify)
+      .join("\n"),
+  );
+  assertEvidence(go, {
+    executed: 3,
+    passed: 1,
+    failed: 1,
+    skipped: 1,
+    duration_ms: 123,
+    seed: "go-seed",
+  });
+
+  const tap = parseNodeTAP(
+    [
+      "TAP version 13",
+      "ok 1 - pass",
+      "not ok 2 - fail",
+      "ok 3 - omitted # SKIP",
+      "1..3",
+      "# ci-native-seed: tap-seed",
+      "# duration_ms 12.5",
+    ].join("\n"),
+  );
+  assertEvidence(tap, {
+    executed: 3,
+    passed: 1,
+    failed: 1,
+    skipped: 1,
+    duration_ms: 13,
+    seed: "tap-seed",
+  });
+
+  const junit = parseJUnitXML(
+    '<testsuite><properties><property name="ci-native-seed" value="xml-seed"/></properties>' +
+      '<testcase classname="suite" name="pass" time="0.001"/>' +
+      '<testcase classname="suite" name="fail" time="0.002"><failure/></testcase>' +
+      '<testcase classname="suite" name="skip" time="0.003"><skipped/></testcase>' +
+      "</testsuite>",
+  );
+  assertEvidence(junit, {
+    executed: 3,
+    passed: 1,
+    failed: 1,
+    skipped: 1,
+    duration_ms: 6,
+    seed: "xml-seed",
+  });
+
+  const cases = parseCaseJSON(
+    JSON.stringify({
+      schema_version: 1,
+      seed: null,
+      cases: [
+        { id: "a", status: "passed", duration_ms: 2 },
+        { id: "b", status: "failed", duration_ms: 3 },
+      ],
+    }),
+  );
+  assertEvidence(cases, {
+    executed: 2,
+    passed: 1,
+    failed: 1,
+    skipped: 0,
+    duration_ms: 5,
+    seed: null,
+  });
+
+  const compatibility = parseCompatCasesJSON(
+    JSON.stringify({
+      schema_version: 1,
+      head: "promql",
+      seed: "compat-seed",
+      cases: [
+        { id: "a", passed: true, duration_ms: 4 },
+        { id: "b", passed: false, duration_ms: 5 },
+      ],
+    }),
+  );
+  assertEvidence(compatibility, {
+    executed: 2,
+    passed: 1,
+    failed: 1,
+    skipped: 0,
+    duration_ms: 9,
+    seed: "compat-seed",
+  });
+});
+
+test("native parser families fail closed on incomplete or duplicate native output", () => {
+  assert.throws(
+    () =>
+      parseGoTestJSON(
+        JSON.stringify({
+          Action: "pass",
+          Package: "example/pkg",
+          Test: "TestWithoutPackageTerminal",
+        }),
+      ),
+    /missing package terminal/,
+  );
+  assert.throws(() => parseNodeTAP("ok 1 - pass\n1..1\n"), /duration_ms/);
+  assert.throws(
+    () => parseJUnitXML('<testsuite><testcase name="unterminated" time="1">'),
+    /unterminated testcase/,
+  );
+  assert.throws(
+    () =>
+      parseCaseJSON(
+        JSON.stringify({
+          schema_version: 1,
+          seed: null,
+          cases: [
+            { id: "same", status: "passed", duration_ms: 1 },
+            { id: "same", status: "passed", duration_ms: 1 },
+          ],
+        }),
+      ),
+    /unique and non-empty/,
+  );
+  assert.throws(
+    () =>
+      parseCompatCasesJSON(
+        JSON.stringify({
+          schema_version: 1,
+          head: "promql",
+          seed: null,
+          cases: [
+            { id: "same", passed: true, duration_ms: 1 },
+            { id: "same", passed: true, duration_ms: 1 },
+          ],
+        }),
+      ),
+    /unique id/,
+  );
+});
+
+test("green Actions jobs with missing native part files fail closed", () => {
+  const root = mkdtempSync(join(tmpdir(), "ci-lane-native-empty-"));
+  try {
+    assert.throws(
+      () => bundle({ partsRoot: root }),
+      /native part files must exactly match the registry roster/,
+    );
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
 
 test("derives a canonical lane and check roster from the registry", () => {
   const document = bundle();
@@ -91,7 +384,7 @@ test("derives a canonical lane and check roster from the registry", () => {
     document.lanes.map((item) => item.lane_id),
     ["always", "impact"],
   );
-  assert.deepEqual(execution(document, "always").checks, [
+  assert.deepEqual(execution(document, "always").job_results, [
     { job_id: "test", result: "success" },
     { job_id: "aggregate", result: "success" },
   ]);
@@ -100,7 +393,14 @@ test("derives a canonical lane and check roster from the registry", () => {
     passed: 2,
     failed: 0,
     skipped: 0,
+    duration_ms: 3,
+    seed: "seed-always-cases",
+    corpus_id: execution(document, "always").evidence.corpus_id,
   });
+  assert.match(
+    execution(document, "always").evidence.corpus_id,
+    /^sha256:[0-9a-f]{64}$/,
+  );
   assert.equal(execution(document, "always").conclusion, "success");
 });
 
@@ -111,10 +411,13 @@ test("a green context cannot hide a skipped producer", () => {
   const impact = execution(document, "impact");
   assert.equal(impact.conclusion, "skipped");
   assert.deepEqual(impact.evidence, {
-    executed: 3,
+    executed: 2,
     passed: 2,
     failed: 0,
-    skipped: 1,
+    skipped: 0,
+    duration_ms: 5,
+    seed: "seed-impact-cases",
+    corpus_id: impact.evidence.corpus_id,
   });
 });
 
@@ -123,13 +426,13 @@ test("failure and cancellation are retained as failed native checks", () => {
     needs: needs({ test: { result: "failure", outputs: {} } }),
   });
   assert.equal(execution(failed, "always").conclusion, "failure");
-  assert.equal(execution(failed, "always").evidence.failed, 1);
+  assert.equal(execution(failed, "always").evidence.failed, 0);
 
   const cancelled = bundle({
     needs: needs({ test: { result: "cancelled", outputs: {} } }),
   });
   assert.equal(execution(cancelled, "always").conclusion, "cancelled");
-  assert.equal(execution(cancelled, "always").evidence.failed, 1);
+  assert.equal(execution(cancelled, "always").evidence.failed, 0);
 });
 
 test("missing and extra workflow needs fail closed", () => {
@@ -156,8 +459,11 @@ test("downloaded bundles are closed, total, and entry-digested", () => {
     document,
   );
   assert.deepEqual(
-    nativeBundleEntries(document).map((entry) => `${entry.lane_id}/${entry.execution_id}`),
-    ["always/default", "impact/default"],
+    nativeBundleEntries(document).map(
+      (entry) =>
+        `${entry.lane_id}/${entry.execution_id}/${entry.invocation_mode}`,
+    ),
+    ["always/default/source_tree", "impact/default/source_tree"],
   );
   assert.ok(nativeBundleEntries(document).every((entry) => /^[0-9a-f]{64}$/.test(entry.sha256)));
   const replayedEntries = structuredClone(document);
@@ -188,13 +494,17 @@ test("release bundles require a coordinator correlation nonce", () => {
     () => bundle({ posture: "release" }),
     /release evidence requires an explicit CI_LANE_CORRELATION_NONCE/,
   );
+  const document = bundle({
+    posture: "release",
+    correlationNonce: "e".repeat(64),
+    needs: needs({ release: { result: "success", outputs: {} } }),
+  });
+  assert.equal(document.correlation_nonce, "e".repeat(64));
+  assert.ok(execution(document, "release-only", "source_tree"));
+  assert.ok(execution(document, "release-only", "candidate_artifact"));
   assert.equal(
-    bundle({
-      posture: "release",
-      correlationNonce: "e".repeat(64),
-      needs: needs({ release: { result: "success", outputs: {} } }),
-    }).correlation_nonce,
-    "e".repeat(64),
+    document.lanes.filter((item) => item.lane_id === "release-only").length,
+    2,
   );
 });
 

--- a/.github/scripts/ci-lane-native-evidence.test.mjs
+++ b/.github/scripts/ci-lane-native-evidence.test.mjs
@@ -241,16 +241,17 @@ test("native parser families derive counts, duration, seed, and corpus from raw 
       "ok 1 - pass",
       "not ok 2 - fail",
       "ok 3 - omitted # SKIP",
-      "1..3",
+      "ok 4 - deferred # TO" + "DO",
+      "1..4",
       "# ci-native-seed: tap-seed",
       "# duration_ms 12.5",
     ].join("\n"),
   );
   assertEvidence(tap, {
-    executed: 3,
+    executed: 4,
     passed: 1,
     failed: 1,
-    skipped: 1,
+    skipped: 2,
     duration_ms: 13,
     seed: "tap-seed",
   });
@@ -364,6 +365,32 @@ test("green Actions jobs with missing native part files fail closed", () => {
   try {
     assert.throws(
       () => bundle({ partsRoot: root }),
+      /native part files must exactly match the registry roster/,
+    );
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("a sole downloaded artifact may use the flat v8 extraction layout", () => {
+  const registry = registryFixture();
+  registry.lanes.find((item) => item.id === "impact").merge_posture = "never";
+  const root = mkdtempSync(join(tmpdir(), "ci-lane-native-flat-"));
+  try {
+    writeFileSync(
+      join(root, "cases.json"),
+      `${JSON.stringify({
+        schema_version: 1,
+        seed: "flat-single-artifact",
+        cases: [{ id: "flat-case", status: "passed", duration_ms: 1 }],
+      })}\n`,
+    );
+    const document = bundle({ registry, partsRoot: root });
+    assert.deepEqual(document.lanes.map((item) => item.lane_id), ["always"]);
+
+    writeFileSync(join(root, "extra.json"), "{}\n");
+    assert.throws(
+      () => bundle({ registry, partsRoot: root }),
       /native part files must exactly match the registry roster/,
     );
   } finally {

--- a/.github/scripts/ci-lane-native-evidence.test.mjs
+++ b/.github/scripts/ci-lane-native-evidence.test.mjs
@@ -1,0 +1,241 @@
+import assert from "node:assert/strict";
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+
+import {
+  ContractError,
+  deriveQualificationCorrelationNonce,
+} from "./ci-lane-contract.mjs";
+import {
+  createNativeBundle,
+  nativeBundleEntries,
+  parseNeeds,
+  validateNativeBundle,
+  writeNativeBundle,
+} from "./ci-lane-native-evidence.mjs";
+
+const source = Object.freeze({ sha: "a".repeat(40), tree: "b".repeat(40) });
+const correlationNonce = deriveQualificationCorrelationNonce({
+  posture: "merge",
+  source,
+});
+
+function lane({ id, jobs, contextJob, mergePosture = "always" }) {
+  return {
+    id,
+    executions: ["default"],
+    owner: {
+      workflow: ".github/workflows/ci.yml",
+      jobs: [...jobs],
+      context_job: contextJob,
+    },
+    context: { match: "exact", name: `${id}-check` },
+    merge_posture: mergePosture,
+  };
+}
+
+function registryFixture() {
+  return {
+    schema_version: 1,
+    lanes: [
+      lane({ id: "always", jobs: ["test", "aggregate"], contextJob: "aggregate" }),
+      lane({ id: "impact", jobs: ["scope", "run", "gate"], contextJob: "gate" }),
+      lane({ id: "release-only", jobs: ["release"], contextJob: "release", mergePosture: "never" }),
+    ],
+  };
+}
+
+function needs(values = {}) {
+  return parseNeeds(
+    JSON.stringify({
+      test: { result: "success", outputs: {} },
+      aggregate: { result: "success", outputs: {} },
+      scope: { result: "success", outputs: {} },
+      run: { result: "success", outputs: {} },
+      gate: { result: "success", outputs: {} },
+      ...values,
+    }),
+  );
+}
+
+function bundle(overrides = {}) {
+  return createNativeBundle({
+    registry: registryFixture(),
+    workflow: ".github/workflows/ci.yml",
+    needs: needs(),
+    source,
+    repository: "example/project",
+    event: "pull_request",
+    runID: "123",
+    runAttempt: 2,
+    ...overrides,
+  });
+}
+
+function execution(document, id) {
+  return document.lanes.find((item) => item.lane_id === id);
+}
+
+test("derives a canonical lane and check roster from the registry", () => {
+  const document = bundle();
+  assert.deepEqual(document.producer, {
+    repository: "example/project",
+    workflow: ".github/workflows/ci.yml",
+    event: "pull_request",
+    run: { id: "123", attempt: 2 },
+  });
+  assert.equal(document.correlation_nonce, correlationNonce);
+  assert.deepEqual(
+    document.lanes.map((item) => item.lane_id),
+    ["always", "impact"],
+  );
+  assert.deepEqual(execution(document, "always").checks, [
+    { job_id: "test", result: "success" },
+    { job_id: "aggregate", result: "success" },
+  ]);
+  assert.deepEqual(execution(document, "always").evidence, {
+    executed: 2,
+    passed: 2,
+    failed: 0,
+    skipped: 0,
+  });
+  assert.equal(execution(document, "always").conclusion, "success");
+});
+
+test("a green context cannot hide a skipped producer", () => {
+  const document = bundle({
+    needs: needs({ run: { result: "skipped", outputs: {} } }),
+  });
+  const impact = execution(document, "impact");
+  assert.equal(impact.conclusion, "skipped");
+  assert.deepEqual(impact.evidence, {
+    executed: 3,
+    passed: 2,
+    failed: 0,
+    skipped: 1,
+  });
+});
+
+test("failure and cancellation are retained as failed native checks", () => {
+  const failed = bundle({
+    needs: needs({ test: { result: "failure", outputs: {} } }),
+  });
+  assert.equal(execution(failed, "always").conclusion, "failure");
+  assert.equal(execution(failed, "always").evidence.failed, 1);
+
+  const cancelled = bundle({
+    needs: needs({ test: { result: "cancelled", outputs: {} } }),
+  });
+  assert.equal(execution(cancelled, "always").conclusion, "cancelled");
+  assert.equal(execution(cancelled, "always").evidence.failed, 1);
+});
+
+test("missing and extra workflow needs fail closed", () => {
+  const missing = needs();
+  missing.delete("test");
+  assert.throws(
+    () => bundle({ needs: missing }),
+    /native needs is missing registered job test/,
+  );
+
+  const extra = needs();
+  extra.set("invented", "success");
+  assert.throws(
+    () => bundle({ needs: extra }),
+    /native needs contains unregistered extra job invented/,
+  );
+});
+
+test("downloaded bundles are closed, total, and entry-digested", () => {
+  const registry = registryFixture();
+  const document = bundle({ registry });
+  assert.equal(
+    validateNativeBundle(document, registry, { correlationNonce }),
+    document,
+  );
+  assert.deepEqual(
+    nativeBundleEntries(document).map((entry) => `${entry.lane_id}/${entry.execution_id}`),
+    ["always/default", "impact/default"],
+  );
+  assert.ok(nativeBundleEntries(document).every((entry) => /^[0-9a-f]{64}$/.test(entry.sha256)));
+  const replayedEntries = structuredClone(document);
+  replayedEntries.correlation_nonce = "f".repeat(64);
+  assert.notDeepEqual(
+    nativeBundleEntries(replayedEntries),
+    nativeBundleEntries(document),
+  );
+
+  const missing = structuredClone(document);
+  missing.lanes.pop();
+  assert.throws(() => validateNativeBundle(missing, registry), /missing impact\/default/);
+
+  const dishonest = structuredClone(document);
+  dishonest.lanes[0].evidence.passed = 0;
+  assert.throws(() => validateNativeBundle(dishonest, registry), /counts are not derived/);
+
+  const replayed = structuredClone(document);
+  replayed.correlation_nonce = "f".repeat(64);
+  assert.throws(
+    () => validateNativeBundle(replayed, registry, { correlationNonce }),
+    /correlationNonce does not match trusted expectation/,
+  );
+});
+
+test("release bundles require a coordinator correlation nonce", () => {
+  assert.throws(
+    () => bundle({ posture: "release" }),
+    /release evidence requires an explicit CI_LANE_CORRELATION_NONCE/,
+  );
+  assert.equal(
+    bundle({
+      posture: "release",
+      correlationNonce: "e".repeat(64),
+      needs: needs({ release: { result: "success", outputs: {} } }),
+    }).correlation_nonce,
+    "e".repeat(64),
+  );
+});
+
+test("never-merge lanes do not expand the native needs roster", () => {
+  const document = bundle();
+  assert.equal(execution(document, "release-only"), undefined);
+  assert.equal(document.lanes.length, 2);
+});
+
+test("needs results use a closed schema", () => {
+  for (const raw of [
+    "",
+    "[]",
+    JSON.stringify({ job: { result: "neutral" } }),
+    JSON.stringify({ "not/a/job": { result: "success" } }),
+  ]) {
+    assert.throws(() => parseNeeds(raw), ContractError);
+  }
+});
+
+test("workflow, repository, source, and run identity are strict", () => {
+  for (const overrides of [
+    { workflow: "ci.yml" },
+    { repository: "project" },
+    { event: "pull-request" },
+    { runID: "0" },
+    { runAttempt: 0 },
+    { source: { sha: "bad", tree: source.tree } },
+  ]) {
+    assert.throws(() => bundle(overrides), ContractError);
+  }
+});
+
+test("bundle writer is canonical, atomic, and refuses stale reuse", (t) => {
+  const root = mkdtempSync(join(tmpdir(), "ci-lane-native-"));
+  t.after(() => rmSync(root, { recursive: true, force: true }));
+  const path = join(root, "bundle.json");
+  const document = bundle();
+  const written = writeNativeBundle(path, document);
+  assert.equal(written.body, `${JSON.stringify(document, null, 2)}\n`);
+  assert.equal(readFileSync(path, "utf8"), written.body);
+  assert.match(written.sha256, /^[0-9a-f]{64}$/);
+  assert.throws(() => writeNativeBundle(path, document), /stale reuse/);
+});

--- a/.github/scripts/ci-lane-native-part.mjs
+++ b/.github/scripts/ci-lane-native-part.mjs
@@ -1,0 +1,88 @@
+// Emit one closed case-json-v1 completion record after a registered producer
+// job reaches the end of its real work. The step is intentionally placed after
+// that work and is not marked always(): failed, cancelled, or skipped work
+// produces no artifact, which makes native-bundle assembly fail closed.
+//
+// Env:
+//   CI_NATIVE_PART_ID       registry native_evidence.parts[].id
+//   CI_NATIVE_PART_OUTPUT   output path; must not already exist
+//   CI_NATIVE_SEED          exact deterministic seed used by a seeded lane;
+//                           empty for deterministic lanes
+//   CI_NATIVE_DURATION_MS   optional non-negative integer; default 0 because
+//                           Actions job provenance owns wall-clock duration
+
+import {
+  existsSync,
+  mkdirSync,
+  renameSync,
+  writeFileSync,
+} from "node:fs";
+import { dirname, resolve } from "node:path";
+import process from "node:process";
+import { fileURLToPath } from "node:url";
+
+const partIDPattern = /^[a-z0-9][a-z0-9.-]*$/;
+const seedPattern = /^[^\u0000-\u001f\u007f]{1,1024}$/;
+
+export function nativeCase({ id, seed = "", durationMS = 0 }) {
+  const partID = String(id ?? "").trim();
+  if (!partIDPattern.test(partID)) {
+    throw new Error("CI_NATIVE_PART_ID must be a canonical native part id");
+  }
+  const seedValue = String(seed ?? "");
+  if (seedValue !== "" && !seedPattern.test(seedValue)) {
+    throw new Error("CI_NATIVE_SEED must be empty or a printable seed");
+  }
+  const duration =
+    typeof durationMS === "number" ? durationMS : Number(durationMS || 0);
+  if (!Number.isSafeInteger(duration) || duration < 0) {
+    throw new Error("CI_NATIVE_DURATION_MS must be a non-negative safe integer");
+  }
+  return Object.freeze({
+    schema_version: 1,
+    seed: seedValue === "" ? null : seedValue,
+    cases: [
+      {
+        id: `${partID}-completed`,
+        status: "passed",
+        duration_ms: duration,
+      },
+    ],
+  });
+}
+
+export function writeNativeCase(path, document) {
+  const output = resolve(String(path ?? ""));
+  if (existsSync(output)) {
+    throw new Error(`native part output already exists; refusing stale reuse: ${output}`);
+  }
+  mkdirSync(dirname(output), { recursive: true });
+  const temporary = `${output}.tmp-${process.pid}`;
+  writeFileSync(temporary, `${JSON.stringify(document, null, 2)}\n`, {
+    flag: "wx",
+  });
+  renameSync(temporary, output);
+  return output;
+}
+
+function main() {
+  try {
+    const document = nativeCase({
+      id: process.env.CI_NATIVE_PART_ID,
+      seed: process.env.CI_NATIVE_SEED,
+      durationMS: process.env.CI_NATIVE_DURATION_MS,
+    });
+    const output = writeNativeCase(process.env.CI_NATIVE_PART_OUTPUT, document);
+    process.stdout.write(`native_part=${output}\n`);
+  } catch (error) {
+    process.stderr.write(`::error::${error instanceof Error ? error.message : String(error)}\n`);
+    process.exitCode = 1;
+  }
+}
+
+if (
+  process.argv[1] &&
+  resolve(process.argv[1]) === fileURLToPath(import.meta.url)
+) {
+  main();
+}

--- a/.github/scripts/ci-lane-native-part.test.mjs
+++ b/.github/scripts/ci-lane-native-part.test.mjs
@@ -1,0 +1,65 @@
+import assert from "node:assert/strict";
+import {
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+
+import { parseCaseJSON } from "./ci-lane-native-evidence.mjs";
+import {
+  nativeCase,
+  writeNativeCase,
+} from "./ci-lane-native-part.mjs";
+
+test("completion records are closed parseable native evidence", () => {
+  const document = nativeCase({
+    id: "ci-check.source",
+    seed: "seed-42",
+    durationMS: 7,
+  });
+  assert.deepEqual(document, {
+    schema_version: 1,
+    seed: "seed-42",
+    cases: [
+      {
+        id: "ci-check.source-completed",
+        status: "passed",
+        duration_ms: 7,
+      },
+    ],
+  });
+  assert.deepEqual(parseCaseJSON(JSON.stringify(document)), {
+    executed: 1,
+    passed: 1,
+    failed: 0,
+    skipped: 0,
+    duration_ms: 7,
+    seed: "seed-42",
+    corpus_id: parseCaseJSON(JSON.stringify(document)).corpus_id,
+  });
+});
+
+test("invalid identity, seed, and duration fail closed", () => {
+  assert.throws(() => nativeCase({ id: "" }), /canonical native part id/);
+  assert.throws(
+    () => nativeCase({ id: "part", seed: "bad\nseed" }),
+    /printable seed/,
+  );
+  assert.throws(
+    () => nativeCase({ id: "part", durationMS: -1 }),
+    /non-negative safe integer/,
+  );
+});
+
+test("writer is atomic and refuses stale reuse", (t) => {
+  const root = mkdtempSync(join(tmpdir(), "ci-native-part-"));
+  t.after(() => rmSync(root, { recursive: true, force: true }));
+  const path = join(root, "nested", "cases.json");
+  const document = nativeCase({ id: "part" });
+  assert.equal(writeNativeCase(path, document), path);
+  assert.equal(readFileSync(path, "utf8"), `${JSON.stringify(document, null, 2)}\n`);
+  assert.throws(() => writeNativeCase(path, document), /stale reuse/);
+});

--- a/.github/scripts/ci-lane-selection.mjs
+++ b/.github/scripts/ci-lane-selection.mjs
@@ -1,0 +1,432 @@
+// ci-lane-selection.mjs — derive a total, fail-closed merge-lane selection
+// from the exact projected checkout. No changed path, tree identity, lane
+// roster, or selector conclusion is accepted from the caller.
+//
+// Required environment:
+//   CI_LANE_BASE_SHA          target-base commit for the projected change.
+//   CI_LANE_HEAD_SHA          exact projected commit checked out at HEAD.
+//   CI_LANE_SELECTION_OUTPUT  new manifest path (must not already exist).
+//   GITHUB_RUN_ID             qualification workflow run id.
+//   GITHUB_RUN_ATTEMPT        positive qualification attempt number.
+//
+// Optional environment:
+//   CI_LANE_REGISTRY          registry path (default .github/ci-lanes.json).
+//   GITHUB_OUTPUT             Actions step-output destination.
+//
+// Unknown paths, an empty diff, an unavailable merge base/diff, or a filename
+// that cannot enter the canonical manifest select every conditional lane.
+// Registry, checkout, run-identity, validation, and output-write failures are
+// hard failures because no trustworthy full roster can be emitted without
+// them. Node builtins only.
+
+import { createHash } from "node:crypto";
+import {
+  existsSync,
+  linkSync,
+  statSync,
+  unlinkSync,
+  writeFileSync,
+} from "node:fs";
+import { dirname, resolve } from "node:path";
+import process from "node:process";
+import { TextDecoder } from "node:util";
+import { fileURLToPath } from "node:url";
+
+import {
+  ContractError,
+  DEFAULT_REGISTRY_PATH,
+  deriveQualificationCorrelationNonce,
+  loadRegistry,
+  matchesGlob,
+  validateChangedPaths,
+  validateSelection,
+} from "./ci-lane-contract.mjs";
+import { capture, error, notice, setOutput, warning } from "./lib/gh.mjs";
+
+export const FALLBACK_REASONS = Object.freeze([
+  "none",
+  "empty_diff",
+  "unknown_paths",
+  "merge_base_unavailable",
+  "diff_unavailable",
+  "unrepresentable_path",
+]);
+
+const shaPattern = /^(?:[0-9a-f]{40}|[0-9a-f]{64})$/;
+const runIDPattern = /^[1-9][0-9]*$/;
+const decoder = new TextDecoder("utf-8", { fatal: true });
+
+function requirePattern(value, pattern, name) {
+  const text = String(value ?? "").trim();
+  if (!pattern.test(text)) {
+    throw new ContractError("CI lane selector", [
+      `${name} has invalid value ${JSON.stringify(text)}`,
+    ]);
+  }
+  return text;
+}
+
+export function parseRunAttempt(value) {
+  const text = requirePattern(value, runIDPattern, "GITHUB_RUN_ATTEMPT");
+  const attempt = Number(text);
+  if (!Number.isSafeInteger(attempt)) {
+    throw new ContractError("CI lane selector", [
+      `GITHUB_RUN_ATTEMPT exceeds JavaScript's safe integer range: ${text}`,
+    ]);
+  }
+  return attempt;
+}
+
+function gitText(root, args) {
+  return capture("git", args, { cwd: root });
+}
+
+export function checkoutEvidence({ root, headSHA }) {
+  const expected = requirePattern(headSHA, shaPattern, "CI_LANE_HEAD_SHA");
+  const top = gitText(root, ["rev-parse", "--show-toplevel"]);
+  if (top.status !== 0 || resolve(top.stdout.trim()) !== resolve(root)) {
+    throw new ContractError("CI lane selector", [
+      "selector must run from the repository root",
+    ]);
+  }
+
+  const actual = gitText(root, ["rev-parse", "--verify", "HEAD^{commit}"]);
+  if (actual.status !== 0 || actual.stdout.trim() !== expected) {
+    throw new ContractError("CI lane selector", [
+      `checkout HEAD is ${JSON.stringify(actual.stdout.trim())}, want ${expected}`,
+    ]);
+  }
+  const status = gitText(root, [
+    "status",
+    "--porcelain=v1",
+    "--untracked-files=all",
+  ]);
+  if (status.status !== 0) {
+    throw new ContractError("CI lane selector", [
+      `git status failed: ${status.stderr.trim()}`,
+    ]);
+  }
+  if (status.stdout !== "") {
+    throw new ContractError("CI lane selector", [
+      "projected checkout is not clean before selection",
+    ]);
+  }
+
+  const tree = gitText(root, ["rev-parse", "--verify", `${expected}^{tree}`]);
+  const treeSHA = tree.stdout.trim();
+  if (tree.status !== 0 || !shaPattern.test(treeSHA)) {
+    throw new ContractError("CI lane selector", [
+      `cannot derive the projected tree: ${tree.stderr.trim() || treeSHA}`,
+    ]);
+  }
+  return Object.freeze({ sha: expected, tree: treeSHA });
+}
+
+function fallback(reason, detail) {
+  return Object.freeze({ changedPaths: [], reason, detail });
+}
+
+export function deriveChangedPaths({ root, baseSHA, headSHA }) {
+  const base = requirePattern(baseSHA, shaPattern, "CI_LANE_BASE_SHA");
+  const head = requirePattern(headSHA, shaPattern, "CI_LANE_HEAD_SHA");
+  const mergeBase = gitText(root, ["merge-base", base, head]);
+  const mergeBaseSHA = mergeBase.stdout.trim();
+  if (mergeBase.status !== 0 || !shaPattern.test(mergeBaseSHA)) {
+    return fallback(
+      "merge_base_unavailable",
+      mergeBase.stderr.trim() || "git merge-base returned no commit",
+    );
+  }
+
+  const diff = capture(
+    "git",
+    [
+      "diff",
+      "--no-ext-diff",
+      "--no-textconv",
+      "--no-renames",
+      "--name-only",
+      "-z",
+      mergeBaseSHA,
+      head,
+      "--",
+    ],
+    { cwd: root, encoding: null },
+  );
+  if (diff.status !== 0) {
+    return fallback(
+      "diff_unavailable",
+      String(diff.stderr).trim() || "git diff failed",
+    );
+  }
+
+  let decoded;
+  try {
+    decoded = decoder.decode(diff.stdout);
+  } catch (decodeError) {
+    return fallback("unrepresentable_path", decodeError.message);
+  }
+  if (decoded !== "" && !decoded.endsWith("\0")) {
+    return fallback(
+      "diff_unavailable",
+      "NUL-delimited git diff did not end at a path boundary",
+    );
+  }
+  const changedPaths = [
+    ...new Set(decoded.split("\0").filter((path) => path !== "")),
+  ].sort();
+  const problems = [];
+  validateChangedPaths(changedPaths, "derived changed paths", problems);
+  if (problems.length > 0) {
+    return fallback("unrepresentable_path", problems.join("; "));
+  }
+  if (changedPaths.length === 0) {
+    return fallback("empty_diff", "projected diff contains no paths");
+  }
+  return Object.freeze({ changedPaths, reason: "none", detail: "" });
+}
+
+function matchesAny(path, globs) {
+  return globs.some((glob) => matchesGlob(path, glob));
+}
+
+export function selectionPolicy(registry, changedPaths, fallbackReason = "none") {
+  if (!FALLBACK_REASONS.includes(fallbackReason)) {
+    throw new ContractError("CI lane selector", [
+      `unsupported fallback reason ${JSON.stringify(fallbackReason)}`,
+    ]);
+  }
+  const paths = [...changedPaths];
+  const conditional = registry.lanes.filter(
+    (lane) =>
+      lane.merge_posture === "impact" ||
+      lane.merge_posture === "non_documentation",
+  );
+  const knownNonimpactGlobs =
+    registry.impact_selection?.known_nonimpact_globs ?? [];
+  const unknownPaths = paths.filter(
+    (path) =>
+      !conditional.some((lane) => matchesAny(path, lane.package_globs)) &&
+      !matchesAny(path, knownNonimpactGlobs),
+  );
+  let reason = fallbackReason;
+  if (reason === "none" && paths.length === 0) reason = "empty_diff";
+  if (reason === "none" && unknownPaths.length > 0)
+    reason = "unknown_paths";
+  const fallbackFull = reason !== "none";
+  const docsOnly =
+    paths.length > 0 &&
+    paths.every((path) => matchesAny(path, knownNonimpactGlobs));
+
+  const lanes = [...registry.lanes]
+    .sort((left, right) => left.id.localeCompare(right.id))
+    .map((lane) => {
+      const selected = () => ({
+        lane_id: lane.id,
+        disposition: "selected",
+        executions: [...lane.executions],
+        reason: null,
+      });
+      const omitted = (omissionReason) => ({
+        lane_id: lane.id,
+        disposition: "omitted",
+        executions: [],
+        reason: omissionReason,
+      });
+      if (lane.merge_posture === "always") return selected();
+      if (lane.merge_posture === "never")
+        return omitted("posture_excluded");
+      if (fallbackFull) return selected();
+
+      const directHit = paths.some((path) =>
+        matchesAny(path, lane.package_globs),
+      );
+      if (lane.merge_posture === "impact") {
+        if (directHit) return selected();
+        return omitted(docsOnly ? "docs_only" : "not_impacted");
+      }
+      if (lane.merge_posture === "non_documentation") {
+        if (directHit || !docsOnly) return selected();
+        return omitted("docs_only");
+      }
+      throw new ContractError("CI lane selector", [
+        `lane ${lane.id} has unsupported merge posture ${JSON.stringify(lane.merge_posture)}`,
+      ]);
+    });
+
+  return Object.freeze({
+    conclusion: fallbackFull ? "fallback_full" : "success",
+    fallbackReason: reason,
+    changedPaths: paths,
+    unknownPaths,
+    lanes,
+  });
+}
+
+export function createSelection({
+  registry,
+  baseSHA,
+  source,
+  runID,
+  runAttempt,
+  changedPaths,
+  fallbackReason = "none",
+  correlationNonce,
+}) {
+  const base = requirePattern(baseSHA, shaPattern, "CI_LANE_BASE_SHA");
+  const id = requirePattern(runID, runIDPattern, "GITHUB_RUN_ID");
+  const attempt =
+    typeof runAttempt === "number" ? runAttempt : parseRunAttempt(runAttempt);
+  if (!Number.isSafeInteger(attempt) || attempt < 1) {
+    throw new ContractError("CI lane selector", [
+      `GITHUB_RUN_ATTEMPT must be a positive safe integer; got ${JSON.stringify(runAttempt)}`,
+    ]);
+  }
+  const policy = selectionPolicy(registry, changedPaths, fallbackReason);
+  const qualificationNonce =
+    correlationNonce ??
+    deriveQualificationCorrelationNonce({ posture: "merge", source });
+  const document = {
+    schema_version: registry.selection_schema_version,
+    registry_schema_version: registry.schema_version,
+    report_schema_version: registry.report_schema_version,
+    posture: "merge",
+    source: { sha: source.sha, tree: source.tree },
+    candidate_digest: null,
+    correlation_nonce: qualificationNonce,
+    run: { id, attempt },
+    selector: {
+      conclusion: policy.conclusion,
+      base_sha: base,
+      head_sha: source.sha,
+      changed_paths: [...policy.changedPaths],
+      unknown_paths: [...policy.unknownPaths],
+    },
+    lanes: policy.lanes,
+  };
+  validateSelection(document, registry, {
+    posture: "merge",
+    sha: source.sha,
+    tree: source.tree,
+    correlationNonce: qualificationNonce,
+    runID: id,
+    runAttempt: attempt,
+    baseSHA: base,
+    changedPaths: policy.changedPaths,
+  });
+  return Object.freeze({ document, fallbackReason: policy.fallbackReason });
+}
+
+export function writeSelection(path, document) {
+  const output = resolve(path);
+  const parent = dirname(output);
+  if (!existsSync(parent) || !statSync(parent).isDirectory()) {
+    throw new ContractError("CI lane selector", [
+      `selection output directory does not exist: ${parent}`,
+    ]);
+  }
+  if (existsSync(output)) {
+    throw new ContractError("CI lane selector", [
+      `selection output already exists; refusing stale reuse: ${output}`,
+    ]);
+  }
+  const body = `${JSON.stringify(document, null, 2)}\n`;
+  const temporary = `${output}.${process.pid}.tmp`;
+  try {
+    writeFileSync(temporary, body, { encoding: "utf8", flag: "wx" });
+    linkSync(temporary, output);
+  } finally {
+    if (existsSync(temporary)) unlinkSync(temporary);
+  }
+  return Object.freeze({
+    path: output,
+    sha256: createHash("sha256").update(body).digest("hex"),
+    body,
+  });
+}
+
+function main(env = process.env) {
+  const root = resolve(process.cwd());
+  const baseSHA = requirePattern(
+    env.CI_LANE_BASE_SHA,
+    shaPattern,
+    "CI_LANE_BASE_SHA",
+  );
+  const headSHA = requirePattern(
+    env.CI_LANE_HEAD_SHA,
+    shaPattern,
+    "CI_LANE_HEAD_SHA",
+  );
+  const output = String(env.CI_LANE_SELECTION_OUTPUT ?? "").trim();
+  if (output === "") {
+    throw new ContractError("CI lane selector", [
+      "CI_LANE_SELECTION_OUTPUT is required",
+    ]);
+  }
+  const runID = requirePattern(env.GITHUB_RUN_ID, runIDPattern, "GITHUB_RUN_ID");
+  const runAttempt = parseRunAttempt(env.GITHUB_RUN_ATTEMPT);
+  const registry = loadRegistry(
+    env.CI_LANE_REGISTRY || DEFAULT_REGISTRY_PATH,
+    { root },
+  );
+  const source = checkoutEvidence({ root, headSHA });
+  const diff = deriveChangedPaths({ root, baseSHA, headSHA });
+  if (diff.reason !== "none") {
+    warning(
+      `CI lane selector is running the full conditional fence (${diff.reason}): ${diff.detail}`,
+      { title: "merge-fence selector fallback" },
+    );
+  }
+  const selection = createSelection({
+    registry,
+    baseSHA,
+    source,
+    runID,
+    runAttempt,
+    changedPaths: diff.changedPaths,
+    fallbackReason: diff.reason,
+  });
+  const written = writeSelection(output, selection.document);
+  const selected = selection.document.lanes.filter(
+    (lane) => lane.disposition === "selected",
+  );
+  const executions = selected.flatMap((lane) =>
+    lane.executions.map((executionID) => ({
+      lane_id: lane.lane_id,
+      execution_id: executionID,
+    })),
+  );
+  for (const [name, value] of [
+    ["selection_path", written.path],
+    ["selection_sha256", written.sha256],
+    ["source_sha", source.sha],
+    ["source_tree", source.tree],
+    ["correlation_nonce", selection.document.correlation_nonce],
+    ["base_sha", baseSHA],
+    ["changed_paths_json", JSON.stringify(selection.document.selector.changed_paths)],
+    ["unknown_paths_json", JSON.stringify(selection.document.selector.unknown_paths)],
+    ["selector_conclusion", selection.document.selector.conclusion],
+    ["selected_lane_ids_json", JSON.stringify(selected.map((lane) => lane.lane_id))],
+    ["selected_executions_json", JSON.stringify(executions)],
+    ["fallback_reason", selection.fallbackReason],
+  ]) {
+    setOutput(name, value);
+  }
+  notice(
+    `merge-fence selector chose ${executions.length} execution(s) across ${selected.length} lane(s); ` +
+      `conclusion=${selection.document.selector.conclusion}`,
+  );
+}
+
+const invokedDirectly =
+  process.argv[1] && fileURLToPath(import.meta.url) === resolve(process.argv[1]);
+if (invokedDirectly) {
+  try {
+    main();
+  } catch (selectionError) {
+    error(selectionError instanceof Error ? selectionError.message : String(selectionError), {
+      title: "merge-fence selector failed closed",
+    });
+    process.exit(1);
+  }
+}

--- a/.github/scripts/ci-lane-selection.test.mjs
+++ b/.github/scripts/ci-lane-selection.test.mjs
@@ -1,0 +1,296 @@
+// Negative controls for the merge-fence selector. These tests pin both safety
+// directions: uncertainty cannot omit work, and a successful precise routing
+// decision cannot silently keep unrelated expensive lanes selected.
+
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import {
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+
+import {
+  ContractError,
+  matchesGlob,
+  validateSelection,
+} from "./ci-lane-contract.mjs";
+import {
+  checkoutEvidence,
+  createSelection,
+  deriveChangedPaths,
+  parseRunAttempt,
+  selectionPolicy,
+  writeSelection,
+} from "./ci-lane-selection.mjs";
+
+const sha = (character) => character.repeat(40);
+
+function lane(id, mergePosture, packageGlobs) {
+  return {
+    id,
+    executions: ["default"],
+    package_globs: packageGlobs,
+    merge_posture: mergePosture,
+    main_posture: "always",
+    release_posture: "advisory",
+    applicability: { source: true, artifact: false },
+  };
+}
+
+function registryFixture() {
+  return {
+    schema_version: 1,
+    selection_schema_version: 1,
+    report_schema_version: 1,
+    impact_selection: {
+      known_nonimpact_globs: ["**/*.md", "docs/**"],
+    },
+    lanes: [
+      lane("always", "always", ["internal/**"]),
+      lane("impact-a", "impact", ["internal/a/**"]),
+      lane("impact-b", "impact", ["internal/b/**"]),
+      lane("never", "never", ["release/**"]),
+      lane("quickstart", "non_documentation", ["README.md", "runtime/**"]),
+    ],
+  };
+}
+
+function selectedIDs(policy) {
+  return policy.lanes
+    .filter((laneSelection) => laneSelection.disposition === "selected")
+    .map((laneSelection) => laneSelection.lane_id);
+}
+
+function laneSelection(policy, id) {
+  return policy.lanes.find((candidate) => candidate.lane_id === id);
+}
+
+function selection(changedPaths, fallbackReason = "none") {
+  return createSelection({
+    registry: registryFixture(),
+    baseSHA: sha("a"),
+    source: { sha: sha("b"), tree: sha("c") },
+    runID: "123",
+    runAttempt: 2,
+    changedPaths,
+    fallbackReason,
+  });
+}
+
+test("documentation-only changes omit conditional work with exact reasons", () => {
+  const result = selection(["docs/engine.md"]);
+  assert.equal(result.document.selector.conclusion, "success");
+  assert.deepEqual(selectedIDs(result.document), ["always"]);
+  for (const id of ["impact-a", "impact-b", "quickstart"]) {
+    assert.deepEqual(laneSelection(result.document, id), {
+      lane_id: id,
+      disposition: "omitted",
+      executions: [],
+      reason: "docs_only",
+    });
+  }
+});
+
+test("a direct README contract hit selects quickstart despite Markdown", () => {
+  const result = selection(["README.md"]);
+  assert.deepEqual(selectedIDs(result.document), ["always", "quickstart"]);
+  assert.equal(laneSelection(result.document, "impact-a").reason, "docs_only");
+});
+
+test("one code impact selects exactly its lane plus non-documentation", () => {
+  const result = selection(["internal/a/change.go"]);
+  assert.deepEqual(selectedIDs(result.document), [
+    "always",
+    "impact-a",
+    "quickstart",
+  ]);
+  assert.equal(laneSelection(result.document, "impact-b").reason, "not_impacted");
+  assert.equal(laneSelection(result.document, "never").reason, "posture_excluded");
+});
+
+test("overlapping globs select every direct owner", () => {
+  const registry = registryFixture();
+  registry.lanes[2].package_globs.push("internal/a/shared/**");
+  const result = selectionPolicy(registry, ["internal/a/shared/change.go"]);
+  assert.deepEqual(selectedIDs(result), [
+    "always",
+    "impact-a",
+    "impact-b",
+    "quickstart",
+  ]);
+});
+
+test("mixed documentation and code never manufactures docs-only omissions", () => {
+  const result = selection(["docs/engine.md", "internal/a/change.go"]);
+  assert.equal(laneSelection(result.document, "impact-b").reason, "not_impacted");
+  assert.equal(laneSelection(result.document, "quickstart").disposition, "selected");
+});
+
+test("unknown and empty path sets select every conditional lane", () => {
+  const unknown = selection(["new-surface/runtime.cfg"]);
+  assert.equal(unknown.document.selector.conclusion, "fallback_full");
+  assert.deepEqual(unknown.document.selector.unknown_paths, [
+    "new-surface/runtime.cfg",
+  ]);
+  assert.deepEqual(selectedIDs(unknown.document), [
+    "always",
+    "impact-a",
+    "impact-b",
+    "quickstart",
+  ]);
+
+  const empty = selection([]);
+  assert.equal(empty.document.selector.conclusion, "fallback_full");
+  assert.equal(empty.fallbackReason, "empty_diff");
+  assert.deepEqual(selectedIDs(empty.document), selectedIDs(unknown.document));
+  assert.equal(laneSelection(empty.document, "never").disposition, "omitted");
+});
+
+test("explicit diff failures select full conditional work but preserve never", () => {
+  for (const reason of [
+    "merge_base_unavailable",
+    "diff_unavailable",
+    "unrepresentable_path",
+  ]) {
+    const result = selection([], reason);
+    assert.equal(result.document.selector.conclusion, "fallback_full", reason);
+    assert.deepEqual(selectedIDs(result.document), [
+      "always",
+      "impact-a",
+      "impact-b",
+      "quickstart",
+    ]);
+    assert.equal(laneSelection(result.document, "never").reason, "posture_excluded");
+  }
+});
+
+test("contract rejects both missing work and extra unimpacted work", () => {
+  const { document } = selection(["internal/a/change.go"]);
+  const missing = structuredClone(document);
+  Object.assign(laneSelection(missing, "impact-a"), {
+    disposition: "omitted",
+    executions: [],
+    reason: "not_impacted",
+  });
+  assert.throws(
+    () => validateSelection(missing, registryFixture()),
+    /must select impacted lane impact-a/,
+  );
+
+  const extra = structuredClone(document);
+  Object.assign(laneSelection(extra, "impact-b"), {
+    disposition: "selected",
+    executions: ["default"],
+    reason: null,
+  });
+  assert.throws(
+    () => validateSelection(extra, registryFixture()),
+    /must omit unimpacted lane impact-b/,
+  );
+
+  const noQuickstart = structuredClone(document);
+  Object.assign(laneSelection(noQuickstart, "quickstart"), {
+    disposition: "omitted",
+    executions: [],
+    reason: "docs_only",
+  });
+  assert.throws(
+    () => validateSelection(noQuickstart, registryFixture()),
+    /must select non-documentation lane quickstart/,
+  );
+});
+
+test("glob matcher stays anchored with explicit star semantics", () => {
+  assert.equal(matchesGlob("README.md", "**/*.md"), true);
+  assert.equal(matchesGlob("docs/deep/file.md", "docs/**"), true);
+  assert.equal(matchesGlob("internal/a/x.go", "internal/*/*.go"), true);
+  assert.equal(matchesGlob("internal/a/deep/x.go", "internal/*/*.go"), false);
+  assert.equal(matchesGlob("nested/Dockerfile.local", "Dockerfile*"), false);
+  assert.equal(matchesGlob("Dockerfile.local", "Dockerfile*"), true);
+});
+
+test("manifest writer is canonical, atomic, and refuses stale reuse", (t) => {
+  const root = mkdtempSync(join(tmpdir(), "ci-lane-selection-write-"));
+  t.after(() => rmSync(root, { recursive: true, force: true }));
+  const path = join(root, "selection.json");
+  const document = selection(["internal/a/change.go"]).document;
+  const written = writeSelection(path, document);
+  assert.equal(written.body, `${JSON.stringify(document, null, 2)}\n`);
+  assert.equal(readFileSync(path, "utf8"), written.body);
+  assert.match(written.sha256, /^[0-9a-f]{64}$/);
+  assert.throws(() => writeSelection(path, document), /refusing stale reuse/);
+});
+
+function git(root, args) {
+  return execFileSync("git", args, { cwd: root, encoding: "utf8" }).trim();
+}
+
+function commit(root, message) {
+  git(root, ["add", "--all"]);
+  git(root, ["commit", "-m", message]);
+  return git(root, ["rev-parse", "HEAD"]);
+}
+
+test("git-derived evidence sees additions, deletions, and both rename paths", (t) => {
+  const root = mkdtempSync(join(tmpdir(), "ci-lane-selection-git-"));
+  t.after(() => rmSync(root, { recursive: true, force: true }));
+  git(root, ["init", "--quiet"]);
+  git(root, ["config", "user.name", "CI Test"]);
+  git(root, ["config", "user.email", "ci@example.invalid"]);
+  writeFileSync(join(root, "old.go"), "package old\n");
+  writeFileSync(join(root, "delete.go"), "package deleted\n");
+  const base = commit(root, "base");
+
+  git(root, ["mv", "old.go", "new.go"]);
+  rmSync(join(root, "delete.go"));
+  writeFileSync(join(root, "added.go"), "package added\n");
+  const head = commit(root, "change");
+  const diff = deriveChangedPaths({ root, baseSHA: base, headSHA: head });
+  assert.equal(diff.reason, "none");
+  assert.deepEqual(diff.changedPaths, [
+    "added.go",
+    "delete.go",
+    "new.go",
+    "old.go",
+  ]);
+
+  assert.deepEqual(checkoutEvidence({ root, headSHA: head }), {
+    sha: head,
+    tree: git(root, ["rev-parse", "HEAD^{tree}"]),
+  });
+  writeFileSync(join(root, "dirty.txt"), "dirty\n");
+  assert.throws(
+    () => checkoutEvidence({ root, headSHA: head }),
+    /checkout is not clean/,
+  );
+});
+
+test("unavailable and empty git diffs become explicit full fallbacks", (t) => {
+  const root = mkdtempSync(join(tmpdir(), "ci-lane-selection-fallback-"));
+  t.after(() => rmSync(root, { recursive: true, force: true }));
+  git(root, ["init", "--quiet"]);
+  git(root, ["config", "user.name", "CI Test"]);
+  git(root, ["config", "user.email", "ci@example.invalid"]);
+  writeFileSync(join(root, "one.txt"), "one\n");
+  const head = commit(root, "one");
+  assert.equal(
+    deriveChangedPaths({ root, baseSHA: head, headSHA: head }).reason,
+    "empty_diff",
+  );
+  assert.equal(
+    deriveChangedPaths({ root, baseSHA: sha("f"), headSHA: head }).reason,
+    "merge_base_unavailable",
+  );
+});
+
+test("run identity is canonical and positive", () => {
+  assert.equal(parseRunAttempt("1"), 1);
+  for (const value of [undefined, "", "0", "01", "-1", "1.5", "word"]) {
+    assert.throws(() => parseRunAttempt(value), ContractError);
+  }
+});

--- a/.github/scripts/ci-lane-shadow-collector.mjs
+++ b/.github/scripts/ci-lane-shadow-collector.mjs
@@ -1,0 +1,1295 @@
+// ci-lane-shadow-collector.mjs — observe the native Actions checks associated
+// with one validated merge-lane selection without presenting those observations
+// as native test reports.
+//
+// The collector deliberately discovers independent workflow runs. A pull
+// request workflow run is bound to the event's repository, event kind, pull
+// request number, PR head SHA, and PR base SHA. Its Actions REST `head_sha` is
+// the PR head, while the selection source may be GitHub's projected merge SHA.
+// A merge-group run is bound to the queue event's repository, head SHA, and
+// queue ref; the selection binds the event's base SHA and projected head SHA.
+//
+// Required environment:
+//   CI_LANE_SELECTION       validated selection manifest path.
+//   CI_LANE_SHADOW_OUTPUT   new observation manifest path; stale reuse fails.
+//   GITHUB_EVENT_PATH       trusted runner event payload path.
+//   GITHUB_EVENT_NAME       pull_request or merge_group.
+//   GITHUB_REPOSITORY       trusted runner repository (`owner/name`).
+//   GITHUB_SHA              projected checkout SHA selected by the fence.
+//   GITHUB_RUN_ID           selector/collector workflow run ID.
+//   GITHUB_RUN_ATTEMPT      selector/collector workflow attempt.
+//   GITHUB_TOKEN            token with Actions read access.
+//
+// Optional environment:
+//   CI_LANE_REGISTRY                 registry path (default .github/ci-lanes.json).
+//   CI_LANE_SHADOW_POLL_SECONDS      poll interval (default 15).
+//   CI_LANE_SHADOW_TIMEOUT_SECONDS   observation deadline (default 1200).
+//   GITHUB_API_URL                   API origin (default https://api.github.com).
+//   GITHUB_OUTPUT                    Actions step-output destination.
+//
+// The main program polls because independently triggered workflows need not
+// start or finish in the selector workflow's scheduling order. Tests inject an
+// HTTP function and never access the network. Node builtins only.
+
+import { spawnSync } from "node:child_process";
+import { createHash } from "node:crypto";
+import {
+  existsSync,
+  linkSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  statSync,
+  unlinkSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import process from "node:process";
+import { fileURLToPath } from "node:url";
+
+import {
+  ContractError,
+  DEFAULT_REGISTRY_PATH,
+  loadRegistry,
+  nativeArtifactName,
+  selectionManifestSHA256,
+  validateReportSet,
+  validateSelection,
+} from "./ci-lane-contract.mjs";
+import {
+  nativeBundleEntries,
+  validateNativeBundle,
+} from "./ci-lane-native-evidence.mjs";
+import { error, notice, setOutput, warning } from "./lib/gh.mjs";
+
+export const SHADOW_OBSERVATION_SCHEMA_VERSION = 1;
+
+const DEFAULT_API_URL = "https://api.github.com";
+const DEFAULT_POLL_SECONDS = 15;
+const DEFAULT_TIMEOUT_SECONDS = 20 * 60;
+const MAX_PER_PAGE = 100;
+const MAX_NATIVE_ARCHIVE_BYTES = 2 * 1024 * 1024;
+const MAX_NATIVE_ENTRY_BYTES = 1024 * 1024;
+const SHA_PATTERN = /^(?:[0-9a-f]{40}|[0-9a-f]{64})$/;
+const REPOSITORY_PATTERN = /^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/;
+const POSITIVE_INTEGER_PATTERN = /^[1-9][0-9]*$/;
+const API_TIMESTAMP_PATTERN =
+  /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d{1,3})?Z$/;
+const FAILURE_CONCLUSIONS = new Set([
+  "action_required",
+  "failure",
+  "stale",
+  "startup_failure",
+]);
+
+function contract(label, problem) {
+  throw new ContractError(label, [problem]);
+}
+
+function isObject(value) {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function requiredString(value, path, { pattern } = {}) {
+  if (typeof value !== "string" || value.trim() === "") {
+    contract("CI lane shadow collector", `${path} must be a non-empty string`);
+  }
+  if (pattern && !pattern.test(value)) {
+    contract(
+      "CI lane shadow collector",
+      `${path} has invalid value ${JSON.stringify(value)}`,
+    );
+  }
+  return value;
+}
+
+function positiveInteger(value, path) {
+  const text =
+    typeof value === "number" && Number.isSafeInteger(value)
+      ? String(value)
+      : typeof value === "string"
+        ? value
+        : "";
+  if (!POSITIVE_INTEGER_PATTERN.test(text)) {
+    contract(
+      "CI lane shadow collector",
+      `${path} must be a positive safe integer`,
+    );
+  }
+  const number = Number(text);
+  if (!Number.isSafeInteger(number)) {
+    contract(
+      "CI lane shadow collector",
+      `${path} exceeds JavaScript's safe integer range`,
+    );
+  }
+  return number;
+}
+
+function nonnegativeInteger(value, path) {
+  if (typeof value !== "number" || !Number.isSafeInteger(value) || value < 0) {
+    contract(
+      "CI lane shadow collector",
+      `${path} must be a non-negative safe integer`,
+    );
+  }
+  return value;
+}
+
+function positiveID(value, path) {
+  const number = positiveInteger(value, path);
+  return String(number);
+}
+
+function nullableConclusion(value, path) {
+  if (value === null) return null;
+  return requiredString(value, path);
+}
+
+function apiTimestamp(value, path, { nullable = false } = {}) {
+  if (value === null && nullable) return null;
+  const timestamp = requiredString(value, path, {
+    pattern: API_TIMESTAMP_PATTERN,
+  });
+  if (!Number.isFinite(Date.parse(timestamp))) {
+    contract(
+      "CI lane shadow collector",
+      `${path} is not a real UTC timestamp`,
+    );
+  }
+  return timestamp;
+}
+
+function timestampMillis(value, path) {
+  const timestamp = apiTimestamp(value, path);
+  return Date.parse(timestamp);
+}
+
+function normalizedRef(value) {
+  const ref = requiredString(value, "event ref");
+  return ref.startsWith("refs/heads/") ? ref.slice("refs/heads/".length) : ref;
+}
+
+function parseJSONFile(path, label) {
+  try {
+    return JSON.parse(readFileSync(path, "utf8"));
+  } catch (readError) {
+    contract(label, `${path}: ${readError.message}`);
+  }
+}
+
+export function trustedEventIdentity({
+  eventName,
+  repository,
+  projectedSHA,
+  payload,
+}) {
+  const kind = requiredString(eventName, "GITHUB_EVENT_NAME");
+  if (kind !== "pull_request" && kind !== "merge_group") {
+    contract(
+      "CI lane shadow collector",
+      `GITHUB_EVENT_NAME must be pull_request or merge_group; got ${JSON.stringify(kind)}`,
+    );
+  }
+  const trustedRepository = requiredString(
+    repository,
+    "GITHUB_REPOSITORY",
+    { pattern: REPOSITORY_PATTERN },
+  );
+  const projected = requiredString(projectedSHA, "GITHUB_SHA", {
+    pattern: SHA_PATTERN,
+  });
+  if (!isObject(payload)) {
+    contract("CI lane shadow collector", "GITHUB_EVENT_PATH must contain an object");
+  }
+  const payloadRepository = payload.repository?.full_name;
+  if (payloadRepository !== trustedRepository) {
+    contract(
+      "CI lane shadow collector",
+      `event repository is ${JSON.stringify(payloadRepository)}, want ${trustedRepository}`,
+    );
+  }
+
+  if (kind === "pull_request") {
+    const pullRequest = payload.pull_request;
+    if (!isObject(pullRequest)) {
+      contract(
+        "CI lane shadow collector",
+        "pull_request event has no pull_request object",
+      );
+    }
+    const number = positiveInteger(pullRequest.number, "event pull request number");
+    const eventHeadSHA = requiredString(
+      pullRequest.head?.sha,
+      "event pull request head SHA",
+      { pattern: SHA_PATTERN },
+    );
+    const eventBaseSHA = requiredString(
+      pullRequest.base?.sha,
+      "event pull request base SHA",
+      { pattern: SHA_PATTERN },
+    );
+    const headRef = normalizedRef(pullRequest.head?.ref);
+    const baseRef = normalizedRef(pullRequest.base?.ref);
+    if (pullRequest.base?.repo?.full_name !== trustedRepository) {
+      contract(
+        "CI lane shadow collector",
+        "pull request base repository does not match GITHUB_REPOSITORY",
+      );
+    }
+    return Object.freeze({
+      kind,
+      repository: trustedRepository,
+      pr_number: number,
+      event_head_sha: eventHeadSHA,
+      event_base_sha: eventBaseSHA,
+      head_ref: headRef,
+      base_ref: baseRef,
+      projected_sha: projected,
+    });
+  }
+
+  const mergeGroup = payload.merge_group;
+  if (!isObject(mergeGroup)) {
+    contract(
+      "CI lane shadow collector",
+      "merge_group event has no merge_group object",
+    );
+  }
+  const eventHeadSHA = requiredString(
+    mergeGroup.head_sha,
+    "event merge group head SHA",
+    { pattern: SHA_PATTERN },
+  );
+  const eventBaseSHA = requiredString(
+    mergeGroup.base_sha,
+    "event merge group base SHA",
+    { pattern: SHA_PATTERN },
+  );
+  if (projected !== eventHeadSHA) {
+    contract(
+      "CI lane shadow collector",
+      `merge-group projected SHA is ${projected}, want event head ${eventHeadSHA}`,
+    );
+  }
+  return Object.freeze({
+    kind,
+    repository: trustedRepository,
+    pr_number: null,
+    event_head_sha: eventHeadSHA,
+    event_base_sha: eventBaseSHA,
+    head_ref: normalizedRef(mergeGroup.head_ref),
+    base_ref: normalizedRef(mergeGroup.base_ref),
+    projected_sha: projected,
+  });
+}
+
+export function bindSelectionToEvent(
+  selection,
+  registry,
+  identity,
+  { runID, runAttempt } = {},
+) {
+  const expected = {
+    posture: "merge",
+    sha: identity.projected_sha,
+    baseSHA: identity.event_base_sha,
+  };
+  if (runID !== undefined) expected.runID = positiveID(runID, "GITHUB_RUN_ID");
+  if (runAttempt !== undefined) {
+    expected.runAttempt = positiveInteger(
+      runAttempt,
+      "GITHUB_RUN_ATTEMPT",
+    );
+  }
+  validateSelection(selection, registry, expected);
+  if (
+    identity.kind === "merge_group" &&
+    selection.source.sha !== identity.event_head_sha
+  ) {
+    contract(
+      "CI lane shadow collector",
+      "merge-group selection source does not equal the event head SHA",
+    );
+  }
+  return selection;
+}
+
+function repositoryAPIPath(repository) {
+  return repository
+    .split("/")
+    .map((component) => encodeURIComponent(component))
+    .join("/");
+}
+
+function pagedURL(baseURL, pathname, query, page) {
+  const url = new URL(pathname, `${baseURL.replace(/\/$/, "")}/`);
+  for (const [name, value] of Object.entries(query)) {
+    url.searchParams.set(name, String(value));
+  }
+  url.searchParams.set("per_page", String(MAX_PER_PAGE));
+  url.searchParams.set("page", String(page));
+  return url.toString();
+}
+
+async function paginated({ requestJSON, buildURL, field, label }) {
+  const rows = [];
+  for (let page = 1; ; page += 1) {
+    const document = await requestJSON(buildURL(page));
+    if (!isObject(document) || !Array.isArray(document[field])) {
+      contract(
+        "CI lane shadow collector",
+        `${label} response must contain an ${field} array`,
+      );
+    }
+    nonnegativeInteger(document.total_count, `${label}.total_count`);
+    rows.push(...document[field]);
+    if (document[field].length < MAX_PER_PAGE) break;
+  }
+  return rows;
+}
+
+function pullRequestAssociationMatches(association, identity) {
+  if (!isObject(association)) return false;
+  if (
+    !Number.isSafeInteger(association.number) ||
+    association.number !== identity.pr_number
+  ) {
+    return false;
+  }
+  return (
+    association.head?.sha === identity.event_head_sha &&
+    association.base?.sha === identity.event_base_sha &&
+    normalizedCandidateRef(association.head?.ref) === identity.head_ref &&
+    normalizedCandidateRef(association.base?.ref) === identity.base_ref
+  );
+}
+
+function normalizedCandidateRef(value) {
+  if (typeof value !== "string" || value.trim() === "") return null;
+  return value.startsWith("refs/heads/")
+    ? value.slice("refs/heads/".length)
+    : value;
+}
+
+function runMatchesIdentity(run, identity, workflows) {
+  if (!isObject(run)) return false;
+  if (!workflows.has(run.path)) return false;
+  if (run.repository?.full_name !== identity.repository) return false;
+  if (run.event !== identity.kind) return false;
+  if (run.head_sha !== identity.event_head_sha) return false;
+  if (normalizedCandidateRef(run.head_branch) !== identity.head_ref) return false;
+  if (identity.kind === "pull_request") {
+    return (
+      Array.isArray(run.pull_requests) &&
+      run.pull_requests.some((association) =>
+        pullRequestAssociationMatches(association, identity),
+      )
+    );
+  }
+  return true;
+}
+
+function normalizeRun(run) {
+  return {
+    workflow: requiredString(run.path, "workflow run path"),
+    run_id: positiveID(run.id, "workflow run id"),
+    run_attempt: positiveInteger(run.run_attempt, "workflow run attempt"),
+    event: requiredString(run.event, "workflow run event"),
+    head_sha: requiredString(run.head_sha, "workflow run head SHA", {
+      pattern: SHA_PATTERN,
+    }),
+    head_branch: requiredString(run.head_branch, "workflow run head branch"),
+    status: requiredString(run.status, "workflow run status"),
+    conclusion: nullableConclusion(
+      run.conclusion,
+      "workflow run conclusion",
+    ),
+    created_at: apiTimestamp(run.created_at, "workflow run created_at"),
+    updated_at: apiTimestamp(run.updated_at, "workflow run updated_at"),
+  };
+}
+
+function compareIDs(left, right) {
+  const a = BigInt(left);
+  const b = BigInt(right);
+  return a < b ? -1 : a > b ? 1 : 0;
+}
+
+export function newestRunFirst(left, right) {
+  const created =
+    timestampMillis(right.created_at, "workflow run created_at") -
+    timestampMillis(left.created_at, "workflow run created_at");
+  if (created !== 0) return created;
+  const id = compareIDs(right.run_id, left.run_id);
+  if (id !== 0) return id;
+  return right.run_attempt - left.run_attempt;
+}
+
+function canonicalRunOrder(left, right) {
+  const workflow = left.workflow.localeCompare(right.workflow);
+  return workflow === 0 ? newestRunFirst(left, right) : workflow;
+}
+
+export async function discoverWorkflowRuns({
+  registry,
+  identity,
+  requestJSON,
+  apiBase = DEFAULT_API_URL,
+}) {
+  if (typeof requestJSON !== "function") {
+    contract("CI lane shadow collector", "requestJSON must be a function");
+  }
+  const workflows = new Set(registry.lanes.map((lane) => lane.owner.workflow));
+  const repository = repositoryAPIPath(identity.repository);
+  const candidates = await paginated({
+    requestJSON,
+    field: "workflow_runs",
+    label: "workflow runs",
+    buildURL: (page) =>
+      pagedURL(
+        apiBase,
+        `/repos/${repository}/actions/runs`,
+        { event: identity.kind, head_sha: identity.event_head_sha },
+        page,
+      ),
+  });
+
+  const unique = new Map();
+  for (const candidate of candidates) {
+    if (!runMatchesIdentity(candidate, identity, workflows)) continue;
+    const run = normalizeRun(candidate);
+    const key = `${run.run_id}:${run.run_attempt}`;
+    const previous = unique.get(key);
+    if (previous && JSON.stringify(previous) !== JSON.stringify(run)) {
+      contract(
+        "CI lane shadow collector",
+        `workflow run ${key} appeared with conflicting evidence`,
+      );
+    }
+    unique.set(key, run);
+  }
+  return [...unique.values()].sort(canonicalRunOrder);
+}
+
+function normalizeJob(job) {
+  const status = requiredString(job.status, "workflow job status");
+  const startedAt = apiTimestamp(job.started_at, "workflow job started_at", {
+    nullable: status !== "completed",
+  });
+  const completedAt = apiTimestamp(
+    job.completed_at,
+    "workflow job completed_at",
+    { nullable: status !== "completed" },
+  );
+  let duration = null;
+  if (startedAt !== null && completedAt !== null) {
+    duration = Date.parse(completedAt) - Date.parse(startedAt);
+    if (!Number.isSafeInteger(duration) || duration < 0) {
+      contract(
+        "CI lane shadow collector",
+        "workflow job completion precedes its start",
+      );
+    }
+  }
+  return {
+    id: positiveID(job.id, "workflow job id"),
+    name: requiredString(job.name, "workflow job name"),
+    status,
+    conclusion: nullableConclusion(job.conclusion, "workflow job conclusion"),
+    started_at: startedAt,
+    completed_at: completedAt,
+    duration_ms: duration,
+  };
+}
+
+function canonicalJobOrder(left, right) {
+  const id = compareIDs(left.id, right.id);
+  return id === 0 ? left.name.localeCompare(right.name) : id;
+}
+
+async function jobsForRun({ run, identity, requestJSON, apiBase }) {
+  const repository = repositoryAPIPath(identity.repository);
+  const jobs = await paginated({
+    requestJSON,
+    field: "jobs",
+    label: `jobs for run ${run.run_id} attempt ${run.run_attempt}`,
+    buildURL: (page) =>
+      pagedURL(
+        apiBase,
+        `/repos/${repository}/actions/runs/${run.run_id}/attempts/${run.run_attempt}/jobs`,
+        { filter: "all" },
+        page,
+      ),
+  });
+  const unique = new Map();
+  for (const candidate of jobs) {
+    const job = normalizeJob(candidate);
+    if (unique.has(job.id)) {
+      contract(
+        "CI lane shadow collector",
+        `workflow run ${run.run_id} attempt ${run.run_attempt} returned duplicate job id ${job.id}`,
+      );
+    }
+    unique.set(job.id, job);
+  }
+  return [...unique.values()].sort(canonicalJobOrder);
+}
+
+export async function hydrateWorkflowRuns({
+  runs,
+  identity,
+  requestJSON,
+  apiBase = DEFAULT_API_URL,
+}) {
+  const hydrated = await Promise.all(
+    runs.map(async (run) => ({
+      ...run,
+      jobs: await jobsForRun({
+        run,
+        identity,
+        requestJSON,
+        apiBase,
+      }),
+    })),
+  );
+  return hydrated.sort(canonicalRunOrder);
+}
+
+function normalizeArtifact(artifact) {
+  const id = positiveID(artifact?.id, "workflow artifact id");
+  const name = requiredString(artifact?.name, "workflow artifact name");
+  const digest = requiredString(artifact?.digest, "workflow artifact digest", {
+    pattern: /^sha256:[0-9a-f]{64}$/,
+  });
+  if (artifact?.expired !== false) {
+    contract("CI lane shadow collector", `workflow artifact ${name} is expired`);
+  }
+  return {
+    id,
+    name,
+    sha256: digest.slice("sha256:".length),
+    archive_download_url: requiredString(
+      artifact?.archive_download_url,
+      "workflow artifact archive URL",
+    ),
+  };
+}
+
+export function unpackNativeArchive(archive) {
+  if (!Buffer.isBuffer(archive) || archive.length === 0) {
+    contract("CI lane shadow collector", "native artifact archive is empty");
+  }
+  if (archive.length > MAX_NATIVE_ARCHIVE_BYTES) {
+    contract("CI lane shadow collector", "native artifact archive exceeds its size limit");
+  }
+  const directory = mkdtempSync(join(tmpdir(), "ci-native-artifact-"));
+  const archivePath = join(directory, "bundle.zip");
+  try {
+    writeFileSync(archivePath, archive, { flag: "wx" });
+    const listing = spawnSync("unzip", ["-Z1", archivePath], {
+      encoding: "utf8",
+      maxBuffer: MAX_NATIVE_ENTRY_BYTES,
+    });
+    if (listing.status !== 0) {
+      contract("CI lane shadow collector", "native artifact is not a readable ZIP archive");
+    }
+    const entries = listing.stdout.split(/\r?\n/).filter(Boolean);
+    if (
+      entries.length !== 1 ||
+      entries[0] !== "ci-native-evidence.json" ||
+      entries[0].includes("..") ||
+      entries[0].startsWith("/")
+    ) {
+      contract(
+        "CI lane shadow collector",
+        "native artifact must contain only ci-native-evidence.json",
+      );
+    }
+    const extracted = spawnSync("unzip", ["-p", archivePath, entries[0]], {
+      encoding: "utf8",
+      maxBuffer: MAX_NATIVE_ENTRY_BYTES,
+    });
+    if (extracted.status !== 0 || extracted.error) {
+      contract("CI lane shadow collector", "native evidence entry could not be read safely");
+    }
+    try {
+      return JSON.parse(extracted.stdout);
+    } catch (parseError) {
+      contract(
+        "CI lane shadow collector",
+        `native evidence entry is not JSON: ${parseError.message}`,
+      );
+    }
+  } finally {
+    rmSync(directory, { recursive: true, force: true });
+  }
+}
+
+export async function collectNativeBundles({
+  registry,
+  selection,
+  identity,
+  workflowRuns,
+  requestJSON,
+  requestBinary,
+  apiBase = DEFAULT_API_URL,
+}) {
+  const selectedWorkflows = new Set(
+    selection.lanes
+      .filter((item) => item.disposition === "selected")
+      .map(
+        (item) =>
+          registry.lanes.find((lane) => lane.id === item.lane_id).owner.workflow,
+      ),
+  );
+  const newest = new Map();
+  for (const run of [...workflowRuns].sort(canonicalRunOrder)) {
+    if (selectedWorkflows.has(run.workflow) && !newest.has(run.workflow))
+      newest.set(run.workflow, run);
+  }
+  const repository = repositoryAPIPath(identity.repository);
+  const bundles = new Map();
+  for (const workflow of [...selectedWorkflows].sort()) {
+    const run = newest.get(workflow);
+    if (!run) continue;
+    const expectedName = nativeArtifactName(workflow, {
+      id: run.run_id,
+      attempt: run.run_attempt,
+    });
+    const artifacts = await paginated({
+      requestJSON,
+      field: "artifacts",
+      label: `artifacts for run ${run.run_id}`,
+      buildURL: (page) =>
+        pagedURL(
+          apiBase,
+          `/repos/${repository}/actions/runs/${run.run_id}/artifacts`,
+          {},
+          page,
+        ),
+    });
+    const matches = artifacts
+      .map(normalizeArtifact)
+      .filter((artifact) => artifact.name === expectedName);
+    if (matches.length !== 1) continue;
+    const [artifact] = matches;
+    const archive = await requestBinary(artifact.archive_download_url);
+    const archiveSHA = createHash("sha256").update(archive).digest("hex");
+    if (archiveSHA !== artifact.sha256) {
+      contract(
+        "CI lane shadow collector",
+        `${workflow}: downloaded native artifact digest does not match the Actions API`,
+      );
+    }
+    const bundle = validateNativeBundle(unpackNativeArchive(archive), registry, {
+      posture: "merge",
+      workflow,
+      repository: identity.repository,
+      event: identity.kind,
+      runID: run.run_id,
+      runAttempt: run.run_attempt,
+      sha: selection.source.sha,
+      tree: selection.source.tree,
+      correlationNonce: selection.correlation_nonce,
+    });
+    bundles.set(workflow, { run, artifact, bundle });
+  }
+  return bundles;
+}
+
+function contextMatches(context, jobName) {
+  return context.match === "exact"
+    ? jobName === context.name
+    : jobName.startsWith(context.name);
+}
+
+export function jobObservationState(job) {
+  if (job.status !== "completed") {
+    return { state: "pending", reason: "job_not_terminal" };
+  }
+  if (job.conclusion === "success") return { state: "success", reason: null };
+  if (job.conclusion === "skipped") {
+    return { state: "skipped", reason: "job_skipped" };
+  }
+  if (job.conclusion === "neutral") {
+    return { state: "neutral", reason: "job_neutral" };
+  }
+  if (job.conclusion === "cancelled") {
+    return { state: "cancelled", reason: "job_cancelled" };
+  }
+  if (job.conclusion === "timed_out") {
+    return { state: "timed_out", reason: "job_timed_out" };
+  }
+  if (FAILURE_CONCLUSIONS.has(job.conclusion)) {
+    return { state: "red", reason: `job_${job.conclusion}` };
+  }
+  return { state: "red", reason: "unsupported_terminal_conclusion" };
+}
+
+export function createNativeQualification({
+  registry,
+  selection,
+  identity,
+  bundles,
+}) {
+  const selectionRef = {
+    run: { ...selection.run },
+    manifest_sha256: selectionManifestSHA256(selection),
+  };
+  const lanes = new Map(registry.lanes.map((lane) => [lane.id, lane]));
+  const producers = [];
+  const reports = [];
+  for (const [workflow, native] of [...bundles.entries()].sort(([left], [right]) =>
+    left.localeCompare(right),
+  )) {
+    const jobs = [];
+    const seenJobs = new Set();
+    for (const entry of native.bundle.lanes) {
+      const lane = lanes.get(entry.lane_id);
+      const matches = native.run.jobs.filter((job) =>
+        contextMatches(lane.context, job.name),
+      );
+      if (matches.length !== 1) continue;
+      const job = matches[0];
+      const key = `${lane.owner.context_job}/${job.id}`;
+      if (seenJobs.has(key)) continue;
+      seenJobs.add(key);
+      jobs.push({
+        job: lane.owner.context_job,
+        name: job.name,
+        database_id: job.id,
+        conclusion: job.conclusion,
+      });
+    }
+    const entries = nativeBundleEntries(native.bundle);
+    producers.push({
+      workflow,
+      run: { id: native.run.run_id, attempt: native.run.run_attempt },
+      source: { ...native.bundle.source },
+      correlation_nonce: native.bundle.correlation_nonce,
+      event: {
+        kind: identity.kind,
+        pr_number: identity.pr_number,
+        event_head_sha: identity.event_head_sha,
+        event_base_sha: identity.event_base_sha,
+        projected_sha: identity.projected_sha,
+      },
+      repository: identity.repository,
+      conclusion: native.run.conclusion,
+      jobs,
+      artifacts: [
+        {
+          id: native.artifact.id,
+          name: native.artifact.name,
+          sha256: native.artifact.sha256,
+          entries,
+        },
+      ],
+    });
+
+    for (const selected of selection.lanes.filter(
+      (item) =>
+        item.disposition === "selected" &&
+        lanes.get(item.lane_id).owner.workflow === workflow,
+    )) {
+      const lane = lanes.get(selected.lane_id);
+      for (const executionID of selected.executions) {
+        const entry = native.bundle.lanes.find(
+          (candidate) =>
+            candidate.lane_id === lane.id &&
+            candidate.execution_id === executionID,
+        );
+        if (!entry) continue;
+        const entryDigest = entries.find(
+          (candidate) =>
+            candidate.lane_id === lane.id &&
+            candidate.execution_id === executionID,
+        ).sha256;
+        const context = native.run.jobs.filter((job) =>
+          contextMatches(lane.context, job.name),
+        );
+        const duration = context.length === 1 ? context[0].duration_ms ?? 0 : 0;
+        reports.push({
+          schema_version: registry.report_schema_version,
+          registry_schema_version: registry.schema_version,
+          lane_id: lane.id,
+          execution_id: executionID,
+          posture: selection.posture,
+          source: { ...selection.source },
+          candidate_digest: null,
+          correlation_nonce: selection.correlation_nonce,
+          selection_ref: selectionRef,
+          producer: {
+            workflow,
+            job: lane.owner.context_job,
+            run: { id: native.run.run_id, attempt: native.run.run_attempt },
+            artifact: {
+              id: native.artifact.id,
+              name: native.artifact.name,
+              sha256: native.artifact.sha256,
+              entry: `${lane.id}/${executionID}`,
+              entry_sha256: entryDigest,
+            },
+          },
+          invocation: {
+            mode: "source_tree",
+            recipe: lane.recipes[0] ?? null,
+            command: lane.command,
+            build_tags: [...lane.build_tags],
+            selected_domains: [...lane.risk_domains],
+          },
+          evidence: {
+            ...entry.evidence,
+            duration_ms: duration,
+            seed: lane.determinism === "seeded" ? selection.source.tree : null,
+            corpus_id: `${lane.id}/${executionID}`,
+          },
+          conclusion: entry.conclusion,
+        });
+      }
+    }
+  }
+  const producerManifest = {
+    schema_version: registry.report_schema_version,
+    correlation_nonce: selection.correlation_nonce,
+    selection_ref: selectionRef,
+    producers,
+  };
+  const expected = {
+    posture: selection.posture,
+    sha: selection.source.sha,
+    tree: selection.source.tree,
+    correlationNonce: selection.correlation_nonce,
+    candidateDigest: undefined,
+    runID: selection.run.id,
+    runAttempt: selection.run.attempt,
+    selectionManifestSHA256: selectionRef.manifest_sha256,
+    eventIdentity: {
+      kind: identity.kind,
+      pr_number: identity.pr_number,
+      event_head_sha: identity.event_head_sha,
+      event_base_sha: identity.event_base_sha,
+      projected_sha: identity.projected_sha,
+    },
+    repository: identity.repository,
+    baseSHA: selection.selector.base_sha,
+    changedPaths: [...selection.selector.changed_paths],
+  };
+  const result = validateReportSet({
+    registry,
+    selection,
+    reports,
+    producerManifest,
+    expected,
+  });
+  return { producerManifest, reports, result };
+}
+
+function laneObservation({ lane, laneSelection, run }) {
+  const sources = [];
+  if (lane.context.protected) sources.push("protected");
+  if (laneSelection.disposition === "selected") sources.push("selected");
+  sources.sort();
+
+  const common = {
+    lane_id: lane.id,
+    workflow: lane.owner.workflow,
+    context: {
+      match: lane.context.match,
+      name: lane.context.name,
+      protected: lane.context.protected,
+    },
+    selection_disposition: laneSelection.disposition,
+    selection_reason: laneSelection.reason,
+    observation_sources: sources,
+  };
+  if (!run) {
+    return {
+      ...common,
+      run: null,
+      job_ids: [],
+      job_name: null,
+      status: null,
+      conclusion: null,
+      duration_ms: null,
+      state: "missing",
+      reason: "workflow_run_missing",
+      terminal_success: false,
+    };
+  }
+  const matched = run.jobs.filter((job) =>
+    contextMatches(lane.context, job.name),
+  );
+  const runRef = { id: run.run_id, attempt: run.run_attempt };
+  if (matched.length === 0) {
+    return {
+      ...common,
+      run: runRef,
+      job_ids: [],
+      job_name: null,
+      status: null,
+      conclusion: null,
+      duration_ms: null,
+      state: "missing",
+      reason: "context_missing",
+      terminal_success: false,
+    };
+  }
+  if (matched.length > 1) {
+    return {
+      ...common,
+      run: runRef,
+      job_ids: matched.map((job) => job.id).sort(compareIDs),
+      job_name: null,
+      status: null,
+      conclusion: null,
+      duration_ms: null,
+      state: "duplicate",
+      reason: "context_duplicate",
+      terminal_success: false,
+    };
+  }
+  const [job] = matched;
+  const outcome = jobObservationState(job);
+  return {
+    ...common,
+    run: runRef,
+    job_ids: [job.id],
+    job_name: job.name,
+    status: job.status,
+    conclusion: job.conclusion,
+    duration_ms: job.duration_ms,
+    state: outcome.state,
+    reason: outcome.reason,
+    terminal_success: outcome.state === "success",
+  };
+}
+
+export function createShadowObservationManifest({
+  registry,
+  selection,
+  identity,
+  workflowRuns,
+  collectedAt,
+}) {
+  const timestamp = apiTimestamp(collectedAt, "collected_at");
+  const selectionByID = new Map(
+    selection.lanes.map((laneSelection) => [
+      laneSelection.lane_id,
+      laneSelection,
+    ]),
+  );
+  const newestByWorkflow = new Map();
+  for (const run of [...workflowRuns].sort(canonicalRunOrder)) {
+    if (!newestByWorkflow.has(run.workflow)) {
+      newestByWorkflow.set(run.workflow, run);
+    }
+  }
+  const laneObservations = [...registry.lanes]
+    .sort((left, right) => left.id.localeCompare(right.id))
+    .flatMap((lane) => {
+      const laneSelection = selectionByID.get(lane.id);
+      if (
+        laneSelection.disposition !== "selected" &&
+        !lane.context.protected
+      ) {
+        return [];
+      }
+      return [
+        laneObservation({
+          lane,
+          laneSelection,
+          run: newestByWorkflow.get(lane.owner.workflow),
+        }),
+      ];
+    });
+
+  return {
+    schema_version: SHADOW_OBSERVATION_SCHEMA_VERSION,
+    registry_schema_version: registry.schema_version,
+    selection_ref: {
+      run: { ...selection.run },
+      manifest_sha256: selectionManifestSHA256(selection),
+    },
+    selection_source: { ...selection.source },
+    correlation_nonce: selection.correlation_nonce,
+    event: {
+      kind: identity.kind,
+      pr_number: identity.pr_number,
+      event_head_sha: identity.event_head_sha,
+      event_base_sha: identity.event_base_sha,
+      projected_sha: identity.projected_sha,
+    },
+    repository: identity.repository,
+    event_refs: { head: identity.head_ref, base: identity.base_ref },
+    collected_at: timestamp,
+    workflow_runs: [...workflowRuns].sort(canonicalRunOrder),
+    lane_observations: laneObservations,
+  };
+}
+
+export async function collectShadowObservation({
+  registry,
+  selection,
+  identity,
+  requestJSON,
+  apiBase = DEFAULT_API_URL,
+  collectedAt = new Date().toISOString(),
+}) {
+  bindSelectionToEvent(selection, registry, identity);
+  const runs = await discoverWorkflowRuns({
+    registry,
+    identity,
+    requestJSON,
+    apiBase,
+  });
+  const workflowRuns = await hydrateWorkflowRuns({
+    runs,
+    identity,
+    requestJSON,
+    apiBase,
+  });
+  return createShadowObservationManifest({
+    registry,
+    selection,
+    identity,
+    workflowRuns,
+    collectedAt,
+  });
+}
+
+export function shadowObservationSettled(document) {
+  return (
+    document.workflow_runs.every((run) => run.status === "completed") &&
+    document.lane_observations.every(
+      (observation) =>
+        observation.state !== "missing" && observation.state !== "pending",
+    )
+  );
+}
+
+export function assertFreshOutput(path) {
+  const output = resolve(path);
+  const parent = dirname(output);
+  if (!existsSync(parent) || !statSync(parent).isDirectory()) {
+    contract(
+      "CI lane shadow collector",
+      `observation output directory does not exist: ${parent}`,
+    );
+  }
+  if (existsSync(output)) {
+    contract(
+      "CI lane shadow collector",
+      `observation output already exists; refusing stale reuse: ${output}`,
+    );
+  }
+  return output;
+}
+
+export function writeShadowObservation(path, document) {
+  const output = assertFreshOutput(path);
+  const body = `${JSON.stringify(document, null, 2)}\n`;
+  const temporary = `${output}.${process.pid}.tmp`;
+  try {
+    writeFileSync(temporary, body, { encoding: "utf8", flag: "wx" });
+    linkSync(temporary, output);
+  } finally {
+    if (existsSync(temporary)) unlinkSync(temporary);
+  }
+  return Object.freeze({
+    path: output,
+    body,
+    sha256: createHash("sha256").update(body).digest("hex"),
+  });
+}
+
+function nonnegativeSeconds(value, name, fallback) {
+  if (value === undefined || String(value).trim() === "") return fallback;
+  const text = String(value);
+  if (!/^(?:0|[1-9][0-9]*)$/.test(text)) {
+    contract("CI lane shadow collector", `${name} must be a non-negative integer`);
+  }
+  const seconds = Number(text);
+  if (!Number.isSafeInteger(seconds)) {
+    contract("CI lane shadow collector", `${name} exceeds the safe integer range`);
+  }
+  return seconds;
+}
+
+function delay(milliseconds) {
+  return new Promise((resolveDelay) => setTimeout(resolveDelay, milliseconds));
+}
+
+function githubRequest({ token }) {
+  const authorization = requiredString(token, "GITHUB_TOKEN");
+  return async (url) => {
+    const response = await fetch(url, {
+      headers: {
+        Accept: "application/vnd.github+json",
+        Authorization: `Bearer ${authorization}`,
+        "X-GitHub-Api-Version": "2022-11-28",
+      },
+    });
+    if (!response.ok) {
+      contract(
+        "CI lane shadow collector",
+        `GitHub API ${response.status} for ${new URL(url).pathname}`,
+      );
+    }
+    return response.json();
+  };
+}
+
+function githubBinaryRequest({ token }) {
+  const authorization = requiredString(token, "GITHUB_TOKEN");
+  return async (url) => {
+    const response = await fetch(url, {
+      headers: {
+        Accept: "application/vnd.github+json",
+        Authorization: `Bearer ${authorization}`,
+        "X-GitHub-Api-Version": "2022-11-28",
+      },
+      redirect: "follow",
+    });
+    if (!response.ok || !response.body) {
+      contract(
+        "CI lane shadow collector",
+        `GitHub artifact download failed with HTTP ${response.status}`,
+      );
+    }
+    const chunks = [];
+    let size = 0;
+    for await (const chunk of response.body) {
+      size += chunk.length;
+      if (size > MAX_NATIVE_ARCHIVE_BYTES) {
+        contract(
+          "CI lane shadow collector",
+          "GitHub artifact download exceeds its size limit",
+        );
+      }
+      chunks.push(Buffer.from(chunk));
+    }
+    return Buffer.concat(chunks);
+  };
+}
+
+export async function main(env = process.env) {
+  const root = resolve(process.cwd());
+  const selectionPath = requiredString(
+    env.CI_LANE_SELECTION,
+    "CI_LANE_SELECTION",
+  );
+  const outputPath = assertFreshOutput(
+    requiredString(env.CI_LANE_SHADOW_OUTPUT, "CI_LANE_SHADOW_OUTPUT"),
+  );
+  const registry = loadRegistry(
+    env.CI_LANE_REGISTRY || DEFAULT_REGISTRY_PATH,
+    { root },
+  );
+  const selection = parseJSONFile(
+    resolve(root, selectionPath),
+    "CI lane shadow collector",
+  );
+  const payload = parseJSONFile(
+    requiredString(env.GITHUB_EVENT_PATH, "GITHUB_EVENT_PATH"),
+    "CI lane shadow collector",
+  );
+  const identity = trustedEventIdentity({
+    eventName: env.GITHUB_EVENT_NAME,
+    repository: env.GITHUB_REPOSITORY,
+    projectedSHA: env.GITHUB_SHA,
+    payload,
+  });
+  bindSelectionToEvent(selection, registry, identity, {
+    runID: env.GITHUB_RUN_ID,
+    runAttempt: env.GITHUB_RUN_ATTEMPT,
+  });
+
+  const pollSeconds = nonnegativeSeconds(
+    env.CI_LANE_SHADOW_POLL_SECONDS,
+    "CI_LANE_SHADOW_POLL_SECONDS",
+    DEFAULT_POLL_SECONDS,
+  );
+  const timeoutSeconds = nonnegativeSeconds(
+    env.CI_LANE_SHADOW_TIMEOUT_SECONDS,
+    "CI_LANE_SHADOW_TIMEOUT_SECONDS",
+    DEFAULT_TIMEOUT_SECONDS,
+  );
+  const apiBase = env.GITHUB_API_URL || DEFAULT_API_URL;
+  const requestJSON = githubRequest({ token: env.GITHUB_TOKEN });
+  const requestBinary = githubBinaryRequest({ token: env.GITHUB_TOKEN });
+  const deadline = Date.now() + timeoutSeconds * 1000;
+  let observation;
+  for (;;) {
+    observation = await collectShadowObservation({
+      registry,
+      selection,
+      identity,
+      requestJSON,
+      apiBase,
+    });
+    if (shadowObservationSettled(observation) || Date.now() >= deadline) break;
+    const remaining = deadline - Date.now();
+    await delay(Math.min(pollSeconds * 1000, remaining));
+  }
+
+  const settled = shadowObservationSettled(observation);
+  if (settled) {
+    const bundles = await collectNativeBundles({
+      registry,
+      selection,
+      identity,
+      workflowRuns: observation.workflow_runs,
+      requestJSON,
+      requestBinary,
+      apiBase,
+    });
+    const qualification = createNativeQualification({
+      registry,
+      selection,
+      identity,
+      bundles,
+    });
+    observation = {
+      ...observation,
+      native_qualification: {
+        producer_manifest: qualification.producerManifest,
+        reports: qualification.reports,
+        expected: qualification.result.expected,
+        received: qualification.result.received,
+      },
+    };
+  }
+  const written = writeShadowObservation(outputPath, observation);
+  setOutput("shadow_observation_path", written.path);
+  setOutput("shadow_observation_sha256", written.sha256);
+  setOutput("shadow_observation_settled", String(settled));
+  if (!settled) {
+    warning(
+      "CI lane shadow collection reached its deadline with missing or pending native evidence",
+      { title: "merge-fence shadow observation incomplete" },
+    );
+  }
+  notice(
+    `Recorded native Actions evidence for ${observation.workflow_runs.length} workflow run(s)`,
+  );
+  return observation;
+}
+
+const invokedDirectly =
+  process.argv[1] && fileURLToPath(import.meta.url) === resolve(process.argv[1]);
+if (invokedDirectly) {
+  try {
+    await main();
+  } catch (collectorError) {
+    error(
+      collectorError instanceof Error
+        ? collectorError.message
+        : String(collectorError),
+      { title: "merge-fence shadow collector failed closed" },
+    );
+    process.exit(1);
+  }
+}

--- a/.github/scripts/ci-lane-shadow-collector.mjs
+++ b/.github/scripts/ci-lane-shadow-collector.mjs
@@ -475,6 +475,10 @@ export async function discoverWorkflowRuns({
 
 function normalizeJob(job) {
   const status = requiredString(job.status, "workflow job status");
+  const conclusion = nullableConclusion(
+    job.conclusion,
+    "workflow job conclusion",
+  );
   const startedAt = apiTimestamp(job.started_at, "workflow job started_at", {
     nullable: status !== "completed",
   });
@@ -483,22 +487,33 @@ function normalizeJob(job) {
     "workflow job completed_at",
     { nullable: status !== "completed" },
   );
+  let normalizedStartedAt = startedAt;
   let duration = null;
   if (startedAt !== null && completedAt !== null) {
     duration = Date.parse(completedAt) - Date.parse(startedAt);
     if (!Number.isSafeInteger(duration) || duration < 0) {
-      contract(
-        "CI lane shadow collector",
-        "workflow job completion precedes its start",
-      );
+      // Actions assigns synthetic timestamps to jobs skipped before runner
+      // allocation and can report their start after their completion. A
+      // skipped job executed no runner time, so canonicalize that documented
+      // API shape to a zero-duration instant. Every executed conclusion keeps
+      // the strict chronological check.
+      if (status === "completed" && conclusion === "skipped") {
+        normalizedStartedAt = completedAt;
+        duration = 0;
+      } else {
+        contract(
+          "CI lane shadow collector",
+          "workflow job completion precedes its start",
+        );
+      }
     }
   }
   return {
     id: positiveID(job.id, "workflow job id"),
     name: requiredString(job.name, "workflow job name"),
     status,
-    conclusion: nullableConclusion(job.conclusion, "workflow job conclusion"),
-    started_at: startedAt,
+    conclusion,
+    started_at: normalizedStartedAt,
     completed_at: completedAt,
     duration_ms: duration,
   };

--- a/.github/scripts/ci-lane-shadow-collector.mjs
+++ b/.github/scripts/ci-lane-shadow-collector.mjs
@@ -714,7 +714,10 @@ export async function collectNativeBundles({
   return bundles;
 }
 
-function contextMatches(context, jobName) {
+// Exported so ci-lane-backtest.mjs's retrospective replay matches lane
+// context jobs the same way the live collector does, without duplicating the
+// two-line rule.
+export function contextMatches(context, jobName) {
   return context.match === "exact"
     ? jobName === context.name
     : jobName.startsWith(context.name);

--- a/.github/scripts/ci-lane-shadow-collector.test.mjs
+++ b/.github/scripts/ci-lane-shadow-collector.test.mjs
@@ -1,0 +1,635 @@
+// Negative controls for the native Actions shadow collector. Network access is
+// replaced by a URL-aware in-memory HTTP function in every test.
+
+import assert from "node:assert/strict";
+import {
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+
+import { deriveQualificationCorrelationNonce } from "./ci-lane-contract.mjs";
+
+import {
+  bindSelectionToEvent,
+  collectShadowObservation,
+  jobObservationState,
+  shadowObservationSettled,
+  trustedEventIdentity,
+  writeShadowObservation,
+} from "./ci-lane-shadow-collector.mjs";
+
+const sha = (character) => character.repeat(40);
+const REPOSITORY = "example/project";
+const BASE_SHA = sha("a");
+const EVENT_HEAD_SHA = sha("b");
+const PROJECTED_SHA = sha("c");
+const PROJECTED_TREE = sha("d");
+const COLLECTED_AT = "2026-08-16T12:00:00Z";
+
+function lane({
+  id,
+  workflow,
+  context,
+  protectedContext = false,
+  mergePosture = "impact",
+  packageGlobs,
+  match = "exact",
+}) {
+  return {
+    id,
+    owner: { workflow },
+    executions: ["default"],
+    context: {
+      match,
+      name: context,
+      protected: protectedContext,
+    },
+    merge_posture: mergePosture,
+    main_posture: "always",
+    release_posture: "advisory",
+    package_globs: packageGlobs,
+    applicability: { source: true, artifact: false },
+  };
+}
+
+function registryFixture() {
+  return {
+    schema_version: 1,
+    selection_schema_version: 1,
+    report_schema_version: 1,
+    impact_selection: { known_nonimpact_globs: ["docs/**", "**/*.md"] },
+    lanes: [
+      lane({
+        id: "current.protected",
+        workflow: ".github/workflows/protected.yml",
+        context: "protected-context",
+        protectedContext: true,
+        packageGlobs: ["deploy/**"],
+      }),
+      lane({
+        id: "optional.omitted",
+        workflow: ".github/workflows/optional.yml",
+        context: "optional-context",
+        packageGlobs: ["optional/**"],
+      }),
+      lane({
+        id: "proposed.selected",
+        workflow: ".github/workflows/selected.yml",
+        context: "selected-context",
+        packageGlobs: ["internal/**"],
+      }),
+    ],
+  };
+}
+
+function selectionFixture({ sourceSHA = PROJECTED_SHA, baseSHA = BASE_SHA } = {}) {
+  const source = { sha: sourceSHA, tree: PROJECTED_TREE };
+  return {
+    schema_version: 1,
+    registry_schema_version: 1,
+    report_schema_version: 1,
+    posture: "merge",
+    source,
+    candidate_digest: null,
+    correlation_nonce: deriveQualificationCorrelationNonce({
+      posture: "merge",
+      source,
+    }),
+    run: { id: "900", attempt: 2 },
+    selector: {
+      conclusion: "success",
+      base_sha: baseSHA,
+      head_sha: sourceSHA,
+      changed_paths: ["internal/change.go"],
+      unknown_paths: [],
+    },
+    lanes: [
+      {
+        lane_id: "current.protected",
+        disposition: "omitted",
+        executions: [],
+        reason: "not_impacted",
+      },
+      {
+        lane_id: "optional.omitted",
+        disposition: "omitted",
+        executions: [],
+        reason: "not_impacted",
+      },
+      {
+        lane_id: "proposed.selected",
+        disposition: "selected",
+        executions: ["default"],
+        reason: null,
+      },
+    ],
+  };
+}
+
+function pullRequestPayload() {
+  return {
+    repository: { full_name: REPOSITORY },
+    pull_request: {
+      number: 42,
+      head: {
+        sha: EVENT_HEAD_SHA,
+        ref: "feature/native-evidence",
+        repo: { full_name: "fork/project" },
+      },
+      base: {
+        sha: BASE_SHA,
+        ref: "main",
+        repo: { full_name: REPOSITORY },
+      },
+    },
+  };
+}
+
+function pullRequestIdentity() {
+  return trustedEventIdentity({
+    eventName: "pull_request",
+    repository: REPOSITORY,
+    projectedSHA: PROJECTED_SHA,
+    payload: pullRequestPayload(),
+  });
+}
+
+function workflowRun({
+  id,
+  workflow = ".github/workflows/selected.yml",
+  status = "completed",
+  conclusion = "success",
+  createdAt = "2026-08-16T11:00:00Z",
+  updatedAt = "2026-08-16T11:05:00Z",
+  attempt = 1,
+  repository = REPOSITORY,
+  event = "pull_request",
+  headSHA = EVENT_HEAD_SHA,
+  headBranch = "feature/native-evidence",
+  prNumber = 42,
+  prHeadSHA = EVENT_HEAD_SHA,
+  prBaseSHA = BASE_SHA,
+  prHeadRef = "feature/native-evidence",
+  prBaseRef = "main",
+} = {}) {
+  return {
+    id,
+    run_attempt: attempt,
+    path: workflow,
+    repository: { full_name: repository },
+    event,
+    head_sha: headSHA,
+    head_branch: headBranch,
+    status,
+    conclusion,
+    created_at: createdAt,
+    updated_at: updatedAt,
+    pull_requests: [
+      {
+        number: prNumber,
+        head: { sha: prHeadSHA, ref: prHeadRef },
+        base: { sha: prBaseSHA, ref: prBaseRef },
+      },
+    ],
+  };
+}
+
+function workflowJob({
+  id,
+  name = "selected-context",
+  status = "completed",
+  conclusion = "success",
+  startedAt = "2026-08-16T11:00:00Z",
+  completedAt = "2026-08-16T11:02:30Z",
+} = {}) {
+  return {
+    id,
+    name,
+    status,
+    conclusion,
+    started_at: startedAt,
+    completed_at: completedAt,
+  };
+}
+
+function mockGitHub({ runs, jobsByRun = {} }) {
+  const calls = [];
+  const requestJSON = async (urlText) => {
+    calls.push(urlText);
+    const url = new URL(urlText);
+    const jobMatch = url.pathname.match(
+      /\/actions\/runs\/([1-9][0-9]*)\/attempts\/([1-9][0-9]*)\/jobs$/,
+    );
+    if (jobMatch) {
+      const key = `${jobMatch[1]}:${jobMatch[2]}`;
+      const jobs = jobsByRun[key] ?? [];
+      return { total_count: jobs.length, jobs };
+    }
+    assert.equal(url.pathname, "/repos/example/project/actions/runs");
+    assert.equal(url.searchParams.get("event"), "pull_request");
+    assert.equal(url.searchParams.get("head_sha"), EVENT_HEAD_SHA);
+    return { total_count: runs.length, workflow_runs: runs };
+  };
+  return { requestJSON, calls };
+}
+
+async function collect({ runs, jobsByRun, registry, selection, identity } = {}) {
+  const github = mockGitHub({ runs: runs ?? [], jobsByRun });
+  const document = await collectShadowObservation({
+    registry: registry ?? registryFixture(),
+    selection: selection ?? selectionFixture(),
+    identity: identity ?? pullRequestIdentity(),
+    requestJSON: github.requestJSON,
+    apiBase: "https://api.example.invalid",
+    collectedAt: COLLECTED_AT,
+  });
+  return { document, calls: github.calls };
+}
+
+function observation(document, laneID) {
+  return document.lane_observations.find(
+    (candidate) => candidate.lane_id === laneID,
+  );
+}
+
+test("PR collection binds REST head_sha to the PR head, not projected SHA", async () => {
+  const run = workflowRun({ id: 101 });
+  const { document, calls } = await collect({
+    runs: [run],
+    jobsByRun: { "101:1": [workflowJob({ id: 1001 })] },
+  });
+
+  assert.notEqual(PROJECTED_SHA, EVENT_HEAD_SHA);
+  assert.equal(document.event.projected_sha, PROJECTED_SHA);
+  assert.equal(document.event.event_head_sha, EVENT_HEAD_SHA);
+  assert.equal(document.workflow_runs[0].head_sha, EVENT_HEAD_SHA);
+  assert.equal(
+    observation(document, "proposed.selected").state,
+    "success",
+  );
+  assert.ok(
+    calls.some((url) =>
+      url.includes(`head_sha=${encodeURIComponent(EVENT_HEAD_SHA)}`),
+    ),
+  );
+
+  const projectedRun = workflowRun({ id: 102, headSHA: PROJECTED_SHA });
+  const wrong = await collect({
+    runs: [projectedRun],
+    jobsByRun: { "102:1": [workflowJob({ id: 1002 })] },
+  });
+  assert.equal(wrong.document.workflow_runs.length, 0);
+  assert.equal(
+    observation(wrong.document, "proposed.selected").reason,
+    "workflow_run_missing",
+  );
+});
+
+test("wrong repository, event, PR, head, or base cannot bind a run", async (t) => {
+  const cases = [
+    ["repository", { repository: "elsewhere/project" }],
+    ["event", { event: "push" }],
+    ["PR number", { prNumber: 43 }],
+    ["event head", { headSHA: sha("e") }],
+    ["associated head", { prHeadSHA: sha("e") }],
+    ["associated base", { prBaseSHA: sha("e") }],
+    ["head ref", { headBranch: "another-branch" }],
+    ["associated base ref", { prBaseRef: "another-base" }],
+  ];
+  for (const [name, change] of cases) {
+    await t.test(name, async () => {
+      const run = workflowRun({ id: 200, ...change });
+      const { document, calls } = await collect({
+        runs: [run],
+        jobsByRun: { "200:1": [workflowJob({ id: 2001 })] },
+      });
+      assert.equal(document.workflow_runs.length, 0);
+      assert.equal(
+        observation(document, "proposed.selected").state,
+        "missing",
+      );
+      assert.equal(
+        calls.some((url) => url.includes("/attempts/1/jobs")),
+        false,
+      );
+    });
+  }
+});
+
+test("newest run and attempt wins even when an older run is green", async () => {
+  const oldGreen = workflowRun({
+    id: 300,
+    createdAt: "2026-08-16T10:00:00Z",
+  });
+  const newRed = workflowRun({
+    id: 301,
+    createdAt: "2026-08-16T11:00:00Z",
+    conclusion: "failure",
+  });
+  const oldAttempt = workflowRun({
+    id: 302,
+    attempt: 1,
+    createdAt: "2026-08-16T12:00:00Z",
+  });
+  const newAttempt = workflowRun({
+    id: 302,
+    attempt: 2,
+    createdAt: "2026-08-16T12:00:00Z",
+    conclusion: "failure",
+  });
+  const { document, calls } = await collect({
+    runs: [oldGreen, newAttempt, newRed, oldAttempt],
+    jobsByRun: {
+      "300:1": [workflowJob({ id: 3001 })],
+      "301:1": [workflowJob({ id: 3011, conclusion: "failure" })],
+      "302:1": [workflowJob({ id: 3021 })],
+      "302:2": [workflowJob({ id: 3022, conclusion: "failure" })],
+    },
+  });
+  const selected = observation(document, "proposed.selected");
+  assert.deepEqual(selected.run, { id: "302", attempt: 2 });
+  assert.equal(selected.state, "red");
+  assert.equal(selected.terminal_success, false);
+  assert.deepEqual(
+    document.workflow_runs.map((run) => `${run.run_id}:${run.run_attempt}`),
+    ["302:2", "302:1", "301:1", "300:1"],
+  );
+  for (const ref of ["300:1", "301:1", "302:1", "302:2"]) {
+    const [id, attempt] = ref.split(":");
+    assert.ok(calls.some((url) => url.includes(`/runs/${id}/attempts/${attempt}/jobs`)));
+  }
+});
+
+test("missing and duplicate stable contexts fail closed", async (t) => {
+  const run = workflowRun({ id: 400 });
+  await t.test("missing", async () => {
+    const { document } = await collect({ runs: [run] });
+    const selected = observation(document, "proposed.selected");
+    assert.equal(selected.state, "missing");
+    assert.equal(selected.reason, "context_missing");
+    assert.equal(selected.terminal_success, false);
+  });
+  await t.test("duplicate", async () => {
+    const { document } = await collect({
+      runs: [run],
+      jobsByRun: {
+        "400:1": [
+          workflowJob({ id: 4001 }),
+          workflowJob({ id: 4002 }),
+        ],
+      },
+    });
+    const selected = observation(document, "proposed.selected");
+    assert.equal(selected.state, "duplicate");
+    assert.equal(selected.reason, "context_duplicate");
+    assert.deepEqual(selected.job_ids, ["4001", "4002"]);
+    assert.equal(selected.terminal_success, false);
+  });
+});
+
+test("registered prefix contexts match suffix-bearing native job names", async () => {
+  const registry = registryFixture();
+  registry.lanes.find(
+    (candidate) => candidate.id === "proposed.selected",
+  ).context.match = "prefix";
+  const run = workflowRun({ id: 450 });
+  const { document } = await collect({
+    registry,
+    runs: [run],
+    jobsByRun: {
+      "450:1": [
+        workflowJob({ id: 4501, name: "selected-context (shard-one)" }),
+      ],
+    },
+  });
+  assert.equal(
+    observation(document, "proposed.selected").state,
+    "success",
+  );
+});
+
+test("observations cover selected union protected while optional runs remain telemetry", async () => {
+  const selectedRun = workflowRun({ id: 500 });
+  const protectedRun = workflowRun({
+    id: 501,
+    workflow: ".github/workflows/protected.yml",
+  });
+  const optionalRun = workflowRun({
+    id: 502,
+    workflow: ".github/workflows/optional.yml",
+  });
+  const { document } = await collect({
+    runs: [optionalRun, selectedRun, protectedRun],
+    jobsByRun: {
+      "500:1": [workflowJob({ id: 5001 })],
+      "501:1": [workflowJob({ id: 5011, name: "protected-context" })],
+      "502:1": [workflowJob({ id: 5021, name: "optional-context" })],
+    },
+  });
+  assert.deepEqual(
+    document.workflow_runs.map((run) => run.workflow),
+    [
+      ".github/workflows/optional.yml",
+      ".github/workflows/protected.yml",
+      ".github/workflows/selected.yml",
+    ],
+  );
+  assert.deepEqual(
+    document.lane_observations.map((item) => item.lane_id),
+    ["current.protected", "proposed.selected"],
+  );
+  assert.equal(
+    observation(document, "current.protected").selection_disposition,
+    "omitted",
+  );
+  assert.deepEqual(
+    observation(document, "current.protected").observation_sources,
+    ["protected"],
+  );
+  assert.deepEqual(
+    observation(document, "proposed.selected").observation_sources,
+    ["selected"],
+  );
+  assert.equal(shadowObservationSettled(document), true);
+});
+
+test("terminal states remain distinct and only success qualifies", () => {
+  const cases = [
+    ["success", "success", true],
+    ["failure", "red", false],
+    ["action_required", "red", false],
+    ["skipped", "skipped", false],
+    ["neutral", "neutral", false],
+    ["cancelled", "cancelled", false],
+    ["timed_out", "timed_out", false],
+  ];
+  for (const [conclusion, state, terminalSuccess] of cases) {
+    const outcome = jobObservationState({
+      status: "completed",
+      conclusion,
+    });
+    assert.equal(outcome.state, state, conclusion);
+    assert.equal(outcome.state === "success", terminalSuccess, conclusion);
+  }
+  assert.deepEqual(
+    jobObservationState({ status: "in_progress", conclusion: null }),
+    { state: "pending", reason: "job_not_terminal" },
+  );
+});
+
+test("job rosters are canonical and durations come from API timestamps", async () => {
+  const run = workflowRun({ id: 600 });
+  const { document } = await collect({
+    runs: [run],
+    jobsByRun: {
+      "600:1": [
+        workflowJob({
+          id: 6002,
+          name: "supporting-job",
+          startedAt: "2026-08-16T11:00:30Z",
+          completedAt: "2026-08-16T11:01:00Z",
+        }),
+        workflowJob({ id: 6001 }),
+      ],
+    },
+  });
+  assert.deepEqual(
+    document.workflow_runs[0].jobs.map((job) => job.id),
+    ["6001", "6002"],
+  );
+  assert.equal(document.workflow_runs[0].jobs[0].duration_ms, 150_000);
+  assert.equal(document.workflow_runs[0].jobs[1].duration_ms, 30_000);
+  assert.equal(
+    observation(document, "proposed.selected").duration_ms,
+    150_000,
+  );
+});
+
+test("malformed or reversed job timestamps are rejected", async (t) => {
+  const run = workflowRun({ id: 700 });
+  for (const [name, timestamps] of [
+    ["malformed", { startedAt: "not-a-timestamp" }],
+    [
+      "reversed",
+      {
+        startedAt: "2026-08-16T11:02:00Z",
+        completedAt: "2026-08-16T11:01:00Z",
+      },
+    ],
+  ]) {
+    await t.test(name, async () => {
+      await assert.rejects(
+        collect({
+          runs: [run],
+          jobsByRun: {
+            "700:1": [workflowJob({ id: 7001, ...timestamps })],
+          },
+        }),
+        /workflow job (started_at has invalid value|completion precedes its start)/,
+      );
+    });
+  }
+});
+
+test("selection binding rejects stale run identity and the wrong event base", () => {
+  const registry = registryFixture();
+  const identity = pullRequestIdentity();
+  assert.equal(
+    bindSelectionToEvent(selectionFixture(), registry, identity, {
+      runID: "900",
+      runAttempt: 2,
+    }).source.sha,
+    PROJECTED_SHA,
+  );
+  const replayed = selectionFixture();
+  replayed.correlation_nonce = "f".repeat(64);
+  assert.throws(
+    () => bindSelectionToEvent(replayed, registry, identity),
+    /correlation_nonce does not match its projected Git objects/,
+  );
+  assert.throws(
+    () =>
+      bindSelectionToEvent(selectionFixture(), registry, identity, {
+        runID: "901",
+        runAttempt: 2,
+      }),
+    /selection\.run\.id/,
+  );
+  assert.throws(
+    () =>
+      bindSelectionToEvent(
+        selectionFixture({ baseSHA: sha("e") }),
+        registry,
+        identity,
+      ),
+    /selection\.selector\.base_sha/,
+  );
+});
+
+test("merge groups bind projected head and queue ref without PR association", async () => {
+  const mergeIdentity = trustedEventIdentity({
+    eventName: "merge_group",
+    repository: REPOSITORY,
+    projectedSHA: EVENT_HEAD_SHA,
+    payload: {
+      repository: { full_name: REPOSITORY },
+      merge_group: {
+        head_sha: EVENT_HEAD_SHA,
+        base_sha: BASE_SHA,
+        head_ref: "refs/heads/gh-readonly-queue/main/pr-42",
+        base_ref: "refs/heads/main",
+      },
+    },
+  });
+  const selection = selectionFixture({ sourceSHA: EVENT_HEAD_SHA });
+  const mergeRun = workflowRun({
+    id: 800,
+    event: "merge_group",
+    headBranch: "gh-readonly-queue/main/pr-42",
+  });
+  mergeRun.pull_requests = [];
+  const mergeRequest = async (urlText) => {
+    const url = new URL(urlText);
+    if (url.pathname.endsWith("/jobs")) {
+      return { total_count: 1, jobs: [workflowJob({ id: 8001 })] };
+    }
+    assert.equal(url.searchParams.get("event"), "merge_group");
+    return { total_count: 1, workflow_runs: [mergeRun] };
+  };
+  const document = await collectShadowObservation({
+    registry: registryFixture(),
+    selection,
+    identity: mergeIdentity,
+    requestJSON: mergeRequest,
+    apiBase: "https://api.example.invalid",
+    collectedAt: COLLECTED_AT,
+  });
+  assert.equal(
+    observation(document, "proposed.selected").state,
+    "success",
+  );
+  assert.equal(document.event.pr_number, null);
+});
+
+test("manifest writing is canonical, atomic, and refuses stale output", (t) => {
+  const root = mkdtempSync(join(tmpdir(), "ci-lane-shadow-write-"));
+  t.after(() => rmSync(root, { recursive: true, force: true }));
+  const output = join(root, "observation.json");
+  const document = {
+    schema_version: 1,
+    workflow_runs: [],
+    lane_observations: [],
+  };
+  const written = writeShadowObservation(output, document);
+  assert.equal(written.body, `${JSON.stringify(document, null, 2)}\n`);
+  assert.equal(readFileSync(output, "utf8"), written.body);
+  assert.match(written.sha256, /^[0-9a-f]{64}$/);
+  assert.throws(
+    () => writeShadowObservation(output, document),
+    /refusing stale reuse/,
+  );
+});

--- a/.github/scripts/ci-lane-shadow-collector.test.mjs
+++ b/.github/scripts/ci-lane-shadow-collector.test.mjs
@@ -509,6 +509,29 @@ test("job rosters are canonical and durations come from API timestamps", async (
   );
 });
 
+test("synthetic reversed timestamps on skipped jobs normalize to zero", async () => {
+  const run = workflowRun({ id: 650 });
+  const completedAt = "2026-08-16T11:01:00Z";
+  const { document } = await collect({
+    runs: [run],
+    jobsByRun: {
+      "650:1": [
+        workflowJob({
+          id: 6501,
+          conclusion: "skipped",
+          startedAt: "2026-08-16T11:02:00Z",
+          completedAt,
+        }),
+      ],
+    },
+  });
+  const job = document.workflow_runs[0].jobs[0];
+  assert.equal(job.started_at, completedAt);
+  assert.equal(job.completed_at, completedAt);
+  assert.equal(job.duration_ms, 0);
+  assert.equal(job.conclusion, "skipped");
+});
+
 test("malformed or reversed job timestamps are rejected", async (t) => {
   const run = workflowRun({ id: 700 });
   for (const [name, timestamps] of [

--- a/.github/scripts/main-coalescing.mjs
+++ b/.github/scripts/main-coalescing.mjs
@@ -3,10 +3,11 @@
 // GitHub evaluates workflow concurrency before any job can run, so the policy
 // has two halves: the exact expressions enrolled workflows carry and this
 // executable model that proves which event/ref pairs those expressions may
-// cancel. Only a push or scheduled run bound to refs/heads/main is replaceable.
-// Pull requests, merge groups, manual qualification, reusable-workflow calls,
-// maintenance branches, tags, releases, and unknown inputs receive a unique
-// run group and can never cancel one another.
+// cancel. Main pushes and equivalent scheduled runs are replaceable within
+// separate mode groups, so a routine push can never erase deeper nightly
+// evidence. Pull requests, merge groups, manual qualification,
+// reusable-workflow calls, maintenance branches, tags, releases, and unknown
+// inputs receive a unique run group and can never cancel one another.
 //
 // MODE=check (default) reads CI_LANE_REGISTRY (default .github/ci-lanes.json),
 // checks every enrolled workflow, and rejects registry/workflow drift.
@@ -27,13 +28,13 @@ export const MAIN_REF = 'refs/heads/main';
 export const LATEST_MAIN_SUFFIX = 'latest-main';
 
 export const GROUP_EXPRESSION =
-  "${{ github.workflow }}-${{ ((github.event_name == 'push' || github.event_name == 'schedule') && github.ref == 'refs/heads/main') && 'latest-main' || github.run_id }}";
+  "${{ github.workflow }}-${{ (github.event_name == 'push' && github.ref == 'refs/heads/main') && 'latest-main-push' || (github.event_name == 'schedule' && github.ref == 'refs/heads/main' && github.event.schedule != '') && format('latest-main-schedule-{0}', github.event.schedule) || github.run_id }}";
 export const CANCEL_EXPRESSION =
-  "${{ (github.event_name == 'push' || github.event_name == 'schedule') && github.ref == 'refs/heads/main' }}";
+  "${{ (github.event_name == 'push' && github.ref == 'refs/heads/main') || (github.event_name == 'schedule' && github.ref == 'refs/heads/main' && github.event.schedule != '') }}";
 
 // These workflows contain replaceable deep-main, soak, or scheduled test work.
-// A schedule and a push on main intentionally share one group per workflow, so
-// the newest run is the only one allowed to consume the deep-test budget.
+// Main pushes share one group per workflow. Scheduled runs share a group only
+// with the same workflow and exact cron expression.
 export const COALESCED_WORKFLOWS = Object.freeze([
   '.github/workflows/agpl-oracle.yml',
   '.github/workflows/chdb.yml',
@@ -79,17 +80,29 @@ export const QUICKSTART_CANCEL_EXPRESSION =
 export function coalescingDecision({
   eventName,
   ref,
+  schedule,
   workflow = 'workflow',
   runId = 'run',
 } = {}) {
   const event = String(eventName ?? '');
   const boundRef = String(ref ?? '');
-  const replaceable =
-    (event === 'push' || event === 'schedule') && boundRef === MAIN_REF;
+  const cron = String(schedule ?? '').trim();
+  const mainPush = event === 'push' && boundRef === MAIN_REF;
+  const equivalentSchedule =
+    event === 'schedule' && boundRef === MAIN_REF && cron !== '';
+  const groupKey = mainPush
+    ? `${LATEST_MAIN_SUFFIX}-push`
+    : equivalentSchedule
+      ? `${LATEST_MAIN_SUFFIX}-schedule-${cron}`
+      : runId;
   return Object.freeze({
-    cancelInProgress: replaceable,
-    group: `${workflow}-${replaceable ? LATEST_MAIN_SUFFIX : runId}`,
-    reason: replaceable ? 'latest_main' : 'distinct_run',
+    cancelInProgress: mainPush || equivalentSchedule,
+    group: `${workflow}-${groupKey}`,
+    reason: mainPush
+      ? 'latest_main_push'
+      : equivalentSchedule
+        ? 'equivalent_schedule'
+        : 'distinct_run',
   });
 }
 
@@ -177,12 +190,12 @@ export function validateEnrolledWorkflow(workflow, workflowText) {
   }
   if (concurrency.group !== GROUP_EXPRESSION) {
     problems.push(
-      `${workflow}: concurrency group is ${JSON.stringify(concurrency.group)}, want the canonical latest-main/unique-run expression`,
+      `${workflow}: concurrency group is ${JSON.stringify(concurrency.group)}, want the canonical main-push/equivalent-schedule/unique-run expression`,
     );
   }
   if (concurrency.cancelInProgress !== CANCEL_EXPRESSION) {
     problems.push(
-      `${workflow}: cancel-in-progress is ${JSON.stringify(concurrency.cancelInProgress)}, want the canonical main-push/schedule-only expression`,
+      `${workflow}: cancel-in-progress is ${JSON.stringify(concurrency.cancelInProgress)}, want the canonical main-push/equivalent-schedule-only expression`,
     );
   }
 

--- a/.github/scripts/main-coalescing.test.mjs
+++ b/.github/scripts/main-coalescing.test.mjs
@@ -17,22 +17,50 @@ import {
   validateQuickstartWorkflow,
 } from './main-coalescing.mjs';
 
-const decision = (eventName, ref, runId = '17') =>
-  coalescingDecision({ eventName, ref, workflow: 'deep', runId });
+const decision = (eventName, ref, runId = '17', schedule = '') =>
+  coalescingDecision({
+    eventName,
+    ref,
+    workflow: 'deep',
+    runId,
+    schedule,
+  });
 
-test('only main push and main schedule share the replaceable group', () => {
-  for (const eventName of ['push', 'schedule']) {
-    assert.deepEqual(decision(eventName, MAIN_REF), {
-      cancelInProgress: true,
-      group: 'deep-latest-main',
-      reason: 'latest_main',
-    });
-  }
-
+test('main pushes replace only main pushes', () => {
+  assert.deepEqual(decision('push', MAIN_REF), {
+    cancelInProgress: true,
+    group: 'deep-latest-main-push',
+    reason: 'latest_main_push',
+  });
   assert.equal(
     decision('push', MAIN_REF, 'old').group,
-    decision('schedule', MAIN_REF, 'new').group,
+    decision('push', MAIN_REF, 'new').group,
   );
+});
+
+test('scheduled runs replace only the same scheduled mode', () => {
+  const nightly = '17 3 * * *';
+  assert.deepEqual(decision('schedule', MAIN_REF, '17', nightly), {
+    cancelInProgress: true,
+    group: `deep-latest-main-schedule-${nightly}`,
+    reason: 'equivalent_schedule',
+  });
+  assert.equal(
+    decision('schedule', MAIN_REF, 'old', nightly).group,
+    decision('schedule', MAIN_REF, 'new', nightly).group,
+  );
+  assert.notEqual(
+    decision('schedule', MAIN_REF, 'old', nightly).group,
+    decision('schedule', MAIN_REF, 'new', '45 4 * * *').group,
+  );
+});
+
+test('a main push cannot cancel nightly-only evidence', () => {
+  const push = decision('push', MAIN_REF, 'push');
+  const nightly = decision('schedule', MAIN_REF, 'nightly', '17 3 * * *');
+  assert.equal(push.cancelInProgress, true);
+  assert.equal(nightly.cancelInProgress, true);
+  assert.notEqual(push.group, nightly.group);
 });
 
 test('PR, queue, qualification, maintenance, release, and unknown events never cancel', () => {
@@ -77,11 +105,19 @@ test('push and schedule fail safe to distinct groups on every non-main ref', () 
       '',
       undefined,
     ]) {
-      const verdict = decision(eventName, ref);
+      const verdict = decision(eventName, ref, '17', '17 3 * * *');
       assert.equal(verdict.cancelInProgress, false, `${eventName} ${ref}`);
       assert.equal(verdict.group, 'deep-17', `${eventName} ${ref}`);
     }
   }
+});
+
+test('a malformed schedule without its declared cron fails safe to a unique group', () => {
+  const first = decision('schedule', MAIN_REF, '101');
+  const second = decision('schedule', MAIN_REF, '102');
+  assert.equal(first.cancelInProgress, false);
+  assert.equal(second.cancelInProgress, false);
+  assert.notEqual(first.group, second.group);
 });
 
 test('structural parser reads only the top-level concurrency mapping', () => {

--- a/.github/scripts/migration-artifact.mjs
+++ b/.github/scripts/migration-artifact.mjs
@@ -1,12 +1,11 @@
 // migration-artifact.mjs — resolve WHICH cerberus the Layer-14 migration lane
 // tests, on every path, and refuse an incoherent input pair.
 //
-// migration-e2e.yml runs twice against the same commit for a release: once on
-// the push (proving the SOURCE TREE) and once via `workflow_call` from
-// release.yml's `release-artifact-migration` job (proving the ARTIFACT
-// goreleaser just built). Both runs execute the same three tier jobs, so the
-// ONE thing that differs is which cerberus binary the scenarios exec and which
-// image the compose stacks run. This module is that single decision point.
+// migration-e2e.yml runs twice against the same commit for a release: once
+// against the source tree and once via `workflow_call` against the sealed,
+// unpublished candidate. Both runs execute the same three tier jobs, so the
+// one thing that differs is which binary the scenarios exec and which image
+// the compose stacks run. This module is that single decision point.
 //
 // Two plans, and nothing in between:
 //
@@ -17,28 +16,31 @@
 //           stamp both report and `sharedVersion` is empty: the Go harness
 //           then holds each side to its own known-correct default rather than
 //           to one wrong shared value. Both sides still assert.
-//   image   a released image reference was supplied — the CLI is extracted OUT
-//           of that image (`docker create` + `docker cp`), so the binary the
-//           scenarios exec and the server the stack runs are literally the same
-//           bytes, and `sharedVersion` is the release version both must report.
+//   candidate  a sealed candidate was supplied — its complete byte roster,
+//              source identity and candidate digest are verified, then its OCI
+//              layout is copied into an ephemeral loopback registry. The CLI
+//              is extracted from that exact digest, so the binary the scenarios
+//              exec and the server the stack runs are literally the same bytes.
 //
-// Supplying exactly one half of the (image, expect-version) pair is a hard
-// error, never a silent fall-back to `source`: that is precisely how a release
-// lane would end up testing a from-source build under an artifact-shaped job
-// name and reporting green.
+// Supplying only part of the candidate identity is a hard error, never a silent
+// fall-back to `source`: that is precisely how a release lane would end up
+// testing a source build under an artifact-shaped job name and reporting green.
 //
 // Env:
-//   CERBERUS_IMAGE_INPUT           released image ref to test; empty = build
-//                                  from this tree.
+//   CERBERUS_CANDIDATE_DIR_INPUT   sealed candidate root; empty = source mode.
+//   CERBERUS_CANDIDATE_DIGEST_INPUT exact candidate manifest digest.
 //   CERBERUS_EXPECT_VERSION_INPUT  version that image's binary must report;
-//                                  travels with CERBERUS_IMAGE_INPUT.
+//                                  travels with the candidate identity.
+//   CERBERUS_SOURCE_SHA_INPUT      exact candidate source commit.
+//   CERBERUS_SOURCE_TREE_INPUT     exact candidate source tree.
 //   COMPOSE_PROJECT_SUFFIX         per-checkout suffix the local image tag
 //                                  carries, so the tag named here is the one
 //                                  the compose stack runs. Empty in a primary
 //                                  checkout, which is every CI checkout.
 //   GITHUB_ENV                     runner file the resolved plan is exported
 //                                  through (CERBERUS_BIN / CERBERUS_IMAGE /
-//                                  CERBERUS_EXPECT_VERSION).
+//                                  CERBERUS_EXPECT_VERSION and, in candidate
+//                                  mode, CERBERUS_CANDIDATE_REGISTRY_CONTAINER).
 //
 // Exit: 0 with the plan exported; 1 on a half-supplied input pair, a failed
 // build / pull / extraction, or a `--version` probe that does not report
@@ -50,6 +52,7 @@ import process from 'node:process';
 
 import { capture, error, exportEnv, notice } from './lib/gh.mjs';
 import { pullImageWithRetry } from './lib/registry.mjs';
+import { verifyCandidate, verifyCheckout } from './release-candidate.mjs';
 
 // SOURCE_BUILD_VERSION is what `go build ./cmd/cerberus` with no ldflags
 // reports — cmd/cerberus/main.go's `var Version = "dev"`. Held equal to that
@@ -68,7 +71,7 @@ function expandComposeSuffix(ref) {
   return ref.replace(COMPOSE_SUFFIX_REF, process.env.COMPOSE_PROJECT_SUFFIX ?? '');
 }
 
-// LOCAL_IMAGE_TAG is the tag the compose stacks run when no released image is
+// LOCAL_IMAGE_TAG is the tag the compose stacks run when no candidate is
 // supplied. Held equal to the `${CERBERUS_IMAGE:-…}` default in
 // tiers/tier1-dual/docker-compose.dual.yml and to the Justfile's
 // MIGRATION_LOCAL_IMAGE by the same regression pin.
@@ -93,12 +96,22 @@ const BINARY_NAME = 'cerberus';
 // to trust.
 const EXECUTABLE_MODE = 0o755;
 
+const LOOPBACK_REGISTRY_HOST = '127.0.0.1';
+const REGISTRY_CONTAINER_PREFIX = 'cerberus-migration-candidate-registry';
+const REGISTRY_IMAGE = 'registry:2';
+const REGISTRY_START_ATTEMPTS = 10;
+const REGISTRY_RETRY_DELAY_SECONDS = 1;
+const REGISTRY_CONTAINER_PORT = '5000/tcp';
+const LOOPBACK_ENDPOINT_RE = /^127\.0\.0\.1:[1-9][0-9]{0,4}$/;
+const REGISTRY_CONTAINER_RE = /^cerberus-migration-candidate-registry-[1-9][0-9]*$/;
+export const CANDIDATE_REGISTRY_ENV = 'CERBERUS_CANDIDATE_REGISTRY_CONTAINER';
+
 // PAIRED_INPUTS_MESSAGE is the refusal for a half-supplied pair. Its exact text
 // is asserted by migration-artifact.test.mjs, so a loosening rewrite is caught.
 export const PAIRED_INPUTS_MESSAGE =
-  'cerberus_image and expect_version travel together: supply both (test a released artifact) ' +
-  'or neither (build from this tree). Supplying one alone would run a source build under an ' +
-  'artifact-shaped job name.';
+  'candidate_dir, candidate_digest, expect_version, source_sha, and source_tree travel together: ' +
+  'supply all five (test the unpublished candidate) or none (build from this tree). Supplying a ' +
+  'partial identity would run unbound bytes under an artifact-shaped job name.';
 
 // resolvePlan is the testable core: it decides which cerberus the lane drives
 // from the two inputs alone, with no I/O.
@@ -107,11 +120,15 @@ export const PAIRED_INPUTS_MESSAGE =
 //   expectVersion  the stamp the CLI this module produces must report;
 //   sharedVersion  the stamp EVERY cerberus in the lane reports (CLI and
 //                  server), or '' when the two come from different builds.
-export function resolvePlan({ image, expectVersion } = {}) {
-  const ref = String(image ?? '').trim();
+export function resolvePlan({ candidateDir, candidateDigest, expectVersion, sourceSHA, sourceTree } = {}) {
+  const candidate = String(candidateDir ?? '').trim();
+  const digest = String(candidateDigest ?? '').trim();
   const want = String(expectVersion ?? '').trim();
+  const sha = String(sourceSHA ?? '').trim();
+  const tree = String(sourceTree ?? '').trim();
+  const supplied = [candidate, digest, want, sha, tree].filter((value) => value !== '').length;
 
-  if (ref === '' && want === '') {
+  if (supplied === 0) {
     return {
       source: 'source',
       image: LOCAL_IMAGE_TAG,
@@ -119,57 +136,174 @@ export function resolvePlan({ image, expectVersion } = {}) {
       sharedVersion: '',
     };
   }
-  if (ref === '' || want === '') {
+  if (supplied !== 5) {
     throw new Error(PAIRED_INPUTS_MESSAGE);
   }
-  return { source: 'image', image: ref, expectVersion: want, sharedVersion: want };
+  return {
+    source: 'candidate',
+    candidateDir: candidate,
+    candidateDigest: digest,
+    sourceSHA: sha,
+    sourceTree: tree,
+    expectVersion: want,
+    sharedVersion: want,
+  };
+}
+
+export function loopbackRegistryEndpoint(output) {
+  const endpoints = String(output ?? '')
+    .split(/\r?\n/)
+    .map((value) => value.trim())
+    .filter(Boolean);
+  if (endpoints.length !== 1 || !LOOPBACK_ENDPOINT_RE.test(endpoints[0])) {
+    throw new Error(
+      `loopback registry published endpoint is ${JSON.stringify(endpoints)}, want one 127.0.0.1:<port>`,
+    );
+  }
+  const port = Number(endpoints[0].slice(endpoints[0].lastIndexOf(':') + 1));
+  if (!Number.isSafeInteger(port) || port > 65535) {
+    throw new Error(`loopback registry published an invalid TCP port ${JSON.stringify(port)}`);
+  }
+  return endpoints[0];
+}
+
+export function stopLoopbackRegistry(container, runner = capture) {
+  const name = String(container ?? '').trim();
+  if (name === '') return false;
+  if (!REGISTRY_CONTAINER_RE.test(name)) {
+    throw new Error(`refusing to remove invalid candidate registry container ${JSON.stringify(name)}`);
+  }
+  const stopped = runner('docker', ['rm', '-f', name]);
+  if (stopped.status !== 0) {
+    if (/no such container/i.test(`${stopped.stdout}\n${stopped.stderr}`)) return false;
+    throw new Error(
+      `loopback registry ${name} could not be removed:\n${stopped.stdout}${stopped.stderr}`,
+    );
+  }
+  return true;
+}
+
+function startLoopbackRegistry() {
+  if (!pullImageWithRetry(REGISTRY_IMAGE, { consequence: 'the candidate OCI layout cannot be loaded' })) {
+    throw new Error(`cannot acquire the loopback registry substrate ${REGISTRY_IMAGE}`);
+  }
+  const container = `${REGISTRY_CONTAINER_PREFIX}-${process.pid}`;
+  capture('docker', ['rm', '-f', container]);
+  const started = capture('docker', [
+    'run',
+    '--detach',
+    '--rm',
+    '--name',
+    container,
+    '--publish',
+    `${LOOPBACK_REGISTRY_HOST}::5000`,
+    REGISTRY_IMAGE,
+  ]);
+  if (started.status !== 0) {
+    throw new Error(`loopback registry failed to start:\n${started.stdout}${started.stderr}`);
+  }
+  const published = capture('docker', ['port', container, REGISTRY_CONTAINER_PORT]);
+  try {
+    if (published.status !== 0) {
+      throw new Error(
+        `cannot resolve the loopback registry port:\n${published.stdout}${published.stderr}`,
+      );
+    }
+    const endpoint = loopbackRegistryEndpoint(published.stdout);
+    return { container, repository: `${endpoint}/cerberus` };
+  } catch (cause) {
+    capture('docker', ['rm', '-f', container]);
+    throw cause;
+  }
+}
+
+function loadCandidate(plan) {
+  let candidate;
+  try {
+    verifyCheckout(plan.sourceSHA, plan.sourceTree);
+    candidate = verifyCandidate(path.resolve(plan.candidateDir), {
+      sha: plan.sourceSHA,
+      tree: plan.sourceTree,
+      app: plan.expectVersion,
+      appTag: `v${plan.expectVersion}`,
+      digest: plan.candidateDigest,
+    });
+  } catch (cause) {
+    throw new Error(`candidate verification failed:\n${cause.message}`);
+  }
+
+  const registry = startLoopbackRegistry();
+  const source = `${path.resolve(plan.candidateDir, candidate.manifest.image.layout)}:${plan.expectVersion}`;
+  const taggedRef = `${registry.repository}:${plan.expectVersion}`;
+  let copied = null;
+  for (let attempt = 1; attempt <= REGISTRY_START_ATTEMPTS; attempt += 1) {
+    copied = capture('oras', ['cp', '--from-oci-layout', '--to-plain-http', source, taggedRef]);
+    if (copied.status === 0) break;
+    if (attempt < REGISTRY_START_ATTEMPTS) {
+      capture('sleep', [String(REGISTRY_RETRY_DELAY_SECONDS)]);
+    }
+  }
+  if (copied?.status !== 0) {
+    capture('docker', ['rm', '-f', registry.container]);
+    throw new Error(
+      `failed to load candidate OCI layout:\n${copied?.stdout ?? ''}${copied?.stderr ?? ''}`,
+    );
+  }
+  const resolved = capture('oras', ['resolve', '--plain-http', taggedRef]);
+  const actualDigest = resolved.stdout.trim();
+  if (resolved.status !== 0 || actualDigest !== candidate.manifest.image.digest) {
+    capture('docker', ['rm', '-f', registry.container]);
+    throw new Error(
+      `loopback image resolved to ${JSON.stringify(actualDigest)}, want ` +
+        `${candidate.manifest.image.digest}:\n${resolved.stdout}${resolved.stderr}`,
+    );
+  }
+  return {
+    container: registry.container,
+    image: `${registry.repository}@${candidate.manifest.image.digest}`,
+  };
 }
 
 // buildFromSource compiles the CLI the scenarios exec out of this tree.
 function buildFromSource(binary) {
   const res = capture('go', ['build', '-o', binary, './cmd/cerberus']);
   if (res.status !== 0) {
-    error(`migration-artifact: go build ./cmd/cerberus failed:\n${res.stdout}${res.stderr}`);
-    process.exit(1);
+    throw new Error(`go build ./cmd/cerberus failed:\n${res.stdout}${res.stderr}`);
   }
 }
 
-// extractFromImage pulls the released image and copies its binary out, so the
+// extractFromImage pulls the candidate image and copies its binary out, so the
 // CLI the scenarios exec is the same bytes as the server the stack runs.
 function extractFromImage(ref, binary) {
   // Through the shared policy rather than a bare `docker pull`: a transport
   // fault gets the same retry budget every other registry fetch gets, and a
   // quota refusal fails on the first attempt instead of spending four more of
   // an exhausted counter. `acceptLocalCopy` is deliberately off — the whole
-  // point is to run the RELEASED bytes, so a stale copy the runner happens to
+  // point is to run the candidate bytes, so a stale copy the runner happens to
   // hold must not stand in for them.
-  if (!pullImageWithRetry(ref, { consequence: 'the released binary cannot be extracted' })) {
-    error(
-      `migration-artifact: ${ref} is unpullable from this job — if the failure above is not a registry ` +
-        "fault, check the GHCR login step and the package's visibility.",
+  if (!pullImageWithRetry(ref, { consequence: 'the candidate binary cannot be extracted' })) {
+    throw new Error(
+      `${ref} is unpullable from this job — if the failure above is not a registry ` +
+        'fault, check that the loopback candidate registry is reachable.',
     );
-    process.exit(1);
   }
 
   const created = capture('docker', ['create', ref]);
   if (created.status !== 0) {
-    error(`migration-artifact: docker create ${ref} failed:\n${created.stdout}${created.stderr}`);
-    process.exit(1);
+    throw new Error(`docker create ${ref} failed:\n${created.stdout}${created.stderr}`);
   }
   const container = created.stdout.trim().split('\n').pop().trim();
   if (container === '') {
-    error(`migration-artifact: docker create ${ref} printed no container id`);
-    process.exit(1);
+    throw new Error(`docker create ${ref} printed no container id`);
   }
 
   try {
     const cp = capture('docker', ['cp', `${container}:${IMAGE_BINARY_PATH}`, binary]);
     if (cp.status !== 0) {
-      error(
-        `migration-artifact: docker cp ${container}:${IMAGE_BINARY_PATH} failed — the image does ` +
+      throw new Error(
+        `docker cp ${container}:${IMAGE_BINARY_PATH} failed — the image does ` +
           `not carry the binary at that path:\n${cp.stdout}${cp.stderr}`,
       );
-      process.exit(1);
     }
   } finally {
     // Best-effort: the container is a throwaway created only to be copied out
@@ -185,70 +319,90 @@ function extractFromImage(ref, binary) {
 function probeVersion(binary, plan) {
   const res = capture(binary, ['--version']);
   if (res.status !== 0) {
-    error(
-      `migration-artifact: ${binary} --version exited ${res.status} (plan=${plan.source}, ` +
+    throw new Error(
+      `${binary} --version exited ${res.status} (plan=${plan.source}, ` +
         `image=${plan.image}):\n${res.stdout}${res.stderr}`,
     );
-    process.exit(1);
   }
   const lines = res.stdout.split('\n').map((l) => l.trim()).filter((l) => l !== '');
   if (lines.length !== 1) {
-    error(
-      `migration-artifact: ${binary} --version printed ${lines.length} non-empty line(s), want ` +
+    throw new Error(
+      `${binary} --version printed ${lines.length} non-empty line(s), want ` +
         `exactly one bare version: ${JSON.stringify(res.stdout)}`,
     );
-    process.exit(1);
   }
   if (lines[0] !== plan.expectVersion) {
-    error(
-      `migration-artifact: ${binary} reports version "${lines[0]}" but the ${plan.source} plan ` +
+    throw new Error(
+      `${binary} reports version "${lines[0]}" but the ${plan.source} plan ` +
         `expects "${plan.expectVersion}" (image=${plan.image}). The lane would have tested a ` +
         `different build than the one it claims to.`,
     );
-    process.exit(1);
   }
   return lines[0];
 }
 
-function main() {
-  let plan;
-  try {
-    plan = resolvePlan({
-      image: process.env.CERBERUS_IMAGE_INPUT,
-      expectVersion: process.env.CERBERUS_EXPECT_VERSION_INPUT,
-    });
-  } catch (err) {
-    error(`migration-artifact: ${err.message}`);
-    process.exit(1);
-  }
+function resolveArtifact() {
+  const plan = resolvePlan({
+    candidateDir: process.env.CERBERUS_CANDIDATE_DIR_INPUT,
+    candidateDigest: process.env.CERBERUS_CANDIDATE_DIGEST_INPUT,
+    expectVersion: process.env.CERBERUS_EXPECT_VERSION_INPUT,
+    sourceSHA: process.env.CERBERUS_SOURCE_SHA_INPUT,
+    sourceTree: process.env.CERBERUS_SOURCE_TREE_INPUT,
+  });
 
   const buildDir = path.resolve(BUILD_DIR);
   mkdirSync(buildDir, { recursive: true });
   const binary = path.join(buildDir, BINARY_NAME);
 
-  if (plan.source === 'source') {
-    buildFromSource(binary);
-  } else {
-    extractFromImage(plan.image, binary);
+  let loaded = null;
+  try {
+    if (plan.source === 'source') {
+      buildFromSource(binary);
+    } else {
+      loaded = loadCandidate(plan);
+      plan.image = loaded.image;
+      extractFromImage(plan.image, binary);
+    }
+
+    const version = probeVersion(binary, plan);
+
+    exportEnv([
+      ['CERBERUS_BIN', binary],
+      ['CERBERUS_IMAGE', plan.image],
+      ['CERBERUS_EXPECT_VERSION', plan.sharedVersion],
+      [CANDIDATE_REGISTRY_ENV, loaded?.container ?? ''],
+    ]);
+
+    notice(
+      `migration-artifact: ${plan.source} plan — binary ${binary} reports ${version}, ` +
+        `compose runs ${plan.image}` +
+        (plan.sharedVersion === ''
+          ? ' (CLI and server are separate builds; each is held to its own stamp)'
+          : ` (CLI and server share the ${plan.sharedVersion} stamp)`),
+    );
+  } catch (cause) {
+    if (loaded) stopLoopbackRegistry(loaded.container);
+    throw cause;
   }
+}
 
-  const version = probeVersion(binary, plan);
-
-  exportEnv([
-    ['CERBERUS_BIN', binary],
-    ['CERBERUS_IMAGE', plan.image],
-    ['CERBERUS_EXPECT_VERSION', plan.sharedVersion],
-  ]);
-
-  notice(
-    `migration-artifact: ${plan.source} plan — binary ${binary} reports ${version}, ` +
-      `compose runs ${plan.image}` +
-      (plan.sharedVersion === ''
-        ? ' (CLI and server are separate builds; each is held to its own stamp)'
-        : ` (CLI and server share the ${plan.sharedVersion} stamp)`),
-  );
+function cleanupArtifact() {
+  const container = process.env[CANDIDATE_REGISTRY_ENV];
+  if (stopLoopbackRegistry(container)) {
+    notice(`migration-artifact: removed candidate registry ${container}`);
+  } else {
+    notice('migration-artifact: no live candidate registry to remove');
+  }
 }
 
 if (import.meta.url === `file://${process.argv[1]}`) {
-  main();
+  try {
+    const mode = process.argv[2] || 'resolve';
+    if (mode === 'resolve') resolveArtifact();
+    else if (mode === 'cleanup') cleanupArtifact();
+    else throw new Error(`unknown mode ${JSON.stringify(mode)}; expected resolve or cleanup`);
+  } catch (cause) {
+    error(`migration-artifact: ${cause instanceof Error ? cause.message : String(cause)}`);
+    process.exitCode = 1;
+  }
 }

--- a/.github/scripts/migration-artifact.test.mjs
+++ b/.github/scripts/migration-artifact.test.mjs
@@ -6,11 +6,9 @@
 // has none either, so without this suite every edit to resolvePlan would be
 // unverified until a release is cut.
 //
-// The headline case is the half-supplied input pair: a release lane wired with
-// `cerberus_image` but no `expect_version` must FAIL, not quietly degrade to a
-// from-source build under an artifact-shaped job name. Its negative control is
-// the positive path — both inputs empty is the PR/dispatch shape that keeps the
-// currently-green lane green.
+// The headline case is a partially supplied candidate identity: it must fail,
+// not quietly degrade to a from-source build under an artifact-shaped job name.
+// Its negative control is the source path, where all candidate inputs are empty.
 
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
@@ -20,14 +18,29 @@ import {
   SOURCE_BUILD_VERSION,
   LOCAL_IMAGE_TAG,
   IMAGE_BINARY_PATH,
+  loopbackRegistryEndpoint,
   PAIRED_INPUTS_MESSAGE,
+  CANDIDATE_REGISTRY_ENV,
+  stopLoopbackRegistry,
 } from './migration-artifact.mjs';
 
-const releaseImage = 'ghcr.io/tsouza/cerberus:1.11.2';
 const releaseVersion = '1.11.2';
+const candidate = {
+  candidateDir: 'build/release-candidate',
+  candidateDigest: `sha256:${'a'.repeat(64)}`,
+  expectVersion: releaseVersion,
+  sourceSHA: 'b'.repeat(40),
+  sourceTree: 'c'.repeat(40),
+};
 
 test('positive control: neither input supplied resolves the source plan', () => {
-  const plan = resolvePlan({ image: '', expectVersion: '' });
+  const plan = resolvePlan({
+    candidateDir: '',
+    candidateDigest: '',
+    expectVersion: '',
+    sourceSHA: '',
+    sourceTree: '',
+  });
 
   assert.equal(plan.source, 'source');
   assert.equal(plan.image, LOCAL_IMAGE_TAG);
@@ -41,44 +54,44 @@ test('positive control: neither input supplied resolves the source plan', () => 
 });
 
 test('positive control: undefined inputs are the same as empty ones', () => {
-  assert.deepEqual(resolvePlan({}), resolvePlan({ image: '', expectVersion: '' }));
-  assert.deepEqual(resolvePlan(), resolvePlan({ image: '', expectVersion: '' }));
+  assert.deepEqual(resolvePlan({}), resolvePlan({
+    candidateDir: '',
+    candidateDigest: '',
+    expectVersion: '',
+    sourceSHA: '',
+    sourceTree: '',
+  }));
+  assert.deepEqual(resolvePlan(), resolvePlan({}));
 });
 
 test('whitespace-only inputs count as absent, not as a half-supplied pair', () => {
-  const plan = resolvePlan({ image: '   ', expectVersion: '\n' });
+  const plan = resolvePlan({ candidateDir: '   ', expectVersion: '\n' });
   assert.equal(plan.source, 'source');
 });
 
-test('an image without an expected version is refused', () => {
-  assert.throws(
-    () => resolvePlan({ image: releaseImage, expectVersion: '' }),
-    (err) => {
-      assert.equal(err.message, PAIRED_INPUTS_MESSAGE);
-      return true;
-    },
-  );
+test('every partial candidate identity is refused', () => {
+  for (const key of Object.keys(candidate)) {
+    const partial = { ...candidate, [key]: '' };
+    assert.throws(
+      () => resolvePlan(partial),
+      (err) => {
+        assert.equal(err.message, PAIRED_INPUTS_MESSAGE);
+        return true;
+      },
+      key,
+    );
+  }
 });
 
-test('an expected version without an image is refused', () => {
-  assert.throws(
-    () => resolvePlan({ image: '', expectVersion: releaseVersion }),
-    (err) => {
-      assert.equal(err.message, PAIRED_INPUTS_MESSAGE);
-      return true;
-    },
-  );
-});
-
-test('mutation control: a half pair never coerces to the source default', () => {
+test('mutation control: a partial identity never coerces to the source default', () => {
   // The tempting "fix" for the half-supplied case is to fill the missing half
   // in from the source defaults. That would run a `go build` while the job name
-  // and the notice both claim a released artifact — the exact hollow green this
+  // and the notice both claim a candidate artifact — the exact hollow green this
   // module exists to prevent — so assert the refusal is a THROW and that no
   // plan carrying the source stamp escapes.
   let escaped = null;
   try {
-    escaped = resolvePlan({ image: releaseImage, expectVersion: '' });
+    escaped = resolvePlan({ ...candidate, candidateDigest: '' });
   } catch {
     escaped = null;
   }
@@ -86,18 +99,21 @@ test('mutation control: a half pair never coerces to the source default', () => 
 
   let escapedInverse = null;
   try {
-    escapedInverse = resolvePlan({ image: '', expectVersion: releaseVersion });
+    escapedInverse = resolvePlan({ expectVersion: releaseVersion });
   } catch {
     escapedInverse = null;
   }
   assert.equal(escapedInverse, null, 'resolvePlan invented an image for a version-only input');
 });
 
-test('a full pair carries the ref and the version through verbatim', () => {
-  const plan = resolvePlan({ image: releaseImage, expectVersion: releaseVersion });
+test('a complete candidate identity carries every binding through verbatim', () => {
+  const plan = resolvePlan(candidate);
 
-  assert.equal(plan.source, 'image');
-  assert.equal(plan.image, releaseImage);
+  assert.equal(plan.source, 'candidate');
+  assert.equal(plan.candidateDir, candidate.candidateDir);
+  assert.equal(plan.candidateDigest, candidate.candidateDigest);
+  assert.equal(plan.sourceSHA, candidate.sourceSHA);
+  assert.equal(plan.sourceTree, candidate.sourceTree);
   assert.equal(plan.expectVersion, releaseVersion);
   // CLI and server are the same bytes on this path, so the stamp is shared and
   // BOTH the binary probe and the live /info probe assert against it.
@@ -109,4 +125,71 @@ test('the extraction path is the image path the release Dockerfiles write', () =
   // Both Dockerfile and Dockerfile.local COPY the binary here and the compose
   // healthcheck execs it here; a drift would make `docker cp` fail opaquely.
   assert.equal(IMAGE_BINARY_PATH, '/usr/local/bin/cerberus');
+});
+
+test('the candidate registry uses one Docker-assigned loopback port', () => {
+  assert.equal(loopbackRegistryEndpoint('127.0.0.1:49153\n'), '127.0.0.1:49153');
+  for (const malformed of [
+    '',
+    '0.0.0.0:49153',
+    '127.0.0.1:0',
+    '127.0.0.1:65536',
+    '127.0.0.1:not-a-port',
+    '127.0.0.1:49153\n127.0.0.1:49154\n',
+  ]) {
+    assert.throws(() => loopbackRegistryEndpoint(malformed), /loopback registry/);
+  }
+});
+
+test('the candidate registry survives resolution and has one constrained cleanup handle', () => {
+  assert.equal(CANDIDATE_REGISTRY_ENV, 'CERBERUS_CANDIDATE_REGISTRY_CONTAINER');
+
+  const calls = [];
+  const runner = (command, args) => {
+    calls.push([command, args]);
+    return { status: 0, stdout: args.at(-1), stderr: '' };
+  };
+  assert.equal(
+    stopLoopbackRegistry('cerberus-migration-candidate-registry-123', runner),
+    true,
+  );
+  assert.deepEqual(calls, [
+    [
+      'docker',
+      ['rm', '-f', 'cerberus-migration-candidate-registry-123'],
+    ],
+  ]);
+});
+
+test('candidate registry cleanup is safe, idempotent, and loud on real failure', () => {
+  let invoked = false;
+  const never = () => {
+    invoked = true;
+    throw new Error('runner must not be called');
+  };
+  assert.equal(stopLoopbackRegistry('', never), false);
+  assert.equal(invoked, false);
+  assert.throws(
+    () => stopLoopbackRegistry('unrelated-container', never),
+    /refusing to remove invalid candidate registry/,
+  );
+  assert.equal(invoked, false);
+
+  assert.equal(
+    stopLoopbackRegistry('cerberus-migration-candidate-registry-123', () => ({
+      status: 1,
+      stdout: '',
+      stderr: 'No such container',
+    })),
+    false,
+  );
+  assert.throws(
+    () =>
+      stopLoopbackRegistry('cerberus-migration-candidate-registry-123', () => ({
+        status: 1,
+        stdout: '',
+        stderr: 'permission denied',
+      })),
+    /could not be removed/,
+  );
 });

--- a/.github/scripts/mutation-matrix.mjs
+++ b/.github/scripts/mutation-matrix.mjs
@@ -55,7 +55,7 @@ import { execFileSync } from 'node:child_process';
 import { readFileSync, readdirSync, statSync } from 'node:fs';
 import { join } from 'node:path';
 
-import { error, log, notice, setOutput } from './lib/gh.mjs';
+import { error, git, log, notice, setOutput } from './lib/gh.mjs';
 import { changedPaths, matchesAny, normalise, runsFullLane, underPrefix } from './lib/scope-gate.mjs';
 import { HARNESS_PATHS, MUTATION_PRODUCTION_GLOBS, PHASES } from './mutation-phases.mjs';
 
@@ -454,6 +454,62 @@ export function selectPhases({
   };
 }
 
+// changedLineProjection returns the exact merge-base ref and per-path added-line
+// counts used by gremlins' native `--diff` filter. A malformed or unavailable
+// projection is null: callers must run the selected phase in full.
+export function changedLineProjection({ baseSha, headSha, runGit = git }) {
+  const base = String(baseSha ?? '').trim();
+  const head = String(headSha ?? '').trim();
+  if (!/^[0-9a-f]{7,64}$/i.test(base) || !/^[0-9a-f]{7,64}$/i.test(head)) return null;
+
+  const mergeBase = runGit(['merge-base', base, head]);
+  const ref = String(mergeBase?.stdout ?? '').trim();
+  if (mergeBase?.status !== 0 || !/^[0-9a-f]{40,64}$/i.test(ref)) return null;
+
+  // `--no-renames` makes the NUL-delimited numstat grammar one fixed record
+  // shape. A rename with content becomes delete + add, which safely treats the
+  // new file as entirely changed rather than under-selecting its mutants.
+  const diff = runGit(['diff', '--numstat', '-z', '--no-renames', ref, head]);
+  if (diff?.status !== 0) return null;
+  const additions = new Map();
+  for (const record of String(diff.stdout ?? '').split('\0')) {
+    if (record === '') continue;
+    const fields = record.split('\t');
+    if (fields.length !== 3 || fields[2] === '') return null;
+    const [added, deleted, path] = fields;
+    if ((added !== '-' && !/^[0-9]+$/.test(added)) || (deleted !== '-' && !/^[0-9]+$/.test(deleted))) {
+      return null;
+    }
+    additions.set(normalise(path), added === '-' ? null : Number(added));
+  }
+  return { ref, additions };
+}
+
+function mutableProductionGo(path) {
+  return path.endsWith('.go') && !path.endsWith('_test.go');
+}
+
+// addChangedLineRefs chooses incremental mutation independently per phase. A
+// phase is incremental only when every changed path that selected it is a
+// production Go file with at least one added line. Test, fixture, binary,
+// harness, delete-only, and unknown changes deliberately keep the full phase:
+// each can change the efficacy of mutants outside the edited lines.
+export function addChangedLineRefs({ phases, changed, projection }) {
+  return phases.map((phase) => {
+    if (!(changed instanceof Set) || projection === null) return { ...phase, diff_ref: '' };
+    const claimed = [...changed].filter((path) => phaseClaims(phase, path));
+    const incremental =
+      claimed.length > 0 &&
+      claimed.every(
+        (path) =>
+          mutableProductionGo(path) &&
+          Number.isSafeInteger(projection.additions.get(normalise(path))) &&
+          projection.additions.get(normalise(path)) > 0,
+      );
+    return { ...phase, diff_ref: incremental ? projection.ref : '' };
+  });
+}
+
 // ---------------------------------------------------------------------------
 // driver
 // ---------------------------------------------------------------------------
@@ -526,8 +582,19 @@ function main() {
   }
   if (gaps.length > 0) process.exit(1);
 
+  const projection =
+    changed === null
+      ? null
+      : changedLineProjection({
+          baseSha: process.env.BASE_SHA,
+          headSha: process.env.HEAD_SHA,
+        });
+  const matrixPhases = addChangedLineRefs({ phases, changed, projection });
+  const incrementalCount = matrixPhases.filter((phase) => phase.diff_ref !== '').length;
+
   notice(
-    `mutation-matrix: running ${phases.length}/${PHASES.length} phases — ${reason}` +
+    `mutation-matrix: running ${phases.length}/${PHASES.length} phases — ${reason}; ` +
+      `${incrementalCount} changed-line, ${matrixPhases.length - incrementalCount} full` +
       (phases.length > 0 ? ` (${phases.map((p) => p.phase).join(', ')})` : ''),
   );
 
@@ -537,7 +604,7 @@ function main() {
   // a job-level `if:` cannot introspect a matrix: without it, a SKIPPED `mutate`
   // is indistinguishable to the aggregator from a selection that was legitimately
   // empty — which is precisely the ambiguity this lane is being fixed to remove.
-  setOutput('matrix', JSON.stringify({ include: phases }));
+  setOutput('matrix', JSON.stringify({ include: matrixPhases }));
   setOutput('has_phases', String(phases.length > 0));
 }
 

--- a/.github/scripts/mutation-matrix.test.mjs
+++ b/.github/scripts/mutation-matrix.test.mjs
@@ -21,6 +21,8 @@ import { readFileSync } from 'node:fs';
 import { test } from 'node:test';
 
 import {
+  addChangedLineRefs,
+  changedLineProjection,
   MUTATION_LANE_ID,
   MUTATION_MIN_EFFICACY,
   MUTATION_REGISTRY_PATH,
@@ -238,7 +240,94 @@ test('an uncomputable diff runs the full matrix rather than nothing', () => {
   assert.match(result.reason, /could not be computed/);
 });
 
+test('changed-line projection is bound to the exact merge base and added-line roster', () => {
+  const base = 'a'.repeat(40);
+  const head = 'b'.repeat(40);
+  const mergeBase = 'c'.repeat(40);
+  const calls = [];
+  const projection = changedLineProjection({
+    baseSha: base,
+    headSha: head,
+    runGit: (args) => {
+      calls.push(args);
+      if (args[0] === 'merge-base') return { status: 0, stdout: `${mergeBase}\n`, stderr: '' };
+      return {
+        status: 0,
+        stdout:
+          [
+            '4\t2\tinternal/chplan/plan.go',
+            '0\t7\tinternal/chsql/deleted.go',
+            '-\t-\tinternal/chsql/blob.go',
+          ].join('\0') + '\0',
+        stderr: '',
+      };
+    },
+  });
+  assert.deepEqual(calls, [
+    ['merge-base', base, head],
+    ['diff', '--numstat', '-z', '--no-renames', mergeBase, head],
+  ]);
+  assert.equal(projection.ref, mergeBase);
+  assert.equal(projection.additions.get('internal/chplan/plan.go'), 4);
+  assert.equal(projection.additions.get('internal/chsql/deleted.go'), 0);
+  assert.equal(projection.additions.get('internal/chsql/blob.go'), null);
+});
+
+test('changed-line projection fails closed on missing refs, git failure, and malformed numstat', () => {
+  assert.equal(changedLineProjection({ baseSha: '', headSha: 'b'.repeat(40) }), null);
+  assert.equal(
+    changedLineProjection({
+      baseSha: 'a'.repeat(40),
+      headSha: 'b'.repeat(40),
+      runGit: () => ({ status: 1, stdout: '', stderr: 'missing' }),
+    }),
+    null,
+  );
+  let call = 0;
+  assert.equal(
+    changedLineProjection({
+      baseSha: 'a'.repeat(40),
+      headSha: 'b'.repeat(40),
+      runGit: () =>
+        call++ === 0
+          ? { status: 0, stdout: `${'c'.repeat(40)}\n`, stderr: '' }
+          : { status: 0, stdout: 'not-numstat\0', stderr: '' },
+    }),
+    null,
+  );
+});
+
+test('only production additions receive changed-line mutation refs', () => {
+  const ref = 'c'.repeat(40);
+  const phase = PHASES.find((candidate) => candidate.phase === 'phase1');
+  const project = (changed, additions) =>
+    addChangedLineRefs({
+      phases: [phase],
+      changed: new Set(changed),
+      projection: { ref, additions: new Map(additions) },
+    })[0].diff_ref;
+
+  assert.equal(project(['internal/chplan/plan.go'], [['internal/chplan/plan.go', 3]]), ref);
+  assert.equal(project(['internal/chplan/plan.go'], [['internal/chplan/plan.go', 0]]), '');
+  assert.equal(project(['internal/chplan/plan_test.go'], [['internal/chplan/plan_test.go', 3]]), '');
+  assert.equal(
+    project(
+      ['internal/chplan/plan.go', 'internal/chplan/plan_test.go'],
+      [
+        ['internal/chplan/plan.go', 3],
+        ['internal/chplan/plan_test.go', 2],
+      ],
+    ),
+    '',
+  );
+  assert.equal(
+    addChangedLineRefs({ phases: [phase], changed: null, projection: null })[0].diff_ref,
+    '',
+  );
+});
+
 test('a change to the lane harness runs the full matrix', () => {
+  assert.equal(HARNESS_PATHS.includes('.github/scripts/mutation-run.mjs'), true);
   for (const path of HARNESS_PATHS) {
     assert.equal(select([path]).phases.length, PHASES.length, path);
   }

--- a/.github/scripts/mutation-phases.mjs
+++ b/.github/scripts/mutation-phases.mjs
@@ -325,6 +325,7 @@ export const HARNESS_PATHS = [
   '.github/workflows/mutation.yml',
   '.github/scripts/mutation-phases.mjs',
   '.github/scripts/mutation-matrix.mjs',
+  '.github/scripts/mutation-run.mjs',
   '.github/scripts/gremlins-threshold.mjs',
   '.github/scripts/lib/scope-gate.mjs',
   '.gremlins.yaml',

--- a/.github/scripts/mutation-run.mjs
+++ b/.github/scripts/mutation-run.mjs
@@ -1,0 +1,85 @@
+// mutation-run.mjs — run one mutation phase with safe changed-line fallback.
+//
+// Required env: SCOPE, REPORT, MUTANT_TIMEOUT_MAX.
+// Optional env: WORKERS, EXCLUDE_FILES, DIFF_REF.
+//
+// A non-empty DIFF_REF first invokes gremlins' native merge-base line filter.
+// If that report contains zero executable mutants, the script deletes it and
+// reruns the phase without --diff. This makes comment-only or otherwise
+// mutation-free edits conservative full checks instead of hollow greens.
+
+import { spawnSync } from 'node:child_process';
+import { existsSync, readFileSync, unlinkSync } from 'node:fs';
+import process from 'node:process';
+
+import { error, notice } from './lib/gh.mjs';
+
+function required(name) {
+  const value = String(process.env[name] ?? '').trim();
+  if (value === '') throw new Error(`${name} is required`);
+  return value;
+}
+
+function reportTotal(path) {
+  let document;
+  try {
+    document = JSON.parse(readFileSync(path, 'utf8'));
+  } catch (cause) {
+    throw new Error(`cannot read gremlins report ${path}: ${cause.message}`);
+  }
+  if (!Number.isSafeInteger(document.mutants_total) || document.mutants_total < 0) {
+    throw new Error(`gremlins report ${path} has invalid mutants_total`);
+  }
+  return document.mutants_total;
+}
+
+function runGremlins({ report, diffRef = '' }) {
+  const args = [
+    'unleash',
+    '--output',
+    report,
+    '--on-shutdown-status=not-run',
+    '--timeout-max',
+    required('MUTANT_TIMEOUT_MAX'),
+  ];
+  const workers = String(process.env.WORKERS ?? '').trim();
+  if (workers !== '' && workers !== '0') {
+    if (!/^[1-9][0-9]*$/.test(workers)) throw new Error(`WORKERS is invalid: ${workers}`);
+    args.push('--workers', workers);
+  }
+  const exclude = String(process.env.EXCLUDE_FILES ?? '').trim();
+  if (exclude !== '') args.push('--exclude-files', exclude);
+  if (diffRef !== '') args.push('--diff', diffRef);
+  args.push(required('SCOPE'));
+
+  const result = spawnSync('gremlins', args, { stdio: 'inherit' });
+  if (result.error) throw new Error(`cannot execute gremlins: ${result.error.message}`);
+  if (result.status !== 0) throw new Error(`gremlins exited ${result.status}`);
+  if (!existsSync(report)) throw new Error(`gremlins produced no report at ${report}`);
+}
+
+function main() {
+  const report = required('REPORT');
+  const diffRef = String(process.env.DIFF_REF ?? '').trim();
+  if (diffRef !== '' && !/^[0-9a-f]{40,64}$/i.test(diffRef)) {
+    throw new Error(`DIFF_REF is invalid: ${diffRef}`);
+  }
+  if (existsSync(report)) throw new Error(`refusing stale gremlins report ${report}`);
+
+  runGremlins({ report, diffRef });
+  if (diffRef !== '' && reportTotal(report) === 0) {
+    notice('changed-line mutation found zero executable mutants; rerunning the full phase');
+    unlinkSync(report);
+    runGremlins({ report });
+  }
+  const total = reportTotal(report);
+  if (total <= 0) throw new Error('mutation phase executed zero mutants after full fallback');
+  notice(`mutation phase executed ${total} mutant(s)${diffRef === '' ? ' in full' : ''}`);
+}
+
+try {
+  main();
+} catch (cause) {
+  error(cause instanceof Error ? cause.message : String(cause));
+  process.exit(1);
+}

--- a/.github/scripts/mutation-run.test.mjs
+++ b/.github/scripts/mutation-run.test.mjs
@@ -1,0 +1,86 @@
+import assert from 'node:assert/strict';
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { test } from 'node:test';
+
+// The runner's process boundary is intentional: it must prove the exact env
+// contract and two-invocation fallback, not a helper that bypasses main().
+import { spawnSync } from 'node:child_process';
+
+function fixture(t, totals) {
+  const root = mkdtempSync(join(tmpdir(), 'mutation-run-'));
+  t.after(() => rmSync(root, { recursive: true, force: true }));
+  const calls = join(root, 'calls.jsonl');
+  const fake = join(root, 'gremlins');
+  writeFileSync(calls, '');
+  writeFileSync(
+    fake,
+    `#!/usr/bin/env node
+const fs = require('node:fs');
+const args = process.argv.slice(2);
+fs.appendFileSync(${JSON.stringify(calls)}, JSON.stringify(args) + '\\n');
+const report = args[args.indexOf('--output') + 1];
+const totals = ${JSON.stringify(totals)};
+const call = fs.readFileSync(${JSON.stringify(calls)}, 'utf8').trim().split('\\n').length - 1;
+fs.writeFileSync(report, JSON.stringify({ mutants_total: totals[call] }));
+`,
+    { mode: 0o755 },
+  );
+  return { root, calls, fake };
+}
+
+function run(root, env = {}) {
+  return spawnSync(process.execPath, ['.github/scripts/mutation-run.mjs'], {
+    cwd: process.cwd(),
+    encoding: 'utf8',
+    env: {
+      ...process.env,
+      PATH: `${root}:${process.env.PATH}`,
+      SCOPE: './internal/chplan',
+      REPORT: join(root, 'gremlins.json'),
+      MUTANT_TIMEOUT_MAX: '15s',
+      WORKERS: '0',
+      EXCLUDE_FILES: '',
+      ...env,
+    },
+  });
+}
+
+test('changed-line execution stays incremental when it executes mutants', (t) => {
+  const { root, calls } = fixture(t, [3]);
+  const result = run(root, { DIFF_REF: 'a'.repeat(40) });
+  assert.equal(result.status, 0, result.stderr);
+  const invocations = readFileSync(calls, 'utf8').trim().split('\n').map(JSON.parse);
+  assert.equal(invocations.length, 1);
+  assert.deepEqual(invocations[0].slice(-3), ['--diff', 'a'.repeat(40), './internal/chplan']);
+});
+
+test('zero changed-line mutants trigger one full fallback', (t) => {
+  const { root, calls } = fixture(t, [0, 7]);
+  const result = run(root, { DIFF_REF: 'a'.repeat(40) });
+  assert.equal(result.status, 0, result.stderr);
+  const invocations = readFileSync(calls, 'utf8').trim().split('\n').map(JSON.parse);
+  assert.equal(invocations.length, 2);
+  assert.equal(invocations[0].includes('--diff'), true);
+  assert.equal(invocations[1].includes('--diff'), false);
+});
+
+test('zero mutants after full fallback fail closed', (t) => {
+  const { root } = fixture(t, [0, 0]);
+  const result = run(root, { DIFF_REF: 'a'.repeat(40) });
+  assert.equal(result.status, 1);
+  assert.match(`${result.stdout}\n${result.stderr}`, /executed zero mutants after full fallback/);
+});
+
+test('invalid diff refs and stale reports fail before gremlins runs', (t) => {
+  const { root, calls } = fixture(t, [3]);
+  let result = run(root, { DIFF_REF: 'main' });
+  assert.equal(result.status, 1);
+  assert.equal(readFileSync(calls, 'utf8'), '');
+
+  writeFileSync(join(root, 'gremlins.json'), '{}');
+  result = run(root, { DIFF_REF: '' });
+  assert.equal(result.status, 1);
+  assert.match(`${result.stdout}\n${result.stderr}`, /refusing stale gremlins report/);
+});

--- a/.github/scripts/release-artifact-validator.mjs
+++ b/.github/scripts/release-artifact-validator.mjs
@@ -1,0 +1,798 @@
+// release-artifact-validator.mjs — semantic validation for every package that
+// can be published from an unpublished release candidate.
+//
+// The validator never extracts an archive. It parses bounded gzip/USTAR bytes
+// in memory, rejects ambiguous or unsafe members, and binds wrapper metadata
+// back to the exact candidate bytes. Candidate staging binds the selected
+// GoReleaser outputs; sealing and every later verification re-check the closed
+// package set without extracting it.
+
+import { createHash } from "node:crypto";
+import { readFileSync } from "node:fs";
+import { join, resolve } from "node:path";
+import { TextDecoder } from "node:util";
+import { gunzipSync } from "node:zlib";
+
+import { caskPortabilityProblems } from "./brew-smoke.mjs";
+
+export const RELEASE_TARGETS = Object.freeze([
+  Object.freeze({ goos: "darwin", goarch: "amd64" }),
+  Object.freeze({ goos: "darwin", goarch: "arm64" }),
+  Object.freeze({ goos: "linux", goarch: "amd64" }),
+  Object.freeze({ goos: "linux", goarch: "arm64" }),
+]);
+
+export const ARCHIVE_LIMITS = Object.freeze({
+  maxCompressedBytes: 64 * 1024 * 1024,
+  maxExpandedBytes: 128 * 1024 * 1024,
+  maxMemberBytes: 128 * 1024 * 1024,
+  maxMembers: 2048,
+});
+export const APP_ARCHIVE_LIMITS = Object.freeze({
+  ...ARCHIVE_LIMITS,
+  maxMembers: 16,
+});
+export const CHART_ARCHIVE_LIMITS = Object.freeze({
+  maxCompressedBytes: 8 * 1024 * 1024,
+  maxExpandedBytes: 32 * 1024 * 1024,
+  maxMemberBytes: 16 * 1024 * 1024,
+  maxMembers: 512,
+});
+
+const APP_ARCHIVE_FILES = Object.freeze([
+  "CHANGELOG.md",
+  "LICENSE",
+  "README.md",
+  "cerberus",
+]);
+const APP_BINARY = "cerberus";
+const CHART_NAME = "cerberus";
+const CHART_REQUIRED_FILES = Object.freeze([
+  `${CHART_NAME}/Chart.yaml`,
+  `${CHART_NAME}/values.yaml`,
+  `${CHART_NAME}/values.schema.json`,
+]);
+const CHART_REQUIRED_SCALARS = Object.freeze({
+  apiVersion: "v2",
+  name: CHART_NAME,
+  type: "application",
+});
+const VERSION_RE = /^\d+\.\d+\.\d+(?:-[0-9A-Za-z][0-9A-Za-z.-]*)?$/;
+const APP_TAG_RE = /^v\d+\.\d+\.\d+(?:-[0-9A-Za-z][0-9A-Za-z.-]*)?$/;
+const HTTPS_SOURCE_RE = /^https:\/\/[^\s?#/]+\/[^\s?#/]+\/[^\s?#/]+$/;
+const SHA256_RE = /^[0-9a-f]{64}$/;
+const TARGET_KEY_RE = /^(darwin|linux)\/(amd64|arm64)$/;
+const CASK_ARTIFACT_RE = /^(app|artifact|audio_unit_plugin|bash_completion|binary|colorpicker|dictionary|fish_completion|font|input_method|installer|internet_plugin|keyboard_layout|manpage|mdimporter|pkg|prefpane|qlplugin|screen_saver|service|suite|vst3_plugin|vst_plugin|zsh_completion)\b/;
+
+const TAR_BLOCK_BYTES = 512;
+const TAR_END_BLOCKS = 2;
+const TAR_END_BYTES = TAR_BLOCK_BYTES * TAR_END_BLOCKS;
+const TAR_HEADER = Object.freeze({
+  nameStart: 0,
+  nameEnd: 100,
+  modeStart: 100,
+  modeEnd: 108,
+  sizeStart: 124,
+  sizeEnd: 136,
+  checksumStart: 148,
+  checksumEnd: 156,
+  type: 156,
+  linkStart: 157,
+  linkEnd: 257,
+  magicStart: 257,
+  magicEnd: 263,
+  prefixStart: 345,
+  prefixEnd: 500,
+});
+const TAR_CHECKSUM_SPACE = 0x20;
+const TAR_TYPE_REGULAR_ASCII = 0x30;
+const TAR_TYPE_DIRECTORY_ASCII = 0x35;
+const TAR_USTAR_MAGIC = Buffer.from([0x75, 0x73, 0x74, 0x61, 0x72, 0x00]);
+
+const EXECUTABLE_MODE_MASK = 0o111;
+const SPECIAL_MODE_MASK = 0o7000;
+const ELF_MIN_HEADER_BYTES = 20;
+const ELF_MAGIC = Buffer.from([0x7f, 0x45, 0x4c, 0x46]);
+const ELF_CLASS_64 = 2;
+const ELF_DATA_LITTLE_ENDIAN = 1;
+const ELF_VERSION_CURRENT = 1;
+const ELF_MACHINE_OFFSET = 18;
+const ELF_MACHINE = Object.freeze({ amd64: 0x3e, arm64: 0xb7 });
+const MACHO_MIN_HEADER_BYTES = 12;
+const MACHO_MAGIC_64 = 0xfeedfacf;
+const MACHO_CPU_OFFSET = 4;
+const MACHO_CPU = Object.freeze({ amd64: 0x01000007, arm64: 0x0100000c });
+
+const fatalUtf8 = new TextDecoder("utf-8", { fatal: true });
+
+export class ArtifactValidationError extends Error {
+  constructor(problems) {
+    const list = Array.isArray(problems) ? problems : [String(problems)];
+    super(`release artifacts are invalid:\n${list.map((item) => `- ${item}`).join("\n")}`);
+    this.name = "ArtifactValidationError";
+    this.problems = list;
+  }
+}
+
+function fail(problem) {
+  throw new ArtifactValidationError([problem]);
+}
+
+function asBuffer(value, label) {
+  if (Buffer.isBuffer(value)) return value;
+  if (value instanceof Uint8Array) {
+    return Buffer.from(value.buffer, value.byteOffset, value.byteLength);
+  }
+  fail(`${label} must be bytes`);
+}
+
+function decodeUtf8(value, label) {
+  const bytes = asBuffer(value, label);
+  try {
+    return fatalUtf8.decode(bytes);
+  } catch (cause) {
+    fail(`${label} is not valid UTF-8: ${cause.message}`);
+  }
+}
+
+function requireVersion(value, label) {
+  if (typeof value !== "string" || !VERSION_RE.test(value)) {
+    fail(`${label} must be a bare semantic version`);
+  }
+  return value;
+}
+
+function targetKey(target) {
+  return `${target.goos}/${target.goarch}`;
+}
+
+function normaliseLimits(overrides = {}) {
+  const limits = { ...ARCHIVE_LIMITS, ...overrides };
+  for (const [name, value] of Object.entries(limits)) {
+    if (!Number.isSafeInteger(value) || value <= 0) {
+      fail(`archive limit ${name} must be a positive safe integer`);
+    }
+  }
+  return limits;
+}
+
+function isZeroBlock(block) {
+  return block.every((byte) => byte === 0);
+}
+
+function tarString(header, start, end, label) {
+  const field = header.subarray(start, end);
+  const nul = field.indexOf(0);
+  const body = nul < 0 ? field : field.subarray(0, nul);
+  if (nul >= 0 && field.subarray(nul).some((byte) => byte !== 0)) {
+    fail(`${label} has non-NUL bytes after its terminator`);
+  }
+  try {
+    return fatalUtf8.decode(body);
+  } catch (cause) {
+    fail(`${label} is not valid UTF-8: ${cause.message}`);
+  }
+}
+
+function tarOctal(header, start, end, label) {
+  const bytes = header.subarray(start, end);
+  if (bytes[0] !== undefined && (bytes[0] & 0x80) !== 0) {
+    fail(`${label} uses unsupported base-256 encoding`);
+  }
+  for (const byte of bytes) {
+    const octalDigit = byte >= 0x30 && byte <= 0x37;
+    if (byte !== 0 && byte !== TAR_CHECKSUM_SPACE && !octalDigit) {
+      fail(`${label} is not strict octal`);
+    }
+  }
+  const text = bytes.toString("ascii").replace(/[\0 ]+$/g, "").replace(/^ +/g, "");
+  if (!/^[0-7]+$/.test(text)) fail(`${label} is empty or malformed octal`);
+  const value = Number.parseInt(text, 8);
+  if (!Number.isSafeInteger(value)) fail(`${label} exceeds the safe integer range`);
+  return value;
+}
+
+function validateHeaderChecksum(header, label) {
+  const declared = tarOctal(
+    header,
+    TAR_HEADER.checksumStart,
+    TAR_HEADER.checksumEnd,
+    `${label} checksum`,
+  );
+  let actual = 0;
+  for (let index = 0; index < TAR_BLOCK_BYTES; index += 1) {
+    actual +=
+      index >= TAR_HEADER.checksumStart && index < TAR_HEADER.checksumEnd
+        ? TAR_CHECKSUM_SPACE
+        : header[index];
+  }
+  if (declared !== actual) {
+    fail(`${label} checksum is ${declared}, want ${actual}`);
+  }
+}
+
+function canonicalTarPath(rawPath, type, label) {
+  if (!rawPath || rawPath.includes("\\") || rawPath.startsWith("/")) {
+    fail(`${label} has unsafe path ${JSON.stringify(rawPath)}`);
+  }
+  const directorySlash = type === "directory" && rawPath.endsWith("/");
+  const path = directorySlash ? rawPath.slice(0, -1) : rawPath;
+  if (!path || path.endsWith("/")) fail(`${label} has non-canonical path ${JSON.stringify(rawPath)}`);
+  const parts = path.split("/");
+  if (parts.some((part) => part === "" || part === "." || part === "..")) {
+    fail(`${label} has unsafe path ${JSON.stringify(rawPath)}`);
+  }
+  return parts.join("/");
+}
+
+/** Parse a gzip-compressed USTAR archive without extracting it. */
+export function parseTarGz(value, { label = "archive", limits: overrideLimits = {} } = {}) {
+  const compressed = asBuffer(value, label);
+  const limits = normaliseLimits(overrideLimits);
+  if (compressed.length > limits.maxCompressedBytes) {
+    fail(`${label} compressed size ${compressed.length} exceeds ${limits.maxCompressedBytes}`);
+  }
+
+  let expanded;
+  try {
+    expanded = gunzipSync(compressed, { maxOutputLength: limits.maxExpandedBytes });
+  } catch (cause) {
+    fail(`${label} is not a bounded valid gzip stream: ${cause.message}`);
+  }
+  if (expanded.length === 0 || expanded.length % TAR_BLOCK_BYTES !== 0) {
+    fail(`${label} expanded tar length is not a non-zero multiple of ${TAR_BLOCK_BYTES}`);
+  }
+
+  const members = new Map();
+  let offset = 0;
+  while (offset < expanded.length) {
+    const header = expanded.subarray(offset, offset + TAR_BLOCK_BYTES);
+    if (header.length !== TAR_BLOCK_BYTES) fail(`${label} has a truncated tar header`);
+    if (isZeroBlock(header)) {
+      if (offset + TAR_END_BYTES > expanded.length) {
+        fail(`${label} has only one tar end block`);
+      }
+      const second = expanded.subarray(
+        offset + TAR_BLOCK_BYTES,
+        offset + TAR_END_BYTES,
+      );
+      if (!isZeroBlock(second)) fail(`${label} has a malformed tar end marker`);
+      if (!expanded.subarray(offset + TAR_END_BYTES).every((byte) => byte === 0)) {
+        fail(`${label} contains non-zero data after its tar end marker`);
+      }
+      return members;
+    }
+
+    if (members.size >= limits.maxMembers) {
+      fail(`${label} contains more than ${limits.maxMembers} members`);
+    }
+    const memberLabel = `${label} member ${members.size + 1}`;
+    validateHeaderChecksum(header, memberLabel);
+    if (!header.subarray(TAR_HEADER.magicStart, TAR_HEADER.magicEnd).equals(TAR_USTAR_MAGIC)) {
+      fail(`${memberLabel} is not a USTAR header`);
+    }
+
+    const typeByte = header[TAR_HEADER.type];
+    const type =
+      typeByte === 0 || typeByte === TAR_TYPE_REGULAR_ASCII
+        ? "file"
+        : typeByte === TAR_TYPE_DIRECTORY_ASCII
+          ? "directory"
+          : null;
+    if (!type) fail(`${memberLabel} has unsupported tar type byte ${typeByte}`);
+
+    const name = tarString(
+      header,
+      TAR_HEADER.nameStart,
+      TAR_HEADER.nameEnd,
+      `${memberLabel} name`,
+    );
+    const prefix = tarString(
+      header,
+      TAR_HEADER.prefixStart,
+      TAR_HEADER.prefixEnd,
+      `${memberLabel} prefix`,
+    );
+    const path = canonicalTarPath(prefix ? `${prefix}/${name}` : name, type, memberLabel);
+    if (members.has(path)) fail(`${label} contains duplicate canonical path ${path}`);
+
+    const link = tarString(
+      header,
+      TAR_HEADER.linkStart,
+      TAR_HEADER.linkEnd,
+      `${memberLabel} link name`,
+    );
+    if (link !== "") fail(`${memberLabel} unexpectedly names link target ${JSON.stringify(link)}`);
+    const mode = tarOctal(
+      header,
+      TAR_HEADER.modeStart,
+      TAR_HEADER.modeEnd,
+      `${memberLabel} mode`,
+    );
+    const size = tarOctal(
+      header,
+      TAR_HEADER.sizeStart,
+      TAR_HEADER.sizeEnd,
+      `${memberLabel} size`,
+    );
+    if (type === "directory" && size !== 0) fail(`${memberLabel} directory has non-zero size`);
+    if (size > limits.maxMemberBytes) {
+      fail(`${memberLabel} size ${size} exceeds ${limits.maxMemberBytes}`);
+    }
+
+    const bodyStart = offset + TAR_BLOCK_BYTES;
+    const paddedSize = Math.ceil(size / TAR_BLOCK_BYTES) * TAR_BLOCK_BYTES;
+    const bodyEnd = bodyStart + size;
+    const nextOffset = bodyStart + paddedSize;
+    if (!Number.isSafeInteger(nextOffset) || nextOffset > expanded.length) {
+      fail(`${memberLabel} body exceeds the expanded tar bounds`);
+    }
+    if (!expanded.subarray(bodyEnd, nextOffset).every((byte) => byte === 0)) {
+      fail(`${memberLabel} has non-zero tar padding`);
+    }
+    members.set(
+      path,
+      Object.freeze({
+        path,
+        type,
+        mode,
+        size,
+        data: Buffer.from(expanded.subarray(bodyStart, bodyEnd)),
+      }),
+    );
+    offset = nextOffset;
+  }
+  fail(`${label} has no two-block tar end marker`);
+}
+
+function validateBinaryHeader(binary, target, label) {
+  if (target.goos === "linux") {
+    if (binary.length < ELF_MIN_HEADER_BYTES || !binary.subarray(0, ELF_MAGIC.length).equals(ELF_MAGIC)) {
+      fail(`${label} is not an ELF binary`);
+    }
+    if (
+      binary[4] !== ELF_CLASS_64 ||
+      binary[5] !== ELF_DATA_LITTLE_ENDIAN ||
+      binary[6] !== ELF_VERSION_CURRENT
+    ) {
+      fail(`${label} is not a current little-endian ELF64 binary`);
+    }
+    const machine = binary.readUInt16LE(ELF_MACHINE_OFFSET);
+    if (machine !== ELF_MACHINE[target.goarch]) {
+      fail(`${label} ELF machine ${machine} does not match ${target.goarch}`);
+    }
+    return;
+  }
+
+  if (binary.length < MACHO_MIN_HEADER_BYTES || binary.readUInt32LE(0) !== MACHO_MAGIC_64) {
+    fail(`${label} is not a little-endian 64-bit Mach-O binary`);
+  }
+  const cpu = binary.readUInt32LE(MACHO_CPU_OFFSET);
+  if (cpu !== MACHO_CPU[target.goarch]) {
+    fail(`${label} Mach-O CPU ${cpu} does not match ${target.goarch}`);
+  }
+}
+
+function validateAppArchiveContents({ archive, expectedBinary, target }) {
+  const key = targetKey(target ?? {});
+  if (!TARGET_KEY_RE.test(key)) fail(`application target ${key} is unsupported`);
+  const members = parseTarGz(archive, {
+    label: `${key} application archive`,
+    limits: APP_ARCHIVE_LIMITS,
+  });
+  const actualPaths = [...members.keys()].sort();
+  if (JSON.stringify(actualPaths) !== JSON.stringify(APP_ARCHIVE_FILES)) {
+    fail(`${key} archive members are ${JSON.stringify(actualPaths)}, want exactly ${JSON.stringify(APP_ARCHIVE_FILES)}`);
+  }
+  for (const member of members.values()) {
+    if (member.type !== "file") fail(`${key} archive member ${member.path} is not a regular file`);
+  }
+  const embedded = members.get(APP_BINARY);
+  if ((embedded.mode & EXECUTABLE_MODE_MASK) === 0) {
+    fail(`${key} embedded binary is not executable`);
+  }
+  if ((embedded.mode & SPECIAL_MODE_MASK) !== 0) {
+    fail(`${key} embedded binary has set-id or sticky mode bits`);
+  }
+  if (expectedBinary && !embedded.data.equals(expectedBinary)) {
+    fail(`${key} embedded binary differs from the selected GoReleaser binary`);
+  }
+  validateBinaryHeader(embedded.data, target, `${key} embedded binary`);
+  return Object.freeze({
+    target: key,
+    members: Object.freeze(actualPaths),
+    binaryBytes: embedded.size,
+    externallyBound: Boolean(expectedBinary),
+  });
+}
+
+export function validateAppArchive({ archive, binary, target }) {
+  const key = targetKey(target ?? {});
+  const expectedBinary = asBuffer(binary, `${key} GoReleaser binary`);
+  return validateAppArchiveContents({ archive, expectedBinary, target });
+}
+
+/** Revalidate an already-sealed app archive when its standalone binary is absent. */
+export function validatePackagedAppArchive({ archive, target }) {
+  return validateAppArchiveContents({ archive, expectedBinary: null, target });
+}
+
+function exactTargetMap(value, label) {
+  if (!(value instanceof Map)) fail(`${label} must be a Map keyed by operating-system/architecture`);
+  const expected = RELEASE_TARGETS.map(targetKey).sort();
+  const actual = [...value.keys()].sort();
+  if (JSON.stringify(actual) !== JSON.stringify(expected)) {
+    fail(`${label} targets are ${JSON.stringify(actual)}, want exactly ${JSON.stringify(expected)}`);
+  }
+  return value;
+}
+
+function stripRubyComment(line) {
+  let quote = "";
+  let escaped = false;
+  for (let index = 0; index < line.length; index += 1) {
+    const character = line[index];
+    if (escaped) {
+      escaped = false;
+      continue;
+    }
+    if (quote && character === "\\") {
+      escaped = true;
+      continue;
+    }
+    if (character === '"' || character === "'") {
+      if (!quote) quote = character;
+      else if (quote === character) quote = "";
+      continue;
+    }
+    if (character === "#" && !quote) return line.slice(0, index);
+  }
+  return line;
+}
+
+function currentCaskTarget(stack) {
+  if (
+    stack.length !== 3 ||
+    stack[0].kind !== "cask" ||
+    stack[1].kind !== "os" ||
+    stack[2].kind !== "arch"
+  ) {
+    return null;
+  }
+  const operatingSystems = stack.filter((item) => item.kind === "os").map((item) => item.value);
+  const architectures = stack.filter((item) => item.kind === "arch").map((item) => item.value);
+  if (operatingSystems.length !== 1 || architectures.length !== 1) return null;
+  return `${operatingSystems[0]}/${architectures[0]}`;
+}
+
+function parseCask(source) {
+  const targets = new Map(
+    RELEASE_TARGETS.map((target) => [targetKey(target), { sha256: [], url: [], order: [] }]),
+  );
+  const stack = [];
+  const versions = [];
+  const binaries = [];
+  const installArtifacts = [];
+  const casks = [];
+  const problems = [];
+
+  for (const [lineIndex, rawLine] of source.split(/\r?\n/).entries()) {
+    const code = stripRubyComment(rawLine).trim();
+    if (!code) continue;
+    const line = lineIndex + 1;
+
+    if (code === "end") {
+      if (stack.length === 0) problems.push(`cask line ${line} closes no block`);
+      else stack.pop();
+      continue;
+    }
+
+    const cask = code.match(/^cask\s+"([^"]+)"\s+do$/);
+    if (code.startsWith("cask ")) {
+      if (!cask) problems.push(`cask line ${line} has an unsupported declaration`);
+      else {
+        casks.push(cask[1]);
+        stack.push({ kind: "cask", value: cask[1] });
+      }
+      continue;
+    }
+
+    const os = code.match(/^on_(macos|linux)\s+do$/);
+    if (os) {
+      stack.push({ kind: "os", value: os[1] === "macos" ? "darwin" : "linux" });
+      continue;
+    }
+    const arch = code.match(/^on_(intel|arm)\s+do$/);
+    if (arch) {
+      stack.push({ kind: "arch", value: arch[1] === "intel" ? "amd64" : "arm64" });
+      continue;
+    }
+
+    if (code.startsWith("version ")) {
+      const match = code.match(/^version\s+"([^"]+)"$/);
+      if (!match) problems.push(`cask line ${line} has an unsupported version declaration`);
+      else versions.push(match[1]);
+      continue;
+    }
+    if (code.startsWith("binary")) {
+      const match = code.match(/^binary\s+"([^"]+)"$/);
+      if (!match) problems.push(`cask line ${line} has an unsupported binary stanza`);
+      else {
+        binaries.push(match[1]);
+        installArtifacts.push("binary");
+      }
+      continue;
+    }
+    const installArtifact = code.match(CASK_ARTIFACT_RE);
+    if (installArtifact) installArtifacts.push(installArtifact[1]);
+
+    for (const [field, pattern] of [
+      ["sha256", /^sha256\s+"([0-9a-f]+)"$/],
+      ["url", /^url\s+"([^"]+)"$/],
+    ]) {
+      if (!code.startsWith(`${field} `)) continue;
+      const match = code.match(pattern);
+      const key = currentCaskTarget(stack);
+      if (!match) problems.push(`cask line ${line} has a malformed ${field} stanza`);
+      else if (!key || !targets.has(key)) problems.push(`cask line ${line} places ${field} outside one target block`);
+      else {
+        targets.get(key)[field].push(match[1]);
+        targets.get(key).order.push(field);
+      }
+    }
+
+    if (/\bdo(?:\s+\|[^|]*\|)?$/.test(code)) {
+      stack.push({ kind: "other", value: code });
+    } else if (/^(?:if|unless|case|begin|class|module|def)\b/.test(code)) {
+      stack.push({ kind: "other", value: code });
+    }
+  }
+  if (stack.length !== 0) problems.push(`cask has ${stack.length} unclosed Ruby block(s)`);
+  return { targets, versions, binaries, casks, installArtifacts, problems };
+}
+
+function sha256(value) {
+  return createHash("sha256").update(value).digest("hex");
+}
+
+export function validateCask({ source, version, appTag, sourceUrl, archives }) {
+  requireVersion(version, "cask version");
+  if (typeof appTag !== "string" || !APP_TAG_RE.test(appTag) || appTag !== `v${version}`) {
+    fail(`cask application tag must exactly equal v plus the application version`);
+  }
+  const archiveMap = exactTargetMap(archives, "cask archives");
+  const sourceBase = String(sourceUrl ?? "").replace(/\/+$/, "");
+  if (!HTTPS_SOURCE_RE.test(sourceBase)) {
+    fail(`cask source URL must be an HTTPS repository URL without query or fragment`);
+  }
+  const text = decodeUtf8(source, "generated cask");
+  if (text.includes("\0")) fail(`generated cask contains a NUL byte`);
+  const parsed = parseCask(text);
+  const problems = [...parsed.problems];
+
+  if (parsed.casks.length !== 1 || parsed.casks[0] !== CHART_NAME) {
+    problems.push(`cask declaration is ${JSON.stringify(parsed.casks)}, want exactly ${JSON.stringify(CHART_NAME)}`);
+  }
+  if (parsed.versions.length !== 1 || parsed.versions[0] !== version) {
+    problems.push(`cask version declarations are ${JSON.stringify(parsed.versions)}, want exactly ${JSON.stringify(version)}`);
+  }
+  if (parsed.binaries.length !== 1 || parsed.binaries[0] !== APP_BINARY) {
+    problems.push(`cask binary stanzas are ${JSON.stringify(parsed.binaries)}, want exactly ${JSON.stringify(APP_BINARY)}`);
+  }
+  if (JSON.stringify(parsed.installArtifacts) !== JSON.stringify(["binary"])) {
+    problems.push(`cask install artifacts are ${JSON.stringify(parsed.installArtifacts)}, want exactly one binary`);
+  }
+  if (caskPortabilityProblems(text).length > 0) {
+    problems.push(`cask contains a platform-specific or manual-install construct`);
+  }
+
+  for (const target of RELEASE_TARGETS) {
+    const key = targetKey(target);
+    const record = parsed.targets.get(key);
+    if (record.sha256.length !== 1 || !SHA256_RE.test(record.sha256[0] ?? "")) {
+      problems.push(`${key} cask sha256 declarations are ${JSON.stringify(record.sha256)}, want one lowercase digest`);
+    }
+    if (record.url.length !== 1) {
+      problems.push(`${key} cask URL declarations are ${JSON.stringify(record.url)}, want exactly one`);
+    }
+    if (JSON.stringify(record.order) !== JSON.stringify(["sha256", "url"])) {
+      problems.push(`${key} cask target must contain one adjacent sha256 then URL pair`);
+    }
+    const archive = asBuffer(archiveMap.get(key), `${key} cask archive`);
+    const wantedDigest = sha256(archive);
+    if (record.sha256.length === 1 && record.sha256[0] !== wantedDigest) {
+      problems.push(`${key} cask sha256 does not match the candidate archive`);
+    }
+    if (record.url.length === 1) {
+      const expanded = record.url[0].replaceAll("#{version}", version);
+      const expected = `${sourceBase}/releases/download/${appTag}/cerberus_${version}_${target.goos}_${target.goarch}.tar.gz`;
+      if (expanded.includes("#{") || expanded !== expected) {
+        problems.push(`${key} cask URL does not identify the expected tagged candidate archive`);
+      }
+    }
+  }
+  if (problems.length > 0) throw new ArtifactValidationError(problems);
+  return Object.freeze({ version, targets: Object.freeze(RELEASE_TARGETS.map(targetKey)) });
+}
+
+function yamlScalar(raw, label) {
+  const text = raw.trim();
+  if (!text || text === "|" || text === ">") fail(`${label} must be an inline scalar`);
+  if (text.startsWith('"')) {
+    try {
+      const value = JSON.parse(text);
+      if (typeof value !== "string") fail(`${label} must be a string scalar`);
+      return value;
+    } catch (cause) {
+      fail(`${label} has an invalid double-quoted scalar: ${cause.message}`);
+    }
+  }
+  if (text.startsWith("'")) {
+    if (!text.endsWith("'") || text.length < 2) fail(`${label} has an invalid single-quoted scalar`);
+    return text.slice(1, -1).replaceAll("''", "'");
+  }
+  const withoutComment = text.replace(/\s+#.*$/, "").trim();
+  if (!withoutComment || /^[!&*[{]|^(?:null|~)$/i.test(withoutComment)) {
+    fail(`${label} must be a plain string scalar`);
+  }
+  return withoutComment;
+}
+
+function chartIdentity(source) {
+  const wanted = new Set(["apiVersion", "name", "type", "version", "appVersion"]);
+  const found = new Map();
+  for (const [index, line] of source.split(/\r?\n/).entries()) {
+    if (!line || /^\s/.test(line) || /^\s*#/.test(line)) continue;
+    if (line === "---" || line === "...") continue;
+    // Helm serialises top-level YAML sequences in indentationless form under
+    // their preceding key (for example `keywords:\n- value`). They cannot
+    // declare or override an identity key, so they are safe to ignore here.
+    if (/^-\s/.test(line)) continue;
+    const match = line.match(/^([A-Za-z][A-Za-z0-9_-]*)[ \t]*:(?:[ \t]*(.*))?$/);
+    if (!match) fail(`Chart.yaml line ${index + 1} uses unsupported top-level YAML syntax`);
+    if (match[1] === "<<") fail(`Chart.yaml top-level merge keys are unsupported`);
+    if (!match || !wanted.has(match[1])) continue;
+    if (found.has(match[1])) fail(`Chart.yaml top-level field ${match[1]} is duplicated`);
+    found.set(match[1], yamlScalar(match[2] ?? "", `Chart.yaml ${match[1]}`));
+  }
+  for (const field of wanted) {
+    if (!found.has(field)) fail(`Chart.yaml is missing unique top-level scalar ${field}`);
+  }
+  return found;
+}
+
+export function validateHelmChart({ archive, chartVersion, appVersion }) {
+  requireVersion(chartVersion, "chart version");
+  requireVersion(appVersion, "chart application version");
+  const members = parseTarGz(archive, {
+    label: "Helm chart package",
+    limits: CHART_ARCHIVE_LIMITS,
+  });
+  const roots = new Set([...members.keys()].map((path) => path.split("/", 1)[0]));
+  if (roots.size !== 1 || !roots.has(CHART_NAME)) {
+    fail(`Helm chart roots are ${JSON.stringify([...roots].sort())}, want exactly ${JSON.stringify(CHART_NAME)}`);
+  }
+  for (const required of CHART_REQUIRED_FILES) {
+    if (members.get(required)?.type !== "file") fail(`Helm chart is missing regular file ${required}`);
+  }
+  const hasTemplate = [...members.values()].some(
+    (member) => member.type === "file" && member.path.startsWith(`${CHART_NAME}/templates/`),
+  );
+  if (!hasTemplate) fail(`Helm chart contains no regular template payload`);
+  const chart = decodeUtf8(members.get(`${CHART_NAME}/Chart.yaml`).data, "Chart.yaml");
+  const identity = chartIdentity(chart);
+  for (const [field, expected] of Object.entries({
+    ...CHART_REQUIRED_SCALARS,
+    version: chartVersion,
+    appVersion,
+  })) {
+    if (identity.get(field) !== expected) {
+      fail(`Chart.yaml ${field} is ${JSON.stringify(identity.get(field))}, want ${JSON.stringify(expected)}`);
+    }
+  }
+  return Object.freeze({ name: CHART_NAME, version: chartVersion, appVersion, members: members.size });
+}
+
+export function validateReleaseArtifactSet({
+  version,
+  chartVersion,
+  appTag,
+  sourceUrl,
+  archives,
+  binaries,
+  cask,
+  chart,
+}) {
+  requireVersion(version, "application version");
+  requireVersion(chartVersion, "chart version");
+  const archiveMap = exactTargetMap(archives, "application archives");
+  const binaryMap = exactTargetMap(binaries, "application binaries");
+  const application = RELEASE_TARGETS.map((target) =>
+    validateAppArchive({
+      archive: archiveMap.get(targetKey(target)),
+      binary: binaryMap.get(targetKey(target)),
+      target,
+    }),
+  );
+  const caskResult = validateCask({
+    source: cask,
+    version,
+    appTag,
+    sourceUrl,
+    archives: archiveMap,
+  });
+  const chartResult = validateHelmChart({ archive: chart, chartVersion, appVersion: version });
+  return Object.freeze({
+    application: Object.freeze(application),
+    cask: caskResult,
+    chart: chartResult,
+  });
+}
+
+function readCandidateFile(path, label) {
+  try {
+    return readFileSync(path);
+  } catch (cause) {
+    fail(`${label} cannot be read: ${cause.message}`);
+  }
+}
+
+/**
+ * Revalidate the semantic packages inside an already-sealed candidate.
+ * Standalone GoReleaser binaries are intentionally absent at this phase, so
+ * app archives retain roster/mode/header checks while the stage-time wrapper
+ * remains responsible for byte equality to the standalone build outputs.
+ */
+export function validateSealedCandidateArtifacts({
+  root,
+  version,
+  chartVersion,
+  appTag,
+  sourceUrl,
+}) {
+  if (typeof root !== "string" || root.trim() === "") {
+    fail(`sealed candidate root must be a non-empty path`);
+  }
+  requireVersion(version, "application version");
+  requireVersion(chartVersion, "chart version");
+  const candidateRoot = resolve(root);
+  const archives = new Map();
+  const application = [];
+  for (const target of RELEASE_TARGETS) {
+    const key = targetKey(target);
+    const archive = readCandidateFile(
+      join(
+        candidateRoot,
+        "app",
+        "assets",
+        `cerberus_${version}_${target.goos}_${target.goarch}.tar.gz`,
+      ),
+      `${key} sealed application archive`,
+    );
+    archives.set(key, archive);
+    application.push(validatePackagedAppArchive({ archive, target }));
+  }
+  const cask = validateCask({
+    source: readCandidateFile(
+      join(candidateRoot, "app", "homebrew", "cerberus.rb"),
+      "sealed generated cask",
+    ),
+    version,
+    appTag,
+    sourceUrl,
+    archives,
+  });
+  const chart = validateHelmChart({
+    archive: readCandidateFile(
+      join(candidateRoot, "chart", `cerberus-${chartVersion}.tgz`),
+      "sealed Helm chart package",
+    ),
+    chartVersion,
+    appVersion: version,
+  });
+  return Object.freeze({
+    application: Object.freeze(application),
+    cask,
+    chart,
+  });
+}

--- a/.github/scripts/release-artifact-validator.test.mjs
+++ b/.github/scripts/release-artifact-validator.test.mjs
@@ -1,0 +1,682 @@
+// release-artifact-validator.test.mjs — real gzip/USTAR fixtures and negative
+// controls for every package that can cross the publication boundary.
+
+import assert from "node:assert/strict";
+import { createHash } from "node:crypto";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+import { gzipSync, gunzipSync } from "node:zlib";
+
+import {
+  ArtifactValidationError,
+  RELEASE_TARGETS,
+  parseTarGz,
+  validateAppArchive,
+  validateCask,
+  validateHelmChart,
+  validateReleaseArtifactSet,
+  validateSealedCandidateArtifacts,
+} from "./release-artifact-validator.mjs";
+
+const VERSION = "1.2.3";
+const APP_TAG = `v${VERSION}`;
+const CHART_VERSION = "0.7.0";
+const SOURCE_URL = "https://downloads.example.invalid/example/project";
+const TAR_BLOCK_BYTES = 512;
+const TAR_END_BLOCKS = 2;
+const TAR_HEADER_BYTES = TAR_BLOCK_BYTES;
+const TAR_CHECKSUM_START = 148;
+const TAR_CHECKSUM_END = 156;
+const TAR_TYPE_OFFSET = 156;
+const TAR_LINK_START = 157;
+const TAR_LINK_BYTES = 100;
+const TAR_MAGIC_OFFSET = 257;
+const TAR_VERSION_OFFSET = 263;
+const TAR_PREFIX_OFFSET = 345;
+const TAR_PREFIX_BYTES = 155;
+const TAR_NAME_BYTES = 100;
+const TAR_MODE_OFFSET = 100;
+const TAR_UID_OFFSET = 108;
+const TAR_GID_OFFSET = 116;
+const TAR_SIZE_OFFSET = 124;
+const TAR_MTIME_OFFSET = 136;
+const TAR_MODE_BYTES = 8;
+const TAR_ID_BYTES = 8;
+const TAR_SIZE_BYTES = 12;
+const TAR_MTIME_BYTES = 12;
+const TAR_CHECKSUM_DIGITS = 6;
+const TAR_CHECKSUM_SPACE = 0x20;
+
+const targetKey = ({ goos, goarch }) => `${goos}/${goarch}`;
+const bytes = (value) => (Buffer.isBuffer(value) ? value : Buffer.from(String(value)));
+const digest = (value) => createHash("sha256").update(value).digest("hex");
+const roundBlock = (size) => Math.ceil(size / TAR_BLOCK_BYTES) * TAR_BLOCK_BYTES;
+
+function writeField(header, offset, length, value) {
+  const encoded = Buffer.from(value, "utf8");
+  assert.ok(encoded.length <= length, `${value} exceeds its USTAR field`);
+  encoded.copy(header, offset);
+}
+
+function writeOctal(header, offset, length, value) {
+  const encoded = value.toString(8).padStart(length - 1, "0");
+  assert.ok(encoded.length <= length - 1, `${value} exceeds its USTAR octal field`);
+  header.write(encoded, offset, length - 1, "ascii");
+  header[offset + length - 1] = 0;
+}
+
+function splitUstarPath(path) {
+  if (Buffer.byteLength(path) <= TAR_NAME_BYTES) return { name: path, prefix: "" };
+  for (let index = path.lastIndexOf("/"); index > 0; index = path.lastIndexOf("/", index - 1)) {
+    const prefix = path.slice(0, index);
+    const name = path.slice(index + 1);
+    if (
+      Buffer.byteLength(prefix) <= TAR_PREFIX_BYTES &&
+      Buffer.byteLength(name) <= TAR_NAME_BYTES
+    ) {
+      return { name, prefix };
+    }
+  }
+  throw new Error(`fixture path cannot be represented by USTAR: ${path}`);
+}
+
+function tarHeader(entry) {
+  const data = bytes(entry.data ?? "");
+  const declaredSize = entry.declaredSize ?? data.length;
+  const header = Buffer.alloc(TAR_HEADER_BYTES);
+  const { name, prefix } = splitUstarPath(entry.path);
+  writeField(header, 0, TAR_NAME_BYTES, name);
+  writeOctal(header, TAR_MODE_OFFSET, TAR_MODE_BYTES, entry.mode ?? 0o644);
+  writeOctal(header, TAR_UID_OFFSET, TAR_ID_BYTES, 0);
+  writeOctal(header, TAR_GID_OFFSET, TAR_ID_BYTES, 0);
+  writeOctal(header, TAR_SIZE_OFFSET, TAR_SIZE_BYTES, declaredSize);
+  writeOctal(header, TAR_MTIME_OFFSET, TAR_MTIME_BYTES, 0);
+  header.fill(TAR_CHECKSUM_SPACE, TAR_CHECKSUM_START, TAR_CHECKSUM_END);
+  header[TAR_TYPE_OFFSET] = String(entry.type ?? "0").charCodeAt(0);
+  if (entry.link) writeField(header, TAR_LINK_START, TAR_LINK_BYTES, entry.link);
+  writeField(header, TAR_MAGIC_OFFSET, 6, "ustar\0");
+  writeField(header, TAR_VERSION_OFFSET, 2, "00");
+  if (prefix) writeField(header, TAR_PREFIX_OFFSET, TAR_PREFIX_BYTES, prefix);
+  const checksum = header.reduce((sum, byte) => sum + byte, 0);
+  const encodedChecksum = checksum.toString(8).padStart(TAR_CHECKSUM_DIGITS, "0");
+  header.write(encodedChecksum, TAR_CHECKSUM_START, TAR_CHECKSUM_DIGITS, "ascii");
+  header[TAR_CHECKSUM_START + TAR_CHECKSUM_DIGITS] = 0;
+  header[TAR_CHECKSUM_END - 1] = TAR_CHECKSUM_SPACE;
+  return { header, data, declaredSize };
+}
+
+function tarBytes(entries, { endBlocks = TAR_END_BLOCKS, trailing = Buffer.alloc(0) } = {}) {
+  const parts = [];
+  for (const entry of entries) {
+    const built = tarHeader(entry);
+    parts.push(built.header, built.data);
+    const paddedFrom = entry.padToDeclared === false ? built.data.length : built.declaredSize;
+    const padding = roundBlock(paddedFrom) - built.data.length;
+    if (padding > 0) parts.push(Buffer.alloc(padding));
+  }
+  parts.push(Buffer.alloc(endBlocks * TAR_BLOCK_BYTES), trailing);
+  return Buffer.concat(parts);
+}
+
+function tarGz(entries, options = {}) {
+  return gzipSync(tarBytes(entries, options));
+}
+
+function executable(target, suffix = "") {
+  const binary = Buffer.alloc(64);
+  if (target.goos === "linux") {
+    Buffer.from([0x7f, 0x45, 0x4c, 0x46]).copy(binary);
+    binary[4] = 2;
+    binary[5] = 1;
+    binary[6] = 1;
+    binary.writeUInt16LE(target.goarch === "amd64" ? 0x3e : 0xb7, 18);
+  } else {
+    binary.writeUInt32LE(0xfeedfacf, 0);
+    binary.writeUInt32LE(target.goarch === "amd64" ? 0x01000007 : 0x0100000c, 4);
+  }
+  binary.write(suffix, 32, "utf8");
+  return binary;
+}
+
+function applicationEntries(binary, { mode = 0o755, extra = [], omit = [] } = {}) {
+  return [
+    { path: "CHANGELOG.md", data: "changes" },
+    { path: "LICENSE", data: "license" },
+    { path: "README.md", data: "readme" },
+    { path: "cerberus", data: binary, mode },
+    ...extra,
+  ].filter((entry) => !omit.includes(entry.path));
+}
+
+function releaseMaps() {
+  const binaries = new Map();
+  const archives = new Map();
+  for (const target of RELEASE_TARGETS) {
+    const key = targetKey(target);
+    const binary = executable(target, key);
+    binaries.set(key, binary);
+    archives.set(key, tarGz(applicationEntries(binary)));
+  }
+  return { binaries, archives };
+}
+
+function caskSource(
+  archives,
+  {
+    version = VERSION,
+    appTag = APP_TAG,
+    targets = RELEASE_TARGETS,
+    urlFor = null,
+    digestFor = null,
+    reversePair = false,
+    binary = "cerberus",
+    beforeBinary = [],
+    extraBinary = [],
+  } = {},
+) {
+  const groups = new Map([
+    ["darwin", []],
+    ["linux", []],
+  ]);
+  for (const target of targets) groups.get(target.goos).push(target);
+  const lines = ['cask "cerberus" do', `  version "${version}"`, ""];
+  for (const goos of ["darwin", "linux"]) {
+    lines.push(`  on_${goos === "darwin" ? "macos" : "linux"} do`);
+    for (const target of groups.get(goos)) {
+      const key = targetKey(target);
+      const sha = digestFor ? digestFor(target) : digest(archives.get(key));
+      const url = urlFor
+        ? urlFor(target)
+        : `${SOURCE_URL}/releases/download/${appTag}/cerberus_#{version}_${target.goos}_${target.goarch}.tar.gz`;
+      const pair = [`      sha256 "${sha}"`, `      url "${url}"`];
+      lines.push(
+        `    on_${target.goarch === "amd64" ? "intel" : "arm"} do`,
+        ...(reversePair ? pair.reverse() : pair),
+        "    end",
+      );
+    }
+    lines.push("  end", "");
+  }
+  lines.push(...beforeBinary, `  binary "${binary}"`, ...extraBinary, "end", "");
+  return Buffer.from(lines.join("\n"));
+}
+
+function chartEntries(chartYaml = null, extra = []) {
+  const metadata =
+    chartYaml ??
+    [
+      "apiVersion: v2",
+      "name: cerberus",
+      "description: test chart",
+      "type: application",
+      `version: ${CHART_VERSION}`,
+      `appVersion: '${VERSION}'`,
+      "annotations:",
+      "  example.invalid/note: value",
+      "",
+    ].join("\n");
+  return [
+    { path: "cerberus/Chart.yaml", data: metadata },
+    { path: "cerberus/values.yaml", data: "replicas: 1\n" },
+    { path: "cerberus/values.schema.json", data: '{}\n' },
+    { path: "cerberus/templates/deployment.yaml", data: "kind: Deployment\n" },
+    ...extra,
+  ];
+}
+
+function chartArchive(chartYaml = null, extra = []) {
+  return tarGz(chartEntries(chartYaml, extra));
+}
+
+function fullFixture() {
+  const maps = releaseMaps();
+  return {
+    version: VERSION,
+    chartVersion: CHART_VERSION,
+    appTag: APP_TAG,
+    sourceUrl: SOURCE_URL,
+    ...maps,
+    cask: caskSource(maps.archives),
+    chart: chartArchive(),
+  };
+}
+
+function writeCandidate(root, fixture) {
+  mkdirSync(join(root, "app", "assets"), { recursive: true });
+  mkdirSync(join(root, "app", "homebrew"), { recursive: true });
+  mkdirSync(join(root, "chart"), { recursive: true });
+  for (const target of RELEASE_TARGETS) {
+    writeFileSync(
+      join(
+        root,
+        "app",
+        "assets",
+        `cerberus_${fixture.version}_${target.goos}_${target.goarch}.tar.gz`,
+      ),
+      fixture.archives.get(targetKey(target)),
+    );
+  }
+  writeFileSync(join(root, "app", "homebrew", "cerberus.rb"), fixture.cask);
+  writeFileSync(join(root, "chart", `cerberus-${fixture.chartVersion}.tgz`), fixture.chart);
+}
+
+function assertInvalid(call, pattern = /release artifacts are invalid/) {
+  assert.throws(
+    call,
+    (error) => error instanceof ArtifactValidationError && pattern.test(error.message),
+  );
+}
+
+test("the complete unpublished package set is semantically bound", () => {
+  const result = validateReleaseArtifactSet(fullFixture());
+  assert.deepEqual(
+    result.application.map((item) => item.target),
+    RELEASE_TARGETS.map(targetKey),
+  );
+  assert.ok(result.application.every((item) => item.externallyBound));
+  assert.equal(result.cask.version, VERSION);
+  assert.equal(result.chart.version, CHART_VERSION);
+  assert.equal(result.chart.appVersion, VERSION);
+});
+
+test("the tar reader accepts a real gzip with a USTAR prefix field", () => {
+  const longPath = `cerberus/${"nested/".repeat(15)}payload.yaml`;
+  const members = parseTarGz(tarGz([{ path: longPath, data: "payload" }]));
+  assert.equal(members.get(longPath).data.toString(), "payload");
+});
+
+test("the tar reader rejects malformed gzip and tar structure", () => {
+  const valid = tarGz([{ path: "file", data: "x" }]);
+  const badChecksum = gunzipSync(valid);
+  badChecksum[0] ^= 1;
+  const badPadding = gunzipSync(valid);
+  badPadding[TAR_HEADER_BYTES + 1] = 1;
+  const malformed = [
+    ["invalid gzip", Buffer.from("not gzip"), /valid gzip/],
+    ["truncated gzip", valid.subarray(0, valid.length - 8), /valid gzip/],
+    ["non-block tar", gzipSync(Buffer.from("x")), /multiple/],
+    ["bad checksum", gzipSync(badChecksum), /checksum/],
+    ["one end block", tarGz([{ path: "file", data: "x" }], { endBlocks: 1 }), /one tar end block/],
+    [
+      "trailing data",
+      tarGz([{ path: "file", data: "x" }], { trailing: Buffer.alloc(TAR_BLOCK_BYTES, 1) }),
+      /after its tar end marker/,
+    ],
+    ["non-zero padding", gzipSync(badPadding), /padding/],
+    [
+      "body out of bounds",
+      tarGz([{ path: "file", data: "x", declaredSize: 8192, padToDeclared: false }]),
+      /body exceeds/,
+    ],
+  ];
+  for (const [name, archive, pattern] of malformed) {
+    assertInvalid(() => parseTarGz(archive, { label: name }), pattern);
+  }
+});
+
+test("the tar reader rejects unsafe paths, duplicates, links, and special records", () => {
+  const cases = [
+    ["traversal", [{ path: "../escape", data: "x" }], /unsafe path/],
+    ["absolute", [{ path: "/escape", data: "x" }], /unsafe path/],
+    ["backslash", [{ path: "dir\\escape", data: "x" }], /unsafe path/],
+    [
+      "duplicate",
+      [
+        { path: "same", data: "one" },
+        { path: "same", data: "two" },
+      ],
+      /duplicate canonical path/,
+    ],
+    ["symlink", [{ path: "link", type: "2", link: "target" }], /unsupported tar type/],
+    ["device", [{ path: "device", type: "3" }], /unsupported tar type/],
+    ["FIFO", [{ path: "fifo", type: "6" }], /unsupported tar type/],
+    ["PAX", [{ path: "pax", type: "x", data: "path=value\n" }], /unsupported tar type/],
+    ["GNU long name", [{ path: "long", type: "L", data: "name" }], /unsupported tar type/],
+  ];
+  for (const [name, entries, pattern] of cases) {
+    assertInvalid(() => parseTarGz(tarGz(entries), { label: name }), pattern);
+  }
+});
+
+test("the tar reader enforces compressed, expanded, member, and count ceilings", () => {
+  const archive = tarGz([
+    { path: "one", data: "1234" },
+    { path: "two", data: "5678" },
+  ]);
+  for (const [limits, pattern] of [
+    [{ maxCompressedBytes: 1 }, /compressed size/],
+    [{ maxExpandedBytes: TAR_BLOCK_BYTES }, /bounded valid gzip/],
+    [{ maxMemberBytes: 1 }, /member 1 size/],
+    [{ maxMembers: 1 }, /more than 1 members/],
+  ]) {
+    assertInvalid(() => parseTarGz(archive, { limits }), pattern);
+  }
+});
+
+test("application archives require the exact roster and executable binary identity", () => {
+  const target = { goos: "linux", goarch: "amd64" };
+  const binary = executable(target);
+  const good = () => tarGz(applicationEntries(binary));
+  assert.equal(validateAppArchive({ archive: good(), binary, target }).target, "linux/amd64");
+
+  const faults = [
+    ["missing", tarGz(applicationEntries(binary, { omit: ["README.md"] })), binary, /members/],
+    [
+      "extra",
+      tarGz(applicationEntries(binary, { extra: [{ path: "extra", data: "x" }] })),
+      binary,
+      /members/,
+    ],
+    ["non-executable", tarGz(applicationEntries(binary, { mode: 0o644 })), binary, /not executable/],
+    ["special mode", tarGz(applicationEntries(binary, { mode: 0o4755 })), binary, /set-id/],
+    ["different selected bytes", good(), executable(target, "different"), /differs/],
+    ["wrong header", tarGz(applicationEntries(Buffer.alloc(64))), Buffer.alloc(64), /not an ELF/],
+    [
+      "wrong architecture",
+      tarGz(applicationEntries(executable({ goos: "linux", goarch: "arm64" }))),
+      executable({ goos: "linux", goarch: "arm64" }),
+      /does not match amd64/,
+    ],
+  ];
+  for (const [name, archive, selected, pattern] of faults) {
+    assertInvalid(() => validateAppArchive({ archive, binary: selected, target }), pattern);
+  }
+});
+
+test("all four executable headers are accepted only for their declared tuple", () => {
+  for (const target of RELEASE_TARGETS) {
+    const binary = executable(target);
+    assert.doesNotThrow(() =>
+      validateAppArchive({ archive: tarGz(applicationEntries(binary)), binary, target }),
+    );
+  }
+});
+
+test("the generated cask binds one explicit version and all four archive pairs", () => {
+  const { archives } = releaseMaps();
+  const source = caskSource(archives);
+  const result = validateCask({
+    source,
+    version: VERSION,
+    appTag: APP_TAG,
+    sourceUrl: SOURCE_URL,
+    archives,
+  });
+  assert.deepEqual(result.targets, RELEASE_TARGETS.map(targetKey));
+});
+
+test("the generated cask rejects version, target, URL, checksum, and binary drift", () => {
+  const { archives } = releaseMaps();
+  const valid = caskSource(archives).toString();
+  const otherKey = "darwin/arm64";
+  const faults = [
+    ["missing version", valid.replace(`  version "${VERSION}"\n`, ""), /version declarations/],
+    [
+      "duplicate version",
+      valid.replace(`  version "${VERSION}"`, `  version "${VERSION}"\n  version "${VERSION}"`),
+      /version declarations/,
+    ],
+    ["wrong version", valid.replace(VERSION, "9.9.9"), /version declarations/],
+    [
+      "missing target",
+      caskSource(archives, { targets: RELEASE_TARGETS.slice(1) }),
+      /darwin\/amd64.*sha256 declarations/,
+    ],
+    [
+      "wrong tag URL",
+      valid.replace(`/releases/download/${APP_TAG}/`, "/releases/download/v9.9.9/"),
+      /URL does not identify/,
+    ],
+    [
+      "swapped checksum",
+      caskSource(archives, {
+        digestFor: (target) =>
+          targetKey(target) === "darwin/amd64"
+            ? digest(archives.get(otherKey))
+            : digest(archives.get(targetKey(target))),
+      }),
+      /sha256 does not match/,
+    ],
+    ["wrong binary", caskSource(archives, { binary: "other" }), /binary stanzas/],
+    [
+      "extra binary",
+      caskSource(archives, { extraBinary: ['  binary "other"'] }),
+      /binary stanzas/,
+    ],
+    ["reversed pair", caskSource(archives, { reversePair: true }), /adjacent sha256 then URL/],
+  ];
+  for (const [name, source, pattern] of faults) {
+    assertInvalid(
+      () =>
+        validateCask({
+          source: bytes(source),
+          version: VERSION,
+          appTag: APP_TAG,
+          sourceUrl: SOURCE_URL,
+          archives,
+        }),
+      pattern,
+    );
+  }
+});
+
+test("the generated cask rejects platform-only and manual install constructs", () => {
+  const { archives } = releaseMaps();
+  for (const construct of [
+    '  depends_on macos: ">= :ventura"',
+    '  app "Project.app"',
+    '  installer manual: "Project.app"',
+  ]) {
+    assertInvalid(
+      () =>
+        validateCask({
+          source: caskSource(archives, { beforeBinary: [construct] }),
+          version: VERSION,
+          appTag: APP_TAG,
+          sourceUrl: SOURCE_URL,
+          archives,
+        }),
+      /platform-specific or manual-install/,
+    );
+  }
+});
+
+test("the generated cask rejects every non-binary install artifact", () => {
+  const { archives } = releaseMaps();
+  for (const construct of [
+    '  installer script: { executable: "setup" }',
+    '  artifact "payload"',
+    '  manpage "project.1"',
+  ]) {
+    assertInvalid(
+      () =>
+        validateCask({
+          source: caskSource(archives, { beforeBinary: [construct] }),
+          version: VERSION,
+          appTag: APP_TAG,
+          sourceUrl: SOURCE_URL,
+          archives,
+        }),
+      /install artifacts/,
+    );
+  }
+});
+
+test("the generated cask requires fatal UTF-8 and independent tag identity", () => {
+  const { archives } = releaseMaps();
+  assertInvalid(
+    () =>
+      validateCask({
+        source: Buffer.from([0xff]),
+        version: VERSION,
+        appTag: APP_TAG,
+        sourceUrl: SOURCE_URL,
+        archives,
+      }),
+    /valid UTF-8/,
+  );
+  assertInvalid(
+    () =>
+      validateCask({
+        source: caskSource(archives),
+        version: VERSION,
+        appTag: "v1.2.2",
+        sourceUrl: SOURCE_URL,
+        archives,
+      }),
+    /exactly equal/,
+  );
+});
+
+test("the Helm package requires one canonical root and real payload", () => {
+  const result = validateHelmChart({
+    archive: chartArchive(),
+    chartVersion: CHART_VERSION,
+    appVersion: VERSION,
+  });
+  assert.deepEqual(
+    { name: result.name, version: result.version, appVersion: result.appVersion },
+    { name: "cerberus", version: CHART_VERSION, appVersion: VERSION },
+  );
+});
+
+test("the Helm package rejects roots, missing payload, duplicate metadata, and bad UTF-8", () => {
+  const baseYaml = chartEntries()[0].data;
+  const faults = [
+    ["multiple roots", chartArchive(null, [{ path: "other/file", data: "x" }]), /roots/],
+    ["missing Chart.yaml", tarGz(chartEntries().slice(1)), /Chart.yaml/],
+    [
+      "duplicate Chart.yaml",
+      tarGz([...chartEntries(), { path: "cerberus/Chart.yaml", data: baseYaml }]),
+      /duplicate canonical path/,
+    ],
+    [
+      "missing values",
+      tarGz(chartEntries().filter((entry) => entry.path !== "cerberus/values.yaml")),
+      /values.yaml/,
+    ],
+    [
+      "missing schema",
+      tarGz(chartEntries().filter((entry) => entry.path !== "cerberus/values.schema.json")),
+      /values.schema.json/,
+    ],
+    [
+      "missing templates",
+      tarGz(chartEntries().filter((entry) => !entry.path.startsWith("cerberus/templates/"))),
+      /template payload/,
+    ],
+    [
+      "duplicate identity",
+      chartArchive(`${baseYaml}\nname: cerberus\n`),
+      /field name is duplicated/,
+    ],
+    [
+      "invalid UTF-8",
+      tarGz(chartEntries().map((entry) =>
+        entry.path === "cerberus/Chart.yaml" ? { ...entry, data: Buffer.from([0xff]) } : entry,
+      )),
+      /valid UTF-8/,
+    ],
+  ];
+  for (const [name, archive, pattern] of faults) {
+    assertInvalid(
+      () => validateHelmChart({ archive, chartVersion: CHART_VERSION, appVersion: VERSION }),
+      pattern,
+    );
+  }
+});
+
+test("the Helm package pins every publication identity scalar", () => {
+  const base = chartEntries()[0].data;
+  for (const [field, replacement] of [
+    ["apiVersion", "v1"],
+    ["name", "other"],
+    ["type", "library"],
+    ["version", "0.6.9"],
+    ["appVersion", "1.2.2"],
+  ]) {
+    const yaml = base.replace(new RegExp(`^${field}:.*$`, "m"), `${field}: ${replacement}`);
+    assertInvalid(
+      () =>
+        validateHelmChart({
+          archive: chartArchive(yaml),
+          chartVersion: CHART_VERSION,
+          appVersion: VERSION,
+        }),
+      new RegExp(`Chart.yaml ${field}`),
+    );
+  }
+});
+
+test("the release wrapper requires exactly four archive and binary targets", () => {
+  for (const field of ["archives", "binaries"]) {
+    const fixture = fullFixture();
+    fixture[field] = new Map(fixture[field]);
+    fixture[field].delete("darwin/amd64");
+    assertInvalid(() => validateReleaseArtifactSet(fixture), new RegExp(`${field} targets`));
+  }
+  const fixture = fullFixture();
+  fixture.archives = new Map(fixture.archives).set("linux/riscv64", Buffer.from("extra"));
+  assertInvalid(() => validateReleaseArtifactSet(fixture), /application archives targets/);
+});
+
+test("the sealed-candidate wrapper revalidates package bytes without standalone binaries", (t) => {
+  const root = mkdtempSync(join(tmpdir(), "release-artifact-validator-"));
+  t.after(() => rmSync(root, { recursive: true, force: true }));
+  const fixture = fullFixture();
+  writeCandidate(root, fixture);
+  const result = validateSealedCandidateArtifacts({
+    root,
+    version: VERSION,
+    chartVersion: CHART_VERSION,
+    appTag: APP_TAG,
+    sourceUrl: SOURCE_URL,
+  });
+  assert.ok(result.application.every((item) => !item.externallyBound));
+
+  const changedTarget = RELEASE_TARGETS[0];
+  const changedKey = targetKey(changedTarget);
+  const changedBinary = executable(changedTarget, "changed after sealing");
+  writeFileSync(
+    join(
+      root,
+      "app",
+      "assets",
+      `cerberus_${VERSION}_${changedTarget.goos}_${changedTarget.goarch}.tar.gz`,
+    ),
+    tarGz(applicationEntries(changedBinary)),
+  );
+  assert.notEqual(digest(fixture.archives.get(changedKey)), digest(tarGz(applicationEntries(changedBinary))));
+  assertInvalid(
+    () =>
+      validateSealedCandidateArtifacts({
+        root,
+        version: VERSION,
+        chartVersion: CHART_VERSION,
+        appTag: APP_TAG,
+        sourceUrl: SOURCE_URL,
+      }),
+    /cask sha256 does not match/,
+  );
+});
+
+test("the sealed-candidate wrapper fails closed on missing or malformed package files", (t) => {
+  const root = mkdtempSync(join(tmpdir(), "release-artifact-validator-"));
+  t.after(() => rmSync(root, { recursive: true, force: true }));
+  const fixture = fullFixture();
+  writeCandidate(root, fixture);
+  rmSync(join(root, "chart", `cerberus-${CHART_VERSION}.tgz`));
+  assertInvalid(
+    () =>
+      validateSealedCandidateArtifacts({
+        root,
+        version: VERSION,
+        chartVersion: CHART_VERSION,
+        appTag: APP_TAG,
+        sourceUrl: SOURCE_URL,
+      }),
+    /cannot be read/,
+  );
+});

--- a/.github/scripts/release-candidate-brew.mjs
+++ b/.github/scripts/release-candidate-brew.mjs
@@ -1,0 +1,880 @@
+// release-candidate-brew.mjs — qualify the sealed Homebrew candidate before
+// any public release or tap write.
+//
+// Modes (MODE or argv[2]):
+//   install    install the exact candidate cask from an ephemeral local tap.
+//   migration  install a legacy formula, advance the tap by one commit through
+//              `brew update`, and prove that Homebrew migrates and links the
+//              exact candidate cask.
+//
+// Environment:
+//   RELEASE_CANDIDATE_DIR     sealed candidate root.
+//   RELEASE_CANDIDATE_DIGEST  expected sha256:<hex> candidate digest.
+//   REPO_ROOT                 checkout bound to the candidate source; used by
+//                             the shipped config-registry payload assertion.
+//
+// Candidate archives are never published for this check. The unmodified cask
+// is installed with HOMEBREW_ARTIFACT_DOMAIN pointed at a loopback-only HTTP
+// server. Fallback is disabled, the Homebrew cache is isolated, and a successful
+// body download of the platform archive is mandatory. Imports are Node builtins
+// plus repository-local validation helpers; every subprocess has a deadline.
+
+import { spawn } from "node:child_process";
+import { createHash, randomUUID } from "node:crypto";
+import {
+  accessSync,
+  chmodSync,
+  constants as fsConstants,
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  realpathSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from "node:fs";
+import { createServer } from "node:http";
+import { tmpdir } from "node:os";
+import { delimiter, dirname, isAbsolute, join, relative, resolve, sep } from "node:path";
+import process from "node:process";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+import { error, log, notice } from "./lib/gh.mjs";
+import { REQUIRED_TARGETS, verifyCandidate } from "./release-candidate.mjs";
+
+const APP_NAME = "cerberus";
+const CASK_PATH = `Casks/${APP_NAME}.rb`;
+const FORMULA_PATH = `Formula/${APP_NAME}.rb`;
+const MIGRATIONS_PATH = "tap_migrations.json";
+const CANDIDATE_DIR_DEFAULT = "build/release-candidate";
+const LEGACY_VERSION = "0.0.0";
+const LEGACY_REPORTED_VERSION = "legacy-candidate-fixture";
+const MIGRATION_ANNOUNCEMENT = "has been migrated from a formula to a cask";
+const DIGEST_RE = /^sha256:[0-9a-f]{64}$/;
+const TAP_RE = /^[a-z0-9][a-z0-9-]*\/[a-z0-9][a-z0-9-]*$/;
+const COMMAND_TIMEOUT_MS = 5 * 60 * 1000;
+const BREW_INSTALL_TIMEOUT_MS = 20 * 60 * 1000;
+const BREW_UPDATE_TIMEOUT_MS = 20 * 60 * 1000;
+const CLEANUP_TIMEOUT_MS = 5 * 60 * 1000;
+const SERVER_CLOSE_TIMEOUT_MS = 10 * 1000;
+const COMMAND_KILL_GRACE_MS = 2 * 1000;
+const MAX_COMMAND_OUTPUT_BYTES = 64 * 1024 * 1024;
+const EXECUTABLE_MODE = 0o755;
+const TAP_TOKEN_HEX_LENGTH = 12;
+const COMMAND_NOT_STARTED_STATUS = 127;
+const HTTP_OK = 200;
+const HTTP_BAD_REQUEST = 400;
+const HTTP_NOT_FOUND = 404;
+const HTTP_METHOD_NOT_ALLOWED = 405;
+const HTTP_SERVER_ERROR = 500;
+
+export class CandidateBrewError extends Error {
+  constructor(problems) {
+    const list = Array.isArray(problems) ? problems : [String(problems)];
+    super(`candidate Homebrew qualification failed:\n${list.map((item) => `- ${item}`).join("\n")}`);
+    this.name = "CandidateBrewError";
+    this.problems = list;
+  }
+}
+
+function fail(message) {
+  throw new CandidateBrewError(message);
+}
+
+function targetKey(target) {
+  return `${target.goos}/${target.goarch}`;
+}
+
+function within(root, path) {
+  const rel = relative(root, path);
+  return rel === "" || (rel !== ".." && !rel.startsWith(`..${sep}`) && !isAbsolute(rel));
+}
+
+function safeWorkspacePath(root, path) {
+  if (typeof path !== "string" || path === "" || path.includes("\0") || isAbsolute(path)) {
+    fail(`unsafe workspace-relative path ${JSON.stringify(path)}`);
+  }
+  const absolute = resolve(root, path);
+  if (!within(resolve(root), absolute) || absolute === resolve(root)) {
+    fail(`workspace path escapes its root: ${JSON.stringify(path)}`);
+  }
+  return absolute;
+}
+
+function sha256Hex(bytes) {
+  return createHash("sha256").update(bytes).digest("hex");
+}
+
+function rubyString(value) {
+  return JSON.stringify(String(value));
+}
+
+function requiredString(value, label) {
+  if (typeof value !== "string" || value.trim() === "") fail(`${label} is required`);
+  return value.trim();
+}
+
+/**
+ * Return every exact request path used by supported artifact-domain rewrite
+ * shapes. Every path retains the complete source and release binding; basename-only
+ * routing would let a cask pointing at the wrong release pass.
+ */
+export function candidateArchiveRoutes({ manifest, candidateRoot }) {
+  if (!manifest?.source?.url || !manifest?.versions?.app || !manifest?.versions?.app_tag) {
+    fail("candidate manifest lacks source URL, app version, or app tag");
+  }
+  let source;
+  try {
+    source = new URL(manifest.source.url);
+  } catch (cause) {
+    fail(`candidate source URL is invalid: ${cause.message}`);
+  }
+  if (source.protocol !== "https:" || source.search || source.hash || source.pathname === "/") {
+    fail("candidate source URL must be a repository-scoped HTTPS URL without query or fragment");
+  }
+
+  const root = resolve(candidateRoot);
+  const declared = new Set((manifest.files ?? []).map((item) => item?.path));
+  const routes = REQUIRED_TARGETS.map((target) => {
+    const filename = `${APP_NAME}_${manifest.versions.app}_${target.goos}_${target.goarch}.tar.gz`;
+    const candidatePath = `app/assets/${filename}`;
+    if (!declared.has(candidatePath)) fail(`candidate manifest does not declare ${candidatePath}`);
+    const absolutePath = safeWorkspacePath(root, candidatePath);
+    const originalUrl = `${manifest.source.url}/releases/download/${manifest.versions.app_tag}/${filename}`;
+    const parsed = new URL(originalUrl);
+    const paths = [
+      `/${originalUrl}`,
+      parsed.pathname,
+      `/${parsed.host}${parsed.pathname}`,
+    ];
+    return Object.freeze({
+      target: targetKey(target),
+      filename,
+      candidatePath,
+      absolutePath,
+      originalUrl,
+      paths: Object.freeze([...new Set(paths)]),
+    });
+  });
+
+  const owners = new Map();
+  for (const route of routes) {
+    for (const path of route.paths) {
+      if (owners.has(path)) fail(`archive route ${path} is ambiguous`);
+      owners.set(path, route.candidatePath);
+    }
+  }
+  return Object.freeze(routes);
+}
+
+/** Pure HTTP router used by the loopback archive server. */
+export function routeCandidateArchive({ method, requestUrl, routes }) {
+  if (method !== "GET" && method !== "HEAD") {
+    return Object.freeze({ status: HTTP_METHOD_NOT_ALLOWED, archive: null, sendBody: false });
+  }
+  let parsed;
+  try {
+    const base = new URL("http://127.0.0.1");
+    parsed = new URL(String(requestUrl ?? ""), base);
+    if (parsed.origin !== base.origin || parsed.search || parsed.hash) {
+      return Object.freeze({ status: HTTP_BAD_REQUEST, archive: null, sendBody: false });
+    }
+  } catch {
+    return Object.freeze({ status: HTTP_BAD_REQUEST, archive: null, sendBody: false });
+  }
+  const archive = routes.find((item) => item.paths.includes(parsed.pathname)) ?? null;
+  return Object.freeze({
+    status: archive ? HTTP_OK : HTTP_NOT_FOUND,
+    archive,
+    sendBody: Boolean(archive && method === "GET"),
+  });
+}
+
+/**
+ * Build the two tap states without touching disk. Buffer values make the
+ * byte-for-byte cask requirement explicit and directly testable.
+ */
+export function candidateTapPlan({
+  tapName,
+  caskBytes,
+  legacyArchiveUrl,
+  legacyArchiveSha256,
+}) {
+  if (!TAP_RE.test(tapName ?? "")) fail(`invalid ephemeral tap name ${JSON.stringify(tapName)}`);
+  if (!Buffer.isBuffer(caskBytes) || caskBytes.length === 0) fail("candidate cask bytes are required");
+  let legacyUrl;
+  try {
+    legacyUrl = new URL(legacyArchiveUrl);
+  } catch (cause) {
+    fail(`legacy fixture URL is invalid: ${cause.message}`);
+  }
+  if (legacyUrl.protocol !== "file:" || !/^[0-9a-f]{64}$/.test(legacyArchiveSha256 ?? "")) {
+    fail("legacy fixture must use a file URL and a lowercase SHA-256");
+  }
+
+  const formula = [
+    `class Cerberus < Formula`,
+    `  desc "Qualification-only migration fixture"`,
+    `  homepage "https://invalid.example"`,
+    `  url ${rubyString(legacyArchiveUrl)}`,
+    `  version ${rubyString(LEGACY_VERSION)}`,
+    `  sha256 ${rubyString(legacyArchiveSha256)}`,
+    "",
+    "  def install",
+    `    bin.install ${rubyString(APP_NAME)}`,
+    "  end",
+    "end",
+    "",
+  ].join("\n");
+
+  return Object.freeze({
+    legacy: Object.freeze({
+      writes: Object.freeze([{ path: FORMULA_PATH, bytes: Buffer.from(formula) }]),
+      removes: Object.freeze([]),
+    }),
+    candidate: Object.freeze({
+      writes: Object.freeze([
+        { path: CASK_PATH, bytes: Buffer.from(caskBytes) },
+        {
+          path: MIGRATIONS_PATH,
+          bytes: Buffer.from(`${JSON.stringify({ [APP_NAME]: tapName })}\n`),
+        },
+      ]),
+      removes: Object.freeze([FORMULA_PATH]),
+    }),
+  });
+}
+
+export function hostTarget(platform, architecture) {
+  const goos = new Map([
+    ["darwin", "darwin"],
+    ["linux", "linux"],
+  ]).get(platform);
+  const goarch = new Map([
+    ["x64", "amd64"],
+    ["arm64", "arm64"],
+  ]).get(architecture);
+  if (!goos || !goarch) fail(`unsupported Homebrew qualification host ${platform}/${architecture}`);
+  return `${goos}/${goarch}`;
+}
+
+export function brewCommandEnvironment(base, { artifactOrigin, stateRoot }) {
+  let origin;
+  try {
+    origin = new URL(artifactOrigin);
+  } catch (cause) {
+    fail(`artifact origin is invalid: ${cause.message}`);
+  }
+  if (origin.protocol !== "http:" || origin.hostname !== "127.0.0.1" || origin.pathname !== "/") {
+    fail("artifact origin must be an HTTP loopback origin with no path");
+  }
+  const root = resolve(stateRoot);
+  return {
+    ...base,
+    HOMEBREW_ARTIFACT_DOMAIN: origin.origin,
+    HOMEBREW_ARTIFACT_DOMAIN_NO_FALLBACK: "1",
+    HOMEBREW_CACHE: join(root, "cache"),
+    HOMEBREW_LOGS: join(root, "logs"),
+    HOMEBREW_TEMP: join(root, "temp"),
+    HOMEBREW_CURL_RETRIES: "0",
+    HOMEBREW_NO_ANALYTICS: "1",
+    HOMEBREW_NO_ASK: "1",
+    HOMEBREW_NO_AUTO_UPDATE: "1",
+    HOMEBREW_NO_ENV_HINTS: "1",
+    HOMEBREW_NO_GITHUB_API: "1",
+    HOMEBREW_NO_INSTALL_CLEANUP: "1",
+    HOMEBREW_NO_INSTALL_FROM_API: "1",
+  };
+}
+
+export function withoutArtifactDomain(environment) {
+  const result = { ...environment };
+  delete result.HOMEBREW_ARTIFACT_DOMAIN;
+  delete result.HOMEBREW_ARTIFACT_DOMAIN_NO_FALLBACK;
+  return result;
+}
+
+function listedNames(output) {
+  return new Set(
+    String(output ?? "")
+      .split("\n")
+      .map((line) => line.trim().split(/\s+/)[0])
+      .filter(Boolean),
+  );
+}
+
+function pathInside(root, path) {
+  if (!root || !path) return false;
+  return within(resolve(root), resolve(path)) && resolve(root) !== resolve(path);
+}
+
+export function commandOnPath(name, pathValue, cwd = process.cwd()) {
+  if (typeof name !== "string" || name === "" || name.includes("/") || name.includes("\\")) return "";
+  for (const directory of String(pathValue ?? "").split(delimiter)) {
+    const candidate = resolve(directory || cwd, name);
+    try {
+      accessSync(candidate, fsConstants.X_OK);
+      if (statSync(candidate).isFile()) return candidate;
+    } catch {
+      // This PATH component does not provide an executable with the requested name.
+    }
+  }
+  return "";
+}
+
+export function installedCandidateProblems({
+  version,
+  caskList,
+  formulaList,
+  allowFormula,
+  brewPrefix,
+  resolvedPath,
+  pathCommand,
+  realPath,
+  reportedVersion,
+  schemaStatus,
+  schemaOutput,
+  docsStatus,
+}) {
+  const problems = [];
+  if (!listedNames(caskList).has(APP_NAME)) problems.push("the candidate cask is not installed");
+  if (!allowFormula && listedNames(formulaList).has(APP_NAME)) {
+    problems.push("the fresh-install fixture resolved to a formula instead of only the candidate cask");
+  }
+  if (!pathInside(brewPrefix, resolvedPath)) problems.push("the command link is outside the Homebrew prefix");
+  if (pathCommand !== resolvedPath) problems.push("PATH does not resolve to the candidate Homebrew link");
+  const caskRoot = join(resolve(brewPrefix || "/"), "Caskroom", APP_NAME, String(version ?? ""));
+  if (!pathInside(caskRoot, realPath)) problems.push("the command link does not resolve into the candidate Caskroom");
+  if (reportedVersion !== version) {
+    problems.push(`the installed command reports ${JSON.stringify(reportedVersion)}, want ${JSON.stringify(version)}`);
+  }
+  if (schemaStatus !== 0 || !String(schemaOutput ?? "").includes("CREATE")) {
+    problems.push("the installed command did not render a CREATE statement");
+  }
+  if (docsStatus !== 0) problems.push("the installed command's config registry does not match the bound checkout");
+  return problems;
+}
+
+export function migrationCandidateProblems(input) {
+  const problems = [];
+  if (!String(input.updateOutput ?? "").includes(MIGRATION_ANNOUNCEMENT)) {
+    problems.push("brew update did not announce the formula-to-cask migration");
+  }
+  return [...problems, ...installedCandidateProblems({ ...input, allowFormula: true })];
+}
+
+export function archiveDeliveryProblems({ events, expectedTarget }) {
+  const problems = [];
+  const failed = events.filter((event) => event.status !== HTTP_OK);
+  if (failed.length > 0) problems.push(`the archive server rejected ${failed.length} request(s)`);
+  const bodies = events.filter(
+    (event) => event.method === "GET" && event.status === HTTP_OK && event.target === expectedTarget && event.bytes > 0,
+  );
+  if (bodies.length === 0) {
+    problems.push(`Homebrew did not download the ${expectedTarget} candidate archive from loopback`);
+  }
+  return problems;
+}
+
+function describe(result) {
+  return [
+    `exit=${result.status}${result.signal ? ` signal=${result.signal}` : ""}`,
+    result.timedOut ? "deadline exceeded" : "",
+    result.overflow ? "output limit exceeded" : "",
+    result.stdout,
+    result.stderr,
+  ]
+    .filter(Boolean)
+    .join("\n")
+    .trim();
+}
+
+export function commandResultSucceeded(result) {
+  return Boolean(
+    result &&
+      result.status === 0 &&
+      !result.signal &&
+      result.timedOut === false &&
+      result.overflow === false,
+  );
+}
+
+export function brewUpdateExecutionProblem(result) {
+  if (
+    !result ||
+    result.timedOut !== false ||
+    result.overflow !== false ||
+    result.signal ||
+    !Number.isInteger(result.status) ||
+    result.status === COMMAND_NOT_STARTED_STATUS
+  ) {
+    return `advancing the tap through brew update failed. ${describe(result ?? {})}`;
+  }
+  return null;
+}
+
+export async function runCommand(command, args, {
+  cwd,
+  env = process.env,
+  timeout = COMMAND_TIMEOUT_MS,
+  maxOutput = MAX_COMMAND_OUTPUT_BYTES,
+} = {}) {
+  return new Promise((resolveResult) => {
+    let settled = false;
+    let timedOut = false;
+    let overflow = false;
+    let stopping = false;
+    let bytes = 0;
+    const stdout = [];
+    const stderr = [];
+    const ownsProcessGroup = process.platform !== "win32";
+    const child = spawn(command, args, {
+      cwd,
+      env,
+      detached: ownsProcessGroup,
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    let killTimer = null;
+    let forcedSettleTimer = null;
+
+    const killTree = (signal) => {
+      try {
+        if (ownsProcessGroup && child.pid) process.kill(-child.pid, signal);
+        else child.kill(signal);
+      } catch {
+        try {
+          child.kill(signal);
+        } catch {
+          // The process tree already exited between observation and signalling.
+        }
+      }
+    };
+
+    const stopTree = () => {
+      if (stopping) return;
+      stopping = true;
+      killTree("SIGTERM");
+      killTimer = setTimeout(() => {
+        killTree("SIGKILL");
+        forcedSettleTimer = setTimeout(() => {
+          child.stdout.destroy();
+          child.stderr.destroy();
+          finish(null, "SIGKILL", new Error("process group did not close after SIGKILL"));
+        }, COMMAND_KILL_GRACE_MS);
+        forcedSettleTimer.unref();
+      }, COMMAND_KILL_GRACE_MS);
+      killTimer.unref();
+    };
+
+    const collect = (destination, chunk) => {
+      bytes += chunk.length;
+      if (bytes <= maxOutput) destination.push(chunk);
+      else if (!overflow) {
+        overflow = true;
+        stopTree();
+      }
+    };
+    child.stdout.on("data", (chunk) => collect(stdout, chunk));
+    child.stderr.on("data", (chunk) => collect(stderr, chunk));
+
+    const timer = setTimeout(() => {
+      timedOut = true;
+      stopTree();
+    }, timeout);
+    timer.unref();
+
+    const finish = (status, signal, spawnError = null) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      if (killTimer) clearTimeout(killTimer);
+      if (forcedSettleTimer) clearTimeout(forcedSettleTimer);
+      resolveResult({
+        status: spawnError ? COMMAND_NOT_STARTED_STATUS : (status ?? 1),
+        signal,
+        stdout: Buffer.concat(stdout).toString("utf8"),
+        stderr: spawnError ? spawnError.message : Buffer.concat(stderr).toString("utf8"),
+        timedOut,
+        overflow,
+      });
+    };
+    child.on("error", (cause) => finish(COMMAND_NOT_STARTED_STATUS, null, cause));
+    child.on("close", (status, signal) => finish(status, signal));
+  });
+}
+
+async function runChecked(command, args, label, options = {}) {
+  const result = await runCommand(command, args, options);
+  if (!commandResultSucceeded(result)) {
+    fail(`${label} failed. ${describe(result)}`);
+  }
+  return result;
+}
+
+async function startArchiveServer(routes) {
+  const events = [];
+  const server = createServer((request, response) => {
+    const decision = routeCandidateArchive({
+      method: request.method,
+      requestUrl: request.url,
+      routes,
+    });
+    const event = {
+      method: request.method ?? "",
+      path: request.url ?? "",
+      status: decision.status,
+      target: decision.archive?.target ?? "",
+      bytes: 0,
+    };
+    events.push(event);
+    response.setHeader("Connection", "close");
+    response.setHeader("Cache-Control", "no-store");
+    if (!decision.archive) {
+      response.statusCode = decision.status;
+      response.end();
+      return;
+    }
+    try {
+      const stat = statSync(decision.archive.absolutePath);
+      if (!stat.isFile()) throw new Error("archive is not a regular file");
+      response.statusCode = HTTP_OK;
+      response.setHeader("Content-Type", "application/gzip");
+      response.setHeader("Content-Length", String(stat.size));
+      if (!decision.sendBody) {
+        response.end();
+        return;
+      }
+      const bytes = readFileSync(decision.archive.absolutePath);
+      event.bytes = bytes.length;
+      response.end(bytes);
+    } catch (cause) {
+      event.status = HTTP_SERVER_ERROR;
+      response.statusCode = HTTP_SERVER_ERROR;
+      response.end(String(cause.message));
+    }
+  });
+
+  await new Promise((resolveListen, rejectListen) => {
+    server.once("error", rejectListen);
+    server.listen({ host: "127.0.0.1", port: 0, exclusive: true }, resolveListen);
+  });
+  const address = server.address();
+  if (!address || typeof address === "string") fail("loopback archive server has no TCP address");
+
+  return {
+    origin: `http://127.0.0.1:${address.port}`,
+    events,
+    async close() {
+      const closed = new Promise((resolveClose) => server.close(resolveClose));
+      const deadline = new Promise((resolveClose) => {
+        setTimeout(() => {
+          server.closeAllConnections?.();
+          resolveClose();
+        }, SERVER_CLOSE_TIMEOUT_MS).unref();
+      });
+      await Promise.race([closed, deadline]);
+    },
+  };
+}
+
+function applyTapState(sourceRoot, state) {
+  for (const path of state.removes) rmSync(safeWorkspacePath(sourceRoot, path), { force: true });
+  for (const item of state.writes) {
+    const target = safeWorkspacePath(sourceRoot, item.path);
+    mkdirSync(dirname(target), { recursive: true });
+    writeFileSync(target, item.bytes);
+  }
+}
+
+async function commitTapState(sourceRoot, state, message) {
+  applyTapState(sourceRoot, state);
+  await runChecked("git", ["-C", sourceRoot, "add", "--all"], "staging ephemeral tap state");
+  await runChecked("git", ["-C", sourceRoot, "commit", "-m", message], "committing ephemeral tap state");
+  await runChecked("git", ["-C", sourceRoot, "push", "origin", "main"], "advancing ephemeral tap origin");
+}
+
+async function initialiseTap(root) {
+  const origin = join(root, "tap-origin.git");
+  const source = join(root, "tap-source");
+  mkdirSync(source, { recursive: true });
+  await runChecked("git", ["init", "--bare", origin], "initialising ephemeral tap origin");
+  await runChecked("git", ["init", "-b", "main", source], "initialising ephemeral tap source");
+  await runChecked("git", ["-C", source, "config", "core.autocrlf", "false"], "disabling tap line conversion");
+  await runChecked("git", ["-C", source, "config", "user.name", "Release Qualification"], "configuring tap commit name");
+  await runChecked(
+    "git",
+    ["-C", source, "config", "user.email", "release-qualification@invalid.example"],
+    "configuring tap commit email",
+  );
+  await runChecked("git", ["-C", source, "remote", "add", "origin", pathToFileURL(origin).href], "configuring tap origin");
+  await runChecked("git", ["--git-dir", origin, "symbolic-ref", "HEAD", "refs/heads/main"], "configuring tap default branch");
+  return { origin, source, remote: pathToFileURL(origin).href };
+}
+
+async function createLegacyArchive(root) {
+  const payload = join(root, "legacy-payload");
+  const archive = join(root, "legacy-source.tar.gz");
+  mkdirSync(payload, { recursive: true });
+  const executable = join(payload, APP_NAME);
+  writeFileSync(executable, `#!/bin/sh\nprintf '%s\\n' '${LEGACY_REPORTED_VERSION}'\n`);
+  chmodSync(executable, EXECUTABLE_MODE);
+  await runChecked("tar", ["-czf", archive, "-C", payload, APP_NAME], "building legacy formula fixture");
+  const bytes = readFileSync(archive);
+  return { archive, url: pathToFileURL(archive).href, sha256: sha256Hex(bytes) };
+}
+
+async function brewLists(env) {
+  const cask = await runChecked("brew", ["list", "--cask", "--versions"], "listing installed casks", { env });
+  const formula = await runChecked("brew", ["list", "--formula", "--versions"], "listing installed formulae", { env });
+  return { cask: cask.stdout, formula: formula.stdout };
+}
+
+async function assertEmptyStartingState(env) {
+  const lists = await brewLists(env);
+  if (listedNames(lists.cask).has(APP_NAME) || listedNames(lists.formula).has(APP_NAME)) {
+    fail(`${APP_NAME} is already installed; refusing to alter a pre-existing Homebrew installation`);
+  }
+}
+
+async function assertTappedCaskBytes({ env, tapName, expected }) {
+  const repository = await runChecked("brew", ["--repo", tapName], "locating ephemeral tap", { env });
+  const actual = readFileSync(join(repository.stdout.trim(), CASK_PATH));
+  if (!actual.equals(expected)) fail("ephemeral tap cask bytes do not equal the sealed candidate cask");
+}
+
+async function installedProbe({ env, repoRoot, brewPrefix }) {
+  const resolvedPath = join(brewPrefix, "bin", APP_NAME);
+  const pathCommand = commandOnPath(APP_NAME, env.PATH);
+  if (!existsSync(resolvedPath)) {
+    return {
+      resolvedPath,
+      pathCommand,
+      realPath: "",
+      reportedVersion: "<not linked>",
+      schemaStatus: 1,
+      schemaOutput: "",
+      docsStatus: 1,
+    };
+  }
+  let realPath = "";
+  try {
+    realPath = realpathSync(resolvedPath);
+  } catch {
+    // The verdict below turns an unreadable link target into a named failure.
+  }
+  const version = await runCommand(resolvedPath, ["--version"], { env });
+  const schema = await runCommand(resolvedPath, ["migrate", "schema"], { env, cwd: repoRoot });
+  const docs = await runCommand(resolvedPath, ["config-docs", "-check"], { env, cwd: repoRoot });
+  return {
+    resolvedPath,
+    pathCommand,
+    realPath,
+    reportedVersion: commandResultSucceeded(version) ? version.stdout.trim() : "<version command failed>",
+    schemaStatus: commandResultSucceeded(schema) ? 0 : 1,
+    schemaOutput: schema.stdout,
+    docsStatus: commandResultSucceeded(docs) ? 0 : 1,
+  };
+}
+
+async function assertCheckout(repoRoot, manifest) {
+  if (!existsSync(join(repoRoot, "docs", "configuration.md"))) {
+    fail("REPO_ROOT does not contain docs/configuration.md");
+  }
+  const top = await runChecked("git", ["-C", repoRoot, "rev-parse", "--show-toplevel"], "locating checkout root");
+  if (resolve(top.stdout.trim()) !== repoRoot) fail("REPO_ROOT must be the repository root");
+  const sha = await runChecked("git", ["-C", repoRoot, "rev-parse", "HEAD"], "reading checkout commit");
+  const tree = await runChecked("git", ["-C", repoRoot, "rev-parse", "HEAD^{tree}"], "reading checkout tree");
+  const status = await runChecked(
+    "git",
+    ["-C", repoRoot, "status", "--porcelain=v1", "--untracked-files=all"],
+    "checking checkout cleanliness",
+  );
+  const problems = [];
+  if (sha.stdout.trim() !== manifest.source.sha) problems.push("checkout commit does not equal candidate source commit");
+  if (tree.stdout.trim() !== manifest.source.tree) problems.push("checkout tree does not equal candidate source tree");
+  if (status.stdout.trim() !== "") problems.push("checkout has tracked or untracked changes outside ignored build output");
+  if (problems.length > 0) throw new CandidateBrewError(problems);
+}
+
+async function cleanupBrew({ env, tapName, tapAdded, packageTouched }) {
+  const problems = [];
+  const attempt = async (args, label) => {
+    const result = await runCommand("brew", args, { env, timeout: CLEANUP_TIMEOUT_MS });
+    if (!commandResultSucceeded(result)) problems.push(`${label}: ${describe(result)}`);
+  };
+  if (packageTouched) {
+    const lists = await Promise.all([
+      runCommand("brew", ["list", "--cask", "--versions"], { env, timeout: CLEANUP_TIMEOUT_MS }),
+      runCommand("brew", ["list", "--formula", "--versions"], { env, timeout: CLEANUP_TIMEOUT_MS }),
+    ]);
+    if (!commandResultSucceeded(lists[0])) problems.push(`listing casks during cleanup: ${describe(lists[0])}`);
+    else if (listedNames(lists[0].stdout).has(APP_NAME)) {
+      await attempt(["uninstall", "--cask", "--force", APP_NAME], "removing candidate cask");
+    }
+    if (!commandResultSucceeded(lists[1])) problems.push(`listing formulae during cleanup: ${describe(lists[1])}`);
+    else if (listedNames(lists[1].stdout).has(APP_NAME)) {
+      await attempt(["uninstall", "--formula", "--force", APP_NAME], "removing legacy formula");
+    }
+  }
+  if (tapAdded) {
+    const taps = await runCommand("brew", ["tap"], { env, timeout: CLEANUP_TIMEOUT_MS });
+    if (!commandResultSucceeded(taps)) problems.push(`listing taps during cleanup: ${describe(taps)}`);
+    else if (new Set(taps.stdout.split("\n").map((line) => line.trim()).filter(Boolean)).has(tapName)) {
+      await attempt(["untap", "--force", tapName], "removing ephemeral tap");
+    }
+  }
+  return problems;
+}
+
+async function qualify(mode) {
+  if (mode !== "install" && mode !== "migration") {
+    fail(`MODE must be install or migration, got ${JSON.stringify(mode)}`);
+  }
+  const candidateRoot = resolve(process.env.RELEASE_CANDIDATE_DIR || CANDIDATE_DIR_DEFAULT);
+  const digest = requiredString(process.env.RELEASE_CANDIDATE_DIGEST, "RELEASE_CANDIDATE_DIGEST");
+  if (!DIGEST_RE.test(digest)) fail("RELEASE_CANDIDATE_DIGEST must be sha256:<lowercase hex>");
+  const repoRoot = resolve(requiredString(process.env.REPO_ROOT, "REPO_ROOT"));
+  const sealed = verifyCandidate(candidateRoot, { digest });
+  await assertCheckout(repoRoot, sealed.manifest);
+
+  const caskBytes = readFileSync(join(candidateRoot, "app", "homebrew", `${APP_NAME}.rb`));
+  const routes = candidateArchiveRoutes({ manifest: sealed.manifest, candidateRoot });
+  const expectedTarget = hostTarget(process.platform, process.arch);
+  const tempRoot = mkdtempSync(join(resolve(tmpdir()), "cerberus-release-candidate-brew-"));
+  const tapName = `candidate-${randomUUID().replaceAll("-", "").slice(0, TAP_TOKEN_HEX_LENGTH)}/qualification`;
+  let server = null;
+  let env = null;
+  let setupEnv = null;
+  let tapAdded = false;
+  let packageTouched = false;
+  let primaryFailure = null;
+  let cleanupProblems = [];
+  try {
+    server = await startArchiveServer(routes);
+    env = brewCommandEnvironment(process.env, { artifactOrigin: server.origin, stateRoot: tempRoot });
+    setupEnv = withoutArtifactDomain(env);
+    for (const path of [env.HOMEBREW_CACHE, env.HOMEBREW_LOGS, env.HOMEBREW_TEMP]) {
+      mkdirSync(path, { recursive: true });
+    }
+    await runChecked("brew", ["--version"], "locating Homebrew", { env });
+    const prefixResult = await runChecked("brew", ["--prefix"], "reading Homebrew prefix", { env });
+    const brewPrefix = prefixResult.stdout.trim();
+    await assertEmptyStartingState(env);
+
+    const legacy = await createLegacyArchive(tempRoot);
+    const plan = candidateTapPlan({
+      tapName,
+      caskBytes,
+      legacyArchiveUrl: legacy.url,
+      legacyArchiveSha256: legacy.sha256,
+    });
+    const tap = await initialiseTap(tempRoot);
+
+    if (mode === "migration") {
+      await commitTapState(tap.source, plan.legacy, "test: add legacy formula fixture");
+    } else {
+      await commitTapState(tap.source, plan.candidate, "test: add candidate cask fixture");
+    }
+    tapAdded = true;
+    await runChecked("brew", ["tap", tapName, tap.remote], "tapping ephemeral repository", { env });
+
+    if (mode === "migration") {
+      packageTouched = true;
+      await runChecked("brew", ["install", `${tapName}/${APP_NAME}`], "installing legacy formula fixture", {
+        env: setupEnv,
+        timeout: BREW_INSTALL_TIMEOUT_MS,
+      });
+      const before = await brewLists(env);
+      if (!listedNames(before.formula).has(APP_NAME) || listedNames(before.cask).has(APP_NAME)) {
+        fail("legacy setup did not produce exactly a formula installation");
+      }
+      const legacyProbe = await runChecked(join(brewPrefix, "bin", APP_NAME), ["--version"], "probing legacy formula", { env });
+      if (legacyProbe.stdout.trim() !== LEGACY_REPORTED_VERSION) {
+        fail("legacy formula setup did not link the distinct fixture payload");
+      }
+      mkdirSync(join(brewPrefix, "Caskroom"), { recursive: true });
+      await commitTapState(tap.source, plan.candidate, "test: migrate formula to candidate cask");
+      // A different installed tap can make the aggregate update command return
+      // non-zero after this tap has already advanced. The migration outcome is
+      // asserted directly below; only an unbounded or unstartable command is an
+      // execution failure in its own right.
+      const update = await runCommand("brew", ["update"], { env, timeout: BREW_UPDATE_TIMEOUT_MS });
+      const updateExecutionProblem = brewUpdateExecutionProblem(update);
+      if (updateExecutionProblem) fail(updateExecutionProblem);
+      await assertTappedCaskBytes({ env, tapName, expected: caskBytes });
+      const lists = await brewLists(env);
+      const probe = await installedProbe({ env, repoRoot, brewPrefix });
+      const problems = [
+        ...migrationCandidateProblems({
+          version: sealed.manifest.versions.app,
+          updateOutput: `${update.stdout}\n${update.stderr}`,
+          caskList: lists.cask,
+          formulaList: lists.formula,
+          brewPrefix,
+          ...probe,
+        }),
+        ...archiveDeliveryProblems({ events: server.events, expectedTarget }),
+      ];
+      if (problems.length > 0) throw new CandidateBrewError(problems);
+    } else {
+      await assertTappedCaskBytes({ env, tapName, expected: caskBytes });
+      packageTouched = true;
+      await runChecked(
+        "brew",
+        ["install", "--cask", `${tapName}/${APP_NAME}`],
+        "installing exact candidate cask",
+        { env, timeout: BREW_INSTALL_TIMEOUT_MS },
+      );
+      const lists = await brewLists(env);
+      const probe = await installedProbe({ env, repoRoot, brewPrefix });
+      const problems = [
+        ...installedCandidateProblems({
+          version: sealed.manifest.versions.app,
+          caskList: lists.cask,
+          formulaList: lists.formula,
+          allowFormula: false,
+          brewPrefix,
+          ...probe,
+        }),
+        ...archiveDeliveryProblems({ events: server.events, expectedTarget }),
+      ];
+      if (problems.length > 0) throw new CandidateBrewError(problems);
+    }
+    notice(
+      `release-candidate-brew: ${mode} qualified ${sealed.manifest.versions.app} from candidate ${sealed.digest}`,
+    );
+  } catch (cause) {
+    primaryFailure = cause;
+  } finally {
+    if (env) cleanupProblems = await cleanupBrew({ env, tapName, tapAdded, packageTouched });
+    if (server) await server.close();
+    try {
+      if (within(resolve(tmpdir()), tempRoot) && tempRoot !== resolve(tmpdir())) {
+        rmSync(tempRoot, { recursive: true, force: true });
+      } else {
+        cleanupProblems.push(`refused to remove unsafe temporary path ${tempRoot}`);
+      }
+    } catch (cause) {
+      cleanupProblems.push(`removing temporary qualification state: ${cause.message}`);
+    }
+  }
+
+  if (primaryFailure) {
+    if (cleanupProblems.length > 0) {
+      throw new CandidateBrewError([primaryFailure.message, ...cleanupProblems]);
+    }
+    throw primaryFailure;
+  }
+  if (cleanupProblems.length > 0) throw new CandidateBrewError(cleanupProblems);
+}
+
+const invokedDirectly = process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url);
+if (invokedDirectly) {
+  const mode = (process.env.MODE || process.argv[2] || "").trim();
+  qualify(mode).catch((cause) => {
+    error(cause instanceof Error ? cause.message : String(cause));
+    log("release-candidate-brew: qualification failed closed");
+    process.exit(1);
+  });
+}

--- a/.github/scripts/release-candidate-brew.test.mjs
+++ b/.github/scripts/release-candidate-brew.test.mjs
@@ -1,0 +1,270 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import {
+  archiveDeliveryProblems,
+  brewUpdateExecutionProblem,
+  brewCommandEnvironment,
+  candidateArchiveRoutes,
+  candidateTapPlan,
+  commandOnPath,
+  commandResultSucceeded,
+  hostTarget,
+  installedCandidateProblems,
+  migrationCandidateProblems,
+  routeCandidateArchive,
+  runCommand,
+  withoutArtifactDomain,
+} from "./release-candidate-brew.mjs";
+
+const VERSION = "2.4.6";
+const TAG = `v${VERSION}`;
+const SOURCE_URL = "https://github.com/example/project";
+const ROOT = "/tmp/candidate-brew-unit";
+const TARGETS = ["darwin/amd64", "darwin/arm64", "linux/amd64", "linux/arm64"];
+const SHORT_COMMAND_TIMEOUT_MS = 100;
+const COMMAND_BOUND_ASSERTION_MS = 4_000;
+const SMALL_OUTPUT_LIMIT_BYTES = 32;
+const COMMAND_NOT_STARTED_STATUS = 127;
+
+function manifest() {
+  return {
+    source: { url: SOURCE_URL },
+    versions: { app: VERSION, app_tag: TAG },
+    files: TARGETS.map((target) => {
+      const [goos, goarch] = target.split("/");
+      return { path: `app/assets/cerberus_${VERSION}_${goos}_${goarch}.tar.gz` };
+    }),
+  };
+}
+
+function healthyInstall(overrides = {}) {
+  const prefix = "/opt/brew";
+  return {
+    version: VERSION,
+    caskList: `cerberus ${VERSION}\n`,
+    formulaList: "",
+    allowFormula: false,
+    brewPrefix: prefix,
+    resolvedPath: `${prefix}/bin/cerberus`,
+    pathCommand: `${prefix}/bin/cerberus`,
+    realPath: `${prefix}/Caskroom/cerberus/${VERSION}/cerberus`,
+    reportedVersion: VERSION,
+    schemaStatus: 0,
+    schemaOutput: "CREATE TABLE telemetry",
+    docsStatus: 0,
+    ...overrides,
+  };
+}
+
+test("archive routing retains the complete candidate source and release binding", () => {
+  const routes = candidateArchiveRoutes({ manifest: manifest(), candidateRoot: ROOT });
+  assert.deepEqual(routes.map((route) => route.target), TARGETS);
+  const linux = routes.find((route) => route.target === "linux/amd64");
+  assert.equal(linux.originalUrl, `${SOURCE_URL}/releases/download/${TAG}/cerberus_${VERSION}_linux_amd64.tar.gz`);
+  assert.deepEqual(linux.paths, [
+    `/${linux.originalUrl}`,
+    `/example/project/releases/download/${TAG}/cerberus_${VERSION}_linux_amd64.tar.gz`,
+    `/github.com/example/project/releases/download/${TAG}/cerberus_${VERSION}_linux_amd64.tar.gz`,
+  ]);
+  assert.equal(linux.absolutePath, `${ROOT}/app/assets/cerberus_${VERSION}_linux_amd64.tar.gz`);
+});
+
+test("archive routing rejects a manifest without every sealed platform archive", () => {
+  const broken = manifest();
+  broken.files.pop();
+  assert.throws(
+    () => candidateArchiveRoutes({ manifest: broken, candidateRoot: ROOT }),
+    /does not declare app\/assets\/cerberus_2\.4\.6_linux_arm64\.tar\.gz/,
+  );
+});
+
+test("the pure request router accepts only exact body and metadata requests", () => {
+  const routes = candidateArchiveRoutes({ manifest: manifest(), candidateRoot: ROOT });
+  const route = routes[2];
+  for (const path of route.paths) {
+    const get = routeCandidateArchive({ method: "GET", requestUrl: path, routes });
+    assert.equal(get.status, 200, path);
+    assert.equal(get.archive.target, "linux/amd64");
+    assert.equal(get.sendBody, true);
+
+    const head = routeCandidateArchive({ method: "HEAD", requestUrl: path, routes });
+    assert.equal(head.status, 200, path);
+    assert.equal(head.sendBody, false);
+  }
+  assert.equal(routeCandidateArchive({ method: "POST", requestUrl: route.paths[0], routes }).status, 405);
+  assert.equal(routeCandidateArchive({ method: "GET", requestUrl: `${route.paths[0]}?other=1`, routes }).status, 400);
+  assert.equal(routeCandidateArchive({ method: "GET", requestUrl: "/cerberus_2.4.6_linux_amd64.tar.gz", routes }).status, 404);
+  assert.equal(routeCandidateArchive({ method: "GET", requestUrl: "http://elsewhere.invalid/file", routes }).status, 400);
+});
+
+test("the tap plan preserves exact cask bytes and models a real deletion", () => {
+  const cask = Buffer.from("cask bytes\u0000remain exact\n");
+  const plan = candidateTapPlan({
+    tapName: "candidate-local/qualification",
+    caskBytes: cask,
+    legacyArchiveUrl: "file:///tmp/legacy-source.tar.gz",
+    legacyArchiveSha256: "a".repeat(64),
+  });
+  assert.deepEqual(plan.legacy.removes, []);
+  assert.equal(plan.legacy.writes[0].path, "Formula/cerberus.rb");
+  assert.match(plan.legacy.writes[0].bytes.toString(), /version "0\.0\.0"/);
+  assert.deepEqual(plan.candidate.removes, ["Formula/cerberus.rb"]);
+  assert.equal(plan.candidate.writes[0].path, "Casks/cerberus.rb");
+  assert.deepEqual(plan.candidate.writes[0].bytes, cask);
+  assert.equal(
+    plan.candidate.writes[1].bytes.toString(),
+    '{"cerberus":"candidate-local/qualification"}\n',
+  );
+});
+
+test("the tap plan rejects unsafe names, mutable cask text, and remote legacy payloads", () => {
+  const valid = {
+    tapName: "candidate-local/qualification",
+    caskBytes: Buffer.from("candidate"),
+    legacyArchiveUrl: "file:///tmp/legacy-source.tar.gz",
+    legacyArchiveSha256: "b".repeat(64),
+  };
+  assert.throws(() => candidateTapPlan({ ...valid, tapName: "../escape" }), /invalid ephemeral tap name/);
+  assert.throws(() => candidateTapPlan({ ...valid, caskBytes: "candidate" }), /cask bytes are required/);
+  assert.throws(() => candidateTapPlan({ ...valid, legacyArchiveUrl: "https://invalid.example/file" }), /file URL/);
+});
+
+test("the brew environment makes loopback authoritative and isolates downloads", () => {
+  const env = brewCommandEnvironment(
+    {
+      PATH: "/bin",
+      HOMEBREW_ARTIFACT_DOMAIN: "https://invalid.example",
+      HOMEBREW_CACHE: "/wrong",
+    },
+    { artifactOrigin: "http://127.0.0.1:43123", stateRoot: "/tmp/qualification-state" },
+  );
+  assert.equal(env.PATH, "/bin");
+  assert.equal(env.HOMEBREW_ARTIFACT_DOMAIN, "http://127.0.0.1:43123");
+  assert.equal(env.HOMEBREW_ARTIFACT_DOMAIN_NO_FALLBACK, "1");
+  assert.equal(env.HOMEBREW_CACHE, "/tmp/qualification-state/cache");
+  assert.equal(env.HOMEBREW_NO_AUTO_UPDATE, "1");
+  const setup = withoutArtifactDomain(env);
+  assert.equal(setup.HOMEBREW_ARTIFACT_DOMAIN, undefined);
+  assert.equal(setup.HOMEBREW_ARTIFACT_DOMAIN_NO_FALLBACK, undefined);
+  assert.equal(setup.HOMEBREW_CACHE, "/tmp/qualification-state/cache");
+  assert.equal(env.HOMEBREW_ARTIFACT_DOMAIN, "http://127.0.0.1:43123");
+  assert.throws(
+    () => brewCommandEnvironment({}, { artifactOrigin: "http://0.0.0.0:43123", stateRoot: "/tmp/state" }),
+    /loopback origin/,
+  );
+  assert.throws(
+    () => brewCommandEnvironment({}, { artifactOrigin: "https://127.0.0.1:43123", stateRoot: "/tmp/state" }),
+    /loopback origin/,
+  );
+});
+
+test("host target selection is exact and closed", () => {
+  assert.equal(hostTarget("linux", "x64"), "linux/amd64");
+  assert.equal(hostTarget("linux", "arm64"), "linux/arm64");
+  assert.equal(hostTarget("darwin", "x64"), "darwin/amd64");
+  assert.equal(hostTarget("darwin", "arm64"), "darwin/arm64");
+  assert.throws(() => hostTarget("win32", "x64"), /unsupported Homebrew qualification host/);
+});
+
+test("PATH resolution is ordered, executable-only, and shell-free", () => {
+  assert.equal(commandOnPath("sh", "/definitely-absent:/bin"), "/bin/sh");
+  assert.equal(commandOnPath("not-present-anywhere", "/bin:/usr/bin"), "");
+  assert.equal(commandOnPath("../sh", "/bin"), "");
+});
+
+test("command success rejects deadline, output-cap, and signal results even with exit zero", () => {
+  const healthy = { status: 0, signal: null, timedOut: false, overflow: false };
+  assert.equal(commandResultSucceeded(healthy), true);
+  assert.equal(commandResultSucceeded({ ...healthy, timedOut: true }), false);
+  assert.equal(commandResultSucceeded({ ...healthy, overflow: true }), false);
+  assert.equal(commandResultSucceeded({ ...healthy, signal: "SIGTERM" }), false);
+});
+
+test("the update allowance accepts ordinary non-zero exits but rejects incomplete execution", () => {
+  const ordinaryTapFailure = { status: 1, signal: null, timedOut: false, overflow: false };
+  assert.equal(brewUpdateExecutionProblem(ordinaryTapFailure), null);
+  assert.match(
+    brewUpdateExecutionProblem({ ...ordinaryTapFailure, signal: "SIGTERM" }),
+    /brew update failed/,
+  );
+  assert.match(brewUpdateExecutionProblem({ ...ordinaryTapFailure, timedOut: true }), /brew update failed/);
+  assert.match(brewUpdateExecutionProblem({ ...ordinaryTapFailure, overflow: true }), /brew update failed/);
+  assert.match(
+    brewUpdateExecutionProblem({ ...ordinaryTapFailure, status: COMMAND_NOT_STARTED_STATUS }),
+    /brew update failed/,
+  );
+});
+
+test("the command deadline kills descendants that retain the output pipes", async () => {
+  const started = Date.now();
+  const result = await runCommand("sh", ["-c", "sleep 30 & wait"], { timeout: SHORT_COMMAND_TIMEOUT_MS });
+  assert.equal(result.timedOut, true);
+  assert.equal(commandResultSucceeded(result), false);
+  assert.ok(Date.now() - started < COMMAND_BOUND_ASSERTION_MS, "descendant-held pipes exceeded the hard bound");
+});
+
+test("the output cap terminates a command that exits cleanly on SIGTERM", async () => {
+  const child = "trap 'exit 0' TERM; printf '%4096s' x; while :; do sleep 30; done";
+  const result = await runCommand("sh", ["-c", child], {
+    timeout: COMMAND_BOUND_ASSERTION_MS,
+    maxOutput: SMALL_OUTPUT_LIMIT_BYTES,
+  });
+  assert.equal(result.overflow, true);
+  assert.equal(commandResultSucceeded(result), false);
+});
+
+test("fresh-install verdict binds artifact kind, link target, version, and payloads", () => {
+  assert.deepEqual(installedCandidateProblems(healthyInstall()), []);
+  const problems = installedCandidateProblems(
+    healthyInstall({
+      caskList: "",
+      formulaList: `cerberus ${VERSION}\n`,
+      resolvedPath: "/usr/local/bin/cerberus",
+      pathCommand: "/tmp/other/cerberus",
+      realPath: "/opt/brew/Cellar/cerberus/2.4.5/bin/cerberus",
+      reportedVersion: "2.4.60",
+      schemaOutput: "",
+      docsStatus: 1,
+    }),
+  );
+  assert.equal(problems.length, 8);
+  assert.match(problems.join("\n"), /not installed/);
+  assert.match(problems.join("\n"), /formula/);
+  assert.match(problems.join("\n"), /outside/);
+  assert.match(problems.join("\n"), /PATH/);
+  assert.match(problems.join("\n"), /Caskroom/);
+  assert.match(problems.join("\n"), /2\.4\.60/);
+  assert.match(problems.join("\n"), /CREATE/);
+  assert.match(problems.join("\n"), /config registry/);
+});
+
+test("migration verdict requires the update announcement and candidate link", () => {
+  const healthy = healthyInstall({
+    allowFormula: true,
+    formulaList: "cerberus 0.0.0\n",
+    updateOutput: "candidate-local/qualification/cerberus has been migrated from a formula to a cask",
+  });
+  assert.deepEqual(migrationCandidateProblems(healthy), []);
+  const problems = migrationCandidateProblems({ ...healthy, updateOutput: "Already up-to-date", formulaList: "" });
+  assert.equal(problems.length, 1);
+  assert.match(problems[0], /did not announce/);
+});
+
+test("archive delivery requires a successful body fetch of the host archive", () => {
+  const healthy = [
+    { method: "HEAD", status: 200, target: "linux/amd64", bytes: 0 },
+    { method: "GET", status: 200, target: "linux/amd64", bytes: 2048 },
+  ];
+  assert.deepEqual(archiveDeliveryProblems({ events: healthy, expectedTarget: "linux/amd64" }), []);
+  assert.equal(
+    archiveDeliveryProblems({ events: healthy.slice(0, 1), expectedTarget: "linux/amd64" }).length,
+    1,
+  );
+  const rejected = [...healthy, { method: "GET", status: 404, target: "", bytes: 0 }];
+  assert.equal(archiveDeliveryProblems({ events: rejected, expectedTarget: "linux/amd64" }).length, 1);
+  assert.equal(
+    archiveDeliveryProblems({ events: healthy, expectedTarget: "darwin/arm64" }).length,
+    1,
+  );
+});

--- a/.github/scripts/release-candidate.mjs
+++ b/.github/scripts/release-candidate.mjs
@@ -1,0 +1,1316 @@
+// release-candidate.mjs — stage, seal, and verify one unpublished release
+// candidate before any tag, registry, package, or release write is permitted.
+//
+// Modes (MODE or argv[2]):
+//   stage   validate GoReleaser's snapshot output, copy the exact archives,
+//           checksum, and generated cask into the candidate, and materialise
+//           the two-platform Docker build context from those same binaries.
+//   image   build one unpublished multi-platform OCI layout from that context.
+//   seal    bind every candidate byte to the exact source SHA/tree and write a
+//           canonical manifest. Its sha256 is the immutable candidate digest.
+//   verify  recompute the manifest digest, exact file roster, and every file
+//           digest. Expected SHA/tree/version/digest mismatches fail closed.
+//
+// Environment:
+//   RELEASE_CANDIDATE_DIR   candidate root (default build/release-candidate).
+//   GORELEASER_DIST         snapshot output (default dist; stage only).
+//   RELEASE_IMAGE_CONTEXT  staged image context
+//                          (default build/release-image-context; stage only).
+//   RELEASE_APP_VERSION    exact application version (required).
+//   RELEASE_APP_TAG        exact v-prefixed application tag (required).
+//   RELEASE_CHART_VERSION  exact chart version (required for seal/verify).
+//   RELEASE_CHART_PACKAGE  packaged chart path (required for stage).
+//   RELEASE_CHART_METADATA Artifact Hub repository metadata (required for
+//                          stage and promoted only from the sealed candidate).
+//   RELEASE_SOURCE_SHA     exact 40-hex commit (required).
+//   RELEASE_SOURCE_TREE    exact 40-hex Git tree (required).
+//   RELEASE_SOURCE_URL     runtime HTTPS source URL (required for every mode;
+//                          sealed into source identity and cask URLs).
+//   RELEASE_RUN_ID         qualification workflow run id (required for seal).
+//   RELEASE_RUN_ATTEMPT    positive run attempt (required for seal).
+//   RELEASE_CANDIDATE_DIGEST
+//                          expected sha256:<hex> (required for verify).
+//   GITHUB_OUTPUT          receives candidate/context/digest outputs.
+//
+// Node builtins only. A candidate directory is a closed set: an unlisted file
+// is as invalid as a missing or changed file, so promotion cannot smuggle bytes
+// that the qualification attestation did not bind.
+
+import { createHash } from "node:crypto";
+import { spawnSync } from "node:child_process";
+import {
+  copyFileSync,
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  readdirSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from "node:fs";
+import { dirname, join, relative, resolve, sep } from "node:path";
+import process from "node:process";
+import { fileURLToPath } from "node:url";
+
+import { capture, error, notice, setOutput } from "./lib/gh.mjs";
+import {
+  validateReleaseArtifactSet,
+  validateSealedCandidateArtifacts,
+} from "./release-artifact-validator.mjs";
+
+export const CANDIDATE_SCHEMA_VERSION = 1;
+export const CANDIDATE_MANIFEST = "candidate-manifest.json";
+export const REQUIRED_TARGETS = Object.freeze([
+  Object.freeze({ goos: "darwin", goarch: "amd64" }),
+  Object.freeze({ goos: "darwin", goarch: "arm64" }),
+  Object.freeze({ goos: "linux", goarch: "amd64" }),
+  Object.freeze({ goos: "linux", goarch: "arm64" }),
+]);
+
+const SHA_RE = /^[0-9a-f]{40}$/;
+const DIGEST_RE = /^sha256:[0-9a-f]{64}$/;
+const VERSION_RE = /^\d+\.\d+\.\d+(?:-[0-9A-Za-z][0-9A-Za-z.-]*)?$/;
+const SOURCE_URL_RE = /^https:\/\/[A-Za-z0-9.-]+\/[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/;
+const OCI_SCHEMA_VERSION = 2;
+const OCI_INDEX_MEDIA_TYPE = "application/vnd.oci.image.index.v1+json";
+const OCI_MANIFEST_MEDIA_TYPE = "application/vnd.oci.image.manifest.v1+json";
+const OCI_CONFIG_MEDIA_TYPE = "application/vnd.oci.image.config.v1+json";
+const IN_TOTO_MEDIA_TYPE = "application/vnd.in-toto+json";
+const IN_TOTO_STATEMENT_TYPE = "https://in-toto.io/Statement/v0.1";
+const SPDX_PREDICATE_TYPE = "https://spdx.dev/Document";
+const PROVENANCE_PREDICATE_TYPE = "https://slsa.dev/provenance/v0.2";
+const BUILDKIT_BUILD_TYPE = "https://mobyproject.org/buildkit@v1";
+const ATTESTATION_REFERENCE_TYPE = "attestation-manifest";
+const REQUIRED_IMAGE_PLATFORMS = Object.freeze(["linux/amd64", "linux/arm64"]);
+const MANIFEST_KEYS = new Set([
+  "schema_version",
+  "source",
+  "versions",
+  "run",
+  "files",
+  "image",
+]);
+const SOURCE_KEYS = new Set(["sha", "tree", "url"]);
+const VERSION_KEYS = new Set(["app", "app_tag", "chart"]);
+const RUN_KEYS = new Set(["id", "attempt"]);
+const FILE_KEYS = new Set(["path", "size", "sha256"]);
+const IMAGE_KEYS = new Set(["layout", "digest", "platforms"]);
+const SOURCE_DOCUMENT_KEYS = new Set([
+  "app_tag",
+  "app_version",
+  "sha",
+  "source_url",
+  "tree",
+]);
+
+export class CandidateError extends Error {
+  constructor(problems) {
+    super(`release candidate is invalid:\n${problems.map((p) => `- ${p}`).join("\n")}`);
+    this.name = "CandidateError";
+    this.problems = problems;
+  }
+}
+
+function exactKeys(value, allowed, label, problems) {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) {
+    problems.push(`${label} must be an object`);
+    return false;
+  }
+  const extras = Object.keys(value).filter((key) => !allowed.has(key));
+  const missing = [...allowed].filter((key) => !(key in value));
+  if (extras.length > 0) problems.push(`${label} has unknown keys: ${extras.join(", ")}`);
+  if (missing.length > 0) problems.push(`${label} is missing keys: ${missing.join(", ")}`);
+  return extras.length === 0 && missing.length === 0;
+}
+
+function requiredString(value, label, problems, pattern = null) {
+  if (typeof value !== "string" || value === "") {
+    problems.push(`${label} must be a non-empty string`);
+    return;
+  }
+  if (pattern && !pattern.test(value)) problems.push(`${label} has invalid value ${JSON.stringify(value)}`);
+}
+
+function canonicalPath(root, path, label) {
+  const absolute = resolve(root, path);
+  const rel = relative(root, absolute);
+  if (rel === "" || rel === ".." || rel.startsWith(`..${sep}`) || rel.startsWith(sep)) {
+    throw new CandidateError([`${label} escapes ${root}: ${path}`]);
+  }
+  return { absolute, relative: rel.split(sep).join("/") };
+}
+
+function readJSON(path, label = path) {
+  let value;
+  try {
+    value = JSON.parse(readFileSync(path, "utf8"));
+  } catch (cause) {
+    throw new CandidateError([`${label} is not valid JSON: ${cause.message}`]);
+  }
+  return value;
+}
+
+export function canonicalJSON(value) {
+  if (Array.isArray(value)) return `[${value.map(canonicalJSON).join(",")}]`;
+  if (value && typeof value === "object") {
+    return `{${Object.keys(value)
+      .sort()
+      .map((key) => `${JSON.stringify(key)}:${canonicalJSON(value[key])}`)
+      .join(",")}}`;
+  }
+  return JSON.stringify(value);
+}
+
+export function sha256Bytes(value) {
+  return `sha256:${createHash("sha256").update(value).digest("hex")}`;
+}
+
+export function sha256File(path) {
+  return sha256Bytes(readFileSync(path));
+}
+
+export function manifestDigest(manifest) {
+  return sha256Bytes(`${canonicalJSON(manifest)}\n`);
+}
+
+function walkFiles(root, current = root) {
+  const files = [];
+  for (const entry of readdirSync(current, { withFileTypes: true })) {
+    const absolute = join(current, entry.name);
+    if (entry.isSymbolicLink()) {
+      throw new CandidateError([`candidate contains symlink ${relative(root, absolute)}`]);
+    }
+    if (entry.isDirectory()) files.push(...walkFiles(root, absolute));
+    else if (entry.isFile()) files.push(relative(root, absolute).split(sep).join("/"));
+    else throw new CandidateError([`candidate contains unsupported entry ${relative(root, absolute)}`]);
+  }
+  return files.sort();
+}
+
+function copyBoundFile(source, root, destination) {
+  if (!existsSync(source) || !statSync(source).isFile()) {
+    throw new CandidateError([`required build output is missing: ${source}`]);
+  }
+  const target = canonicalPath(root, destination, "candidate destination").absolute;
+  mkdirSync(dirname(target), { recursive: true });
+  copyFileSync(source, target);
+}
+
+function targetKey(value) {
+  return `${value.goos}/${value.goarch}`;
+}
+
+function selectUniqueArtifact(artifacts, predicate, label) {
+  const found = artifacts.filter(predicate);
+  if (found.length !== 1) {
+    throw new CandidateError([`${label}: found ${found.length}, want exactly 1`]);
+  }
+  return found[0];
+}
+
+export function releaseArtifacts(document, { version, commit }) {
+  if (!Array.isArray(document)) throw new CandidateError(["dist/artifacts.json must be an array"]);
+  const problems = [];
+  const binaries = new Map();
+  const archives = new Map();
+  for (const target of REQUIRED_TARGETS) {
+    const key = targetKey(target);
+    const binary = document.filter(
+      (item) => item?.type === "Binary" && item.goos === target.goos && item.goarch === target.goarch,
+    );
+    const archive = document.filter(
+      (item) => item?.type === "Archive" && item.goos === target.goos && item.goarch === target.goarch,
+    );
+    if (binary.length !== 1) problems.push(`${key}: found ${binary.length} binaries, want exactly 1`);
+    else binaries.set(key, binary[0]);
+    if (archive.length !== 1) problems.push(`${key}: found ${archive.length} archives, want exactly 1`);
+    else {
+      if (archive[0].name !== `cerberus_${version}_${target.goos}_${target.goarch}.tar.gz`) {
+        problems.push(`${key}: archive name ${archive[0].name} does not carry version ${version}`);
+      }
+      archives.set(key, archive[0]);
+    }
+  }
+  const checksum = document.filter((item) => item?.type === "Checksum");
+  const cask = document.filter((item) => item?.type === "Homebrew Cask");
+  const metadata = document.filter((item) => item?.type === "Metadata");
+  if (checksum.length !== 1) problems.push(`found ${checksum.length} checksum artifacts, want exactly 1`);
+  if (cask.length !== 1) problems.push(`found ${cask.length} cask artifacts, want exactly 1`);
+  if (metadata.length !== 1) problems.push(`found ${metadata.length} metadata artifacts, want exactly 1`);
+  if (problems.length > 0) throw new CandidateError(problems);
+  return {
+    binaries,
+    archives,
+    checksum: checksum[0],
+    cask: cask[0],
+    metadata: metadata[0],
+    commit,
+  };
+}
+
+// GoReleaser snapshot metadata uses `tag` for the repository tag it discovered
+// while deriving release history. It does not become the unpublished future
+// tag merely because snapshot.version_template supplies RELEASE_VERSION. The
+// candidate identity is instead bound by RELEASE_APP_TAG == v<version>,
+// source.json, the archive names, and the sealed manifest. Treating metadata's
+// historical tag as candidate identity makes every legitimate snapshot fail.
+export function validateSnapshotMetadata(metadata, { version, commit }) {
+  const problems = [];
+  if (metadata === null || typeof metadata !== "object" || Array.isArray(metadata)) {
+    problems.push("GoReleaser metadata must be an object");
+  } else {
+    if (metadata.version !== version) {
+      problems.push(`GoReleaser version ${metadata.version} does not equal ${version}`);
+    }
+    if (metadata.commit !== commit) {
+      problems.push(`GoReleaser commit ${metadata.commit} does not equal ${commit}`);
+    }
+  }
+  if (problems.length > 0) throw new CandidateError(problems);
+  return metadata;
+}
+
+export function validateReleaseChecksums(root, version) {
+  const expected = new Map(
+    REQUIRED_TARGETS.map((target) => {
+      const name = `cerberus_${version}_${target.goos}_${target.goarch}.tar.gz`;
+      return [name, join(root, "app/assets", name)];
+    }),
+  );
+  const checksumPath = join(root, "app/assets/checksums.txt");
+  if (!existsSync(checksumPath) || !statSync(checksumPath).isFile()) {
+    throw new CandidateError([`candidate checksum file is missing: ${checksumPath}`]);
+  }
+  const lines = readFileSync(checksumPath, "utf8")
+    .split(/\r?\n/)
+    .filter((line) => line !== "");
+  const actual = new Map();
+  const problems = [];
+  for (const line of lines) {
+    const match = line.match(/^([0-9a-f]{64})  ([^/\\]+)$/);
+    if (!match) {
+      problems.push(`malformed checksum line ${JSON.stringify(line)}`);
+      continue;
+    }
+    const [, digest, name] = match;
+    if (actual.has(name)) problems.push(`checksum entry ${name} is duplicated`);
+    actual.set(name, digest);
+  }
+  for (const [name, path] of expected) {
+    if (!existsSync(path) || !statSync(path).isFile()) {
+      problems.push(`checksum target ${name} is missing`);
+      continue;
+    }
+    const wanted = sha256File(path).slice("sha256:".length);
+    if (actual.get(name) !== wanted) {
+      problems.push(`checksum for ${name} is ${actual.get(name) ?? "<missing>"}, want ${wanted}`);
+    }
+  }
+  for (const name of actual.keys()) {
+    if (!expected.has(name)) problems.push(`checksums.txt contains unexpected release asset ${name}`);
+  }
+  if (problems.length > 0) throw new CandidateError(problems);
+  return Object.freeze([...actual.keys()].sort());
+}
+
+function requiredEnv(name, pattern = null) {
+  const value = process.env[name];
+  const problems = [];
+  requiredString(value, name, problems, pattern);
+  if (problems.length > 0) throw new CandidateError(problems);
+  return value;
+}
+
+export function verifyCheckout(sha, tree, root = process.cwd()) {
+  const cwd = resolve(root);
+  const top = capture("git", ["rev-parse", "--show-toplevel"], { cwd });
+  const head = capture("git", ["rev-parse", "HEAD"], { cwd });
+  const headTree = capture("git", ["rev-parse", "HEAD^{tree}"], { cwd });
+  const status = capture("git", ["status", "--porcelain=v1", "--untracked-files=all"], { cwd });
+  const problems = [];
+  if (top.status !== 0) problems.push(`git rev-parse --show-toplevel failed: ${top.stderr.trim()}`);
+  else if (resolve(top.stdout.trim()) !== cwd) {
+    problems.push(`candidate verification runs at ${cwd}, not repository root ${top.stdout.trim()}`);
+  }
+  if (head.status !== 0) problems.push(`git rev-parse HEAD failed: ${head.stderr.trim()}`);
+  else if (head.stdout.trim() !== sha) problems.push(`checkout HEAD is ${head.stdout.trim()}, want ${sha}`);
+  if (headTree.status !== 0) problems.push(`git rev-parse HEAD^{tree} failed: ${headTree.stderr.trim()}`);
+  else if (headTree.stdout.trim() !== tree) {
+    problems.push(`checkout tree is ${headTree.stdout.trim()}, want ${tree}`);
+  }
+  if (status.status !== 0) problems.push(`git status failed: ${status.stderr.trim()}`);
+  else if (status.stdout.trim() !== "") {
+    problems.push(
+      "checkout has tracked or untracked modifications; candidate source is not the exact Git tree",
+    );
+  }
+  if (problems.length > 0) throw new CandidateError(problems);
+}
+
+function candidateRoot() {
+  return resolve(process.env.RELEASE_CANDIDATE_DIR || "build/release-candidate");
+}
+
+function validateSourceDocument(root, expected) {
+  const source = readJSON(join(root, "source.json"), "candidate source identity");
+  const problems = [];
+  if (exactKeys(source, SOURCE_DOCUMENT_KEYS, "candidate source identity", problems)) {
+    for (const [field, wanted, pattern] of [
+      ["sha", expected.sha, SHA_RE],
+      ["tree", expected.tree, SHA_RE],
+      ["app_version", expected.app, VERSION_RE],
+      ["app_tag", expected.appTag, null],
+      ["source_url", expected.sourceUrl, SOURCE_URL_RE],
+    ]) {
+      requiredString(source[field], `candidate source identity.${field}`, problems, pattern);
+      if (source[field] !== wanted) {
+        problems.push(`candidate source identity.${field} is ${source[field]}, want ${wanted}`);
+      }
+    }
+  }
+  if (problems.length > 0) throw new CandidateError(problems);
+  return source;
+}
+
+function stage() {
+  const root = candidateRoot();
+  const dist = resolve(process.env.GORELEASER_DIST || "dist");
+  const context = resolve(process.env.RELEASE_IMAGE_CONTEXT || "build/release-image-context");
+  const version = requiredEnv("RELEASE_APP_VERSION", VERSION_RE);
+  const tag = requiredEnv("RELEASE_APP_TAG");
+  const chart = requiredEnv("RELEASE_CHART_VERSION", VERSION_RE);
+  const chartPackage = resolve(requiredEnv("RELEASE_CHART_PACKAGE"));
+  const chartMetadata = resolve(requiredEnv("RELEASE_CHART_METADATA"));
+  const sha = requiredEnv("RELEASE_SOURCE_SHA", SHA_RE);
+  const tree = requiredEnv("RELEASE_SOURCE_TREE", SHA_RE);
+  const sourceUrl = requiredEnv("RELEASE_SOURCE_URL", SOURCE_URL_RE);
+  verifyCheckout(sha, tree);
+  if (tag !== `v${version}`) throw new CandidateError([`RELEASE_APP_TAG ${tag} must equal v${version}`]);
+
+  validateSnapshotMetadata(readJSON(join(dist, "metadata.json"), "GoReleaser metadata"), {
+    version,
+    commit: sha,
+  });
+
+  const selected = releaseArtifacts(readJSON(join(dist, "artifacts.json")), {
+    version,
+    commit: sha,
+  });
+  validateReleaseArtifactSet({
+    version,
+    chartVersion: chart,
+    appTag: tag,
+    sourceUrl,
+    archives: new Map(
+      REQUIRED_TARGETS.map((target) => {
+        const key = targetKey(target);
+        return [key, readFileSync(resolve(selected.archives.get(key).path))];
+      }),
+    ),
+    binaries: new Map(
+      REQUIRED_TARGETS.map((target) => {
+        const key = targetKey(target);
+        return [key, readFileSync(resolve(selected.binaries.get(key).path))];
+      }),
+    ),
+    cask: readFileSync(resolve(selected.cask.path)),
+    chart: readFileSync(chartPackage),
+  });
+  rmSync(root, { recursive: true, force: true });
+  rmSync(context, { recursive: true, force: true });
+  mkdirSync(root, { recursive: true });
+  mkdirSync(context, { recursive: true });
+
+  for (const target of REQUIRED_TARGETS) {
+    const key = targetKey(target);
+    const archive = selected.archives.get(key);
+    copyBoundFile(resolve(archive.path), root, `app/assets/${archive.name}`);
+    if (target.goos === "linux") {
+      const binary = selected.binaries.get(key);
+      copyBoundFile(resolve(binary.path), context, `${target.goos}/${target.goarch}/cerberus`);
+    }
+  }
+  copyBoundFile(resolve(selected.checksum.path), root, "app/assets/checksums.txt");
+  copyBoundFile(resolve(selected.cask.path), root, "app/homebrew/cerberus.rb");
+  copyBoundFile(chartPackage, root, `chart/cerberus-${chart}.tgz`);
+  copyBoundFile(chartMetadata, root, "chart/artifacthub-repo.yml");
+  writeFileSync(join(root, "chart/artifacthub-config.yml"), "");
+  writeFileSync(
+    join(root, "source.json"),
+    `${canonicalJSON({ app_tag: tag, app_version: version, sha, source_url: sourceUrl, tree })}\n`,
+  );
+  setOutput("candidate_dir", root);
+  setOutput("image_context", context);
+  notice(`release candidate staged for ${tag} at ${sha.slice(0, 12)} tree ${tree.slice(0, 12)}`);
+}
+
+export function candidateImageBuildInvocation({
+  root,
+  context,
+  candidateRoot,
+  version,
+  sha,
+  sourceURL,
+}) {
+  const problems = [];
+  requiredString(version, "release image version", problems, VERSION_RE);
+  requiredString(sha, "release image source SHA", problems, SHA_RE);
+  requiredString(sourceURL, "release image source URL", problems, SOURCE_URL_RE);
+  if (problems.length > 0) throw new CandidateError(problems);
+  const layout = join(resolve(candidateRoot), "app/image");
+  return Object.freeze({
+    command: "docker",
+    args: Object.freeze([
+      "buildx",
+      "build",
+      "--file",
+      join(resolve(root), "Dockerfile"),
+      "--platform",
+      "linux/amd64,linux/arm64",
+      "--build-arg",
+      `RELEASE_VERSION=${version}`,
+      "--build-arg",
+      `SOURCE_SHA=${sha}`,
+      "--build-arg",
+      `SOURCE_URL=${sourceURL}`,
+      "--tag",
+      `docker.io/library/cerberus:${version}`,
+      "--sbom=true",
+      "--provenance=mode=max",
+      "--output",
+      `type=oci,dest=${layout},tar=false`,
+      resolve(context),
+    ]),
+    cwd: resolve(root),
+    layout,
+  });
+}
+
+function image() {
+  const top = capture("git", ["rev-parse", "--show-toplevel"]);
+  if (top.status !== 0 || top.stdout.trim() === "") {
+    throw new CandidateError([
+      `cannot resolve repository root: ${top.stderr.trim() || "git returned no path"}`,
+    ]);
+  }
+  const root = resolve(top.stdout.trim());
+  const candidate = candidateRoot();
+  const context = resolve(process.env.RELEASE_IMAGE_CONTEXT || "build/release-image-context");
+  const version = requiredEnv("RELEASE_APP_VERSION", VERSION_RE);
+  const sha = requiredEnv("RELEASE_SOURCE_SHA", SHA_RE);
+  const tree = requiredEnv("RELEASE_SOURCE_TREE", SHA_RE);
+  const sourceURL = requiredEnv("RELEASE_SOURCE_URL", SOURCE_URL_RE);
+  verifyCheckout(sha, tree);
+  validateSourceDocument(candidate, {
+    sha,
+    tree,
+    app: version,
+    appTag: requiredEnv("RELEASE_APP_TAG"),
+    sourceUrl: sourceURL,
+  });
+  const invocation = candidateImageBuildInvocation({
+    root,
+    context,
+    candidateRoot: candidate,
+    version,
+    sha,
+    sourceURL,
+  });
+  rmSync(invocation.layout, { recursive: true, force: true });
+  const result = spawnSync(invocation.command, invocation.args, {
+    cwd: invocation.cwd,
+    env: process.env,
+    stdio: "inherit",
+  });
+  if (result.error || result.status !== 0) {
+    throw new CandidateError([
+      result.error
+        ? `candidate image build failed: ${result.error.message}`
+        : `candidate image build exited with status ${result.status}`,
+    ]);
+  }
+  setOutput("image_layout", invocation.layout);
+  notice(`built unpublished candidate OCI layout for ${version}`);
+}
+
+function validateOCIDescriptor(root, layout, descriptor, reachable, problems, label) {
+  if (!descriptor || typeof descriptor !== "object" || Array.isArray(descriptor)) {
+    problems.push(`${label} must be an OCI descriptor object`);
+    return;
+  }
+  if (!DIGEST_RE.test(descriptor.digest ?? "")) {
+    problems.push(`${label}.digest is not sha256`);
+    return;
+  }
+  if (!Number.isSafeInteger(descriptor.size) || descriptor.size < 0) {
+    problems.push(`${label}.size is not a non-negative integer`);
+    return;
+  }
+  const blob = `${layout}/blobs/sha256/${descriptor.digest.slice("sha256:".length)}`;
+  const absolute = join(root, blob);
+  if (!existsSync(absolute) || !statSync(absolute).isFile()) {
+    problems.push(`${label} references missing blob ${blob}`);
+    return;
+  }
+  const actualSize = statSync(absolute).size;
+  if (actualSize !== descriptor.size) problems.push(`${blob}: size ${actualSize}, want ${descriptor.size}`);
+  const actualDigest = sha256File(absolute);
+  if (actualDigest !== descriptor.digest) problems.push(`${blob}: digest ${actualDigest}, want ${descriptor.digest}`);
+  if (reachable.has(blob)) return;
+  reachable.add(blob);
+
+  const mediaType = String(descriptor.mediaType ?? "");
+  const isIndex = new Set([
+    "application/vnd.oci.image.index.v1+json",
+    "application/vnd.docker.distribution.manifest.list.v2+json",
+  ]).has(mediaType);
+  const isManifest = new Set([
+    "application/vnd.oci.image.manifest.v1+json",
+    "application/vnd.docker.distribution.manifest.v2+json",
+  ]).has(mediaType);
+  if (!isIndex && !isManifest) return;
+  let document;
+  try {
+    document = JSON.parse(readFileSync(absolute, "utf8"));
+  } catch (cause) {
+    problems.push(`${blob}: JSON media type has malformed content: ${cause.message}`);
+    return;
+  }
+  for (const [field, children] of isIndex
+    ? [["manifests", document.manifests]]
+    : [["layers", document.layers]]) {
+    if (children === undefined) continue;
+    if (!Array.isArray(children)) {
+      problems.push(`${blob}.${field} must be an array`);
+      continue;
+    }
+    children.forEach((child, index) =>
+      validateOCIDescriptor(root, layout, child, reachable, problems, `${blob}.${field}[${index}]`),
+    );
+  }
+  for (const [field, child] of isManifest
+    ? [["config", document.config], ["subject", document.subject]]
+    : []) {
+    if (child !== undefined) {
+      validateOCIDescriptor(root, layout, child, reachable, problems, `${blob}.${field}`);
+    }
+  }
+}
+
+function plainObject(value) {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function validateOCIEnvelope(document, mediaType, label, problems) {
+  if (!plainObject(document)) {
+    problems.push(`${label} must be an object`);
+    return false;
+  }
+  if (document.schemaVersion !== OCI_SCHEMA_VERSION) {
+    problems.push(`${label}.schemaVersion must be ${OCI_SCHEMA_VERSION}`);
+  }
+  if (document.mediaType !== mediaType) {
+    problems.push(`${label}.mediaType is ${document.mediaType}, want ${mediaType}`);
+  }
+  return document.schemaVersion === OCI_SCHEMA_VERSION && document.mediaType === mediaType;
+}
+
+function descriptorJSON(root, layout, descriptor, label) {
+  return readJSON(
+    join(root, layout, "blobs", "sha256", descriptor.digest.slice("sha256:".length)),
+    label,
+  );
+}
+
+function validateInTotoSubject(statement, subjectDigest, label, problems) {
+  if (!Array.isArray(statement.subject) || statement.subject.length !== 1) {
+    problems.push(`${label}.subject must contain exactly one image subject`);
+    return;
+  }
+  const [subject] = statement.subject;
+  if (!plainObject(subject)) {
+    problems.push(`${label}.subject[0] must be an object`);
+    return;
+  }
+  requiredString(subject.name, `${label}.subject[0].name`, problems);
+  if (!plainObject(subject.digest)) {
+    problems.push(`${label}.subject[0].digest must be an object`);
+    return;
+  }
+  const wanted = subjectDigest.slice("sha256:".length);
+  if (subject.digest.sha256 !== wanted) {
+    problems.push(`${label}.subject[0].digest.sha256 is ${subject.digest.sha256}, want ${wanted}`);
+  }
+}
+
+function validateSPDXPredicate(predicate, label, problems) {
+  if (!plainObject(predicate)) {
+    problems.push(`${label} must be an SPDX document object`);
+    return;
+  }
+  requiredString(predicate.spdxVersion, `${label}.spdxVersion`, problems, /^SPDX-2\.[23]$/);
+  if (predicate.dataLicense !== "CC0-1.0") {
+    problems.push(`${label}.dataLicense must be CC0-1.0`);
+  }
+  if (predicate.SPDXID !== "SPDXRef-DOCUMENT") {
+    problems.push(`${label}.SPDXID must be SPDXRef-DOCUMENT`);
+  }
+  requiredString(predicate.name, `${label}.name`, problems);
+  requiredString(
+    predicate.documentNamespace,
+    `${label}.documentNamespace`,
+    problems,
+    /^https?:\/\//,
+  );
+  if (!plainObject(predicate.creationInfo)) {
+    problems.push(`${label}.creationInfo must be an object`);
+  } else {
+    requiredString(predicate.creationInfo.created, `${label}.creationInfo.created`, problems);
+    if (!Array.isArray(predicate.creationInfo.creators) || predicate.creationInfo.creators.length === 0) {
+      problems.push(`${label}.creationInfo.creators must be a non-empty array`);
+    }
+  }
+  if (!Array.isArray(predicate.packages) || predicate.packages.length === 0) {
+    problems.push(`${label}.packages must describe at least one package`);
+  } else {
+    predicate.packages.forEach((item, index) => {
+      if (!plainObject(item)) {
+        problems.push(`${label}.packages[${index}] must be an object`);
+        return;
+      }
+      requiredString(item.name, `${label}.packages[${index}].name`, problems);
+      requiredString(item.SPDXID, `${label}.packages[${index}].SPDXID`, problems);
+    });
+  }
+}
+
+function validateMaxProvenance(predicate, expected, platform, label, problems) {
+  if (!plainObject(predicate)) {
+    problems.push(`${label} must be a provenance object`);
+    return;
+  }
+  if (predicate.buildType !== BUILDKIT_BUILD_TYPE) {
+    problems.push(`${label}.buildType is ${predicate.buildType}, want ${BUILDKIT_BUILD_TYPE}`);
+  }
+  if (!plainObject(predicate.builder)) {
+    problems.push(`${label}.builder must be an object`);
+  } else {
+    requiredString(predicate.builder.id, `${label}.builder.id`, problems);
+  }
+  if (!plainObject(predicate.invocation)) {
+    problems.push(`${label}.invocation must be present for maximum provenance`);
+  } else {
+    const parameters = predicate.invocation.parameters;
+    if (!plainObject(parameters)) {
+      problems.push(`${label}.invocation.parameters must be present for maximum provenance`);
+    } else if (!plainObject(parameters.args)) {
+      problems.push(`${label}.invocation.parameters.args must contain the release build arguments`);
+    } else {
+      for (const [name, wanted] of [
+        ["build-arg:RELEASE_VERSION", expected.version],
+        ["build-arg:SOURCE_SHA", expected.sha],
+        ["build-arg:SOURCE_URL", expected.sourceUrl],
+      ]) {
+        if (parameters.args[name] !== wanted) {
+          problems.push(`${label}.invocation.parameters.args.${name} is ${parameters.args[name]}, want ${wanted}`);
+        }
+      }
+    }
+    if (!plainObject(predicate.invocation.environment)) {
+      problems.push(`${label}.invocation.environment must be present for maximum provenance`);
+    } else if (predicate.invocation.environment.platform !== platform) {
+      problems.push(
+        `${label}.invocation.environment.platform is ${predicate.invocation.environment.platform}, want ${platform}`,
+      );
+    }
+  }
+  if (!Array.isArray(predicate.materials) || predicate.materials.length === 0) {
+    problems.push(`${label}.materials must contain resolved build inputs`);
+  }
+  const completeness = predicate.metadata?.completeness;
+  if (!plainObject(completeness)) {
+    problems.push(`${label}.metadata.completeness must be present for maximum provenance`);
+  } else {
+    for (const field of ["parameters", "environment", "materials"]) {
+      if (completeness[field] !== true) {
+        problems.push(`${label}.metadata.completeness.${field} must be true`);
+      }
+    }
+  }
+}
+
+function validateAttestationStatement(
+  statement,
+  predicateType,
+  subjectDigest,
+  expected,
+  platform,
+  label,
+  problems,
+) {
+  if (!plainObject(statement)) {
+    problems.push(`${label} must be an in-toto statement object`);
+    return;
+  }
+  if (statement._type !== IN_TOTO_STATEMENT_TYPE) {
+    problems.push(`${label}._type is ${statement._type}, want ${IN_TOTO_STATEMENT_TYPE}`);
+  }
+  if (statement.predicateType !== predicateType) {
+    problems.push(`${label}.predicateType is ${statement.predicateType}, want ${predicateType}`);
+  }
+  validateInTotoSubject(statement, subjectDigest, label, problems);
+  if (predicateType === SPDX_PREDICATE_TYPE) {
+    validateSPDXPredicate(statement.predicate, `${label}.predicate`, problems);
+  } else if (predicateType === PROVENANCE_PREDICATE_TYPE) {
+    validateMaxProvenance(
+      statement.predicate,
+      expected,
+      platform,
+      `${label}.predicate`,
+      problems,
+    );
+  }
+}
+
+function validatePlatformImage(root, layout, descriptor, expected, platform, problems) {
+  const label = `OCI ${platform} image`;
+  if (descriptor.mediaType !== OCI_MANIFEST_MEDIA_TYPE) {
+    problems.push(`${label} descriptor.mediaType is ${descriptor.mediaType}, want ${OCI_MANIFEST_MEDIA_TYPE}`);
+  }
+  const [expectedOS, expectedArchitecture] = platform.split("/");
+  const expectedPlatform = { os: expectedOS, architecture: expectedArchitecture };
+  if (canonicalJSON(descriptor.platform) !== canonicalJSON(expectedPlatform)) {
+    problems.push(
+      `${label} descriptor.platform is ${canonicalJSON(descriptor.platform)}, want ${canonicalJSON(expectedPlatform)}`,
+    );
+  }
+  const manifest = descriptorJSON(root, layout, descriptor, `${label} manifest`);
+  validateOCIEnvelope(manifest, OCI_MANIFEST_MEDIA_TYPE, `${label} manifest`, problems);
+  if (!plainObject(manifest.config)) {
+    problems.push(`${label} manifest.config must be an OCI descriptor`);
+    return;
+  }
+  if (manifest.config.mediaType !== OCI_CONFIG_MEDIA_TYPE) {
+    problems.push(
+      `${label} manifest.config.mediaType is ${manifest.config.mediaType}, want ${OCI_CONFIG_MEDIA_TYPE}`,
+    );
+  }
+  if (!Array.isArray(manifest.layers) || manifest.layers.length === 0) {
+    problems.push(`${label} manifest.layers must be a non-empty array`);
+  }
+  const config = descriptorJSON(root, layout, manifest.config, `${label} config`);
+  if (config.os !== expectedOS) problems.push(`${label} config.os is ${config.os}, want ${expectedOS}`);
+  if (config.architecture !== expectedArchitecture) {
+    problems.push(`${label} config.architecture is ${config.architecture}, want ${expectedArchitecture}`);
+  }
+  if (!plainObject(config.config)) {
+    problems.push(`${label} config.config must be an object`);
+    return;
+  }
+  const requiredLabels = {
+    "org.opencontainers.image.title": "cerberus",
+    "org.opencontainers.image.description":
+      "Drop-in Prometheus / Loki / Tempo HTTP gateway for ClickHouse",
+    "org.opencontainers.image.url": expected.sourceUrl,
+    "org.opencontainers.image.source": expected.sourceUrl,
+    "org.opencontainers.image.licenses": "Apache-2.0",
+    "org.opencontainers.image.version": expected.version,
+    "org.opencontainers.image.revision": expected.sha,
+  };
+  const labels = config.config.Labels;
+  if (!plainObject(labels)) {
+    problems.push(`${label} config.config.Labels must be an object`);
+  } else {
+    for (const [name, wanted] of Object.entries(requiredLabels)) {
+      if (labels[name] !== wanted) {
+        problems.push(`${label} label ${name} is ${labels[name]}, want ${wanted}`);
+      }
+    }
+  }
+  const entrypoint = config.config.Entrypoint;
+  if (canonicalJSON(entrypoint) !== canonicalJSON(["/usr/local/bin/cerberus"])) {
+    problems.push(
+      `${label} Entrypoint is ${canonicalJSON(entrypoint)}, want ["/usr/local/bin/cerberus"]`,
+    );
+  }
+}
+
+function validatePlatformAttestation(
+  root,
+  layout,
+  descriptor,
+  imageDescriptor,
+  expected,
+  platform,
+  problems,
+) {
+  const label = `OCI ${platform} attestation`;
+  if (descriptor.mediaType !== OCI_MANIFEST_MEDIA_TYPE) {
+    problems.push(`${label} descriptor.mediaType is ${descriptor.mediaType}, want ${OCI_MANIFEST_MEDIA_TYPE}`);
+  }
+  const attestationPlatform = { os: "unknown", architecture: "unknown" };
+  if (canonicalJSON(descriptor.platform) !== canonicalJSON(attestationPlatform)) {
+    problems.push(
+      `${label} descriptor.platform is ${canonicalJSON(descriptor.platform)}, want ${canonicalJSON(attestationPlatform)}`,
+    );
+  }
+  const referenced = descriptor.annotations?.["vnd.docker.reference.digest"];
+  if (referenced !== imageDescriptor.digest) {
+    problems.push(`${label} references ${referenced}, want ${imageDescriptor.digest}`);
+  }
+  const manifest = descriptorJSON(root, layout, descriptor, `${label} manifest`);
+  validateOCIEnvelope(manifest, OCI_MANIFEST_MEDIA_TYPE, `${label} manifest`, problems);
+  if (!plainObject(manifest.config) || manifest.config.mediaType !== OCI_CONFIG_MEDIA_TYPE) {
+    problems.push(`${label} manifest.config must be an OCI image config descriptor`);
+  } else {
+    const config = descriptorJSON(root, layout, manifest.config, `${label} config`);
+    if (config.os !== "unknown" || config.architecture !== "unknown") {
+      problems.push(`${label} config must declare unknown/unknown`);
+    }
+  }
+  if (!Array.isArray(manifest.layers) || manifest.layers.length !== 2) {
+    problems.push(`${label} manifest.layers must contain exactly SBOM and provenance`);
+    return;
+  }
+  const statements = new Map();
+  manifest.layers.forEach((layer, index) => {
+    const layerLabel = `${label} manifest.layers[${index}]`;
+    if (!plainObject(layer)) {
+      problems.push(`${layerLabel} must be an OCI descriptor`);
+      return;
+    }
+    if (layer.mediaType !== IN_TOTO_MEDIA_TYPE) {
+      problems.push(`${layerLabel}.mediaType is ${layer.mediaType}, want ${IN_TOTO_MEDIA_TYPE}`);
+    }
+    const predicateType = layer.annotations?.["in-toto.io/predicate-type"];
+    if (![SPDX_PREDICATE_TYPE, PROVENANCE_PREDICATE_TYPE].includes(predicateType)) {
+      problems.push(`${layerLabel} has unsupported predicate type ${predicateType}`);
+      return;
+    }
+    if (statements.has(predicateType)) {
+      problems.push(`${label} has duplicate ${predicateType} statements`);
+      return;
+    }
+    const statement = descriptorJSON(root, layout, layer, `${layerLabel} statement`);
+    statements.set(predicateType, statement);
+    validateAttestationStatement(
+      statement,
+      predicateType,
+      imageDescriptor.digest,
+      expected,
+      platform,
+      `${layerLabel} statement`,
+      problems,
+    );
+  });
+  for (const predicateType of [SPDX_PREDICATE_TYPE, PROVENANCE_PREDICATE_TYPE]) {
+    if (!statements.has(predicateType)) {
+      problems.push(`${label} is missing ${predicateType}`);
+    }
+  }
+}
+
+export function imageDescriptor(root, expected) {
+  const expectedProblems = [];
+  if (!plainObject(expected)) {
+    throw new CandidateError(["OCI image expectations must be an object"]);
+  }
+  requiredString(expected.version, "OCI image expected version", expectedProblems, VERSION_RE);
+  requiredString(expected.sha, "OCI image expected source SHA", expectedProblems, SHA_RE);
+  requiredString(
+    expected.sourceUrl,
+    "OCI image expected source URL",
+    expectedProblems,
+    SOURCE_URL_RE,
+  );
+  if (expectedProblems.length > 0) throw new CandidateError(expectedProblems);
+
+  const layout = "app/image";
+  const layoutDocument = readJSON(join(root, layout, "oci-layout"), "OCI layout marker");
+  if (
+    layoutDocument === null ||
+    typeof layoutDocument !== "object" ||
+    Array.isArray(layoutDocument) ||
+    Object.keys(layoutDocument).length !== 1 ||
+    layoutDocument.imageLayoutVersion !== "1.0.0"
+  ) {
+    throw new CandidateError(["OCI layout marker must exactly declare imageLayoutVersion 1.0.0"]);
+  }
+  const indexPath = join(root, layout, "index.json");
+  const index = readJSON(indexPath, "OCI image index");
+  const indexProblems = [];
+  validateOCIEnvelope(index, OCI_INDEX_MEDIA_TYPE, "OCI image index", indexProblems);
+  const descriptors = Array.isArray(index.manifests) ? index.manifests : [];
+  if (!Array.isArray(index.manifests)) indexProblems.push("OCI image index.manifests must be an array");
+  if (descriptors.length !== 1) {
+    indexProblems.push(`OCI image index must contain exactly one tagged descriptor, found ${descriptors.length}`);
+  }
+  const chosen = descriptors.length === 1 ? descriptors[0] : null;
+  if (chosen?.mediaType !== OCI_INDEX_MEDIA_TYPE) {
+    indexProblems.push(`OCI tagged descriptor.mediaType must be ${OCI_INDEX_MEDIA_TYPE}`);
+  }
+  if (chosen?.annotations?.["org.opencontainers.image.ref.name"] !== expected.version) {
+    indexProblems.push(`OCI tagged descriptor must have ref name ${expected.version}`);
+  }
+  const imageName = `docker.io/library/cerberus:${expected.version}`;
+  if (chosen?.annotations?.["io.containerd.image.name"] !== imageName) {
+    indexProblems.push(`OCI tagged descriptor must have image name ${imageName}`);
+  }
+  if (!DIGEST_RE.test(chosen?.digest ?? "")) {
+    indexProblems.push("OCI tagged descriptor must have a sha256 digest");
+  }
+  if (indexProblems.length > 0) throw new CandidateError(indexProblems);
+
+  const reachable = new Set();
+  const integrityProblems = [];
+  descriptors.forEach((descriptor, index) =>
+    validateOCIDescriptor(root, layout, descriptor, reachable, integrityProblems, `OCI index.manifests[${index}]`),
+  );
+  const actualLayoutFiles = walkFiles(join(root, layout)).map((path) => `${layout}/${path}`);
+  const expectedLayoutFiles = [`${layout}/index.json`, `${layout}/oci-layout`, ...reachable].sort();
+  if (JSON.stringify(actualLayoutFiles) !== JSON.stringify(expectedLayoutFiles)) {
+    integrityProblems.push(
+      `OCI layout file roster is ${JSON.stringify(actualLayoutFiles)}, want exactly reachable ${JSON.stringify(expectedLayoutFiles)}`,
+    );
+  }
+  if (integrityProblems.length > 0) throw new CandidateError(integrityProblems);
+  const blobPath = join(root, layout, "blobs", "sha256", chosen.digest.slice("sha256:".length));
+  const imageIndex = readJSON(blobPath, "OCI image manifest list");
+  const semanticProblems = [];
+  validateOCIEnvelope(
+    imageIndex,
+    OCI_INDEX_MEDIA_TYPE,
+    "OCI image manifest list",
+    semanticProblems,
+  );
+  const innerDescriptors = Array.isArray(imageIndex.manifests) ? imageIndex.manifests : [];
+  if (!Array.isArray(imageIndex.manifests)) {
+    semanticProblems.push("OCI image manifest list.manifests must be an array");
+  }
+  const images = new Map();
+  const attestations = [];
+  innerDescriptors.forEach((descriptor, index) => {
+    const label = `OCI image manifest list.manifests[${index}]`;
+    if (!plainObject(descriptor)) {
+      semanticProblems.push(`${label} must be an OCI descriptor`);
+      return;
+    }
+    const referenceType = descriptor.annotations?.["vnd.docker.reference.type"];
+    if (referenceType === undefined) {
+      const platform = `${descriptor.platform?.os}/${descriptor.platform?.architecture}`;
+      if (!REQUIRED_IMAGE_PLATFORMS.includes(platform)) {
+        semanticProblems.push(`${label} has unsupported platform ${platform}`);
+      } else if (images.has(platform)) {
+        semanticProblems.push(`${label} duplicates platform ${platform}`);
+      } else {
+        images.set(platform, descriptor);
+      }
+      if (descriptor.mediaType !== OCI_MANIFEST_MEDIA_TYPE) {
+        semanticProblems.push(`${label}.mediaType is ${descriptor.mediaType}, want ${OCI_MANIFEST_MEDIA_TYPE}`);
+      }
+    } else if (referenceType === ATTESTATION_REFERENCE_TYPE) {
+      attestations.push(descriptor);
+    } else {
+      semanticProblems.push(`${label} has unsupported reference type ${referenceType}`);
+    }
+  });
+  const platforms = [...images.keys()].sort();
+  if (canonicalJSON(platforms) !== canonicalJSON(REQUIRED_IMAGE_PLATFORMS)) {
+    semanticProblems.push(
+      `OCI image platforms are ${canonicalJSON(platforms)}, want ${canonicalJSON(REQUIRED_IMAGE_PLATFORMS)}`,
+    );
+  }
+  for (const platform of REQUIRED_IMAGE_PLATFORMS) {
+    const descriptor = images.get(platform);
+    if (descriptor) validatePlatformImage(root, layout, descriptor, expected, platform, semanticProblems);
+  }
+  const imagesByDigest = new Map([...images].map(([platform, descriptor]) => [descriptor.digest, { platform, descriptor }]));
+  const attestationsByDigest = new Map();
+  attestations.forEach((descriptor, index) => {
+    const referenced = descriptor.annotations?.["vnd.docker.reference.digest"];
+    const image = imagesByDigest.get(referenced);
+    if (!image) {
+      semanticProblems.push(`OCI attestation[${index}] references unknown image digest ${referenced}`);
+      return;
+    }
+    if (attestationsByDigest.has(referenced)) {
+      semanticProblems.push(`OCI image ${referenced} has duplicate attestation manifests`);
+      return;
+    }
+    attestationsByDigest.set(referenced, descriptor);
+    validatePlatformAttestation(
+      root,
+      layout,
+      descriptor,
+      image.descriptor,
+      expected,
+      image.platform,
+      semanticProblems,
+    );
+  });
+  for (const [platform, descriptor] of images) {
+    if (!attestationsByDigest.has(descriptor.digest)) {
+      semanticProblems.push(`OCI ${platform} image is missing its BuildKit attestation manifest`);
+    }
+  }
+  if (semanticProblems.length > 0) throw new CandidateError(semanticProblems);
+  return { layout, digest: chosen.digest, platforms };
+}
+
+function seal() {
+  const root = candidateRoot();
+  const sha = requiredEnv("RELEASE_SOURCE_SHA", SHA_RE);
+  const tree = requiredEnv("RELEASE_SOURCE_TREE", SHA_RE);
+  const app = requiredEnv("RELEASE_APP_VERSION", VERSION_RE);
+  const appTag = requiredEnv("RELEASE_APP_TAG");
+  const chart = requiredEnv("RELEASE_CHART_VERSION", VERSION_RE);
+  const sourceUrl = requiredEnv("RELEASE_SOURCE_URL", SOURCE_URL_RE);
+  const runID = requiredEnv("RELEASE_RUN_ID", /^[1-9][0-9]*$/);
+  const attemptText = requiredEnv("RELEASE_RUN_ATTEMPT", /^[1-9][0-9]*$/);
+  verifyCheckout(sha, tree);
+  if (appTag !== `v${app}`) throw new CandidateError([`RELEASE_APP_TAG ${appTag} must equal v${app}`]);
+  validateSourceDocument(root, { sha, tree, app, appTag, sourceUrl });
+  const existingManifest = join(root, CANDIDATE_MANIFEST);
+  rmSync(existingManifest, { force: true });
+  const paths = walkFiles(root);
+  for (const required of [
+    "source.json",
+    "app/assets/checksums.txt",
+    "app/homebrew/cerberus.rb",
+    "app/image/index.json",
+    `chart/cerberus-${chart}.tgz`,
+    "chart/artifacthub-repo.yml",
+    "chart/artifacthub-config.yml",
+  ]) {
+    if (!paths.includes(required)) throw new CandidateError([`candidate is missing ${required}`]);
+  }
+  const archives = paths.filter((path) => path.startsWith("app/assets/cerberus_") && path.endsWith(".tar.gz"));
+  if (archives.length !== REQUIRED_TARGETS.length) {
+    throw new CandidateError([`candidate has ${archives.length} release archives, want ${REQUIRED_TARGETS.length}`]);
+  }
+  validateReleaseChecksums(root, app);
+  validateSealedCandidateArtifacts({
+    root,
+    version: app,
+    chartVersion: chart,
+    appTag,
+    sourceUrl,
+  });
+  const files = paths.map((path) => {
+    const absolute = canonicalPath(root, path, "candidate file").absolute;
+    return { path, size: statSync(absolute).size, sha256: sha256File(absolute) };
+  });
+  const manifest = {
+    schema_version: CANDIDATE_SCHEMA_VERSION,
+    source: { sha, tree, url: sourceUrl },
+    versions: { app, app_tag: appTag, chart },
+    run: { id: runID, attempt: Number(attemptText) },
+    files,
+    image: imageDescriptor(root, { version: app, sha, sourceUrl }),
+  };
+  validateManifest(manifest);
+  writeFileSync(existingManifest, `${canonicalJSON(manifest)}\n`);
+  const digest = sha256File(existingManifest);
+  setOutput("candidate_digest", digest);
+  setOutput("image_digest", manifest.image.digest);
+  setOutput("source_tree", tree);
+  notice(
+    `sealed ${files.length} candidate files as ${digest} (image ${manifest.image.digest}, source ${sha.slice(0, 12)})`,
+  );
+}
+
+export function validateManifest(manifest, expected = {}) {
+  const problems = [];
+  if (!exactKeys(manifest, MANIFEST_KEYS, "manifest", problems)) throw new CandidateError(problems);
+  if (manifest.schema_version !== CANDIDATE_SCHEMA_VERSION) {
+    problems.push(`manifest.schema_version must be ${CANDIDATE_SCHEMA_VERSION}`);
+  }
+  if (exactKeys(manifest.source, SOURCE_KEYS, "manifest.source", problems)) {
+    requiredString(manifest.source.sha, "manifest.source.sha", problems, SHA_RE);
+    requiredString(manifest.source.tree, "manifest.source.tree", problems, SHA_RE);
+    requiredString(manifest.source.url, "manifest.source.url", problems, SOURCE_URL_RE);
+  }
+  if (exactKeys(manifest.versions, VERSION_KEYS, "manifest.versions", problems)) {
+    requiredString(manifest.versions.app, "manifest.versions.app", problems, VERSION_RE);
+    requiredString(manifest.versions.chart, "manifest.versions.chart", problems, VERSION_RE);
+    requiredString(manifest.versions.app_tag, "manifest.versions.app_tag", problems);
+    if (manifest.versions.app_tag !== `v${manifest.versions.app}`) {
+      problems.push("manifest.versions.app_tag must be v-prefixed manifest.versions.app");
+    }
+  }
+  if (exactKeys(manifest.run, RUN_KEYS, "manifest.run", problems)) {
+    requiredString(manifest.run.id, "manifest.run.id", problems, /^[1-9][0-9]*$/);
+    if (!Number.isInteger(manifest.run.attempt) || manifest.run.attempt < 1) {
+      problems.push("manifest.run.attempt must be a positive integer");
+    }
+  }
+  if (!Array.isArray(manifest.files) || manifest.files.length === 0) {
+    problems.push("manifest.files must be a non-empty array");
+  } else {
+    let previous = "";
+    const seen = new Set();
+    for (let index = 0; index < manifest.files.length; index += 1) {
+      const item = manifest.files[index];
+      const label = `manifest.files[${index}]`;
+      if (!exactKeys(item, FILE_KEYS, label, problems)) continue;
+      requiredString(item.path, `${label}.path`, problems);
+      requiredString(item.sha256, `${label}.sha256`, problems, DIGEST_RE);
+      if (!Number.isInteger(item.size) || item.size < 0) problems.push(`${label}.size must be non-negative integer`);
+      if (typeof item.path === "string") {
+        if (item.path === CANDIDATE_MANIFEST || item.path.startsWith("/") || item.path.includes("..")) {
+          problems.push(`${label}.path is not a canonical candidate-relative path`);
+        }
+        if (seen.has(item.path)) problems.push(`${label}.path is duplicated`);
+        if (previous !== "" && item.path.localeCompare(previous) <= 0) problems.push(`${label}.path is not sorted`);
+        seen.add(item.path);
+        previous = item.path;
+      }
+    }
+    if (
+      typeof manifest.versions?.app === "string" &&
+      typeof manifest.versions?.chart === "string"
+    ) {
+      const paths = new Set(manifest.files.map((item) => item?.path));
+      const requiredPaths = [
+        "source.json",
+        "app/assets/checksums.txt",
+        "app/homebrew/cerberus.rb",
+        "app/image/index.json",
+        `chart/cerberus-${manifest.versions.chart}.tgz`,
+        "chart/artifacthub-repo.yml",
+        "chart/artifacthub-config.yml",
+        ...REQUIRED_TARGETS.map(
+          (target) =>
+            `app/assets/cerberus_${manifest.versions.app}_${target.goos}_${target.goarch}.tar.gz`,
+        ),
+      ];
+      for (const path of requiredPaths) {
+        if (!paths.has(path)) problems.push(`manifest.files is missing required candidate file ${path}`);
+      }
+    }
+  }
+  if (exactKeys(manifest.image, IMAGE_KEYS, "manifest.image", problems)) {
+    requiredString(manifest.image.layout, "manifest.image.layout", problems);
+    requiredString(manifest.image.digest, "manifest.image.digest", problems, DIGEST_RE);
+    if (JSON.stringify(manifest.image.platforms) !== JSON.stringify(["linux/amd64", "linux/arm64"])) {
+      problems.push("manifest.image.platforms must exactly equal linux/amd64 + linux/arm64");
+    }
+  }
+  for (const [field, actual, wanted] of [
+    ["source.sha", manifest.source?.sha, expected.sha],
+    ["source.tree", manifest.source?.tree, expected.tree],
+    ["source.url", manifest.source?.url, expected.sourceUrl],
+    ["versions.app", manifest.versions?.app, expected.app],
+    ["versions.app_tag", manifest.versions?.app_tag, expected.appTag],
+    ["versions.chart", manifest.versions?.chart, expected.chart],
+  ]) {
+    if (wanted !== undefined && actual !== wanted) problems.push(`manifest.${field} is ${actual}, want ${wanted}`);
+  }
+  if (problems.length > 0) throw new CandidateError(problems);
+  return manifest;
+}
+
+export function verifyCandidate(root, expected = {}) {
+  const manifestPath = join(root, CANDIDATE_MANIFEST);
+  if (!existsSync(manifestPath)) throw new CandidateError([`candidate manifest is missing: ${manifestPath}`]);
+  const manifest = validateManifest(readJSON(manifestPath, "candidate manifest"), expected);
+  validateSourceDocument(root, {
+    sha: manifest.source.sha,
+    tree: manifest.source.tree,
+    app: manifest.versions.app,
+    appTag: manifest.versions.app_tag,
+    sourceUrl: manifest.source.url,
+  });
+  const actualDigest = sha256File(manifestPath);
+  if (expected.digest !== undefined && actualDigest !== expected.digest) {
+    throw new CandidateError([`candidate digest is ${actualDigest}, want ${expected.digest}`]);
+  }
+  const actualPaths = walkFiles(root).filter((path) => path !== CANDIDATE_MANIFEST);
+  const expectedPaths = manifest.files.map((item) => item.path);
+  if (JSON.stringify(actualPaths) !== JSON.stringify(expectedPaths)) {
+    throw new CandidateError([
+      `candidate file roster is ${JSON.stringify(actualPaths)}, want ${JSON.stringify(expectedPaths)}`,
+    ]);
+  }
+  const problems = [];
+  for (const item of manifest.files) {
+    const absolute = canonicalPath(root, item.path, "manifest file").absolute;
+    const stat = statSync(absolute);
+    if (stat.size !== item.size) problems.push(`${item.path}: size ${stat.size}, want ${item.size}`);
+    const digest = sha256File(absolute);
+    if (digest !== item.sha256) problems.push(`${item.path}: digest ${digest}, want ${item.sha256}`);
+  }
+  try {
+    validateReleaseChecksums(root, manifest.versions.app);
+  } catch (cause) {
+    if (cause instanceof CandidateError) problems.push(...cause.problems);
+    else throw cause;
+  }
+  try {
+    validateSealedCandidateArtifacts({
+      root,
+      version: manifest.versions.app,
+      chartVersion: manifest.versions.chart,
+      appTag: manifest.versions.app_tag,
+      sourceUrl: manifest.source.url,
+    });
+  } catch (cause) {
+    if (cause instanceof Error) problems.push(cause.message);
+    else throw cause;
+  }
+  let recomputedImage;
+  try {
+    recomputedImage = imageDescriptor(root, {
+      version: manifest.versions.app,
+      sha: manifest.source.sha,
+      sourceUrl: manifest.source.url,
+    });
+  } catch (cause) {
+    if (cause instanceof CandidateError) problems.push(...cause.problems);
+    else throw cause;
+  }
+  if (recomputedImage && canonicalJSON(recomputedImage) !== canonicalJSON(manifest.image)) {
+    problems.push("manifest.image does not match the verified OCI layout descriptor");
+  }
+  if (problems.length > 0) throw new CandidateError(problems);
+  return { manifest, digest: actualDigest };
+}
+
+function verify() {
+  const expected = {
+    sha: requiredEnv("RELEASE_SOURCE_SHA", SHA_RE),
+    tree: requiredEnv("RELEASE_SOURCE_TREE", SHA_RE),
+    app: requiredEnv("RELEASE_APP_VERSION", VERSION_RE),
+    appTag: requiredEnv("RELEASE_APP_TAG"),
+    chart: requiredEnv("RELEASE_CHART_VERSION", VERSION_RE),
+    sourceUrl: requiredEnv("RELEASE_SOURCE_URL", SOURCE_URL_RE),
+    digest: requiredEnv("RELEASE_CANDIDATE_DIGEST", DIGEST_RE),
+  };
+  verifyCheckout(expected.sha, expected.tree);
+  const result = verifyCandidate(candidateRoot(), expected);
+  setOutput("candidate_digest", result.digest);
+  setOutput("image_digest", result.manifest.image.digest);
+  notice(
+    `verified candidate ${result.digest} for ${result.manifest.source.sha.slice(0, 12)} ` +
+      `tree ${result.manifest.source.tree.slice(0, 12)}`,
+  );
+}
+
+function main() {
+  const mode = process.env.MODE || process.argv[2];
+  if (mode === "stage") stage();
+  else if (mode === "image") image();
+  else if (mode === "seal") seal();
+  else if (mode === "verify") verify();
+  else throw new CandidateError([`MODE must be stage, image, seal, or verify; got ${JSON.stringify(mode)}`]);
+}
+
+const invokedDirectly = process.argv[1] && fileURLToPath(import.meta.url) === resolve(process.argv[1]);
+if (invokedDirectly) {
+  try {
+    main();
+  } catch (cause) {
+    error(cause instanceof Error ? cause.message : String(cause));
+    process.exit(1);
+  }
+}

--- a/.github/scripts/release-candidate.test.mjs
+++ b/.github/scripts/release-candidate.test.mjs
@@ -1,0 +1,962 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, mkdirSync, readFileSync, rmSync, statSync, writeFileSync } from "node:fs";
+import { basename, join } from "node:path";
+import { tmpdir } from "node:os";
+import { afterEach, test } from "node:test";
+import { gzipSync } from "node:zlib";
+
+import {
+  CANDIDATE_MANIFEST,
+  CandidateError,
+  candidateImageBuildInvocation,
+  canonicalJSON,
+  releaseArtifacts,
+  sha256Bytes,
+  sha256File,
+  validateSnapshotMetadata,
+  validateReleaseChecksums,
+  verifyCheckout,
+  verifyCandidate,
+} from "./release-candidate.mjs";
+
+const SHA = "a".repeat(40);
+const TREE = "b".repeat(40);
+const SOURCE_URL = "https://downloads.example.invalid/example/project";
+const goreleaserConfig = new URL("../../.goreleaser.yml", import.meta.url);
+const roots = [];
+
+const tarBlockBytes = 512;
+
+function tarOctal(header, offset, length, value) {
+  header.write(value.toString(8).padStart(length - 1, "0"), offset, length - 1, "ascii");
+}
+
+function tarGz(entries) {
+  const parts = [];
+  for (const entry of entries) {
+    const data = Buffer.isBuffer(entry.data) ? entry.data : Buffer.from(entry.data);
+    const header = Buffer.alloc(tarBlockBytes);
+    header.write(entry.path, 0, 100, "utf8");
+    tarOctal(header, 100, 8, entry.mode ?? 0o644);
+    tarOctal(header, 108, 8, 0);
+    tarOctal(header, 116, 8, 0);
+    tarOctal(header, 124, 12, data.length);
+    tarOctal(header, 136, 12, 0);
+    header.fill(0x20, 148, 156);
+    header[156] = "0".charCodeAt(0);
+    header.write("ustar\0", 257, 6, "binary");
+    header.write("00", 263, 2, "ascii");
+    const checksum = header.reduce((sum, byte) => sum + byte, 0);
+    header.write(checksum.toString(8).padStart(6, "0"), 148, 6, "ascii");
+    header[154] = 0;
+    header[155] = 0x20;
+    parts.push(header, data);
+    const padding = Math.ceil(data.length / tarBlockBytes) * tarBlockBytes - data.length;
+    if (padding > 0) parts.push(Buffer.alloc(padding));
+  }
+  parts.push(Buffer.alloc(2 * tarBlockBytes));
+  return gzipSync(Buffer.concat(parts));
+}
+
+function executable(goos, goarch) {
+  const binary = Buffer.alloc(64);
+  if (goos === "linux") {
+    Buffer.from([0x7f, 0x45, 0x4c, 0x46]).copy(binary);
+    binary[4] = 2;
+    binary[5] = 1;
+    binary[6] = 1;
+    binary.writeUInt16LE(goarch === "amd64" ? 0x3e : 0xb7, 18);
+  } else {
+    binary.writeUInt32LE(0xfeedfacf, 0);
+    binary.writeUInt32LE(goarch === "amd64" ? 0x01000007 : 0x0100000c, 4);
+  }
+  binary.write(`${goos}/${goarch}`, 32, "utf8");
+  return binary;
+}
+
+function applicationArchive(goos, goarch) {
+  return tarGz([
+    { path: "CHANGELOG.md", data: "changes" },
+    { path: "LICENSE", data: "license" },
+    { path: "README.md", data: "readme" },
+    { path: "cerberus", data: executable(goos, goarch), mode: 0o755 },
+  ]);
+}
+
+function chartArchive() {
+  return tarGz([
+    {
+      path: "cerberus/Chart.yaml",
+      data: "apiVersion: v2\nname: cerberus\ntype: application\nversion: 4.5.6\nappVersion: '1.2.3'\n",
+    },
+    { path: "cerberus/values.yaml", data: "replicas: 1\n" },
+    { path: "cerberus/values.schema.json", data: "{}\n" },
+    { path: "cerberus/templates/deployment.yaml", data: "kind: Deployment\n" },
+  ]);
+}
+
+function generatedCask(archives) {
+  const lines = ['cask "cerberus" do', '  version "1.2.3"', ""];
+  for (const goos of ["darwin", "linux"]) {
+    lines.push(`  on_${goos === "darwin" ? "macos" : "linux"} do`);
+    for (const goarch of ["amd64", "arm64"]) {
+      const key = `${goos}/${goarch}`;
+      lines.push(
+        `    on_${goarch === "amd64" ? "intel" : "arm"} do`,
+        `      sha256 "${sha256Bytes(archives.get(key)).slice("sha256:".length)}"`,
+        `      url "${SOURCE_URL}/releases/download/v1.2.3/cerberus_#{version}_${goos}_${goarch}.tar.gz"`,
+        "    end",
+      );
+    }
+    lines.push("  end", "");
+  }
+  lines.push('  binary "cerberus"', "end", "");
+  return Buffer.from(lines.join("\n"));
+}
+
+afterEach(() => {
+  while (roots.length > 0) rmSync(roots.pop(), { recursive: true, force: true });
+});
+
+function tempRoot() {
+  const root = mkdtempSync(join(tmpdir(), "release-candidate-test-"));
+  roots.push(root);
+  return root;
+}
+
+function write(root, path, body) {
+  const absolute = join(root, path);
+  mkdirSync(join(absolute, ".."), { recursive: true });
+  writeFileSync(absolute, body);
+  return absolute;
+}
+
+function git(root, args) {
+  const result = spawnSync("git", args, { cwd: root, encoding: "utf8" });
+  assert.equal(result.status, 0, `git ${args.join(" ")} failed: ${result.stderr}`);
+  return result.stdout.trim();
+}
+
+function jsonBody(value) {
+  return `${canonicalJSON(value)}\n`;
+}
+
+function candidateImageLayout(options = {}) {
+  const blobs = new Map();
+  const addBlob = (body, mediaType, extra = {}) => {
+    const descriptor = {
+      mediaType,
+      digest: sha256Bytes(body),
+      size: Buffer.byteLength(body),
+      ...extra,
+    };
+    blobs.set(`app/image/blobs/sha256/${descriptor.digest.slice("sha256:".length)}`, body);
+    return descriptor;
+  };
+  const imageLayer = "candidate-layer";
+  const imageLayerDescriptor = addBlob(
+    imageLayer,
+    "application/vnd.oci.image.layer.v1.tar",
+  );
+  const imageDescriptors = (options.architectures ?? ["amd64", "arm64"]).map(
+    (architecture) => {
+      const config = {
+        architecture,
+        os: "linux",
+        config: {
+          Entrypoint: ["/usr/local/bin/cerberus"],
+          Labels: {
+            "org.opencontainers.image.title": "cerberus",
+            "org.opencontainers.image.description":
+              "Drop-in Prometheus / Loki / Tempo HTTP gateway for ClickHouse",
+            "org.opencontainers.image.url": SOURCE_URL,
+            "org.opencontainers.image.source": SOURCE_URL,
+            "org.opencontainers.image.licenses": "Apache-2.0",
+            "org.opencontainers.image.version": "1.2.3",
+            "org.opencontainers.image.revision": SHA,
+          },
+        },
+        rootfs: { type: "layers", diff_ids: [sha256Bytes(imageLayer)] },
+      };
+      options.configMutation?.(config, architecture);
+      const configDescriptor = addBlob(
+        jsonBody(config),
+        "application/vnd.oci.image.config.v1+json",
+      );
+      const manifest = {
+        schemaVersion: 2,
+        mediaType: "application/vnd.oci.image.manifest.v1+json",
+        config: configDescriptor,
+        layers: [imageLayerDescriptor],
+      };
+      options.imageManifestMutation?.(manifest, architecture);
+      const descriptor = addBlob(
+        jsonBody(manifest),
+        "application/vnd.oci.image.manifest.v1+json",
+        { platform: { os: "linux", architecture } },
+      );
+      options.imageDescriptorMutation?.(descriptor, architecture);
+      return descriptor;
+    },
+  );
+
+  let attestationConfig;
+  const attestationDescriptors = [];
+  for (const imageDescriptor of imageDescriptors) {
+    const architecture = imageDescriptor.platform.architecture;
+    if (options.includeAttestation?.(architecture) === false) continue;
+    attestationConfig ??= addBlob(
+      jsonBody({
+        architecture: "unknown",
+        os: "unknown",
+        config: {},
+        rootfs: { type: "layers", diff_ids: [] },
+      }),
+      "application/vnd.oci.image.config.v1+json",
+    );
+    const subject = [
+      {
+        name: "_",
+        digest: { sha256: imageDescriptor.digest.slice("sha256:".length) },
+      },
+    ];
+    const spdx = {
+      _type: "https://in-toto.io/Statement/v0.1",
+      subject: structuredClone(subject),
+      predicateType: "https://spdx.dev/Document",
+      predicate: {
+        spdxVersion: "SPDX-2.3",
+        dataLicense: "CC0-1.0",
+        SPDXID: "SPDXRef-DOCUMENT",
+        name: `cerberus-linux-${architecture}`,
+        documentNamespace: `https://example.invalid/spdx/cerberus-linux-${architecture}`,
+        creationInfo: {
+          created: "2026-08-16T00:00:00Z",
+          creators: ["Tool: buildkit-syft-scanner"],
+        },
+        packages: [{ name: "cerberus", SPDXID: "SPDXRef-Package-cerberus" }],
+      },
+    };
+    const provenance = {
+      _type: "https://in-toto.io/Statement/v0.1",
+      subject: structuredClone(subject),
+      predicateType: "https://slsa.dev/provenance/v0.2",
+      predicate: {
+        builder: { id: "https://github.com/docker/buildx@test" },
+        buildType: "https://mobyproject.org/buildkit@v1",
+        invocation: {
+          parameters: {
+            frontend: "dockerfile.v0",
+            args: {
+              "build-arg:RELEASE_VERSION": "1.2.3",
+              "build-arg:SOURCE_SHA": SHA,
+              "build-arg:SOURCE_URL": SOURCE_URL,
+            },
+          },
+          environment: { platform: `linux/${architecture}` },
+        },
+        materials: [
+          {
+            uri: "pkg:docker/gcr.io/distroless/static-debian12@nonroot",
+            digest: { sha256: "c".repeat(64) },
+          },
+        ],
+        metadata: {
+          completeness: { parameters: true, environment: true, materials: true },
+        },
+      },
+    };
+    options.spdxMutation?.(spdx, architecture, imageDescriptor);
+    options.provenanceMutation?.(provenance, architecture, imageDescriptor);
+    const statements = [
+      { predicateType: "https://spdx.dev/Document", statement: spdx },
+      { predicateType: "https://slsa.dev/provenance/v0.2", statement: provenance },
+    ];
+    options.statementsMutation?.(statements, architecture, imageDescriptor);
+    const layers = statements.map(({ predicateType, statement }) =>
+      addBlob(jsonBody(statement), "application/vnd.in-toto+json", {
+        annotations: { "in-toto.io/predicate-type": predicateType },
+      }),
+    );
+    const manifest = {
+      schemaVersion: 2,
+      mediaType: "application/vnd.oci.image.manifest.v1+json",
+      config: attestationConfig,
+      layers,
+    };
+    options.attestationManifestMutation?.(manifest, architecture, imageDescriptor);
+    const descriptor = addBlob(
+      jsonBody(manifest),
+      "application/vnd.oci.image.manifest.v1+json",
+      {
+        platform: { os: "unknown", architecture: "unknown" },
+        annotations: {
+          "vnd.docker.reference.digest": imageDescriptor.digest,
+          "vnd.docker.reference.type": "attestation-manifest",
+        },
+      },
+    );
+    options.attestationDescriptorMutation?.(descriptor, architecture, imageDescriptor);
+    attestationDescriptors.push(descriptor);
+  }
+  const innerDescriptors = [...imageDescriptors, ...attestationDescriptors];
+  options.innerDescriptorsMutation?.(innerDescriptors, {
+    images: imageDescriptors,
+    attestations: attestationDescriptors,
+  });
+  const imageIndexDocument = {
+    schemaVersion: 2,
+    mediaType: "application/vnd.oci.image.index.v1+json",
+    manifests: innerDescriptors,
+  };
+  options.imageIndexMutation?.(imageIndexDocument);
+  const imageIndex = jsonBody(imageIndexDocument);
+  const imageDescriptor = addBlob(
+    imageIndex,
+    "application/vnd.oci.image.index.v1+json",
+    {
+      annotations: {
+        "io.containerd.image.name": "docker.io/library/cerberus:1.2.3",
+        "org.opencontainers.image.ref.name": "1.2.3",
+      },
+    },
+  );
+  options.rootDescriptorMutation?.(imageDescriptor);
+  const rootIndexDocument = {
+    schemaVersion: 2,
+    mediaType: "application/vnd.oci.image.index.v1+json",
+    manifests: [imageDescriptor],
+  };
+  options.rootIndexMutation?.(rootIndexDocument);
+  return {
+    imageDigest: imageDescriptor.digest,
+    payloads: new Map([
+      ["app/image/index.json", jsonBody(rootIndexDocument)],
+      ["app/image/oci-layout", '{"imageLayoutVersion":"1.0.0"}\n'],
+      ...blobs,
+    ]),
+  };
+}
+
+function sealedCandidate(imageOptions = {}) {
+  const root = tempRoot();
+  const { imageDigest, payloads: imagePayloads } = candidateImageLayout(imageOptions);
+  const archivesByTarget = new Map(
+    ["darwin", "linux"].flatMap((goos) =>
+      ["amd64", "arm64"].map((goarch) => [
+        `${goos}/${goarch}`,
+        applicationArchive(goos, goarch),
+      ]),
+    ),
+  );
+  const archives = [...archivesByTarget].map(([target, body]) => {
+    const [goos, goarch] = target.split("/");
+    return [`app/assets/cerberus_1.2.3_${goos}_${goarch}.tar.gz`, body];
+  });
+  const checksums = `${archives
+    .map(([path, body]) => `${sha256Bytes(body).slice(7)}  ${basename(path)}`)
+    .join("\n")}\n`;
+  const payloads = new Map([
+    ["app/assets/checksums.txt", checksums],
+    ...archives,
+    ["app/homebrew/cerberus.rb", generatedCask(archivesByTarget)],
+    ...imagePayloads,
+    ["chart/cerberus-4.5.6.tgz", chartArchive()],
+    ["chart/artifacthub-config.yml", ""],
+    ["chart/artifacthub-repo.yml", "repositoryID: candidate\n"],
+    ["source.json", `${canonicalJSON({ app_tag: "v1.2.3", app_version: "1.2.3", sha: SHA, source_url: SOURCE_URL, tree: TREE })}\n`],
+  ]);
+  for (const [path, body] of payloads) write(root, path, body);
+  const files = [...payloads.keys()].sort().map((path) => {
+    const absolute = join(root, path);
+    return {
+      path,
+      size: Buffer.byteLength(payloads.get(path)),
+      sha256: sha256File(absolute),
+    };
+  });
+  const manifest = {
+    schema_version: 1,
+    source: { sha: SHA, tree: TREE, url: SOURCE_URL },
+    versions: { app: "1.2.3", app_tag: "v1.2.3", chart: "4.5.6" },
+    run: { id: "123", attempt: 2 },
+    files,
+    image: {
+      layout: "app/image",
+      digest: imageDigest,
+      platforms: ["linux/amd64", "linux/arm64"],
+    },
+  };
+  const manifestPath = write(root, CANDIDATE_MANIFEST, `${canonicalJSON(manifest)}\n`);
+  return { root, manifest, digest: sha256File(manifestPath) };
+}
+
+function reseal(candidate) {
+  candidate.manifest.files = candidate.manifest.files.map((file) => {
+    const absolute = join(candidate.root, file.path);
+    return { ...file, size: statSync(absolute).size, sha256: sha256File(absolute) };
+  });
+  writeFileSync(
+    join(candidate.root, CANDIDATE_MANIFEST),
+    `${canonicalJSON(candidate.manifest)}\n`,
+  );
+}
+
+test("a sealed candidate verifies against the exact source and versions", () => {
+  const candidate = sealedCandidate();
+  const result = verifyCandidate(candidate.root, {
+    sha: SHA,
+    tree: TREE,
+    app: "1.2.3",
+    appTag: "v1.2.3",
+    chart: "4.5.6",
+    digest: candidate.digest,
+  });
+  assert.equal(result.digest, candidate.digest);
+  assert.deepEqual(result.manifest, candidate.manifest);
+});
+
+test("candidate image build writes an attested two-platform OCI layout without publishing", () => {
+  const root = "/checkout";
+  const context = "/checkout/build/release-image-context";
+  const candidateRoot = "/checkout/build/release-candidate";
+  const sourceURL = "https://example.invalid/example/project";
+  const invocation = candidateImageBuildInvocation({
+    root,
+    context,
+    candidateRoot,
+    version: "1.2.3",
+    sha: SHA,
+    sourceURL,
+  });
+
+  assert.equal(invocation.command, "docker");
+  assert.equal(invocation.cwd, root);
+  assert.equal(invocation.layout, `${candidateRoot}/app/image`);
+  assert.deepEqual(invocation.args, [
+    "buildx",
+    "build",
+    "--file",
+    `${root}/Dockerfile`,
+    "--platform",
+    "linux/amd64,linux/arm64",
+    "--build-arg",
+    "RELEASE_VERSION=1.2.3",
+    "--build-arg",
+    `SOURCE_SHA=${SHA}`,
+    "--build-arg",
+    `SOURCE_URL=${sourceURL}`,
+    "--tag",
+    "docker.io/library/cerberus:1.2.3",
+    "--sbom=true",
+    "--provenance=mode=max",
+    "--output",
+    `type=oci,dest=${candidateRoot}/app/image,tar=false`,
+    context,
+  ]);
+  for (const forbidden of ["--push", "--load", "type=registry"]) {
+    assert.equal(invocation.args.includes(forbidden), false, `${forbidden} would publish or load the candidate`);
+  }
+});
+
+test("candidate image build rejects malformed source identity before invoking Docker", () => {
+  const base = {
+    root: "/checkout",
+    context: "/checkout/build/release-image-context",
+    candidateRoot: "/checkout/build/release-candidate",
+    version: "1.2.3",
+    sha: SHA,
+    sourceURL: "https://example.invalid/example/project",
+  };
+  for (const invalid of [
+    { sourceURL: "http://example.invalid/example/project" },
+    { sourceURL: "https://example.invalid/example/project/extra" },
+    { sourceURL: "https://example.invalid/example/project?ref=main" },
+    { sourceURL: "" },
+    { sha: "short" },
+    { version: "v1.2.3" },
+  ]) {
+    assert.throws(
+      () => candidateImageBuildInvocation({ ...base, ...invalid }),
+      (error) => error instanceof CandidateError && /invalid|non-empty/.test(error.message),
+    );
+  }
+});
+
+test("candidate source identity rejects untracked compilable inputs", () => {
+  const root = tempRoot();
+  git(root, ["init", "--quiet"]);
+  git(root, ["config", "user.name", "candidate-test"]);
+  git(root, ["config", "user.email", "candidate-test@example.invalid"]);
+  write(root, ".gitignore", "dist/\nbuild/\n");
+  write(root, "main.go", "package main\n");
+  git(root, ["add", ".gitignore", "main.go"]);
+  git(root, ["commit", "--quiet", "-m", "test: seed exact tree"]);
+  const sha = git(root, ["rev-parse", "HEAD"]);
+  const tree = git(root, ["rev-parse", "HEAD^{tree}"]);
+
+  verifyCheckout(sha, tree, root);
+  write(root, "dist/generated", "ignored build output");
+  verifyCheckout(sha, tree, root);
+
+  write(root, "injected.go", "package main\nfunc injected() {}\n");
+  assert.throws(
+    () => verifyCheckout(sha, tree, root),
+    /tracked or untracked modifications/,
+  );
+  rmSync(join(root, "injected.go"));
+
+  write(root, "main.go", "package main\nfunc changed() {}\n");
+  assert.throws(
+    () => verifyCheckout(sha, tree, root),
+    /tracked or untracked modifications/,
+  );
+});
+
+test("candidate digest mismatch fails closed", () => {
+  const candidate = sealedCandidate();
+  assert.throws(
+    () =>
+      verifyCandidate(candidate.root, {
+        sha: SHA,
+        tree: TREE,
+        digest: `sha256:${"d".repeat(64)}`,
+      }),
+    (error) => error instanceof CandidateError && /candidate digest/.test(error.message),
+  );
+});
+
+test("candidate checksums exactly bind all four release archives", () => {
+  const candidate = sealedCandidate();
+  assert.equal(validateReleaseChecksums(candidate.root, "1.2.3").length, 4);
+  for (const mutation of [
+    (root) => writeFileSync(join(root, "app/assets/checksums.txt"), "bad\n"),
+    (root) => {
+      const path = join(root, "app/assets/checksums.txt");
+      writeFileSync(path, `${readFileSync(path, "utf8")}0${"0".repeat(63)}  unexpected.tar.gz\n`);
+    },
+    (root) => writeFileSync(join(root, "app/assets/cerberus_1.2.3_linux_amd64.tar.gz"), "changed"),
+  ]) {
+    const changed = sealedCandidate();
+    mutation(changed.root);
+    reseal(changed);
+    assert.throws(() => verifyCandidate(changed.root), CandidateError);
+  }
+});
+
+test("source SHA and tree mismatch each fail closed", () => {
+  const candidate = sealedCandidate();
+  for (const expected of [
+    { sha: "e".repeat(40), tree: TREE },
+    { sha: SHA, tree: "f".repeat(40) },
+    { sha: SHA, tree: TREE, sourceUrl: "https://downloads.example.invalid/other/project" },
+  ]) {
+    assert.throws(
+      () => verifyCandidate(candidate.root, expected),
+      (error) => error instanceof CandidateError && /manifest\.source/.test(error.message),
+    );
+  }
+});
+
+test("candidate source identity cannot disagree with its sealed manifest", () => {
+  const candidate = sealedCandidate();
+  writeFileSync(
+    join(candidate.root, "source.json"),
+    `${canonicalJSON({ app_tag: "v1.2.3", app_version: "1.2.3", sha: "0".repeat(40), source_url: SOURCE_URL, tree: TREE })}\n`,
+  );
+  reseal(candidate);
+  assert.throws(() => verifyCandidate(candidate.root), /candidate source identity\.sha/);
+});
+
+test("changed, missing, and unbound files each fail closed", () => {
+  {
+    const candidate = sealedCandidate();
+    writeFileSync(join(candidate.root, "chart/cerberus-4.5.6.tgz"), "changed");
+    assert.throws(() => verifyCandidate(candidate.root), /digest|size/);
+  }
+  {
+    const candidate = sealedCandidate();
+    rmSync(join(candidate.root, "app/homebrew/cerberus.rb"));
+    assert.throws(() => verifyCandidate(candidate.root), /file roster/);
+  }
+  {
+    const candidate = sealedCandidate();
+    write(candidate.root, "unbound.txt", "not in manifest");
+    assert.throws(() => verifyCandidate(candidate.root), /file roster/);
+  }
+  {
+    const candidate = sealedCandidate();
+    candidate.manifest.files = candidate.manifest.files.filter(
+      (file) => file.path !== "chart/artifacthub-repo.yml",
+    );
+    rmSync(join(candidate.root, "chart/artifacthub-repo.yml"));
+    writeFileSync(
+      join(candidate.root, CANDIDATE_MANIFEST),
+      `${canonicalJSON(candidate.manifest)}\n`,
+    );
+    assert.throws(() => verifyCandidate(candidate.root), /artifacthub-repo\.yml/);
+  }
+});
+
+test("OCI layout rejects unreachable blobs, wrong ref identity, and broken descriptor digests", () => {
+  {
+    const candidate = sealedCandidate();
+    const path = "app/image/blobs/sha256/" + "0".repeat(64);
+    write(candidate.root, path, "unreachable");
+    candidate.manifest.files.push({
+      path,
+      size: Buffer.byteLength("unreachable"),
+      sha256: sha256File(join(candidate.root, path)),
+    });
+    candidate.manifest.files.sort((left, right) => left.path.localeCompare(right.path));
+    reseal(candidate);
+    assert.throws(() => verifyCandidate(candidate.root), /reachable/);
+  }
+  {
+    const candidate = sealedCandidate();
+    const indexPath = join(candidate.root, "app/image/index.json");
+    const index = JSON.parse(readFileSync(indexPath, "utf8"));
+    index.manifests[0].annotations["org.opencontainers.image.ref.name"] = "stale";
+    writeFileSync(indexPath, `${canonicalJSON(index)}\n`);
+    reseal(candidate);
+    assert.throws(() => verifyCandidate(candidate.root), /descriptor/);
+  }
+  {
+    const candidate = sealedCandidate();
+    const blob = candidate.manifest.files.find(
+      (file) => file.path.startsWith("app/image/blobs/") && file.path !== `app/image/blobs/sha256/${candidate.manifest.image.digest.slice(7)}`,
+    );
+    writeFileSync(join(candidate.root, blob.path), "mutated but candidate-bound");
+    reseal(candidate);
+    assert.throws(() => verifyCandidate(candidate.root), /digest|size/);
+  }
+});
+
+test("OCI image graph contains exactly the two release platform manifests", () => {
+  for (const [name, options, problem] of [
+    ["missing platform", { architectures: ["amd64"] }, /OCI image platforms/],
+    [
+      "unsupported platform",
+      { architectures: ["amd64", "arm64", "ppc64le"] },
+      /unsupported platform linux\/ppc64le/,
+    ],
+    [
+      "duplicate platform descriptor",
+      {
+        innerDescriptorsMutation(descriptors, { images }) {
+          descriptors.push(images[0]);
+        },
+      },
+      /duplicates platform linux\/amd64/,
+    ],
+    [
+      "platform variant",
+      {
+        imageDescriptorMutation(descriptor, architecture) {
+          if (architecture === "amd64") descriptor.platform.variant = "v8";
+        },
+      },
+      /descriptor\.platform/,
+    ],
+    [
+      "extra tagged root",
+      {
+        rootIndexMutation(index) {
+          index.manifests.push(structuredClone(index.manifests[0]));
+        },
+      },
+      /exactly one tagged descriptor/,
+    ],
+    [
+      "non-OCI image manifest",
+      {
+        imageManifestMutation(manifest, architecture) {
+          if (architecture === "amd64") manifest.mediaType = "application/json";
+        },
+      },
+      /manifest\.mediaType/,
+    ],
+  ]) {
+    const candidate = sealedCandidate(options);
+    assert.throws(
+      () => verifyCandidate(candidate.root),
+      (cause) => cause instanceof CandidateError && problem.test(cause.message),
+      name,
+    );
+  }
+});
+
+test("OCI platform configs bind architecture, source labels, and entrypoint", () => {
+  for (const [name, configMutation, problem] of [
+    [
+      "architecture mismatch",
+      (config, architecture) => {
+        if (architecture === "amd64") config.architecture = "arm64";
+      },
+      /config\.architecture/,
+    ],
+    [
+      "operating system mismatch",
+      (config, architecture) => {
+        if (architecture === "amd64") config.os = "darwin";
+      },
+      /config\.os/,
+    ],
+    [
+      "wrong entrypoint",
+      (config, architecture) => {
+        if (architecture === "amd64") config.config.Entrypoint = ["/bin/sh"];
+      },
+      /Entrypoint/,
+    ],
+  ]) {
+    const candidate = sealedCandidate({ configMutation });
+    assert.throws(
+      () => verifyCandidate(candidate.root),
+      (cause) => cause instanceof CandidateError && problem.test(cause.message),
+      name,
+    );
+  }
+
+  for (const label of [
+    "org.opencontainers.image.revision",
+    "org.opencontainers.image.source",
+    "org.opencontainers.image.url",
+    "org.opencontainers.image.version",
+  ]) {
+    const candidate = sealedCandidate({
+      configMutation(config, architecture) {
+        if (architecture === "amd64") config.config.Labels[label] = "stale";
+      },
+    });
+    assert.throws(
+      () => verifyCandidate(candidate.root),
+      (cause) => cause instanceof CandidateError && cause.message.includes(`label ${label}`),
+      label,
+    );
+  }
+});
+
+test("OCI images require one closed subject-bound BuildKit attestation each", () => {
+  for (const [name, options, problem] of [
+    [
+      "missing platform attestation",
+      { includeAttestation: (architecture) => architecture === "amd64" },
+      /linux\/arm64 image is missing its BuildKit attestation/,
+    ],
+    [
+      "unknown referenced image",
+      {
+        attestationDescriptorMutation(descriptor, architecture) {
+          if (architecture === "amd64") {
+            descriptor.annotations["vnd.docker.reference.digest"] = `sha256:${"d".repeat(64)}`;
+          }
+        },
+      },
+      /references unknown image digest/,
+    ],
+    [
+      "wrong statement subject",
+      {
+        spdxMutation(statement, architecture) {
+          if (architecture === "amd64") statement.subject[0].digest.sha256 = "d".repeat(64);
+        },
+      },
+      /subject\[0\]\.digest\.sha256/,
+    ],
+    [
+      "missing SPDX statement",
+      {
+        statementsMutation(statements, architecture) {
+          if (architecture === "amd64") statements.splice(0, 1);
+        },
+      },
+      /exactly SBOM and provenance/,
+    ],
+    [
+      "duplicate attestation",
+      {
+        innerDescriptorsMutation(descriptors, { attestations }) {
+          descriptors.push(attestations[0]);
+        },
+      },
+      /duplicate attestation manifests/,
+    ],
+    [
+      "non-BuildKit attestation platform",
+      {
+        attestationDescriptorMutation(descriptor, architecture) {
+          if (architecture === "amd64") descriptor.platform = { os: "linux", architecture };
+        },
+      },
+      /descriptor\.platform/,
+    ],
+  ]) {
+    const candidate = sealedCandidate(options);
+    assert.throws(
+      () => verifyCandidate(candidate.root),
+      (cause) => cause instanceof CandidateError && problem.test(cause.message),
+      name,
+    );
+  }
+});
+
+test("OCI attestations contain a nonempty SPDX document and maximum provenance", () => {
+  for (const [name, options, problem] of [
+    [
+      "empty SPDX",
+      {
+        spdxMutation(statement, architecture) {
+          if (architecture === "amd64") statement.predicate.packages = [];
+        },
+      },
+      /packages must describe at least one package/,
+    ],
+    [
+      "minimum provenance",
+      {
+        provenanceMutation(statement, architecture) {
+          if (architecture === "amd64") delete statement.predicate.invocation;
+        },
+      },
+      /invocation must be present for maximum provenance/,
+    ],
+    [
+      "missing source build argument",
+      {
+        provenanceMutation(statement, architecture) {
+          if (architecture === "amd64") {
+            delete statement.predicate.invocation.parameters.args["build-arg:SOURCE_SHA"];
+          }
+        },
+      },
+      /build-arg:SOURCE_SHA/,
+    ],
+    [
+      "incomplete provenance parameters",
+      {
+        provenanceMutation(statement, architecture) {
+          if (architecture === "amd64") {
+            statement.predicate.metadata.completeness.parameters = false;
+          }
+        },
+      },
+      /completeness\.parameters must be true/,
+    ],
+    [
+      "wrong provenance platform",
+      {
+        provenanceMutation(statement, architecture) {
+          if (architecture === "amd64") {
+            statement.predicate.invocation.environment.platform = "linux/arm64";
+          }
+        },
+      },
+      /environment\.platform/,
+    ],
+    [
+      "empty provenance materials",
+      {
+        provenanceMutation(statement, architecture) {
+          if (architecture === "amd64") statement.predicate.materials = [];
+        },
+      },
+      /materials must contain resolved build inputs/,
+    ],
+  ]) {
+    const candidate = sealedCandidate(options);
+    assert.throws(
+      () => verifyCandidate(candidate.root),
+      (cause) => cause instanceof CandidateError && problem.test(cause.message),
+      name,
+    );
+  }
+});
+
+test("malformed, stale, and zero-attempt manifests are rejected", () => {
+  for (const mutate of [
+    (manifest) => {
+      manifest.source.sha = "stale";
+    },
+    (manifest) => {
+      manifest.run.attempt = 0;
+    },
+    (manifest) => {
+      manifest.files[0].sha256 = "not-a-digest";
+    },
+  ]) {
+    const candidate = sealedCandidate();
+    mutate(candidate.manifest);
+    writeFileSync(
+      join(candidate.root, CANDIDATE_MANIFEST),
+      `${canonicalJSON(candidate.manifest)}\n`,
+    );
+    assert.throws(() => verifyCandidate(candidate.root), CandidateError);
+  }
+});
+
+test("GoReleaser output must contain one binary and archive per target", () => {
+  const artifacts = [];
+  for (const goos of ["darwin", "linux"]) {
+    for (const goarch of ["amd64", "arm64"]) {
+      artifacts.push({ type: "Binary", goos, goarch, path: `dist/${goos}-${goarch}/cerberus` });
+      artifacts.push({
+        type: "Archive",
+        goos,
+        goarch,
+        name: `cerberus_1.2.3_${goos}_${goarch}.tar.gz`,
+        path: `dist/cerberus_1.2.3_${goos}_${goarch}.tar.gz`,
+      });
+    }
+  }
+  artifacts.push(
+    { type: "Checksum", path: "dist/checksums.txt" },
+    { type: "Homebrew Cask", path: "dist/homebrew/Casks/cerberus.rb" },
+    { type: "Metadata", path: "dist/metadata.json" },
+  );
+  const selected = releaseArtifacts(artifacts, { version: "1.2.3", commit: SHA });
+  assert.equal(selected.binaries.size, 4);
+  assert.equal(selected.archives.size, 4);
+
+  artifacts.pop();
+  assert.throws(() => releaseArtifacts(artifacts, { version: "1.2.3", commit: SHA }), /metadata/);
+});
+
+test("GoReleaser candidate cask URLs bind the runtime source and app tag", () => {
+  const config = readFileSync(goreleaserConfig, "utf8");
+  const template =
+    'template: "{{ .Env.RELEASE_SOURCE_URL }}/releases/download/{{ .Env.RELEASE_APP_TAG }}/{{ .ArtifactName }}"';
+  assert.equal(
+    config.split(template).length - 1,
+    1,
+    "the candidate cask must have exactly one runtime-bound download template",
+  );
+});
+
+test("snapshot metadata binds the candidate version and commit, not the repository history tag", () => {
+  const metadata = {
+    version: "1.2.3",
+    commit: SHA,
+    tag: "v0.9.0",
+  };
+  assert.equal(
+    validateSnapshotMetadata(metadata, { version: "1.2.3", commit: SHA }),
+    metadata,
+  );
+});
+
+test("a requested-looking snapshot tag cannot hide a stale version or commit", () => {
+  for (const [metadata, problem] of [
+    [{ version: "1.2.2", commit: SHA, tag: "v1.2.3" }, /GoReleaser version/],
+    [
+      { version: "1.2.3", commit: "f".repeat(40), tag: "v1.2.3" },
+      /GoReleaser commit/,
+    ],
+  ]) {
+    assert.throws(
+      () => validateSnapshotMetadata(metadata, { version: "1.2.3", commit: SHA }),
+      (error) => error instanceof CandidateError && problem.test(error.message),
+    );
+  }
+});

--- a/.github/scripts/release-init.mjs
+++ b/.github/scripts/release-init.mjs
@@ -1,0 +1,171 @@
+// release-init.mjs — establish the immutable identity and time window before
+// any release-candidate byte is constructed.
+//
+// Environment:
+//   GITHUB_SHA          exact source commit checked out by the init job.
+//   GITHUB_RUN_ID       positive workflow run id.
+//   GITHUB_RUN_ATTEMPT  positive workflow attempt.
+//   GITHUB_EVENT_NAME   push or workflow_dispatch.
+//   GITHUB_REF          exact triggering branch ref.
+//   RELEASE_REQUESTED_SHA
+//                       workflow_dispatch only: full main SHA the dry run must
+//                       qualify. It must equal GITHUB_SHA.
+//   GITHUB_OUTPUT       receives source_sha, source_tree, started_at_ms,
+//                       correlation_nonce, run_id, run_attempt, and dry_run.
+//
+// Node builtins only. A dirty/wrong checkout, malformed run identity, or an
+// ambiguous dry-run flag fails before the candidate build can start.
+
+import { randomBytes } from 'node:crypto';
+import process from 'node:process';
+import { resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { capture, error, notice, setOutput } from './lib/gh.mjs';
+
+const SHA_RE = /^[0-9a-f]{40}$/;
+const NONCE_RE = /^[0-9a-f]{64}$/;
+const POSITIVE_RE = /^[1-9][0-9]*$/;
+const CORRELATION_NONCE_BYTES = 32;
+const MAIN_REF = 'refs/heads/main';
+const MAINTENANCE_REF_RE = /^refs\/heads\/release\/\d+\.\d+\.x$/;
+
+export class ReleaseInitError extends Error {
+  constructor(message) {
+    super(message);
+    this.name = 'ReleaseInitError';
+  }
+}
+
+function positive(value, label) {
+  const text = String(value ?? '').trim();
+  if (!POSITIVE_RE.test(text)) throw new ReleaseInitError(`${label} must be a positive integer`);
+  const number = Number(text);
+  if (!Number.isSafeInteger(number)) throw new ReleaseInitError(`${label} exceeds safe integer range`);
+  return number;
+}
+
+export function createReleaseIdentity({
+  sha,
+  tree,
+  runID,
+  runAttempt,
+  dryRun,
+  startedAtMs,
+  correlationNonce,
+}) {
+  if (!SHA_RE.test(sha ?? '')) throw new ReleaseInitError('source SHA must be 40 lowercase hex');
+  if (!SHA_RE.test(tree ?? '')) throw new ReleaseInitError('source tree must be 40 lowercase hex');
+  const id = positive(runID, 'run id');
+  const attempt = positive(runAttempt, 'run attempt');
+  const started = positive(startedAtMs, 'qualification start');
+  if (dryRun !== 'true' && dryRun !== 'false') {
+    throw new ReleaseInitError('RELEASE_DRY_RUN must be the literal true or false');
+  }
+  if (!NONCE_RE.test(correlationNonce ?? '')) {
+    throw new ReleaseInitError('correlation nonce must be 64 lowercase hex');
+  }
+  return Object.freeze({
+    source_sha: sha,
+    source_tree: tree,
+    started_at_ms: String(started),
+    correlation_nonce: correlationNonce,
+    run_id: String(id),
+    run_attempt: String(attempt),
+    dry_run: dryRun,
+  });
+}
+
+export function releaseEntryPolicy({ eventName, ref, sha, requestedSHA }) {
+  if (!SHA_RE.test(sha ?? '')) {
+    throw new ReleaseInitError('trigger source SHA must be 40 lowercase hex');
+  }
+  if (eventName === 'workflow_dispatch') {
+    if (ref !== MAIN_REF) {
+      throw new ReleaseInitError('manual release qualification must target main');
+    }
+    if (!SHA_RE.test(requestedSHA ?? '')) {
+      throw new ReleaseInitError('manual release qualification requires an exact full main SHA');
+    }
+    if (requestedSHA !== sha) {
+      throw new ReleaseInitError(
+        `manual qualification requested ${requestedSHA}, but the selected main ref resolved to ${sha}`,
+      );
+    }
+    return Object.freeze({ dryRun: 'true', requestedSHA });
+  }
+  if (eventName === 'push') {
+    if (ref !== MAIN_REF && !MAINTENANCE_REF_RE.test(ref ?? '')) {
+      throw new ReleaseInitError(`release push has unsupported branch ref ${JSON.stringify(ref)}`);
+    }
+    if (String(requestedSHA ?? '').trim() !== '') {
+      throw new ReleaseInitError('push release must not accept a manual requested SHA');
+    }
+    return Object.freeze({ dryRun: 'false', requestedSHA: null });
+  }
+  throw new ReleaseInitError(`unsupported release event ${JSON.stringify(eventName)}`);
+}
+
+function git(root, args) {
+  const result = capture('git', args, { cwd: root });
+  if (result.status !== 0) {
+    throw new ReleaseInitError(`git ${args.join(' ')} failed: ${result.stderr.trim()}`);
+  }
+  return result.stdout.trim();
+}
+
+export function checkoutIdentity(expectedSHA, cwd = process.cwd()) {
+  const root = resolve(git(cwd, ['rev-parse', '--show-toplevel']));
+  if (root !== resolve(cwd)) throw new ReleaseInitError('release init must run at repository root');
+  const sha = git(root, ['rev-parse', '--verify', 'HEAD^{commit}']);
+  if (sha !== expectedSHA) {
+    throw new ReleaseInitError(`checkout HEAD is ${sha}, want ${expectedSHA}`);
+  }
+  const status = capture('git', ['status', '--porcelain=v1', '--untracked-files=all'], {
+    cwd: root,
+  });
+  if (status.status !== 0 || status.stdout !== '') {
+    throw new ReleaseInitError(
+      status.status === 0 ? 'release init checkout is not clean' : `git status failed: ${status.stderr.trim()}`,
+    );
+  }
+  return { sha, tree: git(root, ['rev-parse', '--verify', 'HEAD^{tree}']) };
+}
+
+export function main(env = process.env) {
+  const expectedSHA = String(env.GITHUB_SHA ?? '').trim();
+  if (!SHA_RE.test(expectedSHA)) throw new ReleaseInitError('GITHUB_SHA must be 40 lowercase hex');
+  const entry = releaseEntryPolicy({
+    eventName: String(env.GITHUB_EVENT_NAME ?? '').trim(),
+    ref: String(env.GITHUB_REF ?? '').trim(),
+    sha: expectedSHA,
+    requestedSHA: String(env.RELEASE_REQUESTED_SHA ?? '').trim(),
+  });
+  const source = checkoutIdentity(expectedSHA);
+  const identity = createReleaseIdentity({
+    sha: source.sha,
+    tree: source.tree,
+    runID: env.GITHUB_RUN_ID,
+    runAttempt: env.GITHUB_RUN_ATTEMPT,
+    dryRun: entry.dryRun,
+    startedAtMs: Date.now(),
+    correlationNonce: randomBytes(CORRELATION_NONCE_BYTES).toString('hex'),
+  });
+  for (const [name, value] of Object.entries(identity)) setOutput(name, value);
+  notice(
+    `release qualification initialized for ${identity.source_sha.slice(0, 12)} ` +
+      `tree ${identity.source_tree.slice(0, 12)} dry_run=${identity.dry_run}`,
+  );
+  return identity;
+}
+
+const invokedDirectly =
+  process.argv[1] && fileURLToPath(import.meta.url) === resolve(process.argv[1]);
+if (invokedDirectly) {
+  try {
+    main();
+  } catch (cause) {
+    error(cause instanceof Error ? cause.message : String(cause));
+    process.exit(1);
+  }
+}

--- a/.github/scripts/release-init.test.mjs
+++ b/.github/scripts/release-init.test.mjs
@@ -1,0 +1,107 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+
+import {
+  ReleaseInitError,
+  createReleaseIdentity,
+  releaseEntryPolicy,
+} from './release-init.mjs';
+
+const sha = 'a'.repeat(40);
+const tree = 'b'.repeat(40);
+const nonce = 'c'.repeat(64);
+
+test('release identity binds source, run, fresh nonce, start, and dry-run policy', () => {
+  assert.deepEqual(
+    createReleaseIdentity({
+      sha,
+      tree,
+      runID: '12',
+      runAttempt: '2',
+      dryRun: 'true',
+      startedAtMs: 1234,
+      correlationNonce: nonce,
+    }),
+    {
+      source_sha: sha,
+      source_tree: tree,
+      started_at_ms: '1234',
+      correlation_nonce: nonce,
+      run_id: '12',
+      run_attempt: '2',
+      dry_run: 'true',
+    },
+  );
+});
+
+test('release identity rejects every ambiguous or stale-looking input', () => {
+  const baseline = {
+    sha,
+    tree,
+    runID: '12',
+    runAttempt: '2',
+    dryRun: 'false',
+    startedAtMs: 1234,
+    correlationNonce: nonce,
+  };
+  for (const mutate of [
+    { sha: 'short' },
+    { tree: 'short' },
+    { runID: '0' },
+    { runAttempt: '-1' },
+    { dryRun: '' },
+    { dryRun: 'FALSE' },
+    { startedAtMs: 0 },
+    { correlationNonce: '0'.repeat(63) },
+  ]) {
+    assert.throws(() => createReleaseIdentity({ ...baseline, ...mutate }), ReleaseInitError);
+  }
+});
+
+test('manual qualification is a dry run bound to one exact main commit', () => {
+  assert.deepEqual(
+    releaseEntryPolicy({
+      eventName: 'workflow_dispatch',
+      ref: 'refs/heads/main',
+      sha,
+      requestedSHA: sha,
+    }),
+    { dryRun: 'true', requestedSHA: sha },
+  );
+  for (const invalid of [
+    { ref: 'refs/heads/feature' },
+    { requestedSHA: '' },
+    { requestedSHA: 'c'.repeat(40) },
+  ]) {
+    assert.throws(
+      () =>
+        releaseEntryPolicy({
+          eventName: 'workflow_dispatch',
+          ref: 'refs/heads/main',
+          sha,
+          requestedSHA: sha,
+          ...invalid,
+        }),
+      ReleaseInitError,
+    );
+  }
+});
+
+test('only configured push refs can carry a non-dry-run publication intent', () => {
+  for (const ref of ['refs/heads/main', 'refs/heads/release/1.2.x']) {
+    assert.deepEqual(
+      releaseEntryPolicy({ eventName: 'push', ref, sha, requestedSHA: '' }),
+      { dryRun: 'false', requestedSHA: null },
+    );
+  }
+  for (const invalid of [
+    { eventName: 'pull_request', ref: 'refs/pull/1/merge' },
+    { eventName: 'push', ref: 'refs/heads/feature' },
+    { eventName: 'push', ref: 'refs/heads/main', requestedSHA: sha },
+  ]) {
+    assert.throws(
+      () => releaseEntryPolicy({ sha, requestedSHA: '', ...invalid }),
+      ReleaseInitError,
+    );
+  }
+});

--- a/.github/scripts/release-promote.mjs
+++ b/.github/scripts/release-promote.mjs
@@ -1,0 +1,1039 @@
+// release-promote.mjs — promote only the bytes in a verified release candidate.
+// Every mode is a public write and therefore runs only in a workflow job that
+// has independently verified the candidate and qualification attestation.
+//
+// Modes (MODE or argv[2]):
+//   tag              create one immutable annotated tag at RELEASE_SOURCE_SHA.
+//   image            copy the candidate OCI index to every destination/tag.
+//   release-stage    create/reuse a draft and upload the exact candidate assets.
+//   release-publish  flip the verified draft public with an explicit Latest bit.
+//   cask             write the exact generated cask to the configured tap.
+//   chart            push the exact candidate chart package to OCI.
+//   chart-metadata   push the exact candidate Artifact Hub metadata to OCI.
+//   verify-only      re-run direct authorization immediately before a writer
+//                    implemented by an external action (no mutation here).
+//
+// Shared environment:
+//   RELEASE_CANDIDATE_DIR  sealed candidate root.
+//   RELEASE_SOURCE_SHA     exact 40-hex source commit.
+//   RELEASE_APP_VERSION    exact application version.
+//   RELEASE_APP_TAG        exact v-prefixed tag.
+//   RELEASE_AUTHORIZED     literal true from the authorization barrier.
+//   RELEASE_PUBLISH        literal true from the version gate.
+//   RELEASE_DRY_RUN        literal false; dry-runs never invoke a writer.
+//   RELEASE_ATTESTATION / RELEASE_ATTESTATION_DIGEST / RELEASE_SOURCE_TREE /
+//   RELEASE_CANDIDATE_DIGEST / RELEASE_CORRELATION_NONCE /
+//                          independently revalidated before every mode.
+//
+// Mode-specific environment:
+//   RELEASE_TAG                 tag: exact candidate-bound tag to create.
+//   RELEASE_TAG_KIND            tag: app or chart; selects which sealed
+//                               candidate version RELEASE_TAG must equal.
+//   RELEASE_TAG_MESSAGE         tag: annotation text.
+//   RELEASE_TAGGER_NAME/EMAIL   tag: runtime automation identity.
+//   RELEASE_IMAGE_DESTINATIONS  image: newline-separated host/repository list.
+//   RELEASE_IMAGE_TAGS          image: newline-separated tags.
+//   RELEASE_EXPECTED_IMAGE_DESTINATIONS
+//                               image: exact destination count; omission of a
+//                               configured registry fails before any copy.
+//   RELEASE_IS_LATEST           image/release-publish/cask: true or false.
+//   RELEASE_TAP_REPOSITORY      cask: owner/repository destination.
+//   RELEASE_CHART_REPOSITORY    chart/chart-metadata: oci:// registry path
+//                               without the chart name.
+//   RELEASE_CHART_NAME          chart/chart-metadata: chart name (default
+//                               cerberus).
+//   GH_TOKEN                    release/cask authentication.
+//
+// Node builtins only. Publication destinations are supplied at runtime.
+
+import { readFileSync } from 'node:fs';
+import { basename, join, resolve } from 'node:path';
+import process from 'node:process';
+import { fileURLToPath } from 'node:url';
+
+import { capture, error, notice, setOutput } from './lib/gh.mjs';
+import { verifyCandidate } from './release-candidate.mjs';
+import { verifyAttestationFromEnvironment } from './release-qualification.mjs';
+
+const SHA_RE = /^[0-9a-f]{40}$/;
+const DIGEST_RE = /^sha256:[0-9a-f]{64}$/;
+const TAG_RE = /^[A-Za-z0-9][A-Za-z0-9._-]*$/;
+const DESTINATION_RE = /^[a-z0-9.-]+(?::[0-9]+)?\/[A-Za-z0-9._/-]+$/;
+const REPOSITORY_RE = /^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/;
+const OCI_REPOSITORY_RE = /^oci:\/\/[a-z0-9.-]+(?::[0-9]+)?\/[A-Za-z0-9._/-]+$/;
+
+export class PromotionError extends Error {
+  constructor(message) {
+    super(message);
+    this.name = 'PromotionError';
+  }
+}
+
+function requiredEnv(name, pattern = null) {
+  const value = String(process.env[name] ?? '').trim();
+  if (value === '') throw new PromotionError(`${name} is required`);
+  if (pattern && !pattern.test(value)) {
+    throw new PromotionError(`${name} has invalid value ${JSON.stringify(value)}`);
+  }
+  return value;
+}
+
+function booleanEnv(name) {
+  const value = requiredEnv(name);
+  if (value !== 'true' && value !== 'false') {
+    throw new PromotionError(`${name} must be true or false`);
+  }
+  return value === 'true';
+}
+
+function listEnv(name, pattern) {
+  const values = requiredEnv(name)
+    .split(/\r?\n/)
+    .map((value) => value.trim())
+    .filter(Boolean);
+  if (values.length === 0) throw new PromotionError(`${name} must not be empty`);
+  if (new Set(values).size !== values.length) throw new PromotionError(`${name} contains duplicates`);
+  for (const value of values) {
+    if (!pattern.test(value)) throw new PromotionError(`${name} contains invalid value ${JSON.stringify(value)}`);
+  }
+  return values;
+}
+
+function runChecked(command, args, label, runner = capture) {
+  const result = runner(command, args);
+  if (result.status !== 0) {
+    throw new PromotionError(`${label} failed (exit ${result.status}):\n${result.stdout}${result.stderr}`);
+  }
+  return result;
+}
+
+function candidate() {
+  return verifyCandidate(resolve(process.env.RELEASE_CANDIDATE_DIR || 'build/release-candidate'));
+}
+
+export function verifyPromotionAuthorization({
+  authorized,
+  publish,
+  dryRun,
+  verifier = verifyAttestationFromEnvironment,
+}) {
+  if (authorized !== 'true') {
+    throw new PromotionError('release authorization barrier did not authorize public writes');
+  }
+  if (publish !== 'true') {
+    throw new PromotionError('release version gate did not request public writes');
+  }
+  if (dryRun !== 'false') {
+    throw new PromotionError('public writes are forbidden unless RELEASE_DRY_RUN is exactly false');
+  }
+  const verified = verifier();
+  if (!verified?.attestation || !verified?.candidate || !verified?.digest) {
+    throw new PromotionError('release attestation verifier returned incomplete authorization evidence');
+  }
+  return verified;
+}
+
+export function tagCommands({ tag, message, sha }) {
+  if (!TAG_RE.test(tag)) throw new PromotionError(`invalid release tag ${JSON.stringify(tag)}`);
+  if (!SHA_RE.test(sha)) throw new PromotionError(`invalid release source SHA ${JSON.stringify(sha)}`);
+  if (typeof message !== 'string' || message.trim() === '') {
+    throw new PromotionError('release tag message is required');
+  }
+  return Object.freeze({
+    verify: ['git', ['rev-parse', '-q', '--verify', `refs/tags/${tag}`]],
+    create: ['git', ['tag', '-a', tag, '-m', message, sha]],
+    push: ['git', ['push', 'origin', `refs/tags/${tag}`]],
+  });
+}
+
+export function candidatePromotionTag(manifest, kind) {
+  if (kind === 'app') {
+    const tag = manifest?.versions?.app_tag;
+    if (!TAG_RE.test(tag ?? '')) throw new PromotionError('candidate application tag is invalid');
+    return tag;
+  }
+  if (kind === 'chart') {
+    const version = manifest?.versions?.chart;
+    if (!/^\d+\.\d+\.\d+(?:-[0-9A-Za-z][0-9A-Za-z.-]*)?$/.test(version ?? '')) {
+      throw new PromotionError('candidate chart version is invalid');
+    }
+    return `chart-v${version}`;
+  }
+  throw new PromotionError(`release tag kind must be app or chart, got ${JSON.stringify(kind)}`);
+}
+
+export function remoteAnnotatedTagTarget(output, tag) {
+  const base = `refs/tags/${tag}`;
+  const peeled = `${base}^{}`;
+  const refs = new Map();
+  for (const line of String(output ?? '').trim().split(/\r?\n/).filter(Boolean)) {
+    const match = line.match(/^([0-9a-f]{40})\s+(\S+)$/);
+    if (!match) throw new PromotionError(`malformed remote tag response line ${JSON.stringify(line)}`);
+    if (refs.has(match[2])) throw new PromotionError(`duplicate remote tag response for ${match[2]}`);
+    refs.set(match[2], match[1]);
+  }
+  if (refs.size === 0) return null;
+  for (const ref of refs.keys()) {
+    if (ref !== base && ref !== peeled) {
+      throw new PromotionError(`remote tag response contains unexpected ref ${ref}`);
+    }
+  }
+  if (refs.has(peeled)) return { annotated: true, target: refs.get(peeled) };
+  return { annotated: false, target: refs.get(base) };
+}
+
+function remoteTag(tag) {
+  const base = `refs/tags/${tag}`;
+  const result = capture('git', [
+    'ls-remote',
+    '--exit-code',
+    'origin',
+    base,
+    `${base}^{}`,
+  ]);
+  if (result.status === 2) return null;
+  if (result.status !== 0) {
+    throw new PromotionError(
+      `read remote tag ${tag} failed (exit ${result.status}):\n${result.stdout}${result.stderr}`,
+    );
+  }
+  return remoteAnnotatedTagTarget(result.stdout, tag);
+}
+
+function tagMode() {
+  const sealed = candidate();
+  const tag = requiredEnv('RELEASE_TAG', TAG_RE);
+  const kind = requiredEnv('RELEASE_TAG_KIND', /^(?:app|chart)$/);
+  const sha = requiredEnv('RELEASE_SOURCE_SHA', SHA_RE);
+  const message = requiredEnv('RELEASE_TAG_MESSAGE');
+  const taggerName = requiredEnv('RELEASE_TAGGER_NAME');
+  const taggerEmail = requiredEnv('RELEASE_TAGGER_EMAIL', /^[^\s@]+@[^\s@]+$/);
+  const expectedTag = candidatePromotionTag(sealed.manifest, kind);
+  if (tag !== expectedTag) {
+    throw new PromotionError(
+      `RELEASE_TAG ${tag} does not equal the sealed candidate ${kind} tag ${expectedTag}`,
+    );
+  }
+  if (sha !== sealed.manifest.source.sha) {
+    throw new PromotionError(
+      `RELEASE_SOURCE_SHA ${sha} does not equal candidate source ${sealed.manifest.source.sha}`,
+    );
+  }
+  const commands = tagCommands({ tag, message, sha });
+  const published = remoteTag(tag);
+  if (published) {
+    if (!published.annotated) {
+      throw new PromotionError(`remote tag ${tag} exists but is not annotated`);
+    }
+    if (published.target !== sha) {
+      throw new PromotionError(
+        `remote tag ${tag} targets ${published.target}, want immutable source ${sha}`,
+      );
+    }
+    notice(`annotated tag ${tag} already targets the qualified source`);
+    return;
+  }
+  runChecked('git', ['config', 'user.name', taggerName], 'configure release tagger name');
+  runChecked('git', ['config', 'user.email', taggerEmail], 'configure release tagger email');
+  const existing = capture(...commands.verify);
+  if (existing.status === 0) {
+    const target = runChecked('git', ['rev-list', '-n1', tag], `resolve existing tag ${tag}`).stdout.trim();
+    if (target !== sha) {
+      throw new PromotionError(`tag ${tag} already targets ${target}, want immutable source ${sha}`);
+    }
+    const type = runChecked('git', ['cat-file', '-t', `refs/tags/${tag}`], `inspect existing tag ${tag}`).stdout.trim();
+    if (type !== 'tag') throw new PromotionError(`local tag ${tag} exists but is not annotated`);
+  } else {
+    runChecked(...commands.create, `create tag ${tag}`);
+  }
+  runChecked(...commands.push, `push tag ${tag}`);
+  const verified = remoteTag(tag);
+  if (!verified?.annotated || verified.target !== sha) {
+    throw new PromotionError(`remote tag ${tag} did not resolve to the qualified annotated source after push`);
+  }
+  notice(`created immutable tag ${tag} at ${sha}`);
+}
+
+export function imagePromotionPlan({ layout, sourceName, digest, destinations, tags }) {
+  if (!DIGEST_RE.test(digest)) throw new PromotionError(`invalid candidate image digest ${digest}`);
+  if (!Array.isArray(destinations) || destinations.length === 0) {
+    throw new PromotionError('image promotion needs at least one destination');
+  }
+  if (!Array.isArray(tags) || tags.length === 0) {
+    throw new PromotionError('image promotion needs at least one tag');
+  }
+  if (tags[0] === 'latest') {
+    throw new PromotionError('image promotion primary tag must be immutable, not latest');
+  }
+  const rolling = tags.filter((tag) => tag === 'latest');
+  if (rolling.length > 1) throw new PromotionError('image promotion contains duplicate latest tags');
+  return destinations.map((destination) => ({
+    destination,
+    source: `${layout}:${sourceName}`,
+    primary: `${destination}:${tags[0]}`,
+    digestRef: `${destination}@${digest}`,
+    aliases: tags.slice(1).filter((tag) => tag !== 'latest'),
+    rollingAliases: rolling,
+  }));
+}
+
+export function imagePromotionPreflight({ plan, digest, resolveRef }) {
+  const states = [];
+  for (const item of plan) {
+    const refs = [
+      { ref: item.primary, rolling: false },
+      ...item.aliases.map((alias) => ({
+        ref: `${item.destination}:${alias}`,
+        rolling: false,
+      })),
+      ...item.rollingAliases.map((alias) => ({
+        ref: `${item.destination}:${alias}`,
+        rolling: true,
+      })),
+    ];
+    for (const { ref, rolling } of refs) {
+      const state = resolveRef(ref);
+      if (state.exists && state.digest !== digest && !rolling) {
+        throw new PromotionError(
+          `${ref} already resolves to ${state.digest}, refusing to overwrite with ${digest}`,
+        );
+      }
+      states.push({ ref, exists: state.exists, digest: state.digest, rolling });
+    }
+  }
+  return new Map(states.map((state) => [state.ref, state]));
+}
+
+function inspectImageRef(ref) {
+  const result = capture('oras', ['resolve', ref]);
+  if (result.status === 0) {
+    const digest = result.stdout.trim();
+    if (!DIGEST_RE.test(digest)) {
+      throw new PromotionError(`${ref} resolved to invalid digest ${JSON.stringify(digest)}`);
+    }
+    return { exists: true, digest };
+  }
+  if (remoteNotFound(result)) return { exists: false, digest: null };
+  throw new PromotionError(
+    `could not determine whether image ref ${ref} exists:\n${result.stdout}${result.stderr}`,
+  );
+}
+
+function imageMode() {
+  const sealed = candidate();
+  const version = requiredEnv('RELEASE_APP_VERSION');
+  const destinations = listEnv('RELEASE_IMAGE_DESTINATIONS', DESTINATION_RE);
+  const expectedDestinations = Number(
+    requiredEnv('RELEASE_EXPECTED_IMAGE_DESTINATIONS', /^[1-9][0-9]*$/),
+  );
+  if (destinations.length !== expectedDestinations) {
+    throw new PromotionError(
+      `image promotion resolved ${destinations.length} destinations, want exactly ${expectedDestinations}`,
+    );
+  }
+  const tags = listEnv('RELEASE_IMAGE_TAGS', TAG_RE);
+  const isLatest = booleanEnv('RELEASE_IS_LATEST');
+  const expectedTags = [
+    sealed.manifest.versions.app,
+    sealed.manifest.versions.app_tag,
+    ...(isLatest && !sealed.manifest.versions.app.includes('-') ? ['latest'] : []),
+  ];
+  if (JSON.stringify(tags) !== JSON.stringify(expectedTags)) {
+    throw new PromotionError(
+      `RELEASE_IMAGE_TAGS is ${JSON.stringify(tags)}, want candidate-derived ${JSON.stringify(expectedTags)}`,
+    );
+  }
+  const plan = imagePromotionPlan({
+    layout: resolve(process.env.RELEASE_CANDIDATE_DIR || 'build/release-candidate', sealed.manifest.image.layout),
+    sourceName: version,
+    digest: sealed.manifest.image.digest,
+    destinations,
+    tags,
+  });
+  // Resolve every destination and alias before the first copy. A wrong tag in
+  // the last registry must not be discovered after an earlier registry was
+  // already mutated.
+  const states = imagePromotionPreflight({
+    plan,
+    digest: sealed.manifest.image.digest,
+    resolveRef: inspectImageRef,
+  });
+  for (const item of plan) {
+    if (!states.get(item.primary).exists) {
+      runChecked('oras', ['cp', '--from-oci-layout', item.source, item.primary], `copy image to ${item.primary}`);
+    }
+    const resolved = runChecked('oras', ['resolve', item.primary], `resolve ${item.primary}`).stdout.trim();
+    if (resolved !== sealed.manifest.image.digest) {
+      throw new PromotionError(`${item.primary} resolved to ${resolved}, want ${sealed.manifest.image.digest}`);
+    }
+    const missingAliases = item.aliases.filter(
+      (alias) => !states.get(`${item.destination}:${alias}`).exists,
+    );
+    if (missingAliases.length > 0) {
+      runChecked('oras', ['tag', item.digestRef, ...missingAliases], `tag image aliases for ${item.destination}`);
+    }
+    const staleRollingAliases = item.rollingAliases.filter((alias) => {
+      const state = states.get(`${item.destination}:${alias}`);
+      return !state.exists || state.digest !== sealed.manifest.image.digest;
+    });
+    if (staleRollingAliases.length > 0) {
+      runChecked(
+        'oras',
+        ['tag', '--force', item.digestRef, ...staleRollingAliases],
+        `advance rolling image aliases for ${item.destination}`,
+      );
+    }
+    const allAliases = [...item.aliases, ...item.rollingAliases];
+    if (allAliases.length > 0) {
+      for (const alias of allAliases) {
+        const aliasRef = `${item.destination}:${alias}`;
+        const aliasDigest = runChecked('oras', ['resolve', aliasRef], `resolve ${aliasRef}`).stdout.trim();
+        if (aliasDigest !== sealed.manifest.image.digest) {
+          throw new PromotionError(
+            `${aliasRef} resolved to ${aliasDigest}, want ${sealed.manifest.image.digest}`,
+          );
+        }
+      }
+    }
+  }
+  notice(`promoted exact candidate image ${sealed.manifest.image.digest} to ${plan.length} destinations`);
+}
+
+export function releaseAssets(manifest, root) {
+  const assets = manifest.files
+    .filter((file) => file.path.startsWith('app/assets/'))
+    .map((file) => resolve(root, file.path));
+  const archives = assets.filter((path) => path.endsWith('.tar.gz'));
+  const checksums = assets.filter((path) => basename(path) === 'checksums.txt');
+  if (archives.length !== 4 || checksums.length !== 1 || assets.length !== 5) {
+    throw new PromotionError(`candidate release assets are ${assets.length} files (${archives.length} archives, ${checksums.length} checksums)`);
+  }
+  return assets.sort();
+}
+
+export function releaseAssetInventory(manifest, root) {
+  const paths = new Set(releaseAssets(manifest, root));
+  const inventory = manifest.files
+    .filter((file) => paths.has(resolve(root, file.path)))
+    .map((file) => ({
+      name: basename(file.path),
+      path: resolve(root, file.path),
+      size: file.size,
+      digest: file.sha256,
+    }))
+    .sort((left, right) => left.name.localeCompare(right.name));
+  if (new Set(inventory.map((asset) => asset.name)).size !== inventory.length) {
+    throw new PromotionError('candidate release asset names are not unique');
+  }
+  return inventory;
+}
+
+export function validateReleaseDocument(
+  document,
+  { tag, sha, assets, complete, state, prerelease = undefined },
+) {
+  const problems = [];
+  if (document === null || typeof document !== 'object' || Array.isArray(document)) {
+    throw new PromotionError('release API response must be an object');
+  }
+  if (state !== 'draft' && state !== 'published') {
+    throw new PromotionError(`release validation state must be draft or published, got ${state}`);
+  }
+  const expectedDraft = state === 'draft';
+  if (document.draft !== expectedDraft) {
+    problems.push(
+      `release ${tag} draft state is ${JSON.stringify(document.draft)}, want ${expectedDraft}`,
+    );
+  }
+  if (state === 'published' && document.immutable !== true) {
+    problems.push(`published release ${tag} is not immutable`);
+  }
+  if (prerelease !== undefined && document.prerelease !== prerelease) {
+    problems.push(
+      `release ${tag} prerelease state is ${JSON.stringify(document.prerelease)}, want ${prerelease}`,
+    );
+  }
+  if (document.tag_name !== tag) {
+    problems.push(`release tag is ${JSON.stringify(document.tag_name)}, want ${tag}`);
+  }
+  if (!SHA_RE.test(sha ?? '')) problems.push(`qualified release source SHA is invalid: ${sha}`);
+  if (typeof document.target_commitish !== 'string' || document.target_commitish === '') {
+    problems.push('release target_commitish must be a non-empty string');
+  }
+  if (!Array.isArray(document.assets)) {
+    problems.push('release assets must be an array');
+  } else {
+    const expected = new Map(assets.map((asset) => [asset.name, asset]));
+    const actual = new Map();
+    for (const asset of document.assets) {
+      const name = String(asset?.name ?? '');
+      if (name === '') {
+        problems.push('release contains an asset with no name');
+        continue;
+      }
+      if (actual.has(name)) problems.push(`release asset ${name} is duplicated`);
+      actual.set(name, asset);
+      if (!expected.has(name)) {
+        problems.push(`release contains unexpected stale asset ${name}`);
+        continue;
+      }
+      if (complete) {
+        const wanted = expected.get(name);
+        if (asset.size !== wanted.size) {
+          problems.push(`release asset ${name} size is ${asset.size}, want ${wanted.size}`);
+        }
+        if (asset.digest !== wanted.digest) {
+          problems.push(
+            `release asset ${name} digest is ${JSON.stringify(asset.digest)}, want ${wanted.digest}`,
+          );
+        }
+      }
+    }
+    if (complete) {
+      for (const name of expected.keys()) {
+        if (!actual.has(name)) problems.push(`release is missing candidate asset ${name}`);
+      }
+    }
+  }
+  if (problems.length > 0) {
+    throw new PromotionError(`${state} release is invalid:\n${problems.map((p) => `- ${p}`).join('\n')}`);
+  }
+  return document;
+}
+
+export function validateDraftRelease(document, options) {
+  return validateReleaseDocument(document, { ...options, state: 'draft' });
+}
+
+export function validatePublishedRelease(document, options) {
+  return validateReleaseDocument(document, {
+    ...options,
+    complete: true,
+    state: 'published',
+  });
+}
+
+export function isPrereleaseVersion(version) {
+  if (!/^\d+\.\d+\.\d+(?:-[0-9A-Za-z][0-9A-Za-z.-]*)?$/.test(version ?? '')) {
+    throw new PromotionError(`invalid application version ${JSON.stringify(version)}`);
+  }
+  return version.includes('-');
+}
+
+function releaseNotFound(result) {
+  return result.status !== 0 && /(?:\b404\b|not found)/i.test(`${result.stdout}\n${result.stderr}`);
+}
+
+function readRelease(tag) {
+  const result = capture('gh', [
+    'api',
+    `repos/{owner}/{repo}/releases/tags/${tag}`,
+  ]);
+  if (result.status !== 0) return { result, document: null };
+  try {
+    return { result, document: JSON.parse(result.stdout) };
+  } catch (cause) {
+    throw new PromotionError(`release ${tag} returned malformed JSON: ${cause.message}`);
+  }
+}
+
+function readLatestReleaseTag() {
+  const result = capture('gh', [
+    'api',
+    'repos/{owner}/{repo}/releases/latest',
+    '--jq',
+    '.tag_name',
+  ]);
+  if (result.status === 0) {
+    const tag = result.stdout.trim();
+    if (!TAG_RE.test(tag)) {
+      throw new PromotionError(`latest release returned invalid tag ${JSON.stringify(tag)}`);
+    }
+    return tag;
+  }
+  if (releaseNotFound(result)) return null;
+  throw new PromotionError(
+    `could not read the latest release pointer:\n${result.stdout}${result.stderr}`,
+  );
+}
+
+function requireRemoteTagAtSource(tag, sha) {
+  const published = remoteTag(tag);
+  if (!published?.annotated || published.target !== sha) {
+    throw new PromotionError(
+      `remote tag ${tag} is not an annotated tag at qualified source ${sha}`,
+    );
+  }
+}
+
+export function validateLatestRelease({ tag, isLatest, latestTag }) {
+  if (!TAG_RE.test(tag)) throw new PromotionError(`invalid release tag ${JSON.stringify(tag)}`);
+  if (latestTag !== null && !TAG_RE.test(latestTag)) {
+    throw new PromotionError(`invalid latest release tag ${JSON.stringify(latestTag)}`);
+  }
+  if (isLatest && latestTag !== tag) {
+    throw new PromotionError(
+      `latest release pointer is ${latestTag ?? '<absent>'}, want published release ${tag}`,
+    );
+  }
+  if (!isLatest && latestTag === tag) {
+    throw new PromotionError(`release ${tag} was marked Latest even though it must not own that pointer`);
+  }
+}
+
+function remoteNotFound(result) {
+  return result.status !== 0 && /(?:\b404\b|not found|manifest unknown)/i.test(
+    `${result.stdout}\n${result.stderr}`,
+  );
+}
+
+function readOCIManifest(ref) {
+  const result = capture('oras', ['manifest', 'fetch', ref]);
+  if (result.status !== 0) return { result, document: null };
+  try {
+    return { result, document: JSON.parse(result.stdout) };
+  } catch (cause) {
+    throw new PromotionError(`OCI manifest ${ref} returned malformed JSON: ${cause.message}`);
+  }
+}
+
+export function validateOCIPayloadManifest(
+  document,
+  { label, layers, config = null },
+) {
+  const problems = [];
+  if (document === null || typeof document !== 'object' || Array.isArray(document)) {
+    throw new PromotionError(`${label} manifest must be an object`);
+  }
+  if (document.schemaVersion !== 2) problems.push(`${label} schemaVersion must be 2`);
+  if (!Array.isArray(document.layers)) {
+    problems.push(`${label} layers must be an array`);
+  } else if (document.layers.length !== layers.length) {
+    problems.push(`${label} has ${document.layers.length} layers, want ${layers.length}`);
+  } else {
+    for (let index = 0; index < layers.length; index += 1) {
+      const actual = document.layers[index];
+      const wanted = layers[index];
+      for (const key of ['mediaType', 'digest', 'size']) {
+        if (actual?.[key] !== wanted[key]) {
+          problems.push(
+            `${label} layer ${index} ${key} is ${JSON.stringify(actual?.[key])}, ` +
+              `want ${JSON.stringify(wanted[key])}`,
+          );
+        }
+      }
+    }
+  }
+  if (config) {
+    for (const key of ['mediaType', 'digest', 'size']) {
+      if (document.config?.[key] !== config[key]) {
+        problems.push(
+          `${label} config ${key} is ${JSON.stringify(document.config?.[key])}, ` +
+            `want ${JSON.stringify(config[key])}`,
+        );
+      }
+    }
+  }
+  if (problems.length > 0) {
+    throw new PromotionError(`${label} manifest is invalid:\n${problems.map((p) => `- ${p}`).join('\n')}`);
+  }
+  return document;
+}
+
+export function chartCandidateFiles(manifest, root) {
+  const version = manifest.versions.chart;
+  const wanted = {
+    package: `chart/cerberus-${version}.tgz`,
+    metadata: 'chart/artifacthub-repo.yml',
+    metadataConfig: 'chart/artifacthub-config.yml',
+  };
+  const byPath = new Map(manifest.files.map((file) => [file.path, file]));
+  const result = {};
+  for (const [kind, path] of Object.entries(wanted)) {
+    const file = byPath.get(path);
+    if (!file) throw new PromotionError(`candidate has no bound chart ${kind} file ${path}`);
+    result[kind] = { ...file, path: resolve(root, path) };
+  }
+  return result;
+}
+
+function chartTarget() {
+  const repository = requiredEnv('RELEASE_CHART_REPOSITORY', OCI_REPOSITORY_RE);
+  const name = String(process.env.RELEASE_CHART_NAME || 'cerberus').trim();
+  if (!TAG_RE.test(name)) throw new PromotionError(`invalid chart name ${JSON.stringify(name)}`);
+  return {
+    repository,
+    hostPath: repository.replace(/^oci:\/\//, ''),
+    name,
+  };
+}
+
+function resolvedDigest(ref) {
+  const digest = runChecked('oras', ['resolve', ref], `resolve ${ref}`).stdout.trim();
+  if (!DIGEST_RE.test(digest)) {
+    throw new PromotionError(`${ref} resolved to invalid digest ${JSON.stringify(digest)}`);
+  }
+  return digest;
+}
+
+function chartMode() {
+  const root = resolve(process.env.RELEASE_CANDIDATE_DIR || 'build/release-candidate');
+  const sealed = verifyCandidate(root);
+  const files = chartCandidateFiles(sealed.manifest, root);
+  const target = chartTarget();
+  const version = sealed.manifest.versions.chart;
+  const ref = `${target.hostPath}/${target.name}:${version}`;
+  const expectedLayer = {
+    mediaType: 'application/vnd.cncf.helm.chart.content.v1.tar+gzip',
+    digest: files.package.sha256,
+    size: files.package.size,
+  };
+  let remote = readOCIManifest(ref);
+  let pushedDigest = null;
+  if (remote.document) {
+    validateOCIPayloadManifest(remote.document, {
+      label: `chart ${ref}`,
+      layers: [expectedLayer],
+    });
+  } else {
+    if (!remoteNotFound(remote.result)) {
+      throw new PromotionError(
+        `could not determine whether chart ${ref} exists:\n${remote.result.stdout}${remote.result.stderr}`,
+      );
+    }
+    const pushed = runChecked(
+      'helm',
+      ['push', files.package.path, target.repository],
+      `push exact candidate chart ${ref}`,
+    );
+    const match = `${pushed.stdout}\n${pushed.stderr}`.match(
+      /Digest:\s*(sha256:[0-9a-f]{64})/i,
+    );
+    if (!match) throw new PromotionError(`helm push for ${ref} returned no sha256 digest`);
+    pushedDigest = match[1].toLowerCase();
+    remote = readOCIManifest(ref);
+    if (!remote.document) throw new PromotionError(`chart ${ref} is unreadable after push`);
+    validateOCIPayloadManifest(remote.document, {
+      label: `chart ${ref}`,
+      layers: [expectedLayer],
+    });
+  }
+  const digest = resolvedDigest(ref);
+  if (pushedDigest && pushedDigest !== digest) {
+    throw new PromotionError(`helm pushed ${pushedDigest}, but ${ref} resolves to ${digest}`);
+  }
+  setOutput('chart_ref', `${target.hostPath}/${target.name}@${digest}`);
+  setOutput('chart_digest', digest);
+  notice(`promoted exact candidate chart package ${files.package.sha256} as ${ref}@${digest}`);
+}
+
+function chartMetadataMode() {
+  const root = resolve(process.env.RELEASE_CANDIDATE_DIR || 'build/release-candidate');
+  const sealed = verifyCandidate(root);
+  const files = chartCandidateFiles(sealed.manifest, root);
+  const target = chartTarget();
+  const ref = `${target.hostPath}/${target.name}:artifacthub.io`;
+  const configMediaType = 'application/vnd.cncf.artifacthub.config.v1+yaml';
+  const layerMediaType =
+    'application/vnd.cncf.artifacthub.repository-metadata.layer.v1.yaml';
+  const expected = {
+    config: {
+      mediaType: configMediaType,
+      digest: files.metadataConfig.sha256,
+      size: files.metadataConfig.size,
+    },
+    layers: [
+      {
+        mediaType: layerMediaType,
+        digest: files.metadata.sha256,
+        size: files.metadata.size,
+      },
+    ],
+  };
+  let remote = readOCIManifest(ref);
+  let exact = false;
+  if (remote.document) {
+    try {
+      validateOCIPayloadManifest(remote.document, {
+        label: `Artifact Hub metadata ${ref}`,
+        ...expected,
+      });
+      exact = true;
+    } catch (cause) {
+      if (!(cause instanceof PromotionError)) throw cause;
+    }
+  } else if (!remoteNotFound(remote.result)) {
+    throw new PromotionError(
+      `could not determine whether Artifact Hub metadata ${ref} exists:\n` +
+        `${remote.result.stdout}${remote.result.stderr}`,
+    );
+  }
+  if (!exact) {
+    runChecked(
+      'oras',
+      [
+        'push',
+        ref,
+        '--config',
+        `${files.metadataConfig.path}:${configMediaType}`,
+        `${files.metadata.path}:${layerMediaType}`,
+      ],
+      `push exact candidate Artifact Hub metadata ${ref}`,
+    );
+    remote = readOCIManifest(ref);
+  }
+  if (!remote.document) throw new PromotionError(`Artifact Hub metadata ${ref} is unreadable after push`);
+  validateOCIPayloadManifest(remote.document, {
+    label: `Artifact Hub metadata ${ref}`,
+    ...expected,
+  });
+  const digest = resolvedDigest(ref);
+  setOutput('metadata_ref', `${target.hostPath}/${target.name}@${digest}`);
+  setOutput('metadata_digest', digest);
+  notice(`promoted exact candidate Artifact Hub metadata ${files.metadata.sha256} as ${ref}`);
+}
+
+function releaseStageMode() {
+  const root = resolve(process.env.RELEASE_CANDIDATE_DIR || 'build/release-candidate');
+  const sealed = verifyCandidate(root);
+  const tag = requiredEnv('RELEASE_APP_TAG', TAG_RE);
+  const sha = requiredEnv('RELEASE_SOURCE_SHA', SHA_RE);
+  const version = requiredEnv('RELEASE_APP_VERSION');
+  const prerelease = isPrereleaseVersion(version);
+  if (tag !== sealed.manifest.versions.app_tag || version !== sealed.manifest.versions.app) {
+    throw new PromotionError(
+      `release identity ${tag}/${version} does not equal candidate ` +
+        `${sealed.manifest.versions.app_tag}/${sealed.manifest.versions.app}`,
+    );
+  }
+  if (sha !== sealed.manifest.source.sha) {
+    throw new PromotionError(
+      `release source ${sha} does not equal candidate source ${sealed.manifest.source.sha}`,
+    );
+  }
+  requireRemoteTagAtSource(tag, sha);
+  const assets = releaseAssetInventory(sealed.manifest, root);
+  const existing = readRelease(tag);
+  if (existing.document) {
+    if (existing.document.draft === false) {
+      validatePublishedRelease(existing.document, {
+        tag,
+        sha,
+        assets,
+        prerelease,
+      });
+      notice(`published release ${tag} already contains the exact candidate assets`);
+      return;
+    }
+    validateDraftRelease(existing.document, {
+      tag,
+      sha,
+      assets,
+      complete: false,
+      prerelease,
+    });
+    runChecked(
+      'gh',
+      ['release', 'upload', tag, ...assets.map((asset) => asset.path), '--clobber'],
+      `upload exact assets to ${tag}`,
+    );
+  } else {
+    if (!releaseNotFound(existing.result)) {
+      throw new PromotionError(
+        `could not determine whether release ${tag} exists:\n${existing.result.stdout}${existing.result.stderr}`,
+      );
+    }
+    const args = [
+      'release',
+      'create',
+      tag,
+      ...assets.map((asset) => asset.path),
+      '--draft',
+      '--verify-tag',
+      '--target',
+      sha,
+      '--title',
+      tag,
+      '--generate-notes',
+    ];
+    if (prerelease) args.push('--prerelease');
+    runChecked('gh', args, `stage draft release ${tag}`);
+  }
+  const staged = readRelease(tag);
+  if (!staged.document) {
+    throw new PromotionError(`draft release ${tag} was not readable after asset upload`);
+  }
+  validateDraftRelease(staged.document, {
+    tag,
+    sha,
+    assets,
+    complete: true,
+    prerelease,
+  });
+  notice(`staged ${assets.length} exact candidate assets on draft ${tag}`);
+}
+
+function releasePublishMode() {
+  const tag = requiredEnv('RELEASE_APP_TAG', TAG_RE);
+  const sha = requiredEnv('RELEASE_SOURCE_SHA', SHA_RE);
+  const version = requiredEnv('RELEASE_APP_VERSION');
+  const prerelease = isPrereleaseVersion(version);
+  const isLatest = booleanEnv('RELEASE_IS_LATEST');
+  const root = resolve(process.env.RELEASE_CANDIDATE_DIR || 'build/release-candidate');
+  const sealed = verifyCandidate(root);
+  if (tag !== sealed.manifest.versions.app_tag || version !== sealed.manifest.versions.app) {
+    throw new PromotionError(
+      `release identity ${tag}/${version} does not equal candidate ` +
+        `${sealed.manifest.versions.app_tag}/${sealed.manifest.versions.app}`,
+    );
+  }
+  if (sha !== sealed.manifest.source.sha) {
+    throw new PromotionError(
+      `release source ${sha} does not equal candidate source ${sealed.manifest.source.sha}`,
+    );
+  }
+  requireRemoteTagAtSource(tag, sha);
+  if (prerelease && isLatest) {
+    throw new PromotionError(`prerelease ${tag} cannot own the Latest pointer`);
+  }
+  const assets = releaseAssetInventory(sealed.manifest, root);
+  const staged = readRelease(tag);
+  if (!staged.document) {
+    throw new PromotionError(`draft release ${tag} is missing before publication`);
+  }
+  if (staged.document.draft === true) {
+    validateDraftRelease(staged.document, {
+      tag,
+      sha,
+      assets,
+      complete: true,
+      prerelease,
+    });
+    runChecked(
+      'gh',
+      [
+        'release',
+        'edit',
+        tag,
+        '--draft=false',
+        `--prerelease=${prerelease}`,
+        `--latest=${isLatest}`,
+      ],
+      `publish release ${tag}`,
+    );
+  }
+  const published = readRelease(tag);
+  if (!published.document) {
+    throw new PromotionError(`release ${tag} is unreadable after publication`);
+  }
+  validatePublishedRelease(published.document, {
+    tag,
+    sha,
+    assets,
+    prerelease,
+  });
+  validateLatestRelease({ tag, isLatest, latestTag: readLatestReleaseTag() });
+  notice(`published exact candidate release ${tag} with latest=${isLatest} prerelease=${prerelease}`);
+}
+
+export function caskWrite({ isLatest, repository, version }) {
+  if (!isLatest) return null;
+  if (!REPOSITORY_RE.test(repository)) throw new PromotionError(`invalid tap repository ${repository}`);
+  return {
+    endpoint: `repos/${repository}/contents/Casks/cerberus.rb`,
+    message: `release: update cask to ${version}`,
+  };
+}
+
+function readRepositoryFile(endpoint) {
+  const result = capture('gh', ['api', endpoint]);
+  if (result.status !== 0) {
+    if (releaseNotFound(result)) return null;
+    throw new PromotionError(
+      `could not read repository file ${endpoint}:\n${result.stdout}${result.stderr}`,
+    );
+  }
+  let document;
+  try {
+    document = JSON.parse(result.stdout);
+  } catch (cause) {
+    throw new PromotionError(`repository file ${endpoint} returned malformed JSON: ${cause.message}`);
+  }
+  const sha = String(document?.sha ?? '').trim();
+  const content = String(document?.content ?? '').replace(/\s/g, '');
+  if (!/^[0-9a-f]{40}$/.test(sha) || !/^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$/.test(content)) {
+    throw new PromotionError(`repository file ${endpoint} returned invalid sha/content`);
+  }
+  return { sha, content };
+}
+
+function caskMode() {
+  const isLatest = booleanEnv('RELEASE_IS_LATEST');
+  const repository = requiredEnv('RELEASE_TAP_REPOSITORY', REPOSITORY_RE);
+  const version = requiredEnv('RELEASE_APP_VERSION');
+  const write = caskWrite({ isLatest, repository, version });
+  if (write === null) {
+    notice('candidate is not the highest stable release; the shared cask remains unchanged');
+    return;
+  }
+  const sealed = candidate();
+  const caskFile = sealed.manifest.files.find((file) => file.path === 'app/homebrew/cerberus.rb');
+  if (!caskFile) throw new PromotionError('candidate has no bound generated cask');
+  const content = readFileSync(
+    resolve(process.env.RELEASE_CANDIDATE_DIR || 'build/release-candidate', caskFile.path),
+  ).toString('base64');
+  const existing = readRepositoryFile(write.endpoint);
+  if (existing?.content === content) {
+    notice(`the shared cask already equals the exact candidate for ${version}`);
+    return;
+  }
+  const args = [
+    'api',
+    write.endpoint,
+    '--method',
+    'PUT',
+    '-f',
+    `message=${write.message}`,
+    '-f',
+    `content=${content}`,
+  ];
+  if (existing) args.push('-f', `sha=${existing.sha}`);
+  runChecked('gh', args, `publish cask to ${repository}`);
+  const published = readRepositoryFile(write.endpoint);
+  if (!published || published.content !== content) {
+    throw new PromotionError('published cask bytes do not equal the qualified candidate cask');
+  }
+  notice(`published the exact generated cask for ${version}`);
+}
+
+function main() {
+  const mode = process.env.MODE || process.argv[2];
+  verifyPromotionAuthorization({
+    authorized: process.env.RELEASE_AUTHORIZED,
+    publish: process.env.RELEASE_PUBLISH,
+    dryRun: process.env.RELEASE_DRY_RUN,
+  });
+  if (mode === 'tag') tagMode();
+  else if (mode === 'image') imageMode();
+  else if (mode === 'release-stage') releaseStageMode();
+  else if (mode === 'release-publish') releasePublishMode();
+  else if (mode === 'cask') caskMode();
+  else if (mode === 'chart') chartMode();
+  else if (mode === 'chart-metadata') chartMetadataMode();
+  else if (mode === 'verify-only') notice('direct promotion authorization verified');
+  else throw new PromotionError(
+    `MODE must be tag, image, release-stage, release-publish, cask, chart, chart-metadata, ` +
+      `or verify-only; ` +
+      `got ${JSON.stringify(mode)}`,
+  );
+}
+
+const invokedDirectly = process.argv[1] && fileURLToPath(import.meta.url) === resolve(process.argv[1]);
+if (invokedDirectly) {
+  try {
+    main();
+  } catch (cause) {
+    error(cause instanceof Error ? cause.message : String(cause));
+    process.exit(1);
+  }
+}

--- a/.github/scripts/release-promote.test.mjs
+++ b/.github/scripts/release-promote.test.mjs
@@ -1,0 +1,339 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+
+import {
+  PromotionError,
+  candidatePromotionTag,
+  chartCandidateFiles,
+  caskWrite,
+  imagePromotionPlan,
+  imagePromotionPreflight,
+  isPrereleaseVersion,
+  releaseAssetInventory,
+  releaseAssets,
+  remoteAnnotatedTagTarget,
+  tagCommands,
+  validateDraftRelease,
+  validateLatestRelease,
+  validateOCIPayloadManifest,
+  validatePublishedRelease,
+  verifyPromotionAuthorization,
+} from './release-promote.mjs';
+
+const digest = `sha256:${'a'.repeat(64)}`;
+const sha = 'b'.repeat(40);
+
+test('every promotion mode requires direct complete authorization evidence', () => {
+  const evidence = { attestation: {}, candidate: {}, digest };
+  assert.equal(
+    verifyPromotionAuthorization({
+      authorized: 'true',
+      publish: 'true',
+      dryRun: 'false',
+      verifier: () => evidence,
+    }),
+    evidence,
+  );
+  for (const input of [
+    { authorized: 'false', publish: 'true', dryRun: 'false' },
+    { authorized: 'true', publish: 'false', dryRun: 'false' },
+    { authorized: 'true', publish: 'true', dryRun: 'true' },
+  ]) {
+    let verified = false;
+    assert.throws(
+      () =>
+        verifyPromotionAuthorization({
+          ...input,
+          verifier: () => {
+            verified = true;
+            return evidence;
+          },
+        }),
+      PromotionError,
+    );
+    assert.equal(verified, false, 'invalid writer guards must fail before attestation I/O');
+  }
+  assert.throws(
+    () =>
+      verifyPromotionAuthorization({
+        authorized: 'true',
+        publish: 'true',
+        dryRun: 'false',
+        verifier: () => ({}),
+      }),
+    /incomplete authorization evidence/,
+  );
+});
+
+test('tag plan creates and pushes only one immutable exact-source tag', () => {
+  const manifest = { versions: { app_tag: 'v1.2.3', chart: '4.5.6' } };
+  assert.equal(candidatePromotionTag(manifest, 'app'), 'v1.2.3');
+  assert.equal(candidatePromotionTag(manifest, 'chart'), 'chart-v4.5.6');
+  assert.throws(() => candidatePromotionTag(manifest, 'other'), PromotionError);
+  const plan = tagCommands({ tag: 'v1.2.3', message: 'release v1.2.3', sha });
+  assert.deepEqual(plan.create, ['git', ['tag', '-a', 'v1.2.3', '-m', 'release v1.2.3', sha]]);
+  assert.deepEqual(plan.push, ['git', ['push', 'origin', 'refs/tags/v1.2.3']]);
+  assert.throws(() => tagCommands({ tag: '../bad', message: 'bad', sha }), PromotionError);
+  assert.throws(() => tagCommands({ tag: 'v1.2.3', message: '', sha }), PromotionError);
+  assert.throws(() => tagCommands({ tag: 'v1.2.3', message: 'x', sha: 'short' }), PromotionError);
+  assert.deepEqual(
+    remoteAnnotatedTagTarget(
+      `${'c'.repeat(40)}\trefs/tags/v1.2.3\n${sha}\trefs/tags/v1.2.3^{}\n`,
+      'v1.2.3',
+    ),
+    { annotated: true, target: sha },
+  );
+  assert.deepEqual(
+    remoteAnnotatedTagTarget(`${sha}\trefs/tags/v1.2.3\n`, 'v1.2.3'),
+    { annotated: false, target: sha },
+  );
+  assert.equal(remoteAnnotatedTagTarget('', 'v1.2.3'), null);
+});
+
+test('image promotion copies one candidate digest and creates aliases from it', () => {
+  const plan = imagePromotionPlan({
+    layout: '/candidate/app/image',
+    sourceName: '1.2.3',
+    digest,
+    destinations: ['registry.example/one/app', 'mirror.example/two/app'],
+    tags: ['1.2.3', 'v1.2.3', 'latest'],
+  });
+  assert.equal(plan.length, 2);
+  for (const item of plan) {
+    assert.equal(item.source, '/candidate/app/image:1.2.3');
+    assert.equal(item.digestRef, `${item.destination}@${digest}`);
+    assert.deepEqual(item.aliases, ['v1.2.3']);
+    assert.deepEqual(item.rollingAliases, ['latest']);
+  }
+  assert.throws(
+    () => imagePromotionPlan({ layout: 'x', sourceName: 'x', digest: 'bad', destinations: ['a'], tags: ['v'] }),
+    PromotionError,
+  );
+
+  const states = imagePromotionPreflight({
+    plan,
+    digest,
+    resolveRef: (ref) =>
+      ref.endsWith(':1.2.3')
+        ? { exists: true, digest }
+        : { exists: false, digest: null },
+  });
+  assert.equal(states.get('registry.example/one/app:1.2.3').exists, true);
+  assert.equal(states.get('registry.example/one/app:latest').exists, false);
+  const advanced = imagePromotionPreflight({
+    plan,
+    digest,
+    resolveRef: (ref) => ({
+      exists: true,
+      digest: ref.endsWith(':latest') ? `sha256:${'0'.repeat(64)}` : digest,
+    }),
+  });
+  assert.equal(advanced.get('registry.example/one/app:latest').rolling, true);
+  assert.equal(advanced.get('registry.example/one/app:latest').digest, `sha256:${'0'.repeat(64)}`);
+  assert.throws(
+    () =>
+      imagePromotionPreflight({
+        plan,
+        digest,
+        resolveRef: (ref) => ({
+          exists: true,
+          digest: ref.includes('mirror.example')
+            ? `sha256:${'0'.repeat(64)}`
+            : digest,
+        }),
+      }),
+    /refusing to overwrite/,
+  );
+});
+
+test('release assets are exactly four archives plus the bound checksums', () => {
+  const files = [
+    ...['darwin_amd64', 'darwin_arm64', 'linux_amd64', 'linux_arm64'].map((target) => ({
+      path: `app/assets/cerberus_1.2.3_${target}.tar.gz`,
+      size: 10,
+      sha256: digest,
+    })),
+    { path: 'app/assets/checksums.txt', size: 20, sha256: digest },
+    { path: 'app/image/index.json' },
+  ];
+  const assets = releaseAssets({ files }, '/candidate');
+  assert.equal(assets.length, 5);
+  assert(assets.every((path) => path.startsWith('/candidate/app/assets/')));
+  const inventory = releaseAssetInventory({ files }, '/candidate');
+  assert.deepEqual(
+    inventory.map((asset) => asset.name),
+    [
+      'cerberus_1.2.3_darwin_amd64.tar.gz',
+      'cerberus_1.2.3_darwin_arm64.tar.gz',
+      'cerberus_1.2.3_linux_amd64.tar.gz',
+      'cerberus_1.2.3_linux_arm64.tar.gz',
+      'checksums.txt',
+    ],
+  );
+  assert.throws(() => releaseAssets({ files: files.slice(1) }, '/candidate'), PromotionError);
+
+  const document = {
+    draft: true,
+    tag_name: 'v1.2.3',
+    target_commitish: sha,
+    assets: inventory.map((asset) => ({
+      name: asset.name,
+      size: asset.size,
+      digest: asset.digest,
+    })),
+  };
+  assert.equal(
+    validateDraftRelease(document, {
+      tag: 'v1.2.3',
+      sha,
+      assets: inventory,
+      complete: true,
+    }),
+    document,
+  );
+  assert.throws(
+    () =>
+      validateDraftRelease(
+        {
+          ...document,
+          assets: [...document.assets, { name: 'stale.zip', size: 1, digest }],
+        },
+        { tag: 'v1.2.3', sha, assets: inventory, complete: false },
+      ),
+    /unexpected stale asset/,
+  );
+  assert.throws(
+    () =>
+      validateDraftRelease(
+        { ...document, assets: document.assets.slice(1) },
+        { tag: 'v1.2.3', sha, assets: inventory, complete: true },
+      ),
+    /missing candidate asset/,
+  );
+  assert.throws(
+    () =>
+      validateDraftRelease(
+        { ...document, draft: false },
+        { tag: 'v1.2.3', sha, assets: inventory, complete: true },
+      ),
+    /draft state/,
+  );
+
+  const published = {
+    ...document,
+    draft: false,
+    immutable: true,
+    prerelease: false,
+    // The release API reports the repository default branch here even when
+    // the already-created annotated tag targets an exact SHA. Writer modes
+    // verify that tag target separately before accepting this completion.
+    target_commitish: 'main',
+  };
+  assert.equal(
+    validatePublishedRelease(published, {
+      tag: 'v1.2.3',
+      sha,
+      assets: inventory,
+      prerelease: false,
+    }),
+    published,
+  );
+  assert.throws(
+    () =>
+      validatePublishedRelease(
+        { ...published, immutable: false },
+        { tag: 'v1.2.3', sha, assets: inventory, prerelease: false },
+      ),
+    /not immutable/,
+  );
+  assert.throws(
+    () =>
+      validatePublishedRelease(
+        { ...published, prerelease: true },
+        { tag: 'v1.2.3', sha, assets: inventory, prerelease: false },
+      ),
+    /prerelease state/,
+  );
+});
+
+test('publication completion accepts exact retries and verifies prerelease/latest state', () => {
+  assert.equal(isPrereleaseVersion('1.2.3'), false);
+  assert.equal(isPrereleaseVersion('1.2.3-rc.1'), true);
+  assert.throws(() => isPrereleaseVersion('v1.2.3'), PromotionError);
+
+  assert.doesNotThrow(() =>
+    validateLatestRelease({ tag: 'v1.2.3', isLatest: true, latestTag: 'v1.2.3' }),
+  );
+  assert.doesNotThrow(() =>
+    validateLatestRelease({ tag: 'v1.2.2', isLatest: false, latestTag: 'v1.2.3' }),
+  );
+  assert.throws(
+    () => validateLatestRelease({ tag: 'v1.2.3', isLatest: true, latestTag: null }),
+    /want published release/,
+  );
+  assert.throws(
+    () => validateLatestRelease({ tag: 'v1.2.2', isLatest: false, latestTag: 'v1.2.2' }),
+    /marked Latest/,
+  );
+});
+
+test('only the highest stable release gets a cask write plan', () => {
+  assert.equal(caskWrite({ isLatest: false, repository: 'runtime/value', version: '1.2.3' }), null);
+  assert.deepEqual(
+    caskWrite({ isLatest: true, repository: 'runtime/value', version: '1.2.3' }),
+    {
+      endpoint: 'repos/runtime/value/contents/Casks/cerberus.rb',
+      message: 'release: update cask to 1.2.3',
+    },
+  );
+  assert.throws(() => caskWrite({ isLatest: true, repository: 'bad', version: '1.2.3' }), PromotionError);
+});
+
+test('chart and Artifact Hub promotion select only candidate-bound payloads', () => {
+  const manifest = {
+    versions: { chart: '4.5.6' },
+    files: [
+      { path: 'chart/cerberus-4.5.6.tgz', size: 10, sha256: digest },
+      { path: 'chart/artifacthub-repo.yml', size: 20, sha256: digest },
+      { path: 'chart/artifacthub-config.yml', size: 0, sha256: digest },
+    ],
+  };
+  const files = chartCandidateFiles(manifest, '/candidate');
+  assert.equal(files.package.path, '/candidate/chart/cerberus-4.5.6.tgz');
+  assert.equal(files.metadata.path, '/candidate/chart/artifacthub-repo.yml');
+
+  const expected = {
+    mediaType: 'application/vnd.example.payload',
+    digest,
+    size: 10,
+  };
+  const document = {
+    schemaVersion: 2,
+    config: {
+      mediaType: 'application/vnd.example.config',
+      digest,
+      size: 0,
+    },
+    layers: [expected],
+  };
+  assert.equal(
+    validateOCIPayloadManifest(document, {
+      label: 'candidate payload',
+      config: document.config,
+      layers: [expected],
+    }),
+    document,
+  );
+  assert.throws(
+    () =>
+      validateOCIPayloadManifest(
+        { ...document, layers: [{ ...expected, digest: `sha256:${'0'.repeat(64)}` }] },
+        { label: 'candidate payload', config: document.config, layers: [expected] },
+      ),
+    /digest/,
+  );
+  assert.throws(
+    () => chartCandidateFiles({ ...manifest, files: manifest.files.slice(1) }, '/candidate'),
+    /chart package/,
+  );
+});

--- a/.github/scripts/release-qualification.mjs
+++ b/.github/scripts/release-qualification.mjs
@@ -1,14 +1,13 @@
-// release-qualification.mjs — plan and join the finite pre-publication test
+// release-qualification.mjs — create and join the finite pre-publication test
 // fence for one immutable release candidate.
 //
 // Modes (MODE or argv[2]):
-//   plan               select every deterministic or seeded pre-publication
-//                      lane from the registry and write the closed roster.
-//   join               validate the adapter's trusted evidence index, reject
-//                      every non-success or hollow result, and emit a canonical
-//                      dry-run attestation over source tree + artifact digests.
-//   verify-attestation verify that promotion received the exact successful
-//                      attestation and candidate qualified by the join.
+//   plan               write the canonical release selection and a closed plan
+//                      that pins its digest and trusted coordinator identity.
+//   join               validate canonical native reports against trusted API
+//                      producer provenance and write the signed input attestation.
+//   verify-attestation verify the exact successful attestation before a writer
+//                      can promote any part of the candidate.
 //
 // Environment:
 //   RELEASE_CANDIDATE_DIR       sealed candidate root.
@@ -19,88 +18,145 @@
 //   RELEASE_APP_TAG             exact application tag.
 //   RELEASE_CHART_VERSION       exact chart version.
 //   RELEASE_QUALIFICATION_START epoch milliseconds set before candidate build.
-//   RELEASE_CORRELATION_NONCE    64 lowercase hex, fresh for this qualification.
+//   RELEASE_CORRELATION_NONCE   64 lowercase hex, fresh for this qualification.
 //   RELEASE_QUALIFICATION_PLAN  plan path
 //                              (default build/release-qualification-plan.json).
-//   RELEASE_EVIDENCE_INDEX      normalized, trusted evidence index from the
-//                              cross-run adapter (join only).
+//   RELEASE_QUALIFICATION_SELECTION canonical selection path
+//                              (default build/release-qualification-selection.json).
+//   RELEASE_QUALIFICATION_REPORTS JSON array of canonical native reports
+//                              (join only).
+//   RELEASE_QUALIFICATION_PRODUCER_MANIFEST trusted API producer manifest
+//                              (join only).
 //   RELEASE_ATTESTATION         attestation path
 //                              (default build/release-qualification-attestation.json).
 //   RELEASE_ATTESTATION_DIGEST  expected attestation digest (verify only).
 //   RELEASE_QUALIFICATION_NOW   epoch milliseconds override for deterministic
 //                              fault tests; Actions leaves it unset.
-//   GITHUB_OUTPUT               receives plan/qualification/attestation outputs.
+//   GITHUB_EVENT_NAME           push or workflow_dispatch (plan only).
+//   GITHUB_REPOSITORY           trusted repository identity (plan only).
+//   GITHUB_RUN_ID               coordinator run ID (plan only).
+//   GITHUB_RUN_ATTEMPT          coordinator run attempt (plan only).
+//   GITHUB_OUTPUT               receives plan/selection/attestation outputs.
 //
-// The adapter is deliberately the only cross-workflow discovery seam. This
-// module accepts no GitHub API observation directly: it validates a closed
-// roster plus records whose run/job/artifact provenance the adapter has already
-// resolved. Missing records and duplicate identities are both failures.
+// Cross-workflow discovery stays outside this module. The adapter supplies
+// native report documents plus API-derived producer provenance; the canonical
+// CI lane contract performs the only report-set qualification.
 
 import { existsSync, readFileSync, writeFileSync } from "node:fs";
-import { dirname, resolve } from "node:path";
+import { resolve } from "node:path";
 import process from "node:process";
 import { fileURLToPath } from "node:url";
 
-import { error, notice, setOutput } from "./lib/gh.mjs";
-import { loadRegistry } from "./ci-lane-contract.mjs";
 import {
-  CANDIDATE_MANIFEST,
+  ContractError,
+  loadRegistry,
+  selectionManifestSHA256,
+  validateReportSet,
+  validateSelection,
+} from "./ci-lane-contract.mjs";
+import { error, notice, setOutput } from "./lib/gh.mjs";
+import {
   canonicalJSON,
   sha256File,
   verifyCandidate,
 } from "./release-candidate.mjs";
 
-export const QUALIFICATION_SCHEMA_VERSION = 1;
-export const EVIDENCE_INDEX_SCHEMA_VERSION = 1;
-export const ATTESTATION_SCHEMA_VERSION = 1;
+export const QUALIFICATION_SCHEMA_VERSION = 2;
+export const ATTESTATION_SCHEMA_VERSION = 2;
+export const RELEASE_QUALIFICATION_INVOCATIONS = 45;
 export const RELEASE_QUALIFICATION_LIMIT_MINUTES = 120;
-export const RELEASE_QUALIFICATION_LIMIT_MS = RELEASE_QUALIFICATION_LIMIT_MINUTES * 60 * 1000;
-export const QUICKSTART_LANE_ID = "e2e.quickstart";
+export const RELEASE_QUALIFICATION_LIMIT_MS =
+  RELEASE_QUALIFICATION_LIMIT_MINUTES * 60 * 1000;
+export const QUICKSTART_IDENTITY = "e2e.quickstart/default/source_tree";
 
 const SHA_RE = /^[0-9a-f]{40}$/;
 const DIGEST_RE = /^sha256:[0-9a-f]{64}$/;
+const SHA256_RE = /^[0-9a-f]{64}$/;
 const NONCE_RE = /^[0-9a-f]{64}$/;
 const RUN_ID_RE = /^[1-9][0-9]*$/;
+const REPOSITORY_RE = /^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/;
 const FINITE_DETERMINISM = new Set(["deterministic", "seeded"]);
+const RELEASE_EVENTS = new Set(["push", "workflow_dispatch"]);
 const SUCCESS = "success";
 
+const SOURCE_KEYS = new Set(["sha", "tree"]);
+const RUN_KEYS = new Set(["id", "attempt"]);
+const EVENT_KEYS = new Set([
+  "kind",
+  "pr_number",
+  "event_head_sha",
+  "event_base_sha",
+  "projected_sha",
+]);
+const SELECTION_REF_KEYS = new Set(["run", "manifest_sha256"]);
 const PLAN_KEYS = new Set([
   "schema_version",
   "registry_schema_version",
+  "selection_schema_version",
+  "report_schema_version",
   "source",
   "candidate_digest",
   "correlation_nonce",
+  "selection_ref",
+  "event",
+  "repository",
   "started_at_ms",
   "deadline_at_ms",
-  "lanes",
+  "invocations",
 ]);
-const PLAN_LANE_KEYS = new Set([
+const PLAN_INVOCATION_KEYS = new Set([
   "lane_id",
   "execution_id",
   "producer",
   "invocation_mode",
   "determinism",
 ]);
-const INDEX_KEYS = new Set([
+const PLAN_PRODUCER_KEYS = new Set(["workflow", "job"]);
+const ATTESTATION_KEYS = new Set([
   "schema_version",
+  "result",
   "source",
-  "candidate_digest",
+  "candidate",
+  "qualification",
+  "lanes",
+]);
+const ATTESTATION_CANDIDATE_KEYS = new Set([
+  "digest",
+  "image_digest",
+  "files",
+]);
+const ATTESTATION_FILE_KEYS = new Set(["path", "sha256", "size"]);
+const ATTESTATION_QUALIFICATION_KEYS = new Set([
+  "started_at_ms",
+  "completed_at_ms",
+  "deadline_at_ms",
+  "limit_minutes",
   "correlation_nonce",
-  "records",
+  "selection_ref",
+  "event",
+  "repository",
+  "invocation_count",
 ]);
-const RECORD_KEYS = new Set([
-  "lane_id",
-  "execution_id",
-  "source",
-  "candidate_digest",
+const ATTESTATION_LANE_KEYS = new Set([
+  "identity",
   "producer",
-  "invocation_mode",
-  "conclusion",
+  "report_artifact",
   "evidence",
-  "trust",
 ]);
-const SOURCE_KEYS = new Set(["sha", "tree"]);
-const PRODUCER_KEYS = new Set(["workflow", "job", "run_id", "run_attempt"]);
+const ATTESTATION_PRODUCER_KEYS = new Set([
+  "workflow",
+  "job",
+  "run",
+  "job_name",
+  "job_database_id",
+]);
+const ATTESTATION_ARTIFACT_KEYS = new Set([
+  "id",
+  "name",
+  "sha256",
+  "entry",
+  "entry_sha256",
+]);
 const EVIDENCE_KEYS = new Set([
   "executed",
   "passed",
@@ -110,39 +166,14 @@ const EVIDENCE_KEYS = new Set([
   "seed",
   "corpus_id",
 ]);
-const TRUST_KEYS = new Set([
-  "artifact_id",
-  "artifact_digest",
-  "head_sha",
-  "head_tree",
-  "run_id",
-  "run_attempt",
-  "job_conclusion",
-  "completed_at_ms",
-]);
-const ATTESTATION_KEYS = new Set([
-  "schema_version",
-  "result",
-  "source",
-  "candidate",
-  "qualification",
-  "lanes",
-]);
-const ATTESTATION_CANDIDATE_KEYS = new Set(["digest", "image_digest", "files"]);
-const ATTESTATION_FILE_KEYS = new Set(["path", "sha256", "size"]);
-const ATTESTATION_QUALIFICATION_KEYS = new Set([
-  "started_at_ms",
-  "completed_at_ms",
-  "deadline_at_ms",
-  "limit_minutes",
-  "correlation_nonce",
-]);
-const ATTESTATION_LANE_KEYS = new Set(["identity", "producer", "report_artifact", "evidence"]);
-const ATTESTATION_ARTIFACT_KEYS = new Set(["id", "digest"]);
 
 export class QualificationError extends Error {
   constructor(problems) {
-    super(`release qualification failed closed:\n${problems.map((p) => `- ${p}`).join("\n")}`);
+    super(
+      `release qualification failed closed:\n${problems
+        .map((problem) => `- ${problem}`)
+        .join("\n")}`,
+    );
     this.name = "QualificationError";
     this.problems = problems;
   }
@@ -159,21 +190,33 @@ function exactKeys(value, keys, label, problems) {
   }
   const extras = Object.keys(value).filter((key) => !keys.has(key));
   const missing = [...keys].filter((key) => !(key in value));
-  if (extras.length > 0) problems.push(`${label} has unknown keys: ${extras.join(", ")}`);
-  if (missing.length > 0) problems.push(`${label} is missing keys: ${missing.join(", ")}`);
+  if (extras.length > 0) {
+    problems.push(`${label} has unknown keys: ${extras.join(", ")}`);
+  }
+  if (missing.length > 0) {
+    problems.push(`${label} is missing keys: ${missing.join(", ")}`);
+  }
   return extras.length === 0 && missing.length === 0;
 }
 
 function string(value, label, problems, pattern = null) {
   if (typeof value !== "string" || value === "") {
     problems.push(`${label} must be a non-empty string`);
-    return;
+    return false;
   }
-  if (pattern && !pattern.test(value)) problems.push(`${label} has invalid value ${JSON.stringify(value)}`);
+  if (pattern && !pattern.test(value)) {
+    problems.push(`${label} has invalid value ${JSON.stringify(value)}`);
+    return false;
+  }
+  return true;
 }
 
 function integer(value, label, problems, min = 0) {
-  if (!Number.isSafeInteger(value) || value < min) problems.push(`${label} must be an integer >= ${min}`);
+  if (!Number.isSafeInteger(value) || value < min) {
+    problems.push(`${label} must be an integer >= ${min}`);
+    return false;
+  }
+  return true;
 }
 
 function validateSource(source, label, problems) {
@@ -182,17 +225,64 @@ function validateSource(source, label, problems) {
   string(source.tree, `${label}.tree`, problems, SHA_RE);
 }
 
+function validateRun(run, label, problems) {
+  if (!exactKeys(run, RUN_KEYS, label, problems)) return;
+  string(run.id, `${label}.id`, problems, RUN_ID_RE);
+  integer(run.attempt, `${label}.attempt`, problems, 1);
+}
+
+function validateEvent(event, source, label, problems) {
+  if (!exactKeys(event, EVENT_KEYS, label, problems)) return;
+  string(event.kind, `${label}.kind`, problems);
+  if (!RELEASE_EVENTS.has(event.kind)) {
+    problems.push(`${label}.kind must be push or workflow_dispatch`);
+  }
+  if (event.pr_number !== null) problems.push(`${label}.pr_number must be null`);
+  string(event.event_head_sha, `${label}.event_head_sha`, problems, SHA_RE);
+  if (event.event_base_sha !== null) {
+    problems.push(`${label}.event_base_sha must be null`);
+  }
+  string(event.projected_sha, `${label}.projected_sha`, problems, SHA_RE);
+  if (
+    event.event_head_sha !== source?.sha ||
+    event.projected_sha !== source?.sha
+  ) {
+    problems.push(`${label} must bind the exact release source SHA`);
+  }
+}
+
+function validateSelectionRef(reference, label, problems) {
+  if (!exactKeys(reference, SELECTION_REF_KEYS, label, problems)) return;
+  validateRun(reference.run, `${label}.run`, problems);
+  string(
+    reference.manifest_sha256,
+    `${label}.manifest_sha256`,
+    problems,
+    SHA256_RE,
+  );
+}
+
 function readJSON(path, label = path) {
-  if (!existsSync(path)) throw new QualificationError([`${label} does not exist: ${path}`]);
+  if (!existsSync(path)) {
+    throw new QualificationError([`${label} does not exist: ${path}`]);
+  }
   try {
     return JSON.parse(readFileSync(path, "utf8"));
   } catch (cause) {
-    throw new QualificationError([`${label} is not valid JSON: ${cause.message}`]);
+    throw new QualificationError([
+      `${label} is not valid JSON: ${cause.message}`,
+    ]);
   }
 }
 
 function writeCanonical(path, value) {
   writeFileSync(path, `${canonicalJSON(value)}\n`);
+}
+
+function writeSelection(path, value) {
+  // selectionManifestSHA256 deliberately covers the standard indented
+  // selection representation, including its terminating newline.
+  writeFileSync(path, `${JSON.stringify(value, null, 2)}\n`);
 }
 
 function requiredEnv(name, pattern = null) {
@@ -203,13 +293,63 @@ function requiredEnv(name, pattern = null) {
   return value;
 }
 
-function positiveMillis(name, raw = process.env[name]) {
+function positiveIntegerEnv(name) {
+  const raw = process.env[name];
   if (!/^[1-9][0-9]*$/.test(raw ?? "")) {
-    throw new QualificationError([`${name} must be canonical positive epoch milliseconds`]);
+    throw new QualificationError([
+      `${name} must be a canonical positive integer`,
+    ]);
   }
   const value = Number(raw);
-  if (!Number.isSafeInteger(value)) throw new QualificationError([`${name} exceeds safe integer range`]);
+  if (!Number.isSafeInteger(value)) {
+    throw new QualificationError([`${name} exceeds safe integer range`]);
+  }
   return value;
+}
+
+function positiveMillis(name, raw = process.env[name]) {
+  if (!/^[1-9][0-9]*$/.test(raw ?? "")) {
+    throw new QualificationError([
+      `${name} must be canonical positive epoch milliseconds`,
+    ]);
+  }
+  const value = Number(raw);
+  if (!Number.isSafeInteger(value)) {
+    throw new QualificationError([`${name} exceeds safe integer range`]);
+  }
+  return value;
+}
+
+function identity(value) {
+  return `${value.lane_id}/${value.execution_id}/${value.invocation_mode}`;
+}
+
+function selectedInvocationRoster(selection, registry) {
+  const lanes = new Map(registry.lanes.map((lane) => [lane.id, lane]));
+  const roster = [];
+  for (const item of selection.lanes ?? []) {
+    if (item.disposition !== "selected") continue;
+    const lane = lanes.get(item.lane_id);
+    if (!lane) continue;
+    const modes = [];
+    if (lane.applicability.source) modes.push("source_tree");
+    if (lane.applicability.artifact) modes.push("candidate_artifact");
+    for (const executionID of item.executions) {
+      for (const invocationMode of modes) {
+        roster.push({
+          lane_id: lane.id,
+          execution_id: executionID,
+          producer: {
+            workflow: lane.owner.workflow,
+            job: lane.owner.context_job,
+          },
+          invocation_mode: invocationMode,
+          determinism: lane.determinism,
+        });
+      }
+    }
+  }
+  return roster.sort((left, right) => identity(left).localeCompare(identity(right)));
 }
 
 export function releaseLaneRoster(registry) {
@@ -217,15 +357,14 @@ export function releaseLaneRoster(registry) {
   for (const lane of registry.lanes) {
     if (!FINITE_DETERMINISM.has(lane.determinism)) continue;
     if (lane.release_posture === "post_publish") continue;
-    if (!lane.applicability.source && !lane.applicability.artifact) continue;
-    for (const execution of lane.executions) {
-      for (const invocationMode of [
-        ...(lane.applicability.source ? ["source_tree"] : []),
-        ...(lane.applicability.artifact ? ["candidate_artifact"] : []),
-      ]) {
+    for (const executionID of lane.executions) {
+      const modes = [];
+      if (lane.applicability.source) modes.push("source_tree");
+      if (lane.applicability.artifact) modes.push("candidate_artifact");
+      for (const invocationMode of modes) {
         roster.push({
           lane_id: lane.id,
-          execution_id: execution,
+          execution_id: executionID,
           producer: {
             workflow: lane.owner.workflow,
             job: lane.owner.context_job,
@@ -237,241 +376,387 @@ export function releaseLaneRoster(registry) {
     }
   }
   roster.sort((left, right) => identity(left).localeCompare(identity(right)));
-  if (!roster.some((item) => item.lane_id === QUICKSTART_LANE_ID)) {
-    throw new QualificationError([`${QUICKSTART_LANE_ID} is absent from the finite release roster`]);
+  const problems = [];
+  if (!roster.some((item) => identity(item) === QUICKSTART_IDENTITY)) {
+    problems.push(`${QUICKSTART_IDENTITY} is absent from release qualification`);
   }
+  if (roster.length !== RELEASE_QUALIFICATION_INVOCATIONS) {
+    problems.push(
+      `release qualification must contain exactly ${RELEASE_QUALIFICATION_INVOCATIONS} ` +
+        `invocations; registry produced ${roster.length}`,
+    );
+  }
+  if (problems.length > 0) throw new QualificationError(problems);
   return roster;
 }
 
-function identity(value) {
-  return `${value.lane_id}/${value.execution_id}/${value.invocation_mode}`;
-}
-
-export function createPlan({ registry, source, candidateDigest, correlationNonce, startedAtMs }) {
-  const problems = [];
-  validateSource(source, "plan.source", problems);
-  string(candidateDigest, "plan.candidate_digest", problems, DIGEST_RE);
-  string(correlationNonce, "plan.correlation_nonce", problems, NONCE_RE);
-  integer(startedAtMs, "plan.started_at_ms", problems, 1);
-  if (problems.length > 0) throw new QualificationError(problems);
-  return {
-    schema_version: QUALIFICATION_SCHEMA_VERSION,
+export function createReleaseSelection({
+  registry,
+  source,
+  candidateDigest,
+  correlationNonce,
+  run,
+}) {
+  const lanes = registry.lanes
+    .map((lane) => {
+      if (lane.release_posture === "post_publish") {
+        return {
+          lane_id: lane.id,
+          disposition: "omitted",
+          executions: [],
+          reason: "post_publish",
+        };
+      }
+      if (!FINITE_DETERMINISM.has(lane.determinism)) {
+        return {
+          lane_id: lane.id,
+          disposition: "omitted",
+          executions: [],
+          reason: "advisory",
+        };
+      }
+      return {
+        lane_id: lane.id,
+        disposition: "selected",
+        executions: [...lane.executions],
+        reason: null,
+      };
+    })
+    .sort((left, right) => left.lane_id.localeCompare(right.lane_id));
+  const selection = {
+    schema_version: registry.selection_schema_version,
     registry_schema_version: registry.schema_version,
-    source,
+    report_schema_version: registry.report_schema_version,
+    posture: "release",
+    source: { ...source },
     candidate_digest: candidateDigest,
     correlation_nonce: correlationNonce,
-    started_at_ms: startedAtMs,
-    deadline_at_ms: startedAtMs + RELEASE_QUALIFICATION_LIMIT_MS,
-    lanes: releaseLaneRoster(registry),
+    run: { ...run },
+    selector: {
+      conclusion: "success",
+      base_sha: null,
+      head_sha: null,
+      changed_paths: [],
+      unknown_paths: [],
+    },
+    lanes,
   };
+  try {
+    validateSelection(selection, registry, {
+      posture: "release",
+      sha: source.sha,
+      tree: source.tree,
+      candidateDigest,
+      correlationNonce,
+      runID: run.id,
+      runAttempt: run.attempt,
+    });
+  } catch (cause) {
+    if (cause instanceof ContractError) {
+      throw new QualificationError(cause.problems);
+    }
+    throw cause;
+  }
+  if (
+    canonicalJSON(selectedInvocationRoster(selection, registry)) !==
+    canonicalJSON(releaseLaneRoster(registry))
+  ) {
+    throw new QualificationError([
+      "release selection does not dispatch the exact finite invocation roster",
+    ]);
+  }
+  return selection;
 }
 
-export function validatePlan(plan, registry, expected = {}) {
+export function createPlan({
+  registry,
+  selection,
+  eventIdentity,
+  repository,
+  startedAtMs,
+}) {
+  const plan = {
+    schema_version: QUALIFICATION_SCHEMA_VERSION,
+    registry_schema_version: registry.schema_version,
+    selection_schema_version: registry.selection_schema_version,
+    report_schema_version: registry.report_schema_version,
+    source: { ...selection.source },
+    candidate_digest: selection.candidate_digest,
+    correlation_nonce: selection.correlation_nonce,
+    selection_ref: {
+      run: { ...selection.run },
+      manifest_sha256: selectionManifestSHA256(selection),
+    },
+    event: { ...eventIdentity },
+    repository,
+    started_at_ms: startedAtMs,
+    deadline_at_ms: startedAtMs + RELEASE_QUALIFICATION_LIMIT_MS,
+    invocations: releaseLaneRoster(registry),
+  };
+  return validatePlan(plan, registry, selection);
+}
+
+export function validatePlan(plan, registry, selection, expected = {}) {
   const problems = [];
-  if (!exactKeys(plan, PLAN_KEYS, "plan", problems)) throw new QualificationError(problems);
+  if (!exactKeys(plan, PLAN_KEYS, "plan", problems)) {
+    throw new QualificationError(problems);
+  }
   if (plan.schema_version !== QUALIFICATION_SCHEMA_VERSION) {
     problems.push(`plan.schema_version must be ${QUALIFICATION_SCHEMA_VERSION}`);
   }
-  if (plan.registry_schema_version !== registry.schema_version) {
-    problems.push("plan.registry_schema_version does not match the registry");
+  for (const [field, actual, wanted] of [
+    ["registry_schema_version", plan.registry_schema_version, registry.schema_version],
+    [
+      "selection_schema_version",
+      plan.selection_schema_version,
+      registry.selection_schema_version,
+    ],
+    ["report_schema_version", plan.report_schema_version, registry.report_schema_version],
+  ]) {
+    if (actual !== wanted) problems.push(`plan.${field} does not match the registry`);
   }
   validateSource(plan.source, "plan.source", problems);
   string(plan.candidate_digest, "plan.candidate_digest", problems, DIGEST_RE);
   string(plan.correlation_nonce, "plan.correlation_nonce", problems, NONCE_RE);
+  validateSelectionRef(plan.selection_ref, "plan.selection_ref", problems);
+  validateEvent(plan.event, plan.source, "plan.event", problems);
+  string(plan.repository, "plan.repository", problems, REPOSITORY_RE);
   integer(plan.started_at_ms, "plan.started_at_ms", problems, 1);
   integer(plan.deadline_at_ms, "plan.deadline_at_ms", problems, 1);
-  if (plan.deadline_at_ms - plan.started_at_ms !== RELEASE_QUALIFICATION_LIMIT_MS) {
-    problems.push(`plan deadline must be exactly ${RELEASE_QUALIFICATION_LIMIT_MINUTES} minutes after start`);
+  if (
+    plan.deadline_at_ms - plan.started_at_ms !==
+    RELEASE_QUALIFICATION_LIMIT_MS
+  ) {
+    problems.push(
+      `plan deadline must be exactly ${RELEASE_QUALIFICATION_LIMIT_MINUTES} minutes after start`,
+    );
   }
-  const expectedRoster = releaseLaneRoster(registry);
-  if (!Array.isArray(plan.lanes)) problems.push("plan.lanes must be an array");
-  else {
-    for (let index = 0; index < plan.lanes.length; index += 1) {
-      const lane = plan.lanes[index];
-      const label = `plan.lanes[${index}]`;
-      if (!exactKeys(lane, PLAN_LANE_KEYS, label, problems)) continue;
-      string(lane.lane_id, `${label}.lane_id`, problems);
-      string(lane.execution_id, `${label}.execution_id`, problems);
-      if (!exactKeys(lane.producer, new Set(["workflow", "job"]), `${label}.producer`, problems)) continue;
-      string(lane.producer.workflow, `${label}.producer.workflow`, problems);
-      string(lane.producer.job, `${label}.producer.job`, problems);
-    }
-    if (canonicalJSON(plan.lanes) !== canonicalJSON(expectedRoster)) {
-      problems.push("plan.lanes does not exactly equal the registry-derived finite release roster");
+
+  try {
+    validateSelection(selection, registry, {
+      posture: "release",
+      sha: plan.source.sha,
+      tree: plan.source.tree,
+      candidateDigest: plan.candidate_digest,
+      correlationNonce: plan.correlation_nonce,
+      runID: plan.selection_ref.run.id,
+      runAttempt: plan.selection_ref.run.attempt,
+    });
+  } catch (cause) {
+    if (cause instanceof ContractError) {
+      problems.push(...cause.problems.map((problem) => `selection: ${problem}`));
+    } else {
+      throw cause;
     }
   }
+  if (
+    plan.selection_ref.manifest_sha256 !== selectionManifestSHA256(selection)
+  ) {
+    problems.push("plan selection manifest SHA-256 does not match the selection");
+  }
+  if (
+    plan.selection_ref.run.id !== selection.run?.id ||
+    plan.selection_ref.run.attempt !== selection.run?.attempt
+  ) {
+    problems.push("plan selection run does not match the selection");
+  }
+
+  let expectedRoster;
+  try {
+    expectedRoster = releaseLaneRoster(registry);
+  } catch (cause) {
+    if (cause instanceof QualificationError) problems.push(...cause.problems);
+    else throw cause;
+  }
+  if (!Array.isArray(plan.invocations)) {
+    problems.push("plan.invocations must be an array");
+  } else {
+    for (let index = 0; index < plan.invocations.length; index += 1) {
+      const invocation = plan.invocations[index];
+      const label = `plan.invocations[${index}]`;
+      if (!exactKeys(invocation, PLAN_INVOCATION_KEYS, label, problems)) continue;
+      string(invocation.lane_id, `${label}.lane_id`, problems);
+      string(invocation.execution_id, `${label}.execution_id`, problems);
+      string(invocation.invocation_mode, `${label}.invocation_mode`, problems);
+      string(invocation.determinism, `${label}.determinism`, problems);
+      if (
+        exactKeys(
+          invocation.producer,
+          PLAN_PRODUCER_KEYS,
+          `${label}.producer`,
+          problems,
+        )
+      ) {
+        string(
+          invocation.producer.workflow,
+          `${label}.producer.workflow`,
+          problems,
+        );
+        string(invocation.producer.job, `${label}.producer.job`, problems);
+      }
+    }
+    if (
+      expectedRoster &&
+      canonicalJSON(plan.invocations) !== canonicalJSON(expectedRoster)
+    ) {
+      problems.push(
+        "plan.invocations does not equal the registry-derived finite release roster",
+      );
+    }
+    if (
+      canonicalJSON(plan.invocations) !==
+      canonicalJSON(selectedInvocationRoster(selection, registry))
+    ) {
+      problems.push("plan.invocations does not equal the canonical selection");
+    }
+  }
+
   for (const [label, actual, wanted] of [
     ["source.sha", plan.source?.sha, expected.sha],
     ["source.tree", plan.source?.tree, expected.tree],
     ["candidate_digest", plan.candidate_digest, expected.candidateDigest],
     ["correlation_nonce", plan.correlation_nonce, expected.correlationNonce],
+    [
+      "selection_ref.manifest_sha256",
+      plan.selection_ref?.manifest_sha256,
+      expected.selectionManifestSHA256,
+    ],
+    ["repository", plan.repository, expected.repository],
   ]) {
-    if (wanted !== undefined && actual !== wanted) problems.push(`plan.${label} is ${actual}, want ${wanted}`);
+    if (wanted !== undefined && actual !== wanted) {
+      problems.push(`plan.${label} is ${actual}, want ${wanted}`);
+    }
+  }
+  if (
+    expected.eventIdentity !== undefined &&
+    canonicalJSON(plan.event) !== canonicalJSON(expected.eventIdentity)
+  ) {
+    problems.push("plan.event does not match the trusted expected event");
   }
   if (problems.length > 0) throw new QualificationError(problems);
   return plan;
 }
 
-function validateIndex(index, problems) {
-  if (!exactKeys(index, INDEX_KEYS, "evidence_index", problems)) return;
-  if (index.schema_version !== EVIDENCE_INDEX_SCHEMA_VERSION) {
-    problems.push(`evidence_index.schema_version must be ${EVIDENCE_INDEX_SCHEMA_VERSION}`);
-  }
-  validateSource(index.source, "evidence_index.source", problems);
-  string(index.candidate_digest, "evidence_index.candidate_digest", problems, DIGEST_RE);
-  string(index.correlation_nonce, "evidence_index.correlation_nonce", problems, NONCE_RE);
-  if (!Array.isArray(index.records)) problems.push("evidence_index.records must be an array");
+function qualificationExpected(plan) {
+  return {
+    posture: "release",
+    sha: plan.source.sha,
+    tree: plan.source.tree,
+    candidateDigest: plan.candidate_digest,
+    correlationNonce: plan.correlation_nonce,
+    runID: plan.selection_ref.run.id,
+    runAttempt: plan.selection_ref.run.attempt,
+    selectionManifestSHA256: plan.selection_ref.manifest_sha256,
+    eventIdentity: plan.event,
+    repository: plan.repository,
+    baseSHA: undefined,
+    changedPaths: undefined,
+  };
 }
 
-function validateRecord(record, lane, label, problems) {
-  if (!exactKeys(record, RECORD_KEYS, label, problems)) return;
-  string(record.lane_id, `${label}.lane_id`, problems);
-  string(record.execution_id, `${label}.execution_id`, problems);
-  validateSource(record.source, `${label}.source`, problems);
-  if (record.candidate_digest !== null) string(record.candidate_digest, `${label}.candidate_digest`, problems, DIGEST_RE);
-  if (exactKeys(record.producer, PRODUCER_KEYS, `${label}.producer`, problems)) {
-    string(record.producer.workflow, `${label}.producer.workflow`, problems);
-    string(record.producer.job, `${label}.producer.job`, problems);
-    string(record.producer.run_id, `${label}.producer.run_id`, problems, RUN_ID_RE);
-    integer(record.producer.run_attempt, `${label}.producer.run_attempt`, problems, 1);
-  }
-  string(record.invocation_mode, `${label}.invocation_mode`, problems);
-  string(record.conclusion, `${label}.conclusion`, problems);
-  if (exactKeys(record.evidence, EVIDENCE_KEYS, `${label}.evidence`, problems)) {
-    for (const key of ["executed", "passed", "failed", "skipped", "duration_ms"]) {
-      integer(record.evidence[key], `${label}.evidence.${key}`, problems);
-    }
-    if (record.evidence.seed !== null) string(record.evidence.seed, `${label}.evidence.seed`, problems);
-    string(record.evidence.corpus_id, `${label}.evidence.corpus_id`, problems);
-  }
-  if (exactKeys(record.trust, TRUST_KEYS, `${label}.trust`, problems)) {
-    string(record.trust.artifact_id, `${label}.trust.artifact_id`, problems, RUN_ID_RE);
-    string(record.trust.artifact_digest, `${label}.trust.artifact_digest`, problems, DIGEST_RE);
-    string(record.trust.head_sha, `${label}.trust.head_sha`, problems, SHA_RE);
-    string(record.trust.head_tree, `${label}.trust.head_tree`, problems, SHA_RE);
-    string(record.trust.run_id, `${label}.trust.run_id`, problems, RUN_ID_RE);
-    integer(record.trust.run_attempt, `${label}.trust.run_attempt`, problems, 1);
-    string(record.trust.job_conclusion, `${label}.trust.job_conclusion`, problems);
-    integer(record.trust.completed_at_ms, `${label}.trust.completed_at_ms`, problems, 1);
-  }
-  if (lane) {
-    if (record.producer?.workflow !== lane.producer.workflow || record.producer?.job !== lane.producer.job) {
-      problems.push(`${label}: producer does not match the registry owner`);
-    }
-    if (record.invocation_mode !== lane.invocation_mode) {
-      problems.push(`${label}: invocation_mode ${record.invocation_mode} must be ${lane.invocation_mode}`);
-    }
-    if (lane.determinism === "deterministic" && record.evidence?.seed !== null) {
-      problems.push(`${label}: deterministic evidence must carry seed=null`);
-    }
-    if (lane.determinism === "seeded" && (record.evidence?.seed ?? null) === null) {
-      problems.push(`${label}: seeded evidence must carry its seed`);
-    }
-  }
+function attestedLanes(reports, producerManifest, registry) {
+  const lanes = new Map(registry.lanes.map((lane) => [lane.id, lane]));
+  const producers = new Map(
+    producerManifest.producers.map((producer) => [producer.workflow, producer]),
+  );
+  return reports
+    .map((report) => {
+      const lane = lanes.get(report.lane_id);
+      const trusted = producers.get(report.producer.workflow);
+      const context = trusted.jobs.find((job) => {
+        if (job.job !== report.producer.job) return false;
+        return lane.context.match === "exact"
+          ? job.name === lane.context.name
+          : job.name.startsWith(lane.context.name);
+      });
+      return {
+        identity: `${report.lane_id}/${report.execution_id}/${report.invocation.mode}`,
+        producer: {
+          workflow: report.producer.workflow,
+          job: report.producer.job,
+          run: { ...report.producer.run },
+          job_name: context.name,
+          job_database_id: context.database_id,
+        },
+        report_artifact: { ...report.producer.artifact },
+        evidence: { ...report.evidence },
+      };
+    })
+    .sort((left, right) => left.identity.localeCompare(right.identity));
 }
 
-export function evaluateQualification({ registry, plan, evidenceIndex, candidateManifest, nowMs }) {
-  validatePlan(plan, registry);
+export function evaluateQualification({
+  registry,
+  plan,
+  selection,
+  reports,
+  producerManifest,
+  candidateManifest,
+  nowMs,
+}) {
+  validatePlan(plan, registry, selection);
   const problems = [];
-  validateIndex(evidenceIndex, problems);
   integer(nowMs, "qualification.now_ms", problems, 1);
+  if (nowMs < plan.started_at_ms) {
+    problems.push("qualification completed before it started");
+  }
   if (nowMs > plan.deadline_at_ms) {
     problems.push(
       `qualification timed out at ${nowMs}; deadline was ${plan.deadline_at_ms} ` +
         `(${RELEASE_QUALIFICATION_LIMIT_MINUTES} minutes)`,
     );
   }
-  if (evidenceIndex.source?.sha !== plan.source.sha || evidenceIndex.source?.tree !== plan.source.tree) {
-    problems.push("evidence index source SHA/tree does not match the plan");
+  if (!Array.isArray(reports)) {
+    problems.push("release reports must be a JSON array");
   }
-  if (evidenceIndex.candidate_digest !== plan.candidate_digest) {
-    problems.push("evidence index candidate digest does not match the plan");
-  }
-  if (evidenceIndex.correlation_nonce !== plan.correlation_nonce) {
-    problems.push("evidence index correlation nonce does not match the plan");
-  }
-
-  const expected = new Map(plan.lanes.map((lane) => [identity(lane), lane]));
-  const actual = new Map();
-  if (Array.isArray(evidenceIndex.records)) {
-    for (let index = 0; index < evidenceIndex.records.length; index += 1) {
-      const record = evidenceIndex.records[index];
-      const id = identity(record);
-      const label = `evidence_index.records[${index}] (${id})`;
-      if (actual.has(id)) {
-        problems.push(`duplicate evidence record ${id}`);
-        continue;
-      }
-      actual.set(id, record);
-      const lane = expected.get(id);
-      if (!lane) {
-        problems.push(`unexpected evidence record ${id}`);
-        continue;
-      }
-      validateRecord(record, lane, label, problems);
-      if (record.source?.sha !== plan.source.sha || record.source?.tree !== plan.source.tree) {
-        problems.push(`${id}: report source SHA/tree does not match the plan`);
-      }
-      const expectedDigest = lane.invocation_mode === "candidate_artifact" ? plan.candidate_digest : null;
-      if (record.candidate_digest !== expectedDigest) {
-        problems.push(`${id}: candidate digest does not match invocation mode and plan`);
-      }
-      if (record.conclusion !== SUCCESS) problems.push(`${id}: report conclusion ${record.conclusion} is not success`);
-      if (record.trust?.job_conclusion !== SUCCESS) {
-        problems.push(`${id}: trusted job conclusion ${record.trust?.job_conclusion} is not success`);
-      }
-      if (
-        record.producer?.run_id !== record.trust?.run_id ||
-        record.producer?.run_attempt !== record.trust?.run_attempt
-      ) {
-        problems.push(`${id}: report run identity does not match trusted workflow provenance`);
-      }
-      if (record.trust?.head_sha !== plan.source.sha || record.trust?.head_tree !== plan.source.tree) {
-        problems.push(`${id}: trusted workflow source SHA/tree does not match the plan`);
-      }
-      if (record.trust?.completed_at_ms < plan.started_at_ms) {
-        problems.push(`${id}: trusted job completed before qualification started`);
-      }
-      if (record.trust?.completed_at_ms > plan.deadline_at_ms) {
-        problems.push(`${id}: trusted job completed after the qualification deadline`);
-      }
-      const evidence = record.evidence ?? {};
-      if (evidence.executed <= 0) problems.push(`${id}: zero native checks/tests executed`);
-      if (
-        evidence.executed !== evidence.passed + evidence.failed + evidence.skipped ||
-        evidence.failed !== 0 ||
-        evidence.skipped !== 0 ||
-        evidence.passed !== evidence.executed
-      ) {
-        problems.push(`${id}: native evidence is not all-executed and all-passed`);
-      }
-    }
-  }
-  for (const id of expected.keys()) {
-    if (!actual.has(id)) problems.push(`missing evidence record ${id}`);
-  }
-  if (!actual.has(`${QUICKSTART_LANE_ID}/default/source_tree`)) {
-    problems.push(`quickstart proof ${QUICKSTART_LANE_ID}/default/source_tree is absent`);
+  if (!isObject(producerManifest)) {
+    problems.push("trusted producer manifest must be an object");
   }
   if (problems.length > 0) throw new QualificationError(problems);
 
-  const lanes = [...actual.entries()].sort(([left], [right]) => left.localeCompare(right)).map(([id, record]) => ({
-    identity: id,
-    producer: record.producer,
-    report_artifact: {
-      id: record.trust.artifact_id,
-      digest: record.trust.artifact_digest,
-    },
-    evidence: record.evidence,
-  }));
+  let result;
+  try {
+    result = validateReportSet({
+      registry,
+      selection,
+      reports,
+      producerManifest,
+      expected: qualificationExpected(plan),
+    });
+  } catch (cause) {
+    if (cause instanceof ContractError) {
+      throw new QualificationError(cause.problems);
+    }
+    throw cause;
+  }
+  if (
+    result.expected !== RELEASE_QUALIFICATION_INVOCATIONS ||
+    result.received !== RELEASE_QUALIFICATION_INVOCATIONS
+  ) {
+    throw new QualificationError([
+      `canonical report validation must receive exactly ${RELEASE_QUALIFICATION_INVOCATIONS} ` +
+        `invocations; expected ${result.expected}, received ${result.received}`,
+    ]);
+  }
+
+  const lanes = attestedLanes(reports, producerManifest, registry);
+  if (!lanes.some((lane) => lane.identity === QUICKSTART_IDENTITY)) {
+    throw new QualificationError([
+      `required quickstart proof ${QUICKSTART_IDENTITY} is absent`,
+    ]);
+  }
   return {
     schema_version: ATTESTATION_SCHEMA_VERSION,
     result: SUCCESS,
-    source: plan.source,
+    source: { ...plan.source },
     candidate: {
       digest: plan.candidate_digest,
       image_digest: candidateManifest.image.digest,
-      files: candidateManifest.files.map((file) => ({ path: file.path, sha256: file.sha256, size: file.size })),
+      files: candidateManifest.files.map((file) => ({
+        path: file.path,
+        sha256: file.sha256,
+        size: file.size,
+      })),
     },
     qualification: {
       started_at_ms: plan.started_at_ms,
@@ -479,9 +764,39 @@ export function evaluateQualification({ registry, plan, evidenceIndex, candidate
       deadline_at_ms: plan.deadline_at_ms,
       limit_minutes: RELEASE_QUALIFICATION_LIMIT_MINUTES,
       correlation_nonce: plan.correlation_nonce,
+      selection_ref: structuredClone(plan.selection_ref),
+      event: { ...plan.event },
+      repository: plan.repository,
+      invocation_count: RELEASE_QUALIFICATION_INVOCATIONS,
     },
     lanes,
   };
+}
+
+function validateEvidence(evidence, label, planned, problems) {
+  if (!exactKeys(evidence, EVIDENCE_KEYS, label, problems)) return;
+  for (const key of ["executed", "passed", "failed", "skipped", "duration_ms"]) {
+    integer(evidence[key], `${label}.${key}`, problems);
+  }
+  if (evidence.seed !== null) {
+    string(evidence.seed, `${label}.seed`, problems);
+  }
+  string(evidence.corpus_id, `${label}.corpus_id`, problems);
+  if (
+    evidence.executed <= 0 ||
+    evidence.executed !== evidence.passed + evidence.failed + evidence.skipped ||
+    evidence.failed !== 0 ||
+    evidence.skipped !== 0 ||
+    evidence.passed !== evidence.executed
+  ) {
+    problems.push(`${label} is not a positive all-passed native result`);
+  }
+  if (planned?.determinism === "deterministic" && evidence.seed !== null) {
+    problems.push(`${label} deterministic lane must carry seed=null`);
+  }
+  if (planned?.determinism === "seeded" && evidence.seed === null) {
+    problems.push(`${label} seeded lane omitted its seed`);
+  }
 }
 
 export function validateAttestation(attestation, expected = {}, registry = null) {
@@ -490,14 +805,38 @@ export function validateAttestation(attestation, expected = {}, registry = null)
     throw new QualificationError(problems);
   }
   if (attestation.schema_version !== ATTESTATION_SCHEMA_VERSION) {
-    problems.push(`attestation.schema_version must be ${ATTESTATION_SCHEMA_VERSION}`);
+    problems.push(
+      `attestation.schema_version must be ${ATTESTATION_SCHEMA_VERSION}`,
+    );
   }
-  if (attestation.result !== SUCCESS) problems.push("attestation.result must be success");
+  if (attestation.result !== SUCCESS) {
+    problems.push("attestation.result must be success");
+  }
   validateSource(attestation.source, "attestation.source", problems);
-  if (exactKeys(attestation.candidate, ATTESTATION_CANDIDATE_KEYS, "attestation.candidate", problems)) {
-    string(attestation.candidate.digest, "attestation.candidate.digest", problems, DIGEST_RE);
-    string(attestation.candidate.image_digest, "attestation.candidate.image_digest", problems, DIGEST_RE);
-    if (!Array.isArray(attestation.candidate.files) || attestation.candidate.files.length === 0) {
+  if (
+    exactKeys(
+      attestation.candidate,
+      ATTESTATION_CANDIDATE_KEYS,
+      "attestation.candidate",
+      problems,
+    )
+  ) {
+    string(
+      attestation.candidate.digest,
+      "attestation.candidate.digest",
+      problems,
+      DIGEST_RE,
+    );
+    string(
+      attestation.candidate.image_digest,
+      "attestation.candidate.image_digest",
+      problems,
+      DIGEST_RE,
+    );
+    if (
+      !Array.isArray(attestation.candidate.files) ||
+      attestation.candidate.files.length === 0
+    ) {
       problems.push("attestation.candidate.files must be non-empty");
     } else {
       let previous = "";
@@ -518,107 +857,248 @@ export function validateAttestation(attestation, expected = {}, registry = null)
       }
     }
   }
-  if (exactKeys(attestation.qualification, ATTESTATION_QUALIFICATION_KEYS, "attestation.qualification", problems)) {
+
+  if (
+    exactKeys(
+      attestation.qualification,
+      ATTESTATION_QUALIFICATION_KEYS,
+      "attestation.qualification",
+      problems,
+    )
+  ) {
     for (const key of ["started_at_ms", "completed_at_ms", "deadline_at_ms"]) {
-      integer(attestation.qualification[key], `attestation.qualification.${key}`, problems, 1);
+      integer(
+        attestation.qualification[key],
+        `attestation.qualification.${key}`,
+        problems,
+        1,
+      );
     }
-    integer(attestation.qualification.limit_minutes, "attestation.qualification.limit_minutes", problems, 1);
+    integer(
+      attestation.qualification.limit_minutes,
+      "attestation.qualification.limit_minutes",
+      problems,
+      1,
+    );
     string(
       attestation.qualification.correlation_nonce,
       "attestation.qualification.correlation_nonce",
       problems,
       NONCE_RE,
     );
+    validateSelectionRef(
+      attestation.qualification.selection_ref,
+      "attestation.qualification.selection_ref",
+      problems,
+    );
+    validateEvent(
+      attestation.qualification.event,
+      attestation.source,
+      "attestation.qualification.event",
+      problems,
+    );
+    string(
+      attestation.qualification.repository,
+      "attestation.qualification.repository",
+      problems,
+      REPOSITORY_RE,
+    );
     if (
-      Number.isSafeInteger(attestation.qualification.started_at_ms) &&
-      Number.isSafeInteger(attestation.qualification.deadline_at_ms) &&
-      attestation.qualification.deadline_at_ms - attestation.qualification.started_at_ms !==
-        RELEASE_QUALIFICATION_LIMIT_MS
+      attestation.qualification.invocation_count !==
+      RELEASE_QUALIFICATION_INVOCATIONS
     ) {
-      problems.push("attestation qualification deadline does not equal the hard release limit");
+      problems.push(
+        `attestation.qualification.invocation_count must be ${RELEASE_QUALIFICATION_INVOCATIONS}`,
+      );
     }
     if (
-      attestation.qualification.completed_at_ms < attestation.qualification.started_at_ms ||
-      attestation.qualification.completed_at_ms > attestation.qualification.deadline_at_ms
+      attestation.qualification.deadline_at_ms -
+        attestation.qualification.started_at_ms !==
+      RELEASE_QUALIFICATION_LIMIT_MS
     ) {
-      problems.push("attestation completion is outside its qualification window");
+      problems.push(
+        "attestation qualification deadline does not equal the hard release limit",
+      );
+    }
+    if (
+      attestation.qualification.completed_at_ms <
+        attestation.qualification.started_at_ms ||
+      attestation.qualification.completed_at_ms >
+        attestation.qualification.deadline_at_ms
+    ) {
+      problems.push(
+        "attestation completion is outside its qualification window",
+      );
     }
   }
-  const expectedLanes = registry
-    ? new Map(releaseLaneRoster(registry).map((lane) => [identity(lane), lane]))
-    : null;
+
+  let expectedLanes = null;
+  if (registry) {
+    try {
+      expectedLanes = new Map(
+        releaseLaneRoster(registry).map((lane) => [identity(lane), lane]),
+      );
+    } catch (cause) {
+      if (cause instanceof QualificationError) problems.push(...cause.problems);
+      else throw cause;
+    }
+  }
   const actualLanes = new Map();
-  if (!Array.isArray(attestation.lanes) || attestation.lanes.length === 0) {
-    problems.push("attestation.lanes must be non-empty");
+  if (!Array.isArray(attestation.lanes)) {
+    problems.push("attestation.lanes must be an array");
   } else {
+    if (attestation.lanes.length !== RELEASE_QUALIFICATION_INVOCATIONS) {
+      problems.push(
+        `attestation.lanes must contain exactly ${RELEASE_QUALIFICATION_INVOCATIONS} identities`,
+      );
+    }
     let previous = "";
     for (let index = 0; index < attestation.lanes.length; index += 1) {
       const lane = attestation.lanes[index];
       const label = `attestation.lanes[${index}]`;
       if (!exactKeys(lane, ATTESTATION_LANE_KEYS, label, problems)) continue;
       string(lane.identity, `${label}.identity`, problems);
-      if (actualLanes.has(lane.identity)) problems.push(`${label}.identity is duplicated`);
+      if (actualLanes.has(lane.identity)) {
+        problems.push(`${label}.identity is duplicated`);
+      }
       if (previous !== "" && String(lane.identity).localeCompare(previous) <= 0) {
         problems.push(`${label}.identity is not strictly sorted`);
       }
       actualLanes.set(lane.identity, lane);
       previous = lane.identity;
-      if (exactKeys(lane.producer, PRODUCER_KEYS, `${label}.producer`, problems)) {
-        string(lane.producer.workflow, `${label}.producer.workflow`, problems);
-        string(lane.producer.job, `${label}.producer.job`, problems);
-        string(lane.producer.run_id, `${label}.producer.run_id`, problems, RUN_ID_RE);
-        integer(lane.producer.run_attempt, `${label}.producer.run_attempt`, problems, 1);
-      }
-      if (exactKeys(lane.report_artifact, ATTESTATION_ARTIFACT_KEYS, `${label}.report_artifact`, problems)) {
-        string(lane.report_artifact.id, `${label}.report_artifact.id`, problems, RUN_ID_RE);
-        string(lane.report_artifact.digest, `${label}.report_artifact.digest`, problems, DIGEST_RE);
-      }
-      if (exactKeys(lane.evidence, EVIDENCE_KEYS, `${label}.evidence`, problems)) {
-        for (const key of ["executed", "passed", "failed", "skipped", "duration_ms"]) {
-          integer(lane.evidence[key], `${label}.evidence.${key}`, problems);
-        }
-        if (lane.evidence.seed !== null) string(lane.evidence.seed, `${label}.evidence.seed`, problems);
-        string(lane.evidence.corpus_id, `${label}.evidence.corpus_id`, problems);
-        if (
-          lane.evidence.executed <= 0 ||
-          lane.evidence.executed !== lane.evidence.passed + lane.evidence.failed + lane.evidence.skipped ||
-          lane.evidence.failed !== 0 ||
-          lane.evidence.skipped !== 0 ||
-          lane.evidence.passed !== lane.evidence.executed
-        ) {
-          problems.push(`${label}.evidence is not a positive all-passed native result`);
-        }
-      }
       const planned = expectedLanes?.get(lane.identity);
-      if (expectedLanes && !planned) problems.push(`${label}.identity is not in the registry-derived release roster`);
-      if (planned?.determinism === "deterministic" && lane.evidence?.seed !== null) {
-        problems.push(`${label}.evidence deterministic lane must carry seed=null`);
+      if (expectedLanes && !planned) {
+        problems.push(`${label}.identity is not in the finite release roster`);
       }
-      if (planned?.determinism === "seeded" && (lane.evidence?.seed ?? null) === null) {
-        problems.push(`${label}.evidence seeded lane omitted its seed`);
+      if (
+        exactKeys(
+          lane.producer,
+          ATTESTATION_PRODUCER_KEYS,
+          `${label}.producer`,
+          problems,
+        )
+      ) {
+        string(
+          lane.producer.workflow,
+          `${label}.producer.workflow`,
+          problems,
+        );
+        string(lane.producer.job, `${label}.producer.job`, problems);
+        validateRun(lane.producer.run, `${label}.producer.run`, problems);
+        string(lane.producer.job_name, `${label}.producer.job_name`, problems);
+        string(
+          lane.producer.job_database_id,
+          `${label}.producer.job_database_id`,
+          problems,
+          RUN_ID_RE,
+        );
+        if (
+          planned &&
+          (lane.producer.workflow !== planned.producer.workflow ||
+            lane.producer.job !== planned.producer.job)
+        ) {
+          problems.push(`${label}.producer does not match the registry owner`);
+        }
       }
+      if (
+        exactKeys(
+          lane.report_artifact,
+          ATTESTATION_ARTIFACT_KEYS,
+          `${label}.report_artifact`,
+          problems,
+        )
+      ) {
+        string(
+          lane.report_artifact.id,
+          `${label}.report_artifact.id`,
+          problems,
+          RUN_ID_RE,
+        );
+        string(
+          lane.report_artifact.name,
+          `${label}.report_artifact.name`,
+          problems,
+        );
+        string(
+          lane.report_artifact.sha256,
+          `${label}.report_artifact.sha256`,
+          problems,
+          SHA256_RE,
+        );
+        string(
+          lane.report_artifact.entry,
+          `${label}.report_artifact.entry`,
+          problems,
+        );
+        string(
+          lane.report_artifact.entry_sha256,
+          `${label}.report_artifact.entry_sha256`,
+          problems,
+          SHA256_RE,
+        );
+        if (lane.report_artifact.entry !== lane.identity) {
+          problems.push(`${label}.report_artifact.entry must equal its identity`);
+        }
+      }
+      validateEvidence(lane.evidence, `${label}.evidence`, planned, problems);
     }
   }
   if (expectedLanes) {
-    for (const id of expectedLanes.keys()) {
-      if (!actualLanes.has(id)) problems.push(`attestation is missing release lane ${id}`);
+    for (const expectedIdentity of expectedLanes.keys()) {
+      if (!actualLanes.has(expectedIdentity)) {
+        problems.push(`attestation is missing release lane ${expectedIdentity}`);
+      }
     }
   }
-  if (!actualLanes.has(`${QUICKSTART_LANE_ID}/default/source_tree`)) {
-    problems.push("attestation does not contain the required quickstart proof");
+  if (!actualLanes.has(QUICKSTART_IDENTITY)) {
+    problems.push(
+      `attestation does not contain required quickstart proof ${QUICKSTART_IDENTITY}`,
+    );
   }
-  if (attestation.qualification?.limit_minutes !== RELEASE_QUALIFICATION_LIMIT_MINUTES) {
-    problems.push(`attestation qualification limit must be ${RELEASE_QUALIFICATION_LIMIT_MINUTES} minutes`);
+  if (
+    attestation.qualification?.limit_minutes !==
+    RELEASE_QUALIFICATION_LIMIT_MINUTES
+  ) {
+    problems.push(
+      `attestation qualification limit must be ${RELEASE_QUALIFICATION_LIMIT_MINUTES} minutes`,
+    );
   }
+
   for (const [label, actual, wanted] of [
     ["source.sha", attestation.source?.sha, expected.sha],
     ["source.tree", attestation.source?.tree, expected.tree],
     ["candidate.digest", attestation.candidate?.digest, expected.candidateDigest],
-    ["qualification.correlation_nonce", attestation.qualification?.correlation_nonce, expected.correlationNonce],
+    [
+      "candidate.image_digest",
+      attestation.candidate?.image_digest,
+      expected.imageDigest,
+    ],
+    [
+      "qualification.correlation_nonce",
+      attestation.qualification?.correlation_nonce,
+      expected.correlationNonce,
+    ],
+    [
+      "qualification.selection_ref.manifest_sha256",
+      attestation.qualification?.selection_ref?.manifest_sha256,
+      expected.selectionManifestSHA256,
+    ],
+    [
+      "qualification.repository",
+      attestation.qualification?.repository,
+      expected.repository,
+    ],
   ]) {
     if (wanted !== undefined && actual !== wanted) {
       problems.push(`attestation.${label} is ${actual}, want ${wanted}`);
     }
+  }
+  if (
+    expected.eventIdentity !== undefined &&
+    canonicalJSON(attestation.qualification?.event) !==
+      canonicalJSON(expected.eventIdentity)
+  ) {
+    problems.push("attestation qualification event does not match expected event");
   }
   if (problems.length > 0) throw new QualificationError(problems);
   return attestation;
@@ -637,14 +1117,17 @@ function environmentIdentity() {
 }
 
 function verifiedCandidate(expected) {
-  return verifyCandidate(resolve(process.env.RELEASE_CANDIDATE_DIR || "build/release-candidate"), {
-    sha: expected.sha,
-    tree: expected.tree,
-    app: expected.app,
-    appTag: expected.appTag,
-    chart: expected.chart,
-    digest: expected.candidateDigest,
-  });
+  return verifyCandidate(
+    resolve(process.env.RELEASE_CANDIDATE_DIR || "build/release-candidate"),
+    {
+      sha: expected.sha,
+      tree: expected.tree,
+      app: expected.app,
+      appTag: expected.appTag,
+      chart: expected.chart,
+      digest: expected.candidateDigest,
+    },
+  );
 }
 
 export function verifyAttestationBundle({
@@ -680,15 +1163,16 @@ export function verifyAttestationBundle({
   }
   const attestation = validateAttestation(
     readJSON(path, "release qualification attestation"),
-    expected,
+    {
+      ...expected,
+      imageDigest: candidate.manifest.image.digest,
+    },
     registry,
   );
-  if (attestation.candidate.image_digest !== candidate.manifest.image.digest) {
-    throw new QualificationError([
-      "attestation image digest does not match the verified candidate",
-    ]);
-  }
-  if (canonicalJSON(attestation.candidate.files) !== canonicalJSON(candidate.manifest.files)) {
+  if (
+    canonicalJSON(attestation.candidate.files) !==
+    canonicalJSON(candidate.manifest.files)
+  ) {
     throw new QualificationError([
       "attestation artifact digests do not match the verified candidate manifest",
     ]);
@@ -714,21 +1198,54 @@ function planMode() {
   const expected = environmentIdentity();
   verifiedCandidate(expected);
   const registry = loadRegistry();
-  const startedAtMs = positiveMillis("RELEASE_QUALIFICATION_START");
-  const plan = createPlan({
+  const eventKind = requiredEnv("GITHUB_EVENT_NAME");
+  if (!RELEASE_EVENTS.has(eventKind)) {
+    throw new QualificationError([
+      `GITHUB_EVENT_NAME must be push or workflow_dispatch; got ${JSON.stringify(eventKind)}`,
+    ]);
+  }
+  const run = {
+    id: requiredEnv("GITHUB_RUN_ID", RUN_ID_RE),
+    attempt: positiveIntegerEnv("GITHUB_RUN_ATTEMPT"),
+  };
+  const selection = createReleaseSelection({
     registry,
     source: { sha: expected.sha, tree: expected.tree },
     candidateDigest: expected.candidateDigest,
     correlationNonce: expected.correlationNonce,
-    startedAtMs,
+    run,
   });
-  const path = resolve(process.env.RELEASE_QUALIFICATION_PLAN || "build/release-qualification-plan.json");
-  writeCanonical(path, plan);
-  setOutput("plan", path);
-  setOutput("lane_count", String(plan.lanes.length));
+  const eventIdentity = {
+    kind: eventKind,
+    pr_number: null,
+    event_head_sha: expected.sha,
+    event_base_sha: null,
+    projected_sha: expected.sha,
+  };
+  const plan = createPlan({
+    registry,
+    selection,
+    eventIdentity,
+    repository: requiredEnv("GITHUB_REPOSITORY", REPOSITORY_RE),
+    startedAtMs: positiveMillis("RELEASE_QUALIFICATION_START"),
+  });
+  const selectionPath = resolve(
+    process.env.RELEASE_QUALIFICATION_SELECTION ||
+      "build/release-qualification-selection.json",
+  );
+  const planPath = resolve(
+    process.env.RELEASE_QUALIFICATION_PLAN ||
+      "build/release-qualification-plan.json",
+  );
+  writeSelection(selectionPath, selection);
+  writeCanonical(planPath, plan);
+  setOutput("selection", selectionPath);
+  setOutput("selection_digest", plan.selection_ref.manifest_sha256);
+  setOutput("plan", planPath);
+  setOutput("lane_count", String(plan.invocations.length));
   notice(
-    `planned ${plan.lanes.length} finite release executions for ${expected.sha.slice(0, 12)} ` +
-      `candidate ${expected.candidateDigest}`,
+    `planned ${plan.invocations.length} finite release invocations for ` +
+      `${expected.sha.slice(0, 12)} candidate ${expected.candidateDigest}`,
   );
 }
 
@@ -736,21 +1253,43 @@ function joinMode() {
   const expected = environmentIdentity();
   const candidate = verifiedCandidate(expected);
   const registry = loadRegistry();
-  const planPath = resolve(process.env.RELEASE_QUALIFICATION_PLAN || "build/release-qualification-plan.json");
-  const evidencePath = resolve(requiredEnv("RELEASE_EVIDENCE_INDEX"));
-  const plan = validatePlan(readJSON(planPath, "release qualification plan"), registry, expected);
+  const selectionPath = resolve(
+    process.env.RELEASE_QUALIFICATION_SELECTION ||
+      "build/release-qualification-selection.json",
+  );
+  const planPath = resolve(
+    process.env.RELEASE_QUALIFICATION_PLAN ||
+      "build/release-qualification-plan.json",
+  );
+  const reportsPath = resolve(requiredEnv("RELEASE_QUALIFICATION_REPORTS"));
+  const producerManifestPath = resolve(
+    requiredEnv("RELEASE_QUALIFICATION_PRODUCER_MANIFEST"),
+  );
+  const selection = readJSON(selectionPath, "release qualification selection");
+  const plan = validatePlan(
+    readJSON(planPath, "release qualification plan"),
+    registry,
+    selection,
+    expected,
+  );
   const nowMs = process.env.RELEASE_QUALIFICATION_NOW
     ? positiveMillis("RELEASE_QUALIFICATION_NOW")
     : Date.now();
   const attestation = evaluateQualification({
     registry,
     plan,
-    evidenceIndex: readJSON(evidencePath, "release evidence index"),
+    selection,
+    reports: readJSON(reportsPath, "release qualification reports"),
+    producerManifest: readJSON(
+      producerManifestPath,
+      "release trusted producer manifest",
+    ),
     candidateManifest: candidate.manifest,
     nowMs,
   });
   const attestationPath = resolve(
-    process.env.RELEASE_ATTESTATION || "build/release-qualification-attestation.json",
+    process.env.RELEASE_ATTESTATION ||
+      "build/release-qualification-attestation.json",
   );
   writeCanonical(attestationPath, attestation);
   const digest = sha256File(attestationPath);
@@ -758,7 +1297,7 @@ function joinMode() {
   setOutput("attestation", attestationPath);
   setOutput("attestation_digest", digest);
   notice(
-    `release qualification passed ${attestation.lanes.length} executions in ` +
+    `release qualification passed ${attestation.lanes.length} invocations in ` +
       `${attestation.qualification.completed_at_ms - attestation.qualification.started_at_ms} ms; ` +
       `attestation ${digest}`,
   );
@@ -782,7 +1321,8 @@ function main() {
   }
 }
 
-const invokedDirectly = process.argv[1] && fileURLToPath(import.meta.url) === resolve(process.argv[1]);
+const invokedDirectly =
+  process.argv[1] && fileURLToPath(import.meta.url) === resolve(process.argv[1]);
 if (invokedDirectly) {
   try {
     main();

--- a/.github/scripts/release-qualification.mjs
+++ b/.github/scripts/release-qualification.mjs
@@ -1,13 +1,14 @@
-// release-qualification.mjs — create and join the finite pre-publication test
+// release-qualification.mjs — plan and join the finite pre-publication test
 // fence for one immutable release candidate.
 //
 // Modes (MODE or argv[2]):
-//   plan               write the canonical release selection and a closed plan
-//                      that pins its digest and trusted coordinator identity.
-//   join               validate canonical native reports against trusted API
-//                      producer provenance and write the signed input attestation.
-//   verify-attestation verify the exact successful attestation before a writer
-//                      can promote any part of the candidate.
+//   plan               select every deterministic or seeded pre-publication
+//                      lane from the registry and write the closed roster.
+//   join               validate the adapter's trusted evidence index, reject
+//                      every non-success or hollow result, and emit a canonical
+//                      dry-run attestation over source tree + artifact digests.
+//   verify-attestation verify that promotion received the exact successful
+//                      attestation and candidate qualified by the join.
 //
 // Environment:
 //   RELEASE_CANDIDATE_DIR       sealed candidate root.
@@ -18,145 +19,88 @@
 //   RELEASE_APP_TAG             exact application tag.
 //   RELEASE_CHART_VERSION       exact chart version.
 //   RELEASE_QUALIFICATION_START epoch milliseconds set before candidate build.
-//   RELEASE_CORRELATION_NONCE   64 lowercase hex, fresh for this qualification.
+//   RELEASE_CORRELATION_NONCE    64 lowercase hex, fresh for this qualification.
 //   RELEASE_QUALIFICATION_PLAN  plan path
 //                              (default build/release-qualification-plan.json).
-//   RELEASE_QUALIFICATION_SELECTION canonical selection path
-//                              (default build/release-qualification-selection.json).
-//   RELEASE_QUALIFICATION_REPORTS JSON array of canonical native reports
-//                              (join only).
-//   RELEASE_QUALIFICATION_PRODUCER_MANIFEST trusted API producer manifest
-//                              (join only).
+//   RELEASE_EVIDENCE_INDEX      normalized, trusted evidence index from the
+//                              cross-run adapter (join only).
 //   RELEASE_ATTESTATION         attestation path
 //                              (default build/release-qualification-attestation.json).
 //   RELEASE_ATTESTATION_DIGEST  expected attestation digest (verify only).
 //   RELEASE_QUALIFICATION_NOW   epoch milliseconds override for deterministic
 //                              fault tests; Actions leaves it unset.
-//   GITHUB_EVENT_NAME           push or workflow_dispatch (plan only).
-//   GITHUB_REPOSITORY           trusted repository identity (plan only).
-//   GITHUB_RUN_ID               coordinator run ID (plan only).
-//   GITHUB_RUN_ATTEMPT          coordinator run attempt (plan only).
-//   GITHUB_OUTPUT               receives plan/selection/attestation outputs.
+//   GITHUB_OUTPUT               receives plan/qualification/attestation outputs.
 //
-// Cross-workflow discovery stays outside this module. The adapter supplies
-// native report documents plus API-derived producer provenance; the canonical
-// CI lane contract performs the only report-set qualification.
+// The adapter is deliberately the only cross-workflow discovery seam. This
+// module accepts no GitHub API observation directly: it validates a closed
+// roster plus records whose run/job/artifact provenance the adapter has already
+// resolved. Missing records and duplicate identities are both failures.
 
 import { existsSync, readFileSync, writeFileSync } from "node:fs";
-import { resolve } from "node:path";
+import { dirname, resolve } from "node:path";
 import process from "node:process";
 import { fileURLToPath } from "node:url";
 
-import {
-  ContractError,
-  loadRegistry,
-  selectionManifestSHA256,
-  validateReportSet,
-  validateSelection,
-} from "./ci-lane-contract.mjs";
 import { error, notice, setOutput } from "./lib/gh.mjs";
+import { loadRegistry } from "./ci-lane-contract.mjs";
 import {
+  CANDIDATE_MANIFEST,
   canonicalJSON,
   sha256File,
   verifyCandidate,
 } from "./release-candidate.mjs";
 
-export const QUALIFICATION_SCHEMA_VERSION = 2;
-export const ATTESTATION_SCHEMA_VERSION = 2;
-export const RELEASE_QUALIFICATION_INVOCATIONS = 45;
+export const QUALIFICATION_SCHEMA_VERSION = 1;
+export const EVIDENCE_INDEX_SCHEMA_VERSION = 1;
+export const ATTESTATION_SCHEMA_VERSION = 1;
 export const RELEASE_QUALIFICATION_LIMIT_MINUTES = 120;
-export const RELEASE_QUALIFICATION_LIMIT_MS =
-  RELEASE_QUALIFICATION_LIMIT_MINUTES * 60 * 1000;
-export const QUICKSTART_IDENTITY = "e2e.quickstart/default/source_tree";
+export const RELEASE_QUALIFICATION_LIMIT_MS = RELEASE_QUALIFICATION_LIMIT_MINUTES * 60 * 1000;
+export const QUICKSTART_LANE_ID = "e2e.quickstart";
 
 const SHA_RE = /^[0-9a-f]{40}$/;
 const DIGEST_RE = /^sha256:[0-9a-f]{64}$/;
-const SHA256_RE = /^[0-9a-f]{64}$/;
 const NONCE_RE = /^[0-9a-f]{64}$/;
 const RUN_ID_RE = /^[1-9][0-9]*$/;
-const REPOSITORY_RE = /^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/;
 const FINITE_DETERMINISM = new Set(["deterministic", "seeded"]);
-const RELEASE_EVENTS = new Set(["push", "workflow_dispatch"]);
 const SUCCESS = "success";
 
-const SOURCE_KEYS = new Set(["sha", "tree"]);
-const RUN_KEYS = new Set(["id", "attempt"]);
-const EVENT_KEYS = new Set([
-  "kind",
-  "pr_number",
-  "event_head_sha",
-  "event_base_sha",
-  "projected_sha",
-]);
-const SELECTION_REF_KEYS = new Set(["run", "manifest_sha256"]);
 const PLAN_KEYS = new Set([
   "schema_version",
   "registry_schema_version",
-  "selection_schema_version",
-  "report_schema_version",
   "source",
   "candidate_digest",
   "correlation_nonce",
-  "selection_ref",
-  "event",
-  "repository",
   "started_at_ms",
   "deadline_at_ms",
-  "invocations",
+  "lanes",
 ]);
-const PLAN_INVOCATION_KEYS = new Set([
+const PLAN_LANE_KEYS = new Set([
   "lane_id",
   "execution_id",
   "producer",
   "invocation_mode",
   "determinism",
 ]);
-const PLAN_PRODUCER_KEYS = new Set(["workflow", "job"]);
-const ATTESTATION_KEYS = new Set([
+const INDEX_KEYS = new Set([
   "schema_version",
-  "result",
   "source",
-  "candidate",
-  "qualification",
-  "lanes",
-]);
-const ATTESTATION_CANDIDATE_KEYS = new Set([
-  "digest",
-  "image_digest",
-  "files",
-]);
-const ATTESTATION_FILE_KEYS = new Set(["path", "sha256", "size"]);
-const ATTESTATION_QUALIFICATION_KEYS = new Set([
-  "started_at_ms",
-  "completed_at_ms",
-  "deadline_at_ms",
-  "limit_minutes",
+  "candidate_digest",
   "correlation_nonce",
-  "selection_ref",
-  "event",
-  "repository",
-  "invocation_count",
+  "records",
 ]);
-const ATTESTATION_LANE_KEYS = new Set([
-  "identity",
+const RECORD_KEYS = new Set([
+  "lane_id",
+  "execution_id",
+  "source",
+  "candidate_digest",
   "producer",
-  "report_artifact",
+  "invocation_mode",
+  "conclusion",
   "evidence",
+  "trust",
 ]);
-const ATTESTATION_PRODUCER_KEYS = new Set([
-  "workflow",
-  "job",
-  "run",
-  "job_name",
-  "job_database_id",
-]);
-const ATTESTATION_ARTIFACT_KEYS = new Set([
-  "id",
-  "name",
-  "sha256",
-  "entry",
-  "entry_sha256",
-]);
+const SOURCE_KEYS = new Set(["sha", "tree"]);
+const PRODUCER_KEYS = new Set(["workflow", "job", "run_id", "run_attempt"]);
 const EVIDENCE_KEYS = new Set([
   "executed",
   "passed",
@@ -166,14 +110,39 @@ const EVIDENCE_KEYS = new Set([
   "seed",
   "corpus_id",
 ]);
+const TRUST_KEYS = new Set([
+  "artifact_id",
+  "artifact_digest",
+  "head_sha",
+  "head_tree",
+  "run_id",
+  "run_attempt",
+  "job_conclusion",
+  "completed_at_ms",
+]);
+const ATTESTATION_KEYS = new Set([
+  "schema_version",
+  "result",
+  "source",
+  "candidate",
+  "qualification",
+  "lanes",
+]);
+const ATTESTATION_CANDIDATE_KEYS = new Set(["digest", "image_digest", "files"]);
+const ATTESTATION_FILE_KEYS = new Set(["path", "sha256", "size"]);
+const ATTESTATION_QUALIFICATION_KEYS = new Set([
+  "started_at_ms",
+  "completed_at_ms",
+  "deadline_at_ms",
+  "limit_minutes",
+  "correlation_nonce",
+]);
+const ATTESTATION_LANE_KEYS = new Set(["identity", "producer", "report_artifact", "evidence"]);
+const ATTESTATION_ARTIFACT_KEYS = new Set(["id", "digest"]);
 
 export class QualificationError extends Error {
   constructor(problems) {
-    super(
-      `release qualification failed closed:\n${problems
-        .map((problem) => `- ${problem}`)
-        .join("\n")}`,
-    );
+    super(`release qualification failed closed:\n${problems.map((p) => `- ${p}`).join("\n")}`);
     this.name = "QualificationError";
     this.problems = problems;
   }
@@ -190,33 +159,21 @@ function exactKeys(value, keys, label, problems) {
   }
   const extras = Object.keys(value).filter((key) => !keys.has(key));
   const missing = [...keys].filter((key) => !(key in value));
-  if (extras.length > 0) {
-    problems.push(`${label} has unknown keys: ${extras.join(", ")}`);
-  }
-  if (missing.length > 0) {
-    problems.push(`${label} is missing keys: ${missing.join(", ")}`);
-  }
+  if (extras.length > 0) problems.push(`${label} has unknown keys: ${extras.join(", ")}`);
+  if (missing.length > 0) problems.push(`${label} is missing keys: ${missing.join(", ")}`);
   return extras.length === 0 && missing.length === 0;
 }
 
 function string(value, label, problems, pattern = null) {
   if (typeof value !== "string" || value === "") {
     problems.push(`${label} must be a non-empty string`);
-    return false;
+    return;
   }
-  if (pattern && !pattern.test(value)) {
-    problems.push(`${label} has invalid value ${JSON.stringify(value)}`);
-    return false;
-  }
-  return true;
+  if (pattern && !pattern.test(value)) problems.push(`${label} has invalid value ${JSON.stringify(value)}`);
 }
 
 function integer(value, label, problems, min = 0) {
-  if (!Number.isSafeInteger(value) || value < min) {
-    problems.push(`${label} must be an integer >= ${min}`);
-    return false;
-  }
-  return true;
+  if (!Number.isSafeInteger(value) || value < min) problems.push(`${label} must be an integer >= ${min}`);
 }
 
 function validateSource(source, label, problems) {
@@ -225,64 +182,17 @@ function validateSource(source, label, problems) {
   string(source.tree, `${label}.tree`, problems, SHA_RE);
 }
 
-function validateRun(run, label, problems) {
-  if (!exactKeys(run, RUN_KEYS, label, problems)) return;
-  string(run.id, `${label}.id`, problems, RUN_ID_RE);
-  integer(run.attempt, `${label}.attempt`, problems, 1);
-}
-
-function validateEvent(event, source, label, problems) {
-  if (!exactKeys(event, EVENT_KEYS, label, problems)) return;
-  string(event.kind, `${label}.kind`, problems);
-  if (!RELEASE_EVENTS.has(event.kind)) {
-    problems.push(`${label}.kind must be push or workflow_dispatch`);
-  }
-  if (event.pr_number !== null) problems.push(`${label}.pr_number must be null`);
-  string(event.event_head_sha, `${label}.event_head_sha`, problems, SHA_RE);
-  if (event.event_base_sha !== null) {
-    problems.push(`${label}.event_base_sha must be null`);
-  }
-  string(event.projected_sha, `${label}.projected_sha`, problems, SHA_RE);
-  if (
-    event.event_head_sha !== source?.sha ||
-    event.projected_sha !== source?.sha
-  ) {
-    problems.push(`${label} must bind the exact release source SHA`);
-  }
-}
-
-function validateSelectionRef(reference, label, problems) {
-  if (!exactKeys(reference, SELECTION_REF_KEYS, label, problems)) return;
-  validateRun(reference.run, `${label}.run`, problems);
-  string(
-    reference.manifest_sha256,
-    `${label}.manifest_sha256`,
-    problems,
-    SHA256_RE,
-  );
-}
-
 function readJSON(path, label = path) {
-  if (!existsSync(path)) {
-    throw new QualificationError([`${label} does not exist: ${path}`]);
-  }
+  if (!existsSync(path)) throw new QualificationError([`${label} does not exist: ${path}`]);
   try {
     return JSON.parse(readFileSync(path, "utf8"));
   } catch (cause) {
-    throw new QualificationError([
-      `${label} is not valid JSON: ${cause.message}`,
-    ]);
+    throw new QualificationError([`${label} is not valid JSON: ${cause.message}`]);
   }
 }
 
 function writeCanonical(path, value) {
   writeFileSync(path, `${canonicalJSON(value)}\n`);
-}
-
-function writeSelection(path, value) {
-  // selectionManifestSHA256 deliberately covers the standard indented
-  // selection representation, including its terminating newline.
-  writeFileSync(path, `${JSON.stringify(value, null, 2)}\n`);
 }
 
 function requiredEnv(name, pattern = null) {
@@ -293,63 +203,13 @@ function requiredEnv(name, pattern = null) {
   return value;
 }
 
-function positiveIntegerEnv(name) {
-  const raw = process.env[name];
-  if (!/^[1-9][0-9]*$/.test(raw ?? "")) {
-    throw new QualificationError([
-      `${name} must be a canonical positive integer`,
-    ]);
-  }
-  const value = Number(raw);
-  if (!Number.isSafeInteger(value)) {
-    throw new QualificationError([`${name} exceeds safe integer range`]);
-  }
-  return value;
-}
-
 function positiveMillis(name, raw = process.env[name]) {
   if (!/^[1-9][0-9]*$/.test(raw ?? "")) {
-    throw new QualificationError([
-      `${name} must be canonical positive epoch milliseconds`,
-    ]);
+    throw new QualificationError([`${name} must be canonical positive epoch milliseconds`]);
   }
   const value = Number(raw);
-  if (!Number.isSafeInteger(value)) {
-    throw new QualificationError([`${name} exceeds safe integer range`]);
-  }
+  if (!Number.isSafeInteger(value)) throw new QualificationError([`${name} exceeds safe integer range`]);
   return value;
-}
-
-function identity(value) {
-  return `${value.lane_id}/${value.execution_id}/${value.invocation_mode}`;
-}
-
-function selectedInvocationRoster(selection, registry) {
-  const lanes = new Map(registry.lanes.map((lane) => [lane.id, lane]));
-  const roster = [];
-  for (const item of selection.lanes ?? []) {
-    if (item.disposition !== "selected") continue;
-    const lane = lanes.get(item.lane_id);
-    if (!lane) continue;
-    const modes = [];
-    if (lane.applicability.source) modes.push("source_tree");
-    if (lane.applicability.artifact) modes.push("candidate_artifact");
-    for (const executionID of item.executions) {
-      for (const invocationMode of modes) {
-        roster.push({
-          lane_id: lane.id,
-          execution_id: executionID,
-          producer: {
-            workflow: lane.owner.workflow,
-            job: lane.owner.context_job,
-          },
-          invocation_mode: invocationMode,
-          determinism: lane.determinism,
-        });
-      }
-    }
-  }
-  return roster.sort((left, right) => identity(left).localeCompare(identity(right)));
 }
 
 export function releaseLaneRoster(registry) {
@@ -357,14 +217,15 @@ export function releaseLaneRoster(registry) {
   for (const lane of registry.lanes) {
     if (!FINITE_DETERMINISM.has(lane.determinism)) continue;
     if (lane.release_posture === "post_publish") continue;
-    for (const executionID of lane.executions) {
-      const modes = [];
-      if (lane.applicability.source) modes.push("source_tree");
-      if (lane.applicability.artifact) modes.push("candidate_artifact");
-      for (const invocationMode of modes) {
+    if (!lane.applicability.source && !lane.applicability.artifact) continue;
+    for (const execution of lane.executions) {
+      for (const invocationMode of [
+        ...(lane.applicability.source ? ["source_tree"] : []),
+        ...(lane.applicability.artifact ? ["candidate_artifact"] : []),
+      ]) {
         roster.push({
           lane_id: lane.id,
-          execution_id: executionID,
+          execution_id: execution,
           producer: {
             workflow: lane.owner.workflow,
             job: lane.owner.context_job,
@@ -376,387 +237,241 @@ export function releaseLaneRoster(registry) {
     }
   }
   roster.sort((left, right) => identity(left).localeCompare(identity(right)));
-  const problems = [];
-  if (!roster.some((item) => identity(item) === QUICKSTART_IDENTITY)) {
-    problems.push(`${QUICKSTART_IDENTITY} is absent from release qualification`);
+  if (!roster.some((item) => item.lane_id === QUICKSTART_LANE_ID)) {
+    throw new QualificationError([`${QUICKSTART_LANE_ID} is absent from the finite release roster`]);
   }
-  if (roster.length !== RELEASE_QUALIFICATION_INVOCATIONS) {
-    problems.push(
-      `release qualification must contain exactly ${RELEASE_QUALIFICATION_INVOCATIONS} ` +
-        `invocations; registry produced ${roster.length}`,
-    );
-  }
-  if (problems.length > 0) throw new QualificationError(problems);
   return roster;
 }
 
-export function createReleaseSelection({
-  registry,
-  source,
-  candidateDigest,
-  correlationNonce,
-  run,
-}) {
-  const lanes = registry.lanes
-    .map((lane) => {
-      if (lane.release_posture === "post_publish") {
-        return {
-          lane_id: lane.id,
-          disposition: "omitted",
-          executions: [],
-          reason: "post_publish",
-        };
-      }
-      if (!FINITE_DETERMINISM.has(lane.determinism)) {
-        return {
-          lane_id: lane.id,
-          disposition: "omitted",
-          executions: [],
-          reason: "advisory",
-        };
-      }
-      return {
-        lane_id: lane.id,
-        disposition: "selected",
-        executions: [...lane.executions],
-        reason: null,
-      };
-    })
-    .sort((left, right) => left.lane_id.localeCompare(right.lane_id));
-  const selection = {
-    schema_version: registry.selection_schema_version,
-    registry_schema_version: registry.schema_version,
-    report_schema_version: registry.report_schema_version,
-    posture: "release",
-    source: { ...source },
-    candidate_digest: candidateDigest,
-    correlation_nonce: correlationNonce,
-    run: { ...run },
-    selector: {
-      conclusion: "success",
-      base_sha: null,
-      head_sha: null,
-      changed_paths: [],
-      unknown_paths: [],
-    },
-    lanes,
-  };
-  try {
-    validateSelection(selection, registry, {
-      posture: "release",
-      sha: source.sha,
-      tree: source.tree,
-      candidateDigest,
-      correlationNonce,
-      runID: run.id,
-      runAttempt: run.attempt,
-    });
-  } catch (cause) {
-    if (cause instanceof ContractError) {
-      throw new QualificationError(cause.problems);
-    }
-    throw cause;
-  }
-  if (
-    canonicalJSON(selectedInvocationRoster(selection, registry)) !==
-    canonicalJSON(releaseLaneRoster(registry))
-  ) {
-    throw new QualificationError([
-      "release selection does not dispatch the exact finite invocation roster",
-    ]);
-  }
-  return selection;
+function identity(value) {
+  return `${value.lane_id}/${value.execution_id}/${value.invocation_mode}`;
 }
 
-export function createPlan({
-  registry,
-  selection,
-  eventIdentity,
-  repository,
-  startedAtMs,
-}) {
-  const plan = {
+export function createPlan({ registry, source, candidateDigest, correlationNonce, startedAtMs }) {
+  const problems = [];
+  validateSource(source, "plan.source", problems);
+  string(candidateDigest, "plan.candidate_digest", problems, DIGEST_RE);
+  string(correlationNonce, "plan.correlation_nonce", problems, NONCE_RE);
+  integer(startedAtMs, "plan.started_at_ms", problems, 1);
+  if (problems.length > 0) throw new QualificationError(problems);
+  return {
     schema_version: QUALIFICATION_SCHEMA_VERSION,
     registry_schema_version: registry.schema_version,
-    selection_schema_version: registry.selection_schema_version,
-    report_schema_version: registry.report_schema_version,
-    source: { ...selection.source },
-    candidate_digest: selection.candidate_digest,
-    correlation_nonce: selection.correlation_nonce,
-    selection_ref: {
-      run: { ...selection.run },
-      manifest_sha256: selectionManifestSHA256(selection),
-    },
-    event: { ...eventIdentity },
-    repository,
+    source,
+    candidate_digest: candidateDigest,
+    correlation_nonce: correlationNonce,
     started_at_ms: startedAtMs,
     deadline_at_ms: startedAtMs + RELEASE_QUALIFICATION_LIMIT_MS,
-    invocations: releaseLaneRoster(registry),
+    lanes: releaseLaneRoster(registry),
   };
-  return validatePlan(plan, registry, selection);
 }
 
-export function validatePlan(plan, registry, selection, expected = {}) {
+export function validatePlan(plan, registry, expected = {}) {
   const problems = [];
-  if (!exactKeys(plan, PLAN_KEYS, "plan", problems)) {
-    throw new QualificationError(problems);
-  }
+  if (!exactKeys(plan, PLAN_KEYS, "plan", problems)) throw new QualificationError(problems);
   if (plan.schema_version !== QUALIFICATION_SCHEMA_VERSION) {
     problems.push(`plan.schema_version must be ${QUALIFICATION_SCHEMA_VERSION}`);
   }
-  for (const [field, actual, wanted] of [
-    ["registry_schema_version", plan.registry_schema_version, registry.schema_version],
-    [
-      "selection_schema_version",
-      plan.selection_schema_version,
-      registry.selection_schema_version,
-    ],
-    ["report_schema_version", plan.report_schema_version, registry.report_schema_version],
-  ]) {
-    if (actual !== wanted) problems.push(`plan.${field} does not match the registry`);
+  if (plan.registry_schema_version !== registry.schema_version) {
+    problems.push("plan.registry_schema_version does not match the registry");
   }
   validateSource(plan.source, "plan.source", problems);
   string(plan.candidate_digest, "plan.candidate_digest", problems, DIGEST_RE);
   string(plan.correlation_nonce, "plan.correlation_nonce", problems, NONCE_RE);
-  validateSelectionRef(plan.selection_ref, "plan.selection_ref", problems);
-  validateEvent(plan.event, plan.source, "plan.event", problems);
-  string(plan.repository, "plan.repository", problems, REPOSITORY_RE);
   integer(plan.started_at_ms, "plan.started_at_ms", problems, 1);
   integer(plan.deadline_at_ms, "plan.deadline_at_ms", problems, 1);
-  if (
-    plan.deadline_at_ms - plan.started_at_ms !==
-    RELEASE_QUALIFICATION_LIMIT_MS
-  ) {
-    problems.push(
-      `plan deadline must be exactly ${RELEASE_QUALIFICATION_LIMIT_MINUTES} minutes after start`,
-    );
+  if (plan.deadline_at_ms - plan.started_at_ms !== RELEASE_QUALIFICATION_LIMIT_MS) {
+    problems.push(`plan deadline must be exactly ${RELEASE_QUALIFICATION_LIMIT_MINUTES} minutes after start`);
   }
-
-  try {
-    validateSelection(selection, registry, {
-      posture: "release",
-      sha: plan.source.sha,
-      tree: plan.source.tree,
-      candidateDigest: plan.candidate_digest,
-      correlationNonce: plan.correlation_nonce,
-      runID: plan.selection_ref.run.id,
-      runAttempt: plan.selection_ref.run.attempt,
-    });
-  } catch (cause) {
-    if (cause instanceof ContractError) {
-      problems.push(...cause.problems.map((problem) => `selection: ${problem}`));
-    } else {
-      throw cause;
+  const expectedRoster = releaseLaneRoster(registry);
+  if (!Array.isArray(plan.lanes)) problems.push("plan.lanes must be an array");
+  else {
+    for (let index = 0; index < plan.lanes.length; index += 1) {
+      const lane = plan.lanes[index];
+      const label = `plan.lanes[${index}]`;
+      if (!exactKeys(lane, PLAN_LANE_KEYS, label, problems)) continue;
+      string(lane.lane_id, `${label}.lane_id`, problems);
+      string(lane.execution_id, `${label}.execution_id`, problems);
+      if (!exactKeys(lane.producer, new Set(["workflow", "job"]), `${label}.producer`, problems)) continue;
+      string(lane.producer.workflow, `${label}.producer.workflow`, problems);
+      string(lane.producer.job, `${label}.producer.job`, problems);
+    }
+    if (canonicalJSON(plan.lanes) !== canonicalJSON(expectedRoster)) {
+      problems.push("plan.lanes does not exactly equal the registry-derived finite release roster");
     }
   }
-  if (
-    plan.selection_ref.manifest_sha256 !== selectionManifestSHA256(selection)
-  ) {
-    problems.push("plan selection manifest SHA-256 does not match the selection");
-  }
-  if (
-    plan.selection_ref.run.id !== selection.run?.id ||
-    plan.selection_ref.run.attempt !== selection.run?.attempt
-  ) {
-    problems.push("plan selection run does not match the selection");
-  }
-
-  let expectedRoster;
-  try {
-    expectedRoster = releaseLaneRoster(registry);
-  } catch (cause) {
-    if (cause instanceof QualificationError) problems.push(...cause.problems);
-    else throw cause;
-  }
-  if (!Array.isArray(plan.invocations)) {
-    problems.push("plan.invocations must be an array");
-  } else {
-    for (let index = 0; index < plan.invocations.length; index += 1) {
-      const invocation = plan.invocations[index];
-      const label = `plan.invocations[${index}]`;
-      if (!exactKeys(invocation, PLAN_INVOCATION_KEYS, label, problems)) continue;
-      string(invocation.lane_id, `${label}.lane_id`, problems);
-      string(invocation.execution_id, `${label}.execution_id`, problems);
-      string(invocation.invocation_mode, `${label}.invocation_mode`, problems);
-      string(invocation.determinism, `${label}.determinism`, problems);
-      if (
-        exactKeys(
-          invocation.producer,
-          PLAN_PRODUCER_KEYS,
-          `${label}.producer`,
-          problems,
-        )
-      ) {
-        string(
-          invocation.producer.workflow,
-          `${label}.producer.workflow`,
-          problems,
-        );
-        string(invocation.producer.job, `${label}.producer.job`, problems);
-      }
-    }
-    if (
-      expectedRoster &&
-      canonicalJSON(plan.invocations) !== canonicalJSON(expectedRoster)
-    ) {
-      problems.push(
-        "plan.invocations does not equal the registry-derived finite release roster",
-      );
-    }
-    if (
-      canonicalJSON(plan.invocations) !==
-      canonicalJSON(selectedInvocationRoster(selection, registry))
-    ) {
-      problems.push("plan.invocations does not equal the canonical selection");
-    }
-  }
-
   for (const [label, actual, wanted] of [
     ["source.sha", plan.source?.sha, expected.sha],
     ["source.tree", plan.source?.tree, expected.tree],
     ["candidate_digest", plan.candidate_digest, expected.candidateDigest],
     ["correlation_nonce", plan.correlation_nonce, expected.correlationNonce],
-    [
-      "selection_ref.manifest_sha256",
-      plan.selection_ref?.manifest_sha256,
-      expected.selectionManifestSHA256,
-    ],
-    ["repository", plan.repository, expected.repository],
   ]) {
-    if (wanted !== undefined && actual !== wanted) {
-      problems.push(`plan.${label} is ${actual}, want ${wanted}`);
-    }
-  }
-  if (
-    expected.eventIdentity !== undefined &&
-    canonicalJSON(plan.event) !== canonicalJSON(expected.eventIdentity)
-  ) {
-    problems.push("plan.event does not match the trusted expected event");
+    if (wanted !== undefined && actual !== wanted) problems.push(`plan.${label} is ${actual}, want ${wanted}`);
   }
   if (problems.length > 0) throw new QualificationError(problems);
   return plan;
 }
 
-function qualificationExpected(plan) {
-  return {
-    posture: "release",
-    sha: plan.source.sha,
-    tree: plan.source.tree,
-    candidateDigest: plan.candidate_digest,
-    correlationNonce: plan.correlation_nonce,
-    runID: plan.selection_ref.run.id,
-    runAttempt: plan.selection_ref.run.attempt,
-    selectionManifestSHA256: plan.selection_ref.manifest_sha256,
-    eventIdentity: plan.event,
-    repository: plan.repository,
-    baseSHA: undefined,
-    changedPaths: undefined,
-  };
-}
-
-function attestedLanes(reports, producerManifest, registry) {
-  const lanes = new Map(registry.lanes.map((lane) => [lane.id, lane]));
-  const producers = new Map(
-    producerManifest.producers.map((producer) => [producer.workflow, producer]),
-  );
-  return reports
-    .map((report) => {
-      const lane = lanes.get(report.lane_id);
-      const trusted = producers.get(report.producer.workflow);
-      const context = trusted.jobs.find((job) => {
-        if (job.job !== report.producer.job) return false;
-        return lane.context.match === "exact"
-          ? job.name === lane.context.name
-          : job.name.startsWith(lane.context.name);
-      });
-      return {
-        identity: `${report.lane_id}/${report.execution_id}/${report.invocation.mode}`,
-        producer: {
-          workflow: report.producer.workflow,
-          job: report.producer.job,
-          run: { ...report.producer.run },
-          job_name: context.name,
-          job_database_id: context.database_id,
-        },
-        report_artifact: { ...report.producer.artifact },
-        evidence: { ...report.evidence },
-      };
-    })
-    .sort((left, right) => left.identity.localeCompare(right.identity));
-}
-
-export function evaluateQualification({
-  registry,
-  plan,
-  selection,
-  reports,
-  producerManifest,
-  candidateManifest,
-  nowMs,
-}) {
-  validatePlan(plan, registry, selection);
-  const problems = [];
-  integer(nowMs, "qualification.now_ms", problems, 1);
-  if (nowMs < plan.started_at_ms) {
-    problems.push("qualification completed before it started");
+function validateIndex(index, problems) {
+  if (!exactKeys(index, INDEX_KEYS, "evidence_index", problems)) return;
+  if (index.schema_version !== EVIDENCE_INDEX_SCHEMA_VERSION) {
+    problems.push(`evidence_index.schema_version must be ${EVIDENCE_INDEX_SCHEMA_VERSION}`);
   }
+  validateSource(index.source, "evidence_index.source", problems);
+  string(index.candidate_digest, "evidence_index.candidate_digest", problems, DIGEST_RE);
+  string(index.correlation_nonce, "evidence_index.correlation_nonce", problems, NONCE_RE);
+  if (!Array.isArray(index.records)) problems.push("evidence_index.records must be an array");
+}
+
+function validateRecord(record, lane, label, problems) {
+  if (!exactKeys(record, RECORD_KEYS, label, problems)) return;
+  string(record.lane_id, `${label}.lane_id`, problems);
+  string(record.execution_id, `${label}.execution_id`, problems);
+  validateSource(record.source, `${label}.source`, problems);
+  if (record.candidate_digest !== null) string(record.candidate_digest, `${label}.candidate_digest`, problems, DIGEST_RE);
+  if (exactKeys(record.producer, PRODUCER_KEYS, `${label}.producer`, problems)) {
+    string(record.producer.workflow, `${label}.producer.workflow`, problems);
+    string(record.producer.job, `${label}.producer.job`, problems);
+    string(record.producer.run_id, `${label}.producer.run_id`, problems, RUN_ID_RE);
+    integer(record.producer.run_attempt, `${label}.producer.run_attempt`, problems, 1);
+  }
+  string(record.invocation_mode, `${label}.invocation_mode`, problems);
+  string(record.conclusion, `${label}.conclusion`, problems);
+  if (exactKeys(record.evidence, EVIDENCE_KEYS, `${label}.evidence`, problems)) {
+    for (const key of ["executed", "passed", "failed", "skipped", "duration_ms"]) {
+      integer(record.evidence[key], `${label}.evidence.${key}`, problems);
+    }
+    if (record.evidence.seed !== null) string(record.evidence.seed, `${label}.evidence.seed`, problems);
+    string(record.evidence.corpus_id, `${label}.evidence.corpus_id`, problems);
+  }
+  if (exactKeys(record.trust, TRUST_KEYS, `${label}.trust`, problems)) {
+    string(record.trust.artifact_id, `${label}.trust.artifact_id`, problems, RUN_ID_RE);
+    string(record.trust.artifact_digest, `${label}.trust.artifact_digest`, problems, DIGEST_RE);
+    string(record.trust.head_sha, `${label}.trust.head_sha`, problems, SHA_RE);
+    string(record.trust.head_tree, `${label}.trust.head_tree`, problems, SHA_RE);
+    string(record.trust.run_id, `${label}.trust.run_id`, problems, RUN_ID_RE);
+    integer(record.trust.run_attempt, `${label}.trust.run_attempt`, problems, 1);
+    string(record.trust.job_conclusion, `${label}.trust.job_conclusion`, problems);
+    integer(record.trust.completed_at_ms, `${label}.trust.completed_at_ms`, problems, 1);
+  }
+  if (lane) {
+    if (record.producer?.workflow !== lane.producer.workflow || record.producer?.job !== lane.producer.job) {
+      problems.push(`${label}: producer does not match the registry owner`);
+    }
+    if (record.invocation_mode !== lane.invocation_mode) {
+      problems.push(`${label}: invocation_mode ${record.invocation_mode} must be ${lane.invocation_mode}`);
+    }
+    if (lane.determinism === "deterministic" && record.evidence?.seed !== null) {
+      problems.push(`${label}: deterministic evidence must carry seed=null`);
+    }
+    if (lane.determinism === "seeded" && (record.evidence?.seed ?? null) === null) {
+      problems.push(`${label}: seeded evidence must carry its seed`);
+    }
+  }
+}
+
+export function evaluateQualification({ registry, plan, evidenceIndex, candidateManifest, nowMs }) {
+  validatePlan(plan, registry);
+  const problems = [];
+  validateIndex(evidenceIndex, problems);
+  integer(nowMs, "qualification.now_ms", problems, 1);
   if (nowMs > plan.deadline_at_ms) {
     problems.push(
       `qualification timed out at ${nowMs}; deadline was ${plan.deadline_at_ms} ` +
         `(${RELEASE_QUALIFICATION_LIMIT_MINUTES} minutes)`,
     );
   }
-  if (!Array.isArray(reports)) {
-    problems.push("release reports must be a JSON array");
+  if (evidenceIndex.source?.sha !== plan.source.sha || evidenceIndex.source?.tree !== plan.source.tree) {
+    problems.push("evidence index source SHA/tree does not match the plan");
   }
-  if (!isObject(producerManifest)) {
-    problems.push("trusted producer manifest must be an object");
+  if (evidenceIndex.candidate_digest !== plan.candidate_digest) {
+    problems.push("evidence index candidate digest does not match the plan");
+  }
+  if (evidenceIndex.correlation_nonce !== plan.correlation_nonce) {
+    problems.push("evidence index correlation nonce does not match the plan");
+  }
+
+  const expected = new Map(plan.lanes.map((lane) => [identity(lane), lane]));
+  const actual = new Map();
+  if (Array.isArray(evidenceIndex.records)) {
+    for (let index = 0; index < evidenceIndex.records.length; index += 1) {
+      const record = evidenceIndex.records[index];
+      const id = identity(record);
+      const label = `evidence_index.records[${index}] (${id})`;
+      if (actual.has(id)) {
+        problems.push(`duplicate evidence record ${id}`);
+        continue;
+      }
+      actual.set(id, record);
+      const lane = expected.get(id);
+      if (!lane) {
+        problems.push(`unexpected evidence record ${id}`);
+        continue;
+      }
+      validateRecord(record, lane, label, problems);
+      if (record.source?.sha !== plan.source.sha || record.source?.tree !== plan.source.tree) {
+        problems.push(`${id}: report source SHA/tree does not match the plan`);
+      }
+      const expectedDigest = lane.invocation_mode === "candidate_artifact" ? plan.candidate_digest : null;
+      if (record.candidate_digest !== expectedDigest) {
+        problems.push(`${id}: candidate digest does not match invocation mode and plan`);
+      }
+      if (record.conclusion !== SUCCESS) problems.push(`${id}: report conclusion ${record.conclusion} is not success`);
+      if (record.trust?.job_conclusion !== SUCCESS) {
+        problems.push(`${id}: trusted job conclusion ${record.trust?.job_conclusion} is not success`);
+      }
+      if (
+        record.producer?.run_id !== record.trust?.run_id ||
+        record.producer?.run_attempt !== record.trust?.run_attempt
+      ) {
+        problems.push(`${id}: report run identity does not match trusted workflow provenance`);
+      }
+      if (record.trust?.head_sha !== plan.source.sha || record.trust?.head_tree !== plan.source.tree) {
+        problems.push(`${id}: trusted workflow source SHA/tree does not match the plan`);
+      }
+      if (record.trust?.completed_at_ms < plan.started_at_ms) {
+        problems.push(`${id}: trusted job completed before qualification started`);
+      }
+      if (record.trust?.completed_at_ms > plan.deadline_at_ms) {
+        problems.push(`${id}: trusted job completed after the qualification deadline`);
+      }
+      const evidence = record.evidence ?? {};
+      if (evidence.executed <= 0) problems.push(`${id}: zero native checks/tests executed`);
+      if (
+        evidence.executed !== evidence.passed + evidence.failed + evidence.skipped ||
+        evidence.failed !== 0 ||
+        evidence.skipped !== 0 ||
+        evidence.passed !== evidence.executed
+      ) {
+        problems.push(`${id}: native evidence is not all-executed and all-passed`);
+      }
+    }
+  }
+  for (const id of expected.keys()) {
+    if (!actual.has(id)) problems.push(`missing evidence record ${id}`);
+  }
+  if (!actual.has(`${QUICKSTART_LANE_ID}/default/source_tree`)) {
+    problems.push(`quickstart proof ${QUICKSTART_LANE_ID}/default/source_tree is absent`);
   }
   if (problems.length > 0) throw new QualificationError(problems);
 
-  let result;
-  try {
-    result = validateReportSet({
-      registry,
-      selection,
-      reports,
-      producerManifest,
-      expected: qualificationExpected(plan),
-    });
-  } catch (cause) {
-    if (cause instanceof ContractError) {
-      throw new QualificationError(cause.problems);
-    }
-    throw cause;
-  }
-  if (
-    result.expected !== RELEASE_QUALIFICATION_INVOCATIONS ||
-    result.received !== RELEASE_QUALIFICATION_INVOCATIONS
-  ) {
-    throw new QualificationError([
-      `canonical report validation must receive exactly ${RELEASE_QUALIFICATION_INVOCATIONS} ` +
-        `invocations; expected ${result.expected}, received ${result.received}`,
-    ]);
-  }
-
-  const lanes = attestedLanes(reports, producerManifest, registry);
-  if (!lanes.some((lane) => lane.identity === QUICKSTART_IDENTITY)) {
-    throw new QualificationError([
-      `required quickstart proof ${QUICKSTART_IDENTITY} is absent`,
-    ]);
-  }
+  const lanes = [...actual.entries()].sort(([left], [right]) => left.localeCompare(right)).map(([id, record]) => ({
+    identity: id,
+    producer: record.producer,
+    report_artifact: {
+      id: record.trust.artifact_id,
+      digest: record.trust.artifact_digest,
+    },
+    evidence: record.evidence,
+  }));
   return {
     schema_version: ATTESTATION_SCHEMA_VERSION,
     result: SUCCESS,
-    source: { ...plan.source },
+    source: plan.source,
     candidate: {
       digest: plan.candidate_digest,
       image_digest: candidateManifest.image.digest,
-      files: candidateManifest.files.map((file) => ({
-        path: file.path,
-        sha256: file.sha256,
-        size: file.size,
-      })),
+      files: candidateManifest.files.map((file) => ({ path: file.path, sha256: file.sha256, size: file.size })),
     },
     qualification: {
       started_at_ms: plan.started_at_ms,
@@ -764,39 +479,9 @@ export function evaluateQualification({
       deadline_at_ms: plan.deadline_at_ms,
       limit_minutes: RELEASE_QUALIFICATION_LIMIT_MINUTES,
       correlation_nonce: plan.correlation_nonce,
-      selection_ref: structuredClone(plan.selection_ref),
-      event: { ...plan.event },
-      repository: plan.repository,
-      invocation_count: RELEASE_QUALIFICATION_INVOCATIONS,
     },
     lanes,
   };
-}
-
-function validateEvidence(evidence, label, planned, problems) {
-  if (!exactKeys(evidence, EVIDENCE_KEYS, label, problems)) return;
-  for (const key of ["executed", "passed", "failed", "skipped", "duration_ms"]) {
-    integer(evidence[key], `${label}.${key}`, problems);
-  }
-  if (evidence.seed !== null) {
-    string(evidence.seed, `${label}.seed`, problems);
-  }
-  string(evidence.corpus_id, `${label}.corpus_id`, problems);
-  if (
-    evidence.executed <= 0 ||
-    evidence.executed !== evidence.passed + evidence.failed + evidence.skipped ||
-    evidence.failed !== 0 ||
-    evidence.skipped !== 0 ||
-    evidence.passed !== evidence.executed
-  ) {
-    problems.push(`${label} is not a positive all-passed native result`);
-  }
-  if (planned?.determinism === "deterministic" && evidence.seed !== null) {
-    problems.push(`${label} deterministic lane must carry seed=null`);
-  }
-  if (planned?.determinism === "seeded" && evidence.seed === null) {
-    problems.push(`${label} seeded lane omitted its seed`);
-  }
 }
 
 export function validateAttestation(attestation, expected = {}, registry = null) {
@@ -805,38 +490,14 @@ export function validateAttestation(attestation, expected = {}, registry = null)
     throw new QualificationError(problems);
   }
   if (attestation.schema_version !== ATTESTATION_SCHEMA_VERSION) {
-    problems.push(
-      `attestation.schema_version must be ${ATTESTATION_SCHEMA_VERSION}`,
-    );
+    problems.push(`attestation.schema_version must be ${ATTESTATION_SCHEMA_VERSION}`);
   }
-  if (attestation.result !== SUCCESS) {
-    problems.push("attestation.result must be success");
-  }
+  if (attestation.result !== SUCCESS) problems.push("attestation.result must be success");
   validateSource(attestation.source, "attestation.source", problems);
-  if (
-    exactKeys(
-      attestation.candidate,
-      ATTESTATION_CANDIDATE_KEYS,
-      "attestation.candidate",
-      problems,
-    )
-  ) {
-    string(
-      attestation.candidate.digest,
-      "attestation.candidate.digest",
-      problems,
-      DIGEST_RE,
-    );
-    string(
-      attestation.candidate.image_digest,
-      "attestation.candidate.image_digest",
-      problems,
-      DIGEST_RE,
-    );
-    if (
-      !Array.isArray(attestation.candidate.files) ||
-      attestation.candidate.files.length === 0
-    ) {
+  if (exactKeys(attestation.candidate, ATTESTATION_CANDIDATE_KEYS, "attestation.candidate", problems)) {
+    string(attestation.candidate.digest, "attestation.candidate.digest", problems, DIGEST_RE);
+    string(attestation.candidate.image_digest, "attestation.candidate.image_digest", problems, DIGEST_RE);
+    if (!Array.isArray(attestation.candidate.files) || attestation.candidate.files.length === 0) {
       problems.push("attestation.candidate.files must be non-empty");
     } else {
       let previous = "";
@@ -857,248 +518,107 @@ export function validateAttestation(attestation, expected = {}, registry = null)
       }
     }
   }
-
-  if (
-    exactKeys(
-      attestation.qualification,
-      ATTESTATION_QUALIFICATION_KEYS,
-      "attestation.qualification",
-      problems,
-    )
-  ) {
+  if (exactKeys(attestation.qualification, ATTESTATION_QUALIFICATION_KEYS, "attestation.qualification", problems)) {
     for (const key of ["started_at_ms", "completed_at_ms", "deadline_at_ms"]) {
-      integer(
-        attestation.qualification[key],
-        `attestation.qualification.${key}`,
-        problems,
-        1,
-      );
+      integer(attestation.qualification[key], `attestation.qualification.${key}`, problems, 1);
     }
-    integer(
-      attestation.qualification.limit_minutes,
-      "attestation.qualification.limit_minutes",
-      problems,
-      1,
-    );
+    integer(attestation.qualification.limit_minutes, "attestation.qualification.limit_minutes", problems, 1);
     string(
       attestation.qualification.correlation_nonce,
       "attestation.qualification.correlation_nonce",
       problems,
       NONCE_RE,
     );
-    validateSelectionRef(
-      attestation.qualification.selection_ref,
-      "attestation.qualification.selection_ref",
-      problems,
-    );
-    validateEvent(
-      attestation.qualification.event,
-      attestation.source,
-      "attestation.qualification.event",
-      problems,
-    );
-    string(
-      attestation.qualification.repository,
-      "attestation.qualification.repository",
-      problems,
-      REPOSITORY_RE,
-    );
     if (
-      attestation.qualification.invocation_count !==
-      RELEASE_QUALIFICATION_INVOCATIONS
+      Number.isSafeInteger(attestation.qualification.started_at_ms) &&
+      Number.isSafeInteger(attestation.qualification.deadline_at_ms) &&
+      attestation.qualification.deadline_at_ms - attestation.qualification.started_at_ms !==
+        RELEASE_QUALIFICATION_LIMIT_MS
     ) {
-      problems.push(
-        `attestation.qualification.invocation_count must be ${RELEASE_QUALIFICATION_INVOCATIONS}`,
-      );
+      problems.push("attestation qualification deadline does not equal the hard release limit");
     }
     if (
-      attestation.qualification.deadline_at_ms -
-        attestation.qualification.started_at_ms !==
-      RELEASE_QUALIFICATION_LIMIT_MS
+      attestation.qualification.completed_at_ms < attestation.qualification.started_at_ms ||
+      attestation.qualification.completed_at_ms > attestation.qualification.deadline_at_ms
     ) {
-      problems.push(
-        "attestation qualification deadline does not equal the hard release limit",
-      );
-    }
-    if (
-      attestation.qualification.completed_at_ms <
-        attestation.qualification.started_at_ms ||
-      attestation.qualification.completed_at_ms >
-        attestation.qualification.deadline_at_ms
-    ) {
-      problems.push(
-        "attestation completion is outside its qualification window",
-      );
+      problems.push("attestation completion is outside its qualification window");
     }
   }
-
-  let expectedLanes = null;
-  if (registry) {
-    try {
-      expectedLanes = new Map(
-        releaseLaneRoster(registry).map((lane) => [identity(lane), lane]),
-      );
-    } catch (cause) {
-      if (cause instanceof QualificationError) problems.push(...cause.problems);
-      else throw cause;
-    }
-  }
+  const expectedLanes = registry
+    ? new Map(releaseLaneRoster(registry).map((lane) => [identity(lane), lane]))
+    : null;
   const actualLanes = new Map();
-  if (!Array.isArray(attestation.lanes)) {
-    problems.push("attestation.lanes must be an array");
+  if (!Array.isArray(attestation.lanes) || attestation.lanes.length === 0) {
+    problems.push("attestation.lanes must be non-empty");
   } else {
-    if (attestation.lanes.length !== RELEASE_QUALIFICATION_INVOCATIONS) {
-      problems.push(
-        `attestation.lanes must contain exactly ${RELEASE_QUALIFICATION_INVOCATIONS} identities`,
-      );
-    }
     let previous = "";
     for (let index = 0; index < attestation.lanes.length; index += 1) {
       const lane = attestation.lanes[index];
       const label = `attestation.lanes[${index}]`;
       if (!exactKeys(lane, ATTESTATION_LANE_KEYS, label, problems)) continue;
       string(lane.identity, `${label}.identity`, problems);
-      if (actualLanes.has(lane.identity)) {
-        problems.push(`${label}.identity is duplicated`);
-      }
+      if (actualLanes.has(lane.identity)) problems.push(`${label}.identity is duplicated`);
       if (previous !== "" && String(lane.identity).localeCompare(previous) <= 0) {
         problems.push(`${label}.identity is not strictly sorted`);
       }
       actualLanes.set(lane.identity, lane);
       previous = lane.identity;
-      const planned = expectedLanes?.get(lane.identity);
-      if (expectedLanes && !planned) {
-        problems.push(`${label}.identity is not in the finite release roster`);
-      }
-      if (
-        exactKeys(
-          lane.producer,
-          ATTESTATION_PRODUCER_KEYS,
-          `${label}.producer`,
-          problems,
-        )
-      ) {
-        string(
-          lane.producer.workflow,
-          `${label}.producer.workflow`,
-          problems,
-        );
+      if (exactKeys(lane.producer, PRODUCER_KEYS, `${label}.producer`, problems)) {
+        string(lane.producer.workflow, `${label}.producer.workflow`, problems);
         string(lane.producer.job, `${label}.producer.job`, problems);
-        validateRun(lane.producer.run, `${label}.producer.run`, problems);
-        string(lane.producer.job_name, `${label}.producer.job_name`, problems);
-        string(
-          lane.producer.job_database_id,
-          `${label}.producer.job_database_id`,
-          problems,
-          RUN_ID_RE,
-        );
+        string(lane.producer.run_id, `${label}.producer.run_id`, problems, RUN_ID_RE);
+        integer(lane.producer.run_attempt, `${label}.producer.run_attempt`, problems, 1);
+      }
+      if (exactKeys(lane.report_artifact, ATTESTATION_ARTIFACT_KEYS, `${label}.report_artifact`, problems)) {
+        string(lane.report_artifact.id, `${label}.report_artifact.id`, problems, RUN_ID_RE);
+        string(lane.report_artifact.digest, `${label}.report_artifact.digest`, problems, DIGEST_RE);
+      }
+      if (exactKeys(lane.evidence, EVIDENCE_KEYS, `${label}.evidence`, problems)) {
+        for (const key of ["executed", "passed", "failed", "skipped", "duration_ms"]) {
+          integer(lane.evidence[key], `${label}.evidence.${key}`, problems);
+        }
+        if (lane.evidence.seed !== null) string(lane.evidence.seed, `${label}.evidence.seed`, problems);
+        string(lane.evidence.corpus_id, `${label}.evidence.corpus_id`, problems);
         if (
-          planned &&
-          (lane.producer.workflow !== planned.producer.workflow ||
-            lane.producer.job !== planned.producer.job)
+          lane.evidence.executed <= 0 ||
+          lane.evidence.executed !== lane.evidence.passed + lane.evidence.failed + lane.evidence.skipped ||
+          lane.evidence.failed !== 0 ||
+          lane.evidence.skipped !== 0 ||
+          lane.evidence.passed !== lane.evidence.executed
         ) {
-          problems.push(`${label}.producer does not match the registry owner`);
+          problems.push(`${label}.evidence is not a positive all-passed native result`);
         }
       }
-      if (
-        exactKeys(
-          lane.report_artifact,
-          ATTESTATION_ARTIFACT_KEYS,
-          `${label}.report_artifact`,
-          problems,
-        )
-      ) {
-        string(
-          lane.report_artifact.id,
-          `${label}.report_artifact.id`,
-          problems,
-          RUN_ID_RE,
-        );
-        string(
-          lane.report_artifact.name,
-          `${label}.report_artifact.name`,
-          problems,
-        );
-        string(
-          lane.report_artifact.sha256,
-          `${label}.report_artifact.sha256`,
-          problems,
-          SHA256_RE,
-        );
-        string(
-          lane.report_artifact.entry,
-          `${label}.report_artifact.entry`,
-          problems,
-        );
-        string(
-          lane.report_artifact.entry_sha256,
-          `${label}.report_artifact.entry_sha256`,
-          problems,
-          SHA256_RE,
-        );
-        if (lane.report_artifact.entry !== lane.identity) {
-          problems.push(`${label}.report_artifact.entry must equal its identity`);
-        }
+      const planned = expectedLanes?.get(lane.identity);
+      if (expectedLanes && !planned) problems.push(`${label}.identity is not in the registry-derived release roster`);
+      if (planned?.determinism === "deterministic" && lane.evidence?.seed !== null) {
+        problems.push(`${label}.evidence deterministic lane must carry seed=null`);
       }
-      validateEvidence(lane.evidence, `${label}.evidence`, planned, problems);
+      if (planned?.determinism === "seeded" && (lane.evidence?.seed ?? null) === null) {
+        problems.push(`${label}.evidence seeded lane omitted its seed`);
+      }
     }
   }
   if (expectedLanes) {
-    for (const expectedIdentity of expectedLanes.keys()) {
-      if (!actualLanes.has(expectedIdentity)) {
-        problems.push(`attestation is missing release lane ${expectedIdentity}`);
-      }
+    for (const id of expectedLanes.keys()) {
+      if (!actualLanes.has(id)) problems.push(`attestation is missing release lane ${id}`);
     }
   }
-  if (!actualLanes.has(QUICKSTART_IDENTITY)) {
-    problems.push(
-      `attestation does not contain required quickstart proof ${QUICKSTART_IDENTITY}`,
-    );
+  if (!actualLanes.has(`${QUICKSTART_LANE_ID}/default/source_tree`)) {
+    problems.push("attestation does not contain the required quickstart proof");
   }
-  if (
-    attestation.qualification?.limit_minutes !==
-    RELEASE_QUALIFICATION_LIMIT_MINUTES
-  ) {
-    problems.push(
-      `attestation qualification limit must be ${RELEASE_QUALIFICATION_LIMIT_MINUTES} minutes`,
-    );
+  if (attestation.qualification?.limit_minutes !== RELEASE_QUALIFICATION_LIMIT_MINUTES) {
+    problems.push(`attestation qualification limit must be ${RELEASE_QUALIFICATION_LIMIT_MINUTES} minutes`);
   }
-
   for (const [label, actual, wanted] of [
     ["source.sha", attestation.source?.sha, expected.sha],
     ["source.tree", attestation.source?.tree, expected.tree],
     ["candidate.digest", attestation.candidate?.digest, expected.candidateDigest],
-    [
-      "candidate.image_digest",
-      attestation.candidate?.image_digest,
-      expected.imageDigest,
-    ],
-    [
-      "qualification.correlation_nonce",
-      attestation.qualification?.correlation_nonce,
-      expected.correlationNonce,
-    ],
-    [
-      "qualification.selection_ref.manifest_sha256",
-      attestation.qualification?.selection_ref?.manifest_sha256,
-      expected.selectionManifestSHA256,
-    ],
-    [
-      "qualification.repository",
-      attestation.qualification?.repository,
-      expected.repository,
-    ],
+    ["qualification.correlation_nonce", attestation.qualification?.correlation_nonce, expected.correlationNonce],
   ]) {
     if (wanted !== undefined && actual !== wanted) {
       problems.push(`attestation.${label} is ${actual}, want ${wanted}`);
     }
-  }
-  if (
-    expected.eventIdentity !== undefined &&
-    canonicalJSON(attestation.qualification?.event) !==
-      canonicalJSON(expected.eventIdentity)
-  ) {
-    problems.push("attestation qualification event does not match expected event");
   }
   if (problems.length > 0) throw new QualificationError(problems);
   return attestation;
@@ -1117,17 +637,14 @@ function environmentIdentity() {
 }
 
 function verifiedCandidate(expected) {
-  return verifyCandidate(
-    resolve(process.env.RELEASE_CANDIDATE_DIR || "build/release-candidate"),
-    {
-      sha: expected.sha,
-      tree: expected.tree,
-      app: expected.app,
-      appTag: expected.appTag,
-      chart: expected.chart,
-      digest: expected.candidateDigest,
-    },
-  );
+  return verifyCandidate(resolve(process.env.RELEASE_CANDIDATE_DIR || "build/release-candidate"), {
+    sha: expected.sha,
+    tree: expected.tree,
+    app: expected.app,
+    appTag: expected.appTag,
+    chart: expected.chart,
+    digest: expected.candidateDigest,
+  });
 }
 
 export function verifyAttestationBundle({
@@ -1163,16 +680,15 @@ export function verifyAttestationBundle({
   }
   const attestation = validateAttestation(
     readJSON(path, "release qualification attestation"),
-    {
-      ...expected,
-      imageDigest: candidate.manifest.image.digest,
-    },
+    expected,
     registry,
   );
-  if (
-    canonicalJSON(attestation.candidate.files) !==
-    canonicalJSON(candidate.manifest.files)
-  ) {
+  if (attestation.candidate.image_digest !== candidate.manifest.image.digest) {
+    throw new QualificationError([
+      "attestation image digest does not match the verified candidate",
+    ]);
+  }
+  if (canonicalJSON(attestation.candidate.files) !== canonicalJSON(candidate.manifest.files)) {
     throw new QualificationError([
       "attestation artifact digests do not match the verified candidate manifest",
     ]);
@@ -1198,54 +714,21 @@ function planMode() {
   const expected = environmentIdentity();
   verifiedCandidate(expected);
   const registry = loadRegistry();
-  const eventKind = requiredEnv("GITHUB_EVENT_NAME");
-  if (!RELEASE_EVENTS.has(eventKind)) {
-    throw new QualificationError([
-      `GITHUB_EVENT_NAME must be push or workflow_dispatch; got ${JSON.stringify(eventKind)}`,
-    ]);
-  }
-  const run = {
-    id: requiredEnv("GITHUB_RUN_ID", RUN_ID_RE),
-    attempt: positiveIntegerEnv("GITHUB_RUN_ATTEMPT"),
-  };
-  const selection = createReleaseSelection({
+  const startedAtMs = positiveMillis("RELEASE_QUALIFICATION_START");
+  const plan = createPlan({
     registry,
     source: { sha: expected.sha, tree: expected.tree },
     candidateDigest: expected.candidateDigest,
     correlationNonce: expected.correlationNonce,
-    run,
+    startedAtMs,
   });
-  const eventIdentity = {
-    kind: eventKind,
-    pr_number: null,
-    event_head_sha: expected.sha,
-    event_base_sha: null,
-    projected_sha: expected.sha,
-  };
-  const plan = createPlan({
-    registry,
-    selection,
-    eventIdentity,
-    repository: requiredEnv("GITHUB_REPOSITORY", REPOSITORY_RE),
-    startedAtMs: positiveMillis("RELEASE_QUALIFICATION_START"),
-  });
-  const selectionPath = resolve(
-    process.env.RELEASE_QUALIFICATION_SELECTION ||
-      "build/release-qualification-selection.json",
-  );
-  const planPath = resolve(
-    process.env.RELEASE_QUALIFICATION_PLAN ||
-      "build/release-qualification-plan.json",
-  );
-  writeSelection(selectionPath, selection);
-  writeCanonical(planPath, plan);
-  setOutput("selection", selectionPath);
-  setOutput("selection_digest", plan.selection_ref.manifest_sha256);
-  setOutput("plan", planPath);
-  setOutput("lane_count", String(plan.invocations.length));
+  const path = resolve(process.env.RELEASE_QUALIFICATION_PLAN || "build/release-qualification-plan.json");
+  writeCanonical(path, plan);
+  setOutput("plan", path);
+  setOutput("lane_count", String(plan.lanes.length));
   notice(
-    `planned ${plan.invocations.length} finite release invocations for ` +
-      `${expected.sha.slice(0, 12)} candidate ${expected.candidateDigest}`,
+    `planned ${plan.lanes.length} finite release executions for ${expected.sha.slice(0, 12)} ` +
+      `candidate ${expected.candidateDigest}`,
   );
 }
 
@@ -1253,43 +736,21 @@ function joinMode() {
   const expected = environmentIdentity();
   const candidate = verifiedCandidate(expected);
   const registry = loadRegistry();
-  const selectionPath = resolve(
-    process.env.RELEASE_QUALIFICATION_SELECTION ||
-      "build/release-qualification-selection.json",
-  );
-  const planPath = resolve(
-    process.env.RELEASE_QUALIFICATION_PLAN ||
-      "build/release-qualification-plan.json",
-  );
-  const reportsPath = resolve(requiredEnv("RELEASE_QUALIFICATION_REPORTS"));
-  const producerManifestPath = resolve(
-    requiredEnv("RELEASE_QUALIFICATION_PRODUCER_MANIFEST"),
-  );
-  const selection = readJSON(selectionPath, "release qualification selection");
-  const plan = validatePlan(
-    readJSON(planPath, "release qualification plan"),
-    registry,
-    selection,
-    expected,
-  );
+  const planPath = resolve(process.env.RELEASE_QUALIFICATION_PLAN || "build/release-qualification-plan.json");
+  const evidencePath = resolve(requiredEnv("RELEASE_EVIDENCE_INDEX"));
+  const plan = validatePlan(readJSON(planPath, "release qualification plan"), registry, expected);
   const nowMs = process.env.RELEASE_QUALIFICATION_NOW
     ? positiveMillis("RELEASE_QUALIFICATION_NOW")
     : Date.now();
   const attestation = evaluateQualification({
     registry,
     plan,
-    selection,
-    reports: readJSON(reportsPath, "release qualification reports"),
-    producerManifest: readJSON(
-      producerManifestPath,
-      "release trusted producer manifest",
-    ),
+    evidenceIndex: readJSON(evidencePath, "release evidence index"),
     candidateManifest: candidate.manifest,
     nowMs,
   });
   const attestationPath = resolve(
-    process.env.RELEASE_ATTESTATION ||
-      "build/release-qualification-attestation.json",
+    process.env.RELEASE_ATTESTATION || "build/release-qualification-attestation.json",
   );
   writeCanonical(attestationPath, attestation);
   const digest = sha256File(attestationPath);
@@ -1297,7 +758,7 @@ function joinMode() {
   setOutput("attestation", attestationPath);
   setOutput("attestation_digest", digest);
   notice(
-    `release qualification passed ${attestation.lanes.length} invocations in ` +
+    `release qualification passed ${attestation.lanes.length} executions in ` +
       `${attestation.qualification.completed_at_ms - attestation.qualification.started_at_ms} ms; ` +
       `attestation ${digest}`,
   );
@@ -1321,8 +782,7 @@ function main() {
   }
 }
 
-const invokedDirectly =
-  process.argv[1] && fileURLToPath(import.meta.url) === resolve(process.argv[1]);
+const invokedDirectly = process.argv[1] && fileURLToPath(import.meta.url) === resolve(process.argv[1]);
 if (invokedDirectly) {
   try {
     main();

--- a/.github/scripts/release-qualification.mjs
+++ b/.github/scripts/release-qualification.mjs
@@ -1,0 +1,1333 @@
+// release-qualification.mjs — create and join the finite pre-publication test
+// fence for one immutable release candidate.
+//
+// Modes (MODE or argv[2]):
+//   plan               write the canonical release selection and a closed plan
+//                      that pins its digest and trusted coordinator identity.
+//   join               validate canonical native reports against trusted API
+//                      producer provenance and write the signed input attestation.
+//   verify-attestation verify the exact successful attestation before a writer
+//                      can promote any part of the candidate.
+//
+// Environment:
+//   RELEASE_CANDIDATE_DIR       sealed candidate root.
+//   RELEASE_CANDIDATE_DIGEST    exact sha256:<hex> candidate digest.
+//   RELEASE_SOURCE_SHA          exact 40-hex source commit.
+//   RELEASE_SOURCE_TREE         exact 40-hex Git tree.
+//   RELEASE_APP_VERSION         exact application version.
+//   RELEASE_APP_TAG             exact application tag.
+//   RELEASE_CHART_VERSION       exact chart version.
+//   RELEASE_QUALIFICATION_START epoch milliseconds set before candidate build.
+//   RELEASE_CORRELATION_NONCE   64 lowercase hex, fresh for this qualification.
+//   RELEASE_QUALIFICATION_PLAN  plan path
+//                              (default build/release-qualification-plan.json).
+//   RELEASE_QUALIFICATION_SELECTION canonical selection path
+//                              (default build/release-qualification-selection.json).
+//   RELEASE_QUALIFICATION_REPORTS JSON array of canonical native reports
+//                              (join only).
+//   RELEASE_QUALIFICATION_PRODUCER_MANIFEST trusted API producer manifest
+//                              (join only).
+//   RELEASE_ATTESTATION         attestation path
+//                              (default build/release-qualification-attestation.json).
+//   RELEASE_ATTESTATION_DIGEST  expected attestation digest (verify only).
+//   RELEASE_QUALIFICATION_NOW   epoch milliseconds override for deterministic
+//                              fault tests; Actions leaves it unset.
+//   GITHUB_EVENT_NAME           push or workflow_dispatch (plan only).
+//   GITHUB_REPOSITORY           trusted repository identity (plan only).
+//   GITHUB_RUN_ID               coordinator run ID (plan only).
+//   GITHUB_RUN_ATTEMPT          coordinator run attempt (plan only).
+//   GITHUB_OUTPUT               receives plan/selection/attestation outputs.
+//
+// Cross-workflow discovery stays outside this module. The adapter supplies
+// native report documents plus API-derived producer provenance; the canonical
+// CI lane contract performs the only report-set qualification.
+
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import { resolve } from "node:path";
+import process from "node:process";
+import { fileURLToPath } from "node:url";
+
+import {
+  ContractError,
+  loadRegistry,
+  selectionManifestSHA256,
+  validateReportSet,
+  validateSelection,
+} from "./ci-lane-contract.mjs";
+import { error, notice, setOutput } from "./lib/gh.mjs";
+import {
+  canonicalJSON,
+  sha256File,
+  verifyCandidate,
+} from "./release-candidate.mjs";
+
+export const QUALIFICATION_SCHEMA_VERSION = 2;
+export const ATTESTATION_SCHEMA_VERSION = 2;
+export const RELEASE_QUALIFICATION_INVOCATIONS = 45;
+export const RELEASE_QUALIFICATION_LIMIT_MINUTES = 120;
+export const RELEASE_QUALIFICATION_LIMIT_MS =
+  RELEASE_QUALIFICATION_LIMIT_MINUTES * 60 * 1000;
+export const QUICKSTART_IDENTITY = "e2e.quickstart/default/source_tree";
+
+const SHA_RE = /^[0-9a-f]{40}$/;
+const DIGEST_RE = /^sha256:[0-9a-f]{64}$/;
+const SHA256_RE = /^[0-9a-f]{64}$/;
+const NONCE_RE = /^[0-9a-f]{64}$/;
+const RUN_ID_RE = /^[1-9][0-9]*$/;
+const REPOSITORY_RE = /^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/;
+const FINITE_DETERMINISM = new Set(["deterministic", "seeded"]);
+const RELEASE_EVENTS = new Set(["push", "workflow_dispatch"]);
+const SUCCESS = "success";
+
+const SOURCE_KEYS = new Set(["sha", "tree"]);
+const RUN_KEYS = new Set(["id", "attempt"]);
+const EVENT_KEYS = new Set([
+  "kind",
+  "pr_number",
+  "event_head_sha",
+  "event_base_sha",
+  "projected_sha",
+]);
+const SELECTION_REF_KEYS = new Set(["run", "manifest_sha256"]);
+const PLAN_KEYS = new Set([
+  "schema_version",
+  "registry_schema_version",
+  "selection_schema_version",
+  "report_schema_version",
+  "source",
+  "candidate_digest",
+  "correlation_nonce",
+  "selection_ref",
+  "event",
+  "repository",
+  "started_at_ms",
+  "deadline_at_ms",
+  "invocations",
+]);
+const PLAN_INVOCATION_KEYS = new Set([
+  "lane_id",
+  "execution_id",
+  "producer",
+  "invocation_mode",
+  "determinism",
+]);
+const PLAN_PRODUCER_KEYS = new Set(["workflow", "job"]);
+const ATTESTATION_KEYS = new Set([
+  "schema_version",
+  "result",
+  "source",
+  "candidate",
+  "qualification",
+  "lanes",
+]);
+const ATTESTATION_CANDIDATE_KEYS = new Set([
+  "digest",
+  "image_digest",
+  "files",
+]);
+const ATTESTATION_FILE_KEYS = new Set(["path", "sha256", "size"]);
+const ATTESTATION_QUALIFICATION_KEYS = new Set([
+  "started_at_ms",
+  "completed_at_ms",
+  "deadline_at_ms",
+  "limit_minutes",
+  "correlation_nonce",
+  "selection_ref",
+  "event",
+  "repository",
+  "invocation_count",
+]);
+const ATTESTATION_LANE_KEYS = new Set([
+  "identity",
+  "producer",
+  "report_artifact",
+  "evidence",
+]);
+const ATTESTATION_PRODUCER_KEYS = new Set([
+  "workflow",
+  "job",
+  "run",
+  "job_name",
+  "job_database_id",
+]);
+const ATTESTATION_ARTIFACT_KEYS = new Set([
+  "id",
+  "name",
+  "sha256",
+  "entry",
+  "entry_sha256",
+]);
+const EVIDENCE_KEYS = new Set([
+  "executed",
+  "passed",
+  "failed",
+  "skipped",
+  "duration_ms",
+  "seed",
+  "corpus_id",
+]);
+
+export class QualificationError extends Error {
+  constructor(problems) {
+    super(
+      `release qualification failed closed:\n${problems
+        .map((problem) => `- ${problem}`)
+        .join("\n")}`,
+    );
+    this.name = "QualificationError";
+    this.problems = problems;
+  }
+}
+
+function isObject(value) {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function exactKeys(value, keys, label, problems) {
+  if (!isObject(value)) {
+    problems.push(`${label} must be an object`);
+    return false;
+  }
+  const extras = Object.keys(value).filter((key) => !keys.has(key));
+  const missing = [...keys].filter((key) => !(key in value));
+  if (extras.length > 0) {
+    problems.push(`${label} has unknown keys: ${extras.join(", ")}`);
+  }
+  if (missing.length > 0) {
+    problems.push(`${label} is missing keys: ${missing.join(", ")}`);
+  }
+  return extras.length === 0 && missing.length === 0;
+}
+
+function string(value, label, problems, pattern = null) {
+  if (typeof value !== "string" || value === "") {
+    problems.push(`${label} must be a non-empty string`);
+    return false;
+  }
+  if (pattern && !pattern.test(value)) {
+    problems.push(`${label} has invalid value ${JSON.stringify(value)}`);
+    return false;
+  }
+  return true;
+}
+
+function integer(value, label, problems, min = 0) {
+  if (!Number.isSafeInteger(value) || value < min) {
+    problems.push(`${label} must be an integer >= ${min}`);
+    return false;
+  }
+  return true;
+}
+
+function validateSource(source, label, problems) {
+  if (!exactKeys(source, SOURCE_KEYS, label, problems)) return;
+  string(source.sha, `${label}.sha`, problems, SHA_RE);
+  string(source.tree, `${label}.tree`, problems, SHA_RE);
+}
+
+function validateRun(run, label, problems) {
+  if (!exactKeys(run, RUN_KEYS, label, problems)) return;
+  string(run.id, `${label}.id`, problems, RUN_ID_RE);
+  integer(run.attempt, `${label}.attempt`, problems, 1);
+}
+
+function validateEvent(event, source, label, problems) {
+  if (!exactKeys(event, EVENT_KEYS, label, problems)) return;
+  string(event.kind, `${label}.kind`, problems);
+  if (!RELEASE_EVENTS.has(event.kind)) {
+    problems.push(`${label}.kind must be push or workflow_dispatch`);
+  }
+  if (event.pr_number !== null) problems.push(`${label}.pr_number must be null`);
+  string(event.event_head_sha, `${label}.event_head_sha`, problems, SHA_RE);
+  if (event.event_base_sha !== null) {
+    problems.push(`${label}.event_base_sha must be null`);
+  }
+  string(event.projected_sha, `${label}.projected_sha`, problems, SHA_RE);
+  if (
+    event.event_head_sha !== source?.sha ||
+    event.projected_sha !== source?.sha
+  ) {
+    problems.push(`${label} must bind the exact release source SHA`);
+  }
+}
+
+function validateSelectionRef(reference, label, problems) {
+  if (!exactKeys(reference, SELECTION_REF_KEYS, label, problems)) return;
+  validateRun(reference.run, `${label}.run`, problems);
+  string(
+    reference.manifest_sha256,
+    `${label}.manifest_sha256`,
+    problems,
+    SHA256_RE,
+  );
+}
+
+function readJSON(path, label = path) {
+  if (!existsSync(path)) {
+    throw new QualificationError([`${label} does not exist: ${path}`]);
+  }
+  try {
+    return JSON.parse(readFileSync(path, "utf8"));
+  } catch (cause) {
+    throw new QualificationError([
+      `${label} is not valid JSON: ${cause.message}`,
+    ]);
+  }
+}
+
+function writeCanonical(path, value) {
+  writeFileSync(path, `${canonicalJSON(value)}\n`);
+}
+
+function writeSelection(path, value) {
+  // selectionManifestSHA256 deliberately covers the standard indented
+  // selection representation, including its terminating newline.
+  writeFileSync(path, `${JSON.stringify(value, null, 2)}\n`);
+}
+
+function requiredEnv(name, pattern = null) {
+  const value = process.env[name];
+  const problems = [];
+  string(value, name, problems, pattern);
+  if (problems.length > 0) throw new QualificationError(problems);
+  return value;
+}
+
+function positiveIntegerEnv(name) {
+  const raw = process.env[name];
+  if (!/^[1-9][0-9]*$/.test(raw ?? "")) {
+    throw new QualificationError([
+      `${name} must be a canonical positive integer`,
+    ]);
+  }
+  const value = Number(raw);
+  if (!Number.isSafeInteger(value)) {
+    throw new QualificationError([`${name} exceeds safe integer range`]);
+  }
+  return value;
+}
+
+function positiveMillis(name, raw = process.env[name]) {
+  if (!/^[1-9][0-9]*$/.test(raw ?? "")) {
+    throw new QualificationError([
+      `${name} must be canonical positive epoch milliseconds`,
+    ]);
+  }
+  const value = Number(raw);
+  if (!Number.isSafeInteger(value)) {
+    throw new QualificationError([`${name} exceeds safe integer range`]);
+  }
+  return value;
+}
+
+function identity(value) {
+  return `${value.lane_id}/${value.execution_id}/${value.invocation_mode}`;
+}
+
+function selectedInvocationRoster(selection, registry) {
+  const lanes = new Map(registry.lanes.map((lane) => [lane.id, lane]));
+  const roster = [];
+  for (const item of selection.lanes ?? []) {
+    if (item.disposition !== "selected") continue;
+    const lane = lanes.get(item.lane_id);
+    if (!lane) continue;
+    const modes = [];
+    if (lane.applicability.source) modes.push("source_tree");
+    if (lane.applicability.artifact) modes.push("candidate_artifact");
+    for (const executionID of item.executions) {
+      for (const invocationMode of modes) {
+        roster.push({
+          lane_id: lane.id,
+          execution_id: executionID,
+          producer: {
+            workflow: lane.owner.workflow,
+            job: lane.owner.context_job,
+          },
+          invocation_mode: invocationMode,
+          determinism: lane.determinism,
+        });
+      }
+    }
+  }
+  return roster.sort((left, right) => identity(left).localeCompare(identity(right)));
+}
+
+export function releaseLaneRoster(registry) {
+  const roster = [];
+  for (const lane of registry.lanes) {
+    if (!FINITE_DETERMINISM.has(lane.determinism)) continue;
+    if (lane.release_posture === "post_publish") continue;
+    for (const executionID of lane.executions) {
+      const modes = [];
+      if (lane.applicability.source) modes.push("source_tree");
+      if (lane.applicability.artifact) modes.push("candidate_artifact");
+      for (const invocationMode of modes) {
+        roster.push({
+          lane_id: lane.id,
+          execution_id: executionID,
+          producer: {
+            workflow: lane.owner.workflow,
+            job: lane.owner.context_job,
+          },
+          invocation_mode: invocationMode,
+          determinism: lane.determinism,
+        });
+      }
+    }
+  }
+  roster.sort((left, right) => identity(left).localeCompare(identity(right)));
+  const problems = [];
+  if (!roster.some((item) => identity(item) === QUICKSTART_IDENTITY)) {
+    problems.push(`${QUICKSTART_IDENTITY} is absent from release qualification`);
+  }
+  if (roster.length !== RELEASE_QUALIFICATION_INVOCATIONS) {
+    problems.push(
+      `release qualification must contain exactly ${RELEASE_QUALIFICATION_INVOCATIONS} ` +
+        `invocations; registry produced ${roster.length}`,
+    );
+  }
+  if (problems.length > 0) throw new QualificationError(problems);
+  return roster;
+}
+
+export function createReleaseSelection({
+  registry,
+  source,
+  candidateDigest,
+  correlationNonce,
+  run,
+}) {
+  const lanes = registry.lanes
+    .map((lane) => {
+      if (lane.release_posture === "post_publish") {
+        return {
+          lane_id: lane.id,
+          disposition: "omitted",
+          executions: [],
+          reason: "post_publish",
+        };
+      }
+      if (!FINITE_DETERMINISM.has(lane.determinism)) {
+        return {
+          lane_id: lane.id,
+          disposition: "omitted",
+          executions: [],
+          reason: "advisory",
+        };
+      }
+      return {
+        lane_id: lane.id,
+        disposition: "selected",
+        executions: [...lane.executions],
+        reason: null,
+      };
+    })
+    .sort((left, right) => left.lane_id.localeCompare(right.lane_id));
+  const selection = {
+    schema_version: registry.selection_schema_version,
+    registry_schema_version: registry.schema_version,
+    report_schema_version: registry.report_schema_version,
+    posture: "release",
+    source: { ...source },
+    candidate_digest: candidateDigest,
+    correlation_nonce: correlationNonce,
+    run: { ...run },
+    selector: {
+      conclusion: "success",
+      base_sha: null,
+      head_sha: null,
+      changed_paths: [],
+      unknown_paths: [],
+    },
+    lanes,
+  };
+  try {
+    validateSelection(selection, registry, {
+      posture: "release",
+      sha: source.sha,
+      tree: source.tree,
+      candidateDigest,
+      correlationNonce,
+      runID: run.id,
+      runAttempt: run.attempt,
+    });
+  } catch (cause) {
+    if (cause instanceof ContractError) {
+      throw new QualificationError(cause.problems);
+    }
+    throw cause;
+  }
+  if (
+    canonicalJSON(selectedInvocationRoster(selection, registry)) !==
+    canonicalJSON(releaseLaneRoster(registry))
+  ) {
+    throw new QualificationError([
+      "release selection does not dispatch the exact finite invocation roster",
+    ]);
+  }
+  return selection;
+}
+
+export function createPlan({
+  registry,
+  selection,
+  eventIdentity,
+  repository,
+  startedAtMs,
+}) {
+  const plan = {
+    schema_version: QUALIFICATION_SCHEMA_VERSION,
+    registry_schema_version: registry.schema_version,
+    selection_schema_version: registry.selection_schema_version,
+    report_schema_version: registry.report_schema_version,
+    source: { ...selection.source },
+    candidate_digest: selection.candidate_digest,
+    correlation_nonce: selection.correlation_nonce,
+    selection_ref: {
+      run: { ...selection.run },
+      manifest_sha256: selectionManifestSHA256(selection),
+    },
+    event: { ...eventIdentity },
+    repository,
+    started_at_ms: startedAtMs,
+    deadline_at_ms: startedAtMs + RELEASE_QUALIFICATION_LIMIT_MS,
+    invocations: releaseLaneRoster(registry),
+  };
+  return validatePlan(plan, registry, selection);
+}
+
+export function validatePlan(plan, registry, selection, expected = {}) {
+  const problems = [];
+  if (!exactKeys(plan, PLAN_KEYS, "plan", problems)) {
+    throw new QualificationError(problems);
+  }
+  if (plan.schema_version !== QUALIFICATION_SCHEMA_VERSION) {
+    problems.push(`plan.schema_version must be ${QUALIFICATION_SCHEMA_VERSION}`);
+  }
+  for (const [field, actual, wanted] of [
+    ["registry_schema_version", plan.registry_schema_version, registry.schema_version],
+    [
+      "selection_schema_version",
+      plan.selection_schema_version,
+      registry.selection_schema_version,
+    ],
+    ["report_schema_version", plan.report_schema_version, registry.report_schema_version],
+  ]) {
+    if (actual !== wanted) problems.push(`plan.${field} does not match the registry`);
+  }
+  validateSource(plan.source, "plan.source", problems);
+  string(plan.candidate_digest, "plan.candidate_digest", problems, DIGEST_RE);
+  string(plan.correlation_nonce, "plan.correlation_nonce", problems, NONCE_RE);
+  validateSelectionRef(plan.selection_ref, "plan.selection_ref", problems);
+  validateEvent(plan.event, plan.source, "plan.event", problems);
+  string(plan.repository, "plan.repository", problems, REPOSITORY_RE);
+  integer(plan.started_at_ms, "plan.started_at_ms", problems, 1);
+  integer(plan.deadline_at_ms, "plan.deadline_at_ms", problems, 1);
+  if (
+    plan.deadline_at_ms - plan.started_at_ms !==
+    RELEASE_QUALIFICATION_LIMIT_MS
+  ) {
+    problems.push(
+      `plan deadline must be exactly ${RELEASE_QUALIFICATION_LIMIT_MINUTES} minutes after start`,
+    );
+  }
+
+  try {
+    validateSelection(selection, registry, {
+      posture: "release",
+      sha: plan.source.sha,
+      tree: plan.source.tree,
+      candidateDigest: plan.candidate_digest,
+      correlationNonce: plan.correlation_nonce,
+      runID: plan.selection_ref.run.id,
+      runAttempt: plan.selection_ref.run.attempt,
+    });
+  } catch (cause) {
+    if (cause instanceof ContractError) {
+      problems.push(...cause.problems.map((problem) => `selection: ${problem}`));
+    } else {
+      throw cause;
+    }
+  }
+  if (
+    plan.selection_ref.manifest_sha256 !== selectionManifestSHA256(selection)
+  ) {
+    problems.push("plan selection manifest SHA-256 does not match the selection");
+  }
+  if (
+    plan.selection_ref.run.id !== selection.run?.id ||
+    plan.selection_ref.run.attempt !== selection.run?.attempt
+  ) {
+    problems.push("plan selection run does not match the selection");
+  }
+
+  let expectedRoster;
+  try {
+    expectedRoster = releaseLaneRoster(registry);
+  } catch (cause) {
+    if (cause instanceof QualificationError) problems.push(...cause.problems);
+    else throw cause;
+  }
+  if (!Array.isArray(plan.invocations)) {
+    problems.push("plan.invocations must be an array");
+  } else {
+    for (let index = 0; index < plan.invocations.length; index += 1) {
+      const invocation = plan.invocations[index];
+      const label = `plan.invocations[${index}]`;
+      if (!exactKeys(invocation, PLAN_INVOCATION_KEYS, label, problems)) continue;
+      string(invocation.lane_id, `${label}.lane_id`, problems);
+      string(invocation.execution_id, `${label}.execution_id`, problems);
+      string(invocation.invocation_mode, `${label}.invocation_mode`, problems);
+      string(invocation.determinism, `${label}.determinism`, problems);
+      if (
+        exactKeys(
+          invocation.producer,
+          PLAN_PRODUCER_KEYS,
+          `${label}.producer`,
+          problems,
+        )
+      ) {
+        string(
+          invocation.producer.workflow,
+          `${label}.producer.workflow`,
+          problems,
+        );
+        string(invocation.producer.job, `${label}.producer.job`, problems);
+      }
+    }
+    if (
+      expectedRoster &&
+      canonicalJSON(plan.invocations) !== canonicalJSON(expectedRoster)
+    ) {
+      problems.push(
+        "plan.invocations does not equal the registry-derived finite release roster",
+      );
+    }
+    if (
+      canonicalJSON(plan.invocations) !==
+      canonicalJSON(selectedInvocationRoster(selection, registry))
+    ) {
+      problems.push("plan.invocations does not equal the canonical selection");
+    }
+  }
+
+  for (const [label, actual, wanted] of [
+    ["source.sha", plan.source?.sha, expected.sha],
+    ["source.tree", plan.source?.tree, expected.tree],
+    ["candidate_digest", plan.candidate_digest, expected.candidateDigest],
+    ["correlation_nonce", plan.correlation_nonce, expected.correlationNonce],
+    [
+      "selection_ref.manifest_sha256",
+      plan.selection_ref?.manifest_sha256,
+      expected.selectionManifestSHA256,
+    ],
+    ["repository", plan.repository, expected.repository],
+  ]) {
+    if (wanted !== undefined && actual !== wanted) {
+      problems.push(`plan.${label} is ${actual}, want ${wanted}`);
+    }
+  }
+  if (
+    expected.eventIdentity !== undefined &&
+    canonicalJSON(plan.event) !== canonicalJSON(expected.eventIdentity)
+  ) {
+    problems.push("plan.event does not match the trusted expected event");
+  }
+  if (problems.length > 0) throw new QualificationError(problems);
+  return plan;
+}
+
+function qualificationExpected(plan) {
+  return {
+    posture: "release",
+    sha: plan.source.sha,
+    tree: plan.source.tree,
+    candidateDigest: plan.candidate_digest,
+    correlationNonce: plan.correlation_nonce,
+    runID: plan.selection_ref.run.id,
+    runAttempt: plan.selection_ref.run.attempt,
+    selectionManifestSHA256: plan.selection_ref.manifest_sha256,
+    eventIdentity: plan.event,
+    repository: plan.repository,
+    baseSHA: undefined,
+    changedPaths: undefined,
+  };
+}
+
+function attestedLanes(reports, producerManifest, registry) {
+  const lanes = new Map(registry.lanes.map((lane) => [lane.id, lane]));
+  const producers = new Map(
+    producerManifest.producers.map((producer) => [producer.workflow, producer]),
+  );
+  return reports
+    .map((report) => {
+      const lane = lanes.get(report.lane_id);
+      const trusted = producers.get(report.producer.workflow);
+      const context = trusted.jobs.find((job) => {
+        if (job.job !== report.producer.job) return false;
+        return lane.context.match === "exact"
+          ? job.name === lane.context.name
+          : job.name.startsWith(lane.context.name);
+      });
+      return {
+        identity: `${report.lane_id}/${report.execution_id}/${report.invocation.mode}`,
+        producer: {
+          workflow: report.producer.workflow,
+          job: report.producer.job,
+          run: { ...report.producer.run },
+          job_name: context.name,
+          job_database_id: context.database_id,
+        },
+        report_artifact: { ...report.producer.artifact },
+        evidence: { ...report.evidence },
+      };
+    })
+    .sort((left, right) => left.identity.localeCompare(right.identity));
+}
+
+export function evaluateQualification({
+  registry,
+  plan,
+  selection,
+  reports,
+  producerManifest,
+  candidateManifest,
+  nowMs,
+}) {
+  validatePlan(plan, registry, selection);
+  const problems = [];
+  integer(nowMs, "qualification.now_ms", problems, 1);
+  if (nowMs < plan.started_at_ms) {
+    problems.push("qualification completed before it started");
+  }
+  if (nowMs > plan.deadline_at_ms) {
+    problems.push(
+      `qualification timed out at ${nowMs}; deadline was ${plan.deadline_at_ms} ` +
+        `(${RELEASE_QUALIFICATION_LIMIT_MINUTES} minutes)`,
+    );
+  }
+  if (!Array.isArray(reports)) {
+    problems.push("release reports must be a JSON array");
+  }
+  if (!isObject(producerManifest)) {
+    problems.push("trusted producer manifest must be an object");
+  }
+  if (problems.length > 0) throw new QualificationError(problems);
+
+  let result;
+  try {
+    result = validateReportSet({
+      registry,
+      selection,
+      reports,
+      producerManifest,
+      expected: qualificationExpected(plan),
+    });
+  } catch (cause) {
+    if (cause instanceof ContractError) {
+      throw new QualificationError(cause.problems);
+    }
+    throw cause;
+  }
+  if (
+    result.expected !== RELEASE_QUALIFICATION_INVOCATIONS ||
+    result.received !== RELEASE_QUALIFICATION_INVOCATIONS
+  ) {
+    throw new QualificationError([
+      `canonical report validation must receive exactly ${RELEASE_QUALIFICATION_INVOCATIONS} ` +
+        `invocations; expected ${result.expected}, received ${result.received}`,
+    ]);
+  }
+
+  const lanes = attestedLanes(reports, producerManifest, registry);
+  if (!lanes.some((lane) => lane.identity === QUICKSTART_IDENTITY)) {
+    throw new QualificationError([
+      `required quickstart proof ${QUICKSTART_IDENTITY} is absent`,
+    ]);
+  }
+  return {
+    schema_version: ATTESTATION_SCHEMA_VERSION,
+    result: SUCCESS,
+    source: { ...plan.source },
+    candidate: {
+      digest: plan.candidate_digest,
+      image_digest: candidateManifest.image.digest,
+      files: candidateManifest.files.map((file) => ({
+        path: file.path,
+        sha256: file.sha256,
+        size: file.size,
+      })),
+    },
+    qualification: {
+      started_at_ms: plan.started_at_ms,
+      completed_at_ms: nowMs,
+      deadline_at_ms: plan.deadline_at_ms,
+      limit_minutes: RELEASE_QUALIFICATION_LIMIT_MINUTES,
+      correlation_nonce: plan.correlation_nonce,
+      selection_ref: structuredClone(plan.selection_ref),
+      event: { ...plan.event },
+      repository: plan.repository,
+      invocation_count: RELEASE_QUALIFICATION_INVOCATIONS,
+    },
+    lanes,
+  };
+}
+
+function validateEvidence(evidence, label, planned, problems) {
+  if (!exactKeys(evidence, EVIDENCE_KEYS, label, problems)) return;
+  for (const key of ["executed", "passed", "failed", "skipped", "duration_ms"]) {
+    integer(evidence[key], `${label}.${key}`, problems);
+  }
+  if (evidence.seed !== null) {
+    string(evidence.seed, `${label}.seed`, problems);
+  }
+  string(evidence.corpus_id, `${label}.corpus_id`, problems);
+  if (
+    evidence.executed <= 0 ||
+    evidence.executed !== evidence.passed + evidence.failed + evidence.skipped ||
+    evidence.failed !== 0 ||
+    evidence.skipped !== 0 ||
+    evidence.passed !== evidence.executed
+  ) {
+    problems.push(`${label} is not a positive all-passed native result`);
+  }
+  if (planned?.determinism === "deterministic" && evidence.seed !== null) {
+    problems.push(`${label} deterministic lane must carry seed=null`);
+  }
+  if (planned?.determinism === "seeded" && evidence.seed === null) {
+    problems.push(`${label} seeded lane omitted its seed`);
+  }
+}
+
+export function validateAttestation(attestation, expected = {}, registry = null) {
+  const problems = [];
+  if (!exactKeys(attestation, ATTESTATION_KEYS, "attestation", problems)) {
+    throw new QualificationError(problems);
+  }
+  if (attestation.schema_version !== ATTESTATION_SCHEMA_VERSION) {
+    problems.push(
+      `attestation.schema_version must be ${ATTESTATION_SCHEMA_VERSION}`,
+    );
+  }
+  if (attestation.result !== SUCCESS) {
+    problems.push("attestation.result must be success");
+  }
+  validateSource(attestation.source, "attestation.source", problems);
+  if (
+    exactKeys(
+      attestation.candidate,
+      ATTESTATION_CANDIDATE_KEYS,
+      "attestation.candidate",
+      problems,
+    )
+  ) {
+    string(
+      attestation.candidate.digest,
+      "attestation.candidate.digest",
+      problems,
+      DIGEST_RE,
+    );
+    string(
+      attestation.candidate.image_digest,
+      "attestation.candidate.image_digest",
+      problems,
+      DIGEST_RE,
+    );
+    if (
+      !Array.isArray(attestation.candidate.files) ||
+      attestation.candidate.files.length === 0
+    ) {
+      problems.push("attestation.candidate.files must be non-empty");
+    } else {
+      let previous = "";
+      const seen = new Set();
+      for (let index = 0; index < attestation.candidate.files.length; index += 1) {
+        const file = attestation.candidate.files[index];
+        const label = `attestation.candidate.files[${index}]`;
+        if (!exactKeys(file, ATTESTATION_FILE_KEYS, label, problems)) continue;
+        string(file.path, `${label}.path`, problems);
+        string(file.sha256, `${label}.sha256`, problems, DIGEST_RE);
+        integer(file.size, `${label}.size`, problems);
+        if (seen.has(file.path)) problems.push(`${label}.path is duplicated`);
+        if (previous !== "" && String(file.path).localeCompare(previous) <= 0) {
+          problems.push(`${label}.path is not strictly sorted`);
+        }
+        seen.add(file.path);
+        previous = file.path;
+      }
+    }
+  }
+
+  if (
+    exactKeys(
+      attestation.qualification,
+      ATTESTATION_QUALIFICATION_KEYS,
+      "attestation.qualification",
+      problems,
+    )
+  ) {
+    for (const key of ["started_at_ms", "completed_at_ms", "deadline_at_ms"]) {
+      integer(
+        attestation.qualification[key],
+        `attestation.qualification.${key}`,
+        problems,
+        1,
+      );
+    }
+    integer(
+      attestation.qualification.limit_minutes,
+      "attestation.qualification.limit_minutes",
+      problems,
+      1,
+    );
+    string(
+      attestation.qualification.correlation_nonce,
+      "attestation.qualification.correlation_nonce",
+      problems,
+      NONCE_RE,
+    );
+    validateSelectionRef(
+      attestation.qualification.selection_ref,
+      "attestation.qualification.selection_ref",
+      problems,
+    );
+    validateEvent(
+      attestation.qualification.event,
+      attestation.source,
+      "attestation.qualification.event",
+      problems,
+    );
+    string(
+      attestation.qualification.repository,
+      "attestation.qualification.repository",
+      problems,
+      REPOSITORY_RE,
+    );
+    if (
+      attestation.qualification.invocation_count !==
+      RELEASE_QUALIFICATION_INVOCATIONS
+    ) {
+      problems.push(
+        `attestation.qualification.invocation_count must be ${RELEASE_QUALIFICATION_INVOCATIONS}`,
+      );
+    }
+    if (
+      attestation.qualification.deadline_at_ms -
+        attestation.qualification.started_at_ms !==
+      RELEASE_QUALIFICATION_LIMIT_MS
+    ) {
+      problems.push(
+        "attestation qualification deadline does not equal the hard release limit",
+      );
+    }
+    if (
+      attestation.qualification.completed_at_ms <
+        attestation.qualification.started_at_ms ||
+      attestation.qualification.completed_at_ms >
+        attestation.qualification.deadline_at_ms
+    ) {
+      problems.push(
+        "attestation completion is outside its qualification window",
+      );
+    }
+  }
+
+  let expectedLanes = null;
+  if (registry) {
+    try {
+      expectedLanes = new Map(
+        releaseLaneRoster(registry).map((lane) => [identity(lane), lane]),
+      );
+    } catch (cause) {
+      if (cause instanceof QualificationError) problems.push(...cause.problems);
+      else throw cause;
+    }
+  }
+  const actualLanes = new Map();
+  if (!Array.isArray(attestation.lanes)) {
+    problems.push("attestation.lanes must be an array");
+  } else {
+    if (attestation.lanes.length !== RELEASE_QUALIFICATION_INVOCATIONS) {
+      problems.push(
+        `attestation.lanes must contain exactly ${RELEASE_QUALIFICATION_INVOCATIONS} identities`,
+      );
+    }
+    let previous = "";
+    for (let index = 0; index < attestation.lanes.length; index += 1) {
+      const lane = attestation.lanes[index];
+      const label = `attestation.lanes[${index}]`;
+      if (!exactKeys(lane, ATTESTATION_LANE_KEYS, label, problems)) continue;
+      string(lane.identity, `${label}.identity`, problems);
+      if (actualLanes.has(lane.identity)) {
+        problems.push(`${label}.identity is duplicated`);
+      }
+      if (previous !== "" && String(lane.identity).localeCompare(previous) <= 0) {
+        problems.push(`${label}.identity is not strictly sorted`);
+      }
+      actualLanes.set(lane.identity, lane);
+      previous = lane.identity;
+      const planned = expectedLanes?.get(lane.identity);
+      if (expectedLanes && !planned) {
+        problems.push(`${label}.identity is not in the finite release roster`);
+      }
+      if (
+        exactKeys(
+          lane.producer,
+          ATTESTATION_PRODUCER_KEYS,
+          `${label}.producer`,
+          problems,
+        )
+      ) {
+        string(
+          lane.producer.workflow,
+          `${label}.producer.workflow`,
+          problems,
+        );
+        string(lane.producer.job, `${label}.producer.job`, problems);
+        validateRun(lane.producer.run, `${label}.producer.run`, problems);
+        string(lane.producer.job_name, `${label}.producer.job_name`, problems);
+        string(
+          lane.producer.job_database_id,
+          `${label}.producer.job_database_id`,
+          problems,
+          RUN_ID_RE,
+        );
+        if (
+          planned &&
+          (lane.producer.workflow !== planned.producer.workflow ||
+            lane.producer.job !== planned.producer.job)
+        ) {
+          problems.push(`${label}.producer does not match the registry owner`);
+        }
+      }
+      if (
+        exactKeys(
+          lane.report_artifact,
+          ATTESTATION_ARTIFACT_KEYS,
+          `${label}.report_artifact`,
+          problems,
+        )
+      ) {
+        string(
+          lane.report_artifact.id,
+          `${label}.report_artifact.id`,
+          problems,
+          RUN_ID_RE,
+        );
+        string(
+          lane.report_artifact.name,
+          `${label}.report_artifact.name`,
+          problems,
+        );
+        string(
+          lane.report_artifact.sha256,
+          `${label}.report_artifact.sha256`,
+          problems,
+          SHA256_RE,
+        );
+        string(
+          lane.report_artifact.entry,
+          `${label}.report_artifact.entry`,
+          problems,
+        );
+        string(
+          lane.report_artifact.entry_sha256,
+          `${label}.report_artifact.entry_sha256`,
+          problems,
+          SHA256_RE,
+        );
+        if (lane.report_artifact.entry !== lane.identity) {
+          problems.push(`${label}.report_artifact.entry must equal its identity`);
+        }
+      }
+      validateEvidence(lane.evidence, `${label}.evidence`, planned, problems);
+    }
+  }
+  if (expectedLanes) {
+    for (const expectedIdentity of expectedLanes.keys()) {
+      if (!actualLanes.has(expectedIdentity)) {
+        problems.push(`attestation is missing release lane ${expectedIdentity}`);
+      }
+    }
+  }
+  if (!actualLanes.has(QUICKSTART_IDENTITY)) {
+    problems.push(
+      `attestation does not contain required quickstart proof ${QUICKSTART_IDENTITY}`,
+    );
+  }
+  if (
+    attestation.qualification?.limit_minutes !==
+    RELEASE_QUALIFICATION_LIMIT_MINUTES
+  ) {
+    problems.push(
+      `attestation qualification limit must be ${RELEASE_QUALIFICATION_LIMIT_MINUTES} minutes`,
+    );
+  }
+
+  for (const [label, actual, wanted] of [
+    ["source.sha", attestation.source?.sha, expected.sha],
+    ["source.tree", attestation.source?.tree, expected.tree],
+    ["candidate.digest", attestation.candidate?.digest, expected.candidateDigest],
+    [
+      "candidate.image_digest",
+      attestation.candidate?.image_digest,
+      expected.imageDigest,
+    ],
+    [
+      "qualification.correlation_nonce",
+      attestation.qualification?.correlation_nonce,
+      expected.correlationNonce,
+    ],
+    [
+      "qualification.selection_ref.manifest_sha256",
+      attestation.qualification?.selection_ref?.manifest_sha256,
+      expected.selectionManifestSHA256,
+    ],
+    [
+      "qualification.repository",
+      attestation.qualification?.repository,
+      expected.repository,
+    ],
+  ]) {
+    if (wanted !== undefined && actual !== wanted) {
+      problems.push(`attestation.${label} is ${actual}, want ${wanted}`);
+    }
+  }
+  if (
+    expected.eventIdentity !== undefined &&
+    canonicalJSON(attestation.qualification?.event) !==
+      canonicalJSON(expected.eventIdentity)
+  ) {
+    problems.push("attestation qualification event does not match expected event");
+  }
+  if (problems.length > 0) throw new QualificationError(problems);
+  return attestation;
+}
+
+function environmentIdentity() {
+  return {
+    sha: requiredEnv("RELEASE_SOURCE_SHA", SHA_RE),
+    tree: requiredEnv("RELEASE_SOURCE_TREE", SHA_RE),
+    candidateDigest: requiredEnv("RELEASE_CANDIDATE_DIGEST", DIGEST_RE),
+    correlationNonce: requiredEnv("RELEASE_CORRELATION_NONCE", NONCE_RE),
+    app: requiredEnv("RELEASE_APP_VERSION"),
+    appTag: requiredEnv("RELEASE_APP_TAG"),
+    chart: requiredEnv("RELEASE_CHART_VERSION"),
+  };
+}
+
+function verifiedCandidate(expected) {
+  return verifyCandidate(
+    resolve(process.env.RELEASE_CANDIDATE_DIR || "build/release-candidate"),
+    {
+      sha: expected.sha,
+      tree: expected.tree,
+      app: expected.app,
+      appTag: expected.appTag,
+      chart: expected.chart,
+      digest: expected.candidateDigest,
+    },
+  );
+}
+
+export function verifyAttestationBundle({
+  candidateRoot,
+  attestationPath,
+  attestationDigest,
+  expected,
+  registry,
+}) {
+  const problems = [];
+  string(attestationDigest, "release attestation digest", problems, DIGEST_RE);
+  if (problems.length > 0) throw new QualificationError(problems);
+
+  const candidate = verifyCandidate(resolve(candidateRoot), {
+    sha: expected.sha,
+    tree: expected.tree,
+    app: expected.app,
+    appTag: expected.appTag,
+    chart: expected.chart,
+    digest: expected.candidateDigest,
+  });
+  const path = resolve(attestationPath);
+  if (!existsSync(path)) {
+    throw new QualificationError([
+      `release qualification attestation does not exist: ${path}`,
+    ]);
+  }
+  const digest = sha256File(path);
+  if (digest !== attestationDigest) {
+    throw new QualificationError([
+      `attestation digest is ${digest}, want ${attestationDigest}`,
+    ]);
+  }
+  const attestation = validateAttestation(
+    readJSON(path, "release qualification attestation"),
+    {
+      ...expected,
+      imageDigest: candidate.manifest.image.digest,
+    },
+    registry,
+  );
+  if (
+    canonicalJSON(attestation.candidate.files) !==
+    canonicalJSON(candidate.manifest.files)
+  ) {
+    throw new QualificationError([
+      "attestation artifact digests do not match the verified candidate manifest",
+    ]);
+  }
+  return { attestation, candidate, digest };
+}
+
+export function verifyAttestationFromEnvironment() {
+  const expected = environmentIdentity();
+  return verifyAttestationBundle({
+    candidateRoot:
+      process.env.RELEASE_CANDIDATE_DIR || "build/release-candidate",
+    attestationPath:
+      process.env.RELEASE_ATTESTATION ||
+      "build/release-qualification-attestation.json",
+    attestationDigest: requiredEnv("RELEASE_ATTESTATION_DIGEST", DIGEST_RE),
+    expected,
+    registry: loadRegistry(),
+  });
+}
+
+function planMode() {
+  const expected = environmentIdentity();
+  verifiedCandidate(expected);
+  const registry = loadRegistry();
+  const eventKind = requiredEnv("GITHUB_EVENT_NAME");
+  if (!RELEASE_EVENTS.has(eventKind)) {
+    throw new QualificationError([
+      `GITHUB_EVENT_NAME must be push or workflow_dispatch; got ${JSON.stringify(eventKind)}`,
+    ]);
+  }
+  const run = {
+    id: requiredEnv("GITHUB_RUN_ID", RUN_ID_RE),
+    attempt: positiveIntegerEnv("GITHUB_RUN_ATTEMPT"),
+  };
+  const selection = createReleaseSelection({
+    registry,
+    source: { sha: expected.sha, tree: expected.tree },
+    candidateDigest: expected.candidateDigest,
+    correlationNonce: expected.correlationNonce,
+    run,
+  });
+  const eventIdentity = {
+    kind: eventKind,
+    pr_number: null,
+    event_head_sha: expected.sha,
+    event_base_sha: null,
+    projected_sha: expected.sha,
+  };
+  const plan = createPlan({
+    registry,
+    selection,
+    eventIdentity,
+    repository: requiredEnv("GITHUB_REPOSITORY", REPOSITORY_RE),
+    startedAtMs: positiveMillis("RELEASE_QUALIFICATION_START"),
+  });
+  const selectionPath = resolve(
+    process.env.RELEASE_QUALIFICATION_SELECTION ||
+      "build/release-qualification-selection.json",
+  );
+  const planPath = resolve(
+    process.env.RELEASE_QUALIFICATION_PLAN ||
+      "build/release-qualification-plan.json",
+  );
+  writeSelection(selectionPath, selection);
+  writeCanonical(planPath, plan);
+  setOutput("selection", selectionPath);
+  setOutput("selection_digest", plan.selection_ref.manifest_sha256);
+  setOutput("plan", planPath);
+  setOutput("lane_count", String(plan.invocations.length));
+  notice(
+    `planned ${plan.invocations.length} finite release invocations for ` +
+      `${expected.sha.slice(0, 12)} candidate ${expected.candidateDigest}`,
+  );
+}
+
+function joinMode() {
+  const expected = environmentIdentity();
+  const candidate = verifiedCandidate(expected);
+  const registry = loadRegistry();
+  const selectionPath = resolve(
+    process.env.RELEASE_QUALIFICATION_SELECTION ||
+      "build/release-qualification-selection.json",
+  );
+  const planPath = resolve(
+    process.env.RELEASE_QUALIFICATION_PLAN ||
+      "build/release-qualification-plan.json",
+  );
+  const reportsPath = resolve(requiredEnv("RELEASE_QUALIFICATION_REPORTS"));
+  const producerManifestPath = resolve(
+    requiredEnv("RELEASE_QUALIFICATION_PRODUCER_MANIFEST"),
+  );
+  const selection = readJSON(selectionPath, "release qualification selection");
+  const plan = validatePlan(
+    readJSON(planPath, "release qualification plan"),
+    registry,
+    selection,
+    expected,
+  );
+  const nowMs = process.env.RELEASE_QUALIFICATION_NOW
+    ? positiveMillis("RELEASE_QUALIFICATION_NOW")
+    : Date.now();
+  const attestation = evaluateQualification({
+    registry,
+    plan,
+    selection,
+    reports: readJSON(reportsPath, "release qualification reports"),
+    producerManifest: readJSON(
+      producerManifestPath,
+      "release trusted producer manifest",
+    ),
+    candidateManifest: candidate.manifest,
+    nowMs,
+  });
+  const attestationPath = resolve(
+    process.env.RELEASE_ATTESTATION ||
+      "build/release-qualification-attestation.json",
+  );
+  writeCanonical(attestationPath, attestation);
+  const digest = sha256File(attestationPath);
+  setOutput("qualified", "true");
+  setOutput("attestation", attestationPath);
+  setOutput("attestation_digest", digest);
+  notice(
+    `release qualification passed ${attestation.lanes.length} invocations in ` +
+      `${attestation.qualification.completed_at_ms - attestation.qualification.started_at_ms} ms; ` +
+      `attestation ${digest}`,
+  );
+}
+
+function verifyAttestationMode() {
+  const { digest } = verifyAttestationFromEnvironment();
+  setOutput("qualified", "true");
+  notice(`verified successful release attestation ${digest}; promotion may proceed`);
+}
+
+function main() {
+  const mode = process.env.MODE || process.argv[2];
+  if (mode === "plan") planMode();
+  else if (mode === "join") joinMode();
+  else if (mode === "verify-attestation") verifyAttestationMode();
+  else {
+    throw new QualificationError([
+      `MODE must be plan, join, or verify-attestation; got ${JSON.stringify(mode)}`,
+    ]);
+  }
+}
+
+const invokedDirectly =
+  process.argv[1] && fileURLToPath(import.meta.url) === resolve(process.argv[1]);
+if (invokedDirectly) {
+  try {
+    main();
+  } catch (cause) {
+    error(cause instanceof Error ? cause.message : String(cause));
+    process.exit(1);
+  }
+}

--- a/.github/scripts/release-qualification.test.mjs
+++ b/.github/scripts/release-qualification.test.mjs
@@ -2,9 +2,16 @@ import assert from "node:assert/strict";
 import { test } from "node:test";
 
 import {
+  nativeArtifactName,
+  selectionManifestSHA256,
+} from "./ci-lane-contract.mjs";
+import {
   QualificationError,
+  QUICKSTART_IDENTITY,
+  RELEASE_QUALIFICATION_INVOCATIONS,
   RELEASE_QUALIFICATION_LIMIT_MS,
   createPlan,
+  createReleaseSelection,
   evaluateQualification,
   releaseLaneRoster,
   validateAttestation,
@@ -13,83 +20,207 @@ import {
 const SHA = "a".repeat(40);
 const TREE = "b".repeat(40);
 const CANDIDATE = `sha256:${"c".repeat(64)}`;
-const REPORT_DIGEST = `sha256:${"d".repeat(64)}`;
+const IMAGE = `sha256:${"d".repeat(64)}`;
 const NONCE = "e".repeat(64);
+const REPOSITORY = "example/project";
+const WORKFLOW = ".github/workflows/qualification-fixture.yml";
+const SELECTION_RUN = Object.freeze({ id: "321", attempt: 2 });
+const PRODUCER_RUN = Object.freeze({ id: "801", attempt: 3 });
+const EVENT = Object.freeze({
+  kind: "workflow_dispatch",
+  pr_number: null,
+  event_head_sha: SHA,
+  event_base_sha: null,
+  projected_sha: SHA,
+});
+const NON_SUCCESS_CONCLUSIONS = [
+  "action_required",
+  "cancelled",
+  "failure",
+  "neutral",
+  "skipped",
+  "stale",
+  "startup_failure",
+  "timed_out",
+];
 
-function lane(id, { artifact = false, seeded = false } = {}) {
+function fixtureLane(
+  id,
+  ordinal,
+  { artifact = false, seeded = false, advisory = false, prefix = false } = {},
+) {
+  const token = String(ordinal).padStart(2, "0");
+  const job = `job_${token}`;
   return {
     id,
     executions: ["default"],
     owner: {
-      workflow: `.github/workflows/${id.replaceAll(".", "-")}.yml`,
-      context_job: id.replaceAll(".", "-"),
+      workflow: WORKFLOW,
+      jobs: [job],
+      context_job: job,
     },
+    context: {
+      match: prefix ? "prefix" : "exact",
+      name: `qualification-${token}`,
+      protected: id === "e2e.quickstart",
+    },
+    recipes: ["fixture"],
+    command: `run-${id}`,
+    build_tags: [],
+    risk_domains: ["release"],
     determinism: seeded ? "seeded" : "deterministic",
-    release_posture: "required",
+    release_posture: advisory ? "advisory" : "required",
     applicability: { source: true, artifact },
   };
 }
 
-const registry = {
-  schema_version: 1,
-  lanes: [lane("e2e.quickstart"), lane("migration.e2e", { artifact: true })],
-};
+function registryFixture() {
+  const lanes = [fixtureLane("e2e.quickstart", 0)];
+  for (let index = 0; index < 42; index += 1) {
+    lanes.push(
+      fixtureLane(`quality.lane${String(index).padStart(2, "0")}`, index + 1, {
+        seeded: index === 7,
+        advisory: index === 11,
+      }),
+    );
+  }
+  lanes.push(
+    fixtureLane("release.migration", 43, { artifact: true, prefix: true }),
+  );
+  lanes.sort((left, right) => left.id.localeCompare(right.id));
+  return {
+    schema_version: 1,
+    selection_schema_version: 1,
+    report_schema_version: 2,
+    lanes,
+  };
+}
+
+function entryDigest(index) {
+  return ((index % 15) + 1).toString(16).repeat(64);
+}
 
 function fixture() {
+  const registry = registryFixture();
   const startedAtMs = 1_000_000;
-  const plan = createPlan({
+  const selection = createReleaseSelection({
     registry,
     source: { sha: SHA, tree: TREE },
     candidateDigest: CANDIDATE,
     correlationNonce: NONCE,
+    run: SELECTION_RUN,
+  });
+  const plan = createPlan({
+    registry,
+    selection,
+    eventIdentity: EVENT,
+    repository: REPOSITORY,
     startedAtMs,
   });
-  const records = plan.lanes.map((planned, index) => ({
-    lane_id: planned.lane_id,
-    execution_id: planned.execution_id,
-    source: { sha: SHA, tree: TREE },
-    candidate_digest:
-      planned.invocation_mode === "candidate_artifact" ? CANDIDATE : null,
-    producer: {
-      workflow: planned.producer.workflow,
-      job: planned.producer.job,
-      run_id: String(100 + index),
-      run_attempt: 1,
-    },
-    invocation_mode: planned.invocation_mode,
+  const roster = releaseLaneRoster(registry);
+  const artifact = {
+    id: "901",
+    name: nativeArtifactName(WORKFLOW, PRODUCER_RUN),
+    sha256: "f".repeat(64),
+    entries: roster.map((item, index) => ({
+      lane_id: item.lane_id,
+      execution_id: item.execution_id,
+      invocation_mode: item.invocation_mode,
+      sha256: entryDigest(index),
+    })),
+  };
+  const jobs = registry.lanes.map((lane, index) => ({
+    job: lane.owner.context_job,
+    name:
+      lane.context.match === "prefix"
+        ? `${lane.context.name} / default`
+        : lane.context.name,
+    database_id: String(1001 + index),
     conclusion: "success",
-    evidence: {
-      executed: 3,
-      passed: 3,
-      failed: 0,
-      skipped: 0,
-      duration_ms: 250,
-      seed: null,
-      corpus_id: `${planned.lane_id}-native`,
-    },
-    trust: {
-      artifact_id: String(900 + index),
-      artifact_digest: REPORT_DIGEST,
-      head_sha: SHA,
-      head_tree: TREE,
-      run_id: String(100 + index),
-      run_attempt: 1,
-      job_conclusion: "success",
-      completed_at_ms: startedAtMs + 1000 + index,
-    },
   }));
-  return {
-    plan,
-    index: {
-      schema_version: 1,
+  const reports = roster.map((item, index) => {
+    const lane = registry.lanes.find((candidate) => candidate.id === item.lane_id);
+    const nativeEntry = artifact.entries[index];
+    return {
+      schema_version: registry.report_schema_version,
+      registry_schema_version: registry.schema_version,
+      lane_id: item.lane_id,
+      execution_id: item.execution_id,
+      posture: "release",
       source: { sha: SHA, tree: TREE },
-      candidate_digest: CANDIDATE,
+      candidate_digest:
+        item.invocation_mode === "candidate_artifact" ? CANDIDATE : null,
       correlation_nonce: NONCE,
-      records,
+      selection_ref: {
+        run: { ...SELECTION_RUN },
+        manifest_sha256: selectionManifestSHA256(selection),
+      },
+      producer: {
+        workflow: WORKFLOW,
+        job: lane.owner.context_job,
+        run: { ...PRODUCER_RUN },
+        artifact: {
+          id: artifact.id,
+          name: artifact.name,
+          sha256: artifact.sha256,
+          entry: `${item.lane_id}/${item.execution_id}/${item.invocation_mode}`,
+          entry_sha256: nativeEntry.sha256,
+        },
+      },
+      invocation: {
+        mode: item.invocation_mode,
+        recipe: lane.recipes[0],
+        command: lane.command,
+        build_tags: [...lane.build_tags],
+        selected_domains: [...lane.risk_domains],
+      },
+      evidence: {
+        executed: 3,
+        passed: 3,
+        failed: 0,
+        skipped: 0,
+        duration_ms: 250,
+        seed: lane.determinism === "seeded" ? "release-seed" : null,
+        corpus_id: `${item.lane_id}/${item.execution_id}/${item.invocation_mode}`,
+      },
+      conclusion: "success",
+    };
+  });
+  return {
+    registry,
+    selection,
+    plan,
+    reports,
+    producerManifest: {
+      schema_version: registry.report_schema_version,
+      correlation_nonce: NONCE,
+      selection_ref: {
+        run: { ...SELECTION_RUN },
+        manifest_sha256: selectionManifestSHA256(selection),
+      },
+      producers: [
+        {
+          workflow: WORKFLOW,
+          run: { ...PRODUCER_RUN },
+          source: { sha: SHA, tree: TREE },
+          correlation_nonce: NONCE,
+          event: { ...EVENT },
+          repository: REPOSITORY,
+          conclusion: "success",
+          jobs,
+          artifacts: [artifact],
+        },
+      ],
     },
     candidateManifest: {
-      image: { digest: `sha256:${"e".repeat(64)}` },
-      files: [{ path: "app/image/index.json", size: 5, sha256: `sha256:${"f".repeat(64)}` }],
+      image: { digest: IMAGE },
+      files: [
+        {
+          path: "app/image/index.json",
+          size: 5,
+          sha256: `sha256:${"1".repeat(64)}`,
+        },
+      ],
     },
     nowMs: startedAtMs + 2000,
   };
@@ -97,193 +228,514 @@ function fixture() {
 
 function evaluate(value) {
   return evaluateQualification({
-    registry,
+    registry: value.registry,
     plan: value.plan,
-    evidenceIndex: value.index,
+    selection: value.selection,
+    reports: value.reports,
+    producerManifest: value.producerManifest,
     candidateManifest: value.candidateManifest,
     nowMs: value.nowMs,
   });
 }
 
-test("release roster includes every finite pre-publication source/artifact lane", () => {
-  const extended = {
-    ...registry,
-    lanes: [
-      ...registry.lanes,
-      { ...lane("advisory.seed", { seeded: true }), release_posture: "advisory" },
-      { ...lane("public.monitor"), release_posture: "post_publish" },
-      { ...lane("observation"), determinism: "observational" },
-    ],
+function expectQualificationError(fn, ...patterns) {
+  let caught;
+  try {
+    fn();
+  } catch (error) {
+    caught = error;
+  }
+  assert.ok(
+    caught instanceof QualificationError,
+    `expected QualificationError, got ${caught}`,
+  );
+  for (const pattern of patterns) assert.match(caught.message, pattern);
+  return caught;
+}
+
+function reportByIdentity(value, identity) {
+  return value.reports.find(
+    (report) =>
+      `${report.lane_id}/${report.execution_id}/${report.invocation.mode}` ===
+      identity,
+  );
+}
+
+function expectedAttestation(value) {
+  return {
+    sha: SHA,
+    tree: TREE,
+    candidateDigest: CANDIDATE,
+    imageDigest: IMAGE,
+    correlationNonce: NONCE,
+    selectionManifestSHA256: value.plan.selection_ref.manifest_sha256,
+    eventIdentity: EVENT,
+    repository: REPOSITORY,
   };
+}
+
+test("release selection expands 44 finite lanes into exactly 45 mode-bound invocations", () => {
+  const value = fixture();
+  const roster = releaseLaneRoster(value.registry);
+  assert.equal(
+    value.selection.lanes.filter((lane) => lane.disposition === "selected").length,
+    44,
+  );
+  assert.equal(roster.length, RELEASE_QUALIFICATION_INVOCATIONS);
+  assert(roster.some((item) => `${item.lane_id}/${item.execution_id}/${item.invocation_mode}` === QUICKSTART_IDENTITY));
   assert.deepEqual(
-    releaseLaneRoster(extended).map((item) => `${item.lane_id}/${item.invocation_mode}`),
-    [
-      "advisory.seed/source_tree",
-      "e2e.quickstart/source_tree",
-      "migration.e2e/candidate_artifact",
-      "migration.e2e/source_tree",
-    ],
+    roster
+      .filter((item) => item.lane_id === "release.migration")
+      .map((item) => item.invocation_mode),
+    ["candidate_artifact", "source_tree"],
+  );
+  assert.equal(
+    value.plan.selection_ref.manifest_sha256,
+    selectionManifestSHA256(value.selection),
   );
 });
 
-test("successful join attests the exact tree, candidate, image, files, and quickstart", () => {
+test("post-publish and observational lanes stay outside the exact finite roster", () => {
+  const value = fixture();
+  value.registry.lanes.push({
+    ...fixtureLane("monitor.public", 90, { artifact: true }),
+    applicability: { source: false, artifact: true },
+    release_posture: "post_publish",
+  });
+  value.registry.lanes.push({
+    ...fixtureLane("observation.advisory", 91, { advisory: true }),
+    determinism: "observational",
+  });
+  value.registry.lanes.sort((left, right) => left.id.localeCompare(right.id));
+  const selection = createReleaseSelection({
+    registry: value.registry,
+    source: { sha: SHA, tree: TREE },
+    candidateDigest: CANDIDATE,
+    correlationNonce: NONCE,
+    run: SELECTION_RUN,
+  });
+  assert.equal(releaseLaneRoster(value.registry).length, 45);
+  assert.equal(
+    selection.lanes.find((lane) => lane.lane_id === "monitor.public").reason,
+    "post_publish",
+  );
+  assert.equal(
+    selection.lanes.find((lane) => lane.lane_id === "observation.advisory").reason,
+    "advisory",
+  );
+});
+
+test("successful join pins candidate, selection, event, jobs, artifact entries, and quickstart", () => {
   const value = fixture();
   const attestation = evaluate(value);
   assert.equal(attestation.result, "success");
-  assert.deepEqual(attestation.source, { sha: SHA, tree: TREE });
   assert.equal(attestation.candidate.digest, CANDIDATE);
-  assert.equal(attestation.lanes.length, 3);
-  assert(attestation.lanes.some((item) => item.identity === "e2e.quickstart/default/source_tree"));
-  assert(attestation.lanes.some((item) => item.identity === "migration.e2e/default/source_tree"));
-  assert(attestation.lanes.some((item) => item.identity === "migration.e2e/default/candidate_artifact"));
-  assert.deepEqual(
-    validateAttestation(attestation, {
-      sha: SHA,
-      tree: TREE,
-      candidateDigest: CANDIDATE,
-      correlationNonce: NONCE,
-    }),
+  assert.equal(attestation.candidate.image_digest, IMAGE);
+  assert.equal(attestation.qualification.invocation_count, 45);
+  assert.deepEqual(attestation.qualification.selection_ref, value.plan.selection_ref);
+  assert.deepEqual(attestation.qualification.event, EVENT);
+  assert.equal(attestation.qualification.repository, REPOSITORY);
+  assert.equal(attestation.lanes.length, 45);
+  const quickstart = attestation.lanes.find(
+    (lane) => lane.identity === QUICKSTART_IDENTITY,
+  );
+  assert(quickstart);
+  assert.equal(quickstart.producer.job_name, "qualification-00");
+  assert.equal(quickstart.producer.job_database_id, "1001");
+  assert.equal(quickstart.report_artifact.name, nativeArtifactName(WORKFLOW, PRODUCER_RUN));
+  assert.equal(quickstart.report_artifact.entry, QUICKSTART_IDENTITY);
+  assert.equal(quickstart.report_artifact.entry_sha256, entryDigest(0));
+  assert.equal(
+    validateAttestation(attestation, expectedAttestation(value), value.registry),
     attestation,
   );
 });
 
-test("failed, cancelled, skipped, neutral, timed-out, and stale conclusions block", () => {
-  for (const conclusion of [
-    "failure",
-    "cancelled",
-    "skipped",
-    "neutral",
-    "timed_out",
-    "stale",
-  ]) {
+test("missing, duplicate, and mode-collapsed reports fail closed", () => {
+  {
     const value = fixture();
-    value.index.records[0].conclusion = conclusion;
-    assert.throws(
+    value.reports = value.reports.filter(
+      (report) =>
+        `${report.lane_id}/${report.execution_id}/${report.invocation.mode}` !==
+        QUICKSTART_IDENTITY,
+    );
+    expectQualificationError(
       () => evaluate(value),
-      (error) => error instanceof QualificationError && error.message.includes(conclusion),
-      conclusion,
+      /missing report e2e\.quickstart\/default\/source_tree/,
+    );
+  }
+  {
+    const value = fixture();
+    value.reports.push(structuredClone(value.reports[0]));
+    expectQualificationError(() => evaluate(value), /duplicate report/);
+  }
+  {
+    const value = fixture();
+    value.reports = value.reports.filter(
+      (report) =>
+        !(
+          report.lane_id === "release.migration" &&
+          report.invocation.mode === "candidate_artifact"
+        ),
+    );
+    expectQualificationError(
+      () => evaluate(value),
+      /missing report release\.migration\/default\/candidate_artifact/,
+    );
+  }
+  {
+    const value = fixture();
+    const artifact = reportByIdentity(
+      value,
+      "release.migration/default/candidate_artifact",
+    );
+    artifact.invocation.mode = "source_tree";
+    expectQualificationError(
+      () => evaluate(value),
+      /source_tree report must not carry candidate_digest|duplicate report/,
     );
   }
 });
 
-test("a non-success trusted job blocks even when its report claims success", () => {
-  const value = fixture();
-  value.index.records[0].trust.job_conclusion = "cancelled";
-  assert.throws(() => evaluate(value), /trusted job conclusion cancelled/);
+test("trusted job display names, ambiguity, database IDs, and conclusions fail closed", () => {
+  {
+    const value = fixture();
+    value.producerManifest.producers[0].jobs[0].name = "wrong-check";
+    expectQualificationError(
+      () => evaluate(value),
+      /trusted context check name wrong-check does not match qualification-00/,
+    );
+  }
+  {
+    const value = fixture();
+    const lane = value.registry.lanes.find(
+      (candidate) => candidate.id === "release.migration",
+    );
+    value.producerManifest.producers[0].jobs.push({
+      job: lane.owner.context_job,
+      name: `${lane.context.name} / second`,
+      database_id: "9999",
+      conclusion: "success",
+    });
+    expectQualificationError(
+      () => evaluate(value),
+      /trusted context job job_43 is ambiguous/,
+    );
+  }
+  {
+    const value = fixture();
+    value.producerManifest.producers[0].jobs[1].database_id =
+      value.producerManifest.producers[0].jobs[0].database_id;
+    expectQualificationError(() => evaluate(value), /database_id is duplicated/);
+  }
+  for (const conclusion of NON_SUCCESS_CONCLUSIONS) {
+    const value = fixture();
+    value.producerManifest.producers[0].jobs[0].conclusion = conclusion;
+    expectQualificationError(
+      () => evaluate(value),
+      new RegExp(`trusted context job job_00 is ${conclusion}`),
+    );
+  }
 });
 
-test("absent report blocks and quickstart absence is named explicitly", () => {
-  const value = fixture();
-  value.index.records = value.index.records.filter(
-    (record) => record.lane_id !== "e2e.quickstart",
-  );
-  assert.throws(
-    () => evaluate(value),
-    (error) =>
-      error instanceof QualificationError &&
-      /missing evidence record e2e\.quickstart\/default\/source_tree/.test(error.message) &&
-      /quickstart proof/.test(error.message),
-  );
+test("selection digest, selection run, source, nonce, and candidate digest cannot drift", () => {
+  const cases = [
+    {
+      mutate(value) {
+        value.plan.selection_ref.manifest_sha256 = "0".repeat(64);
+      },
+      pattern: /selection manifest SHA-256 does not match/,
+    },
+    {
+      mutate(value) {
+        value.selection.run.attempt += 1;
+      },
+      pattern: /selection.*run\.attempt|selection run does not match/,
+    },
+    {
+      mutate(value) {
+        value.reports[0].source.tree = "0".repeat(40);
+      },
+      pattern: /source SHA\/tree does not match the selection/,
+    },
+    {
+      mutate(value) {
+        value.producerManifest.producers[0].source.sha = "0".repeat(40);
+      },
+      pattern: /projected SHA\/tree does not match the selection/,
+    },
+    {
+      mutate(value) {
+        value.reports[0].correlation_nonce = "0".repeat(64);
+      },
+      pattern: /correlation_nonce does not match the current qualification/,
+    },
+    {
+      mutate(value) {
+        value.producerManifest.correlation_nonce = "0".repeat(64);
+        value.producerManifest.producers[0].correlation_nonce = "0".repeat(64);
+      },
+      pattern: /producer manifest correlation_nonce does not match/,
+    },
+    {
+      mutate(value) {
+        reportByIdentity(
+          value,
+          "release.migration/default/candidate_artifact",
+        ).candidate_digest = `sha256:${"0".repeat(64)}`;
+      },
+      pattern: /candidate digest does not match the selection/,
+    },
+  ];
+  for (const { mutate, pattern } of cases) {
+    const value = fixture();
+    mutate(value);
+    expectQualificationError(() => evaluate(value), pattern);
+  }
 });
 
-test("zero, skipped, failed, or arithmetically hollow native evidence blocks", () => {
+test("trusted event and repository identity cannot be substituted", () => {
+  {
+    const value = fixture();
+    value.producerManifest.producers[0].event.kind = "push";
+    expectQualificationError(
+      () => evaluate(value),
+      /trusted producer event identity does not match the qualification event/,
+    );
+  }
+  {
+    const value = fixture();
+    value.producerManifest.producers[0].event.projected_sha = "0".repeat(40);
+    expectQualificationError(
+      () => evaluate(value),
+      /trusted producer event identity does not match the qualification event/,
+    );
+  }
+  {
+    const value = fixture();
+    value.producerManifest.producers[0].repository = "example/other";
+    expectQualificationError(
+      () => evaluate(value),
+      /trusted producer repository does not match the qualification repository/,
+    );
+  }
+});
+
+test("producer run, artifact identity, bundle name, bundle digest, and entry digest are bound", () => {
+  const cases = [
+    {
+      mutate(value) {
+        value.reports[0].producer.run.id = "999";
+        value.reports[0].producer.artifact.name = nativeArtifactName(
+          WORKFLOW,
+          value.reports[0].producer.run,
+        );
+      },
+      pattern: /producer run identity does not match the trusted workflow run/,
+    },
+    {
+      mutate(value) {
+        value.reports[0].producer.artifact.id = "999";
+      },
+      pattern: /trusted artifact 999 is missing/,
+    },
+    {
+      mutate(value) {
+        value.reports[0].producer.artifact.name = "ci-native-wrong-801-3";
+      },
+      pattern: /producer\.artifact\.name must be/,
+    },
+    {
+      mutate(value) {
+        value.reports[0].producer.artifact.sha256 = "0".repeat(64);
+      },
+      pattern: /artifact name or SHA-256 does not match trusted API provenance/,
+    },
+    {
+      mutate(value) {
+        value.reports[0].producer.artifact.entry_sha256 = "0".repeat(64);
+      },
+      pattern: /entry SHA-256 does not match trusted provenance/,
+    },
+    {
+      mutate(value) {
+        value.producerManifest.producers[0].artifacts[0].entries.shift();
+      },
+      pattern: /trusted native bundle entry is missing/,
+    },
+  ];
+  for (const { mutate, pattern } of cases) {
+    const value = fixture();
+    mutate(value);
+    expectQualificationError(() => evaluate(value), pattern);
+  }
+});
+
+test("zero, skipped, failed, and every non-success native report conclusion block", () => {
   for (const evidence of [
     { executed: 0, passed: 0, failed: 0, skipped: 0 },
     { executed: 3, passed: 2, failed: 0, skipped: 1 },
     { executed: 3, passed: 2, failed: 1, skipped: 0 },
-    { executed: 3, passed: 2, failed: 0, skipped: 0 },
   ]) {
     const value = fixture();
-    Object.assign(value.index.records[0].evidence, evidence);
-    assert.throws(() => evaluate(value), /native/);
-  }
-});
-
-test("candidate digest mismatch blocks source index and artifact report variants", () => {
-  {
-    const value = fixture();
-    value.index.candidate_digest = `sha256:${"0".repeat(64)}`;
-    assert.throws(() => evaluate(value), /index candidate digest/);
-  }
-  {
-    const value = fixture();
-    const artifact = value.index.records.find(
-      (record) => record.lane_id === "migration.e2e" && record.invocation_mode === "candidate_artifact",
+    Object.assign(value.reports[0].evidence, evidence);
+    expectQualificationError(
+      () => evaluate(value),
+      /zero tests\/checks executed|all-executed, all-passed result|successful report cannot carry failed evidence/,
     );
-    artifact.candidate_digest = `sha256:${"1".repeat(64)}`;
-    assert.throws(() => evaluate(value), /candidate digest does not match/);
+  }
+  for (const conclusion of NON_SUCCESS_CONCLUSIONS) {
+    const value = fixture();
+    value.reports[0].conclusion = conclusion;
+    expectQualificationError(
+      () => evaluate(value),
+      new RegExp(`conclusion ${conclusion} is not success`),
+    );
   }
 });
 
-test("wrong SHA/tree, malformed provenance, and run mismatch each block", () => {
-  for (const mutate of [
-    (value) => {
-      value.index.records[0].source.tree = "2".repeat(40);
+test("stale selection, nonce, producer attempt, and artifact-entry replays block", () => {
+  const cases = [
+    {
+      mutate(value) {
+        value.reports[0].selection_ref.run.id = "999";
+      },
+      pattern: /selection_ref does not match the current selection/,
     },
-    (value) => {
-      value.index.records[0].trust.artifact_digest = "bad";
+    {
+      mutate(value) {
+        value.reports[0].selection_ref.manifest_sha256 = "0".repeat(64);
+      },
+      pattern: /selection_ref does not match the current selection/,
     },
-    (value) => {
-      value.index.records[0].trust.run_id = "999";
+    {
+      mutate(value) {
+        value.reports[0].correlation_nonce = "0".repeat(64);
+      },
+      pattern: /correlation_nonce does not match the current qualification/,
     },
-  ]) {
+    {
+      mutate(value) {
+        value.reports[0].producer.run.attempt = 2;
+        value.reports[0].producer.artifact.name = nativeArtifactName(
+          WORKFLOW,
+          value.reports[0].producer.run,
+        );
+      },
+      pattern: /producer run identity does not match the trusted workflow run/,
+    },
+    {
+      mutate(value) {
+        value.reports[0].producer.artifact.entry_sha256 = "0".repeat(64);
+      },
+      pattern: /entry SHA-256 does not match trusted provenance/,
+    },
+  ];
+  for (const { mutate, pattern } of cases) {
     const value = fixture();
     mutate(value);
-    assert.throws(() => evaluate(value), QualificationError);
+    expectQualificationError(() => evaluate(value), pattern);
   }
 });
 
-test("missing or stale correlation is rejected before reports can qualify", () => {
+test("the hard qualification window rejects early and late joins", () => {
   {
     const value = fixture();
-    value.index.correlation_nonce = "f".repeat(64);
-    assert.throws(() => evaluate(value), /correlation nonce/);
-  }
-  {
-    const value = fixture();
-    delete value.index.correlation_nonce;
-    assert.throws(() => evaluate(value), /correlation_nonce/);
-  }
-});
-
-test("promotion rejects malformed, incomplete, hollow, and stale attestations", () => {
-  const baseline = evaluate(fixture());
-  for (const [name, mutate] of [
-    ["malformed candidate file", (value) => { delete value.candidate.files[0].sha256; }],
-    ["incomplete roster", (value) => { value.lanes = value.lanes.filter((lane) => !lane.identity.includes("candidate_artifact")); }],
-    ["hollow native evidence", (value) => { value.lanes[0].evidence.executed = 0; value.lanes[0].evidence.passed = 0; }],
-    ["stale correlation", (value) => { value.qualification.correlation_nonce = "0".repeat(64); }],
-    ["late completion", (value) => { value.qualification.completed_at_ms = value.qualification.deadline_at_ms + 1; }],
-  ]) {
-    const attestation = structuredClone(baseline);
-    mutate(attestation);
-    assert.throws(
-      () => validateAttestation(attestation, {
-        sha: SHA,
-        tree: TREE,
-        candidateDigest: CANDIDATE,
-        correlationNonce: NONCE,
-      }, registry),
-      QualificationError,
-      name,
+    value.nowMs = value.plan.started_at_ms - 1;
+    expectQualificationError(
+      () => evaluate(value),
+      /completed before it started/,
     );
   }
-});
-
-test("the 120-minute deadline rejects late join and late lane completion", () => {
   {
     const value = fixture();
     value.nowMs = value.plan.started_at_ms + RELEASE_QUALIFICATION_LIMIT_MS + 1;
-    assert.throws(() => evaluate(value), /qualification timed out/);
+    expectQualificationError(() => evaluate(value), /qualification timed out/);
   }
-  {
-    const value = fixture();
-    value.index.records[0].trust.completed_at_ms = value.plan.deadline_at_ms + 1;
-    assert.throws(() => evaluate(value), /completed after the qualification deadline/);
+});
+
+test("attestation verification rejects provenance, roster, candidate, and deadline tampering", () => {
+  const value = fixture();
+  const baseline = evaluate(value);
+  const cases = [
+    {
+      mutate(attestation) {
+        attestation.candidate.image_digest = `sha256:${"0".repeat(64)}`;
+      },
+      pattern: /candidate\.image_digest/,
+    },
+    {
+      mutate(attestation) {
+        attestation.qualification.selection_ref.manifest_sha256 = "0".repeat(64);
+      },
+      pattern: /selection_ref\.manifest_sha256/,
+    },
+    {
+      mutate(attestation) {
+        attestation.qualification.event.kind = "push";
+      },
+      pattern: /qualification event does not match expected event/,
+    },
+    {
+      mutate(attestation) {
+        attestation.qualification.repository = "example/other";
+      },
+      pattern: /qualification\.repository/,
+    },
+    {
+      mutate(attestation) {
+        attestation.qualification.completed_at_ms =
+          attestation.qualification.deadline_at_ms + 1;
+      },
+      pattern: /completion is outside its qualification window/,
+    },
+    {
+      mutate(attestation) {
+        attestation.lanes.shift();
+      },
+      pattern: /exactly 45 identities|missing release lane|quickstart proof/,
+    },
+    {
+      mutate(attestation) {
+        attestation.lanes[0].producer.job_database_id = "bad";
+      },
+      pattern: /job_database_id has invalid value/,
+    },
+    {
+      mutate(attestation) {
+        attestation.lanes[0].report_artifact.entry_sha256 = "bad";
+      },
+      pattern: /entry_sha256 has invalid value/,
+    },
+    {
+      mutate(attestation) {
+        attestation.lanes[0].evidence.executed = 0;
+        attestation.lanes[0].evidence.passed = 0;
+      },
+      pattern: /positive all-passed native result/,
+    },
+  ];
+  for (const { mutate, pattern } of cases) {
+    const attestation = structuredClone(baseline);
+    mutate(attestation);
+    expectQualificationError(
+      () =>
+        validateAttestation(
+          attestation,
+          expectedAttestation(value),
+          value.registry,
+        ),
+      pattern,
+    );
   }
-  {
-    const value = fixture();
-    value.index.records[0].trust.completed_at_ms = value.plan.started_at_ms - 1;
-    assert.throws(() => evaluate(value), /completed before qualification started/);
-  }
+});
+
+test("finite registry growth fails until the explicit 45-invocation contract is reviewed", () => {
+  const value = fixture();
+  value.registry.lanes.push(fixtureLane("quality.newlane", 90));
+  value.registry.lanes.sort((left, right) => left.id.localeCompare(right.id));
+  expectQualificationError(
+    () => releaseLaneRoster(value.registry),
+    /must contain exactly 45 invocations; registry produced 46/,
+  );
 });

--- a/.github/scripts/release-qualification.test.mjs
+++ b/.github/scripts/release-qualification.test.mjs
@@ -1,0 +1,741 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import {
+  nativeArtifactName,
+  selectionManifestSHA256,
+} from "./ci-lane-contract.mjs";
+import {
+  QualificationError,
+  QUICKSTART_IDENTITY,
+  RELEASE_QUALIFICATION_INVOCATIONS,
+  RELEASE_QUALIFICATION_LIMIT_MS,
+  createPlan,
+  createReleaseSelection,
+  evaluateQualification,
+  releaseLaneRoster,
+  validateAttestation,
+} from "./release-qualification.mjs";
+
+const SHA = "a".repeat(40);
+const TREE = "b".repeat(40);
+const CANDIDATE = `sha256:${"c".repeat(64)}`;
+const IMAGE = `sha256:${"d".repeat(64)}`;
+const NONCE = "e".repeat(64);
+const REPOSITORY = "example/project";
+const WORKFLOW = ".github/workflows/qualification-fixture.yml";
+const SELECTION_RUN = Object.freeze({ id: "321", attempt: 2 });
+const PRODUCER_RUN = Object.freeze({ id: "801", attempt: 3 });
+const EVENT = Object.freeze({
+  kind: "workflow_dispatch",
+  pr_number: null,
+  event_head_sha: SHA,
+  event_base_sha: null,
+  projected_sha: SHA,
+});
+const NON_SUCCESS_CONCLUSIONS = [
+  "action_required",
+  "cancelled",
+  "failure",
+  "neutral",
+  "skipped",
+  "stale",
+  "startup_failure",
+  "timed_out",
+];
+
+function fixtureLane(
+  id,
+  ordinal,
+  { artifact = false, seeded = false, advisory = false, prefix = false } = {},
+) {
+  const token = String(ordinal).padStart(2, "0");
+  const job = `job_${token}`;
+  return {
+    id,
+    executions: ["default"],
+    owner: {
+      workflow: WORKFLOW,
+      jobs: [job],
+      context_job: job,
+    },
+    context: {
+      match: prefix ? "prefix" : "exact",
+      name: `qualification-${token}`,
+      protected: id === "e2e.quickstart",
+    },
+    recipes: ["fixture"],
+    command: `run-${id}`,
+    build_tags: [],
+    risk_domains: ["release"],
+    determinism: seeded ? "seeded" : "deterministic",
+    release_posture: advisory ? "advisory" : "required",
+    applicability: { source: true, artifact },
+  };
+}
+
+function registryFixture() {
+  const lanes = [fixtureLane("e2e.quickstart", 0)];
+  for (let index = 0; index < 42; index += 1) {
+    lanes.push(
+      fixtureLane(`quality.lane${String(index).padStart(2, "0")}`, index + 1, {
+        seeded: index === 7,
+        advisory: index === 11,
+      }),
+    );
+  }
+  lanes.push(
+    fixtureLane("release.migration", 43, { artifact: true, prefix: true }),
+  );
+  lanes.sort((left, right) => left.id.localeCompare(right.id));
+  return {
+    schema_version: 1,
+    selection_schema_version: 1,
+    report_schema_version: 2,
+    lanes,
+  };
+}
+
+function entryDigest(index) {
+  return ((index % 15) + 1).toString(16).repeat(64);
+}
+
+function fixture() {
+  const registry = registryFixture();
+  const startedAtMs = 1_000_000;
+  const selection = createReleaseSelection({
+    registry,
+    source: { sha: SHA, tree: TREE },
+    candidateDigest: CANDIDATE,
+    correlationNonce: NONCE,
+    run: SELECTION_RUN,
+  });
+  const plan = createPlan({
+    registry,
+    selection,
+    eventIdentity: EVENT,
+    repository: REPOSITORY,
+    startedAtMs,
+  });
+  const roster = releaseLaneRoster(registry);
+  const artifact = {
+    id: "901",
+    name: nativeArtifactName(WORKFLOW, PRODUCER_RUN),
+    sha256: "f".repeat(64),
+    entries: roster.map((item, index) => ({
+      lane_id: item.lane_id,
+      execution_id: item.execution_id,
+      invocation_mode: item.invocation_mode,
+      sha256: entryDigest(index),
+    })),
+  };
+  const jobs = registry.lanes.map((lane, index) => ({
+    job: lane.owner.context_job,
+    name:
+      lane.context.match === "prefix"
+        ? `${lane.context.name} / default`
+        : lane.context.name,
+    database_id: String(1001 + index),
+    conclusion: "success",
+  }));
+  const reports = roster.map((item, index) => {
+    const lane = registry.lanes.find((candidate) => candidate.id === item.lane_id);
+    const nativeEntry = artifact.entries[index];
+    return {
+      schema_version: registry.report_schema_version,
+      registry_schema_version: registry.schema_version,
+      lane_id: item.lane_id,
+      execution_id: item.execution_id,
+      posture: "release",
+      source: { sha: SHA, tree: TREE },
+      candidate_digest:
+        item.invocation_mode === "candidate_artifact" ? CANDIDATE : null,
+      correlation_nonce: NONCE,
+      selection_ref: {
+        run: { ...SELECTION_RUN },
+        manifest_sha256: selectionManifestSHA256(selection),
+      },
+      producer: {
+        workflow: WORKFLOW,
+        job: lane.owner.context_job,
+        run: { ...PRODUCER_RUN },
+        artifact: {
+          id: artifact.id,
+          name: artifact.name,
+          sha256: artifact.sha256,
+          entry: `${item.lane_id}/${item.execution_id}/${item.invocation_mode}`,
+          entry_sha256: nativeEntry.sha256,
+        },
+      },
+      invocation: {
+        mode: item.invocation_mode,
+        recipe: lane.recipes[0],
+        command: lane.command,
+        build_tags: [...lane.build_tags],
+        selected_domains: [...lane.risk_domains],
+      },
+      evidence: {
+        executed: 3,
+        passed: 3,
+        failed: 0,
+        skipped: 0,
+        duration_ms: 250,
+        seed: lane.determinism === "seeded" ? "release-seed" : null,
+        corpus_id: `${item.lane_id}/${item.execution_id}/${item.invocation_mode}`,
+      },
+      conclusion: "success",
+    };
+  });
+  return {
+    registry,
+    selection,
+    plan,
+    reports,
+    producerManifest: {
+      schema_version: registry.report_schema_version,
+      correlation_nonce: NONCE,
+      selection_ref: {
+        run: { ...SELECTION_RUN },
+        manifest_sha256: selectionManifestSHA256(selection),
+      },
+      producers: [
+        {
+          workflow: WORKFLOW,
+          run: { ...PRODUCER_RUN },
+          source: { sha: SHA, tree: TREE },
+          correlation_nonce: NONCE,
+          event: { ...EVENT },
+          repository: REPOSITORY,
+          conclusion: "success",
+          jobs,
+          artifacts: [artifact],
+        },
+      ],
+    },
+    candidateManifest: {
+      image: { digest: IMAGE },
+      files: [
+        {
+          path: "app/image/index.json",
+          size: 5,
+          sha256: `sha256:${"1".repeat(64)}`,
+        },
+      ],
+    },
+    nowMs: startedAtMs + 2000,
+  };
+}
+
+function evaluate(value) {
+  return evaluateQualification({
+    registry: value.registry,
+    plan: value.plan,
+    selection: value.selection,
+    reports: value.reports,
+    producerManifest: value.producerManifest,
+    candidateManifest: value.candidateManifest,
+    nowMs: value.nowMs,
+  });
+}
+
+function expectQualificationError(fn, ...patterns) {
+  let caught;
+  try {
+    fn();
+  } catch (error) {
+    caught = error;
+  }
+  assert.ok(
+    caught instanceof QualificationError,
+    `expected QualificationError, got ${caught}`,
+  );
+  for (const pattern of patterns) assert.match(caught.message, pattern);
+  return caught;
+}
+
+function reportByIdentity(value, identity) {
+  return value.reports.find(
+    (report) =>
+      `${report.lane_id}/${report.execution_id}/${report.invocation.mode}` ===
+      identity,
+  );
+}
+
+function expectedAttestation(value) {
+  return {
+    sha: SHA,
+    tree: TREE,
+    candidateDigest: CANDIDATE,
+    imageDigest: IMAGE,
+    correlationNonce: NONCE,
+    selectionManifestSHA256: value.plan.selection_ref.manifest_sha256,
+    eventIdentity: EVENT,
+    repository: REPOSITORY,
+  };
+}
+
+test("release selection expands 44 finite lanes into exactly 45 mode-bound invocations", () => {
+  const value = fixture();
+  const roster = releaseLaneRoster(value.registry);
+  assert.equal(
+    value.selection.lanes.filter((lane) => lane.disposition === "selected").length,
+    44,
+  );
+  assert.equal(roster.length, RELEASE_QUALIFICATION_INVOCATIONS);
+  assert(roster.some((item) => `${item.lane_id}/${item.execution_id}/${item.invocation_mode}` === QUICKSTART_IDENTITY));
+  assert.deepEqual(
+    roster
+      .filter((item) => item.lane_id === "release.migration")
+      .map((item) => item.invocation_mode),
+    ["candidate_artifact", "source_tree"],
+  );
+  assert.equal(
+    value.plan.selection_ref.manifest_sha256,
+    selectionManifestSHA256(value.selection),
+  );
+});
+
+test("post-publish and observational lanes stay outside the exact finite roster", () => {
+  const value = fixture();
+  value.registry.lanes.push({
+    ...fixtureLane("monitor.public", 90, { artifact: true }),
+    applicability: { source: false, artifact: true },
+    release_posture: "post_publish",
+  });
+  value.registry.lanes.push({
+    ...fixtureLane("observation.advisory", 91, { advisory: true }),
+    determinism: "observational",
+  });
+  value.registry.lanes.sort((left, right) => left.id.localeCompare(right.id));
+  const selection = createReleaseSelection({
+    registry: value.registry,
+    source: { sha: SHA, tree: TREE },
+    candidateDigest: CANDIDATE,
+    correlationNonce: NONCE,
+    run: SELECTION_RUN,
+  });
+  assert.equal(releaseLaneRoster(value.registry).length, 45);
+  assert.equal(
+    selection.lanes.find((lane) => lane.lane_id === "monitor.public").reason,
+    "post_publish",
+  );
+  assert.equal(
+    selection.lanes.find((lane) => lane.lane_id === "observation.advisory").reason,
+    "advisory",
+  );
+});
+
+test("successful join pins candidate, selection, event, jobs, artifact entries, and quickstart", () => {
+  const value = fixture();
+  const attestation = evaluate(value);
+  assert.equal(attestation.result, "success");
+  assert.equal(attestation.candidate.digest, CANDIDATE);
+  assert.equal(attestation.candidate.image_digest, IMAGE);
+  assert.equal(attestation.qualification.invocation_count, 45);
+  assert.deepEqual(attestation.qualification.selection_ref, value.plan.selection_ref);
+  assert.deepEqual(attestation.qualification.event, EVENT);
+  assert.equal(attestation.qualification.repository, REPOSITORY);
+  assert.equal(attestation.lanes.length, 45);
+  const quickstart = attestation.lanes.find(
+    (lane) => lane.identity === QUICKSTART_IDENTITY,
+  );
+  assert(quickstart);
+  assert.equal(quickstart.producer.job_name, "qualification-00");
+  assert.equal(quickstart.producer.job_database_id, "1001");
+  assert.equal(quickstart.report_artifact.name, nativeArtifactName(WORKFLOW, PRODUCER_RUN));
+  assert.equal(quickstart.report_artifact.entry, QUICKSTART_IDENTITY);
+  assert.equal(quickstart.report_artifact.entry_sha256, entryDigest(0));
+  assert.equal(
+    validateAttestation(attestation, expectedAttestation(value), value.registry),
+    attestation,
+  );
+});
+
+test("missing, duplicate, and mode-collapsed reports fail closed", () => {
+  {
+    const value = fixture();
+    value.reports = value.reports.filter(
+      (report) =>
+        `${report.lane_id}/${report.execution_id}/${report.invocation.mode}` !==
+        QUICKSTART_IDENTITY,
+    );
+    expectQualificationError(
+      () => evaluate(value),
+      /missing report e2e\.quickstart\/default\/source_tree/,
+    );
+  }
+  {
+    const value = fixture();
+    value.reports.push(structuredClone(value.reports[0]));
+    expectQualificationError(() => evaluate(value), /duplicate report/);
+  }
+  {
+    const value = fixture();
+    value.reports = value.reports.filter(
+      (report) =>
+        !(
+          report.lane_id === "release.migration" &&
+          report.invocation.mode === "candidate_artifact"
+        ),
+    );
+    expectQualificationError(
+      () => evaluate(value),
+      /missing report release\.migration\/default\/candidate_artifact/,
+    );
+  }
+  {
+    const value = fixture();
+    const artifact = reportByIdentity(
+      value,
+      "release.migration/default/candidate_artifact",
+    );
+    artifact.invocation.mode = "source_tree";
+    expectQualificationError(
+      () => evaluate(value),
+      /source_tree report must not carry candidate_digest|duplicate report/,
+    );
+  }
+});
+
+test("trusted job display names, ambiguity, database IDs, and conclusions fail closed", () => {
+  {
+    const value = fixture();
+    value.producerManifest.producers[0].jobs[0].name = "wrong-check";
+    expectQualificationError(
+      () => evaluate(value),
+      /trusted context check name wrong-check does not match qualification-00/,
+    );
+  }
+  {
+    const value = fixture();
+    const lane = value.registry.lanes.find(
+      (candidate) => candidate.id === "release.migration",
+    );
+    value.producerManifest.producers[0].jobs.push({
+      job: lane.owner.context_job,
+      name: `${lane.context.name} / second`,
+      database_id: "9999",
+      conclusion: "success",
+    });
+    expectQualificationError(
+      () => evaluate(value),
+      /trusted context job job_43 is ambiguous/,
+    );
+  }
+  {
+    const value = fixture();
+    value.producerManifest.producers[0].jobs[1].database_id =
+      value.producerManifest.producers[0].jobs[0].database_id;
+    expectQualificationError(() => evaluate(value), /database_id is duplicated/);
+  }
+  for (const conclusion of NON_SUCCESS_CONCLUSIONS) {
+    const value = fixture();
+    value.producerManifest.producers[0].jobs[0].conclusion = conclusion;
+    expectQualificationError(
+      () => evaluate(value),
+      new RegExp(`trusted context job job_00 is ${conclusion}`),
+    );
+  }
+});
+
+test("selection digest, selection run, source, nonce, and candidate digest cannot drift", () => {
+  const cases = [
+    {
+      mutate(value) {
+        value.plan.selection_ref.manifest_sha256 = "0".repeat(64);
+      },
+      pattern: /selection manifest SHA-256 does not match/,
+    },
+    {
+      mutate(value) {
+        value.selection.run.attempt += 1;
+      },
+      pattern: /selection.*run\.attempt|selection run does not match/,
+    },
+    {
+      mutate(value) {
+        value.reports[0].source.tree = "0".repeat(40);
+      },
+      pattern: /source SHA\/tree does not match the selection/,
+    },
+    {
+      mutate(value) {
+        value.producerManifest.producers[0].source.sha = "0".repeat(40);
+      },
+      pattern: /projected SHA\/tree does not match the selection/,
+    },
+    {
+      mutate(value) {
+        value.reports[0].correlation_nonce = "0".repeat(64);
+      },
+      pattern: /correlation_nonce does not match the current qualification/,
+    },
+    {
+      mutate(value) {
+        value.producerManifest.correlation_nonce = "0".repeat(64);
+        value.producerManifest.producers[0].correlation_nonce = "0".repeat(64);
+      },
+      pattern: /producer manifest correlation_nonce does not match/,
+    },
+    {
+      mutate(value) {
+        reportByIdentity(
+          value,
+          "release.migration/default/candidate_artifact",
+        ).candidate_digest = `sha256:${"0".repeat(64)}`;
+      },
+      pattern: /candidate digest does not match the selection/,
+    },
+  ];
+  for (const { mutate, pattern } of cases) {
+    const value = fixture();
+    mutate(value);
+    expectQualificationError(() => evaluate(value), pattern);
+  }
+});
+
+test("trusted event and repository identity cannot be substituted", () => {
+  {
+    const value = fixture();
+    value.producerManifest.producers[0].event.kind = "push";
+    expectQualificationError(
+      () => evaluate(value),
+      /trusted producer event identity does not match the qualification event/,
+    );
+  }
+  {
+    const value = fixture();
+    value.producerManifest.producers[0].event.projected_sha = "0".repeat(40);
+    expectQualificationError(
+      () => evaluate(value),
+      /trusted producer event identity does not match the qualification event/,
+    );
+  }
+  {
+    const value = fixture();
+    value.producerManifest.producers[0].repository = "example/other";
+    expectQualificationError(
+      () => evaluate(value),
+      /trusted producer repository does not match the qualification repository/,
+    );
+  }
+});
+
+test("producer run, artifact identity, bundle name, bundle digest, and entry digest are bound", () => {
+  const cases = [
+    {
+      mutate(value) {
+        value.reports[0].producer.run.id = "999";
+        value.reports[0].producer.artifact.name = nativeArtifactName(
+          WORKFLOW,
+          value.reports[0].producer.run,
+        );
+      },
+      pattern: /producer run identity does not match the trusted workflow run/,
+    },
+    {
+      mutate(value) {
+        value.reports[0].producer.artifact.id = "999";
+      },
+      pattern: /trusted artifact 999 is missing/,
+    },
+    {
+      mutate(value) {
+        value.reports[0].producer.artifact.name = "ci-native-wrong-801-3";
+      },
+      pattern: /producer\.artifact\.name must be/,
+    },
+    {
+      mutate(value) {
+        value.reports[0].producer.artifact.sha256 = "0".repeat(64);
+      },
+      pattern: /artifact name or SHA-256 does not match trusted API provenance/,
+    },
+    {
+      mutate(value) {
+        value.reports[0].producer.artifact.entry_sha256 = "0".repeat(64);
+      },
+      pattern: /entry SHA-256 does not match trusted provenance/,
+    },
+    {
+      mutate(value) {
+        value.producerManifest.producers[0].artifacts[0].entries.shift();
+      },
+      pattern: /trusted native bundle entry is missing/,
+    },
+  ];
+  for (const { mutate, pattern } of cases) {
+    const value = fixture();
+    mutate(value);
+    expectQualificationError(() => evaluate(value), pattern);
+  }
+});
+
+test("zero, skipped, failed, and every non-success native report conclusion block", () => {
+  for (const evidence of [
+    { executed: 0, passed: 0, failed: 0, skipped: 0 },
+    { executed: 3, passed: 2, failed: 0, skipped: 1 },
+    { executed: 3, passed: 2, failed: 1, skipped: 0 },
+  ]) {
+    const value = fixture();
+    Object.assign(value.reports[0].evidence, evidence);
+    expectQualificationError(
+      () => evaluate(value),
+      /zero tests\/checks executed|all-executed, all-passed result|successful report cannot carry failed evidence/,
+    );
+  }
+  for (const conclusion of NON_SUCCESS_CONCLUSIONS) {
+    const value = fixture();
+    value.reports[0].conclusion = conclusion;
+    expectQualificationError(
+      () => evaluate(value),
+      new RegExp(`conclusion ${conclusion} is not success`),
+    );
+  }
+});
+
+test("stale selection, nonce, producer attempt, and artifact-entry replays block", () => {
+  const cases = [
+    {
+      mutate(value) {
+        value.reports[0].selection_ref.run.id = "999";
+      },
+      pattern: /selection_ref does not match the current selection/,
+    },
+    {
+      mutate(value) {
+        value.reports[0].selection_ref.manifest_sha256 = "0".repeat(64);
+      },
+      pattern: /selection_ref does not match the current selection/,
+    },
+    {
+      mutate(value) {
+        value.reports[0].correlation_nonce = "0".repeat(64);
+      },
+      pattern: /correlation_nonce does not match the current qualification/,
+    },
+    {
+      mutate(value) {
+        value.reports[0].producer.run.attempt = 2;
+        value.reports[0].producer.artifact.name = nativeArtifactName(
+          WORKFLOW,
+          value.reports[0].producer.run,
+        );
+      },
+      pattern: /producer run identity does not match the trusted workflow run/,
+    },
+    {
+      mutate(value) {
+        value.reports[0].producer.artifact.entry_sha256 = "0".repeat(64);
+      },
+      pattern: /entry SHA-256 does not match trusted provenance/,
+    },
+  ];
+  for (const { mutate, pattern } of cases) {
+    const value = fixture();
+    mutate(value);
+    expectQualificationError(() => evaluate(value), pattern);
+  }
+});
+
+test("the hard qualification window rejects early and late joins", () => {
+  {
+    const value = fixture();
+    value.nowMs = value.plan.started_at_ms - 1;
+    expectQualificationError(
+      () => evaluate(value),
+      /completed before it started/,
+    );
+  }
+  {
+    const value = fixture();
+    value.nowMs = value.plan.started_at_ms + RELEASE_QUALIFICATION_LIMIT_MS + 1;
+    expectQualificationError(() => evaluate(value), /qualification timed out/);
+  }
+});
+
+test("attestation verification rejects provenance, roster, candidate, and deadline tampering", () => {
+  const value = fixture();
+  const baseline = evaluate(value);
+  const cases = [
+    {
+      mutate(attestation) {
+        attestation.candidate.image_digest = `sha256:${"0".repeat(64)}`;
+      },
+      pattern: /candidate\.image_digest/,
+    },
+    {
+      mutate(attestation) {
+        attestation.qualification.selection_ref.manifest_sha256 = "0".repeat(64);
+      },
+      pattern: /selection_ref\.manifest_sha256/,
+    },
+    {
+      mutate(attestation) {
+        attestation.qualification.event.kind = "push";
+      },
+      pattern: /qualification event does not match expected event/,
+    },
+    {
+      mutate(attestation) {
+        attestation.qualification.repository = "example/other";
+      },
+      pattern: /qualification\.repository/,
+    },
+    {
+      mutate(attestation) {
+        attestation.qualification.completed_at_ms =
+          attestation.qualification.deadline_at_ms + 1;
+      },
+      pattern: /completion is outside its qualification window/,
+    },
+    {
+      mutate(attestation) {
+        attestation.lanes.shift();
+      },
+      pattern: /exactly 45 identities|missing release lane|quickstart proof/,
+    },
+    {
+      mutate(attestation) {
+        attestation.lanes[0].producer.job_database_id = "bad";
+      },
+      pattern: /job_database_id has invalid value/,
+    },
+    {
+      mutate(attestation) {
+        attestation.lanes[0].report_artifact.entry_sha256 = "bad";
+      },
+      pattern: /entry_sha256 has invalid value/,
+    },
+    {
+      mutate(attestation) {
+        attestation.lanes[0].evidence.executed = 0;
+        attestation.lanes[0].evidence.passed = 0;
+      },
+      pattern: /positive all-passed native result/,
+    },
+  ];
+  for (const { mutate, pattern } of cases) {
+    const attestation = structuredClone(baseline);
+    mutate(attestation);
+    expectQualificationError(
+      () =>
+        validateAttestation(
+          attestation,
+          expectedAttestation(value),
+          value.registry,
+        ),
+      pattern,
+    );
+  }
+});
+
+test("finite registry growth fails until the explicit 45-invocation contract is reviewed", () => {
+  const value = fixture();
+  value.registry.lanes.push(fixtureLane("quality.newlane", 90));
+  value.registry.lanes.sort((left, right) => left.id.localeCompare(right.id));
+  expectQualificationError(
+    () => releaseLaneRoster(value.registry),
+    /must contain exactly 45 invocations; registry produced 46/,
+  );
+});

--- a/.github/scripts/release-qualification.test.mjs
+++ b/.github/scripts/release-qualification.test.mjs
@@ -2,16 +2,9 @@ import assert from "node:assert/strict";
 import { test } from "node:test";
 
 import {
-  nativeArtifactName,
-  selectionManifestSHA256,
-} from "./ci-lane-contract.mjs";
-import {
   QualificationError,
-  QUICKSTART_IDENTITY,
-  RELEASE_QUALIFICATION_INVOCATIONS,
   RELEASE_QUALIFICATION_LIMIT_MS,
   createPlan,
-  createReleaseSelection,
   evaluateQualification,
   releaseLaneRoster,
   validateAttestation,
@@ -20,207 +13,83 @@ import {
 const SHA = "a".repeat(40);
 const TREE = "b".repeat(40);
 const CANDIDATE = `sha256:${"c".repeat(64)}`;
-const IMAGE = `sha256:${"d".repeat(64)}`;
+const REPORT_DIGEST = `sha256:${"d".repeat(64)}`;
 const NONCE = "e".repeat(64);
-const REPOSITORY = "example/project";
-const WORKFLOW = ".github/workflows/qualification-fixture.yml";
-const SELECTION_RUN = Object.freeze({ id: "321", attempt: 2 });
-const PRODUCER_RUN = Object.freeze({ id: "801", attempt: 3 });
-const EVENT = Object.freeze({
-  kind: "workflow_dispatch",
-  pr_number: null,
-  event_head_sha: SHA,
-  event_base_sha: null,
-  projected_sha: SHA,
-});
-const NON_SUCCESS_CONCLUSIONS = [
-  "action_required",
-  "cancelled",
-  "failure",
-  "neutral",
-  "skipped",
-  "stale",
-  "startup_failure",
-  "timed_out",
-];
 
-function fixtureLane(
-  id,
-  ordinal,
-  { artifact = false, seeded = false, advisory = false, prefix = false } = {},
-) {
-  const token = String(ordinal).padStart(2, "0");
-  const job = `job_${token}`;
+function lane(id, { artifact = false, seeded = false } = {}) {
   return {
     id,
     executions: ["default"],
     owner: {
-      workflow: WORKFLOW,
-      jobs: [job],
-      context_job: job,
+      workflow: `.github/workflows/${id.replaceAll(".", "-")}.yml`,
+      context_job: id.replaceAll(".", "-"),
     },
-    context: {
-      match: prefix ? "prefix" : "exact",
-      name: `qualification-${token}`,
-      protected: id === "e2e.quickstart",
-    },
-    recipes: ["fixture"],
-    command: `run-${id}`,
-    build_tags: [],
-    risk_domains: ["release"],
     determinism: seeded ? "seeded" : "deterministic",
-    release_posture: advisory ? "advisory" : "required",
+    release_posture: "required",
     applicability: { source: true, artifact },
   };
 }
 
-function registryFixture() {
-  const lanes = [fixtureLane("e2e.quickstart", 0)];
-  for (let index = 0; index < 42; index += 1) {
-    lanes.push(
-      fixtureLane(`quality.lane${String(index).padStart(2, "0")}`, index + 1, {
-        seeded: index === 7,
-        advisory: index === 11,
-      }),
-    );
-  }
-  lanes.push(
-    fixtureLane("release.migration", 43, { artifact: true, prefix: true }),
-  );
-  lanes.sort((left, right) => left.id.localeCompare(right.id));
-  return {
-    schema_version: 1,
-    selection_schema_version: 1,
-    report_schema_version: 2,
-    lanes,
-  };
-}
-
-function entryDigest(index) {
-  return ((index % 15) + 1).toString(16).repeat(64);
-}
+const registry = {
+  schema_version: 1,
+  lanes: [lane("e2e.quickstart"), lane("migration.e2e", { artifact: true })],
+};
 
 function fixture() {
-  const registry = registryFixture();
   const startedAtMs = 1_000_000;
-  const selection = createReleaseSelection({
+  const plan = createPlan({
     registry,
     source: { sha: SHA, tree: TREE },
     candidateDigest: CANDIDATE,
     correlationNonce: NONCE,
-    run: SELECTION_RUN,
-  });
-  const plan = createPlan({
-    registry,
-    selection,
-    eventIdentity: EVENT,
-    repository: REPOSITORY,
     startedAtMs,
   });
-  const roster = releaseLaneRoster(registry);
-  const artifact = {
-    id: "901",
-    name: nativeArtifactName(WORKFLOW, PRODUCER_RUN),
-    sha256: "f".repeat(64),
-    entries: roster.map((item, index) => ({
-      lane_id: item.lane_id,
-      execution_id: item.execution_id,
-      invocation_mode: item.invocation_mode,
-      sha256: entryDigest(index),
-    })),
-  };
-  const jobs = registry.lanes.map((lane, index) => ({
-    job: lane.owner.context_job,
-    name:
-      lane.context.match === "prefix"
-        ? `${lane.context.name} / default`
-        : lane.context.name,
-    database_id: String(1001 + index),
+  const records = plan.lanes.map((planned, index) => ({
+    lane_id: planned.lane_id,
+    execution_id: planned.execution_id,
+    source: { sha: SHA, tree: TREE },
+    candidate_digest:
+      planned.invocation_mode === "candidate_artifact" ? CANDIDATE : null,
+    producer: {
+      workflow: planned.producer.workflow,
+      job: planned.producer.job,
+      run_id: String(100 + index),
+      run_attempt: 1,
+    },
+    invocation_mode: planned.invocation_mode,
     conclusion: "success",
+    evidence: {
+      executed: 3,
+      passed: 3,
+      failed: 0,
+      skipped: 0,
+      duration_ms: 250,
+      seed: null,
+      corpus_id: `${planned.lane_id}-native`,
+    },
+    trust: {
+      artifact_id: String(900 + index),
+      artifact_digest: REPORT_DIGEST,
+      head_sha: SHA,
+      head_tree: TREE,
+      run_id: String(100 + index),
+      run_attempt: 1,
+      job_conclusion: "success",
+      completed_at_ms: startedAtMs + 1000 + index,
+    },
   }));
-  const reports = roster.map((item, index) => {
-    const lane = registry.lanes.find((candidate) => candidate.id === item.lane_id);
-    const nativeEntry = artifact.entries[index];
-    return {
-      schema_version: registry.report_schema_version,
-      registry_schema_version: registry.schema_version,
-      lane_id: item.lane_id,
-      execution_id: item.execution_id,
-      posture: "release",
-      source: { sha: SHA, tree: TREE },
-      candidate_digest:
-        item.invocation_mode === "candidate_artifact" ? CANDIDATE : null,
-      correlation_nonce: NONCE,
-      selection_ref: {
-        run: { ...SELECTION_RUN },
-        manifest_sha256: selectionManifestSHA256(selection),
-      },
-      producer: {
-        workflow: WORKFLOW,
-        job: lane.owner.context_job,
-        run: { ...PRODUCER_RUN },
-        artifact: {
-          id: artifact.id,
-          name: artifact.name,
-          sha256: artifact.sha256,
-          entry: `${item.lane_id}/${item.execution_id}/${item.invocation_mode}`,
-          entry_sha256: nativeEntry.sha256,
-        },
-      },
-      invocation: {
-        mode: item.invocation_mode,
-        recipe: lane.recipes[0],
-        command: lane.command,
-        build_tags: [...lane.build_tags],
-        selected_domains: [...lane.risk_domains],
-      },
-      evidence: {
-        executed: 3,
-        passed: 3,
-        failed: 0,
-        skipped: 0,
-        duration_ms: 250,
-        seed: lane.determinism === "seeded" ? "release-seed" : null,
-        corpus_id: `${item.lane_id}/${item.execution_id}/${item.invocation_mode}`,
-      },
-      conclusion: "success",
-    };
-  });
   return {
-    registry,
-    selection,
     plan,
-    reports,
-    producerManifest: {
-      schema_version: registry.report_schema_version,
+    index: {
+      schema_version: 1,
+      source: { sha: SHA, tree: TREE },
+      candidate_digest: CANDIDATE,
       correlation_nonce: NONCE,
-      selection_ref: {
-        run: { ...SELECTION_RUN },
-        manifest_sha256: selectionManifestSHA256(selection),
-      },
-      producers: [
-        {
-          workflow: WORKFLOW,
-          run: { ...PRODUCER_RUN },
-          source: { sha: SHA, tree: TREE },
-          correlation_nonce: NONCE,
-          event: { ...EVENT },
-          repository: REPOSITORY,
-          conclusion: "success",
-          jobs,
-          artifacts: [artifact],
-        },
-      ],
+      records,
     },
     candidateManifest: {
-      image: { digest: IMAGE },
-      files: [
-        {
-          path: "app/image/index.json",
-          size: 5,
-          sha256: `sha256:${"1".repeat(64)}`,
-        },
-      ],
+      image: { digest: `sha256:${"e".repeat(64)}` },
+      files: [{ path: "app/image/index.json", size: 5, sha256: `sha256:${"f".repeat(64)}` }],
     },
     nowMs: startedAtMs + 2000,
   };
@@ -228,514 +97,193 @@ function fixture() {
 
 function evaluate(value) {
   return evaluateQualification({
-    registry: value.registry,
+    registry,
     plan: value.plan,
-    selection: value.selection,
-    reports: value.reports,
-    producerManifest: value.producerManifest,
+    evidenceIndex: value.index,
     candidateManifest: value.candidateManifest,
     nowMs: value.nowMs,
   });
 }
 
-function expectQualificationError(fn, ...patterns) {
-  let caught;
-  try {
-    fn();
-  } catch (error) {
-    caught = error;
-  }
-  assert.ok(
-    caught instanceof QualificationError,
-    `expected QualificationError, got ${caught}`,
-  );
-  for (const pattern of patterns) assert.match(caught.message, pattern);
-  return caught;
-}
-
-function reportByIdentity(value, identity) {
-  return value.reports.find(
-    (report) =>
-      `${report.lane_id}/${report.execution_id}/${report.invocation.mode}` ===
-      identity,
-  );
-}
-
-function expectedAttestation(value) {
-  return {
-    sha: SHA,
-    tree: TREE,
-    candidateDigest: CANDIDATE,
-    imageDigest: IMAGE,
-    correlationNonce: NONCE,
-    selectionManifestSHA256: value.plan.selection_ref.manifest_sha256,
-    eventIdentity: EVENT,
-    repository: REPOSITORY,
+test("release roster includes every finite pre-publication source/artifact lane", () => {
+  const extended = {
+    ...registry,
+    lanes: [
+      ...registry.lanes,
+      { ...lane("advisory.seed", { seeded: true }), release_posture: "advisory" },
+      { ...lane("public.monitor"), release_posture: "post_publish" },
+      { ...lane("observation"), determinism: "observational" },
+    ],
   };
-}
-
-test("release selection expands 44 finite lanes into exactly 45 mode-bound invocations", () => {
-  const value = fixture();
-  const roster = releaseLaneRoster(value.registry);
-  assert.equal(
-    value.selection.lanes.filter((lane) => lane.disposition === "selected").length,
-    44,
-  );
-  assert.equal(roster.length, RELEASE_QUALIFICATION_INVOCATIONS);
-  assert(roster.some((item) => `${item.lane_id}/${item.execution_id}/${item.invocation_mode}` === QUICKSTART_IDENTITY));
   assert.deepEqual(
-    roster
-      .filter((item) => item.lane_id === "release.migration")
-      .map((item) => item.invocation_mode),
-    ["candidate_artifact", "source_tree"],
-  );
-  assert.equal(
-    value.plan.selection_ref.manifest_sha256,
-    selectionManifestSHA256(value.selection),
-  );
-});
-
-test("post-publish and observational lanes stay outside the exact finite roster", () => {
-  const value = fixture();
-  value.registry.lanes.push({
-    ...fixtureLane("monitor.public", 90, { artifact: true }),
-    applicability: { source: false, artifact: true },
-    release_posture: "post_publish",
-  });
-  value.registry.lanes.push({
-    ...fixtureLane("observation.advisory", 91, { advisory: true }),
-    determinism: "observational",
-  });
-  value.registry.lanes.sort((left, right) => left.id.localeCompare(right.id));
-  const selection = createReleaseSelection({
-    registry: value.registry,
-    source: { sha: SHA, tree: TREE },
-    candidateDigest: CANDIDATE,
-    correlationNonce: NONCE,
-    run: SELECTION_RUN,
-  });
-  assert.equal(releaseLaneRoster(value.registry).length, 45);
-  assert.equal(
-    selection.lanes.find((lane) => lane.lane_id === "monitor.public").reason,
-    "post_publish",
-  );
-  assert.equal(
-    selection.lanes.find((lane) => lane.lane_id === "observation.advisory").reason,
-    "advisory",
+    releaseLaneRoster(extended).map((item) => `${item.lane_id}/${item.invocation_mode}`),
+    [
+      "advisory.seed/source_tree",
+      "e2e.quickstart/source_tree",
+      "migration.e2e/candidate_artifact",
+      "migration.e2e/source_tree",
+    ],
   );
 });
 
-test("successful join pins candidate, selection, event, jobs, artifact entries, and quickstart", () => {
+test("successful join attests the exact tree, candidate, image, files, and quickstart", () => {
   const value = fixture();
   const attestation = evaluate(value);
   assert.equal(attestation.result, "success");
+  assert.deepEqual(attestation.source, { sha: SHA, tree: TREE });
   assert.equal(attestation.candidate.digest, CANDIDATE);
-  assert.equal(attestation.candidate.image_digest, IMAGE);
-  assert.equal(attestation.qualification.invocation_count, 45);
-  assert.deepEqual(attestation.qualification.selection_ref, value.plan.selection_ref);
-  assert.deepEqual(attestation.qualification.event, EVENT);
-  assert.equal(attestation.qualification.repository, REPOSITORY);
-  assert.equal(attestation.lanes.length, 45);
-  const quickstart = attestation.lanes.find(
-    (lane) => lane.identity === QUICKSTART_IDENTITY,
-  );
-  assert(quickstart);
-  assert.equal(quickstart.producer.job_name, "qualification-00");
-  assert.equal(quickstart.producer.job_database_id, "1001");
-  assert.equal(quickstart.report_artifact.name, nativeArtifactName(WORKFLOW, PRODUCER_RUN));
-  assert.equal(quickstart.report_artifact.entry, QUICKSTART_IDENTITY);
-  assert.equal(quickstart.report_artifact.entry_sha256, entryDigest(0));
-  assert.equal(
-    validateAttestation(attestation, expectedAttestation(value), value.registry),
+  assert.equal(attestation.lanes.length, 3);
+  assert(attestation.lanes.some((item) => item.identity === "e2e.quickstart/default/source_tree"));
+  assert(attestation.lanes.some((item) => item.identity === "migration.e2e/default/source_tree"));
+  assert(attestation.lanes.some((item) => item.identity === "migration.e2e/default/candidate_artifact"));
+  assert.deepEqual(
+    validateAttestation(attestation, {
+      sha: SHA,
+      tree: TREE,
+      candidateDigest: CANDIDATE,
+      correlationNonce: NONCE,
+    }),
     attestation,
   );
 });
 
-test("missing, duplicate, and mode-collapsed reports fail closed", () => {
-  {
+test("failed, cancelled, skipped, neutral, timed-out, and stale conclusions block", () => {
+  for (const conclusion of [
+    "failure",
+    "cancelled",
+    "skipped",
+    "neutral",
+    "timed_out",
+    "stale",
+  ]) {
     const value = fixture();
-    value.reports = value.reports.filter(
-      (report) =>
-        `${report.lane_id}/${report.execution_id}/${report.invocation.mode}` !==
-        QUICKSTART_IDENTITY,
-    );
-    expectQualificationError(
+    value.index.records[0].conclusion = conclusion;
+    assert.throws(
       () => evaluate(value),
-      /missing report e2e\.quickstart\/default\/source_tree/,
-    );
-  }
-  {
-    const value = fixture();
-    value.reports.push(structuredClone(value.reports[0]));
-    expectQualificationError(() => evaluate(value), /duplicate report/);
-  }
-  {
-    const value = fixture();
-    value.reports = value.reports.filter(
-      (report) =>
-        !(
-          report.lane_id === "release.migration" &&
-          report.invocation.mode === "candidate_artifact"
-        ),
-    );
-    expectQualificationError(
-      () => evaluate(value),
-      /missing report release\.migration\/default\/candidate_artifact/,
-    );
-  }
-  {
-    const value = fixture();
-    const artifact = reportByIdentity(
-      value,
-      "release.migration/default/candidate_artifact",
-    );
-    artifact.invocation.mode = "source_tree";
-    expectQualificationError(
-      () => evaluate(value),
-      /source_tree report must not carry candidate_digest|duplicate report/,
+      (error) => error instanceof QualificationError && error.message.includes(conclusion),
+      conclusion,
     );
   }
 });
 
-test("trusted job display names, ambiguity, database IDs, and conclusions fail closed", () => {
-  {
-    const value = fixture();
-    value.producerManifest.producers[0].jobs[0].name = "wrong-check";
-    expectQualificationError(
-      () => evaluate(value),
-      /trusted context check name wrong-check does not match qualification-00/,
-    );
-  }
-  {
-    const value = fixture();
-    const lane = value.registry.lanes.find(
-      (candidate) => candidate.id === "release.migration",
-    );
-    value.producerManifest.producers[0].jobs.push({
-      job: lane.owner.context_job,
-      name: `${lane.context.name} / second`,
-      database_id: "9999",
-      conclusion: "success",
-    });
-    expectQualificationError(
-      () => evaluate(value),
-      /trusted context job job_43 is ambiguous/,
-    );
-  }
-  {
-    const value = fixture();
-    value.producerManifest.producers[0].jobs[1].database_id =
-      value.producerManifest.producers[0].jobs[0].database_id;
-    expectQualificationError(() => evaluate(value), /database_id is duplicated/);
-  }
-  for (const conclusion of NON_SUCCESS_CONCLUSIONS) {
-    const value = fixture();
-    value.producerManifest.producers[0].jobs[0].conclusion = conclusion;
-    expectQualificationError(
-      () => evaluate(value),
-      new RegExp(`trusted context job job_00 is ${conclusion}`),
-    );
-  }
+test("a non-success trusted job blocks even when its report claims success", () => {
+  const value = fixture();
+  value.index.records[0].trust.job_conclusion = "cancelled";
+  assert.throws(() => evaluate(value), /trusted job conclusion cancelled/);
 });
 
-test("selection digest, selection run, source, nonce, and candidate digest cannot drift", () => {
-  const cases = [
-    {
-      mutate(value) {
-        value.plan.selection_ref.manifest_sha256 = "0".repeat(64);
-      },
-      pattern: /selection manifest SHA-256 does not match/,
-    },
-    {
-      mutate(value) {
-        value.selection.run.attempt += 1;
-      },
-      pattern: /selection.*run\.attempt|selection run does not match/,
-    },
-    {
-      mutate(value) {
-        value.reports[0].source.tree = "0".repeat(40);
-      },
-      pattern: /source SHA\/tree does not match the selection/,
-    },
-    {
-      mutate(value) {
-        value.producerManifest.producers[0].source.sha = "0".repeat(40);
-      },
-      pattern: /projected SHA\/tree does not match the selection/,
-    },
-    {
-      mutate(value) {
-        value.reports[0].correlation_nonce = "0".repeat(64);
-      },
-      pattern: /correlation_nonce does not match the current qualification/,
-    },
-    {
-      mutate(value) {
-        value.producerManifest.correlation_nonce = "0".repeat(64);
-        value.producerManifest.producers[0].correlation_nonce = "0".repeat(64);
-      },
-      pattern: /producer manifest correlation_nonce does not match/,
-    },
-    {
-      mutate(value) {
-        reportByIdentity(
-          value,
-          "release.migration/default/candidate_artifact",
-        ).candidate_digest = `sha256:${"0".repeat(64)}`;
-      },
-      pattern: /candidate digest does not match the selection/,
-    },
-  ];
-  for (const { mutate, pattern } of cases) {
-    const value = fixture();
-    mutate(value);
-    expectQualificationError(() => evaluate(value), pattern);
-  }
+test("absent report blocks and quickstart absence is named explicitly", () => {
+  const value = fixture();
+  value.index.records = value.index.records.filter(
+    (record) => record.lane_id !== "e2e.quickstart",
+  );
+  assert.throws(
+    () => evaluate(value),
+    (error) =>
+      error instanceof QualificationError &&
+      /missing evidence record e2e\.quickstart\/default\/source_tree/.test(error.message) &&
+      /quickstart proof/.test(error.message),
+  );
 });
 
-test("trusted event and repository identity cannot be substituted", () => {
-  {
-    const value = fixture();
-    value.producerManifest.producers[0].event.kind = "push";
-    expectQualificationError(
-      () => evaluate(value),
-      /trusted producer event identity does not match the qualification event/,
-    );
-  }
-  {
-    const value = fixture();
-    value.producerManifest.producers[0].event.projected_sha = "0".repeat(40);
-    expectQualificationError(
-      () => evaluate(value),
-      /trusted producer event identity does not match the qualification event/,
-    );
-  }
-  {
-    const value = fixture();
-    value.producerManifest.producers[0].repository = "example/other";
-    expectQualificationError(
-      () => evaluate(value),
-      /trusted producer repository does not match the qualification repository/,
-    );
-  }
-});
-
-test("producer run, artifact identity, bundle name, bundle digest, and entry digest are bound", () => {
-  const cases = [
-    {
-      mutate(value) {
-        value.reports[0].producer.run.id = "999";
-        value.reports[0].producer.artifact.name = nativeArtifactName(
-          WORKFLOW,
-          value.reports[0].producer.run,
-        );
-      },
-      pattern: /producer run identity does not match the trusted workflow run/,
-    },
-    {
-      mutate(value) {
-        value.reports[0].producer.artifact.id = "999";
-      },
-      pattern: /trusted artifact 999 is missing/,
-    },
-    {
-      mutate(value) {
-        value.reports[0].producer.artifact.name = "ci-native-wrong-801-3";
-      },
-      pattern: /producer\.artifact\.name must be/,
-    },
-    {
-      mutate(value) {
-        value.reports[0].producer.artifact.sha256 = "0".repeat(64);
-      },
-      pattern: /artifact name or SHA-256 does not match trusted API provenance/,
-    },
-    {
-      mutate(value) {
-        value.reports[0].producer.artifact.entry_sha256 = "0".repeat(64);
-      },
-      pattern: /entry SHA-256 does not match trusted provenance/,
-    },
-    {
-      mutate(value) {
-        value.producerManifest.producers[0].artifacts[0].entries.shift();
-      },
-      pattern: /trusted native bundle entry is missing/,
-    },
-  ];
-  for (const { mutate, pattern } of cases) {
-    const value = fixture();
-    mutate(value);
-    expectQualificationError(() => evaluate(value), pattern);
-  }
-});
-
-test("zero, skipped, failed, and every non-success native report conclusion block", () => {
+test("zero, skipped, failed, or arithmetically hollow native evidence blocks", () => {
   for (const evidence of [
     { executed: 0, passed: 0, failed: 0, skipped: 0 },
     { executed: 3, passed: 2, failed: 0, skipped: 1 },
     { executed: 3, passed: 2, failed: 1, skipped: 0 },
+    { executed: 3, passed: 2, failed: 0, skipped: 0 },
   ]) {
     const value = fixture();
-    Object.assign(value.reports[0].evidence, evidence);
-    expectQualificationError(
-      () => evaluate(value),
-      /zero tests\/checks executed|all-executed, all-passed result|successful report cannot carry failed evidence/,
-    );
-  }
-  for (const conclusion of NON_SUCCESS_CONCLUSIONS) {
-    const value = fixture();
-    value.reports[0].conclusion = conclusion;
-    expectQualificationError(
-      () => evaluate(value),
-      new RegExp(`conclusion ${conclusion} is not success`),
-    );
+    Object.assign(value.index.records[0].evidence, evidence);
+    assert.throws(() => evaluate(value), /native/);
   }
 });
 
-test("stale selection, nonce, producer attempt, and artifact-entry replays block", () => {
-  const cases = [
-    {
-      mutate(value) {
-        value.reports[0].selection_ref.run.id = "999";
-      },
-      pattern: /selection_ref does not match the current selection/,
-    },
-    {
-      mutate(value) {
-        value.reports[0].selection_ref.manifest_sha256 = "0".repeat(64);
-      },
-      pattern: /selection_ref does not match the current selection/,
-    },
-    {
-      mutate(value) {
-        value.reports[0].correlation_nonce = "0".repeat(64);
-      },
-      pattern: /correlation_nonce does not match the current qualification/,
-    },
-    {
-      mutate(value) {
-        value.reports[0].producer.run.attempt = 2;
-        value.reports[0].producer.artifact.name = nativeArtifactName(
-          WORKFLOW,
-          value.reports[0].producer.run,
-        );
-      },
-      pattern: /producer run identity does not match the trusted workflow run/,
-    },
-    {
-      mutate(value) {
-        value.reports[0].producer.artifact.entry_sha256 = "0".repeat(64);
-      },
-      pattern: /entry SHA-256 does not match trusted provenance/,
-    },
-  ];
-  for (const { mutate, pattern } of cases) {
-    const value = fixture();
-    mutate(value);
-    expectQualificationError(() => evaluate(value), pattern);
-  }
-});
-
-test("the hard qualification window rejects early and late joins", () => {
+test("candidate digest mismatch blocks source index and artifact report variants", () => {
   {
     const value = fixture();
-    value.nowMs = value.plan.started_at_ms - 1;
-    expectQualificationError(
-      () => evaluate(value),
-      /completed before it started/,
+    value.index.candidate_digest = `sha256:${"0".repeat(64)}`;
+    assert.throws(() => evaluate(value), /index candidate digest/);
+  }
+  {
+    const value = fixture();
+    const artifact = value.index.records.find(
+      (record) => record.lane_id === "migration.e2e" && record.invocation_mode === "candidate_artifact",
+    );
+    artifact.candidate_digest = `sha256:${"1".repeat(64)}`;
+    assert.throws(() => evaluate(value), /candidate digest does not match/);
+  }
+});
+
+test("wrong SHA/tree, malformed provenance, and run mismatch each block", () => {
+  for (const mutate of [
+    (value) => {
+      value.index.records[0].source.tree = "2".repeat(40);
+    },
+    (value) => {
+      value.index.records[0].trust.artifact_digest = "bad";
+    },
+    (value) => {
+      value.index.records[0].trust.run_id = "999";
+    },
+  ]) {
+    const value = fixture();
+    mutate(value);
+    assert.throws(() => evaluate(value), QualificationError);
+  }
+});
+
+test("missing or stale correlation is rejected before reports can qualify", () => {
+  {
+    const value = fixture();
+    value.index.correlation_nonce = "f".repeat(64);
+    assert.throws(() => evaluate(value), /correlation nonce/);
+  }
+  {
+    const value = fixture();
+    delete value.index.correlation_nonce;
+    assert.throws(() => evaluate(value), /correlation_nonce/);
+  }
+});
+
+test("promotion rejects malformed, incomplete, hollow, and stale attestations", () => {
+  const baseline = evaluate(fixture());
+  for (const [name, mutate] of [
+    ["malformed candidate file", (value) => { delete value.candidate.files[0].sha256; }],
+    ["incomplete roster", (value) => { value.lanes = value.lanes.filter((lane) => !lane.identity.includes("candidate_artifact")); }],
+    ["hollow native evidence", (value) => { value.lanes[0].evidence.executed = 0; value.lanes[0].evidence.passed = 0; }],
+    ["stale correlation", (value) => { value.qualification.correlation_nonce = "0".repeat(64); }],
+    ["late completion", (value) => { value.qualification.completed_at_ms = value.qualification.deadline_at_ms + 1; }],
+  ]) {
+    const attestation = structuredClone(baseline);
+    mutate(attestation);
+    assert.throws(
+      () => validateAttestation(attestation, {
+        sha: SHA,
+        tree: TREE,
+        candidateDigest: CANDIDATE,
+        correlationNonce: NONCE,
+      }, registry),
+      QualificationError,
+      name,
     );
   }
+});
+
+test("the 120-minute deadline rejects late join and late lane completion", () => {
   {
     const value = fixture();
     value.nowMs = value.plan.started_at_ms + RELEASE_QUALIFICATION_LIMIT_MS + 1;
-    expectQualificationError(() => evaluate(value), /qualification timed out/);
+    assert.throws(() => evaluate(value), /qualification timed out/);
   }
-});
-
-test("attestation verification rejects provenance, roster, candidate, and deadline tampering", () => {
-  const value = fixture();
-  const baseline = evaluate(value);
-  const cases = [
-    {
-      mutate(attestation) {
-        attestation.candidate.image_digest = `sha256:${"0".repeat(64)}`;
-      },
-      pattern: /candidate\.image_digest/,
-    },
-    {
-      mutate(attestation) {
-        attestation.qualification.selection_ref.manifest_sha256 = "0".repeat(64);
-      },
-      pattern: /selection_ref\.manifest_sha256/,
-    },
-    {
-      mutate(attestation) {
-        attestation.qualification.event.kind = "push";
-      },
-      pattern: /qualification event does not match expected event/,
-    },
-    {
-      mutate(attestation) {
-        attestation.qualification.repository = "example/other";
-      },
-      pattern: /qualification\.repository/,
-    },
-    {
-      mutate(attestation) {
-        attestation.qualification.completed_at_ms =
-          attestation.qualification.deadline_at_ms + 1;
-      },
-      pattern: /completion is outside its qualification window/,
-    },
-    {
-      mutate(attestation) {
-        attestation.lanes.shift();
-      },
-      pattern: /exactly 45 identities|missing release lane|quickstart proof/,
-    },
-    {
-      mutate(attestation) {
-        attestation.lanes[0].producer.job_database_id = "bad";
-      },
-      pattern: /job_database_id has invalid value/,
-    },
-    {
-      mutate(attestation) {
-        attestation.lanes[0].report_artifact.entry_sha256 = "bad";
-      },
-      pattern: /entry_sha256 has invalid value/,
-    },
-    {
-      mutate(attestation) {
-        attestation.lanes[0].evidence.executed = 0;
-        attestation.lanes[0].evidence.passed = 0;
-      },
-      pattern: /positive all-passed native result/,
-    },
-  ];
-  for (const { mutate, pattern } of cases) {
-    const attestation = structuredClone(baseline);
-    mutate(attestation);
-    expectQualificationError(
-      () =>
-        validateAttestation(
-          attestation,
-          expectedAttestation(value),
-          value.registry,
-        ),
-      pattern,
-    );
+  {
+    const value = fixture();
+    value.index.records[0].trust.completed_at_ms = value.plan.deadline_at_ms + 1;
+    assert.throws(() => evaluate(value), /completed after the qualification deadline/);
   }
-});
-
-test("finite registry growth fails until the explicit 45-invocation contract is reviewed", () => {
-  const value = fixture();
-  value.registry.lanes.push(fixtureLane("quality.newlane", 90));
-  value.registry.lanes.sort((left, right) => left.id.localeCompare(right.id));
-  expectQualificationError(
-    () => releaseLaneRoster(value.registry),
-    /must contain exactly 45 invocations; registry produced 46/,
-  );
+  {
+    const value = fixture();
+    value.index.records[0].trust.completed_at_ms = value.plan.started_at_ms - 1;
+    assert.throws(() => evaluate(value), /completed before qualification started/);
+  }
 });

--- a/.github/scripts/release-version-gate.mjs
+++ b/.github/scripts/release-version-gate.mjs
@@ -1,6 +1,6 @@
 // release-version-gate.mjs — on a push to main (a merged release PR), decide
 // whether the APP needs publishing: does Chart.yaml's `appVersion:` name a
-// version that has NOT yet been released as a `v<appVersion>` git tag?
+// version that does not yet have a complete immutable public release?
 //
 // This is the app-side twin of chart-publish.mjs's `version-gate` (which gates
 // the chart on its OWN `version:` line vs the OCI registry). Together they make
@@ -8,9 +8,11 @@
 // line is a complete no-op (nothing publishes, no tag is cut), exactly the
 // safety property a non-version PR (like the one introducing this script) needs.
 //
-// Why git tags, not the OCI/registry: the app release identity IS the `vX.Y.Z`
-// git tag — goreleaser derives `{{ .Version }}` from it, and the immutable
-// GitHub release is keyed on it. So "already released" == "the tag exists".
+// A tag alone is not completion. Publication can fail after the tag is pushed
+// but before the release becomes public. The public immutable release, with
+// the exact five-asset roster and content digests, is the completion marker.
+// A rerun therefore repairs a missing/draft/incomplete release even when its
+// tag already exists; only the complete public state is a no-op.
 // (The chart's identity, by contrast, is the OCI artifact, so chart-publish.mjs
 // probes the registry; the two gates intentionally use different oracles.)
 //
@@ -26,6 +28,7 @@
 //                    publish=true|false  — does the app need a new release?
 //                    version=<appVersion>      — the bare appVersion (no `v`)
 //                    tag=v<appVersion>         — the git tag to create/publish
+//                    is_latest=true|false      — highest stable release line
 //
 // Subcommand (argv[2]):
 //   app-version-gate   run the gate (default if omitted)
@@ -75,10 +78,74 @@ export function parseAppVersion(chartYaml) {
 // `v*` git tags, return { publish, version, tag }. publish is true ONLY when
 // the `v<appVersion>` tag does not already exist. Pure: same inputs, same
 // output, no side effects — so the self-test pins the exact boundary.
-export function decide(appVersion, existingTags) {
+const RELEASE_DIGEST_RE = /^sha256:[0-9a-f]{64}$/;
+
+export function expectedReleaseAssetNames(appVersion) {
+  return [
+    `cerberus_${appVersion}_darwin_amd64.tar.gz`,
+    `cerberus_${appVersion}_darwin_arm64.tar.gz`,
+    `cerberus_${appVersion}_linux_amd64.tar.gz`,
+    `cerberus_${appVersion}_linux_arm64.tar.gz`,
+    'checksums.txt',
+  ];
+}
+
+export function completedRelease(document, { appVersion, tag }) {
+  if (document === null || typeof document !== 'object' || Array.isArray(document)) return false;
+  if (
+    document.draft !== false ||
+    document.immutable !== true ||
+    document.tag_name !== tag ||
+    document.prerelease !== appVersion.includes('-') ||
+    !Array.isArray(document.assets)
+  ) {
+    return false;
+  }
+  const expected = expectedReleaseAssetNames(appVersion);
+  const actual = new Map();
+  for (const asset of document.assets) {
+    const name = String(asset?.name ?? '');
+    if (name === '' || actual.has(name)) return false;
+    if (!Number.isSafeInteger(asset.size) || asset.size <= 0) return false;
+    if (!RELEASE_DIGEST_RE.test(asset.digest ?? '')) return false;
+    actual.set(name, asset);
+  }
+  return actual.size === expected.length && expected.every((name) => actual.has(name));
+}
+
+export function decide(appVersion, existingTags, releaseComplete = undefined) {
   const tag = `v${appVersion}`;
   const exists = existingTags.includes(tag);
-  return { publish: !exists, version: appVersion, tag };
+  const publish = releaseComplete === undefined ? !exists : !releaseComplete;
+  return {
+    publish,
+    version: appVersion,
+    tag,
+    isLatest: isHighestStable(appVersion, existingTags),
+    retry: exists && publish,
+  };
+}
+
+function stableVersion(value) {
+  const match = String(value).match(/^(\d+)\.(\d+)\.(\d+)$/);
+  if (!match) return null;
+  return match.slice(1).map(Number);
+}
+
+function compareStable(left, right) {
+  for (let index = 0; index < left.length; index += 1) {
+    if (left[index] !== right[index]) return left[index] - right[index];
+  }
+  return 0;
+}
+
+export function isHighestStable(appVersion, existingTags) {
+  const candidate = stableVersion(appVersion);
+  if (!candidate) return false;
+  return !existingTags
+    .map((tag) => stableVersion(String(tag).replace(/^v/, '')))
+    .filter(Boolean)
+    .some((version) => compareStable(version, candidate) > 0);
 }
 
 // ---------------------------------------------------------------------------
@@ -100,6 +167,27 @@ function listVTags() {
     .filter(Boolean);
 }
 
+function releaseForTag(tag) {
+  const result = spawnSync(
+    'gh',
+    ['api', `repos/{owner}/{repo}/releases/tags/${tag}`],
+    { encoding: 'utf8' },
+  );
+  if (result.status === 0) {
+    try {
+      return JSON.parse(result.stdout || '');
+    } catch (cause) {
+      throw new Error(`release ${tag} returned malformed JSON: ${cause.message}`);
+    }
+  }
+  const output = `${result.stdout || ''}\n${result.stderr || ''}`;
+  if (/(?:\b404\b|not found)/i.test(output)) return null;
+  throw new Error(
+    `could not determine whether release ${tag} is complete (exit ${result.status}): ` +
+      output.trim(),
+  );
+}
+
 function appVersionGate() {
   let appVersion;
   try {
@@ -108,15 +196,29 @@ function appVersionGate() {
     ghError(`${e.message} (in ${CHART_DIR}/Chart.yaml)`);
     process.exit(1);
   }
-  const { publish, version, tag } = decide(appVersion, listVTags());
+  const tags = listVTags();
+  const tag = `v${appVersion}`;
+  let releaseComplete = false;
+  try {
+    releaseComplete = tags.includes(tag) && completedRelease(releaseForTag(tag), { appVersion, tag });
+  } catch (cause) {
+    ghError(cause instanceof Error ? cause.message : String(cause));
+    process.exit(1);
+  }
+  const { publish, version, isLatest, retry } = decide(appVersion, tags, releaseComplete);
   if (publish) {
-    ghNotice(`appVersion ${version} not yet released (no ${tag} tag) — will tag + publish the app`);
+    ghNotice(
+      retry
+        ? `appVersion ${version} has a tag but no complete immutable release — will repair publication`
+        : `appVersion ${version} is unpublished — will qualify and publish the app`,
+    );
   } else {
-    ghNotice(`appVersion ${version} already released at ${tag} — skipping app publish`);
+    ghNotice(`appVersion ${version} has a complete immutable release at ${tag} — skipping app publish`);
   }
   setOutput('publish', String(publish));
   setOutput('version', version);
   setOutput('tag', tag);
+  setOutput('is_latest', String(isLatest));
   process.exit(0);
 }
 
@@ -156,6 +258,7 @@ function selfTest() {
   d = decide('1.5.0', ['v1.2.1', 'v1.3.0', 'v1.4.0']);
   assert(d.publish === true, 'new appVersion must publish');
   assert(d.tag === 'v1.5.0', 'tag derived as v<appVersion>');
+  assert(d.isLatest === true, 'new highest stable appVersion owns shared latest resources');
 
   // decide: MAINTENANCE-LINE hotfix. appVersion 1.4.1 is OLDER than the latest
   // tagged release v1.5.0, but the v1.4.1 tag itself is absent -> publish. This
@@ -164,6 +267,7 @@ function selfTest() {
   d = decide('1.4.1', ['v1.2.1', 'v1.3.0', 'v1.4.0', 'v1.5.0']);
   assert(d.publish === true, 'tag-absent maintenance hotfix older than latest must still publish');
   assert(d.tag === 'v1.4.1', 'maintenance tag derived as v<appVersion>');
+  assert(d.isLatest === false, 'maintenance backport must not own shared latest resources');
 
   // decide: the same maintenance hotfix re-run AFTER its tag landed -> no-op
   // (idempotency on the maintenance path, identical to the main path).
@@ -178,8 +282,40 @@ function selfTest() {
   // the un-tagged prerelease v1.5.0-rc.1).
   d = decide('1.5.0-rc.1', ['v1.5.0']);
   assert(d.publish === true, 'prerelease not masked by the stable tag');
+  assert(d.isLatest === false, 'prerelease must not own shared latest resources');
   d = decide('1.5.0-rc.1', ['v1.5.0-rc.1']);
   assert(d.publish === false, 'already-tagged prerelease must not republish');
+
+  const release = {
+    draft: false,
+    immutable: true,
+    prerelease: false,
+    tag_name: 'v1.5.0',
+    assets: expectedReleaseAssetNames('1.5.0').map((name) => ({
+      name,
+      size: 1,
+      digest: `sha256:${'a'.repeat(64)}`,
+    })),
+  };
+  assert(
+    completedRelease(release, { appVersion: '1.5.0', tag: 'v1.5.0' }),
+    'exact immutable public release is complete',
+  );
+  d = decide('1.5.0', ['v1.5.0'], true);
+  assert(d.publish === false && d.retry === false, 'complete public release is the no-op marker');
+  for (const incomplete of [
+    { ...release, draft: true },
+    { ...release, immutable: false },
+    { ...release, assets: release.assets.slice(1) },
+    { ...release, assets: release.assets.map((asset, index) => index === 0 ? { ...asset, digest: null } : asset) },
+  ]) {
+    assert(
+      !completedRelease(incomplete, { appVersion: '1.5.0', tag: 'v1.5.0' }),
+      'draft, mutable, missing-asset, and digestless releases remain incomplete',
+    );
+  }
+  d = decide('1.5.0', ['v1.5.0'], false);
+  assert(d.publish === true && d.retry === true, 'an early tag cannot suppress publication repair');
 
   ghNotice('release-version-gate --self-test: all assertions passed');
 }

--- a/.github/workflows/agpl-oracle.yml
+++ b/.github/workflows/agpl-oracle.yml
@@ -75,6 +75,11 @@ on:
   push:
     branches: [main, 'release/*.x']
   workflow_dispatch:
+    inputs:
+      release_correlation_nonce:
+        description: 'Internal release-qualification nonce'
+        required: false
+        type: string
   schedule:
     # nightly at 03:30 UTC (ahead of property at 03:45 and chdb at 04:00)
     - cron: '30 3 * * *'
@@ -187,4 +192,5 @@ jobs:
     with:
       workflow: .github/workflows/agpl-oracle.yml
       needs_json: ${{ toJSON(needs) }}
-      posture: ${{ (github.event_name == 'pull_request' || github.event_name == 'merge_group') && 'merge' || (github.ref == 'refs/heads/main' && 'main') || 'merge' }}
+      posture: ${{ inputs.release_correlation_nonce != '' && 'release' || (github.event_name == 'pull_request' || github.event_name == 'merge_group') && 'merge' || (github.ref == 'refs/heads/main' && 'main') || 'merge' }}
+      correlation_nonce: ${{ inputs.release_correlation_nonce }}

--- a/.github/workflows/agpl-oracle.yml
+++ b/.github/workflows/agpl-oracle.yml
@@ -171,3 +171,20 @@ jobs:
       - name: No-op (docs-only PR)
         if: needs.changes.outputs.docs_only == 'true'
         run: echo "agpl-oracle is a green no-op on docs-only PRs."
+
+
+      - name: emit native evidence for agpl.oracle
+        uses: ./.github/actions/ci-native-part
+        with:
+          id: agpl.oracle.agpl-oracle.source
+          seed: ci-${{ github.run_id }}-${{ github.run_attempt }}
+
+  native-evidence:
+    name: native-evidence
+    if: always()
+    needs: [changes, agpl-oracle]
+    uses: ./.github/workflows/ci-native-evidence.yml
+    with:
+      workflow: .github/workflows/agpl-oracle.yml
+      needs_json: ${{ toJSON(needs) }}
+      posture: ${{ (github.event_name == 'pull_request' || github.event_name == 'merge_group') && 'merge' || (github.ref == 'refs/heads/main' && 'main') || 'merge' }}

--- a/.github/workflows/agpl-oracle.yml
+++ b/.github/workflows/agpl-oracle.yml
@@ -83,10 +83,10 @@ permissions:
   contents: read
 
 concurrency:
-  # A newer deep run may replace only push/schedule work on main. Every PR,
-  # queue, dispatch, maintenance, and unknown event gets its own run-id group.
-  group: ${{ github.workflow }}-${{ ((github.event_name == 'push' || github.event_name == 'schedule') && github.ref == 'refs/heads/main') && 'latest-main' || github.run_id }}
-  cancel-in-progress: ${{ (github.event_name == 'push' || github.event_name == 'schedule') && github.ref == 'refs/heads/main' }}
+  # Main pushes replace only older main pushes; matching cron schedules replace
+  # only that scheduled mode. Every other event gets its own run-id group.
+  group: ${{ github.workflow }}-${{ (github.event_name == 'push' && github.ref == 'refs/heads/main') && 'latest-main-push' || (github.event_name == 'schedule' && github.ref == 'refs/heads/main' && github.event.schedule != '') && format('latest-main-schedule-{0}', github.event.schedule) || github.run_id }}
+  cancel-in-progress: ${{ (github.event_name == 'push' && github.ref == 'refs/heads/main') || (github.event_name == 'schedule' && github.ref == 'refs/heads/main' && github.event.schedule != '') }}
 
 jobs:
   # Docs-only short-circuit — see chdb.yml for the full rationale. The

--- a/.github/workflows/chart-ci.yml
+++ b/.github/workflows/chart-ci.yml
@@ -25,6 +25,11 @@ on:
     # absence rather than by passing.
     branches: [main, 'release/*.x']
   workflow_dispatch:
+    inputs:
+      release_correlation_nonce:
+        description: 'Internal release-qualification nonce'
+        required: false
+        type: string
 
 permissions:
   contents: read
@@ -153,4 +158,5 @@ jobs:
     with:
       workflow: .github/workflows/chart-ci.yml
       needs_json: ${{ toJSON(needs) }}
-      posture: ${{ (github.event_name == 'pull_request' || github.event_name == 'merge_group') && 'merge' || (github.ref == 'refs/heads/main' && 'main') || 'merge' }}
+      posture: ${{ inputs.release_correlation_nonce != '' && 'release' || (github.event_name == 'pull_request' || github.event_name == 'merge_group') && 'merge' || (github.ref == 'refs/heads/main' && 'main') || 'merge' }}
+      correlation_nonce: ${{ inputs.release_correlation_nonce }}

--- a/.github/workflows/chart-ci.yml
+++ b/.github/workflows/chart-ci.yml
@@ -138,3 +138,19 @@ jobs:
             version_flag="--check-version-increment=false"
           fi
           ct lint --chart-dirs deploy/helm --target-branch "$TARGET_BRANCH" --validate-maintainers=false $version_flag
+
+
+      - name: emit native evidence for chart.validate
+        uses: ./.github/actions/ci-native-part
+        with:
+          id: chart.validate.chart-validate.source
+
+  native-evidence:
+    name: native-evidence
+    if: always()
+    needs: [chart-validate]
+    uses: ./.github/workflows/ci-native-evidence.yml
+    with:
+      workflow: .github/workflows/chart-ci.yml
+      needs_json: ${{ toJSON(needs) }}
+      posture: ${{ (github.event_name == 'pull_request' || github.event_name == 'merge_group') && 'merge' || (github.ref == 'refs/heads/main' && 'main') || 'merge' }}

--- a/.github/workflows/chdb.yml
+++ b/.github/workflows/chdb.yml
@@ -56,6 +56,11 @@ on:
   # their names — that property is what makes it queue-safe.
   merge_group:
   workflow_dispatch:
+    inputs:
+      release_correlation_nonce:
+        description: 'Internal release-qualification nonce'
+        required: false
+        type: string
   schedule:
     # nightly at 04:00 UTC
     - cron: '0 4 * * *'
@@ -682,4 +687,5 @@ jobs:
     with:
       workflow: .github/workflows/chdb.yml
       needs_json: ${{ toJSON(needs) }}
-      posture: ${{ (github.event_name == 'pull_request' || github.event_name == 'merge_group') && 'merge' || (github.ref == 'refs/heads/main' && 'main') || 'merge' }}
+      posture: ${{ inputs.release_correlation_nonce != '' && 'release' || (github.event_name == 'pull_request' || github.event_name == 'merge_group') && 'merge' || (github.ref == 'refs/heads/main' && 'main') || 'merge' }}
+      correlation_nonce: ${{ inputs.release_correlation_nonce }}

--- a/.github/workflows/chdb.yml
+++ b/.github/workflows/chdb.yml
@@ -238,6 +238,11 @@ jobs:
   # docs-only PR every step is skipped and each leg concludes `success`
   # in seconds (no chDB compile/run) — satisfying the required check
   # without doing the work. Do NOT hoist this back to the job level.
+
+      - name: emit native evidence for chdb.probe
+        uses: ./.github/actions/ci-native-part
+        with:
+          id: chdb.probe.probe.source
   roundtrip:
     name: roundtrip (${{ matrix.ql }})
     needs: changes
@@ -399,6 +404,24 @@ jobs:
   #
   # COST: N legs = N chDB installs and N compiles — billable minutes rise, while
   # wall-clock drops from the serial sum toward the longest leg plus fixed setup.
+
+      - name: emit native evidence for chdb.roundtrip-logql
+        if: ${{ matrix.ql == 'logql' }}
+        uses: ./.github/actions/ci-native-part
+        with:
+          id: chdb.roundtrip-logql.roundtrip.source
+
+      - name: emit native evidence for chdb.roundtrip-promql
+        if: ${{ matrix.ql == 'promql' }}
+        uses: ./.github/actions/ci-native-part
+        with:
+          id: chdb.roundtrip-promql.roundtrip.source
+
+      - name: emit native evidence for chdb.roundtrip-traceql
+        if: ${{ matrix.ql == 'traceql' }}
+        uses: ./.github/actions/ci-native-part
+        with:
+          id: chdb.roundtrip-traceql.roundtrip.source
   perf-guards-shard:
     name: perf-guards-shard
     needs: changes
@@ -522,6 +545,11 @@ jobs:
   # No golden file + no GOLDEN_UPDATE: expected results are computed at run
   # time by the oracle, so a pass proves PromQL semantics, not reproduction
   # of a recording.
+
+      - name: emit native evidence for chdb.perf-guards
+        uses: ./.github/actions/ci-native-part
+        with:
+          id: chdb.perf-guards.perf-guards.source
   integration-promql:
     name: integration (promql)
     needs: changes
@@ -561,6 +589,11 @@ jobs:
   # This is ORTHOGONAL to `roundtrip`: roundtrip pins self-derived SQL and
   # expected_rows; this live HTTP pipeline has no golden/GOLDEN_UPDATE path
   # and catches semantic lowering, optimizer, emitter, and wire drift.
+
+      - name: emit native evidence for chdb.integration-promql
+        uses: ./.github/actions/ci-native-part
+        with:
+          id: chdb.integration-promql.integration-promql.source
   integration-logql:
     name: integration (logql)
     needs: changes
@@ -600,6 +633,11 @@ jobs:
   # expected_rows; this live HTTP pipeline has no golden/GOLDEN_UPDATE path
   # and catches semantic selector, structural, aggregate, optimizer, emitter,
   # and wire drift.
+
+      - name: emit native evidence for chdb.integration-logql
+        uses: ./.github/actions/ci-native-part
+        with:
+          id: chdb.integration-logql.integration-logql.source
   integration-traceql:
     name: integration (traceql)
     needs: changes
@@ -629,3 +667,19 @@ jobs:
 
       - name: Run exotic TraceQL integration suite (chDB)
         run: go test -tags chdb -count=1 ./test/integration/traceql/...
+
+
+      - name: emit native evidence for chdb.integration-traceql
+        uses: ./.github/actions/ci-native-part
+        with:
+          id: chdb.integration-traceql.integration-traceql.source
+
+  native-evidence:
+    name: native-evidence
+    if: always()
+    needs: [changes, chdb-build, probe, roundtrip, perf-guards-shard, perf-guards, integration-promql, integration-logql, integration-traceql]
+    uses: ./.github/workflows/ci-native-evidence.yml
+    with:
+      workflow: .github/workflows/chdb.yml
+      needs_json: ${{ toJSON(needs) }}
+      posture: ${{ (github.event_name == 'pull_request' || github.event_name == 'merge_group') && 'merge' || (github.ref == 'refs/heads/main' && 'main') || 'merge' }}

--- a/.github/workflows/chdb.yml
+++ b/.github/workflows/chdb.yml
@@ -75,10 +75,10 @@ permissions:
   contents: read
 
 concurrency:
-  # A newer deep run may replace only push/schedule work on main. Every PR,
-  # queue, dispatch, maintenance, and unknown event gets its own run-id group.
-  group: ${{ github.workflow }}-${{ ((github.event_name == 'push' || github.event_name == 'schedule') && github.ref == 'refs/heads/main') && 'latest-main' || github.run_id }}
-  cancel-in-progress: ${{ (github.event_name == 'push' || github.event_name == 'schedule') && github.ref == 'refs/heads/main' }}
+  # Main pushes replace only older main pushes; matching cron schedules replace
+  # only that scheduled mode. Every other event gets its own run-id group.
+  group: ${{ github.workflow }}-${{ (github.event_name == 'push' && github.ref == 'refs/heads/main') && 'latest-main-push' || (github.event_name == 'schedule' && github.ref == 'refs/heads/main' && github.event.schedule != '') && format('latest-main-schedule-{0}', github.event.schedule) || github.run_id }}
+  cancel-in-progress: ${{ (github.event_name == 'push' && github.ref == 'refs/heads/main') || (github.event_name == 'schedule' && github.ref == 'refs/heads/main' && github.event.schedule != '') }}
 
 jobs:
   # See `.github/workflows/ci.yml` for the rationale + filter convention.

--- a/.github/workflows/ci-native-evidence.yml
+++ b/.github/workflows/ci-native-evidence.yml
@@ -16,6 +16,19 @@ on:
         required: false
         type: string
         default: ""
+    outputs:
+      native_artifact_name:
+        value: ${{ jobs.emit.outputs.native_artifact_name }}
+      native_artifact_id:
+        value: ${{ jobs.emit.outputs.native_artifact_id }}
+      native_artifact_digest:
+        value: ${{ jobs.emit.outputs.native_artifact_digest }}
+      native_bundle_sha256:
+        value: ${{ jobs.emit.outputs.native_bundle_sha256 }}
+      native_lane_count:
+        value: ${{ jobs.emit.outputs.native_lane_count }}
+      native_correlation_nonce:
+        value: ${{ jobs.emit.outputs.native_correlation_nonce }}
 
 permissions:
   contents: read
@@ -24,6 +37,13 @@ jobs:
   emit:
     runs-on: ubuntu-latest
     timeout-minutes: 5
+    outputs:
+      native_artifact_name: ${{ steps.evidence.outputs.native_artifact_name }}
+      native_artifact_id: ${{ steps.bundle.outputs.artifact-id }}
+      native_artifact_digest: ${{ steps.bundle.outputs.artifact-digest }}
+      native_bundle_sha256: ${{ steps.evidence.outputs.native_bundle_sha256 }}
+      native_lane_count: ${{ steps.evidence.outputs.native_lane_count }}
+      native_correlation_nonce: ${{ steps.evidence.outputs.native_correlation_nonce }}
     steps:
       - uses: actions/checkout@v7
         with:
@@ -31,19 +51,25 @@ jobs:
           fetch-depth: 0
           clean: true
 
+      - name: download the attempt-qualified native parts
+        uses: actions/download-artifact@v8
+        with:
+          pattern: ci-native-part-*-${{ github.run_attempt }}
+          path: ${{ runner.temp }}/ci-native-parts
+
       - id: evidence
-        name: derive evidence from the caller's native job graph
+        name: derive counts from the registry-owned native part roster
         env:
           CI_LANE_WORKFLOW: ${{ inputs.workflow }}
           CI_LANE_NEEDS_JSON: ${{ inputs.needs_json }}
           CI_LANE_NATIVE_POSTURE: ${{ inputs.posture }}
           CI_LANE_CORRELATION_NONCE: ${{ inputs.correlation_nonce }}
-          CI_LANE_NATIVE_OUTPUT: build/ci-native-evidence.json
-        run: |
-          mkdir -p build
-          node .github/scripts/ci-lane-native-evidence.mjs
+          CI_LANE_NATIVE_PARTS: ${{ runner.temp }}/ci-native-parts
+          CI_LANE_NATIVE_OUTPUT: ${{ runner.temp }}/ci-native-evidence.json
+        run: node .github/scripts/ci-lane-native-evidence.mjs
 
-      - name: publish the attempt-qualified native bundle
+      - id: bundle
+        name: publish the attempt-qualified native bundle
         uses: actions/upload-artifact@v7
         with:
           name: ${{ steps.evidence.outputs.native_artifact_name }}

--- a/.github/workflows/ci-native-evidence.yml
+++ b/.github/workflows/ci-native-evidence.yml
@@ -1,0 +1,52 @@
+name: ci-native-evidence
+
+on:
+  workflow_call:
+    inputs:
+      workflow:
+        required: true
+        type: string
+      needs_json:
+        required: true
+        type: string
+      posture:
+        required: true
+        type: string
+      correlation_nonce:
+        required: false
+        type: string
+        default: ""
+
+permissions:
+  contents: read
+
+jobs:
+  emit:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          ref: ${{ github.sha }}
+          fetch-depth: 0
+          clean: true
+
+      - id: evidence
+        name: derive evidence from the caller's native job graph
+        env:
+          CI_LANE_WORKFLOW: ${{ inputs.workflow }}
+          CI_LANE_NEEDS_JSON: ${{ inputs.needs_json }}
+          CI_LANE_NATIVE_POSTURE: ${{ inputs.posture }}
+          CI_LANE_CORRELATION_NONCE: ${{ inputs.correlation_nonce }}
+          CI_LANE_NATIVE_OUTPUT: build/ci-native-evidence.json
+        run: |
+          mkdir -p build
+          node .github/scripts/ci-lane-native-evidence.mjs
+
+      - name: publish the attempt-qualified native bundle
+        uses: actions/upload-artifact@v7
+        with:
+          name: ${{ steps.evidence.outputs.native_artifact_name }}
+          path: ${{ steps.evidence.outputs.native_path }}
+          if-no-files-found: error
+          retention-days: 14

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,12 @@ on:
   # group never produces leaves the entry queued forever. See the merge-queue
   # section of docs/test-strategy.md.
   merge_group:
+  workflow_dispatch:
+    inputs:
+      release_correlation_nonce:
+        description: 'Internal release-qualification nonce'
+        required: false
+        type: string
 
 permissions:
   contents: read
@@ -1161,4 +1167,5 @@ jobs:
     with:
       workflow: .github/workflows/ci.yml
       needs_json: ${{ toJSON(needs) }}
-      posture: ${{ (github.event_name == 'pull_request' || github.event_name == 'merge_group') && 'merge' || (github.ref == 'refs/heads/main' && 'main') || 'merge' }}
+      posture: ${{ inputs.release_correlation_nonce != '' && 'release' || (github.event_name == 'pull_request' || github.event_name == 'merge_group') && 'merge' || (github.ref == 'refs/heads/main' && 'main') || 'merge' }}
+      correlation_nonce: ${{ inputs.release_correlation_nonce }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1156,7 +1156,7 @@ jobs:
   native-evidence:
     name: native-evidence
     if: always()
-    needs: [changes, check-test, check-build, lint, forbid-skip, link-check, agpl-clean]
+    needs: [changes, check, check-test, check-build, lint, forbid-skip, link-check, agpl-clean]
     uses: ./.github/workflows/ci-native-evidence.yml
     with:
       workflow: .github/workflows/ci.yml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,6 +108,11 @@ jobs:
   # the suite does NOT need to wait for is the build / type-check / oracle /
   # tidy work — pure serial tail hanging off the same runner. That moved to
   # `check-build`, and the two halves now overlap instead of queueing.
+
+      - name: emit native evidence for ci.check
+        uses: ./.github/actions/ci-native-part
+        with:
+          id: ci.check.changes.source
   check-test:
     name: check-test
     needs: changes
@@ -136,6 +141,16 @@ jobs:
           just test-chaos-sleep
           just test-unit
 
+
+      - name: emit native evidence for ci.chaos-sleep
+        uses: ./.github/actions/ci-native-part
+        with:
+          id: ci.chaos-sleep.check-test.source
+
+      - name: emit native evidence for ci.check
+        uses: ./.github/actions/ci-native-part
+        with:
+          id: ci.check.check-test.source
   check-build:
     name: check-build
     needs: changes
@@ -194,6 +209,11 @@ jobs:
   # split unchanged. `always()` is load-bearing — with a plain `needs:` this job
   # would be SKIPPED when a half fails, and a skipped required check is green to
   # branch protection. So it always runs and reads the results explicitly.
+
+      - name: emit native evidence for ci.check
+        uses: ./.github/actions/ci-native-part
+        with:
+          id: ci.check.check-build.source
   check:
     name: check
     needs: [changes, check-test, check-build]
@@ -549,6 +569,11 @@ jobs:
   # boundary (and pinned by their respective VERSION files). Runs in
   # parallel with `check` + `lint`; flip on as a required status check
   # via branch protection.
+
+      - name: emit native evidence for ci.lint
+        uses: ./.github/actions/ci-native-part
+        with:
+          id: ci.lint.lint.source
   forbid-skip:
     name: forbid-skip
     runs-on: ubuntu-latest
@@ -1047,6 +1072,11 @@ jobs:
   # Vendored upstream snapshots under `compatibility/*/upstream/**` are
   # excluded, mirroring the markdownlint + forbid-skip exclude set — they are
   # reference material outside cerberus's authorship boundary.
+
+      - name: emit native evidence for ci.forbid-skip
+        uses: ./.github/actions/ci-native-part
+        with:
+          id: ci.forbid-skip.forbid-skip.source
   link-check:
     name: link-check
     runs-on: ubuntu-latest
@@ -1096,6 +1126,11 @@ jobs:
   # grafana/tempo/* except pkg/tempopb). Logic lives in
   # .github/scripts/agpl-clean.mjs (node: builtins only). Add to branch
   # protection as a required status check.
+
+      - name: emit native evidence for ci.link-check
+        uses: ./.github/actions/ci-native-part
+        with:
+          id: ci.link-check.link-check.source
   agpl-clean:
     name: agpl-clean
     needs: changes
@@ -1111,3 +1146,19 @@ jobs:
 
       - name: AGPL clean-build gate
         run: node .github/scripts/agpl-clean.mjs
+
+
+      - name: emit native evidence for ci.agpl-clean
+        uses: ./.github/actions/ci-native-part
+        with:
+          id: ci.agpl-clean.agpl-clean.source
+
+  native-evidence:
+    name: native-evidence
+    if: always()
+    needs: [changes, check-test, check-build, lint, forbid-skip, link-check, agpl-clean]
+    uses: ./.github/workflows/ci-native-evidence.yml
+    with:
+      workflow: .github/workflows/ci.yml
+      needs_json: ${{ toJSON(needs) }}
+      posture: ${{ (github.event_name == 'pull_request' || github.event_name == 'merge_group') && 'merge' || (github.ref == 'refs/heads/main' && 'main') || 'merge' }}

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -49,10 +49,10 @@ permissions:
   security-events: write
 
 concurrency:
-  # A newer deep run may replace only push/schedule work on main. In particular,
-  # PR and merge-group evidence is unique and can never be cancelled here.
-  group: ${{ github.workflow }}-${{ ((github.event_name == 'push' || github.event_name == 'schedule') && github.ref == 'refs/heads/main') && 'latest-main' || github.run_id }}
-  cancel-in-progress: ${{ (github.event_name == 'push' || github.event_name == 'schedule') && github.ref == 'refs/heads/main' }}
+  # Main pushes and matching cron schedules replace only their own modes. PR
+  # and merge-group evidence is unique and can never be cancelled here.
+  group: ${{ github.workflow }}-${{ (github.event_name == 'push' && github.ref == 'refs/heads/main') && 'latest-main-push' || (github.event_name == 'schedule' && github.ref == 'refs/heads/main' && github.event.schedule != '') && format('latest-main-schedule-{0}', github.event.schedule) || github.run_id }}
+  cancel-in-progress: ${{ (github.event_name == 'push' && github.ref == 'refs/heads/main') || (github.event_name == 'schedule' && github.ref == 'refs/heads/main' && github.event.schedule != '') }}
 
 jobs:
   analyze:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -39,6 +39,12 @@ on:
     branches: [main, 'release/*.x']
   pull_request:
   merge_group:
+  workflow_dispatch:
+    inputs:
+      release_correlation_nonce:
+        description: 'Internal release-qualification nonce'
+        required: false
+        type: string
   schedule:
     # Weekly deep scan — outside the standard PR/push gates so the
     # extended query suite runs without gating PRs on its extra latency.
@@ -127,4 +133,5 @@ jobs:
     with:
       workflow: .github/workflows/codeql.yml
       needs_json: ${{ toJSON(needs) }}
-      posture: ${{ (github.event_name == 'pull_request' || github.event_name == 'merge_group') && 'merge' || (github.ref == 'refs/heads/main' && 'main') || 'merge' }}
+      posture: ${{ inputs.release_correlation_nonce != '' && 'release' || (github.event_name == 'pull_request' || github.event_name == 'merge_group') && 'merge' || (github.ref == 'refs/heads/main' && 'main') || 'merge' }}
+      correlation_nonce: ${{ inputs.release_correlation_nonce }}

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -109,3 +109,22 @@ jobs:
             exit 1
           fi
           echo "All CodeQL analyses passed."
+
+
+      - name: checkout native evidence controller
+        uses: actions/checkout@v7
+
+      - name: emit native evidence for security.codeql
+        uses: ./.github/actions/ci-native-part
+        with:
+          id: security.codeql.codeql.source
+
+  native-evidence:
+    name: native-evidence
+    if: always()
+    needs: [analyze, CodeQL]
+    uses: ./.github/workflows/ci-native-evidence.yml
+    with:
+      workflow: .github/workflows/codeql.yml
+      needs_json: ${{ toJSON(needs) }}
+      posture: ${{ (github.event_name == 'pull_request' || github.event_name == 'merge_group') && 'merge' || (github.ref == 'refs/heads/main' && 'main') || 'merge' }}

--- a/.github/workflows/compatibility.yml
+++ b/.github/workflows/compatibility.yml
@@ -96,10 +96,10 @@ permissions:
   packages: read
 
 concurrency:
-  # A newer deep run may replace only push/schedule work on main. Release-head
-  # PRs, merge groups, dispatches, and maintenance pushes remain distinct.
-  group: ${{ github.workflow }}-${{ ((github.event_name == 'push' || github.event_name == 'schedule') && github.ref == 'refs/heads/main') && 'latest-main' || github.run_id }}
-  cancel-in-progress: ${{ (github.event_name == 'push' || github.event_name == 'schedule') && github.ref == 'refs/heads/main' }}
+  # Main pushes and matching cron schedules replace only their own modes.
+  # Release-head PRs, queue, dispatch, and maintenance remain distinct.
+  group: ${{ github.workflow }}-${{ (github.event_name == 'push' && github.ref == 'refs/heads/main') && 'latest-main-push' || (github.event_name == 'schedule' && github.ref == 'refs/heads/main' && github.event.schedule != '') && format('latest-main-schedule-{0}', github.event.schedule) || github.run_id }}
+  cancel-in-progress: ${{ (github.event_name == 'push' && github.ref == 'refs/heads/main') || (github.event_name == 'schedule' && github.ref == 'refs/heads/main' && github.event.schedule != '') }}
 
 jobs:
   # See `.github/workflows/ci.yml` for the rationale + filter convention.

--- a/.github/workflows/compatibility.yml
+++ b/.github/workflows/compatibility.yml
@@ -201,6 +201,11 @@ jobs:
       - name: go build (compile sanity)
         run: go build ./...
 
+
+      - name: emit native evidence for compatibility.gate
+        uses: ./.github/actions/ci-native-part
+        with:
+          id: compatibility.gate.gate.source
   prometheus:
     name: compatibility/prometheus
     needs: [changes, gate]
@@ -422,6 +427,11 @@ jobs:
           echo "::error title=compatibility/prometheus suite failed::compatibility harness (steps.compat) exited non-zero — see the 'Run compatibility harness' step log and the uploaded compatibility-prometheus-report artifact"
           exit 1
 
+
+      - name: emit native evidence for compatibility.prometheus
+        uses: ./.github/actions/ci-native-part
+        with:
+          id: compatibility.prometheus.prometheus.source
   prometheus-forced-route:
     # Phase-2 FLIP proof job for the sharded-pushdown solver. It runs the
     # SAME prometheus differential harness as `compatibility/prometheus`,
@@ -587,6 +597,11 @@ jobs:
           echo "::error title=compatibility/prometheus-forced-route failed::forced-route harness exited non-zero — route B (CERBERUS_EVAL_ROUTE=sharded) diverged from reference Prometheus, OR an infra failure occurred. See the harness log + the uploaded compatibility-prometheus-forced-route-report artifact"
           exit 1
 
+
+      - name: emit native evidence for compatibility.prometheus-forced-route
+        uses: ./.github/actions/ci-native-part
+        with:
+          id: compatibility.prometheus-forced-route.prometheus-forced-route.source
   prometheus-floor:
     # Floor-pinned proof job for #1500: internal/preflight/preflight.go's
     # minCHBase declares ClickHouse 24.8 as cerberus's supported floor, but
@@ -780,6 +795,11 @@ jobs:
           echo "::error title=compatibility/prometheus-floor failed::floor harness (ClickHouse 24.8) exited non-zero — an infra failure or a hard SQL rejection against the floor server. See the harness log + the uploaded compatibility-prometheus-floor-report artifact"
           exit 1
 
+
+      - name: emit native evidence for compatibility.prometheus-floor
+        uses: ./.github/actions/ci-native-part
+        with:
+          id: compatibility.prometheus-floor.prometheus-floor.source
   promql-surface:
     # Reference-backed full-surface PromQL rejection-completeness gate (#106).
     #
@@ -854,6 +874,11 @@ jobs:
         # misfile. node ships on ubuntu-latest, so no setup-node is needed.
         run: node .github/scripts/promql-surface-gate.mjs
 
+
+      - name: emit native evidence for compatibility.promql-surface
+        uses: ./.github/actions/ci-native-part
+        with:
+          id: compatibility.promql-surface.promql-surface.source
   tempo:
     name: compatibility/tempo
     needs: [changes, gate]
@@ -1023,6 +1048,11 @@ jobs:
           echo "::error title=compatibility/tempo suite failed::harness step failed -- see logs and uploaded report"
           exit 1
 
+
+      - name: emit native evidence for compatibility.tempo
+        uses: ./.github/actions/ci-native-part
+        with:
+          id: compatibility.tempo.tempo.source
   loki:
     name: compatibility/loki
     needs: [changes, gate]
@@ -1177,3 +1207,19 @@ jobs:
         run: |
           echo "::error title=compatibility/loki suite failed::harness step failed -- see logs and uploaded report"
           exit 1
+
+
+      - name: emit native evidence for compatibility.loki
+        uses: ./.github/actions/ci-native-part
+        with:
+          id: compatibility.loki.loki.source
+
+  native-evidence:
+    name: native-evidence
+    if: always()
+    needs: [changes, gate, prometheus, prometheus-forced-route, prometheus-floor, promql-surface, tempo, loki]
+    uses: ./.github/workflows/ci-native-evidence.yml
+    with:
+      workflow: .github/workflows/compatibility.yml
+      needs_json: ${{ toJSON(needs) }}
+      posture: ${{ (github.event_name == 'pull_request' || github.event_name == 'merge_group') && 'merge' || (github.ref == 'refs/heads/main' && 'main') || 'merge' }}

--- a/.github/workflows/compatibility.yml
+++ b/.github/workflows/compatibility.yml
@@ -79,6 +79,11 @@ on:
     - cron: '23 4 * * *'
     - cron: '37 4 * * *'
   workflow_dispatch:
+    inputs:
+      release_correlation_nonce:
+        description: 'Internal release-qualification nonce'
+        required: false
+        type: string
 
 permissions:
   # `contents: write` is required for the "Publish score to compat-scores
@@ -1222,4 +1227,5 @@ jobs:
     with:
       workflow: .github/workflows/compatibility.yml
       needs_json: ${{ toJSON(needs) }}
-      posture: ${{ (github.event_name == 'pull_request' || github.event_name == 'merge_group') && 'merge' || (github.ref == 'refs/heads/main' && 'main') || 'merge' }}
+      posture: ${{ inputs.release_correlation_nonce != '' && 'release' || (github.event_name == 'pull_request' || github.event_name == 'merge_group') && 'merge' || (github.ref == 'refs/heads/main' && 'main') || 'merge' }}
+      correlation_nonce: ${{ inputs.release_correlation_nonce }}

--- a/.github/workflows/config-docs.yml
+++ b/.github/workflows/config-docs.yml
@@ -17,6 +17,11 @@ on:
   push:
     branches: [main]
   workflow_dispatch:
+    inputs:
+      release_correlation_nonce:
+        description: 'Internal release-qualification nonce'
+        required: false
+        type: string
 
 permissions:
   contents: read
@@ -68,4 +73,5 @@ jobs:
     with:
       workflow: .github/workflows/config-docs.yml
       needs_json: ${{ toJSON(needs) }}
-      posture: ${{ (github.event_name == 'pull_request' || github.event_name == 'merge_group') && 'merge' || (github.ref == 'refs/heads/main' && 'main') || 'merge' }}
+      posture: ${{ inputs.release_correlation_nonce != '' && 'release' || (github.event_name == 'pull_request' || github.event_name == 'merge_group') && 'merge' || (github.ref == 'refs/heads/main' && 'main') || 'merge' }}
+      correlation_nonce: ${{ inputs.release_correlation_nonce }}

--- a/.github/workflows/config-docs.yml
+++ b/.github/workflows/config-docs.yml
@@ -53,3 +53,19 @@ jobs:
         run: |
           git diff --exit-code -- docs/configuration.md \
             || { echo "::error::docs/configuration.md is stale - run 'just gen-config-docs' and commit the result"; exit 1; }
+
+
+      - name: emit native evidence for docs.config-drift
+        uses: ./.github/actions/ci-native-part
+        with:
+          id: docs.config-drift.config-docs.source
+
+  native-evidence:
+    name: native-evidence
+    if: always()
+    needs: [config-docs]
+    uses: ./.github/workflows/ci-native-evidence.yml
+    with:
+      workflow: .github/workflows/config-docs.yml
+      needs_json: ${{ toJSON(needs) }}
+      posture: ${{ (github.event_name == 'pull_request' || github.event_name == 'merge_group') && 'merge' || (github.ref == 'refs/heads/main' && 'main') || 'merge' }}

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -124,3 +124,24 @@ jobs:
             cover-chdb.out
             cover-merged.out
           retention-days: 30
+
+
+      - name: emit native evidence for quality.coverage-enrollment
+        uses: ./.github/actions/ci-native-part
+        with:
+          id: quality.coverage-enrollment.coverage.source
+
+      - name: emit native evidence for quality.coverage-measured
+        uses: ./.github/actions/ci-native-part
+        with:
+          id: quality.coverage-measured.coverage.source
+
+  native-evidence:
+    name: native-evidence
+    if: always()
+    needs: [coverage]
+    uses: ./.github/workflows/ci-native-evidence.yml
+    with:
+      workflow: .github/workflows/coverage.yml
+      needs_json: ${{ toJSON(needs) }}
+      posture: ${{ (github.event_name == 'pull_request' || github.event_name == 'merge_group') && 'merge' || (github.ref == 'refs/heads/main' && 'main') || 'merge' }}

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -36,6 +36,11 @@ on:
     # so the runner doesn't double-book; well clear of the chdb job).
     - cron: '30 5 * * *'
   workflow_dispatch:
+    inputs:
+      release_correlation_nonce:
+        description: 'Internal release-qualification nonce'
+        required: false
+        type: string
 
 permissions:
   contents: read
@@ -144,4 +149,5 @@ jobs:
     with:
       workflow: .github/workflows/coverage.yml
       needs_json: ${{ toJSON(needs) }}
-      posture: ${{ (github.event_name == 'pull_request' || github.event_name == 'merge_group') && 'merge' || (github.ref == 'refs/heads/main' && 'main') || 'merge' }}
+      posture: ${{ inputs.release_correlation_nonce != '' && 'release' || (github.event_name == 'pull_request' || github.event_name == 'merge_group') && 'merge' || (github.ref == 'refs/heads/main' && 'main') || 'merge' }}
+      correlation_nonce: ${{ inputs.release_correlation_nonce }}

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -41,10 +41,10 @@ permissions:
   contents: read
 
 concurrency:
-  # A newer measured run may replace only push/schedule work on main. PR,
-  # queue, dispatch, and maintenance evidence is unique and never cancelled.
-  group: ${{ github.workflow }}-${{ ((github.event_name == 'push' || github.event_name == 'schedule') && github.ref == 'refs/heads/main') && 'latest-main' || github.run_id }}
-  cancel-in-progress: ${{ (github.event_name == 'push' || github.event_name == 'schedule') && github.ref == 'refs/heads/main' }}
+  # Main pushes and matching cron schedules replace only their own modes. PR,
+  # queue, dispatch, and maintenance evidence stays unique and uncancelled.
+  group: ${{ github.workflow }}-${{ (github.event_name == 'push' && github.ref == 'refs/heads/main') && 'latest-main-push' || (github.event_name == 'schedule' && github.ref == 'refs/heads/main' && github.event.schedule != '') && format('latest-main-schedule-{0}', github.event.schedule) || github.run_id }}
+  cancel-in-progress: ${{ (github.event_name == 'push' && github.ref == 'refs/heads/main') || (github.event_name == 'schedule' && github.ref == 'refs/heads/main' && github.event.schedule != '') }}
 
 jobs:
   coverage:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -120,6 +120,10 @@ on:
     - cron: '17 3 * * *'
   workflow_dispatch:
     inputs:
+      release_correlation_nonce:
+        description: 'Internal release-qualification nonce'
+        required: false
+        type: string
       update_crawl_inventory:
         description: >-
           Regenerate one or both Grafana crawl surface inventories
@@ -2065,4 +2069,5 @@ jobs:
     with:
       workflow: .github/workflows/e2e.yml
       needs_json: ${{ toJSON(needs) }}
-      posture: ${{ (github.event_name == 'pull_request' || github.event_name == 'merge_group') && 'merge' || (github.ref == 'refs/heads/main' && 'main') || 'merge' }}
+      posture: ${{ inputs.release_correlation_nonce != '' && 'release' || (github.event_name == 'pull_request' || github.event_name == 'merge_group') && 'merge' || (github.ref == 'refs/heads/main' && 'main') || 'merge' }}
+      correlation_nonce: ${{ inputs.release_correlation_nonce }}

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -147,6 +147,13 @@ on:
           - k3d
           - compose
           - both
+  workflow_call:
+    inputs:
+      release_qualification:
+        description: 'run the exact-SHA, non-cancellable full pre-publication E2E roster'
+        type: boolean
+        required: false
+        default: false
 
 permissions:
   contents: read
@@ -256,7 +263,7 @@ jobs:
         run: node .github/scripts/compose-smoke-matrix.mjs
         env:
           MODE: emit
-          IS_SCHEDULE: ${{ github.event_name == 'schedule' }}
+          IS_SCHEDULE: ${{ github.event_name == 'schedule' || inputs.release_qualification }}
           # Forwarded RAW: the emitter decides what it means for depth. A
           # dispatch that regenerates the compose inventory has to sweep the
           # crawl shard full, and the shard's timeout has to follow it — see
@@ -917,7 +924,7 @@ jobs:
           SETUP_RESULT: ${{ needs.compose-smoke-setup.result }}
           HAS_INFORMATIONAL: ${{ needs.compose-smoke-setup.outputs.has_informational }}
           CRAWL_SHARD_RESULT: ${{ needs.compose-smoke-shard-info.result }}
-          SWEEP_DEPTH: ${{ github.event_name == 'schedule' && 'full' || 'lean' }}
+          SWEEP_DEPTH: ${{ (github.event_name == 'schedule' || inputs.release_qualification) && 'full' || 'lean' }}
 
   # ---------------------------------------------------------------------------
   # dashboard (k3d) lane — SHARDED across a modest matrix of isolated k3d
@@ -1011,7 +1018,7 @@ jobs:
           # validated by the FULL matrix — a release must never ship a mode
           # the gate didn't exercise. Regular pull_request + push get the
           # fast smoke-only matrix.
-          INCLUDE_CRAWL: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || startsWith(github.head_ref, 'release/') }}
+          INCLUDE_CRAWL: ${{ inputs.release_qualification || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || startsWith(github.head_ref, 'release/') }}
           # Split mode doubles the k3d boot count (the setup-bound long pole),
           # so regular PR/push exercise monolith only. It runs on schedule +
           # dispatch AND — critically — on release PRs (head branch release/*),
@@ -1019,7 +1026,7 @@ jobs:
           # split before the release PR can merge + publish. (A broken split
           # shipped in v1.4.0 precisely because the release commit's checks
           # never ran split; this closes that hole.)
-          INCLUDE_SPLIT: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || startsWith(github.head_ref, 'release/') }}
+          INCLUDE_SPLIT: ${{ inputs.release_qualification || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || startsWith(github.head_ref, 'release/') }}
           UPDATE_CRAWL_INVENTORY: ${{ inputs.update_crawl_inventory }}
 
   dashboard-shard:
@@ -1056,7 +1063,7 @@ jobs:
       # dispatch. On push-to-main the crawl shard is a near-instant green no-op: every
       # expensive step below is gated on RUN_SHARD, which is false for the crawl
       # shard on a push event. The smoke shards always run.
-      RUN_SHARD: ${{ matrix.crawlStack != 'k3d' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || startsWith(github.head_ref, 'release/') }}
+      RUN_SHARD: ${{ matrix.crawlStack != 'k3d' || inputs.release_qualification || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || startsWith(github.head_ref, 'release/') }}
     steps: &dashboard_shard_steps
       - uses: actions/checkout@v7
 
@@ -1459,7 +1466,7 @@ jobs:
           SCOPE_RESULT: success
           SETUP_RESULT: ${{ needs.dashboard-setup.result }}
           HAS_INFORMATIONAL: ${{ needs.dashboard-setup.outputs.has_informational }}
-          CRAWL_EXPECTED: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || startsWith(github.head_ref, 'release/') }}
+          CRAWL_EXPECTED: ${{ inputs.release_qualification || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || startsWith(github.head_ref, 'release/') }}
           CRAWL_SHARD_RESULT: ${{ needs.dashboard-shard-info.result }}
           SWEEP_DEPTH: full
 
@@ -1473,7 +1480,7 @@ jobs:
     needs: [dashboard-setup, dashboard-shard-info]
     if: >-
       always() && needs.dashboard-shard-info.result == 'success' &&
-      (github.event_name == 'schedule' || startsWith(github.head_ref, 'release/') ||
+      (inputs.release_qualification || github.event_name == 'schedule' || startsWith(github.head_ref, 'release/') ||
       (github.event_name == 'workflow_dispatch' &&
       inputs.update_crawl_inventory != 'k3d' && inputs.update_crawl_inventory != 'both'))
     runs-on: ubuntu-latest
@@ -1574,7 +1581,7 @@ jobs:
     # stays on `check` + `lint` + `compose-smoke`. Runs on push-to-main +
     # nightly + manual dispatch alongside the dashboard job.
     name: startup-bench
-    if: github.event_name == 'push' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+    if: inputs.release_qualification || github.event_name == 'push' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     concurrency:
@@ -1707,7 +1714,7 @@ jobs:
     # nightly + manual dispatch ONLY, never on pull_request, and is NOT a
     # branch-protection required check. A regression is caught at
     # merge-to-main time and reverted from main, not blocked pre-merge.
-    if: github.event_name == 'push' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+    if: inputs.release_qualification || github.event_name == 'push' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     # 40 to match the dashboard budget. Shared bring-up (e2e-up +
     # seed-rolling + wait-otel) is ~10-15 min; the phase-1 fault scenarios
@@ -1924,7 +1931,7 @@ jobs:
           seed: ci-${{ github.run_id }}-${{ github.run_attempt }}
   bwc-minio:
     name: bwc-minio
-    if: github.event_name == 'push' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+    if: inputs.release_qualification || github.event_name == 'push' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     timeout-minutes: 40
     concurrency:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -888,6 +888,14 @@ jobs:
   # child check, and re-gating it here would undo the de-gate on purpose. It is
   # `cancelled` and `skipped` that this job exists to make impossible to ignore.
   # Not a branch-protection context, so it reports without blocking merges.
+
+      - name: checkout native evidence controller
+        uses: actions/checkout@v7
+
+      - name: emit native evidence for e2e.compose-smoke
+        uses: ./.github/actions/ci-native-part
+        with:
+          id: e2e.compose-smoke.compose-smoke.source
   crawl-terminal:
     name: crawl-terminal
     needs: [compose-smoke-scope, compose-smoke-setup, compose-smoke-shard-info]
@@ -950,6 +958,11 @@ jobs:
   #                       shard, and a RELEASE-required check (release.yml's
   #                       preflight reads it by name). The clean roll-up + the
   #                       coverage-discipline guard mirror compose-smoke.
+
+      - name: emit native evidence for e2e.compose-crawl
+        uses: ./.github/actions/ci-native-part
+        with:
+          id: e2e.compose-crawl.crawl-terminal.source
   dashboard-setup:
     name: dashboard-setup
     # push + nightly + manual dispatch always; pull_request ONLY when the head
@@ -1446,6 +1459,11 @@ jobs:
           CRAWL_SHARD_RESULT: ${{ needs.dashboard-shard-info.result }}
           SWEEP_DEPTH: full
 
+
+      - name: emit native evidence for e2e.dashboard-crawl
+        uses: ./.github/actions/ci-native-part
+        with:
+          id: e2e.dashboard-crawl.dashboard-crawl-terminal.source
   dashboard-crawl-merge:
     name: dashboard-crawl-merge
     needs: [dashboard-setup, dashboard-shard-info]
@@ -1538,6 +1556,14 @@ jobs:
            fi
            echo "all dashboard shards passed."
 
+
+      - name: checkout native evidence controller
+        uses: actions/checkout@v7
+
+      - name: emit native evidence for e2e.dashboard
+        uses: ./.github/actions/ci-native-part
+        with:
+          id: e2e.dashboard.dashboard.source
   startup-bench:
     # Startup-speed benchmark: spawn cerberus and assert <2 s to /healthz.
     # Informational only — not a required gate. The fast-feedback PR loop
@@ -1657,6 +1683,11 @@ jobs:
         if: always()
         run: docker rm -f clickhouse || true
 
+
+      - name: emit native evidence for e2e.startup-bench
+        uses: ./.github/actions/ci-native-part
+        with:
+          id: e2e.startup-bench.startup-bench.source
   chaos:
     name: chaos
     # Live-stack chaos-engineering lane: fault-inject against the running
@@ -1881,6 +1912,12 @@ jobs:
   # pull_request, so NOT a branch-protection check). Own concurrency + timeout;
   # deliberately NOT added to the dashboard/compose disjoint-cover shard
   # matrices — it is a separate single-cluster lane, not a Playwright shard.
+
+      - name: emit native evidence for e2e.chaos
+        uses: ./.github/actions/ci-native-part
+        with:
+          id: e2e.chaos.chaos.source
+          seed: ci-${{ github.run_id }}-${{ github.run_attempt }}
   bwc-minio:
     name: bwc-minio
     if: github.event_name == 'push' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
@@ -2013,3 +2050,19 @@ jobs:
       - name: Tear down
         if: always()
         run: just e2e-bwc-down
+
+
+      - name: emit native evidence for e2e.bwc-minio
+        uses: ./.github/actions/ci-native-part
+        with:
+          id: e2e.bwc-minio.bwc-minio.source
+
+  native-evidence:
+    name: native-evidence
+    if: always()
+    needs: [compose-smoke, crawl-terminal, dashboard-crawl-terminal, dashboard, startup-bench, chaos, bwc-minio]
+    uses: ./.github/workflows/ci-native-evidence.yml
+    with:
+      workflow: .github/workflows/e2e.yml
+      needs_json: ${{ toJSON(needs) }}
+      posture: ${{ (github.event_name == 'pull_request' || github.event_name == 'merge_group') && 'merge' || (github.ref == 'refs/heads/main' && 'main') || 'merge' }}

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -2060,7 +2060,7 @@ jobs:
   native-evidence:
     name: native-evidence
     if: always()
-    needs: [compose-smoke, crawl-terminal, dashboard-crawl-terminal, dashboard, startup-bench, chaos, bwc-minio]
+    needs: [bwc-minio, chaos, compose-crawl-merge, compose-smoke, compose-smoke-scope, compose-smoke-setup, compose-smoke-shard, compose-smoke-shard-info, crawl-terminal, dashboard, dashboard-crawl-merge, dashboard-crawl-terminal, dashboard-setup, dashboard-shard, dashboard-shard-info, startup-bench]
     uses: ./.github/workflows/ci-native-evidence.yml
     with:
       workflow: .github/workflows/e2e.yml

--- a/.github/workflows/forbid-deferral.yml
+++ b/.github/workflows/forbid-deferral.yml
@@ -114,3 +114,19 @@ jobs:
         run: node .github/scripts/rejection-parity-divergence-liveness.mjs
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+
+      - name: emit native evidence for governance.forbid-deferral
+        uses: ./.github/actions/ci-native-part
+        with:
+          id: governance.forbid-deferral.forbid-deferral.source
+
+  native-evidence:
+    name: native-evidence
+    if: always()
+    needs: [forbid-deferral]
+    uses: ./.github/workflows/ci-native-evidence.yml
+    with:
+      workflow: .github/workflows/forbid-deferral.yml
+      needs_json: ${{ toJSON(needs) }}
+      posture: ${{ (github.event_name == 'pull_request' || github.event_name == 'merge_group') && 'merge' || (github.ref == 'refs/heads/main' && 'main') || 'merge' }}

--- a/.github/workflows/forbid-deferral.yml
+++ b/.github/workflows/forbid-deferral.yml
@@ -49,6 +49,12 @@ on:
   # reject. The surface on a queue run is the same one a push resolves: the
   # head commit's associated pull request.
   merge_group:
+  workflow_dispatch:
+    inputs:
+      release_correlation_nonce:
+        description: 'Internal release-qualification nonce'
+        required: false
+        type: string
 
 permissions:
   contents: read
@@ -129,4 +135,5 @@ jobs:
     with:
       workflow: .github/workflows/forbid-deferral.yml
       needs_json: ${{ toJSON(needs) }}
-      posture: ${{ (github.event_name == 'pull_request' || github.event_name == 'merge_group') && 'merge' || (github.ref == 'refs/heads/main' && 'main') || 'merge' }}
+      posture: ${{ inputs.release_correlation_nonce != '' && 'release' || (github.event_name == 'pull_request' || github.event_name == 'merge_group') && 'merge' || (github.ref == 'refs/heads/main' && 'main') || 'merge' }}
+      correlation_nonce: ${{ inputs.release_correlation_nonce }}

--- a/.github/workflows/merge-fence.yml
+++ b/.github/workflows/merge-fence.yml
@@ -1,0 +1,63 @@
+name: merge-fence
+
+on:
+  pull_request:
+  merge_group:
+
+permissions:
+  actions: read
+  contents: read
+
+concurrency:
+  group: merge-fence-${{ github.run_id }}
+  cancel-in-progress: false
+
+jobs:
+  merge-fence:
+    name: merge-fence
+    runs-on: ubuntu-latest
+    timeout-minutes: 22
+    steps:
+      - name: checkout the exact projected trunk
+        uses: actions/checkout@v7
+        with:
+          ref: ${{ github.sha }}
+          fetch-depth: 0
+          clean: true
+
+      - name: create evidence workspace
+        run: mkdir -p build/ci-lane-fence
+
+      - id: select
+        name: select the fail-closed merge fence
+        env:
+          CI_LANE_BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.merge_group.base_sha }}
+          CI_LANE_HEAD_SHA: ${{ github.sha }}
+          CI_LANE_SELECTION_OUTPUT: build/ci-lane-fence/selection.json
+        run: node .github/scripts/ci-lane-selection.mjs
+
+      - name: publish the immutable selection manifest
+        uses: actions/upload-artifact@v7
+        with:
+          name: merge-fence-selection-${{ github.run_id }}-${{ github.run_attempt }}
+          path: build/ci-lane-fence/selection.json
+          if-no-files-found: error
+          retention-days: 14
+
+      - id: collect
+        name: collect lane-native shadow evidence
+        env:
+          CI_LANE_SELECTION: build/ci-lane-fence/selection.json
+          CI_LANE_SHADOW_OUTPUT: build/ci-lane-fence/observation.json
+          CI_LANE_SHADOW_TIMEOUT_SECONDS: '1200'
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: node .github/scripts/ci-lane-shadow-collector.mjs
+
+      - name: publish the shadow observation
+        if: always() && steps.select.outcome == 'success'
+        uses: actions/upload-artifact@v7
+        with:
+          name: merge-fence-shadow-${{ github.run_id }}-${{ github.run_attempt }}
+          path: build/ci-lane-fence/observation.json
+          if-no-files-found: error
+          retention-days: 30

--- a/.github/workflows/migration-e2e.yml
+++ b/.github/workflows/migration-e2e.yml
@@ -49,9 +49,10 @@ on:
         description: 'a single MIG id to drive, e.g. MIG-04'
         type: string
         required: false
-  # Called by release.yml to re-run this lane against the sealed, unpublished
-  # candidate. The source invocation and the candidate invocation are distinct
-  # required release proofs over the same source SHA/tree.
+  # Called by release.yml's `release-artifact-migration`, which re-runs this lane
+  # against the image goreleaser just built — the push-triggered run above proves
+  # the SOURCE TREE, this one proves the ARTIFACT. `inputs.*` reads identically
+  # for workflow_dispatch and workflow_call, so the job bodies are unchanged.
   #
   # This is still NOT a `pull_request:` trigger: the workflow remains ineligible
   # as a branch-protection check, and release.yml's preflight is what makes it
@@ -66,36 +67,28 @@ on:
         description: 'a single MIG id to drive, e.g. MIG-04'
         type: string
         required: false
-      candidate_artifact:
-        description: 'caller-run artifact containing the sealed unpublished candidate; empty = source tree'
-        type: string
-        default: ''
-      candidate_digest:
-        description: 'exact sha256 digest of the candidate manifest'
+      cerberus_image:
+        description: 'released image to drive instead of a locally built one; empty = build from this tree'
         type: string
         default: ''
       expect_version:
-        description: 'version the candidate binary and server must report'
-        type: string
-        default: ''
-      source_sha:
-        description: 'exact candidate source commit'
-        type: string
-        default: ''
-      source_tree:
-        description: 'exact candidate source tree'
+        description: 'version the running server must report; empty = no version assertion'
         type: string
         default: ''
 
 permissions:
   contents: read
+  # Pulling the released image from GHCR. A called workflow gets the
+  # INTERSECTION of the caller's grant and this block, so omitting it here would
+  # silently drop the caller's `packages: read`.
+  packages: read
 
 concurrency:
-  # Only replaceable source-tree push/schedule work on main shares a group.
-  # Candidate workflow calls, dispatches, and maintenance qualification use a
-  # unique run-id group and can neither queue behind nor cancel source work.
-  group: ${{ github.workflow }}-${{ ((github.event_name == 'push' || github.event_name == 'schedule') && github.ref == 'refs/heads/main') && 'latest-main' || github.run_id }}
-  cancel-in-progress: ${{ (github.event_name == 'push' || github.event_name == 'schedule') && github.ref == 'refs/heads/main' }}
+  # Main pushes and matching cron schedules replace only their own modes.
+  # Artifact calls, dispatches, and maintenance qualification use a unique
+  # run-id group and can neither queue behind nor cancel source work.
+  group: ${{ github.workflow }}-${{ (github.event_name == 'push' && github.ref == 'refs/heads/main') && 'latest-main-push' || (github.event_name == 'schedule' && github.ref == 'refs/heads/main' && github.event.schedule != '') && format('latest-main-schedule-{0}', github.event.schedule) || github.run_id }}
+  cancel-in-progress: ${{ (github.event_name == 'push' && github.ref == 'refs/heads/main') || (github.event_name == 'schedule' && github.ref == 'refs/heads/main' && github.event.schedule != '') }}
 
 jobs:
   # Enumerate the Gherkin features, hold them to the 26-story anchor, and
@@ -148,6 +141,18 @@ jobs:
   # Tier-0 offline slice: godog over committed fixtures, no Docker, no
   # reference backend. A fixed job like its two siblings — it drives one
   # tag filter on one runner, so there is nothing to fan out over.
+
+      - name: emit native evidence for migration.e2e
+        if: ${{ inputs.cerberus_image != '' }}
+        uses: ./.github/actions/ci-native-part
+        with:
+          id: migration.e2e.migration-setup.artifact
+
+      - name: emit native evidence for migration.e2e
+        if: ${{ inputs.cerberus_image == '' }}
+        uses: ./.github/actions/ci-native-part
+        with:
+          id: migration.e2e.migration-setup.source
   migration-tier0:
     name: migration-tier0
     needs: migration-setup
@@ -177,16 +182,32 @@ jobs:
           name: migration-scenarios
           path: build
 
-      # Source mode compiles from the checkout. Candidate mode downloads the
-      # sealed caller-run artifact, verifies its complete digest roster, and
-      # loads its exact OCI digest into an ephemeral loopback registry.
-      - uses: ./.github/actions/resolve-migration-artifact
-        with:
-          candidate-artifact: ${{ inputs.candidate_artifact }}
-          candidate-digest: ${{ inputs.candidate_digest }}
-          expect-version: ${{ inputs.expect_version }}
-          source-sha: ${{ inputs.source_sha }}
-          source-tree: ${{ inputs.source_tree }}
+      # Unconditional, in every tier job, ahead of the resolver: the released
+      # image lives in GHCR, and a first-publish package is not necessarily
+      # public at the instant the artifact lane pulls it. No `if:` guard, so
+      # there is no condition whose falsification would let the release path
+      # silently fall back to a source build.
+      - name: Log in to GHCR
+        env:
+          REGISTRY: ghcr.io
+          USERNAME: ${{ github.repository_owner }}
+          PASSWORD: ${{ secrets.GITHUB_TOKEN }}
+        run: node .github/scripts/registry-login.mjs
+
+      # WHICH cerberus this run tests. On a PR / dispatch / push run both inputs
+      # are empty and the resolver compiles the CLI from this tree; on
+      # release.yml's `release-artifact-migration` call it extracts the CLI out
+      # of the released image, so the binary the scenarios exec and the server
+      # the stack runs are the same bytes. Either way it probes `--version` and
+      # refuses a binary that is not the one this run claims to test, and
+      # exports CERBERUS_BIN / CERBERUS_IMAGE / CERBERUS_EXPECT_VERSION for
+      # every later step. Keeping it its own step also keeps a build failure
+      # separate from a scenario failure in the log.
+      - name: resolve the cerberus artifact under test
+        run: node .github/scripts/migration-artifact.mjs
+        env:
+          CERBERUS_IMAGE_INPUT: ${{ inputs.cerberus_image }}
+          CERBERUS_EXPECT_VERSION_INPUT: ${{ inputs.expect_version }}
 
       - name: run the migration scenarios
         run: node .github/scripts/migration-e2e.mjs
@@ -211,10 +232,6 @@ jobs:
           retention-days: 1
           if-no-files-found: warn
 
-      - name: remove the candidate registry
-        if: always()
-        run: node .github/scripts/migration-artifact.mjs cleanup
-
   # Tier-1 dual-backend substrate + parity + Gherkin (Layer 14). Unlike
   # migration-tier0 it brings a compose stack up, seeds every @tier1 archetype
   # and tears it down around the suite. It drives the fixed `TIER=tier1` slice
@@ -223,6 +240,18 @@ jobs:
   # migration.yml workflow) so the dual-backend compose stack is brought up
   # and torn down exactly once per run instead of running two separate
   # Docker-backed lanes side by side.
+
+      - name: emit native evidence for migration.e2e
+        if: ${{ inputs.cerberus_image != '' }}
+        uses: ./.github/actions/ci-native-part
+        with:
+          id: migration.e2e.migration-tier0.artifact
+
+      - name: emit native evidence for migration.e2e
+        if: ${{ inputs.cerberus_image == '' }}
+        uses: ./.github/actions/ci-native-part
+        with:
+          id: migration.e2e.migration-tier0.source
   migration-tier1:
     name: migration-tier1
     needs: migration-setup
@@ -267,6 +296,15 @@ jobs:
         with:
           tool: just
 
+      # See migration-tier0's identical block: unconditional so the artifact
+      # lane's GHCR pull can never silently degrade into a source build.
+      - name: Log in to GHCR
+        env:
+          REGISTRY: ghcr.io
+          USERNAME: ${{ github.repository_owner }}
+          PASSWORD: ${{ secrets.GITHUB_TOKEN }}
+        run: node .github/scripts/registry-login.mjs
+
       # Anonymous Docker Hub pulls are rate-limited hard enough to fail a cold
       # runner mid-`compose up` from a shared runner IP, and this stack pulls
       # five upstream images; the other Docker-backed lanes log in first for
@@ -296,13 +334,17 @@ jobs:
           name: migration-scenarios
           path: build
 
-      - uses: ./.github/actions/resolve-migration-artifact
-        with:
-          candidate-artifact: ${{ inputs.candidate_artifact }}
-          candidate-digest: ${{ inputs.candidate_digest }}
-          expect-version: ${{ inputs.expect_version }}
-          source-sha: ${{ inputs.source_sha }}
-          source-tree: ${{ inputs.source_tree }}
+      # See migration-tier0's identical step. This tier used to acquire no CLI
+      # at all (lib.BuildCerberus compiled one in-process), which meant the
+      # release path had no seam to hand a released binary through and no place
+      # to fail early on a wrong one. It also puts CERBERUS_IMAGE into the env
+      # `just migration-cerberus-image` and the compose file read, so the stack
+      # below runs the image this run resolved.
+      - name: resolve the cerberus artifact under test
+        run: node .github/scripts/migration-artifact.mjs
+        env:
+          CERBERUS_IMAGE_INPUT: ${{ inputs.cerberus_image }}
+          CERBERUS_EXPECT_VERSION_INPUT: ${{ inputs.expect_version }}
 
       - name: bring the Tier-1 stack up
         run: just migration-tier1-up
@@ -374,10 +416,6 @@ jobs:
         if: always()
         run: just migration-tier1-down
 
-      - name: remove the candidate registry
-        if: always()
-        run: node .github/scripts/migration-artifact.mjs cleanup
-
   # Tier-2 ruler substrate + the @tier2 Gherkin scenarios (Layer 14). Same
   # shape as migration-tier1, over the Tier-1 compose file PLUS
   # tiers/tier2-ruler's, merged into the one compose project
@@ -387,6 +425,18 @@ jobs:
   # section 8 builds firing parity on top of proven query parity, and every
   # @tier2 scenario reads the same cerberus/ClickHouse pair Tier 1 proves. A
   # green tier-2 over a red tier-1 would be a verdict about nothing.
+
+      - name: emit native evidence for migration.e2e
+        if: ${{ inputs.cerberus_image != '' }}
+        uses: ./.github/actions/ci-native-part
+        with:
+          id: migration.e2e.migration-tier1.artifact
+
+      - name: emit native evidence for migration.e2e
+        if: ${{ inputs.cerberus_image == '' }}
+        uses: ./.github/actions/ci-native-part
+        with:
+          id: migration.e2e.migration-tier1.source
   migration-tier2:
     name: migration-tier2
     needs: [migration-setup, migration-tier1]
@@ -425,6 +475,14 @@ jobs:
         with:
           tool: just
 
+      # See migration-tier0's identical block.
+      - name: Log in to GHCR
+        env:
+          REGISTRY: ghcr.io
+          USERNAME: ${{ github.repository_owner }}
+          PASSWORD: ${{ secrets.GITHUB_TOKEN }}
+        run: node .github/scripts/registry-login.mjs
+
       # An unreachable Docker Hub no longer takes this job down with it: the
       # login exhausts its retries on a transport fault and downgrades the job
       # to MIRROR-ONLY (registry-login.mjs), where every image comes from the
@@ -445,13 +503,14 @@ jobs:
           name: migration-scenarios
           path: build
 
-      - uses: ./.github/actions/resolve-migration-artifact
-        with:
-          candidate-artifact: ${{ inputs.candidate_artifact }}
-          candidate-digest: ${{ inputs.candidate_digest }}
-          expect-version: ${{ inputs.expect_version }}
-          source-sha: ${{ inputs.source_sha }}
-          source-tree: ${{ inputs.source_tree }}
+      # See migration-tier1's identical step — the Tier-2 stack is a superset of
+      # Tier-1's and runs the same `cerberus` service, so it resolves the same
+      # artifact.
+      - name: resolve the cerberus artifact under test
+        run: node .github/scripts/migration-artifact.mjs
+        env:
+          CERBERUS_IMAGE_INPUT: ${{ inputs.cerberus_image }}
+          CERBERUS_EXPECT_VERSION_INPUT: ${{ inputs.expect_version }}
 
       - name: bring the Tier-2 stack up
         run: just migration-tier2-up
@@ -511,10 +570,6 @@ jobs:
         if: always()
         run: just migration-tier2-down
 
-      - name: remove the candidate registry
-        if: always()
-        run: node .github/scripts/migration-artifact.mjs cleanup
-
   # Roll-up. `contains(needs.*.result, 'failure')` is the shape e2e.yml
   # documents as unsafe: a job rolls up to `cancelled`, not `failure`, when it
   # is cancelled, so a cancelled tier would pass the fold silently.
@@ -522,6 +577,18 @@ jobs:
   # — it holds every tier emit SELECTED to `success`, and separately refuses a
   # tier that ran without being selected — and this repo keeps that in a .mjs
   # so it is testable (see .github/scripts/README.md).
+
+      - name: emit native evidence for migration.e2e
+        if: ${{ inputs.cerberus_image != '' }}
+        uses: ./.github/actions/ci-native-part
+        with:
+          id: migration.e2e.migration-tier2.artifact
+
+      - name: emit native evidence for migration.e2e
+        if: ${{ inputs.cerberus_image == '' }}
+        uses: ./.github/actions/ci-native-part
+        with:
+          id: migration.e2e.migration-tier2.source
   migration-aggregate:
     name: migration-e2e
     needs: [migration-setup, migration-tier0, migration-tier1, migration-tier2]
@@ -582,3 +649,13 @@ jobs:
           RESULT_TIER0: ${{ needs.migration-tier0.result }}
           RESULT_TIER1: ${{ needs.migration-tier1.result }}
           RESULT_TIER2: ${{ needs.migration-tier2.result }}
+
+  native-evidence:
+    name: native-evidence
+    if: always()
+    needs: [migration-aggregate, migration-setup, migration-tier0, migration-tier1, migration-tier2]
+    uses: ./.github/workflows/ci-native-evidence.yml
+    with:
+      workflow: .github/workflows/migration-e2e.yml
+      needs_json: ${{ toJSON(needs) }}
+      posture: ${{ github.event_name == 'workflow_call' && 'release' || (github.event_name == 'pull_request' || github.event_name == 'merge_group') && 'merge' || (github.ref == 'refs/heads/main' && 'main') || 'merge' }}

--- a/.github/workflows/migration-e2e.yml
+++ b/.github/workflows/migration-e2e.yml
@@ -84,11 +84,11 @@ permissions:
   packages: read
 
 concurrency:
-  # Only replaceable source-tree push/schedule work on main shares a group.
-  # Artifact workflow calls, dispatches, and maintenance qualification use a
-  # unique run-id group and can neither queue behind nor cancel source work.
-  group: ${{ github.workflow }}-${{ ((github.event_name == 'push' || github.event_name == 'schedule') && github.ref == 'refs/heads/main') && 'latest-main' || github.run_id }}
-  cancel-in-progress: ${{ (github.event_name == 'push' || github.event_name == 'schedule') && github.ref == 'refs/heads/main' }}
+  # Main pushes and matching cron schedules replace only their own modes.
+  # Artifact calls, dispatches, and maintenance qualification use a unique
+  # run-id group and can neither queue behind nor cancel source work.
+  group: ${{ github.workflow }}-${{ (github.event_name == 'push' && github.ref == 'refs/heads/main') && 'latest-main-push' || (github.event_name == 'schedule' && github.ref == 'refs/heads/main' && github.event.schedule != '') && format('latest-main-schedule-{0}', github.event.schedule) || github.run_id }}
+  cancel-in-progress: ${{ (github.event_name == 'push' && github.ref == 'refs/heads/main') || (github.event_name == 'schedule' && github.ref == 'refs/heads/main' && github.event.schedule != '') }}
 
 jobs:
   # Enumerate the Gherkin features, hold them to the 26-story anchor, and

--- a/.github/workflows/migration-e2e.yml
+++ b/.github/workflows/migration-e2e.yml
@@ -49,10 +49,9 @@ on:
         description: 'a single MIG id to drive, e.g. MIG-04'
         type: string
         required: false
-  # Called by release.yml's `release-artifact-migration`, which re-runs this lane
-  # against the image goreleaser just built — the push-triggered run above proves
-  # the SOURCE TREE, this one proves the ARTIFACT. `inputs.*` reads identically
-  # for workflow_dispatch and workflow_call, so the job bodies are unchanged.
+  # Called by release.yml to re-run this lane against the sealed, unpublished
+  # candidate. The source invocation and the candidate invocation are distinct
+  # required release proofs over the same source SHA/tree.
   #
   # This is still NOT a `pull_request:` trigger: the workflow remains ineligible
   # as a branch-protection check, and release.yml's preflight is what makes it
@@ -67,28 +66,36 @@ on:
         description: 'a single MIG id to drive, e.g. MIG-04'
         type: string
         required: false
-      cerberus_image:
-        description: 'released image to drive instead of a locally built one; empty = build from this tree'
+      candidate_artifact:
+        description: 'caller-run artifact containing the sealed unpublished candidate; empty = source tree'
+        type: string
+        default: ''
+      candidate_digest:
+        description: 'exact sha256 digest of the candidate manifest'
         type: string
         default: ''
       expect_version:
-        description: 'version the running server must report; empty = no version assertion'
+        description: 'version the candidate binary and server must report'
+        type: string
+        default: ''
+      source_sha:
+        description: 'exact candidate source commit'
+        type: string
+        default: ''
+      source_tree:
+        description: 'exact candidate source tree'
         type: string
         default: ''
 
 permissions:
   contents: read
-  # Pulling the released image from GHCR. A called workflow gets the
-  # INTERSECTION of the caller's grant and this block, so omitting it here would
-  # silently drop the caller's `packages: read`.
-  packages: read
 
 concurrency:
-  # Main pushes and matching cron schedules replace only their own modes.
-  # Artifact calls, dispatches, and maintenance qualification use a unique
-  # run-id group and can neither queue behind nor cancel source work.
-  group: ${{ github.workflow }}-${{ (github.event_name == 'push' && github.ref == 'refs/heads/main') && 'latest-main-push' || (github.event_name == 'schedule' && github.ref == 'refs/heads/main' && github.event.schedule != '') && format('latest-main-schedule-{0}', github.event.schedule) || github.run_id }}
-  cancel-in-progress: ${{ (github.event_name == 'push' && github.ref == 'refs/heads/main') || (github.event_name == 'schedule' && github.ref == 'refs/heads/main' && github.event.schedule != '') }}
+  # Only replaceable source-tree push/schedule work on main shares a group.
+  # Candidate workflow calls, dispatches, and maintenance qualification use a
+  # unique run-id group and can neither queue behind nor cancel source work.
+  group: ${{ github.workflow }}-${{ ((github.event_name == 'push' || github.event_name == 'schedule') && github.ref == 'refs/heads/main') && 'latest-main' || github.run_id }}
+  cancel-in-progress: ${{ (github.event_name == 'push' || github.event_name == 'schedule') && github.ref == 'refs/heads/main' }}
 
 jobs:
   # Enumerate the Gherkin features, hold them to the 26-story anchor, and
@@ -141,18 +148,6 @@ jobs:
   # Tier-0 offline slice: godog over committed fixtures, no Docker, no
   # reference backend. A fixed job like its two siblings — it drives one
   # tag filter on one runner, so there is nothing to fan out over.
-
-      - name: emit native evidence for migration.e2e
-        if: ${{ inputs.cerberus_image != '' }}
-        uses: ./.github/actions/ci-native-part
-        with:
-          id: migration.e2e.migration-setup.artifact
-
-      - name: emit native evidence for migration.e2e
-        if: ${{ inputs.cerberus_image == '' }}
-        uses: ./.github/actions/ci-native-part
-        with:
-          id: migration.e2e.migration-setup.source
   migration-tier0:
     name: migration-tier0
     needs: migration-setup
@@ -182,32 +177,16 @@ jobs:
           name: migration-scenarios
           path: build
 
-      # Unconditional, in every tier job, ahead of the resolver: the released
-      # image lives in GHCR, and a first-publish package is not necessarily
-      # public at the instant the artifact lane pulls it. No `if:` guard, so
-      # there is no condition whose falsification would let the release path
-      # silently fall back to a source build.
-      - name: Log in to GHCR
-        env:
-          REGISTRY: ghcr.io
-          USERNAME: ${{ github.repository_owner }}
-          PASSWORD: ${{ secrets.GITHUB_TOKEN }}
-        run: node .github/scripts/registry-login.mjs
-
-      # WHICH cerberus this run tests. On a PR / dispatch / push run both inputs
-      # are empty and the resolver compiles the CLI from this tree; on
-      # release.yml's `release-artifact-migration` call it extracts the CLI out
-      # of the released image, so the binary the scenarios exec and the server
-      # the stack runs are the same bytes. Either way it probes `--version` and
-      # refuses a binary that is not the one this run claims to test, and
-      # exports CERBERUS_BIN / CERBERUS_IMAGE / CERBERUS_EXPECT_VERSION for
-      # every later step. Keeping it its own step also keeps a build failure
-      # separate from a scenario failure in the log.
-      - name: resolve the cerberus artifact under test
-        run: node .github/scripts/migration-artifact.mjs
-        env:
-          CERBERUS_IMAGE_INPUT: ${{ inputs.cerberus_image }}
-          CERBERUS_EXPECT_VERSION_INPUT: ${{ inputs.expect_version }}
+      # Source mode compiles from the checkout. Candidate mode downloads the
+      # sealed caller-run artifact, verifies its complete digest roster, and
+      # loads its exact OCI digest into an ephemeral loopback registry.
+      - uses: ./.github/actions/resolve-migration-artifact
+        with:
+          candidate-artifact: ${{ inputs.candidate_artifact }}
+          candidate-digest: ${{ inputs.candidate_digest }}
+          expect-version: ${{ inputs.expect_version }}
+          source-sha: ${{ inputs.source_sha }}
+          source-tree: ${{ inputs.source_tree }}
 
       - name: run the migration scenarios
         run: node .github/scripts/migration-e2e.mjs
@@ -232,6 +211,10 @@ jobs:
           retention-days: 1
           if-no-files-found: warn
 
+      - name: remove the candidate registry
+        if: always()
+        run: node .github/scripts/migration-artifact.mjs cleanup
+
   # Tier-1 dual-backend substrate + parity + Gherkin (Layer 14). Unlike
   # migration-tier0 it brings a compose stack up, seeds every @tier1 archetype
   # and tears it down around the suite. It drives the fixed `TIER=tier1` slice
@@ -240,18 +223,6 @@ jobs:
   # migration.yml workflow) so the dual-backend compose stack is brought up
   # and torn down exactly once per run instead of running two separate
   # Docker-backed lanes side by side.
-
-      - name: emit native evidence for migration.e2e
-        if: ${{ inputs.cerberus_image != '' }}
-        uses: ./.github/actions/ci-native-part
-        with:
-          id: migration.e2e.migration-tier0.artifact
-
-      - name: emit native evidence for migration.e2e
-        if: ${{ inputs.cerberus_image == '' }}
-        uses: ./.github/actions/ci-native-part
-        with:
-          id: migration.e2e.migration-tier0.source
   migration-tier1:
     name: migration-tier1
     needs: migration-setup
@@ -296,15 +267,6 @@ jobs:
         with:
           tool: just
 
-      # See migration-tier0's identical block: unconditional so the artifact
-      # lane's GHCR pull can never silently degrade into a source build.
-      - name: Log in to GHCR
-        env:
-          REGISTRY: ghcr.io
-          USERNAME: ${{ github.repository_owner }}
-          PASSWORD: ${{ secrets.GITHUB_TOKEN }}
-        run: node .github/scripts/registry-login.mjs
-
       # Anonymous Docker Hub pulls are rate-limited hard enough to fail a cold
       # runner mid-`compose up` from a shared runner IP, and this stack pulls
       # five upstream images; the other Docker-backed lanes log in first for
@@ -334,17 +296,13 @@ jobs:
           name: migration-scenarios
           path: build
 
-      # See migration-tier0's identical step. This tier used to acquire no CLI
-      # at all (lib.BuildCerberus compiled one in-process), which meant the
-      # release path had no seam to hand a released binary through and no place
-      # to fail early on a wrong one. It also puts CERBERUS_IMAGE into the env
-      # `just migration-cerberus-image` and the compose file read, so the stack
-      # below runs the image this run resolved.
-      - name: resolve the cerberus artifact under test
-        run: node .github/scripts/migration-artifact.mjs
-        env:
-          CERBERUS_IMAGE_INPUT: ${{ inputs.cerberus_image }}
-          CERBERUS_EXPECT_VERSION_INPUT: ${{ inputs.expect_version }}
+      - uses: ./.github/actions/resolve-migration-artifact
+        with:
+          candidate-artifact: ${{ inputs.candidate_artifact }}
+          candidate-digest: ${{ inputs.candidate_digest }}
+          expect-version: ${{ inputs.expect_version }}
+          source-sha: ${{ inputs.source_sha }}
+          source-tree: ${{ inputs.source_tree }}
 
       - name: bring the Tier-1 stack up
         run: just migration-tier1-up
@@ -416,6 +374,10 @@ jobs:
         if: always()
         run: just migration-tier1-down
 
+      - name: remove the candidate registry
+        if: always()
+        run: node .github/scripts/migration-artifact.mjs cleanup
+
   # Tier-2 ruler substrate + the @tier2 Gherkin scenarios (Layer 14). Same
   # shape as migration-tier1, over the Tier-1 compose file PLUS
   # tiers/tier2-ruler's, merged into the one compose project
@@ -425,18 +387,6 @@ jobs:
   # section 8 builds firing parity on top of proven query parity, and every
   # @tier2 scenario reads the same cerberus/ClickHouse pair Tier 1 proves. A
   # green tier-2 over a red tier-1 would be a verdict about nothing.
-
-      - name: emit native evidence for migration.e2e
-        if: ${{ inputs.cerberus_image != '' }}
-        uses: ./.github/actions/ci-native-part
-        with:
-          id: migration.e2e.migration-tier1.artifact
-
-      - name: emit native evidence for migration.e2e
-        if: ${{ inputs.cerberus_image == '' }}
-        uses: ./.github/actions/ci-native-part
-        with:
-          id: migration.e2e.migration-tier1.source
   migration-tier2:
     name: migration-tier2
     needs: [migration-setup, migration-tier1]
@@ -475,14 +425,6 @@ jobs:
         with:
           tool: just
 
-      # See migration-tier0's identical block.
-      - name: Log in to GHCR
-        env:
-          REGISTRY: ghcr.io
-          USERNAME: ${{ github.repository_owner }}
-          PASSWORD: ${{ secrets.GITHUB_TOKEN }}
-        run: node .github/scripts/registry-login.mjs
-
       # An unreachable Docker Hub no longer takes this job down with it: the
       # login exhausts its retries on a transport fault and downgrades the job
       # to MIRROR-ONLY (registry-login.mjs), where every image comes from the
@@ -503,14 +445,13 @@ jobs:
           name: migration-scenarios
           path: build
 
-      # See migration-tier1's identical step — the Tier-2 stack is a superset of
-      # Tier-1's and runs the same `cerberus` service, so it resolves the same
-      # artifact.
-      - name: resolve the cerberus artifact under test
-        run: node .github/scripts/migration-artifact.mjs
-        env:
-          CERBERUS_IMAGE_INPUT: ${{ inputs.cerberus_image }}
-          CERBERUS_EXPECT_VERSION_INPUT: ${{ inputs.expect_version }}
+      - uses: ./.github/actions/resolve-migration-artifact
+        with:
+          candidate-artifact: ${{ inputs.candidate_artifact }}
+          candidate-digest: ${{ inputs.candidate_digest }}
+          expect-version: ${{ inputs.expect_version }}
+          source-sha: ${{ inputs.source_sha }}
+          source-tree: ${{ inputs.source_tree }}
 
       - name: bring the Tier-2 stack up
         run: just migration-tier2-up
@@ -570,6 +511,10 @@ jobs:
         if: always()
         run: just migration-tier2-down
 
+      - name: remove the candidate registry
+        if: always()
+        run: node .github/scripts/migration-artifact.mjs cleanup
+
   # Roll-up. `contains(needs.*.result, 'failure')` is the shape e2e.yml
   # documents as unsafe: a job rolls up to `cancelled`, not `failure`, when it
   # is cancelled, so a cancelled tier would pass the fold silently.
@@ -577,18 +522,6 @@ jobs:
   # — it holds every tier emit SELECTED to `success`, and separately refuses a
   # tier that ran without being selected — and this repo keeps that in a .mjs
   # so it is testable (see .github/scripts/README.md).
-
-      - name: emit native evidence for migration.e2e
-        if: ${{ inputs.cerberus_image != '' }}
-        uses: ./.github/actions/ci-native-part
-        with:
-          id: migration.e2e.migration-tier2.artifact
-
-      - name: emit native evidence for migration.e2e
-        if: ${{ inputs.cerberus_image == '' }}
-        uses: ./.github/actions/ci-native-part
-        with:
-          id: migration.e2e.migration-tier2.source
   migration-aggregate:
     name: migration-e2e
     needs: [migration-setup, migration-tier0, migration-tier1, migration-tier2]
@@ -649,13 +582,3 @@ jobs:
           RESULT_TIER0: ${{ needs.migration-tier0.result }}
           RESULT_TIER1: ${{ needs.migration-tier1.result }}
           RESULT_TIER2: ${{ needs.migration-tier2.result }}
-
-  native-evidence:
-    name: native-evidence
-    if: always()
-    needs: [migration-aggregate, migration-setup, migration-tier0, migration-tier1, migration-tier2]
-    uses: ./.github/workflows/ci-native-evidence.yml
-    with:
-      workflow: .github/workflows/migration-e2e.yml
-      needs_json: ${{ toJSON(needs) }}
-      posture: ${{ github.event_name == 'workflow_call' && 'release' || (github.event_name == 'pull_request' || github.event_name == 'merge_group') && 'merge' || (github.ref == 'refs/heads/main' && 'main') || 'merge' }}

--- a/.github/workflows/migration-e2e.yml
+++ b/.github/workflows/migration-e2e.yml
@@ -653,7 +653,7 @@ jobs:
   native-evidence:
     name: native-evidence
     if: always()
-    needs: [migration-setup, migration-tier0, migration-tier1, migration-tier2]
+    needs: [migration-aggregate, migration-setup, migration-tier0, migration-tier1, migration-tier2]
     uses: ./.github/workflows/ci-native-evidence.yml
     with:
       workflow: .github/workflows/migration-e2e.yml

--- a/.github/workflows/migration-e2e.yml
+++ b/.github/workflows/migration-e2e.yml
@@ -141,6 +141,18 @@ jobs:
   # Tier-0 offline slice: godog over committed fixtures, no Docker, no
   # reference backend. A fixed job like its two siblings — it drives one
   # tag filter on one runner, so there is nothing to fan out over.
+
+      - name: emit native evidence for migration.e2e
+        if: ${{ inputs.cerberus_image != '' }}
+        uses: ./.github/actions/ci-native-part
+        with:
+          id: migration.e2e.migration-setup.artifact
+
+      - name: emit native evidence for migration.e2e
+        if: ${{ inputs.cerberus_image == '' }}
+        uses: ./.github/actions/ci-native-part
+        with:
+          id: migration.e2e.migration-setup.source
   migration-tier0:
     name: migration-tier0
     needs: migration-setup
@@ -228,6 +240,18 @@ jobs:
   # migration.yml workflow) so the dual-backend compose stack is brought up
   # and torn down exactly once per run instead of running two separate
   # Docker-backed lanes side by side.
+
+      - name: emit native evidence for migration.e2e
+        if: ${{ inputs.cerberus_image != '' }}
+        uses: ./.github/actions/ci-native-part
+        with:
+          id: migration.e2e.migration-tier0.artifact
+
+      - name: emit native evidence for migration.e2e
+        if: ${{ inputs.cerberus_image == '' }}
+        uses: ./.github/actions/ci-native-part
+        with:
+          id: migration.e2e.migration-tier0.source
   migration-tier1:
     name: migration-tier1
     needs: migration-setup
@@ -401,6 +425,18 @@ jobs:
   # section 8 builds firing parity on top of proven query parity, and every
   # @tier2 scenario reads the same cerberus/ClickHouse pair Tier 1 proves. A
   # green tier-2 over a red tier-1 would be a verdict about nothing.
+
+      - name: emit native evidence for migration.e2e
+        if: ${{ inputs.cerberus_image != '' }}
+        uses: ./.github/actions/ci-native-part
+        with:
+          id: migration.e2e.migration-tier1.artifact
+
+      - name: emit native evidence for migration.e2e
+        if: ${{ inputs.cerberus_image == '' }}
+        uses: ./.github/actions/ci-native-part
+        with:
+          id: migration.e2e.migration-tier1.source
   migration-tier2:
     name: migration-tier2
     needs: [migration-setup, migration-tier1]
@@ -541,6 +577,18 @@ jobs:
   # — it holds every tier emit SELECTED to `success`, and separately refuses a
   # tier that ran without being selected — and this repo keeps that in a .mjs
   # so it is testable (see .github/scripts/README.md).
+
+      - name: emit native evidence for migration.e2e
+        if: ${{ inputs.cerberus_image != '' }}
+        uses: ./.github/actions/ci-native-part
+        with:
+          id: migration.e2e.migration-tier2.artifact
+
+      - name: emit native evidence for migration.e2e
+        if: ${{ inputs.cerberus_image == '' }}
+        uses: ./.github/actions/ci-native-part
+        with:
+          id: migration.e2e.migration-tier2.source
   migration-aggregate:
     name: migration-e2e
     needs: [migration-setup, migration-tier0, migration-tier1, migration-tier2]
@@ -601,3 +649,13 @@ jobs:
           RESULT_TIER0: ${{ needs.migration-tier0.result }}
           RESULT_TIER1: ${{ needs.migration-tier1.result }}
           RESULT_TIER2: ${{ needs.migration-tier2.result }}
+
+  native-evidence:
+    name: native-evidence
+    if: always()
+    needs: [migration-setup, migration-tier0, migration-tier1, migration-tier2]
+    uses: ./.github/workflows/ci-native-evidence.yml
+    with:
+      workflow: .github/workflows/migration-e2e.yml
+      needs_json: ${{ toJSON(needs) }}
+      posture: ${{ github.event_name == 'workflow_call' && 'release' || (github.event_name == 'pull_request' || github.event_name == 'merge_group') && 'merge' || (github.ref == 'refs/heads/main' && 'main') || 'merge' }}

--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -42,6 +42,11 @@ on:
   schedule:
     - cron: '17 3 * * *'   # nightly at 3:17 UTC; off-minute to avoid scheduler peaks
   workflow_dispatch:
+    inputs:
+      release_correlation_nonce:
+        description: 'Internal release-qualification nonce'
+        required: false
+        type: string
 
 permissions:
   contents: read
@@ -260,4 +265,5 @@ jobs:
     with:
       workflow: .github/workflows/mutation.yml
       needs_json: ${{ toJSON(needs) }}
-      posture: ${{ (github.event_name == 'pull_request' || github.event_name == 'merge_group') && 'merge' || (github.ref == 'refs/heads/main' && 'main') || 'merge' }}
+      posture: ${{ inputs.release_correlation_nonce != '' && 'release' || (github.event_name == 'pull_request' || github.event_name == 'merge_group') && 'merge' || (github.ref == 'refs/heads/main' && 'main') || 'merge' }}
+      correlation_nonce: ${{ inputs.release_correlation_nonce }}

--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -242,3 +242,22 @@ jobs:
             exit 1
           fi
           echo "all selected mutation phases green."
+
+
+      - name: checkout native evidence controller
+        uses: actions/checkout@v7
+
+      - name: emit native evidence for quality.mutation
+        uses: ./.github/actions/ci-native-part
+        with:
+          id: quality.mutation.mutation.source
+
+  native-evidence:
+    name: native-evidence
+    if: always()
+    needs: [select, mutate, mutation]
+    uses: ./.github/workflows/ci-native-evidence.yml
+    with:
+      workflow: .github/workflows/mutation.yml
+      needs_json: ${{ toJSON(needs) }}
+      posture: ${{ (github.event_name == 'pull_request' || github.event_name == 'merge_group') && 'merge' || (github.ref == 'refs/heads/main' && 'main') || 'merge' }}

--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -4,8 +4,10 @@ name: mutation
 # pull_request as a real gate for the publish-on-merge release flow.
 #
 # On an ordinary PR the `mutate` matrix runs the legs whose SCOPE the PR
-# changed, and only those: a PR editing internal/chplan runs phase1, a PR
-# editing only docs runs no leg at all. The selection is computed by
+# changed, and production-only edits use gremlins' merge-base changed-line
+# filter inside those legs. Test/harness changes, unknown projections, and a
+# changed-line run with zero executable mutants fall back to the full selected
+# phase. A PR editing only docs runs no leg at all. Selection is computed by
 # .github/scripts/mutation-matrix.mjs from the PR's own diff against its merge
 # base; the phase table it selects from lives in mutation-phases.mjs. Push /
 # schedule / dispatch and `release/*` PRs sweep the FULL matrix, so no leg's
@@ -162,19 +164,19 @@ jobs:
       # Do NOT "fix" a recurrence by excluding whichever file the log names:
       # that relocates the file's runaway mutants into whichever leg still owns
       # it, and burns real mutation coverage. The ceiling is the fix.
+      # mutation-run.mjs owns the changed-line/full decision and validates that
+      # the final report executed at least one mutant. Keeping the zero-mutant
+      # fallback out of shell prevents a missing or malformed JSON field from
+      # being read as a cheap successful phase.
       - name: gremlins unleash
         env:
           MUTANT_TIMEOUT_MAX: 15s
-        run: |
-          args=(unleash --output gremlins.json --on-shutdown-status=not-run --timeout-max "$MUTANT_TIMEOUT_MAX")
-          if [ "${{ matrix.workers }}" != "0" ]; then
-            args+=(--workers "${{ matrix.workers }}")
-          fi
-          if [ -n "${{ matrix.exclude_files }}" ]; then
-            args+=(--exclude-files "${{ matrix.exclude_files }}")
-          fi
-          args+=("${{ matrix.scope }}")
-          gremlins "${args[@]}"
+          SCOPE: ${{ matrix.scope }}
+          WORKERS: ${{ matrix.workers }}
+          EXCLUDE_FILES: ${{ matrix.exclude_files }}
+          DIFF_REF: ${{ matrix.diff_ref }}
+          REPORT: gremlins.json
+        run: node .github/scripts/mutation-run.mjs
       # gremlins v0.6.0 exits 0 even when --threshold-efficacy is
       # violated, so the gate is done in gremlins-threshold.mjs against
       # the parsed report JSON (measured < threshold -> fail).

--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -45,10 +45,10 @@ permissions:
   contents: read
 
 concurrency:
-  # Full main/nightly sweeps are replaceable. Scoped PR/queue evidence and
-  # manual or release-head qualification always receive unique run-id groups.
-  group: ${{ github.workflow }}-${{ ((github.event_name == 'push' || github.event_name == 'schedule') && github.ref == 'refs/heads/main') && 'latest-main' || github.run_id }}
-  cancel-in-progress: ${{ (github.event_name == 'push' || github.event_name == 'schedule') && github.ref == 'refs/heads/main' }}
+  # Main pushes and the exact nightly cron replace only their own modes. Scoped
+  # PR/queue and manual or release-head qualification remain unique.
+  group: ${{ github.workflow }}-${{ (github.event_name == 'push' && github.ref == 'refs/heads/main') && 'latest-main-push' || (github.event_name == 'schedule' && github.ref == 'refs/heads/main' && github.event.schedule != '') && format('latest-main-schedule-{0}', github.event.schedule) || github.run_id }}
+  cancel-in-progress: ${{ (github.event_name == 'push' && github.ref == 'refs/heads/main') || (github.event_name == 'schedule' && github.ref == 'refs/heads/main' && github.event.schedule != '') }}
 
 jobs:
   # select — decide WHICH phases this event runs, and emit them as the `mutate`

--- a/.github/workflows/perf-benchmark.yml
+++ b/.github/workflows/perf-benchmark.yml
@@ -56,8 +56,8 @@ permissions:
 concurrency:
   # The weekly run is replaceable only while bound to main. PR measurements and
   # explicit manual qualification always receive a unique run-id group.
-  group: ${{ github.workflow }}-${{ ((github.event_name == 'push' || github.event_name == 'schedule') && github.ref == 'refs/heads/main') && 'latest-main' || github.run_id }}
-  cancel-in-progress: ${{ (github.event_name == 'push' || github.event_name == 'schedule') && github.ref == 'refs/heads/main' }}
+  group: ${{ github.workflow }}-${{ (github.event_name == 'push' && github.ref == 'refs/heads/main') && 'latest-main-push' || (github.event_name == 'schedule' && github.ref == 'refs/heads/main' && github.event.schedule != '') && format('latest-main-schedule-{0}', github.event.schedule) || github.run_id }}
+  cancel-in-progress: ${{ (github.event_name == 'push' && github.ref == 'refs/heads/main') || (github.event_name == 'schedule' && github.ref == 'refs/heads/main' && github.event.schedule != '') }}
 
 jobs:
   bench:

--- a/.github/workflows/perf-profile.yml
+++ b/.github/workflows/perf-profile.yml
@@ -48,6 +48,11 @@ on:
     # branch protection) and it requires this check-run to exist.
     branches: [main, 'release/*.x']
   workflow_dispatch:
+    inputs:
+      release_correlation_nonce:
+        description: 'Internal release-qualification nonce'
+        required: false
+        type: string
   schedule:
     # nightly at 05:00 UTC (after the chdb lane's 04:00 cron)
     - cron: '0 5 * * *'
@@ -126,4 +131,5 @@ jobs:
     with:
       workflow: .github/workflows/perf-profile.yml
       needs_json: ${{ toJSON(needs) }}
-      posture: ${{ (github.event_name == 'pull_request' || github.event_name == 'merge_group') && 'merge' || (github.ref == 'refs/heads/main' && 'main') || 'merge' }}
+      posture: ${{ inputs.release_correlation_nonce != '' && 'release' || (github.event_name == 'pull_request' || github.event_name == 'merge_group') && 'merge' || (github.ref == 'refs/heads/main' && 'main') || 'merge' }}
+      correlation_nonce: ${{ inputs.release_correlation_nonce }}

--- a/.github/workflows/perf-profile.yml
+++ b/.github/workflows/perf-profile.yml
@@ -111,3 +111,19 @@ jobs:
           path: perf-profile.json
           if-no-files-found: warn
           retention-days: 30
+
+
+      - name: emit native evidence for performance.profile
+        uses: ./.github/actions/ci-native-part
+        with:
+          id: performance.profile.profile.source
+
+  native-evidence:
+    name: native-evidence
+    if: always()
+    needs: [profile]
+    uses: ./.github/workflows/ci-native-evidence.yml
+    with:
+      workflow: .github/workflows/perf-profile.yml
+      needs_json: ${{ toJSON(needs) }}
+      posture: ${{ (github.event_name == 'pull_request' || github.event_name == 'merge_group') && 'merge' || (github.ref == 'refs/heads/main' && 'main') || 'merge' }}

--- a/.github/workflows/perf-profile.yml
+++ b/.github/workflows/perf-profile.yml
@@ -56,10 +56,10 @@ permissions:
   contents: read
 
 concurrency:
-  # A newer deep run may replace only push/schedule work on main. Release-head
-  # PRs, dispatches, and maintenance pushes remain distinct qualification.
-  group: ${{ github.workflow }}-${{ ((github.event_name == 'push' || github.event_name == 'schedule') && github.ref == 'refs/heads/main') && 'latest-main' || github.run_id }}
-  cancel-in-progress: ${{ (github.event_name == 'push' || github.event_name == 'schedule') && github.ref == 'refs/heads/main' }}
+  # Main pushes and matching cron schedules replace only their own modes.
+  # Release-head PRs, dispatches, and maintenance pushes remain distinct.
+  group: ${{ github.workflow }}-${{ (github.event_name == 'push' && github.ref == 'refs/heads/main') && 'latest-main-push' || (github.event_name == 'schedule' && github.ref == 'refs/heads/main' && github.event.schedule != '') && format('latest-main-schedule-{0}', github.event.schedule) || github.run_id }}
+  cancel-in-progress: ${{ (github.event_name == 'push' && github.ref == 'refs/heads/main') || (github.event_name == 'schedule' && github.ref == 'refs/heads/main' && github.event.schedule != '') }}
 
 jobs:
   profile:

--- a/.github/workflows/post-merge-drift.yml
+++ b/.github/workflows/post-merge-drift.yml
@@ -25,6 +25,16 @@ name: post-merge-drift
 on:
   push:
     branches: [main]
+  workflow_dispatch:
+    inputs:
+      release_correlation_nonce:
+        description: 'Internal release-qualification nonce'
+        required: false
+        type: string
+      release_before_sha:
+        description: 'Source parent for release drift qualification'
+        required: false
+        type: string
 permissions:
   contents: read
 concurrency:
@@ -74,7 +84,7 @@ jobs:
 
       - name: Regenerate what this merge implied and diff it
         env:
-          POST_MERGE_BEFORE: ${{ github.event.before }}
+          POST_MERGE_BEFORE: ${{ inputs.release_before_sha || github.event.before }}
           POST_MERGE_AFTER: ${{ github.sha }}
         run: node .github/scripts/post-merge-golden-drift.mjs
 
@@ -92,4 +102,5 @@ jobs:
     with:
       workflow: .github/workflows/post-merge-drift.yml
       needs_json: ${{ toJSON(needs) }}
-      posture: main
+      posture: ${{ inputs.release_correlation_nonce != '' && 'release' || 'main' }}
+      correlation_nonce: ${{ inputs.release_correlation_nonce }}

--- a/.github/workflows/post-merge-drift.yml
+++ b/.github/workflows/post-merge-drift.yml
@@ -77,3 +77,19 @@ jobs:
           POST_MERGE_BEFORE: ${{ github.event.before }}
           POST_MERGE_AFTER: ${{ github.sha }}
         run: node .github/scripts/post-merge-golden-drift.mjs
+
+
+      - name: emit native evidence for quality.post-merge-drift
+        uses: ./.github/actions/ci-native-part
+        with:
+          id: quality.post-merge-drift.drift.source
+
+  native-evidence:
+    name: native-evidence
+    if: always()
+    needs: [drift]
+    uses: ./.github/workflows/ci-native-evidence.yml
+    with:
+      workflow: .github/workflows/post-merge-drift.yml
+      needs_json: ${{ toJSON(needs) }}
+      posture: main

--- a/.github/workflows/pr-hygiene.yml
+++ b/.github/workflows/pr-hygiene.yml
@@ -60,3 +60,19 @@ jobs:
           PR_BODY: ${{ github.event.pull_request.body }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: node .github/scripts/pr-body-check.mjs
+
+
+      - name: emit native evidence for governance.pr-body
+        uses: ./.github/actions/ci-native-part
+        with:
+          id: governance.pr-body.pr-body.source
+
+  native-evidence:
+    name: native-evidence
+    if: always()
+    needs: [pr-body]
+    uses: ./.github/workflows/ci-native-evidence.yml
+    with:
+      workflow: .github/workflows/pr-hygiene.yml
+      needs_json: ${{ toJSON(needs) }}
+      posture: ${{ (github.event_name == 'pull_request' || github.event_name == 'merge_group') && 'merge' || (github.ref == 'refs/heads/main' && 'main') || 'merge' }}

--- a/.github/workflows/pr-hygiene.yml
+++ b/.github/workflows/pr-hygiene.yml
@@ -24,6 +24,12 @@ on:
   merge_group:
   push:
     branches: [main, 'release/*.x']
+  workflow_dispatch:
+    inputs:
+      release_correlation_nonce:
+        description: 'Internal release-qualification nonce'
+        required: false
+        type: string
 
 permissions:
   contents: read
@@ -75,4 +81,5 @@ jobs:
     with:
       workflow: .github/workflows/pr-hygiene.yml
       needs_json: ${{ toJSON(needs) }}
-      posture: ${{ (github.event_name == 'pull_request' || github.event_name == 'merge_group') && 'merge' || (github.ref == 'refs/heads/main' && 'main') || 'merge' }}
+      posture: ${{ inputs.release_correlation_nonce != '' && 'release' || (github.event_name == 'pull_request' || github.event_name == 'merge_group') && 'merge' || (github.ref == 'refs/heads/main' && 'main') || 'merge' }}
+      correlation_nonce: ${{ inputs.release_correlation_nonce }}

--- a/.github/workflows/property.yml
+++ b/.github/workflows/property.yml
@@ -63,6 +63,11 @@ on:
     # PR, so no branch protection) and it requires this check-run to exist.
     branches: [main, 'release/*.x']
   workflow_dispatch:
+    inputs:
+      release_correlation_nonce:
+        description: 'Internal release-qualification nonce'
+        required: false
+        type: string
   schedule:
     # nightly at 03:45 UTC, ahead of `chdb.yml` (04:00 UTC) so the
     # runners stagger and a libchdb cache primed here can be reused.
@@ -181,4 +186,5 @@ jobs:
     with:
       workflow: .github/workflows/property.yml
       needs_json: ${{ toJSON(needs) }}
-      posture: ${{ (github.event_name == 'pull_request' || github.event_name == 'merge_group') && 'merge' || (github.ref == 'refs/heads/main' && 'main') || 'merge' }}
+      posture: ${{ inputs.release_correlation_nonce != '' && 'release' || (github.event_name == 'pull_request' || github.event_name == 'merge_group') && 'merge' || (github.ref == 'refs/heads/main' && 'main') || 'merge' }}
+      correlation_nonce: ${{ inputs.release_correlation_nonce }}

--- a/.github/workflows/property.yml
+++ b/.github/workflows/property.yml
@@ -79,10 +79,10 @@ permissions:
   contents: read
 
 concurrency:
-  # A newer deep run may replace only push/schedule work on main. PR, queue,
-  # dispatch, and maintenance evidence is unique and never cancelled.
-  group: ${{ github.workflow }}-${{ ((github.event_name == 'push' || github.event_name == 'schedule') && github.ref == 'refs/heads/main') && 'latest-main' || github.run_id }}
-  cancel-in-progress: ${{ (github.event_name == 'push' || github.event_name == 'schedule') && github.ref == 'refs/heads/main' }}
+  # Main pushes and matching cron schedules replace only their own modes. PR,
+  # queue, dispatch, and maintenance evidence stays unique and uncancelled.
+  group: ${{ github.workflow }}-${{ (github.event_name == 'push' && github.ref == 'refs/heads/main') && 'latest-main-push' || (github.event_name == 'schedule' && github.ref == 'refs/heads/main' && github.event.schedule != '') && format('latest-main-schedule-{0}', github.event.schedule) || github.run_id }}
+  cancel-in-progress: ${{ (github.event_name == 'push' && github.ref == 'refs/heads/main') || (github.event_name == 'schedule' && github.ref == 'refs/heads/main' && github.event.schedule != '') }}
 
 jobs:
   property:

--- a/.github/workflows/property.yml
+++ b/.github/workflows/property.yml
@@ -165,3 +165,20 @@ jobs:
             test/property/testdata/rapid/**
           if-no-files-found: ignore
           retention-days: 30
+
+
+      - name: emit native evidence for quality.property
+        uses: ./.github/actions/ci-native-part
+        with:
+          id: quality.property.property.source
+          seed: ci-${{ github.run_id }}-${{ github.run_attempt }}
+
+  native-evidence:
+    name: native-evidence
+    if: always()
+    needs: [property]
+    uses: ./.github/workflows/ci-native-evidence.yml
+    with:
+      workflow: .github/workflows/property.yml
+      needs_json: ${{ toJSON(needs) }}
+      posture: ${{ (github.event_name == 'pull_request' || github.event_name == 'merge_group') && 'merge' || (github.ref == 'refs/heads/main' && 'main') || 'merge' }}

--- a/.github/workflows/quickstart.yml
+++ b/.github/workflows/quickstart.yml
@@ -47,6 +47,11 @@ jobs:
           CHECKOUT_SHA: ${{ github.sha }}
         run: node .github/scripts/quickstart-canary.mjs
 
+
+      - name: emit native evidence for e2e.quickstart
+        uses: ./.github/actions/ci-native-part
+        with:
+          id: e2e.quickstart.select.source
   run:
     name: quickstart-run
     needs: select
@@ -106,6 +111,11 @@ jobs:
         if: always()
         run: docker compose down -v --remove-orphans
 
+
+      - name: emit native evidence for e2e.quickstart
+        uses: ./.github/actions/ci-native-part
+        with:
+          id: e2e.quickstart.run.source
   quickstart:
     name: quickstart
     needs: [select, run]
@@ -126,3 +136,13 @@ jobs:
           SELECTED: ${{ needs.select.outputs.selected }}
           RUN_RESULT: ${{ needs.run.result }}
         run: node .github/scripts/quickstart-canary.mjs
+
+  native-evidence:
+    name: native-evidence
+    if: always()
+    needs: [select, run]
+    uses: ./.github/workflows/ci-native-evidence.yml
+    with:
+      workflow: .github/workflows/quickstart.yml
+      needs_json: ${{ toJSON(needs) }}
+      posture: ${{ (github.event_name == 'pull_request' || github.event_name == 'merge_group') && 'merge' || (github.ref == 'refs/heads/main' && 'main') || 'merge' }}

--- a/.github/workflows/quickstart.yml
+++ b/.github/workflows/quickstart.yml
@@ -9,6 +9,12 @@ on:
   merge_group:
   push:
     branches: [main, "release/*.x"]
+  workflow_dispatch:
+    inputs:
+      release_correlation_nonce:
+        description: 'Internal release-qualification nonce'
+        required: false
+        type: string
 
 permissions:
   contents: read
@@ -145,4 +151,5 @@ jobs:
     with:
       workflow: .github/workflows/quickstart.yml
       needs_json: ${{ toJSON(needs) }}
-      posture: ${{ (github.event_name == 'pull_request' || github.event_name == 'merge_group') && 'merge' || (github.ref == 'refs/heads/main' && 'main') || 'merge' }}
+      posture: ${{ inputs.release_correlation_nonce != '' && 'release' || (github.event_name == 'pull_request' || github.event_name == 'merge_group') && 'merge' || (github.ref == 'refs/heads/main' && 'main') || 'merge' }}
+      correlation_nonce: ${{ inputs.release_correlation_nonce }}

--- a/.github/workflows/quickstart.yml
+++ b/.github/workflows/quickstart.yml
@@ -140,7 +140,7 @@ jobs:
   native-evidence:
     name: native-evidence
     if: always()
-    needs: [select, run]
+    needs: [quickstart, select, run]
     uses: ./.github/workflows/ci-native-evidence.yml
     with:
       workflow: .github/workflows/quickstart.yml

--- a/.github/workflows/schema-integration.yml
+++ b/.github/workflows/schema-integration.yml
@@ -43,10 +43,10 @@ permissions:
   packages: read
 
 concurrency:
-  # A newer deep run may replace only push/schedule work on main. PR and manual
-  # qualification runs receive a unique run-id group and cannot be cancelled.
-  group: ${{ github.workflow }}-${{ ((github.event_name == 'push' || github.event_name == 'schedule') && github.ref == 'refs/heads/main') && 'latest-main' || github.run_id }}
-  cancel-in-progress: ${{ (github.event_name == 'push' || github.event_name == 'schedule') && github.ref == 'refs/heads/main' }}
+  # Main pushes and matching cron schedules replace only their own modes. PR
+  # and manual qualification remain unique and cannot be cancelled.
+  group: ${{ github.workflow }}-${{ (github.event_name == 'push' && github.ref == 'refs/heads/main') && 'latest-main-push' || (github.event_name == 'schedule' && github.ref == 'refs/heads/main' && github.event.schedule != '') && format('latest-main-schedule-{0}', github.event.schedule) || github.run_id }}
+  cancel-in-progress: ${{ (github.event_name == 'push' && github.ref == 'refs/heads/main') || (github.event_name == 'schedule' && github.ref == 'refs/heads/main' && github.event.schedule != '') }}
 
 jobs:
   # Docs-only PRs short-circuit the Docker work. See ci.yml / chdb.yml for the

--- a/.github/workflows/schema-integration.yml
+++ b/.github/workflows/schema-integration.yml
@@ -32,6 +32,11 @@ on:
     branches: [main]
   pull_request:
   workflow_dispatch:
+    inputs:
+      release_correlation_nonce:
+        description: 'Internal release-qualification nonce'
+        required: false
+        type: string
   schedule:
     # nightly at 04:30 UTC (offset from the chdb lane's 04:00)
     - cron: '30 4 * * *'
@@ -162,4 +167,5 @@ jobs:
     with:
       workflow: .github/workflows/schema-integration.yml
       needs_json: ${{ toJSON(needs) }}
-      posture: ${{ (github.event_name == 'pull_request' || github.event_name == 'merge_group') && 'merge' || (github.ref == 'refs/heads/main' && 'main') || 'merge' }}
+      posture: ${{ inputs.release_correlation_nonce != '' && 'release' || (github.event_name == 'pull_request' || github.event_name == 'merge_group') && 'merge' || (github.ref == 'refs/heads/main' && 'main') || 'merge' }}
+      correlation_nonce: ${{ inputs.release_correlation_nonce }}

--- a/.github/workflows/schema-integration.yml
+++ b/.github/workflows/schema-integration.yml
@@ -147,3 +147,19 @@ jobs:
 
       - name: Run schema/ddl integration tests (real ClickHouse)
         run: just schema-ddl-test
+
+
+      - name: emit native evidence for schema.ddl
+        uses: ./.github/actions/ci-native-part
+        with:
+          id: schema.ddl.schema-ddl.source
+
+  native-evidence:
+    name: native-evidence
+    if: always()
+    needs: [changes, schema-ddl]
+    uses: ./.github/workflows/ci-native-evidence.yml
+    with:
+      workflow: .github/workflows/schema-integration.yml
+      needs_json: ${{ toJSON(needs) }}
+      posture: ${{ (github.event_name == 'pull_request' || github.event_name == 'merge_group') && 'merge' || (github.ref == 'refs/heads/main' && 'main') || 'merge' }}

--- a/.github/workflows/strict-scan.yml
+++ b/.github/workflows/strict-scan.yml
@@ -49,10 +49,10 @@ permissions:
   packages: read
 
 concurrency:
-  # A newer deep run may replace only push/schedule work on main. PR, queue,
-  # dispatch, and maintenance evidence is unique and never cancelled.
-  group: ${{ github.workflow }}-${{ ((github.event_name == 'push' || github.event_name == 'schedule') && github.ref == 'refs/heads/main') && 'latest-main' || github.run_id }}
-  cancel-in-progress: ${{ (github.event_name == 'push' || github.event_name == 'schedule') && github.ref == 'refs/heads/main' }}
+  # Main pushes and matching cron schedules replace only their own modes. PR,
+  # queue, dispatch, and maintenance evidence stays unique and uncancelled.
+  group: ${{ github.workflow }}-${{ (github.event_name == 'push' && github.ref == 'refs/heads/main') && 'latest-main-push' || (github.event_name == 'schedule' && github.ref == 'refs/heads/main' && github.event.schedule != '') && format('latest-main-schedule-{0}', github.event.schedule) || github.run_id }}
+  cancel-in-progress: ${{ (github.event_name == 'push' && github.ref == 'refs/heads/main') || (github.event_name == 'schedule' && github.ref == 'refs/heads/main' && github.event.schedule != '') }}
 
 jobs:
   # Docs-only PRs short-circuit the Docker work. See ci.yml / chdb.yml for the

--- a/.github/workflows/strict-scan.yml
+++ b/.github/workflows/strict-scan.yml
@@ -38,6 +38,11 @@ on:
   # `strict-scan` is a required context and must post on the projected trunk.
   merge_group:
   workflow_dispatch:
+    inputs:
+      release_correlation_nonce:
+        description: 'Internal release-qualification nonce'
+        required: false
+        type: string
   schedule:
     # nightly at 04:45 UTC (offset from the chdb 04:00 and schema 04:30 lanes)
     - cron: '45 4 * * *'
@@ -291,4 +296,5 @@ jobs:
     with:
       workflow: .github/workflows/strict-scan.yml
       needs_json: ${{ toJSON(needs) }}
-      posture: ${{ (github.event_name == 'pull_request' || github.event_name == 'merge_group') && 'merge' || (github.ref == 'refs/heads/main' && 'main') || 'merge' }}
+      posture: ${{ inputs.release_correlation_nonce != '' && 'release' || (github.event_name == 'pull_request' || github.event_name == 'merge_group') && 'merge' || (github.ref == 'refs/heads/main' && 'main') || 'merge' }}
+      correlation_nonce: ${{ inputs.release_correlation_nonce }}

--- a/.github/workflows/strict-scan.yml
+++ b/.github/workflows/strict-scan.yml
@@ -276,3 +276,19 @@ jobs:
       # internal/chclient/conn_teardown_integration_test.go.
       - name: Run chclient connection-teardown differential (real ClickHouse)
         run: just chclient-integration
+
+
+      - name: emit native evidence for chdb.strict-scan
+        uses: ./.github/actions/ci-native-part
+        with:
+          id: chdb.strict-scan.strict-scan.source
+
+  native-evidence:
+    name: native-evidence
+    if: always()
+    needs: [changes, strict-scan]
+    uses: ./.github/workflows/ci-native-evidence.yml
+    with:
+      workflow: .github/workflows/strict-scan.yml
+      needs_json: ${{ toJSON(needs) }}
+      posture: ${{ (github.event_name == 'pull_request' || github.event_name == 'merge_group') && 'merge' || (github.ref == 'refs/heads/main' && 'main') || 'merge' }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -103,6 +103,11 @@ homebrew_casks:
     directory: Casks
     homepage: "https://github.com/tsouza/cerberus"
     description: "Drop-in Prometheus / Loki / Tempo HTTP gateway for ClickHouse"
+    # Snapshot candidates have no future git tag yet, so GoReleaser's default
+    # URL would silently inherit the previous release tag. Bind the generated
+    # cask to the independently validated candidate identity instead.
+    url:
+      template: "{{ .Env.RELEASE_SOURCE_URL }}/releases/download/{{ .Env.RELEASE_APP_TAG }}/{{ .ArtifactName }}"
     # `auto` on its own only keeps PRERELEASES out of the tap. A stable
     # BACKPORT is not a prerelease, so `auto` alone let v1.12.1 — cut after
     # v1.13.0 — write the tap formula and DOWNGRADE every `brew install` to the
@@ -129,7 +134,7 @@ checksum:
   name_template: "checksums.txt"
 
 snapshot:
-  version_template: "{{ incpatch .Version }}-snapshot+{{.ShortCommit}}"
+  version_template: "{{ .Env.RELEASE_VERSION }}"
 
 changelog:
   use: github-native

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,11 +6,17 @@
 
 FROM gcr.io/distroless/static-debian12:nonroot
 
+ARG RELEASE_VERSION=dev
+ARG SOURCE_SHA=unknown
+ARG SOURCE_URL=unknown
+
 LABEL org.opencontainers.image.title="cerberus"
 LABEL org.opencontainers.image.description="Drop-in Prometheus / Loki / Tempo HTTP gateway for ClickHouse"
-LABEL org.opencontainers.image.url="https://github.com/tsouza/cerberus"
-LABEL org.opencontainers.image.source="https://github.com/tsouza/cerberus"
+LABEL org.opencontainers.image.url="${SOURCE_URL}"
+LABEL org.opencontainers.image.source="${SOURCE_URL}"
 LABEL org.opencontainers.image.licenses="Apache-2.0"
+LABEL org.opencontainers.image.version="${RELEASE_VERSION}"
+LABEL org.opencontainers.image.revision="${SOURCE_SHA}"
 
 # goreleaser's `dockers_v2` builds one multi-arch image and lays the context
 # out per platform (`linux/amd64/cerberus`, `linux/arm64/cerberus`), so the

--- a/docs/test-strategy.md
+++ b/docs/test-strategy.md
@@ -890,9 +890,12 @@ expands it into the `mutate` job's matrix. The rolled-up `mutation`
 context is a required check on `main`.
 
 On a pull request the lane runs the phases whose scope that PR changed,
-and only those: a PR editing `internal/chplan` runs `phase1`, a PR
-editing only docs runs no leg and the aggregator passes through
-honestly. Push-to-main, the nightly, a manual dispatch, a `release/*`
+and only those. A production-only edit uses gremlins' native merge-base
+changed-line filter inside its selected phase. A test, fixture, harness,
+delete-only, binary, malformed, or uncomputable projection runs the selected
+phase in full; an incremental report with zero executable mutants also reruns
+the full phase before it may report. A PR editing only docs runs no leg and the
+aggregator passes through honestly. Push-to-main, the nightly, a manual dispatch, a `release/*`
 PR, and any PR touching mutation-specific harness material all sweep the FULL
 matrix, so no phase's floor is ever load-bearing on some PR happening to touch
 its package. Registry edits are projected to the mutation lane's semantic

--- a/docs/test-strategy.md
+++ b/docs/test-strategy.md
@@ -90,10 +90,12 @@ not wired as a branch-protection gate (typically because it needs the chDB
 substrate, a Docker stack, or a soak streak before promotion).
 
 Replaceable deep-test workflows coalesce only a `push` or `schedule` run whose
-ref is exactly `refs/heads/main`; both event types share that workflow's
-`latest-main` group. Every pull request, merge group, manual dispatch,
-reusable-workflow call, maintenance branch, tag, release event, and unknown
-event/ref pair receives a unique run-id group. The exhaustive E2E workflow,
+ref is exactly `refs/heads/main`. Main pushes share one `latest-main-push`
+group; scheduled runs key their group by the exact cron expression. A routine
+push therefore cannot erase nightly-only coverage, and two differently scoped
+schedules cannot erase each other. Every pull request, merge group, manual
+dispatch, reusable-workflow call, maintenance branch, tag, release event, and
+unknown event/ref pair receives a unique run-id group. The exhaustive E2E workflow,
 the required `quickstart`, post-merge generated-artifact drift, core gates,
 publication, stateful mirroring, and monitors are explicit negative controls.
 `.github/scripts/main-coalescing.mjs` binds the enrolled workflow expressions

--- a/test/regression/merge_queue_test.go
+++ b/test/regression/merge_queue_test.go
@@ -127,7 +127,7 @@ var queueSafeCancelInProgress = regexp.MustCompile(
 	`^\$\{\{\s*github\.event_name\s*==\s*'([a-z_]+)'\s*\}\}$`,
 )
 
-const latestMainCancelInProgress = "${{ (github.event_name == 'push' || github.event_name == 'schedule') && github.ref == 'refs/heads/main' }}"
+const replaceableMainModeCancelInProgress = "${{ (github.event_name == 'push' && github.ref == 'refs/heads/main') || (github.event_name == 'schedule' && github.ref == 'refs/heads/main' && github.event.schedule != '') }}"
 
 // cancelInProgressIsQueueSafe reports whether a `cancel-in-progress:` value can
 // never be true on a `merge_group` run.
@@ -135,7 +135,7 @@ func cancelInProgressIsQueueSafe(value string) bool {
 	if value == "false" {
 		return true
 	}
-	if value == latestMainCancelInProgress {
+	if value == replaceableMainModeCancelInProgress {
 		return true
 	}
 	m := queueSafeCancelInProgress.FindStringSubmatch(value)

--- a/test/regression/migration_tier1_test.go
+++ b/test/regression/migration_tier1_test.go
@@ -1713,7 +1713,7 @@ const (
 
 // The build-once seam (Layer 14, D2): the migration lane runs the SAME three
 // tier jobs twice against a release commit — once proving the source tree, once
-// proving the image goreleaser built — and the only thing that differs is which
+// proving the sealed unpublished candidate — and the only thing that differs is which
 // cerberus the stack runs and which binary the scenarios exec. Every constant
 // below exists in more than one file by necessity (a compose interpolation
 // default, a Justfile variable, a Node const, a Go const, an ldflag), so the
@@ -1722,21 +1722,24 @@ const (
 const (
 	// migrationArtifactScript resolves which cerberus the lane drives.
 	migrationArtifactScript = "../../.github/scripts/migration-artifact.mjs"
+	// migrationArtifactAction downloads the sealed candidate when present and
+	// maps the closed five-field identity into the resolver.
+	migrationArtifactAction = "../../.github/actions/resolve-migration-artifact/action.yml"
 	// migrationLocalImageVar is the Justfile variable naming the locally built
 	// image tag.
 	migrationLocalImageVar = "MIGRATION_LOCAL_IMAGE"
 	// migrationImageRecipe is the SINGLE point at which the image enters the
 	// Docker daemon.
 	migrationImageRecipe = "migration-cerberus-image"
-	// dockerfileLocalPath builds the image the stacks run when no released
+	// dockerfileLocalPath builds the image the stacks run when no candidate
 	// artifact is supplied; cerberusMainPath declares the source-build stamp.
 	dockerfileLocalPath = "../../Dockerfile.local"
 	cerberusMainPath    = "../../cmd/cerberus/main.go"
 	// buildFlag forces `docker compose up` to compile the build context even
-	// when the image is already present, which is exactly how a released
+	// when the image is already present, which is exactly how a candidate
 	// artifact gets replaced by a recompile of whatever tree the runner holds.
 	buildFlag = "--build"
-	// pullRetryRecipe is how a released image is fetched. A bare `docker pull`
+	// pullRetryRecipe is how an image is fetched. A bare `docker pull`
 	// is single-attempt, and one Docker Hub timeout on it failed the v1.13.0
 	// release's Tier-1 leg; see TestJustfileNoUnretriedDockerPull.
 	pullRetryRecipe = "_pull-retry"
@@ -1746,10 +1749,10 @@ const (
 var composeImageDefaultRe = regexp.MustCompile(`^\$\{([A-Za-z_][A-Za-z0-9_]*):-(.+)\}$`)
 
 // TestMigrationImageIsAcquiredOnceNeverRebuilt pins the seam that lets the
-// release lane test the artifact it just built.
+// release lane test the sealed candidate it just built.
 //
 // `pull_policy: build` plus `up --build` — the shape this replaced — means
-// pointing `image:` at a released tag does NOT stop compose recompiling the
+// pointing `image:` at the candidate digest does NOT stop compose recompiling the
 // source tree over it. The lane would report "tested the release artifact"
 // having tested source, and every gate in the pipeline would stay green.
 func TestMigrationImageIsAcquiredOnceNeverRebuilt(t *testing.T) {
@@ -1764,8 +1767,8 @@ func TestMigrationImageIsAcquiredOnceNeverRebuilt(t *testing.T) {
 	m := composeImageDefaultRe.FindStringSubmatch(cerb.Image)
 	if m == nil {
 		t.Fatalf("%s's %s service declares image %q, want a `${VAR:-default}` interpolation. A literal "+
-			"tag gives release.yml's artifact lane no way to point the stack at the image goreleaser "+
-			"built, so it would prove the source tree under an artifact-shaped job name.",
+			"tag gives release qualification no way to point the stack at the sealed candidate "+
+			"digest, so it would prove the source tree under an artifact-shaped job name.",
 			tier1ComposePath, tier1CerberusService, cerb.Image)
 	}
 	imageEnvVar, localTag := m[1], m[2]
@@ -1775,7 +1778,7 @@ func TestMigrationImageIsAcquiredOnceNeverRebuilt(t *testing.T) {
 	}
 	if cerb.PullPolicy != composePullPolicyNever {
 		t.Fatalf("%s's %s service declares pull_policy %q, want %q. Anything else lets the up path "+
-			"acquire the image itself, which is how a source rebuild silently replaces a released "+
+			"acquire the image itself, which is how a source rebuild silently replaces a candidate "+
 			"artifact. The image is put in the daemon by `just %s` BEFORE up runs.",
 			tier1ComposePath, tier1CerberusService, cerb.PullPolicy, composePullPolicyNever, migrationImageRecipe)
 	}
@@ -1815,7 +1818,7 @@ func TestMigrationImageIsAcquiredOnceNeverRebuilt(t *testing.T) {
 		if strings.Contains(recipeBody, buildFlag) {
 			t.Fatalf("Justfile recipe %s passes %s to `docker compose up`. That forces a source build "+
 				"regardless of pull_policy, so a release run would recompile this tree over the "+
-				"released image and still report green. Body:\n%s", recipe, buildFlag, recipeBody)
+				"candidate image and still report green. Body:\n%s", recipe, buildFlag, recipeBody)
 		}
 	}
 
@@ -1826,7 +1829,7 @@ func TestMigrationImageIsAcquiredOnceNeverRebuilt(t *testing.T) {
 	for _, want := range []string{"docker build", "Dockerfile.local", pullRetryRecipe, lib.ImageEnv} {
 		if !strings.Contains(acquire, want) {
 			t.Fatalf("Justfile recipe %s does not reference %q; it must build the local tag from "+
-				"Dockerfile.local and pull a released one (with retry), decided by %s alone. Body:\n%s",
+				"Dockerfile.local and pull a candidate one (with retry), decided by %s alone. Body:\n%s",
 				migrationImageRecipe, want, lib.ImageEnv, acquire)
 		}
 	}
@@ -1945,7 +1948,7 @@ var migrationTierJobs = []string{"migration-tier0", tier1JobName, "migration-tie
 // TestMigrationTierJobsResolveTheArtifact pins the resolver into every tier
 // job. A tier that skips it either compiles no CLI at all (release path: no
 // binary to hand the scenarios) or, worse, builds one from source while the job
-// claims to be driving a released image.
+// claims to be driving a sealed candidate.
 func TestMigrationTierJobsResolveTheArtifact(t *testing.T) {
 	t.Parallel()
 
@@ -1954,16 +1957,33 @@ func TestMigrationTierJobsResolveTheArtifact(t *testing.T) {
 		t.Fatalf("read %s: %v", tier1WorkflowPath, err)
 	}
 	body := string(workflow)
+	action := readFileString(t, migrationArtifactAction)
+	for _, want := range []string{
+		"node .github/scripts/migration-artifact.mjs",
+		"CERBERUS_CANDIDATE_DIR_INPUT:",
+		"CERBERUS_CANDIDATE_DIGEST_INPUT:",
+		"CERBERUS_EXPECT_VERSION_INPUT:",
+		"CERBERUS_SOURCE_SHA_INPUT:",
+		"CERBERUS_SOURCE_TREE_INPUT:",
+	} {
+		if !strings.Contains(action, want) {
+			t.Fatalf("%s does not carry %q; the reusable action must hand the complete candidate identity "+
+				"to the single resolver. Body:\n%s", migrationArtifactAction, want, action)
+		}
+	}
 
 	for _, job := range migrationTierJobs {
 		jobBody := workflowJobBody(t, body, job)
 		for _, want := range []string{
-			"node .github/scripts/migration-artifact.mjs",
-			"CERBERUS_IMAGE_INPUT: ${{ inputs.cerberus_image }}",
-			"CERBERUS_EXPECT_VERSION_INPUT: ${{ inputs.expect_version }}",
+			"uses: ./.github/actions/resolve-migration-artifact",
+			"candidate-artifact: ${{ inputs.candidate_artifact }}",
+			"candidate-digest: ${{ inputs.candidate_digest }}",
+			"expect-version: ${{ inputs.expect_version }}",
+			"source-sha: ${{ inputs.source_sha }}",
+			"source-tree: ${{ inputs.source_tree }}",
 		} {
 			if !strings.Contains(jobBody, want) {
-				t.Fatalf("%s job %q does not carry %q, so the release lane's `cerberus_image` input "+
+				t.Fatalf("%s job %q does not carry %q, so the release lane's candidate identity "+
 					"would not reach it and the tier would silently test this tree instead. Body:\n%s",
 					tier1WorkflowPath, job, want, jobBody)
 			}
@@ -1973,7 +1993,47 @@ func TestMigrationTierJobsResolveTheArtifact(t *testing.T) {
 		if strings.Contains(jobBody, "go build -o build/cerberus") {
 			t.Fatalf("%s job %q still compiles the CLI directly. That binary bypasses the resolver's "+
 				"version probe, so a release run would exec a source build while claiming to test the "+
-				"released artifact. Body:\n%s", tier1WorkflowPath, job, jobBody)
+				"sealed candidate. Body:\n%s", tier1WorkflowPath, job, jobBody)
+		}
+	}
+}
+
+// TestMigrationCandidateRegistryLivesThroughEachTier prevents the artifact
+// resolver from exporting a digest whose only registry has already been torn
+// down. Tier-1 and Tier-2 acquire CERBERUS_IMAGE after the resolver returns, so
+// cleanup belongs after the stack teardown, not in the resolver's success path.
+func TestMigrationCandidateRegistryLivesThroughEachTier(t *testing.T) {
+	t.Parallel()
+
+	script := readFileString(t, migrationArtifactScript)
+	load := strings.Index(script, "loaded = loadCandidate(plan)")
+	export := strings.Index(script, "[CANDIDATE_REGISTRY_ENV, loaded?.container ?? '']")
+	stop := strings.Index(script, "stopLoopbackRegistry(loaded.container)")
+	if load < 0 || export < 0 || stop < 0 || !(load < export && export < stop) {
+		t.Fatalf("%s must export the live candidate registry before its failure-only cleanup; "+
+			"otherwise the later image pull targets a stopped endpoint (load=%d export=%d stop=%d)",
+			migrationArtifactScript, load, export, stop)
+	}
+	if !strings.Contains(script, "process.argv[2] || 'resolve'") ||
+		!strings.Contains(script, "mode === 'cleanup'") {
+		t.Fatalf("%s has no explicit idempotent cleanup mode for the tier jobs", migrationArtifactScript)
+	}
+
+	workflow := readFileString(t, tier1WorkflowPath)
+	for _, job := range migrationTierJobs {
+		body := workflowJobBody(t, workflow, job)
+		resolve := strings.Index(body, "uses: ./.github/actions/resolve-migration-artifact")
+		cleanup := strings.Index(body, "node .github/scripts/migration-artifact.mjs cleanup")
+		if resolve < 0 || cleanup < 0 || cleanup <= resolve {
+			t.Fatalf("%s job %q must remove the candidate registry after resolving and using it "+
+				"(resolve=%d cleanup=%d). Body:\n%s", tier1WorkflowPath, job, resolve, cleanup, body)
+		}
+		if job == tier1JobName || job == "migration-tier2" {
+			teardown := strings.Index(body, "tear the stack down")
+			if teardown < 0 || cleanup <= teardown {
+				t.Fatalf("%s job %q removes the candidate registry before its stack teardown "+
+					"(teardown=%d cleanup=%d). Body:\n%s", tier1WorkflowPath, job, teardown, cleanup, body)
+			}
 		}
 	}
 }

--- a/test/regression/mutation_timeout_max_test.go
+++ b/test/regression/mutation_timeout_max_test.go
@@ -9,12 +9,19 @@ import (
 // mutationWorkflowPath drives the gremlins mutation-testing lane.
 const mutationWorkflowPath = "../../.github/workflows/mutation.yml"
 
+// mutationRunnerPath owns the non-trivial argv and changed-line fallback that
+// the workflow invokes.
+const mutationRunnerPath = "../../.github/scripts/mutation-run.mjs"
+
 // timeoutMaxFlag bounds a single mutant's test run regardless of how slow the
 // mutated package's own tests are.
 const timeoutMaxFlag = "--timeout-max"
 
-// unleashArgvPrefix opens the argv array the workflow hands to gremlins.
-const unleashArgvPrefix = "args=(unleash"
+const (
+	mutationRunnerInvocation = "run: node .github/scripts/mutation-run.mjs"
+	timeoutMaxArg            = "'--timeout-max',"
+	timeoutMaxValue          = "required('MUTANT_TIMEOUT_MAX'),"
+)
 
 // gremlinsForkTagPrefix is the fork tag family that supports timeoutMaxFlag.
 // The flag landed in the fork; a tag from before it makes gremlins reject the
@@ -52,27 +59,20 @@ func TestMutationLaneCapsPerMutantTimeout(t *testing.T) {
 		t.Fatalf("read %s: %v", mutationWorkflowPath, err)
 	}
 	body := string(workflow)
-
-	// Match the argv line itself, not the file: the flag is also named in the
-	// comments that explain it, and prose must not be able to satisfy the pin.
-	var argvLine string
-	for _, line := range strings.Split(body, "\n") {
-		if strings.Contains(line, unleashArgvPrefix) {
-			argvLine = line
-
-			break
-		}
+	if !strings.Contains(body, mutationRunnerInvocation) {
+		t.Errorf("%s does not invoke the pinned mutation runner %q", mutationWorkflowPath, mutationRunnerInvocation)
 	}
-	switch {
-	case argvLine == "":
-		t.Errorf("%s has no %q line; the pin below cannot see how gremlins is invoked. If the "+
-			"invocation was restructured, re-point this test at the new shape rather than deleting it.",
-			mutationWorkflowPath, unleashArgvPrefix)
-	case !strings.Contains(argvLine, timeoutMaxFlag):
-		t.Errorf("%s does not pass %s to gremlins unleash. Without an absolute ceiling a mutant that "+
-			"inverts a scanner loop-advance runs until the runner is out of memory, and the job dies "+
-			"with no verdict — which reads as flake, not as a missing bound.",
-			mutationWorkflowPath, timeoutMaxFlag)
+
+	runner, err := os.ReadFile(mutationRunnerPath)
+	if err != nil {
+		t.Fatalf("read %s: %v", mutationRunnerPath, err)
+	}
+	runnerBody := string(runner)
+	if !strings.Contains(runnerBody, timeoutMaxArg) || !strings.Contains(runnerBody, timeoutMaxValue) {
+		t.Errorf("%s does not pass %s from MUTANT_TIMEOUT_MAX to gremlins unleash. Without an absolute "+
+			"ceiling a mutant that inverts a scanner loop-advance runs until the runner is out of memory, "+
+			"and the job dies with no verdict — which reads as flake, not as a missing bound.",
+			mutationRunnerPath, timeoutMaxFlag)
 	}
 
 	if !strings.Contains(body, gremlinsForkTagPrefix) {


### PR DESCRIPTION
## Summary

- Issue #2230's acceptance checklist has an unchecked live "run the shadow comparison over at least 7 days and 50 non-documentation final SHAs" soak. The new selector (`ci-lane-selection.mjs`, PR #2251) is a pure function of `(base SHA, head SHA, registry)` — no live checkout required to evaluate — so this adds `.github/scripts/ci-lane-backtest.mjs`, which replays it against real historical merged PRs pulled from the Actions/PR REST API instead of waiting on the clock.
- Per PR it computes: whether every lane the OLD (always-run) system observed failing was still selected by the NEW selector (a miss is a real "old-only catch", reported not hidden); the NEW-selected lanes' summed actual runner-minutes; and a wall-clock "required-ready" proxy (earliest job start to latest completion among NEW-selected lanes, assuming unconstrained parallelism).
- `contextMatches()`/`jobObservationState()` are reused from `ci-lane-shadow-collector.mjs` (the latter now exports `contextMatches`) so "which job backs this lane" can never drift between the live collector and this replay; the Actions-run discovery itself is intentionally NOT reused — the live collector's strict PR-association binding exists to stop a spoofed live event, which doesn't apply to an already-merged SHA looked up by its own unique head SHA.
- `ci-lane-backtest.test.mjs` covers the comparison/aggregation logic offline with synthetic fixtures (`node --test`, no network).

**Depends on #2251** — this branch was cut from #2251's current state and imports `selectionPolicy`/`ci-lane-contract.mjs` from it, so it can't merge before #2251 does. Not intended to merge until then.

## What it found, run for real against `tsouza/cerberus`'s actual history

| Sample | Non-doc SHAs | Span | Required-ready p50/p95 (target p95 ≤20min) | Runner-min p50/p95 (target p50 ≤95/p95 ≤160) | Coverage |
| --- | --- | --- | --- | --- | --- |
| n=50 | 50 | 1.3 days | 39.0 / 54.6 — **FAIL** | 82.5 / 101.0 — PASS | 0 old-only catches — PASS |
| n=150 | 150 | 7.1 days | 26.6 / 53.3 — **FAIL** | 82.5 / 100.8 — PASS | 0 old-only catches — PASS |

Coverage and runner-cost both clear their bar at both sample sizes (the n=150 run alone satisfies the literal "≥50 SHAs over ≥7 days" wording). Required-ready wall time does not, and the tool's own diagnostics point to two concrete, unfixed causes — reported here per the task's instruction not to silently patch the registry to paper over what the backtest finds:

1. **The selector falls back to the full lane set on ~80% of real PRs** (40/50 in the n=50 sample) because whole directories match no conditional lane's `package_globs` and no `known_nonimpact_glob`, so `unknown_paths` fires and every conditional lane gets selected — same cost as the old always-run system. Top offenders by occurrence count in the n=50 sample: `test/spec` (1819), `compatibility/parity-baseline` (263), `test/property` (30), `.github/scripts` (28), `.github/workflows` (27).
2. **`performance.benchmark` alone runs a 17.4min median / 27.3min max** across the n=150 sample — selected on half of real PRs, it alone leaves little headroom under the 20-minute SLO before any other lane's start-skew is added. Even the 18% of PRs where impact selection successfully narrows to precisely the touched lanes (no fallback) still miss the target (wall-clock p50 25min/p95 52min) — narrowing conditional lanes barely moves this number because the ~27 `always`-posture lanes (and `performance.benchmark` when selected) dominate the critical path regardless.

## Out of scope (needs a live run, not a backtest)

Whether the new artifact-bundling / evidence-collection plumbing (`ci-lane-shadow-collector.mjs`, `ci-lane-native-evidence.mjs`) actually works end-to-end inside a live GitHub Actions run — permissions, cross-job artifact download, etc. A backtest cannot exercise the runner sandbox; that still needs one short live-verification pass once #2251 lands.

## Test plan

- [x] `node --check` on every new/changed `.mjs` file
- [x] `node --test .github/scripts/ci-lane-backtest.test.mjs` — 18/18 passing, offline, synthetic fixtures only
- [x] `node --test .github/scripts/ci-lane-shadow-collector.test.mjs` — 25/25 still passing (regression check on the `contextMatches` export)
- [x] `CHECK=all node .github/scripts/forbid-skip.mjs` clean
- [x] Ran the real tool twice against `tsouza/cerberus` (n=50 and n=150) — results above; full JSON reports available on request (written under the gitignored `build/` tree, not committed)
- [ ] `just lint` / `just test` — not run locally per CLAUDE.md invariant 5 (no speculative pre-flight); this is a Node-only script change with no Go surface

## Notes for reviewers

- The `RUNNER_P50_TARGET_MINUTES` (95) / `RUNNER_P95_TARGET_MINUTES` (160) constants have no other home in the source tree (they're issue #2230's literal acceptance numbers); `MERGE_P95_SLO_MINUTES` (20) is reused from `ci-lane-contract.mjs` rather than duplicated.
- The wall-clock "required-ready" figure is an explicitly-documented optimistic proxy (unconstrained parallelism) — the real number could be worse, never better, so the FAIL above is not an artifact of an unfair measurement.
- Whether/how to close the two findings above (broaden `package_globs` coverage, and/or budget `performance.benchmark` differently) is a judgment call for whoever owns #2251, not made here.