### PR TITLE
fix(promql): support min/max/count/present/last/first_over_time over exp-histograms

### DIFF
--- a/internal/promql/histogram_native_count_present_over_time.go
+++ b/internal/promql/histogram_native_count_present_over_time.go
@@ -1,0 +1,192 @@
+package promql
+
+import (
+	"github.com/prometheus/prometheus/promql/parser"
+
+	"github.com/tsouza/cerberus/internal/chplan"
+	"github.com/tsouza/cerberus/internal/schema"
+)
+
+// histogram_native_count_present_over_time.go lowers count_over_time() and
+// present_over_time() over an OTel exponential (native) histogram selector
+// into a FLOAT-valued result (cerberus issue #2480).
+//
+// Reference Prometheus's funcCountOverTime / funcPresentOverTime
+// (tsouza/prometheus's promql/functions.go) both run through the shared
+// aggrOverTime helper, which answers a series' one row whenever that
+// series has ANY sample — float OR histogram — in the matched window:
+//
+//	func aggrOverTime(matrixVal Matrix, enh *EvalNodeHelper, aggrFn func(Series) float64) Vector {
+//	    if len(matrixVal) == 0 {
+//	        return enh.Out
+//	    }
+//	    el := matrixVal[0]
+//	    return append(enh.Out, Sample{F: aggrFn(el)})
+//	}
+//
+//	func funcCountOverTime(...) (Vector, annotations.Annotations) {
+//	    return aggrOverTime(matrixVals, enh, func(s Series) float64 {
+//	        return float64(len(s.Floats) + len(s.Histograms))
+//	    }), nil
+//	}
+//
+//	func funcPresentOverTime(...) (Vector, annotations.Annotations) {
+//	    return aggrOverTime(matrixVals, enh, func(Series) float64 { return 1 }), nil
+//	}
+//
+// Neither guards on `len(s.Floats) == 0` the way min_over_time / max_over_time
+// (compareOverTime) or the seven #2477 float-only reducers do — so an
+// ALL-HISTOGRAM window answers a non-empty count / presence value in
+// reference, not an empty vector. The DROP treatment
+// [rangeVectorFloatOnlyDropFuncs] applies to deriv/mad_over_time/
+// stddev_over_time/stdvar_over_time would therefore be WRONG here. This
+// file gives both functions their own histogram-aware windowed lowering
+// instead: a per-(series, anchor) collapse that counts (or, for
+// present_over_time, merely confirms) the in-window rows without ever
+// reading a bucket/count/sum column — the same value-blind posture
+// [lowerExpHistogramCountOrGroupOverPlan] already uses for the GROUP()
+// aggregation operator.
+//
+// Both functions DROP `__name__` — neither is in [rangeFnPreservesName]'s
+// set, matching reference: aggrOverTime's Sample carries no Metric labels
+// of its own.
+const (
+	countOverTimeWindowFn   = "count_over_time"
+	presentOverTimeWindowFn = "present_over_time"
+)
+
+// countPresentOverExpHistogram recognises `count_over_time(<selector>[r])`
+// / `present_over_time(<selector>[r])` where the selector names an
+// exp-histogram metric — the one shape this file answers. Mirrors
+// [overTimeOverExpHistogram]'s own recognizer shape (sum_over_time /
+// avg_over_time) rung for rung, differing only in which two function
+// names it admits.
+func countPresentOverExpHistogram(expr parser.Expr, s schema.Metrics, ctx lowerCtx) (fn string, ms *parser.MatrixSelector, vs *parser.VectorSelector, ok bool) {
+	if s.ExpHistogramTable == "" || ctx.metadataFullRange {
+		return "", nil, nil, false
+	}
+	call, ok := peelWrappers(expr).(*parser.Call)
+	if !ok || (call.Func.Name != countOverTimeWindowFn && call.Func.Name != presentOverTimeWindowFn) || len(call.Args) != 1 {
+		return "", nil, nil, false
+	}
+	ms, ok = peelWrappers(call.Args[0]).(*parser.MatrixSelector)
+	if !ok || ms.Range <= 0 {
+		return "", nil, nil, false
+	}
+	vs, ok = peelWrappers(ms.VectorSelector).(*parser.VectorSelector)
+	if !ok || !s.IsExpHistogramMetric(metricNameFromMatchers(vs.LabelMatchers)) {
+		return "", nil, nil, false
+	}
+	return call.Func.Name, ms, vs, true
+}
+
+// lowerCountPresentOverExpHistogram lowers the recognised shape across the
+// three evaluation grids [rangeGridShapeFor] distinguishes — see
+// [lowerExpHistogramBare] for what each means.
+func lowerCountPresentOverExpHistogram(fn string, ms *parser.MatrixSelector, vs *parser.VectorSelector, s schema.Metrics, ctx lowerCtx) (chplan.Node, error) {
+	switch rangeGridShapeFor(vs, ctx) {
+	case gridFanout:
+		return lowerExpHistogramCountPresentRange(fn, ms, vs, s, ctx), nil
+	case gridBroadcast:
+		windowed, err := expHistogramCountPresentWindowed(fn, ms, vs, s, ctx)
+		if err != nil {
+			return nil, err
+		}
+		grid := &chplan.StepGrid{Start: ctx.start.UTC(), End: ctx.end.UTC(), Step: ctx.step}
+		return expHistogramCountPresentProjection(
+			&chplan.CrossJoin{Left: grid, Right: windowed},
+			&chplan.ColumnRef{Name: stepGridAnchorColumn}, s,
+		), nil
+	default:
+		windowed, err := expHistogramCountPresentWindowed(fn, ms, vs, s, ctx)
+		if err != nil {
+			return nil, err
+		}
+		return expHistogramCountPresentProjection(windowed, chplan.NowNano(), s), nil
+	}
+}
+
+// expHistogramCountPresentValueAgg is the aggregate that collapses an
+// in-window group of exp-histogram rows to count_over_time's / present_
+// over_time's scalar Value: a genuine row COUNT for count_over_time
+// (reference sums `len(Floats)+len(Histograms)`, which over an
+// all-histogram window is exactly the in-window row count) or, for
+// present_over_time, the constant 1 (reference never inspects the sample
+// beyond its existence). `any(toFloat64(1))` is the same value-blind
+// pattern [lowerExpHistogramCountOrGroupOverPlan] uses for the GROUP()
+// aggregation operator: pick any row, ignore its payload.
+func expHistogramCountPresentValueAgg(fn string, s schema.Metrics) chplan.AggFunc {
+	if fn == presentOverTimeWindowFn {
+		return chplan.AggFunc{
+			Fn: chplan.FnAny,
+			Args: []chplan.Expr{&chplan.FuncCall{
+				Fn:   chplan.FnToFloat64,
+				Args: []chplan.Expr{&chplan.LitInt{V: 1}},
+			}},
+			Alias: s.ValueColumn,
+		}
+	}
+	return chplan.AggFunc{Fn: chplan.FnCount, Alias: s.ValueColumn}
+}
+
+// expHistogramCountPresentWindowed builds the instant-mode subtree: the
+// selector's matcher-filtered scan bound to `(anchor - ms.Range, anchor]`
+// — the same left-open/right-closed window [lowerMatrixSelector] applies;
+// count_over_time / present_over_time read the WHOLE matched window, not
+// a staleness lookback — collapsed to one row per series via the
+// value-blind aggregate above. A series with zero in-window rows produces
+// no group and therefore no output row, matching reference's "series
+// absent from the selector's per-step Matrix" behavior.
+func expHistogramCountPresentWindowed(fn string, ms *parser.MatrixSelector, vs *parser.VectorSelector, s schema.Metrics, ctx lowerCtx) (chplan.Node, error) {
+	anchor, err := selectorAnchor(vs, ctx)
+	if err != nil {
+		return nil, err
+	}
+	pred := buildPredicate(vs.LabelMatchers, s)
+	pred = andExpr(pred, timeBoundExpr(s.TimestampColumn, anchor))
+	pred = andExpr(pred, stalenessLowerBoundExpr(s.TimestampColumn, anchor, ms.Range))
+	var input chplan.Node = &chplan.Scan{Table: s.ExpHistogramTable}
+	if pred != nil {
+		input = &chplan.Filter{Input: input, Predicate: pred}
+	}
+	return &chplan.Aggregate{
+		Input:              input,
+		GroupBy:            []chplan.Expr{histogramIdentityExpr(s)},
+		GroupByAliases:     []string{s.AttributesColumn},
+		AggFuncs:           []chplan.AggFunc{expHistogramCountPresentValueAgg(fn, s)},
+		DropEmptyOnNoGroup: true,
+	}, nil
+}
+
+// lowerExpHistogramCountPresentRange is the query_range shape: fan the
+// stored histogram rows across the request's step grid via
+// [buildHistogramBucketFanout], one `[ms.Range]` window per step anchor —
+// reusing [windowFor] the same way [lowerExpHistogramOverTimeRange] does
+// for sum_over_time / avg_over_time — and collapse each (series, anchor)
+// group with the same value-blind aggregate the instant path uses.
+func lowerExpHistogramCountPresentRange(fn string, ms *parser.MatrixSelector, vs *parser.VectorSelector, s schema.Metrics, ctx lowerCtx) chplan.Node {
+	fanout := buildHistogramBucketFanout(
+		&chplan.Scan{Table: s.ExpHistogramTable},
+		buildPredicate(vs.LabelMatchers, s), nil,
+		windowFor(vs, ms.Range),
+		[]chplan.Expr{histogramIdentityExpr(s)}, []string{s.AttributesColumn},
+		[]chplan.AggFunc{expHistogramCountPresentValueAgg(fn, s)},
+		s, ctx,
+	)
+	return expHistogramCountPresentProjection(fanout, &chplan.ColumnRef{Name: stepGridAnchorColumn}, s)
+}
+
+// expHistogramCountPresentProjection caps the counted/presence subtree
+// with the canonical four-column sample quartet. `__name__` drops — see
+// this file's own doc for why neither function preserves it.
+func expHistogramCountPresentProjection(input chplan.Node, tsExpr chplan.Expr, s schema.Metrics) chplan.Node {
+	return &chplan.Project{
+		Input: input,
+		Projections: []chplan.Projection{
+			{Expr: &chplan.LitString{V: ""}, Alias: s.MetricNameColumn},
+			{Expr: &chplan.ColumnRef{Name: s.AttributesColumn}, Alias: s.AttributesColumn},
+			{Expr: tsExpr, Alias: s.TimestampColumn},
+			{Expr: &chplan.ColumnRef{Name: s.ValueColumn}, Alias: s.ValueColumn},
+		},
+	}
+}

