### PR TITLE
fix(promql): accept a windowed float side in a sum/avg-wrapped mixed or

### DIFF
--- a/internal/promql/histogram_native_mixed_or.go
+++ b/internal/promql/histogram_native_mixed_or.go
@@ -108,11 +108,7 @@ func lowerMixedExpHistogramSetOp(b *parser.BinaryExpr, s schema.Metrics, ctx low
 		return nil, fmt.Errorf("promql: 'bool' modifier is only allowed on comparison binary ops")
 	}
 
-	// The root-only leaf recognizer allows a windowed/derived float side
-	// (cerberus issue #2333) — see lowerMixedExpHistogramOperands's own
-	// doc comment for why this is NOT the same acceptance the sum/avg
-	// wrapper (histogram_native_mixed_or_aggregate.go, issue #2346) gets.
-	histNode, floatNode, histOnLeft, err := lowerMixedExpHistogramOperands(b, s, ctx, true)
+	histNode, floatNode, histOnLeft, err := lowerMixedExpHistogramOperands(b, s, ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -147,23 +143,30 @@ func lowerMixedExpHistogramSetOp(b *parser.BinaryExpr, s schema.Metrics, ctx low
 // SAME two operand plans without duplicating the histogram-valued /
 // float-valued dispatch.
 //
-// allowWindowedFloatSide is per-caller, not a shared constant, because the
-// two callers' float-side acceptance genuinely differs:
+// Both callers accept a windowed/derived float side (matrix RangeWindow
+// or an instant-reduced shape), not just the plain canonical-shape float
+// side #2330 originally shipped — the shape guard below accepts all
+// three row shapes internal/chsql's vectorSetOpCanonicalArmFrag doc
+// comment names. The two callers earn that acceptance through two
+// DIFFERENT mechanisms, though, which is worth knowing when touching
+// either:
 //   - The root-only leaf recognizer ([lowerMixedExpHistogramSetOp], issue
-//     #2333) passes true: internal/chsql's mixedVectorSetOpArmFrag
-//     canonicalises a matrix RangeWindow or a reduced instant shape
-//     through the exact same vectorSetOpCanonicalQuartetFrags helper the
-//     plain (non-Mixed) VectorSetOp path already uses, so a windowed/
-//     derived float side is safe there.
+//     #2333) relies on internal/chsql's mixedVectorSetOpArmFrag, which
+//     canonicalises the float arm through the exact same
+//     vectorSetOpCanonicalQuartetFrags helper the plain (non-Mixed)
+//     VectorSetOp path already uses — entirely inside the chsql emitter,
+//     no chplan-level change needed.
 //   - The sum/avg-wrapped recognizer
-//     ([lowerSumOrAvgOverMixedExpHistogramSetOp], issue #2346) passes
-//     false: it feeds floatNode into its OWN aggregation reduction
-//     ([lowerPlainAggOverMixedFloatArm]), which has not been taught that
-//     canonicalisation, so a windowed float side there is a separate,
-//     unimplemented axis — pinned by
-//     TestLower_ExpHistogram_MixedSetOpOr_SumWrapped_WindowedFloatSideRejects.
+//     ([lowerSumOrAvgOverMixedExpHistogramSetOp], issue #2346 then #2453)
+//     feeds floatNode into its OWN aggregation reduction
+//     ([lowerPlainAggOverMixedFloatArm], histogram_native_mixed_or_aggregate.go),
+//     which cannot rely on the chsql emitter the same way: one of its two
+//     possible float arms never passes through a VectorSetOp at all (the
+//     "kept unconditionally" side of the `or` shadow rule), so that file's
+//     own [canonicalizeFloatArmForAgg] mirrors vectorSetOpCanonicalQuartetFrags
+//     at the chplan level instead.
 func lowerMixedExpHistogramOperands(
-	b *parser.BinaryExpr, s schema.Metrics, ctx lowerCtx, allowWindowedFloatSide bool,
+	b *parser.BinaryExpr, s schema.Metrics, ctx lowerCtx,
 ) (histNode, floatNode chplan.Node, histOnLeft bool, err error) {
 	histOnLeft = isExpHistogramValuedShape(b.LHS, s, ctx)
 	histExpr, floatExpr := b.LHS, b.RHS
@@ -181,20 +184,11 @@ func lowerMixedExpHistogramOperands(
 	}
 	shape := chplan.RowShapeOf(floatNode)
 	accepted := shape == chplan.SampleRowShape ||
-		(allowWindowedFloatSide && (shape == chplan.GridWindowRowShape || shape == chplan.ReducedWindowRowShape))
+		shape == chplan.GridWindowRowShape || shape == chplan.ReducedWindowRowShape
 	if !accepted {
-		if allowWindowedFloatSide {
-			return nil, nil, false, fmt.Errorf(
-				"promql: 'or' between a float-valued and a histogram-valued operand does not "+
-					"support a %s-shaped float operand, which cerberus issue #2333 does not "+
-					"cover",
-				shape,
-			)
-		}
 		return nil, nil, false, fmt.Errorf(
-			"promql: 'or' between a float-valued and a histogram-valued operand only "+
-				"supports a plain (non-windowed) float side today; got a %s-shaped float "+
-				"operand, which cerberus issue #2330 does not yet cover",
+			"promql: 'or' between a float-valued and a histogram-valued operand does not "+
+				"support a %s-shaped float operand",
 			shape,
 		)
 	}

--- a/internal/promql/histogram_native_mixed_or_aggregate.go
+++ b/internal/promql/histogram_native_mixed_or_aggregate.go
@@ -42,9 +42,12 @@ import (
 //
 //  1. [lowerMixedExpHistogramOperands] lowers the `or`'s two operands
 //     exactly as the leaf recognizer does — one histogram-valued, one
-//     plain float-valued (issue #2330's shape restriction still
-//     applies: a windowed float arm is issue #2333's separate axis, not
-//     this file's).
+//     plain float-valued, now including a windowed/derived float side
+//     (cerberus issue #2453 taught [canonicalizeFloatArmForAgg] the
+//     matrix/derived-shape canonicalisation
+//     [lowerPlainAggOverMixedFloatArm] needs to reduce one; issue #2333
+//     shipped the identical acceptance for the root-only leaf recognizer
+//     first).
 //  2. The `or`'s OWN shadow rule (every row of the side that's LHS in
 //     the source AST, plus only the RHS rows whose label signature is
 //     absent from LHS) is resolved with a [chplan.VectorSetOp] UNLESS —
@@ -101,11 +104,18 @@ func lowerSumOrAvgOverMixedExpHistogramSetOp(agg *parser.AggregateExpr, b *parse
 		return nil, fmt.Errorf("promql: 'bool' modifier is only allowed on comparison binary ops")
 	}
 
-	// false: the sum/avg-wrapped path does not yet accept a windowed float
-	// side — see lowerMixedExpHistogramOperands's own doc comment for why
-	// this is NOT the same acceptance the root-only leaf recognizer
-	// (issue #2333) gets.
-	histNode, floatNode, histOnLeft, err := lowerMixedExpHistogramOperands(b, s, ctx, false)
+	// A windowed float side (cerberus issue #2453) is safe here because
+	// every floatForAgg branch below is canonicalised to
+	// chplan.SampleRowShape before it reaches
+	// [lowerPlainAggOverMixedFloatArm]: the mixedOrShadowUnless-wrapped
+	// branch gets it as a side effect of that VectorSetOp's own arm
+	// canonicalisation (vectorSetOpCanonicalArmFrag /
+	// vectorSetOpCanonicalQuartetFrags, internal/chsql), and the
+	// unwrapped branch (float side kept unconditionally per the `or`
+	// shadow rule) gets it explicitly from [canonicalizeFloatArmForAgg]
+	// below, this file's own promql-level mirror of that same
+	// canonicalisation.
+	histNode, floatNode, histOnLeft, err := lowerMixedExpHistogramOperands(b, s, ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -116,12 +126,21 @@ func lowerSumOrAvgOverMixedExpHistogramSetOp(agg *parser.AggregateExpr, b *parse
 	// This is the identical mixed-type UNLESS #2337 already ships for
 	// `and`/`unless` between a histogram-valued and a float-valued
 	// operand — reused verbatim rather than re-derived.
+	//
+	// Only the FILTERED side passes through mixedOrShadowUnless's own
+	// VectorSetOp, which canonicalises it to chplan.SampleRowShape as a
+	// side effect (see this function's own doc comment above). The side
+	// kept unconditionally never goes through that node, so a windowed
+	// float arm on THAT side needs [canonicalizeFloatArmForAgg] applied
+	// explicitly before lowerPlainAggOverMixedFloatArm's Aggregate can
+	// reference its Timestamp/Attributes columns by name.
 	orMatch := mixedExpHistogramMatch(b)
 	histForAgg, floatForAgg := histNode, floatNode
 	if histOnLeft {
 		floatForAgg = mixedOrShadowUnless(floatNode, histNode, false, orMatch, s, ctx)
 	} else {
 		histForAgg = mixedOrShadowUnless(histNode, floatNode, true, orMatch, s, ctx)
+		floatForAgg = canonicalizeFloatArmForAgg(floatNode, s)
 	}
 
 	histBranch, err := lowerExpHistogramSumOrAvgOverPlan(agg, histForAgg, s)
@@ -196,12 +215,80 @@ func combineMixedAggregateBranches(histBranch, floatBranch chplan.Node, s schema
 	}
 }
 
+// canonicalizeFloatArmForAgg widens arm — the "keep unconditionally"
+// side of a mixed `or`'s own shadow rule, i.e. the side
+// [lowerSumOrAvgOverMixedExpHistogramSetOp] never passes through
+// [mixedOrShadowUnless]'s own VectorSetOp — to the canonical
+// chplan.SampleRowShape quartet (MetricName, Attributes, Timestamp,
+// Value), so [lowerPlainAggOverMixedFloatArm]'s Aggregate can reference
+// s.TimestampColumn / s.AttributesColumn by name regardless of whether
+// arm is a raw windowed/derived shape.
+//
+// This is the promql-level mirror of internal/chsql's
+// vectorSetOpCanonicalArmFrag / vectorSetOpCanonicalQuartetFrags — the
+// exact canonicalisation the root-only leaf recognizer
+// ([lowerMixedExpHistogramSetOp], issue #2333) gets for free from the
+// chsql emitter of its own VectorSetOp, and the SAME one the OTHER
+// (filtered) arm here gets for free from mixedOrShadowUnless's own
+// VectorSetOp. Split out as its own chplan.Project — rather than
+// re-deriving that chsql logic — because this arm never passes through
+// any VectorSetOp at all, so nothing else canonicalises it. Two of the
+// three cases that helper distinguishes apply here:
+//
+//   - chplan.SampleRowShape (already canonical — a plain selector, or
+//     anything wrapAggregateForSample already re-projected) — returned
+//     unchanged.
+//   - chplan.GridWindowRowShape (a matrix RangeWindow / RangeWindowGridNative,
+//     e.g. `rate(m[5m])` in range mode) — its own SELECT already
+//     exposes the grid anchor under the schema's TimestampColumn name
+//     directly (chplan.RowShapeOf's own doc comment), so Timestamp is a
+//     passthrough reference, matching vectorSetOpArmTimestampCol's
+//     identical no-alias-needed case for an arm whose own TimestampColumn
+//     field is the same schema name.
+//   - chplan.ReducedWindowRowShape (an instant-reduced window, e.g.
+//     `rate(m[5m])` in instant mode) — no per-row timestamp exists at
+//     all, so Timestamp is synthesised via chplan.NowNanoMinusStaleness,
+//     byte-for-byte the same synthesized anchor
+//     vectorSetOpSynthesizedAnchorFrag renders for the identical case.
+//
+// Attributes and Value are always passed through unchanged: every
+// windowed/derived shape this family of lowerings produces preserves the
+// full Attributes map under the schema's own column name as its GroupBy
+// key (the same assumption vectorSetOpCanonicalQuartetFrags's
+// unconditional `Col(s.AttributesColumn)` already relies on), and Value
+// is the schema-named reduced/per-row value column on every shape alike.
+func canonicalizeFloatArmForAgg(arm chplan.Node, s schema.Metrics) chplan.Node {
+	if chplan.RowShapeOf(arm) == chplan.SampleRowShape {
+		return arm
+	}
+
+	tsExpr := chplan.NowNanoMinusStaleness()
+	if chplan.RowShapeOf(arm) == chplan.GridWindowRowShape {
+		tsExpr = &chplan.ColumnRef{Name: s.TimestampColumn}
+	}
+
+	return &chplan.Project{
+		Input: arm,
+		Projections: []chplan.Projection{
+			{Expr: &chplan.LitString{V: ""}, Alias: s.MetricNameColumn},
+			{Expr: &chplan.ColumnRef{Name: s.AttributesColumn}, Alias: s.AttributesColumn},
+			{Expr: tsExpr, Alias: s.TimestampColumn},
+			{Expr: &chplan.ColumnRef{Name: s.ValueColumn}, Alias: s.ValueColumn},
+		},
+	}
+}
+
 // lowerPlainAggOverMixedFloatArm reduces input — the shadow-resolved
 // float-valued arm of a mixed `or` — with the SAME `sum`/`avg` CH-native
 // aggregate an ordinary (non-histogram) PromQL aggregation uses
 // ([aggregateGroupBy], [buildAggFunc], [promAggregateAttributesExpr]),
 // grouped by the evaluation Timestamp in addition to the user's
-// `by`/`without` labels.
+// `by`/`without` labels. Callers must canonicalise input to
+// chplan.SampleRowShape first (via mixedOrShadowUnless's own VectorSetOp
+// or, for the arm that skips it, [canonicalizeFloatArmForAgg]) — this
+// function's GroupBy/Projections reference s.TimestampColumn and
+// s.AttributesColumn by name, which only a canonical-shape input
+// exposes.
 //
 // Grouping by Timestamp unconditionally (not only when ctx.step > 0)
 // mirrors [lowerExpHistogramSumOrAvgOverPlan]'s identical choice for the

--- a/internal/promql/histogram_native_mixed_or_aggregate_test.go
+++ b/internal/promql/histogram_native_mixed_or_aggregate_test.go
@@ -82,27 +82,102 @@ func TestLower_ExpHistogram_MixedSetOpOr_SumWrapped(t *testing.T) {
 	}
 }
 
-// TestLower_ExpHistogram_MixedSetOpOr_SumWrapped_WindowedFloatSideRejects
-// pins that wrapping the mixed `or` in `sum(...)` does not widen
-// histogram_native_mixed_or.go's pre-existing float-side shape
-// restriction (cerberus issue #2330/#2333): a windowed float arm
-// combined with the nested `sum(...)` composition this file adds
-// (cerberus issue #2346) is explicitly out of scope for both issues, so
-// the query is still rejected with a clear error.
-func TestLower_ExpHistogram_MixedSetOpOr_SumWrapped_WindowedFloatSideRejects(t *testing.T) {
+// TestLower_ExpHistogram_MixedSetOpOr_SumWrapped_WindowedFloatSide pins
+// cerberus issue #2453: wrapping the mixed `or` in `sum`/`avg(...)` now
+// composes with a windowed/derived float arm too — the intersection of
+// #2333 (windowed float side, root-only leaf recognizer) and #2346
+// (sum/avg-wrapped composition, plain float side only) that neither of
+// those issues covered on its own. Both orderings of the `or` operands
+// are covered because histogram_native_mixed_or_aggregate.go's own
+// shadow-resolution step canonicalises each side through a DIFFERENT
+// mechanism depending on whether it is LHS (kept unconditionally) or RHS
+// (shadow-filtered) in the source AST — see canonicalizeFloatArmForAgg's
+// doc comment.
+func TestLower_ExpHistogram_MixedSetOpOr_SumWrapped_WindowedFloatSide(t *testing.T) {
 	t.Parallel()
 
 	s := schema.DefaultOTelMetrics()
 	p := parser.NewParser(parser.Options{EnableExperimentalFunctions: true})
 	at := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
 
-	query := `sum(rate(up[5m]) or latency_exp_hist)`
+	cases := []struct {
+		name  string
+		query string
+	}{
+		{
+			name:  "issue representative query, windowed float on left",
+			query: `sum(rate(up[5m]) or demo_latency_exp_hist)`,
+		},
+		{
+			name:  "windowed float on right",
+			query: `avg(demo_latency_exp_hist or rate(up[5m]))`,
+		},
+		{
+			name:  "range mode, windowed float on left",
+			query: `sum(rate(up[5m]) or latency_exp_hist)`,
+		},
+		{
+			name:  "range mode, windowed float on right, by(...)",
+			query: `sum by (service) (latency_exp_hist or rate(up[5m]))`,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			expr, err := p.ParseExpr(tc.query)
+			if err != nil {
+				t.Fatalf("ParseExpr(%q): %v", tc.query, err)
+			}
+			plan, err := promql.LowerAt(context.Background(), expr, s, at, at)
+			if err != nil {
+				t.Fatalf("LowerAt(%q): unexpected error: %v", tc.query, err)
+			}
+			if shape := chplan.RowShapeOf(plan); shape != chplan.MixedRowShape {
+				t.Fatalf("lower(%q): plan root publishes %s, want %s", tc.query, shape, chplan.MixedRowShape)
+			}
+			setOp, ok := plan.(*chplan.VectorSetOp)
+			if !ok {
+				t.Fatalf("lower(%q): plan root is %T, want *chplan.VectorSetOp", tc.query, plan)
+			}
+			if !setOp.Mixed {
+				t.Fatalf("lower(%q): VectorSetOp.Mixed = false, want true", tc.query)
+			}
+			if setOp.Op != chplan.VectorSetOr {
+				t.Fatalf("lower(%q): VectorSetOp.Op = %v, want %v", tc.query, setOp.Op, chplan.VectorSetOr)
+			}
+		})
+	}
+}
+
+// TestLower_ExpHistogram_MixedSetOpOr_SumWrapped_RangeMode pins that
+// TestLower_ExpHistogram_MixedSetOpOr_SumWrapped_WindowedFloatSide's
+// range-mode cases (ctx.step > 0) also lower successfully — the
+// windowed float arm's canonicalisation differs by mode
+// (canonicalizeFloatArmForAgg passes the matrix RangeWindow's own
+// Timestamp column through directly in range mode instead of
+// synthesising an instant anchor), so range mode needs its own coverage
+// rather than trusting the instant-mode case above to stand in for it.
+func TestLower_ExpHistogram_MixedSetOpOr_SumWrapped_RangeMode(t *testing.T) {
+	t.Parallel()
+
+	s := schema.DefaultOTelMetrics()
+	p := parser.NewParser(parser.Options{EnableExperimentalFunctions: true})
+	start := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	end := start.Add(10 * time.Minute)
+	const step = time.Minute
+
+	query := `sum(rate(up[5m]) or demo_latency_exp_hist)`
 	expr, err := p.ParseExpr(query)
 	if err != nil {
 		t.Fatalf("ParseExpr(%q): %v", query, err)
 	}
-	if _, err := promql.LowerAt(context.Background(), expr, s, at, at); err == nil {
-		t.Fatalf("lower(%q): expected an error, got none", query)
+	plan, err := promql.LowerAtRange(context.Background(), expr, s, start, end, step)
+	if err != nil {
+		t.Fatalf("LowerAtRange(%q): unexpected error: %v", query, err)
+	}
+	if shape := chplan.RowShapeOf(plan); shape != chplan.MixedRowShape {
+		t.Fatalf("lower(%q): plan root publishes %s, want %s", query, shape, chplan.MixedRowShape)
 	}
 }
 


### PR DESCRIPTION
## What

`sum(rate(up[5m]) or demo_latency_exp_hist)` and `avg(demo_latency_exp_hist or rate(up[5m]))`
now lower successfully. This closes the gap #2333 and #2346 each explicitly scoped out of
their own fix: #2333 taught the root-only mixed histogram/float `or` recognizer to accept a
windowed/derived float side; #2346 taught the `sum()`/`avg()`-wrapped composition to accept a
mixed `or`, but only for a plain (non-windowed) float side. The intersection — windowed float
side **and** sum/avg-wrapped — was tracked as #2453.

## Why it was rejected

`lowerSumOrAvgOverMixedExpHistogramSetOp` (`internal/promql/histogram_native_mixed_or_aggregate.go`)
feeds the mixed `or`'s float-valued arm into its own aggregation reduction
(`lowerPlainAggOverMixedFloatArm`), which references the schema's `TimestampColumn` /
`AttributesColumn` by name. That only resolves when the arm is already canonical-shaped
(`chplan.SampleRowShape`); a raw windowed/derived arm (a matrix `RangeWindow` or an
instant-reduced one) doesn't expose those names directly. The root-only leaf recognizer
(`lowerMixedExpHistogramSetOp`, #2333) never hit this because `internal/chsql`'s
`vectorSetOpCanonicalArmFrag` / `vectorSetOpCanonicalQuartetFrags` canonicalise a `VectorSetOp`
arm at SQL-emission time regardless of shape — but that canonicalisation is chsql-internal and
wasn't available to the aggregate wrapper's own `chplan.Aggregate` construction.

Of the mixed `or`'s two operands, one already gets this canonicalisation for free: the side
that needs shadow-filtering (`mixedOrShadowUnless`'s own `VectorSetOp`) is canonicalised as a
side effect of that node's own SQL emission. The other side — the one kept unconditionally per
`or`'s own shadow rule (the source AST's LHS) — never passes through a `VectorSetOp` at all, so
nothing canonicalised it.

## The fix

Added `canonicalizeFloatArmForAgg` (`internal/promql/histogram_native_mixed_or_aggregate.go`),
a promql-level mirror of `vectorSetOpCanonicalQuartetFrags`: a no-op for an already-canonical
arm, a passthrough Timestamp reference for a matrix `RangeWindow` (which already exposes the
grid anchor under the schema's `TimestampColumn` name), and a synthesised instant anchor
(`chplan.NowNanoMinusStaleness`, byte-for-byte what `vectorSetOpSynthesizedAnchorFrag` renders)
for an instant-reduced shape. `lowerSumOrAvgOverMixedExpHistogramSetOp` applies it to whichever
arm skips `mixedOrShadowUnless`'s own canonicalisation.

With both arms now reliably canonical before reaching `lowerPlainAggOverMixedFloatArm`, the
`lowerMixedExpHistogramOperands` shape guard's `allowWindowedFloatSide` parameter is dropped —
both callers accept a windowed float side now, so the parameter was down to always `true`.

## Tests

- `TestLower_ExpHistogram_MixedSetOpOr_SumWrapped_WindowedFloatSide` replaces the old pinned
  `..._WindowedFloatSideRejects` test (which explicitly locked in the *old* rejecting
  behaviour) with cases covering both operand orderings, `sum` and `avg`, and a `by (...)`
  clause, in instant mode.
- `TestLower_ExpHistogram_MixedSetOpOr_SumWrapped_RangeMode` covers the same query in range
  mode, since the windowed arm's canonicalisation takes a different branch there (passthrough
  vs. synthesised anchor).
- Verified with `chsql.Emit` locally (not checked in) that both repro queries from the issue
  render to valid SQL text with no missing-column references.

## Rejection-parity catalogue

This PR's fix eliminates the `allowWindowedFloatSide` branch entirely, so the `divergence`
catalogue entry for `sum(rate(up[5m]) or demo_latency_exp_hist)` (tracking issue #2453,
`internal/promql/histogram_native_mixed_or.go:lowerMixedExpHistogramOperands#38b18b37`) no
longer has a rejection site to repoint to — the query now succeeds. Dispatching
`update-golden.yml` with the `parity` shard (auto-widened as needed) to regenerate the
catalogue, which should delete that entry per its own documented ratchet ("if someone fixes
the divergence, claim 1 fails ... and the entry must be deleted").

Closes #2453
