### PR TITLE
fix(chsql): render the structural-join depth bound via typed Lt/InlineLit

### DIFF
--- a/internal/chsql/structural_join.go
+++ b/internal/chsql/structural_join.go
@@ -1075,7 +1075,7 @@ func inStringLiteralsFrag(col Frag, ids []string) Frag {
 // of erroring with CH code 306 (TOO_DEEP_RECURSION).
 func structuralDepthBoundFrag(maxDepth int) Frag {
 	bound := effectiveRecursionDepth(maxDepth)
-	return verbatim("c._depth < " + strconv.Itoa(bound))
+	return Lt(verbatim("c._depth"), InlineLit(bound))
 }
 
 // findScanTable walks a plan subtree looking for the first chplan.Scan


### PR DESCRIPTION
## Summary

- Confirmed audit finding (chsql area, high severity): `structuralDepthBoundFrag` in
  `internal/chsql/structural_join.go` hand-built the recursive-CTE depth predicate
  (`c._depth < <cap>`) via `verbatim("c._depth < " + strconv.Itoa(bound))`, string-concatenating an
  emitter-computed integer into a comparison instead of composing it through the typed chsql API
  (hard invariant 10).
- `c._depth` itself stays `verbatim` — `builder.go`'s own doc comment for `verbatim` explicitly
  sanctions bare qualified references like `c._depth` as a legitimate escape (no typed accessor
  exists for a CTE's synthetic column alias). What was wrong was concatenating the numeric bound
  into that same string instead of composing it through `Lt(...)` + `InlineLit(...)`.
- Fix: `return Lt(verbatim("c._depth"), InlineLit(bound))`. `Lt`'s `binOp` renders
  `"<l> < <r>"` with the same single-space padding the original string literal used, so the
  emitted SQL is byte-identical — no golden fixtures changed.

## Scope note

The same audit finding also flagged `internal/chsql/nested_set_annotate.go:378` and `:388`
(window-function shapes built via `verbatim` + string concat instead of the typed `Window(...)`
Frag constructor). That part needs `Window` extended with a frame-clause parameter (no existing
call site needs one) plus a behavior-preserving rewrite of a correctness- and performance-critical
nested-set numbering pass, with a `chsql` golden regen to follow — real design/verification work,
not a same-turn mechanical fix. Filed as tsouza/cerberus#2297 instead of bundled here.

## Test plan

- [x] `go build ./internal/chsql/...`
- [x] `go test ./internal/chsql/ -run '^TestEmit_StructuralJoinRecursiveBoundedDepth$'` — pass
- [x] `go test ./internal/chsql/ -run 'Structural'` — pass
- [x] `node .github/scripts/forbid-sql-raw.mjs` — clean
- [x] `gofmt -l` / `gofumpt -l` on the touched file — clean
