### PR TITLE
refactor(migration-lane): dedupe HTTP getOK and errWriter helpers

### DIFF
--- a/.go-arch-lint.yml
+++ b/.go-arch-lint.yml
@@ -370,6 +370,14 @@ deps:
       - chplan
       - promrules
 
+  # migrateinventory probes a live source's runtime cardinality (TSDB head
+  # stats, per-selector Loki index stats). It reuses migrate's errWriter for
+  # the same Fprintf-error-collapsing text-report sink the other migration
+  # blocks share; it opens no chplan or CH connection of its own.
+  migrateinventory:
+    mayDependOn:
+      - migrate
+
   # migrateverify is the online parity gate. It reads the migrate corpus format
   # (Corpus / CorpusQuery / Lang*) and routes each entry to a head lane, which
   # needs the two in-house leaf parsers to tell a metric query from a log-stream

--- a/internal/migrate/classify.go
+++ b/internal/migrate/classify.go
@@ -112,50 +112,50 @@ func Classify(rep Report) Classification {
 // same numbers as Prometheus — then the per-bucket counts, then one block per
 // bucket, then the skipped entries with their reasons.
 func (c Classification) Write(w io.Writer) error {
-	bw := &errWriter{w: w}
-	bw.printf("# cerberus migrate classify\n")
-	bw.printf("#\n")
-	bw.printf("# Buckets each corpus query by how cleanly it maps onto cerberus's PromQL\n")
-	bw.printf("# support, using the exact offline explain pipeline (parse -> lower -> emit):\n")
-	bw.printf("#   supported   — parses, lowers, and EMITS ClickHouse SQL (PromQL-pure / rewritable)\n")
-	bw.printf("#   unsupported — the offline pipeline rejected it (no-equivalent; construct named)\n")
-	bw.printf("#   risky       — a SUPPORTED query that also carries an offline fan-out risk flag\n")
-	bw.printf("#\n")
-	bw.printf("# HONESTY: \"supported\" means the query TRANSLATES to SQL, NOT that cerberus\n")
-	bw.printf("# returns the same numbers as Prometheus — only `cerberus migrate verify` proves parity.\n")
-	bw.printf("#\n")
-	bw.printf("# %d queries: %d supported (%d risky), %d unsupported; %d skipped\n\n",
+	bw := NewErrWriter(w)
+	bw.Printf("# cerberus migrate classify\n")
+	bw.Printf("#\n")
+	bw.Printf("# Buckets each corpus query by how cleanly it maps onto cerberus's PromQL\n")
+	bw.Printf("# support, using the exact offline explain pipeline (parse -> lower -> emit):\n")
+	bw.Printf("#   supported   — parses, lowers, and EMITS ClickHouse SQL (PromQL-pure / rewritable)\n")
+	bw.Printf("#   unsupported — the offline pipeline rejected it (no-equivalent; construct named)\n")
+	bw.Printf("#   risky       — a SUPPORTED query that also carries an offline fan-out risk flag\n")
+	bw.Printf("#\n")
+	bw.Printf("# HONESTY: \"supported\" means the query TRANSLATES to SQL, NOT that cerberus\n")
+	bw.Printf("# returns the same numbers as Prometheus — only `cerberus migrate verify` proves parity.\n")
+	bw.Printf("#\n")
+	bw.Printf("# %d queries: %d supported (%d risky), %d unsupported; %d skipped\n\n",
 		c.Counts.Total, c.Counts.Supported, c.Counts.Risky, c.Counts.Unsupported, len(c.Skipped))
 
-	bw.printf("== supported (%d)\n", c.Counts.Supported)
+	bw.Printf("== supported (%d)\n", c.Counts.Supported)
 	for _, q := range c.Queries {
 		if q.Bucket != BucketSupported {
 			continue
 		}
-		bw.printf("   [%s] %s\n", q.Kind, q.Source)
-		bw.printf("     expr: %s\n", q.Expr)
+		bw.Printf("   [%s] %s\n", q.Kind, q.Source)
+		bw.Printf("     expr: %s\n", q.Expr)
 		for _, risk := range q.Risks {
-			bw.printf("     RISKY: %s\n", risk)
+			bw.Printf("     RISKY: %s\n", risk)
 		}
 	}
 
-	bw.printf("\n== unsupported (%d)\n", c.Counts.Unsupported)
+	bw.Printf("\n== unsupported (%d)\n", c.Counts.Unsupported)
 	for _, q := range c.Queries {
 		if q.Bucket != BucketUnsupported {
 			continue
 		}
-		bw.printf("   [%s] %s\n", q.Kind, q.Source)
-		bw.printf("     expr:      %s\n", q.Expr)
-		bw.printf("     construct: %s\n", q.Construct)
+		bw.Printf("   [%s] %s\n", q.Kind, q.Source)
+		bw.Printf("     expr:      %s\n", q.Expr)
+		bw.Printf("     construct: %s\n", q.Construct)
 	}
 
 	if len(c.Skipped) > 0 {
-		bw.printf("\n== skipped (%d)\n", len(c.Skipped))
+		bw.Printf("\n== skipped (%d)\n", len(c.Skipped))
 		for _, s := range c.Skipped {
-			bw.printf("   %s: %s\n", s.Source, s.Reason)
+			bw.Printf("   %s: %s\n", s.Source, s.Reason)
 		}
 	}
-	return bw.err
+	return bw.Err
 }
 
 // WriteJSON renders the classification as deterministic, indented JSON with a

--- a/internal/migrate/migrate.go
+++ b/internal/migrate/migrate.go
@@ -294,58 +294,68 @@ func BuildReport(ctx context.Context, src CorpusSource, ex Explainer) (Report, e
 // honesty note that cardinality is unknown offline, then one block per query,
 // then the skipped entries with their reasons.
 func (r Report) Write(w io.Writer) error {
-	bw := &errWriter{w: w}
-	bw.printf("# cerberus migrate explain\n")
-	bw.printf("#\n")
-	bw.printf("# Offline preview: the exact ClickHouse SQL cerberus will run for each\n")
-	bw.printf("# PromQL query, the physical tables it touches, and conservative IR risk\n")
-	bw.printf("# flags. Row COUNT / cardinality is NOT knowable offline (it depends on\n")
-	bw.printf("# data this tool never reads) — it is deliberately not estimated here.\n")
-	bw.printf("#\n")
-	bw.printf("# %d queries, %d skipped\n\n", len(r.Queries), len(r.Skipped))
+	bw := NewErrWriter(w)
+	bw.Printf("# cerberus migrate explain\n")
+	bw.Printf("#\n")
+	bw.Printf("# Offline preview: the exact ClickHouse SQL cerberus will run for each\n")
+	bw.Printf("# PromQL query, the physical tables it touches, and conservative IR risk\n")
+	bw.Printf("# flags. Row COUNT / cardinality is NOT knowable offline (it depends on\n")
+	bw.Printf("# data this tool never reads) — it is deliberately not estimated here.\n")
+	bw.Printf("#\n")
+	bw.Printf("# %d queries, %d skipped\n\n", len(r.Queries), len(r.Skipped))
 
 	for _, q := range r.Queries {
-		bw.printf("== [%s] %s\n", q.Query.Kind, q.Query.Source)
-		bw.printf("   expr:  %s\n", q.Query.Expr)
+		bw.Printf("== [%s] %s\n", q.Query.Kind, q.Query.Source)
+		bw.Printf("   expr:  %s\n", q.Query.Expr)
 		if q.Unsupported != "" {
-			bw.printf("   UNSUPPORTED: %s\n", q.Unsupported)
-			bw.printf("\n")
+			bw.Printf("   UNSUPPORTED: %s\n", q.Unsupported)
+			bw.Printf("\n")
 			continue
 		}
-		bw.printf("   sql:   %s\n", q.SQL)
+		bw.Printf("   sql:   %s\n", q.SQL)
 		if len(q.Tables) > 0 {
-			bw.printf("   tables: %s\n", strings.Join(q.Tables, ", "))
+			bw.Printf("   tables: %s\n", strings.Join(q.Tables, ", "))
 		}
 		if len(q.Risks) > 0 {
 			for _, risk := range q.Risks {
-				bw.printf("   risk:  %s\n", risk)
+				bw.Printf("   risk:  %s\n", risk)
 			}
 		} else {
-			bw.printf("   risk:  none flagged offline (cardinality unknown)\n")
+			bw.Printf("   risk:  none flagged offline (cardinality unknown)\n")
 		}
-		bw.printf("\n")
+		bw.Printf("\n")
 	}
 
 	if len(r.Skipped) > 0 {
-		bw.printf("== skipped (%d)\n", len(r.Skipped))
+		bw.Printf("== skipped (%d)\n", len(r.Skipped))
 		for _, s := range r.Skipped {
-			bw.printf("   %s: %s\n", s.Source, s.Reason)
+			bw.Printf("   %s: %s\n", s.Source, s.Reason)
 		}
 	}
-	return bw.err
+	return bw.Err
 }
 
-// errWriter collapses the repeated Fprintf error checks in Write into a single
-// short-circuiting sink: once a write fails, later printf calls are no-ops and
-// the first error is returned.
-type errWriter struct {
+// ErrWriter collapses the repeated Fprintf error checks in every migration
+// block's text-report Write method into a single short-circuiting sink: once a
+// write fails, later Printf calls are no-ops and the first error is returned.
+// It is exported so migrate, migrategate, migrateinventory and migrateverify —
+// the four Layer-14 blocks that each render a scannable text report — share
+// one definition instead of hand-copying it.
+type ErrWriter struct {
 	w   io.Writer
-	err error
+	Err error
 }
 
-func (e *errWriter) printf(format string, args ...any) {
-	if e.err != nil {
+// NewErrWriter wraps w in an ErrWriter ready for a sequence of Printf calls.
+func NewErrWriter(w io.Writer) *ErrWriter {
+	return &ErrWriter{w: w}
+}
+
+// Printf is a no-op once a prior write has failed; otherwise it writes format
+// against args and records any error as Err.
+func (e *ErrWriter) Printf(format string, args ...any) {
+	if e.Err != nil {
 		return
 	}
-	_, e.err = fmt.Fprintf(e.w, format, args...)
+	_, e.Err = fmt.Fprintf(e.w, format, args...)
 }

--- a/internal/migrate/rulegraph.go
+++ b/internal/migrate/rulegraph.go
@@ -480,58 +480,58 @@ func splitLokiRuleGroups(file string, rg promrules.RuleGroups) (recorded []Recor
 // consumed recorded series with their consumer edges (what MUST keep being
 // materialized), then the skipped inputs with their reasons.
 func (g RuleGraph) Write(w io.Writer) error {
-	bw := &errWriter{w: w}
-	bw.printf("# cerberus migrate rulegraph\n")
-	bw.printf("#\n")
-	bw.printf("# cerberus has NO ruler: a recording rule's OUTPUT series is not produced\n")
-	bw.printf("# by cerberus. Every recorded series a dashboard panel or alert still reads\n")
-	bw.printf("# MUST be materialized elsewhere post-cutover, or the panel goes silently\n")
-	bw.printf("# blank. This graph links each recorded series to the queries that consume it.\n")
-	bw.printf("#\n")
-	bw.printf("# HONESTY: this is a NAME-LEVEL dependency approximation — a consumer links to\n")
-	bw.printf("# a recorded series when it references that series' metric NAME. Label matchers\n")
-	bw.printf("# and value equality are not analysed; rule-to-rule chains ARE (a recording\n")
-	bw.printf("# rule's own expr is scanned as a consumer). Unparseable consumer\n")
-	bw.printf("# exprs — and consumers whose __name__ set can't be statically reduced (a regex or\n")
-	bw.printf("# negated __name__ matcher, or no name constraint) — are counted as skips below\n")
-	bw.printf("# (never under-linked to nothing), so the over-link direction stays honest.\n")
-	bw.printf("#\n")
-	bw.printf("# %d recorded series: %d consumed, %d orphan; %d consumers; %d skipped\n\n",
+	bw := NewErrWriter(w)
+	bw.Printf("# cerberus migrate rulegraph\n")
+	bw.Printf("#\n")
+	bw.Printf("# cerberus has NO ruler: a recording rule's OUTPUT series is not produced\n")
+	bw.Printf("# by cerberus. Every recorded series a dashboard panel or alert still reads\n")
+	bw.Printf("# MUST be materialized elsewhere post-cutover, or the panel goes silently\n")
+	bw.Printf("# blank. This graph links each recorded series to the queries that consume it.\n")
+	bw.Printf("#\n")
+	bw.Printf("# HONESTY: this is a NAME-LEVEL dependency approximation — a consumer links to\n")
+	bw.Printf("# a recorded series when it references that series' metric NAME. Label matchers\n")
+	bw.Printf("# and value equality are not analysed; rule-to-rule chains ARE (a recording\n")
+	bw.Printf("# rule's own expr is scanned as a consumer). Unparseable consumer\n")
+	bw.Printf("# exprs — and consumers whose __name__ set can't be statically reduced (a regex or\n")
+	bw.Printf("# negated __name__ matcher, or no name constraint) — are counted as skips below\n")
+	bw.Printf("# (never under-linked to nothing), so the over-link direction stays honest.\n")
+	bw.Printf("#\n")
+	bw.Printf("# %d recorded series: %d consumed, %d orphan; %d consumers; %d skipped\n\n",
 		g.Counts.Recorded, g.Counts.Consumed, g.Counts.Orphan, g.Counts.Consumers, g.Counts.Skipped)
 
-	bw.printf("== orphan recorded series (%d) — nothing scanned reads these\n", g.Counts.Orphan)
+	bw.Printf("== orphan recorded series (%d) — nothing scanned reads these\n", g.Counts.Orphan)
 	for _, n := range g.Recorded {
 		if n.Status != StatusOrphan {
 			continue
 		}
-		bw.printf("   %s (%s)\n", n.Name, n.Source)
+		bw.Printf("   %s (%s)\n", n.Name, n.Source)
 	}
 
-	bw.printf("\n== consumed recorded series (%d) — MUST keep being materialized\n", g.Counts.Consumed)
+	bw.Printf("\n== consumed recorded series (%d) — MUST keep being materialized\n", g.Counts.Consumed)
 	for _, n := range g.Recorded {
 		if n.Status != StatusConsumed {
 			continue
 		}
-		bw.printf("   %s (%s)\n", n.Name, n.Source)
+		bw.Printf("   %s (%s)\n", n.Name, n.Source)
 		for _, c := range n.Consumers {
-			bw.printf("     <- %s\n", c)
+			bw.Printf("     <- %s\n", c)
 		}
 	}
 
-	bw.printf("\n== consumers referencing recorded series (%d)\n", g.Counts.Consumers)
+	bw.Printf("\n== consumers referencing recorded series (%d)\n", g.Counts.Consumers)
 	for _, c := range g.Consumers {
-		bw.printf("   [%s] %s\n", c.Kind, c.Source)
-		bw.printf("     expr: %s\n", c.Expr)
-		bw.printf("     refs: %s\n", strings.Join(c.References, ", "))
+		bw.Printf("   [%s] %s\n", c.Kind, c.Source)
+		bw.Printf("     expr: %s\n", c.Expr)
+		bw.Printf("     refs: %s\n", strings.Join(c.References, ", "))
 	}
 
 	if len(g.Skipped) > 0 {
-		bw.printf("\n== skipped (%d)\n", len(g.Skipped))
+		bw.Printf("\n== skipped (%d)\n", len(g.Skipped))
 		for _, s := range g.Skipped {
-			bw.printf("   %s: %s\n", s.Source, s.Reason)
+			bw.Printf("   %s: %s\n", s.Source, s.Reason)
 		}
 	}
-	return bw.err
+	return bw.Err
 }
 
 // WriteJSON renders the graph as deterministic, indented JSON with a trailing

--- a/internal/migrategate/report.go
+++ b/internal/migrategate/report.go
@@ -4,36 +4,38 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+
+	"github.com/tsouza/cerberus/internal/migrate"
 )
 
 // Write renders the decision as a scannable go/no-go checklist: one line per
 // stage with its verdict and whether it blocks, each stage's reasons indented
 // beneath it, then the overall PASS/FAIL verdict last.
 func (d Decision) Write(w io.Writer) error {
-	bw := &errWriter{w: w}
-	bw.printf("# cerberus migrate gate\n")
-	bw.printf("#\n")
-	bw.printf("# Folds the migration artifacts into one cutover go/no-go decision.\n")
-	bw.printf("# A blocking stage (FAIL, or a missing REQUIRED artifact) fails the gate;\n")
-	bw.printf("# a WARN is surfaced but does not block. Exit 0 only on overall PASS.\n")
-	bw.printf("#\n")
+	bw := migrate.NewErrWriter(w)
+	bw.Printf("# cerberus migrate gate\n")
+	bw.Printf("#\n")
+	bw.Printf("# Folds the migration artifacts into one cutover go/no-go decision.\n")
+	bw.Printf("# A blocking stage (FAIL, or a missing REQUIRED artifact) fails the gate;\n")
+	bw.Printf("# a WARN is surfaced but does not block. Exit 0 only on overall PASS.\n")
+	bw.Printf("#\n")
 
 	for _, s := range d.Stages {
 		if s.Blocking {
-			bw.printf("  %-9s %-7s BLOCKING\n", s.Stage, s.Verdict)
+			bw.Printf("  %-9s %-7s BLOCKING\n", s.Stage, s.Verdict)
 		} else {
-			bw.printf("  %-9s %s\n", s.Stage, s.Verdict)
+			bw.Printf("  %-9s %s\n", s.Stage, s.Verdict)
 		}
 		for _, r := range s.Reasons {
-			bw.printf("      %s\n", r)
+			bw.Printf("      %s\n", r)
 		}
 	}
 
 	if len(d.Missing) > 0 {
-		bw.printf("\n# missing artifacts: %v\n", d.Missing)
+		bw.Printf("\n# missing artifacts: %v\n", d.Missing)
 	}
-	bw.printf("\nOVERALL: %s\n", d.Overall)
-	return bw.err
+	bw.Printf("\nOVERALL: %s\n", d.Overall)
+	return bw.Err
 }
 
 // WriteJSON renders the decision as deterministic, indented JSON with a
@@ -59,19 +61,4 @@ func (d Decision) WriteJSON(w io.Writer) error {
 		return fmt.Errorf("migrategate: write decision: %w", err)
 	}
 	return nil
-}
-
-// errWriter collapses the repeated Fprintf error checks in Write into a single
-// short-circuiting sink: once a write fails, later printf calls are no-ops and
-// the first error is returned.
-type errWriter struct {
-	w   io.Writer
-	err error
-}
-
-func (e *errWriter) printf(format string, args ...any) {
-	if e.err != nil {
-		return
-	}
-	_, e.err = fmt.Fprintf(e.w, format, args...)
 }

--- a/internal/migrateinventory/inventory.go
+++ b/internal/migrateinventory/inventory.go
@@ -309,12 +309,21 @@ func (c *Client) fetchMetadataTotal(ctx context.Context) (int, error) {
 // (including a 404 of an endpoint an old Prometheus lacks) is an error carrying
 // the status, so the caller can surface it and exit non-zero.
 func (c *Client) getOK(ctx context.Context, path string) ([]byte, error) {
-	reqURL := c.BaseURL + path
+	return httpGetOK(ctx, c.HTTP, c.BaseURL, path)
+}
+
+// httpGetOK issues GET {baseURL}{path} via client and returns the body only on
+// a 200. A non-200 (including a 404 of an endpoint an old source lacks) is an
+// error carrying the status, so the caller can surface it and exit non-zero.
+// Shared by every probe client in this package (Client, LokiClient) so the
+// request-build / do / capped-read / status-check sequence is written once.
+func httpGetOK(ctx context.Context, client *http.Client, baseURL, path string) ([]byte, error) {
+	reqURL := baseURL + path
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, reqURL, nil)
 	if err != nil {
 		return nil, fmt.Errorf("build request %s: %w", path, err)
 	}
-	resp, err := c.HTTP.Do(req)
+	resp, err := client.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("GET %s: %w", path, err)
 	}

--- a/internal/migrateinventory/loki.go
+++ b/internal/migrateinventory/loki.go
@@ -188,25 +188,8 @@ func (c *LokiClient) fetchIndexStats(ctx context.Context, selector, startParam, 
 }
 
 // getOK issues GET {base}{path} and returns the body only on HTTP 200,
-// mirroring the Prometheus Client's capped-read, non-200-is-error discipline.
+// mirroring the Prometheus Client's capped-read, non-200-is-error discipline
+// (both share the httpGetOK helper in inventory.go).
 func (c *LokiClient) getOK(ctx context.Context, path string) ([]byte, error) {
-	reqURL := c.BaseURL + path
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, reqURL, nil)
-	if err != nil {
-		return nil, fmt.Errorf("build request %s: %w", path, err)
-	}
-	resp, err := c.HTTP.Do(req)
-	if err != nil {
-		return nil, fmt.Errorf("GET %s: %w", path, err)
-	}
-	defer func() { _ = resp.Body.Close() }()
-
-	body, err := readCappedBody(resp.Body, maxResponseBytes)
-	if err != nil {
-		return nil, fmt.Errorf("read %s body: %w", path, err)
-	}
-	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("GET %s: HTTP %d", path, resp.StatusCode)
-	}
-	return body, nil
+	return httpGetOK(ctx, c.HTTP, c.BaseURL, path)
 }

--- a/internal/migrateinventory/report.go
+++ b/internal/migrateinventory/report.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"io"
 	"time"
+
+	"github.com/tsouza/cerberus/internal/migrate"
 )
 
 // WriteJSON renders the inventory as machine-readable JSON with a trailing
@@ -25,34 +27,34 @@ func (inv Inventory) WriteJSON(w io.Writer) error {
 // OOM risk, not a cerberus memory prediction), then the head-block size, then
 // the ranked risk tables, then any enrichment notes.
 func (inv Inventory) WriteText(w io.Writer) error {
-	bw := &errWriter{w: w}
-	bw.printf("# cerberus migrate inventory\n")
-	bw.printf("#\n")
-	bw.printf("# Live cardinality probed from the SOURCE Prometheus TSDB (%s).\n", inv.Source)
-	bw.printf("# These are source-Prometheus runtime facts — the realized series counts\n")
-	bw.printf("# config can't reveal offline. High-cardinality metrics are the OOM\n")
-	bw.printf("# CANDIDATES cerberus can't see before cutover. They RANK RISK; they do\n")
-	bw.printf("# NOT predict cerberus's exact memory (that depends on the query + engine).\n")
+	bw := migrate.NewErrWriter(w)
+	bw.Printf("# cerberus migrate inventory\n")
+	bw.Printf("#\n")
+	bw.Printf("# Live cardinality probed from the SOURCE Prometheus TSDB (%s).\n", inv.Source)
+	bw.Printf("# These are source-Prometheus runtime facts — the realized series counts\n")
+	bw.Printf("# config can't reveal offline. High-cardinality metrics are the OOM\n")
+	bw.Printf("# CANDIDATES cerberus can't see before cutover. They RANK RISK; they do\n")
+	bw.Printf("# NOT predict cerberus's exact memory (that depends on the query + engine).\n")
 	if inv.Window != "" {
-		bw.printf("# Observation window (operator context): %s. TSDB status is a\n", inv.Window)
-		bw.printf("# point-in-time head snapshot, so the window frames the numbers.\n")
+		bw.Printf("# Observation window (operator context): %s. TSDB status is a\n", inv.Window)
+		bw.Printf("# point-in-time head snapshot, so the window frames the numbers.\n")
 	}
-	bw.printf("#\n\n")
+	bw.Printf("#\n\n")
 
-	bw.printf("== head block\n")
-	bw.printf("  series:      %d\n", inv.Head.NumSeries)
-	bw.printf("  label pairs: %d\n", inv.Head.NumLabelPairs)
-	bw.printf("  chunks:      %d\n", inv.Head.ChunkCount)
+	bw.Printf("== head block\n")
+	bw.Printf("  series:      %d\n", inv.Head.NumSeries)
+	bw.Printf("  label pairs: %d\n", inv.Head.NumLabelPairs)
+	bw.Printf("  chunks:      %d\n", inv.Head.ChunkCount)
 	if hasHeadSpan(inv.Head) {
-		bw.printf("  head span:   %s .. %s\n", formatMillis(inv.Head.MinTime), formatMillis(inv.Head.MaxTime))
+		bw.Printf("  head span:   %s .. %s\n", formatMillis(inv.Head.MinTime), formatMillis(inv.Head.MaxTime))
 	}
 	if inv.MetricNameTotal >= 0 {
-		bw.printf("  distinct metric names: %d\n", inv.MetricNameTotal)
+		bw.Printf("  distinct metric names: %d\n", inv.MetricNameTotal)
 	}
 	if inv.MetadataMetricTotal >= 0 {
-		bw.printf("  metrics with metadata: %d\n", inv.MetadataMetricTotal)
+		bw.Printf("  metrics with metadata: %d\n", inv.MetadataMetricTotal)
 	}
-	bw.printf("\n")
+	bw.Printf("\n")
 
 	writeRanked(bw, fmt.Sprintf("top %d metrics by series count (OOM candidates)", inv.Top),
 		inv.TopMetricsBySeries, "series")
@@ -62,40 +64,40 @@ func (inv Inventory) WriteText(w io.Writer) error {
 		inv.TopLabelsByMemory, "bytes")
 
 	if len(inv.Notes) > 0 {
-		bw.printf("== notes (%d)\n", len(inv.Notes))
+		bw.Printf("== notes (%d)\n", len(inv.Notes))
 		for _, n := range inv.Notes {
-			bw.printf("  %s\n", n)
+			bw.Printf("  %s\n", n)
 		}
 	}
 
 	writeLokiSection(bw, inv.Loki)
 	writeTempoSection(bw, inv.Tempo)
 
-	return bw.err
+	return bw.Err
 }
 
 // writeLokiSection prints the optional per-selector Loki section, or nothing
 // at all when the operator never supplied a Loki source — a nil section is
 // simply absent from the report, never rendered as an empty ranked table.
-func writeLokiSection(bw *errWriter, loki *LokiInventory) {
+func writeLokiSection(bw *migrate.ErrWriter, loki *LokiInventory) {
 	if loki == nil {
 		return
 	}
-	bw.printf("\n== loki: %s\n", loki.Source)
+	bw.Printf("\n== loki: %s\n", loki.Source)
 	if loki.Window != "" {
-		bw.printf("  window: %s\n", loki.Window)
+		bw.Printf("  window: %s\n", loki.Window)
 	}
 	if len(loki.Selectors) == 0 {
-		bw.printf("  none reported by the source\n")
+		bw.Printf("  none reported by the source\n")
 	}
 	for i, s := range loki.Selectors {
-		bw.printf("  %3d. %-*s %d streams %d chunks %d entries %d bytes\n",
+		bw.Printf("  %3d. %-*s %d streams %d chunks %d entries %d bytes\n",
 			i+1, rankNameWidth, s.Selector, s.Streams, s.Chunks, s.Entries, s.Bytes)
 	}
 	if len(loki.Notes) > 0 {
-		bw.printf("  notes (%d):\n", len(loki.Notes))
+		bw.Printf("  notes (%d):\n", len(loki.Notes))
 		for _, n := range loki.Notes {
-			bw.printf("    %s\n", n)
+			bw.Printf("    %s\n", n)
 		}
 	}
 }
@@ -103,26 +105,26 @@ func writeLokiSection(bw *errWriter, loki *LokiInventory) {
 // writeTempoSection prints the optional, always-fixed Tempo out-of-scope
 // section, or nothing at all when the operator never supplied a Tempo
 // source.
-func writeTempoSection(bw *errWriter, tempo *TempoInventory) {
+func writeTempoSection(bw *migrate.ErrWriter, tempo *TempoInventory) {
 	if tempo == nil {
 		return
 	}
-	bw.printf("\n== tempo: %s\n", tempo.Source)
-	bw.printf("  out of scope: %s\n", tempo.OutOfScope)
+	bw.Printf("\n== tempo: %s\n", tempo.Source)
+	bw.Printf("  out of scope: %s\n", tempo.OutOfScope)
 }
 
 // writeRanked prints one ranked table, or an explicit "none reported" line so an
 // empty array is visible rather than a silent gap.
-func writeRanked(bw *errWriter, title string, rows []NameValue, unit string) {
-	bw.printf("== %s\n", title)
+func writeRanked(bw *migrate.ErrWriter, title string, rows []NameValue, unit string) {
+	bw.Printf("== %s\n", title)
 	if len(rows) == 0 {
-		bw.printf("  none reported by the source\n\n")
+		bw.Printf("  none reported by the source\n\n")
 		return
 	}
 	for i, r := range rows {
-		bw.printf("  %3d. %-*s %d %s\n", i+1, rankNameWidth, r.Name, r.Value, unit)
+		bw.Printf("  %3d. %-*s %d %s\n", i+1, rankNameWidth, r.Name, r.Value, unit)
 	}
-	bw.printf("\n")
+	bw.Printf("\n")
 }
 
 // rankNameWidth pads the name column so the value column lines up in the ranked
@@ -141,19 +143,4 @@ func hasHeadSpan(h HeadStats) bool {
 // formatMillis renders a Prometheus millisecond epoch as an RFC3339 UTC instant.
 func formatMillis(ms int64) string {
 	return time.UnixMilli(ms).UTC().Format(time.RFC3339)
-}
-
-// errWriter collapses the Fprintf error checks in the text writers into a single
-// short-circuiting sink: once a write fails, later printf calls no-op and the
-// first error is returned.
-type errWriter struct {
-	w   io.Writer
-	err error
-}
-
-func (e *errWriter) printf(format string, args ...any) {
-	if e.err != nil {
-		return
-	}
-	_, e.err = fmt.Fprintf(e.w, format, args...)
 }

--- a/internal/migrateverify/verify.go
+++ b/internal/migrateverify/verify.go
@@ -43,6 +43,8 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+
+	"github.com/tsouza/cerberus/internal/migrate"
 )
 
 // DefaultTolerance is the absolute epsilon two sample values may differ by and
@@ -1087,7 +1089,7 @@ func (r Report) WriteTextGuided(w io.Writer, g TextGuidance) error {
 // its candidate-cause attribution), the out-of-scope accounting, the roll-up
 // counts, and — on failure — a "Report this to cerberus" bug-report section.
 func (r Report) writeText(w io.Writer, g *TextGuidance) error {
-	bw := &errWriter{w: w}
+	bw := migrate.NewErrWriter(w)
 
 	// R1: lead with a prominent, unmistakable verdict line.
 	if r.Failed() {
@@ -1096,60 +1098,60 @@ func (r Report) writeText(w io.Writer, g *TextGuidance) error {
 		// with no visible cause. The no-evidence reasons follow it for the same
 		// reason — a run that failed because a lane compared nothing must say so on
 		// the load-bearing line, not only in the table below it.
-		bw.printf("VERIFICATION FAILED — %d diverged, %d errored, %d unjudged (unconfigured lane), %d matched (of %d replayed)\n",
+		bw.Printf("VERIFICATION FAILED — %d diverged, %d errored, %d unjudged (unconfigured lane), %d matched (of %d replayed)\n",
 			r.Summary.Diverge, r.Summary.Error, r.Summary.Unconfigured, r.Summary.Match, r.Summary.Total)
 		for _, reason := range r.noEvidenceReasons() {
-			bw.printf("                     %s\n", reason)
+			bw.Printf("                     %s\n", reason)
 		}
-		bw.printf("\n")
+		bw.Printf("\n")
 	} else if r.Summary.Unsupported > 0 {
 		// Unsupported queries pass the gate but are NOT matches; the banner must
 		// not equate Total with matched or it overstates what agreed.
-		bw.printf("VERIFICATION PASSED — %d matched, %d unsupported, 0 diverged (of %d)\n\n",
+		bw.Printf("VERIFICATION PASSED — %d matched, %d unsupported, 0 diverged (of %d)\n\n",
 			r.Summary.Match, r.Summary.Unsupported, r.Summary.Total)
 	} else {
-		bw.printf("VERIFICATION PASSED — all %d queries matched\n\n", r.Summary.Total)
+		bw.Printf("VERIFICATION PASSED — all %d queries matched\n\n", r.Summary.Total)
 	}
 
-	bw.printf("# cerberus migrate verify\n")
-	bw.printf("#\n")
+	bw.Printf("# cerberus migrate verify\n")
+	bw.Printf("#\n")
 	if r.hasNonMatrixFamily() {
 		// A run that judged more than one result shape describes itself in the
 		// vocabulary that covers all of them: "series" is the matrix lane's unit,
 		// and a header that says it while a log-stream lane ran would name the
 		// wrong evidence.
-		bw.printf("# Parity gate: each corpus query replayed against its head's reference backend\n")
-		bw.printf("# and cerberus over one window, results diffed by the comparator its result\n")
-		bw.printf("# shape selects. A divergence is never allow-listed — the gate fails if any\n")
-		bw.printf("# query diverges or errors, if a head's replayable queries had no backend pair\n")
-		bw.printf("# to judge them, if nothing was replayable at all, or if any family compared\n")
-		bw.printf("# nothing.\n")
+		bw.Printf("# Parity gate: each corpus query replayed against its head's reference backend\n")
+		bw.Printf("# and cerberus over one window, results diffed by the comparator its result\n")
+		bw.Printf("# shape selects. A divergence is never allow-listed — the gate fails if any\n")
+		bw.Printf("# query diverges or errors, if a head's replayable queries had no backend pair\n")
+		bw.Printf("# to judge them, if nothing was replayable at all, or if any family compared\n")
+		bw.Printf("# nothing.\n")
 	} else {
-		bw.printf("# Parity gate: each corpus query replayed against its head's reference backend\n")
-		bw.printf("# and cerberus over one query_range window, results diffed series-by-series.\n")
-		bw.printf("# A divergence is never allow-listed — the gate fails if any query diverges\n")
-		bw.printf("# or errors, if a head's replayable queries had no backend pair to judge them,\n")
-		bw.printf("# if nothing was replayable at all, or if any lane diffed zero series.\n")
+		bw.Printf("# Parity gate: each corpus query replayed against its head's reference backend\n")
+		bw.Printf("# and cerberus over one query_range window, results diffed series-by-series.\n")
+		bw.Printf("# A divergence is never allow-listed — the gate fails if any query diverges\n")
+		bw.Printf("# or errors, if a head's replayable queries had no backend pair to judge them,\n")
+		bw.Printf("# if nothing was replayable at all, or if any lane diffed zero series.\n")
 	}
-	bw.printf("#\n")
-	bw.printf("# Note: %s\n", ExperimentalNote)
-	bw.printf("#\n")
+	bw.Printf("#\n")
+	bw.Printf("# Note: %s\n", ExperimentalNote)
+	bw.Printf("#\n")
 	// Surface the tolerance the matches were judged at: a loosened tolerance
 	// silently weakens every "match", so the operator must see how strict the
 	// comparison actually was.
-	bw.printf("# Match tolerance: %s (absolute; relative granularity also applied at large magnitudes)\n", formatValue(r.Params.Tolerance))
-	bw.printf("#\n")
-	bw.printf("# %d queries: %d match, %d diverge, %d unsupported, %d error (+%d unconfigured, +%d out of scope, +%d harvest-skipped)\n",
+	bw.Printf("# Match tolerance: %s (absolute; relative granularity also applied at large magnitudes)\n", formatValue(r.Params.Tolerance))
+	bw.Printf("#\n")
+	bw.Printf("# %d queries: %d match, %d diverge, %d unsupported, %d error (+%d unconfigured, +%d out of scope, +%d harvest-skipped)\n",
 		r.Summary.Total, r.Summary.Match, r.Summary.Diverge, r.Summary.Unsupported, r.Summary.Error,
 		r.Summary.Unconfigured, r.Summary.OutOfScope, r.Summary.HarvestSkipped)
 	if r.Summary.Undecidable > 0 {
 		// Undecidable is NOT folded into the match count: both backends answered
 		// and nothing disagreed, but a named limitation stopped short of a parity
 		// claim, and a reader who sees only "match" would take the stronger claim.
-		bw.printf("# %d undecidable — a named, counted limitation prevented a parity claim; see \"not judged\" below\n",
+		bw.Printf("# %d undecidable — a named, counted limitation prevented a parity claim; see \"not judged\" below\n",
 			r.Summary.Undecidable)
 	}
-	bw.printf("\n")
+	bw.Printf("\n")
 
 	r.writeHeadTable(bw)
 
@@ -1157,30 +1159,30 @@ func (r Report) writeText(w io.Writer, g *TextGuidance) error {
 		if res.Verdict == VerdictMatch {
 			continue
 		}
-		bw.printf("== [%s] %s %s\n", res.Verdict, res.Head, res.Source)
-		bw.printf("   expr:   %s\n", res.Expr)
+		bw.Printf("== [%s] %s %s\n", res.Verdict, res.Head, res.Source)
+		bw.Printf("   expr:   %s\n", res.Expr)
 		if res.Detail != "" {
-			bw.printf("   detail: %s\n", res.Detail)
+			bw.Printf("   detail: %s\n", res.Detail)
 		}
 		if res.FirstDiff != nil {
 			writeFirstDiff(bw, res.FirstDiff)
 		}
 		for _, a := range res.Attribution {
-			bw.printf("   candidate-cause [%s]: %s\n", a.Category, a.Note)
+			bw.Printf("   candidate-cause [%s]: %s\n", a.Category, a.Note)
 		}
-		bw.printf("\n")
+		bw.Printf("\n")
 	}
 
 	// Unconfigured prints BEFORE out-of-scope because it blocks: an operator
 	// scanning a failing report must reach the lane they forgot to configure
 	// before the non-blocking accounting.
 	if len(r.Unconfigured) > 0 {
-		bw.printf("== unconfigured (%d) — replayable queries whose head lane had no backend pair; the gate did not judge them\n", len(r.Unconfigured))
+		bw.Printf("== unconfigured (%d) — replayable queries whose head lane had no backend pair; the gate did not judge them\n", len(r.Unconfigured))
 		for _, e := range r.Unconfigured {
-			bw.printf("   %s  %s\n", e.Head, e.Source)
-			bw.printf("        %s\n", e.Reason)
+			bw.Printf("   %s  %s\n", e.Head, e.Source)
+			bw.Printf("        %s\n", e.Reason)
 		}
-		bw.printf("\n")
+		bw.Printf("\n")
 	}
 
 	// What the run could not judge, with the count each statement covers. It sits
@@ -1188,57 +1190,57 @@ func (r Report) writeText(w io.Writer, g *TextGuidance) error {
 	// thing a reader cannot infer from the verdict counts, because a dimension
 	// nobody compared leaves no trace in them.
 	if r.Summary.Undecidable > 0 || len(r.Summary.Limitations) > 0 {
-		bw.printf("== not judged — dimensions no comparator could judge, and how much each covers\n")
+		bw.Printf("== not judged — dimensions no comparator could judge, and how much each covers\n")
 		if r.Summary.Undecidable > 0 {
-			bw.printf("   %d quer%s reached no parity claim at all\n",
+			bw.Printf("   %d quer%s reached no parity claim at all\n",
 				r.Summary.Undecidable, pluralQueries(r.Summary.Undecidable))
 		}
 		for _, l := range r.Summary.Limitations {
-			bw.printf("   [%s] %d: %s\n", l.Code, l.Count, l.Detail)
+			bw.Printf("   [%s] %d: %s\n", l.Code, l.Count, l.Detail)
 		}
-		bw.printf("\n")
+		bw.Printf("\n")
 	}
 
 	if len(r.OutOfScope) > 0 {
-		bw.printf("== out of scope (%d) — no parity is definable for these queries\n", len(r.OutOfScope))
+		bw.Printf("== out of scope (%d) — no parity is definable for these queries\n", len(r.OutOfScope))
 		for _, e := range r.OutOfScope {
-			bw.printf("   %s %s %s: %s\n", outOfScopeLane(e), e.Kind, e.Source, e.Reason)
+			bw.Printf("   %s %s %s: %s\n", outOfScopeLane(e), e.Kind, e.Source, e.Reason)
 		}
-		bw.printf("\n")
+		bw.Printf("\n")
 	}
 
 	if len(r.HarvestSkipped) > 0 {
-		bw.printf("== harvest-skipped (%d) — never became a replayable query, not checked\n", len(r.HarvestSkipped))
+		bw.Printf("== harvest-skipped (%d) — never became a replayable query, not checked\n", len(r.HarvestSkipped))
 		for _, e := range r.HarvestSkipped {
-			bw.printf("   %s: %s\n", e.Source, e.Reason)
+			bw.Printf("   %s: %s\n", e.Source, e.Reason)
 		}
-		bw.printf("\n")
+		bw.Printf("\n")
 	}
 
 	if r.Failed() {
-		bw.printf("FAIL: %d diverge, %d error, %d unconfigured\n", r.Summary.Diverge, r.Summary.Error, r.Summary.Unconfigured)
+		bw.Printf("FAIL: %d diverge, %d error, %d unconfigured\n", r.Summary.Diverge, r.Summary.Error, r.Summary.Unconfigured)
 		for _, reason := range r.noEvidenceReasons() {
-			bw.printf("FAIL: %s\n", reason)
+			bw.Printf("FAIL: %s\n", reason)
 		}
 		r.writeBugReport(bw, g)
 	} else {
 		if r.hasNonMatrixFamily() {
-			bw.printf("PASS: %d match, %d undecidable, %d unsupported, %d comparison units compared (no divergence)\n",
+			bw.Printf("PASS: %d match, %d undecidable, %d unsupported, %d comparison units compared (no divergence)\n",
 				r.Summary.Match, r.Summary.Undecidable, r.Summary.Unsupported, r.Summary.ComparedUnits)
 		} else {
-			bw.printf("PASS: %d match, %d unsupported, %d series compared (no divergence)\n",
+			bw.Printf("PASS: %d match, %d unsupported, %d series compared (no divergence)\n",
 				r.Summary.Match, r.Summary.Unsupported, r.Summary.ComparedSeries)
 		}
 		for _, h := range r.IdleLanes() {
-			bw.printf("NOTE: head %s was configured but had no replayable query (%d out of scope); "+
+			bw.Printf("NOTE: head %s was configured but had no replayable query (%d out of scope); "+
 				"this lane was not judged\n", h.Head, h.Summary.OutOfScope)
 		}
 		for _, f := range r.IdleDerivedFamilies() {
-			bw.printf("NOTE: head %s ran trace-search but never derived a %s probe (no trace-search result "+
+			bw.Printf("NOTE: head %s ran trace-search but never derived a %s probe (no trace-search result "+
 				"gave it a trace both backends have); that shape was not judged this run\n", f.Head, f.Kind)
 		}
 	}
-	return bw.err
+	return bw.Err
 }
 
 // noEvidenceReasons renders the blocking causes that are an ABSENCE rather than a
@@ -1292,19 +1294,19 @@ func (r Report) hasNonMatrixFamily() bool {
 // routing it through formatValue's float rendering would print a present-day
 // nanosecond epoch as "1.78e+18" and lose the entry it points at. A trace-search
 // anchor is a trace, optionally a span within it, and the field that differed.
-func writeFirstDiff(bw *errWriter, fd *FirstDiff) {
+func writeFirstDiff(bw *migrate.ErrWriter, fd *FirstDiff) {
 	switch fd.Kind {
 	case KindLogStream:
-		bw.printf("   first-diff: stream=%s ts=%sns ref=%s cerberus=%s (%s)\n",
+		bw.Printf("   first-diff: stream=%s ts=%sns ref=%s cerberus=%s (%s)\n",
 			fd.Stream, fd.TimestampNano, fd.RefValue, fd.CerberusValue, fd.Reason)
 	case KindTraceSearch, KindTraceByID:
-		bw.printf("   first-diff: %s ref=%s cerberus=%s (%s)\n",
+		bw.Printf("   first-diff: %s ref=%s cerberus=%s (%s)\n",
 			traceDiffAnchor(fd), fd.RefValue, fd.CerberusValue, fd.Reason)
 	case KindTagDiscovery:
-		bw.printf("   first-diff: %s ref=%s cerberus=%s (%s)\n",
+		bw.Printf("   first-diff: %s ref=%s cerberus=%s (%s)\n",
 			tagDiffAnchor(fd), fd.RefValue, fd.CerberusValue, fd.Reason)
 	default:
-		bw.printf("   first-diff: series=%s ts=%s ref=%s cerberus=%s (%s)\n",
+		bw.Printf("   first-diff: series=%s ts=%s ref=%s cerberus=%s (%s)\n",
 			fd.Series, formatValue(fd.Timestamp), fd.RefValue, fd.CerberusValue, fd.Reason)
 	}
 }
@@ -1349,27 +1351,27 @@ func tagDiffAnchor(fd *FirstDiff) string {
 // that left anything undecidable, moves its evidence to one indented row per
 // family — the head line alone would sum two shapes into one number, which is the
 // masking the split exists to prevent.
-func (r Report) writeHeadTable(bw *errWriter) {
+func (r Report) writeHeadTable(bw *migrate.ErrWriter) {
 	if len(r.Heads) == 0 {
 		return
 	}
-	bw.printf("# per-head lanes:\n")
+	bw.Printf("# per-head lanes:\n")
 	for _, h := range r.Heads {
 		s := h.Summary
 		if len(h.Families) > 1 || s.Undecidable > 0 {
-			bw.printf("#   %-6s %-14s %d replayed: %d match, %d diverge, %d unsupported, %d error, %d unconfigured; %d out of scope\n",
+			bw.Printf("#   %-6s %-14s %d replayed: %d match, %d diverge, %d unsupported, %d error, %d unconfigured; %d out of scope\n",
 				h.Head, headLaneState(h), s.Total, s.Match, s.Diverge, s.Unsupported, s.Error, s.Unconfigured, s.OutOfScope)
 			for _, f := range h.Families {
-				bw.printf("#          %-14s %d replayed: %d match, %d diverge, %d undecidable, %d unsupported, %d error; %d %s compared\n",
+				bw.Printf("#          %-14s %d replayed: %d match, %d diverge, %d undecidable, %d unsupported, %d error; %d %s compared\n",
 					f.Kind, f.Total, f.Match, f.Diverge, f.Undecidable, f.Unsupported, f.Error, f.Compared, f.Unit)
 			}
 			continue
 		}
-		bw.printf("#   %-6s %-14s %d replayed: %d match, %d diverge, %d unsupported, %d error, %d unconfigured; %d %s compared, %d out of scope\n",
+		bw.Printf("#   %-6s %-14s %d replayed: %d match, %d diverge, %d unsupported, %d error, %d unconfigured; %d %s compared, %d out of scope\n",
 			h.Head, headLaneState(h), s.Total, s.Match, s.Diverge, s.Unsupported, s.Error, s.Unconfigured,
 			s.ComparedUnits, headLaneUnit(h), s.OutOfScope)
 	}
-	bw.printf("\n")
+	bw.Printf("\n")
 }
 
 // headLaneUnit names the unit a single-family head's evidence is counted in. A
@@ -1406,34 +1408,19 @@ func outOfScopeLane(e OutOfScopeEntry) string {
 // failing run: it frames a divergence as a possible cerberus bug, points at the
 // issues tracker, prints the exact copy-pasteable command to regenerate the
 // diagnostic (when the CLI supplied it), and asks the operator to attach the JSON.
-func (r Report) writeBugReport(bw *errWriter, g *TextGuidance) {
-	bw.printf("\n")
-	bw.printf("== Report this to cerberus\n")
-	bw.printf("   A divergence may indicate a cerberus bug. If the candidate causes above\n")
-	bw.printf("   (especially experimental-CH-feature deviations) are ruled out, please\n")
-	bw.printf("   open an issue so it can be fixed at the source:\n")
-	bw.printf("     %s\n", IssuesURL)
+func (r Report) writeBugReport(bw *migrate.ErrWriter, g *TextGuidance) {
+	bw.Printf("\n")
+	bw.Printf("== Report this to cerberus\n")
+	bw.Printf("   A divergence may indicate a cerberus bug. If the candidate causes above\n")
+	bw.Printf("   (especially experimental-CH-feature deviations) are ruled out, please\n")
+	bw.Printf("   open an issue so it can be fixed at the source:\n")
+	bw.Printf("     %s\n", IssuesURL)
 	if g != nil && g.ReproCommand != "" {
-		bw.printf("   Regenerate the full JSON diagnostic with this exact command:\n")
-		bw.printf("     %s\n", g.ReproCommand)
-		bw.printf("   Then attach the resulting verify-report.json to the issue.\n")
+		bw.Printf("   Regenerate the full JSON diagnostic with this exact command:\n")
+		bw.Printf("     %s\n", g.ReproCommand)
+		bw.Printf("   Then attach the resulting verify-report.json to the issue.\n")
 	} else {
-		bw.printf("   Re-run with --report verify-report.json to capture the full JSON\n")
-		bw.printf("   diagnostic, and attach it to the issue.\n")
+		bw.Printf("   Re-run with --report verify-report.json to capture the full JSON\n")
+		bw.Printf("   diagnostic, and attach it to the issue.\n")
 	}
-}
-
-// errWriter collapses the repeated Fprintf error checks into a single
-// short-circuiting sink: once a write fails, later printf calls are no-ops and
-// the first error is returned.
-type errWriter struct {
-	w   io.Writer
-	err error
-}
-
-func (e *errWriter) printf(format string, args ...any) {
-	if e.err != nil {
-		return
-	}
-	_, e.err = fmt.Fprintf(e.w, format, args...)
 }


### PR DESCRIPTION
## Summary

Fixes two confirmed DRY findings from the migration-lane audit pass, both
already independently verified as real:

- `internal/migrateinventory/inventory.go:311` — `Client.getOK` and
  `LokiClient.getOK` were byte-identical 21-line HTTP-GET helpers. Extracted
  a package-private `httpGetOK(ctx, client, baseURL, path)` in
  `inventory.go`; both methods now delegate to it in one line.
- `internal/migrate/migrate.go:341` — an identical `errWriter` type +
  `printf` method was hand-copied verbatim into `migrate`, `migrategate`,
  `migrateinventory`, and `migrateverify`. Exported it once from `migrate`
  as `ErrWriter` / `NewErrWriter` / `Printf` / `Err`, and switched the other
  three packages to consume it. `.go-arch-lint.yml` already allowed
  `migrategate` and `migrateverify` to depend on `migrate`; added the one
  new non-cyclic `migrateinventory -> migrate` edge the consolidation needed.

Both are pure mechanical dedups — no behavior change, output text and JSON
shapes are byte-identical to before.

## Test plan

- [x] `go build ./...`
- [x] `go test -race ./internal/migrate/... ./internal/migrategate/... ./internal/migrateinventory/... ./internal/migrateverify/...`
- [x] `go vet -tags=migration_tier1 ./test/e2e/migration/...`
- [x] `go vet -tags=migration_tier2 ./test/e2e/migration/...`
- [x] `go-arch-lint check` (local binary) — OK, no warnings
- [x] `gofmt -l .` / `gofumpt -extra` / `goimports -local` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
