### PR TITLE
fix(cardinality): regenerate baseline for exp-histogram binop fixtures

### DIFF
--- a/test/perf/cardinality-baseline/promql/exp_histogram_binop_add.json
+++ b/test/perf/cardinality-baseline/promql/exp_histogram_binop_add.json
@@ -1,0 +1,11 @@
+{
+  "fixture": "promql/exp_histogram_binop_add",
+  "fan_factor": 1,
+  "scan_rows": 4,
+  "peak_intermediate": 4,
+  "has_cross_join": false,
+  "has_array_join": false,
+  "has_recursive_cte": false,
+  "max_recursion_depth": 0,
+  "uncountable_levels": 0
+}

--- a/test/perf/cardinality-baseline/promql/exp_histogram_binop_add_downscale_fold.json
+++ b/test/perf/cardinality-baseline/promql/exp_histogram_binop_add_downscale_fold.json
@@ -1,0 +1,11 @@
+{
+  "fixture": "promql/exp_histogram_binop_add_downscale_fold",
+  "fan_factor": 1,
+  "scan_rows": 2,
+  "peak_intermediate": 2,
+  "has_cross_join": false,
+  "has_array_join": false,
+  "has_recursive_cte": false,
+  "max_recursion_depth": 0,
+  "uncountable_levels": 0
+}

--- a/test/perf/cardinality-baseline/promql/exp_histogram_binop_add_range.json
+++ b/test/perf/cardinality-baseline/promql/exp_histogram_binop_add_range.json
@@ -1,0 +1,11 @@
+{
+  "fixture": "promql/exp_histogram_binop_add_range",
+  "fan_factor": 10,
+  "scan_rows": 3,
+  "peak_intermediate": 30,
+  "has_cross_join": false,
+  "has_array_join": true,
+  "has_recursive_cte": false,
+  "max_recursion_depth": 0,
+  "uncountable_levels": 0
+}

--- a/test/perf/cardinality-baseline/promql/exp_histogram_binop_sub.json
+++ b/test/perf/cardinality-baseline/promql/exp_histogram_binop_sub.json
@@ -1,0 +1,11 @@
+{
+  "fixture": "promql/exp_histogram_binop_sub",
+  "fan_factor": 1,
+  "scan_rows": 2,
+  "peak_intermediate": 2,
+  "has_cross_join": false,
+  "has_array_join": false,
+  "has_recursive_cte": false,
+  "max_recursion_depth": 0,
+  "uncountable_levels": 0
+}


### PR DESCRIPTION
## Summary

- `feat(promql): support +/- between two exponential-histogram selectors (#2278)` added four new
  TXTAR fixtures (`test/spec/promql/exp_histogram_binop_add.txtar`,
  `exp_histogram_binop_add_downscale_fold.txtar`, `exp_histogram_binop_add_range.txtar`,
  `exp_histogram_binop_sub.txtar`) but did not regenerate the `cardinality` golden shard for them,
  per invariant 9 (`just update-golden <shard>...` — the shard argument is required, and `cardinality`
  is one of the generated artefacts it maintains alongside `promql`).
- This regenerates just the `cardinality` shard via the `update-golden.yml` workflow, adding the four
  missing `test/perf/cardinality-baseline/promql/exp_histogram_binop_*.json` baseline entries so the
  cardinality ratchet has a pinned baseline for those fixtures.

## Test plan

- [x] `chore(goldens): regenerate selected shards` produced by `update-golden.yml -f shards=cardinality`,
      verified as a clean fast-forward onto the current commit.
- [x] Diff is exactly the four new baseline JSON files — no other shard touched.
