### PR TITLE
fix(promql): reattach doc comment and dedup subquery modifier-strip

### DIFF
--- a/internal/promql/lower.go
+++ b/internal/promql/lower.go
@@ -299,6 +299,25 @@ func lower(expr parser.Expr, s schema.Metrics, ctx lowerCtx) (chplan.Node, error
 	}
 }
 
+// stripSelectorModifierForRangeVector returns a copy of vs with its `@` /
+// `offset` modifiers cleared and a copy of ctx with inRangeVector set. Every
+// range-vector-consuming lowering path (rate / *_over_time, subqueries, the
+// RangeWindow wrappers) applies this same prep before recursing into
+// lowerVectorSelector: the caller's own window bound owns the selector's
+// timing instead of a duplicate modifier-derived predicate, and
+// inRangeVector suppresses the bare-selector LWR wrap so every in-window
+// sample survives.
+func stripSelectorModifierForRangeVector(vs *parser.VectorSelector, ctx lowerCtx) (parser.VectorSelector, lowerCtx) {
+	vsNoMod := *vs
+	vsNoMod.Timestamp = nil
+	vsNoMod.OriginalOffset = 0
+	vsNoMod.Offset = 0
+	vsNoMod.StartOrEnd = 0
+	rangeCtx := ctx
+	rangeCtx.inRangeVector = true
+	return vsNoMod, rangeCtx
+}
+
 // lowerMatrixSelector handles a TOP-LEVEL range-vector selector —
 // `up[5m]` sent to /api/v1/query. Reference Prometheus answers these
 // with resultType "matrix": every RAW sample in `(eval − range, eval]`
