### PR TITLE
docs(ci): fix stale mutation-context comment in mutation.yml

### DIFF
--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -45,10 +45,11 @@ name: mutation
 
 on:
   pull_request:
-  # `mutation` is a required context, so the aggregator has to post inside the
-  # queue. The merge group selects legs from its OWN diff (`base_sha..head_sha`,
-  # the union of the batched PRs' diffs) exactly as a PR does — see the
-  # merge_group clause in .github/scripts/lib/scope-gate.mjs.
+  # `mutation` is informational (see the header above), but the aggregator
+  # still posts inside the merge queue for the same early-signal reason it
+  # runs on an ordinary PR. The merge group selects legs from its OWN diff
+  # (`base_sha..head_sha`, the union of the batched PRs' diffs) exactly as a
+  # PR does — see the merge_group clause in .github/scripts/lib/scope-gate.mjs.
   merge_group:
   push:
     branches: [main]


### PR DESCRIPTION
## Summary

- `.github/workflows/mutation.yml:48` had a leftover trigger comment claiming
  `mutation` is a required status-check context. That directly contradicts the
  file's own header (lines 6-14), which documents that `mutation` became
  INFORMATIONAL on an ordinary PR as of #2230's merge/release two-tier split —
  it is not in `release.yml`'s `RELEASE_REQUIRED_CHECKS`, only its
  `RELEASE_INFORMATIONAL_CHECKS`. Confirmed against the live
  required-status-checks list (16 contexts, no `mutation`) and against
  `release.yml`'s actual `RELEASE_INFORMATIONAL_CHECKS`.
- Rewrote the comment to state the real reason the aggregator still posts
  inside the merge queue: the same early-signal rationale that applies on an
  ordinary PR, not a required-context obligation that no longer exists.

Found during a pre-release audit of `ci-workflows`.

## Test plan

- [x] `actionlint .github/workflows/mutation.yml` — clean
- [x] `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/mutation.yml'))"` — parses
- Doc-only comment change; no behavioral change to the workflow.
