### PR TITLE
docs(promql): drop the hqMerge alias' blanket compensated-fold claim

### DIFF
--- a/internal/promql/histogram_native_sum.go
+++ b/internal/promql/histogram_native_sum.go
@@ -10,8 +10,16 @@ import (
 )
 
 const (
-	// hqMergeCountsArrayAlias and hqMergeSumsArrayAlias carry the two scalar
-	// fields through the same compensated across-series fold as every bucket.
+	// hqMergeCountsArrayAlias and hqMergeSumsArrayAlias name the groupArray
+	// columns that collect the Count/Sum scalar fields across matched rows,
+	// shared by every merge in this package. Most callers (this file,
+	// histogram_quantile_native_window.go) fold that array through the same
+	// compensated across-series fold as every bucket — [promHistogramKahanSum]
+	// — but histogram_native_binop.go's two-operand merge deliberately folds
+	// it with the PLAIN [plainArraySum] instead, matching reference
+	// Prometheus's uncompensated FloatHistogram.Add/Sub (see that file's
+	// header doc for why). The aliases only name the collected array; they
+	// carry no compensation guarantee of their own.
 	hqMergeCountsArrayAlias = "_hq_merge_counts"
 	hqMergeSumsArrayAlias   = "_hq_merge_sums"
 )


### PR DESCRIPTION
## What

Fixes a doc-drift finding from the pre-release audit (area `promql-histogram`).

`hqMergeCountsArrayAlias` / `hqMergeSumsArrayAlias` (declared in
`internal/promql/histogram_native_sum.go`) carried a doc comment claiming a
blanket guarantee: "carry the two scalar fields through the same compensated
across-series fold as every bucket." That was true when the aliases had only
two consumers (this file and `histogram_quantile_native_window.go`, both
folding via the Kahan-compensated `promHistogramKahanSum`).

`histogram_native_binop.go` (added in #2278, lowering `+`/`-` between two
exponential-histogram selectors) now reuses the same two aliases but folds
them with `plainArraySum` — a deliberately UNcompensated fold, matching
reference Prometheus's plain `FloatHistogram.Add`/`Sub` (see that file's own
header doc for the full rationale). The constants' doc comment was never
updated when this third, non-compensated consumer landed, so it now
overclaims for one of its three actual call sites.

## Fix

Reworded the doc comment to describe what the aliases actually guarantee
(naming a shared groupArray column) versus what is caller-specific (which
fold — compensated or plain — each consumer applies), with a pointer to
`histogram_native_binop.go`'s header doc for why its fold differs.

Doc-only change; no behavior change. `go build` / `go vet` on
`internal/promql` are clean.

## Test plan

- [x] `go build ./internal/promql/...`
- [x] `go vet ./internal/promql/...`
- [x] `gofumpt -l` clean on the edited file
