### PR TITLE
fix(engine): charge histogram range-fanout subquery grids against the anchor budget

### DIFF
--- a/internal/api/prom/handler_subquery_budget_test.go
+++ b/internal/api/prom/handler_subquery_budget_test.go
@@ -75,3 +75,63 @@ func TestQuery_SubqueryWithinBudget_NotGated(t *testing.T) {
 		t.Fatal("within-budget subquery never reached execution; the anchor gate over-rejected")
 	}
 }
+
+// TestQuery_HistogramSubqueryAnchorBudget422 — #2408 regression pin. A
+// classic-histogram `histogram_quantile(...)` used as a SUBQUERY INNER
+// materialises its own [chplan.RangeBucketFanout] directly off the
+// subquery's [OuterRange:Step] grid, rather than through an
+// OuterRange-bearing [chplan.RangeWindow] the way a bare-selector subquery
+// does (see subquery_inner_histogram_quantile.txtar for the shape). Before
+// RangeBucketFanout.NumAnchors was wired into subqueryAnchorLoad, that grid
+// was invisible to this gate: the scalar sibling
+// TestQuery_SubqueryAnchorBudget422 already rejected the identical
+// [90d:1s] shape, but the histogram-valued analogue sailed straight
+// through to execution with the same 7,776,001-anchor-per-series
+// intermediate. This pins that the two now reject identically.
+func TestQuery_HistogramSubqueryAnchorBudget422(t *testing.T) {
+	t.Parallel()
+
+	q := &stubQuerier{} // returns nothing; the gate must reject before reaching it
+	srv := newServerWithAnchorBudget(q, 1_000_000)
+	t.Cleanup(srv.Close)
+
+	q1 := url.QueryEscape("max_over_time(histogram_quantile(0.9, http_requests_bucket)[90d:1s])")
+	resp, err := http.Get(srv.URL + "/api/v1/query?query=" + q1)
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	assertBudget422(t, resp)
+
+	if q.lastSQL != "" {
+		t.Fatalf("anchor gate must reject before emitting SQL; querier saw SQL: %q", q.lastSQL)
+	}
+}
+
+// TestQuery_HistogramSubqueryWithinBudget_NotGated — the histogram-inner
+// counterpart of TestQuery_SubqueryWithinBudget_NotGated: a normal
+// histogram_quantile subquery (5m:1m, matching
+// subquery_inner_histogram_quantile.txtar's own shape) must still reach
+// execution rather than being over-rejected by the new RangeBucketFanout
+// charge.
+func TestQuery_HistogramSubqueryWithinBudget_NotGated(t *testing.T) {
+	t.Parallel()
+
+	q := &stubQuerier{samples: []chclient.Sample{
+		{MetricName: "http_requests_bucket", Labels: map[string]string{"job": "api"}, Value: 1},
+	}}
+	srv := newServerWithAnchorBudget(q, 1_000_000)
+	t.Cleanup(srv.Close)
+
+	q1 := url.QueryEscape("max_over_time(histogram_quantile(0.9, http_requests_bucket)[5m:1m])")
+	resp, err := http.Get(srv.URL + "/api/v1/query?query=" + q1)
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	_ = resp.Body.Close()
+	if resp.StatusCode == http.StatusUnprocessableEntity {
+		t.Fatalf("within-budget histogram subquery wrongly gated (422); the anchor budget over-rejected")
+	}
+	if q.lastSQL == "" {
+		t.Fatal("within-budget histogram subquery never reached execution; the anchor gate over-rejected")
+	}
+}

--- a/internal/chplan/range_bucket_fanout.go
+++ b/internal/chplan/range_bucket_fanout.go
@@ -121,6 +121,36 @@ func (*RangeBucketFanout) planNode() {}
 
 func (r *RangeBucketFanout) Children() []Node { return []Node{r.Input} }
 
