### PR TITLE
chore(release): cerberus v1.15.3 / chart 0.15.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to cerberus will be documented in this file. The format roug
 
 ## [Unreleased]
 
+## [v1.15.3] — 2026-08-19
+
+### Fixed
+
+- **solver:** sweep HistogramQuantile's GroupBy/PhiExpr and fix carrier depth (#2392)
+- **chsql:** bound the DELTA-temporality prefix-reconstruction scan (#2390)
+- **solver:** slice RangeBucketFanout, fixing classic-histogram range OOMs (#2387)
+
+### Performance
+
+- **promql:** bind the exponential-histogram merged bucket start once per merge site (#2386)
+
 ## [v1.15.2] — 2026-08-19
 
 ### Added

--- a/deploy/helm/cerberus/Chart.yaml
+++ b/deploy/helm/cerberus/Chart.yaml
@@ -8,11 +8,11 @@ type: application
 # upgrade?" and is the publish trigger: a chart-only fix bumps this without an
 # app re-tag; an app-only release bumps appVersion + a PATCH here for the new
 # default image. Starts 0.x because the values contract is not yet frozen.
-version: 0.15.2
+version: 0.15.3
 
 # appVersion tracks the GA cerberus binary. Quoted so SemVer-shaped values
 # aren't coerced to floats. image.tag defaults from this when left empty.
-appVersion: "1.15.2"
+appVersion: "1.15.3"
 
 # autoscaling/v2 + policy/v1 (PDB) + networking/v1 (Ingress) are all GA from
 # 1.21+; 1.23 is the conservative floor matching the manifests this chart
@@ -45,11 +45,15 @@ annotations:
       url: https://github.com/tsouza/cerberus/blob/main/docs/operations.md
   artifacthub.io/images: |
     - name: cerberus
-      image: ghcr.io/tsouza/cerberus:v1.15.2
+      image: ghcr.io/tsouza/cerberus:v1.15.3
   # Bump the `1.0.0` floor here when the chart raises its minimum supported
   # cerberus release; informational for Artifact Hub's compatibility hints.
   artifacthub.io/changes: |
-    - kind: added
-      description: "engine: log a WARN line for every non-ok query exit (#2376)"
     - kind: fixed
-      description: "chclient: stop clickhouse-go from clobbering the query timeout setting (#2377)"
+      description: "solver: sweep HistogramQuantile's GroupBy/PhiExpr and fix carrier depth (#2392)"
+    - kind: fixed
+      description: "chsql: bound the DELTA-temporality prefix-reconstruction scan (#2390)"
+    - kind: fixed
+      description: "solver: slice RangeBucketFanout, fixing classic-histogram range OOMs (#2387)"
+    - kind: changed
+      description: "promql: bind the exponential-histogram merged bucket start once per merge site (#2386)"

--- a/deploy/helm/cerberus/README.md
+++ b/deploy/helm/cerberus/README.md
@@ -5,7 +5,7 @@
      pipe-aligned, and the version footer adds a trailing blank — both are
      owned by helm-docs; realigning would fight the chart-ci drift check. -->
 
-![Version: 0.15.2](https://img.shields.io/badge/Version-0.15.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.15.2](https://img.shields.io/badge/AppVersion-1.15.2-informational?style=flat-square)
+![Version: 0.15.3](https://img.shields.io/badge/Version-0.15.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.15.3](https://img.shields.io/badge/AppVersion-1.15.3-informational?style=flat-square)
 
 Drop-in Prometheus / Loki / Tempo HTTP gateway for ClickHouse — a single stateless gateway that speaks three upstream query wire formats and lowers each to parameterised ClickHouse SQL.
 


### PR DESCRIPTION
Release-prep for **v1.15.3** (chart **0.15.3**), generated by `prepare-release.yml`.

- appVersion 1.15.2 -> 1.15.3, chart 0.15.2 -> 0.15.3

### Changes

### Fixed

- **solver:** sweep HistogramQuantile's GroupBy/PhiExpr and fix carrier depth (#2392)
- **chsql:** bound the DELTA-temporality prefix-reconstruction scan (#2390)
- **solver:** slice RangeBucketFanout, fixing classic-histogram range OOMs (#2387)

### Performance

- **promql:** bind the exponential-histogram merged bucket start once per merge site (#2386)

Generated from the conventional commits since the last tag. Review and edit before merging; the tag is cut once this lands.
