### PR TITLE
fix(promql): answer absent() over a raw exp-histogram selector

### DIFF
--- a/internal/promql/absent.go
+++ b/internal/promql/absent.go
@@ -43,6 +43,15 @@ import (
 // window the bare-selector LWR wrap uses. For the compatibility-harness
 // fixtures and the OTel-CH gauge tables, "metric has zero rows in the
 // table" is the signal that matters.
+//
+// A bare `v` never reads a sample's value — reference's own funcAbsent
+// only asks `len(vectorVals[0]) > 0`, so it answers just as readily over
+// an exponential-histogram selector as over a float one. The
+// VectorSelector arm below therefore routes through
+// lowerAbsencePresenceSelector rather than lowerVectorSelector directly:
+// the latter would hit expHistogramSelectorRouting's rejection for a
+// selector shape absent() never actually needed a Value column from
+// (cerberus issue #2443).
 func lowerAbsent(c *parser.Call, s schema.Metrics, ctx lowerCtx) (chplan.Node, error) {
 	if len(c.Args) != 1 {
 		return nil, fmt.Errorf("promql: absent() expects 1 argument, got %d", len(c.Args))
@@ -58,11 +67,10 @@ func lowerAbsent(c *parser.Call, s schema.Metrics, ctx lowerCtx) (chplan.Node, e
 		err   error
 	)
 	if vs, ok := arg.(*parser.VectorSelector); ok {
-		// Build the inner filtered Scan via the standard selector
-		// lowering with the range-vector flag set: that path skips the
-		// LWR wrap and only applies the matchers (plus the @/offset time
-		// bound when present). The wrapping Aggregate doesn't need a
-		// per-series collapse — it just counts rows.
+		// Build the inner filtered Scan via lowerAbsencePresenceSelector,
+		// which skips the LWR wrap and only applies the matchers (plus the
+		// @/offset time bound when present). The wrapping Aggregate
+		// doesn't need a per-series collapse — it just counts rows.
 		//
 		// Strip the modifier so the inner Filter doesn't carry a
 		// duplicate time-bound predicate; absent() doesn't currently
@@ -76,7 +84,7 @@ func lowerAbsent(c *parser.Call, s schema.Metrics, ctx lowerCtx) (chplan.Node, e
 		vsNoMod.StartOrEnd = 0
 		rangeCtx := ctx
 		rangeCtx.inRangeVector = true
-		inner, err = lowerVectorSelector(&vsNoMod, s, rangeCtx)
+		inner, err = lowerAbsencePresenceSelector(&vsNoMod, s, rangeCtx)
 		if err != nil {
 			return nil, err
 		}
@@ -235,7 +243,7 @@ func lowerAbsentOverTime(c *parser.Call, s schema.Metrics, ctx lowerCtx) (chplan
 	vsNoMod.StartOrEnd = 0
 	rangeCtx := ctx
 	rangeCtx.inRangeVector = true
-	inner, err := lowerAbsentOverTimeSelector(&vsNoMod, s, rangeCtx)
+	inner, err := lowerAbsencePresenceSelector(&vsNoMod, s, rangeCtx)
 	if err != nil {
 		return nil, err
 	}
@@ -281,19 +289,25 @@ func lowerAbsentOverTime(c *parser.Call, s schema.Metrics, ctx lowerCtx) (chplan
 	return a, nil
 }
 
-// lowerAbsentOverTimeSelector builds the matcher-filtered presence stream
-// consumed by [chplan.AbsentOverTime]. Exponential-histogram rows do not
-// carry the scalar Value column expected by the ordinary selector pipeline,
-// but absence is value-agnostic: the dedicated node only needs timestamps
-// from rows that satisfy the selector's label predicates.
+// lowerAbsencePresenceSelector builds the matcher-filtered presence stream
+// shared by instant `absent(<selector>)` (lowerAbsent, above) and
+// `absent_over_time(<selector>[range])` (lowerAbsentOverTime, below), both of
+// which only need to know whether ANY row matches the selector's label
+// predicates — never a sample's value. Exponential-histogram rows do not
+// carry the scalar Value column the ordinary selector pipeline expects, so
+// routing either function through the standard lowerVectorSelector path hits
+// expHistogramSelectorRouting's rejection for a shape neither caller actually
+// needs (cerberus issue #2443, the absent() sibling of #2226's
+// absent_over_time() fix).
 //
 // Keep the ordinary path for every non-native selector so its established
 // table unions and label routing remain unchanged. A pinned native-histogram
 // selector instead scans the exponential-histogram table directly, applies
 // its predicates while all raw label/resource columns are still in scope,
-// and projects only the timestamp needed by the absence emitter. In
+// and projects only the timestamp column — enough for absent_over_time's
+// per-anchor lookback check and for absent's plain row count alike. In
 // particular, this path must never synthesize or reference s.ValueColumn.
-func lowerAbsentOverTimeSelector(vs *parser.VectorSelector, s schema.Metrics, ctx lowerCtx) (chplan.Node, error) {
+func lowerAbsencePresenceSelector(vs *parser.VectorSelector, s schema.Metrics, ctx lowerCtx) (chplan.Node, error) {
 	metricName := metricNameFromMatchers(vs.LabelMatchers)
 	if s.ExpHistogramTable == "" || !s.IsExpHistogramMetric(metricName) {
 		return lowerVectorSelector(vs, s, ctx)

--- a/internal/promql/exp_histogram_absent_test.go
+++ b/internal/promql/exp_histogram_absent_test.go
@@ -1,0 +1,168 @@
+package promql_test
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/prometheus/prometheus/promql/parser"
+
+	"github.com/tsouza/cerberus/internal/chplan"
+	"github.com/tsouza/cerberus/internal/chsql"
+	"github.com/tsouza/cerberus/internal/promql"
+	"github.com/tsouza/cerberus/internal/schema"
+)
+
+// TestLower_ExpHistogram_AbsentIsPresenceOnly pins issue #2443: instant
+// `absent(v)` is value-agnostic in reference Prometheus (funcAbsent only
+// asks len(vectorVals[0]) > 0, never reading a sample's H/F field), so a
+// bare exponential-histogram selector argument must lower successfully
+// instead of hitting expHistogramSelectorRouting's rejection — the same
+// class of bug #2226 fixed for absent_over_time().
+func TestLower_ExpHistogram_AbsentIsPresenceOnly(t *testing.T) {
+	t.Parallel()
+
+	s := schema.DefaultOTelMetrics()
+	p := parser.NewParser(parser.Options{EnableExperimentalFunctions: true})
+	start := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	end := start.Add(5 * time.Minute)
+
+	cases := []struct {
+		name  string
+		query string
+		lower func(parser.Expr) (chplan.Node, error)
+	}{
+		{
+			name:  "instant",
+			query: `absent(latency_exp_hist{job="api"})`,
+			lower: func(e parser.Expr) (chplan.Node, error) {
+				return promql.LowerAt(context.Background(), e, s, end, end)
+			},
+		},
+		{
+			name:  "range",
+			query: `absent(latency_exp_hist{job="api"})`,
+			lower: func(e parser.Expr) (chplan.Node, error) {
+				return promql.LowerAtRange(context.Background(), e, s, start, end, time.Minute)
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			expr, err := p.ParseExpr(tc.query)
+			if err != nil {
+				t.Fatalf("ParseExpr(%q): %v", tc.query, err)
+			}
+			plan, err := tc.lower(expr)
+			if err != nil {
+				t.Fatalf("Lower(%q): %v", tc.query, err)
+			}
+
+			var scan *chplan.Scan
+			chplan.Walk(plan, func(n chplan.Node) bool {
+				if candidate, ok := n.(*chplan.Scan); ok {
+					scan = candidate
+				}
+				return true
+			})
+			if scan == nil || scan.Table != s.ExpHistogramTable {
+				t.Fatalf("presence scan = %#v, want table %q", scan, s.ExpHistogramTable)
+			}
+
+			var agg *chplan.Aggregate
+			chplan.Walk(plan, func(n chplan.Node) bool {
+				if candidate, ok := n.(*chplan.Aggregate); ok && agg == nil {
+					agg = candidate
+				}
+				return true
+			})
+			if agg == nil || len(agg.AggFuncs) != 1 || agg.AggFuncs[0].Fn != chplan.FnCount {
+				t.Fatalf("presence aggregate = %#v, want a single count() aggregate", agg)
+			}
+
+			// The presence stream must never reference the exp-histogram
+			// table's absent scalar Value column: absent() only counts
+			// rows, so a Value reference would mean the lowering fell
+			// back onto the ordinary float selector pipeline this fix
+			// bypasses.
+			chplan.Walk(agg, func(n chplan.Node) bool {
+				chplan.InspectNodeExprs(n, func(e chplan.Expr) {
+					chplan.InspectExpr(e, func(inner chplan.Expr) bool {
+						if col, ok := inner.(*chplan.ColumnRef); ok && col.Name == s.ValueColumn {
+							t.Errorf("presence-only input references nonexistent float column %q", s.ValueColumn)
+						}
+						return true
+					})
+				})
+				return true
+			})
+
+			sqlText, _, err := chsql.Emit(context.Background(), plan)
+			if err != nil {
+				t.Fatalf("Emit(%q): %v", tc.query, err)
+			}
+			if strings.Contains(sqlText, "`Value` AS `Value` FROM (SELECT * FROM `"+s.ExpHistogramTable+"`") {
+				t.Fatalf("native-histogram scan was routed through a float Value projection:\n%s", sqlText)
+			}
+		})
+	}
+}
+
+// TestLower_ExpHistogram_AbsentLabelsMirrorMatchers pins the output label
+// rule absent() applies over a bare selector argument even when the
+// selector names a native-histogram metric: Prom's
+// createLabelsForAbsentFunction lifts the argument's equality matchers onto
+// the synthesised `{...} 1` row, unaffected by which physical table the
+// presence check reads from.
+func TestLower_ExpHistogram_AbsentLabelsMirrorMatchers(t *testing.T) {
+	t.Parallel()
+
+	s := schema.DefaultOTelMetrics()
+	p := parser.NewParser(parser.Options{EnableExperimentalFunctions: true})
+	end := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+
+	expr, err := p.ParseExpr(`absent(latency_exp_hist{job="api",env="prod"})`)
+	if err != nil {
+		t.Fatalf("ParseExpr: %v", err)
+	}
+	plan, err := promql.LowerAt(context.Background(), expr, s, end, end)
+	if err != nil {
+		t.Fatalf("Lower: %v", err)
+	}
+
+	proj, ok := plan.(*chplan.Project)
+	if !ok {
+		t.Fatalf("plan = %T, want *chplan.Project", plan)
+	}
+	var attrsExpr chplan.Expr
+	for _, p := range proj.Projections {
+		if p.Alias == s.AttributesColumn {
+			attrsExpr = p.Expr
+		}
+	}
+	call, ok := attrsExpr.(*chplan.FuncCall)
+	if !ok || call.Fn != chplan.FnMap {
+		t.Fatalf("Attributes projection = %#v, want a map() FuncCall", attrsExpr)
+	}
+	got := map[string]string{}
+	for i := 0; i+1 < len(call.Args); i += 2 {
+		k, kok := call.Args[i].(*chplan.LitString)
+		v, vok := call.Args[i+1].(*chplan.LitString)
+		if !kok || !vok {
+			t.Fatalf("map() arg pair %d/%d = %#v/%#v, want string literals", i, i+1, call.Args[i], call.Args[i+1])
+		}
+		got[k.V] = v.V
+	}
+	want := map[string]string{"job": "api", "env": "prod"}
+	if len(got) != len(want) {
+		t.Fatalf("Attributes = %#v, want %#v", got, want)
+	}
+	for k, v := range want {
+		if got[k] != v {
+			t.Errorf("Attributes[%q] = %q, want %q", k, got[k], v)
+		}
+	}
+}

--- a/test/perf/solver-decision-baseline/exp_histogram_absent_missing/fanout.json
+++ b/test/perf/solver-decision-baseline/exp_histogram_absent_missing/fanout.json
@@ -1,0 +1,11 @@
+{
+  "query": "exp_histogram_absent_missing/fanout",
+  "lowering": "fanout",
+  "routed": false,
+  "k": 0,
+  "reason": "not-sliceable",
+  "n_anchors": 241,
+  "fanout": 0,
+  "cumulative_d": "0s",
+  "outer_range": "1h0m0s"
+}

--- a/test/perf/solver-decision-baseline/exp_histogram_absent_missing/native.json
+++ b/test/perf/solver-decision-baseline/exp_histogram_absent_missing/native.json
@@ -1,0 +1,11 @@
+{
+  "query": "exp_histogram_absent_missing/native",
+  "lowering": "native",
+  "routed": false,
+  "k": 0,
+  "reason": "not-sliceable",
+  "n_anchors": 241,
+  "fanout": 0,
+  "cumulative_d": "0s",
+  "outer_range": "1h0m0s"
+}

--- a/test/perf/solver-decision-baseline/exp_histogram_absent_present/fanout.json
+++ b/test/perf/solver-decision-baseline/exp_histogram_absent_present/fanout.json
@@ -1,0 +1,11 @@
+{
+  "query": "exp_histogram_absent_present/fanout",
+  "lowering": "fanout",
+  "routed": false,
+  "k": 0,
+  "reason": "not-sliceable",
+  "n_anchors": 241,
+  "fanout": 0,
+  "cumulative_d": "0s",
+  "outer_range": "1h0m0s"
+}

--- a/test/perf/solver-decision-baseline/exp_histogram_absent_present/native.json
+++ b/test/perf/solver-decision-baseline/exp_histogram_absent_present/native.json
@@ -1,0 +1,11 @@
+{
+  "query": "exp_histogram_absent_present/native",
+  "lowering": "native",
+  "routed": false,
+  "k": 0,
+  "reason": "not-sliceable",
+  "n_anchors": 241,
+  "fanout": 0,
+  "cumulative_d": "0s",
+  "outer_range": "1h0m0s"
+}

--- a/test/regression/parity-enrolment-baselines/promql/baseline.txt
+++ b/test/regression/parity-enrolment-baselines/promql/baseline.txt
@@ -129,6 +129,8 @@ edge_sqrt_over_aggregate.txtar
 edge_subquery_nested.txtar
 empty_ignoring_join.txtar
 empty_on_join.txtar
+exp_histogram_absent_missing.txtar
+exp_histogram_absent_present.txtar
 exp_histogram_avg.txtar
 exp_histogram_avg_by.txtar
 exp_histogram_avg_over_time.txtar

--- a/test/rejection-parity/catalogue/internal__promql__lower.go.json
+++ b/test/rejection-parity/catalogue/internal__promql__lower.go.json
@@ -94,8 +94,8 @@
       "site": "internal/promql/lower.go:expHistogramSelectorRouting#bf746b59",
       "message": "promql: %q is an exponential histogram metric; only a bare %q selector, sum()/avg()/count() over one, rate()/increase()/delta()/irate()/idelta()/sum_over_time()/avg_over_time()/resets()/changes() over one, histogram_quantile(), histogram_count(), histogram_sum(), and the %q/%q companion selectors are supported",
       "class": "divergence",
-      "trigger_query": "absent(demo_latency_exp_hist)",
-      "tracking_issue": 2443,
+      "trigger_query": "sort(demo_latency_exp_hist)",
+      "tracking_issue": 2456,
       "evidence": {
         "guard": [
           "past returning if bare, col, hasCompanion := s.HistogramCompanionColumn(metricName); hasCompanion \u0026\u0026 s.IsExpHistogramMetric(bare) \u0026\u0026 s.ExpHistogramTable != \"\"",
@@ -105,7 +105,7 @@
           "resolveSelectorRouting"
         ]
       },
-      "since": "2026-08-21"
+      "since": "2026-08-22"
     },
     {
       "head": "promql",

--- a/test/spec/promql/exp_histogram_absent_missing.txtar
+++ b/test/spec/promql/exp_histogram_absent_missing.txtar
@@ -1,0 +1,34 @@
+# absent() over a native-histogram selector whose table exists but has
+# no row matching the selector's matchers (cerberus issue #2443). The
+# seeded row belongs to a different `job`, so the presence Scan's
+# filtered count is 0, the outer `_cerb_n = 0` filter passes the
+# candidate sample through, and the Project synthesises the absent row
+# with the equality matcher (`job=api`) lifted onto it — the same output
+# label rule a float-metric absent() applies (createLabelsForAbsentFunction).
+
+-- query.promql --
+absent(latency_exp_hist{job="api"})
+-- parity --
+oracle: prometheus
+endpoint: /api/v1/query
+scope: full
+-- seed --
+CREATE TABLE otel_metrics_exponential_histogram (
+    MetricName String,
+    Attributes Map(String, String),
+    TimeUnix DateTime64(9),
+    Count UInt64,
+    Sum Float64,
+    Scale Int32,
+    ZeroCount UInt64,
+    PositiveOffset Int32,
+    PositiveBucketCounts Array(UInt64),
+    NegativeOffset Int32,
+    NegativeBucketCounts Array(UInt64)
+) ENGINE = MergeTree ORDER BY (MetricName, Attributes, TimeUnix);
+INSERT INTO otel_metrics_exponential_histogram VALUES
+    ('latency_exp_hist', map('job', 'db', 'instance', 'c'), toDateTime64('2026-01-01 00:00:00', 9), 1, 1, 0, 0, 0, [1], 0, []);
+-- expected_rows --
+[
+  ["", {"job": "api"}, "2026-01-01T00:00:01Z", 1.0]
+]

--- a/test/spec/promql/exp_histogram_absent_missing.txtar
+++ b/test/spec/promql/exp_histogram_absent_missing.txtar
@@ -32,3 +32,33 @@ INSERT INTO otel_metrics_exponential_histogram VALUES
 [
   ["", {"job": "api"}, "2026-01-01T00:00:01Z", 1.0]
 ]
+-- args --
+[0] string = ""
+[1] string = "job"
+[2] string = "api"
+[3] string = "2026-01-01 00:00:01.000000000"
+[4] int64 = 9
+[5] float64 = 1
+[6] string = "latency_exp_hist"
+[7] string = "latency.exp.hist"
+[8] string = "latency.exp/hist"
+[9] string = "latency.exp_hist"
+[10] string = "latency/exp/hist"
+[11] string = "latency/exp_hist"
+[12] string = "latency_exp.hist"
+[13] string = "job"
+[14] string = ""
+[15] string = "job"
+[16] string = ""
+[17] string = ""
+[18] string = "api"
+[19] int64 = 0
+-- chplan --
+Project ["" AS MetricName, FnMap("job", "api") AS Attributes, FnToDateTime64("2026-01-01 00:00:01.000000000", 9) AS TimeUnix, 1 AS Value]
+  Filter predicate=(_cerb_n = 0)
+    Aggregate groupBy=[] funcs=[FnCount() AS _cerb_n]
+      Project [TimeUnix AS TimeUnix]
+        Filter predicate=((FnCoalesce(FnNullIf(Attributes["job"], ""), FnNullIf(ResourceAttributes["job"], ""), "") = "api") AND (MetricName IN ("latency_exp_hist", "latency.exp.hist", "latency.exp/hist", "latency.exp_hist", "latency/exp/hist", "latency/exp_hist", "latency_exp.hist")))
+          Scan(otel_metrics_exponential_histogram)
+-- sql --
+SELECT ? AS `MetricName`, map(?, ?) AS `Attributes`, toDateTime64(?, ?) AS `TimeUnix`, toFloat64(?) AS `Value` FROM (SELECT * FROM (SELECT toFloat64(count()) AS `_cerb_n` FROM (SELECT `TimeUnix` AS `TimeUnix` FROM (SELECT * FROM `otel_metrics_exponential_histogram` PREWHERE (`MetricName` IN (?, ?, ?, ?, ?, ?, ?)) WHERE (coalesce(nullIf(`Attributes`[?], ?), nullIf(`ResourceAttributes`[?], ?), ?) = ?)))) WHERE (`_cerb_n` = ?))

--- a/test/spec/promql/exp_histogram_absent_present.txtar
+++ b/test/spec/promql/exp_histogram_absent_present.txtar
@@ -35,3 +35,33 @@ INSERT INTO otel_metrics_exponential_histogram VALUES
     ('latency_exp_hist', map('job', 'api', 'instance', 'a'), toDateTime64('2026-01-01 00:00:00', 9), 1, 1, 0, 0, 0, [1], 0, []);
 -- expected_rows --
 []
+-- args --
+[0] string = ""
+[1] string = "job"
+[2] string = "api"
+[3] string = "2026-01-01 00:00:01.000000000"
+[4] int64 = 9
+[5] float64 = 1
+[6] string = "latency_exp_hist"
+[7] string = "latency.exp.hist"
+[8] string = "latency.exp/hist"
+[9] string = "latency.exp_hist"
+[10] string = "latency/exp/hist"
+[11] string = "latency/exp_hist"
+[12] string = "latency_exp.hist"
+[13] string = "job"
+[14] string = ""
+[15] string = "job"
+[16] string = ""
+[17] string = ""
+[18] string = "api"
+[19] int64 = 0
+-- chplan --
+Project ["" AS MetricName, FnMap("job", "api") AS Attributes, FnToDateTime64("2026-01-01 00:00:01.000000000", 9) AS TimeUnix, 1 AS Value]
+  Filter predicate=(_cerb_n = 0)
+    Aggregate groupBy=[] funcs=[FnCount() AS _cerb_n]
+      Project [TimeUnix AS TimeUnix]
+        Filter predicate=((FnCoalesce(FnNullIf(Attributes["job"], ""), FnNullIf(ResourceAttributes["job"], ""), "") = "api") AND (MetricName IN ("latency_exp_hist", "latency.exp.hist", "latency.exp/hist", "latency.exp_hist", "latency/exp/hist", "latency/exp_hist", "latency_exp.hist")))
+          Scan(otel_metrics_exponential_histogram)
+-- sql --
+SELECT ? AS `MetricName`, map(?, ?) AS `Attributes`, toDateTime64(?, ?) AS `TimeUnix`, toFloat64(?) AS `Value` FROM (SELECT * FROM (SELECT toFloat64(count()) AS `_cerb_n` FROM (SELECT `TimeUnix` AS `TimeUnix` FROM (SELECT * FROM `otel_metrics_exponential_histogram` PREWHERE (`MetricName` IN (?, ?, ?, ?, ?, ?, ?)) WHERE (coalesce(nullIf(`Attributes`[?], ?), nullIf(`ResourceAttributes`[?], ?), ?) = ?)))) WHERE (`_cerb_n` = ?))

--- a/test/spec/promql/exp_histogram_absent_present.txtar
+++ b/test/spec/promql/exp_histogram_absent_present.txtar
@@ -1,0 +1,37 @@
+# absent() over a native-histogram selector whose table DOES contain a
+# matching row (cerberus issue #2443). Reference Prometheus's funcAbsent
+# never reads a sample's H/F field — it only asks whether the input
+# vector is non-empty — so a bare exponential-histogram selector answers
+# exactly like a float selector would: the inner presence Scan counts
+# the matching row, the outer `_cerb_n = 0` filter drops the candidate
+# sample, and the surrounding Project produces zero output rows.
+#
+# The presence Scan reads otel_metrics_exponential_histogram directly
+# (lowerAbsencePresenceSelector) rather than routing through the ordinary
+# float selector pipeline, which has no Value column for this table and
+# would otherwise reject the query at expHistogramSelectorRouting.
+
+-- query.promql --
+absent(latency_exp_hist{job="api"})
+-- parity --
+oracle: prometheus
+endpoint: /api/v1/query
+scope: full
+-- seed --
+CREATE TABLE otel_metrics_exponential_histogram (
+    MetricName String,
+    Attributes Map(String, String),
+    TimeUnix DateTime64(9),
+    Count UInt64,
+    Sum Float64,
+    Scale Int32,
+    ZeroCount UInt64,
+    PositiveOffset Int32,
+    PositiveBucketCounts Array(UInt64),
+    NegativeOffset Int32,
+    NegativeBucketCounts Array(UInt64)
+) ENGINE = MergeTree ORDER BY (MetricName, Attributes, TimeUnix);
+INSERT INTO otel_metrics_exponential_histogram VALUES
+    ('latency_exp_hist', map('job', 'api', 'instance', 'a'), toDateTime64('2026-01-01 00:00:00', 9), 1, 1, 0, 0, 0, [1], 0, []);
+-- expected_rows --
+[]


### PR DESCRIPTION
## Summary

- `absent(v)` over a raw exponential-histogram selector (e.g.
  `absent(demo_latency_exp_hist)`) was hard-rejected by
  `expHistogramSelectorRouting`, while reference Prometheus answers it
  normally: `funcAbsent` never reads a sample's `.H`/`.F` field, it only
  checks whether the input vector is non-empty.
- `lowerAbsent`'s bare-`VectorSelector` branch routed through
  `lowerVectorSelector` directly, which has no histogram-valued-shape
  exemption. Renamed `lowerAbsentOverTimeSelector` to
  `lowerAbsencePresenceSelector` and share it between `lowerAbsent` and
  `lowerAbsentOverTime` — both only need to know whether ANY row matches
  the selector's predicates, never a sample's value, so the exp-histogram
  direct-table-scan path #2226 added for `absent_over_time()` now serves
  `absent()` too.
- Rotated the rejection-parity catalogue's `expHistogramSelectorRouting`
  divergence entry to its next reachable trigger,
  `sort(demo_latency_exp_hist)` (verified locally against the pinned
  Prometheus fork: `funcSort`/`funcSortDesc` drop histogram samples via
  `filterFloats` before sorting, so reference answers an empty vector
  where cerberus currently still rejects), filing #2456 to track that
  gap.

Closes #2443.

## Test plan

- `go test ./internal/promql/...` — full package, including two new
  focused tests: `TestLower_ExpHistogram_AbsentIsPresenceOnly` (instant +
  range, asserts the presence scan reads the exp-histogram table, the
  aggregate is a plain `count()`, and no `Value` column is referenced) and
  `TestLower_ExpHistogram_AbsentLabelsMirrorMatchers` (equality-matcher
  labels lift onto the synthesised absent row).
- `go build ./...` and `go vet ./...`.
- `node .github/scripts/forbid-sql-raw.mjs`.
- `go test ./test/rejection-parity/... ./test/regression/... -run 'TestCatalogueIsRegenerable|TestCatalogueEntriesAreClassified|TestPromQLRejectionTriggersUseSeededMetrics'` — confirms the rotated catalogue entry is well-formed and still resolves to a seeded metric family.
- Added two TXTAR fixtures (`test/spec/promql/exp_histogram_absent_present.txtar`,
  `test/spec/promql/exp_histogram_absent_missing.txtar`) covering both
  branches of `absent()` over a native-histogram selector; filled in via
  the `update-golden.yml` workflow (`promql` shard).
