### PR TITLE
fix(scripts): auto-expand a narrow golden-shard dispatch to its full DAG

### DIFF
--- a/.github/scripts/README.md
+++ b/.github/scripts/README.md
@@ -2174,17 +2174,20 @@ what actually runs.
     Neither relation is written down as a table of paths;
     `test/regression/golden_shard_coverage_test.go` pins that, along with the
     check firing in both directions.
-  - Before dispatching `update-golden.yml` on a pushed branch, run this same
-    check locally instead of guessing a shard list: `GOLDEN_UPDATE_CHECK_ONLY=1
-    GOLDEN_SHARDS=<any one shard name> node .github/scripts/golden-update.mjs`
-    is a seconds-long, chDB-free `node` call — the exact check the workflow's
-    `plan` job runs — and a failure's `run: ...` line is the definitive shard
-    set to pass as `-f shards=`, no CI round trip needed to find it. A single
-    `internal/promql` or `internal/chplan` change routinely implies most or all
-    of the other shards; verified directly (`go list -deps -test`), that is
-    real coupling — `internal/chplan` is the shared IR nearly every generator's
-    package closure reaches, and several generators' own test files import
-    `internal/promql` directly — not this check over-firing.
+  - Before running the LOCAL `just update-golden <shard>...` recipe by hand,
+    `GOLDEN_UPDATE_CHECK_ONLY=1 GOLDEN_SHARDS=<any one shard name> node
+    .github/scripts/golden-update.mjs` is a seconds-long, chDB-free dry run of
+    this same check, and a failure's `run: ...` line is the exact command to
+    retype. A single `internal/promql` or `internal/chplan` change routinely
+    implies most or all of the other shards; verified directly (`go list
+    -deps -test`), that is real coupling — `internal/chplan` is the shared IR
+    nearly every generator's package closure reaches, and several generators'
+    own test files import `internal/promql` directly — not this check
+    over-firing. There is no need to run this before dispatching
+    `update-golden.yml`, though: that workflow's own `plan` job (see
+    `manual-golden-update.mjs` below) computes and merges in the same implied
+    set automatically, so a narrow `-f shards=` guess there no longer costs a
+    round trip to correct.
 
 - **`manual-golden-update.mjs`** — `update-golden.yml`, the trusted controller
   for manually regenerating selected shards on an existing same-repository PR
@@ -2196,6 +2199,17 @@ what actually runs.
   a matrix leg publish or letting duplicate predecessor output enter its patch.
   The workflow rejects the default branch and requires `RELEASE_PAT`: a push
   made with the default `GITHUB_TOKEN` would not trigger the target PR's checks.
