### PR TITLE
test(property): reach range × label_replace compositions in the PromQL generator

### DIFF
--- a/test/property/gen/promql.go
+++ b/test/property/gen/promql.go
@@ -70,7 +70,7 @@ func drawPromQLQuery(t *rapid.T, d property.Dataset, shapeID ShapeID) property.Q
 	matchers := drawMatchers(t, name, d.Metrics)
 	groupLabels := mapKeys(d.Metrics.LabelsPresentFor(name))
 
-	expr := drawExpr(t, name, matchers, groupLabels, shapeID)
+	expr := drawExpr(t, name, matchers, groupLabels, shapeID, maxComposableWrapDepth)
 
 	// EvalTs: pick a timestamp AFTER every dataset sample but
 	// well within the 5-minute LookbackDelta (Prom's default,
@@ -90,8 +90,36 @@ func drawPromQLQuery(t *rapid.T, d property.Dataset, shapeID ShapeID) property.Q
 	}
 }
 
-// drawExpr picks the random expression shape per the PR 2 accept-set.
-// Each draw is uniform over the candidate shapes; the breakdown:
+// maxComposableWrapDepth bounds how many composable wrapper shapes (today
+// just promQLLabelReplaceShape / promQLRangeLabelReplaceShape) drawExpr and
+// drawRangeExpr may nest before they must fall back to drawing a base
+// (non-wrapping) shape. The generator has exactly one wrapper case today, so
+// a single unit of budget already guarantees termination on its own; the
+// constant exists — and is threaded through as an explicit parameter rather
+// than left implicit — so a second wrapper shape added later inherits the
+// same bound instead of the recursion silently becoming unbounded (and, with
+// it, the per-iteration generated-expression size and rapid draw count
+// blowing up).
+const maxComposableWrapDepth = 1
+
+// promQLBaseShapeRoster is the non-wrapping subset of promQLShapeRoster
+// (gen/shapes.go): every shape drawLabelReplaceWrap may pick as the inner
+// expression it wraps in label_replace(...). Kept as its own slice, rather
+// than filtering promQLShapeRoster at call time, so "these are the shapes a
+// wrapper can wrap" is visible at a glance and a future wrapper shape isn't
+// forgotten from the exclusion the way a filter predicate could silently
+// miss it.
+var promQLBaseShapeRoster = []ShapeID{
+	promQLSelectorShape,
+	promQLSumShape,
+	promQLSumByShape,
+	promQLRateShape,
+	promQLSumRateShape,
+}
+
+// drawExpr picks the random expression shape per the PR 2 accept-set, plus
+// the composable label_replace wrapper added for #2383. Each draw is uniform
+// over the candidate shapes; the breakdown:
 //
 //   - bare vector selector             — exercises the LWR rule
 //   - sum(selector)                    — exercises aggregation + LWR
@@ -101,15 +129,27 @@ func drawPromQLQuery(t *rapid.T, d property.Dataset, shapeID ShapeID) property.Q
 //     (positive, zero, and negative) so the offset output-timestamp labeling
 //     is exercised against the oracle, not just window membership.
 //   - sum(rate(selector[60s] offset <d>)) — exercises composition + offset
+//   - label_replace(<any of the above>, ...) — exercises compositionality:
+//     an arbitrary already-generated expression wrapped in another
+//     construct, the exact "guard × aggregation" shape #2383 documents
+//     (`label_replace(sum by (uri)(rate(X[5m])), ...)`) was unreachable
+//     without.
 //
 // Aggregations strip __name__; the bare selector keeps it. Both
 // shapes are valid Prom queries.
+//
+// wrapBudget is the remaining [maxComposableWrapDepth] budget: drawExpr
+// decrements it by one on every wrapper draw and panics rather than
+// recursing once it's exhausted, so a generator defect that somehow routed a
+// wrapper shape into its own inner-shape pool fails loudly instead of
+// looping.
 func drawExpr(
 	t *rapid.T,
 	name string,
 	matchers []*labels.Matcher,
 	groupLabels []string,
 	shapeID ShapeID,
+	wrapBudget int,
 ) parser.Expr {
 	sel := &parser.VectorSelector{Name: name, LabelMatchers: matchers}
 	switch shapeID {
@@ -136,8 +176,62 @@ func drawExpr(
 				Args: []parser.Expr{drawRangeSelector(t, name, matchers)},
 			},
 		}
+	case promQLLabelReplaceShape:
+		if wrapBudget <= 0 {
+			panic("gen/promql: label-replace shape exceeded maxComposableWrapDepth")
+		}
+		innerShape := rapid.SampledFrom(promQLBaseShapeRoster).Draw(t, "labelReplaceInnerShape")
+		inner := drawExpr(t, name, matchers, groupLabels, innerShape, wrapBudget-1)
+		return drawLabelReplaceWrap(t, inner, groupLabels)
 	}
 	panic("gen/promql: unhandled shape " + string(shapeID))
