### PR TITLE
test(regression): cite the commit/PR each meta-test guards against

### DIFF
--- a/test/regression/build_base_image_arg_test.go
+++ b/test/regression/build_base_image_arg_test.go
@@ -10,7 +10,8 @@ import (
 	"testing"
 )
 
-// A build's `FROM` is the one image acquisition the GHCR mirror could not reach.
+// A build's `FROM` is the one image acquisition the GHCR mirror could not reach
+// (#1605).
 //
 // `pullImageWithRetry` serves a mirrored copy by pulling it and re-tagging it to
 // the upstream name in the HOST daemon. That covers a compose `image:` key and a

--- a/test/regression/canonical_map_func_constant_test.go
+++ b/test/regression/canonical_map_func_constant_test.go
@@ -1,6 +1,7 @@
 package regression
 
-// Pins the Map key-order invariant to a single named function.
+// Pins the Map key-order invariant to a single named function (#1365: the
+// function used to be spelled out at two call sites and drifted).
 //
 // Every series-identity key in the engine depends on the attributes Map
 // being ordered by key: a CH Map compares, groups and hashes POSITIONALLY

--- a/test/regression/cardinality_baseline_fanout_test.go
+++ b/test/regression/cardinality_baseline_fanout_test.go
@@ -11,6 +11,10 @@ import (
 	"testing"
 )
 
+// This pins the sharded regeneration contract added in #2123, which fanned the
+// cardinality baseline write out across CI legs so it stopped timing out as a
+// single-leg run.
+//
 // cardinalityUpdateModule is the runner behind `just update-cardinality-baseline`.
 const cardinalityUpdateModule = ".github/scripts/cardinality-baseline-update.mjs"
 

--- a/test/regression/ch_conn_lifetime_margin_test.go
+++ b/test/regression/ch_conn_lifetime_margin_test.go
@@ -13,7 +13,8 @@ import (
 )
 
 // Layer 8 — the ClickHouse connection age-eviction default against the chaos
-// lane's recovery deadline.
+// lane's recovery deadline (#1347, which added the eviction and its release-
+// on-cursor-teardown fix).
 //
 // ConnMaxLifetime is the backstop that bounds recovery after a ClickHouse pod
 // is force-killed: the pod's socket can stay ESTABLISHED with no FIN/RST, the

