### PR TITLE
test(chsql): kill the 18 LIVED gremlins mutants in phase2-other

### DIFF
--- a/internal/chsql/gremlins_kill_test.go
+++ b/internal/chsql/gremlins_kill_test.go
@@ -4066,3 +4066,95 @@ func TestWindowFrag_PartitionByBoundary(t *testing.T) {
 		t.Errorf("empty partition list must NOT emit a dangling PARTITION BY; got %q", without)
 	}
 }
+
+// --- range_window.go predict_linear slope-column dispatch (411:5) ---
+
+// TestPredictLinear_SlopeColumnDispatch kills the CONDITIONALS_NEGATION
+// mutant at range_window.go:411 (`r.PredictLinearSlopeColumn == ""`).
+// An empty slope column must route through the plain single-value writer
+// (only the `Value` column projected); a non-empty one must route through
+// the "with extra" writer, projecting a SECOND column that reads the
+// slope out of the same simpleLinearRegression tuple
+// (`tupleElement(..., 1)`). The `==` → `!=` flip swaps which shape gets
+// which path.
+func TestPredictLinear_SlopeColumnDispatch(t *testing.T) {
+	t.Parallel()
+
+	base := func() *chplan.RangeWindow {
+		return &chplan.RangeWindow{
+			Input:           &chplan.Scan{Table: "otel_metrics_gauge"},
+			Func:            "predict_linear",
+			Scalars:         []float64{3600},
+			Range:           5 * time.Minute,
+			TimestampColumn: "TimeUnix",
+			ValueColumn:     "Value",
+		}
+	}
+
+	sqlWithout, _, err := Emit(context.Background(), base())
+	if err != nil {
+		t.Fatalf("Emit(no slope column): %v", err)
+	}
+	plan := base()
+	plan.PredictLinearSlopeColumn = "predict_slope"
+	sqlWith, _, err := Emit(context.Background(), plan)
+	if err != nil {
+		t.Fatalf("Emit(slope column set): %v", err)
+	}
+
+	t.Run("no slope column → no extra projection", func(t *testing.T) {
+		t.Parallel()
+		if strings.Contains(sqlWithout, "predict_slope") {
+			t.Errorf("expected no slope projection with PredictLinearSlopeColumn unset\nSQL: %s", sqlWithout)
+		}
+	})
+
+	t.Run("slope column set → extra projection reads slot 1", func(t *testing.T) {
+		t.Parallel()
+		// The extra projection reads the SLOPE slot (tupleElement index
+		// 1) of the regression tuple, mirroring the slope term already
+		// inside `predict` (`... , 1) * ?`) — pinning the exact suffix
+		// distinguishes "the slope projection was added" from "some
+		// other tupleElement(...) call happens to precede the alias".
+		if !strings.Contains(sqlWith, "), 1) AS predict_slope") {
+			t.Errorf("expected the slope projection (tupleElement(..., 1) AS predict_slope) with PredictLinearSlopeColumn set\nSQL: %s", sqlWith)
+		}
+		if strings.Contains(sqlWithout, "predict_slope") {
+			t.Errorf("baseline SQL must not carry the slope alias\nSQL: %s", sqlWithout)
+		}
+	})
+}
+
+// --- range_window.go anchorGridCeilIdxFrag arithmetic (1812:41) ---
+
+// TestAnchorGridCeilIdxFrag_ShiftsAddNSDownByOne kills the ARITHMETIC_BASE
+// mutant at range_window.go:1812 (`addNS-1` → `addNS+1`) inside
+// anchorGridCeilIdxFrag. The ceiling index is documented to equal the
+// floor index with its addend shifted down by exactly one nanosecond;
+// this pins that relationship directly against anchorGridFloorIdxFrag
+// rather than against a hand-rendered literal, so it can't drift with the
+// floor helper's own rendering.
+func TestAnchorGridCeilIdxFrag_ShiftsAddNSDownByOne(t *testing.T) {
+	t.Parallel()
+	render := func(f Frag) string {
+		b := &Builder{}
+		f(b)
+		return b.String()
+	}
+
+	dist := BareIdent("dist")
+	const addNS = int64(5_000_000_000) // 5s, an arbitrary non-zero addend
+	const stepNS = int64(60_000_000_000)
+
+	got := render(anchorGridCeilIdxFrag(dist, addNS, stepNS))
+	want := render(anchorGridFloorIdxFrag(dist, addNS-1, stepNS))
+	if got != want {
+		t.Errorf("anchorGridCeilIdxFrag(dist, %d, step) must equal anchorGridFloorIdxFrag(dist, %d-1, step)\ngot:  %s\nwant: %s",
+			addNS, addNS, got, want)
+	}
+	// Negative control: the `addNS+1` mutant would instead match this.
+	wrong := render(anchorGridFloorIdxFrag(dist, addNS+1, stepNS))
+	if got == wrong {
+		t.Errorf("anchorGridCeilIdxFrag(dist, %d, step) unexpectedly matches the +1 shift (line 1812 flipped?): %s", addNS, got)
+	}
+}

