### PR TITLE
fix(promql): stop flattening asymmetric-shape and/unless set-op chains

### DIFF
--- a/internal/optimizer/flatten_vector_set_op.go
+++ b/internal/optimizer/flatten_vector_set_op.go
@@ -78,6 +78,26 @@ func (FlattenVectorSetOp) Apply(n chplan.Node) (chplan.Node, bool) {
 	arms := flattenLeftArms(binary)
 	arms = append(arms, binary.Right)
 
+	// cerberus issue #2325: a mixed `and`/`unless` between a histogram-
+	// valued and a float-valued operand sets VectorSetOp.Histogram from
+	// the FORWARDED (left) arm's shape alone, not from both arms
+	// agreeing (see lowerVectorSetOp's doc comment) — unlike the
+	// homogeneous chains this rule was designed for, where Histogram
+	// means every arm publishes a HistogramProjection. NaryVectorSetOp
+	// carries a single Histogram bool for its whole UNION-ALL
+	// projection (naryVectorSetOpOutputCols), widening every arm's SELECT
+	// uniformly from that one flag — flattening a chain with a
+	// non-uniform arm would ask a float-shaped arm to project columns
+	// its own SELECT never produces, which ClickHouse rejects with code
+	// 47 "Unknown expression identifier". Bail and leave the (already
+	// correct) nested binary VectorSetOp shape in place whenever any arm
+	// disagrees with the flag chosen for the whole chain.
+	for _, arm := range arms {
+		if (chplan.RowShapeOf(arm) == chplan.HistogramRowShape) != binary.Histogram {
+			return n, false
+		}
+	}
+
 	return &chplan.NaryVectorSetOp{
 		Arms:             arms,
 		Op:               binary.Op,

--- a/test/spec/parity_chdb.go
+++ b/test/spec/parity_chdb.go
@@ -941,7 +941,8 @@ func compareSampleValue(
 // Sample field to be in range.
 func (sc sampleColumns) arity() int {
 	n := 0
-	for _, idx := range append([]int{sc.name, sc.attrs, sc.ts, sc.value}, sc.hist.indices()...) {
+	idxs := append([]int{sc.name, sc.attrs, sc.ts, sc.value, sc.mixedIsHistogram}, sc.hist.indices()...)
+	for _, idx := range idxs {
 		if idx+1 > n {
 			n = idx + 1
 		}
@@ -1412,6 +1413,12 @@ type sampleColumns struct {
 	// hist locates the native-histogram fields, or is nil when the
 	// projection answers with plain floats. See [locateHistogramColumns].
 	hist *histogramColumns
+
+	// mixedIsHistogram locates [colSetOpMixedIsHistogram], or is -1 when
+	// the projection carries no such discriminator — every fixture except
+	// a Mixed VectorSetOr (cerberus issue #2330), whose hist columns are
+	// real on some rows and placeholders on others.
+	mixedIsHistogram int
 }
 
 // locateSampleColumns maps a projection's column names onto the Sample
@@ -1427,7 +1434,7 @@ type sampleColumns struct {
 // to TimeUnix. If both are present, TimeUnix remains authoritative and
 // anchor_ts is only subquery scaffolding.
 func locateSampleColumns(cols []string) (sampleColumns, error) {
-	sc := sampleColumns{name: -1, attrs: -1, ts: -1, value: -1}
+	sc := sampleColumns{name: -1, attrs: -1, ts: -1, value: -1, mixedIsHistogram: -1}
 	anchorTS := -1
 	for i, col := range cols {
 		switch col {
@@ -1441,6 +1448,8 @@ func locateSampleColumns(cols []string) (sampleColumns, error) {
 			sc.ts = i
 		case colValue:
 			sc.value = i
+		case colSetOpMixedIsHistogram:
+			sc.mixedIsHistogram = i
 		}
 	}
 	if sc.ts < 0 {
@@ -1502,8 +1511,26 @@ func referenceShapeOfExpectedRows(rt *RoundTripSections, sc sampleColumns) ([]re
 
 		var hist *oracle.Histogram
 		if sc.hist != nil {
-			if hist, err = histogramFromExpectedRow(row, sc.hist, i); err != nil {
-				return nil, err
+			// A Mixed VectorSetOr's projection (cerberus issue #2330)
+			// carries all nine Histogram* columns on EVERY row — real on
+			// the histogram-shaped arm's rows, typed placeholders on the
+			// float arm's — so their mere presence doesn't mean this row
+			// is histogram-valued. Only build hist when there's no such
+			// discriminator (every other histogram-shaped projection,
+			// which is homogeneously histogram-valued) or the
+			// discriminator says this row is real.
+			rowIsHistogram := true
+			if sc.mixedIsHistogram >= 0 {
+				disc, derr := rowInt32(row[sc.mixedIsHistogram], i, colSetOpMixedIsHistogram)
+				if derr != nil {
+					return nil, derr
+				}
+				rowIsHistogram = disc != 0
+			}
+			if rowIsHistogram {
+				if hist, err = histogramFromExpectedRow(row, sc.hist, i); err != nil {
+					return nil, err
+				}
 			}
 		}
 

--- a/test/spec/parity_native_histogram_chdb.go
+++ b/test/spec/parity_native_histogram_chdb.go
@@ -383,6 +383,20 @@ const (
 	colHistogramNegativeBuckets = "HistogramNegativeBucketCounts"
 )
 
+// colSetOpMixedIsHistogram is the per-row discriminator a Mixed
+// VectorSetOr's fourteen-column projection carries (cerberus issue
+// #2330): 1 when the row's Histogram* columns are the real answer, 0
+// when they are the float arm's typed placeholders and Value is the real
+// answer instead. Mirrors internal/chsql/vector_set_op.go's
+// setOpMixedIsHistogramCol literal, duplicated here for the same reason
+// the Histogram*Column names above are — this package cannot import
+// internal/chsql's unexported constant, and locating by name is the
+// established convention. Every row of a Mixed projection carries all
+// nine Histogram* columns (real or placeholder), so [locateHistogramColumns]
+// alone cannot tell a real histogram row from a placeholder one; only this
+// discriminator can.
+const colSetOpMixedIsHistogram = "_setop_is_histogram"
+
 // locateHistogramColumns maps a projection's column names onto the fields
 // of a native-histogram sample, or reports nil when the projection carries
 // no histogram at all — the ordinary case, since most of the corpus

--- a/test/spec/promql/exp_histogram_set_op_or_mixed_float_left.txtar
+++ b/test/spec/promql/exp_histogram_set_op_or_mixed_float_left.txtar
@@ -29,7 +29,7 @@ CREATE TABLE otel_metrics_exponential_histogram (
 -- native-histogram sample at once, exactly the mixed-type union upstream
 -- allows and cerberus previously rejected outright.
 INSERT INTO otel_metrics_exponential_histogram VALUES
-    ('http_server_duration_exp_hist', map('service', 'api'), toDateTime64('2026-01-01 00:00:00', 9), 4, 10.0, 0, 0, 0, [1, 2, 3, 4], 0, []),
+    ('http_server_duration_exp_hist', map('service', 'api'), toDateTime64('2026-01-01 00:00:00', 9), 10, 10.0, 0, 0, 0, [1, 2, 3, 4], 0, []),
     ('http_client_duration_exp_hist', map('service', 'web'), toDateTime64('2026-01-01 00:00:00', 9), 3, 3.0,  0, 0, 0, [9],           0, []);
 -- expected_rows --
 [

--- a/test/spec/promql/exp_histogram_set_op_or_mixed_histogram_left.txtar
+++ b/test/spec/promql/exp_histogram_set_op_or_mixed_histogram_left.txtar
@@ -28,7 +28,7 @@ CREATE TABLE otel_metrics_exponential_histogram (
 -- (VectorSetOp.MixedHistogramOnLeft) produces the identical union, not
 -- just the float-on-left ordering.
 INSERT INTO otel_metrics_exponential_histogram VALUES
-    ('http_server_duration_exp_hist', map('service', 'api'), toDateTime64('2026-01-01 00:00:00', 9), 4, 10.0, 0, 0, 0, [1, 2, 3, 4], 0, []),
+    ('http_server_duration_exp_hist', map('service', 'api'), toDateTime64('2026-01-01 00:00:00', 9), 10, 10.0, 0, 0, 0, [1, 2, 3, 4], 0, []),
     ('http_client_duration_exp_hist', map('service', 'web'), toDateTime64('2026-01-01 00:00:00', 9), 3, 3.0,  0, 0, 0, [9],           0, []);
 -- expected_rows --
 [


### PR DESCRIPTION
## Summary

Fixes a real, deterministic regression currently breaking `main`'s `roundtrip (promql)` CI leg (`Code: 47. DB::Exception: Unknown expression identifier 'HistogramCount'`), plus a related test-harness gap it was masking.

- `FlattenVectorSetOp` linearised an `and`/`unless` set op between a histogram-valued and a float-valued operand (#2325) into a `NaryVectorSetOp` using `VectorSetOp.Histogram` alone. That flag only describes the FORWARDED (left) arm's shape for a mixed chain, not every arm's — but `NaryVectorSetOp`'s single UNION-ALL projection widens every arm uniformly from that one flag, so a flattened mixed chain asked the float-shaped arm to project `Histogram*` columns its own SELECT never produces. Fixed by bailing out of flattening whenever any gathered arm's actual `RowShapeOf` disagrees with the chain's chosen `Histogram` flag — the nested binary `VectorSetOp` shape (already correct for this case) is left in place instead.
- The parity harness's `expected_rows` reader didn't know about the Mixed `VectorSetOr`'s per-row `_setop_is_histogram` discriminator (#2330): it treated every row of a Mixed projection as histogram-valued whenever the `Histogram*` columns were merely present, even the float arm's rows carrying typed placeholders. This masked the flatten bug's own parity check behind a "different kind of answer" error, and separately caused two existing Mixed-`or` fixtures' float-side parity checks to compare against an all-zero histogram placeholder instead of the real float answer. Fixed the reader to honor the discriminator.
- Fixing the harness surfaced a genuine pre-existing data bug in those same two fixtures: their seeded exponential-histogram row's `Count` field disagreed with its own bucket-count array (`Count=4` vs. buckets summing to `10`), so `histogram_quantile()` computed off an internally inconsistent histogram and diverged from the reference engine. Fixed the seed data to keep `Count` consistent with its buckets, matching every other exp-histogram fixture's convention.

## Test plan

- [x] `go test -tags chdb -run '^TestLower$/^exp_histogram_set_op' -v ./internal/promql/` — all 9 `exp_histogram_set_op_*` fixtures pass, including the two that reproduced the CI failure 100% deterministically before this fix.
- [x] `go test ./internal/optimizer/...` — flatten rule's own unit tests pass unchanged.
- [ ] Golden regen (`shards=all`, forced by the `internal/optimizer` diff) via CI, then full CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
