### PR TITLE
fix(promql): preserve exp-histogram samples for sort_by_label()/sort_by_label_desc() (#2462)

### DIFF
--- a/internal/chplan/row_shape.go
+++ b/internal/chplan/row_shape.go
@@ -238,6 +238,21 @@ func RowShapeOf(n Node) RowShape {
 		// letting it fall through would leave that looking like an
 		// oversight.
 		return SampleRowShape
+	case *OrderBy:
+		// emitOrderBy renders `SELECT * FROM (<input>) ORDER BY ...` — a
+		// genuine passthrough of every column its input publishes, sort
+		// keys included. Its own SELECT therefore exposes exactly the
+		// shape its input does, whichever one that is (a plain sample
+		// selector's OrderBy, PromQL `sort_by_label()`'s ordinary case,
+		// stays SampleRowShape through the default branch below; wrapping
+		// a [HistogramProjection] — PromQL `sort_by_label()` /
+		// `sort_by_label_desc()` over an exp-histogram-valued vector,
+		// cerberus issue #2462 — must report HistogramRowShape or the
+		// wire layer's wrapWithSampleProjection re-projects only the
+		// canonical quartet and silently drops the nine histogram
+		// columns). Forwarding is recursive so a further OrderBy over an
+		// OrderBy (never built today) still resolves correctly.
+		return RowShapeOf(v.Input)
 	}
 	return SampleRowShape
 }

