### PR TITLE
chore: enable Buy Me a Coffee sponsor button

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+buy_me_a_coffee: tsouza


### PR DESCRIPTION
## Summary
- Adds `.github/FUNDING.yml` so GitHub shows a Sponsor button on the repo page, linking to buymeacoffee.com/tsouza.

## Test plan
- [x] No code path affected; this is a GitHub-native metadata file, no build/test impact.