### PR TITLE
refactor(api): dedupe writeEngineHeaders into shared httperr package

### DIFF
--- a/internal/api/httperr/httperr.go
+++ b/internal/api/httperr/httperr.go
@@ -105,6 +105,27 @@ func WriteJSON(w http.ResponseWriter, status int, body any) {
 	_, _ = w.Write(buf.Bytes())
 }
 
+// WriteEngineHeaders stamps the X-Cerberus-* response headers populated by
+// engine.Engine.Query / QueryCursor / QueryPlan onto w before the response
+// body fires. Safe to call with a nil / empty map (no-op).
+//
+// Each handler calls this once per successful query — the engine populates
+// the canonical bag (Strategy / Plan-Nodes / CH-Millis) so adding a new
+// engine-level header (e.g. SQL-Length) requires no per-handler change.
+//
+// Prom-specific note: the middleware-driven X-Cerberus-CH-Millis stamp
+// still runs after the handler returns (see prom/middleware.go); when the
+// engine populated hdr[X-Cerberus-CH-Millis] this Set happens first and the
+// middleware's later Set is a no-op overwrite with the equivalent value
+// (engine CH timing is also written into the per-request counter in
+// executeInstant). The middleware path stays as a safety net for error
+// responses where the engine never produced a Result.
+func WriteEngineHeaders(w http.ResponseWriter, hdr map[string]string) {
+	for k, v := range hdr {
+		w.Header().Set(k, v)
+	}
+}
+
 // writeMarshalFailure reports an unmarshalable response body as a 500. It
 // is reached only when [WriteJSON]'s caller handed over a value the JSON
 // encoder rejects, so the status the caller asked for is discarded: that

