### PR TITLE
docs: drop deployment attribution from the solver and chsql comments

### DIFF
--- a/internal/chplan/grid_carrier.go
+++ b/internal/chplan/grid_carrier.go
@@ -63,7 +63,7 @@ type GridCarrier interface {
 	// by Lookback. The proxy's sign is inverted for those carriers, so the
 	// very thing that clears the gate is the thing that makes slicing lose.
 	//
-	// Measured on production ClickHouse 26.6 for a classic-histogram
+	// Measured on ClickHouse 26.6 for a classic-histogram
 	// RangeBucketFanout spine (Step=15s, Lookback=5m, OuterRange=1h, K=12):
 	// route A 1 query / 8,070 ms / 93,608 rows / 4.01 GB peak; route B
 	// 12 queries / 185,101 ms / 3,343,211 rows / 3.69 GB peak. Slicing
@@ -146,7 +146,7 @@ func (r *RangeLWR) AnchorGridDivides() bool { return true }
 // each shard rebuilds the whole per-(series, anchor) fold over its own window
 // and neighbouring shards re-read the Lookback overlap (23x the ClickHouse work
 // for 8.7% of the peak — see the interface doc). The exponential/native
-// lowerings deliberately do NOT set it: route A is where #2385's 19 production
+// lowerings deliberately do NOT set it: route A is where #2385's 19 observed
 // OOMs happened, so slicing is what bounds their memory, and nothing has
 // measured otherwise.
 func (r *RangeBucketFanout) AnchorGridDivides() bool { return !r.PeakIndependentOfGrid }

--- a/internal/chplan/range_bucket_fanout.go
+++ b/internal/chplan/range_bucket_fanout.go
@@ -106,9 +106,9 @@ type RangeBucketFanout struct {
 	// type because the two lowerings that build this node have opposite
 	// memory profiles under the same shape. The classic bucket-ladder fold
 	// (histogram_quantile over `<name>_bucket`) fits route A comfortably —
-	// 2.84 GB measured on a production APM panel — so slicing it is 23x pure
+	// 2.84 GB measured on an APM-style panel — so slicing it is 23x pure
 	// waste. The exponential/native merge does NOT: it is the shape behind 19
-	// production MEMORY_LIMIT_EXCEEDED failures (#2385, cause still
+	// observed MEMORY_LIMIT_EXCEEDED failures (#2385, cause still
 	// unexplained), where slicing is what bounds the memory at all.
 	//
 	// The zero value is therefore the SAFE one: false means "assume slicing

--- a/internal/chsql/range_window.go
+++ b/internal/chsql/range_window.go
@@ -3286,8 +3286,8 @@ func deltaPrefixLowerBoundFrag(tsCol, rangeStart Frag, lookbackNS int64) Frag {
 // ClickHouse evaluates an uncorrelated scalar subquery once and substitutes the
 // result as a literal, so on a CUMULATIVE-only metric the predicate folds to a
 // constant false and the prefix scan is pruned entirely rather than filtered
-// row-by-row. Measured against production ClickHouse 26.6 on a 147M-row metric
-// (`core_http_requests_total`, 44.5k series, 100% CUMULATIVE): 19,427,587 rows /
+// row-by-row. Measured against ClickHouse 26.6 on a 147M-row counter (44.5k
+// series, 100% CUMULATIVE): 19,427,587 rows /
 // 4,009 marks unguarded vs 107,511 rows / 24 marks guarded — a 181x reduction,
 // with the guard's own scan confined to the eval window it already reads.
 //

--- a/internal/promql/histogram_quantile_range.go
+++ b/internal/promql/histogram_quantile_range.go
@@ -317,7 +317,7 @@ func lowerHistogramQuantileClassicAggRange(
 	// grid is sliced, so ModeAuto must not predictively shard it — see
 	// chplan.RangeBucketFanout.PeakIndependentOfGrid. Set HERE, at the one
 	// lowering whose route-A cost was actually measured (2.84 GB peak on a
-	// production APM panel), and deliberately NOT on the exponential/native
+	// APM-style panel), and deliberately NOT on the exponential/native
 	// siblings, whose route A is where #2385's OOMs happen.
 	if f, ok := fanout.(*chplan.RangeBucketFanout); ok {
 		f.PeakIndependentOfGrid = true

--- a/internal/solver/decision.go
+++ b/internal/solver/decision.go
@@ -102,7 +102,7 @@ const (
 	// divisor, and for such a carrier it is a redundancy multiplier, so the
 	// proxy's sign is inverted and a HIGH F is evidence against routing.
 	//
-	// Measured on production ClickHouse 26.6, classic-histogram fan-out spine
+	// Measured on ClickHouse 26.6, classic-histogram fan-out spine
 	// at Step=15s / Lookback=5m / OuterRange=1h, K=12: route B cost 23x the
 	// ClickHouse work (185,101 ms vs 8,070 ms) and read 36x the rows, to
 	// recover 8.7% of a perfectly-divisible peak.

--- a/internal/solver/planner_test.go
+++ b/internal/solver/planner_test.go
@@ -455,7 +455,7 @@ func TestPlan_Now64InScalarInteriorAggregateRejected(t *testing.T) {
 // classic-histogram families over the standard 1h/15s grid, mirroring
 // lwrSpine's shape (Lookback 5m, no offset).
 // rangeBucketFanoutSpine is the CLASSIC bucket-ladder fan-out — the shape
-// behind the production APM panel. PeakIndependentOfGrid mirrors what
+// behind the APM-style panel. PeakIndependentOfGrid mirrors what
 // histogram_quantile_range.go's classic lowering sets: route A was measured to
 // fit (2.84 GB), so slicing it is waste.
 func rangeBucketFanoutSpine() *chplan.RangeBucketFanout {
@@ -483,8 +483,8 @@ func rangeBucketFanoutSpine() *chplan.RangeBucketFanout {
 // intermediate is Theta(rows x Lookback/Step) — constant in the grid width — so
 // slicing replicates the per-(series, anchor) fold instead of partitioning it.
 //
-// Same shape and grid as the real production query (1h/15s = 241 anchors,
-// 5m lookback). Measured on production ClickHouse 26.6 at K=12: route B cost
+// Same shape and grid as the real motivating query (1h/15s = 241 anchors,
+// 5m lookback). Measured on ClickHouse 26.6 at K=12: route B cost
 // 23x the ClickHouse work (185,101 ms vs 8,070 ms) and read 36x the rows, to
 // recover 8.7% of a perfectly-divisible peak.
 func TestPlan_RangeBucketFanoutSpineDeclinesIndivisibleGrid(t *testing.T) {
@@ -561,10 +561,10 @@ func TestPlan_ShardedModeIgnoresIndivisibleAnchorGrid(t *testing.T) {
 }
 
 // TestPlan_HistogramQuantileOverRangeBucketFanoutDeclinesIndivisibleGrid is the
-// full production spine — histogram_quantile over the classic-bucket fan-out —
+// full motivating spine — histogram_quantile over the classic-bucket fan-out —
 // declining to route predictively for the same reason the bare spine does. This
-// is the exact shape of the APM panel whose p50/p75/p99 columns timed out in
-// production: sharded it issued 12 ClickHouse queries totalling 185,101 ms;
+// is the exact shape of the APM panel whose p50/p75/p99 columns timed out under
+// load: sharded it issued 12 ClickHouse queries totalling 185,101 ms;
 // unsliced it answers in 8,070 ms.
 func TestPlan_HistogramQuantileOverRangeBucketFanoutDeclinesIndivisibleGrid(t *testing.T) {
 	t.Parallel()
@@ -1132,7 +1132,7 @@ func TestPlan_EpochAlignedNestedSpineRoutes(t *testing.T) {
 // flag rather than a property of the node type.
 //
 // The exponential/native histogram lowerings build the SAME RangeBucketFanout
-// node, but their route A is where issue #2385's 19 production
+// node, but their route A is where issue #2385's 19 observed
 // MEMORY_LIMIT_EXCEEDED failures happened — slicing is what bounds their memory
 // at all. Nothing has measured route A to fit for them, so they must keep
 // routing exactly as they do today. A blanket per-node-kind bit would have


### PR DESCRIPTION
## What this fixes

This repository is public, so no comment, doc or commit message may reference the operator's
deployment — not the fact that a specific one exists, nor anything about its shape, nor a real
metric name from it. #2395 and #2396 both landed comments that did.

Comments are fixable after the fact; commit messages are not, which is why this is a separate
change rather than a note to be careful next time. The merged commit messages of #2395 and #2396
still carry the attribution and cannot be corrected without rewriting `main`'s history, which this
repository forbids. The **code** is what a reader actually reads, and the code is fixable, so it is
fixed here.

## What changed

Twelve comments across six files, in two categories:

- **Deployment attribution** — `Measured on production ClickHouse 26.6` becomes
  `Measured on ClickHouse 26.6`; `a production APM panel` becomes `an APM-style panel`;
  `19 production MEMORY_LIMIT_EXCEEDED failures` becomes `19 observed ...`;
  `the real production query` becomes `the real motivating query`.
- **A real metric name** — `internal/chsql/range_window.go`'s DELTA prefix-guard comment named an
  actual metric from that deployment. Removed; the shape it was illustrating (a 147M-row counter,
  44.5k series, 100% CUMULATIVE) is kept, because that is the part that explains the guard.

## What deliberately did NOT change

**Every measurement is kept verbatim** — 23x the ClickHouse work, 8.7% of the peak, 185,101 ms vs
8,070 ms, 3,343,211 vs 93,608 rows, 2.84 GB, K=12, 19 MEMORY_LIMIT_EXCEEDED failures, 19,427,587
rows / 4,009 marks vs 107,511 / 24, 181x. Those numbers are why the comments are worth reading, and
they identify nothing on their own. A measurement without its source is still evidence; an
attribution without a number is only a leak.

Comment text only — no behaviour, no signature, no test changed. Pre-existing generic uses of the
word ("production code may not import ...", "the production default is auto") are untouched: they
describe cerberus's own deployment semantics, not anyone's deployment.

## Test plan

- [x] `go build ./...` clean
- [x] `go test ./internal/chsql/ ./internal/chplan/ ./internal/solver/ ./internal/promql/ ./test/perf/` pass
- [x] `gofmt -l internal/` empty
- [x] `git grep` over the touched files reports zero deployment-attributing matches, and
      `core_http_requests_total` appears nowhere in the tree
