### PR TITLE
fix(chclient): stop clickhouse-go from clobbering the query timeout setting

### DIFF
--- a/internal/chclient/client.go
+++ b/internal/chclient/client.go
@@ -892,8 +892,14 @@ var queryIDCounter atomic.Uint64
 // active trace. clickhouse.Context merges per-option with any QueryOptions
 // already on ctx (e.g. the progress callback installed by
 // WithProgressFor), so stacking is safe and the existing options are
-// preserved. When neither a setting nor a query_id is available the ctx
-// is returned unchanged.
+// preserved.
+//
+// The returned context also hides its own Deadline() from anything reading
+// it downstream — see hiddenDeadlineContext for why: clickhouse-go/v2
+// otherwise derives its OWN `max_execution_time` from ctx's Deadline() and
+// silently overwrites whatever this method just computed, which structurally
+// prevents ClickHouse's clean server-side timeout abort from ever winning
+// the race against the caller's own ctx cancellation.
 //
 // The query_id is computed ONCE here, stored on the returned context, and
 // reused by queryIDFromContext, so the value stamped via WithQueryID is the
@@ -905,6 +911,7 @@ var queryIDCounter atomic.Uint64
 func (c *Client) queryContext(ctx context.Context) context.Context {
 	s := c.querySettings(ctx)
 	queryID, ctx := ensureQueryID(ctx)
+	ctx = hiddenDeadlineContext(ctx)
 	if s == nil && queryID == "" {
 		return ctx
 	}

--- a/internal/chclient/query_timeout_clean_cancel_integration_test.go
+++ b/internal/chclient/query_timeout_clean_cancel_integration_test.go
@@ -1,0 +1,199 @@
+//go:build integration
+
+package chclient_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	tcclickhouse "github.com/testcontainers/testcontainers-go/modules/clickhouse"
+
+	"github.com/tsouza/cerberus/internal/chclient"
+)
+
+// chTimeoutExceededCode is ClickHouse's TIMEOUT_EXCEEDED server error code
+// (159): the clean, designed-for-purpose abort a query's own
+// `max_execution_time` setting raises. This is what a client-configured
+// query timeout is SUPPOSED to end in.
+const chTimeoutExceededCode = 159
+
+// TestQueryTimeout_ServerSideCleanAbort pins the fix for a production
+// incident: ClickHouse logging `NetException: Unknown packet from client` /
+// "Client has dropped the connection" for queries that had already run past
+// cerberus's own configured query timeout, instead of the clean
+// TIMEOUT_EXCEEDED (code 159) abort the `max_execution_time` setting exists
+// to produce — meaning ClickHouse kept doing (sometimes multi-GB) work for a
+// client that had already walked away, with no protocol-level signal telling
+// it to stop.
+//
+// Root cause: reqctx.ApplyQueryTimeout stamps the SAME budget onto both
+// chclient.WithQueryTimeout (ClickHouse's own `max_execution_time`) and a Go
+// context.WithTimeout deadline (a backstop watchdog — see its doc comment).
+// clickhouse-go/v2's own queryOptions() (context.go) derives ITS OWN
+// `max_execution_time` from ctx.Deadline() — `time.Until(deadline) + 5s` —
+// and stamps it into the outgoing settings map UNCONDITIONALLY, clobbering
+// whatever chclient.querySettings already computed. Because that
+// driver-derived cap is, by construction, always LATER than ctx's own Done()
+// firing time, ClickHouse's clean server-side abort can never win the race
+// against the caller's own Go ctx — every query that ran its full budget
+// aborted through the client-ctx cancellation path instead, which is itself
+// racy inside the driver (the outer ctx.Done() select races the raw
+// socket's own ctx.Deadline()-derived read/write deadline) and, when the
+// raw-socket side won, ClickHouse never received a protocol Cancel packet at
+// all — it only noticed the dropped TCP connection.
+//
+// The fix (chclient.hiddenDeadlineContext, wired into queryContext) hides
+// ctx's Deadline() from the driver so its auto-override never fires:
+// chclient's own `max_execution_time` reaches ClickHouse unmodified and gets
+// the first chance to abort cleanly.
+//
+// This test cannot assert PURELY on client-observed timing (both the clean
+// and the broken behaviour make client.Query return in ~budget seconds), so
+// it asserts on ClickHouse's OWN account of what happened —
+// system.query_log — which is the one place the two behaviours are
+// distinguishable: TIMEOUT_EXCEEDED (159) for the fix, versus a NetException
+// (ClickHouse error codes in the 236 / "unknown packet" family) for the
+// regression.
+//
+// Gated behind the `integration` build tag (Docker required); the
+// strict-scan lane runs it via `just chclient-integration`.
+func TestQueryTimeout_ServerSideCleanAbort(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), timeoutContainerBudget)
+	defer cancel()
+
+	container, err := tcclickhouse.Run(
+		ctx,
+		"clickhouse/clickhouse-server:25.8-alpine",
+		tcclickhouse.WithUsername("cerberus"),
+		tcclickhouse.WithPassword("cerberus"),
+		tcclickhouse.WithDatabase("otel"),
+	)
+	if err != nil {
+		t.Fatalf("start clickhouse: %v", err)
+	}
+	t.Cleanup(func() { _ = container.Terminate(ctx) })
+
+	host, err := container.Host(ctx)
+	if err != nil {
+		t.Fatalf("host: %v", err)
+	}
+	port, err := container.MappedPort(ctx, "9000/tcp")
+	if err != nil {
+		t.Fatalf("port: %v", err)
+	}
+
+	client, err := chclient.New(chclient.Config{
+		Addr:         host + ":" + port.Port(),
+		Database:     "otel",
+		Username:     "cerberus",
+		Password:     "cerberus",
+		QueryTimeout: timeoutQueryBudget,
+	})
+	if err != nil {
+		t.Fatalf("connect: %v", err)
+	}
+	t.Cleanup(func() { _ = client.Close() })
+
+	// A separate observer connection reads system.query_log so the assertion
+	// is ClickHouse's own account, not driver bookkeeping.
+	observer, err := chclient.New(chclient.Config{
+		Addr:     host + ":" + port.Port(),
+		Database: "otel",
+		Username: "cerberus",
+		Password: "cerberus",
+	})
+	if err != nil {
+		t.Fatalf("connect observer: %v", err)
+	}
+	t.Cleanup(func() { _ = observer.Close() })
+
+	queryID := "chclient-timeout-clean-abort-probe"
+	// A per-row sleep with a small block size, so the query runs far longer
+	// than timeoutQueryBudget without ever hitting ClickHouse's OWN
+	// per-block sleep guard (3s) or exhausting inside a single block.
+	const sql = "SELECT count() FROM numbers(100000) WHERE sleepEachRow(0.001) = 0"
+
+	// Mirrors reqctx.ApplyQueryTimeout's actual production wiring exactly:
+	// the SAME budget on both the CH-side setting and the Go ctx deadline.
+	qctx, qcancel := context.WithTimeout(ctx, timeoutQueryBudget)
+	defer qcancel()
+	qctx = chclient.WithQueryTimeout(qctx, timeoutQueryBudget)
+	qctx = chclient.WithQueryID(qctx, queryID)
+	qctx = chclient.WithMaxBlockSize(qctx, timeoutQueryBlockRows)
+
+	if _, err := client.Query(qctx, sql); err == nil {
+		t.Fatalf("client.Query: expected a timeout error, got nil")
+	}
+
+	typ, code, exc := waitForQueryLogOutcome(ctx, t, observer, queryID)
+	t.Logf("system.query_log: type=%s exception_code=%d exception=%q", typ, code, exc)
+
+	if code != chTimeoutExceededCode {
+		t.Fatalf(
+			"system.query_log exception_code = %d (%q); want %d (TIMEOUT_EXCEEDED) — "+
+				"ClickHouse did not abort the query itself, meaning it kept working "+
+				"past cerberus's own client timeout instead of receiving a clean "+
+				"server-side cap",
+			code, exc, chTimeoutExceededCode,
+		)
+	}
+}
+
+// timeoutContainerBudget covers a cold image pull plus server startup plus
+// the probe's own run time.
+const timeoutContainerBudget = 5 * time.Minute
+
+// timeoutQueryBudget is the query timeout this test configures on both the
+// ClickHouse-side max_execution_time setting and the Go ctx watchdog,
+// mirroring reqctx.ApplyQueryTimeout's real production wiring. Short enough
+// to keep the test fast, long enough that ClickHouse's own abort has to win
+// a genuine race rather than a trivially-fast one.
+const timeoutQueryBudget = 2 * time.Second
+
+// timeoutQueryBlockRows caps the probe's block size so each block's
+// sleepEachRow total (rows * 1ms) stays comfortably under ClickHouse's own
+// per-block sleep ceiling (3s) while still taking a fraction of a second —
+// long enough that the query's overall runtime is dominated by many blocks,
+// not swallowed by a single one finishing before the timeout ever matters.
+const timeoutQueryBlockRows = 1000
+
+// queryLogPollBudget bounds how long this test waits for system.query_log to
+// carry the probe's outcome — the table is flushed asynchronously (SYSTEM
+// FLUSH LOGS nudges it, but does not guarantee immediacy under load).
+const queryLogPollBudget = 15 * time.Second
+
+// queryLogPollInterval is the gap between poll attempts while waiting for
+// system.query_log to settle.
+const queryLogPollInterval = 200 * time.Millisecond
+
+// waitForQueryLogOutcome polls system.query_log for the terminal row
+// (type != 'QueryStart') matching queryID, issuing SYSTEM FLUSH LOGS on each
+// attempt so the async flush is nudged rather than relied on to race the
+// poll. Fails the test if no terminal row appears within queryLogPollBudget.
+func waitForQueryLogOutcome(
+	ctx context.Context, t *testing.T, observer *chclient.Client, queryID string,
+) (typ string, code int32, exception string) {
+	t.Helper()
+
+	deadline := time.Now().Add(queryLogPollBudget)
+	for {
+		if err := observer.Exec(ctx, "SYSTEM FLUSH LOGS"); err != nil {
+			t.Logf("SYSTEM FLUSH LOGS: %v", err)
+		}
+		row := observer.Conn().QueryRow(ctx, `
+			SELECT type, exception_code, exception
+			FROM system.query_log
+			WHERE query_id = ? AND type != 'QueryStart'
+			ORDER BY event_time DESC
+			LIMIT 1
+		`, queryID)
+		if err := row.Scan(&typ, &code, &exception); err == nil {
+			return typ, code, exception
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("system.query_log: no terminal row for query_id %q within %s", queryID, queryLogPollBudget)
+		}
+		time.Sleep(queryLogPollInterval)
+	}
+}

