### PR TITLE
feat(engine): log a WARN line for every non-ok query exit

### DIFF
--- a/docs/observability.md
+++ b/docs/observability.md
@@ -81,15 +81,21 @@ ready`, `signal received, shutting down`, `cerberus stopped`).
 The codebase follows a small set of consistent keys so a future query
 across `otel_logs` can filter without guessing:
 
-| Key                            | Type   | Notes                                                                                                      |
-| ------------------------------ | ------ | ---------------------------------------------------------------------------------------------------------- |
-| `api`                          | string | `prom` / `loki` / `tempo`, set on the per-handler logger via `.With("api", ...)` in `cmd/cerberus/main.go` |
-| `promql` / `logql` / `traceql` | string | The query text as received                                                                                 |
-| `sql`                          | string | The emitted ClickHouse SQL                                                                                 |
-| `args`                         | []any  | Parameterised SQL args                                                                                     |
-| `err`                          | error  | Native `error` value — slog encodes via `.Error()` for json + `%v` for text                                |
-| `trace_id`                     | string | Tempo `traceByID` handler only                                                                             |
-| `tag`                          | string | Tempo tag-values handler                                                                                   |
+| Key                            | Type   | Notes                                                                                                                 |
+| ------------------------------ | ------ | --------------------------------------------------------------------------------------------------------------------- |
+| `api`                          | string | `prom` / `loki` / `tempo`, set on the per-handler logger via `.With("api", ...)` in `cmd/cerberus/main.go`            |
+| `promql` / `logql` / `traceql` | string | The query text as received                                                                                            |
+| `sql`                          | string | The emitted ClickHouse SQL                                                                                            |
+| `args`                         | []any  | Parameterised SQL args                                                                                                |
+| `err`                          | error  | Native `error` value — slog encodes via `.Error()` for json + `%v` for text                                           |
+| `trace_id`                     | string | Tempo `traceByID` handler only                                                                                        |
+| `tag`                          | string | Tempo tag-values handler                                                                                              |
+| `cerberus_ql`                  | string | `promql` / `logql` / `traceql`, on the query-failure log line (§"Query failure log line")                             |
+| `shape_id`                     | string | The literal-free `cerb:<root>[;mod...]` plan shape id (`internal/engine.planShapeID`), same line                      |
+| `decision_reason`              | string | The sharded-pushdown solver's `Reason` for this dispatch, or `""` when no classification ran, same line               |
+| `exit_class`                   | string | The failure class (`timeout` / `oom` / `sample_budget` / `byte_budget` / `breaker` / `canceled` / `error`), same line |
+| `duration_ms`                  | int64  | Wall-clock milliseconds the failing dispatch ran for, same line                                                       |
+| `query_id`                     | string | The ClickHouse `query_id` (the join key into `system.query_log`), same line, empty when dispatch never reached CH     |
 
 Always pass the native `error` as `"err", err` rather than `err.Error()`
 so a future `slog.Handler` middleware can branch on `errors.As` /
@@ -365,6 +371,60 @@ degrading: an export failure means the gateway has lost its OWN
 telemetry, which is precisely what an operator reaches for when
 diagnosing a failure. The fixed message plus the `component` field make
 the rate of these expressible as an alert.
+
+### Query failure log line
+
+Before this, a query that failed against ClickHouse — a timeout, an
+OOM / memory-limit abort, a ClickHouse exception, a caller cancellation,
+or any other non-`ok` exit — left no trace in `kubectl logs` at all. The
+only record was cerberus's own ClickHouse-side performance corpus
+(`internal/optcorpus`, `docs/router-rules.md`), which is off by default
+(`CERBERUS_CH_OPT_CORPUS_ENABLED`) and, even when on, is written on an
+interval into a table an operator troubleshooting "things are slow" has
+no reason to think of querying. A routine incident investigation ended
+up as a multi-hour ClickHouse-side deep-dive instead of a five-minute
+`grep`.
+
+`internal/engine` now logs one `WARN`-level, structured line at every
+seam where a dispatched query's outcome resolves to something other
+than a clean finish — the eager `Query` / `QueryPlan` path (every PromQL
+instant query, every LogQL query, every eager TraceQL query), the
+streaming `QueryCursor` / `QueryPlanCursor` path's open-time and
+mid-drain failures (the Prom `/query_range` matrix path), and the
+dormant sharded-pushdown route-B path. It never fires for a query that
+completes cleanly — logging every successful query would be a
+production log-volume problem, not an observability improvement — and
+it fires unconditionally, independent of whether the corpus reconciler
+is even registered, so the gap does not silently reopen on a deployment
+that never turned the corpus on.
+
+```json
+{"level":"WARN","msg":"cerberus query failed","cerberus_ql":"promql","shape_id":"cerb:project;agg=1;rw","decision_reason":"","exit_class":"timeout","duration_ms":30012,"query_id":"a1b2c3-...-4","err":"engine: execute: query execution timeout exceeded"}
+```
+
+The classification (`exit_class`) reuses the exact same predicates the
+corpus already uses to classify a cerberus-side outcome
+(`sample_budget` / `byte_budget` / `breaker` / `oom`), widened with the
+two classes only a synchronous caller can see (`timeout` / `canceled`)
+and the honest `error` floor for a ClickHouse exception that matches
+none of the above — so the log line and the corpus row for the SAME
+failure can never name a different cause. `shape_id` and
+`decision_reason` are empty rather than fabricated at the one call site
+with no plan/decision in scope (a mid-drain failure reported back from
+the handler, which owns the drain and has no plan reference).
+`duration_ms` and `query_id` are logged because they are already known
+at every call site at zero extra cost; the per-query ClickHouse memory
+usage the corpus's `system.query_log` join eventually learns is
+deliberately NOT fetched here — doing so would mean an extra ClickHouse
+round trip on every failure, which this line exists to avoid, not add.
+
+Deliberately `WARN`, not `ERROR`: most non-`ok` exits here are not
+cerberus defects (a caller cancelling, a query that ran into its own
+configured budget) rather than something "worth a page" the way this
+page's `ERROR` vocabulary above describes. A genuine cerberus defect
+still reaches `ERROR` through its own existing site (the recovered-panic
+log in `telemetry.QueryMiddleware`); this line's job is visibility, not
+alerting.
 
 ### Resource attributes
 

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -72,7 +72,11 @@ ready`, `signal received, shutting down`, `cerberus stopped`).
   by the peer in the Loki `/tail` handler), plus degradation of a
   background subsystem — a dropped self-telemetry export, an optcorpus
   sink write that failed. Carries `component` so the subsystem is
