### PR TITLE
perf(engine): disable ClickHouse's new analyzer for native-histogram merge queries

### DIFF
--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -197,12 +197,15 @@ func strategyFor(meta Meta) string {
 // (QueryPlanCursor) execute sites so the native path is gated the same
 // way regardless of which one runs.
 //
-// On top of the always-on ts-grid gate, execContext layers the DARK,
-// flag-gated settings rules from e.settings() (optimize_aggregation_in_order,
-// log_comment shape id). Each rule is OFF unless its CERBERUS_* flag is set,
-// so the default ctx is byte-identical to before these rules existed. Every
-// rule writes through chclient.WithQuerySetting, so a plan that triggers more
-// than one rule carries all of them on the one per-request settings map.
+// On top of the always-on ts-grid gate, spill bound, compare() memory bound
+// and native-histogram analyzer fix, execContext layers the DARK, flag-gated
+// settings rules from e.settings() (optimize_aggregation_in_order, log_comment
+// shape id). Each of THOSE rules is OFF unless its CERBERUS_* flag is set, so
+// the default ctx is byte-identical to before they existed; the always-on
+// rules above them fire unconditionally whenever their plan shape matches.
+// Every rule writes through chclient.WithQuerySetting, so a plan that
+// triggers more than one rule carries all of them on the one per-request
+// settings map.
 func (e *Engine) execContext(ctx context.Context, plan chplan.Node, language string, decision *solver.Decision) (context.Context, string) {
 	if planHasTSGridNative(plan) {
 		ctx = chclient.WithTSGridSetting(ctx)
@@ -215,6 +218,12 @@ func (e *Engine) execContext(ctx context.Context, plan chplan.Node, language str
 	// for the wide attribute Map columns can't blow the budget even after the
 	// aggregation spills. Fires only on the metrics-compare plan shape.
 	ctx = applyCompareMemoryBound(ctx, plan, memCap)
+	// Native-histogram-only: disable ClickHouse's newer query analyzer, whose
+	// cost on the merge/window-fold machinery's deeply nested lambda/arrayMap
+	// expressions is wildly superlinear on the floor-pinned CH 24.8 relative
+	// to the older analyzer (cerberus issue #2355). Always-on and
+	// result-equivalent, like the compare() bound above.
+	ctx = applyNativeHistogramAnalyzerFix(ctx, plan)
 	ctx = e.settings().apply(ctx, plan)
 	// Fix the per-dispatch ClickHouse query_id ONCE here, on the ctx that
 	// flows into the chclient dispatch, so the corpus reconciler records the

--- a/internal/engine/query_settings_rules.go
+++ b/internal/engine/query_settings_rules.go
@@ -195,6 +195,84 @@ func planHasMetricsCompare(plan chplan.Node) bool {
 	return found
 }
 
+// applyNativeHistogramAnalyzerFix stamps enable_analyzer=0 on a query whose
+// plan reaches the native (exponential) histogram merge/window-fold machinery
+// — histogram_quantile.go's promHistogramKahanSum and the deeply-nested
+// arrayFold/arrayMap/tupleElement trees it builds, shared by every
+// histogram_quantile()/sum()/avg()/rate()/increase() lowering over an
+// exponential histogram (histogram_quantile_native_window.go,
+// histogram_native_sum.go).
+//
+// It exists because ClickHouse's newer query analyzer (the GA default since
+// well before cerberus's 24.8 floor) has a cost on that specific shape —
+// deeply nested lambda/arrayMap/arrayFold expressions — that is wildly
+// superlinear relative to the OLDER analyzer, and almost entirely
+// PRE-EXECUTION: `send_logs_level=trace` against a floor-pinned CH 24.8 shows
+// the gap sits between `executeQuery` and the first `Planner` trace line, not
+// in row processing. Measured on CH 24.8.14 with
+// `histogram_quantile(0.9, sum(rate(demo_shifting_latency_exp_hist[1m])))`
+// (the cerberus issue #2355 regression case), averaged over 8 runs each via
+// system.query_log's OSCPUVirtualTimeMicroseconds: ~8.4s with the new
+// analyzer (default) vs ~1.4s with it disabled — an 83% reduction, comfortably
+// inside the compatibility harness's 10s per-query deadline where the default
+// analyzer left only a ~1.5s margin under CI contention. The SAME query on CH
+// 26.5 is fast either way (0.57s new analyzer vs 1.2s old analyzer) — both
+// settings names (`enable_analyzer` / `allow_experimental_analyzer`) alias the
+// same underlying flag on every ClickHouse version cerberus supports, so this
+// is a strict, version-safe win on the floor and a bounded, harmless trade
+// (well under any deadline) on newer servers.
+//
+// It is an execution-PLANNER choice, not a result rewrite — RESULT-EQUIVALENT
+// like every other rule in this file — so it is unconditional (no CERBERUS_*
+// opt-in) and always stamped when the plan shape matches, mirroring
+// applyCompareMemoryBound's always-on treatment of a validated, plan-shape-
+// gated fix rather than SettingsRules' operator-opt-in rules.
+//
+// Two OTHER levers were tried and measured flat before this one: hoisting
+// promHistogramKahanSum's shared fold lambda into a query-level
+// `WITH (kh_acc, kh_x) -> ... AS name` CTE referenced by all ~11 call sites
+// (ClickHouse rejects resolving a LAMBDA-typed WITH alias across a subquery
+// scope boundary — "Resolve identifier ... from parent scope only supported
+// for constants and CTE"), and the SAME hoist scoped locally to the three
+// same-statement call-site clusters (5/2/4 occurrences) that CAN share a
+// local WITH — which parses and runs correctly, cuts rendered SQL by ~9%, but
+// moved wall-clock/CPU time by less than run-to-run noise (measured via the
+// same OSCPUVirtualTimeMicroseconds profile event). Neither reduces the
+// ANALYZER's real per-call-site work; disabling the analyzer itself does.
+func applyNativeHistogramAnalyzerFix(ctx context.Context, plan chplan.Node) context.Context {
+	if !planHasNativeHistogramMerge(plan) {
+		return ctx
+	}
+	return chclient.WithQuerySetting(ctx, settingEnableAnalyzer, 0)
+}
+
+// planHasNativeHistogramMerge reports whether plan contains a
+// chplan.HistogramQuantileNative or chplan.HistogramProjection node anywhere
+// in its tree — the two IR nodes exclusive to the exponential (native)
+// histogram lowering (both carry the Scale/ZeroCount/PositiveOffset/
+// NegativeOffset field set no classic-histogram or non-histogram node has),
+// and the only roots internal/promql builds over histogram_quantile.go's
+// shared merge/window-fold machinery. A bare native-histogram selector with no
+// range function or cross-series aggregation still reaches
+// HistogramQuantileNative / HistogramProjection, so this can over-match a
+// cheap query — harmless, since the setting is result-equivalent either way.
+//
+// The sweep is chplan.WalkDeep, matching planHasMetricsCompare /
+// planHasTSGridNative: a native-histogram node nested inside a scalar-binding
+// subtree (an Expr slot Walk does not follow) must still be found.
+func planHasNativeHistogramMerge(plan chplan.Node) bool {
+	found := false
+	chplan.WalkDeep(plan, func(n chplan.Node) bool {
+		switch n.(type) {
+		case *chplan.HistogramQuantileNative, *chplan.HistogramProjection:
+			found = true
+			return false
+		}
+		return true
+	})
+	return found
+}
+
 // eligibleForAggregationInOrder reports whether plan's single Aggregate has a
 // GROUP BY that is a genuine bare-column prefix of its scanned table's
 // sorting key. The check is deliberately conservative: it returns false on

--- a/internal/engine/query_settings_rules_test.go
+++ b/internal/engine/query_settings_rules_test.go
@@ -268,3 +268,67 @@ func TestApplyCompareMemoryBound_NonCompareStampsNeither(t *testing.T) {
 		t.Errorf("non-compare plan: max_bytes_before_external_group_by = %v; want absent (compare rule must not fire)", got)
 	}
 }
+
+// TestApplyNativeHistogramAnalyzerFix_QuantileStampsDisabled — a plan whose
+// root is chplan.HistogramQuantileNative (histogram_quantile() over a native
+// histogram, e.g. cerberus issue #2355's
+// `histogram_quantile(0.9, sum(rate(demo_shifting_latency_exp_hist[1m])))`)
+// gets enable_analyzer=0 stamped, since it always reaches
+// histogram_quantile.go's Kahan-fold merge/window-fold machinery.
+func TestApplyNativeHistogramAnalyzerFix_QuantileStampsDisabled(t *testing.T) {
+	plan := &chplan.HistogramQuantileNative{Input: aggOverScan("otel_metrics_exponential_histogram", "Attributes")}
+
+	ctx := applyNativeHistogramAnalyzerFix(context.Background(), plan)
+
+	if got, want := settingValue(ctx, settingEnableAnalyzer), 0; got != want {
+		t.Errorf("enable_analyzer = %v; want %v", got, want)
+	}
+}
+
+// TestApplyNativeHistogramAnalyzerFix_ProjectionStampsDisabled — a plan whose
+// root is chplan.HistogramProjection (a histogram-VALUED sum()/avg()/rate()/
+// bare-selector result over a native histogram) gets the same stamp, since it
+// shares the same merge/window-fold machinery as HistogramQuantileNative.
+func TestApplyNativeHistogramAnalyzerFix_ProjectionStampsDisabled(t *testing.T) {
+	plan := &chplan.HistogramProjection{Input: aggOverScan("otel_metrics_exponential_histogram", "Attributes")}
+
+	ctx := applyNativeHistogramAnalyzerFix(context.Background(), plan)
+
+	if got, want := settingValue(ctx, settingEnableAnalyzer), 0; got != want {
+		t.Errorf("enable_analyzer = %v; want %v", got, want)
+	}
+}
+
+// TestApplyNativeHistogramAnalyzerFix_NestedStampsDisabled — a native
+// histogram quantile nested inside a scalar-binding subtree (an Expr slot
+// chplan.Walk does not follow) is still found, because the sweep is
+// chplan.WalkDeep — mirrors planHasTSGridNative's own nested-scalar case.
+func TestApplyNativeHistogramAnalyzerFix_NestedStampsDisabled(t *testing.T) {
+	inner := &chplan.HistogramQuantileNative{Input: aggOverScan("otel_metrics_exponential_histogram", "Attributes")}
+	plan := &chplan.Project{
+		Input: &chplan.Scan{Table: "otel_metrics_gauge"},
+		Projections: []chplan.Projection{{
+			Expr:  &chplan.ScalarSubquery{Input: inner},
+			Alias: "Value",
+		}},
+	}
+
+	ctx := applyNativeHistogramAnalyzerFix(context.Background(), plan)
+
+	if got, want := settingValue(ctx, settingEnableAnalyzer), 0; got != want {
+		t.Errorf("enable_analyzer = %v; want %v", got, want)
+	}
+}
+
+// TestApplyNativeHistogramAnalyzerFix_NonHistogramStampsNothing — an ordinary
+// {} | rate() plan over a counter never reaches the native-histogram
+// machinery, so the fix never rides it.
+func TestApplyNativeHistogramAnalyzerFix_NonHistogramStampsNothing(t *testing.T) {
+	plan := &chplan.RangeWindow{Input: aggOverScan("otel_metrics_sum", "MetricName")}
+
+	ctx := applyNativeHistogramAnalyzerFix(context.Background(), plan)
+
+	if got := settingValue(ctx, settingEnableAnalyzer); got != nil {
+		t.Errorf("non-histogram plan: enable_analyzer = %v; want absent", got)
+	}
+}


### PR DESCRIPTION
## Summary

Fixes #2355: `compatibility/prometheus-floor`'s `demo_shifting_latency_exp_hist` cases
intermittently timing out (`context deadline exceeded`, 10s deadline) against the
floor-pinned ClickHouse 24.8.

- Stamps `enable_analyzer=0` (`chclient.WithQuerySetting`, the engine's existing
  plan-shape-gated per-query ClickHouse settings mechanism — same idiom as
  `applyCompareMemoryBound` / `applySpillSettings`) on any query whose plan reaches
  `chplan.HistogramQuantileNative` or `chplan.HistogramProjection` — the two IR nodes
  exclusive to the native (exponential) histogram lowering, and the only roots that reach
  `histogram_quantile.go`'s shared cross-series merge / window-fold machinery
  (`promHistogramKahanSum`, `expHistogramMergeBucketsExpr`).
- Unconditional (no `CERBERUS_*` opt-in) and result-equivalent — an execution-planner
  choice, not a result rewrite — so it fires whenever the plan shape matches, the same
  treatment the engine already gives `applyCompareMemoryBound`.

## Why this lever, not the one #2355's own history already tried

#2355's own comment thread already tried and discarded one lever: hoisting
`counterIncreaseFold`'s per-column `arraySort` calls, which "does not move the needle" —
rendered SQL went from 26,485 → 27,104 bytes (flat), wall-clock statistically
indistinguishable under box load. That comment flagged `promHistogramKahanSum` /
`expHistogramMergeBucketsExpr` as a similar, unverified "closures re-derive shared
intermediates" shape worth investigating.

This PR investigated that lead and found it does NOT explain the timeout — but a
different property of the SAME machinery does:

1. **Tried and measured flat (lever 1):** hoisting the Kahan-fold's shared lambda body
   (called ~11 times per query, byte-identical each time) into a query-level
   `WITH (kh_acc, kh_x) -> ... AS name` CTE referenced by name at every call site.
   ClickHouse 24.8 **rejects** this outright once the reference crosses a subquery
   boundary: `Resolve identifier '_hq_kahan_step' from parent scope only supported for
   constants and CTE. Actual ... node type LAMBDA` — a hard, syntactic wall, not a
   performance question.
2. **Tried and measured flat (lever 2):** the same hoist scoped to the three
   same-statement call-site clusters that CAN share a local `WITH` (5 / 2 / 4 co-located
   calls respectively — merge stage, window bucket-fold, reset-detection). This parses,
   runs, and returns the correct result, and cuts rendered SQL by ~9% (24,895 → 22,641
   bytes on the literalized query). Measured via `system.query_log`'s
   `OSCPUVirtualTimeMicroseconds` over 7-8 runs each on a real CH 24.8 container: no
   measurable difference — the two distributions overlap entirely within run-to-run
   noise. Mechanistically this makes sense in retrospect: ClickHouse's `WITH`-lambda
   alias is syntactic sugar the analyzer re-expands per reference, not a memoized value
   the way `WithScalar`'s scalar-CTE form is — so sharing the lambda's *name* doesn't
   reduce the analyzer's real per-call-site work, only the source byte count.
3. **The actual lever (this PR):** `send_logs_level=trace` against real CH 24.8 already
   showed the cost sits almost entirely between `executeQuery` and the first `Planner`
   trace line — i.e. it's the *analyzer itself*, not row processing. Toggling
   `enable_analyzer` (ClickHouse's newer query analyzer, GA well before the 24.8 floor)
   off entirely, with the SQL text completely unchanged, is what actually moves it.

## Measurement (real ClickHouse 24.8.14, via the actual cerberus HTTP path)

Built both binaries (pre-fix = current `main`, post-fix = this branch), pointed at the
same freshly-seeded, auto-provisioned real ClickHouse 24.8.14 container (not chDB), and
issued the exact regressed queries from issue #2355's comment history against
`/api/v1/query`:

| Query | Pre-fix | Post-fix |
|---|---|---|
| `histogram_quantile(0.9, sum(rate(demo_shifting_latency_exp_hist[1m])))` | 7.23s / 9.55s / 8.64s (3 runs) | 1.68s / 1.68s / 1.61s / 1.58s (4 runs) |
| `histogram_quantile(1, rate(demo_shifting_latency_exp_hist[1m])))` | (same class, cited in the 32116742817 run) | 1.25s |

Same correct result both ways (`27.801238408877097`) — confirms this is a pure
execution-planner change, not a query-shape change (no `chsql`/`chplan` diff, no golden
regen needed). ~80-85% wall-clock reduction, comfortably inside the 10s deadline instead
of sitting right against it.

On CH 26.5 (the default lane) the same query is fast either way (0.57s new analyzer vs
1.2s old analyzer) — both settings names (`enable_analyzer` / `allow_experimental_analyzer`)
alias the same flag on every ClickHouse version cerberus supports, so this is a strict win
on the floor and a bounded, harmless trade well under any deadline on newer servers.

## Test plan

- [x] `go test -race ./internal/engine/...` — new `TestApplyNativeHistogramAnalyzerFix_*`
      cases (quantile root, projection root, nested-in-scalar-subquery via `WalkDeep`,
      non-histogram plan stamps nothing) plus the full existing package, green.
- [x] `go test -race ./internal/api/prom/... ./internal/api/loki/... ./internal/api/tempo/...`
      — green (the shared `execContext` seam every head dispatches through).
- [x] End-to-end against a real ClickHouse 24.8.14 container via the actual `cmd/cerberus`
      binary and HTTP API (see measurement table above), confirming both the timing win
      and correctness (identical result value pre/post).
- [x] `gofumpt -extra` / `goimports -local` clean; no `chsql`/`chplan`/emitted-SQL diff, so
      no `test/spec` golden regeneration is needed.

## Follow-up

Resolved in this change: commented on #2355 with a link to this PR and the measured
numbers, and this merge closes #2355. Filed #2359 to track re-evaluating the
unconditional `enable_analyzer=0` toggle as cerberus's supported ClickHouse
version range moves forward.

