### PR TITLE
fix(promql): drop native-histogram samples for sort()/sort_desc()

### DIFF
--- a/internal/promql/sort.go
+++ b/internal/promql/sort.go
@@ -36,9 +36,27 @@ const naturalSortKeyPadWidth = 20
 // sample, they reorder existing ones — so no MetricName rewrite applies
 // (unlike the instant-math fns); the inner plan's columns flow through
 // the OrderBy unchanged.
+//
+// Prom's shared entry point (prometheus/promql/functions.go::funcSort /
+// funcSortDesc) starts from `filterFloats(vectorVals[0])`, which drops
+// every sample whose `.H` field is set before sorting the remainder —
+// the same "process only float samples" rule the instant-math functions
+// (#2221) and the clamp family (#2345) apply. `sort`/`sort_desc` never
+// got the same treatment, so a bare exp-histogram selector argument fell
+// through to the generic dispatch and hit the catch-all rejection
+// instead of Prom's drop-and-answer-empty semantics (#2456). Checking
+// [lowerExpHistogramValuedShape] first and answering via
+// [dropExpHistogramSamples] closes that gap: an all-histogram input
+// sorts to an (correctly empty) float vector rather than erroring.
 func lowerSort(c *parser.Call, s schema.Metrics, ctx lowerCtx) (chplan.Node, error) {
 	if len(c.Args) != 1 {
 		return nil, fmt.Errorf("promql: %s expects 1 argument, got %d", c.Func.Name, len(c.Args))
+	}
+	if hist, ok, err := lowerExpHistogramValuedShape(c.Args[0], s, ctx); ok {
+		if err != nil {
+			return nil, err
+		}
+		return dropExpHistogramSamples(hist, s), nil
 	}
 	inner, err := lower(c.Args[0], s, ctx)
 	if err != nil {

--- a/internal/promql/sort_exp_histogram_test.go
+++ b/internal/promql/sort_exp_histogram_test.go
@@ -1,0 +1,56 @@
+package promql_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/prometheus/prometheus/promql/parser"
+
+	"github.com/tsouza/cerberus/internal/promql"
+	"github.com/tsouza/cerberus/internal/schema"
+)
+
+// TestLower_ExpHistogram_SortFamilyDropsSamples pins issue #2456: reference
+// Prometheus's funcSort/funcSortDesc (promql/functions.go) both start from
+// filterFloats(vectorVals[0]), which drops every sample whose H field is
+// set before sorting the remainder — the same "process only float samples"
+// rule the instant-math functions (#2221) and the clamp family (#2345)
+// apply. sort()/sort_desc() never got the same treatment: lowerSort routed
+// its vector arg straight through the generic lower() dispatch with no
+// lowerExpHistogramValuedShape check, so a bare exp-histogram selector
+// argument fell through to expHistogramSelectorRouting's catch-all
+// rejection instead of Prom's drop-and-answer-empty semantics.
+func TestLower_ExpHistogram_SortFamilyDropsSamples(t *testing.T) {
+	t.Parallel()
+
+	s := schema.DefaultOTelMetrics()
+	p := parser.NewParser(parser.Options{})
+	at := time.Date(2026, 1, 1, 0, 0, 1, 0, time.UTC)
+
+	queries := []string{
+		`sort(latency_exp_hist)`,
+		`sort_desc(latency_exp_hist)`,
+
+		// The consumer sees histogram-valued results, not only selectors.
+		`sort(sum(latency_exp_hist))`,
+		`sort_desc(rate(latency_exp_hist[5m]))`,
+	}
+
+	for _, query := range queries {
+		query := query
+		t.Run(query, func(t *testing.T) {
+			t.Parallel()
+
+			expr, err := p.ParseExpr(query)
+			if err != nil {
+				t.Fatalf("ParseExpr(%q): %v", query, err)
+			}
+			plan, err := promql.LowerAt(context.Background(), expr, s, at, at)
+			if err != nil {
+				t.Fatalf("LowerAt(%q): %v", query, err)
+			}
+			assertEmptyFloatProjection(t, plan)
+		})
+	}
+}

--- a/test/rejection-parity/catalogue/internal__promql__lower.go.json
+++ b/test/rejection-parity/catalogue/internal__promql__lower.go.json
@@ -94,8 +94,8 @@
       "site": "internal/promql/lower.go:expHistogramSelectorRouting#bf746b59",
       "message": "promql: %q is an exponential histogram metric; only a bare %q selector, sum()/avg()/count() over one, rate()/increase()/delta()/irate()/idelta()/sum_over_time()/avg_over_time()/resets()/changes() over one, histogram_quantile(), histogram_count(), histogram_sum(), and the %q/%q companion selectors are supported",
       "class": "divergence",
-      "trigger_query": "sort(demo_latency_exp_hist)",
-      "tracking_issue": 2456,
+      "trigger_query": "sort_by_label(demo_latency_exp_hist, \"job\")",
+      "tracking_issue": 2462,
       "evidence": {
         "guard": [
           "past returning if bare, col, hasCompanion := s.HistogramCompanionColumn(metricName); hasCompanion \u0026\u0026 s.IsExpHistogramMetric(bare) \u0026\u0026 s.ExpHistogramTable != \"\"",


### PR DESCRIPTION
## Summary

Closes #2456 — `sort(demo_latency_exp_hist)` (and `sort_desc(...)`) hard-rejected a raw
exponential-histogram selector instead of answering with reference-matching drop semantics.

Reference Prometheus's shared `funcSort`/`funcSortDesc` (`promql/functions.go`) both start from
`filterFloats(vectorVals[0])`, which drops every sample whose `H` field is set before sorting the
remainder — the same "process only float samples" rule `simpleFloatFunc` already applies for
`abs`/`ceil`/`floor`/`round`/etc (issue #2221) and the clamp family applies (#2345). `lowerSort`
(`internal/promql/sort.go`) never routed its vector argument through
`lowerExpHistogramValuedShape`, so a histogram-valued selector fell through to `lower()`'s generic
dispatch and hit `expHistogramSelectorRouting`'s catch-all rejection (`internal/promql/lower.go`)
instead.

**Fix**: `lowerSort` now checks `lowerExpHistogramValuedShape` on its vector argument before the
generic `lower()` dispatch, mirroring the guard `lowerInstantFn`/`lowerClamp` already apply — a
histogram-valued argument now answers an empty float vector via `dropExpHistogramSamples`, for
both `sort` and `sort_desc`, including when the histogram value is produced by a nested shape
(`sum(...)`, `rate(...)`) rather than a bare selector.

`sort_by_label`/`sort_by_label_desc` (`lowerSortByLabel`) share the same gap but were explicitly
out of scope for this issue's own trigger query; filed #2462 to track that separately.

**Rejection-parity catalogue**: `expHistogramSelectorRouting`'s single catalogued divergence entry
(`test/rejection-parity/catalogue/internal__promql__lower.go.json`) used
`sort(demo_latency_exp_hist)` as its trigger query; that trigger now lowers successfully, so it
would no longer exercise the site. Verified the next reachable trigger at this exact site is
`sort_by_label(demo_latency_exp_hist, "job")` — probed directly against `promql.LowerAt` on this
branch pre-fix and confirmed it still returns `expHistogramSelectorRouting`'s exact rejection
message. Filed #2462 to track that specific gap and repointed the catalogue entry's
`trigger_query`/`tracking_issue` at it, following the same rotation this site's entry has gone
through before (#1801 → #2087 → #2189 → #2224 → #2225 → #2226 → #2331 → #2339 → #2342 → #2345 →
#2443 → now #2462).

## Test plan

- `go test -run '^TestLower_ExpHistogram_SortFamilyDropsSamples$' ./internal/promql/` — new unit
  test pinning `sort`/`sort_desc` over a bare exp-histogram selector and over nested
  histogram-valued shapes (`sum(...)`, `rate(...)`), asserting each answers the same
  empty-float-projection shape `abs`/`ceil`/`clamp`/etc already do.
- `go test -count=1 ./internal/promql/...` — full package, no regressions.
- `go test -run '^TestCatalogueIsRegenerable$|^TestCatalogueEntriesAreClassified$|^TestRejectionTriggersExerciseSites$|^TestParityCorpusMatchesCatalogue$' ./test/rejection-parity/...`
  — the catalogue's own self-checks: the new `sort_by_label(demo_latency_exp_hist, "job")` trigger
  still reaches `expHistogramSelectorRouting`'s exact message, and the parity corpus stays derived
  1:1 from the catalogue.
- `go test -count=1 ./test/rejection-parity/... ./test/surface-parity/...` — clean.
- `node .github/scripts/forbid-sql-raw.mjs` — clean (no chsql touched by this change, sanity check
  only).
- `go build ./internal/promql/... ./test/rejection-parity/...` — clean.

No `test/spec/` TXTAR golden touches this shape — the sibling `abs`/`ceil`/etc and
`clamp`/`clamp_min`/`clamp_max` drop-semantics fixes (#2221, #2345) are likewise pinned only by a
Go unit test, not a TXTAR fixture — so no `just update-golden` / `update-golden.yml` run was
needed.

Closes #2456.
