### PR TITLE
fix(perf): tighten nightly headroom per-sentinel using measured noise

### DIFF
--- a/test/perf/nightly-baseline.json
+++ b/test/perf/nightly-baseline.json
@@ -3,26 +3,26 @@
     {
       "name": "classic_histogram_quantile_by_route",
       "expected_status": 200,
-      "max_of_n_bytes": 463466575,
-      "ceiling_bytes": 695199862
+      "max_of_n_bytes": 471533546,
+      "ceiling_bytes": 565840255
     },
     {
       "name": "request_rate_by_method",
       "expected_status": 422,
-      "max_of_n_bytes": 252364637,
-      "ceiling_bytes": 378546955
+      "max_of_n_bytes": 232981938,
+      "ceiling_bytes": 349472907
     },
     {
       "name": "pod_status_reason_gauge",
       "expected_status": 200,
-      "max_of_n_bytes": 823750613,
+      "max_of_n_bytes": 790107267,
       "ceiling_bytes": 912680550
     },
     {
       "name": "error_ratio_by_namespace",
       "expected_status": 422,
-      "max_of_n_bytes": 340975066,
-      "ceiling_bytes": 511462599
+      "max_of_n_bytes": 297180720,
+      "ceiling_bytes": 430912044
     }
   ]
 }

--- a/test/perf/nightly/realch_perfnightly_integration_test.go
+++ b/test/perf/nightly/realch_perfnightly_integration_test.go
@@ -44,7 +44,7 @@
 //     baseline-less sentinel.
 //   - PRONG (b): a committed per-sentinel ceiling in nightly-baseline.json,
 //     the calibration-time max-of-N measurement times a headroom multiplier
-//     (nightlyBaselineHeadroom) — tighter than PRONG (a), so it is what
+//     (Sentinel.BaselineHeadroom, per-sentinel) — tighter than PRONG (a), so it is what
 //     actually catches a real regression long before the absolute ceiling
 //     would.
 //
@@ -133,10 +133,14 @@ const perfNightlyMemoryCapBytes int64 = 1 << 30 // 1 GiB
 // staying meaningfully below ClickHouse's own 1.0 OOM boundary.
 const nightlyMemoryCapFraction = 0.85
 
-// nightlyBaselineHeadroom mirrors test/perf/smoke's sentinelBaselineHeadroom
-// (1.5x) — see its own comment for why a memory metric wants a tighter
-// multiplier than scale_wall_pin_chdb_test.go's noisier wall-clock prong.
-const nightlyBaselineHeadroom = 1.5
+// Per-sentinel committed-ceiling headroom multipliers used to be one
+// package-wide nightlyBaselineHeadroom constant (1.5x, mirroring
+// test/perf/smoke's sentinelBaselineHeadroom). A real noise investigation
+// found the four sentinels' run-to-run peak-memory variance differs by
+// nearly an order of magnitude, so a single multiplier was either too loose
+// for the quiet sentinels or flake-risked the noisy ones — see each
+// sentinel's own BaselineHeadroom field and sentinels.go's *BaselineHeadroom
+// constants for the real measurements backing each value.
 
 // nightlySentinelRepeats (N) mirrors test/perf/smoke's sentinelRepeats — a
 // ceiling gate wants the worst observed case, so max-of-N, never
