### PR TITLE
perf(ci): shard perf-profile.yml's corpus fan-out walk across a matrix

### DIFF
--- a/.github/ci-lanes.json
+++ b/.github/ci-lanes.json
@@ -1483,11 +1483,11 @@
     },
     {
       "id": "performance.profile",
-      "description": "Corpus-wide deterministic compute fan-out profile.",
+      "description": "Corpus-wide deterministic compute fan-out profile, sharded across profile-shard legs.",
       "owner": {
         "workflow": ".github/workflows/perf-profile.yml",
-        "jobs": ["profile"],
-        "producer_jobs": [],
+        "jobs": ["profile-shard", "profile"],
+        "producer_jobs": ["profile-shard"],
         "context_job": "profile"
       },
       "executions": ["default"],
@@ -1495,10 +1495,10 @@
       "purpose": "performance",
       "layers": ["12"],
       "oracle_class": "performance",
-      "recipes": ["perf-chdb"],
-      "command": "corpus-wide EXPLAIN and count() fan-out profile",
+      "recipes": ["perf-profile"],
+      "command": "corpus-wide EXPLAIN and count() fan-out profile, sharded",
       "build_tags": ["chdb"],
-      "package_globs": ["internal/**", "test/perf/**", "test/spec/**"],
+      "package_globs": ["cmd/perf-profile/**", "internal/**", "test/perf/**", "test/spec/**"],
       "substrate": "chdb",
       "risk_domains": ["cardinality", "performance", "sql"],
       "merge_posture": "never",

--- a/.github/scripts/README.md
+++ b/.github/scripts/README.md
@@ -1550,6 +1550,31 @@ what actually runs.
   - Exit: `0` when every shard passed or the lane was correctly
     short-circuited, `1` otherwise.
 
+- **`perf-profile-aggregate.mjs`** — `perf-profile.yml`, the `profile` job. Same
+  shape as `perf-guards-aggregate.mjs`, one level simpler: the corpus-wide
+  fan-out PROFILE (breadth report, not a pass/fail assertion) was one job
+  walking the whole TXTAR corpus serially, and 9 of the 11 most recent non-PR
+  runs before a stopgap timeout doubling were killed by the job's own timeout
+  as `test/spec` kept growing, with no error of their own (tsouza/cerberus#2375).
+  It shards the SAME corpus through the SAME partition
+  (`test/perf/profile.ProfileCorpusShard`) `perf-guards-shard` already uses, so
+  `profile-shard (n)` — never `profile` — is what GitHub actually posts, and
+  this aggregator keeps the required name. It has no `changes`/`docs_only`
+  input (this lane is release-gated, not PR-gated, so its skip condition is
+  simpler): a heavy run (push / schedule / dispatch / release PR) must see the
+  matrix roll up to `success`, and an ordinary PR must see it `skipped`; any
+  other combination means the two jobs' RUN_HEAVY gates drifted apart. On a
+  green verdict the `profile` job goes on to run
+  `go run ./cmd/perf-profile -merge '<dir>/*.json' ...` (see
+  `cmd/perf-profile/report.go`) to fold the shards' JSON outputs into the one
+  combined report + step summary the lane always produced.
+  `perf-profile-aggregate.test.mjs` is the `node --test` guard (run on
+  `ci.yml`'s scripts lane) that pins both directions.
+  - Env: `RUN_HEAVY` (this job's own env value), `SHARDS_RESULT` (the
+    matrix's rolled-up result).
+  - Exit: `0` when the shards rolled up the way RUN_HEAVY says they should,
+    `1` otherwise.
+
 - **`chdb-roundtrip.mjs`** — `chdb.yml`, the `roundtrip (<ql>)` matrix job. Runs
   one head's chDB-executing TXTAR walk: `./test/spec/<ql>/` (pre-optimizer) and
   `./internal/<ql>/` (post-optimizer plus the reference-engine parity). It

--- a/.github/scripts/perf-profile-aggregate.mjs
+++ b/.github/scripts/perf-profile-aggregate.mjs
@@ -1,0 +1,123 @@
+// perf-profile-aggregate.mjs — decide whether the `profile-shard` matrix
+// rolled up cleanly enough for the `profile` aggregator job to merge its
+// per-leg JSON outputs (perf-profile.yml).
+//
+// Why this exists
+// ---------------
+// `profile` used to be one job walking the WHOLE test/spec/** corpus serially
+// through cmd/perf-profile. Of the 11 most recent non-PR runs before a
+// stopgap timeout doubling, 9 were killed by the job's own timeout with no
+// error of its own — the walk simply outgrew its budget as the corpus kept
+// growing (tsouza/cerberus#2375). The durable fix is the same one
+// `perf-guards-shard` / `perf-guards` in chdb.yml already applies to this
+// exact corpus (test/perf/profile.ProfileCorpusShard, shared by both lanes):
+// split the walk across a matrix of `profile-shard` legs, each profiling one
+// disjoint PERF_SHARD_INDEX/PERF_SHARD_COUNT slice, and keep ONE aggregator
+// job named `profile` so branch protection's required-contexts set (well,
+// `profile` is not itself in that set — see below) and, more importantly,
+// release.yml's RELEASE_REQUIRED_CHECKS (which DOES resolve `profile` by
+// exact text) never see a stale or missing context.
+//
+// Choosing an aggregator over N per-shard required contexts is deliberate,
+// mirroring perf-guards-aggregate.mjs's reasoning: per-shard contexts would
+// have to be added to release.yml's pin BEFORE they can ever report, removed
+// before a shard count is ever reduced, and any stale
+// `profile-shard (n)` left behind blocks a release forever on a check that
+// will never arrive. With the aggregator the shard count is an
+// implementation detail of one workflow file.
+//
+// What it asserts
+// ---------------
+// `profile-shard` is job-level gated on the SAME RUN_HEAVY condition
+// perf-profile.yml has always used (push/schedule/dispatch, or a `release/*`
+// PR): on an ordinary PR the whole matrix is skipped rather than spun up as
+// N no-op legs. The aggregator has to read the ONE fact GitHub Actions
+// exposes about a skipped/rolled-up matrix — `needs.profile-shard.result` —
+// together with whether this run was supposed to be heavy, and tell the two
+// legitimate skips (ordinary PR, nothing to do) apart from the two illegit-
+// imate ones (heavy run whose matrix never ran; heavy run where a leg failed
+// or was cancelled by ITS OWN timeout).
+//
+// Env:
+//   RUN_HEAVY      the job's own RUN_HEAVY env value ('true' | 'false').
+//   SHARDS_RESULT  `needs.profile-shard.result`.
+//
+// Exit: 0 when it is safe to proceed (merge on a heavy run, or report the
+// no-op on a non-heavy one); 1 otherwise.
+//
+// node: builtins only (via lib/gh.mjs).
+
+import process from 'node:process';
+import { error, notice } from './lib/gh.mjs';
+
+/**
+ * Pure decision over the two `needs`/env facts. Returns `{ ok, shouldMerge,
+ * message }` — `shouldMerge` tells the caller whether to run the merge step;
+ * `ok`/`message` become the `::notice::`/`::error::` and exit code. Kept pure
+ * so the test can drive every branch without a workflow run.
+ */
+export function classifyPerfProfile({ runHeavy, shardsResult }) {
+  const heavy = runHeavy === 'true';
+
+  if (!heavy) {
+    if (shardsResult === 'skipped') {
+      return {
+        ok: true,
+        shouldMerge: false,
+        message: 'ordinary PR — profile-shard was correctly skipped, nothing to merge.',
+      };
+    }
+    return {
+      ok: false,
+      shouldMerge: false,
+      message:
+        `RUN_HEAVY was false but profile-shard reported "${shardsResult}" instead of "skipped" — ` +
+        'the job-level gate and this aggregator have drifted out of sync.',
+    };
+  }
+
+  if (shardsResult === 'skipped') {
+    return {
+      ok: false,
+      shouldMerge: false,
+      message:
+        'this is a heavy run (push / schedule / dispatch / release PR) but profile-shard never ran — ' +
+        'the job-level RUN_HEAVY gate on profile-shard has drifted from this job\'s own.',
+    };
+  }
+
+  if (shardsResult !== 'success') {
+    return {
+      ok: false,
+      shouldMerge: false,
+      message:
+        `one or more profile-shard legs did not succeed (rolled-up: ${shardsResult}). A matrix rolls up to ` +
+        '"success" only when EVERY leg succeeded, so this covers a leg killed by its own timeout (reported ' +
+        'as "cancelled") and a leg that never ran. Open the red `profile-shard (n)` child check.',
+    };
+  }
+
+  return {
+    ok: true,
+    shouldMerge: true,
+    message: 'every profile-shard leg passed — merging the per-shard profiles into one report.',
+  };
+}
+
+function main() {
+  const verdict = classifyPerfProfile({
+    runHeavy: process.env.RUN_HEAVY ?? '',
+    shardsResult: process.env.SHARDS_RESULT ?? '',
+  });
+  if (verdict.ok) {
+    notice(`perf-profile-aggregate: ${verdict.message}`);
+    process.exit(0);
+  }
+  error(`perf-profile-aggregate: ${verdict.message}`, { title: 'profile-shard matrix did not roll up cleanly' });
+  process.exit(1);
+}
+
+// Only dispatch when run as a script — importing for the unit test must not
+// exit the test runner.
+const invokedDirectly = process.argv[1] && import.meta.url === new URL(`file://${process.argv[1]}`).href;
+if (invokedDirectly) main();

--- a/.github/scripts/perf-profile-aggregate.test.mjs
+++ b/.github/scripts/perf-profile-aggregate.test.mjs
@@ -1,0 +1,53 @@
+// perf-profile-aggregate.test.mjs — node:test guard for the profile-shard
+// roll-up decision.
+//
+// This aggregator is the ONLY thing that decides whether the `profile` job
+// (which release.yml's RELEASE_REQUIRED_CHECKS resolves by exact text)
+// proceeds to merge the profile-shard matrix's outputs or reports a no-op.
+// A version that drifts toward "always ok" would let a merge run over a
+// partial or failed shard sweep and publish it as if it were the whole
+// corpus — so these pin both directions: every legitimate case must pass,
+// and every drifted/failed one must actually fail.
+
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+
+import { classifyPerfProfile } from './perf-profile-aggregate.mjs';
+
+test('a heavy run where every shard succeeded merges', () => {
+  const v = classifyPerfProfile({ runHeavy: 'true', shardsResult: 'success' });
+  assert.equal(v.ok, true);
+  assert.equal(v.shouldMerge, true);
+});
+
+test('a heavy run where the matrix rolled up to anything but success fails, whatever the reason', () => {
+  // A matrix reports ONE result to its dependents. `failure` is the obvious
+  // case; `cancelled` is the one a naive `contains(…, 'failure')` test would
+  // let through, and it is exactly how a `timeout-minutes` kill on a leg is
+  // recorded.
+  for (const result of ['failure', 'cancelled', '']) {
+    const v = classifyPerfProfile({ runHeavy: 'true', shardsResult: result });
+    assert.equal(v.ok, false, `shardsResult=${result} must not pass`);
+    assert.equal(v.shouldMerge, false);
+  }
+});
+
+test('a heavy run whose matrix never ran (gate drift) fails', () => {
+  const v = classifyPerfProfile({ runHeavy: 'true', shardsResult: 'skipped' });
+  assert.equal(v.ok, false);
+  assert.match(v.message, /never ran/);
+});
+
+test('an ordinary PR with the matrix correctly skipped is a green no-op', () => {
+  const v = classifyPerfProfile({ runHeavy: 'false', shardsResult: 'skipped' });
+  assert.equal(v.ok, true);
+  assert.equal(v.shouldMerge, false);
+});
+
+test('an ordinary PR whose matrix somehow ran anyway (gate drift) fails', () => {
+  for (const result of ['success', 'failure', 'cancelled']) {
+    const v = classifyPerfProfile({ runHeavy: 'false', shardsResult: result });
+    assert.equal(v.ok, false, `shardsResult=${result} on a non-heavy run must not pass`);
+    assert.match(v.message, /drifted/);
+  }
+});

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -771,6 +771,14 @@ jobs:
       - name: Assert the perf-guards shard roll-up cannot report a hollow green
         run: node --test .github/scripts/perf-guards-aggregate.test.mjs
 
+      # Same shape, different lane: `profile` is the required-by-release
+      # aggregator that rolls perf-profile.yml's sharded `profile-shard`
+      # matrix up under the name release.yml's RELEASE_REQUIRED_CHECKS
+      # resolves (tsouza/cerberus#2375). Pure in-process test over the
+      # module, ~100ms.
+      - name: Assert the perf-profile shard roll-up cannot report a hollow green
+        run: node --test .github/scripts/perf-profile-aggregate.test.mjs
+
       # The `roundtrip (<ql>)` leg runner. Two of its properties are invisible
       # in the chDB lane itself until they fail 10-20 minutes in: that every leg
       # declares an explicit `go test -timeout` (without one the leg runs under

--- a/.github/workflows/perf-profile.yml
+++ b/.github/workflows/perf-profile.yml
@@ -38,6 +38,31 @@ name: perf-profile
 # always-on lane; this one stays breadth-coverage. Mirrors chart-ci.yml's no-op
 # pattern.
 #
+# # Sharding (tsouza/cerberus#2375)
+#
+# This used to be ONE job walking the whole corpus serially. Job history
+# showed the real (RUN_HEAVY) run creeping toward and then past its 30-minute
+# budget as test/spec grew: 9 of the 11 most recent non-PR runs before a
+# stopgap timeout doubling (30m -> 60m, since superseded by this sharded
+# design) were killed by the timeout with no error of their own — the walk
+# was still working, just not finished; the two that completed took 22m21s
+# and 28m58s at the job level, both close to the old ceiling. That is a
+# capacity problem, not a flake: doubling the timeout again on the next
+# regrowth is not a sustainable pattern.
+#
+# The durable fix mirrors `perf-guards-shard` / `perf-guards` in chdb.yml,
+# which already shards this EXACT corpus walk (both lanes call
+# test/perf/profile.ProfileCorpusShard — perf-guards-shard for
+# TestCardinalityRatchet's pass/fail assertion, profile-shard here for the
+# breadth report) across PERF_SHARD_INDEX / PERF_SHARD_COUNT
+# (test/perf/profile/shard.go). `profile-shard` is the matrix, one leg per
+# corpus slice; `profile` is the AGGREGATOR, kept at exactly that name
+# because release.yml's RELEASE_REQUIRED_CHECKS resolves `profile` by exact
+# text (matrix children report as `profile-shard (n)`, never `profile`) — a
+# required context that a renamed job stops posting sits "Expected" forever.
+# See .github/scripts/perf-profile-aggregate.mjs for the roll-up logic and
+# PERF_PROFILE_SHARD_COUNT below for the leg count.
+#
 # Triggers: pull_request (release/* only) + push-to-main + nightly + dispatch.
 
 on:
@@ -62,34 +87,135 @@ concurrency:
   cancel-in-progress: ${{ (github.event_name == 'push' && github.ref == 'refs/heads/main') || (github.event_name == 'schedule' && github.ref == 'refs/heads/main' && github.event.schedule != '') }}
 
 jobs:
+  # `profile-shard` — the matrix; each leg profiles ONLY the corpus slice its
+  # PERF_SHARD_INDEX names, via the same cmd/perf-profile binary the old
+  # single-job lane ran, unchanged apart from reading the shard from env
+  # (test/perf/profile.ShardFromEnv). No matrix-generator script: the
+  # partition is computed at RUN TIME from the fixture id, exactly as
+  # perf-guards-shard's is, so the matrix carries no membership information —
+  # only how many legs there are. Changing PERF_PROFILE_SHARD_COUNT below and
+  # the `shard:` list together is the whole knob; the partition rebalances
+  # itself and no baseline or check name moves.
+  profile-shard:
+    name: profile-shard
+    runs-on: ubuntu-latest
+    # Job-level, not step-level: `env` context is not available in a job
+    # `if:`, so this repeats (rather than reads) the same RUN_HEAVY condition
+    # the `profile` aggregator's own `env.RUN_HEAVY` uses for its steps.
+    # Skipping the WHOLE matrix — not just its steps — on an ordinary PR
+    # avoids spinning up 8 legs that would each immediately no-op; mirrors
+    # mutation.yml's has_phases short-circuit.
+    if: github.event_name != 'pull_request' || startsWith(github.head_ref, 'release/')
+    # A leg profiles ~1/8 of the corpus that used to take 22-29 minutes
+    # serially — a few minutes of real work plus setup. 20m leaves a wide
+    # margin over that while still catching a genuine hang well inside the
+    # aggregator's own budget; it is a hang detector, not an estimate.
+    timeout-minutes: 20
+    strategy:
+      # MANDATORY: one shard's failure must not cancel its siblings — the
+      # default (true) would cancel in-flight legs into the ambiguous
+      # `cancelled` rollup and hide whether the others would also have
+      # failed, and for a corpus-wide fan-out sweep a regression typically
+      # shows up in several slices at once.
+      fail-fast: false
+      matrix:
+        # PERF_PROFILE_SHARD_COUNT. The corpus (test/spec/**) held 963
+        # executable fixtures when this was written; the unsharded walk
+        # measured 22m21s-28m58s at the job level on an isolated GH runner
+        # (tsouza/cerberus#2375). 8 legs — the same count `perf-guards-shard`
+        # in chdb.yml already uses to shard THIS EXACT walk (both lanes call
+        # test/perf/profile.ProfileCorpusShard over the same corpus) — puts
+        # each leg's own profiling work at roughly (22-29 min)/8 ≈ 3-4
+        # minutes on CI-grade hardware. A local run of a 1/8 slice (133
+        # fixtures) measured 4m50s of pure profiling time on a machine
+        # shared with other concurrent chdb-tagged processes — see the
+        # `perf-chdb` recipe's own caveat in Justfile about why a local
+        # figure taken under contention runs high; the issue's own CI
+        # figures are the trustworthy baseline here. Either number leaves
+        # wide headroom under this job's 20-minute ceiling, let alone the
+        # 60-minute one the old serial job used. Even after the corpus
+        # roughly triples, a leg stays comfortably inside that ceiling.
+        # Changing the leg count is just editing this list — the partition
+        # in test/perf/profile/shard.go rebalances itself, no baseline
+        # to regenerate.
+        shard: [1, 2, 3, 4, 5, 6, 7, 8]
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-go@v7
+        with:
+          go-version-file: 'go.mod'
+          cache: true
+
+      - uses: taiki-e/install-action@82cd3e7658a6f96c86c0234aeeda1748937cb0a1  # v2.85.13
+        with:
+          tool: just
+
+      - name: Install libchdb.so
+        run: just chdb-install
+
+      # PERF_SHARD_COUNT comes from `strategy.job-total`, NOT a second
+      # literal: it is the number of legs this matrix actually fans out to,
+      # so the count the partition divides by cannot drift from the count
+      # that runs. A hand-written 8 left behind after the list changed would
+      # silently leave a slice of the corpus profiled by nobody.
+      - name: Profile corpus fan-out — shard ${{ matrix.shard }}/${{ strategy.job-total }}
+        run: |
+          go run -tags chdb ./cmd/perf-profile \
+            -spec test/spec \
+            -out perf-profile-shard-${{ matrix.shard }}.json \
+            -top 0
+        env:
+          PERF_SHARD_INDEX: ${{ matrix.shard }}
+          PERF_SHARD_COUNT: ${{ strategy.job-total }}
+
+      - name: Upload shard profile artifact
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: perf-profile-shard-${{ matrix.shard }}
+          path: perf-profile-shard-${{ matrix.shard }}.json
+          if-no-files-found: warn
+          retention-days: 30
+
+  # The AGGREGATOR — named EXACTLY `profile` because that is the name
+  # release.yml's RELEASE_REQUIRED_CHECKS resolves by text (see the
+  # workflow-level comment above). It merges the profile-shard matrix's
+  # per-leg JSON into the SAME single combined artifact + step-summary table
+  # the old unsharded job produced, so the sharded lane still leaves one
+  # place to look rather than 8 disconnected partial reports.
+  #
+  # This job runs the DEFAULT (non-chdb-tagged) build of cmd/perf-profile:
+  # `-merge` only reads/ranks JSON someone else already collected (see
+  # cmd/perf-profile/report.go), so the aggregator needs neither
+  # `just chdb-install` nor the `chdb` build tag.
   profile:
     name: profile
+    needs: profile-shard
+    # always() so it still runs — and still reports the required release
+    # check — when profile-shard was skipped on an ordinary PR. A required
+    # context that goes missing is indistinguishable from one still running.
+    if: always()
     runs-on: ubuntu-latest
-    # The corpus-wide walk's cost tracks the size of test/spec, which has been
-    # growing. Job history shows the real (RUN_HEAVY) run now sits close to
-    # or past a 30-minute budget even when it completes cleanly (two recent
-    # successes: 22m21s and 28m58s at the job level), and 9 of the 11 most
-    # recent non-PR runs before this change were killed by that timeout with
-    # no error of their own - the step was still working, just not finished.
-    # Confirmed by direct log comparison: a genuinely successful run has the
-    # exact same multi-minute silent gap (no stdout between the last `go:
-    # downloading` line and the final results table) that the killed runs
-    # show right up to the point they get cut off - the silence is normal
-    # output shape for this step, not evidence of a stall. Double the budget
-    # for real headroom rather than retrying an operation that was never
-    # stuck. cerberus issue #2375 tracks reducing the step's own cost (e.g.
-    # sharding the corpus walk the way the e2e crawl lanes already do) as the
-    # more durable fix; this bump is what actually restores a working gate
-    # today.
-    timeout-minutes: 60
-    # RUN_HEAVY gates the real work: true on push / schedule / dispatch, and on
-    # a release PR (head branch release/*). On a regular PR every heavy step is
-    # skipped and the job reports green without work — so `profile` gates the
-    # release and release PRs, and never blocks an ordinary PR.
+    timeout-minutes: 10
+    # Same RUN_HEAVY condition profile-shard's job-level `if:` inlines; here
+    # it can live in `env` because step `if:`s (unlike a job `if:`) can read
+    # the `env` context.
     env:
       RUN_HEAVY: ${{ github.event_name != 'pull_request' || startsWith(github.head_ref, 'release/') }}
     steps:
       - uses: actions/checkout@v7
+
+      # Fails the job — before anything else runs — unless the shard matrix
+      # rolled up exactly the way this run's RUN_HEAVY says it should:
+      # skipped on an ordinary PR, all-success on a heavy run. See the
+      # script for the full decision table (a skipped-but-heavy or
+      # ran-but-not-heavy result means the two jobs' gates drifted apart;
+      # `failure`/`cancelled` means a leg genuinely broke or hung).
+      - name: Verify the profile-shard matrix rolled up cleanly
+        run: node .github/scripts/perf-profile-aggregate.mjs
+        env:
+          SHARDS_RESULT: ${{ needs.profile-shard.result }}
 
       - if: env.RUN_HEAVY == 'true'
         uses: actions/setup-go@v7
@@ -97,20 +223,29 @@ jobs:
           go-version-file: 'go.mod'
           cache: true
 
-      - if: env.RUN_HEAVY == 'true'
-        uses: taiki-e/install-action@82cd3e7658a6f96c86c0234aeeda1748937cb0a1  # v2.85.13
-        with:
-          tool: just
-
-      - name: Install libchdb.so
+      - name: Download shard profiles
         if: env.RUN_HEAVY == 'true'
-        run: just chdb-install
+        uses: actions/download-artifact@v8
+        with:
+          pattern: perf-profile-shard-*
+          path: shards
+          merge-multiple: true
 
-      - name: Profile corpus fan-out
+      # No `-expect-shards`: that would mean a second literal repeating
+      # profile-shard's matrix length here, exactly the kind of copy that
+      # drifts silently when the shard list changes (mirrors chdb.yml's
+      # `perf-guards` aggregator, which for the same reason never passes
+      # `strategy.job-total` across jobs either). Completeness is proven
+      # upstream instead: the "rolled up cleanly" step above already refused
+      # to reach this point unless EVERY profile-shard leg succeeded — i.e.
+      # every leg uploaded its artifact — and mergeRecords' own duplicate-
+      # fixture check (report.go) still catches a partition that somehow
+      # stopped being disjoint.
+      - name: Merge shard profiles into one report
         if: env.RUN_HEAVY == 'true'
         run: |
-          go run -tags chdb ./cmd/perf-profile \
-            -spec test/spec \
+          go run ./cmd/perf-profile \
+            -merge 'shards/*.json' \
             -out perf-profile.json \
             -md "$GITHUB_STEP_SUMMARY" \
             -top 40

--- a/Justfile
+++ b/Justfile
@@ -262,16 +262,24 @@ property:
 perf-chdb:
     go test -timeout 27m -tags chdb -count=1 ./test/perf/...
 
-# Profile the WHOLE TXTAR corpus for compute fan-out (perf-assessment
-# Component B). Walks every executable fixture under test/spec/** (those
-# with `seed:` + `expected_rows:` + `sql:`) and, per fixture, runs
-# EXPLAIN PLAN actions=1 (CROSS JOIN / ARRAY JOIN / recursive-CTE
-# detection) + a per-subquery-level count() decomposition (peak
-# intermediate cardinality vs leaf scan rows) in-process via chDB.
-# Writes a JSON profile array and prints the top fan_factor fixtures.
-# Requires libchdb.so (see `just chdb-install`). Drives the nightly
-# perf-profile.yml lane — NOT a per-PR gate (corpus-wide breadth over
-# ~640 fixtures is too heavy for every PR). Override OUT / TOP to taste.
+# Profile the TXTAR corpus for compute fan-out (perf-assessment Component B).
+# Walks every executable fixture under test/spec/** (those with `seed:` +
+# `expected_rows:` + `sql:`) and, per fixture, runs EXPLAIN PLAN actions=1
+# (CROSS JOIN / ARRAY JOIN / recursive-CTE detection) + a per-subquery-level
+# count() decomposition (peak intermediate cardinality vs leaf scan rows) in
+# process via chDB. Writes a JSON profile array and prints the top fan_factor
+# fixtures. Requires libchdb.so (see `just chdb-install`).
+#
+# Like `perf-chdb`, this recipe runs the corpus slice named by
+# PERF_SHARD_INDEX / PERF_SHARD_COUNT (test/perf/profile/shard.go) — both
+# unset, the local default, is the WHOLE corpus. perf-profile.yml's
+# `profile-shard` matrix sets both, one leg per slice, and its `profile`
+# aggregator then runs `go run ./cmd/perf-profile -merge '<dir>/*.json' ...`
+# (no chDB, no `chdb` tag — see cmd/perf-profile/report.go) to fold the legs'
+# JSON outputs back into one combined report — the same shape the lane
+# produced before sharding existed (tsouza/cerberus#2375). NOT a per-PR gate:
+# corpus-wide breadth over ~950 fixtures is too heavy for every PR. Override
+# OUT / TOP to taste.
 perf-profile OUT="perf-profile.json" TOP="40":
     go run -tags chdb ./cmd/perf-profile -spec test/spec -out {{OUT}} -top {{TOP}}
 

--- a/cmd/perf-profile/main_chdb.go
+++ b/cmd/perf-profile/main_chdb.go
@@ -8,21 +8,42 @@
 // It is built with the `chdb` tag (requires libchdb.so — `just
 // chdb-install`) because the profiling work runs in-process against an
 // embedded chDB engine. Without the tag, the build falls back to the
-// stub in main_nochdb.go which prints an instruction and exits non-zero.
+// stub in main_nochdb.go, which still supports `-merge` (see below) but
+// otherwise prints an instruction and exits non-zero.
 //
 // Usage:
 //
 //	perf-profile -spec test/spec -out profile.json [-top 25]
+//	perf-profile -merge 'shards/*.json' -out profile.json [-top 25]
 //
 // Flags:
 //
-//	-spec   root directory of the TXTAR corpus (default "test/spec")
-//	-out    path to write the JSON profile array (default stdout)
-//	-top    print the top-N fan_factor fixtures to stderr as a table
-//	        (default 25; 0 disables)
-//	-fail-over  exit non-zero if any fixture's fan_factor exceeds this
-//	            threshold (default 0 = never fail; nightly lane reports,
-//	            it does not gate)
+//	-spec        root directory of the TXTAR corpus (default "test/spec")
+//	-out         path to write the JSON profile array (default stdout)
+//	-md          path to append a markdown top-fan_factor table (for GITHUB_STEP_SUMMARY)
+//	-top         print the top-N fan_factor fixtures to stderr as a table
+//	             (default 25; 0 disables)
+//	-fail-over   exit non-zero if any fixture's fan_factor exceeds this
+//	             threshold (default 0 = never fail; nightly lane reports,
+//	             it does not gate)
+//	-merge          glob of shard JSON files to combine into one report
+//	                INSTEAD of profiling (see report.go). Needs no chDB —
+//	                works identically in the tag-free build.
+//	-expect-shards  (-merge only) fail unless exactly this many files
+//	                matched -merge (0 = don't check)
+//
+// # Sharding
+//
+// A single process profiles only the corpus slice named by the
+// environment: PERF_SHARD_INDEX / PERF_SHARD_COUNT
+// (test/perf/profile/shard.go). Both unset — the local default — is the
+// WHOLE corpus, exactly as before sharding existed. perf-profile.yml's
+// `profile-shard` matrix job sets both, one leg per slice, and the
+// `profile` aggregator job then runs this same binary with `-merge` to
+// fold the legs' JSON outputs back into one combined report — mirroring
+// `perf-guards-shard` / `perf-guards` in chdb.yml, which shards this
+// exact package's ProfileCorpusShard call for a different (pass/fail
+// assertion) consumer.
 //
 // The JSON output is an array of profile.Record. The nightly
 // perf-profile.yml lane uploads it as an artifact and renders the
@@ -30,171 +51,30 @@
 package main
 
 import (
-	"encoding/json"
-	"flag"
 	"fmt"
 	"os"
-	"strings"
 
 	"github.com/tsouza/cerberus/test/perf/profile"
 )
 
 func main() {
-	specDir := flag.String("spec", "test/spec", "root directory of the TXTAR corpus")
-	outPath := flag.String("out", "", "path to write the JSON profile array (default stdout)")
-	mdPath := flag.String("md", "", "path to append a markdown top-fan_factor table (for GITHUB_STEP_SUMMARY)")
-	top := flag.Int("top", 25, "print the top-N fan_factor fixtures to stderr (0 disables)")
-	failOver := flag.Float64("fail-over", 0, "exit non-zero if any fixture fan_factor exceeds this (0 = never)")
-	flag.Parse()
+	f := parseFlags()
 
-	recs, err := profile.ProfileCorpus(*specDir)
+	if f.mergeGlob != "" {
+		os.Exit(runMerge(f))
+	}
+
+	shard, err := profile.ShardFromEnv()
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "perf-profile: %v\n", err)
 		os.Exit(1)
 	}
 
-	if err := writeJSON(*outPath, recs); err != nil {
-		fmt.Fprintf(os.Stderr, "perf-profile: write output: %v\n", err)
+	recs, err := profile.ProfileCorpusShard(f.specDir, shard)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "perf-profile: %v\n", err)
 		os.Exit(1)
 	}
 
-	if *top > 0 {
-		printTopTable(os.Stderr, recs, *top)
-	}
-
-	// Summary line: total fixtures, how many had errors, how many are
-	// unmeasured (fan_factor nil — see [profile.Record.FanFactor]).
-	var nErr, nUnmeasured int
-	var maxFan float64
-	for _, r := range recs {
-		if r.Err != "" {
-			nErr++
-		}
-		if r.FanFactor == nil {
-			nUnmeasured++
-			continue
-		}
-		if *r.FanFactor > maxFan {
-			maxFan = *r.FanFactor
-		}
-	}
-
-	if *mdPath != "" {
-		n := *top
-		if n <= 0 {
-			n = 25
-		}
-		if err := writeMarkdown(*mdPath, recs, n, len(recs), nErr, nUnmeasured, maxFan); err != nil {
-			fmt.Fprintf(os.Stderr, "perf-profile: write markdown summary: %v\n", err)
-			os.Exit(1)
-		}
-	}
-	fmt.Fprintf(os.Stderr, "perf-profile: profiled %d fixtures (%d with errors, %d unmeasured), max fan_factor = %.2f\n",
-		len(recs), nErr, nUnmeasured, maxFan)
-
-	if *failOver > 0 && maxFan > *failOver {
-		fmt.Fprintf(os.Stderr, "perf-profile: FAIL — max fan_factor %.2f exceeds threshold %.2f\n", maxFan, *failOver)
-		os.Exit(2)
-	}
-}
-
-// writeJSON marshals recs as an indented JSON array to outPath, or to
-// stdout when outPath is empty.
-func writeJSON(outPath string, recs []profile.Record) error {
-	data, err := json.MarshalIndent(recs, "", "  ")
-	if err != nil {
-		return err
-	}
-	data = append(data, '\n')
-	if outPath == "" {
-		_, werr := os.Stdout.Write(data)
-		return werr
-	}
-	return os.WriteFile(outPath, data, 0o644) //nolint:gosec // profile artifact, not a secret
-}
-
-// writeMarkdown appends a GitHub-flavoured markdown table of the top-n
-// fan_factor fixtures plus a one-line corpus summary to mdPath (opened
-// in append mode so it can target $GITHUB_STEP_SUMMARY directly).
-func writeMarkdown(mdPath string, recs []profile.Record, n, total, nErr, nUnmeasured int, maxFan float64) error {
-	if n > len(recs) {
-		n = len(recs)
-	}
-	var b strings.Builder
-	fmt.Fprintf(&b, "## perf-profile (corpus fan-out)\n\n")
-	fmt.Fprintf(&b, "Profiled **%d** executable fixtures (%d with errors, %d unmeasured). Max fan_factor: **%.2f**.\n\n",
-		total, nErr, nUnmeasured, maxFan)
-	fmt.Fprintf(&b, "### top %d fixtures by fan_factor\n\n", n)
-	b.WriteString("| fixture | fan_factor | scan_rows | peak_intermediate | result_rows | cross_join | array_join | recursive_cte |\n")
-	b.WriteString("| --- | ---: | ---: | ---: | ---: | :---: | :---: | :---: |\n")
-	for i := 0; i < n; i++ {
-		r := recs[i]
-		fmt.Fprintf(&b, "| `%s` | %s | %d | %d | %d | %s | %s | %s |\n",
-			r.Fixture, fanFactorLabel(r.FanFactor), r.ScanRows, r.PeakIntermediate, r.ResultRows,
-			mdYesNo(r.HasCrossJoin), mdYesNo(r.HasArrayJoin), mdYesNo(r.HasRecursiveCTE))
-	}
-	b.WriteString("\n_fan_factor = peak intermediate cardinality / leaf scan rows. " +
-		"Fixtures are small golden seeds, so absolute counts are tiny; the ratio is the fan-out signal. " +
-		"`unmeasured` means the profiler could not see through every pipeline stage (a CTE reference or a " +
-		"recursive CTE step) — see [profile.Record.FanFactor]._\n\n")
-
-	f, err := os.OpenFile(mdPath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o644) //nolint:gosec // step-summary path
-	if err != nil {
-		return err
-	}
-	defer func() { _ = f.Close() }()
-	_, werr := f.WriteString(b.String())
-	return werr
-}
-
-// fanFactorLabel renders a nullable fan_factor for the human-facing
-// summary tables — nil (unmeasured) is spelled out rather than
-// collapsed to a fabricated number.
-func fanFactorLabel(f *float64) string {
-	if f == nil {
-		return "unmeasured"
-	}
-	return fmt.Sprintf("%.2f", *f)
-}
-
-func mdYesNo(v bool) string {
-	if v {
-		return "✓"
-	}
-	return ""
-}
-
-// printTopTable renders the top-n records (already sorted descending by
-// fan factor) as a fixed-width table to w. Used for the nightly
-// step-summary preview and local runs.
-func printTopTable(w *os.File, recs []profile.Record, n int) {
-	if n > len(recs) {
-		n = len(recs)
-	}
-	fmt.Fprintf(w, "\n=== top %d fixtures by fan_factor ===\n", n)
-	fmt.Fprintf(w, "%-48s %10s %12s %12s %6s %6s %6s\n",
-		"fixture", "fan_factor", "scan_rows", "peak_inter", "xjoin", "ajoin", "rcte")
-	for i := 0; i < n; i++ {
-		r := recs[i]
-		fmt.Fprintf(w, "%-48s %10s %12d %12d %6s %6s %6s\n",
-			truncate(r.Fixture, 48), fanFactorLabel(r.FanFactor), r.ScanRows, r.PeakIntermediate,
-			yesno(r.HasCrossJoin), yesno(r.HasArrayJoin), yesno(r.HasRecursiveCTE))
-	}
-}
-
-func truncate(s string, n int) string {
-	if len(s) <= n {
-		return s
-	}
-	if n <= 1 {
-		return s[:n]
-	}
-	return s[:n-1] + "…"
-}
-
-func yesno(b bool) string {
-	if b {
-		return "yes"
-	}
-	return "-"
+	os.Exit(emitReport(recs, f.outPath, f.mdPath, f.top, f.failOver))
 }

--- a/cmd/perf-profile/main_nochdb.go
+++ b/cmd/perf-profile/main_nochdb.go
@@ -1,9 +1,15 @@
 //go:build !chdb
 
-// Command perf-profile requires the `chdb` build tag (libchdb.so) to do
-// any work — it profiles fixtures in-process against an embedded chDB
-// engine. This stub keeps `go build ./...` green on the default
-// CGO-free lane while making the requirement explicit at runtime.
+// Command perf-profile requires the `chdb` build tag (libchdb.so) to
+// PROFILE fixtures — that work runs in-process against an embedded chDB
+// engine. This build supports only `-merge` (folding N shard JSON
+// outputs, produced elsewhere by the chdb-tagged binary, into one
+// combined report — see report.go, which never touches chDB); any other
+// invocation prints an instruction and exits non-zero.
+//
+// perf-profile.yml's `profile` aggregator job runs THIS build: it only
+// merges the `profile-shard` matrix's per-leg JSON artifacts, so it pays
+// for neither `just chdb-install` nor the `chdb` tag.
 package main
 
 import (
@@ -12,9 +18,16 @@ import (
 )
 
 func main() {
+	f := parseFlags()
+
+	if f.mergeGlob != "" {
+		os.Exit(runMerge(f))
+	}
+
 	fmt.Fprintln(os.Stderr,
 		"perf-profile: built without the `chdb` tag — rebuild with "+
 			"`go build -tags chdb ./cmd/perf-profile` (requires libchdb.so; "+
-			"see `just chdb-install`).")
+			"see `just chdb-install`) to profile fixtures, or pass -merge to "+
+			"combine existing shard outputs (no chDB needed).")
 	os.Exit(1)
 }

--- a/cmd/perf-profile/report.go
+++ b/cmd/perf-profile/report.go
@@ -1,0 +1,275 @@
+// Deliberately NOT `//go:build chdb`. Everything here reads/writes/ranks
+// []profile.Record — plain JSON in, a markdown/text table out — and never
+// opens a chDB session. Keeping it untagged is what lets `-merge` (folding N
+// shards' JSON outputs into one combined report) run in the DEFAULT build,
+// with no libchdb.so and no `chdb` tag: the perf-profile.yml aggregator job
+// that combines the profile-shard matrix's outputs needs none of the chDB
+// toolchain main_chdb.go's actual profiling requires. main_chdb.go (single-
+// shard profiling) and main_nochdb.go (the merge-capable stub) both call into
+// this file.
+package main
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/tsouza/cerberus/test/perf/profile"
+)
+
+// cliFlags is the flag set shared verbatim by main_chdb.go and
+// main_nochdb.go, so `-h` output and flag semantics are identical whichever
+// build tag produced the binary.
+type cliFlags struct {
+	specDir      string
+	outPath      string
+	mdPath       string
+	top          int
+	failOver     float64
+	mergeGlob    string
+	expectShards int
+}
+
+// parseFlags registers and parses the flags both entrypoints accept.
+func parseFlags() cliFlags {
+	var f cliFlags
+	flag.StringVar(&f.specDir, "spec", "test/spec", "root directory of the TXTAR corpus")
+	flag.StringVar(&f.outPath, "out", "", "path to write the JSON profile array (default stdout)")
+	flag.StringVar(&f.mdPath, "md", "", "path to append a markdown top-fan_factor table (for GITHUB_STEP_SUMMARY)")
+	flag.IntVar(&f.top, "top", 25, "print the top-N fan_factor fixtures to stderr (0 disables)")
+	flag.Float64Var(&f.failOver, "fail-over", 0, "exit non-zero if any fixture fan_factor exceeds this (0 = never)")
+	flag.StringVar(&f.mergeGlob, "merge", "",
+		"glob of shard JSON files to MERGE into one combined report, instead of profiling. "+
+			"Needs no chDB — works in the tag-free build too.")
+	flag.IntVar(&f.expectShards, "expect-shards", 0,
+		"(-merge only) fail unless exactly this many files matched -merge (0 = don't check)")
+	flag.Parse()
+	return f
+}
+
+// runMerge implements `-merge`: read every file -merge's glob matches as a
+// []profile.Record JSON array, concatenate, and run the same report pipeline
+// -spec's direct profiling run would (writeJSON / printTopTable / writeMarkdown
+// / -fail-over). Returns the process exit code.
+func runMerge(f cliFlags) int {
+	recs, err := mergeRecords(f.mergeGlob, f.expectShards)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "perf-profile: merge: %v\n", err)
+		return 1
+	}
+	return emitReport(recs, f.outPath, f.mdPath, f.top, f.failOver)
+}
+
+// mergeRecords globs pattern, decodes each match as a []profile.Record JSON
+// array, and returns every record concatenated and re-sorted by fan factor.
+//
+// A fixture ID appearing in more than one input file is a HARD error rather
+// than a silently-deduplicated or silently-doubled record: the corpus
+// partition (test/perf/profile/shard.go) guarantees a disjoint cover, so a
+// duplicate means the shard count the matrix ran with does not match the
+// count the aggregator was told to expect, or a shard re-ran and both
+// artifacts got merged — either way the combined report is not trustworthy
+// until that is fixed at the source.
+func mergeRecords(pattern string, expectShards int) ([]profile.Record, error) {
+	if pattern == "" {
+		return nil, fmt.Errorf("empty -merge pattern")
+	}
+	paths, err := filepath.Glob(pattern)
+	if err != nil {
+		return nil, fmt.Errorf("glob %q: %w", pattern, err)
+	}
+	sort.Strings(paths)
+	if len(paths) == 0 {
+		return nil, fmt.Errorf("-merge %q matched no files", pattern)
+	}
+	if expectShards > 0 && len(paths) != expectShards {
+		return nil, fmt.Errorf("-merge %q matched %d file(s), expected exactly %d (-expect-shards) — "+
+			"a shard's artifact may be missing, or the matrix's shard count drifted from what the "+
+			"aggregator was told to expect", pattern, len(paths), expectShards)
+	}
+
+	owner := make(map[string]string) // fixture ID -> the file it first appeared in
+	var merged []profile.Record
+	for _, path := range paths {
+		data, rerr := os.ReadFile(path) //nolint:gosec // CI artifact path, not user input
+		if rerr != nil {
+			return nil, fmt.Errorf("read %s: %w", path, rerr)
+		}
+		var recs []profile.Record
+		if uerr := json.Unmarshal(data, &recs); uerr != nil {
+			return nil, fmt.Errorf("decode %s: %w", path, uerr)
+		}
+		for _, r := range recs {
+			if prior, dup := owner[r.Fixture]; dup {
+				return nil, fmt.Errorf("fixture %q appears in both %s and %s — shard partitions must be disjoint",
+					r.Fixture, prior, path)
+			}
+			owner[r.Fixture] = path
+		}
+		merged = append(merged, recs...)
+	}
+
+	profile.SortByFanFactor(merged)
+	return merged, nil
+}
+
+// emitReport is the report pipeline shared by a direct profiling run and a
+// merge run: write the JSON array, print the top-N table, append the
+// markdown step summary, print the one-line corpus summary, and apply
+// -fail-over. Returns the process exit code.
+func emitReport(recs []profile.Record, outPath, mdPath string, top int, failOver float64) int {
+	if err := writeJSON(outPath, recs); err != nil {
+		fmt.Fprintf(os.Stderr, "perf-profile: write output: %v\n", err)
+		return 1
+	}
+
+	if top > 0 {
+		printTopTable(os.Stderr, recs, top)
+	}
+
+	nErr, nUnmeasured, maxFan := summarize(recs)
+
+	if mdPath != "" {
+		n := top
+		if n <= 0 {
+			n = 25
+		}
+		if err := writeMarkdown(mdPath, recs, n, len(recs), nErr, nUnmeasured, maxFan); err != nil {
+			fmt.Fprintf(os.Stderr, "perf-profile: write markdown summary: %v\n", err)
+			return 1
+		}
+	}
+	fmt.Fprintf(os.Stderr, "perf-profile: profiled %d fixtures (%d with errors, %d unmeasured), max fan_factor = %.2f\n",
+		len(recs), nErr, nUnmeasured, maxFan)
+
+	if failOver > 0 && maxFan > failOver {
+		fmt.Fprintf(os.Stderr, "perf-profile: FAIL — max fan_factor %.2f exceeds threshold %.2f\n", maxFan, failOver)
+		return 2
+	}
+	return 0
+}
+
+// summarize computes the three headline numbers the report's summary line
+// and markdown table share: how many fixtures errored, how many are
+// unmeasured (nil FanFactor — see [profile.Record.FanFactor]), and the
+// highest FanFactor among the measured ones.
+func summarize(recs []profile.Record) (nErr, nUnmeasured int, maxFan float64) {
+	for _, r := range recs {
+		if r.Err != "" {
+			nErr++
+		}
+		if r.FanFactor == nil {
+			nUnmeasured++
+			continue
+		}
+		if *r.FanFactor > maxFan {
+			maxFan = *r.FanFactor
+		}
+	}
+	return nErr, nUnmeasured, maxFan
+}
+
+// writeJSON marshals recs as an indented JSON array to outPath, or to
+// stdout when outPath is empty.
+func writeJSON(outPath string, recs []profile.Record) error {
+	data, err := json.MarshalIndent(recs, "", "  ")
+	if err != nil {
+		return err
+	}
+	data = append(data, '\n')
+	if outPath == "" {
+		_, werr := os.Stdout.Write(data)
+		return werr
+	}
+	return os.WriteFile(outPath, data, 0o644) //nolint:gosec // profile artifact, not a secret
+}
+
+// writeMarkdown appends a GitHub-flavoured markdown table of the top-n
+// fan_factor fixtures plus a one-line corpus summary to mdPath (opened
+// in append mode so it can target $GITHUB_STEP_SUMMARY directly).
+func writeMarkdown(mdPath string, recs []profile.Record, n, total, nErr, nUnmeasured int, maxFan float64) error {
+	if n > len(recs) {
+		n = len(recs)
+	}
+	var b strings.Builder
+	fmt.Fprintf(&b, "## perf-profile (corpus fan-out)\n\n")
+	fmt.Fprintf(&b, "Profiled **%d** executable fixtures (%d with errors, %d unmeasured). Max fan_factor: **%.2f**.\n\n",
+		total, nErr, nUnmeasured, maxFan)
+	fmt.Fprintf(&b, "### top %d fixtures by fan_factor\n\n", n)
+	b.WriteString("| fixture | fan_factor | scan_rows | peak_intermediate | result_rows | cross_join | array_join | recursive_cte |\n")
+	b.WriteString("| --- | ---: | ---: | ---: | ---: | :---: | :---: | :---: |\n")
+	for i := 0; i < n; i++ {
+		r := recs[i]
+		fmt.Fprintf(&b, "| `%s` | %s | %d | %d | %d | %s | %s | %s |\n",
+			r.Fixture, fanFactorLabel(r.FanFactor), r.ScanRows, r.PeakIntermediate, r.ResultRows,
+			mdYesNo(r.HasCrossJoin), mdYesNo(r.HasArrayJoin), mdYesNo(r.HasRecursiveCTE))
+	}
+	b.WriteString("\n_fan_factor = peak intermediate cardinality / leaf scan rows. " +
+		"Fixtures are small golden seeds, so absolute counts are tiny; the ratio is the fan-out signal. " +
+		"`unmeasured` means the profiler could not see through every pipeline stage (a CTE reference or a " +
+		"recursive CTE step) — see [profile.Record.FanFactor]._\n\n")
+
+	f, err := os.OpenFile(mdPath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o644) //nolint:gosec // step-summary path
+	if err != nil {
+		return err
+	}
+	defer func() { _ = f.Close() }()
+	_, werr := f.WriteString(b.String())
+	return werr
+}
+
+// fanFactorLabel renders a nullable fan_factor for the human-facing
+// summary tables — nil (unmeasured) is spelled out rather than
+// collapsed to a fabricated number.
+func fanFactorLabel(f *float64) string {
+	if f == nil {
+		return "unmeasured"
+	}
+	return fmt.Sprintf("%.2f", *f)
+}
+
+func mdYesNo(v bool) string {
+	if v {
+		return "✓"
+	}
+	return ""
+}
+
+// printTopTable renders the top-n records (already sorted descending by
+// fan factor) as a fixed-width table to w. Used for the nightly
+// step-summary preview and local runs.
+func printTopTable(w *os.File, recs []profile.Record, n int) {
+	if n > len(recs) {
+		n = len(recs)
+	}
+	fmt.Fprintf(w, "\n=== top %d fixtures by fan_factor ===\n", n)
+	fmt.Fprintf(w, "%-48s %10s %12s %12s %6s %6s %6s\n",
+		"fixture", "fan_factor", "scan_rows", "peak_inter", "xjoin", "ajoin", "rcte")
+	for i := 0; i < n; i++ {
+		r := recs[i]
+		fmt.Fprintf(w, "%-48s %10s %12d %12d %6s %6s %6s\n",
+			truncate(r.Fixture, 48), fanFactorLabel(r.FanFactor), r.ScanRows, r.PeakIntermediate,
+			yesno(r.HasCrossJoin), yesno(r.HasArrayJoin), yesno(r.HasRecursiveCTE))
+	}
+}
+
+func truncate(s string, n int) string {
+	if len(s) <= n {
+		return s
+	}
+	if n <= 1 {
+		return s[:n]
+	}
+	return s[:n-1] + "…"
+}
+
+func yesno(b bool) string {
+	if b {
+		return "yes"
+	}
+	return "-"
+}

