### PR TITLE
refactor(logql): drop redundant private twin of NormalizeDottedLabels

### DIFF
--- a/internal/logql/coverage_gaps_internal_test.go
+++ b/internal/logql/coverage_gaps_internal_test.go
@@ -113,10 +113,6 @@ func TestNormalizeDottedLabels_RewritesOnlyTheSelectorKeys(t *testing.T) {
 	if !strings.Contains(got, `"a.b"`) {
 		t.Fatalf("the value must not be rewritten: %q", got)
 	}
-	// The package-private twin Lang.Parse routes through must agree.
-	if other := normalizeLokiDottedLabels(`{service.name="a.b"}`); other != got {
-		t.Fatalf("normalizeLokiDottedLabels = %q, want %q", other, got)
-	}
 }
 
 // =================================================================

--- a/internal/logql/dotted_labels.go
+++ b/internal/logql/dotted_labels.go
@@ -13,10 +13,3 @@ import syntax "github.com/tsouza/cerberus/internal/logql/lsyntax"
 func NormalizeDottedLabels(q string) string {
 	return syntax.NormalizeDottedLabels(q)
 }
-
-// normalizeLokiDottedLabels is the package-private form Lang.Parse
-// routes through, for symmetry with the PromQL head's own
-// dotted-name normaliser.
-func normalizeLokiDottedLabels(q string) string {
-	return syntax.NormalizeDottedLabels(q)
-}

--- a/internal/logql/lang.go
+++ b/internal/logql/lang.go
@@ -356,7 +356,7 @@ func parseExprTraced(ctx context.Context, query string) (syntax.Expr, error) {
 	// `parse error … unexpected '.'`. The OTel-CH schema stores both
 	// forms on each row, so the underscored matcher targets the same
 	// data the dotted form would.
-	expr, err := ParseExprPermissive(normalizeLokiDottedLabels(query))
+	expr, err := ParseExprPermissive(NormalizeDottedLabels(query))
 	if err != nil {
 		span.RecordError(err)
 		return nil, err


### PR DESCRIPTION
## Summary

- Fixes a confirmed pre-release audit finding (area: logql): `normalizeLokiDottedLabels` in
  `internal/logql/dotted_labels.go:17` was a byte-identical, entirely redundant private duplicate
  of the exported `NormalizeDottedLabels` in the same file. Its comment claimed the pair existed
  "for symmetry with the PromQL head's own dotted-name normaliser," but no such PromQL
  exported/private pair exists.
- `Lang.Parse` (`internal/logql/lang.go:359`) now calls the exported `NormalizeDottedLabels`
  directly instead of the removed private twin.
- Removed the test assertion in `coverage_gaps_internal_test.go` that only existed to check the
  two duplicate functions agreed with each other.

## Test plan

- [x] `go test -race -run '^(TestNormalizeDottedLabels_RewritesOnlyTheSelectorKeys|TestLang_Parse_NormalisesDottedStreamSelectorKeys)$' ./internal/logql/`
- [x] `go test -race ./internal/logql/...` (full package + subpackages)
- [x] `gofumpt -l` / `goimports -local` clean on touched files

🤖 Generated with [Claude Code](https://claude.com/claude-code)
