### PR TITLE
feat(perf): render a clear pass/regression verdict in perf-nightly's step summary

### DIFF
--- a/.github/scripts/perf-nightly-step-summary.mjs
+++ b/.github/scripts/perf-nightly-step-summary.mjs
@@ -1,0 +1,144 @@
+// perf-nightly-step-summary.mjs — render the #2370 nightly lane's own
+// per-sentinel verdict as a clear markdown table in the job's
+// $GITHUB_STEP_SUMMARY, ahead of (and independent from) the raw `go test
+// -v` log.
+//
+// Why this exists
+// ----------------
+// realch_perfnightly_integration_test.go's own doc comment explains that 2
+// of the 4 sentinels are CALIBRATED to be rejected with HTTP 422 (issue
+// #2429) — that rejection is the correct, expected outcome. cerberus's own
+// engine.go logs a WARN-level "cerberus query failed" line for EVERY
+// non-2xx query outcome unconditionally (docs/observability.md) — that is
+// correct application logging, not a bug, and this script does not touch
+// it. The actual gap a human hit reading a real nightly run
+// (https://github.com/tsouza/cerberus/actions/runs/32555114292) was
+// visibility: nothing in the run summarised "2 sentinels passed cleanly, 2
+// were correctly rejected as designed, 0 regressed" before the raw log —
+// a reader had to manually correlate each WARN line against sentinels.go's
+// own ExpectedStatus field to tell an expected rejection apart from a real
+// regression.
+//
+// Go is the single source of truth for the verdict: results.go's
+// SentinelResult.Pass is computed once, in the same test code that
+// performs the actual assertions (realch_perfnightly_integration_test.go).
+// renderSummary() below only renders that JSON — it must never re-derive
+// pass/fail from raw fields, or the two could silently disagree.
+//
+// Env contract:
+//   PERF_NIGHTLY_RESULTS_JSON   path to the JSON results.go's
+//                               writeResultsJSON produced (same variable
+//                               name .github/workflows/perf-nightly.yml
+//                               sets before the test step runs).
+//
+// Runs under `if: always()` after the test step, so it renders a verdict
+// table even when TestPerfNightlyRealCH itself failed — that is precisely
+// the case a clear summary matters most for. When the results file is
+// missing entirely (the job died before writing anything — e.g. the
+// ClickHouse container never started), this prints a plain notice instead
+// of failing, the same escape-hatch shape compat-step-summary.mjs already
+// uses for a missing compat-score.json: the "Fail job" semantics belong to
+// the test step's own exit code, never to this housekeeping step.
+//
+// Exit codes: always 0 (housekeeping step; never gates — see above).
+
+import { existsSync, readFileSync } from 'node:fs';
+import process from 'node:process';
+import { pathToFileURL } from 'node:url';
+import { appendStepSummary, log } from './lib/gh.mjs';
+
+export function formatBytes(n) {
+  if (n === undefined || n === null) return '—';
+  const mib = n / (1024 * 1024);
+  return `${mib.toFixed(1)} MiB`;
+}
+
+export function formatPct(n) {
+  if (n === undefined || n === null) return '—';
+  return `${n.toFixed(1)}%`;
+}
+
+// verdictCell renders one sentinel's own SentinelResult.Pass (Go's single
+// source of truth, see the header) as a human verdict — it inspects the
+// supporting fields ONLY to choose which failure reason to print, never to
+// decide pass/fail itself.
+export function verdictCell(sentinel) {
+  if (sentinel.pass && sentinel.rejected) return '✅ correctly rejected (expected)';
+  if (sentinel.pass) return '✅ pass';
+  if (!sentinel.status_ok) {
+    return `❌ FAIL — status ${sentinel.actual_status} (want ${sentinel.expected_status})`;
+  }
+  if (!sentinel.cap_ok) return '❌ FAIL — exceeds absolute cap-relative ceiling';
+  if (sentinel.has_baseline && !sentinel.baseline_ok) return '❌ FAIL — exceeds committed baseline ceiling';
+  return '❌ FAIL';
+}
+
+// renderSummary builds the full markdown block from a parsed
+// NightlyResults document (results.go's JSON shape). Pure function — no
+// env/fs access — so it is the one thing this module's own test exercises
+// directly.
+export function renderSummary(doc) {
+  const sentinels = doc.sentinels || [];
+  const headline = doc.all_pass
+    ? `✅ all ${sentinels.length} sentinels passed`
+    : `❌ ${sentinels.filter((s) => !s.pass).length} of ${sentinels.length} sentinel(s) regressed`;
+
+  const rows = sentinels.map((s) => {
+    const baselineCell = s.has_baseline ? formatBytes(s.baseline_ceiling_bytes) : 'n/a (calibration run)';
+    return `| ${s.name} | ${s.family} | ${s.expected_status} | ${s.actual_status} | ${formatBytes(s.max_of_n_bytes)} | ${formatPct(s.cap_fraction_pct)} | ${baselineCell} | ${verdictCell(s)} |`;
+  });
+
+  return [
+    '### perf-nightly',
+    '',
+    `**${headline}**`,
+    '',
+    '| sentinel | family | expected status | actual status | max-of-N memory | % of cap | baseline ceiling | verdict |',
+    '|---|---|---|---|---|---|---|---|',
+    ...rows,
+    '',
+    '`WARN cerberus query failed` lines in the raw log below for the sentinels marked "correctly ' +
+      "rejected (expected)\" above are cerberus's own intended application logging for a query the " +
+      'engine genuinely rejected (see docs/observability.md) — not evidence of a problem by ' +
+      'themselves. Only a row marked FAIL above is a real regression.',
+    '',
+  ].join('\n');
+}
+
+function main() {
+  const resultsPath = process.env.PERF_NIGHTLY_RESULTS_JSON || '';
+
+  if (!resultsPath) {
+    log('perf-nightly-step-summary.mjs: PERF_NIGHTLY_RESULTS_JSON is unset; nothing to render');
+    process.exit(0);
+  }
+
+  if (!existsSync(resultsPath)) {
+    appendStepSummary(
+      [
+        '### perf-nightly',
+        '',
+        `no results were produced at \`${resultsPath}\` — the run likely failed before any ` +
+          'sentinel completed (e.g. the ClickHouse container never started, or sample loading ' +
+          'failed). See the raw log below for the actual failure.',
+        '',
+      ].join('\n'),
+    );
+    process.exit(0);
+  }
+
+  let doc;
+  try {
+    doc = JSON.parse(readFileSync(resultsPath, 'utf8'));
+  } catch (e) {
+    appendStepSummary(['### perf-nightly', '', `could not parse ${resultsPath}: ${e.message}`, ''].join('\n'));
+    process.exit(0);
+  }
+
+  appendStepSummary(renderSummary(doc));
+  process.exit(0);
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main();
+}