--- a/internal/promql/sort.go
+++ b/internal/promql/sort.go
@@ -108,13 +108,43 @@ func lowerSort(c *parser.Call, s schema.Metrics, ctx lowerCtx) (chplan.Node, err
 // order. Cerberus reproduces that by returning the lowered input
 // untouched — no OrderBy node, which is precisely the "existing order"
 // an unsorted instant vector already has.
+//
+// UNLIKE `sort`/`sort_desc` (#2456), reference Prometheus's
+// funcSortByLabel/funcSortByLabelDesc (promql/functions.go) do NOT start
+// from filterFloats: they sort `vectorVals[0]` in place with
+// `slices.SortFunc` over the named labels' VALUES alone, never touching
+// `.H`/`.F`, so a histogram sample sorts (and survives) right alongside
+// float samples — confirmed against the vendored reference engine
+// (github.com/tsouza/prometheus's promql/promqltest,
+// `sort_by_label(<native-histogram-series>, "job")` answers the sample
+// unchanged, not empty). `lowerSortByLabel` still needs the
+// [lowerExpHistogramValuedShape] check `sort`/`sort_desc` added, but for
+// the OPPOSITE reason: an exp-histogram-valued argument must be
+// recognised and PRESERVED, not dropped, because it fell through the
+// generic [lower] dispatch and hit [expHistogramSelectorRouting]'s
+// catch-all rejection instead of ever reaching label-sort logic at all
+// (#2462). Once recognised, the histogram-valued plan is ordered by the
+// exact same natural-sort-key machinery the float arm uses — the row
+// shape underneath the sort keys never enters the comparison — and
+// [chplan.RowShapeOf]'s OrderBy arm forwards [chplan.HistogramRowShape]
+// through unchanged so the wire layer keeps every histogram column
+// instead of re-projecting down to the canonical float quartet.
 func lowerSortByLabel(c *parser.Call, s schema.Metrics, ctx lowerCtx) (chplan.Node, error) {
 	if len(c.Args) < 1 {
 		return nil, fmt.Errorf("promql: %s expects at least 1 argument (vector[, label…]), got %d", c.Func.Name, len(c.Args))
 	}
-	inner, err := lower(c.Args[0], s, ctx)
-	if err != nil {
-		return nil, err
+	var inner chplan.Node
+	if hist, ok, err := lowerExpHistogramValuedShape(c.Args[0], s, ctx); ok {
+		if err != nil {
+			return nil, err
+		}
+		inner = hist
+	} else {
+		lowered, err := lower(c.Args[0], s, ctx)
+		if err != nil {
+			return nil, err
+		}
+		inner = lowered
 	}
 	if len(c.Args) == 1 {
 		// No sort key: identity ordering, per funcSortByLabel's

--- a/internal/promql/sort_by_label_exp_histogram_chdb_test.go
+++ b/internal/promql/sort_by_label_exp_histogram_chdb_test.go
@@ -1,0 +1,150 @@
+//go:build chdb
+
+// chDB-backed proof that PromQL `sort_by_label`/`sort_by_label_desc` over an
+// exp-histogram-valued vector (cerberus issue #2462) actually PRESERVES the
+// histogram sample at real ClickHouse execution, reordered by the named
+// label — not merely that the lowered plan's Go shape looks right.
+//
+// Unlike `sort`/`sort_desc` (#2456, which genuinely drop every histogram
+// sample — reference Prometheus's funcSort/funcSortDesc start from
+// filterFloats), funcSortByLabel/funcSortByLabelDesc sort the vector by
+// label value alone and never touch `.H`/`.F`, so a histogram sample
+// survives the sort unchanged. This test seeds real Count/Sum/bucket data
+// across several series, sorts by a label, and asserts both the resulting
+// ROW ORDER and that the histogram payload (Count) rode through untouched —
+// proving lowerSortByLabel's chplan.OrderBy-over-HistogramProjection wiring
+// (and chplan.RowShapeOf's OrderBy forwarding arm) actually emit SQL
+// ClickHouse accepts and answers correctly, not just SQL that type-checks
+// in Go.
+package promql_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/prometheus/prometheus/promql/parser"
+
+	"github.com/tsouza/cerberus/internal/chsql"
+	"github.com/tsouza/cerberus/internal/promql"
+	"github.com/tsouza/cerberus/internal/schema"
+	"github.com/tsouza/cerberus/internal/testsql"
+)
+
+// sortByLabelExpHistogramMetric is the metric name every case below
+// queries — distinct from histogramMergeBoundMetric (histogram_merge_
+// bound_chdb_test.go) so the two fixtures' seeds never collide on the
+// same MetricName within the shared chDB session.
+const sortByLabelExpHistogramMetric = "sort_by_label_target_exp_hist"
+
+// sortByLabelExpHistogramSeed declares the exp-histogram table (same shape
+// as histogramMergeBoundSeedDDL — CREATE OR REPLACE keeps re-application
+// idempotent across the shared in-process chDB session) and seeds three
+// series in an order that matches neither ascending nor descending label
+// sort, so a passing assertion can only come from the emitted ORDER BY.
+// Each series carries a distinct Count so the row-order assertion and the
+// payload-survival assertion are the same read.
+var sortByLabelExpHistogramSeed = "" +
+	"CREATE OR REPLACE TABLE otel_metrics_exponential_histogram (" +
+	"`MetricName` String, `Attributes` Map(String, String), " +
+	"`ResourceAttributes` Map(String, String) DEFAULT map(), `ServiceName` LowCardinality(String) DEFAULT '', " +
+	"`TimeUnix` DateTime64(9), " +
+	"`Count` UInt64, `Sum` Float64, `Scale` Int32, `ZeroCount` UInt64, " +
+	"`PositiveOffset` Int32, `PositiveBucketCounts` Array(UInt64), " +
+	"`NegativeOffset` Int32, `NegativeBucketCounts` Array(UInt64)" +
+	") ENGINE = MergeTree ORDER BY (`MetricName`, `Attributes`, `TimeUnix`);\n" +
+	"INSERT INTO otel_metrics_exponential_histogram " +
+	"(MetricName, Attributes, TimeUnix, Count, Sum, Scale, ZeroCount, PositiveOffset, PositiveBucketCounts, NegativeOffset, NegativeBucketCounts) VALUES\n" +
+	"    ('" + sortByLabelExpHistogramMetric + "', map('job', 'c'), toDateTime64('2026-01-01 00:00:00', 9), 30, 3.0, 0, 0, 0, [30], 0, []),\n" +
+	"    ('" + sortByLabelExpHistogramMetric + "', map('job', 'a'), toDateTime64('2026-01-01 00:00:00', 9), 10, 1.0, 0, 0, 0, [10], 0, []),\n" +
+	"    ('" + sortByLabelExpHistogramMetric + "', map('job', 'b'), toDateTime64('2026-01-01 00:00:00', 9), 20, 2.0, 0, 0, 0, [20], 0, []);\n"
+
+// sortByLabelExpHistogramEvalTS sits one second after every seeded row —
+// well inside the bare-selector staleness lookback.
+var sortByLabelExpHistogramEvalTS = time.Date(2026, 1, 1, 0, 0, 1, 0, time.UTC)
+
+func TestSortByLabel_ExpHistogram_ChDB_PreservesAndOrders(t *testing.T) {
+	fixture := newChDBFixture(t, sortByLabelExpHistogramSeed)
+
+	s := schema.DefaultOTelMetrics()
+	p := parser.NewParser(parser.Options{EnableExperimentalFunctions: true})
+
+	cases := []struct {
+		name      string
+		query     string
+		wantJobs  []string
+		wantCount []float64
+	}{
+		{
+			name:      "asc",
+			query:     fmt.Sprintf(`sort_by_label(%s, "job")`, sortByLabelExpHistogramMetric),
+			wantJobs:  []string{"a", "b", "c"},
+			wantCount: []float64{10, 20, 30},
+		},
+		{
+			name:      "desc",
+			query:     fmt.Sprintf(`sort_by_label_desc(%s, "job")`, sortByLabelExpHistogramMetric),
+			wantJobs:  []string{"c", "b", "a"},
+			wantCount: []float64{30, 20, 10},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			expr, err := p.ParseExpr(tc.query)
+			if err != nil {
+				t.Fatalf("ParseExpr(%q): %v", tc.query, err)
+			}
+			plan, err := promql.LowerAt(context.Background(), expr, s, sortByLabelExpHistogramEvalTS, sortByLabelExpHistogramEvalTS)
+			if err != nil {
+				t.Fatalf("LowerAt(%q): %v", tc.query, err)
+			}
+			sqlStr, args, err := chsql.Emit(context.Background(), plan)
+			if err != nil {
+				t.Fatalf("Emit(%q): %v", tc.query, err)
+			}
+
+			// Project the label value plus HistogramCount (the wire alias
+			// [chplan.HistogramProjection] publishes for the Count column,
+			// see chplan.HistogramCountColumn) as plain scalar columns —
+			// the same Map-scan sidestep sort_by_label_chdb_test.go uses —
+			// preserving the ORDER BY-produced row order.
+			projection := "`Attributes`['job'] AS job, `HistogramCount` AS cnt"
+			rows := fixture.queryOverEmitted(t, projection, sqlStr, args)
+			defer func() { _ = rows.Close() }()
+
+			var gotJobs []string
+			var gotCounts []float64
+			for rows.Next() {
+				var job string
+				var cnt float64
+				if err := rows.Scan(&job, &cnt); err != nil {
+					t.Fatalf("scan: %v", err)
+				}
+				gotJobs = append(gotJobs, job)
+				gotCounts = append(gotCounts, cnt)
+			}
+			if err := testsql.TolerantRowsErr(rows.Err()); err != nil {
+				t.Fatalf("rows.Err: %v", err)
+			}
+
+			if len(gotJobs) != len(tc.wantJobs) {
+				t.Fatalf("%s: got %d rows %v, want %d %v — the histogram sample(s) must survive the sort, not be dropped",
+					tc.query, len(gotJobs), gotJobs, len(tc.wantJobs), tc.wantJobs)
+			}
+			for i := range tc.wantJobs {
+				if gotJobs[i] != tc.wantJobs[i] {
+					t.Errorf("%s: job order mismatch at %d: got %v, want %v", tc.query, i, gotJobs, tc.wantJobs)
+					break
+				}
+			}
+			for i := range tc.wantCount {
+				if gotCounts[i] != tc.wantCount[i] {
+					t.Errorf("%s: Count mismatch at row %d (job=%s): got %v, want %v — the histogram payload did not ride through the sort unchanged",
+						tc.query, i, gotJobs[i], gotCounts[i], tc.wantCount[i])
+				}
+			}
+		})
+	}
+}

--- a/internal/promql/sort_exp_histogram_test.go
+++ b/internal/promql/sort_exp_histogram_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/prometheus/prometheus/promql/parser"
 
+	"github.com/tsouza/cerberus/internal/chplan"
 	"github.com/tsouza/cerberus/internal/promql"
 	"github.com/tsouza/cerberus/internal/schema"
 )
@@ -51,6 +52,60 @@ func TestLower_ExpHistogram_SortFamilyDropsSamples(t *testing.T) {
 				t.Fatalf("LowerAt(%q): %v", query, err)
 			}
 			assertEmptyFloatProjection(t, plan)
+		})
+	}
+}
+
+// TestLower_ExpHistogram_SortByLabelFamilyPreservesSamples pins issue
+// #2462. Unlike sort()/sort_desc() (#2456), reference Prometheus's
+// funcSortByLabel/funcSortByLabelDesc (promql/functions.go) do NOT start
+// from filterFloats: they sort the vector in place by the named labels'
+// VALUES alone, so a histogram sample sorts (and survives) right
+// alongside float samples — verified directly against the vendored
+// reference engine (see sort.go's lowerSortByLabel doc comment for the
+// promqltest probe). `lowerSortByLabel` still needs a
+// lowerExpHistogramValuedShape check because, before this fix, an
+// exp-histogram argument fell through the generic lower() dispatch and
+// hit expHistogramSelectorRouting's catch-all rejection before label-sort
+// logic was ever reached — but the correct answer on recognising the
+// shape is to PRESERVE it (ordered by label, chplan.HistogramRowShape
+// forwarded through chplan.OrderBy), never to drop it to an empty float
+// vector.
+func TestLower_ExpHistogram_SortByLabelFamilyPreservesSamples(t *testing.T) {
+	t.Parallel()
+
+	s := schema.DefaultOTelMetrics()
+	at := time.Date(2026, 1, 1, 0, 0, 1, 0, time.UTC)
+
+	queries := []string{
+		`sort_by_label(latency_exp_hist, "job")`,
+		`sort_by_label_desc(latency_exp_hist, "job")`,
+
+		// No label list: funcSortByLabel's zero-comparator stable sort —
+		// still histogram-valued, no OrderBy wraps it.
+		`sort_by_label(latency_exp_hist)`,
+
+		// Multiple tie-breaker labels.
+		`sort_by_label(latency_exp_hist, "job", "instance")`,
+
+		// The consumer sees histogram-valued results, not only selectors.
+		`sort_by_label(sum(latency_exp_hist), "job")`,
+		`sort_by_label_desc(rate(latency_exp_hist[5m]), "job")`,
+	}
+
+	for _, query := range queries {
+		query := query
+		t.Run(query, func(t *testing.T) {
+			t.Parallel()
+
+			expr := parseExprExp(t, query)
+			plan, err := promql.LowerAt(context.Background(), expr, s, at, at)
+			if err != nil {
+				t.Fatalf("LowerAt(%q): %v", query, err)
+			}
+			if shape := chplan.RowShapeOf(plan); shape != chplan.HistogramRowShape {
+				t.Fatalf("LowerAt(%q) plan publishes %s, want histogram — the sample must be preserved, not dropped", query, shape)
+			}
 		})
 	}
 }

