### PR TITLE
feat(promql): answer 'or' between float and histogram operands

### DIFF
--- a/docs/coverage.md
+++ b/docs/coverage.md
@@ -86,7 +86,7 @@ single canonical probe, so a function that lowers `sort_by_label(v, "l")` and
 rejects `sort_by_label(v)` still counts as one supported symbol.
 
 Shape-level wrong-rejections are measured separately, by the rejection-parity
-catalogue: across all three heads it records **3** open argument-shape
+catalogue: across all three heads it records **4** open argument-shape
 divergences — queries the reference backend answers and cerberus rejects. Each
 is one `class: "divergence"` row in
 [`test/rejection-parity/catalogue/`](../test/rejection-parity/catalogue),

--- a/internal/api/prom/handler.go
+++ b/internal/api/prom/handler.go
@@ -1264,7 +1264,18 @@ func wrapWithSampleProjection(plan chplan.Node, s schema.Metrics) chplan.Node {
 	// answer back as the placeholder float — so the correct wrapper here
 	// is no wrapper at all. RowShapeOf is the one classifier for "what
 	// does this node publish"; see chplan.HistogramRowShape.
-	if chplan.RowShapeOf(plan) == chplan.HistogramRowShape {
+	//
+	// A Mixed plan (chplan.MixedRowShape, cerberus issue #2330 — `or`
+	// between a float-valued and a histogram-valued operand) needs the
+	// identical no-op: its own SELECT already publishes the same
+	// thirteen columns PLUS the trailing discriminator
+	// internal/chclient's cursor probes for (shapeSampleMixed). Wrapping
+	// it here would re-project just the quartet, dropping both the nine
+	// histogram columns AND the discriminator — the cursor would then
+	// fall back to the plain four-column shape and silently answer every
+	// row as its (possibly placeholder) Value.
+	switch chplan.RowShapeOf(plan) {
+	case chplan.HistogramRowShape, chplan.MixedRowShape:
 		return plan
 	}
 	projections := []chplan.Projection{

--- a/internal/chclient/cursor.go
+++ b/internal/chclient/cursor.go
@@ -225,6 +225,19 @@ const (
 	// columnar fast path instead of being re-dispatched to ClickHouse in
 	// full by columnarDecoder.decode's row fallback (issue #1967).
 	shapeSampleHistogram
+	// shapeSampleMixed is shapeSampleHistogram plus ONE further trailing
+	// column: a per-row discriminator (cerberus issue #2330). It latches
+	// for a `VectorSetOr` between a float-valued and a histogram-valued
+	// PromQL operand — chplan.VectorSetOp.Mixed — whose UNION carries
+	// BOTH float and native-histogram samples in the same result set,
+	// unlike shapeSampleHistogram's every-row-is-a-histogram contract.
+	// The discriminator says, per row, which half of the fourteen
+	// columns is real: [Sample.Histogram] is populated only when it's
+	// set, leaving [Sample.Value] as the real answer on every other row
+	// (mirroring the wire format's own `value` / `histogram` mutual
+	// exclusion). See internal/chsql/vector_set_op.go's
+	// emitMixedVectorSetOp for the SQL shape.
+	shapeSampleMixed
 	// shapeLogRow is the Loki log-stream row — (Line, Attributes,
 	// TimeUnix) — which binds THREE destinations and no float at all.
 	// A log line has no numeric value, so the projection emits no Value
@@ -301,6 +314,21 @@ const histogramColumnCount = 9
 // requires changing this literal too.
 const histogramLastColumn = "HistogramNegativeBucketCounts"
 
+// mixedDiscriminatorColumn is the trailing alias a Mixed VectorSetOr's
+// fourteen-column projection carries — internal/chsql/vector_set_op.go's
+// setOpMixedIsHistogramCol — duplicated here by the same by-convention
+// pairing histogramLastColumn already has with chsql's own emitted alias
+// (chclient may not import chsql: see .go-arch-lint.yml). 1 marks a row
+// that came from the histogram-shaped arm (its nine Histogram*Column
+// destinations are real, Value is the [chplan.HistogramProjection]
+// placeholder); 0 marks a row from the float-shaped arm (the mirror
+// image).
+const mixedDiscriminatorColumn = "_setop_is_histogram"
+
+// mixedColumns is the width of the [shapeSampleMixed] projection:
+// [sampleColumns] + [histogramColumnCount] + the trailing discriminator.
+const mixedColumns = sampleColumns + histogramColumnCount + 1
+
 // probeRowShape resolves a result set's positional layout from its column
 // names. cols is driver.Rows.Columns() — the emitter's output aliases, in
 // projection order.
@@ -330,6 +358,8 @@ func probeRowShape(cols []string) rowShape {
 		return shapeLogRowMetadata
 	case len(cols) == sampleColumns+histogramColumnCount && last == histogramLastColumn:
 		return shapeSampleHistogram
+	case len(cols) == mixedColumns && last == mixedDiscriminatorColumn:
+		return shapeSampleMixed
 	}
 	return shapeSample
 }
@@ -384,6 +414,28 @@ func (c *rowsCursor) Next() bool {
 			return false
 		}
 		s.Histogram = &hv
+	case shapeSampleMixed:
+		// Same thirteen destinations as shapeSampleHistogram, plus the
+		// trailing discriminator. The nine Histogram* destinations
+		// always scan (every row of this result set carries all
+		// fourteen columns — emitMixedVectorSetOp's placeholder side
+		// projects typed zero-value stand-ins, never NULL), so decoding
+		// into hv is safe on every row; the discriminator alone decides
+		// whether hv is the real answer or the unread placeholder.
+		var isHistogram uint8
+		if err := c.rows.Scan(
+			&s.MetricName, &labels, &s.Timestamp, &s.Value,
+			&hv.Count, &hv.Sum, &hv.Scale, &hv.ZeroThreshold, &hv.ZeroCount,
+			&hv.PositiveOffset, &hv.PositiveBucketCounts,
+			&hv.NegativeOffset, &hv.NegativeBucketCounts,
+			&isHistogram,
+		); err != nil {
+			c.err = fmt.Errorf("chclient: scan: %w", err)
+			return false
+		}
+		if isHistogram != 0 {
+			s.Histogram = &hv
+		}
 	// The two log-row layouts bind NO numeric destination: a log stream has
 	// no value, so the projection carries no Value column and s.Value stays
 	// zero. The line lands in s.MetricName — the positional row's first,

--- a/internal/chclient/cursor_logrow_test.go
+++ b/internal/chclient/cursor_logrow_test.go
@@ -59,6 +59,17 @@ func TestProbeRowShape(t *testing.T) {
 		{"log row with structured metadata", logRowMetadataProjectionColumns, shapeLogRowMetadata},
 		{"sample row", sampleProjectionColumns, shapeSample},
 		{"histogram row", histogramProjectionColumns, shapeSampleHistogram},
+		{"mixed row", mixedProjectionColumns, shapeSampleMixed},
+		// One column short of the mixed width but ending in the mixed
+		// discriminator's alias: not the trailing alias the histogram
+		// probe keys on, and one short of mixedColumns, so this must
+		// fall back to the default rather than being mistaken for
+		// either sample-shaped layout.
+		{
+			"thirteen wide ending in the mixed discriminator alias",
+			append(append([]string{}, sampleProjectionColumns...), "_setop_is_histogram"),
+			shapeSample,
+		},
 		// No columns at all: nothing to key off, so the default
 		// four-destination scan — the behaviour every path had before any
 		// probe existed. fakeRows leaves Columns() nil in the pre-existing

--- a/internal/chclient/cursor_test.go
+++ b/internal/chclient/cursor_test.go
@@ -44,6 +44,13 @@ func (r *fakeRows) Next() bool {
 // mismatching.
 const wantHistogramDest = 4 + histogramColumnCount
 
+// wantMixedDest is the destination count rowsCursor.Next binds when the
+// mixed probe latches true (cerberus issue #2330): wantHistogramDest
+// plus the trailing discriminator. mixedColumns is the production
+// constant, so a drift between the two fails this test file to compile
+// rather than silently mismatching.
+const wantMixedDest = mixedColumns
+
 // scanLeadingThree binds the (String, label map, timestamp) prefix every
 // layout shares, whatever follows it.
 func scanLeadingThree(dest []any, s Sample) {
@@ -149,9 +156,57 @@ func (r *fakeRows) Scan(dest ...any) error {
 		if p, ok := dest[12].(*[]float64); ok {
 			*p = hv.NegativeBucketCounts
 		}
+	case len(dest) == wantMixedDest:
+		scanLeadingThree(dest, s)
+		if p, ok := dest[3].(*float64); ok {
+			*p = s.Value
+		}
+		// A mixed-shaped fixture row is float-valued when Histogram is
+		// nil: the nine trailing Histogram* destinations still get
+		// bound (every row of a real mixed result carries typed
+		// placeholders on the side it isn't, never a gap), just to the
+		// fixture's zero HistogramValue rather than a real one.
+		hv := s.Histogram
+		if hv == nil {
+			hv = &HistogramValue{}
+		}
+		if p, ok := dest[4].(*float64); ok {
+			*p = hv.Count
+		}
+		if p, ok := dest[5].(*float64); ok {
+			*p = hv.Sum
+		}
+		if p, ok := dest[6].(*int32); ok {
+			*p = hv.Scale
+		}
+		if p, ok := dest[7].(*float64); ok {
+			*p = hv.ZeroThreshold
+		}
+		if p, ok := dest[8].(*float64); ok {
+			*p = hv.ZeroCount
+		}
+		if p, ok := dest[9].(*int32); ok {
+			*p = hv.PositiveOffset
+		}
+		if p, ok := dest[10].(*[]float64); ok {
+			*p = hv.PositiveBucketCounts
+		}
+		if p, ok := dest[11].(*int32); ok {
+			*p = hv.NegativeOffset
+		}
+		if p, ok := dest[12].(*[]float64); ok {
+			*p = hv.NegativeBucketCounts
+		}
+		if p, ok := dest[13].(*uint8); ok {
+			if s.Histogram != nil {
+				*p = 1
+			} else {
+				*p = 0
+			}
+		}
 	default:
-		return fmt.Errorf("fakeRows.Scan: want %d, %d or %d destinations, got %d",
-			logRowColumns, sampleColumns, wantHistogramDest, len(dest))
+		return fmt.Errorf("fakeRows.Scan: want %d, %d, %d or %d destinations, got %d",
+			logRowColumns, sampleColumns, wantHistogramDest, wantMixedDest, len(dest))
 	}
 	return nil
 }
@@ -271,6 +326,14 @@ var histogramProjectionColumns = []string{
 	"HistogramNegativeOffset", "HistogramNegativeBucketCounts",
 }
 
+// mixedProjectionColumns is histogramProjectionColumns plus the trailing
+// discriminator a Mixed VectorSetOr's fourteen-column projection carries
+// (cerberus issue #2330).
+var mixedProjectionColumns = append(
+	append([]string{}, histogramProjectionColumns...),
+	"_setop_is_histogram",
+)
+
 // TestRowsCursor_DecodesHistogramColumns pins the decode-side half of
 // issue #1926's shared prerequisite: a result set whose trailing column
 // matches histogramLastColumn is scanned as a 13-destination histogram
@@ -325,6 +388,73 @@ func TestRowsCursor_DecodesHistogramColumns(t *testing.T) {
 	}
 	if cursor.Next() {
 		t.Fatal("Next should return false after the single row")
+	}
+}
+
+// TestRowsCursor_DecodesMixedColumns pins the decode-side half of
+// cerberus issue #2330: a result set whose trailing column matches
+// mixedDiscriminatorColumn scans as a 14-destination mixed row, and the
+// discriminator — NOT the shape of the fixture data — decides whether
+// Sample.Histogram or Sample.Value is the real answer for each row. The
+// two rows below deliberately carry a NON-zero Value on the row whose
+// discriminator marks it histogram-shaped and a NON-zero HistogramValue
+// on the row marked float-shaped, so a cursor that read the wrong
+// column set (or ignored the discriminator and guessed off the data
+// present) would fail this test instead of merely losing coverage.
+func TestRowsCursor_DecodesMixedColumns(t *testing.T) {
+	t.Parallel()
+
+	ts := time.Date(2026, 8, 1, 0, 0, 0, 0, time.UTC)
+	hv := HistogramValue{
+		Count:                6,
+		Sum:                  42.5,
+		PositiveBucketCounts: []float64{1, 2, 3},
+		NegativeBucketCounts: []float64{},
+	}
+	rows := &fakeRows{
+		columns: mixedProjectionColumns,
+		samples: []Sample{
+			{
+				MetricName: "http_client_duration_exp_hist",
+				Labels:     map[string]string{"service": "web"},
+				Timestamp:  ts,
+				Value:      999, // the meaningless placeholder a histogram row carries
+				Histogram:  &hv,
+			},
+			{
+				MetricName: "",
+				Labels:     map[string]string{"service": "api"},
+				Timestamp:  ts,
+				Value:      0.5, // the real float quantile
+				Histogram:  nil,
+			},
+		},
+	}
+	cursor := &rowsCursor{rows: rows}
+
+	var got []Sample
+	for cursor.Next() {
+		got = append(got, cursor.Sample())
+	}
+	if err := cursor.Err(); err != nil {
+		t.Fatalf("Err: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("got %d samples, want 2", len(got))
+	}
+	if got[0].Histogram == nil {
+		t.Fatalf("row 0: Histogram is nil, want the decoded HistogramValue")
+	}
+	if !reflect.DeepEqual(*got[0].Histogram, hv) {
+		t.Errorf("row 0 Histogram:\n got  %+v\n want %+v", *got[0].Histogram, hv)
+	}
+	if got[1].Histogram != nil {
+		t.Errorf("row 1: Histogram = %+v, want nil — the discriminator marks this row "+
+			"float-shaped even though the fixture's placeholder HistogramValue is present "+
+			"in the underlying columns", got[1].Histogram)
+	}
+	if got[1].Value != 0.5 {
+		t.Errorf("row 1 Value: got %v, want 0.5 — the real float answer", got[1].Value)
 	}
 }
 

--- a/internal/chplan/row_shape.go
+++ b/internal/chplan/row_shape.go
@@ -122,6 +122,26 @@ const (
 	// SHAPE a node's own SELECT publishes, not which Go type built it, so
 	// this is still the correct answer here.
 	HistogramRowShape
+
+	// MixedRowShape is [VectorSetOp]'s answer when its Mixed field is
+	// set — internal/promql's lowerMixedExpHistogramSetOp builds one for
+	// `or` between a float-valued operand and a histogram-valued operand
+	// (cerberus issue #2330). The SELECT it publishes is the canonical
+	// quartet, the nine Histogram*Column outputs, AND a trailing
+	// discriminator column (unlike [HistogramRowShape]'s thirteen), so a
+	// generic forwarder that reads `Value` unconditionally — the same
+	// hazard [HistogramRowShape]'s doc comment describes — is just as
+	// wrong here: on a histogram-shaped ROW within this result, Value is
+	// still only the placeholder [HistogramProjection] always carries.
+	// [assertValueShapedInput] (internal/promql/histogram_shape_guard.go)
+	// panics on this shape for exactly that reason. Every consumer that
+	// builds a Mixed-shaped node keeps it at the query ROOT — see that
+	// lowering's own doc comment for why nesting one under another
+	// PromQL wrapper is deliberately left unrecognised (falls through to
+	// the pre-existing exp-histogram-selector rejection) rather than
+	// silently forwarding a column whose meaning depends on a per-row
+	// discriminator no generic consumer reads.
+	MixedRowShape
 )
 
 // String names the shape for test and error output. The names are the
@@ -135,6 +155,8 @@ func (s RowShape) String() string {
 		return "reduced-window"
 	case HistogramRowShape:
 		return "histogram"
+	case MixedRowShape:
+		return "mixed"
 	case SampleRowShape:
 		return "sample"
 	}
@@ -172,6 +194,9 @@ func RowShapeOf(n Node) RowShape {
 	case *VectorSetOp:
 		if v.Histogram {
 			return HistogramRowShape
+		}
+		if v.Mixed {
+			return MixedRowShape
 		}
 	case *NaryVectorSetOp:
 		if v.Histogram {

--- a/internal/chplan/row_shape_test.go
+++ b/internal/chplan/row_shape_test.go
@@ -133,6 +133,37 @@ func TestRowShapeOf_RangeWindowSplitsOnOuterRange(t *testing.T) {
 	}
 }
 
+// TestRowShapeOf_VectorSetOpFlags pins the two boolean flags
+// chplan.RowShapeOf reads off a *VectorSetOp directly, since
+// allNodeKinds() only exercises the zero-value instance (both flags
+// false, SampleRowShape — already covered by
+// TestRowShapeOf_ClassifiesEveryNodeKind). Histogram is #2324's
+// both-arms-histogram flag; Mixed is #2330's exactly-one-arm-histogram
+// sibling — the two are mutually exclusive in practice (chsql's
+// validateVectorSetOpCols rejects both set), but RowShapeOf itself
+// checks Histogram first, so this also pins that ordering doesn't
+// accidentally mask Mixed.
+func TestRowShapeOf_VectorSetOpFlags(t *testing.T) {
+	t.Parallel()
+
+	base := chplan.VectorSetOp{
+		Left: &chplan.Scan{Table: "otel_metrics_sum"}, Right: &chplan.Scan{Table: "otel_metrics_sum"},
+		Op: chplan.VectorSetOr,
+	}
+
+	histogram := base
+	histogram.Histogram = true
+	if got := chplan.RowShapeOf(&histogram); got != chplan.HistogramRowShape {
+		t.Errorf("RowShapeOf(VectorSetOp{Histogram: true}) = %s, want %s", got, chplan.HistogramRowShape)
+	}
+
+	mixed := base
+	mixed.Mixed = true
+	if got := chplan.RowShapeOf(&mixed); got != chplan.MixedRowShape {
+		t.Errorf("RowShapeOf(VectorSetOp{Mixed: true}) = %s, want %s", got, chplan.MixedRowShape)
+	}
+}
+
 // TestRowShapeString pins the names the failure messages above are written
 // against, including the answer for a value outside the declared set — a
 // forwarder reading a corrupt shape should say so rather than print an
@@ -140,7 +171,7 @@ func TestRowShapeOf_RangeWindowSplitsOnOuterRange(t *testing.T) {
 func TestRowShapeString(t *testing.T) {
 	t.Parallel()
 
-	const outsideDeclaredSet = chplan.HistogramRowShape + 1
+	const outsideDeclaredSet = chplan.MixedRowShape + 1
 
 	for _, tc := range []struct {
 		shape chplan.RowShape
@@ -150,6 +181,7 @@ func TestRowShapeString(t *testing.T) {
 		{chplan.GridWindowRowShape, "grid-window"},
 		{chplan.ReducedWindowRowShape, "reduced-window"},
 		{chplan.HistogramRowShape, "histogram"},
+		{chplan.MixedRowShape, "mixed"},
 		{outsideDeclaredSet, "unknown"},
 	} {
 		if got := tc.shape.String(); got != tc.want {

--- a/internal/chplan/vector_set_op.go
+++ b/internal/chplan/vector_set_op.go
@@ -66,6 +66,45 @@ type VectorSetOp struct {
 	// plumbing is needed here.
 	Histogram bool
 
+	// Mixed marks a VectorSetOr whose Left and Right disagree on value
+	// type -- exactly one is a [HistogramProjection] (or a nested
+	// histogram-shaped VectorSetOp) and the other is a plain
+	// [SampleRowShape] float vector (cerberus issue #2330, the
+	// mixed-type sibling of the Histogram flag above). Reference
+	// Prometheus's `or` never inspects value type, only labels, so a
+	// `Vector` it returns can freely hold both float and native-histogram
+	// `Sample`s at once -- cerberus answers that by widening BOTH arms to
+	// the same fourteen-column projection (the canonical quartet, the
+	// nine Histogram*Column outputs, and a trailing per-row
+	// discriminator) and letting the non-native side publish placeholder
+	// values for the columns its own shape doesn't have: the float arm's
+	// nine histogram columns are placeholders (mirroring
+	// histogramSampleValuePlaceholder's Value placeholder on the
+	// histogram side, just the other four-vs-nine way around), and the
+	// histogram arm's Value stays the placeholder [HistogramProjection]
+	// already carries. See internal/chsql/vector_set_op.go's
+	// emitMixedVectorSetOp for the SQL shape and
+	// internal/chclient/cursor.go's shapeSampleMixed for the decode side
+	// that reads the discriminator to decide, per row, whether
+	// Sample.Histogram or Sample.Value is the real answer.
+	//
+	// Mixed and Histogram are mutually exclusive: Histogram means BOTH
+	// arms are already histogram-shaped (no discriminator needed, no
+	// placeholders), Mixed means exactly one is. Only VectorSetOr
+	// supports Mixed today -- `and`/`unless` between a float-valued and a
+	// histogram-valued operand remains cerberus issue #2325, which this
+	// field does not attempt.
+	Mixed bool
+
+	// MixedHistogramOnLeft is meaningful only when Mixed is true: true
+	// when Left is the histogram-shaped arm and Right is the float arm,
+	// false when it's the other way around. `or`'s union keeps every
+	// Left row unconditionally and only the Right rows whose signature
+	// Left doesn't already have, so which side is which changes which
+	// arm's rows win a signature collision -- this flag preserves the
+	// query's own LHS/RHS order rather than normalising it away.
+	MixedHistogramOnLeft bool
+
 	MetricNameColumn string
 	AttributesColumn string
 	TimestampColumn  string
@@ -82,6 +121,9 @@ func (s *VectorSetOp) Equal(other Node) bool {
 		return false
 	}
 	if s.Op != o.Op || !s.Match.Equal(o.Match) || s.StepAligned != o.StepAligned || s.Histogram != o.Histogram {
+		return false
+	}
+	if s.Mixed != o.Mixed || s.MixedHistogramOnLeft != o.MixedHistogramOnLeft {
 		return false
 	}
 	if s.MetricNameColumn != o.MetricNameColumn ||

--- a/internal/chsql/vector_set_op.go
+++ b/internal/chsql/vector_set_op.go
@@ -15,6 +15,16 @@ import (
 const (
 	setOpSideCol    = "_setop_side"
 	setOpHasLeftCol = "_setop_has_left"
+	// setOpMixedIsHistogramCol is the trailing per-row discriminator a
+	// Mixed VectorSetOr's fourteen-column projection carries (cerberus
+	// issue #2330): 1 when the row came from the histogram-shaped arm
+	// (its nine Histogram*Column outputs are real, its Value is the
+	// [HistogramProjection] placeholder), 0 when it came from the
+	// float-shaped arm (the mirror image — Value is real, the nine
+	// histogram columns are placeholders). internal/chclient/cursor.go's
+	// shapeSampleMixed probes for this exact trailing alias, the same
+	// way shapeSampleHistogram probes for histogramLastColumn.
+	setOpMixedIsHistogramCol = "_setop_is_histogram"
 )
 
 // emitVectorSetOp renders a PromQL vector set operator (`and`, `or`,
@@ -68,6 +78,9 @@ const (
 func (e *emitter) emitVectorSetOp(s *chplan.VectorSetOp) error {
 	if err := e.validateVectorSetOpCols(s); err != nil {
 		return err
+	}
+	if s.Mixed {
+		return e.emitMixedVectorSetOp(s)
 	}
 
 	leftFrag, err := e.subqueryFrag(s.Left)
@@ -204,6 +217,149 @@ func (e *emitter) emitVectorSetOp(s *chplan.VectorSetOp) error {
 	return fmt.Errorf("%w: vector set op %q", ErrUnsupported, s.Op)
 }
 
+// emitMixedVectorSetOp renders a VectorSetOr whose two arms disagree on
+// value type — one is histogram-shaped, one is a plain float sample
+// (cerberus issue #2330; chplan.VectorSetOp.Mixed's doc comment has the
+// design). It is the identical single-pass left+anti-right shape
+// [emitVectorSetOp]'s VectorSetOr case renders — a side marker plus a
+// windowed "does a left row share this signature?" flag deciding which
+// right-arm rows survive — with two differences localised entirely to
+// the per-arm projection:
+//
+//  1. Each arm is canonicalised to FOURTEEN columns instead of four —
+//     the canonical quartet, the nine Histogram*Column outputs, and a
+//     trailing discriminator — via [mixedVectorSetOpArmFrag], instead of
+//     [vectorSetOpCanonicalArmFrag]. The histogram-shaped arm publishes
+//     its nine columns for real and 0/1 for the discriminator; the
+//     float-shaped arm publishes nine typed placeholders (matching the
+//     exact CH types histogramFloatFrag / histogramIndexFrag /
+//     histogramBucketsFrag pin, so the UNION ALL's positional type
+//     unification never hits NO_COMMON_TYPE) and the opposite
+//     discriminator value.
+//  2. The output column list is [mixedVectorSetOpOutputCols], not
+//     [vectorSetOpOutputCols] — it carries the discriminator all the way
+//     to the final SELECT (unlike `_setop_side` / `_setop_has_left`,
+//     which are internal bookkeeping the outer SELECT drops), because
+//     internal/chclient's cursor needs it on every row of the actual
+//     result set to decide which of Sample.Value / Sample.Histogram is
+//     the real answer.
+func (e *emitter) emitMixedVectorSetOp(s *chplan.VectorSetOp) error {
+	leftFrag, err := e.subqueryFrag(s.Left)
+	if err != nil {
+		return err
+	}
+	rightFrag, err := e.subqueryFrag(s.Right)
+	if err != nil {
+		return err
+	}
+
+	leftArm := mixedVectorSetOpArmFrag(s, s.Left, leftFrag, s.MixedHistogramOnLeft)
+	rightArm := mixedVectorSetOpArmFrag(s, s.Right, rightFrag, !s.MixedHistogramOnLeft)
+
+	sideArmL := mixedVectorSetOpSideArmFrag(s, leftArm, 0)
+	sideArmR := mixedVectorSetOpSideArmFrag(s, rightArm, 1)
+	windowed := NewQuery().
+		Select(append(
+			mixedVectorSetOpOutputCols(s),
+			Col(setOpSideCol),
+			As(
+				Window(
+					Call("max", Eq(Col(setOpSideCol), InlineLit(0))),
+					setOpMatchKeyFrags(s.Match, s.AttributesColumn, s.TimestampColumn, s.StepAligned),
+					nil,
+				),
+				setOpHasLeftCol,
+			),
+		)...).
+		From(Paren(UnionAll(sideArmL, sideArmR)))
+	outer := NewQuery().
+		Select(mixedVectorSetOpOutputCols(s)...).
+		From(windowed.Frag()).
+		Where(Or(
+			Eq(Col(setOpSideCol), InlineLit(0)),
+			Eq(Col(setOpHasLeftCol), InlineLit(0)),
+		))
+	return e.emitSelect(outer)
+}
+
+// mixedVectorSetOpOutputCols returns the fourteen-column explicit
+// projection list a Mixed VectorSetOr uses for both its per-arm and its
+// outer SELECTs: the canonical quartet, the nine Histogram*Column
+// outputs, and the trailing [setOpMixedIsHistogramCol] discriminator.
+func mixedVectorSetOpOutputCols(s *chplan.VectorSetOp) []Frag {
+	return append(
+		append(vectorSetOpOutputCols(s), vectorSetOpHistogramCols()...),
+		Col(setOpMixedIsHistogramCol),
+	)
+}
+
+// mixedVectorSetOpArmFrag canonicalises one arm of a Mixed VectorSetOr to
+// the shared fourteen-column shape [mixedVectorSetOpOutputCols] names.
+// isHistogramArm selects which half is real and which is a placeholder:
+// a histogram-shaped arm publishes its own nine structural columns for
+// real and forwards Value unchanged (it is already the
+// [HistogramProjection] placeholder, nothing more to do); a float-shaped
+// arm publishes Value for real and nine typed placeholders standing in
+// for the histogram columns it doesn't have.
+func mixedVectorSetOpArmFrag(s *chplan.VectorSetOp, arm chplan.Node, armFrag Frag, isHistogramArm bool) Frag {
+	cols := vectorSetOpCanonicalQuartetFrags(s, arm)
+	discriminator := InlineLit(0)
+	if isHistogramArm {
+		cols = append(cols, vectorSetOpHistogramCols()...)
+		discriminator = InlineLit(1)
+	} else {
+		cols = append(cols, mixedVectorSetOpHistogramPlaceholderCols()...)
+	}
+	cols = append(cols, As(discriminator, setOpMixedIsHistogramCol))
+	inner := NewQuery().
+		Select(cols...).
+		From(armFrag)
+	return inner.Frag()
+}
+
+// mixedVectorSetOpHistogramPlaceholderCols returns the nine
+// Histogram*Column placeholders a Mixed VectorSetOr's float-shaped arm
+// projects, typed to match [histogramFloatFrag] / [histogramIndexFrag] /
+// [histogramBucketsFrag] exactly — the same Float64 / Int32 /
+// Array(Float64) triple [vectorSetOpHistogramCols] forwards for real
+// from the histogram-shaped arm — so the UNION ALL's positional column
+// unification sees identical types on both arms instead of failing with
+// NO_COMMON_TYPE. The discriminator (appended by the caller, not here)
+// is what marks these unread on decode, mirroring
+// histogramSampleValuePlaceholder's identical convention for the
+// histogram-shaped arm's own placeholder Value.
+func mixedVectorSetOpHistogramPlaceholderCols() []Frag {
+	zeroFloat := Call("toFloat64", InlineLit(0))
+	zeroInt := Call("toInt32", InlineLit(0))
+	emptyBuckets := Call("emptyArrayFloat64")
+	return []Frag{
+		As(zeroFloat, chplan.HistogramCountColumn),
+		As(zeroFloat, chplan.HistogramSumColumn),
+		As(zeroInt, chplan.HistogramScaleColumn),
+		As(zeroFloat, chplan.HistogramZeroThresholdColumn),
+		As(zeroFloat, chplan.HistogramZeroCountColumn),
+		As(zeroInt, chplan.HistogramPositiveOffsetColumn),
+		As(emptyBuckets, chplan.HistogramPositiveBucketCountsColumn),
+		As(zeroInt, chplan.HistogramNegativeOffsetColumn),
+		As(emptyBuckets, chplan.HistogramNegativeBucketCountsColumn),
+	}
+}
+
+// mixedVectorSetOpSideArmFrag is [vectorSetOpSideArmFrag]'s Mixed
+// sibling: it wraps an already fourteen-column-canonicalised arm Frag in
+// a `SELECT <mixed cols>, <side> AS _setop_side FROM (<arm>)` so the
+// VectorSetOr single-pass UNION ALL carries the side marker as a 15th
+// column, the same role it plays in the symmetric emission.
+func mixedVectorSetOpSideArmFrag(s *chplan.VectorSetOp, armFrag Frag, side int) Frag {
+	q := NewQuery().
+		Select(append(
+			mixedVectorSetOpOutputCols(s),
+			As(InlineLit(side), setOpSideCol),
+		)...).
+		From(armFrag)
+	return Paren(q.Frag())
+}
+
 // vectorSetOpCanonicalArmFrag returns a Frag rendering the per-arm
 // canonical 4-column projection used inside the VectorSetOp UNION ALL /
 // IN-subquery shapes. The arm's chplan node is inspected to decide
@@ -272,6 +428,25 @@ func (e *emitter) emitVectorSetOp(s *chplan.VectorSetOp) error {
 // derived emitter still passes Attributes + the schema-named
 // ValueColumn through).
 func vectorSetOpCanonicalArmFrag(s *chplan.VectorSetOp, arm chplan.Node, armFrag Frag) Frag {
+	cols := vectorSetOpCanonicalQuartetFrags(s, arm)
+	if s.Histogram {
+		cols = append(cols, vectorSetOpHistogramCols()...)
+	}
+	inner := NewQuery().
+		Select(cols...).
+		From(armFrag)
+	return inner.Frag()
+}
+
+// vectorSetOpCanonicalQuartetFrags returns the four canonical-shape Frags
+// (MetricName, Attributes, TimeUnix, Value) for arm, synthesising
+// whichever of MetricName / TimeUnix arm's own SELECT doesn't expose —
+// see [vectorSetOpCanonicalArmFrag]'s doc comment for the three
+// resolution shapes this covers. Split out so
+// [mixedVectorSetOpArmFrag] (cerberus issue #2330) can reuse the exact
+// same derived/matrix-shape resolution the symmetric Histogram /
+// float-only paths already use, instead of re-deriving it.
+func vectorSetOpCanonicalQuartetFrags(s *chplan.VectorSetOp, arm chplan.Node) []Frag {
 	derived := chplan.IsDerivedShape(arm, vectorSetOpSampleColumns(s))
 	armTsCol, matrix := vectorSetOpArmTimestampCol(arm, s)
 
@@ -292,19 +467,12 @@ func vectorSetOpCanonicalArmFrag(s *chplan.VectorSetOp, arm chplan.Node, armFrag
 		timeFrag = Col(s.TimestampColumn)
 	}
 
-	cols := []Frag{
+	return []Frag{
 		metricNameFrag,
 		Col(s.AttributesColumn),
 		timeFrag,
 		Col(s.ValueColumn),
 	}
-	if s.Histogram {
-		cols = append(cols, vectorSetOpHistogramCols()...)
-	}
-	inner := NewQuery().
-		Select(cols...).
-		From(armFrag)
-	return inner.Frag()
 }
 
 // vectorSetOpHistogramCols returns the nine chplan.Histogram*Column
@@ -467,6 +635,10 @@ func (e *emitter) validateVectorSetOpCols(s *chplan.VectorSetOp) error {
 		return fmt.Errorf("%w: VectorSetOp.TimestampColumn unset", ErrUnsupported)
 	case s.ValueColumn == "":
 		return fmt.Errorf("%w: VectorSetOp.ValueColumn unset", ErrUnsupported)
+	case s.Mixed && s.Histogram:
+		return fmt.Errorf("%w: VectorSetOp.Mixed and .Histogram are mutually exclusive", ErrUnsupported)
+	case s.Mixed && s.Op != chplan.VectorSetOr:
+		return fmt.Errorf("%w: VectorSetOp.Mixed is only supported for %q, got %q", ErrUnsupported, chplan.VectorSetOr, s.Op)
 	}
 	return nil
 }

--- a/internal/optimizer/flatten_vector_set_op.go
+++ b/internal/optimizer/flatten_vector_set_op.go
@@ -53,6 +53,23 @@ func (FlattenVectorSetOp) Apply(n chplan.Node) (chplan.Node, bool) {
 	if !flattenableVectorSetOp(binary.Op) {
 		return n, false
 	}
+	// A Mixed VectorSetOr (cerberus issue #2330) carries its
+	// asymmetric per-arm shape — which side is histogram-valued — on
+	// fields chplan.NaryVectorSetOp has no room for (it only threads
+	// Histogram, the symmetric both-arms case, through). Rebuilding one
+	// as an N-ary node would silently drop MixedHistogramOnLeft, which
+	// downgrades chplan.RowShapeOf's answer from MixedRowShape to the
+	// default SampleRowShape — exactly the silent-placeholder-Value
+	// hazard [assertValueShapedInput] exists to catch, except
+	// [wrapWithSampleProjection] has no guard of its own and would
+	// happily wrap the flattened node's Value column, discarding every
+	// histogram-shaped row's real payload. A Mixed node never actually
+	// chains today (mixedExpHistogramSetOp only matches a bare two-arm
+	// BinaryExpr at the query root — see its own doc comment), so
+	// skipping it here costs nothing: there is no chain to linearise.
+	if binary.Mixed {
+		return n, false
+	}
 
 	// Gather the left-leaning chain's arms in left-to-right source
 	// order. The left child is absorbed when it's a same-shaped binary

--- a/internal/optimizer/flatten_vector_set_op_test.go
+++ b/internal/optimizer/flatten_vector_set_op_test.go
@@ -246,3 +246,35 @@ func TestFlattenVectorSetOp_SingleBinaryFlattensToTwoArms(t *testing.T) {
 		t.Fatalf("Arms = %d, want 2", len(nary.Arms))
 	}
 }
+
+// TestFlattenVectorSetOp_MixedValueTypeSkipsFlattening pins cerberus
+// issue #2330's structural guarantee: unlike the plain two-arm case
+// TestFlattenVectorSetOp_SingleBinaryFlattensToTwoArms just above (which
+// DOES flatten to a NaryVectorSetOp even with no chain to linearise),
+// a VectorSetOp whose Mixed flag is set must be left as a binary node.
+// chplan.NaryVectorSetOp has no MixedHistogramOnLeft field to carry the
+// asymmetric per-arm shape, so rebuilding one here would silently
+// downgrade chplan.RowShapeOf's answer from MixedRowShape to the default
+// SampleRowShape — the exact silent-placeholder-Value hazard this rule's
+// own Mixed guard (see its doc comment) exists to avoid.
+func TestFlattenVectorSetOp_MixedValueTypeSkipsFlattening(t *testing.T) {
+	t.Parallel()
+	mk := setOpCols("MetricName", "Attributes", "TimeUnix", "Value")
+	in := mk(chplan.VectorSetOr, tableScan("float"), tableScan("hist"))
+	in.Mixed = true
+	in.MixedHistogramOnLeft = false
+
+	out := optimizer.New(optimizer.FlattenVectorSetOp{}).Run(context.Background(), in)
+
+	got, ok := out.(*chplan.VectorSetOp)
+	if !ok {
+		t.Fatalf("expected the node to stay *chplan.VectorSetOp, got %T", out)
+	}
+	if !got.Equal(in) {
+		t.Errorf("Mixed VectorSetOp was rewritten: got %#v, want it unchanged", got)
+	}
+	if chplan.RowShapeOf(out) != chplan.MixedRowShape {
+		t.Errorf("RowShapeOf(out) = %s, want %s — flattening must not downgrade the shape",
+			chplan.RowShapeOf(out), chplan.MixedRowShape)
+	}
+}

--- a/internal/promql/histogram_native_mixed_or.go
+++ b/internal/promql/histogram_native_mixed_or.go
@@ -1,0 +1,149 @@
+package promql
+
+import (
+	"fmt"
+
+	"github.com/prometheus/prometheus/promql/parser"
+
+	"github.com/tsouza/cerberus/internal/chplan"
+	"github.com/tsouza/cerberus/internal/schema"
+)
+
+// histogram_native_mixed_or.go lowers PromQL's `or` between a
+// float-VALUED operand and a histogram-VALUED operand into a genuinely
+// mixed-type result (cerberus issue #2330).
+//
+// Reference Prometheus never rejects this: a `Vector` is a slice of
+// `Sample`, and `Sample` itself carries either a float `F` or a native
+// histogram `H` — nothing stops one evaluation's result vector holding
+// both at once, which is exactly what `or`'s union produces when its two
+// arms disagree on value type. `histogram_native_set_op.go`'s
+// [expHistogramSetOp] already answers the case where BOTH arms are
+// histogram-valued (cerberus issue #2324); this file is its
+// exactly-one-side sibling.
+//
+// Why this is a genuinely different mechanism from #2324's, not a
+// parameter on it: `and`/`unless` always forward one side's rows
+// verbatim, so their result is homogeneously that side's own value type
+// regardless of what the OTHER side's value type is (issue #2325 covers
+// teaching them to accept a differently-typed other side; this file does
+// not touch `and`/`unless` at all). `or`'s result is different in kind —
+// every LHS row PLUS every RHS row absent from LHS — so when the two
+// arms disagree on value type the union genuinely needs to carry both
+// shapes at once. Cerberus answers that the same way the wire format
+// already does (a Prometheus API result item's `value` and `histogram`
+// keys are mutually exclusive per item): both arms are widened to the
+// same fourteen-column projection — the canonical quartet, the nine
+// Histogram*Column outputs, and a trailing per-row discriminator — with
+// the arm that doesn't natively have one half of that shape publishing
+// placeholders for it (see [chplan.VectorSetOp.Mixed]'s doc comment).
+// [chplan.RowShapeOf] answers [chplan.MixedRowShape] for the result;
+// internal/chsql/vector_set_op.go's emitMixedVectorSetOp is the SQL
+// shape and internal/chclient/cursor.go's shapeSampleMixed is the decode
+// side that reads the discriminator per row.
+//
+// Deliberately root-only. [mixedExpHistogramSetOp] is registered in
+// [lowerRoot] directly — NOT inside [lowerExpHistogramValuedShape]'s
+// recursive dispatch table the way [expHistogramSetOp] is — so a Mixed
+// node is only ever the WHOLE query's plan, never composed under a
+// further `sum`/`avg`/label-rewrite/arithmetic wrapper. That is a
+// deliberate scope line, not an oversight: every generic forwarder
+// (projectValueOverInner, projectAttributesOverInner) reads `Value`
+// unconditionally, which is only a placeholder on a Mixed result's
+// histogram-shaped rows — see [assertValueShapedInput]
+// (histogram_shape_guard.go), which panics if a Mixed node ever DOES
+// reach one of those forwarders. Keeping this recognizer root-only is
+// what keeps that an impossible state instead of a live hazard: `sum(a
+// or b)` / `abs(a or b)` for a mixed `a or b` still fall through to
+// [expHistogramSelectorRouting]'s pre-existing rejection, exactly as
+// they did before this file existed. Composing a Mixed result under a
+// further PromQL wrapper is real follow-on work, not attempted here.
+func mixedExpHistogramSetOp(expr parser.Expr, s schema.Metrics, ctx lowerCtx) (*parser.BinaryExpr, bool) {
+	if s.ExpHistogramTable == "" || ctx.metadataFullRange {
+		return nil, false
+	}
+	b, isBin := unwrapBinaryExpr(expr)
+	if !isBin || b.Op != parser.LOR {
+		return nil, false
+	}
+	lhsHist := isExpHistogramValuedShape(b.LHS, s, ctx)
+	rhsHist := isExpHistogramValuedShape(b.RHS, s, ctx)
+	if lhsHist == rhsHist {
+		// Both histogram-valued is [expHistogramSetOp]'s shape; neither
+		// histogram-valued is the plain float [lowerVectorSetOp] path.
+		// Either way this recognizer has nothing to add.
+		return nil, false
+	}
+	return b, true
+}
+
+// lowerMixedExpHistogramSetOp lowers the shape [mixedExpHistogramSetOp]
+// recognised: the histogram-valued side defers to its own existing
+// histogram-valued lowering (via [lowerExpHistogramSetOpOperand], the
+// same helper #2324's both-histogram path uses, so a nested set-op or
+// sum/avg on that side composes identically); the float-valued side
+// defers to the ordinary [lower]. Both are then widened to the shared
+// fourteen-column Mixed contract by the chsql emitter — this function
+// only builds the [chplan.VectorSetOp] naming which side is which.
+func lowerMixedExpHistogramSetOp(b *parser.BinaryExpr, s schema.Metrics, ctx lowerCtx) (chplan.Node, error) {
+	if b.ReturnBool {
+		return nil, fmt.Errorf("promql: 'bool' modifier is only allowed on comparison binary ops")
+	}
+
+	histOnLeft := isExpHistogramValuedShape(b.LHS, s, ctx)
+	histExpr, floatExpr := b.LHS, b.RHS
+	if !histOnLeft {
+		histExpr, floatExpr = b.RHS, b.LHS
+	}
+
+	histNode, err := lowerExpHistogramSetOpOperand(histExpr, s, ctx)
+	if err != nil {
+		return nil, err
+	}
+	floatNode, err := lower(floatExpr, s, ctx)
+	if err != nil {
+		return nil, err
+	}
+	// The float side must publish the plain canonical quartet: a
+	// windowed / already-derived float shape (a matrix rate(), a
+	// reduced instant aggregation) needs its OWN reconciliation against
+	// the histogram side's row shape that this file does not attempt —
+	// scoped out deliberately rather than silently mis-projected. Every
+	// shape this rejects today was ALREADY rejected before this file
+	// existed (the histogram side hit expHistogramSelectorRouting), so
+	// this is not a regression, only a narrower acceptance than the
+	// eventual general case.
+	if shape := chplan.RowShapeOf(floatNode); shape != chplan.SampleRowShape {
+		return nil, fmt.Errorf(
+			"promql: 'or' between a float-valued and a histogram-valued operand only "+
+				"supports a plain (non-windowed) float side today; got a %s-shaped float "+
+				"operand, which cerberus issue #2330 does not yet cover",
+			shape,
+		)
+	}
+
+	match := chplan.VectorMatch{}
+	if b.VectorMatching != nil {
+		match.Labels = append([]string(nil), b.VectorMatching.MatchingLabels...)
+		match.On = b.VectorMatching.On
+	}
+
+	left, right := floatNode, histNode
+	if histOnLeft {
+		left, right = histNode, floatNode
+	}
+
+	return &chplan.VectorSetOp{
+		Left:                 left,
+		Right:                right,
+		Op:                   chplan.VectorSetOr,
+		Match:                match,
+		StepAligned:          ctx.step > 0,
+		Mixed:                true,
+		MixedHistogramOnLeft: histOnLeft,
+		MetricNameColumn:     s.MetricNameColumn,
+		AttributesColumn:     s.AttributesColumn,
+		TimestampColumn:      s.TimestampColumn,
+		ValueColumn:          s.ValueColumn,
+	}, nil
+}

--- a/internal/promql/histogram_native_mixed_or_test.go
+++ b/internal/promql/histogram_native_mixed_or_test.go
@@ -1,0 +1,135 @@
+package promql_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/prometheus/prometheus/promql/parser"
+
+	"github.com/tsouza/cerberus/internal/chplan"
+	"github.com/tsouza/cerberus/internal/promql"
+	"github.com/tsouza/cerberus/internal/schema"
+)
+
+// TestLower_ExpHistogram_MixedSetOpOr pins cerberus issue #2330: `or`
+// between a float-valued operand (histogram_quantile's output) and a
+// raw histogram-valued selector lowers successfully — in BOTH source
+// orders — to a *chplan.VectorSetOp whose Mixed flag is set and whose
+// MixedHistogramOnLeft field names which side is which.
+func TestLower_ExpHistogram_MixedSetOpOr(t *testing.T) {
+	t.Parallel()
+
+	s := schema.DefaultOTelMetrics()
+	p := parser.NewParser(parser.Options{EnableExperimentalFunctions: true})
+	at := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+
+	cases := []struct {
+		name          string
+		query         string
+		histogramLeft bool
+		leftIsFloat   bool
+	}{
+		{
+			name:          "float left",
+			query:         `histogram_quantile(0.5, latency_exp_hist) or latency_exp_hist`,
+			histogramLeft: false,
+			leftIsFloat:   true,
+		},
+		{
+			name:          "histogram left",
+			query:         `latency_exp_hist or histogram_quantile(0.5, latency_exp_hist)`,
+			histogramLeft: true,
+			leftIsFloat:   false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			expr, err := p.ParseExpr(tc.query)
+			if err != nil {
+				t.Fatalf("ParseExpr(%q): %v", tc.query, err)
+			}
+			plan, err := promql.LowerAt(context.Background(), expr, s, at, at)
+			if err != nil {
+				t.Fatalf("LowerAt(%q): unexpected error: %v", tc.query, err)
+			}
+			if shape := chplan.RowShapeOf(plan); shape != chplan.MixedRowShape {
+				t.Fatalf("lower(%q): plan root publishes %s, want %s", tc.query, shape, chplan.MixedRowShape)
+			}
+			setOp, ok := plan.(*chplan.VectorSetOp)
+			if !ok {
+				t.Fatalf("lower(%q): plan root is %T, want *chplan.VectorSetOp", tc.query, plan)
+			}
+			if !setOp.Mixed {
+				t.Fatalf("lower(%q): VectorSetOp.Mixed = false, want true", tc.query)
+			}
+			if setOp.Histogram {
+				t.Fatalf("lower(%q): VectorSetOp.Histogram = true, want false (Mixed and Histogram are mutually exclusive)", tc.query)
+			}
+			if setOp.MixedHistogramOnLeft != tc.histogramLeft {
+				t.Fatalf("lower(%q): MixedHistogramOnLeft = %v, want %v", tc.query, setOp.MixedHistogramOnLeft, tc.histogramLeft)
+			}
+			leftIsHistogramProjection := false
+			if _, ok := setOp.Left.(*chplan.HistogramProjection); ok {
+				leftIsHistogramProjection = true
+			}
+			if leftIsHistogramProjection == tc.leftIsFloat {
+				t.Fatalf("lower(%q): Left is %T, histogramLeft=%v mismatch", tc.query, setOp.Left, tc.histogramLeft)
+			}
+		})
+	}
+}
+
+// TestLower_ExpHistogram_MixedSetOpOr_WindowedFloatSideRejects pins the
+// deliberate scope line lowerMixedExpHistogramSetOp draws: a float side
+// that is itself a windowed / derived shape (here, a range-vector
+// `rate()` over a float metric) is not yet reconciled against the
+// histogram side's row shape, so the query is rejected with a clear
+// error rather than silently mis-projected. This is not a regression —
+// the histogram side of this exact query was ALREADY rejected before
+// this file existed (expHistogramSelectorRouting's catch-all).
+func TestLower_ExpHistogram_MixedSetOpOr_WindowedFloatSideRejects(t *testing.T) {
+	t.Parallel()
+
+	s := schema.DefaultOTelMetrics()
+	p := parser.NewParser(parser.Options{EnableExperimentalFunctions: true})
+	at := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+
+	query := `rate(up[5m]) or latency_exp_hist`
+	expr, err := p.ParseExpr(query)
+	if err != nil {
+		t.Fatalf("ParseExpr(%q): %v", query, err)
+	}
+	if _, err := promql.LowerAt(context.Background(), expr, s, at, at); err == nil {
+		t.Fatalf("lower(%q): expected an error, got none", query)
+	}
+}
+
+// TestLower_ExpHistogram_MixedSetOpOr_AndUnlessStillReject pins that
+// `and` / `unless` between a float-valued and a histogram-valued
+// operand are OUT OF SCOPE for this file (cerberus issue #2325, not yet
+// implemented) — mixedExpHistogramSetOp only recognises `or`, so these
+// still fall through to the pre-existing expHistogramSelectorRouting
+// rejection unchanged.
+func TestLower_ExpHistogram_MixedSetOpOr_AndUnlessStillReject(t *testing.T) {
+	t.Parallel()
+
+	s := schema.DefaultOTelMetrics()
+	p := parser.NewParser(parser.Options{EnableExperimentalFunctions: true})
+	at := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+
+	for _, query := range []string{
+		`histogram_quantile(0.5, latency_exp_hist) and latency_exp_hist`,
+		`histogram_quantile(0.5, latency_exp_hist) unless latency_exp_hist`,
+	} {
+		expr, err := p.ParseExpr(query)
+		if err != nil {
+			t.Fatalf("ParseExpr(%q): %v", query, err)
+		}
+		if _, err := promql.LowerAt(context.Background(), expr, s, at, at); err == nil {
+			t.Fatalf("lower(%q): expected an error, got none", query)
+		}
+	}
+}

--- a/internal/promql/histogram_shape_guard.go
+++ b/internal/promql/histogram_shape_guard.go
@@ -52,24 +52,49 @@ import (
 // shared recognizer set above, or a dedicated lowering of its own — the
 // first test that exercises it dies with a message naming the forwarder and
 // the fix, instead of quietly returning zeros.
+//
+// [chplan.MixedRowShape] (cerberus issue #2330, histogram_native_mixed_or.go)
+// earns the identical structural guarantee the same way: its lowering
+// (lowerMixedExpHistogramSetOp) is registered only at the query ROOT, never
+// inside [lowerExpHistogramValuedShape]'s recursive dispatch table, so
+// nothing composes a further wrapper around a Mixed node — a query that
+// tries (`abs(a or b)`, `sum(a or b)` for a mixed `a`/`b`) keeps falling
+// through to [expHistogramSelectorRouting]'s existing rejection, exactly as
+// it did before this file learned the Mixed shape.
 
 // assertValueShapedInput panics when inner publishes
-// [chplan.HistogramRowShape], the one shape whose `Value` column is a
-// placeholder rather than the sample's actual magnitude. forwarder names
-// the calling helper so the panic points at the projection that needs
-// teaching. See this file's comment for why the state is unreachable and
-// why an unreachable state is still worth asserting.
+// [chplan.HistogramRowShape] or [chplan.MixedRowShape] — the two shapes
+// whose `Value` column is a placeholder on at least some rows rather than
+// every row's actual magnitude. forwarder names the calling helper so the
+// panic points at the projection that needs teaching. See this file's
+// comment for why the state is unreachable and why an unreachable state is
+// still worth asserting.
+//
+// MixedRowShape (cerberus issue #2330) widens the same hazard rather than
+// sidestepping it: a [chplan.VectorSetOp] with Mixed set publishes Value
+// for every row, but on the rows whose discriminator marks them
+// histogram-shaped that Value is the identical
+// histogramSampleValuePlaceholder a pure [chplan.HistogramProjection]
+// carries. internal/promql's lowerMixedExpHistogramSetOp only ever builds
+// a Mixed node at the query ROOT (see that function's doc comment for
+// why), so — like the pure-histogram case — no generic forwarder should
+// ever actually receive one; this assertion is the same "impossible state,
+// asserted anyway" contract as the HistogramRowShape case below.
 func assertValueShapedInput(inner chplan.Node, forwarder string) {
-	if chplan.RowShapeOf(inner) != chplan.HistogramRowShape {
+	shape := chplan.RowShapeOf(inner)
+	if shape != chplan.HistogramRowShape && shape != chplan.MixedRowShape {
 		return
 	}
 	panic(fmt.Sprintf(
 		"promql: %s received a %s-shaped input: its projection forwards %q, "+
-			"which a chplan.HistogramProjection publishes only as a placeholder "+
-			"alongside the nine Histogram*Column outputs. Projecting it would "+
-			"answer 0 and drop the histogram. Either route this node through the "+
-			"shared histogram-valued recognizer set (see this file's doc comment) "+
-			"instead of %s, or teach %s the histogram shape directly.",
-		forwarder, chplan.HistogramRowShape, "Value", forwarder, forwarder,
+			"which is only a placeholder on at least some rows rather than every "+
+			"row's actual magnitude (a chplan.HistogramProjection publishes it "+
+			"alongside the nine Histogram*Column outputs; a Mixed chplan.VectorSetOp "+
+			"publishes it as the placeholder on its histogram-shaped rows only). "+
+			"Projecting it would answer 0 and drop the histogram on those rows. "+
+			"Either route this node through the shared histogram-valued recognizer "+
+			"set (see this file's doc comment) instead of %s, or teach %s the "+
+			"%s shape directly.",
+		forwarder, shape, "Value", forwarder, forwarder, shape,
 	))
 }

--- a/internal/promql/lower.go
+++ b/internal/promql/lower.go
@@ -230,6 +230,14 @@ func LowerMetadataRange(ctx context.Context, expr parser.Expr, s schema.Metrics,
 // because at most one operand is histogram-valued — so ordering it last
 // cannot shadow either.
 //
+// `or` between a float-valued operand and a histogram-valued operand
+// (cerberus issue #2330) is the exactly-one-side sibling of that shape,
+// recognised by [mixedExpHistogramSetOp] (histogram_native_mixed_or.go)
+// — but registered as its OWN direct dispatch just below, not inside
+// [lowerExpHistogramValuedShape]: unlike the both-histogram case, its
+// result does NOT compose (see that recognizer's own doc comment for
+// why), so it deliberately does not get the same recursive reach.
+//
 // Metadata lowering ([LowerMetadataRange]) deliberately does NOT route
 // through here: it enumerates series and labels rather than evaluating an
 // expression, consumes no Value column, and already has its own
@@ -240,6 +248,16 @@ func lowerRoot(expr parser.Expr, s schema.Metrics, ctx lowerCtx) (chplan.Node, e
 	}
 	if plan, ok, err := lowerExpHistogramValuedShape(expr, s, ctx); ok {
 		return plan, err
+	}
+	// `or` between a float-valued operand and a histogram-valued operand
+	// (cerberus issue #2330) — the exactly-one-side sibling of
+	// [expHistogramSetOp]'s both-sides-histogram case just above.
+	// Deliberately checked only here at the root; see
+	// [mixedExpHistogramSetOp]'s doc comment for why it must never be
+	// registered inside [lowerExpHistogramValuedShape]'s recursive
+	// dispatch table.
+	if b, ok := mixedExpHistogramSetOp(expr, s, ctx); ok {
+		return lowerMixedExpHistogramSetOp(b, s, ctx)
 	}
 	if shape, ok := overTimeOverExpHistogram(expr, s, ctx); ok {
 		return lowerExpHistogramOverTime(shape, s, ctx)

--- a/test/perf/cardinality-baseline/promql/exp_histogram_set_op_or_mixed_float_left.json
+++ b/test/perf/cardinality-baseline/promql/exp_histogram_set_op_or_mixed_float_left.json
@@ -1,0 +1,11 @@
+{
+  "fixture": "promql/exp_histogram_set_op_or_mixed_float_left",
+  "fan_factor": 1,
+  "scan_rows": 2,
+  "peak_intermediate": 2,
+  "has_cross_join": false,
+  "has_array_join": false,
+  "has_recursive_cte": false,
+  "max_recursion_depth": 0,
+  "uncountable_levels": 0
+}

--- a/test/perf/cardinality-baseline/promql/exp_histogram_set_op_or_mixed_histogram_left.json
+++ b/test/perf/cardinality-baseline/promql/exp_histogram_set_op_or_mixed_histogram_left.json
@@ -1,0 +1,11 @@
+{
+  "fixture": "promql/exp_histogram_set_op_or_mixed_histogram_left",
+  "fan_factor": 1,
+  "scan_rows": 2,
+  "peak_intermediate": 2,
+  "has_cross_join": false,
+  "has_array_join": false,
+  "has_recursive_cte": false,
+  "max_recursion_depth": 0,
+  "uncountable_levels": 0
+}

--- a/test/perf/solver-decision-baseline/exp_histogram_set_op_or_mixed_float_left/fanout.json
+++ b/test/perf/solver-decision-baseline/exp_histogram_set_op_or_mixed_float_left/fanout.json
@@ -1,0 +1,11 @@
+{
+  "query": "exp_histogram_set_op_or_mixed_float_left/fanout",
+  "lowering": "fanout",
+  "routed": false,
+  "k": 0,
+  "reason": "not-sliceable",
+  "n_anchors": 241,
+  "fanout": 20,
+  "cumulative_d": "10m0s",
+  "outer_range": "1h0m0s"
+}

--- a/test/perf/solver-decision-baseline/exp_histogram_set_op_or_mixed_float_left/native.json
+++ b/test/perf/solver-decision-baseline/exp_histogram_set_op_or_mixed_float_left/native.json
@@ -1,0 +1,11 @@
+{
+  "query": "exp_histogram_set_op_or_mixed_float_left/native",
+  "lowering": "native",
+  "routed": false,
+  "k": 0,
+  "reason": "not-sliceable",
+  "n_anchors": 241,
+  "fanout": 20,
+  "cumulative_d": "10m0s",
+  "outer_range": "1h0m0s"
+}

--- a/test/perf/solver-decision-baseline/exp_histogram_set_op_or_mixed_histogram_left/fanout.json
+++ b/test/perf/solver-decision-baseline/exp_histogram_set_op_or_mixed_histogram_left/fanout.json
@@ -1,0 +1,11 @@
+{
+  "query": "exp_histogram_set_op_or_mixed_histogram_left/fanout",
+  "lowering": "fanout",
+  "routed": false,
+  "k": 0,
+  "reason": "not-sliceable",
+  "n_anchors": 241,
+  "fanout": 20,
+  "cumulative_d": "10m0s",
+  "outer_range": "1h0m0s"
+}

--- a/test/perf/solver-decision-baseline/exp_histogram_set_op_or_mixed_histogram_left/native.json
+++ b/test/perf/solver-decision-baseline/exp_histogram_set_op_or_mixed_histogram_left/native.json
@@ -1,0 +1,11 @@
+{
+  "query": "exp_histogram_set_op_or_mixed_histogram_left/native",
+  "lowering": "native",
+  "routed": false,
+  "k": 0,
+  "reason": "not-sliceable",
+  "n_anchors": 241,
+  "fanout": 20,
+  "cumulative_d": "10m0s",
+  "outer_range": "1h0m0s"
+}

--- a/test/regression/parity-enrolment-baselines/promql/baseline.txt
+++ b/test/regression/parity-enrolment-baselines/promql/baseline.txt
@@ -169,6 +169,8 @@ exp_histogram_scalar_mul_bare.txtar
 exp_histogram_scalar_mul_rate.txtar
 exp_histogram_set_op_and.txtar
 exp_histogram_set_op_or.txtar
+exp_histogram_set_op_or_mixed_float_left.txtar
+exp_histogram_set_op_or_mixed_histogram_left.txtar
 exp_histogram_set_op_unless.txtar
 exp_histogram_sum.txtar
 exp_histogram_sum_by.txtar

--- a/test/rejection-parity/catalogue/internal__promql__histogram_native_mixed_or.go.json
+++ b/test/rejection-parity/catalogue/internal__promql__histogram_native_mixed_or.go.json
@@ -1,0 +1,43 @@
+{
+  "entries": [
+    {
+      "head": "promql",
+      "site": "internal/promql/histogram_native_mixed_or.go:lowerMixedExpHistogramSetOp#38b18b37",
+      "message": "promql: 'or' between a float-valued and a histogram-valued operand only supports a plain (non-windowed) float side today; got a %s-shaped float operand, which cerberus issue #2330 does not yet cover",
+      "class": "divergence",
+      "trigger_query": "rate(up[5m]) or demo_latency_exp_hist",
+      "tracking_issue": 2333,
+      "evidence": {
+        "guard": [
+          "past returning if b.ReturnBool",
+          "past returning if err != nil",
+          "past returning if err != nil",
+          "if shape := chplan.RowShapeOf(floatNode); shape != chplan.SampleRowShape"
+        ],
+        "callers": [
+          "lowerRoot"
+        ]
+      },
+      "since": "2026-08-17"
+    },
+    {
+      "head": "promql",
+      "site": "internal/promql/histogram_native_mixed_or.go:lowerMixedExpHistogramSetOp#6cdf660e",
+      "message": "promql: 'bool' modifier is only allowed on comparison binary ops",
+      "class": "internal",
+      "rationale": "the parser rejects `bool` on non-comparison operators (\"bool modifier can only be used on comparison operators\"), same as lowerVectorSetOp's identical check for the float case and lowerExpHistogramSetOp's identical check for the both-histogram case",
+      "evidence": {
+        "guard": [
+          "if b.ReturnBool"
+        ],
+        "callers": [
+          "lowerRoot"
+        ],
+        "cited": [
+          "lowerExpHistogramSetOp",
+          "lowerVectorSetOp"
+        ]
+      }
+    }
+  ]
+}

--- a/test/rejection-parity/catalogue/internal__promql__histogram_native_set_op.go.json
+++ b/test/rejection-parity/catalogue/internal__promql__histogram_native_set_op.go.json
@@ -23,7 +23,7 @@
       "site": "internal/promql/histogram_native_set_op.go:lowerExpHistogramSetOpOperand#8deac7ac",
       "message": "promql: internal invariant violated: exp-histogram set-op operand lowering published %s row shape (%T), want %s",
       "class": "internal",
-      "rationale": "internal invariant: expHistogramSetOp only recognises operands isExpHistogramValuedShape already confirmed histogram-valued, so lowerExpHistogramSetOpOperand's own histogram-valued lowering can never publish a non-HistogramRowShape node here",
+      "rationale": "internal invariant: both callers of lowerExpHistogramSetOpOperand only ever pass an operand isExpHistogramValuedShape already confirmed histogram-valued -- lowerExpHistogramSetOp's own both-arms-histogram expHistogramSetOp recognizer for one, and lowerMixedExpHistogramSetOp's own histOnLeft selection (cerberus issue #2330) for the other -- so lowerExpHistogramSetOpOperand's histogram-valued lowering can never publish a non-HistogramRowShape node here",
       "evidence": {
         "guard": [
           "past returning if err != nil",
@@ -31,12 +31,15 @@
           "if chplan.RowShapeOf(node) != chplan.HistogramRowShape"
         ],
         "callers": [
-          "lowerExpHistogramSetOp"
+          "lowerExpHistogramSetOp",
+          "lowerMixedExpHistogramSetOp"
         ],
         "cited": [
           "expHistogramSetOp",
           "isExpHistogramValuedShape",
-          "lowerExpHistogramSetOpOperand"
+          "lowerExpHistogramSetOp",
+          "lowerExpHistogramSetOpOperand",
+          "lowerMixedExpHistogramSetOp"
         ]
       }
     },
@@ -45,20 +48,23 @@
       "site": "internal/promql/histogram_native_set_op.go:lowerExpHistogramSetOpOperand#9d51e668",
       "message": "promql: internal invariant violated: exp-histogram set-op operand matched no known histogram-valued shape for %v",
       "class": "internal",
-      "rationale": "internal invariant: expHistogramSetOp only recognises operands isExpHistogramValuedShape already confirmed match a known histogram-valued shape, so lowerExpHistogramSetOpOperand's own re-dispatch through lowerExpHistogramValuedShape can never report unmatched here",
+      "rationale": "internal invariant: both callers of lowerExpHistogramSetOpOperand only ever pass an operand isExpHistogramValuedShape already confirmed match a known histogram-valued shape -- lowerExpHistogramSetOp's own expHistogramSetOp recognizer for one, and lowerMixedExpHistogramSetOp's own histOnLeft selection (cerberus issue #2330) for the other -- so lowerExpHistogramSetOpOperand's own re-dispatch through lowerExpHistogramValuedShape can never report unmatched here",
       "evidence": {
         "guard": [
           "past returning if err != nil",
           "if !matched"
         ],
         "callers": [
-          "lowerExpHistogramSetOp"
+          "lowerExpHistogramSetOp",
+          "lowerMixedExpHistogramSetOp"
         ],
         "cited": [
           "expHistogramSetOp",
           "isExpHistogramValuedShape",
+          "lowerExpHistogramSetOp",
           "lowerExpHistogramSetOpOperand",
-          "lowerExpHistogramValuedShape"
+          "lowerExpHistogramValuedShape",
+          "lowerMixedExpHistogramSetOp"
         ]
       }
     }

--- a/test/rejection-parity/catalogue/internal__promql__lower.go.json
+++ b/test/rejection-parity/catalogue/internal__promql__lower.go.json
@@ -111,7 +111,7 @@
       "site": "internal/promql/lower.go:lower#d33d0084",
       "message": "promql: unsupported expression %T",
       "class": "internal",
-      "rationale": "Every expression shape reaching lower() through the HTTP handlers is dispatched (top-level matrix selectors included). The remaining inhabitants — NumberLiteral and StringLiteral, answered by the handler's constant fold / string shortcut before the engine runs, and StepInvariantExpr, which only parser.PreprocessExpr mints and cerberus never calls — cannot arrive here from the wire. The query entry points now reach this switch through lowerRoot, which peels off exactly one shape (a bare exp-histogram selector, answered by a histogram-valued lowering) and otherwise delegates unchanged, so it narrows the set of expressions that arrive rather than widening it. Re-verified across the in-package callers that re-enter lower() with a sub-expression, lowerHistogramQuantileClassicFloat included: each passes an operand of an already-parsed query whose position the upstream typechecker constrains to a vector, so no caller widens the set of shapes that reach the default arm. lowerExpHistogramDroppingVectorBinop (cerberus issue #2331) is the newest such caller: it re-enters lower() only for one BinaryExpr operand of an already-parsed vector-vector query, likewise typechecker-constrained to a vector, so it does not widen the set either.",
+      "rationale": "Every expression shape reaching lower() through the HTTP handlers is dispatched (top-level matrix selectors included). The remaining inhabitants — NumberLiteral and StringLiteral, answered by the handler's constant fold / string shortcut before the engine runs, and StepInvariantExpr, which only parser.PreprocessExpr mints and cerberus never calls — cannot arrive here from the wire. The query entry points now reach this switch through lowerRoot, which peels off exactly one shape (a bare exp-histogram selector, answered by a histogram-valued lowering) and otherwise delegates unchanged, so it narrows the set of expressions that arrive rather than widening it. Re-verified across the in-package callers that re-enter lower() with a sub-expression, lowerHistogramQuantileClassicFloat included: each passes an operand of an already-parsed query whose position the upstream typechecker constrains to a vector, so no caller widens the set of shapes that reach the default arm. lowerExpHistogramDroppingVectorBinop (cerberus issue #2331) and lowerMixedExpHistogramSetOp (cerberus issue #2330) are the newest such callers: each re-enters lower() only for one BinaryExpr operand of an already-parsed vector-vector query, likewise typechecker-constrained to a vector, so neither widens the set either.",
       "evidence": {
         "guard": [
           "default of switch e := expr.(type) over [case *parser.VectorSelector; case *parser.Call; case *parser.AggregateExpr; case *parser.ParenExpr; case *parser.BinaryExpr; case *parser.SubqueryExpr; case *parser.MatrixSelector; case *parser.UnaryExpr; default]"
@@ -135,6 +135,7 @@
           "lowerLimitK",
           "lowerLimitRatio",
           "lowerMetadataCatalog",
+          "lowerMixedExpHistogramSetOp",
           "lowerRoot",
           "lowerRoundToNearest",
           "lowerScalarArg",
@@ -151,6 +152,7 @@
           "lower",
           "lowerExpHistogramDroppingVectorBinop",
           "lowerHistogramQuantileClassicFloat",
+          "lowerMixedExpHistogramSetOp",
           "lowerRoot"
         ]
       }
@@ -300,11 +302,12 @@
       "site": "internal/promql/lower.go:lowerRoot#53e0f9b3",
       "message": "promql: internal invariant violated: count_values input is not histogram-valued: %v",
       "class": "internal",
-      "rationale": "countValuesOverExpHistogramValue already ran isExpHistogramValuedShape to decide ok=true, so the immediately following lowerExpHistogramValuedShape call on the same agg.Expr cannot come back unmatched",
+      "rationale": "countValuesOverExpHistogramValue already ran isExpHistogramValuedShape to decide ok=true, so the immediately following lowerExpHistogramValuedShape call on the same agg.Expr cannot come back unmatched. The mixedExpHistogramSetOp guard now checked earlier in lowerRoot's chain (cerberus issue #2330) only recognises a VectorSetOp BinaryExpr with exactly one histogram-valued operand — a shape count_values's AggregateExpr is not — so it cannot intercept a query before it reaches this branch, and does not affect this claim.",
       "evidence": {
         "guard": [
           "past returning if call, ok := labelReplaceOverExpHistogram(expr, s, ctx); ok",
           "past returning if plan, ok, err := lowerExpHistogramValuedShape(expr, s, ctx); ok",
+          "past returning if b, ok := mixedExpHistogramSetOp(expr, s, ctx); ok",
           "past returning if shape, ok := overTimeOverExpHistogram(expr, s, ctx); ok",
           "past returning if shape, ok := resetsOrChangesOverExpHistogram(expr, s, ctx); ok",
           "past returning if agg, vs, ok := countOverExpHistogram(expr, s, ctx); ok",
@@ -320,7 +323,9 @@
         "cited": [
           "countValuesOverExpHistogramValue",
           "isExpHistogramValuedShape",
-          "lowerExpHistogramValuedShape"
+          "lowerExpHistogramValuedShape",
+          "lowerRoot",
+          "mixedExpHistogramSetOp"
         ]
       }
     },
@@ -329,11 +334,12 @@
       "site": "internal/promql/lower.go:lowerRoot#c7dbd629",
       "message": "promql: internal invariant violated: count/group input is not histogram-valued: %v",
       "class": "internal",
-      "rationale": "countOrGroupOverExpHistogramValue already ran isExpHistogramValuedShape to decide ok=true, so the immediately following lowerExpHistogramValuedShape call on the same agg.Expr cannot come back unmatched",
+      "rationale": "countOrGroupOverExpHistogramValue already ran isExpHistogramValuedShape to decide ok=true, so the immediately following lowerExpHistogramValuedShape call on the same agg.Expr cannot come back unmatched. The mixedExpHistogramSetOp guard now checked earlier in lowerRoot's chain (cerberus issue #2330) only recognises a VectorSetOp BinaryExpr with exactly one histogram-valued operand — a shape count/group's AggregateExpr is not — so it cannot intercept a query before it reaches this branch, and does not affect this claim.",
       "evidence": {
         "guard": [
           "past returning if call, ok := labelReplaceOverExpHistogram(expr, s, ctx); ok",
           "past returning if plan, ok, err := lowerExpHistogramValuedShape(expr, s, ctx); ok",
+          "past returning if b, ok := mixedExpHistogramSetOp(expr, s, ctx); ok",
           "past returning if shape, ok := overTimeOverExpHistogram(expr, s, ctx); ok",
           "past returning if shape, ok := resetsOrChangesOverExpHistogram(expr, s, ctx); ok",
           "past returning if agg, vs, ok := countOverExpHistogram(expr, s, ctx); ok",
@@ -348,7 +354,9 @@
         "cited": [
           "countOrGroupOverExpHistogramValue",
           "isExpHistogramValuedShape",
-          "lowerExpHistogramValuedShape"
+          "lowerExpHistogramValuedShape",
+          "lowerRoot",
+          "mixedExpHistogramSetOp"
         ]
       }
     },

--- a/test/rejection-parity/divergence-ceiling.json
+++ b/test/rejection-parity/divergence-ceiling.json
@@ -1,3 +1,3 @@
 {
-  "max_entries": 3
+  "max_entries": 4
 }

--- a/test/spec/promql/exp_histogram_set_op_or_mixed_float_left.txtar
+++ b/test/spec/promql/exp_histogram_set_op_or_mixed_float_left.txtar
@@ -1,0 +1,130 @@
+-- query.promql --
+histogram_quantile(0.5, http_server_duration_exp_hist) or http_client_duration_exp_hist
+-- parity --
+oracle: prometheus
+endpoint: /api/v1/query
+scope: full
+-- seed --
+CREATE TABLE otel_metrics_exponential_histogram (
+    MetricName String,
+    Attributes Map(String, String),
+    TimeUnix DateTime64(9),
+    Count UInt64,
+    Sum Float64,
+    Scale Int32,
+    ZeroCount UInt64,
+    PositiveOffset Int32,
+    PositiveBucketCounts Array(UInt64),
+    NegativeOffset Int32,
+    NegativeBucketCounts Array(UInt64)
+) ENGINE = MergeTree ORDER BY (MetricName, Attributes, TimeUnix);
+-- `histogram_quantile(0.5, <selector A>) or <selector B>` (cerberus
+-- issue #2330): the LHS reduces every `A` series to a FLOAT quantile —
+-- float-valued — while the RHS is a raw histogram-valued selector over
+-- the DIFFERENT metric `B`. Reference Prometheus's `or` matches purely
+-- on labels, never value type: the two metrics' label sets are disjoint
+-- (`service=api` vs `service=web`), so every LHS row survives (as
+-- always) AND every RHS row survives too (its signature is absent from
+-- the LHS) — the result genuinely carries one float sample and one
+-- native-histogram sample at once, exactly the mixed-type union upstream
+-- allows and cerberus previously rejected outright.
+INSERT INTO otel_metrics_exponential_histogram VALUES
+    ('http_server_duration_exp_hist', map('service', 'api'), toDateTime64('2026-01-01 00:00:00', 9), 4, 10.0, 0, 0, 0, [1, 2, 3, 4], 0, []),
+    ('http_client_duration_exp_hist', map('service', 'web'), toDateTime64('2026-01-01 00:00:00', 9), 3, 3.0,  0, 0, 0, [9],           0, []);
+-- expected_rows --
+[
+  ["", {"service": "api"}, "2026-01-01T00:00:01Z", 4, 0, 0, 0, 0, 0, 0, [], 0, [], 0],
+  ["http_client_duration_exp_hist", {"service": "web"}, "2026-01-01T00:00:01Z", 0, 3, 3, 0, 0, 0, 0, [9], 0, [], 1]
+]
+-- args --
+[0] string = ""
+[1] int64 = 9
+[2] string = "service.name"
+[3] string = "service_name"
+[4] string = "service.name"
+[5] string = "service_name"
+[6] string = ""
+[7] string = "service_name"
+[8] string = "http_server_duration_exp_hist"
+[9] string = "http.server.duration.exp.hist"
+[10] string = "http.server.duration.exp/hist"
+[11] string = "http.server.duration.exp_hist"
+[12] string = "http.server.duration/exp/hist"
+[13] string = "http.server.duration/exp_hist"
+[14] string = "http.server.duration_exp.hist"
+[15] string = "http.server.duration_exp_hist"
+[16] string = "http.server/duration/exp/hist"
+[17] string = "http.server/duration/exp_hist"
+[18] string = "http.server/duration_exp_hist"
+[19] string = "http.server_duration.exp.hist"
+[20] string = "http.server_duration.exp_hist"
+[21] string = "http.server_duration_exp.hist"
+[22] string = "http.server_duration_exp_hist"
+[23] string = "http/server/duration/exp/hist"
+[24] string = "http/server/duration/exp_hist"
+[25] string = "http/server/duration_exp_hist"
+[26] string = "http/server_duration_exp_hist"
+[27] string = "http_server.duration.exp.hist"
+[28] string = "http_server.duration.exp_hist"
+[29] string = "http_server.duration_exp.hist"
+[30] string = "http_server.duration_exp_hist"
+[31] string = "http_server_duration.exp.hist"
+[32] string = "http_server_duration.exp_hist"
+[33] string = "http_server_duration_exp.hist"
+[34] string = "2026-01-01 00:00:01.000000000"
+[35] int64 = 9
+[36] string = "2026-01-01 00:00:01.000000000"
+[37] int64 = 9
+[38] int64 = 300000000000
+[39] int64 = 9
+[40] float64 = 0
+[41] string = "service.name"
+[42] string = "service_name"
+[43] string = "service.name"
+[44] string = "service_name"
+[45] string = ""
+[46] string = "service_name"
+[47] string = "http_client_duration_exp_hist"
+[48] string = "http.client.duration.exp.hist"
+[49] string = "http.client.duration.exp/hist"
+[50] string = "http.client.duration.exp_hist"
+[51] string = "http.client.duration/exp/hist"
+[52] string = "http.client.duration/exp_hist"
+[53] string = "http.client.duration_exp.hist"
+[54] string = "http.client.duration_exp_hist"
+[55] string = "http.client/duration/exp/hist"
+[56] string = "http.client/duration/exp_hist"
+[57] string = "http.client/duration_exp_hist"
+[58] string = "http.client_duration.exp.hist"
+[59] string = "http.client_duration.exp_hist"
+[60] string = "http.client_duration_exp.hist"
+[61] string = "http.client_duration_exp_hist"
+[62] string = "http/client/duration/exp/hist"
+[63] string = "http/client/duration/exp_hist"
+[64] string = "http/client/duration_exp_hist"
+[65] string = "http/client_duration_exp_hist"
+[66] string = "http_client.duration.exp.hist"
+[67] string = "http_client.duration.exp_hist"
+[68] string = "http_client.duration_exp.hist"
+[69] string = "http_client.duration_exp_hist"
+[70] string = "http_client_duration.exp.hist"
+[71] string = "http_client_duration.exp_hist"
+[72] string = "http_client_duration_exp.hist"
+[73] string = "2026-01-01 00:00:01.000000000"
+[74] int64 = 9
+[75] string = "2026-01-01 00:00:01.000000000"
+[76] int64 = 9
+[77] int64 = 300000000000
+-- chplan --
+VectorSetOp op=or match=default
+  Project ["" AS MetricName, Attributes AS Attributes, FnNow64(9) AS TimeUnix, Value AS Value]
+    HistogramQuantileNative phi=0.5 groupBy=[Attributes AS Attributes]
+      Aggregate groupBy=[FnMapSort(FnMapMerge(FnMapUpdate(FnMapFromArrays(FnArrayMap(k -> FnRegexReplaceAll(k, "[^a-zA-Z0-9_]", "_"), FnMapKeys(FnMapFilter((k, v) -> (k NOT IN ("service.name", "service_name")), ResourceAttributes))), FnMapValues(FnMapFilter((k, v) -> (k NOT IN ("service.name", "service_name")), ResourceAttributes))), FnMapFromArrays(FnArrayMap(k -> FnRegexReplaceAll(k, "[^a-zA-Z0-9_]", "_"), FnMapKeys(Attributes)), FnMapValues(Attributes))), FnMapFilter((k, v) -> (v != ""), FnMap("service_name", FnToString(ServiceName))))) AS Attributes] funcs=[FnArgMax(Count, TimeUnix) AS Count, FnArgMax(Sum, TimeUnix) AS Sum, FnArgMax(Scale, TimeUnix) AS Scale, FnArgMax(ZeroCount, TimeUnix) AS ZeroCount, FnArgMax(PositiveOffset, TimeUnix) AS PositiveOffset, FnArgMax(PositiveBucketCounts, TimeUnix) AS PositiveBucketCounts, FnArgMax(NegativeOffset, TimeUnix) AS NegativeOffset, FnArgMax(NegativeBucketCounts, TimeUnix) AS NegativeBucketCounts]
+        Filter predicate=(((MetricName IN ("http_server_duration_exp_hist", "http.server.duration.exp.hist", "http.server.duration.exp/hist", "http.server.duration.exp_hist", "http.server.duration/exp/hist", "http.server.duration/exp_hist", "http.server.duration_exp.hist", "http.server.duration_exp_hist", "http.server/duration/exp/hist", "http.server/duration/exp_hist", "http.server/duration_exp_hist", "http.server_duration.exp.hist", "http.server_duration.exp_hist", "http.server_duration_exp.hist", "http.server_duration_exp_hist", "http/server/duration/exp/hist", "http/server/duration/exp_hist", "http/server/duration_exp_hist", "http/server_duration_exp_hist", "http_server.duration.exp.hist", "http_server.duration.exp_hist", "http_server.duration_exp.hist", "http_server.duration_exp_hist", "http_server_duration.exp.hist", "http_server_duration.exp_hist", "http_server_duration_exp.hist")) AND (TimeUnix <= FnToDateTime64("2026-01-01 00:00:01.000000000", 9))) AND (TimeUnix > (FnToDateTime64("2026-01-01 00:00:01.000000000", 9) - FnToIntervalNanosecond(300000000000))))
+          Scan(otel_metrics_exponential_histogram)
+  HistogramProjection project=[MetricName AS MetricName, Attributes AS Attributes, FnNow64(9) AS TimeUnix, 0 AS Value]
+    Aggregate groupBy=[FnMapSort(FnMapMerge(FnMapUpdate(FnMapFromArrays(FnArrayMap(k -> FnRegexReplaceAll(k, "[^a-zA-Z0-9_]", "_"), FnMapKeys(FnMapFilter((k, v) -> (k NOT IN ("service.name", "service_name")), ResourceAttributes))), FnMapValues(FnMapFilter((k, v) -> (k NOT IN ("service.name", "service_name")), ResourceAttributes))), FnMapFromArrays(FnArrayMap(k -> FnRegexReplaceAll(k, "[^a-zA-Z0-9_]", "_"), FnMapKeys(Attributes)), FnMapValues(Attributes))), FnMapFilter((k, v) -> (v != ""), FnMap("service_name", FnToString(ServiceName))))) AS Attributes] funcs=[FnArgMax(MetricName, TimeUnix) AS MetricName, FnArgMax(Count, TimeUnix) AS Count, FnArgMax(Sum, TimeUnix) AS Sum, FnArgMax(Scale, TimeUnix) AS Scale, FnArgMax(ZeroCount, TimeUnix) AS ZeroCount, FnArgMax(PositiveOffset, TimeUnix) AS PositiveOffset, FnArgMax(PositiveBucketCounts, TimeUnix) AS PositiveBucketCounts, FnArgMax(NegativeOffset, TimeUnix) AS NegativeOffset, FnArgMax(NegativeBucketCounts, TimeUnix) AS NegativeBucketCounts]
+      Filter predicate=(((MetricName IN ("http_client_duration_exp_hist", "http.client.duration.exp.hist", "http.client.duration.exp/hist", "http.client.duration.exp_hist", "http.client.duration/exp/hist", "http.client.duration/exp_hist", "http.client.duration_exp.hist", "http.client.duration_exp_hist", "http.client/duration/exp/hist", "http.client/duration/exp_hist", "http.client/duration_exp_hist", "http.client_duration.exp.hist", "http.client_duration.exp_hist", "http.client_duration_exp.hist", "http.client_duration_exp_hist", "http/client/duration/exp/hist", "http/client/duration/exp_hist", "http/client/duration_exp_hist", "http/client_duration_exp_hist", "http_client.duration.exp.hist", "http_client.duration.exp_hist", "http_client.duration_exp.hist", "http_client.duration_exp_hist", "http_client_duration.exp.hist", "http_client_duration.exp_hist", "http_client_duration_exp.hist")) AND (TimeUnix <= FnToDateTime64("2026-01-01 00:00:01.000000000", 9))) AND (TimeUnix > (FnToDateTime64("2026-01-01 00:00:01.000000000", 9) - FnToIntervalNanosecond(300000000000))))
+        Scan(otel_metrics_exponential_histogram)
+-- sql --
+SELECT `MetricName`, `Attributes`, `TimeUnix`, `Value`, `HistogramCount`, `HistogramSum`, `HistogramScale`, `HistogramZeroThreshold`, `HistogramZeroCount`, `HistogramPositiveOffset`, `HistogramPositiveBucketCounts`, `HistogramNegativeOffset`, `HistogramNegativeBucketCounts`, `_setop_is_histogram` FROM (SELECT `MetricName`, `Attributes`, `TimeUnix`, `Value`, `HistogramCount`, `HistogramSum`, `HistogramScale`, `HistogramZeroThreshold`, `HistogramZeroCount`, `HistogramPositiveOffset`, `HistogramPositiveBucketCounts`, `HistogramNegativeOffset`, `HistogramNegativeBucketCounts`, `_setop_is_histogram`, `_setop_side`, max(`_setop_side` = 0) OVER (PARTITION BY mapSort(`Attributes`)) AS `_setop_has_left` FROM (((SELECT `MetricName`, `Attributes`, `TimeUnix`, `Value`, `HistogramCount`, `HistogramSum`, `HistogramScale`, `HistogramZeroThreshold`, `HistogramZeroCount`, `HistogramPositiveOffset`, `HistogramPositiveBucketCounts`, `HistogramNegativeOffset`, `HistogramNegativeBucketCounts`, `_setop_is_histogram`, 0 AS `_setop_side` FROM (SELECT `MetricName`, `Attributes`, `TimeUnix`, `Value`, toFloat64(0) AS `HistogramCount`, toFloat64(0) AS `HistogramSum`, toInt32(0) AS `HistogramScale`, toFloat64(0) AS `HistogramZeroThreshold`, toFloat64(0) AS `HistogramZeroCount`, toInt32(0) AS `HistogramPositiveOffset`, emptyArrayFloat64() AS `HistogramPositiveBucketCounts`, toInt32(0) AS `HistogramNegativeOffset`, emptyArrayFloat64() AS `HistogramNegativeBucketCounts`, 0 AS `_setop_is_histogram` FROM (SELECT ? AS `MetricName`, `Attributes` AS `Attributes`, now64(?) AS `TimeUnix`, `Value` AS `Value` FROM (SELECT `Attributes` AS `Attributes`, if(0.5 < 0, -inf, if(0.5 > 1, inf, if(`Count` = 0, nan, if(0.5 = 0, if(arrayFirstIndex(c -> c > 0, `_cerb_hq_buckets`) <= length(`NegativeBucketCounts`), -pow(pow(2, pow(2, -`Scale`)), `NegativeOffset` + (length(`NegativeBucketCounts`) - arrayFirstIndex(c -> c > 0, `_cerb_hq_buckets`)) + 1), if(arrayFirstIndex(c -> c > 0, `_cerb_hq_buckets`) = length(`NegativeBucketCounts`) + 1, if(length(`NegativeBucketCounts`) = 0 AND length(`PositiveBucketCounts`) > 0, 0., -0.), pow(pow(2, pow(2, -`Scale`)), `PositiveOffset` + (arrayFirstIndex(c -> c > 0, `_cerb_hq_buckets`) - length(`NegativeBucketCounts`) - 2)))), if(0.5 = 1, if(arrayLastIndex(c -> c > 0, `_cerb_hq_buckets`) <= length(`NegativeBucketCounts`), -pow(pow(2, pow(2, -`Scale`)), `NegativeOffset` + (length(`NegativeBucketCounts`) - arrayLastIndex(c -> c > 0, `_cerb_hq_buckets`))), if(arrayLastIndex(c -> c > 0, `_cerb_hq_buckets`) = length(`NegativeBucketCounts`) + 1, if(length(`PositiveBucketCounts`) = 0 AND length(`NegativeBucketCounts`) > 0, 0., 0.), pow(pow(2, pow(2, -`Scale`)), `PositiveOffset` + (arrayLastIndex(c -> c > 0, `_cerb_hq_buckets`) - length(`NegativeBucketCounts`) - 1)))), if(`_cerb_hq_idx` = 0, nan, if(`_cerb_hq_value_idx` <= length(`NegativeBucketCounts`), -pow(pow(2, pow(2, -`Scale`)), `NegativeOffset` + (length(`NegativeBucketCounts`) - `_cerb_hq_value_idx`) + 1 - ((0.5 * `Count`) - `_cerb_hq_cum`[`_cerb_hq_idx` - 1]) / `_cerb_hq_buckets`[`_cerb_hq_value_idx`]), if(`_cerb_hq_value_idx` = length(`NegativeBucketCounts`) + 1, if(length(`NegativeBucketCounts`) = 0 AND length(`PositiveBucketCounts`) > 0, 0., -0.) + (if(length(`PositiveBucketCounts`) = 0 AND length(`NegativeBucketCounts`) > 0, 0., 0.) - if(length(`NegativeBucketCounts`) = 0 AND length(`PositiveBucketCounts`) > 0, 0., -0.)) * ((0.5 * `Count`) - `_cerb_hq_cum`[`_cerb_hq_idx` - 1]) / `_cerb_hq_buckets`[`_cerb_hq_value_idx`], pow(pow(2, pow(2, -`Scale`)), `PositiveOffset` + (`_cerb_hq_value_idx` - length(`NegativeBucketCounts`) - 2) + ((0.5 * `Count`) - `_cerb_hq_cum`[`_cerb_hq_idx` - 1]) / `_cerb_hq_buckets`[`_cerb_hq_value_idx`]))))))))) AS `Value` FROM (SELECT *, if(isNaN(`Sum`), if(length(`PositiveBucketCounts`) > 0, length(`NegativeBucketCounts`) + 1 + length(`PositiveBucketCounts`), if(`ZeroCount` > 0, length(`NegativeBucketCounts`) + 1, length(`NegativeBucketCounts`))), `_cerb_hq_idx`) AS `_cerb_hq_value_idx` FROM (SELECT *, if(isNaN(`Sum`), arrayFirstIndex(c -> c >= (0.5 * `Count`), `_cerb_hq_cum`), arrayFirstIndex(c -> `_cerb_hq_cum`[length(`_cerb_hq_cum`)] - c < ((1 - 0.5) * `Count`), `_cerb_hq_cum`)) AS `_cerb_hq_idx` FROM (SELECT *, arrayCumSum(`_cerb_hq_buckets`) AS `_cerb_hq_cum` FROM (SELECT *, arrayConcat(arrayReverse(`NegativeBucketCounts`), [`ZeroCount`], `PositiveBucketCounts`) AS `_cerb_hq_buckets` FROM (SELECT mapSort(mapConcat(mapUpdate(mapFromArrays(arrayMap(k -> replaceRegexpAll(k, '[^a-zA-Z0-9_]', '_'), mapKeys(mapFilter((k, v) -> (k NOT IN (?, ?)), `ResourceAttributes`))), mapValues(mapFilter((k, v) -> (k NOT IN (?, ?)), `ResourceAttributes`))), mapFromArrays(arrayMap(k -> replaceRegexpAll(k, '[^a-zA-Z0-9_]', '_'), mapKeys(`Attributes`)), mapValues(`Attributes`))), mapFilter((k, v) -> (v != ?), map(?, toString(`ServiceName`))))) AS `Attributes`, argMax(`Count`, `TimeUnix`) AS `Count`, argMax(`Sum`, `TimeUnix`) AS `Sum`, argMax(`Scale`, `TimeUnix`) AS `Scale`, argMax(`ZeroCount`, `TimeUnix`) AS `ZeroCount`, argMax(`PositiveOffset`, `TimeUnix`) AS `PositiveOffset`, argMax(`PositiveBucketCounts`, `TimeUnix`) AS `PositiveBucketCounts`, argMax(`NegativeOffset`, `TimeUnix`) AS `NegativeOffset`, argMax(`NegativeBucketCounts`, `TimeUnix`) AS `NegativeBucketCounts` FROM (SELECT * FROM `otel_metrics_exponential_histogram` PREWHERE (`MetricName` IN (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)) WHERE (`TimeUnix` <= toDateTime64(?, ?)) AND (`TimeUnix` > (toDateTime64(?, ?) - toIntervalNanosecond(?)))) GROUP BY `Attributes`)))))))))) UNION ALL ((SELECT `MetricName`, `Attributes`, `TimeUnix`, `Value`, `HistogramCount`, `HistogramSum`, `HistogramScale`, `HistogramZeroThreshold`, `HistogramZeroCount`, `HistogramPositiveOffset`, `HistogramPositiveBucketCounts`, `HistogramNegativeOffset`, `HistogramNegativeBucketCounts`, `_setop_is_histogram`, 1 AS `_setop_side` FROM (SELECT `MetricName`, `Attributes`, `TimeUnix`, `Value`, `HistogramCount`, `HistogramSum`, `HistogramScale`, `HistogramZeroThreshold`, `HistogramZeroCount`, `HistogramPositiveOffset`, `HistogramPositiveBucketCounts`, `HistogramNegativeOffset`, `HistogramNegativeBucketCounts`, 1 AS `_setop_is_histogram` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, now64(?) AS `TimeUnix`, toFloat64(?) AS `Value`, toFloat64(`Count`) AS `HistogramCount`, toFloat64(`Sum`) AS `HistogramSum`, toInt32(`Scale`) AS `HistogramScale`, toFloat64(0.) AS `HistogramZeroThreshold`, toFloat64(`ZeroCount`) AS `HistogramZeroCount`, toInt32(`PositiveOffset`) AS `HistogramPositiveOffset`, arrayMap(x -> toFloat64(x), `PositiveBucketCounts`) AS `HistogramPositiveBucketCounts`, toInt32(`NegativeOffset`) AS `HistogramNegativeOffset`, arrayMap(x -> toFloat64(x), `NegativeBucketCounts`) AS `HistogramNegativeBucketCounts` FROM (SELECT mapSort(mapConcat(mapUpdate(mapFromArrays(arrayMap(k -> replaceRegexpAll(k, '[^a-zA-Z0-9_]', '_'), mapKeys(mapFilter((k, v) -> (k NOT IN (?, ?)), `ResourceAttributes`))), mapValues(mapFilter((k, v) -> (k NOT IN (?, ?)), `ResourceAttributes`))), mapFromArrays(arrayMap(k -> replaceRegexpAll(k, '[^a-zA-Z0-9_]', '_'), mapKeys(`Attributes`)), mapValues(`Attributes`))), mapFilter((k, v) -> (v != ?), map(?, toString(`ServiceName`))))) AS `Attributes`, argMax(`MetricName`, `TimeUnix`) AS `MetricName`, argMax(`Count`, `TimeUnix`) AS `Count`, argMax(`Sum`, `TimeUnix`) AS `Sum`, argMax(`Scale`, `TimeUnix`) AS `Scale`, argMax(`ZeroCount`, `TimeUnix`) AS `ZeroCount`, argMax(`PositiveOffset`, `TimeUnix`) AS `PositiveOffset`, argMax(`PositiveBucketCounts`, `TimeUnix`) AS `PositiveBucketCounts`, argMax(`NegativeOffset`, `TimeUnix`) AS `NegativeOffset`, argMax(`NegativeBucketCounts`, `TimeUnix`) AS `NegativeBucketCounts` FROM (SELECT * FROM `otel_metrics_exponential_histogram` PREWHERE (`MetricName` IN (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)) WHERE (`TimeUnix` <= toDateTime64(?, ?)) AND (`TimeUnix` > (toDateTime64(?, ?) - toIntervalNanosecond(?)))) GROUP BY `Attributes`))))))) WHERE `_setop_side` = 0 OR `_setop_has_left` = 0

--- a/test/spec/promql/exp_histogram_set_op_or_mixed_histogram_left.txtar
+++ b/test/spec/promql/exp_histogram_set_op_or_mixed_histogram_left.txtar
@@ -1,0 +1,129 @@
+-- query.promql --
+http_client_duration_exp_hist or histogram_quantile(0.5, http_server_duration_exp_hist)
+-- parity --
+oracle: prometheus
+endpoint: /api/v1/query
+scope: full
+-- seed --
+CREATE TABLE otel_metrics_exponential_histogram (
+    MetricName String,
+    Attributes Map(String, String),
+    TimeUnix DateTime64(9),
+    Count UInt64,
+    Sum Float64,
+    Scale Int32,
+    ZeroCount UInt64,
+    PositiveOffset Int32,
+    PositiveBucketCounts Array(UInt64),
+    NegativeOffset Int32,
+    NegativeBucketCounts Array(UInt64)
+) ENGINE = MergeTree ORDER BY (MetricName, Attributes, TimeUnix);
+-- Mirror image of exp_histogram_set_op_or_mixed_float_left.txtar
+-- (cerberus issue #2330): the raw histogram-valued selector is now the
+-- LHS and the float-valued histogram_quantile() is the RHS. `or` is not
+-- commutative when the two arms' signatures overlap (LHS always wins a
+-- collision), but this fixture's two metrics have disjoint label sets
+-- exactly like the sibling fixture, so both directions answer the same
+-- TWO rows — this pins that the histogram-side-on-LEFT wiring
+-- (VectorSetOp.MixedHistogramOnLeft) produces the identical union, not
+-- just the float-on-left ordering.
+INSERT INTO otel_metrics_exponential_histogram VALUES
+    ('http_server_duration_exp_hist', map('service', 'api'), toDateTime64('2026-01-01 00:00:00', 9), 4, 10.0, 0, 0, 0, [1, 2, 3, 4], 0, []),
+    ('http_client_duration_exp_hist', map('service', 'web'), toDateTime64('2026-01-01 00:00:00', 9), 3, 3.0,  0, 0, 0, [9],           0, []);
+-- expected_rows --
+[
+  ["", {"service": "api"}, "2026-01-01T00:00:01Z", 4, 0, 0, 0, 0, 0, 0, [], 0, [], 0],
+  ["http_client_duration_exp_hist", {"service": "web"}, "2026-01-01T00:00:01Z", 0, 3, 3, 0, 0, 0, 0, [9], 0, [], 1]
+]
+-- args --
+[0] int64 = 9
+[1] float64 = 0
+[2] string = "service.name"
+[3] string = "service_name"
+[4] string = "service.name"
+[5] string = "service_name"
+[6] string = ""
+[7] string = "service_name"
+[8] string = "http_client_duration_exp_hist"
+[9] string = "http.client.duration.exp.hist"
+[10] string = "http.client.duration.exp/hist"
+[11] string = "http.client.duration.exp_hist"
+[12] string = "http.client.duration/exp/hist"
+[13] string = "http.client.duration/exp_hist"
+[14] string = "http.client.duration_exp.hist"
+[15] string = "http.client.duration_exp_hist"
+[16] string = "http.client/duration/exp/hist"
+[17] string = "http.client/duration/exp_hist"
+[18] string = "http.client/duration_exp_hist"
+[19] string = "http.client_duration.exp.hist"
+[20] string = "http.client_duration.exp_hist"
+[21] string = "http.client_duration_exp.hist"
+[22] string = "http.client_duration_exp_hist"
+[23] string = "http/client/duration/exp/hist"
+[24] string = "http/client/duration/exp_hist"
+[25] string = "http/client/duration_exp_hist"
+[26] string = "http/client_duration_exp_hist"
+[27] string = "http_client.duration.exp.hist"
+[28] string = "http_client.duration.exp_hist"
+[29] string = "http_client.duration_exp.hist"
+[30] string = "http_client.duration_exp_hist"
+[31] string = "http_client_duration.exp.hist"
+[32] string = "http_client_duration.exp_hist"
+[33] string = "http_client_duration_exp.hist"
+[34] string = "2026-01-01 00:00:01.000000000"
+[35] int64 = 9
+[36] string = "2026-01-01 00:00:01.000000000"
+[37] int64 = 9
+[38] int64 = 300000000000
+[39] string = ""
+[40] int64 = 9
+[41] string = "service.name"
+[42] string = "service_name"
+[43] string = "service.name"
+[44] string = "service_name"
+[45] string = ""
+[46] string = "service_name"
+[47] string = "http_server_duration_exp_hist"
+[48] string = "http.server.duration.exp.hist"
+[49] string = "http.server.duration.exp/hist"
+[50] string = "http.server.duration.exp_hist"
+[51] string = "http.server.duration/exp/hist"
+[52] string = "http.server.duration/exp_hist"
+[53] string = "http.server.duration_exp.hist"
+[54] string = "http.server.duration_exp_hist"
+[55] string = "http.server/duration/exp/hist"
+[56] string = "http.server/duration/exp_hist"
+[57] string = "http.server/duration_exp_hist"
+[58] string = "http.server_duration.exp.hist"
+[59] string = "http.server_duration.exp_hist"
+[60] string = "http.server_duration_exp.hist"
+[61] string = "http.server_duration_exp_hist"
+[62] string = "http/server/duration/exp/hist"
+[63] string = "http/server/duration/exp_hist"
+[64] string = "http/server/duration_exp_hist"
+[65] string = "http/server_duration_exp_hist"
+[66] string = "http_server.duration.exp.hist"
+[67] string = "http_server.duration.exp_hist"
+[68] string = "http_server.duration_exp.hist"
+[69] string = "http_server.duration_exp_hist"
+[70] string = "http_server_duration.exp.hist"
+[71] string = "http_server_duration.exp_hist"
+[72] string = "http_server_duration_exp.hist"
+[73] string = "2026-01-01 00:00:01.000000000"
+[74] int64 = 9
+[75] string = "2026-01-01 00:00:01.000000000"
+[76] int64 = 9
+[77] int64 = 300000000000
+-- chplan --
+VectorSetOp op=or match=default
+  HistogramProjection project=[MetricName AS MetricName, Attributes AS Attributes, FnNow64(9) AS TimeUnix, 0 AS Value]
+    Aggregate groupBy=[FnMapSort(FnMapMerge(FnMapUpdate(FnMapFromArrays(FnArrayMap(k -> FnRegexReplaceAll(k, "[^a-zA-Z0-9_]", "_"), FnMapKeys(FnMapFilter((k, v) -> (k NOT IN ("service.name", "service_name")), ResourceAttributes))), FnMapValues(FnMapFilter((k, v) -> (k NOT IN ("service.name", "service_name")), ResourceAttributes))), FnMapFromArrays(FnArrayMap(k -> FnRegexReplaceAll(k, "[^a-zA-Z0-9_]", "_"), FnMapKeys(Attributes)), FnMapValues(Attributes))), FnMapFilter((k, v) -> (v != ""), FnMap("service_name", FnToString(ServiceName))))) AS Attributes] funcs=[FnArgMax(MetricName, TimeUnix) AS MetricName, FnArgMax(Count, TimeUnix) AS Count, FnArgMax(Sum, TimeUnix) AS Sum, FnArgMax(Scale, TimeUnix) AS Scale, FnArgMax(ZeroCount, TimeUnix) AS ZeroCount, FnArgMax(PositiveOffset, TimeUnix) AS PositiveOffset, FnArgMax(PositiveBucketCounts, TimeUnix) AS PositiveBucketCounts, FnArgMax(NegativeOffset, TimeUnix) AS NegativeOffset, FnArgMax(NegativeBucketCounts, TimeUnix) AS NegativeBucketCounts]
+      Filter predicate=(((MetricName IN ("http_client_duration_exp_hist", "http.client.duration.exp.hist", "http.client.duration.exp/hist", "http.client.duration.exp_hist", "http.client.duration/exp/hist", "http.client.duration/exp_hist", "http.client.duration_exp.hist", "http.client.duration_exp_hist", "http.client/duration/exp/hist", "http.client/duration/exp_hist", "http.client/duration_exp_hist", "http.client_duration.exp.hist", "http.client_duration.exp_hist", "http.client_duration_exp.hist", "http.client_duration_exp_hist", "http/client/duration/exp/hist", "http/client/duration/exp_hist", "http/client/duration_exp_hist", "http/client_duration_exp_hist", "http_client.duration.exp.hist", "http_client.duration.exp_hist", "http_client.duration_exp.hist", "http_client.duration_exp_hist", "http_client_duration.exp.hist", "http_client_duration.exp_hist", "http_client_duration_exp.hist")) AND (TimeUnix <= FnToDateTime64("2026-01-01 00:00:01.000000000", 9))) AND (TimeUnix > (FnToDateTime64("2026-01-01 00:00:01.000000000", 9) - FnToIntervalNanosecond(300000000000))))
+        Scan(otel_metrics_exponential_histogram)
+  Project ["" AS MetricName, Attributes AS Attributes, FnNow64(9) AS TimeUnix, Value AS Value]
+    HistogramQuantileNative phi=0.5 groupBy=[Attributes AS Attributes]
+      Aggregate groupBy=[FnMapSort(FnMapMerge(FnMapUpdate(FnMapFromArrays(FnArrayMap(k -> FnRegexReplaceAll(k, "[^a-zA-Z0-9_]", "_"), FnMapKeys(FnMapFilter((k, v) -> (k NOT IN ("service.name", "service_name")), ResourceAttributes))), FnMapValues(FnMapFilter((k, v) -> (k NOT IN ("service.name", "service_name")), ResourceAttributes))), FnMapFromArrays(FnArrayMap(k -> FnRegexReplaceAll(k, "[^a-zA-Z0-9_]", "_"), FnMapKeys(Attributes)), FnMapValues(Attributes))), FnMapFilter((k, v) -> (v != ""), FnMap("service_name", FnToString(ServiceName))))) AS Attributes] funcs=[FnArgMax(Count, TimeUnix) AS Count, FnArgMax(Sum, TimeUnix) AS Sum, FnArgMax(Scale, TimeUnix) AS Scale, FnArgMax(ZeroCount, TimeUnix) AS ZeroCount, FnArgMax(PositiveOffset, TimeUnix) AS PositiveOffset, FnArgMax(PositiveBucketCounts, TimeUnix) AS PositiveBucketCounts, FnArgMax(NegativeOffset, TimeUnix) AS NegativeOffset, FnArgMax(NegativeBucketCounts, TimeUnix) AS NegativeBucketCounts]
+        Filter predicate=(((MetricName IN ("http_server_duration_exp_hist", "http.server.duration.exp.hist", "http.server.duration.exp/hist", "http.server.duration.exp_hist", "http.server.duration/exp/hist", "http.server.duration/exp_hist", "http.server.duration_exp.hist", "http.server.duration_exp_hist", "http.server/duration/exp/hist", "http.server/duration/exp_hist", "http.server/duration_exp_hist", "http.server_duration.exp.hist", "http.server_duration.exp_hist", "http.server_duration_exp.hist", "http.server_duration_exp_hist", "http/server/duration/exp/hist", "http/server/duration/exp_hist", "http/server/duration_exp_hist", "http/server_duration_exp_hist", "http_server.duration.exp.hist", "http_server.duration.exp_hist", "http_server.duration_exp.hist", "http_server.duration_exp_hist", "http_server_duration.exp.hist", "http_server_duration.exp_hist", "http_server_duration_exp.hist")) AND (TimeUnix <= FnToDateTime64("2026-01-01 00:00:01.000000000", 9))) AND (TimeUnix > (FnToDateTime64("2026-01-01 00:00:01.000000000", 9) - FnToIntervalNanosecond(300000000000))))
+          Scan(otel_metrics_exponential_histogram)
+-- sql --
+SELECT `MetricName`, `Attributes`, `TimeUnix`, `Value`, `HistogramCount`, `HistogramSum`, `HistogramScale`, `HistogramZeroThreshold`, `HistogramZeroCount`, `HistogramPositiveOffset`, `HistogramPositiveBucketCounts`, `HistogramNegativeOffset`, `HistogramNegativeBucketCounts`, `_setop_is_histogram` FROM (SELECT `MetricName`, `Attributes`, `TimeUnix`, `Value`, `HistogramCount`, `HistogramSum`, `HistogramScale`, `HistogramZeroThreshold`, `HistogramZeroCount`, `HistogramPositiveOffset`, `HistogramPositiveBucketCounts`, `HistogramNegativeOffset`, `HistogramNegativeBucketCounts`, `_setop_is_histogram`, `_setop_side`, max(`_setop_side` = 0) OVER (PARTITION BY mapSort(`Attributes`)) AS `_setop_has_left` FROM (((SELECT `MetricName`, `Attributes`, `TimeUnix`, `Value`, `HistogramCount`, `HistogramSum`, `HistogramScale`, `HistogramZeroThreshold`, `HistogramZeroCount`, `HistogramPositiveOffset`, `HistogramPositiveBucketCounts`, `HistogramNegativeOffset`, `HistogramNegativeBucketCounts`, `_setop_is_histogram`, 0 AS `_setop_side` FROM (SELECT `MetricName`, `Attributes`, `TimeUnix`, `Value`, `HistogramCount`, `HistogramSum`, `HistogramScale`, `HistogramZeroThreshold`, `HistogramZeroCount`, `HistogramPositiveOffset`, `HistogramPositiveBucketCounts`, `HistogramNegativeOffset`, `HistogramNegativeBucketCounts`, 1 AS `_setop_is_histogram` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, now64(?) AS `TimeUnix`, toFloat64(?) AS `Value`, toFloat64(`Count`) AS `HistogramCount`, toFloat64(`Sum`) AS `HistogramSum`, toInt32(`Scale`) AS `HistogramScale`, toFloat64(0.) AS `HistogramZeroThreshold`, toFloat64(`ZeroCount`) AS `HistogramZeroCount`, toInt32(`PositiveOffset`) AS `HistogramPositiveOffset`, arrayMap(x -> toFloat64(x), `PositiveBucketCounts`) AS `HistogramPositiveBucketCounts`, toInt32(`NegativeOffset`) AS `HistogramNegativeOffset`, arrayMap(x -> toFloat64(x), `NegativeBucketCounts`) AS `HistogramNegativeBucketCounts` FROM (SELECT mapSort(mapConcat(mapUpdate(mapFromArrays(arrayMap(k -> replaceRegexpAll(k, '[^a-zA-Z0-9_]', '_'), mapKeys(mapFilter((k, v) -> (k NOT IN (?, ?)), `ResourceAttributes`))), mapValues(mapFilter((k, v) -> (k NOT IN (?, ?)), `ResourceAttributes`))), mapFromArrays(arrayMap(k -> replaceRegexpAll(k, '[^a-zA-Z0-9_]', '_'), mapKeys(`Attributes`)), mapValues(`Attributes`))), mapFilter((k, v) -> (v != ?), map(?, toString(`ServiceName`))))) AS `Attributes`, argMax(`MetricName`, `TimeUnix`) AS `MetricName`, argMax(`Count`, `TimeUnix`) AS `Count`, argMax(`Sum`, `TimeUnix`) AS `Sum`, argMax(`Scale`, `TimeUnix`) AS `Scale`, argMax(`ZeroCount`, `TimeUnix`) AS `ZeroCount`, argMax(`PositiveOffset`, `TimeUnix`) AS `PositiveOffset`, argMax(`PositiveBucketCounts`, `TimeUnix`) AS `PositiveBucketCounts`, argMax(`NegativeOffset`, `TimeUnix`) AS `NegativeOffset`, argMax(`NegativeBucketCounts`, `TimeUnix`) AS `NegativeBucketCounts` FROM (SELECT * FROM `otel_metrics_exponential_histogram` PREWHERE (`MetricName` IN (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)) WHERE (`TimeUnix` <= toDateTime64(?, ?)) AND (`TimeUnix` > (toDateTime64(?, ?) - toIntervalNanosecond(?)))) GROUP BY `Attributes`))))) UNION ALL ((SELECT `MetricName`, `Attributes`, `TimeUnix`, `Value`, `HistogramCount`, `HistogramSum`, `HistogramScale`, `HistogramZeroThreshold`, `HistogramZeroCount`, `HistogramPositiveOffset`, `HistogramPositiveBucketCounts`, `HistogramNegativeOffset`, `HistogramNegativeBucketCounts`, `_setop_is_histogram`, 1 AS `_setop_side` FROM (SELECT `MetricName`, `Attributes`, `TimeUnix`, `Value`, toFloat64(0) AS `HistogramCount`, toFloat64(0) AS `HistogramSum`, toInt32(0) AS `HistogramScale`, toFloat64(0) AS `HistogramZeroThreshold`, toFloat64(0) AS `HistogramZeroCount`, toInt32(0) AS `HistogramPositiveOffset`, emptyArrayFloat64() AS `HistogramPositiveBucketCounts`, toInt32(0) AS `HistogramNegativeOffset`, emptyArrayFloat64() AS `HistogramNegativeBucketCounts`, 0 AS `_setop_is_histogram` FROM (SELECT ? AS `MetricName`, `Attributes` AS `Attributes`, now64(?) AS `TimeUnix`, `Value` AS `Value` FROM (SELECT `Attributes` AS `Attributes`, if(0.5 < 0, -inf, if(0.5 > 1, inf, if(`Count` = 0, nan, if(0.5 = 0, if(arrayFirstIndex(c -> c > 0, `_cerb_hq_buckets`) <= length(`NegativeBucketCounts`), -pow(pow(2, pow(2, -`Scale`)), `NegativeOffset` + (length(`NegativeBucketCounts`) - arrayFirstIndex(c -> c > 0, `_cerb_hq_buckets`)) + 1), if(arrayFirstIndex(c -> c > 0, `_cerb_hq_buckets`) = length(`NegativeBucketCounts`) + 1, if(length(`NegativeBucketCounts`) = 0 AND length(`PositiveBucketCounts`) > 0, 0., -0.), pow(pow(2, pow(2, -`Scale`)), `PositiveOffset` + (arrayFirstIndex(c -> c > 0, `_cerb_hq_buckets`) - length(`NegativeBucketCounts`) - 2)))), if(0.5 = 1, if(arrayLastIndex(c -> c > 0, `_cerb_hq_buckets`) <= length(`NegativeBucketCounts`), -pow(pow(2, pow(2, -`Scale`)), `NegativeOffset` + (length(`NegativeBucketCounts`) - arrayLastIndex(c -> c > 0, `_cerb_hq_buckets`))), if(arrayLastIndex(c -> c > 0, `_cerb_hq_buckets`) = length(`NegativeBucketCounts`) + 1, if(length(`PositiveBucketCounts`) = 0 AND length(`NegativeBucketCounts`) > 0, 0., 0.), pow(pow(2, pow(2, -`Scale`)), `PositiveOffset` + (arrayLastIndex(c -> c > 0, `_cerb_hq_buckets`) - length(`NegativeBucketCounts`) - 1)))), if(`_cerb_hq_idx` = 0, nan, if(`_cerb_hq_value_idx` <= length(`NegativeBucketCounts`), -pow(pow(2, pow(2, -`Scale`)), `NegativeOffset` + (length(`NegativeBucketCounts`) - `_cerb_hq_value_idx`) + 1 - ((0.5 * `Count`) - `_cerb_hq_cum`[`_cerb_hq_idx` - 1]) / `_cerb_hq_buckets`[`_cerb_hq_value_idx`]), if(`_cerb_hq_value_idx` = length(`NegativeBucketCounts`) + 1, if(length(`NegativeBucketCounts`) = 0 AND length(`PositiveBucketCounts`) > 0, 0., -0.) + (if(length(`PositiveBucketCounts`) = 0 AND length(`NegativeBucketCounts`) > 0, 0., 0.) - if(length(`NegativeBucketCounts`) = 0 AND length(`PositiveBucketCounts`) > 0, 0., -0.)) * ((0.5 * `Count`) - `_cerb_hq_cum`[`_cerb_hq_idx` - 1]) / `_cerb_hq_buckets`[`_cerb_hq_value_idx`], pow(pow(2, pow(2, -`Scale`)), `PositiveOffset` + (`_cerb_hq_value_idx` - length(`NegativeBucketCounts`) - 2) + ((0.5 * `Count`) - `_cerb_hq_cum`[`_cerb_hq_idx` - 1]) / `_cerb_hq_buckets`[`_cerb_hq_value_idx`]))))))))) AS `Value` FROM (SELECT *, if(isNaN(`Sum`), if(length(`PositiveBucketCounts`) > 0, length(`NegativeBucketCounts`) + 1 + length(`PositiveBucketCounts`), if(`ZeroCount` > 0, length(`NegativeBucketCounts`) + 1, length(`NegativeBucketCounts`))), `_cerb_hq_idx`) AS `_cerb_hq_value_idx` FROM (SELECT *, if(isNaN(`Sum`), arrayFirstIndex(c -> c >= (0.5 * `Count`), `_cerb_hq_cum`), arrayFirstIndex(c -> `_cerb_hq_cum`[length(`_cerb_hq_cum`)] - c < ((1 - 0.5) * `Count`), `_cerb_hq_cum`)) AS `_cerb_hq_idx` FROM (SELECT *, arrayCumSum(`_cerb_hq_buckets`) AS `_cerb_hq_cum` FROM (SELECT *, arrayConcat(arrayReverse(`NegativeBucketCounts`), [`ZeroCount`], `PositiveBucketCounts`) AS `_cerb_hq_buckets` FROM (SELECT mapSort(mapConcat(mapUpdate(mapFromArrays(arrayMap(k -> replaceRegexpAll(k, '[^a-zA-Z0-9_]', '_'), mapKeys(mapFilter((k, v) -> (k NOT IN (?, ?)), `ResourceAttributes`))), mapValues(mapFilter((k, v) -> (k NOT IN (?, ?)), `ResourceAttributes`))), mapFromArrays(arrayMap(k -> replaceRegexpAll(k, '[^a-zA-Z0-9_]', '_'), mapKeys(`Attributes`)), mapValues(`Attributes`))), mapFilter((k, v) -> (v != ?), map(?, toString(`ServiceName`))))) AS `Attributes`, argMax(`Count`, `TimeUnix`) AS `Count`, argMax(`Sum`, `TimeUnix`) AS `Sum`, argMax(`Scale`, `TimeUnix`) AS `Scale`, argMax(`ZeroCount`, `TimeUnix`) AS `ZeroCount`, argMax(`PositiveOffset`, `TimeUnix`) AS `PositiveOffset`, argMax(`PositiveBucketCounts`, `TimeUnix`) AS `PositiveBucketCounts`, argMax(`NegativeOffset`, `TimeUnix`) AS `NegativeOffset`, argMax(`NegativeBucketCounts`, `TimeUnix`) AS `NegativeBucketCounts` FROM (SELECT * FROM `otel_metrics_exponential_histogram` PREWHERE (`MetricName` IN (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)) WHERE (`TimeUnix` <= toDateTime64(?, ?)) AND (`TimeUnix` > (toDateTime64(?, ?) - toIntervalNanosecond(?)))) GROUP BY `Attributes`)))))))))))) WHERE `_setop_side` = 0 OR `_setop_has_left` = 0


### PR DESCRIPTION
## What

Closes #2330: `or` between a float-valued and a histogram-valued operand now lowers and executes,
matching reference Prometheus's per-`Sample` value-type flexibility instead of cerberus's prior
whole-query single-shape assumption.

`chplan.RowShapeOf` grows a `Mixed` state alongside its existing float/histogram answers for
`VectorSetOp`/`NaryVectorSetOp`; every caller (chclient's per-row decode, the handler's
`wrapWithSampleProjection`) now branches on a per-row discriminator instead of deciding the whole
query's shape once. The chsql emitter's `UNION ALL` between an `or` operator's two arms widens to a
shared fourteen-column projection (canonical quartet + nine `Histogram*Column`s + a trailing
discriminator) via `emitMixedVectorSetOp`, NULL-padding whichever arm is missing columns.

## Deliberately scoped out — tracked by #2333

Scoped to a plain (non-windowed) float side for now — a windowed or derived float operand
(`rate(...)`, an `_over_time` reducer, a matrix `query_range` window) still explicitly rejects with
a clear error, not a silent wrong-SQL bug. Closing that needs the same matrix/derived-shape
canonicalisation `vectorSetOpCanonicalArmFrag` already has for the plain (non-Mixed) case, and
combining that with this PR's histogram/float asymmetry work in one PR would mix two axes of
complexity. Filed as **#2333**.

## Verification

- [x] `go build ./...`, `go vet ./...`
- [x] `go test -race ./internal/promql/... ./internal/chplan/... ./internal/chsql/...`
- [x] chDB round-trip TXTAR fixtures for both operand orderings
      (`exp_histogram_set_op_or_mixed_float_left.txtar`,
      `exp_histogram_set_op_or_mixed_histogram_left.txtar`)
- [x] `CERBERUS_UPDATE_INVENTORY=1 go test ./test/surface-parity/ ./test/rejection-parity/` — clean