### PR TITLE
docs(compat): correct the prometheus-floor timing claim with re-measured numbers

### DIFF
--- a/compatibility/prometheus/scripts/run-prometheus-compatibility.sh
+++ b/compatibility/prometheus/scripts/run-prometheus-compatibility.sh
@@ -78,14 +78,32 @@
 #                      each other that some individually-fast queries miss
 #                      the shared 10s deadline purely from contention —
 #                      "context deadline exceeded" with an empty diff, not
-#                      a semantic divergence. Confirmed by direct
-#                      measurement: every one of the CI-observed timeout
-#                      cases answers in under 3s in isolation; firing the
-#                      same query set at -query-parallelism-equivalent
-#                      concurrency against a 2-vCPU-constrained container
-#                      (matching a GH Actions standard runner) reproduces
-#                      individual response times past 10s at concurrency
-#                      20, comfortably under it at concurrency 2.
+#                      a semantic divergence. That contention argument is
+#                      why the flag is set low at all, and it holds for
+#                      the corpus at large. It does NOT hold for the
+#                      exponential-histogram family, whose cases the flag
+#                      cannot rescue at any value. Re-measured against
+#                      this lane's own CH_IMAGE with this script's own
+#                      seed fixture, ONE query at a time against an
+#                      otherwise idle, unconstrained multi-core host —
+#                      i.e. strictly kinder than a 2-vCPU CI runner and
+#                      with no contention at all:
+#                        histogram_quantile(<phi>,
+#                            sum(rate(demo_shifting_latency_exp_hist[1m|5m])))
+#                            and the bare-selector variant  9-13s
+#                        count_values("hist",
+#                            rate(demo_shifting_latency_exp_hist[5m]))    19-20s
+#                      Both sit at or past the comparer's 10s deadline
+#                      already, so lowering -query-parallelism further
+#                      buys nothing for them. Every one of those seconds
+#                      is ClickHouse-side expression evaluation over the
+#                      fixture's 520 stored rows — measured by timing the
+#                      emitted query's nested sub-SELECTs one level at a
+#                      time, it splits roughly 58% per-series across-TIME
+#                      window fold, 14% across-series bucket merge, 22%
+#                      quantile value expression. Cerberus issue #2267
+#                      owns making that arithmetic cheaper; this knob is
+#                      not the lever.
 #
 # Upstream tester invocation (post-PR #298 / #300 audit):
 #   The upstream `promql-compliance-tester` only accepts `-config-file`


### PR DESCRIPTION
## What this is

Issue #2267 proposed two remediation directions for the red
`compatibility/prometheus-floor` lane and asked for the algorithmic one to be
pursued as the root-cause fix: hoist the three `arraySort(...)` calls that
`expHistogramMergeBucketsExpr` embeds inside the outer `arrayMap(t -> ...)`
into `Project`-level column aliases, on the hypothesis that ClickHouse
re-evaluates them once per target bucket `t`.

**The hypothesis does not hold, and #2258 is not the cause of the regression.**
This PR therefore carries no chsql/chplan change. It carries the one thing the
investigation did prove wrong in the tree: the measurement claim in
`run-prometheus-compatibility.sh` that justifies the lane's only mitigation.

## Evidence

### 1. The three `arraySort`s are textually inside the lambda, but ClickHouse hoists them

`test/spec/promql/histogram_quantile_native_agg.txtar`'s `-- sql --` does embed
them inside the `t` lambda, as the issue expected:

```
arrayMap(t -> arrayReduce(?, arrayMap((s, off, arr) -> …,
    arraySort((row, key) -> key, `_hq_scales`,       `_hq_series_order_key`),
    arraySort((row, key) -> key, `_hq_pos_offsets`,  `_hq_series_order_key`),
    arraySort((row, key) -> key, `_hq_pos_buckets`,  `_hq_series_order_key`))),
  range(toUInt64(…)))
```

But `EXPLAIN actions=1`, on **both** ClickHouse 24.8 (the floor lane's own
image) and 26.6, shows each `arraySort` as a top-level `FUNCTION` node in the
enclosing per-row ActionsDAG, feeding the lambda through a `Capture`:

```
FUNCTION arraySort(__table1.arr :: 4) -> arraySort(__table1.arr) Array(Float64) : 1
FUNCTION Capture[Array(Float64), UInt8](UInt8) -> Float64(arraySort(__table1.arr) :: 1, …)
```

The analyzer lifts lambda-invariant subexpressions out of higher-order-function
bodies and computes them once per row. `arrayMin(arrayMap((sm, om) -> …))` —
the merged-start expression, nested three lambdas deep — is lifted the same way.

