### PR TITLE
fix(migrate): strict-decode corpus.json on both read paths

### DIFF
--- a/internal/migrate/corpus.go
+++ b/internal/migrate/corpus.go
@@ -1,6 +1,7 @@
 package migrate
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -116,7 +117,9 @@ func (s CorpusFileSource) Harvest(_ context.Context) ([]HarvestedQuery, []Skippe
 		return nil, nil, fmt.Errorf("migrate: read corpus %q: %w", s.Path, err)
 	}
 	var c Corpus
-	if err := json.Unmarshal(data, &c); err != nil {
+	dec := json.NewDecoder(bytes.NewReader(data))
+	dec.DisallowUnknownFields()
+	if err := dec.Decode(&c); err != nil {
 		return nil, nil, fmt.Errorf("migrate: parse corpus %q: %w", s.Path, err)
 	}
 	if c.Version != CorpusVersion {

--- a/internal/migrateverify/client.go
+++ b/internal/migrateverify/client.go
@@ -1,6 +1,7 @@
 package migrateverify
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -425,7 +426,9 @@ func LoadCorpus(path string) (Corpus, error) {
 		return Corpus{}, fmt.Errorf("read corpus %q: %w", path, err)
 	}
 	var c migrate.Corpus
-	if err := json.Unmarshal(data, &c); err != nil {
+	dec := json.NewDecoder(bytes.NewReader(data))
+	dec.DisallowUnknownFields()
+	if err := dec.Decode(&c); err != nil {
 		return Corpus{}, fmt.Errorf("decode corpus %q: %w", path, err)
 	}
 	if c.Version != migrate.CorpusVersion {


### PR DESCRIPTION
## Summary

- `internal/migrate.CorpusFileSource.Harvest` and `internal/migrateverify.LoadCorpus` decoded `corpus.json` with plain `json.Unmarshal`, skipping the `DisallowUnknownFields` strict-decode discipline the migration lane documents as its policy for every artifact (see `internal/migrategate/gate.go`'s `readArtifact`, whose comment states: "Every artifact is decoded strictly (unknown fields rejected)... A schema-drifted, wrong-type, or version-mismatched artifact is a hard error, not a struct that zero-fills its counts to a silent PASS.").
- `corpus.json` was the one artifact exempted from that guarantee, on two of the lane's own read paths. Switched both to `json.NewDecoder(...).DisallowUnknownFields()`, matching `readArtifact`'s pattern.

## Test plan

- [x] `go build ./internal/migrate/... ./internal/migrateverify/...`
- [x] `go test -race ./internal/migrate/... ./internal/migrateverify/...` — both pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
