### PR TITLE
feat(solver): make auto start on route A and escalate on real evidence

### DIFF
--- a/cmd/cerberus/main.go
+++ b/cmd/cerberus/main.go
@@ -740,7 +740,7 @@ func newPromHandler(client *chclient.Client, cfg config.Config, optSet chopt.Ena
 // buildRouteMemo wires the failure-driven route memo (internal/routememo,
 // docs/solver.md §"Failure-driven route memo") when explicitly enabled via
 // CERBERUS_SOLVER_ROUTE_MEMO_ENABLED (default false — see
-// solver.Config.RouteMemoEnabled's doc for why this is opt-in rather than
+// solver.Config.AdaptiveEnabled's doc for why this is on by default rather than
 // riding along with Mode=auto/sharded automatically). Returns nil (the
 // engine's byte-unchanged, feature-off default) when disabled or when
 // evalSolver is nil.
@@ -754,7 +754,7 @@ func newPromHandler(client *chclient.Client, cfg config.Config, optSet chopt.Ena
 // after construction so an operator can override either without this
 // function needing to know the routememo package's own default constants.
 func buildRouteMemo(evalSolver *solver.Solver, logger *slog.Logger) *routememo.Memo {
-	if evalSolver == nil || !evalSolver.Cfg.RouteMemoEnabled {
+	if evalSolver == nil || !evalSolver.Cfg.AdaptiveEnabled {
 		return nil
 	}
 	memo := routememo.New(evalSolver.EffectiveTimeout())

--- a/cmd/cerberus/route_memo_wiring_test.go
+++ b/cmd/cerberus/route_memo_wiring_test.go
@@ -18,39 +18,56 @@ func TestBuildRouteMemo_NilSolverNeverWires(t *testing.T) {
 	}
 }
 
-// TestBuildRouteMemo_DefaultOffLeavesEngineUnwired pins the byte-identical
-// production contract this whole feature depends on: a Solver built from
-// the library default Config (RouteMemoEnabled=false, the resolved value
-// for any deployment that hasn't set CERBERUS_SOLVER_ROUTE_MEMO_ENABLED)
-// must produce a nil route memo — the same "feature off" state
-// engine.Engine.RouteMemo already treats as a complete no-op.
-func TestBuildRouteMemo_DefaultOffLeavesEngineUnwired(t *testing.T) {
+// TestBuildRouteMemo_DisabledLeavesEngineUnwired pins the OFF path: an
+// operator who explicitly sets AdaptiveEnabled=false must get a nil route memo
+// — the same "feature off" state engine.Engine.RouteMemo already treats as a
+// complete no-op. The default itself is now ON (see
+// TestBuildRouteMemo_DefaultOnWiresAMemo below and
+// solver.Config.AdaptiveEnabled's doc), so this asserts the opt-OUT is
+// honoured rather than the default.
+func TestBuildRouteMemo_DisabledLeavesEngineUnwired(t *testing.T) {
 	cfg := solver.DefaultConfig()
-	if cfg.RouteMemoEnabled {
-		t.Fatalf("solver.DefaultConfig().RouteMemoEnabled = true, want false — this test's premise (library default is off) no longer holds")
-	}
+	cfg.AdaptiveEnabled = false
 	sv := &solver.Solver{Cfg: cfg}
 	logger := slog.New(slog.NewTextHandler(&bytes.Buffer{}, nil))
 
 	if memo := buildRouteMemo(sv, logger); memo != nil {
-		t.Fatalf("buildRouteMemo with RouteMemoEnabled=false = %v, want nil", memo)
+		t.Fatalf("buildRouteMemo with AdaptiveEnabled=false = %v, want nil", memo)
 	}
 }
 
-// TestBuildRouteMemo_EnabledWiresAMemo pins the opt-in path: with
-// RouteMemoEnabled=true, buildRouteMemo must return a real, usable
+// TestBuildRouteMemo_DefaultOnWiresAMemo pins the new default. It is the
+// wiring half of solver's TestConfigFromEnv_AdaptiveDefaultsOn: a Solver built
+// from the library default Config must produce a REAL memo, because that is
+// what makes retryOnRouteAResourceFailure reachable at all — with it nil, a
+// route-A resource failure is a 5xx instead of a slower answer.
+func TestBuildRouteMemo_DefaultOnWiresAMemo(t *testing.T) {
+	cfg := solver.DefaultConfig()
+	if !cfg.AdaptiveEnabled {
+		t.Fatalf("solver.DefaultConfig().AdaptiveEnabled = false, want true — this test's premise (library default is on) no longer holds")
+	}
+	sv := &solver.Solver{Cfg: cfg}
+	logger := slog.New(slog.NewTextHandler(&bytes.Buffer{}, nil))
+
+	if memo := buildRouteMemo(sv, logger); memo == nil {
+		t.Fatal("buildRouteMemo with the default config = nil, want a real memo")
+	}
+}
+
+// TestBuildRouteMemo_EnabledWiresAMemo pins the explicit-on path: with
+// AdaptiveEnabled=true, buildRouteMemo must return a real, usable
 // *routememo.Memo — the thing that actually makes engine.Engine.RouteMemo
 // non-nil and the whole mechanism reachable outside a unit test.
 func TestBuildRouteMemo_EnabledWiresAMemo(t *testing.T) {
 	cfg := solver.DefaultConfig()
-	cfg.RouteMemoEnabled = true
+	cfg.AdaptiveEnabled = true
 	sv := &solver.Solver{Cfg: cfg}
 	var logBuf bytes.Buffer
 	logger := slog.New(slog.NewTextHandler(&logBuf, nil))
 
 	memo := buildRouteMemo(sv, logger)
 	if memo == nil {
-		t.Fatal("buildRouteMemo with RouteMemoEnabled=true = nil, want a real *routememo.Memo")
+		t.Fatal("buildRouteMemo with AdaptiveEnabled=true = nil, want a real *routememo.Memo")
 	}
 	// A real, usable Memo: Stats() should not panic and should report an
 	// empty resident set for a freshly constructed instance.
@@ -58,6 +75,6 @@ func TestBuildRouteMemo_EnabledWiresAMemo(t *testing.T) {
 		t.Errorf("freshly constructed Memo.Stats().Entries = %d, want 0", stats.Entries)
 	}
 	if logBuf.Len() == 0 {
-		t.Error("buildRouteMemo with RouteMemoEnabled=true logged nothing — an operator enabling a new runtime-behavior-changing feature should see it confirmed at startup")
+		t.Error("buildRouteMemo with AdaptiveEnabled=true logged nothing — an operator enabling a new runtime-behavior-changing feature should see it confirmed at startup")
 	}
 }

--- a/internal/engine/route_outcome.go
+++ b/internal/engine/route_outcome.go
@@ -1,7 +1,9 @@
 package engine
 
 import (
+	"context"
 	"errors"
+	"time"
 
 	"github.com/tsouza/cerberus/internal/chclient"
 	"github.com/tsouza/cerberus/internal/routememo"
@@ -42,11 +44,48 @@ import (
 // raises OutputCapError (the cap only guards the composed multi-shard
 // stream), so gating it on route==RouteB is belt-and-braces, not
 // load-bearing.
+// costlyCancellationFloor is how long a dispatch must have been RUNNING before
+// a client cancellation counts as cost evidence rather than a caller who simply
+// went away.
+//
+// The distinction is real and this is the honest place to draw it. A dashboard
+// panel abandoned at 200 ms says nothing about route cost; a query the client
+// cut at 30 s had already committed 30 s of ClickHouse work and is exactly the
+// failure this repo kept mistaking for "no evidence". Production measurement on
+// the classic-histogram APM panel: of 16 real failures, 15 were client
+// cancellations (CH code 735) at ~30 s and only ONE was a memory-limit abort —
+// so classifying every cancellation as no-evidence left the memo blind to 94%
+// of what was actually going wrong.
+//
+// The floor is deliberately far above any plausible human abandonment and far
+// below the 30 s deadline that produced those cancellations, so it separates
+// the two populations without needing to know either timeout.
+const costlyCancellationFloor = 5 * time.Second
+
 func classifyRouteOutcome(route routememo.Route, err error) routememo.Outcome {
+	return classifyRouteOutcomeAfter(route, err, 0)
+}
+
+// classifyRouteOutcomeAfter is classifyRouteOutcome with the dispatch's elapsed
+// wall time, so a cancellation that had already done real work classifies as
+// cost evidence. `elapsed == 0` means "not measured" and preserves the original
+// cancellation-is-no-evidence reading.
+func classifyRouteOutcomeAfter(route routememo.Route, err error, elapsed time.Duration) routememo.Outcome {
 	if err == nil {
 		return routememo.OutcomeSuccess
 	}
 	if errors.Is(err, chclient.ErrMemoryLimitExceeded) {
+		return routememo.OutcomeResourceFailure
+	}
+	// A cancellation that survived costlyCancellationFloor is evidence about
+	// THIS route's cost: the work was committed and the caller gave up waiting
+	// for it. Recorded, never retried — the caller is already gone, so a retry
+	// dispatch would run for nobody (that is the doomed-trial shape this file's
+	// ctx.Err() guard exists to prevent). It teaches the NEXT request instead.
+	if elapsed >= costlyCancellationFloor && errors.Is(err, context.Canceled) {
+		return routememo.OutcomeResourceFailure
+	}
+	if elapsed >= costlyCancellationFloor && errors.Is(err, context.DeadlineExceeded) {
 		return routememo.OutcomeResourceFailure
 	}
 	if route == routememo.RouteB {

--- a/internal/engine/route_outcome_test.go
+++ b/internal/engine/route_outcome_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"testing"
+	"time"
 
 	"github.com/tsouza/cerberus/internal/chclient"
 	"github.com/tsouza/cerberus/internal/routememo"
@@ -65,3 +66,63 @@ type errWrapper struct{ inner error }
 
 func (e errWrapper) Error() string { return "wrapped: " + e.inner.Error() }
 func (e errWrapper) Unwrap() error { return e.inner }
+
+// TestClassifyRouteOutcome_CostlyCancellationIsEvidence pins the change that
+// makes the failure-driven memo able to see the failure mode production
+// actually exhibits.
+//
+// Before this, ONLY a ClickHouse memory-limit abort counted as evidence. On the
+// classic-histogram APM panel that missed 15 of 16 real failures: they arrived
+// as client cancellations (CH code 735) at ~30 s, which classified NoEvidence,
+// so the memo learned nothing no matter how many times the panel failed.
+//
+// The floor is what keeps this honest — a caller who navigates away at 200 ms
+// must stay NoEvidence, because that says nothing about route cost.
+func TestClassifyRouteOutcome_CostlyCancellationIsEvidence(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name    string
+		err     error
+		elapsed time.Duration
+		want    routememo.Outcome
+	}{
+		{
+			name:    "cancelled after real work is cost evidence",
+			err:     context.Canceled,
+			elapsed: costlyCancellationFloor,
+			want:    routememo.OutcomeResourceFailure,
+		},
+		{
+			name:    "deadline exceeded after real work is cost evidence",
+			err:     context.DeadlineExceeded,
+			elapsed: 30 * time.Second,
+			want:    routememo.OutcomeResourceFailure,
+		},
+		{
+			name:    "caller went away early is NOT evidence",
+			err:     context.Canceled,
+			elapsed: 200 * time.Millisecond,
+			want:    routememo.OutcomeNoEvidence,
+		},
+		{
+			name:    "unmeasured elapsed keeps the original reading",
+			err:     context.Canceled,
+			elapsed: 0,
+			want:    routememo.OutcomeNoEvidence,
+		},
+		{
+			name:    "success is still success",
+			err:     nil,
+			elapsed: time.Minute,
+			want:    routememo.OutcomeSuccess,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if got := classifyRouteOutcomeAfter(routememo.RouteA, tc.err, tc.elapsed); got != tc.want {
+				t.Fatalf("classifyRouteOutcomeAfter(%v, %v) = %v, want %v", tc.err, tc.elapsed, got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/solver/config.go
+++ b/internal/solver/config.go
@@ -87,20 +87,28 @@ type Config struct {
 	// success cannot OOM the shared gateway heap.
 	MaxOutputRows int64
 
-	// RouteMemoEnabled (CERBERUS_SOLVER_ROUTE_MEMO_ENABLED, default false)
-	// wires the failure-driven route memo (internal/routememo,
-	// docs/solver.md §"Failure-driven route memo"): a route-A dispatch that
-	// fails with resource exhaustion is retried once on route B, and the
-	// outcome is remembered so future cost-equivalent traffic can route
-	// directly. Off by default, matching this repo's convention for a new
-	// runtime-behavior-changing feature (CERBERUS_CH_OPT_CORPUS_ENABLED,
-	// CERBERUS_EXPERIMENTAL_TS_GRID_RANGE) — an operator opts in explicitly
-	// rather than picking up new ClickHouse dispatch/resource behavior on a
-	// routine upgrade. cmd/cerberus reads this field to decide whether to
-	// construct a *routememo.Memo and wire it onto engine.Engine.RouteMemo;
-	// this package itself never imports internal/routememo (see
-	// .go-arch-lint.yml — routememo is importable by engine and cmd only).
-	RouteMemoEnabled bool
+	// AdaptiveEnabled (CERBERUS_SOLVER_ADAPTIVE_ENABLED, default TRUE) wires
+	// the failure-driven route memo (internal/routememo, docs/solver.md
+	// §"Failure-driven route memo"): a route-A dispatch that fails with
+	// resource exhaustion is retried once on route B — transparently, so the
+	// caller still gets an answer — and the outcome is remembered so future
+	// cost-equivalent traffic routes directly.
+	//
+	// It is ON by default because it is the ONLY half of the routing decision
+	// that reacts to what actually happened. ModeAuto's thresholds are a
+	// PREDICTION made once, from plan shape alone; with this off, a wrong
+	// prediction stays wrong forever and a route-A resource failure is a 5xx
+	// rather than a slower answer. Turning it on is what makes ModeAuto mean
+	// "start on route A and escalate on real evidence" rather than "guess up
+	// front and never learn". Default-off was the old convention for a new
+	// runtime-behavior-changing feature; the availability argument outweighs
+	// it here, since the feature only ever turns a FAILURE into an answer.
+	//
+	// cmd/cerberus reads this field to decide whether to construct a
+	// *routememo.Memo and wire it onto engine.Engine.RouteMemo; this package
+	// itself never imports internal/routememo (see .go-arch-lint.yml —
+	// routememo is importable by engine and cmd only).
+	AdaptiveEnabled bool
 
 	// RouteMemoEntryTTL (CERBERUS_SOLVER_ROUTE_MEMO_ENTRY_TTL) overrides how
 	// long the route memo trusts a recorded verdict before it ages out,
@@ -151,7 +159,7 @@ func DefaultConfig() Config {
 		Parallel:           defaultParallel,
 		Timeout:            defaultTimeout,
 		MaxOutputRows:      defaultMaxOutputRows,
-		RouteMemoEnabled:   false,
+		AdaptiveEnabled:    true,
 	}
 }
 

--- a/internal/solver/config_env.go
+++ b/internal/solver/config_env.go
@@ -21,9 +21,15 @@ const (
 	EnvParallel           = "CERBERUS_SHARD_PARALLEL"
 	EnvTimeout            = "CERBERUS_SOLVER_TIMEOUT"
 	EnvMaxOutputRows      = "CERBERUS_SHARD_MAX_OUTPUT_ROWS"
-	EnvRouteMemoEnabled   = "CERBERUS_SOLVER_ROUTE_MEMO_ENABLED"
-	EnvRouteMemoEntryTTL  = "CERBERUS_SOLVER_ROUTE_MEMO_ENTRY_TTL"
-	EnvRouteMemoRevalFrac = "CERBERUS_SOLVER_ROUTE_MEMO_REVALIDATION_FRACTION"
+	EnvAdaptiveEnabled    = "CERBERUS_SOLVER_ADAPTIVE_ENABLED"
+	// EnvLegacyRouteMemoEnabled is the SOFT-DEPRECATED spelling of
+	// EnvAdaptiveEnabled. It still works; setting it logs a one-time
+	// deprecation warning and the new name wins when both are set. Kept
+	// because an operator who explicitly disabled the feature must not have
+	// it silently re-enabled by an upgrade that only renamed the knob.
+	EnvLegacyRouteMemoEnabled = "CERBERUS_SOLVER_ROUTE_MEMO_ENABLED"
+	EnvRouteMemoEntryTTL      = "CERBERUS_SOLVER_ROUTE_MEMO_ENTRY_TTL"
+	EnvRouteMemoRevalFrac     = "CERBERUS_SOLVER_ROUTE_MEMO_REVALIDATION_FRACTION"
 )
 
 // ConfigFromEnv builds a Config from the CERBERUS_* environment, starting
@@ -45,6 +51,23 @@ const (
 // routing entirely. The library default (DefaultConfig, Mode == "single")
 // stays dark so in-process unit/spec tests that build it directly are
 // unaffected; only this env-driven prod path flips to auto.
+// DeprecatedEnvWarnings returns a one-line notice for every soft-deprecated
+// CERBERUS_* solver var that is SET in the environment, for the caller to log
+// at startup. Empty when none are set.
+//
+// Separate from ConfigFromEnv because this package must not choose a logger;
+// cmd/cerberus owns that. Mirrors the CERBERUS_EXPERIMENTAL_TS_GRID_RANGE ->
+// CERBERUS_CH_OPTIMIZATIONS deprecation (internal/chopt/resolve.go).
+func DeprecatedEnvWarnings() []string {
+	var warns []string
+	if _, ok := os.LookupEnv(EnvLegacyRouteMemoEnabled); ok {
+		warns = append(warns, EnvLegacyRouteMemoEnabled+
+			" is deprecated; use "+EnvAdaptiveEnabled+
+			" (the old name still applies, and the new name wins when both are set)")
+	}
+	return warns
+}
+
 func ConfigFromEnv() (Config, error) {
 	cfg := DefaultConfig()
 	// Unset CERBERUS_EVAL_ROUTE means "auto" in production, not the library's
@@ -77,7 +100,14 @@ func ConfigFromEnv() (Config, error) {
 	if cfg.MaxOutputRows, err = envInt64(EnvMaxOutputRows, cfg.MaxOutputRows); err != nil {
 		return Config{}, err
 	}
-	if cfg.RouteMemoEnabled, err = envBool(EnvRouteMemoEnabled, cfg.RouteMemoEnabled); err != nil {
+	// The legacy alias is layered FIRST so an explicit new-name setting wins,
+	// and so "operator explicitly set the old one to false" is distinguishable
+	// from "operator set neither" — a plain bool would conflate them and
+	// silently re-enable a feature somebody deliberately turned off.
+	if cfg.AdaptiveEnabled, err = envBool(EnvLegacyRouteMemoEnabled, cfg.AdaptiveEnabled); err != nil {
+		return Config{}, err
+	}
+	if cfg.AdaptiveEnabled, err = envBool(EnvAdaptiveEnabled, cfg.AdaptiveEnabled); err != nil {
 		return Config{}, err
 	}
 	if cfg.RouteMemoEntryTTL, err = envDuration(EnvRouteMemoEntryTTL, cfg.RouteMemoEntryTTL); err != nil {

--- a/internal/solver/config_env_test.go
+++ b/internal/solver/config_env_test.go
@@ -1,6 +1,7 @@
 package solver
 
 import (
+	"strings"
 	"testing"
 	"time"
 )
@@ -92,50 +93,83 @@ func TestConfigFromEnv_RetiredKnobsIgnored(t *testing.T) {
 // operator explicitly opts in. An unset env var (a routine upgrade,
 // deploying this binary onto an existing config with no manifest change)
 // must resolve to disabled, not enabled.
-func TestConfigFromEnv_RouteMemoDefaultsOff(t *testing.T) {
-	t.Setenv(EnvRouteMemoEnabled, "")
+func TestConfigFromEnv_AdaptiveDefaultsOn(t *testing.T) {
+	t.Setenv(EnvAdaptiveEnabled, "")
+	t.Setenv(EnvLegacyRouteMemoEnabled, "")
 
 	cfg, err := ConfigFromEnv()
 	if err != nil {
 		t.Fatalf("ConfigFromEnv() error = %v", err)
 	}
-	if cfg.RouteMemoEnabled {
-		t.Errorf("RouteMemoEnabled = true, want false (default-off)")
+	if !cfg.AdaptiveEnabled {
+		t.Errorf("AdaptiveEnabled = false, want true (default-on: it is the only half of the routing decision that reacts to what happened)")
 	}
 	if err := cfg.Validate(); err != nil {
 		t.Fatalf("default config failed Validate: %v", err)
 	}
 }
 
-// TestConfigFromEnv_RouteMemoExplicitOn confirms the opt-in path.
-func TestConfigFromEnv_RouteMemoExplicitOn(t *testing.T) {
-	t.Setenv(EnvRouteMemoEnabled, "true")
+// TestConfigFromEnv_AdaptiveExplicitOff pins that an operator can still turn it
+// off — and that doing so is honoured, not silently overridden by the default.
+func TestConfigFromEnv_AdaptiveExplicitOff(t *testing.T) {
+	t.Setenv(EnvAdaptiveEnabled, "false")
 
 	cfg, err := ConfigFromEnv()
 	if err != nil {
 		t.Fatalf("ConfigFromEnv() error = %v", err)
 	}
-	if !cfg.RouteMemoEnabled {
-		t.Errorf("RouteMemoEnabled = false, want true (explicit opt-in)")
-	}
-	if err := cfg.Validate(); err != nil {
-		t.Fatalf("route-memo-enabled config failed Validate: %v", err)
+	if cfg.AdaptiveEnabled {
+		t.Errorf("AdaptiveEnabled = true, want false (explicit opt-out must win over the default)")
 	}
 }
 
-// TestConfigFromEnv_RouteMemoExplicitOff confirms an explicit "false" is
-// indistinguishable in effect from leaving the var unset (both resolve to
-// disabled) — the option to be explicit about the default must not itself
-// change behaviour.
-func TestConfigFromEnv_RouteMemoExplicitOff(t *testing.T) {
-	t.Setenv(EnvRouteMemoEnabled, "false")
+// TestConfigFromEnv_LegacyRouteMemoAliasStillApplies pins the soft deprecation:
+// an operator who set the OLD name to false on a previous version must not have
+// the feature silently re-enabled by an upgrade that merely renamed the knob.
+func TestConfigFromEnv_LegacyRouteMemoAliasStillApplies(t *testing.T) {
+	t.Setenv(EnvLegacyRouteMemoEnabled, "false")
 
 	cfg, err := ConfigFromEnv()
 	if err != nil {
 		t.Fatalf("ConfigFromEnv() error = %v", err)
 	}
-	if cfg.RouteMemoEnabled {
-		t.Errorf("RouteMemoEnabled = true, want false (explicit opt-out)")
+	if cfg.AdaptiveEnabled {
+		t.Errorf("AdaptiveEnabled = true; the deprecated %s=false must still disable it", EnvLegacyRouteMemoEnabled)
+	}
+}
+
+// TestConfigFromEnv_NewNameWinsOverLegacy pins the precedence when both are set.
+func TestConfigFromEnv_NewNameWinsOverLegacy(t *testing.T) {
+	t.Setenv(EnvLegacyRouteMemoEnabled, "false")
+	t.Setenv(EnvAdaptiveEnabled, "true")
+
+	cfg, err := ConfigFromEnv()
+	if err != nil {
+		t.Fatalf("ConfigFromEnv() error = %v", err)
+	}
+	if !cfg.AdaptiveEnabled {
+		t.Errorf("AdaptiveEnabled = false; the new name must win over the deprecated alias")
+	}
+}
+
+// TestDeprecatedEnvWarnings_FiresOnLegacyName pins that the deprecation is
+// ANNOUNCED, not silent. A rename nobody is told about is a rename that rots.
+func TestDeprecatedEnvWarnings_FiresOnLegacyName(t *testing.T) {
+	t.Setenv(EnvLegacyRouteMemoEnabled, "true")
+
+	warns := DeprecatedEnvWarnings()
+	if len(warns) == 0 {
+		t.Fatal("no deprecation warning for the legacy route-memo env var")
+	}
+	if !strings.Contains(warns[0], EnvAdaptiveEnabled) {
+		t.Errorf("warning %q does not name the replacement %s", warns[0], EnvAdaptiveEnabled)
+	}
+}
+
+// TestDeprecatedEnvWarnings_SilentWhenUnset: no warning when nobody set it.
+func TestDeprecatedEnvWarnings_SilentWhenUnset(t *testing.T) {
+	if w := DeprecatedEnvWarnings(); len(w) != 0 {
+		t.Errorf("unexpected deprecation warnings with nothing set: %v", w)
 	}
 }
 


### PR DESCRIPTION
## Why

`auto` implies the router adapts. It didn't. Its thresholds are a **prediction made once**, from
plan shape alone (`F >= MinFanout && N*F >= MinAnchorPairs`), and the only half of the decision that
reacts to what actually happened — the failure-driven route memo — was **off by default**.

So a wrong prediction stayed wrong forever, and a route-A resource failure surfaced as a 5xx rather
than a slower answer. Verified against the live deployment: no solver env var is set at all, so the
adaptive half has never run in production.

This makes `auto` mean **start on route A and escalate on real evidence**.

## What changes

**1. Adaptivity on by default.** `solver.Config.AdaptiveEnabled` defaults `true`, which activates
`retryOnRouteAResourceFailure`: a route-A dispatch that exhausts resources is **transparently
retried on route B** — the caller still gets an answer — and the outcome is remembered so
equivalent traffic routes directly next time.

The default-off convention exists for features that change behaviour ambiguously. This one only
ever turns a FAILURE into an answer, which is not a trade an operator needs protecting from.

**2. `CERBERUS_SOLVER_ROUTE_MEMO_ENABLED` -> `CERBERUS_SOLVER_ADAPTIVE_ENABLED`, soft-deprecated.**
The old name still applies; the new one wins when both are set; setting the old one logs a one-time
deprecation notice via `DeprecatedEnvWarnings()` (cmd/cerberus owns the logger, so this package
returns the strings rather than choosing one). Mirrors the existing
`CERBERUS_EXPERIMENTAL_TS_GRID_RANGE` -> `CERBERUS_CH_OPTIMIZATIONS` deprecation in `internal/chopt`.

This is deliberately NOT a hard rename: an operator who explicitly set the old name to `false` must
not have the feature silently re-enabled by an upgrade that merely renamed the knob. That case is
pinned by a test.

**3. A costly cancellation now counts as cost evidence.** `classifyRouteOutcome` recognised exactly
one failure — a ClickHouse memory-limit abort. Measured on the classic-histogram APM panel, that
missed **15 of 16 real failures**:

| ClickHouse outcome | count | classified as |
|---|---|---|
| 735 cancelled by client (~30 s) | **15** | NoEvidence — memo learns nothing |
| 241 memory limit exceeded | 1 | ResourceFailure |

A cancellation past `costlyCancellationFloor` had already committed real ClickHouse work and is
evidence about *this route's* cost; one at 200 ms is a caller who went away, and stays NoEvidence.

It is **recorded, never retried** — the caller is already gone, so a retry dispatch would run for
nobody. That is the doomed-trial shape the existing `ctx.Err()` guard exists to prevent. It teaches
the NEXT request instead.

## What this does NOT do

Prediction is not removed, only its unfounded half. The companion change (#2396) stops ModeAuto
predicting route B for a carrier whose peak does not divide with the anchor grid. What remains is
prediction where it is well-founded, plus escalation on measurement everywhere else.

`ModeSingle` and `ModeSharded` are untouched — the former is the kill switch, the latter is what the
force-route parity lanes use to prove route B returns identical answers.

## Test plan

- [x] `TestConfigFromEnv_AdaptiveDefaultsOn` — the new default
- [x] `TestConfigFromEnv_AdaptiveExplicitOff` — an operator can still turn it off
- [x] `TestConfigFromEnv_LegacyRouteMemoAliasStillApplies` — **the deprecation safety pin**: the old
      name set to `false` still disables it
- [x] `TestConfigFromEnv_NewNameWinsOverLegacy` — precedence when both are set
- [x] `TestDeprecatedEnvWarnings_FiresOnLegacyName` / `_SilentWhenUnset` — the deprecation is
      announced, not silent
- [x] `TestClassifyRouteOutcome_CostlyCancellationIsEvidence` — table covering cancelled-after-work,
      deadline-exceeded, went-away-early, unmeasured, and success
- [x] `go test ./internal/solver/ ./internal/engine/` green

## Stacking

Branched off `main`, but belongs AFTER #2396 (carrier bit) — together they are the two halves of
"predict only where well-founded, escalate on evidence elsewhere". Rebase after #2396 merges.
