### PR TITLE
fix(ci): backfill missing cardinality-baseline rows and quote step names truncated by YAML comments

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -778,7 +778,7 @@ jobs:
       # (MUTATIONS well-formed, drift detection) here too. The real
       # mutate-and-assert-caught run against a live ClickHouse stays
       # exclusive to the weekly workflow.
-      - name: Assert #2437's self-check mutations are well-formed
+      - name: "Assert #2437's self-check mutations are well-formed"
         run: node --test .github/scripts/perf-nightly-selfcheck.test.mjs
 
       # Pins e2e.yml's dashboard-crawl-merge wiring: the required `dashboard`

--- a/.github/workflows/perf-nightly-selfcheck.yml
+++ b/.github/workflows/perf-nightly-selfcheck.yml
@@ -79,7 +79,7 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           docker-hub-pat: ${{ secrets.DOCKER_HUB_PAT }}
 
-      - name: Run #2437's periodic mutation self-check (real ClickHouse)
+      - name: "Run #2437's periodic mutation self-check (real ClickHouse)"
         run: just perf-nightly-selfcheck
 
   # Files/refreshes a single tracking issue when the SCHEDULE run does not

--- a/.github/workflows/perf-nightly.yml
+++ b/.github/workflows/perf-nightly.yml
@@ -71,7 +71,7 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           docker-hub-pat: ${{ secrets.DOCKER_HUB_PAT }}
 
-      - name: Run the #2370 nightly measurement harness (real ClickHouse)
+      - name: "Run the #2370 nightly measurement harness (real ClickHouse)"
         run: just perf-nightly-integration
 
   # Files/refreshes a single tracking issue when the SCHEDULE run does not


### PR DESCRIPTION
## Summary

Two small, unrelated CI-hygiene fixes discovered while driving another PR to green — bundled here
since neither is large enough to warrant its own PR.

- **Cardinality baseline gap**: the scheduled `coverage` workflow's `cardinality_ratchet_test.go`
  failed (https://github.com/tsouza/cerberus/actions/runs/32555305426) because 3 fixtures added by
  #2451 (mixed float/histogram `or` composed under `sum()`/`avg()`, issue #2346) have no row in the
  cardinality baseline — that PR's own `just update-cardinality-baseline` run apparently didn't
  cover them. Regenerating via `update-golden.yml -f shards=cardinality` (dispatched against this
  branch), which fans out across its 8 `cardinality-leg` jobs, seals, and pushes the resulting patch
  directly here.
- **YAML step-name truncation**: three workflow step names contain an unquoted ` #<digits>`
  (an issue reference), which YAML parses as a comment start in an unquoted scalar, silently
  truncating the name shown in the Actions UI (confirmed live on
  `perf-nightly` job https://github.com/tsouza/cerberus/actions/runs/32555114292/job/96987947582,
  where "Run the #2370 nightly measurement harness (real ClickHouse)" rendered as just "Run the").
  Wrapped each in double quotes in `ci.yml`, `perf-nightly-selfcheck.yml`, and `perf-nightly.yml`.

## Test plan

- [x] `grep -rn 'name: [^"'"'"'].* #[0-9]' .github/workflows/*.yml` — confirms exactly these three
      sites and nothing else.
- [x] `actionlint` on the three edited workflow files — exit 0, no issues.
- [x] `python3 -c "import yaml; ..."` parse of all three files — confirms each step name now reads
      as the full intended text (no truncation at ` #`).
- [ ] `gh workflow run update-golden.yml -f shards=cardinality -f branch=<this-branch>` — regenerate
      and push the missing cardinality-baseline rows; verify the resulting commit touches only the
      3 previously-missing fixtures with no unrelated drift. (in progress)