--- a/test/perf/profile/doc.go
+++ b/test/perf/profile/doc.go
@@ -1,0 +1,53 @@
+// Package profile is the corpus-wide perf profiler (Component B of the
+// perf-assessment framework).
+//
+// # Why this exists
+//
+// The Phase-1 perf audit (wf_a7e317b9) found that every perf bug
+// cerberus shipped was COMPUTE FAN-OUT: the table scan read a normal
+// number of rows, but an intermediate pipeline stage (a CROSS JOIN, an
+// ARRAY JOIN, a range-window cross product, a recursive-CTE closure)
+// exploded the row count between the scan and the final result, blowing
+// up peak memory. The existing reactive guards under test/perf/ each pin
+// ONE construct a human already found broken (range_lwr_scaling,
+// histogram_range_scaling, setop_chain_scaling, …). They share a style
+// but they only cover constructs someone remembered to register — a
+// fan-out in an unregistered construct sails through.
+//
+// This profiler closes that gap with corpus-wide BREADTH. It walks every
+// committed TXTAR fixture that is executable (declares `seed:` +
+// `expected_rows:` + `sql:`), and for each one measures the fan-out
+// signal directly in chDB:
+//
+//   - EXPLAIN PLAN actions=1 — detect the fan-out OPERATORS (CROSS JOIN,
+//     ARRAY JOIN, recursive CTE) structurally, before they run.
+//   - a per-subquery-level count() decomposition — peak INTERMEDIATE
+//     cardinality vs the leaf SCAN row count. fan_factor =
+//     peak_intermediate / scan_rows is the headline fan-out number.
+//   - the chDB native per-query stats (bytes_read as the peak-memory
+//     proxy; chDB's embedded engine does not expose query_log /
+//     peak_memory_usage, so bytes_read is the closest available signal).
+//
+// It emits one [Record] per fixture. The nightly perf-profile.yml lane
+// runs the whole corpus, uploads the JSON, and surfaces the highest
+// fan_factor fixtures in the step summary — so a newly-introduced fan-out
+// shows up as an outlier even in a construct no per-construct guard
+// covers.
+//
+// # chDB seam reuse
+//
+// Seeding + SQL rewriting go through the SAME pipeline the round-trip
+// assertion uses (test/spec.PrepareRoundTrip), so the SQL profiled here
+// is byte-identical to the SQL CI executes. The profiler does not invent
+// its own seed or its own now64/Map rewrites.
+//
+// # Build-tag split
+//
+// [Record], [LevelCount] and [SortByFanFactor] (record.go) carry NO
+// `//go:build chdb` tag: they are plain data plus a comparison, with no
+// chDB dependency, so anything that only needs to read/merge/rank
+// profiles someone else already collected — cmd/perf-profile's `-merge`
+// mode, in particular — can import this package without pulling in
+// libchdb.so. Everything that actually QUERIES chDB (profile.go,
+// corpus.go) stays tagged.
+package profile

