### PR TITLE
fix(ci): skip coverage.yml's redundant push run after a release PR merge

### DIFF
--- a/.github/scripts/README.md
+++ b/.github/scripts/README.md
@@ -794,6 +794,33 @@ what actually runs.
   - Exit: `0` when every statement-carrying full-lane package has a
     positive floor and every floor names a live package, `1` on
     listing/instrumentation/input failure or structural drift.
+- **`coverage-run-heavy.mjs`** — `coverage.yml`, the `decide run_heavy` step.
+  Decides whether the job's heavy lane (`just coverage`: the full instrumented
+  test run + chdb install) does real work for this event
+  (tsouza/cerberus#2416, part 2 of #2394). `pull_request` / `merge_group` /
+  `schedule` / `workflow_dispatch` are unchanged from the old inline GHA
+  expression — delegated to `lib/scope-gate.mjs`'s `runsFullLane`, the same
+  helper `mutation.yml` and `compose-smoke-scope.mjs` share. A `push` gets an
+  ADDITIONAL check: it resolves the PR that produced the pushed commit
+  (`lib/resolve-source-pr.mjs`'s exact `merged && merge_commit_sha` match) and
+  skips the heavy run ONLY when that PR resolved AND its own head ref started
+  with `release/` — i.e. only when the identical tree already ran heavy and
+  posted `coverage`'s check-run somewhere `release-preflight.mjs`'s SOURCE-PR
+  CREDIT will find it. Every other push (an ordinary-PR merge, an unresolved
+  match, a maintenance-line hotfix with no PR at all) still runs heavy —
+  fail-safe by construction. `coverage-run-heavy.test.mjs` pins the decision
+  table; it runs inside `coverage.yml`'s own always-on "Test coverage gates"
+  step (that workflow has a `pull_request:` trigger, unlike release.yml, so it
+  needs no separate ci.yml wiring).
+  - Modes: `verify` (loads the policy, no network) | `emit` (decide + append
+    `run_heavy=true|false` to `GITHUB_OUTPUT`; calls the GitHub API only on a
+    `push` event).
+  - Env: `MODE` (also argv[2]), `EVENT_NAME`, `HEAD_REF` (pull_request /
+    merge_group only), `GITHUB_SHA` / `GITHUB_REPOSITORY` / `GITHUB_TOKEN` /
+    `GITHUB_API_URL` (push only), `GITHUB_OUTPUT`.
+  - Exit: `0` always in `emit` mode (a resolution failure fails SAFE to
+    `run_heavy=true`, logged via `::notice::`, never a hard failure); `1` on an
+    unrecognised `MODE`.
 - **`gremlins-threshold.mjs`** — `mutation.yml`, the
   `enforce efficacy threshold` step.
   - Env: `REPORT` (default `gremlins.json`), `THRESHOLD` (a number).

--- a/.github/scripts/coverage-run-heavy.mjs
+++ b/.github/scripts/coverage-run-heavy.mjs
@@ -1,0 +1,159 @@
+// coverage-run-heavy.mjs — decides whether `coverage.yml`'s heavy lane
+// (`just coverage`: the full instrumented test run + chdb install) does real
+// work for THIS event, closing part of tsouza/cerberus#2416 (part 2 of
+// #2394).
+//
+// The shape before this module existed
+// --------------------------------------
+// `coverage.yml` computed RUN_HEAVY as a single job-level GHA expression:
+//
+//   (event != pull_request && event != merge_group) || startsWith(head_ref, 'release/')
+//
+// which is true on every `push`, unconditionally. That is correct for a push
+// produced by an ORDINARY PR — RUN_HEAVY was false on that PR's own run, so
+// the push is the FIRST real coverage measurement for that tree — but it is
+// REDUNDANT for a push produced by a `release/*`-headed PR: that PR's own
+// `pull_request` run already had RUN_HEAVY=true (same expression, its own
+// head_ref matched `release/*`) and posted `coverage`'s required check-run on
+// its own tip commit. The push-to-main run after such a PR merges re-runs the
+// identical `just coverage` work against a byte-identical tree for nothing.
+//
+// The fix
+// -------
+// For `pull_request` / `merge_group`, behaviour is UNCHANGED — delegated to
+// `scope-gate.mjs`'s `runsFullLane`, the same helper `mutation.yml` and
+// `e2e.yml`'s `compose-smoke-scope` already share, so this lane's PR-time
+// decision cannot drift from theirs. For `schedule` / `workflow_dispatch`,
+// also unchanged: always heavy (the nightly/manual safety net every scoped
+// path leans on).
+//
+// For `push`, `decide()` takes an ADDITIONAL input: the PR (if any) that
+// produced the pushed commit, resolved via `lib/resolve-source-pr.mjs`'s
+// exact `merged && merge_commit_sha === pushedSha` match (tsouza/cerberus#2394).
+// RUN_HEAVY is false ONLY when that PR resolved AND its own head ref started
+// with `release/` — i.e. only when we can PROVE the identical tree already
+// ran the heavy lane and posted `coverage`'s check-run somewhere
+// `release-preflight.mjs`'s SOURCE-PR CREDIT will find it (on the PR's own
+// tip commit). Every other push — an ordinary-PR merge, an unresolved source
+// PR (network hiccup, or a maintenance-line hotfix pushed with no PR at all,
+// which release.yml's preflight requires this check-run to exist for) —
+// keeps running heavy. Fail-safe by construction: uncertainty always resolves
+// to "run it for real", never to "skip it".
+//
+// Modes (MODE, or argv[2]; default `verify`):
+//   - verify: validate the module loads and the mode is known. No network.
+//   - emit: decide and append `run_heavy=true|false` to GITHUB_OUTPUT. Calls
+//     the GitHub API (via lib/resolve-source-pr.mjs) ONLY on a `push` event.
+//
+// Environment:
+//   MODE                `emit` | `verify` (also argv[2]).
+//   EVENT_NAME           github.event_name.
+//   HEAD_REF             github.head_ref (pull_request / merge_group only).
+//   GITHUB_SHA           the pushed commit sha (push event only).
+//   GITHUB_REPOSITORY    "owner/name" (push event only).
+//   GITHUB_TOKEN         token with pull-requests:read (push event only).
+//   GITHUB_API_URL       API base, default https://api.github.com.
+//   GITHUB_OUTPUT        emit destination.
+//
+// node: builtins only — no npm dependencies or setup-node step.
+
+import process from 'node:process';
+import { pathToFileURL } from 'node:url';
+
+import { runsFullLane } from './lib/scope-gate.mjs';
+import { resolveSourcePR } from './lib/resolve-source-pr.mjs';
+import { error, log, notice, setOutput } from './lib/gh.mjs';
+
+// decide — pure. `sourcePR` is only meaningful (and only ever passed) for a
+// `push` event: `{ number, headRef }` for an exact-match resolved PR, or
+// `null` when none resolved (no PR, ambiguous match, or a resolution
+// failure the caller already logged). Ignored for every other event.
+export function decide({ eventName, headRef, sourcePR = null }) {
+  const event = String(eventName ?? '').trim();
+
+  if (event !== 'push') {
+    const runHeavy = runsFullLane({ eventName: event, headRef });
+    return {
+      runHeavy,
+      reason: runHeavy
+        ? `event "${event || '<unknown>'}" runs the heavy coverage lane`
+        : 'ordinary pull_request/merge_group — package-enrollment gate only, same as before',
+    };
+  }
+
+  if (sourcePR && typeof sourcePR.headRef === 'string' && sourcePR.headRef.startsWith('release/')) {
+    return {
+      runHeavy: false,
+      reason:
+        `redundant with PR #${sourcePR.number} (${sourcePR.headRef}), which already ran the heavy coverage ` +
+        `lane and posted its own "coverage" check-run on its tip commit — release-preflight.mjs's ` +
+        `SOURCE-PR CREDIT (tsouza/cerberus#2394) reads that run instead of demanding a fresh one here`,
+    };
+  }
+
+  return {
+    runHeavy: true,
+    reason: sourcePR
+      ? `source PR #${sourcePR.number} (${sourcePR.headRef ?? '<no head ref>'}) was not release/*-headed — ` +
+        'this push is the first real coverage run for this tree'
+      : 'no source PR resolved for this push (ordinary-PR merge, unresolved match, or a maintenance-line ' +
+        'hotfix with no PR at all) — running heavy for real (fail-safe default)',
+  };
+}
+
+async function resolvePushSourcePR({ repo, sha, token, apiBase }) {
+  if (!repo || !sha || !token) {
+    notice(
+      'coverage-run-heavy: GITHUB_REPOSITORY/GITHUB_SHA/GITHUB_TOKEN not all set for a push event — ' +
+        'cannot resolve a source PR, running heavy for real (fail-safe default).',
+    );
+    return null;
+  }
+  try {
+    return await resolveSourcePR({ repo, sha, token, apiBase });
+  } catch (e) {
+    notice(
+      `coverage-run-heavy: could not resolve a source PR for ${String(sha).slice(0, 8)} (${e.message}) — ` +
+        'running heavy for real (fail-safe default).',
+    );
+    return null;
+  }
+}
+
+async function main() {
+  const mode = (process.env.MODE || process.argv[2] || 'verify').trim();
+  if (mode !== 'verify' && mode !== 'emit') {
+    error(`coverage-run-heavy: MODE must be "verify" or "emit" (got "${mode}")`);
+    process.exit(1);
+  }
+
+  if (mode === 'verify') {
+    log('coverage-run-heavy: RUN_HEAVY decision policy loaded.');
+    return;
+  }
+
+  const eventName = process.env.EVENT_NAME;
+  const headRef = process.env.HEAD_REF;
+
+  let sourcePR = null;
+  if (String(eventName ?? '').trim() === 'push') {
+    sourcePR = await resolvePushSourcePR({
+      repo: process.env.GITHUB_REPOSITORY,
+      sha: process.env.GITHUB_SHA,
+      token: process.env.GITHUB_TOKEN,
+      apiBase: process.env.GITHUB_API_URL || 'https://api.github.com',
+    });
+  }
+
+  const verdict = decide({ eventName, headRef, sourcePR });
+  notice(`coverage-run-heavy: run_heavy=${verdict.runHeavy} — ${verdict.reason}`);
+  setOutput('run_heavy', String(verdict.runHeavy));
+}
+
+const invokedDirectly = process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href;
+if (invokedDirectly) {
+  main().catch((e) => {
+    error(`coverage-run-heavy failed: ${e.message}`);
+    process.exit(1);
+  });
+}

--- a/.github/scripts/coverage-run-heavy.test.mjs
+++ b/.github/scripts/coverage-run-heavy.test.mjs
@@ -1,0 +1,63 @@
+// coverage-run-heavy.test.mjs — node:test guard for the RUN_HEAVY decision
+// behind coverage.yml's push lane (tsouza/cerberus#2416, part 2 of #2394).
+//
+// What it pins:
+//   - pull_request / merge_group / schedule / workflow_dispatch behave
+//     EXACTLY as the old inline GHA expression did (delegated to
+//     scope-gate.mjs's runsFullLane, shared with mutation.yml and
+//     e2e.yml's compose-smoke-scope);
+//   - a push produced by a release/*-headed source PR is the ONE case that
+//     newly skips — everything else (an ordinary-PR push, an unresolved
+//     source PR, a maintenance-line hotfix push with no PR at all) still
+//     runs heavy, so the fail-safe default is "run it", never "skip it".
+
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { decide } from './coverage-run-heavy.mjs';
+
+test('pull_request and merge_group are unchanged: release/*-headed runs heavy, everything else does not', () => {
+  assert.equal(decide({ eventName: 'pull_request', headRef: 'release/1.14.x' }).runHeavy, true);
+  assert.equal(decide({ eventName: 'pull_request', headRef: 'fix/some-bug' }).runHeavy, false);
+  assert.equal(decide({ eventName: 'pull_request', headRef: '' }).runHeavy, false);
+  // A merge_group event never actually carries a head_ref in production (GitHub
+  // does not populate one for a batch), so this is always false in practice —
+  // runsFullLane applies the identical rule regardless, exactly as the old
+  // inline GHA expression did.
+  assert.equal(decide({ eventName: 'merge_group', headRef: '' }).runHeavy, false);
+});
+
+test('schedule and workflow_dispatch always run heavy, sourcePR or not', () => {
+  for (const eventName of ['schedule', 'workflow_dispatch']) {
+    assert.equal(decide({ eventName }).runHeavy, true, eventName);
+    assert.equal(decide({ eventName, sourcePR: { number: 1, headRef: 'release/1.14.x' } }).runHeavy, true, eventName);
+  }
+});
+
+test('push produced by a release/*-headed source PR is redundant — skips', () => {
+  const v = decide({ eventName: 'push', sourcePR: { number: 2400, headRef: 'release/1.14.x' } });
+  assert.equal(v.runHeavy, false);
+  assert.match(v.reason, /redundant with PR #2400/);
+  assert.match(v.reason, /SOURCE-PR CREDIT/);
+});
+
+test('push produced by an ordinary (non-release) source PR is the first real run — runs heavy', () => {
+  const v = decide({ eventName: 'push', sourcePR: { number: 41, headRef: 'fix/something' } });
+  assert.equal(v.runHeavy, true);
+  assert.match(v.reason, /first real coverage run/);
+});
+
+test('push with no resolved source PR (maintenance hotfix, or resolution failure) fails safe to heavy', () => {
+  const v = decide({ eventName: 'push', sourcePR: null });
+  assert.equal(v.runHeavy, true);
+  assert.match(v.reason, /fail-safe default/);
+});
+
+test('a source PR match with no head ref (malformed) is treated as not release-headed — runs heavy', () => {
+  const v = decide({ eventName: 'push', sourcePR: { number: 7, headRef: null } });
+  assert.equal(v.runHeavy, true);
+});
+
+test('an unfamiliar event name fails open, same as scope-gate.runsFullLane', () => {
+  assert.equal(decide({ eventName: 'some_future_event' }).runHeavy, true);
+});

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -20,6 +20,18 @@ name: coverage
 # release PRs additionally run full coverage, so their green status includes
 # the measured floor comparison.
 #
+# tsouza/cerberus#2416 (part 2 of #2394): a push-to-main produced by a
+# release/*-headed PR merging is REDUNDANT — that PR's own pull_request run
+# already measured coverage on the identical tree and posted this job's
+# required check-run on its own tip commit. .github/scripts/coverage-run-heavy.mjs
+# resolves the PR that produced the pushed commit (lib/resolve-source-pr.mjs's
+# exact-match contract) and skips the heavy run ONLY in that one provable
+# case; release-preflight.mjs's SOURCE-PR CREDIT already knows to read the
+# check-run off that PR's tip instead of demanding a fresh one here. Every
+# other push — an ordinary-PR merge (the FIRST real run for that tree), an
+# unresolved source PR, or a maintenance-line hotfix pushed with no PR at all
+# — still runs heavy; see the script's own header for the full decision table.
+#
 # Triggers: pull_request + push-to-main + nightly + manual dispatch.
 
 on:
@@ -39,6 +51,10 @@ on:
 
 permissions:
   contents: read
+  # coverage-run-heavy.mjs resolves the PR that produced a pushed commit via
+  # GET /commits/{sha}/pulls (lib/resolve-source-pr.mjs) — read-only, and only
+  # exercised on a `push` event.
+  pull-requests: read
 
 concurrency:
   # Main pushes and matching cron schedules replace only their own modes. PR,
@@ -58,11 +74,12 @@ jobs:
     # nothing on the PR path — and a timeout here lands red on main, where
     # nobody's PR was ever asked to catch it.
     timeout-minutes: 60
-    # RUN_HEAVY gates the measured profile: true on push / schedule / dispatch,
-    # and on a release PR (head branch release/*). Every event still runs the
-    # structural enrollment check over both build configurations, so an
-    # ordinary PR cannot add code the first post-merge profile discovers has no
-    # floor.
+    # RUN_HEAVY gates the measured profile: true on push / schedule / dispatch
+    # (unless a resolved source PR proves this push redundant — see the
+    # `decide run_heavy` step below), and on a release PR (head branch
+    # release/*). Every event still runs the structural enrollment check over
+    # both build configurations, so an ordinary PR cannot add code the first
+    # post-merge profile discovers has no floor.
     #
     # A merge-queue entry is held to the PR posture, not the push posture. The
     # queue validates the projected trunk against the SAME contexts branch
@@ -70,8 +87,6 @@ jobs:
     # dequeue a PR that was green, which is the livelock the queue exists to
     # remove. The real run is not lost — `main` advances to the merge group's
     # own head SHA, and the push trigger above sweeps coverage on that commit.
-    env:
-      RUN_HEAVY: ${{ (github.event_name != 'pull_request' && github.event_name != 'merge_group') || startsWith(github.head_ref, 'release/') }}
     steps:
       - uses: actions/checkout@v7
 
@@ -84,17 +99,34 @@ jobs:
         run: |
           node --test .github/scripts/coverage-summary.test.mjs
           node --test .github/scripts/coverage-package-floor.test.mjs
+          node --test .github/scripts/coverage-run-heavy.test.mjs
 
       - name: Verify package floor enrollment
         run: node .github/scripts/coverage-package-floor.mjs
 
-      - if: env.RUN_HEAVY == 'true'
+      # Computed as a step output rather than a static job-level `env:` GHA
+      # expression: a `push` event needs a network call (resolve the source PR
+      # that produced the pushed commit) to know whether it is redundant with
+      # that PR's own run, and job-level `env:` has no `steps` context to read
+      # such a call's result from. See coverage-run-heavy.mjs's header for the
+      # full decision table; GITHUB_TOKEN is used read-only and only reached on
+      # a `push` event.
+      - id: run_heavy
+        name: decide run_heavy
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          MODE: emit
+          EVENT_NAME: ${{ github.event_name }}
+          HEAD_REF: ${{ github.head_ref }}
+        run: node .github/scripts/coverage-run-heavy.mjs
+
+      - if: steps.run_heavy.outputs.run_heavy == 'true'
         uses: taiki-e/install-action@82cd3e7658a6f96c86c0234aeeda1748937cb0a1  # v2.85.13
         with:
           tool: just
 
       - name: Install libchdb.so
-        if: env.RUN_HEAVY == 'true'
+        if: steps.run_heavy.outputs.run_heavy == 'true'
         run: just chdb-install
 
       # `just coverage` ends by running .github/scripts/coverage-summary.mjs,
@@ -105,17 +137,17 @@ jobs:
       # comparing a narrower profile — so it skips the comparison, and the lane
       # reports green having gated nothing.
       - name: Run coverage
-        if: env.RUN_HEAVY == 'true'
+        if: steps.run_heavy.outputs.run_heavy == 'true'
         env:
           COVERAGE_REQUIRE_LANES: default+chdb
         run: just coverage
 
-      - name: Full coverage deferred (ordinary PR)
-        if: env.RUN_HEAVY != 'true'
-        run: echo "package enrollment passed; measured coverage runs on push/nightly/dispatch and release/* PRs."
+      - name: Full coverage deferred (ordinary PR / redundant push)
+        if: steps.run_heavy.outputs.run_heavy != 'true'
+        run: echo "package enrollment passed; measured coverage runs on push/nightly/dispatch and release/* PRs (skipped here — see the 'decide run_heavy' step log for why)."
 
       - name: Upload coverage profile
-        if: always() && env.RUN_HEAVY == 'true'
+        if: always() && steps.run_heavy.outputs.run_heavy == 'true'
         uses: actions/upload-artifact@v7
         with:
           name: coverage-profile

--- a/test/regression/coverage_pr_gate_test.go
+++ b/test/regression/coverage_pr_gate_test.go
@@ -11,7 +11,7 @@ const (
 	coverageGateTest     = "node --test .github/scripts/coverage-package-floor.test.mjs"
 	coverageGateRun      = "node .github/scripts/coverage-package-floor.mjs"
 	coverageSetupGo      = "uses: actions/setup-go@v7"
-	coverageHeavyGuard   = "if: env.RUN_HEAVY == 'true'"
+	coverageHeavyGuard   = "if: steps.run_heavy.outputs.run_heavy == 'true'"
 )
 
 // TestCoveragePRGateIsNotConditionedOnHeavyCoverage pins the ordinary-PR path


### PR DESCRIPTION
## What

`coverage.yml`'s push-to-main run always executed the full `just coverage` lane (the instrumented test run + chdb install), even when the merged PR was `release/*`-headed and had *already* run it — an identical tree, with the same required `coverage` check-run already posted on that PR's own tip commit. This PR closes that one redundant case.

`coverage-run-heavy.mjs` resolves the PR that produced the pushed commit, via `lib/resolve-source-pr.mjs`'s exact `merged && merge_commit_sha === pushedSha` match (the mechanism #2394/#2417 shipped), and skips the heavy run **only** when that resolves to a `release/*`-headed PR. `release-preflight.mjs`'s SOURCE-PR CREDIT already knows to read that PR's own `coverage` check-run instead of demanding a fresh one on the push commit — this is the first lane that actually exercises that (previously no-op) mechanism.

Every other push still runs heavy, fail-safe by construction:
- an ordinary-PR merge — that PR's own run was a green no-op (`RUN_HEAVY=false`), so the push is the *first* real measurement for that tree;
- an unresolved source PR (network hiccup, ambiguous match) — can't prove redundancy, so it runs;
- a maintenance-line (`release/*.x`) hotfix pushed with no PR at all — `release-preflight.mjs`'s maintenance mode has no PR to credit, and requires this check-run to exist.

`pull_request` / `merge_group` / `schedule` / `workflow_dispatch` behavior is **unchanged** — delegated to `lib/scope-gate.mjs`'s `runsFullLane`, the same helper `mutation.yml` and `e2e.yml`'s `compose-smoke-scope` already share, so this lane's PR-time decision can't drift from theirs.

## Why this lane, why not the other three

#2416 named four lanes (`mutation.yml`, `coverage.yml`, `compatibility.yml`, `e2e.yml`) and its own investigation found none of them share a uniform shape:

- `compatibility.yml` has **no PR-time short-circuit at all** today, and its push-to-main run has a side effect unrelated to gating (publishing `compat-score.json` to the orphan `compat-scores` branch for the shields.io badge) that has to be separated from the gate-skip.
- `mutation.yml`'s push-to-main sweeps the **full, unscoped matrix** with no `RUN_HEAVY`-style gate; an ordinary PR only sweeps the legs its own diff touches, so push is *not* a duplicate of an ordinary PR's run — only of a `release/*`-headed one, and doing that safely needs a PER-LEG comparison against what that PR actually swept.
- `e2e.yml` hosts two lanes with two different shapes (`compose-smoke` is redundant on every merge; `dashboard` only for a `release/*`-headed source PR, plus the crawl-leg nuance #2361 already had to solve once).

`coverage.yml`, by contrast, already gated its heavy work behind a single boolean (`RUN_HEAVY`) that matches this PR's "redundant iff the source PR was `release/*`-headed" condition one-for-one — no per-leg reasoning, no side effect to preserve. It was the safest lane to convert first.

## Scope: #2416 stays open, narrowed

This PR does not close #2416. `mutation.yml`, `compatibility.yml`, and `e2e.yml` still need their own bespoke, higher-risk design work — I'm leaving #2416 open, narrowed to those three (a comment on the issue records the narrowing and this PR).

Investigating this also turned up that `property.yml` and `perf-profile.yml` (both `RELEASE_REQUIRED_CHECKS` lanes) — and `chdb.yml`'s own `run_heavy` computation — share the *exact* same shape `coverage.yml` had. That's new scope #2416 never named, so it's tracked separately rather than folded in here: #2426.

## Test plan

- [x] `node --test .github/scripts/coverage-run-heavy.test.mjs` — the decision table (pull_request/merge_group/schedule/dispatch unchanged; push redundant only for a resolved release/*-headed source PR; every other push fails safe to heavy).
- [x] `node --test .github/scripts/coverage-summary.test.mjs .github/scripts/coverage-package-floor.test.mjs` — unaffected siblings still green.
- [x] `go test -race ./test/regression/...` — `TestCoveragePRGateIsNotConditionedOnHeavyCoverage` updated for the new `steps.run_heavy.outputs.run_heavy` guard string and still passes; the rest of the regression package is untouched and green.
- [x] `actionlint .github/workflows/coverage.yml` — clean.
- [x] `CHECK=all node .github/scripts/forbid-skip.mjs`, `node .github/scripts/forbid-sql-raw.mjs` — clean.
- [x] `go build ./...`, `gofumpt -extra -l`, `markdownlint-cli2 .github/scripts/README.md` — clean.
- [ ] CI (`lint`, `strict-scan`, and the real `coverage` run itself) — can't be settled locally per CLAUDE.md; will read the CI log directly if anything goes red.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

