### PR TITLE
fix(promql): answer timestamp() over an exp-histogram-valued argument

### DIFF
--- a/internal/promql/date_fns.go
+++ b/internal/promql/date_fns.go
@@ -62,6 +62,21 @@ func lowerDateFn(c *parser.Call, s schema.Metrics, ctx lowerCtx) (chplan.Node, e
 		return lowerDateFnNoArg(c.Func.Name, s, ctx)
 	}
 
+	// `timestamp(v)` is defined for a histogram-VALUED argument exactly as
+	// it is for a float-valued one — reference reads only Point.T, never
+	// Point.H/Point.F (see this file's package doc). Every other
+	// date-component function's argument is genuinely FLOAT-only (its
+	// value math divides/casts the sample's own Value), so this check is
+	// scoped to `timestamp` alone. See histogram_native_timestamp.go for
+	// why the generic `lower()` call below cannot answer it: an
+	// exp-histogram-valued argument falls through to
+	// expHistogramSelectorRouting's catch-all rejection without this.
+	if c.Func.Name == "timestamp" {
+		if node, ok, err := lowerTimestampOverExpHistogram(c.Args[0], s, ctx); ok {
+			return node, err
+		}
+	}
+
 	// The argument is lowered under an ARGUMENT ctx rather than the caller's
 	// own, because `timestamp(<vector-selector>)` needs the selector seam to
 	// publish a column no other consumer asks for. Every other function/shape

--- a/internal/promql/histogram_native_timestamp.go
+++ b/internal/promql/histogram_native_timestamp.go
@@ -1,0 +1,232 @@
+package promql
+
+import (
+	"github.com/prometheus/prometheus/promql/parser"
+
+	"github.com/tsouza/cerberus/internal/chplan"
+	"github.com/tsouza/cerberus/internal/schema"
+)
+
+// histogram_native_timestamp.go lowers `timestamp(<exp-histogram-valued
+// argument>)` (cerberus issue #2474). It is the sibling `sort`/`sort_desc`
+// (#2456) and `clamp`/`absent` (#2345/#2443) already have: `lowerDateFn`
+// (date_fns.go) calls the generic `lower()` on its argument unconditionally,
+// which for a bare exp-histogram selector falls through to
+// `expHistogramSelectorRouting`'s catch-all rejection instead of ever
+// reaching `timestamp`'s own logic — and for any OTHER histogram-valued
+// shape (`sum(m_exp_hist)`, `rate(m_exp_hist[5m])`, …) the recursive
+// `lower()` call bypasses [lowerRoot]'s histogram-aware dispatch entirely
+// (that dispatch only runs at the ROOT of the whole expression tree), so
+// even a shape `sum(m_exp_hist)` alone lowers successfully hits the exact
+// same rejection once wrapped in `timestamp(...)`.
+//
+// Reference semantics (tsouza/prometheus@cerberus-parser promql/engine.go,
+// funcTimestamp / rangeEvalTimestampFunctionOverVectorSelector — see
+// date_fns.go's [timestampResultExpr] for the full citation): `timestamp(v)`
+// reads only the selected sample's `Point.T`, never `Point.H`/`Point.F`, so
+// it answers identically whether v is float- or histogram-valued. The
+// PARSER SHAPE of the argument — not its runtime type — picks WHICH
+// timestamp:
+//
+//   - a bare (optionally parenthesised / `@`-pinned) VectorSelector reports
+//     the SELECTED SAMPLE's own raw timestamp;
+//   - every other shape reports the EVALUATION instant instead.
+//
+// This file reproduces that same split for a histogram-valued argument:
+//
+//   - [lowerTimestampOverExpHistogramBareSelector] handles the selector
+//     case. It needs a raw timestamp none of the existing histogram
+//     lowerings expose: [nativeHistogramProjection] (histogram_native_bare.go)
+//     — the projection every OTHER bare-selector-rooted histogram
+//     consumer shares — collapses to the newest sample via
+//     `argMax(<col>, TimeUnix)` and then stamps its OWN TimeUnix output
+//     with the eval instant (`now64(9)` / the grid anchor), discarding the
+//     selected sample's actual time. That eval-instant stamp is correct
+//     for every other histogram-valued consumer (their VALUE math never
+//     depends on the sample's own time — see [lowerHistogramValueFnInstant]),
+//     but wrong for `timestamp()`, so this sibling mirrors
+//     [lowerExpHistogramBare]'s three range-grid branches with a much
+//     lighter aggregate — just `max(TimeUnix)`, via
+//     [histogramSampleTimestampAgg] — since `timestamp()` never touches a
+//     single bucket/count/sum column.
+//   - every other histogram-valued shape reuses
+//     [lowerExpHistogramValuedShape] directly (the same recognizer
+//     `sort`/`instant_fns.go` already gate on) purely for its ROW
+//     IDENTITY (Attributes) and PLAN SHAPE; [projectExpHistogramEvalInstant]
+//     discards that plan's own TimeUnix column (which may be wall-clock
+//     `now64(9)`, not the request's eval anchor — see
+//     [nativeHistogramProjection]'s doc) and replaces it with
+//     [evalInstantExpr], the SAME expression the float, non-selector arm
+//     of [timestampResultExpr] already uses.
+func lowerTimestampOverExpHistogram(arg parser.Expr, s schema.Metrics, ctx lowerCtx) (chplan.Node, bool, error) {
+	if vs, ok := bareExpHistogramSelector(arg, s, ctx); ok {
+		node, err := lowerTimestampOverExpHistogramBareSelector(vs, s, ctx)
+		return node, true, err
+	}
+	if hist, ok, err := lowerExpHistogramValuedShape(arg, s, ctx); ok {
+		if err != nil {
+			return nil, true, err
+		}
+		return projectExpHistogramEvalInstant(hist, s, ctx), true, nil
+	}
+	return nil, false, nil
+}
+
+// expHistogramSampleTimestampAlias names the one column
+// [histogramSampleTimestampAgg] adds to an otherwise-ordinary histogram
+// bare-selector aggregate: the raw `max(TimeUnix)` of the selected sample.
+// It is deliberately distinct from both s.TimestampColumn (which the
+// range-mode branches use for the STEP ANCHOR — see [timestampRangeProjection])
+// and [stepGridAnchorColumn], so a single row can carry both without either
+// value shadowing the other.
+const expHistogramSampleTimestampAlias = "exp_hist_sample_ts"
+
+// histogramSampleTimestampAgg is the aggregate function `timestamp()` needs
+// from a bare exp-histogram selector: just the SELECTED SAMPLE's own raw
+// TimeUnix. Unlike [nativeExpHistBareAggs] it never reads a single field of
+// the histogram itself — `timestamp(v)` answers `Point.T` and never touches
+// `Point.H`/`Point.F` — so the bucket ladder never needs to leave the
+// aggregate.
+func histogramSampleTimestampAgg(s schema.Metrics) []chplan.AggFunc {
+	return []chplan.AggFunc{
+		{
+			Fn:    chplan.FnMax,
+			Args:  []chplan.Expr{&chplan.ColumnRef{Name: s.TimestampColumn}},
+			Alias: expHistogramSampleTimestampAlias,
+		},
+	}
+}
+
+// lowerTimestampOverExpHistogramBareSelector lowers `timestamp(<bare
+// exp-histogram selector>)` across the same three range-grid shapes
+// [lowerExpHistogramBare] distinguishes — see this file's doc for why it
+// cannot reuse that sibling's own projection.
+func lowerTimestampOverExpHistogramBareSelector(vs *parser.VectorSelector, s schema.Metrics, ctx lowerCtx) (chplan.Node, error) {
+	switch rangeGridShapeFor(vs, ctx) {
+	case gridFanout:
+		scan := &chplan.Scan{Table: s.ExpHistogramTable}
+		pred := buildPredicate(vs.LabelMatchers, s)
+		fanout := buildHistogramBucketFanout(
+			scan, pred, nil, windowFor(vs, instantLookback),
+			[]chplan.Expr{histogramIdentityExpr(s)}, []string{s.AttributesColumn},
+			histogramSampleTimestampAgg(s), s, ctx,
+		)
+		return timestampRangeProjection(fanout, s), nil
+	case gridBroadcast:
+		// Same split as [lowerExpHistogramBare]'s own gridBroadcast arm:
+		// the pinned window is resolved ONCE via the instant-mode
+		// aggregate, then fanned across the step grid — every step
+		// reports the SAME selected sample's timestamp, at its own
+		// step position.
+		latest, err := expHistogramSampleTimestampLatest(vs, s, ctx)
+		if err != nil {
+			return nil, err
+		}
+		grid := &chplan.StepGrid{Start: ctx.start.UTC(), End: ctx.end.UTC(), Step: ctx.step}
+		return timestampRangeProjection(&chplan.CrossJoin{Left: grid, Right: latest}, s), nil
+	default:
+		latest, err := expHistogramSampleTimestampLatest(vs, s, ctx)
+		if err != nil {
+			return nil, err
+		}
+		return timestampInstantProjection(latest, s), nil
+	}
+}
+
+// expHistogramSampleTimestampLatest builds the instant-mode subtree beneath
+// [lowerTimestampOverExpHistogramBareSelector]'s single-anchor and
+// gridBroadcast branches: the filtered exp-histogram scan collapsed to the
+// newest in-window sample per series, exposing only
+// [expHistogramSampleTimestampAlias]. Window/predicate logic is identical
+// to [expHistogramBareLatest] — same matchers, same instant-window bound —
+// only the aggregate list differs.
+func expHistogramSampleTimestampLatest(vs *parser.VectorSelector, s schema.Metrics, ctx lowerCtx) (chplan.Node, error) {
+	scan := &chplan.Scan{Table: s.ExpHistogramTable}
+	pred := buildPredicate(vs.LabelMatchers, s)
+	pred, err := andInstantWindow(pred, vs, s.TimestampColumn, ctx)
+	if err != nil {
+		return nil, err
+	}
+	var input chplan.Node = scan
+	if pred != nil {
+		input = &chplan.Filter{Input: scan, Predicate: pred}
+	}
+	return latestSampleAgg(input, histogramSampleTimestampAgg(s), s), nil
+}
+
+// timestampInstantProjection projects the INSTANT-mode latest-sample
+// aggregate into the canonical float Sample shape `timestamp()` reports:
+// `__name__` drops (a derived sample, like every other histogram-valued
+// function's output — see [bareExpHistogramNameExpr]'s doc for the
+// bare-selector exception that does NOT apply here), and BOTH the reported
+// TimeUnix and the Value are the raw sample time — mirroring the plain
+// float instant seam, where `timestamp(<selector>)` reads the very column
+// the LWR aggregate already reports as TimeUnix (see [timestampResultExpr]'s
+// doc: "the instant seam already emits `max(TimeUnix) AS lwr_ts`").
+func timestampInstantProjection(inner chplan.Node, s schema.Metrics) chplan.Node {
+	ts := &chplan.ColumnRef{Name: expHistogramSampleTimestampAlias}
+	return &chplan.Project{
+		Input: inner,
+		Projections: []chplan.Projection{
+			{Expr: &chplan.LitString{V: ""}, Alias: s.MetricNameColumn},
+			{Expr: &chplan.ColumnRef{Name: s.AttributesColumn}, Alias: s.AttributesColumn},
+			{Expr: ts, Alias: s.TimestampColumn},
+			{Expr: asFloat64(dateFnExpr("timestamp", nil, ts)), Alias: s.ValueColumn},
+		},
+	}
+}
+
+// timestampRangeProjection projects a RANGE-mode plan — either
+// [buildHistogramBucketFanout]'s per-(series,anchor) fan-out or the
+// gridBroadcast CrossJoin — into the canonical float Sample shape. Unlike
+// the instant projection, the reported TimeUnix and the Value diverge: the
+// former is the STEP ANCHOR (every range-mode row is positioned along the
+// matrix by its anchor, exactly like [lowerHistogramValueFnRange] and
+// [nativeHistogramProjection]'s own range branches), while the latter stays
+// the selected sample's raw time, via [expHistogramSampleTimestampAlias].
+func timestampRangeProjection(inner chplan.Node, s schema.Metrics) chplan.Node {
+	anchor := &chplan.ColumnRef{Name: stepGridAnchorColumn}
+	rawTs := &chplan.ColumnRef{Name: expHistogramSampleTimestampAlias}
+	return &chplan.Project{
+		Input: inner,
+		Projections: []chplan.Projection{
+			{Expr: &chplan.LitString{V: ""}, Alias: s.MetricNameColumn},
+			{Expr: &chplan.ColumnRef{Name: s.AttributesColumn}, Alias: s.AttributesColumn},
+			{Expr: anchor, Alias: s.TimestampColumn},
+			{Expr: asFloat64(dateFnExpr("timestamp", nil, rawTs)), Alias: s.ValueColumn},
+		},
+	}
+}
+
+// projectExpHistogramEvalInstant projects any OTHER exp-histogram-valued
+// shape (`sum(m)`, `rate(m[5m])`, a histogram/histogram binop, …) — i.e.
+// every shape [lowerExpHistogramValuedShape] recognises OTHER than a bare
+// selector, which [lowerTimestampOverExpHistogram] routes to
+// [lowerTimestampOverExpHistogramBareSelector] instead — into the float
+// Sample shape `timestamp()` reports for a non-selector argument: the
+// EVALUATION instant, via [evalInstantExpr], the same expression the
+// float, non-selector arm of [timestampResultExpr] already uses.
+//
+// hist's own TimeUnix column is deliberately never read here: every
+// histogram-valued lowering stamps it with SOME eval-instant-shaped value
+// of its own choosing (`now64(9)` in instant mode — see
+// [nativeHistogramProjection]'s doc — or the grid anchor in range mode),
+// which for the RANGE case happens to already equal [evalInstantExpr]'s
+// answer but for the INSTANT case does not: `now64(9)` is the wall-clock
+// time the query executes, not the request's own eval anchor
+// ([evalInstantExpr] reads the anchor the request pinned, falling back to
+// `now64(9)` only when none was threaded). Overriding it here rather than
+// forwarding it keeps this projection correct for both modes without a
+// mode branch of its own — [evalInstantExpr] already contains that branch.
+func projectExpHistogramEvalInstant(hist chplan.Node, s schema.Metrics, ctx lowerCtx) chplan.Node {
+	ts := evalInstantExpr(s, ctx)
+	return &chplan.Project{
+		Input: hist,
+		Projections: []chplan.Projection{
+			{Expr: &chplan.LitString{V: ""}, Alias: s.MetricNameColumn},
+			{Expr: &chplan.ColumnRef{Name: s.AttributesColumn}, Alias: s.AttributesColumn},
+			{Expr: ts, Alias: s.TimestampColumn},
+			{Expr: asFloat64(dateFnExpr("timestamp", nil, ts)), Alias: s.ValueColumn},
+		},
+	}
+}

