### PR TITLE
fix(ci): skip chdb.yml's redundant push run after a release PR merge

### DIFF
--- a/.github/scripts/README.md
+++ b/.github/scripts/README.md
@@ -1628,6 +1628,30 @@ what actually runs.
   - Exit: `0` when the shards rolled up the way RUN_HEAVY says they should,
     `1` otherwise.
 
+- **`chdb-run-heavy.mjs`** — `chdb.yml`, the `changes` job's `decide run_heavy`
+  step. A port of `coverage-run-heavy.mjs`'s #2416 fix to a fourth lane
+  (tsouza/cerberus#2426), replacing the inline shell branch the `compute`
+  step used to compute `run_heavy` in (semantically identical to
+  `scope-gate.mjs`'s `runsFullLane`, just hand-duplicated in shell). Skips
+  chdb.yml's push-to-main run — for ALL six lanes `run_heavy` gates
+  (`chdb-build`, `roundtrip` ×3, `perf-guards`/`perf-guards-shard`,
+  `integration-<ql>` ×3) at once, since they all read the SAME `changes`
+  output — ONLY when it is redundant with a resolved, `release/*`-headed
+  source PR that already ran them heavy and posted their check-runs on its
+  tip commit. Same decision table, same fail-safe default as every other
+  #2416/#2426 lane; `docs_only` (computed in the same job) is untouched.
+  `chdb-run-heavy.test.mjs` pins the decision table; it runs inside
+  `changes`'s own always-on "Test chdb run_heavy gate" step.
+  - Modes: `verify` (loads the policy, no network) | `emit` (decide + append
+    `run_heavy=true|false` to `GITHUB_OUTPUT`; calls the GitHub API only on a
+    `push` event).
+  - Env: `MODE` (also argv[2]), `EVENT_NAME`, `HEAD_REF` (pull_request /
+    merge_group only), `GITHUB_SHA` / `GITHUB_REPOSITORY` / `GITHUB_TOKEN` /
+    `GITHUB_API_URL` (push only), `GITHUB_OUTPUT`.
+  - Exit: `0` always in `emit` mode (a resolution failure fails SAFE to
+    `run_heavy=true`, logged via `::notice::`, never a hard failure); `1` on an
+    unrecognised `MODE`.
+
 - **`chdb-roundtrip.mjs`** — `chdb.yml`, the `roundtrip (<ql>)` matrix job. Runs
   one head's chDB-executing TXTAR walk: `./test/spec/<ql>/` (pre-optimizer) and
   `./internal/<ql>/` (post-optimizer plus the reference-engine parity). It

--- a/.github/scripts/chdb-run-heavy.mjs
+++ b/.github/scripts/chdb-run-heavy.mjs
@@ -1,0 +1,160 @@
+// chdb-run-heavy.mjs — decides whether `chdb.yml`'s release-gate lanes
+// (`chdb-build`, `roundtrip (<ql>)`, `perf-guards`/`perf-guards-shard`,
+// `integration-<ql>`) do real work for THIS event, closing part of
+// tsouza/cerberus#2426 (a port of coverage-run-heavy.mjs's #2416 fix).
+//
+// The shape before this module existed
+// --------------------------------------
+// `chdb.yml`'s `changes` job computed `run_heavy` inline, in its `compute`
+// step's shell script:
+//
+//   if event != pull_request && event != merge_group: true
+//   elif head_ref starts with release/: true
+//   else: false
+//
+// Semantically identical to `scope-gate.mjs`'s `runsFullLane` (the same
+// helper `mutation.yml`, `compose-smoke-scope.mjs`, `coverage-run-heavy.mjs`
+// and `property-run-heavy.mjs` already share), but hand-duplicated in shell
+// rather than delegated to it — and, like every one of those lanes before
+// their own #2416/#2426 fix, `true` on every `push` unconditionally. Correct
+// for a push produced by an ORDINARY PR (the push is the FIRST real run for
+// that tree) but REDUNDANT for a push produced by a `release/*`-headed PR:
+// that PR's own `pull_request` run already had `run_heavy=true` and posted
+// every one of chdb.yml's release-gate check-runs on its own tip commit.
+//
+// Unlike coverage.yml/property.yml (one job, one lane) and perf-profile.yml
+// (two jobs, one lane), chdb.yml's `run_heavy` output feeds SIX lanes at
+// once — `chdb-build`, `roundtrip` (3 matrix legs, per-STEP gated — see that
+// job's own comment for why job-level would hide the per-leg context names),
+// `perf-guards-shard`/`perf-guards`, and all three `integration-<ql>` jobs —
+// all downstream of the SAME `changes` job. This module changes nothing
+// about that fan-out: it only replaces the `compute` step's inline
+// `run_heavy` shell branch with the SAME decision every other #2416/#2426
+// lane now makes, so every downstream consumer keeps reading
+// `needs.changes.outputs.run_heavy` exactly as before. `docs_only` (also
+// computed in `changes`) is untouched — that is a separate, PR-only decision
+// this module has no opinion on.
+//
+// The fix, and everything below, is coverage-run-heavy.mjs's own design
+// verbatim — see that module's header for the full rationale (the fail-safe
+// default, the SOURCE-PR CREDIT cross-reference, why `pull_request` /
+// `merge_group` / `schedule` / `workflow_dispatch` stay unchanged). Only the
+// lane name in the log/notice text differs.
+//
+// Modes (MODE, or argv[2]; default `verify`):
+//   - verify: validate the module loads and the mode is known. No network.
+//   - emit: decide and append `run_heavy=true|false` to GITHUB_OUTPUT. Calls
+//     the GitHub API (via lib/resolve-source-pr.mjs) ONLY on a `push` event.
+//
+// Environment:
+//   MODE                `emit` | `verify` (also argv[2]).
+//   EVENT_NAME           github.event_name.
+//   HEAD_REF             github.head_ref (pull_request / merge_group only).
+//   GITHUB_SHA           the pushed commit sha (push event only).
+//   GITHUB_REPOSITORY    "owner/name" (push event only).
+//   GITHUB_TOKEN         token with pull-requests:read (push event only).
+//   GITHUB_API_URL       API base, default https://api.github.com.
+//   GITHUB_OUTPUT        emit destination.
+//
+// node: builtins only — no npm dependencies or setup-node step.
+
+import process from 'node:process';
+import { pathToFileURL } from 'node:url';
+
+import { runsFullLane } from './lib/scope-gate.mjs';
+import { resolveSourcePR } from './lib/resolve-source-pr.mjs';
+import { error, log, notice, setOutput } from './lib/gh.mjs';
+
+// decide — pure. `sourcePR` is only meaningful (and only ever passed) for a
+// `push` event: `{ number, headRef }` for an exact-match resolved PR, or
+// `null` when none resolved (no PR, ambiguous match, or a resolution
+// failure the caller already logged). Ignored for every other event.
+export function decide({ eventName, headRef, sourcePR = null }) {
+  const event = String(eventName ?? '').trim();
+
+  if (event !== 'push') {
+    const runHeavy = runsFullLane({ eventName: event, headRef });
+    return {
+      runHeavy,
+      reason: runHeavy
+        ? `event "${event || '<unknown>'}" runs the heavy chdb lanes`
+        : 'ordinary pull_request/merge_group — package-enrollment gate only, same as before',
+    };
+  }
+
+  if (sourcePR && typeof sourcePR.headRef === 'string' && sourcePR.headRef.startsWith('release/')) {
+    return {
+      runHeavy: false,
+      reason:
+        `redundant with PR #${sourcePR.number} (${sourcePR.headRef}), which already ran the heavy chdb ` +
+        `lanes and posted their check-runs on its tip commit — release-preflight.mjs's SOURCE-PR CREDIT ` +
+        `(tsouza/cerberus#2394) reads that run instead of demanding a fresh one here`,
+    };
+  }
+
+  return {
+    runHeavy: true,
+    reason: sourcePR
+      ? `source PR #${sourcePR.number} (${sourcePR.headRef ?? '<no head ref>'}) was not release/*-headed — ` +
+        'this push is the first real chdb run for this tree'
+      : 'no source PR resolved for this push (ordinary-PR merge, unresolved match, or a maintenance-line ' +
+        'hotfix with no PR at all) — running heavy for real (fail-safe default)',
+  };
+}
+
+async function resolvePushSourcePR({ repo, sha, token, apiBase }) {
+  if (!repo || !sha || !token) {
+    notice(
+      'chdb-run-heavy: GITHUB_REPOSITORY/GITHUB_SHA/GITHUB_TOKEN not all set for a push event — ' +
+        'cannot resolve a source PR, running heavy for real (fail-safe default).',
+    );
+    return null;
+  }
+  try {
+    return await resolveSourcePR({ repo, sha, token, apiBase });
+  } catch (e) {
+    notice(
+      `chdb-run-heavy: could not resolve a source PR for ${String(sha).slice(0, 8)} (${e.message}) — ` +
+        'running heavy for real (fail-safe default).',
+    );
+    return null;
+  }
+}
+
+async function main() {
+  const mode = (process.env.MODE || process.argv[2] || 'verify').trim();
+  if (mode !== 'verify' && mode !== 'emit') {
+    error(`chdb-run-heavy: MODE must be "verify" or "emit" (got "${mode}")`);
+    process.exit(1);
+  }
+
+  if (mode === 'verify') {
+    log('chdb-run-heavy: RUN_HEAVY decision policy loaded.');
+    return;
+  }
+
+  const eventName = process.env.EVENT_NAME;
+  const headRef = process.env.HEAD_REF;
+
+  let sourcePR = null;
+  if (String(eventName ?? '').trim() === 'push') {
+    sourcePR = await resolvePushSourcePR({
+      repo: process.env.GITHUB_REPOSITORY,
+      sha: process.env.GITHUB_SHA,
+      token: process.env.GITHUB_TOKEN,
+      apiBase: process.env.GITHUB_API_URL || 'https://api.github.com',
+    });
+  }
+
+  const verdict = decide({ eventName, headRef, sourcePR });
+  notice(`chdb-run-heavy: run_heavy=${verdict.runHeavy} — ${verdict.reason}`);
+  setOutput('run_heavy', String(verdict.runHeavy));
+}
+
+const invokedDirectly = process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href;
+if (invokedDirectly) {
+  main().catch((e) => {
+    error(`chdb-run-heavy failed: ${e.message}`);
+    process.exit(1);
+  });
+}

--- a/.github/scripts/chdb-run-heavy.test.mjs
+++ b/.github/scripts/chdb-run-heavy.test.mjs
@@ -1,0 +1,60 @@
+// chdb-run-heavy.test.mjs — node:test guard for the RUN_HEAVY decision
+// behind chdb.yml's push lane (tsouza/cerberus#2426, a port of
+// coverage-run-heavy.test.mjs for tsouza/cerberus#2416).
+//
+// What it pins:
+//   - pull_request and merge_group are unchanged: release/*-headed runs
+//     heavy, everything else does not (delegated to scope-gate.mjs's
+//     runsFullLane, shared with mutation.yml and e2e.yml's
+//     compose-smoke-scope);
+//   - a push produced by a release/*-headed source PR is the ONE case that
+//     newly skips — everything else (an ordinary-PR push, an unresolved
+//     source PR, a maintenance-line hotfix push with no PR at all) still
+//     runs heavy, so the fail-safe default is "run it", never "skip it".
+
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { decide } from './chdb-run-heavy.mjs';
+
+test('pull_request and merge_group are unchanged: release/*-headed runs heavy, everything else does not', () => {
+  assert.equal(decide({ eventName: 'pull_request', headRef: 'release/1.14.x' }).runHeavy, true);
+  assert.equal(decide({ eventName: 'pull_request', headRef: 'fix/some-bug' }).runHeavy, false);
+  assert.equal(decide({ eventName: 'pull_request', headRef: '' }).runHeavy, false);
+  assert.equal(decide({ eventName: 'merge_group', headRef: '' }).runHeavy, false);
+});
+
+test('schedule and workflow_dispatch always run heavy, sourcePR or not', () => {
+  for (const eventName of ['schedule', 'workflow_dispatch']) {
+    assert.equal(decide({ eventName }).runHeavy, true, eventName);
+    assert.equal(decide({ eventName, sourcePR: { number: 1, headRef: 'release/1.14.x' } }).runHeavy, true, eventName);
+  }
+});
+
+test('push produced by a release/*-headed source PR is redundant — skips', () => {
+  const v = decide({ eventName: 'push', sourcePR: { number: 2400, headRef: 'release/1.14.x' } });
+  assert.equal(v.runHeavy, false);
+  assert.match(v.reason, /redundant with PR #2400/);
+  assert.match(v.reason, /SOURCE-PR CREDIT/);
+});
+
+test('push produced by an ordinary (non-release) source PR is the first real run — runs heavy', () => {
+  const v = decide({ eventName: 'push', sourcePR: { number: 41, headRef: 'fix/something' } });
+  assert.equal(v.runHeavy, true);
+  assert.match(v.reason, /first real chdb run/);
+});
+
+test('push with no resolved source PR (maintenance hotfix, or resolution failure) fails safe to heavy', () => {
+  const v = decide({ eventName: 'push', sourcePR: null });
+  assert.equal(v.runHeavy, true);
+  assert.match(v.reason, /fail-safe default/);
+});
+
+test('a source PR match with no head ref (malformed) is treated as not release-headed — runs heavy', () => {
+  const v = decide({ eventName: 'push', sourcePR: { number: 7, headRef: null } });
+  assert.equal(v.runHeavy, true);
+});
+
+test('an unfamiliar event name fails open, same as scope-gate.runsFullLane', () => {
+  assert.equal(decide({ eventName: 'some_future_event' }).runHeavy, true);
+});

--- a/.github/workflows/chdb.yml
+++ b/.github/workflows/chdb.yml
@@ -37,6 +37,17 @@ name: chdb
 #
 # If you widen `probe`'s trigger scope, audit the required-checks list at
 # the same time — a context that never runs blocks every PR.
+#
+# tsouza/cerberus#2426: a push-to-main produced by a release/*-headed PR
+# merging is REDUNDANT for every run_heavy-gated lane above (chdb-build,
+# roundtrip, perf-guards, integration-<ql>) — that PR's own pull_request run
+# already ran them heavy and posted their check-runs on its own tip commit.
+# `changes`'s `decide run_heavy` step (.github/scripts/chdb-run-heavy.mjs, a
+# port of coverage.yml's #2416 fix) resolves the PR that produced the pushed
+# commit and skips the heavy run ONLY in that one provable case; every other
+# push — an ordinary-PR merge, an unresolved source PR, or a maintenance-line
+# hotfix with no PR at all — still runs heavy. See the script's own header
+# for the full decision table.
 
 on:
   push:
@@ -76,6 +87,10 @@ env:
 
 permissions:
   contents: read
+  # chdb-run-heavy.mjs resolves the PR that produced a pushed commit via
+  # GET /commits/{sha}/pulls (lib/resolve-source-pr.mjs) — read-only, and
+  # only exercised on a `push` event.
+  pull-requests: read
 
 concurrency:
   # Main pushes replace only older main pushes; matching cron schedules replace
@@ -94,15 +109,18 @@ jobs:
       # run_heavy — the merge/release two-tier split (#2230). `roundtrip`,
       # `integration-*`, `chdb-build` and `perf-guards` are release-gate lanes,
       # not merge-gate ones: they do their real (chDB-heavy) work on push /
-      # schedule / dispatch and on a `release/*` head-branch PR, and short-
-      # circuit to a fast no-op everywhere else (an ordinary PR, or a
-      # merge-group entry, which is held to the PR posture — see coverage.yml /
-      # property.yml for the same pattern). `probe` is NOT gated on this: it
-      # stays a normal, always-real PR check.
-      run_heavy: ${{ steps.compute.outputs.run_heavy }}
+      # schedule / dispatch and on a `release/*` head-branch PR (unless a
+      # resolved source PR proves a push redundant — see the `decide
+      # run_heavy` step below), and short-circuit to a fast no-op everywhere
+      # else (an ordinary PR, or a merge-group entry, which is held to the PR
+      # posture — see coverage.yml / property.yml for the same pattern).
+      # `probe` is NOT gated on this: it stays a normal, always-real PR check.
+      run_heavy: ${{ steps.run_heavy.outputs.run_heavy }}
     steps:
       - uses: actions/checkout@v7
-        if: github.event_name == 'pull_request'
+
+      - name: Test chdb run_heavy gate
+        run: node --test .github/scripts/chdb-run-heavy.test.mjs
 
       - id: filter
         if: github.event_name == 'pull_request'
@@ -125,13 +143,6 @@ jobs:
               - '!README*'
 
       - id: compute
-        # HEAD_REF is passed through the environment, never interpolated
-        # directly into the script: github.head_ref is attacker-controlled on
-        # a fork PR (it is a branch name), and a raw `${{ github.head_ref }}`
-        # in a `run:` block is a script-injection hazard. github.event_name is
-        # server-controlled and safe to interpolate directly.
-        env:
-          HEAD_REF: ${{ github.head_ref }}
         run: |
           if [ "${{ github.event_name }}" = "pull_request" ]; then
             if [ "${{ steps.filter.outputs.code }}" = "false" ]; then
@@ -143,13 +154,20 @@ jobs:
             echo "docs_only=false" >> "$GITHUB_OUTPUT"
           fi
 
-          if [ "${{ github.event_name }}" != "pull_request" ] && [ "${{ github.event_name }}" != "merge_group" ]; then
-            echo "run_heavy=true" >> "$GITHUB_OUTPUT"
-          elif [[ "$HEAD_REF" == release/* ]]; then
-            echo "run_heavy=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "run_heavy=false" >> "$GITHUB_OUTPUT"
-          fi
+      # Computed as a step output rather than inline in the `compute` step
+      # above: a `push` event needs a network call (resolve the source PR
+      # that produced the pushed commit) to know whether it is redundant with
+      # that PR's own run. See chdb-run-heavy.mjs's header for the full
+      # decision table; GITHUB_TOKEN is used read-only and only reached on a
+      # `push` event.
+      - id: run_heavy
+        name: decide run_heavy
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          MODE: emit
+          EVENT_NAME: ${{ github.event_name }}
+          HEAD_REF: ${{ github.head_ref }}
+        run: node .github/scripts/chdb-run-heavy.mjs
 
   # `chdb-build` is a FAST, PR-visible compile gate over the entire
   # chdb-tagged tree. It does NOT run any tests — `go build` + `go vet`


### PR DESCRIPTION
## Summary

Third and final lane of #2426. `chdb.yml`'s `changes` job computed `run_heavy` inline in its `compute` step's shell script — semantically identical to `scope-gate.mjs`'s `runsFullLane` but hand-duplicated in bash rather than delegated to it, and (like the other two lanes) `true` on every `push` unconditionally, even when redundant with a `release/*`-headed source PR that already ran everything heavy and posted the check-runs on its own tip commit.

This is the audit case the issue called out: `run_heavy` here feeds SIX release-gate lanes at once — `chdb-build`, `roundtrip` (3 matrix legs, per-step gated), `perf-guards`/`perf-guards-shard`, and all three `integration-<ql>` jobs — all downstream of the one `changes` job. Confirmed `docs_only` (computed in the same job) is a fully separate, PR-only decision this change has no opinion on, and `probe` is explicitly NOT gated on `run_heavy` at all (stays a normal, always-real PR check) — so the fix is a single-job replacement: swap the inline shell branch for `chdb-run-heavy.mjs` (a straight port of `coverage-run-heavy.mjs`'s #2416 fix), and every downstream consumer keeps reading `needs.changes.outputs.run_heavy` exactly as before.

`actions/checkout` in the `changes` job was previously gated to `pull_request` only (the old inline shell needed no repo files); broadened to run on every event since the new script needs the file present.

## Test plan

- [x] `node --test .github/scripts/chdb-run-heavy.test.mjs` (7 new tests, decision table pinned both directions)
- [x] `node --test .github/scripts/*.test.mjs` (776 tests, full suite, no collateral breakage)
- [x] `go test -run '^TestCILaneRegistry$' ./test/regression/...`
- [x] `go test ./test/regression/...` (full package)
- [x] `node --test .github/scripts/main-coalescing.test.mjs`
- [x] `node .github/scripts/ci-lane-contract.mjs` — 53 lanes structurally valid
- [x] `actionlint .github/workflows/chdb.yml`
- [x] `npx markdownlint-cli2 .github/scripts/README.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)