-  selectable.
+  selectable. Also every query that did NOT complete cleanly — a
+  timeout, an OOM abort, a ClickHouse exception, a caller cancellation
+  (§"Query failure log line") — even though the request itself failed:
+  most of these are not cerberus defects, so `Error`'s alerting posture
+  would misclassify them.
 - **`Error`** — handler-level failures that produce a 5xx (CH connection
   reset, plan emission internal error). The bridge to alerting.
 

--- a/internal/api/prom/handler.go
+++ b/internal/api/prom/handler.go
@@ -596,6 +596,7 @@ func (h *Handler) handleQueryRange(w http.ResponseWriter, r *http.Request) {
 	})
 	defer closeOriginal()
 
+	drainStart := time.Now()
 	matrixResult, drainErr := matrixFromCursor(result.Cursor, start, end, step)
 	if drainErr == nil {
 		// The failure-driven route memo's unconditional bookkeeping hook —
@@ -635,7 +636,7 @@ func (h *Handler) handleQueryRange(w http.ResponseWriter, r *http.Request) {
 	// — surface the ORIGINAL drain error exactly as before this mechanism
 	// existed. See the comment on h.respondRangeRetry's own drain-failure
 	// path for why this is stamped onto the corpus the same way.
-	h.Engine.ObserveDrainOutcome(result.QueryID, "promql", drainErr)
+	h.Engine.ObserveDrainOutcome(result.QueryID, "promql", time.Since(drainStart), drainErr)
 	h.respondError(w, classifyDrainError(drainErr))
 }
 
@@ -686,6 +687,7 @@ func (h *Handler) respondRangeRetry(
 	})
 	defer closeRetry()
 