--- a/internal/chclient/timeout.go
+++ b/internal/chclient/timeout.go
@@ -200,6 +200,62 @@ func (c *Client) classifyDriverErr(ctx context.Context, err error) error {
 	return wrapQueryTimeout(wrapMemoryLimit(err, c.maxMemory), c.effectiveQueryTimeout(ctx))
 }
 
+// hiddenDeadlineContext hides ctx's own Deadline() from anything reading it
+// downstream — Done(), Err() and Value() all delegate straight through to
+// ctx unchanged, so cancellation still fires at exactly the same instant it
+// always did; only the Deadline() ACCESSOR reports "none".
+//
+// This exists to work around a clickhouse-go/v2 behaviour that otherwise
+// silently overrides cerberus's own per-query `max_execution_time` setting.
+// clickhouse-go/v2's queryOptions() (context.go) derives its own
+// `max_execution_time` from the ctx it is handed — `time.Until(ctx.
+// Deadline()) + 5s` — and stamps it into the outgoing settings map whenever
+// ctx carries a Deadline() more than a second away, UNCONDITIONALLY
+// clobbering whatever value querySettings already placed there. Because that
+// derived cap is, by construction, always LATER than ctx's own Done() firing
+// time (ctx-remaining + 5s is always > ctx-remaining), ClickHouse's clean
+// server-side abort (TIMEOUT_EXCEEDED, code 159 — the very thing
+// classifyDriverErr/wrapQueryTimeout exist to classify) can never win the
+// race against the caller's own Go ctx: every data-plane query that runs its
+// full configured budget ends up cancelled through the client-ctx path
+// instead. That path is itself racy inside the driver (conn_process.go races
+// the outer ctx.Done() select against the raw socket's own
+// ctx.Deadline()-derived read/write deadline — see startReadWriteTimeout),
+// and when the raw-socket side of that race wins, ClickHouse never receives
+// a protocol-level Cancel packet at all: it only notices the dropped TCP
+// connection, which surfaces server-side as a NetException instead of a
+// clean cancellation. This was confirmed against a live ClickHouse instance:
+// the same request-shaped query flipped between a clean
+// QUERY_WAS_CANCELLED_BY_CLIENT (code 735) and a bare "client has dropped
+// the connection" NetException (code 236) across otherwise-identical runs,
+// with ClickHouse's own max_execution_time never getting a chance to fire.
+//
+// Hiding Deadline() from the driver disarms both the auto-override AND the
+// internal race: chclient's own querySettings-computed `max_execution_time`
+// (or its deliberate absence, when no timeout is configured — see
+// Config.QueryTimeout's "0 = don't set the setting" contract) reaches
+// ClickHouse unmodified and gets the first chance to abort the query
+// cleanly; the caller's Go ctx remains the backstop it was always meant to
+// be (queryContext / reqctx.ApplyQueryTimeout's own doc comment), unblocking
+// a hung call exactly when it always did, via the SAME Done() channel.
+func hiddenDeadlineContext(ctx context.Context) context.Context {
+	if _, ok := ctx.Deadline(); !ok {
+		return ctx
+	}
+	return noDeadlineContext{ctx}
+}
+
+// noDeadlineContext embeds a context.Context so Done() / Err() / Value() all
+// delegate to it unchanged, while Deadline() is overridden to report "none".
+// See hiddenDeadlineContext.
+type noDeadlineContext struct {
+	context.Context
+}
+
+func (noDeadlineContext) Deadline() (time.Time, bool) {
+	return time.Time{}, false
+}
+
 // effectiveQueryTimeout resolves the wall-clock cap a query runs under:
 // the Client's configured default (c.queryTimeout) unless ctx carries a
 // per-request WithQueryTimeout override, in which case the SMALLER of

