### PR TITLE
refactor(promql): dedup count_values group-key switch

### DIFF
--- a/internal/promql/subquery.go
+++ b/internal/promql/subquery.go
@@ -2193,27 +2193,9 @@ func lowerSubqueryOverCountValues(
 	// branches), followed by the synthetic value-as-label key and the
 	// per-anchor key so the count reducer fires once per (partition,
 	// distinct value, anchor).
-	var (
-		groupBy []chplan.Expr
-		aliases []string
-	)
-	switch {
-	case agg.Without && len(agg.Grouping) == 0:
-		groupBy = []chplan.Expr{&chplan.ColumnRef{Name: s.AttributesColumn}}
-		aliases = []string{"gkey_0"}
-	case agg.Without:
-		groupBy = []chplan.Expr{&chplan.MapWithoutKeys{
-			Map:  &chplan.ColumnRef{Name: s.AttributesColumn},
-			Keys: append([]string(nil), agg.Grouping...),
-		}}
-		aliases = []string{"gkey_0"}
-	default:
-		groupBy = make([]chplan.Expr, 0, len(agg.Grouping))
-		aliases = make([]string, 0, len(agg.Grouping))
-		for i, lbl := range agg.Grouping {
-			groupBy = append(groupBy, attributeLookup(s.AttributesColumn, lbl))
-			aliases = append(aliases, fmt.Sprintf("gkey_%d", i))
-		}
+	groupBy, aliases, err := subqueryAggregateGroupBy(agg, s)
+	if err != nil {
+		return nil, err
 	}
 	groupBy = append(groupBy, &chplan.FuncCall{
 		Fn:   chplan.FnToString,


### PR DESCRIPTION
## Summary

Pre-release audit finding (area: promql-core): `lowerSubqueryOverCountValues`
re-implemented the exact by/without group-key-building switch that
`subqueryAggregateGroupBy` already provides in the same file, instead of
calling it — even though `lowerSubqueryOverAggregate` already calls
`subqueryAggregateGroupBy` for the identical need.

- `internal/promql/subquery.go:2192` — replaced the inline three-armed
  `switch { agg.Without && len(agg.Grouping)==0 / agg.Without / default }`
  with a call to `subqueryAggregateGroupBy(agg, s)`.

No behavior change: the extracted helper's three cases are byte-for-byte
identical to what the inline switch built.

## Test plan

- [x] `go build ./internal/promql/...`
- [x] `go test ./internal/promql/... -run '^TestLower$'` — all `count_values`
      and `subquery_over_count_values` TXTAR cases pass
- [x] `go test ./internal/promql/...` — full package green
- [x] `gofumpt -l` / `goimports -l` clean on the touched file