--- a/internal/chsql/histogram_quantile_test.go
+++ b/internal/chsql/histogram_quantile_test.go
@@ -21,3 +21,67 @@ func TestHistogramQuantileValueFrag_DividesRankBeforeWidth(t *testing.T) {
 		t.Fatalf("interpolation must divide the rank offset before multiplying by the bucket width:\n%s", b.String())
 	}
 }
+
+// TestHistogramQuantileValueFrag_PhiExprGating kills the two
+// CONDITIONALS_NEGATION mutants at histogram_quantile.go:217
+// (`h.PhiExpr != nil`, inside the arrayFirstIndex predicate) and :318
+// (`h.PhiExpr == nil`, the early return before the isNaN wrapper).
+//
+// The literal-Phi path (h.PhiExpr == nil) must render the BARE `c >=
+// <target>` comparison as the arrayFirstIndex predicate and must NOT
+// wrap the whole expression in an `isNaN(phi) → nan` guard (h.Phi is a
+// query-shape constant, never NaN). The computed-PhiExpr path is the
+// mirror: CH 24.8 rejects a scalar subquery inside arrayFirstIndex's
+// filter unless the comparison is re-folded through `if(...)`, so the
+// predicate must render as `(if(c >= <target>, 1, 0) = 1)`, and the
+// runtime phi CAN be NaN, so the isNaN guard must wrap the whole
+// expression.
+//
+// Negating 217 alone would apply the wrapped `if(...)  = 1)` predicate
+// to the literal-Phi path (and the bare predicate to the PhiExpr path);
+// negating 318 alone would apply (or skip) the isNaN wrapper on the
+// wrong path. Asserting both markers on both cases pins each
+// independently.
+func TestHistogramQuantileValueFrag_PhiExprGating(t *testing.T) {
+	t.Parallel()
+
+	t.Run("literal phi: bare predicate, no isNaN guard", func(t *testing.T) {
+		t.Parallel()
+		b := NewBuilder()
+		histogramQuantileValueFrag(&chplan.HistogramQuantile{
+			Phi:                  0.5,
+			BucketCountsColumn:   "BucketCounts",
+			ExplicitBoundsColumn: "ExplicitBounds",
+		})(b)
+		sql := b.String()
+		if !strings.Contains(sql, "arrayFirstIndex(c -> c >=") {
+			t.Errorf("literal phi must use the bare `c >= target` predicate (line 217 flipped?):\n%s", sql)
+		}
+		if strings.Contains(sql, "arrayFirstIndex(c -> (if(") {
+			t.Errorf("literal phi must NOT wrap the predicate in if(...)=1 (line 217 flipped?):\n%s", sql)
+		}
+		if strings.Contains(sql, "isNaN(") {
+			t.Errorf("literal phi must NOT carry the isNaN guard (line 318 flipped?):\n%s", sql)
+		}
+	})
+
+	t.Run("computed phi: wrapped predicate and isNaN guard", func(t *testing.T) {
+		t.Parallel()
+		b := NewBuilder()
+		histogramQuantileValueFrag(&chplan.HistogramQuantile{
+			PhiExpr:              &chplan.ColumnRef{Name: "PhiCol"},
+			BucketCountsColumn:   "BucketCounts",
+			ExplicitBoundsColumn: "ExplicitBounds",
+		})(b)
+		sql := b.String()
+		if !strings.Contains(sql, "arrayFirstIndex(c -> (if(c >=") {
+			t.Errorf("computed phi must wrap the predicate as (if(c >= ..., 1, 0) = 1) (line 217 flipped?):\n%s", sql)
+		}
+		if !strings.Contains(sql, "= 1),") {
+			t.Errorf("computed phi predicate must close with `= 1)` (line 217 flipped?):\n%s", sql)
+		}
+		if !strings.HasPrefix(sql, "if(isNaN(") {
+			t.Errorf("computed phi must lead with the isNaN(phi) guard (line 318 flipped?):\n%s", sql)
+		}
+	})
+}