--- a/internal/promql/histogram_native_count_present_over_time_test.go
+++ b/internal/promql/histogram_native_count_present_over_time_test.go
@@ -1,0 +1,147 @@
+package promql_test
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/prometheus/prometheus/promql/parser"
+
+	"github.com/tsouza/cerberus/internal/chplan"
+	"github.com/tsouza/cerberus/internal/chsql"
+	"github.com/tsouza/cerberus/internal/promql"
+	"github.com/tsouza/cerberus/internal/schema"
+)
+
+// TestLower_ExpHistogram_CountPresentOverTimeIsFloatValued pins cerberus
+// issue #2480: count_over_time() / present_over_time() over a bare
+// exp-histogram selector answer a FLOAT-valued plan — never
+// expHistogramSelectorRouting's rejection, and never the empty-vector drop
+// [rangeVectorFloatOnlyDropFuncs] applies to min_over_time / max_over_time
+// — because reference Prometheus's funcCountOverTime / funcPresentOverTime
+// never guard on `len(samples.Floats) == 0` before answering.
+func TestLower_ExpHistogram_CountPresentOverTimeIsFloatValued(t *testing.T) {
+	t.Parallel()
+
+	s := schema.DefaultOTelMetrics()
+	p := parser.NewParser(parser.Options{})
+	start := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	end := start.Add(time.Hour)
+
+	for _, tc := range []struct {
+		name  string
+		query string
+		lower func(parser.Expr) (chplan.Node, error)
+	}{
+		{
+			name:  "instant count",
+			query: `count_over_time(latency_exp_hist[5m])`,
+			lower: func(e parser.Expr) (chplan.Node, error) {
+				return promql.LowerAt(context.Background(), e, s, end, end)
+			},
+		},
+		{
+			name:  "instant present",
+			query: `present_over_time(latency_exp_hist{service="api"}[5m])`,
+			lower: func(e parser.Expr) (chplan.Node, error) {
+				return promql.LowerAt(context.Background(), e, s, end, end)
+			},
+		},
+		{
+			name:  "count offset",
+			query: `count_over_time(latency_exp_hist[5m] offset 10m)`,
+			lower: func(e parser.Expr) (chplan.Node, error) {
+				return promql.LowerAt(context.Background(), e, s, end, end)
+			},
+		},
+		{
+			name:  "count range",
+			query: `count_over_time(latency_exp_hist[5m])`,
+			lower: func(e parser.Expr) (chplan.Node, error) {
+				return promql.LowerAtRange(context.Background(), e, s, start, end, time.Minute)
+			},
+		},
+		{
+			name:  "present range at pin",
+			query: `present_over_time(latency_exp_hist[5m] @ 1767225600)`,
+			lower: func(e parser.Expr) (chplan.Node, error) {
+				return promql.LowerAtRange(context.Background(), e, s, start, end, time.Minute)
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			expr, err := p.ParseExpr(tc.query)
+			if err != nil {
+				t.Fatalf("ParseExpr(%q): %v", tc.query, err)
+			}
+			plan, err := tc.lower(expr)
+			if err != nil {
+				t.Fatalf("lower(%q): %v", tc.query, err)
+			}
+			proj, ok := plan.(*chplan.Project)
+			if !ok {
+				t.Fatalf("lower(%q) root = %T, want *chplan.Project", tc.query, plan)
+			}
+			if got := len(proj.Projections); got != 4 {
+				t.Fatalf("lower(%q) projections = %d, want 4 (canonical float Sample quartet)", tc.query, got)
+			}
+			name, ok := proj.Projections[0].Expr.(*chplan.LitString)
+			if !ok || name.V != "" {
+				t.Fatalf("lower(%q) MetricName projection = %#v, want empty derived name", tc.query, proj.Projections[0].Expr)
+			}
+			if alias := proj.Projections[3].Alias; alias != s.ValueColumn {
+				t.Fatalf("lower(%q) 4th projection alias = %q, want %q", tc.query, alias, s.ValueColumn)
+			}
+		})
+	}
+}
+
+// TestLower_ExpHistogram_CountOverTimeEmitsRowCount pins the SQL shape:
+// count_over_time() must emit an actual count() aggregate over the
+// windowed rows, and present_over_time() must emit the constant-1
+// any(toFloat64(1)) pattern [lowerExpHistogramCountOrGroupOverPlan]
+// already uses for GROUP() — never a literal 0 (the drop shape) and never
+// each other's aggregate.
+func TestLower_ExpHistogram_CountOverTimeEmitsRowCount(t *testing.T) {
+	t.Parallel()
+
+	s := schema.DefaultOTelMetrics()
+	at := time.Date(2026, 1, 1, 0, 0, 1, 0, time.UTC)
+
+	for _, tc := range []struct {
+		query    string
+		wantSQL  string
+		unwanted string
+	}{
+		{query: `count_over_time(latency_exp_hist[5m])`, wantSQL: "count(", unwanted: "any(toFloat64("},
+		{query: `present_over_time(latency_exp_hist[5m])`, wantSQL: "any(toFloat64(", unwanted: "count("},
+	} {
+		t.Run(tc.query, func(t *testing.T) {
+			t.Parallel()
+			p := parser.NewParser(parser.Options{})
+			expr, err := p.ParseExpr(tc.query)
+			if err != nil {
+				t.Fatalf("ParseExpr: %v", err)
+			}
+			plan, err := promql.LowerAt(context.Background(), expr, s, at, at)
+			if err != nil {
+				t.Fatalf("LowerAt: %v", err)
+			}
+			sql, _, err := chsql.Emit(context.Background(), plan)
+			if err != nil {
+				t.Fatalf("Emit: %v", err)
+			}
+			if !strings.Contains(sql, tc.wantSQL) {
+				t.Errorf("SQL missing %q:\n%s", tc.wantSQL, sql)
+			}
+			if strings.Contains(sql, tc.unwanted) {
+				t.Errorf("SQL unexpectedly contains %q:\n%s", tc.unwanted, sql)
+			}
+			if strings.Contains(sql, "WHERE false") || strings.Contains(sql, "WHERE FALSE") {
+				t.Errorf("SQL applies the drop-to-empty shape, want a real windowed count:\n%s", sql)
+			}
+		})
+	}
+}

--- a/internal/promql/histogram_native_last_first_over_time.go
+++ b/internal/promql/histogram_native_last_first_over_time.go
@@ -1,0 +1,210 @@
+package promql
+
+import (
+	"github.com/prometheus/prometheus/promql/parser"
+
+	"github.com/tsouza/cerberus/internal/chplan"
+	"github.com/tsouza/cerberus/internal/schema"
+)
+
+// histogram_native_last_first_over_time.go lowers last_over_time() and
+// first_over_time() over an OTel exponential (native) histogram selector
+// into a HISTOGRAM-valued result (cerberus issue #2480).
+//
+// Reference Prometheus's funcLastOverTime / funcFirstOverTime
+// (tsouza/prometheus's promql/functions.go) read the window's raw H/F
+// Point directly and choose between them by timestamp:
+//
+//	if h.H == nil || (len(el.Floats) > 0 && h.T < f.T) {
+//	    return append(enh.Out, Sample{Metric: el.Metric, F: f.F}), nil
+//	}
+//	return append(enh.Out, Sample{Metric: el.Metric, H: h.H.Copy()}), nil
+//
+// Over a window holding EXCLUSIVELY histogram samples (h.H != nil, no
+// Floats), both functions therefore answer the selected histogram sample
+// itself — PRESERVED, not dropped, and with `Metric: el.Metric` keeping
+// `__name__` — the same "preserve, don't drop" class
+// [rangeFnPreservesName] already special-cases for the plain-float path
+// (last_over_time/first_over_time are its only two members). This file
+// gives the exp-histogram argument its own histogram-passthrough lowering:
+// last_over_time collapses each series' in-window rows to the NEWEST
+// sample (argMax by TimeUnix — the same "selected sample" collapse
+// [lowerExpHistogramBare] already uses for a bare selector, just widened
+// from the fixed staleness lookback to the matched `[range]`);
+// first_over_time collapses to the OLDEST (argMin by TimeUnix — the mirror
+// image, via [earliestArgMin]).
+//
+// The plan shape mirrors [lowerExpHistogramBare] rung for rung: same Scan,
+// same matcher predicate, same per-series collapse, same
+// [chplan.RangeBucketFanout] in range mode, same
+// [chplan.HistogramProjection] cap — differing only in the window width
+// (ms.Range instead of the fixed instantLookback) and, for first_over_time,
+// the selection direction.
+const (
+	lastOverTimeWindowFn  = "last_over_time"
+	firstOverTimeWindowFn = "first_over_time"
+)
+
+// lastFirstOverExpHistogram recognises `last_over_time(<selector>[r])` /
+// `first_over_time(<selector>[r])` where the selector names an
+// exp-histogram metric — the one shape this file answers. Mirrors
+// [countPresentOverExpHistogram]'s own recognizer shape rung for rung,
+// differing only in which two function names it admits.
+func lastFirstOverExpHistogram(expr parser.Expr, s schema.Metrics, ctx lowerCtx) (fn string, ms *parser.MatrixSelector, vs *parser.VectorSelector, ok bool) {
+	if s.ExpHistogramTable == "" || ctx.metadataFullRange {
+		return "", nil, nil, false
+	}
+	call, ok := peelWrappers(expr).(*parser.Call)
+	if !ok || (call.Func.Name != lastOverTimeWindowFn && call.Func.Name != firstOverTimeWindowFn) || len(call.Args) != 1 {
+		return "", nil, nil, false
+	}
+	ms, ok = peelWrappers(call.Args[0]).(*parser.MatrixSelector)
+	if !ok || ms.Range <= 0 {
+		return "", nil, nil, false
+	}
+	vs, ok = peelWrappers(ms.VectorSelector).(*parser.VectorSelector)
+	if !ok || !s.IsExpHistogramMetric(metricNameFromMatchers(vs.LabelMatchers)) {
+		return "", nil, nil, false
+	}
+	return call.Func.Name, ms, vs, true
+}
+
+// lowerLastFirstOverExpHistogram lowers the recognised shape across the
+// three evaluation grids [rangeGridShapeFor] distinguishes — see
+// [lowerExpHistogramBare] for what each means.
+func lowerLastFirstOverExpHistogram(fn string, ms *parser.MatrixSelector, vs *parser.VectorSelector, s schema.Metrics, ctx lowerCtx) (chplan.Node, error) {
+	switch rangeGridShapeFor(vs, ctx) {
+	case gridFanout:
+		return lowerExpHistogramLastFirstRange(fn, ms, vs, s, ctx), nil
+	case gridBroadcast:
+		selected, err := expHistogramLastFirstWindowed(fn, ms, vs, s, ctx)
+		if err != nil {
+			return nil, err
+		}
+		// Same broadcast placement as [lowerExpHistogramBare]'s own
+		// gridBroadcast arm: the cross join goes UNDER the histogram
+		// projection, so the pinned window is resolved ONCE and every
+		// step reports that one selected sample at its own timestamp.
+		grid := &chplan.StepGrid{Start: ctx.start.UTC(), End: ctx.end.UTC(), Step: ctx.step}
+		return nativeHistogramProjection(
+			&chplan.CrossJoin{Left: grid, Right: selected},
+			bareExpHistogramNameExpr(s),
+			&chplan.ColumnRef{Name: stepGridAnchorColumn},
+			s,
+		), nil
+	default:
+		selected, err := expHistogramLastFirstWindowed(fn, ms, vs, s, ctx)
+		if err != nil {
+			return nil, err
+		}
+		return nativeHistogramProjection(selected, bareExpHistogramNameExpr(s), chplan.NowNano(), s), nil
+	}
+}
+
+// expHistogramLastFirstWindowed builds the instant-mode subtree: the
+// selector's matcher-filtered scan bound to `(anchor - ms.Range, anchor]`
+// — the same window [expHistogramCountPresentWindowed] applies —
+// collapsed to one row per series via the direction-appropriate
+// argMax/argMin aggregate set.
+func expHistogramLastFirstWindowed(fn string, ms *parser.MatrixSelector, vs *parser.VectorSelector, s schema.Metrics, ctx lowerCtx) (chplan.Node, error) {
+	anchor, err := selectorAnchor(vs, ctx)
+	if err != nil {
+		return nil, err
+	}
+	pred := buildPredicate(vs.LabelMatchers, s)
+	pred = andExpr(pred, timeBoundExpr(s.TimestampColumn, anchor))
+	pred = andExpr(pred, stalenessLowerBoundExpr(s.TimestampColumn, anchor, ms.Range))
+	var input chplan.Node = &chplan.Scan{Table: s.ExpHistogramTable}
+	if pred != nil {
+		input = &chplan.Filter{Input: input, Predicate: pred}
+	}
+	return latestSampleAgg(input, nativeExpHistBareAggsDirectional(fn, s), s), nil
+}
+
+// lowerExpHistogramLastFirstRange is the query_range shape: one
+// `[ms.Range]` window per step anchor via [buildHistogramBucketFanout] —
+// reusing [windowFor] the same way [lowerExpHistogramBareRange] does for a
+// bare selector, just with ms.Range in place of the fixed staleness
+// lookback — capped with the histogram projection instead of a quantile
+// or a folded distribution.
+func lowerExpHistogramLastFirstRange(fn string, ms *parser.MatrixSelector, vs *parser.VectorSelector, s schema.Metrics, ctx lowerCtx) chplan.Node {
+	fanout := buildHistogramBucketFanout(
+		&chplan.Scan{Table: s.ExpHistogramTable},
+		buildPredicate(vs.LabelMatchers, s), nil,
+		windowFor(vs, ms.Range),
+		[]chplan.Expr{histogramIdentityExpr(s)}, []string{s.AttributesColumn},
+		nativeExpHistBareAggsDirectional(fn, s), s, ctx,
+	)
+	return nativeHistogramProjection(fanout, bareExpHistogramNameExpr(s), &chplan.ColumnRef{Name: stepGridAnchorColumn}, s)
+}
+
+// nativeExpHistBareAggsDirectional is [nativeExpHistBareAggs] generalised
+// by a selection direction: last_over_time wants the newest in-window
+// sample (argMax by TimeUnix — the exact aggregate set [nativeExpHistBareAggs]
+// already builds), first_over_time wants the oldest (argMin, via
+// [earliestArgMin]). Every field is picked at the SAME selected row —
+// keying every column's argMax/argMin off the identical TimeUnix order
+// column, exactly as [nativeExpHistBareAggs] already does for last —
+// which is what keeps the histogram's Scale / offsets / bucket arrays
+// mutually consistent rather than each column independently optimised.
+func nativeExpHistBareAggsDirectional(fn string, s schema.Metrics) []chplan.AggFunc {
+	if fn == firstOverTimeWindowFn {
+		return append(
+			[]chplan.AggFunc{earliestArgMin(s.MetricNameColumn, s)},
+			nativeExpHistValuedLatestAggsDirectional(firstOverTimeWindowFn, s)...,
+		)
+	}
+	return nativeExpHistBareAggs(s)
+}
+
+// nativeExpHistValuedLatestAggsDirectional is [nativeExpHistValuedLatestAggs]
+// generalised the same way [nativeExpHistBareAggsDirectional] generalises
+// its own caller — see that function's doc.
+func nativeExpHistValuedLatestAggsDirectional(fn string, s schema.Metrics) []chplan.AggFunc {
+	if fn != firstOverTimeWindowFn {
+		return nativeExpHistValuedLatestAggs(s)
+	}
+	return append(
+		[]chplan.AggFunc{
+			earliestArgMin(s.CountColumn, s),
+			earliestArgMin(s.SumColumn, s),
+		},
+		nativeExpHistLatestAggsDirectional(fn, s)...,
+	)
+}
+
+// nativeExpHistLatestAggsDirectional is [nativeExpHistLatestAggs]
+// generalised the same way [nativeExpHistBareAggsDirectional] generalises
+// its own caller — see that function's doc.
+func nativeExpHistLatestAggsDirectional(fn string, s schema.Metrics) []chplan.AggFunc {
+	if fn != firstOverTimeWindowFn {
+		return nativeExpHistLatestAggs(s)
+	}
+	aggs := []chplan.AggFunc{
+		earliestArgMin(s.ScaleColumn, s),
+		earliestArgMin(s.ZeroCountColumn, s),
+		earliestArgMin(s.PositiveOffsetColumn, s),
+		earliestArgMin(s.PositiveBucketCountsColumn, s),
+		earliestArgMin(s.NegativeOffsetColumn, s),
+		earliestArgMin(s.NegativeBucketCountsColumn, s),
+	}
+	if s.ZeroThresholdColumn != "" {
+		aggs = append(aggs, earliestArgMin(s.ZeroThresholdColumn, s))
+	}
+	return aggs
+}
+
+// earliestArgMin is `argMin(<col>, TimeUnix) AS <col>` — the
+// first_over_time counterpart of [latestArgMax]: same column, same order
+// key, opposite selection direction (the OLDEST row in the group instead
+// of the newest).
+func earliestArgMin(col string, s schema.Metrics) chplan.AggFunc {
+	return chplan.AggFunc{
+		Fn: chplan.FnArgMin,
+		Args: []chplan.Expr{
+			&chplan.ColumnRef{Name: col},
+			&chplan.ColumnRef{Name: s.TimestampColumn},
+		},
+		Alias: col,
+	}
+}

