### PR TITLE
chore(release): cerberus v1.15.1 / chart 0.15.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to cerberus will be documented in this file. The format roug
 
 ## [Unreleased]
 
+## [v1.15.1] — 2026-08-18
+
+### Fixed
+
+- **chsql:** materialize native-quantile bucket-edge scans instead of re-deriving them (#2366)
+
+### Performance
+
+- **chsql:** materialise the classic histogram_quantile array walks once per row (#2367)
+
 ## [v1.15.0] — 2026-08-18
 
 ### Added

--- a/deploy/helm/cerberus/Chart.yaml
+++ b/deploy/helm/cerberus/Chart.yaml
@@ -8,11 +8,11 @@ type: application
 # upgrade?" and is the publish trigger: a chart-only fix bumps this without an
 # app re-tag; an app-only release bumps appVersion + a PATCH here for the new
 # default image. Starts 0.x because the values contract is not yet frozen.
-version: 0.15.0
+version: 0.15.1
 
 # appVersion tracks the GA cerberus binary. Quoted so SemVer-shaped values
 # aren't coerced to floats. image.tag defaults from this when left empty.
-appVersion: "1.15.0"
+appVersion: "1.15.1"
 
 # autoscaling/v2 + policy/v1 (PDB) + networking/v1 (Ingress) are all GA from
 # 1.21+; 1.23 is the conservative floor matching the manifests this chart
@@ -45,27 +45,11 @@ annotations:
       url: https://github.com/tsouza/cerberus/blob/main/docs/operations.md
   artifacthub.io/images: |
     - name: cerberus
-      image: ghcr.io/tsouza/cerberus:v1.15.0
+      image: ghcr.io/tsouza/cerberus:v1.15.1
   # Bump the `1.0.0` floor here when the chart raises its minimum supported
   # cerberus release; informational for Artifact Hub's compatibility hints.
   artifacthub.io/changes: |
-    - kind: added
-      description: "promql: scale a histogram by a float-vector MUL/DIV operand (#2343)"
-    - kind: added
-      description: "promql: answer mixed float/histogram and/or/unless operands (#2337)"
-    - kind: added
-      description: "promql: answer 'or' between float and histogram operands (#2335)"
-    - kind: added
-      description: "promql: answer group_left()/group_right() for exp-histogram binops (#2334)"
-    - kind: added
-      description: "promql: answer on()/ignoring() matching and bool modifier for exp-histogram binops (#2329)"
-    - kind: added
-      description: "promql: answer == and != between two exponential histograms (#2323)"
-    - kind: added
-      description: "ci: add forbid-verbatim-concat, catch verbatim() shape-building (#2322)"
-    - kind: added
-      description: "promql: support +/- between two exponential-histogram selectors (#2278)"
-    - kind: added
-      description: "promql: answer scalar * and / over a native-histogram sample (#2179)"
-    - kind: added
-      description: "chplan: add the sealed Fn vocabulary and chsql resolution table (#2176)"
+    - kind: fixed
+      description: "chsql: materialize native-quantile bucket-edge scans instead of re-deriving them (#2366)"
+    - kind: changed
+      description: "chsql: materialise the classic histogram_quantile array walks once per row (#2367)"

--- a/deploy/helm/cerberus/README.md
+++ b/deploy/helm/cerberus/README.md
@@ -5,7 +5,7 @@
      pipe-aligned, and the version footer adds a trailing blank — both are
      owned by helm-docs; realigning would fight the chart-ci drift check. -->
 
-![Version: 0.15.0](https://img.shields.io/badge/Version-0.15.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.15.0](https://img.shields.io/badge/AppVersion-1.15.0-informational?style=flat-square)
+![Version: 0.15.1](https://img.shields.io/badge/Version-0.15.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.15.1](https://img.shields.io/badge/AppVersion-1.15.1-informational?style=flat-square)
 
 Drop-in Prometheus / Loki / Tempo HTTP gateway for ClickHouse — a single stateless gateway that speaks three upstream query wire formats and lowers each to parameterised ClickHouse SQL.
 


### PR DESCRIPTION
Release-prep for **v1.15.1** (chart **0.15.1**), generated by `prepare-release.yml`.

- appVersion 1.15.0 -> 1.15.1, chart 0.15.0 -> 0.15.1

### Changes

### Fixed

- **chsql:** materialize native-quantile bucket-edge scans instead of re-deriving them (#2366)

### Performance

- **chsql:** materialise the classic histogram_quantile array walks once per row (#2367)

Generated from the conventional commits since the last tag. Review and edit before merging; the tag is cut once this lands.
