### PR TITLE
fix(release): re-validate release-staging PR's own dashboard result (#2361)

### DIFF
--- a/.github/scripts/README.md
+++ b/.github/scripts/README.md
@@ -1051,6 +1051,50 @@ what actually runs.
   - Exit (`eol-retire-line`): `0` always (fail-open — a retirement failure must
     never fail an already-published release); `1` only on a gross wiring error
     (missing repo/token) before any publish-affecting work.
+- **`release-source-pr-dashboard-gate.mjs`** — `release.yml`, the `preflight`
+  job, one step after `release-preflight.mjs`. Closes tsouza/cerberus#2361:
+  `dashboard`'s crawl leg (the ~50min k3d Grafana BFS) is dispatched by
+  `dashboard-matrix.mjs`'s `INCLUDE_CRAWL` only for a `release/*`-headed
+  `pull_request`, `schedule`, or manual dispatch — never for a `push` — so the
+  push-triggered `dashboard` check-run `release-preflight.mjs` reads on the
+  merge commit is a smoke-only verdict with zero crawl-coverage evidence for
+  that commit, even when it reports `success`. `dashboard` is also not a
+  native branch-protection required context on `main` (a deliberate trade —
+  see `e2e.yml`'s header), so GitHub's auto-merge never waited for it either:
+  PR #2360 auto-merged to `main` with its own `dashboard` / crawl result
+  FAILURE and nothing before this step would have refused it. Given the merge
+  commit, this resolves the release-staging PR GitHub associates with it
+  (`GET /commits/{sha}/pulls`, filtered to a `release/`-headed `head.ref` —
+  the same signal `dashboard-matrix.mjs` / `e2e.yml`'s `dashboard-setup`
+  already condition the crawl leg on) and re-reads THAT PR's own `dashboard`
+  check-run on its own head commit — the one run that ever actually exercised
+  the crawl leg — instead of trusting the push run's smoke-only proxy. A
+  commit with no associated `release/`-headed PR (an ordinary merge, or a
+  maintenance-line hotfix pushed with no PR at all) is a clean no-op: nothing
+  extra to re-validate, and `release-preflight.mjs`'s existing
+  `RELEASE_REQUIRED_CHECKS` read already covers whatever ran on it. **ABSENCE
+  IS A FAILURE**, the same posture as `release-preflight.mjs`: a release PR
+  whose own head commit never posted a `dashboard` check-run at all (e.g.
+  merged before the k3d lane finished) blocks exactly like a red one.
+  Pure exported `isReleaseStagingPR(pr)` + `releaseStagingSourcePRs(pulls)` +
+  `latestDashboardCheckRun(checkRuns)` + `sourcePRDashboardProblem({pr,
+  checkRuns})` + `evaluateSourcePRs({pulls, checkRunsByPR})` (no network, no
+  `process.exit`) + a `--self-test`.
+  `release-source-pr-dashboard-gate.test.mjs` is the `node --test` sibling
+  wired into the required `lint` lane — `release.yml` has no `pull_request:`
+  trigger, so without it every edit here would be unverified until a release
+  is cut. Its headline case is the exact #2361 incident shape: a release-
+  staging PR whose own `dashboard` check-run is FAILURE blocks the publish.
+  - Env: `GITHUB_TOKEN` (`pull-requests:read` + `checks:read`),
+    `GITHUB_REPOSITORY`, `GITHUB_SHA` (the pushed merge commit),
+    `GITHUB_API_URL` (default `https://api.github.com`).
+  - Args: argv `--self-test` runs the assertion suite; no command re-validates
+    the merge commit's release-staging source PR(s).
+  - Exit: `0` when no `release/`-headed source PR is associated with the
+    commit, or every one found has a completed, successful `dashboard`
+    check-run on its own head commit — or a green self-test; `1` on any
+    absent / still-running / non-`success` `dashboard` result on a source
+    PR's own head commit, or a missing required env var.
 - **`brew-smoke.mjs`** — `release.yml`, the `brew-smoke` job (post-`publish`),
   and `brew-verify.yml`, which re-runs the identical assertions on demand or
   weekly against an ALREADY-published version (the release-run job cannot be

--- a/.github/scripts/release-source-pr-dashboard-gate.mjs
+++ b/.github/scripts/release-source-pr-dashboard-gate.mjs
@@ -1,0 +1,371 @@
+// release-source-pr-dashboard-gate.mjs — re-validates the release-staging PR's
+// OWN `dashboard` (k3d Grafana crawl) verdict before a publish, closing
+// tsouza/cerberus#2361.
+//
+// The gap this closes
+// --------------------
+// `dashboard`'s crawl leg — the ~50min k3d BFS that walks every Grafana
+// surface — is dispatched by `.github/scripts/dashboard-matrix.mjs`
+// (INCLUDE_CRAWL) only for schedule, workflow_dispatch, or a `release/*`-headed
+// `pull_request`. It is NEVER dispatched for a plain `push` (see
+// dashboard-matrix.mjs and e2e.yml's `dashboard-setup` job). So the ONLY CI run
+// that ever exercises the crawl against a release commit is the release-staging
+// PR's own run — the push-to-main run that follows the merge gets a
+// smoke-only `dashboard` verdict with zero crawl-coverage evidence for that
+// exact commit, even though it reports `success`.
+//
+// `dashboard` is also not a native branch-protection required context on
+// `main` (a deliberate trade — see e2e.yml's header and docs/operations.md's
+// "Two-tier test fence"), so GitHub's native auto-merge does not wait for it
+// either. #2361 is the incident: PR #2360 auto-merged to `main` while its own
+// `dashboard` / crawl result was FAILURE, and `release.yml`'s existing
+// `RELEASE_REQUIRED_CHECKS` read of the push-triggered run's `dashboard` check
+// (release-preflight.mjs) could not have caught it even if the merge had
+// waited, because that push run never runs the crawl leg at all.
+//
+// The fix
+// -------
+// Given the merge commit, resolve the ORIGINAL release-staging PR via GitHub's
+// commit -> pull-request association (`GET /commits/{sha}/pulls`), then read
+// THAT PR's own `dashboard` check-run — the one run that ever actually
+// exercised the crawl leg — directly, instead of trusting the push run's
+// smoke-only proxy. A release-staging PR is identified structurally, the same
+// way dashboard-matrix.mjs / e2e.yml pick it: a head ref starting with
+// `release/`. A commit with no such associated PR (an ordinary merge, or a
+// maintenance-line hotfix pushed with no PR at all) has nothing extra to
+// re-validate here — release-preflight.mjs's existing RELEASE_REQUIRED_CHECKS
+// read already covers whatever DID run on that push, and this gate adds
+// nothing to relax.
+//
+// ABSENCE IS A FAILURE, same posture as release-preflight.mjs: a release
+// PR whose own head commit never posted a `dashboard` check-run at all (e.g.
+// merged manually before the k3d lane finished) blocks exactly like a red one
+// — the crawl either ran and passed, or the release does not publish.
+//
+// Env:
+//   GITHUB_TOKEN       token with pull-requests:read + checks:read.
+//   GITHUB_REPOSITORY  "owner/name".
+//   GITHUB_SHA         the pushed (merge) commit SHA.
+//   GITHUB_API_URL     API base (default https://api.github.com).
+//   argv `--self-test` runs the pure-logic assertions and exits.
+//
+// Exit: 0 when no release-staging source PR is found, or every one found has a
+// completed, successful `dashboard` check-run on its own head commit; 1
+// otherwise.
+
+import process from 'node:process';
+
+// dashboard-matrix.mjs / e2e.yml's own `dashboard-setup` select the crawl leg
+// off exactly this prefix on `github.head_ref` — mirrored here so a PR is
+// recognised as a release-staging PR the same way the lane that ran its crawl
+// recognised it.
+export const RELEASE_HEAD_REF_PREFIX = 'release/';
+
+// The aggregator job name in e2e.yml. Exact match only — see
+// release_required_checks_test.go's checkOwnerIndex comment on why a prefix
+// match would accept a name nothing posts.
+export const DASHBOARD_CHECK_NAME = 'dashboard';
+
+function short(sha) {
+  return String(sha ?? '').slice(0, 8);
+}
+
+// isReleaseStagingPR — a PR counts as release-staging iff its head ref starts
+// with `release/`, exactly the signal dashboard-matrix.mjs's INCLUDE_CRAWL and
+// e2e.yml's dashboard-setup `if:` already condition the crawl leg on.
+export function isReleaseStagingPR(pr) {
+  return typeof pr?.head?.ref === 'string' && pr.head.ref.startsWith(RELEASE_HEAD_REF_PREFIX);
+}
+
+// releaseStagingSourcePRs — filter the commit's associated pull requests down
+// to the release-staging one(s). Squash-merging normally associates exactly
+// one PR with the resulting commit; the filter (rather than taking pulls[0])
+// is defensive against the API ever returning more than one, and against a
+// non-release PR sharing the association list.
+export function releaseStagingSourcePRs(pulls) {
+  return (pulls ?? []).filter(isReleaseStagingPR);
+}
+
+// latestDashboardCheckRun — the highest-id `dashboard` check-run in the set (a
+// re-run leaves several with the same name; the highest id is current), or
+// null if none posted.
+export function latestDashboardCheckRun(checkRuns) {
+  let latest = null;
+  for (const cr of checkRuns ?? []) {
+    if (cr?.name !== DASHBOARD_CHECK_NAME) continue;
+    if (!latest || cr.id > latest.id) latest = cr;
+  }
+  return latest;
+}
+
+// sourcePRDashboardProblem — the blocking-problem string for one release-
+// staging PR, or null when its own `dashboard` check-run is a completed
+// success. Pure — no network — so the self-test pins the exact boundary.
+export function sourcePRDashboardProblem({ pr, checkRuns }) {
+  const run = latestDashboardCheckRun(checkRuns);
+  if (!run) {
+    return (
+      `PR #${pr.number} (${pr.head.ref}) never posted a "${DASHBOARD_CHECK_NAME}" check-run on its ` +
+      `own head commit ${short(pr.head.sha)}. That PR's run is the ONLY one that ever exercises the ` +
+      `k3d crawl leg for this commit (dashboard-matrix.mjs's INCLUDE_CRAWL never fires on a push), so ` +
+      `its absence blocks the release the same as a red one would. See tsouza/cerberus#2361.`
+    );
+  }
+  if (run.status !== 'completed') {
+    return (
+      `PR #${pr.number} (${pr.head.ref}): "${DASHBOARD_CHECK_NAME}" is still ${run.status} on its own ` +
+      `head commit ${short(pr.head.sha)} — the release-staging PR merged before its own dashboard/crawl ` +
+      `verdict settled. See tsouza/cerberus#2361.`
+    );
+  }
+  if (run.conclusion !== 'success') {
+    return (
+      `PR #${pr.number} (${pr.head.ref}): "${DASHBOARD_CHECK_NAME}" concluded ${run.conclusion} on its ` +
+      `own head commit ${short(pr.head.sha)} — the k3d Grafana crawl that validated this release found a ` +
+      `regression, and merging past it (native auto-merge does not wait on it; see #2361) did not clear ` +
+      `it. Refusing to publish.`
+    );
+  }
+  return null;
+}
+
+// evaluateSourcePRs — orchestrates the pure decision over every release-
+// staging PR associated with the merge commit, given a name->check-runs
+// lookup already fetched by the caller. Returns { problems, checked }; empty
+// problems (checked may be 0) means publish may proceed.
+export function evaluateSourcePRs({ pulls, checkRunsByPR }) {
+  const releasePRs = releaseStagingSourcePRs(pulls);
+  const problems = [];
+  for (const pr of releasePRs) {
+    const checkRuns = checkRunsByPR?.get(pr.number) ?? [];
+    const problem = sourcePRDashboardProblem({ pr, checkRuns });
+    if (problem) problems.push(problem);
+  }
+  return { problems, checked: releasePRs.length };
+}
+
+// ---------------------------------------------------------------------------
+// network (thin — the decision logic above is what the self-test pins)
+// ---------------------------------------------------------------------------
+
+async function getJSON(url, headers, fetchImpl) {
+  const res = await fetchImpl(url, { headers });
+  if (!res.ok) {
+    throw new Error(`GET ${url} -> ${res.status} ${res.statusText}`);
+  }
+  return res.json();
+}
+
+// associatedPulls — every pull request GitHub associates with a commit. For a
+// squash-merged commit on `main` this is normally exactly the one PR that
+// produced it, even after its head branch was deleted post-merge.
+export async function associatedPulls({ apiBase, repo, sha, headers, fetchImpl = globalThis.fetch }) {
+  return getJSON(`${apiBase}/repos/${repo}/commits/${sha}/pulls?per_page=100`, headers, fetchImpl);
+}
+
+// checkRunsForSha — every check-run GitHub has posted on a commit (paginated).
+export async function checkRunsForSha({ apiBase, repo, sha, headers, fetchImpl = globalThis.fetch }) {
+  const out = [];
+  let page = 1;
+  for (;;) {
+    const data = await getJSON(
+      `${apiBase}/repos/${repo}/commits/${sha}/check-runs?per_page=100&page=${page}`,
+      headers,
+      fetchImpl,
+    );
+    const runs = data.check_runs ?? [];
+    out.push(...runs);
+    if (runs.length < 100) break;
+    page += 1;
+  }
+  return out;
+}
+
+function ghNotice(msg) {
+  process.stdout.write(`::notice::${String(msg).replace(/\r?\n/g, '%0A')}\n`);
+}
+
+function ghError(msg) {
+  process.stdout.write(`::error::${String(msg).replace(/\r?\n/g, '%0A')}\n`);
+}
+
+async function main() {
+  const repo = process.env.GITHUB_REPOSITORY;
+  const sha = process.env.GITHUB_SHA;
+  const token = process.env.GITHUB_TOKEN;
+  const apiBase = process.env.GITHUB_API_URL || 'https://api.github.com';
+
+  if (!repo || !sha || !token) {
+    ghError('release-source-pr-dashboard-gate: GITHUB_REPOSITORY, GITHUB_SHA, and GITHUB_TOKEN are all required');
+    process.exit(1);
+  }
+
+  const headers = {
+    Authorization: `Bearer ${token}`,
+    Accept: 'application/vnd.github+json',
+    'X-GitHub-Api-Version': '2022-11-28',
+  };
+
+  const pulls = await associatedPulls({ apiBase, repo, sha, headers });
+  const releasePRs = releaseStagingSourcePRs(pulls);
+
+  if (releasePRs.length === 0) {
+    ghNotice(
+      `release-source-pr-dashboard-gate: ${short(sha)} has no associated release-staging (${RELEASE_HEAD_REF_PREFIX}*` +
+        `-headed) pull request — nothing extra to re-validate here; the push-triggered RELEASE_REQUIRED_CHECKS ` +
+        `read already covers whatever ran on this commit.`,
+    );
+    process.exit(0);
+  }
+
+  const checkRunsByPR = new Map();
+  for (const pr of releasePRs) {
+    checkRunsByPR.set(pr.number, await checkRunsForSha({ apiBase, repo, sha: pr.head.sha, headers }));
+  }
+
+  const { problems, checked } = evaluateSourcePRs({ pulls, checkRunsByPR });
+
+  if (problems.length > 0) {
+    for (const p of problems) ghError(p);
+    ghError(
+      `release-source-pr-dashboard-gate: ${short(sha)} BLOCKED — ${problems.length} problem(s) across ` +
+        `${checked} release-staging source PR(s). See tsouza/cerberus#2361.`,
+    );
+    process.exit(1);
+  }
+
+  ghNotice(
+    `release-source-pr-dashboard-gate: ${short(sha)} OK — ${checked} release-staging source PR(s), every ` +
+      `own "${DASHBOARD_CHECK_NAME}" check-run completed successfully.`,
+  );
+  process.exit(0);
+}
+
+// ---------------------------------------------------------------------------
+// self-test
+// ---------------------------------------------------------------------------
+
+function selfTest() {
+  const assert = (c, m) => {
+    if (!c) throw new Error('self-test: ' + m);
+  };
+
+  const dashboardRun = (conclusion, status = 'completed', id = 1) => ({
+    name: DASHBOARD_CHECK_NAME,
+    status,
+    conclusion,
+    id,
+  });
+  const otherRun = (name, id = 1) => ({ name, status: 'completed', conclusion: 'success', id });
+
+  const releasePR = (number, ref = 'release/v1.15.0-chart-0.15.0', sha = 'aaaa1111') => ({
+    number,
+    head: { ref, sha },
+  });
+  const ordinaryPR = (number, sha = 'bbbb2222') => ({ number, head: { ref: 'fix/some-bug', sha } });
+
+  // --- isReleaseStagingPR / releaseStagingSourcePRs -------------------------
+  assert(isReleaseStagingPR(releasePR(1)), 'a release/*-headed PR is release-staging');
+  assert(!isReleaseStagingPR(ordinaryPR(1)), 'an ordinary head ref is not release-staging');
+  assert(!isReleaseStagingPR({}), 'a PR with no head is not release-staging');
+
+  assert(
+    releaseStagingSourcePRs([releasePR(1), ordinaryPR(2)]).length === 1,
+    'the filter keeps only the release-staging PR',
+  );
+  assert(releaseStagingSourcePRs([]).length === 0, 'no pulls -> nothing found');
+  assert(releaseStagingSourcePRs(undefined).length === 0, 'undefined pulls -> nothing found (defensive)');
+
+  // --- latestDashboardCheckRun ----------------------------------------------
+  assert(latestDashboardCheckRun([]) === null, 'no runs -> null');
+  assert(latestDashboardCheckRun([otherRun('lint')]) === null, 'no dashboard run among others -> null');
+  {
+    const runs = [dashboardRun('failure', 'completed', 1), dashboardRun('success', 'completed', 2)];
+    const latest = latestDashboardCheckRun(runs);
+    assert(latest.conclusion === 'success', 'a re-run supersedes an earlier one by id');
+  }
+
+  // --- sourcePRDashboardProblem: absence, running, red, green ---------------
+  const pr = releasePR(2360);
+
+  {
+    const problem = sourcePRDashboardProblem({ pr, checkRuns: [otherRun('lint')] });
+    assert(problem && /never posted a "dashboard" check-run/.test(problem), 'absence blocks: ' + problem);
+  }
+  {
+    const problem = sourcePRDashboardProblem({ pr, checkRuns: [dashboardRun(null, 'in_progress')] });
+    assert(problem && /is still in_progress/.test(problem), 'a still-running dashboard run blocks: ' + problem);
+  }
+  {
+    // This is the exact #2361 incident shape: dashboard concluded FAILURE on
+    // the release-staging PR's own head commit.
+    const problem = sourcePRDashboardProblem({ pr, checkRuns: [dashboardRun('failure')] });
+    assert(problem && /concluded failure/.test(problem), 'a red dashboard run blocks: ' + problem);
+  }
+  {
+    const problem = sourcePRDashboardProblem({ pr, checkRuns: [dashboardRun('success')] });
+    assert(problem === null, 'a completed successful dashboard run does not block: ' + problem);
+  }
+  {
+    // `skipped` must NOT be treated as green here — dashboard-setup always
+    // runs (INCLUDE_CRAWL true) for a release/*-headed PR, so a skipped
+    // aggregator on a release PR is itself a wiring anomaly, not a pass.
+    const problem = sourcePRDashboardProblem({ pr, checkRuns: [dashboardRun('skipped')] });
+    assert(problem && /concluded skipped/.test(problem), 'a skipped dashboard run on a release PR blocks: ' + problem);
+  }
+
+  // --- evaluateSourcePRs: orchestration -------------------------------------
+  {
+    // No release-staging PR associated with the commit -> nothing to check.
+    const r = evaluateSourcePRs({ pulls: [ordinaryPR(1)], checkRunsByPR: new Map() });
+    assert(r.problems.length === 0 && r.checked === 0, 'no release-staging PR -> clean no-op: ' + JSON.stringify(r));
+  }
+  {
+    // Exactly the #2361 shape: one release-staging PR, its own dashboard run
+    // is FAILURE -> blocks, naming the PR.
+    const r = evaluateSourcePRs({
+      pulls: [releasePR(2360)],
+      checkRunsByPR: new Map([[2360, [dashboardRun('failure')]]]),
+    });
+    assert(r.checked === 1 && r.problems.length === 1, 'the #2361 shape blocks exactly once: ' + JSON.stringify(r));
+  }
+  {
+    // A green release-staging PR -> clean.
+    const r = evaluateSourcePRs({
+      pulls: [releasePR(2360)],
+      checkRunsByPR: new Map([[2360, [dashboardRun('success')]]]),
+    });
+    assert(r.problems.length === 0, 'a green release-staging PR passes: ' + JSON.stringify(r));
+  }
+  {
+    // A non-release PR sharing the association list is ignored entirely, even
+    // when it has no dashboard run of its own.
+    const r = evaluateSourcePRs({
+      pulls: [releasePR(2360), ordinaryPR(9)],
+      checkRunsByPR: new Map([
+        [2360, [dashboardRun('success')]],
+        [9, []],
+      ]),
+    });
+    assert(r.problems.length === 0 && r.checked === 1, 'an ordinary co-associated PR is not checked: ' + JSON.stringify(r));
+  }
+
+  process.stdout.write('::notice::release-source-pr-dashboard-gate --self-test: all assertions passed\n');
+}
+
+// ---------------------------------------------------------------------------
+// dispatcher
+// ---------------------------------------------------------------------------
+
+const invokedDirectly = process.argv[1] && import.meta.url === new URL(`file://${process.argv[1]}`).href;
+
+if (invokedDirectly) {
+  if (process.argv.includes('--self-test')) {
+    selfTest();
+    process.exit(0);
+  }
+  main().catch((e) => {
+    ghError(`release-source-pr-dashboard-gate failed: ${e.message}`);
+    process.exit(1);
+  });
+}

--- a/.github/scripts/release-source-pr-dashboard-gate.test.mjs
+++ b/.github/scripts/release-source-pr-dashboard-gate.test.mjs
@@ -1,0 +1,216 @@
+// release-source-pr-dashboard-gate.test.mjs — node:test guard for the #2361
+// fix, run on the required `lint` lane.
+//
+// Why it exists separately from the module's own `--self-test`: that self-test
+// only runs inside release.yml's `preflight` job, which fires on push-to-main /
+// a maintenance push — never on an ordinary pull_request. Every change here
+// would otherwise be unverified until a release is actually cut. This suite
+// runs on every PR.
+//
+// What it pins: the exact #2361 incident shape (a release-staging PR whose own
+// `dashboard` check-run is FAILURE) must block; a green one must not; a commit
+// with no associated release-staging PR must be a clean no-op (this gate adds,
+// it never relaxes, release-preflight.mjs's existing coverage); and the
+// network helpers correctly authenticate + paginate.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  DASHBOARD_CHECK_NAME,
+  RELEASE_HEAD_REF_PREFIX,
+  isReleaseStagingPR,
+  releaseStagingSourcePRs,
+  latestDashboardCheckRun,
+  sourcePRDashboardProblem,
+  evaluateSourcePRs,
+  associatedPulls,
+  checkRunsForSha,
+} from './release-source-pr-dashboard-gate.mjs';
+
+const releasePR = (number, ref = 'release/v1.15.0-chart-0.15.0', sha = 'aaaa1111') => ({
+  number,
+  head: { ref, sha },
+});
+const ordinaryPR = (number, sha = 'bbbb2222') => ({ number, head: { ref: 'fix/some-bug', sha } });
+const run = (conclusion, status = 'completed', id = 1, name = DASHBOARD_CHECK_NAME) => ({
+  name,
+  status,
+  conclusion,
+  id,
+});
+
+test('RELEASE_HEAD_REF_PREFIX matches dashboard-matrix.mjs / e2e.yml INCLUDE_CRAWL selection', () => {
+  assert.equal(RELEASE_HEAD_REF_PREFIX, 'release/');
+});
+
+test('isReleaseStagingPR discriminates on head.ref', () => {
+  assert.equal(isReleaseStagingPR(releasePR(1)), true);
+  assert.equal(isReleaseStagingPR(ordinaryPR(1)), false);
+  assert.equal(isReleaseStagingPR({}), false);
+  assert.equal(isReleaseStagingPR(undefined), false);
+});
+
+test('releaseStagingSourcePRs filters a mixed pulls list', () => {
+  assert.deepEqual(
+    releaseStagingSourcePRs([releasePR(1), ordinaryPR(2), releasePR(3, 'release/2.0.x-staging', 'cccc')]).map(
+      (pr) => pr.number,
+    ),
+    [1, 3],
+  );
+  assert.deepEqual(releaseStagingSourcePRs([]), []);
+  assert.deepEqual(releaseStagingSourcePRs(undefined), []);
+});
+
+test('latestDashboardCheckRun picks the highest id and ignores other names', () => {
+  assert.equal(latestDashboardCheckRun([]), null);
+  assert.equal(latestDashboardCheckRun([run('success', 'completed', 1, 'lint')]), null);
+  const latest = latestDashboardCheckRun([
+    run('failure', 'completed', 1),
+    run('success', 'completed', 3),
+    run('failure', 'completed', 2),
+  ]);
+  assert.equal(latest.id, 3);
+  assert.equal(latest.conclusion, 'success');
+});
+
+test('sourcePRDashboardProblem: absence blocks', () => {
+  const problem = sourcePRDashboardProblem({ pr: releasePR(2360), checkRuns: [] });
+  assert.match(problem, /never posted a "dashboard" check-run/);
+  assert.match(problem, /#2361/);
+});
+
+test('sourcePRDashboardProblem: still-running blocks', () => {
+  const problem = sourcePRDashboardProblem({
+    pr: releasePR(2360),
+    checkRuns: [run(null, 'in_progress')],
+  });
+  assert.match(problem, /is still in_progress/);
+});
+
+test('sourcePRDashboardProblem: the exact #2361 incident shape (own head commit red) blocks', () => {
+  const problem = sourcePRDashboardProblem({
+    pr: releasePR(2360),
+    checkRuns: [run('failure')],
+  });
+  assert.match(problem, /concluded failure/);
+  assert.match(problem, /native auto-merge does not wait on it/);
+});
+
+test('sourcePRDashboardProblem: a completed success does not block', () => {
+  assert.equal(sourcePRDashboardProblem({ pr: releasePR(2360), checkRuns: [run('success')] }), null);
+});
+
+test('sourcePRDashboardProblem: skipped is not treated as green on a release PR', () => {
+  const problem = sourcePRDashboardProblem({ pr: releasePR(2360), checkRuns: [run('skipped')] });
+  assert.match(problem, /concluded skipped/);
+});
+
+test('sourcePRDashboardProblem: a re-run supersedes an earlier failure by id', () => {
+  const problem = sourcePRDashboardProblem({
+    pr: releasePR(2360),
+    checkRuns: [run('failure', 'completed', 1), run('success', 'completed', 2)],
+  });
+  assert.equal(problem, null, 'the later, higher-id success must win: ' + problem);
+});
+
+test('evaluateSourcePRs: no associated release-staging PR is a clean no-op', () => {
+  const r = evaluateSourcePRs({ pulls: [ordinaryPR(1)], checkRunsByPR: new Map() });
+  assert.deepEqual(r, { problems: [], checked: 0 });
+});
+
+test('evaluateSourcePRs: the #2361 shape — one release-staging PR, its own dashboard run is FAILURE', () => {
+  const r = evaluateSourcePRs({
+    pulls: [releasePR(2360)],
+    checkRunsByPR: new Map([[2360, [run('failure')]]]),
+  });
+  assert.equal(r.checked, 1);
+  assert.equal(r.problems.length, 1);
+  assert.match(r.problems[0], /PR #2360/);
+});
+
+test('evaluateSourcePRs: a green release-staging PR passes', () => {
+  const r = evaluateSourcePRs({
+    pulls: [releasePR(2360)],
+    checkRunsByPR: new Map([[2360, [run('success')]]]),
+  });
+  assert.deepEqual(r, { problems: [], checked: 1 });
+});
+
+test('evaluateSourcePRs: an ordinary PR sharing the association list is never checked', () => {
+  const r = evaluateSourcePRs({
+    pulls: [releasePR(2360), ordinaryPR(9)],
+    checkRunsByPR: new Map([
+      [2360, [run('success')]],
+      [9, []], // would be an absence-failure if this PR were (wrongly) checked
+    ]),
+  });
+  assert.deepEqual(r, { problems: [], checked: 1 });
+});
+
+test('evaluateSourcePRs: multiple release-staging PRs are each checked independently', () => {
+  const r = evaluateSourcePRs({
+    pulls: [releasePR(1, 'release/1.15.x-a', 'sha-a'), releasePR(2, 'release/1.15.x-b', 'sha-b')],
+    checkRunsByPR: new Map([
+      [1, [run('success')]],
+      [2, [run('failure')]],
+    ]),
+  });
+  assert.equal(r.checked, 2);
+  assert.equal(r.problems.length, 1);
+  assert.match(r.problems[0], /PR #2/);
+});
+
+// --- network helpers: auth header + pagination, mocked fetch ---------------
+
+test('associatedPulls sends the bearer token and returns the parsed array', async () => {
+  let seenUrl = null;
+  let seenAuth = null;
+  const pulls = await associatedPulls({
+    apiBase: 'https://api.invalid',
+    repo: 'tsouza/cerberus',
+    sha: 'deadbeef',
+    headers: { Authorization: 'Bearer test-token' },
+    fetchImpl: async (url, options) => {
+      seenUrl = url;
+      seenAuth = options.headers.Authorization;
+      return { ok: true, json: async () => [releasePR(2360)] };
+    },
+  });
+  assert.equal(seenAuth, 'Bearer test-token');
+  assert.match(seenUrl, /\/repos\/tsouza\/cerberus\/commits\/deadbeef\/pulls/);
+  assert.equal(pulls.length, 1);
+});
+
+test('associatedPulls throws on a non-ok response rather than swallowing it', async () => {
+  await assert.rejects(
+    () =>
+      associatedPulls({
+        apiBase: 'https://api.invalid',
+        repo: 'tsouza/cerberus',
+        sha: 'deadbeef',
+        headers: {},
+        fetchImpl: async () => ({ ok: false, status: 404, statusText: 'Not Found' }),
+      }),
+    /404 Not Found/,
+  );
+});
+
+test('checkRunsForSha paginates until a short page', async () => {
+  let calls = 0;
+  const page1 = Array.from({ length: 100 }, (_, i) => run('success', 'completed', i));
+  const page2 = [run('failure', 'completed', 999)];
+  const runs = await checkRunsForSha({
+    apiBase: 'https://api.invalid',
+    repo: 'tsouza/cerberus',
+    sha: 'aaaa1111',
+    headers: {},
+    fetchImpl: async (url) => {
+      calls += 1;
+      const page = new URL(url).searchParams.get('page');
+      return { ok: true, json: async () => ({ check_runs: page === '1' ? page1 : page2 }) };
+    },
+  });
+  assert.equal(calls, 2, 'a full 100-item page must trigger a second fetch');
+  assert.equal(runs.length, 101);
+});

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -465,6 +465,18 @@ jobs:
       - name: release-preflight self-test (required-set guard)
         run: node --test .github/scripts/release-preflight.test.mjs
 
+      # tsouza/cerberus#2361's fix: release.yml's preflight re-reads the
+      # release-staging PR's OWN `dashboard` check-run (the only run that ever
+      # exercises the k3d crawl leg for a release commit) instead of trusting
+      # the push-triggered run's smoke-only proxy. Same reasoning as the
+      # preflight suite above — this only ever executes for real while a
+      # release is being cut, so its pure decision logic (the exact #2361
+      # incident shape: a red dashboard result on the source PR's own head
+      # commit must block; a green one must not; a commit with no associated
+      # release-staging PR is a clean no-op) runs here, on every PR.
+      - name: release-source-pr-dashboard-gate self-test (#2361 guard)
+        run: node --test .github/scripts/release-source-pr-dashboard-gate.test.mjs
+
       # Same reasoning one level out: release-gate-drift.yml is schedule-only, so
       # its detector would otherwise go unexercised between weekly runs. The pure
       # half — the release.yml block-scalar parse and the two drift comparisons —

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -174,6 +174,10 @@ jobs:
       contents: read
       checks: read
       statuses: read
+      # release-source-pr-dashboard-gate.mjs resolves the release-staging PR
+      # associated with this merge commit via GET /commits/{sha}/pulls — see
+      # that job step below.
+      pull-requests: read
     steps:
       - uses: actions/checkout@v7
 
@@ -182,6 +186,12 @@ jobs:
 
       - name: preflight required-set guard
         run: node --test .github/scripts/release-preflight.test.mjs
+
+      - name: release-source-pr-dashboard-gate self-test
+        run: node .github/scripts/release-source-pr-dashboard-gate.mjs --self-test
+
+      - name: release-source-pr-dashboard-gate guard
+        run: node --test .github/scripts/release-source-pr-dashboard-gate.test.mjs
 
       - name: Verify every required lane ran and the commit is fully green
         env:
@@ -295,6 +305,31 @@ jobs:
         # (the line is EOL, gets no hotfixes). See docs/operations.md "Release
         # support window / EOL policy".
         run: node .github/scripts/release-preflight.mjs
+
+      # tsouza/cerberus#2361: `dashboard`'s crawl leg (the ~50min k3d Grafana
+      # BFS) is dispatched by dashboard-matrix.mjs's INCLUDE_CRAWL only for a
+      # `release/*`-headed pull_request, schedule, or manual dispatch — never
+      # for a push. So the RELEASE_REQUIRED_CHECKS read above, which reads the
+      # push-triggered `dashboard` check-run on THIS commit, is a smoke-only
+      # verdict with zero crawl-coverage evidence — even when `dashboard` is
+      # not itself a native branch-protection required context on `main`
+      # (a deliberate trade; see e2e.yml's header and docs/operations.md's
+      # "Two-tier test fence"), so GitHub's auto-merge never waited for it
+      # either. #2360 merged to `main` with its own `dashboard` / crawl result
+      # FAILURE and nothing before this step would have refused it.
+      #
+      # This step resolves the release-staging PR associated with this exact
+      # merge commit and re-reads THAT PR's own `dashboard` check-run — the
+      # one run that ever actually exercised the crawl leg — instead of
+      # trusting the push run's smoke-only proxy. A commit with no associated
+      # `release/*`-headed PR (an ordinary merge, or a maintenance-line hotfix
+      # pushed with no PR at all) is a clean no-op: nothing extra to
+      # re-validate, and the RELEASE_REQUIRED_CHECKS read above already covers
+      # whatever ran on it.
+      - name: Re-validate the release-staging PR's own dashboard/crawl result
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: node .github/scripts/release-source-pr-dashboard-gate.mjs
 
   # App release — binary archives + multi-arch images (GHCR + Docker Hub) +
   # SLSA provenance. Runs ONLY when the app gate says appVersion is new.

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -1441,9 +1441,15 @@ a raw tag is pushed (release-please-style). The flow:
    included) does its real work instead of short-circuiting to a no-op, so a
    release PR's green status reflects the *complete* matrix.
 3. **Merge when green.** The maintainer merges once every required check is
-   green on a tree up to date with main. That merge-when-green gate is the only
-   thing standing between a release PR and publication — the commit on main is
-   releasable by construction (its checks ran against the exact merged tree).
+   green on a tree up to date with main. That merge-when-green gate covers
+   only the checks that are native branch-protection required contexts;
+   `compose-smoke` / `dashboard` / `profile` are deliberately not among them
+   (see "Two-tier test fence" above), so GitHub's native auto-merge does not
+   wait for them — a release PR can auto-merge while one of them is still red.
+   `preflight` (below) is what catches that: it re-reads the release-staging
+   PR's own `dashboard` check-run — the one CI run that ever exercises the
+   k3d Grafana crawl against a release commit — directly from the source PR,
+   rather than trusting the weaker push-triggered proxy (tsouza/cerberus#2361).
 4. **`release.yml` publishes on the push to main.** It runs two per-line
    version gates:
    - **app** (`release-version-gate.mjs`): is Chart.yaml `appVersion` newer
@@ -1474,7 +1480,15 @@ Each edge is a gate, not a sequence:
   `migration-e2e` (Layer 14) — are not. So the preflight carries its own
   **expected set** (`RELEASE_REQUIRED_CHECKS`) and refuses to publish when a
   required lane posted *no* check-run on the commit. A lane that did not run has
-  not passed.
+  not passed. It also re-validates `dashboard` a second, more specific way:
+  `dashboard`'s crawl leg never runs on a push (only on a `release/*`-headed
+  PR, schedule, or dispatch), so the push-triggered check-run this step
+  otherwise reads is a smoke-only proxy with no crawl-coverage evidence for
+  the exact commit being published. `release-source-pr-dashboard-gate.mjs`
+  resolves the release-staging PR GitHub associates with the merge commit and
+  re-reads *that* PR's own `dashboard` check-run instead — closing the gap
+  that let PR #2360 auto-merge to main with a red crawl result
+  (tsouza/cerberus#2361).
 - **`goreleaser`** builds and uploads, but leaves the GitHub release a **draft**.
 - **`release-artifact-migration`** re-runs the migration lane
   (`uses: ./.github/workflows/migration-e2e.yml`) against the image that was just


### PR DESCRIPTION
## Summary

Closes #2361. PR #2360 (a release-staging PR) auto-merged to `main` while its
own `dashboard` / crawl check was `FAILURE`, because `dashboard` is
release-required (`RELEASE_REQUIRED_CHECKS`) but not a native
branch-protection required context on `main` — GitHub's native auto-merge only
waits on branch-protection contexts, so it never waited for `dashboard`.

## Which fix shape, and why

The issue's first suggested direction — add `dashboard` to `main`'s native
branch-protection required contexts, so auto-merge structurally can't outrun
it — was investigated first, as instructed, by reading `e2e.yml`'s
`dashboard-setup` / `dashboard` aggregator and `dashboard-matrix.mjs` closely.

`dashboard-setup`'s `if:` already skips the whole k3d lane on any ordinary
(non-`release/*`) PR, and the `dashboard` aggregator (`if: always()`) already
resolves that to a fast `success` in seconds — so, contrary to the concern
in the dispatch, making it required would **not** force every ordinary PR to
pay the ~50min crawl cost.

What actually rules Option 1 out is a different, harder constraint I found
while checking `main` for a merge queue: `test/regression/merge_queue_test.go`
(`TestEveryRequiredContextPostsOnTheMergeGroup`) asserts that **every**
branch-protection-required context must be posted by a job carrying a
`merge_group:` trigger, or a future merge queue stalls silently waiting for a
check-run that never arrives. `e2e.yml` (and `perf-profile.yml`, which shares
the identical short-circuit shape) declare no `merge_group:` trigger, and
teaching `dashboard-setup`'s `if:` to treat `merge_group` the same as an
ordinary PR isn't structurally available today — `github.head_ref` (the signal
`INCLUDE_CRAWL` keys off) doesn't exist on a `merge_group` event, so
detecting "is the queued PR release-staging" needs its own design. No merge
queue is active on this repo today (confirmed via `gh api
.../rulesets` and the branch protection response), but the regression test is
active and would go red regardless, and — more importantly — it would leave a
landmine: the moment a queue is ever enabled, `dashboard`/`profile` would
silently switch from "always a fast no-op off `main`" to "full smoke matrix on
every queue batch." That's a real, avoidable regression this PR does not want
to introduce as a side effect. It would also blur `docs/operations.md`'s
carefully documented, test-pinned "Two-tier test fence" (merge gate vs.
release gate) split.

So this PR implements the issue's **third** suggested direction instead:
`release.yml`'s `preflight` job now resolves the release-staging PR GitHub
associates with the merge commit (`GET /commits/{sha}/pulls`, filtered to a
`release/`-headed `head.ref`) and re-reads **that PR's own** `dashboard`
check-run directly — the one CI run that ever actually exercises the k3d crawl
leg — instead of trusting the existing `RELEASE_REQUIRED_CHECKS` read of the
push-triggered run, which is provably a smoke-only proxy:
`dashboard-matrix.mjs`'s `INCLUDE_CRAWL` never fires on a `push`, only on a
`release/*`-headed `pull_request`, `schedule`, or manual dispatch.

This closes the actual gap the task's acceptance criteria named as
sufficient: "failing preflight before it publishes/tags" is one of the three
explicitly acceptable mechanisms. A release-staging PR with a red
`dashboard` result can still merge to `main` (native auto-merge is
unaffected), but it can no longer **publish** — the exact incident shape (a
red `dashboard` on the source PR's own head commit) now fails
`release-source-pr-dashboard-gate.mjs` and blocks `goreleaser` /
`chart-release`.

## What's new

- `.github/scripts/release-source-pr-dashboard-gate.mjs` — pure decision logic
  (`isReleaseStagingPR`, `releaseStagingSourcePRs`, `latestDashboardCheckRun`,
  `sourcePRDashboardProblem`, `evaluateSourcePRs`) + a thin network driver, a
  `--self-test`, following `release-preflight.mjs` / `release-gate-drift.mjs`'s
  house style. Absence (no `dashboard` check-run at all on the source PR's own
  head commit) blocks the same as a red one — same posture as the existing
  preflight.
- `.github/scripts/release-source-pr-dashboard-gate.test.mjs` — `node --test`
  companion (18 cases), wired into `ci.yml`'s required `lint` lane so the pure
  logic is verified on every PR (`release.yml` has no `pull_request:` trigger).
- `release.yml`: new `preflight` step running the gate after the existing
  `RELEASE_REQUIRED_CHECKS` check; `pull-requests: read` added to the job's
  permissions for the commit→PR association lookup.
- `docs/operations.md` / `.github/scripts/README.md`: documented the new gate
  and the auto-merge caveat in the release pipeline walkthrough.

## Verification

- `node .github/scripts/release-source-pr-dashboard-gate.mjs --self-test` and
  `node --test .github/scripts/release-source-pr-dashboard-gate.test.mjs` —
  both green locally (18/18 tests, including the exact #2361 incident shape).
- `go test ./test/regression/...` — green, including the release-gate pins
  (`release_gate_test.go`, `release_required_checks_test.go`,
  `merge_queue_test.go`, `ci_lane_registry_test.go`) unaffected by this change
  (branch protection / required-context lists are untouched).
- `actionlint` on `ci.yml` + `release.yml` — clean.
- `markdownlint-cli2` on the two touched docs — clean.
- Did **not** touch live branch protection on `main` — verified but did not
  change it, per the caution in the dispatch about that being a hard-to-reverse
  repo-wide setting.

## Test plan

- [ ] CI green on this PR (`lint` runs the new `node --test` guard).
- [ ] `dashboard` / e2e lanes can't be verified locally (~50min, needs
      k3d) — not exercised by this change's own logic path since it only adds
      a `preflight`-time re-read; will watch the actual `release.yml` behavior
      on the next real release-staging PR.

Closes #2361
