### PR TITLE
fix(solver): sweep HistogramQuantile's GroupBy/PhiExpr and fix carrier depth

### DIFF
--- a/docs/solver.md
+++ b/docs/solver.md
@@ -40,9 +40,10 @@ The signals, each gathered in the one pass:
    marker is proven.
 2. **Routable spine family.** Re-anchoring rewrites the grid carried by the
    `RangeWindow` matrix family, the `RangeWindowGridNative` ClickHouse-native
-   `timeSeries*ToGrid` family, and the `RangeLWR` bare-selector
-   last-with-respect-to family. Every other grid carrier —
-   `RangeWindowStaleResample`, `RangeBucketFanout`, `StepGrid`, `AbsentOverTime` —
+   `timeSeries*ToGrid` family, the `RangeLWR` bare-selector
+   last-with-respect-to family, and the `RangeBucketFanout` array-aggregate
+   fan-out behind the classic-histogram families. Every other grid carrier —
+   `RangeWindowStaleResample`, `StepGrid`, `AbsentOverTime` —
    carries its own eval grid that re-anchoring clones verbatim, so a plan whose
    spine bound-carrier is one of those fails closed to route A (every shard
    would otherwise emit stale bounds).
@@ -54,7 +55,7 @@ The signals, each gathered in the one pass:
    shard that re-gridded one and shared another verbatim would compose the
    shared arm's full-grid answer `K` times over.
 
-   The three re-anchorable kinds are exactly the kinds the slicer's `unpinSpineCOW`
+   The four re-anchorable kinds are exactly the kinds the slicer's `unpinSpineCOW`
    zeroes and exactly the kinds `carrierGeometryOf` marks re-anchorable. A kind
    that re-anchoring learns but `unpinSpineCOW` does not stays pinned at the full
    request grid, so every slice aborts with a grid mismatch and the plan falls
@@ -114,8 +115,10 @@ The signals, each gathered in the one pass:
    a genuinely independent, unboundedly wide scan — an `@`-pinned interior, or
    one whose span has nothing to do with the outer grid — which really would
    multiply `K×` into real extra cost and stays heavy. A `RangeBucketFanout`
-   is never admitted regardless of its bounds (it is outside the routable
-   spine family on the main spine too, signal 2); a purely row-wise scalar
+   is never admitted here regardless of its bounds — unlike the main spine
+   (signal 2, where it IS now routable), no equality/reanchor argument has
+   been built for the Expr-embedded, never-reanchored replication case this
+   check governs, so it stays conservatively heavy; a purely row-wise scalar
    interior (no windowed node at all) was always cheap and stays admissible.
 
 When every signal passes, the plan is **eligible**. The cost grid then decides

