### PR TITLE
fix(promql): drop exp-histogram samples for float-only range reducers

### DIFF
--- a/internal/promql/lower.go
+++ b/internal/promql/lower.go
@@ -2376,6 +2376,22 @@ func lowerRangeVectorCall(c *parser.Call, s schema.Metrics, ctx lowerCtx) (chpla
 		return nil, fmt.Errorf("promql: matrix selector's inner must be a VectorSelector, got %T",
 			ms.VectorSelector)
 	}
+	// deriv / mad_over_time / stddev_over_time / stdvar_over_time read
+	// only the window's float samples in reference Prometheus and answer
+	// an empty vector — no error — when the window holds exclusively
+	// histogram samples; see [rangeVectorFloatOnlyDropFuncs] and
+	// [dropExpHistogramSamplesForRangeVector]. Every other function
+	// reaching this generic fallthrough either never sees a histogram
+	// selector here (rate/increase/delta/... are claimed upstream by
+	// lowerRoot's histogram-valued recognisers) or must PRESERVE the
+	// histogram sample rather than drop it (last_over_time /
+	// first_over_time), so the check is keyed on the function name
+	// rather than applied unconditionally.
+	if rangeVectorFloatOnlyDropFuncs[c.Func.Name] {
+		if node, matched, err := dropExpHistogramSamplesForRangeVector(ms, s, ctx); matched {
+			return node, err
+		}
+	}
 
 	anchor, err := anchorFromSelector(vs, ctx)
 	if err != nil {

--- a/internal/promql/lower.go
+++ b/internal/promql/lower.go
@@ -2330,6 +2330,31 @@ func lowerCall(c *parser.Call, s schema.Metrics, ctx lowerCtx) (chplan.Node, err
 	return nil, fmt.Errorf("promql: function %s is not a recognized lowering target", c.Func.Name)
 }
 
+// matrixSelectorArg validates that c carries exactly one range-vector
+// argument and unwraps it to the (MatrixSelector, its inner VectorSelector)
+// pair lowerRangeVectorCall's generic path operates on. Split out of
+// lowerRangeVectorCall itself so that function's own maintainability index
+// stays clear of golangci-lint's `maintidx` floor (.golangci.yml) — this
+// block is a self-contained validate-and-unwrap step with no dependency on
+// anything lowerRangeVectorCall does afterward.
+func matrixSelectorArg(c *parser.Call) (*parser.MatrixSelector, *parser.VectorSelector, error) {
+	if len(c.Args) != 1 {
+		return nil, nil, fmt.Errorf("promql: %s expects exactly 1 argument, got %d", c.Func.Name, len(c.Args))
+	}
+	arg := peelWrappers(c.Args[0])
+	ms, ok := arg.(*parser.MatrixSelector)
+	if !ok {
+		return nil, nil, fmt.Errorf("promql: %s argument must be a range-vector selector, got %T",
+			c.Func.Name, arg)
+	}
+	vs, ok := ms.VectorSelector.(*parser.VectorSelector)
+	if !ok {
+		return nil, nil, fmt.Errorf("promql: matrix selector's inner must be a VectorSelector, got %T",
+			ms.VectorSelector)
+	}
+	return ms, vs, nil
+}
+
 // lowerRangeVectorCall handles range-vector functions: rate, increase,
 // delta, and the `*_over_time` family. The single argument is a
 // MatrixSelector wrapping a VectorSelector; we lower the VectorSelector
@@ -2362,19 +2387,9 @@ func lowerRangeVectorCall(c *parser.Call, s schema.Metrics, ctx lowerCtx) (chpla
 	// prometheus/promql/functions.go::funcFirstOverTime. Like
 	// last_over_time it preserves `__name__` via the
 	// wrapRangeWindowPreserveName special-case below.
-	if len(c.Args) != 1 {
-		return nil, fmt.Errorf("promql: %s expects exactly 1 argument, got %d", c.Func.Name, len(c.Args))
-	}
-	arg := peelWrappers(c.Args[0])
-	ms, ok := arg.(*parser.MatrixSelector)
-	if !ok {
-		return nil, fmt.Errorf("promql: %s argument must be a range-vector selector, got %T",
-			c.Func.Name, arg)
-	}
-	vs, ok := ms.VectorSelector.(*parser.VectorSelector)
-	if !ok {
-		return nil, fmt.Errorf("promql: matrix selector's inner must be a VectorSelector, got %T",
-			ms.VectorSelector)
+	ms, vs, err := matrixSelectorArg(c)
+	if err != nil {
+		return nil, err
 	}
 	// deriv / mad_over_time / stddev_over_time / stdvar_over_time read
 	// only the window's float samples in reference Prometheus and answer

--- a/internal/promql/range_fns.go
+++ b/internal/promql/range_fns.go
@@ -47,6 +47,13 @@ func lowerPredictLinear(c *parser.Call, s schema.Metrics, ctx lowerCtx) (chplan.
 	if err != nil {
 		return nil, err
 	}
+	// Reference Prometheus's funcPredictLinear reads only the window's
+	// float samples (`samples.Floats`) and answers an empty vector — no
+	// error — when the window holds exclusively histogram samples; see
+	// [dropExpHistogramSamplesForRangeVector].
+	if node, matched, err := dropExpHistogramSamplesForRangeVector(ms, s, ctx); matched {
+		return node, err
+	}
 
 	anchor, err := anchorFromSelector(vs, ctx)
 	if err != nil {
@@ -141,6 +148,13 @@ func lowerHoltWinters(c *parser.Call, s schema.Metrics, ctx lowerCtx) (chplan.No
 	ms, vs, err := matrixAndSelector(c, c.Args[0])
 	if err != nil {
 		return nil, err
+	}
+	// Reference Prometheus's funcDoubleExponentialSmoothing reads only the
+	// window's float samples and answers an empty vector — no error —
+	// when the window holds exclusively histogram samples; see
+	// [dropExpHistogramSamplesForRangeVector].
+	if node, matched, err := dropExpHistogramSamplesForRangeVector(ms, s, ctx); matched {
+		return node, err
 	}
 
 	anchor, err := anchorFromSelector(vs, ctx)
@@ -322,6 +336,14 @@ func lowerQuantileOverTime(c *parser.Call, s schema.Metrics, ctx lowerCtx) (chpl
 	if err != nil {
 		return nil, err
 	}
+	// Reference Prometheus's funcQuantileOverTime checks the window's
+	// float-sample count BEFORE it even looks at phi, and answers an
+	// empty vector — no error, no out-of-range-phi annotation — when the
+	// window holds exclusively histogram samples; see
+	// [dropExpHistogramSamplesForRangeVector].
+	if node, matched, err := dropExpHistogramSamplesForRangeVector(ms, s, ctx); matched {
+		return node, err
+	}
 
 	anchor, err := anchorFromSelector(vs, ctx)
 	if err != nil {
@@ -456,4 +478,61 @@ func matrixAndSelector(c *parser.Call, arg parser.Expr) (*parser.MatrixSelector,
 			ms.VectorSelector)
 	}
 	return ms, vs, nil
+}
+
+// rangeVectorFloatOnlyDropFuncs is the subset of range-vector reducers
+// dispatched through lowerRangeVectorCall's GENERIC fallthrough (i.e. not
+// predict_linear / holt_winters / quantile_over_time, which each resolve
+// their MatrixSelector argument at their own call site) whose reference
+// window walk (tsouza/prometheus's promql/functions.go) reads Point.F
+// exclusively and answers an empty vector — no error, no annotation —
+// when the lookback window holds only histogram samples: funcDeriv and
+// varianceOverTime (stddev_over_time / stdvar_over_time, via
+// funcStddevOverTime / funcStdvarOverTime) both early-return `enh.Out, nil`
+// on `len(samples.Floats) == 0`. mad_over_time's funcMadOverTime does the
+// identical `len(samples.Floats) == 0` early return.
+//
+// last_over_time / first_over_time are deliberately EXCLUDED: reference
+// Prometheus (funcLastOverTime / funcFirstOverTime) reads the window's
+// raw H/F Point directly and PRESERVES a histogram sample rather than
+// dropping it, so admitting them here would silently discard a value
+// Prom actually returns — they need their own histogram-passthrough
+// lowering, not this drop treatment. rate / increase / delta / irate /
+// idelta / changes / resets / sum_over_time / avg_over_time never reach
+// this generic path for a histogram selector at all: lowerRoot's earlier
+// histogram-valued recognisers (histogram_native_range_fn.go,
+// histogram_native_over_time.go, histogram_native_resets.go) claim those
+// shapes first. min_over_time / max_over_time / count_over_time /
+// present_over_time are left untouched — cerberus issue #2477 tracks
+// exactly the seven reducers enumerated here plus predict_linear /
+// holt_winters / quantile_over_time, not the full float-only surface.
+var rangeVectorFloatOnlyDropFuncs = map[string]bool{
+	"deriv":            true,
+	"mad_over_time":    true,
+	"stddev_over_time": true,
+	"stdvar_over_time": true,
+}
+
+// dropExpHistogramSamplesForRangeVector recognises a range-vector
+// reducer's MatrixSelector argument as a bare exp-histogram selector and,
+// if so, answers the canonical drop-and-empty plan
+// [dropExpHistogramSamples] wraps: reference Prometheus's float-only
+// range-vector reducers read only the window's float samples and answer
+// an empty vector — never an error — when the window holds exclusively
+// histogram samples (see [rangeVectorFloatOnlyDropFuncs] and the
+// predict_linear / double_exponential_smoothing / quantile_over_time
+// call sites in this file for the per-function evidence).
+//
+// matched is false whenever ms's inner selector is not itself an
+// exp-histogram-valued shape, in which case callers fall through to
+// their ordinary lowering unchanged.
+func dropExpHistogramSamplesForRangeVector(ms *parser.MatrixSelector, s schema.Metrics, ctx lowerCtx) (node chplan.Node, matched bool, err error) {
+	hist, ok, err := lowerExpHistogramValuedShape(ms.VectorSelector, s, ctx)
+	if !ok {
+		return nil, false, nil
+	}
+	if err != nil {
+		return nil, true, err
+	}
+	return dropExpHistogramSamples(hist, s), true, nil
 }

--- a/internal/promql/range_vector_float_only_reducer_exp_histogram_test.go
+++ b/internal/promql/range_vector_float_only_reducer_exp_histogram_test.go
@@ -1,0 +1,116 @@
+package promql_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/tsouza/cerberus/internal/promql"
+	"github.com/tsouza/cerberus/internal/schema"
+)
+
+// TestLower_ExpHistogram_FloatOnlyRangeVectorReducersDropSamples pins issue
+// #2477: reference Prometheus's seven float-only range-vector reducers —
+// predict_linear(), double_exponential_smoothing() (and its holt_winters
+// alias), deriv(), mad_over_time(), quantile_over_time(), stddev_over_time()
+// and stdvar_over_time() — each read only Point.F from their lookback
+// window (tsouza/prometheus's promql/functions.go: funcPredictLinear,
+// funcDoubleExponentialSmoothing, funcDeriv, funcMadOverTime,
+// funcQuantileOverTime, varianceOverTime) and answer an empty vector — no
+// error — when the window holds exclusively histogram samples. None of the
+// seven had the lowerExpHistogramValuedShape / dropExpHistogramSamples
+// check the instant math functions (#2221), the clamp family (#2345) and
+// sort()/sort_desc() (#2456) already apply, so a bare exp-histogram matrix
+// selector fell through to expHistogramSelectorRouting's catch-all
+// rejection instead of Prom's drop-and-answer-empty semantics.
+//
+// mad_over_time / double_exponential_smoothing / holt_winters are
+// experimental functions in the reference parser, so every query here
+// parses through [parseExprExp] (defined in sort_by_label_test.go) rather
+// than a plain parser.Options{}.
+func TestLower_ExpHistogram_FloatOnlyRangeVectorReducersDropSamples(t *testing.T) {
+	t.Parallel()
+
+	s := schema.DefaultOTelMetrics()
+	at := time.Date(2026, 1, 1, 0, 0, 1, 0, time.UTC)
+
+	queries := []string{
+		`predict_linear(latency_exp_hist[5m], 60)`,
+		// `holt_winters(...)` is the legacy spelling of
+		// double_exponential_smoothing(); the reference parser no longer
+		// accepts that name at all (removed upstream — see
+		// internal/promql/subquery.go's own note), so only the current
+		// spelling is reachable from PromQL text. lowerHoltWinters (the
+		// shared lowering both spellings dispatch through, keyed on IR
+		// Func="holt_winters" regardless of source spelling) is exercised
+		// via this query either way.
+		`double_exponential_smoothing(latency_exp_hist[5m], 0.5, 0.5)`,
+		`deriv(latency_exp_hist[5m])`,
+		`mad_over_time(latency_exp_hist[5m])`,
+		`quantile_over_time(0.5, latency_exp_hist[5m])`,
+		`stddev_over_time(latency_exp_hist[5m])`,
+		`stdvar_over_time(latency_exp_hist[5m])`,
+
+		// A computed (non-literal) parameter must not bypass the check:
+		// the drop happens before the parameter is even resolved.
+		`predict_linear(latency_exp_hist[5m], scalar(vector(60)))`,
+		`quantile_over_time(scalar(vector(0.9)), latency_exp_hist[5m])`,
+
+		// An `@`-pinned broadcast reaches the same drop path — the
+		// histogram-selector recognition happens before the grid-shape
+		// switch.
+		`deriv(latency_exp_hist[5m] @ 1767225601)`,
+	}
+
+	for _, query := range queries {
+		query := query
+		t.Run(query, func(t *testing.T) {
+			t.Parallel()
+
+			expr := parseExprExp(t, query)
+			plan, err := promql.LowerAt(context.Background(), expr, s, at, at)
+			if err != nil {
+				t.Fatalf("LowerAt(%q): %v", query, err)
+			}
+			assertEmptyFloatProjection(t, plan)
+		})
+	}
+}
+
+// TestLower_ExpHistogram_FloatOnlyRangeVectorReducersRangeMode pins the
+// query_range shape for the same seven reducers: LowerAtRange threads a
+// non-zero step, which would otherwise route through the gridFanout /
+// applyStepGridFanout branch these reducers never reach once the
+// histogram-selector check fires first.
+func TestLower_ExpHistogram_FloatOnlyRangeVectorReducersRangeMode(t *testing.T) {
+	t.Parallel()
+
+	s := schema.DefaultOTelMetrics()
+	start := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	end := start.Add(5 * time.Minute)
+	step := time.Minute
+
+	queries := []string{
+		`predict_linear(latency_exp_hist[5m], 60)`,
+		`double_exponential_smoothing(latency_exp_hist[5m], 0.5, 0.5)`,
+		`deriv(latency_exp_hist[5m])`,
+		`mad_over_time(latency_exp_hist[5m])`,
+		`quantile_over_time(0.5, latency_exp_hist[5m])`,
+		`stddev_over_time(latency_exp_hist[5m])`,
+		`stdvar_over_time(latency_exp_hist[5m])`,
+	}
+
+	for _, query := range queries {
+		query := query
+		t.Run(query, func(t *testing.T) {
+			t.Parallel()
+
+			expr := parseExprExp(t, query)
+			plan, err := promql.LowerAtRange(context.Background(), expr, s, start, end, step)
+			if err != nil {
+				t.Fatalf("LowerAtRange(%q): %v", query, err)
+			}
+			assertEmptyFloatProjection(t, plan)
+		})
+	}
+}

--- a/test/perf/cardinality-baseline/promql/predict_linear_exp_histogram_drops.json
+++ b/test/perf/cardinality-baseline/promql/predict_linear_exp_histogram_drops.json
@@ -1,0 +1,11 @@
+{
+  "fixture": "promql/predict_linear_exp_histogram_drops",
+  "fan_factor": 1,
+  "scan_rows": 1,
+  "peak_intermediate": 1,
+  "has_cross_join": false,
+  "has_array_join": false,
+  "has_recursive_cte": false,
+  "max_recursion_depth": 0,
+  "uncountable_levels": 0
+}

--- a/test/perf/solver-decision-baseline/predict_linear_exp_histogram_drops/fanout.json
+++ b/test/perf/solver-decision-baseline/predict_linear_exp_histogram_drops/fanout.json
@@ -1,0 +1,11 @@
+{
+  "query": "predict_linear_exp_histogram_drops/fanout",
+  "lowering": "fanout",
+  "routed": false,
+  "k": 0,
+  "reason": "not-sliceable",
+  "n_anchors": 241,
+  "fanout": 20,
+  "cumulative_d": "5m0s",
+  "outer_range": "1h0m0s"
+}

--- a/test/perf/solver-decision-baseline/predict_linear_exp_histogram_drops/native.json
+++ b/test/perf/solver-decision-baseline/predict_linear_exp_histogram_drops/native.json
@@ -1,0 +1,11 @@
+{
+  "query": "predict_linear_exp_histogram_drops/native",
+  "lowering": "native",
+  "routed": false,
+  "k": 0,
+  "reason": "not-sliceable",
+  "n_anchors": 241,
+  "fanout": 20,
+  "cumulative_d": "5m0s",
+  "outer_range": "1h0m0s"
+}

--- a/test/regression/parity-enrolment-baselines/promql/baseline.txt
+++ b/test/regression/parity-enrolment-baselines/promql/baseline.txt
@@ -429,6 +429,7 @@ pinned_name_selector_no_histogram_fanout.txtar
 pow_arithmetic.txtar
 power_op_basic.txtar
 power_op_vv.txtar
+predict_linear_exp_histogram_drops.txtar
 predict_linear_scalar_horizon.txtar
 predict_linear_simple.txtar
 predict_linear_subscrape_drops.txtar

--- a/test/rejection-parity/catalogue/internal__promql__lower.go.json
+++ b/test/rejection-parity/catalogue/internal__promql__lower.go.json
@@ -94,8 +94,8 @@
       "site": "internal/promql/lower.go:expHistogramSelectorRouting#bf746b59",
       "message": "promql: %q is an exponential histogram metric; only a bare %q selector, sum()/avg()/count() over one, rate()/increase()/delta()/irate()/idelta()/sum_over_time()/avg_over_time()/resets()/changes() over one, histogram_quantile(), histogram_count(), histogram_sum(), and the %q/%q companion selectors are supported",
       "class": "divergence",
-      "trigger_query": "predict_linear(demo_latency_exp_hist[5m], 60)",
-      "tracking_issue": 2477,
+      "trigger_query": "min_over_time(demo_latency_exp_hist[5m])",
+      "tracking_issue": 2480,
       "evidence": {
         "guard": [
           "past returning if bare, col, hasCompanion := s.HistogramCompanionColumn(metricName); hasCompanion \u0026\u0026 s.IsExpHistogramMetric(bare) \u0026\u0026 s.ExpHistogramTable != \"\"",

--- a/test/rejection-parity/catalogue/internal__promql__lower.go.json
+++ b/test/rejection-parity/catalogue/internal__promql__lower.go.json
@@ -269,60 +269,6 @@
     },
     {
       "head": "promql",
-      "site": "internal/promql/lower.go:lowerRangeVectorCall#064574ba",
-      "message": "promql: %s expects exactly 1 argument, got %d",
-      "class": "internal",
-      "rationale": "parser-enforced arity: the range-vector functions are pinned at one argument in parser.Functions",
-      "evidence": {
-        "guard": [
-          "past exhaustive switch c.Func.Name over [case \"predict_linear\"; case \"holt_winters\", \"double_exponential_smoothing\"; case \"absent_over_time\"]",
-          "if len(c.Args) != 1"
-        ],
-        "callers": [
-          "lowerCall"
-        ]
-      }
-    },
-    {
-      "head": "promql",
-      "site": "internal/promql/lower.go:lowerRangeVectorCall#5fccc59e",
-      "message": "promql: matrix selector's inner must be a VectorSelector, got %T",
-      "class": "internal",
-      "rationale": "the parser only builds MatrixSelector around a VectorSelector",
-      "evidence": {
-        "guard": [
-          "past exhaustive switch c.Func.Name over [case \"predict_linear\"; case \"holt_winters\", \"double_exponential_smoothing\"; case \"absent_over_time\"]",
-          "past returning if len(c.Args) != 1",
-          "past returning if !ok",
-          "if !ok"
-        ],
-        "callers": [
-          "lowerCall"
-        ]
-      }
-    },
-    {
-      "head": "promql",
-      "site": "internal/promql/lower.go:lowerRangeVectorCall#ccda8b22",
-      "message": "promql: %s argument must be a range-vector selector, got %T",
-      "class": "internal",
-      "rationale": "subquery arguments are intercepted by lowerOuterRangeFnOverSubquery; the parser's typechecker admits only matrix-typed arguments otherwise",
-      "evidence": {
-        "guard": [
-          "past exhaustive switch c.Func.Name over [case \"predict_linear\"; case \"holt_winters\", \"double_exponential_smoothing\"; case \"absent_over_time\"]",
-          "past returning if len(c.Args) != 1",
-          "if !ok"
-        ],
-        "callers": [
-          "lowerCall"
-        ],
-        "cited": [
-          "lowerOuterRangeFnOverSubquery"
-        ]
-      }
-    },
-    {
-      "head": "promql",
       "site": "internal/promql/lower.go:lowerRoot#53e0f9b3",
       "message": "promql: internal invariant violated: count_values input is not histogram-valued: %v",
       "class": "internal",
@@ -397,6 +343,57 @@
           "mixedExpHistogramSetOp",
           "peelWrappers",
           "sumOrAvgOverMixedExpHistogramSetOp"
+        ]
+      }
+    },
+    {
+      "head": "promql",
+      "site": "internal/promql/lower.go:matrixSelectorArg#064574ba",
+      "message": "promql: %s expects exactly 1 argument, got %d",
+      "class": "internal",
+      "rationale": "parser-enforced arity: the range-vector functions are pinned at one argument in parser.Functions",
+      "evidence": {
+        "guard": [
+          "if len(c.Args) != 1"
+        ],
+        "callers": [
+          "lowerRangeVectorCall"
+        ]
+      }
+    },
+    {
+      "head": "promql",
+      "site": "internal/promql/lower.go:matrixSelectorArg#5fccc59e",
+      "message": "promql: matrix selector's inner must be a VectorSelector, got %T",
+      "class": "internal",
+      "rationale": "the parser only builds MatrixSelector around a VectorSelector",
+      "evidence": {
+        "guard": [
+          "past returning if len(c.Args) != 1",
+          "past returning if !ok",
+          "if !ok"
+        ],
+        "callers": [
+          "lowerRangeVectorCall"
+        ]
+      }
+    },
+    {
+      "head": "promql",
+      "site": "internal/promql/lower.go:matrixSelectorArg#ccda8b22",
+      "message": "promql: %s argument must be a range-vector selector, got %T",
+      "class": "internal",
+      "rationale": "subquery arguments are intercepted by lowerOuterRangeFnOverSubquery; the parser's typechecker admits only matrix-typed arguments otherwise",
+      "evidence": {
+        "guard": [
+          "past returning if len(c.Args) != 1",
+          "if !ok"
+        ],
+        "callers": [
+          "lowerRangeVectorCall"
+        ],
+        "cited": [
+          "lowerOuterRangeFnOverSubquery"
         ]
       }
     },

--- a/test/spec/promql/predict_linear_exp_histogram_drops.txtar
+++ b/test/spec/promql/predict_linear_exp_histogram_drops.txtar
@@ -34,3 +34,44 @@ INSERT INTO otel_metrics_exponential_histogram VALUES
     ('demo_latency_exp_hist', map('service', 'api'), toDateTime64('2026-01-01 00:00:00', 9), 6, 42.5, 0, 0, 0, [1, 2, 3], 0, []);
 -- expected_rows --
 []
+-- args --
+[0] string = ""
+[1] float64 = 0
+[2] int64 = 9
+[3] float64 = 0
+[4] string = "service_name"
+[5] string = "service.name"
+[6] string = "service_name"
+[7] string = "service.name"
+[8] string = "service_name"
+[9] string = ""
+[10] string = "service_name"
+[11] string = "demo_latency_exp_hist"
+[12] string = "demo.latency.exp.hist"
+[13] string = "demo.latency.exp/hist"
+[14] string = "demo.latency.exp_hist"
+[15] string = "demo.latency/exp/hist"
+[16] string = "demo.latency/exp_hist"
+[17] string = "demo.latency_exp.hist"
+[18] string = "demo.latency_exp_hist"
+[19] string = "demo/latency/exp/hist"
+[20] string = "demo/latency/exp_hist"
+[21] string = "demo/latency_exp_hist"
+[22] string = "demo_latency.exp.hist"
+[23] string = "demo_latency.exp_hist"
+[24] string = "demo_latency_exp.hist"
+[25] string = "2026-01-01 00:00:01.000000000"
+[26] int64 = 9
+[27] string = "2026-01-01 00:00:01.000000000"
+[28] int64 = 9
+[29] int64 = 300000000000
+[30] bool = false
+-- chplan --
+Project ["" AS MetricName, Attributes AS Attributes, TimeUnix AS TimeUnix, 0 AS Value]
+  Filter predicate=false
+    HistogramProjection project=[MetricName AS MetricName, Attributes AS Attributes, FnNow64(9) AS TimeUnix, 0 AS Value]
+      Aggregate groupBy=[FnMapSort(FnMapMerge(FnMapFilter((k, v) -> (k NOT IN ("service_name")), FnMapUpdate(FnMapFromArrays(FnArrayMap(k -> FnRegexReplaceAll(k, "[^a-zA-Z0-9_]", "_"), FnMapKeys(FnMapFilter((k, v) -> (k NOT IN ("service.name", "service_name")), ResourceAttributes))), FnMapValues(FnMapFilter((k, v) -> (k NOT IN ("service.name", "service_name")), ResourceAttributes))), FnMapFromArrays(FnArrayMap(k -> FnRegexReplaceAll(k, "[^a-zA-Z0-9_]", "_"), FnMapKeys(Attributes)), FnMapValues(Attributes)))), FnMapFilter((k, v) -> (v != ""), FnMap("service_name", FnToString(ServiceName))))) AS Attributes] funcs=[FnArgMax(MetricName, TimeUnix) AS MetricName, FnArgMax(Count, TimeUnix) AS Count, FnArgMax(Sum, TimeUnix) AS Sum, FnArgMax(Scale, TimeUnix) AS Scale, FnArgMax(ZeroCount, TimeUnix) AS ZeroCount, FnArgMax(PositiveOffset, TimeUnix) AS PositiveOffset, FnArgMax(PositiveBucketCounts, TimeUnix) AS PositiveBucketCounts, FnArgMax(NegativeOffset, TimeUnix) AS NegativeOffset, FnArgMax(NegativeBucketCounts, TimeUnix) AS NegativeBucketCounts]
+        Filter predicate=(((MetricName IN ("demo_latency_exp_hist", "demo.latency.exp.hist", "demo.latency.exp/hist", "demo.latency.exp_hist", "demo.latency/exp/hist", "demo.latency/exp_hist", "demo.latency_exp.hist", "demo.latency_exp_hist", "demo/latency/exp/hist", "demo/latency/exp_hist", "demo/latency_exp_hist", "demo_latency.exp.hist", "demo_latency.exp_hist", "demo_latency_exp.hist")) AND (TimeUnix <= FnToDateTime64("2026-01-01 00:00:01.000000000", 9))) AND (TimeUnix > (FnToDateTime64("2026-01-01 00:00:01.000000000", 9) - FnToIntervalNanosecond(300000000000))))
+          Scan(otel_metrics_exponential_histogram)
+-- sql --
+SELECT ? AS `MetricName`, `Attributes` AS `Attributes`, `TimeUnix` AS `TimeUnix`, toFloat64(?) AS `Value` FROM (SELECT * FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, now64(?) AS `TimeUnix`, toFloat64(?) AS `Value`, toFloat64(`Count`) AS `HistogramCount`, toFloat64(`Sum`) AS `HistogramSum`, toInt32(`Scale`) AS `HistogramScale`, toFloat64(0.) AS `HistogramZeroThreshold`, toFloat64(`ZeroCount`) AS `HistogramZeroCount`, toInt32(`PositiveOffset`) AS `HistogramPositiveOffset`, arrayMap(x -> toFloat64(x), `PositiveBucketCounts`) AS `HistogramPositiveBucketCounts`, toInt32(`NegativeOffset`) AS `HistogramNegativeOffset`, arrayMap(x -> toFloat64(x), `NegativeBucketCounts`) AS `HistogramNegativeBucketCounts` FROM (SELECT mapSort(mapConcat(mapFilter((k, v) -> (k NOT IN (?)), mapUpdate(mapFromArrays(arrayMap(k -> replaceRegexpAll(k, '[^a-zA-Z0-9_]', '_'), mapKeys(mapFilter((k, v) -> (k NOT IN (?, ?)), `ResourceAttributes`))), mapValues(mapFilter((k, v) -> (k NOT IN (?, ?)), `ResourceAttributes`))), mapFromArrays(arrayMap(k -> replaceRegexpAll(k, '[^a-zA-Z0-9_]', '_'), mapKeys(`Attributes`)), mapValues(`Attributes`)))), mapFilter((k, v) -> (v != ?), map(?, toString(`ServiceName`))))) AS `Attributes`, argMax(`MetricName`, `TimeUnix`) AS `MetricName`, argMax(`Count`, `TimeUnix`) AS `Count`, argMax(`Sum`, `TimeUnix`) AS `Sum`, argMax(`Scale`, `TimeUnix`) AS `Scale`, argMax(`ZeroCount`, `TimeUnix`) AS `ZeroCount`, argMax(`PositiveOffset`, `TimeUnix`) AS `PositiveOffset`, argMax(`PositiveBucketCounts`, `TimeUnix`) AS `PositiveBucketCounts`, argMax(`NegativeOffset`, `TimeUnix`) AS `NegativeOffset`, argMax(`NegativeBucketCounts`, `TimeUnix`) AS `NegativeBucketCounts` FROM (SELECT * FROM `otel_metrics_exponential_histogram` PREWHERE (`MetricName` IN (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)) WHERE (`TimeUnix` <= toDateTime64(?, ?)) AND (`TimeUnix` > (toDateTime64(?, ?) - toIntervalNanosecond(?)))) GROUP BY `Attributes`)) WHERE ?)

--- a/test/spec/promql/predict_linear_exp_histogram_drops.txtar
+++ b/test/spec/promql/predict_linear_exp_histogram_drops.txtar
@@ -1,0 +1,36 @@
+# predict_linear() over a bare exp-histogram selector whose window holds
+# ONLY histogram samples (cerberus issue #2477). Reference Prometheus's
+# funcPredictLinear reads only Point.F from the window
+# (tsouza/prometheus's promql/functions.go) and, with zero float points in
+# range, answers an empty vector — no error, no annotation. Before #2477
+# cerberus hard-rejected this shape at expHistogramSelectorRouting instead
+# of lowering it at all; dropExpHistogramSamplesForRangeVector now
+# recognises the bare exp-histogram matrix-selector argument up front and
+# answers the same drop-to-empty plan sort()/sort_desc() (#2456) and the
+# instant math functions (#2221) already produce for their own
+# histogram-only inputs.
+
+-- query.promql --
+predict_linear(demo_latency_exp_hist[5m], 60)
+-- parity --
+oracle: prometheus
+endpoint: /api/v1/query
+scope: full
+-- seed --
+CREATE TABLE otel_metrics_exponential_histogram (
+    MetricName String,
+    Attributes Map(String, String),
+    TimeUnix DateTime64(9),
+    Count UInt64,
+    Sum Float64,
+    Scale Int32,
+    ZeroCount UInt64,
+    PositiveOffset Int32,
+    PositiveBucketCounts Array(UInt64),
+    NegativeOffset Int32,
+    NegativeBucketCounts Array(UInt64)
+) ENGINE = MergeTree ORDER BY (MetricName, Attributes, TimeUnix);
+INSERT INTO otel_metrics_exponential_histogram VALUES
+    ('demo_latency_exp_hist', map('service', 'api'), toDateTime64('2026-01-01 00:00:00', 9), 6, 42.5, 0, 0, 0, [1, 2, 3], 0, []);
+-- expected_rows --
+[]


### PR DESCRIPTION
## Summary

- Reference Prometheus's seven float-only range-vector reducers — `predict_linear()`,
  `double_exponential_smoothing()` (and its `holt_winters` alias), `deriv()`, `mad_over_time()`,
  `quantile_over_time()`, `stddev_over_time()`, `stdvar_over_time()` — each read only `Point.F`
  from their lookback window and answer an empty vector, never an error, when the window holds
  exclusively histogram samples. None had the `lowerExpHistogramValuedShape` check the instant
  math functions (#2221), the clamp family (#2345) and `sort()`/`sort_desc()` (#2456) already
  apply, so a bare exp-histogram matrix-selector argument fell through to
  `expHistogramSelectorRouting`'s catch-all rejection instead.
- Verified each function's window walk directly against `tsouza/prometheus`'s
  `promql/functions.go` before implementing, rather than trusting the issue text's "all seven are
  uniform" claim at face value — all seven do early-return an empty vector on
  `len(samples.Floats) == 0` (or `< 2`, with no mixed-histogram annotation once floats are zero).
- Adds `dropExpHistogramSamplesForRangeVector` (`internal/promql/range_fns.go`), wired at
  `predict_linear` / `holt_winters` / `quantile_over_time`'s own call sites and, for `deriv` /
  `mad_over_time` / `stddev_over_time` / `stdvar_over_time`, once at
  `lowerRangeVectorCall`'s shared generic dispatch fallthrough (`rangeVectorFloatOnlyDropFuncs`) —
  the single shared dispatch point the issue's own text identified for those four.
  `last_over_time` / `first_over_time` are deliberately excluded from that shared check: reference
  Prometheus *preserves* rather than drops their selected histogram sample, so admitting them here
  would silently discard a value Prom actually returns.

## Rejection-parity catalogue

Rotates `test/rejection-parity/catalogue/internal__promql__lower.go.json`'s
`expHistogramSelectorRouting` entry to the next reachable trigger, `min_over_time()` over a raw
exp-histogram matrix selector, tracked by #2480 — filed in this session. `min_over_time()` /
`max_over_time()` share this issue's exact drop pattern (`compareOverTime` early-returns empty on
zero float samples, same as the seven fixed here); `count_over_time()` / `present_over_time()` /
`last_over_time()` / `first_over_time()` do **not** — verified against the vendored fork that they
need their own histogram-aware (not drop) lowering, so #2480 documents that distinction rather
than assuming uniformity.

## Test plan

- [x] `go build ./...`
- [x] `go test ./internal/promql/...` — full package, including the new
      `TestLower_ExpHistogram_FloatOnlyRangeVectorReducersDropSamples` /
      `...RangeMode` unit tests covering all seven functions (instant + query_range +
      `@`-broadcast + computed-parameter shapes)
- [x] `node .github/scripts/forbid-sql-raw.mjs`
- [ ] New TXTAR fixture `test/spec/promql/predict_linear_exp_histogram_drops.txtar` — a real
      chDB round-trip proving `predict_linear()` over an all-histogram window answers zero rows,
      not just that the lowered plan's Go shape looks right. Needs `update-golden.yml` (promql
      shard) to fill in `args`/`chplan`/`sql`/`expected_rows`; will pull the regenerated goldens
      back onto this branch before merge.

Closes #2477

https://claude.ai/code/session_01DP3Dc7EMAp8QCBaEaKp9P9