--- a/internal/promql/histogram_native_last_first_over_time_test.go
+++ b/internal/promql/histogram_native_last_first_over_time_test.go
@@ -1,0 +1,144 @@
+package promql_test
+
+import (
+	"context"
+	"slices"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/prometheus/prometheus/promql/parser"
+
+	"github.com/tsouza/cerberus/internal/chplan"
+	"github.com/tsouza/cerberus/internal/chsql"
+	"github.com/tsouza/cerberus/internal/promql"
+	"github.com/tsouza/cerberus/internal/schema"
+)
+
+// TestLower_ExpHistogram_LastFirstOverTimeIsHistogramValued pins cerberus
+// issue #2480: last_over_time() / first_over_time() over a bare
+// exp-histogram selector answer a HISTOGRAM-valued plan that PRESERVES
+// `__name__` — reference Prometheus's funcLastOverTime / funcFirstOverTime
+// read the window's raw H/F Point and, over an all-histogram window,
+// answer `Sample{Metric: el.Metric, H: h.H.Copy()}` — the source series'
+// own name and its selected histogram, never dropped and never emptied.
+func TestLower_ExpHistogram_LastFirstOverTimeIsHistogramValued(t *testing.T) {
+	t.Parallel()
+
+	s := schema.DefaultOTelMetrics()
+	start := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	end := start.Add(time.Hour)
+
+	for _, tc := range []struct {
+		name  string
+		query string
+		lower func(parser.Expr) (chplan.Node, error)
+	}{
+		{
+			name:  "instant last",
+			query: `last_over_time(latency_exp_hist[5m])`,
+			lower: func(e parser.Expr) (chplan.Node, error) {
+				return promql.LowerAt(context.Background(), e, s, end, end)
+			},
+		},
+		{
+			name:  "instant first",
+			query: `first_over_time(latency_exp_hist{service="api"}[5m])`,
+			lower: func(e parser.Expr) (chplan.Node, error) {
+				return promql.LowerAt(context.Background(), e, s, end, end)
+			},
+		},
+		{
+			name:  "last offset",
+			query: `last_over_time(latency_exp_hist[5m] offset 10m)`,
+			lower: func(e parser.Expr) (chplan.Node, error) {
+				return promql.LowerAt(context.Background(), e, s, end, end)
+			},
+		},
+		{
+			name:  "first range",
+			query: `first_over_time(latency_exp_hist[5m])`,
+			lower: func(e parser.Expr) (chplan.Node, error) {
+				return promql.LowerAtRange(context.Background(), e, s, start, end, time.Minute)
+			},
+		},
+		{
+			name:  "last range at pin",
+			query: `last_over_time(latency_exp_hist[5m] @ 1767225600)`,
+			lower: func(e parser.Expr) (chplan.Node, error) {
+				return promql.LowerAtRange(context.Background(), e, s, start, end, time.Minute)
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			expr := parseExprExp(t, tc.query)
+			plan, err := tc.lower(expr)
+			if err != nil {
+				t.Fatalf("lower(%q): %v", tc.query, err)
+			}
+			if shape := chplan.RowShapeOf(plan); shape != chplan.HistogramRowShape {
+				t.Fatalf("RowShapeOf(lower(%q)) = %s, want %s", tc.query, shape, chplan.HistogramRowShape)
+			}
+			hp, ok := plan.(*chplan.HistogramProjection)
+			if !ok {
+				t.Fatalf("lower(%q) root = %T, want *chplan.HistogramProjection", tc.query, plan)
+			}
+			wantAliases := []string{s.MetricNameColumn, s.AttributesColumn, s.TimestampColumn, s.ValueColumn}
+			if !slices.Equal(hp.GroupByAliases, wantAliases) {
+				t.Fatalf("lower(%q) leading aliases = %v, want %v", tc.query, hp.GroupByAliases, wantAliases)
+			}
+			// __name__ PRESERVED: the MetricName projection is a
+			// ColumnRef sourced from the selected row's own MetricName
+			// aggregate, NOT the empty-literal every derived (dropping)
+			// histogram consumer projects.
+			if _, isLit := hp.GroupBy[0].(*chplan.LitString); isLit {
+				t.Fatalf("lower(%q) name projection = %#v, want a preserved column reference, not an empty literal", tc.query, hp.GroupBy[0])
+			}
+			col, ok := hp.GroupBy[0].(*chplan.ColumnRef)
+			if !ok || col.Name != s.MetricNameColumn {
+				t.Fatalf("lower(%q) name projection = %#v, want ColumnRef{%s}", tc.query, hp.GroupBy[0], s.MetricNameColumn)
+			}
+		})
+	}
+}
+
+// TestLower_ExpHistogram_FirstOverTimeSelectsOldest pins the SELECTION
+// DIRECTION split: last_over_time must emit argMax(<col>, TimeUnix) (the
+// same aggregate a bare exp-histogram selector already uses) while
+// first_over_time must emit argMin(<col>, TimeUnix) — never the other
+// direction, and never both on the same column.
+func TestLower_ExpHistogram_FirstOverTimeSelectsOldest(t *testing.T) {
+	t.Parallel()
+
+	s := schema.DefaultOTelMetrics()
+	at := time.Date(2026, 1, 1, 0, 0, 1, 0, time.UTC)
+
+	for _, tc := range []struct {
+		query    string
+		want     string
+		unwanted string
+	}{
+		{query: `last_over_time(latency_exp_hist[5m])`, want: "argMax(", unwanted: "argMin("},
+		{query: `first_over_time(latency_exp_hist[5m])`, want: "argMin(", unwanted: ""},
+	} {
+		t.Run(tc.query, func(t *testing.T) {
+			t.Parallel()
+			expr := parseExprExp(t, tc.query)
+			plan, err := promql.LowerAt(context.Background(), expr, s, at, at)
+			if err != nil {
+				t.Fatalf("LowerAt: %v", err)
+			}
+			sql, _, err := chsql.Emit(context.Background(), plan)
+			if err != nil {
+				t.Fatalf("Emit: %v", err)
+			}
+			if !strings.Contains(sql, tc.want) {
+				t.Errorf("SQL missing %q:\n%s", tc.want, sql)
+			}
+			if tc.unwanted != "" && strings.Contains(sql, tc.unwanted) {
+				t.Errorf("SQL unexpectedly contains %q:\n%s", tc.unwanted, sql)
+			}
+		})
+	}
+}