--- a/internal/promql/histogram_native_timestamp.go
+++ b/internal/promql/histogram_native_timestamp.go
@@ -17,8 +17,8 @@ import (
 // shape (`sum(m_exp_hist)`, `rate(m_exp_hist[5m])`, …) the recursive
 // `lower()` call bypasses [lowerRoot]'s histogram-aware dispatch entirely
 // (that dispatch only runs at the ROOT of the whole expression tree), so
-// even a shape `sum(m_exp_hist)` alone lowers successfully hits the exact
-// same rejection once wrapped in `timestamp(...)`.
+// even a shape like `sum(m_exp_hist)` — which lowers successfully on its
+// own — hits the exact same rejection once wrapped in `timestamp(...)`.
 //
 // Reference semantics (tsouza/prometheus@cerberus-parser promql/engine.go,
 // funcTimestamp / rangeEvalTimestampFunctionOverVectorSelector — see

--- a/internal/promql/histogram_native_timestamp_test.go
+++ b/internal/promql/histogram_native_timestamp_test.go
@@ -1,0 +1,170 @@
+package promql_test
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/prometheus/prometheus/promql/parser"
+
+	"github.com/tsouza/cerberus/internal/chplan"
+	"github.com/tsouza/cerberus/internal/chsql"
+	"github.com/tsouza/cerberus/internal/promql"
+	"github.com/tsouza/cerberus/internal/schema"
+)
+
+// TestLower_ExpHistogram_Timestamp pins cerberus issue #2474:
+// `timestamp(v)` reads only the selected sample's own timestamp, never its
+// value, so it is defined for a histogram-valued argument exactly as it is
+// for a float-valued one — unlike the float-only date-component functions
+// (year/month/hour/…) and unlike sort/clamp/absent's "drop the histogram
+// samples" posture. Every representative shape below must lower
+// successfully to the canonical float [chplan.SampleRowShape], both in
+// instant and range mode, and the produced SQL must actually compile
+// through the chsql emitter.
+func TestLower_ExpHistogram_Timestamp(t *testing.T) {
+	t.Parallel()
+
+	s := schema.DefaultOTelMetrics()
+	p := parser.NewParser(parser.Options{EnableExperimentalFunctions: true})
+	at := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	start := at.Add(-time.Hour)
+
+	cases := []struct {
+		name  string
+		query string
+	}{
+		{
+			name:  "issue representative query: bare exp-histogram selector",
+			query: `timestamp(demo_latency_exp_hist)`,
+		},
+		{
+			name:  "bare selector with label matcher",
+			query: `timestamp(demo_latency_exp_hist{service="api"})`,
+		},
+		{
+			name:  "parenthesised bare selector",
+			query: `timestamp((demo_latency_exp_hist))`,
+		},
+		{
+			name:  "sum() wrapping a bare exp-histogram selector",
+			query: `timestamp(sum(demo_latency_exp_hist))`,
+		},
+		{
+			name:  "avg() wrapping a bare exp-histogram selector",
+			query: `timestamp(avg(demo_latency_exp_hist))`,
+		},
+		{
+			name:  "rate() over an exp-histogram range selector",
+			query: `timestamp(rate(demo_latency_exp_hist[5m]))`,
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name+"/instant", func(t *testing.T) {
+			t.Parallel()
+			expr, err := p.ParseExpr(tc.query)
+			if err != nil {
+				t.Fatalf("ParseExpr(%q): %v", tc.query, err)
+			}
+			plan, err := promql.LowerAt(context.Background(), expr, s, at, at)
+			if err != nil {
+				t.Fatalf("LowerAt(%q): unexpected error: %v", tc.query, err)
+			}
+			if shape := chplan.RowShapeOf(plan); shape != chplan.SampleRowShape {
+				t.Fatalf("lower(%q): plan root publishes %s, want %s", tc.query, shape, chplan.SampleRowShape)
+			}
+			if _, _, err := chsql.Emit(context.Background(), plan); err != nil {
+				t.Fatalf("chsql.Emit(%q): %v", tc.query, err)
+			}
+		})
+		t.Run(tc.name+"/range", func(t *testing.T) {
+			t.Parallel()
+			expr, err := p.ParseExpr(tc.query)
+			if err != nil {
+				t.Fatalf("ParseExpr(%q): %v", tc.query, err)
+			}
+			plan, err := promql.LowerAtRange(context.Background(), expr, s, start, at, 30*time.Second)
+			if err != nil {
+				t.Fatalf("LowerAtRange(%q): unexpected error: %v", tc.query, err)
+			}
+			if shape := chplan.RowShapeOf(plan); shape != chplan.SampleRowShape {
+				t.Fatalf("lower(%q) range: plan root publishes %s, want %s", tc.query, shape, chplan.SampleRowShape)
+			}
+			if _, _, err := chsql.Emit(context.Background(), plan); err != nil {
+				t.Fatalf("chsql.Emit(%q) range: %v", tc.query, err)
+			}
+		})
+	}
+}
+
+// TestLower_ExpHistogram_Timestamp_AtPin covers the range-query, `@`-pinned
+// (gridBroadcast) shape for a bare exp-histogram selector: the pinned
+// window is resolved once and its selected sample's timestamp is fanned
+// across the step grid, at each step's own anchor position.
+func TestLower_ExpHistogram_Timestamp_AtPin(t *testing.T) {
+	t.Parallel()
+
+	s := schema.DefaultOTelMetrics()
+	p := parser.NewParser(parser.Options{EnableExperimentalFunctions: true})
+	at := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	start := at.Add(-time.Hour)
+
+	query := `timestamp(demo_latency_exp_hist @ 1735689600)`
+	expr, err := p.ParseExpr(query)
+	if err != nil {
+		t.Fatalf("ParseExpr(%q): %v", query, err)
+	}
+	plan, err := promql.LowerAtRange(context.Background(), expr, s, start, at, 30*time.Second)
+	if err != nil {
+		t.Fatalf("LowerAtRange(%q): unexpected error: %v", query, err)
+	}
+	if shape := chplan.RowShapeOf(plan); shape != chplan.SampleRowShape {
+		t.Fatalf("lower(%q): plan root publishes %s, want %s", query, shape, chplan.SampleRowShape)
+	}
+	if _, _, err := chsql.Emit(context.Background(), plan); err != nil {
+		t.Fatalf("chsql.Emit(%q): %v", query, err)
+	}
+}
+
+// TestLower_ExpHistogram_Timestamp_OtherDateFnsStillRejectHistograms
+// guards the fix's scope: `timestamp()` is the ONLY date-component
+// function whose value is independent of the sample's payload (reference
+// reads only Point.T). Every sibling (year/month/day_of_month/…) computes
+// its value FROM the sample's Value column via [valueAsDateTime], which a
+// native histogram sample never populates meaningfully — those must keep
+// hitting expHistogramSelectorRouting's rejection over a bare exp-histogram
+// selector, exactly as before this fix.
+func TestLower_ExpHistogram_Timestamp_OtherDateFnsStillRejectHistograms(t *testing.T) {
+	t.Parallel()
+
+	s := schema.DefaultOTelMetrics()
+	p := parser.NewParser(parser.Options{EnableExperimentalFunctions: true})
+	at := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+
+	for _, query := range []string{
+		`year(demo_latency_exp_hist)`,
+		`month(demo_latency_exp_hist)`,
+		`hour(demo_latency_exp_hist)`,
+		`minute(demo_latency_exp_hist)`,
+		`day_of_week(demo_latency_exp_hist)`,
+	} {
+		query := query
+		t.Run(query, func(t *testing.T) {
+			t.Parallel()
+			expr, err := p.ParseExpr(query)
+			if err != nil {
+				t.Fatalf("ParseExpr(%q): %v", query, err)
+			}
+			_, err = promql.LowerAt(context.Background(), expr, s, at, at)
+			if err == nil {
+				t.Fatalf("LowerAt(%q): expected the exponential-histogram routing rejection, got nil error", query)
+			}
+			if !strings.Contains(err.Error(), "is an exponential histogram metric") {
+				t.Fatalf("LowerAt(%q): unexpected error: %v", query, err)
+			}
+		})
+	}
+}