--- a/test/rejection-parity/catalogue/internal__promql__lower.go.json
+++ b/test/rejection-parity/catalogue/internal__promql__lower.go.json
@@ -94,8 +94,8 @@
       "site": "internal/promql/lower.go:expHistogramSelectorRouting#bf746b59",
       "message": "promql: %q is an exponential histogram metric; only a bare %q selector, sum()/avg()/count() over one, rate()/increase()/delta()/irate()/idelta()/sum_over_time()/avg_over_time()/resets()/changes() over one, histogram_quantile(), histogram_count(), histogram_sum(), and the %q/%q companion selectors are supported",
       "class": "divergence",
-      "trigger_query": "sort_by_label(demo_latency_exp_hist, \"job\")",
-      "tracking_issue": 2462,
+      "trigger_query": "timestamp(demo_latency_exp_hist)",
+      "tracking_issue": 2474,
       "evidence": {
         "guard": [
           "past returning if bare, col, hasCompanion := s.HistogramCompanionColumn(metricName); hasCompanion \u0026\u0026 s.IsExpHistogramMetric(bare) \u0026\u0026 s.ExpHistogramTable != \"\"",


### PR DESCRIPTION
## Summary

- Closes #2462: `sort_by_label(demo_latency_exp_hist, "job")` / `sort_by_label_desc(...)` were
  hard-rejected because `lowerSortByLabel` (`internal/promql/sort.go`) routed its vector argument
  straight through `lower()` with no `lowerExpHistogramValuedShape` check, falling through to
  `expHistogramSelectorRouting`'s catch-all rejection.
- **The issue's own premise does not hold.** #2462 asked for the same drop-to-empty pattern #2456
  applied to `sort()`/`sort_desc()`, on the claim that reference Prometheus's
  `funcSortByLabel`/`funcSortByLabelDesc` also start from `filterFloats`. They don't — verified
  directly against the vendored reference engine
  (`github.com/tsouza/prometheus`'s `promql/promqltest`): those two functions sort the vector
  in-place by the named labels' *values* alone and never touch `.H`/`.F`, so a native-histogram
  sample sorts (and survives) right alongside float samples. `sort()`/`sort_desc()` sort by
  *value*, which is genuinely undefined for a histogram sample — that's why they drop. Shipping
  the drop-to-empty fix as asked would have introduced a real divergence from reference Prometheus
  instead of closing one, so it was not implemented; the actual reference-matching behavior is
  implemented instead.
- `lowerSortByLabel` now recognises an exp-histogram-valued argument and **preserves** it, applying
  the same natural-sort-key `OrderBy` the float arm already uses.
- `chplan.RowShapeOf` gains a forwarding arm for `*OrderBy`: `emitOrderBy` renders `SELECT * FROM
  (<input>) ORDER BY ...`, a genuine column passthrough, so its row shape must be whatever its
  input publishes. It previously defaulted to `SampleRowShape` for every `OrderBy` (fine while every
  existing `OrderBy` wrapped a float-shaped plan) — wrapping a `HistogramProjection` without this
  fix would have made the wire layer's `wrapWithSampleProjection` re-project down to the canonical
  float quartet, silently dropping all nine histogram columns.
- Rotates the rejection-parity catalogue's `expHistogramSelectorRouting` divergence entry to its
  next reachable trigger, `timestamp(demo_latency_exp_hist)`, now that `sort_by_label()` no longer
  exercises it. Filed **#2474** to track that rotation — `lowerDateFn`'s `timestamp()` has the
  identical gap (reference answers with the sample's own timestamp regardless of its value;
  cerberus still rejects), confirmed against the same vendored reference engine.

## Verification

- `go test ./internal/promql/...` — full package, green.
- `go test ./internal/chplan/...` — green.
- `go test -tags chdb -run TestSortByLabel_ExpHistogram_ChDB_PreservesAndOrders ./internal/promql/...`
  — new chDB-backed test proving the emitted SQL round-trips through real ClickHouse: the row order
  matches the label sort and the histogram `Count` payload rides through unchanged (not the
  placeholder value dropping would leave).
- `go test -tags chdb ./internal/promql/...` — full chdb-tagged package suite, green (421s).
- `go test ./test/rejection-parity/...` (`TestCatalogueIsRegenerable`, `TestRejectionTriggersExerciseSites`,
  `TestParityCorpusMatchesCatalogue`, `TestCatalogueEntriesAreClassified`,
  `TestDivergenceEntriesRespectAgeCap`) — green; the catalogue rotation is byte-identical to what
  regeneration would produce.
- `node .github/scripts/forbid-sql-raw.mjs` — clean (no raw SQL touched; typed chsql API unchanged).

## Test plan

- [ ] CI green (lint, test, build, chdb roundtrip)
- [ ] `update-golden.yml` regen (dispatched for `promql`) lands clean

Closes #2462