--- a/test/perf/profile/profile.go
+++ b/test/perf/profile/profile.go
@@ -1,53 +1,13 @@
 //go:build chdb
 
-// Package profile is the corpus-wide perf profiler (Component B of the
-// perf-assessment framework).
-//
-// # Why this exists
-//
-// The Phase-1 perf audit (wf_a7e317b9) found that every perf bug
-// cerberus shipped was COMPUTE FAN-OUT: the table scan read a normal
-// number of rows, but an intermediate pipeline stage (a CROSS JOIN, an
-// ARRAY JOIN, a range-window cross product, a recursive-CTE closure)
-// exploded the row count between the scan and the final result, blowing
-// up peak memory. The existing reactive guards under test/perf/ each pin
-// ONE construct a human already found broken (range_lwr_scaling,
-// histogram_range_scaling, setop_chain_scaling, …). They share a style
-// but they only cover constructs someone remembered to register — a
-// fan-out in an unregistered construct sails through.
-//
-// This profiler closes that gap with corpus-wide BREADTH. It walks every
-// committed TXTAR fixture that is executable (declares `seed:` +
-// `expected_rows:` + `sql:`), and for each one measures the fan-out
-// signal directly in chDB:
-//
-//   - EXPLAIN PLAN actions=1 — detect the fan-out OPERATORS (CROSS JOIN,
-//     ARRAY JOIN, recursive CTE) structurally, before they run.
-//   - a per-subquery-level count() decomposition — peak INTERMEDIATE
-//     cardinality vs the leaf SCAN row count. fan_factor =
-//     peak_intermediate / scan_rows is the headline fan-out number.
-//   - the chDB native per-query stats (bytes_read as the peak-memory
-//     proxy; chDB's embedded engine does not expose query_log /
-//     peak_memory_usage, so bytes_read is the closest available signal).
-//
-// It emits one [Record] per fixture. The nightly perf-profile.yml lane
-// runs the whole corpus, uploads the JSON, and surfaces the highest
-// fan_factor fixtures in the step summary — so a newly-introduced fan-out
-// shows up as an outlier even in a construct no per-construct guard
-// covers.
-//
-// # chDB seam reuse
-//
-// Seeding + SQL rewriting go through the SAME pipeline the round-trip
-// assertion uses (test/spec.PrepareRoundTrip), so the SQL profiled here
-// is byte-identical to the SQL CI executes. The profiler does not invent
-// its own seed or its own now64/Map rewrites.
+// The package doc comment lives in doc.go, which carries no build tag so it
+// stays visible to `go doc` even when this file — the chDB-querying half of
+// the package — is excluded from the build.
 package profile
 
 import (
 	"encoding/json"
 	"fmt"
-	"sort"
 	"strings"
 
 	"github.com/tsouza/cerberus/internal/testsql"
@@ -56,104 +16,6 @@ import (
 
 	"github.com/tsouza/cerberus/test/spec"
 )
-
-// Record is the structured per-fixture profile emitted by [ProfileFixture].
-// One JSON object per executable fixture; the nightly lane collects them
-// into an array artifact and ranks by FanFactor.
-type Record struct {
-	// Fixture is the fixture identity as "<head>/<name>" (e.g.
-	// "promql/lwr_range_rate"), derived from the path relative to
-	// test/spec/.
-	Fixture string `json:"fixture"`
-
-	// ScanRows is the sum of the deepest (leaf) FROM-source subquery level
-	// in every scan pipeline — the rows actually read off the seeded tables
-	// before any fan-out stage. A UNION ALL contributes one leaf per arm.
-	// The fan-out denominator.
-	ScanRows int64 `json:"scan_rows"`
-
-	// PeakIntermediate is the maximum count() over every non-aggregating
-	// FROM-source subquery level, including the outer query. The fan-out
-	// numerator: the widest the row set gets anywhere in the pipeline.
-	PeakIntermediate int64 `json:"peak_intermediate"`
-
-	// FanFactor is PeakIntermediate / ScanRows (1.0 when nothing fans
-	// out; >1 when an intermediate stage widened the row set; 0 when
-	// ScanRows is 0 — an empty-seed or all-filtered fixture, where every
-	// level WAS measured and they all counted zero rows, a degenerate
-	// ratio rather than an opaque one). The headline number the nightly
-	// lane ranks on. nil (JSON null) — NEVER a fabricated 1.00 —
-	// whenever [UncountableLevels] is nonzero: at least one pipeline
-	// stage was opaque to the per-level count() decomposition (a CTE
-	// reference, a pre-rendered subquery splice, or a RECURSIVE CTE
-	// step), so PeakIntermediate does not actually reflect the widest
-	// the row set gets anywhere in the pipeline. A 1.00 in that state
-	// reads as "no fan-out" on exactly the shapes most likely to hide
-	// one — see issue #1519, where emitSetOperation's `&&` CTE arms
-	// measured fan_factor=1.00 while costing 4 leaf reads.
-	FanFactor *float64 `json:"fan_factor"`
-
-	// UncountableLevels is the number of pipeline stages the profiler
-	// could not see through: a WITH-prefixed subquery (CTE reference /
-	// pre-rendered subquery splice) the leftmost-descent decomposition
-	// refused to enter because its body's names are only in scope at its
-	// own level, a RECURSIVE CTE step (detected structurally via EXPLAIN
-	// PLAN, wherever in the plan it sits), or a level whose isolated
-	// count() outright failed. Nonzero forces [FanFactor] to nil — see
-	// that field's doc. Zero means every level the decomposition visited
-	// was measured, so FanFactor (when ScanRows > 0) is trustworthy.
-	UncountableLevels int `json:"uncountable_levels"`
-
-	// UncountableReasons is one human-readable line per event counted in
-	// UncountableLevels, naming the depth (where applicable) and why it
-	// was opaque. Kept for debugging an unmeasured fixture — parallel to
-	// Levels but for the stages excluded from it.
-	UncountableReasons []string `json:"uncountable_reasons,omitempty"`
-
-	// ResultRows is count() of the full outer query — the rows the
-	// fixture's SQL ultimately returns.
-	ResultRows int64 `json:"result_rows"`
-
-	// HasCrossJoin / HasArrayJoin / HasRecursiveCTE are structural flags
-	// read off EXPLAIN PLAN actions=1. A CROSS JOIN or ARRAY JOIN over a
-	// non-trivial scan is the classic fan-out shape; a recursive CTE is
-	// the structural-recursion shape the cycle guards pin.
-	HasCrossJoin    bool `json:"has_cross_join"`
-	HasArrayJoin    bool `json:"has_array_join"`
-	HasRecursiveCTE bool `json:"has_recursive_cte"`
-
-	// MaxRecursionDepth is a lower-bound estimate of the recursive-CTE
-	// expansion: when the plan carries a recursive CTE, it is the
-	// result-row count of the recursive level (the closure size). 0 when
-	// the query has no recursive CTE.
-	MaxRecursionDepth int64 `json:"max_recursion_depth"`
-
-	// PeakBytesRead is the chDB native bytes_read stat for the full
-	// query — the peak-memory proxy. chDB's embedded engine exposes
-	// neither system.query_log nor peak_memory_usage through any driver
-	// surface, so bytes_read (the volume the engine pulled through the
-	// pipeline) stands in for peak memory. Larger = more memory pressure.
-	PeakBytesRead uint64 `json:"peak_bytes_read"`
-
-	// Levels is the per-subquery-level count() decomposition, deepest
-	// first. Kept for debugging an outlier: it shows exactly which
-	// pipeline stage widened the row set.
-	Levels []LevelCount `json:"levels,omitempty"`
-
-	// Err, when non-empty, records why the fixture could not be fully
-	// profiled (seed failure, unrunnable SQL). The fixture still emits a
-	// Record so the nightly lane can surface profiling gaps rather than
-	// silently dropping them.
-	Err string `json:"err,omitempty"`
-}
-
-// LevelCount is the count() of one FROM-source subquery level. Depth 0 is
-// the outermost query; higher depth is deeper nesting (closer to the
-// leaf scan).
-type LevelCount struct {
-	Depth int   `json:"depth"`
-	Count int64 `json:"count"`
-}
 
 // Profiler holds a chDB session shared across fixtures. The session is a
 // process-global singleton in chdb-go, so the profiler seeds each
@@ -382,26 +244,4 @@ func parseSingleCount(jsonBody string) (int64, error) {
 		return n, nil
 	}
 	return 0, nil
-}
-
-// SortByFanFactor orders records descending by FanFactor (then by
-// PeakIntermediate, then fixture name) so the nightly step-summary lists
-// the worst fan-outs first. A nil FanFactor (unmeasured — see that
-// field's doc) sorts before every measured value: an unknown fan-out is
-// at least as much of a risk signal as a known-bad one, so it must not
-// silently sink to the bottom of the list.
-func SortByFanFactor(recs []Record) {
-	sort.Slice(recs, func(i, j int) bool {
-		fi, fj := recs[i].FanFactor, recs[j].FanFactor
-		if (fi == nil) != (fj == nil) {
-			return fi == nil
-		}
-		if fi != nil && fj != nil && *fi != *fj {
-			return *fi > *fj
-		}
-		if recs[i].PeakIntermediate != recs[j].PeakIntermediate {
-			return recs[i].PeakIntermediate > recs[j].PeakIntermediate
-		}
-		return recs[i].Fixture < recs[j].Fixture
-	})
 }