--- a/internal/chsql/range_window_mutation_test.go
+++ b/internal/chsql/range_window_mutation_test.go
@@ -412,3 +412,67 @@ func TestOverTimeDirectMatrixNoGroupBy(t *testing.T) {
 		t.Errorf("expected matrix anchor fan-out, got:\n%s", sql)
 	}
 }
+
+// TestFusedSamplesQueryTemporalityGate kills the CONDITIONALS_NEGATION
+// mutant at range_window_fused.go:234 (`g.temporality != nil`, inside
+// samplesQuery). When the inner window carries a TemporalityColumn, the
+// fused samples layer must read the series' single AggregationTemporality
+// via `any(...)` under windowTemporalityAlias; when it doesn't, that
+// projection must be absent entirely. The `!=` → `==` flip would invert
+// both cases: absent when needed (the DELTA/CUMULATIVE split in
+// fusedExtrapolatedValueFrag then reads an unprojected column) and present
+// when not (an any() over a column no plan ever set).
+func TestFusedSamplesQueryTemporalityGate(t *testing.T) {
+	t.Parallel()
+	const wantProjection = "any(`AggregationTemporality`) AS `temporality`"
+
+	t.Run("TemporalityColumn set → any() projected", func(t *testing.T) {
+		t.Parallel()
+		r := fusedOuter()
+		r.Input.(*chplan.RangeWindow).TemporalityColumn = "AggregationTemporality"
+		sql, _, err := Emit(context.Background(), r)
+		if err != nil {
+			t.Fatalf("Emit: %v", err)
+		}
+		if !strings.Contains(sql, wantProjection) {
+			t.Errorf("expected %q in the fused samples layer (line 234 flipped?)\nSQL: %s", wantProjection, sql)
+		}
+	})
+
+	t.Run("TemporalityColumn unset → no any() projected", func(t *testing.T) {
+		t.Parallel()
+		sql, _, err := Emit(context.Background(), fusedOuter())
+		if err != nil {
+			t.Fatalf("Emit: %v", err)
+		}
+		if strings.Contains(sql, wantProjection) {
+			t.Errorf("unexpected %q with no TemporalityColumn set (line 234 flipped?)\nSQL: %s", wantProjection, sql)
+		}
+	})
+}
+
+// TestFusedMatrixOuterAnchorCount kills the ARITHMETIC_BASE mutants at
+// range_window_fused.go:408 (`r.OuterRange.Nanoseconds()/outerStepNS + 1`,
+// emitFusedMatrixSubquery's OUTER anchor grid — distinct from the INNER
+// grid TestFusedInstantAnchorCount already pins at line 158). Choosing an
+// outer OuterRange/Step pair (6m / 2m) that differs from fusibleInner's
+// (10m / 1m) makes the outer count's literal unambiguous: a `/`→`*` flip
+// or a `+`→`-` flip on the outer arithmetic cannot hide behind the inner
+// grid's own (unrelated) range(11) literal.
+func TestFusedMatrixOuterAnchorCount(t *testing.T) {
+	t.Parallel()
+	r := fusedOuter()
+	r.Step = 2 * time.Minute
+	r.OuterRange = 6 * time.Minute
+	sql, _, err := Emit(context.Background(), r)
+	if err != nil {
+		t.Fatalf("Emit(fused matrix subquery): %v", err)
+	}
+	// OuterRange 6m / Step 2m + 1 = 4 outer anchors.
+	if !strings.Contains(sql, "range(4)") {
+		t.Errorf("outer anchor grid must be range(4) (OuterRange/Step + 1) — line 408 arithmetic flipped\nSQL: %s", sql)
+	}
+	if strings.Contains(sql, "range(2)") {
+		t.Errorf("found range(2) — `+ 1` mutated to `- 1` (line 408)\nSQL: %s", sql)
+	}
+}

