### PR TITLE
fix(perf): bump real-CH image floor and fix the classic-histogram nightly sentinel

### DIFF
--- a/.github/scripts/lib/mirror.mjs
+++ b/.github/scripts/lib/mirror.mjs
@@ -72,7 +72,7 @@ export const mirroredImages = [
   // k3d stack, the startup bench, and the `-tags=integration` testcontainers
   // lanes (24.8 is the older server the replicated-DDL pins are proved on).
   'clickhouse/clickhouse-server:24.8-alpine',
-  'clickhouse/clickhouse-server:25.8-alpine',
+  'clickhouse/clickhouse-server:25.9-alpine',
   'clickhouse/clickhouse-server:26.3',
   'clickhouse/clickhouse-server:26.5',
   'clickhouse/clickhouse-server:26.5-alpine',

--- a/Justfile
+++ b/Justfile
@@ -1082,7 +1082,7 @@ E2E_BWC_IMAGES := "minio/minio:RELEASE.2025-09-07T16-13-09Z minio/mc:RELEASE.202
 # the DDL still applies on the previous supported line, so only that lane needs
 # it. TestIntegrationImagePinsMatchTheJustfile holds both against the literals in
 # the test sources.
-CH_TEST_IMAGE := "clickhouse/clickhouse-server:25.8-alpine"
+CH_TEST_IMAGE := "clickhouse/clickhouse-server:25.9-alpine"
 CH_TEST_IMAGE_PRIOR := "clickhouse/clickhouse-server:24.8-alpine"
 
 # CH_STRICT_SCAN_IMAGE is the server the strict-scan differential boots. Unlike

--- a/cmd/cerberus/auto_create_integration_test.go
+++ b/cmd/cerberus/auto_create_integration_test.go
@@ -30,7 +30,7 @@ func TestAutoCreateSchema_StartupWiring(t *testing.T) {
 
 	container, err := tcclickhouse.Run(
 		ctx,
-		"clickhouse/clickhouse-server:25.8-alpine",
+		"clickhouse/clickhouse-server:25.9-alpine",
 		tcclickhouse.WithUsername("cerberus"),
 		tcclickhouse.WithPassword("cerberus"),
 		tcclickhouse.WithDatabase("otel"),

--- a/internal/api/prom/handler_histogram_integration_test.go
+++ b/internal/api/prom/handler_histogram_integration_test.go
@@ -137,7 +137,7 @@ func TestHistogram_RealExporterSchema_Integration(t *testing.T) {
 
 	container, err := tcclickhouse.Run(
 		ctx,
-		"clickhouse/clickhouse-server:25.8-alpine",
+		"clickhouse/clickhouse-server:25.9-alpine",
 		tcclickhouse.WithUsername("cerberus"),
 		tcclickhouse.WithPassword("cerberus"),
 		tcclickhouse.WithDatabase("otel"),

--- a/internal/api/prom/handler_route_b_realch_integration_test.go
+++ b/internal/api/prom/handler_route_b_realch_integration_test.go
@@ -87,7 +87,7 @@ import (
 // routeBCHImage matches the other real-CH integration lanes (strict-scan,
 // router-rules, solver-memory-apportion, chclient) so every real-CH lane
 // exercises the same server version.
-const routeBCHImage = "clickhouse/clickhouse-server:25.8-alpine"
+const routeBCHImage = "clickhouse/clickhouse-server:25.9-alpine"
 
 // routeBMetric is the counter series both handlers query. Named away from
 // any reserved suffix (_bucket / _count / _sum / _exp_hist) so it is read as

--- a/internal/api/tempo/traces_scan_window_integration_test.go
+++ b/internal/api/tempo/traces_scan_window_integration_test.go
@@ -51,7 +51,7 @@ import (
 
 // scanWinCHImage pins the same ClickHouse server image the other real-CH lanes
 // use.
-const scanWinCHImage = "clickhouse/clickhouse-server:25.8-alpine"
+const scanWinCHImage = "clickhouse/clickhouse-server:25.9-alpine"
 
 const scanWinDB = "default"
 

--- a/internal/chclient/client_integration_test.go
+++ b/internal/chclient/client_integration_test.go
@@ -24,7 +24,7 @@ func TestQuery_E2E(t *testing.T) {
 
 	container, err := tcclickhouse.Run(
 		ctx,
-		"clickhouse/clickhouse-server:25.8-alpine",
+		"clickhouse/clickhouse-server:25.9-alpine",
 		tcclickhouse.WithUsername("cerberus"),
 		tcclickhouse.WithPassword("cerberus"),
 		tcclickhouse.WithDatabase("otel"),

--- a/internal/chclient/columnar_integration_test.go
+++ b/internal/chclient/columnar_integration_test.go
@@ -147,7 +147,7 @@ func startColumnarCH(ctx context.Context, t *testing.T) string {
 	t.Helper()
 	container, err := tcclickhouse.Run(
 		ctx,
-		"clickhouse/clickhouse-server:25.8-alpine",
+		"clickhouse/clickhouse-server:25.9-alpine",
 		tcclickhouse.WithUsername("cerberus"),
 		tcclickhouse.WithPassword("cerberus"),
 		tcclickhouse.WithDatabase("otel"),

--- a/internal/chclient/conn_teardown_integration_test.go
+++ b/internal/chclient/conn_teardown_integration_test.go
@@ -277,7 +277,7 @@ func startTeardownFixture(ctx context.Context, t *testing.T) teardownFixture {
 
 	container, err := tcclickhouse.Run(
 		ctx,
-		"clickhouse/clickhouse-server:25.8-alpine",
+		"clickhouse/clickhouse-server:25.9-alpine",
 		tcclickhouse.WithUsername("cerberus"),
 		tcclickhouse.WithPassword("cerberus"),
 		tcclickhouse.WithDatabase("otel"),

--- a/internal/chclient/query_timeout_clean_cancel_integration_test.go
+++ b/internal/chclient/query_timeout_clean_cancel_integration_test.go
@@ -64,7 +64,7 @@ func TestQueryTimeout_ServerSideCleanAbort(t *testing.T) {
 
 	container, err := tcclickhouse.Run(
 		ctx,
-		"clickhouse/clickhouse-server:25.8-alpine",
+		"clickhouse/clickhouse-server:25.9-alpine",
 		tcclickhouse.WithUsername("cerberus"),
 		tcclickhouse.WithPassword("cerberus"),
 		tcclickhouse.WithDatabase("otel"),

--- a/internal/chclient/ts_grid_probe_integration_test.go
+++ b/internal/chclient/ts_grid_probe_integration_test.go
@@ -25,17 +25,17 @@ import (
 // to fan-out. The fix projects a String column (`SELECT '1'`) that QueryStrings
 // decodes cleanly, so a healthy server reads as the Available verdict it is.
 //
-// This stands up a real, unconstrained ClickHouse on the 25.8 line (which has
-// the experimental setting) and asserts the verdict is Available -- the assertion
-// that fails on the pre-fix `SELECT 1` body. Gated by the `integration` build
-// tag (requires Docker); the E2E workflow runs it, regular CI doesn't.
+// This stands up a real, unconstrained ClickHouse (which has the experimental
+// setting) and asserts the verdict is Available -- the assertion that fails on
+// the pre-fix `SELECT 1` body. Gated by the `integration` build tag (requires
+// Docker); the E2E workflow runs it, regular CI doesn't.
 func TestProbeTSGridCapability_HealthyServerIsAvailable(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
 	defer cancel()
 
 	container, err := tcclickhouse.Run(
 		ctx,
-		"clickhouse/clickhouse-server:25.8-alpine",
+		"clickhouse/clickhouse-server:25.9-alpine",
 		tcclickhouse.WithUsername("cerberus"),
 		tcclickhouse.WithPassword("cerberus"),
 	)
@@ -77,7 +77,7 @@ func TestProbeTSGridCapability_HealthyServerIsAvailable(t *testing.T) {
 
 	got := client.ProbeTSGridCapability(ctx)
 	if got != chopt.CapabilityAvailable {
-		t.Fatalf("ProbeTSGridCapability on a healthy, unconstrained 25.8 server = %v; want %v "+
+		t.Fatalf("ProbeTSGridCapability on a healthy, unconstrained server = %v; want %v "+
 			"(a UInt8 probe body that QueryStrings cannot scan misclassifies this as Unreachable)",
 			got, chopt.CapabilityAvailable)
 	}

--- a/internal/chclient/version_probe_integration_test.go
+++ b/internal/chclient/version_probe_integration_test.go
@@ -42,7 +42,7 @@ func TestProbeVersion_DatabaseAbsent(t *testing.T) {
 	// cold-cluster bootstrap path a fresh k8s/compose deployment hits.
 	container, err := tcclickhouse.Run(
 		ctx,
-		"clickhouse/clickhouse-server:25.8-alpine",
+		"clickhouse/clickhouse-server:25.9-alpine",
 		tcclickhouse.WithUsername("cerberus"),
 		tcclickhouse.WithPassword("cerberus"),
 	)
@@ -111,13 +111,13 @@ func TestProbeVersion_DatabaseAbsent(t *testing.T) {
 		if err != nil {
 			t.Fatalf("ProbeVersion over default-bound connection (otel absent): %v", err)
 		}
-		// The testcontainers image is the 25.8 line; the probe must resolve a
+		// The testcontainers image is the 25.9 line; the probe must resolve a
 		// real, non-zero version rather than fall through to the 24.8 floor.
 		if v.Major == 0 {
 			t.Fatalf("probe resolved a zero version: %+v", v)
 		}
-		if v.Major != 25 || v.Minor != 8 {
-			t.Errorf("probe version mismatch: got %s, want 25.8 (server image line)", v.String())
+		if v.Major != 25 || v.Minor != 9 {
+			t.Errorf("probe version mismatch: got %s, want 25.9 (server image line)", v.String())
 		}
 	})
 }

--- a/internal/optcorpus/queryexit_realch_integration_test.go
+++ b/internal/optcorpus/queryexit_realch_integration_test.go
@@ -39,7 +39,7 @@ import (
 
 // queryExitCHImage pins the ClickHouse server image, matching every other
 // real-CH lane so all of them exercise the same server version.
-const queryExitCHImage = "clickhouse/clickhouse-server:25.8-alpine"
+const queryExitCHImage = "clickhouse/clickhouse-server:25.9-alpine"
 
 // queryExitCHStartTimeout bounds container pull + start + the seed/read cycle.
 const queryExitCHStartTimeout = 5 * time.Minute

--- a/internal/routerrules/realch_integration_test.go
+++ b/internal/routerrules/realch_integration_test.go
@@ -94,7 +94,7 @@ const realCHStartTimeout = 5 * time.Minute
 
 // realCHImage pins the ClickHouse server image, matching the chclient + strict-
 // scan integration lanes so all real-CH lanes exercise the same server version.
-const realCHImage = "clickhouse/clickhouse-server:25.8-alpine"
+const realCHImage = "clickhouse/clickhouse-server:25.9-alpine"
 
 // TestCorpusWriteReadRealClickHouse is the real-CH end-to-end guard for the
 // router-corpus WRITE (optcorpus.CHTableSink) and READ (chCorpusSource) paths.

--- a/internal/schema/ddl/ddl_integration_test.go
+++ b/internal/schema/ddl/ddl_integration_test.go
@@ -26,7 +26,7 @@ func startClickHouse(t *testing.T) (driver.Conn, string) {
 
 	container, err := tcclickhouse.Run(
 		ctx,
-		"clickhouse/clickhouse-server:25.8-alpine",
+		"clickhouse/clickhouse-server:25.9-alpine",
 		tcclickhouse.WithUsername("cerberus"),
 		tcclickhouse.WithPassword("cerberus"),
 		tcclickhouse.WithDatabase("otel"),
@@ -85,7 +85,7 @@ func startClickHouseDefaultDB(t *testing.T) driver.Conn {
 
 	container, err := tcclickhouse.Run(
 		ctx,
-		"clickhouse/clickhouse-server:25.8-alpine",
+		"clickhouse/clickhouse-server:25.9-alpine",
 		tcclickhouse.WithUsername("cerberus"),
 		tcclickhouse.WithPassword("cerberus"),
 	)

--- a/internal/schema/ddl/ddl_tiering_integration_test.go
+++ b/internal/schema/ddl/ddl_tiering_integration_test.go
@@ -74,7 +74,7 @@ func startClickHouseTiered(t *testing.T) driver.Conn {
 
 	container, err := tcclickhouse.Run(
 		ctx,
-		"clickhouse/clickhouse-server:25.8-alpine",
+		"clickhouse/clickhouse-server:25.9-alpine",
 		tcclickhouse.WithUsername("cerberus"),
 		tcclickhouse.WithPassword("cerberus"),
 		tcclickhouse.WithDatabase("otel"),

--- a/internal/solver/executor_realch_integration_test.go
+++ b/internal/solver/executor_realch_integration_test.go
@@ -90,7 +90,7 @@ import (
 // memProbeCHImage pins the ClickHouse server image, matching the other
 // real-CH integration lanes (strict-scan, router-rules, chclient) so every
 // real-CH lane exercises the same server version.
-const memProbeCHImage = "clickhouse/clickhouse-server:25.8-alpine"
+const memProbeCHImage = "clickhouse/clickhouse-server:25.9-alpine"
 
 // memProbeStartTimeout bounds container pull + start + both Executor runs.
 const memProbeStartTimeout = 5 * time.Minute

--- a/test/perf/nightly-baseline.json
+++ b/test/perf/nightly-baseline.json
@@ -3,26 +3,26 @@
     {
       "name": "classic_histogram_quantile_by_route",
       "expected_status": 200,
-      "max_of_n_bytes": 9726370,
-      "ceiling_bytes": 14589555
+      "max_of_n_bytes": 463466575,
+      "ceiling_bytes": 695199862
     },
     {
       "name": "request_rate_by_method",
       "expected_status": 422,
-      "max_of_n_bytes": 278242204,
-      "ceiling_bytes": 417363306
+      "max_of_n_bytes": 252364637,
+      "ceiling_bytes": 378546955
     },
     {
       "name": "pod_status_reason_gauge",
       "expected_status": 200,
-      "max_of_n_bytes": 817730723,
+      "max_of_n_bytes": 823750613,
       "ceiling_bytes": 912680550
     },
     {
       "name": "error_ratio_by_namespace",
       "expected_status": 422,
-      "max_of_n_bytes": 296620019,
-      "ceiling_bytes": 444930028
+      "max_of_n_bytes": 340975066,
+      "ceiling_bytes": 511462599
     }
   ]
 }

--- a/test/perf/nightly/realch_perfnightly_integration_test.go
+++ b/test/perf/nightly/realch_perfnightly_integration_test.go
@@ -97,14 +97,16 @@ import (
 
 	"github.com/tsouza/cerberus/internal/api/prom"
 	"github.com/tsouza/cerberus/internal/chclient"
+	"github.com/tsouza/cerberus/internal/chopt"
 	"github.com/tsouza/cerberus/internal/optcorpus"
+	"github.com/tsouza/cerberus/internal/promql"
 	"github.com/tsouza/cerberus/internal/schema"
 	"github.com/tsouza/cerberus/internal/schema/ddl"
 )
 
 // perfNightlyCHImage matches every other strict-scan/perf real-CH lane's
 // pinned tag (test/perf/smoke's own perfSmokeCHImage).
-const perfNightlyCHImage = "clickhouse/clickhouse-server:25.8-alpine"
+const perfNightlyCHImage = "clickhouse/clickhouse-server:25.9-alpine"
 
 const perfNightlyDB = "default"
 
@@ -181,6 +183,13 @@ func TestPerfNightlyRealCH(t *testing.T) {
 	}
 
 	metricsHandler := prom.New(client, schema.DefaultOTelMetrics(), nil)
+	// Wire the SAME classic-histogram native/fan-out decision cmd/cerberus's
+	// own boot path makes (nativeRangeLowerers, main.go), scoped to just this
+	// one field — see nightlyClassicHistogramLowerer's own doc comment for
+	// why prom.New's zero-value Lowerers table alone would leave
+	// chplan.RangeBucketGridNative permanently unreachable here regardless of
+	// perfNightlyCHImage's pinned version.
+	metricsHandler.Lowerers.ClassicHistogram = nightlyClassicHistogramLowerer(ctx, t, client)
 	mux := http.NewServeMux()
 	metricsHandler.Mount(mux)
 
@@ -359,10 +368,14 @@ func TestPerfNightlyRealCH(t *testing.T) {
 // confirm the RIGHT guard fired.
 func runSentinelOnce(t *testing.T, mux *http.ServeMux, sentinel Sentinel, queryID string) (int, string) {
 	t.Helper()
-	params := sentinel.Params(sampleWindowStart, sampleWindowEnd)
-	params.Set("start", formatPromTime(sampleWindowStart))
-	params.Set("end", formatPromTime(sampleWindowEnd))
-	params.Set("step", sentinelStep.String())
+	start, end, step := sampleWindowStart, sampleWindowEnd, sentinelStep
+	if !sentinel.WindowStart.IsZero() {
+		start, end, step = sentinel.WindowStart, sentinel.WindowEnd, sentinel.Step
+	}
+	params := sentinel.Params(start, end)
+	params.Set("start", formatPromTime(start))
+	params.Set("end", formatPromTime(end))
+	params.Set("step", step.String())
 
 	req := httptest.NewRequest(http.MethodGet, sentinel.Path+"?"+params.Encode(), nil)
 	req = req.WithContext(chclient.WithQueryID(req.Context(), queryID))
@@ -381,6 +394,56 @@ func formatPromTime(t time.Time) string {
 func sampleParquetPath(t *testing.T, name string) string {
 	t.Helper()
 	return filepath.Join("testdata", "samples", name)
+}
+
+// nightlyClassicHistogramLowerer probes the live container's ClickHouse
+// version and experimental-setting capability and resolves the SAME
+// chopt.FeatureTSGridHistogram decision cmd/cerberus's own boot wiring
+// (nativeRangeLowerers, main.go) makes, returning just the one
+// promql.ClassicHistogramWindowLowerer classic_histogram_quantile_by_route
+// needs.
+//
+// Without this, metricsHandler.Lowerers stays at prom.New's zero value:
+// promql.RangeLowerers.withDefaults normalizes every nil field to its
+// concrete FAN-OUT impl at the lowering entry, so a bare prom.New handler is
+// permanently fan-out-only regardless of the connected server's version —
+// bumping perfNightlyCHImage past the 25.9 floor alone would never make
+// chplan.RangeBucketGridNative fire in this harness. That gap is real and
+// repo-wide (test/perf/smoke and internal/api/prom's own real-CH integration
+// tests build their handlers the identical zero-Lowerers way), so this fix
+// is deliberately scoped to just the ONE field this lane's histogram
+// sentinel needs, not a general native-lowerers-in-tests refactor — see
+// issue #2487, which tracks wiring the other six native ts_grid families
+// (rate/staleness/changes/resets/deriv/predict_linear) across the other
+// lanes.
+func nightlyClassicHistogramLowerer(ctx context.Context, t *testing.T, client *chclient.Client) promql.ClassicHistogramWindowLowerer {
+	t.Helper()
+	version, err := client.ProbeVersion(ctx)
+	if err != nil {
+		t.Fatalf("probe clickhouse version: %v", err)
+	}
+	capability := client.ProbeTSGridCapability(ctx)
+	set, warnings, err := chopt.Resolve(chopt.Config{
+		Optimizations: "auto",
+		Mode:          chopt.Enforcing,
+		Capability:    capability,
+	}, version)
+	if err != nil {
+		t.Fatalf("resolve clickhouse optimizations: %v", err)
+	}
+	for _, w := range warnings {
+		t.Logf("ch_opt: %s", w)
+	}
+	enabled := set.Has(chopt.FeatureTSGridHistogram)
+	t.Logf("probed clickhouse %s, ts_grid capability %s, ts_grid_histogram enabled=%v",
+		version.String(), capability.String(), enabled)
+
+	if enabled {
+		return promql.NativeClassicHistogramWindowLowerer{
+			Fallback: promql.FanoutClassicHistogramWindowLowerer{},
+		}
+	}
+	return promql.FanoutClassicHistogramWindowLowerer{}
 }
 
 func startPerfNightlyCH(ctx context.Context, t *testing.T) (*tcclickhouse.ClickHouseContainer, *chclient.Client) {

--- a/test/perf/nightly/sentinels.go
+++ b/test/perf/nightly/sentinels.go
@@ -66,6 +66,14 @@ type Sentinel struct {
 	// is the response body substring proving THIS SPECIFIC guard fired —
 	// not some unrelated failure that happens to share the status code.
 	ExpectedErrorSubstring string
+	// WindowStart / WindowEnd / Step, when WindowStart is non-zero,
+	// override the shared sampleWindowStart / sampleWindowEnd / sentinelStep
+	// for THIS sentinel only — see classic_histogram_quantile_by_route's own
+	// comment for why one sentinel needs a narrower window than the other
+	// three's shared production-representative one.
+	WindowStart time.Time
+	WindowEnd   time.Time
+	Step        time.Duration
 }
 
 // Sentinels is PR A's "prove the mechanism, print the numbers" corpus — no
@@ -74,13 +82,55 @@ type Sentinel struct {
 // produce, the same task-4 methodology test/perf/smoke's own PR followed.
 var Sentinels = []Sentinel{
 	{
+		// Params MUST include `le` in the by(...) clause and query the
+		// `_bucket` series — histogramAggShapeLowerable (internal/promql/
+		// histogram_quantile.go) only recognizes the classic-bucket
+		// aggregation shape `<agg> by (le, ...) (<fn>(<bucket_selector>
+		// [range]))`; a by-clause omitting `le`, or a selector missing the
+		// `_bucket` suffix, resolves to an entirely different (and here,
+		// unintended) ordinary-float-bucket/Gauge-Sum companion-column
+		// fallback instead — silently never reaching RangeBucketFanout /
+		// RangeBucketGridNative at all, which defeated this sentinel's whole
+		// purpose until this fix (see the PR that added this comment).
+		//
+		// WindowStart/WindowEnd/Step deliberately narrow this ONE sentinel's
+		// window instead of sharing the other three's ~4h20m/1m production
+		// window: at that full window this query genuinely reaches
+		// chplan.RangeBucketGridNative (confirmed via this harness's own
+		// "ts_grid_histogram enabled=true" boot log against a real
+		// ClickHouse 25.9+) but runs all the way to a genuine ClickHouse
+		// MEMORY_LIMIT_EXCEEDED abort at ~99.9% of the memory cap — unlike
+		// RangeBucketFanout, the native path has no resource-bound guard of
+		// its own yet (internal/chsql/lwr_fanout_bound.go's guard is wired
+		// only into RangeBucketFanout's collapse; tracked as issue #2486).
+		// A near-cap abort is real signal but a DIFFERENT one than this
+		// sentinel exists to produce: #2408's own cost story is 71% of
+		// ClickHouse CPU on a query that SUCCEEDS, and #2429/error_ratio's
+		// own precedent for an "expected 422" sentinel is a CHEAP guard
+		// rejection (~2s at 16-22% of cap), not a near-cap abort — baking a
+		// near-cap OOM in as "the expected, passing behavior" here would
+		// mask #2486 rather than measure #2408.
+		//
+		// The window below (5 anchors) is the calibration sweep's safest
+		// pick, not merely the largest that happens to succeed: memory grows
+		// steeply non-linearly with anchor count for this shape (real,
+		// same-series-cardinality measurements against this sample: 5
+		// anchors -> 43.1% of cap, 10 -> 53.9%, 20 -> 72.4%, 60 -> genuine
+		// MEMORY_LIMIT_EXCEEDED) — itself further evidence for #2486, since
+		// even a modest ~20-minute panel already sits uncomfortably close to
+		// the cap. 5 anchors leaves ~20 points of margin under
+		// nightlyMemoryCapFraction even after the committed baseline's own
+		// 1.5x headroom, which the 10- and 20-anchor points do not.
 		Name:           "classic_histogram_quantile_by_route",
 		Family:         "histogram_quantile over a classic (bucket/bounds) histogram — issue #2408's arrayJoin bucket-rate fan-out",
 		Path:           "/api/v1/query_range",
 		ExpectedStatus: http.StatusOK,
+		WindowStart:    time.Date(2026, 8, 18, 9, 5, 0, 0, time.UTC),
+		WindowEnd:      time.Date(2026, 8, 18, 9, 10, 0, 0, time.UTC),
+		Step:           time.Minute,
 		Params: func(start, end time.Time) url.Values {
 			return url.Values{
-				"query": {`histogram_quantile(0.95, sum by (http_route) (rate(` + histogramMetric + `[5m])))`},
+				"query": {`histogram_quantile(0.95, sum by (http_route, le) (rate(` + histogramMetric + `_bucket[5m])))`},
 			}
 		},
 	},

--- a/test/perf/smoke/realch_perfsmoke_integration_test.go
+++ b/test/perf/smoke/realch_perfsmoke_integration_test.go
@@ -18,7 +18,7 @@
 //
 // This test drives the mounted PRODUCTION prom + tempo handlers over real
 // HTTP against a real ClickHouse (testcontainers-go,
-// clickhouse/clickhouse-server:25.8-alpine — the same tag every other
+// clickhouse/clickhouse-server:25.9-alpine — the same tag every other
 // strict-scan real-CH lane uses), seeded at the scale each incident's own
 // root-cause mechanism needs to actually engage (see sentinels.go's
 // Sentinels and seed.go's builders), and reads peak per-query memory back
@@ -55,7 +55,7 @@ import (
 // strict-scan real-CH lane uses (traces_scan_window_integration_test.go
 // etc.) — testcontainers' own wait-strategy against this alpine tag doesn't
 // hit the healthcheck race docker-compose's Ubuntu-base image does.
-const perfSmokeCHImage = "clickhouse/clickhouse-server:25.8-alpine"
+const perfSmokeCHImage = "clickhouse/clickhouse-server:25.9-alpine"
 
 const perfSmokeDB = "default"
 

--- a/test/spec/metadata_endpoints_realch_integration_test.go
+++ b/test/spec/metadata_endpoints_realch_integration_test.go
@@ -77,7 +77,7 @@ import (
 // metadataEndpointsCHImage matches the other real-CH integration lanes
 // (strict-scan, router-rules, solver-memory-apportion, route-B, chclient)
 // so every real-CH lane exercises the same server version.
-const metadataEndpointsCHImage = "clickhouse/clickhouse-server:25.8-alpine"
+const metadataEndpointsCHImage = "clickhouse/clickhouse-server:25.9-alpine"
 
 // metadataEndpointsAnchor is the past-anchored base timestamp every seeded
 // row and every request window derives from. It is computed relative to

--- a/test/spec/traces_scan_resource_bound_integration_test.go
+++ b/test/spec/traces_scan_resource_bound_integration_test.go
@@ -81,7 +81,7 @@ import (
 
 // scanBoundCHImage pins the same ClickHouse server image the other real-CH
 // lanes (strict-scan, chclient integration) use.
-const scanBoundCHImage = "clickhouse/clickhouse-server:25.8-alpine"
+const scanBoundCHImage = "clickhouse/clickhouse-server:25.9-alpine"
 
 // scanBoundDB is the connection's default database. The lowered SQL references
 // otel_traces unqualified, so the table must live in the connection's database.


### PR DESCRIPTION
## Summary

- Every real-ClickHouse Go integration test in this repo was pinned below PR #2401's
  `chplan.RangeBucketGridNative` feature floor (`chopt.FeatureTSGridHistogram`, `MinVersion{25,9}`) —
  bumped all 20 sub-floor image-pin occurrences (`internal/schema/ddl/ddl_replicated_integration_test.go`
  deliberately excluded — it pins 24.8 ON PURPOSE to prove the DDL applies at cerberus's actual
  minimum-supported floor, a different concern) plus the Justfile's `CH_TEST_IMAGE` source of truth.
- `test/perf/nightly/sentinels.go`'s `classic_histogram_quantile_by_route` sentinel queried the wrong
  shape (no `le`, no `_bucket`) and silently fell back to an unrelated code path despite its own doc
  string citing #2408 — corrected the query, and found the version bump alone was NOT sufficient to
  make it reach `RangeBucketGridNative` (the harness never wires native Lowerers at all — added a
  narrowly-scoped fix for just this one field).
- Empirically determined `ExpectedStatus` rather than guessing: at the shared corpus window this
  corrected query genuinely OOMs ClickHouse via the (currently unguarded) native path, so gave this one
  sentinel its own calibrated, safe window instead of accepting a near-cap abort as "expected." Filed
  #2486 for the underlying resource-bound gap this surfaced, and #2487 for the broader
  native-lowerers-untested-in-real-CH-lanes gap.

## Details

### Fix 1 — image floor

Bumped every sub-25.9 real-CH Go integration test image pin (20 occurrences across ~19 files, found
via `grep -rn "clickhouse-server:2[0-5]\." --include="*.go"`) to `clickhouse/clickhouse-server:25.9-alpine`
— the literal feature floor, not a newer minor line. I originally tried `26.6-alpine` (matching this
repo's own compose/e2e stack, for "consistency"), but that surfaced a **real, reproducible upstream
ClickHouse Parquet-reader regression**, unrelated to cerberus: selecting a named-tuple subcolumn whose
key is a dotted PREFIX of another key in the same tuple (`ResourceAttributes.deployment.environment`
vs. `ResourceAttributes.deployment.environment.name`, both real fields in the nightly sample) fails
with `NOT_FOUND_COLUMN_IN_BLOCK` on CH 26.1 through at least 26.6, reproduced with a bare
`clickhouse-local` query with no cerberus code involved. 25.9 and 25.10 are clean; picked 25.9 as the
literal floor.

Also bumped the Justfile's `CH_TEST_IMAGE` (the single source of truth
`test/regression/justfile_pull_retry_test.go`'s `TestIntegrationImagePinsMatchTheJustfile` enforces
every Go image-pin literal against) — missed this on the first pass; the regression test caught it
immediately, confirming the guard works. Also fixed two now-stale hardcoded assertions that would have
broken against the new image: `internal/chclient/version_probe_integration_test.go` asserted the
probed version was literally `25.8`; `internal/chclient/ts_grid_probe_integration_test.go`'s doc
comment named the 25.8 line specifically.

### Fix 2 — the sentinel, plus a wiring gap the version bump alone couldn't fix

Corrected the query to the actual classic-bucket shape:
`histogram_quantile(0.95, sum by (http_route, le) (rate(svc_http_request_duration_seconds_bucket[5m])))`.

Bumping the image was **necessary but not sufficient**: `test/perf/nightly/realch_perfnightly_integration_test.go`
builds its handler as `prom.New(client, schema, nil)` and never wires `.Lowerers` —
`promql.RangeLowerers.withDefaults()` normalizes every nil field to its fan-out implementation, so this
(and every other real-CH lane built the same way — `test/perf/smoke`, `internal/api/prom`'s own
histogram integration test) is permanently fan-out-only regardless of the connected server's version.
Added `nightlyClassicHistogramLowerer`, which probes the live container's version + capability and
calls `chopt.Resolve`, mirroring `cmd/cerberus/main.go`'s own boot wiring for exactly this one field —
confirmed activation via the harness's own boot log (`ts_grid_histogram enabled=true`) and by watching
the emitted error surface change from the old fan-out guard message to a genuine ClickHouse
`MEMORY_LIMIT_EXCEEDED` (a different code path entirely) before narrowing the window below.

**The `ExpectedStatus` design call.** At the shared corpus window (~4h20m, 1m step, 3,741 series), the
corrected query — now routing through `RangeBucketGridNative` — genuinely **OOMs ClickHouse**:
`MEMORY_LIMIT_EXCEEDED` at ~99.9% of the 1 GiB cap, a real resource abort, not a deliberate pre-flight
rejection. `RangeBucketGridNative`'s emitter never calls `internal/chsql/lwr_fanout_bound.go`'s guard —
that guard is wired only into `RangeBucketFanout`'s collapse. Filed this as **#2486** with a real
calibration sweep. Given that, I did not keep the sentinel expecting 422 at the full window: unlike
the two existing `422` sentinels (a cheap, deliberate ~2s guard firing at 16-27% of cap), a near-cap
genuine abort also fails the harness's own PRONG (a) absolute-ceiling gate (85% of cap) — accepting it
as "the expected, passing behavior" isn't just philosophically wrong, it's not even mechanically stable
as a gate. Instead, added a per-sentinel window override (`Sentinel.WindowStart/WindowEnd/Step`, used
only when `WindowStart` is set — the other three sentinels are untouched, still sharing the corpus's
production window) and picked the safest point from a real calibration sweep:

| window @ 1m step | anchors | peak memory | % of cap |
|---|---|---|---|
| 5 min  | 5   | 462,554,931 B | 43.1% |
| 10 min | 10  | 579,252,712 B | 53.9% |
| 20 min | 20  | 777,250,946 B | 72.4% |
| 60 min | 60  | (aborted) | ~99.9% (genuine OOM) |
| ~4h20m | 260 | (aborted) | ~99.9% (genuine OOM) |

Memory grows steeply non-linearly with anchor count — even a fairly ordinary 20-minute/1m panel is
already uncomfortably close to the cap. Picked the 5-minute point: ~20 points of real margin under the
absolute ceiling even after the committed baseline's own 1.5x headroom, where 10 and 20 minutes did
not leave enough. This is itself real evidence #2486 is needed well below "obviously large" query
scale — posted as a calibration-data comment on that issue.

### Follow-up issues filed (found while fixing this, out of scope to fix here)

- **#2486** — `chplan.RangeBucketGridNative` has no resource-bound guard analogous to
  `lwr_fanout_bound.go`'s protection for `RangeBucketFanout`; genuinely OOMs ClickHouse at real, fairly
  ordinary production scale rather than being cleanly pre-flight-rejected.
- **#2487** — no real-ClickHouse integration lane in this repo exercises the native `ts_grid_*`
  Lowerers wiring outside a full `cmd/cerberus` binary boot; every `prom.New(...)`-based real-CH test
  (including this one, before this PR's narrow fix) is permanently fan-out-only regardless of the
  ClickHouse version it pins.

Related to #2408 — this PR fixes only the measurement infrastructure for it (the real-CH image floor
and the sentinel that's supposed to track it); #2408 itself stays open.

## Test plan

- [x] `internal/routerrules`'s two real-CH tests (`TestCorpusWriteReadRealClickHouse`,
      `TestQueryLogReadRealClickHouse`) pass against 25.9-alpine with real numbers (13 resolved
      params / 26 findings; 1 terminal row strict-scanned) — this lane is unrelated to histogram
      lowering, pinned only for cross-lane version consistency, so no other change was needed there.
- [x] `test/regression`'s `TestIntegrationImagePinsMatchTheJustfile` passes.
- [x] `TestPerfNightlyRealCH` passes end-to-end against real ClickHouse 25.9-alpine; all four
      sentinels correct (`classic_histogram_quantile_by_route` now 200 via the real native path at
      43.1% of cap; the other three sentinels unaffected across repeated runs, within normal
      run-to-run variance).
- [x] `test/perf/nightly-baseline.json` regenerated via
      `UPDATE_NIGHTLY_PERF_BASELINE=1 go test ...` (7 lines changed — exactly the four sentinels'
      calibrated numbers, diff reviewed by hand).
- [x] `gofumpt -l`, `go vet ./...`, and `go vet -tags=integration ./...` clean on the full tree.
- [x] Spot-checked the remaining bumped real-CH packages (chclient, schema/ddl, api/prom, api/tempo,
      optcorpus, solver, cmd/cerberus, test/spec, test/perf/smoke) against 25.9-alpine.
- [ ] CI green

## Notes for reviewers

The `ExpectedStatus`/window decision above is the one real judgment call in this PR — happy to discuss
if a different window or #2486-first sequencing seems better on review.
