### PR TITLE
feat(promql): scale a histogram by a float-vector MUL/DIV operand

### DIFF
--- a/.github/scripts/forbid-verbatim-concat.mjs
+++ b/.github/scripts/forbid-verbatim-concat.mjs
@@ -59,8 +59,8 @@ import process from 'node:process';
 const KNOWN_GOOD = new Set([
   // Category 1 — synthetic single-letter join alias + fixed punctuation.
   'internal/chsql/structural_join.go:556', // starExceptKeys: verbatim(side+".*")
-  'internal/chsql/vector_join.go:770',     // qualColFrag: verbatim(side+".")
-  'internal/chsql/vector_join.go:784',     // aliasedFrag: verbatim(" AS "+bareAlias)
+  'internal/chsql/vector_join.go:792',     // qualColFrag: verbatim(side+".")
+  'internal/chsql/vector_join.go:806',     // aliasedFrag: verbatim(" AS "+bareAlias)
 
   // Category 2 — tracked pre-existing debt, not yet fixed.
   // These two are already fixed by #2297 / PR #2319 (open, converts both to

--- a/.github/scripts/mutation-phases.mjs
+++ b/.github/scripts/mutation-phases.mjs
@@ -75,7 +75,7 @@ export const PHASES = [
     // metrics_compare + prewhere + exemplars + structural_join + late_mat +
     // range_window_grid_native + range_bucket_fanout + emit + vector_set_op + set_op.
     exclude_files:
-      '^(absent_over_time|builder|chaos_sleep|chaos_sleep_stub|ddl|doc|duplicate_labelset|emit_node|fnresolution|histogram_over_time|histogram_projection|histogram_quantile|histogram_quantile_native|histogram_vector_join|info_join|metrics_second_stage|nary_vector_set_op|nested_set_annotate|query_exemplars|range_lwr|range_window|range_window_fused|range_window_stale_resample|range_window_variants|scan_resource_bound|search_trace_limit|tableshape|vector_join)\\.go$',
+      '^(absent_over_time|builder|chaos_sleep|chaos_sleep_stub|ddl|doc|duplicate_labelset|emit_node|fnresolution|histogram_float_vector_join|histogram_over_time|histogram_projection|histogram_quantile|histogram_quantile_native|histogram_vector_join|info_join|metrics_second_stage|nary_vector_set_op|nested_set_annotate|query_exemplars|range_lwr|range_window|range_window_fused|range_window_stale_resample|range_window_variants|scan_resource_bound|search_trace_limit|tableshape|vector_join)\\.go$',
   },
   {
     phase: 'phase2-builder',
@@ -84,10 +84,12 @@ export const PHASES = [
     workers: DEFAULT_WORKERS,
     // builder + emit_node + histogram_over_time + vector_join + range_lwr +
     // histogram_quantile_native + histogram_projection + range_window_stale_resample +
-    // query_exemplars. histogram_vector_join.go is left unexcluded here (rather
-    // than falling to the phase2-other catch-all) because it belongs here: it is
-    // vector_join.go's declared sibling — the same broadcast + Include-overlay
-    // join shape generalized to carry a histogram payload per side — and
+    // query_exemplars. histogram_vector_join.go and histogram_float_vector_join.go
+    // are left unexcluded here (rather than falling to the phase2-other
+    // catch-all) because they belong here: both are vector_join.go's declared
+    // siblings — the same broadcast + Include-overlay join shape generalized to
+    // carry a histogram payload per side (histogram_vector_join.go) or a
+    // per-row float scale factor (histogram_float_vector_join.go) — and
     // vector_join.go is itself only ever claimed by this leg.
     exclude_files:
       '^(absent_over_time|chaos_sleep|chaos_sleep_stub|ddl|doc|duplicate_labelset|emit|exemplars|fnresolution|histogram_quantile|info_join|late_mat|metrics_compare|metrics_second_stage|nary_vector_set_op|nested_set_annotate|prewhere|range_bucket_fanout|range_window|range_window_fused|range_window_grid_native|range_window_variants|scan_resource_bound|search_trace_limit|set_op|structural_join|tableshape|vector_set_op)\\.go$',
@@ -104,16 +106,17 @@ export const PHASES = [
     // is why this leg keeps no positive file list to fall out of sync. The two
     // legs above DO enumerate it, so a new file is briefly mutated three times
     // over; TestMutationLegsPartitionEveryScopedFile fails on exactly that.
-    // histogram_projection.go and histogram_vector_join.go are explicitly
-    // enumerated (rather than left to this catch-all) because each belongs to
-    // phase2-builder: histogram_projection.go is histogram_quantile_native.go's
-    // declared sibling (same single-plan-node emitter shape, same
-    // zeroBandOrigin() constant it shares from that file), and
-    // histogram_vector_join.go is vector_join.go's declared sibling (same
-    // broadcast + Include-overlay join shape) — both siblings are themselves
-    // only ever claimed by phase2-builder.
+    // histogram_projection.go, histogram_vector_join.go, and
+    // histogram_float_vector_join.go are explicitly enumerated (rather than
+    // left to this catch-all) because each belongs to phase2-builder:
+    // histogram_projection.go is histogram_quantile_native.go's declared
+    // sibling (same single-plan-node emitter shape, same zeroBandOrigin()
+    // constant it shares from that file), and histogram_vector_join.go /
+    // histogram_float_vector_join.go are vector_join.go's declared siblings
+    // (same broadcast + Include-overlay join shape) — all three siblings are
+    // themselves only ever claimed by phase2-builder.
     exclude_files:
-      '^(builder|emit|emit_node|exemplars|histogram_over_time|histogram_projection|histogram_quantile_native|histogram_vector_join|late_mat|metrics_compare|prewhere|query_exemplars|range_bucket_fanout|range_lwr|range_window_grid_native|range_window_stale_resample|set_op|structural_join|vector_join|vector_set_op)\\.go$',
+      '^(builder|emit|emit_node|exemplars|histogram_float_vector_join|histogram_over_time|histogram_projection|histogram_quantile_native|histogram_vector_join|late_mat|metrics_compare|prewhere|query_exemplars|range_bucket_fanout|range_lwr|range_window_grid_native|range_window_stale_resample|set_op|structural_join|vector_join|vector_set_op)\\.go$',
   },
   {
     phase: 'phase3-optimizer',

--- a/internal/chplan/clone.go
+++ b/internal/chplan/clone.go
@@ -191,6 +191,12 @@ func cloneCompositeNode(n Node) Node {
 		c.Match.Labels = cloneStrings(v.Match.Labels)
 		c.Include = cloneStrings(v.Include)
 		return &c
+	case *HistogramFloatVectorJoin:
+		c := *v
+		c.Left = CloneNode(v.Left)
+		c.Right = CloneNode(v.Right)
+		c.Match.Labels = cloneStrings(v.Match.Labels)
+		return &c
 	case *VectorSetOp:
 		c := *v
 		c.Left = CloneNode(v.Left)

--- a/internal/chplan/clone_test.go
+++ b/internal/chplan/clone_test.go
@@ -79,6 +79,10 @@ func allNodeKinds() []chplan.Node {
 			Card: chplan.CardManyToOne, Include: []string{"region"},
 			MetricNameColumn: "MetricName", AttributesColumn: "Attributes", TimestampColumn: "TimeUnix",
 		},
+		&chplan.HistogramFloatVectorJoin{
+			Left: leaf, Right: &chplan.Scan{Table: "r"}, Match: chplan.VectorMatch{},
+			MetricNameColumn: "MetricName", AttributesColumn: "Attributes", TimestampColumn: "TimeUnix", ValueColumn: "Value",
+		},
 		&chplan.VectorSetOp{Left: leaf, Right: &chplan.Scan{Table: "r"}, Match: chplan.VectorMatch{Labels: []string{"job"}}, ValueColumn: "Value"},
 		&chplan.NaryVectorSetOp{
 			Arms: []chplan.Node{leaf, &chplan.Scan{Table: "r"}, &chplan.Scan{Table: "s"}},

--- a/internal/chplan/derived_shape_test.go
+++ b/internal/chplan/derived_shape_test.go
@@ -46,12 +46,17 @@ var derivedShapeVerdicts = map[string]bool{
 
 	// Everything else keeps the canonical columns in scope (or is
 	// re-canonicalised by its own emit, as a nested VectorSetOp is).
-	"AbsentOverTime":           false,
-	"CrossJoin":                false,
-	"Filter":                   false,
-	"HistogramQuantile":        false,
-	"HistogramQuantileNative":  false,
-	"HistogramProjection":      false,
+	"AbsentOverTime":          false,
+	"CrossJoin":               false,
+	"Filter":                  false,
+	"HistogramQuantile":       false,
+	"HistogramQuantileNative": false,
+	"HistogramProjection":     false,
+	// HistogramFloatVectorJoin's own SELECT names a real bare
+	// MetricName column (from its histogram-valued Left side, byte-
+	// identical to HistogramProjection's own output), unlike
+	// HistogramVectorJoin's `_hq_L_*`/`_hq_R_*`-prefixed shape above.
+	"HistogramFloatVectorJoin": false,
 	"InfoJoin":                 false,
 	"Limit":                    false,
 	"MetricsCompare":           false,

--- a/internal/chplan/histogram_float_vector_join.go
+++ b/internal/chplan/histogram_float_vector_join.go
@@ -1,0 +1,77 @@
+package chplan
+
+// HistogramFloatVectorJoin implements MUL (either operand order) and
+// histogram-left DIV histogram-SCALING by a genuine per-series float-
+// VECTOR operand, under DEFAULT (full-Attributes) one-to-one vector
+// matching (cerberus issue #2339). [expHistogramScalarBinop]'s scaling
+// machinery (internal/promql/histogram_native_scalar_binop.go, #2087)
+// already folds a compile-time scalar LITERAL scale factor into every
+// histogram bucket; this node supplies the row-by-row MATCH a genuine
+// per-series float-VECTOR operand needs before that same fold can run —
+// a real INNER JOIN keyed on Attributes, mirroring [VectorJoin]'s
+// default one-to-one shape (vector_join.go) and [HistogramVectorJoin]'s
+// histogram-side handling (histogram_vector_join.go, #2328), but neither
+// of those directly: unlike VectorJoin, one side carries nine histogram
+// fields instead of a single Value; unlike HistogramVectorJoin, the
+// OTHER side carries a single plain Value instead of nine histogram
+// fields, and there is no group_left()/group_right() cardinality here to
+// broadcast.
+//
+// Left is the already-lowered histogram-valued operand (a
+// *HistogramProjection); Right is the already-lowered PLAIN float-valued
+// operand. The emitter (internal/chsql/histogram_float_vector_join.go)
+// publishes ONE row per matched pair under the SAME canonical column
+// names Left's own HistogramProjection cap publishes — MetricName,
+// Attributes, TimeUnix, and the nine fixed Histogram*Column fields —
+// plus Right's own ValueColumn carrying the per-series float scale
+// factor. That is deliberately the exact shape [HistogramProjection]
+// itself publishes, plus one extra Value column, so the calling
+// lowering can feed this node straight into the SAME per-bucket
+// scale-fold [scaleHistogramProjection] already applies for the
+// literal-scalar case, reading the scale factor off Value instead of a
+// constant.
+//
+// Only default (full-Attributes) one-to-one matching is supported today:
+// Match must carry no Labels and On == false. on()/ignoring() reduced-key
+// matching and group_left()/group_right() many-to-one broadcast for this
+// histogram/float-vector scaling shape are tracked as follow-up work —
+// see the #2339 PR body for the filed issue. The emitter rejects any
+// other Match shape outright rather than silently mis-joining.
+type HistogramFloatVectorJoin struct {
+	Left  Node // *HistogramProjection, the histogram-valued operand.
+	Right Node // The plain float-valued operand.
+
+	Match VectorMatch
+
+	// StepAligned mirrors VectorJoin.StepAligned / HistogramVectorJoin.
+	// StepAligned: when true (range mode) the emitter additionally ANDs
+	// `L.<ts> = R.<ts>` into the JOIN's ON clause so each per-step grid
+	// anchor only joins its own per-anchor pair.
+	StepAligned bool
+
+	MetricNameColumn string
+	AttributesColumn string
+	TimestampColumn  string
+	ValueColumn      string
+}
+
+func (*HistogramFloatVectorJoin) planNode() {}
+
+func (j *HistogramFloatVectorJoin) Children() []Node { return []Node{j.Left, j.Right} }
+
+func (j *HistogramFloatVectorJoin) Equal(other Node) bool {
+	o, ok := other.(*HistogramFloatVectorJoin)
+	if !ok {
+		return false
+	}
+	if !j.Match.Equal(o.Match) || j.StepAligned != o.StepAligned {
+		return false
+	}
+	if j.MetricNameColumn != o.MetricNameColumn ||
+		j.AttributesColumn != o.AttributesColumn ||
+		j.TimestampColumn != o.TimestampColumn ||
+		j.ValueColumn != o.ValueColumn {
+		return false
+	}
+	return j.Left.Equal(o.Left) && j.Right.Equal(o.Right)
+}

--- a/internal/chplan/rewrite_children.go
+++ b/internal/chplan/rewrite_children.go
@@ -249,6 +249,13 @@ func rewriteBinaryNode(n Node, fn func(Node) (Node, bool)) (out Node, changed, h
 			cp.Right = r
 			return &cp
 		})
+	case *HistogramFloatVectorJoin:
+		out, changed = rewriteLeftRight(v, v.Left, v.Right, fn, func(l, r Node) Node {
+			cp := *v
+			cp.Left = l
+			cp.Right = r
+			return &cp
+		})
 	case *VectorSetOp:
 		out, changed = rewriteLeftRight(v, v.Left, v.Right, fn, func(l, r Node) Node {
 			cp := *v

--- a/internal/chplan/rewrite_children_exhaustive_test.go
+++ b/internal/chplan/rewrite_children_exhaustive_test.go
@@ -125,6 +125,7 @@ func allNodeCases() []nodeExhaustivenessCase {
 		{"StructuralJoin", &StructuralJoin{Left: sentinelChild(), Right: sentinelChild()}, false},
 		{"VectorJoin", &VectorJoin{Left: sentinelChild(), Right: sentinelChild()}, false},
 		{"HistogramVectorJoin", &HistogramVectorJoin{Left: sentinelChild(), Right: sentinelChild()}, false},
+		{"HistogramFloatVectorJoin", &HistogramFloatVectorJoin{Left: sentinelChild(), Right: sentinelChild()}, false},
 		{"VectorSetOp", &VectorSetOp{Left: sentinelChild(), Right: sentinelChild()}, false},
 		{"SetOperation", &SetOperation{Left: sentinelChild(), Right: sentinelChild()}, false},
 	}

--- a/internal/chplan/row_shape.go
+++ b/internal/chplan/row_shape.go
@@ -215,6 +215,20 @@ func RowShapeOf(n Node) RowShape {
 		// [IsDerivedShape]'s HistogramVectorJoin arm for the same
 		// reasoning from the MetricName side.
 		return SampleRowShape
+	case *HistogramFloatVectorJoin:
+		// Its own SELECT genuinely does publish the canonical
+		// MetricName/Attributes/TimeUnix names plus the nine fixed
+		// Histogram*Column fields — unlike HistogramVectorJoin's
+		// `_hq_L_*`/`_hq_R_*`-prefixed shape above — but ALSO an extra
+		// Value column no HistogramRowShape consumer expects, so
+		// neither fixed shape is an exact fit. SampleRowShape here is
+		// likewise a documentation default rather than a claim about
+		// live columns: no generic forwarder is ever placed directly
+		// over it — the calling lowering (internal/promql's
+		// histogram_native_float_vector_scaling_binop.go) always wraps
+		// it in an explicit-column Project first, exactly as
+		// HistogramVectorJoin's callers do.
+		return SampleRowShape
 	case *RangeWindowStaleResample:
 		// Spelled out because it is the third `RangeWindow*` node and the
 		// one most likely to be swept in here by analogy. Its emitter

--- a/internal/chplan/row_shape_test.go
+++ b/internal/chplan/row_shape_test.go
@@ -40,6 +40,7 @@ var rowShapeVerdicts = map[string]chplan.RowShape{
 	"HistogramQuantileNative":  chplan.SampleRowShape,
 	"HistogramProjection":      chplan.HistogramRowShape,
 	"HistogramVectorJoin":      chplan.SampleRowShape,
+	"HistogramFloatVectorJoin": chplan.SampleRowShape,
 	"InfoJoin":                 chplan.SampleRowShape,
 	"Limit":                    chplan.SampleRowShape,
 	"MetricsAggregate":         chplan.SampleRowShape,

--- a/internal/chsql/emit.go
+++ b/internal/chsql/emit.go
@@ -320,6 +320,8 @@ func (e *emitter) emitNode(n chplan.Node) error {
 		return e.emitVectorJoin(v)
 	case *chplan.HistogramVectorJoin:
 		return e.emitHistogramVectorJoin(v)
+	case *chplan.HistogramFloatVectorJoin:
+		return e.emitHistogramFloatVectorJoin(v)
 	case *chplan.VectorSetOp:
 		return e.emitVectorSetOp(v)
 	case *chplan.NaryVectorSetOp:

--- a/internal/chsql/histogram_float_vector_join.go
+++ b/internal/chsql/histogram_float_vector_join.go
@@ -1,0 +1,131 @@
+package chsql
+
+import (
+	"fmt"
+
+	"github.com/tsouza/cerberus/internal/chplan"
+)
+
+// histogram_float_vector_join.go emits chplan.HistogramFloatVectorJoin
+// (cerberus issue #2339): a real INNER JOIN between a histogram-valued
+// operand (Left, a *chplan.HistogramProjection) and a plain float-valued
+// operand (Right), keyed on Attributes under DEFAULT one-to-one vector
+// matching only.
+//
+// Unlike emitHistogramVectorJoin, the two sides are NOT symmetric: only
+// Left carries the nine histogram fields, and they ride through under
+// their PLAIN canonical names (MetricName, Attributes, TimeUnix, the
+// fixed Histogram*Column set) rather than `_hq_L_*`/`_hq_R_*` — matching
+// exactly what Left's own HistogramProjection cap already publishes, so
+// the calling lowering can feed this node straight into the same
+// per-bucket scale-fold literal-scalar scaling uses
+// (internal/promql/histogram_native_scalar_binop.go's
+// scaleHistogramProjection), reading the scale factor off the joined
+// Value column instead of a compile-time constant. Right contributes
+// only that single Value column, reusing [emitter.joinSideFrag] — the
+// exact per-side "latest sample" argMax / derived-shape / step-aligned
+// logic emitVectorJoin's own Right arm already exercises — so this file
+// adds no new per-side join mechanics of its own, only the histogram
+// Left arm and the outer SELECT/JOIN shape.
+func (e *emitter) emitHistogramFloatVectorJoin(j *chplan.HistogramFloatVectorJoin) error {
+	if err := e.validateHistogramFloatVectorJoinCols(j); err != nil {
+		return err
+	}
+
+	leftFrag, err := e.histogramFloatVectorJoinHistSideFrag(j)
+	if err != nil {
+		return err
+	}
+	rightFrag, err := e.joinSideFrag(
+		j.Match, j.MetricNameColumn, j.AttributesColumn, j.TimestampColumn, j.ValueColumn, j.StepAligned, j.Right, roleMany,
+	)
+	if err != nil {
+		return err
+	}
+
+	cols := histogramFloatVectorJoinHistCols(j)
+	selects := make([]Frag, 0, len(cols)+1)
+	for _, col := range cols {
+		selects = append(selects, As(qualColFrag("L", col), col))
+	}
+	selects = append(selects, As(qualColFrag("R", j.ValueColumn), j.ValueColumn))
+
+	sb := NewQuery().
+		Select(selects...).
+		From(aliasedFrag(leftFrag, "L")).
+		Join(InnerJoin, aliasedFrag(rightFrag, "R"), vectorMatchPredicateFrag(j.Match, j.AttributesColumn, j.TimestampColumn, j.StepAligned))
+	return e.emitSelect(sb)
+}
+
+func (e *emitter) validateHistogramFloatVectorJoinCols(j *chplan.HistogramFloatVectorJoin) error {
+	switch {
+	case j.AttributesColumn == "":
+		return fmt.Errorf("%w: HistogramFloatVectorJoin.AttributesColumn unset", ErrUnsupported)
+	case j.MetricNameColumn == "":
+		return fmt.Errorf("%w: HistogramFloatVectorJoin.MetricNameColumn unset", ErrUnsupported)
+	case j.TimestampColumn == "":
+		return fmt.Errorf("%w: HistogramFloatVectorJoin.TimestampColumn unset", ErrUnsupported)
+	case j.ValueColumn == "":
+		return fmt.Errorf("%w: HistogramFloatVectorJoin.ValueColumn unset", ErrUnsupported)
+	case len(j.Match.Labels) != 0 || j.Match.On:
+		// on()/ignoring() reduced-key matching for this histogram/
+		// float-vector scaling shape is tracked as follow-up work (see
+		// the node's own doc comment) — reject outright rather than
+		// silently mis-joining on the wrong key.
+		return fmt.Errorf("%w: HistogramFloatVectorJoin only supports default (full-Attributes) vector matching", ErrUnsupported)
+	}
+	return nil
+}
+
+// histogramFloatVectorJoinHistCols lists every field the join's Left
+// (histogram) arm carries through: MetricName, Attributes, TimeUnix,
+// then the nine fixed histogram payload columns — byte-identical to
+// histogramVectorJoinFieldCols' own list, minus the Right side's fields
+// (there are none to list: Right contributes only ValueColumn, handled
+// separately by [emitter.joinSideFrag]).
+func histogramFloatVectorJoinHistCols(j *chplan.HistogramFloatVectorJoin) []string {
+	return []string{
+		j.MetricNameColumn, j.AttributesColumn, j.TimestampColumn,
+		chplan.HistogramScaleColumn, chplan.HistogramCountColumn, chplan.HistogramSumColumn,
+		chplan.HistogramZeroCountColumn, chplan.HistogramZeroThresholdColumn,
+		chplan.HistogramPositiveOffsetColumn, chplan.HistogramPositiveBucketCountsColumn,
+		chplan.HistogramNegativeOffsetColumn, chplan.HistogramNegativeBucketCountsColumn,
+	}
+}
+
+// histogramFloatVectorJoinHistSideFrag renders the join's Left
+// (histogram) arm as a Frag emitting a parenthesised SELECT subquery. A
+// *chplan.HistogramProjection input already carries at most one row per
+// (series, anchor) by construction — the same "many" guarantee
+// histogramVectorJoinSideFrag's own roleMany branch relies on — so this
+// is a straight passthrough of the nine histogram fields plus
+// MetricName/Attributes/TimeUnix, no aggregation needed: default
+// (full-Attributes) matching is the only shape
+// [validateHistogramFloatVectorJoinCols] admits, and a HistogramProjection
+// row is already unique on that exact key.
+//
+// Field columns route through the shared `_join_*`-alias-then-outer-
+// rename pattern vectorJoinSideFrag documents (breaks CH's alias-chain
+// trace through the aggregation subquery, avoiding a false
+// ILLEGAL_AGGREGATION) — joinAlias is reused verbatim from vector_join.go.
+func (e *emitter) histogramFloatVectorJoinHistSideFrag(j *chplan.HistogramFloatVectorJoin) (Frag, error) {
+	sub, err := e.subqueryFrag(j.Left)
+	if err != nil {
+		return nil, err
+	}
+	cols := histogramFloatVectorJoinHistCols(j)
+
+	inner := NewQuery().From(sub)
+	innerProjs := make([]Frag, 0, len(cols))
+	for _, col := range cols {
+		innerProjs = append(innerProjs, As(Col(col), joinAlias(col)))
+	}
+	inner.Select(innerProjs...)
+
+	outerProjs := make([]Frag, 0, len(cols))
+	for _, col := range cols {
+		outerProjs = append(outerProjs, As(Col(joinAlias(col)), col))
+	}
+	outer := NewQuery().Select(outerProjs...).From(inner.Frag())
+	return outer.Frag(), nil
+}

--- a/internal/chsql/vector_join.go
+++ b/internal/chsql/vector_join.go
@@ -174,6 +174,28 @@ func vectorJoinRoles(j *chplan.VectorJoin) (sideRole, sideRole) {
 // and outer SELECT continue to reference `L.Attributes` / `R.Value`
 // naturally.
 func (e *emitter) vectorJoinSideFrag(j *chplan.VectorJoin, n chplan.Node, role sideRole) (Frag, error) {
+	return e.joinSideFrag(j.Match, j.MetricNameColumn, j.AttributesColumn, j.TimestampColumn, j.ValueColumn, j.StepAligned, n, role)
+}
+
+// joinSideFrag is vectorJoinSideFrag's body, generalised to plain
+// parameters rather than a *chplan.VectorJoin so
+// [chplan.HistogramFloatVectorJoin]'s float-valued side (histogram_
+// float_vector_join.go, cerberus issue #2339) can reuse the identical,
+// already-exercised per-side join logic — the "latest sample" argMax
+// pick, the derived-shape / step-aligned branches, and the roleOne
+// uniqueness guard — rather than re-deriving a second copy that could
+// silently drift from this one. See vectorJoinSideFrag's own former
+// doc (now here) for why the `_join_*`-alias-then-outer-rename dance
+// exists.
+func (e *emitter) joinSideFrag(match chplan.VectorMatch, metricNameCol, attrsCol, tsCol, valCol string, stepAligned bool, n chplan.Node, role sideRole) (Frag, error) {
+	j := &chplan.VectorJoin{
+		Match:            match,
+		StepAligned:      stepAligned,
+		MetricNameColumn: metricNameCol,
+		AttributesColumn: attrsCol,
+		TimestampColumn:  tsCol,
+		ValueColumn:      valCol,
+	}
 	sub, err := e.subqueryFrag(n)
 	if err != nil {
 		return nil, err

--- a/internal/engine/resource_bound_classification_test.go
+++ b/internal/engine/resource_bound_classification_test.go
@@ -77,10 +77,11 @@ var resourceBoundClassification = map[string]struct {
 	"HistogramProjection":     {boundStructural, "1:1 row map — publishes the bounded input's native-histogram structural columns verbatim (no fan-out, no aggregation, no per-row quantile compute); same shape as Project"},
 
 	// Binary / set vector ops over two already-bounded operand vectors.
-	"VectorJoin":          {boundRuntimeNet, "axis 4: on()/ignoring() match join over two bounded vectors; max_memory_usage"},
-	"HistogramVectorJoin": {boundRuntimeNet, "axis 4: group_left()/group_right() match join between two bounded histogram-valued operand vectors (VectorJoin's many-to-one counterpart for native histograms); max_memory_usage"},
-	"VectorSetOp":         {boundStructural, "and/or/unless — ≤ the union of the two bounded operand vectors"},
-	"UnionAll":            {boundStructural, "≤ the sum of its bounded inputs"},
+	"VectorJoin":               {boundRuntimeNet, "axis 4: on()/ignoring() match join over two bounded vectors; max_memory_usage"},
+	"HistogramVectorJoin":      {boundRuntimeNet, "axis 4: group_left()/group_right() match join between two bounded histogram-valued operand vectors (VectorJoin's many-to-one counterpart for native histograms); max_memory_usage"},
+	"HistogramFloatVectorJoin": {boundRuntimeNet, "axis 4: MUL/DIV histogram-scaling match join between a bounded histogram-valued operand and a bounded float-valued operand vector (VectorJoin's per-row-scale-factor counterpart for native histograms); max_memory_usage"},
+	"VectorSetOp":              {boundStructural, "and/or/unless — ≤ the union of the two bounded operand vectors"},
+	"UnionAll":                 {boundStructural, "≤ the sum of its bounded inputs"},
 }
 
 // TestResourceBoundClassification_Exhaustive discovers every chplan plan-node

--- a/internal/promql/histogram_native_float_vector_binop_test.go
+++ b/internal/promql/histogram_native_float_vector_binop_test.go
@@ -50,8 +50,10 @@ func TestLower_ExpHistogram_IncompatibleFloatVectorBinopDropsSamples(t *testing.
 		// Float-vector-on-left DIV of a histogram divisor drops (the
 		// float side is never the numerator of a supported scaling
 		// shape); histogram-left DIV of a float-vector divisor is the
-		// UNSUPPORTED scaling direction and is covered separately by
-		// TestLower_ExpHistogram_FloatVectorScalingShapesStillRejected.
+		// SUPPORTED scaling direction and is covered separately by
+		// TestLower_ExpHistogram_FloatVectorScalingBinopAnswersScaledHistogram
+		// (histogram_native_float_vector_scaling_binop_test.go, cerberus
+		// issue #2339).
 		{name: "float vector divided by histogram", query: `histogram_quantile(0.5, latency_exp_hist) / latency_exp_hist`},
 		{name: "parenthesised", query: `(histogram_quantile(0.5, latency_exp_hist)) + latency_exp_hist`},
 		{name: "rate() plus float vector", query: `rate(latency_exp_hist[5m]) + histogram_quantile(0.5, latency_exp_hist)`},
@@ -97,40 +99,10 @@ func TestLower_ExpHistogram_IncompatibleFloatVectorBinopDropsSamples(t *testing.
 	}
 }
 
-// TestLower_ExpHistogram_FloatVectorScalingShapesStillRejected pins the
-// deliberate boundary this file's header doc explains: MUL (either
-// side) and histogram-left DIV between a histogram-valued operand and a
-// genuine (non-literal) float-VECTOR operand are reference Prometheus's
-// supported histogram-SCALING shapes, but cerberus only implements the
-// scaling machinery for a compile-time scalar LITERAL — so these keep
-// hitting expHistogramSelectorRouting's pre-existing catch-all
-// rejection rather than being answered OR silently mis-dropped. A
-// future issue can widen scaling to a genuine float-vector operand;
-// until then, dropping these would answer empty where reference answers
-// a scaled histogram, which is a worse divergence than a clean
-// rejection.
-func TestLower_ExpHistogram_FloatVectorScalingShapesStillRejected(t *testing.T) {
-	t.Parallel()
-
-	s := schema.DefaultOTelMetrics()
-	p := parser.NewParser(parser.Options{EnableExperimentalFunctions: true})
-	end := time.Date(2026, 1, 1, 1, 0, 0, 0, time.UTC)
-
-	queries := []string{
-		`histogram_quantile(0.5, latency_exp_hist) * latency_exp_hist`,
-		`latency_exp_hist * histogram_quantile(0.5, latency_exp_hist)`,
-		`latency_exp_hist / histogram_quantile(0.5, latency_exp_hist)`,
-	}
-	for _, q := range queries {
-		t.Run(q, func(t *testing.T) {
-			t.Parallel()
-			expr, err := p.ParseExpr(q)
-			if err != nil {
-				t.Fatalf("ParseExpr(%q): %v", q, err)
-			}
-			if _, err := promql.LowerAt(context.Background(), expr, s, end, end); err == nil {
-				t.Fatalf("LowerAt(%q): expected the pre-existing catch-all rejection, got success", q)
-			}
-		})
-	}
-}
+// The float-vector MUL / histogram-left-DIV scaling shapes this file's
+// header doc used to describe as a deliberate, still-rejected boundary
+// are now answered — see
+// TestLower_ExpHistogram_FloatVectorScalingBinopAnswersScaledHistogram
+// and its "still rejected" sibling in
+// histogram_native_float_vector_scaling_binop_test.go (cerberus issue
+// #2339).

--- a/internal/promql/histogram_native_float_vector_scaling_binop.go
+++ b/internal/promql/histogram_native_float_vector_scaling_binop.go
@@ -1,0 +1,126 @@
+package promql
+
+import (
+	"github.com/prometheus/prometheus/promql/parser"
+
+	"github.com/tsouza/cerberus/internal/chplan"
+	"github.com/tsouza/cerberus/internal/schema"
+)
+
+// histogram_native_float_vector_scaling_binop.go answers MUL (either
+// operand order) and histogram-left DIV histogram-SCALING by a genuine
+// per-series float-VECTOR operand, under default (full-Attributes)
+// one-to-one vector matching (cerberus issue #2339) — the gap
+// histogram_native_float_vector_binop.go's own header doc calls out as
+// deliberately left unmatched when that file shipped (#2331/#2332):
+// [expHistogramScalarBinop] (histogram_native_scalar_binop.go, #2087)
+// already scales a histogram by a compile-time scalar LITERAL
+// multiplier/divisor; this file supplies the missing row-by-row MATCH a
+// genuine per-series float-VECTOR operand needs before that SAME
+// per-bucket fold can run, via [chplan.HistogramFloatVectorJoin]
+// (internal/chplan/histogram_float_vector_join.go) — a real INNER JOIN
+// keyed on Attributes, rather than a compile-time constant riding along
+// for free.
+//
+// Reference Prometheus answers this with the identical vectorElemBinop
+// arms [expHistogramScalarBinop]'s own header doc quotes — `hlhs.Mul(rhs)`
+// / `hlhs.Div(rhs)` — except `rhs` here is each matched pair's own
+// joined float sample rather than a query-wide constant.
+//
+// Only MUL and histogram-left DIV are recognised here: the rest of the
+// op family (`+`/`-`/`^`/`%`/every comparison/`atan2`, and float-vector-
+// left DIV) already drops via [expHistogramDroppingVectorBinop]
+// (histogram_native_float_vector_binop.go, #2331), unchanged by this
+// file — [expHistogramScalarOpDropsSample] already excludes
+// histogram-left DIV from its own drop family, and MUL was never in it,
+// so the two recognisers stay disjoint without an explicit exclusion
+// here.
+//
+// Only DEFAULT (full-Attributes) one-to-one vector matching is
+// recognised: on()/ignoring() reduced-key matching and
+// group_left()/group_right() many-to-one broadcast for this
+// histogram/float-vector scaling shape fall through to
+// [expHistogramSelectorRouting]'s pre-existing catch-all rejection,
+// same as before this file existed — tracked as follow-up work (see the
+// #2339 PR body for the filed issue).
+//
+// Wired at [lowerRoot] ahead of [expHistogramDroppingVectorBinop] — the
+// same TOP-LEVEL-only dispatch point as its siblings, mirroring how the
+// literal-scalar scaling recognizer precedes its own dropping sibling
+// so a scalable shape keeps its value rather than being dropped by a
+// broader, later-checked recognizer.
+func expHistogramFloatVectorScalingBinop(expr parser.Expr, s schema.Metrics, ctx lowerCtx) (histSide, floatSide parser.Expr, op chplan.BinaryOp, ok bool) {
+	if s.ExpHistogramTable == "" || ctx.metadataFullRange {
+		return nil, nil, "", false
+	}
+	b, isBin := unwrapBinaryExpr(expr)
+	if !isBin || (b.Op != parser.MUL && b.Op != parser.DIV) {
+		return nil, nil, "", false
+	}
+	if !isDefaultMatching(b.VectorMatching) {
+		return nil, nil, "", false
+	}
+	// A compile-time scalar literal on either side is
+	// [expHistogramScalarBinop]'s own shape — excluding it here keeps
+	// the two recognisers disjoint instead of double-matching the same
+	// operator pair, mirroring [expHistogramDroppingVectorBinop]'s
+	// identical exclusion.
+	if _, isScalar := tryScalarLiteral(b.LHS); isScalar {
+		return nil, nil, "", false
+	}
+	if _, isScalar := tryScalarLiteral(b.RHS); isScalar {
+		return nil, nil, "", false
+	}
+	chOp, err := promBinaryOp(b.Op)
+	if err != nil {
+		return nil, nil, "", false
+	}
+	lhsHist := isExpHistogramValuedShape(b.LHS, s, ctx)
+	rhsHist := isExpHistogramValuedShape(b.RHS, s, ctx)
+	if b.Op == parser.MUL {
+		switch {
+		case lhsHist && !rhsHist:
+			return b.LHS, b.RHS, chOp, true
+		case rhsHist && !lhsHist:
+			return b.RHS, b.LHS, chOp, true
+		}
+		return nil, nil, "", false
+	}
+	// DIV is not commutative — only histogram-left DIV is a supported
+	// scaling shape (reference's own switch keys off which OPERAND
+	// carries the histogram, and a histogram can only be the numerator
+	// here), mirroring [expHistogramScalarBinop]'s identical DIV
+	// restriction for the literal case.
+	if lhsHist && !rhsHist {
+		return b.LHS, b.RHS, chOp, true
+	}
+	return nil, nil, "", false
+}
+
+// lowerExpHistogramFloatVectorScalingBinop lowers the shape
+// [expHistogramFloatVectorScalingBinop] recognised: joins histSide's own
+// HistogramProjection against floatSide's ordinary lowering via
+// [chplan.HistogramFloatVectorJoin], then applies the SAME per-bucket
+// scale-fold [scaleHistogramProjection] applies for a literal scalar,
+// reading the scale factor off the join's own ValueColumn instead of a
+// constant.
+func lowerExpHistogramFloatVectorScalingBinop(histSide, floatSide parser.Expr, op chplan.BinaryOp, s schema.Metrics, ctx lowerCtx) (chplan.Node, error) {
+	hp, err := lowerExpHistogramValuedOperand(histSide, s, ctx)
+	if err != nil {
+		return nil, err
+	}
+	floatNode, err := lower(floatSide, s, ctx)
+	if err != nil {
+		return nil, err
+	}
+	join := &chplan.HistogramFloatVectorJoin{
+		Left:             hp,
+		Right:            floatNode,
+		StepAligned:      ctx.step > 0,
+		MetricNameColumn: s.MetricNameColumn,
+		AttributesColumn: s.AttributesColumn,
+		TimestampColumn:  s.TimestampColumn,
+		ValueColumn:      s.ValueColumn,
+	}
+	return scaleHistogramProjection(join, op, &chplan.ColumnRef{Name: s.ValueColumn}, s), nil
+}

--- a/internal/promql/histogram_native_float_vector_scaling_binop_test.go
+++ b/internal/promql/histogram_native_float_vector_scaling_binop_test.go
@@ -1,0 +1,148 @@
+package promql_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/prometheus/prometheus/promql/parser"
+
+	"github.com/tsouza/cerberus/internal/chplan"
+	"github.com/tsouza/cerberus/internal/promql"
+	"github.com/tsouza/cerberus/internal/schema"
+)
+
+// TestLower_ExpHistogram_FloatVectorScalingBinopAnswersScaledHistogram
+// pins cerberus issue #2339: MUL (either operand order) and
+// histogram-left DIV between a histogram-valued operand and a genuine
+// (non-literal) float-VECTOR operand, under default (full-Attributes)
+// one-to-one vector matching, now answer a scaled histogram — a
+// *chplan.HistogramProjection rooted in a *chplan.HistogramFloatVectorJoin
+// — rather than the pre-existing catch-all rejection
+// TestLower_ExpHistogram_FloatVectorScalingShapesStillRejected used to
+// pin (histogram_native_float_vector_binop_test.go, now superseded).
+func TestLower_ExpHistogram_FloatVectorScalingBinopAnswersScaledHistogram(t *testing.T) {
+	t.Parallel()
+
+	s := schema.DefaultOTelMetrics()
+	p := parser.NewParser(parser.Options{EnableExperimentalFunctions: true})
+	start := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	end := start.Add(time.Hour)
+
+	cases := []struct {
+		name  string
+		query string
+		lower func(parser.Expr) (chplan.Node, error)
+	}{
+		{
+			name:  "histogram times float vector",
+			query: `latency_exp_hist * histogram_quantile(0.5, latency_exp_hist)`,
+			lower: func(e parser.Expr) (chplan.Node, error) {
+				return promql.LowerAt(context.Background(), e, s, end, end)
+			},
+		},
+		{
+			name:  "float vector times histogram (commutative)",
+			query: `histogram_quantile(0.5, latency_exp_hist) * latency_exp_hist`,
+			lower: func(e parser.Expr) (chplan.Node, error) {
+				return promql.LowerAt(context.Background(), e, s, end, end)
+			},
+		},
+		{
+			name:  "histogram divided by float vector",
+			query: `latency_exp_hist / histogram_quantile(0.5, latency_exp_hist)`,
+			lower: func(e parser.Expr) (chplan.Node, error) {
+				return promql.LowerAt(context.Background(), e, s, end, end)
+			},
+		},
+		{
+			name:  "histogram times float vector, range",
+			query: `latency_exp_hist * histogram_quantile(0.5, latency_exp_hist)`,
+			lower: func(e parser.Expr) (chplan.Node, error) {
+				return promql.LowerAtRange(context.Background(), e, s, start, end, 30*time.Second)
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			expr, err := p.ParseExpr(tc.query)
+			if err != nil {
+				t.Fatalf("ParseExpr(%q): %v", tc.query, err)
+			}
+			plan, err := tc.lower(expr)
+			if err != nil {
+				t.Fatalf("lower(%q): unexpected error: %v", tc.query, err)
+			}
+			if shape := chplan.RowShapeOf(plan); shape != chplan.HistogramRowShape {
+				t.Fatalf("lower(%q): plan root publishes %s, want histogram", tc.query, shape)
+			}
+			hp, ok := plan.(*chplan.HistogramProjection)
+			if !ok {
+				t.Fatalf("lower(%q): plan root is %T, want *chplan.HistogramProjection", tc.query, plan)
+			}
+			name, ok := hp.GroupBy[0].(*chplan.LitString)
+			if !ok || name.V != "" {
+				t.Fatalf("lower(%q): metric-name projection is %#v, want empty literal", tc.query, hp.GroupBy[0])
+			}
+			if !planContainsHistogramFloatVectorJoin(hp) {
+				t.Fatalf("lower(%q): plan does not root in a *chplan.HistogramFloatVectorJoin", tc.query)
+			}
+		})
+	}
+}
+
+// planContainsHistogramFloatVectorJoin walks n's Input/Children chain
+// looking for a *chplan.HistogramFloatVectorJoin — confirming the
+// scaling lowering actually took the JOIN path rather than, say,
+// silently degenerating to the literal-scalar scaling machinery.
+func planContainsHistogramFloatVectorJoin(n chplan.Node) bool {
+	for cur := n; cur != nil; {
+		if _, ok := cur.(*chplan.HistogramFloatVectorJoin); ok {
+			return true
+		}
+		children := cur.Children()
+		if len(children) == 0 {
+			return false
+		}
+		cur = children[0]
+	}
+	return false
+}
+
+// TestLower_ExpHistogram_FloatVectorScalingBinopStillRejected pins the
+// residual boundary this file's header doc leaves in place: on()/
+// ignoring() reduced-key matching and group_left()/group_right()
+// many-to-one broadcast are NOT supported for the histogram/float-vector
+// scaling shape — only default (full-Attributes) one-to-one matching is
+// — so those still hit expHistogramSelectorRouting's pre-existing
+// catch-all rejection, same as every MUL/histogram-left-DIV float-vector
+// scaling shape did before cerberus issue #2339.
+func TestLower_ExpHistogram_FloatVectorScalingBinopStillRejected(t *testing.T) {
+	t.Parallel()
+
+	s := schema.DefaultOTelMetrics()
+	p := parser.NewParser(parser.Options{EnableExperimentalFunctions: true})
+	end := time.Date(2026, 1, 1, 1, 0, 0, 0, time.UTC)
+
+	queries := []string{
+		`latency_exp_hist * on(service) histogram_quantile(0.5, latency_exp_hist)`,
+		`latency_exp_hist * ignoring(service) histogram_quantile(0.5, latency_exp_hist)`,
+		`latency_exp_hist * on(service) group_left() histogram_quantile(0.5, latency_exp_hist)`,
+		`histogram_quantile(0.5, latency_exp_hist) * on(service) group_right() latency_exp_hist`,
+		`latency_exp_hist / on(service) group_left() histogram_quantile(0.5, latency_exp_hist)`,
+	}
+	for _, q := range queries {
+		t.Run(q, func(t *testing.T) {
+			t.Parallel()
+			expr, err := p.ParseExpr(q)
+			if err != nil {
+				t.Fatalf("ParseExpr(%q): %v", q, err)
+			}
+			if _, err := promql.LowerAt(context.Background(), expr, s, end, end); err == nil {
+				t.Fatalf("LowerAt(%q): expected the pre-existing catch-all rejection, got success", q)
+			}
+		})
+	}
+}

--- a/internal/promql/histogram_native_scalar_binop.go
+++ b/internal/promql/histogram_native_scalar_binop.go
@@ -231,12 +231,23 @@ func lowerExpHistogramScalarBinop(histSide parser.Expr, op chplan.BinaryOp, scal
 	return scaleHistogramProjection(hp, op, scale, s), nil
 }
 
-// scaleHistogramProjection rewrites hp's Input so the row it publishes
-// is scaled by `scale` under `op` — the same five-field split
+// scaleHistogramProjection wraps hp in a Project that scales it by
+// `scale` under `op` — the same five-field split
 // [expHistogramAvgScaleProjections] applies for avg()'s "divide by the
 // group's member count", generalised to an arbitrary scalar expression
 // and operator (cerberus issue #2087).
-func scaleHistogramProjection(hp *chplan.HistogramProjection, op chplan.BinaryOp, scale chplan.Expr, s schema.Metrics) *chplan.HistogramProjection {
+//
+// hp is typed as a plain chplan.Node (not *chplan.HistogramProjection)
+// so [scaleHistogramFloatVectorProjections] (histogram_native_float_
+// vector_scaling_binop.go, cerberus issue #2339) can feed it a
+// *chplan.HistogramFloatVectorJoin instead: that node's own SELECT
+// publishes the identical column shape a *chplan.HistogramProjection
+// does (MetricName/Attributes/TimeUnix + the nine fixed
+// Histogram*Column fields — see that node's doc) plus one extra Value
+// column carrying a PER-ROW scale factor, so the same Project-based
+// fold below applies unchanged whether `scale` is a compile-time
+// LitFloat or a ColumnRef reading that per-row Value.
+func scaleHistogramProjection(hp chplan.Node, op chplan.BinaryOp, scale chplan.Expr, s schema.Metrics) *chplan.HistogramProjection {
 	histSchema := histogramProjectionSchema(s)
 	passthroughCols := []string{
 		s.AttributesColumn,

--- a/internal/promql/lower.go
+++ b/internal/promql/lower.go
@@ -229,6 +229,17 @@ func LowerMetadataRange(ctx context.Context, expr parser.Expr, s schema.Metrics,
 // scalar literal, and from [expHistogramDroppingHistogramBinop]'s
 // because at most one operand is histogram-valued — so ordering it last
 // cannot shadow either.
+// [expHistogramFloatVectorScalingBinop] is registered ahead of that drop
+// leg (cerberus issue #2339): MUL (either operand order) and
+// histogram-left DIV between a histogram-valued operand and a genuine
+// float-VECTOR operand are reference's supported histogram-SCALING
+// shapes — the row-by-row match a float-vector operand needs before
+// [scaleHistogramProjection]'s per-bucket fold can apply, via
+// [chplan.HistogramFloatVectorJoin]. Registering the scaling recognizer
+// first mirrors [expHistogramScalarBinop]'s own precedence over
+// [expHistogramDroppingScalarBinop] for the literal-scalar case: a
+// scalable shape keeps its value rather than falling into a broader
+// drop recognizer checked later.
 //
 // `or` between a float-valued operand and a histogram-valued operand
 // (cerberus issue #2330) is the exactly-one-side sibling of that shape,
@@ -296,6 +307,9 @@ func lowerRoot(expr parser.Expr, s schema.Metrics, ctx lowerCtx) (chplan.Node, e
 	}
 	if lhs, rhs, ok := expHistogramDroppingHistogramBinop(expr, s, ctx); ok {
 		return lowerExpHistogramDroppingHistogramBinop(lhs, rhs, s, ctx)
+	}
+	if histSide, floatSide, op, ok := expHistogramFloatVectorScalingBinop(expr, s, ctx); ok {
+		return lowerExpHistogramFloatVectorScalingBinop(histSide, floatSide, op, s, ctx)
 	}
 	if histSide, floatSide, ok := expHistogramDroppingVectorBinop(expr, s, ctx); ok {
 		return lowerExpHistogramDroppingVectorBinop(histSide, floatSide, s, ctx)

--- a/test/perf/cardinality-baseline/promql/exp_histogram_float_vector_scaling_div.json
+++ b/test/perf/cardinality-baseline/promql/exp_histogram_float_vector_scaling_div.json
@@ -1,0 +1,11 @@
+{
+  "fixture": "promql/exp_histogram_float_vector_scaling_div",
+  "fan_factor": 1,
+  "scan_rows": 1,
+  "peak_intermediate": 1,
+  "has_cross_join": false,
+  "has_array_join": false,
+  "has_recursive_cte": false,
+  "max_recursion_depth": 0,
+  "uncountable_levels": 0
+}

--- a/test/perf/cardinality-baseline/promql/exp_histogram_float_vector_scaling_mul.json
+++ b/test/perf/cardinality-baseline/promql/exp_histogram_float_vector_scaling_mul.json
@@ -1,0 +1,11 @@
+{
+  "fixture": "promql/exp_histogram_float_vector_scaling_mul",
+  "fan_factor": 1,
+  "scan_rows": 1,
+  "peak_intermediate": 1,
+  "has_cross_join": false,
+  "has_array_join": false,
+  "has_recursive_cte": false,
+  "max_recursion_depth": 0,
+  "uncountable_levels": 0
+}

--- a/test/perf/cardinality-baseline/promql/exp_histogram_float_vector_scaling_mul_commute.json
+++ b/test/perf/cardinality-baseline/promql/exp_histogram_float_vector_scaling_mul_commute.json
@@ -1,0 +1,11 @@
+{
+  "fixture": "promql/exp_histogram_float_vector_scaling_mul_commute",
+  "fan_factor": 1,
+  "scan_rows": 1,
+  "peak_intermediate": 1,
+  "has_cross_join": false,
+  "has_array_join": false,
+  "has_recursive_cte": false,
+  "max_recursion_depth": 0,
+  "uncountable_levels": 0
+}

--- a/test/perf/solver-decision-baseline/exp_histogram_float_vector_scaling_div/fanout.json
+++ b/test/perf/solver-decision-baseline/exp_histogram_float_vector_scaling_div/fanout.json
@@ -1,0 +1,11 @@
+{
+  "query": "exp_histogram_float_vector_scaling_div/fanout",
+  "lowering": "fanout",
+  "routed": false,
+  "k": 0,
+  "reason": "not-sliceable",
+  "n_anchors": 241,
+  "fanout": 20,
+  "cumulative_d": "10m0s",
+  "outer_range": "1h0m0s"
+}

--- a/test/perf/solver-decision-baseline/exp_histogram_float_vector_scaling_div/native.json
+++ b/test/perf/solver-decision-baseline/exp_histogram_float_vector_scaling_div/native.json
@@ -1,0 +1,11 @@
+{
+  "query": "exp_histogram_float_vector_scaling_div/native",
+  "lowering": "native",
+  "routed": false,
+  "k": 0,
+  "reason": "not-sliceable",
+  "n_anchors": 241,
+  "fanout": 20,
+  "cumulative_d": "10m0s",
+  "outer_range": "1h0m0s"
+}

--- a/test/perf/solver-decision-baseline/exp_histogram_float_vector_scaling_mul/fanout.json
+++ b/test/perf/solver-decision-baseline/exp_histogram_float_vector_scaling_mul/fanout.json
@@ -1,0 +1,11 @@
+{
+  "query": "exp_histogram_float_vector_scaling_mul/fanout",
+  "lowering": "fanout",
+  "routed": false,
+  "k": 0,
+  "reason": "not-sliceable",
+  "n_anchors": 241,
+  "fanout": 20,
+  "cumulative_d": "10m0s",
+  "outer_range": "1h0m0s"
+}

--- a/test/perf/solver-decision-baseline/exp_histogram_float_vector_scaling_mul/native.json
+++ b/test/perf/solver-decision-baseline/exp_histogram_float_vector_scaling_mul/native.json
@@ -1,0 +1,11 @@
+{
+  "query": "exp_histogram_float_vector_scaling_mul/native",
+  "lowering": "native",
+  "routed": false,
+  "k": 0,
+  "reason": "not-sliceable",
+  "n_anchors": 241,
+  "fanout": 20,
+  "cumulative_d": "10m0s",
+  "outer_range": "1h0m0s"
+}

--- a/test/perf/solver-decision-baseline/exp_histogram_float_vector_scaling_mul_commute/fanout.json
+++ b/test/perf/solver-decision-baseline/exp_histogram_float_vector_scaling_mul_commute/fanout.json
@@ -1,0 +1,11 @@
+{
+  "query": "exp_histogram_float_vector_scaling_mul_commute/fanout",
+  "lowering": "fanout",
+  "routed": false,
+  "k": 0,
+  "reason": "not-sliceable",
+  "n_anchors": 241,
+  "fanout": 20,
+  "cumulative_d": "10m0s",
+  "outer_range": "1h0m0s"
+}

--- a/test/perf/solver-decision-baseline/exp_histogram_float_vector_scaling_mul_commute/native.json
+++ b/test/perf/solver-decision-baseline/exp_histogram_float_vector_scaling_mul_commute/native.json
@@ -1,0 +1,11 @@
+{
+  "query": "exp_histogram_float_vector_scaling_mul_commute/native",
+  "lowering": "native",
+  "routed": false,
+  "k": 0,
+  "reason": "not-sliceable",
+  "n_anchors": 241,
+  "fanout": 20,
+  "cumulative_d": "10m0s",
+  "outer_range": "1h0m0s"
+}

--- a/test/regression/parity-enrolment-baselines/promql/baseline.txt
+++ b/test/regression/parity-enrolment-baselines/promql/baseline.txt
@@ -154,6 +154,9 @@ exp_histogram_changes.txtar
 exp_histogram_count.txtar
 exp_histogram_count_by.txtar
 exp_histogram_delta.txtar
+exp_histogram_float_vector_scaling_div.txtar
+exp_histogram_float_vector_scaling_mul.txtar
+exp_histogram_float_vector_scaling_mul_commute.txtar
 exp_histogram_idelta.txtar
 exp_histogram_increase_boundary.txtar
 exp_histogram_increase_cumulative_temporality_control.txtar

--- a/test/rejection-parity/catalogue/internal__promql__binary.go.json
+++ b/test/rejection-parity/catalogue/internal__promql__binary.go.json
@@ -134,18 +134,20 @@
       "site": "internal/promql/binary.go:promBinaryOp#2d85dac3",
       "message": "promql: vector set op %s should route through lowerVectorSetOp",
       "class": "internal",
-      "rationale": "internal routing invariant: set operators are dispatched to lowerVectorSetOp before op mapping, for every caller — lowerBinary and lowerScalarArg route a parser.BinaryExpr's own set-operator check first, and expHistogramScalarBinop (cerberus issue #2087) never reaches this function with a set-operator op at all: it calls promBinaryOp only after confirming b.Op is MUL or DIV.",
+      "rationale": "internal routing invariant: set operators are dispatched to lowerVectorSetOp before op mapping, for every caller — lowerBinary and lowerScalarArg route a parser.BinaryExpr's own set-operator check first, and expHistogramScalarBinop (cerberus issue #2087) never reaches this function with a set-operator op at all: it calls promBinaryOp only after confirming b.Op is MUL or DIV. expHistogramFloatVectorScalingBinop (cerberus issue #2339) is the newest caller and holds to the same constraint: it guards `b.Op != parser.MUL \u0026\u0026 b.Op != parser.DIV` before ever reaching the promBinaryOp call, so it cannot pass a set-operator op either.",
       "evidence": {
         "guard": [
           "past exhaustive switch op over [case parser.ADD; case parser.SUB; case parser.MUL; case parser.DIV; case parser.MOD; case parser.POW; case parser.ATAN2; case parser.EQLC; case parser.NEQ; case parser.LSS; case parser.LTE; case parser.GTR; case parser.GTE]",
           "if op.IsSetOperator()"
         ],
         "callers": [
+          "expHistogramFloatVectorScalingBinop",
           "expHistogramScalarBinop",
           "lowerBinary",
           "lowerScalarArg"
         ],
         "cited": [
+          "expHistogramFloatVectorScalingBinop",
           "expHistogramScalarBinop",
           "lowerBinary",
           "lowerScalarArg",
@@ -159,18 +161,20 @@
       "site": "internal/promql/binary.go:promBinaryOp#63a5ec6e",
       "message": "promql: binary op %s unsupported",
       "class": "internal",
-      "rationale": "Every binary operator the PromQL parser produces now maps to a chplan op (arithmetic including pow and atan2, all six comparisons); set operators route through lowerVectorSetOp before this function is called — no parseable operator reaches the default arm. expHistogramScalarBinop (cerberus issue #2087) narrows further still: it only ever calls promBinaryOp with MUL or DIV, both already covered by the switch above.",
+      "rationale": "Every binary operator the PromQL parser produces now maps to a chplan op (arithmetic including pow and atan2, all six comparisons); set operators route through lowerVectorSetOp before this function is called — no parseable operator reaches the default arm. expHistogramScalarBinop (cerberus issue #2087) narrows further still: it only ever calls promBinaryOp with MUL or DIV, both already covered by the switch above. expHistogramFloatVectorScalingBinop (cerberus issue #2339) is the newest caller and holds the identical narrowing: its own MUL/DIV guard runs before the promBinaryOp call, so it too only ever supplies an operator the switch already covers.",
       "evidence": {
         "guard": [
           "past exhaustive switch op over [case parser.ADD; case parser.SUB; case parser.MUL; case parser.DIV; case parser.MOD; case parser.POW; case parser.ATAN2; case parser.EQLC; case parser.NEQ; case parser.LSS; case parser.LTE; case parser.GTR; case parser.GTE]",
           "past returning if op.IsSetOperator()"
         ],
         "callers": [
+          "expHistogramFloatVectorScalingBinop",
           "expHistogramScalarBinop",
           "lowerBinary",
           "lowerScalarArg"
         ],
         "cited": [
+          "expHistogramFloatVectorScalingBinop",
           "expHistogramScalarBinop",
           "lowerVectorSetOp",
           "promBinaryOp"

--- a/test/rejection-parity/catalogue/internal__promql__histogram_native_binop.go.json
+++ b/test/rejection-parity/catalogue/internal__promql__histogram_native_binop.go.json
@@ -5,7 +5,7 @@
       "site": "internal/promql/histogram_native_binop.go:lowerExpHistogramValuedOperand#2fa7ca70",
       "message": "promql: internal invariant violated: exp-histogram binop operand matched no known histogram-valued shape for %v",
       "class": "internal",
-      "rationale": "all five callers (lowerExpHistogramHistogramBinop for +/-, lowerExpHistogramHistogramCompareBinop for ==/!=, lowerExpHistogramHistogramCompareBoolBinop for == bool/!= bool, lowerExpHistogramDroppingHistogramBinop for the histogram/histogram incompatible-type drop family, and lowerExpHistogramDroppingVectorBinop for the float-vector/histogram incompatible-type drop family, cerberus issue #2331) admit only isExpHistogramValuedShape operands — the first four on both sides, the fifth only on the single operand expHistogramDroppingVectorBinop already verified isExpHistogramValuedShape against before returning it as histSide — whose lowerExpHistogramValuedShape producer never returns matched=false for a shape that recogniser already accepted",
+      "rationale": "all six callers (lowerExpHistogramHistogramBinop for +/-, lowerExpHistogramHistogramCompareBinop for ==/!=, lowerExpHistogramHistogramCompareBoolBinop for == bool/!= bool, lowerExpHistogramDroppingHistogramBinop for the histogram/histogram incompatible-type drop family, lowerExpHistogramDroppingVectorBinop for the float-vector/histogram incompatible-type drop family (cerberus issue #2331), and lowerExpHistogramFloatVectorScalingBinop for the MUL / histogram-left-DIV float-vector scaling shape (cerberus issue #2339)) admit only isExpHistogramValuedShape operands — the first four on both sides, the last two only on the single operand each recogniser already verified isExpHistogramValuedShape against before returning it as histSide — whose lowerExpHistogramValuedShape producer never returns matched=false for a shape that recogniser already accepted",
       "evidence": {
         "guard": [
           "past returning if err != nil",
@@ -14,15 +14,16 @@
         "callers": [
           "lowerExpHistogramDroppingHistogramBinop",
           "lowerExpHistogramDroppingVectorBinop",
+          "lowerExpHistogramFloatVectorScalingBinop",
           "lowerExpHistogramHistogramBinop",
           "lowerExpHistogramHistogramCompareBinop",
           "lowerExpHistogramHistogramCompareBoolBinop"
         ],
         "cited": [
-          "expHistogramDroppingVectorBinop",
           "isExpHistogramValuedShape",
           "lowerExpHistogramDroppingHistogramBinop",
           "lowerExpHistogramDroppingVectorBinop",
+          "lowerExpHistogramFloatVectorScalingBinop",
           "lowerExpHistogramHistogramBinop",
           "lowerExpHistogramHistogramCompareBinop",
           "lowerExpHistogramHistogramCompareBoolBinop",
@@ -35,7 +36,7 @@
       "site": "internal/promql/histogram_native_binop.go:lowerExpHistogramValuedOperand#f7926a05",
       "message": "promql: internal invariant violated: exp-histogram binop operand lowering did not cap with *chplan.HistogramProjection, got %T",
       "class": "internal",
-      "rationale": "lowerExpHistogramValuedShape's producer contract ends in *chplan.HistogramProjection for every shape it reports matched=true for — the same contract histogram_native_scalar_binop.go's lowerExpHistogramScalarBinop, and now all five of lowerExpHistogramHistogramBinop, lowerExpHistogramHistogramCompareBinop, lowerExpHistogramHistogramCompareBoolBinop, lowerExpHistogramDroppingHistogramBinop, and lowerExpHistogramDroppingVectorBinop (cerberus issue #2331), already rely on",
+      "rationale": "lowerExpHistogramValuedShape's producer contract ends in *chplan.HistogramProjection for every shape it reports matched=true for — the same contract histogram_native_scalar_binop.go's lowerExpHistogramScalarBinop, and now all six of lowerExpHistogramHistogramBinop, lowerExpHistogramHistogramCompareBinop, lowerExpHistogramHistogramCompareBoolBinop, lowerExpHistogramDroppingHistogramBinop, lowerExpHistogramDroppingVectorBinop (cerberus issue #2331), and lowerExpHistogramFloatVectorScalingBinop (cerberus issue #2339), already rely on",
       "evidence": {
         "guard": [
           "past returning if err != nil",
@@ -45,6 +46,7 @@
         "callers": [
           "lowerExpHistogramDroppingHistogramBinop",
           "lowerExpHistogramDroppingVectorBinop",
+          "lowerExpHistogramFloatVectorScalingBinop",
           "lowerExpHistogramHistogramBinop",
           "lowerExpHistogramHistogramCompareBinop",
           "lowerExpHistogramHistogramCompareBoolBinop"
@@ -52,6 +54,7 @@
         "cited": [
           "lowerExpHistogramDroppingHistogramBinop",
           "lowerExpHistogramDroppingVectorBinop",
+          "lowerExpHistogramFloatVectorScalingBinop",
           "lowerExpHistogramHistogramBinop",
           "lowerExpHistogramHistogramCompareBinop",
           "lowerExpHistogramHistogramCompareBoolBinop",

--- a/test/rejection-parity/catalogue/internal__promql__lower.go.json
+++ b/test/rejection-parity/catalogue/internal__promql__lower.go.json
@@ -111,7 +111,7 @@
       "site": "internal/promql/lower.go:lower#d33d0084",
       "message": "promql: unsupported expression %T",
       "class": "internal",
-      "rationale": "Every expression shape reaching lower() through the HTTP handlers is dispatched (top-level matrix selectors included). The remaining inhabitants — NumberLiteral and StringLiteral, answered by the handler's constant fold / string shortcut before the engine runs, and StepInvariantExpr, which only parser.PreprocessExpr mints and cerberus never calls — cannot arrive here from the wire. The query entry points now reach this switch through lowerRoot, which peels off exactly one shape (a bare exp-histogram selector, answered by a histogram-valued lowering) and otherwise delegates unchanged, so it narrows the set of expressions that arrive rather than widening it. Re-verified across the in-package callers that re-enter lower() with a sub-expression, lowerHistogramQuantileClassicFloat included: each passes an operand of an already-parsed query whose position the upstream typechecker constrains to a vector, so no caller widens the set of shapes that reach the default arm. lowerExpHistogramDroppingVectorBinop (cerberus issue #2331) and lowerMixedExpHistogramSetOp (cerberus issue #2330) re-enter lower() for one BinaryExpr operand of an already-parsed vector-vector query apiece, likewise typechecker-constrained to a vector, so neither widens the set either. lowerVectorSetOpOperand (cerberus issue #2325) is the newest caller and replaces binary.go's lowerVectorSetOp as the direct one: lowerVectorSetOp no longer calls lower() itself, routing both its `and`/`or`/`unless` operands through this helper instead, which forwards to lower() only the operand it has itself confirmed is NOT exp-histogram-valued -- the same already-parsed, typechecker-constrained-to-vector expr lowerVectorSetOp used to pass straight through -- so it narrows rather than widens the set reaching the default arm too.",
+      "rationale": "Every expression shape reaching lower() through the HTTP handlers is dispatched (top-level matrix selectors included). The remaining inhabitants — NumberLiteral and StringLiteral, answered by the handler's constant fold / string shortcut before the engine runs, and StepInvariantExpr, which only parser.PreprocessExpr mints and cerberus never calls — cannot arrive here from the wire. The query entry points now reach this switch through lowerRoot, which peels off exactly one shape (a bare exp-histogram selector, answered by a histogram-valued lowering) and otherwise delegates unchanged, so it narrows the set of expressions that arrive rather than widening it. Re-verified across the in-package callers that re-enter lower() with a sub-expression, lowerHistogramQuantileClassicFloat included: each passes an operand of an already-parsed query whose position the upstream typechecker constrains to a vector, so no caller widens the set of shapes that reach the default arm. lowerExpHistogramDroppingVectorBinop (cerberus issue #2331) and lowerMixedExpHistogramSetOp (cerberus issue #2330) re-enter lower() for one BinaryExpr operand of an already-parsed vector-vector query apiece, likewise typechecker-constrained to a vector, so neither widens the set either. lowerVectorSetOpOperand (cerberus issue #2325) replaces binary.go's lowerVectorSetOp as the direct caller: lowerVectorSetOp no longer calls lower() itself, routing both its and/or/unless operands through this helper instead, which forwards to lower() only the operand it has itself confirmed is NOT exp-histogram-valued — the same already-parsed, typechecker-constrained-to-vector expr lowerVectorSetOp used to pass straight through — so it narrows rather than widens too. lowerExpHistogramFloatVectorScalingBinop (cerberus issue #2339) is the newest caller: it re-enters lower() only for the float-valued operand of an already-parsed MUL/DIV BinaryExpr, likewise typechecker-constrained to a vector, so it doesn't widen the set either.",
       "evidence": {
         "guard": [
           "default of switch e := expr.(type) over [case *parser.VectorSelector; case *parser.Call; case *parser.AggregateExpr; case *parser.ParenExpr; case *parser.BinaryExpr; case *parser.SubqueryExpr; case *parser.MatrixSelector; case *parser.UnaryExpr; default]"
@@ -125,6 +125,7 @@
           "lowerCountValues",
           "lowerDateFn",
           "lowerExpHistogramDroppingVectorBinop",
+          "lowerExpHistogramFloatVectorScalingBinop",
           "lowerHistogramQuantile",
           "lowerHistogramQuantileClassicFloat",
           "lowerHistogramValueFn",
@@ -151,6 +152,7 @@
         "cited": [
           "lower",
           "lowerExpHistogramDroppingVectorBinop",
+          "lowerExpHistogramFloatVectorScalingBinop",
           "lowerHistogramQuantileClassicFloat",
           "lowerMixedExpHistogramSetOp",
           "lowerRoot",

--- a/test/spec/promql/exp_histogram_float_vector_scaling_div.txtar
+++ b/test/spec/promql/exp_histogram_float_vector_scaling_div.txtar
@@ -1,0 +1,76 @@
+-- query.promql --
+latency_exp_hist / histogram_quantile(0.5, latency_exp_hist)
+-- parity --
+oracle: prometheus
+endpoint: /api/v1/query
+scope: full
+-- seed --
+CREATE TABLE otel_metrics_exponential_histogram (
+    MetricName String,
+    Attributes Map(String, String),
+    TimeUnix DateTime64(9),
+    Count UInt64,
+    Sum Float64,
+    Scale Int32,
+    ZeroCount UInt64,
+    PositiveOffset Int32,
+    PositiveBucketCounts Array(UInt64),
+    NegativeOffset Int32,
+    NegativeBucketCounts Array(UInt64)
+) ENGINE = MergeTree ORDER BY (MetricName, Attributes, TimeUnix);
+INSERT INTO otel_metrics_exponential_histogram VALUES
+    ('latency_exp_hist', map('service', 'api'), toDateTime64('2026-01-01 00:00:00', 9), 13, 30, 0, 1, 0, [3, 5, 2], 1, [2]);
+-- expected_rows --
+[
+  ["", {"service": "api"}, "2026-01-01T00:00:01Z", 0, 6.0647144449892485, 13.995494873052111, 0, 0, 0.4665164957684037, 0, [1.3995494873052112,2.3325824788420184,0.9330329915368074], 1, [0.9330329915368074]]
+]
+-- args --
+[0] string = ""
+[1] float64 = 0
+[2] int64 = 9
+[3] float64 = 0
+[4] string = "service.name"
+[5] string = "service_name"
+[6] string = "service.name"
+[7] string = "service_name"
+[8] string = ""
+[9] string = "service_name"
+[10] string = "latency_exp_hist"
+[11] string = "latency.exp.hist"
+[12] string = "latency.exp/hist"
+[13] string = "latency.exp_hist"
+[14] string = "latency/exp/hist"
+[15] string = "latency/exp_hist"
+[16] string = "latency_exp.hist"
+[17] string = "2026-01-01 00:00:01.000000000"
+[18] int64 = 9
+[19] string = "2026-01-01 00:00:01.000000000"
+[20] int64 = 9
+[21] int64 = 300000000000
+[22] string = ""
+[23] string = ""
+[24] int64 = 9
+[25] string = "service.name"
+[26] string = "service_name"
+[27] string = "service.name"
+[28] string = "service_name"
+[29] string = ""
+[30] string = "service_name"
+[31] string = "latency_exp_hist"
+[32] string = "latency.exp.hist"
+[33] string = "latency.exp/hist"
+[34] string = "latency.exp_hist"
+[35] string = "latency/exp/hist"
+[36] string = "latency/exp_hist"
+[37] string = "latency_exp.hist"
+[38] string = "2026-01-01 00:00:01.000000000"
+[39] int64 = 9
+[40] string = "2026-01-01 00:00:01.000000000"
+[41] int64 = 9
+[42] int64 = 300000000000
+-- chplan --
+HistogramProjection project=["" AS MetricName, Attributes AS Attributes, TimeUnix AS TimeUnix, 0 AS Value]
+  Project [Attributes AS Attributes, TimeUnix AS TimeUnix, HistogramScale AS HistogramScale, HistogramZeroThreshold AS HistogramZeroThreshold, HistogramPositiveOffset AS HistogramPositiveOffset, HistogramNegativeOffset AS HistogramNegativeOffset, (HistogramCount / Value) AS HistogramCount, (HistogramSum / Value) AS HistogramSum, (HistogramZeroCount / Value) AS HistogramZeroCount, FnArrayMap(b -> (b / Value), HistogramPositiveBucketCounts) AS HistogramPositiveBucketCounts, FnArrayMap(b -> (b / Value), HistogramNegativeBucketCounts) AS HistogramNegativeBucketCounts]
+    <unknown:*chplan.HistogramFloatVectorJoin>
+-- sql --
+SELECT ? AS `MetricName`, `Attributes` AS `Attributes`, `TimeUnix` AS `TimeUnix`, toFloat64(?) AS `Value`, toFloat64(`HistogramCount`) AS `HistogramCount`, toFloat64(`HistogramSum`) AS `HistogramSum`, toInt32(`HistogramScale`) AS `HistogramScale`, toFloat64(`HistogramZeroThreshold`) AS `HistogramZeroThreshold`, toFloat64(`HistogramZeroCount`) AS `HistogramZeroCount`, toInt32(`HistogramPositiveOffset`) AS `HistogramPositiveOffset`, arrayMap(x -> toFloat64(x), `HistogramPositiveBucketCounts`) AS `HistogramPositiveBucketCounts`, toInt32(`HistogramNegativeOffset`) AS `HistogramNegativeOffset`, arrayMap(x -> toFloat64(x), `HistogramNegativeBucketCounts`) AS `HistogramNegativeBucketCounts` FROM (SELECT `Attributes` AS `Attributes`, `TimeUnix` AS `TimeUnix`, `HistogramScale` AS `HistogramScale`, `HistogramZeroThreshold` AS `HistogramZeroThreshold`, `HistogramPositiveOffset` AS `HistogramPositiveOffset`, `HistogramNegativeOffset` AS `HistogramNegativeOffset`, (`HistogramCount` / `Value`) AS `HistogramCount`, (`HistogramSum` / `Value`) AS `HistogramSum`, (`HistogramZeroCount` / `Value`) AS `HistogramZeroCount`, arrayMap(b -> (b / `Value`), `HistogramPositiveBucketCounts`) AS `HistogramPositiveBucketCounts`, arrayMap(b -> (b / `Value`), `HistogramNegativeBucketCounts`) AS `HistogramNegativeBucketCounts` FROM (SELECT L.`MetricName` AS `MetricName`, L.`Attributes` AS `Attributes`, L.`TimeUnix` AS `TimeUnix`, L.`HistogramScale` AS `HistogramScale`, L.`HistogramCount` AS `HistogramCount`, L.`HistogramSum` AS `HistogramSum`, L.`HistogramZeroCount` AS `HistogramZeroCount`, L.`HistogramZeroThreshold` AS `HistogramZeroThreshold`, L.`HistogramPositiveOffset` AS `HistogramPositiveOffset`, L.`HistogramPositiveBucketCounts` AS `HistogramPositiveBucketCounts`, L.`HistogramNegativeOffset` AS `HistogramNegativeOffset`, L.`HistogramNegativeBucketCounts` AS `HistogramNegativeBucketCounts`, R.`Value` AS `Value` FROM (SELECT `_join_MetricName` AS `MetricName`, `_join_Attributes` AS `Attributes`, `_join_TimeUnix` AS `TimeUnix`, `_join_HistogramScale` AS `HistogramScale`, `_join_HistogramCount` AS `HistogramCount`, `_join_HistogramSum` AS `HistogramSum`, `_join_HistogramZeroCount` AS `HistogramZeroCount`, `_join_HistogramZeroThreshold` AS `HistogramZeroThreshold`, `_join_HistogramPositiveOffset` AS `HistogramPositiveOffset`, `_join_HistogramPositiveBucketCounts` AS `HistogramPositiveBucketCounts`, `_join_HistogramNegativeOffset` AS `HistogramNegativeOffset`, `_join_HistogramNegativeBucketCounts` AS `HistogramNegativeBucketCounts` FROM (SELECT `MetricName` AS `_join_MetricName`, `Attributes` AS `_join_Attributes`, `TimeUnix` AS `_join_TimeUnix`, `HistogramScale` AS `_join_HistogramScale`, `HistogramCount` AS `_join_HistogramCount`, `HistogramSum` AS `_join_HistogramSum`, `HistogramZeroCount` AS `_join_HistogramZeroCount`, `HistogramZeroThreshold` AS `_join_HistogramZeroThreshold`, `HistogramPositiveOffset` AS `_join_HistogramPositiveOffset`, `HistogramPositiveBucketCounts` AS `_join_HistogramPositiveBucketCounts`, `HistogramNegativeOffset` AS `_join_HistogramNegativeOffset`, `HistogramNegativeBucketCounts` AS `_join_HistogramNegativeBucketCounts` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, now64(?) AS `TimeUnix`, toFloat64(?) AS `Value`, toFloat64(`Count`) AS `HistogramCount`, toFloat64(`Sum`) AS `HistogramSum`, toInt32(`Scale`) AS `HistogramScale`, toFloat64(0.) AS `HistogramZeroThreshold`, toFloat64(`ZeroCount`) AS `HistogramZeroCount`, toInt32(`PositiveOffset`) AS `HistogramPositiveOffset`, arrayMap(x -> toFloat64(x), `PositiveBucketCounts`) AS `HistogramPositiveBucketCounts`, toInt32(`NegativeOffset`) AS `HistogramNegativeOffset`, arrayMap(x -> toFloat64(x), `NegativeBucketCounts`) AS `HistogramNegativeBucketCounts` FROM (SELECT mapSort(mapConcat(mapUpdate(mapFromArrays(arrayMap(k -> replaceRegexpAll(k, '[^a-zA-Z0-9_]', '_'), mapKeys(mapFilter((k, v) -> (k NOT IN (?, ?)), `ResourceAttributes`))), mapValues(mapFilter((k, v) -> (k NOT IN (?, ?)), `ResourceAttributes`))), mapFromArrays(arrayMap(k -> replaceRegexpAll(k, '[^a-zA-Z0-9_]', '_'), mapKeys(`Attributes`)), mapValues(`Attributes`))), mapFilter((k, v) -> (v != ?), map(?, toString(`ServiceName`))))) AS `Attributes`, argMax(`MetricName`, `TimeUnix`) AS `MetricName`, argMax(`Count`, `TimeUnix`) AS `Count`, argMax(`Sum`, `TimeUnix`) AS `Sum`, argMax(`Scale`, `TimeUnix`) AS `Scale`, argMax(`ZeroCount`, `TimeUnix`) AS `ZeroCount`, argMax(`PositiveOffset`, `TimeUnix`) AS `PositiveOffset`, argMax(`PositiveBucketCounts`, `TimeUnix`) AS `PositiveBucketCounts`, argMax(`NegativeOffset`, `TimeUnix`) AS `NegativeOffset`, argMax(`NegativeBucketCounts`, `TimeUnix`) AS `NegativeBucketCounts` FROM (SELECT * FROM `otel_metrics_exponential_histogram` PREWHERE (`MetricName` IN (?, ?, ?, ?, ?, ?, ?)) WHERE (`TimeUnix` <= toDateTime64(?, ?)) AND (`TimeUnix` > (toDateTime64(?, ?) - toIntervalNanosecond(?)))) GROUP BY `Attributes`)))) AS L INNER JOIN (SELECT `_join_MetricName` AS `MetricName`, `_join_Attributes` AS `Attributes`, `_join_TimeUnix` AS `TimeUnix`, `_join_Value` AS `Value` FROM (SELECT ? AS `_join_MetricName`, mapSort(`Attributes`) AS `_join_Attributes`, max(`TimeUnix`) AS `_join_TimeUnix`, argMax(`Value`, `TimeUnix`) AS `_join_Value` FROM (SELECT ? AS `MetricName`, `Attributes` AS `Attributes`, now64(?) AS `TimeUnix`, `Value` AS `Value` FROM (SELECT `Attributes` AS `Attributes`, if(0.5 < 0, -inf, if(0.5 > 1, inf, if(`Count` = 0, nan, if(0.5 = 0, if(arrayFirstIndex(c -> c > 0, `_cerb_hq_buckets`) <= length(`NegativeBucketCounts`), -pow(pow(2, pow(2, -`Scale`)), `NegativeOffset` + (length(`NegativeBucketCounts`) - arrayFirstIndex(c -> c > 0, `_cerb_hq_buckets`)) + 1), if(arrayFirstIndex(c -> c > 0, `_cerb_hq_buckets`) = length(`NegativeBucketCounts`) + 1, if(length(`NegativeBucketCounts`) = 0 AND length(`PositiveBucketCounts`) > 0, 0., -0.), pow(pow(2, pow(2, -`Scale`)), `PositiveOffset` + (arrayFirstIndex(c -> c > 0, `_cerb_hq_buckets`) - length(`NegativeBucketCounts`) - 2)))), if(0.5 = 1, if(arrayLastIndex(c -> c > 0, `_cerb_hq_buckets`) <= length(`NegativeBucketCounts`), -pow(pow(2, pow(2, -`Scale`)), `NegativeOffset` + (length(`NegativeBucketCounts`) - arrayLastIndex(c -> c > 0, `_cerb_hq_buckets`))), if(arrayLastIndex(c -> c > 0, `_cerb_hq_buckets`) = length(`NegativeBucketCounts`) + 1, if(length(`PositiveBucketCounts`) = 0 AND length(`NegativeBucketCounts`) > 0, 0., 0.), pow(pow(2, pow(2, -`Scale`)), `PositiveOffset` + (arrayLastIndex(c -> c > 0, `_cerb_hq_buckets`) - length(`NegativeBucketCounts`) - 1)))), if(`_cerb_hq_idx` = 0, nan, if(`_cerb_hq_value_idx` <= length(`NegativeBucketCounts`), -pow(pow(2, pow(2, -`Scale`)), `NegativeOffset` + (length(`NegativeBucketCounts`) - `_cerb_hq_value_idx`) + 1 - ((0.5 * `Count`) - `_cerb_hq_cum`[`_cerb_hq_idx` - 1]) / `_cerb_hq_buckets`[`_cerb_hq_value_idx`]), if(`_cerb_hq_value_idx` = length(`NegativeBucketCounts`) + 1, if(length(`NegativeBucketCounts`) = 0 AND length(`PositiveBucketCounts`) > 0, 0., -0.) + (if(length(`PositiveBucketCounts`) = 0 AND length(`NegativeBucketCounts`) > 0, 0., 0.) - if(length(`NegativeBucketCounts`) = 0 AND length(`PositiveBucketCounts`) > 0, 0., -0.)) * ((0.5 * `Count`) - `_cerb_hq_cum`[`_cerb_hq_idx` - 1]) / `_cerb_hq_buckets`[`_cerb_hq_value_idx`], pow(pow(2, pow(2, -`Scale`)), `PositiveOffset` + (`_cerb_hq_value_idx` - length(`NegativeBucketCounts`) - 2) + ((0.5 * `Count`) - `_cerb_hq_cum`[`_cerb_hq_idx` - 1]) / `_cerb_hq_buckets`[`_cerb_hq_value_idx`]))))))))) AS `Value` FROM (SELECT *, if(isNaN(`Sum`), if(length(`PositiveBucketCounts`) > 0, length(`NegativeBucketCounts`) + 1 + length(`PositiveBucketCounts`), if(`ZeroCount` > 0, length(`NegativeBucketCounts`) + 1, length(`NegativeBucketCounts`))), `_cerb_hq_idx`) AS `_cerb_hq_value_idx` FROM (SELECT *, if(isNaN(`Sum`), arrayFirstIndex(c -> c >= (0.5 * `Count`), `_cerb_hq_cum`), arrayFirstIndex(c -> `_cerb_hq_cum`[length(`_cerb_hq_cum`)] - c < ((1 - 0.5) * `Count`), `_cerb_hq_cum`)) AS `_cerb_hq_idx` FROM (SELECT *, arrayCumSum(`_cerb_hq_buckets`) AS `_cerb_hq_cum` FROM (SELECT *, arrayConcat(arrayReverse(`NegativeBucketCounts`), [`ZeroCount`], `PositiveBucketCounts`) AS `_cerb_hq_buckets` FROM (SELECT mapSort(mapConcat(mapUpdate(mapFromArrays(arrayMap(k -> replaceRegexpAll(k, '[^a-zA-Z0-9_]', '_'), mapKeys(mapFilter((k, v) -> (k NOT IN (?, ?)), `ResourceAttributes`))), mapValues(mapFilter((k, v) -> (k NOT IN (?, ?)), `ResourceAttributes`))), mapFromArrays(arrayMap(k -> replaceRegexpAll(k, '[^a-zA-Z0-9_]', '_'), mapKeys(`Attributes`)), mapValues(`Attributes`))), mapFilter((k, v) -> (v != ?), map(?, toString(`ServiceName`))))) AS `Attributes`, argMax(`Count`, `TimeUnix`) AS `Count`, argMax(`Sum`, `TimeUnix`) AS `Sum`, argMax(`Scale`, `TimeUnix`) AS `Scale`, argMax(`ZeroCount`, `TimeUnix`) AS `ZeroCount`, argMax(`PositiveOffset`, `TimeUnix`) AS `PositiveOffset`, argMax(`PositiveBucketCounts`, `TimeUnix`) AS `PositiveBucketCounts`, argMax(`NegativeOffset`, `TimeUnix`) AS `NegativeOffset`, argMax(`NegativeBucketCounts`, `TimeUnix`) AS `NegativeBucketCounts` FROM (SELECT * FROM `otel_metrics_exponential_histogram` PREWHERE (`MetricName` IN (?, ?, ?, ?, ?, ?, ?)) WHERE (`TimeUnix` <= toDateTime64(?, ?)) AND (`TimeUnix` > (toDateTime64(?, ?) - toIntervalNanosecond(?)))) GROUP BY `Attributes`))))))) GROUP BY mapSort(`Attributes`))) AS R ON mapSort(L.`Attributes`) = mapSort(R.`Attributes`)))

--- a/test/spec/promql/exp_histogram_float_vector_scaling_mul.txtar
+++ b/test/spec/promql/exp_histogram_float_vector_scaling_mul.txtar
@@ -1,0 +1,76 @@
+-- query.promql --
+histogram_quantile(0.5, latency_exp_hist) * latency_exp_hist
+-- parity --
+oracle: prometheus
+endpoint: /api/v1/query
+scope: full
+-- seed --
+CREATE TABLE otel_metrics_exponential_histogram (
+    MetricName String,
+    Attributes Map(String, String),
+    TimeUnix DateTime64(9),
+    Count UInt64,
+    Sum Float64,
+    Scale Int32,
+    ZeroCount UInt64,
+    PositiveOffset Int32,
+    PositiveBucketCounts Array(UInt64),
+    NegativeOffset Int32,
+    NegativeBucketCounts Array(UInt64)
+) ENGINE = MergeTree ORDER BY (MetricName, Attributes, TimeUnix);
+INSERT INTO otel_metrics_exponential_histogram VALUES
+    ('latency_exp_hist', map('service', 'api'), toDateTime64('2026-01-01 00:00:00', 9), 13, 30, 0, 1, 0, [3, 5, 2], 1, [2]);
+-- expected_rows --
+[
+  ["", {"service": "api"}, "2026-01-01T00:00:01Z", 0, 27.86611002594362, 64.30640775217759, 0, 0, 2.1435469250725863, 0, [6.430640775217759,10.717734625362931,4.2870938501451725], 1, [4.2870938501451725]]
+]
+-- args --
+[0] string = ""
+[1] float64 = 0
+[2] int64 = 9
+[3] float64 = 0
+[4] string = "service.name"
+[5] string = "service_name"
+[6] string = "service.name"
+[7] string = "service_name"
+[8] string = ""
+[9] string = "service_name"
+[10] string = "latency_exp_hist"
+[11] string = "latency.exp.hist"
+[12] string = "latency.exp/hist"
+[13] string = "latency.exp_hist"
+[14] string = "latency/exp/hist"
+[15] string = "latency/exp_hist"
+[16] string = "latency_exp.hist"
+[17] string = "2026-01-01 00:00:01.000000000"
+[18] int64 = 9
+[19] string = "2026-01-01 00:00:01.000000000"
+[20] int64 = 9
+[21] int64 = 300000000000
+[22] string = ""
+[23] string = ""
+[24] int64 = 9
+[25] string = "service.name"
+[26] string = "service_name"
+[27] string = "service.name"
+[28] string = "service_name"
+[29] string = ""
+[30] string = "service_name"
+[31] string = "latency_exp_hist"
+[32] string = "latency.exp.hist"
+[33] string = "latency.exp/hist"
+[34] string = "latency.exp_hist"
+[35] string = "latency/exp/hist"
+[36] string = "latency/exp_hist"
+[37] string = "latency_exp.hist"
+[38] string = "2026-01-01 00:00:01.000000000"
+[39] int64 = 9
+[40] string = "2026-01-01 00:00:01.000000000"
+[41] int64 = 9
+[42] int64 = 300000000000
+-- chplan --
+HistogramProjection project=["" AS MetricName, Attributes AS Attributes, TimeUnix AS TimeUnix, 0 AS Value]
+  Project [Attributes AS Attributes, TimeUnix AS TimeUnix, HistogramScale AS HistogramScale, HistogramZeroThreshold AS HistogramZeroThreshold, HistogramPositiveOffset AS HistogramPositiveOffset, HistogramNegativeOffset AS HistogramNegativeOffset, (HistogramCount * Value) AS HistogramCount, (HistogramSum * Value) AS HistogramSum, (HistogramZeroCount * Value) AS HistogramZeroCount, FnArrayMap(b -> (b * Value), HistogramPositiveBucketCounts) AS HistogramPositiveBucketCounts, FnArrayMap(b -> (b * Value), HistogramNegativeBucketCounts) AS HistogramNegativeBucketCounts]
+    <unknown:*chplan.HistogramFloatVectorJoin>
+-- sql --
+SELECT ? AS `MetricName`, `Attributes` AS `Attributes`, `TimeUnix` AS `TimeUnix`, toFloat64(?) AS `Value`, toFloat64(`HistogramCount`) AS `HistogramCount`, toFloat64(`HistogramSum`) AS `HistogramSum`, toInt32(`HistogramScale`) AS `HistogramScale`, toFloat64(`HistogramZeroThreshold`) AS `HistogramZeroThreshold`, toFloat64(`HistogramZeroCount`) AS `HistogramZeroCount`, toInt32(`HistogramPositiveOffset`) AS `HistogramPositiveOffset`, arrayMap(x -> toFloat64(x), `HistogramPositiveBucketCounts`) AS `HistogramPositiveBucketCounts`, toInt32(`HistogramNegativeOffset`) AS `HistogramNegativeOffset`, arrayMap(x -> toFloat64(x), `HistogramNegativeBucketCounts`) AS `HistogramNegativeBucketCounts` FROM (SELECT `Attributes` AS `Attributes`, `TimeUnix` AS `TimeUnix`, `HistogramScale` AS `HistogramScale`, `HistogramZeroThreshold` AS `HistogramZeroThreshold`, `HistogramPositiveOffset` AS `HistogramPositiveOffset`, `HistogramNegativeOffset` AS `HistogramNegativeOffset`, (`HistogramCount` * `Value`) AS `HistogramCount`, (`HistogramSum` * `Value`) AS `HistogramSum`, (`HistogramZeroCount` * `Value`) AS `HistogramZeroCount`, arrayMap(b -> (b * `Value`), `HistogramPositiveBucketCounts`) AS `HistogramPositiveBucketCounts`, arrayMap(b -> (b * `Value`), `HistogramNegativeBucketCounts`) AS `HistogramNegativeBucketCounts` FROM (SELECT L.`MetricName` AS `MetricName`, L.`Attributes` AS `Attributes`, L.`TimeUnix` AS `TimeUnix`, L.`HistogramScale` AS `HistogramScale`, L.`HistogramCount` AS `HistogramCount`, L.`HistogramSum` AS `HistogramSum`, L.`HistogramZeroCount` AS `HistogramZeroCount`, L.`HistogramZeroThreshold` AS `HistogramZeroThreshold`, L.`HistogramPositiveOffset` AS `HistogramPositiveOffset`, L.`HistogramPositiveBucketCounts` AS `HistogramPositiveBucketCounts`, L.`HistogramNegativeOffset` AS `HistogramNegativeOffset`, L.`HistogramNegativeBucketCounts` AS `HistogramNegativeBucketCounts`, R.`Value` AS `Value` FROM (SELECT `_join_MetricName` AS `MetricName`, `_join_Attributes` AS `Attributes`, `_join_TimeUnix` AS `TimeUnix`, `_join_HistogramScale` AS `HistogramScale`, `_join_HistogramCount` AS `HistogramCount`, `_join_HistogramSum` AS `HistogramSum`, `_join_HistogramZeroCount` AS `HistogramZeroCount`, `_join_HistogramZeroThreshold` AS `HistogramZeroThreshold`, `_join_HistogramPositiveOffset` AS `HistogramPositiveOffset`, `_join_HistogramPositiveBucketCounts` AS `HistogramPositiveBucketCounts`, `_join_HistogramNegativeOffset` AS `HistogramNegativeOffset`, `_join_HistogramNegativeBucketCounts` AS `HistogramNegativeBucketCounts` FROM (SELECT `MetricName` AS `_join_MetricName`, `Attributes` AS `_join_Attributes`, `TimeUnix` AS `_join_TimeUnix`, `HistogramScale` AS `_join_HistogramScale`, `HistogramCount` AS `_join_HistogramCount`, `HistogramSum` AS `_join_HistogramSum`, `HistogramZeroCount` AS `_join_HistogramZeroCount`, `HistogramZeroThreshold` AS `_join_HistogramZeroThreshold`, `HistogramPositiveOffset` AS `_join_HistogramPositiveOffset`, `HistogramPositiveBucketCounts` AS `_join_HistogramPositiveBucketCounts`, `HistogramNegativeOffset` AS `_join_HistogramNegativeOffset`, `HistogramNegativeBucketCounts` AS `_join_HistogramNegativeBucketCounts` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, now64(?) AS `TimeUnix`, toFloat64(?) AS `Value`, toFloat64(`Count`) AS `HistogramCount`, toFloat64(`Sum`) AS `HistogramSum`, toInt32(`Scale`) AS `HistogramScale`, toFloat64(0.) AS `HistogramZeroThreshold`, toFloat64(`ZeroCount`) AS `HistogramZeroCount`, toInt32(`PositiveOffset`) AS `HistogramPositiveOffset`, arrayMap(x -> toFloat64(x), `PositiveBucketCounts`) AS `HistogramPositiveBucketCounts`, toInt32(`NegativeOffset`) AS `HistogramNegativeOffset`, arrayMap(x -> toFloat64(x), `NegativeBucketCounts`) AS `HistogramNegativeBucketCounts` FROM (SELECT mapSort(mapConcat(mapUpdate(mapFromArrays(arrayMap(k -> replaceRegexpAll(k, '[^a-zA-Z0-9_]', '_'), mapKeys(mapFilter((k, v) -> (k NOT IN (?, ?)), `ResourceAttributes`))), mapValues(mapFilter((k, v) -> (k NOT IN (?, ?)), `ResourceAttributes`))), mapFromArrays(arrayMap(k -> replaceRegexpAll(k, '[^a-zA-Z0-9_]', '_'), mapKeys(`Attributes`)), mapValues(`Attributes`))), mapFilter((k, v) -> (v != ?), map(?, toString(`ServiceName`))))) AS `Attributes`, argMax(`MetricName`, `TimeUnix`) AS `MetricName`, argMax(`Count`, `TimeUnix`) AS `Count`, argMax(`Sum`, `TimeUnix`) AS `Sum`, argMax(`Scale`, `TimeUnix`) AS `Scale`, argMax(`ZeroCount`, `TimeUnix`) AS `ZeroCount`, argMax(`PositiveOffset`, `TimeUnix`) AS `PositiveOffset`, argMax(`PositiveBucketCounts`, `TimeUnix`) AS `PositiveBucketCounts`, argMax(`NegativeOffset`, `TimeUnix`) AS `NegativeOffset`, argMax(`NegativeBucketCounts`, `TimeUnix`) AS `NegativeBucketCounts` FROM (SELECT * FROM `otel_metrics_exponential_histogram` PREWHERE (`MetricName` IN (?, ?, ?, ?, ?, ?, ?)) WHERE (`TimeUnix` <= toDateTime64(?, ?)) AND (`TimeUnix` > (toDateTime64(?, ?) - toIntervalNanosecond(?)))) GROUP BY `Attributes`)))) AS L INNER JOIN (SELECT `_join_MetricName` AS `MetricName`, `_join_Attributes` AS `Attributes`, `_join_TimeUnix` AS `TimeUnix`, `_join_Value` AS `Value` FROM (SELECT ? AS `_join_MetricName`, mapSort(`Attributes`) AS `_join_Attributes`, max(`TimeUnix`) AS `_join_TimeUnix`, argMax(`Value`, `TimeUnix`) AS `_join_Value` FROM (SELECT ? AS `MetricName`, `Attributes` AS `Attributes`, now64(?) AS `TimeUnix`, `Value` AS `Value` FROM (SELECT `Attributes` AS `Attributes`, if(0.5 < 0, -inf, if(0.5 > 1, inf, if(`Count` = 0, nan, if(0.5 = 0, if(arrayFirstIndex(c -> c > 0, `_cerb_hq_buckets`) <= length(`NegativeBucketCounts`), -pow(pow(2, pow(2, -`Scale`)), `NegativeOffset` + (length(`NegativeBucketCounts`) - arrayFirstIndex(c -> c > 0, `_cerb_hq_buckets`)) + 1), if(arrayFirstIndex(c -> c > 0, `_cerb_hq_buckets`) = length(`NegativeBucketCounts`) + 1, if(length(`NegativeBucketCounts`) = 0 AND length(`PositiveBucketCounts`) > 0, 0., -0.), pow(pow(2, pow(2, -`Scale`)), `PositiveOffset` + (arrayFirstIndex(c -> c > 0, `_cerb_hq_buckets`) - length(`NegativeBucketCounts`) - 2)))), if(0.5 = 1, if(arrayLastIndex(c -> c > 0, `_cerb_hq_buckets`) <= length(`NegativeBucketCounts`), -pow(pow(2, pow(2, -`Scale`)), `NegativeOffset` + (length(`NegativeBucketCounts`) - arrayLastIndex(c -> c > 0, `_cerb_hq_buckets`))), if(arrayLastIndex(c -> c > 0, `_cerb_hq_buckets`) = length(`NegativeBucketCounts`) + 1, if(length(`PositiveBucketCounts`) = 0 AND length(`NegativeBucketCounts`) > 0, 0., 0.), pow(pow(2, pow(2, -`Scale`)), `PositiveOffset` + (arrayLastIndex(c -> c > 0, `_cerb_hq_buckets`) - length(`NegativeBucketCounts`) - 1)))), if(`_cerb_hq_idx` = 0, nan, if(`_cerb_hq_value_idx` <= length(`NegativeBucketCounts`), -pow(pow(2, pow(2, -`Scale`)), `NegativeOffset` + (length(`NegativeBucketCounts`) - `_cerb_hq_value_idx`) + 1 - ((0.5 * `Count`) - `_cerb_hq_cum`[`_cerb_hq_idx` - 1]) / `_cerb_hq_buckets`[`_cerb_hq_value_idx`]), if(`_cerb_hq_value_idx` = length(`NegativeBucketCounts`) + 1, if(length(`NegativeBucketCounts`) = 0 AND length(`PositiveBucketCounts`) > 0, 0., -0.) + (if(length(`PositiveBucketCounts`) = 0 AND length(`NegativeBucketCounts`) > 0, 0., 0.) - if(length(`NegativeBucketCounts`) = 0 AND length(`PositiveBucketCounts`) > 0, 0., -0.)) * ((0.5 * `Count`) - `_cerb_hq_cum`[`_cerb_hq_idx` - 1]) / `_cerb_hq_buckets`[`_cerb_hq_value_idx`], pow(pow(2, pow(2, -`Scale`)), `PositiveOffset` + (`_cerb_hq_value_idx` - length(`NegativeBucketCounts`) - 2) + ((0.5 * `Count`) - `_cerb_hq_cum`[`_cerb_hq_idx` - 1]) / `_cerb_hq_buckets`[`_cerb_hq_value_idx`]))))))))) AS `Value` FROM (SELECT *, if(isNaN(`Sum`), if(length(`PositiveBucketCounts`) > 0, length(`NegativeBucketCounts`) + 1 + length(`PositiveBucketCounts`), if(`ZeroCount` > 0, length(`NegativeBucketCounts`) + 1, length(`NegativeBucketCounts`))), `_cerb_hq_idx`) AS `_cerb_hq_value_idx` FROM (SELECT *, if(isNaN(`Sum`), arrayFirstIndex(c -> c >= (0.5 * `Count`), `_cerb_hq_cum`), arrayFirstIndex(c -> `_cerb_hq_cum`[length(`_cerb_hq_cum`)] - c < ((1 - 0.5) * `Count`), `_cerb_hq_cum`)) AS `_cerb_hq_idx` FROM (SELECT *, arrayCumSum(`_cerb_hq_buckets`) AS `_cerb_hq_cum` FROM (SELECT *, arrayConcat(arrayReverse(`NegativeBucketCounts`), [`ZeroCount`], `PositiveBucketCounts`) AS `_cerb_hq_buckets` FROM (SELECT mapSort(mapConcat(mapUpdate(mapFromArrays(arrayMap(k -> replaceRegexpAll(k, '[^a-zA-Z0-9_]', '_'), mapKeys(mapFilter((k, v) -> (k NOT IN (?, ?)), `ResourceAttributes`))), mapValues(mapFilter((k, v) -> (k NOT IN (?, ?)), `ResourceAttributes`))), mapFromArrays(arrayMap(k -> replaceRegexpAll(k, '[^a-zA-Z0-9_]', '_'), mapKeys(`Attributes`)), mapValues(`Attributes`))), mapFilter((k, v) -> (v != ?), map(?, toString(`ServiceName`))))) AS `Attributes`, argMax(`Count`, `TimeUnix`) AS `Count`, argMax(`Sum`, `TimeUnix`) AS `Sum`, argMax(`Scale`, `TimeUnix`) AS `Scale`, argMax(`ZeroCount`, `TimeUnix`) AS `ZeroCount`, argMax(`PositiveOffset`, `TimeUnix`) AS `PositiveOffset`, argMax(`PositiveBucketCounts`, `TimeUnix`) AS `PositiveBucketCounts`, argMax(`NegativeOffset`, `TimeUnix`) AS `NegativeOffset`, argMax(`NegativeBucketCounts`, `TimeUnix`) AS `NegativeBucketCounts` FROM (SELECT * FROM `otel_metrics_exponential_histogram` PREWHERE (`MetricName` IN (?, ?, ?, ?, ?, ?, ?)) WHERE (`TimeUnix` <= toDateTime64(?, ?)) AND (`TimeUnix` > (toDateTime64(?, ?) - toIntervalNanosecond(?)))) GROUP BY `Attributes`))))))) GROUP BY mapSort(`Attributes`))) AS R ON mapSort(L.`Attributes`) = mapSort(R.`Attributes`)))

--- a/test/spec/promql/exp_histogram_float_vector_scaling_mul_commute.txtar
+++ b/test/spec/promql/exp_histogram_float_vector_scaling_mul_commute.txtar
@@ -1,0 +1,76 @@
+-- query.promql --
+latency_exp_hist * histogram_quantile(0.5, latency_exp_hist)
+-- parity --
+oracle: prometheus
+endpoint: /api/v1/query
+scope: full
+-- seed --
+CREATE TABLE otel_metrics_exponential_histogram (
+    MetricName String,
+    Attributes Map(String, String),
+    TimeUnix DateTime64(9),
+    Count UInt64,
+    Sum Float64,
+    Scale Int32,
+    ZeroCount UInt64,
+    PositiveOffset Int32,
+    PositiveBucketCounts Array(UInt64),
+    NegativeOffset Int32,
+    NegativeBucketCounts Array(UInt64)
+) ENGINE = MergeTree ORDER BY (MetricName, Attributes, TimeUnix);
+INSERT INTO otel_metrics_exponential_histogram VALUES
+    ('latency_exp_hist', map('service', 'api'), toDateTime64('2026-01-01 00:00:00', 9), 13, 30, 0, 1, 0, [3, 5, 2], 1, [2]);
+-- expected_rows --
+[
+  ["", {"service": "api"}, "2026-01-01T00:00:01Z", 0, 27.86611002594362, 64.30640775217759, 0, 0, 2.1435469250725863, 0, [6.430640775217759,10.717734625362931,4.2870938501451725], 1, [4.2870938501451725]]
+]
+-- args --
+[0] string = ""
+[1] float64 = 0
+[2] int64 = 9
+[3] float64 = 0
+[4] string = "service.name"
+[5] string = "service_name"
+[6] string = "service.name"
+[7] string = "service_name"
+[8] string = ""
+[9] string = "service_name"
+[10] string = "latency_exp_hist"
+[11] string = "latency.exp.hist"
+[12] string = "latency.exp/hist"
+[13] string = "latency.exp_hist"
+[14] string = "latency/exp/hist"
+[15] string = "latency/exp_hist"
+[16] string = "latency_exp.hist"
+[17] string = "2026-01-01 00:00:01.000000000"
+[18] int64 = 9
+[19] string = "2026-01-01 00:00:01.000000000"
+[20] int64 = 9
+[21] int64 = 300000000000
+[22] string = ""
+[23] string = ""
+[24] int64 = 9
+[25] string = "service.name"
+[26] string = "service_name"
+[27] string = "service.name"
+[28] string = "service_name"
+[29] string = ""
+[30] string = "service_name"
+[31] string = "latency_exp_hist"
+[32] string = "latency.exp.hist"
+[33] string = "latency.exp/hist"
+[34] string = "latency.exp_hist"
+[35] string = "latency/exp/hist"
+[36] string = "latency/exp_hist"
+[37] string = "latency_exp.hist"
+[38] string = "2026-01-01 00:00:01.000000000"
+[39] int64 = 9
+[40] string = "2026-01-01 00:00:01.000000000"
+[41] int64 = 9
+[42] int64 = 300000000000
+-- chplan --
+HistogramProjection project=["" AS MetricName, Attributes AS Attributes, TimeUnix AS TimeUnix, 0 AS Value]
+  Project [Attributes AS Attributes, TimeUnix AS TimeUnix, HistogramScale AS HistogramScale, HistogramZeroThreshold AS HistogramZeroThreshold, HistogramPositiveOffset AS HistogramPositiveOffset, HistogramNegativeOffset AS HistogramNegativeOffset, (HistogramCount * Value) AS HistogramCount, (HistogramSum * Value) AS HistogramSum, (HistogramZeroCount * Value) AS HistogramZeroCount, FnArrayMap(b -> (b * Value), HistogramPositiveBucketCounts) AS HistogramPositiveBucketCounts, FnArrayMap(b -> (b * Value), HistogramNegativeBucketCounts) AS HistogramNegativeBucketCounts]
+    <unknown:*chplan.HistogramFloatVectorJoin>
+-- sql --
+SELECT ? AS `MetricName`, `Attributes` AS `Attributes`, `TimeUnix` AS `TimeUnix`, toFloat64(?) AS `Value`, toFloat64(`HistogramCount`) AS `HistogramCount`, toFloat64(`HistogramSum`) AS `HistogramSum`, toInt32(`HistogramScale`) AS `HistogramScale`, toFloat64(`HistogramZeroThreshold`) AS `HistogramZeroThreshold`, toFloat64(`HistogramZeroCount`) AS `HistogramZeroCount`, toInt32(`HistogramPositiveOffset`) AS `HistogramPositiveOffset`, arrayMap(x -> toFloat64(x), `HistogramPositiveBucketCounts`) AS `HistogramPositiveBucketCounts`, toInt32(`HistogramNegativeOffset`) AS `HistogramNegativeOffset`, arrayMap(x -> toFloat64(x), `HistogramNegativeBucketCounts`) AS `HistogramNegativeBucketCounts` FROM (SELECT `Attributes` AS `Attributes`, `TimeUnix` AS `TimeUnix`, `HistogramScale` AS `HistogramScale`, `HistogramZeroThreshold` AS `HistogramZeroThreshold`, `HistogramPositiveOffset` AS `HistogramPositiveOffset`, `HistogramNegativeOffset` AS `HistogramNegativeOffset`, (`HistogramCount` * `Value`) AS `HistogramCount`, (`HistogramSum` * `Value`) AS `HistogramSum`, (`HistogramZeroCount` * `Value`) AS `HistogramZeroCount`, arrayMap(b -> (b * `Value`), `HistogramPositiveBucketCounts`) AS `HistogramPositiveBucketCounts`, arrayMap(b -> (b * `Value`), `HistogramNegativeBucketCounts`) AS `HistogramNegativeBucketCounts` FROM (SELECT L.`MetricName` AS `MetricName`, L.`Attributes` AS `Attributes`, L.`TimeUnix` AS `TimeUnix`, L.`HistogramScale` AS `HistogramScale`, L.`HistogramCount` AS `HistogramCount`, L.`HistogramSum` AS `HistogramSum`, L.`HistogramZeroCount` AS `HistogramZeroCount`, L.`HistogramZeroThreshold` AS `HistogramZeroThreshold`, L.`HistogramPositiveOffset` AS `HistogramPositiveOffset`, L.`HistogramPositiveBucketCounts` AS `HistogramPositiveBucketCounts`, L.`HistogramNegativeOffset` AS `HistogramNegativeOffset`, L.`HistogramNegativeBucketCounts` AS `HistogramNegativeBucketCounts`, R.`Value` AS `Value` FROM (SELECT `_join_MetricName` AS `MetricName`, `_join_Attributes` AS `Attributes`, `_join_TimeUnix` AS `TimeUnix`, `_join_HistogramScale` AS `HistogramScale`, `_join_HistogramCount` AS `HistogramCount`, `_join_HistogramSum` AS `HistogramSum`, `_join_HistogramZeroCount` AS `HistogramZeroCount`, `_join_HistogramZeroThreshold` AS `HistogramZeroThreshold`, `_join_HistogramPositiveOffset` AS `HistogramPositiveOffset`, `_join_HistogramPositiveBucketCounts` AS `HistogramPositiveBucketCounts`, `_join_HistogramNegativeOffset` AS `HistogramNegativeOffset`, `_join_HistogramNegativeBucketCounts` AS `HistogramNegativeBucketCounts` FROM (SELECT `MetricName` AS `_join_MetricName`, `Attributes` AS `_join_Attributes`, `TimeUnix` AS `_join_TimeUnix`, `HistogramScale` AS `_join_HistogramScale`, `HistogramCount` AS `_join_HistogramCount`, `HistogramSum` AS `_join_HistogramSum`, `HistogramZeroCount` AS `_join_HistogramZeroCount`, `HistogramZeroThreshold` AS `_join_HistogramZeroThreshold`, `HistogramPositiveOffset` AS `_join_HistogramPositiveOffset`, `HistogramPositiveBucketCounts` AS `_join_HistogramPositiveBucketCounts`, `HistogramNegativeOffset` AS `_join_HistogramNegativeOffset`, `HistogramNegativeBucketCounts` AS `_join_HistogramNegativeBucketCounts` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, now64(?) AS `TimeUnix`, toFloat64(?) AS `Value`, toFloat64(`Count`) AS `HistogramCount`, toFloat64(`Sum`) AS `HistogramSum`, toInt32(`Scale`) AS `HistogramScale`, toFloat64(0.) AS `HistogramZeroThreshold`, toFloat64(`ZeroCount`) AS `HistogramZeroCount`, toInt32(`PositiveOffset`) AS `HistogramPositiveOffset`, arrayMap(x -> toFloat64(x), `PositiveBucketCounts`) AS `HistogramPositiveBucketCounts`, toInt32(`NegativeOffset`) AS `HistogramNegativeOffset`, arrayMap(x -> toFloat64(x), `NegativeBucketCounts`) AS `HistogramNegativeBucketCounts` FROM (SELECT mapSort(mapConcat(mapUpdate(mapFromArrays(arrayMap(k -> replaceRegexpAll(k, '[^a-zA-Z0-9_]', '_'), mapKeys(mapFilter((k, v) -> (k NOT IN (?, ?)), `ResourceAttributes`))), mapValues(mapFilter((k, v) -> (k NOT IN (?, ?)), `ResourceAttributes`))), mapFromArrays(arrayMap(k -> replaceRegexpAll(k, '[^a-zA-Z0-9_]', '_'), mapKeys(`Attributes`)), mapValues(`Attributes`))), mapFilter((k, v) -> (v != ?), map(?, toString(`ServiceName`))))) AS `Attributes`, argMax(`MetricName`, `TimeUnix`) AS `MetricName`, argMax(`Count`, `TimeUnix`) AS `Count`, argMax(`Sum`, `TimeUnix`) AS `Sum`, argMax(`Scale`, `TimeUnix`) AS `Scale`, argMax(`ZeroCount`, `TimeUnix`) AS `ZeroCount`, argMax(`PositiveOffset`, `TimeUnix`) AS `PositiveOffset`, argMax(`PositiveBucketCounts`, `TimeUnix`) AS `PositiveBucketCounts`, argMax(`NegativeOffset`, `TimeUnix`) AS `NegativeOffset`, argMax(`NegativeBucketCounts`, `TimeUnix`) AS `NegativeBucketCounts` FROM (SELECT * FROM `otel_metrics_exponential_histogram` PREWHERE (`MetricName` IN (?, ?, ?, ?, ?, ?, ?)) WHERE (`TimeUnix` <= toDateTime64(?, ?)) AND (`TimeUnix` > (toDateTime64(?, ?) - toIntervalNanosecond(?)))) GROUP BY `Attributes`)))) AS L INNER JOIN (SELECT `_join_MetricName` AS `MetricName`, `_join_Attributes` AS `Attributes`, `_join_TimeUnix` AS `TimeUnix`, `_join_Value` AS `Value` FROM (SELECT ? AS `_join_MetricName`, mapSort(`Attributes`) AS `_join_Attributes`, max(`TimeUnix`) AS `_join_TimeUnix`, argMax(`Value`, `TimeUnix`) AS `_join_Value` FROM (SELECT ? AS `MetricName`, `Attributes` AS `Attributes`, now64(?) AS `TimeUnix`, `Value` AS `Value` FROM (SELECT `Attributes` AS `Attributes`, if(0.5 < 0, -inf, if(0.5 > 1, inf, if(`Count` = 0, nan, if(0.5 = 0, if(arrayFirstIndex(c -> c > 0, `_cerb_hq_buckets`) <= length(`NegativeBucketCounts`), -pow(pow(2, pow(2, -`Scale`)), `NegativeOffset` + (length(`NegativeBucketCounts`) - arrayFirstIndex(c -> c > 0, `_cerb_hq_buckets`)) + 1), if(arrayFirstIndex(c -> c > 0, `_cerb_hq_buckets`) = length(`NegativeBucketCounts`) + 1, if(length(`NegativeBucketCounts`) = 0 AND length(`PositiveBucketCounts`) > 0, 0., -0.), pow(pow(2, pow(2, -`Scale`)), `PositiveOffset` + (arrayFirstIndex(c -> c > 0, `_cerb_hq_buckets`) - length(`NegativeBucketCounts`) - 2)))), if(0.5 = 1, if(arrayLastIndex(c -> c > 0, `_cerb_hq_buckets`) <= length(`NegativeBucketCounts`), -pow(pow(2, pow(2, -`Scale`)), `NegativeOffset` + (length(`NegativeBucketCounts`) - arrayLastIndex(c -> c > 0, `_cerb_hq_buckets`))), if(arrayLastIndex(c -> c > 0, `_cerb_hq_buckets`) = length(`NegativeBucketCounts`) + 1, if(length(`PositiveBucketCounts`) = 0 AND length(`NegativeBucketCounts`) > 0, 0., 0.), pow(pow(2, pow(2, -`Scale`)), `PositiveOffset` + (arrayLastIndex(c -> c > 0, `_cerb_hq_buckets`) - length(`NegativeBucketCounts`) - 1)))), if(`_cerb_hq_idx` = 0, nan, if(`_cerb_hq_value_idx` <= length(`NegativeBucketCounts`), -pow(pow(2, pow(2, -`Scale`)), `NegativeOffset` + (length(`NegativeBucketCounts`) - `_cerb_hq_value_idx`) + 1 - ((0.5 * `Count`) - `_cerb_hq_cum`[`_cerb_hq_idx` - 1]) / `_cerb_hq_buckets`[`_cerb_hq_value_idx`]), if(`_cerb_hq_value_idx` = length(`NegativeBucketCounts`) + 1, if(length(`NegativeBucketCounts`) = 0 AND length(`PositiveBucketCounts`) > 0, 0., -0.) + (if(length(`PositiveBucketCounts`) = 0 AND length(`NegativeBucketCounts`) > 0, 0., 0.) - if(length(`NegativeBucketCounts`) = 0 AND length(`PositiveBucketCounts`) > 0, 0., -0.)) * ((0.5 * `Count`) - `_cerb_hq_cum`[`_cerb_hq_idx` - 1]) / `_cerb_hq_buckets`[`_cerb_hq_value_idx`], pow(pow(2, pow(2, -`Scale`)), `PositiveOffset` + (`_cerb_hq_value_idx` - length(`NegativeBucketCounts`) - 2) + ((0.5 * `Count`) - `_cerb_hq_cum`[`_cerb_hq_idx` - 1]) / `_cerb_hq_buckets`[`_cerb_hq_value_idx`]))))))))) AS `Value` FROM (SELECT *, if(isNaN(`Sum`), if(length(`PositiveBucketCounts`) > 0, length(`NegativeBucketCounts`) + 1 + length(`PositiveBucketCounts`), if(`ZeroCount` > 0, length(`NegativeBucketCounts`) + 1, length(`NegativeBucketCounts`))), `_cerb_hq_idx`) AS `_cerb_hq_value_idx` FROM (SELECT *, if(isNaN(`Sum`), arrayFirstIndex(c -> c >= (0.5 * `Count`), `_cerb_hq_cum`), arrayFirstIndex(c -> `_cerb_hq_cum`[length(`_cerb_hq_cum`)] - c < ((1 - 0.5) * `Count`), `_cerb_hq_cum`)) AS `_cerb_hq_idx` FROM (SELECT *, arrayCumSum(`_cerb_hq_buckets`) AS `_cerb_hq_cum` FROM (SELECT *, arrayConcat(arrayReverse(`NegativeBucketCounts`), [`ZeroCount`], `PositiveBucketCounts`) AS `_cerb_hq_buckets` FROM (SELECT mapSort(mapConcat(mapUpdate(mapFromArrays(arrayMap(k -> replaceRegexpAll(k, '[^a-zA-Z0-9_]', '_'), mapKeys(mapFilter((k, v) -> (k NOT IN (?, ?)), `ResourceAttributes`))), mapValues(mapFilter((k, v) -> (k NOT IN (?, ?)), `ResourceAttributes`))), mapFromArrays(arrayMap(k -> replaceRegexpAll(k, '[^a-zA-Z0-9_]', '_'), mapKeys(`Attributes`)), mapValues(`Attributes`))), mapFilter((k, v) -> (v != ?), map(?, toString(`ServiceName`))))) AS `Attributes`, argMax(`Count`, `TimeUnix`) AS `Count`, argMax(`Sum`, `TimeUnix`) AS `Sum`, argMax(`Scale`, `TimeUnix`) AS `Scale`, argMax(`ZeroCount`, `TimeUnix`) AS `ZeroCount`, argMax(`PositiveOffset`, `TimeUnix`) AS `PositiveOffset`, argMax(`PositiveBucketCounts`, `TimeUnix`) AS `PositiveBucketCounts`, argMax(`NegativeOffset`, `TimeUnix`) AS `NegativeOffset`, argMax(`NegativeBucketCounts`, `TimeUnix`) AS `NegativeBucketCounts` FROM (SELECT * FROM `otel_metrics_exponential_histogram` PREWHERE (`MetricName` IN (?, ?, ?, ?, ?, ?, ?)) WHERE (`TimeUnix` <= toDateTime64(?, ?)) AND (`TimeUnix` > (toDateTime64(?, ?) - toIntervalNanosecond(?)))) GROUP BY `Attributes`))))))) GROUP BY mapSort(`Attributes`))) AS R ON mapSort(L.`Attributes`) = mapSort(R.`Attributes`)))


### PR DESCRIPTION
## What

Closes #2339: `some_float_vector * demo_latency_exp_hist`, `demo_latency_exp_hist *
some_float_vector`, and `demo_latency_exp_hist / some_float_vector` now lower and execute, matching
reference Prometheus's histogram-scaling `vectorElemBinop` shapes (`hlhs.Mul(rhs)`/`hlhs.Div(rhs)`).

Generalizes `histogram_native_scalar_binop.go`'s per-bucket scale machinery (previously
compile-time-literal-scalar only) to a per-row float factor joined from the other operand by label
signature, via a new `HistogramFloatVectorJoin` plan/emitter pair mirroring the
`HistogramVectorJoin` broadcast shape #2328/#2334 already built for `group_left`/`group_right`.

`float-right DIV` (`demo_latency_exp_hist / some_float_vector`) is supported; `some_float_vector /
demo_latency_exp_hist` is **not** a reference-supported shape and remains correctly rejected,
unchanged.

## Rejection-parity catalogue

`internal/promql/lower.go:expHistogramSelectorRouting#bf746b59`'s trigger query (`some_float_vector
* demo_latency_exp_hist`, tracking #2339) now succeeds — repointed/reclassified per
`CERBERUS_UPDATE_INVENTORY=1`'s regeneration; verified locally.

## Verification

- [x] `go build ./...`, `go vet ./...`
- [x] `go test -race ./internal/promql/... ./internal/chplan/... ./internal/chsql/...`
- [x] chDB round-trip TXTAR fixtures for both MUL orderings and histogram-left DIV
- [x] `CERBERUS_UPDATE_INVENTORY=1 go test ./test/surface-parity/ ./test/rejection-parity/` — clean