--- a/internal/chsql/range_window_variants_test.go
+++ b/internal/chsql/range_window_variants_test.go
@@ -171,6 +171,22 @@ func TestEmitFusedVariantsRejectsIllFormed(t *testing.T) {
 		"stepless anchor grid": func(r *chplan.RangeWindow) {
 			r.Step = 0
 		},
+		// checkFusedVariants.go:92 — the fused emitter drives only the
+		// *_over_time array reducers, which take no scalar parameters.
+		// A scalar argument here is untested territory: the guard's
+		// condition is EVALUATED on every fused Emit (both operands are
+		// always 0 in every other case above), so an `||`→`&&` flip
+		// would still show false everywhere else and only this case
+		// exercises the true branch.
+		"scalar argument present": func(r *chplan.RangeWindow) {
+			r.Scalars = []float64{1}
+		},
+		// checkFusedVariants.go:95 — the fused emitter consults no
+		// temporality column (each arm's own reducer never reads
+		// windowTemporalityRef). Same coverage gap as the scalar case.
+		"temporality column present": func(r *chplan.RangeWindow) {
+			r.TemporalityColumn = "AggregationTemporality"
+		},
 	}
 	for name, mutate := range cases {
 		r := fusedTestWindow()
@@ -203,6 +219,130 @@ func TestFusedVariantValueLayout(t *testing.T) {
 	}
 	if _, _, err := Emit(context.Background(), r); err != nil {
 		t.Fatalf("Emit shared-value fused window: %v", err)
+	}
+}
+
+// TestEmitFusedVariants_InstantVsMatrixDispatch kills the
+// CONDITIONALS_NEGATION / CONDITIONALS_BOUNDARY mutants at
+// range_window_variants.go:114 (`r.OuterRange > 0`) in
+// emitRangeWindowVariants. The instant shape (OuterRange == 0) has no
+// anchor grid at all — no `anchor_ts` column anywhere in the emitted
+// SQL — while the matrix shape fans out across one. A `>` → `<=` flip
+// would route the instant case into the matrix emitter (or vice
+// versa); every other test in this file exercises only the matrix
+// side (fusedTestWindow's default OuterRange > 0), so this is the only
+// coverage of the instant branch existing before this change.
+func TestEmitFusedVariants_InstantVsMatrixDispatch(t *testing.T) {
+	t.Parallel()
+
+	t.Run("OuterRange == 0 → instant, no anchor grid", func(t *testing.T) {
+		t.Parallel()
+		r := fusedTestWindow()
+		r.OuterRange = 0
+		sql, _, err := Emit(context.Background(), r)
+		if err != nil {
+			t.Fatalf("Emit: %v", err)
+		}
+		if strings.Contains(sql, "anchor_ts") {
+			t.Errorf("instant fused window (OuterRange=0) must not fan out across anchors\nSQL: %s", sql)
+		}
+	})
+
+	t.Run("OuterRange > 0 → matrix, anchor grid present", func(t *testing.T) {
+		t.Parallel()
+		sql, _, err := Emit(context.Background(), fusedTestWindow())
+		if err != nil {
+			t.Fatalf("Emit: %v", err)
+		}
+		if !strings.Contains(sql, "anchor_ts") {
+			t.Errorf("matrix fused window (OuterRange>0) must fan out across anchors\nSQL: %s", sql)
+		}
+	})
+}
+
+// TestEmitFusedVariantsMatrix_TimestampColumnAnchorTsAlias kills the
+// CONDITIONALS_NEGATION mutant at range_window_variants.go:351
+// (`r.TimestampColumn != "anchor_ts"`). The matrix outer layer always
+// selects the raw `anchor_ts` column; it additionally re-projects it
+// under the schema timestamp column's own alias UNLESS that alias
+// would just be "anchor_ts" again, in which case the duplicate
+// projection must be skipped. A `!=` → `==` flip inverts which case
+// gets the extra projection.
+func TestEmitFusedVariantsMatrix_TimestampColumnAnchorTsAlias(t *testing.T) {
+	t.Parallel()
+
+	t.Run(`TimestampColumn != "anchor_ts" → extra alias projected`, func(t *testing.T) {
+		t.Parallel()
+		sql, _, err := Emit(context.Background(), fusedTestWindow()) // TimestampColumn: "Timestamp"
+		if err != nil {
+			t.Fatalf("Emit: %v", err)
+		}
+		if !strings.Contains(sql, "anchor_ts AS `Timestamp`") {
+			t.Errorf("expected the schema-timestamp re-projection `anchor_ts AS `Timestamp`` (line 351 flipped?)\nSQL: %s", sql)
+		}
+	})
+
+	t.Run(`TimestampColumn == "anchor_ts" → no duplicate projection`, func(t *testing.T) {
+		t.Parallel()
+		r := fusedTestWindow()
+		r.TimestampColumn = "anchor_ts"
+		sql, _, err := Emit(context.Background(), r)
+		if err != nil {
+			t.Fatalf("Emit: %v", err)
+		}
+		if strings.Contains(sql, "anchor_ts AS") {
+			t.Errorf("expected no duplicate anchor_ts re-projection when TimestampColumn==\"anchor_ts\" (line 351 flipped?)\nSQL: %s", sql)
+		}
+	})
+}
+
+// TestVariantValsFrag_TupleSlotArithmetic kills the ARITHMETIC_BASE mutant
+// at range_window_variants.go:151 (`valueSlot + firstValueSlot`). Tuple
+// slot 1 is always the timestamp, so value slot 0 must read tuple index 2
+// and value slot 1 must read tuple index 3; a `+`→`-` flip would read
+// negative/zero indices and a `+`→`*` flip would collide slot 0 onto index
+// 0 instead of 2.
+func TestVariantValsFrag_TupleSlotArithmetic(t *testing.T) {
+	t.Parallel()
+	render := func(f Frag) string {
+		b := &Builder{}
+		f(b)
+		return b.String()
+	}
+	cases := []struct {
+		valueSlot int
+		wantIndex string
+	}{
+		{0, "tupleElement(p, 2)"},
+		{1, "tupleElement(p, 3)"},
+		{2, "tupleElement(p, 4)"},
+	}
+	for _, c := range cases {
+		got := render(variantValsFrag(BareIdent("window_pairs"), c.valueSlot))
+		if !strings.Contains(got, c.wantIndex) {
+			t.Errorf("variantValsFrag(valueSlot=%d) missing %q (line 151 arithmetic flipped?)\ngot: %s",
+				c.valueSlot, c.wantIndex, got)
+		}
+	}
+}
+
+// TestEmitFusedVariantsMatrix_AnchorCountArithmetic kills the
+// ARITHMETIC_BASE mutants at range_window_variants.go:293
+// (`r.OuterRange.Nanoseconds()/stepNS + 1`). fusedTestWindow's OuterRange
+// (1m) / Step (30s) + 1 = 3 anchors, surfacing as the sample-fanout's
+// `least(3, ...)` upper clamp. A `/`→`*` flip overflows to a huge count;
+// a `+`→`-` flip yields `least(1, ...)`.
+func TestEmitFusedVariantsMatrix_AnchorCountArithmetic(t *testing.T) {
+	t.Parallel()
+	sql, _, err := Emit(context.Background(), fusedTestWindow())
+	if err != nil {
+		t.Fatalf("Emit: %v", err)
+	}
+	if !strings.Contains(sql, "least(3, ") {
+		t.Errorf("expected least(3, ...) anchor-count clamp (OuterRange/Step + 1 = 3) — line 293 arithmetic flipped?\nSQL: %s", sql)
+	}
+	if strings.Contains(sql, "least(1, ") {
+		t.Errorf("found least(1, ...) — `+ 1` mutated to `- 1` (line 293)\nSQL: %s", sql)
 	}
 }
 


