### PR TITLE
fix(ci): give the mutation lane's gremlins job a deep checkout for its diff_ref

### DIFF
--- a/.github/scripts/mutation-matrix.test.mjs
+++ b/.github/scripts/mutation-matrix.test.mjs
@@ -64,6 +64,36 @@ test('the shipped PHASES table is sound against this tree', () => {
   );
 });
 
+// A non-empty matrix.diff_ref makes the `mutate` job's own `gremlins
+// unleash` step run `git diff DIFF_REF` internally (mutation-run.mjs's
+// header: "A non-empty DIFF_REF first invokes gremlins' native merge-base
+// line filter"), which needs that ref's object actually fetched. A shallow
+// (depth-1) checkout only has the job's own head commit, so any diff_ref
+// pointing anywhere else fails with `fatal: bad object <sha>` — observed
+// on PRs #2282-#2284, all opened against the same recent main tip, and
+// silent on later PRs only because their diff_ref happened to come back
+// empty (no changed-line scoping needed), not because the checkout was
+// sufficient. Pins the `mutate` job's checkout to the same fetch-depth: 0
+// the `select` job right above it already carries, and for the identical
+// documented reason.
+test("the mutate job's checkout can resolve any diff_ref gremlins might diff against", () => {
+  const workflow = readFileSync('.github/workflows/mutation.yml', 'utf8');
+  const mutateStart = workflow.indexOf('\n  mutate:');
+  assert.ok(mutateStart >= 0, 'mutation.yml: missing mutate job');
+  const nextJob = workflow.indexOf('\n  mutation:', mutateStart);
+  const mutateJob = workflow.slice(mutateStart, nextJob >= 0 ? nextJob : undefined);
+  const checkoutIndex = mutateJob.indexOf('actions/checkout@');
+  assert.ok(checkoutIndex >= 0, 'mutate job: no actions/checkout step');
+  const nextStepIndex = mutateJob.indexOf('\n      - uses:', checkoutIndex);
+  const checkoutStep = mutateJob.slice(checkoutIndex, nextStepIndex >= 0 ? nextStepIndex : undefined);
+  assert.match(
+    checkoutStep,
+    /fetch-depth:\s*0/,
+    'mutate job: checkout needs fetch-depth: 0 — gremlins diffs matrix.diff_ref internally and a ' +
+      'shallow clone cannot resolve an arbitrary ref',
+  );
+});
+
 test('the registry-owned universe survives deletion of a complete phase', () => {
   const withoutChplan = PHASES.filter((phase) => phase.phase !== 'phase1');
   const problems = ownershipViolations({

--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -136,6 +136,19 @@ jobs:
       matrix: ${{ fromJSON(needs.select.outputs.matrix) }}
     steps:
       - uses: actions/checkout@v7
+        with:
+          # A non-empty matrix.diff_ref (below) makes gremlins run its own
+          # `git diff DIFF_REF` internally to scope mutants to changed lines
+          # — the exact hazard the `select` job's own checkout comment
+          # already documents for the identical operation: "a shallow clone
+          # cannot resolve" a merge-base diff. This job's checkout was never
+          # given the same fetch-depth: 0, so gremlins failed outright with
+          # `fatal: bad object <sha>` on every phase whose diff_ref pointed
+          # at a commit this shallow (depth-1) clone never fetched (observed
+          # on PRs #2282-#2284, all opened against the same recent main tip;
+          # #2286+ passed only because later phases happened not to need the
+          # diff path, not because the checkout was sufficient).
+          fetch-depth: 0
       - uses: actions/setup-go@v7
         with:
           go-version-file: 'go.mod'


### PR DESCRIPTION
## Summary

- an "awkward pattern" on the latest audit PRs — `gremlins phase1` failing on PR #2282, a pure two-line comment/citation change with zero code diff, which cannot legitimately fail a mutation-score gate.
- Root cause: `gremlins phase1`'s log shows `ERROR: an error occured while calling git diff: exit status 128` / `fatal: bad object fc2ce8be17aa68d72b91c0291fd6dfd8726fde10`. `matrix.diff_ref` (main's tip at the time these PRs opened) is passed to gremlins as `DIFF_REF`; per `mutation-run.mjs`'s own header, a non-empty `DIFF_REF` makes gremlins run `git diff DIFF_REF` internally to scope mutants to changed lines. The `mutate` job's `actions/checkout@v7` step is a plain shallow (depth-1) clone — it never fetches that ref, so gremlins' internal diff fails outright.
- The `select` job earlier in the same file already hit and fixed the identical class of bug for its own merge-base diff, with the comment: *"The selector diffs the PR head against its MERGE BASE, which a shallow clone cannot resolve."* — but that `fetch-depth: 0` was never mirrored onto the `mutate` job, which needs it for the same reason.
- Confirmed this isn't diff-scoping-specific flakiness: PRs #2282-#2284 (all opened against the same recent main tip) failed identically; later audit PRs' gremlins legs (e.g. #2286) passed only because their `diff_ref` happened to come back empty that run (verified directly in the job log: `DIFF_REF: ` with nothing after it) — not because the shallow checkout was actually sufficient.

## Fix

- `.github/workflows/mutation.yml`: give the `mutate` job's checkout `fetch-depth: 0`, matching the `select` job's existing pattern and reasoning.
- `.github/scripts/mutation-matrix.test.mjs`: new regression test parsing the workflow YAML directly (mirroring the existing `propertyJobTimeoutMinutes()`-style pattern in `property-fanout.test.mjs`) that asserts the `mutate` job's checkout carries `fetch-depth: 0`. Verified it fails against the pre-fix workflow and passes with the fix.

## Test plan

- [x] `node --test .github/scripts/mutation-matrix.test.mjs` — 35/35 pass.
- [x] New test verified to fail against the pre-fix `mutation.yml` (not vacuous).
- [x] `actionlint .github/workflows/mutation.yml` — clean.
- [ ] Real validation is the `gremlins`/`mutation` checks on this PR itself and the next audit-style PR opened after a `main` push moves the diff_ref forward again.