--- a/internal/chclient/timeout_test.go
+++ b/internal/chclient/timeout_test.go
@@ -242,3 +242,67 @@ func TestChCodeTimeoutExceeded_ExactCode(t *testing.T) {
 		t.Errorf("chCodeTimeoutExceeded = %d; want %d", chCodeTimeoutExceeded, want)
 	}
 }
+
+// TestHiddenDeadlineContext_HidesDeadlineOnly pins the exact contract
+// hiddenDeadlineContext must uphold: Deadline() reports "none" so
+// clickhouse-go/v2's own queryOptions() never derives (and clobbers
+// chclient's own) max_execution_time from it, while Done()/Err()/Value()
+// are byte-identical to the wrapped context — cancellation still fires at
+// exactly the same instant it always did.
+func TestHiddenDeadlineContext_HidesDeadlineOnly(t *testing.T) {
+	t.Parallel()
+
+	type key struct{}
+	inner, cancel := context.WithTimeout(context.WithValue(context.Background(), key{}, "v"), time.Hour)
+	defer cancel()
+
+	wrapped := hiddenDeadlineContext(inner)
+
+	if _, ok := wrapped.Deadline(); ok {
+		t.Error("Deadline() reported a deadline; want none")
+	}
+	if wrapped.Done() != inner.Done() {
+		t.Error("Done() channel diverged from the wrapped context — cancellation timing would change")
+	}
+	if wrapped.Err() != inner.Err() {
+		t.Errorf("Err() = %v; want %v (delegated unchanged)", wrapped.Err(), inner.Err())
+	}
+	if got := wrapped.Value(key{}); got != "v" {
+		t.Errorf("Value(key{}) = %v; want %q", got, "v")
+	}
+}
+
+// TestHiddenDeadlineContext_NoOpWithoutDeadline — a ctx that never had a
+// Deadline() is returned unchanged (no wrapper allocation, no behavioural
+// difference): the fix only needs to intervene when there is a Deadline() to
+// hide in the first place.
+func TestHiddenDeadlineContext_NoOpWithoutDeadline(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	if got := hiddenDeadlineContext(ctx); got != ctx {
+		t.Errorf("hiddenDeadlineContext returned a different context for a Deadline()-less input")
+	}
+}
+
+// TestQueryContext_HidesCallerDeadline — the seam every data-plane query
+// routes through (queryContext) must apply hiddenDeadlineContext to
+// whatever it hands the driver, or the fix has no effect in production: this
+// is what actually reaches c.conn.Query.
+func TestQueryContext_HidesCallerDeadline(t *testing.T) {
+	t.Parallel()
+
+	c := &Client{}
+	ctx, cancel := context.WithTimeout(context.Background(), time.Hour)
+	defer cancel()
+
+	got := c.queryContext(ctx)
+	if _, ok := got.Deadline(); ok {
+		t.Error("queryContext's returned ctx still reports a Deadline() — clickhouse-go's own max_execution_time auto-override would still clobber chclient's own setting")
+	}
+	if got.Done() != ctx.Done() {
+		t.Error("queryContext's returned ctx has a different Done() channel — cancellation timing changed")
+	}
+}


