### PR TITLE
feat(perf): gate the #2370 nightly lane and settings changes on sentinel coverage

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -120,6 +120,16 @@ test/perf/scale-wall-baseline.json           -merge
 #   memory-cost increase is genuinely intended.
 test/perf/perf-smoke-baseline.json           -merge
 
+# Regenerate: `just update-nightly-perf-baseline`
+#   (UPDATE_NIGHTLY_PERF_BASELINE=1 go test -timeout 15m -tags=integration
+#    -count=1 -run TestPerfNightlyRealCH ./test/perf/nightly/... — needs
+#    Docker + the trimmed sample parquet files via `git lfs pull`). NOT
+#    chained into `just update-golden`: like perf-smoke-baseline.json it
+#    records a measured per-sentinel memory ceiling (and the HTTP status
+#    each sentinel is calibrated to expect), so it moves only when a
+#    memory-cost increase or an outcome-class change is genuinely intended.
+test/perf/nightly-baseline.json              -merge
+
 # Regenerate: `just update-metadata-query-size-baseline`
 #   (UPDATE_METADATA_QUERY_SIZE_BASELINE=1 go test -count=1
 #    -run TestMetadataQuerySizeRatchet ./test/perf/ — pure Go, no chDB). NOT

--- a/.github/ci-lanes.json
+++ b/.github/ci-lanes.json
@@ -1471,7 +1471,7 @@
     },
     {
       "id": "perf-nightly.perf-nightly",
-      "description": "#2370 nightly real-data measurement harness: loads the real, trimmed production sample into a real ClickHouse and logs sentinel peak_memory_usage/duration. PR A — no baseline/gate yet.",
+      "description": "#2370 nightly real-data regression gate: loads the real, trimmed production sample into a real ClickHouse and asserts each sentinel's max-of-5 peak memory (and expected HTTP outcome) against a committed baseline plus an absolute cap-relative ceiling (PR B).",
       "owner": {
         "workflow": ".github/workflows/perf-nightly.yml",
         "jobs": ["perf-nightly"],
@@ -1490,12 +1490,41 @@
       "substrate": "real-clickhouse",
       "risk_domains": ["performance"],
       "merge_posture": "never",
-      "main_posture": "never",
-      "release_posture": "advisory",
-      "determinism": "observational",
+      "main_posture": "coalesced",
+      "release_posture": "required",
+      "determinism": "deterministic",
       "applicability": { "source": true, "artifact": false },
       "timeout_minutes": 20,
       "slo_minutes": 20,
+      "accountable_owner": "query-quality"
+    },
+    {
+      "id": "perf-nightly.perf-nightly-health-notify",
+      "description": "Roll up the perf-nightly schedule run and file/refresh a tracking issue on any non-success (#1861's mechanism, second consumer).",
+      "owner": {
+        "workflow": ".github/workflows/perf-nightly.yml",
+        "jobs": ["perf-nightly-health-notify"],
+        "producer_jobs": [],
+        "context_job": "perf-nightly-health-notify"
+      },
+      "executions": ["default"],
+      "context": { "match": "exact", "name": "perf-nightly-health-notify", "protected": false },
+      "purpose": "quality",
+      "layers": ["11"],
+      "oracle_class": "monitor",
+      "recipes": [],
+      "command": "node .github/scripts/notify-perf-nightly-failure.mjs",
+      "build_tags": [],
+      "package_globs": ["test/perf/nightly/**"],
+      "substrate": "github-api",
+      "risk_domains": ["observability"],
+      "merge_posture": "never",
+      "main_posture": "never",
+      "release_posture": "advisory",
+      "determinism": "deterministic",
+      "applicability": { "source": true, "artifact": false },
+      "timeout_minutes": 5,
+      "slo_minutes": 5,
       "accountable_owner": "query-quality"
     },
     {

--- a/.github/scripts/forbid-deferral.mjs
+++ b/.github/scripts/forbid-deferral.mjs
@@ -766,7 +766,7 @@ export function resolveRange({ baseSha, headSha }) {
 
 // commitsIn — every commit in base..head as { sha, message }. `git log -z`
 // separates records with NUL, so a message containing blank lines survives.
-function commitsIn(base, head) {
+export function commitsIn(base, head) {
   const res = git(['log', '-z', '--format=%H%n%B', `${base}..${head}`]);
   if (res.status !== 0) {
     throw new Error(`git log ${base}..${head} failed: ${res.stderr.trim()}`);
@@ -784,7 +784,7 @@ function commitsIn(base, head) {
     .filter((c) => c.sha !== '');
 }
 
-function diffOf(base, head) {
+export function diffOf(base, head) {
   const res = git(['diff', `--unified=${CITATION_WINDOW_LINES}`, `${base}...${head}`]);
   if (res.status !== 0) {
     throw new Error(`git diff ${base}...${head} failed: ${res.stderr.trim()}`);
@@ -807,7 +807,7 @@ async function probeStatus(url, token) {
   return { ok: res.ok, status: res.status, statusText: res.statusText };
 }
 
-async function apiJson(url, token, what) {
+export async function apiJson(url, token, what) {
   const res = await fetch(url, { headers: apiHeaders(token) });
   if (res.status === HTTP_NOT_FOUND) return null;
   if (!res.ok) {
@@ -890,7 +890,13 @@ export async function descriptionSurface({ eventName, repo, head, token, apiBase
   };
 }
 
-async function resolveRefs(numbers, { repo, token, apiBase }) {
+// resolveRefs (and commitsIn / diffOf / apiJson above it) are exported for
+// perf-sentinel-obligation.mjs, which reuses this exact citation-resolution
+// machinery — the same issuesReadability() 404-ambiguity guard included —
+// rather than re-deriving it for its own, narrower "one specific waiver
+// citation" obligation. Nothing here changed to accommodate that reuse;
+// these are the same functions this file's own main() has always called.
+export async function resolveRefs(numbers, { repo, token, apiBase }) {
   const resolved = new Map();
   // The capability probe runs at most once per run, and only once a lookup has
   // actually come back empty: a run whose every citation resolves has nothing

--- a/.github/scripts/lib/nightly-health-notify.mjs
+++ b/.github/scripts/lib/nightly-health-notify.mjs
@@ -1,0 +1,183 @@
+// lib/nightly-health-notify.mjs — the stable-title tracking-issue lifecycle
+// #1861's notify-nightly-failure.mjs (e2e) established, generalised so a
+// second `schedule`-triggered lane (#2370's perf-nightly) can reuse the
+// exact same mechanism rather than re-deriving it.
+//
+// A `schedule` trigger has no PR, no reviewer, no default notification
+// path — a red run reports into a place nobody looks unless something
+// files/refreshes a tracking issue for it. This is that mechanism,
+// factored so it does not know which lane is calling it: every lane-
+// specific fact (the tracking title, which jobs matter, the body text's
+// lane label) is a parameter, never a constant baked in here.
+//
+// node: builtins only (via ./gh.mjs) + the `gh` CLI already authenticated
+// by the calling workflow's GH_TOKEN.
+
+import process from 'node:process';
+import { capture, error, notice } from './gh.mjs';
+
+/**
+ * Pure roll-up over a schedule run's terminal job results. Anything other
+ * than `success` — a real `failure`, a `cancelled` kill, or an unexpected
+ * `skipped` — counts against a clean night, mirroring each lane's own
+ * terminal-aggregator rule.
+ */
+export function classifyNightlyHealth(jobResults) {
+  const failed = Object.entries(jobResults)
+    .filter(([, result]) => result !== 'success')
+    .map(([name, result]) => `${name}: ${result || '(missing)'}`);
+  return { ok: failed.length === 0, failed };
+}
+
+/** Find the open tracking issue, if any, by its exact stable title. Pure so
+ * the dedup logic is tested without a `gh` round-trip. */
+export function findTrackingIssue(issues, title) {
+  const match = (issues || []).find((issue) => issue.title === title);
+  return match ? match.number : null;
+}
+
+/**
+ * Pure decision over (current health) x (an existing tracking issue or
+ * not). Four cells, all named explicitly rather than derived, so a guard
+ * test can drive every one directly.
+ */
+export function decideNotifyAction({ ok, existingIssueNumber }) {
+  const hasExisting = existingIssueNumber !== null && existingIssueNumber !== undefined;
+  if (!ok) {
+    return hasExisting ? { action: 'comment', number: existingIssueNumber } : { action: 'create' };
+  }
+  return hasExisting ? { action: 'close', number: existingIssueNumber } : { action: 'noop' };
+}
+
+/** laneLabel names the lane in the body text (e.g. "e2e", "perf-nightly");
+ * issueRef is the design-rationale issue/PR this mechanism traces back to
+ * for THIS lane (not necessarily #1861 — a lane adopting this mechanism
+ * later should cite its own adoption issue). */
+export function buildFailureBody({ laneLabel, failed, runUrl, runId, issueRef }) {
+  const list = failed.map((f) => `- \`${f}\``).join('\n');
+  return [
+    `The nightly \`${laneLabel}\` schedule run did not reach a clean pass.`,
+    '',
+    `Run: ${runUrl} (id ${runId})`,
+    '',
+    'Non-success jobs (anything but `success` — a real failure, a `cancelled`',
+    'kill, or an unexpected `skipped`):',
+    list,
+    '',
+    `Filed/updated automatically by this lane's notify script — see ${issueRef} for why this mechanism` +
+      ' exists: a nightly that reports red into a place nobody looks is as silent as one that never' +
+      ' reports at all. This issue closes itself on the next clean nightly.',
+  ].join('\n');
+}
+
+export function buildRecoveryBody({ laneLabel, runUrl, runId }) {
+  return [
+    `The nightly \`${laneLabel}\` schedule run reached a clean pass.`,
+    '',
+    `Run: ${runUrl} (id ${runId})`,
+    '',
+    'Closing automatically.',
+  ].join('\n');
+}
+
+function ghOrDie(args, failMessage, contextTitle) {
+  const res = capture('gh', args);
+  if (res.status !== 0) {
+    error(`${failMessage}: ${res.stderr.trim() || res.stdout.trim()}`, { title: contextTitle });
+    process.exit(1);
+  }
+  return res.stdout;
+}
+
+/**
+ * The shared create/comment/close/noop orchestration every lane's `main()`
+ * drives. Exits the process itself (1 on a non-clean night or a `gh`
+ * failure, implicit 0 otherwise) — matches notify-nightly-failure.mjs's
+ * original behaviour, which the lane's own required-check step relies on
+ * to fail loudly.
+ *
+ * trackingLabels: the `gh issue list --label` filter (both ANDed).
+ * trackingTitle: the exact, stable dedup title — never interpolate the run
+ *   id or date into it, or every bad night opens a NEW issue instead of
+ *   refreshing the one that already tracks the incident.
+ * laneLabel / issueRef: passed straight through to buildFailureBody /
+ *   buildRecoveryBody.
+ * contextTitle: the `error()`/`notice()` title tag for this lane's log
+ *   lines (e.g. "nightly-health-notify", "perf-nightly-health-notify").
+ * failureNoticeTitle: the title used specifically on the create/comment
+ *   error() call (e.g. "nightly e2e run failed").
+ */
+export function runNotifyMain({
+  repo,
+  runId,
+  runUrl,
+  jobResults,
+  trackingLabels,
+  trackingTitle,
+  laneLabel,
+  issueRef,
+  contextTitle,
+  failureNoticeTitle,
+}) {
+  const health = classifyNightlyHealth(jobResults);
+
+  const labelArgs = trackingLabels.flatMap((l) => ['--label', l]);
+  const listOut = ghOrDie(
+    ['issue', 'list', '--repo', repo, '--state', 'open', ...labelArgs, '--json', 'number,title', '--limit', '30'],
+    'gh issue list failed',
+    contextTitle,
+  );
+  let issues;
+  try {
+    issues = JSON.parse(listOut);
+  } catch (err) {
+    error(`gh issue list returned unparsable JSON: ${err.message}`, { title: contextTitle });
+    process.exit(1);
+  }
+  const existingIssueNumber = findTrackingIssue(issues, trackingTitle);
+  const decision = decideNotifyAction({ ok: health.ok, existingIssueNumber });
+
+  switch (decision.action) {
+    case 'create': {
+      const body = buildFailureBody({ laneLabel, failed: health.failed, runUrl, runId, issueRef });
+      const out = ghOrDie(
+        ['issue', 'create', '--repo', repo, '--title', trackingTitle, '--body', body, ...labelArgs],
+        'gh issue create failed',
+        contextTitle,
+      );
+      error(`nightly ${laneLabel} run did not reach a clean pass (${health.failed.join('; ')}); filed ${out.trim()}`, {
+        title: failureNoticeTitle,
+      });
+      process.exit(1);
+      break;
+    }
+    case 'comment': {
+      const body = buildFailureBody({ laneLabel, failed: health.failed, runUrl, runId, issueRef });
+      ghOrDie(
+        ['issue', 'comment', String(decision.number), '--repo', repo, '--body', body],
+        'gh issue comment failed',
+        contextTitle,
+      );
+      error(
+        `nightly ${laneLabel} run did not reach a clean pass (${health.failed.join('; ')}); updated #${decision.number}`,
+        { title: failureNoticeTitle },
+      );
+      process.exit(1);
+      break;
+    }
+    case 'close': {
+      const body = buildRecoveryBody({ laneLabel, runUrl, runId });
+      ghOrDie(
+        ['issue', 'close', String(decision.number), '--repo', repo, '--comment', body],
+        'gh issue close failed',
+        contextTitle,
+      );
+      notice(`nightly ${laneLabel} run reached a clean pass; closed tracking issue #${decision.number}.`);
+      break;
+    }
+    case 'noop':
+    default:
+      notice(`nightly ${laneLabel} run reached a clean pass; no tracking issue open.`);
+      break;
+  }
+}

--- a/.github/scripts/main-coalescing.mjs
+++ b/.github/scripts/main-coalescing.mjs
@@ -44,6 +44,7 @@ export const COALESCED_WORKFLOWS = Object.freeze([
   '.github/workflows/migration-e2e.yml',
   '.github/workflows/mutation.yml',
   '.github/workflows/perf-benchmark.yml',
+  '.github/workflows/perf-nightly.yml',
   '.github/workflows/perf-profile.yml',
   '.github/workflows/property.yml',
   '.github/workflows/schema-integration.yml',
@@ -71,6 +72,18 @@ export const NEVER_COALESCED_WORKFLOWS = Object.freeze([
   '.github/workflows/release-gate-drift.yml',
   '.github/workflows/release.yml',
 ]);
+
+// Per-LANE exclusion, finer than NEVER_COALESCED_WORKFLOWS: perf-nightly.yml
+// is genuinely mixed — its `perf-nightly` job needs coalescing (a real,
+// expensive ClickHouse run that a rapid main push should replace, not
+// queue behind), but `perf-nightly-health-notify` runs only on
+// `schedule` (`if: github.event_name == 'schedule'`) and never on the
+// push-to-main trigger the workflow otherwise coalesces for, so its own
+// lane posture correctly stays `never` even though its owning workflow is
+// coalesced-enrolled. A whole-workflow exclusion (the perf-benchmark
+// pattern below) does not fit here because the OTHER lane in the same
+// workflow does need coalescing.
+export const NEVER_COALESCED_LANES = Object.freeze(new Set(['perf-nightly.perf-nightly-health-notify']));
 
 export const QUICKSTART_GROUP_EXPRESSION =
   "quickstart-${{ github.event_name == 'pull_request' && github.event.pull_request.number || github.run_id }}";
@@ -354,6 +367,7 @@ export function auditMainCoalescing(root = process.cwd()) {
       continue;
     }
     for (const lane of lanes) {
+      if (NEVER_COALESCED_LANES.has(lane.id)) continue;
       if (lane.main_posture !== 'coalesced') {
         problems.push(
           `${lane.id}: owner ${workflow} is latest-main enrolled but lane posture is ${lane.main_posture}`,
@@ -368,6 +382,15 @@ export function auditMainCoalescing(root = process.cwd()) {
   if (benchmark.length === 0 || benchmark.some((lane) => lane.main_posture !== 'never')) {
     problems.push(
       'perf-benchmark schedule is coalesced, but its no-push main posture must remain never',
+    );
+  }
+
+  const nightlyNotify = registry.lanes.find((lane) => lane.id === 'perf-nightly.perf-nightly-health-notify');
+  if (!nightlyNotify || nightlyNotify.main_posture !== 'never') {
+    problems.push(
+      'perf-nightly.perf-nightly-health-notify must remain main-never — it runs only on schedule ' +
+        "(if: github.event_name == 'schedule'), never on the push-to-main trigger the rest of its " +
+        'owning workflow coalesces for',
     );
   }
 

--- a/.github/scripts/notify-nightly-failure.mjs
+++ b/.github/scripts/notify-nightly-failure.mjs
@@ -26,21 +26,11 @@
 // What this does
 // ---------------
 // Runs as the last job of a `schedule`-triggered e2e.yml run, downstream of
-// every terminal aggregator/leaf job the lane has. Rolls their `needs.*.result`
-// facts up with the same strict `!== 'success'` rule the aggregators
-// themselves use (catches `failure` AND `cancelled` AND an unexpected
-// `skipped` in one comparison — see perf-guards-aggregate.mjs / dashboard's
-// own gate step for the same rule applied one level up):
-//
-//   - not all clean -> open or update the ONE nightly-health tracking issue
-//     (matched by an exact, stable title so consecutive bad nights update the
-//     same issue instead of piling up duplicates) and exit 1, so the job
-//     itself is loud too.
-//   - all clean, and a tracking issue is open -> comment + close it. A
-//     tracking issue nobody ever closes is its own kind of noise: the next
-//     person to look would not be able to tell a live incident from a stale
-//     one.
-//   - all clean, no tracking issue -> nothing to do.
+// every terminal aggregator/leaf job the lane has. The actual create/
+// comment/close/noop lifecycle lives in lib/nightly-health-notify.mjs,
+// shared with #2370's perf-nightly lane (notify-perf-nightly-failure.mjs) —
+// this file supplies only what's specific to e2e: which jobs matter, the
+// stable tracking title, and the labels.
 //
 // Uses the existing `automated` + `area/ci` labels (both already exist in the
 // repo) rather than a new label, so there is no separate label-provisioning
@@ -63,7 +53,16 @@
 // by the workflow's GH_TOKEN.
 
 import process from 'node:process';
-import { capture, error, notice } from './lib/gh.mjs';
+import {
+  classifyNightlyHealth,
+  findTrackingIssue,
+  decideNotifyAction,
+  buildFailureBody as libBuildFailureBody,
+  buildRecoveryBody as libBuildRecoveryBody,
+  runNotifyMain,
+} from './lib/nightly-health-notify.mjs';
+
+export { classifyNightlyHealth, findTrackingIssue, decideNotifyAction };
 
 /** The one label pair used to find (and file) the tracking issue. Both
  * already exist as repo labels; `gh issue list --label` ANDs multiple
@@ -75,67 +74,12 @@ export const NIGHTLY_TRACKING_LABELS = ['automated', 'area/ci'];
  * refreshing the one that already tracks the incident. */
 export const NIGHTLY_TRACKING_TITLE = 'nightly e2e run did not reach a clean pass';
 
-/**
- * Pure roll-up over the terminal job results a schedule run produces.
- * Mirrors the aggregators' own rule: anything other than `success` — a real
- * `failure`, a `cancelled` kill, or an unexpected `skipped` — counts against
- * a clean night. Every job named here is unconditional on `schedule` (see
- * each job's own `if:` in e2e.yml), so `skipped` is never the benign case it
- * would be on another trigger.
- */
-export function classifyNightlyHealth(jobResults) {
-  const failed = Object.entries(jobResults)
-    .filter(([, result]) => result !== 'success')
-    .map(([name, result]) => `${name}: ${result || '(missing)'}`);
-  return { ok: failed.length === 0, failed };
-}
-
-/** Find the open tracking issue, if any, by its exact stable title. Pure so
- * the dedup logic is tested without a `gh` round-trip. */
-export function findTrackingIssue(issues, title) {
-  const match = (issues || []).find((issue) => issue.title === title);
-  return match ? match.number : null;
-}
-
-/**
- * Pure decision over (current health) x (an existing tracking issue or not).
- * Four cells, all named explicitly rather than derived, so a guard test can
- * drive every one directly.
- */
-export function decideNotifyAction({ ok, existingIssueNumber }) {
-  const hasExisting = existingIssueNumber !== null && existingIssueNumber !== undefined;
-  if (!ok) {
-    return hasExisting ? { action: 'comment', number: existingIssueNumber } : { action: 'create' };
-  }
-  return hasExisting ? { action: 'close', number: existingIssueNumber } : { action: 'noop' };
-}
-
 export function buildFailureBody({ failed, runUrl, runId }) {
-  const list = failed.map((f) => `- \`${f}\``).join('\n');
-  return [
-    'The nightly `e2e` schedule run did not reach a clean pass.',
-    '',
-    `Run: ${runUrl} (id ${runId})`,
-    '',
-    'Non-success jobs (anything but `success` — a real failure, a `cancelled`',
-    'kill, or an unexpected `skipped`):',
-    list,
-    '',
-    'Filed/updated automatically by `.github/scripts/notify-nightly-failure.mjs`' +
-      ' — see tsouza/cerberus#1861 for why this exists: a nightly that reports' +
-      ' red into a place nobody looks is as silent as one that never reports at' +
-      ' all. This issue closes itself on the next clean nightly.',
-  ].join('\n');
+  return libBuildFailureBody({ laneLabel: 'e2e', failed, runUrl, runId, issueRef: 'tsouza/cerberus#1861' });
 }
 
 export function buildRecoveryBody({ runUrl, runId }) {
-  return [
-    'The nightly `e2e` schedule run reached a clean pass.',
-    '',
-    `Run: ${runUrl} (id ${runId})`,
-    '',
-    'Closing automatically — see `.github/scripts/notify-nightly-failure.mjs`.',
-  ].join('\n');
+  return libBuildRecoveryBody({ laneLabel: 'e2e', runUrl, runId });
 }
 
 function readJobResults(env) {
@@ -150,88 +94,19 @@ function readJobResults(env) {
   };
 }
 
-function ghOrDie(args, failMessage) {
-  const res = capture('gh', args);
-  if (res.status !== 0) {
-    error(`${failMessage}: ${res.stderr.trim() || res.stdout.trim()}`, { title: 'nightly-health-notify' });
-    process.exit(1);
-  }
-  return res.stdout;
-}
-
 function main() {
-  const repo = process.env.REPO ?? '';
-  const runId = process.env.RUN_ID ?? '';
-  const runUrl = process.env.RUN_URL ?? '';
-  const jobResults = readJobResults(process.env);
-
-  const health = classifyNightlyHealth(jobResults);
-
-  const labelArgs = NIGHTLY_TRACKING_LABELS.flatMap((l) => ['--label', l]);
-  const listOut = ghOrDie(
-    ['issue', 'list', '--repo', repo, '--state', 'open', ...labelArgs, '--json', 'number,title', '--limit', '30'],
-    'gh issue list failed',
-  );
-  let issues;
-  try {
-    issues = JSON.parse(listOut);
-  } catch (err) {
-    error(`gh issue list returned unparsable JSON: ${err.message}`, { title: 'nightly-health-notify' });
-    process.exit(1);
-  }
-  const existingIssueNumber = findTrackingIssue(issues, NIGHTLY_TRACKING_TITLE);
-  const decision = decideNotifyAction({ ok: health.ok, existingIssueNumber });
-
-  switch (decision.action) {
-    case 'create': {
-      const body = buildFailureBody({ failed: health.failed, runUrl, runId });
-      const out = ghOrDie(
-        [
-          'issue',
-          'create',
-          '--repo',
-          repo,
-          '--title',
-          NIGHTLY_TRACKING_TITLE,
-          '--body',
-          body,
-          ...labelArgs,
-        ],
-        'gh issue create failed',
-      );
-      error(`nightly e2e run did not reach a clean pass (${health.failed.join('; ')}); filed ${out.trim()}`, {
-        title: 'nightly e2e run failed',
-      });
-      process.exit(1);
-      break;
-    }
-    case 'comment': {
-      const body = buildFailureBody({ failed: health.failed, runUrl, runId });
-      ghOrDie(
-        ['issue', 'comment', String(decision.number), '--repo', repo, '--body', body],
-        'gh issue comment failed',
-      );
-      error(
-        `nightly e2e run did not reach a clean pass (${health.failed.join('; ')}); updated #${decision.number}`,
-        { title: 'nightly e2e run failed' },
-      );
-      process.exit(1);
-      break;
-    }
-    case 'close': {
-      const body = buildRecoveryBody({ runUrl, runId });
-      ghOrDie(
-        ['issue', 'close', String(decision.number), '--repo', repo, '--comment', body],
-        'gh issue close failed',
-      );
-      notice(`nightly e2e run reached a clean pass; closed tracking issue #${decision.number}.`);
-      break;
-    }
-    case 'noop':
-    default:
-      notice('nightly e2e run reached a clean pass; no tracking issue open.');
-      break;
-  }
+  runNotifyMain({
+    repo: process.env.REPO ?? '',
+    runId: process.env.RUN_ID ?? '',
+    runUrl: process.env.RUN_URL ?? '',
+    jobResults: readJobResults(process.env),
+    trackingLabels: NIGHTLY_TRACKING_LABELS,
+    trackingTitle: NIGHTLY_TRACKING_TITLE,
+    laneLabel: 'e2e',
+    issueRef: 'tsouza/cerberus#1861',
+    contextTitle: 'nightly-health-notify',
+    failureNoticeTitle: 'nightly e2e run failed',
+  });
 }
 
 // Only dispatch when run as a script — importing for the unit test must not

--- a/.github/scripts/notify-perf-nightly-failure.mjs
+++ b/.github/scripts/notify-perf-nightly-failure.mjs
@@ -1,0 +1,69 @@
+// notify-perf-nightly-failure.mjs — file (or refresh) a single tracking
+// issue when the #2370 nightly `perf-nightly` schedule run does not reach a
+// clean pass, and close it automatically on the next clean night.
+//
+// Why this exists
+// ---------------
+// perf-nightly.yml's `schedule` trigger has no PR, no reviewer, no default
+// notification path — exactly the gap #1861 named for e2e.yml's own nightly
+// run (see notify-nightly-failure.mjs's fuller "why"), and the same gap
+// applies here: a regression in the #2370 statistical gate (a real
+// production-cardinality query starting to OOM again, or a genuine memory
+// or outcome-class regression the gate is designed to catch) reports red
+// into a place nobody looks unless something files/refreshes a tracking
+// issue for it. This reuses lib/nightly-health-notify.mjs's mechanism
+// verbatim rather than re-deriving it — the SAME create/comment/close/noop
+// lifecycle, a distinct stable title so the two lanes' incidents never
+// collide.
+//
+// perf-nightly has one job (unlike e2e's seven), so this file's own
+// "what's specific" surface is smaller: one RESULT_* env var.
+//
+// Env:
+//   REPO             `owner/repo` (github.repository).
+//   RUN_ID / RUN_URL identify the run in the issue body.
+//   RESULT_PERF_NIGHTLY  `needs.perf-nightly.result`.
+//
+// Exit: 0 when the nightly reached a clean pass (whether or not a stale
+// tracking issue needed closing); 1 when it did not, or when the gh calls
+// themselves fail.
+//
+// node: builtins only (via lib/gh.mjs) + the `gh` CLI already authenticated
+// by the workflow's GH_TOKEN.
+
+import process from 'node:process';
+import { runNotifyMain } from './lib/nightly-health-notify.mjs';
+
+/** Mirrors notify-nightly-failure.mjs's NIGHTLY_TRACKING_LABELS — same two
+ * pre-existing repo labels, no new label-provisioning step. */
+export const PERF_NIGHTLY_TRACKING_LABELS = ['automated', 'area/ci'];
+
+/** Exact, stable title — the dedup key, distinct from e2e's own so the two
+ * lanes never share or clobber a tracking issue. */
+export const PERF_NIGHTLY_TRACKING_TITLE = 'nightly perf-nightly run did not reach a clean pass';
+
+function readJobResults(env) {
+  return {
+    'perf-nightly': env.RESULT_PERF_NIGHTLY ?? '',
+  };
+}
+
+function main() {
+  runNotifyMain({
+    repo: process.env.REPO ?? '',
+    runId: process.env.RUN_ID ?? '',
+    runUrl: process.env.RUN_URL ?? '',
+    jobResults: readJobResults(process.env),
+    trackingLabels: PERF_NIGHTLY_TRACKING_LABELS,
+    trackingTitle: PERF_NIGHTLY_TRACKING_TITLE,
+    laneLabel: 'perf-nightly',
+    issueRef: 'tsouza/cerberus#2370',
+    contextTitle: 'perf-nightly-health-notify',
+    failureNoticeTitle: 'nightly perf-nightly run failed',
+  });
+}
+
+// Only dispatch when run as a script — importing for the unit test must not
+// exit the test runner or shell out to `gh`.
+const invokedDirectly = process.argv[1] && import.meta.url === new URL(`file://${process.argv[1]}`).href;
+if (invokedDirectly) main();

--- a/.github/scripts/notify-perf-nightly-failure.test.mjs
+++ b/.github/scripts/notify-perf-nightly-failure.test.mjs
@@ -1,0 +1,93 @@
+// notify-perf-nightly-failure.test.mjs — node:test guard for #2370's
+// perf-nightly tracking-issue roll-up, the second consumer of
+// lib/nightly-health-notify.mjs (the #1861 mechanism e2e.yml's own
+// notify-nightly-failure.mjs established first).
+//
+// The pure roll-up/dedup/decision functions are already exhaustively
+// pinned by notify-nightly-failure.test.mjs against the SAME
+// lib/nightly-health-notify.mjs implementation — re-asserting them here
+// would just be testing the same function object twice. This file covers
+// what's actually specific to this consumer: its own constants, its
+// single-job result shape, the generalised body builders taking a
+// `laneLabel`, and the workflow/ci wiring.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+import { classifyNightlyHealth } from './lib/nightly-health-notify.mjs';
+import { PERF_NIGHTLY_TRACKING_LABELS, PERF_NIGHTLY_TRACKING_TITLE } from './notify-perf-nightly-failure.mjs';
+import { buildFailureBody, buildRecoveryBody } from './lib/nightly-health-notify.mjs';
+
+test('perf-nightly single-job success is a clean night', () => {
+  const v = classifyNightlyHealth({ 'perf-nightly': 'success' });
+  assert.equal(v.ok, true);
+  assert.deepEqual(v.failed, []);
+});
+
+test('perf-nightly single-job failure is caught', () => {
+  const v = classifyNightlyHealth({ 'perf-nightly': 'failure' });
+  assert.equal(v.ok, false);
+  assert.deepEqual(v.failed, ['perf-nightly: failure']);
+});
+
+test('a missing/empty result reads as a failure, not a silent pass', () => {
+  const v = classifyNightlyHealth({ 'perf-nightly': '' });
+  assert.equal(v.ok, false);
+  assert.match(v.failed[0], /perf-nightly: \(missing\)/);
+});
+
+test('the tracking title is distinct from e2e\'s own', () => {
+  assert.equal(PERF_NIGHTLY_TRACKING_TITLE, 'nightly perf-nightly run did not reach a clean pass');
+  assert.notEqual(PERF_NIGHTLY_TRACKING_TITLE, 'nightly e2e run did not reach a clean pass');
+});
+
+test('the tracking labels match the shared automated + area/ci pair', () => {
+  assert.deepEqual(PERF_NIGHTLY_TRACKING_LABELS, ['automated', 'area/ci']);
+});
+
+test('buildFailureBody names the perf-nightly lane and the run', () => {
+  const body = buildFailureBody({
+    laneLabel: 'perf-nightly',
+    failed: ['perf-nightly: failure'],
+    runUrl: 'https://x/run/1',
+    runId: '1',
+    issueRef: 'tsouza/cerberus#2370',
+  });
+  assert.match(body, /`perf-nightly`/);
+  assert.match(body, /perf-nightly: failure/);
+  assert.match(body, /https:\/\/x\/run\/1/);
+  assert.match(body, /#2370/);
+});
+
+test('buildRecoveryBody names the perf-nightly lane and the run', () => {
+  const body = buildRecoveryBody({ laneLabel: 'perf-nightly', runUrl: 'https://x/run/2', runId: '2' });
+  assert.match(body, /`perf-nightly`/);
+  assert.match(body, /https:\/\/x\/run\/2/);
+  assert.match(body, /clean pass/);
+});
+
+// Wiring pins, mirroring notify-nightly-failure.test.mjs's regex-over-source
+// approach: a job/needs edit that silently drops the trigger scope or
+// widens it off `schedule` compiles fine and passes every unit test above,
+// so the only thing that catches it is pinning the source text directly.
+
+const perfNightlyWorkflow = readFileSync(resolve('.github/workflows/perf-nightly.yml'), 'utf8');
+const ciWorkflow = readFileSync(resolve('.github/workflows/ci.yml'), 'utf8');
+
+test('perf-nightly-health-notify needs perf-nightly and runs on schedule only', () => {
+  assert.match(
+    perfNightlyWorkflow,
+    /perf-nightly-health-notify:\n {4}name: perf-nightly-health-notify\n {4}needs: \[perf-nightly\]\n {4}if: always\(\) && github\.event_name == 'schedule'/,
+  );
+});
+
+test('perf-nightly-health-notify has issues: write and invokes the script', () => {
+  assert.match(perfNightlyWorkflow, /perf-nightly-health-notify[\s\S]{0,400}issues: write/);
+  assert.match(perfNightlyWorkflow, /run: node \.github\/scripts\/notify-perf-nightly-failure\.mjs/);
+});
+
+test('the self-test runs on the PR path via ci.yml', () => {
+  assert.match(ciWorkflow, /node --test \.github\/scripts\/notify-perf-nightly-failure\.test\.mjs/);
+});

--- a/.github/scripts/perf-sentinel-obligation.mjs
+++ b/.github/scripts/perf-sentinel-obligation.mjs
@@ -1,0 +1,241 @@
+// perf-sentinel-obligation.mjs — the same-PR obligation gate for #2370's
+// perf sentinel corpora.
+//
+// Repo policy, one level more specific than forbid-deferral.mjs's own
+// "work becomes an issue, filed before merge" discipline: a change to
+// `internal/engine/query_settings_rules.go` or `internal/engine/spill.go`
+// — the two files defining which per-query settings the engine's memory-
+// bounding mechanisms apply, and how — is exactly the shape of change
+// #2364 traced back to. #2358 silently removed a CSE fold those settings
+// relied on; production hit MEMORY_LIMIT_EXCEEDED 6h8m later (#2364),
+// because nothing in CI measured real memory at real scale. test/perf/
+// smoke's sentinel corpus (sentinels.go) and #2370's nightly one
+// (test/perf/nightly/sentinels.go) exist specifically to catch this class
+// before it reaches production — a change to the settings machinery that
+// adds no new sentinel coverage risks shipping in exactly the state #2364
+// did.
+//
+// So: a diff touching either settings file must ALSO touch one of the two
+// sentinel files, or cite a waiver — `PERF-SENTINEL-WAIVER: #<issue>` —
+// naming an OPEN issue tracking why new coverage genuinely isn't owed by
+// this change (a pure refactor with no behavioural change, verified by a
+// human reviewer, is the shape this exists for; this gate cannot make
+// that judgement itself, only require someone did).
+//
+// WHAT IS SCANNED for the waiver citation — the same two surfaces
+// forbid-deferral.mjs reads for a marker's citation, minus the diff
+// itself: the pull request description and the commit messages in the
+// range base..head. Not the diff: `PERF-SENTINEL-WAIVER:` is a statement
+// ABOUT the change, not code, so requiring it in a source comment would
+// force an otherwise-unnecessary edit into files this gate is trying to
+// keep additions-only.
+//
+// Citation resolution reuses forbid-deferral.mjs's own machinery
+// verbatim — resolveRefs, issuesReadability's 404-ambiguity guard,
+// descriptionSurface's per-event-type resolution, commitsIn, diffOf —
+// rather than re-deriving any of it. See forbid-deferral.mjs's own header
+// for the full "why" behind each piece (the capability probe, the
+// per-part description attribution, the 404-means-two-things problem).
+//
+// Env contract: identical to forbid-deferral.mjs's (see its header) —
+// GITHUB_REPOSITORY, GITHUB_TOKEN, GITHUB_EVENT_NAME, PR_BODY,
+// GITHUB_EVENT_PATH, BASE_SHA, HEAD_SHA, GITHUB_API_URL.
+//
+// The pure halves of this module are exported and pinned by
+// perf-sentinel-obligation.test.mjs; the scan itself runs only when this
+// file is invoked as the program.
+//
+// Exit codes: 0 = the trigger files were not touched, or were touched
+// alongside sentinel coverage or a valid open-issue waiver; 1 = touched
+// with neither, or a malformed input.
+
+import process from 'node:process';
+import { pathToFileURL } from 'node:url';
+
+import { appendStepSummary, error, log, notice } from './lib/gh.mjs';
+import {
+  commitsIn,
+  descriptionSurface,
+  diffOf,
+  parseDiff,
+  resolveRange,
+  resolveRefs,
+} from './forbid-deferral.mjs';
+
+// TRIGGER_FILES — touching any of these is what obligates new sentinel
+// coverage (or a waiver). Repo-root-relative paths, exactly as `git diff`
+// reports them.
+export const TRIGGER_FILES = Object.freeze([
+  'internal/engine/query_settings_rules.go',
+  'internal/engine/spill.go',
+]);
+
+// SENTINEL_FILES — touching either satisfies the obligation directly, no
+// waiver needed. Both corpora are named (not just one) because either is
+// real, current coverage: a change that adds a smoke-tier sentinel is
+// exactly as much new coverage as one that adds a nightly one.
+export const SENTINEL_FILES = Object.freeze([
+  'test/perf/smoke/sentinels.go',
+  'test/perf/nightly/sentinels.go',
+]);
+
+// WAIVER_PATTERN matches the single accepted waiver shape: the label,
+// immediately followed by its own citation — unlike forbid-deferral.mjs's
+// markers, which are found first and matched to a NEARBY citation, this
+// marker self-contains its citation by construction, so there is nothing
+// to search a window around.
+export const WAIVER_PATTERN = /PERF-SENTINEL-WAIVER:\s*#(\d+)\b/g;
+
+// waiverRefs — every #<n> a PERF-SENTINEL-WAIVER: label cites in `text`.
+export function waiverRefs(text) {
+  const src = String(text ?? '');
+  const numbers = new Set();
+  for (const m of src.matchAll(WAIVER_PATTERN)) numbers.add(Number(m[1]));
+  return [...numbers].sort((a, b) => a - b);
+}
+
+// needsObligation — does this changed-file set touch a trigger file?
+export function needsObligation(files) {
+  return (files ?? []).some((f) => TRIGGER_FILES.includes(f));
+}
+
+// satisfiesViaSentinel — did the SAME changed-file set also touch a
+// sentinel corpus?
+export function satisfiesViaSentinel(files) {
+  return (files ?? []).some((f) => SENTINEL_FILES.includes(f));
+}
+
+// verdict — the pure decision, given the changed files and every waiver
+// number found across the scanned surfaces, each resolved to its
+// kind/state via the SAME resolution forbid-deferral.mjs uses.
+// `resolved` maps number -> { kind: 'missing' | 'pull-request' | 'issue',
+// state }, exactly resolveRefs's own return shape.
+export function verdict({ files, waiverNumbers, resolved }) {
+  if (!needsObligation(files)) {
+    return { obligated: false };
+  }
+  if (satisfiesViaSentinel(files)) {
+    return { obligated: true, satisfied: true, via: 'sentinel' };
+  }
+  const reasons = [];
+  for (const n of waiverNumbers ?? []) {
+    const r = resolved?.get(n);
+    if (!r || r.kind === 'missing') {
+      reasons.push(`#${n} names nothing in this repository`);
+      continue;
+    }
+    if (r.kind === 'pull-request') {
+      reasons.push(`#${n} is a pull request, not an issue`);
+      continue;
+    }
+    if (r.state !== 'open') {
+      reasons.push(`#${n} is a ${r.state} issue, so it does not track an active waiver`);
+      continue;
+    }
+    return { obligated: true, satisfied: true, via: 'waiver', number: n };
+  }
+  return {
+    obligated: true,
+    satisfied: false,
+    reason:
+      waiverNumbers && waiverNumbers.length > 0
+        ? reasons.join('; ')
+        : 'no PERF-SENTINEL-WAIVER: #<issue> citation was found in the description or commit messages',
+  };
+}
+
+const REMEDY =
+  'This change touches a memory-bounding settings file '
+  + `(${TRIGGER_FILES.join(' or ')}) without touching either sentinel corpus `
+  + `(${SENTINEL_FILES.join(' or ')}). Remedy, whichever is true: (1) add a `
+  + 'sentinel that would have caught this class of change (see test/perf/smoke/'
+  + 'sentinels.go or test/perf/nightly/sentinels.go for the shape); or (2) if '
+  + 'new coverage is genuinely not owed here — a pure refactor with no '
+  + 'behavioural change, verified by review — open an issue saying so and cite '
+  + 'it as `PERF-SENTINEL-WAIVER: #<issue>` in the PR description or a commit '
+  + 'message.';
+
+async function main() {
+  const repo = process.env.GITHUB_REPOSITORY;
+  if (!repo) throw new Error('GITHUB_REPOSITORY is unset — the gate cannot resolve a cited waiver without it');
+  const token = process.env.GITHUB_TOKEN;
+  if (!token) throw new Error('GITHUB_TOKEN is unset — resolving a cited waiver needs issues:read');
+  const eventName = process.env.GITHUB_EVENT_NAME;
+  if (!eventName) throw new Error('GITHUB_EVENT_NAME is unset — the description surface is resolved per event');
+  const apiBase = process.env.GITHUB_API_URL || 'https://api.github.com';
+
+  const { base, head } = resolveRange({
+    baseSha: process.env.BASE_SHA,
+    headSha: process.env.HEAD_SHA,
+  });
+
+  const commits = commitsIn(base, head);
+  if (commits.length === 0) {
+    throw new Error(
+      `${base.slice(0, 12)}..${head.slice(0, 12)} resolved to zero commits — the gate would `
+        + 'inspect no change at all',
+    );
+  }
+
+  const diffText = diffOf(base, head);
+  const { files } = parseDiff(diffText);
+  if (files.length === 0) {
+    throw new Error(
+      `${base.slice(0, 12)}...${head.slice(0, 12)} parsed to an empty file set — either the `
+        + 'range is wrong or the diff parser stopped understanding git output',
+    );
+  }
+
+  if (!needsObligation(files)) {
+    notice(
+      `perf-sentinel-obligation: neither ${TRIGGER_FILES.join(' nor ')} was touched — no obligation.`,
+      { title: 'perf-sentinel-obligation' },
+    );
+    return;
+  }
+
+  const description = await descriptionSurface({ eventName, repo, head, token, apiBase });
+  const waiverText = [
+    ...description.parts.map((p) => p.text),
+    ...commits.map((c) => c.message),
+  ].join('\n\n');
+  const waiverNumbers = waiverRefs(waiverText);
+  const resolved = waiverNumbers.length > 0
+    ? await resolveRefs(waiverNumbers, { repo, token, apiBase })
+    : new Map();
+
+  const v = verdict({ files, waiverNumbers, resolved });
+
+  const inspected = [
+    `- trigger files touched: ${TRIGGER_FILES.filter((f) => files.includes(f)).join(', ')}`,
+    `- sentinel files touched: ${SENTINEL_FILES.filter((f) => files.includes(f)).join(', ') || '(none)'}`,
+    `- waiver citations found: ${waiverNumbers.length > 0 ? waiverNumbers.map((n) => `#${n}`).join(', ') : '(none)'}`,
+  ];
+  appendStepSummary(
+    [
+      '## perf-sentinel-obligation',
+      '',
+      ...inspected,
+      '',
+      v.satisfied ? `Satisfied via ${v.via}${v.number ? ` (#${v.number})` : ''}.` : `Not satisfied: ${v.reason}`,
+    ].join('\n'),
+  );
+  for (const line of inspected) log(line.replace(/[*`]/g, ''));
+
+  if (!v.satisfied) {
+    error(`perf-sentinel-obligation: ${v.reason}. ${REMEDY}`, { title: 'perf-sentinel-obligation' });
+    process.exit(1);
+  }
+
+  notice(
+    `perf-sentinel-obligation: satisfied via ${v.via}${v.number ? ` (#${v.number})` : ''}.`,
+    { title: 'perf-sentinel-obligation' },
+  );
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main().catch((e) => {
+    error(`perf-sentinel-obligation: ${String(e?.message ?? e)}`, { title: 'perf-sentinel-obligation' });
+    process.exit(1);
+  });
+}

--- a/.github/scripts/perf-sentinel-obligation.test.mjs
+++ b/.github/scripts/perf-sentinel-obligation.test.mjs
@@ -1,0 +1,196 @@
+// perf-sentinel-obligation.test.mjs — node:test guard for #2370's
+// same-PR obligation gate over the memory-bounding settings files.
+//
+// Pins both directions, matching forbid-deferral.test.mjs's own
+// discipline: a change to a trigger file with no sentinel coverage and no
+// waiver must FAIL, and every honest resolution (sentinel coverage, an
+// open-issue waiver) must PASS — a test file that only asserted the
+// rejection path would be satisfied by a gate that always fails, and one
+// that only asserted the happy path would be satisfied by a gate that
+// never fires at all.
+
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+import {
+  TRIGGER_FILES,
+  SENTINEL_FILES,
+  WAIVER_PATTERN,
+  waiverRefs,
+  needsObligation,
+  satisfiesViaSentinel,
+  verdict,
+} from './perf-sentinel-obligation.mjs';
+
+// The three real fixtures forbid-deferral.test.mjs already established for
+// this repository — reused here rather than inventing new ones, since the
+// citation-resolution shape (kind/state) is identical.
+const RESOLVED = new Map([
+  [1535, { kind: 'issue', state: 'open' }],
+  [1486, { kind: 'issue', state: 'closed' }],
+  [1143, { kind: 'pull-request', state: 'closed' }],
+]);
+
+// --- constants ---------------------------------------------------------------
+
+test('the trigger and sentinel file lists are non-empty and disjoint', () => {
+  assert.ok(TRIGGER_FILES.length > 0, 'an empty trigger list makes the gate vacuous');
+  assert.ok(SENTINEL_FILES.length > 0, 'an empty sentinel list makes every obligation unsatisfiable');
+  for (const f of TRIGGER_FILES) {
+    assert.ok(!SENTINEL_FILES.includes(f), `${f} cannot be both a trigger and a satisfying sentinel file`);
+  }
+});
+
+test('WAIVER_PATTERN compiles and is global (matchAll-safe)', () => {
+  assert.ok(WAIVER_PATTERN.flags.includes('g'));
+});
+
+// --- waiverRefs ---------------------------------------------------------------
+
+test('waiverRefs extracts the cited issue number', () => {
+  assert.deepEqual(waiverRefs('PERF-SENTINEL-WAIVER: #1535'), [1535]);
+});
+
+test('waiverRefs is case- and spacing-tolerant is NOT required — exact label only', () => {
+  // Deliberately strict: this is an opt-in marker a human writes on purpose,
+  // unlike forbid-deferral's markers which must catch loose prose. Requiring
+  // the exact label keeps the citation searchable and greppable.
+  assert.deepEqual(waiverRefs('perf-sentinel-waiver: #1535'), []);
+});
+
+test('waiverRefs finds multiple distinct citations and de-duplicates', () => {
+  assert.deepEqual(
+    waiverRefs('PERF-SENTINEL-WAIVER: #1535\n\nAlso PERF-SENTINEL-WAIVER: #1535 and PERF-SENTINEL-WAIVER: #1486'),
+    [1486, 1535],
+  );
+});
+
+test('waiverRefs returns empty on prose with no label at all', () => {
+  assert.deepEqual(waiverRefs('This change tunes spill.go for #1535, no new sentinel needed.'), []);
+});
+
+test('waiverRefs handles null/undefined input without throwing', () => {
+  assert.deepEqual(waiverRefs(undefined), []);
+  assert.deepEqual(waiverRefs(null), []);
+});
+
+// --- needsObligation / satisfiesViaSentinel -----------------------------------
+
+test('needsObligation is true when a trigger file is in the changed set', () => {
+  assert.equal(needsObligation(['internal/engine/spill.go', 'docs/README.md']), true);
+});
+
+test('needsObligation is false when no trigger file is touched', () => {
+  assert.equal(needsObligation(['internal/engine/other.go', 'docs/README.md']), false);
+});
+
+test('needsObligation is false on an empty or missing file list', () => {
+  assert.equal(needsObligation([]), false);
+  assert.equal(needsObligation(undefined), false);
+});
+
+test('satisfiesViaSentinel is true when either sentinel file is touched', () => {
+  assert.equal(satisfiesViaSentinel(['test/perf/smoke/sentinels.go']), true);
+  assert.equal(satisfiesViaSentinel(['test/perf/nightly/sentinels.go']), true);
+});
+
+test('satisfiesViaSentinel is false when neither is touched', () => {
+  assert.equal(satisfiesViaSentinel(['test/perf/smoke/seed.go']), false);
+});
+
+// --- verdict -------------------------------------------------------------------
+
+test('verdict: no trigger file touched -> not obligated at all', () => {
+  const v = verdict({ files: ['docs/README.md'], waiverNumbers: [], resolved: new Map() });
+  assert.deepEqual(v, { obligated: false });
+});
+
+test('verdict: trigger file touched alongside smoke sentinel -> satisfied', () => {
+  const v = verdict({
+    files: ['internal/engine/spill.go', 'test/perf/smoke/sentinels.go'],
+    waiverNumbers: [],
+    resolved: new Map(),
+  });
+  assert.equal(v.obligated, true);
+  assert.equal(v.satisfied, true);
+  assert.equal(v.via, 'sentinel');
+});
+
+test('verdict: trigger file touched alongside nightly sentinel -> satisfied', () => {
+  const v = verdict({
+    files: ['internal/engine/query_settings_rules.go', 'test/perf/nightly/sentinels.go'],
+    waiverNumbers: [],
+    resolved: new Map(),
+  });
+  assert.equal(v.obligated, true);
+  assert.equal(v.satisfied, true);
+  assert.equal(v.via, 'sentinel');
+});
+
+test('verdict: trigger file touched, no sentinel, an OPEN waiver -> satisfied', () => {
+  const v = verdict({
+    files: ['internal/engine/spill.go'],
+    waiverNumbers: [1535],
+    resolved: RESOLVED,
+  });
+  assert.equal(v.obligated, true);
+  assert.equal(v.satisfied, true);
+  assert.equal(v.via, 'waiver');
+  assert.equal(v.number, 1535);
+});
+
+test('verdict: trigger file touched, no sentinel, no waiver at all -> unsatisfied', () => {
+  const v = verdict({ files: ['internal/engine/spill.go'], waiverNumbers: [], resolved: new Map() });
+  assert.equal(v.obligated, true);
+  assert.equal(v.satisfied, false);
+  assert.match(v.reason, /no PERF-SENTINEL-WAIVER/);
+});
+
+test('verdict: waiver cites a CLOSED issue -> unsatisfied, named as such', () => {
+  const v = verdict({ files: ['internal/engine/spill.go'], waiverNumbers: [1486], resolved: RESOLVED });
+  assert.equal(v.satisfied, false);
+  assert.match(v.reason, /#1486 is a closed issue/);
+});
+
+test('verdict: waiver cites a PULL REQUEST, not an issue -> unsatisfied, named as such', () => {
+  const v = verdict({ files: ['internal/engine/spill.go'], waiverNumbers: [1143], resolved: RESOLVED });
+  assert.equal(v.satisfied, false);
+  assert.match(v.reason, /#1143 is a pull request/);
+});
+
+test('verdict: waiver cites a number that names nothing -> unsatisfied, named as such', () => {
+  const v = verdict({ files: ['internal/engine/spill.go'], waiverNumbers: [999999], resolved: new Map() });
+  assert.equal(v.satisfied, false);
+  assert.match(v.reason, /#999999 names nothing/);
+});
+
+test('verdict: multiple waiver citations — the first VALID one satisfies, even if cited after an invalid one', () => {
+  const v = verdict({
+    files: ['internal/engine/spill.go'],
+    waiverNumbers: [1486, 1535],
+    resolved: RESOLVED,
+  });
+  assert.equal(v.satisfied, true);
+  assert.equal(v.number, 1535);
+});
+
+test('verdict: sentinel coverage wins even when an invalid waiver is also present', () => {
+  const v = verdict({
+    files: ['internal/engine/spill.go', 'test/perf/smoke/sentinels.go'],
+    waiverNumbers: [999999],
+    resolved: new Map(),
+  });
+  assert.equal(v.satisfied, true);
+  assert.equal(v.via, 'sentinel');
+});
+
+// --- wiring pin ----------------------------------------------------------------
+
+const forbidDeferralWorkflow = readFileSync(resolve('.github/workflows/forbid-deferral.yml'), 'utf8');
+
+test('the obligation gate rides forbid-deferral.yml and invokes the script', () => {
+  assert.match(forbidDeferralWorkflow, /run: node \.github\/scripts\/perf-sentinel-obligation\.mjs/);
+  assert.match(forbidDeferralWorkflow, /run: node --test \.github\/scripts\/perf-sentinel-obligation\.test\.mjs/);
+});

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -761,6 +761,12 @@ jobs:
       - name: Assert the nightly-health notifier cannot go silently hollow
         run: node --test .github/scripts/notify-nightly-failure.test.mjs
 
+      # Same #1861 mechanism, second consumer (#2370's perf-nightly lane) —
+      # asserts the shared lib/nightly-health-notify.mjs generalisation and
+      # perf-nightly's own wiring didn't silently drift from e2e's.
+      - name: Assert the perf-nightly-health notifier cannot go silently hollow
+        run: node --test .github/scripts/notify-perf-nightly-failure.test.mjs
+
       # Pins e2e.yml's dashboard-crawl-merge wiring: the required `dashboard`
       # aggregator must depend on it (so a merge failure can gate a release),
       # and the release/dispatch trigger conditions that decide when the

--- a/.github/workflows/forbid-deferral.yml
+++ b/.github/workflows/forbid-deferral.yml
@@ -114,3 +114,21 @@ jobs:
         run: node .github/scripts/rejection-parity-divergence-liveness.mjs
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      # #2370's same-PR obligation gate: a change to a memory-bounding
+      # settings file (internal/engine/query_settings_rules.go,
+      # internal/engine/spill.go) must add sentinel coverage or cite an
+      # open-issue waiver — the same #2364 postmortem this whole lane
+      # traces back to. Reuses forbid-deferral.mjs's own citation-
+      # resolution machinery, so it rides this same job/workflow rather
+      # than re-deriving the PR-description-as-a-surface trigger setup
+      # above (the `edited` type is exactly as load-bearing for a
+      # waiver-in-the-body fix as it is for a deferral-marker one).
+      - name: Assert the perf-sentinel obligation scanner matches
+        run: node --test .github/scripts/perf-sentinel-obligation.test.mjs
+      - name: Reject a settings-file change with no sentinel coverage or waiver
+        run: node .github/scripts/perf-sentinel-obligation.mjs
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_BODY: ${{ github.event.pull_request.body }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.merge_group.base_sha || github.event.before }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}

--- a/.github/workflows/perf-nightly.yml
+++ b/.github/workflows/perf-nightly.yml
@@ -1,20 +1,38 @@
 name: perf-nightly
 
-# The #2370 nightly, real-data measurement harness (PR A): loads the real,
-# trimmed production sample (test/perf/nightly/testdata/samples/*.parquet)
-# into a real ClickHouse and runs a curated PromQL sentinel corpus, logging
-# real peak_memory_usage/duration numbers. See
-# test/perf/nightly/realch_perfnightly_integration_test.go's doc comment for
-# the full "why".
+# The #2370 nightly, real-data measurement + regression gate: loads the
+# real, trimmed production sample (test/perf/nightly/testdata/samples/*.parquet)
+# into a real ClickHouse and asserts a curated PromQL sentinel corpus's
+# max-of-5 peak memory (and expected HTTP outcome) against a committed
+# baseline (test/perf/nightly-baseline.json) plus an absolute cap-relative
+# ceiling. See test/perf/nightly/realch_perfnightly_integration_test.go's
+# doc comment for the full "why" and gate mechanics.
 #
-# workflow_dispatch only for now — PR A's own scope is "prove the mechanism,
-# print the numbers," not gate anything yet. A follow-up PR adds the nightly
-# `schedule:` cron, release-gate mode, a committed statistical baseline, and
-# alerting on failure (reusing notify-nightly-failure.mjs's stable-title
-# issue lifecycle) once this harness's own numbers have calibrated one.
+# There is deliberately NO `pull_request:` trigger — same posture and same
+# reasoning as migration-e2e.yml: this workflow can never become a
+# branch-protection (merge-gate) check, only a RELEASE-gate one
+# (release.yml's RELEASE_REQUIRED_CHECKS), so it never adds latency or cost
+# to an ordinary PR. `push: branches: [main, 'release/*.x']` exists so the
+# maintenance publish path (a direct push to a release/*.x line, no PR)
+# still gets a real check-run for release.yml's preflight to wait on —
+# without it, a required check named in RELEASE_REQUIRED_CHECKS but never
+# posting there blocks every maintenance release forever.
 
 on:
+  push:
+    branches: [main, 'release/*.x']
+  schedule:
+    # 05:17 UTC — offset from perf-profile.yml's 05:00 nightly cron.
+    - cron: '17 5 * * *'
   workflow_dispatch:
+
+concurrency:
+  # Main pushes and matching cron schedules replace only their own modes.
+  # A release/*.x push or a manual dispatch uses a unique run-id group and
+  # can neither queue behind nor cancel source work. See
+  # main-coalescing.mjs (this workflow is enrolled in COALESCED_WORKFLOWS).
+  group: ${{ github.workflow }}-${{ (github.event_name == 'push' && github.ref == 'refs/heads/main') && 'latest-main-push' || (github.event_name == 'schedule' && github.ref == 'refs/heads/main' && github.event.schedule != '') && format('latest-main-schedule-{0}', github.event.schedule) || github.run_id }}
+  cancel-in-progress: ${{ (github.event_name == 'push' && github.ref == 'refs/heads/main') || (github.event_name == 'schedule' && github.ref == 'refs/heads/main' && github.event.schedule != '') }}
 
 permissions:
   contents: read
@@ -55,3 +73,38 @@ jobs:
 
       - name: Run the #2370 nightly measurement harness (real ClickHouse)
         run: just perf-nightly-integration
+
+  # Files/refreshes a single tracking issue when the SCHEDULE run does not
+  # reach a clean pass, closes it on the next clean night. Same mechanism
+  # e2e.yml's nightly-health-notify job uses (notify-nightly-failure.mjs,
+  # #1861) via the shared lib/nightly-health-notify.mjs — see
+  # notify-perf-nightly-failure.mjs's own header for the fuller "why".
+  #
+  # Scoped to `github.event_name == 'schedule'` only: a push-triggered run
+  # (main / release/*.x) already has a visible required check-run for
+  # release.yml's preflight to react to, and workflow_dispatch is a manual,
+  # already-attended action — the silent-red gap this exists to close is
+  # specifically the unattended cron trigger.
+  perf-nightly-health-notify:
+    name: perf-nightly-health-notify
+    needs: [perf-nightly]
+    if: always() && github.event_name == 'schedule'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    # Job-level permissions REPLACE the workflow-level block (see e2e.yml's
+    # nightly-health-notify for the same note) — contents: read has to be
+    # restated for checkout, and issues: write is what lets this
+    # file/comment/close the tracking issue.
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - uses: actions/checkout@v7
+      - name: roll up the nightly run and notify on non-success
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          RUN_ID: ${{ github.run_id }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          RESULT_PERF_NIGHTLY: ${{ needs.perf-nightly.result }}
+        run: node .github/scripts/notify-perf-nightly-failure.mjs

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -264,6 +264,7 @@ jobs:
             profile
             property (PromQL + LogQL + TraceQL, rapid N=500)
             migration-e2e
+            perf-nightly
             CodeQL
           # De-gated INFORMATIONAL lanes, matched by name prefix (matrix children
           # carry a "(shard-…)" suffix). The required `compose-smoke` aggregate

--- a/Justfile
+++ b/Justfile
@@ -362,18 +362,37 @@ perf-smoke-integration:
     @just _pull-retry {{CH_TEST_IMAGE}}
     go test -timeout 15m -tags=integration -count=1 -run TestPerfSmoke ./test/perf/smoke/...
 
-# Run the #2370 nightly measurement harness: loads the real, trimmed
-# production sample (test/perf/nightly/testdata/samples/*.parquet, LFS —
-# needs `git lfs pull` first if not already fetched) into a real ClickHouse
-# and issues a curated sentinel corpus, logging real
-# peak_memory_usage/duration numbers. No baseline/gate yet (PR A of #2370 —
-# "prove the mechanism, print the numbers"). Requires Docker; gated behind
-# the `integration` build tag. See
+# Run the #2370 nightly measurement + regression gate: loads the real,
+# trimmed production sample (test/perf/nightly/testdata/samples/*.parquet,
+# LFS — needs `git lfs pull` first if not already fetched) into a real
+# ClickHouse and issues a curated sentinel corpus, gating each one's
+# max-of-N peak memory against a committed baseline (nightly-baseline.json)
+# plus an absolute cap-relative ceiling, and its HTTP status against the
+# outcome each sentinel was calibrated to expect (PR B of #2370). Requires
+# Docker; gated behind the `integration` build tag. See
 # test/perf/nightly/realch_perfnightly_integration_test.go and
 # .github/workflows/perf-nightly.yml.
 perf-nightly-integration:
     @just _pull-retry {{CH_TEST_IMAGE}}
     go test -v -timeout 15m -tags=integration -count=1 -run TestPerfNightlyRealCH ./test/perf/nightly/...
+
+# Regenerate nightly-baseline.json: for each #2370 nightly sentinel the
+# calibration-time max-of-N peak memory_usage plus the headroom-multiplied
+# ceiling (nightlyBaselineHeadroom) the gate actually asserts against, and
+# the HTTP status it was calibrated to expect. Requires Docker and (once,
+# if not already fetched) `git lfs pull` for the trimmed sample parquet
+# files. Run this — and REVIEW THE DIFF — only when a bound move is
+# genuinely intended (a real, justified memory-cost increase, or a
+# deliberate change to which sentinels are expected to be rejected by a
+# resource bound); a silent loosen is exactly the regression this lane
+# exists to catch. The gating assertion is TestPerfNightlyRealCH, wired
+# into .github/workflows/perf-nightly.yml.
+update-nightly-perf-baseline:
+    @just _pull-retry {{CH_TEST_IMAGE}}
+    UPDATE_NIGHTLY_PERF_BASELINE=1 go test -timeout 15m -tags=integration -count=1 -run TestPerfNightlyRealCH ./test/perf/nightly/...
+    @echo
+    @echo "Diff of regenerated baseline:"
+    @git --no-pager diff --stat test/perf/nightly-baseline.json || true
 
 # Run the solver's mandatory per-shard memory-apportionment real-CH guard:
 # proves Executor.runShard's max_memory_usage WithQuerySetting override is

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -1336,7 +1336,11 @@ carries as much weight as the steps themselves:
 3. **Audit the delta.** One last pass over the complete diff since the previous
    release: code against comments against docs, DRY, KISS, soundness. This is
    the final gate — findings are fixed and merged onto `main` here, before any
-   line is backported and before any tag exists.
+   line is backported and before any tag exists. Also glance at `perf-nightly`'s
+   own trend across the cycle's runs, not just its latest pass/fail: the gate
+   catches a single run regressing past its committed ceiling, but a slow,
+   multi-cycle creep that stays under headroom on every individual night is
+   exactly the shape it cannot see by design.
 4. **Backport everything to every line that stays supported.** Every fix that
    landed on `main` since the previous release goes onto every
    `release/<major>.<minor>.x` line that is still supported once this cycle
@@ -1399,8 +1403,11 @@ selection between them:
   cost-dominating lanes an ordinary PR does not need to wait on —
   `perf-guards` and `benchstat diff`, the chDB `roundtrip` / `integration` /
   `chdb-build` lanes, `gremlins` mutation testing, all six `compatibility/*`
-  differential heads, `migration-e2e`, and the substrate smoke lanes
-  `compose-smoke` / `dashboard` (never a branch-protection required context
+  differential heads, `migration-e2e`, `perf-nightly` (the #2370 real-data
+  regression gate — like `migration-e2e` it has no `pull_request:` trigger
+  at all, only `push: [main, release/*.x]` + `schedule` + manual dispatch,
+  so it never runs on an ordinary PR, heavy or otherwise), and the substrate
+  smoke lanes `compose-smoke` / `dashboard` (never a branch-protection required context
   on `main` — `release.yml`'s preflight is their only reader; see
   `e2e.yml`'s header). Each of those lanes still triggers on every
   `pull_request` (so its check-run stays visible for author feedback), but

--- a/test/perf/nightly-baseline.json
+++ b/test/perf/nightly-baseline.json
@@ -1,0 +1,28 @@
+{
+  "sentinels": [
+    {
+      "name": "classic_histogram_quantile_by_route",
+      "expected_status": 200,
+      "max_of_n_bytes": 9726370,
+      "ceiling_bytes": 14589555
+    },
+    {
+      "name": "request_rate_by_method",
+      "expected_status": 422,
+      "max_of_n_bytes": 278242204,
+      "ceiling_bytes": 417363306
+    },
+    {
+      "name": "pod_status_reason_gauge",
+      "expected_status": 200,
+      "max_of_n_bytes": 817730723,
+      "ceiling_bytes": 912680550
+    },
+    {
+      "name": "error_ratio_by_namespace",
+      "expected_status": 422,
+      "max_of_n_bytes": 296620019,
+      "ceiling_bytes": 444930028
+    }
+  ]
+}

--- a/test/perf/nightly/realch_perfnightly_integration_test.go
+++ b/test/perf/nightly/realch_perfnightly_integration_test.go
@@ -1,42 +1,81 @@
 //go:build integration
 
 // realch_perfnightly_integration_test.go — the nightly, real-data
-// measurement harness (#2370 PR A).
+// measurement + regression gate (#2370 PR A + PR B).
 //
 // # Why this lane exists
 //
 // test/perf/smoke's real-ClickHouse sentinel differential (#2370 PR 1,
 // merged) proves 3 fixed, calibrated sentinels on SYNTHETIC data would have
 // caught the #2364 incident — but it's a snapshot, not a growing net. This
-// harness is the first slice of the actual "large-scale, realistic-scale
+// harness is the next slice of the actual "large-scale, realistic-scale
 // performance/resource-cost test lane" #2370 itself is titled: it loads the
 // REAL 14-day production sample (test/perf/smoke/testdata/samples/*.parquet,
-// #2411, already scrubbed and merged, but never wired into any test) —
-// trimmed to one representative day for sustainable nightly LFS bandwidth,
-// see testdata/samples/README.md — and issues a curated sentinel corpus
-// broader than the smoke tier's 3 fixed queries, covering construct
-// families the smoke tier never reaches at all: a CLASSIC (bucket/bounds)
-// histogram_quantile (the real sample is classic-shaped, not exponential —
-// issue #2408's arrayJoin bucket-rate fan-out), a Gauge aggregation (zero
-// smoke-tier coverage of this signal type), and a cross-series ratio shape.
+// #2411, already scrubbed) — trimmed to one representative day for
+// sustainable nightly LFS bandwidth, see testdata/samples/README.md — and
+// issues a curated sentinel corpus broader than the smoke tier's 3 fixed
+// queries, covering construct families the smoke tier never reaches at all:
+// a CLASSIC (bucket/bounds) histogram_quantile (the real sample is
+// classic-shaped, not exponential — issue #2408's arrayJoin bucket-rate
+// fan-out), a Gauge aggregation (zero smoke-tier coverage of this signal
+// type), a plain counter rate, and a cross-series ratio shape.
 //
-// This PR deliberately ships NO baseline or gate yet — see Sentinels' own
-// doc comment. Its own test plan is "run it, print the numbers": the
-// measured peak_memory_usage/query_duration_ms this test logs is what a
-// follow-up PR calibrates a committed statistical baseline against, the
-// same "task 4: real numbers, not the plan's starting-point guesses"
-// methodology test/perf/smoke's own PR followed.
+// PR A shipped no baseline or gate — its test plan was "run it, print the
+// numbers." Two of those numbers (request_rate_by_method,
+// error_ratio_by_namespace) turned out to be issue #2429: a plain
+// `sum by()(rate())`-shaped query genuinely OOMing at this sample's real
+// series count and anchor grid, despite applySpillSettings' always-on
+// spill. #2429 is now fixed — internal/chsql's rate-window fanout resource
+// bound rejects both cleanly (422) instead of letting ClickHouse OOM — so
+// this PR (PR B) is the first run with real, POST-FIX numbers to calibrate
+// a committed baseline against, the same "task 4: real numbers, not the
+// plan's starting-point guesses" methodology test/perf/smoke's own PR
+// followed.
+//
+// # The gate
+//
+// Two-pronged, mirroring test/perf/smoke's perf-smoke-baseline.json exactly
+// (see its own realch_perfsmoke_integration_test.go for the fuller
+// rationale this reuses verbatim):
+//
+//   - PRONG (a): an absolute, cap-relative ceiling every sentinel's peak
+//     memory must stay under (nightlyMemoryCapFraction), independent of any
+//     committed baseline — catches a regression even on a freshly-created,
+//     baseline-less sentinel.
+//   - PRONG (b): a committed per-sentinel ceiling in nightly-baseline.json,
+//     the calibration-time max-of-N measurement times a headroom multiplier
+//     (nightlyBaselineHeadroom) — tighter than PRONG (a), so it is what
+//     actually catches a real regression long before the absolute ceiling
+//     would.
+//
+// A THIRD check this lane adds beyond test/perf/smoke's shape, because two
+// of its four sentinels are EXPECTED to be rejected rather than to
+// complete: every repeat's HTTP status must match sentinel.ExpectedStatus
+// exactly, and when that status isn't 200 the response body must carry
+// sentinel.ExpectedErrorSubstring. A status-class change either
+// direction — the #2429 bound silently breaking (OOM risk returns) or
+// silently over-broadening (a legitimate query starts being rejected) — is
+// itself the regression signal for those two sentinels, and is checked
+// BEFORE the memory prongs (a rejected query's "peak memory at rejection"
+// is a real, trackable number too, but only meaningful once the rejection
+// itself is confirmed to be the RIGHT one).
 //
 // Gated behind the `integration` build tag (Docker required); wired into
 // .github/workflows/perf-nightly.yml via `just perf-nightly-integration`.
+// Regenerate the baseline via `just update-nightly-perf-baseline`
+// (UPDATE_NIGHTLY_PERF_BASELINE=1) — never hand-edited (invariant 9).
 package nightly
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
+	"math"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -59,6 +98,34 @@ const perfNightlyDB = "default"
 // see test/perf/smoke's sentinelMemoryCapBytes for why this is the value a
 // real deployment runs under, not a value tuned for this test.
 const perfNightlyMemoryCapBytes int64 = 1 << 30 // 1 GiB
+
+// nightlyMemoryCapFraction is PRONG (a)'s absolute ceiling. Same rationale
+// as test/perf/smoke's sentinelMemoryCapFraction (above
+// spillThreshold(cap)'s implied 0.5, below 1.0's OOM boundary), but NOT the
+// same value — 0.75 (smoke's own midpoint pick) does not fit this lane's
+// real measured data. Calibrated against this lane's own real
+// post-#2429-fix, max-of-5 numbers: the two ExpectedStatus=200 sentinels
+// measured 0.9% and 76.2% of cap; the two ExpectedStatus=422 sentinels
+// (rejected BEFORE the expensive stage runs, by design) measured 25.9% and
+// 27.6% at rejection. pod_status_reason_gauge's 76.2% already exceeds
+// 0.75x — a plain `sum by (reason) (...)` gauge aggregation over this
+// sample's real 7,024-series cardinality (855 distinct pods, only 8
+// distinct `reason` values it collapses to) genuinely costs this much;
+// filed as issue #2435 for its own investigation rather than silently
+// absorbed into a looser fraction picked to avoid looking at it. 0.85
+// keeps real, verified margin (~8 points) above that measured cost while
+// staying meaningfully below ClickHouse's own 1.0 OOM boundary.
+const nightlyMemoryCapFraction = 0.85
+
+// nightlyBaselineHeadroom mirrors test/perf/smoke's sentinelBaselineHeadroom
+// (1.5x) — see its own comment for why a memory metric wants a tighter
+// multiplier than scale_wall_pin_chdb_test.go's noisier wall-clock prong.
+const nightlyBaselineHeadroom = 1.5
+
+// nightlySentinelRepeats (N) mirrors test/perf/smoke's sentinelRepeats — a
+// ceiling gate wants the worst observed case, so max-of-N, never
+// median/mean.
+const nightlySentinelRepeats = 5
 
 func TestPerfNightlyRealCH(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Minute)
@@ -105,46 +172,122 @@ func TestPerfNightlyRealCH(t *testing.T) {
 
 	logSource := optcorpus.NewCHQueryLogSource(conn, 30*time.Second, time.Hour)
 
-	// This PR ships NO baseline or gate (Sentinels' own doc comment) — its
-	// test plan is "run it, print the numbers," so a sentinel hitting the
-	// real memory cap is itself a finding to report, not a test bug to fail
-	// on. Every outcome (success or cap-exceeded) still reads back
-	// query_log, since ClickHouse logs a terminated query's peak memory at
-	// the point it was killed too — that number is exactly the kind of real
-	// data point a follow-up calibration or investigation needs.
+	baseline := loadNightlyBaseline(t)
+	update := os.Getenv("UPDATE_NIGHTLY_PERF_BASELINE") == "1"
+	updated := make(map[string]nightlyBound, len(Sentinels))
+
 	for _, sentinel := range Sentinels {
 		t.Run(sentinel.Name, func(t *testing.T) {
-			queryID := fmt.Sprintf("perfnightly-%s", sentinel.Name)
-			code := runSentinelOnce(t, mux, sentinel, queryID)
-
-			if err := conn.Exec(ctx, "SYSTEM FLUSH LOGS"); err != nil {
-				t.Fatalf("%s: flush logs: %v", sentinel.Name, err)
-			}
-			rows, err := logSource.FinishedByQueryID(ctx, []string{queryID})
-			if err != nil {
-				t.Fatalf("%s: read query_log: %v", sentinel.Name, err)
-			}
-			if len(rows) != 1 {
-				t.Fatalf("%s: expected 1 query_log row for query_id %q, got %d",
-					sentinel.Name, queryID, len(rows))
+			// One untimed, unmeasured warm-up — mirrors test/perf/smoke's own
+			// rationale: the OPTIMIZE ... FINAL pass above leaves this
+			// sentinel's tables cold, and the first query after that pays a
+			// real extra allocation this warm-up absorbs.
+			warmupID := fmt.Sprintf("perfnightly-%s-warmup", sentinel.Name)
+			if code, body := runSentinelOnce(t, mux, sentinel, warmupID); code != sentinel.ExpectedStatus {
+				t.Fatalf("%s warm-up: HTTP %d (want %d): %s", sentinel.Name, code, sentinel.ExpectedStatus, body)
+			} else if sentinel.ExpectedStatus != http.StatusOK && !strings.Contains(body, sentinel.ExpectedErrorSubstring) {
+				t.Fatalf("%s warm-up: HTTP %d body does not carry %q: %s", sentinel.Name, code, sentinel.ExpectedErrorSubstring, body)
 			}
 
-			if code != http.StatusOK || rows[0].ExitStatus != optcorpus.ExitOK {
-				t.Logf("FINDING %s (%s): HTTP %d, query_log exit=%v, peak memory_usage at termination = %d bytes (%.1f%% of %d-byte cap) — a real query over real data did not complete within the configured cap",
-					sentinel.Name, sentinel.Family, code, rows[0].ExitStatus, rows[0].MemoryUsage,
-					100*float64(rows[0].MemoryUsage)/float64(perfNightlyMemoryCapBytes), perfNightlyMemoryCapBytes)
+			var maxBytes uint64
+			for i := 0; i < nightlySentinelRepeats; i++ {
+				queryID := fmt.Sprintf("perfnightly-%s-%d", sentinel.Name, i)
+				code, body := runSentinelOnce(t, mux, sentinel, queryID)
+				// The status-class check comes first and is fatal, not just a
+				// logged finding: for the two ExpectedStatus=422 sentinels this
+				// IS the #2429 regression signal (the bound silently breaking
+				// or over-broadening), not a missed memory ceiling.
+				if code != sentinel.ExpectedStatus {
+					t.Fatalf("%s repeat %d: HTTP %d (want %d) — a status-class change is itself the regression here: %s",
+						sentinel.Name, i, code, sentinel.ExpectedStatus, body)
+				}
+				if sentinel.ExpectedStatus != http.StatusOK && !strings.Contains(body, sentinel.ExpectedErrorSubstring) {
+					t.Fatalf("%s repeat %d: HTTP %d body does not carry %q — a different fault than intended may be firing: %s",
+						sentinel.Name, i, code, sentinel.ExpectedErrorSubstring, body)
+				}
+
+				if err := conn.Exec(ctx, "SYSTEM FLUSH LOGS"); err != nil {
+					t.Fatalf("%s repeat %d: flush logs: %v", sentinel.Name, i, err)
+				}
+				rows, err := logSource.FinishedByQueryID(ctx, []string{queryID})
+				if err != nil {
+					t.Fatalf("%s repeat %d: read query_log: %v", sentinel.Name, i, err)
+				}
+				if len(rows) != 1 {
+					t.Fatalf("%s repeat %d: expected 1 query_log row for query_id %q, got %d",
+						sentinel.Name, i, queryID, len(rows))
+				}
+				if rows[0].MemoryUsage > maxBytes {
+					maxBytes = rows[0].MemoryUsage
+				}
+			}
+
+			// math.Round forces this through runtime float64 arithmetic rather
+			// than Go's exact-rational constant folding — (1<<30)*0.85 is not
+			// itself an exact integer, unlike smoke's own 0.75 (which happens
+			// to divide 2^30 evenly), so a bare uint64(...) conversion of the
+			// constant expression fails to compile.
+			capCeiling := uint64(math.Round(float64(perfNightlyMemoryCapBytes) * nightlyMemoryCapFraction))
+			t.Logf("%s (%s): max-of-%d peak memory_usage = %d bytes (%.1f%% of %d-byte cap; absolute ceiling %d), expected status %d",
+				sentinel.Name, sentinel.Family, nightlySentinelRepeats, maxBytes,
+				100*float64(maxBytes)/float64(perfNightlyMemoryCapBytes), perfNightlyMemoryCapBytes, capCeiling, sentinel.ExpectedStatus)
+
+			if update {
+				// Clamp to capCeiling: for a sentinel already close to the
+				// absolute ceiling (pod_status_reason_gauge measured 76.6%
+				// against a 1.5x headroom — 1.5x of THAT already exceeds the
+				// 1 GiB cap outright), an unclamped committed ceiling would
+				// sit above PRONG (a)'s own bound, making PRONG (b)
+				// permanently unable to fire — a looser "tighter" check is a
+				// gate that silently never gates. PRONG (b) must never be
+				// looser than PRONG (a).
+				ceiling := min(uint64(float64(maxBytes)*nightlyBaselineHeadroom), capCeiling)
+				updated[sentinel.Name] = nightlyBound{
+					Name: sentinel.Name, ExpectedStatus: sentinel.ExpectedStatus,
+					MaxOfNBytes: maxBytes, CeilingBytes: ceiling,
+				}
 				return
 			}
 
-			t.Logf("%s (%s): peak memory_usage = %d bytes (%.1f%% of %d-byte cap), duration = %d ms",
-				sentinel.Name, sentinel.Family, rows[0].MemoryUsage,
-				100*float64(rows[0].MemoryUsage)/float64(perfNightlyMemoryCapBytes),
-				perfNightlyMemoryCapBytes, rows[0].QueryDurationMS)
+			// PRONG (a): absolute, cap-relative ceiling.
+			if maxBytes > capCeiling {
+				t.Errorf("%s: peak memory %d bytes exceeds the absolute cap-relative ceiling %d bytes "+
+					"(%.0f%% of the %d-byte cap) — %s may have regressed",
+					sentinel.Name, maxBytes, capCeiling, 100*nightlyMemoryCapFraction, perfNightlyMemoryCapBytes, sentinel.Family)
+			}
+
+			// PRONG (b): committed per-sentinel ceiling.
+			bound, ok := baselineFor(baseline, sentinel.Name)
+			if !ok {
+				t.Fatalf("%s: no committed bound in nightly-baseline.json — run `just update-nightly-perf-baseline`", sentinel.Name)
+			}
+			if bound.ExpectedStatus != sentinel.ExpectedStatus {
+				t.Fatalf("%s: committed baseline expects status %d but the sentinel now expects %d — "+
+					"run `just update-nightly-perf-baseline` if this change is genuinely intended",
+					sentinel.Name, bound.ExpectedStatus, sentinel.ExpectedStatus)
+			}
+			if maxBytes > bound.CeilingBytes {
+				t.Errorf("%s: peak memory %d bytes exceeds the committed ceiling %d bytes (measured max-of-N was "+
+					"%d at calibration time, %.2fx headroom) — %s may have regressed; only run "+
+					"`just update-nightly-perf-baseline` if the increase is genuinely intended",
+					sentinel.Name, maxBytes, bound.CeilingBytes, bound.MaxOfNBytes, nightlyBaselineHeadroom, sentinel.Family)
+			}
 		})
+	}
+
+	if update {
+		writeNightlyBaseline(t, updated)
 	}
 }
 
-func runSentinelOnce(t *testing.T, mux *http.ServeMux, sentinel Sentinel, queryID string) int {
+// runSentinelOnce issues one GET for sentinel over the sample's fixed
+// window (sampleWindowStart / sampleWindowEnd, sentinels.go) with ctx
+// pre-stamped to queryID so the ClickHouse dispatch that results carries
+// EXACTLY this query_id in system.query_log. Returns the HTTP status and
+// response body — the body matters here (unlike test/perf/smoke's
+// same-named helper) because ExpectedStatus != 200 sentinels need it to
+// confirm the RIGHT guard fired.
+func runSentinelOnce(t *testing.T, mux *http.ServeMux, sentinel Sentinel, queryID string) (int, string) {
 	t.Helper()
 	params := sentinel.Params(sampleWindowStart, sampleWindowEnd)
 	params.Set("start", formatPromTime(sampleWindowStart))
@@ -155,10 +298,7 @@ func runSentinelOnce(t *testing.T, mux *http.ServeMux, sentinel Sentinel, queryI
 	req = req.WithContext(chclient.WithQueryID(req.Context(), queryID))
 	rec := httptest.NewRecorder()
 	mux.ServeHTTP(rec, req)
-	if rec.Code != http.StatusOK {
-		t.Logf("%s: HTTP %d body: %s", sentinel.Name, rec.Code, rec.Body.String())
-	}
-	return rec.Code
+	return rec.Code, rec.Body.String()
 }
 
 func formatPromTime(t time.Time) string {
@@ -208,4 +348,79 @@ func startPerfNightlyCH(ctx context.Context, t *testing.T) (*tcclickhouse.ClickH
 	}
 	t.Cleanup(func() { _ = client.Close() })
 	return container, client
+}
+
+// --- baseline load/write (invariant 9: never hand-edited) -----------------
+
+// nightlyBaselinePath is the committed bound file, a sibling of
+// perf-smoke-baseline.json one level up from this package.
+const nightlyBaselinePath = "../nightly-baseline.json"
+
+// nightlyBound is one sentinel's committed bound: the calibration-time
+// max-of-N measurement (kept for the diff/failure message), the
+// headroom-multiplied ceiling the gate actually asserts against, and the
+// HTTP status the sentinel was calibrated to expect (PRONG (b) itself
+// re-checks this against the sentinel's CURRENT ExpectedStatus, catching a
+// baseline gone stale relative to sentinels.go rather than silently
+// comparing memory across two different outcome classes).
+type nightlyBound struct {
+	Name           string `json:"name"`
+	ExpectedStatus int    `json:"expected_status"`
+	MaxOfNBytes    uint64 `json:"max_of_n_bytes"`
+	CeilingBytes   uint64 `json:"ceiling_bytes"`
+}
+
+type nightlyBaseline struct {
+	Sentinels []nightlyBound `json:"sentinels"`
+}
+
+func baselineFor(b nightlyBaseline, name string) (nightlyBound, bool) {
+	for _, s := range b.Sentinels {
+		if s.Name == name {
+			return s, true
+		}
+	}
+	return nightlyBound{}, false
+}
+
+func loadNightlyBaseline(t *testing.T) nightlyBaseline {
+	t.Helper()
+	buf, err := os.ReadFile(nightlyBaselinePath)
+	if err != nil {
+		if os.Getenv("UPDATE_NIGHTLY_PERF_BASELINE") == "1" {
+			return nightlyBaseline{}
+		}
+		t.Fatalf("read baseline %s: %v — run `just update-nightly-perf-baseline` to create it", nightlyBaselinePath, err)
+	}
+	var b nightlyBaseline
+	if err := json.Unmarshal(buf, &b); err != nil {
+		t.Fatalf("parse baseline %s: %v", nightlyBaselinePath, err)
+	}
+	return b
+}
+
+// writeNightlyBaseline serialises updated (keyed by sentinel name, in
+// Sentinels order) as pretty JSON with a trailing newline, so the committed
+// file diffs cleanly and is never hand-edited (invariant 9) — this is the
+// ONLY code path that writes nightly-baseline.json, gated on
+// UPDATE_NIGHTLY_PERF_BASELINE=1.
+func writeNightlyBaseline(t *testing.T, updated map[string]nightlyBound) {
+	t.Helper()
+	out := nightlyBaseline{Sentinels: make([]nightlyBound, 0, len(Sentinels))}
+	for _, s := range Sentinels {
+		bound, ok := updated[s.Name]
+		if !ok {
+			t.Fatalf("writeNightlyBaseline: no measurement for sentinel %q", s.Name)
+		}
+		out.Sentinels = append(out.Sentinels, bound)
+	}
+	buf, err := json.MarshalIndent(out, "", "  ")
+	if err != nil {
+		t.Fatalf("marshal baseline: %v", err)
+	}
+	buf = append(buf, '\n')
+	if err := os.WriteFile(nightlyBaselinePath, buf, 0o644); err != nil {
+		t.Fatalf("write baseline: %v", err)
+	}
+	t.Logf("wrote %s", nightlyBaselinePath)
 }

--- a/test/perf/nightly/sentinels.go
+++ b/test/perf/nightly/sentinels.go
@@ -1,8 +1,11 @@
 package nightly
 
 import (
+	"net/http"
 	"net/url"
 	"time"
+
+	"github.com/tsouza/cerberus/internal/chsql"
 )
 
 // Metric names as they appear in testdata/samples/*.parquet's MetricName
@@ -46,6 +49,23 @@ type Sentinel struct {
 	Family string
 	Path   string
 	Params func(start, end time.Time) url.Values
+	// ExpectedStatus is the HTTP status this sentinel's query is expected
+	// to return at real production cardinality. http.StatusOK for every
+	// sentinel except the two #2429 found: at this sample's real series
+	// count and the shared anchor grid below, a plain
+	// `sum by()(rate(...))`-shaped query genuinely exceeds
+	// internal/chsql's rate-window fanout resource bound by design — the
+	// fix's own point was turning that from a silent OOM into a clean,
+	// deliberate rejection, not making the underlying cost disappear. The
+	// gate (PR B) asserts on THIS field so a status-class change either
+	// direction — the bound silently breaking (OOM risk returns) or
+	// silently over-broadening (a legitimate query starts being rejected)
+	// — is itself the regression signal, not just a missed memory ceiling.
+	ExpectedStatus int
+	// ExpectedErrorSubstring, populated only when ExpectedStatus != 200,
+	// is the response body substring proving THIS SPECIFIC guard fired —
+	// not some unrelated failure that happens to share the status code.
+	ExpectedErrorSubstring string
 }
 
 // Sentinels is PR A's "prove the mechanism, print the numbers" corpus — no
@@ -54,9 +74,10 @@ type Sentinel struct {
 // produce, the same task-4 methodology test/perf/smoke's own PR followed.
 var Sentinels = []Sentinel{
 	{
-		Name:   "classic_histogram_quantile_by_route",
-		Family: "histogram_quantile over a classic (bucket/bounds) histogram — issue #2408's arrayJoin bucket-rate fan-out",
-		Path:   "/api/v1/query_range",
+		Name:           "classic_histogram_quantile_by_route",
+		Family:         "histogram_quantile over a classic (bucket/bounds) histogram — issue #2408's arrayJoin bucket-rate fan-out",
+		Path:           "/api/v1/query_range",
+		ExpectedStatus: http.StatusOK,
 		Params: func(start, end time.Time) url.Values {
 			return url.Values{
 				"query": {`histogram_quantile(0.95, sum by (http_route) (rate(` + histogramMetric + `[5m])))`},
@@ -65,14 +86,22 @@ var Sentinels = []Sentinel{
 	},
 	{
 		// Real numbers from this exact sentinel against the committed sample
-		// data: 99.8% of the 1 GiB cap at 3,741 series / 260 steps — despite
-		// applySpillSettings' always-on spill, which should have converted
-		// this into a slower disk spill rather than an OOM abort. Filed as
-		// issue #2429 (needs investigation, not a quick fix from this one
-		// data point) rather than silently accepted.
-		Name:   "request_rate_by_method",
-		Family: "plain counter rate() + sum by() — baseline construct, no histogram/gauge machinery",
-		Path:   "/api/v1/query_range",
+		// data: 99.8% of the 1 GiB cap at 3,741 series / 260 steps under the
+		// original (unfixed) engine — despite applySpillSettings' always-on
+		// spill, which should have converted this into a slower disk spill
+		// rather than an OOM abort. Filed and fixed as issue #2429: at this
+		// scale the query is genuinely too expensive to serve safely, so
+		// internal/chsql's rate-window fanout resource bound now rejects it
+		// cleanly (422) rather than letting ClickHouse OOM. That rejection
+		// IS this sentinel's expected, correct outcome at real production
+		// cardinality — a regression here is either the bound silently
+		// breaking (status flips back toward an OOM) or the query starting
+		// to succeed at a genuinely unsafe scale, not "still 422".
+		Name:                   "request_rate_by_method",
+		Family:                 "plain counter rate() + sum by() — baseline construct, no histogram/gauge machinery",
+		Path:                   "/api/v1/query_range",
+		ExpectedStatus:         http.StatusUnprocessableEntity,
+		ExpectedErrorSubstring: chsql.RateWindowFanoutBudgetMessage,
 		Params: func(start, end time.Time) url.Values {
 			return url.Values{
 				"query": {`sum by (method) (rate(` + sumMetric + `[5m]))`},
@@ -80,9 +109,10 @@ var Sentinels = []Sentinel{
 		},
 	},
 	{
-		Name:   "pod_status_reason_gauge",
-		Family: "Gauge aggregation — signal type the smoke tier has zero coverage of",
-		Path:   "/api/v1/query_range",
+		Name:           "pod_status_reason_gauge",
+		Family:         "Gauge aggregation — signal type the smoke tier has zero coverage of",
+		Path:           "/api/v1/query_range",
+		ExpectedStatus: http.StatusOK,
 		Params: func(start, end time.Time) url.Values {
 			return url.Values{
 				"query": {`sum by (reason) (` + gaugeMetric + `)`},
@@ -96,11 +126,14 @@ var Sentinels = []Sentinel{
 		// VALUE, not just identifier-bearing keys, so "5xx"-style literal
 		// filtering is not meaningful against this data; any real distinct
 		// value exercises the identical filtered-numerator-over-denominator
-		// construct this sentinel targets. Also hits issue #2429: 100.0% of
-		// the 1 GiB cap at this cardinality.
-		Name:   "error_ratio_by_namespace",
-		Family: "cross-series ratio (error-rate shape) — two independent rate() aggregations divided, a common real-world PromQL construct absent from the smoke tier entirely",
-		Path:   "/api/v1/query_range",
+		// construct this sentinel targets. Also hits (and, post-#2429-fix,
+		// is correctly rejected by) the same rate-window fanout bound as
+		// request_rate_by_method above — see its comment.
+		Name:                   "error_ratio_by_namespace",
+		Family:                 "cross-series ratio (error-rate shape) — two independent rate() aggregations divided, a common real-world PromQL construct absent from the smoke tier entirely",
+		Path:                   "/api/v1/query_range",
+		ExpectedStatus:         http.StatusUnprocessableEntity,
+		ExpectedErrorSubstring: chsql.RateWindowFanoutBudgetMessage,
 		Params: func(start, end time.Time) url.Values {
 			return url.Values{
 				"query": {

--- a/test/regression/generated_artifact_merge_gate_test.go
+++ b/test/regression/generated_artifact_merge_gate_test.go
@@ -121,6 +121,7 @@ const parityEnrolmentBaselineRecipe = "just update-golden parity"
 var generatedArtifacts = []generatedArtifact{
 	{"test/perf/scale-wall-baseline.json", "just update-scale-wall-baseline"},
 	{"test/perf/perf-smoke-baseline.json", "just update-perf-smoke-baseline"},
+	{"test/perf/nightly-baseline.json", "just update-nightly-perf-baseline"},
 	{"test/perf/metadata-query-size-baseline.json", "just update-metadata-query-size-baseline"},
 	{"test/coverage-floor.json", "just update-coverage-floor"},
 


### PR DESCRIPTION
## Summary

PR B and PR C of #2370, following PR A (#2430, the nightly measurement harness — "run it, print the numbers"). Both land in one PR: PR C conceptually follows PR B, and this repo's invariants forbid branching a new PR off another in-flight one, so PR C's commit rides this same branch rather than waiting on PR B to merge first.

### PR B — the statistical regression gate

- **Two-pronged memory gate**, mirroring `test/perf/smoke`'s `perf-smoke-baseline.json` mechanism: N=5-repeat max-of-N peak memory against a committed per-sentinel ceiling (`test/perf/nightly-baseline.json`), plus an absolute cap-relative ceiling as a backstop.
- **A third, outcome-class check this lane needs that smoke's doesn't**: two of the four sentinels are now correctly rejected (HTTP 422) by #2429's rate-window fanout resource bound at this sample's real cardinality. Each sentinel asserts its calibrated `ExpectedStatus` — a status-class change either direction (the bound silently breaking, or silently over-broadening) is the regression signal for those two, not a missed memory ceiling.
- **A real design bug found while calibrating against real numbers**: a fixed 1.5x headroom multiplier on a sentinel already near 77% of its memory cap produces a committed ceiling *above* the cap itself — a "tighter" check that can structurally never fire. Fixed by clamping the per-sentinel ceiling to never exceed the absolute cap-relative one.
- **A genuine, unexplained cost surfaced by calibration**: `pod_status_reason_gauge` — a plain `sum by (reason) (...)` gauge aggregation, no `rate()`/histogram involved — measures 76.6% of a 1 GiB cap at this sample's real 7,024-series cardinality. Verified real (reproducible, real cardinality), not a measurement fluke. Filed as #2435 rather than silently absorbed into a looser ceiling.
- **Release-gate wiring**: `perf-nightly.yml` gains a `schedule:` cron (05:17 UTC), a `push: [main, release/*.x]` trigger (so the maintenance publish path — no PR — still gets a real check-run for `release.yml`'s preflight to wait on, matching `migration-e2e.yml`'s exact posture), and the standard concurrency-coalescing group. `perf-nightly` joins `release.yml`'s `RELEASE_REQUIRED_CHECKS`. No `pull_request:` trigger at all — this can never become a branch-protection (merge-gate) check, only a release-gate one, so it adds zero cost to an ordinary PR.
- **Alerting**: extracted the stable-title tracking-issue lifecycle #1861's `notify-nightly-failure.mjs` established into `lib/nightly-health-notify.mjs`, so a second consumer (`notify-perf-nightly-failure.mjs`) reuses it verbatim rather than re-deriving it. `notify-nightly-failure.mjs` (e2e) is now a thin wrapper over the same shared code — its existing test suite (18 tests) passes unmodified.
- **`docs/operations.md`**: added `perf-nightly` to the release-gate lane list, and a release-ritual step-3 note to glance at the nightly trend across a cycle.

### PR C — the same-PR obligation gate

- New `.github/scripts/perf-sentinel-obligation.mjs`: a change touching `internal/engine/query_settings_rules.go` or `internal/engine/spill.go` — the exact shape of change #2364 traced back to (#2358 silently removed a CSE fold those settings relied on; production OOM'd 6h8m later) — must also touch a sentinel corpus (`test/perf/smoke/sentinels.go` or `test/perf/nightly/sentinels.go`), or cite an open-issue waiver (`PERF-SENTINEL-WAIVER: #<issue>`) for the rare case new coverage genuinely isn't owed.
- Reuses `forbid-deferral.mjs`'s citation-resolution machinery verbatim (`resolveRefs`, `issuesReadability`'s 404-ambiguity guard, `descriptionSurface`, `commitsIn`, `diffOf`) via a purely additive export change — its own 51-test suite passes unmodified.
- Rides `forbid-deferral.yml`'s existing job (same reasoning `rejection-parity-divergence-liveness.mjs` already established: the PR-description-as-a-surface `edited` trigger is exactly as load-bearing for a waiver-in-the-body fix as for a deferral-marker one) rather than a new workflow.
- **Not yet a required branch-protection context.** That needs a live `gh api ... branches/main/protection` change — a repo-wide, hard-to-reverse infra change outside what a code PR should make unilaterally. Flagging for explicit follow-up once this lands and has run clean for a bit.

## Test plan

- [x] `go build ./...`, `go vet ./...`, `go vet -tags=integration ./...`, `just vet-tagged`
- [x] `go test ./...` (full suite)
- [x] `go test ./test/regression/...` — CI-lane registry, release-required-checks, generated-artifact-merge-gate all pass with the new lanes/artifact registered
- [x] `node --test .github/scripts/*.test.mjs` (769 tests, including the new `notify-perf-nightly-failure.test.mjs`, `perf-sentinel-obligation.test.mjs`, and the updated `main-coalescing.test.mjs` / `forbid-deferral.test.mjs`)
- [x] `node .github/scripts/ci-lane-contract.mjs`
- [x] `actionlint` on every touched workflow
- [x] `just update-nightly-perf-baseline` then `just perf-nightly-integration` (real Docker + real ClickHouse + the real trimmed production sample) — clean pass, all 4 sentinels, confirming the gate actually works end-to-end against real data
- [x] `npx markdownlint-cli2 docs/operations.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
