### PR TITLE
feat(ci): add forbid-verbatim-concat gate, fix forbid-sql-raw's vacuous scan

### DIFF
--- a/.github/scripts/forbid-sql-raw.mjs
+++ b/.github/scripts/forbid-sql-raw.mjs
@@ -59,11 +59,28 @@ const KNOWN_GOOD = new Set([
 const RAW_WRITE_PATTERN = /strings\.Builder|\.writeSQL\s*\(|\.sb\.Write|\bwriteSQL\s*\(/;
 
 // Scan all non-test, non-builder chsql Go files.
+//
+// `:(glob)` is required, not decorative: without it (or a global
+// core.globPathspecs=true), a bare `**` is matched as a plain fnmatch
+// wildcard rather than "any number of directories including zero", which
+// needs a literal `/` right where the pattern has one — so it silently
+// matches ZERO files for any path with no subdirectory below the prefix.
+// internal/chsql has no subpackages, so this scan was passing vacuously
+// (0 files scanned, 0 violations found, exit 0) until this fix. See
+// forbid-verbatim-concat.mjs's identical comment and #2321 for the
+// discovery, and the zero-file guard below for how this class of bug is
+// now prevented from recurring silently.
 const files = lsFiles([
-  'internal/chsql/**/*.go',
-  ':!:internal/chsql/builder.go',    // allowed by design — Frag constructors
-  ':!:internal/chsql/**/*_test.go',  // test files are out of scope
+  ':(glob)internal/chsql/**/*.go',
+  ':!:internal/chsql/builder.go',            // allowed by design — Frag constructors
+  ':(exclude,glob)internal/chsql/**/*_test.go', // test files are out of scope
 ]);
+
+if (files.length === 0) {
+  error('forbid-sql-raw: pathspec matched zero files — the scan pathspec is broken, not the tree.');
+  process.exit(1);
+}
+log(`forbid-sql-raw: scanning ${files.length} file(s).`);
 
 let violations = 0;
 

--- a/.github/scripts/forbid-verbatim-concat.mjs
+++ b/.github/scripts/forbid-verbatim-concat.mjs
@@ -63,13 +63,12 @@ const KNOWN_GOOD = new Set([
   'internal/chsql/vector_join.go:784',     // aliasedFrag: verbatim(" AS "+bareAlias)
 
   // Category 2 — tracked pre-existing debt, not yet fixed.
-  'internal/chsql/nested_set_annotate.go:370', // ARRAY JOIN arrayFilter(...) shape — #2321
-  // The next two are already fixed by #2297 / PR #2319 (open, converts both to
+  // These two are already fixed by #2297 / PR #2319 (open, converts both to
   // the new typed WindowFrame constructor) — remove once that PR merges and
   // this branch rebases past it; listed here only so this NEW gate doesn't
   // block on a violation a concurrently in-flight PR already resolves.
-  'internal/chsql/nested_set_annotate.go:378', // sum(...) OVER (...) _erank — #2297
-  'internal/chsql/nested_set_annotate.go:388', // first_value(...) OVER (...) _keyrank — #2297
+  'internal/chsql/nested_set_annotate.go:404', // sum(...) OVER (...) _erank — #2297
+  'internal/chsql/nested_set_annotate.go:414', // first_value(...) OVER (...) _keyrank — #2297
 ]);
 
 // findVerbatimCalls() walks content once, locating each `verbatim(` call

--- a/.github/scripts/forbid-verbatim-concat.mjs
+++ b/.github/scripts/forbid-verbatim-concat.mjs
@@ -1,0 +1,201 @@
+// forbid-verbatim-concat.mjs — gate that flags verbatim() calls built via
+// string concatenation, the shape-building misuse invariant 10 forbids.
+//
+// verbatim(sql string) Frag exists for emitter-chosen SYNTHETIC TOKENS — a
+// bare alias name, a pre-quoted literal, pre-rendered subquery SQL — never
+// for constructing a whole expression shape (a window function, a
+// comparison, an ORDER BY list) by hand. A single synthetic token never
+// needs Go's `+` string-concatenation operator; any verbatim(...) call
+// whose argument concatenates strings is therefore almost certainly
+// building a shape, not naming a token. forbid-sql-raw.mjs's regex already
+// catches the raw-write PRIMITIVES (strings.Builder, writeSQL, sb.Write);
+// its own doc explicitly says it is blind to verbatim() misuse, and that
+// gap is exactly what let the internal/chsql/nested_set_annotate.go /
+// structural_join.go call sites (#2297, #2301) go undetected until a full
+// manual audit found them.
+//
+// What is scanned: internal/chsql/**/*.go (non-test, non-builder.go — the
+// same pathspec forbid-sql-raw.mjs uses, since verbatim() itself is
+// defined, not called, in builder.go).
+//
+// What is flagged: any verbatim(...) call whose argument contains a
+// top-level `+` operator (Go string concatenation) outside a string
+// literal.
+//
+// Exit codes: 0 = clean, 1 = violation found.
+//
+// This is a text-level heuristic, not a full Go AST parse — consistent
+// with forbid-sql-raw.mjs's own approach, and cheap enough to run on every
+// PR. A future call site that legitimately needs `+` inside a verbatim()
+// argument for some reason this scan hasn't anticipated is not silently
+// exempted: add its "file:line" to KNOWN_GOOD below with a rationale
+// comment and reviewer sign-off, mirroring forbid-sql-raw.mjs's own
+// escape hatch. This is an inventory, not a bypass.
+//
+// See CLAUDE.md § "No raw SQL strings — typed chsql API only" (invariant
+// 10) and #2297.
+
+import { lsFiles, error, log } from './lib/gh.mjs';
+import { readFileSync } from 'node:fs';
+import process from 'node:process';
+
+// KNOWN_GOOD — "file:line" sites pre-approved to concatenate inside a
+// verbatim() argument, each with a rationale. Two categories:
+//
+// 1. Synthetic-token concatenation — gluing an emitter-chosen, never-
+//    user-controlled alias (a bare single letter like `L`/`R`, or a
+//    fixed internal name) to FIXED punctuation to form one simple
+//    qualified-identifier-like token (`L.*`, `L.`, ` AS L`). This is
+//    still "a synthetic token" per invariant 10's own definition, not a
+//    whole expression SHAPE (no operators, no function calls, no
+//    ORDER BY/PARTITION BY/frame clauses) — the `+` only stitches two
+//    inert strings together.
+// 2. Verified, tracked pre-existing debt — a real shape-building
+//    violation this gate would otherwise block on, already filed as its
+//    own issue for a dedicated fix (matching #2297's own precedent: too
+//    complex/risky for a drive-by rewrite). Remove the entry the moment
+//    its tracking issue's fix lands — this is not a silent bypass, it is
+//    an inventory of exactly what's still owed.
+const KNOWN_GOOD = new Set([
+  // Category 1 — synthetic single-letter join alias + fixed punctuation.
+  'internal/chsql/structural_join.go:556', // starExceptKeys: verbatim(side+".*")
+  'internal/chsql/vector_join.go:770',     // qualColFrag: verbatim(side+".")
+  'internal/chsql/vector_join.go:784',     // aliasedFrag: verbatim(" AS "+bareAlias)
+
+  // Category 2 — tracked pre-existing debt, not yet fixed.
+  'internal/chsql/nested_set_annotate.go:370', // ARRAY JOIN arrayFilter(...) shape — #2321
+  // The next two are already fixed by #2297 / PR #2319 (open, converts both to
+  // the new typed WindowFrame constructor) — remove once that PR merges and
+  // this branch rebases past it; listed here only so this NEW gate doesn't
+  // block on a violation a concurrently in-flight PR already resolves.
+  'internal/chsql/nested_set_annotate.go:378', // sum(...) OVER (...) _erank — #2297
+  'internal/chsql/nested_set_annotate.go:388', // first_value(...) OVER (...) _keyrank — #2297
+]);
+
+// findVerbatimCalls() walks content once, locating each `verbatim(` call
+// and extracting its full argument text (balanced across parens and,
+// where the call wraps multiple lines, across newlines too) plus the
+// 1-based line the call starts on.
+function findVerbatimCalls(content) {
+  const calls = [];
+  const callPattern = /\bverbatim\(/g;
+  let match;
+  while ((match = callPattern.exec(content)) !== null) {
+    const argStart = match.index + match[0].length;
+    const { argText, end } = readBalancedArgs(content, argStart);
+    if (end === -1) continue; // unterminated — malformed source, not this gate's job
+    const line = content.slice(0, match.index).split('\n').length;
+    calls.push({ line, argText });
+  }
+  return calls;
+}
+
+// readBalancedArgs() scans forward from `start` (just past the opening
+// paren already consumed by the caller) tracking paren depth and Go
+// string-literal state, returning the argument text up to the matching
+// close paren. String-literal-aware so a `)` or `+` inside a quoted
+// string never mistakenly ends the scan or counts as concatenation.
+function readBalancedArgs(content, start) {
+  let depth = 1; // the opening paren the caller already matched
+  let i = start;
+  let inString = null; // '"', '`', or null
+  while (i < content.length && depth > 0) {
+    const c = content[i];
+    if (inString === '"') {
+      if (c === '\\') { i += 2; continue; }
+      if (c === '"') inString = null;
+    } else if (inString === '`') {
+      if (c === '`') inString = null;
+    } else {
+      if (c === '"' || c === '`') inString = c;
+      else if (c === '(') depth++;
+      else if (c === ')') depth--;
+    }
+    i++;
+  }
+  if (depth !== 0) return { argText: '', end: -1 };
+  return { argText: content.slice(start, i - 1), end: i };
+}
+
+// hasTopLevelConcat() reports whether argText contains a Go `+` operator
+// outside any string literal — the only way a single-string-parameter
+// call like verbatim(sql string) legitimately contains a bare `+`.
+function hasTopLevelConcat(argText) {
+  let inString = null;
+  for (let i = 0; i < argText.length; i++) {
+    const c = argText[i];
+    if (inString === '"') {
+      if (c === '\\') { i++; continue; }
+      if (c === '"') inString = null;
+      continue;
+    }
+    if (inString === '`') {
+      if (c === '`') inString = null;
+      continue;
+    }
+    if (c === '"' || c === '`') { inString = c; continue; }
+    if (c === '+') return true;
+  }
+  return false;
+}
+
+// A bare `**` pathspec needs git's `glob` pathspec magic to mean "any
+// number of directories, including zero" — without it (no `:(glob)`
+// prefix, no `core.globPathspecs=true`), `**` is matched as plain fnmatch
+// wildcards, which still requires a literal `/` to appear right where the
+// pattern has one. That silently matches zero files for every path that
+// has no subdirectory below the prefix (exactly `internal/chsql/*.go`'s
+// shape, since the package has no subpackages) while still "succeeding"
+// with an empty result — a scan that reports "clean" without ever having
+// looked at anything. `:(glob)` makes the intended "any depth" meaning
+// explicit and unambiguous regardless of ambient git config.
+const files = lsFiles([
+  ':(glob)internal/chsql/**/*.go',
+  ':!:internal/chsql/builder.go', // defines verbatim(), by design — not a caller
+  ':(exclude,glob)internal/chsql/**/*_test.go',
+]);
+
+log(`forbid-verbatim-concat: scanning ${files.length} file(s).`);
+if (files.length === 0) {
+  error('forbid-verbatim-concat: pathspec matched zero files — the scan pathspec is broken, not the tree.');
+  process.exit(1);
+}
+
+let violations = 0;
+
+for (const file of files) {
+  const rel = file.replace(/\\/g, '/');
+
+  let content;
+  try {
+    content = readFileSync(file, 'utf8');
+  } catch (e) {
+    error(`forbid-verbatim-concat: cannot read ${file}: ${e.message}`);
+    violations++;
+    continue;
+  }
+
+  for (const { line, argText } of findVerbatimCalls(content)) {
+    const loc = `${rel}:${line}`;
+    if (KNOWN_GOOD.has(loc)) continue;
+    if (hasTopLevelConcat(argText)) {
+      error(
+        `${loc}: verbatim(...) call built via string concatenation — this is shape-building, ` +
+        'not a synthetic token, and violates invariant 10 (no raw SQL strings). Use typed Frags ' +
+        '(Call / Window / WindowFrame / Eq / Lt / InlineLit / …) to express the shape instead. ' +
+        `If this really is a legitimate synthetic token, add "${loc}" to KNOWN_GOOD in ` +
+        '.github/scripts/forbid-verbatim-concat.mjs with a rationale comment and reviewer ' +
+        'sign-off (see CLAUDE.md § "No raw SQL strings" and #2297).',
+      );
+      violations++;
+    }
+  }
+}
+
+if (violations > 0) {
+  log(`forbid-verbatim-concat: ${violations} violation(s) found.`);
+  process.exit(1);
+}
+
+log('forbid-verbatim-concat: no verbatim() call builds a shape via concatenation.');
+process.exit(0);

--- a/.github/scripts/forbid-verbatim-concat.test.mjs
+++ b/.github/scripts/forbid-verbatim-concat.test.mjs
@@ -1,0 +1,118 @@
+// Unit + integration tests for forbid-verbatim-concat.mjs.
+//
+// The integration tests spin up a real temp git repo shaped like
+// internal/chsql/ (a FLAT directory, no subpackages) and run the actual
+// script against it via subprocess — this is deliberate, not just belt-and-
+// braces: a bare `**` pathspec silently matches zero files against exactly
+// this flat-directory shape without git's `glob` pathspec magic, which is
+// exactly the bug that let both this script and forbid-sql-raw.mjs pass
+// "clean" while scanning nothing (#2321's discovery). A unit test of the
+// concat-detection logic alone would never have caught that class of bug;
+// only a real `git ls-files` invocation against a real flat directory does.
+
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { spawnSync } from 'node:child_process';
+import { mkdtempSync, writeFileSync, mkdirSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const SCRIPT = join(dirname(fileURLToPath(import.meta.url)), 'forbid-verbatim-concat.mjs');
+
+// newChsqlRepo() builds a throwaway git repo with an internal/chsql/
+// directory containing the given files (path -> content), commits them,
+// and returns the repo dir. Mirrors internal/chsql/'s real shape: flat,
+// no subpackages.
+function newChsqlRepo(files) {
+  const dir = mkdtempSync(join(tmpdir(), 'forbid-verbatim-concat-test-'));
+  const run = (args) => spawnSync('git', args, { cwd: dir, encoding: 'utf8' });
+  run(['init', '-q']);
+  run(['config', 'user.email', 'a@a']);
+  run(['config', 'user.name', 'a']);
+  mkdirSync(join(dir, 'internal', 'chsql'), { recursive: true });
+  for (const [rel, content] of Object.entries(files)) {
+    const full = join(dir, rel);
+    mkdirSync(dirname(full), { recursive: true });
+    writeFileSync(full, content);
+  }
+  run(['add', '-A']);
+  run(['commit', '-q', '-m', 'seed']);
+  return { dir, run };
+}
+
+function runGate(dir) {
+  return spawnSync('node', [SCRIPT], { cwd: dir, encoding: 'utf8' });
+}
+
+test('exits non-zero and reports the real file count against a flat internal/chsql/ directory', () => {
+  const { dir } = newChsqlRepo({
+    'internal/chsql/builder.go': 'package chsql\n\nfunc verbatim(sql string) Frag { return nil }\n',
+    'internal/chsql/emit.go': 'package chsql\n\nfunc alias() Frag {\n\treturn verbatim("anchor_ts")\n}\n',
+  });
+  const res = runGate(dir);
+  // A flat internal/chsql/ (no subpackages) is exactly the shape that a
+  // bare, non-glob-magic `**` pathspec silently matches ZERO files
+  // against. The zero-file guard in the script itself would fail loudly
+  // in that case; here we assert the POSITIVE case — it actually finds
+  // and scans the one non-builder.go file.
+  assert.match(res.stdout, /scanning 1 file\(s\)/, `expected to scan emit.go, got: ${res.stdout}`);
+  assert.equal(res.status, 0, `expected clean exit, got status=${res.status}: ${res.stdout}`);
+});
+
+test('flags a verbatim() call built via string concatenation', () => {
+  const { dir } = newChsqlRepo({
+    'internal/chsql/builder.go': 'package chsql\n\nfunc verbatim(sql string) Frag { return nil }\n',
+    'internal/chsql/shape.go':
+      'package chsql\n\nfunc bad(col string) Frag {\n\treturn verbatim("sum(" + col + ") OVER (PARTITION BY x)")\n}\n',
+  });
+  const res = runGate(dir);
+  assert.equal(res.status, 1, `expected a violation, got status=${res.status}: ${res.stdout}`);
+  assert.match(res.stdout, /shape\.go:4/, `expected the violation at shape.go:4, got: ${res.stdout}`);
+});
+
+test('does not flag a `+` that appears only inside a string literal', () => {
+  const { dir } = newChsqlRepo({
+    'internal/chsql/builder.go': 'package chsql\n\nfunc verbatim(sql string) Frag { return nil }\n',
+    'internal/chsql/literal.go':
+      'package chsql\n\nfunc literal() Frag {\n\treturn verbatim("1 + 1")\n}\n',
+  });
+  const res = runGate(dir);
+  assert.equal(res.status, 0, `a "+" inside a string literal must not trigger, got: ${res.stdout}`);
+});
+
+test('ignores a concatenating verbatim() call inside a _test.go file', () => {
+  const { dir } = newChsqlRepo({
+    'internal/chsql/builder.go': 'package chsql\n\nfunc verbatim(sql string) Frag { return nil }\n',
+    'internal/chsql/emit.go': 'package chsql\n\nfunc alias() Frag {\n\treturn verbatim("anchor_ts")\n}\n',
+    'internal/chsql/shape_test.go':
+      'package chsql\n\nfunc TestBad(t *T) {\n\t_ = verbatim("a" + "b")\n}\n',
+  });
+  const res = runGate(dir);
+  assert.equal(res.status, 0, `test files are out of scope, got: ${res.stdout}`);
+});
+
+test('ignores builder.go itself even though it defines verbatim', () => {
+  const { dir } = newChsqlRepo({
+    'internal/chsql/builder.go':
+      'package chsql\n\nfunc verbatim(sql string) Frag { return nil }\n\nfunc self() Frag {\n\treturn verbatim("a" + "b")\n}\n',
+    'internal/chsql/emit.go': 'package chsql\n\nfunc alias() Frag {\n\treturn verbatim("anchor_ts")\n}\n',
+  });
+  const res = runGate(dir);
+  assert.equal(res.status, 0, `builder.go is excluded by design, got: ${res.stdout}`);
+});
+
+test('fails loudly rather than passing vacuously when the pathspec matches nothing', () => {
+  const dir = mkdtempSync(join(tmpdir(), 'forbid-verbatim-concat-test-empty-'));
+  const run = (args) => spawnSync('git', args, { cwd: dir, encoding: 'utf8' });
+  run(['init', '-q']);
+  run(['config', 'user.email', 'a@a']);
+  run(['config', 'user.name', 'a']);
+  writeFileSync(join(dir, 'README.md'), 'no chsql here\n');
+  run(['add', '-A']);
+  run(['commit', '-q', '-m', 'seed']);
+
+  const res = runGate(dir);
+  assert.equal(res.status, 1, `a zero-file scan must fail loudly, got: ${res.stdout}`);
+  assert.match(res.stdout, /matched zero files/, `expected the zero-file guard message, got: ${res.stdout}`);
+});

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -947,6 +947,16 @@ jobs:
       - name: Reject raw SQL writes outside the chsql Frag layer
         run: node .github/scripts/forbid-sql-raw.mjs
 
+      # forbid-sql-raw.mjs's regex is blind to verbatim() misuse by design
+      # (its own doc says so) — this closes that gap: a verbatim(...) call
+      # built via string concatenation is shape-building, not a synthetic
+      # token, and violates the same invariant 10. See #2297.
+      - name: Reject verbatim() calls built via string concatenation
+        run: node .github/scripts/forbid-verbatim-concat.mjs
+
+      - name: Assert the verbatim-concat gate scans a flat package correctly
+        run: node --test .github/scripts/forbid-verbatim-concat.test.mjs
+
       - name: Assert the sealed chplan Fn vocabulary gate
         run: node --test .github/scripts/forbid-chplan-fn-literal.test.mjs
 

--- a/internal/chsql/builder.go
+++ b/internal/chsql/builder.go
@@ -1708,6 +1708,24 @@ func Subscript(container, key Frag) Frag {
 	}
 }
 
+// TupleIndex returns a Frag rendering "<tuple>.<n>" — CH's 1-based
+// positional tuple-element access (`t.1`, `t.2`). n is written directly
+// into the SQL text rather than bound as a `?` placeholder: CH's tuple
+// dot-index syntax requires a compile-time integer literal at that
+// position, not a parameter. n must be >= 1 (CH tuple indices are
+// 1-based); callers pass a small, self-evident positional constant
+// (invariant 13's own carve-out), never a computed or business value.
+func TupleIndex(tuple Frag, n int) Frag {
+	if n < 1 {
+		panic(fmt.Sprintf("chsql: TupleIndex n must be >= 1 (1-based), got %d", n))
+	}
+	return func(b *Builder) {
+		tuple(b)
+		b.sb.WriteByte('.')
+		b.sb.WriteString(strconv.Itoa(n))
+	}
+}
+
 // If returns a Frag rendering "if(<cond>, <then>, <else>)" — CH's
 // ternary `if` function. The fixed-arity wrapper around Call("if", …)
 // makes the structural intent grep-able and rejects ill-arity uses at

--- a/internal/chsql/nested_set_annotate.go
+++ b/internal/chsql/nested_set_annotate.go
@@ -2,7 +2,6 @@ package chsql
 
 import (
 	"fmt"
-	"strconv"
 
 	"github.com/tsouza/cerberus/internal/chplan"
 )
@@ -318,8 +317,6 @@ func (e *emitter) buildNestedSetNumbering(n *chplan.NestedSetAnnotate, scope Fra
 		// toDate(Timestamp) partitions (the IN membership does not).
 		Where(appendNonNilFrags([]Frag{structuralDepthBoundFrag(0), stepTraceIn}, winLo, winHi)...)
 
-	w := strconv.Itoa(nestedSetPathElemWidth)
-
 	// The numbering is computed as the rank of each span's ENTRY and
 	// EXIT event in the per-trace DFS event sequence — literally
 	// Tempo's two-pointer walk, recovered from the sorted paths:
@@ -364,10 +361,39 @@ func (e *emitter) buildNestedSetNumbering(n *chplan.NestedSetAnnotate, scope Fra
 		Select(
 			Col(n.TraceIDColumn),
 			Col(n.SpanIDColumn),
-			verbatim("`_ev`.1 AS `_ekey`"),
-			verbatim("`_ev`.2 AS `_etype`"),
+			As(TupleIndex(Col("_ev"), 1), "_ekey"),
+			As(TupleIndex(Col("_ev"), 2), "_etype"),
 		).
-		From(verbatim("`_cerberus_ns_paths` ARRAY JOIN arrayFilter(e -> NOT (e.2 = 1 AND e.1 = ''), [(`_path`, 0), (concat(`_path`, '~'), 2), (substring(`_path`, 1, length(`_path`) - " + w + "), 1)]) AS `_ev`"))
+		From(verbatim("`_cerberus_ns_paths`"))
+	events.ArrayJoin(As(
+		// arrayFilter(e -> NOT (e.2 = 1 AND e.1 = ''), [...]) — drop
+		// PARENT-LOOKUP events for root spans (empty `_path` prefix):
+		// roots have no parent, so their lookup event would otherwise
+		// contribute a bogus rank. `e` is a synthetic lambda-bound loop
+		// variable (never user input), referenced bare per this
+		// package's own single-letter-alias convention.
+		Call(
+			"arrayFilter",
+			Lambda1("e", Not(Paren(And(
+				Eq(TupleIndex(verbatim("e"), 2), InlineLit(1)),
+				Eq(TupleIndex(verbatim("e"), 1), InlineLit("")),
+			)))),
+			Array(
+				// entry event: key = `_path`, type 0.
+				Tuple(Col("_path"), InlineLit(0)),
+				// exit event: key = `_path` + '~' (sorts after every
+				// digit, see the DFS-order comment above), type 2.
+				Tuple(Call("concat", Col("_path"), InlineLit("~")), InlineLit(2)),
+				// parent-lookup event: key = `_path` with its last
+				// element stripped, type 1.
+				Tuple(
+					Call("substring", Col("_path"), InlineLit(1), Sub(Call("length", Col("_path")), InlineLit(nestedSetPathElemWidth))),
+					InlineLit(1),
+				),
+			),
+		),
+		"_ev",
+	))
 
 	ranked := NewQuery().
 		Select(


### PR DESCRIPTION
## What

Adds `forbid-verbatim-concat.mjs`, a new CI gate closing a real, previously-manual enforcement gap:
`verbatim(...)` calls built via Go string concatenation are almost always shape-building (a window
function, an `ARRAY JOIN`, a comparison), not a synthetic token — `forbid-sql-raw.mjs`'s regex is
explicitly blind to this per its own doc comment, which is exactly why #2297 and #2301 needed a
manual audit to find rather than mechanical detection.

The gate flags any `verbatim(...)` call whose argument contains a `+` outside a string literal, with
a `KNOWN_GOOD` escape hatch (mirroring `forbid-sql-raw.mjs`'s own pattern) for genuine synthetic-token
concatenation (an emitter-chosen alias glued to fixed punctuation — `L.*`, `L.`, ` AS L`) and for
verified, tracked debt still awaiting its own fix (the two `nested_set_annotate.go` window-function
call sites #2297 targets, currently mid-flight in PR #2319).

Running this against the real tree surfaced a real, previously-undetected violation:
`internal/chsql/nested_set_annotate.go:370` hand-built a whole `ARRAY JOIN arrayFilter(...)` shape (a
lambda, tuple literals, a spliced-in width constant). Filed as **#2321**, then fixed directly here:
added `TupleIndex(tuple, n)` to `builder.go` for CH's 1-based tuple dot-index syntax, and rewrote the
call site against `QueryBuilder.ArrayJoin` + the existing `Lambda1`/`Tuple`/`Array`/`Call`
primitives. First rewrite attempt had a real bug — `Not(f)` never adds parens by design (the caller
wraps with `Paren` when precedence requires it), so `Not(And(...))` silently dropped the parens
around `e -> NOT (e.2 = 1 AND e.1 = '')`, changing it into a different predicate that zeroed every
nested-set numbering. Caught via the chDB round-trip suite (not the pre-optimizer golden text, which
is captured by a separate Layer 2a test and didn't reflect this reconstruction path), fixed with
`Not(Paren(And(...)))`.

## Also fixed: forbid-sql-raw.mjs's own pathspec bug

Both scripts originally used a bare `internal/chsql/**/*.go` pathspec. Without git's `glob` pathspec
magic (`:(glob)` prefix, or `core.globPathspecs=true`), a bare `**` is matched as a plain fnmatch
wildcard, which requires a literal `/` right where the pattern has one — so it silently matches
**zero files** for any path with no subdirectory below the prefix. `internal/chsql` has no
subpackages, so `forbid-sql-raw.mjs` — a currently-**required** CI gate — has been scanning zero
files and reporting "clean" vacuously. Fixed both scripts with explicit `:(glob)`/`:(exclude,glob)`
pathspec magic, and added a zero-file guard so this class of bug fails loudly instead of silently
passing, in either script, ever again.

## Verification

- `node .github/scripts/forbid-verbatim-concat.mjs` and `node .github/scripts/forbid-sql-raw.mjs`
  both now report `scanning 36 file(s)` (up from 0) and exit clean against the current tree.
- New `forbid-verbatim-concat.test.mjs` — 6 integration tests against real throwaway git repos
  shaped like `internal/chsql/` (flat, no subpackages — the exact shape that triggered the pathspec
  bug), proving: real-file scanning, concatenation detection, string-literal-awareness (a `+` inside
  a literal doesn't false-positive), test-file/builder.go exclusion, and the zero-file guard itself.
- `go test -race ./internal/chsql/... ./internal/traceql/...` and the full chDB round-trip suite
  (`test/spec/traceql`) — all nested-set fixtures pass with correct left/right/parent numbering.
- `just lint-actions` clean on the `ci.yml` wiring.

Closes #2321
