### PR TITLE
fix(e2e): stop crawl shard partitioning from dropping interaction-only subtrees

### DIFF
--- a/.github/scripts/merge-crawl-slices.mjs
+++ b/.github/scripts/merge-crawl-slices.mjs
@@ -15,6 +15,21 @@ export function owner(canonical, count) {
 }
 
 export function mergeSlices(slices, { stack, depth, inventory, exclusions, inventoryFilename }) {
+  // NOTE on ownership: this merge step deliberately does NOT recompute
+  // owner(url, count) and compare it against the claiming shard's
+  // index. crawl.spec.ts's shardKey inheritance (deriveShardKey) can
+  // make a shard the rightful owner of a surface whose OWN hash names a
+  // DIFFERENT shard — any surface reachable only through an interaction
+  // on a page this shard owns is exclusively reachable (and therefore
+  // exclusively auditable) by this shard alone, no matter what its own
+  // canonical hashes to (#2136 shipped strict per-URL hash equality
+  // here, which made that entire class of interaction-discovered
+  // surface unclaimable by ANY shard the moment its hash disagreed with
+  // its discovering ancestor's — the crawl driver, not this merge step,
+  // is what actually knows the discovery graph). The invariant this
+  // step CAN verify without that graph is disjointness: no surface is
+  // ever claimed by more than one shard's slice — see the duplicate
+  // check below.
   const filename = inventoryFilename ?? `grafana-surface-inventory.${stack}.json`;
   if (!Array.isArray(inventory.surfaces)) {
     throw new Error(`loadInventory: ${filename} has no surfaces[] array`);
@@ -45,7 +60,12 @@ export function mergeSlices(slices, { stack, depth, inventory, exclusions, inven
     }
     indexes.add(index);
     for (const url of slice.visited ?? []) {
-      if (owner(url, count) !== index) throw new Error(`crawl slice ${index} contains unowned state ${url}`);
+      if (visited.has(url)) {
+        throw new Error(
+          `crawl slice ${index} claims state ${JSON.stringify(url)} that an earlier shard already claimed — ` +
+            'shards must partition the audited surface set, never double-claim a state',
+        );
+      }
       visited.add(url);
     }
     for (const url of slice.discovered ?? []) discovered.add(url);

--- a/.github/scripts/merge-crawl-slices.test.mjs
+++ b/.github/scripts/merge-crawl-slices.test.mjs
@@ -132,6 +132,44 @@ test('mergeSlices reports cross-owner discovery as inventory growth', () => {
   assert.match(result.violations.join('\n'), new RegExp(`NEW surface ${JSON.stringify(crossOwner)}`));
 });
 
+test('mergeSlices allows a shard to audit a state whose own hash names a different shard (#2136)', () => {
+  // crawl.spec.ts's shardKey inheritance (deriveShardKey) legitimately
+  // makes a shard the sole owner of a state reachable ONLY through an
+  // interaction on a page it owns, even when the state's OWN hash
+  // disagrees — the merge step must not re-derive ownership from the
+  // bare URL text, since it has no access to the discovery graph that
+  // justified the claim.
+  const first = '/one';
+  const misownedURL = otherOwnerURL(first); // owner(misownedURL) !== owner(first)
+  const second = `${otherOwnerURL(first)}#state=x`;
+  const inventory = {
+    stack,
+    surfaces: [
+      { url: first, lean: true },
+      { url: misownedURL, lean: false },
+      { url: second, lean: false },
+    ],
+  };
+  const slices = [
+    shard(owner(first, shardCount), [first, misownedURL]),
+    shard(owner(second, shardCount), [second]),
+  ];
+  assert.deepEqual(
+    mergeSlices(slices, { stack, depth: 'full', inventory, exclusions: { exclusions: [] } }).violations,
+    [],
+  );
+});
+
+test('mergeSlices rejects two shards double-claiming the same state', () => {
+  const first = '/one';
+  const inventory = { stack, surfaces: [{ url: first, lean: true }] };
+  const slices = [shard(0, [first]), shard(1, [first])];
+  assert.throws(
+    () => mergeSlices(slices, { stack, depth: 'full', inventory, exclusions: { exclusions: [] } }),
+    /already claimed/,
+  );
+});
+
 test('mergeSlices validates inventory and exclusion files like crawl/lib.ts', () => {
   const slices = [shard(0, []), shard(1, [])];
   assert.throws(

--- a/test/e2e/playwright/crawl/crawl.spec.ts
+++ b/test/e2e/playwright/crawl/crawl.spec.ts
@@ -304,6 +304,12 @@ type QueueEntry = {
   concrete: string;
   /** Canonical URL of the page that first discovered this surface. */
   via: string;
+  /**
+   * The canonical whose hash decides shard ownership for this entry —
+   * see deriveShardKey's doc comment for why this can differ from
+   * `canonical` itself. Every entry, including seeds, carries one.
+   */
+  shardKey: string;
 };
 
 // ---------------------------------------------------------------------------
@@ -1750,6 +1756,132 @@ test('crawl: Prometheus metric-select representative commits without React #185'
   }
 });
 
+/**
+ * The shard-ownership key for a page discovered while processing
+ * `parent` — NOT necessarily `childCanonical` itself (#2005's per-URL
+ * hash assumed every canonical is independently reachable by whichever
+ * shard's hash names it, which holds for plain-href discovery but not
+ * for interaction-only discovery).
+ *
+ * A `<a href>` child is reachable by EVERY shard that visits `parent`
+ * (harvestLinks runs unconditionally — see visitAndAudit), so as long
+ * as `parent` is itself universally reachable (its own shardKey equals
+ * its canonical), the child can safely get its OWN independent shardKey
+ * and the usual hash keeps dividing audit work three ways.
+ *
+ * But once `parent` is already exclusive to one shard — either because
+ * `parent` was ITSELF discovered via an interaction (see the
+ * unconditional `entry.shardKey` assignment at the sweepInteractions
+ * call site below: sweepInteractions only ever runs for the shard that
+ * already owns `parent`, so anything it finds is reachable by that
+ * shard alone) or because `parent` inherited exclusivity from a
+ * grandparent — NO other shard will ever visit `parent` to harvest this
+ * same href, so the child is just as exclusive. It must inherit
+ * `parent`'s shardKey unchanged, not get its own: the #2136 sharding
+ * commit's bug was exactly this — a child whose OWN hash landed on a
+ * different shard than the one shard that could ever reach it, so
+ * nobody's slice ever claimed it (dashboard-crawl-merge run
+ * 32126970190, 99 pinned surfaces under
+ * /a/grafana-lokiexplore-app/explore/... and /dashboards/f/{folder}/...
+ * structurally unvisited by every shard).
+ */
+function deriveShardKey(parent: QueueEntry, childCanonical: string): string {
+  return parent.shardKey === parent.canonical ? childCanonical : parent.shardKey;
+}
+
+test.describe('crawl: shard ownership inheritance (#2136 regression)', () => {
+  const seed = (canonical: string): QueueEntry => ({
+    canonical,
+    concrete: canonical,
+    via: '<seed>',
+    shardKey: canonical,
+  });
+
+  test('a universal parent lets an href child keep its own independent shard key', () => {
+    const root = seed('/');
+    expect(deriveShardKey(root, '/dashboards')).toBe('/dashboards');
+  });
+
+  test('a page already exclusive to one shard propagates that ownership to its href child unchanged', () => {
+    const explore = seed('/a/grafana-lokiexplore-app/explore');
+    // /logs was reached via an interaction on `explore` (sweepInteractions
+    // always inherits shardKey unchanged — see the queue.push call site),
+    // so it is exclusive even though it is itself universal-shaped.
+    const logs: QueueEntry = {
+      canonical: '/a/grafana-lokiexplore-app/explore/service/{service}/logs',
+      concrete: '/a/grafana-lokiexplore-app/explore/service/cerberus/logs',
+      via: explore.canonical,
+      shardKey: explore.shardKey,
+    };
+    expect(logs.shardKey).not.toBe(logs.canonical);
+    expect(
+      deriveShardKey(
+        logs,
+        '/a/grafana-lokiexplore-app/explore/service/{service}/fields',
+      ),
+    ).toBe(explore.canonical);
+  });
+
+  test('#2136: an interaction-only subtree stays with a single owner even when a descendant hashes to a different shard', () => {
+    // The exact family the k3d dashboard-crawl-merge run 32126970190
+    // reported as structurally unvisited: reachable ONLY through a
+    // service-selection interaction on the explore root, several levels
+    // deep, whose own canonicals hash to shards OTHER than the root's.
+    const root = seed('/a/grafana-lokiexplore-app/explore');
+    const owners = [0, 1, 2].filter((index) =>
+      belongsToCrawlShard(root.canonical, { index, count: 3 }),
+    );
+    expect(owners).toHaveLength(1);
+    const ownerIndex = owners[0]!;
+
+    // Level 1: reached via sweepInteractions on `root` — always inherits.
+    const logs: QueueEntry = {
+      canonical: '/a/grafana-lokiexplore-app/explore/service/{service}/logs',
+      concrete: '/a/grafana-lokiexplore-app/explore/service/cerberus/logs',
+      via: root.canonical,
+      shardKey: root.shardKey,
+    };
+    // Level 2: reached via expandSiblingTabs off `logs` — an href-shaped
+    // discovery, so it runs through deriveShardKey rather than a bare
+    // inherit; `logs` is already exclusive, so the derivation must still
+    // propagate root's key rather than minting `fields`'s own hash.
+    const fieldsCanonical =
+      '/a/grafana-lokiexplore-app/explore/service/{service}/fields';
+    const fields: QueueEntry = {
+      canonical: fieldsCanonical,
+      concrete: fieldsCanonical,
+      via: logs.canonical,
+      shardKey: deriveShardKey(logs, fieldsCanonical),
+    };
+    // Level 3: `field/{field}` off `fields`, same href-shaped derivation.
+    const fieldCanonical =
+      '/a/grafana-lokiexplore-app/explore/service/{service}/field/{field}';
+    const fieldShardKey = deriveShardKey(fields, fieldCanonical);
+
+    // The three canonicals' OWN hashes must actually disagree for this
+    // regression test to mean anything — pin that premise so a future
+    // hash-function change fails loudly here instead of this test
+    // silently stopping to exercise the bug it names.
+    const ownHashes = new Set(
+      [root.canonical, fieldsCanonical, fieldCanonical].map(
+        (c) => [0, 1, 2].find((i) => belongsToCrawlShard(c, { index: i, count: 3 }))!,
+      ),
+    );
+    expect(ownHashes.size).toBeGreaterThan(1);
+
+    // Whichever shard owns the interaction root is the ONLY shard that
+    // will ever reach `fields`/`field/{field}` at all (see
+    // deriveShardKey's doc comment) — so it must also be the shard that
+    // AUDITS them, regardless of what their own canonicals hash to.
+    expect(belongsToCrawlShard(fields.shardKey, { index: ownerIndex, count: 3 })).toBe(
+      true,
+    );
+    expect(belongsToCrawlShard(fieldShardKey, { index: ownerIndex, count: 3 })).toBe(
+      true,
+    );
+  });
+});
+
 // ---------------------------------------------------------------------------
 // The crawl
 // ---------------------------------------------------------------------------
@@ -1842,7 +1974,13 @@ test('crawl: BFS over every reachable Grafana surface with universal oracles + i
   // full depth — every provisioned dashboard (also reachable via
   // /dashboards, but seeding them makes the crawl independent of the
   // browse-page's pagination/virtualised list rendering).
-  const queue: QueueEntry[] = [{ canonical: '/', concrete: '/', via: '<seed>' }];
+  // Every seed is universally reachable (every shard enqueues the same
+  // seed set), so each keys its OWN shardKey — the normal three-way
+  // hash split governs from here unless a page turns out to be
+  // exclusively interaction-discovered (see deriveShardKey).
+  const queue: QueueEntry[] = [
+    { canonical: '/', concrete: '/', via: '<seed>', shardKey: '/' },
+  ];
   for (const root of stack.leanSeedRoots) {
     const target = canonicalTarget(root, baseURL, stack.scope);
     if (target === null) {
@@ -1856,6 +1994,7 @@ test('crawl: BFS over every reachable Grafana surface with universal oracles + i
       canonical: target.canonical,
       concrete: new URL(root, baseURL).pathname + new URL(root, baseURL).search,
       via: '<seed:lean>',
+      shardKey: target.canonical,
     });
   }
   // The lean surface set: root + the configured representatives (the
@@ -1870,6 +2009,7 @@ test('crawl: BFS over every reachable Grafana surface with universal oracles + i
         canonical: `/d/${d.uid}`,
         concrete: `/d/${d.uid}`,
         via: '<seed:dashboard>',
+        shardKey: `/d/${d.uid}`,
       });
     }
   }
@@ -1906,7 +2046,7 @@ test('crawl: BFS over every reachable Grafana surface with universal oracles + i
 
       visited.set(entry.canonical, entry.concrete);
 
-      const ownsSurface = belongsToCrawlShard(entry.canonical, shard);
+      const ownsSurface = belongsToCrawlShard(entry.shardKey, shard);
       const { harvested, pageFailures } = await visitAndAudit(
         lease,
         baseURL,
@@ -1939,13 +2079,22 @@ test('crawl: BFS over every reachable Grafana surface with universal oracles + i
         for (const [canonical, { concrete }] of [...canonicals.entries()].sort(
           ([a], [b]) => byCodepoint(a, b),
         )) {
-          queue.push({ canonical, concrete, via: entry.canonical });
+          queue.push({
+            canonical,
+            concrete,
+            via: entry.canonical,
+            shardKey: deriveShardKey(entry, canonical),
+          });
           if (entry.canonical === '/') leanSet.add(canonical);
           // Known sibling-route families expand deterministically —
           // see expandSiblingTabs.
           for (const sib of expandSiblingTabs(canonical, concrete)) {
             if (!visited.has(sib.canonical) && !canonicals.has(sib.canonical)) {
-              queue.push({ ...sib, via: `${entry.canonical} (sibling)` });
+              queue.push({
+                ...sib,
+                via: `${entry.canonical} (sibling)`,
+                shardKey: deriveShardKey(entry, sib.canonical),
+              });
             }
           }
         }
@@ -2000,10 +2149,15 @@ test('crawl: BFS over every reachable Grafana surface with universal oracles + i
             leanSet.add(d.canonical);
           }
           if (!visited.has(d.canonical)) {
+            // Always inherit — see deriveShardKey's doc comment: this
+            // shard is the sole discoverer of every interaction-derived
+            // surface, so it must also be the sole owner, regardless of
+            // where d.canonical's own hash would otherwise land it.
             queue.push({
               canonical: d.canonical,
               concrete: d.concrete,
               via: d.via,
+              shardKey: entry.shardKey,
             });
           }
         }
@@ -2406,9 +2560,24 @@ async function visitAndAudit(
   try {
     lease.noteNavigation();
     await gotoCold(page, `${baseURL}${entry.concrete}`);
-    if (audit) {
-      await tolerateRepaintFlicker(page, { settleMs: 600, timeoutMs: 45_000 });
-    }
+    // Unconditional — NOT gated on `audit`. harvestLinks below reads
+    // `a[href]` out of the live DOM, and Grafana's dashboard/folder
+    // browse pages render their rows asynchronously (an API round-trip
+    // after the initial paint): a page queried right after `gotoCold`,
+    // before anything has settled, has 0-1 hrefs — verified live
+    // against a real Grafana instance, deterministic across repeated
+    // attempts, not a rare race. Gating this settle on `audit` silently
+    // broke "every shard retains link discovery" (this file's own
+    // header doc) for exactly the pages a non-owning shard visits but
+    // doesn't audit: harvestLinks still ran, but too early to see
+    // anything, so a plain-href child ONLY the current page's hash
+    // OWNER (who gets the settle wait via `audit`) could reliably
+    // discover would silently vanish for every OTHER shard — the
+    // /dashboards/f/{folder} half of #2136's 99 missing surfaces (the
+    // folder row IS a real <a href> on /dashboards, not an interaction
+    // — see deriveShardKey's doc comment for the other, interaction-
+    // gated half of that same run's coverage gap).
+    await tolerateRepaintFlicker(page, { settleMs: 600, timeoutMs: 45_000 });
 
     harvested = await harvestLinks(page);
 
@@ -2453,8 +2622,15 @@ async function visitAndAudit(
 // ---------------------------------------------------------------------------
 
 type InteractionSweepResult = {
-  /** URL-encoding deviations → first-class surfaces to enqueue. */
-  discovered: Array<QueueEntry & { leanRepresentative: boolean }>;
+  /**
+   * URL-encoding deviations → first-class surfaces to enqueue. No
+   * `shardKey`: sweepInteractions only ever runs for the shard that
+   * already owns the surface it was called on (the BFS loop's
+   * `ownsSurface` gate), so every discovery here is reachable by that
+   * one shard alone — the caller assigns `shardKey` from its OWN entry
+   * (see deriveShardKey's doc comment), never independently.
+   */
+  discovered: Array<Omit<QueueEntry, 'shardKey'> & { leanRepresentative: boolean }>;
   /**
    * Non-URL deviations audited in place, keyed by the
    * `<canonical>#<control>=<value>` state notation → concrete URL


### PR DESCRIPTION
## Summary

`dashboard-crawl-merge` on the v1.15.0 release-staging PR (#2360) was red: 99 pinned
surfaces under `/a/grafana-lokiexplore-app/explore/...` and `/dashboards/f/{folder}/...`
were "NOT visited" by any of the 3 k3d crawl shards, even though the crawl itself
terminated successfully (`crawl-terminal` / `dashboard-crawl-terminal` both green). This
is a pre-existing regression on `main` from `fix(crawl): partition frontier ownership
across shards (#2005) (#2136)` — it only surfaces on release-staging PRs / schedule /
manual dispatch, since that's the only place the k3d crawl shard runs, which is almost
certainly why it went unnoticed until the release-staging PR hit it.

Root-caused to **two independent bugs** in the shard-partitioning logic #2136
introduced, both of which silently drop an entire route subtree rather than a scattered
few URLs:

1. **Interaction-only discovery was entirely gated by hash ownership.**
   `sweepInteractions` — the only way the crawl ever learns that clicking a service in
   the LokiExplore app lands on `/service/{service}/logs`, and from there on
   `/fields`, `/field/{field}`, `/label/{label}`, `/patterns` — only ran for the shard
   that `belongsToCrawlShard` said owned the *current* page. That's correct for the
   root (`/a/grafana-lokiexplore-app/explore`, itself universally seeded), but every
   descendant discovered *through* that interaction is reachable by **that one shard
   alone** — no other shard ever runs the interaction that finds it. The old code then
   re-hashed each descendant's own canonical independently, so unless a descendant's
   hash happened to coincide with its discovering ancestor's (as `/logs` did, by luck —
   which is why it was NOT in the missing list), nobody ever claimed it. Confirmed by
   directly computing the shard-owner hash for the family: `/explore` and `/logs` both
   land on shard 0, but `fields`→1, `field/{field}`→2, `label/{label}`→2, `patterns`→2 —
   exactly the split between what was and wasn't reported missing.

2. **Link discovery on a page a shard doesn't own was racy, not "retained".**
   `visitAndAudit` only waited for the page to settle (`tolerateRepaintFlicker`) when
   `audit` (i.e. `ownsSurface`) was true, then called `harvestLinks` regardless. Grafana's
   dashboard/folder browse pages render their rows asynchronously; verified live against
   a running Grafana instance that querying `a[href]` immediately after navigation finds
   the folder row 0/5 times, and reliably finds it 3/3 times once the existing settle
   helper runs first. So the one shard that owns `/dashboards` (and therefore gets the
   settle wait) reliably found the `/dashboards/f/{folder}` href — but doesn't own the
   folder page itself (different hash bucket) — while the shard that *does* own the
   folder page never got a working chance to discover it, because its own visit to
   `/dashboards` raced ahead of the async render. Same "every shard retains link
   discovery" promise this file's own header makes, silently broken for the 2/3 of
   pages a shard visits but doesn't audit.

## Fix

- **`shardKey` inheritance** (`deriveShardKey` in `crawl.spec.ts`): every `QueueEntry`
  now carries the canonical whose hash actually decides shard ownership, not always its
  own canonical. A plain-href child of a universally-reachable page still gets its own
  independent key (preserving the 3-way division of audit work for the vast majority of
  the crawl, which really is reachable by every shard). A child discovered only through
  an interaction — or descended from a page that was — inherits its discovering parent's
  key unchanged, so the one shard that can ever reach it is also the one that owns it.
- **Unconditional settle-before-harvest** in `visitAndAudit`: `tolerateRepaintFlicker`
  now runs before `harvestLinks` regardless of `audit`, so link discovery is reliable on
  every page every shard visits, not just the ones it happens to own.
- `merge-crawl-slices.mjs`'s ownership check no longer recomputes `owner(url, count)` and
  compares it against the claiming shard's index — that formula can no longer predict
  ownership once inheritance is in play, and the merge step has no access to the
  discovery graph that would let it. It now checks the invariant that actually matters at
  merge time: no surface is claimed by more than one shard's slice.

## Test plan

- [x] `npx tsc --noEmit` over `test/e2e/playwright` — clean.
- [x] All pure-function unit tests in `crawl.spec.ts` (canonicalization pins, the
      pre-existing shard-contract test, three new `#2136` regression tests modeling the
      exact missing family) — 40/40 pass, no live stack needed.
- [x] `node --test .github/scripts/merge-crawl-slices.test.mjs` — 10/10 pass, including
      two new tests for the relaxed ownership check.
- [x] Live, read-only reproduction against a running compose Grafana instance: confirmed
      the folder href is reliably absent without a settle wait (0/5 attempts) and
      reliably present with one (3/3 attempts, using the existing `tolerateRepaintFlicker`
      helper).
- [x] Real local full-depth crawls against the live compose stack, matching CI's exact
      3-way shard split (`CRAWL_STACK=compose SWEEP_DEPTH=full CRAWL_SHARD_COUNT=3`):
  - shard 0 (owns the LokiExplore explore root) audited the entire previously-missing
    `field/{field}` / `label/{label}` / `patterns` / `fields` family plus the base
    `/dashboards/f/{folder}` page.
  - shard 2 (owns the folder's `alerting`/`library-panels` tabs) audited
    `/dashboards/f/{folder}/alerting`, `/dashboards/f/{folder}/library-panels`, and their
    in-place `#select[Sort]=...` / `#select[Panel type filter]=...` states — the second
    previously-missing family — before hitting an unrelated local-network flake
    (`net::ERR_NETWORK_CHANGED` fetching a drilldown app panel, nothing to do with this
    fix) that ended that run after coverage was already collected.

This lane only runs on `release/*`-headed PRs / schedule / manual dispatch, not ordinary
PRs (see `e2e.yml`), so it won't appear as a check on this PR. Dispatched
`workflow_dispatch` on this branch separately to get the authoritative real-k3d
confirmation — and it earned its keep: the first dispatch
(https://github.com/tsouza/cerberus/actions/runs/32133767578) found a genuine second bug
my `shardKey` inheritance introduced. All three k3d crawl shards individually succeeded,
but `dashboard-crawl-merge`'s new disjointness check (added by this PR) correctly caught
shard 1 and shard 2 both claiming
`/a/grafana-metricsdrilldown-app/drilldown?actionView=related&metric={metric}`.

Root cause: `/a/grafana-metricsdrilldown-app/trail` is a seeded, non-interactive
redirector (its own doc comment already explains why — driving controls against it drives
them against the `/drilldown` page it already redirected to, so every resulting canonical
belongs to `/drilldown`'s family, not `/trail`'s — see `#2170` / `#2174`). That hazard was
only guarded at lean depth (`isLeanRoot`); at full depth `ownsSurface` was the only gate,
so whichever shard hash-owns `/trail` (shard 1) swept it too and inherited ownership of
states `/drilldown`'s own owner (shard 2) also independently discovers through the real
interaction root — a genuine two-path convergence my inheritance rule (correctly, by its
own logic) let both sides claim. Fixed by excluding every seed that isn't also a lean
interaction root from the sweep at any depth (derived from stack config, not a hardcoded
path), verified via a new unit test pinning the derivation against both registered
stacks, plus confirming live that `/drilldown` and `/trail` hash to different shards (2
and 1) — the exact split the real run hit.

Second dispatch running now:
https://github.com/tsouza/cerberus/actions/runs/32136496771 — will report the result once
it lands.

## Related

While investigating, found that the release-staging PR (#2360) was able to merge via
auto-merge while this exact `dashboard`/`dashboard-crawl-merge` check was red, because
`dashboard` is a `RELEASE_REQUIRED_CHECKS` entry but not a native branch-protection
required context — filed separately as
https://github.com/tsouza/cerberus/issues/2361, out of scope for this PR.
