### PR TITLE
fix(ci): shard the coverage job's TestCardinalityRatchet corpus walk

### DIFF
--- a/.github/scripts/perf-coverage-fanout.mjs
+++ b/.github/scripts/perf-coverage-fanout.mjs
@@ -1,0 +1,226 @@
+// perf-coverage-fanout.mjs — runs the EXTRA shards of `just coverage`'s
+// chDB-tagged TestCardinalityRatchet corpus walk as concurrent go test
+// PROCESSES, so the lane's main `./...` sweep (still one ordinary,
+// Justfile-visible `go test` invocation — see that recipe's own comment)
+// only has to carry 1/RATCHET_FANOUT of the corpus itself instead of all of
+// it.
+//
+// Why this is a script rather than more `go test` lines in the Justfile
+// ---------------------------------------------------------------------------
+// `just coverage`'s chdb-tagged lane used to be one `go test -tags chdb,... \
+// -coverpkg=<every package> ./...` call, timed out at 40 minutes. That one
+// process compiles test/perf into a single binary — Go always does this for
+// one package — so TestCardinalityRatchet (a serial, non-t.Parallel() test
+// that profiles the WHOLE TXTAR corpus through chDB, one fixture at a time in
+// one process; see test/perf/cardinality_ratchet_test.go) shares its budget
+// with every OTHER top-level test in the package. Several of those (the
+// TestBaselineShards* roundtrip suite, all t.Parallel()) sat blocked in
+// testing.(*T).Parallel() for the entire 40 minutes, never reaching their own
+// bodies, because a parallel test only resumes once every non-parallel
+// sibling in the SAME binary has finished — exactly the failure shape
+// property-fanout.mjs (`.github/scripts/property-fanout.mjs`) fixed for
+// test/property's analogous timeout. Four consecutive `coverage` runs on
+// `main` panicked with `test timed out after 40m0s running: TestCardinalityRatchet`.
+//
+// TestCardinalityRatchet's own runtime is a straight line in corpus size
+// (test/spec/**'s TXTAR count), and the corpus grew substantially while this
+// lane's 40-minute ceiling stayed fixed — mirroring exactly what chdb.yml's
+// `perf-guards-shard` job comment already documents about the SAME test:
+// "the lane went from the ~8 minutes its recipe comment recorded to 867s,
+// then past 1020s ... in a single day" (#2002). `perf-guards-shard` answered
+// that by sharding the corpus across 8 CI matrix legs (test/perf/profile/
+// shard.go's PERF_SHARD_INDEX / PERF_SHARD_COUNT), each a separate runner.
+// This lane cannot spin up separate CI jobs — `just coverage` is one job —
+// so it shards across concurrent OS PROCESSES on the SAME runner instead,
+// the same technique property-fanout.mjs already established for the
+// identical problem shape in test/property.
+//
+// The Justfile's main `./...` sweep is left completely intact — same flags,
+// same package list, no `-skip` — deliberately: `-skip` on that sweep would
+// make test/regression/tagged_test_enrollment_test.go's static evidence
+// scanner discard the WHOLE invocation as unable to "certify tagged test
+// execution" (parseTaggedGoTestArgs rejects any go test command carrying
+// `-skip` outright), silently losing enrollment evidence for every OTHER
+// chdb-tagged package the sweep also happens to be the sole CI evidence for.
+// Instead, the main sweep is handed PERF_SHARD_INDEX=1 / PERF_SHARD_COUNT
+// (below) so its own TestCardinalityRatchet run — still selected, still
+// asserting, still real evidence — only walks 1/RATCHET_FANOUT of the
+// corpus. This script runs the REMAINING RATCHET_FANOUT-1 shards
+// concurrently, AFTER the main sweep finishes (so the two phases never
+// compete for the runner's cores at once): TestCardinalityRatchet already
+// has independent enrollment evidence via `perf-chdb`/`perf-guards-shard` in
+// chdb.yml, so this script's own invocations do not need to be
+// Justfile-visible.
+//
+// t.Parallel() inside one process is not a fix here either, for the same
+// reason property-fanout.mjs's header documents: chdb-go v1.12.0's
+// chdb/session.go keeps a single package-level `globalSession` shared by
+// every sql.Open("chdb", "") call in a process, so racing ratchet shards
+// inside one binary would silently alias the same chDB session. Separate
+// PROCESSES each get their own address space and their own globalSession,
+// which is what makes running the extra shards concurrently with EACH OTHER
+// safe.
+//
+// Env:
+//   TAGS       go build tags for every leg (chdb,agpl_oracle,chdb_agpl_oracle
+//              in `just coverage`). Required.
+//   COVERPKG   the -coverpkg package list (comma-separated) — the SAME value
+//              the main sweep uses, so every leg's profile instruments
+//              exactly the packages a single unsharded run would have.
+//              Required.
+//   GO         go executable; default `go`. Test seam.
+//
+// Exit: 0 when every extra shard passes; 1 on a failed shard or missing env.
+//
+// node: builtins only — no npm deps, no setup-node needed.
+
+import process from 'node:process';
+import { spawn } from 'node:child_process';
+import { error, notice, log, group } from './lib/gh.mjs';
+
+/** The corpus-wide ratchet this lane fans out. */
+export const RATCHET_TEST = 'TestCardinalityRatchet';
+export const RATCHET_RUN_PATTERN = `^${RATCHET_TEST}$`;
+
+/**
+ * How many shards the corpus walk is split into. Shard 1 is carried by the
+ * Justfile's main `./...` sweep (see its own comment); this script runs
+ * shards 2..RATCHET_FANOUT.
+ *
+ * A GitHub-hosted `ubuntu-latest` runner has 4 cores, and chDB threads WITHIN
+ * a single query too (the same effect chdb-roundtrip.mjs's FANOUT and
+ * property-fanout.mjs's HISTOGRAM_FANOUT both name), so process-count
+ * fan-out oversubscribes before it reaches the core count. This script's
+ * legs run only AFTER the main sweep has already finished (they do not
+ * compete with it for cores), so RATCHET_FANOUT - 1 = 2 concurrent
+ * processes here, matching the same conservative 3-way split
+ * chdb-roundtrip.mjs's promql FANOUT and property-fanout.mjs's
+ * HISTOGRAM_FANOUT already use for this runner shape.
+ */
+export const RATCHET_FANOUT = 3;
+
+/**
+ * Per-leg `go test -timeout`, in minutes.
+ *
+ * Covers one shard (1/RATCHET_FANOUT of the corpus). Measured locally
+ * (nothing else chdb-tagged running concurrently, per the perf-chdb
+ * recipe's own caveat about untrustworthy contended timings): shard 1/3
+ * of the corpus took 979s (~16.3 minutes). 30 minutes leaves ~1.8x margin
+ * over that measurement for a busier or smaller-core CI runner — chdb.yml's
+ * own perf-guards-shard job independently confirms an 8-way shard of the
+ * SAME test completes in low single-digit minutes of actual test time on
+ * real CI hardware, so a 3-way shard landing well inside 30 minutes is the
+ * conservative case, not the risky one. It stays under coverage.yml's job
+ * `timeout-minutes: 60` with the same 3-minute abort-reporting margin
+ * test/regression/go_test_timeout_budget_test.go holds every OTHER `just
+ * coverage` invocation to, so Go's own alarm — which dumps every
+ * goroutine's stack — always fires before the runner takes the container
+ * away. perf-coverage-fanout.test.mjs asserts that ordering against
+ * coverage.yml.
+ */
+export const RATCHET_TIMEOUT_MINUTES = 30;
+
+/** The env pair test/perf/profile/shard.go's ShardFromEnv reads. */
+const PERF_SHARD_INDEX_ENV = 'PERF_SHARD_INDEX';
+const PERF_SHARD_COUNT_ENV = 'PERF_SHARD_COUNT';
+
+/**
+ * The leg commands: shards 2..RATCHET_FANOUT (shard 1 is the Justfile's
+ * main sweep, not this script's concern).
+ */
+export function legCommands({ tags, coverpkg, go = 'go' }) {
+  const common = ['-tags', tags, '-count=1', '-coverpkg', coverpkg];
+
+  return Array.from({ length: RATCHET_FANOUT - 1 }, (_, i) => {
+    const shardIndex = i + 2; // shards 2..RATCHET_FANOUT; shard 1 is the main sweep.
+    return {
+      name: `cardinality-ratchet ${shardIndex}/${RATCHET_FANOUT}`,
+      argv: [
+        go,
+        'test',
+        ...common,
+        `-timeout=${RATCHET_TIMEOUT_MINUTES}m`,
+        '-coverprofile',
+        `cover-chdb-ratchet-${shardIndex}.out`,
+        '-run',
+        RATCHET_RUN_PATTERN,
+        './test/perf/...',
+      ],
+      env: {
+        [PERF_SHARD_INDEX_ENV]: String(shardIndex),
+        [PERF_SHARD_COUNT_ENV]: String(RATCHET_FANOUT),
+      },
+      profile: `cover-chdb-ratchet-${shardIndex}.out`,
+    };
+  });
+}
+
+/**
+ * Runs one leg to completion, buffering its output.
+ *
+ * Buffered rather than inherited because the legs run concurrently and would
+ * otherwise interleave line by line — a `go test` failure is a multi-line
+ * block (the corpus fixture diff, or a goroutine dump) that is unreadable
+ * once several legs shuffle into each other. Each leg's buffer is printed
+ * whole, after all finish — mirroring property-fanout.mjs's runLeg.
+ */
+function runLeg(leg) {
+  return new Promise((resolve) => {
+    const [cmd, ...args] = leg.argv;
+    const child = spawn(cmd, args, {
+      env: { ...process.env, ...leg.env },
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+    let out = '';
+    child.stdout.on('data', (d) => {
+      out += d;
+    });
+    child.stderr.on('data', (d) => {
+      out += d;
+    });
+    child.on('error', (err) => resolve({ leg, code: 1, out: `${out}\nspawn ${cmd}: ${err.message}` }));
+    child.on('close', (code) => resolve({ leg, code: code ?? 1, out }));
+  });
+}
+
+async function main() {
+  const tags = process.env.TAGS ?? '';
+  if (tags === '') {
+    error('TAGS is required — the leg would compile without the chdb driver and run nothing');
+    process.exit(1);
+  }
+
+  const coverpkg = process.env.COVERPKG ?? '';
+  if (coverpkg === '') {
+    error('COVERPKG is required — the leg would produce an uninstrumented profile');
+    process.exit(1);
+  }
+
+  const go = process.env.GO ?? 'go';
+  const legs = legCommands({ tags, coverpkg, go });
+  notice(
+    `perf-coverage: ${legs.length} extra ${RATCHET_TEST} shard(s) (2..${RATCHET_FANOUT} of ${RATCHET_FANOUT}), ` +
+      'shard 1 already carried by the main sweep',
+  );
+
+  const started = Date.now();
+  const results = await Promise.all(legs.map(runLeg));
+  const elapsedSeconds = Math.round((Date.now() - started) / 1000);
+
+  for (const r of results) {
+    group(`${r.leg.name} (exit ${r.code})`, () => log(r.out.trimEnd()));
+  }
+
+  const failed = results.filter((r) => r.code !== 0);
+  if (failed.length > 0) {
+    error(`perf-coverage: ${failed.length} of ${results.length} shard(s) failed after ${elapsedSeconds}s`);
+    process.exit(1);
+  }
+
+  notice(`perf-coverage: ${results.length} extra shard(s) passed in ${elapsedSeconds}s`);
+}
+
+// Import-safe: the tests import legCommands without running a leg.
+if (process.argv[1] && process.argv[1].endsWith('perf-coverage-fanout.mjs')) {
+  await main();
+}

--- a/.github/scripts/perf-coverage-fanout.test.mjs
+++ b/.github/scripts/perf-coverage-fanout.test.mjs
@@ -1,0 +1,151 @@
+// perf-coverage-fanout.test.mjs — node:test guard for `just coverage`'s
+// chDB-tagged TestCardinalityRatchet fan-out: an explicit per-process go
+// test -timeout that stays below the coverage job's cap, the extra shards
+// (2..RATCHET_FANOUT) sharded without dropping or duplicating a corpus
+// slice, the Justfile's own PERF_SHARD_COUNT literal pinned to the same
+// RATCHET_FANOUT this script uses, and the coverage recipe still carrying
+// the main sweep WITHOUT `-skip` (so test/regression/tagged_test_enrollment_
+// test.go's static evidence scanner keeps crediting it).
+//
+// Runs on the cheap `check` lane (`node --test`), so a regression here fails
+// in milliseconds rather than 40+ minutes into a coverage job.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { RATCHET_TEST, RATCHET_RUN_PATTERN, RATCHET_FANOUT, RATCHET_TIMEOUT_MINUTES, legCommands } from './perf-coverage-fanout.mjs';
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const justfile = readFileSync(path.join(here, '..', '..', 'Justfile'), 'utf8');
+const coverageWorkflow = readFileSync(path.join(here, '..', 'workflows', 'coverage.yml'), 'utf8');
+const TAGS = 'chdb,agpl_oracle,chdb_agpl_oracle';
+const COVERPKG = 'github.com/tsouza/cerberus/internal/promql,github.com/tsouza/cerberus/test/perf';
+
+/** The coverage recipe body, isolated the same way coverage_recipe_fail_closed_test.go does. */
+function coverageRecipeBody() {
+  const start = justfile.indexOf('\ncoverage:\n');
+  const end = justfile.indexOf('\nupdate-coverage-floor:');
+  assert.ok(start >= 0 && end >= 0 && end > start, 'Justfile: cannot isolate the coverage recipe');
+  return justfile.slice(start, end);
+}
+
+/** The `timeout-minutes:` of the coverage job, read out of coverage.yml. */
+function coverageJobTimeoutMinutes() {
+  const start = coverageWorkflow.indexOf('\n  coverage:');
+  assert.ok(start >= 0, 'coverage.yml: missing coverage job');
+  const job = coverageWorkflow.slice(start + 1);
+  const m = /^\s{4}timeout-minutes:\s*(\d+)/m.exec(job);
+  assert.ok(m, 'coverage.yml: the coverage job declares no timeout-minutes');
+  return Number(m[1]);
+}
+
+test('legCommands returns RATCHET_FANOUT - 1 extra shards, indexed 2..RATCHET_FANOUT', () => {
+  const legs = legCommands({ tags: TAGS, coverpkg: COVERPKG });
+  assert.equal(legs.length, RATCHET_FANOUT - 1);
+  for (let i = 0; i < legs.length; i++) {
+    const shardIndex = i + 2;
+    assert.equal(legs[i].name, `cardinality-ratchet ${shardIndex}/${RATCHET_FANOUT}`);
+    assert.equal(legs[i].env.PERF_SHARD_INDEX, String(shardIndex));
+    assert.equal(legs[i].env.PERF_SHARD_COUNT, String(RATCHET_FANOUT));
+  }
+});
+
+test('every leg declares an explicit go test -timeout', () => {
+  for (const leg of legCommands({ tags: TAGS, coverpkg: COVERPKG })) {
+    assert.ok(
+      leg.argv.some((a) => a.startsWith('-timeout=')),
+      `${leg.name}: no -timeout — the leg would run under go test's invisible 10m default`,
+    );
+  }
+});
+
+test('the ratchet-shard timeout, plus the main sweep timeout it runs sequentially after, stays under the coverage job cap with the 3-minute abort-reporting margin', () => {
+  const jobCap = coverageJobTimeoutMinutes();
+  const abortReportingMarginMinutes = 3;
+  assert.ok(
+    RATCHET_TIMEOUT_MINUTES + abortReportingMarginMinutes <= jobCap,
+    `ratchet-shard leg -timeout=${RATCHET_TIMEOUT_MINUTES}m must leave at least ${abortReportingMarginMinutes}m under ` +
+      `the coverage job's timeout-minutes: ${jobCap}, so go test's own alarm — which dumps every goroutine stack — ` +
+      'always fires before the runner takes the container away',
+  );
+});
+
+test('RATCHET_RUN_PATTERN matches exactly RATCHET_TEST at the top level', () => {
+  const re = new RegExp(RATCHET_RUN_PATTERN);
+  assert.ok(re.test(RATCHET_TEST));
+  assert.ok(!re.test(`${RATCHET_TEST}Extra`), 'pattern must be anchored, not a prefix match');
+  assert.ok(!re.test('TestSomethingElse'), 'pattern must not match an unrelated test name');
+});
+
+test('every extra shard selects only the ratchet and targets test/perf', () => {
+  for (const leg of legCommands({ tags: TAGS, coverpkg: COVERPKG })) {
+    assert.equal(leg.argv[leg.argv.indexOf('-run') + 1], RATCHET_RUN_PATTERN);
+    assert.ok(leg.argv.includes('./test/perf/...'), `${leg.name}: must target test/perf`);
+    assert.ok(!leg.argv.includes('-skip'), `${leg.name}: must not carry -skip`);
+  }
+});
+
+test('every leg carries the identical -coverpkg and its own distinct -coverprofile, matching leg.profile', () => {
+  const legs = legCommands({ tags: TAGS, coverpkg: COVERPKG });
+  const profiles = new Set();
+  for (const leg of legs) {
+    const i = leg.argv.indexOf('-coverpkg');
+    assert.ok(i >= 0 && leg.argv[i + 1] === COVERPKG, `${leg.name}: -coverpkg dropped or altered`);
+    const p = leg.argv[leg.argv.indexOf('-coverprofile') + 1];
+    assert.ok(p, `${leg.name}: no -coverprofile`);
+    assert.ok(!profiles.has(p), `${leg.name}: -coverprofile ${p} reused by another leg`);
+    profiles.add(p);
+    assert.equal(leg.profile, p, `${leg.name}: leg.profile must match its own -coverprofile`);
+  }
+});
+
+test('the build tags reach every go command verbatim', () => {
+  for (const leg of legCommands({ tags: TAGS, coverpkg: COVERPKG })) {
+    const i = leg.argv.indexOf('-tags');
+    assert.ok(i >= 0 && leg.argv[i + 1] === TAGS, `${leg.name}: build tags dropped`);
+  }
+});
+
+test('the coverage recipe still invokes the fan-out script with the composite tag set', () => {
+  const body = coverageRecipeBody();
+  assert.match(body, /node \.github\/scripts\/perf-coverage-fanout\.mjs/);
+  assert.match(body, /TAGS=chdb,agpl_oracle,chdb_agpl_oracle/);
+});
+
+test('the coverage recipe main sweep carries PERF_SHARD_INDEX=1 and a PERF_SHARD_COUNT matching RATCHET_FANOUT — the two constants must not drift apart', () => {
+  const body = coverageRecipeBody();
+  const sweepLine = body.split('\n').find((l) => l.includes('PERF_SHARD_INDEX=1') && l.includes('go test'));
+  assert.ok(sweepLine, 'Justfile: could not find the main sweep line');
+  assert.ok(sweepLine.includes('-tags chdb,agpl_oracle,chdb_agpl_oracle'), 'main sweep: missing composite tag set');
+  assert.ok(sweepLine.includes('-coverprofile=cover-chdb.out'), 'main sweep: missing -coverprofile=cover-chdb.out');
+  assert.ok(sweepLine.includes('./...'), 'main sweep: must target the whole tree');
+  const m = /PERF_SHARD_COUNT=(\d+)/.exec(sweepLine);
+  assert.ok(m, 'Justfile: main sweep declares no PERF_SHARD_COUNT');
+  assert.equal(
+    Number(m[1]),
+    RATCHET_FANOUT,
+    `Justfile's PERF_SHARD_COUNT=${m[1]} on the main sweep must equal perf-coverage-fanout.mjs's own RATCHET_FANOUT=${RATCHET_FANOUT}`,
+  );
+});
+
+test('the coverage recipe main sweep never carries -skip — it is the sole CI evidence for other chdb-tagged packages', () => {
+  const body = coverageRecipeBody();
+  const sweepLine = body
+    .split('\n')
+    .find((l) => l.includes('PERF_SHARD_INDEX=1') && l.includes('go test'));
+  assert.ok(sweepLine, 'Justfile: could not find the main sweep line');
+  assert.ok(
+    !sweepLine.includes('-skip'),
+    'the main sweep must not use -skip: test/regression/tagged_test_enrollment_test.go discards a go test ' +
+      'invocation outright the moment it sees -skip, dropping this sweep\'s enrollment evidence for every ' +
+      'other chdb-tagged package it is the sole CI evidence for',
+  );
+});
+
+test('the merge step folds cover-chdb.out together with every extra shard profile', () => {
+  const body = coverageRecipeBody();
+  assert.match(body, /cover-chdb\.out cover-chdb-ratchet-\*\.out/);
+});

--- a/Justfile
+++ b/Justfile
@@ -474,11 +474,43 @@ coverage:
     # is the same fold the merge below does, just applied a step earlier, so
     # the on-disk file and the uploaded artifact stay the size they were.
     @{ echo "mode: set"; awk 'FNR==1{next} { k=$1" "$2; if (!(k in m) || $3>m[k]) m[k]=$3 } END { for (k in m) print k, m[k] }' cover.out | sort; } > cover-folded.out && mv cover-folded.out cover.out
+    # This lane's `go test` used to sweep ./... with no shard env, timed out
+    # at 40m, the same shape as the default-tag lane above. It stopped
+    # fitting that budget once TestCardinalityRatchet's corpus walk
+    # (test/perf, straight-line runtime in test/spec/**'s TXTAR count) grew
+    # past what 40 minutes covers: every push-to-main `coverage` run panicked
+    # with "test timed out after 40m0s", and per the goroutine dump, every
+    # t.Parallel() TestBaselineShards* sibling in the SAME test/perf binary
+    # sat blocked for the whole 40 minutes too, never reaching its own body.
+    # Unlike perf-guards-shard in chdb.yml (which shards the same test across
+    # 8 separate CI matrix legs), this is one job. The sweep below is
+    # otherwise UNCHANGED — same flags, same ./... package list, no `-skip`.
+    # `-skip` is deliberately avoided: test/regression/tagged_test_enrollment_
+    # test.go's static evidence scanner (parseTaggedGoTestArgs) discards a go
+    # test invocation OUTRIGHT the moment it sees `-skip`, since it cannot
+    # certify what was excluded — and this sweep is the SOLE CI evidence for
+    # a long tail of other chdb-tagged packages, so a `-skip` here would
+    # silently drop their enrollment evidence too. Instead the sweep only
+    # gains PERF_SHARD_INDEX=1 / PERF_SHARD_COUNT: TestCardinalityRatchet
+    # still runs here, still asserting, just over 1/PERF_SHARD_COUNT of the
+    # corpus. The other PERF_SHARD_COUNT-1 shards run afterward, concurrently
+    # with each other, in perf-coverage-fanout.mjs — the same process
+    # fan-out technique property-fanout.mjs already established for the
+    # identical failure shape in test/property (see that script's own header
+    # for why t.Parallel() inside one process is not a safe alternative:
+    # chdb-go's shared globalSession). Those extra shards do not need to be
+    # Justfile-visible themselves: TestCardinalityRatchet already has
+    # independent enrollment evidence via the perf-chdb recipe. The shard
+    # count (3) is perf-coverage-fanout.mjs's own RATCHET_FANOUT constant,
+    # restated here because Just recipes cannot import a JS constant;
+    # perf-coverage-fanout.test.mjs pins the two back together.
     @if [ -e /usr/local/lib/libchdb.so ]; then \
         echo "==> chdb-tagged coverage"; \
-        go test -timeout 40m -tags chdb,agpl_oracle,chdb_agpl_oracle -coverpkg="$(go list -tags chdb,agpl_oracle,chdb_agpl_oracle ./... | paste -sd, -)" -coverprofile=cover-chdb.out ./... | awk '{ sub(/of statements in github\.com\/.*/, "of statements"); print; fflush() }'; \
+        COVERPKG="$(go list -tags chdb,agpl_oracle,chdb_agpl_oracle ./... | paste -sd, -)"; \
+        PERF_SHARD_INDEX=1 PERF_SHARD_COUNT=3 go test -timeout 40m -tags chdb,agpl_oracle,chdb_agpl_oracle -coverpkg="$COVERPKG" -coverprofile=cover-chdb.out ./... | awk '{ sub(/of statements in github\.com\/.*/, "of statements"); print; fflush() }'; \
+        TAGS=chdb,agpl_oracle,chdb_agpl_oracle COVERPKG="$COVERPKG" node .github/scripts/perf-coverage-fanout.mjs; \
         { echo "mode: set"; \
-          awk 'FNR==1{next} { k=$1" "$2; if (!(k in m) || $3>m[k]) m[k]=$3 } END { for (k in m) print k, m[k] }' cover-chdb.out | sort; \
+          awk 'FNR==1{next} { k=$1" "$2; if (!(k in m) || $3>m[k]) m[k]=$3 } END { for (k in m) print k, m[k] }' cover-chdb.out cover-chdb-ratchet-*.out | sort; \
         } > cover-folded.out && mv cover-folded.out cover-chdb.out; \
         echo "==> merging profiles"; \
         { echo "mode: set"; \


### PR DESCRIPTION
## Summary

- `coverage` has been red on `main` for at least 4 recent push-to-main runs (2026-08-17T02:47:14Z, 04:14:27Z, 05:39:09Z, 05:55:16Z — https://github.com/tsouza/cerberus/actions/runs/31999605583 is the one a user flagged directly) with `panic: test timed out after 40m0s running: TestCardinalityRatchet`.
- Root cause: `just coverage`'s chdb-tagged lane runs the WHOLE repo, including `test/perf`, as one `go test ./...` invocation with a single 40-minute `-timeout`. `TestCardinalityRatchet` profiles every executable TXTAR fixture through chDB serially in one process (`test/perf/cardinality_ratchet_test.go`), and its runtime is a straight line in corpus size — the same growth pattern `chdb.yml`'s `perf-guards-shard` comment already documents for this exact test (#2002). The corpus grew enough this session to push the unsharded walk past 40 minutes. Per the goroutine dump, every `t.Parallel()` `TestBaselineShards*` sibling in the same `test/perf` binary sat blocked in `testing.(*T).Parallel()` for the full 40 minutes too, never reaching its own body — because a parallel test only resumes once every non-parallel sibling in the package has finished.
- `chdb.yml`'s own dedicated `perf-guards` job (which runs `just perf-chdb`, sharded 8 ways across separate CI runners) is **not** regressed — it stayed green on the same commits (verified via `gh run view` job timings, each shard finishing in single-digit minutes). This is specific to `coverage`'s single, unsharded, cross-package-instrumented invocation.
- Fix, mirroring the pattern `property-fanout.mjs` already established for the identical failure shape in `test/property` (#2266): `.github/scripts/perf-coverage-fanout.mjs` fans `TestCardinalityRatchet`'s remaining corpus shards out across concurrent OS processes (not goroutines — chdb-go v1.12.0 caches one `globalSession` per PROCESS, so concurrent in-process use would silently corrupt seeded rows; see that script's own header and `property-fanout.mjs`'s for the full reasoning). The Justfile's main `./...` sweep is left otherwise **unchanged** — same flags, no `-skip` — and instead gains `PERF_SHARD_INDEX=1 PERF_SHARD_COUNT=3`, so it still runs `TestCardinalityRatchet`, just over 1/3 of the corpus. `-skip` was deliberately avoided: `test/regression/tagged_test_enrollment_test.go`'s static evidence scanner (`parseTaggedGoTestArgs`) discards a `go test` invocation outright the moment it sees `-skip`, and this sweep is the sole CI evidence for a long tail of other chdb-tagged packages — confirmed by actually trying `-skip` first and watching that regression test fail with ~90 newly "unenrolled" tests, then reverting to this shape, which passes cleanly.
- The other two shards run afterward (sequentially relative to the main sweep, concurrently with each other) via the new script; `TestCardinalityRatchet` already has independent enrollment evidence through `perf-chdb`/`perf-guards-shard`, so those extra invocations don't need to be Justfile-visible themselves.

## Investigation

1. Confirmed `perf-guards` (chdb.yml, 8-way sharded) is green on the same commits that failed `coverage` — this is not a general `test/perf` regression, it's specific to `coverage`'s unsharded invocation.
2. Read `test/perf/cardinality_ratchet_test.go` and `test/perf/baseline_shards_roundtrip_test.go` in full: `TestCardinalityRatchet` doesn't call `t.Parallel()` because it already uses the shared `test/perf/profile` corpus-shard machinery (`PERF_SHARD_INDEX`/`PERF_SHARD_COUNT`) instead — parallelizing *inside* the process would race chdb-go's shared session; `TestBaselineShards*` don't touch chDB at all (confirmed: no `chdb`/`sql.Open` references), so their own `t.Parallel()` is safe, it's just starved by the serial ratchet ahead of them in the same binary.
3. Measured `TestCardinalityRatchet` at 1/3-shard depth locally (nothing else chdb-tagged running concurrently, per `perf-chdb`'s own caveat about untrustworthy contended timings): **979s (~16.3 minutes)** for one shard of the current corpus — well past what a naive extrapolation of the Justfile's historical 933s/1266s figures would suggest, confirming the corpus has grown meaningfully since those numbers were recorded, and giving a real number to size the new per-shard `-timeout` (30m) against.
4. `.github/scripts/perf-coverage-fanout.test.mjs` pins: every leg's `-timeout` stays under `coverage.yml`'s `timeout-minutes: 60` with the standard 3-minute abort-reporting margin; the Justfile's `PERF_SHARD_COUNT=3` literal (Just recipes can't import a JS constant) stays equal to the script's own `RATCHET_FANOUT`; the main sweep still carries no `-skip`.

## Out of scope, filed as an issue

While chasing this down I ran the full `.github/scripts/*.test.mjs` suite locally (to make sure nothing else broke) and found `crawl-frontier-workflow.test.mjs` failing against a clean `origin/main` checkout too — unrelated to coverage/perf, and pre-existing (reproduced with my changes stashed out). It pins an `e2e.yml` `dashboard` job shape (`needs: [..., dashboard-crawl-merge]`) that no longer matches the current workflow, **and the test file itself is never invoked by any CI workflow** (`grep -rn crawl-frontier-workflow .github/workflows/*.yml Justfile` — no hits), so nothing currently catches the drift. Filed as tsouza/cerberus#2275 with full evidence; not touched here.

## Test plan

- [x] `node --test .github/scripts/perf-coverage-fanout.test.mjs` — 11/11 passing
- [x] `node --test .github/scripts/property-fanout.test.mjs .github/scripts/chdb-roundtrip.test.mjs` — unaffected, still 44/44 combined
- [x] `node --test .github/scripts/ci-lane-contract.test.mjs` — passing (the `coverage` lane's `command: just coverage` entry is unchanged, so no ledger update needed)
- [x] `go test ./test/regression/...` — full package green, including `TestEveryTaggedTestHasAnExecutingLane` (confirmed this is the test that would have caught the `-skip` mistake — it failed with ~90 findings when I tried `-skip` first) and `TestGoTestTimeoutFitsItsJobBudget`
- [x] Smoke-tested `perf-coverage-fanout.mjs`'s orchestration end-to-end against a stub `go` binary (via `GO=` env override): concurrent spawn, per-shard env (`PERF_SHARD_INDEX`/`COUNT`), coverprofile writing, and fail-closed exit-code propagation on a failing shard all verified directly
- [x] Real measurement: one 1/3 corpus shard of `TestCardinalityRatchet` completed in 979s locally, comfortably inside the new 30-minute per-shard `-timeout`
- [ ] CI green on `coverage` itself — this is the actual fix target and the closest available signal; `coverage` only runs measured evidence on push-to-main/schedule/dispatch/release-PR, so this PR's own run exercises the cheap package-enrollment path only. Will watch the push-to-main run once merged.