### PR DESCRIPTION
## Summary

A production incident showed ClickHouse logging `NetException` errors (e.g. "client has dropped
the connection" / "unknown packet from client") for queries that had already run past cerberus's
own configured query timeout, instead of the clean `TIMEOUT_EXCEEDED` (code 159) abort the
`max_execution_time` setting exists to produce. ClickHouse kept doing work — sometimes multi-GB of
memory — for a client that had already walked away, with no protocol-level signal telling it to
stop.

Root cause: `reqctx.ApplyQueryTimeout` stamps the *same* budget onto both
`chclient.WithQueryTimeout` (ClickHouse's own `max_execution_time` setting) and a Go
`context.WithTimeout` deadline (a backstop watchdog, per its own doc comment — meant to fire only
"if the server-side cap somehow doesn't fire"). `clickhouse-go/v2`'s own `queryOptions()`
(`context.go`) derives its *own* `max_execution_time` from whatever `ctx.Deadline()` it is handed —
`time.Until(deadline) + 5s` — and stamps that into the outgoing settings map unconditionally,
silently clobbering the value chclient's `querySettings` had already computed. Because the
driver-derived cap is, by construction, always *later* than the ctx's own `Done()` firing time, the
clean server-side abort can never win: every query that ran its full budget ended up cancelled
through the client-side ctx path instead — which is itself racy inside the driver (the outer
`ctx.Done()` select races the raw socket's own `ctx.Deadline()`-derived read/write deadline), and
when the raw-socket side of that race won, ClickHouse never received a protocol `Cancel` packet at
all — only the dropped TCP connection, surfacing as a `NetException`.

Confirmed against a live ClickHouse instance: the *same* request-shaped slow query flipped between
a clean `QUERY_WAS_CANCELLED_BY_CLIENT` (code 735) and a bare "client has dropped the connection"
`NetException` (code 236) across otherwise-identical runs, with ClickHouse's own
`max_execution_time` never getting the chance to fire — 0 of 10 runs showed a clean server-side
abort before the fix.

## Fix

- `internal/chclient/timeout.go`: add `hiddenDeadlineContext`, a context wrapper that hides
  `Deadline()` from anything reading it downstream while `Done()` / `Err()` / `Value()` delegate
  through unchanged — cancellation still fires at exactly the same instant it always did.
- `internal/chclient/client.go`: wire it into `queryContext`, the single seam every data-plane
  query routes through before reaching `c.conn.Query`.

With `Deadline()` hidden, `clickhouse-go/v2`'s auto-override never fires, so chclient's own
`max_execution_time` reaches ClickHouse unmodified and gets first right of way. Re-running the same
live-ClickHouse repro after the fix: 15 of 15 runs show a clean server-side abort (`TIMEOUT_EXCEEDED`,
code 159, or — when no `max_execution_time` is configured at all — a clean protocol
`QUERY_WAS_CANCELLED_BY_CLIENT`), zero `NetException`s.

## Test plan

- [x] New unit tests (`internal/chclient/timeout_test.go`): `hiddenDeadlineContext` hides
      `Deadline()` only, `queryContext` applies it to the context every data-plane query dispatches
      on.
- [x] New integration test (`internal/chclient/query_timeout_clean_cancel_integration_test.go`,
      `integration` build tag, testcontainers ClickHouse): fires a query that runs well past a
      configured `QueryTimeout` with the same ctx-shape `reqctx.ApplyQueryTimeout` produces in
      production, then asserts `system.query_log` recorded a clean `TIMEOUT_EXCEEDED` (159), not a
      `NetException`. Verified this test fails on the pre-fix code (reproduces code 236) and passes
      on the fixed code.
- [x] `go build ./...`
- [x] `just chclient-integration` (race-enabled, real ClickHouse via testcontainers)
- [x] `just test-unit` (race-enabled unit + spec suite)