+}
+
+// labelReplaceWrap is one (dst, replacement, regex) trio drawLabelReplaceWrap
+// draws from. Both entries in labelReplaceWrapPool are pure copy-or-tag
+// rewrites — neither depends on the source value's content beyond whether it
+// is empty — so every draw is guaranteed to produce a valid, deterministic
+// label_replace call regardless of which src label ends up selected.
+type labelReplaceWrap struct {
+	dst, replacement, regex string
+}
+
+// labelReplaceWrapPool covers both branches evalLabelReplace
+// (test/property/oracle/promql/label_transform.go) implements: a regex that
+// matches any non-empty value and copies it verbatim to dst (the exact
+// "endpoint" rename shape from #2383's own reproducer,
+// `label_replace(sum by (uri)(rate(X[5m])), "endpoint", "$1", "uri",
+// "(.+)")`), and a regex that matches only an ABSENT src label, tagging dst
+// with a fixed sentinel — exercising label_replace's pass-through path when
+// the wrapped inner expression's shape drops the src label entirely (e.g.
+// promQLSumShape, which strips every label).
+var labelReplaceWrapPool = []labelReplaceWrap{
+	{dst: "endpoint", replacement: "$1", regex: "(.+)"},
+	{dst: "region_missing", replacement: "unknown", regex: "^$"},
+}
+
+// drawLabelReplaceWrap wraps inner in label_replace(inner, dst, replacement,
+// src, regex). src is drawn from groupLabels when the metric has any
+// observed labels (so the "copy an existing label" branch has real data to
+// match); when the metric carries none, src falls back to "__name__" — a
+// label every selector-derived series always carries — so the wrap never
+// panics on an empty label pool the way promQLSumByShape's inner draw would.
+func drawLabelReplaceWrap(t *rapid.T, inner parser.Expr, groupLabels []string) parser.Expr {
+	src := "__name__"
+	if len(groupLabels) > 0 {
+		src = rapid.SampledFrom(groupLabels).Draw(t, "labelReplaceSrc")
+	}
+	wrap := rapid.SampledFrom(labelReplaceWrapPool).Draw(t, "labelReplaceWrap")
+	return &parser.Call{
+		Func: parser.Functions["label_replace"],
+		Args: parser.Expressions{
+			inner,
+			&parser.StringLiteral{Val: wrap.dst},
+			&parser.StringLiteral{Val: wrap.replacement},
+			&parser.StringLiteral{Val: src},
+			&parser.StringLiteral{Val: wrap.regex},
+		},
+	}
 }
 
 // rangeSelectorWindow is the fixed `[range]` span attached to every

--- a/test/property/gen/promql_range.go
+++ b/test/property/gen/promql_range.go
@@ -94,7 +94,7 @@ func drawPromQLRangeQuery(t *rapid.T, d property.Dataset, shapeID ShapeID) Range
 	name := rapid.SampledFrom(names).Draw(t, "metric")
 	matchers := drawMatchers(t, name, d.Metrics)
 	groupLabels := mapKeys(d.Metrics.LabelsPresentFor(name))
-	expr := drawRangeExpr(t, name, matchers, groupLabels, shapeID)
+	expr := drawRangeExpr(t, name, matchers, groupLabels, shapeID, maxComposableWrapDepth)
 
 	startOffset := rapid.SampledFrom(RangeGridStartOffsets).Draw(t, "startOffset")
 	step := rapid.SampledFrom(RangeGridSteps).Draw(t, "step")
@@ -111,17 +111,41 @@ func drawPromQLRangeQuery(t *rapid.T, d property.Dataset, shapeID ShapeID) Range
 	}
 }
 
+// promQLRangeBaseShapeRoster is the non-wrapping subset of
+// promQLRangeShapeRoster (gen/shapes.go): every shape drawRangeExpr's
+// promQLRangeLabelReplaceShape case may pick as the inner expression it
+// wraps in label_replace(...). Mirrors promQLBaseShapeRoster's role for the
+// instant generator (promql.go).
+var promQLRangeBaseShapeRoster = []ShapeID{
+	promQLRangeSelectorShape,
+	promQLRangeSumByShape,
+	promQLRangeRateShape,
+}
+
 // drawRangeExpr picks a restricted expression shape for the range-
