### PR TITLE
ci: extract registry-login and free-disk-space into composite actions

### DIFF
--- a/.github/actions/free-disk-space/action.yml
+++ b/.github/actions/free-disk-space/action.yml
@@ -1,0 +1,33 @@
+name: Free disk space
+description: >
+  Reclaim unused runner disk space, logging free space before and after so
+  an exhaustion shows up in the step output rather than surfacing only as a
+  mid-job "no space left on device" abort.
+
+# Why a composite action: every Docker/ClickHouse-heavy job needs the same
+# reclaim before its stack boots (build layers plus a running ClickHouse
+# exhaust bone-stock ubuntu-latest's ~14 GB free root fs). docker-images,
+# large-packages and tool-cache are all `false` at every call site - the
+# stacks these jobs bring up need Docker's prebaked images, and reclaiming
+# the smaller large-packages/tool-cache categories was never worth their
+# extra time - so those knobs are fixed here rather than exposed as inputs.
+# Pinned to a commit SHA: the action only ships @main, and the repo rule is
+# to pin CI dependencies explicitly rather than track a moving default.
+
+runs:
+  using: composite
+  steps:
+    - name: Disk free (before reclaim)
+      shell: bash
+      run: df -h
+
+    - name: Free disk space
+      uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # main as of 2026-06-18
+      with:
+        docker-images: false
+        large-packages: false
+        tool-cache: false
+
+    - name: Disk free (after reclaim)
+      shell: bash
+      run: df -h

--- a/.github/actions/registry-login/action.yml
+++ b/.github/actions/registry-login/action.yml
@@ -1,0 +1,66 @@
+name: Registry login
+description: >
+  Log in to the GHCR image mirror, then (if a Docker Hub PAT is configured)
+  to Docker Hub, in that order.
+
+# Why a composite action: every Docker/k3d-backed job needs the identical
+# two-step login pair, and a composite action's steps have no implicit
+# access to the caller's `secrets` context, so the credentials travel in as
+# inputs instead.
+#
+# Order matters and is the whole point of this action: GHCR is the PRIMARY
+# acquisition path (cerberus's own mirror of every upstream image this job
+# pulls - see .github/scripts/lib/mirror.mjs) and Docker Hub is the
+# fallback. Authenticating the fallback first is what let a Docker Hub
+# outage kill a job before the mirror it exists to fall back TO was ever
+# contacted (issue #1933).
+#
+# An unreachable Docker Hub no longer takes a job down with it either: the
+# login exhausts its retries on a transport fault and downgrades the job to
+# MIRROR-ONLY (registry-login.mjs), where every image comes from the GHCR
+# mirror and one the mirror cannot serve fails the job naming itself rather
+# than being pulled anonymously. A quota refusal or a rejected credential
+# still fails here on the first attempt.
+
+inputs:
+  github-token:
+    description: Token used to authenticate to the GHCR image mirror.
+    required: true
+  docker-hub-pat:
+    description: >
+      Docker Hub personal access token. Empty (as on a fork PR, where the
+      secret is unavailable) skips the Docker Hub login and leaves the job
+      on GHCR plus anonymous Docker Hub pulls.
+    required: false
+    default: ''
+  run-docker-hub-login:
+    description: >
+      Extra gate ANDed with `docker-hub-pat` being set. Lets a caller with
+      its own job-level run condition (e.g. a sharded matrix job) skip the
+      Docker Hub login without also skipping the GHCR login, which some
+      callers need to run unconditionally.
+    required: false
+    default: 'true'
+
+runs:
+  using: composite
+  steps:
+    - name: Log in to the image mirror (GHCR)
+      shell: bash
+      env:
+        REGISTRY: ghcr.io
+        USERNAME: ${{ github.repository_owner }}
+        PASSWORD: ${{ inputs.github-token }}
+      run: node "$GITHUB_WORKSPACE/.github/scripts/registry-login.mjs"
+
+    # Authenticated Docker Hub pulls get a far higher rate limit than
+    # anonymous pulls from shared runner IPs. Skips silently when the PAT is
+    # absent (forks); GHCR mirroring above is the stronger long-term fix.
+    - name: Log in to Docker Hub
+      if: ${{ inputs.run-docker-hub-login == 'true' && env.DOCKER_HUB_PAT_SET == 'true' }}
+      shell: bash
+      env:
+        DOCKER_HUB_PAT_SET: ${{ inputs.docker-hub-pat != '' }}
+        USERNAME: tsouza
+        PASSWORD: ${{ inputs.docker-hub-pat }}
+      run: node "$GITHUB_WORKSPACE/.github/scripts/registry-login.mjs"

--- a/.github/scripts/assert-image-jobs-authenticate.test.mjs
+++ b/.github/scripts/assert-image-jobs-authenticate.test.mjs
@@ -18,7 +18,7 @@
 // here directly.
 
 import assert from 'node:assert/strict';
