### PR TITLE
docs(chplan): repoint stale combinator-split citation to #2280

### DIFF
--- a/internal/chplan/aggregate.go
+++ b/internal/chplan/aggregate.go
@@ -7,7 +7,7 @@ package chplan
 //
 // Fn is the sealed function symbol. A combinator-suffixed spelling
 // (`argMinIf`) is, for now, its own Fn symbol rather than a
-// structural combinator; the structural split is #2060 PR 3's job, not
+// structural combinator; the structural split is #2280's job, not
 // this one's.
 type AggFunc struct {
 	Fn Fn

--- a/internal/chplan/fn.go
+++ b/internal/chplan/fn.go
@@ -537,7 +537,7 @@ const (
 
 	// argMinIf(arg, val, cond) aggregate — argMin over only the rows where cond is
 	// true; CH's `-If` combinator applied to argMin, spelled as one literal name
-	// pending the structural Combinators split (issue #2060 PR 3).
+	// pending the structural Combinators split (issue #2280).
 	FnArgMinIf Fn = "argMinIf"
 
 	// avg(x) aggregate — the arithmetic mean of non-NULL x in the group.


### PR DESCRIPTION
## What

Repoints two doc comments in `internal/chplan` off a dead issue citation.

`internal/chplan/aggregate.go:8-11` (`AggFunc` doc) and `internal/chplan/fn.go:538-541`
(`FnArgMinIf`) both deferred the "structural Combinators split" — turning combinator-suffixed
aggregate spellings like `argMinIf` into `AggFunc{Fn: FnArgMin, Combinators: []AggCombinator{...}}`
instead of one literal `Fn` constant — to "issue #2060 PR 3".

That work never shipped: `AggFunc` has no `Combinators` field today, `FnArgMinIf` is still one
literal `Fn` constant. But #2060 and its full six-issue PR series (#2180-#2185) are all closed, so
the citation now points nowhere a reader could find the remaining work tracked.

Filed #2280 to track the split itself and repointed both comments to it.

## Why

Found during a pre-release doc-drift audit of `internal/chplan`. A citation to a closed issue for
still-open work is misleading to the next reader, and the repo's own deferral discipline requires
an open issue backing any "pending" comment.

## Test plan

- [x] `go build ./internal/chplan/...`
- [x] `go vet ./internal/chplan/...`
- Doc-only change; no behaviour, no golden churn.

Related: #2280 (tracks the actual structural split; stays open after this PR).