+  `buildPlan` treats the dispatched `shards` as a FLOOR, not the final answer:
+  it merges in whatever `impliedShards` (`lib/golden-shards.mjs`) says the
+  target branch's own diff needs before building the matrix, so a dispatch
+  that under-names the shard set still regenerates everything on the first
+  try — a `::notice::` names what got added. This is the opposite choice from
+  `golden-update.mjs`'s LOCAL recipe (which still refuses and prints the exact
+  command instead of silently doing more): there, a contributor is standing by
+  to read a refusal and retype it in seconds; here, a CI dispatch that fails
+  the old coverage check three stages downstream, after the matrix already
+  ran short, cost a ~15-minute round trip for an answer the dependency graph
+  already had.
   `cardinality` is the one exception to "one shard, one matrix row" (#2341):
   `buildPlan` excludes it from `matrix.include` and reports it separately (which
   OTHER selected shards its legs need regenerated first), because its own

--- a/.github/scripts/README.md
+++ b/.github/scripts/README.md
@@ -2174,6 +2174,17 @@ what actually runs.
     Neither relation is written down as a table of paths;
     `test/regression/golden_shard_coverage_test.go` pins that, along with the
     check firing in both directions.
+  - Before dispatching `update-golden.yml` on a pushed branch, run this same
+    check locally instead of guessing a shard list: `GOLDEN_UPDATE_CHECK_ONLY=1
+    GOLDEN_SHARDS=<any one shard name> node .github/scripts/golden-update.mjs`
+    is a seconds-long, chDB-free `node` call — the exact check the workflow's
+    `plan` job runs — and a failure's `run: ...` line is the definitive shard
+    set to pass as `-f shards=`, no CI round trip needed to find it. A single
+    `internal/promql` or `internal/chplan` change routinely implies most or all
+    of the other shards; verified directly (`go list -deps -test`), that is
+    real coupling — `internal/chplan` is the shared IR nearly every generator's
+    package closure reaches, and several generators' own test files import
+    `internal/promql` directly — not this check over-firing.
 
 - **`manual-golden-update.mjs`** — `update-golden.yml`, the trusted controller
   for manually regenerating selected shards on an existing same-repository PR

--- a/.github/scripts/golden-update.mjs
+++ b/.github/scripts/golden-update.mjs
@@ -74,13 +74,10 @@
 // one invocation surfaces every failure in that stage rather than just the
 // first; a later stage never starts once its predecessor reports a failure.
 //
-// Discovering the correct shard set WITHOUT a CI round trip: update-golden.yml
-// dispatches this exact same coverage check (GOLDEN_UPDATE_CHECK_ONLY=1) as its
-// "plan golden shards" step, against the target branch's diff against
-// origin/main. Running it here first is seconds, needs no chDB and no test
-// execution, and gives the definitive answer instead of a guess — pass any
-// single shard name as a seed (it does not have to be the right one) and read
-// the `run: ...` line the failure prints:
+// Discovering the correct shard set for the LOCAL recipe, in seconds, with no
+// chDB and no test execution: pass any single shard name as a seed (it does
+// not have to be the right one) and read the `run: ...` line the failure
+// prints:
 //
 //   GOLDEN_UPDATE_CHECK_ONLY=1 GOLDEN_SHARDS=promql node .github/scripts/golden-update.mjs
 //
@@ -89,6 +86,14 @@
 // imports (chplan is the shared IR nearly every generator's package closure
 // reaches; several generators' own test files import promql directly), so the
 // wide list is the honest answer, not a bug to route around.
+//
+// update-golden.yml's own "Verify requested shards cover the target branch
+// diff" step still runs this exact check (GOLDEN_UPDATE_CHECK_ONLY=1) against
+// `steps.plan.outputs.shards` — but that value is no longer the raw dispatch
+// input verbatim. manual-golden-update.mjs's `buildPlan` merges the same
+// implied set in BEFORE building the regeneration matrix, so a narrow
+// `-f shards=` dispatch there self-corrects on the first run instead of
+// failing this check and costing a retry.
 
 import { spawnSync } from 'node:child_process';
 import { existsSync } from 'node:fs';
@@ -98,6 +103,7 @@ import { error, log } from './lib/gh.mjs';
 import { runTagged } from './lib/spawn-tagged.mjs';
 import {
   SHARDS,
+  changedFilesFrom,
   commandsFor,
   coverageViolations,
   flattenSteps,
@@ -115,31 +121,11 @@ function splitList(raw) {
     .filter(Boolean);
 }
 
-function git(args) {
-  const r = spawnSync('git', args, { cwd: repoRoot, encoding: 'utf8' });
-  if (r.status !== 0) return null;
-  return r.stdout.split('\n').filter(Boolean);
-}
-
-/**
- * Every file this branch changed, working tree included.
- *
- * The base is the merge-base with origin/main rather than HEAD, because the
- * #1573 trap does not require the change to be uncommitted: a contributor who
- * commits a new fixture and only then runs the recipe has a clean `git diff
- * HEAD` and would sail past a working-tree-only check.
- */
+/** Every file this branch changed, working tree included. */
 function changedFiles() {
   const override = process.env.GOLDEN_UPDATE_CHANGED_FILES;
   if (override !== undefined && override !== '') return splitList(override);
-
-  const explicitBase = process.env.GOLDEN_UPDATE_BASE_REF;
-  const base =
-    explicitBase || (git(['merge-base', 'HEAD', 'origin/main']) ?? ['HEAD'])[0] || 'HEAD';
-
-  const tracked = git(['diff', '--name-only', base]) ?? [];
-  const untracked = git(['ls-files', '--others', '--exclude-standard']) ?? [];
-  return [...tracked, ...untracked];
+  return changedFilesFrom(repoRoot, { baseRef: process.env.GOLDEN_UPDATE_BASE_REF });
 }
 
 /** git-diff pathspecs for a shard's goldens (glob tails trimmed off). */

--- a/.github/scripts/golden-update.mjs
+++ b/.github/scripts/golden-update.mjs
@@ -73,6 +73,22 @@
 // shard's siblings still finish (they were already running concurrently) so
 // one invocation surfaces every failure in that stage rather than just the
 // first; a later stage never starts once its predecessor reports a failure.
+//
+// Discovering the correct shard set WITHOUT a CI round trip: update-golden.yml
+// dispatches this exact same coverage check (GOLDEN_UPDATE_CHECK_ONLY=1) as its
+// "plan golden shards" step, against the target branch's diff against
+// origin/main. Running it here first is seconds, needs no chDB and no test
+// execution, and gives the definitive answer instead of a guess — pass any
+// single shard name as a seed (it does not have to be the right one) and read
+// the `run: ...` line the failure prints:
+//
+//   GOLDEN_UPDATE_CHECK_ONLY=1 GOLDEN_SHARDS=promql node .github/scripts/golden-update.mjs
+//
+// A wide implied set for one small `internal/promql` or `internal/chplan`
+// change is not this script over-firing: `go list -deps -test` finds real
+// imports (chplan is the shared IR nearly every generator's package closure
+// reaches; several generators' own test files import promql directly), so the
+// wide list is the honest answer, not a bug to route around.
 
 import { spawnSync } from 'node:child_process';
 import { existsSync } from 'node:fs';

--- a/.github/scripts/lib/golden-shards.mjs
+++ b/.github/scripts/lib/golden-shards.mjs
@@ -32,15 +32,54 @@
 //      every spec shard; a change to `internal/logql` reaches only its own.
 //      The import graph draws that line, not a comment.
 //
-// Consumed by `.github/scripts/golden-update.mjs` (the runner behind
-// `just update-golden`) and pinned by `test/regression/golden_shard_coverage_test.go`.
+// Consumed two ways, over the same `impliedShards`/`coverageViolations` pair:
+//
+//   - `.github/scripts/golden-update.mjs` (the runner behind the LOCAL
+//     `just update-golden <shard>...`) REFUSES an under-covering set and
+//     prints the exact command to run instead — pinned by
+//     `test/regression/golden_shard_coverage_test.go`. Refusing here, rather
+//     than silently doing more than asked, keeps a contributor from being
+//     surprised by a regeneration diff wider than the shards they typed.
+//   - `.github/scripts/manual-golden-update.mjs` (`update-golden.yml`'s CI
+//     dispatch plan step) instead MERGES the implied set into the requested
+//     one before building the regeneration matrix, because there a narrow
+//     `-f shards=` guess has no contributor standing by to read a refusal and
+//     retry — it is a ~15-minute CI round trip for an answer the dependency
+//     graph already knows. `changedFilesFrom` is the "what changed" half
+//     both callers share.
 
-import { execFileSync } from 'node:child_process';
+import { execFileSync, spawnSync } from 'node:child_process';
 import { existsSync, readdirSync, statSync } from 'node:fs';
 import path from 'node:path';
 
 /** The Go module path every first-party package import starts with. */
 const MODULE_PATH = 'github.com/tsouza/cerberus';
+
+function gitLines(repoRoot, args) {
+  const r = spawnSync('git', args, { cwd: repoRoot, encoding: 'utf8' });
+  if (r.status !== 0) return null;
+  return r.stdout.split('\n').filter(Boolean);
+}
+
+/**
+ * Every file `repoRoot`'s current branch has changed relative to `baseRef`
+ * (or, when omitted, its merge-base with `defaultBranchRef`, falling back to
+ * HEAD when that merge-base cannot be resolved), working tree included.
+ *
+ * Shared by `golden-update.mjs` (the local `just update-golden` recipe) and
+ * `manual-golden-update.mjs` (the `update-golden.yml` CI dispatch's plan
+ * step) so both compute "what changed" identically — the base must be the
+ * merge-base rather than HEAD because the #1573 trap does not require the
+ * change to be uncommitted: a contributor who commits a new fixture and only
+ * then plans a regeneration has a clean `git diff HEAD` and would sail past a
+ * working-tree-only check.
+ */
+export function changedFilesFrom(repoRoot, { baseRef, defaultBranchRef = 'origin/main' } = {}) {
+  const base = baseRef || (gitLines(repoRoot, ['merge-base', 'HEAD', defaultBranchRef]) ?? ['HEAD'])[0] || 'HEAD';
+  const tracked = gitLines(repoRoot, ['diff', '--name-only', base]) ?? [];
+  const untracked = gitLines(repoRoot, ['ls-files', '--others', '--exclude-standard']) ?? [];
+  return [...tracked, ...untracked];
+}
 
 /** The TXTAR corpus root every per-fixture shard id resolves against. */
 export const SPEC_CORPUS = 'test/spec';

--- a/.github/scripts/manual-golden-update.mjs
+++ b/.github/scripts/manual-golden-update.mjs
@@ -19,6 +19,20 @@
 // cardinality` artifact the `publish` job already expects — so `publish`
 // itself needs no cardinality-specific code at all.
 //
+// `buildPlan` also MERGES in whatever `impliedShards` (golden-shards.mjs)
+// says the target branch's own diff needs, flat, on top of whatever
+// `SHARDS_INPUT` named — the caller's request is a FLOOR, not the final
+// answer. Before this, a dispatch that named too few shards sailed through
+// `plan`, built an under-covering matrix, and only failed several minutes
+// later in the "Verify requested shards cover the target branch diff" step —
+// a guess-and-wait round trip the dependency graph could have avoided
+// outright, since `plan` already has the target branch checked out with full
+// history. Unlike `golden-update.mjs`'s LOCAL recipe (which still refuses and
+// prints the exact command — a contributor typing a narrow list is standing
+// right there to read it and retry in seconds), a CI dispatch has nobody
+// watching to react to a refusal; merging the true set in up front is what
+// makes the first dispatch also the last one.
+//
 // Modes and environment:
 //
 //   node manual-golden-update.mjs dump
@@ -50,7 +64,14 @@ import path from 'node:path';
 import process from 'node:process';
 import { fileURLToPath } from 'node:url';
 
-import { SHARDS, needsChdb, resolveRequested } from './lib/golden-shards.mjs';
+import {
+  SHARDS,
+  changedFilesFrom,
+  impliedShards,
+  needsChdb,
+  orderShards,
+  resolveRequested,
+} from './lib/golden-shards.mjs';
 
 const SCRIPT = fileURLToPath(import.meta.url);
 
@@ -95,10 +116,38 @@ export function validateBranch(branch, defaultBranch) {
   return branch;
 }
 
-/** A matrix row gets every selected predecessor as regeneration context. */
-export function buildPlan(raw) {
-  const selected = parseShards(raw);
+/**
+ * The shards a dispatch's diff implies are stale, beyond whatever the caller
+ * requested — empty when `repoRoot` is omitted (the static `dump` catalogue
+ * has no branch to diff) or when nothing about the diff implies more than
+ * what was already requested. `changedFiles`, when given, REPLACES the
+ * git-derived diff outright — the same synthetic-diff escape hatch
+ * `golden-update.mjs`'s own `GOLDEN_UPDATE_CHANGED_FILES` gives its coverage
+ * check, so a test can drive this over a fixed diff without a real branch.
+ */
+function impliedBeyond(requested, { repoRoot, defaultBranchRef, changedFiles } = {}) {
+  if (!repoRoot) return [];
+  const changed = changedFiles ?? changedFilesFrom(repoRoot, { defaultBranchRef });
+  const implied = impliedShards(changed, { repoRoot });
+  return orderShards([...implied.keys()]).filter((name) => !requested.includes(name));
+}
+
+/**
+ * A matrix row gets every selected predecessor as regeneration context.
+ *
+ * `requested` is a FLOOR: `selected` is `requested` merged flat with whatever
+ * the target branch's own diff implies (see this file's header), so a caller
+ * that under-names the shard set still gets a complete regeneration on the
+ * first dispatch. `added` names exactly what the merge contributed, for the
+ * caller to log.
+ */
+export function buildPlan(raw, opts = {}) {
+  const requested = parseShards(raw);
+  const added = impliedBeyond(requested, opts);
+  const selected = orderShards([...requested, ...added]);
   return {
+    requested,
+    added,
     selected,
     matrix: {
       include: selected
@@ -242,8 +291,19 @@ function plan(env) {
     fail('RELEASE_PAT is required so the generated push triggers pull-request checks');
   }
 
-  const result = buildPlan(required(env, 'SHARDS_INPUT'));
+  const shardsInput = required(env, 'SHARDS_INPUT');
+  const result = buildPlan(shardsInput, {
+    repoRoot: targetRoot,
+    defaultBranchRef: `refs/remotes/origin/${env.DEFAULT_BRANCH}`,
+  });
   const targetSha = git(targetRoot, ['rev-parse', 'HEAD']).stdout.trim();
+
+  if (result.added.length > 0) {
+    process.stdout.write(
+      `::notice::requested shards (${shardsInput}) did not cover this branch's own diff; ` +
+        `auto-expanded to include: ${result.added.join(' ')}. Full set: ${result.selected.join(' ')}\n`,
+    );
+  }
 
   writeOutput('matrix', JSON.stringify(result.matrix), env.GITHUB_OUTPUT);
   writeOutput('shards', result.selected.join(' '), env.GITHUB_OUTPUT);

--- a/.github/scripts/manual-golden-update.test.mjs
+++ b/.github/scripts/manual-golden-update.test.mjs
@@ -17,6 +17,7 @@ import { test } from 'node:test';
 import { buildPlan, main, pathOwnedBy, validateBranch } from './manual-golden-update.mjs';
 
 const SCRIPT = fileURLToPath(new URL('./manual-golden-update.mjs', import.meta.url));
+const REPO_ROOT = fileURLToPath(new URL('../../', import.meta.url));
 
 function command(name, args, options = {}) {
   const result = spawnSync(name, args, { encoding: 'utf8', ...options });
@@ -80,6 +81,36 @@ test('cardinality is reported separately from the matrix, with its selected pred
   // cardinality alone: no predecessor shard was also selected, so its legs
   // regenerate against the corpus as committed rather than re-deriving it.
   assert.deepEqual(buildPlan('cardinality').cardinality, { predecessors: [] });
+});
+
+test('buildPlan merges the diff-implied shards into the requested set', () => {
+  // Mirrors test/regression/golden_shard_coverage_test.go's own "fires on an
+  // under-covering set" fixture: a PromQL fixture change feeds the solver
+  // decision baseline and the cardinality baseline, and its own fixture goes
+  // through the parity ledgers — so `promql` alone under-covers it. Here that
+  // must MERGE those shards in rather than fail.
+  const plan = buildPlan('promql', {
+    repoRoot: REPO_ROOT,
+    changedFiles: ['test/spec/promql/fixture_under_test.txtar'],
+  });
+  assert.deepEqual(plan.requested, ['promql']);
+  assert.deepEqual(plan.added, ['parity', 'solver', 'cardinality']);
+  assert.deepEqual(plan.selected, ['parity', 'solver', 'promql', 'cardinality']);
+});
+
+test('buildPlan adds nothing once the requested set already covers the diff', () => {
+  const plan = buildPlan('parity solver promql cardinality', {
+    repoRoot: REPO_ROOT,
+    changedFiles: ['test/spec/promql/fixture_under_test.txtar'],
+  });
+  assert.deepEqual(plan.added, []);
+  assert.deepEqual(plan.selected, ['parity', 'solver', 'promql', 'cardinality']);
+});
+
+test('buildPlan implies nothing without a repoRoot, matching the static dump catalogue', () => {
+  const plan = buildPlan('promql', { changedFiles: ['test/spec/promql/fixture_under_test.txtar'] });
+  assert.deepEqual(plan.added, []);
+  assert.deepEqual(plan.selected, ['promql']);
 });
 
 test('branch validation rejects the protected branch and ref-shaped input', () => {

--- a/Justfile
+++ b/Justfile
@@ -638,25 +638,18 @@ update-parity-enrolment-baseline:
 # it produces a zero diff (#1898), and chDB is single-threaded per process, so
 # nobody should pay for the heads they did not touch by accident.
 #
-# DO NOT GUESS a shard list for a REMOTE `gh workflow run update-golden.yml`
-# dispatch. A change touching `internal/promql` or `internal/chplan` routinely
-# implies most or all of the other shards too, because the coupling is REAL —
-# `internal/chplan` is the shared plan IR every head lowers to and nearly every
-# generator's package closure imports it; `internal/chsql`'s own generator test
-# files import `internal/promql` directly to lower through the real pipeline —
-# not an over-broad detection rule to route around. A guessed narrow list fails
-# the `plan golden shards` CI step and costs a full round trip to find out.
-# Get the definitive list FOR FREE first: the exact coverage check that CI step
-# runs is a local `node` one-liner, seconds long, no chDB, no test execution —
-# pass any single shard name as a seed (it need not be the right one) and read
-# the `run: ...` line the failure prints:
-#
-#     GOLDEN_UPDATE_CHECK_ONLY=1 GOLDEN_SHARDS=promql \
-#       node .github/scripts/golden-update.mjs
-#
-# That is the exact shard set to pass to `-f shards=`. See
-# `.github/scripts/golden-update.mjs`'s own header for the rest of its env
-# inputs (`GOLDEN_UPDATE_BASE_REF`, `GOLDEN_UPDATE_CHANGED_FILES`, ...).
+# A REMOTE `gh workflow run update-golden.yml -f shards=...` dispatch does not
+# need a precisely-guessed list: its `plan` job (manual-golden-update.mjs's
+# `buildPlan`) merges in whatever the target branch's own diff implies is
+# stale — the same derivation this recipe runs locally — BEFORE building the
+# regeneration matrix, and logs a `::notice::` naming what it added. A change
+# touching `internal/promql` or `internal/chplan` routinely implies most or
+# all of the other shards, because the coupling is REAL (`internal/chplan` is
+# the shared plan IR every head lowers to and nearly every generator's package
+# closure imports it; `internal/chsql`'s own generator test files import
+# `internal/promql` directly), so a narrow `-f shards=` guess there now
+# self-corrects on the first dispatch instead of failing a downstream CI step
+# and costing a round trip.
 #
 # The obvious hazard is that naming a shard reintroduces the trap the recipe's
 # unconditional chaining was built to close (#1573; hit by #1571 and again by

--- a/Justfile
+++ b/Justfile
@@ -638,6 +638,26 @@ update-parity-enrolment-baseline:
 # it produces a zero diff (#1898), and chDB is single-threaded per process, so
 # nobody should pay for the heads they did not touch by accident.
 #
+# DO NOT GUESS a shard list for a REMOTE `gh workflow run update-golden.yml`
+# dispatch. A change touching `internal/promql` or `internal/chplan` routinely
+# implies most or all of the other shards too, because the coupling is REAL —
+# `internal/chplan` is the shared plan IR every head lowers to and nearly every
+# generator's package closure imports it; `internal/chsql`'s own generator test
+# files import `internal/promql` directly to lower through the real pipeline —
+# not an over-broad detection rule to route around. A guessed narrow list fails
+# the `plan golden shards` CI step and costs a full round trip to find out.
+# Get the definitive list FOR FREE first: the exact coverage check that CI step
+# runs is a local `node` one-liner, seconds long, no chDB, no test execution —
+# pass any single shard name as a seed (it need not be the right one) and read
+# the `run: ...` line the failure prints:
+#
+#     GOLDEN_UPDATE_CHECK_ONLY=1 GOLDEN_SHARDS=promql \
+#       node .github/scripts/golden-update.mjs
+#
+# That is the exact shard set to pass to `-f shards=`. See
+# `.github/scripts/golden-update.mjs`'s own header for the rest of its env
+# inputs (`GOLDEN_UPDATE_BASE_REF`, `GOLDEN_UPDATE_CHANGED_FILES`, ...).
+#
 # The obvious hazard is that naming a shard reintroduces the trap the recipe's
 # unconditional chaining was built to close (#1573; hit by #1571 and again by
 # #1592): a contributor regenerates one artefact, sees zero remaining churn,


### PR DESCRIPTION
## Summary

- `update-golden.yml`'s "plan golden shards" step used to fail outright when a
  `gh workflow run update-golden.yml -f shards=...` dispatch under-named the
  shard set the target branch's own diff implied was stale, costing a full CI
  round trip (~15 minutes) to retype the exact command the failure already
  printed. This happened repeatedly across this session's parallel work.
- `manual-golden-update.mjs`'s `buildPlan` now treats the dispatched `shards`
  as a **floor, not the final answer**: it computes the same implied-shard set
  `impliedShards` (`lib/golden-shards.mjs`) already derives from the target
  branch's diff, and merges it in **before** building the regeneration
  matrix — so a narrow dispatch self-corrects and regenerates the full correct
  set on the first run. A `::notice::` names what got auto-added.
  `changedFilesFrom` is the new shared "what changed" derivation both this and
  `golden-update.mjs`'s own local recipe now use, replacing the duplicated
  git-diff logic that used to live only in `golden-update.mjs`.
- The **local** `just update-golden <shard>...` recipe keeps its existing
  refusal behavior unchanged (a contributor typing a narrow list is standing
  right there to read the failure and retype it in seconds) — only the CI
  dispatch path, which has nobody watching to react to a refusal, switches to
  auto-merging. `test/regression/golden_shard_coverage_test.go` (the pin for
  that local refusal) is untouched and still green.
- Also updates `.github/scripts/README.md` and the `Justfile` recipe comment
  (previously documenting only the manual pre-check workaround) to describe
  the new auto-merge behavior.

## Test plan

- `node --test .github/scripts/manual-golden-update.test.mjs` — 11/11 pass,
  including 3 new cases covering the merge (under-covering input, already-
  covering input, and no-`repoRoot` backward compatibility).
- `node --test .github/scripts/*.test.mjs` — 820/820 pass across the whole
  `.github/scripts` suite.
- `go test -run '^TestUpdateGoldenRefusesAnUncoveredShardSet$|^TestUpdateGoldenHasNoDefaultShard$|^TestGoldenShardRelationIsDerived$' ./test/regression/...`
  — unchanged, still green: the local recipe's refusal behavior is untouched.
- `just lint-md` — clean.
