### PR TITLE
fix(optimizer): close constant-fold and dead-code audit findings

### DIFF
--- a/internal/optimizer/constant_fold.go
+++ b/internal/optimizer/constant_fold.go
@@ -139,12 +139,12 @@ func foldNode(n chplan.Node, foldFn func(chplan.Expr) (chplan.Expr, bool)) (chpl
 // flavours (semantic literal arithmetic, heuristic boolean identities)
 // differ only in that per-Binary function.
 //
-// Every chplan Expr kind that holds a child Expr must appear here — a
-// missing case silently strands any pure-literal subtree nested inside
-// it unfolded. This mirrors projection_pushdown.go's walkExpr, which
-// documents the same exhaustiveness requirement for column-reference
-// discovery; the two switches should be kept in lockstep over the
-// chplan Expr vocabulary.
+// Every chplan Expr kind that holds a child Expr must appear here or in
+// foldExprSingleChild — a missing case silently strands any pure-literal
+// subtree nested inside it unfolded. This mirrors projection_pushdown.go's
+// walkExpr, which documents the same exhaustiveness requirement for
+// column-reference discovery; the switches should be kept in lockstep over
+// the chplan Expr vocabulary.
 func foldExprWith(e chplan.Expr, foldBinary func(*chplan.Binary) (chplan.Expr, bool)) (chplan.Expr, bool) {
 	switch v := e.(type) {
 	case *chplan.Binary:
@@ -198,12 +198,6 @@ func foldExprWith(e chplan.Expr, foldBinary func(*chplan.Binary) (chplan.Expr, b
 			return v, false
 		}
 		return &chplan.InList{Left: nl, List: newList, Negated: v.Negated}, true
-	case *chplan.FieldAccess:
-		ns, ch := foldExprWith(v.Source, foldBinary)
-		if !ch {
-			return v, false
-		}
-		return &chplan.FieldAccess{Source: ns, Path: v.Path}, true
 	case *chplan.Subscript:
 		nc, cc := foldExprWith(v.Container, foldBinary)
 		nk, kc := foldExprWith(v.Key, foldBinary)
@@ -211,6 +205,22 @@ func foldExprWith(e chplan.Expr, foldBinary func(*chplan.Binary) (chplan.Expr, b
 			return v, false
 		}
 		return &chplan.Subscript{Container: nc, Key: nk}, true
+	}
+	return foldExprSingleChild(e, foldBinary)
+}
+
+// foldExprSingleChild handles the chplan Expr kinds that hold exactly one
+// child Expr and rebuild via a field copy — split out of foldExprWith
+// purely to keep that function's cognitive complexity within budget; see
+// its doc comment for the exhaustiveness requirement this shares.
+func foldExprSingleChild(e chplan.Expr, foldBinary func(*chplan.Binary) (chplan.Expr, bool)) (chplan.Expr, bool) {
+	switch v := e.(type) {
+	case *chplan.FieldAccess:
+		ns, ch := foldExprWith(v.Source, foldBinary)
+		if !ch {
+			return v, false
+		}
+		return &chplan.FieldAccess{Source: ns, Path: v.Path}, true
 	case *chplan.Lambda:
 		nb, ch := foldExprWith(v.Body, foldBinary)
 		if !ch {

--- a/internal/optimizer/constant_fold.go
+++ b/internal/optimizer/constant_fold.go
@@ -138,6 +138,13 @@ func foldNode(n chplan.Node, foldFn func(chplan.Expr) (chplan.Expr, bool)) (chpl
 // Binary node after that node's children have been folded. The two
 // flavours (semantic literal arithmetic, heuristic boolean identities)
 // differ only in that per-Binary function.
+//
+// Every chplan Expr kind that holds a child Expr must appear here — a
+// missing case silently strands any pure-literal subtree nested inside
+// it unfolded. This mirrors projection_pushdown.go's walkExpr, which
+// documents the same exhaustiveness requirement for column-reference
+// discovery; the two switches should be kept in lockstep over the
+// chplan Expr vocabulary.
 func foldExprWith(e chplan.Expr, foldBinary func(*chplan.Binary) (chplan.Expr, bool)) (chplan.Expr, bool) {
 	switch v := e.(type) {
 	case *chplan.Binary:
@@ -176,6 +183,87 @@ func foldExprWith(e chplan.Expr, foldBinary func(*chplan.Binary) (chplan.Expr, b
 			return v, false
 		}
 		return &chplan.FuncCall{Fn: v.Fn, Args: newArgs}, true
+	case *chplan.InList:
+		nl, lc := foldExprWith(v.Left, foldBinary)
+		newList := make([]chplan.Expr, len(v.List))
+		anyChange := lc
+		for i, e := range v.List {
+			ne, ch := foldExprWith(e, foldBinary)
+			newList[i] = ne
+			if ch {
+				anyChange = true
+			}
+		}
+		if !anyChange {
+			return v, false
+		}
+		return &chplan.InList{Left: nl, List: newList, Negated: v.Negated}, true
+	case *chplan.FieldAccess:
+		ns, ch := foldExprWith(v.Source, foldBinary)
+		if !ch {
+			return v, false
+		}
+		return &chplan.FieldAccess{Source: ns, Path: v.Path}, true
+	case *chplan.Subscript:
+		nc, cc := foldExprWith(v.Container, foldBinary)
+		nk, kc := foldExprWith(v.Key, foldBinary)
+		if !cc && !kc {
+			return v, false
+		}
+		return &chplan.Subscript{Container: nc, Key: nk}, true
+	case *chplan.Lambda:
+		nb, ch := foldExprWith(v.Body, foldBinary)
+		if !ch {
+			return v, false
+		}
+		return &chplan.Lambda{Params: v.Params, Body: nb}, true
+	case *chplan.LabelJoin:
+		nm, ch := foldExprWith(v.Map, foldBinary)
+		if !ch {
+			return v, false
+		}
+		cp := *v
+		cp.Map = nm
+		return &cp, true
+	case *chplan.LabelReplace:
+		nm, ch := foldExprWith(v.Map, foldBinary)
+		if !ch {
+			return v, false
+		}
+		cp := *v
+		cp.Map = nm
+		return &cp, true
+	case *chplan.LineContent:
+		ns, ch := foldExprWith(v.Source, foldBinary)
+		if !ch {
+			return v, false
+		}
+		cp := *v
+		cp.Source = ns
+		return &cp, true
+	case *chplan.MapWithoutEmptyValues:
+		nm, ch := foldExprWith(v.Map, foldBinary)
+		if !ch {
+			return v, false
+		}
+		return &chplan.MapWithoutEmptyValues{Map: nm}, true
+	case *chplan.MapWithoutKeys:
+		nm, ch := foldExprWith(v.Map, foldBinary)
+		if !ch {
+			return v, false
+		}
+		return &chplan.MapWithoutKeys{Map: nm, Keys: v.Keys}, true
+	case *chplan.NestedArrayExists:
+		if v.Value == nil {
+			return v, false
+		}
+		nval, ch := foldExprWith(v.Value, foldBinary)
+		if !ch {
+			return v, false
+		}
+		cp := *v
+		cp.Value = nval
+		return &cp, true
 	}
 	return e, false
 }

--- a/internal/optimizer/constant_fold_expr_positions_test.go
+++ b/internal/optimizer/constant_fold_expr_positions_test.go
@@ -1,0 +1,126 @@
+package optimizer_test
+
+// Regression coverage for foldExprWith's expression-position walker
+// (internal/optimizer/constant_fold.go). The walker must recurse into
+// every chplan Expr kind that holds a child Expr — a missing case
+// silently strands a pure-literal Binary subtree unfolded when it sits
+// under a Lambda body, an InList element, a FieldAccess/Subscript/
+// LineContent source, a LabelJoin/LabelReplace/MapWithoutKeys/
+// MapWithoutEmptyValues map, or a NestedArrayExists value. Each of
+// these is a real lowering shape (e.g. LogQL lowers predicates through
+// Lambda bodies), so an unfolded literal here reaches the emitter as a
+// live Binary instead of the collapsed Lit downstream rules assume.
+
+import (
+	"testing"
+
+	"github.com/tsouza/cerberus/internal/chplan"
+	"github.com/tsouza/cerberus/internal/optimizer"
+)
+
+// literalSum is the canonical pure-literal Binary every case embeds:
+// `1 + 2`, which ConstantFoldSemantic collapses to LitInt(3).
+func literalSum() *chplan.Binary {
+	return &chplan.Binary{Op: chplan.OpAdd, Left: &chplan.LitInt{V: 1}, Right: &chplan.LitInt{V: 2}}
+}
+
+func TestConstantFoldSemantic_RecursesEveryExprPosition(t *testing.T) {
+	t.Parallel()
+
+	want := &chplan.LitInt{V: 3}
+
+	cases := []struct {
+		name    string
+		wrap    func(inner chplan.Expr) chplan.Expr
+		extract func(e chplan.Expr) chplan.Expr
+	}{
+		{
+			name: "Lambda.Body",
+			wrap: func(inner chplan.Expr) chplan.Expr {
+				return &chplan.Lambda{Params: []string{"x"}, Body: inner}
+			},
+			extract: func(e chplan.Expr) chplan.Expr { return e.(*chplan.Lambda).Body },
+		},
+		{
+			name: "InList element",
+			wrap: func(inner chplan.Expr) chplan.Expr {
+				return &chplan.InList{Left: &chplan.ColumnRef{Name: "c"}, List: []chplan.Expr{inner}}
+			},
+			extract: func(e chplan.Expr) chplan.Expr { return e.(*chplan.InList).List[0] },
+		},
+		{
+			name: "FieldAccess.Source",
+			wrap: func(inner chplan.Expr) chplan.Expr {
+				return &chplan.FieldAccess{Source: inner, Path: "http.method"}
+			},
+			extract: func(e chplan.Expr) chplan.Expr { return e.(*chplan.FieldAccess).Source },
+		},
+		{
+			name: "Subscript.Container",
+			wrap: func(inner chplan.Expr) chplan.Expr {
+				return &chplan.Subscript{Container: inner, Key: &chplan.LitString{V: "k"}}
+			},
+			extract: func(e chplan.Expr) chplan.Expr { return e.(*chplan.Subscript).Container },
+		},
+		{
+			name: "LabelJoin.Map",
+			wrap: func(inner chplan.Expr) chplan.Expr {
+				return &chplan.LabelJoin{Map: inner, Dst: "d", Separator: "-", Srcs: []string{"a"}}
+			},
+			extract: func(e chplan.Expr) chplan.Expr { return e.(*chplan.LabelJoin).Map },
+		},
+		{
+			name: "LabelReplace.Map",
+			wrap: func(inner chplan.Expr) chplan.Expr {
+				return &chplan.LabelReplace{Map: inner, Dst: "d", Src: "s", Regex: ".*", Replacement: "r"}
+			},
+			extract: func(e chplan.Expr) chplan.Expr { return e.(*chplan.LabelReplace).Map },
+		},
+		{
+			name: "MapWithoutKeys.Map",
+			wrap: func(inner chplan.Expr) chplan.Expr {
+				return &chplan.MapWithoutKeys{Map: inner, Keys: []string{"k"}}
+			},
+			extract: func(e chplan.Expr) chplan.Expr { return e.(*chplan.MapWithoutKeys).Map },
+		},
+		{
+			name: "MapWithoutEmptyValues.Map",
+			wrap: func(inner chplan.Expr) chplan.Expr {
+				return &chplan.MapWithoutEmptyValues{Map: inner}
+			},
+			extract: func(e chplan.Expr) chplan.Expr { return e.(*chplan.MapWithoutEmptyValues).Map },
+		},
+		{
+			name: "LineContent.Source",
+			wrap: func(inner chplan.Expr) chplan.Expr {
+				return &chplan.LineContent{Source: inner, Pattern: "p"}
+			},
+			extract: func(e chplan.Expr) chplan.Expr { return e.(*chplan.LineContent).Source },
+		},
+		{
+			name: "NestedArrayExists.Value",
+			wrap: func(inner chplan.Expr) chplan.Expr {
+				return &chplan.NestedArrayExists{Column: "Links", SubField: "Attributes", Key: "k", Op: chplan.OpEq, Value: inner}
+			},
+			extract: func(e chplan.Expr) chplan.Expr { return e.(*chplan.NestedArrayExists).Value },
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			filter := &chplan.Filter{Input: &chplan.Scan{Table: "t"}, Predicate: tc.wrap(literalSum())}
+
+			out, changed := optimizer.ConstantFoldSemantic{}.Apply(filter)
+			if !changed {
+				t.Fatalf("ConstantFoldSemantic did not report a change; the literal Binary under %s was never reached", tc.name)
+			}
+			got := tc.extract(out.(*chplan.Filter).Predicate)
+			if !got.Equal(want) {
+				t.Fatalf("literal Binary under %s folded to %#v; want %#v", tc.name, got, want)
+			}
+		})
+	}
+}

--- a/internal/optimizer/flatten_vector_set_op.go
+++ b/internal/optimizer/flatten_vector_set_op.go
@@ -57,10 +57,7 @@ func (FlattenVectorSetOp) Apply(n chplan.Node) (chplan.Node, bool) {
 	// order. The left child is absorbed when it's a same-shaped binary
 	// VectorSetOp or an already-flattened NaryVectorSetOp; otherwise it
 	// is a single arm.
-	arms, absorbed := flattenLeftArms(binary)
-	if !absorbed {
-		return n, false
-	}
+	arms := flattenLeftArms(binary)
 	arms = append(arms, binary.Right)
 
 	return &chplan.NaryVectorSetOp{
@@ -76,32 +73,30 @@ func (FlattenVectorSetOp) Apply(n chplan.Node) (chplan.Node, bool) {
 }
 
 // flattenLeftArms returns the arms contributed by the left child of a
-// binary VectorSetOp, in left-to-right order, plus whether the child was
-// an absorbable same-shaped chain link. When the left child is a
+// binary VectorSetOp, in left-to-right order. When the left child is a
 // matching binary VectorSetOp its own (recursively gathered) arms are
 // returned; when it's an already-flattened NaryVectorSetOp its arms are
 // spliced in; otherwise the left child is a single opaque arm.
-func flattenLeftArms(binary *chplan.VectorSetOp) (arms []chplan.Node, absorbed bool) {
+func flattenLeftArms(binary *chplan.VectorSetOp) (arms []chplan.Node) {
 	switch left := binary.Left.(type) {
 	case *chplan.VectorSetOp:
 		if !sameVectorSetOpShape(binary, left.Op, left.Match, left.StepAligned,
 			left.MetricNameColumn, left.AttributesColumn,
 			left.TimestampColumn, left.ValueColumn) {
-			return []chplan.Node{binary.Left}, true
+			return []chplan.Node{binary.Left}
 		}
-		inner, _ := flattenLeftArms(left)
-		return append(inner, left.Right), true
+		return append(flattenLeftArms(left), left.Right)
 	case *chplan.NaryVectorSetOp:
 		if !sameVectorSetOpShape(binary, left.Op, left.Match, left.StepAligned,
 			left.MetricNameColumn, left.AttributesColumn,
 			left.TimestampColumn, left.ValueColumn) {
-			return []chplan.Node{binary.Left}, true
+			return []chplan.Node{binary.Left}
 		}
 		out := make([]chplan.Node, len(left.Arms))
 		copy(out, left.Arms)
-		return out, true
+		return out
 	default:
-		return []chplan.Node{binary.Left}, true
+		return []chplan.Node{binary.Left}
 	}
 }
 

--- a/internal/optimizer/pattern.go
+++ b/internal/optimizer/pattern.go
@@ -47,8 +47,11 @@ func KindOf(n chplan.Node) NodeKind {
 	return NodeKind{t: reflect.TypeOf(n)}
 }
 
-// Predefined kinds for every concrete chplan operator. Kept in lockstep
-// with the chplan package; new operators land here when they land there.
+// Predefined kinds for the chplan operators a PatternRule currently
+// matches on. This is NOT exhaustive over chplan's concrete node
+// vocabulary — a new chplan operator does not need an entry here until
+// some PatternRule wants to capture it; KindOf gives a one-off lookup
+// for anything else.
 var (
 	KindScan           = NodeKind{t: reflect.TypeOf((*chplan.Scan)(nil))}
 	KindFilter         = NodeKind{t: reflect.TypeOf((*chplan.Filter)(nil))}


### PR DESCRIPTION
## Summary

Fixes three confirmed findings from the pre-release full-codebase audit, area `optimizer`.

- **`internal/optimizer/constant_fold.go:141`** (medium, illogical) — `foldExprWith`'s
  expression walker only recursed into `Binary`, `MapAccess`, and `FuncCall`, so a
  pure-literal `Binary` subtree nested inside a `Lambda` body, `InList` element,
  `FieldAccess`/`Subscript`/`LineContent` source, `LabelJoin`/`LabelReplace`/
  `MapWithoutKeys`/`MapWithoutEmptyValues` map, or `NestedArrayExists` value silently
  never folded — reachable in real lowerings (e.g. LogQL Lambda-bodied predicates).
  Extended the switch to the same exhaustive chplan `Expr` vocabulary
  `projection_pushdown.go`'s `walkExpr` already covers, and added a table-driven
  regression test (`constant_fold_expr_positions_test.go`) — one case per position,
  each verified to fail against the pre-fix walker and pass against the fix.

- **`internal/optimizer/flatten_vector_set_op.go:61`** (low, kiss) — `flattenLeftArms`'s
  `absorbed` return value was `true` on every one of its five return statements, making
  `Apply`'s `if !absorbed` guard dead code that could never execute. Dropped the unused
  return value.

- **`internal/optimizer/pattern.go:50`** (low, doc-drift) — the `NodeKind` var-block
  comment claimed to be "kept in lockstep with the chplan package", but only kinds an
  actual `PatternRule` matches on (3 of them, in practice) get a predefined `Kind*` var
  — not all ~31 concrete chplan node types. Corrected the comment to describe the real
  policy (predefined only for what a rule currently captures; `KindOf` covers the rest)
  instead of a false exhaustiveness claim.

All three findings were pre-verified as real by a prior audit pass; this PR re-read the
current `file:line` against fresh `origin/main` before editing (no other audit-fix PR had
already touched these three call sites).

## Test plan

- [x] `go build ./internal/optimizer/...`
- [x] `go test -race ./internal/optimizer/...` — full package green
- [x] New regression test verified RED against the pre-fix `foldExprWith` (via
      `git stash` of just `constant_fold.go`), GREEN with the fix restored
- [x] `gofumpt -l` clean on all touched files
- [x] `go vet ./internal/optimizer/...` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
