### PR TITLE
fix(api/tempo): add the reqctx.ApplyQueryTimeout backstop to every query entrypoint

### DIFF
--- a/.go-arch-lint.yml
+++ b/.go-arch-lint.yml
@@ -438,6 +438,7 @@ deps:
       - optimizer
       - traceql
       - traceql-ast
+      - api-reqctx
   api-tempo-grpc:
     mayDependOn:
       - api-tempo

--- a/cmd/cerberus/main.go
+++ b/cmd/cerberus/main.go
@@ -191,6 +191,12 @@ func mountAPIHeads(
 		tempoHandler := tempo.New(tempoClient, cfg.Traces, Version, logger.With("api", "tempo"))
 		tempoHandler.Limiter = limiters.tempo
 		tempoHandler.StructuralTwoPhase = cfg.TempoStructuralTwoPhase
+		// Same knob + wiring shape as the prom and loki heads (see
+		// newPromHandler / newLokiHandler above): the Go-side context-deadline
+		// backstop that unblocks a hung handler and releases its admit slot +
+		// pooled connection even if the server-side ClickHouse cap doesn't
+		// fire. See issue #2302.
+		tempoHandler.QueryTimeout = cfg.ClickHouse.QueryTimeout
 		tempoHandler.Engine.Settings = settingsRules(cfg, optSet)
 		// The per-query sample budget the ENGINE-level bounds read. The cursor
 		// enforces the same ceiling on rows it drains from ClickHouse, but the

--- a/internal/api/reqctx/reqctx.go
+++ b/internal/api/reqctx/reqctx.go
@@ -1,12 +1,18 @@
-// Package reqctx hosts the request-context derivation shared by the
-// prom and loki HTTP handlers. Envelope shaping and error writing stay
-// per-handler (each upstream API has its own wire format); what this
-// package owns is the neutral plumbing those handlers run identically —
-// today, the `?timeout=` budget resolution + context wiring.
+// Package reqctx hosts the request-context derivation shared across all
+// three heads' HTTP handlers — prom, loki, and tempo. Envelope shaping and
+// error writing stay per-handler (each upstream API has its own wire
+// format); what this package owns is the neutral plumbing those handlers
+// run identically — today, the `?timeout=` budget resolution + context
+// wiring.
 //
-// Tempo does not call ApplyQueryTimeout: its handlers rely solely on the
-// chclient's static configured QueryTimeout, with no per-request context
-// deadline backstop. See https://github.com/tsouza/cerberus/issues/2302.
+// Tempo's own wire format has no `?timeout=` convention of its own (unlike
+// Prometheus's `?timeout=<duration>`), so its entrypoints call
+// ApplyQueryTimeout purely for the static configured default: the Go-side
+// watchdog that unblocks a hung handler and releases its admit slot +
+// pooled connection even if the server-side ClickHouse cap doesn't fire.
+// The `?timeout=` resolution below still applies if a caller sends one to
+// a Tempo route — nothing Tempo-specific rejects it — but no Tempo client
+// does today, so in practice only the default ever caps a Tempo request.
 package reqctx
 
 import (

--- a/internal/api/tempo/handler.go
+++ b/internal/api/tempo/handler.go
@@ -24,6 +24,7 @@ import (
 	"github.com/tsouza/cerberus/internal/api/admit"
 	"github.com/tsouza/cerberus/internal/api/format"
 	"github.com/tsouza/cerberus/internal/api/httperr"
+	"github.com/tsouza/cerberus/internal/api/reqctx"
 	"github.com/tsouza/cerberus/internal/cerbtrace"
 	"github.com/tsouza/cerberus/internal/chclient"
 	"github.com/tsouza/cerberus/internal/chplan"
@@ -152,6 +153,17 @@ type Handler struct {
 	// false every search takes the traditional single wide query. New() defaults
 	// it true; cmd/ overrides from config.
 	StructuralTwoPhase bool
+
+	// QueryTimeout is the default per-request wall-clock budget every query
+	// entrypoint installs via applyQueryTimeout, wired from
+	// Config.ClickHouse.QueryTimeout — the same knob prom and loki draw
+	// theirs from. It is the Go-side watchdog that unblocks a hung handler
+	// and releases its admit slot + pooled connection even if the
+	// server-side ClickHouse cap somehow doesn't fire. Zero disables the
+	// backstop entirely (the pre-#2302 behaviour). Tempo's wire format has
+	// no `?timeout=` convention of its own, so in practice this static
+	// default is the only source of the budget — see applyQueryTimeout.
+	QueryTimeout time.Duration
 }
 
 // New constructs a Handler with the seed optimizer wired in.
@@ -388,6 +400,30 @@ func (h *Handler) withSpanDrainBudget(ctx context.Context) context.Context {
 	return chclient.WithDrainByteBudget(ctx, chclient.NewTempoSpanDrainBudget())
 }
 
+// applyQueryTimeout derives the request context every Tempo query
+// entrypoint runs under, via the shared [reqctx.ApplyQueryTimeout] — the
+// same helper prom and loki call. Tempo's wire format has no `?timeout=`
+// convention of its own (unlike Prometheus's `?timeout=<duration>`), so in
+// practice this installs only the configured QueryTimeout default as a
+// context deadline; a `?timeout=` sent anyway is still honoured by the
+// shared resolution logic, harmlessly, since no Tempo client sends one
+// today. Either way this closes the reliability gap #2302 described: a
+// hung handler now unblocks and releases its admit slot + pooled
+// connection even if the server-side ClickHouse cap doesn't fire.
+//
+// The caller MUST defer the returned cancel (a no-op when no deadline was
+// installed). A malformed `?timeout=` is a 400 via Tempo's own error
+// envelope; ok=false signals the caller already wrote the error and must
+// return.
+func (h *Handler) applyQueryTimeout(w http.ResponseWriter, r *http.Request) (context.Context, context.CancelFunc, bool) {
+	ctx, cancel, err := reqctx.ApplyQueryTimeout(r, h.QueryTimeout)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, "", "", err)
+		return r.Context(), func() {}, false
+	}
+	return ctx, cancel, true
+}
+
 func (h *Handler) handleSearch(w http.ResponseWriter, r *http.Request) {
 	q := r.URL.Query().Get("q")
 	if q == "" {
@@ -426,7 +462,11 @@ func (h *Handler) handleSearch(w http.ResponseWriter, r *http.Request) {
 		start = end.Add(-DefaultSearchLookback)
 	}
 
-	ctx := r.Context()
+	ctx, cancel, ok := h.applyQueryTimeout(w, r)
+	if !ok {
+		return
+	}
+	defer cancel()
 	// Thread the response trace limit into lowering so the nested-set
 	// numbering walk only numbers the traces this response will keep —
 	// without it the structure-tab `select(nestedSet*)` query numbers
@@ -582,7 +622,12 @@ func (h *Handler) handleSearchRecent(w http.ResponseWriter, r *http.Request) {
 	}
 	plan = &chplan.Limit{Input: plan, Count: limit}
 
-	ctx := h.withSpanDrainBudget(r.Context())
+	ctx, cancel, ok := h.applyQueryTimeout(w, r)
+	if !ok {
+		return
+	}
+	defer cancel()
+	ctx = h.withSpanDrainBudget(ctx)
 	// /search/recent doesn't go through a parser, so use QueryPlan
 	// directly. IsTraceByID stays false: the OrderBy+Limit shape
 	// benefits from the seed optimizer's projection-pushdown pass.
@@ -681,7 +726,12 @@ func (h *Handler) serveTraceByID(w http.ResponseWriter, r *http.Request, v2 bool
 	// canonical before emit.
 	// Trace-by-id folds the FULL per-span SpanAttributes map into the projection
 	// (the fattest wide drain), so it must carry the byte budget too.
-	ctx := h.withSpanDrainBudget(r.Context())
+	ctx, cancel, ok := h.applyQueryTimeout(w, r)
+	if !ok {
+		return
+	}
+	defer cancel()
+	ctx = h.withSpanDrainBudget(ctx)
 	res, err := h.Engine.QueryPlan(ctx, h.lang, plan, engine.Meta{
 		IsTraceByID:   true,
 		ResponseShape: "tempo-trace",

--- a/internal/api/tempo/handler_query_timeout_test.go
+++ b/internal/api/tempo/handler_query_timeout_test.go
@@ -1,0 +1,254 @@
+package tempo_test
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/tsouza/cerberus/internal/api/tempo"
+	"github.com/tsouza/cerberus/internal/chclient"
+	"github.com/tsouza/cerberus/internal/schema"
+)
+
+// configuredQueryTimeout is the Handler.QueryTimeout every test in this
+// file installs — small enough that the deadline fires well inside a test
+// timeout, but large enough that ordinary scheduling jitter cannot make an
+// UNCAPPED request look capped by accident.
+const configuredQueryTimeout = 50 * time.Millisecond
+
+// hangSafetyNet is how long hangingQuerier waits for ctx cancellation
+// before giving up and returning its own error. It exists purely so a
+// wiring regression (the deadline never gets installed) fails the test
+// promptly instead of hanging the suite — a real deployment has no such
+// ceiling.
+const hangSafetyNet = 5 * time.Second
+
+// unblockBound is the ceiling TestHungQuery_UnblocksAtConfiguredTimeout
+// allows between issuing the request and getting a response. It sits well
+// above configuredQueryTimeout (scheduling slack) and well below
+// hangSafetyNet, so passing this bound is only possible if the context
+// deadline — not the safety net — is what unblocked the handler.
+const unblockBound = 2 * time.Second
+
+// hangingQuerier never returns on its own: every Query / QueryStrings call
+// blocks until its context is cancelled (the property issue #2302 is
+// about — a genuinely hung ClickHouse round-trip must still release the
+// handler) or hangSafetyNet elapses, whichever comes first.
+type hangingQuerier struct{}
+
+func (hangingQuerier) Query(ctx context.Context, _ string, _ ...any) ([]chclient.Sample, error) {
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	case <-time.After(hangSafetyNet):
+		return nil, errors.New("hangingQuerier: safety net elapsed without ctx cancellation")
+	}
+}
+
+func (hangingQuerier) QueryStrings(ctx context.Context, _ string, _ ...any) ([]string, error) {
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	case <-time.After(hangSafetyNet):
+		return nil, errors.New("hangingQuerier: safety net elapsed without ctx cancellation")
+	}
+}
+
+// newTimeoutServer stands up a Tempo handler with QueryTimeout wired to
+// configuredQueryTimeout, mirroring newServerWithTimeout in the prom head's
+// handler_query_timeout_test.go.
+func newTimeoutServer(q tempo.Querier) *testServer {
+	h := tempo.New(q, schema.DefaultOTelTraces(), "v1.0.0-test", nil)
+	h.QueryTimeout = configuredQueryTimeout
+	mux := http.NewServeMux()
+	h.Mount(mux)
+	return &testServer{Server: httptest.NewServer(mux)}
+}
+
+// tempoTimeoutEntrypoint names one query-handling Tempo route this file
+// exercises and the URL that reaches it. It exists so both
+// TestHungQuery_UnblocksAtConfiguredTimeout and
+// TestEveryQueryEntrypoint_InstallsConfiguredDeadline run the identical
+// route list — the reliability property and the coverage-completeness
+// property are pinned against the same set of entrypoints, not two
+// independently-typed lists that can silently drift apart.
+type tempoTimeoutEntrypoint struct {
+	name string
+	url  func(base string) string
+}
+
+// tempoTimeoutEntrypoints is every Tempo HTTP route that reaches
+// ClickHouse — search, search/recent, trace-by-id (v1 + v2), the V1 + V2
+// tag-discovery routes, and both metrics routes. handleEcho /
+// handleVersion / handleStatusBuildinfo are deliberately excluded: they
+// never touch h.Client or h.Engine, so there is nothing for a query
+// timeout to bound.
+func tempoTimeoutEntrypoints() []tempoTimeoutEntrypoint {
+	metricsParams := func(extra map[string]string) string {
+		vals := url.Values{}
+		vals.Set("q", "{} | rate()")
+		vals.Set("start", fixtureStartUnix)
+		vals.Set("end", fixtureEndUnix)
+		for k, v := range extra {
+			vals.Set(k, v)
+		}
+		return vals.Encode()
+	}
+	return []tempoTimeoutEntrypoint{
+		{"search", func(base string) string { return base + "/api/search?q=%7B%7D" }},
+		{"search/recent", func(base string) string { return base + "/api/search/recent" }},
+		{"traces/{id}", func(base string) string { return base + "/api/traces/0123456789abcdef" }},
+		{"v2/traces/{id}", func(base string) string { return base + "/api/v2/traces/0123456789abcdef" }},
+		{"search/tags", func(base string) string { return base + "/api/search/tags" }},
+		{"v2/search/tags", func(base string) string { return base + "/api/v2/search/tags" }},
+		{"search/tag/{name}/values", func(base string) string { return base + "/api/search/tag/name/values" }},
+		{"v2/search/tag/{name}/values", func(base string) string { return base + "/api/v2/search/tag/name/values" }},
+		{"metrics/query_range", func(base string) string {
+			return base + "/api/metrics/query_range?" + metricsParams(map[string]string{"step": "60s"})
+		}},
+		{"metrics/query", func(base string) string { return base + "/api/metrics/query?" + metricsParams(nil) }},
+	}
+}
+
+// TestHungQuery_UnblocksAtConfiguredTimeout is the core reliability
+// property issue #2302 is about: with every Tempo entrypoint wired to
+// h.QueryTimeout, a ClickHouse round-trip that never returns on its own
+// still unblocks the HTTP handler at roughly the configured budget — not
+// at hangSafetyNet, and not never. Before this fix Tempo had no
+// context.WithTimeout anywhere, so hangingQuerier would have hung every
+// one of these requests for the full hangSafetyNet.
+func TestHungQuery_UnblocksAtConfiguredTimeout(t *testing.T) {
+	t.Parallel()
+
+	srv := newTimeoutServer(hangingQuerier{})
+	t.Cleanup(srv.Close)
+
+	for _, ep := range tempoTimeoutEntrypoints() {
+		t.Run(ep.name, func(t *testing.T) {
+			t.Parallel()
+
+			before := time.Now()
+			resp, err := http.Get(ep.url(srv.URL))
+			if err != nil {
+				t.Fatalf("GET: %v", err)
+			}
+			elapsed := time.Since(before)
+			body := readBody(t, resp)
+
+			// The context-deadline backstop fires as context.DeadlineExceeded,
+			// which errclass.go's ClassifyErr maps to ErrClassUnavailable (503)
+			// on the engine-routed routes and — via tagsErrStatus's identical
+			// sentinel handling — the same 503 on the metadata routes that call
+			// h.Client directly. A 503 here is itself part of the proof: it can
+			// only be the deadline firing, not some unrelated success path.
+			if resp.StatusCode != http.StatusServiceUnavailable {
+				t.Fatalf("status: got %d, want %d (context deadline exceeded); body=%s",
+					resp.StatusCode, http.StatusServiceUnavailable, body)
+			}
+			if elapsed > unblockBound {
+				t.Fatalf("handler took %s to respond; want well under %s — "+
+					"the %s safety net firing (not the %s configured timeout) means "+
+					"the context deadline was never installed on this entrypoint's ctx",
+					elapsed, unblockBound, hangSafetyNet, configuredQueryTimeout)
+			}
+		})
+	}
+}
+
+// deadlineCapturingQuerier records whether the context it was called with
+// carried a deadline, and if so, the absolute deadline time — so a test
+// can assert the handler installed exactly the configured default (no
+// ?timeout= is sent in this file, matching the decision that Tempo has no
+// `?timeout=` convention of its own; see applyQueryTimeout's doc-comment).
+//
+// The deadline is recorded as an absolute time.Time rather than a
+// time.Until(dl) delta computed here: under a full, heavily parallel test
+// run this method can itself be scheduled well after the context was
+// created (handler parsing/lowering plus Go scheduler contention from
+// every other concurrent subtest), which would make a delta captured at
+// call time read anywhere from "smaller than expected" to outright
+// negative even though the deadline the handler installed was exactly on
+// budget. Recording the absolute deadline and letting the caller diff it
+// against ITS OWN pre-request timestamp isolates the assertion from that
+// scheduling jitter.
+type deadlineCapturingQuerier struct {
+	mu          sync.Mutex
+	sawDeadline bool
+	deadline    time.Time
+}
+
+func (q *deadlineCapturingQuerier) note(ctx context.Context) {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+	dl, ok := ctx.Deadline()
+	q.sawDeadline = ok
+	if ok {
+		q.deadline = dl
+	}
+}
+
+func (q *deadlineCapturingQuerier) Query(ctx context.Context, _ string, _ ...any) ([]chclient.Sample, error) {
+	q.note(ctx)
+	return nil, nil
+}
+
+func (q *deadlineCapturingQuerier) QueryStrings(ctx context.Context, _ string, _ ...any) ([]string, error) {
+	q.note(ctx)
+	return nil, nil
+}
+
+// TestEveryQueryEntrypoint_InstallsConfiguredDeadline is the wiring-
+// completeness half of the #2302 fix: every route in
+// tempoTimeoutEntrypoints must derive its query context from
+// applyQueryTimeout, not from the bare r.Context(). A route that still
+// used r.Context() would pass with no deadline at all — sawDeadline would
+// be false — so this fails loudly for exactly the entrypoints the scope
+// list in #2302 named (metrics_query_range.go, metrics_query_instant.go,
+// search_tags.go, search_tag_values.go, and handler.go's /api/search,
+// /api/search/recent and /api/traces/{id} paths).
+func TestEveryQueryEntrypoint_InstallsConfiguredDeadline(t *testing.T) {
+	t.Parallel()
+
+	for _, ep := range tempoTimeoutEntrypoints() {
+		t.Run(ep.name, func(t *testing.T) {
+			t.Parallel()
+
+			q := &deadlineCapturingQuerier{}
+			srv := newTimeoutServer(q)
+			t.Cleanup(srv.Close)
+
+			before := time.Now()
+			resp, err := http.Get(ep.url(srv.URL))
+			if err != nil {
+				t.Fatalf("GET: %v", err)
+			}
+			body := readBody(t, resp)
+
+			q.mu.Lock()
+			sawDeadline, deadline := q.sawDeadline, q.deadline
+			q.mu.Unlock()
+
+			if !sawDeadline {
+				t.Fatalf("query ctx carried no deadline; want one from the configured "+
+					"QueryTimeout default (status=%d body=%s)", resp.StatusCode, body)
+			}
+			// The deadline must sit close to configuredQueryTimeout out from
+			// request start — comfortably inside unblockBound's slack, well
+			// below hangSafetyNet — proving it is the configured default and
+			// not some unrelated (e.g. accidentally huge) value. Diffed against
+			// this goroutine's own `before` (not a delta captured inside the
+			// querier) so scheduling delay between request start and the
+			// querier actually running cannot manufacture a false negative.
+			delta := deadline.Sub(before)
+			if delta <= 0 || delta > unblockBound {
+				t.Fatalf("deadline %s out from request start; want roughly %s (the configured default)",
+					delta, configuredQueryTimeout)
+			}
+		})
+	}
+}

--- a/internal/api/tempo/metrics_query_instant.go
+++ b/internal/api/tempo/metrics_query_instant.go
@@ -83,7 +83,11 @@ func (h *Handler) handleMetricsQueryInstant(w http.ResponseWriter, r *http.Reque
 		return
 	}
 
-	ctx := r.Context()
+	ctx, cancel, ok := h.applyQueryTimeout(w, r)
+	if !ok {
+		return
+	}
+	defer cancel()
 	// Parse + lower inline (same pattern as handleMetricsQueryRange) so
 	// we can wrap the lowered plan with the matrix-shape RangeWindow
 	// before engine.QueryPlan runs.

--- a/internal/api/tempo/metrics_query_range.go
+++ b/internal/api/tempo/metrics_query_range.go
@@ -276,7 +276,11 @@ func (h *Handler) handleMetricsQueryRange(w http.ResponseWriter, r *http.Request
 		return
 	}
 
-	ctx := r.Context()
+	ctx, cancel, ok := h.applyQueryTimeout(w, r)
+	if !ok {
+		return
+	}
+	defer cancel()
 	// Parse + lower inline so we can wrap the lowered plan with the
 	// matrix-shape RangeWindow before engine.QueryPlan runs.
 	parseT := telemetry.ObserveStage(telemetry.StageParse, telemetry.QLTraceQL)

--- a/internal/api/tempo/search_tag_values.go
+++ b/internal/api/tempo/search_tag_values.go
@@ -123,12 +123,18 @@ func (h *Handler) respondTagValues(w http.ResponseWriter, r *http.Request, route
 	// fact table (same map-explosion failure as /search/tags).
 	start, end = BoundDiscoveryWindow(start, end)
 
+	ctx, cancel, ok := h.applyQueryTimeout(w, r)
+	if !ok {
+		return
+	}
+	defer cancel()
+
 	// The optional `?q=` narrowing filter — the same one the tag-NAME
 	// routes take, resolved through the same tagQueryFilter so a `q`
 	// selects the same spans wherever it is sent. It is read after the
 	// window so a request that gets both wrong reports the window first,
 	// matching upstream's parameter order.
-	filter, err := h.tagQueryFilter(r.Context(), route, r.URL.Query().Get("q"), start, end)
+	filter, err := h.tagQueryFilter(ctx, route, r.URL.Query().Get("q"), start, end)
 	if err != nil {
 		writeError(w, tagsErrStatus(err), "", "", err)
 		return
@@ -155,7 +161,7 @@ func (h *Handler) respondTagValues(w http.ResponseWriter, r *http.Request, route
 		"sql", sqlStr,
 		"args", telemetry.SanitizeArgsForLog(args))
 
-	values, err := h.Client.QueryStrings(r.Context(), sqlStr, args...)
+	values, err := h.Client.QueryStrings(ctx, sqlStr, args...)
 	if err != nil {
 		h.Logger.Error("cerberus tempo /search/tag/values CH query failed", "err", err, "tag", name)
 		writeError(w, tagsErrStatus(err), "", "", err)

--- a/internal/api/tempo/search_tags.go
+++ b/internal/api/tempo/search_tags.go
@@ -178,17 +178,23 @@ func (h *Handler) respondTags(w http.ResponseWriter, r *http.Request, route Tags
 		return
 	}
 
+	ctx, cancel, ok := h.applyQueryTimeout(w, r)
+	if !ok {
+		return
+	}
+	defer cancel()
+
 	// The optional `?q=` narrowing filter, which only the V2 route takes —
 	// tagQueryFilter discards it on V1. It is read after `scope` so a
 	// request that gets both wrong still reports the scope first, matching
 	// upstream's parameter order.
-	filter, err := h.tagQueryFilter(r.Context(), route, r.URL.Query().Get("q"), start, end)
+	filter, err := h.tagQueryFilter(ctx, route, r.URL.Query().Get("q"), start, end)
 	if err != nil {
 		writeError(w, tagsErrStatus(err), "", "", err)
 		return
 	}
 
-	scopes, err := h.collectAttributeTagScopes(r.Context(), scope, filter, start, end)
+	scopes, err := h.collectAttributeTagScopes(ctx, scope, filter, start, end)
 	if err != nil {
 		writeError(w, tagsErrStatus(err), "", "", err)
 		return


### PR DESCRIPTION
## Summary

Tempo never called `reqctx.ApplyQueryTimeout`, the shared per-request timeout
backstop prom and loki both use. A hung Tempo query handler had no Go-side
watchdog to unblock it and release its admit slot + pooled connection if the
server-side ClickHouse cap didn't fire — Tempo relied solely on chclient's
static configured `QueryTimeout`.

- Added a `QueryTimeout time.Duration` field to `tempo.Handler`, wired from
  `Config.ClickHouse.QueryTimeout` in `cmd/cerberus/main.go` — the same knob
  and wiring shape `newPromHandler` / `newLokiHandler` already use.
- Added `Handler.applyQueryTimeout`, mirroring prom's and loki's identically
  named method, and called it from every Tempo query-issuing entrypoint:
  `/api/search`, `/api/search/recent`, `/api/traces/{id}` (v1 + v2, both
  routed through `serveTraceByID`), `/api/search/tags` (v1 + v2) and
  `/api/search/tag/{name}/values` (v1 + v2, both routed through
  `respondTags` / `respondTagValues`), and both metrics routes
  (`/api/metrics/query_range`, `/api/metrics/query`). `/api/echo`,
  `/api/status/version`, and `/api/status/buildinfo` are untouched — they
  never reach ClickHouse.
- Corrected `internal/api/reqctx/reqctx.go`'s package doc, which previously
  (and correctly, as of #2303) stated Tempo did not participate — it now
  describes Tempo's participation and why the static default is, in
  practice, the only source of the budget for Tempo requests.

### `?timeout=` decision

Tempo's own wire format has no `?timeout=` convention (unlike Prometheus's
`?timeout=<duration>`), so no Tempo-specific override parsing was added.
`applyQueryTimeout` calls the same shared `reqctx.ApplyQueryTimeout` prom and
loki call, mirroring their call-site shape exactly — this installs the
static `QueryTimeout` default as a context deadline. Because the helper is
generic, it would still honour a `?timeout=` if a caller ever sent one to a
Tempo route, but that isn't part of Tempo's documented contract and no
client sends one today. This matches the issue's own acceptable-scope
guidance: the core reliability gap — no Go-side watchdog at all — is what
matters, not inventing a per-request override Tempo's API has no place for.

## Test plan

- [x] `internal/api/tempo/handler_query_timeout_test.go` (new):
  - `TestHungQuery_UnblocksAtConfiguredTimeout` — a `hangingQuerier` that
    never returns on its own proves each of the 10 query entrypoints above
    unblocks well inside a 2s bound at a 50ms configured timeout, not at
    the test's 5s hang-safety-net. This is the direct proof a hung query is
    now unblocked.
  - `TestEveryQueryEntrypoint_InstallsConfiguredDeadline` — a
    deadline-capturing stub proves each entrypoint's query context carries
    a deadline landing at the configured default, anchored to the request's
    own start time so scheduling jitter under a parallel run can't produce
    a false pass/fail.
- [x] `go test -race ./internal/api/tempo/... ./internal/api/reqctx/...` —
  green, including 5x repeats of the new tests for flake-checking.
- [x] `go build ./...` — Tempo package + `cmd/cerberus` wiring compile.
- [x] `node .github/scripts/forbid-sql-raw.mjs` — clean (no raw SQL touched).
- [x] `gofumpt -l -extra` / `goimports -l -local` — clean on every changed
      file.

Closes #2302