@@ -306,7 +310,7 @@ func TestPerfNightlyRealCH(t *testing.T) {
 				// permanently unable to fire — a looser "tighter" check is a
 				// gate that silently never gates. PRONG (b) must never be
 				// looser than PRONG (a).
-				ceiling := min(uint64(float64(maxBytes)*nightlyBaselineHeadroom), capCeiling)
+				ceiling := min(uint64(float64(maxBytes)*sentinel.BaselineHeadroom), capCeiling)
 				updated[sentinel.Name] = nightlyBound{
 					Name: sentinel.Name, ExpectedStatus: sentinel.ExpectedStatus,
 					MaxOfNBytes: maxBytes, CeilingBytes: ceiling,
@@ -338,7 +342,7 @@ func TestPerfNightlyRealCH(t *testing.T) {
 				t.Errorf("%s: peak memory %d bytes exceeds the committed ceiling %d bytes (measured max-of-N was "+
 					"%d at calibration time, %.2fx headroom) — %s may have regressed; only run "+
 					"`just update-nightly-perf-baseline` if the increase is genuinely intended",
-					sentinel.Name, maxBytes, bound.CeilingBytes, bound.MaxOfNBytes, nightlyBaselineHeadroom, sentinel.Family)
+					sentinel.Name, maxBytes, bound.CeilingBytes, bound.MaxOfNBytes, sentinel.BaselineHeadroom, sentinel.Family)
 			}
 
 			// Every check above passed — this is the ONLY place Pass is set

--- a/test/perf/nightly/sentinels.go
+++ b/test/perf/nightly/sentinels.go
@@ -34,6 +34,60 @@ var (
 
 const sentinelStep = time.Minute
 
+// Per-sentinel committed-ceiling headroom multipliers, replacing a single
+// package-wide constant (formerly nightlyBaselineHeadroom, 1.5x for every
+// sentinel). A real noise investigation (issue #2370's headroom-tightening
+// follow-up) measured each sentinel's run-to-run peak-memory variance across
+// repeated, INDEPENDENT `go test -tags=integration -run TestPerfNightlyRealCH`
+// invocations (not just the in-test max-of-N sampling in
+// realch_perfnightly_integration_test.go, which only captures intra-process
+// variance) at the unmodified calibration point, and found the four
+// sentinels' noise floors differ by nearly an order of magnitude — far too
+// much for one multiplier to serve every sentinel honestly: tight enough to
+// catch a real ~25% regression on the quiet sentinels would flake constantly
+// on the noisy ones, and loose enough to never flake the noisy ones leaves
+// the quiet ones no tighter than before.
+//
+//   - histogramBaselineHeadroom (classic_histogram_quantile_by_route, n=5
+//     independent runs): 456.3M-471.0M bytes, max/min = 1.032x (CV 1.26%) —
+//     by far the quietest of the four. This is also the exact sentinel
+//     issue #2408's own investigation regression-tested (a real +24.6%
+//     window-widening regression that a 1.5x headroom passed cleanly), so
+//     it gets the tightest headroom: 1.20x leaves ~16% cushion over the
+//     observed swing while a worst-case calibration/regression draw still
+//     trips at ~+24% — squarely the target range.
+//   - gaugeBaselineHeadroom (pod_status_reason_gauge, n=5): 725.5M-817.7M
+//     bytes, max/min = 1.127x (CV 4.48%). Real memory usage here already
+//     sits at 78-88% of the 1 GiB cap — nightlyMemoryCapFraction (0.85, see
+//     its own comment in realch_perfnightly_integration_test.go) caps the
+//     committed ceiling at 912,680,550 bytes regardless of this multiplier
+//     for ANY headroom above ~1.12x, which the observed noise itself
+//     (1.127x) does not leave enough cushion below to use safely. This
+//     sentinel's real regression protection is PRONG (a)'s absolute cap,
+//     not this constant, so it is left unchanged at 1.5x rather than
+//     pretend a tightened value here buys any real sensitivity — see
+//     issue #2435 for the cap-fraction margin itself.
+//   - requestRateBaselineHeadroom (request_rate_by_method, n=8): 235.1M-
+//     313.4M bytes, max/min = 1.333x (CV 10.45%) — an ExpectedStatus=422
+//     sentinel: "peak memory" is memory used BEFORE the rate-window fanout
+//     bound rejects the query, not a completed query's memory, and that
+//     early-abort point is inherently noisier (scan-ordering/scheduling
+//     dependent) than the two 200-status sentinels above. Left unchanged at
+//     1.5x: the observed worst-case swing alone consumes most of that
+//     headroom (1.5x / 1.333x = 1.125x real cushion), and tightening
+//     further risks flaking on exactly the noise this measurement found.
+//   - errorRatioBaselineHeadroom (error_ratio_by_namespace, n=8): 269.9M-
+//     340.5M bytes, max/min = 1.262x (CV 8.93%) — same rejection-noise
+//     character as request_rate_by_method, modestly less noisy. Tightened
+//     to 1.45x, keeping ~15% real cushion over the observed swing
+//     (1.45x / 1.262x = 1.149x).
+const (
+	histogramBaselineHeadroom   = 1.20
+	gaugeBaselineHeadroom       = 1.50
+	requestRateBaselineHeadroom = 1.50
+	errorRatioBaselineHeadroom  = 1.45
+)
+
 // Sentinel describes one real-data query the nightly harness issues and the
 // construct family it exercises. Unlike test/perf/smoke's fixed 3-sentinel
 // set (each calibrated to trip one specific memory-bounding mechanism on
@@ -74,6 +128,12 @@ type Sentinel struct {
 	WindowStart time.Time
 	WindowEnd   time.Time
 	Step        time.Duration
+	// BaselineHeadroom is this sentinel's own committed-ceiling multiplier
+	// against the max-of-N calibration measurement — see the
+	// *BaselineHeadroom constants above for the real, independent-process
+	// noise data each value is calibrated against, and why a single
+	// package-wide multiplier does not fit all four sentinels.
+	BaselineHeadroom float64
 }
 
 // Sentinels is PR A's "prove the mechanism, print the numbers" corpus — no
@@ -121,13 +181,14 @@ var Sentinels = []Sentinel{
 		// the cap. 5 anchors leaves ~20 points of margin under
 		// nightlyMemoryCapFraction even after the committed baseline's own
 		// 1.5x headroom, which the 10- and 20-anchor points do not.
-		Name:           "classic_histogram_quantile_by_route",
-		Family:         "histogram_quantile over a classic (bucket/bounds) histogram — issue #2408's arrayJoin bucket-rate fan-out",
-		Path:           "/api/v1/query_range",
-		ExpectedStatus: http.StatusOK,
-		WindowStart:    time.Date(2026, 8, 18, 9, 5, 0, 0, time.UTC),
-		WindowEnd:      time.Date(2026, 8, 18, 9, 10, 0, 0, time.UTC),
-		Step:           time.Minute,
+		Name:             "classic_histogram_quantile_by_route",
+		Family:           "histogram_quantile over a classic (bucket/bounds) histogram — issue #2408's arrayJoin bucket-rate fan-out",
+		Path:             "/api/v1/query_range",
+		ExpectedStatus:   http.StatusOK,
+		WindowStart:      time.Date(2026, 8, 18, 9, 5, 0, 0, time.UTC),
+		WindowEnd:        time.Date(2026, 8, 18, 9, 10, 0, 0, time.UTC),
+		Step:             time.Minute,
+		BaselineHeadroom: histogramBaselineHeadroom,
 		Params: func(start, end time.Time) url.Values {
 			return url.Values{
 				"query": {`histogram_quantile(0.95, sum by (http_route, le) (rate(` + histogramMetric + `_bucket[5m])))`},
@@ -152,6 +213,7 @@ var Sentinels = []Sentinel{
 		Path:                   "/api/v1/query_range",
 		ExpectedStatus:         http.StatusUnprocessableEntity,
 		ExpectedErrorSubstring: chsql.RateWindowFanoutBudgetMessage,
+		BaselineHeadroom:       requestRateBaselineHeadroom,
 		Params: func(start, end time.Time) url.Values {
 			return url.Values{
 				"query": {`sum by (method) (rate(` + sumMetric + `[5m]))`},
@@ -159,10 +221,11 @@ var Sentinels = []Sentinel{
 		},
 	},
 	{
-		Name:           "pod_status_reason_gauge",
-		Family:         "Gauge aggregation — signal type the smoke tier has zero coverage of",
-		Path:           "/api/v1/query_range",
-		ExpectedStatus: http.StatusOK,
+		Name:             "pod_status_reason_gauge",
+		Family:           "Gauge aggregation — signal type the smoke tier has zero coverage of",
+		Path:             "/api/v1/query_range",
+		ExpectedStatus:   http.StatusOK,
+		BaselineHeadroom: gaugeBaselineHeadroom,
 		Params: func(start, end time.Time) url.Values {
 			return url.Values{
 				"query": {`sum by (reason) (` + gaugeMetric + `)`},
@@ -184,6 +247,7 @@ var Sentinels = []Sentinel{
 		Path:                   "/api/v1/query_range",
 		ExpectedStatus:         http.StatusUnprocessableEntity,
 		ExpectedErrorSubstring: chsql.RateWindowFanoutBudgetMessage,
+		BaselineHeadroom:       errorRatioBaselineHeadroom,
 		Params: func(start, end time.Time) url.Values {
 			return url.Values{
 				"query": {

--- a/test/perf/nightly/sentinels_test.go
+++ b/test/perf/nightly/sentinels_test.go
@@ -32,6 +32,11 @@ func TestSentinels_Roster(t *testing.T) {
 		if s.Params == nil {
 			t.Fatalf("sentinel %s has nil Params", s.Name)
 		}
+		if s.BaselineHeadroom <= 1.0 {
+			t.Fatalf("sentinel %s has BaselineHeadroom %v, want > 1.0 — a zero/blank value would silently "+
+				"compute a committed ceiling at or below the calibration measurement itself, permanently failing PRONG (b)",
+				s.Name, s.BaselineHeadroom)
+		}
 		params := s.Params(sampleWindowStart, sampleWindowEnd)
 		if params.Get("query") == "" {
 			t.Fatalf("sentinel %s produced an empty query", s.Name)


### PR DESCRIPTION
## Summary

A prior investigation of `test/perf/nightly/`'s regression gate found `nightlyBaselineHeadroom`
(a single package-wide 1.5x multiplier) too loose: a real, deliberate +24.6% memory regression on
`classic_histogram_quantile_by_route` (via widening its query window, a realistic regression
vector) passed the gate cleanly with comfortable margin, and even a +42.6% regression barely
tripped it. The gate only fired at +64.5%.

This PR measures the real noise floor with repeated, **independent-process** runs (not just the
in-test max-of-N sampling, which only captures intra-process variance) and retightens the headroom
using that data, per sentinel.

## Real noise measurements

5-8 separate `go test -timeout 20m -tags=integration -count=1 -run '^TestPerfNightlyRealCH$' ./test/perf/nightly/...`
invocations per sentinel, at the unmodified calibration point:

| Sentinel | n | min bytes | max bytes | mean | max/min | CV (stdev/mean) |
|---|---|---|---|---|---|---|
| `classic_histogram_quantile_by_route` | 5 | 456.3M | 471.0M | 464.3M | **1.032x** | 1.26% |
| `pod_status_reason_gauge` | 5 | 725.5M | 817.7M | 785.0M | **1.127x** | 4.48% |
| `request_rate_by_method` | 8 | 235.1M | 313.4M | 265.9M | **1.333x** | 10.45% |
| `error_ratio_by_namespace` | 8 | 269.9M | 340.5M | 301.7M | **1.262x** | 8.93% |

The two `ExpectedStatus=200` sentinels (complete a real query) are far quieter than the two
`ExpectedStatus=422` sentinels (rejected by the rate-window fanout bound before the expensive
stage runs) — "peak memory at rejection" is inherently noisier (scan-ordering/scheduling
dependent) than a completed query's memory. This is a real, order-of-magnitude difference in
noise floor across the four sentinels, which is why a single global constant can't serve all four
honestly.

## Design: per-sentinel headroom, not a single constant

Added a `BaselineHeadroom float64` field to the `Sentinel` struct (`test/perf/nightly/sentinels.go`),
replacing the single `nightlyBaselineHeadroom` constant. Chosen values, each with real margin over
the measured noise:

- **`classic_histogram_quantile_by_route`: 1.20x** (was 1.5x) — the quietest sentinel by far
  (max/min 1.032x), and the exact one the prior investigation regression-tested. 1.20x leaves
  ~16% cushion over the observed swing.
- **`error_ratio_by_namespace`: 1.45x** (was 1.5x) — modest tightening, keeping ~15% real cushion
  over its 1.262x observed swing.
- **`request_rate_by_method`: 1.5x, unchanged** — its 1.333x observed max/min swing over 8
  independent runs already consumes most of a 1.5x headroom (1.5/1.333 = 1.125x real cushion);
  tightening further risks flaking on exactly the noise this measurement found.
- **`pod_status_reason_gauge`: 1.5x, unchanged (see note below)**.

### Why `pod_status_reason_gauge` doesn't tighten

This sentinel's real memory usage (725-818M) already sits at 78-88% of the 1 GiB memory cap.
`nightlyMemoryCapFraction` (0.85, unchanged here — its own rationale is documented in the closed
issue #2435) caps
PRONG (a)'s absolute ceiling at 912,680,550 bytes. Any headroom above ~1.12x multiplies the
calibration measurement past that absolute cap, so PRONG (b) clamps to the same 912,680,550 value
regardless of the exact headroom picked — confirmed in the regenerated baseline (`ceiling_bytes`
for this sentinel is `912680550`, exactly `nightlyMemoryCapFraction * 1 GiB`, both before and
after this PR). A headroom tight enough to escape the clamp (below ~1.12x) sits inside this
sentinel's own observed 1.127x noise swing and would flake. This sentinel's real regression
protection already comes from PRONG (a)'s absolute cap, independent of `BaselineHeadroom` — so the
constant is left unchanged rather than pretending a tightened value buys real sensitivity.

## Sensitivity: before vs after

Validated with the exact same regression-injection technique the prior investigation used:
widened `classic_histogram_quantile_by_route`'s window from 5 to 10 minutes on a throwaway local
diff (reverted before this commit — not part of the diff you're reviewing).

- **Before (1.5x headroom):** a +24.6% real regression passed cleanly; the gate only fired at
  +64.5%.
- **After (1.20x headroom):** the same style of regression (measured 588,964,468 bytes vs. a
  471,533,546-byte calibration, a real **+24.9%**) now fails the gate — `peak memory 588964468
  bytes exceeds the committed ceiling 565840255 bytes`. Under the *old* 1.5x headroom this same
  measurement would need to exceed 707,300,319 bytes to fail — nowhere close, confirming it would
  have passed cleanly as before.

This lands squarely in the target 20-30% sensitivity range for the sentinel the original
investigation was built around.

## Changes

- `test/perf/nightly/sentinels.go` — new `BaselineHeadroom` field on `Sentinel`, four named
  `*BaselineHeadroom` constants with the real measurements backing each value.
- `test/perf/nightly/realch_perfnightly_integration_test.go` — ceiling computation and the
  regression-failure message now use `sentinel.BaselineHeadroom` instead of the removed
  `nightlyBaselineHeadroom` constant.
- `test/perf/nightly/sentinels_test.go` — `TestSentinels_Roster` now asserts every sentinel has a
  `BaselineHeadroom > 1.0`, so a blank/zero value (which would silently make PRONG (b) impossible
  to pass) fails fast in the default (non-integration) build.
- `test/perf/nightly-baseline.json` — regenerated via
  `UPDATE_NIGHTLY_PERF_BASELINE=1 go test -timeout 15m -tags=integration -count=1 -run '^TestPerfNightlyRealCH$' ./test/perf/nightly/...`
  (invariant 9 — never hand-edited). Re-ran twice more without the update flag to confirm the
  retightened gate is stable (no flakes) at the new headroom values.

## Test plan

- [x] `go build ./...`, `go vet ./...`, `go vet -tags=integration ./...` clean.
- [x] `go test -run '^TestSentinels_'` (default build) — the new `BaselineHeadroom` guard passes.
- [x] 5-8 independent full-harness runs per sentinel at the unmodified calibration point, to
      measure real run-to-run noise (see table above).
- [x] Baseline regenerated with `UPDATE_NIGHTLY_PERF_BASELINE=1`; re-run twice more without the
      update flag — both PASS, no flakes.
- [x] Regression-injection validation (throwaway diff, reverted): confirmed the retightened gate
      fires at ~+24.9% versus the prior +64.5% floor.

