### PR TITLE
fix(solver): slice RangeBucketFanout, fixing classic-histogram range OOMs

### DIFF
--- a/internal/chplan/reanchor.go
+++ b/internal/chplan/reanchor.go
@@ -106,6 +106,17 @@ func reanchor(n Node, start, end time.Time) (Node, error) {
 		return reanchorUnionAll(v, start, end)
 	case *RangeLWR:
 		return reanchorRangeLWR(v, start, end)
+	case *RangeBucketFanout:
+		return reanchorRangeBucketFanout(v, start, end)
+	case *HistogramQuantile:
+		input, err := reanchor(v.Input, start, end)
+		if err != nil {
+			return nil, err
+		}
+		// Phi / other scalar params are off-grid immutable: share.
+		c := *v
+		c.Input = input
+		return &c, nil
 	case *Project:
 		input, err := reanchor(v.Input, start, end)
 		if err != nil {
@@ -328,6 +339,37 @@ func reanchorRangeLWR(v *RangeLWR, start, end time.Time) (Node, error) {
 // timestamp with now64(9), a wall-clock that diverges across shards);
 // registration is by node kind, so that guard — not this function — is what
 // excludes it.
+// reanchorRangeBucketFanout re-grids the array-aggregate fan-out behind the
+// classic-histogram families — the RangeLWR sibling that collapses each
+// (series, anchor)'s raw BucketCounts/ExplicitBounds rows via
+// `GROUP BY (<user keys>, anchor)` instead of picking one last sample. Its
+// per-anchor membership window is the same shape as RangeLWR's:
+// `(anchor - Offset - Lookback, anchor - Offset]`, and it carries no
+// OuterRange field and no StepAlign mode (RangeBucketFanout only ever
+// lowers already gridded to the request's own step, never as a
+// subquery-inner epoch-aligned leaf) — so this mirrors reanchorRangeLWR
+// with the StepAlign branch dropped.
+func reanchorRangeBucketFanout(v *RangeBucketFanout, start, end time.Time) (Node, error) {
+	if v.Step <= 0 {
+		// No anchor grid to re-grid; share verbatim.
+		return v, nil
+	}
+	if err := checkPredictedGridBucketFanout(v, start, end); err != nil {
+		return nil, err
+	}
+	c := *v
+	c.Start = start
+	c.End = end
+	// The membership window looks back Offset+Lookback from each anchor;
+	// widen the input spine by that much so every anchor finds its samples.
+	input, err := reanchor(v.Input, c.Start.Add(-v.Offset-v.Lookback), c.End)
+	if err != nil {
+		return nil, err
+	}
+	c.Input = input
+	return &c, nil
+}
+
 func reanchorVectorJoin(v *VectorJoin, start, end time.Time) (Node, error) {
 	left, err := reanchor(v.Left, start, end)
 	if err != nil {
@@ -420,6 +462,26 @@ func checkPredictedGridLWR(r *RangeLWR, predStart, predEnd time.Time) error {
 		return nil
 	}
 	return fmt.Errorf("%w: RangeLWR bounds (Start=%v End=%v) "+
+		"do not match predicted grid (Start=%v End=%v) — an @-pinned or non-grid anchor",
+		ErrReanchorGridMismatch,
+		r.Start, r.End,
+		predStart, predEnd)
+}
+
+// checkPredictedGridBucketFanout is checkPredictedGrid for a
+// RangeBucketFanout. Like RangeLWR it carries no OuterRange field — its
+// grid span is End-Start directly — so the predicted grid is just
+// [predStart, predEnd]. Either the bounds are unpinned (zero Start and End —
+// the slicer's UnpinSpine shape) or they already sit exactly on the
+// predicted grid. Anything else is rejected so the solver routes A.
+func checkPredictedGridBucketFanout(r *RangeBucketFanout, predStart, predEnd time.Time) error {
+	if r.Start.IsZero() && r.End.IsZero() {
+		return nil
+	}
+	if r.Start.Equal(predStart) && r.End.Equal(predEnd) {
+		return nil
+	}
+	return fmt.Errorf("%w: RangeBucketFanout bounds (Start=%v End=%v) "+
 		"do not match predicted grid (Start=%v End=%v) — an @-pinned or non-grid anchor",
 		ErrReanchorGridMismatch,
 		r.Start, r.End,

--- a/internal/chplan/sliceinvariant.go
+++ b/internal/chplan/sliceinvariant.go
@@ -41,13 +41,16 @@ func IsSliceInvariant(n Node) bool {
 //
 //   - Scan / Filter / Project — pure row-wise passthroughs; no cross-row,
 //     cross-anchor, or scan-order dependence.
+//
 //   - Aggregate — keyed per (series, anchor) (the GroupBy carries the
 //     anchor key in the matrix lowerings), so each output row reduces only
 //     the rows of one anchor's window.
+//
 //   - RangeWindow / RangeLWR / RangeBucketFanout — the windowed-array and
 //     bounded sample-fan-out families: each (series, anchor) value is the
 //     reduce of exactly that anchor's `(anchor - Offset - Range, anchor -
 //     Offset]` window membership, independent of the scan lower bound.
+//
 //   - RangeWindowGridNative — the ClickHouse-native timeSeries<fn>ToGrid lowering
 //     of the SAME window semantics. The aggregate is handed (start, end, step,
 //     window) and evaluates grid point i from exactly the samples inside
@@ -65,9 +68,12 @@ func IsSliceInvariant(n Node) bool {
 //     against the fan-out arm on a 500k-row / 5000-series seed across three
 //     temporality mixes: identical cell key sets, zero missing and zero extra
 //     cells (issue #2117).
+//
 //   - StepGrid — emits the anchor grid itself; a sub-grid is a subset.
+//
 //   - UnionAll — slice-invariant iff every arm is (checked structurally by
 //     the whole-plan walk, since each arm is itself visited).
+//
 //   - VectorJoin — a step-aligned vector-vector binary join. Each output row
 //     is the per-pair binary op of two per-(match-key, anchor) inputs joined
 //     on the match key AND the anchor timestamp (the emitter ANDs
@@ -87,10 +93,28 @@ func IsSliceInvariant(n Node) bool {
 //     route A. VectorSetOp / NaryVectorSetOp (and/or/unless) remain absent —
 //     each is its own PR.
 //
+//   - HistogramQuantile — the classic-histogram bucket-array-to-quantile
+//     interpolation. Its input is RangeBucketFanout, whose GROUP BY carries
+//     the anchor key (AnchorAlias, always prepended), so HistogramQuantile's
+//     own row-wise Project/interpolation reads exactly one (series, anchor)
+//     group's BucketCounts/ExplicitBounds columns — no cross-anchor read, no
+//     scan-order dependence, no window function (the emitter,
+//     internal/chsql/histogram_quantile.go, renders plain arrayMap/arraySort
+//     over one row's array columns). Its per-(series, anchor) output is
+//     therefore exactly as scan-lower-bound-independent as its
+//     RangeBucketFanout input already is. See internal/chplan/reanchor.go's
+//     *HistogramQuantile arm (a pass-through, mirroring *Project) and
+//     internal/solver/avb_chdb_lane_test.go's classic-histogram fixtures for
+//     the differential (route A vs K-sharded route B) proof this registry
+//     entry rests on. HistogramQuantileNative / HistogramProjection (the
+//     native/exponential-histogram siblings) remain DELIBERATELY ABSENT —
+//     same shape family, but no production traffic exists yet to validate
+//     against; a follow-up PR with its own fixtures registers them.
+//
 // Extension point. Phase-3 node families (TopK as per-anchor LIMIT K BY,
-// VectorSetOp, HistogramQuantile{,Native}, AbsentOverTime, RangeWindowStaleResample,
-// the metrics_* TraceQL family, nested spines under the lcm clamp) are
-// DELIBERATELY ABSENT:
+// VectorSetOp, HistogramQuantileNative, HistogramProjection, AbsentOverTime,
+// RangeWindowStaleResample, the metrics_* TraceQL family, nested spines under
+// the lcm clamp) are DELIBERATELY ABSENT:
 // each enters this registry only with its own slice-invariance proof + the
 // reset-at-seam fixture family, one node family per PR. To register a kind,
 // argue its per-(series, anchor) output is scan-lower-bound-independent, add
@@ -106,6 +130,7 @@ var sliceInvariantKinds = func() map[reflect.Type]struct{} {
 		&RangeWindowGridNative{},
 		&RangeLWR{},
 		&RangeBucketFanout{},
+		&HistogramQuantile{},
 		&StepGrid{},
 		&UnionAll{},
 		&VectorJoin{},

--- a/internal/chplan/sliceinvariant_test.go
+++ b/internal/chplan/sliceinvariant_test.go
@@ -22,6 +22,7 @@ func sliceInvariantRegisteredKinds() []chplan.Node {
 		&chplan.RangeWindowGridNative{},
 		&chplan.RangeLWR{},
 		&chplan.RangeBucketFanout{},
+		&chplan.HistogramQuantile{},
 		&chplan.StepGrid{},
 		&chplan.UnionAll{},
 		&chplan.VectorJoin{},

--- a/internal/solver/avb_chdb_lane_test.go
+++ b/internal/solver/avb_chdb_lane_test.go
@@ -160,6 +160,28 @@ INSERT INTO otel_metrics_sum (MetricName, Attributes, ServiceName, TimeUnix, Val
 SELECT 'http_errors_total', map('job', 'd'), 'svc',
   toDateTime64('2026-06-13 00:00:00', 9) + toIntervalSecond(number * 15),
   toFloat64(100)
+FROM numbers(241);
+CREATE OR REPLACE TABLE otel_metrics_histogram (
+  MetricName String,
+  Attributes Map(String, String),
+  ResourceAttributes Map(String, String) DEFAULT map(),
+  ServiceName LowCardinality(String),
+  AggregationTemporality Int32 DEFAULT 2,
+  TimeUnix DateTime64(9),
+  BucketCounts Array(UInt64),
+  ExplicitBounds Array(Float64)
+) ENGINE = MergeTree ORDER BY (MetricName, Attributes, TimeUnix);
+INSERT INTO otel_metrics_histogram (MetricName, Attributes, ServiceName, TimeUnix, BucketCounts, ExplicitBounds)
+SELECT 'http_latency_seconds', map('job', 'a'), 'svc',
+  toDateTime64('2026-06-13 00:00:00', 9) + toIntervalSecond(number * 15),
+  [number, number * 2, number * 3],
+  [0.1, 0.5]
+FROM numbers(241);
+INSERT INTO otel_metrics_histogram (MetricName, Attributes, ServiceName, TimeUnix, BucketCounts, ExplicitBounds)
+SELECT 'http_latency_seconds', map('job', 'b'), 'svc',
+  toDateTime64('2026-06-13 00:00:00', 9) + toIntervalSecond(number * 15),
+  [number * 2, number * 3, number * 4],
+  [0.1, 0.5]
 FROM numbers(241);`
 
 // laneFixtures are the eligible shapes the lane proves. Each is a real shape
@@ -228,6 +250,17 @@ var laneFixtures = []string{
 	// the ratio fixtures above.
 	"clamp_max(http_requests_total, scalar(http_requests_total{job=\"a\"}))",
 	"clamp_min(http_requests_total, scalar(http_requests_total{job=\"b\"}))",
+	// The classic-histogram production-incident fix: histogram_quantile over
+	// an aggregated rate() of a classic (explicit-bucket) histogram lowers to
+	// HistogramQuantile wrapping a RangeBucketFanout — shape
+	// cerb:project;agg=1;rbf, the exact shape that OOM'd in production at real
+	// cardinality because the Planner refused to slice it (no ReanchorRange
+	// arm). job=a / job=b are dense monotonic bucket-count series (like
+	// http_requests_total above), so every anchor_ts carries both series
+	// pre-quantile, and each shard boundary falls mid-[5m] window — the seam
+	// this shape's per-(series,anchor) window-fold must get right identically
+	// to route A's single pass.
+	"histogram_quantile(0.99, sum by (le, job) (rate(http_latency_seconds_bucket[5m])))",
 }
 
 // TestSolver_AvsB_ChDB_Differential is the per-PR parity workhorse. For each

--- a/internal/solver/carrier_geometry_test.go
+++ b/internal/solver/carrier_geometry_test.go
@@ -153,6 +153,12 @@ func carrierCases() []carrierCase {
 			reanchorable: false,
 		},
 		{
+			// RangeBucketFanout is re-anchored by chplan.ReanchorRange (and
+			// zeroed/re-filled by the slicer's UnpinSpine) the same way RangeLWR
+			// is — the classic-histogram OOM fix. See
+			// TestPlan_RangeBucketFanoutSpineRoutes /
+			// TestPlan_HistogramQuantileOverRangeBucketFanoutRoutes for the
+			// positive routing assertions.
 			kind: "RangeBucketFanout",
 			plan: func() chplan.Node {
 				return &chplan.RangeBucketFanout{
@@ -172,7 +178,7 @@ func carrierCases() []carrierCase {
 			},
 			wantD:        geomFanoutLookback,
 			wantFanout:   int64(geomFanoutLookback / gridStep),
-			reanchorable: false,
+			reanchorable: true,
 		},
 		{
 			kind: "AbsentOverTime",
@@ -222,9 +228,11 @@ func carrierCases() []carrierCase {
 // collapses on CumulativeD alone for the same reason.
 //
 // It also pins the correctness half in the same rows: measuring a carrier must
-// never make it sliceable. Only the two re-anchorable families may be eligible;
-// the other five are refused with a non-zero grid, which is exactly the state
-// the corpus needs (what it cost, and why we declined).
+// never make it sliceable UNLESS it is one of the re-anchorable families
+// (RangeWindow / RangeWindowGridNative / RangeLWR / RangeBucketFanout); the
+// remaining three (RangeWindowStaleResample, AbsentOverTime, StepGrid) are
+// refused with a non-zero grid, which is exactly the state the corpus needs
+// (what it cost, and why we declined).
 func TestCarrierGeometry_ExtractsFeaturesForEveryKind(t *testing.T) {
 	t.Parallel()
 

--- a/internal/solver/planner.go
+++ b/internal/solver/planner.go
@@ -218,16 +218,18 @@ func (p *Planner) classify(plan chplan.Node, meta RequestMeta) (sig signals, dec
 		return sig, notRouted(ReasonNotSliceable).withGrid(sig, meta), 0, false
 	}
 	// (1b) Routable-spine restriction: the routable spine families are the
-	// RangeWindow matrix family, the RangeWindowGridNative timeSeries*ToGrid family
-	// and the RangeLWR bare-selector last-with-respect-to family — ReanchorRange
-	// re-grids all three. Every other [chplan.GridCarrier] kind
-	// (RangeWindowStaleResample, RangeBucketFanout, StepGrid, AbsentOverTime) has its
-	// grid CloneNode'd verbatim, so each shard would emit the original full-grid
-	// bounds; they fail closed to route A. Note the asymmetry this gate exists
-	// to preserve: the extractor MEASURES all seven kinds so the corpus can see
-	// what a refused plan costs, while only the re-anchored families may be
-	// SLICED. Admitting a kind here means teaching ReanchorRange (and the
-	// slicer's UnpinSpine) its grid first, not widening carrierGeometryOf.
+	// RangeWindow matrix family, the RangeWindowGridNative timeSeries*ToGrid family,
+	// the RangeLWR bare-selector last-with-respect-to family, and the
+	// RangeBucketFanout array-aggregate fan-out behind the classic-histogram
+	// families — ReanchorRange re-grids all four. Every other
+	// [chplan.GridCarrier] kind (RangeWindowStaleResample, StepGrid,
+	// AbsentOverTime) has its grid CloneNode'd verbatim, so each shard would
+	// emit the original full-grid bounds; they fail closed to route A. Note
+	// the asymmetry this gate exists to preserve: the extractor MEASURES all
+	// seven kinds so the corpus can see what a refused plan costs, while only
+	// the re-anchored families may be SLICED. Admitting a kind here means
+	// teaching ReanchorRange (and the slicer's UnpinSpine) its grid first, not
+	// widening carrierGeometryOf.
 	if sig.sawNonRangeWindowSpine {
 		return sig, notRouted(ReasonNotSliceable).withGrid(sig, meta), 0, false
 	}
@@ -513,11 +515,12 @@ func (p *Planner) walkNode(n chplan.Node, predStart, predEnd time.Time, predStep
 		// RangeBucketFanout is the array-aggregate sibling of RangeLWR and
 		// is slice-invariant; like Aggregate it carries group keys + agg
 		// args that the spine recursion never sweeps. Cover the same now64
-		// gap. It also carries its own eval grid (Start/End/Step) that
-		// ReanchorRange clones VERBATIM (never re-anchors), so every shard
-		// would emit stale bounds — recordGridCarrier fails it closed to
-		// route A while still measuring the grid it does carry.
+		// gap. It carries its own eval grid (Start/End/Step), re-anchored by
+		// chplan.ReanchorRange the same way RangeLWR is (checkRangeBucketFanoutGrid
+		// runs the same bound-pinning / grid-prediction gates
+		// checkRangeLWRGrid does).
 		p.recordGridCarrier(v, depth, sig)
+		p.checkRangeBucketFanoutGrid(v, predStart, predEnd, depth, sig)
 		for _, e := range v.GroupBy {
 			p.walkExpr(e, predStart, predEnd, v.Step, sig)
 		}
@@ -529,7 +532,11 @@ func (p *Planner) walkNode(n chplan.Node, predStart, predEnd time.Time, predStep
 				p.walkExpr(e, predStart, predEnd, v.Step, sig)
 			}
 		}
-		p.walkNode(v.Input, predStart, predEnd, v.Step, depth, sig)
+		// Each anchor's membership window looks back Offset+Lookback (mirrors
+		// the RangeLWR arm above); widen the input spine by that much so the
+		// grid this predicts for the child matches what ReanchorRange actually
+		// produces (see reanchorRangeBucketFanout).
+		p.walkNode(v.Input, predStart.Add(-v.Offset-v.Lookback), predEnd, v.Step, depth, sig)
 		return
 
 	case *chplan.StepGrid:
@@ -777,10 +784,13 @@ func carrierGeometryOf(gc chplan.GridCarrier) (carrierGeometry, bool) {
 		}, true
 
 	case *chplan.RangeBucketFanout:
-		// The array-aggregate fan-out behind the histogram families. Its
-		// per-node shape is slice-invariant, but its grid is cloned verbatim,
-		// which is why measuring it must not be confused with routing it.
-		return carrierGeometry{outerRange: v.End.Sub(v.Start), lookback: v.Lookback, reanchorable: false}, true
+		// The array-aggregate fan-out behind the classic-histogram families:
+		// the RangeLWR sibling that collapses each (series, anchor)'s raw
+		// BucketCounts/ExplicitBounds rows via GROUP BY instead of picking one
+		// last sample. Re-gridded by chplan.ReanchorRange (and zeroed/re-filled
+		// by the slicer's UnpinSpine) the same way RangeLWR is, so it is
+		// routable.
+		return carrierGeometry{outerRange: v.End.Sub(v.Start), lookback: v.Lookback, reanchorable: true}, true
 
 	case *chplan.AbsentOverTime:
 		// absent_over_time's own grid; Range is the per-anchor window.
@@ -1007,6 +1017,35 @@ func rangeWindowGridMatches(v *chplan.RangeWindow, predStart, predEnd time.Time)
 // rangeLWRGridMatches is rangeWindowGridMatches for a RangeLWR: it carries
 // no separate OuterRange field, so the predicted span is End-Start directly.
 func rangeLWRGridMatches(v *chplan.RangeLWR, predStart, predEnd time.Time) bool {
+	return v.Start.Equal(predStart) && v.End.Equal(predEnd)
+}
+
+// checkRangeBucketFanoutGrid is checkRangeLWRGrid for RangeBucketFanout —
+// same shape (no OuterRange field, a spine leaf whose grid-prediction
+// comparison is meaningful only at depth 0), since RangeBucketFanout carries
+// no StepAlign mode.
+func (p *Planner) checkRangeBucketFanoutGrid(v *chplan.RangeBucketFanout, predStart, predEnd time.Time, depth int, sig *signals) {
+	startZero := v.Start.IsZero()
+	endZero := v.End.IsZero()
+	if depth == 0 {
+		if startZero || endZero {
+			sig.sawUnpinnedBound = true
+		}
+		if !startZero && !endZero && !rangeBucketFanoutGridMatches(v, predStart, predEnd) {
+			sig.sawGridMismatch = true
+		}
+	} else if startZero != endZero {
+		sig.sawUnpinnedBound = true
+	}
+	// A RangeBucketFanout's anchors are generated backward from End with no
+	// epoch snap (mirrors the plain RangeLWR case checkRangeLWRGrid handles),
+	// so a nested one always constrains the slice quantum.
+	if depth > 0 && v.Step > 0 {
+		sig.endPhasedResolutions = append(sig.endPhasedResolutions, v.Step)
+	}
+}
+
+func rangeBucketFanoutGridMatches(v *chplan.RangeBucketFanout, predStart, predEnd time.Time) bool {
 	return v.Start.Equal(predStart) && v.End.Equal(predEnd)
 }
 

--- a/internal/solver/planner_test.go
+++ b/internal/solver/planner_test.go
@@ -451,36 +451,155 @@ func TestPlan_Now64InScalarInteriorAggregateRejected(t *testing.T) {
 	}
 }
 
+// rangeBucketFanoutSpine builds the array-aggregate fan-out behind the
+// classic-histogram families over the standard 1h/15s grid, mirroring
+// lwrSpine's shape (Lookback 5m, no offset).
+func rangeBucketFanoutSpine() *chplan.RangeBucketFanout {
+	return &chplan.RangeBucketFanout{
+		Input:        leafScan(),
+		Start:        gridStart,
+		End:          gridEnd,
+		Step:         gridStep,
+		Lookback:     5 * time.Minute,
+		AnchorAlias:  "anchor_ts",
+		TimestampCol: "TimeUnix",
+		AggFuncs: []chplan.AggFunc{{
+			Fn:    chplan.FnSumForEach,
+			Args:  []chplan.Expr{&chplan.ColumnRef{Name: "BucketCounts"}},
+			Alias: "BucketCounts",
+		}},
+	}
+}
+
+// TestPlan_RangeBucketFanoutSpineRoutes is the production-incident fix: a
+// bare RangeBucketFanout spine that route A left un-sliceable now ROUTES B
+// with K >= 2 and correctly-anchored slices — the same shape and grid
+// (gridStart/gridEnd/gridStep = 1h/15s = 240 anchors) as the real production
+// query that OOM'd on shape cerb:project;agg=1;rbf.
+func TestPlan_RangeBucketFanoutSpineRoutes(t *testing.T) {
+	t.Parallel()
+	p := &Planner{Cfg: autoCfg()}
+	d, routed := p.Plan(rangeBucketFanoutSpine(), oomMeta())
+	if !routed {
+		t.Fatalf("RangeBucketFanout spine must route; got reason=%q", d.Reason)
+	}
+	if d.Reason != ReasonRouted {
+		t.Fatalf("reason = %q, want %q", d.Reason, ReasonRouted)
+	}
+	if d.K < 2 {
+		t.Fatalf("K = %d, want >= 2", d.K)
+	}
+	if d.Strategy != StrategyShardedTimeslice {
+		t.Fatalf("strategy = %q, want %q", d.Strategy, StrategyShardedTimeslice)
+	}
+	if len(d.Slices) != d.K {
+		t.Fatalf("len(Slices) = %d, want K=%d", len(d.Slices), d.K)
+	}
+	oldest := d.Slices[0].Plan.(*chplan.RangeBucketFanout)
+	newest := d.Slices[len(d.Slices)-1].Plan.(*chplan.RangeBucketFanout)
+	if !oldest.Start.Equal(gridStart) {
+		t.Fatalf("oldest slice Start=%v, want grid Start=%v", oldest.Start, gridStart)
+	}
+	if !newest.End.Equal(gridEnd) {
+		t.Fatalf("newest slice End=%v, want grid End=%v", newest.End, gridEnd)
+	}
+	for _, sl := range d.Slices {
+		r := sl.Plan.(*chplan.RangeBucketFanout)
+		if r.Start.IsZero() || r.End.IsZero() {
+			t.Fatalf("slice %d left RangeBucketFanout bounds unpinned: Start=%v End=%v",
+				sl.Index, r.Start, r.End)
+		}
+		if r.Step != gridStep || r.Lookback != 5*time.Minute {
+			t.Fatalf("slice %d RangeBucketFanout lost a non-grid field: %+v", sl.Index, r)
+		}
+	}
+}
+
+// TestPlan_HistogramQuantileOverRangeBucketFanoutRoutes pins the CRITICAL
+// correctness fix alongside the routing one: a HistogramQuantile wrapping a
+// RangeBucketFanout — the actual production spine
+// (Project -> HistogramQuantile -> Project -> RangeBucketFanout -> Filter ->
+// Scan) — must ALSO route, proving the HistogramQuantile pass-through arm in
+// chplan.ReanchorRange (and its sliceInvariantKinds registration) are wired.
+// Before this fix, registering ONLY RangeBucketFanout without also teaching
+// ReanchorRange a *HistogramQuantile arm would have been silently WRONG: gate
+// (1) allSliceInvariant would still block on the unregistered HistogramQuantile
+// node (dead code, still route A) — or, had HistogramQuantile been registered
+// slice-invariant without a matching reanchor arm, ReanchorRange's default
+// case would return it UNRECURSED, handing every shard the ORIGINAL
+// full-grid RangeBucketFanout — K silently-duplicated copies of the same
+// rows, not an error. This test is what a regression in either half would
+// break.
+func TestPlan_HistogramQuantileOverRangeBucketFanoutRoutes(t *testing.T) {
+	t.Parallel()
+	plan := &chplan.HistogramQuantile{
+		Input:                rangeBucketFanoutSpine(),
+		Phi:                  0.99,
+		BucketCountsColumn:   "BucketCounts",
+		ExplicitBoundsColumn: "ExplicitBounds",
+		MetricNameColumn:     "MetricName",
+		AttributesColumn:     "Attributes",
+		TimestampColumn:      "TimeUnix",
+	}
+	p := &Planner{Cfg: autoCfg()}
+	d, routed := p.Plan(plan, oomMeta())
+	if !routed {
+		t.Fatalf("HistogramQuantile over RangeBucketFanout must route; got reason=%q", d.Reason)
+	}
+	if d.Reason != ReasonRouted {
+		t.Fatalf("reason = %q, want %q", d.Reason, ReasonRouted)
+	}
+	if d.K < 2 {
+		t.Fatalf("K = %d, want >= 2", d.K)
+	}
+	// Every produced slice must be a HistogramQuantile whose inner
+	// RangeBucketFanout is re-gridded to that slice's own bounds — a
+	// duplication bug would instead show every slice sharing the SAME
+	// (unsliced) inner bounds.
+	seen := map[time.Time]bool{}
+	for _, sl := range d.Slices {
+		hq, ok := sl.Plan.(*chplan.HistogramQuantile)
+		if !ok {
+			t.Fatalf("slice %d plan is %T, want *chplan.HistogramQuantile", sl.Index, sl.Plan)
+		}
+		rbf, ok := hq.Input.(*chplan.RangeBucketFanout)
+		if !ok {
+			t.Fatalf("slice %d HistogramQuantile.Input is %T, want *chplan.RangeBucketFanout", sl.Index, hq.Input)
+		}
+		if rbf.Start.IsZero() || rbf.End.IsZero() {
+			t.Fatalf("slice %d left inner RangeBucketFanout bounds unpinned: Start=%v End=%v",
+				sl.Index, rbf.Start, rbf.End)
+		}
+		if seen[rbf.Start] {
+			t.Fatalf("slice %d inner RangeBucketFanout.Start=%v duplicates an earlier slice — "+
+				"every shard re-gridded to the SAME bounds instead of its own (the silent K-duplication hazard)",
+				sl.Index, rbf.Start)
+		}
+		seen[rbf.Start] = true
+	}
+	oldest := d.Slices[0].Plan.(*chplan.HistogramQuantile).Input.(*chplan.RangeBucketFanout)
+	newest := d.Slices[len(d.Slices)-1].Plan.(*chplan.HistogramQuantile).Input.(*chplan.RangeBucketFanout)
+	if !oldest.Start.Equal(gridStart) {
+		t.Fatalf("oldest slice inner Start=%v, want grid Start=%v", oldest.Start, gridStart)
+	}
+	if !newest.End.Equal(gridEnd) {
+		t.Fatalf("newest slice inner End=%v, want grid End=%v", newest.End, gridEnd)
+	}
+}
+
 // TestPlan_NonRangeWindowSpineRejected pins the residual routable-spine
-// restriction after phase 3: the routable bound-carriers are *RangeWindow
-// (phase 1) and *RangeLWR (phase 3). A RangeBucketFanout / StepGrid spine still
-// carries a grid ReanchorRange leaves un-re-anchored (CloneNode'd verbatim), so
-// each such plan must fail closed to route A with Reason=not-sliceable.
+// restriction: the routable bound-carriers are *RangeWindow (phase 1),
+// *RangeLWR (phase 3), and *RangeBucketFanout (the classic-histogram
+// OOM fix — see TestPlan_RangeBucketFanoutSpineRoutes for the positive case).
+// A StepGrid spine still carries a grid ReanchorRange leaves un-re-anchored
+// (CloneNode'd verbatim), so it must fail closed to route A with
+// Reason=not-sliceable.
 func TestPlan_NonRangeWindowSpineRejected(t *testing.T) {
 	t.Parallel()
 	cases := []struct {
 		name string
 		plan func() chplan.Node
 	}{
-		{
-			name: "RangeBucketFanout spine",
-			plan: func() chplan.Node {
-				return &chplan.RangeBucketFanout{
-					Input:        leafScan(),
-					Start:        gridStart,
-					End:          gridEnd,
-					Step:         gridStep,
-					Lookback:     5 * time.Minute,
-					AnchorAlias:  "anchor_ts",
-					TimestampCol: "TimeUnix",
-					AggFuncs: []chplan.AggFunc{{
-						Fn:    chplan.FnSumForEach,
-						Args:  []chplan.Expr{&chplan.ColumnRef{Name: "BucketCounts"}},
-						Alias: "BucketCounts",
-					}},
-				}
-			},
-		},
 		{
 			name: "StepGrid spine",
 			plan: func() chplan.Node {

--- a/internal/solver/slicer.go
+++ b/internal/solver/slicer.go
@@ -225,6 +225,21 @@ func unpinSpineCOW(n chplan.Node) (chplan.Node, bool) {
 		c.End = time.Time{}
 		c.Input = input
 		return &c, true
+	case *chplan.RangeBucketFanout:
+		input, _ := unpinSpineCOW(v.Input)
+		c := *v
+		c.Start = time.Time{}
+		c.End = time.Time{}
+		c.Input = input
+		return &c, true
+	case *chplan.HistogramQuantile:
+		input, changed := unpinSpineCOW(v.Input)
+		if !changed {
+			return v, false
+		}
+		c := *v
+		c.Input = input
+		return &c, true
 	case *chplan.Filter:
 		input, changed := unpinSpineCOW(v.Input)
 		if !changed {
@@ -286,6 +301,8 @@ func subtreeHasZeroableSpine(n chplan.Node) bool {
 		switch v := node.(type) {
 		case *chplan.RangeLWR:
 			found = true
+		case *chplan.RangeBucketFanout:
+			found = true
 		case *chplan.RangeWindow:
 			if v.Step > 0 {
 				found = true
@@ -322,6 +339,11 @@ func zeroSpineInPlace(n chplan.Node) {
 		zeroSpineInPlace(v.Input)
 		return
 	case *chplan.RangeLWR:
+		v.Start = time.Time{}
+		v.End = time.Time{}
+		zeroSpineInPlace(v.Input)
+		return
+	case *chplan.RangeBucketFanout:
 		v.Start = time.Time{}
 		v.End = time.Time{}
 		zeroSpineInPlace(v.Input)

--- a/test/perf/solver-decision-baseline/exp_histogram_changes/fanout.json
+++ b/test/perf/solver-decision-baseline/exp_histogram_changes/fanout.json
@@ -1,9 +1,9 @@
 {
   "query": "exp_histogram_changes/fanout",
   "lowering": "fanout",
-  "routed": false,
-  "k": 0,
-  "reason": "not-sliceable",
+  "routed": true,
+  "k": 8,
+  "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,
   "cumulative_d": "5m0s",

--- a/test/perf/solver-decision-baseline/exp_histogram_changes/native.json
+++ b/test/perf/solver-decision-baseline/exp_histogram_changes/native.json
@@ -1,9 +1,9 @@
 {
   "query": "exp_histogram_changes/native",
   "lowering": "native",
-  "routed": false,
-  "k": 0,
-  "reason": "not-sliceable",
+  "routed": true,
+  "k": 8,
+  "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,
   "cumulative_d": "5m0s",

--- a/test/perf/solver-decision-baseline/exp_histogram_count/fanout.json
+++ b/test/perf/solver-decision-baseline/exp_histogram_count/fanout.json
@@ -1,9 +1,9 @@
 {
   "query": "exp_histogram_count/fanout",
   "lowering": "fanout",
-  "routed": false,
-  "k": 0,
-  "reason": "not-sliceable",
+  "routed": true,
+  "k": 8,
+  "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,
   "cumulative_d": "5m0s",

--- a/test/perf/solver-decision-baseline/exp_histogram_count/native.json
+++ b/test/perf/solver-decision-baseline/exp_histogram_count/native.json
@@ -1,9 +1,9 @@
 {
   "query": "exp_histogram_count/native",
   "lowering": "native",
-  "routed": false,
-  "k": 0,
-  "reason": "not-sliceable",
+  "routed": true,
+  "k": 8,
+  "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,
   "cumulative_d": "5m0s",

--- a/test/perf/solver-decision-baseline/exp_histogram_count_by/fanout.json
+++ b/test/perf/solver-decision-baseline/exp_histogram_count_by/fanout.json
@@ -1,9 +1,9 @@
 {
   "query": "exp_histogram_count_by/fanout",
   "lowering": "fanout",
-  "routed": false,
-  "k": 0,
-  "reason": "not-sliceable",
+  "routed": true,
+  "k": 8,
+  "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,
   "cumulative_d": "5m0s",

--- a/test/perf/solver-decision-baseline/exp_histogram_count_by/native.json
+++ b/test/perf/solver-decision-baseline/exp_histogram_count_by/native.json
@@ -1,9 +1,9 @@
 {
   "query": "exp_histogram_count_by/native",
   "lowering": "native",
-  "routed": false,
-  "k": 0,
-  "reason": "not-sliceable",
+  "routed": true,
+  "k": 8,
+  "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,
   "cumulative_d": "5m0s",

--- a/test/perf/solver-decision-baseline/exp_histogram_resets/fanout.json
+++ b/test/perf/solver-decision-baseline/exp_histogram_resets/fanout.json
@@ -1,9 +1,9 @@
 {
   "query": "exp_histogram_resets/fanout",
   "lowering": "fanout",
-  "routed": false,
-  "k": 0,
-  "reason": "not-sliceable",
+  "routed": true,
+  "k": 8,
+  "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,
   "cumulative_d": "5m0s",

--- a/test/perf/solver-decision-baseline/exp_histogram_resets/native.json
+++ b/test/perf/solver-decision-baseline/exp_histogram_resets/native.json
@@ -1,9 +1,9 @@
 {
   "query": "exp_histogram_resets/native",
   "lowering": "native",
-  "routed": false,
-  "k": 0,
-  "reason": "not-sliceable",
+  "routed": true,
+  "k": 8,
+  "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,
   "cumulative_d": "5m0s",

--- a/test/perf/solver-decision-baseline/histogram_avg_exp/fanout.json
+++ b/test/perf/solver-decision-baseline/histogram_avg_exp/fanout.json
@@ -1,9 +1,9 @@
 {
   "query": "histogram_avg_exp/fanout",
   "lowering": "fanout",
-  "routed": false,
-  "k": 0,
-  "reason": "not-sliceable",
+  "routed": true,
+  "k": 8,
+  "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,
   "cumulative_d": "5m0s",

--- a/test/perf/solver-decision-baseline/histogram_avg_exp/native.json
+++ b/test/perf/solver-decision-baseline/histogram_avg_exp/native.json
@@ -1,9 +1,9 @@
 {
   "query": "histogram_avg_exp/native",
   "lowering": "native",
-  "routed": false,
-  "k": 0,
-  "reason": "not-sliceable",
+  "routed": true,
+  "k": 8,
+  "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,
   "cumulative_d": "5m0s",

--- a/test/perf/solver-decision-baseline/histogram_avg_exp_latest_sample/fanout.json
+++ b/test/perf/solver-decision-baseline/histogram_avg_exp_latest_sample/fanout.json
@@ -1,9 +1,9 @@
 {
   "query": "histogram_avg_exp_latest_sample/fanout",
   "lowering": "fanout",
-  "routed": false,
-  "k": 0,
-  "reason": "not-sliceable",
+  "routed": true,
+  "k": 8,
+  "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,
   "cumulative_d": "5m0s",

--- a/test/perf/solver-decision-baseline/histogram_avg_exp_latest_sample/native.json
+++ b/test/perf/solver-decision-baseline/histogram_avg_exp_latest_sample/native.json
@@ -1,9 +1,9 @@
 {
   "query": "histogram_avg_exp_latest_sample/native",
   "lowering": "native",
-  "routed": false,
-  "k": 0,
-  "reason": "not-sliceable",
+  "routed": true,
+  "k": 8,
+  "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,
   "cumulative_d": "5m0s",

--- a/test/perf/solver-decision-baseline/histogram_avg_exp_range_latest_sample/fanout.json
+++ b/test/perf/solver-decision-baseline/histogram_avg_exp_range_latest_sample/fanout.json
@@ -1,9 +1,9 @@
 {
   "query": "histogram_avg_exp_range_latest_sample/fanout",
   "lowering": "fanout",
-  "routed": false,
-  "k": 0,
-  "reason": "not-sliceable",
+  "routed": true,
+  "k": 8,
+  "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,
   "cumulative_d": "5m0s",

--- a/test/perf/solver-decision-baseline/histogram_avg_exp_range_latest_sample/native.json
+++ b/test/perf/solver-decision-baseline/histogram_avg_exp_range_latest_sample/native.json
@@ -1,9 +1,9 @@
 {
   "query": "histogram_avg_exp_range_latest_sample/native",
   "lowering": "native",
-  "routed": false,
-  "k": 0,
-  "reason": "not-sliceable",
+  "routed": true,
+  "k": 8,
+  "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,
   "cumulative_d": "5m0s",

--- a/test/perf/solver-decision-baseline/histogram_count_exp/fanout.json
+++ b/test/perf/solver-decision-baseline/histogram_count_exp/fanout.json
@@ -1,9 +1,9 @@
 {
   "query": "histogram_count_exp/fanout",
   "lowering": "fanout",
-  "routed": false,
-  "k": 0,
-  "reason": "not-sliceable",
+  "routed": true,
+  "k": 8,
+  "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,
   "cumulative_d": "5m0s",

--- a/test/perf/solver-decision-baseline/histogram_count_exp/native.json
+++ b/test/perf/solver-decision-baseline/histogram_count_exp/native.json
@@ -1,9 +1,9 @@
 {
   "query": "histogram_count_exp/native",
   "lowering": "native",
-  "routed": false,
-  "k": 0,
-  "reason": "not-sliceable",
+  "routed": true,
+  "k": 8,
+  "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,
   "cumulative_d": "5m0s",

--- a/test/perf/solver-decision-baseline/histogram_count_exp_bare_stale/fanout.json
+++ b/test/perf/solver-decision-baseline/histogram_count_exp_bare_stale/fanout.json
@@ -1,9 +1,9 @@
 {
   "query": "histogram_count_exp_bare_stale/fanout",
   "lowering": "fanout",
-  "routed": false,
-  "k": 0,
-  "reason": "not-sliceable",
+  "routed": true,
+  "k": 8,
+  "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,
   "cumulative_d": "5m0s",

--- a/test/perf/solver-decision-baseline/histogram_count_exp_bare_stale/native.json
+++ b/test/perf/solver-decision-baseline/histogram_count_exp_bare_stale/native.json
@@ -1,9 +1,9 @@
 {
   "query": "histogram_count_exp_bare_stale/native",
   "lowering": "native",
-  "routed": false,
-  "k": 0,
-  "reason": "not-sliceable",
+  "routed": true,
+  "k": 8,
+  "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,
   "cumulative_d": "5m0s",

--- a/test/perf/solver-decision-baseline/histogram_count_exp_latest_sample/fanout.json
+++ b/test/perf/solver-decision-baseline/histogram_count_exp_latest_sample/fanout.json
@@ -1,9 +1,9 @@
 {
   "query": "histogram_count_exp_latest_sample/fanout",
   "lowering": "fanout",
-  "routed": false,
-  "k": 0,
-  "reason": "not-sliceable",
+  "routed": true,
+  "k": 8,
+  "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,
   "cumulative_d": "5m0s",

--- a/test/perf/solver-decision-baseline/histogram_count_exp_latest_sample/native.json
+++ b/test/perf/solver-decision-baseline/histogram_count_exp_latest_sample/native.json
@@ -1,9 +1,9 @@
 {
   "query": "histogram_count_exp_latest_sample/native",
   "lowering": "native",
-  "routed": false,
-  "k": 0,
-  "reason": "not-sliceable",
+  "routed": true,
+  "k": 8,
+  "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,
   "cumulative_d": "5m0s",

--- a/test/perf/solver-decision-baseline/histogram_count_exp_range_latest_sample/fanout.json
+++ b/test/perf/solver-decision-baseline/histogram_count_exp_range_latest_sample/fanout.json
@@ -1,9 +1,9 @@
 {
   "query": "histogram_count_exp_range_latest_sample/fanout",
   "lowering": "fanout",
-  "routed": false,
-  "k": 0,
-  "reason": "not-sliceable",
+  "routed": true,
+  "k": 8,
+  "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,
   "cumulative_d": "5m0s",

--- a/test/perf/solver-decision-baseline/histogram_count_exp_range_latest_sample/native.json
+++ b/test/perf/solver-decision-baseline/histogram_count_exp_range_latest_sample/native.json
@@ -1,9 +1,9 @@
 {
   "query": "histogram_count_exp_range_latest_sample/native",
   "lowering": "native",
-  "routed": false,
-  "k": 0,
-  "reason": "not-sliceable",
+  "routed": true,
+  "k": 8,
+  "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,
   "cumulative_d": "5m0s",

--- a/test/perf/solver-decision-baseline/histogram_count_float_metric_empty/fanout.json
+++ b/test/perf/solver-decision-baseline/histogram_count_float_metric_empty/fanout.json
@@ -1,9 +1,9 @@
 {
   "query": "histogram_count_float_metric_empty/fanout",
   "lowering": "fanout",
-  "routed": false,
-  "k": 0,
-  "reason": "not-sliceable",
+  "routed": true,
+  "k": 8,
+  "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,
   "cumulative_d": "5m0s",

--- a/test/perf/solver-decision-baseline/histogram_count_float_metric_empty/native.json
+++ b/test/perf/solver-decision-baseline/histogram_count_float_metric_empty/native.json
@@ -1,9 +1,9 @@
 {
   "query": "histogram_count_float_metric_empty/native",
   "lowering": "native",
-  "routed": false,
-  "k": 0,
-  "reason": "not-sliceable",
+  "routed": true,
+  "k": 8,
+  "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,
   "cumulative_d": "5m0s",

--- a/test/perf/solver-decision-baseline/histogram_fraction_exp/fanout.json
+++ b/test/perf/solver-decision-baseline/histogram_fraction_exp/fanout.json
@@ -1,9 +1,9 @@
 {
   "query": "histogram_fraction_exp/fanout",
   "lowering": "fanout",
-  "routed": false,
-  "k": 0,
-  "reason": "not-sliceable",
+  "routed": true,
+  "k": 8,
+  "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,
   "cumulative_d": "5m0s",

--- a/test/perf/solver-decision-baseline/histogram_fraction_exp/native.json
+++ b/test/perf/solver-decision-baseline/histogram_fraction_exp/native.json
@@ -1,9 +1,9 @@
 {
   "query": "histogram_fraction_exp/native",
   "lowering": "native",
-  "routed": false,
-  "k": 0,
-  "reason": "not-sliceable",
+  "routed": true,
+  "k": 8,
+  "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,
   "cumulative_d": "5m0s",

--- a/test/perf/solver-decision-baseline/histogram_fraction_exp_negative_bounds/fanout.json
+++ b/test/perf/solver-decision-baseline/histogram_fraction_exp_negative_bounds/fanout.json
@@ -1,9 +1,9 @@
 {
   "query": "histogram_fraction_exp_negative_bounds/fanout",
   "lowering": "fanout",
-  "routed": false,
-  "k": 0,
-  "reason": "not-sliceable",
+  "routed": true,
+  "k": 8,
+  "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,
   "cumulative_d": "5m0s",

--- a/test/perf/solver-decision-baseline/histogram_fraction_exp_negative_bounds/native.json
+++ b/test/perf/solver-decision-baseline/histogram_fraction_exp_negative_bounds/native.json
@@ -1,9 +1,9 @@
 {
   "query": "histogram_fraction_exp_negative_bounds/native",
   "lowering": "native",
-  "routed": false,
-  "k": 0,
-  "reason": "not-sliceable",
+  "routed": true,
+  "k": 8,
+  "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,
   "cumulative_d": "5m0s",

--- a/test/perf/solver-decision-baseline/histogram_fraction_exp_negative_range/fanout.json
+++ b/test/perf/solver-decision-baseline/histogram_fraction_exp_negative_range/fanout.json
@@ -1,9 +1,9 @@
 {
   "query": "histogram_fraction_exp_negative_range/fanout",
   "lowering": "fanout",
-  "routed": false,
-  "k": 0,
-  "reason": "not-sliceable",
+  "routed": true,
+  "k": 8,
+  "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,
   "cumulative_d": "5m0s",

--- a/test/perf/solver-decision-baseline/histogram_fraction_exp_negative_range/native.json
+++ b/test/perf/solver-decision-baseline/histogram_fraction_exp_negative_range/native.json
@@ -1,9 +1,9 @@
 {
   "query": "histogram_fraction_exp_negative_range/native",
   "lowering": "native",
-  "routed": false,
-  "k": 0,
-  "reason": "not-sliceable",
+  "routed": true,
+  "k": 8,
+  "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,
   "cumulative_d": "5m0s",

--- a/test/perf/solver-decision-baseline/histogram_quantile_agg_empty/fanout.json
+++ b/test/perf/solver-decision-baseline/histogram_quantile_agg_empty/fanout.json
@@ -1,9 +1,9 @@
 {
   "query": "histogram_quantile_agg_empty/fanout",
   "lowering": "fanout",
-  "routed": false,
-  "k": 0,
-  "reason": "not-sliceable",
+  "routed": true,
+  "k": 8,
+  "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,
   "cumulative_d": "5m0s",

--- a/test/perf/solver-decision-baseline/histogram_quantile_agg_empty/native.json
+++ b/test/perf/solver-decision-baseline/histogram_quantile_agg_empty/native.json
@@ -1,9 +1,9 @@
 {
   "query": "histogram_quantile_agg_empty/native",
   "lowering": "native",
-  "routed": false,
-  "k": 0,
-  "reason": "not-sliceable",
+  "routed": true,
+  "k": 8,
+  "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,
   "cumulative_d": "5m0s",

--- a/test/perf/solver-decision-baseline/histogram_quantile_agg_no_range_wrapper/fanout.json
+++ b/test/perf/solver-decision-baseline/histogram_quantile_agg_no_range_wrapper/fanout.json
@@ -1,9 +1,9 @@
 {
   "query": "histogram_quantile_agg_no_range_wrapper/fanout",
   "lowering": "fanout",
-  "routed": false,
-  "k": 0,
-  "reason": "not-sliceable",
+  "routed": true,
+  "k": 8,
+  "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,
   "cumulative_d": "5m0s",

--- a/test/perf/solver-decision-baseline/histogram_quantile_agg_no_range_wrapper/native.json
+++ b/test/perf/solver-decision-baseline/histogram_quantile_agg_no_range_wrapper/native.json
@@ -1,9 +1,9 @@
 {
   "query": "histogram_quantile_agg_no_range_wrapper/native",
   "lowering": "native",
-  "routed": false,
-  "k": 0,
-  "reason": "not-sliceable",
+  "routed": true,
+  "k": 8,
+  "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,
   "cumulative_d": "5m0s",

--- a/test/perf/solver-decision-baseline/histogram_quantile_avg_by_le/fanout.json
+++ b/test/perf/solver-decision-baseline/histogram_quantile_avg_by_le/fanout.json
@@ -1,9 +1,9 @@
 {
   "query": "histogram_quantile_avg_by_le/fanout",
   "lowering": "fanout",
-  "routed": false,
-  "k": 0,
-  "reason": "not-sliceable",
+  "routed": true,
+  "k": 8,
+  "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,
   "cumulative_d": "5m0s",

--- a/test/perf/solver-decision-baseline/histogram_quantile_avg_by_le/native.json
+++ b/test/perf/solver-decision-baseline/histogram_quantile_avg_by_le/native.json
@@ -1,9 +1,9 @@
 {
   "query": "histogram_quantile_avg_by_le/native",
   "lowering": "native",
-  "routed": false,
-  "k": 0,
-  "reason": "not-sliceable",
+  "routed": true,
+  "k": 8,
+  "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,
   "cumulative_d": "5m0s",

--- a/test/perf/solver-decision-baseline/histogram_quantile_bare_name_unsatisfiable/fanout.json
+++ b/test/perf/solver-decision-baseline/histogram_quantile_bare_name_unsatisfiable/fanout.json
@@ -1,9 +1,9 @@
 {
   "query": "histogram_quantile_bare_name_unsatisfiable/fanout",
   "lowering": "fanout",
-  "routed": false,
-  "k": 0,
-  "reason": "not-sliceable",
+  "routed": true,
+  "k": 8,
+  "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,
   "cumulative_d": "5m0s",

--- a/test/perf/solver-decision-baseline/histogram_quantile_bare_name_unsatisfiable/native.json
+++ b/test/perf/solver-decision-baseline/histogram_quantile_bare_name_unsatisfiable/native.json
@@ -1,9 +1,9 @@
 {
   "query": "histogram_quantile_bare_name_unsatisfiable/native",
   "lowering": "native",
-  "routed": false,
-  "k": 0,
-  "reason": "not-sliceable",
+  "routed": true,
+  "k": 8,
+  "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,
   "cumulative_d": "5m0s",

--- a/test/perf/solver-decision-baseline/histogram_quantile_classic_agg_offset_range/fanout.json
+++ b/test/perf/solver-decision-baseline/histogram_quantile_classic_agg_offset_range/fanout.json
@@ -3,7 +3,7 @@
   "lowering": "fanout",
   "routed": false,
   "k": 0,
-  "reason": "not-sliceable",
+  "reason": "below-threshold",
   "n_anchors": 241,
   "fanout": 8,
   "cumulative_d": "2m0s",

--- a/test/perf/solver-decision-baseline/histogram_quantile_classic_agg_offset_range/native.json
+++ b/test/perf/solver-decision-baseline/histogram_quantile_classic_agg_offset_range/native.json
@@ -3,7 +3,7 @@
   "lowering": "native",
   "routed": false,
   "k": 0,
-  "reason": "not-sliceable",
+  "reason": "below-threshold",
   "n_anchors": 241,
   "fanout": 8,
   "cumulative_d": "2m0s",

--- a/test/perf/solver-decision-baseline/histogram_quantile_classic_agg_plateau/fanout.json
+++ b/test/perf/solver-decision-baseline/histogram_quantile_classic_agg_plateau/fanout.json
@@ -1,9 +1,9 @@
 {
   "query": "histogram_quantile_classic_agg_plateau/fanout",
   "lowering": "fanout",
-  "routed": false,
-  "k": 0,
-  "reason": "not-sliceable",
+  "routed": true,
+  "k": 8,
+  "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,
   "cumulative_d": "5m0s",

--- a/test/perf/solver-decision-baseline/histogram_quantile_classic_agg_plateau/native.json
+++ b/test/perf/solver-decision-baseline/histogram_quantile_classic_agg_plateau/native.json
@@ -1,9 +1,9 @@
 {
   "query": "histogram_quantile_classic_agg_plateau/native",
   "lowering": "native",
-  "routed": false,
-  "k": 0,
-  "reason": "not-sliceable",
+  "routed": true,
+  "k": 8,
+  "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,
   "cumulative_d": "5m0s",

--- a/test/perf/solver-decision-baseline/histogram_quantile_classic_agg_rate_min_samples/fanout.json
+++ b/test/perf/solver-decision-baseline/histogram_quantile_classic_agg_rate_min_samples/fanout.json
@@ -3,7 +3,7 @@
   "lowering": "fanout",
   "routed": false,
   "k": 0,
-  "reason": "not-sliceable",
+  "reason": "below-threshold",
   "n_anchors": 241,
   "fanout": 4,
   "cumulative_d": "1m0s",

--- a/test/perf/solver-decision-baseline/histogram_quantile_classic_agg_rate_min_samples/native.json
+++ b/test/perf/solver-decision-baseline/histogram_quantile_classic_agg_rate_min_samples/native.json
@@ -3,7 +3,7 @@
   "lowering": "native",
   "routed": false,
   "k": 0,
-  "reason": "not-sliceable",
+  "reason": "below-threshold",
   "n_anchors": 241,
   "fanout": 4,
   "cumulative_d": "1m0s",

--- a/test/perf/solver-decision-baseline/histogram_quantile_classic_bare_rate_min_samples/fanout.json
+++ b/test/perf/solver-decision-baseline/histogram_quantile_classic_bare_rate_min_samples/fanout.json
@@ -3,7 +3,7 @@
   "lowering": "fanout",
   "routed": false,
   "k": 0,
-  "reason": "not-sliceable",
+  "reason": "below-threshold",
   "n_anchors": 241,
   "fanout": 4,
   "cumulative_d": "1m0s",

--- a/test/perf/solver-decision-baseline/histogram_quantile_classic_bare_rate_min_samples/native.json
+++ b/test/perf/solver-decision-baseline/histogram_quantile_classic_bare_rate_min_samples/native.json
@@ -3,7 +3,7 @@
   "lowering": "native",
   "routed": false,
   "k": 0,
-  "reason": "not-sliceable",
+  "reason": "below-threshold",
   "n_anchors": 241,
   "fanout": 4,
   "cumulative_d": "1m0s",

--- a/test/perf/solver-decision-baseline/histogram_quantile_classic_count_values_by_le/fanout.json
+++ b/test/perf/solver-decision-baseline/histogram_quantile_classic_count_values_by_le/fanout.json
@@ -1,9 +1,9 @@
 {
   "query": "histogram_quantile_classic_count_values_by_le/fanout",
   "lowering": "fanout",
-  "routed": false,
-  "k": 0,
-  "reason": "not-sliceable",
+  "routed": true,
+  "k": 8,
+  "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,
   "cumulative_d": "5m0s",

--- a/test/perf/solver-decision-baseline/histogram_quantile_classic_count_values_by_le/native.json
+++ b/test/perf/solver-decision-baseline/histogram_quantile_classic_count_values_by_le/native.json
@@ -1,9 +1,9 @@
 {
   "query": "histogram_quantile_classic_count_values_by_le/native",
   "lowering": "native",
-  "routed": false,
-  "k": 0,
-  "reason": "not-sliceable",
+  "routed": true,
+  "k": 8,
+  "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,
   "cumulative_d": "5m0s",

--- a/test/perf/solver-decision-baseline/histogram_quantile_classic_delta_temporality/fanout.json
+++ b/test/perf/solver-decision-baseline/histogram_quantile_classic_delta_temporality/fanout.json
@@ -3,7 +3,7 @@
   "lowering": "fanout",
   "routed": false,
   "k": 0,
-  "reason": "not-sliceable",
+  "reason": "below-threshold",
   "n_anchors": 241,
   "fanout": 4,
   "cumulative_d": "1m0s",

--- a/test/perf/solver-decision-baseline/histogram_quantile_classic_delta_temporality/native.json
+++ b/test/perf/solver-decision-baseline/histogram_quantile_classic_delta_temporality/native.json
@@ -3,7 +3,7 @@
   "lowering": "native",
   "routed": false,
   "k": 0,
-  "reason": "not-sliceable",
+  "reason": "below-threshold",
   "n_anchors": 241,
   "fanout": 4,
   "cumulative_d": "1m0s",

--- a/test/perf/solver-decision-baseline/histogram_quantile_classic_duplicate_bounds/fanout.json
+++ b/test/perf/solver-decision-baseline/histogram_quantile_classic_duplicate_bounds/fanout.json
@@ -1,9 +1,9 @@
 {
   "query": "histogram_quantile_classic_duplicate_bounds/fanout",
   "lowering": "fanout",
-  "routed": false,
-  "k": 0,
-  "reason": "not-sliceable",
+  "routed": true,
+  "k": 8,
+  "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,
   "cumulative_d": "5m0s",

--- a/test/perf/solver-decision-baseline/histogram_quantile_classic_duplicate_bounds/native.json
+++ b/test/perf/solver-decision-baseline/histogram_quantile_classic_duplicate_bounds/native.json
@@ -1,9 +1,9 @@
 {
   "query": "histogram_quantile_classic_duplicate_bounds/native",
   "lowering": "native",
-  "routed": false,
-  "k": 0,
-  "reason": "not-sliceable",
+  "routed": true,
+  "k": 8,
+  "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,
   "cumulative_d": "5m0s",

--- a/test/perf/solver-decision-baseline/histogram_quantile_classic_edge_p0/fanout.json
+++ b/test/perf/solver-decision-baseline/histogram_quantile_classic_edge_p0/fanout.json
@@ -1,9 +1,9 @@
 {
   "query": "histogram_quantile_classic_edge_p0/fanout",
   "lowering": "fanout",
-  "routed": false,
-  "k": 0,
-  "reason": "not-sliceable",
+  "routed": true,
+  "k": 8,
+  "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,
   "cumulative_d": "5m0s",

--- a/test/perf/solver-decision-baseline/histogram_quantile_classic_edge_p0/native.json
+++ b/test/perf/solver-decision-baseline/histogram_quantile_classic_edge_p0/native.json
@@ -1,9 +1,9 @@
 {
   "query": "histogram_quantile_classic_edge_p0/native",
   "lowering": "native",
-  "routed": false,
-  "k": 0,
-  "reason": "not-sliceable",
+  "routed": true,
+  "k": 8,
+  "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,
   "cumulative_d": "5m0s",

--- a/test/perf/solver-decision-baseline/histogram_quantile_classic_edge_p100/fanout.json
+++ b/test/perf/solver-decision-baseline/histogram_quantile_classic_edge_p100/fanout.json
@@ -1,9 +1,9 @@
 {
   "query": "histogram_quantile_classic_edge_p100/fanout",
   "lowering": "fanout",
-  "routed": false,
-  "k": 0,
-  "reason": "not-sliceable",
+  "routed": true,
+  "k": 8,
+  "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,
   "cumulative_d": "5m0s",

--- a/test/perf/solver-decision-baseline/histogram_quantile_classic_edge_p100/native.json
+++ b/test/perf/solver-decision-baseline/histogram_quantile_classic_edge_p100/native.json
@@ -1,9 +1,9 @@
 {
   "query": "histogram_quantile_classic_edge_p100/native",
   "lowering": "native",
-  "routed": false,
-  "k": 0,
-  "reason": "not-sliceable",
+  "routed": true,
+  "k": 8,
+  "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,
   "cumulative_d": "5m0s",

--- a/test/perf/solver-decision-baseline/histogram_quantile_classic_empty/fanout.json
+++ b/test/perf/solver-decision-baseline/histogram_quantile_classic_empty/fanout.json
@@ -1,9 +1,9 @@
 {
   "query": "histogram_quantile_classic_empty/fanout",
   "lowering": "fanout",
-  "routed": false,
-  "k": 0,
-  "reason": "not-sliceable",
+  "routed": true,
+  "k": 8,
+  "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,
   "cumulative_d": "5m0s",

--- a/test/perf/solver-decision-baseline/histogram_quantile_classic_empty/native.json
+++ b/test/perf/solver-decision-baseline/histogram_quantile_classic_empty/native.json
@@ -1,9 +1,9 @@
 {
   "query": "histogram_quantile_classic_empty/native",
   "lowering": "native",
-  "routed": false,
-  "k": 0,
-  "reason": "not-sliceable",
+  "routed": true,
+  "k": 8,
+  "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,
   "cumulative_d": "5m0s",

--- a/test/perf/solver-decision-baseline/histogram_quantile_classic_latest_sample/fanout.json
+++ b/test/perf/solver-decision-baseline/histogram_quantile_classic_latest_sample/fanout.json
@@ -1,9 +1,9 @@
 {
   "query": "histogram_quantile_classic_latest_sample/fanout",
   "lowering": "fanout",
-  "routed": false,
-  "k": 0,
-  "reason": "not-sliceable",
+  "routed": true,
+  "k": 8,
+  "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,
   "cumulative_d": "5m0s",

--- a/test/perf/solver-decision-baseline/histogram_quantile_classic_latest_sample/native.json
+++ b/test/perf/solver-decision-baseline/histogram_quantile_classic_latest_sample/native.json
@@ -1,9 +1,9 @@
 {
   "query": "histogram_quantile_classic_latest_sample/native",
   "lowering": "native",
-  "routed": false,
-  "k": 0,
-  "reason": "not-sliceable",
+  "routed": true,
+  "k": 8,
+  "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,
   "cumulative_d": "5m0s",

--- a/test/perf/solver-decision-baseline/histogram_quantile_classic_multi_series/fanout.json
+++ b/test/perf/solver-decision-baseline/histogram_quantile_classic_multi_series/fanout.json
@@ -1,9 +1,9 @@
 {
   "query": "histogram_quantile_classic_multi_series/fanout",
   "lowering": "fanout",
-  "routed": false,
-  "k": 0,
-  "reason": "not-sliceable",
+  "routed": true,
+  "k": 8,
+  "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,
   "cumulative_d": "5m0s",

--- a/test/perf/solver-decision-baseline/histogram_quantile_classic_multi_series/native.json
+++ b/test/perf/solver-decision-baseline/histogram_quantile_classic_multi_series/native.json
@@ -1,9 +1,9 @@
 {
   "query": "histogram_quantile_classic_multi_series/native",
   "lowering": "native",
-  "routed": false,
-  "k": 0,
-  "reason": "not-sliceable",
+  "routed": true,
+  "k": 8,
+  "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,
   "cumulative_d": "5m0s",

--- a/test/perf/solver-decision-baseline/histogram_quantile_classic_negative_bound_upper_rank/fanout.json
+++ b/test/perf/solver-decision-baseline/histogram_quantile_classic_negative_bound_upper_rank/fanout.json
@@ -1,9 +1,9 @@
 {
   "query": "histogram_quantile_classic_negative_bound_upper_rank/fanout",
   "lowering": "fanout",
-  "routed": false,
-  "k": 0,
-  "reason": "not-sliceable",
+  "routed": true,
+  "k": 8,
+  "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,
   "cumulative_d": "5m0s",

--- a/test/perf/solver-decision-baseline/histogram_quantile_classic_negative_bound_upper_rank/native.json
+++ b/test/perf/solver-decision-baseline/histogram_quantile_classic_negative_bound_upper_rank/native.json
@@ -1,9 +1,9 @@
 {
   "query": "histogram_quantile_classic_negative_bound_upper_rank/native",
   "lowering": "native",
-  "routed": false,
-  "k": 0,
-  "reason": "not-sliceable",
+  "routed": true,
+  "k": 8,
+  "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,
   "cumulative_d": "5m0s",

--- a/test/perf/solver-decision-baseline/histogram_quantile_classic_negative_lowest_bound/fanout.json
+++ b/test/perf/solver-decision-baseline/histogram_quantile_classic_negative_lowest_bound/fanout.json
@@ -1,9 +1,9 @@
 {
   "query": "histogram_quantile_classic_negative_lowest_bound/fanout",
   "lowering": "fanout",
-  "routed": false,
-  "k": 0,
-  "reason": "not-sliceable",
+  "routed": true,
+  "k": 8,
+  "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,
   "cumulative_d": "5m0s",

--- a/test/perf/solver-decision-baseline/histogram_quantile_classic_negative_lowest_bound/native.json
+++ b/test/perf/solver-decision-baseline/histogram_quantile_classic_negative_lowest_bound/native.json
@@ -1,9 +1,9 @@
 {
   "query": "histogram_quantile_classic_negative_lowest_bound/native",
   "lowering": "native",
-  "routed": false,
-  "k": 0,
-  "reason": "not-sliceable",
+  "routed": true,
+  "k": 8,
+  "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,
   "cumulative_d": "5m0s",

--- a/test/perf/solver-decision-baseline/histogram_quantile_classic_plateau_overflow/fanout.json
+++ b/test/perf/solver-decision-baseline/histogram_quantile_classic_plateau_overflow/fanout.json
@@ -1,9 +1,9 @@
 {
   "query": "histogram_quantile_classic_plateau_overflow/fanout",
   "lowering": "fanout",
-  "routed": false,
-  "k": 0,
-  "reason": "not-sliceable",
+  "routed": true,
+  "k": 8,
+  "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,
   "cumulative_d": "5m0s",

--- a/test/perf/solver-decision-baseline/histogram_quantile_classic_plateau_overflow/native.json
+++ b/test/perf/solver-decision-baseline/histogram_quantile_classic_plateau_overflow/native.json
@@ -1,9 +1,9 @@
 {
   "query": "histogram_quantile_classic_plateau_overflow/native",
   "lowering": "native",
-  "routed": false,
-  "k": 0,
-  "reason": "not-sliceable",
+  "routed": true,
+  "k": 8,
+  "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,
   "cumulative_d": "5m0s",

--- a/test/perf/solver-decision-baseline/histogram_quantile_classic_range_step/fanout.json
+++ b/test/perf/solver-decision-baseline/histogram_quantile_classic_range_step/fanout.json
@@ -1,9 +1,9 @@
 {
   "query": "histogram_quantile_classic_range_step/fanout",
   "lowering": "fanout",
-  "routed": false,
-  "k": 0,
-  "reason": "not-sliceable",
+  "routed": true,
+  "k": 8,
+  "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,
   "cumulative_d": "5m0s",

--- a/test/perf/solver-decision-baseline/histogram_quantile_classic_range_step/native.json
+++ b/test/perf/solver-decision-baseline/histogram_quantile_classic_range_step/native.json
@@ -1,9 +1,9 @@
 {
   "query": "histogram_quantile_classic_range_step/native",
   "lowering": "native",
-  "routed": false,
-  "k": 0,
-  "reason": "not-sliceable",
+  "routed": true,
+  "k": 8,
+  "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,
   "cumulative_d": "5m0s",

--- a/test/perf/solver-decision-baseline/histogram_quantile_classic_range_step_bare/fanout.json
+++ b/test/perf/solver-decision-baseline/histogram_quantile_classic_range_step_bare/fanout.json
@@ -1,9 +1,9 @@
 {
   "query": "histogram_quantile_classic_range_step_bare/fanout",
   "lowering": "fanout",
-  "routed": false,
-  "k": 0,
-  "reason": "not-sliceable",
+  "routed": true,
+  "k": 8,
+  "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,
   "cumulative_d": "5m0s",

--- a/test/perf/solver-decision-baseline/histogram_quantile_classic_range_step_bare/native.json
+++ b/test/perf/solver-decision-baseline/histogram_quantile_classic_range_step_bare/native.json
@@ -1,9 +1,9 @@
 {
   "query": "histogram_quantile_classic_range_step_bare/native",
   "lowering": "native",
-  "routed": false,
-  "k": 0,
-  "reason": "not-sliceable",
+  "routed": true,
+  "k": 8,
+  "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,
   "cumulative_d": "5m0s",

--- a/test/perf/solver-decision-baseline/histogram_quantile_classic_single_bucket/fanout.json
+++ b/test/perf/solver-decision-baseline/histogram_quantile_classic_single_bucket/fanout.json
@@ -1,9 +1,9 @@
 {
   "query": "histogram_quantile_classic_single_bucket/fanout",
   "lowering": "fanout",
-  "routed": false,
-  "k": 0,
-  "reason": "not-sliceable",
+  "routed": true,
+  "k": 8,
+  "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,
   "cumulative_d": "5m0s",

--- a/test/perf/solver-decision-baseline/histogram_quantile_classic_single_bucket/native.json
+++ b/test/perf/solver-decision-baseline/histogram_quantile_classic_single_bucket/native.json
@@ -1,9 +1,9 @@
 {
   "query": "histogram_quantile_classic_single_bucket/native",
   "lowering": "native",
-  "routed": false,
-  "k": 0,
-  "reason": "not-sliceable",
+  "routed": true,
+  "k": 8,
+  "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,
   "cumulative_d": "5m0s",

--- a/test/perf/solver-decision-baseline/histogram_quantile_classic_zero_count_plateau/fanout.json
+++ b/test/perf/solver-decision-baseline/histogram_quantile_classic_zero_count_plateau/fanout.json
@@ -1,9 +1,9 @@
 {
   "query": "histogram_quantile_classic_zero_count_plateau/fanout",
   "lowering": "fanout",
-  "routed": false,
-  "k": 0,
-  "reason": "not-sliceable",
+  "routed": true,
+  "k": 8,
+  "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,
   "cumulative_d": "5m0s",

--- a/test/perf/solver-decision-baseline/histogram_quantile_classic_zero_count_plateau/native.json
+++ b/test/perf/solver-decision-baseline/histogram_quantile_classic_zero_count_plateau/native.json
@@ -1,9 +1,9 @@
 {
   "query": "histogram_quantile_classic_zero_count_plateau/native",
   "lowering": "native",
-  "routed": false,
-  "k": 0,
-  "reason": "not-sliceable",
+  "routed": true,
+  "k": 8,
+  "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,
   "cumulative_d": "5m0s",

--- a/test/perf/solver-decision-baseline/histogram_quantile_count_by_le/fanout.json
+++ b/test/perf/solver-decision-baseline/histogram_quantile_count_by_le/fanout.json
@@ -1,9 +1,9 @@
 {
   "query": "histogram_quantile_count_by_le/fanout",
   "lowering": "fanout",
-  "routed": false,
-  "k": 0,
-  "reason": "not-sliceable",
+  "routed": true,
+  "k": 8,
+  "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,
   "cumulative_d": "5m0s",

--- a/test/perf/solver-decision-baseline/histogram_quantile_count_by_le/native.json
+++ b/test/perf/solver-decision-baseline/histogram_quantile_count_by_le/native.json
@@ -1,9 +1,9 @@
 {
   "query": "histogram_quantile_count_by_le/native",
   "lowering": "native",
-  "routed": false,
-  "k": 0,
-  "reason": "not-sliceable",
+  "routed": true,
+  "k": 8,
+  "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,
   "cumulative_d": "5m0s",

--- a/test/perf/solver-decision-baseline/histogram_quantile_le_not_in_by/fanout.json
+++ b/test/perf/solver-decision-baseline/histogram_quantile_le_not_in_by/fanout.json
@@ -1,9 +1,9 @@
 {
   "query": "histogram_quantile_le_not_in_by/fanout",
   "lowering": "fanout",
-  "routed": false,
-  "k": 0,
-  "reason": "not-sliceable",
+  "routed": true,
+  "k": 8,
+  "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,
   "cumulative_d": "5m0s",

--- a/test/perf/solver-decision-baseline/histogram_quantile_le_not_in_by/native.json
+++ b/test/perf/solver-decision-baseline/histogram_quantile_le_not_in_by/native.json
@@ -1,9 +1,9 @@
 {
   "query": "histogram_quantile_le_not_in_by/native",
   "lowering": "native",
-  "routed": false,
-  "k": 0,
-  "reason": "not-sliceable",
+  "routed": true,
+  "k": 8,
+  "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,
   "cumulative_d": "5m0s",

--- a/test/perf/solver-decision-baseline/histogram_quantile_le_regex_bound_subset/fanout.json
+++ b/test/perf/solver-decision-baseline/histogram_quantile_le_regex_bound_subset/fanout.json
@@ -1,9 +1,9 @@
 {
   "query": "histogram_quantile_le_regex_bound_subset/fanout",
   "lowering": "fanout",
-  "routed": false,
-  "k": 0,
-  "reason": "not-sliceable",
+  "routed": true,
+  "k": 8,
+  "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,
   "cumulative_d": "5m0s",

--- a/test/perf/solver-decision-baseline/histogram_quantile_le_regex_bound_subset/native.json
+++ b/test/perf/solver-decision-baseline/histogram_quantile_le_regex_bound_subset/native.json
@@ -1,9 +1,9 @@
 {
   "query": "histogram_quantile_le_regex_bound_subset/native",
   "lowering": "native",
-  "routed": false,
-  "k": 0,
-  "reason": "not-sliceable",
+  "routed": true,
+  "k": 8,
+  "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,
   "cumulative_d": "5m0s",

--- a/test/perf/solver-decision-baseline/histogram_quantile_max_by_le/fanout.json
+++ b/test/perf/solver-decision-baseline/histogram_quantile_max_by_le/fanout.json
@@ -1,9 +1,9 @@
 {
   "query": "histogram_quantile_max_by_le/fanout",
   "lowering": "fanout",
-  "routed": false,
-  "k": 0,
-  "reason": "not-sliceable",
+  "routed": true,
+  "k": 8,
+  "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,
   "cumulative_d": "5m0s",

--- a/test/perf/solver-decision-baseline/histogram_quantile_max_by_le/native.json
+++ b/test/perf/solver-decision-baseline/histogram_quantile_max_by_le/native.json
@@ -1,9 +1,9 @@
 {
   "query": "histogram_quantile_max_by_le/native",
   "lowering": "native",
-  "routed": false,
-  "k": 0,
-  "reason": "not-sliceable",
+  "routed": true,
+  "k": 8,
+  "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,
   "cumulative_d": "5m0s",

--- a/test/perf/solver-decision-baseline/histogram_quantile_over_sum_over_time_bucket/fanout.json
+++ b/test/perf/solver-decision-baseline/histogram_quantile_over_sum_over_time_bucket/fanout.json
@@ -1,9 +1,9 @@
 {
   "query": "histogram_quantile_over_sum_over_time_bucket/fanout",
   "lowering": "fanout",
-  "routed": false,
-  "k": 0,
-  "reason": "not-sliceable",
+  "routed": true,
+  "k": 8,
+  "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,
   "cumulative_d": "5m0s",

--- a/test/perf/solver-decision-baseline/histogram_quantile_over_sum_over_time_bucket/native.json
+++ b/test/perf/solver-decision-baseline/histogram_quantile_over_sum_over_time_bucket/native.json
@@ -1,9 +1,9 @@
 {
   "query": "histogram_quantile_over_sum_over_time_bucket/native",
   "lowering": "native",
-  "routed": false,
-  "k": 0,
-  "reason": "not-sliceable",
+  "routed": true,
+  "k": 8,
+  "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,
   "cumulative_d": "5m0s",

--- a/test/perf/solver-decision-baseline/histogram_quantile_quantile_by_le/fanout.json
+++ b/test/perf/solver-decision-baseline/histogram_quantile_quantile_by_le/fanout.json
@@ -1,9 +1,9 @@
 {
   "query": "histogram_quantile_quantile_by_le/fanout",
   "lowering": "fanout",
-  "routed": false,
-  "k": 0,
-  "reason": "not-sliceable",
+  "routed": true,
+  "k": 8,
+  "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,
   "cumulative_d": "5m0s",

--- a/test/perf/solver-decision-baseline/histogram_quantile_quantile_by_le/native.json
+++ b/test/perf/solver-decision-baseline/histogram_quantile_quantile_by_le/native.json
@@ -1,9 +1,9 @@
 {
   "query": "histogram_quantile_quantile_by_le/native",
   "lowering": "native",
-  "routed": false,
-  "k": 0,
-  "reason": "not-sliceable",
+  "routed": true,
+  "k": 8,
+  "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,
   "cumulative_d": "5m0s",

--- a/test/perf/solver-decision-baseline/histogram_quantile_scalar_phi/fanout.json
+++ b/test/perf/solver-decision-baseline/histogram_quantile_scalar_phi/fanout.json
@@ -1,9 +1,9 @@
 {
   "query": "histogram_quantile_scalar_phi/fanout",
   "lowering": "fanout",
-  "routed": false,
-  "k": 0,
-  "reason": "not-sliceable",
+  "routed": true,
+  "k": 8,
+  "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,
   "cumulative_d": "5m0s",

--- a/test/perf/solver-decision-baseline/histogram_quantile_scalar_phi/native.json
+++ b/test/perf/solver-decision-baseline/histogram_quantile_scalar_phi/native.json
@@ -1,9 +1,9 @@
 {
   "query": "histogram_quantile_scalar_phi/native",
   "lowering": "native",
-  "routed": false,
-  "k": 0,
-  "reason": "not-sliceable",
+  "routed": true,
+  "k": 8,
+  "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,
   "cumulative_d": "5m0s",

--- a/test/perf/solver-decision-baseline/histogram_quantile_sum_by_le/fanout.json
+++ b/test/perf/solver-decision-baseline/histogram_quantile_sum_by_le/fanout.json
@@ -1,9 +1,9 @@
 {
   "query": "histogram_quantile_sum_by_le/fanout",
   "lowering": "fanout",
-  "routed": false,
-  "k": 0,
-  "reason": "not-sliceable",
+  "routed": true,
+  "k": 8,
+  "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,
   "cumulative_d": "5m0s",

--- a/test/perf/solver-decision-baseline/histogram_quantile_sum_by_le/native.json
+++ b/test/perf/solver-decision-baseline/histogram_quantile_sum_by_le/native.json
@@ -1,9 +1,9 @@
 {
   "query": "histogram_quantile_sum_by_le/native",
   "lowering": "native",
-  "routed": false,
-  "k": 0,
-  "reason": "not-sliceable",
+  "routed": true,
+  "k": 8,
+  "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,
   "cumulative_d": "5m0s",

--- a/test/perf/solver-decision-baseline/histogram_quantile_sum_by_le_layout_change_midwindow/fanout.json
+++ b/test/perf/solver-decision-baseline/histogram_quantile_sum_by_le_layout_change_midwindow/fanout.json
@@ -1,9 +1,9 @@
 {
   "query": "histogram_quantile_sum_by_le_layout_change_midwindow/fanout",
   "lowering": "fanout",
-  "routed": false,
-  "k": 0,
-  "reason": "not-sliceable",
+  "routed": true,
+  "k": 8,
+  "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,
   "cumulative_d": "5m0s",

--- a/test/perf/solver-decision-baseline/histogram_quantile_sum_by_le_layout_change_midwindow/native.json
+++ b/test/perf/solver-decision-baseline/histogram_quantile_sum_by_le_layout_change_midwindow/native.json
@@ -1,9 +1,9 @@
 {
   "query": "histogram_quantile_sum_by_le_layout_change_midwindow/native",
   "lowering": "native",
-  "routed": false,
-  "k": 0,
-  "reason": "not-sliceable",
+  "routed": true,
+  "k": 8,
+  "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,
   "cumulative_d": "5m0s",

--- a/test/perf/solver-decision-baseline/histogram_quantile_sum_by_le_mixed_layouts/fanout.json
+++ b/test/perf/solver-decision-baseline/histogram_quantile_sum_by_le_mixed_layouts/fanout.json
@@ -1,9 +1,9 @@
 {
   "query": "histogram_quantile_sum_by_le_mixed_layouts/fanout",
   "lowering": "fanout",
-  "routed": false,
-  "k": 0,
-  "reason": "not-sliceable",
+  "routed": true,
+  "k": 8,
+  "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,
   "cumulative_d": "5m0s",

--- a/test/perf/solver-decision-baseline/histogram_quantile_sum_by_le_mixed_layouts/native.json
+++ b/test/perf/solver-decision-baseline/histogram_quantile_sum_by_le_mixed_layouts/native.json
@@ -1,9 +1,9 @@
 {
   "query": "histogram_quantile_sum_by_le_mixed_layouts/native",
   "lowering": "native",
-  "routed": false,
-  "k": 0,
-  "reason": "not-sliceable",
+  "routed": true,
+  "k": 8,
+  "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,
   "cumulative_d": "5m0s",

--- a/test/perf/solver-decision-baseline/histogram_quantile_sum_by_le_p50/fanout.json
+++ b/test/perf/solver-decision-baseline/histogram_quantile_sum_by_le_p50/fanout.json
@@ -1,9 +1,9 @@
 {
   "query": "histogram_quantile_sum_by_le_p50/fanout",
   "lowering": "fanout",
-  "routed": false,
-  "k": 0,
-  "reason": "not-sliceable",
+  "routed": true,
+  "k": 8,
+  "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,
   "cumulative_d": "5m0s",

--- a/test/perf/solver-decision-baseline/histogram_quantile_sum_by_le_p50/native.json
+++ b/test/perf/solver-decision-baseline/histogram_quantile_sum_by_le_p50/native.json
@@ -1,9 +1,9 @@
 {
   "query": "histogram_quantile_sum_by_le_p50/native",
   "lowering": "native",
-  "routed": false,
-  "k": 0,
-  "reason": "not-sliceable",
+  "routed": true,
+  "k": 8,
+  "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,
   "cumulative_d": "5m0s",

--- a/test/perf/solver-decision-baseline/histogram_quantile_with_filter/fanout.json
+++ b/test/perf/solver-decision-baseline/histogram_quantile_with_filter/fanout.json
@@ -1,9 +1,9 @@
 {
   "query": "histogram_quantile_with_filter/fanout",
   "lowering": "fanout",
-  "routed": false,
-  "k": 0,
-  "reason": "not-sliceable",
+  "routed": true,
+  "k": 8,
+  "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,
   "cumulative_d": "5m0s",

--- a/test/perf/solver-decision-baseline/histogram_quantile_with_filter/native.json
+++ b/test/perf/solver-decision-baseline/histogram_quantile_with_filter/native.json
@@ -1,9 +1,9 @@
 {
   "query": "histogram_quantile_with_filter/native",
   "lowering": "native",
-  "routed": false,
-  "k": 0,
-  "reason": "not-sliceable",
+  "routed": true,
+  "k": 8,
+  "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,
   "cumulative_d": "5m0s",

--- a/test/perf/solver-decision-baseline/histogram_quantiles_classic_multi_phi/fanout.json
+++ b/test/perf/solver-decision-baseline/histogram_quantiles_classic_multi_phi/fanout.json
@@ -1,9 +1,9 @@
 {
   "query": "histogram_quantiles_classic_multi_phi/fanout",
   "lowering": "fanout",
-  "routed": false,
-  "k": 0,
-  "reason": "not-sliceable",
+  "routed": true,
+  "k": 6,
+  "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,
   "cumulative_d": "10m0s",

--- a/test/perf/solver-decision-baseline/histogram_quantiles_classic_multi_phi/native.json
+++ b/test/perf/solver-decision-baseline/histogram_quantiles_classic_multi_phi/native.json
@@ -1,9 +1,9 @@
 {
   "query": "histogram_quantiles_classic_multi_phi/native",
   "lowering": "native",
-  "routed": false,
-  "k": 0,
-  "reason": "not-sliceable",
+  "routed": true,
+  "k": 6,
+  "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,
   "cumulative_d": "10m0s",

--- a/test/perf/solver-decision-baseline/histogram_quantiles_computed_phi/fanout.json
+++ b/test/perf/solver-decision-baseline/histogram_quantiles_computed_phi/fanout.json
@@ -1,9 +1,9 @@
 {
   "query": "histogram_quantiles_computed_phi/fanout",
   "lowering": "fanout",
-  "routed": false,
-  "k": 0,
-  "reason": "not-sliceable",
+  "routed": true,
+  "k": 8,
+  "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,
   "cumulative_d": "5m0s",

--- a/test/perf/solver-decision-baseline/histogram_quantiles_computed_phi_sci/fanout.json
+++ b/test/perf/solver-decision-baseline/histogram_quantiles_computed_phi_sci/fanout.json
@@ -1,9 +1,9 @@
 {
   "query": "histogram_quantiles_computed_phi_sci/fanout",
   "lowering": "fanout",
-  "routed": false,
-  "k": 0,
-  "reason": "not-sliceable",
+  "routed": true,
+  "k": 8,
+  "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,
   "cumulative_d": "5m0s",

--- a/test/perf/solver-decision-baseline/histogram_stddev_exp/fanout.json
+++ b/test/perf/solver-decision-baseline/histogram_stddev_exp/fanout.json
@@ -1,9 +1,9 @@
 {
   "query": "histogram_stddev_exp/fanout",
   "lowering": "fanout",
-  "routed": false,
-  "k": 0,
-  "reason": "not-sliceable",
+  "routed": true,
+  "k": 8,
+  "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,
   "cumulative_d": "5m0s",

--- a/test/perf/solver-decision-baseline/histogram_stddev_exp/native.json
+++ b/test/perf/solver-decision-baseline/histogram_stddev_exp/native.json
@@ -1,9 +1,9 @@
 {
   "query": "histogram_stddev_exp/native",
   "lowering": "native",
-  "routed": false,
-  "k": 0,
-  "reason": "not-sliceable",
+  "routed": true,
+  "k": 8,
+  "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,
   "cumulative_d": "5m0s",

--- a/test/perf/solver-decision-baseline/histogram_stdvar_exp/fanout.json
+++ b/test/perf/solver-decision-baseline/histogram_stdvar_exp/fanout.json
@@ -1,9 +1,9 @@
 {
   "query": "histogram_stdvar_exp/fanout",
   "lowering": "fanout",
-  "routed": false,
-  "k": 0,
-  "reason": "not-sliceable",
+  "routed": true,
+  "k": 8,
+  "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,
   "cumulative_d": "5m0s",

--- a/test/perf/solver-decision-baseline/histogram_stdvar_exp/native.json
+++ b/test/perf/solver-decision-baseline/histogram_stdvar_exp/native.json
@@ -1,9 +1,9 @@
 {
   "query": "histogram_stdvar_exp/native",
   "lowering": "native",
-  "routed": false,
-  "k": 0,
-  "reason": "not-sliceable",
+  "routed": true,
+  "k": 8,
+  "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,
   "cumulative_d": "5m0s",

--- a/test/perf/solver-decision-baseline/histogram_sum_exp/fanout.json
+++ b/test/perf/solver-decision-baseline/histogram_sum_exp/fanout.json
@@ -1,9 +1,9 @@
 {
   "query": "histogram_sum_exp/fanout",
   "lowering": "fanout",
-  "routed": false,
-  "k": 0,
-  "reason": "not-sliceable",
+  "routed": true,
+  "k": 8,
+  "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,
   "cumulative_d": "5m0s",

--- a/test/perf/solver-decision-baseline/histogram_sum_exp/native.json
+++ b/test/perf/solver-decision-baseline/histogram_sum_exp/native.json
@@ -1,9 +1,9 @@
 {
   "query": "histogram_sum_exp/native",
   "lowering": "native",
-  "routed": false,
-  "k": 0,
-  "reason": "not-sliceable",
+  "routed": true,
+  "k": 8,
+  "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,
   "cumulative_d": "5m0s",

--- a/test/perf/solver-decision-baseline/histogram_sum_exp_latest_sample/fanout.json
+++ b/test/perf/solver-decision-baseline/histogram_sum_exp_latest_sample/fanout.json
@@ -1,9 +1,9 @@
 {
   "query": "histogram_sum_exp_latest_sample/fanout",
   "lowering": "fanout",
-  "routed": false,
-  "k": 0,
-  "reason": "not-sliceable",
+  "routed": true,
+  "k": 8,
+  "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,
   "cumulative_d": "5m0s",

--- a/test/perf/solver-decision-baseline/histogram_sum_exp_latest_sample/native.json
+++ b/test/perf/solver-decision-baseline/histogram_sum_exp_latest_sample/native.json
@@ -1,9 +1,9 @@
 {
   "query": "histogram_sum_exp_latest_sample/native",
   "lowering": "native",
-  "routed": false,
-  "k": 0,
-  "reason": "not-sliceable",
+  "routed": true,
+  "k": 8,
+  "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,
   "cumulative_d": "5m0s",

--- a/test/perf/solver-decision-baseline/histogram_sum_exp_range_latest_sample/fanout.json
+++ b/test/perf/solver-decision-baseline/histogram_sum_exp_range_latest_sample/fanout.json
@@ -1,9 +1,9 @@
 {
   "query": "histogram_sum_exp_range_latest_sample/fanout",
   "lowering": "fanout",
-  "routed": false,
-  "k": 0,
-  "reason": "not-sliceable",
+  "routed": true,
+  "k": 8,
+  "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,
   "cumulative_d": "5m0s",

--- a/test/perf/solver-decision-baseline/histogram_sum_exp_range_latest_sample/native.json
+++ b/test/perf/solver-decision-baseline/histogram_sum_exp_range_latest_sample/native.json
@@ -1,9 +1,9 @@
 {
   "query": "histogram_sum_exp_range_latest_sample/native",
   "lowering": "native",
-  "routed": false,
-  "k": 0,
-  "reason": "not-sliceable",
+  "routed": true,
+  "k": 8,
+  "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,
   "cumulative_d": "5m0s",

--- a/test/perf/solver-decision-baseline/map_key_order_exp_histogram_count/fanout.json
+++ b/test/perf/solver-decision-baseline/map_key_order_exp_histogram_count/fanout.json
@@ -1,9 +1,9 @@
 {
   "query": "map_key_order_exp_histogram_count/fanout",
   "lowering": "fanout",
-  "routed": false,
-  "k": 0,
-  "reason": "not-sliceable",
+  "routed": true,
+  "k": 8,
+  "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,
   "cumulative_d": "5m0s",

--- a/test/perf/solver-decision-baseline/map_key_order_exp_histogram_count/native.json
+++ b/test/perf/solver-decision-baseline/map_key_order_exp_histogram_count/native.json
@@ -1,9 +1,9 @@
 {
   "query": "map_key_order_exp_histogram_count/native",
   "lowering": "native",
-  "routed": false,
-  "k": 0,
-  "reason": "not-sliceable",
+  "routed": true,
+  "k": 8,
+  "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,
   "cumulative_d": "5m0s",

--- a/test/perf/solver-decision-baseline/map_key_order_histogram_quantile/fanout.json
+++ b/test/perf/solver-decision-baseline/map_key_order_histogram_quantile/fanout.json
@@ -1,9 +1,9 @@
 {
   "query": "map_key_order_histogram_quantile/fanout",
   "lowering": "fanout",
-  "routed": false,
-  "k": 0,
-  "reason": "not-sliceable",
+  "routed": true,
+  "k": 8,
+  "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,
   "cumulative_d": "5m0s",

--- a/test/perf/solver-decision-baseline/map_key_order_histogram_quantile/native.json
+++ b/test/perf/solver-decision-baseline/map_key_order_histogram_quantile/native.json
@@ -1,9 +1,9 @@
 {
   "query": "map_key_order_histogram_quantile/native",
   "lowering": "native",
-  "routed": false,
-  "k": 0,
-  "reason": "not-sliceable",
+  "routed": true,
+  "k": 8,
+  "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,
   "cumulative_d": "5m0s",

--- a/test/perf/solver-decision-baseline/subquery_inner_histogram_quantile/fanout.json
+++ b/test/perf/solver-decision-baseline/subquery_inner_histogram_quantile/fanout.json
@@ -3,7 +3,7 @@
   "lowering": "fanout",
   "routed": false,
   "k": 0,
-  "reason": "not-sliceable",
+  "reason": "incommensurate",
   "n_anchors": 241,
   "fanout": 20,
   "cumulative_d": "10m0s",

--- a/test/perf/solver-decision-baseline/subquery_inner_histogram_quantile/native.json
+++ b/test/perf/solver-decision-baseline/subquery_inner_histogram_quantile/native.json
@@ -3,7 +3,7 @@
   "lowering": "native",
   "routed": false,
   "k": 0,
-  "reason": "not-sliceable",
+  "reason": "incommensurate",
   "n_anchors": 241,
   "fanout": 20,
   "cumulative_d": "10m0s",


### PR DESCRIPTION
## Summary

Fixes a real, confirmed production incident: `histogram_quantile(...)` over an aggregated
`rate()`/`increase()` of a classic (explicit-bucket) histogram OOMs ClickHouse
(`MEMORY_LIMIT_EXCEEDED`) at production cardinality under `query_range`. 19 real occurrences
in production, all shape `cerb:project;agg=1;rbf`, all `decision_reason=not-sliceable, route=A`.

## Root cause

`histogram_quantile(...)` over a classic-histogram `rate()` lowers to `HistogramQuantile`
wrapping `RangeBucketFanout`. The sharded-pushdown solver already exists and already handles
comparable-scale shapes (`RangeWindow`, `RangeWindowGridNative`, `RangeLWR`) correctly, but
`chplan.ReanchorRange` had no case for `RangeBucketFanout` — every such plan failed closed to
the unbounded route A.

Live bisection against real production ClickHouse confirmed cost is driven by the product of
(step count) × (raw per-series cardinality before the user's `by(...)` collapses it) — every
step independently recomputes a full per-series window-fold with no bounding.

The specific machinery driving this cost
(`internal/promql/histogram_quantile_window.go`) did not exist in v1.14.0 — it landed
2026-08-03 (#1633) to fix real correctness bugs (#1533/#1535/#1584), and made the per-series
reduction correct but inherently more expensive. The pre-existing (since June) routing gap
turned that into real OOMs once #1633 shipped in v1.15.0.

## Fix

- `internal/chplan/sliceinvariant.go`: register `HistogramQuantile` slice-invariant.
- `internal/chplan/reanchor.go`: add a `RangeBucketFanout` arm (mirrors `RangeLWR`) and a
  `HistogramQuantile` pass-through arm (mirrors `Project`). **Both are required together** —
  registering `HistogramQuantile` slice-invariant without the reanchor arm would have been
  silently wrong: `ReanchorRange`'s default case returns a node unrecursed, so every shard
  would have inherited the original full-grid `RangeBucketFanout` — K duplicated copies of the
  same rows, HTTP 200, wrong data.
  `TestPlan_HistogramQuantileOverRangeBucketFanoutRoutes` pins exactly this hazard.
- `internal/solver/planner.go`: `RangeBucketFanout` joins the routable-spine set, its own
  grid-prediction walk widens by `Offset+Lookback` to match, `checkRangeBucketFanoutGrid` mirrors
  `checkRangeLWRGrid`.
- `internal/solver/slicer.go`: `RangeBucketFanout` joins `UnpinSpine`'s zeroed set;
  `HistogramQuantile` joins the COW pass-through set.

Native (exponential) histograms share the same `RangeBucketFanout` construction site and get the
routing fix for free, but `HistogramQuantileNative`/`HistogramProjection` are deliberately left
out of the slice-invariance registry — zero production native-histogram traffic exists today to
validate against, so that registration ships as its own follow-up with its own fixtures.

## Verification

- New unit tests prove routing **and** the no-silent-duplication property directly
  (`TestPlan_RangeBucketFanoutSpineRoutes`, `TestPlan_HistogramQuantileOverRangeBucketFanoutRoutes`).
- New classic-histogram fixture in the real-chDB route-A-vs-B differential lane
  (`internal/solver/avb_chdb_lane_test.go`) proves route B's sharded output is byte-for-byte
  identical to route A's single-pass output.
- Live re-verification against the actual production ClickHouse cluster (local pre-fix vs.
  fixed cerberus build, read-only, over a port-forward, torn down after use): the exact
  historically-OOMing query, same live data, same moment — pre-fix binary: HTTP 422
  `MEMORY_LIMIT_EXCEEDED` in 15.9s; fixed binary: HTTP 200, real p99 values,
  `sharded-timeslice;k=8;reason=routed`, milliseconds of ClickHouse time.

## Test plan

- [x] `go test -race ./internal/solver/... ./internal/chplan/... ./internal/promql/...`
- [x] `go test -tags chdb -race ./internal/solver/...` (real-chDB differential lane, 10/10
      fixtures, zero diffs)
- [x] Live production data verification (see above)
