### PR TITLE
fix(promql): regenerate stale expected_rows for two mixed-or fixtures

### DIFF
--- a/test/spec/promql/exp_histogram_set_op_or_mixed_float_left.txtar
+++ b/test/spec/promql/exp_histogram_set_op_or_mixed_float_left.txtar
@@ -33,7 +33,7 @@ INSERT INTO otel_metrics_exponential_histogram VALUES
     ('http_client_duration_exp_hist', map('service', 'web'), toDateTime64('2026-01-01 00:00:00', 9), 3, 3.0,  0, 0, 0, [9],           0, []);
 -- expected_rows --
 [
-  ["", {"service": "api"}, "2026-01-01T00:00:01Z", 4, 0, 0, 0, 0, 0, 0, [], 0, [], 0],
+  ["", {"service": "api"}, "2026-01-01T00:00:01Z", 6.3496042078727974, 0, 0, 0, 0, 0, 0, [], 0, [], 0],
   ["http_client_duration_exp_hist", {"service": "web"}, "2026-01-01T00:00:01Z", 0, 3, 3, 0, 0, 0, 0, [9], 0, [], 1]
 ]
 -- args --

--- a/test/spec/promql/exp_histogram_set_op_or_mixed_histogram_left.txtar
+++ b/test/spec/promql/exp_histogram_set_op_or_mixed_histogram_left.txtar
@@ -32,7 +32,7 @@ INSERT INTO otel_metrics_exponential_histogram VALUES
     ('http_client_duration_exp_hist', map('service', 'web'), toDateTime64('2026-01-01 00:00:00', 9), 3, 3.0,  0, 0, 0, [9],           0, []);
 -- expected_rows --
 [
-  ["", {"service": "api"}, "2026-01-01T00:00:01Z", 4, 0, 0, 0, 0, 0, 0, [], 0, [], 0],
+  ["", {"service": "api"}, "2026-01-01T00:00:01Z", 6.3496042078727974, 0, 0, 0, 0, 0, 0, [], 0, [], 0],
   ["http_client_duration_exp_hist", {"service": "web"}, "2026-01-01T00:00:01Z", 0, 3, 3, 0, 0, 0, 0, [9], 0, [], 1]
 ]
 -- args --


### PR DESCRIPTION
## Summary

Hotfix for a currently-red `main`: `roundtrip (promql)` is failing on the merge commit of #2347 (see e.g. https://github.com/tsouza/cerberus/actions/runs/32079793085/job/95540419656).

#2347 fixed `exp_histogram_set_op_or_mixed_float_left.txtar` / `exp_histogram_set_op_or_mixed_histogram_left.txtar`'s seed data (their `Count` field now matches their own bucket-count array), but the PR's `update-golden` CI dispatch never finished publishing before the PR itself got merged — its `publish golden updates` job failed with `target branch ... does not resolve to exactly one remote head` because the branch was deleted by the merge while the workflow was mid-run. So the corrected seed landed on `main` carrying its OLD `expected_rows` (computed against the old, self-inconsistent seed), and `TestLower`'s round-trip check now correctly flags the mismatch.

Regenerated locally via `just update-golden promql`. Diff is exactly the two `expected_rows` cells for the two fixtures #2347 touched — nothing else.

## Test plan

- [x] `go test -tags chdb -run '^TestLower$/^exp_histogram_set_op' -v ./internal/promql/` — all 9 fixtures pass.
- [x] `go build ./...`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
