### PR TITLE
chore(compat): sync prometheus baseline roster with new arithmetic cases

### DIFF
--- a/compatibility/parity-baseline/prometheus/10.json
+++ b/compatibility/parity-baseline/prometheus/10.json
@@ -7,6 +7,7 @@
     "0.12345 * demo_memory_usage_bytes",
     "1 + time()",
     "absent(sum(nonexistent_metric_name))",
+    "demo_latency_exp_hist + demo_latency_exp_hist",
     "demo_memory_usage_bytes atan2 demo_memory_usage_bytes",
     "demo_memory_usage_bytes{job=~\"dem\"}",
     "demo_num_cpus <= bool on(instance) demo_num_cpus",

--- a/compatibility/parity-baseline/prometheus/2b.json
+++ b/compatibility/parity-baseline/prometheus/2b.json
@@ -8,6 +8,7 @@
     "avg by (instance) (rate(demo_shifting_latency_exp_hist[5m]))",
     "changes(demo_batch_last_success_timestamp_seconds[15s])",
     "clamp_min(demo_memory_usage_bytes, 2)",
+    "demo_latency_exp_hist - demo_latency_exp_hist",
     "demo_memory_usage_bytes - on(instance, job, type) demo_memory_usage_bytes",
     "demo_memory_usage_bytes or demo_sparse_memory_bytes",
     "histogram_avg(demo_latency_exp_hist)",


### PR DESCRIPTION
## Summary

- The `compatibility/prometheus` job in CI run
  [32072404725](https://github.com/tsouza/cerberus/actions/runs/32072404725) failed because two
  cases new to the corpus (`demo_latency_exp_hist + demo_latency_exp_hist` and
  `demo_latency_exp_hist - demo_latency_exp_hist`) weren't yet recorded in the committed baseline
  roster (`compatibility/parity-baseline/prometheus/{10,2b}.json`). Both cases passed in that run —
  this is a roster gap, not a real divergence.
- Regenerated the roster with the purpose-built
  `.github/scripts/compat-baseline-sync.mjs`, which refuses to write if any case in the source run
  failed (it did not — 968/968 passing). The resulting diff adds exactly the two missing case IDs,
  nothing else.

## Test plan

- [x] `node .github/scripts/compat-baseline-sync.mjs <compat-cases.json>` exited 0 and reported
      "968 passing case(s) ... 2 bucket(s) rewritten, 0 stale file(s) pruned".
- [x] `git diff` on the two touched files shows only the two new case IDs inserted in sorted order,
      no other changes.
