### PR TITLE
fix(test): pin mixedIsHistogram in TestLocateSampleColumns expectations

### DIFF
--- a/test/spec/parity_columns_chdb_test.go
+++ b/test/spec/parity_columns_chdb_test.go
@@ -30,14 +30,14 @@ func TestLocateSampleColumns(t *testing.T) {
 		{
 			name: "canonical Sample projection",
 			cols: []string{"MetricName", "Attributes", "TimeUnix", "Value"},
-			want: sampleColumns{name: 0, attrs: 1, ts: 2, value: 3},
+			want: sampleColumns{name: 0, attrs: 1, ts: 2, value: 3, mixedIsHistogram: -1},
 		},
 		{
 			// An instant aggregation drops __name__ and has no sample
 			// time to report, so it projects only what its answer has.
 			name: "instant aggregation projection",
 			cols: []string{"Attributes", "Value"},
-			want: sampleColumns{name: -1, attrs: 0, ts: -1, value: 1},
+			want: sampleColumns{name: -1, attrs: 0, ts: -1, value: 1, mixedIsHistogram: -1},
 		},
 		{
 			// anchor_ts is scaffolding of the emitted subquery, not a
@@ -45,19 +45,19 @@ func TestLocateSampleColumns(t *testing.T) {
 			// sample time sitting behind it.
 			name: "subquery projection interposing anchor_ts",
 			cols: []string{"Attributes", "anchor_ts", "TimeUnix", "Value"},
-			want: sampleColumns{name: -1, attrs: 0, ts: 2, value: 3},
+			want: sampleColumns{name: -1, attrs: 0, ts: 2, value: 3, mixedIsHistogram: -1},
 		},
 		{
 			// A raw range projection is wrapped into the public Sample
 			// shape by renaming anchor_ts to TimeUnix in the HTTP layer.
 			name: "range projection whose sample time is anchor_ts",
 			cols: []string{"Attributes", "anchor_ts", "Value"},
-			want: sampleColumns{name: -1, attrs: 0, ts: 1, value: 2},
+			want: sampleColumns{name: -1, attrs: 0, ts: 1, value: 2, mixedIsHistogram: -1},
 		},
 		{
 			name: "named subquery projection interposing anchor_ts",
 			cols: []string{"MetricName", "Attributes", "anchor_ts", "TimeUnix", "Value"},
-			want: sampleColumns{name: 0, attrs: 1, ts: 3, value: 4},
+			want: sampleColumns{name: 0, attrs: 1, ts: 3, value: 4, mixedIsHistogram: -1},
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {


### PR DESCRIPTION
## Summary

Hotfix for a currently-red `main`: the `coverage` lane (e.g. https://github.com/tsouza/cerberus/actions/runs/32081535416/job/95545421863) fails on `TestLocateSampleColumns` in `test/spec/parity_columns_chdb_test.go`.

This is my own regression from #2347: that PR added a `mixedIsHistogram` field to `test/spec`'s `sampleColumns` struct (the parity harness's Mixed-`VectorSetOr` discriminator locator) but never updated this test's five expected struct literals, which predate the field. Every case now implicitly wants Go's zero value `0` for the new field instead of the "column absent" sentinel `-1` `locateSampleColumns` actually returns for every one of these (non-Mixed) projections — none of the five carries the `_setop_is_histogram` column at all.

Pinned `mixedIsHistogram: -1` on all five cases.

This only surfaced in the `coverage` lane's unsharded `go test ./...` sweep — none of my own `TestLower`-scoped verification for #2347 exercised `test/spec`'s own package tests, which is how it slipped through. Ran the full `test/spec` package this time (`go test -tags chdb ./test/spec/`) to catch anything else in the same blast radius; nothing else was affected.

## Test plan

- [x] `go test -tags chdb -run '^TestLocateSampleColumns$' -v ./test/spec/` — all 5 subtests pass.
- [x] `go test -tags chdb ./test/spec/` — full package green.
- [x] `go build ./...`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
