### PR TITLE
ci(link-check): exclude slsa.dev from the external link checker

### DIFF
--- a/.github/workflows/link-check-external.yml
+++ b/.github/workflows/link-check-external.yml
@@ -50,6 +50,13 @@ jobs:
       # rather than propagated, so the job stays green even with dead links;
       # the report below carries the signal.
       # The same upstream-snapshot + node_modules excludes as the internal gate.
+      #
+      # `--exclude 'https://slsa\.dev'`: slsa.dev has fired "Connection
+      # failed. Check network connectivity and firewall settings" on every
+      # run that has hit it (#1315, #2272) despite being reachable from a
+      # browser — it blocks the GitHub Actions runner range / lychee's
+      # non-browser user agent, not an actual outage. The link itself is
+      # valid; this checker cannot verify it, so stop asking it to.
       - name: lychee (external links)
         id: lychee
         env:
@@ -65,6 +72,7 @@ jobs:
             --exclude-path compatibility/tempo/upstream \
             --exclude-path compatibility/loki/upstream \
             --exclude-path node_modules \
+            --exclude 'https://slsa\.dev' \
             "**/*.md"
           echo "exit_code=$?" >> "$GITHUB_OUTPUT"
 


### PR DESCRIPTION
## Summary

The weekly `link-check-external` job has opened a false-alarm issue for `https://slsa.dev/`
twice now (#1315, #2272), three weeks apart, both times with lychee's generic "Connection
failed. Check network connectivity and firewall settings" error. The link is reachable from a
normal browser; slsa.dev is blocking the checker's traffic (GitHub Actions runner range and/or
lychee's non-browser user agent), not actually down. There is nothing on our side to fix about
the connectivity itself, and a repeatedly-false-positive automated issue is pure noise.

Excludes `slsa.dev` from `lychee`'s external check via `--exclude`, verified locally to drop it
from the checked-URL set while leaving every other external link (including the two `slsa.dev`
references in `README.md` and `docs/migration.md`) untouched otherwise.

## Test plan

- [x] `actionlint .github/workflows/link-check-external.yml` — clean
- [x] `lychee --exclude 'https://slsa\.dev' --dump README.md docs/migration.md` — confirms
      `slsa.dev` no longer appears in the checked-URL dump, versus appearing twice without the
      flag
- [ ] CI: the workflow itself only runs on a weekly schedule / manual dispatch, so this PR's own
      CI won't exercise the `lychee (external links)` step — the local verification above is the
      evidence