+// NumAnchors is the number of grid anchor points this fan-out materialises:
+// one row per Step across [Start, End] (end-inclusive), i.e.
+// (End-Start)/Step + 1 — mirrors the chsql emitter's own `span/stepNS + 1`
+// (internal/chsql/range_bucket_fanout.go) so the budget gate and the emit
+// agree on the count, and mirrors [RangeWindow.NumAnchors]'s role for the
+// identical resource axis on this node's own grid.
+//
+// Zero when Start/End are both unset (the now64() fixture shape, where the
+// emitter substitutes a single anchor) or Step <= 0 — there is no
+// materialised grid to charge in either case.
+//
+// This is the per-series intermediate row count [requireSubquerySampleBudget]
+// exists to bound (docs/resource-bound-audit): when this node lowers a
+// histogram range function whose Start/End/Step come from a PromQL subquery
+// grid (`histogram_quantile(...)[OuterRange:Step]` nested inside an outer
+// `<reducer>_over_time(...)`), NOTHING else in the plan carries that grid's
+// width — the histogram lowering (internal/promql) absorbs the subquery's
+// own materialisation into THIS node directly rather than wrapping it in an
+// OuterRange-bearing [RangeWindow], unlike a bare-selector subquery. Before
+// this method existed, [requireSubquerySampleBudget]'s
+// *chplan.RangeWindow-only type switch could not see this axis at all, so a
+// histogram-quantile-as-subquery-inner query with a divergent [range:step]
+// escaped the same protection its scalar sibling already had.
+func (r *RangeBucketFanout) NumAnchors() int64 {
+	if r.Start.IsZero() || r.End.IsZero() || r.Step <= 0 {
+		return 0
+	}
+	return r.End.Sub(r.Start).Nanoseconds()/r.Step.Nanoseconds() + 1
+}
+
 func (r *RangeBucketFanout) Equal(other Node) bool {
 	o, ok := other.(*RangeBucketFanout)
 	if !ok {

--- a/internal/chplan/range_bucket_grid_native.go
+++ b/internal/chplan/range_bucket_grid_native.go
@@ -81,6 +81,23 @@ func (*RangeBucketGridNative) planNode() {}
 
 func (r *RangeBucketGridNative) Children() []Node { return []Node{r.Input} }
 
+// NumAnchors is the number of grid anchor points this native aggregate
+// materialises: one row per Step across [Start, End] (end-inclusive), i.e.
+// (End-Start)/Step + 1. Unlike [RangeBucketFanout] and [RangeLWR] this node
+// is only ever built with a pinned, non-zero Start/End (range mode is a
+// precondition — see emitRangeBucketGridNative's own validation), but the
+// zero-grid guard is kept for the same defence-in-depth reason
+// [RangeBucketFanout.NumAnchors] keeps it: a caller of this method should
+// never have to also know this node's own construction invariants hold.
+// Same rationale as [RangeBucketFanout.NumAnchors] for why this axis needs
+// its own charge in [requireSubquerySampleBudget].
+func (r *RangeBucketGridNative) NumAnchors() int64 {
+	if r.Start.IsZero() || r.End.IsZero() || r.Step <= 0 {
+		return 0
+	}
+	return r.End.Sub(r.Start).Nanoseconds()/r.Step.Nanoseconds() + 1
+}
+
 func (r *RangeBucketGridNative) Equal(other Node) bool {
 	o, ok := other.(*RangeBucketGridNative)
 	if !ok {

--- a/internal/chplan/range_lwr.go
+++ b/internal/chplan/range_lwr.go
@@ -124,6 +124,19 @@ func (*RangeLWR) planNode() {}
 
 func (r *RangeLWR) Children() []Node { return []Node{r.Input} }
 
+// NumAnchors is the number of grid anchor points this fan-out materialises:
+// one row per Step across [Start, End] (end-inclusive), i.e.
+// (End-Start)/Step + 1. Same formula and same rationale as
+// [RangeBucketFanout.NumAnchors] — see that method's doc for why this axis
+// needs its own charge in [requireSubquerySampleBudget] rather than relying
+// on an ancestor [RangeWindow].
+func (r *RangeLWR) NumAnchors() int64 {
+	if r.Start.IsZero() || r.End.IsZero() || r.Step <= 0 {
+		return 0
+	}
+	return r.End.Sub(r.Start).Nanoseconds()/r.Step.Nanoseconds() + 1
+}
+
 func (r *RangeLWR) Equal(other Node) bool {
 	o, ok := other.(*RangeLWR)
 	if !ok {

--- a/internal/engine/anchor_budget.go
+++ b/internal/engine/anchor_budget.go
@@ -72,20 +72,38 @@ func requireSubquerySampleBudget(plan chplan.Node, maxSamples int64) error {
 // input subtree does. Saturates at math.MaxInt64 so a deeply nested product can
 // never wrap negative and slip under the budget.
 //
-// Plan subtrees that hang off an Expr slot (a chplan.ScalarSubquery binding a
-// per-step scalar parameter, a chplan.InSubquery cohort) are counted too:
-// Children() does not report them, so before they were swept a subquery grid
-// buried in `scalar(<subquery>)` escaped the budget completely and materialised
-// its anchor rows unbounded. They contribute as a PEER maximum rather than a
-// multiplicand — ClickHouse evaluates such a subquery once, independent of the
-// outer anchor grid, so multiplying would reject shapes that never stack.
+// [chplan.RangeBucketFanout], [chplan.RangeLWR] and [chplan.RangeBucketGridNative]
+// contribute their own NumAnchors the same way (#2408): each materialises
+// exactly the same "one row per Step across [Start, End]" per-series
+// intermediate RangeWindow does, and the histogram range-function lowerings
+// (internal/promql) build one of these DIRECTLY off a subquery's own
+// [OuterRange:Step] grid — `histogram_quantile(...)[range:step]` nested
+// inside an outer `<reducer>_over_time(...)` — without ever wrapping that
+// grid in an OuterRange-bearing RangeWindow (the histogram lowering absorbs
+// the subquery's materialisation into the fan-out node itself). Before this
+// case existed, that grid was invisible to this walk: a bare-selector
+// subquery `<reducer>_over_time(m[range:step])` was rejected once its inner
+// grid crossed the budget, but the histogram-valued analogue
+// `<reducer>_over_time(histogram_quantile(...)[range:step])` was not,
+// despite materialising the identical per-series row count. Because these
+// nodes are the SOLE representation of their own subquery grid — no
+// RangeWindow duplicates it above or below them — adding them here cannot
+// double-count an already-counted grid; it only closes the gap for the one
+// grid shape nothing else on this walk could see.
 func subqueryAnchorLoad(n chplan.Node) int64 {
 	if n == nil {
 		return 0
 	}
 	var self int64
-	if rw, ok := n.(*chplan.RangeWindow); ok {
-		self = rw.NumAnchors()
+	switch v := n.(type) {
+	case *chplan.RangeWindow:
+		self = v.NumAnchors()
+	case *chplan.RangeBucketFanout:
+		self = v.NumAnchors()
+	case *chplan.RangeLWR:
+		self = v.NumAnchors()
+	case *chplan.RangeBucketGridNative:
+		self = v.NumAnchors()
 	}
 	// The heaviest nested load among the input subtree(s).
 	var childLoad int64

--- a/internal/engine/resource_bound_classification_test.go
+++ b/internal/engine/resource_bound_classification_test.go
@@ -52,9 +52,9 @@ var resourceBoundClassification = map[string]struct {
 	"RangeWindowGridNative":    {boundGated, "axis 5: native timeSeries*ToGrid variant of RangeWindow; same anchor-grid bound"},
 	"RangeWindowStaleResample": {boundGated, "axis 5: native-staleness resample variant; same anchor-grid bound"},
 	"StepGrid":                 {boundStructural, "axis 5: query_range step grid capped at format.MaxResolutionPoints in the head handler"},
-	"RangeBucketFanout":        {boundRuntimeNet, "axis 4/7: histogram bucket fan-out over the scan-bounded window; spill + max_memory_usage"},
-	"RangeBucketGridNative":    {boundRuntimeNet, "axis 4/7: native histogram bucket ladder aggregate over the scan-bounded window; spill + max_memory_usage"},
-	"RangeLWR":                 {boundRuntimeNet, "axis 7: linear-regression-window compute over the scan-bounded window"},
+	"RangeBucketFanout":        {boundGated, "axis 5: own grid (Start/End/Step) gated by requireSubquerySampleBudget via RangeBucketFanout.NumAnchors, #2408; axis 4/7 fan-out cardinality over the scan-bounded window remains spill + max_memory_usage"},
+	"RangeBucketGridNative":    {boundGated, "axis 5: own grid gated by requireSubquerySampleBudget via RangeBucketGridNative.NumAnchors, #2408; axis 4/7 native bucket ladder aggregate over the scan-bounded window remains spill + max_memory_usage"},
+	"RangeLWR":                 {boundGated, "axis 5: own grid gated by requireSubquerySampleBudget via RangeLWR.NumAnchors, #2408; axis 7 linear-regression-window compute over the scan-bounded window remains spill + max_memory_usage"},
 	"AbsentOverTime":           {boundStructural, "one synthesized row per absent series over the bounded window"},
 
 	// Recursive / structural-join walks — axis 3, depth caps.


### PR DESCRIPTION
## Summary

#2408 is a design/investigation issue about why classic-histogram queries
dominate ClickHouse CPU cost, and names four research directions with no
committed acceptance criteria. This PR is scoped to research direction #3:
whether `chplan.RangeBucketFanout`'s own `arrayJoin(arrayMap(...))` fan-out
needs a resource bound the way #2428's exp-histogram binop merge did
(reusing `maxHistogramMergeBucketWidth` via a `throwIf`).

**Direction #3's original question, answered:** `RangeBucketFanout`'s
per-sample fan-out width is *not* a genuine gap. It is bounded by
`min(Lookback/Step, numAnchors) + 1` — the `least(numAnchors, …)` clamp in
`internal/chsql/range_lwr.go`'s `lwrAnchorFanoutFrag` (shared by
`RangeBucketFanout` and `RangeLWR`) caps it regardless of how large
`Lookback` gets, unlike #2428's exp-histogram merge width, which had no such
clamp and could grow unboundedly from Scale/Offset divergence between two
input rows. No fix needed on that specific axis.

**What this PR actually fixes**, found while verifying that: none of
`RangeBucketFanout`, `RangeLWR`, or `RangeBucketGridNative`'s own
`[Start, End, Step]` grid was ever charged against
`internal/engine`'s subquery anchor budget
(`requireSubquerySampleBudget` / `subqueryAnchorLoad`), even though each
materialises exactly the same "one row per Step across [Start, End]"
per-series intermediate a `RangeWindow` subquery does. Concretely:

```
max_over_time(rate(m[1m])[90d:1s])                          -> 422 today (already gated)
max_over_time(histogram_quantile(0.9, bucket_metric)[90d:1s]) -> 200 today (NOT gated)
```

Both materialise the identical 7,776,001-anchor-per-series intermediate. The
histogram-valued shape escapes the gate because
`internal/promql`'s histogram range-function lowering
(`histogram_quantile_range.go` / `histogram_native_range_fn.go`) builds its
`RangeBucketFanout` directly off the subquery's own
`[OuterRange:Step]` grid, rather than wrapping it in an OuterRange-bearing
`RangeWindow` the way a bare-selector subquery does — see
`test/spec/promql/subquery_inner_histogram_quantile.txtar`'s own `chplan`
golden, where the printed `RangeBucketFanout` carries the subquery's
`[5m:1m]` grid directly and the outer `RangeWindow` above it has
`OuterRange=0` (a one-time, non-subquery reduction over the fan-out's
already-materialised output). `subqueryAnchorLoad`'s type switch only
recognized `*chplan.RangeWindow`, so this axis was invisible to it.

## The fix

- `RangeBucketFanout.NumAnchors()`, `RangeLWR.NumAnchors()`,
  `RangeBucketGridNative.NumAnchors()` (new, `internal/chplan`): mirror
  `RangeWindow.NumAnchors()`'s `(End-Start)/Step + 1` formula — matching each
  node's own chsql emitter arithmetic (`span/stepNS + 1`) so the budget gate
  and the emit agree on the count, same contract `RangeWindow.NumAnchors`'s
  own doc states.
- `subqueryAnchorLoad` (`internal/engine/anchor_budget.go`): widened from an
  `if _, ok := n.(*chplan.RangeWindow)` check to a type switch also matching
  the three node types above. No new threshold — reuses the existing
  `Config.MaxQuerySamples` budget the `RangeWindow` case already enforces.
- Because these three node types are the *sole* representation of their own
  subquery grid in this specific lowering (no ancestor `RangeWindow`
  duplicates the same grid — the ancestor `RangeWindow`, when one exists, has
  its own `OuterRange=0`), adding them cannot double-count an
  already-counted grid; it only closes the coverage hole for the one shape
  nothing else on this walk could see. Verified this concretely against the
  real `subquery_inner_histogram_quantile.txtar` chplan shape rather than
  assuming it.
- `internal/engine/resource_bound_classification_test.go`: reclassified the
  three node types from `boundRuntimeNet` to `boundGated` for this axis,
  noting the *other* axis (fan-out row-count/cardinality feeding the
  blocking regroup `GROUP BY`) remains `boundRuntimeNet` — that axis is real
  but calibration-dependent (see below), filed separately.

## What's still open (and correctly out of scope here)

#2408's own headline finding — histogram queries dominating ClickHouse CPU —
is about a *different* axis: `RangeBucketFanout`'s total fan-out **row
count** (not per-row width) feeding its blocking regroup `GROUP BY`, the same
mechanism `internal/chsql/rate_window_fanout_bound.go` (#2429) closed for a
different emitter after real ClickHouse + real production data calibration
(four design iterations, a measurement-harness bug caught along the way).
`RangeBucketFanout` shares that exact mechanism and carries a *heavier*
per-row payload (`BucketCounts`/`ExplicitBounds` arrays vs. #2429's scalar
`Value`), and `internal/engine/resource_bound_classification_test.go`
already documents this as a deliberate `boundRuntimeNet` (spill +
`max_memory_usage` only) classification from the prior audit — not an
oversight this PR is silently overturning.

Closing that responsibly needs the same kind of empirical calibration #2429
needed and this sandboxed environment does not have access to (a real
testcontainers ClickHouse loaded with representative
`BucketCounts`/`ExplicitBounds`-payload production-scale data). Filed as
#2447, following #2429's own playbook.

## Test plan

- `TestQuery_HistogramSubqueryAnchorBudget422` (new,
  `internal/api/prom/handler_subquery_budget_test.go`): end-to-end HTTP test,
  `max_over_time(histogram_quantile(0.9, http_requests_bucket)[90d:1s])`
  against a stub querier that would fail the test if it ever saw SQL —
  asserts 422 *before* execution. Verified this is a genuine regression pin
  by reverting just the `anchor_budget.go` type-switch change locally and
  confirming the test fails (200 instead of 422) without the fix.
- `TestQuery_HistogramSubqueryWithinBudget_NotGated` (new): the same query
  shape at `[5m:1m]` (matching the txtar fixture) must still reach
  execution — proves the fix doesn't over-reject.
- Existing `TestRequireSubquerySampleBudget`, `TestRangeWindowNumAnchors`,
  `TestSubqueryAnchorLoad_NestedProduct`, `TestResourceBoundClassification_Exhaustive`
  all still pass unmodified.
- `go build ./... && go vet ./...` — clean.
- `node .github/scripts/forbid-sql-raw.mjs` — clean (no chsql changes in
  this PR; the emitted SQL is byte-identical, only the pre-execution
  rejection decision changes, so no `test/spec` golden regeneration is
  needed).
- `go test ./internal/api/prom/... ./internal/promql/... ./internal/chplan/... ./internal/engine/...`
  — all green.

Related: #2408 (parent investigation, stays open — other research
directions remain unaddressed), #2447 (follow-up, the cardinality-axis
calibration work).