--- a/.github/scripts/perf-nightly-step-summary.test.mjs
+++ b/.github/scripts/perf-nightly-step-summary.test.mjs
@@ -1,0 +1,150 @@
+// perf-nightly-step-summary.test.mjs — the failure this script exists to
+// prevent is a real regression getting buried in a wall of expected WARN
+// log noise, and a correctly-rejected sentinel getting misread as a real
+// failure. The load-bearing cases here are exactly those two
+// discriminations, plus the escape hatches (missing/unparseable results
+// file) a housekeeping step must never fail the job over.
+
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import process from 'node:process';
+import { fileURLToPath } from 'node:url';
+import { test } from 'node:test';
+
+import { formatBytes, formatPct, renderSummary, verdictCell } from './perf-nightly-step-summary.mjs';
+
+const SCRIPT = fileURLToPath(new URL('./perf-nightly-step-summary.mjs', import.meta.url));
+
+function sentinel(overrides = {}) {
+  return {
+    name: 'classic_histogram_quantile_by_route',
+    family: 'histogram_quantile over a classic histogram',
+    expected_status: 200,
+    actual_status: 200,
+    status_ok: true,
+    max_of_n_bytes: 9_000_000,
+    cap_ceiling_bytes: 912_680_550,
+    cap_fraction_pct: 0.8,
+    cap_ok: true,
+    has_baseline: true,
+    baseline_ceiling_bytes: 20_000_000,
+    baseline_ok: true,
+    pass: true,
+    rejected: false,
+    ...overrides,
+  };
+}
+
+test('formatBytes / formatPct render human units and a placeholder for missing data', () => {
+  assert.equal(formatBytes(2 * 1024 * 1024), '2.0 MiB');
+  assert.equal(formatBytes(undefined), '—');
+  assert.equal(formatPct(16.3), '16.3%');
+  assert.equal(formatPct(null), '—');
+});
+
+test('verdictCell marks an expected-rejection PASS distinctly from a plain PASS', () => {
+  const ok200 = sentinel();
+  assert.equal(verdictCell(ok200), '✅ pass');
+
+  const ok422 = sentinel({ expected_status: 422, actual_status: 422, rejected: true, pass: true });
+  assert.equal(verdictCell(ok422), '✅ correctly rejected (expected)');
+});
+
+test('verdictCell names the SPECIFIC failure reason for a real regression', () => {
+  const statusFail = sentinel({ status_ok: false, actual_status: 500, pass: false });
+  assert.match(verdictCell(statusFail), /FAIL — status 500 \(want 200\)/);
+
+  const capFail = sentinel({ cap_ok: false, pass: false });
+  assert.match(verdictCell(capFail), /exceeds absolute cap-relative ceiling/);
+
+  const baselineFail = sentinel({ baseline_ok: false, pass: false });
+  assert.match(verdictCell(baselineFail), /exceeds committed baseline ceiling/);
+});
+
+test('renderSummary headlines a clean pass and a real regression differently', () => {
+  const clean = renderSummary({ all_pass: true, sentinels: [sentinel(), sentinel({ name: 'gauge' })] });
+  assert.match(clean, /all 2 sentinels passed/);
+
+  const regressed = renderSummary({
+    all_pass: false,
+    sentinels: [sentinel(), sentinel({ name: 'gauge', pass: false, cap_ok: false })],
+  });
+  assert.match(regressed, /1 of 2 sentinel\(s\) regressed/);
+  assert.match(regressed, /gauge.*exceeds absolute cap-relative ceiling/s);
+});
+
+test('renderSummary never re-derives pass/fail — a pass=true row always renders as passing', () => {
+  // Even a row whose supporting fields look inconsistent (e.g. cap_ok false
+  // but pass true, which Go itself would never produce) must still render
+  // via the `pass` field alone — this script is a renderer, not a second
+  // opinion.
+  const summary = renderSummary({
+    all_pass: true,
+    sentinels: [sentinel({ cap_ok: false, pass: true })],
+  });
+  assert.match(summary, /✅ pass/);
+  assert.doesNotMatch(summary, /❌/);
+});
+
+test('renderSummary labels a calibration-run sentinel (no committed baseline) explicitly', () => {
+  const summary = renderSummary({
+    all_pass: true,
+    sentinels: [sentinel({ has_baseline: false, baseline_ceiling_bytes: undefined })],
+  });
+  assert.match(summary, /n\/a \(calibration run\)/);
+});
+
+// --- end-to-end script invocation (env contract + escape hatches) --------
+
+function run(env = {}) {
+  return spawnSync(process.execPath, [SCRIPT], {
+    encoding: 'utf8',
+    env: { ...process.env, GITHUB_STEP_SUMMARY: '', ...env },
+  });
+}
+
+test('missing PERF_NIGHTLY_RESULTS_JSON is a no-op, not a failure', () => {
+  const res = run({ PERF_NIGHTLY_RESULTS_JSON: '' });
+  assert.equal(res.status, 0);
+});
+
+test('a missing results file prints a notice and still exits 0 — never fails the job', () => {
+  const dir = mkdtempSync(path.join(tmpdir(), 'perf-nightly-summary-'));
+  const missing = path.join(dir, 'does-not-exist.json');
+  const summaryFile = path.join(dir, 'step-summary.md');
+  writeFileSync(summaryFile, '');
+  try {
+    const res = run({ PERF_NIGHTLY_RESULTS_JSON: missing, GITHUB_STEP_SUMMARY: summaryFile });
+    assert.equal(res.status, 0);
+    const summary = readFileSync(summaryFile, 'utf8');
+    assert.match(summary, /no results were produced/);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('a real results file renders the verdict table into $GITHUB_STEP_SUMMARY', () => {
+  const dir = mkdtempSync(path.join(tmpdir(), 'perf-nightly-summary-'));
+  const resultsFile = path.join(dir, 'results.json');
+  const summaryFile = path.join(dir, 'step-summary.md');
+  writeFileSync(
+    resultsFile,
+    JSON.stringify({
+      all_pass: true,
+      sentinels: [sentinel(), sentinel({ name: 'request_rate_by_method', expected_status: 422, actual_status: 422, rejected: true })],
+    }),
+  );
+  writeFileSync(summaryFile, '');
+  try {
+    const res = run({ PERF_NIGHTLY_RESULTS_JSON: resultsFile, GITHUB_STEP_SUMMARY: summaryFile });
+    assert.equal(res.status, 0);
+    const summary = readFileSync(summaryFile, 'utf8');
+    assert.match(summary, /all 2 sentinels passed/);
+    assert.match(summary, /request_rate_by_method/);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -564,6 +564,16 @@ jobs:
       - name: migration-artifact self-test (build-once seam guard)
         run: node --test .github/scripts/migration-artifact.test.mjs
 
+      # perf-nightly.yml's step-summary rendering is a pure function of the
+      # JSON test/perf/nightly's results.go writes (see its own doc
+      # comment): a wrong verdictCell()/renderSummary() would silently
+      # misreport a real regression as an expected rejection, or vice
+      # versa, with nothing in perf-nightly.yml itself able to catch that —
+      # it's a Docker-gated nightly/release lane, never a PR check. This
+      # self-test pins the discrimination offline.
+      - name: perf-nightly-step-summary self-test
+        run: node --test .github/scripts/perf-nightly-step-summary.test.mjs
+
   # `forbid-skip` is the GA test-discipline gate. The maintainer's
   # NON-NEGOTIABLE rule is "no t.Skip in test files — fix the bug, do
   # not skip." Greps `*_test.go` for `t.Skip` / `t.Skipf` / `t.SkipNow`

--- a/.github/workflows/perf-nightly.yml
+++ b/.github/workflows/perf-nightly.yml
@@ -47,6 +47,15 @@ jobs:
     # Generous: pulls one ClickHouse image, loads ~4.3M real rows across 3
     # tables, and issues 4 sentinel queries.
     timeout-minutes: 20
+    env:
+      # Read by results.go's writeResultsJSON (the test step) and by
+      # perf-nightly-step-summary.mjs (the summary step below) — same
+      # variable name, same literal value, so the two steps can never point
+      # at different files. A plain literal (not a `${{ runner.temp }}`
+      # expression: job-level `env:` does not have the `runner` context
+      # available) under /tmp — a per-run scratch path on the ephemeral
+      # `ubuntu-latest` runner, never committed to the checkout.
+      PERF_NIGHTLY_RESULTS_JSON: /tmp/perf-nightly-results.json
     steps:
       - uses: actions/checkout@v7
         with:
@@ -73,6 +82,18 @@ jobs:
 
       - name: Run the #2370 nightly measurement harness (real ClickHouse)
         run: just perf-nightly-integration
+
+      # Renders the per-sentinel verdict as a clear table in the job's
+      # Summary tab BEFORE the raw log — see perf-nightly-step-summary.mjs's
+      # own doc comment for why this exists (a wall of raw WARN log lines
+      # with no synthesis at the top makes an intentionally-rejected
+      # sentinel indistinguishable from a real regression at a glance).
+      # `if: always()` so a verdict table (and, on a real failure, the
+      # specific reason) still renders even when the test step above
+      # failed — that is exactly the case a clear summary matters most for.
+      - name: Render the nightly verdict summary
+        if: always()
+        run: node .github/scripts/perf-nightly-step-summary.mjs
 
   # Files/refreshes a single tracking issue when the SCHEDULE run does not
   # reach a clean pass, closes it on the next clean night. Same mechanism

--- a/test/perf/nightly/realch_perfnightly_integration_test.go
+++ b/test/perf/nightly/realch_perfnightly_integration_test.go
@@ -64,6 +64,20 @@
 // .github/workflows/perf-nightly.yml via `just perf-nightly-integration`.
 // Regenerate the baseline via `just update-nightly-perf-baseline`
 // (UPDATE_NIGHTLY_PERF_BASELINE=1) — never hand-edited (invariant 9).
+//
+// # Reporting
+//
+// Every sentinel's final verdict (status-class match, both memory prongs,
+// and the single overall Pass) is also captured into a results.go
+// SentinelResult and written, at the end of a non-calibration run, to
+// PERF_NIGHTLY_RESULTS_JSON — see results.go's own doc comment for why:
+// two of the four sentinels above are SUPPOSED to be rejected, and
+// cerberus's own engine.go correctly logs a WARN line for every rejected
+// query unconditionally, so the raw `go test -v` log alone cannot tell a
+// human apart "expected rejection" from "real regression" without manually
+// cross-referencing sentinels.go. perf-nightly-step-summary.mjs renders
+// that JSON into perf-nightly.yml's own $GITHUB_STEP_SUMMARY as an
+// unambiguous verdict table, ahead of the raw log.
 package nightly
 
 import (
@@ -176,16 +190,49 @@ func TestPerfNightlyRealCH(t *testing.T) {
 	update := os.Getenv("UPDATE_NIGHTLY_PERF_BASELINE") == "1"
 	updated := make(map[string]nightlyBound, len(Sentinels))
 
+	// results accumulates one SentinelResult per sentinel regardless of
+	// pass/fail — a subtest's t.Errorf/t.Fatalf aborts only that subtest's
+	// own goroutine (see results.go's doc comment), so this loop always
+	// runs to completion and the write below always has something to
+	// render, even on a real regression. Skipped entirely in calibration
+	// mode (update=true): there is no committed baseline to compare
+	// against yet, so "pass/fail" is not a meaningful concept for that run.
+	results := make([]SentinelResult, 0, len(Sentinels))
+
 	for _, sentinel := range Sentinels {
 		t.Run(sentinel.Name, func(t *testing.T) {
+			// result accumulates this sentinel's outcome as the subtest
+			// progresses; Pass defaults to false and is only ever flipped to
+			// true once every check below has actually succeeded, so a
+			// t.Fatalf anywhere in this closure (which aborts the goroutine
+			// via runtime.Goexit, skipping everything textually after it)
+			// still leaves an honest, correctly-failing result behind for
+			// the Cleanup below to capture.
+			result := SentinelResult{
+				Name:           sentinel.Name,
+				Family:         sentinel.Family,
+				ExpectedStatus: sentinel.ExpectedStatus,
+				Rejected:       sentinel.ExpectedStatus != http.StatusOK,
+			}
+			if !update {
+				// t.Cleanup (unlike code textually after a t.Fatalf) always
+				// runs, including after the Goexit a fatal assertion
+				// triggers — this is what lets a genuinely regressed
+				// sentinel still show up in the step summary as a clear
+				// FAIL instead of silently vanishing from the report.
+				t.Cleanup(func() { results = append(results, result) })
+			}
+
 			// One untimed, unmeasured warm-up — mirrors test/perf/smoke's own
 			// rationale: the OPTIMIZE ... FINAL pass above leaves this
 			// sentinel's tables cold, and the first query after that pays a
 			// real extra allocation this warm-up absorbs.
 			warmupID := fmt.Sprintf("perfnightly-%s-warmup", sentinel.Name)
 			if code, body := runSentinelOnce(t, mux, sentinel, warmupID); code != sentinel.ExpectedStatus {
+				result.ActualStatus = code
 				t.Fatalf("%s warm-up: HTTP %d (want %d): %s", sentinel.Name, code, sentinel.ExpectedStatus, body)
 			} else if sentinel.ExpectedStatus != http.StatusOK && !strings.Contains(body, sentinel.ExpectedErrorSubstring) {
+				result.ActualStatus = code
 				t.Fatalf("%s warm-up: HTTP %d body does not carry %q: %s", sentinel.Name, code, sentinel.ExpectedErrorSubstring, body)
 			}
 
@@ -193,6 +240,7 @@ func TestPerfNightlyRealCH(t *testing.T) {
 			for i := 0; i < nightlySentinelRepeats; i++ {
 				queryID := fmt.Sprintf("perfnightly-%s-%d", sentinel.Name, i)
 				code, body := runSentinelOnce(t, mux, sentinel, queryID)
+				result.ActualStatus = code
 				// The status-class check comes first and is fatal, not just a
 				// logged finding: for the two ExpectedStatus=422 sentinels this
 				// IS the #2429 regression signal (the bound silently breaking
@@ -221,6 +269,9 @@ func TestPerfNightlyRealCH(t *testing.T) {
 					maxBytes = rows[0].MemoryUsage
 				}
 			}
+			// Every repeat above matched sentinel.ExpectedStatus exactly, or
+			// this point is never reached (a mismatch is fatal).
+			result.StatusOK = true
 
 			// math.Round forces this through runtime float64 arithmetic rather
 			// than Go's exact-rational constant folding — (1<<30)*0.85 is not
@@ -231,6 +282,11 @@ func TestPerfNightlyRealCH(t *testing.T) {
 			t.Logf("%s (%s): max-of-%d peak memory_usage = %d bytes (%.1f%% of %d-byte cap; absolute ceiling %d), expected status %d",
 				sentinel.Name, sentinel.Family, nightlySentinelRepeats, maxBytes,
 				100*float64(maxBytes)/float64(perfNightlyMemoryCapBytes), perfNightlyMemoryCapBytes, capCeiling, sentinel.ExpectedStatus)
+
+			result.MaxOfNBytes = maxBytes
+			result.CapCeilingBytes = capCeiling
+			result.CapFractionPct = 100 * float64(maxBytes) / float64(perfNightlyMemoryCapBytes)
+			result.CapOK = maxBytes <= capCeiling
 
 			if update {
 				// Clamp to capCeiling: for a sentinel already close to the
@@ -261,18 +317,32 @@ func TestPerfNightlyRealCH(t *testing.T) {
 			if !ok {
 				t.Fatalf("%s: no committed bound in nightly-baseline.json — run `just update-nightly-perf-baseline`", sentinel.Name)
 			}
+			result.HasBaseline = true
 			if bound.ExpectedStatus != sentinel.ExpectedStatus {
 				t.Fatalf("%s: committed baseline expects status %d but the sentinel now expects %d — "+
 					"run `just update-nightly-perf-baseline` if this change is genuinely intended",
 					sentinel.Name, bound.ExpectedStatus, sentinel.ExpectedStatus)
 			}
+			result.BaselineCeilingBytes = bound.CeilingBytes
+			result.BaselineOK = maxBytes <= bound.CeilingBytes
 			if maxBytes > bound.CeilingBytes {
 				t.Errorf("%s: peak memory %d bytes exceeds the committed ceiling %d bytes (measured max-of-N was "+
 					"%d at calibration time, %.2fx headroom) — %s may have regressed; only run "+
 					"`just update-nightly-perf-baseline` if the increase is genuinely intended",
 					sentinel.Name, maxBytes, bound.CeilingBytes, bound.MaxOfNBytes, nightlyBaselineHeadroom, sentinel.Family)
 			}
+
+			// Every check above passed — this is the ONLY place Pass is set
+			// true, so any earlier t.Fatalf/t.Errorf leaves it at its zero
+			// value (false).
+			result.Pass = result.StatusOK && result.CapOK && result.BaselineOK
 		})
+	}
+
+	if !update {
+		if err := writeResultsJSON(results); err != nil {
+			t.Fatalf("write nightly results JSON: %v", err)
+		}
 	}
 
 	if update {

--- a/test/perf/nightly/results.go
+++ b/test/perf/nightly/results.go
@@ -119,5 +119,5 @@ func writeResultsJSON(results []SentinelResult) error {
 		return err
 	}
 	buf = append(buf, '\n')
-	return os.WriteFile(nightlyResultsPath(), buf, 0o644)
+	return os.WriteFile(nightlyResultsPath(), buf, 0o644) //nolint:gosec // per-run scratch artifact, world-readable is fine
 }

--- a/test/perf/nightly/results.go
+++ b/test/perf/nightly/results.go
@@ -1,0 +1,123 @@
+// results.go — the nightly gate's own per-sentinel verdict, serialised so
+// perf-nightly-step-summary.mjs can render an unambiguous table in the
+// workflow's $GITHUB_STEP_SUMMARY.
+//
+// Why this exists: 2 of the 4 sentinels in sentinels.go are CALIBRATED to
+// be rejected with HTTP 422 (issue #2429) — that rejection is the correct,
+// expected outcome, not a failure, and cerberus's own engine.go logs a
+// WARN-level "cerberus query failed" line for every non-2xx query outcome
+// unconditionally (see docs/observability.md) because a query genuinely
+// failing IS a WARN-worthy event from the engine's own perspective. A human
+// skimming a nightly run's raw log has no way to tell "the 2 sentinels that
+// are SUPPOSED to 422" apart from "something regressed" without reading and
+// correlating every WARN line by hand. This file's SentinelResult is the
+// single source of truth for each sentinel's pass/fail verdict — Go decides
+// it once, here, exactly where the gate's own assertions live; the .mjs
+// script only renders the JSON, it never re-derives the verdict.
+//
+// No build tag: this file (and its marshaling) is exercised by
+// results_test.go under the default build, independent of the `integration`
+// build tag realch_perfnightly_integration_test.go carries (Docker
+// required) — matching the same default-build-unit-coverage pattern
+// loader_test.go and sentinels_test.go already established for this
+// package.
+package nightly
+
+import (
+	"encoding/json"
+	"os"
+)
+
+// nightlyResultsJSONEnv names the environment variable
+// .github/workflows/perf-nightly.yml sets to a path under $RUNNER_TEMP;
+// perf-nightly-step-summary.mjs reads the exact same path from the exact
+// same variable, so the two sides can never drift onto different files.
+const nightlyResultsJSONEnv = "PERF_NIGHTLY_RESULTS_JSON"
+
+// SentinelResult is one sentinel's fully-resolved outcome for one nightly
+// run.
+type SentinelResult struct {
+	// Name / Family mirror the Sentinel this result came from.
+	Name   string `json:"name"`
+	Family string `json:"family"`
+
+	// ExpectedStatus / ActualStatus / StatusOK — the THIRD check
+	// realch_perfnightly_integration_test.go's own doc comment describes: a
+	// status-class mismatch is itself the regression for the two
+	// ExpectedStatus=422 sentinels, checked before either memory prong.
+	ExpectedStatus int  `json:"expected_status"`
+	ActualStatus   int  `json:"actual_status"`
+	StatusOK       bool `json:"status_ok"`
+
+	// MaxOfNBytes is the max-of-N peak memory_usage measurement (or, for a
+	// correctly-rejected sentinel, the peak memory used before the
+	// rejection fired).
+	MaxOfNBytes uint64 `json:"max_of_n_bytes"`
+
+	// CapCeilingBytes / CapFractionPct / CapOK — PRONG (a), the absolute
+	// cap-relative ceiling (nightlyMemoryCapFraction).
+	CapCeilingBytes uint64  `json:"cap_ceiling_bytes"`
+	CapFractionPct  float64 `json:"cap_fraction_pct"`
+	CapOK           bool    `json:"cap_ok"`
+
+	// HasBaseline / BaselineCeilingBytes / BaselineOK — PRONG (b), the
+	// committed per-sentinel ceiling. HasBaseline is false only for a
+	// calibration (UPDATE_NIGHTLY_PERF_BASELINE=1) run, where PRONG (b)
+	// does not apply yet.
+	HasBaseline          bool   `json:"has_baseline"`
+	BaselineCeilingBytes uint64 `json:"baseline_ceiling_bytes,omitempty"`
+	BaselineOK           bool   `json:"baseline_ok"`
+
+	// Pass is the single overall verdict for this sentinel: StatusOK &&
+	// CapOK && (!HasBaseline || BaselineOK).
+	Pass bool `json:"pass"`
+
+	// Rejected is true for a sentinel whose ExpectedStatus != 200 — the
+	// step-summary rendering uses this to label a passing 422 result
+	// "correctly rejected (expected)" rather than a bare "PASS", so a
+	// reader never mistakes the intentional #2429 rejection for a fluke.
+	Rejected bool `json:"rejected"`
+}
+
+// NightlyResults is the top-level document written to
+// PERF_NIGHTLY_RESULTS_JSON.
+type NightlyResults struct {
+	Sentinels []SentinelResult `json:"sentinels"`
+	AllPass   bool             `json:"all_pass"`
+}
+
+// nightlyResultsPath resolves where to write the results document: the
+// path named by PERF_NIGHTLY_RESULTS_JSON when set (the workflow always
+// sets this), or a fixed name in os.TempDir() for a local/manual run so
+// `go test -tags=integration -run TestPerfNightlyRealCH` still works
+// without erroring.
+func nightlyResultsPath() string {
+	if p := os.Getenv(nightlyResultsJSONEnv); p != "" {
+		return p
+	}
+	return os.TempDir() + string(os.PathSeparator) + "perf-nightly-results.json"
+}
+
+// writeResultsJSON serialises results as pretty JSON to nightlyResultsPath().
+// Unlike nightly-baseline.json (invariant 9: never hand-edited, committed to
+// git) this file is a per-run scratch artifact — never committed, written
+// unconditionally at the end of every non-calibration run so the step
+// summary has something to render even when a sentinel subtest failed
+// (a Go subtest's t.Errorf/t.Fatalf aborts only that subtest's goroutine;
+// the parent test function — and this write — still runs after the loop).
+func writeResultsJSON(results []SentinelResult) error {
+	allPass := true
+	for _, r := range results {
+		if !r.Pass {
+			allPass = false
+			break
+		}
+	}
+	doc := NightlyResults{Sentinels: results, AllPass: allPass}
+	buf, err := json.MarshalIndent(doc, "", "  ")
+	if err != nil {
+		return err
+	}
+	buf = append(buf, '\n')
+	return os.WriteFile(nightlyResultsPath(), buf, 0o644)
+}

--- a/test/perf/nightly/results_test.go
+++ b/test/perf/nightly/results_test.go
@@ -1,0 +1,99 @@
+package nightly
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestWriteResultsJSON_RoundTrip asserts the results document written by
+// writeResultsJSON is valid JSON at the path PERF_NIGHTLY_RESULTS_JSON
+// names, and that AllPass reflects every sentinel's own Pass field exactly
+// — this is the single piece of business logic
+// perf-nightly-step-summary.mjs relies on Go having already decided, so a
+// wrong AllPass here would make every downstream rendering wrong too.
+func TestWriteResultsJSON_RoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "results.json")
+	t.Setenv(nightlyResultsJSONEnv, path)
+
+	results := []SentinelResult{
+		{
+			Name: "classic_histogram_quantile_by_route", Family: "histogram_quantile",
+			ExpectedStatus: 200, ActualStatus: 200, StatusOK: true,
+			MaxOfNBytes: 1234, CapCeilingBytes: 912680550, CapFractionPct: 0.1, CapOK: true,
+			HasBaseline: true, BaselineCeilingBytes: 5000, BaselineOK: true,
+			Pass: true, Rejected: false,
+		},
+		{
+			Name: "request_rate_by_method", Family: "plain counter rate",
+			ExpectedStatus: 422, ActualStatus: 422, StatusOK: true,
+			MaxOfNBytes: 278203396, CapCeilingBytes: 912680550, CapFractionPct: 25.9, CapOK: true,
+			HasBaseline: true, BaselineCeilingBytes: 417305094, BaselineOK: true,
+			Pass: true, Rejected: true,
+		},
+	}
+
+	if err := writeResultsJSON(results); err != nil {
+		t.Fatalf("writeResultsJSON: %v", err)
+	}
+
+	buf, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read results: %v", err)
+	}
+	var got NightlyResults
+	if err := json.Unmarshal(buf, &got); err != nil {
+		t.Fatalf("unmarshal results: %v", err)
+	}
+	if !got.AllPass {
+		t.Errorf("AllPass = false, want true (every sentinel above has Pass=true)")
+	}
+	if len(got.Sentinels) != len(results) {
+		t.Fatalf("len(Sentinels) = %d, want %d", len(got.Sentinels), len(results))
+	}
+	if got.Sentinels[1].Rejected != true {
+		t.Errorf("Sentinels[1].Rejected = false, want true")
+	}
+}
+
+// TestWriteResultsJSON_AllPassFalseOnAnyFailure asserts a single failing
+// sentinel flips the document-level AllPass to false, even when every
+// other sentinel passed — the step summary's headline verdict line reads
+// this field directly.
+func TestWriteResultsJSON_AllPassFalseOnAnyFailure(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "results.json")
+	t.Setenv(nightlyResultsJSONEnv, path)
+
+	results := []SentinelResult{
+		{Name: "a", Pass: true},
+		{Name: "b", Pass: false},
+		{Name: "c", Pass: true},
+	}
+	if err := writeResultsJSON(results); err != nil {
+		t.Fatalf("writeResultsJSON: %v", err)
+	}
+	buf, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read results: %v", err)
+	}
+	var got NightlyResults
+	if err := json.Unmarshal(buf, &got); err != nil {
+		t.Fatalf("unmarshal results: %v", err)
+	}
+	if got.AllPass {
+		t.Errorf("AllPass = true, want false (Sentinels[1].Pass is false)")
+	}
+}
+
+// TestNightlyResultsPath_DefaultsWhenEnvUnset asserts a local run (no
+// PERF_NIGHTLY_RESULTS_JSON set) still resolves to a usable path rather
+// than an empty string, so writeResultsJSON never silently no-ops.
+func TestNightlyResultsPath_DefaultsWhenEnvUnset(t *testing.T) {
+	t.Setenv(nightlyResultsJSONEnv, "")
+	if got := nightlyResultsPath(); got == "" {
+		t.Errorf("nightlyResultsPath() = %q, want a non-empty default", got)
+	}
+}


### PR DESCRIPTION
## Summary

A real `perf-nightly` run (run 32555114292) buried its actual verdict in raw log noise. 2 of the
4 sentinels (`request_rate_by_method`, `error_ratio_by_namespace`) are deliberately calibrated to
be rejected by issue #2429's resource bound, and cerberus's own `engine.go` correctly logs a
`WARN cerberus query failed` line for every rejected query unconditionally (this is intentional
application logging, see `docs/observability.md` — not a bug, and this PR does not touch it).
Nothing in the run distinguished "correctly rejected as designed" from "a real regression" before
a human had to manually cross-reference each WARN line against `sentinels.go`'s own
`ExpectedStatus` field.

This PR adds a clear, unambiguous verdict table to the job's Step Summary, rendered ahead of the
raw log:

- `test/perf/nightly/results.go` (default build, no Docker needed) captures each sentinel's
  already-computed pass/fail verdict — the gate's own single source of truth, computed once in
  `realch_perfnightly_integration_test.go`'s existing assertions — into a per-run JSON document.
  Robust to a `t.Fatalf` mid-subtest via `t.Cleanup`, so a real regression still shows up in the
  summary instead of silently vanishing.
- `.github/scripts/perf-nightly-step-summary.mjs` renders that JSON as a markdown table (sentinel,
  family, expected/actual status, memory vs. cap, memory vs. committed baseline, and an explicit
  "✅ correctly rejected (expected)" vs "❌ FAIL" verdict) into `$GITHUB_STEP_SUMMARY`, wired into
  `perf-nightly.yml` under `if: always()` so it renders even when the test step itself fails.
- Both are unit-tested without Docker (`results_test.go`, `perf-nightly-step-summary.test.mjs`,
  the latter wired into `ci.yml`'s `lint` job as a self-test).

## Scope note (per the requesting task)

This was originally a broader investigation: the repo owner also asked for the nightly lane to
"fully explore many queries including native and classic histogram" and use "a longer time window
of data," calling the current 3-minute run too narrow. Findings on those two asks, reported to the
owner directly (not implemented here — both are real cost/scope tradeoffs against #2370's own
explicit "zero added cost" decision, and need the owner's sign-off before implementation, not a
unilateral change):

- **Longer time window**: the FULL, un-trimmed 14-day real production sample already exists in the
  repo via LFS (`test/perf/smoke/testdata/samples/`, ~72 MB / ~58.9M rows) — nightly currently uses
  only a single-day, ~5 MB trim of it. Widening nightly's own data pull would multiply its LFS
  bandwidth well past GitHub's free 1 GiB/month quota (72 MB × ~30 nightly runs/month ≈ 2.16 GB/
  month) — a real, named cost the original design deliberately traded off, not something to change
  silently.
- **Native histogram_quantile**: the real production sample has NO native/exponential-histogram
  data at all (only classic histogram, counter, and gauge) — there is no real corpus to query. The
  only way to add native-histogram coverage would be synthetic seed data (reusing
  `test/perf/smoke`'s own generator) injected into an otherwise "real production data" lane, which
  changes what the lane represents and also needs sign-off.
- **More query diversity** over the 3 metric types nightly already loads is comparatively cheap
  (a few more real-data sentinels, each costing single-digit seconds against already-loaded
  tables) and was NOT implemented here either, since any new sentinel needs a real Docker+
  ClickHouse run to calibrate its `ExpectedStatus` and baseline ceiling (`just
  update-nightly-perf-baseline`) — not available in this sandbox, and not something to guess at.

## Test plan

- [x] `go build -tags=integration ./test/perf/nightly/...` and `go vet -tags=integration
      ./test/perf/nightly/...` — compiles cleanly (Docker not available in this sandbox to run the
      integration test itself; unchanged assertions, only additive result-capture around them).
- [x] `go test ./test/perf/nightly/...` — all default-build unit tests pass, including the two new
      `results_test.go` cases.
- [x] `node --test .github/scripts/perf-nightly-step-summary.test.mjs` — all 9 cases pass
      (formatting, expected-rejection-vs-fail discrimination, missing/unparseable-file escape
      hatches, end-to-end script invocation against a fixture JSON).
- [x] `just lint-actions` — clean on both modified workflows.
- [x] `gofumpt -l` — clean on all changed Go files.
- [ ] CI (lint, test, build, forbid-deferral, etc.) — pending on this PR.
