### PR TITLE
fix(promql): drop native-histogram samples for clamp/clamp_min/clamp_max

### DIFF
--- a/internal/promql/histogram_native_float_fn_test.go
+++ b/internal/promql/histogram_native_float_fn_test.go
@@ -70,6 +70,50 @@ func TestLower_ExpHistogram_FloatOnlyFunctionsDropSamples(t *testing.T) {
 	}
 }
 
+// TestLower_ExpHistogram_ClampFamilyDropsSamples pins issue #2345: reference
+// Prometheus's shared clamp() helper (promql/functions.go) skips every
+// sample whose H field is set — the same "process only float samples" rule
+// simpleFloatFunc applies for abs/ceil/floor/round/etc — so clamp_max,
+// clamp_min and the 3-arg clamp must drop a histogram-valued argument to an
+// empty float vector rather than hard-reject it. Before the fix, the clamp
+// family's vector arg never went through lowerExpHistogramValuedShape, so a
+// histogram selector fell through to the generic lower() dispatch and hit
+// expHistogramSelectorRouting's catch-all rejection.
+func TestLower_ExpHistogram_ClampFamilyDropsSamples(t *testing.T) {
+	t.Parallel()
+
+	s := schema.DefaultOTelMetrics()
+	p := parser.NewParser(parser.Options{})
+	at := time.Date(2026, 1, 1, 0, 0, 1, 0, time.UTC)
+
+	queries := []string{
+		`clamp_max(latency_exp_hist, 5)`,
+		`clamp_min(latency_exp_hist, 0)`,
+		`clamp(latency_exp_hist, 0, 5)`,
+
+		// The consumer sees histogram-valued results, not only selectors.
+		`clamp_max(sum(latency_exp_hist), 5)`,
+		`clamp_max(rate(latency_exp_hist[5m]), 5)`,
+	}
+
+	for _, query := range queries {
+		query := query
+		t.Run(query, func(t *testing.T) {
+			t.Parallel()
+
+			expr, err := p.ParseExpr(query)
+			if err != nil {
+				t.Fatalf("ParseExpr(%q): %v", query, err)
+			}
+			plan, err := promql.LowerAt(context.Background(), expr, s, at, at)
+			if err != nil {
+				t.Fatalf("LowerAt(%q): %v", query, err)
+			}
+			assertEmptyFloatProjection(t, plan)
+		})
+	}
+}
+
 func TestLower_ExpHistogram_FloatOnlyFunctionRangeDropsSamples(t *testing.T) {
 	t.Parallel()
 

--- a/internal/promql/instant_fns.go
+++ b/internal/promql/instant_fns.go
@@ -160,7 +160,27 @@ func lowerRoundToNearest(c *parser.Call, s schema.Metrics, ctx lowerCtx) (chplan
 //     `NOT (max < min)` Filter (NaN bounds compare false, so they
 //     keep the rows and resolve to NaN values — exactly Prom's
 //     behaviour).
+//
+// Prom's shared clamp() helper (promql/functions.go) skips every sample
+// whose H field is set before applying math.Max/math.Min — the exact
+// "process only float samples" rule simpleFloatFunc applies for
+// abs/ceil/floor/round/etc. Unlike those, the clamp family didn't route
+// its vector arg through lowerExpHistogramValuedShape, so a histogram
+// selector fell through to lower()'s generic dispatch and hit
+// expHistogramSelectorRouting's catch-all rejection instead of Prom's
+// drop-and-answer-empty semantics (cerberus issue #2345). Checking it
+// here, before the literal/computed bound split below, makes all three
+// clamp forms answer an empty float vector for a histogram-valued arg
+// exactly as dropExpHistogramSamples does for the unary math functions.
 func lowerClamp(c *parser.Call, s schema.Metrics, ctx lowerCtx) (chplan.Node, error) {
+	if len(c.Args) >= 1 {
+		if hist, ok, err := lowerExpHistogramValuedShape(c.Args[0], s, ctx); ok {
+			if err != nil {
+				return nil, err
+			}
+			return dropExpHistogramSamples(hist, s), nil
+		}
+	}
 	switch c.Func.Name {
 	case "clamp_max", "clamp_min":
 		if len(c.Args) != 2 {

--- a/test/rejection-parity/catalogue/internal__promql__lower.go.json
+++ b/test/rejection-parity/catalogue/internal__promql__lower.go.json
@@ -76,8 +76,8 @@
       "site": "internal/promql/lower.go:expHistogramSelectorRouting#bf746b59",
       "message": "promql: %q is an exponential histogram metric; only a bare %q selector, sum()/avg()/count() over one, rate()/increase()/delta()/irate()/idelta()/sum_over_time()/avg_over_time()/resets()/changes() over one, histogram_quantile(), histogram_count(), histogram_sum(), and the %q/%q companion selectors are supported",
       "class": "divergence",
-      "trigger_query": "clamp_max(demo_latency_exp_hist, 5)",
-      "tracking_issue": 2345,
+      "trigger_query": "absent(demo_latency_exp_hist)",
+      "tracking_issue": 2443,
       "evidence": {
         "guard": [
           "past returning if bare, col, hasCompanion := s.HistogramCompanionColumn(metricName); hasCompanion \u0026\u0026 s.IsExpHistogramMetric(bare) \u0026\u0026 s.ExpHistogramTable != \"\"",
@@ -87,7 +87,7 @@
           "resolveSelectorRouting"
         ]
       },
-      "since": "2026-08-17"
+      "since": "2026-08-21"
     },
     {
       "head": "promql",


### PR DESCRIPTION
## Summary

Closes #2345 — `clamp_max(demo_latency_exp_hist, 5)` (and its `clamp_min` / 3-arg `clamp`
siblings) hard-rejected a raw exponential-histogram selector instead of answering with
reference-matching drop semantics.

Reference Prometheus's shared `clamp()` helper (`promql/functions.go`) skips every sample
whose `H` field is set before applying `math.Max`/`math.Min` — the exact "process only float
samples" rule `simpleFloatFunc` already applies for `abs`/`ceil`/`floor`/`round`/etc (issue
#2221, `internal/promql/instant_fns.go` `lowerInstantFn`). The clamp family
(`internal/promql/instant_fns.go` `lowerClamp`) never routed its vector arg through
`lowerExpHistogramValuedShape`, so a histogram-valued selector fell through to `lower()`'s
generic dispatch and hit `expHistogramSelectorRouting`'s catch-all rejection
(`internal/promql/lower.go`) instead.

**Fix**: `lowerClamp` now checks `lowerExpHistogramValuedShape` on its vector argument before
the literal/computed-bound dispatch, mirroring the guard `lowerInstantFn` already applies —
a histogram-valued argument now answers an empty float vector via `dropExpHistogramSamples`,
for all three of `clamp`, `clamp_min` and `clamp_max`, including when the histogram value is
produced by a nested shape (`sum(...)`, `rate(...)`) rather than a bare selector.

**Rejection-parity catalogue**: `expHistogramSelectorRouting`'s single catalogued divergence
entry (`test/rejection-parity/catalogue/internal__promql__lower.go.json`) used
`clamp_max(demo_latency_exp_hist, 5)` as its trigger query; that trigger now lowers
successfully, so it would no longer exercise the site. Verified the next reachable trigger at
this exact site is `absent(demo_latency_exp_hist)` — `absent()` never reads a sample's value
(same rationale as the already-fixed `absent_over_time`, #2226) but still isn't routed through
the histogram-valued-shape exemption, so cerberus still hard-rejects it while reference answers
it. Filed #2443 to track that specific gap and repointed the catalogue entry's `trigger_query`
/ `tracking_issue` / `since` at it, following the same rotation this site's entry has gone
through before (#1801 → #2087 → #2189 → #2224 → #2225 → #2226 → #2331 → #2339 → #2342 → #2345
→ now #2443).

## Test plan

- `go test -run '^TestLower_ExpHistogram_ClampFamilyDropsSamples$' ./internal/promql/` — new
  unit test pinning `clamp_max`/`clamp_min`/`clamp` over a bare exp-histogram selector and over
  nested histogram-valued shapes (`sum(...)`, `rate(...)`), asserting each answers the same
  empty-float-projection shape `abs`/`ceil`/etc already do.
- `go test -count=1 ./internal/promql/...` — full package, no regressions.
- `go test -run '^TestCatalogueIsRegenerable$|^TestCatalogueEntriesAreClassified$|^TestRejectionTriggersExerciseSites$|^TestParityCorpusMatchesCatalogue$|^TestDivergence' -v ./test/rejection-parity/...` —
  the catalogue's own self-checks: the new `absent(demo_latency_exp_hist)` trigger still
  reaches `expHistogramSelectorRouting`'s exact message, the divergence age-cap/ceiling
  ratchets hold, and the parity corpus stays derived 1:1 from the catalogue.
- `go test -count=1 ./test/surface-parity/ ./test/rejection-parity/` — the full ledger-adjacent
  suite `update-parity-ledgers` runs, clean.
- `go build ./...` and `go vet ./...` — clean.

No `test/spec/` TXTAR golden touches this shape (the sibling `abs`/`ceil`/etc drop-semantics
fix from #2221 is likewise pinned only by a Go unit test, not a TXTAR fixture), so no
`just update-golden` run was needed.
