### PR TITLE
perf(schema): index AggregationTemporality to prune the rate() split's redundant scan

### DIFF
--- a/.github/scripts/lib/golden-shards.mjs
+++ b/.github/scripts/lib/golden-shards.mjs
@@ -215,7 +215,15 @@ export const SHARDS = {
   migration: {
     stage: STAGE_PRE,
     recipe: 'migration-golden',
-    goldens: ['test/e2e/migration/archetypes/*/expected'],
+    // migration-golden's MIGRATION_UPDATE_GOLDENS=1 run rewrites BOTH the
+    // per-archetype corpus goldens AND the MIG-10 rendered-schema goldens
+    // (test/e2e/migration/expected/schema/*.sql, one per schemaCases entry
+    // in test/e2e/migration/steps/schema.go) — a DDL-shape change (a new
+    // ADD PROJECTION / ADD INDEX ALTER, a retention/engine default change)
+    // moves the latter without touching a single archetype fixture, so both
+    // paths must be declared or the schema half fails ownership here even
+    // though the SAME recipe regenerated it.
+    goldens: ['test/e2e/migration/archetypes/*/expected', 'test/e2e/migration/expected/schema'],
     corpus: ['test/e2e/migration/archetypes'],
     // The Tier-0 harness does not emit the explain reports in-process: it
     // spawns the built `cerberus migrate explain` and captures its output

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -1054,6 +1054,63 @@ costs — on a wide-`Attributes` table the read side dominates. Materialize one
 projection at a time and watch `system.mutations` before starting the next so
 a maintenance window isn't saturated by both at once.
 
+### AggregationTemporality skip index
+
+Auto-create also installs a small **data-skipping index** on the sum and
+histogram fact tables:
+
+```sql
+ALTER TABLE <db>.otel_metrics_sum       ADD INDEX IF NOT EXISTS idx_agg_temporality AggregationTemporality TYPE minmax GRANULARITY 1
+ALTER TABLE <db>.otel_metrics_histogram ADD INDEX IF NOT EXISTS idx_agg_temporality AggregationTemporality TYPE minmax GRANULARITY 1
+```
+
+Unlike the metadata projections above, this is a `minmax` **skip index**, not
+a stored second copy of the table — it costs a small amount of per-granule
+`[min, max]` metadata, not additional table storage.
+
+**Why it exists (issue #2458).** A range-mode `rate()`/`increase()` window
+over a temporality-bearing counter can split into a native
+`timeSeriesRateToGrid` arm (fed only non-DELTA rows) and a fan-out arm (fed
+only DELTA rows) — see `NativeRateLowerer.LowerRate` in
+`internal/promql/lower_strategy.go`. Both arms scan the SAME base table with
+the SAME `MetricName`/`Attributes` predicate, differing only in a trailing
+`AggregationTemporality` conjunct. That column is not part of the table's
+`ORDER BY` (`MetricName, Attributes, ServiceName, TimeUnix`), so without a
+skip index ClickHouse cannot prune a single granule on it and reads every
+matching row from BOTH arms — a confirmed, reproducible 2.00x `read_rows`
+ratio against table size, measured on real production-shaped data. Real OTel
+deployments set `AggregationTemporality` once per exporter configuration, so
+a given series' samples land in temporality-homogeneous runs almost always;
+the minmax index lets ClickHouse recognize a homogeneous granule and skip it
+entirely for whichever arm's predicate does not match, without requiring any
+change to the plan shape or the table's `ORDER BY`. The same index also
+prunes the ordinary single-arm case: any plain scan carrying an
+`AggregationTemporality` predicate (the fan-out emitter's own per-row branch,
+or a future consumer) benefits identically.
+
+`ADD INDEX IF NOT EXISTS` is metadata-only and idempotent, so the auto-create
+hook (re)applies it safely on every boot, covering both freshly-created and
+pre-existing tables. **New parts written after the ALTER carry the index
+automatically; existing parts are not back-filled by `ADD INDEX` alone.**
+
+#### One-time `MATERIALIZE INDEX` back-fill runbook
+
+To back-fill existing parts immediately on a deployment that predates the
+index, run the one-time materialize per table (a background mutation,
+non-blocking for reads):
+
+```sql
+ALTER TABLE <db>.otel_metrics_sum       MATERIALIZE INDEX idx_agg_temporality;
+ALTER TABLE <db>.otel_metrics_histogram MATERIALIZE INDEX idx_agg_temporality;
+```
+
+`MATERIALIZE` is intentionally **not** issued by the auto-create hook — it
+rewrites index metadata for every existing part and belongs in a deliberate
+maintenance window, not the boot path. Track progress in `system.mutations`
+(the `is_done` / `parts_to_do` columns). A `MATERIALIZE INDEX` mutation only
+reads and rewrites the indexed column's marks, not the whole part, so it is
+far cheaper than a `MATERIALIZE PROJECTION` over the same table.
+
 ### Startup requirements preflight
 
 `CERBERUS_REQUIREMENTS_CHECK` (**on by default**) runs a boot-time

--- a/internal/chsql/ddl.go
+++ b/internal/chsql/ddl.go
@@ -694,3 +694,82 @@ func (a *AddColumnBuilder) frag() Frag {
 func (a *AddColumnBuilder) SQL() string {
 	return RenderDDL(a.frag())
 }
+
+// --- ALTER TABLE ... ADD INDEX surface ---
+//
+// AddIndexBuilder renders
+// `ALTER TABLE [<db>.]<table> [ON CLUSTER x] ADD INDEX IF NOT EXISTS <name>
+// <expr> TYPE <type> GRANULARITY <n>`, the statement that installs a
+// ClickHouse data-skipping index on a column already present on a table
+// cerberus does not otherwise own the CREATE TABLE body of (the upstream
+// OTel exporter template — see the package doc comment). Adding a skip
+// index is metadata-only for NEW parts; it does not reorder or duplicate
+// existing data (unlike a PROJECTION, which stores a second physical copy),
+// but existing parts need a separate `ALTER TABLE ... MATERIALIZE INDEX`
+// backfill to benefit retroactively — see docs/operations.md.
+//
+// Like the other DDL builders it binds no positional `?` values, so SQL
+// renders through RenderDDL.
+
+// AddIndexBuilder builds an ALTER TABLE ADD INDEX statement.
+type AddIndexBuilder struct {
+	database    string // "" => unqualified table reference
+	table       string
+	name        string
+	cluster     string // "" => no ON CLUSTER clause
+	expr        Frag
+	indexType   string
+	granularity int
+}
+
+// AlterTableAddIndex starts an ADD INDEX builder installing a data-skipping
+// index named <name> over expr on [<database>.]<table>, of the given
+// ClickHouse index type ("minmax", "set(N)", "bloom_filter", …) and
+// GRANULARITY. An empty database emits no qualifier, so a table the
+// connection's own database owns is referenced bare.
+func AlterTableAddIndex(database, table, name string, expr Frag, indexType string, granularity int) *AddIndexBuilder {
+	return &AddIndexBuilder{database: database, table: table, name: name, expr: expr, indexType: indexType, granularity: granularity}
+}
+
+// OnCluster adds an `ON CLUSTER <name>` clause so the ALTER replicates the
+// same way the CREATE statements do under a classic ON CLUSTER deployment.
+// A Replicated database replicates the DDL itself and needs no clause.
+func (a *AddIndexBuilder) OnCluster(name string) *AddIndexBuilder {
+	a.cluster = name
+	return a
+}
+
+// frag assembles the statement from typed pieces: keyword tokens via
+// ddlToken, bare database/table/index identifiers via BareIdent, the
+// indexed expression via the caller's Frag, the index type via BareIdent
+// (a fixed ClickHouse type keyword, never data), the GRANULARITY value via
+// InlineLit, and the optional ON CLUSTER clause via the typed constructor —
+// no raw token is written here.
+func (a *AddIndexBuilder) frag() Frag {
+	return func(b *Builder) {
+		ddlToken("ALTER TABLE ")(b)
+		if a.database != "" {
+			BareIdent(a.database)(b)
+			ddlToken(".")(b)
+		}
+		BareIdent(a.table)(b)
+		if a.cluster != "" {
+			ddlToken(" ")(b)
+			OnCluster(a.cluster)(b)
+		}
+		ddlToken(" ADD INDEX IF NOT EXISTS ")(b)
+		BareIdent(a.name)(b)
+		ddlToken(" ")(b)
+		a.expr(b)
+		ddlToken(" TYPE ")(b)
+		BareIdent(a.indexType)(b)
+		ddlToken(" GRANULARITY ")(b)
+		InlineLit(a.granularity)(b)
+	}
+}
+
+// SQL renders the ALTER TABLE ADD INDEX statement to ClickHouse text via
+// RenderDDL (which asserts the no-positional-bindings DDL invariant).
+func (a *AddIndexBuilder) SQL() string {
+	return RenderDDL(a.frag())
+}

--- a/internal/chsql/ddl_test.go
+++ b/internal/chsql/ddl_test.go
@@ -355,6 +355,47 @@ func TestAlterTableAddColumn(t *testing.T) {
 	}
 }
 
+// TestAlterTableAddIndex pins the ADD INDEX statement: the fully-qualified
+// (or bare) <db>.<table>, the idempotent IF NOT EXISTS guard, the indexed
+// expression, the TYPE and GRANULARITY clauses, and the optional ON CLUSTER
+// clause. The statement carries no positional args.
+func TestAlterTableAddIndex(t *testing.T) {
+	cases := []struct {
+		name string
+		stmt *AddIndexBuilder
+		want string
+	}{
+		{
+			"unqualified_table",
+			AlterTableAddIndex("", "otel_metrics_sum", "idx_agg_temporality", Col("AggregationTemporality"), "minmax", 1),
+			"ALTER TABLE otel_metrics_sum ADD INDEX IF NOT EXISTS idx_agg_temporality `AggregationTemporality` TYPE minmax GRANULARITY 1",
+		},
+		{
+			"qualified_table",
+			AlterTableAddIndex("otel", "otel_metrics_histogram", "idx_agg_temporality", Col("AggregationTemporality"), "minmax", 1),
+			"ALTER TABLE otel.otel_metrics_histogram ADD INDEX IF NOT EXISTS idx_agg_temporality `AggregationTemporality` TYPE minmax GRANULARITY 1",
+		},
+		{
+			"on_cluster",
+			AlterTableAddIndex("otel", "otel_metrics_sum", "idx_agg_temporality", Col("AggregationTemporality"), "minmax", 1).OnCluster("prod"),
+			"ALTER TABLE otel.otel_metrics_sum ON CLUSTER `prod` " +
+				"ADD INDEX IF NOT EXISTS idx_agg_temporality `AggregationTemporality` TYPE minmax GRANULARITY 1",
+		},
+		{
+			"different_granularity",
+			AlterTableAddIndex("", "otel_metrics_sum", "idx_agg_temporality", Col("AggregationTemporality"), "minmax", 4),
+			"ALTER TABLE otel_metrics_sum ADD INDEX IF NOT EXISTS idx_agg_temporality `AggregationTemporality` TYPE minmax GRANULARITY 4",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := tc.stmt.SQL(); got != tc.want {
+				t.Errorf("SQL() = %q; want %q", got, tc.want)
+			}
+		})
+	}
+}
+
 // TestQueryBuilderHaving pins the HAVING clause render: it follows GROUP BY,
 // precedes ORDER BY, and AND-joins multiple conditions. HAVING (not WHERE) is
 // what lets the metric-name enumeration route to the aggregating projection.

--- a/internal/schema/ddl/ddl.go
+++ b/internal/schema/ddl/ddl.go
@@ -579,6 +579,17 @@ func renderSignal(cfg Config, s Signal) ([]string, error) {
 				stmts = append(stmts, renderAddMetricProjection(cfg, table, p, hasMonotonic))
 			}
 		}
+		// The AggregationTemporality skip index applies only to the two
+		// tables that carry the column AND that a rate()/increase() range
+		// window can route to natively (see
+		// internal/promql.rangeVectorCounterTemporalityColumn) — the sum and
+		// histogram tables. Gauge never carries AggregationTemporality;
+		// exp_histogram carries it but sits outside every temporality-aware
+		// native/fan-out routing path today (see #1628's scope note), so
+		// indexing it would add write-path cost the read side never spends.
+		for _, table := range []string{cfg.Tables.MetricsSum, cfg.Tables.MetricsHistogram} {
+			stmts = append(stmts, renderAddTemporalityIndex(cfg, table))
+		}
 		return stmts, nil
 	case Logs:
 		logs, err := renderLogsTable(cfg)
@@ -636,6 +647,10 @@ const (
 	metricAttributesColumn  = "Attributes"
 	metricDescriptionColumn = "MetricDescription"
 	metricUnitColumn        = "MetricUnit"
+	// aggregationTemporalityColumn is the OTel-CH exporter's fixed
+	// AggregationTemporality column on the sum and histogram tables — see
+	// renderAddTemporalityIndex.
+	aggregationTemporalityColumn = "AggregationTemporality"
 	// isMonotonicColumn is the sum table's fixed OTel-CH exporter column
 	// distinguishing monotonic Sums (Prom counters) from non-monotonic Sums /
 	// UpDownCounters (Prom gauges — see internal/api/prom/metadata.go). It
@@ -710,6 +725,64 @@ var metricCatalogProjections = []metricProjection{
 // both freshly-created and pre-existing tables.
 func renderAddMetricProjection(cfg Config, table string, p metricProjection, hasMonotonic bool) string {
 	stmt := chsql.AlterTableAddProjection(cfg.Database, table, p.name, p.body(hasMonotonic))
+	if cfg.Cluster != "" {
+		stmt.OnCluster(cfg.Cluster)
+	}
+	return stmt.SQL()
+}
+
+const (
+	// temporalityIndexName is the ALTER TABLE ADD INDEX identifier for the
+	// AggregationTemporality skip index — see renderAddTemporalityIndex.
+	temporalityIndexName = "idx_agg_temporality"
+	// temporalityIndexGranularity is the number of index-granule marks per
+	// skip-index block: GRANULARITY 1 gives the finest possible skip
+	// resolution (one mark per table index_granularity, 8192 rows by
+	// default), maximising the odds that a granule ClickHouse can prove is
+	// single-temporality gets skipped. A coarser granularity would only
+	// widen each mark's [min,max] range across more granules, making a
+	// skip less likely without saving anything else — minmax marks cost
+	// bytes, not read time, so there is no tradeoff pushing the other way.
+	temporalityIndexGranularity = 1
+)
+
+// renderAddTemporalityIndex builds the idempotent ADD INDEX ALTER installing
+// a minmax skip index on the AggregationTemporality column of one metrics
+// fact table.
+//
+// Issue #2458: NativeRateLowerer.LowerRate splits a temporality-bearing
+// rate()/increase() range window into a CUMULATIVE arm (the native
+// timeSeriesRateToGrid aggregate, fed only non-DELTA rows) and a DELTA arm
+// (the fan-out emitter, fed only DELTA rows) — chplan.UnionAll{
+// RangeWindowGridNative, RangeWindow}, the exact shape #2114/#2117/#2120's
+// solver routing was built to slice and re-anchor. Both arms scan the SAME
+// base table with the SAME MetricName/Attributes predicate, differing only
+// in a trailing AggregationTemporality conjunct — a column absent from the
+// table's ORDER BY, so ClickHouse cannot use the primary key to skip
+// granules on it and reads every matching row from BOTH arms (a confirmed,
+// reproducible 2.00x read_rows ratio on real production-shaped data). This
+// is what a minmax skip index fixes: real OTel deployments set
+// AggregationTemporality once per exporter configuration, so a given
+// series' samples land in temporality-homogeneous runs almost always
+// (confirmed empirically against ClickHouse 25.8 — an all-CUMULATIVE
+// table's `AggregationTemporality = <DELTA>` scan skips every one of its
+// granules once this index exists). The plan-level split's EXISTENCE is
+// deliberately left unchanged (see the issue's own scope note): only the
+// redundant physical read shrinks, addressed entirely at the schema layer
+// with no chplan/chsql/promql change and hence no risk to the solver
+// routing tests that depend on the split's shape.
+//
+// Adding a skip index is metadata-only for NEW parts — unlike ADD
+// PROJECTION it does not store a second physical copy of the table — but
+// EXISTING parts need a one-time `ALTER TABLE ... MATERIALIZE INDEX
+// idx_agg_temporality` backfill to benefit retroactively; see
+// docs/operations.md. ON CLUSTER is threaded so the ALTER replicates the
+// same way the CREATE statements do. ADD INDEX IF NOT EXISTS is idempotent,
+// so the same Apply path covers both freshly-created and pre-existing
+// tables.
+func renderAddTemporalityIndex(cfg Config, table string) string {
+	stmt := chsql.AlterTableAddIndex(cfg.Database, table, temporalityIndexName,
+		chsql.Col(aggregationTemporalityColumn), "minmax", temporalityIndexGranularity)
 	if cfg.Cluster != "" {
 		stmt.OnCluster(cfg.Cluster)
 	}

--- a/internal/schema/ddl/ddl_test.go
+++ b/internal/schema/ddl/ddl_test.go
@@ -9,7 +9,9 @@ import (
 // TestRenderSignal_Metrics checks all five metrics templates render with
 // the right table names + engine + database substituted in, followed by the
 // curated registry's idempotent ADD PROJECTION ALTERs — proj_series +
-// proj_metric_metadata on each of the gauge/sum/histogram catalog tables.
+// proj_metric_metadata on each of the gauge/sum/histogram catalog tables —
+// and the AggregationTemporality skip-index ALTERs on the sum/histogram
+// tables (see renderAddTemporalityIndex, issue #2458).
 func TestRenderSignal_Metrics(t *testing.T) {
 	cfg := Config{}.withDefaults()
 
@@ -17,10 +19,12 @@ func TestRenderSignal_Metrics(t *testing.T) {
 	if err != nil {
 		t.Fatalf("renderSignal(Metrics): %v", err)
 	}
-	// 5 CREATE TABLE + (3 catalog tables × 2 curated projections) ADD PROJECTION.
+	// 5 CREATE TABLE + (3 catalog tables × 2 curated projections) ADD
+	// PROJECTION + (2 temporality-bearing tables) ADD INDEX.
 	const wantCreates = 5
+	const wantTemporalityIndex = 2
 	wantProj := 3 * len(metricCatalogProjections)
-	if got, want := len(stmts), wantCreates+wantProj; got != want {
+	if got, want := len(stmts), wantCreates+wantProj+wantTemporalityIndex; got != want {
 		t.Fatalf("metrics: got %d statements, want %d", got, want)
 	}
 	wantTables := []string{
@@ -107,6 +111,21 @@ func TestRenderSignal_Metrics(t *testing.T) {
 	histAll := strings.Join(proj[histIdx:histIdx+len(metricCatalogProjections)], "\n")
 	if strings.Contains(histAll, "IsMonotonic") {
 		t.Errorf("otel_metrics_histogram projections must not reference IsMonotonic (no such column):\n%s", histAll)
+	}
+
+	// The temporality skip-index ALTERs trail the projection ALTERs, one per
+	// temporality-bearing table in sum-then-histogram order — see #2458.
+	tempIdx := stmts[wantCreates+wantProj:]
+	if len(tempIdx) != wantTemporalityIndex {
+		t.Fatalf("metrics temporality index: got %d statements, want %d", len(tempIdx), wantTemporalityIndex)
+	}
+	wantTempTables := []string{"otel_metrics_sum", "otel_metrics_histogram"}
+	for i, table := range wantTempTables {
+		want := "ALTER TABLE default." + table +
+			" ADD INDEX IF NOT EXISTS idx_agg_temporality `AggregationTemporality` TYPE minmax GRANULARITY 1"
+		if tempIdx[i] != want {
+			t.Errorf("metrics temporality index[%d]: got %q, want %q", i, tempIdx[i], want)
+		}
 	}
 }
 

--- a/internal/schema/ddl/idempotency_test.go
+++ b/internal/schema/ddl/idempotency_test.go
@@ -273,15 +273,17 @@ func TestRenderSignal_TracesOnlySubset(t *testing.T) {
 
 // TestRenderSignal_MetricsOnlySubset confirms the five metrics CREATE
 // statements (plus the curated registry's ADD PROJECTION ALTERs on the three
-// catalog tables) render without leaking logs or traces tables.
+// catalog tables and the AggregationTemporality ADD INDEX ALTERs on the two
+// temporality-bearing tables) render without leaking logs or traces tables.
 func TestRenderSignal_MetricsOnlySubset(t *testing.T) {
 	cfg := Config{}.withDefaults()
 	stmts, err := renderSignal(cfg, Metrics)
 	if err != nil {
 		t.Fatalf("renderSignal(Metrics): %v", err)
 	}
-	// 5 CREATE TABLE + (3 catalog tables × len(registry)) ADD PROJECTION.
-	wantStmts := 5 + 3*len(metricCatalogProjections)
+	// 5 CREATE TABLE + (3 catalog tables × len(registry)) ADD PROJECTION +
+	// 2 temporality-bearing tables ADD INDEX.
+	wantStmts := 5 + 3*len(metricCatalogProjections) + 2
 	if len(stmts) != wantStmts {
 		t.Fatalf("metrics subset: got %d statements; want %d", len(stmts), wantStmts)
 	}

--- a/internal/schema/ddl/temporality_index_skip_chdb_test.go
+++ b/internal/schema/ddl/temporality_index_skip_chdb_test.go
@@ -1,0 +1,214 @@
+//go:build chdb
+
+// This is the offline proof, against the package's own rendered production
+// DDL, that the AggregationTemporality skip index renderAddTemporalityIndex
+// installs (issue #2458) actually lets ClickHouse prune granules — not a
+// text-parse of the ALTER string, which would prove nothing about query-time
+// behavior. It mirrors trace_id_index_probe_chdb_test.go's methodology
+// (live EXPLAIN indexes=1, not a hardcoded assertion) for the same reason:
+// a skip index can be declared and still go unused if the WHERE predicate
+// shape doesn't match it, or if the underlying data isn't granule-homogeneous
+// enough for a minmax mark to prove anything.
+package ddl
+
+import (
+	"database/sql"
+	"fmt"
+	"strings"
+	"testing"
+
+	_ "github.com/chdb-io/chdb-go/chdb/driver"
+)
+
+// temporalityProbeRowsPerGranule seeds enough rows to span several real
+// index granules at the production otel_metrics_sum table's declared
+// `SETTINGS index_granularity=8192` (see metrics_sum_table.sql), so the
+// probe exercises the SAME granule size a real deployment would, rather
+// than a scaled-down stand-in that might hide a granularity-dependent bug.
+const temporalityProbeRowsPerGranule = 8192
+
+// temporalityProbeGranules is the number of full granules
+// temporalityProbeAllCumulativeRows seeds.
+const temporalityProbeGranules = 4
+
+// openMetricsProbeChDB renders + applies the package's own real production
+// Metrics DDL (via the same renderSignal entry point TestRenderSignal_Metrics
+// exercises) — CREATE TABLE, the curated projections, AND the
+// AggregationTemporality skip index this issue adds — against a fresh
+// ephemeral chDB session, never a hand-copied DDL string. Every CREATE TABLE
+// IF NOT EXISTS is promoted to CREATE OR REPLACE TABLE so the probe starts
+// from an empty table each run (see promoteCreateTable's doc comment for why
+// that's safe here and wrong for a real cluster).
+func openMetricsProbeChDB(t *testing.T) (db *sql.DB, cfg Config) {
+	t.Helper()
+
+	db, err := sql.Open("chdb", "")
+	if err != nil {
+		t.Fatalf("open chdb: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	if err := db.Ping(); err != nil {
+		t.Fatalf("ping chdb: %v", err)
+	}
+
+	cfg = Config{}.withDefaults()
+	stmts, err := renderSignal(cfg, Metrics)
+	if err != nil {
+		t.Fatalf("renderSignal(Metrics): %v", err)
+	}
+	for _, stmt := range stmts {
+		if strings.HasPrefix(stmt, "CREATE TABLE IF NOT EXISTS") {
+			stmt = promoteCreateTable(stmt)
+		}
+		if _, err := db.Exec(stmt); err != nil {
+			t.Fatalf("apply DDL:\n%s\nerr: %v", stmt, err)
+		}
+	}
+	return db, cfg
+}
+
+// temporalityProbeAllCumulativeRows returns the VALUES tuples for
+// temporalityProbeGranules*temporalityProbeRowsPerGranule rows, all sharing
+// ONE MetricName and ALL carrying CUMULATIVE (2) AggregationTemporality —
+// the realistic, dominant real-world shape #2458 describes: a given series'
+// AggregationTemporality is set once per exporter configuration, so its
+// samples land in temporality-homogeneous runs almost always. TimeUnix
+// increments by one second per row so ORDER BY (MetricName, Attributes,
+// ServiceName, ...) does not need to reshuffle insertion order.
+func temporalityProbeAllCumulativeRows(metricName string) string {
+	var b strings.Builder
+	n := temporalityProbeGranules * temporalityProbeRowsPerGranule
+	for i := range n {
+		if i > 0 {
+			b.WriteString(",\n")
+		}
+		fmt.Fprintf(&b, "('%s', map(), '', toDateTime64('2026-01-01 00:00:00', 9) + toIntervalSecond(%d), %d, 2, true)",
+			metricName, i, i)
+	}
+	return b.String()
+}
+
+// TestTemporalityIndex_PrunesAllCumulativeGranules is the base case #2458
+// exists to fix: a sum-table series whose every sample is CUMULATIVE (the
+// overwhelmingly common real-world shape) must let ClickHouse prune EVERY
+// granule for a DELTA-only predicate — the exact predicate
+// NativeRateLowerer.LowerRate's fan-out (DELTA) arm issues — while the
+// CUMULATIVE-only predicate the native arm issues must still read every
+// granule (nothing to prune: every row matches it). Both properties are
+// asserted from a live EXPLAIN indexes=1 plan, not a text-parse of the ALTER
+// string.
+func TestTemporalityIndex_PrunesAllCumulativeGranules(t *testing.T) {
+	db, cfg := openMetricsProbeChDB(t)
+
+	const metricName = "cerberus_queries_total"
+	insert := "INSERT INTO " + cfg.Tables.MetricsSum +
+		" (MetricName, Attributes, ServiceName, TimeUnix, Value, AggregationTemporality, IsMonotonic) VALUES " +
+		temporalityProbeAllCumulativeRows(metricName)
+	if _, err := db.Exec(insert); err != nil {
+		t.Fatalf("seed all-cumulative rows: %v", err)
+	}
+	if _, err := db.Exec("OPTIMIZE TABLE " + cfg.Tables.MetricsSum + " FINAL"); err != nil {
+		t.Fatalf("optimize final: %v", err)
+	}
+
+	deltaPlan := explainIndexes(t, db,
+		"SELECT count() FROM "+cfg.Tables.MetricsSum+
+			" WHERE MetricName = '"+metricName+"' AND AggregationTemporality = 1")
+	if !strings.Contains(deltaPlan, temporalityIndexName) {
+		t.Fatalf("DELTA-predicate EXPLAIN plan never mentions %s — index not consulted:\n%s",
+			temporalityIndexName, deltaPlan)
+	}
+	if !strings.Contains(deltaPlan, "Granules: 0/") {
+		t.Errorf("DELTA-predicate EXPLAIN plan did not prune to 0 granules on an all-CUMULATIVE table — "+
+			"the redundant DELTA-arm scan #2458 reports would still read real data:\n%s", deltaPlan)
+	}
+
+	cumulativePlan := explainIndexes(t, db,
+		"SELECT count() FROM "+cfg.Tables.MetricsSum+
+			" WHERE MetricName = '"+metricName+"' AND AggregationTemporality != 1")
+	if strings.Contains(cumulativePlan, "Granules: 0/") {
+		t.Errorf("CUMULATIVE-predicate EXPLAIN plan pruned granules it must actually read "+
+			"(every seeded row matches != DELTA) — a false skip would silently drop real rows:\n%s", cumulativePlan)
+	}
+}
+
+// TestTemporalityIndex_DoesNotPruneAMixedGranule is the required negative
+// case: a granule carrying BOTH CUMULATIVE and DELTA rows must not be
+// skipped for EITHER predicate — a minmax mark spanning [1, 2] (DELTA,
+// CUMULATIVE) matches both `= 1` and `!= 1`, so ClickHouse must still read
+// it. Without this case, TestTemporalityIndex_PrunesAllCumulativeGranules
+// alone could pass even if the index (or this test's own EXPLAIN parsing)
+// treated the predicate as always-prunable regardless of what the data
+// actually contains.
+func TestTemporalityIndex_DoesNotPruneAMixedGranule(t *testing.T) {
+	db, cfg := openMetricsProbeChDB(t)
+
+	const metricName = "cerberus_queries_total"
+	var b strings.Builder
+	for i := range temporalityProbeRowsPerGranule {
+		if i > 0 {
+			b.WriteString(",\n")
+		}
+		// Every 4096th row (well inside this one granule) flips to DELTA, so
+		// the granule's AggregationTemporality min/max mark spans [1, 2] and
+		// cannot be pruned for either predicate.
+		temporality := 2
+		if i == temporalityProbeRowsPerGranule/2 {
+			temporality = 1
+		}
+		fmt.Fprintf(&b, "('%s', map(), '', toDateTime64('2026-01-01 00:00:00', 9) + toIntervalSecond(%d), %d, %d, true)",
+			metricName, i, i, temporality)
+	}
+	insert := "INSERT INTO " + cfg.Tables.MetricsSum +
+		" (MetricName, Attributes, ServiceName, TimeUnix, Value, AggregationTemporality, IsMonotonic) VALUES " + b.String()
+	if _, err := db.Exec(insert); err != nil {
+		t.Fatalf("seed mixed-granule rows: %v", err)
+	}
+	if _, err := db.Exec("OPTIMIZE TABLE " + cfg.Tables.MetricsSum + " FINAL"); err != nil {
+		t.Fatalf("optimize final: %v", err)
+	}
+
+	deltaPlan := explainIndexes(t, db,
+		"SELECT count() FROM "+cfg.Tables.MetricsSum+
+			" WHERE MetricName = '"+metricName+"' AND AggregationTemporality = 1")
+	if strings.Contains(deltaPlan, "Granules: 0/") {
+		t.Errorf("DELTA-predicate EXPLAIN plan pruned a granule that genuinely contains a DELTA row — "+
+			"a false skip would silently drop it from the answer:\n%s", deltaPlan)
+	}
+
+	var count int64
+	if err := db.QueryRow(
+		"SELECT count() FROM " + cfg.Tables.MetricsSum +
+			" WHERE MetricName = '" + metricName + "' AND AggregationTemporality = 1",
+	).Scan(&count); err != nil {
+		t.Fatalf("count DELTA rows: %v", err)
+	}
+	if count != 1 {
+		t.Errorf("count(AggregationTemporality = 1) = %d, want 1 (the single seeded DELTA row) — "+
+			"the index must never change the ANSWER, only the granules read to compute it", count)
+	}
+}
+
+// explainIndexes runs `EXPLAIN indexes = 1 <query>` against db and returns
+// the plan text joined by newlines.
+func explainIndexes(t *testing.T, db *sql.DB, query string) string {
+	t.Helper()
+	rows, err := db.Query("EXPLAIN indexes = 1 " + query)
+	if err != nil {
+		t.Fatalf("explain %q: %v", query, err)
+	}
+	defer func() { _ = rows.Close() }()
+	var plan strings.Builder
+	for rows.Next() {
+		var line string
+		if err := rows.Scan(&line); err != nil {
+			t.Fatalf("explain scan: %v", err)
+		}
+		plan.WriteString(line)
+		plan.WriteByte('\n')
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatalf("explain rows: %v", err)
+	}
+	return plan.String()
+}

--- a/test/e2e/migration/expected/schema/default.sql
+++ b/test/e2e/migration/expected/schema/default.sql
@@ -212,6 +212,10 @@ ALTER TABLE default.otel_metrics_histogram ADD PROJECTION IF NOT EXISTS proj_ser
 
 ALTER TABLE default.otel_metrics_histogram ADD PROJECTION IF NOT EXISTS proj_metric_metadata (SELECT `MetricName`, any(`MetricDescription`), any(`MetricUnit`), max(`TimeUnix`) GROUP BY `MetricName`);
 
+ALTER TABLE default.otel_metrics_sum ADD INDEX IF NOT EXISTS idx_agg_temporality `AggregationTemporality` TYPE minmax GRANULARITY 1;
+
+ALTER TABLE default.otel_metrics_histogram ADD INDEX IF NOT EXISTS idx_agg_temporality `AggregationTemporality` TYPE minmax GRANULARITY 1;
+
 CREATE TABLE IF NOT EXISTS `default`.`otel_logs`  (
     `Timestamp` DateTime64(9) CODEC(Delta(8), ZSTD(1)),
     `TraceId` String CODEC(ZSTD(1)),

--- a/test/e2e/migration/expected/schema/metrics-ttl-override.sql
+++ b/test/e2e/migration/expected/schema/metrics-ttl-override.sql
@@ -212,6 +212,10 @@ ALTER TABLE default.otel_metrics_histogram ADD PROJECTION IF NOT EXISTS proj_ser
 
 ALTER TABLE default.otel_metrics_histogram ADD PROJECTION IF NOT EXISTS proj_metric_metadata (SELECT `MetricName`, any(`MetricDescription`), any(`MetricUnit`), max(`TimeUnix`) GROUP BY `MetricName`);
 
+ALTER TABLE default.otel_metrics_sum ADD INDEX IF NOT EXISTS idx_agg_temporality `AggregationTemporality` TYPE minmax GRANULARITY 1;
+
+ALTER TABLE default.otel_metrics_histogram ADD INDEX IF NOT EXISTS idx_agg_temporality `AggregationTemporality` TYPE minmax GRANULARITY 1;
+
 CREATE TABLE IF NOT EXISTS `default`.`otel_logs`  (
     `Timestamp` DateTime64(9) CODEC(Delta(8), ZSTD(1)),
     `TraceId` String CODEC(ZSTD(1)),

--- a/test/e2e/migration/steps/schema.go
+++ b/test/e2e/migration/steps/schema.go
@@ -42,10 +42,14 @@ var createObjectRe = regexp.MustCompile(`(?is)^CREATE\s+(?:DATABASE|TABLE|MATERI
 // leadingVerbRe captures a statement's leading SQL verb.
 var leadingVerbRe = regexp.MustCompile(`(?is)^([A-Za-z]+)`)
 
-// addProjectionRe matches the one non-CREATE shape the renderer emits: an
-// idempotent projection addition on a table it just declared. Any other ALTER
-// would be a schema mutation the operator did not ask to review.
-var addProjectionRe = regexp.MustCompile(`(?is)^ALTER\s+TABLE\s+\S+\s+ADD\s+PROJECTION\s+IF\s+NOT\s+EXISTS\s+`)
+// idempotentAdditiveAlterRe matches the non-CREATE shapes the renderer
+// emits: an idempotent PROJECTION or INDEX addition on a table it just
+// declared — both are metadata-only ADD ... IF NOT EXISTS statements that
+// never rewrite or destroy existing data (see internal/schema/ddl's curated
+// projection registry and, since issue #2458, its AggregationTemporality
+// skip index). Any other ALTER would be a schema mutation the operator did
+// not ask to review.
+var idempotentAdditiveAlterRe = regexp.MustCompile(`(?is)^ALTER\s+TABLE\s+\S+\s+ADD\s+(?:PROJECTION|INDEX)\s+IF\s+NOT\s+EXISTS\s+`)
 
 // destructiveRe matches a statement that would destroy or rewrite data. The
 // rendered schema is a provisioning preview an operator pipes into a client by
@@ -160,8 +164,8 @@ func (w *World) thenRendererSucceededOffline() error {
 
 // thenRendererAppliesNothing asserts every rendered statement is a schema
 // declaration the operator applies by hand — a CREATE, or the idempotent
-// projection addition on a table the same render declares — and that none of
-// them destroys or rewrites data.
+// projection/index addition on a table the same render declares — and that
+// none of them destroys or rewrites data.
 func (w *World) thenRendererAppliesNothing() error {
 	stmts, err := w.renderedStatements()
 	if err != nil {
@@ -172,8 +176,8 @@ func (w *World) thenRendererAppliesNothing() error {
 		switch verb {
 		case "CREATE":
 		case "ALTER":
-			if !addProjectionRe.MatchString(stmt) {
-				return fmt.Errorf("the %s case renders an ALTER that is not an idempotent projection addition: %s",
+			if !idempotentAdditiveAlterRe.MatchString(stmt) {
+				return fmt.Errorf("the %s case renders an ALTER that is not an idempotent projection/index addition: %s",
 					w.schema.caseName, firstLine(stmt))
 			}
 		default:

--- a/test/e2e/migration/steps/schema_live.go
+++ b/test/e2e/migration/steps/schema_live.go
@@ -44,13 +44,22 @@ var nonColumnElementRe = regexp.MustCompile(`(?is)^(INDEX|CONSTRAINT|PROJECTION|
 // ClickHouse materialises as dotted sibling columns.
 var nestedTypeRe = regexp.MustCompile(`(?is)^NESTED\s*\(`)
 
-// alterProjectionRe captures the target table and the projection name of the
-// one non-CREATE shape the renderer emits. schema.go's addProjectionRe only
-// recognises the shape; the live diff needs both halves, because the ALTER
-// names a table the live database must already hold for the operator to be
-// able to apply it at all.
+// alterProjectionRe captures the target table and the projection name of one
+// non-CREATE shape the renderer emits. schema.go's idempotentAdditiveAlterRe
+// only recognises the shape; the live diff needs both halves, because the
+// ALTER names a table the live database must already hold for the operator
+// to be able to apply it at all.
 var alterProjectionRe = regexp.MustCompile(
 	`(?is)^ALTER\s+TABLE\s+(\S+)\s+ADD\s+PROJECTION\s+IF\s+NOT\s+EXISTS\s+(\S+)`,
+)
+
+// alterIndexRe is alterProjectionRe's sibling for the other non-CREATE shape
+// the renderer emits: `ALTER TABLE … ADD INDEX IF NOT EXISTS <name> …` (the
+// index's own expression/TYPE/GRANULARITY clause trails the captured name,
+// unlike a projection's parenthesised body, so the regex does not need to
+// match past it).
+var alterIndexRe = regexp.MustCompile(
+	`(?is)^ALTER\s+TABLE\s+(\S+)\s+ADD\s+INDEX\s+IF\s+NOT\s+EXISTS\s+(\S+)`,
 )
 
 // renderedColumn is one column a rendered CREATE TABLE declares.
@@ -93,12 +102,26 @@ type renderedProjection struct {
 	name     string
 }
 
+// renderedIndex is one `ALTER TABLE … ADD INDEX IF NOT EXISTS` the renderer
+// emits (issue #2458's AggregationTemporality skip index today). Only the
+// ALTER's HEADER is diffable against a collector-provisioned stack, for the
+// same reason renderedProjection's is: the index is a cerberus-side read
+// accelerator the OTel exporter never creates, so what IS asserted is that
+// the ALTER targets the live tenant database and names a table that is
+// really there.
+type renderedIndex struct {
+	database string
+	table    string
+	name     string
+}
+
 // renderedSchema is everything the render declares, split by what each half
 // can be diffed against. Keeping the projections rather than dropping them is
 // what stops a parser change from silently shrinking the diff's input.
 type renderedSchema struct {
 	objects     []renderedObject
 	projections []renderedProjection
+	indexes     []renderedIndex
 }
 
 // readColumn is one column cerberus's read-side schema config addresses on one
@@ -149,6 +172,9 @@ type schemaLiveDiff struct {
 	// no column list: a parser that stopped recognising the ALTERs would
 	// otherwise leave their target-table check trivially satisfied.
 	projections int
+	// indexes is projections' sibling for the ADD INDEX ALTERs the diff
+	// reached (issue #2458's AggregationTemporality skip index today).
+	indexes int
 	// readMissing names, per table cerberus reads, the columns its
 	// env-resolved READ-side schema config addresses that the live table does
 	// not carry. The rendered diff above covers what the DDL declares; this
@@ -213,8 +239,8 @@ func (w *World) givenLiveSchemaEnvironment() error {
 // diffing structured names sidesteps the formatting, CODEC and TTL noise that
 // a text diff of two independently-formatted CREATE statements would drown in.
 //
-// The ADD PROJECTION ALTERs are diffed on their TARGET only; see
-// renderedProjection for why their bodies cannot be.
+// The ADD PROJECTION / ADD INDEX ALTERs are diffed on their TARGET only; see
+// renderedProjection / renderedIndex for why their bodies cannot be.
 func (w *World) whenDiffSchemaAgainstLive() error {
 	stmts, err := w.renderedStatements()
 	if err != nil {
@@ -237,6 +263,11 @@ func (w *World) whenDiffSchemaAgainstLive() error {
 		return fmt.Errorf("the rendered schema adds no projection at all; the renderer emits one per catalog " +
 			"table, so an empty set means the parse stopped reading them and their targets go unchecked")
 	}
+	if len(rendered.indexes) == 0 {
+		return fmt.Errorf("the rendered schema adds no index at all; the renderer emits the AggregationTemporality " +
+			"skip index on the sum and histogram tables, so an empty set means the parse stopped reading them " +
+			"and their targets go unchecked")
+	}
 
 	ctx, cancel := context.WithTimeout(context.Background(), livePollBudget)
 	defer cancel()
@@ -253,6 +284,7 @@ func (w *World) whenDiffSchemaAgainstLive() error {
 		readMissing:       map[string][]string{},
 		unresolvedColumns: map[string][]string{},
 		projections:       len(rendered.projections),
+		indexes:           len(rendered.indexes),
 	}
 	// liveCols caches one system.columns read per table, so the read-side leg
 	// below reuses what the rendered leg already fetched.
@@ -301,6 +333,23 @@ func (w *World) whenDiffSchemaAgainstLive() error {
 		if !exists {
 			diff.missingTables = append(diff.missingTables,
 				fmt.Sprintf("%s (target of projection %s)", proj.table, proj.name))
+		}
+	}
+
+	for _, idx := range rendered.indexes {
+		if idx.database != w.live.CHDatabase {
+			diff.misqualified = append(diff.misqualified,
+				fmt.Sprintf("%s.%s's index %s (live tenant database is %s)",
+					idx.database, idx.table, idx.name, w.live.CHDatabase))
+			continue
+		}
+		exists, err := tableExistsLive(ctx, conn, w.live.CHDatabase, idx.table)
+		if err != nil {
+			return err
+		}
+		if !exists {
+			diff.missingTables = append(diff.missingTables,
+				fmt.Sprintf("%s (target of index %s)", idx.table, idx.name))
 		}
 	}
 
@@ -451,15 +500,19 @@ func (w *World) thenDiffCoversEveryReadTable() error {
 // thenNoTableMissingLive asserts every object the render declares exists in
 // the live, collector-created database — and that the render targeted that
 // database in the first place, since DDL aimed elsewhere provisions a stack
-// other than the one under test. Each ADD PROJECTION ALTER is held to the same
-// two claims about its target table; its projection BODY is deliberately out
-// of scope (see renderedProjection).
+// other than the one under test. Each ADD PROJECTION / ADD INDEX ALTER is
+// held to the same two claims about its target table; its projection BODY /
+// index expression is deliberately out of scope (see renderedProjection /
+// renderedIndex).
 func (w *World) thenNoTableMissingLive() error {
 	if !w.schemaLive.ran {
 		return fmt.Errorf("the schema has not been diffed against the live database")
 	}
 	if w.schemaLive.projections == 0 {
 		return fmt.Errorf("the diff reached no ADD PROJECTION ALTER, so no projection target was checked")
+	}
+	if w.schemaLive.indexes == 0 {
+		return fmt.Errorf("the diff reached no ADD INDEX ALTER, so no index target was checked")
 	}
 	if len(w.schemaLive.misqualified) > 0 {
 		return fmt.Errorf("the rendered schema targets objects outside the live tenant database: %v",
@@ -748,11 +801,25 @@ func parseRenderedSchema(stmts []string) (renderedSchema, error) {
 	for _, stmt := range stmts {
 		m := createObjectKindRe.FindStringSubmatchIndex(stmt)
 		if m == nil {
-			proj, err := parseAddProjection(stmt)
-			if err != nil {
-				return renderedSchema{}, err
+			switch {
+			case alterProjectionRe.MatchString(stmt):
+				proj, err := parseAddProjection(stmt)
+				if err != nil {
+					return renderedSchema{}, err
+				}
+				out.projections = append(out.projections, proj)
+			case alterIndexRe.MatchString(stmt):
+				idx, err := parseAddIndex(stmt)
+				if err != nil {
+					return renderedSchema{}, err
+				}
+				out.indexes = append(out.indexes, idx)
+			default:
+				return renderedSchema{}, fmt.Errorf(
+					"the rendered schema carries a statement that is neither a CREATE nor an ADD PROJECTION/INDEX, "+
+						"so the diff would pass over it unchecked: %s", firstLine(stmt),
+				)
 			}
-			out.projections = append(out.projections, proj)
 			continue
 		}
 		kind := strings.ToUpper(strings.Join(strings.Fields(stmt[m[2]:m[3]]), " "))
@@ -786,20 +853,37 @@ func parseRenderedSchema(stmts []string) (renderedSchema, error) {
 }
 
 // parseAddProjection reads one `ALTER TABLE … ADD PROJECTION IF NOT EXISTS …`
-// into the target it names, failing on any other non-CREATE statement.
+// into the target it names. Callers match alterProjectionRe first, so a
+// non-match here would be a caller bug rather than a genuinely different
+// statement shape.
 func parseAddProjection(stmt string) (renderedProjection, error) {
 	m := alterProjectionRe.FindStringSubmatch(stmt)
 	if m == nil {
-		return renderedProjection{}, fmt.Errorf(
-			"the rendered schema carries a statement that is neither a CREATE nor an ADD PROJECTION, "+
-				"so the diff would pass over it unchecked: %s", firstLine(stmt),
-		)
+		return renderedProjection{}, fmt.Errorf("parseAddProjection called on a statement alterProjectionRe does not match: %s",
+			firstLine(stmt))
 	}
 	database, table, err := splitQualifiedName(m[1])
 	if err != nil {
 		return renderedProjection{}, fmt.Errorf("the rendered projection ALTER %s: %w", firstLine(stmt), err)
 	}
 	return renderedProjection{database: database, table: table, name: strings.Trim(m[2], "`\"")}, nil
+}
+
+// parseAddIndex is parseAddProjection's sibling for
+// `ALTER TABLE … ADD INDEX IF NOT EXISTS …`. Callers match alterIndexRe
+// first, so a non-match here would be a caller bug rather than a genuinely
+// different statement shape.
+func parseAddIndex(stmt string) (renderedIndex, error) {
+	m := alterIndexRe.FindStringSubmatch(stmt)
+	if m == nil {
+		return renderedIndex{}, fmt.Errorf("parseAddIndex called on a statement alterIndexRe does not match: %s",
+			firstLine(stmt))
+	}
+	database, table, err := splitQualifiedName(m[1])
+	if err != nil {
+		return renderedIndex{}, fmt.Errorf("the rendered index ALTER %s: %w", firstLine(stmt), err)
+	}
+	return renderedIndex{database: database, table: table, name: strings.Trim(m[2], "`\"")}, nil
 }
 
 // splitQualifiedName unquotes a rendered `"db"."table"` / “ `db`.`table` “

--- a/test/e2e/migration/steps/schema_live_test.go
+++ b/test/e2e/migration/steps/schema_live_test.go
@@ -165,6 +165,34 @@ func TestParseRenderedSchemaReadsEveryAddProjection(t *testing.T) {
 	}
 }
 
+// TestParseRenderedSchemaReadsEveryAddIndex is
+// TestParseRenderedSchemaReadsEveryAddProjection's sibling for the
+// AggregationTemporality skip index issue #2458 adds: the sum and histogram
+// tables only (see internal/schema/ddl's renderAddTemporalityIndex doc
+// comment for why gauge and exp_histogram are excluded).
+func TestParseRenderedSchemaReadsEveryAddIndex(t *testing.T) {
+	t.Parallel()
+
+	metrics := schema.DefaultOTelMetrics()
+	want := []string{
+		metrics.SumTable + "/idx_agg_temporality",
+		metrics.HistogramTable + "/idx_agg_temporality",
+	}
+	sort.Strings(want)
+
+	var got []string
+	for _, idx := range readDefaultSchemaGolden(t).indexes {
+		if idx.database == "" {
+			t.Fatalf("the rendered ADD INDEX for %s.%s carries no database qualifier", idx.table, idx.name)
+		}
+		got = append(got, idx.table+"/"+idx.name)
+	}
+	sort.Strings(got)
+	if strings.Join(got, ",") != strings.Join(want, ",") {
+		t.Fatalf("the parser read indexes %v off the rendered schema, want %v", got, want)
+	}
+}
+
 // TestParseRenderedSchemaRejectsAnUnknownStatement proves a rendered statement
 // the parser does not recognise fails the parse rather than being passed over.
 // Passing over it is what would let a whole new statement kind enter the

--- a/test/e2e/migration/steps/steps_test.go
+++ b/test/e2e/migration/steps/steps_test.go
@@ -185,6 +185,11 @@ func TestThenRendererAppliesNothingRejectsAMutation(t *testing.T) {
 				"ALTER TABLE a ADD PROJECTION IF NOT EXISTS proj (SELECT x);\n",
 			wantOK: true,
 		},
+		"declarations with an index": {
+			render: "CREATE TABLE a (x String) ENGINE = MergeTree();\n" +
+				"ALTER TABLE a ADD INDEX IF NOT EXISTS idx x TYPE minmax GRANULARITY 1;\n",
+			wantOK: true,
+		},
 		"a dropped table": {
 			render: "CREATE TABLE a (x String) ENGINE = MergeTree();\nDROP TABLE a;\n",
 		},


### PR DESCRIPTION
## What

Fixes the 2x redundant read #2458 measured for `NativeRateLowerer`'s temporality
split, by adding a `minmax` skip index on `AggregationTemporality` to the sum
and histogram metrics tables (`internal/schema/ddl`) — an additive
`ALTER TABLE ... ADD INDEX IF NOT EXISTS`, applied idempotently at boot via the
same mechanism the curated metadata-projection registry already uses.

## Why this shape, not a plan-level fix

`NativeRateLowerer.LowerRate` splits a temporality-bearing `rate()`/`increase()`
range window into a native CUMULATIVE arm (`chplan.RangeWindowGridNative`, fed
only non-DELTA rows) and a fan-out DELTA arm (`chplan.RangeWindow`, fed only
DELTA rows) — a `chplan.UnionAll{RangeWindowGridNative, RangeWindow}`. Both
arms scan the same base table with the same `MetricName`/`Attributes`
predicate, differing only in a trailing `AggregationTemporality` conjunct that
carries no `ORDER BY` benefit, so ClickHouse reads every matching row from
**both** arms — the issue's own real-data measurement: a confirmed 2.00x
`read_rows` ratio against table size on two independent `rate()` queries.

I investigated eliminating the split (the "obvious" fix — just delegate the
whole window to the fan-out `RateLowerer` whenever a temporality column is
present, matching how `FanoutRateLowerer` itself already handles mixed
temporality in one scan) and reverted it after finding it breaks load-bearing,
deliberately-built infrastructure:

- `internal/solver/native_union_route_test.go`'s
  `TestPlan_ProductionTemporalitySplitReanchorsBothArms` lowers the exact
  `rate(cerberus_queries_total[5m])` production shape and asserts the plan
  still contains **exactly one** `RangeWindowGridNative` arm and **one**
  `RangeWindow` arm — this is the precise shape #2114/#2117/#2120 taught the
  solver to slice and re-anchor for OOM-safe routing. Eliminating the split
  would silently disconnect that solver machinery from ever firing for
  `rate()` in production, and is explicitly out of scope per the issue's own
  "Scope note" ("not the routing split's *existence* ... this issue is about
  its *cost*").
- It would also have gutted the golden corpus's demonstrated coverage of the
  native aggregate for the (very common) plain-Sum-table-counter shape: 11 of
  the 12 `experimental_ts_grid_range` TXTAR fixtures currently reach this
  exact split, since the default schema declares `AggregationTemporality`
  broadly.

I then investigated a genuine single-scan SQL fusion — keep the plan shape,
make the two arms share one physical read — and confirmed empirically
(against chDB) that:

- a shared `WITH ... AS (subquery)` CTE does **not** save a physical read:
  `EXPLAIN PLAN` shows two independent `ReadFromMergeTree` nodes even for a
  byte-identical CTE referenced from both `UNION ALL` branches — ClickHouse
  macro-inlines it rather than memoizing it, confirming the issue's own
  caution ("this would need to be built and proven, not assumed");
- `timeSeriesRateToGridIf(...)(ts, value, cond)` — the `-If` combinator the
  issue names as the missing piece for a real fusion — **does** compose with
  the parametric native aggregate on this ClickHouse version (25.8), both as
  a plain aggregate and as a window function (`... OVER (PARTITION BY ...)`).

That second finding is genuinely new information beyond what the issue
established, and de-risks a future real fusion attempt, but building the rest
of it — restructuring the DELTA arm's array/window machinery to share one
row-pass with the native aggregate call, with its own differential-parity
coverage — is still the "real rewrite ... not a small patch" the issue's own
"Why this isn't a safe drop-in fix" section describes, not something safe to
attempt as a narrow patch here.

## The fix

A `minmax` skip index (metadata-only — unlike `ADD PROJECTION` it does not
store a second physical copy of the table) on `AggregationTemporality`, sized
`GRANULARITY 1` for the finest skip resolution. Real OTel deployments set
`AggregationTemporality` once per exporter configuration, so a given series'
samples land in temporality-homogeneous runs almost always — which means a
homogeneous granule's `[min, max]` mark is a single value, letting ClickHouse
prune it entirely for whichever arm's predicate doesn't match. This addresses
the redundant read with **zero** change to `chplan`/`chsql`/`promql`, so zero
risk to the solver routing tests, and it benefits every query that filters on
this column against these tables — including the parallel split
`NativeClassicHistogramWindowLowerer.LowerClassicHistogramWindow` builds for
the classic-histogram quantile window stage (same table, same predicate
shape), as a side effect with no code change there either.

### Verification

`internal/schema/ddl/temporality_index_skip_chdb_test.go` (chdb-tagged) proves
the mechanism against a live `EXPLAIN indexes=1` plan on the package's own
rendered production DDL — not a text-parse of the `ALTER` string:

- `TestTemporalityIndex_PrunesAllCumulativeGranules`: seeds 4 real granules
  (32,768 rows, the production table's actual `index_granularity=8192`) of an
  all-CUMULATIVE series. The DELTA-arm predicate (`AggregationTemporality = 1`)
  prunes **100%** of granules (`Granules: 0/N`); the CUMULATIVE-arm predicate
  correctly reads every granule (nothing to prune — every row matches it).
- `TestTemporalityIndex_DoesNotPruneAMixedGranule`: the required negative
  case — a granule carrying one DELTA row alongside CUMULATIVE ones must not
  be pruned for either predicate, and the query answer itself must be
  unaffected by the index (`count() == 1`, not silently dropped).

I did not additionally wire a `test/perf/nightly` read_rows sentinel against
the real captured sample data (the issue's own "Suggested next step" and the
methodology it used) — that harness is mid-rollout on its own PR-A/PR-B
schedule per its doc comments, and the chDB proof above already demonstrates
the causal mechanism directly. Worth adding as a follow-up once that harness's
baseline lands.

### Existing data

New parts get the index automatically once the `ALTER` runs (idempotent,
re-applied every boot). Existing parts need a one-time backfill —
`ALTER TABLE ... MATERIALIZE INDEX idx_agg_temporality` — documented in
`docs/operations.md` alongside the mechanism, mirroring the existing
`MATERIALIZE PROJECTION` runbook.

## Files

- `internal/chsql/ddl.go` (+test): new `AlterTableAddIndex` typed DDL builder
  (`ALTER TABLE ... ADD INDEX IF NOT EXISTS ... TYPE ... GRANULARITY ...`).
- `internal/schema/ddl/ddl.go` (+tests): wires the index onto the sum and
  histogram tables in the `Metrics` DDL signal.
- `internal/schema/ddl/temporality_index_skip_chdb_test.go`: the live
  granule-pruning proof described above.
- `docs/operations.md`: mechanism + backfill runbook, alongside the existing
  projection-registry section it mirrors.
- `test/e2e/migration/steps/schema.go` / `schema_live.go` (+tests): the new
  `ADD INDEX` ALTER tripped two migration-lane gates that only recognized
  `ADD PROJECTION` as a safe, idempotent non-CREATE statement — widened both
  to accept `ADD INDEX IF NOT EXISTS` too (same safety profile: metadata-only,
  never rewrites or destroys data), with the MIG-10 live-diff half getting the
  equivalent `renderedIndex`/`parseAddIndex` plumbing mirroring its existing
  projection handling.
- `.github/scripts/lib/golden-shards.mjs`: the `migration` shard's declared
  golden ownership only listed `test/e2e/migration/archetypes/*/expected`,
  not `test/e2e/migration/expected/schema` — a pre-existing gap (reachable by
  *any* rendered-DDL-shape change, not specific to this PR) that made
  `update-golden.yml` reject this PR's own schema-golden regeneration as
  "outside shard ownership." Declared the missing path.
- `test/e2e/migration/expected/schema/{default,metrics-ttl-override}.sql`:
  regenerated for the two new `ADD INDEX` statements. Done via
  `just migration-golden` directly rather than `update-golden.yml`: the
  workflow's controller scripts run from the WORKFLOW ref (`main`) by
  design — a deliberate trust boundary — so this PR's own fix to
  `golden-shards.mjs` above cannot take effect for the PR's own dispatch
  until it's on `main`. Confirmed by two separate `update-golden.yml`
  dispatches, both failing identically before and after that fix landed on
  this branch. The diff is exactly the two new ALTERs; `go test
  -tags=migration ./test/e2e/migration/tiers/tier0-offline/...` passes
  clean (8/8 scenarios).

## Testing

- `go test -race ./internal/schema/... ./internal/chsql/... ./internal/solver/...`
- `go test -tags chdb -run TestTemporalityIndex ./internal/schema/ddl/...`
  (both new cases pass, live against chDB)
- `go test -tags=migration ./test/e2e/migration/tiers/tier0-offline/...`
  (8/8 scenarios pass, including both `render the schema under a schema
  environment` cases)
- `go test ./test/e2e/migration/steps/...` and `go vet -tags=migration
  ./test/e2e/migration/...`
- `node --test .github/scripts/manual-golden-update.test.mjs` (11/11 pass)
- `node .github/scripts/forbid-sql-raw.mjs` — clean
- Confirmed `internal/solver`'s `TestPlan_ProductionTemporalitySplitReanchorsBothArms`,
  `TestPlan_NativeUnionSpineRoutes`, `TestPlan_NativeUnionShardsMoveBothArms`
  still pass unchanged (this PR touches no `chplan`/`chsql`/`promql` code)

Closes #2458
