### PR TITLE
ci(lint): raise golangci-lint's timeout to a runaway guard, not a contention tripwire

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -232,6 +232,20 @@ jobs:
   lint:
     name: lint
     runs-on: ubuntu-latest
+    # Undeclared here defaults to GitHub's 360-minute cap, which is no bound
+    # at all and would silently become the tighter constraint once the two
+    # golangci-lint steps' own `run.timeout` (.golangci.yml) grew a real
+    # runaway-analysis guard rather than the old 5m contention tripwire (see
+    # that file's comment for the measured cold-cost basis, issue #2388).
+    # 30m = 2 x golangci-lint's 10m internal cap (the worst case if BOTH the
+    # tagged and untagged passes independently ran to their own timeout) plus
+    # slack for the job's remaining steps (migration tier-0, go-arch-lint,
+    # actionlint, commitlint, markdownlint), which together settled under 90s
+    # across the same 2026-08-20 sample. The whole job's clean total measured
+    # 4m41s-6m28s over that sample, so 30m keeps golangci-lint's own timeout
+    # the one that fires first on a genuine runaway, the same relationship
+    # `check-test` / `check-build` keep with `just test-unit`'s own timeout.
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v7
         with:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -50,7 +50,20 @@
 version: "2"
 
 run:
-  timeout: 5m
+  # `10m` is a runaway-analysis guard, not a contention tripwire — the `lint`
+  # job's own `timeout-minutes` (.github/workflows/ci.yml) is the outer safety
+  # net, so this cap only needs to fire on a genuinely pathological analysis,
+  # not on ordinary shared-runner noise. Measured cold (`golangci-lint cache
+  # clean`, matching CI's `skip-cache: true`) across five consecutive `main`
+  # runs on 2026-08-20, the tagged pass — the more expensive of the two
+  # `run: ./...` invocations this timeout applies to — took 2m46s-3m47s; a
+  # sixth run (#32253179854 attempt 1, same commit that passed at 3m07s on
+  # retry) hit the OLD 5m cap at 5m05s on pure runner contention, confirmed by
+  # near-identical CPU-seconds between the failing and passing attempts
+  # (issue #2388). 10m is >2.6x the worst clean pass observed, comfortably
+  # absorbing that class of contention while still catching an actual
+  # runaway.
+  timeout: 10m
 
   # golangci-lint analyses ONE build configuration per invocation, so a run
   # that sets no tags cannot see a single tagged file — 120 `chdb` files (the


### PR DESCRIPTION
## Summary

- `.golangci.yml`'s `run.timeout: 5m` gave only ~30% headroom over the ~3m30s cold tagged pass, so ordinary shared-runner contention could fail the `lint` gate *after* golangci-lint had already printed `0 issues.` — the worst possible failure mode for a required check.
- Raise `run.timeout` to `10m`, a genuine runaway-analysis guard rather than a contention tripwire, and give the `lint` job an explicit `timeout-minutes: 30` (previously unset, i.e. GitHub's 360m default) so it stays the looser of the two bounds.

## Evidence (measured locally + reproduced against live CI runs)

Reproduced the issue's own methodology (`golangci-lint cache clean`, matching CI's `skip-cache: true`, same `v2.12.2`) and cross-checked against the 5 most recent `main` `lint` job runs as of 2026-08-20:

| run | tagged pass |
| --- | --- |
| #32354168217 | 3m47s |
| #32354438656 | 2m46s |
| #32344530849 | 3m43s |
| #32334116186 | 2m53s |
| #32330431999 | 3m42s |

Still the same ~3-3.5min range the issue reported — nothing has drifted since it was filed. Also re-fetched the failing run cited in the issue (#32253179854 attempt 1): tagged pass ran 5m05s and hit the old 5m cap, while attempt 2 on the identical commit passed at 3m07s — confirming the failure was pure contention, not a real regression.

`10m` is >2.6x the worst clean cold pass observed (3m47s), comfortably absorbing that class of contention while still catching an actual runaway. `30m` at the job level = 2 × golangci-lint's own 10m cap (worst case if both the tagged and untagged passes independently ran to their own timeout) + slack for the job's other steps (migration tier-0, go-arch-lint, actionlint, commitlint, markdownlint — combined well under 90s), keeping golangci-lint's own timeout the one that fires first in a genuine runaway rather than the job-level cutoff.

Both values are explained in-place as YAML comments per the repo's no-magic-numbers invariant.

Closes #2388

## Test plan

- [x] `golangci-lint config verify` — clean.
- [x] `actionlint .github/workflows/ci.yml` — clean.
- [x] `golangci-lint run ./internal/config/...` — config parses and runs correctly with the new timeout.
- [ ] CI's `lint` job goes green on this PR (the real verification for a lint-lane change — local timing measurement supports the value chosen but CI's own outcome is the evidence per repo policy).
