### PR TITLE
fix(test): sort the reference oracle's samples with cerberus's labelKey

### DIFF
--- a/test/spec/parity_chdb.go
+++ b/test/spec/parity_chdb.go
@@ -838,6 +838,24 @@ func compareAgainstReference(
 		t.Fatalf("fixture %s: %v", c.Name, err)
 	}
 
+	// got arrives sorted by the reference oracle's OWN canonicalisation
+	// (Prometheus's `labels.Labels.String()`, e.g. Evaluate's sortResults),
+	// not cerberus's labelKey. The two disagree on where an EMPTY label set
+	// sorts relative to a non-empty one: Prometheus's bracketed form "{}"
+	// sorts after "{job=...}" (`}` > `j`), while labelKey's plain "" sorts
+	// before "job=...". referenceShapeOfExpectedRows above sorts want with
+	// labelKey, so re-sorting got the same way here is what keeps the
+	// position-wise comparison below meaningful whenever one side of a
+	// query (e.g. an `or` between a `sum by(...)` branch and a
+	// no-group-by branch) mixes an empty and a non-empty label set in one
+	// answer — the case that first exposed the mismatch.
+	sort.SliceStable(got, func(i, j int) bool {
+		if ki, kj := labelKey(got[i].Labels), labelKey(got[j].Labels); ki != kj {
+			return ki < kj
+		}
+		return got[i].TMillis < got[j].TMillis
+	})
+
 	if len(got) != len(want) {
 		t.Fatalf(
 			"fixture %s: reference engine returned %d sample(s), cerberus %d.\n"+


### PR DESCRIPTION
## Summary

`main`'s `chdb` and `coverage` workflows were red on
`TestLower/exp_histogram_set_op_or_mixed_sum_wrapped_windowed_float_range` and
`..._instant`. Both traced to the same root cause in the chDB parity comparator
(`test/spec/parity_chdb.go`), not a lowering bug — the underlying query answer was
already correct.

`compareAgainstReference` compares cerberus's recorded `expected_rows` against the live
Prometheus reference oracle's output position-by-position. `referenceShapeOfExpectedRows`
sorts the cerberus side with cerberus's own `labelKey` (an empty label set sorts as `""`,
before any non-empty key), but the reference side was left in the oracle's own
`sortResults` order (Prometheus's bracketed `labels.String()`, where `"{}"` sorts *after*
`"{job=...}"` since `}` > `j`). The two canonicalisations agree almost always, but disagree
whenever one side of a query mixes an empty and a non-empty label set in the same answer —
exactly what `sum by (job) (rate(...) or a_bucketless_histogram)` produces. The mismatch
showed up as two correctly-matching groups of 5 samples reported as "labels differ", not as
any actual value or label discrepancy.

Fix: sort the reference oracle's output with the same `labelKey` immediately before the
comparison, so both sides share one canonicalisation.

## Test plan

- [x] `go test -tags chdb -run '^TestLower$/^exp_histogram_set_op_or_mixed_sum_wrapped_windowed_float_(range|instant)$' ./internal/promql/...` — was 100% reproducible failing (3/3 runs), now passes.
- [x] The full `./test/spec/promql/... ./internal/promql/...` chdb lane (~950 fixtures, the exact scope of the failing `roundtrip (promql)` CI job) run locally with the fix.
- This PR's own `roundtrip (promql)` and `coverage` CI checks re-run the identical failing tests as independent confirmation.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
