### PR TITLE
feat(promql): support +/- between two exponential-histogram selectors

### DIFF
--- a/compatibility/prometheus/query-corpus/fragments/006-native-histograms.yml
+++ b/compatibility/prometheus/query-corpus/fragments/006-native-histograms.yml
@@ -119,6 +119,19 @@
   # but not to the buckets.
   - query: 'avg(demo_latency_exp_hist)'
   - query: 'avg by (instance) (demo_latency_exp_hist)'
+  # Binary `+`/`-` between two histogram-valued selectors (cerberus issue
+  # #2263). Reference answers these via FloatHistogram's PLAIN Add/Sub —
+  # a different reference method from the cross-series sum() above, which
+  # goes through the Kahan-compensated KahanAdd instead (see
+  # internal/promql/histogram_native_binop.go's header doc). `+` doubles
+  # each of the two instances' own distribution rather than merging them
+  # with each other, so a lowering that accidentally joined the two
+  # DIFFERENT instances (rather than pairing each with itself) would
+  # answer with half as many output series and the wrong bucket layout.
+  # `-` self-cancels to an all-zero histogram, which pins the negation
+  # path independently of the addition path.
+  - query: 'demo_latency_exp_hist + demo_latency_exp_hist'
+  - query: 'demo_latency_exp_hist - demo_latency_exp_hist'
   # Cross-SCALE merge. demo_shifting_latency_exp_hist's third instance
   # is seeded at scale -1 against the other two at scale 0, so summing
   # the three coarsens the merged histogram's schema and folds bucket

--- a/compatibility/prometheus/query-corpus/header.yml
+++ b/compatibility/prometheus/query-corpus/header.yml
@@ -93,6 +93,12 @@
 #     neighbouring array and absent paths, but none of these reducers over a
 #     rate/increase inner, so it cannot exercise either the materialized
 #     direct aggregate or its fused equivalent (#2053).
+# 11. Two cerberus-owned cases cover binary `+`/`-` between two
+#     histogram-valued selectors (#2263), previously rejected outright.
+#     Reference answers these via FloatHistogram's PLAIN (uncompensated)
+#     Add/Sub — a different reference method from the Kahan-compensated
+#     KahanAdd edit 7's `sum()` case exercises — so neither case is
+#     redundant with it.
 #
 # Series schema: the harness seeds a fixture that mirrors PromLabs's demo
 # service labels (`instance` / `job` / `type` / `mode` / `method` / `path`

--- a/docs/coverage.md
+++ b/docs/coverage.md
@@ -86,7 +86,7 @@ single canonical probe, so a function that lowers `sort_by_label(v, "l")` and
 rejects `sort_by_label(v)` still counts as one supported symbol.
 
 Shape-level wrong-rejections are measured separately, by the rejection-parity
-catalogue: across all three heads it records **3** open argument-shape
+catalogue: across all three heads it records **4** open argument-shape
 divergences — queries the reference backend answers and cerberus rejects. Each
 is one `class: "divergence"` row in
 [`test/rejection-parity/catalogue/`](../test/rejection-parity/catalogue),

--- a/internal/promql/histogram_native_binop.go
+++ b/internal/promql/histogram_native_binop.go
@@ -1,0 +1,186 @@
+package promql
+
+import (
+	"fmt"
+
+	"github.com/prometheus/prometheus/promql/parser"
+
+	"github.com/tsouza/cerberus/internal/chplan"
+	"github.com/tsouza/cerberus/internal/schema"
+)
+
+// histogram_native_binop.go lowers binary arithmetic between two
+// histogram-VALUED shapes — `<exp-hist shape> (+|-) <exp-hist shape>` —
+// into a histogram-VALUED result (cerberus issue #2263).
+//
+// Reference Prometheus answers `+` between two native-histogram samples
+// with FloatHistogram.Add: bucket-wise addition after reconciling the
+// two operands' scales to the coarser of the two
+// (promql/engine.go's vectorElemBinop, the `hlhs != nil && hrhs != nil`
+// case). `-` is FloatHistogram.Sub, which upstream documents as "works
+// like Add but subtracts the other histogram" — the identical
+// reconciliation, with the second operand's counts negated first.
+//
+// Every other histogram/histogram binary op (`*`, `/`, `^`, `%`,
+// `atan2`, and every comparison except `==`/`!=`) is rejected by
+// reference Prometheus itself (NewIncompatibleTypesInBinOpInfo);
+// cerberus's existing rejection at expHistogramSelectorRouting
+// (lower.go) already answers those the same way reference does, so this
+// file leaves them alone. `==`/`!=` between two histograms ARE answered
+// by reference (a structural-equality filter, not a merge), but need
+// different mechanics than the bucket-merge below and are tracked
+// separately, along with on()/ignoring()/group_left()/group_right()
+// support for `+`/`-` (see this file's rejection error below).
+//
+// The merge itself is NOT new arithmetic: it is the exact scale-fold +
+// offset-align + zero-pad reconciliation [expHistogramMergeAggs] /
+// [expHistogramMergeProjections] already implement for the cross-SERIES
+// sum() merge (histogram_native_sum.go) and the histogram_quantile()
+// cross-series fold (histogram_quantile_native_window.go) — both exist
+// because Prometheus's own aggregation walks a group calling
+// FloatHistogram.Add on each member, definitionally the same operation
+// as this file's two-operand case. Reusing it here means a binary op
+// between two histograms and `sum()` over two histogram samples can
+// never drift apart in their arithmetic.
+//
+// Lowering shape (instant mode):
+//
+//	HistogramProjection [MetricName='', Attributes, now64(9), Value=0, <nine histogram columns>]
+//	  Project [Attributes (rebuilt from the shared match key), merged
+//	           Scale / ZeroCount / ZeroThreshold / {Pos,Neg}{Offset,BucketCounts},
+//	           Count, Sum]
+//	    Aggregate groupBy=[Attributes] having=count()=2
+//	              funcs=<histogramCountSumMergeAggs>
+//	      UnionAll
+//	        <lhs HistogramProjection>
+//	        <rhs HistogramProjection, negated for `-`>
+//
+// The `having count() = 2` clause stands in for VectorJoin's INNER JOIN:
+// default vector matching (no on()/ignoring()/group_left()/group_right())
+// keys on the full Attributes map — the same map each operand's own
+// HistogramProjection is already grouped by — so a matching key with
+// fewer than two contributing rows means the series existed on only one
+// side, which PromQL's default one-to-one V-V matching drops. Two rows
+// sharing a key on the SAME side cannot happen (each operand's own
+// grouping already guarantees one row per Attributes value), so
+// `!= 2` can only mean "unmatched", never "ambiguous" — unlike
+// VectorJoin's on()/ignoring() case, no runtime many-to-many guard is
+// needed here.
+func expHistogramHistogramBinop(expr parser.Expr, s schema.Metrics, ctx lowerCtx) (lhs, rhs parser.Expr, sub bool, vm *parser.VectorMatching, ok bool) {
+	if s.ExpHistogramTable == "" || ctx.metadataFullRange {
+		return nil, nil, false, nil, false
+	}
+	b, isBin := unwrapBinaryExpr(expr)
+	if !isBin || (b.Op != parser.ADD && b.Op != parser.SUB) {
+		return nil, nil, false, nil, false
+	}
+	if !isExpHistogramValuedShape(b.LHS, s, ctx) || !isExpHistogramValuedShape(b.RHS, s, ctx) {
+		return nil, nil, false, nil, false
+	}
+	return b.LHS, b.RHS, b.Op == parser.SUB, b.VectorMatching, true
+}
+
+// lowerExpHistogramHistogramBinop lowers the shape
+// [expHistogramHistogramBinop] recognised. Both operands defer to their
+// own existing histogram-valued lowering unchanged — this function only
+// adds the join + merge on top.
+func lowerExpHistogramHistogramBinop(lhsExpr, rhsExpr parser.Expr, sub bool, vm *parser.VectorMatching, s schema.Metrics, ctx lowerCtx) (chplan.Node, error) {
+	if !isDefaultMatching(vm) {
+		return nil, fmt.Errorf(
+			"promql: on()/ignoring()/group_left()/group_right() matching is not yet supported for binary " +
+				"arithmetic between two exponential histogram selectors; only default (full label set) matching is supported",
+		)
+	}
+	hpL, err := lowerExpHistogramValuedOperand(lhsExpr, s, ctx)
+	if err != nil {
+		return nil, err
+	}
+	hpR, err := lowerExpHistogramValuedOperand(rhsExpr, s, ctx)
+	if err != nil {
+		return nil, err
+	}
+	if sub {
+		// `h1 - h2` is FloatHistogram.Sub, which reference documents as
+		// Add with the second operand's counts negated first — reuse the
+		// existing scalar-scaling machinery (issue #2087) to negate every
+		// count-bearing field (Count, Sum, ZeroCount, both bucket
+		// ladders) while leaving Scale/ZeroThreshold/offsets untouched,
+		// then fold through the same merge as `+`.
+		hpR = scaleHistogramProjection(hpR, chplan.OpMul, &chplan.LitFloat{V: -1}, s)
+	}
+	return mergeTwoHistogramProjections(hpL, hpR, s, ctx), nil
+}
+
+// lowerExpHistogramValuedOperand lowers one binop operand through its own
+// histogram-valued recogniser and asserts the shared HistogramProjection
+// cap every such lowering publishes.
+func lowerExpHistogramValuedOperand(expr parser.Expr, s schema.Metrics, ctx lowerCtx) (*chplan.HistogramProjection, error) {
+	node, matched, err := lowerExpHistogramValuedShape(expr, s, ctx)
+	if err != nil {
+		return nil, err
+	}
+	if !matched {
+		return nil, fmt.Errorf("promql: internal invariant violated: exp-histogram binop operand matched no known histogram-valued shape for %v", expr)
+	}
+	hp, ok := node.(*chplan.HistogramProjection)
+	if !ok {
+		return nil, fmt.Errorf("promql: internal invariant violated: exp-histogram binop operand lowering did not cap with *chplan.HistogramProjection, got %T", node)
+	}
+	return hp, nil
+}
+
+// mergeTwoHistogramProjections adds hpL and hpR's distributions,
+// series-by-series, via the same scale-fold + offset-align + zero-pad
+// reconciliation the cross-series merges apply. See this file's doc for
+// why the join collapses to a `having count() = 2` guard rather than a
+// VectorJoin.
+func mergeTwoHistogramProjections(hpL, hpR *chplan.HistogramProjection, s schema.Metrics, ctx lowerCtx) chplan.Node {
+	histSchema := histogramProjectionSchema(s)
+	groupBy, groupByAliases, attrsRebuild := histogramAggGroupBy(
+		nil, &chplan.ColumnRef{Name: histSchema.AttributesColumn}, histSchema,
+	)
+
+	stepAligned := ctx.step > 0
+	var projs []chplan.Projection
+	if stepAligned {
+		// Range mode: both operands' HistogramProjection already
+		// publishes the per-step grid anchor under the canonical
+		// TimestampColumn (see nativeHistogramProjection), so grouping
+		// by it keeps each anchor's merge independent — the same
+		// prepend [expHistogramGroupMerge] applies for its own anchor
+		// parameter.
+		anchor := &chplan.ColumnRef{Name: histSchema.TimestampColumn}
+		groupBy = append([]chplan.Expr{anchor}, groupBy...)
+		groupByAliases = append([]string{histSchema.TimestampColumn}, groupByAliases...)
+		projs = append(projs, chplan.Projection{Expr: anchor, Alias: histSchema.TimestampColumn})
+	}
+
+	merged := &chplan.Aggregate{
+		Input:              &chplan.UnionAll{Inputs: []chplan.Node{hpL, hpR}},
+		GroupBy:            groupBy,
+		GroupByAliases:     groupByAliases,
+		AggFuncs:           histogramCountSumMergeAggs(histSchema),
+		Having:             histogramBinopBothSidesMatchedGuard(),
+		DropEmptyOnNoGroup: true,
+	}
+	projs = append(projs, chplan.Projection{Expr: attrsRebuild, Alias: histSchema.AttributesColumn})
+	projs = append(projs, histogramCountSumMergeProjections(histSchema)...)
+	reshaped := &chplan.Project{Input: merged, Projections: projs}
+
+	tsExpr := chplan.Expr(chplan.NowNano())
+	if stepAligned {
+		tsExpr = &chplan.ColumnRef{Name: histSchema.TimestampColumn}
+	}
+	return nativeHistogramProjection(reshaped, &chplan.LitString{V: ""}, tsExpr, histSchema)
+}
+
+// histogramBinopBothSidesMatchedGuard renders `count() = 2` — see this
+// file's doc comment for why that alone implements default one-to-one
+// V-V matching's INNER JOIN semantics here.
+func histogramBinopBothSidesMatchedGuard() chplan.Expr {
+	return &chplan.Binary{
+		Op:    chplan.OpEq,
+		Left:  &chplan.FuncCall{Fn: chplan.FnCount},
+		Right: &chplan.LitInt{V: 2},
+	}
+}