--- a/internal/api/loki/handler.go
+++ b/internal/api/loki/handler.go
@@ -346,7 +346,7 @@ func (h *Handler) handleQuery(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	writeEngineHeaders(w, res.Headers)
+	httperr.WriteEngineHeaders(w, res.Headers)
 	writeJSON(w, http.StatusOK, Response{
 		Status: "success",
 		Data:   data,
@@ -432,7 +432,7 @@ func (h *Handler) handleQueryRange(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	writeEngineHeaders(w, res.Headers)
+	httperr.WriteEngineHeaders(w, res.Headers)
 	writeJSON(w, http.StatusOK, Response{
 		Status: "success",
 		Data:   data,
@@ -462,20 +462,6 @@ func (h *Handler) langForRequest(start, end time.Time) *logql.Lang {
 // lowering.
 func (h *Handler) langForRangeRequest(start, end time.Time, step time.Duration) *logql.Lang {
 	return &logql.Lang{Schema: h.Schema, Start: start, End: end, Step: step}
-}
-
-// writeEngineHeaders stamps the X-Cerberus-* response headers populated
-// by engine.Engine.Query / QueryPlan onto w before the response body
-// fires. Safe to call with a nil / empty map (no-op).
-//
-// Each handler calls this once per successful query — the engine
-// populates the canonical bag (Strategy / Plan-Nodes / CH-Millis) so
-// adding a new engine-level header (e.g. SQL-Length) requires no
-// per-handler change.
-func writeEngineHeaders(w http.ResponseWriter, hdr map[string]string) {
-	for k, v := range hdr {
-		w.Header().Set(k, v)
-	}
 }
 
 // classifyEngineErr maps the error chains engine.Engine returns onto

--- a/internal/api/prom/handler.go
+++ b/internal/api/prom/handler.go
@@ -386,7 +386,7 @@ func (h *Handler) handleQuery(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	writeEngineHeaders(w, hdr)
+	httperr.WriteEngineHeaders(w, hdr)
 	if expr.Type() == promparser.ValueTypeMatrix {
 		// Top-level range-vector / subquery expression: resultType
 		// "matrix" with every returned sample at its own timestamp,
@@ -650,7 +650,7 @@ func (h *Handler) respondRangeMatrix(w http.ResponseWriter, hdr map[string]strin
 	if h.onRangeDrain != nil {
 		h.onRangeDrain(cursor.Inspected())
 	}
-	writeEngineHeaders(w, hdr)
+	httperr.WriteEngineHeaders(w, hdr)
 	writeJSON(w, http.StatusOK, Response{
 		Status: "success",
 		Data:   &QueryData{ResultType: "matrix", Result: result},
@@ -907,23 +907,6 @@ func (h *Handler) executeInstant(ctx context.Context, query string, start, end t
 		h.onInstantDrain(res.Inspected)
 	}
 	return res.Samples, res.Headers, nil
-}
-
-// writeEngineHeaders stamps the X-Cerberus-* response headers populated
-// by engine.Engine.Query / QueryCursor onto w before the response body
-// fires. Safe to call with a nil / empty map (no-op).
-//
-// The middleware-driven X-Cerberus-CH-Millis stamp still runs after the
-// handler returns (see middleware.go); when the engine populated
-// res.Headers[X-Cerberus-CH-Millis] we Set the same key here first and
-// the middleware's later Set is a no-op overwrite with the equivalent
-// value (engine CH timing is also written into the per-request counter
-// in executeInstant). The middleware path stays as a safety net for
-// error responses where the engine never produced a Result.
-func writeEngineHeaders(w http.ResponseWriter, hdr map[string]string) {
-	for k, v := range hdr {
-		w.Header().Set(k, v)
-	}
 }
 
 // promMaxSamplesMessage is upstream Prometheus's exact wire message for

--- a/internal/api/tempo/handler.go
+++ b/internal/api/tempo/handler.go
@@ -480,22 +480,12 @@ func (h *Handler) handleSearch(w http.ResponseWriter, r *http.Request) {
 			applyRootMetadata(summaries, roots)
 		}
 	}
-	writeEngineHeaders(w, res.Headers)
+	httperr.WriteEngineHeaders(w, res.Headers)
 	writeInspectedSpans(w, inspectedSpans)
 	writeJSON(w, http.StatusOK, SearchResponse{
 		Traces:  summaries,
 		Metrics: metrics,
 	})
-}
-
-// writeEngineHeaders stamps the X-Cerberus-* response headers populated
-// by engine.Engine.Query / QueryPlan onto w before the response body
-// fires. Safe to call with a nil / empty map (no-op). See the matching
-// helper in internal/api/loki/handler.go for the full rationale.
-func writeEngineHeaders(w http.ResponseWriter, hdr map[string]string) {
-	for k, v := range hdr {
-		w.Header().Set(k, v)
-	}
 }
 
 // search/recent page-size bounds: the Tempo Search UI's first-page
@@ -620,7 +610,7 @@ func (h *Handler) handleSearchRecent(w http.ResponseWriter, r *http.Request) {
 	// summary set is never truncated in Go and the pre-truncation trace
 	// count is simply the grouped set.
 	metrics, inspectedSpans := SearchMetricsFor(summaries, res.Samples)
-	writeEngineHeaders(w, res.Headers)
+	httperr.WriteEngineHeaders(w, res.Headers)
 	writeInspectedSpans(w, inspectedSpans)
 	writeJSON(w, http.StatusOK, SearchResponse{
 		Traces:  summaries,
@@ -703,7 +693,7 @@ func (h *Handler) serveTraceByID(w http.ResponseWriter, r *http.Request, v2 bool
 	}
 	h.Logger.Debug("cerberus tempo traceByID", "trace_id", traceID, "sql", res.SQL, "args", telemetry.SanitizeArgsForLog(res.Args))
 
-	writeEngineHeaders(w, res.Headers)
+	httperr.WriteEngineHeaders(w, res.Headers)
 
 	// Grafana 11.x's Tempo datasource plugin sends
 	// `Accept: application/protobuf` and proto.Unmarshal-s the response

--- a/internal/api/tempo/metrics_query_instant.go
+++ b/internal/api/tempo/metrics_query_instant.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/tsouza/cerberus/internal/api/format"
+	"github.com/tsouza/cerberus/internal/api/httperr"
 	"github.com/tsouza/cerberus/internal/chclient"
 	"github.com/tsouza/cerberus/internal/chplan"
 	"github.com/tsouza/cerberus/internal/telemetry"
@@ -123,7 +124,7 @@ func (h *Handler) handleMetricsQueryInstant(w http.ResponseWriter, r *http.Reque
 		return
 	}
 
-	writeEngineHeaders(w, router.Headers)
+	httperr.WriteEngineHeaders(w, router.Headers)
 	writeJSON(w, http.StatusOK, MetricsQueryInstantResponse{
 		Series: router.Series,
 	})

--- a/internal/api/tempo/metrics_query_range.go
+++ b/internal/api/tempo/metrics_query_range.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/tsouza/cerberus/internal/api/format"
+	"github.com/tsouza/cerberus/internal/api/httperr"
 	"github.com/tsouza/cerberus/internal/chclient"
 	"github.com/tsouza/cerberus/internal/chplan"
 	"github.com/tsouza/cerberus/internal/engine"
@@ -317,7 +318,7 @@ func (h *Handler) handleMetricsQueryRange(w http.ResponseWriter, r *http.Request
 		return
 	}
 
-	writeEngineHeaders(w, router.Headers)
+	httperr.WriteEngineHeaders(w, router.Headers)
 	writeJSON(w, http.StatusOK, MetricsQueryRangeResponse{
 		Series: router.Series,
 	})


### PR DESCRIPTION
## Summary

- Pre-release audit finding (area `api-heads`): `writeEngineHeaders` was a byte-identical
  6-line helper duplicated verbatim in `internal/api/prom/handler.go`,
  `internal/api/loki/handler.go`, and `internal/api/tempo/handler.go`. Tempo's own comment
  above its copy even pointed at loki's copy as "the matching helper" — acknowledging the
  duplication instead of importing a shared implementation, unlike `writeJSON`, which each
  head already forwards to `httperr.WriteJSON` for exactly this reason.
- Moves the helper to `internal/api/httperr` as `httperr.WriteEngineHeaders`, alongside
  `WriteJSON` which already serves this cross-head role, and updates all six call sites
  (prom's two, loki's two, tempo's four across `handler.go` /
  `metrics_query_instant.go` / `metrics_query_range.go`).
- No behavior change — the loop body is unchanged, only its home moved.

## Test plan

- [x] `go build ./...`
- [x] `gofumpt -extra -l` / `gofmt -l` clean on every touched file
- [x] `go vet ./internal/api/...`
- [x] `go test -race ./internal/api/prom/... ./internal/api/loki/... ./internal/api/tempo/... ./internal/api/httperr/...` — all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