--- a/internal/promql/lower.go
+++ b/internal/promql/lower.go
@@ -312,6 +312,23 @@ func lowerRoot(expr parser.Expr, s schema.Metrics, ctx lowerCtx) (chplan.Node, e
 	if shape, ok := resetsOrChangesOverExpHistogram(expr, s, ctx); ok {
 		return lowerExpHistogramResetsOrChanges(shape, s, ctx)
 	}
+	// count_over_time() / present_over_time() (cerberus issue #2480): the
+	// window-counting sibling of sum_over_time / avg_over_time just above
+	// — see histogram_native_count_present_over_time.go's own doc for why
+	// they need a windowed COUNT rather than either the drop treatment
+	// (rangeVectorFloatOnlyDropFuncs) or the fold treatment
+	// (overTimeOverExpHistogram) applies.
+	if fn, ms, vs, ok := countPresentOverExpHistogram(expr, s, ctx); ok {
+		return lowerCountPresentOverExpHistogram(fn, ms, vs, s, ctx)
+	}
+	// last_over_time() / first_over_time() (cerberus issue #2480): the
+	// histogram-PRESERVING sibling of count_over_time / present_over_time
+	// just above — see histogram_native_last_first_over_time.go's own doc
+	// for why reference selects (rather than drops or counts) the
+	// window's newest/oldest sample.
+	if fn, ms, vs, ok := lastFirstOverExpHistogram(expr, s, ctx); ok {
+		return lowerLastFirstOverExpHistogram(fn, ms, vs, s, ctx)
+	}
 	if agg, vs, ok := countOverExpHistogram(expr, s, ctx); ok {
 		return lowerExpHistogramCount(agg, vs, s, ctx)
 	}

--- a/internal/promql/range_fns.go
+++ b/internal/promql/range_fns.go
@@ -490,27 +490,37 @@ func matrixAndSelector(c *parser.Call, arg parser.Expr) (*parser.MatrixSelector,
 // varianceOverTime (stddev_over_time / stdvar_over_time, via
 // funcStddevOverTime / funcStdvarOverTime) both early-return `enh.Out, nil`
 // on `len(samples.Floats) == 0`. mad_over_time's funcMadOverTime does the
-// identical `len(samples.Floats) == 0` early return.
+// identical `len(samples.Floats) == 0` early return. compareOverTime
+// (min_over_time / max_over_time) does too — verified directly against
+// tsouza/prometheus's promql/functions.go (cerberus issue #2480): `if
+// len(samples.Floats) == 0 { return enh.Out, nil }` runs before it ever
+// looks at samples.Histograms, so an all-histogram window answers empty
+// exactly like the other five here.
 //
 // last_over_time / first_over_time are deliberately EXCLUDED: reference
 // Prometheus (funcLastOverTime / funcFirstOverTime) reads the window's
 // raw H/F Point directly and PRESERVES a histogram sample rather than
 // dropping it, so admitting them here would silently discard a value
-// Prom actually returns — they need their own histogram-passthrough
-// lowering, not this drop treatment. rate / increase / delta / irate /
-// idelta / changes / resets / sum_over_time / avg_over_time never reach
-// this generic path for a histogram selector at all: lowerRoot's earlier
-// histogram-valued recognisers (histogram_native_range_fn.go,
-// histogram_native_over_time.go, histogram_native_resets.go) claim those
-// shapes first. min_over_time / max_over_time / count_over_time /
-// present_over_time are left untouched — cerberus issue #2477 tracks
-// exactly the seven reducers enumerated here plus predict_linear /
-// holt_winters / quantile_over_time, not the full float-only surface.
+// Prom actually returns — they get their own histogram-passthrough
+// lowering in histogram_native_last_first_over_time.go instead. rate /
+// increase / delta / irate / idelta / changes / resets / sum_over_time /
+// avg_over_time never reach this generic path for a histogram selector at
+// all: lowerRoot's earlier histogram-valued recognisers
+// (histogram_native_range_fn.go, histogram_native_over_time.go,
+// histogram_native_resets.go) claim those shapes first. count_over_time /
+// present_over_time are ALSO excluded — reference's funcCountOverTime /
+// funcPresentOverTime (aggrOverTime) never guard on
+// `len(samples.Floats) == 0` at all, so an all-histogram window answers a
+// non-empty count / presence value, not empty; the DROP treatment here
+// would be wrong for them, so they get their own windowed-count lowering
+// in histogram_native_count_present_over_time.go (cerberus issue #2480).
 var rangeVectorFloatOnlyDropFuncs = map[string]bool{
 	"deriv":            true,
 	"mad_over_time":    true,
 	"stddev_over_time": true,
 	"stdvar_over_time": true,
+	"min_over_time":    true,
+	"max_over_time":    true,
 }
 
 // dropExpHistogramSamplesForRangeVector recognises a range-vector

--- a/internal/promql/range_vector_float_only_reducer_exp_histogram_test.go
+++ b/internal/promql/range_vector_float_only_reducer_exp_histogram_test.go
@@ -24,6 +24,17 @@ import (
 // selector fell through to expHistogramSelectorRouting's catch-all
 // rejection instead of Prom's drop-and-answer-empty semantics.
 //
+// min_over_time() / max_over_time() (compareOverTime) join the same drop
+// class here per cerberus issue #2480: `if len(samples.Floats) == 0 {
+// return enh.Out, nil }` runs before compareOverTime ever reads
+// samples.Histograms, so an all-histogram window answers empty exactly
+// like the other five. #2480's own filing verified this directly against
+// tsouza/prometheus's promql/functions.go rather than assuming it from
+// the shared aggrOverTime plumbing — count_over_time / present_over_time
+// use that same plumbing but do NOT guard on Floats, so they deliberately
+// get their own lowering (histogram_native_count_present_over_time.go)
+// instead of joining this list.
+//
 // mad_over_time / double_exponential_smoothing / holt_winters are
 // experimental functions in the reference parser, so every query here
 // parses through [parseExprExp] (defined in sort_by_label_test.go) rather
@@ -50,6 +61,8 @@ func TestLower_ExpHistogram_FloatOnlyRangeVectorReducersDropSamples(t *testing.T
 		`quantile_over_time(0.5, latency_exp_hist[5m])`,
 		`stddev_over_time(latency_exp_hist[5m])`,
 		`stdvar_over_time(latency_exp_hist[5m])`,
+		`min_over_time(latency_exp_hist[5m])`,
+		`max_over_time(latency_exp_hist[5m])`,
 
 		// A computed (non-literal) parameter must not bypass the check:
 		// the drop happens before the parameter is even resolved.
@@ -98,6 +111,8 @@ func TestLower_ExpHistogram_FloatOnlyRangeVectorReducersRangeMode(t *testing.T) 
 		`quantile_over_time(0.5, latency_exp_hist[5m])`,
 		`stddev_over_time(latency_exp_hist[5m])`,
 		`stdvar_over_time(latency_exp_hist[5m])`,
+		`min_over_time(latency_exp_hist[5m])`,
+		`max_over_time(latency_exp_hist[5m])`,
 	}
 
 	for _, query := range queries {

--- a/test/perf/cardinality-baseline/promql/count_over_time_exp_histogram.json
+++ b/test/perf/cardinality-baseline/promql/count_over_time_exp_histogram.json
@@ -1,0 +1,11 @@
+{
+  "fixture": "promql/count_over_time_exp_histogram",
+  "fan_factor": 1,
+  "scan_rows": 1,
+  "peak_intermediate": 1,
+  "has_cross_join": false,
+  "has_array_join": false,
+  "has_recursive_cte": false,
+  "max_recursion_depth": 0,
+  "uncountable_levels": 0
+}

--- a/test/perf/cardinality-baseline/promql/last_over_time_exp_histogram_preserves.json
+++ b/test/perf/cardinality-baseline/promql/last_over_time_exp_histogram_preserves.json
@@ -1,0 +1,11 @@
+{
+  "fixture": "promql/last_over_time_exp_histogram_preserves",
+  "fan_factor": 1,
+  "scan_rows": 1,
+  "peak_intermediate": 1,
+  "has_cross_join": false,
+  "has_array_join": false,
+  "has_recursive_cte": false,
+  "max_recursion_depth": 0,
+  "uncountable_levels": 0
+}

--- a/test/perf/cardinality-baseline/promql/min_over_time_exp_histogram_drops.json
+++ b/test/perf/cardinality-baseline/promql/min_over_time_exp_histogram_drops.json
@@ -1,0 +1,11 @@
+{
+  "fixture": "promql/min_over_time_exp_histogram_drops",
+  "fan_factor": 1,
+  "scan_rows": 1,
+  "peak_intermediate": 1,
+  "has_cross_join": false,
+  "has_array_join": false,
+  "has_recursive_cte": false,
+  "max_recursion_depth": 0,
+  "uncountable_levels": 0
+}

--- a/test/perf/cardinality-baseline/promql/present_over_time_exp_histogram.json
+++ b/test/perf/cardinality-baseline/promql/present_over_time_exp_histogram.json
@@ -1,0 +1,11 @@
+{
+  "fixture": "promql/present_over_time_exp_histogram",
+  "fan_factor": 1,
+  "scan_rows": 1,
+  "peak_intermediate": 1,
+  "has_cross_join": false,
+  "has_array_join": false,
+  "has_recursive_cte": false,
+  "max_recursion_depth": 0,
+  "uncountable_levels": 0
+}

--- a/test/perf/solver-decision-baseline/count_over_time_exp_histogram/fanout.json
+++ b/test/perf/solver-decision-baseline/count_over_time_exp_histogram/fanout.json
@@ -1,0 +1,11 @@
+{
+  "query": "count_over_time_exp_histogram/fanout",
+  "lowering": "fanout",
+  "routed": true,
+  "k": 8,
+  "reason": "routed",
+  "n_anchors": 241,
+  "fanout": 20,
+  "cumulative_d": "5m0s",
+  "outer_range": "1h0m0s"
+}

--- a/test/perf/solver-decision-baseline/count_over_time_exp_histogram/native.json
+++ b/test/perf/solver-decision-baseline/count_over_time_exp_histogram/native.json
@@ -1,0 +1,11 @@
+{
+  "query": "count_over_time_exp_histogram/native",
+  "lowering": "native",
+  "routed": true,
+  "k": 8,
+  "reason": "routed",
+  "n_anchors": 241,
+  "fanout": 20,
+  "cumulative_d": "5m0s",
+  "outer_range": "1h0m0s"
+}

--- a/test/perf/solver-decision-baseline/last_over_time_exp_histogram_preserves/fanout.json
+++ b/test/perf/solver-decision-baseline/last_over_time_exp_histogram_preserves/fanout.json
@@ -1,0 +1,11 @@
+{
+  "query": "last_over_time_exp_histogram_preserves/fanout",
+  "lowering": "fanout",
+  "routed": false,
+  "k": 0,
+  "reason": "not-sliceable",
+  "n_anchors": 241,
+  "fanout": 20,
+  "cumulative_d": "5m0s",
+  "outer_range": "1h0m0s"
+}

--- a/test/perf/solver-decision-baseline/last_over_time_exp_histogram_preserves/native.json
+++ b/test/perf/solver-decision-baseline/last_over_time_exp_histogram_preserves/native.json
@@ -1,0 +1,11 @@
+{
+  "query": "last_over_time_exp_histogram_preserves/native",
+  "lowering": "native",
+  "routed": false,
+  "k": 0,
+  "reason": "not-sliceable",
+  "n_anchors": 241,
+  "fanout": 20,
+  "cumulative_d": "5m0s",
+  "outer_range": "1h0m0s"
+}

--- a/test/perf/solver-decision-baseline/min_over_time_exp_histogram_drops/fanout.json
+++ b/test/perf/solver-decision-baseline/min_over_time_exp_histogram_drops/fanout.json
@@ -1,0 +1,11 @@
+{
+  "query": "min_over_time_exp_histogram_drops/fanout",
+  "lowering": "fanout",
+  "routed": false,
+  "k": 0,
+  "reason": "not-sliceable",
+  "n_anchors": 241,
+  "fanout": 20,
+  "cumulative_d": "5m0s",
+  "outer_range": "1h0m0s"
+}

--- a/test/perf/solver-decision-baseline/min_over_time_exp_histogram_drops/native.json
+++ b/test/perf/solver-decision-baseline/min_over_time_exp_histogram_drops/native.json
@@ -1,0 +1,11 @@
+{
+  "query": "min_over_time_exp_histogram_drops/native",
+  "lowering": "native",
+  "routed": false,
+  "k": 0,
+  "reason": "not-sliceable",
+  "n_anchors": 241,
+  "fanout": 20,
+  "cumulative_d": "5m0s",
+  "outer_range": "1h0m0s"
+}

--- a/test/perf/solver-decision-baseline/present_over_time_exp_histogram/fanout.json
+++ b/test/perf/solver-decision-baseline/present_over_time_exp_histogram/fanout.json
@@ -1,0 +1,11 @@
+{
+  "query": "present_over_time_exp_histogram/fanout",
+  "lowering": "fanout",
+  "routed": true,
+  "k": 8,
+  "reason": "routed",
+  "n_anchors": 241,
+  "fanout": 20,
+  "cumulative_d": "5m0s",
+  "outer_range": "1h0m0s"
+}

--- a/test/perf/solver-decision-baseline/present_over_time_exp_histogram/native.json
+++ b/test/perf/solver-decision-baseline/present_over_time_exp_histogram/native.json
@@ -1,0 +1,11 @@
+{
+  "query": "present_over_time_exp_histogram/native",
+  "lowering": "native",
+  "routed": true,
+  "k": 8,
+  "reason": "routed",
+  "n_anchors": 241,
+  "fanout": 20,
+  "cumulative_d": "5m0s",
+  "outer_range": "1h0m0s"
+}

--- a/test/regression/parity-enrolment-baselines/promql/baseline.txt
+++ b/test/regression/parity-enrolment-baselines/promql/baseline.txt
@@ -69,6 +69,7 @@ clamp_scalar_min_literal_max.txtar
 comparison_arithmetic.txtar
 count_agg_returns_float.txtar
 count_no_group.txtar
+count_over_time_exp_histogram.txtar
 count_values_basic.txtar
 count_values_without.txtar
 count_values_without_empty.txtar
@@ -359,6 +360,7 @@ label_replace_probed_shared_capture_name.txtar
 label_replace_regex_capture.txtar
 label_replace_shared_capture_name.txtar
 label_replace_truncated_shared_capture_name.txtar
+last_over_time_exp_histogram_preserves.txtar
 last_over_time_regex_name.txtar
 limit_ratio_complement.txtar
 limit_ratio_half.txtar
@@ -390,6 +392,7 @@ matcher_and_agg_by_service_name.txtar
 matcher_dotted_source.txtar
 matcher_service_name.txtar
 matrix_selector_top_level.txtar
+min_over_time_exp_histogram_drops.txtar
 minute_default.txtar
 minute_of_vector.txtar
 mod_arithmetic.txtar
@@ -433,6 +436,7 @@ predict_linear_exp_histogram_drops.txtar
 predict_linear_scalar_horizon.txtar
 predict_linear_simple.txtar
 predict_linear_subscrape_drops.txtar
+present_over_time_exp_histogram.txtar
 present_over_time_with_data.txtar
 quantile_by_job.txtar
 quantile_over_time_p95.txtar

--- a/test/rejection-parity/catalogue/internal__promql__lower.go.json
+++ b/test/rejection-parity/catalogue/internal__promql__lower.go.json
@@ -272,7 +272,7 @@
       "site": "internal/promql/lower.go:lowerRoot#53e0f9b3",
       "message": "promql: internal invariant violated: count_values input is not histogram-valued: %v",
       "class": "internal",
-      "rationale": "countValuesOverExpHistogramValue already ran isExpHistogramValuedShape to decide ok=true, so the immediately following lowerExpHistogramValuedShape call on the same agg.Expr cannot come back unmatched. The mixedExpHistogramSetOp guard checked earlier in lowerRoot's chain (cerberus issue #2330) only recognises a VectorSetOp BinaryExpr with exactly one histogram-valued operand — a shape count_values's AggregateExpr is not — so it cannot intercept a query before it reaches this branch, and does not affect this claim. sumOrAvgOverMixedExpHistogramSetOp (cerberus issue #2346), checked immediately after it, only recognises an AggregateExpr whose Op expHistogramAggOpIsMergeable confirms is SUM or AVG — count_values's Op is COUNT_VALUES — so it cannot intercept this shape either. labelCallOverMixedExpHistogramSetOp (cerberus issue #2449), checked immediately after that, only recognises a *parser.Call named label_replace/label_join — count_values's AggregateExpr is neither — so it cannot intercept this shape either. mathFnOverMixedExpHistogramSetOp (cerberus issue #2449), checked immediately after that, type-asserts peelWrappers(expr) as a *parser.Call before doing anything else — count_values's top-level expr is an *parser.AggregateExpr, which peelWrappers (ParenExpr/StepInvariantExpr only) never turns into a Call — so it cannot intercept this shape either.",
+      "rationale": "countValuesOverExpHistogramValue already ran isExpHistogramValuedShape to decide ok=true, so the immediately following lowerExpHistogramValuedShape call on the same agg.Expr cannot come back unmatched. The mixedExpHistogramSetOp guard checked earlier in lowerRoot's chain (cerberus issue #2330) only recognises a VectorSetOp BinaryExpr with exactly one histogram-valued operand — a shape count_values's AggregateExpr is not — so it cannot intercept a query before it reaches this branch, and does not affect this claim. sumOrAvgOverMixedExpHistogramSetOp (cerberus issue #2346), checked immediately after it, only recognises an AggregateExpr whose Op expHistogramAggOpIsMergeable confirms is SUM or AVG — count_values's Op is COUNT_VALUES — so it cannot intercept this shape either. labelCallOverMixedExpHistogramSetOp (cerberus issue #2449), checked immediately after that, only recognises a *parser.Call named label_replace/label_join — count_values's AggregateExpr is neither — so it cannot intercept this shape either. mathFnOverMixedExpHistogramSetOp (cerberus issue #2449), checked immediately after that, type-asserts peelWrappers(expr) as a *parser.Call before doing anything else — count_values's top-level expr is an *parser.AggregateExpr, which peelWrappers (ParenExpr/StepInvariantExpr only) never turns into a Call — so it cannot intercept this shape either. countPresentOverExpHistogram and lastFirstOverExpHistogram (cerberus issue #2480), checked immediately after that, each type-assert peelWrappers(expr) as a *parser.Call named count_over_time/present_over_time or last_over_time/first_over_time before doing anything else — count_values's top-level expr is an *parser.AggregateExpr, which peelWrappers never turns into a Call, so neither can intercept this shape either.",
       "evidence": {
         "guard": [
           "past returning if call, ok := labelReplaceOverExpHistogram(expr, s, ctx); ok",
@@ -283,6 +283,8 @@
           "past returning if call, b, chFn, ok := mathFnOverMixedExpHistogramSetOp(expr, s, ctx); ok",
           "past returning if shape, ok := overTimeOverExpHistogram(expr, s, ctx); ok",
           "past returning if shape, ok := resetsOrChangesOverExpHistogram(expr, s, ctx); ok",
+          "past returning if fn, ms, vs, ok := countPresentOverExpHistogram(expr, s, ctx); ok",
+          "past returning if fn, ms, vs, ok := lastFirstOverExpHistogram(expr, s, ctx); ok",
           "past returning if agg, vs, ok := countOverExpHistogram(expr, s, ctx); ok",
           "past returning if agg, ok := countOrGroupOverExpHistogramValue(expr, s, ctx); ok",
           "if agg, ok := countValuesOverExpHistogramValue(expr, s, ctx); ok",
@@ -294,10 +296,12 @@
           "LowerAtRangeOpts"
         ],
         "cited": [
+          "countPresentOverExpHistogram",
           "countValuesOverExpHistogramValue",
           "expHistogramAggOpIsMergeable",
           "isExpHistogramValuedShape",
           "labelCallOverMixedExpHistogramSetOp",
+          "lastFirstOverExpHistogram",
           "lowerExpHistogramValuedShape",
           "lowerRoot",
           "mathFnOverMixedExpHistogramSetOp",
@@ -312,7 +316,7 @@
       "site": "internal/promql/lower.go:lowerRoot#c7dbd629",
       "message": "promql: internal invariant violated: count/group input is not histogram-valued: %v",
       "class": "internal",
-      "rationale": "countOrGroupOverExpHistogramValue already ran isExpHistogramValuedShape to decide ok=true, so the immediately following lowerExpHistogramValuedShape call on the same agg.Expr cannot come back unmatched. The mixedExpHistogramSetOp guard checked earlier in lowerRoot's chain (cerberus issue #2330) only recognises a VectorSetOp BinaryExpr with exactly one histogram-valued operand — a shape count/group's AggregateExpr is not — so it cannot intercept a query before it reaches this branch, and does not affect this claim. sumOrAvgOverMixedExpHistogramSetOp (cerberus issue #2346), checked immediately after it, only recognises an AggregateExpr whose Op expHistogramAggOpIsMergeable confirms is SUM or AVG — count/group's Op is COUNT or GROUP — so it cannot intercept this shape either. labelCallOverMixedExpHistogramSetOp (cerberus issue #2449), checked immediately after that, only recognises a *parser.Call named label_replace/label_join — count/group's AggregateExpr is neither — so it cannot intercept this shape either. mathFnOverMixedExpHistogramSetOp (cerberus issue #2449), checked immediately after that, type-asserts peelWrappers(expr) as a *parser.Call before doing anything else — count/group's top-level expr is an *parser.AggregateExpr, which peelWrappers (ParenExpr/StepInvariantExpr only) never turns into a Call — so it cannot intercept this shape either.",
+      "rationale": "countOrGroupOverExpHistogramValue already ran isExpHistogramValuedShape to decide ok=true, so the immediately following lowerExpHistogramValuedShape call on the same agg.Expr cannot come back unmatched. The mixedExpHistogramSetOp guard checked earlier in lowerRoot's chain (cerberus issue #2330) only recognises a VectorSetOp BinaryExpr with exactly one histogram-valued operand — a shape count/group's AggregateExpr is not — so it cannot intercept a query before it reaches this branch, and does not affect this claim. sumOrAvgOverMixedExpHistogramSetOp (cerberus issue #2346), checked immediately after it, only recognises an AggregateExpr whose Op expHistogramAggOpIsMergeable confirms is SUM or AVG — count/group's Op is COUNT or GROUP — so it cannot intercept this shape either. labelCallOverMixedExpHistogramSetOp (cerberus issue #2449), checked immediately after that, only recognises a *parser.Call named label_replace/label_join — count/group's AggregateExpr is neither — so it cannot intercept this shape either. mathFnOverMixedExpHistogramSetOp (cerberus issue #2449), checked immediately after that, type-asserts peelWrappers(expr) as a *parser.Call before doing anything else — count/group's top-level expr is an *parser.AggregateExpr, which peelWrappers (ParenExpr/StepInvariantExpr only) never turns into a Call — so it cannot intercept this shape either. countPresentOverExpHistogram and lastFirstOverExpHistogram (cerberus issue #2480), checked immediately after that, each type-assert peelWrappers(expr) as a *parser.Call named count_over_time/present_over_time or last_over_time/first_over_time before doing anything else — count/group's top-level expr is an *parser.AggregateExpr, which peelWrappers never turns into a Call, so neither can intercept this shape either.",
       "evidence": {
         "guard": [
           "past returning if call, ok := labelReplaceOverExpHistogram(expr, s, ctx); ok",
@@ -323,6 +327,8 @@
           "past returning if call, b, chFn, ok := mathFnOverMixedExpHistogramSetOp(expr, s, ctx); ok",
           "past returning if shape, ok := overTimeOverExpHistogram(expr, s, ctx); ok",
           "past returning if shape, ok := resetsOrChangesOverExpHistogram(expr, s, ctx); ok",
+          "past returning if fn, ms, vs, ok := countPresentOverExpHistogram(expr, s, ctx); ok",
+          "past returning if fn, ms, vs, ok := lastFirstOverExpHistogram(expr, s, ctx); ok",
           "past returning if agg, vs, ok := countOverExpHistogram(expr, s, ctx); ok",
           "if agg, ok := countOrGroupOverExpHistogramValue(expr, s, ctx); ok",
           "past returning if err != nil",
@@ -334,9 +340,11 @@
         ],
         "cited": [
           "countOrGroupOverExpHistogramValue",
+          "countPresentOverExpHistogram",
           "expHistogramAggOpIsMergeable",
           "isExpHistogramValuedShape",
           "labelCallOverMixedExpHistogramSetOp",
+          "lastFirstOverExpHistogram",
           "lowerExpHistogramValuedShape",
           "lowerRoot",
           "mathFnOverMixedExpHistogramSetOp",

--- a/test/rejection-parity/catalogue/internal__promql__lower.go.json
+++ b/test/rejection-parity/catalogue/internal__promql__lower.go.json
@@ -94,8 +94,8 @@
       "site": "internal/promql/lower.go:expHistogramSelectorRouting#bf746b59",
       "message": "promql: %q is an exponential histogram metric; only a bare %q selector, sum()/avg()/count() over one, rate()/increase()/delta()/irate()/idelta()/sum_over_time()/avg_over_time()/resets()/changes() over one, histogram_quantile(), histogram_count(), histogram_sum(), and the %q/%q companion selectors are supported",
       "class": "divergence",
-      "trigger_query": "min_over_time(demo_latency_exp_hist[5m])",
-      "tracking_issue": 2480,
+      "trigger_query": "ts_of_first_over_time(demo_latency_exp_hist[5m])",
+      "tracking_issue": 2482,
       "evidence": {
         "guard": [
           "past returning if bare, col, hasCompanion := s.HistogramCompanionColumn(metricName); hasCompanion \u0026\u0026 s.IsExpHistogramMetric(bare) \u0026\u0026 s.ExpHistogramTable != \"\"",

--- a/test/spec/promql/count_over_time_exp_histogram.txtar
+++ b/test/spec/promql/count_over_time_exp_histogram.txtar
@@ -1,0 +1,34 @@
+# count_over_time() over a bare exp-histogram selector whose window holds
+# ONLY histogram samples (cerberus issue #2480). Reference Prometheus's
+# funcCountOverTime (via the shared aggrOverTime helper) never guards on
+# `len(samples.Floats) == 0` — it answers `len(s.Floats) + len(s.Histograms)`
+# unconditionally, so an all-histogram window answers a NON-EMPTY count,
+# unlike min_over_time / max_over_time's drop-to-empty semantics. Before
+# this fix cerberus hard-rejected this shape at expHistogramSelectorRouting
+# instead of lowering it at all; lowerCountPresentOverExpHistogram now
+# answers the actual in-window row count via a windowed count() aggregate.
+
+-- query.promql --
+count_over_time(demo_latency_exp_hist[5m])
+-- parity --
+oracle: prometheus
+endpoint: /api/v1/query
+scope: full
+-- seed --
+CREATE TABLE otel_metrics_exponential_histogram (
+    MetricName String,
+    Attributes Map(String, String),
+    TimeUnix DateTime64(9),
+    Count UInt64,
+    Sum Float64,
+    Scale Int32,
+    ZeroCount UInt64,
+    PositiveOffset Int32,
+    PositiveBucketCounts Array(UInt64),
+    NegativeOffset Int32,
+    NegativeBucketCounts Array(UInt64)
+) ENGINE = MergeTree ORDER BY (MetricName, Attributes, TimeUnix);
+INSERT INTO otel_metrics_exponential_histogram VALUES
+    ('demo_latency_exp_hist', map('service', 'api'), toDateTime64('2026-01-01 00:00:00', 9), 6, 42.5, 0, 0, 0, [1, 2, 3], 0, []);
+-- expected_rows --
+[]

--- a/test/spec/promql/count_over_time_exp_histogram.txtar
+++ b/test/spec/promql/count_over_time_exp_histogram.txtar
@@ -31,4 +31,42 @@ CREATE TABLE otel_metrics_exponential_histogram (
 INSERT INTO otel_metrics_exponential_histogram VALUES
     ('demo_latency_exp_hist', map('service', 'api'), toDateTime64('2026-01-01 00:00:00', 9), 6, 42.5, 0, 0, 0, [1, 2, 3], 0, []);
 -- expected_rows --
-[]
+[
+  ["", {"service": "api"}, "2026-01-01T00:00:01Z", 1]
+]
+-- args --
+[0] string = ""
+[1] int64 = 9
+[2] string = "service_name"
+[3] string = "service.name"
+[4] string = "service_name"
+[5] string = "service.name"
+[6] string = "service_name"
+[7] string = ""
+[8] string = "service_name"
+[9] string = "demo_latency_exp_hist"
+[10] string = "demo.latency.exp.hist"
+[11] string = "demo.latency.exp/hist"
+[12] string = "demo.latency.exp_hist"
+[13] string = "demo.latency/exp/hist"
+[14] string = "demo.latency/exp_hist"
+[15] string = "demo.latency_exp.hist"
+[16] string = "demo.latency_exp_hist"
+[17] string = "demo/latency/exp/hist"
+[18] string = "demo/latency/exp_hist"
+[19] string = "demo/latency_exp_hist"
+[20] string = "demo_latency.exp.hist"
+[21] string = "demo_latency.exp_hist"
+[22] string = "demo_latency_exp.hist"
+[23] string = "2026-01-01 00:00:01.000000000"
+[24] int64 = 9
+[25] string = "2026-01-01 00:00:01.000000000"
+[26] int64 = 9
+[27] int64 = 300000000000
+-- chplan --
+Project ["" AS MetricName, Attributes AS Attributes, FnNow64(9) AS TimeUnix, Value AS Value]
+  Aggregate groupBy=[FnMapSort(FnMapMerge(FnMapFilter((k, v) -> (k NOT IN ("service_name")), FnMapUpdate(FnMapFromArrays(FnArrayMap(k -> FnRegexReplaceAll(k, "[^a-zA-Z0-9_]", "_"), FnMapKeys(FnMapFilter((k, v) -> (k NOT IN ("service.name", "service_name")), ResourceAttributes))), FnMapValues(FnMapFilter((k, v) -> (k NOT IN ("service.name", "service_name")), ResourceAttributes))), FnMapFromArrays(FnArrayMap(k -> FnRegexReplaceAll(k, "[^a-zA-Z0-9_]", "_"), FnMapKeys(Attributes)), FnMapValues(Attributes)))), FnMapFilter((k, v) -> (v != ""), FnMap("service_name", FnToString(ServiceName))))) AS Attributes] funcs=[FnCount() AS Value]
+    Filter predicate=(((MetricName IN ("demo_latency_exp_hist", "demo.latency.exp.hist", "demo.latency.exp/hist", "demo.latency.exp_hist", "demo.latency/exp/hist", "demo.latency/exp_hist", "demo.latency_exp.hist", "demo.latency_exp_hist", "demo/latency/exp/hist", "demo/latency/exp_hist", "demo/latency_exp_hist", "demo_latency.exp.hist", "demo_latency.exp_hist", "demo_latency_exp.hist")) AND (TimeUnix <= FnToDateTime64("2026-01-01 00:00:01.000000000", 9))) AND (TimeUnix > (FnToDateTime64("2026-01-01 00:00:01.000000000", 9) - FnToIntervalNanosecond(300000000000))))
+      Scan(otel_metrics_exponential_histogram)
+-- sql --
+SELECT ? AS `MetricName`, `Attributes` AS `Attributes`, now64(?) AS `TimeUnix`, `Value` AS `Value` FROM (SELECT mapSort(mapConcat(mapFilter((k, v) -> (k NOT IN (?)), mapUpdate(mapFromArrays(arrayMap(k -> replaceRegexpAll(k, '[^a-zA-Z0-9_]', '_'), mapKeys(mapFilter((k, v) -> (k NOT IN (?, ?)), `ResourceAttributes`))), mapValues(mapFilter((k, v) -> (k NOT IN (?, ?)), `ResourceAttributes`))), mapFromArrays(arrayMap(k -> replaceRegexpAll(k, '[^a-zA-Z0-9_]', '_'), mapKeys(`Attributes`)), mapValues(`Attributes`)))), mapFilter((k, v) -> (v != ?), map(?, toString(`ServiceName`))))) AS `Attributes`, toFloat64(count()) AS `Value` FROM (SELECT * FROM `otel_metrics_exponential_histogram` PREWHERE (`MetricName` IN (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)) WHERE (`TimeUnix` <= toDateTime64(?, ?)) AND (`TimeUnix` > (toDateTime64(?, ?) - toIntervalNanosecond(?)))) GROUP BY `Attributes`)

--- a/test/spec/promql/last_over_time_exp_histogram_preserves.txtar
+++ b/test/spec/promql/last_over_time_exp_histogram_preserves.txtar
@@ -35,4 +35,42 @@ CREATE TABLE otel_metrics_exponential_histogram (
 INSERT INTO otel_metrics_exponential_histogram VALUES
     ('demo_latency_exp_hist', map('service', 'api'), toDateTime64('2026-01-01 00:00:00', 9), 6, 42.5, 0, 0, 0, [1, 2, 3], 0, []);
 -- expected_rows --
-[]
+[
+  ["demo_latency_exp_hist", {"service": "api"}, "2026-01-01T00:00:01Z", 0, 6, 42.5, 0, 0, 0, 0, [1,2,3], 0, []]
+]
+-- args --
+[0] int64 = 9
+[1] float64 = 0
+[2] string = "service_name"
+[3] string = "service.name"
+[4] string = "service_name"
+[5] string = "service.name"
+[6] string = "service_name"
+[7] string = ""
+[8] string = "service_name"
+[9] string = "demo_latency_exp_hist"
+[10] string = "demo.latency.exp.hist"
+[11] string = "demo.latency.exp/hist"
+[12] string = "demo.latency.exp_hist"
+[13] string = "demo.latency/exp/hist"
+[14] string = "demo.latency/exp_hist"
+[15] string = "demo.latency_exp.hist"
+[16] string = "demo.latency_exp_hist"
+[17] string = "demo/latency/exp/hist"
+[18] string = "demo/latency/exp_hist"
+[19] string = "demo/latency_exp_hist"
+[20] string = "demo_latency.exp.hist"
+[21] string = "demo_latency.exp_hist"
+[22] string = "demo_latency_exp.hist"
+[23] string = "2026-01-01 00:00:01.000000000"
+[24] int64 = 9
+[25] string = "2026-01-01 00:00:01.000000000"
+[26] int64 = 9
+[27] int64 = 300000000000
+-- chplan --
+HistogramProjection project=[MetricName AS MetricName, Attributes AS Attributes, FnNow64(9) AS TimeUnix, 0 AS Value]
+  Aggregate groupBy=[FnMapSort(FnMapMerge(FnMapFilter((k, v) -> (k NOT IN ("service_name")), FnMapUpdate(FnMapFromArrays(FnArrayMap(k -> FnRegexReplaceAll(k, "[^a-zA-Z0-9_]", "_"), FnMapKeys(FnMapFilter((k, v) -> (k NOT IN ("service.name", "service_name")), ResourceAttributes))), FnMapValues(FnMapFilter((k, v) -> (k NOT IN ("service.name", "service_name")), ResourceAttributes))), FnMapFromArrays(FnArrayMap(k -> FnRegexReplaceAll(k, "[^a-zA-Z0-9_]", "_"), FnMapKeys(Attributes)), FnMapValues(Attributes)))), FnMapFilter((k, v) -> (v != ""), FnMap("service_name", FnToString(ServiceName))))) AS Attributes] funcs=[FnArgMax(MetricName, TimeUnix) AS MetricName, FnArgMax(Count, TimeUnix) AS Count, FnArgMax(Sum, TimeUnix) AS Sum, FnArgMax(Scale, TimeUnix) AS Scale, FnArgMax(ZeroCount, TimeUnix) AS ZeroCount, FnArgMax(PositiveOffset, TimeUnix) AS PositiveOffset, FnArgMax(PositiveBucketCounts, TimeUnix) AS PositiveBucketCounts, FnArgMax(NegativeOffset, TimeUnix) AS NegativeOffset, FnArgMax(NegativeBucketCounts, TimeUnix) AS NegativeBucketCounts]
+    Filter predicate=(((MetricName IN ("demo_latency_exp_hist", "demo.latency.exp.hist", "demo.latency.exp/hist", "demo.latency.exp_hist", "demo.latency/exp/hist", "demo.latency/exp_hist", "demo.latency_exp.hist", "demo.latency_exp_hist", "demo/latency/exp/hist", "demo/latency/exp_hist", "demo/latency_exp_hist", "demo_latency.exp.hist", "demo_latency.exp_hist", "demo_latency_exp.hist")) AND (TimeUnix <= FnToDateTime64("2026-01-01 00:00:01.000000000", 9))) AND (TimeUnix > (FnToDateTime64("2026-01-01 00:00:01.000000000", 9) - FnToIntervalNanosecond(300000000000))))
+      Scan(otel_metrics_exponential_histogram)
+-- sql --
+SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, now64(?) AS `TimeUnix`, toFloat64(?) AS `Value`, toFloat64(`Count`) AS `HistogramCount`, toFloat64(`Sum`) AS `HistogramSum`, toInt32(`Scale`) AS `HistogramScale`, toFloat64(0.) AS `HistogramZeroThreshold`, toFloat64(`ZeroCount`) AS `HistogramZeroCount`, toInt32(`PositiveOffset`) AS `HistogramPositiveOffset`, arrayMap(x -> toFloat64(x), `PositiveBucketCounts`) AS `HistogramPositiveBucketCounts`, toInt32(`NegativeOffset`) AS `HistogramNegativeOffset`, arrayMap(x -> toFloat64(x), `NegativeBucketCounts`) AS `HistogramNegativeBucketCounts` FROM (SELECT mapSort(mapConcat(mapFilter((k, v) -> (k NOT IN (?)), mapUpdate(mapFromArrays(arrayMap(k -> replaceRegexpAll(k, '[^a-zA-Z0-9_]', '_'), mapKeys(mapFilter((k, v) -> (k NOT IN (?, ?)), `ResourceAttributes`))), mapValues(mapFilter((k, v) -> (k NOT IN (?, ?)), `ResourceAttributes`))), mapFromArrays(arrayMap(k -> replaceRegexpAll(k, '[^a-zA-Z0-9_]', '_'), mapKeys(`Attributes`)), mapValues(`Attributes`)))), mapFilter((k, v) -> (v != ?), map(?, toString(`ServiceName`))))) AS `Attributes`, argMax(`MetricName`, `TimeUnix`) AS `MetricName`, argMax(`Count`, `TimeUnix`) AS `Count`, argMax(`Sum`, `TimeUnix`) AS `Sum`, argMax(`Scale`, `TimeUnix`) AS `Scale`, argMax(`ZeroCount`, `TimeUnix`) AS `ZeroCount`, argMax(`PositiveOffset`, `TimeUnix`) AS `PositiveOffset`, argMax(`PositiveBucketCounts`, `TimeUnix`) AS `PositiveBucketCounts`, argMax(`NegativeOffset`, `TimeUnix`) AS `NegativeOffset`, argMax(`NegativeBucketCounts`, `TimeUnix`) AS `NegativeBucketCounts` FROM (SELECT * FROM `otel_metrics_exponential_histogram` PREWHERE (`MetricName` IN (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)) WHERE (`TimeUnix` <= toDateTime64(?, ?)) AND (`TimeUnix` > (toDateTime64(?, ?) - toIntervalNanosecond(?)))) GROUP BY `Attributes`)

--- a/test/spec/promql/last_over_time_exp_histogram_preserves.txtar
+++ b/test/spec/promql/last_over_time_exp_histogram_preserves.txtar
@@ -1,0 +1,38 @@
+# last_over_time() over a bare exp-histogram selector whose window holds
+# ONLY histogram samples (cerberus issue #2480). Reference Prometheus's
+# funcLastOverTime reads the window's raw H/F Point directly and, over an
+# all-histogram window, answers `Sample{Metric: el.Metric, H: h.H.Copy()}`
+# — the source series' own `__name__` PRESERVED and its selected
+# histogram sample PRESERVED, never dropped and never emptied (unlike
+# min_over_time / max_over_time's drop class, or count_over_time /
+# present_over_time's value-blind float class). Before this fix cerberus
+# hard-rejected this shape at expHistogramSelectorRouting instead of
+# lowering it at all; lowerLastFirstOverExpHistogram now answers the
+# actual selected histogram via the same HistogramProjection shape a bare
+# selector already publishes, windowed by the matched `[range]` instead of
+# the fixed staleness lookback.
+
+-- query.promql --
+last_over_time(demo_latency_exp_hist[5m])
+-- parity --
+oracle: prometheus
+endpoint: /api/v1/query
+scope: full
+-- seed --
+CREATE TABLE otel_metrics_exponential_histogram (
+    MetricName String,
+    Attributes Map(String, String),
+    TimeUnix DateTime64(9),
+    Count UInt64,
+    Sum Float64,
+    Scale Int32,
+    ZeroCount UInt64,
+    PositiveOffset Int32,
+    PositiveBucketCounts Array(UInt64),
+    NegativeOffset Int32,
+    NegativeBucketCounts Array(UInt64)
+) ENGINE = MergeTree ORDER BY (MetricName, Attributes, TimeUnix);
+INSERT INTO otel_metrics_exponential_histogram VALUES
+    ('demo_latency_exp_hist', map('service', 'api'), toDateTime64('2026-01-01 00:00:00', 9), 6, 42.5, 0, 0, 0, [1, 2, 3], 0, []);
+-- expected_rows --
+[]

--- a/test/spec/promql/min_over_time_exp_histogram_drops.txtar
+++ b/test/spec/promql/min_over_time_exp_histogram_drops.txtar
@@ -31,3 +31,44 @@ INSERT INTO otel_metrics_exponential_histogram VALUES
     ('demo_latency_exp_hist', map('service', 'api'), toDateTime64('2026-01-01 00:00:00', 9), 6, 42.5, 0, 0, 0, [1, 2, 3], 0, []);
 -- expected_rows --
 []
+-- args --
+[0] string = ""
+[1] float64 = 0
+[2] int64 = 9
+[3] float64 = 0
+[4] string = "service_name"
+[5] string = "service.name"
+[6] string = "service_name"
+[7] string = "service.name"
+[8] string = "service_name"
+[9] string = ""
+[10] string = "service_name"
+[11] string = "demo_latency_exp_hist"
+[12] string = "demo.latency.exp.hist"
+[13] string = "demo.latency.exp/hist"
+[14] string = "demo.latency.exp_hist"
+[15] string = "demo.latency/exp/hist"
+[16] string = "demo.latency/exp_hist"
+[17] string = "demo.latency_exp.hist"
+[18] string = "demo.latency_exp_hist"
+[19] string = "demo/latency/exp/hist"
+[20] string = "demo/latency/exp_hist"
+[21] string = "demo/latency_exp_hist"
+[22] string = "demo_latency.exp.hist"
+[23] string = "demo_latency.exp_hist"
+[24] string = "demo_latency_exp.hist"
+[25] string = "2026-01-01 00:00:01.000000000"
+[26] int64 = 9
+[27] string = "2026-01-01 00:00:01.000000000"
+[28] int64 = 9
+[29] int64 = 300000000000
+[30] bool = false
+-- chplan --
+Project ["" AS MetricName, Attributes AS Attributes, TimeUnix AS TimeUnix, 0 AS Value]
+  Filter predicate=false
+    HistogramProjection project=[MetricName AS MetricName, Attributes AS Attributes, FnNow64(9) AS TimeUnix, 0 AS Value]
+      Aggregate groupBy=[FnMapSort(FnMapMerge(FnMapFilter((k, v) -> (k NOT IN ("service_name")), FnMapUpdate(FnMapFromArrays(FnArrayMap(k -> FnRegexReplaceAll(k, "[^a-zA-Z0-9_]", "_"), FnMapKeys(FnMapFilter((k, v) -> (k NOT IN ("service.name", "service_name")), ResourceAttributes))), FnMapValues(FnMapFilter((k, v) -> (k NOT IN ("service.name", "service_name")), ResourceAttributes))), FnMapFromArrays(FnArrayMap(k -> FnRegexReplaceAll(k, "[^a-zA-Z0-9_]", "_"), FnMapKeys(Attributes)), FnMapValues(Attributes)))), FnMapFilter((k, v) -> (v != ""), FnMap("service_name", FnToString(ServiceName))))) AS Attributes] funcs=[FnArgMax(MetricName, TimeUnix) AS MetricName, FnArgMax(Count, TimeUnix) AS Count, FnArgMax(Sum, TimeUnix) AS Sum, FnArgMax(Scale, TimeUnix) AS Scale, FnArgMax(ZeroCount, TimeUnix) AS ZeroCount, FnArgMax(PositiveOffset, TimeUnix) AS PositiveOffset, FnArgMax(PositiveBucketCounts, TimeUnix) AS PositiveBucketCounts, FnArgMax(NegativeOffset, TimeUnix) AS NegativeOffset, FnArgMax(NegativeBucketCounts, TimeUnix) AS NegativeBucketCounts]
+        Filter predicate=(((MetricName IN ("demo_latency_exp_hist", "demo.latency.exp.hist", "demo.latency.exp/hist", "demo.latency.exp_hist", "demo.latency/exp/hist", "demo.latency/exp_hist", "demo.latency_exp.hist", "demo.latency_exp_hist", "demo/latency/exp/hist", "demo/latency/exp_hist", "demo/latency_exp_hist", "demo_latency.exp.hist", "demo_latency.exp_hist", "demo_latency_exp.hist")) AND (TimeUnix <= FnToDateTime64("2026-01-01 00:00:01.000000000", 9))) AND (TimeUnix > (FnToDateTime64("2026-01-01 00:00:01.000000000", 9) - FnToIntervalNanosecond(300000000000))))
+          Scan(otel_metrics_exponential_histogram)
+-- sql --
+SELECT ? AS `MetricName`, `Attributes` AS `Attributes`, `TimeUnix` AS `TimeUnix`, toFloat64(?) AS `Value` FROM (SELECT * FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, now64(?) AS `TimeUnix`, toFloat64(?) AS `Value`, toFloat64(`Count`) AS `HistogramCount`, toFloat64(`Sum`) AS `HistogramSum`, toInt32(`Scale`) AS `HistogramScale`, toFloat64(0.) AS `HistogramZeroThreshold`, toFloat64(`ZeroCount`) AS `HistogramZeroCount`, toInt32(`PositiveOffset`) AS `HistogramPositiveOffset`, arrayMap(x -> toFloat64(x), `PositiveBucketCounts`) AS `HistogramPositiveBucketCounts`, toInt32(`NegativeOffset`) AS `HistogramNegativeOffset`, arrayMap(x -> toFloat64(x), `NegativeBucketCounts`) AS `HistogramNegativeBucketCounts` FROM (SELECT mapSort(mapConcat(mapFilter((k, v) -> (k NOT IN (?)), mapUpdate(mapFromArrays(arrayMap(k -> replaceRegexpAll(k, '[^a-zA-Z0-9_]', '_'), mapKeys(mapFilter((k, v) -> (k NOT IN (?, ?)), `ResourceAttributes`))), mapValues(mapFilter((k, v) -> (k NOT IN (?, ?)), `ResourceAttributes`))), mapFromArrays(arrayMap(k -> replaceRegexpAll(k, '[^a-zA-Z0-9_]', '_'), mapKeys(`Attributes`)), mapValues(`Attributes`)))), mapFilter((k, v) -> (v != ?), map(?, toString(`ServiceName`))))) AS `Attributes`, argMax(`MetricName`, `TimeUnix`) AS `MetricName`, argMax(`Count`, `TimeUnix`) AS `Count`, argMax(`Sum`, `TimeUnix`) AS `Sum`, argMax(`Scale`, `TimeUnix`) AS `Scale`, argMax(`ZeroCount`, `TimeUnix`) AS `ZeroCount`, argMax(`PositiveOffset`, `TimeUnix`) AS `PositiveOffset`, argMax(`PositiveBucketCounts`, `TimeUnix`) AS `PositiveBucketCounts`, argMax(`NegativeOffset`, `TimeUnix`) AS `NegativeOffset`, argMax(`NegativeBucketCounts`, `TimeUnix`) AS `NegativeBucketCounts` FROM (SELECT * FROM `otel_metrics_exponential_histogram` PREWHERE (`MetricName` IN (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)) WHERE (`TimeUnix` <= toDateTime64(?, ?)) AND (`TimeUnix` > (toDateTime64(?, ?) - toIntervalNanosecond(?)))) GROUP BY `Attributes`)) WHERE ?)

--- a/test/spec/promql/min_over_time_exp_histogram_drops.txtar
+++ b/test/spec/promql/min_over_time_exp_histogram_drops.txtar
@@ -1,0 +1,33 @@
+# min_over_time() over a bare exp-histogram selector whose window holds
+# ONLY histogram samples (cerberus issue #2480). Reference Prometheus's
+# compareOverTime (funcMinOverTime / funcMaxOverTime) checks
+# `len(samples.Floats) == 0` BEFORE it ever reads samples.Histograms and
+# answers an empty vector — no error, no annotation — matching the
+# rangeVectorFloatOnlyDropFuncs drop class #2477 built and #2480 extended
+# min_over_time / max_over_time into. Before this fix cerberus hard-rejected
+# this shape at expHistogramSelectorRouting instead of lowering it at all.
+
+-- query.promql --
+min_over_time(demo_latency_exp_hist[5m])
+-- parity --
+oracle: prometheus
+endpoint: /api/v1/query
+scope: full
+-- seed --
+CREATE TABLE otel_metrics_exponential_histogram (
+    MetricName String,
+    Attributes Map(String, String),
+    TimeUnix DateTime64(9),
+    Count UInt64,
+    Sum Float64,
+    Scale Int32,
+    ZeroCount UInt64,
+    PositiveOffset Int32,
+    PositiveBucketCounts Array(UInt64),
+    NegativeOffset Int32,
+    NegativeBucketCounts Array(UInt64)
+) ENGINE = MergeTree ORDER BY (MetricName, Attributes, TimeUnix);
+INSERT INTO otel_metrics_exponential_histogram VALUES
+    ('demo_latency_exp_hist', map('service', 'api'), toDateTime64('2026-01-01 00:00:00', 9), 6, 42.5, 0, 0, 0, [1, 2, 3], 0, []);
+-- expected_rows --
+[]

--- a/test/spec/promql/present_over_time_exp_histogram.txtar
+++ b/test/spec/promql/present_over_time_exp_histogram.txtar
@@ -1,0 +1,34 @@
+# present_over_time() over a bare exp-histogram selector whose window
+# holds ONLY histogram samples (cerberus issue #2480). Reference
+# Prometheus's funcPresentOverTime (via aggrOverTime) always answers 1
+# whenever the series has ANY in-window sample, float or histogram — it
+# never inspects the sample's payload at all. Before this fix cerberus
+# hard-rejected this shape at expHistogramSelectorRouting instead of
+# lowering it at all; lowerCountPresentOverExpHistogram now answers the
+# constant presence value via the same value-blind any(toFloat64(1))
+# pattern the GROUP() aggregation operator already uses.
+
+-- query.promql --
+present_over_time(demo_latency_exp_hist[5m])
+-- parity --
+oracle: prometheus
+endpoint: /api/v1/query
+scope: full
+-- seed --
+CREATE TABLE otel_metrics_exponential_histogram (
+    MetricName String,
+    Attributes Map(String, String),
+    TimeUnix DateTime64(9),
+    Count UInt64,
+    Sum Float64,
+    Scale Int32,
+    ZeroCount UInt64,
+    PositiveOffset Int32,
+    PositiveBucketCounts Array(UInt64),
+    NegativeOffset Int32,
+    NegativeBucketCounts Array(UInt64)
+) ENGINE = MergeTree ORDER BY (MetricName, Attributes, TimeUnix);
+INSERT INTO otel_metrics_exponential_histogram VALUES
+    ('demo_latency_exp_hist', map('service', 'api'), toDateTime64('2026-01-01 00:00:00', 9), 6, 42.5, 0, 0, 0, [1, 2, 3], 0, []);
+-- expected_rows --
+[]

--- a/test/spec/promql/present_over_time_exp_histogram.txtar
+++ b/test/spec/promql/present_over_time_exp_histogram.txtar
@@ -31,4 +31,43 @@ CREATE TABLE otel_metrics_exponential_histogram (
 INSERT INTO otel_metrics_exponential_histogram VALUES
     ('demo_latency_exp_hist', map('service', 'api'), toDateTime64('2026-01-01 00:00:00', 9), 6, 42.5, 0, 0, 0, [1, 2, 3], 0, []);
 -- expected_rows --
-[]
+[
+  ["", {"service": "api"}, "2026-01-01T00:00:01Z", 1]
+]
+-- args --
+[0] string = ""
+[1] int64 = 9
+[2] string = "service_name"
+[3] string = "service.name"
+[4] string = "service_name"
+[5] string = "service.name"
+[6] string = "service_name"
+[7] string = ""
+[8] string = "service_name"
+[9] int64 = 1
+[10] string = "demo_latency_exp_hist"
+[11] string = "demo.latency.exp.hist"
+[12] string = "demo.latency.exp/hist"
+[13] string = "demo.latency.exp_hist"
+[14] string = "demo.latency/exp/hist"
+[15] string = "demo.latency/exp_hist"
+[16] string = "demo.latency_exp.hist"
+[17] string = "demo.latency_exp_hist"
+[18] string = "demo/latency/exp/hist"
+[19] string = "demo/latency/exp_hist"
+[20] string = "demo/latency_exp_hist"
+[21] string = "demo_latency.exp.hist"
+[22] string = "demo_latency.exp_hist"
+[23] string = "demo_latency_exp.hist"
+[24] string = "2026-01-01 00:00:01.000000000"
+[25] int64 = 9
+[26] string = "2026-01-01 00:00:01.000000000"
+[27] int64 = 9
+[28] int64 = 300000000000
+-- chplan --
+Project ["" AS MetricName, Attributes AS Attributes, FnNow64(9) AS TimeUnix, Value AS Value]
+  Aggregate groupBy=[FnMapSort(FnMapMerge(FnMapFilter((k, v) -> (k NOT IN ("service_name")), FnMapUpdate(FnMapFromArrays(FnArrayMap(k -> FnRegexReplaceAll(k, "[^a-zA-Z0-9_]", "_"), FnMapKeys(FnMapFilter((k, v) -> (k NOT IN ("service.name", "service_name")), ResourceAttributes))), FnMapValues(FnMapFilter((k, v) -> (k NOT IN ("service.name", "service_name")), ResourceAttributes))), FnMapFromArrays(FnArrayMap(k -> FnRegexReplaceAll(k, "[^a-zA-Z0-9_]", "_"), FnMapKeys(Attributes)), FnMapValues(Attributes)))), FnMapFilter((k, v) -> (v != ""), FnMap("service_name", FnToString(ServiceName))))) AS Attributes] funcs=[FnAny(FnToFloat64(1)) AS Value]
+    Filter predicate=(((MetricName IN ("demo_latency_exp_hist", "demo.latency.exp.hist", "demo.latency.exp/hist", "demo.latency.exp_hist", "demo.latency/exp/hist", "demo.latency/exp_hist", "demo.latency_exp.hist", "demo.latency_exp_hist", "demo/latency/exp/hist", "demo/latency/exp_hist", "demo/latency_exp_hist", "demo_latency.exp.hist", "demo_latency.exp_hist", "demo_latency_exp.hist")) AND (TimeUnix <= FnToDateTime64("2026-01-01 00:00:01.000000000", 9))) AND (TimeUnix > (FnToDateTime64("2026-01-01 00:00:01.000000000", 9) - FnToIntervalNanosecond(300000000000))))
+      Scan(otel_metrics_exponential_histogram)
+-- sql --
+SELECT ? AS `MetricName`, `Attributes` AS `Attributes`, now64(?) AS `TimeUnix`, `Value` AS `Value` FROM (SELECT mapSort(mapConcat(mapFilter((k, v) -> (k NOT IN (?)), mapUpdate(mapFromArrays(arrayMap(k -> replaceRegexpAll(k, '[^a-zA-Z0-9_]', '_'), mapKeys(mapFilter((k, v) -> (k NOT IN (?, ?)), `ResourceAttributes`))), mapValues(mapFilter((k, v) -> (k NOT IN (?, ?)), `ResourceAttributes`))), mapFromArrays(arrayMap(k -> replaceRegexpAll(k, '[^a-zA-Z0-9_]', '_'), mapKeys(`Attributes`)), mapValues(`Attributes`)))), mapFilter((k, v) -> (v != ?), map(?, toString(`ServiceName`))))) AS `Attributes`, any(toFloat64(?)) AS `Value` FROM (SELECT * FROM `otel_metrics_exponential_histogram` PREWHERE (`MetricName` IN (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)) WHERE (`TimeUnix` <= toDateTime64(?, ?)) AND (`TimeUnix` > (toDateTime64(?, ?) - toIntervalNanosecond(?)))) GROUP BY `Attributes`)


### PR DESCRIPTION
## Problem

Issue #2477 fixed seven float-only range-vector reducers so a bare exp-histogram matrix-selector
argument answers reference's empty-vector semantics instead of hitting
`expHistogramSelectorRouting`'s catch-all rejection. #2480 named six more reducers dispatched
through the same generic `lowerRangeVectorCall` fallthrough that still hit that rejection, and its
own filing already determined the six are **not** a uniform bug class.

## What this PR does

Implements all six, split into their three distinct treatment classes — each verified directly
against `tsouza/prometheus`'s `promql/functions.go` before implementing, not assumed from the
issue text:

- **`min_over_time()` / `max_over_time()`** (`compareOverTime`): the identical
  `if len(samples.Floats) == 0 { return enh.Out, nil }` drop-and-answer-empty pattern #2477's
  seven reducers already use. Both simply join `rangeVectorFloatOnlyDropFuncs`
  (`internal/promql/range_fns.go`).
- **`count_over_time()` / `present_over_time()`** (`aggrOverTime`-based `funcCountOverTime` /
  `funcPresentOverTime`): never guard on `len(samples.Floats) == 0` at all, so an all-histogram
  window answers a real (non-empty) count or presence value — the drop treatment would be wrong.
  New file `internal/promql/histogram_native_count_present_over_time.go` gives them their own
  windowed lowering: a per-`(series, anchor)` collapse via `count()` /
  `any(toFloat64(1))` (the same value-blind aggregate `lowerExpHistogramCountOrGroupOverPlan`
  already uses for the `GROUP()` aggregation operator), windowed by the matched `[range]`.
- **`last_over_time()` / `first_over_time()`** (`funcLastOverTime` / `funcFirstOverTime`): read the
  window's raw H/F `Point` directly and, over an all-histogram window, answer the selected
  histogram sample itself with `__name__` PRESERVED — never dropped, never emptied, never counted.
  New file `internal/promql/histogram_native_last_first_over_time.go` mirrors
  `lowerExpHistogramBare`'s three grid shapes (fanout / `@`-broadcast / single-anchor), widened
  from the fixed staleness lookback to the matched `[range]`; `first_over_time` collapses via
  `argMin` (`earliestArgMin`, new) instead of `argMax` to select the OLDEST in-window sample.

All six recognizers are registered at `lowerRoot`'s top level in `internal/promql/lower.go`,
alongside the existing `sum_over_time`/`avg_over_time`/`resets`/`changes` histogram-aware
dispatches.

## Rejection-parity catalogue

Repoints the `expHistogramSelectorRouting` entry's `trigger_query` from `min_over_time(...)` (no
longer rejected) to `ts_of_first_over_time(...)` — the next reachable trigger, confirmed directly
against `promql.LowerAt` on this branch. While hunting for that next trigger, `ts_of_first_over_time`
/ `ts_of_last_over_time` / `ts_of_max_over_time` / `ts_of_min_over_time` turned out to have the
identical unaddressed-selector gap (and, per a first pass against reference, split the same way:
the two `ts_of_{max,min}_over_time` share `compareOverTime`'s drop pattern, the two
`ts_of_{first,last}_over_time` need their own preserved-timestamp lowering). That's a distinct,
verified finding outside this issue's stated scope, filed as **tsouza/cerberus#2482** rather than
folded into this change.

## Testing

- `internal/promql/histogram_native_count_present_over_time_test.go` (new): pins the float-valued
  plan shape for `count_over_time`/`present_over_time` over an exp-histogram selector (instant,
  offset, `@`-broadcast, range-mode) and the `count(...)` vs `any(toFloat64(...))` SQL split.
- `internal/promql/histogram_native_last_first_over_time_test.go` (new): pins the
  `HistogramProjection` (preserved-`__name__`) plan shape for `last_over_time`/`first_over_time`
  across the same grid shapes, and the `argMax`/`argMin` selection-direction split.
- `internal/promql/range_vector_float_only_reducer_exp_histogram_test.go` (extended): adds
  `min_over_time`/`max_over_time` to #2477's existing drop-class table (instant + range mode).
- Four new `test/spec/promql/*.txtar` fixtures — one per behavior class (drop / count / present /
  preserve) — regenerated via the `update-golden.yml` workflow (see below) rather than hand-filled.
- `go test -race ./internal/promql/...` green locally.

## Golden regeneration

Pushed, then ran `update-golden.yml` for the `promql` + `parity` shards (auto-expanded per this
branch's own diff) and pulled the regenerated goldens back onto this branch before marking ready.

Closes #2480