--- a/internal/promql/histogram_native_binop.go
+++ b/internal/promql/histogram_native_binop.go
@@ -32,16 +32,44 @@ import (
 // separately, along with on()/ignoring()/group_left()/group_right()
 // support for `+`/`-` (see this file's rejection error below).
 //
-// The merge itself is NOT new arithmetic: it is the exact scale-fold +
-// offset-align + zero-pad reconciliation [expHistogramMergeAggs] /
-// [expHistogramMergeProjections] already implement for the cross-SERIES
+// The bucket RECONCILIATION (which absolute index each operand's own
+// buckets land on at the merged, coarser Scale) is the same integer
+// index-alignment math [expHistogramMergeBucketsBoundsExpr] /
+// [expHistogramMergeOffsetExpr] already implement for the cross-SERIES
 // sum() merge (histogram_native_sum.go) and the histogram_quantile()
-// cross-series fold (histogram_quantile_native_window.go) — both exist
-// because Prometheus's own aggregation walks a group calling
-// FloatHistogram.Add on each member, definitionally the same operation
-// as this file's two-operand case. Reusing it here means a binary op
-// between two histograms and `sum()` over two histogram samples can
-// never drift apart in their arithmetic.
+// cross-series fold (histogram_quantile_native_window.go), reused here
+// unchanged — it is purely structural (bitShiftRight / arrayMin /
+// arrayMax over Scale and Offset), independent of how the VALUES at
+// each resolved index get folded, so sharing it cannot let a binary op
+// between two histograms and `sum()` drift apart on WHERE a bucket ends
+// up.
+//
+// The VALUE fold is deliberately NOT shared with that merge. sum() /
+// avg() / histogram_quantile() answer a cross-SERIES GROUP, and
+// reference Prometheus's own aggregation evaluator folds that group
+// with FloatHistogram.KahanAdd — a Neumaier-compensated recurrence
+// (promql/engine.go's `sum`/`avg` aggregation path calls
+// `group.histogramValue.KahanAdd(h, group.histogramKahanC)`) — which is why
+// [expHistogramMergeBucketsExpr] / [promHistogramKahanSum] exist and why
+// [histogram_quantile.go]'s own within-row downscale fold routes through
+// that same compensated recurrence: upstream's KahanAdd downscales via
+// `kahanReduceResolution`, itself compensated.
+//
+// The V-V binary operator this file answers is a DIFFERENT reference
+// method: `vectorElemBinop`'s `hlhs != nil && hrhs != nil` case calls
+// the PLAIN `hlhs.Copy().Add(hrhs)` / `.Sub(hrhs)` — model/histogram/
+// float_histogram.go's `Add`/`Sub` do `h.Sum += other.Sum`,
+// `targetBuckets[i] += originBuckets[...]` with NO compensation
+// anywhere, including their OWN within-row downscale fold
+// (`mustReduceResolution` → `reduceResolution`, a plain `+=` loop —
+// contrast `KahanAdd`'s `kahanReduceResolution`). Reusing the Kahan
+// merge here would silently diverge from reference at the ULP level
+// for any two-histogram `+`/`-` whose Count/Sum/bucket values do not
+// happen to add up exactly in float64 (which plain integer/round test
+// fixtures cannot surface, since Kahan compensation is a no-op exactly
+// when there is no rounding error to correct). The two-operand fold
+// below ([histogramBinopMergeProjections]) is therefore a SEPARATE,
+// plain implementation — see its doc for the specific functions.
 //
 // Lowering shape (instant mode):
 //
@@ -50,7 +78,7 @@ import (
 //	           Scale / ZeroCount / ZeroThreshold / {Pos,Neg}{Offset,BucketCounts},
 //	           Count, Sum]
 //	    Aggregate groupBy=[Attributes] having=count()=2
-//	              funcs=<histogramCountSumMergeAggs>
+//	              funcs=<histogramBinopMergeAggs>
 //	      UnionAll
 //	        <lhs HistogramProjection>
 //	        <rhs HistogramProjection, negated for `-`>
@@ -159,12 +187,12 @@ func mergeTwoHistogramProjections(hpL, hpR *chplan.HistogramProjection, s schema
 		Input:              &chplan.UnionAll{Inputs: []chplan.Node{hpL, hpR}},
 		GroupBy:            groupBy,
 		GroupByAliases:     groupByAliases,
-		AggFuncs:           histogramCountSumMergeAggs(histSchema),
+		AggFuncs:           histogramBinopMergeAggs(histSchema),
 		Having:             histogramBinopBothSidesMatchedGuard(),
 		DropEmptyOnNoGroup: true,
 	}
 	projs = append(projs, chplan.Projection{Expr: attrsRebuild, Alias: histSchema.AttributesColumn})
-	projs = append(projs, histogramCountSumMergeProjections(histSchema)...)
+	projs = append(projs, histogramBinopMergeProjections(histSchema)...)
 	reshaped := &chplan.Project{Input: merged, Projections: projs}
 
 	tsExpr := chplan.Expr(chplan.NowNano())
@@ -183,4 +211,173 @@ func histogramBinopBothSidesMatchedGuard() chplan.Expr {
 		Left:  &chplan.FuncCall{Fn: chplan.FnCount},
 		Right: &chplan.LitInt{V: 2},
 	}
+}
+
+// histogramBinopMergeAggs collects the group's Count / Sum arrays plus
+// the same Scale (min) / ZeroCount / ZeroThreshold (max) / signed-bucket
+// (Offset + BucketCounts, both keyed by Scale) groupArrays
+// [expHistogramMergeAggs] collects for the cross-series merge — the
+// COLLECTION shape is identical (groupArray has no notion of
+// compensation; only the FOLD below does), and [histogramBinopMergeAggs]
+// / [histogramBinopMergeProjections]'s Having guard guarantees each
+// array holds exactly the two matched operands' own values.
+func histogramBinopMergeAggs(s schema.Metrics) []chplan.AggFunc {
+	return append([]chplan.AggFunc{
+		{Fn: chplan.FnGroupArray, Args: []chplan.Expr{&chplan.ColumnRef{Name: s.CountColumn}}, Alias: hqMergeCountsArrayAlias},
+		{Fn: chplan.FnGroupArray, Args: []chplan.Expr{&chplan.ColumnRef{Name: s.SumColumn}}, Alias: hqMergeSumsArrayAlias},
+	}, expHistogramMergeAggs(s)...)
+}
+
+// histogramBinopMergeProjections folds the two-element groupArrays
+// [histogramBinopMergeAggs] collected into the merged histogram row,
+// using PLAIN (uncompensated) arithmetic throughout — matching
+// reference Prometheus's `Add` / `Sub` (see this file's header doc for
+// why the Kahan-compensated [expHistogramMergeProjections] the
+// cross-series merge uses is the WRONG fold here). Scale / ZeroThreshold
+// / both Offsets are structural (bitShiftRight / min / max index
+// arithmetic, no float-summation policy involved) and are reused from
+// [expHistogramMergeOffsetExpr] unchanged; only the fields that fold
+// floats — Count, Sum, ZeroCount and both bucket ladders — get the
+// plain implementation.
+func histogramBinopMergeProjections(s schema.Metrics) []chplan.Projection {
+	projs := []chplan.Projection{
+		{Expr: plainArraySum(&chplan.ColumnRef{Name: hqMergeCountsArrayAlias}), Alias: s.CountColumn},
+		{Expr: plainArraySum(&chplan.ColumnRef{Name: hqMergeSumsArrayAlias}), Alias: s.SumColumn},
+		{Expr: &chplan.ColumnRef{Name: hqAggMergedScaleAlias}, Alias: s.ScaleColumn},
+		{Expr: plainArraySum(&chplan.ColumnRef{Name: hqMergeZeroCountsArrayAlias}), Alias: s.ZeroCountColumn},
+	}
+	if s.ZeroThresholdColumn != "" {
+		projs = append(projs, chplan.Projection{
+			Expr:  &chplan.ColumnRef{Name: s.ZeroThresholdColumn},
+			Alias: s.ZeroThresholdColumn,
+		})
+	}
+	return append(projs, []chplan.Projection{
+		{Expr: expHistogramMergeOffsetExpr(hqAggPosOffsetsArrayAlias, hqAggScalesArrayAlias, hqAggMergedScaleAlias), Alias: s.PositiveOffsetColumn},
+		{Expr: histogramBinopMergedBucketsExpr(hqAggPosOffsetsArrayAlias, hqAggPosBucketsArrayAlias, hqAggScalesArrayAlias, hqAggMergedScaleAlias), Alias: s.PositiveBucketCountsColumn},
+		{Expr: expHistogramMergeOffsetExpr(hqAggNegOffsetsArrayAlias, hqAggScalesArrayAlias, hqAggMergedScaleAlias), Alias: s.NegativeOffsetColumn},
+		{Expr: histogramBinopMergedBucketsExpr(hqAggNegOffsetsArrayAlias, hqAggNegBucketsArrayAlias, hqAggScalesArrayAlias, hqAggMergedScaleAlias), Alias: s.NegativeBucketCountsColumn},
+	}...)
+}
+
+// plainArraySum renders CH's `arraySum(<values>)` — a single plain
+// accumulation with no Kahan/Neumaier compensation. Over the exactly
+// two-element arrays [histogramBinopMergeAggs] collects (guaranteed by
+// [histogramBinopBothSidesMatchedGuard]'s `count() = 2` Having), this
+// computes exactly one floating-point addition — bit-identical to
+// reference's plain `h.Sum += other.Sum` — regardless of which order
+// groupArray happened to collect the two rows in, since IEEE754
+// addition of exactly two operands is commutative (unlike Kahan-
+// Neumaier compensated summation, which is NOT bit-identical to a plain
+// add even for two terms — see this file's header doc).
+func plainArraySum(values chplan.Expr) chplan.Expr {
+	return &chplan.FuncCall{Fn: chplan.FnArraySum, Args: []chplan.Expr{values}}
+}
+
+// histogramBinopMergedBucketsExpr renders the merged PositiveBucketCounts
+// (or NegativeBucketCounts) for the binop's two-element groupArrays,
+// mirroring [expHistogramMergeBucketsExpr]'s structure (same bounds via
+// [expHistogramMergeBucketsBoundsExpr], same per-row index-matching
+// picker via [expHistogramRowContribsExpr]) but folding with
+// [plainArraySum] via [histogramBinopBucketRowContribExpr] instead of
+// the Kahan-compensated arrayReduce('sumKahan', ...) — see this file's
+// header doc for why. There is no series-order sort here (contrast
+// [expHistogramMergeBucketsExpr]'s [expHistogramSortRowsByKeyExpr] calls,
+// needed only because Kahan-Neumaier summation is order-sensitive even
+// once the same set of terms is fixed): a plain add of exactly two
+// terms is order-invariant, so which of the two groupArray positions is
+// the caller's LHS or RHS never affects the result.
+func histogramBinopMergedBucketsExpr(offArrAlias, bucArrAlias, scalesArrAlias, mergedScaleAlias string) chplan.Expr {
+	mergedScale := &chplan.ColumnRef{Name: mergedScaleAlias}
+	scalesArr := &chplan.ColumnRef{Name: scalesArrAlias}
+	offArr := &chplan.ColumnRef{Name: offArrAlias}
+	bucArr := &chplan.ColumnRef{Name: bucArrAlias}
+
+	mergedStart, mergedLength := expHistogramMergeBucketsBoundsExpr(scalesArr, offArr, bucArr, mergedScale)
+
+	const paramT = "t"
+	rowContribs := expHistogramRowContribsExpr(
+		scalesArr, offArr, bucArr,
+		histogramBinopBucketRowContribExpr(mergedScale, mergedStart, paramT),
+	)
+	rowsSum := plainArraySum(rowContribs)
+
+	return &chplan.FuncCall{
+		Fn: chplan.FnArrayMap,
+		Args: []chplan.Expr{
+			&chplan.Lambda{Params: []string{paramT}, Body: rowsSum},
+			&chplan.FuncCall{
+				Fn: chplan.FnRange,
+				Args: []chplan.Expr{
+					&chplan.FuncCall{Fn: chplan.FnToUInt64, Args: []chplan.Expr{mergedLength}},
+				},
+			},
+		},
+	}
+}
+
+// histogramBinopBucketRowContribExpr is [expHistogramBucketRowContribExpr]
+// with its within-row downscale fold changed from the Kahan-compensated
+// [promHistogramKahanSum] to [plainArraySum] — matching reference's own
+// split between `KahanAdd`'s compensated `kahanReduceResolution` and
+// `Add`/`Sub`'s plain `reduceResolution` (see this file's header doc).
+// The index-matching picker (which stored position lands on target
+// bucket `mergedStart+t`) is otherwise byte-for-byte the same
+// expression, bound by the same lambda parameter names
+// ([expHistogramRowContribsExpr]'s outer arrayMap binds
+// paramExpRowScale / paramExpRowOffset / paramExpRowBuckets) so this
+// drops into that shared wrapper unchanged.
+func histogramBinopBucketRowContribExpr(mergedScale, mergedStart chplan.Expr, paramT string) chplan.Expr {
+	return plainArraySum(
+		&chplan.FuncCall{
+			Fn: chplan.FnArrayMap,
+			Args: []chplan.Expr{
+				&chplan.Lambda{
+					Params: []string{paramExpBucketPos},
+					Body: &chplan.FuncCall{
+						Fn: chplan.FnIf,
+						Args: []chplan.Expr{
+							&chplan.Binary{
+								Op: chplan.OpEq,
+								Left: &chplan.FuncCall{
+									Fn: chplan.FnBitShiftRight,
+									Args: []chplan.Expr{
+										&chplan.Binary{
+											Op:   chplan.OpAdd,
+											Left: &chplan.BareIdent{Name: paramExpRowOffset},
+											Right: &chplan.Binary{
+												Op:    chplan.OpSub,
+												Left:  &chplan.BareIdent{Name: paramExpBucketPos},
+												Right: &chplan.LitInt{V: 1},
+											},
+										},
+										&chplan.Binary{
+											Op:    chplan.OpSub,
+											Left:  &chplan.BareIdent{Name: paramExpRowScale},
+											Right: mergedScale,
+										},
+									},
+								},
+								// target absolute index = mergedStart + t (t is 0-based).
+								Right: &chplan.Binary{
+									Op:    chplan.OpAdd,
+									Left:  mergedStart,
+									Right: &chplan.BareIdent{Name: paramT},
+								},
+							},
+							&chplan.Subscript{
+								Container: &chplan.BareIdent{Name: paramExpRowBuckets},
+								Key:       &chplan.BareIdent{Name: paramExpBucketPos},
+							},
+							&chplan.LitInt{V: 0},
+						},
+					},
+				},
+				&chplan.FuncCall{
+					Fn:   chplan.FnArrayEnumerate,
+					Args: []chplan.Expr{&chplan.BareIdent{Name: paramExpRowBuckets}},
+				},
+			},
+		},
+	)
 }

--- a/internal/promql/histogram_native_binop.go
+++ b/internal/promql/histogram_native_binop.go
@@ -321,63 +321,9 @@ func histogramBinopMergedBucketsExpr(offArrAlias, bucArrAlias, scalesArrAlias, m
 // [promHistogramKahanSum] to [plainArraySum] — matching reference's own
 // split between `KahanAdd`'s compensated `kahanReduceResolution` and
 // `Add`/`Sub`'s plain `reduceResolution` (see this file's header doc).
-// The index-matching picker (which stored position lands on target
-// bucket `mergedStart+t`) is otherwise byte-for-byte the same
-// expression, bound by the same lambda parameter names
-// ([expHistogramRowContribsExpr]'s outer arrayMap binds
-// paramExpRowScale / paramExpRowOffset / paramExpRowBuckets) so this
-// drops into that shared wrapper unchanged.
+// The index-matching picker itself is shared verbatim via
+// [expHistogramBucketPositionPickerExpr] — only the fold wrapping it
+// differs between the two callers.
 func histogramBinopBucketRowContribExpr(mergedScale, mergedStart chplan.Expr, paramT string) chplan.Expr {
-	return plainArraySum(
-		&chplan.FuncCall{
-			Fn: chplan.FnArrayMap,
-			Args: []chplan.Expr{
-				&chplan.Lambda{
-					Params: []string{paramExpBucketPos},
-					Body: &chplan.FuncCall{
-						Fn: chplan.FnIf,
-						Args: []chplan.Expr{
-							&chplan.Binary{
-								Op: chplan.OpEq,
-								Left: &chplan.FuncCall{
-									Fn: chplan.FnBitShiftRight,
-									Args: []chplan.Expr{
-										&chplan.Binary{
-											Op:   chplan.OpAdd,
-											Left: &chplan.BareIdent{Name: paramExpRowOffset},
-											Right: &chplan.Binary{
-												Op:    chplan.OpSub,
-												Left:  &chplan.BareIdent{Name: paramExpBucketPos},
-												Right: &chplan.LitInt{V: 1},
-											},
-										},
-										&chplan.Binary{
-											Op:    chplan.OpSub,
-											Left:  &chplan.BareIdent{Name: paramExpRowScale},
-											Right: mergedScale,
-										},
-									},
-								},
-								// target absolute index = mergedStart + t (t is 0-based).
-								Right: &chplan.Binary{
-									Op:    chplan.OpAdd,
-									Left:  mergedStart,
-									Right: &chplan.BareIdent{Name: paramT},
-								},
-							},
-							&chplan.Subscript{
-								Container: &chplan.BareIdent{Name: paramExpRowBuckets},
-								Key:       &chplan.BareIdent{Name: paramExpBucketPos},
-							},
-							&chplan.LitInt{V: 0},
-						},
-					},
-				},
-				&chplan.FuncCall{
-					Fn:   chplan.FnArrayEnumerate,
-					Args: []chplan.Expr{&chplan.BareIdent{Name: paramExpRowBuckets}},
-				},
-			},
-		},
-	)
+	return plainArraySum(expHistogramBucketPositionPickerExpr(mergedScale, mergedStart, paramT))
 }

--- a/internal/promql/histogram_native_binop_test.go
+++ b/internal/promql/histogram_native_binop_test.go
@@ -1,0 +1,197 @@
+package promql_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/prometheus/prometheus/promql/parser"
+
+	"github.com/tsouza/cerberus/internal/chplan"
+	"github.com/tsouza/cerberus/internal/promql"
+	"github.com/tsouza/cerberus/internal/schema"
+)
+
+// TestLower_ExpHistogram_HistogramBinopIsHistogramValued pins cerberus
+// issue #2263: `<exp-hist shape> (+|-) <exp-hist shape>` is answerable
+// for the bare-selector, sum()/avg(), and rate()/increase() histogram-
+// valued shapes on either side, and composes with the scalar-scaling
+// shape (#2087) and a further sum() — the answer is always a
+// chplan.HistogramProjection publishing the same thirteen-column
+// contract every other histogram-valued shape does.
+func TestLower_ExpHistogram_HistogramBinopIsHistogramValued(t *testing.T) {
+	t.Parallel()
+
+	s := schema.DefaultOTelMetrics()
+	p := parser.NewParser(parser.Options{EnableExperimentalFunctions: true})
+	start := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	end := start.Add(time.Hour)
+
+	cases := []struct {
+		name  string
+		query string
+		lower func(parser.Expr) (chplan.Node, error)
+	}{
+		{name: "two bare selectors, same metric", query: `latency_exp_hist + latency_exp_hist`},
+		{name: "two bare selectors, different metrics", query: `latency_exp_hist + other_exp_hist`},
+		{name: "subtraction", query: `latency_exp_hist - other_exp_hist`},
+		{name: "sum() plus bare selector", query: `sum(latency_exp_hist) + other_exp_hist`},
+		{name: "rate() plus rate()", query: `rate(latency_exp_hist[5m]) + rate(other_exp_hist[5m])`},
+		{name: "parenthesised", query: `(latency_exp_hist + other_exp_hist)`},
+		{name: "composes with scalar scaling", query: `(latency_exp_hist + other_exp_hist) * 2`},
+		{name: "composes with sum()", query: `sum(latency_exp_hist + other_exp_hist)`},
+		{
+			name:  "range query",
+			query: `latency_exp_hist + other_exp_hist`,
+			lower: func(e parser.Expr) (chplan.Node, error) {
+				return promql.LowerAtRange(context.Background(), e, s, start, end, 30*time.Second)
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			expr, err := p.ParseExpr(tc.query)
+			if err != nil {
+				t.Fatalf("ParseExpr(%q): %v", tc.query, err)
+			}
+			lower := tc.lower
+			if lower == nil {
+				lower = func(e parser.Expr) (chplan.Node, error) {
+					return promql.LowerAt(context.Background(), e, s, end, end)
+				}
+			}
+			plan, err := lower(expr)
+			if err != nil {
+				t.Fatalf("lower(%q): unexpected error: %v", tc.query, err)
+			}
+			if shape := chplan.RowShapeOf(plan); shape != chplan.HistogramRowShape {
+				t.Fatalf("lower(%q): plan root publishes %s, want histogram", tc.query, shape)
+			}
+			hp, ok := plan.(*chplan.HistogramProjection)
+			if !ok {
+				t.Fatalf("lower(%q): plan root is %T, want *chplan.HistogramProjection", tc.query, plan)
+			}
+			name, ok := hp.GroupBy[0].(*chplan.LitString)
+			if !ok || name.V != "" {
+				t.Fatalf("lower(%q): metric-name projection is %#v, want empty literal", tc.query, hp.GroupBy[0])
+			}
+		})
+	}
+}
+
+// TestLower_ExpHistogram_HistogramBinopRejectsNonDefaultMatching pins
+// that on()/ignoring()/group_left()/group_right() are explicitly
+// rejected for now (tracked as a follow-up, see this file's sibling
+// histogram_native_binop.go) rather than silently mismatching series.
+func TestLower_ExpHistogram_HistogramBinopRejectsNonDefaultMatching(t *testing.T) {
+	t.Parallel()
+
+	s := schema.DefaultOTelMetrics()
+	p := parser.NewParser(parser.Options{EnableExperimentalFunctions: true})
+	at := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+
+	queries := []string{
+		`latency_exp_hist + on(service) other_exp_hist`,
+		`latency_exp_hist + ignoring(service) other_exp_hist`,
+		`latency_exp_hist + on(service) group_left() other_exp_hist`,
+		`latency_exp_hist + on(service) group_right() other_exp_hist`,
+	}
+
+	for _, query := range queries {
+		t.Run(query, func(t *testing.T) {
+			t.Parallel()
+			expr, err := p.ParseExpr(query)
+			if err != nil {
+				t.Fatalf("ParseExpr(%q): %v", query, err)
+			}
+			_, err = promql.LowerAt(context.Background(), expr, s, at, at)
+			if err == nil {
+				t.Fatalf("lower(%q): expected an error, got none", query)
+			}
+		})
+	}
+}
+
+// TestLower_ExpHistogram_HistogramBinopMergesViaUnionAllAndCountGuard
+// pins the plan SHAPE the merge builds: a chplan.UnionAll of the two
+// operands feeding a chplan.Aggregate grouped by Attributes with a
+// `count() = 2` Having guard — the stand-in for VectorJoin's INNER JOIN
+// default one-to-one matching (see histogram_native_binop.go's doc for
+// why that guard alone is sufficient here). Subtraction additionally
+// wraps the RHS arm in the existing scalar-scaling machinery (issue
+// #2087) with op=Mul, scale=-1, negating every count-bearing field
+// before it enters the same merge as `+`.
+func TestLower_ExpHistogram_HistogramBinopMergesViaUnionAllAndCountGuard(t *testing.T) {
+	t.Parallel()
+
+	s := schema.DefaultOTelMetrics()
+	p := parser.NewParser(parser.Options{EnableExperimentalFunctions: true})
+	at := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+
+	cases := []struct {
+		name       string
+		query      string
+		rhsNegated bool
+	}{
+		{name: "addition", query: `latency_exp_hist + other_exp_hist`, rhsNegated: false},
+		{name: "subtraction", query: `latency_exp_hist - other_exp_hist`, rhsNegated: true},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			expr, err := p.ParseExpr(tc.query)
+			if err != nil {
+				t.Fatalf("ParseExpr(%q): %v", tc.query, err)
+			}
+			plan, err := promql.LowerAt(context.Background(), expr, s, at, at)
+			if err != nil {
+				t.Fatalf("LowerAt(%q): %v", tc.query, err)
+			}
+			hp, ok := plan.(*chplan.HistogramProjection)
+			if !ok {
+				t.Fatalf("lower(%q): plan root is %T, want *chplan.HistogramProjection", tc.query, plan)
+			}
+			reshape, ok := hp.Input.(*chplan.Project)
+			if !ok {
+				t.Fatalf("lower(%q): HistogramProjection.Input is %T, want *chplan.Project", tc.query, hp.Input)
+			}
+			agg, ok := reshape.Input.(*chplan.Aggregate)
+			if !ok {
+				t.Fatalf("lower(%q): reshape.Input is %T, want *chplan.Aggregate", tc.query, reshape.Input)
+			}
+			if agg.Having == nil {
+				t.Fatalf("lower(%q): Aggregate.Having is nil, want the both-sides-matched count() = 2 guard", tc.query)
+			}
+			having, ok := agg.Having.(*chplan.Binary)
+			if !ok || having.Op != chplan.OpEq {
+				t.Fatalf("lower(%q): Aggregate.Having = %#v, want an Eq Binary", tc.query, agg.Having)
+			}
+			if _, ok := having.Left.(*chplan.FuncCall); !ok {
+				t.Fatalf("lower(%q): Aggregate.Having.Left = %#v, want a count() FuncCall", tc.query, having.Left)
+			}
+			lit, ok := having.Right.(*chplan.LitInt)
+			if !ok || lit.V != 2 {
+				t.Fatalf("lower(%q): Aggregate.Having.Right = %#v, want LitInt(2)", tc.query, having.Right)
+			}
+
+			union, ok := agg.Input.(*chplan.UnionAll)
+			if !ok || len(union.Inputs) != 2 {
+				t.Fatalf("lower(%q): Aggregate.Input = %#v, want a two-arm UnionAll", tc.query, agg.Input)
+			}
+			if _, ok := union.Inputs[0].(*chplan.HistogramProjection); !ok {
+				t.Fatalf("lower(%q): UnionAll.Inputs[0] is %T, want *chplan.HistogramProjection", tc.query, union.Inputs[0])
+			}
+			rhsArm, ok := union.Inputs[1].(*chplan.HistogramProjection)
+			if !ok {
+				t.Fatalf("lower(%q): UnionAll.Inputs[1] is %T, want *chplan.HistogramProjection", tc.query, union.Inputs[1])
+			}
+			_, rhsWrapped := rhsArm.Input.(*chplan.Project)
+			if rhsWrapped != tc.rhsNegated {
+				t.Fatalf("lower(%q): RHS arm wrapped in a negating Project = %v, want %v", tc.query, rhsWrapped, tc.rhsNegated)
+			}
+		})
+	}
+}

--- a/internal/promql/histogram_native_float_fn.go
+++ b/internal/promql/histogram_native_float_fn.go
@@ -46,6 +46,10 @@ func lowerExpHistogramValuedShape(expr parser.Expr, s schema.Metrics, ctx lowerC
 		plan, err := lowerExpHistogramScalarBinop(histSide, op, scale, s, ctx, false)
 		return plan, true, err
 	}
+	if lhs, rhs, sub, vm, ok := expHistogramHistogramBinop(expr, s, ctx); ok {
+		plan, err := lowerExpHistogramHistogramBinop(lhs, rhs, sub, vm, s, ctx)
+		return plan, true, err
+	}
 	return nil, false, nil
 }
 

--- a/internal/promql/histogram_native_scalar_binop.go
+++ b/internal/promql/histogram_native_scalar_binop.go
@@ -183,6 +183,15 @@ func isExpHistogramValuedShape(expr parser.Expr, s schema.Metrics, ctx lowerCtx)
 			return scalar
 		}
 	}
+	// `<exp-hist shape> (+|-) <exp-hist shape>` with default matching
+	// (cerberus issue #2263) — see histogram_native_binop.go. Gated on
+	// default matching so this predicate only reports true for a shape
+	// [lowerExpHistogramHistogramBinop] actually lowers successfully;
+	// on()/ignoring()/group_left()/group_right() stay unrecognised here
+	// and fall through to that lowering's own explicit rejection.
+	if _, _, _, vm, ok := expHistogramHistogramBinop(expr, s, ctx); ok && isDefaultMatching(vm) {
+		return true
+	}
 	return false
 }
 

--- a/internal/promql/histogram_native_sum.go
+++ b/internal/promql/histogram_native_sum.go
@@ -321,68 +321,38 @@ func histogramProjectionSchema(s schema.Metrics) schema.Metrics {
 	return s
 }
 
-// expHistogramGroupMergeAggs is [histogramCountSumMergeAggs] — the
-// shared scale-fold + offset-align + zero-pad collection plus the Count
-// / Sum arrays, the arithmetic of FloatHistogram.Add — widened by
-// `avg()`'s own group's member count, the divisor it scales the merged
-// distribution by (see [expHistogramGroupSeriesCountAgg]). `sum()` does
-// NOT collect it: it has no use for the column, and adding one to a
-// shipped lowering's emitted SQL would cost a counter per group and
-// churn its goldens for nothing.
+// expHistogramGroupMergeAggs is [expHistogramMergeAggs] — the shared
+// scale-fold + offset-align + zero-pad collection, the arithmetic of
+// FloatHistogram.Add — widened by the two whole-histogram scalars a
+// histogram-VALUED answer must also publish.
+//
+// Count and Sum are collected into arrays and folded with the same
+// compensated recurrence as the buckets: they are the group's total
+// observation count and total observed value, and neither depends on bucket
+// alignment, but Prometheus's FloatHistogram.KahanAdd makes their rounding
+// behavior part of parity.
+// `avg()` additionally collects the group's member count, the divisor it
+// scales the merged distribution by (see
+// [expHistogramGroupSeriesCountAgg]). `sum()` does NOT collect it: it
+// has no use for the column, and adding one to a shipped lowering's
+// emitted SQL would cost a counter per group and churn its goldens for
+// nothing.
 func expHistogramGroupMergeAggs(agg *parser.AggregateExpr, s schema.Metrics) []chplan.AggFunc {
-	aggs := histogramCountSumArraysAggs(s)
+	aggs := []chplan.AggFunc{
+		{Fn: chplan.FnGroupArray, Args: []chplan.Expr{&chplan.ColumnRef{Name: s.CountColumn}}, Alias: hqMergeCountsArrayAlias},
+		{Fn: chplan.FnGroupArray, Args: []chplan.Expr{&chplan.ColumnRef{Name: s.SumColumn}}, Alias: hqMergeSumsArrayAlias},
+	}
 	if expHistogramGroupIsAvg(agg) {
-		// Inserted BEFORE the merge aggs, not appended after, to keep the
-		// avg()-shipped fixtures' emitted SQL column order byte-stable —
-		// avg's group-size counter has always sat right after Count/Sum.
 		aggs = append(aggs, expHistogramGroupSeriesCountAgg())
 	}
 	return append(aggs, expHistogramMergeAggs(s)...)
 }
 
