### PR TITLE
fix(routememo): touch LRU on corroboration bump and stale-PreferB revalidation

### DIFF
--- a/internal/routememo/memo.go
+++ b/internal/routememo/memo.go
@@ -411,11 +411,13 @@ func (m *Memo) observeRouteAResourceFailureLocked(k Key, now time.Time) {
 	switch v.state {
 	case PreferB:
 		v.createdAt = now
+		m.touchLRULocked(k)
 	case BothFail:
 	case Unknown:
 		if v.corroboration < minCorroboratingFailures {
 			v.corroboration++
 		}
+		m.touchLRULocked(k)
 	}
 }
 

--- a/internal/routememo/memo_test.go
+++ b/internal/routememo/memo_test.go
@@ -411,6 +411,76 @@ func TestLRUEvictsLeastRecentlyTouchedFirst(t *testing.T) {
 	}
 }
 
+// TestLRUTouchesOnCorroborationBumpAndStaleRevalidation pins that the two
+// non-creation route-A resource-failure transitions inside
+// observeRouteAResourceFailureLocked — bumping corroboration on a live
+// Unknown entry, and refreshing a stale PreferB entry on re-validation —
+// both count as a touch for LRU purposes, matching the "least-recently-
+// touched" eviction policy documented at memoMaxEntries. Each subtest fills
+// the memo to exactly capacity, re-touches `first` via the transition under
+// test, then adds ONE more distinct key to force a single eviction: if the
+// transition touched the LRU, `first` moved off the front and something
+// else is evicted instead; if it did not, `first` is still the
+// least-recently-touched entry and is evicted.
+func TestLRUTouchesOnCorroborationBumpAndStaleRevalidation(t *testing.T) {
+	t.Run("Unknown corroboration bump", func(t *testing.T) {
+		m, _ := newTestMemo()
+
+		first := testKey("oldest")
+		m.Observe(first, RouteA, OutcomeResourceFailure) // creates Unknown, corroboration=1
+
+		// Fill up to (but not past) capacity with distinct keys, all touched
+		// AFTER `first`'s creation.
+		fillDistinctPreferB(m, memoMaxEntries-1, func(i int) Key { return Key{RootKind: testKeyName(i)} })
+
+		// Re-touch `first` via a second route-A failure (bumps corroboration,
+		// capped at minCorroboratingFailures) — now the MOST recently
+		// touched entry, if the transition touches the LRU at all.
+		m.Observe(first, RouteA, OutcomeResourceFailure)
+
+		// One more distinct key pushes past capacity, forcing exactly one
+		// eviction from the front.
+		m.Observe(testKey("overflow"), RouteB, OutcomeSuccess)
+
+		m.mu.Lock()
+		_, stillPresent := m.entries[first]
+		m.mu.Unlock()
+		if !stillPresent {
+			t.Fatalf("expected the corroboration-bumped key to have been touched (MRU), not evicted first")
+		}
+	})
+
+	t.Run("stale PreferB re-validation", func(t *testing.T) {
+		m, clk := newTestMemo()
+
+		first := testKey("oldest")
+		m.Observe(first, RouteA, OutcomeResourceFailure)
+		m.Observe(first, RouteA, OutcomeResourceFailure)
+		release, _ := m.BeginProbe(first)
+		m.Observe(first, RouteB, OutcomeSuccess)
+		release()
+
+		fillDistinctPreferB(m, memoMaxEntries-1, func(i int) Key { return Key{RootKind: testKeyName(i)} })
+
+		clk.advance(memoEntryTTL/reValidationFraction + time.Second)
+		if state, stale := m.Lookup(first); state != PreferB || !stale {
+			t.Fatalf("expected stale PreferB at the midpoint, got (%v, %v)", state, stale)
+		}
+
+		// The stale re-validation failure refreshes createdAt AND must touch
+		// the LRU, before one more distinct key forces a single eviction.
+		m.Observe(first, RouteA, OutcomeResourceFailure)
+		m.Observe(testKey("overflow"), RouteB, OutcomeSuccess)
+
+		m.mu.Lock()
+		_, stillPresent := m.entries[first]
+		m.mu.Unlock()
+		if !stillPresent {
+			t.Fatalf("expected the re-validated key to have been touched (MRU), not evicted first")
+		}
+	})
+}
+
 func testKeyName(i int) string {
 	// Deterministic, distinct closed-vocabulary-shaped tag per iteration —
 	// not a real node-kind string, just a unique bucket for the test.


### PR DESCRIPTION
## Summary

Audit finding (area: solver-perf, confirmed real): `internal/routememo/memo.go`'s bounded LRU
only moved an entry to MRU on creation or a route-B transition — a route-A corroboration bump
on a live `Unknown` entry, and a stale-`PreferB` re-validation refresh (both inside
`observeRouteAResourceFailureLocked`), never called `touchLRULocked`. That contradicted the
policy documented at `memoMaxEntries` ("A bounded LRU evicts the least-recently-touched entry"):
under sustained cardinality pressure, an actively-queried route-A key was exactly as evictable
as an hour-idle one.

- Fix: call `m.touchLRULocked(k)` in the `PreferB` (stale revalidation) and `Unknown`
  (corroboration bump) branches of `observeRouteAResourceFailureLocked`'s switch. The `BothFail`
  branch is intentionally left untouched — its own doc comment says it is "left to expire at its
  own TTL", i.e. deliberately not refreshed by any access.
- Test: `TestLRUTouchesOnCorroborationBumpAndStaleRevalidation` in
  `internal/routememo/memo_test.go`, covering both transitions. Verified red against the
  pre-fix code (reverting the two `touchLRULocked` calls locally reproduces both subtest
  failures) and green with the fix.

## Test plan

- [x] `go test -race ./internal/routememo/...` passes
- [x] New test fails without the fix (verified locally by reverting the two-line change) and
      passes with it
- [x] `gofumpt -extra` / `goimports` clean on the touched files

🤖 Generated with [Claude Code](https://claude.com/claude-code)
