### PR TITLE
fix(compat): reclassify closed histogram matching divergences to rejection

### DIFF
--- a/test/rejection-parity/catalogue/internal__promql__histogram_native_binop.go.json
+++ b/test/rejection-parity/catalogue/internal__promql__histogram_native_binop.go.json
@@ -4,9 +4,8 @@
       "head": "promql",
       "site": "internal/promql/histogram_native_binop.go:lowerExpHistogramHistogramBinop#f9a375de",
       "message": "promql: on()/ignoring()/group_left()/group_right() matching is not yet supported for binary arithmetic between two exponential histogram selectors; only default (full label set) matching is supported",
-      "class": "divergence",
+      "class": "rejection",
       "trigger_query": "demo_latency_exp_hist + on(job) demo_latency_exp_hist",
-      "tracking_issue": 2273,
       "evidence": {
         "guard": [
           "if !isDefaultMatching(vm)"
@@ -14,8 +13,7 @@
         "callers": [
           "lowerExpHistogramValuedShape"
         ]
-      },
-      "since": "2026-08-17"
+      }
     },
     {
       "head": "promql",

--- a/test/rejection-parity/catalogue/internal__promql__histogram_native_binop_eq.go.json
+++ b/test/rejection-parity/catalogue/internal__promql__histogram_native_binop_eq.go.json
@@ -22,9 +22,8 @@
       "head": "promql",
       "site": "internal/promql/histogram_native_binop_eq.go:lowerExpHistogramHistogramCompareBinop#f3d0ee83",
       "message": "promql: on()/ignoring()/group_left()/group_right() matching is not yet supported for == or != between two exponential histogram selectors; only default (full label set) matching is supported",
-      "class": "divergence",
+      "class": "rejection",
       "trigger_query": "demo_latency_exp_hist == on(job) demo_latency_exp_hist",
-      "tracking_issue": 2273,
       "evidence": {
         "guard": [
           "if !isDefaultMatching(vm)"
@@ -32,8 +31,7 @@
         "callers": [
           "lowerExpHistogramValuedShape"
         ]
-      },
-      "since": "2026-08-17"
+      }
     }
   ]
 }

--- a/test/rejection-parity/divergence-ceiling.json
+++ b/test/rejection-parity/divergence-ceiling.json
@@ -1,3 +1,3 @@
 {
-  "max_entries": 6
+  "max_entries": 4
 }


### PR DESCRIPTION
## What

Main's post-merge `compatibility/prometheus` check started failing after #2323 (`==`/`!=` between two
exponential histograms) landed: the rejection-parity driver now reports `divergence_closed` for two
catalogue entries tracking issue #2273 (custom `on()`/`ignoring()` matching for histogram binops) —
`histogram_native_binop.go#f9a375de` (`demo_latency_exp_hist + on(job) demo_latency_exp_hist`) and
`histogram_native_binop_eq.go#f3d0ee83` (`demo_latency_exp_hist == on(job) demo_latency_exp_hist`).
The reference now rejects both trigger queries too, so the previously-catalogued divergence no longer
reproduces.

Per the harness's own classification rule
(`compatibility/cmd/rejection-parity/main.go`: "a divergence_closed means it must be reclassified to
'rejection'"), reclassified both entries from `"divergence"` to `"rejection"`, dropping
`tracking_issue`/`since` to match the rejection schema. Regenerated the derived evidence and
`divergence-ceiling.json` via `CERBERUS_UPDATE_INVENTORY=1`.

Issue #2273 itself remains open — the third entry in `histogram_native_binop_eq.go` (the `bool`
modifier case, `demo_latency_exp_hist == bool demo_latency_exp_hist`) still diverges from the
reference and continues to track it.

## Verification

- `CERBERUS_UPDATE_INVENTORY=1 go test ./test/surface-parity/ ./test/rejection-parity/` — clean.
- `go test -run '^TestRejectionTriggersExerciseSites$' ./test/rejection-parity/...` — all triggers,
  including both reclassified entries, still exercise their sites.