### PR TITLE
fix(e2e): gate the required dashboard check on dashboard-crawl-merge

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -716,6 +716,15 @@ jobs:
           node --test .github/scripts/crawl-budget.test.mjs
           node --test .github/scripts/assert-crawl-terminal.test.mjs
 
+      # Pins e2e.yml's dashboard-crawl-merge wiring: the required `dashboard`
+      # aggregator must depend on it (so a merge failure can gate a release),
+      # and the release/dispatch trigger conditions that decide when the
+      # crawl matrix runs at all. A pure in-process regex-over-YAML test
+      # (~10ms) — it caught a real gap (#2275) that had gone unnoticed
+      # because nothing invoked it.
+      - name: Assert the dashboard-crawl-merge wiring holds
+        run: node --test .github/scripts/crawl-frontier-workflow.test.mjs
+
       # `perf-guards` is a REQUIRED context posted by an aggregator job that
       # runs no tests of its own — it exists only to roll the sharded
       # `perf-guards-shard` matrix up under the name branch protection and

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1505,7 +1505,7 @@ jobs:
   # where dashboard-setup does not run).
   dashboard:
     name: dashboard
-    needs: [dashboard-setup, dashboard-shard]
+    needs: [dashboard-setup, dashboard-shard, dashboard-crawl-merge]
     if: always()
     runs-on: ubuntu-latest
     timeout-minutes: 5
@@ -1514,6 +1514,7 @@ jobs:
         run: |
           echo "setup  = ${{ needs.dashboard-setup.result }}"
            echo "shards = ${{ needs.dashboard-shard.result }}"
+          echo "crawl-merge = ${{ needs.dashboard-crawl-merge.result }}"
           # If setup was skipped (docs-only PR, or a non-PR/push/schedule/
           # dispatch path), there is nothing to aggregate — report green
           # without work. On a code PR setup runs, so this branch does not fire
@@ -1536,6 +1537,16 @@ jobs:
             echo "::error::one or more dashboard shards failed/cancelled (rolled-up: ${{ needs.dashboard-shard.result }})."
              exit 1
            fi
+          # dashboard-crawl-merge's own `if:` only runs it on schedule/dispatch/
+          # a release/* PR (see its job definition) — `skipped` there is the
+          # expected, correct outcome on an ordinary push or PR, not a failure.
+          # `success` is the only other acceptable outcome; `failure` or
+          # `cancelled` means the crawl inventory did not merge cleanly and
+          # must gate exactly like a failed shard does above.
+          if [ "${{ needs.dashboard-crawl-merge.result }}" != "success" ] && [ "${{ needs.dashboard-crawl-merge.result }}" != "skipped" ]; then
+            echo "::error::dashboard crawl slice merge did not succeed (${{ needs.dashboard-crawl-merge.result }})."
+            exit 1
+          fi
            echo "all dashboard shards passed."
 
   startup-bench:


### PR DESCRIPTION
## Summary

`e2e.yml`'s required `dashboard` aggregator job did not depend on `dashboard-crawl-merge`, even
though that job exists in the same workflow — so a failure merging the sharded Grafana
surface-crawl slices could never fail the required `dashboard` check or block a release. Its own
pinning test (`crawl-frontier-workflow.test.mjs`) was also never wired into any CI job, so this
drift had no way to surface.

- Adds `dashboard-crawl-merge` to `dashboard`'s `needs` list and a skip-aware gate check (its own
  `if:` only runs it on schedule/dispatch/a `release/*` PR, so `skipped` is the expected non-failure
  outcome on an ordinary push or PR — only `failure`/`cancelled` now fails the aggregator).
- Wires `crawl-frontier-workflow.test.mjs` into the required `forbid-skip` job, alongside the
  existing `crawl-budget.test.mjs` / `assert-crawl-terminal.test.mjs` wiring pins for the same lane.

Closes #2275

## Test plan

- [x] `node --test .github/scripts/crawl-frontier-workflow.test.mjs` — all 3 assertions pass
      (previously failing against `origin/main`)
- [x] `actionlint .github/workflows/e2e.yml .github/workflows/ci.yml` — clean
- [ ] CI: `forbid-skip` (required) now runs this test on every PR
