### PR TITLE
fix(rejection-parity): repoint the exp-histogram V-V-op divergence at #2263

### DIFF
--- a/test/rejection-parity/catalogue/internal__promql__lower.go.json
+++ b/test/rejection-parity/catalogue/internal__promql__lower.go.json
@@ -77,7 +77,7 @@
       "message": "promql: %q is an exponential histogram metric; only a bare %q selector, sum()/avg()/count() over one, rate()/increase()/delta()/irate()/idelta()/sum_over_time()/avg_over_time()/resets()/changes() over one, histogram_quantile(), histogram_count(), histogram_sum(), and the %q/%q companion selectors are supported",
       "class": "divergence",
       "trigger_query": "demo_latency_exp_hist + demo_latency_exp_hist",
-      "tracking_issue": 2243,
+      "tracking_issue": 2263,
       "evidence": {
         "guard": [
           "past returning if bare, col, hasCompanion := s.HistogramCompanionColumn(metricName); hasCompanion \u0026\u0026 s.IsExpHistogramMetric(bare) \u0026\u0026 s.ExpHistogramTable != \"\"",


### PR DESCRIPTION
## Summary

- `internal/promql/lower.go:expHistogramSelectorRouting#bf746b59`'s catalogue entry (`test/rejection-parity/catalogue/internal__promql__lower.go.json`) cited tracking issue #2243, which closed via #2245 without fixing this specific divergence (binary arithmetic between two bare exponential-histogram selectors, e.g. `demo_latency_exp_hist + demo_latency_exp_hist`). That leaves the entry citing a dead issue, and `rejection-parity-divergence-liveness` (part of the required `forbid-deferral` job) has been red on `main` since #2245 merged.
- #2263 re-files the still-open divergence. This PR repoints the catalogue entry's `tracking_issue` at #2263.
- Verified the class stays `"divergence"` rather than `"rejection"`: reference Prometheus DOES answer `histogram + histogram` — `promql/engine.go`'s `vectorElemBinop`, the `hlhs != nil && hrhs != nil` case, calls `hlhs.Copy().Add(hrhs)` (also `Sub`, `EQLC`/`NEQ` via `.Equals`) — confirmed by reading the actual function body in `github.com/prometheus/prometheus@v0.311.3`. It is not a rejection on the reference side, so reclassifying would be dishonest per this repo's rejection-parity contract (`test/rejection-parity/doc.go`).
- Full investigation notes, including the recommended implementation scope for actually closing the gap, are posted as a comment on #2263 rather than implemented here — see that comment for why (new `chplan` node + a ~800-line-class new `chsql` emitter, comparable in size to the existing vector-vector join, plus rigorous numeric testing given this area's history of subtle Kahan-fold-order bugs).

## Test plan

- [x] `go test ./test/rejection-parity/... -run 'TestCatalogueEntriesAreClassified|TestDivergenceCeilingRatchet$|TestDivergenceEntriesRespectAgeCap|TestCatalogueIsRegenerable|TestRejectionTriggersExerciseSites|TestParityCorpusMatchesCatalogue'` — all PASS
- [x] Ran the actual liveness-gate script locally against the updated catalogue: `GITHUB_REPOSITORY=tsouza/cerberus GITHUB_TOKEN=$(gh auth token) node .github/scripts/rejection-parity-divergence-liveness.mjs` → `violations: 0` (was 1 before this change)

Closes #2263? No — #2263 stays open as the tracking issue for the underlying feature (native-histogram binary arithmetic between two selectors). This PR only fixes the now-dead tracking-issue citation that's failing CI on `main`.