### PR TITLE
test(coverage): restore the loki-compliance-tester and property/gen floors

### DIFF
--- a/compatibility/loki/cmd/loki-compliance-tester/patterns_live_test.go
+++ b/compatibility/loki/cmd/loki-compliance-tester/patterns_live_test.go
@@ -129,6 +129,343 @@ func TestObserveLivePatterns_RejectsNonIntegerSampleEncoding(t *testing.T) {
 	}
 }
 
+func TestReadLivePatternsMetadata_MissingFile(t *testing.T) {
+	t.Parallel()
+	_, err := readLivePatternsMetadata(filepath.Join(t.TempDir(), "missing.json"), time.Now())
+	if err == nil {
+		t.Fatal("missing file: want error, got nil")
+	}
+}
+
+func TestReadLivePatternsMetadata_MalformedJSON(t *testing.T) {
+	t.Parallel()
+	path := filepath.Join(t.TempDir(), "live.json")
+	if err := os.WriteFile(path, []byte("not json"), 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	if _, err := readLivePatternsMetadata(path, time.Now()); err == nil || !strings.Contains(err.Error(), "decode:") {
+		t.Fatalf("malformed JSON error=%v, want decode diagnostic", err)
+	}
+}
+
+func TestValidateLivePatternsMetadata_RejectsEachInvalidField(t *testing.T) {
+	t.Parallel()
+	base := livePatternsTestMetadata()
+	defaultNow := base.CreatedAt.Add(time.Minute)
+
+	tests := []struct {
+		name    string
+		mutate  func(livePatternsMetadata) livePatternsMetadata
+		now     time.Time
+		wantErr string
+	}{
+		{
+			name: "version mismatch",
+			mutate: func(m livePatternsMetadata) livePatternsMetadata {
+				m.Version = livePatternsMetadataVersion + 1
+				return m
+			},
+			wantErr: "version=",
+		},
+		{
+			name: "empty selector",
+			mutate: func(m livePatternsMetadata) livePatternsMetadata {
+				m.Selector = ""
+				return m
+			},
+			wantErr: "selector is empty",
+		},
+		{
+			name: "invalid window",
+			mutate: func(m livePatternsMetadata) livePatternsMetadata {
+				m.Start = m.End
+				return m
+			},
+			wantErr: "invalid window",
+		},
+		{
+			name: "window span too wide",
+			mutate: func(m livePatternsMetadata) livePatternsMetadata {
+				m.End = m.Start.Add(livePatternsWindowMaxSpan + time.Minute)
+				m.CreatedAt = m.End
+				return m
+			},
+			wantErr: "exceeds",
+		},
+		{
+			name: "created_at precedes window end",
+			mutate: func(m livePatternsMetadata) livePatternsMetadata {
+				m.CreatedAt = m.End.Add(-time.Second)
+				return m
+			},
+			wantErr: "precedes window end",
+		},
+		{
+			name: "created_at in the future",
+			mutate: func(m livePatternsMetadata) livePatternsMetadata {
+				return m
+			},
+			now:     base.CreatedAt.Add(-time.Minute),
+			wantErr: "is in the future",
+		},
+		{
+			name: "entries_by_level empty",
+			mutate: func(m livePatternsMetadata) livePatternsMetadata {
+				m.EntriesByLevel = map[string]int{}
+				return m
+			},
+			wantErr: "entries_by_level is empty",
+		},
+		{
+			name: "level key empty",
+			mutate: func(m livePatternsMetadata) livePatternsMetadata {
+				m.EntriesByLevel = map[string]int{"": 10}
+				return m
+			},
+			wantErr: "invalid level volume",
+		},
+		{
+			name: "level key not lowercase",
+			mutate: func(m livePatternsMetadata) livePatternsMetadata {
+				m.EntriesByLevel = map[string]int{"Error": 10}
+				return m
+			},
+			wantErr: "invalid level volume",
+		},
+		{
+			name: "level count not positive",
+			mutate: func(m livePatternsMetadata) livePatternsMetadata {
+				m.EntriesByLevel = map[string]int{"error": 0}
+				return m
+			},
+			wantErr: "invalid level volume",
+		},
+	}
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			metadata := tc.mutate(base)
+			now := tc.now
+			if now.IsZero() {
+				now = defaultNow
+			}
+			err := validateLivePatternsMetadata(metadata, now)
+			if err == nil || !strings.Contains(err.Error(), tc.wantErr) {
+				t.Fatalf("err=%v, want substring %q", err, tc.wantErr)
+			}
+		})
+	}
+}
+
+func TestCompareLivePatterns_ReportsFetchFailures(t *testing.T) {
+	t.Parallel()
+	metadata := livePatternsTestMetadata()
+	ok := livePatternsServer(t, metadata, `{"status":"success","data":[{"pattern":"p","level":"info","samples":[[%d,10]]}]}`)
+	client := &http.Client{Timeout: 5 * time.Second}
+
+	t.Run("reference unreachable", func(t *testing.T) {
+		t.Parallel()
+		results := compareLivePatterns(client, flags{addr1: "http://127.0.0.1:1", addr2: ok.URL}, metadata)
+		for _, r := range results {
+			if !strings.Contains(r.UnexpectedFailure, "reference (-addr-1) failed") {
+				t.Fatalf("result=%+v, want reference failure", r)
+			}
+		}
+	})
+
+	t.Run("test endpoint unreachable", func(t *testing.T) {
+		t.Parallel()
+		results := compareLivePatterns(client, flags{addr1: ok.URL, addr2: "http://127.0.0.1:1"}, metadata)
+		for _, r := range results {
+			if !strings.Contains(r.UnexpectedFailure, "test endpoint (-addr-2) failed") {
+				t.Fatalf("result=%+v, want test endpoint failure", r)
+			}
+		}
+	})
+}
+
+func TestFetchLivePatterns_NonOKStatus(t *testing.T) {
+	t.Parallel()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte("boom"))
+	}))
+	t.Cleanup(server.Close)
+	metadata := livePatternsTestMetadata()
+	_, err := fetchLivePatterns(&http.Client{Timeout: 5 * time.Second}, server.URL, metadata)
+	if err == nil || !strings.Contains(err.Error(), "status=500") {
+		t.Fatalf("err=%v, want status=500 diagnostic", err)
+	}
+}
+
+func TestDecodePatternsWire_HandlesMalformedEnvelopes(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name string
+		body string
+		want func(patternsWire) bool
+	}{
+		{
+			name: "not JSON",
+			body: `not json`,
+			want: func(w patternsWire) bool { return strings.HasPrefix(w.Status, "decode error:") },
+		},
+		{
+			name: "missing status",
+			body: `{"data":[]}`,
+			want: func(w patternsWire) bool { return w.Status == "missing" },
+		},
+		{
+			name: "non-string status",
+			body: `{"status":42,"data":[]}`,
+			want: func(w patternsWire) bool { return strings.HasPrefix(w.Status, "invalid:") },
+		},
+		{
+			name: "data not an array",
+			body: `{"status":"success","data":{"oops":true}}`,
+			want: func(w patternsWire) bool {
+				return len(w.Data) == 1 && strings.HasPrefix(w.Data[0].Level, "__data_decode_error__")
+			},
+		},
+	}
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := decodePatternsWire([]byte(tc.body))
+			if !tc.want(got) {
+				t.Fatalf("decodePatternsWire(%q) = %+v", tc.body, got)
+			}
+		})
+	}
+}
+
+func TestObserveLivePatterns_SetsEnvelopeError(t *testing.T) {
+	t.Parallel()
+	metadata := livePatternsTestMetadata()
+
+	t.Run("status not success", func(t *testing.T) {
+		t.Parallel()
+		obs := observeLivePatterns(patternsWire{Status: "error"}, metadata)
+		if !strings.Contains(obs.envelopeErr, `status field="error"`) {
+			t.Fatalf("envelopeErr=%q", obs.envelopeErr)
+		}
+	})
+
+	t.Run("empty data", func(t *testing.T) {
+		t.Parallel()
+		obs := observeLivePatterns(patternsWire{Status: "success"}, metadata)
+		if obs.envelopeErr != "data is missing, null, or empty" {
+			t.Fatalf("envelopeErr=%q", obs.envelopeErr)
+		}
+	})
+}
+
+func TestObserveLivePatterns_RejectsMalformedSamples(t *testing.T) {
+	t.Parallel()
+	metadata := livePatternsTestMetadata()
+	inWindow := metadata.Start.Add(time.Minute).Unix()
+
+	tests := []struct {
+		name    string
+		samples string
+		want    string
+	}{
+		{
+			name:    "wrong tuple length",
+			samples: fmt.Sprintf(`[[%d,10,20]]`, inWindow),
+			want:    "want 2",
+		},
+		{
+			name:    "timestamp outside window",
+			samples: fmt.Sprintf(`[[%d,10]]`, metadata.End.Add(time.Hour).Unix()),
+			want:    "outside",
+		},
+		{
+			name:    "non-positive count",
+			samples: fmt.Sprintf(`[[%d,0]]`, inWindow),
+			want:    "want positive",
+		},
+	}
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			body := fmt.Sprintf(`{"status":"success","data":[{"level":"info","samples":%s}]}`, tc.samples)
+			wire := decodePatternsWire([]byte(body))
+			obs := observeLivePatterns(wire, metadata)
+			if !strings.Contains(obs.encodingErr, tc.want) {
+				t.Fatalf("encodingErr=%q, want substring %q", obs.encodingErr, tc.want)
+			}
+		})
+	}
+}
+
+func TestSideErrors_RendersEachCombination(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name      string
+		reference string
+		test      string
+		want      string
+	}{
+		{name: "both empty", reference: "", test: "", want: ""},
+		{name: "reference only", reference: "ref boom", test: "", want: "axis: reference=ref boom"},
+		{name: "test only", reference: "", test: "test boom", want: "axis: test endpoint=test boom"},
+		{name: "both", reference: "ref boom", test: "test boom", want: "axis: reference=ref boom; test endpoint=test boom"},
+	}
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if got := sideErrors("axis", tc.reference, tc.test); got != tc.want {
+				t.Fatalf("sideErrors=%q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestSideSliceDiff_ReportsMismatch(t *testing.T) {
+	t.Parallel()
+	if got := sideSliceDiff("levels", []string{"error", "info"}, []string{"error"}, []string{"error", "info"}); got == "" {
+		t.Fatal("mismatched reference: want non-empty diff")
+	}
+	if got := sideSliceDiff("levels", []string{"error", "info"}, []string{"error", "info"}, []string{"info"}); got == "" {
+		t.Fatal("mismatched test endpoint: want non-empty diff")
+	}
+}
+
+func TestCompareLivePatternsAxis_UnknownKindReportsDiagnostic(t *testing.T) {
+	t.Parallel()
+	metadata := livePatternsTestMetadata()
+	got := compareLivePatternsAxis("bogus_axis", patternsObservation{}, patternsObservation{}, metadata)
+	if !strings.Contains(got, "unknown live patterns axis bogus_axis") {
+		t.Fatalf("got=%q", got)
+	}
+}
+
+func TestCompareLivePatternsAxis_LevelsMismatch(t *testing.T) {
+	t.Parallel()
+	metadata := livePatternsTestMetadata()
+	reference := patternsObservation{levels: []string{"error", "info", "warn"}}
+	test := patternsObservation{levels: []string{"info", "warn"}}
+	if got := compareLivePatternsAxis("patterns_levels", reference, test, metadata); got == "" {
+		t.Fatal("mismatched levels: want non-empty diff")
+	}
+}
+
+func TestCompareLivePatternsAxis_VolumeUndercountReported(t *testing.T) {
+	t.Parallel()
+	metadata := livePatternsTestMetadata()
+	reference := patternsObservation{volume: map[string]int64{"error": 40, "info": 40, "warn": 40}}
+	test := patternsObservation{volume: map[string]int64{"error": 0, "info": 40, "warn": 40}}
+	got := compareLivePatternsAxis("patterns_volume", reference, test, metadata)
+	if !strings.Contains(got, `test endpoint level="error" volume=0`) {
+		t.Fatalf("got=%q", got)
+	}
+}
+
 func livePatternsServer(t *testing.T, metadata livePatternsMetadata, bodyFormat string) *httptest.Server {
 	t.Helper()
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/test/property/gen/shapes_test.go
+++ b/test/property/gen/shapes_test.go
@@ -7,6 +7,8 @@ import (
 	"testing"
 
 	"github.com/prometheus/prometheus/promql/parser"
+
+	"github.com/tsouza/cerberus/test/property"
 )
 
 func TestShapeRostersAreExact(t *testing.T) {
@@ -340,6 +342,33 @@ func TestByShapeGeneratorsDoNotCollapse(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestByShapeGeneratorsPanicOnUnknownShape pins the invariant every
+// *ForShape generator relies on: the shape ID it is called with always
+// comes from that generator's own roster (PromQLShapeIDs and friends), so a
+// shape ID absent from the roster is a caller bug, not runtime input to
+// tolerate. Each generator panics loudly instead of silently drawing a
+// mismatched case.
+func TestByShapeGeneratorsPanicOnUnknownShape(t *testing.T) {
+	const bogus ShapeID = "unknown.shape"
+
+	wantPanic := func(t *testing.T, label string, fn func()) {
+		t.Helper()
+		defer func() {
+			if recover() == nil {
+				t.Fatalf("%s: want panic for unknown shape, got none", label)
+			}
+		}()
+		fn()
+	}
+
+	wantPanic(t, "PromQLQueryForShape", func() { PromQLQueryForShape(property.Dataset{}, bogus) })
+	wantPanic(t, "PromQLRangeQueryForShape", func() { PromQLRangeQueryForShape(property.Dataset{}, bogus) })
+	wantPanic(t, "ExpHistogramQueryForShape", func() { ExpHistogramQueryForShape(property.Dataset{}, bogus) })
+	wantPanic(t, "LogQLQueryForShape", func() { LogQLQueryForShape(property.Dataset{}, bogus) })
+	wantPanic(t, "TraceQLQueryForShape", func() { TraceQLQueryForShape(property.Dataset{}, bogus) })
+	wantPanic(t, "InstantWindowSweepForShape", func() { InstantWindowSweepForShape(bogus) })
 }
 
 func assertStampedShape(t *testing.T, got ShapeID, query string, want ShapeID) {


### PR DESCRIPTION
## Summary

- `main`'s required `coverage` check is red on two packages: `compatibility/loki/cmd/loki-compliance-tester` (84.19% < floor 85.3%) and `test/property/gen` (94.37% < floor 94.8%). Both floors in `test/coverage-floor.json` predate the code that dropped below them and were never re-measured/re-ratcheted after it landed — this restores real coverage instead.
- `loki-compliance-tester`: #2218 (`test(compat/loki): drive patterns with a live fixture`, 2026-08-16) added `patterns_live.go` (313 lines) with a test file that only exercised the happy path. The package's floor (85.3%) was set five days earlier, before that file existed. Added tests for every rejection branch of `validateLivePatternsMetadata`, the file-read/decode error paths of `readLivePatternsMetadata`, both fetch-failure branches of `compareLivePatterns`, the non-200 branch of `fetchLivePatterns`, every malformed-envelope shape of `decodePatternsWire`, the envelope-error/malformed-sample branches of `observeLivePatterns`, all `sideErrors`/`sideSliceDiff` combinations, and `compareLivePatternsAxis`'s mismatch/unknown-axis branches. Isolated package coverage: 84.2% → 87.5%.
- `test/property/gen`: #2242 (`test: harden test-fence enrollment semantics`, 2026-08-16) landed hours after that same day's floor bump to 94.8%. It introduced a roster/lookup system (`shapes.go`) and gave `PromQLQueryForShape`, `PromQLRangeQueryForShape`, `ExpHistogramQueryForShape`, `LogQLQueryForShape`, `TraceQLQueryForShape`, and `InstantWindowSweepForShape` each a defensive `panic` on an unrecognised `ShapeID` — none of which any test ever triggered. Added one test that calls each generator with an unknown shape and asserts it panics, which also exercises `containsShapeID`'s and `instantWindowShapeByID`'s "not found" return paths. CI-methodology-accurate merged coverage: 94.4% → 95.4%.
- No floor in `test/coverage-floor.json` changed — both packages now clear their existing, unmodified floor with margin.

## Test plan

- [x] `go build ./...` and `go build -tags chdb,agpl_oracle,chdb_agpl_oracle ./...` clean
- [x] `go vet` clean on both touched packages (default + chdb tags)
- [x] `go test -race ./compatibility/loki/cmd/loki-compliance-tester/... ./test/property/gen/...` green
- [x] `gofumpt -extra -l` clean on both touched files
- [x] Isolated `go test -cover ./compatibility/loki/cmd/loki-compliance-tester/...`: 84.2% → 87.5% (floor 85.3%)
- [x] Narrow reproduction of `test/property/gen`'s CI-accurate merged (`-coverpkg`, default-tag ∪ chdb-tagged, matching `coverage-summary.mjs`'s own union-fold) coverage: 94.4% → 95.4% (floor 94.8%)
- [x] Full `just coverage` recipe (both lanes, `libchdb.so` installed) run end-to-end on the fixed tree — real, CI-identical numbers: `compatibility/loki/cmd/loki-compliance-tester` 87.46% (830/949) vs floor 85.3%, `test/property/gen` 95.31% (711/746) vs floor 94.8%. Final verdict: `coverage-summary: 89 package floor(s) clear`.
- [ ] CI green

## Notes for reviewers

Root-caused via `git log`/`git show` on `test/coverage-floor.json` and the two packages: each floor was a snapshot from the SAME DAY as (but hours before) the PR that added the undertested code, so `coverage-summary.mjs`'s gate never got a chance to catch the regression at merge time — the floor was already stale before the next `main` push. This change restores the two floors' coverage; no other process change is needed.