-// query generator: bare selector, ALWAYS-grouped sum-by, or bare
-// rate(). Deliberately excludes the ungrouped `sum(...)` and
-// `sum(rate(...))` shapes drawExpr draws for the instant-query
-// generator (see PromQLRangeQuery's doc comment for why).
+// query generator: bare selector, ALWAYS-grouped sum-by, bare
+// rate(), or label_replace(...) wrapping any of the three. Deliberately
+// excludes the ungrouped `sum(...)` and `sum(rate(...))` shapes drawExpr
+// draws for the instant-query generator (see PromQLRangeQuery's doc comment
+// for why).
+//
+// The label_replace wrapper is what makes this generator able to reach
+// #2383's reproducer shape (`label_replace(sum by (uri)(rate(X[5m])), ...)`
+// under /api/v1/query_range) — the range-mode `bucket_ts` alias
+// guardKeysOnTimestamp had to learn to recognize
+// (internal/promql/duplicate_labelset_guard.go) only matters once a
+// label-set-rewriting operation sits ABOVE a range-bucketed Aggregate, which
+// no shape in this file's roster could produce before.
+//
+// wrapBudget mirrors drawExpr's: see [maxComposableWrapDepth]'s doc comment
+// in promql.go for why it's threaded explicitly rather than left implicit.
 func drawRangeExpr(
 	t *rapid.T,
 	name string,
 	matchers []*labels.Matcher,
 	groupLabels []string,
 	shapeID ShapeID,
+	wrapBudget int,
 ) parser.Expr {
 	sel := &parser.VectorSelector{Name: name, LabelMatchers: matchers}
 	switch shapeID {
@@ -140,6 +164,13 @@ func drawRangeExpr(
 			Func: parser.Functions["rate"],
 			Args: []parser.Expr{drawRangeSelector(t, name, matchers)},
 		}
+	case promQLRangeLabelReplaceShape:
+		if wrapBudget <= 0 {
+			panic("gen/promql-range: label-replace shape exceeded maxComposableWrapDepth")
+		}
+		innerShape := rapid.SampledFrom(promQLRangeBaseShapeRoster).Draw(t, "rangeLabelReplaceInnerShape")
+		inner := drawRangeExpr(t, name, matchers, groupLabels, innerShape, wrapBudget-1)
+		return drawLabelReplaceWrap(t, inner, groupLabels)
 	}
 	panic("gen/promql-range: unhandled shape " + string(shapeID))
 }

