### PR TITLE
fix(e2e): never sweep interactions on a redirector-only seed at full depth

### DIFF
--- a/test/e2e/playwright/crawl/crawl.spec.ts
+++ b/test/e2e/playwright/crawl/crawl.spec.ts
@@ -167,6 +167,7 @@ import {
   activeStack,
   knownStackNames,
   stackByName,
+  type CrawlStackConfig,
 } from './stacks.js';
 
 // Self-traffic warmup — same rationale + value as the iterate-* specs:
@@ -1789,6 +1790,41 @@ function deriveShardKey(parent: QueueEntry, childCanonical: string): string {
   return parent.shardKey === parent.canonical ? childCanonical : parent.shardKey;
 }
 
+/**
+ * Seeds that exist ONLY to prove a redirector still lands somewhere
+ * in-scope (e.g. the Metrics Drilldown app's legacy `/trail` alias —
+ * see METRICS_DRILLDOWN_LEGACY_TRAIL_SEED's doc comment in stacks.ts)
+ * are seeded but deliberately excluded from `leanInteractionRoots`:
+ * driving controls against one drives them against the page it ALREADY
+ * redirected to, so every resulting canonical belongs to that OTHER
+ * page's family, not this seed's own. At lean depth `isLeanRoot` already
+ * keeps the sweep off these; at full depth `ownsSurface` was the ONLY
+ * gate, so every non-interactive seed got swept anyway — whichever
+ * shard owns it (co-)discovers the SAME states the seed it's an alias
+ * of independently discovers too, so two shards' slices can legitimately
+ * both claim the same surface. This is a real, observed regression
+ * (dashboard-crawl-merge run 32133767578: `/a/grafana-metricsdrilldown-
+ * app/drilldown?actionView=related&metric={metric}` claimed by both the
+ * `/drilldown` seed's owner and the `/trail` seed's owner). Excluding
+ * every non-interaction-root seed from the sweep, at ANY depth, closes
+ * this for the known /trail case and any future one — matching the lean
+ * gate's existing behaviour instead of only mimicking it below full
+ * depth's page cap.
+ */
+function nonInteractiveSeedSet(
+  stack: CrawlStackConfig,
+  baseURL: string,
+): Set<string> {
+  return new Set(
+    stack.leanSeedRoots
+      .map((root) => canonicalTarget(root, baseURL, stack.scope)?.canonical)
+      .filter(
+        (c): c is string =>
+          c !== undefined && !stack.leanInteractionRoots.includes(c),
+      ),
+  );
+}
+
 test.describe('crawl: shard ownership inheritance (#2136 regression)', () => {
   const seed = (canonical: string): QueueEntry => ({
     canonical,
@@ -1879,6 +1915,40 @@ test.describe('crawl: shard ownership inheritance (#2136 regression)', () => {
     expect(belongsToCrawlShard(fieldShardKey, { index: ownerIndex, count: 3 })).toBe(
       true,
     );
+  });
+
+  test('#2136 follow-up (run 32133767578): a redirector-only seed never gets independently swept', () => {
+    // Every registered stack's non-interactive seeds today are exactly
+    // its lean seed roots minus its lean interaction roots — the
+    // Metrics Drilldown app's legacy `/trail` alias is the only one
+    // (see METRICS_DRILLDOWN_LEGACY_TRAIL_SEED in stacks.ts), but this
+    // asserts the DERIVATION, not a hardcoded path, so a future stack
+    // adding another alias-only seed is covered for free.
+    for (const name of knownStackNames()) {
+      const stack = stackByName(name);
+      const base = 'http://localhost:3000';
+      const nonInteractive = nonInteractiveSeedSet(stack, base);
+      const interactionRoots = new Set(
+        stack.leanInteractionRoots.map(
+          (root) => canonicalTarget(root, base, stack.scope)?.canonical,
+        ),
+      );
+      for (const canonical of nonInteractive) {
+        expect(
+          interactionRoots.has(canonical),
+          `${name}: a non-interactive seed must never also be an interaction root (${canonical})`,
+        ).toBe(false);
+      }
+      // Live regression: the trail seed is in the registry precisely
+      // because it must stay excluded from the sweep at every depth.
+      const trail = canonicalTarget(
+        '/a/grafana-metricsdrilldown-app/trail',
+        base,
+        stack.scope,
+      );
+      expect(trail).not.toBeNull();
+      expect(nonInteractive.has(trail!.canonical)).toBe(true);
+    }
   });
 });
 
@@ -1997,6 +2067,7 @@ test('crawl: BFS over every reachable Grafana surface with universal oracles + i
       shardKey: target.canonical,
     });
   }
