### PR TITLE
refactor(traceql): dedup lowerAggregate's envelope AggFuncs

### DIFF
--- a/internal/traceql/aggregate.go
+++ b/internal/traceql/aggregate.go
@@ -93,19 +93,17 @@ func lowerAggregate(prev chplan.Node, agg traceql.Aggregate, s schema.Traces) (c
 	if needsNestedSet {
 		prev = annotateNestedSet(prev, s)
 	}
+	// spansetEnvelopeAggFuncs (group_coalesce.go) returns the same
+	// envelope tail group()/coalesce() use, with a count-shaped Value
+	// in slot 0; swap in this aggregate's own valueFunc so the two
+	// AggFunc lists can't drift out of lock-step.
+	envelopeAggFuncs := spansetEnvelopeAggFuncs(s)
+	envelopeAggFuncs[0] = valueFunc
 	return &chplan.Aggregate{
 		Input:          prev,
 		GroupBy:        []chplan.Expr{&chplan.ColumnRef{Name: s.TraceIDColumn}},
 		GroupByAliases: []string{aggTraceIDAlias},
-		AggFuncs: []chplan.AggFunc{
-			valueFunc,
-			anyAggFunc(s.SpanNameColumn, aggMetricNameAlias),
-			anyAggFunc(s.ResourceAttributesColumn, aggResourceAttrsAlias),
-			anyAggFunc(s.ParentSpanIDColumn, aggParentSpanIDAlias),
-			minAggFunc(s.TimestampColumn, aggTimeUnixAlias),
-			traceStartNsAggFunc(s.TimestampColumn),
-			traceEndNsAggFunc(s.TimestampColumn, s.DurationColumn),
-		},
+		AggFuncs:       envelopeAggFuncs,
 	}, nil
 }
 


### PR DESCRIPTION
## Summary

- `lowerAggregate` (internal/traceql/aggregate.go) hand-duplicated the exact six-AggFunc spanset
  envelope tail (`any(SpanName)`, `any(ResourceAttributes)`, `any(ParentSpanId)`,
  `min(Timestamp)`, `traceStartNsAggFunc`, `traceEndNsAggFunc`) that
  `spansetEnvelopeAggFuncs` (internal/traceql/group_coalesce.go) already factors out and that
  `lowerGroup` / `lowerCoalesce` already call.
- `lowerAggregate`'s own doc comment says it "piggybacks representative envelope columns" the same
  way `group()`/`coalesce()` do, but it was never refactored to reuse the shared helper, so the
  envelope shape had two places that had to be kept in lock-step by hand.
- Fix: call `spansetEnvelopeAggFuncs(s)` and swap in this call site's own count/sum/avg/min/max
  `valueFunc` at slot 0, instead of re-listing all five envelope AggFuncs inline.

Found during a pre-release audit of the traceql area (finding
`internal/traceql/aggregate.go:100`, dry/medium).

## Test plan

- `go test ./internal/traceql/...` — passes, including `TestLower`, which walks every
  `test/spec/traceql/*.txtar` fixture (count.txtar, avg_duration.txtar, sum_duration.txtar, etc.)
  and confirms the emitted `chplan.Aggregate.AggFuncs` shape is byte-identical to before the
  refactor.
- `gofumpt -l internal/traceql/aggregate.go` — clean.