--- a/test/perf/cardinality-baseline/promql/timestamp_of_exp_histogram_bare_selector.json
+++ b/test/perf/cardinality-baseline/promql/timestamp_of_exp_histogram_bare_selector.json
@@ -1,0 +1,11 @@
+{
+  "fixture": "promql/timestamp_of_exp_histogram_bare_selector",
+  "fan_factor": 1,
+  "scan_rows": 1,
+  "peak_intermediate": 1,
+  "has_cross_join": false,
+  "has_array_join": false,
+  "has_recursive_cte": false,
+  "max_recursion_depth": 0,
+  "uncountable_levels": 0
+}

--- a/test/perf/cardinality-baseline/promql/timestamp_of_exp_histogram_bare_selector_range.json
+++ b/test/perf/cardinality-baseline/promql/timestamp_of_exp_histogram_bare_selector_range.json
@@ -1,0 +1,11 @@
+{
+  "fixture": "promql/timestamp_of_exp_histogram_bare_selector_range",
+  "fan_factor": 10,
+  "scan_rows": 1,
+  "peak_intermediate": 10,
+  "has_cross_join": false,
+  "has_array_join": true,
+  "has_recursive_cte": false,
+  "max_recursion_depth": 0,
+  "uncountable_levels": 0
+}

--- a/test/perf/cardinality-baseline/promql/timestamp_of_exp_histogram_sum.json
+++ b/test/perf/cardinality-baseline/promql/timestamp_of_exp_histogram_sum.json
@@ -1,0 +1,11 @@
+{
+  "fixture": "promql/timestamp_of_exp_histogram_sum",
+  "fan_factor": 1,
+  "scan_rows": 1,
+  "peak_intermediate": 1,
+  "has_cross_join": false,
+  "has_array_join": false,
+  "has_recursive_cte": false,
+  "max_recursion_depth": 0,
+  "uncountable_levels": 0
+}

--- a/test/perf/solver-decision-baseline/timestamp_of_exp_histogram_bare_selector/fanout.json
+++ b/test/perf/solver-decision-baseline/timestamp_of_exp_histogram_bare_selector/fanout.json
@@ -1,0 +1,11 @@
+{
+  "query": "timestamp_of_exp_histogram_bare_selector/fanout",
+  "lowering": "fanout",
+  "routed": true,
+  "k": 8,
+  "reason": "routed",
+  "n_anchors": 241,
+  "fanout": 20,
+  "cumulative_d": "5m0s",
+  "outer_range": "1h0m0s"
+}

--- a/test/perf/solver-decision-baseline/timestamp_of_exp_histogram_bare_selector/native.json
+++ b/test/perf/solver-decision-baseline/timestamp_of_exp_histogram_bare_selector/native.json
@@ -1,0 +1,11 @@
+{
+  "query": "timestamp_of_exp_histogram_bare_selector/native",
+  "lowering": "native",
+  "routed": true,
+  "k": 8,
+  "reason": "routed",
+  "n_anchors": 241,
+  "fanout": 20,
+  "cumulative_d": "5m0s",
+  "outer_range": "1h0m0s"
+}

--- a/test/perf/solver-decision-baseline/timestamp_of_exp_histogram_bare_selector_range/fanout.json
+++ b/test/perf/solver-decision-baseline/timestamp_of_exp_histogram_bare_selector_range/fanout.json
@@ -1,0 +1,11 @@
+{
+  "query": "timestamp_of_exp_histogram_bare_selector_range/fanout",
+  "lowering": "fanout",
+  "routed": true,
+  "k": 8,
+  "reason": "routed",
+  "n_anchors": 241,
+  "fanout": 20,
+  "cumulative_d": "5m0s",
+  "outer_range": "1h0m0s"
+}

--- a/test/perf/solver-decision-baseline/timestamp_of_exp_histogram_bare_selector_range/native.json
+++ b/test/perf/solver-decision-baseline/timestamp_of_exp_histogram_bare_selector_range/native.json
@@ -1,0 +1,11 @@
+{
+  "query": "timestamp_of_exp_histogram_bare_selector_range/native",
+  "lowering": "native",
+  "routed": true,
+  "k": 8,
+  "reason": "routed",
+  "n_anchors": 241,
+  "fanout": 20,
+  "cumulative_d": "5m0s",
+  "outer_range": "1h0m0s"
+}

--- a/test/perf/solver-decision-baseline/timestamp_of_exp_histogram_sum/fanout.json
+++ b/test/perf/solver-decision-baseline/timestamp_of_exp_histogram_sum/fanout.json
@@ -1,0 +1,11 @@
+{
+  "query": "timestamp_of_exp_histogram_sum/fanout",
+  "lowering": "fanout",
+  "routed": false,
+  "k": 0,
+  "reason": "not-sliceable",
+  "n_anchors": 241,
+  "fanout": 20,
+  "cumulative_d": "5m0s",
+  "outer_range": "1h0m0s"
+}

--- a/test/perf/solver-decision-baseline/timestamp_of_exp_histogram_sum/native.json
+++ b/test/perf/solver-decision-baseline/timestamp_of_exp_histogram_sum/native.json
@@ -1,0 +1,11 @@
+{
+  "query": "timestamp_of_exp_histogram_sum/native",
+  "lowering": "native",
+  "routed": false,
+  "k": 0,
+  "reason": "not-sliceable",
+  "n_anchors": 241,
+  "fanout": 20,
+  "cumulative_d": "5m0s",
+  "outer_range": "1h0m0s"
+}

--- a/test/regression/parity-enrolment-baselines/promql/baseline.txt
+++ b/test/regression/parity-enrolment-baselines/promql/baseline.txt
@@ -597,6 +597,9 @@ time_eq_bool_time_range.txtar
 time_minus_time_range.txtar
 time_plus_time_range.txtar
 time_returns_eval_ts.txtar
+timestamp_of_exp_histogram_bare_selector.txtar
+timestamp_of_exp_histogram_bare_selector_range.txtar
+timestamp_of_exp_histogram_sum.txtar
 timestamp_of_metric.txtar
 timestamp_of_metric_range_step.txtar
 timestamp_of_metric_range_step_native_resample.txtar

--- a/test/rejection-parity/catalogue/internal__promql__lower.go.json
+++ b/test/rejection-parity/catalogue/internal__promql__lower.go.json
@@ -94,8 +94,8 @@
       "site": "internal/promql/lower.go:expHistogramSelectorRouting#bf746b59",
       "message": "promql: %q is an exponential histogram metric; only a bare %q selector, sum()/avg()/count() over one, rate()/increase()/delta()/irate()/idelta()/sum_over_time()/avg_over_time()/resets()/changes() over one, histogram_quantile(), histogram_count(), histogram_sum(), and the %q/%q companion selectors are supported",
       "class": "divergence",
