### PR TITLE
refactor(ci-scripts): dedupe the buffered leg runner into spawn-tagged.mjs

### DIFF
--- a/.github/scripts/README.md
+++ b/.github/scripts/README.md
@@ -1973,10 +1973,12 @@ what actually runs.
     so asserts instead of rewriting), a missing closing step, and the leg count
     drifting from the count `test/perf/profile/shard_test.go` asserts the
     partition's cover and balance at.
-  - `lib/spawn-tagged.mjs` holds the one child-process runner both this and
-    `golden-update.mjs` fan out with: line-tagged output so concurrent legs stay
-    readable, and every leg allowed to finish before the group's verdict, so one
-    invocation surfaces every failure rather than just the first.
+  - `lib/spawn-tagged.mjs` holds the child-process runners this and
+    `golden-update.mjs` fan out with (line-tagged, streamed output; every leg
+    allowed to finish before the group's verdict), plus `runLegBuffered`, the
+    buffer-then-print-whole runner `perf-coverage-fanout.mjs`,
+    `property-fanout.mjs` and `chdb-roundtrip.mjs` share for legs whose
+    failures are multi-line blocks that streaming would interleave.
 
 ## Notes
 

--- a/.github/scripts/chdb-roundtrip.mjs
+++ b/.github/scripts/chdb-roundtrip.mjs
@@ -47,8 +47,8 @@
 // node: builtins only — no npm deps, no setup-node needed.
 
 import process from 'node:process';
-import { spawn } from 'node:child_process';
 import { error, notice, log, group } from './lib/gh.mjs';
+import { runLegBuffered } from './lib/spawn-tagged.mjs';
 
 /**
  * How many PROCESSES each head's leg fans out to.
@@ -160,35 +160,6 @@ export function warmupCommand({ ql, tags, go = 'go' }) {
   };
 }
 
-/**
- * Runs one leg to completion, buffering its output.
- *
- * Buffered rather than inherited because concurrent legs interleave line by
- * line otherwise, and a `go test` failure is a multi-line block (the fixture
- * name, the got/want diff, or a goroutine dump) that is unreadable once two
- * legs shuffle into each other. Every leg's buffer is printed whole, in leg
- * order, after the run — including the `-timeout` panic dump, which arrives in
- * the buffer because the bound above always fires before the job cap.
- */
-function runLeg(leg) {
-  return new Promise((resolve) => {
-    const [cmd, ...args] = leg.argv;
-    const child = spawn(cmd, args, {
-      env: { ...process.env, ...leg.env },
-      stdio: ['ignore', 'pipe', 'pipe'],
-    });
-    let out = '';
-    child.stdout.on('data', (d) => {
-      out += d;
-    });
-    child.stderr.on('data', (d) => {
-      out += d;
-    });
-    child.on('error', (err) => resolve({ leg, code: 1, out: `${out}\nspawn ${cmd}: ${err.message}` }));
-    child.on('close', (code) => resolve({ leg, code: code ?? 1, out }));
-  });
-}
-
 async function main() {
   const ql = process.env.QL ?? '';
   const tags = process.env.TAGS ?? '';
@@ -209,7 +180,7 @@ async function main() {
 
   const warmup = warmupCommand({ ql, tags, go });
   if (warmup) {
-    const built = await runLeg(warmup);
+    const built = await runLegBuffered(warmup);
     if (built.code !== 0) {
       group(`${warmup.name} (exit ${built.code})`, () => log(built.out.trimEnd()));
       error(`roundtrip ${ql}: the leg binaries did not build`);
@@ -217,7 +188,7 @@ async function main() {
     }
   }
 
-  const results = await Promise.all(legs.map(runLeg));
+  const results = await Promise.all(legs.map(runLegBuffered));
   const elapsedSeconds = Math.round((Date.now() - started) / 1000);
 
   for (const r of results) {

--- a/.github/scripts/lib/spawn-tagged.mjs
+++ b/.github/scripts/lib/spawn-tagged.mjs
@@ -1,13 +1,17 @@
 // spawn-tagged.mjs — run child processes concurrently with readable output.
 //
-// Shared by the two regeneration runners that fan a corpus walk out across
-// processes: golden-update.mjs (the TXTAR goldens, partitioned by
-// test/spec/shard.go) and cardinality-baseline-update.mjs (the perf cardinality
-// baseline, partitioned by test/perf/profile/shard.go). Both need exactly the
-// same two things — tag each child's output so concurrent legs stay readable,
-// and let every leg finish before deciding whether the group failed — and a
-// second copy of that would be a second set of failure semantics to keep in
-// step.
+// Shared by every fan-out runner that splits a corpus walk across concurrent
+// `go test` processes: golden-update.mjs and cardinality-baseline-update.mjs
+// tag each child's output and stream it line-by-line (`runTagged` /
+// `runAllTagged`); perf-coverage-fanout.mjs, property-fanout.mjs and
+// chdb-roundtrip.mjs instead buffer each child's output whole and print it
+// after every leg finishes (`runLegBuffered`), because their failures are
+// multi-line blocks — a fixture diff or a goroutine dump — that streaming
+// would interleave into unreadable garbage across concurrent legs. All five
+// callers need the same failure-propagation contract regardless of which
+// output mode they use — let every leg finish before deciding whether the
+// group failed — and a second copy of that per caller would be a second set
+// of failure semantics to keep in step.
 //
 // No env inputs; it is a library, not a step.
 
@@ -65,4 +69,36 @@ export async function runAllTagged(commands, cwd, sink) {
   );
 
   return codes.find((c) => c !== 0) ?? 0;
+}
+
+/**
+ * Runs one leg (`{ argv, env? }`) to completion, buffering its stdout and
+ * stderr rather than streaming them.
+ *
+ * Buffered rather than tagged-and-streamed because these callers' legs run
+ * concurrently and a failure is a multi-line block — a `go test` fixture
+ * diff or a goroutine dump — that becomes unreadable once several legs
+ * shuffle their lines into each other. Callers print each leg's whole
+ * buffer only after every leg has finished. Resolves rather than rejects
+ * (including on a spawn error) so `Promise.all` over several legs always
+ * waits for the group, the same contract `runTagged` holds for the
+ * streaming callers above.
+ */
+export function runLegBuffered(leg) {
+  return new Promise((resolve) => {
+    const [cmd, ...args] = leg.argv;
+    const child = spawn(cmd, args, {
+      env: { ...process.env, ...leg.env },
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+    let out = '';
+    child.stdout.on('data', (d) => {
+      out += d;
+    });
+    child.stderr.on('data', (d) => {
+      out += d;
+    });
+    child.on('error', (err) => resolve({ leg, code: 1, out: `${out}\nspawn ${cmd}: ${err.message}` }));
+    child.on('close', (code) => resolve({ leg, code: code ?? 1, out }));
+  });
 }

--- a/.github/scripts/perf-coverage-fanout.mjs
+++ b/.github/scripts/perf-coverage-fanout.mjs
@@ -75,8 +75,8 @@
 // node: builtins only — no npm deps, no setup-node needed.
 
 import process from 'node:process';
-import { spawn } from 'node:child_process';
 import { error, notice, log, group } from './lib/gh.mjs';
+import { runLegBuffered } from './lib/spawn-tagged.mjs';
 
 /** The corpus-wide ratchet this lane fans out. */
 export const RATCHET_TEST = 'TestCardinalityRatchet';
@@ -155,34 +155,6 @@ export function legCommands({ tags, coverpkg, go = 'go' }) {
   });
 }
 
-/**
- * Runs one leg to completion, buffering its output.
- *
- * Buffered rather than inherited because the legs run concurrently and would
- * otherwise interleave line by line — a `go test` failure is a multi-line
- * block (the corpus fixture diff, or a goroutine dump) that is unreadable
- * once several legs shuffle into each other. Each leg's buffer is printed
- * whole, after all finish — mirroring property-fanout.mjs's runLeg.
- */
-function runLeg(leg) {
-  return new Promise((resolve) => {
-    const [cmd, ...args] = leg.argv;
-    const child = spawn(cmd, args, {
-      env: { ...process.env, ...leg.env },
-      stdio: ['ignore', 'pipe', 'pipe'],
-    });
-    let out = '';
-    child.stdout.on('data', (d) => {
-      out += d;
-    });
-    child.stderr.on('data', (d) => {
-      out += d;
-    });
-    child.on('error', (err) => resolve({ leg, code: 1, out: `${out}\nspawn ${cmd}: ${err.message}` }));
-    child.on('close', (code) => resolve({ leg, code: code ?? 1, out }));
-  });
-}
-
 async function main() {
   const tags = process.env.TAGS ?? '';
   if (tags === '') {
@@ -204,7 +176,7 @@ async function main() {
   );
 
   const started = Date.now();
-  const results = await Promise.all(legs.map(runLeg));
+  const results = await Promise.all(legs.map(runLegBuffered));
   const elapsedSeconds = Math.round((Date.now() - started) / 1000);
 
   for (const r of results) {

--- a/.github/scripts/property-fanout.mjs
+++ b/.github/scripts/property-fanout.mjs
@@ -97,8 +97,8 @@
 // node: builtins only — no npm deps, no setup-node needed.
 
 import process from 'node:process';
-import { spawn } from 'node:child_process';
 import { error, notice, log, group } from './lib/gh.mjs';
+import { runLegBuffered } from './lib/spawn-tagged.mjs';
 
 /** The randomized native-histogram sweep, fanned out across HISTOGRAM_FANOUT processes. */
 export const HISTOGRAM_SWEEP_TEST = 'TestPromQL_Property_NativeHistogram';
@@ -287,34 +287,6 @@ export function findTruncatedRapidRuns(output, expectRapidChecks) {
   return findings;
 }
 
-/**
- * Runs one leg to completion, buffering its output.
- *
- * Buffered rather than inherited because the legs run concurrently and
- * would otherwise interleave line by line — a `go test -v` failure is a
- * multi-line block (the rapid seed, the got/want diff, or a goroutine dump)
- * that is unreadable once several legs shuffle into each other. Each leg's
- * buffer is printed whole, after all finish.
- */
-function runLeg(leg) {
-  return new Promise((resolve) => {
-    const [cmd, ...args] = leg.argv;
-    const child = spawn(cmd, args, {
-      env: process.env,
-      stdio: ['ignore', 'pipe', 'pipe'],
-    });
-    let out = '';
-    child.stdout.on('data', (d) => {
-      out += d;
-    });
-    child.stderr.on('data', (d) => {
-      out += d;
-    });
-    child.on('error', (err) => resolve({ leg, code: 1, out: `${out}\nspawn ${cmd}: ${err.message}` }));
-    child.on('close', (code) => resolve({ leg, code: code ?? 1, out }));
-  });
-}
-
 async function main() {
   const tags = process.env.TAGS ?? '';
   if (tags === '') {
@@ -330,7 +302,7 @@ async function main() {
   );
 
   const started = Date.now();
-  const results = await Promise.all(legs.map(runLeg));
+  const results = await Promise.all(legs.map(runLegBuffered));
   const elapsedSeconds = Math.round((Date.now() - started) / 1000);
 
   for (const r of results) {


### PR DESCRIPTION
## Summary

- Fixes a confirmed audit finding (area `ci-scripts`): `perf-coverage-fanout.mjs`,
  `property-fanout.mjs`, and `chdb-roundtrip.mjs` each hand-rolled an identical
  buffer-then-print-whole `runLeg` for their concurrent `go test` fan-out, instead of
  sharing an implementation — even though `.github/scripts/lib/spawn-tagged.mjs`
  already exists as the purpose-built shared helper for exactly this problem class
  (its own header names the "second copy = second set of failure semantics" principle).
  The gap was that `spawn-tagged.mjs` only offered a streamed, line-tagged runner
  (`runTagged`/`runAllTagged`), not the buffered, print-whole-after-all-finish mode
  these three legs need (their failures are multi-line blocks — a fixture diff or a
  goroutine dump — that streaming would interleave into garbage across concurrent
  legs).
- Adds `runLegBuffered` to `lib/spawn-tagged.mjs` alongside the existing streamed
  runners, and switches all three fan-out scripts to import and call it instead of
  keeping their own copy. Net effect: -47 lines, one failure-propagation contract
  instead of three.
- Updates `.github/scripts/README.md`'s note on `spawn-tagged.mjs` to describe both
  runner modes and their callers.

## Test plan

- [x] `node --check` on every edited `.mjs` file
- [x] `node --test perf-coverage-fanout.test.mjs property-fanout.test.mjs chdb-roundtrip.test.mjs`
      — 44/44 passing (none of these test `runLeg` directly, only the exported
      `legCommands`/`warmupCommand`/pure helpers, so the refactor is test-invisible
      by design)
- [x] Ad-hoc smoke of `runLegBuffered` against a real child process (exit 0 and
      non-zero, stdout captured) confirms the buffered contract is unchanged
- [x] `lefthook`'s pre-push gates (markdownlint, forbid-sql-raw, forbid-skip,
      forbid-escape-hatch, actionlint, etc.) all green on push

🤖 Generated with [Claude Code](https://claude.com/claude-code)
