### PR TITLE
fix(ci): retry a proxy.golang.org 403 as a transient registry fault

### DIFF
--- a/.github/scripts/build-with-registry-retry.test.mjs
+++ b/.github/scripts/build-with-registry-retry.test.mjs
@@ -63,3 +63,29 @@ test('a genuine failure with no registry/network signal in its output fails on t
   // error() (lib/gh.mjs) writes the ::error:: workflow-command line to stdout.
   assert.match(res.stdout, /failed with status 3.*no registry or network fault/s);
 });
+
+test('a proxy.golang.org 403 (edge/abuse-protection throttling, not a real refusal) is retried, not failed on the first attempt', () => {
+  // Confirmed transient on main's own CI: the same URL served the file
+  // cleanly moments later from an unrelated network, and re-running the
+  // identical job (no code change) succeeded. IMAGE_BUILD_RETRY_BACKOFF_SECONDS=0
+  // keeps the exhausted-budget path (this command never succeeds) fast.
+  const res = spawnSync(
+    'node',
+    [
+      SCRIPT,
+      'bash',
+      '-c',
+      'echo "go: github.com/grafana/loki/v3@v3.7.1: reading https://proxy.golang.org/github.com/grafana/loki/v3/@v/v3.7.1.zip: 403 Forbidden"; exit 1',
+    ],
+    {
+      encoding: 'utf8',
+      env: { ...process.env, GO_IMAGE: 'golang:1.26', IMAGE_BUILD_RETRY_BACKOFF_SECONDS: '0' },
+    },
+  );
+  assert.equal(res.status, 1);
+  // Reached the exhausted-budget message (every attempt spent, never the
+  // "no registry or network fault" first-attempt bail-out) — proof the 403
+  // was classified as a transient transport fault and actually retried.
+  assert.doesNotMatch(res.stdout, /no registry or network fault/);
+  assert.match(res.stdout, /failed 5 times, every one of them on a transport fault/);
+});

--- a/.github/scripts/lib/registry.mjs
+++ b/.github/scripts/lib/registry.mjs
@@ -247,6 +247,16 @@ const transientRegistryFailurePatterns = [
   /temporary failure in name resolution/i,
   /no such host/i,
   /server misbehaving/i,
+  // proxy.golang.org occasionally answers a shared CI IP range with a 403
+  // (edge/abuse-protection throttling, not a real per-module refusal) — seen
+  // on a `go mod download` inside a build stage: `go: <module>@<version>:
+  // reading https://proxy.golang.org/.../@v/<version>.zip: 403 Forbidden`.
+  // Confirmed transient, not a genuinely missing/blocked module: the exact
+  // same URL served the file cleanly moments later from an unrelated
+  // network, and re-running the identical CI job with no code change
+  // succeeded. Scoped to proxy.golang.org specifically — a bare "any 403"
+  // pattern would also swallow a real auth/permission refusal elsewhere.
+  /proxy\.golang\.org\/\S*: 403 Forbidden/i,
 ];
 
 // A rate-limited fetch is reported by BuildKit as `unexpected status from HEAD


### PR DESCRIPTION
## Summary

`main`'s own `quickstart` (required, push-triggered) failed with:

```text
go: github.com/grafana/loki/v3@v3.7.1: reading https://proxy.golang.org/github.com/grafana/loki/v3/@v/v3.7.1.zip: 403 Forbidden
go: github.com/klauspost/compress@v1.19.1: reading https://proxy.golang.org/github.com/klauspost/compress/@v/v1.19.1.zip: 403 Forbidden
go: github.com/pierrec/lz4/v4@v4.1.27: reading https://proxy.golang.org/github.com/pierrec/lz4/v4/@v/v4.1.27.zip: 403 Forbidden
go: google.golang.org/api@v0.278.0: reading https://proxy.golang.org/google.golang.org/api/@v/v0.278.0.zip: 403 Forbidden
```

— 4 unrelated modules, identical 403 pattern, all 5 of `build-with-registry-retry.mjs`'s existing
retry attempts within ~42s. The job's own error message named the actual gap precisely: `` `docker
compose up --wait` failed with status 1, and its output names no registry or network fault. ``` —
`lib/registry.mjs`'s `transientRegistryFailurePatterns` already anticipated `go mod download`
failing this way against `proxy.golang.org` (its own comment says so), but had no pattern for the
403 status specifically, so the classifier correctly refused to retry a failure it didn't
recognize.

Verified this was a real transient fault, not a genuinely blocked/missing module, before adding
the pattern:

- Probed the exact same URLs directly (from an unrelated network) moments after the CI failure —
  both served the file cleanly (`302`, valid `ETag`, `cache-control: public, max-age=10800`).
- Re-ran the identical CI job with no code change — it succeeded.
- Checked the last 30 `quickstart.yml` runs: this is the only occurrence of this specific failure
  signature; the one other historical failure in that window was an unrelated CI-lane-registry
  validation error.

This matches a class this repo already has precedent for (Docker Hub's 429, `lib/registry.mjs`'s
own `isRegistryRateLimit`) — a shared CI IP range getting edge/abuse-protection throttled by a
Google-operated proxy — just surfaced as a bare 403 instead of an explicit rate-limit message, so
it fell through to the "genuine failure" branch instead of the retry branch.

- `.github/scripts/lib/registry.mjs` — adds `/proxy\.golang\.org\/\S*: 403 Forbidden/i` to
  `transientRegistryFailurePatterns`, scoped to `proxy.golang.org` specifically (a bare "any 403"
  pattern would also swallow a real auth/permission refusal elsewhere, which this classifier
  exists to NOT retry).
- `.github/scripts/build-with-registry-retry.test.mjs` — a regression test proving this exact
  failure signature is now retried (reaches the "exhausted the retry budget" message) rather than
  failing on the first attempt.

## Test plan

- [x] `node --test .github/scripts/build-with-registry-retry.test.mjs` — new test passes; verifies
      the pattern is scoped correctly (doesn't touch `isRegistryRateLimit`)
- [x] `node --test .github/scripts/lib/*.test.mjs` — unaffected siblings still green
- [x] Manually verified the new pattern matches the exact real failure line and does NOT match
      via `isRegistryRateLimit`
- [x] `go build ./...` — unaffected
- [x] `actionlint`, `node .github/scripts/forbid-sql-raw.mjs`,
      `CHECK=all node .github/scripts/forbid-skip.mjs` — clean