Timing agrees. Replaying the fixture's own merge expression on 24.8 over 360
group rows x 3 series x 60 buckets, with the three sorts left embedded versus
hoisted into sibling SELECT aliases, produces identical results and
indistinguishable times (~0.8-1.0s either way, run-to-run noise larger than the
difference). The proposed hoist would churn ~24 goldens for no measured gain.

### 2. #2258 did not make these queries slower

Built cerberus at `38d8ed115` (#2258's parent) and at `cfc5e0225` (#2258),
pointed both at one seeded ClickHouse 24.8 loaded by this harness's own seeder,
and alternated `/api/v1/query_range` over the harness's own window (1h, step
10s), 10 samples per side:

| query | before #2258 | after #2258 |
| --- | --- | --- |
| `histogram_quantile(0.9, sum(rate(demo_shifting_latency_exp_hist[1m])))` | 10.5-12.1s (median ~11.0s) | 9.2-13.7s (median ~11.0s) |
| `histogram_quantile(0.5, sum(rate(demo_shifting_latency_exp_hist[5m])))` | 11.1-11.7s | 9.4-9.8s |
| `histogram_quantile(0.5, rate(demo_shifting_latency_exp_hist[1m]))` | 10.6-11.4s | 10.4-10.8s |
| `count_values("hist", rate(demo_shifting_latency_exp_hist[5m]))` | 18.6-20.1s | 19.2-19.8s |

Every case was already at or over the comparer's 10s deadline **before** #2258,
with a single query in flight and no contention. The 1 -> 20 flip in the ratchet
is a set of cases sitting on a hard threshold, not a step change in their cost.

Structurally, #2258 made the emitted SQL slightly *cheaper*: on
`histogram_quantile_native_agg.txtar` it is `arraySort` 26 -> 32, `arrayMap`
152 -> 148, and `arrayFold` 13 -> 11, the two removed `arrayFold`s having been
replaced by native `arrayReduce('sumKahan', …)`.

### 3. Two factual corrections to #2267 itself

- The nine bare `histogram_quantile(<phi>, rate(demo_shifting_latency_exp_hist[1m]))`
  cases are **not** on an untouched code path. Their emitted SQL contains
  `_hq_series_order_key` and changed length 29104 -> 28553 across #2258, so all
  20 regressed cases run the changed merge — and all 20 are unchanged in cost.
- `compatibility/prometheus-floor` is not in `main`'s required status-check set
  (`compatibility/prometheus`, `-forced-route`, `loki` and `tempo` are), so it
  does not block merges the way the issue describes.

### 4. Where the time actually goes

Timing the emitted query's nested sub-SELECTs one level at a time on 24.8
(`max_threads=2`, medians of 3), for
`histogram_quantile(0.5, sum(rate(demo_shifting_latency_exp_hist[5m])))`:

| stage | cumulative | delta |
| --- | --- | --- |
| step-grid fanout aggregate | 0.58s | — |
| per-series across-TIME window fold | 6.43s | **+5.85s (58%)** |
| across-series merge aggregate + merge projections | 7.53s | +1.10s (14%) |
| bucket concat / cumsum / index | 8.08s | +0.55s |
| quantile value expression | 10.30s | +2.22s (22%) |

520 stored rows in, 359 rows out, 10.3s of pure ClickHouse expression
evaluation. #2258's code is inside the 14% band, and measurably free within it.
The lever that would actually turn this lane green is the per-series across-time
window fold, then the quantile value expression.

## What changed here

`compatibility/prometheus/scripts/run-prometheus-compatibility.sh`'s
`TESTER_QUERY_PARALLELISM` comment claimed, as directly measured, that "every
one of the CI-observed timeout cases answers in under 3s in isolation" and that
concurrency 2 stays "comfortably under" the deadline. Measurement (2) refutes
both for the exponential-histogram family. The comment now carries the
re-measured numbers, the per-stage split, and the conclusion that this knob
cannot rescue those cases at any value. The knob itself is unchanged — the
contention argument still holds for the rest of the corpus.

## Verification

- Comment-only change to a shell script; `bash -n` clean, `shellcheck` reports
  only the pre-existing SC2329 on the trap-invoked `cleanup`.
- No `internal/chsql`, `internal/chplan` or `internal/promql` change, so no
  golden regeneration is implied and `node .github/scripts/forbid-sql-raw.mjs`
  is clean.
- The wall-clock numbers above come from a local ClickHouse 24.8 container plus
  this harness's own seeder, not from CI; the compat lanes cannot be settled
  locally in their full form, and no claim here rests on a CI-observed
  improvement.

Refs #2267 — the issue stays open, since nothing here makes the floor lane green.