--- a/test/property/gen/shapes.go
+++ b/test/property/gen/shapes.go
@@ -3,15 +3,17 @@ package gen
 type ShapeID string
 
 const (
-	promQLSelectorShape ShapeID = "promql.instant.selector"
-	promQLSumShape      ShapeID = "promql.instant.sum"
-	promQLSumByShape    ShapeID = "promql.instant.sum-by"
-	promQLRateShape     ShapeID = "promql.instant.rate"
-	promQLSumRateShape  ShapeID = "promql.instant.sum-rate"
+	promQLSelectorShape     ShapeID = "promql.instant.selector"
+	promQLSumShape          ShapeID = "promql.instant.sum"
+	promQLSumByShape        ShapeID = "promql.instant.sum-by"
+	promQLRateShape         ShapeID = "promql.instant.rate"
+	promQLSumRateShape      ShapeID = "promql.instant.sum-rate"
+	promQLLabelReplaceShape ShapeID = "promql.instant.label-replace"
 
-	promQLRangeSelectorShape ShapeID = "promql.range.selector"
-	promQLRangeSumByShape    ShapeID = "promql.range.sum-by"
-	promQLRangeRateShape     ShapeID = "promql.range.rate"
+	promQLRangeSelectorShape     ShapeID = "promql.range.selector"
+	promQLRangeSumByShape        ShapeID = "promql.range.sum-by"
+	promQLRangeRateShape         ShapeID = "promql.range.rate"
+	promQLRangeLabelReplaceShape ShapeID = "promql.range.label-replace"
 
 	expHistogramCountFunctionShape         ShapeID = "promql.native-histogram.function.count"
 	expHistogramSumFunctionShape           ShapeID = "promql.native-histogram.function.sum"
@@ -97,12 +99,14 @@ var promQLShapeRoster = [...]ShapeID{
 	promQLSumByShape,
 	promQLRateShape,
 	promQLSumRateShape,
+	promQLLabelReplaceShape,
 }
 
 var promQLRangeShapeRoster = [...]ShapeID{
 	promQLRangeSelectorShape,
 	promQLRangeSumByShape,
 	promQLRangeRateShape,
+	promQLRangeLabelReplaceShape,
 }
 
 var expHistogramShapeRoster = [...]ShapeID{

--- a/test/property/gen/shapes_test.go
+++ b/test/property/gen/shapes_test.go
@@ -26,6 +26,7 @@ func TestShapeRostersAreExact(t *testing.T) {
 				"promql.instant.sum-by",
 				"promql.instant.rate",
 				"promql.instant.sum-rate",
+				"promql.instant.label-replace",
 			},
 		},
 		{
@@ -35,6 +36,7 @@ func TestShapeRostersAreExact(t *testing.T) {
 				"promql.range.selector",
 				"promql.range.sum-by",
 				"promql.range.rate",
+				"promql.range.label-replace",
 			},
 		},
 		{
@@ -396,8 +398,11 @@ func classifyPromQLInstant(query string) (ShapeID, error) {
 	case *parser.VectorSelector:
 		return promQLSelectorShape, nil
 	case *parser.Call:
-		if node.Func.Name == "rate" {
+		switch node.Func.Name {
+		case "rate":
 			return promQLRateShape, nil
+		case "label_replace":
+			return promQLLabelReplaceShape, nil
 		}
 	case *parser.AggregateExpr:
 		if len(node.Grouping) > 0 {
@@ -426,8 +431,11 @@ func classifyPromQLRange(query string) (ShapeID, error) {
 		}
 		return promQLRangeSumByShape, nil
 	case *parser.Call:
-		if node.Func.Name == "rate" {
+		switch node.Func.Name {
+		case "rate":
 			return promQLRangeRateShape, nil
+		case "label_replace":
+			return promQLRangeLabelReplaceShape, nil
 		}
 	}
 	return "", fmt.Errorf("unrecognized PromQL range AST %T", expr)


### PR DESCRIPTION
## Summary

The PromQL property generator (`test/property/gen`) was structurally unable
to reach "guard × aggregation" compositions — the shape that hid the
`duplicate_labelset_guard.go` `bucket_ts`-alias bug (fixed separately,
already on `main`) from this test layer. This closes that reachability gap
per the issue's own suggested fix, deliberately scoped cheap:

- **Composable `label_replace(...)` wrapper.** `drawExpr` (instant) and
  `drawRangeExpr` (range) each gain a `promQL(Range)LabelReplaceShape` case
  that draws one of the roster's existing *base* shapes recursively and
  wraps it in `label_replace(...)`, rather than adding a 6th/4th flat case.
  Recursion is bounded by `maxComposableWrapDepth` (a named constant, per
  invariant 13) so a future second wrapper case can't make the generator
  unboundedly recursive.
- **Range-query mode.** Already existed on `main` (`gen.PromQLRangeQuery` /
  `TestPromQL_RangeProperty_FromScratch`, added for #1499) — the
  `label_replace` wrapper is wired into it too, which is what actually lets
  the generator reach `label_replace(sum by (...)(...), ...)` under
  `/api/v1/query_range`, the exact shape from the issue's reproducer.
- **Oracle `label_replace` support.** Already existed on `main`
  (`test/property/oracle/promql/label_transform.go`) — no changes needed.

## Verification

- `TestPromQL_PropertyShapeRoster` / `TestPromQL_RangePropertyShapeRoster`
  (deterministic one-per-shape floor): both new shapes pass.
- `TestPromQL_Property_FromScratch` / `TestPromQL_RangeProperty_FromScratch`
  at `-rapid.checks=300`: green, and a probe run confirmed the range
  generator reliably draws `label_replace(sum by (...)(rate(...)), ...)`
  and `label_replace(sum by (...)(...), ...)` under a real
  `[start,end,step]` grid.
- **Regression proof**: temporarily reverted
  `isTimestampAlias`'s `bucket_ts` recognition
  (`internal/promql/duplicate_labelset_guard.go`) to reintroduce the
  original bug, reran `TestPromQL_RangeProperty_FromScratch` — it failed
  within 17 iterations on
  `label_replace(sum by (instance) (up), "endpoint", "$1", "instance",
  "(.+)")` under `/api/v1/query_range`, with the exact original
  false-positive `vector cannot contain metrics with the same labelset`
  error. Reverted the temporary change back (confirmed `git diff` on that
  file is empty) and reran green.
- Full `./test/property/...` (equivalent to `just property`) is green,
  including `test/property/gen`'s pinned exact-roster and
  by-shape-classification tests (updated for the two new shape IDs) and
  `test/regression`'s property live-roster/random-runner floor tests
  (unaffected — they pin wiring, not shape counts).

## Test plan

- [x] `go test -tags chdb,agpl_oracle,chdb_agpl_oracle -count=1 ./test/property/...` (green)
- [x] `go test -tags chdb,agpl_oracle,chdb_agpl_oracle ./test/property/gen/...` (green, including updated roster/classifier tests)
- [x] `go test -run 'TestPropertyLiveRosterFloor|TestPropertyRandomRunnerFloor' ./test/regression/...` (green)
- [x] Regression proof: reverted the guard fix locally, confirmed the widened generator catches the false positive, reverted back
- [ ] CI green

Closes #2383
