### PR TITLE
fix(ci): widen property histogram-sweep timeout margin, stop truncating its own failure log

### DIFF
--- a/.github/scripts/property-fanout.mjs
+++ b/.github/scripts/property-fanout.mjs
@@ -67,7 +67,7 @@
 //      checkDeadline() reads t.Deadline()) and, when it estimates it is
 //      running short, quietly stops early and still reports "[rapid] OK" —
 //      a PASS with fewer than the requested checks, not a failure (see
-//      assertNoSilentTruncation below). With the roster sharing a share's
+//      findTruncatedRapidRuns below). With the roster sharing a share's
 //      budget, the property sweep alone used 696 of a 720s (12m) deadline,
 //      leaving the roster only 24s — not enough — and the hard `go test`
 //      alarm fired mid-roster. Isolating the roster removes that entirely.
@@ -76,7 +76,7 @@
 //
 // No product code changes and no test is skipped: every property test
 // still runs exactly once, and TestPromQL_Property_NativeHistogram's checks
-// still sum to the full requested depth — assertNoSilentTruncation is the
+// still sum to the full requested depth — findTruncatedRapidRuns is the
 // check that keeps that true rather than merely hoped-for. Without it, a
 // too-tight per-process -timeout (this one included, before it was
 // measured and corrected) degrades coverage silently: `go test` still
@@ -137,16 +137,23 @@ export const HISTOGRAM_FANOUT = 3;
  * Per-process go test -timeout, in minutes.
  *
  * HISTOGRAM_TIMEOUT_MINUTES covers one sweep share (~500/HISTOGRAM_FANOUT,
- * i.e. ~167 checks). Measured locally: 3 concurrent shares of ~167
- * requested checks each, running alongside the rest leg, needed ~5.0-5.5s
- * PER CHECK under that contention (derived from a 12-minute deadline that
- * was too tight and made rapid self-truncate — see the header) — so the
- * full ~167 checks need roughly 167 * 5.5s ≈ 918s (~15.3 minutes) in the
- * worst observed case. 20 minutes (unchanged from the pre-split single-
- * process ceiling) leaves comfortable headroom over that, and
- * assertNoSilentTruncation below fails the run outright if a share ever
- * needs more than its budget allows rather than accepting a quietly
- * shrunk pass.
+ * i.e. ~167 checks). The original 20-minute budget was derived from a
+ * local measurement of ~5.0-5.5s per check under contention (~15.3 minutes
+ * worst case for 167 checks) and proved too tight in production: CI run
+ * 32009891549 (2026-08-17) measured 3 concurrent shares actually costing
+ * 6.55-7.12s PER CHECK on the real ubuntu-latest runner — 164/167, 166/166
+ * and 167/167 checks completed in 18m07s-19m28s, i.e. within single-digit
+ * minutes, sometimes single-digit PERCENT, of the 20-minute ceiling. One
+ * share (164/167) crossed rapid's own internal deadline margin and
+ * self-truncated, which findTruncatedRapidRuns below correctly turned into
+ * a hard failure rather than a hollow green — but a hard failure on
+ * essentially every push is not an acceptable steady state. 30 minutes,
+ * derived from the observed worst-case rate (167 * 7.12s ≈ 1189s ≈ 19.8
+ * minutes) with ~50% headroom rather than the ~30% the original estimate
+ * assumed, gives the sweep genuine margin against the same run-to-run
+ * variance (which rapid seed hits how many of the 16 expensive shapes)
+ * that the header already documents as expected. property.yml's job-level
+ * timeout-minutes must stay comfortably above this — see that file.
  *
  * ROSTER_TIMEOUT_MINUTES covers only the deterministic shape roster,
  * decoupled from any checks budget; it does not use rapid.Check; even the
@@ -159,7 +166,7 @@ export const HISTOGRAM_FANOUT = 3;
  * 30-90s in the measured run, ~350s total; 10 minutes leaves more than 6x
  * headroom.
  */
-export const HISTOGRAM_TIMEOUT_MINUTES = 20;
+export const HISTOGRAM_TIMEOUT_MINUTES = 30;
 export const ROSTER_TIMEOUT_MINUTES = 5;
 export const REST_TIMEOUT_MINUTES = 10;
 
@@ -221,7 +228,7 @@ export function legCommands({
       `-rapid.shrinktime=${rapidShrinktime}`,
     ],
     // The requested check depth this leg must actually reach —
-    // assertNoSilentTruncation cross-checks the log against this.
+    // findTruncatedRapidRuns cross-checks the log against this.
     expectRapidChecks: share,
   }));
 
@@ -358,7 +365,21 @@ async function main() {
       `property: ${failed.length} of ${results.length} leg(s) failed, ` +
         `${truncated.length} silent rapid truncation(s), after ${elapsedSeconds}s`,
     );
