### PR TITLE
docs(operations): fix stale de-gated-lanes count after CodeQL row removal

### DIFF
--- a/docs/operations.md
+++ b/docs/operations.md
@@ -1499,7 +1499,7 @@ or a stable backport never drags any of the three backwards.
 #### De-gated lanes on the publish path
 
 The preflight's expected set (`RELEASE_REQUIRED_CHECKS`) covers every
-branch-protection context except the three below, which are listed in
+branch-protection context except the two below, which are listed in
 `RELEASE_INFORMATIONAL_CHECKS` instead: they run, they report, and their
 verdict does not hold a publish. Each one is a deliberate trade, so each one
 carries its reason here — `TestReleasePreflightCoversEveryBranchProtectionContext`


### PR DESCRIPTION
## Summary

- Fixes a stale numeral in `docs/operations.md`'s "De-gated lanes on the
  publish path" section: #2256 moved `CodeQL` out of
  `RELEASE_INFORMATIONAL_CHECKS` (into `RELEASE_REQUIRED_CHECKS`) and dropped
  its table row, leaving two de-gated lanes (`compose-smoke-shard-info`,
  `mutation`), but the lead-in prose still said "except the three below".

## Audit finding this addresses

Pre-release full-codebase audit, area `ci-workflows`:

> docs/operations.md:1502 — prose says the release preflight's required set
> covers every branch-protection context "except the three below", but the
> table immediately following has only two rows, matching release.yml's
> actual `RELEASE_INFORMATIONAL_CHECKS` (2 entries).

Re-verified directly against `origin/main` before editing.

## Other finding for this area

A second confirmed finding (DRY: the registry-login step pair and the
disk-free 3-step block are duplicated 14 and 12 times respectively across
`e2e.yml` / `compatibility.yml` / `schema-integration.yml` / `strict-scan.yml`
/ `migration-e2e.yml`, instead of composite actions like the existing
`setup-lychee` / `setup-buildx` convention) is a structural refactor spanning
five workflow files, not a small well-scoped fix, so it is filed as
tsouza/cerberus#2304 rather than attempted here.

## Test plan

- [x] `markdownlint-cli2` / `md-table-align` (lefthook `pre-commit`) — clean.
- [x] `actionlint` (lefthook `pre-push`) — clean (no workflow files touched).
- [x] No test pins the "except the N below" prose numeral
      (`grep -rn "except the" test/regression/release_required_checks_test.go`
      — empty); the regression test only asserts the table's *lane names*
      match `RELEASE_INFORMATIONAL_CHECKS`, not this lead-in count.
