### PR TITLE
fix(ci): mark CodeQL required in the lane registry to match release.yml

### DIFF
--- a/.github/ci-lanes.json
+++ b/.github/ci-lanes.json
@@ -1938,7 +1938,7 @@
       "risk_domains": ["security"],
       "merge_posture": "always",
       "main_posture": "coalesced",
-      "release_posture": "advisory",
+      "release_posture": "required",
       "determinism": "deterministic",
       "applicability": { "source": true, "artifact": false },
       "selector": { "unknown_paths": "full", "failure": "full" },


### PR DESCRIPTION
## Summary

\`release.yml\`'s \`RELEASE_REQUIRED_CHECKS\` gained \`CodeQL\` in #2256, but \`.github/ci-lanes.json\`'s registry entry for it still said \`release_posture: advisory\`, so \`TestCILaneRegistry\` started failing on every branch synced past that merge (found while sweeping PR #2245's CI).

## Test plan
- [x] \`go test -run '^TestCILaneRegistry$' ./test/regression/...\` passes locally
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)