### PR DESCRIPTION
## What

Closes #2338 — the `gremlins phase2-other (./internal/chsql @ 95%)` mutation
lane fell to 94.90% (18 LIVED mutants) on PR #2334's run. This PR adds
targeted, behaviour-pinning test assertions in the four files the issue
named, so each previously-LIVED branch/arithmetic op now has a test whose
assertion would observably fail if that mutation applied.

## Where

- `internal/chsql/histogram_quantile_test.go` — `TestHistogramQuantileValueFrag_PhiExprGating`
  pins the two `h.PhiExpr` conditionals in `histogramQuantileValueFrag`: the
  literal-Phi path must render the bare `arrayFirstIndex` comparison and must
  NOT carry the `isNaN(phi) → nan` guard; the computed-PhiExpr path must
  render the CH-24.8 `if(...)=1` wrapped predicate AND lead with the isNaN
  guard. Kills both CONDITIONALS_NEGATION mutants in one pinned pair.

- `internal/chsql/gremlins_kill_test.go`:
  - `TestPredictLinear_SlopeColumnDispatch` — pins the
    `PredictLinearSlopeColumn == ""` dispatch between the plain and
    "with-extra-column" predict_linear writers, asserting the extra
    `predict_slope` projection's presence/absence and its exact tuple slot.
  - `TestAnchorGridCeilIdxFrag_ShiftsAddNSDownByOne` — pins
    `anchorGridCeilIdxFrag`'s documented `addNS-1` relationship directly
    against `anchorGridFloorIdxFrag`'s own rendering (rather than a
    hand-written literal), with a negative control for the `addNS+1` flip.
    This function had zero unit coverage outside a chDB-tagged (and
    therefore mutation-lane-invisible) integration test.

