### PR TITLE
docs(optimizer): correct false mirroring claim in range-window transpose

### DIFF
--- a/internal/optimizer/filter_range_window_transpose.go
+++ b/internal/optimizer/filter_range_window_transpose.go
@@ -44,8 +44,14 @@ import "github.com/tsouza/cerberus/internal/chplan"
 //   - Empty `GroupBy` — no per-series identity is passthrough.
 //   - `GroupBy[i]` that is not a bare `ColumnRef` (e.g. a function
 //     call or arithmetic) — could be substituted into the predicate,
-//     but that's a more involved rewrite (mirrors the
-//     `FilterAggregateTranspose` policy).
+//     but that's a more involved rewrite. Unlike `FilterAggregateTranspose`,
+//     which skips only the offending entry and keeps the remaining bare
+//     keys passthrough-safe, this rule declines the rewrite entirely for
+//     the whole `GroupBy` when any single entry is non-bare (see
+//     `seriesIdentifyingColumns` below) — deliberately more conservative,
+//     since a RangeWindow's grid/value columns make substituting the
+//     computed key back into the predicate a riskier rewrite than for a
+//     plain Aggregate.
 //   - `ColumnRef` with a non-empty `Qualifier` in the predicate.
 //   - Mixed predicates (one safe AND one unsafe sub-clause): we keep
 //     the *entire* Filter above the RangeWindow. Splitting an AND


### PR DESCRIPTION
## Summary

Fixes a false cross-reference in `FilterRangeWindowTranspose`'s doc comment, found during a
pre-release audit of `internal/optimizer`.

- `filter_range_window_transpose.go`'s doc claimed its computed-group-key policy "mirrors the
  `FilterAggregateTranspose` policy" (old lines 45-48), but the two sibling helpers implement
  different behavior on the same condition:
  - `seriesIdentifyingColumns` (this file) aborts the **entire** passthrough set — `return nil` —
    the moment any single `GroupBy` entry is not a bare, unqualified `ColumnRef`.
  - `passthroughGroupKeys` (`filter_aggregate_transpose.go`) only **skips** the offending entry —
    `continue` — and keeps building the passthrough set from the remaining bare keys.
- Rewrote the doc to describe the actual (stricter) policy instead of the false "mirrors" claim,
  and note why the extra caution makes sense for a `RangeWindow` (grid/value columns raise the
  stakes of substituting a computed key back into the predicate, versus a plain `Aggregate`).

No behavior change — this is a documentation-only fix. Whether the two rules' policies *should* be
aligned (i.e. whether `seriesIdentifyingColumns` should also just skip bad entries rather than
bailing out entirely) is a separate, untested behavioral question filed as its own issue rather
than bundled into this doc fix.

## Test plan

- [x] `go build ./internal/optimizer/...`
- [x] `go vet ./internal/optimizer/...`
- [x] `go test -race -run 'TestFilterRangeWindowTranspose|TestFilterAggregateTranspose' ./internal/optimizer/...` — pass