--- a/test/perf/profile/record.go
+++ b/test/perf/profile/record.go
@@ -1,0 +1,130 @@
+// Deliberately NOT `//go:build chdb`. Record, LevelCount and SortByFanFactor
+// are plain data plus a comparison — nothing here opens a chDB session or
+// runs a query, unlike the rest of this package (profile.go, corpus.go). See
+// the "Build-tag split" section of doc.go for why that matters: it lets a
+// consumer that only merges/ranks profiles someone else already collected
+// (cmd/perf-profile's `-merge` mode) import this package without pulling in
+// libchdb.so.
+package profile
+
+import "sort"
+
+// Record is the structured per-fixture profile emitted by [ProfileFixture].
+// One JSON object per executable fixture; the nightly lane collects them
+// into an array artifact and ranks by FanFactor.
+type Record struct {
+	// Fixture is the fixture identity as "<head>/<name>" (e.g.
+	// "promql/lwr_range_rate"), derived from the path relative to
+	// test/spec/.
+	Fixture string `json:"fixture"`
+
+	// ScanRows is the sum of the deepest (leaf) FROM-source subquery level
+	// in every scan pipeline — the rows actually read off the seeded tables
+	// before any fan-out stage. A UNION ALL contributes one leaf per arm.
+	// The fan-out denominator.
+	ScanRows int64 `json:"scan_rows"`
+
+	// PeakIntermediate is the maximum count() over every non-aggregating
+	// FROM-source subquery level, including the outer query. The fan-out
+	// numerator: the widest the row set gets anywhere in the pipeline.
+	PeakIntermediate int64 `json:"peak_intermediate"`
+
+	// FanFactor is PeakIntermediate / ScanRows (1.0 when nothing fans
+	// out; >1 when an intermediate stage widened the row set; 0 when
+	// ScanRows is 0 — an empty-seed or all-filtered fixture, where every
+	// level WAS measured and they all counted zero rows, a degenerate
+	// ratio rather than an opaque one). The headline number the nightly
+	// lane ranks on. nil (JSON null) — NEVER a fabricated 1.00 —
+	// whenever [UncountableLevels] is nonzero: at least one pipeline
+	// stage was opaque to the per-level count() decomposition (a CTE
+	// reference, a pre-rendered subquery splice, or a RECURSIVE CTE
+	// step), so PeakIntermediate does not actually reflect the widest
+	// the row set gets anywhere in the pipeline. A 1.00 in that state
+	// reads as "no fan-out" on exactly the shapes most likely to hide
+	// one — see issue #1519, where emitSetOperation's `&&` CTE arms
+	// measured fan_factor=1.00 while costing 4 leaf reads.
+	FanFactor *float64 `json:"fan_factor"`
+
+	// UncountableLevels is the number of pipeline stages the profiler
+	// could not see through: a WITH-prefixed subquery (CTE reference /
+	// pre-rendered subquery splice) the leftmost-descent decomposition
+	// refused to enter because its body's names are only in scope at its
+	// own level, a RECURSIVE CTE step (detected structurally via EXPLAIN
+	// PLAN, wherever in the plan it sits), or a level whose isolated
+	// count() outright failed. Nonzero forces [FanFactor] to nil — see
+	// that field's doc. Zero means every level the decomposition visited
+	// was measured, so FanFactor (when ScanRows > 0) is trustworthy.
+	UncountableLevels int `json:"uncountable_levels"`
+
+	// UncountableReasons is one human-readable line per event counted in
+	// UncountableLevels, naming the depth (where applicable) and why it
+	// was opaque. Kept for debugging an unmeasured fixture — parallel to
+	// Levels but for the stages excluded from it.
+	UncountableReasons []string `json:"uncountable_reasons,omitempty"`
+
+	// ResultRows is count() of the full outer query — the rows the
+	// fixture's SQL ultimately returns.
+	ResultRows int64 `json:"result_rows"`
+
+	// HasCrossJoin / HasArrayJoin / HasRecursiveCTE are structural flags
+	// read off EXPLAIN PLAN actions=1. A CROSS JOIN or ARRAY JOIN over a
+	// non-trivial scan is the classic fan-out shape; a recursive CTE is
+	// the structural-recursion shape the cycle guards pin.
+	HasCrossJoin    bool `json:"has_cross_join"`
+	HasArrayJoin    bool `json:"has_array_join"`
+	HasRecursiveCTE bool `json:"has_recursive_cte"`
+
+	// MaxRecursionDepth is a lower-bound estimate of the recursive-CTE
+	// expansion: when the plan carries a recursive CTE, it is the
+	// result-row count of the recursive level (the closure size). 0 when
+	// the query has no recursive CTE.
+	MaxRecursionDepth int64 `json:"max_recursion_depth"`
+
+	// PeakBytesRead is the chDB native bytes_read stat for the full
+	// query — the peak-memory proxy. chDB's embedded engine exposes
+	// neither system.query_log nor peak_memory_usage through any driver
+	// surface, so bytes_read (the volume the engine pulled through the
+	// pipeline) stands in for peak memory. Larger = more memory pressure.
+	PeakBytesRead uint64 `json:"peak_bytes_read"`
+
+	// Levels is the per-subquery-level count() decomposition, deepest
+	// first. Kept for debugging an outlier: it shows exactly which
+	// pipeline stage widened the row set.
+	Levels []LevelCount `json:"levels,omitempty"`
+
+	// Err, when non-empty, records why the fixture could not be fully
+	// profiled (seed failure, unrunnable SQL). The fixture still emits a
+	// Record so the nightly lane can surface profiling gaps rather than
+	// silently dropping them.
+	Err string `json:"err,omitempty"`
+}
+
+// LevelCount is the count() of one FROM-source subquery level. Depth 0 is
+// the outermost query; higher depth is deeper nesting (closer to the
+// leaf scan).
+type LevelCount struct {
+	Depth int   `json:"depth"`
+	Count int64 `json:"count"`
+}
+
+// SortByFanFactor orders records descending by FanFactor (then by
+// PeakIntermediate, then fixture name) so the nightly step-summary lists
+// the worst fan-outs first. A nil FanFactor (unmeasured — see that
+// field's doc) sorts before every measured value: an unknown fan-out is
+// at least as much of a risk signal as a known-bad one, so it must not
+// silently sink to the bottom of the list.
+func SortByFanFactor(recs []Record) {
+	sort.Slice(recs, func(i, j int) bool {
+		fi, fj := recs[i].FanFactor, recs[j].FanFactor
+		if (fi == nil) != (fj == nil) {
+			return fi == nil
+		}
+		if fi != nil && fj != nil && *fi != *fj {
+			return *fi > *fj
+		}
+		if recs[i].PeakIntermediate != recs[j].PeakIntermediate {
+			return recs[i].PeakIntermediate > recs[j].PeakIntermediate
+		}
+		return recs[i].Fixture < recs[j].Fixture
+	})
+}