--- a/internal/chplan/sliceinvariant.go
+++ b/internal/chplan/sliceinvariant.go
@@ -94,15 +94,15 @@ func IsSliceInvariant(n Node) bool {
 //     each is its own PR.
 //
 //   - HistogramQuantile — the classic-histogram bucket-array-to-quantile
-//     interpolation. Its input is RangeBucketFanout, whose GROUP BY carries
-//     the anchor key (AnchorAlias, always prepended), so HistogramQuantile's
-//     own row-wise Project/interpolation reads exactly one (series, anchor)
-//     group's BucketCounts/ExplicitBounds columns — no cross-anchor read, no
-//     scan-order dependence, no window function (the emitter,
-//     internal/chsql/histogram_quantile.go, renders plain arrayMap/arraySort
-//     over one row's array columns). Its per-(series, anchor) output is
-//     therefore exactly as scan-lower-bound-independent as its
-//     RangeBucketFanout input already is. See internal/chplan/reanchor.go's
+//     interpolation. Its input is a reshape Project over a RangeBucketFanout,
+//     whose GROUP BY carries the anchor key (AnchorAlias, always prepended),
+//     so HistogramQuantile's own row-wise Project/interpolation reads exactly
+//     one (series, anchor) group's BucketCounts/ExplicitBounds columns — no
+//     cross-anchor read, no scan-order dependence, no window function (the
+//     emitter, internal/chsql/histogram_quantile.go, renders plain
+//     arrayMap/arraySort over one row's array columns). Its per-(series,
+//     anchor) output is therefore exactly as scan-lower-bound-independent as
+//     its RangeBucketFanout input already is. See internal/chplan/reanchor.go's
 //     *HistogramQuantile arm (a pass-through, mirroring *Project) and
 //     internal/solver/avb_chdb_lane_test.go's classic-histogram fixtures for
 //     the differential (route A vs K-sharded route B) proof this registry

--- a/internal/solver/planner.go
+++ b/internal/solver/planner.go
@@ -535,8 +535,33 @@ func (p *Planner) walkNode(n chplan.Node, predStart, predEnd time.Time, predStep
 		// Each anchor's membership window looks back Offset+Lookback (mirrors
 		// the RangeLWR arm above); widen the input spine by that much so the
 		// grid this predicts for the child matches what ReanchorRange actually
-		// produces (see reanchorRangeBucketFanout).
-		p.walkNode(v.Input, predStart.Add(-v.Offset-v.Lookback), predEnd, v.Step, depth, sig)
+		// produces (see reanchorRangeBucketFanout). depth+1 mirrors every
+		// other GridCarrier arm above (RangeWindow / RangeLWR /
+		// RangeWindowGridNative / AbsentOverTime): this node's own grid is a
+		// nesting boundary, so anything a further-nested carrier inside
+		// v.Input predicts a grid against must see itself as nested, not as
+		// depth 0.
+		p.walkNode(v.Input, predStart.Add(-v.Offset-v.Lookback), predEnd, v.Step, depth+1, sig)
+		return
+
+	case *chplan.HistogramQuantile:
+		// The classic-histogram quantile interpolation: off-grid immutable
+		// itself (see chplan.reanchor's *HistogramQuantile arm — a
+		// pass-through mirroring *Project), so it carries no own grid to
+		// record or widen by. But GroupBy and PhiExpr are exactly the
+		// unswept-slot hazard walkScalarInterior's own doc already names by
+		// example ("a histogram_quantile's phi... escaped the gate and
+		// routed B") — PhiExpr is typically a ScalarSubquery (see
+		// chplan.HistogramQuantile.PhiExpr's doc), so leaving it unswept here
+		// would let an embedded now64 or scalar-heavy interior escape every
+		// gate now that this kind is registered slice-invariant. Sweep them
+		// explicitly, mirroring the Aggregate arm above, then recurse into
+		// Input at the same depth (this node adds no grid nesting).
+		for _, e := range v.GroupBy {
+			p.walkExpr(e, predStart, predEnd, predStep, sig)
+		}
+		p.walkExpr(v.PhiExpr, predStart, predEnd, predStep, sig)
+		p.walkNode(v.Input, predStart, predEnd, predStep, depth, sig)
 		return
 
 	case *chplan.StepGrid:
@@ -1218,10 +1243,13 @@ func (p *Planner) checkScalarHeavy(inner chplan.Node, predStart, predEnd time.Ti
 // unboundedly wide scan (an @-pinned interior, an interior whose span or
 // cadence has nothing to do with the outer grid) that really would multiply
 // K× into real extra cost. A RangeBucketFanout is never admitted regardless
-// of its bounds: it is excluded from the routable spine family on the MAIN
-// spine too (signal 1b, carrierGeometry.reanchorable), and this package has
-// no argument that makes it safe here that it does not already have there.
-// RangeWindowStaleResample and AbsentOverTime are absent from
+// of its bounds: unlike the MAIN spine — where it IS now routable (signal
+// 1b, carrierGeometry.reanchorable — the classic-histogram OOM fix) — route
+// B never re-anchors an Expr-embedded interior at all, so admitting it here
+// would replicate its full unsliced grid K× rather than a per-shard slice;
+// no equality argument bounding that replication cost has been built for it
+// here, unlike the RangeWindow / RangeLWR / RangeWindowGridNative arms
+// above. RangeWindowStaleResample and AbsentOverTime are absent from
 // chplan.IsSliceInvariant's registry, so one appearing inside an interior
 // already fails the whole plan via walkScalarInterior's slice-invariance
 // sweep before this function's answer can matter. RangeWindowGridNative IS

--- a/internal/solver/planner.go
+++ b/internal/solver/planner.go
@@ -551,17 +551,9 @@ func (p *Planner) walkNode(n chplan.Node, predStart, predEnd time.Time, predStep
 		// record or widen by. But GroupBy and PhiExpr are exactly the
 		// unswept-slot hazard walkScalarInterior's own doc already names by
 		// example ("a histogram_quantile's phi... escaped the gate and
-		// routed B") — PhiExpr is typically a ScalarSubquery (see
-		// chplan.HistogramQuantile.PhiExpr's doc), so leaving it unswept here
-		// would let an embedded now64 or scalar-heavy interior escape every
-		// gate now that this kind is registered slice-invariant. Sweep them
-		// explicitly, mirroring the Aggregate arm above, then recurse into
-		// Input at the same depth (this node adds no grid nesting).
-		for _, e := range v.GroupBy {
-			p.walkExpr(e, predStart, predEnd, predStep, sig)
-		}
-		p.walkExpr(v.PhiExpr, predStart, predEnd, predStep, sig)
-		p.walkNode(v.Input, predStart, predEnd, predStep, depth, sig)
+		// routed B") — see walkHistogramQuantile (factored out to keep
+		// walkNode under funlen's statement cap).
+		p.walkHistogramQuantile(v, predStart, predEnd, predStep, depth, sig)
 		return
 
 	case *chplan.StepGrid:
@@ -1043,6 +1035,24 @@ func rangeWindowGridMatches(v *chplan.RangeWindow, predStart, predEnd time.Time)
 // no separate OuterRange field, so the predicted span is End-Start directly.
 func rangeLWRGridMatches(v *chplan.RangeLWR, predStart, predEnd time.Time) bool {
 	return v.Start.Equal(predStart) && v.End.Equal(predEnd)
+}
+
+// walkHistogramQuantile sweeps a HistogramQuantile's GroupBy and PhiExpr for
+// now64 / scalar-heavy hazards, then recurses into Input at the same depth
+// (the node adds no grid nesting of its own — see chplan.reanchor's
+// *HistogramQuantile arm, a pass-through mirroring *Project). PhiExpr is
+// typically a ScalarSubquery for a computed phi (see
+// chplan.HistogramQuantile.PhiExpr's doc), so leaving it unswept would let an
+// embedded now64 or scalar-heavy interior escape every gate now that this
+// kind is registered slice-invariant — mirrors the Aggregate arm's sweep.
+// Factored out of walkNode's switch to keep that function under funlen's
+// statement cap.
+func (p *Planner) walkHistogramQuantile(v *chplan.HistogramQuantile, predStart, predEnd time.Time, predStep time.Duration, depth int, sig *signals) {
+	for _, e := range v.GroupBy {
+		p.walkExpr(e, predStart, predEnd, predStep, sig)
+	}
+	p.walkExpr(v.PhiExpr, predStart, predEnd, predStep, sig)
+	p.walkNode(v.Input, predStart, predEnd, predStep, depth, sig)
 }
 
 // checkRangeBucketFanoutGrid is checkRangeLWRGrid for RangeBucketFanout —

--- a/internal/solver/planner_test.go
+++ b/internal/solver/planner_test.go
@@ -587,6 +587,45 @@ func TestPlan_HistogramQuantileOverRangeBucketFanoutRoutes(t *testing.T) {
 	}
 }
 
+// TestPlan_Now64InHistogramQuantilePhiExprRejected pins the walkNode arm
+// HistogramQuantile needs alongside its slice-invariance registration: a
+// computed phi (`histogram_quantile(scalar(x), b)`) lowers PhiExpr to a
+// ScalarSubquery (see chplan.HistogramQuantile.PhiExpr's doc), and
+// walkScalarInterior's own doc already names "a histogram_quantile's phi" as
+// a historically-missed slot that let a now64 escape every gate and route B.
+// Registering HistogramQuantile as slice-invariant (the classic-histogram OOM
+// fix) reopens exactly that hazard at this package's own top-level walk
+// unless walkNode also sweeps GroupBy/PhiExpr the way the Aggregate arm
+// sweeps its own — this test is what a regression in that sweep would break.
+func TestPlan_Now64InHistogramQuantilePhiExprRejected(t *testing.T) {
+	t.Parallel()
+	scalarInner := &chplan.Aggregate{
+		Input: leafScan(),
+		AggFuncs: []chplan.AggFunc{{
+			Fn:    chplan.FnSum,
+			Args:  []chplan.Expr{&chplan.FuncCall{Fn: chplan.FnNow64, Args: []chplan.Expr{&chplan.LitInt{V: 9}}}},
+			Alias: "v",
+		}},
+	}
+	plan := &chplan.HistogramQuantile{
+		Input:                rangeBucketFanoutSpine(),
+		PhiExpr:              &chplan.ScalarSubquery{Input: scalarInner},
+		BucketCountsColumn:   "BucketCounts",
+		ExplicitBoundsColumn: "ExplicitBounds",
+		MetricNameColumn:     "MetricName",
+		AttributesColumn:     "Attributes",
+		TimestampColumn:      "TimeUnix",
+	}
+	p := &Planner{Cfg: autoCfg()}
+	d, routed := p.Plan(plan, oomMeta())
+	if routed {
+		t.Fatal("now64 in HistogramQuantile.PhiExpr's scalar interior must not route")
+	}
+	if d.Reason != ReasonNow64 {
+		t.Fatalf("reason = %q, want %q", d.Reason, ReasonNow64)
+	}
+}
+
 // TestPlan_NonRangeWindowSpineRejected pins the residual routable-spine
 // restriction: the routable bound-carriers are *RangeWindow (phase 1),
 // *RangeLWR (phase 3), and *RangeBucketFanout (the classic-histogram

--- a/test/perf/solver-decision-baseline/histogram_quantile_scalar_phi/native.json
+++ b/test/perf/solver-decision-baseline/histogram_quantile_scalar_phi/native.json
@@ -1,9 +1,9 @@
 {
   "query": "histogram_quantile_scalar_phi/native",
   "lowering": "native",
-  "routed": true,
-  "k": 8,
-  "reason": "routed",
+  "routed": false,
+  "k": 0,
+  "reason": "not-sliceable",
   "n_anchors": 241,
   "fanout": 20,
   "cumulative_d": "5m0s",


### PR DESCRIPTION
## Summary

Pre-release audit of v1.15.3 over the 4 commits since v1.15.2 (`bb4e853d4`, `f892c2e89`, `e4e2b2184`, `f940207fc`), focused on the two production-incident hotfixes (#2387, #2390). #2386 and #2391 came back clean. #2390 came back clean (well-threaded `DeltaPrefixLookback` through every route A/B emit site, accurate docs, real DRY extraction of `applyMatrixFanoutScanBound`). #2387 had one real regression, fixed here:

- **`internal/solver/planner.go`**: #2387 registered `chplan.HistogramQuantile` as slice-invariant to unblock routing the classic-histogram OOM shape, but `walkNode` had no dedicated arm for it — it fell through to the default case, which only recurses into `Children()` (i.e. `Input`) and never sweeps `GroupBy`/`PhiExpr`. A computed phi (`histogram_quantile(scalar(x), b)`) lowers `PhiExpr` to a `ScalarSubquery` — exactly the slot `walkScalarInterior`'s own doc already names by name as a historically-missed now64 escape hatch ("a histogram_quantile's phi... escaped the gate and routed B"). Before this PR, `HistogramQuantile` being unregistered meant any plan containing it failed closed to route A regardless — that's what masked the gap. Once it's slice-invariant, an embedded `now64()` or scalar-heavy subquery in a computed phi could route to sharded execution unchecked. Added the missing arm, mirroring the `Aggregate` arm's sweep, with a regression test (`TestPlan_Now64InHistogramQuantilePhiExprRejected`) that I confirmed fails without the fix and passes with it.

- Also fixed `RangeBucketFanout`'s `walkNode` arm passing `depth` instead of `depth+1` when recursing into `Input`. Every other `GridCarrier` arm (`RangeWindow`, `RangeLWR`, `RangeWindowGridNative`, `AbsentOverTime`) increments `depth` to mark the grid-nesting boundary; the new `RangeBucketFanout` arm's own comment claims to mirror the `RangeLWR` arm above it but didn't on this point. Currently dormant — `RangeBucketFanout.Input` is always a raw `Scan`/`Filter` by construction at both of its two callsites (verified) — but a real inconsistency that would misclassify a future nested carrier's depth.

- **`docs/solver.md`**: fixed stale "three re-anchorable kinds" prose that still described `RangeBucketFanout` as clone-verbatim/not-routable, contradicting the shipped fix.

- **`internal/chplan/sliceinvariant.go`**: fixed the `HistogramQuantile` registry doc, which said its input IS a `RangeBucketFanout`; it's actually a reshape `Project` over one (per `histogramRangeQuantileTree`).

No fixes needed for #2386 or #2391.

## Test plan

- [x] `go build ./...` — clean
- [x] `go vet ./...` — clean
- [x] `gofumpt -extra -l` on touched Go files — clean
- [x] `go test -race ./internal/solver/... ./internal/chplan/...` — all pass
- [x] New regression test verified to fail on the pre-fix code (reverted the fix locally, confirmed `TestPlan_Now64InHistogramQuantilePhiExprRejected` fails, restored the fix, confirmed it passes)
- [x] All pre-existing tests in both packages still pass, including the #2387 routing tests (`TestPlan_RangeBucketFanoutSpineRoutes`, `TestPlan_HistogramQuantileOverRangeBucketFanoutRoutes`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Solver-decision-ratchet regression (justified)

`test/perf/solver-decision-baseline` flags one intentional **REGRESSION** row:
`histogram_quantile_scalar_phi/native`: `routed=true K=8` → `routed=false K=0
reason="not-sliceable"`.

This is the exact query shape the `walkNode` fix above targets: a computed `histogram_quantile`
phi expression. Before this PR, the missing `HistogramQuantile` sweep meant a `now64()`/scalar-heavy
`PhiExpr` was invisible to the routing-safety gate, so this fixture was (incorrectly) routed to
sharded execution. After the fix, it correctly fails closed to route A. Fewer routed queries here is
the point, not a threshold tweak — baseline regenerated via `just update-solver-decision-baseline`
(run through `update-golden.yml`) to record the corrected decision.