- `internal/chsql/range_window_mutation_test.go`:
  - `TestFusedSamplesQueryTemporalityGate` — pins the fused samples layer's
    `g.temporality != nil` gate: the `any(<TemporalityColumn>)` projection
    must appear only when the inner window actually carries a
    TemporalityColumn.
  - `TestFusedMatrixOuterAnchorCount` — pins the OUTER anchor-count
    arithmetic in `emitFusedMatrixSubquery` (`r.OuterRange.Nanoseconds() /
    outerStepNS + 1`) with an outer step/range pair distinct from the
    existing inner-grid test's values, so the two arithmetic sites can't
    hide behind each other's literal.

  Both `range_window_fused.go` gaps trace to the same root cause: the file
  had no non-chDB unit tests at all before this change (only a
  `chdb`-build-tagged integration test), and the mutation lane never
  compiles chDB-tagged tests, so this shape was structurally invisible to
  gremlins regardless of how much chDB coverage existed.

- `internal/chsql/range_window_variants_test.go`:
  - Added "scalar argument present" / "temporality column present" cases to
    the existing `TestEmitFusedVariantsRejectsIllFormed` table — the fused
    emitter's `checkFusedVariants` guards against both, but no case
    previously drove either condition's true branch.
  - `TestEmitFusedVariants_InstantVsMatrixDispatch` — pins the
    `OuterRange > 0` instant-vs-matrix dispatch; every other test in the
    file exercised only the matrix side.
  - `TestVariantValsFrag_TupleSlotArithmetic` — pins the `valueSlot +
    firstValueSlot` tuple-index arithmetic across three value slots.
  - `TestEmitFusedVariantsMatrix_AnchorCountArithmetic` — pins the matrix
    path's own `OuterRange/Step + 1` anchor-count arithmetic via its
    `least(3, ...)` clamp.
  - `TestEmitFusedVariantsMatrix_TimestampColumnAnchorTsAlias` — pins the
    `TimestampColumn != "anchor_ts"` guard that skips the duplicate
    schema-timestamp re-projection when the schema alias already IS
    `anchor_ts`.

## Verification

- `go build ./...` clean.
- `go test -race -count=1 ./internal/chsql/...` passes.
- `gofumpt -extra -l` clean on the touched files.
- `node .github/scripts/forbid-sql-raw.mjs` clean (test-only change, no new
  chsql emission code).
- A gremlins run narrowed to just the four touched files (`--exclude-files`
  carving `./internal/chsql` down to `histogram_quantile.go`,
  `range_window.go`, `range_window_fused.go`, `range_window_variants.go`,
  `--timeout-max 15s`, `--on-shutdown-status=not-run`) reported **0 LIVED**
  mutants across every mutant it was able to execute (11 killed, including
  the exact mutant this PR targets at `range_window_variants.go:351`). Heavy
  concurrent load on the local runner (other agents' work; load average
  peaked over 30 on an 8-core box) pushed the large majority of the 302
  scheduled mutants into TIMED OUT rather than a real KILLED/LIVED verdict
  — timeouts don't count against the `KILLED / (KILLED + LIVED)` efficacy
  formula, so the local number isn't a substitute for CI's clean-runner
  result, but it is corroborating evidence: nothing this PR touches
  survived a real evaluation locally. The authoritative number will be
  CI's `gremlins phase2-other` job on this PR — I'll update this
  description once it reports.

No production code changed — this is test-only, scoped to `internal/chsql`,
consistent with the issue's ask.

## False-flags considered

None. Every one of the 18 LIVED sites named in #2338 (or its current-main
equivalent — the file has grown since the issue was filed by several
sibling histogram-binop PRs, shifting line numbers) traced to a real,
previously-unobserved branch or arithmetic operation, not dead/defensive
code.