--- a/test/regression/chart_config_parity_test.go
+++ b/test/regression/chart_config_parity_test.go
@@ -13,7 +13,7 @@ import (
 // TestChartEnvKeysAreReachableFromAConfigFile pins the promise a nested
 // cerberus.yaml makes: it is written in the same shape as the chart's
 // values.yaml, so an operator who has configured cerberus in Kubernetes has
-// configured it on a VM too.
+// configured it on a VM too (#1316, which introduced the nested shape).
 //
 // The chart's `cerberus.nonSecretEnv` helper is the only place the typed values
 // blocks are lowered to CERBERUS_* variables, which makes it the authority on

--- a/test/regression/ci_lane_registry_test.go
+++ b/test/regression/ci_lane_registry_test.go
@@ -11,6 +11,11 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
+// This pins the shadow test-fence registry contract added in #2233: the
+// registry below is the schema every CI lane entry must satisfy, so a lane
+// that drifts from its own declared shape is caught here rather than by a
+// silent gap in enforcement.
+
 const ciLaneRegistryPath = "../../.github/ci-lanes.json"
 
 type ciLaneRegistry struct {

--- a/test/regression/compose_project_isolation_test.go
+++ b/test/regression/compose_project_isolation_test.go
@@ -16,7 +16,8 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
-// Docker Compose scopes containers, networks and volumes by PROJECT name, and
+// This pins #1390: Docker Compose scopes containers, networks and volumes by
+// PROJECT name, and
 // two stacks that resolve the same project name are one stack as far as the
 // daemon is concerned: `up` adopts the other's containers, `down -v
 // --remove-orphans` destroys them. Nothing about that is loud — the second

--- a/test/regression/corpus_exit_status_lockstep_test.go
+++ b/test/regression/corpus_exit_status_lockstep_test.go
@@ -15,7 +15,8 @@ import (
 const exitStatusColumn = "exit_status"
 
 // TestCorpusExitStatusLockstep pins the exit_status token set across the two
-// packages that hold their own copy of it.
+// packages that hold their own copy of it (#1341, which reconciled the enum
+// after the two drifted).
 //
 // optcorpus WRITES the column; routerrules VALIDATES mining rules against a
 // closed domain for it, and deliberately keeps its own copy so it depends on

--- a/test/regression/corpus_nonpromql_reason_e2e_test.go
+++ b/test/regression/corpus_nonpromql_reason_e2e_test.go
@@ -95,7 +95,8 @@ func e2eTracedContext(ctx context.Context) context.Context {
 // TestCorpusNonPromQLReasonReachesPersistedRow drives a REAL non-PromQL query
 // (TraceQL) through the real engine into a real optcorpus.Reconciler and asserts
 // the persisted Row carries decision_reason="non-promql" with no route and no
-// solver geometry.
+// solver geometry. It pins the gap #1421 closed: recording non-PromQL dispatch
+// reasons.
 //
 // It exists because the two unit layers each proved half of this and the whole
 // was still broken. internal/engine's solver-wiring test proved the dispatch

--- a/test/regression/cursor_teardown_order_test.go
+++ b/test/regression/cursor_teardown_order_test.go
@@ -16,7 +16,8 @@ import (
 	"github.com/tsouza/cerberus/internal/schema"
 )
 
-// Layer 10 — cursor-teardown ordering and bounding at the HTTP seam.
+// Layer 10 — cursor-teardown ordering and bounding at the HTTP seam (#1347,
+// which fixed pooled ClickHouse connections leaking on cursor teardown).
 //
 // clickhouse-go releases a pooled connection only when a query reaches its
 // terminal state with the query context STILL LIVE. Close on an already-

--- a/test/regression/forbid_deferral_trigger_test.go
+++ b/test/regression/forbid_deferral_trigger_test.go
@@ -5,9 +5,9 @@ import (
 	"testing"
 )
 
-// `forbid-deferral` reads three surfaces, and one of them — the pull request
-// DESCRIPTION — is not part of the git history at all. That makes its trigger
-// list load-bearing in a way no other gate's is.
+// This pins #1560. `forbid-deferral` reads three surfaces, and one of them —
+// the pull request DESCRIPTION — is not part of the git history at all. That
+// makes its trigger list load-bearing in a way no other gate's is.
 //
 // GitHub's default `pull_request:` trigger is opened + synchronize + reopened.
 // `edited`, which is the event a description change raises, is NOT in it. The

--- a/test/regression/fork_version_skew_test.go
+++ b/test/regression/fork_version_skew_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 )
 
-// TestForkVersionSkew pins the correspondence between the upstream version
+// TestForkVersionSkew (#832) pins the correspondence between the upstream version
 // each tsouza/* parser fork is based on (recorded as the `require` line in
 // go.mod that the fork's `replace` substitutes for) and the reference
 // backend container the matching compatibility harness diffs cerberus

--- a/test/regression/goleak_test.go
+++ b/test/regression/goleak_test.go
@@ -22,7 +22,7 @@ import (
 	"github.com/tsouza/cerberus/internal/schema"
 )
 
-// Layer 11 — goroutine-leak detector tests. Each test opens a real
+// Layer 11 — goroutine-leak detector tests (#253). Each test opens a real
 // httptest.Server, drives N requests through one handler entrypoint,
 // closes the server, and asserts goleak.VerifyNone(t) finds no leaked
 // goroutines.

--- a/test/regression/grafana_dashboard_copy_parity_test.go
+++ b/test/regression/grafana_dashboard_copy_parity_test.go
@@ -10,8 +10,9 @@ import (
 	"testing"
 )
 
-// The cerberus self-observability dashboard exists in three places, and every
-// one of them is hand-maintained:
+// This pins the drift #2042 surfaced when the error-rate panel landed in one
+// copy but not the others. The cerberus self-observability dashboard exists
+// in three places, and every one of them is hand-maintained:
 //
 //   - test/e2e/grafana/dashboards/cerberus.json — the k3d editable copy.
 //   - test/e2e/k3s/grafana-dashboards.yaml — the k3d DEPLOYED copy, the same

--- a/test/regression/guard_git_hook_test.go
+++ b/test/regression/guard_git_hook_test.go
@@ -10,7 +10,7 @@ import (
 	"testing"
 )
 
-// `.claude/hooks/guard-git.mjs` is a PreToolUse hook that refuses a `git
+// This pins #1853. `.claude/hooks/guard-git.mjs` is a PreToolUse hook that refuses a `git
 // commit` / `git push` aimed at `main`, and refuses either while lefthook's
 // git hooks are missing. Its whole value is that it fires on the commands an
 // agent actually types, and its whole cost is that a false positive blocks

--- a/test/regression/inert_seeded_fixture_test.go
+++ b/test/regression/inert_seeded_fixture_test.go
@@ -30,7 +30,7 @@ const (
 	floorValidatedKey = "validated:"
 )
 
-// TestNoInertSeededFixtures fails when a TXTAR fixture carries a
+// TestNoInertSeededFixtures (#1411) fails when a TXTAR fixture carries a
 // non-empty `-- seed --` but cannot execute, without declaring why.
 //
 // The class it pins: a seeded fixture with no `-- expected_rows --`

--- a/test/regression/lint_build_tags_test.go
+++ b/test/regression/lint_build_tags_test.go
@@ -12,7 +12,7 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
-// golangci-lint analyses ONE build configuration per invocation. That single
+// This pins #1613. golangci-lint analyses ONE build configuration per invocation. That single
 // fact is why a lint gate can report green over a tree it never read: a run
 // that sets no tags cannot see a `//go:build chdb` file, and `./...` reports
 // clean over what is left. The green then reads as "the tree is clean" when it

--- a/test/regression/lint_cache_test.go
+++ b/test/regression/lint_cache_test.go
@@ -18,7 +18,7 @@ const golangciActionMarker = "golangci/golangci-lint-action@"
 // skipCacheInput is the input that makes the lane analyse cold.
 const skipCacheInput = "skip-cache: true"
 
-// TestLintLaneAnalysesCold pins the `lint` job to a cache-independent run.
+// TestLintLaneAnalysesCold (#1363) pins the `lint` job to a cache-independent run.
 //
 // golangci-lint-action stores its analysis cache as a GitHub Actions cache
 // entry, and those entries are immutable: a key is written once and every

--- a/test/regression/logsafe_codeql_barrier_test.go
+++ b/test/regression/logsafe_codeql_barrier_test.go
@@ -1,7 +1,8 @@
 package regression
 
 // Pins the two strings.ReplaceAll calls that make telemetry.SanitizeForLog a
-// barrier CodeQL can see.
+// barrier CodeQL can see (#1903, the field inventory whose review surfaced
+// the CodeQL log-injection barrier requirement).
 //
 // Every request-derived value cerberus logs goes through SanitizeForLog, which
 // escapes the whole control-character range and is therefore correct at runtime

--- a/test/regression/migration_story_dispatch_test.go
+++ b/test/regression/migration_story_dispatch_test.go
@@ -9,7 +9,7 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
-// The migration lane's `story` dispatch input narrows a manual run to ONE MIG
+// This pins #1328. The migration lane's `story` dispatch input narrows a manual run to ONE MIG
 // id, so an operator debugging a single story does not pay for the full
 // three-tier substrate. The narrowing is per-tier: each tier job's
 // scenario-executing step forwards STORY, and migration-e2e.mjs turns it into

--- a/test/regression/migration_tier0_pr_gate_test.go
+++ b/test/regression/migration_tier0_pr_gate_test.go
@@ -1,6 +1,6 @@
 package regression
 
-// Pins the Tier-0 migration scenarios to a required pull-request lane.
+// Pins the Tier-0 migration scenarios to a required pull-request lane (#1364).
 //
 // The Tier-0 slice asserts, byte for byte, that `cerberus migrate` still
 // emits the committed explain goldens under

--- a/test/regression/migration_tier2_test.go
+++ b/test/regression/migration_tier2_test.go
@@ -5,7 +5,8 @@ import (
 	"testing"
 )
 
-// Tier-2's own published-port band, and the pins that keep it honest.
+// Tier-2's own published-port band, and the pins that keep it honest (#2068,
+// which diffed MIG-18/MIG-19 against a real incumbent ruler).
 //
 // Tier-1 has had TestMigrationTier1PortBand since it was written; Tier-2 had
 // none, so its ports were governed only by a comment in the compose file. That

--- a/test/regression/migration_tier_reports_test.go
+++ b/test/regression/migration_tier_reports_test.go
@@ -10,6 +10,9 @@ import (
 	"testing"
 )
 
+// This pins #1293, which let tier-2 write the run report its scenarios are
+// attested from.
+//
 // tiersDir holds one package per tier, each standing up its own godog suite.
 const tiersDir = "../../test/e2e/migration/tiers"
 

--- a/test/regression/mirror_inventory_test.go
+++ b/test/regression/mirror_inventory_test.go
@@ -9,7 +9,7 @@ import (
 	"testing"
 )
 
-// The GHCR mirror only helps for images it actually holds. `mirroredRef`
+// This pins #1579. The GHCR mirror only helps for images it actually holds. `mirroredRef`
 // returns null for anything outside `mirroredImages`, and `pullImageWithRetry`
 // then falls straight through to Docker Hub — quietly, because a fallback is
 // the correct behaviour for an image nobody has mirrored yet.

--- a/test/regression/mirror_login_test.go
+++ b/test/regression/mirror_login_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 )
 
-// The GHCR mirror (.github/scripts/lib/mirror.mjs) holds cerberus's own copy of
+// This pins #1579. The GHCR mirror (.github/scripts/lib/mirror.mjs) holds cerberus's own copy of
 // every upstream image its CI pulls, and `pullImageWithRetry` reaches for that
 // copy before Docker Hub. The packages are PRIVATE — publishing them would put
 // other projects' images under this org's name for anyone to pull — so a job

--- a/test/regression/mutation_leg_partition_test.go
+++ b/test/regression/mutation_leg_partition_test.go
@@ -11,6 +11,9 @@ import (
 	"testing"
 )
 
+// This pins #1295: reclaiming uncovered files and pinning the mutation-leg
+// partition.
+
 // repoRoot locates the module root from this package's directory.
 const repoRoot = "../.."
 

--- a/test/regression/mutation_timeout_max_test.go
+++ b/test/regression/mutation_timeout_max_test.go
@@ -28,7 +28,7 @@ const (
 // argument outright.
 const gremlinsForkTagPrefix = "github.com/tsouza/gremlins/cmd/gremlins@v0.6.0-cerberus-timeout-max"
 
-// TestMutationLaneCapsPerMutantTimeout pins the one bound that keeps the
+// TestMutationLaneCapsPerMutantTimeout (#1294) pins the one bound that keeps the
 // mutation lane from killing its own runner.
 //
 // gremlins derives a mutant's test timeout as `timeout-coefficient x the

--- a/test/regression/parity_coverage_test.go
+++ b/test/regression/parity_coverage_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/tsouza/cerberus/test/spec"
 )
 
-// TestPromQLParityCoverageIsComplete closes the PromQL corpus: every fixture
+// TestPromQLParityCoverageIsComplete (#2187) closes the PromQL corpus: every fixture
 // carries either a real parity enrolment or a reviewed, closed-vocabulary
 // exemption, never neither and never both.
 func TestPromQLParityCoverageIsComplete(t *testing.T) {

--- a/test/regression/parity_enrolment_test.go
+++ b/test/regression/parity_enrolment_test.go
@@ -20,7 +20,7 @@ const (
 
 var parityEnrolmentHeads = []string{"promql", "logql", "traceql"}
 
-// TestParityEnrolmentBaseline pins the exact identity of every TXTAR fixture
+// TestParityEnrolmentBaseline (split out of the parity contract in #2194) pins the exact identity of every TXTAR fixture
 // carrying a live-reference parity contract. Counts are insufficient here: a
 // removed oracle case and an unrelated new case in the same head would preserve
 // the count while silently changing the semantic surface.

--- a/test/regression/parity_helpers_test.go
+++ b/test/regression/parity_helpers_test.go
@@ -7,6 +7,10 @@ import (
 	"testing"
 )
 
+// Shared fixture-path helpers, split out of the single parity contract test
+// in #2194 so each of the resulting ratchets (coverage, enrolment, sections,
+// vocabulary) can be read and fail independently.
+
 func repoRootForParity(t *testing.T) string {
 	t.Helper()
 	wd, err := os.Getwd()

--- a/test/regression/parity_oracle_imports_test.go
+++ b/test/regression/parity_oracle_imports_test.go
@@ -6,6 +6,9 @@ import (
 	"testing"
 )
 
+// This pins #1983, which checked TXTAR fixtures against the real Prometheus
+// engine and made the oracle's independence from cerberus load-bearing.
+//
 // parityOraclePkgs is the pattern covering every reference-engine
 // package whose independence from cerberus is the load-bearing property
 // of the whole parity layer.

--- a/test/regression/parity_sections_test.go
+++ b/test/regression/parity_sections_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/tsouza/cerberus/test/spec"
 )
 
-// TestParitySectionsParse asserts every fixture carrying a `parity:`
+// TestParitySectionsParse (split out of the parity contract in #2194) asserts every fixture carrying a `parity:`
 // section has a WELL-FORMED one.
 //
 // LoadParity deliberately errors rather than skipping on a malformed body,

--- a/test/regression/parity_vocabulary_test.go
+++ b/test/regression/parity_vocabulary_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/tsouza/cerberus/test/spec"
 )
 
-// TestParityVocabulariesAreClosed asserts the accepted values are a closed
+// TestParityVocabulariesAreClosed (split out of the parity contract in #2194) asserts the accepted values are a closed
 // set with no empty members — the property LoadParity's rejection path
 // depends on.
 func TestParityVocabulariesAreClosed(t *testing.T) {

--- a/test/regression/quickstart_canary_test.go
+++ b/test/regression/quickstart_canary_test.go
@@ -11,6 +11,8 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
+// This pins #2246, which required the published quickstart canary.
+
 const (
 	quickstartWorkflowPath = "../../.github/workflows/quickstart.yml"
 	quickstartScriptPath   = "../../.github/scripts/quickstart-canary.mjs"

--- a/test/regression/release_gate_test.go
+++ b/test/regression/release_gate_test.go
@@ -8,7 +8,7 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
-// The release pipeline's shape is the only thing standing between a merge and a
+// This pins #1296. The release pipeline's shape is the only thing standing between a merge and a
 // public artifact, and none of it is exercised by a PR: release.yml has no
 // `pull_request:` trigger, so every edit to it is unverified until a release is
 // actually cut. The pins below are pure file reads over the workflows and

--- a/test/regression/release_required_checks_test.go
+++ b/test/regression/release_required_checks_test.go
@@ -17,6 +17,9 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
+// This pins #1322, which closed three gaps that let a release ship
+// unverified.
+//
 // On the MAINTENANCE publish path (`release/*.x`) there is no pull request, so
 // there is no branch protection either: release.yml's preflight is the ONLY
 // gate between a push and a published artifact. That makes two silent failure

--- a/test/regression/router_corpus_seed_test.go
+++ b/test/regression/router_corpus_seed_test.go
@@ -11,6 +11,8 @@ import (
 	"github.com/tsouza/cerberus/internal/solver"
 )
 
+// This pins #1062, the concrete 5-rule ruleset and chDB-parity harness.
+//
 // routerCorpusDir holds every JSONL fixture the routerrules harnesses mine.
 // Path is relative to this test package directory.
 const routerCorpusDir = "../../internal/routerrules/testdata"

--- a/test/regression/scan_resource_bound_test.go
+++ b/test/regression/scan_resource_bound_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/tsouza/cerberus/internal/chplan"
 )
 
-// This meta-test pins the spans-scan resource-bound invariant at the chplan
+// This pins #1154 (the traces-drilldown OOM). This meta-test pins the spans-scan resource-bound invariant at the chplan
 // level: chplan.RequireSpansScansBounded must reject a bare (unbounded) spans
 // Scan and accept the three legitimate partition-bounded leaf shapes. It is a
 // static plan-walk pin — no SQL emission, no chDB — so a regression that

--- a/test/regression/strict_scan_image_floor_test.go
+++ b/test/regression/strict_scan_image_floor_test.go
@@ -16,7 +16,7 @@ const strictScanSourcePath = "../spec/strictscan_integration_test.go"
 // strictScanImageVar is the Justfile variable the strict-scan recipe pre-pulls.
 const strictScanImageVar = "CH_STRICT_SCAN_IMAGE"
 
-// TestStrictScanImageClearsChoptFloors is the ratchet that keeps the strict-scan
+// TestStrictScanImageClearsChoptFloors (#1411) is the ratchet that keeps the strict-scan
 // lane able to EXECUTE every shape the emitter can produce.
 //
 // The lane runs the spec corpus's emitted SQL against a real ClickHouse. When

--- a/test/regression/tagged_test_enrollment_test.go
+++ b/test/regression/tagged_test_enrollment_test.go
@@ -23,6 +23,8 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
+// This pins #2242, which hardened test-fence enrollment semantics.
+
 const (
 	taggedEntrypointDirect = "direct"
 	taggedEntrypointRecipe = "recipe"

--- a/test/regression/telemetry_provider_ordering_test.go
+++ b/test/regression/telemetry_provider_ordering_test.go
@@ -8,7 +8,8 @@ import (
 	"testing"
 )
 
-// Layer 8 — startup ordering of the OTel MeterProvider install.
+// Layer 8 — startup ordering of the OTel MeterProvider install (#1347, whose
+// cursor-teardown fix is what surfaced the seeded-counter ordering hazard).
 //
 // OTel's package-global MeterProvider is a DELEGATING shim. Instruments minted
 // off it before the real provider is installed forward to the SDK once

--- a/test/regression/tempo_entrypoint_parity_test.go
+++ b/test/regression/tempo_entrypoint_parity_test.go
@@ -1,4 +1,4 @@
-// Cross-transport parity for the Tempo head. The same query, driven
+// This pins #1581. Cross-transport parity for the Tempo head. The same query, driven
 // against the same stub ClickHouse client, must produce the same
 // ANSWER over HTTP and over the gRPC StreamingQuerier — both the
 // error classification and the search-metrics accounting.


### PR DESCRIPTION
## Summary

- `test/regression/doc.go` requires every meta-test here to reference the commit / PR / bug it
  guards against, so a future maintainer knows the motivation if the test fails on an unrelated
  change. A pre-release audit found 42 of the 77 `test/regression/*_test.go` files carried no such
  reference at all — several with substantial mechanism prose but no citation.
- For each of the 42 files, this adds a citation to the file's real introducing PR (found via
  `git log --follow --diff-filter=A`), woven into the existing doc comment rather than bolted on as
  a bare number.
- Comment-only change; no test behavior, assertions, or build tags touched.

## Test plan

- [x] `gofmt -l` / `gofumpt -extra -l` clean on every touched file
- [x] `go vet ./test/regression/...` clean
- [x] `go test -run '^$' ./test/regression/...` compiles (`[no tests to run]`)
- [x] Verified 0/77 files remain without a traceable `#NNNN` / issue / commit reference
- [x] `lefthook` pre-commit (gofumpt, goimports, commitlint) and pre-push (forbid-skip,
      forbid-sql-raw, forbid-escape-hatch, actionlint, etc.) all green locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)