--- a/test/perf/profile/shard_test.go
+++ b/test/perf/profile/shard_test.go
@@ -21,10 +21,15 @@ import (
 // than against synthetic ids that would balance by construction.
 const corpusRosterDir = "../cardinality-baseline"
 
-// productionShardCount is the number of legs `perf-guards-shard` fans out to in
-// .github/workflows/chdb.yml. The balance assertion below is only meaningful at
-// the count CI actually runs, and test/regression/perf_guards_gate_test.go pins
-// the workflow to the same number from the other side.
+// productionShardCount is the number of legs BOTH sharded CI consumers of this
+// package's partition fan out to: `perf-guards-shard` in
+// .github/workflows/chdb.yml (the pass/fail cardinality ratchet), and
+// `profile-shard` in .github/workflows/perf-profile.yml (the breadth report,
+// tsouza/cerberus#2375). They share one partition function (ShardOf) and one
+// corpus, so one count serves both. The balance assertion below is only
+// meaningful at the count CI actually runs, and
+// test/regression/perf_guards_gate_test.go + perf_profile_gate_test.go each
+// pin their own workflow to this same number from the other side.
 const productionShardCount = 8
 
 // maxShardImbalance is how far the biggest shard may exceed the smallest, as a

--- a/test/regression/perf_profile_gate_test.go
+++ b/test/regression/perf_profile_gate_test.go
@@ -1,0 +1,233 @@
+package regression
+
+import (
+	"fmt"
+	"sort"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+// The corpus-wide fan-out profiler (test/perf/profile, Component B of the
+// perf-assessment framework) only reaches release.yml's RELEASE_REQUIRED_CHECKS
+// through a chain of links, and every one of them lives outside the Go package
+// the profiler is written in:
+//
+//	cmd/perf-profile  ->  perf-profile.yml `profile-shard` (the matrix)
+//	                  ->  perf-profile.yml `profile` (the aggregator)
+//	                  ->  release.yml RELEASE_REQUIRED_CHECKS
+//
+// Break any link and the lane keeps existing, keeps reporting a green
+// `profile` check — release.yml resolves that name by exact text — and stops
+// meaning anything. This is the same failure shape
+// test/regression/perf_guards_gate_test.go pins for chdb.yml's
+// `perf-guards-shard` / `perf-guards` (#2002): both lanes shard the SAME
+// corpus through the SAME partition (test/perf/profile.ProfileCorpusShard /
+// ShardOf), so the same class of silent breakage applies to both, and
+// tsouza/cerberus#2375 is why this one was sharded too — 9 of 11 recent
+// non-PR runs of the old single-job lane were killed by their own timeout as
+// the corpus grew past what a serial walk could finish in budget.
+//
+// What this file pins, everything a PR diff CAN break:
+//
+//   - the JOB NAME release.yml's RELEASE_REQUIRED_CHECKS refers to. Rename
+//     the aggregator and the required context is never posted again;
+//   - the AGGREGATOR's dependency on the matrix. A `profile` that stopped
+//     `needs:`-ing `profile-shard` would report green in seconds over a
+//     matrix that failed or never ran — the hollow-green shape;
+//   - the AGGREGATOR's verdict script. `needs:` alone does not gate: a
+//     matrix rolls up to one `.result` and something has to actually read
+//     it, including telling an ordinary-PR skip apart from a heavy run
+//     whose matrix crashed before dispatching;
+//   - the SHARD WIRING. The partition divides by PERF_SHARD_COUNT, so a
+//     count that disagrees with the number of legs actually dispatched
+//     leaves part of the corpus profiled by no leg, with every leg still
+//     green;
+//   - `continue-on-error`, which turns a job into decoration while keeping
+//     its name and its logs;
+//   - the shard job still building cmd/perf-profile with the `chdb` tag
+//     against the full `test/spec` corpus, rather than a narrowed/no-op
+//     invocation that would leave the required check green over nothing;
+//   - membership in release.yml's RELEASE_REQUIRED_CHECKS, so a publish
+//     waits on the same lane a release PR does. release.yml has no
+//     `pull_request:` trigger for ordinary PRs, so nothing else checks that
+//     at PR time.
+const (
+	perfProfileWorkflowPath = "../../.github/workflows/perf-profile.yml"
+
+	// The aggregator job branch protection / release.yml names, and the
+	// matrix job that does the profiling. Both strings some other system
+	// resolves by exact text.
+	perfProfileJob      = "profile"
+	perfProfileShardJob = "profile-shard"
+
+	// The aggregator's verdict script. Without it the job is an empty green.
+	perfProfileAggregateScript = "perf-profile-aggregate.mjs"
+
+	// The shard contract, spelled exactly as the workflow must spell it —
+	// identical to perfGuards*'s, since both matrices derive PERF_SHARD_COUNT
+	// from `strategy.job-total` for the same reason: it cannot drift from the
+	// `shard:` list that way.
+	perfProfileShardIndexExpr = "PERF_SHARD_INDEX: ${{ matrix.shard }}"
+	perfProfileShardCountExpr = "PERF_SHARD_COUNT: ${{ strategy.job-total }}"
+
+	// What the shard job must still invoke: the chdb-tagged binary, over the
+	// whole corpus. A recipe/invocation narrowed to a `-run`-style filter or a
+	// smaller `-spec` would leave the required check green while profiling
+	// less than the full corpus.
+	perfProfileChdbTag  = "-tags chdb"
+	perfProfileSpecFlag = "-spec test/spec"
+)
+
+// TestPerfProfileLaneRunsTheProfiler pins the in-repo links: the matrix job
+// that actually profiles, and the aggregator that lends the whole thing the
+// name release.yml resolves.
+func TestPerfProfileLaneRunsTheProfiler(t *testing.T) {
+	t.Parallel()
+
+	workflow := readFileString(t, perfProfileWorkflowPath)
+	shardJob := workflowJobBody(t, workflow, perfProfileShardJob)
+	aggregate := workflowJobBody(t, workflow, perfProfileJob)
+
+	for _, want := range []string{perfProfileChdbTag, perfProfileSpecFlag} {
+		if !strings.Contains(shardJob, want) {
+			t.Errorf("%s job %q no longer contains %q — the shard job may have stopped profiling the "+
+				"chdb-tagged binary over the whole corpus. Body:\n%s",
+				perfProfileWorkflowPath, perfProfileShardJob, want, shardJob)
+		}
+	}
+
+	for _, job := range []struct{ name, body string }{
+		{perfProfileShardJob, shardJob},
+		{perfProfileJob, aggregate},
+	} {
+		if strings.Contains(job.body, continueOnError) {
+			t.Errorf("%s job %q sets %s — it keeps its name and its logs and loses its verdict, which is "+
+				"strictly worse than not gating at all because the required check now reports green over "+
+				"a lane that did not actually profile anything.",
+				perfProfileWorkflowPath, job.name, continueOnError)
+		}
+	}
+
+	// Read the `needs:` LINE, not the job body: the body also mentions
+	// `needs.profile-shard.result` inside the aggregate script's step env, so
+	// a plain substring search over the whole body stays green after the
+	// dependency edge itself is removed — the exact edit that turns the gate
+	// off.
+	needsLine := needsDeclarationRe.FindStringSubmatch(aggregate)
+	if needsLine == nil || !strings.Contains(needsLine[1], perfProfileShardJob) {
+		declared := "(none)"
+		if needsLine != nil {
+			declared = needsLine[1]
+		}
+		t.Errorf("%s job %q declares `needs: %s`, which does not include %q. It is the job that posts "+
+			"the required context, and without that edge it reports green in seconds no matter what the "+
+			"shard matrix did.",
+			perfProfileWorkflowPath, perfProfileJob, declared, perfProfileShardJob)
+	}
+	if !strings.Contains(aggregate, perfProfileAggregateScript) {
+		t.Errorf("%s job %q no longer runs %s. `needs:` alone does not gate: a matrix rolls up to one "+
+			"result and the aggregate must actually read it — including telling an ordinary-PR skip apart "+
+			"from a heavy run whose matrix never dispatched. Body:\n%s",
+			perfProfileWorkflowPath, perfProfileJob, perfProfileAggregateScript, aggregate)
+	}
+
+	for _, want := range []string{perfProfileShardIndexExpr, perfProfileShardCountExpr} {
+		if !strings.Contains(shardJob, want) {
+			t.Errorf("%s job %q does not wire `%s`. PERF_SHARD_COUNT must come from `strategy.job-total` "+
+				"(the number of legs that actually run), never a repeated literal: a count left behind "+
+				"after the `shard:` list changed leaves part of the corpus profiled by no leg, and every "+
+				"leg still reports green. Body:\n%s",
+				perfProfileWorkflowPath, perfProfileShardJob, want, shardJob)
+		}
+	}
+}
+
+// TestPerfProfileShardMatrixCoversEverySlice pins the shape of the
+// profile-shard matrix against the SAME productionShardCount
+// test/perf/profile/shard_test.go asserts the partition's balance at — the
+// partition function (and the corpus it partitions) is shared with
+// `perf-guards-shard`, so one constant serves both lanes' pins. Let the
+// matrix's leg count and that constant drift and the balance properties are
+// still proven, just about a partition this lane does not run.
+//
+// Reuses shardMatrixListRe / productionShardCountRe from
+// perf_guards_gate_test.go: same file shape, same regexes, same package.
+func TestPerfProfileShardMatrixCoversEverySlice(t *testing.T) {
+	t.Parallel()
+
+	shardJob := workflowJobBody(t, readFileString(t, perfProfileWorkflowPath), perfProfileShardJob)
+
+	list := shardMatrixListRe.FindStringSubmatch(shardJob)
+	if list == nil {
+		t.Fatalf("%s job %q declares no `shard: [...]` matrix list. The lane is sharded precisely "+
+			"because one process cannot finish it in budget (tsouza/cerberus#2375); a matrix that "+
+			"stopped fanning out is the old serial lane back, under a name that says otherwise. "+
+			"Body:\n%s", perfProfileWorkflowPath, perfProfileShardJob, shardJob)
+	}
+
+	var legs []int
+	for _, field := range strings.Split(list[1], ",") {
+		field = strings.TrimSpace(field)
+		if field == "" {
+			continue
+		}
+		n, err := strconv.Atoi(field)
+		if err != nil {
+			t.Fatalf("%s job %q has a non-integer shard %q in `shard: [%s]`",
+				perfProfileWorkflowPath, perfProfileShardJob, field, list[1])
+		}
+		legs = append(legs, n)
+	}
+
+	sort.Ints(legs)
+	want := make([]int, 0, len(legs))
+	for i := range legs {
+		want = append(want, i+1)
+	}
+	if fmt.Sprint(legs) != fmt.Sprint(want) {
+		t.Errorf("%s job %q declares shards %v, which is not the contiguous 1..%d PERF_SHARD_INDEX "+
+			"needs. The count the partition divides by is `strategy.job-total` = %d, so an index "+
+			"outside [1, %d] owns a slice that does not exist and some slice that does exist is owned "+
+			"by nobody — with every leg green.",
+			perfProfileWorkflowPath, perfProfileShardJob, legs, len(legs), len(legs), len(legs))
+	}
+
+	partitionTest := readFileString(t, shardPartitionTestPath)
+	declared := productionShardCountRe.FindStringSubmatch(partitionTest)
+	if declared == nil {
+		t.Fatalf("%s declares no `const productionShardCount` — the partition's balance and coverage "+
+			"assertions no longer say which shard count they hold at", shardPartitionTestPath)
+	}
+	asserted, err := strconv.Atoi(declared[1])
+	if err != nil {
+		t.Fatalf("%s productionShardCount = %q is not an integer", shardPartitionTestPath, declared[1])
+	}
+	if asserted != len(legs) {
+		t.Errorf("%s dispatches %d profile-shard legs but %s asserts the shared partition's coverage, "+
+			"disjointness and balance at %d. Those properties then hold for a partition this lane does "+
+			"not run at the count it actually runs.",
+			perfProfileWorkflowPath, len(legs), shardPartitionTestPath, asserted)
+	}
+}
+
+// TestReleasePreflightRequiresThePerfProfileLane pins the release half: a
+// lane every PR must pass conditionally (release/* PRs) is not automatically
+// a lane every publish waits for.
+func TestReleasePreflightRequiresThePerfProfileLane(t *testing.T) {
+	t.Parallel()
+
+	job := workflowJobBody(t, readFileString(t, releaseWorkflowPath), preflightJob)
+	required := requiredChecksFromPreflight(t, job)
+
+	for _, name := range required {
+		if name == perfProfileJob {
+			return
+		}
+	}
+	t.Errorf("%s job %q does not require %q (required set: %q). The preflight is observation-derived "+
+		"for everything outside that set, so a lane that never ran contributes zero problems and the "+
+		"release publishes on a silence. release-gate-drift.yml reports the same gap from the other "+
+		"side on a schedule; this fails at PR time instead.",
+		releaseWorkflowPath, preflightJob, perfProfileJob, required)
+}


### PR DESCRIPTION
## Summary

`perf-profile.yml`'s "Profile corpus fan-out" step walked every executable
TXTAR fixture under `test/spec/**` serially in one job. As the corpus grew,
9 of the 11 most recent non-PR runs before a stopgap timeout doubling
(30m → 60m, already on `main`) were killed by the job's own timeout with no
error of their own — a capacity problem, not a flake (#2375). This PR is the
durable fix the issue calls for: shard the walk across a CI matrix instead of
re-doubling the timeout.

- Splits the single `profile` job into an 8-leg `profile-shard` matrix (each
  leg profiling one disjoint corpus slice via `PERF_SHARD_INDEX` /
  `PERF_SHARD_COUNT`) plus a `profile` aggregator that merges the legs' JSON
  back into the same single combined report + step-summary table the lane
  always produced. `profile` keeps its exact name because `release.yml`'s
  `RELEASE_REQUIRED_CHECKS` resolves it by text.
- Reuses the corpus partition `perf-guards-shard` in `chdb.yml` already
  applies to this *exact* walk (`test/perf/profile.ProfileCorpusShard`, same
  corpus, same `ShardOf` hash) — same shard count (8), same
  `strategy.job-total`-derived `PERF_SHARD_COUNT` (never a repeated literal),
  same fail-fast:false rationale, same aggregator-over-per-shard-required-
  contexts reasoning. `.github/scripts/perf-profile-aggregate.mjs` mirrors
  `perf-guards-aggregate.mjs`'s roll-up shape.
- `cmd/perf-profile` gained a `-merge` mode (`cmd/perf-profile/report.go`,
  untagged) that folds N shard JSON files into one report and never touches
  chDB — so the aggregator job needs neither `just chdb-install` nor the
  `chdb` build tag. `profile.Record` / `LevelCount` / `SortByFanFactor` moved
  out of the `//go:build chdb` file into a new untagged
  `test/perf/profile/record.go` to make that possible.
- `test/regression/perf_profile_gate_test.go` pins the new wiring (job
  rename, `needs:` edge, `continue-on-error`, shard-count/`strategy.job-total`
  agreement, `RELEASE_REQUIRED_CHECKS` membership) the same way
  `perf_guards_gate_test.go` already pins `chdb.yml`'s lane, and
  `.github/ci-lanes.json`'s `performance.profile` entry now lists both jobs
  with `profile-shard` as the declared producer.

## Shard count

8 legs, matching `perf-guards-shard`'s count for the same corpus and the same
profiling code path (`TestCardinalityRatchet` also calls
`ProfileCorpusShard`). The corpus held 963 executable fixtures at the time of
writing; the unsharded walk measured 22m21s–28m58s at the job level on an
isolated GH runner (from #2375's own data). That puts each leg's raw
profiling work at roughly 3–4 minutes on CI-grade hardware — comfortably
inside the 20-minute per-leg timeout, itself far inside the 60-minute ceiling
the old serial job needed. `test/perf/profile/shard_test.go`'s
`productionShardCount` constant is shared by both lanes' pins, so a future
recount only has to move in one place.

## Verification

- **By code inspection / local execution** (this is a `RUN_HEAVY`
  push/schedule/dispatch/release-PR-only lane — an ordinary PR reports a
  no-op green in seconds, so the sharded walk itself cannot be exercised by
  *this* PR's own CI):
  - `go build` / `go vet`, both with and without `-tags chdb`, over the
    whole tree — clean.
  - `go test -tags chdb ./test/perf/profile/...` — all existing tests pass
    unchanged after the `Record`/`LevelCount`/`SortByFanFactor` split.
  - Ran the sharded chdb-tagged binary locally against the real
    `test/spec` corpus with `PERF_SHARD_INDEX`/`PERF_SHARD_COUNT` set
    (1/40 and 1/8 slices) — profiled the expected fixture subset and
    produced valid JSON.
  - Exercised `-merge` end-to-end with synthetic shard JSON: correct
    fan-factor sort, correct combined step-summary markdown, and both
    guard-rail failure paths (`-expect-shards` mismatch, a fixture ID
    duplicated across two shard files) fail loudly as designed.
  - `node --test .github/scripts/perf-profile-aggregate.test.mjs` and the
    full `test/regression` package — green.
  - `actionlint` on the changed workflows — clean.
- **Not verified live in this PR**: an actual sharded `perf-profile.yml` CI
  run (needs a push/schedule/dispatch trigger on `main`, or manual
  `workflow_dispatch` after merge, since the lane doesn't run on an ordinary
  PR) proving the real wall-clock win. Happy to dispatch it manually once
  this merges if that evidence is wanted before considering the issue fully
  closed.

Closes #2375
