### PR TITLE
fix(e2e): actively wait for the cerberus_ql panel's ds/query response

### DIFF
--- a/test/e2e/playwright/compose_grafana_smoke.spec.ts
+++ b/test/e2e/playwright/compose_grafana_smoke.spec.ts
@@ -88,6 +88,16 @@ const WARMUP_BEFOREALL_TIMEOUT_MS =
   (SEED_TRAFFIC_SECONDS + WARMUP_BOUNDED_WAITS * WARMUP_SIGNAL_DEADLINE_SECONDS) *
   1000;
 
+// Bound on ACTIVELY waiting for the "Query rate by language" panel's own
+// /api/ds/query response once `networkidle` has already settled without it
+// having arrived. Grafana's scene runtime does not dispatch every panel's
+// query on a fixed schedule relative to network activity — dispatch can
+// follow a debounced query-runner tick or template-variable resolution,
+// neither of which is network traffic `networkidle` observes — so a panel's
+// request can legitimately fire (and its response land) after the passive
+// capture window has already closed. See driveCerberusQLPartition.
+const PANEL_QUERY_LATE_RESPONSE_TIMEOUT_MS = 60_000;
+
 test.beforeAll(async ({ request }) => {
   test.setTimeout(WARMUP_BEFOREALL_TIMEOUT_MS);
   await generateSelfTraffic(request, SEED_TRAFFIC_SECONDS);
@@ -752,10 +762,44 @@ async function driveCerberusQLPartition(
   // PromQL into the response envelope alongside the result, so
   // `body.includes('cerberus_ql')` narrows to the panel's request
   // without parsing the JSON.
-  const panelResponses = captured.filter((c) => c.body.includes('cerberus_ql'));
+  let panelResponses = captured.filter((c) => c.body.includes('cerberus_ql'));
+  if (panelResponses.length === 0) {
+    // Nothing landed in the passive `captured` buffer during the
+    // navigation + networkidle window above. Rather than trust that
+    // window's timing (see PANEL_QUERY_LATE_RESPONSE_TIMEOUT_MS), give
+    // the panel's own query one more, actively-awaited chance to
+    // dispatch and resolve before declaring it missing — this is not a
+    // cache-serving artifact (the request is a POST, which browsers do
+    // not disk-cache, and Playwright's response event fires for the
+    // real network round trip regardless), it is a dispatch-timing race
+    // between the panel and our capture window.
+    const late = await page
+      .waitForResponse(
+        async (resp) => {
+          if (!resp.url().includes('/api/ds/query')) return false;
+          try {
+            return (await resp.text()).includes('cerberus_ql');
+          } catch {
+            return false;
+          }
+        },
+        { timeout: PANEL_QUERY_LATE_RESPONSE_TIMEOUT_MS },
+      )
+      .catch(() => null);
+    if (late) {
+      let body = '';
+      try {
+        body = await late.text();
+      } catch {
+        body = '';
+      }
+      captured.push({ url: late.url(), body, status: late.status() });
+      panelResponses = captured.filter((c) => c.body.includes('cerberus_ql'));
+    }
+  }
   if (panelResponses.length === 0) {
     failures.push(
-      `[partition:${panelTitle}] no /api/ds/query response referenced cerberus_ql — Grafana may have served the panel from cache; rerun with cleared session if seen`,
+      `[partition:${panelTitle}] no /api/ds/query response referenced cerberus_ql within ${PANEL_QUERY_LATE_RESPONSE_TIMEOUT_MS}ms of the panel becoming visible — its backend query never dispatched or its response never resolved`,
     );
     return failures;
   }


### PR DESCRIPTION
## Summary

- The `dashboard` release-gate check went red on the v1.15.2 release commit
  (run 32226789340) because `compose_grafana_smoke.spec.ts`'s
  `driveCerberusQLPartition` flaked once, then passed cleanly on Playwright's
  automatic retry — but `failOnFlakyTests` still exits nonzero on a flaky
  spec, and the `dashboard` aggregate job requires the shard's raw `result`
  to be `success`.
- Root cause: the assertion relies on a **passive** `page.on('response')`
  listener that gets detached right after `networkidle` settles (or 45s
  elapses). Grafana's scene runtime does not dispatch every panel's backend
  query on a fixed schedule relative to network activity — dispatch can
  follow a debounced query-runner tick or template-variable resolution,
  neither of which is network traffic `networkidle` observes — so the
  "Query rate by language" panel's `/api/ds/query` request can legitimately
  fire (and its response land) *after* the passive capture window has
  already closed. The old failure message blamed browser caching, but the
  request is a `POST`, which browsers do not disk-cache, and Playwright's
  `response` event fires for the real network round trip regardless — so
  that theory doesn't hold up; this is a dispatch-timing race, not a cache
  hit.
- Checked the last 30 `e2e.yml` runs / 6 recent failures for the same
  `no /api/ds/query response referenced cerberus_ql` signature: only the
  target run has it, so this is the first occurrence of this particular
  race, not a chronic one — still fixed at the root per this repo's
  "never label a real failure a flake without evidence and a fix" rule.

## Change

`test/e2e/playwright/compose_grafana_smoke.spec.ts`:
- Added `PANEL_QUERY_LATE_RESPONSE_TIMEOUT_MS` (60s) — a named constant per
  the no-magic-constants invariant.
- When the passive `captured` buffer has no `cerberus_ql`-bearing
  `/api/ds/query` response by the time the panel is confirmed present, the
  test now **actively** waits (`page.waitForResponse`, bounded by the new
  constant) for one more matching response before declaring the panel's
  query missing. This directly targets the coordination gap instead of
  papering over the flake with a retry-tolerant assertion. No unrelated
  code in the file was touched; the self-traffic seeding mechanism
  (`seedCerberusSelfTraffic`, PRs #664/#681/#682) is untouched.

## Test plan

- [x] `npx tsc --noEmit -p test/e2e/playwright/tsconfig.json` — clean, no
      type errors.
- [x] Reviewed the diff for scope: only `driveCerberusQLPartition`'s
      response-detection logic changed.
- [ ] The real verification is the `dashboard` e2e lane on this PR's own
      CI run — e2e/compose-smoke lanes cannot be run locally per this
      repo's documented policy (need k3d/Docker).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