+	drainStart := time.Now()
 	retryMatrix, retryErr := matrixFromCursor(retryResult.Cursor, start, end, step)
 	if retryErr == nil {
 		if retryResult.ObserveDrainOutcome != nil {
@@ -703,7 +705,7 @@ func (h *Handler) respondRangeRetry(
 	// retained, exit overridden); a memory-cap abort is recorded
 	// terminally so the corpus does not depend on the query_log join
 	// landing a row.
-	h.Engine.ObserveDrainOutcome(retryResult.QueryID, "promql", retryErr)
+	h.Engine.ObserveDrainOutcome(retryResult.QueryID, "promql", time.Since(drainStart), retryErr)
 	h.respondError(w, classifyDrainError(retryErr))
 }
 

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -27,6 +27,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log/slog"
 	"math"
 	"sort"
 	"strconv"
@@ -373,7 +374,10 @@ const (
 // path. No-op when no observer is registered (the default hot path is
 // byte-unchanged).
 func (e *Engine) observeOutcomeForErr(queryID, language string, plan chplan.Node, decision *solver.Decision, err error) {
-	if e.QueryObserver == nil || err == nil {
+	if err == nil {
+		return
+	}
+	if e.QueryObserver == nil {
 		return
 	}
 	switch token := outcomeTokenForErr(err); token {
@@ -386,6 +390,108 @@ func (e *Engine) observeOutcomeForErr(queryID, language string, plan chplan.Node
 	case optcorpusExitOOM:
 		e.observeDispatchedRejection(queryID, language, plan, decision, optcorpusExitOOM)
 	}
+}
+
+// Synchronous exit classes logQueryFailure names that outcomeTokenForErr
+// cannot: a caller-visible timeout / cancellation, or the honest floor for a
+// ClickHouse exception (or any other dispatch error) that matches none of
+// outcomeTokenForErr's cerberus-side outcomes. "error" mirrors
+// optcorpus.ExitError's own reading — state that the query failed without
+// inventing a cause — and "timeout" / "canceled" mirror the wire-shape names
+// internal/api/prom's own queryTimeoutAPIError / queryCanceledAPIError use for
+// the same two error classes, so an operator correlating the log line against
+// the HTTP response sees matching vocabulary. Deliberately NOT combined with
+// the optcorpusExit* consts above: those name the corpus's ExitStatus wire
+// contract (a Row field with its own DDL), while these two name only this log
+// line's own attribute, so a future ExitStatus rename cannot silently rename
+// what operators grep for in kubectl logs.
+const (
+	logExitTimeout  = "timeout"
+	logExitCanceled = "canceled"
+	logExitError    = "error"
+)
+
+// queryFailureClass classifies a dispatch error into the small, stable label
+// logQueryFailure attaches to a non-ok-exit log line. It starts from
+// outcomeTokenForErr — the exact same predicates the corpus already uses to
+// classify a cerberus-side outcome (sample_budget / byte_budget / breaker /
+// oom) — so the class a query is logged under can never name a different
+// cause than the corpus row the SAME error produces. It then widens the
+// vocabulary with the classes only a synchronous caller can see: a wall-clock
+// timeout (ClickHouse's own TIMEOUT_EXCEEDED or the handler's context
+// deadline), a caller-initiated cancellation, and the honest "error" floor
+// for a ClickHouse exception that matches none of the above — never
+// invented, exactly the same discipline optcorpus.ExitError documents for
+// the query_log-derived path.
+func queryFailureClass(err error) string {
+	if token := outcomeTokenForErr(err); token != "" {
+		return token
+	}
+	switch {
+	case errors.Is(err, chclient.ErrQueryTimeout), errors.Is(err, context.DeadlineExceeded):
+		return logExitTimeout
+	case errors.Is(err, context.Canceled):
+		return logExitCanceled
+	default:
+		return logExitError
+	}
+}
+
+// logQueryFailureMsg is the fixed message every non-ok-exit log line carries,
+// so `kubectl logs | grep` (or an aggregator query) can find every one of
+// them with one literal string regardless of exit class.
+const logQueryFailureMsg = "cerberus query failed"
+
+// logQueryFailure emits the WARN-level structured log line for a query that
+// did NOT complete cleanly: a timeout, a memory-limit / OOM abort, a
+// ClickHouse exception, a caller cancellation, or any other non-ok exit. It
+// is the fix for a production gap where two live replicas logged eleven
+// INFO-level startup lines across an investigation window that included
+// dozens of failing queries — none of them visible via kubectl logs, because
+// the only record of a failure lived in the OPTIONAL, interval-driven
+// ClickHouse-side corpus (internal/optcorpus, off unless
+// CERBERUS_CH_OPT_CORPUS_ENABLED is set) rather than in the log stream every
+// deployment already collects.
+//
+// It hangs off the exact classification the corpus already computes for the
+// cerberus-side outcomes (queryFailureClass wraps outcomeTokenForErr) so the
+// two can never name a different cause for the same failure, and it fires
+// unconditionally — independent of whether the corpus reconciler is even
+// registered — so the gap it closes does not silently reopen on a deployment
+// that never turned the corpus on.
+//
+// plan is nil at the one call site with no plan in scope (the handler-side
+// cursor-drain seam, see Engine.ObserveDrainOutcome): shapeID is then ""
+// rather than fabricated. decision is nil whenever no routing classification
+// ran (Solver off, or a non-PromQL head); routeFeatures already reports that
+// case as an empty decision_reason rather than guessing.
+//
+// Deliberately WARN, never ERROR: most non-ok exits here are not cerberus
+// defects (a caller cancelling, a query that ran into its own configured
+// budget) and docs/observability.md reserves ERROR for handler-level
+// failures that are themselves "worth a page." A genuine cerberus defect
+// still reaches ERROR via its own existing site (e.g. the recovered-panic
+// log in telemetry.QueryMiddleware); this line's job is visibility, not
+// alerting.
+func (e *Engine) logQueryFailure(language string, plan chplan.Node, decision *solver.Decision, duration time.Duration, queryID string, err error) {
+	if err == nil {
+		return
+	}
+	shapeID := ""
+	if plan != nil {
+		shapeID = planShapeID(plan)
+	}
+	_, _, _, _, _, _, _, _, reason := routeFeatures(language, decision)
+	slog.Default().Warn(
+		logQueryFailureMsg,
+		"cerberus_ql", language,
+		"shape_id", shapeID,
+		"decision_reason", reason,
+		"exit_class", queryFailureClass(err),
+		"duration_ms", duration.Milliseconds(),
+		"query_id", queryID,
+		"err", err,
+	)
 }
 
 // observeRejection records a decision-only corpus row for a request rejected
@@ -1154,6 +1260,7 @@ func (e *Engine) QueryPlan(ctx context.Context, lang Lang, plan chplan.Node, met
 		// sample-budget 422 (or a breaker fast-fail) surfaces here. Stamp the
 		// cerberus-side outcome onto the corpus before wrapping the error.
 		e.observeOutcomeForErr(queryID, lang.Name(), plan, decision, err)
+		e.logQueryFailure(lang.Name(), plan, decision, time.Since(start), queryID, err)
 		return Result{}, fmt.Errorf("engine: execute: %w", err)
 	}
 
@@ -1286,6 +1393,7 @@ func (e *Engine) executeRouted(
 	)
 	if err != nil {
 		execT.Done(ctx)
+		e.logQueryFailure(lang.Name(), plan, decision, time.Since(start), "", err)
 		return Result{}, fmt.Errorf("engine: solver execute: %w", err)
 	}
 	// Record the fan-out at its dispatch seam, symmetrically with route A's
@@ -1301,6 +1409,7 @@ func (e *Engine) executeRouted(
 	}
 	if cerr := cursor.Err(); cerr != nil {
 		execT.Done(ctx)
+		e.logQueryFailure(lang.Name(), plan, decision, time.Since(start), routedQueryID(info), cerr)
 		return Result{}, fmt.Errorf("engine: solver drain: %w", cerr)
 	}
 	chMillis := time.Since(start).Milliseconds()
@@ -1504,6 +1613,7 @@ func (e *Engine) QueryPlanCursor(ctx context.Context, lang Lang, plan chplan.Nod
 		return result, nil
 	}
 
+	dispatchStart := time.Now()
 	result, err := e.dispatchRouteACursor(ctx, lang, meta, plan, decision)
 	if err != nil {
 		return CursorResult{}, err
@@ -1522,8 +1632,12 @@ func (e *Engine) QueryPlanCursor(ctx context.Context, lang Lang, plan chplan.Nod
 		}
 		// The sample-budget 422 instead surfaces later during the handler's
 		// drain via ObserveDrainOutcome. Stamp any cerberus-side open-time
-		// outcome here.
+		// outcome here. The A->B retry above declined (or wasn't eligible),
+		// so this request will not get a clean answer — log it now rather
+		// than at the retry site, where it would double-count a failure the
+		// retry went on to recover from.
 		e.observeOutcomeForErr(result.queryID, lang.Name(), plan, decision, err)
+		e.logQueryFailure(lang.Name(), plan, decision, time.Since(dispatchStart), result.queryID, err)
 		return CursorResult{}, fmt.Errorf("engine: execute: %w", err)
 	}
 
@@ -1690,19 +1804,28 @@ func routedQueryID(info *solver.ExecInfo) string {
 }
 
 // ObserveDrainOutcome stamps a CERBERUS-side terminal outcome that surfaced
-// while the handler drained a cursor onto the corpus record for queryID. It is
-// the cursor-path sibling of the eager path's in-engine observeOutcomeForErr:
-// the drain happens in the handler, so the handler calls this with the
-// CursorResult.QueryID and the drain error. The sample-budget 422 (fires after a
-// clean CH finish) is stamped via ObserveOutcome so the reconciler keeps the
-// joined cost and overrides exit_status; a memory-cap abort (CH code 241,
-// "oom") surfacing mid-drain is recorded as a dispatched rejection so the row
-// lands even if the query_log join misses. No-op when no observer is registered,
-// the queryID is empty, or the error is not a recorded outcome. The drain site
-// has no plan/decision, so the dispatched-rejection row carries the language but
-// no routing read-out (routePresent=false) — exit_status stays the operator signal.
-func (e *Engine) ObserveDrainOutcome(queryID, language string, err error) {
-	if e.QueryObserver == nil || queryID == "" || err == nil {
+// while the handler drained a cursor onto the corpus record for queryID, and
+// — independently of whether the corpus is even enabled — logs the failure
+// (see logQueryFailure). It is the cursor-path sibling of the eager path's
+// in-engine observeOutcomeForErr: the drain happens in the handler, so the
+// handler calls this with the CursorResult.QueryID, how long the drain ran,
+// and the drain error. The sample-budget 422 (fires after a clean CH finish)
+// is stamped via ObserveOutcome so the reconciler keeps the joined cost and
+// overrides exit_status; a memory-cap abort (CH code 241, "oom") surfacing
+// mid-drain is recorded as a dispatched rejection so the row lands even if
+// the query_log join misses. The corpus stamp is skipped when no observer is
+// registered, the queryID is empty, or the error is not a recorded cerberus-
+// side outcome — the log line has no such gate, since it is not conditioned
+// on the corpus at all. The drain site has no plan/decision, so both the
+// dispatched-rejection row and the log line carry the language but no
+// routing read-out / shape id — exit_status / exit_class stay the operator
+// signal.
+func (e *Engine) ObserveDrainOutcome(queryID, language string, duration time.Duration, err error) {
+	if err == nil {
+		return
+	}
+	e.logQueryFailure(language, nil, nil, duration, queryID, err)
+	if e.QueryObserver == nil || queryID == "" {
 		return
 	}
 	switch token := outcomeTokenForErr(err); token {
@@ -1751,11 +1874,13 @@ func (e *Engine) executeRoutedCursor(
 		return CursorResult{}, fmt.Errorf("engine: solver routed without an Executor")
 	}
 	execT := telemetry.ObserveStage(telemetry.StageExecute, lang.Name())
+	start := time.Now()
 	cursor, info, err := e.Solver.Executor.Execute(
 		routeBExecCtx(ctx, lang.Name(), meta.ResponseShape, decision), lang.Name(), decision, chclient.SampleBudgetFromContext(ctx),
 	)
 	execT.Done(ctx)
 	if err != nil {
+		e.logQueryFailure(lang.Name(), plan, decision, time.Since(start), "", err)
 		return CursorResult{}, fmt.Errorf("engine: solver execute: %w", err)
 	}
 	// Dispatch seam for the streaming route-B path (the caller owns the drain,

--- a/internal/engine/engine_test.go
+++ b/internal/engine/engine_test.go
@@ -664,10 +664,10 @@ func TestEngine_ObserveDrainOutcome(t *testing.T) {
 	eng := newEngine(&fakeQuerier{})
 	eng.QueryObserver = obs
 
-	eng.ObserveDrainOutcome("qid-d", "promql", chclient.ErrTooManySamples)
-	eng.ObserveDrainOutcome("qid-d", "promql", nil)                     // no-op
-	eng.ObserveDrainOutcome("", "promql", chclient.ErrTooManySamples)   // no-op
-	eng.ObserveDrainOutcome("qid-d", "promql", errors.New("transport")) // no-op
+	eng.ObserveDrainOutcome("qid-d", "promql", 0, chclient.ErrTooManySamples)
+	eng.ObserveDrainOutcome("qid-d", "promql", 0, nil)                     // no-op
+	eng.ObserveDrainOutcome("", "promql", 0, chclient.ErrTooManySamples)   // no-op on the corpus seam (empty id); still logged
+	eng.ObserveDrainOutcome("qid-d", "promql", 0, errors.New("transport")) // no-op on the corpus seam (unclassified error); still logged
 
 	if len(obs.outcomes) != 1 {
 		t.Fatalf("ObserveOutcome calls = %d; want exactly 1", len(obs.outcomes))
@@ -681,7 +681,7 @@ func TestEngine_ObserveDrainOutcome(t *testing.T) {
 
 	// A memory-cap abort surfacing mid-drain is recorded as a dispatched
 	// rejection (terminal, zero cost), carrying the language and the query_id.
-	eng.ObserveDrainOutcome("qid-oom", "logql", chclient.ErrMemoryLimitExceeded)
+	eng.ObserveDrainOutcome("qid-oom", "logql", 0, chclient.ErrMemoryLimitExceeded)
 	if len(obs.dispatchedRej) != 1 {
 		t.Fatalf("ObserveDispatchedRejection calls = %d; want 1", len(obs.dispatchedRej))
 	}
@@ -720,7 +720,7 @@ func TestEngine_ObserveDrainOutcome_ByteBudget(t *testing.T) {
 			eng := newEngine(&fakeQuerier{})
 			eng.QueryObserver = obs
 
-			eng.ObserveDrainOutcome("qid-bytes", "promql", tc.err)
+			eng.ObserveDrainOutcome("qid-bytes", "promql", 0, tc.err)
 
 			if len(obs.outcomes) != 1 {
 				t.Fatalf("ObserveOutcome calls = %d; want exactly 1", len(obs.outcomes))
@@ -783,7 +783,7 @@ func TestEngine_NoObserver_OutcomeNoop(t *testing.T) {
 		t.Fatal("expected error")
 	}
 	eng.ObserveCapRejection("promql")
-	eng.ObserveDrainOutcome("x", "promql", chclient.ErrTooManySamples)
+	eng.ObserveDrainOutcome("x", "promql", 0, chclient.ErrTooManySamples)
 }
 
 // scanRewriteRule is a probe rule for the IsTraceByID test: it

--- a/internal/engine/query_failure_log_test.go
+++ b/internal/engine/query_failure_log_test.go
@@ -1,0 +1,211 @@
+package engine_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"log/slog"
+	"testing"
+
+	"github.com/tsouza/cerberus/internal/chclient"
+)
+
+// decodeLogRecords parses the JSON lines a slog.JSONHandler wrote, mirroring
+// internal/telemetry's own test helper (there is no shared one to import
+// without creating a test-only dependency between the two packages).
+func decodeLogRecords(t *testing.T, buf *bytes.Buffer) []map[string]any {
+	t.Helper()
+	var out []map[string]any
+	dec := json.NewDecoder(bytes.NewReader(buf.Bytes()))
+	for dec.More() {
+		var rec map[string]any
+		if err := dec.Decode(&rec); err != nil {
+			t.Fatalf("decode log record: %v", err)
+		}
+		out = append(out, rec)
+	}
+	return out
+}
+
+// withCapturedDefaultLog swaps slog's package-global default logger for a
+// JSON handler writing into buf, for the duration of the test. logQueryFailure
+// (internal/engine/engine.go) logs through slog.Default() — the same
+// convention internal/telemetry/errorhandler.go and internal/config/config.go
+// already use for a subsystem that has no logger of its own threaded to it —
+// so this is the only seam available to observe it.
+func withCapturedDefaultLog(t *testing.T) *bytes.Buffer {
+	t.Helper()
+	var buf bytes.Buffer
+	prev := slog.Default()
+	t.Cleanup(func() { slog.SetDefault(prev) })
+	slog.SetDefault(slog.New(slog.NewJSONHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug})))
+	return &buf
+}
+
+// findQueryFailureRecords filters decoded records down to the ones this
+// change's log line produces, so a test isn't tripped up by an unrelated WARN
+// some other subsystem emits incidentally during the same run.
+func findQueryFailureRecords(records []map[string]any) []map[string]any {
+	var out []map[string]any
+	for _, r := range records {
+		if r["msg"] == "cerberus query failed" {
+			out = append(out, r)
+		}
+	}
+	return out
+}
+
+// TestLogQueryFailure_EagerDispatchError is the core regression this change
+// exists for: a production incident found cerberus emitted NO application log
+// for a query that failed against ClickHouse — timeouts, OOMs, aborts were
+// visible only by querying cerberus's own ClickHouse-side telemetry table
+// directly. A dispatch error on the eager engine.Query path (the path every
+// PromQL instant query, every LogQL query, and every eager TraceQL query
+// funnels through) must now produce exactly one WARN-level, structured log
+// line naming the failure.
+func TestLogQueryFailure_EagerDispatchError(t *testing.T) {
+	buf := withCapturedDefaultLog(t)
+
+	q := &fakeQuerier{err: chclient.ErrQueryTimeout}
+	lang := &fakeLang{name: "promql"}
+	eng := newEngine(q)
+
+	if _, err := eng.Query(context.Background(), lang, "up"); err == nil {
+		t.Fatal("Query: expected an error from the dispatch")
+	}
+
+	records := findQueryFailureRecords(decodeLogRecords(t, buf))
+	if len(records) != 1 {
+		t.Fatalf("cerberus query failed records = %d; want exactly 1 (log: %s)", len(records), buf.String())
+	}
+	rec := records[0]
+
+	if got := rec["level"]; got != "WARN" {
+		t.Errorf("level = %v; want WARN", got)
+	}
+	if got := rec["cerberus_ql"]; got != "promql" {
+		t.Errorf("cerberus_ql = %v; want promql", got)
+	}
+	// planShapeID is literal-free by design (docs: no metric names, no label
+	// values) — the assertion is on the stable "cerb:" namespace prefix, not
+	// on the query's own literals.
+	shapeID, _ := rec["shape_id"].(string)
+	if shapeID == "" || shapeID[:5] != "cerb:" {
+		t.Errorf("shape_id = %q; want a non-empty cerb:-prefixed shape id", shapeID)
+	}
+	if got := rec["exit_class"]; got != "timeout" {
+		t.Errorf("exit_class = %v; want timeout", got)
+	}
+	if _, ok := rec["duration_ms"]; !ok {
+		t.Error("duration_ms: missing")
+	}
+	if _, ok := rec["query_id"]; !ok {
+		t.Error("query_id: missing")
+	}
+	errField, ok := rec["err"].(string)
+	if !ok || errField == "" {
+		t.Errorf("err = %v; want the native error's message", rec["err"])
+	}
+	// decision_reason is present (possibly empty-string) rather than absent —
+	// the Solver is nil in this test (unclassified head), which routeFeatures
+	// reports as an empty reason, not a missing key.
+	if _, ok := rec["decision_reason"]; !ok {
+		t.Error("decision_reason: missing key (want present, even if empty)")
+	}
+}
+
+// TestLogQueryFailure_SuccessfulQuery_NoLog is the volume-discipline half of
+// the same change: a clean query must NEVER produce this log line, or every
+// production deployment would pay a per-query logging cost for the common
+// case the task explicitly rules out.
+func TestLogQueryFailure_SuccessfulQuery_NoLog(t *testing.T) {
+	buf := withCapturedDefaultLog(t)
+
+	q := &fakeQuerier{rows: []chclient.Sample{{MetricName: "up", Value: 1}}}
+	lang := &fakeLang{name: "promql"}
+	eng := newEngine(q)
+
+	if _, err := eng.Query(context.Background(), lang, "up"); err != nil {
+		t.Fatalf("Query: unexpected err: %v", err)
+	}
+
+	if records := findQueryFailureRecords(decodeLogRecords(t, buf)); len(records) != 0 {
+		t.Errorf("cerberus query failed records = %d; want 0 on a clean query (log: %s)", len(records), buf.String())
+	}
+}
+
+// TestLogQueryFailure_CursorDrainError pins the streaming sibling: a range
+// query's cursor drain fails in the HANDLER (outside the engine package
+// entirely), and the handler reports it back through
+// Engine.ObserveDrainOutcome — the same seam that stamps the ClickHouse-side
+// corpus. The log line must fire from that seam too, and must fire whether or
+// not the corpus observer is even registered (most deployments run with
+// CERBERUS_CH_OPT_CORPUS_ENABLED unset).
+func TestLogQueryFailure_CursorDrainError(t *testing.T) {
+	buf := withCapturedDefaultLog(t)
+
+	eng := newEngine(&fakeQuerier{})
+	// No QueryObserver registered — the default hot path.
+
+	eng.ObserveDrainOutcome("qid-drain", "promql", 0, chclient.ErrMemoryLimitExceeded)
+
+	records := findQueryFailureRecords(decodeLogRecords(t, buf))
+	if len(records) != 1 {
+		t.Fatalf("cerberus query failed records = %d; want exactly 1 (log: %s)", len(records), buf.String())
+	}
+	rec := records[0]
+	if got := rec["exit_class"]; got != "oom" {
+		t.Errorf("exit_class = %v; want oom", got)
+	}
+	if got := rec["query_id"]; got != "qid-drain" {
+		t.Errorf("query_id = %v; want qid-drain", got)
+	}
+	// The drain seam has no plan in scope (see logQueryFailure's doc comment):
+	// shape_id must be honestly empty, never fabricated.
+	if got, ok := rec["shape_id"]; !ok || got != "" {
+		t.Errorf("shape_id = %v; want empty string (no plan at the drain seam)", got)
+	}
+}
+
+// TestLogQueryFailure_CursorDrain_NilErrorNoLog mirrors the success-path
+// no-log guard for the drain seam: a clean drain (nil error) must not log.
+func TestLogQueryFailure_CursorDrain_NilErrorNoLog(t *testing.T) {
+	buf := withCapturedDefaultLog(t)
+
+	eng := newEngine(&fakeQuerier{})
+	eng.ObserveDrainOutcome("qid-drain", "promql", 0, nil)
+
+	if records := findQueryFailureRecords(decodeLogRecords(t, buf)); len(records) != 0 {
+		t.Errorf("cerberus query failed records = %d; want 0 on a clean drain (log: %s)", len(records), buf.String())
+	}
+}
+
+// TestLogQueryFailure_UnclassifiedError pins the honest floor: a ClickHouse
+// exception (or any error) that matches none of outcomeTokenForErr's
+// cerberus-side outcomes and none of the synchronous timeout/cancel checks
+// still produces the log line, classified "error" rather than being silently
+// dropped — this is precisely the class of failure (a plain CH exception)
+// the production incident found invisible.
+func TestLogQueryFailure_UnclassifiedError(t *testing.T) {
+	buf := withCapturedDefaultLog(t)
+
+	q := &fakeQuerier{err: errors.New("Code: 999. DB::Exception: something exploded")}
+	lang := &fakeLang{name: "logql"}
+	eng := newEngine(q)
+
+	if _, err := eng.Query(context.Background(), lang, "{app=\"x\"}"); err == nil {
+		t.Fatal("Query: expected an error from the dispatch")
+	}
+
+	records := findQueryFailureRecords(decodeLogRecords(t, buf))
+	if len(records) != 1 {
+		t.Fatalf("cerberus query failed records = %d; want exactly 1 (log: %s)", len(records), buf.String())
+	}
+	if got := records[0]["exit_class"]; got != "error" {
+		t.Errorf("exit_class = %v; want error", got)
+	}
+	if got := records[0]["cerberus_ql"]; got != "logql" {
+		t.Errorf("cerberus_ql = %v; want logql", got)
+	}
+}

--- a/internal/engine/routed_corpus_observe_test.go
+++ b/internal/engine/routed_corpus_observe_test.go
@@ -339,7 +339,7 @@ func TestExecuteRoutedCursor_DrainOutcomeUsesLogicalRouteBRecord(t *testing.T) {
 		t.Fatalf("routed cursor QueryID %q is not one of the logical record's shard ids %v", cr.QueryID, routed[0])
 	}
 
-	eng.ObserveDrainOutcome(cr.QueryID, solver.LangPromQL, chclient.ErrTooManySamples)
+	eng.ObserveDrainOutcome(cr.QueryID, solver.LangPromQL, 0, chclient.ErrTooManySamples)
 	obs.mu.Lock()
 	defer obs.mu.Unlock()
 	if len(obs.outcomes) != 1 {


### PR DESCRIPTION
## Summary

A production incident investigation found that cerberus emits essentially no
application-level logging: two live replicas logged eleven INFO-level startup
lines total across an entire investigation window that included dozens of
live query failures (timeouts, OOMs, aborts). None of that failure
information was visible via `kubectl logs` — the only record lived in
cerberus's own ClickHouse-side performance corpus (`internal/optcorpus`),
which is off by default and, even when enabled, is written on an interval
into a table nobody troubleshooting "things are slow" would think to query.
A routine investigation turned into a multi-hour ClickHouse-side deep-dive
instead of a five-minute `grep`.

This PR adds one `WARN`-level, structured log line whenever a query does
**not** complete cleanly — timeout, OOM/memory-limit exceeded, ClickHouse
exception, context-cancelled, circuit-breaker rejection, or any other
non-`ok` exit. It intentionally does **not** log successful queries (that
would be a production log-volume problem, not an improvement).

- Chokepoint: `internal/engine`, at every seam where a dispatched query's
  outcome is already resolved for the corpus (`observeOutcomeForErr`,
  `ObserveDrainOutcome`, and the two dormant sharded-pushdown execute/drain
  sites) — the same place the router-corpus row is built, so the log line
  and the corpus row can never name a different cause for the same failure.
  This covers the eager path (every PromQL instant query, every LogQL query,
  every eager TraceQL query) and the streaming path (Prom's `/query_range`
  matrix cursor, both open-time and mid-drain failures).
- Fields: `cerberus_ql` (promql/logql/traceql), `shape_id` (the existing
  literal-free `cerb:<root>[;mod...]` plan shape id), `decision_reason` (the
  solver's routing `Reason`, empty when unclassified), `exit_class`
  (`timeout` / `oom` / `sample_budget` / `byte_budget` / `breaker` /
  `canceled` / `error`), `duration_ms`, `query_id`, and the native `err`.
  Memory usage is deliberately **not** fetched here — it is not available
  synchronously without an extra ClickHouse round trip, which would add the
  exact cost this change exists to avoid; it remains visible via the
  existing corpus/`system.query_log` path when that's enabled.
- Fires unconditionally, independent of whether the corpus reconciler is
  registered (`CERBERUS_CH_OPT_CORPUS_ENABLED` is off by default), so the
  visibility gap does not silently reopen on a deployment that never turned
  the corpus on.
- `WARN`, not `ERROR`: most non-`ok` exits here are not cerberus defects (a
  caller cancelling, a query hitting its own configured budget), matching
  this repo's existing WARN-vs-ERROR convention in `docs/observability.md`.
  A genuine cerberus defect still reaches `ERROR` through its own existing
  site (the recovered-panic log in `telemetry.QueryMiddleware`).
- `docs/observability.md` documents the new log line and its fields.

## Test plan

- [x] `go build ./...`
- [x] `go test -race ./internal/engine/...` — new tests assert the log line
      fires exactly once on a dispatch failure, on a cursor-drain failure,
      and on an unclassified ClickHouse exception, and does **not** fire on
      a clean query or a clean drain.
- [x] `go test -race ./internal/api/... ./internal/chclient/... ./cmd/...`
      (packages touched or exercising the changed `Engine.ObserveDrainOutcome`
      signature) — all green.
- [x] `just lint-md` — clean.
- [x] `node .github/scripts/forbid-sql-raw.mjs` / `forbid-skip.mjs` — clean.
- [x] `just fmt` — no additional changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
