### PR TITLE
docs(api/reqctx): stop claiming Tempo shares the timeout backstop

### DIFF
--- a/internal/api/reqctx/reqctx.go
+++ b/internal/api/reqctx/reqctx.go
@@ -1,9 +1,12 @@
-// Package reqctx hosts the request-context derivation shared across the
-// prom / loki / tempo HTTP handlers. Envelope shaping and error writing
-// stay per-handler (each upstream API has its own wire format); what
-// this package owns is the neutral plumbing every handler runs
-// identically — today, the `?timeout=` budget resolution + context
-// wiring.
+// Package reqctx hosts the request-context derivation shared by the
+// prom and loki HTTP handlers. Envelope shaping and error writing stay
+// per-handler (each upstream API has its own wire format); what this
+// package owns is the neutral plumbing those handlers run identically —
+// today, the `?timeout=` budget resolution + context wiring.
+//
+// Tempo does not call ApplyQueryTimeout: its handlers rely solely on the
+// chclient's static configured QueryTimeout, with no per-request context
+// deadline backstop. See https://github.com/tsouza/cerberus/issues/2302.
 package reqctx
 
 import (


### PR DESCRIPTION
## Summary

- `internal/api/reqctx`'s package doc claimed the `?timeout=` derivation it
  hosts is shared across all three heads ("prom / loki / tempo"), but
  `ApplyQueryTimeout` is only called from `internal/api/prom/handler.go:716`
  and `internal/api/loki/handler.go:479` — Tempo has no `QueryTimeout` field
  and no per-request context-deadline backstop anywhere in
  `internal/api/tempo/*.go`.
- Corrects the doc comment to name only prom and loki, and adds a pointer to
  the tracking issue for the underlying gap.

## Why not fix the gap itself here

Wiring an actual timeout backstop into Tempo is a real behavior change, not
a doc fix: it needs a new `Handler.QueryTimeout` field, config plumbing from
`cmd/cerberus`, a decision on whether Tempo accepts a `?timeout=` override,
and updating every Tempo query entrypoint (`metrics_query_range.go`,
`metrics_query_instant.go`, `search_tags.go`, `search_tag_values.go`,
`root_lookup.go`, plus `/api/search` and `/api/traces/{id}` in
`handler.go`), each needing its own test coverage. That's tracked in #2302.

## Test plan

- [x] `go build ./internal/api/...`
- [x] `go test ./internal/api/reqctx/...`