@@ -329,13 +348,7 @@ func lowerMatrixSelector(ms *parser.MatrixSelector, s schema.Metrics, ctx lowerC
 	// Strip the modifier — the window bound below carries the anchor;
 	// inRangeVector suppresses the LWR wrap so every in-window sample
 	// survives.
-	vsNoMod := *vs
-	vsNoMod.Timestamp = nil
-	vsNoMod.OriginalOffset = 0
-	vsNoMod.Offset = 0
-	vsNoMod.StartOrEnd = 0
-	rangeCtx := ctx
-	rangeCtx.inRangeVector = true
+	vsNoMod, rangeCtx := stripSelectorModifierForRangeVector(vs, ctx)
 	inner, err := lowerVectorSelector(&vsNoMod, s, rangeCtx)
 	if err != nil {
 		return nil, err
@@ -363,22 +376,6 @@ func lowerMatrixSelector(ms *parser.MatrixSelector, s schema.Metrics, ctx lowerC
 	}, nil
 }
 
-// lowerVectorSelector turns `metric{label="val"}` into Scan + Filter.
-// `@` and `offset` modifiers add a `Timestamp <= anchor` predicate so the
-// instant evaluation reflects the requested shifted time.
-//
-// When ctx.inRangeVector is false (the default — top-level selector,
-// under aggregations, or inside instant arithmetic) cerberus also
-// applies PromQL's Latest-With-Respect-to-T (LWR) rule: filter the
-// scan to samples with `Timestamp <= anchor` AND
-// `anchor - Timestamp < 5m` (Prom's default staleness window), then
-// collapse to one row per series via `argMax(Value, TimeUnix)` /
-// `max(TimeUnix)` grouped by `(MetricName, Attributes)`. That's the
-// per-series-latest-within-lookback contract any downstream aggregation
-// must aggregate over. Range-vector consumers (rate / *_over_time /
-// subqueries) bypass the LWR wrap by setting `inRangeVector` before
-// recursing — the RangeWindow node owns the in-window aggregation
-// itself.
 // lowerHistogramSelectorInput builds the selector's input subtree for the
 // classic-histogram companion (`_count` / `_sum`) and `_bucket` fan-out
 // paths, returning the (possibly wrapped) input node, the residual
@@ -610,6 +607,22 @@ func resolveSelectorRouting(metricName string, s schema.Metrics, ctx lowerCtx, d
 	return route, nil
 }
 
+// lowerVectorSelector turns `metric{label="val"}` into Scan + Filter.
+// `@` and `offset` modifiers add a `Timestamp <= anchor` predicate so the
+// instant evaluation reflects the requested shifted time.
+//
+// When ctx.inRangeVector is false (the default — top-level selector,
+// under aggregations, or inside instant arithmetic) cerberus also
+// applies PromQL's Latest-With-Respect-to-T (LWR) rule: filter the
+// scan to samples with `Timestamp <= anchor` AND
+// `anchor - Timestamp < 5m` (Prom's default staleness window), then
+// collapse to one row per series via `argMax(Value, TimeUnix)` /
+// `max(TimeUnix)` grouped by `(MetricName, Attributes)`. That's the
+// per-series-latest-within-lookback contract any downstream aggregation
+// must aggregate over. Range-vector consumers (rate / *_over_time /
+// subqueries) bypass the LWR wrap by setting `inRangeVector` before
+// recursing — the RangeWindow node owns the in-window aggregation
+// itself.
 func lowerVectorSelector(v *parser.VectorSelector, s schema.Metrics, ctx lowerCtx) (chplan.Node, error) {
 	metricName := metricNameFromMatchers(v.LabelMatchers)
 	if hasUnpinnedMetricNameMatcher(v.LabelMatchers) && s.HistogramTable != "" {
@@ -2275,13 +2288,7 @@ func lowerRangeVectorCall(c *parser.Call, s schema.Metrics, ctx lowerCtx) (chpla
 	// Build the inner Scan/Filter without the modifier-derived bound here.
 	// The inRangeVector flag also suppresses the bare-selector LWR wrap so
 	// every in-window sample reaches the RangeWindow node.
-	vsNoModifier := *vs
-	vsNoModifier.Timestamp = nil
-	vsNoModifier.OriginalOffset = 0
-	vsNoModifier.Offset = 0
-	vsNoModifier.StartOrEnd = 0
-	rangeCtx := ctx
-	rangeCtx.inRangeVector = true
+	vsNoModifier, rangeCtx := stripSelectorModifierForRangeVector(vs, ctx)
 	// rate() / increase() / irate() apply Prometheus's counter-reset rule,
 	// which assumes CUMULATIVE storage — reading a DELTA-temporality counter
 	// the same way silently inflates every window (see issue #1628). Decide

--- a/internal/promql/subquery.go
+++ b/internal/promql/subquery.go
@@ -89,7 +89,12 @@ func lowerSubqueryOverUnary(
 		return subqueryAnchorShape(inner, s), nil
 	}
 
-	rangeCtx := ctx
+	// Mirrors lowerSubqueryOverBinary's synthetic-operand offset shift (PR
+	// #1418): a subquery offset must shift a synthetic source's (e.g.
+	// time()) own evaluation grid along with its window, or it evaluates at
+	// the outer grid while the enclosing RangeWindow reads the shifted
+	// subquery grid.
+	rangeCtx := subqueryOffsetCtx(sub, ctx)
 	rangeCtx.inRangeVector = true
 	inner, err := lowerUnary(u, s, rangeCtx)
 	if err != nil {
@@ -374,13 +379,7 @@ func lowerSubqueryOverCall(
 	// Strip the inner VS modifier — the subquery's own modifier shadows it.
 	// inRangeVector also suppresses the bare-selector LWR wrap so every
 	// in-window sample reaches the surrounding RangeWindow.
-	vsNoModifier := *vs
-	vsNoModifier.Timestamp = nil
-	vsNoModifier.OriginalOffset = 0
-	vsNoModifier.Offset = 0
-	vsNoModifier.StartOrEnd = 0
-	rangeCtx := ctx
-	rangeCtx.inRangeVector = true
+	vsNoModifier, rangeCtx := stripSelectorModifierForRangeVector(vs, ctx)
 	// A subquery's inner counter function reads the SAME stored samples the
 	// un-nested call does, so it owes the same DELTA-vs-CUMULATIVE runtime
 	// branch: `max_over_time(rate(m[5m])[1h:1m])` over a DELTA-temporality
@@ -616,13 +615,7 @@ func lowerSubqueryOverVectorSelector(
 	s schema.Metrics,
 	ctx lowerCtx,
 ) (chplan.Node, error) {
-	vsNoModifier := *vs
-	vsNoModifier.Timestamp = nil
-	vsNoModifier.OriginalOffset = 0
-	vsNoModifier.Offset = 0
-	vsNoModifier.StartOrEnd = 0
-	rangeCtx := ctx
-	rangeCtx.inRangeVector = true
+	vsNoModifier, rangeCtx := stripSelectorModifierForRangeVector(vs, ctx)
 	inner, err := lowerVectorSelector(&vsNoModifier, s, rangeCtx)
 	if err != nil {
 		return nil, err
@@ -1572,13 +1565,7 @@ func lowerSubqueryOverAbsent(
 
 	if len(call.Args) == 1 {
 		if vs, ok := unwrapParens(call.Args[0]).(*parser.VectorSelector); ok {
-			vsNoMod := *vs
-			vsNoMod.Timestamp = nil
-			vsNoMod.OriginalOffset = 0
-			vsNoMod.Offset = 0
-			vsNoMod.StartOrEnd = 0
-			rangeCtx := ctx
-			rangeCtx.inRangeVector = true
+			vsNoMod, rangeCtx := stripSelectorModifierForRangeVector(vs, ctx)
 			inner, err := lowerVectorSelector(&vsNoMod, s, rangeCtx)
 			if err != nil {
 				return nil, err


### PR DESCRIPTION
## Summary

Fixes three confirmed findings from the promql-core area of the pre-release full-codebase audit
(all previously verified real by an independent skeptic pass):

- **doc-drift** (`internal/promql/lower.go:366`): the doc comment describing `lowerVectorSelector`'s
  LWR/`@`-modifier behaviour had no blank line before `lowerHistogramSelectorInput`'s own doc
  comment, so Go's doc-comment attachment rule glued the whole merged block onto
  `lowerHistogramSelectorInput` instead — leaving the real `lowerVectorSelector` (further down the
  file) undocumented. Split the comment back onto the function it actually describes; verified with
  `go doc -u` that both symbols now carry their own correct doc text.
- **dry** (`internal/promql/subquery.go:92` and 4 other sites): the "strip `@`/`offset` off a copied
  `VectorSelector`, then set `inRangeVector`" block was copy-pasted byte-for-byte five times across
  `lower.go` and `subquery.go`. Extracted into `stripSelectorModifierForRangeVector` and called it
  from all five sites.
- **inconsistent** (`internal/promql/subquery.go:92`): `lowerSubqueryOverUnary`'s raw-stream fallback
  never applied the subquery-offset shift (`subqueryOffsetCtx`) that its structurally identical
  sibling `lowerSubqueryOverBinary` applies (PR #1418) for synthetic sources like `time()`. The
  prior audit pass verified this asymmetry is currently inert on every reachable production path
  (the grid branch both functions share already offset-shifts identically; only the never-reached
  raw-stream fallback differed, and `subqueryOffsetCtx` no-ops when `ctx.start`/`ctx.end` are zero,
  the only way to reach that fallback today). Applied the same shift for consistency and
  future-proofing.

All three were small, well-scoped fixes (doc correction, helper extraction, inconsistency fix) with
no behavior change on any reachable path, so none needed a deferral issue.

## Test plan

- [x] `go build ./internal/promql/...`
- [x] `go test ./internal/promql/...` (covers `TestLower`'s TXTAR-driven pre-optimizer spec corpus
      for both `lower.go` and `subquery.go`)
- [x] `go vet ./internal/promql/...`
- [x] `go doc -u ./internal/promql lowerVectorSelector` / `lowerHistogramSelectorInput` — each now
      shows its own correct doc text
- [x] `gofumpt -l` / `goimports -l` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
