### PR TITLE
fix(ci): skip property.yml's redundant push run after a release PR merge

### DIFF
--- a/.github/scripts/README.md
+++ b/.github/scripts/README.md
@@ -821,6 +821,24 @@ what actually runs.
   - Exit: `0` always in `emit` mode (a resolution failure fails SAFE to
     `run_heavy=true`, logged via `::notice::`, never a hard failure); `1` on an
     unrecognised `MODE`.
+- **`property-run-heavy.mjs`** — `property.yml`, the `decide run_heavy` step.
+  A straight port of `coverage-run-heavy.mjs`'s #2416 fix to a second lane
+  (tsouza/cerberus#2426): skips property.yml's push-to-main run ONLY when it
+  is redundant with a resolved, `release/*`-headed source PR that already ran
+  the heavy rapid sweep and posted the check-run release-preflight.mjs's
+  SOURCE-PR CREDIT will find. Same decision table, same fail-safe default —
+  see that module's own header, and `coverage-run-heavy.mjs`'s above, for the
+  full rationale. `property-run-heavy.test.mjs` pins the decision table; it
+  runs inside `property.yml`'s own always-on "Test property gates" step.
+  - Modes: `verify` (loads the policy, no network) | `emit` (decide + append
+    `run_heavy=true|false` to `GITHUB_OUTPUT`; calls the GitHub API only on a
+    `push` event).
+  - Env: `MODE` (also argv[2]), `EVENT_NAME`, `HEAD_REF` (pull_request /
+    merge_group only), `GITHUB_SHA` / `GITHUB_REPOSITORY` / `GITHUB_TOKEN` /
+    `GITHUB_API_URL` (push only), `GITHUB_OUTPUT`.
+  - Exit: `0` always in `emit` mode (a resolution failure fails SAFE to
+    `run_heavy=true`, logged via `::notice::`, never a hard failure); `1` on an
+    unrecognised `MODE`.
 - **`gremlins-threshold.mjs`** — `mutation.yml`, the
   `enforce efficacy threshold` step.
   - Env: `REPORT` (default `gremlins.json`), `THRESHOLD` (a number).

--- a/.github/scripts/property-run-heavy.mjs
+++ b/.github/scripts/property-run-heavy.mjs
@@ -1,0 +1,144 @@
+// property-run-heavy.mjs — decides whether `property.yml`'s heavy lane (the
+// rapid N=500 property sweep) does real work for THIS event, closing part of
+// tsouza/cerberus#2426 (a straight port of coverage-run-heavy.mjs's fix for
+// tsouza/cerberus#2416).
+//
+// The shape before this module existed
+// --------------------------------------
+// `property.yml` computed RUN_HEAVY as a single job-level GHA expression,
+// byte-identical to coverage.yml's pre-#2425 one:
+//
+//   (event != pull_request && event != merge_group) || startsWith(head_ref, 'release/')
+//
+// true on every `push`, unconditionally. Correct for a push produced by an
+// ORDINARY PR — RUN_HEAVY was false on that PR's own run, so the push is the
+// FIRST real rapid sweep for that tree — but REDUNDANT for a push produced by
+// a `release/*`-headed PR: that PR's own `pull_request` run already had
+// RUN_HEAVY=true (same expression, its own head_ref matched `release/*`) and
+// posted `property (…)`'s required check-run on its own tip commit. The
+// push-to-main run after such a PR merges re-runs the identical rapid N=500
+// sweep against a byte-identical tree for nothing.
+//
+// The fix, and everything below, is coverage-run-heavy.mjs's own design
+// verbatim — see that module's header for the full rationale (the fail-safe
+// default, the SOURCE-PR CREDIT cross-reference, why `pull_request` /
+// `merge_group` / `schedule` / `workflow_dispatch` stay unchanged). Only the
+// lane name in the log/notice text differs.
+//
+// Modes (MODE, or argv[2]; default `verify`):
+//   - verify: validate the module loads and the mode is known. No network.
+//   - emit: decide and append `run_heavy=true|false` to GITHUB_OUTPUT. Calls
+//     the GitHub API (via lib/resolve-source-pr.mjs) ONLY on a `push` event.
+//
+// Environment:
+//   MODE                `emit` | `verify` (also argv[2]).
+//   EVENT_NAME           github.event_name.
+//   HEAD_REF             github.head_ref (pull_request / merge_group only).
+//   GITHUB_SHA           the pushed commit sha (push event only).
+//   GITHUB_REPOSITORY    "owner/name" (push event only).
+//   GITHUB_TOKEN         token with pull-requests:read (push event only).
+//   GITHUB_API_URL       API base, default https://api.github.com.
+//   GITHUB_OUTPUT        emit destination.
+//
+// node: builtins only — no npm dependencies or setup-node step.
+
+import process from 'node:process';
+import { pathToFileURL } from 'node:url';
+
+import { runsFullLane } from './lib/scope-gate.mjs';
+import { resolveSourcePR } from './lib/resolve-source-pr.mjs';
+import { error, log, notice, setOutput } from './lib/gh.mjs';
+
+// decide — pure. `sourcePR` is only meaningful (and only ever passed) for a
+// `push` event: `{ number, headRef }` for an exact-match resolved PR, or
+// `null` when none resolved (no PR, ambiguous match, or a resolution
+// failure the caller already logged). Ignored for every other event.
+export function decide({ eventName, headRef, sourcePR = null }) {
+  const event = String(eventName ?? '').trim();
+
+  if (event !== 'push') {
+    const runHeavy = runsFullLane({ eventName: event, headRef });
+    return {
+      runHeavy,
+      reason: runHeavy
+        ? `event "${event || '<unknown>'}" runs the heavy property lane`
+        : 'ordinary pull_request/merge_group — green no-op, same as before',
+    };
+  }
+
+  if (sourcePR && typeof sourcePR.headRef === 'string' && sourcePR.headRef.startsWith('release/')) {
+    return {
+      runHeavy: false,
+      reason:
+        `redundant with PR #${sourcePR.number} (${sourcePR.headRef}), which already ran the heavy property ` +
+        `sweep and posted its own "property (…)" check-run on its tip commit — release-preflight.mjs's ` +
+        `SOURCE-PR CREDIT (tsouza/cerberus#2394) reads that run instead of demanding a fresh one here`,
+    };
+  }
+
+  return {
+    runHeavy: true,
+    reason: sourcePR
+      ? `source PR #${sourcePR.number} (${sourcePR.headRef ?? '<no head ref>'}) was not release/*-headed — ` +
+        'this push is the first real property sweep for this tree'
+      : 'no source PR resolved for this push (ordinary-PR merge, unresolved match, or a maintenance-line ' +
+        'hotfix with no PR at all) — running heavy for real (fail-safe default)',
+  };
+}
+
+async function resolvePushSourcePR({ repo, sha, token, apiBase }) {
+  if (!repo || !sha || !token) {
+    notice(
+      'property-run-heavy: GITHUB_REPOSITORY/GITHUB_SHA/GITHUB_TOKEN not all set for a push event — ' +
+        'cannot resolve a source PR, running heavy for real (fail-safe default).',
+    );
+    return null;
+  }
+  try {
+    return await resolveSourcePR({ repo, sha, token, apiBase });
+  } catch (e) {
+    notice(
+      `property-run-heavy: could not resolve a source PR for ${String(sha).slice(0, 8)} (${e.message}) — ` +
+        'running heavy for real (fail-safe default).',
+    );
+    return null;
+  }
+}
+
+async function main() {
+  const mode = (process.env.MODE || process.argv[2] || 'verify').trim();
+  if (mode !== 'verify' && mode !== 'emit') {
+    error(`property-run-heavy: MODE must be "verify" or "emit" (got "${mode}")`);
+    process.exit(1);
+  }
+
+  if (mode === 'verify') {
+    log('property-run-heavy: RUN_HEAVY decision policy loaded.');
+    return;
+  }
+
+  const eventName = process.env.EVENT_NAME;
+  const headRef = process.env.HEAD_REF;
+
+  let sourcePR = null;
+  if (String(eventName ?? '').trim() === 'push') {
+    sourcePR = await resolvePushSourcePR({
+      repo: process.env.GITHUB_REPOSITORY,
+      sha: process.env.GITHUB_SHA,
+      token: process.env.GITHUB_TOKEN,
+      apiBase: process.env.GITHUB_API_URL || 'https://api.github.com',
+    });
+  }
+
+  const verdict = decide({ eventName, headRef, sourcePR });
+  notice(`property-run-heavy: run_heavy=${verdict.runHeavy} — ${verdict.reason}`);
+  setOutput('run_heavy', String(verdict.runHeavy));
+}
+
+const invokedDirectly = process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href;
+if (invokedDirectly) {
+  main().catch((e) => {
+    error(`property-run-heavy failed: ${e.message}`);
+    process.exit(1);
+  });
+}

--- a/.github/scripts/property-run-heavy.test.mjs
+++ b/.github/scripts/property-run-heavy.test.mjs
@@ -1,0 +1,60 @@
+// property-run-heavy.test.mjs — node:test guard for the RUN_HEAVY decision
+// behind property.yml's push lane (tsouza/cerberus#2426, a straight port of
+// coverage-run-heavy.test.mjs for tsouza/cerberus#2416).
+//
+// What it pins:
+//   - pull_request / merge_group / schedule / workflow_dispatch behave
+//     EXACTLY as the old inline GHA expression did (delegated to
+//     scope-gate.mjs's runsFullLane, shared with mutation.yml and
+//     e2e.yml's compose-smoke-scope);
+//   - a push produced by a release/*-headed source PR is the ONE case that
+//     newly skips — everything else (an ordinary-PR push, an unresolved
+//     source PR, a maintenance-line hotfix push with no PR at all) still
+//     runs heavy, so the fail-safe default is "run it", never "skip it".
+
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { decide } from './property-run-heavy.mjs';
+
+test('pull_request and merge_group are unchanged: release/*-headed runs heavy, everything else does not', () => {
+  assert.equal(decide({ eventName: 'pull_request', headRef: 'release/1.14.x' }).runHeavy, true);
+  assert.equal(decide({ eventName: 'pull_request', headRef: 'fix/some-bug' }).runHeavy, false);
+  assert.equal(decide({ eventName: 'pull_request', headRef: '' }).runHeavy, false);
+  assert.equal(decide({ eventName: 'merge_group', headRef: '' }).runHeavy, false);
+});
+
+test('schedule and workflow_dispatch always run heavy, sourcePR or not', () => {
+  for (const eventName of ['schedule', 'workflow_dispatch']) {
+    assert.equal(decide({ eventName }).runHeavy, true, eventName);
+    assert.equal(decide({ eventName, sourcePR: { number: 1, headRef: 'release/1.14.x' } }).runHeavy, true, eventName);
+  }
+});
+
+test('push produced by a release/*-headed source PR is redundant — skips', () => {
+  const v = decide({ eventName: 'push', sourcePR: { number: 2400, headRef: 'release/1.14.x' } });
+  assert.equal(v.runHeavy, false);
+  assert.match(v.reason, /redundant with PR #2400/);
+  assert.match(v.reason, /SOURCE-PR CREDIT/);
+});
+
+test('push produced by an ordinary (non-release) source PR is the first real run — runs heavy', () => {
+  const v = decide({ eventName: 'push', sourcePR: { number: 41, headRef: 'fix/something' } });
+  assert.equal(v.runHeavy, true);
+  assert.match(v.reason, /first real property sweep/);
+});
+
+test('push with no resolved source PR (maintenance hotfix, or resolution failure) fails safe to heavy', () => {
+  const v = decide({ eventName: 'push', sourcePR: null });
+  assert.equal(v.runHeavy, true);
+  assert.match(v.reason, /fail-safe default/);
+});
+
+test('a source PR match with no head ref (malformed) is treated as not release-headed — runs heavy', () => {
+  const v = decide({ eventName: 'push', sourcePR: { number: 7, headRef: null } });
+  assert.equal(v.runHeavy, true);
+});
+
+test('an unfamiliar event name fails open, same as scope-gate.runsFullLane', () => {
+  assert.equal(decide({ eventName: 'some_future_event' }).runHeavy, true);
+});

--- a/.github/workflows/property.yml
+++ b/.github/workflows/property.yml
@@ -52,6 +52,16 @@ name: property
 # single term — see test/regression/lint_build_tags_test.go — so it can't
 # spell `chdb && agpl_oracle` directly). The step below passes all three
 # tags for every property test in one invocation.
+#
+# tsouza/cerberus#2426: a push-to-main produced by a release/*-headed PR
+# merging is REDUNDANT — that PR's own pull_request run already ran the rapid
+# sweep on the identical tree and posted this job's required check-run on its
+# own tip commit. .github/scripts/property-run-heavy.mjs (a straight port of
+# coverage.yml's #2416 fix) resolves the PR that produced the pushed commit
+# and skips the heavy run ONLY in that one provable case; every other push —
+# an ordinary-PR merge, an unresolved source PR, or a maintenance-line hotfix
+# with no PR at all — still runs heavy. See the script's own header for the
+# full decision table.
 
 on:
   pull_request:
@@ -77,6 +87,10 @@ env:
 
 permissions:
   contents: read
+  # property-run-heavy.mjs resolves the PR that produced a pushed commit via
+  # GET /commits/{sha}/pulls (lib/resolve-source-pr.mjs) — read-only, and only
+  # exercised on a `push` event.
+  pull-requests: read
 
 concurrency:
   # Main pushes and matching cron schedules replace only their own modes. PR,
@@ -93,42 +107,61 @@ jobs:
     # see that constant's comment for the real measured per-check cost this
     # is derived from, and why 30 was too tight in practice.
     timeout-minutes: 40
-    # RUN_HEAVY gates the real work: true on push / schedule / dispatch, and on
-    # a release PR (head branch release/*). On a regular PR every heavy step is
-    # skipped and the job reports green without work — so `property …` can be a
-    # required check that gates release PRs but never blocks ordinary PRs.
+    # RUN_HEAVY gates the real work: true on push / schedule / dispatch (unless
+    # a resolved source PR proves this push redundant — see the `decide
+    # run_heavy` step below), and on a release PR (head branch release/*). On a
+    # regular PR every heavy step is skipped and the job reports green without
+    # work — so `property …` can be a required check that gates release PRs
+    # but never blocks ordinary PRs.
     #
     # A merge-queue entry is held to the PR posture, not the push posture: the
     # queue answers the same contexts branch protection asks a PR for, and a
     # queue that runs work the PR never ran can dequeue a PR that was green. The
     # rapid sweep is not lost — `main` advances to the merge group's own head
     # SHA and the push trigger above runs it there.
-    env:
-      RUN_HEAVY: ${{ (github.event_name != 'pull_request' && github.event_name != 'merge_group') || startsWith(github.head_ref, 'release/') }}
     steps:
       - uses: actions/checkout@v7
 
-      - if: env.RUN_HEAVY == 'true'
+      - name: Test property gates
+        run: node --test .github/scripts/property-run-heavy.test.mjs
+
+      # Computed as a step output rather than a static job-level `env:` GHA
+      # expression: a `push` event needs a network call (resolve the source PR
+      # that produced the pushed commit) to know whether it is redundant with
+      # that PR's own run, and job-level `env:` has no `steps` context to read
+      # such a call's result from. See property-run-heavy.mjs's header for the
+      # full decision table; GITHUB_TOKEN is used read-only and only reached on
+      # a `push` event.
+      - id: run_heavy
+        name: decide run_heavy
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          MODE: emit
+          EVENT_NAME: ${{ github.event_name }}
+          HEAD_REF: ${{ github.head_ref }}
+        run: node .github/scripts/property-run-heavy.mjs
+
+      - if: steps.run_heavy.outputs.run_heavy == 'true'
         uses: actions/setup-go@v7
         with:
           go-version-file: 'go.mod'
           cache: true
 
-      - if: env.RUN_HEAVY == 'true'
+      - if: steps.run_heavy.outputs.run_heavy == 'true'
         uses: taiki-e/install-action@82cd3e7658a6f96c86c0234aeeda1748937cb0a1  # v2.85.13
         with:
           tool: just
 
       - name: Install libchdb.so
-        if: env.RUN_HEAVY == 'true'
+        if: steps.run_heavy.outputs.run_heavy == 'true'
         run: just chdb-install
 
       - name: No-op (non-release PR)
-        if: env.RUN_HEAVY != 'true'
+        if: steps.run_heavy.outputs.run_heavy != 'true'
         run: echo "property is a green no-op on non-release PRs (real run on push/nightly/dispatch + release/* PRs)."
 
       - name: Run property tests (rapid N=500)
-        if: env.RUN_HEAVY == 'true'
+        if: steps.run_heavy.outputs.run_heavy == 'true'
         # `-tags chdb,agpl_oracle,chdb_agpl_oracle` enables the chdb-tagged
         # property entry points AND the LogQL property test's from-scratch
         # oracle (which additionally needs `agpl_oracle`) AND


### PR DESCRIPTION
## Summary

Part of #2426 (the property.yml lane). property.yml computed `RUN_HEAVY` as a single job-level GHA expression, byte-identical to `coverage.yml`'s pre-#2425 shape: true on every `push`, unconditionally. Correct for a push produced by an ordinary PR (the push is the FIRST real rapid N=500 sweep for that tree), but redundant for a push produced by a `release/*`-headed PR — that PR's own `pull_request` run already ran heavy and posted `property (…)`'s required check-run on its own tip commit.

Ports `coverage-run-heavy.mjs` (landed in #2425) verbatim as `property-run-heavy.mjs`: `pull_request`/`merge_group`/`schedule`/`workflow_dispatch` behavior is unchanged (delegated to `scope-gate.mjs`'s `runsFullLane`); a `push` resolves the source PR via `lib/resolve-source-pr.mjs`'s exact `merged && merge_commit_sha` match and skips the heavy run ONLY when that PR resolved AND its own head ref started with `release/`. Every other push — an ordinary-PR merge, an unresolved match, a maintenance-line hotfix with no PR at all — still runs heavy, fail-safe by construction.

`property.yml`'s job-level `RUN_HEAVY` GHA expression becomes a step output (`decide run_heavy`), matching `coverage.yml`'s shape, since a `push` now needs a network call the static job-level `env:` context can't make.

## Test plan

- [x] `node --test .github/scripts/property-run-heavy.test.mjs` (7 new tests, decision table pinned both directions)
- [x] `node --test .github/scripts/*.test.mjs` (776 tests, full suite, no collateral breakage)
- [x] `node .github/scripts/ci-lane-contract.mjs` — 53 lanes structurally valid
- [x] `actionlint .github/workflows/property.yml`
- [x] `npx markdownlint-cli2 .github/scripts/README.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)