### PR TITLE
docs(promql): repoint #2296's histogram-forwarder citations to closed state

### DIFF
--- a/internal/chplan/row_shape.go
+++ b/internal/chplan/row_shape.go
@@ -97,11 +97,19 @@ const (
 	// Three lowerings build this node today (internal/promql's
 	// histogram_native_bare.go, histogram_native_sum.go and
 	// histogram_native_range_fn.go). Generic forwarders still cannot
-	// consume it. Histogram-aware label transforms and scalar arithmetic
-	// intercept it before those forwarders, while float-only functions drop
-	// every histogram sample and re-project an empty canonical float shape.
-	// Every other wrapping shape remains behind expHistogramSelectorRouting
-	// until it grows its own histogram-aware lowering (issue #2296).
+	// consume it directly, and issue #2296 asked whether every wrapping
+	// shape PromQL can put around a histogram-valued result reaches one of
+	// them anyway. It does not: histogram-aware label transforms
+	// (label_replace / label_join) and scalar/histogram or
+	// histogram/histogram arithmetic recognise their operand directly,
+	// composing `sum`/`avg` over an ALREADY histogram-valued result (for
+	// example `sum(rate(m_exp_hist[5m]))`) is recognised recursively by
+	// internal/promql's mergeableExpHistogramAggregate before it would ever
+	// reach a forwarder, and float-only functions drop every histogram
+	// sample and re-project an empty canonical float shape (#2245 closed
+	// #2296 on that basis). Every remaining wrapping shape stays behind
+	// expHistogramSelectorRouting until it grows its own histogram-aware
+	// lowering or an extension to that recognizer set.
 	HistogramRowShape
 )
 