-      "trigger_query": "timestamp(demo_latency_exp_hist)",
-      "tracking_issue": 2474,
+      "trigger_query": "predict_linear(demo_latency_exp_hist[5m], 60)",
+      "tracking_issue": 2477,
       "evidence": {
         "guard": [
           "past returning if bare, col, hasCompanion := s.HistogramCompanionColumn(metricName); hasCompanion \u0026\u0026 s.IsExpHistogramMetric(bare) \u0026\u0026 s.ExpHistogramTable != \"\"",

--- a/test/spec/promql/timestamp_of_exp_histogram_bare_selector.txtar
+++ b/test/spec/promql/timestamp_of_exp_histogram_bare_selector.txtar
@@ -1,0 +1,24 @@
+-- query.promql --
+timestamp(demo_latency_exp_hist)
+-- parity --
+oracle: prometheus
+endpoint: /api/v1/query
+scope: full
+-- seed --
+CREATE TABLE otel_metrics_exponential_histogram (
+    MetricName String,
+    Attributes Map(String, String),
+    TimeUnix DateTime64(9),
+    Count UInt64,
+    Sum Float64,
+    Scale Int32,
+    ZeroCount UInt64,
+    PositiveOffset Int32,
+    PositiveBucketCounts Array(UInt64),
+    NegativeOffset Int32,
+    NegativeBucketCounts Array(UInt64)
+) ENGINE = MergeTree ORDER BY (MetricName, Attributes, TimeUnix);
+INSERT INTO otel_metrics_exponential_histogram VALUES
+    ('demo_latency_exp_hist', map('service', 'api'), toDateTime64('2026-01-01 00:00:00', 9), 6, 42.5, 0, 0, 0, [1, 2, 3], 0, []);
+-- expected_rows --
+[]

--- a/test/spec/promql/timestamp_of_exp_histogram_bare_selector.txtar
+++ b/test/spec/promql/timestamp_of_exp_histogram_bare_selector.txtar
@@ -21,4 +21,42 @@ CREATE TABLE otel_metrics_exponential_histogram (
 INSERT INTO otel_metrics_exponential_histogram VALUES
     ('demo_latency_exp_hist', map('service', 'api'), toDateTime64('2026-01-01 00:00:00', 9), 6, 42.5, 0, 0, 0, [1, 2, 3], 0, []);
 -- expected_rows --
-[]
+[
+  ["", {"service": "api"}, "2026-01-01T00:00:00Z", 1767225600]
+]
+-- args --
+[0] string = ""
+[1] float64 = 1e+09
+[2] string = "service_name"
+[3] string = "service.name"
+[4] string = "service_name"
+[5] string = "service.name"
+[6] string = "service_name"
+[7] string = ""
+[8] string = "service_name"
+[9] string = "demo_latency_exp_hist"
+[10] string = "demo.latency.exp.hist"
+[11] string = "demo.latency.exp/hist"
+[12] string = "demo.latency.exp_hist"
+[13] string = "demo.latency/exp/hist"
+[14] string = "demo.latency/exp_hist"
+[15] string = "demo.latency_exp.hist"
+[16] string = "demo.latency_exp_hist"
+[17] string = "demo/latency/exp/hist"
+[18] string = "demo/latency/exp_hist"
+[19] string = "demo/latency_exp_hist"
+[20] string = "demo_latency.exp.hist"
+[21] string = "demo_latency.exp_hist"
+[22] string = "demo_latency_exp.hist"
+[23] string = "2026-01-01 00:00:01.000000000"
+[24] int64 = 9
+[25] string = "2026-01-01 00:00:01.000000000"
+[26] int64 = 9
+[27] int64 = 300000000000
+-- chplan --
+Project ["" AS MetricName, Attributes AS Attributes, exp_hist_sample_ts AS TimeUnix, FnToFloat64((FnToUnixNanos(exp_hist_sample_ts) / 1e+09)) AS Value]
+  Aggregate groupBy=[FnMapSort(FnMapMerge(FnMapFilter((k, v) -> (k NOT IN ("service_name")), FnMapUpdate(FnMapFromArrays(FnArrayMap(k -> FnRegexReplaceAll(k, "[^a-zA-Z0-9_]", "_"), FnMapKeys(FnMapFilter((k, v) -> (k NOT IN ("service.name", "service_name")), ResourceAttributes))), FnMapValues(FnMapFilter((k, v) -> (k NOT IN ("service.name", "service_name")), ResourceAttributes))), FnMapFromArrays(FnArrayMap(k -> FnRegexReplaceAll(k, "[^a-zA-Z0-9_]", "_"), FnMapKeys(Attributes)), FnMapValues(Attributes)))), FnMapFilter((k, v) -> (v != ""), FnMap("service_name", FnToString(ServiceName))))) AS Attributes] funcs=[FnMax(TimeUnix) AS exp_hist_sample_ts]
+    Filter predicate=(((MetricName IN ("demo_latency_exp_hist", "demo.latency.exp.hist", "demo.latency.exp/hist", "demo.latency.exp_hist", "demo.latency/exp/hist", "demo.latency/exp_hist", "demo.latency_exp.hist", "demo.latency_exp_hist", "demo/latency/exp/hist", "demo/latency/exp_hist", "demo/latency_exp_hist", "demo_latency.exp.hist", "demo_latency.exp_hist", "demo_latency_exp.hist")) AND (TimeUnix <= FnToDateTime64("2026-01-01 00:00:01.000000000", 9))) AND (TimeUnix > (FnToDateTime64("2026-01-01 00:00:01.000000000", 9) - FnToIntervalNanosecond(300000000000))))
+      Scan(otel_metrics_exponential_histogram)
+-- sql --
+SELECT ? AS `MetricName`, `Attributes` AS `Attributes`, `exp_hist_sample_ts` AS `TimeUnix`, toFloat64((toUnixTimestamp64Nano(`exp_hist_sample_ts`) / toFloat64(?))) AS `Value` FROM (SELECT mapSort(mapConcat(mapFilter((k, v) -> (k NOT IN (?)), mapUpdate(mapFromArrays(arrayMap(k -> replaceRegexpAll(k, '[^a-zA-Z0-9_]', '_'), mapKeys(mapFilter((k, v) -> (k NOT IN (?, ?)), `ResourceAttributes`))), mapValues(mapFilter((k, v) -> (k NOT IN (?, ?)), `ResourceAttributes`))), mapFromArrays(arrayMap(k -> replaceRegexpAll(k, '[^a-zA-Z0-9_]', '_'), mapKeys(`Attributes`)), mapValues(`Attributes`)))), mapFilter((k, v) -> (v != ?), map(?, toString(`ServiceName`))))) AS `Attributes`, max(`TimeUnix`) AS `exp_hist_sample_ts` FROM (SELECT * FROM `otel_metrics_exponential_histogram` PREWHERE (`MetricName` IN (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)) WHERE (`TimeUnix` <= toDateTime64(?, ?)) AND (`TimeUnix` > (toDateTime64(?, ?) - toIntervalNanosecond(?)))) GROUP BY `Attributes`)

--- a/test/spec/promql/timestamp_of_exp_histogram_bare_selector_range.txtar
+++ b/test/spec/promql/timestamp_of_exp_histogram_bare_selector_range.txtar
@@ -23,4 +23,72 @@ CREATE TABLE otel_metrics_exponential_histogram (
 INSERT INTO otel_metrics_exponential_histogram VALUES
     ('demo_latency_exp_hist', map('service', 'api'), toDateTime64('2026-01-01 00:00:00', 9), 6, 42.5, 0, 0, 0, [1, 2, 3], 0, []);
 -- expected_rows --
-[]
+[
+  ["", {"service": "api"}, "2026-01-01T00:00:00Z", 1767225600],
+  ["", {"service": "api"}, "2026-01-01T00:00:30Z", 1767225600],
+  ["", {"service": "api"}, "2026-01-01T00:01:00Z", 1767225600],
+  ["", {"service": "api"}, "2026-01-01T00:01:30Z", 1767225600],
+  ["", {"service": "api"}, "2026-01-01T00:02:00Z", 1767225600],
+  ["", {"service": "api"}, "2026-01-01T00:02:30Z", 1767225600],
+  ["", {"service": "api"}, "2026-01-01T00:03:00Z", 1767225600],
+  ["", {"service": "api"}, "2026-01-01T00:03:30Z", 1767225600],
+  ["", {"service": "api"}, "2026-01-01T00:04:00Z", 1767225600],
+  ["", {"service": "api"}, "2026-01-01T00:04:30Z", 1767225600]
+]
+-- args --
+[0] string = ""
+[1] float64 = 1e+09
+[2] string = "service_name"
+[3] string = "service.name"
+[4] string = "service_name"
+[5] string = "service.name"
+[6] string = "service_name"
+[7] string = ""
+[8] string = "service_name"
+[9] string = "demo_latency_exp_hist"
+[10] string = "demo.latency.exp.hist"
+[11] string = "demo.latency.exp/hist"
+[12] string = "demo.latency.exp_hist"
+[13] string = "demo.latency/exp/hist"
+[14] string = "demo.latency/exp_hist"
+[15] string = "demo.latency_exp.hist"
+[16] string = "demo.latency_exp_hist"
+[17] string = "demo/latency/exp/hist"
+[18] string = "demo/latency/exp_hist"
+[19] string = "demo/latency_exp_hist"
+[20] string = "demo_latency.exp.hist"
+[21] string = "demo_latency.exp_hist"
+[22] string = "demo_latency_exp.hist"
+[23] string = "service"
+[24] string = ""
+[25] string = "service"
+[26] string = ""
+[27] string = ""
+[28] string = "api"
+[29] string = "demo_latency_exp_hist"
+[30] string = "demo.latency.exp.hist"
+[31] string = "demo.latency.exp/hist"
+[32] string = "demo.latency.exp_hist"
+[33] string = "demo.latency/exp/hist"
+[34] string = "demo.latency/exp_hist"
+[35] string = "demo.latency_exp.hist"
+[36] string = "demo.latency_exp_hist"
+[37] string = "demo/latency/exp/hist"
+[38] string = "demo/latency/exp_hist"
+[39] string = "demo/latency_exp_hist"
+[40] string = "demo_latency.exp.hist"
+[41] string = "demo_latency.exp_hist"
+[42] string = "demo_latency_exp.hist"
+[43] string = "service"
+[44] string = ""
+[45] string = "service"
+[46] string = ""
+[47] string = ""
+[48] string = "api"
+-- chplan --
+Project ["" AS MetricName, Attributes AS Attributes, anchor_ts AS TimeUnix, FnToFloat64((FnToUnixNanos(exp_hist_sample_ts) / 1e+09)) AS Value]
+  RangeBucketFanout step=30s lookback=5m0s groupBy=[FnMapSort(FnMapMerge(FnMapFilter((k, v) -> (k NOT IN ("service_name")), FnMapUpdate(FnMapFromArrays(FnArrayMap(k -> FnRegexReplaceAll(k, "[^a-zA-Z0-9_]", "_"), FnMapKeys(FnMapFilter((k, v) -> (k NOT IN ("service.name", "service_name")), ResourceAttributes))), FnMapValues(FnMapFilter((k, v) -> (k NOT IN ("service.name", "service_name")), ResourceAttributes))), FnMapFromArrays(FnArrayMap(k -> FnRegexReplaceAll(k, "[^a-zA-Z0-9_]", "_"), FnMapKeys(Attributes)), FnMapValues(Attributes)))), FnMapFilter((k, v) -> (v != ""), FnMap("service_name", FnToString(ServiceName))))) AS Attributes] funcs=[FnMax(TimeUnix) AS exp_hist_sample_ts] start=2026-01-01T00:00:00Z end=2026-01-01T00:05:00Z
+    Filter predicate=((FnCoalesce(FnNullIf(Attributes["service"], ""), FnNullIf(ResourceAttributes["service"], ""), "") = "api") AND (MetricName IN ("demo_latency_exp_hist", "demo.latency.exp.hist", "demo.latency.exp/hist", "demo.latency.exp_hist", "demo.latency/exp/hist", "demo.latency/exp_hist", "demo.latency_exp.hist", "demo.latency_exp_hist", "demo/latency/exp/hist", "demo/latency/exp_hist", "demo/latency_exp_hist", "demo_latency.exp.hist", "demo_latency.exp_hist", "demo_latency_exp.hist")))
+      Scan(otel_metrics_exponential_histogram)
+-- sql --
+SELECT ? AS `MetricName`, `Attributes` AS `Attributes`, `anchor_ts` AS `TimeUnix`, toFloat64((toUnixTimestamp64Nano(`exp_hist_sample_ts`) / toFloat64(?))) AS `Value` FROM (SELECT anchor_ts AS `anchor_ts`, mapSort(mapConcat(mapFilter((k, v) -> (k NOT IN (?)), mapUpdate(mapFromArrays(arrayMap(k -> replaceRegexpAll(k, '[^a-zA-Z0-9_]', '_'), mapKeys(mapFilter((k, v) -> (k NOT IN (?, ?)), `ResourceAttributes`))), mapValues(mapFilter((k, v) -> (k NOT IN (?, ?)), `ResourceAttributes`))), mapFromArrays(arrayMap(k -> replaceRegexpAll(k, '[^a-zA-Z0-9_]', '_'), mapKeys(`Attributes`)), mapValues(`Attributes`)))), mapFilter((k, v) -> (v != ?), map(?, toString(`ServiceName`))))) AS `Attributes`, max(`TimeUnix`) AS `exp_hist_sample_ts` FROM (SELECT * FROM (SELECT * FROM (SELECT *, arrayJoin(arrayMap(i -> toDateTime64('2026-01-01 00:05:00.000000000', 9) - toIntervalNanosecond(i * 30000000000), range(greatest(0, intDiv(dateDiff('nanosecond', `TimeUnix`, toDateTime64('2026-01-01 00:05:00.000000000', 9)) - 300000000000, toInt64(30000000000)) - (modulo(dateDiff('nanosecond', `TimeUnix`, toDateTime64('2026-01-01 00:05:00.000000000', 9)) - 300000000000, toInt64(30000000000)) < 0) + 1), least(11, intDiv(dateDiff('nanosecond', `TimeUnix`, toDateTime64('2026-01-01 00:05:00.000000000', 9)), toInt64(30000000000)) - (modulo(dateDiff('nanosecond', `TimeUnix`, toDateTime64('2026-01-01 00:05:00.000000000', 9)), toInt64(30000000000)) < 0) + 1)))) AS anchor_ts FROM (SELECT * FROM `otel_metrics_exponential_histogram` PREWHERE (`MetricName` IN (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)) WHERE (coalesce(nullIf(`Attributes`[?], ?), nullIf(`ResourceAttributes`[?], ?), ?) = ?)) WHERE `TimeUnix` > toDateTime64('2026-01-01 00:00:00.000000000', 9) - toIntervalNanosecond(300000000000) AND `TimeUnix` <= toDateTime64('2026-01-01 00:05:00.000000000', 9)) LIMIT 4000001) WHERE throwIf((SELECT count() AS `n` FROM (SELECT `TimeUnix` FROM (SELECT *, arrayJoin(arrayMap(i -> toDateTime64('2026-01-01 00:05:00.000000000', 9) - toIntervalNanosecond(i * 30000000000), range(greatest(0, intDiv(dateDiff('nanosecond', `TimeUnix`, toDateTime64('2026-01-01 00:05:00.000000000', 9)) - 300000000000, toInt64(30000000000)) - (modulo(dateDiff('nanosecond', `TimeUnix`, toDateTime64('2026-01-01 00:05:00.000000000', 9)) - 300000000000, toInt64(30000000000)) < 0) + 1), least(11, intDiv(dateDiff('nanosecond', `TimeUnix`, toDateTime64('2026-01-01 00:05:00.000000000', 9)), toInt64(30000000000)) - (modulo(dateDiff('nanosecond', `TimeUnix`, toDateTime64('2026-01-01 00:05:00.000000000', 9)), toInt64(30000000000)) < 0) + 1)))) AS anchor_ts FROM (SELECT * FROM `otel_metrics_exponential_histogram` PREWHERE (`MetricName` IN (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)) WHERE (coalesce(nullIf(`Attributes`[?], ?), nullIf(`ResourceAttributes`[?], ?), ?) = ?)) WHERE `TimeUnix` > toDateTime64('2026-01-01 00:00:00.000000000', 9) - toIntervalNanosecond(300000000000) AND `TimeUnix` <= toDateTime64('2026-01-01 00:05:00.000000000', 9)) LIMIT 4000001)) > 4000000, 'histogram/LWR sample fanout exceeds the series-times-anchors resource bound') = 0) GROUP BY anchor_ts, `Attributes`)

--- a/test/spec/promql/timestamp_of_exp_histogram_bare_selector_range.txtar
+++ b/test/spec/promql/timestamp_of_exp_histogram_bare_selector_range.txtar
@@ -1,0 +1,26 @@
+-- query.promql --
+timestamp(demo_latency_exp_hist{service="api"})
+-- parity --
+oracle: prometheus
+endpoint: /api/v1/query_range
+scope: full
+-- range_step --
+30s
+-- seed --
+CREATE TABLE otel_metrics_exponential_histogram (
+    MetricName String,
+    Attributes Map(String, String),
+    TimeUnix DateTime64(9),
+    Count UInt64,
+    Sum Float64,
+    Scale Int32,
+    ZeroCount UInt64,
+    PositiveOffset Int32,
+    PositiveBucketCounts Array(UInt64),
+    NegativeOffset Int32,
+    NegativeBucketCounts Array(UInt64)
+) ENGINE = MergeTree ORDER BY (MetricName, Attributes, TimeUnix);
+INSERT INTO otel_metrics_exponential_histogram VALUES
+    ('demo_latency_exp_hist', map('service', 'api'), toDateTime64('2026-01-01 00:00:00', 9), 6, 42.5, 0, 0, 0, [1, 2, 3], 0, []);
+-- expected_rows --
+[]

--- a/test/spec/promql/timestamp_of_exp_histogram_sum.txtar
+++ b/test/spec/promql/timestamp_of_exp_histogram_sum.txtar
@@ -21,4 +21,141 @@ CREATE TABLE otel_metrics_exponential_histogram (
 INSERT INTO otel_metrics_exponential_histogram VALUES
     ('demo_latency_exp_hist', map('service', 'api'), toDateTime64('2026-01-01 00:00:00', 9), 6, 42.5, 0, 0, 0, [1, 2, 3], 0, []);
 -- expected_rows --
-[]
+[
+  ["", {}, "2026-01-01T00:00:01Z", 1767225601]
+]
+-- args --
+[0] string = ""
+[1] string = "2026-01-01 00:00:01.000000000"
+[2] int64 = 9
+[3] string = "2026-01-01 00:00:01.000000000"
+[4] int64 = 9
+[5] float64 = 1e+09
+[6] string = ""
+[7] int64 = 9
+[8] float64 = 0
+[9] string = "Map(String,String)"
+[10] int64 = 1
+[11] int64 = 2
+[12] float64 = 0
+[13] int64 = 2
+[14] int64 = 1
+[15] int64 = 1
+[16] int64 = 1
+[17] int64 = 1
+[18] int64 = 1
+[19] float64 = 0
+[20] float64 = 0
+[21] int64 = 1
+[22] int64 = 1
+[23] int64 = 2
+[24] float64 = 0
+[25] int64 = 2
+[26] int64 = 1
+[27] int64 = 1
+[28] int64 = 1
+[29] int64 = 1
+[30] int64 = 1
+[31] float64 = 0
+[32] float64 = 0
+[33] int64 = 1
+[34] int64 = 1
+[35] int64 = 2
+[36] float64 = 0
+[37] int64 = 2
+[38] int64 = 1
+[39] int64 = 1
+[40] int64 = 1
+[41] int64 = 1
+[42] int64 = 1
+[43] float64 = 0
+[44] float64 = 0
+[45] int64 = 1
+[46] string = "sumKahan"
+[47] int64 = 1
+[48] int64 = 2
+[49] float64 = 0
+[50] int64 = 2
+[51] int64 = 1
+[52] int64 = 1
+[53] int64 = 1
+[54] int64 = 1
+[55] int64 = 1
+[56] int64 = 1
+[57] int64 = 0
+[58] float64 = 0
+[59] float64 = 0
+[60] int64 = 1
+[61] int64 = 0
+[62] int64 = 1
+[63] int64 = 1
+[64] int64 = 1
+[65] string = "sumKahan"
+[66] int64 = 1
+[67] int64 = 2
+[68] float64 = 0
+[69] int64 = 2
+[70] int64 = 1
+[71] int64 = 1
+[72] int64 = 1
+[73] int64 = 1
+[74] int64 = 1
+[75] int64 = 1
+[76] int64 = 0
+[77] float64 = 0
+[78] float64 = 0
+[79] int64 = 1
+[80] int64 = 0
+[81] int64 = 1
+[82] int64 = 1
+[83] int64 = 1
+[84] string = "service_name"
+[85] string = "service.name"
+[86] string = "service_name"
+[87] string = "service.name"
+[88] string = "service_name"
+[89] string = ""
+[90] string = "service_name"
+[91] string = "demo_latency_exp_hist"
+[92] string = "demo.latency.exp.hist"
+[93] string = "demo.latency.exp/hist"
+[94] string = "demo.latency.exp_hist"
+[95] string = "demo.latency/exp/hist"
+[96] string = "demo.latency/exp_hist"
+[97] string = "demo.latency_exp.hist"
+[98] string = "demo.latency_exp_hist"
+[99] string = "demo/latency/exp/hist"
+[100] string = "demo/latency/exp_hist"
+[101] string = "demo/latency_exp_hist"
+[102] string = "demo_latency.exp.hist"
+[103] string = "demo_latency.exp_hist"
+[104] string = "demo_latency_exp.hist"
+[105] string = "2026-01-01 00:00:01.000000000"
+[106] int64 = 9
+[107] string = "2026-01-01 00:00:01.000000000"
+[108] int64 = 9
+[109] int64 = 300000000000
+[110] int64 = 4096
+[111] int64 = 0
+[112] int64 = 1
+[113] int64 = 1
+[114] int64 = 1
+[115] int64 = 16384
+[116] int64 = 0
+[117] int64 = 1
+[118] int64 = 1
+[119] int64 = 1
+[120] int64 = 16384
+[121] int64 = 0
+-- chplan --
+Project ["" AS MetricName, Attributes AS Attributes, FnToDateTime64("2026-01-01 00:00:01.000000000", 9) AS TimeUnix, FnToFloat64((FnToUnixNanos(FnToDateTime64("2026-01-01 00:00:01.000000000", 9)) / 1e+09)) AS Value]
+  HistogramProjection project=["" AS MetricName, Attributes AS Attributes, FnNow64(9) AS TimeUnix, 0 AS Value]
+    Project [FnCast(FnMap(), "Map(String,String)") AS Attributes, FnArrayMap(kh_final -> (FnTupleElement(kh_final, 1) + FnTupleElement(kh_final, 2)), FnArray(FnArrayFold((kh_acc, kh_x) -> FnArrayMap(kh_total -> FnTuple(kh_total, FnIf(FnIsInfinite(kh_total), 0, (FnTupleElement(kh_acc, 2) + FnIf((FnAbs(FnTupleElement(kh_acc, 1)) >= FnAbs(kh_x)), ((FnTupleElement(kh_acc, 1) - kh_total) + kh_x), ((kh_x - kh_total) + FnTupleElement(kh_acc, 1)))))), FnArray((FnTupleElement(kh_acc, 1) + kh_x)))[1], _hq_merge_counts, FnTuple(0, 0))))[1] AS Count, FnArrayMap(kh_final -> (FnTupleElement(kh_final, 1) + FnTupleElement(kh_final, 2)), FnArray(FnArrayFold((kh_acc, kh_x) -> FnArrayMap(kh_total -> FnTuple(kh_total, FnIf(FnIsInfinite(kh_total), 0, (FnTupleElement(kh_acc, 2) + FnIf((FnAbs(FnTupleElement(kh_acc, 1)) >= FnAbs(kh_x)), ((FnTupleElement(kh_acc, 1) - kh_total) + kh_x), ((kh_x - kh_total) + FnTupleElement(kh_acc, 1)))))), FnArray((FnTupleElement(kh_acc, 1) + kh_x)))[1], _hq_merge_sums, FnTuple(0, 0))))[1] AS Sum, _hq_merged_scale AS Scale, FnArrayMap(kh_final -> (FnTupleElement(kh_final, 1) + FnTupleElement(kh_final, 2)), FnArray(FnArrayFold((kh_acc, kh_x) -> FnArrayMap(kh_total -> FnTuple(kh_total, FnIf(FnIsInfinite(kh_total), 0, (FnTupleElement(kh_acc, 2) + FnIf((FnAbs(FnTupleElement(kh_acc, 1)) >= FnAbs(kh_x)), ((FnTupleElement(kh_acc, 1) - kh_total) + kh_x), ((kh_x - kh_total) + FnTupleElement(kh_acc, 1)))))), FnArray((FnTupleElement(kh_acc, 1) + kh_x)))[1], _hq_merge_zero_counts, FnTuple(0, 0))))[1] AS ZeroCount, FnArrayMin(FnArrayMap((s, off) -> FnBitShiftRight(off, (s - _hq_merged_scale)), _hq_scales, _hq_pos_offsets)) AS PositiveOffset, FnArrayMap(mst -> FnArrayMap(t -> FnArrayReduce("sumKahan", FnArrayMap((s, off, arr) -> FnArrayMap(kh_final -> (FnTupleElement(kh_final, 1) + FnTupleElement(kh_final, 2)), FnArray(FnArrayFold((kh_acc, kh_x) -> FnArrayMap(kh_total -> FnTuple(kh_total, FnIf(FnIsInfinite(kh_total), 0, (FnTupleElement(kh_acc, 2) + FnIf((FnAbs(FnTupleElement(kh_acc, 1)) >= FnAbs(kh_x)), ((FnTupleElement(kh_acc, 1) - kh_total) + kh_x), ((kh_x - kh_total) + FnTupleElement(kh_acc, 1)))))), FnArray((FnTupleElement(kh_acc, 1) + kh_x)))[1], FnArrayMap(j -> FnIf((FnBitShiftRight((off + (j - 1)), (s - _hq_merged_scale)) = (mst + t)), arr[j], 0), FnArrayEnumerate(arr)), FnTuple(0, 0))))[1], _hq_scales, _hq_pos_offsets, _hq_pos_buckets)), FnRange(FnToUInt64(FnGreatest(0, ((FnArrayMax(FnArrayMap((sm, om, am) -> FnBitShiftRight((om + (FnLength(am) - 1)), (sm - _hq_merged_scale)), _hq_scales, _hq_pos_offsets, _hq_pos_buckets)) - mst) + 1))))), FnArray(FnArrayMin(FnArrayMap((sm, om) -> FnBitShiftRight(om, (sm - _hq_merged_scale)), _hq_scales, _hq_pos_offsets))))[1] AS PositiveBucketCounts, FnArrayMin(FnArrayMap((s, off) -> FnBitShiftRight(off, (s - _hq_merged_scale)), _hq_scales, _hq_neg_offsets)) AS NegativeOffset, FnArrayMap(mst -> FnArrayMap(t -> FnArrayReduce("sumKahan", FnArrayMap((s, off, arr) -> FnArrayMap(kh_final -> (FnTupleElement(kh_final, 1) + FnTupleElement(kh_final, 2)), FnArray(FnArrayFold((kh_acc, kh_x) -> FnArrayMap(kh_total -> FnTuple(kh_total, FnIf(FnIsInfinite(kh_total), 0, (FnTupleElement(kh_acc, 2) + FnIf((FnAbs(FnTupleElement(kh_acc, 1)) >= FnAbs(kh_x)), ((FnTupleElement(kh_acc, 1) - kh_total) + kh_x), ((kh_x - kh_total) + FnTupleElement(kh_acc, 1)))))), FnArray((FnTupleElement(kh_acc, 1) + kh_x)))[1], FnArrayMap(j -> FnIf((FnBitShiftRight((off + (j - 1)), (s - _hq_merged_scale)) = (mst + t)), arr[j], 0), FnArrayEnumerate(arr)), FnTuple(0, 0))))[1], _hq_scales, _hq_neg_offsets, _hq_neg_buckets)), FnRange(FnToUInt64(FnGreatest(0, ((FnArrayMax(FnArrayMap((sm, om, am) -> FnBitShiftRight((om + (FnLength(am) - 1)), (sm - _hq_merged_scale)), _hq_scales, _hq_neg_offsets, _hq_neg_buckets)) - mst) + 1))))), FnArray(FnArrayMin(FnArrayMap((sm, om) -> FnBitShiftRight(om, (sm - _hq_merged_scale)), _hq_scales, _hq_neg_offsets))))[1] AS NegativeBucketCounts]
+      Project * REPLACE [FnArraySort((row, key) -> key, _hq_scales, _hq_series_order_key) AS _hq_scales, FnArraySort((row, key) -> key, _hq_pos_offsets, _hq_series_order_key) AS _hq_pos_offsets, FnArraySort((row, key) -> key, _hq_pos_buckets, _hq_series_order_key) AS _hq_pos_buckets, FnArraySort((row, key) -> key, _hq_neg_offsets, _hq_series_order_key) AS _hq_neg_offsets, FnArraySort((row, key) -> key, _hq_neg_buckets, _hq_series_order_key) AS _hq_neg_buckets]
+        Filter predicate=(FnThrowIf(((FnLength(_hq_scales) > 4096) OR ((FnArrayMap(mst -> FnGreatest(0, ((FnArrayMax(FnArrayMap((sm, om, am) -> FnBitShiftRight((om + (FnLength(am) - 1)), (sm - _hq_merged_scale)), _hq_scales, _hq_pos_offsets, _hq_pos_buckets)) - mst) + 1)), FnArray(FnArrayMin(FnArrayMap((sm, om) -> FnBitShiftRight(om, (sm - _hq_merged_scale)), _hq_scales, _hq_pos_offsets))))[1] > 16384) OR (FnArrayMap(mst -> FnGreatest(0, ((FnArrayMax(FnArrayMap((sm, om, am) -> FnBitShiftRight((om + (FnLength(am) - 1)), (sm - _hq_merged_scale)), _hq_scales, _hq_neg_offsets, _hq_neg_buckets)) - mst) + 1)), FnArray(FnArrayMin(FnArrayMap((sm, om) -> FnBitShiftRight(om, (sm - _hq_merged_scale)), _hq_scales, _hq_neg_offsets))))[1] > 16384))), "native histogram merge exceeds the series-per-group or merged-bucket-width resource bound") = 0)
+          Aggregate groupBy=[] funcs=[FnGroupArray(Count) AS _hq_merge_counts, FnGroupArray(Sum) AS _hq_merge_sums, FnMin(Scale) AS _hq_merged_scale, FnGroupArray(ZeroCount) AS _hq_merge_zero_counts, FnGroupArray(Scale) AS _hq_scales, FnGroupArray(PositiveOffset) AS _hq_pos_offsets, FnGroupArray(PositiveBucketCounts) AS _hq_pos_buckets, FnGroupArray(NegativeOffset) AS _hq_neg_offsets, FnGroupArray(NegativeBucketCounts) AS _hq_neg_buckets, FnGroupArray(FnToString(FnMapSort(Attributes))) AS _hq_series_order_key]
+            Aggregate groupBy=[FnMapSort(FnMapMerge(FnMapFilter((k, v) -> (k NOT IN ("service_name")), FnMapUpdate(FnMapFromArrays(FnArrayMap(k -> FnRegexReplaceAll(k, "[^a-zA-Z0-9_]", "_"), FnMapKeys(FnMapFilter((k, v) -> (k NOT IN ("service.name", "service_name")), ResourceAttributes))), FnMapValues(FnMapFilter((k, v) -> (k NOT IN ("service.name", "service_name")), ResourceAttributes))), FnMapFromArrays(FnArrayMap(k -> FnRegexReplaceAll(k, "[^a-zA-Z0-9_]", "_"), FnMapKeys(Attributes)), FnMapValues(Attributes)))), FnMapFilter((k, v) -> (v != ""), FnMap("service_name", FnToString(ServiceName))))) AS Attributes] funcs=[FnArgMax(Count, TimeUnix) AS Count, FnArgMax(Sum, TimeUnix) AS Sum, FnArgMax(Scale, TimeUnix) AS Scale, FnArgMax(ZeroCount, TimeUnix) AS ZeroCount, FnArgMax(PositiveOffset, TimeUnix) AS PositiveOffset, FnArgMax(PositiveBucketCounts, TimeUnix) AS PositiveBucketCounts, FnArgMax(NegativeOffset, TimeUnix) AS NegativeOffset, FnArgMax(NegativeBucketCounts, TimeUnix) AS NegativeBucketCounts]
+              Filter predicate=(((MetricName IN ("demo_latency_exp_hist", "demo.latency.exp.hist", "demo.latency.exp/hist", "demo.latency.exp_hist", "demo.latency/exp/hist", "demo.latency/exp_hist", "demo.latency_exp.hist", "demo.latency_exp_hist", "demo/latency/exp/hist", "demo/latency/exp_hist", "demo/latency_exp_hist", "demo_latency.exp.hist", "demo_latency.exp_hist", "demo_latency_exp.hist")) AND (TimeUnix <= FnToDateTime64("2026-01-01 00:00:01.000000000", 9))) AND (TimeUnix > (FnToDateTime64("2026-01-01 00:00:01.000000000", 9) - FnToIntervalNanosecond(300000000000))))
+                Scan(otel_metrics_exponential_histogram)
+-- sql --
+SELECT ? AS `MetricName`, `Attributes` AS `Attributes`, toDateTime64(?, ?) AS `TimeUnix`, toFloat64((toUnixTimestamp64Nano(toDateTime64(?, ?)) / toFloat64(?))) AS `Value` FROM (SELECT ? AS `MetricName`, `Attributes` AS `Attributes`, now64(?) AS `TimeUnix`, toFloat64(?) AS `Value`, toFloat64(`Count`) AS `HistogramCount`, toFloat64(`Sum`) AS `HistogramSum`, toInt32(`Scale`) AS `HistogramScale`, toFloat64(0.) AS `HistogramZeroThreshold`, toFloat64(`ZeroCount`) AS `HistogramZeroCount`, toInt32(`PositiveOffset`) AS `HistogramPositiveOffset`, arrayMap(x -> toFloat64(x), `PositiveBucketCounts`) AS `HistogramPositiveBucketCounts`, toInt32(`NegativeOffset`) AS `HistogramNegativeOffset`, arrayMap(x -> toFloat64(x), `NegativeBucketCounts`) AS `HistogramNegativeBucketCounts` FROM (SELECT CAST(map(), ?) AS `Attributes`, arrayMap(kh_final -> (tupleElement(kh_final, ?) + tupleElement(kh_final, ?)), array(arrayFold((kh_acc, kh_x) -> arrayMap(kh_total -> tuple(kh_total, if(isInfinite(kh_total), toFloat64(?), (tupleElement(kh_acc, ?) + if((abs(tupleElement(kh_acc, ?)) >= abs(kh_x)), ((tupleElement(kh_acc, ?) - kh_total) + kh_x), ((kh_x - kh_total) + tupleElement(kh_acc, ?)))))), array((tupleElement(kh_acc, ?) + kh_x)))[?], `_hq_merge_counts`, tuple(toFloat64(?), toFloat64(?)))))[?] AS `Count`, arrayMap(kh_final -> (tupleElement(kh_final, ?) + tupleElement(kh_final, ?)), array(arrayFold((kh_acc, kh_x) -> arrayMap(kh_total -> tuple(kh_total, if(isInfinite(kh_total), toFloat64(?), (tupleElement(kh_acc, ?) + if((abs(tupleElement(kh_acc, ?)) >= abs(kh_x)), ((tupleElement(kh_acc, ?) - kh_total) + kh_x), ((kh_x - kh_total) + tupleElement(kh_acc, ?)))))), array((tupleElement(kh_acc, ?) + kh_x)))[?], `_hq_merge_sums`, tuple(toFloat64(?), toFloat64(?)))))[?] AS `Sum`, `_hq_merged_scale` AS `Scale`, arrayMap(kh_final -> (tupleElement(kh_final, ?) + tupleElement(kh_final, ?)), array(arrayFold((kh_acc, kh_x) -> arrayMap(kh_total -> tuple(kh_total, if(isInfinite(kh_total), toFloat64(?), (tupleElement(kh_acc, ?) + if((abs(tupleElement(kh_acc, ?)) >= abs(kh_x)), ((tupleElement(kh_acc, ?) - kh_total) + kh_x), ((kh_x - kh_total) + tupleElement(kh_acc, ?)))))), array((tupleElement(kh_acc, ?) + kh_x)))[?], `_hq_merge_zero_counts`, tuple(toFloat64(?), toFloat64(?)))))[?] AS `ZeroCount`, arrayMin(arrayMap((s, off) -> bitShiftRight(off, (s - `_hq_merged_scale`)), `_hq_scales`, `_hq_pos_offsets`)) AS `PositiveOffset`, arrayMap(mst -> arrayMap(t -> arrayReduce(?, arrayMap((s, off, arr) -> arrayMap(kh_final -> (tupleElement(kh_final, ?) + tupleElement(kh_final, ?)), array(arrayFold((kh_acc, kh_x) -> arrayMap(kh_total -> tuple(kh_total, if(isInfinite(kh_total), toFloat64(?), (tupleElement(kh_acc, ?) + if((abs(tupleElement(kh_acc, ?)) >= abs(kh_x)), ((tupleElement(kh_acc, ?) - kh_total) + kh_x), ((kh_x - kh_total) + tupleElement(kh_acc, ?)))))), array((tupleElement(kh_acc, ?) + kh_x)))[?], arrayMap(j -> if((bitShiftRight((off + (j - ?)), (s - `_hq_merged_scale`)) = (mst + t)), arr[j], ?), arrayEnumerate(arr)), tuple(toFloat64(?), toFloat64(?)))))[?], `_hq_scales`, `_hq_pos_offsets`, `_hq_pos_buckets`)), range(toUInt64(greatest(?, ((arrayMax(arrayMap((sm, om, am) -> bitShiftRight((om + (length(am) - ?)), (sm - `_hq_merged_scale`)), `_hq_scales`, `_hq_pos_offsets`, `_hq_pos_buckets`)) - mst) + ?))))), array(arrayMin(arrayMap((sm, om) -> bitShiftRight(om, (sm - `_hq_merged_scale`)), `_hq_scales`, `_hq_pos_offsets`))))[?] AS `PositiveBucketCounts`, arrayMin(arrayMap((s, off) -> bitShiftRight(off, (s - `_hq_merged_scale`)), `_hq_scales`, `_hq_neg_offsets`)) AS `NegativeOffset`, arrayMap(mst -> arrayMap(t -> arrayReduce(?, arrayMap((s, off, arr) -> arrayMap(kh_final -> (tupleElement(kh_final, ?) + tupleElement(kh_final, ?)), array(arrayFold((kh_acc, kh_x) -> arrayMap(kh_total -> tuple(kh_total, if(isInfinite(kh_total), toFloat64(?), (tupleElement(kh_acc, ?) + if((abs(tupleElement(kh_acc, ?)) >= abs(kh_x)), ((tupleElement(kh_acc, ?) - kh_total) + kh_x), ((kh_x - kh_total) + tupleElement(kh_acc, ?)))))), array((tupleElement(kh_acc, ?) + kh_x)))[?], arrayMap(j -> if((bitShiftRight((off + (j - ?)), (s - `_hq_merged_scale`)) = (mst + t)), arr[j], ?), arrayEnumerate(arr)), tuple(toFloat64(?), toFloat64(?)))))[?], `_hq_scales`, `_hq_neg_offsets`, `_hq_neg_buckets`)), range(toUInt64(greatest(?, ((arrayMax(arrayMap((sm, om, am) -> bitShiftRight((om + (length(am) - ?)), (sm - `_hq_merged_scale`)), `_hq_scales`, `_hq_neg_offsets`, `_hq_neg_buckets`)) - mst) + ?))))), array(arrayMin(arrayMap((sm, om) -> bitShiftRight(om, (sm - `_hq_merged_scale`)), `_hq_scales`, `_hq_neg_offsets`))))[?] AS `NegativeBucketCounts` FROM (SELECT * REPLACE (arraySort((row, key) -> key, `_hq_scales`, `_hq_series_order_key`) AS `_hq_scales`, arraySort((row, key) -> key, `_hq_pos_offsets`, `_hq_series_order_key`) AS `_hq_pos_offsets`, arraySort((row, key) -> key, `_hq_pos_buckets`, `_hq_series_order_key`) AS `_hq_pos_buckets`, arraySort((row, key) -> key, `_hq_neg_offsets`, `_hq_series_order_key`) AS `_hq_neg_offsets`, arraySort((row, key) -> key, `_hq_neg_buckets`, `_hq_series_order_key`) AS `_hq_neg_buckets`) FROM (SELECT * FROM (SELECT `_hq_merge_counts`, `_hq_merge_sums`, `_hq_merged_scale`, `_hq_merge_zero_counts`, `_hq_scales`, `_hq_pos_offsets`, `_hq_pos_buckets`, `_hq_neg_offsets`, `_hq_neg_buckets`, `_hq_series_order_key` FROM (SELECT groupArray(`Count`) AS `_hq_merge_counts`, groupArray(`Sum`) AS `_hq_merge_sums`, min(`Scale`) AS `_hq_merged_scale`, groupArray(`ZeroCount`) AS `_hq_merge_zero_counts`, groupArray(`Scale`) AS `_hq_scales`, groupArray(`PositiveOffset`) AS `_hq_pos_offsets`, groupArray(`PositiveBucketCounts`) AS `_hq_pos_buckets`, groupArray(`NegativeOffset`) AS `_hq_neg_offsets`, groupArray(`NegativeBucketCounts`) AS `_hq_neg_buckets`, groupArray(toString(mapSort(`Attributes`))) AS `_hq_series_order_key`, count() AS `_cerb_n` FROM (SELECT mapSort(mapConcat(mapFilter((k, v) -> (k NOT IN (?)), mapUpdate(mapFromArrays(arrayMap(k -> replaceRegexpAll(k, '[^a-zA-Z0-9_]', '_'), mapKeys(mapFilter((k, v) -> (k NOT IN (?, ?)), `ResourceAttributes`))), mapValues(mapFilter((k, v) -> (k NOT IN (?, ?)), `ResourceAttributes`))), mapFromArrays(arrayMap(k -> replaceRegexpAll(k, '[^a-zA-Z0-9_]', '_'), mapKeys(`Attributes`)), mapValues(`Attributes`)))), mapFilter((k, v) -> (v != ?), map(?, toString(`ServiceName`))))) AS `Attributes`, argMax(`Count`, `TimeUnix`) AS `Count`, argMax(`Sum`, `TimeUnix`) AS `Sum`, argMax(`Scale`, `TimeUnix`) AS `Scale`, argMax(`ZeroCount`, `TimeUnix`) AS `ZeroCount`, argMax(`PositiveOffset`, `TimeUnix`) AS `PositiveOffset`, argMax(`PositiveBucketCounts`, `TimeUnix`) AS `PositiveBucketCounts`, argMax(`NegativeOffset`, `TimeUnix`) AS `NegativeOffset`, argMax(`NegativeBucketCounts`, `TimeUnix`) AS `NegativeBucketCounts` FROM (SELECT * FROM `otel_metrics_exponential_histogram` PREWHERE (`MetricName` IN (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)) WHERE (`TimeUnix` <= toDateTime64(?, ?)) AND (`TimeUnix` > (toDateTime64(?, ?) - toIntervalNanosecond(?)))) GROUP BY `Attributes`)) WHERE `_cerb_n` > 0) WHERE (throwIf(((length(`_hq_scales`) > ?) OR ((arrayMap(mst -> greatest(?, ((arrayMax(arrayMap((sm, om, am) -> bitShiftRight((om + (length(am) - ?)), (sm - `_hq_merged_scale`)), `_hq_scales`, `_hq_pos_offsets`, `_hq_pos_buckets`)) - mst) + ?)), array(arrayMin(arrayMap((sm, om) -> bitShiftRight(om, (sm - `_hq_merged_scale`)), `_hq_scales`, `_hq_pos_offsets`))))[?] > ?) OR (arrayMap(mst -> greatest(?, ((arrayMax(arrayMap((sm, om, am) -> bitShiftRight((om + (length(am) - ?)), (sm - `_hq_merged_scale`)), `_hq_scales`, `_hq_neg_offsets`, `_hq_neg_buckets`)) - mst) + ?)), array(arrayMin(arrayMap((sm, om) -> bitShiftRight(om, (sm - `_hq_merged_scale`)), `_hq_scales`, `_hq_neg_offsets`))))[?] > ?))), 'native histogram merge exceeds the series-per-group or merged-bucket-width resource bound') = ?)))))

--- a/test/spec/promql/timestamp_of_exp_histogram_sum.txtar
+++ b/test/spec/promql/timestamp_of_exp_histogram_sum.txtar
@@ -1,0 +1,24 @@
+-- query.promql --
+timestamp(sum(demo_latency_exp_hist))
+-- parity --
+oracle: prometheus
+endpoint: /api/v1/query
+scope: full
+-- seed --
+CREATE TABLE otel_metrics_exponential_histogram (
+    MetricName String,
+    Attributes Map(String, String),
+    TimeUnix DateTime64(9),
+    Count UInt64,
+    Sum Float64,
+    Scale Int32,
+    ZeroCount UInt64,
+    PositiveOffset Int32,
+    PositiveBucketCounts Array(UInt64),
+    NegativeOffset Int32,
+    NegativeBucketCounts Array(UInt64)
+) ENGINE = MergeTree ORDER BY (MetricName, Attributes, TimeUnix);
+INSERT INTO otel_metrics_exponential_histogram VALUES
+    ('demo_latency_exp_hist', map('service', 'api'), toDateTime64('2026-01-01 00:00:00', 9), 6, 42.5, 0, 0, 0, [1, 2, 3], 0, []);
+-- expected_rows --
+[]


### PR DESCRIPTION
## Summary

- `timestamp(demo_latency_exp_hist)` was hard-rejected: reference Prometheus's `timestamp(v)` reads
  only the selected sample's own `Point.T`, never `Point.H`/`Point.F`, so it is defined identically
  for a float- or histogram-valued argument. `lowerDateFn` (`internal/promql/date_fns.go`) called
  `lower()` on its argument unconditionally, with no `lowerExpHistogramValuedShape` check, so an
  exp-histogram-valued `timestamp()` argument fell through to
  `expHistogramSelectorRouting`'s catch-all rejection.
- Unlike the recent `sort()`/`clamp()`/`absent()` fixes, `timestamp()` must **not** drop histogram
  samples — it projects the row's own timestamp as the output value for *every* row regardless of
  payload type. `internal/promql/histogram_native_timestamp.go` adds that projection:
  - A **bare exp-histogram selector** needs the *selected sample's* raw timestamp, matching
    reference's `rangeEvalTimestampFunctionOverVectorSelector` special case. None of the existing
    histogram lowerings expose that (they all stamp their own `TimeUnix` output with the eval
    instant, since that's what every other histogram-valued consumer's VALUE math wants), so this
    adds a light `max(TimeUnix)`-only aggregate for that one shape, mirrored across all three
    range-grid modes `lowerExpHistogramBare` already distinguishes (single instant anchor, unpinned
    range fan-out, `@`-pinned range broadcast).
  - Every **other** exp-histogram-valued shape (`sum()`/`avg()`/`rate()`/…) reuses
    `lowerExpHistogramValuedShape` directly — the same recognizer `sort`/the instant-math functions
    already gate on — purely for its row identity, and reports the evaluation instant, matching the
    float non-selector arm of `timestampResultExpr`.
- Rotates the rejection-parity catalogue's `expHistogramSelectorRouting` entry
  (`test/rejection-parity/catalogue/internal__promql__lower.go.json`) to the next reachable trigger:
  `predict_linear(demo_latency_exp_hist[5m], 60)`. Filed #2477 to track that class (seven float-only
  range-vector reducers — `predict_linear`, `double_exponential_smoothing`, `deriv`,
  `mad_over_time`, `quantile_over_time`, `stddev_over_time`, `stdvar_over_time` — that should drop
  histogram samples and answer empty, per reference, but still hard-reject).

Closes #2474

## Test plan

- [x] `go test -run '^TestLower_ExpHistogram_Timestamp' ./internal/promql/...` — new unit coverage:
      bare selector (plain / label-matched / parenthesised), `sum()`/`avg()`/`rate()` wrapping a
      selector, all in both instant and range mode, plus the `@`-pinned range-broadcast shape.
      Asserts the plan lowers to `chplan.SampleRowShape` and the resulting plan emits through
      `chsql.Emit` without error.
- [x] `go test -run '^TestLower_ExpHistogram_Timestamp_OtherDateFnsStillRejectHistograms' ./internal/promql/...`
      — guards the fix's scope: every other date-component function (`year`/`month`/`hour`/…) still
      hits the `expHistogramSelectorRouting` rejection over a bare exp-histogram selector, since
      their value math genuinely depends on the sample's `Value` column.
- [x] `go test -race ./internal/promql/...` — no regressions (the only local failures are the three
      new TXTAR fixtures' `-- chplan --`/`-- sql --`/`-- args --` sections, expected to be empty
      until `update-golden.yml` fills them in).
- [ ] New TXTAR fixtures (`timestamp_of_exp_histogram_bare_selector`,
      `timestamp_of_exp_histogram_bare_selector_range`, `timestamp_of_exp_histogram_sum`) need
      `update-golden.yml` (shards `promql solver cardinality`) to fill in `-- args --`/`-- chplan --`
      /`-- sql --`/`-- expected_rows --` before merge.
