### PR TITLE
ci(e2e): notify on a nightly that does not reach a clean pass (#1861)

### DIFF
--- a/.github/ci-lanes.json
+++ b/.github/ci-lanes.json
@@ -975,6 +975,53 @@
       "accountable_owner": "system-quality"
     },
     {
+      "id": "e2e.nightly-health-notify",
+      "description": "Roll up the nightly's terminal jobs and file/refresh a tracking issue on any non-success (#1861).",
+      "owner": {
+        "workflow": ".github/workflows/e2e.yml",
+        "jobs": [
+          "nightly-health-notify"
+        ],
+        "producer_jobs": [],
+        "context_job": "nightly-health-notify"
+      },
+      "executions": [
+        "default"
+      ],
+      "context": {
+        "match": "exact",
+        "name": "nightly-health-notify",
+        "protected": false
+      },
+      "purpose": "quality",
+      "layers": [
+        "13",
+        "14"
+      ],
+      "oracle_class": "notification",
+      "recipes": [],
+      "command": "node .github/scripts/notify-nightly-failure.mjs",
+      "build_tags": [],
+      "package_globs": [
+        "test/e2e/**"
+      ],
+      "substrate": "github-api",
+      "risk_domains": [
+        "observability"
+      ],
+      "merge_posture": "never",
+      "main_posture": "never",
+      "release_posture": "advisory",
+      "determinism": "deterministic",
+      "applicability": {
+        "source": false,
+        "artifact": false
+      },
+      "timeout_minutes": 5,
+      "slo_minutes": 5,
+      "accountable_owner": "system-quality"
+    },
+    {
       "id": "e2e.chaos",
       "description": "Live k3d fault injection over the gateway and its dependencies.",
       "owner": {

--- a/.github/ci-lanes.json
+++ b/.github/ci-lanes.json
@@ -975,53 +975,6 @@
       "accountable_owner": "system-quality"
     },
     {
-      "id": "e2e.nightly-health-notify",
-      "description": "Roll up the nightly's terminal jobs and file/refresh a tracking issue on any non-success (#1861).",
-      "owner": {
-        "workflow": ".github/workflows/e2e.yml",
-        "jobs": [
-          "nightly-health-notify"
-        ],
-        "producer_jobs": [],
-        "context_job": "nightly-health-notify"
-      },
-      "executions": [
-        "default"
-      ],
-      "context": {
-        "match": "exact",
-        "name": "nightly-health-notify",
-        "protected": false
-      },
-      "purpose": "quality",
-      "layers": [
-        "13",
-        "14"
-      ],
-      "oracle_class": "notification",
-      "recipes": [],
-      "command": "node .github/scripts/notify-nightly-failure.mjs",
-      "build_tags": [],
-      "package_globs": [
-        "test/e2e/**"
-      ],
-      "substrate": "github-api",
-      "risk_domains": [
-        "observability"
-      ],
-      "merge_posture": "never",
-      "main_posture": "never",
-      "release_posture": "advisory",
-      "determinism": "deterministic",
-      "applicability": {
-        "source": false,
-        "artifact": false
-      },
-      "timeout_minutes": 5,
-      "slo_minutes": 5,
-      "accountable_owner": "system-quality"
-    },
-    {
       "id": "e2e.chaos",
       "description": "Live k3d fault injection over the gateway and its dependencies.",
       "owner": {
@@ -1233,6 +1186,35 @@
       "applicability": { "source": true, "artifact": false },
       "timeout_minutes": 120,
       "slo_minutes": 120,
+      "accountable_owner": "system-quality"
+    },
+    {
+      "id": "e2e.nightly-health-notify",
+      "description": "Roll up the nightly's terminal jobs and file/refresh a tracking issue on any non-success (#1861).",
+      "owner": {
+        "workflow": ".github/workflows/e2e.yml",
+        "jobs": ["nightly-health-notify"],
+        "producer_jobs": [],
+        "context_job": "nightly-health-notify"
+      },
+      "executions": ["default"],
+      "context": { "match": "exact", "name": "nightly-health-notify", "protected": false },
+      "purpose": "quality",
+      "layers": ["13", "14"],
+      "oracle_class": "monitor",
+      "recipes": [],
+      "command": "node .github/scripts/notify-nightly-failure.mjs",
+      "build_tags": [],
+      "package_globs": ["test/e2e/**"],
+      "substrate": "github-api",
+      "risk_domains": ["observability"],
+      "merge_posture": "never",
+      "main_posture": "never",
+      "release_posture": "advisory",
+      "determinism": "deterministic",
+      "applicability": { "source": true, "artifact": false },
+      "timeout_minutes": 5,
+      "slo_minutes": 5,
       "accountable_owner": "system-quality"
     },
     {

--- a/.github/scripts/README.md
+++ b/.github/scripts/README.md
@@ -1523,6 +1523,32 @@ what actually runs.
   - Exit: `0` clean / matrix emitted, `1` on any coverage violation or bad
     `MODE`.
 
+- **`notify-nightly-failure.mjs`** — `e2e.yml`, the `nightly-health-notify`
+  job (`schedule` trigger only). Reaching a real terminal `failure` instead of
+  `cancelled` (the job above) is not the same as anyone SEEING that failure —
+  the nightly trigger has no PR, no reviewer, nothing watching it by default,
+  and a real nightly `failure` ran FOUR consecutive nights before anyone
+  noticed, by accident (#1861's reopening comment). This rolls every terminal
+  job the nightly produces (`compose-smoke`, `crawl-terminal`, `dashboard`,
+  `dashboard-crawl-terminal`, `startup-bench`, `chaos`, `bwc-minio`) up with
+  the same strict `!== 'success'` rule the aggregators use, and files (or
+  comments on) a single tracking issue — matched by an exact, stable title so
+  consecutive bad nights update the same issue instead of piling up
+  duplicates — labelled `automated` + `area/ci` (both pre-existing labels; no
+  new label to provision). A clean night with a tracking issue still open
+  closes it, so a stale issue can't be mistaken for a live incident.
+  `notify-nightly-failure.test.mjs` is the `node --test` guard (run on
+  `ci.yml`'s scripts lane, even though the job itself only runs on
+  `schedule`) — the roll-up/dedup logic is pure and unit-tested; a few
+  regex-over-source cases additionally pin the job's `needs:` list and its
+  `if: … && github.event_name == 'schedule'` guard, mirroring
+  `crawl-frontier-workflow.test.mjs`.
+  - Env: `REPO`, `RUN_ID`, `RUN_URL`, and one `RESULT_*` var per terminal job
+    (`needs.<job>.result`).
+  - Exit: `0` on a clean night (whether or not it closed a stale tracking
+    issue), `1` when any job was not a clean `success`, or when a `gh` call
+    itself fails.
+
 - **`perf-guards-aggregate.mjs`** — `chdb.yml`, the `perf-guards` job. Rolls the
   sharded `perf-guards-shard` matrix up into the single status check branch
   protection and `release.yml`'s `RELEASE_REQUIRED_CHECKS` both resolve by exact

--- a/.github/scripts/notify-nightly-failure.mjs
+++ b/.github/scripts/notify-nightly-failure.mjs
@@ -1,0 +1,240 @@
+// notify-nightly-failure.mjs — file (or refresh) a single tracking issue when
+// the nightly `e2e` schedule run does not reach a clean pass, and close it
+// automatically on the next clean night.
+//
+// Why this exists
+// ---------------
+// #1861 named two failures. The first — the nightly `shard-crawl` job being
+// KILLED (`cancelled`) instead of reaching a real verdict — is fixed:
+// crawl-terminal / dashboard-crawl-terminal (assert-crawl-terminal.mjs) now
+// fail the run loudly on anything but `success`/`failure`, and real nightly
+// runs since have reached `failure`, a genuine terminal result.
+//
+// That fix uncovered the second failure the issue's own acceptance text asked
+// for and a first pass at this issue did not deliver: a `failure` that
+// reports into a place nobody looks is exactly as silent as a `cancelled`
+// that reports nowhere. The nightly `schedule` trigger has no PR, no
+// reviewer, no default notification path — `e2e.yml`'s two exhaustive lanes
+// are release gates, not PR gates (see the file header), so nothing reads a
+// nightly run's result unless a human goes looking. The nightly ran
+// `failure` for FOUR consecutive nights (2026-08-15 .. 2026-08-18) before
+// anyone noticed, and it was noticed by accident — a release-staging PR
+// happened to be the first `release/*` PR since the regression, and that
+// lane's own required check is what surfaced it (see #1861's reopening
+// comment).
+//
+// What this does
+// ---------------
+// Runs as the last job of a `schedule`-triggered e2e.yml run, downstream of
+// every terminal aggregator/leaf job the lane has. Rolls their `needs.*.result`
+// facts up with the same strict `!== 'success'` rule the aggregators
+// themselves use (catches `failure` AND `cancelled` AND an unexpected
+// `skipped` in one comparison — see perf-guards-aggregate.mjs / dashboard's
+// own gate step for the same rule applied one level up):
+//
+//   - not all clean -> open or update the ONE nightly-health tracking issue
+//     (matched by an exact, stable title so consecutive bad nights update the
+//     same issue instead of piling up duplicates) and exit 1, so the job
+//     itself is loud too.
+//   - all clean, and a tracking issue is open -> comment + close it. A
+//     tracking issue nobody ever closes is its own kind of noise: the next
+//     person to look would not be able to tell a live incident from a stale
+//     one.
+//   - all clean, no tracking issue -> nothing to do.
+//
+// Uses the existing `automated` + `area/ci` labels (both already exist in the
+// repo) rather than a new label, so there is no separate label-provisioning
+// step that could itself go stale.
+//
+// Env:
+//   REPO                        `owner/repo` (github.repository).
+//   RUN_ID / RUN_URL            identify the run in the issue body.
+//   RESULT_COMPOSE_SMOKE, RESULT_CRAWL_TERMINAL, RESULT_DASHBOARD,
+//   RESULT_DASHBOARD_CRAWL_TERMINAL, RESULT_STARTUP_BENCH, RESULT_CHAOS,
+//   RESULT_BWC_MINIO            `needs.<job>.result` for every terminal job
+//                                the nightly run fans out to (e2e.yml's job
+//                                graph — see the `nightly-health-notify` job).
+//
+// Exit: 0 when the nightly reached a clean pass (whether or not a stale
+// tracking issue needed closing); 1 when it did not, or when the gh calls
+// themselves fail.
+//
+// node: builtins only (via lib/gh.mjs) + the `gh` CLI already authenticated
+// by the workflow's GH_TOKEN.
+
+import process from 'node:process';
+import { capture, error, notice } from './lib/gh.mjs';
+
+/** The one label pair used to find (and file) the tracking issue. Both
+ * already exist as repo labels; `gh issue list --label` ANDs multiple
+ * `--label` flags, so this narrows to issues carrying BOTH. */
+export const NIGHTLY_TRACKING_LABELS = ['automated', 'area/ci'];
+
+/** Exact, stable title — the dedup key. Never interpolate the run id or date
+ * into it: doing so would make every bad night open a NEW issue instead of
+ * refreshing the one that already tracks the incident. */
+export const NIGHTLY_TRACKING_TITLE = 'nightly e2e run did not reach a clean pass';
+
+/**
+ * Pure roll-up over the terminal job results a schedule run produces.
+ * Mirrors the aggregators' own rule: anything other than `success` — a real
+ * `failure`, a `cancelled` kill, or an unexpected `skipped` — counts against
+ * a clean night. Every job named here is unconditional on `schedule` (see
+ * each job's own `if:` in e2e.yml), so `skipped` is never the benign case it
+ * would be on another trigger.
+ */
+export function classifyNightlyHealth(jobResults) {
+  const failed = Object.entries(jobResults)
+    .filter(([, result]) => result !== 'success')
+    .map(([name, result]) => `${name}: ${result || '(missing)'}`);
+  return { ok: failed.length === 0, failed };
+}
+
+/** Find the open tracking issue, if any, by its exact stable title. Pure so
+ * the dedup logic is tested without a `gh` round-trip. */
+export function findTrackingIssue(issues, title) {
+  const match = (issues || []).find((issue) => issue.title === title);
+  return match ? match.number : null;
+}
+
+/**
+ * Pure decision over (current health) x (an existing tracking issue or not).
+ * Four cells, all named explicitly rather than derived, so a guard test can
+ * drive every one directly.
+ */
+export function decideNotifyAction({ ok, existingIssueNumber }) {
+  const hasExisting = existingIssueNumber !== null && existingIssueNumber !== undefined;
+  if (!ok) {
+    return hasExisting ? { action: 'comment', number: existingIssueNumber } : { action: 'create' };
+  }
+  return hasExisting ? { action: 'close', number: existingIssueNumber } : { action: 'noop' };
+}
+
+export function buildFailureBody({ failed, runUrl, runId }) {
+  const list = failed.map((f) => `- \`${f}\``).join('\n');
+  return [
+    'The nightly `e2e` schedule run did not reach a clean pass.',
+    '',
+    `Run: ${runUrl} (id ${runId})`,
+    '',
+    'Non-success jobs (anything but `success` — a real failure, a `cancelled`',
+    'kill, or an unexpected `skipped`):',
+    list,
+    '',
+    'Filed/updated automatically by `.github/scripts/notify-nightly-failure.mjs`' +
+      ' — see tsouza/cerberus#1861 for why this exists: a nightly that reports' +
+      ' red into a place nobody looks is as silent as one that never reports at' +
+      ' all. This issue closes itself on the next clean nightly.',
+  ].join('\n');
+}
+
+export function buildRecoveryBody({ runUrl, runId }) {
+  return [
+    'The nightly `e2e` schedule run reached a clean pass.',
+    '',
+    `Run: ${runUrl} (id ${runId})`,
+    '',
+    'Closing automatically — see `.github/scripts/notify-nightly-failure.mjs`.',
+  ].join('\n');
+}
+
+function readJobResults(env) {
+  return {
+    'compose-smoke': env.RESULT_COMPOSE_SMOKE ?? '',
+    'crawl-terminal': env.RESULT_CRAWL_TERMINAL ?? '',
+    dashboard: env.RESULT_DASHBOARD ?? '',
+    'dashboard-crawl-terminal': env.RESULT_DASHBOARD_CRAWL_TERMINAL ?? '',
+    'startup-bench': env.RESULT_STARTUP_BENCH ?? '',
+    chaos: env.RESULT_CHAOS ?? '',
+    'bwc-minio': env.RESULT_BWC_MINIO ?? '',
+  };
+}
+
+function ghOrDie(args, failMessage) {
+  const res = capture('gh', args);
+  if (res.status !== 0) {
+    error(`${failMessage}: ${res.stderr.trim() || res.stdout.trim()}`, { title: 'nightly-health-notify' });
+    process.exit(1);
+  }
+  return res.stdout;
+}
+
+function main() {
+  const repo = process.env.REPO ?? '';
+  const runId = process.env.RUN_ID ?? '';
+  const runUrl = process.env.RUN_URL ?? '';
+  const jobResults = readJobResults(process.env);
+
+  const health = classifyNightlyHealth(jobResults);
+
+  const labelArgs = NIGHTLY_TRACKING_LABELS.flatMap((l) => ['--label', l]);
+  const listOut = ghOrDie(
+    ['issue', 'list', '--repo', repo, '--state', 'open', ...labelArgs, '--json', 'number,title', '--limit', '30'],
+    'gh issue list failed',
+  );
+  let issues;
+  try {
+    issues = JSON.parse(listOut);
+  } catch (err) {
+    error(`gh issue list returned unparsable JSON: ${err.message}`, { title: 'nightly-health-notify' });
+    process.exit(1);
+  }
+  const existingIssueNumber = findTrackingIssue(issues, NIGHTLY_TRACKING_TITLE);
+  const decision = decideNotifyAction({ ok: health.ok, existingIssueNumber });
+
+  switch (decision.action) {
+    case 'create': {
+      const body = buildFailureBody({ failed: health.failed, runUrl, runId });
+      const out = ghOrDie(
+        [
+          'issue',
+          'create',
+          '--repo',
+          repo,
+          '--title',
+          NIGHTLY_TRACKING_TITLE,
+          '--body',
+          body,
+          ...labelArgs,
+        ],
+        'gh issue create failed',
+      );
+      error(`nightly e2e run did not reach a clean pass (${health.failed.join('; ')}); filed ${out.trim()}`, {
+        title: 'nightly e2e run failed',
+      });
+      process.exit(1);
+      break;
+    }
+    case 'comment': {
+      const body = buildFailureBody({ failed: health.failed, runUrl, runId });
+      ghOrDie(
+        ['issue', 'comment', String(decision.number), '--repo', repo, '--body', body],
+        'gh issue comment failed',
+      );
+      error(
+        `nightly e2e run did not reach a clean pass (${health.failed.join('; ')}); updated #${decision.number}`,
+        { title: 'nightly e2e run failed' },
+      );
+      process.exit(1);
+      break;
+    }
+    case 'close': {
+      const body = buildRecoveryBody({ runUrl, runId });
+      ghOrDie(
+        ['issue', 'close', String(decision.number), '--repo', repo, '--comment', body],
+        'gh issue close failed',
+      );
+      notice(`nightly e2e run reached a clean pass; closed tracking issue #${decision.number}.`);
+      break;
+    }
+    case 'noop':
+    default:
+      notice('nightly e2e run reached a clean pass; no tracking issue open.');
+      break;
+  }
+}
+
+// Only dispatch when run as a script — importing for the unit test must not
+// exit the test runner or shell out to `gh`.
+const invokedDirectly = process.argv[1] && import.meta.url === new URL(`file://${process.argv[1]}`).href;
+if (invokedDirectly) main();

--- a/.github/scripts/notify-nightly-failure.test.mjs
+++ b/.github/scripts/notify-nightly-failure.test.mjs
@@ -1,0 +1,149 @@
+// notify-nightly-failure.test.mjs — node:test guard for the nightly-health
+// tracking-issue roll-up (#1861 acceptance criterion #2: a future
+// cancellation, or any other non-success nightly, must be VISIBLE, not just
+// a red job nobody watches).
+//
+// Pins both directions: the benign cells (clean night, no stale issue left
+// open) must stay quiet, and every not-clean cell must actually notify —
+// a test file that only asserted the happy path would be satisfied by
+// `() => ({ ok: true })`.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+import {
+  classifyNightlyHealth,
+  findTrackingIssue,
+  decideNotifyAction,
+  buildFailureBody,
+  buildRecoveryBody,
+  NIGHTLY_TRACKING_TITLE,
+} from './notify-nightly-failure.mjs';
+
+const allGreen = {
+  'compose-smoke': 'success',
+  'crawl-terminal': 'success',
+  dashboard: 'success',
+  'dashboard-crawl-terminal': 'success',
+  'startup-bench': 'success',
+  chaos: 'success',
+  'bwc-minio': 'success',
+};
+
+test('every job success is a clean night', () => {
+  const v = classifyNightlyHealth(allGreen);
+  assert.equal(v.ok, true);
+  assert.deepEqual(v.failed, []);
+});
+
+test('a real failure is caught', () => {
+  const v = classifyNightlyHealth({ ...allGreen, dashboard: 'failure' });
+  assert.equal(v.ok, false);
+  assert.deepEqual(v.failed, ['dashboard: failure']);
+});
+
+test('a cancellation is caught exactly like a failure — the #1861 regression shape', () => {
+  const v = classifyNightlyHealth({ ...allGreen, 'crawl-terminal': 'cancelled' });
+  assert.equal(v.ok, false);
+  assert.deepEqual(v.failed, ['crawl-terminal: cancelled']);
+});
+
+test('an unexpected skip on a schedule run is caught, not laundered as benign', () => {
+  const v = classifyNightlyHealth({ ...allGreen, chaos: 'skipped' });
+  assert.equal(v.ok, false);
+  assert.deepEqual(v.failed, ['chaos: skipped']);
+});
+
+test('a missing/empty result reads as a failure, not a silent pass', () => {
+  const v = classifyNightlyHealth({ ...allGreen, 'bwc-minio': '' });
+  assert.equal(v.ok, false);
+  assert.match(v.failed[0], /bwc-minio: \(missing\)/);
+});
+
+test('multiple simultaneous non-successes are all named', () => {
+  const v = classifyNightlyHealth({ ...allGreen, dashboard: 'failure', chaos: 'cancelled' });
+  assert.equal(v.ok, false);
+  assert.equal(v.failed.length, 2);
+});
+
+test('findTrackingIssue matches the exact stable title only', () => {
+  const issues = [
+    { number: 42, title: 'some unrelated issue' },
+    { number: 99, title: NIGHTLY_TRACKING_TITLE },
+  ];
+  assert.equal(findTrackingIssue(issues, NIGHTLY_TRACKING_TITLE), 99);
+});
+
+test('findTrackingIssue returns null when nothing matches', () => {
+  assert.equal(findTrackingIssue([{ number: 1, title: 'unrelated' }], NIGHTLY_TRACKING_TITLE), null);
+  assert.equal(findTrackingIssue([], NIGHTLY_TRACKING_TITLE), null);
+  assert.equal(findTrackingIssue(undefined, NIGHTLY_TRACKING_TITLE), null);
+});
+
+test('decideNotifyAction: not-ok + no existing issue -> create', () => {
+  const d = decideNotifyAction({ ok: false, existingIssueNumber: null });
+  assert.deepEqual(d, { action: 'create' });
+});
+
+test('decideNotifyAction: not-ok + an existing issue -> comment on it, never a duplicate', () => {
+  const d = decideNotifyAction({ ok: false, existingIssueNumber: 99 });
+  assert.deepEqual(d, { action: 'comment', number: 99 });
+});
+
+test('decideNotifyAction: ok + an existing (now-stale) issue -> close it', () => {
+  const d = decideNotifyAction({ ok: true, existingIssueNumber: 99 });
+  assert.deepEqual(d, { action: 'close', number: 99 });
+});
+
+test('decideNotifyAction: ok + nothing open -> noop', () => {
+  const d = decideNotifyAction({ ok: true, existingIssueNumber: null });
+  assert.deepEqual(d, { action: 'noop' });
+});
+
+test('decideNotifyAction: existingIssueNumber 0 would be falsy but is never a valid issue number', () => {
+  // gh issue numbers are 1-based; this only pins that the check is an
+  // explicit null/undefined test, not a truthiness test that would treat a
+  // (hypothetical, never-real) 0 as "no issue".
+  const d = decideNotifyAction({ ok: false, existingIssueNumber: 0 });
+  assert.deepEqual(d, { action: 'comment', number: 0 });
+});
+
+test('buildFailureBody names every failed job and the run', () => {
+  const body = buildFailureBody({ failed: ['dashboard: failure', 'chaos: cancelled'], runUrl: 'https://x/run/1', runId: '1' });
+  assert.match(body, /dashboard: failure/);
+  assert.match(body, /chaos: cancelled/);
+  assert.match(body, /https:\/\/x\/run\/1/);
+  assert.match(body, /#1861/);
+});
+
+test('buildRecoveryBody names the run and says it closed automatically', () => {
+  const body = buildRecoveryBody({ runUrl: 'https://x/run/2', runId: '2' });
+  assert.match(body, /https:\/\/x\/run\/2/);
+  assert.match(body, /clean pass/);
+});
+
+// Wiring pins, mirroring crawl-frontier-workflow.test.mjs's regex-over-source
+// approach: a job/needs edit that silently drops a leg or widens the trigger
+// off `schedule` compiles fine and passes every unit test above, so the only
+// thing that catches it is pinning the source text directly.
+
+const e2eWorkflow = readFileSync(resolve('.github/workflows/e2e.yml'), 'utf8');
+const ciWorkflow = readFileSync(resolve('.github/workflows/ci.yml'), 'utf8');
+
+test('nightly-health-notify needs every terminal job and runs on schedule only', () => {
+  assert.match(
+    e2eWorkflow,
+    /nightly-health-notify:\n    name: nightly-health-notify\n    needs:\n {6}\[compose-smoke, crawl-terminal, dashboard, dashboard-crawl-terminal, startup-bench, chaos, bwc-minio\]\n {4}if: always\(\) && github\.event_name == 'schedule'/,
+  );
+});
+
+test('nightly-health-notify has issues: write and invokes the script', () => {
+  assert.match(e2eWorkflow, /nightly-health-notify[\s\S]{0,400}issues: write/);
+  assert.match(e2eWorkflow, /run: node \.github\/scripts\/notify-nightly-failure\.mjs/);
+});
+
+test('the self-test runs on the PR path via ci.yml', () => {
+  assert.match(ciWorkflow, /node --test \.github\/scripts\/notify-nightly-failure\.test\.mjs/);
+});

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -752,6 +752,15 @@ jobs:
           node --test .github/scripts/crawl-budget.test.mjs
           node --test .github/scripts/assert-crawl-terminal.test.mjs
 
+      # #1861 acceptance criterion #2: reaching a real terminal result is not
+      # the same as anyone SEEING it — the nightly `schedule` trigger has no
+      # PR, no reviewer, nothing watching it by default. Pure in-process test
+      # over the roll-up + tracking-issue-dedup logic (no `gh` calls
+      # exercised), so it runs on the PR path even though the notify job
+      # itself only ever runs on `schedule`.
+      - name: Assert the nightly-health notifier cannot go silently hollow
+        run: node --test .github/scripts/notify-nightly-failure.test.mjs
+
       # Pins e2e.yml's dashboard-crawl-merge wiring: the required `dashboard`
       # aggregator must depend on it (so a merge failure can gate a release),
       # and the release/dispatch trigger conditions that decide when the

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1795,3 +1795,56 @@ jobs:
       - name: Tear down
         if: always()
         run: just e2e-bwc-down
+
+  # #1861 acceptance criterion #2. Reaching a real terminal `failure` instead
+  # of `cancelled` (crawl-terminal / dashboard-crawl-terminal, above) is not
+  # the same as anyone SEEING that failure: the `schedule` trigger has no PR,
+  # no reviewer, nothing watching it by default — e2e.yml's two exhaustive
+  # lanes are release gates, not PR gates (see the file header). The nightly
+  # ran a genuine `failure` for FOUR consecutive nights (2026-08-15 ..
+  # 2026-08-18) before anyone noticed, and it was noticed by accident: a
+  # release-staging PR happened to be the first `release/*` PR since the
+  # regression, and that PR's own required check is what surfaced it (#1861's
+  # reopening comment). A `failure` reporting into a place nobody looks is as
+  # silent as a `cancelled` reporting nowhere.
+  #
+  # This job is the "somebody looks": on a `schedule` run only, roll every
+  # terminal job this lane produces up with notify-nightly-failure.mjs and
+  # file (or refresh) a single tracking issue when any of them is not a clean
+  # `success` — closing it automatically on the next clean night so it can
+  # never rot into a permanent false alarm. `needs` lists every job whose
+  # result actually matters for "did the nightly pass": the two required
+  # aggregates (`compose-smoke`, `dashboard`), the two crawl-terminality
+  # readers, and the three informational-but-schedule-run leaf jobs. `always()`
+  # so it still runs (and can still notify) when an upstream job failed rather
+  # than being skipped by GitHub's default `success()` gate.
+  nightly-health-notify:
+    name: nightly-health-notify
+    needs:
+      [compose-smoke, crawl-terminal, dashboard, dashboard-crawl-terminal, startup-bench, chaos, bwc-minio]
+    if: always() && github.event_name == 'schedule'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    # Job-level permissions REPLACE the workflow-level block (see
+    # dashboard-crawl-merge's own note) — contents: read has to be restated
+    # for checkout, and issues: write is what lets this file/comment/close the
+    # tracking issue.
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - uses: actions/checkout@v7
+      - name: roll up the nightly's terminal jobs and notify on non-success
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          RUN_ID: ${{ github.run_id }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          RESULT_COMPOSE_SMOKE: ${{ needs.compose-smoke.result }}
+          RESULT_CRAWL_TERMINAL: ${{ needs.crawl-terminal.result }}
+          RESULT_DASHBOARD: ${{ needs.dashboard.result }}
+          RESULT_DASHBOARD_CRAWL_TERMINAL: ${{ needs.dashboard-crawl-terminal.result }}
+          RESULT_STARTUP_BENCH: ${{ needs.startup-bench.result }}
+          RESULT_CHAOS: ${{ needs.chaos.result }}
+          RESULT_BWC_MINIO: ${{ needs.bwc-minio.result }}
+        run: node .github/scripts/notify-nightly-failure.mjs


### PR DESCRIPTION
## Summary

Closes #1861

This is acceptance criterion #2 of that issue, which the issue's own
reopening comment confirms was never really delivered by an earlier pass.

- Adds `nightly-health-notify` to `e2e.yml`: a `schedule`-only job that rolls
  every terminal job the nightly run produces (`compose-smoke`,
  `crawl-terminal`, `dashboard`, `dashboard-crawl-terminal`, `startup-bench`,
  `chaos`, `bwc-minio`) up with the same strict `!== 'success'` rule the
  existing aggregators use, and files (or refreshes) a single GitHub tracking
  issue when any of them is not a clean `success`. The issue is matched by an
  exact, stable title, so consecutive bad nights update the same issue
  instead of piling up duplicates, and it closes itself automatically on the
  next clean night.
- New `.github/scripts/notify-nightly-failure.mjs` (+ `.test.mjs`) does the
  roll-up/dedup logic as pure, unit-tested functions, following the repo's
  aggregator-script house style (`perf-guards-aggregate.mjs`,
  `assert-crawl-terminal.mjs`). Wired into `ci.yml`'s scripts self-test lane
  so the pure logic is checked on every PR even though the job itself only
  ever runs on `schedule`.
- Uses the pre-existing `automated` + `area/ci` labels — no new label to
  provision.

## Investigation (the three things #1861 asked to determine)

**1. Why the job was `cancelled` rather than failing with a real error.**
Already root-caused and fixed on `main` before this PR: the crawl shard's
`timeout-minutes` used to exceed its own concurrency-slot budget, so a hang
was killed by the runner (`cancelled`) instead of the Playwright spec's own
budget timing out first (a real `failure`). `.github/scripts/lib/crawl-budget.mjs`
now derives both from one ordering, and `assert-crawl-terminal.mjs` /
`dashboard-crawl-terminal` assert the crawl reaches `success` or `failure`.

**2. Whether the #1855 body-read bound already fixed this — confirmed by
observation, not inference.** Pulled real nightly `schedule` run history:

```
gh run list --repo tsouza/cerberus --workflow e2e.yml --event schedule --limit 8 \
  --json databaseId,conclusion,createdAt
```

| date | conclusion |
|---|---|
| 2026-08-13, 2026-08-14 | `cancelled` |
| 2026-08-15 → 2026-08-20 (6 consecutive nights, including last night) | `failure` — a genuine terminal result |

So yes: every nightly since 2026-08-15 has reached a real terminal verdict,
never `cancelled`. Acceptance criterion #1 ("a nightly run in which
`shard-crawl` reaches a terminal `success` or `failure`") is met and has been
for six nights running — verified against real run data, not inferred from
the code landing.

**3. Whether a cancelled `shard-crawl` should fail the workflow rather than
being silently tolerated.** Already implemented on `main`
(`assert-crawl-terminal.mjs`, the `crawl-terminal` / `dashboard-crawl-terminal`
jobs): a cancellation, an unexpected skip, or a real failure all fail those
jobs loudly.

**What was still missing, and what this PR adds.** Per #1861's reopening
comment: reaching a real terminal `failure` is not the same as anyone SEEING
it. The `schedule` trigger has no PR, no reviewer, and `e2e.yml`'s two
exhaustive lanes are release gates, not PR gates — nothing reads a nightly's
result by default. The real nightly ran `failure` for four consecutive nights
(2026-08-15 → 2026-08-18) before anyone noticed, and it was only noticed
because a release-staging PR happened to be the first `release/*` PR since
the regression. Pulling fresh data for this PR shows the streak is now **six**
consecutive nights (through 2026-08-20, `compose-smoke: failure` — the
separate 99-pinned-surface crawl-coverage regression #1861's reopening
comment already tracks as in-flight elsewhere), still with zero notification.
`nightly-health-notify` is the "somebody looks" the acceptance text asks for.

## What I verified vs. what I could not

- Unit-tested the roll-up/dedup logic directly: `node --test
  .github/scripts/notify-nightly-failure.test.mjs` (18/18 passing), including
  wiring pins (regex-over-source, mirroring `crawl-frontier-workflow.test.mjs`)
  that catch a future edit silently dropping a leg from `needs:` or widening
  the `if:` off `schedule`.
- `actionlint` clean on both changed workflow files; both parse as valid YAML.
- I did **not** exercise the real `gh issue create`/`comment`/`close` calls
  end-to-end against the live repo — that requires filing/mutating a real
  issue, which needs explicit permission I don't have in an automated
  session. The `gh` CLI flag usage (`--label` repeated for AND-filtering,
  `issue create --label`, `issue close --comment`) is confirmed against `gh
  --help` output, and the script's only side-effecting surface (`capture('gh',
  args)`) is a thin, directly-inspectable wrapper around exactly those calls.
- This PR's own `pull_request` trigger runs `e2e.yml`, but
  `nightly-health-notify` is deliberately gated to `github.event_name ==
  'schedule'` only (matching the issue's own framing — the gap is specifically
  about the unwatched nightly, not about adding another PR-time check), so it
  will not run on this PR and cannot be observed completing here. The first
  real observation will be tonight's scheduled run once this merges to `main`
  (GitHub Actions resolves `schedule` triggers off the default branch's
  workflow file).

## Test plan

- [x] `node --test .github/scripts/notify-nightly-failure.test.mjs` — 18/18
      passing locally.
- [x] `actionlint .github/workflows/e2e.yml .github/workflows/ci.yml` — clean.
- [x] Confirmed via `gh run list`/`gh run view` that every nightly since
      2026-08-15 (6 consecutive nights) reached a real terminal `failure`,
      never `cancelled`.
- [ ] CI on this PR (lint, the new self-test step in `ci.yml`'s scripts lane).
- [ ] First real nightly `schedule` run after merge — the earliest point
      `nightly-health-notify` can be observed running for real.
