### PR TITLE
fix(test/property): stop the instant-window oracle rejecting empty series

### DIFF
--- a/test/property/instant_window_test.go
+++ b/test/property/instant_window_test.go
@@ -174,8 +174,8 @@ const (
 // presence, and value. Unsupported functions are harness errors, never an
 // implicit empty result.
 func oracleInstantWindow(c gen.InstantWindowCase) property.Outcome {
-	if invalid := property.ValidateGeneratedDataset(c.Dataset); invalid != "" {
-		return property.Outcome{Err: fmt.Errorf("instant-window oracle: invalid dataset: %s", invalid)}
+	if c.Dataset.Metrics == nil {
+		return property.Outcome{Err: fmt.Errorf("instant-window oracle: missing metrics model")}
 	}
 	if len(c.Dataset.Metrics.Series) != 1 {
 		return property.Outcome{Err: fmt.Errorf(


### PR DESCRIPTION
## Summary

- `coverage` on `main` has been failing consistently since at least
  2026-08-16T17:12:50Z on
  `TestInstantWindowOracleReturnsAbsentForInsufficientSamples/zero_samples`.
- `oracleInstantWindow` (`test/property/instant_window_test.go`) called the
  shared `property.ValidateGeneratedDataset` before its own `minimumSamples`
  gate. That shared validator exists to catch broken random-generator draws
  (see its doc comment: "keep a generator defect from consuming a randomized
  check without executing either side of the fence") and rejects any series
  with zero points outright. The "zero samples" subtest hand-builds exactly
  that input to exercise the oracle's *own* graceful "insufficient samples"
  path (`if len(window) < minimumSamples { return property.Outcome{} }`),
  which is semantically correct but was unreachable because the shared
  validator errored out first.
- Confirmed this is not a repo-wide convention: `oracleInstantWindow` was the
  only oracle function in `test/property/` calling the shared validator
  internally (the sibling `oracleRangeOutcome` doesn't), and both real
  rapid-generator callers (`TestPromQL_InstantWindowSweep_FromScratch`,
  `TestPromQL_InstantWindowShapeRoster`) already call
  `ValidateMetricsDataset`/`ValidateGeneratedDataset` on the dataset before
  invoking the oracle, making the oracle's internal call purely redundant for
  them.
- Fix: drop the internal `ValidateGeneratedDataset` call from
  `oracleInstantWindow` and replace it with a narrow nil-`Metrics` guard
  (avoids a nil-pointer panic on `c.Dataset.Metrics.Series` for a
  theoretically malformed case, without pre-empting the legitimate
  zero-sample-series path). The shared `ValidateMetricsDataset` itself is
  untouched — it's relied on by other property tests.

## Test plan

- [x] `go test -tags chdb -run '^TestInstantWindowOracleReturnsAbsentForInsufficientSamples$' -v ./test/property/` — both `zero_samples` and `one_sample` subtests pass.
- [x] `go test -tags chdb -run '^TestInstantWindowOracleRejectsDuplicateTimestamp$|^TestInstantWindowOracleRejectsUnknownFunction$|^TestInstantWindowOracleExtrapolatedFunctionsCoverEveryValueGeometry$|^TestInstantWindowOracleUsesLeftExclusiveRightInclusiveWindow$' -v ./test/property/` — all pass, confirming the oracle's own error paths (duplicate timestamp, unsupported function) still fire without the removed check.
- [x] `go test -tags chdb ./test/property/ -run '^TestPromQL_InstantWindowSweep_FromScratch$' -v -rapid.checks=50` — 50 rapid-generated cases pass, confirming the caller-side validation still protects the random lane.
- [x] `go test -tags chdb -run '^TestPromQL_InstantWindowShapeRoster$' -v ./test/property/...` — full shape roster passes.
- [x] `go build` / `go vet -tags chdb ./test/property/...` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
