### PR TITLE
fix(promql): support ts_of_first/last/max/min_over_time over exp-histograms

### DIFF
--- a/internal/chplan/fn.go
+++ b/internal/chplan/fn.go
@@ -444,6 +444,13 @@ const (
 	// toMonth(d) — d's calendar month (1-12).
 	FnToMonth Fn = "toMonth"
 
+	// toUnixTimestamp64Milli(dt) — dt (DateTime64) as an Int64 count of
+	// milliseconds since the Unix epoch, TRUNCATING any sub-millisecond
+	// tail. Used wherever a DateTime64(9) column must be compared against
+	// Prometheus's own millisecond-resolution Point.T rather than leaking
+	// nanosecond precision Prom never has.
+	FnToUnixMillis Fn = "toUnixTimestamp64Milli"
+
 	// toUnixTimestamp64Nano(dt) — dt (DateTime64) as an Int64 count of nanoseconds
 	// since the Unix epoch.
 	FnToUnixNanos Fn = "toUnixTimestamp64Nano"

--- a/internal/chsql/fnresolution.go
+++ b/internal/chsql/fnresolution.go
@@ -158,6 +158,7 @@ var fnResolutions = map[chplan.Fn]fnResolution{
 	chplan.FnToLastDayOfMonth: {Name: "toLastDayOfMonth"},
 	chplan.FnToMinute:         {Name: "toMinute"},
 	chplan.FnToMonth:          {Name: "toMonth"},
+	chplan.FnToUnixMillis:     {Name: "toUnixTimestamp64Milli"},
 	chplan.FnToUnixNanos:      {Name: "toUnixTimestamp64Nano"},
 	chplan.FnToYear:           {Name: "toYear"},
 

--- a/internal/promql/histogram_native_ts_of_first_last_over_time.go
+++ b/internal/promql/histogram_native_ts_of_first_last_over_time.go
@@ -1,0 +1,251 @@
+package promql
+
+import (
+	"github.com/prometheus/prometheus/promql/parser"
+
+	"github.com/tsouza/cerberus/internal/chplan"
+	"github.com/tsouza/cerberus/internal/schema"
+)
+
+// histogram_native_ts_of_first_last_over_time.go lowers
+// `ts_of_first_over_time(<exp-histogram selector>[range])` /
+// `ts_of_last_over_time(<exp-histogram selector>[range])` (cerberus issue
+// #2482, the ts_of_first/ts_of_last half — see
+// range_fns.go's rangeVectorFloatOnlyDropFuncs for the ts_of_max/ts_of_min
+// half, which joins the existing DROP class instead of needing a file of
+// its own).
+//
+// Reference (tsouza/prometheus@cerberus-parser promql/functions.go,
+// funcTsOfFirstOverTime / funcTsOfLastOverTime — cited in full in cerberus
+// issue #2482):
+//
+//	var tf int64 = math.MaxInt64   // funcTsOfFirstOverTime; = 0 for Last
+//	if len(el.Floats) > 0 { tf = el.Floats[0].T }        // [len-1].T for Last
+//	var th int64 = math.MaxInt64   // = 0 for Last
+//	if len(el.Histograms) > 0 { th = el.Histograms[0].T }  // [len-1].T for Last
+//	return Sample{Metric: el.Metric, F: float64(min(tf, th)) / 1000}  // max(...) for Last
+//
+// i.e. the EARLIER (first) / LATER (last) of the window's own float and
+// histogram timestamps, reported as an epoch-SECONDS float. Over a window
+// holding EXCLUSIVELY histogram samples (the one shape a bare exp-histogram
+// selector can ever produce — cerberus never mixes a metric's samples
+// across the float and exp-histogram tables), tf's sentinel default drops
+// out of the min/max entirely: `min(tf, th) == th` for ts_of_first
+// (real millisecond timestamps are always < math.MaxInt64), and
+// `max(tf, th) == th` for ts_of_last (real timestamps are always > the
+// zero sentinel), so both reduce to just the histogram's own EARLIEST
+// (first) / LATEST (last) in-window sample timestamp — the exact same
+// argMin/argMax-by-TimeUnix selection direction
+// histogram_native_last_first_over_time.go's last_over_time/first_over_time
+// already apply, just reporting the picked TIMESTAMP itself as the output
+// VALUE instead of preserving the picked sample.
+//
+// `__name__` is dropped, NOT preserved, despite `Sample{Metric: el.Metric,
+// ...}` appearing to keep it: reference Prometheus's engine strips
+// `__name__` from EVERY range-vector function's output except literally
+// `last_over_time` / `first_over_time` (tsouza/prometheus's
+// promql/engine.go:2114 — `dropName := (e.Func.Name != "last_over_time" &&
+// e.Func.Name != "first_over_time")` — this cerberus package's own
+// [rangeFnPreservesName] already encodes that exact exception list for the
+// classic float path), so `ts_of_first_over_time` / `ts_of_last_over_time`
+// hit dropName=true regardless of what the function body itself assigns to
+// Sample.Metric. Verified directly against cerberus's own EXISTING classic
+// (plain-float) lowering for these two functions
+// (test/spec/promql/ts_of_first_over_time.txtar's `-- expected_rows --`
+// carries no metric name, and its `-- chplan --` / `-- sql --` project only
+// (Attributes, Value) — no MetricName column at all) rather than trusting
+// the "PRESERVED" claim in cerberus issue #2482's own filing text, which
+// read only the function body and missed the engine-level dropName
+// override; this file's exp-histogram lowering matches that VERIFIED
+// existing behaviour instead.
+//
+// The plan shape mirrors [lowerTimestampOverExpHistogramBareSelector]
+// (histogram_native_timestamp.go) rung for rung — same three range-grid
+// branches, same instant-vs-range projection split, same ms-truncated
+// epoch-seconds value expression — differing only in: the window bound is
+// `ms.Range` (matching last_over_time/first_over_time's own windowed
+// selection) rather than the fixed staleness lookback `timestamp()` uses,
+// and the picked-sample aggregate is directional (MIN for first, MAX for
+// last) rather than always the newest sample.
+const (
+	tsOfFirstOverTimeExpHistFn = "ts_of_first_over_time"
+	tsOfLastOverTimeExpHistFn  = "ts_of_last_over_time"
+)
+
+// tsOfFirstLastOverExpHistogram recognises `ts_of_first_over_time(<selector>[r])`
+// / `ts_of_last_over_time(<selector>[r])` where the selector names an
+// exp-histogram metric — the one shape this file answers. Mirrors
+// [lastFirstOverExpHistogram]'s own recognizer shape rung for rung,
+// differing only in which two function names it admits.
+func tsOfFirstLastOverExpHistogram(expr parser.Expr, s schema.Metrics, ctx lowerCtx) (fn string, ms *parser.MatrixSelector, vs *parser.VectorSelector, ok bool) {
+	if s.ExpHistogramTable == "" || ctx.metadataFullRange {
+		return "", nil, nil, false
+	}
+	call, ok := peelWrappers(expr).(*parser.Call)
+	if !ok || (call.Func.Name != tsOfFirstOverTimeExpHistFn && call.Func.Name != tsOfLastOverTimeExpHistFn) || len(call.Args) != 1 {
+		return "", nil, nil, false
+	}
+	ms, ok = peelWrappers(call.Args[0]).(*parser.MatrixSelector)
+	if !ok || ms.Range <= 0 {
+		return "", nil, nil, false
+	}
+	vs, ok = peelWrappers(ms.VectorSelector).(*parser.VectorSelector)
+	if !ok || !s.IsExpHistogramMetric(metricNameFromMatchers(vs.LabelMatchers)) {
+		return "", nil, nil, false
+	}
+	return call.Func.Name, ms, vs, true
+}
+
+// tsOfSampleTimestampAlias names the one column
+// [tsOfSampleTimestampAgg] adds: the raw, direction-selected TimeUnix of
+// the picked sample. Deliberately distinct from both s.TimestampColumn
+// (the RANGE-mode branches use it for the STEP ANCHOR — see
+// [tsOfRangeProjection]) and [stepGridAnchorColumn], mirroring
+// [expHistogramSampleTimestampAlias]'s own reasoning.
+const tsOfSampleTimestampAlias = "ts_of_exp_hist_sample_ts"
+
+// tsOfSampleTimestampAgg is the aggregate ts_of_first_over_time /
+// ts_of_last_over_time need from a bare exp-histogram selector: just the
+// direction-selected raw TimeUnix — MIN (earliest) for
+// ts_of_first_over_time, MAX (latest) for ts_of_last_over_time. Unlike
+// [nativeExpHistBareAggsDirectional] this never reads a single field of
+// the histogram itself (bucket ladder, count, sum): the reported VALUE is
+// the timestamp, not the histogram, so a plain MIN/MAX suffices — no
+// argMin/argMax-by-TimeUnix column correlation is needed.
+func tsOfSampleTimestampAgg(fn string, s schema.Metrics) []chplan.AggFunc {
+	aggFn := chplan.FnMax
+	if fn == tsOfFirstOverTimeExpHistFn {
+		aggFn = chplan.FnMin
+	}
+	return []chplan.AggFunc{
+		{
+			Fn:    aggFn,
+			Args:  []chplan.Expr{&chplan.ColumnRef{Name: s.TimestampColumn}},
+			Alias: tsOfSampleTimestampAlias,
+		},
+	}
+}
+
+// lowerTsOfFirstLastOverExpHistogram lowers the recognised shape across
+// the three evaluation grids [rangeGridShapeFor] distinguishes — see
+// [lowerExpHistogramBare] for what each means.
+func lowerTsOfFirstLastOverExpHistogram(fn string, ms *parser.MatrixSelector, vs *parser.VectorSelector, s schema.Metrics, ctx lowerCtx) (chplan.Node, error) {
+	switch rangeGridShapeFor(vs, ctx) {
+	case gridFanout:
+		scan := &chplan.Scan{Table: s.ExpHistogramTable}
+		pred := buildPredicate(vs.LabelMatchers, s)
+		fanout := buildHistogramBucketFanout(
+			scan, pred, nil, windowFor(vs, ms.Range),
+			[]chplan.Expr{histogramIdentityExpr(s)}, []string{s.AttributesColumn},
+			tsOfSampleTimestampAgg(fn, s), s, ctx,
+		)
+		return tsOfRangeProjection(fanout, s), nil
+	case gridBroadcast:
+		// Same split as [lowerTimestampOverExpHistogramBareSelector]'s own
+		// gridBroadcast arm: the pinned window is resolved ONCE via the
+		// instant-mode aggregate, then fanned across the step grid — every
+		// step reports the SAME picked sample's timestamp value, at its
+		// own step position.
+		selected, err := tsOfSampleTimestampSelected(fn, ms, vs, s, ctx)
+		if err != nil {
+			return nil, err
+		}
+		grid := &chplan.StepGrid{Start: ctx.start.UTC(), End: ctx.end.UTC(), Step: ctx.step}
+		return tsOfRangeProjection(&chplan.CrossJoin{Left: grid, Right: selected}, s), nil
+	default:
+		selected, err := tsOfSampleTimestampSelected(fn, ms, vs, s, ctx)
+		if err != nil {
+			return nil, err
+		}
+		return tsOfInstantProjection(selected, s), nil
+	}
+}
+
+// tsOfSampleTimestampSelected builds the instant-mode subtree beneath
+// [lowerTsOfFirstLastOverExpHistogram]'s single-anchor and gridBroadcast
+// branches: the filtered exp-histogram scan, windowed to `(anchor -
+// ms.Range, anchor]` (the same window [expHistogramLastFirstWindowed]
+// applies), collapsed to one row per series via [tsOfSampleTimestampAgg]'s
+// direction-selected MIN/MAX.
+func tsOfSampleTimestampSelected(fn string, ms *parser.MatrixSelector, vs *parser.VectorSelector, s schema.Metrics, ctx lowerCtx) (chplan.Node, error) {
+	anchor, err := selectorAnchor(vs, ctx)
+	if err != nil {
+		return nil, err
+	}
+	pred := buildPredicate(vs.LabelMatchers, s)
+	pred = andExpr(pred, timeBoundExpr(s.TimestampColumn, anchor))
+	pred = andExpr(pred, stalenessLowerBoundExpr(s.TimestampColumn, anchor, ms.Range))
+	var input chplan.Node = &chplan.Scan{Table: s.ExpHistogramTable}
+	if pred != nil {
+		input = &chplan.Filter{Input: input, Predicate: pred}
+	}
+	return latestSampleAgg(input, tsOfSampleTimestampAgg(fn, s), s), nil
+}
+
+// tsOfInstantProjection projects the INSTANT-mode picked-timestamp
+// aggregate into the canonical float Sample shape ts_of_first_over_time /
+// ts_of_last_over_time report: `__name__` drops (see this file's doc for
+// why, despite reference's Sample literal appearing to preserve it), the
+// reported TimeUnix is the evaluation instant (matching the classic
+// plain-float path's own reported timestamp for these two functions —
+// neither is in [rangeFnPreservesName], so neither gets a raw-sample
+// timestamp column of its own), and the Value is the picked sample's own
+// timestamp, converted to ms-precision epoch seconds via
+// [tsOfEpochSecondsExpr].
+func tsOfInstantProjection(inner chplan.Node, s schema.Metrics) chplan.Node {
+	ts := &chplan.ColumnRef{Name: tsOfSampleTimestampAlias}
+	return &chplan.Project{
+		Input: inner,
+		Projections: []chplan.Projection{
+			{Expr: &chplan.LitString{V: ""}, Alias: s.MetricNameColumn},
+			{Expr: &chplan.ColumnRef{Name: s.AttributesColumn}, Alias: s.AttributesColumn},
+			{Expr: chplan.NowNano(), Alias: s.TimestampColumn},
+			{Expr: tsOfEpochSecondsExpr(ts), Alias: s.ValueColumn},
+		},
+	}
+}
+
+// tsOfRangeProjection projects a RANGE-mode plan — either
+// [buildHistogramBucketFanout]'s per-(series,anchor) fan-out or the
+// gridBroadcast CrossJoin — into the canonical float Sample shape. The
+// reported TimeUnix is the STEP ANCHOR (every range-mode row is positioned
+// along the matrix by its anchor, matching every other range-mode
+// exp-histogram consumer); the Value stays the picked sample's own
+// timestamp via [tsOfSampleTimestampAlias].
+func tsOfRangeProjection(inner chplan.Node, s schema.Metrics) chplan.Node {
+	anchor := &chplan.ColumnRef{Name: stepGridAnchorColumn}
+	rawTs := &chplan.ColumnRef{Name: tsOfSampleTimestampAlias}
+	return &chplan.Project{
+		Input: inner,
+		Projections: []chplan.Projection{
+			{Expr: &chplan.LitString{V: ""}, Alias: s.MetricNameColumn},
+			{Expr: &chplan.ColumnRef{Name: s.AttributesColumn}, Alias: s.AttributesColumn},
+			{Expr: anchor, Alias: s.TimestampColumn},
+			{Expr: tsOfEpochSecondsExpr(rawTs), Alias: s.ValueColumn},
+		},
+	}
+}
+
+// tsOfEpochSecondsExpr renders `toFloat64(toUnixTimestamp64Milli(<ts>)) /
+// 1000` — the DateTime64(9) → epoch-seconds (ms-precision) conversion
+// ts_of_first_over_time / ts_of_last_over_time report, chplan-Expr-level
+// mirror of chsql's [chsql.tsEpochSecondsFrag] (the classic plain-float
+// path's own identical conversion — see that function's doc for why
+// TRUNCATING to milliseconds first, rather than dividing a nanosecond
+// count by 1e9, is the correct match for Prometheus's own
+// millisecond-resolution Point.T: a plain nanosecond division would leak
+// sub-millisecond precision from the exp-histogram table's DateTime64(9)
+// column that Prometheus's own int64-millisecond Sample.T never carries,
+// diverging from reference on data with genuine sub-ms timestamps even
+// though the classic float path (fed the identical seed data) would not).
+func tsOfEpochSecondsExpr(ts chplan.Expr) chplan.Expr {
+	const millisPerSecond = 1000
+	return &chplan.Binary{
+		Op: chplan.OpDiv,
+		Left: &chplan.FuncCall{
+			Fn:   chplan.FnToFloat64,
+			Args: []chplan.Expr{&chplan.FuncCall{Fn: chplan.FnToUnixMillis, Args: []chplan.Expr{ts}}},
+		},
+		Right: &chplan.LitFloat{V: float64(millisPerSecond)},
+	}
+}

--- a/internal/promql/histogram_native_ts_of_first_last_over_time_test.go
+++ b/internal/promql/histogram_native_ts_of_first_last_over_time_test.go
@@ -1,0 +1,190 @@
+package promql_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/prometheus/prometheus/promql/parser"
+
+	"github.com/tsouza/cerberus/internal/chplan"
+	"github.com/tsouza/cerberus/internal/chsql"
+	"github.com/tsouza/cerberus/internal/promql"
+	"github.com/tsouza/cerberus/internal/schema"
+)
+
+// TestLower_ExpHistogram_TsOfFirstLastOverTime pins cerberus issue #2482's
+// ts_of_first_over_time / ts_of_last_over_time half: over a bare
+// exp-histogram matrix selector, reference Prometheus's
+// funcTsOfFirstOverTime / funcTsOfLastOverTime reduce to the window's own
+// earliest / latest histogram-sample timestamp (see
+// histogram_native_ts_of_first_last_over_time.go's doc for the full
+// min(tf,th)/max(tf,th) derivation) reported as a float epoch-seconds
+// VALUE with `__name__` dropped. Every representative shape below must
+// lower successfully to the canonical float [chplan.SampleRowShape], both
+// in instant and range mode, and the produced SQL must actually compile
+// through the chsql emitter — the exact shape that used to hit
+// expHistogramSelectorRouting's catch-all rejection instead.
+func TestLower_ExpHistogram_TsOfFirstLastOverTime(t *testing.T) {
+	t.Parallel()
+
+	s := schema.DefaultOTelMetrics()
+	p := parser.NewParser(parser.Options{EnableExperimentalFunctions: true})
+	at := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	start := at.Add(-time.Hour)
+
+	cases := []struct {
+		name  string
+		query string
+	}{
+		{
+			name:  "issue representative query: ts_of_first_over_time",
+			query: `ts_of_first_over_time(demo_latency_exp_hist[5m])`,
+		},
+		{
+			name:  "issue representative query: ts_of_last_over_time",
+			query: `ts_of_last_over_time(demo_latency_exp_hist[5m])`,
+		},
+		{
+			name:  "ts_of_first_over_time with label matcher",
+			query: `ts_of_first_over_time(demo_latency_exp_hist{service="api"}[5m])`,
+		},
+		{
+			name:  "ts_of_last_over_time with label matcher",
+			query: `ts_of_last_over_time(demo_latency_exp_hist{service="api"}[5m])`,
+		},
+		{
+			name:  "parenthesised call",
+			query: `(ts_of_first_over_time(demo_latency_exp_hist[5m]))`,
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name+"/instant", func(t *testing.T) {
+			t.Parallel()
+			expr, err := p.ParseExpr(tc.query)
+			if err != nil {
+				t.Fatalf("ParseExpr(%q): %v", tc.query, err)
+			}
+			plan, err := promql.LowerAt(context.Background(), expr, s, at, at)
+			if err != nil {
+				t.Fatalf("LowerAt(%q): unexpected error: %v", tc.query, err)
+			}
+			if shape := chplan.RowShapeOf(plan); shape != chplan.SampleRowShape {
+				t.Fatalf("lower(%q): plan root publishes %s, want %s", tc.query, shape, chplan.SampleRowShape)
+			}
+			if _, _, err := chsql.Emit(context.Background(), plan); err != nil {
+				t.Fatalf("chsql.Emit(%q): %v", tc.query, err)
+			}
+		})
+		t.Run(tc.name+"/range", func(t *testing.T) {
+			t.Parallel()
+			expr, err := p.ParseExpr(tc.query)
+			if err != nil {
+				t.Fatalf("ParseExpr(%q): %v", tc.query, err)
+			}
+			plan, err := promql.LowerAtRange(context.Background(), expr, s, start, at, 30*time.Second)
+			if err != nil {
+				t.Fatalf("LowerAtRange(%q): unexpected error: %v", tc.query, err)
+			}
+			if shape := chplan.RowShapeOf(plan); shape != chplan.SampleRowShape {
+				t.Fatalf("lower(%q) range: plan root publishes %s, want %s", tc.query, shape, chplan.SampleRowShape)
+			}
+			if _, _, err := chsql.Emit(context.Background(), plan); err != nil {
+				t.Fatalf("chsql.Emit(%q) range: %v", tc.query, err)
+			}
+		})
+	}
+}
+
+// TestLower_ExpHistogram_TsOfFirstLastOverTime_AtPin covers the
+// range-query, `@`-pinned (gridBroadcast) shape for a bare exp-histogram
+// selector: the pinned window is resolved once and its picked sample's
+// timestamp value is fanned across the step grid, at each step's own
+// anchor position — mirroring TestLower_ExpHistogram_Timestamp_AtPin.
+func TestLower_ExpHistogram_TsOfFirstLastOverTime_AtPin(t *testing.T) {
+	t.Parallel()
+
+	s := schema.DefaultOTelMetrics()
+	p := parser.NewParser(parser.Options{EnableExperimentalFunctions: true})
+	at := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	start := at.Add(-time.Hour)
+
+	for _, query := range []string{
+		`ts_of_first_over_time(demo_latency_exp_hist[5m] @ 1735689600)`,
+		`ts_of_last_over_time(demo_latency_exp_hist[5m] @ 1735689600)`,
+	} {
+		query := query
+		t.Run(query, func(t *testing.T) {
+			t.Parallel()
+			expr, err := p.ParseExpr(query)
+			if err != nil {
+				t.Fatalf("ParseExpr(%q): %v", query, err)
+			}
+			plan, err := promql.LowerAtRange(context.Background(), expr, s, start, at, 30*time.Second)
+			if err != nil {
+				t.Fatalf("LowerAtRange(%q): unexpected error: %v", query, err)
+			}
+			if shape := chplan.RowShapeOf(plan); shape != chplan.SampleRowShape {
+				t.Fatalf("lower(%q): plan root publishes %s, want %s", query, shape, chplan.SampleRowShape)
+			}
+			if _, _, err := chsql.Emit(context.Background(), plan); err != nil {
+				t.Fatalf("chsql.Emit(%q): %v", query, err)
+			}
+		})
+	}
+}
+
+// TestLower_ExpHistogram_TsOfFirstLastOverTime_NameDropped pins the
+// __name__-handling half of cerberus issue #2482's finding: despite
+// reference Prometheus's funcTsOfFirstOverTime / funcTsOfLastOverTime
+// literally assigning `Sample{Metric: el.Metric, ...}`, the engine's
+// separate dropName gate (promql/engine.go:2114) strips it for every
+// function except literally "last_over_time"/"first_over_time" — so the
+// projected MetricName here must be the empty-string literal, matching
+// cerberus's own existing (verified) classic float-selector lowering for
+// these two functions, not a preserved name.
+func TestLower_ExpHistogram_TsOfFirstLastOverTime_NameDropped(t *testing.T) {
+	t.Parallel()
+
+	s := schema.DefaultOTelMetrics()
+	p := parser.NewParser(parser.Options{EnableExperimentalFunctions: true})
+	at := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+
+	for _, query := range []string{
+		`ts_of_first_over_time(demo_latency_exp_hist[5m])`,
+		`ts_of_last_over_time(demo_latency_exp_hist[5m])`,
+	} {
+		query := query
+		t.Run(query, func(t *testing.T) {
+			t.Parallel()
+			expr, err := p.ParseExpr(query)
+			if err != nil {
+				t.Fatalf("ParseExpr(%q): %v", query, err)
+			}
+			plan, err := promql.LowerAt(context.Background(), expr, s, at, at)
+			if err != nil {
+				t.Fatalf("LowerAt(%q): unexpected error: %v", query, err)
+			}
+			project, ok := plan.(*chplan.Project)
+			if !ok {
+				t.Fatalf("plan root = %T, want *chplan.Project", plan)
+			}
+			found := false
+			for _, proj := range project.Projections {
+				if proj.Alias != s.MetricNameColumn {
+					continue
+				}
+				found = true
+				lit, ok := proj.Expr.(*chplan.LitString)
+				if !ok || lit.V != "" {
+					t.Fatalf("MetricName projection = %#v, want empty LitString", proj.Expr)
+				}
+			}
+			if !found {
+				t.Fatalf("no MetricName projection found in %#v", project.Projections)
+			}
+		})
+	}
+}

--- a/internal/promql/lower.go
+++ b/internal/promql/lower.go
@@ -341,6 +341,15 @@ func lowerRoot(expr parser.Expr, s schema.Metrics, ctx lowerCtx) (chplan.Node, e
 	if fn, ms, vs, ok := lastFirstOverExpHistogram(expr, s, ctx); ok {
 		return lowerLastFirstOverExpHistogram(fn, ms, vs, s, ctx)
 	}
+	// ts_of_first_over_time() / ts_of_last_over_time() (cerberus issue
+	// #2482): the timestamp-reporting siblings of last_over_time /
+	// first_over_time just above — see
+	// histogram_native_ts_of_first_last_over_time.go's own doc for why
+	// they need their own lowering (the output is a float TIMESTAMP
+	// value with `__name__` DROPPED, not a preserved histogram sample).
+	if fn, ms, vs, ok := tsOfFirstLastOverExpHistogram(expr, s, ctx); ok {
+		return lowerTsOfFirstLastOverExpHistogram(fn, ms, vs, s, ctx)
+	}
 	if agg, vs, ok := countOverExpHistogram(expr, s, ctx); ok {
 		return lowerExpHistogramCount(agg, vs, s, ctx)
 	}

--- a/internal/promql/range_fns.go
+++ b/internal/promql/range_fns.go
@@ -491,11 +491,15 @@ func matrixAndSelector(c *parser.Call, arg parser.Expr) (*parser.MatrixSelector,
 // funcStddevOverTime / funcStdvarOverTime) both early-return `enh.Out, nil`
 // on `len(samples.Floats) == 0`. mad_over_time's funcMadOverTime does the
 // identical `len(samples.Floats) == 0` early return. compareOverTime
-// (min_over_time / max_over_time) does too — verified directly against
-// tsouza/prometheus's promql/functions.go (cerberus issue #2480): `if
-// len(samples.Floats) == 0 { return enh.Out, nil }` runs before it ever
-// looks at samples.Histograms, so an all-histogram window answers empty
-// exactly like the other five here.
+// (min_over_time / max_over_time, and — cerberus issue #2482 — their
+// timestamp-reporting siblings ts_of_max_over_time / ts_of_min_over_time,
+// which route through the SAME compareOverTime with returnTimestamp=true)
+// does too — verified directly against tsouza/prometheus's
+// promql/functions.go (cerberus issues #2480 and #2482): `if
+// len(samples.Floats) == 0 { return enh.Out, nil }` runs before
+// compareOverTime ever looks at samples.Histograms, so an all-histogram
+// window answers empty exactly like the other five here, regardless of
+// whether the caller wants the extreme VALUE or its TIMESTAMP.
 //
 // last_over_time / first_over_time are deliberately EXCLUDED: reference
 // Prometheus (funcLastOverTime / funcFirstOverTime) reads the window's
@@ -515,12 +519,14 @@ func matrixAndSelector(c *parser.Call, arg parser.Expr) (*parser.MatrixSelector,
 // would be wrong for them, so they get their own windowed-count lowering
 // in histogram_native_count_present_over_time.go (cerberus issue #2480).
 var rangeVectorFloatOnlyDropFuncs = map[string]bool{
-	"deriv":            true,
-	"mad_over_time":    true,
-	"stddev_over_time": true,
-	"stdvar_over_time": true,
-	"min_over_time":    true,
-	"max_over_time":    true,
+	"deriv":               true,
+	"mad_over_time":       true,
+	"stddev_over_time":    true,
+	"stdvar_over_time":    true,
+	"min_over_time":       true,
+	"max_over_time":       true,
+	"ts_of_max_over_time": true,
+	"ts_of_min_over_time": true,
 }
 
 // dropExpHistogramSamplesForRangeVector recognises a range-vector

--- a/internal/promql/ts_of_max_min_over_time_exp_histogram_test.go
+++ b/internal/promql/ts_of_max_min_over_time_exp_histogram_test.go
@@ -1,0 +1,87 @@
+package promql_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/tsouza/cerberus/internal/promql"
+	"github.com/tsouza/cerberus/internal/schema"
+)
+
+// TestLower_ExpHistogram_TsOfMaxMinOverTimeDropSamples pins cerberus issue
+// #2482's ts_of_max_over_time / ts_of_min_over_time half: both dispatch
+// through the SAME compareOverTime helper min_over_time / max_over_time
+// use, just with returnTimestamp=true (tsouza/prometheus's
+// promql/functions.go: funcTsOfMaxOverTime / funcTsOfMinOverTime call
+// compareOverTime(..., returnTimestamp: true), and compareOverTime itself
+// early-returns `enh.Out, nil` on `len(samples.Floats) == 0` before it
+// ever reads samples.Histograms — the identical guard min_over_time /
+// max_over_time joined [rangeVectorFloatOnlyDropFuncs] over per cerberus
+// issue #2480). A bare exp-histogram matrix selector therefore answers an
+// empty vector, matching reference exactly, and previously fell through
+// to expHistogramSelectorRouting's catch-all rejection instead.
+func TestLower_ExpHistogram_TsOfMaxMinOverTimeDropSamples(t *testing.T) {
+	t.Parallel()
+
+	s := schema.DefaultOTelMetrics()
+	at := time.Date(2026, 1, 1, 0, 0, 1, 0, time.UTC)
+
+	queries := []string{
+		`ts_of_max_over_time(latency_exp_hist[5m])`,
+		`ts_of_min_over_time(latency_exp_hist[5m])`,
+		// An `@`-pinned broadcast reaches the same drop path — the
+		// histogram-selector recognition happens before the grid-shape
+		// switch, mirroring the sibling min_over_time/max_over_time
+		// coverage in range_vector_float_only_reducer_exp_histogram_test.go.
+		`ts_of_max_over_time(latency_exp_hist[5m] @ 1767225601)`,
+	}
+
+	for _, query := range queries {
+		query := query
+		t.Run(query, func(t *testing.T) {
+			t.Parallel()
+
+			expr := parseExprExp(t, query)
+			plan, err := promql.LowerAt(context.Background(), expr, s, at, at)
+			if err != nil {
+				t.Fatalf("LowerAt(%q): %v", query, err)
+			}
+			assertEmptyFloatProjection(t, plan)
+		})
+	}
+}
+
+// TestLower_ExpHistogram_TsOfMaxMinOverTimeRangeMode pins the query_range
+// shape for the same two reducers — see
+// TestLower_ExpHistogram_FloatOnlyRangeVectorReducersRangeMode for why
+// range mode needs its own coverage (LowerAtRange threads a non-zero
+// step, which would otherwise route through the gridFanout branch these
+// reducers never reach once the histogram-selector check fires first).
+func TestLower_ExpHistogram_TsOfMaxMinOverTimeRangeMode(t *testing.T) {
+	t.Parallel()
+
+	s := schema.DefaultOTelMetrics()
+	start := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	end := start.Add(5 * time.Minute)
+	step := time.Minute
+
+	queries := []string{
+		`ts_of_max_over_time(latency_exp_hist[5m])`,
+		`ts_of_min_over_time(latency_exp_hist[5m])`,
+	}
+
+	for _, query := range queries {
+		query := query
+		t.Run(query, func(t *testing.T) {
+			t.Parallel()
+
+			expr := parseExprExp(t, query)
+			plan, err := promql.LowerAtRange(context.Background(), expr, s, start, end, step)
+			if err != nil {
+				t.Fatalf("LowerAtRange(%q): %v", query, err)
+			}
+			assertEmptyFloatProjection(t, plan)
+		})
+	}
+}

--- a/test/rejection-parity/catalogue/internal__promql__lower.go.json
+++ b/test/rejection-parity/catalogue/internal__promql__lower.go.json
@@ -94,8 +94,8 @@
       "site": "internal/promql/lower.go:expHistogramSelectorRouting#bf746b59",
       "message": "promql: %q is an exponential histogram metric; only a bare %q selector, sum()/avg()/count() over one, rate()/increase()/delta()/irate()/idelta()/sum_over_time()/avg_over_time()/resets()/changes() over one, histogram_quantile(), histogram_count(), histogram_sum(), and the %q/%q companion selectors are supported",
       "class": "divergence",
-      "trigger_query": "ts_of_first_over_time(demo_latency_exp_hist[5m])",
-      "tracking_issue": 2482,
+      "trigger_query": "year(demo_latency_exp_hist)",
+      "tracking_issue": 2498,
       "evidence": {
         "guard": [
           "past returning if bare, col, hasCompanion := s.HistogramCompanionColumn(metricName); hasCompanion \u0026\u0026 s.IsExpHistogramMetric(bare) \u0026\u0026 s.ExpHistogramTable != \"\"",
@@ -105,7 +105,7 @@
           "resolveSelectorRouting"
         ]
       },
-      "since": "2026-08-22"
+      "since": "2026-08-23"
     },
     {
       "head": "promql",
@@ -272,7 +272,7 @@
       "site": "internal/promql/lower.go:lowerRoot#53e0f9b3",
       "message": "promql: internal invariant violated: count_values input is not histogram-valued: %v",
       "class": "internal",
-      "rationale": "countValuesOverExpHistogramValue already ran isExpHistogramValuedShape to decide ok=true, so the immediately following lowerExpHistogramValuedShape call on the same agg.Expr cannot come back unmatched. The mixedExpHistogramSetOp guard checked earlier in lowerRoot's chain (cerberus issue #2330) only recognises a VectorSetOp BinaryExpr with exactly one histogram-valued operand — a shape count_values's AggregateExpr is not — so it cannot intercept a query before it reaches this branch, and does not affect this claim. sumOrAvgOverMixedExpHistogramSetOp (cerberus issue #2346), checked immediately after it, only recognises an AggregateExpr whose Op expHistogramAggOpIsMergeable confirms is SUM or AVG — count_values's Op is COUNT_VALUES — so it cannot intercept this shape either. labelCallOverMixedExpHistogramSetOp (cerberus issue #2449), checked immediately after that, only recognises a *parser.Call named label_replace/label_join — count_values's AggregateExpr is neither — so it cannot intercept this shape either. mathFnOverMixedExpHistogramSetOp (cerberus issue #2449), checked immediately after that, type-asserts peelWrappers(expr) as a *parser.Call before doing anything else — count_values's top-level expr is an *parser.AggregateExpr, which peelWrappers (ParenExpr/StepInvariantExpr only) never turns into a Call — so it cannot intercept this shape either. arithmeticOverMixedExpHistogramSetOp (cerberus issue #2449), checked immediately after that, type-asserts unwrapBinaryExpr(expr) as a *parser.BinaryExpr before doing anything else — count_values's top-level expr is an *parser.AggregateExpr, which unwrapBinaryExpr (ParenExpr/StepInvariantExpr only) never turns into a BinaryExpr — so it cannot intercept this shape either. countPresentOverExpHistogram and lastFirstOverExpHistogram (cerberus issue #2480), checked immediately after that, each type-assert peelWrappers(expr) as a *parser.Call named count_over_time/present_over_time or last_over_time/first_over_time before doing anything else — count_values's top-level expr is an *parser.AggregateExpr, which peelWrappers never turns into a Call, so neither can intercept this shape either.",
+      "rationale": "countValuesOverExpHistogramValue already ran isExpHistogramValuedShape to decide ok=true, so the immediately following lowerExpHistogramValuedShape call on the same agg.Expr cannot come back unmatched. The mixedExpHistogramSetOp guard checked earlier in lowerRoot's chain (cerberus issue #2330) only recognises a VectorSetOp BinaryExpr with exactly one histogram-valued operand — a shape count_values's AggregateExpr is not — so it cannot intercept a query before it reaches this branch, and does not affect this claim. sumOrAvgOverMixedExpHistogramSetOp (cerberus issue #2346), checked immediately after it, only recognises an AggregateExpr whose Op expHistogramAggOpIsMergeable confirms is SUM or AVG — count_values's Op is COUNT_VALUES — so it cannot intercept this shape either. labelCallOverMixedExpHistogramSetOp (cerberus issue #2449), checked immediately after that, only recognises a *parser.Call named label_replace/label_join — count_values's AggregateExpr is neither — so it cannot intercept this shape either. mathFnOverMixedExpHistogramSetOp (cerberus issue #2449), checked immediately after that, type-asserts peelWrappers(expr) as a *parser.Call before doing anything else — count_values's top-level expr is an *parser.AggregateExpr, which peelWrappers (ParenExpr/StepInvariantExpr only) never turns into a Call — so it cannot intercept this shape either. arithmeticOverMixedExpHistogramSetOp (cerberus issue #2449), checked immediately after that, type-asserts unwrapBinaryExpr(expr) as a *parser.BinaryExpr before doing anything else — count_values's top-level expr is an *parser.AggregateExpr, which unwrapBinaryExpr (ParenExpr/StepInvariantExpr only) never turns into a BinaryExpr — so it cannot intercept this shape either. countPresentOverExpHistogram and lastFirstOverExpHistogram (cerberus issue #2480), checked immediately after that, each type-assert peelWrappers(expr) as a *parser.Call named count_over_time/present_over_time or last_over_time/first_over_time before doing anything else — count_values's top-level expr is an *parser.AggregateExpr, which peelWrappers never turns into a Call, so neither can intercept this shape either. tsOfFirstLastOverExpHistogram (cerberus issue #2482), checked immediately after that, likewise type-asserts peelWrappers(expr) as a *parser.Call named ts_of_first_over_time/ts_of_last_over_time before doing anything else — count_values's top-level expr is an *parser.AggregateExpr, which peelWrappers never turns into a Call, so it cannot intercept this shape either.",
       "evidence": {
         "guard": [
           "past returning if call, ok := labelReplaceOverExpHistogram(expr, s, ctx); ok",
@@ -286,6 +286,7 @@
           "past returning if shape, ok := resetsOrChangesOverExpHistogram(expr, s, ctx); ok",
           "past returning if fn, ms, vs, ok := countPresentOverExpHistogram(expr, s, ctx); ok",
           "past returning if fn, ms, vs, ok := lastFirstOverExpHistogram(expr, s, ctx); ok",
+          "past returning if fn, ms, vs, ok := tsOfFirstLastOverExpHistogram(expr, s, ctx); ok",
           "past returning if agg, vs, ok := countOverExpHistogram(expr, s, ctx); ok",
           "past returning if agg, ok := countOrGroupOverExpHistogramValue(expr, s, ctx); ok",
           "if agg, ok := countValuesOverExpHistogramValue(expr, s, ctx); ok",
@@ -310,6 +311,7 @@
           "mixedExpHistogramSetOp",
           "peelWrappers",
           "sumOrAvgOverMixedExpHistogramSetOp",
+          "tsOfFirstLastOverExpHistogram",
           "unwrapBinaryExpr"
         ]
       }
@@ -319,7 +321,7 @@
       "site": "internal/promql/lower.go:lowerRoot#c7dbd629",
       "message": "promql: internal invariant violated: count/group input is not histogram-valued: %v",
       "class": "internal",
-      "rationale": "countOrGroupOverExpHistogramValue already ran isExpHistogramValuedShape to decide ok=true, so the immediately following lowerExpHistogramValuedShape call on the same agg.Expr cannot come back unmatched. The mixedExpHistogramSetOp guard checked earlier in lowerRoot's chain (cerberus issue #2330) only recognises a VectorSetOp BinaryExpr with exactly one histogram-valued operand — a shape count/group's AggregateExpr is not — so it cannot intercept a query before it reaches this branch, and does not affect this claim. sumOrAvgOverMixedExpHistogramSetOp (cerberus issue #2346), checked immediately after it, only recognises an AggregateExpr whose Op expHistogramAggOpIsMergeable confirms is SUM or AVG — count/group's Op is COUNT or GROUP — so it cannot intercept this shape either. labelCallOverMixedExpHistogramSetOp (cerberus issue #2449), checked immediately after that, only recognises a *parser.Call named label_replace/label_join — count/group's AggregateExpr is neither — so it cannot intercept this shape either. mathFnOverMixedExpHistogramSetOp (cerberus issue #2449), checked immediately after that, type-asserts peelWrappers(expr) as a *parser.Call before doing anything else — count/group's top-level expr is an *parser.AggregateExpr, which peelWrappers (ParenExpr/StepInvariantExpr only) never turns into a Call — so it cannot intercept this shape either. arithmeticOverMixedExpHistogramSetOp (cerberus issue #2449), checked immediately after that, type-asserts unwrapBinaryExpr(expr) as a *parser.BinaryExpr before doing anything else — count/group's top-level expr is an *parser.AggregateExpr, which unwrapBinaryExpr (ParenExpr/StepInvariantExpr only) never turns into a BinaryExpr — so it cannot intercept this shape either. countPresentOverExpHistogram and lastFirstOverExpHistogram (cerberus issue #2480), checked immediately after that, each type-assert peelWrappers(expr) as a *parser.Call named count_over_time/present_over_time or last_over_time/first_over_time before doing anything else — count/group's top-level expr is an *parser.AggregateExpr, which peelWrappers never turns into a Call, so neither can intercept this shape either.",
+      "rationale": "countOrGroupOverExpHistogramValue already ran isExpHistogramValuedShape to decide ok=true, so the immediately following lowerExpHistogramValuedShape call on the same agg.Expr cannot come back unmatched. The mixedExpHistogramSetOp guard checked earlier in lowerRoot's chain (cerberus issue #2330) only recognises a VectorSetOp BinaryExpr with exactly one histogram-valued operand — a shape count/group's AggregateExpr is not — so it cannot intercept a query before it reaches this branch, and does not affect this claim. sumOrAvgOverMixedExpHistogramSetOp (cerberus issue #2346), checked immediately after it, only recognises an AggregateExpr whose Op expHistogramAggOpIsMergeable confirms is SUM or AVG — count/group's Op is COUNT or GROUP — so it cannot intercept this shape either. labelCallOverMixedExpHistogramSetOp (cerberus issue #2449), checked immediately after that, only recognises a *parser.Call named label_replace/label_join — count/group's AggregateExpr is neither — so it cannot intercept this shape either. mathFnOverMixedExpHistogramSetOp (cerberus issue #2449), checked immediately after that, type-asserts peelWrappers(expr) as a *parser.Call before doing anything else — count/group's top-level expr is an *parser.AggregateExpr, which peelWrappers (ParenExpr/StepInvariantExpr only) never turns into a Call — so it cannot intercept this shape either. arithmeticOverMixedExpHistogramSetOp (cerberus issue #2449), checked immediately after that, type-asserts unwrapBinaryExpr(expr) as a *parser.BinaryExpr before doing anything else — count/group's top-level expr is an *parser.AggregateExpr, which unwrapBinaryExpr (ParenExpr/StepInvariantExpr only) never turns into a BinaryExpr — so it cannot intercept this shape either. countPresentOverExpHistogram and lastFirstOverExpHistogram (cerberus issue #2480), checked immediately after that, each type-assert peelWrappers(expr) as a *parser.Call named count_over_time/present_over_time or last_over_time/first_over_time before doing anything else — count/group's top-level expr is an *parser.AggregateExpr, which peelWrappers never turns into a Call, so neither can intercept this shape either. tsOfFirstLastOverExpHistogram (cerberus issue #2482), checked immediately after that, likewise type-asserts peelWrappers(expr) as a *parser.Call named ts_of_first_over_time/ts_of_last_over_time before doing anything else — count/group's top-level expr is an *parser.AggregateExpr, which peelWrappers never turns into a Call, so it cannot intercept this shape either.",
       "evidence": {
         "guard": [
           "past returning if call, ok := labelReplaceOverExpHistogram(expr, s, ctx); ok",
@@ -333,6 +335,7 @@
           "past returning if shape, ok := resetsOrChangesOverExpHistogram(expr, s, ctx); ok",
           "past returning if fn, ms, vs, ok := countPresentOverExpHistogram(expr, s, ctx); ok",
           "past returning if fn, ms, vs, ok := lastFirstOverExpHistogram(expr, s, ctx); ok",
+          "past returning if fn, ms, vs, ok := tsOfFirstLastOverExpHistogram(expr, s, ctx); ok",
           "past returning if agg, vs, ok := countOverExpHistogram(expr, s, ctx); ok",
           "if agg, ok := countOrGroupOverExpHistogramValue(expr, s, ctx); ok",
           "past returning if err != nil",
@@ -356,6 +359,7 @@
           "mixedExpHistogramSetOp",
           "peelWrappers",
           "sumOrAvgOverMixedExpHistogramSetOp",
+          "tsOfFirstLastOverExpHistogram",
           "unwrapBinaryExpr"
         ]
       }

--- a/test/spec/chplan_print.go
+++ b/test/spec/chplan_print.go
@@ -952,6 +952,7 @@ var fnGoNames = map[chplan.Fn]string{
 	chplan.FnToLastDayOfMonth:                "FnToLastDayOfMonth",
 	chplan.FnToMinute:                        "FnToMinute",
 	chplan.FnToMonth:                         "FnToMonth",
+	chplan.FnToUnixMillis:                    "FnToUnixMillis",
 	chplan.FnToUnixNanos:                     "FnToUnixNanos",
 	chplan.FnToYear:                          "FnToYear",
 	chplan.FnAbs:                             "FnAbs",


### PR DESCRIPTION
## Summary

Cerberus issue #2482 found four range-vector reducers — `ts_of_first_over_time`,
`ts_of_last_over_time`, `ts_of_max_over_time`, `ts_of_min_over_time` — that rejected a bare
exp-histogram matrix-selector argument via `lowerRangeVectorCall`'s generic
`expHistogramSelectorRouting` catch-all. This PR adds support for all four:

- **`ts_of_max_over_time` / `ts_of_min_over_time`** route through the same `compareOverTime`
  helper `min_over_time`/`max_over_time` use (`returnTimestamp: true`), with the identical
  `len(samples.Floats) == 0` early return verified against `tsouza/prometheus`'s
  `promql/functions.go`. They join `rangeVectorFloatOnlyDropFuncs` (#2480's own DROP class) —
  over an all-histogram window they now correctly answer an empty vector, matching reference. No
  new lowering file needed.
- **`ts_of_first_over_time` / `ts_of_last_over_time`** get a new lowering
  (`internal/promql/histogram_native_ts_of_first_last_over_time.go`) that reduces, over an
  all-histogram window, to the window's own earliest/latest histogram-sample timestamp (the
  `min(tf,th)`/`max(tf,th)` sentinel collapse — see the file's doc comment for the full
  derivation), reported as a float epoch-seconds value. Notably, `__name__` is **dropped**, not
  preserved as the issue's own filing text assumed — verified directly against
  `tsouza/prometheus`'s `engine.go` `dropName` gate (only literally `last_over_time` /
  `first_over_time` survive it) and against cerberus's existing classic float-selector lowering
  for these two functions. The plan shape mirrors `histogram_native_timestamp.go`'s
  three-range-grid-shape split, with a directional MIN/MAX(TimeUnix) aggregate instead of a fixed
  newest-sample one.
- A new `chplan.FnToUnixMillis` (`toUnixTimestamp64Milli`) mirrors the classic path's own
  ms-truncated epoch-seconds conversion so both paths answer identically on data with
  sub-millisecond timestamps. A follow-up commit registers it in
  `test/spec/chplan_print.go`'s `fnGoNames` completeness map (`TestFnGoNames_CoversEveryDeclaredFn`
  was failing without it).
- Rotates the rejection-parity catalogue's `expHistogramSelectorRouting` entry to the next
  reachable trigger, `year()` over a raw exp-histogram selector, now tracked by #2498 (filed
  during this change — reference's `dateWrapper` drops a histogram sample for every
  date-component function except `timestamp()`, so `year`/`month`/`day_of_month`/`day_of_year`/
  `day_of_week`/`days_in_month`/`hour`/`minute` still wrongly hard-reject instead of answering
  empty).

## Scope vs #2482

All four functions named in #2482's acceptance criteria are implemented, and the
rejection-parity catalogue no longer tracks the site under #2482 (rotated to #2498, a distinct
gap in the `year()`/date-component family). This closes #2482 in full.

Closes #2482

## Test plan

- [x] `go build ./...` — clean
- [x] `go vet ./...` — clean
- [x] New unit coverage: `internal/promql/histogram_native_ts_of_first_last_over_time_test.go`
      (instant, range, `@`-pinned broadcast, and `__name__`-dropped shapes) and
      `internal/promql/ts_of_max_min_over_time_exp_histogram_test.go` (empty-vector drop
      semantics, instant and range mode)
- [x] Rejection-parity catalogue updated to reflect the closed site and its rotation to #2498

🤖 Generated with [Claude Code](https://claude.com/claude-code)