-// expHistogramGroupMergeProjections is [histogramCountSumMergeProjections]
-// unchanged — kept as its own name for the sum()/avg() call sites, which
-// widen it further with avg's division (see
-// [expHistogramAvgScaleProjections]).
+// expHistogramGroupMergeProjections is [expHistogramMergeProjections] plus
+// the Count / Sum pass-through, so the reshaped row carries all nine
+// fields [chplan.HistogramProjection] reads by name rather than the
+// seven the quantile kernel needs.
 func expHistogramGroupMergeProjections(s schema.Metrics) []chplan.Projection {
-	return histogramCountSumMergeProjections(s)
-}
-
-// histogramCountSumMergeAggs collects the group's Count and Sum arrays
-// alongside [expHistogramMergeAggs]' scale-fold + offset-align + zero-pad
-// bucket collection, so the projections below can fold all nine
-// histogram fields from one Aggregate. Count and Sum are collected into
-// arrays and folded with the same compensated recurrence as the
-// buckets: they are the group's total observation count and total
-// observed value, and neither depends on bucket alignment, but
-// Prometheus's FloatHistogram.KahanAdd makes their rounding behavior
-// part of parity.
-//
-// Shared by the cross-series sum()/avg() merge above and the two-operand
-// binary-op merge (histogram_native_binop.go, cerberus issue #2263) —
-// both are the same FloatHistogram.Add reconciliation over a group of
-// histogram rows, differing only in how the group's members were
-// gathered (cross-series vs. a two-arm UnionAll).
-func histogramCountSumMergeAggs(s schema.Metrics) []chplan.AggFunc {
-	return append(histogramCountSumArraysAggs(s), expHistogramMergeAggs(s)...)
-}
-
-// histogramCountSumArraysAggs is just the Count / Sum groupArray pair —
-// split out of [histogramCountSumMergeAggs] so [expHistogramGroupMergeAggs]
-// can splice avg()'s series-count agg between it and the merge aggs,
-// preserving the emitted SQL column order avg()'s shipped fixtures pin.
-func histogramCountSumArraysAggs(s schema.Metrics) []chplan.AggFunc {
-	return []chplan.AggFunc{
-		{Fn: chplan.FnGroupArray, Args: []chplan.Expr{&chplan.ColumnRef{Name: s.CountColumn}}, Alias: hqMergeCountsArrayAlias},
-		{Fn: chplan.FnGroupArray, Args: []chplan.Expr{&chplan.ColumnRef{Name: s.SumColumn}}, Alias: hqMergeSumsArrayAlias},
-	}
-}
-
-// histogramCountSumMergeProjections is [expHistogramMergeProjections]
-// plus the Count / Sum fold [histogramCountSumMergeAggs] collected, so
-// the reshaped row carries all nine fields [chplan.HistogramProjection]
-// reads by name rather than the seven the quantile kernel needs.
-func histogramCountSumMergeProjections(s schema.Metrics) []chplan.Projection {
 	return append(
 		[]chplan.Projection{
 			{Expr: promHistogramKahanSum(&chplan.ColumnRef{Name: hqMergeCountsArrayAlias}), Alias: s.CountColumn},

--- a/internal/promql/histogram_native_sum.go
+++ b/internal/promql/histogram_native_sum.go
@@ -321,38 +321,68 @@ func histogramProjectionSchema(s schema.Metrics) schema.Metrics {
 	return s
 }
 
-// expHistogramGroupMergeAggs is [expHistogramMergeAggs] — the shared
-// scale-fold + offset-align + zero-pad collection, the arithmetic of
-// FloatHistogram.Add — widened by the two whole-histogram scalars a
-// histogram-VALUED answer must also publish.
-//
-// Count and Sum are collected into arrays and folded with the same
-// compensated recurrence as the buckets: they are the group's total
-// observation count and total observed value, and neither depends on bucket
-// alignment, but Prometheus's FloatHistogram.KahanAdd makes their rounding
-// behavior part of parity.
-// `avg()` additionally collects the group's member count, the divisor it
-// scales the merged distribution by (see
-// [expHistogramGroupSeriesCountAgg]). `sum()` does NOT collect it: it
-// has no use for the column, and adding one to a shipped lowering's
-// emitted SQL would cost a counter per group and churn its goldens for
-// nothing.
+// expHistogramGroupMergeAggs is [histogramCountSumMergeAggs] — the
+// shared scale-fold + offset-align + zero-pad collection plus the Count
+// / Sum arrays, the arithmetic of FloatHistogram.Add — widened by
+// `avg()`'s own group's member count, the divisor it scales the merged
+// distribution by (see [expHistogramGroupSeriesCountAgg]). `sum()` does
+// NOT collect it: it has no use for the column, and adding one to a
+// shipped lowering's emitted SQL would cost a counter per group and
+// churn its goldens for nothing.
 func expHistogramGroupMergeAggs(agg *parser.AggregateExpr, s schema.Metrics) []chplan.AggFunc {
-	aggs := []chplan.AggFunc{
-		{Fn: chplan.FnGroupArray, Args: []chplan.Expr{&chplan.ColumnRef{Name: s.CountColumn}}, Alias: hqMergeCountsArrayAlias},
-		{Fn: chplan.FnGroupArray, Args: []chplan.Expr{&chplan.ColumnRef{Name: s.SumColumn}}, Alias: hqMergeSumsArrayAlias},
-	}
+	aggs := histogramCountSumArraysAggs(s)
 	if expHistogramGroupIsAvg(agg) {
+		// Inserted BEFORE the merge aggs, not appended after, to keep the
+		// avg()-shipped fixtures' emitted SQL column order byte-stable —
+		// avg's group-size counter has always sat right after Count/Sum.
 		aggs = append(aggs, expHistogramGroupSeriesCountAgg())
 	}
 	return append(aggs, expHistogramMergeAggs(s)...)
 }
 
-// expHistogramGroupMergeProjections is [expHistogramMergeProjections] plus
-// the Count / Sum pass-through, so the reshaped row carries all nine
-// fields [chplan.HistogramProjection] reads by name rather than the
-// seven the quantile kernel needs.
+// expHistogramGroupMergeProjections is [histogramCountSumMergeProjections]
+// unchanged — kept as its own name for the sum()/avg() call sites, which
+// widen it further with avg's division (see
+// [expHistogramAvgScaleProjections]).
 func expHistogramGroupMergeProjections(s schema.Metrics) []chplan.Projection {
+	return histogramCountSumMergeProjections(s)
+}
+
+// histogramCountSumMergeAggs collects the group's Count and Sum arrays
+// alongside [expHistogramMergeAggs]' scale-fold + offset-align + zero-pad
+// bucket collection, so the projections below can fold all nine
+// histogram fields from one Aggregate. Count and Sum are collected into
+// arrays and folded with the same compensated recurrence as the
+// buckets: they are the group's total observation count and total
+// observed value, and neither depends on bucket alignment, but
+// Prometheus's FloatHistogram.KahanAdd makes their rounding behavior
+// part of parity.
+//
+// Shared by the cross-series sum()/avg() merge above and the two-operand
+// binary-op merge (histogram_native_binop.go, cerberus issue #2263) —
+// both are the same FloatHistogram.Add reconciliation over a group of
+// histogram rows, differing only in how the group's members were
+// gathered (cross-series vs. a two-arm UnionAll).
+func histogramCountSumMergeAggs(s schema.Metrics) []chplan.AggFunc {
+	return append(histogramCountSumArraysAggs(s), expHistogramMergeAggs(s)...)
+}
+
+// histogramCountSumArraysAggs is just the Count / Sum groupArray pair —
+// split out of [histogramCountSumMergeAggs] so [expHistogramGroupMergeAggs]
+// can splice avg()'s series-count agg between it and the merge aggs,
+// preserving the emitted SQL column order avg()'s shipped fixtures pin.
+func histogramCountSumArraysAggs(s schema.Metrics) []chplan.AggFunc {
+	return []chplan.AggFunc{
+		{Fn: chplan.FnGroupArray, Args: []chplan.Expr{&chplan.ColumnRef{Name: s.CountColumn}}, Alias: hqMergeCountsArrayAlias},
+		{Fn: chplan.FnGroupArray, Args: []chplan.Expr{&chplan.ColumnRef{Name: s.SumColumn}}, Alias: hqMergeSumsArrayAlias},
+	}
+}
+
+// histogramCountSumMergeProjections is [expHistogramMergeProjections]
+// plus the Count / Sum fold [histogramCountSumMergeAggs] collected, so
+// the reshaped row carries all nine fields [chplan.HistogramProjection]
+// reads by name rather than the seven the quantile kernel needs.
+func histogramCountSumMergeProjections(s schema.Metrics) []chplan.Projection {
 	return append(
 		[]chplan.Projection{
 			{Expr: promHistogramKahanSum(&chplan.ColumnRef{Name: hqMergeCountsArrayAlias}), Alias: s.CountColumn},

--- a/internal/promql/histogram_quantile.go
+++ b/internal/promql/histogram_quantile.go
@@ -2377,60 +2377,76 @@ func expHistogramMergeSeriesOrderKeyExpr(s schema.Metrics) chplan.Expr {
 // position lands where, and a second transcription of this shift is
 // exactly where they would stop agreeing.
 func expHistogramBucketRowContribExpr(mergedScale, mergedStart chplan.Expr, paramT string) chplan.Expr {
-	// For one (s, off, arr) tuple and target absolute index T,
 	// KahanSum(arrayMap(j -> if(bitShiftRight(off + j - 1, s - merged_scale) = T, arr[j], 0), arrayEnumerate(arr))).
-	return promHistogramKahanSum(
-		&chplan.FuncCall{
-			Fn: chplan.FnArrayMap,
-			Args: []chplan.Expr{
-				&chplan.Lambda{
-					Params: []string{paramExpBucketPos},
-					Body: &chplan.FuncCall{
-						Fn: chplan.FnIf,
-						Args: []chplan.Expr{
-							&chplan.Binary{
-								Op: chplan.OpEq,
-								Left: &chplan.FuncCall{
-									Fn: chplan.FnBitShiftRight,
-									Args: []chplan.Expr{
-										&chplan.Binary{
-											Op:   chplan.OpAdd,
-											Left: &chplan.BareIdent{Name: paramExpRowOffset},
-											Right: &chplan.Binary{
-												Op:    chplan.OpSub,
-												Left:  &chplan.BareIdent{Name: paramExpBucketPos},
-												Right: &chplan.LitInt{V: 1},
-											},
-										},
-										&chplan.Binary{
+	return promHistogramKahanSum(expHistogramBucketPositionPickerExpr(mergedScale, mergedStart, paramT))
+}
+
+// expHistogramBucketPositionPickerExpr builds the within-row bucket-position
+// picker shared by [expHistogramBucketRowContribExpr] (the cross-series
+// Kahan-compensated merge) and [histogramBinopBucketRowContribExpr] (the
+// two-operand plain-arithmetic binop, internal/promql/histogram_native_binop.go)
+// — for one (s, off, arr) tuple and target absolute index T:
+//
+//	arrayMap(j -> if(bitShiftRight(off + j - 1, s - merged_scale) = T, arr[j], 0), arrayEnumerate(arr))
+//
+// The two callers differ ONLY in which fold reduces this array afterward
+// (Kahan-compensated vs plain), matching reference Prometheus's own split
+// between FloatHistogram.KahanAdd's compensated `kahanReduceResolution` and
+// Add/Sub's plain `reduceResolution` — see histogram_native_binop.go's
+// header doc. The picker itself has no fold-order sensitivity of its own
+// (each element is independent), so sharing it cannot let the two callers'
+// bucket-index math drift apart.
+func expHistogramBucketPositionPickerExpr(mergedScale, mergedStart chplan.Expr, paramT string) chplan.Expr {
+	return &chplan.FuncCall{
+		Fn: chplan.FnArrayMap,
+		Args: []chplan.Expr{
+			&chplan.Lambda{
+				Params: []string{paramExpBucketPos},
+				Body: &chplan.FuncCall{
+					Fn: chplan.FnIf,
+					Args: []chplan.Expr{
+						&chplan.Binary{
+							Op: chplan.OpEq,
+							Left: &chplan.FuncCall{
+								Fn: chplan.FnBitShiftRight,
+								Args: []chplan.Expr{
+									&chplan.Binary{
+										Op:   chplan.OpAdd,
+										Left: &chplan.BareIdent{Name: paramExpRowOffset},
+										Right: &chplan.Binary{
 											Op:    chplan.OpSub,
-											Left:  &chplan.BareIdent{Name: paramExpRowScale},
-											Right: mergedScale,
+											Left:  &chplan.BareIdent{Name: paramExpBucketPos},
+											Right: &chplan.LitInt{V: 1},
 										},
 									},
-								},
-								// target absolute index = mergedStart + t (t is 0-based).
-								Right: &chplan.Binary{
-									Op:    chplan.OpAdd,
-									Left:  mergedStart,
-									Right: &chplan.BareIdent{Name: paramT},
+									&chplan.Binary{
+										Op:    chplan.OpSub,
+										Left:  &chplan.BareIdent{Name: paramExpRowScale},
+										Right: mergedScale,
+									},
 								},
 							},
-							&chplan.Subscript{
-								Container: &chplan.BareIdent{Name: paramExpRowBuckets},
-								Key:       &chplan.BareIdent{Name: paramExpBucketPos},
+							// target absolute index = mergedStart + t (t is 0-based).
+							Right: &chplan.Binary{
+								Op:    chplan.OpAdd,
+								Left:  mergedStart,
+								Right: &chplan.BareIdent{Name: paramT},
 							},
-							&chplan.LitInt{V: 0},
 						},
+						&chplan.Subscript{
+							Container: &chplan.BareIdent{Name: paramExpRowBuckets},
+							Key:       &chplan.BareIdent{Name: paramExpBucketPos},
+						},
+						&chplan.LitInt{V: 0},
 					},
 				},
-				&chplan.FuncCall{
-					Fn:   chplan.FnArrayEnumerate,
-					Args: []chplan.Expr{&chplan.BareIdent{Name: paramExpRowBuckets}},
-				},
+			},
+			&chplan.FuncCall{
+				Fn:   chplan.FnArrayEnumerate,
+				Args: []chplan.Expr{&chplan.BareIdent{Name: paramExpRowBuckets}},
 			},
 		},
-	)
+	}
 }
 
 // expHistogramRowContribsExpr renders the PER-ROW contributions at one

--- a/test/perf/solver-decision-baseline/exp_histogram_binop_add/fanout.json
+++ b/test/perf/solver-decision-baseline/exp_histogram_binop_add/fanout.json
@@ -1,0 +1,11 @@
+{
+  "query": "exp_histogram_binop_add/fanout",
+  "lowering": "fanout",
+  "routed": false,
+  "k": 0,
+  "reason": "not-sliceable",
+  "n_anchors": 241,
+  "fanout": 20,
+  "cumulative_d": "10m0s",
+  "outer_range": "1h0m0s"
+}

--- a/test/perf/solver-decision-baseline/exp_histogram_binop_add/native.json
+++ b/test/perf/solver-decision-baseline/exp_histogram_binop_add/native.json
@@ -1,0 +1,11 @@
+{
+  "query": "exp_histogram_binop_add/native",
+  "lowering": "native",
+  "routed": false,
+  "k": 0,
+  "reason": "not-sliceable",
+  "n_anchors": 241,
+  "fanout": 20,
+  "cumulative_d": "10m0s",
+  "outer_range": "1h0m0s"
+}

--- a/test/perf/solver-decision-baseline/exp_histogram_binop_add_downscale_fold/fanout.json
+++ b/test/perf/solver-decision-baseline/exp_histogram_binop_add_downscale_fold/fanout.json
@@ -1,0 +1,11 @@
+{
+  "query": "exp_histogram_binop_add_downscale_fold/fanout",
+  "lowering": "fanout",
+  "routed": false,
+  "k": 0,
+  "reason": "not-sliceable",
+  "n_anchors": 241,
+  "fanout": 20,
+  "cumulative_d": "10m0s",
+  "outer_range": "1h0m0s"
+}

--- a/test/perf/solver-decision-baseline/exp_histogram_binop_add_downscale_fold/native.json
+++ b/test/perf/solver-decision-baseline/exp_histogram_binop_add_downscale_fold/native.json
@@ -1,0 +1,11 @@
+{
+  "query": "exp_histogram_binop_add_downscale_fold/native",
+  "lowering": "native",
+  "routed": false,
+  "k": 0,
+  "reason": "not-sliceable",
+  "n_anchors": 241,
+  "fanout": 20,
+  "cumulative_d": "10m0s",
+  "outer_range": "1h0m0s"
+}

--- a/test/perf/solver-decision-baseline/exp_histogram_binop_add_range/fanout.json
+++ b/test/perf/solver-decision-baseline/exp_histogram_binop_add_range/fanout.json
@@ -1,0 +1,11 @@
+{
+  "query": "exp_histogram_binop_add_range/fanout",
+  "lowering": "fanout",
+  "routed": false,
+  "k": 0,
+  "reason": "not-sliceable",
+  "n_anchors": 241,
+  "fanout": 20,
+  "cumulative_d": "10m0s",
+  "outer_range": "1h0m0s"
+}

--- a/test/perf/solver-decision-baseline/exp_histogram_binop_add_range/native.json
+++ b/test/perf/solver-decision-baseline/exp_histogram_binop_add_range/native.json
@@ -1,0 +1,11 @@
+{
+  "query": "exp_histogram_binop_add_range/native",
+  "lowering": "native",
+  "routed": false,
+  "k": 0,
+  "reason": "not-sliceable",
+  "n_anchors": 241,
+  "fanout": 20,
+  "cumulative_d": "10m0s",
+  "outer_range": "1h0m0s"
+}

--- a/test/perf/solver-decision-baseline/exp_histogram_binop_sub/fanout.json
+++ b/test/perf/solver-decision-baseline/exp_histogram_binop_sub/fanout.json
@@ -1,0 +1,11 @@
+{
+  "query": "exp_histogram_binop_sub/fanout",
+  "lowering": "fanout",
+  "routed": false,
+  "k": 0,
+  "reason": "not-sliceable",
+  "n_anchors": 241,
+  "fanout": 20,
+  "cumulative_d": "10m0s",
+  "outer_range": "1h0m0s"
+}

--- a/test/perf/solver-decision-baseline/exp_histogram_binop_sub/native.json
+++ b/test/perf/solver-decision-baseline/exp_histogram_binop_sub/native.json
@@ -1,0 +1,11 @@
+{
+  "query": "exp_histogram_binop_sub/native",
+  "lowering": "native",
+  "routed": false,
+  "k": 0,
+  "reason": "not-sliceable",
+  "n_anchors": 241,
+  "fanout": 20,
+  "cumulative_d": "10m0s",
+  "outer_range": "1h0m0s"
+}

--- a/test/regression/parity-enrolment-baselines/promql/baseline.txt
+++ b/test/regression/parity-enrolment-baselines/promql/baseline.txt
@@ -134,6 +134,10 @@ exp_histogram_avg_by.txtar
 exp_histogram_avg_over_time.txtar
 exp_histogram_bare_selector.txtar
 exp_histogram_bare_selector_range.txtar
+exp_histogram_binop_add.txtar
+exp_histogram_binop_add_downscale_fold.txtar
+exp_histogram_binop_add_range.txtar
+exp_histogram_binop_sub.txtar
 exp_histogram_changes.txtar
 exp_histogram_count.txtar
 exp_histogram_count_by.txtar

--- a/test/rejection-parity/catalogue/internal__promql__histogram_native_binop.go.json
+++ b/test/rejection-parity/catalogue/internal__promql__histogram_native_binop.go.json
@@ -1,0 +1,63 @@
+{
+  "entries": [
+    {
+      "head": "promql",
+      "site": "internal/promql/histogram_native_binop.go:lowerExpHistogramHistogramBinop#f9a375de",
+      "message": "promql: on()/ignoring()/group_left()/group_right() matching is not yet supported for binary arithmetic between two exponential histogram selectors; only default (full label set) matching is supported",
+      "class": "divergence",
+      "trigger_query": "demo_latency_exp_hist + on(job) demo_latency_exp_hist",
+      "tracking_issue": 2273,
+      "evidence": {
+        "guard": [
+          "if !isDefaultMatching(vm)"
+        ],
+        "callers": [
+          "lowerExpHistogramValuedShape"
+        ]
+      },
+      "since": "2026-08-17"
+    },
+    {
+      "head": "promql",
+      "site": "internal/promql/histogram_native_binop.go:lowerExpHistogramValuedOperand#2fa7ca70",
+      "message": "promql: internal invariant violated: exp-histogram binop operand matched no known histogram-valued shape for %v",
+      "class": "internal",
+      "rationale": "expHistogramHistogramBinop admits only isExpHistogramValuedShape operands on both sides, whose lowerExpHistogramValuedShape producer never returns matched=false for a shape that recogniser already accepted",
+      "evidence": {
+        "guard": [
+          "past returning if err != nil",
+          "if !matched"
+        ],
+        "callers": [
+          "lowerExpHistogramHistogramBinop"
+        ],
+        "cited": [
+          "expHistogramHistogramBinop",
+          "isExpHistogramValuedShape",
+          "lowerExpHistogramValuedShape"
+        ]
+      }
+    },
+    {
+      "head": "promql",
+      "site": "internal/promql/histogram_native_binop.go:lowerExpHistogramValuedOperand#f7926a05",
+      "message": "promql: internal invariant violated: exp-histogram binop operand lowering did not cap with *chplan.HistogramProjection, got %T",
+      "class": "internal",
+      "rationale": "lowerExpHistogramValuedShape's producer contract ends in *chplan.HistogramProjection for every shape it reports matched=true for — the same contract histogram_native_scalar_binop.go's lowerExpHistogramScalarBinop already relies on",
+      "evidence": {
+        "guard": [
+          "past returning if err != nil",
+          "past returning if !matched",
+          "if !ok"
+        ],
+        "callers": [
+          "lowerExpHistogramHistogramBinop"
+        ],
+        "cited": [
+          "lowerExpHistogramScalarBinop",
+          "lowerExpHistogramValuedShape"
+        ]
+      }
+    }
+  ]
+}

--- a/test/rejection-parity/catalogue/internal__promql__lower.go.json
+++ b/test/rejection-parity/catalogue/internal__promql__lower.go.json
@@ -75,8 +75,9 @@
       "head": "promql",
       "site": "internal/promql/lower.go:expHistogramSelectorRouting#bf746b59",
       "message": "promql: %q is an exponential histogram metric; only a bare %q selector, sum()/avg()/count() over one, rate()/increase()/delta()/irate()/idelta()/sum_over_time()/avg_over_time()/resets()/changes() over one, histogram_quantile(), histogram_count(), histogram_sum(), and the %q/%q companion selectors are supported",
-      "class": "rejection",
+      "class": "divergence",
       "trigger_query": "demo_latency_exp_hist * demo_latency_exp_hist",
+      "tracking_issue": 2277,
       "evidence": {
         "guard": [
           "past returning if bare, col, hasCompanion := s.HistogramCompanionColumn(metricName); hasCompanion \u0026\u0026 s.IsExpHistogramMetric(bare) \u0026\u0026 s.ExpHistogramTable != \"\"",
@@ -85,7 +86,8 @@
         "callers": [
           "resolveSelectorRouting"
         ]
-      }
+      },
+      "since": "2026-08-17"
     },
     {
       "head": "promql",

--- a/test/rejection-parity/catalogue/internal__promql__lower.go.json
+++ b/test/rejection-parity/catalogue/internal__promql__lower.go.json
@@ -75,9 +75,8 @@
       "head": "promql",
       "site": "internal/promql/lower.go:expHistogramSelectorRouting#bf746b59",
       "message": "promql: %q is an exponential histogram metric; only a bare %q selector, sum()/avg()/count() over one, rate()/increase()/delta()/irate()/idelta()/sum_over_time()/avg_over_time()/resets()/changes() over one, histogram_quantile(), histogram_count(), histogram_sum(), and the %q/%q companion selectors are supported",
-      "class": "divergence",
-      "trigger_query": "demo_latency_exp_hist + demo_latency_exp_hist",
-      "tracking_issue": 2263,
+      "class": "rejection",
+      "trigger_query": "demo_latency_exp_hist * demo_latency_exp_hist",
       "evidence": {
         "guard": [
           "past returning if bare, col, hasCompanion := s.HistogramCompanionColumn(metricName); hasCompanion \u0026\u0026 s.IsExpHistogramMetric(bare) \u0026\u0026 s.ExpHistogramTable != \"\"",
@@ -86,8 +85,7 @@
         "callers": [
           "resolveSelectorRouting"
         ]
-      },
-      "since": "2026-08-16"
+      }
     },
     {
       "head": "promql",

--- a/test/rejection-parity/divergence-ceiling.json
+++ b/test/rejection-parity/divergence-ceiling.json
@@ -1,3 +1,3 @@
 {
-  "max_entries": 3
+  "max_entries": 4
 }

--- a/test/spec/promql/exp_histogram_binop_add.txtar
+++ b/test/spec/promql/exp_histogram_binop_add.txtar
@@ -1,0 +1,41 @@
+-- query.promql --
+http_server_duration_exp_hist + http_client_duration_exp_hist
+-- parity --
+oracle: prometheus
+endpoint: /api/v1/query
+scope: full
+-- seed --
+CREATE TABLE otel_metrics_exponential_histogram (
+    MetricName String,
+    Attributes Map(String, String),
+    TimeUnix DateTime64(9),
+    Count UInt64,
+    Sum Float64,
+    Scale Int32,
+    ZeroCount UInt64,
+    PositiveOffset Int32,
+    PositiveBucketCounts Array(UInt64),
+    NegativeOffset Int32,
+    NegativeBucketCounts Array(UInt64)
+) ENGINE = MergeTree ORDER BY (MetricName, Attributes, TimeUnix);
+-- Binary `+` between two DIFFERENT exp-histogram metrics (cerberus issue
+-- #2263). Reference Prometheus's FloatHistogram.Add reconciles the two
+-- operands to the coarser Scale before adding buckets — the same fold
+-- exp_histogram_sum_mixed_scale.txtar exercises for a cross-series
+-- sum(), reused here for a two-operand binop:
+--
+--   `shared`: server at Scale=1 [1,2,3,4]@offset0 downscales to Scale=0
+--   as [1+2,3+4]=[3,7]; client is already Scale=0 [5,10]@offset0.
+--   merged = [3+5, 7+10] = [8, 17] at Scale=0, PositiveOffset=0.
+--   Count 10+15=25, Sum 1+2=3, ZeroCount 0+0=0.
+--
+-- `server_only` and `client_only` each exist on ONE side only — PromQL's
+-- default one-to-one V-V matching drops a series absent from either
+-- operand, so neither reaches the output.
+INSERT INTO otel_metrics_exponential_histogram VALUES
+    ('http_server_duration_exp_hist', map('series', 'shared'),      toDateTime64('2026-01-01 00:00:00', 9), 10, 1.0, 1, 0, 0, [1, 2, 3, 4], 0, []),
+    ('http_server_duration_exp_hist', map('series', 'server_only'), toDateTime64('2026-01-01 00:00:00', 9), 4,  0.4, 0, 0, 0, [7],           0, []),
+    ('http_client_duration_exp_hist', map('series', 'shared'),      toDateTime64('2026-01-01 00:00:00', 9), 15, 2.0, 0, 0, 0, [5, 10],       0, []),
+    ('http_client_duration_exp_hist', map('series', 'client_only'), toDateTime64('2026-01-01 00:00:00', 9), 3,  0.1, 0, 0, 0, [9],            0, []);
+-- expected_rows --
+[]

--- a/test/spec/promql/exp_histogram_binop_add.txtar
+++ b/test/spec/promql/exp_histogram_binop_add.txtar
@@ -38,4 +38,114 @@ INSERT INTO otel_metrics_exponential_histogram VALUES
     ('http_client_duration_exp_hist', map('series', 'shared'),      toDateTime64('2026-01-01 00:00:00', 9), 15, 2.0, 0, 0, 0, [5, 10],       0, []),
     ('http_client_duration_exp_hist', map('series', 'client_only'), toDateTime64('2026-01-01 00:00:00', 9), 3,  0.1, 0, 0, 0, [9],            0, []);
 -- expected_rows --
-[]
+[
+  ["", {"series": "shared"}, "2026-01-01T00:00:01Z", 0, 25, 3, 0, 0, 0, 0, [8,17], 0, []]
+]
+-- args --
+[0] string = ""
+[1] int64 = 9
+[2] float64 = 0
+[3] int64 = 1
+[4] int64 = 0
+[5] int64 = 0
+[6] int64 = 1
+[7] int64 = 1
+[8] int64 = 1
+[9] int64 = 0
+[10] int64 = 0
+[11] int64 = 1
+[12] int64 = 1
+[13] int64 = 9
+[14] float64 = 0
+[15] string = "service.name"
+[16] string = "service_name"
+[17] string = "service.name"
+[18] string = "service_name"
+[19] string = ""
+[20] string = "service_name"
+[21] string = "http_server_duration_exp_hist"
+[22] string = "http.server.duration.exp.hist"
+[23] string = "http.server.duration.exp/hist"
+[24] string = "http.server.duration.exp_hist"
+[25] string = "http.server.duration/exp/hist"
+[26] string = "http.server.duration/exp_hist"
+[27] string = "http.server.duration_exp.hist"
+[28] string = "http.server.duration_exp_hist"
+[29] string = "http.server/duration/exp/hist"
+[30] string = "http.server/duration/exp_hist"
+[31] string = "http.server/duration_exp_hist"
+[32] string = "http.server_duration.exp.hist"
+[33] string = "http.server_duration.exp_hist"
+[34] string = "http.server_duration_exp.hist"
+[35] string = "http.server_duration_exp_hist"
+[36] string = "http/server/duration/exp/hist"
+[37] string = "http/server/duration/exp_hist"
+[38] string = "http/server/duration_exp_hist"
+[39] string = "http/server_duration_exp_hist"
+[40] string = "http_server.duration.exp.hist"
+[41] string = "http_server.duration.exp_hist"
+[42] string = "http_server.duration_exp.hist"
+[43] string = "http_server.duration_exp_hist"
+[44] string = "http_server_duration.exp.hist"
+[45] string = "http_server_duration.exp_hist"
+[46] string = "http_server_duration_exp.hist"
+[47] string = "2026-01-01 00:00:01.000000000"
+[48] int64 = 9
+[49] string = "2026-01-01 00:00:01.000000000"
+[50] int64 = 9
+[51] int64 = 300000000000
+[52] int64 = 9
+[53] float64 = 0
+[54] string = "service.name"
+[55] string = "service_name"
+[56] string = "service.name"
+[57] string = "service_name"
+[58] string = ""
+[59] string = "service_name"
+[60] string = "http_client_duration_exp_hist"
+[61] string = "http.client.duration.exp.hist"
+[62] string = "http.client.duration.exp/hist"
+[63] string = "http.client.duration.exp_hist"
+[64] string = "http.client.duration/exp/hist"
+[65] string = "http.client.duration/exp_hist"
+[66] string = "http.client.duration_exp.hist"
+[67] string = "http.client.duration_exp_hist"
+[68] string = "http.client/duration/exp/hist"
+[69] string = "http.client/duration/exp_hist"
+[70] string = "http.client/duration_exp_hist"
+[71] string = "http.client_duration.exp.hist"
+[72] string = "http.client_duration.exp_hist"
+[73] string = "http.client_duration_exp.hist"
+[74] string = "http.client_duration_exp_hist"
+[75] string = "http/client/duration/exp/hist"
+[76] string = "http/client/duration/exp_hist"
+[77] string = "http/client/duration_exp_hist"
+[78] string = "http/client_duration_exp_hist"
+[79] string = "http_client.duration.exp.hist"
+[80] string = "http_client.duration.exp_hist"
+[81] string = "http_client.duration_exp.hist"
+[82] string = "http_client.duration_exp_hist"
+[83] string = "http_client_duration.exp.hist"
+[84] string = "http_client_duration.exp_hist"
+[85] string = "http_client_duration_exp.hist"
+[86] string = "2026-01-01 00:00:01.000000000"
+[87] int64 = 9
+[88] string = "2026-01-01 00:00:01.000000000"
+[89] int64 = 9
+[90] int64 = 300000000000
+[91] int64 = 2
+-- chplan --
+HistogramProjection project=["" AS MetricName, Attributes AS Attributes, FnNow64(9) AS TimeUnix, 0 AS Value]
+  Project [gkey_0 AS Attributes, FnArraySum(_hq_merge_counts) AS HistogramCount, FnArraySum(_hq_merge_sums) AS HistogramSum, _hq_merged_scale AS HistogramScale, FnArraySum(_hq_merge_zero_counts) AS HistogramZeroCount, HistogramZeroThreshold AS HistogramZeroThreshold, FnArrayMin(FnArrayMap((s, off) -> FnBitShiftRight(off, (s - _hq_merged_scale)), _hq_scales, _hq_pos_offsets)) AS HistogramPositiveOffset, FnArrayMap(t -> FnArraySum(FnArrayMap((s, off, arr) -> FnArraySum(FnArrayMap(j -> FnIf((FnBitShiftRight((off + (j - 1)), (s - _hq_merged_scale)) = (FnArrayMin(FnArrayMap((sm, om) -> FnBitShiftRight(om, (sm - _hq_merged_scale)), _hq_scales, _hq_pos_offsets)) + t)), arr[j], 0), FnArrayEnumerate(arr))), _hq_scales, _hq_pos_offsets, _hq_pos_buckets)), FnRange(FnToUInt64(FnGreatest(0, ((FnArrayMax(FnArrayMap((sm, om, am) -> FnBitShiftRight((om + (FnLength(am) - 1)), (sm - _hq_merged_scale)), _hq_scales, _hq_pos_offsets, _hq_pos_buckets)) - FnArrayMin(FnArrayMap((sm, om) -> FnBitShiftRight(om, (sm - _hq_merged_scale)), _hq_scales, _hq_pos_offsets))) + 1))))) AS HistogramPositiveBucketCounts, FnArrayMin(FnArrayMap((s, off) -> FnBitShiftRight(off, (s - _hq_merged_scale)), _hq_scales, _hq_neg_offsets)) AS HistogramNegativeOffset, FnArrayMap(t -> FnArraySum(FnArrayMap((s, off, arr) -> FnArraySum(FnArrayMap(j -> FnIf((FnBitShiftRight((off + (j - 1)), (s - _hq_merged_scale)) = (FnArrayMin(FnArrayMap((sm, om) -> FnBitShiftRight(om, (sm - _hq_merged_scale)), _hq_scales, _hq_neg_offsets)) + t)), arr[j], 0), FnArrayEnumerate(arr))), _hq_scales, _hq_neg_offsets, _hq_neg_buckets)), FnRange(FnToUInt64(FnGreatest(0, ((FnArrayMax(FnArrayMap((sm, om, am) -> FnBitShiftRight((om + (FnLength(am) - 1)), (sm - _hq_merged_scale)), _hq_scales, _hq_neg_offsets, _hq_neg_buckets)) - FnArrayMin(FnArrayMap((sm, om) -> FnBitShiftRight(om, (sm - _hq_merged_scale)), _hq_scales, _hq_neg_offsets))) + 1))))) AS HistogramNegativeBucketCounts]
+    Aggregate groupBy=[Attributes AS gkey_0] funcs=[FnGroupArray(HistogramCount) AS _hq_merge_counts, FnGroupArray(HistogramSum) AS _hq_merge_sums, FnMin(HistogramScale) AS _hq_merged_scale, FnGroupArray(HistogramZeroCount) AS _hq_merge_zero_counts, FnMax(HistogramZeroThreshold) AS HistogramZeroThreshold, FnGroupArray(HistogramScale) AS _hq_scales, FnGroupArray(HistogramPositiveOffset) AS _hq_pos_offsets, FnGroupArray(HistogramPositiveBucketCounts) AS _hq_pos_buckets, FnGroupArray(HistogramNegativeOffset) AS _hq_neg_offsets, FnGroupArray(HistogramNegativeBucketCounts) AS _hq_neg_buckets, FnGroupArray(FnToString(FnMapSort(Attributes))) AS _hq_series_order_key] having=(FnCount() = 2)
+      UnionAll arms=2
+        HistogramProjection project=[MetricName AS MetricName, Attributes AS Attributes, FnNow64(9) AS TimeUnix, 0 AS Value]
+          Aggregate groupBy=[FnMapSort(FnMapMerge(FnMapUpdate(FnMapFromArrays(FnArrayMap(k -> FnRegexReplaceAll(k, "[^a-zA-Z0-9_]", "_"), FnMapKeys(FnMapFilter((k, v) -> (k NOT IN ("service.name", "service_name")), ResourceAttributes))), FnMapValues(FnMapFilter((k, v) -> (k NOT IN ("service.name", "service_name")), ResourceAttributes))), FnMapFromArrays(FnArrayMap(k -> FnRegexReplaceAll(k, "[^a-zA-Z0-9_]", "_"), FnMapKeys(Attributes)), FnMapValues(Attributes))), FnMapFilter((k, v) -> (v != ""), FnMap("service_name", FnToString(ServiceName))))) AS Attributes] funcs=[FnArgMax(MetricName, TimeUnix) AS MetricName, FnArgMax(Count, TimeUnix) AS Count, FnArgMax(Sum, TimeUnix) AS Sum, FnArgMax(Scale, TimeUnix) AS Scale, FnArgMax(ZeroCount, TimeUnix) AS ZeroCount, FnArgMax(PositiveOffset, TimeUnix) AS PositiveOffset, FnArgMax(PositiveBucketCounts, TimeUnix) AS PositiveBucketCounts, FnArgMax(NegativeOffset, TimeUnix) AS NegativeOffset, FnArgMax(NegativeBucketCounts, TimeUnix) AS NegativeBucketCounts]
+            Filter predicate=(((MetricName IN ("http_server_duration_exp_hist", "http.server.duration.exp.hist", "http.server.duration.exp/hist", "http.server.duration.exp_hist", "http.server.duration/exp/hist", "http.server.duration/exp_hist", "http.server.duration_exp.hist", "http.server.duration_exp_hist", "http.server/duration/exp/hist", "http.server/duration/exp_hist", "http.server/duration_exp_hist", "http.server_duration.exp.hist", "http.server_duration.exp_hist", "http.server_duration_exp.hist", "http.server_duration_exp_hist", "http/server/duration/exp/hist", "http/server/duration/exp_hist", "http/server/duration_exp_hist", "http/server_duration_exp_hist", "http_server.duration.exp.hist", "http_server.duration.exp_hist", "http_server.duration_exp.hist", "http_server.duration_exp_hist", "http_server_duration.exp.hist", "http_server_duration.exp_hist", "http_server_duration_exp.hist")) AND (TimeUnix <= FnToDateTime64("2026-01-01 00:00:01.000000000", 9))) AND (TimeUnix > (FnToDateTime64("2026-01-01 00:00:01.000000000", 9) - FnToIntervalNanosecond(300000000000))))
+              Scan(otel_metrics_exponential_histogram)
+        HistogramProjection project=[MetricName AS MetricName, Attributes AS Attributes, FnNow64(9) AS TimeUnix, 0 AS Value]
+          Aggregate groupBy=[FnMapSort(FnMapMerge(FnMapUpdate(FnMapFromArrays(FnArrayMap(k -> FnRegexReplaceAll(k, "[^a-zA-Z0-9_]", "_"), FnMapKeys(FnMapFilter((k, v) -> (k NOT IN ("service.name", "service_name")), ResourceAttributes))), FnMapValues(FnMapFilter((k, v) -> (k NOT IN ("service.name", "service_name")), ResourceAttributes))), FnMapFromArrays(FnArrayMap(k -> FnRegexReplaceAll(k, "[^a-zA-Z0-9_]", "_"), FnMapKeys(Attributes)), FnMapValues(Attributes))), FnMapFilter((k, v) -> (v != ""), FnMap("service_name", FnToString(ServiceName))))) AS Attributes] funcs=[FnArgMax(MetricName, TimeUnix) AS MetricName, FnArgMax(Count, TimeUnix) AS Count, FnArgMax(Sum, TimeUnix) AS Sum, FnArgMax(Scale, TimeUnix) AS Scale, FnArgMax(ZeroCount, TimeUnix) AS ZeroCount, FnArgMax(PositiveOffset, TimeUnix) AS PositiveOffset, FnArgMax(PositiveBucketCounts, TimeUnix) AS PositiveBucketCounts, FnArgMax(NegativeOffset, TimeUnix) AS NegativeOffset, FnArgMax(NegativeBucketCounts, TimeUnix) AS NegativeBucketCounts]
+            Filter predicate=(((MetricName IN ("http_client_duration_exp_hist", "http.client.duration.exp.hist", "http.client.duration.exp/hist", "http.client.duration.exp_hist", "http.client.duration/exp/hist", "http.client.duration/exp_hist", "http.client.duration_exp.hist", "http.client.duration_exp_hist", "http.client/duration/exp/hist", "http.client/duration/exp_hist", "http.client/duration_exp_hist", "http.client_duration.exp.hist", "http.client_duration.exp_hist", "http.client_duration_exp.hist", "http.client_duration_exp_hist", "http/client/duration/exp/hist", "http/client/duration/exp_hist", "http/client/duration_exp_hist", "http/client_duration_exp_hist", "http_client.duration.exp.hist", "http_client.duration.exp_hist", "http_client.duration_exp.hist", "http_client.duration_exp_hist", "http_client_duration.exp.hist", "http_client_duration.exp_hist", "http_client_duration_exp.hist")) AND (TimeUnix <= FnToDateTime64("2026-01-01 00:00:01.000000000", 9))) AND (TimeUnix > (FnToDateTime64("2026-01-01 00:00:01.000000000", 9) - FnToIntervalNanosecond(300000000000))))
+              Scan(otel_metrics_exponential_histogram)
+-- sql --
+SELECT ? AS `MetricName`, `Attributes` AS `Attributes`, now64(?) AS `TimeUnix`, toFloat64(?) AS `Value`, toFloat64(`HistogramCount`) AS `HistogramCount`, toFloat64(`HistogramSum`) AS `HistogramSum`, toInt32(`HistogramScale`) AS `HistogramScale`, toFloat64(`HistogramZeroThreshold`) AS `HistogramZeroThreshold`, toFloat64(`HistogramZeroCount`) AS `HistogramZeroCount`, toInt32(`HistogramPositiveOffset`) AS `HistogramPositiveOffset`, arrayMap(x -> toFloat64(x), `HistogramPositiveBucketCounts`) AS `HistogramPositiveBucketCounts`, toInt32(`HistogramNegativeOffset`) AS `HistogramNegativeOffset`, arrayMap(x -> toFloat64(x), `HistogramNegativeBucketCounts`) AS `HistogramNegativeBucketCounts` FROM (SELECT `gkey_0` AS `Attributes`, arraySum(`_hq_merge_counts`) AS `HistogramCount`, arraySum(`_hq_merge_sums`) AS `HistogramSum`, `_hq_merged_scale` AS `HistogramScale`, arraySum(`_hq_merge_zero_counts`) AS `HistogramZeroCount`, `HistogramZeroThreshold` AS `HistogramZeroThreshold`, arrayMin(arrayMap((s, off) -> bitShiftRight(off, (s - `_hq_merged_scale`)), `_hq_scales`, `_hq_pos_offsets`)) AS `HistogramPositiveOffset`, arrayMap(t -> arraySum(arrayMap((s, off, arr) -> arraySum(arrayMap(j -> if((bitShiftRight((off + (j - ?)), (s - `_hq_merged_scale`)) = (arrayMin(arrayMap((sm, om) -> bitShiftRight(om, (sm - `_hq_merged_scale`)), `_hq_scales`, `_hq_pos_offsets`)) + t)), arr[j], ?), arrayEnumerate(arr))), `_hq_scales`, `_hq_pos_offsets`, `_hq_pos_buckets`)), range(toUInt64(greatest(?, ((arrayMax(arrayMap((sm, om, am) -> bitShiftRight((om + (length(am) - ?)), (sm - `_hq_merged_scale`)), `_hq_scales`, `_hq_pos_offsets`, `_hq_pos_buckets`)) - arrayMin(arrayMap((sm, om) -> bitShiftRight(om, (sm - `_hq_merged_scale`)), `_hq_scales`, `_hq_pos_offsets`))) + ?))))) AS `HistogramPositiveBucketCounts`, arrayMin(arrayMap((s, off) -> bitShiftRight(off, (s - `_hq_merged_scale`)), `_hq_scales`, `_hq_neg_offsets`)) AS `HistogramNegativeOffset`, arrayMap(t -> arraySum(arrayMap((s, off, arr) -> arraySum(arrayMap(j -> if((bitShiftRight((off + (j - ?)), (s - `_hq_merged_scale`)) = (arrayMin(arrayMap((sm, om) -> bitShiftRight(om, (sm - `_hq_merged_scale`)), `_hq_scales`, `_hq_neg_offsets`)) + t)), arr[j], ?), arrayEnumerate(arr))), `_hq_scales`, `_hq_neg_offsets`, `_hq_neg_buckets`)), range(toUInt64(greatest(?, ((arrayMax(arrayMap((sm, om, am) -> bitShiftRight((om + (length(am) - ?)), (sm - `_hq_merged_scale`)), `_hq_scales`, `_hq_neg_offsets`, `_hq_neg_buckets`)) - arrayMin(arrayMap((sm, om) -> bitShiftRight(om, (sm - `_hq_merged_scale`)), `_hq_scales`, `_hq_neg_offsets`))) + ?))))) AS `HistogramNegativeBucketCounts` FROM (SELECT `Attributes` AS `gkey_0`, groupArray(`HistogramCount`) AS `_hq_merge_counts`, groupArray(`HistogramSum`) AS `_hq_merge_sums`, min(`HistogramScale`) AS `_hq_merged_scale`, groupArray(`HistogramZeroCount`) AS `_hq_merge_zero_counts`, max(`HistogramZeroThreshold`) AS `HistogramZeroThreshold`, groupArray(`HistogramScale`) AS `_hq_scales`, groupArray(`HistogramPositiveOffset`) AS `_hq_pos_offsets`, groupArray(`HistogramPositiveBucketCounts`) AS `_hq_pos_buckets`, groupArray(`HistogramNegativeOffset`) AS `_hq_neg_offsets`, groupArray(`HistogramNegativeBucketCounts`) AS `_hq_neg_buckets`, groupArray(toString(mapSort(`Attributes`))) AS `_hq_series_order_key` FROM ((SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, now64(?) AS `TimeUnix`, toFloat64(?) AS `Value`, toFloat64(`Count`) AS `HistogramCount`, toFloat64(`Sum`) AS `HistogramSum`, toInt32(`Scale`) AS `HistogramScale`, toFloat64(0.) AS `HistogramZeroThreshold`, toFloat64(`ZeroCount`) AS `HistogramZeroCount`, toInt32(`PositiveOffset`) AS `HistogramPositiveOffset`, arrayMap(x -> toFloat64(x), `PositiveBucketCounts`) AS `HistogramPositiveBucketCounts`, toInt32(`NegativeOffset`) AS `HistogramNegativeOffset`, arrayMap(x -> toFloat64(x), `NegativeBucketCounts`) AS `HistogramNegativeBucketCounts` FROM (SELECT mapSort(mapConcat(mapUpdate(mapFromArrays(arrayMap(k -> replaceRegexpAll(k, '[^a-zA-Z0-9_]', '_'), mapKeys(mapFilter((k, v) -> (k NOT IN (?, ?)), `ResourceAttributes`))), mapValues(mapFilter((k, v) -> (k NOT IN (?, ?)), `ResourceAttributes`))), mapFromArrays(arrayMap(k -> replaceRegexpAll(k, '[^a-zA-Z0-9_]', '_'), mapKeys(`Attributes`)), mapValues(`Attributes`))), mapFilter((k, v) -> (v != ?), map(?, toString(`ServiceName`))))) AS `Attributes`, argMax(`MetricName`, `TimeUnix`) AS `MetricName`, argMax(`Count`, `TimeUnix`) AS `Count`, argMax(`Sum`, `TimeUnix`) AS `Sum`, argMax(`Scale`, `TimeUnix`) AS `Scale`, argMax(`ZeroCount`, `TimeUnix`) AS `ZeroCount`, argMax(`PositiveOffset`, `TimeUnix`) AS `PositiveOffset`, argMax(`PositiveBucketCounts`, `TimeUnix`) AS `PositiveBucketCounts`, argMax(`NegativeOffset`, `TimeUnix`) AS `NegativeOffset`, argMax(`NegativeBucketCounts`, `TimeUnix`) AS `NegativeBucketCounts` FROM (SELECT * FROM `otel_metrics_exponential_histogram` PREWHERE (`MetricName` IN (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)) WHERE (`TimeUnix` <= toDateTime64(?, ?)) AND (`TimeUnix` > (toDateTime64(?, ?) - toIntervalNanosecond(?)))) GROUP BY `Attributes`)) UNION ALL (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, now64(?) AS `TimeUnix`, toFloat64(?) AS `Value`, toFloat64(`Count`) AS `HistogramCount`, toFloat64(`Sum`) AS `HistogramSum`, toInt32(`Scale`) AS `HistogramScale`, toFloat64(0.) AS `HistogramZeroThreshold`, toFloat64(`ZeroCount`) AS `HistogramZeroCount`, toInt32(`PositiveOffset`) AS `HistogramPositiveOffset`, arrayMap(x -> toFloat64(x), `PositiveBucketCounts`) AS `HistogramPositiveBucketCounts`, toInt32(`NegativeOffset`) AS `HistogramNegativeOffset`, arrayMap(x -> toFloat64(x), `NegativeBucketCounts`) AS `HistogramNegativeBucketCounts` FROM (SELECT mapSort(mapConcat(mapUpdate(mapFromArrays(arrayMap(k -> replaceRegexpAll(k, '[^a-zA-Z0-9_]', '_'), mapKeys(mapFilter((k, v) -> (k NOT IN (?, ?)), `ResourceAttributes`))), mapValues(mapFilter((k, v) -> (k NOT IN (?, ?)), `ResourceAttributes`))), mapFromArrays(arrayMap(k -> replaceRegexpAll(k, '[^a-zA-Z0-9_]', '_'), mapKeys(`Attributes`)), mapValues(`Attributes`))), mapFilter((k, v) -> (v != ?), map(?, toString(`ServiceName`))))) AS `Attributes`, argMax(`MetricName`, `TimeUnix`) AS `MetricName`, argMax(`Count`, `TimeUnix`) AS `Count`, argMax(`Sum`, `TimeUnix`) AS `Sum`, argMax(`Scale`, `TimeUnix`) AS `Scale`, argMax(`ZeroCount`, `TimeUnix`) AS `ZeroCount`, argMax(`PositiveOffset`, `TimeUnix`) AS `PositiveOffset`, argMax(`PositiveBucketCounts`, `TimeUnix`) AS `PositiveBucketCounts`, argMax(`NegativeOffset`, `TimeUnix`) AS `NegativeOffset`, argMax(`NegativeBucketCounts`, `TimeUnix`) AS `NegativeBucketCounts` FROM (SELECT * FROM `otel_metrics_exponential_histogram` PREWHERE (`MetricName` IN (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)) WHERE (`TimeUnix` <= toDateTime64(?, ?)) AND (`TimeUnix` > (toDateTime64(?, ?) - toIntervalNanosecond(?)))) GROUP BY `Attributes`))) GROUP BY `gkey_0` HAVING (count() = ?)))

--- a/test/spec/promql/exp_histogram_binop_add_downscale_fold.txtar
+++ b/test/spec/promql/exp_histogram_binop_add_downscale_fold.txtar
@@ -1,0 +1,51 @@
+-- query.promql --
+http_server_duration_exp_hist + http_client_duration_exp_hist
+-- parity --
+oracle: prometheus
+endpoint: /api/v1/query
+scope: full
+-- seed --
+CREATE TABLE otel_metrics_exponential_histogram (
+    MetricName String,
+    Attributes Map(String, String),
+    TimeUnix DateTime64(9),
+    Count UInt64,
+    Sum Float64,
+    Scale Int32,
+    ZeroCount UInt64,
+    PositiveOffset Int32,
+    PositiveBucketCounts Array(UInt64),
+    NegativeOffset Int32,
+    NegativeBucketCounts Array(UInt64)
+) ENGINE = MergeTree ORDER BY (MetricName, Attributes, TimeUnix);
+-- Pins that the binary-op merge's within-row downscale fold uses PLAIN
+-- (uncompensated) summation, matching reference Prometheus's `Add`/`Sub`
+-- (model/histogram/float_histogram.go's `Add`/`Sub` -> `reduceResolution`,
+-- a bare `+=` loop) — NOT the Kahan-Neumaier compensated fold cerberus's
+-- cross-series sum()/avg()/histogram_quantile() merge correctly uses for
+-- reference's SEPARATE `KahanAdd` method (see histogram_native_binop.go).
+--
+-- `server` sits at Scale=2 with FOUR buckets [1e16, 1, 1, 1] at offset 0
+-- (absolute indices 0..3). Downscaling to the merged Scale=0 (min(2,0))
+-- folds all four onto ONE target bucket (0>>2 = 1>>2 = 2>>2 = 3>>2 = 0).
+-- `client` is already at Scale=0 with a single bucket [5] at offset 0
+-- (absolute index 0) — the same target.
+--
+-- Naive sequential PLAIN summation in stored order
+-- (1e16, 1, 1, 1, 5) — Prometheus's own `+=` loop order, and the order
+-- this file's histogramBinopBucketRowContribExpr / plainArraySum
+-- reproduce — loses the three `1`s (1e16 has no mantissa room left) but
+-- keeps the final `+5` since by then the running total already lost the
+-- opportunity: 1e16 -> 1e16 -> 1e16 -> 1e16 -> 10000000000000004.
+-- Kahan-Neumaier compensated summation of the SAME five values instead
+-- recovers 10000000000000008 (verified against a hand-rolled reference
+-- implementation) — 4 apart from the plain result, a decisive, non-
+-- coincidental divergence that a change reverting to the Kahan merge
+-- here would immediately fail.
+--
+-- Count 10+5=15, Sum 1.0+2.0=3.0, ZeroCount 0+0=0.
+INSERT INTO otel_metrics_exponential_histogram VALUES
+    ('http_server_duration_exp_hist', map('series', 'x'), toDateTime64('2026-01-01 00:00:00', 9), 10, 1.0, 2, 0, 0, [10000000000000000, 1, 1, 1], 0, []),
+    ('http_client_duration_exp_hist', map('series', 'x'), toDateTime64('2026-01-01 00:00:00', 9), 5,  2.0, 0, 0, 0, [5],                          0, []);
+-- expected_rows --
+[]

--- a/test/spec/promql/exp_histogram_binop_add_downscale_fold.txtar
+++ b/test/spec/promql/exp_histogram_binop_add_downscale_fold.txtar
@@ -48,4 +48,114 @@ INSERT INTO otel_metrics_exponential_histogram VALUES
     ('http_server_duration_exp_hist', map('series', 'x'), toDateTime64('2026-01-01 00:00:00', 9), 10, 1.0, 2, 0, 0, [10000000000000000, 1, 1, 1], 0, []),
     ('http_client_duration_exp_hist', map('series', 'x'), toDateTime64('2026-01-01 00:00:00', 9), 5,  2.0, 0, 0, 0, [5],                          0, []);
 -- expected_rows --
-[]
+[
+  ["", {"series": "x"}, "2026-01-01T00:00:01Z", 0, 15, 3, 0, 0, 0, 0, [10000000000000004], 0, []]
+]
+-- args --
+[0] string = ""
+[1] int64 = 9
+[2] float64 = 0
+[3] int64 = 1
+[4] int64 = 0
+[5] int64 = 0
+[6] int64 = 1
+[7] int64 = 1
+[8] int64 = 1
+[9] int64 = 0
+[10] int64 = 0
+[11] int64 = 1
+[12] int64 = 1
+[13] int64 = 9
+[14] float64 = 0
+[15] string = "service.name"
+[16] string = "service_name"
+[17] string = "service.name"
+[18] string = "service_name"
+[19] string = ""
+[20] string = "service_name"
+[21] string = "http_server_duration_exp_hist"
+[22] string = "http.server.duration.exp.hist"
+[23] string = "http.server.duration.exp/hist"
+[24] string = "http.server.duration.exp_hist"
+[25] string = "http.server.duration/exp/hist"
+[26] string = "http.server.duration/exp_hist"
+[27] string = "http.server.duration_exp.hist"
+[28] string = "http.server.duration_exp_hist"
+[29] string = "http.server/duration/exp/hist"
+[30] string = "http.server/duration/exp_hist"
+[31] string = "http.server/duration_exp_hist"
+[32] string = "http.server_duration.exp.hist"
+[33] string = "http.server_duration.exp_hist"
+[34] string = "http.server_duration_exp.hist"
+[35] string = "http.server_duration_exp_hist"
+[36] string = "http/server/duration/exp/hist"
+[37] string = "http/server/duration/exp_hist"
+[38] string = "http/server/duration_exp_hist"
+[39] string = "http/server_duration_exp_hist"
+[40] string = "http_server.duration.exp.hist"
+[41] string = "http_server.duration.exp_hist"
+[42] string = "http_server.duration_exp.hist"
+[43] string = "http_server.duration_exp_hist"
+[44] string = "http_server_duration.exp.hist"
+[45] string = "http_server_duration.exp_hist"
+[46] string = "http_server_duration_exp.hist"
+[47] string = "2026-01-01 00:00:01.000000000"
+[48] int64 = 9
+[49] string = "2026-01-01 00:00:01.000000000"
+[50] int64 = 9
+[51] int64 = 300000000000
+[52] int64 = 9
+[53] float64 = 0
+[54] string = "service.name"
+[55] string = "service_name"
+[56] string = "service.name"
+[57] string = "service_name"
+[58] string = ""
+[59] string = "service_name"
+[60] string = "http_client_duration_exp_hist"
+[61] string = "http.client.duration.exp.hist"
+[62] string = "http.client.duration.exp/hist"
+[63] string = "http.client.duration.exp_hist"
+[64] string = "http.client.duration/exp/hist"
+[65] string = "http.client.duration/exp_hist"
+[66] string = "http.client.duration_exp.hist"
+[67] string = "http.client.duration_exp_hist"
+[68] string = "http.client/duration/exp/hist"
+[69] string = "http.client/duration/exp_hist"
+[70] string = "http.client/duration_exp_hist"
+[71] string = "http.client_duration.exp.hist"
+[72] string = "http.client_duration.exp_hist"
+[73] string = "http.client_duration_exp.hist"
+[74] string = "http.client_duration_exp_hist"
+[75] string = "http/client/duration/exp/hist"
+[76] string = "http/client/duration/exp_hist"
+[77] string = "http/client/duration_exp_hist"
+[78] string = "http/client_duration_exp_hist"
+[79] string = "http_client.duration.exp.hist"
+[80] string = "http_client.duration.exp_hist"
+[81] string = "http_client.duration_exp.hist"
+[82] string = "http_client.duration_exp_hist"
+[83] string = "http_client_duration.exp.hist"
+[84] string = "http_client_duration.exp_hist"
+[85] string = "http_client_duration_exp.hist"
+[86] string = "2026-01-01 00:00:01.000000000"
+[87] int64 = 9
+[88] string = "2026-01-01 00:00:01.000000000"
+[89] int64 = 9
+[90] int64 = 300000000000
+[91] int64 = 2
+-- chplan --
+HistogramProjection project=["" AS MetricName, Attributes AS Attributes, FnNow64(9) AS TimeUnix, 0 AS Value]
+  Project [gkey_0 AS Attributes, FnArraySum(_hq_merge_counts) AS HistogramCount, FnArraySum(_hq_merge_sums) AS HistogramSum, _hq_merged_scale AS HistogramScale, FnArraySum(_hq_merge_zero_counts) AS HistogramZeroCount, HistogramZeroThreshold AS HistogramZeroThreshold, FnArrayMin(FnArrayMap((s, off) -> FnBitShiftRight(off, (s - _hq_merged_scale)), _hq_scales, _hq_pos_offsets)) AS HistogramPositiveOffset, FnArrayMap(t -> FnArraySum(FnArrayMap((s, off, arr) -> FnArraySum(FnArrayMap(j -> FnIf((FnBitShiftRight((off + (j - 1)), (s - _hq_merged_scale)) = (FnArrayMin(FnArrayMap((sm, om) -> FnBitShiftRight(om, (sm - _hq_merged_scale)), _hq_scales, _hq_pos_offsets)) + t)), arr[j], 0), FnArrayEnumerate(arr))), _hq_scales, _hq_pos_offsets, _hq_pos_buckets)), FnRange(FnToUInt64(FnGreatest(0, ((FnArrayMax(FnArrayMap((sm, om, am) -> FnBitShiftRight((om + (FnLength(am) - 1)), (sm - _hq_merged_scale)), _hq_scales, _hq_pos_offsets, _hq_pos_buckets)) - FnArrayMin(FnArrayMap((sm, om) -> FnBitShiftRight(om, (sm - _hq_merged_scale)), _hq_scales, _hq_pos_offsets))) + 1))))) AS HistogramPositiveBucketCounts, FnArrayMin(FnArrayMap((s, off) -> FnBitShiftRight(off, (s - _hq_merged_scale)), _hq_scales, _hq_neg_offsets)) AS HistogramNegativeOffset, FnArrayMap(t -> FnArraySum(FnArrayMap((s, off, arr) -> FnArraySum(FnArrayMap(j -> FnIf((FnBitShiftRight((off + (j - 1)), (s - _hq_merged_scale)) = (FnArrayMin(FnArrayMap((sm, om) -> FnBitShiftRight(om, (sm - _hq_merged_scale)), _hq_scales, _hq_neg_offsets)) + t)), arr[j], 0), FnArrayEnumerate(arr))), _hq_scales, _hq_neg_offsets, _hq_neg_buckets)), FnRange(FnToUInt64(FnGreatest(0, ((FnArrayMax(FnArrayMap((sm, om, am) -> FnBitShiftRight((om + (FnLength(am) - 1)), (sm - _hq_merged_scale)), _hq_scales, _hq_neg_offsets, _hq_neg_buckets)) - FnArrayMin(FnArrayMap((sm, om) -> FnBitShiftRight(om, (sm - _hq_merged_scale)), _hq_scales, _hq_neg_offsets))) + 1))))) AS HistogramNegativeBucketCounts]
+    Aggregate groupBy=[Attributes AS gkey_0] funcs=[FnGroupArray(HistogramCount) AS _hq_merge_counts, FnGroupArray(HistogramSum) AS _hq_merge_sums, FnMin(HistogramScale) AS _hq_merged_scale, FnGroupArray(HistogramZeroCount) AS _hq_merge_zero_counts, FnMax(HistogramZeroThreshold) AS HistogramZeroThreshold, FnGroupArray(HistogramScale) AS _hq_scales, FnGroupArray(HistogramPositiveOffset) AS _hq_pos_offsets, FnGroupArray(HistogramPositiveBucketCounts) AS _hq_pos_buckets, FnGroupArray(HistogramNegativeOffset) AS _hq_neg_offsets, FnGroupArray(HistogramNegativeBucketCounts) AS _hq_neg_buckets, FnGroupArray(FnToString(FnMapSort(Attributes))) AS _hq_series_order_key] having=(FnCount() = 2)
+      UnionAll arms=2
+        HistogramProjection project=[MetricName AS MetricName, Attributes AS Attributes, FnNow64(9) AS TimeUnix, 0 AS Value]
+          Aggregate groupBy=[FnMapSort(FnMapMerge(FnMapUpdate(FnMapFromArrays(FnArrayMap(k -> FnRegexReplaceAll(k, "[^a-zA-Z0-9_]", "_"), FnMapKeys(FnMapFilter((k, v) -> (k NOT IN ("service.name", "service_name")), ResourceAttributes))), FnMapValues(FnMapFilter((k, v) -> (k NOT IN ("service.name", "service_name")), ResourceAttributes))), FnMapFromArrays(FnArrayMap(k -> FnRegexReplaceAll(k, "[^a-zA-Z0-9_]", "_"), FnMapKeys(Attributes)), FnMapValues(Attributes))), FnMapFilter((k, v) -> (v != ""), FnMap("service_name", FnToString(ServiceName))))) AS Attributes] funcs=[FnArgMax(MetricName, TimeUnix) AS MetricName, FnArgMax(Count, TimeUnix) AS Count, FnArgMax(Sum, TimeUnix) AS Sum, FnArgMax(Scale, TimeUnix) AS Scale, FnArgMax(ZeroCount, TimeUnix) AS ZeroCount, FnArgMax(PositiveOffset, TimeUnix) AS PositiveOffset, FnArgMax(PositiveBucketCounts, TimeUnix) AS PositiveBucketCounts, FnArgMax(NegativeOffset, TimeUnix) AS NegativeOffset, FnArgMax(NegativeBucketCounts, TimeUnix) AS NegativeBucketCounts]
+            Filter predicate=(((MetricName IN ("http_server_duration_exp_hist", "http.server.duration.exp.hist", "http.server.duration.exp/hist", "http.server.duration.exp_hist", "http.server.duration/exp/hist", "http.server.duration/exp_hist", "http.server.duration_exp.hist", "http.server.duration_exp_hist", "http.server/duration/exp/hist", "http.server/duration/exp_hist", "http.server/duration_exp_hist", "http.server_duration.exp.hist", "http.server_duration.exp_hist", "http.server_duration_exp.hist", "http.server_duration_exp_hist", "http/server/duration/exp/hist", "http/server/duration/exp_hist", "http/server/duration_exp_hist", "http/server_duration_exp_hist", "http_server.duration.exp.hist", "http_server.duration.exp_hist", "http_server.duration_exp.hist", "http_server.duration_exp_hist", "http_server_duration.exp.hist", "http_server_duration.exp_hist", "http_server_duration_exp.hist")) AND (TimeUnix <= FnToDateTime64("2026-01-01 00:00:01.000000000", 9))) AND (TimeUnix > (FnToDateTime64("2026-01-01 00:00:01.000000000", 9) - FnToIntervalNanosecond(300000000000))))
+              Scan(otel_metrics_exponential_histogram)
+        HistogramProjection project=[MetricName AS MetricName, Attributes AS Attributes, FnNow64(9) AS TimeUnix, 0 AS Value]
+          Aggregate groupBy=[FnMapSort(FnMapMerge(FnMapUpdate(FnMapFromArrays(FnArrayMap(k -> FnRegexReplaceAll(k, "[^a-zA-Z0-9_]", "_"), FnMapKeys(FnMapFilter((k, v) -> (k NOT IN ("service.name", "service_name")), ResourceAttributes))), FnMapValues(FnMapFilter((k, v) -> (k NOT IN ("service.name", "service_name")), ResourceAttributes))), FnMapFromArrays(FnArrayMap(k -> FnRegexReplaceAll(k, "[^a-zA-Z0-9_]", "_"), FnMapKeys(Attributes)), FnMapValues(Attributes))), FnMapFilter((k, v) -> (v != ""), FnMap("service_name", FnToString(ServiceName))))) AS Attributes] funcs=[FnArgMax(MetricName, TimeUnix) AS MetricName, FnArgMax(Count, TimeUnix) AS Count, FnArgMax(Sum, TimeUnix) AS Sum, FnArgMax(Scale, TimeUnix) AS Scale, FnArgMax(ZeroCount, TimeUnix) AS ZeroCount, FnArgMax(PositiveOffset, TimeUnix) AS PositiveOffset, FnArgMax(PositiveBucketCounts, TimeUnix) AS PositiveBucketCounts, FnArgMax(NegativeOffset, TimeUnix) AS NegativeOffset, FnArgMax(NegativeBucketCounts, TimeUnix) AS NegativeBucketCounts]
+            Filter predicate=(((MetricName IN ("http_client_duration_exp_hist", "http.client.duration.exp.hist", "http.client.duration.exp/hist", "http.client.duration.exp_hist", "http.client.duration/exp/hist", "http.client.duration/exp_hist", "http.client.duration_exp.hist", "http.client.duration_exp_hist", "http.client/duration/exp/hist", "http.client/duration/exp_hist", "http.client/duration_exp_hist", "http.client_duration.exp.hist", "http.client_duration.exp_hist", "http.client_duration_exp.hist", "http.client_duration_exp_hist", "http/client/duration/exp/hist", "http/client/duration/exp_hist", "http/client/duration_exp_hist", "http/client_duration_exp_hist", "http_client.duration.exp.hist", "http_client.duration.exp_hist", "http_client.duration_exp.hist", "http_client.duration_exp_hist", "http_client_duration.exp.hist", "http_client_duration.exp_hist", "http_client_duration_exp.hist")) AND (TimeUnix <= FnToDateTime64("2026-01-01 00:00:01.000000000", 9))) AND (TimeUnix > (FnToDateTime64("2026-01-01 00:00:01.000000000", 9) - FnToIntervalNanosecond(300000000000))))
+              Scan(otel_metrics_exponential_histogram)
+-- sql --
+SELECT ? AS `MetricName`, `Attributes` AS `Attributes`, now64(?) AS `TimeUnix`, toFloat64(?) AS `Value`, toFloat64(`HistogramCount`) AS `HistogramCount`, toFloat64(`HistogramSum`) AS `HistogramSum`, toInt32(`HistogramScale`) AS `HistogramScale`, toFloat64(`HistogramZeroThreshold`) AS `HistogramZeroThreshold`, toFloat64(`HistogramZeroCount`) AS `HistogramZeroCount`, toInt32(`HistogramPositiveOffset`) AS `HistogramPositiveOffset`, arrayMap(x -> toFloat64(x), `HistogramPositiveBucketCounts`) AS `HistogramPositiveBucketCounts`, toInt32(`HistogramNegativeOffset`) AS `HistogramNegativeOffset`, arrayMap(x -> toFloat64(x), `HistogramNegativeBucketCounts`) AS `HistogramNegativeBucketCounts` FROM (SELECT `gkey_0` AS `Attributes`, arraySum(`_hq_merge_counts`) AS `HistogramCount`, arraySum(`_hq_merge_sums`) AS `HistogramSum`, `_hq_merged_scale` AS `HistogramScale`, arraySum(`_hq_merge_zero_counts`) AS `HistogramZeroCount`, `HistogramZeroThreshold` AS `HistogramZeroThreshold`, arrayMin(arrayMap((s, off) -> bitShiftRight(off, (s - `_hq_merged_scale`)), `_hq_scales`, `_hq_pos_offsets`)) AS `HistogramPositiveOffset`, arrayMap(t -> arraySum(arrayMap((s, off, arr) -> arraySum(arrayMap(j -> if((bitShiftRight((off + (j - ?)), (s - `_hq_merged_scale`)) = (arrayMin(arrayMap((sm, om) -> bitShiftRight(om, (sm - `_hq_merged_scale`)), `_hq_scales`, `_hq_pos_offsets`)) + t)), arr[j], ?), arrayEnumerate(arr))), `_hq_scales`, `_hq_pos_offsets`, `_hq_pos_buckets`)), range(toUInt64(greatest(?, ((arrayMax(arrayMap((sm, om, am) -> bitShiftRight((om + (length(am) - ?)), (sm - `_hq_merged_scale`)), `_hq_scales`, `_hq_pos_offsets`, `_hq_pos_buckets`)) - arrayMin(arrayMap((sm, om) -> bitShiftRight(om, (sm - `_hq_merged_scale`)), `_hq_scales`, `_hq_pos_offsets`))) + ?))))) AS `HistogramPositiveBucketCounts`, arrayMin(arrayMap((s, off) -> bitShiftRight(off, (s - `_hq_merged_scale`)), `_hq_scales`, `_hq_neg_offsets`)) AS `HistogramNegativeOffset`, arrayMap(t -> arraySum(arrayMap((s, off, arr) -> arraySum(arrayMap(j -> if((bitShiftRight((off + (j - ?)), (s - `_hq_merged_scale`)) = (arrayMin(arrayMap((sm, om) -> bitShiftRight(om, (sm - `_hq_merged_scale`)), `_hq_scales`, `_hq_neg_offsets`)) + t)), arr[j], ?), arrayEnumerate(arr))), `_hq_scales`, `_hq_neg_offsets`, `_hq_neg_buckets`)), range(toUInt64(greatest(?, ((arrayMax(arrayMap((sm, om, am) -> bitShiftRight((om + (length(am) - ?)), (sm - `_hq_merged_scale`)), `_hq_scales`, `_hq_neg_offsets`, `_hq_neg_buckets`)) - arrayMin(arrayMap((sm, om) -> bitShiftRight(om, (sm - `_hq_merged_scale`)), `_hq_scales`, `_hq_neg_offsets`))) + ?))))) AS `HistogramNegativeBucketCounts` FROM (SELECT `Attributes` AS `gkey_0`, groupArray(`HistogramCount`) AS `_hq_merge_counts`, groupArray(`HistogramSum`) AS `_hq_merge_sums`, min(`HistogramScale`) AS `_hq_merged_scale`, groupArray(`HistogramZeroCount`) AS `_hq_merge_zero_counts`, max(`HistogramZeroThreshold`) AS `HistogramZeroThreshold`, groupArray(`HistogramScale`) AS `_hq_scales`, groupArray(`HistogramPositiveOffset`) AS `_hq_pos_offsets`, groupArray(`HistogramPositiveBucketCounts`) AS `_hq_pos_buckets`, groupArray(`HistogramNegativeOffset`) AS `_hq_neg_offsets`, groupArray(`HistogramNegativeBucketCounts`) AS `_hq_neg_buckets`, groupArray(toString(mapSort(`Attributes`))) AS `_hq_series_order_key` FROM ((SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, now64(?) AS `TimeUnix`, toFloat64(?) AS `Value`, toFloat64(`Count`) AS `HistogramCount`, toFloat64(`Sum`) AS `HistogramSum`, toInt32(`Scale`) AS `HistogramScale`, toFloat64(0.) AS `HistogramZeroThreshold`, toFloat64(`ZeroCount`) AS `HistogramZeroCount`, toInt32(`PositiveOffset`) AS `HistogramPositiveOffset`, arrayMap(x -> toFloat64(x), `PositiveBucketCounts`) AS `HistogramPositiveBucketCounts`, toInt32(`NegativeOffset`) AS `HistogramNegativeOffset`, arrayMap(x -> toFloat64(x), `NegativeBucketCounts`) AS `HistogramNegativeBucketCounts` FROM (SELECT mapSort(mapConcat(mapUpdate(mapFromArrays(arrayMap(k -> replaceRegexpAll(k, '[^a-zA-Z0-9_]', '_'), mapKeys(mapFilter((k, v) -> (k NOT IN (?, ?)), `ResourceAttributes`))), mapValues(mapFilter((k, v) -> (k NOT IN (?, ?)), `ResourceAttributes`))), mapFromArrays(arrayMap(k -> replaceRegexpAll(k, '[^a-zA-Z0-9_]', '_'), mapKeys(`Attributes`)), mapValues(`Attributes`))), mapFilter((k, v) -> (v != ?), map(?, toString(`ServiceName`))))) AS `Attributes`, argMax(`MetricName`, `TimeUnix`) AS `MetricName`, argMax(`Count`, `TimeUnix`) AS `Count`, argMax(`Sum`, `TimeUnix`) AS `Sum`, argMax(`Scale`, `TimeUnix`) AS `Scale`, argMax(`ZeroCount`, `TimeUnix`) AS `ZeroCount`, argMax(`PositiveOffset`, `TimeUnix`) AS `PositiveOffset`, argMax(`PositiveBucketCounts`, `TimeUnix`) AS `PositiveBucketCounts`, argMax(`NegativeOffset`, `TimeUnix`) AS `NegativeOffset`, argMax(`NegativeBucketCounts`, `TimeUnix`) AS `NegativeBucketCounts` FROM (SELECT * FROM `otel_metrics_exponential_histogram` PREWHERE (`MetricName` IN (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)) WHERE (`TimeUnix` <= toDateTime64(?, ?)) AND (`TimeUnix` > (toDateTime64(?, ?) - toIntervalNanosecond(?)))) GROUP BY `Attributes`)) UNION ALL (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, now64(?) AS `TimeUnix`, toFloat64(?) AS `Value`, toFloat64(`Count`) AS `HistogramCount`, toFloat64(`Sum`) AS `HistogramSum`, toInt32(`Scale`) AS `HistogramScale`, toFloat64(0.) AS `HistogramZeroThreshold`, toFloat64(`ZeroCount`) AS `HistogramZeroCount`, toInt32(`PositiveOffset`) AS `HistogramPositiveOffset`, arrayMap(x -> toFloat64(x), `PositiveBucketCounts`) AS `HistogramPositiveBucketCounts`, toInt32(`NegativeOffset`) AS `HistogramNegativeOffset`, arrayMap(x -> toFloat64(x), `NegativeBucketCounts`) AS `HistogramNegativeBucketCounts` FROM (SELECT mapSort(mapConcat(mapUpdate(mapFromArrays(arrayMap(k -> replaceRegexpAll(k, '[^a-zA-Z0-9_]', '_'), mapKeys(mapFilter((k, v) -> (k NOT IN (?, ?)), `ResourceAttributes`))), mapValues(mapFilter((k, v) -> (k NOT IN (?, ?)), `ResourceAttributes`))), mapFromArrays(arrayMap(k -> replaceRegexpAll(k, '[^a-zA-Z0-9_]', '_'), mapKeys(`Attributes`)), mapValues(`Attributes`))), mapFilter((k, v) -> (v != ?), map(?, toString(`ServiceName`))))) AS `Attributes`, argMax(`MetricName`, `TimeUnix`) AS `MetricName`, argMax(`Count`, `TimeUnix`) AS `Count`, argMax(`Sum`, `TimeUnix`) AS `Sum`, argMax(`Scale`, `TimeUnix`) AS `Scale`, argMax(`ZeroCount`, `TimeUnix`) AS `ZeroCount`, argMax(`PositiveOffset`, `TimeUnix`) AS `PositiveOffset`, argMax(`PositiveBucketCounts`, `TimeUnix`) AS `PositiveBucketCounts`, argMax(`NegativeOffset`, `TimeUnix`) AS `NegativeOffset`, argMax(`NegativeBucketCounts`, `TimeUnix`) AS `NegativeBucketCounts` FROM (SELECT * FROM `otel_metrics_exponential_histogram` PREWHERE (`MetricName` IN (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)) WHERE (`TimeUnix` <= toDateTime64(?, ?)) AND (`TimeUnix` > (toDateTime64(?, ?) - toIntervalNanosecond(?)))) GROUP BY `Attributes`))) GROUP BY `gkey_0` HAVING (count() = ?)))

--- a/test/spec/promql/exp_histogram_binop_add_range.txtar
+++ b/test/spec/promql/exp_histogram_binop_add_range.txtar
@@ -37,4 +37,110 @@ INSERT INTO otel_metrics_exponential_histogram VALUES
     ('http_server_duration_exp_hist', map('service', 'web'), toDateTime64('2026-01-01 00:00:00', 9), 9, 10.5, 0, 2, 1, [4, 5],    0, []),
     ('http_client_duration_exp_hist', map('service', 'api'), toDateTime64('2026-01-01 00:00:00', 9), 9, 10.5, 0, 2, 0, [4, 5, 6], 0, []);
 -- expected_rows --
-[]
+[
+  ["", {"service": "api"}, "2026-01-01T00:00:00Z", 0, 15, 53, 0, 0, 3, 0, [5,7,9], 0, []],
+  ["", {"service": "api"}, "2026-01-01T00:00:30Z", 0, 15, 53, 0, 0, 3, 0, [5,7,9], 0, []],
+  ["", {"service": "api"}, "2026-01-01T00:01:00Z", 0, 15, 53, 0, 0, 3, 0, [5,7,9], 0, []],
+  ["", {"service": "api"}, "2026-01-01T00:01:30Z", 0, 15, 53, 0, 0, 3, 0, [5,7,9], 0, []],
+  ["", {"service": "api"}, "2026-01-01T00:02:00Z", 0, 15, 53, 0, 0, 3, 0, [5,7,9], 0, []],
+  ["", {"service": "api"}, "2026-01-01T00:02:30Z", 0, 15, 53, 0, 0, 3, 0, [5,7,9], 0, []],
+  ["", {"service": "api"}, "2026-01-01T00:03:00Z", 0, 15, 53, 0, 0, 3, 0, [5,7,9], 0, []],
+  ["", {"service": "api"}, "2026-01-01T00:03:30Z", 0, 15, 53, 0, 0, 3, 0, [5,7,9], 0, []],
+  ["", {"service": "api"}, "2026-01-01T00:04:00Z", 0, 15, 53, 0, 0, 3, 0, [5,7,9], 0, []],
+  ["", {"service": "api"}, "2026-01-01T00:04:30Z", 0, 15, 53, 0, 0, 3, 0, [5,7,9], 0, []]
+]
+-- args --
+[0] string = ""
+[1] float64 = 0
+[2] int64 = 1
+[3] int64 = 0
+[4] int64 = 0
+[5] int64 = 1
+[6] int64 = 1
+[7] int64 = 1
+[8] int64 = 0
+[9] int64 = 0
+[10] int64 = 1
+[11] int64 = 1
+[12] float64 = 0
+[13] string = "service.name"
+[14] string = "service_name"
+[15] string = "service.name"
+[16] string = "service_name"
+[17] string = ""
+[18] string = "service_name"
+[19] string = "http_server_duration_exp_hist"
+[20] string = "http.server.duration.exp.hist"
+[21] string = "http.server.duration.exp/hist"
+[22] string = "http.server.duration.exp_hist"
+[23] string = "http.server.duration/exp/hist"
+[24] string = "http.server.duration/exp_hist"
+[25] string = "http.server.duration_exp.hist"
+[26] string = "http.server.duration_exp_hist"
+[27] string = "http.server/duration/exp/hist"
+[28] string = "http.server/duration/exp_hist"
+[29] string = "http.server/duration_exp_hist"
+[30] string = "http.server_duration.exp.hist"
+[31] string = "http.server_duration.exp_hist"
+[32] string = "http.server_duration_exp.hist"
+[33] string = "http.server_duration_exp_hist"
+[34] string = "http/server/duration/exp/hist"
+[35] string = "http/server/duration/exp_hist"
+[36] string = "http/server/duration_exp_hist"
+[37] string = "http/server_duration_exp_hist"
+[38] string = "http_server.duration.exp.hist"
+[39] string = "http_server.duration.exp_hist"
+[40] string = "http_server.duration_exp.hist"
+[41] string = "http_server.duration_exp_hist"
+[42] string = "http_server_duration.exp.hist"
+[43] string = "http_server_duration.exp_hist"
+[44] string = "http_server_duration_exp.hist"
+[45] float64 = 0
+[46] string = "service.name"
+[47] string = "service_name"
+[48] string = "service.name"
+[49] string = "service_name"
+[50] string = ""
+[51] string = "service_name"
+[52] string = "http_client_duration_exp_hist"
+[53] string = "http.client.duration.exp.hist"
+[54] string = "http.client.duration.exp/hist"
+[55] string = "http.client.duration.exp_hist"
+[56] string = "http.client.duration/exp/hist"
+[57] string = "http.client.duration/exp_hist"
+[58] string = "http.client.duration_exp.hist"
+[59] string = "http.client.duration_exp_hist"
+[60] string = "http.client/duration/exp/hist"
+[61] string = "http.client/duration/exp_hist"
+[62] string = "http.client/duration_exp_hist"
+[63] string = "http.client_duration.exp.hist"
+[64] string = "http.client_duration.exp_hist"
+[65] string = "http.client_duration_exp.hist"
+[66] string = "http.client_duration_exp_hist"
+[67] string = "http/client/duration/exp/hist"
+[68] string = "http/client/duration/exp_hist"
+[69] string = "http/client/duration_exp_hist"
+[70] string = "http/client_duration_exp_hist"
+[71] string = "http_client.duration.exp.hist"
+[72] string = "http_client.duration.exp_hist"
+[73] string = "http_client.duration_exp.hist"
+[74] string = "http_client.duration_exp_hist"
+[75] string = "http_client_duration.exp.hist"
+[76] string = "http_client_duration.exp_hist"
+[77] string = "http_client_duration_exp.hist"
+[78] int64 = 2
+-- chplan --
+HistogramProjection project=["" AS MetricName, Attributes AS Attributes, TimeUnix AS TimeUnix, 0 AS Value]
+  Project [TimeUnix AS TimeUnix, gkey_0 AS Attributes, FnArraySum(_hq_merge_counts) AS HistogramCount, FnArraySum(_hq_merge_sums) AS HistogramSum, _hq_merged_scale AS HistogramScale, FnArraySum(_hq_merge_zero_counts) AS HistogramZeroCount, HistogramZeroThreshold AS HistogramZeroThreshold, FnArrayMin(FnArrayMap((s, off) -> FnBitShiftRight(off, (s - _hq_merged_scale)), _hq_scales, _hq_pos_offsets)) AS HistogramPositiveOffset, FnArrayMap(t -> FnArraySum(FnArrayMap((s, off, arr) -> FnArraySum(FnArrayMap(j -> FnIf((FnBitShiftRight((off + (j - 1)), (s - _hq_merged_scale)) = (FnArrayMin(FnArrayMap((sm, om) -> FnBitShiftRight(om, (sm - _hq_merged_scale)), _hq_scales, _hq_pos_offsets)) + t)), arr[j], 0), FnArrayEnumerate(arr))), _hq_scales, _hq_pos_offsets, _hq_pos_buckets)), FnRange(FnToUInt64(FnGreatest(0, ((FnArrayMax(FnArrayMap((sm, om, am) -> FnBitShiftRight((om + (FnLength(am) - 1)), (sm - _hq_merged_scale)), _hq_scales, _hq_pos_offsets, _hq_pos_buckets)) - FnArrayMin(FnArrayMap((sm, om) -> FnBitShiftRight(om, (sm - _hq_merged_scale)), _hq_scales, _hq_pos_offsets))) + 1))))) AS HistogramPositiveBucketCounts, FnArrayMin(FnArrayMap((s, off) -> FnBitShiftRight(off, (s - _hq_merged_scale)), _hq_scales, _hq_neg_offsets)) AS HistogramNegativeOffset, FnArrayMap(t -> FnArraySum(FnArrayMap((s, off, arr) -> FnArraySum(FnArrayMap(j -> FnIf((FnBitShiftRight((off + (j - 1)), (s - _hq_merged_scale)) = (FnArrayMin(FnArrayMap((sm, om) -> FnBitShiftRight(om, (sm - _hq_merged_scale)), _hq_scales, _hq_neg_offsets)) + t)), arr[j], 0), FnArrayEnumerate(arr))), _hq_scales, _hq_neg_offsets, _hq_neg_buckets)), FnRange(FnToUInt64(FnGreatest(0, ((FnArrayMax(FnArrayMap((sm, om, am) -> FnBitShiftRight((om + (FnLength(am) - 1)), (sm - _hq_merged_scale)), _hq_scales, _hq_neg_offsets, _hq_neg_buckets)) - FnArrayMin(FnArrayMap((sm, om) -> FnBitShiftRight(om, (sm - _hq_merged_scale)), _hq_scales, _hq_neg_offsets))) + 1))))) AS HistogramNegativeBucketCounts]
+    Aggregate groupBy=[TimeUnix AS TimeUnix, Attributes AS gkey_0] funcs=[FnGroupArray(HistogramCount) AS _hq_merge_counts, FnGroupArray(HistogramSum) AS _hq_merge_sums, FnMin(HistogramScale) AS _hq_merged_scale, FnGroupArray(HistogramZeroCount) AS _hq_merge_zero_counts, FnMax(HistogramZeroThreshold) AS HistogramZeroThreshold, FnGroupArray(HistogramScale) AS _hq_scales, FnGroupArray(HistogramPositiveOffset) AS _hq_pos_offsets, FnGroupArray(HistogramPositiveBucketCounts) AS _hq_pos_buckets, FnGroupArray(HistogramNegativeOffset) AS _hq_neg_offsets, FnGroupArray(HistogramNegativeBucketCounts) AS _hq_neg_buckets, FnGroupArray(FnToString(FnMapSort(Attributes))) AS _hq_series_order_key] having=(FnCount() = 2)
+      UnionAll arms=2
+        HistogramProjection project=[MetricName AS MetricName, Attributes AS Attributes, anchor_ts AS TimeUnix, 0 AS Value]
+          RangeBucketFanout step=30s lookback=5m0s groupBy=[FnMapSort(FnMapMerge(FnMapUpdate(FnMapFromArrays(FnArrayMap(k -> FnRegexReplaceAll(k, "[^a-zA-Z0-9_]", "_"), FnMapKeys(FnMapFilter((k, v) -> (k NOT IN ("service.name", "service_name")), ResourceAttributes))), FnMapValues(FnMapFilter((k, v) -> (k NOT IN ("service.name", "service_name")), ResourceAttributes))), FnMapFromArrays(FnArrayMap(k -> FnRegexReplaceAll(k, "[^a-zA-Z0-9_]", "_"), FnMapKeys(Attributes)), FnMapValues(Attributes))), FnMapFilter((k, v) -> (v != ""), FnMap("service_name", FnToString(ServiceName))))) AS Attributes] funcs=[FnArgMax(MetricName, TimeUnix) AS MetricName, FnArgMax(Count, TimeUnix) AS Count, FnArgMax(Sum, TimeUnix) AS Sum, FnArgMax(Scale, TimeUnix) AS Scale, FnArgMax(ZeroCount, TimeUnix) AS ZeroCount, FnArgMax(PositiveOffset, TimeUnix) AS PositiveOffset, FnArgMax(PositiveBucketCounts, TimeUnix) AS PositiveBucketCounts, FnArgMax(NegativeOffset, TimeUnix) AS NegativeOffset, FnArgMax(NegativeBucketCounts, TimeUnix) AS NegativeBucketCounts] start=2026-01-01T00:00:00Z end=2026-01-01T00:05:00Z
+            Filter predicate=(MetricName IN ("http_server_duration_exp_hist", "http.server.duration.exp.hist", "http.server.duration.exp/hist", "http.server.duration.exp_hist", "http.server.duration/exp/hist", "http.server.duration/exp_hist", "http.server.duration_exp.hist", "http.server.duration_exp_hist", "http.server/duration/exp/hist", "http.server/duration/exp_hist", "http.server/duration_exp_hist", "http.server_duration.exp.hist", "http.server_duration.exp_hist", "http.server_duration_exp.hist", "http.server_duration_exp_hist", "http/server/duration/exp/hist", "http/server/duration/exp_hist", "http/server/duration_exp_hist", "http/server_duration_exp_hist", "http_server.duration.exp.hist", "http_server.duration.exp_hist", "http_server.duration_exp.hist", "http_server.duration_exp_hist", "http_server_duration.exp.hist", "http_server_duration.exp_hist", "http_server_duration_exp.hist"))
+              Scan(otel_metrics_exponential_histogram)
+        HistogramProjection project=[MetricName AS MetricName, Attributes AS Attributes, anchor_ts AS TimeUnix, 0 AS Value]
+          RangeBucketFanout step=30s lookback=5m0s groupBy=[FnMapSort(FnMapMerge(FnMapUpdate(FnMapFromArrays(FnArrayMap(k -> FnRegexReplaceAll(k, "[^a-zA-Z0-9_]", "_"), FnMapKeys(FnMapFilter((k, v) -> (k NOT IN ("service.name", "service_name")), ResourceAttributes))), FnMapValues(FnMapFilter((k, v) -> (k NOT IN ("service.name", "service_name")), ResourceAttributes))), FnMapFromArrays(FnArrayMap(k -> FnRegexReplaceAll(k, "[^a-zA-Z0-9_]", "_"), FnMapKeys(Attributes)), FnMapValues(Attributes))), FnMapFilter((k, v) -> (v != ""), FnMap("service_name", FnToString(ServiceName))))) AS Attributes] funcs=[FnArgMax(MetricName, TimeUnix) AS MetricName, FnArgMax(Count, TimeUnix) AS Count, FnArgMax(Sum, TimeUnix) AS Sum, FnArgMax(Scale, TimeUnix) AS Scale, FnArgMax(ZeroCount, TimeUnix) AS ZeroCount, FnArgMax(PositiveOffset, TimeUnix) AS PositiveOffset, FnArgMax(PositiveBucketCounts, TimeUnix) AS PositiveBucketCounts, FnArgMax(NegativeOffset, TimeUnix) AS NegativeOffset, FnArgMax(NegativeBucketCounts, TimeUnix) AS NegativeBucketCounts] start=2026-01-01T00:00:00Z end=2026-01-01T00:05:00Z
+            Filter predicate=(MetricName IN ("http_client_duration_exp_hist", "http.client.duration.exp.hist", "http.client.duration.exp/hist", "http.client.duration.exp_hist", "http.client.duration/exp/hist", "http.client.duration/exp_hist", "http.client.duration_exp.hist", "http.client.duration_exp_hist", "http.client/duration/exp/hist", "http.client/duration/exp_hist", "http.client/duration_exp_hist", "http.client_duration.exp.hist", "http.client_duration.exp_hist", "http.client_duration_exp.hist", "http.client_duration_exp_hist", "http/client/duration/exp/hist", "http/client/duration/exp_hist", "http/client/duration_exp_hist", "http/client_duration_exp_hist", "http_client.duration.exp.hist", "http_client.duration.exp_hist", "http_client.duration_exp.hist", "http_client.duration_exp_hist", "http_client_duration.exp.hist", "http_client_duration.exp_hist", "http_client_duration_exp.hist"))
+              Scan(otel_metrics_exponential_histogram)
+-- sql --
+SELECT ? AS `MetricName`, `Attributes` AS `Attributes`, `TimeUnix` AS `TimeUnix`, toFloat64(?) AS `Value`, toFloat64(`HistogramCount`) AS `HistogramCount`, toFloat64(`HistogramSum`) AS `HistogramSum`, toInt32(`HistogramScale`) AS `HistogramScale`, toFloat64(`HistogramZeroThreshold`) AS `HistogramZeroThreshold`, toFloat64(`HistogramZeroCount`) AS `HistogramZeroCount`, toInt32(`HistogramPositiveOffset`) AS `HistogramPositiveOffset`, arrayMap(x -> toFloat64(x), `HistogramPositiveBucketCounts`) AS `HistogramPositiveBucketCounts`, toInt32(`HistogramNegativeOffset`) AS `HistogramNegativeOffset`, arrayMap(x -> toFloat64(x), `HistogramNegativeBucketCounts`) AS `HistogramNegativeBucketCounts` FROM (SELECT `TimeUnix` AS `TimeUnix`, `gkey_0` AS `Attributes`, arraySum(`_hq_merge_counts`) AS `HistogramCount`, arraySum(`_hq_merge_sums`) AS `HistogramSum`, `_hq_merged_scale` AS `HistogramScale`, arraySum(`_hq_merge_zero_counts`) AS `HistogramZeroCount`, `HistogramZeroThreshold` AS `HistogramZeroThreshold`, arrayMin(arrayMap((s, off) -> bitShiftRight(off, (s - `_hq_merged_scale`)), `_hq_scales`, `_hq_pos_offsets`)) AS `HistogramPositiveOffset`, arrayMap(t -> arraySum(arrayMap((s, off, arr) -> arraySum(arrayMap(j -> if((bitShiftRight((off + (j - ?)), (s - `_hq_merged_scale`)) = (arrayMin(arrayMap((sm, om) -> bitShiftRight(om, (sm - `_hq_merged_scale`)), `_hq_scales`, `_hq_pos_offsets`)) + t)), arr[j], ?), arrayEnumerate(arr))), `_hq_scales`, `_hq_pos_offsets`, `_hq_pos_buckets`)), range(toUInt64(greatest(?, ((arrayMax(arrayMap((sm, om, am) -> bitShiftRight((om + (length(am) - ?)), (sm - `_hq_merged_scale`)), `_hq_scales`, `_hq_pos_offsets`, `_hq_pos_buckets`)) - arrayMin(arrayMap((sm, om) -> bitShiftRight(om, (sm - `_hq_merged_scale`)), `_hq_scales`, `_hq_pos_offsets`))) + ?))))) AS `HistogramPositiveBucketCounts`, arrayMin(arrayMap((s, off) -> bitShiftRight(off, (s - `_hq_merged_scale`)), `_hq_scales`, `_hq_neg_offsets`)) AS `HistogramNegativeOffset`, arrayMap(t -> arraySum(arrayMap((s, off, arr) -> arraySum(arrayMap(j -> if((bitShiftRight((off + (j - ?)), (s - `_hq_merged_scale`)) = (arrayMin(arrayMap((sm, om) -> bitShiftRight(om, (sm - `_hq_merged_scale`)), `_hq_scales`, `_hq_neg_offsets`)) + t)), arr[j], ?), arrayEnumerate(arr))), `_hq_scales`, `_hq_neg_offsets`, `_hq_neg_buckets`)), range(toUInt64(greatest(?, ((arrayMax(arrayMap((sm, om, am) -> bitShiftRight((om + (length(am) - ?)), (sm - `_hq_merged_scale`)), `_hq_scales`, `_hq_neg_offsets`, `_hq_neg_buckets`)) - arrayMin(arrayMap((sm, om) -> bitShiftRight(om, (sm - `_hq_merged_scale`)), `_hq_scales`, `_hq_neg_offsets`))) + ?))))) AS `HistogramNegativeBucketCounts` FROM (SELECT `TimeUnix` AS `TimeUnix`, `Attributes` AS `gkey_0`, groupArray(`HistogramCount`) AS `_hq_merge_counts`, groupArray(`HistogramSum`) AS `_hq_merge_sums`, min(`HistogramScale`) AS `_hq_merged_scale`, groupArray(`HistogramZeroCount`) AS `_hq_merge_zero_counts`, max(`HistogramZeroThreshold`) AS `HistogramZeroThreshold`, groupArray(`HistogramScale`) AS `_hq_scales`, groupArray(`HistogramPositiveOffset`) AS `_hq_pos_offsets`, groupArray(`HistogramPositiveBucketCounts`) AS `_hq_pos_buckets`, groupArray(`HistogramNegativeOffset`) AS `_hq_neg_offsets`, groupArray(`HistogramNegativeBucketCounts`) AS `_hq_neg_buckets`, groupArray(toString(mapSort(`Attributes`))) AS `_hq_series_order_key` FROM ((SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, `anchor_ts` AS `TimeUnix`, toFloat64(?) AS `Value`, toFloat64(`Count`) AS `HistogramCount`, toFloat64(`Sum`) AS `HistogramSum`, toInt32(`Scale`) AS `HistogramScale`, toFloat64(0.) AS `HistogramZeroThreshold`, toFloat64(`ZeroCount`) AS `HistogramZeroCount`, toInt32(`PositiveOffset`) AS `HistogramPositiveOffset`, arrayMap(x -> toFloat64(x), `PositiveBucketCounts`) AS `HistogramPositiveBucketCounts`, toInt32(`NegativeOffset`) AS `HistogramNegativeOffset`, arrayMap(x -> toFloat64(x), `NegativeBucketCounts`) AS `HistogramNegativeBucketCounts` FROM (SELECT anchor_ts AS `anchor_ts`, mapSort(mapConcat(mapUpdate(mapFromArrays(arrayMap(k -> replaceRegexpAll(k, '[^a-zA-Z0-9_]', '_'), mapKeys(mapFilter((k, v) -> (k NOT IN (?, ?)), `ResourceAttributes`))), mapValues(mapFilter((k, v) -> (k NOT IN (?, ?)), `ResourceAttributes`))), mapFromArrays(arrayMap(k -> replaceRegexpAll(k, '[^a-zA-Z0-9_]', '_'), mapKeys(`Attributes`)), mapValues(`Attributes`))), mapFilter((k, v) -> (v != ?), map(?, toString(`ServiceName`))))) AS `Attributes`, argMax(`MetricName`, `TimeUnix`) AS `MetricName`, argMax(`Count`, `TimeUnix`) AS `Count`, argMax(`Sum`, `TimeUnix`) AS `Sum`, argMax(`Scale`, `TimeUnix`) AS `Scale`, argMax(`ZeroCount`, `TimeUnix`) AS `ZeroCount`, argMax(`PositiveOffset`, `TimeUnix`) AS `PositiveOffset`, argMax(`PositiveBucketCounts`, `TimeUnix`) AS `PositiveBucketCounts`, argMax(`NegativeOffset`, `TimeUnix`) AS `NegativeOffset`, argMax(`NegativeBucketCounts`, `TimeUnix`) AS `NegativeBucketCounts` FROM (SELECT *, arrayJoin(arrayMap(i -> toDateTime64('2026-01-01 00:05:00.000000000', 9) - toIntervalNanosecond(i * 30000000000), range(greatest(0, intDiv(dateDiff('nanosecond', `TimeUnix`, toDateTime64('2026-01-01 00:05:00.000000000', 9)) - 300000000000, toInt64(30000000000)) - (modulo(dateDiff('nanosecond', `TimeUnix`, toDateTime64('2026-01-01 00:05:00.000000000', 9)) - 300000000000, toInt64(30000000000)) < 0) + 1), least(11, intDiv(dateDiff('nanosecond', `TimeUnix`, toDateTime64('2026-01-01 00:05:00.000000000', 9)), toInt64(30000000000)) - (modulo(dateDiff('nanosecond', `TimeUnix`, toDateTime64('2026-01-01 00:05:00.000000000', 9)), toInt64(30000000000)) < 0) + 1)))) AS anchor_ts FROM (SELECT * FROM `otel_metrics_exponential_histogram` WHERE (`MetricName` IN (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?))) WHERE `TimeUnix` > toDateTime64('2026-01-01 00:00:00.000000000', 9) - toIntervalNanosecond(300000000000) AND `TimeUnix` <= toDateTime64('2026-01-01 00:05:00.000000000', 9)) GROUP BY anchor_ts, `Attributes`)) UNION ALL (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, `anchor_ts` AS `TimeUnix`, toFloat64(?) AS `Value`, toFloat64(`Count`) AS `HistogramCount`, toFloat64(`Sum`) AS `HistogramSum`, toInt32(`Scale`) AS `HistogramScale`, toFloat64(0.) AS `HistogramZeroThreshold`, toFloat64(`ZeroCount`) AS `HistogramZeroCount`, toInt32(`PositiveOffset`) AS `HistogramPositiveOffset`, arrayMap(x -> toFloat64(x), `PositiveBucketCounts`) AS `HistogramPositiveBucketCounts`, toInt32(`NegativeOffset`) AS `HistogramNegativeOffset`, arrayMap(x -> toFloat64(x), `NegativeBucketCounts`) AS `HistogramNegativeBucketCounts` FROM (SELECT anchor_ts AS `anchor_ts`, mapSort(mapConcat(mapUpdate(mapFromArrays(arrayMap(k -> replaceRegexpAll(k, '[^a-zA-Z0-9_]', '_'), mapKeys(mapFilter((k, v) -> (k NOT IN (?, ?)), `ResourceAttributes`))), mapValues(mapFilter((k, v) -> (k NOT IN (?, ?)), `ResourceAttributes`))), mapFromArrays(arrayMap(k -> replaceRegexpAll(k, '[^a-zA-Z0-9_]', '_'), mapKeys(`Attributes`)), mapValues(`Attributes`))), mapFilter((k, v) -> (v != ?), map(?, toString(`ServiceName`))))) AS `Attributes`, argMax(`MetricName`, `TimeUnix`) AS `MetricName`, argMax(`Count`, `TimeUnix`) AS `Count`, argMax(`Sum`, `TimeUnix`) AS `Sum`, argMax(`Scale`, `TimeUnix`) AS `Scale`, argMax(`ZeroCount`, `TimeUnix`) AS `ZeroCount`, argMax(`PositiveOffset`, `TimeUnix`) AS `PositiveOffset`, argMax(`PositiveBucketCounts`, `TimeUnix`) AS `PositiveBucketCounts`, argMax(`NegativeOffset`, `TimeUnix`) AS `NegativeOffset`, argMax(`NegativeBucketCounts`, `TimeUnix`) AS `NegativeBucketCounts` FROM (SELECT *, arrayJoin(arrayMap(i -> toDateTime64('2026-01-01 00:05:00.000000000', 9) - toIntervalNanosecond(i * 30000000000), range(greatest(0, intDiv(dateDiff('nanosecond', `TimeUnix`, toDateTime64('2026-01-01 00:05:00.000000000', 9)) - 300000000000, toInt64(30000000000)) - (modulo(dateDiff('nanosecond', `TimeUnix`, toDateTime64('2026-01-01 00:05:00.000000000', 9)) - 300000000000, toInt64(30000000000)) < 0) + 1), least(11, intDiv(dateDiff('nanosecond', `TimeUnix`, toDateTime64('2026-01-01 00:05:00.000000000', 9)), toInt64(30000000000)) - (modulo(dateDiff('nanosecond', `TimeUnix`, toDateTime64('2026-01-01 00:05:00.000000000', 9)), toInt64(30000000000)) < 0) + 1)))) AS anchor_ts FROM (SELECT * FROM `otel_metrics_exponential_histogram` WHERE (`MetricName` IN (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?))) WHERE `TimeUnix` > toDateTime64('2026-01-01 00:00:00.000000000', 9) - toIntervalNanosecond(300000000000) AND `TimeUnix` <= toDateTime64('2026-01-01 00:05:00.000000000', 9)) GROUP BY anchor_ts, `Attributes`))) GROUP BY `TimeUnix`, `gkey_0` HAVING (count() = ?)))

--- a/test/spec/promql/exp_histogram_binop_add_range.txtar
+++ b/test/spec/promql/exp_histogram_binop_add_range.txtar
@@ -1,0 +1,40 @@
+-- query.promql --
+http_server_duration_exp_hist + http_client_duration_exp_hist
+-- parity --
+oracle: prometheus
+endpoint: /api/v1/query_range
+scope: full
+-- range_step --
+30s
+-- seed --
+CREATE TABLE otel_metrics_exponential_histogram (
+    MetricName String,
+    Attributes Map(String, String),
+    TimeUnix DateTime64(9),
+    Count UInt64,
+    Sum Float64,
+    Scale Int32,
+    ZeroCount UInt64,
+    PositiveOffset Int32,
+    PositiveBucketCounts Array(UInt64),
+    NegativeOffset Int32,
+    NegativeBucketCounts Array(UInt64)
+) ENGINE = MergeTree ORDER BY (MetricName, Attributes, TimeUnix);
+-- query_range shape: each step anchor resolves its own per-series
+-- staleness lookback first (the bare-selector range fanout each operand's
+-- own histogram-valued lowering already builds), and only then joins +
+-- merges the two operands within that anchor — the same per-anchor
+-- broadcast exp_histogram_sum_range.txtar shows for a cross-series
+-- sum(), with a two-operand binop on top instead.
+--
+--   merged = [1,2,3] + [4,5,6] = [5,7,9] at Scale=0, PositiveOffset=0.
+--   Count 6+9=15, Sum 42.5+10.5=53, ZeroCount 1+2=3.
+--
+-- `web` exists only on the server side, so it never matches and never
+-- reaches the output at any anchor.
+INSERT INTO otel_metrics_exponential_histogram VALUES
+    ('http_server_duration_exp_hist', map('service', 'api'), toDateTime64('2026-01-01 00:00:00', 9), 6, 42.5, 0, 1, 0, [1, 2, 3], 0, []),
+    ('http_server_duration_exp_hist', map('service', 'web'), toDateTime64('2026-01-01 00:00:00', 9), 9, 10.5, 0, 2, 1, [4, 5],    0, []),
+    ('http_client_duration_exp_hist', map('service', 'api'), toDateTime64('2026-01-01 00:00:00', 9), 9, 10.5, 0, 2, 0, [4, 5, 6], 0, []);
+-- expected_rows --
+[]

--- a/test/spec/promql/exp_histogram_binop_sub.txtar
+++ b/test/spec/promql/exp_histogram_binop_sub.txtar
@@ -1,0 +1,32 @@
+-- query.promql --
+http_server_duration_exp_hist - http_client_duration_exp_hist
+-- parity --
+oracle: prometheus
+endpoint: /api/v1/query
+scope: full
+-- seed --
+CREATE TABLE otel_metrics_exponential_histogram (
+    MetricName String,
+    Attributes Map(String, String),
+    TimeUnix DateTime64(9),
+    Count UInt64,
+    Sum Float64,
+    Scale Int32,
+    ZeroCount UInt64,
+    PositiveOffset Int32,
+    PositiveBucketCounts Array(UInt64),
+    NegativeOffset Int32,
+    NegativeBucketCounts Array(UInt64)
+) ENGINE = MergeTree ORDER BY (MetricName, Attributes, TimeUnix);
+-- Binary `-` between two exp-histogram metrics (cerberus issue #2263).
+-- Reference Prometheus's FloatHistogram.Sub is Add with the second
+-- operand's counts negated first — both series here share Scale=0 /
+-- PositiveOffset=0 so the fold is a plain element-wise subtraction:
+--
+--   Count 20-8=12, Sum 5.0-1.0=4.0, ZeroCount 2-1=1,
+--   PositiveBucketCounts [10,6] - [4,2] = [6,4].
+INSERT INTO otel_metrics_exponential_histogram VALUES
+    ('http_server_duration_exp_hist', map('series', 'only'), toDateTime64('2026-01-01 00:00:00', 9), 20, 5.0, 0, 2, 0, [10, 6], 0, []),
+    ('http_client_duration_exp_hist', map('series', 'only'), toDateTime64('2026-01-01 00:00:00', 9), 8,  1.0, 0, 1, 0, [4, 2],  0, []);
+-- expected_rows --
+[]

--- a/test/spec/promql/exp_histogram_binop_sub.txtar
+++ b/test/spec/promql/exp_histogram_binop_sub.txtar
@@ -29,4 +29,123 @@ INSERT INTO otel_metrics_exponential_histogram VALUES
     ('http_server_duration_exp_hist', map('series', 'only'), toDateTime64('2026-01-01 00:00:00', 9), 20, 5.0, 0, 2, 0, [10, 6], 0, []),
     ('http_client_duration_exp_hist', map('series', 'only'), toDateTime64('2026-01-01 00:00:00', 9), 8,  1.0, 0, 1, 0, [4, 2],  0, []);
 -- expected_rows --
-[]
+[
+  ["", {"series": "only"}, "2026-01-01T00:00:01Z", 0, 12, 4, 0, 0, 1, 0, [6,4], 0, []]
+]
+-- args --
+[0] string = ""
+[1] int64 = 9
+[2] float64 = 0
+[3] int64 = 1
+[4] int64 = 0
+[5] int64 = 0
+[6] int64 = 1
+[7] int64 = 1
+[8] int64 = 1
+[9] int64 = 0
+[10] int64 = 0
+[11] int64 = 1
+[12] int64 = 1
+[13] int64 = 9
+[14] float64 = 0
+[15] string = "service.name"
+[16] string = "service_name"
+[17] string = "service.name"
+[18] string = "service_name"
+[19] string = ""
+[20] string = "service_name"
+[21] string = "http_server_duration_exp_hist"
+[22] string = "http.server.duration.exp.hist"
+[23] string = "http.server.duration.exp/hist"
+[24] string = "http.server.duration.exp_hist"
+[25] string = "http.server.duration/exp/hist"
+[26] string = "http.server.duration/exp_hist"
+[27] string = "http.server.duration_exp.hist"
+[28] string = "http.server.duration_exp_hist"
+[29] string = "http.server/duration/exp/hist"
+[30] string = "http.server/duration/exp_hist"
+[31] string = "http.server/duration_exp_hist"
+[32] string = "http.server_duration.exp.hist"
+[33] string = "http.server_duration.exp_hist"
+[34] string = "http.server_duration_exp.hist"
+[35] string = "http.server_duration_exp_hist"
+[36] string = "http/server/duration/exp/hist"
+[37] string = "http/server/duration/exp_hist"
+[38] string = "http/server/duration_exp_hist"
+[39] string = "http/server_duration_exp_hist"
+[40] string = "http_server.duration.exp.hist"
+[41] string = "http_server.duration.exp_hist"
+[42] string = "http_server.duration_exp.hist"
+[43] string = "http_server.duration_exp_hist"
+[44] string = "http_server_duration.exp.hist"
+[45] string = "http_server_duration.exp_hist"
+[46] string = "http_server_duration_exp.hist"
+[47] string = "2026-01-01 00:00:01.000000000"
+[48] int64 = 9
+[49] string = "2026-01-01 00:00:01.000000000"
+[50] int64 = 9
+[51] int64 = 300000000000
+[52] string = ""
+[53] float64 = 0
+[54] float64 = -1
+[55] float64 = -1
+[56] float64 = -1
+[57] float64 = -1
+[58] float64 = -1
+[59] int64 = 9
+[60] float64 = 0
+[61] string = "service.name"
+[62] string = "service_name"
+[63] string = "service.name"
+[64] string = "service_name"
+[65] string = ""
+[66] string = "service_name"
+[67] string = "http_client_duration_exp_hist"
+[68] string = "http.client.duration.exp.hist"
+[69] string = "http.client.duration.exp/hist"
+[70] string = "http.client.duration.exp_hist"
+[71] string = "http.client.duration/exp/hist"
+[72] string = "http.client.duration/exp_hist"
+[73] string = "http.client.duration_exp.hist"
+[74] string = "http.client.duration_exp_hist"
+[75] string = "http.client/duration/exp/hist"
+[76] string = "http.client/duration/exp_hist"
+[77] string = "http.client/duration_exp_hist"
+[78] string = "http.client_duration.exp.hist"
+[79] string = "http.client_duration.exp_hist"
+[80] string = "http.client_duration_exp.hist"
+[81] string = "http.client_duration_exp_hist"
+[82] string = "http/client/duration/exp/hist"
+[83] string = "http/client/duration/exp_hist"
+[84] string = "http/client/duration_exp_hist"
+[85] string = "http/client_duration_exp_hist"
+[86] string = "http_client.duration.exp.hist"
+[87] string = "http_client.duration.exp_hist"
+[88] string = "http_client.duration_exp.hist"
+[89] string = "http_client.duration_exp_hist"
+[90] string = "http_client_duration.exp.hist"
+[91] string = "http_client_duration.exp_hist"
+[92] string = "http_client_duration_exp.hist"
+[93] string = "2026-01-01 00:00:01.000000000"
+[94] int64 = 9
+[95] string = "2026-01-01 00:00:01.000000000"
+[96] int64 = 9
+[97] int64 = 300000000000
+[98] int64 = 2
+-- chplan --
+HistogramProjection project=["" AS MetricName, Attributes AS Attributes, FnNow64(9) AS TimeUnix, 0 AS Value]
+  Project [gkey_0 AS Attributes, FnArraySum(_hq_merge_counts) AS HistogramCount, FnArraySum(_hq_merge_sums) AS HistogramSum, _hq_merged_scale AS HistogramScale, FnArraySum(_hq_merge_zero_counts) AS HistogramZeroCount, HistogramZeroThreshold AS HistogramZeroThreshold, FnArrayMin(FnArrayMap((s, off) -> FnBitShiftRight(off, (s - _hq_merged_scale)), _hq_scales, _hq_pos_offsets)) AS HistogramPositiveOffset, FnArrayMap(t -> FnArraySum(FnArrayMap((s, off, arr) -> FnArraySum(FnArrayMap(j -> FnIf((FnBitShiftRight((off + (j - 1)), (s - _hq_merged_scale)) = (FnArrayMin(FnArrayMap((sm, om) -> FnBitShiftRight(om, (sm - _hq_merged_scale)), _hq_scales, _hq_pos_offsets)) + t)), arr[j], 0), FnArrayEnumerate(arr))), _hq_scales, _hq_pos_offsets, _hq_pos_buckets)), FnRange(FnToUInt64(FnGreatest(0, ((FnArrayMax(FnArrayMap((sm, om, am) -> FnBitShiftRight((om + (FnLength(am) - 1)), (sm - _hq_merged_scale)), _hq_scales, _hq_pos_offsets, _hq_pos_buckets)) - FnArrayMin(FnArrayMap((sm, om) -> FnBitShiftRight(om, (sm - _hq_merged_scale)), _hq_scales, _hq_pos_offsets))) + 1))))) AS HistogramPositiveBucketCounts, FnArrayMin(FnArrayMap((s, off) -> FnBitShiftRight(off, (s - _hq_merged_scale)), _hq_scales, _hq_neg_offsets)) AS HistogramNegativeOffset, FnArrayMap(t -> FnArraySum(FnArrayMap((s, off, arr) -> FnArraySum(FnArrayMap(j -> FnIf((FnBitShiftRight((off + (j - 1)), (s - _hq_merged_scale)) = (FnArrayMin(FnArrayMap((sm, om) -> FnBitShiftRight(om, (sm - _hq_merged_scale)), _hq_scales, _hq_neg_offsets)) + t)), arr[j], 0), FnArrayEnumerate(arr))), _hq_scales, _hq_neg_offsets, _hq_neg_buckets)), FnRange(FnToUInt64(FnGreatest(0, ((FnArrayMax(FnArrayMap((sm, om, am) -> FnBitShiftRight((om + (FnLength(am) - 1)), (sm - _hq_merged_scale)), _hq_scales, _hq_neg_offsets, _hq_neg_buckets)) - FnArrayMin(FnArrayMap((sm, om) -> FnBitShiftRight(om, (sm - _hq_merged_scale)), _hq_scales, _hq_neg_offsets))) + 1))))) AS HistogramNegativeBucketCounts]
+    Aggregate groupBy=[Attributes AS gkey_0] funcs=[FnGroupArray(HistogramCount) AS _hq_merge_counts, FnGroupArray(HistogramSum) AS _hq_merge_sums, FnMin(HistogramScale) AS _hq_merged_scale, FnGroupArray(HistogramZeroCount) AS _hq_merge_zero_counts, FnMax(HistogramZeroThreshold) AS HistogramZeroThreshold, FnGroupArray(HistogramScale) AS _hq_scales, FnGroupArray(HistogramPositiveOffset) AS _hq_pos_offsets, FnGroupArray(HistogramPositiveBucketCounts) AS _hq_pos_buckets, FnGroupArray(HistogramNegativeOffset) AS _hq_neg_offsets, FnGroupArray(HistogramNegativeBucketCounts) AS _hq_neg_buckets, FnGroupArray(FnToString(FnMapSort(Attributes))) AS _hq_series_order_key] having=(FnCount() = 2)
+      UnionAll arms=2
+        HistogramProjection project=[MetricName AS MetricName, Attributes AS Attributes, FnNow64(9) AS TimeUnix, 0 AS Value]
+          Aggregate groupBy=[FnMapSort(FnMapMerge(FnMapUpdate(FnMapFromArrays(FnArrayMap(k -> FnRegexReplaceAll(k, "[^a-zA-Z0-9_]", "_"), FnMapKeys(FnMapFilter((k, v) -> (k NOT IN ("service.name", "service_name")), ResourceAttributes))), FnMapValues(FnMapFilter((k, v) -> (k NOT IN ("service.name", "service_name")), ResourceAttributes))), FnMapFromArrays(FnArrayMap(k -> FnRegexReplaceAll(k, "[^a-zA-Z0-9_]", "_"), FnMapKeys(Attributes)), FnMapValues(Attributes))), FnMapFilter((k, v) -> (v != ""), FnMap("service_name", FnToString(ServiceName))))) AS Attributes] funcs=[FnArgMax(MetricName, TimeUnix) AS MetricName, FnArgMax(Count, TimeUnix) AS Count, FnArgMax(Sum, TimeUnix) AS Sum, FnArgMax(Scale, TimeUnix) AS Scale, FnArgMax(ZeroCount, TimeUnix) AS ZeroCount, FnArgMax(PositiveOffset, TimeUnix) AS PositiveOffset, FnArgMax(PositiveBucketCounts, TimeUnix) AS PositiveBucketCounts, FnArgMax(NegativeOffset, TimeUnix) AS NegativeOffset, FnArgMax(NegativeBucketCounts, TimeUnix) AS NegativeBucketCounts]
+            Filter predicate=(((MetricName IN ("http_server_duration_exp_hist", "http.server.duration.exp.hist", "http.server.duration.exp/hist", "http.server.duration.exp_hist", "http.server.duration/exp/hist", "http.server.duration/exp_hist", "http.server.duration_exp.hist", "http.server.duration_exp_hist", "http.server/duration/exp/hist", "http.server/duration/exp_hist", "http.server/duration_exp_hist", "http.server_duration.exp.hist", "http.server_duration.exp_hist", "http.server_duration_exp.hist", "http.server_duration_exp_hist", "http/server/duration/exp/hist", "http/server/duration/exp_hist", "http/server/duration_exp_hist", "http/server_duration_exp_hist", "http_server.duration.exp.hist", "http_server.duration.exp_hist", "http_server.duration_exp.hist", "http_server.duration_exp_hist", "http_server_duration.exp.hist", "http_server_duration.exp_hist", "http_server_duration_exp.hist")) AND (TimeUnix <= FnToDateTime64("2026-01-01 00:00:01.000000000", 9))) AND (TimeUnix > (FnToDateTime64("2026-01-01 00:00:01.000000000", 9) - FnToIntervalNanosecond(300000000000))))
+              Scan(otel_metrics_exponential_histogram)
+        HistogramProjection project=["" AS MetricName, Attributes AS Attributes, TimeUnix AS TimeUnix, 0 AS Value]
+          Project [Attributes AS Attributes, TimeUnix AS TimeUnix, HistogramScale AS HistogramScale, HistogramZeroThreshold AS HistogramZeroThreshold, HistogramPositiveOffset AS HistogramPositiveOffset, HistogramNegativeOffset AS HistogramNegativeOffset, (HistogramCount * -1) AS HistogramCount, (HistogramSum * -1) AS HistogramSum, (HistogramZeroCount * -1) AS HistogramZeroCount, FnArrayMap(b -> (b * -1), HistogramPositiveBucketCounts) AS HistogramPositiveBucketCounts, FnArrayMap(b -> (b * -1), HistogramNegativeBucketCounts) AS HistogramNegativeBucketCounts]
+            HistogramProjection project=[MetricName AS MetricName, Attributes AS Attributes, FnNow64(9) AS TimeUnix, 0 AS Value]
+              Aggregate groupBy=[FnMapSort(FnMapMerge(FnMapUpdate(FnMapFromArrays(FnArrayMap(k -> FnRegexReplaceAll(k, "[^a-zA-Z0-9_]", "_"), FnMapKeys(FnMapFilter((k, v) -> (k NOT IN ("service.name", "service_name")), ResourceAttributes))), FnMapValues(FnMapFilter((k, v) -> (k NOT IN ("service.name", "service_name")), ResourceAttributes))), FnMapFromArrays(FnArrayMap(k -> FnRegexReplaceAll(k, "[^a-zA-Z0-9_]", "_"), FnMapKeys(Attributes)), FnMapValues(Attributes))), FnMapFilter((k, v) -> (v != ""), FnMap("service_name", FnToString(ServiceName))))) AS Attributes] funcs=[FnArgMax(MetricName, TimeUnix) AS MetricName, FnArgMax(Count, TimeUnix) AS Count, FnArgMax(Sum, TimeUnix) AS Sum, FnArgMax(Scale, TimeUnix) AS Scale, FnArgMax(ZeroCount, TimeUnix) AS ZeroCount, FnArgMax(PositiveOffset, TimeUnix) AS PositiveOffset, FnArgMax(PositiveBucketCounts, TimeUnix) AS PositiveBucketCounts, FnArgMax(NegativeOffset, TimeUnix) AS NegativeOffset, FnArgMax(NegativeBucketCounts, TimeUnix) AS NegativeBucketCounts]
+                Filter predicate=(((MetricName IN ("http_client_duration_exp_hist", "http.client.duration.exp.hist", "http.client.duration.exp/hist", "http.client.duration.exp_hist", "http.client.duration/exp/hist", "http.client.duration/exp_hist", "http.client.duration_exp.hist", "http.client.duration_exp_hist", "http.client/duration/exp/hist", "http.client/duration/exp_hist", "http.client/duration_exp_hist", "http.client_duration.exp.hist", "http.client_duration.exp_hist", "http.client_duration_exp.hist", "http.client_duration_exp_hist", "http/client/duration/exp/hist", "http/client/duration/exp_hist", "http/client/duration_exp_hist", "http/client_duration_exp_hist", "http_client.duration.exp.hist", "http_client.duration.exp_hist", "http_client.duration_exp.hist", "http_client.duration_exp_hist", "http_client_duration.exp.hist", "http_client_duration.exp_hist", "http_client_duration_exp.hist")) AND (TimeUnix <= FnToDateTime64("2026-01-01 00:00:01.000000000", 9))) AND (TimeUnix > (FnToDateTime64("2026-01-01 00:00:01.000000000", 9) - FnToIntervalNanosecond(300000000000))))
+                  Scan(otel_metrics_exponential_histogram)
+-- sql --
+SELECT ? AS `MetricName`, `Attributes` AS `Attributes`, now64(?) AS `TimeUnix`, toFloat64(?) AS `Value`, toFloat64(`HistogramCount`) AS `HistogramCount`, toFloat64(`HistogramSum`) AS `HistogramSum`, toInt32(`HistogramScale`) AS `HistogramScale`, toFloat64(`HistogramZeroThreshold`) AS `HistogramZeroThreshold`, toFloat64(`HistogramZeroCount`) AS `HistogramZeroCount`, toInt32(`HistogramPositiveOffset`) AS `HistogramPositiveOffset`, arrayMap(x -> toFloat64(x), `HistogramPositiveBucketCounts`) AS `HistogramPositiveBucketCounts`, toInt32(`HistogramNegativeOffset`) AS `HistogramNegativeOffset`, arrayMap(x -> toFloat64(x), `HistogramNegativeBucketCounts`) AS `HistogramNegativeBucketCounts` FROM (SELECT `gkey_0` AS `Attributes`, arraySum(`_hq_merge_counts`) AS `HistogramCount`, arraySum(`_hq_merge_sums`) AS `HistogramSum`, `_hq_merged_scale` AS `HistogramScale`, arraySum(`_hq_merge_zero_counts`) AS `HistogramZeroCount`, `HistogramZeroThreshold` AS `HistogramZeroThreshold`, arrayMin(arrayMap((s, off) -> bitShiftRight(off, (s - `_hq_merged_scale`)), `_hq_scales`, `_hq_pos_offsets`)) AS `HistogramPositiveOffset`, arrayMap(t -> arraySum(arrayMap((s, off, arr) -> arraySum(arrayMap(j -> if((bitShiftRight((off + (j - ?)), (s - `_hq_merged_scale`)) = (arrayMin(arrayMap((sm, om) -> bitShiftRight(om, (sm - `_hq_merged_scale`)), `_hq_scales`, `_hq_pos_offsets`)) + t)), arr[j], ?), arrayEnumerate(arr))), `_hq_scales`, `_hq_pos_offsets`, `_hq_pos_buckets`)), range(toUInt64(greatest(?, ((arrayMax(arrayMap((sm, om, am) -> bitShiftRight((om + (length(am) - ?)), (sm - `_hq_merged_scale`)), `_hq_scales`, `_hq_pos_offsets`, `_hq_pos_buckets`)) - arrayMin(arrayMap((sm, om) -> bitShiftRight(om, (sm - `_hq_merged_scale`)), `_hq_scales`, `_hq_pos_offsets`))) + ?))))) AS `HistogramPositiveBucketCounts`, arrayMin(arrayMap((s, off) -> bitShiftRight(off, (s - `_hq_merged_scale`)), `_hq_scales`, `_hq_neg_offsets`)) AS `HistogramNegativeOffset`, arrayMap(t -> arraySum(arrayMap((s, off, arr) -> arraySum(arrayMap(j -> if((bitShiftRight((off + (j - ?)), (s - `_hq_merged_scale`)) = (arrayMin(arrayMap((sm, om) -> bitShiftRight(om, (sm - `_hq_merged_scale`)), `_hq_scales`, `_hq_neg_offsets`)) + t)), arr[j], ?), arrayEnumerate(arr))), `_hq_scales`, `_hq_neg_offsets`, `_hq_neg_buckets`)), range(toUInt64(greatest(?, ((arrayMax(arrayMap((sm, om, am) -> bitShiftRight((om + (length(am) - ?)), (sm - `_hq_merged_scale`)), `_hq_scales`, `_hq_neg_offsets`, `_hq_neg_buckets`)) - arrayMin(arrayMap((sm, om) -> bitShiftRight(om, (sm - `_hq_merged_scale`)), `_hq_scales`, `_hq_neg_offsets`))) + ?))))) AS `HistogramNegativeBucketCounts` FROM (SELECT `Attributes` AS `gkey_0`, groupArray(`HistogramCount`) AS `_hq_merge_counts`, groupArray(`HistogramSum`) AS `_hq_merge_sums`, min(`HistogramScale`) AS `_hq_merged_scale`, groupArray(`HistogramZeroCount`) AS `_hq_merge_zero_counts`, max(`HistogramZeroThreshold`) AS `HistogramZeroThreshold`, groupArray(`HistogramScale`) AS `_hq_scales`, groupArray(`HistogramPositiveOffset`) AS `_hq_pos_offsets`, groupArray(`HistogramPositiveBucketCounts`) AS `_hq_pos_buckets`, groupArray(`HistogramNegativeOffset`) AS `_hq_neg_offsets`, groupArray(`HistogramNegativeBucketCounts`) AS `_hq_neg_buckets`, groupArray(toString(mapSort(`Attributes`))) AS `_hq_series_order_key` FROM ((SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, now64(?) AS `TimeUnix`, toFloat64(?) AS `Value`, toFloat64(`Count`) AS `HistogramCount`, toFloat64(`Sum`) AS `HistogramSum`, toInt32(`Scale`) AS `HistogramScale`, toFloat64(0.) AS `HistogramZeroThreshold`, toFloat64(`ZeroCount`) AS `HistogramZeroCount`, toInt32(`PositiveOffset`) AS `HistogramPositiveOffset`, arrayMap(x -> toFloat64(x), `PositiveBucketCounts`) AS `HistogramPositiveBucketCounts`, toInt32(`NegativeOffset`) AS `HistogramNegativeOffset`, arrayMap(x -> toFloat64(x), `NegativeBucketCounts`) AS `HistogramNegativeBucketCounts` FROM (SELECT mapSort(mapConcat(mapUpdate(mapFromArrays(arrayMap(k -> replaceRegexpAll(k, '[^a-zA-Z0-9_]', '_'), mapKeys(mapFilter((k, v) -> (k NOT IN (?, ?)), `ResourceAttributes`))), mapValues(mapFilter((k, v) -> (k NOT IN (?, ?)), `ResourceAttributes`))), mapFromArrays(arrayMap(k -> replaceRegexpAll(k, '[^a-zA-Z0-9_]', '_'), mapKeys(`Attributes`)), mapValues(`Attributes`))), mapFilter((k, v) -> (v != ?), map(?, toString(`ServiceName`))))) AS `Attributes`, argMax(`MetricName`, `TimeUnix`) AS `MetricName`, argMax(`Count`, `TimeUnix`) AS `Count`, argMax(`Sum`, `TimeUnix`) AS `Sum`, argMax(`Scale`, `TimeUnix`) AS `Scale`, argMax(`ZeroCount`, `TimeUnix`) AS `ZeroCount`, argMax(`PositiveOffset`, `TimeUnix`) AS `PositiveOffset`, argMax(`PositiveBucketCounts`, `TimeUnix`) AS `PositiveBucketCounts`, argMax(`NegativeOffset`, `TimeUnix`) AS `NegativeOffset`, argMax(`NegativeBucketCounts`, `TimeUnix`) AS `NegativeBucketCounts` FROM (SELECT * FROM `otel_metrics_exponential_histogram` PREWHERE (`MetricName` IN (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)) WHERE (`TimeUnix` <= toDateTime64(?, ?)) AND (`TimeUnix` > (toDateTime64(?, ?) - toIntervalNanosecond(?)))) GROUP BY `Attributes`)) UNION ALL (SELECT ? AS `MetricName`, `Attributes` AS `Attributes`, `TimeUnix` AS `TimeUnix`, toFloat64(?) AS `Value`, toFloat64(`HistogramCount`) AS `HistogramCount`, toFloat64(`HistogramSum`) AS `HistogramSum`, toInt32(`HistogramScale`) AS `HistogramScale`, toFloat64(`HistogramZeroThreshold`) AS `HistogramZeroThreshold`, toFloat64(`HistogramZeroCount`) AS `HistogramZeroCount`, toInt32(`HistogramPositiveOffset`) AS `HistogramPositiveOffset`, arrayMap(x -> toFloat64(x), `HistogramPositiveBucketCounts`) AS `HistogramPositiveBucketCounts`, toInt32(`HistogramNegativeOffset`) AS `HistogramNegativeOffset`, arrayMap(x -> toFloat64(x), `HistogramNegativeBucketCounts`) AS `HistogramNegativeBucketCounts` FROM (SELECT `Attributes` AS `Attributes`, `TimeUnix` AS `TimeUnix`, `HistogramScale` AS `HistogramScale`, `HistogramZeroThreshold` AS `HistogramZeroThreshold`, `HistogramPositiveOffset` AS `HistogramPositiveOffset`, `HistogramNegativeOffset` AS `HistogramNegativeOffset`, (`HistogramCount` * toFloat64(?)) AS `HistogramCount`, (`HistogramSum` * toFloat64(?)) AS `HistogramSum`, (`HistogramZeroCount` * toFloat64(?)) AS `HistogramZeroCount`, arrayMap(b -> (b * toFloat64(?)), `HistogramPositiveBucketCounts`) AS `HistogramPositiveBucketCounts`, arrayMap(b -> (b * toFloat64(?)), `HistogramNegativeBucketCounts`) AS `HistogramNegativeBucketCounts` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, now64(?) AS `TimeUnix`, toFloat64(?) AS `Value`, toFloat64(`Count`) AS `HistogramCount`, toFloat64(`Sum`) AS `HistogramSum`, toInt32(`Scale`) AS `HistogramScale`, toFloat64(0.) AS `HistogramZeroThreshold`, toFloat64(`ZeroCount`) AS `HistogramZeroCount`, toInt32(`PositiveOffset`) AS `HistogramPositiveOffset`, arrayMap(x -> toFloat64(x), `PositiveBucketCounts`) AS `HistogramPositiveBucketCounts`, toInt32(`NegativeOffset`) AS `HistogramNegativeOffset`, arrayMap(x -> toFloat64(x), `NegativeBucketCounts`) AS `HistogramNegativeBucketCounts` FROM (SELECT mapSort(mapConcat(mapUpdate(mapFromArrays(arrayMap(k -> replaceRegexpAll(k, '[^a-zA-Z0-9_]', '_'), mapKeys(mapFilter((k, v) -> (k NOT IN (?, ?)), `ResourceAttributes`))), mapValues(mapFilter((k, v) -> (k NOT IN (?, ?)), `ResourceAttributes`))), mapFromArrays(arrayMap(k -> replaceRegexpAll(k, '[^a-zA-Z0-9_]', '_'), mapKeys(`Attributes`)), mapValues(`Attributes`))), mapFilter((k, v) -> (v != ?), map(?, toString(`ServiceName`))))) AS `Attributes`, argMax(`MetricName`, `TimeUnix`) AS `MetricName`, argMax(`Count`, `TimeUnix`) AS `Count`, argMax(`Sum`, `TimeUnix`) AS `Sum`, argMax(`Scale`, `TimeUnix`) AS `Scale`, argMax(`ZeroCount`, `TimeUnix`) AS `ZeroCount`, argMax(`PositiveOffset`, `TimeUnix`) AS `PositiveOffset`, argMax(`PositiveBucketCounts`, `TimeUnix`) AS `PositiveBucketCounts`, argMax(`NegativeOffset`, `TimeUnix`) AS `NegativeOffset`, argMax(`NegativeBucketCounts`, `TimeUnix`) AS `NegativeBucketCounts` FROM (SELECT * FROM `otel_metrics_exponential_histogram` PREWHERE (`MetricName` IN (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)) WHERE (`TimeUnix` <= toDateTime64(?, ?)) AND (`TimeUnix` > (toDateTime64(?, ?) - toIntervalNanosecond(?)))) GROUP BY `Attributes`))))) GROUP BY `gkey_0` HAVING (count() = ?)))


### PR DESCRIPTION
## Summary

- Answers `+`/`-` between two histogram-VALUED shapes (bare exp-histogram selectors, `sum()`/`avg()`, `rate()`/`increase()`, and their compositions) with default vector matching — cerberus issue #2263. Recognized at `lowerExpHistogramValuedShape`'s dispatch point in `internal/promql/histogram_native_binop.go`, so it composes with every other histogram-valued shape rather than only the literal bare-selector case the issue titled.
- The merge reuses the existing `sum()`/`avg()` cross-series bucket-index reconciliation (`expHistogramMergeBucketsBoundsExpr` / `expHistogramMergeOffsetExpr` — purely structural, scale/offset alignment) but deliberately does **not** reuse that path's Kahan-compensated value fold: reference Prometheus's `vectorElemBinop` answers two-histogram `+`/`-` with `FloatHistogram.Add`/`.Sub`, a *different* method from the `KahanAdd` the `sum()`/`avg()` aggregation evaluator uses — plain, uncompensated arithmetic throughout, including the within-row downscale fold. Reusing the Kahan path here would have silently diverged from reference at the ULP level. See `histogram_native_binop.go`'s header doc for the full trace through `model/histogram/float_histogram.go`, and `test/spec/promql/exp_histogram_binop_add_downscale_fold.txtar` for a chDB-executed fixture that pins the numeric difference (plain `10000000000000004` vs. what a Kahan reuse would give, `10000000000000008`).
- `-` reuses the existing scalar-negation machinery (issue #2087) to negate the RHS operand's count-bearing fields before folding it through the same merge as `+`.
- Scope is deliberately narrower than reference's full surface: only default (full-`Attributes`) vector matching for `+`/`-`, and `==`/`!=` between two histograms (a structural-equality filter, not a merge) are out of scope — both real reference capabilities, tracked in #2273. Every other histogram-histogram op (`*`, `/`, `^`, `%`, comparisons other than `==`/`!=`, `atan2`) stays rejected as before.
- While tracing reference's exact behavior for those still-rejected ops to update the rejection-parity catalogue, found that reference does **not** hard-error them either — `vectorElemBinop`'s incompatible-type case returns an `annotations.PromQLInfo`-wrapped error that `handleVectorBinopError` downgrades to a response warning, so reference answers HTTP 200 with an empty vector. Cerberus's existing guard hard-errors instead. Filed #2277 for that (a real, separate gap: cerberus's own `histogram_native_scalar_binop.go` already implements the correct "degrade to empty" pattern for the *scalar*/histogram case, issue #2189, just not yet extended to histogram/histogram) and kept the `expHistogramSelectorRouting` rejection-parity entry `class: "divergence"` (not `"rejection"` — the `"rejection"` class's own contract requires the reference backend to also reject, which this does not satisfy).

## Test plan

- [x] `go build ./...`
- [x] `go test -race ./internal/promql/... ./test/rejection-parity/...` (unit + rejection-parity catalogue self-checks)
- [x] `CGO_ENABLED=1 go test -tags chdb ./test/spec/promql/... -run TestRoundTripChDB` — all `exp_histogram_binop_*` fixtures and the full pre-existing `exp_histogram_*` suite (sum/avg/quantile/rate/etc, unaffected by the merge-function rename) pass against real chDB execution
- [x] `just update-golden migration parity solver promql chsql codegen cardinality` (the shard set the diff requires) — TXTAR chplan/sql/expected_rows, solver decision baseline, parity-enrolment baseline all regenerated and reviewed
- [x] `gofumpt -extra` / `goimports -local` clean on touched files
- [x] New / updated TXTAR fixtures reviewed:
  - `test/spec/promql/exp_histogram_binop_add.txtar` (two different metrics, cross-metric match, unmatched series dropped)
  - `test/spec/promql/exp_histogram_binop_add_range.txtar` (query_range / fanout shape)
  - `test/spec/promql/exp_histogram_binop_sub.txtar` (subtraction / negation path)
  - `test/spec/promql/exp_histogram_binop_add_downscale_fold.txtar` (the plain-vs-Kahan discriminating case)
- [x] Two new compat-corpus cases (`demo_latency_exp_hist + demo_latency_exp_hist`, `... - ...`) added to `compatibility/prometheus/query-corpus/fragments/006-native-histograms.yml` for the live differential harness (`just compat-promql`, CI-only per repo policy — needs real ClickHouse)
- [ ] CI green

## Notes for reviewers

- `internal/promql/histogram_native_binop.go`'s header doc is the primary design writeup — it explains the reused-vs-not-reused split (index reconciliation shared, value fold separate) and cites the exact reference source lines for both `Add`/`Sub` (plain) and `KahanAdd` (compensated).
- Two follow-up issues filed before this merges, per repo policy: #2273 (matching modifiers + `==`/`!=` for histogram-histogram `+`/`-`) and #2277 (histogram-histogram incompatible ops should degrade to empty+warning like the scalar case, not hard-error).
- `test/rejection-parity/divergence-ceiling.json`'s `max_entries` bumped 3→4 for the one net-new divergence entry (`lowerExpHistogramHistogramBinop`'s matching-modifier rejection, tracking #2273); the pre-existing `expHistogramSelectorRouting` divergence entry was already counted, only its trigger query and tracking issue changed (2263→2277, since it no longer fires for `+`/`-`).

Closes #2263