+  const nonInteractiveSeeds = nonInteractiveSeedSet(stack, baseURL);
   // The lean surface set: root + the configured representatives (the
   // nav links harvested from the root page join it during the
   // root visit below). Snapshot BEFORE the full-depth dashboard
@@ -2108,7 +2179,11 @@ test('crawl: BFS over every reachable Grafana surface with universal oracles + i
       // the pairwise bound: surfaces pinning ≥2 structural params are
       // terminal (planInteractions returns an empty plan for them).
       const isLeanRoot = stack.leanInteractionRoots.includes(entry.canonical);
-      if (ownsSurface && (depth === 'full' || isLeanRoot)) {
+      if (
+        ownsSurface &&
+        !nonInteractiveSeeds.has(entry.canonical) &&
+        (depth === 'full' || isLeanRoot)
+      ) {
         const sweep = await sweepInteractions(
           lease,
           baseURL,


### PR DESCRIPTION
## Summary

Follow-up to #2362 (already merged as commit `5bcf99dca`), carrying a fix that PR found
but that never made it into the merge — #2362's branch got a second commit pushed to it
after the PR had already been merged, so it's now orphaned. This is that commit,
cherry-picked cleanly onto current `main`.

#2362 fixed a crawl shard-partitioning coverage gap by having a shard inherit ownership
of any surface it discovers exclusively through an interaction (`deriveShardKey`). That
inheritance is correct when a surface truly has only one discovery path, but it is not
always true: `/a/grafana-metricsdrilldown-app/trail` is a seeded, non-interactive
redirector (see its doc comment in `stacks.ts` — driving controls against it drives them
against the `/drilldown` page it already redirected to, a known hazard from `#2170` /
`#2174`). At full depth, `ownsSurface` was the *only* gate on running the interaction
sweep — the `isLeanRoot` check that keeps this off `/trail` at lean depth doesn't apply —
so whichever shard hash-owns `/trail` swept it anyway, inherited ownership of states
`/drilldown`'s own owner independently discovers through the real interaction root, and
both shards' slices ended up claiming the same surface.

This was caught for real: dispatching the k3d crawl against #2362's fix (before this
commit landed) triggered `dashboard-crawl-merge`'s own new disjointness check (also added
by #2362) — `crawl slice 2 claims state
"/a/grafana-metricsdrilldown-app/drilldown?actionView=related&metric={metric}" that an
earlier shard already claimed` (run
https://github.com/tsouza/cerberus/actions/runs/32133767578). All three crawl shards
individually succeeded; only the merge step's cross-shard invariant caught it.

## Fix

Exclude every seed that is *not* also a lean interaction root from the interaction sweep
at any depth, not just lean — derived from stack config (`leanSeedRoots` minus
`leanInteractionRoots`), so it covers `/trail` today and any future alias-only seed
without hardcoding an app path into the engine (`nonInteractiveSeedSet` in
`crawl.spec.ts`).

## Test plan

- [x] `npx tsc --noEmit` — clean.
- [x] 41/41 `crawl.spec.ts` unit tests, including a new one pinning the derivation against
      both registered stacks (asserts no non-interactive seed is ever also an interaction
      root) plus a live regression check that the `/trail` seed lands in the excluded
      set.
- [x] Confirmed live: `owner('/a/grafana-metricsdrilldown-app/drilldown', 3) = 2` while
      `owner('.../trail', 3) = 1` — the exact cross-shard split the real run hit.
- [ ] Real k3d `dashboard-crawl-merge` — dispatched separately on the source branch before
      this PR existed (https://github.com/tsouza/cerberus/actions/runs/32136496771,
      carrying the identical diff); will report the result here once it lands.
