### PR TITLE
docs(forbid-skip): fix stale row numbering for should_skip/escape-hatch

### DIFF
--- a/docs/forbid-skip.md
+++ b/docs/forbid-skip.md
@@ -46,9 +46,9 @@ the script directly) and as a step inside the `forbid-skip` CI job. The
 lefthook `forbid-skip-self-test` command runs the same script on
 pre-push.
 
-Rows 1–5 of the summary table below are carried by all three copies.
-Rows 6–8 are carried by CI **and** lefthook; only the self-test's
-coverage differs:
+Rows 1–4 and 7–8 of the summary table below are carried by all three
+copies. Rows 5 and 6 are carried by CI **and** lefthook only —
+`scripts/test-forbid-skip.sh` has no case for either:
 
 | Row(s) | CI step (`CHECK=`)                                                            | lefthook `pre-push` command   | `scripts/test-forbid-skip.sh` |
 | ------ | ----------------------------------------------------------------------------- | ----------------------------- | ----------------------------- |
@@ -58,12 +58,12 @@ coverage differs:
 | 6      | Reject test escape-hatch patterns (`escape-hatch`)                            | `forbid-escape-hatch`         | no                            |
 | 7–8    | Reject scenario-suppressing tags and godog skip routes (`feature-discipline`) | `forbid-feature-discipline`   | yes                           |
 
-Row 6 rejects every non-empty `should_skip:` block in
+Row 5 rejects every non-empty `should_skip:` block in
 `compatibility/**/*.{yml,yaml}` outright. lefthook's
-`forbid-escape-hatch` command carries rows 6 and 7 together: the row-7
-ERE over `*.{ts,tsx,go}` plus the row-6 `perl -0777` slurp over the
+`forbid-escape-hatch` command carries rows 5 and 6 together: the row-6
+ERE over `*.{ts,tsx,go}` plus the row-5 `perl -0777` slurp over the
 compatibility YAML, which the CI job splits across two `CHECK` arms.
-Rows 6 and 7 have no `scripts/test-forbid-skip.sh` case, so their
+Rows 5 and 6 have no `scripts/test-forbid-skip.sh` case, so their
 regexes are pinned by the CI and lefthook copies alone.
 
 ## Patterns vs CHECK categories — the count that the gate pins
@@ -126,7 +126,7 @@ shape.
 | 7 | Reject scenario-suppressing Gherkin tags (`@wip` / `@skip` / `@ignore` / `@manual` / `@todo` / `@pending`) | `*.feature`                  | #1268 |
 | 8 | Reject godog skip / pending routes (`godog.ErrSkip`, `godog.ErrPending`, `.Skip` / `.Skipf` / `.SkipNow`)  | `test/e2e/migration/**/*.go` | #1268 |
 
-Row 6 rejects any non-empty `should_skip:` block outright (see
+Row 5 rejects any non-empty `should_skip:` block outright (see
 `.github/workflows/ci.yml` `forbid-skip` job step "Reject should_skip
 overlay entries"). The only accepted form is `should_skip: []`; any
 element under the key fails CI.


### PR DESCRIPTION
## Summary

Fixes a stale row-numbering inconsistency in `docs/forbid-skip.md`, found during a pre-release
docs audit.

- The prose at line 49 claimed "Rows 1–5 of the summary table below are carried by all three
  copies" (i.e. self-tested by `scripts/test-forbid-skip.sh`), but the table two lines below shows
  row 5 (`should_skip` overlay entries) has self-test = `no`. `scripts/test-forbid-skip.sh:190`
  confirms the self-test case for that row was removed (PR #596) and never carried.
- The same off-by-one recurs twice more in the doc: lines 61/63–66 call `should_skip` "row 6" and
  escape-hatch "row 7", and line 129 calls `should_skip` "row 6" again — one row off from both the
  line-53 summary table and the line-117 Summary table, which both anchor `should_skip` at row 5
  and escape-hatch at row 6.

All three spots are corrected to match the tables that anchor them. No code changes; verified with
`node .github/scripts/doc-counts.mjs` (still reports all doc-stated counts matching source) and
`markdownlint-cli2 docs/forbid-skip.md` (0 errors).

## Test plan

- [x] `node .github/scripts/doc-counts.mjs` — all doc-stated counts match source
- [x] `npx markdownlint-cli2 docs/forbid-skip.md` — 0 errors
- [x] `lefthook` pre-push discipline scans (forbid-skip-self-test, forbid-escape-hatch, etc.) — all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)