-    process.exit(1);
+    // NOT process.exit(1) here: stdout is a pipe under GH Actions (not a
+    // TTY), so process.stdout.write() — every log()/error()/group() call
+    // above, including the per-leg -v dumps, some of them large — can be
+    // asynchronously queued rather than delivered synchronously. exit()
+    // tears the process down immediately, before libuv drains that queue,
+    // so a large enough backlog is silently truncated mid-write with no
+    // trace of why (observed in CI run 32009891549: the log cut off
+    // mid-word inside the LAST leg's dump, and every error() message below
+    // this point — the one explaining what actually failed — was lost,
+    // turning a diagnosable failure into an apparent crash). Setting
+    // exitCode and returning lets Node exit only once every queued write
+    // has flushed, which is what a step whose entire value is its log
+    // needs.
+    process.exitCode = 1;
+    return;
   }
   notice(`property: ${results.length} leg(s) passed with full rapid depth in ${elapsedSeconds}s`);
 }

--- a/.github/workflows/property.yml
+++ b/.github/workflows/property.yml
@@ -88,7 +88,11 @@ jobs:
   property:
     name: property (PromQL + LogQL + TraceQL, rapid N=500)
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    # Must stay comfortably above HISTOGRAM_TIMEOUT_MINUTES in
+    # property-fanout.mjs (the slowest leg the job waits on) plus setup —
+    # see that constant's comment for the real measured per-check cost this
+    # is derived from, and why 30 was too tight in practice.
+    timeout-minutes: 40
     # RUN_HEAVY gates the real work: true on push / schedule / dispatch, and on
     # a release PR (head branch release/*). On a regular PR every heavy step is
     # skipped and the job reports green without work — so `property …` can be a


### PR DESCRIPTION
## Summary

- `property` has failed on every completed push run to `main` since #2266's fanout landed a few hours ago (run 32004173961 at 30.3min, run 32009891549 at 27.5min — both effectively at the ceiling). This is not a one-off flake.
- Root cause: `HISTOGRAM_TIMEOUT_MINUTES` (20) was sized from a local measurement of ~5.0-5.5s/check under 3-way concurrent contention (~15.3min worst case for a 167-check share). The real `ubuntu-latest` runner costs 6.55-7.12s/check under the same contention — close enough to the 20-minute ceiling that `rapid.Check`'s own internal deadline logic self-truncated one share (164/167 checks) in run 32009891549, which `findTruncatedRapidRuns` correctly turned into a hard failure rather than a hollow green (working exactly as #2266 designed it to).
- The failure was hard to diagnose live because the script's own explanation of it never reached the log: `process.exit(1)`, called right after the large buffered per-leg `-v` dumps, tears the process down before Node finishes draining `process.stdout`'s write queue — asynchronous whenever stdout is a pipe, which it always is under GH Actions. The job log cut off mid-word with no `FAIL`, no panic, and no artifact, which is why this initially looked like an OOM/crash mystery rather than the intentional truncation-detector firing.
- PR #2278 (native-histogram binop support, merged just before this failure) was investigated and ruled out: it does not touch `test/property/gen/` or `promql_exp_histogram_test.go`, so the property sweep's generator/shape space is unchanged by it.

## Fix

- `HISTOGRAM_TIMEOUT_MINUTES`: 20 → 30 (~50% margin over the measured 7.12s/check worst case, vs. the ~30% the original estimate assumed).
- `property.yml`'s job `timeout-minutes`: 30 → 40, to stay comfortably above the new per-leg ceiling.
- `property-fanout.mjs`'s failure path: `process.exit(1)` → `process.exitCode = 1; return;`, so a genuine future failure's own diagnostic message survives in the log instead of being silently dropped by the same truncation hazard. Verified with a standalone repro: a 2MB `stdout.write()` immediately followed by `process.exit()` delivered only 81920 bytes downstream to a piped consumer; `process.exitCode` + a natural return delivered the full 2097152 bytes.
- Also fixed 4 stale `assertNoSilentTruncation` comment references left over from that function's rename to `findTruncatedRapidRuns`.

## Evidence

- `gh run rerun 32009891549 --failed` was run as an independent check; see the linked run in the PR thread / this description's follow-up for its outcome (a rerun of the *unmodified* code, to distinguish a one-off scheduling fluke from a reproducible margin problem — both are consistent with the diagnosis above regardless of its outcome, since the real per-check cost is a runner-load-dependent distribution, not a hard constant, and the fix widens the margin rather than relying on any single run to prove or disprove it).
- Local `node --test .github/scripts/property-fanout.test.mjs`: 22/22 pass, including the existing "every per-process timeout stays strictly below the job cap" guard against the new 30/40 values.
- `actionlint .github/workflows/property.yml`: no issues.

## Test plan

- [x] `node --test .github/scripts/property-fanout.test.mjs` passes locally (22/22).
- [x] `actionlint` clean on the workflow diff.
- [x] Standalone repro confirms the `process.exit()` truncation hazard and the fix.
- [ ] CI's own `property` check on this PR is a no-op on a non-release PR (`RUN_HEAVY` gate) — the real validation is the next push to `main` after merge.