--- a/internal/promql/histogram_native_sum.go
+++ b/internal/promql/histogram_native_sum.go
@@ -92,9 +92,16 @@ const (
 // ordinary descent and is still rejected there.
 //
 // The inner expression must unwrap to a bare selector. `sum(rate(
-// m_exp_hist[5m]))` does not: its aggregand is a range-vector function
-// with its own histogram-valued lowering to grow (issue #2296), and
-// admitting it here would silently drop the rate.
+// m_exp_hist[5m]))` does not: its aggregand is a range-vector function, and
+// admitting it here would silently drop the rate. That composed shape is
+// answered by a different recognizer, not this one — mergeableExpHistogramAggregate
+// (also in this file) matches a `sum`/`avg` wrapping ANY already
+// histogram-valued shape, [lowerExpHistogramValuedShape] recurses into the
+// aggregand to lower the `rate()` first, and
+// [lowerExpHistogramSumOrAvgOverPlan] then reuses this function's merge
+// machinery over that already-histogram-valued result (issue #2296, closed
+// by #2245). Keeping this recognizer narrow to the bare-selector fast path
+// keeps its byte-stable direct lowering unchanged by that composition.
 func sumOrAvgOverExpHistogram(expr parser.Expr, s schema.Metrics, ctx lowerCtx) (*parser.AggregateExpr, *parser.VectorSelector, bool) {
 	if s.ExpHistogramTable == "" || ctx.metadataFullRange {
 		return nil, nil, false

--- a/internal/promql/histogram_shape_guard.go
+++ b/internal/promql/histogram_shape_guard.go
@@ -22,23 +22,36 @@ import (
 // possible failure mode for a numeric gateway.
 //
 // Today that cannot happen, and the reason is structural rather than
-// defensive: a HistogramProjection is built ONLY by [lowerRoot], which is
-// reached only from the two public entry points ([Lower] and [LowerRange])
-// and never recursively, so the node is only ever the query ROOT. A
-// forwarder, by construction, wraps something — it is only ever called on
-// a non-root position. Every nested exp-histogram selector is refused
-// earlier still, by [expHistogramSelectorRouting].
+// defensive. A HistogramProjection CAN now sit at a non-root position —
+// composing `sum`/`avg` over an already histogram-valued result
+// (`sum(rate(m_exp_hist[5m]))`) or rewriting attributes for `label_replace`
+// / `label_join` both feed a nested HistogramProjection into another node
+// — but the node directly above it is never one of these two forwarders.
+// It is always another histogram-aware consumer: [lowerExpHistogramValuedShape]
+// recognises the composed shape recursively (via mergeableExpHistogramAggregate
+// for the aggregation case, labelCallOverExpHistogram for the label-rewrite
+// case) and hands the nested HistogramProjection to a dedicated lowering
+// (histogram_native_sum.go's lowerExpHistogramSumOrAvgOverPlan,
+// histogram_native_label_replace.go's rewriteHistogramProjectionAttributes)
+// that reads its nine columns by name instead of going through
+// [projectValueOverInner] / [projectAttributesOverInner]. Every remaining
+// consumer either recognises its histogram-valued operand directly
+// (scalar/histogram and histogram/histogram binops) or drops it
+// ([dropExpHistogramSamples], for float-only functions). Every nested
+// exp-histogram selector that reaches none of those recognisers is refused
+// by [expHistogramSelectorRouting] before a forwarder ever sees it.
 //
 // So this is an assertion about an impossible state, not a user-facing
 // rejection, and it panics rather than returning an error for exactly
 // that reason — the same contract [scanFromTables]'s "called with no
 // candidate tables" panic keeps. What it buys is the failure mode issue
-// #1967 asked for: the day someone teaches a nested shape to carry a
-// histogram (lifting the routing guard for `label_join`, `abs`, or
-// arithmetic — see issue #2296, since `label_replace` itself now has its
-// own dedicated lowering) without first teaching these forwarders the
-// shape, the first test that exercises it dies with a message naming the
-// forwarder and the fix, instead of quietly returning zeros.
+// #1967 first asked for and issue #2296 confirmed still held once
+// `sum`/`avg` composition and label rewrites grew their own histogram-aware
+// lowerings (#2245): the day a FUTURE consumer routes a histogram-valued
+// node through one of these two generic forwarders — instead of through the
+// shared recognizer set above, or a dedicated lowering of its own — the
+// first test that exercises it dies with a message naming the forwarder and
+// the fix, instead of quietly returning zeros.
 
 // assertValueShapedInput panics when inner publishes
 // [chplan.HistogramRowShape], the one shape whose `Value` column is a
@@ -54,8 +67,9 @@ func assertValueShapedInput(inner chplan.Node, forwarder string) {
 		"promql: %s received a %s-shaped input: its projection forwards %q, "+
 			"which a chplan.HistogramProjection publishes only as a placeholder "+
 			"alongside the nine Histogram*Column outputs. Projecting it would "+
-			"answer 0 and drop the histogram. Teach %s the histogram shape "+
-			"before routing a histogram-valued node through it (issue #2296).",
-		forwarder, chplan.HistogramRowShape, "Value", forwarder,
+			"answer 0 and drop the histogram. Either route this node through the "+
+			"shared histogram-valued recognizer set (see this file's doc comment) "+
+			"instead of %s, or teach %s the histogram shape directly.",
+		forwarder, chplan.HistogramRowShape, "Value", forwarder, forwarder,
 	))
 }

--- a/internal/promql/histogram_shape_guard_test.go
+++ b/internal/promql/histogram_shape_guard_test.go
@@ -67,8 +67,8 @@ func TestProjectForwarders_PanicOnHistogramShapedInput(t *testing.T) {
 			if !strings.Contains(msg, chplan.HistogramRowShape.String()) {
 				t.Errorf("panic message does not name the %s shape: %s", chplan.HistogramRowShape, msg)
 			}
-			if !strings.Contains(msg, "#2296") {
-				t.Errorf("panic message does not cite the tracking issue: %s", msg)
+			if !strings.Contains(msg, "recognizer") {
+				t.Errorf("panic message does not point at the shared recognizer set: %s", msg)
 			}
 		})
 	}

--- a/internal/promql/lower.go
+++ b/internal/promql/lower.go
@@ -187,10 +187,9 @@ func LowerMetadataRange(ctx context.Context, expr parser.Expr, s schema.Metrics,
 // shape with a histogram projection would either fail in ClickHouse with
 // code 47 or, worse, silently reduce the placeholder Value. Deciding
 // here — where the absence of a parent is a fact rather than an
-// inference — keeps those shapes on [expHistogramSelectorRouting]'s
-// explicit rejection until each grows its own histogram-AWARE lowering
-// (issue #2296), and never widens the exemption by accident: a nested
-// selector never reaches this function.
+// inference — keeps every shape that has grown NO histogram-aware lowering
+// on [expHistogramSelectorRouting]'s explicit rejection, and never widens
+// the exemption by accident: a nested selector never reaches this function.
 //
 // The direct histogram-valued dispatches are ordered but not mutually
 // exclusive in principle, and the order is arbitrary:
@@ -200,10 +199,16 @@ func LowerMetadataRange(ctx context.Context, expr parser.Expr, s schema.Metrics,
 // Histogram-preserving wrappers dispatch before them because their operand
 // is one of those payload shapes.
 // [rangeFnOverExpHistogram] additionally refuses an aggregation WRAPPER, so
-// `sum(rate(...))` — which needs both reductions — matches neither it nor
-// [sumOrAvgOverExpHistogram] and stays rejected. The scaling scalar-binop
-// recognizer intentionally precedes the dropping recognizer so histogram /
-// scalar keeps its value while scalar / histogram drops it.
+// the direct dispatch alone does not answer `sum(rate(...))` — which needs
+// both reductions. [lowerExpHistogramValuedShape] (called just below, and
+// recursively from inside itself) is what closes that gap:
+// mergeableExpHistogramAggregate recognises a `sum`/`avg` wrapping ANY
+// already-histogram-valued shape, not only a bare selector, so
+// `sum(rate(m_exp_hist[5m]))` recurses into the `rate()` dispatch and feeds
+// its result to [lowerExpHistogramSumOrAvgOverPlan] (issue #2296, closed by
+// #2245). The scaling scalar-binop recognizer intentionally precedes the
+// dropping recognizer so histogram / scalar keeps its value while scalar /
+// histogram drops it.
 //
 // Metadata lowering ([LowerMetadataRange]) deliberately does NOT route
 // through here: it enumerates series and labels rather than evaluating an


### PR DESCRIPTION
## Summary

Issue #2296 tracked two things: the generic row-shape-aware forwarders
(`projectValueOverInner` / `projectAttributesOverInner`) panicking on a
`chplan.HistogramRowShape` input, and `sum(rate(m_exp_hist[5m]))` (a
stacked aggregation-over-range-fn reduction) staying hard-rejected. Both
cite the closed #1967 as their tracking issue, which #2296 was filed to
correct.

Investigating the actual current state on `main` (this branch is cut from
`origin/main` at `25f08715d`, which already includes #2245, "compose
native histogram consumers", merged 2026-08-17 02:58 — ahead of #2299's
doc-only citation repoint that filed/pointed at #2296 at 11:23 the same
day) shows #2245 already closed both halves of #2296's scope, just not by
teaching the two generic forwarders directly:

- `mergeableExpHistogramAggregate` (histogram_native_sum.go) recognizes a
  `sum`/`avg` wrapping **any** already histogram-valued shape, not only a
  bare selector. `lowerExpHistogramValuedShape` (histogram_native_float_fn.go)
  recurses into the aggregand — `rate(m_exp_hist[5m])` — lowers it via
  `rangeFnOverExpHistogram`, and feeds the result to
  `lowerExpHistogramSumOrAvgOverPlan`, which reuses this file's
  cross-series merge over the already-histogram-valued input. This
  answers `sum(rate(m_exp_hist[5m]))` end to end.
- `labelCallOverExpHistogram` (histogram_native_label_replace.go) already
  covers both `label_replace` **and** `label_join` (despite the filename),
  each recursing the same way for a composed operand like
  `label_join(rate(m_exp_hist[5m]), ...)`.
- Every other consumer that could otherwise wrap a histogram-valued node
  already intercepts it before it would reach a generic forwarder:
  scalar/histogram and histogram/histogram binops recognize their operand
  directly, and float-only functions (`abs`, `round`, …) drop the
  histogram via `dropExpHistogramSamples`.

So a `HistogramRowShape` node genuinely cannot reach
`projectValueOverInner` / `projectAttributesOverInner` today — same as
before #2245, just for a larger, now-composable set of reasons. The
`assertValueShapedInput` panic guard is correct to stay in place as a
structural safety net for a future consumer that bypasses the shared
recognizer set; there's nothing left to "teach" the two forwarders
because nothing routes a histogram-valued node through them.

## Verification

Confirmed live, not just by code reading:

```
go test -race ./internal/promql/... ./internal/chplan/...
go test -tags chdb -run TestQuery_NestedHistogramConsumers_ChDB -v ./internal/api/prom/...
```

`TestQuery_NestedHistogramConsumers_ChDB` (added by #2245) already pins
`sum(rate(latency_exp_hist[5m]))`, `avg by (service) (rate(...))`, and
`label_join(rate(latency_exp_hist[5m]), ...)` through a real chDB
round-trip — all three pass. `test/spec/promql/exp_histogram_sum_over_rate.txtar`
already pins the plan/SQL shape for the same query with `expected_rows`
filled in. No new fixture or golden regen is needed; nothing this PR
touches changes plan shape, emitted SQL, or wire output — it's a doc-only
correction of stale citations, so `just update-golden` has nothing to
regenerate here.

## Changes

Repointed the four sites #2296 named as citing the dead #1967 (which had
already been repointed to #2296 by #2299) to describe the *actual*, now
fully-closed state instead of citing #2296 as still-open work:

- `internal/chplan/row_shape.go` — `HistogramRowShape`'s doc comment now
  explains which recognizer intercepts each wrapping shape instead of
  saying generic forwarders block the remainder.
- `internal/promql/histogram_shape_guard.go` — the file's doc comment
  corrects the now-inaccurate "a HistogramProjection is only ever the
  query ROOT" claim (composition *can* nest one under an `Aggregate` or a
  label-rewrite `Project` now, just never directly under a generic
  forwarder) and the panic message drops the dead issue citation in favor
  of pointing at the shared recognizer set.
- `internal/promql/lower.go` — `lowerRoot`'s doc comment no longer claims
  `sum(rate(...))` "stays rejected"; it now names
  `mergeableExpHistogramAggregate` as the composition path that answers
  it.
- `internal/promql/histogram_native_sum.go` — `sumOrAvgOverExpHistogram`'s
  doc comment clarifies that its own bare-selector-only recognition stays
  intentionally narrow because the composed shape is answered by a
  *different* recognizer in the same file, not because the gap is open.
- `internal/promql/histogram_shape_guard_test.go` — the panic-message
  assertion now checks for the pointer to the shared recognizer set
  instead of asserting a citation to what is now a closed issue.

## Test plan

- [x] `go build ./internal/chplan/... ./internal/promql/...`
- [x] `go vet ./internal/chplan/... ./internal/promql/...` and `go vet -tags chdb` over the same plus `./internal/api/prom/...`
- [x] `go test -race ./internal/promql/... ./internal/chplan/...`
- [x] `go test -tags chdb -run TestQuery_NestedHistogramConsumers_ChDB -v ./internal/api/prom/...` (sum/avg/label_join over `rate()` on a native histogram, real chDB round-trip)
- [x] `gofumpt -extra -l` / `goimports -local` clean on every touched file

Closes #2296