-import { mkdtempSync, readFileSync, writeFileSync } from 'node:fs';
+import { cpSync, mkdtempSync, readFileSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import test from 'node:test';
@@ -67,14 +67,50 @@ function scanWith(file, edit) {
   return scan({ root: repoRoot, workflowDir: dir });
 }
 
+// scanWithAction — the real tree, with ONE composite action's action.yml
+// doctored and every workflow file left untouched.
+//
+// The registry-login pair used to be duplicated inline at every call site, so
+// doctoring the CALLING workflow's copy was doctoring the thing under test.
+// Since #2304 it lives once in .github/actions/registry-login, resolved into
+// every caller by `step()`'s own `uses: ./` handling (proved separately by
+// "a composite action contributes its own steps"). A negative control that
+// still edited the calling workflow's text would prove nothing — the text it
+// is looking for no longer exists there — so this doctors the action file
+// the resolver actually reads, and leaves a real, untouched copy of the
+// calling workflow to resolve `uses:` into it.
+//
+// root mirrors just the pieces the resolver reads (Justfile, .github/scripts,
+// .github/actions), with the target action doctored; workflowDir is a temp
+// copy of the ONE untouched calling workflow, matching scanWith's shape of
+// scanning a single file rather than the whole tree.
+function scanWithAction(actionRelPath, workflowFile, edit) {
+  const root = mkdtempSync(join(tmpdir(), 'image-auth-gate-root-'));
+  cpSync(join(repoRoot, 'Justfile'), join(root, 'Justfile'));
+  cpSync(join(repoRoot, '.github/scripts'), join(root, '.github/scripts'), { recursive: true });
+  cpSync(join(repoRoot, '.github/actions'), join(root, '.github/actions'), { recursive: true });
+
+  const original = readFileSync(join(root, actionRelPath), 'utf8');
+  const doctored = edit(original);
+  assert.notEqual(doctored, original, 'the negative control did not change the action text');
+  writeFileSync(join(root, actionRelPath), doctored);
+
+  const wfDir = mkdtempSync(join(tmpdir(), 'image-auth-gate-wf-'));
+  writeFileSync(join(wfDir, workflowFile), readFileSync(join(workflows, workflowFile), 'utf8'));
+
+  return scan({ root, workflowDir: wfDir });
+}
+
 // Removes EVERY `- name: <title>` step, each up to the next step at its own
 // indentation. Deleting the login is the regression this gate exists to catch,
 // so it is also the way to prove the gate catches it.
 //
-// Every occurrence, not the first: `Log in to Docker Hub` is the title of a step
-// in six jobs of e2e.yml, so removing one match doctors whichever job happens to
-// come first in the file — which is not the job under test, and leaves the
-// control asserting that an untouched job is still clean.
+// Every occurrence, not the first: before #2304 `Log in to Docker Hub` was the
+// title of a step in six jobs of e2e.yml, so removing one match doctored
+// whichever job happened to come first in the file rather than the job under
+// test. Now that the pair lives once in the registry-login composite action,
+// "every occurrence" is exactly one — but the loop stays generic rather than
+// assuming that, so it still holds if a step title is ever repeated again.
 function withoutStep(title) {
   return (text) => {
     const lines = text.split('\n');
@@ -207,8 +243,10 @@ test('a composite action contributes its own steps', () => {
 // Negative controls — each rule, proved against the real workflow text.
 // ---------------------------------------------------------------------------
 
+const registryLoginAction = '.github/actions/registry-login/action.yml';
+
 test('R1 fires when an acquiring job has no login at all', () => {
-  const results = scanWith('e2e.yml', (text) =>
+  const results = scanWithAction(registryLoginAction, 'e2e.yml', (text) =>
     withoutStep('Log in to the image mirror (GHCR)')(withoutStep('Log in to Docker Hub')(text)),
   );
   const violations = violationsFor(specimenJob, findingsFor(specimenJob, results));
@@ -217,7 +255,7 @@ test('R1 fires when an acquiring job has no login at all', () => {
 });
 
 test('R2 fires when an acquiring job has no Docker Hub login', () => {
-  const results = scanWith('e2e.yml', withoutStep('Log in to Docker Hub'));
+  const results = scanWithAction(registryLoginAction, 'e2e.yml', withoutStep('Log in to Docker Hub'));
   const violations = violationsFor(specimenJob, findingsFor(specimenJob, results));
   assert.equal(violations.length, 1);
   assert.match(violations[0], /clickhouse\/clickhouse-server:[\d.]+/);
@@ -225,7 +263,7 @@ test('R2 fires when an acquiring job has no Docker Hub login', () => {
 });
 
 test('R3 fires when a job pulling through the mirror has no ghcr.io login', () => {
-  const results = scanWith('e2e.yml', withoutStep('Log in to the image mirror (GHCR)'));
+  const results = scanWithAction(registryLoginAction, 'e2e.yml', withoutStep('Log in to the image mirror (GHCR)'));
   const violations = violationsFor(specimenJob, findingsFor(specimenJob, results));
   assert.equal(violations.length, 1);
   assert.match(violations[0], /no ghcr\.io login/);
@@ -242,10 +280,14 @@ test('R3 fires when a job pulling through the mirror has no ghcr.io login', () =
 // what makes the order a separate rule rather than a stylistic one.
 // ---------------------------------------------------------------------------
 
-// swapLoginOrder — put the Docker Hub login back ahead of the mirror login, the
-// pre-#1933 shape, by moving the mirror step to just after the Hub step. Only
-// the pair in the specimen job is touched, so the rest of the file stays clean.
-function swapLoginOrder(text) {
+// swapActionLoginOrder — put the Docker Hub login back ahead of the ghcr.io
+// login, the pre-#1933 shape, by moving the mirror step to just after the Hub
+// step. Before #2304 this had to search out ONE job's own copy of the pair
+// among e2e.yml's several duplicates; the registry-login composite action now
+// holds the pair exactly once, so there is no per-job scoping left to do —
+// swapping its one copy swaps the order for every caller at once, and the
+// specimen job is enough to observe that.
+function swapActionLoginOrder(text) {
   const lines = text.split('\n');
   const stepAt = (title, from) => {
     const i = lines.findIndex((l, n) => n >= from && l.trim() === `- name: ${title}`);
@@ -260,10 +302,7 @@ function swapLoginOrder(text) {
     while (end - 1 > i && lines[end - 1].trim() === '') end--;
     return [i, end];
   };
-  // The specimen's own pair: find the mirror login that precedes its Hub login.
-  const bench = lines.findIndex((l) => l.trim() === 'startup-bench:');
-  assert.notEqual(bench, -1, 'startup-bench did not appear in e2e.yml');
-  const [mTop, mEnd] = stepAt('Log in to the image mirror (GHCR)', bench);
+  const [mTop, mEnd] = stepAt('Log in to the image mirror (GHCR)', 0);
   const [hTop, hEnd] = stepAt('Log in to Docker Hub', mEnd);
   const mirror = lines.slice(mTop, mEnd);
   const hub = lines.slice(hTop, hEnd);
@@ -271,7 +310,7 @@ function swapLoginOrder(text) {
 }
 
 test('R5 fires when the Docker Hub login runs before the ghcr.io one', () => {
-  const results = scanWith('e2e.yml', swapLoginOrder);
+  const results = scanWithAction(registryLoginAction, 'e2e.yml', swapActionLoginOrder);
   const findings = findingsFor(specimenJob, results);
   const violations = violationsFor(specimenJob, findings);
   assert.ok(
@@ -311,9 +350,10 @@ test('R6 fires when a job that writes to a registry loses its opt-out', () => {
 });
 
 test('R6 fires when a consuming job opts itself out of mirror-only mode', () => {
-  // The e2e specimen: adding the opt-out to its Docker Hub login is the exact
-  // one-line edit that would quietly undo this change for that lane.
-  const results = scanWith('e2e.yml', (text) =>
+  // The registry-login composite's own Docker Hub step: adding the opt-out
+  // there is the exact one-line edit that would quietly undo this change for
+  // every consuming caller of the composite, e2e.yml's specimen included.
+  const results = scanWithAction(registryLoginAction, 'e2e.yml', (text) =>
     text.replace(/(\n(\s+)USERNAME: tsouza\n)/, `$1$2ON_TRANSPORT_FAULT: fail\n`),
   );
   const violations = results.flatMap((r) => violationsFor(r.id, r.findings));

--- a/.github/workflows/compatibility.yml
+++ b/.github/workflows/compatibility.yml
@@ -268,16 +268,7 @@ jobs:
       # aborts. Reclaim ~25-30 GB of unused pre-baked toolchains first; KEEP
       # Docker images (the stack needs them). Pinned to a commit SHA (action
       # only ships @main; repo CI rule: pin explicitly, no HEAD).
-      - name: Disk free (before reclaim)
-        run: df -h
-      - name: Free disk space
-        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # main as of 2026-06-18
-        with:
-          docker-images: false
-          large-packages: false
-          tool-cache: false
-      - name: Disk free (after reclaim)
-        run: df -h
+      - uses: ./.github/actions/free-disk-space
 
       - uses: actions/setup-go@v7
         with:
@@ -288,42 +279,10 @@ jobs:
         with:
           tool: just
 
-      # Cerberus's own copy of every upstream image this job pulls lives in a
-      # PRIVATE GHCR namespace, and `pullImageWithRetry` reaches for it before
-      # Docker Hub. That reach works only once this step has written ghcr.io
-      # credentials; without it the pull falls back to the shared anonymous
-      # Docker Hub quota. See .github/scripts/lib/mirror.mjs.
-      #
-      # FIRST, ahead of the Docker Hub login below, because this is the PRIMARY
-      # acquisition path and that one is the fallback. Authenticating the
-      # fallback first is what let a Docker Hub outage kill this job before the
-      # mirror it exists to fall back TO was ever contacted (issue #1933).
-      - name: Log in to the image mirror (GHCR)
-        env:
-          REGISTRY: ghcr.io
-          USERNAME: ${{ github.repository_owner }}
-          PASSWORD: ${{ secrets.GITHUB_TOKEN }}
-        run: node .github/scripts/registry-login.mjs
-
-      # Authenticated Docker Hub pulls get a far higher rate limit than
-      # anonymous pulls from shared runner IPs — two image-pull flakes
-      # in one night hit this workflow (run 27241748868). Skips
-      # silently when the secrets are absent (forks). The GHCR mirror
-      # login above is what removes the dependence on this limit.
-      #
-      # An unreachable Docker Hub no longer takes this job down with it: the
-      # login exhausts its retries on a transport fault and downgrades the job
-      # to MIRROR-ONLY (registry-login.mjs), where every image comes from the
-      # mirror and one the mirror cannot serve fails the job naming itself
-      # rather than being pulled anonymously. A quota refusal or a rejected
-      # credential still fails here on the first attempt.
-      - name: Log in to Docker Hub
-        if: ${{ env.DOCKER_HUB_PAT_SET == 'true' }}
-        env:
-          DOCKER_HUB_PAT_SET: ${{ secrets.DOCKER_HUB_PAT != '' }}
-          USERNAME: tsouza
-          PASSWORD: ${{ secrets.DOCKER_HUB_PAT }}
-        run: node .github/scripts/registry-login.mjs
+      - uses: ./.github/actions/registry-login
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          docker-hub-pat: ${{ secrets.DOCKER_HUB_PAT }}
 
       - name: Run compatibility harness
         id: compat
@@ -488,16 +447,7 @@ jobs:
       # Same compose stack + same DiskPressure risk as compatibility/prometheus.
       # Reclaim ~25-30 GB of unused toolchains first; KEEP Docker images. Pinned
       # to a commit SHA (action only ships @main).
-      - name: Disk free (before reclaim)
-        run: df -h
-      - name: Free disk space
-        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # main as of 2026-06-18
-        with:
-          docker-images: false
-          large-packages: false
-          tool-cache: false
-      - name: Disk free (after reclaim)
-        run: df -h
+      - uses: ./.github/actions/free-disk-space
 
       - uses: actions/setup-go@v7
         with:
@@ -508,36 +458,10 @@ jobs:
         with:
           tool: just
 
-      # Cerberus's own copy of every upstream image this job pulls lives in a
-      # PRIVATE GHCR namespace, and `pullImageWithRetry` reaches for it before
-      # Docker Hub. That reach works only once this step has written ghcr.io
-      # credentials; without it the pull falls back to the shared anonymous
-      # Docker Hub quota. See .github/scripts/lib/mirror.mjs.
-      #
-      # FIRST, ahead of the Docker Hub login below, because this is the PRIMARY
-      # acquisition path and that one is the fallback. Authenticating the
-      # fallback first is what let a Docker Hub outage kill this job before the
-      # mirror it exists to fall back TO was ever contacted (issue #1933).
-      - name: Log in to the image mirror (GHCR)
-        env:
-          REGISTRY: ghcr.io
-          USERNAME: ${{ github.repository_owner }}
-          PASSWORD: ${{ secrets.GITHUB_TOKEN }}
-        run: node .github/scripts/registry-login.mjs
-
-      # An unreachable Docker Hub no longer takes this job down with it: the
-      # login exhausts its retries on a transport fault and downgrades the job
-      # to MIRROR-ONLY (registry-login.mjs), where every image comes from the
-      # mirror and one the mirror cannot serve fails the job naming itself
-      # rather than being pulled anonymously. A quota refusal or a rejected
-      # credential still fails here on the first attempt.
-      - name: Log in to Docker Hub
-        if: ${{ env.DOCKER_HUB_PAT_SET == 'true' }}
-        env:
-          DOCKER_HUB_PAT_SET: ${{ secrets.DOCKER_HUB_PAT != '' }}
-          USERNAME: tsouza
-          PASSWORD: ${{ secrets.DOCKER_HUB_PAT }}
-        run: node .github/scripts/registry-login.mjs
+      - uses: ./.github/actions/registry-login
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          docker-hub-pat: ${{ secrets.DOCKER_HUB_PAT }}
 
       - name: Run forced-route compatibility harness
         id: compat
@@ -663,16 +587,7 @@ jobs:
 
       # ---- free runner disk BEFORE the compose stack boots (infra-flake fix) ----
       # Same compose stack + same DiskPressure risk as compatibility/prometheus.
-      - name: Disk free (before reclaim)
-        run: df -h
-      - name: Free disk space
-        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # main as of 2026-06-18
-        with:
-          docker-images: false
-          large-packages: false
-          tool-cache: false
-      - name: Disk free (after reclaim)
-        run: df -h
+      - uses: ./.github/actions/free-disk-space
 
       - uses: actions/setup-go@v7
         with:
@@ -683,26 +598,10 @@ jobs:
         with:
           tool: just
 
-      - name: Log in to the image mirror (GHCR)
-        env:
-          REGISTRY: ghcr.io
-          USERNAME: ${{ github.repository_owner }}
-          PASSWORD: ${{ secrets.GITHUB_TOKEN }}
-        run: node .github/scripts/registry-login.mjs
-
-      # An unreachable Docker Hub no longer takes this job down with it: the
-      # login exhausts its retries on a transport fault and downgrades the job
-      # to MIRROR-ONLY (registry-login.mjs), where every image comes from the
-      # mirror and one the mirror cannot serve fails the job naming itself
-      # rather than being pulled anonymously. A quota refusal or a rejected
-      # credential still fails here on the first attempt.
-      - name: Log in to Docker Hub
-        if: ${{ env.DOCKER_HUB_PAT_SET == 'true' }}
-        env:
-          DOCKER_HUB_PAT_SET: ${{ secrets.DOCKER_HUB_PAT != '' }}
-          USERNAME: tsouza
-          PASSWORD: ${{ secrets.DOCKER_HUB_PAT }}
-        run: node .github/scripts/registry-login.mjs
+      - uses: ./.github/actions/registry-login
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          docker-hub-pat: ${{ secrets.DOCKER_HUB_PAT }}
 
       - name: Run floor-pinned compatibility harness
         id: compat
@@ -846,39 +745,10 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
-      # Cerberus's own copy of every upstream image this job pulls lives in a
-      # PRIVATE GHCR namespace, and `pullImageWithRetry` reaches for it before
-      # Docker Hub. That reach works only once this step has written ghcr.io
-      # credentials; without it the pull falls back to the shared anonymous
-      # Docker Hub quota. See .github/scripts/lib/mirror.mjs.
-      #
-      # FIRST, ahead of the Docker Hub login below, because this is the PRIMARY
-      # acquisition path and that one is the fallback. Authenticating the
-      # fallback first is what let a Docker Hub outage kill this job before the
-      # mirror it exists to fall back TO was ever contacted (issue #1933).
-      - name: Log in to the image mirror (GHCR)
-        env:
-          REGISTRY: ghcr.io
-          USERNAME: ${{ github.repository_owner }}
-          PASSWORD: ${{ secrets.GITHUB_TOKEN }}
-        run: node .github/scripts/registry-login.mjs
-
-      # See the prometheus job: authed Docker Hub pulls dodge the anonymous
-      # rate limit shared across runner IPs; skips silently on forks.
-      #
-      # An unreachable Docker Hub no longer takes this job down with it: the
-      # login exhausts its retries on a transport fault and downgrades the job
-      # to MIRROR-ONLY (registry-login.mjs), where every image comes from the
-      # mirror and one the mirror cannot serve fails the job naming itself
-      # rather than being pulled anonymously. A quota refusal or a rejected
-      # credential still fails here on the first attempt.
-      - name: Log in to Docker Hub
-        if: ${{ env.DOCKER_HUB_PAT_SET == 'true' }}
-        env:
-          DOCKER_HUB_PAT_SET: ${{ secrets.DOCKER_HUB_PAT != '' }}
-          USERNAME: tsouza
-          PASSWORD: ${{ secrets.DOCKER_HUB_PAT }}
-        run: node .github/scripts/registry-login.mjs
+      - uses: ./.github/actions/registry-login
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          docker-hub-pat: ${{ secrets.DOCKER_HUB_PAT }}
 
       - name: Run PromQL surface-completeness gate
         id: gate
@@ -902,52 +772,12 @@ jobs:
       # tempo + CH + a freshly-built cerberus — same DiskPressure risk as the
       # prometheus job. Reclaim ~25-30 GB of unused toolchains first; KEEP
       # Docker images. Pinned to a commit SHA (action only ships @main).
-      - name: Disk free (before reclaim)
-        run: df -h
-      - name: Free disk space
-        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # main as of 2026-06-18
+      - uses: ./.github/actions/free-disk-space
+
+      - uses: ./.github/actions/registry-login
         with:
-          docker-images: false
-          large-packages: false
-          tool-cache: false
-      - name: Disk free (after reclaim)
-        run: df -h
-
-      # Cerberus's own copy of every upstream image this job pulls lives in a
-      # PRIVATE GHCR namespace, and `pullImageWithRetry` reaches for it before
-      # Docker Hub. That reach works only once this step has written ghcr.io
-      # credentials; without it the pull falls back to the shared anonymous
-      # Docker Hub quota. See .github/scripts/lib/mirror.mjs.
-      #
-      # FIRST, ahead of the Docker Hub login below, because this is the PRIMARY
-      # acquisition path and that one is the fallback. Authenticating the
-      # fallback first is what let a Docker Hub outage kill this job before the
-      # mirror it exists to fall back TO was ever contacted (issue #1933).
-      - name: Log in to the image mirror (GHCR)
-        env:
-          REGISTRY: ghcr.io
-          USERNAME: ${{ github.repository_owner }}
-          PASSWORD: ${{ secrets.GITHUB_TOKEN }}
-        run: node .github/scripts/registry-login.mjs
-
-      # See the prometheus job: authed Docker Hub pulls dodge the
-      # anonymous rate limit shared across runner IPs; skips silently
-      # on forks without the secrets. Ahead of the builder setup so the
-      # BuildKit bootstrap image is fetched under the same credentials.
-      #
-      # An unreachable Docker Hub no longer takes this job down with it: the
-      # login exhausts its retries on a transport fault and downgrades the job
-      # to MIRROR-ONLY (registry-login.mjs), where every image comes from the
-      # mirror and one the mirror cannot serve fails the job naming itself
-      # rather than being pulled anonymously. A quota refusal or a rejected
-      # credential still fails here on the first attempt.
-      - name: Log in to Docker Hub
-        if: ${{ env.DOCKER_HUB_PAT_SET == 'true' }}
-        env:
-          DOCKER_HUB_PAT_SET: ${{ secrets.DOCKER_HUB_PAT != '' }}
-          USERNAME: tsouza
-          PASSWORD: ${{ secrets.DOCKER_HUB_PAT }}
-        run: node .github/scripts/registry-login.mjs
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          docker-hub-pat: ${{ secrets.DOCKER_HUB_PAT }}
 
       # Buildx gives the Compose build cache, multi-arch support, and a
       # consistent build backend. The harness uses local build contexts
@@ -1079,16 +909,7 @@ jobs:
       # CH + a freshly-built cerberus — same DiskPressure risk as the
       # prometheus job. Reclaim ~25-30 GB of unused toolchains first; KEEP
       # Docker images. Pinned to a commit SHA (action only ships @main).
-      - name: Disk free (before reclaim)
-        run: df -h
-      - name: Free disk space
-        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # main as of 2026-06-18
-        with:
-          docker-images: false
-          large-packages: false
-          tool-cache: false
-      - name: Disk free (after reclaim)
-        run: df -h
+      - uses: ./.github/actions/free-disk-space
 
       # The run script does `go run ./cmd/seed` + `go test -c` of the
       # vendored bench driver, so we need a Go toolchain. setup-go
@@ -1098,41 +919,10 @@ jobs:
           go-version-file: 'go.mod'
           cache: true
 
-      # Cerberus's own copy of every upstream image this job pulls lives in a
-      # PRIVATE GHCR namespace, and `pullImageWithRetry` reaches for it before
-      # Docker Hub. That reach works only once this step has written ghcr.io
-      # credentials; without it the pull falls back to the shared anonymous
-      # Docker Hub quota. See .github/scripts/lib/mirror.mjs.
-      #
-      # FIRST, ahead of the Docker Hub login below, because this is the PRIMARY
-      # acquisition path and that one is the fallback. Authenticating the
-      # fallback first is what let a Docker Hub outage kill this job before the
-      # mirror it exists to fall back TO was ever contacted (issue #1933).
-      - name: Log in to the image mirror (GHCR)
-        env:
-          REGISTRY: ghcr.io
-          USERNAME: ${{ github.repository_owner }}
-          PASSWORD: ${{ secrets.GITHUB_TOKEN }}
-        run: node .github/scripts/registry-login.mjs
-
-      # See the prometheus job: authed Docker Hub pulls dodge the
-      # anonymous rate limit shared across runner IPs; skips silently
-      # on forks without the secrets. Ahead of the builder setup so the
-      # BuildKit bootstrap image is fetched under the same credentials.
-      #
-      # An unreachable Docker Hub no longer takes this job down with it: the
-      # login exhausts its retries on a transport fault and downgrades the job
-      # to MIRROR-ONLY (registry-login.mjs), where every image comes from the
-      # mirror and one the mirror cannot serve fails the job naming itself
-      # rather than being pulled anonymously. A quota refusal or a rejected
-      # credential still fails here on the first attempt.
-      - name: Log in to Docker Hub
-        if: ${{ env.DOCKER_HUB_PAT_SET == 'true' }}
-        env:
-          DOCKER_HUB_PAT_SET: ${{ secrets.DOCKER_HUB_PAT != '' }}
-          USERNAME: tsouza
-          PASSWORD: ${{ secrets.DOCKER_HUB_PAT }}
-        run: node .github/scripts/registry-login.mjs
+      - uses: ./.github/actions/registry-login
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          docker-hub-pat: ${{ secrets.DOCKER_HUB_PAT }}
 
       # Buildx gives the Compose build cache + a consistent backend
       # for the local cerberus image context.

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -301,54 +301,12 @@ jobs:
       # docker-images: false -> KEEP Docker's prebaked images (the stack
       # needs them). Pinned to a commit SHA (the action only ships @main;
       # repo CI rule: pin explicitly, no HEAD).
-      - name: Disk free (before reclaim)
-        run: df -h
-      - name: Free disk space
-        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # main as of 2026-06-18
+      - uses: ./.github/actions/free-disk-space
+
+      - uses: ./.github/actions/registry-login
         with:
-          docker-images: false
-          large-packages: false
-          tool-cache: false
-      - name: Disk free (after reclaim)
-        run: df -h
-
-      # Cerberus's own copy of every upstream image this job pulls lives in a
-      # PRIVATE GHCR namespace, and `pullImageWithRetry` reaches for it before
-      # Docker Hub. That reach works only once this step has written ghcr.io
-      # credentials; without it the pull falls back to the shared anonymous
-      # Docker Hub quota. See .github/scripts/lib/mirror.mjs.
-      #
-      # FIRST, ahead of the Docker Hub login below, because this is the PRIMARY
-      # acquisition path and that one is the fallback. Authenticating the
-      # fallback first is what let a Docker Hub outage kill this job before the
-      # mirror it exists to fall back TO was ever contacted (issue #1933).
-      - name: Log in to the image mirror (GHCR)
-        env:
-          REGISTRY: ghcr.io
-          USERNAME: ${{ github.repository_owner }}
-          PASSWORD: ${{ secrets.GITHUB_TOKEN }}
-        run: node .github/scripts/registry-login.mjs
-
-      # Authenticated Docker Hub pulls get a far higher rate limit than
-      # anonymous pulls from shared runner IPs (same hardening as the
-      # compatibility workflow's compose jobs). Skips silently when the
-      # secrets are absent (forks); GHCR mirroring is the stronger
-      # long-term fix. Ahead of the builder setup so the BuildKit
-      # bootstrap image is fetched under the same credentials.
-      #
-      # An unreachable Docker Hub no longer takes this job down with it: the
-      # login exhausts its retries on a transport fault and downgrades the job
-      # to MIRROR-ONLY (registry-login.mjs), where every image comes from the
-      # mirror and one the mirror cannot serve fails the job naming itself
-      # rather than being pulled anonymously. A quota refusal or a rejected
-      # credential still fails here on the first attempt.
-      - name: Log in to Docker Hub
-        if: ${{ env.DOCKER_HUB_PAT_SET == 'true' }}
-        env:
-          DOCKER_HUB_PAT_SET: ${{ secrets.DOCKER_HUB_PAT != '' }}
-          USERNAME: tsouza
-          PASSWORD: ${{ secrets.DOCKER_HUB_PAT }}
-        run: node .github/scripts/registry-login.mjs
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          docker-hub-pat: ${{ secrets.DOCKER_HUB_PAT }}
 
       - uses: ./.github/actions/setup-buildx
 
@@ -566,50 +524,12 @@ jobs:
       # pre-baked toolchains so the compose stack can't exhaust the runner
       # disk -> DiskPressure/Evicted. KEEP Docker images (docker-images:
       # false). Pinned to a commit SHA (action only ships @main).
-      - name: Disk free (before reclaim)
-        run: df -h
-      - name: Free disk space
-        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # main as of 2026-06-18
+      - uses: ./.github/actions/free-disk-space
+
+      - uses: ./.github/actions/registry-login
         with:
-          docker-images: false
-          large-packages: false
-          tool-cache: false
-      - name: Disk free (after reclaim)
-        run: df -h
-
-      # Cerberus's own copy of every upstream image this job pulls lives in a
-      # PRIVATE GHCR namespace, and `pullImageWithRetry` reaches for it before
-      # Docker Hub. That reach works only once this step has written ghcr.io
-      # credentials; without it the pull falls back to the shared anonymous
-      # Docker Hub quota. See .github/scripts/lib/mirror.mjs.
-      #
-      # FIRST, ahead of the Docker Hub login below, because this is the PRIMARY
-      # acquisition path and that one is the fallback. Authenticating the
-      # fallback first is what let a Docker Hub outage kill this job before the
-      # mirror it exists to fall back TO was ever contacted (issue #1933).
-      - name: Log in to the image mirror (GHCR)
-        env:
-          REGISTRY: ghcr.io
-          USERNAME: ${{ github.repository_owner }}
-          PASSWORD: ${{ secrets.GITHUB_TOKEN }}
-        run: node .github/scripts/registry-login.mjs
-
-      # Ahead of the builder setup so the BuildKit bootstrap image is
-      # fetched under the same credentials.
-      #
-      # An unreachable Docker Hub no longer takes this job down with it: the
-      # login exhausts its retries on a transport fault and downgrades the job
-      # to MIRROR-ONLY (registry-login.mjs), where every image comes from the
-      # mirror and one the mirror cannot serve fails the job naming itself
-      # rather than being pulled anonymously. A quota refusal or a rejected
-      # credential still fails here on the first attempt.
-      - name: Log in to Docker Hub
-        if: ${{ env.DOCKER_HUB_PAT_SET == 'true' }}
-        env:
-          DOCKER_HUB_PAT_SET: ${{ secrets.DOCKER_HUB_PAT != '' }}
-          USERNAME: tsouza
-          PASSWORD: ${{ secrets.DOCKER_HUB_PAT }}
-        run: node .github/scripts/registry-login.mjs
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          docker-hub-pat: ${{ secrets.DOCKER_HUB_PAT }}
 
       - uses: ./.github/actions/setup-buildx
 
@@ -1049,23 +969,11 @@ jobs:
       # filesystem, which kubelet watches for ephemeral-storage. Bone-stock
       # ubuntu-latest leaves too little headroom -> kubelet DiskPressure,
       # pods Evicted ("node was low on resource: ephemeral-storage"), exit
-      # 137, then the port-forward fails. Reclaim ~25-30 GB of unused
-      # toolchains first. KEEP Docker images (the stack needs them). Gated on
-      # RUN_SHARD so the crawl shard's push no-op stays near-instant. Pinned
-      # to a commit SHA (action only ships @main).
-      - name: Disk free (before reclaim)
-        if: env.RUN_SHARD == 'true'
-        run: df -h
+      # 137, then the port-forward fails. Gated on RUN_SHARD so the crawl
+      # shard's push no-op stays near-instant.
       - name: Free disk space
         if: env.RUN_SHARD == 'true'
-        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # main as of 2026-06-18
-        with:
-          docker-images: false
-          large-packages: false
-          tool-cache: false
-      - name: Disk free (after reclaim)
-        if: env.RUN_SHARD == 'true'
-        run: df -h
+        uses: ./.github/actions/free-disk-space
 
       - uses: actions/setup-go@v7
         if: env.RUN_SHARD == 'true'
@@ -1103,36 +1011,13 @@ jobs:
       # credentials; without it the pull falls back to the shared anonymous
       # Docker Hub quota. See .github/scripts/lib/mirror.mjs.
       #
-      # FIRST, ahead of the Docker Hub login below, because this is the PRIMARY
-      # acquisition path and that one is the fallback. Authenticating the
-      # fallback first is what let a Docker Hub outage kill this job before the
-      # mirror it exists to fall back TO was ever contacted (issue #1933).
-      - name: Log in to the image mirror (GHCR)
-        env:
-          REGISTRY: ghcr.io
-          USERNAME: ${{ github.repository_owner }}
-          PASSWORD: ${{ secrets.GITHUB_TOKEN }}
-        run: node .github/scripts/registry-login.mjs
-
-      # `just e2e-up` pulls the k3s node image + every external image on
-      # the HOST docker daemon (then `k3d image import`s them into the
-      # cluster's containerd — see Justfile's e2e-up/_pull-retry), so this
-      # login is what actually raises the pull-rate ceiling for k3d jobs,
-      # exactly like the compose-smoke jobs above.
-      #
-      # An unreachable Docker Hub no longer takes this job down with it: the
-      # login exhausts its retries on a transport fault and downgrades the job
-      # to MIRROR-ONLY (registry-login.mjs), where every image comes from the
-      # mirror and one the mirror cannot serve fails the job naming itself
-      # rather than being pulled anonymously. A quota refusal or a rejected
-      # credential still fails here on the first attempt.
-      - name: Log in to Docker Hub
-        if: ${{ env.RUN_SHARD == 'true' && env.DOCKER_HUB_PAT_SET == 'true' }}
-        env:
-          DOCKER_HUB_PAT_SET: ${{ secrets.DOCKER_HUB_PAT != '' }}
-          USERNAME: tsouza
-          PASSWORD: ${{ secrets.DOCKER_HUB_PAT }}
-        run: node .github/scripts/registry-login.mjs
+      # No RUN_SHARD guard on the GHCR login itself: it always runs (the
+      # `just e2e-up` pull-rate ceiling below is what's gated on RUN_SHARD).
+      - uses: ./.github/actions/registry-login
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          docker-hub-pat: ${{ secrets.DOCKER_HUB_PAT }}
+          run-docker-hub-login: ${{ env.RUN_SHARD }}
 
       - name: Bring up k3d stack
         if: env.RUN_SHARD == 'true'
@@ -1583,42 +1468,10 @@ jobs:
         with:
           tool: just
 
-      # Cerberus's own copy of every upstream image this job pulls lives in a
-      # PRIVATE GHCR namespace, and `pullImageWithRetry` reaches for it before
-      # Docker Hub. That reach works only once this step has written ghcr.io
-      # credentials; without it the pull falls back to the shared anonymous
-      # Docker Hub quota. See .github/scripts/lib/mirror.mjs.
-      #
-      # FIRST, ahead of the Docker Hub login below, because this is the PRIMARY
-      # acquisition path and that one is the fallback. Authenticating the
-      # fallback first is what let a Docker Hub outage kill this job before the
-      # mirror it exists to fall back TO was ever contacted (issue #1933).
-      - name: Log in to the image mirror (GHCR)
-        env:
-          REGISTRY: ghcr.io
-          USERNAME: ${{ github.repository_owner }}
-          PASSWORD: ${{ secrets.GITHUB_TOKEN }}
-        run: node .github/scripts/registry-login.mjs
-
-      # The mirror is reached for FIRST, but a mirror miss falls back to Docker
-      # Hub — and that fallback is the anonymous shared per-runner-IP quota
-      # unless this step has run. Every other image-acquiring job in this
-      # workflow carries both logins; this one carried only the mirror half,
-      # which is invisible for as long as the mirror keeps hitting.
-      #
-      # An unreachable Docker Hub no longer takes this job down with it: the
-      # login exhausts its retries on a transport fault and downgrades the job
-      # to MIRROR-ONLY (registry-login.mjs), where every image comes from the
-      # mirror and one the mirror cannot serve fails the job naming itself
-      # rather than being pulled anonymously. A quota refusal or a rejected
-      # credential still fails here on the first attempt.
-      - name: Log in to Docker Hub
-        if: ${{ env.DOCKER_HUB_PAT_SET == 'true' }}
-        env:
-          DOCKER_HUB_PAT_SET: ${{ secrets.DOCKER_HUB_PAT != '' }}
-          USERNAME: tsouza
-          PASSWORD: ${{ secrets.DOCKER_HUB_PAT }}
-        run: node .github/scripts/registry-login.mjs
+      - uses: ./.github/actions/registry-login
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          docker-hub-pat: ${{ secrets.DOCKER_HUB_PAT }}
 
       # `docker run` pulls a missing image itself, single-attempt: a Docker Hub
       # blip fails the job before ClickHouse is even started. `_pull-retry`
@@ -1705,16 +1558,7 @@ jobs:
       # Evicted pods before the fault scenarios even run. Reclaim ~25-30 GB of
       # unused toolchains first; KEEP Docker images. Pinned to a commit SHA
       # (action only ships @main).
-      - name: Disk free (before reclaim)
-        run: df -h
-      - name: Free disk space
-        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # main as of 2026-06-18
-        with:
-          docker-images: false
-          large-packages: false
-          tool-cache: false
-      - name: Disk free (after reclaim)
-        run: df -h
+      - uses: ./.github/actions/free-disk-space
 
       - uses: actions/setup-go@v7
         with:
@@ -1740,42 +1584,10 @@ jobs:
         run: |
           curl -sSfL https://raw.githubusercontent.com/k3d-io/k3d/main/install.sh | TAG=v5.8.3 bash
 
-      # Cerberus's own copy of every upstream image this job pulls lives in a
-      # PRIVATE GHCR namespace, and `pullImageWithRetry` reaches for it before
-      # Docker Hub. That reach works only once this step has written ghcr.io
-      # credentials; without it the pull falls back to the shared anonymous
-      # Docker Hub quota. See .github/scripts/lib/mirror.mjs.
-      #
-      # FIRST, ahead of the Docker Hub login below, because this is the PRIMARY
-      # acquisition path and that one is the fallback. Authenticating the
-      # fallback first is what let a Docker Hub outage kill this job before the
-      # mirror it exists to fall back TO was ever contacted (issue #1933).
-      - name: Log in to the image mirror (GHCR)
-        env:
-          REGISTRY: ghcr.io
-          USERNAME: ${{ github.repository_owner }}
-          PASSWORD: ${{ secrets.GITHUB_TOKEN }}
-        run: node .github/scripts/registry-login.mjs
-
-      # `just e2e-up` pulls the k3s node image + every external image on
-      # the HOST docker daemon (then `k3d image import`s them into the
-      # cluster's containerd — see Justfile's e2e-up/_pull-retry), so this
-      # login is what actually raises the pull-rate ceiling for k3d jobs,
-      # exactly like the compose-smoke jobs above.
-      #
-      # An unreachable Docker Hub no longer takes this job down with it: the
-      # login exhausts its retries on a transport fault and downgrades the job
-      # to MIRROR-ONLY (registry-login.mjs), where every image comes from the
-      # mirror and one the mirror cannot serve fails the job naming itself
-      # rather than being pulled anonymously. A quota refusal or a rejected
-      # credential still fails here on the first attempt.
-      - name: Log in to Docker Hub
-        if: ${{ env.DOCKER_HUB_PAT_SET == 'true' }}
-        env:
-          DOCKER_HUB_PAT_SET: ${{ secrets.DOCKER_HUB_PAT != '' }}
-          USERNAME: tsouza
-          PASSWORD: ${{ secrets.DOCKER_HUB_PAT }}
-        run: node .github/scripts/registry-login.mjs
+      - uses: ./.github/actions/registry-login
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          docker-hub-pat: ${{ secrets.DOCKER_HUB_PAT }}
 
       # Reuse the e2e k3d bring-up (same first steps as the dashboard job):
       # cluster, cerberus:e2e image, manifests, host port maps
@@ -1911,16 +1723,7 @@ jobs:
       # rationale as dashboard-shard: reclaim ~25-30 GB of unused toolchains so
       # the stack can't trip DiskPressure. KEEP Docker images. Pinned to a commit
       # SHA (action only ships @main).
-      - name: Disk free (before reclaim)
-        run: df -h
-      - name: Free disk space
-        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # main as of 2026-06-18
-        with:
-          docker-images: false
-          large-packages: false
-          tool-cache: false
-      - name: Disk free (after reclaim)
-        run: df -h
+      - uses: ./.github/actions/free-disk-space
 
       - uses: actions/setup-go@v7
         with:
@@ -1948,42 +1751,10 @@ jobs:
         run: |
           curl -sSfL https://raw.githubusercontent.com/k3d-io/k3d/main/install.sh | TAG=v5.8.3 bash
 
-      # Cerberus's own copy of every upstream image this job pulls lives in a
-      # PRIVATE GHCR namespace, and `pullImageWithRetry` reaches for it before
-      # Docker Hub. That reach works only once this step has written ghcr.io
-      # credentials; without it the pull falls back to the shared anonymous
-      # Docker Hub quota. See .github/scripts/lib/mirror.mjs.
-      #
-      # FIRST, ahead of the Docker Hub login below, because this is the PRIMARY
-      # acquisition path and that one is the fallback. Authenticating the
-      # fallback first is what let a Docker Hub outage kill this job before the
-      # mirror it exists to fall back TO was ever contacted (issue #1933).
-      - name: Log in to the image mirror (GHCR)
-        env:
-          REGISTRY: ghcr.io
-          USERNAME: ${{ github.repository_owner }}
-          PASSWORD: ${{ secrets.GITHUB_TOKEN }}
-        run: node .github/scripts/registry-login.mjs
-
-      # `just e2e-bwc-up` pulls the k3s node image + every external/bwc image
-      # on the HOST docker daemon (then `k3d image import`s them into the
-      # cluster's containerd — see Justfile's e2e-bwc-up/_pull-retry), so
-      # this login is what actually raises the pull-rate ceiling here,
-      # exactly like the compose-smoke jobs above.
-      #
-      # An unreachable Docker Hub no longer takes this job down with it: the
-      # login exhausts its retries on a transport fault and downgrades the job
-      # to MIRROR-ONLY (registry-login.mjs), where every image comes from the
-      # mirror and one the mirror cannot serve fails the job naming itself
-      # rather than being pulled anonymously. A quota refusal or a rejected
-      # credential still fails here on the first attempt.
-      - name: Log in to Docker Hub
-        if: ${{ env.DOCKER_HUB_PAT_SET == 'true' }}
-        env:
-          DOCKER_HUB_PAT_SET: ${{ secrets.DOCKER_HUB_PAT != '' }}
-          USERNAME: tsouza
-          PASSWORD: ${{ secrets.DOCKER_HUB_PAT }}
-        run: node .github/scripts/registry-login.mjs
+      - uses: ./.github/actions/registry-login
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          docker-hub-pat: ${{ secrets.DOCKER_HUB_PAT }}
 
       - name: Bring up k3d + MinIO + bundled-ClickHouse stack
         run: just e2e-bwc-up

--- a/.github/workflows/migration-e2e.yml
+++ b/.github/workflows/migration-e2e.yml
@@ -252,16 +252,7 @@ jobs:
       # as a scenario failure. Reclaim the unused pre-baked toolchains; KEEP
       # Docker images, the stack needs them. Same shape as compatibility.yml's
       # reclaim, pinned to a commit SHA (the action only ships @main).
-      - name: Disk free (before reclaim)
-        run: df -h
-      - name: Free disk space
-        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # main as of 2026-06-18
-        with:
-          docker-images: false
-          large-packages: false
-          tool-cache: false
-      - name: Disk free (after reclaim)
-        run: df -h
+      - uses: ./.github/actions/free-disk-space
 
       - uses: actions/setup-go@v7
         with:
@@ -419,16 +410,7 @@ jobs:
 
       # See the identical block in migration-tier1 — this stack is a strict
       # superset of that one, so the disk pressure is strictly worse.
-      - name: Disk free (before reclaim)
-        run: df -h
-      - name: Free disk space
-        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # main as of 2026-06-18
-        with:
-          docker-images: false
-          large-packages: false
-          tool-cache: false
-      - name: Disk free (after reclaim)
-        run: df -h
+      - uses: ./.github/actions/free-disk-space
 
       - uses: actions/setup-go@v7
         with:

--- a/.github/workflows/schema-integration.yml
+++ b/.github/workflows/schema-integration.yml
@@ -114,40 +114,10 @@ jobs:
         with:
           tool: just
 
-      # Cerberus's own copy of every upstream image this job pulls lives in a
-      # PRIVATE GHCR namespace, and `pullImageWithRetry` reaches for it before
-      # Docker Hub. That reach works only once this step has written ghcr.io
-      # credentials; without it the pull falls back to the shared anonymous
-      # Docker Hub quota. See .github/scripts/lib/mirror.mjs.
-      #
-      # FIRST, ahead of the Docker Hub login below, because this is the PRIMARY
-      # acquisition path and that one is the fallback. Authenticating the
-      # fallback first is what let a Docker Hub outage kill this job before the
-      # mirror it exists to fall back TO was ever contacted (issue #1933).
-      - name: Log in to the image mirror (GHCR)
-        env:
-          REGISTRY: ghcr.io
-          USERNAME: ${{ github.repository_owner }}
-          PASSWORD: ${{ secrets.GITHUB_TOKEN }}
-        run: node .github/scripts/registry-login.mjs
-
-      # The mirror above is reached for FIRST, but a mirror miss falls back to
-      # Docker Hub — and that fallback spends the anonymous shared
-      # per-runner-IP quota unless this step has run.
-      #
-      # An unreachable Docker Hub no longer takes this job down with it: the
-      # login exhausts its retries on a transport fault and downgrades the job
-      # to MIRROR-ONLY (registry-login.mjs), where every image comes from the
-      # mirror and one the mirror cannot serve fails the job naming itself
-      # rather than being pulled anonymously. A quota refusal or a rejected
-      # credential still fails here on the first attempt.
-      - name: Log in to Docker Hub
-        if: ${{ env.DOCKER_HUB_PAT_SET == 'true' }}
-        env:
-          DOCKER_HUB_PAT_SET: ${{ secrets.DOCKER_HUB_PAT != '' }}
-          USERNAME: tsouza
-          PASSWORD: ${{ secrets.DOCKER_HUB_PAT }}
-        run: node .github/scripts/registry-login.mjs
+      - uses: ./.github/actions/registry-login
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          docker-hub-pat: ${{ secrets.DOCKER_HUB_PAT }}
 
       - name: Run schema/ddl integration tests (real ClickHouse)
         run: just schema-ddl-test

--- a/.github/workflows/strict-scan.yml
+++ b/.github/workflows/strict-scan.yml
@@ -116,40 +116,10 @@ jobs:
         with:
           tool: just
 
-      # Cerberus's own copy of every upstream image this job pulls lives in a
-      # PRIVATE GHCR namespace, and `pullImageWithRetry` reaches for it before
-      # Docker Hub. That reach works only once this step has written ghcr.io
-      # credentials; without it the pull falls back to the shared anonymous
-      # Docker Hub quota. See .github/scripts/lib/mirror.mjs.
-      #
-      # FIRST, ahead of the Docker Hub login below, because this is the PRIMARY
-      # acquisition path and that one is the fallback. Authenticating the
-      # fallback first is what let a Docker Hub outage kill this job before the
-      # mirror it exists to fall back TO was ever contacted (issue #1933).
-      - name: Log in to the image mirror (GHCR)
-        env:
-          REGISTRY: ghcr.io
-          USERNAME: ${{ github.repository_owner }}
-          PASSWORD: ${{ secrets.GITHUB_TOKEN }}
-        run: node .github/scripts/registry-login.mjs
-
-      # The mirror above is reached for FIRST, but a mirror miss falls back to
-      # Docker Hub — and that fallback spends the anonymous shared
-      # per-runner-IP quota unless this step has run.
-      #
-      # An unreachable Docker Hub no longer takes this job down with it: the
-      # login exhausts its retries on a transport fault and downgrades the job
-      # to MIRROR-ONLY (registry-login.mjs), where every image comes from the
-      # mirror and one the mirror cannot serve fails the job naming itself
-      # rather than being pulled anonymously. A quota refusal or a rejected
-      # credential still fails here on the first attempt.
-      - name: Log in to Docker Hub
-        if: ${{ env.DOCKER_HUB_PAT_SET == 'true' }}
-        env:
-          DOCKER_HUB_PAT_SET: ${{ secrets.DOCKER_HUB_PAT != '' }}
-          USERNAME: tsouza
-          PASSWORD: ${{ secrets.DOCKER_HUB_PAT }}
-        run: node .github/scripts/registry-login.mjs
+      - uses: ./.github/actions/registry-login
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          docker-hub-pat: ${{ secrets.DOCKER_HUB_PAT }}
 
       - name: Run strict-scan differential (real ClickHouse)
         run: just strict-scan-test

--- a/test/regression/mirror_login_test.go
+++ b/test/regression/mirror_login_test.go
@@ -29,6 +29,13 @@ import (
 // and survives the next change of login mechanism.
 var mirrorLoginMarker = regexp.MustCompile(`(?im)^\s*registry:\s*ghcr\.io\s*$`)
 
+// localActionUseRE matches a step delegating to a local composite action:
+// `uses: ./.github/actions/<name>`. The captured group is the action's
+// directory, relative to the repo root, in the same spelling the `uses:`
+// value itself uses — which is what lets it key straight into
+// compositeActionsLoggingIntoMirror below.
+var localActionUseRE = regexp.MustCompile(`(?m)^\s*-?\s*uses:\s*\./(\.github/actions/[A-Za-z0-9_-]+)\s*$`)
+
 // mirrorLoginRemedy is what to add when the gate fires. It names the script
 // rather than an Action because `registry-login.mjs` retries transport faults
 // and refuses to retry a spent quota or a rejected credential.
@@ -129,6 +136,46 @@ func pullingScripts(t *testing.T) map[string]bool {
 	return scripts
 }
 
+// compositeActionsLoggingIntoMirror is the set of local composite-action
+// directories (e.g. ".github/actions/registry-login") whose own action.yml
+// carries the ghcr.io login. #2304 moved the GHCR + Docker Hub login pair out
+// of 14 duplicated inline call sites into .github/actions/registry-login, so a
+// job can now satisfy the mirror-login requirement by delegating to a
+// composite action instead of carrying `REGISTRY: ghcr.io` inline — the login
+// still runs in that job, just not in that job's own YAML text.
+func compositeActionsLoggingIntoMirror(t *testing.T) map[string]bool {
+	t.Helper()
+
+	logging := map[string]bool{}
+	for _, file := range buildScanFiles(t) {
+		base := filepath.Base(file)
+		if base != "action.yml" && base != "action.yaml" {
+			continue
+		}
+		src, err := os.ReadFile(file)
+		if err != nil {
+			t.Fatalf("read %s: %v", file, err)
+		}
+		if mirrorLoginMarker.MatchString(string(src)) {
+			dir := strings.TrimPrefix(filepath.ToSlash(filepath.Dir(file)), "../../")
+			logging[dir] = true
+		}
+	}
+	return logging
+}
+
+// jobDelegatesMirrorLogin reports whether body's job reaches the mirror login
+// through a `uses: ./.github/actions/<name>` step rather than carrying it
+// inline.
+func jobDelegatesMirrorLogin(body string, mirrorActions map[string]bool) bool {
+	for _, m := range localActionUseRE.FindAllStringSubmatch(body, -1) {
+		if mirrorActions[m[1]] {
+			return true
+		}
+	}
+	return false
+}
+
 // TestEveryImageConsumingJobLogsIntoTheMirror pins that a workflow job which
 // acquires an upstream image first authenticates to the registry the mirrored
 // copy lives in. Without the login the job still works — it just works the old
@@ -139,6 +186,7 @@ func TestEveryImageConsumingJobLogsIntoTheMirror(t *testing.T) {
 
 	pulls := pullingRecipes(t)
 	scripts := pullingScripts(t)
+	mirrorActions := compositeActionsLoggingIntoMirror(t)
 
 	consuming := 0
 	for _, file := range buildScanFiles(t) {
@@ -156,7 +204,7 @@ func TestEveryImageConsumingJobLogsIntoTheMirror(t *testing.T) {
 				continue
 			}
 			consuming++
-			if !mirrorLoginMarker.MatchString(body) {
+			if !mirrorLoginMarker.MatchString(body) && !jobDelegatesMirrorLogin(body, mirrorActions) {
 				t.Errorf("%s job %q acquires images (%s) but never logs into ghcr.io, so every pull it makes "+
 					"misses the mirror and falls back to Docker Hub's shared anonymous quota. Add a %s "+
 					"and give the job `packages: read`.",


### PR DESCRIPTION
## What

Two step blocks were duplicated verbatim across five workflow files instead of being extracted into composite actions, unlike the established `.github/actions/setup-lychee` / `.github/actions/setup-buildx` convention:

1. **Registry-login pair** — the "Log in to the image mirror (GHCR)" + "Log in to Docker Hub" steps, duplicated 14 times across `e2e.yml`, `compatibility.yml`, `schema-integration.yml`, `strict-scan.yml`.
2. **Disk-free 3-step block** — a "Free disk space" step plus its two `df -h` companion steps, duplicated 12 times across `e2e.yml`, `compatibility.yml`, `migration-e2e.yml`.

## Fix

- Added `.github/actions/registry-login/action.yml` (composite), wrapping the GHCR + Docker Hub login pair. Since a composite action has no implicit access to the caller's `secrets` context, credentials travel in as `github-token` / `docker-hub-pat` inputs. The `if: ${{ env.DOCKER_HUB_PAT_SET == 'true' }}` conditional is reproduced inside the composite from the `docker-hub-pat` input. Replaced all 14 call sites.
- Added `.github/actions/free-disk-space/action.yml` (composite), wrapping the 3-step disk-free block. Replaced all 12 call sites.
- One call site (e2e.yml's sharded k3d job) was non-uniform: the GHCR login there runs unconditionally while only the Docker Hub login and the whole disk-free block are gated on `RUN_SHARD`. That's preserved via a `run-docker-hub-login` input on the registry-login call and a step-level `if:` on the free-disk-space call, so behavior is unchanged.
- Stripped the boilerplate rationale comment that had been copy-pasted ahead of 12 of the 14 registry-login call sites (issue #1933 ordering, MIRROR-ONLY fallback behavior) since that reasoning now lives once in the composite action's own header comment. Left the free-disk-space call sites' leading comments alone — those vary genuinely by call site (which compose stack, what's consuming the disk) rather than being copy-pasted boilerplate.

## Verification

- `just lint-actions` (actionlint) passes locally.
- `python3 -c 'yaml.safe_load(...)'` over every touched workflow file and both new action files confirms valid YAML.
- Grepped `.github/workflows/*.yml` for the old inline step names (`Log in to the image mirror`, `Log in to Docker Hub`) and the raw `jlumbroso/free-disk-space` action reference: zero remaining occurrences outside the two new composite action files, plus the (deliberately untouched, differently-named) `Log in to GHCR` sites in `migration-e2e.yml`/`mirror-images.yml`/`release.yml` that the issue did not include in its 14-site count.
- Spot-checked the rendered YAML at one call site per touched file (`schema-integration.yml`, `strict-scan.yml`, `compatibility.yml`, `migration-e2e.yml`) — indentation and step order match what the original inline steps produced.
- Did not re-run the full e2e/compatibility CI lanes locally (they need k3d/Docker); that's covered by this PR's own CI run.

Closes #2304
