### PR TITLE
fix(promql): drop exp-histogram samples for the date-component functions

### DIFF
--- a/internal/promql/date_fns.go
+++ b/internal/promql/date_fns.go
@@ -75,6 +75,25 @@ func lowerDateFn(c *parser.Call, s schema.Metrics, ctx lowerCtx) (chplan.Node, e
 		if node, ok, err := lowerTimestampOverExpHistogram(c.Args[0], s, ctx); ok {
 			return node, err
 		}
+	} else {
+		// Reference Prometheus routes year/month/day_of_month/day_of_year/
+		// day_of_week/days_in_month/hour/minute through a shared dateWrapper
+		// helper (promql/functions.go) that explicitly skips every sample
+		// whose H field is set before computing the date component from F —
+		// the same "process only float samples, drop the rest" rule
+		// simpleFloatFunc applies for abs/ceil/floor/round/etc (issue
+		// #2221) and clamp/sort already mirror (issues #2345, #2456).
+		// These eight never routed their argument through
+		// lowerExpHistogramValuedShape, so a histogram-valued argument fell
+		// through to the generic lower() dispatch below and hit
+		// expHistogramSelectorRouting's catch-all rejection instead of
+		// Prom's drop-and-answer-empty semantics (cerberus issue #2498).
+		if hist, ok, err := lowerExpHistogramValuedShape(c.Args[0], s, ctx); ok {
+			if err != nil {
+				return nil, err
+			}
+			return dropExpHistogramSamples(hist, s), nil
+		}
 	}
 
 	// The argument is lowered under an ARGUMENT ctx rather than the caller's

--- a/internal/promql/histogram_native_date_fns_test.go
+++ b/internal/promql/histogram_native_date_fns_test.go
@@ -1,0 +1,98 @@
+package promql_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/prometheus/prometheus/promql/parser"
+
+	"github.com/tsouza/cerberus/internal/chsql"
+	"github.com/tsouza/cerberus/internal/promql"
+	"github.com/tsouza/cerberus/internal/schema"
+)
+
+// TestLower_ExpHistogram_DateComponentFunctionsDropSamples pins issue #2498:
+// reference Prometheus's shared dateWrapper helper (promql/functions.go),
+// used by year/month/day_of_month/day_of_year/day_of_week/days_in_month/
+// hour/minute, explicitly skips every sample whose H field is set before
+// computing the date component from F — the same "process only float
+// samples" rule simpleFloatFunc applies for abs/ceil/floor/round/etc
+// (issue #2221) and the clamp/sort families already mirror (issues #2345,
+// #2456). Before this fix none of these eight routed their argument
+// through lowerExpHistogramValuedShape, so a histogram-valued argument fell
+// through to the generic lower() dispatch and hit
+// expHistogramSelectorRouting's catch-all rejection instead of Prom's
+// drop-and-answer-empty semantics.
+//
+// timestamp() is deliberately excluded here: its value is independent of
+// the sample's payload (reference reads only Point.T), so it was already
+// fixed separately by issue #2474/#2478 to ANSWER over a histogram
+// argument rather than drop it — see histogram_native_timestamp_test.go.
+func TestLower_ExpHistogram_DateComponentFunctionsDropSamples(t *testing.T) {
+	t.Parallel()
+
+	s := schema.DefaultOTelMetrics()
+	p := parser.NewParser(parser.Options{})
+	at := time.Date(2026, 1, 1, 0, 0, 1, 0, time.UTC)
+
+	queries := []string{
+		`year(latency_exp_hist)`,
+		`month(latency_exp_hist)`,
+		`day_of_month(latency_exp_hist)`,
+		`day_of_year(latency_exp_hist)`,
+		`day_of_week(latency_exp_hist)`,
+		`days_in_month(latency_exp_hist)`,
+		`hour(latency_exp_hist)`,
+		`minute(latency_exp_hist)`,
+
+		// The consumer sees histogram-valued results, not only selectors.
+		`year(sum(latency_exp_hist))`,
+		`hour(rate(latency_exp_hist[5m]))`,
+	}
+
+	for _, query := range queries {
+		query := query
+		t.Run(query, func(t *testing.T) {
+			t.Parallel()
+
+			expr, err := p.ParseExpr(query)
+			if err != nil {
+				t.Fatalf("ParseExpr(%q): %v", query, err)
+			}
+			plan, err := promql.LowerAt(context.Background(), expr, s, at, at)
+			if err != nil {
+				t.Fatalf("LowerAt(%q): %v", query, err)
+			}
+			assertEmptyFloatProjection(t, plan)
+			if _, _, err := chsql.Emit(context.Background(), plan); err != nil {
+				t.Fatalf("chsql.Emit(%q): %v", query, err)
+			}
+		})
+	}
+}
+
+// TestLower_ExpHistogram_DateComponentFunctionRangeDropsSamples covers
+// range-query mode: a bare exp-histogram selector under a date-component
+// function still drops to an empty float vector rather than rejecting, one
+// representative function of the eight (day_of_week exercises the modulo
+// rewrite, the most distinctive of the eight expressions).
+func TestLower_ExpHistogram_DateComponentFunctionRangeDropsSamples(t *testing.T) {
+	t.Parallel()
+
+	s := schema.DefaultOTelMetrics()
+	p := parser.NewParser(parser.Options{})
+	expr, err := p.ParseExpr(`day_of_week(latency_exp_hist)`)
+	if err != nil {
+		t.Fatalf("ParseExpr: %v", err)
+	}
+	start := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	plan, err := promql.LowerAtRange(context.Background(), expr, s, start, start.Add(time.Minute), 15*time.Second)
+	if err != nil {
+		t.Fatalf("LowerAtRange: %v", err)
+	}
+	assertEmptyFloatProjection(t, plan)
+	if _, _, err := chsql.Emit(context.Background(), plan); err != nil {
+		t.Fatalf("chsql.Emit: %v", err)
+	}
+}

--- a/internal/promql/histogram_native_timestamp_test.go
+++ b/internal/promql/histogram_native_timestamp_test.go
@@ -2,7 +2,6 @@ package promql_test
 
 import (
 	"context"
-	"strings"
 	"testing"
 	"time"
 
@@ -129,15 +128,21 @@ func TestLower_ExpHistogram_Timestamp_AtPin(t *testing.T) {
 	}
 }
 
-// TestLower_ExpHistogram_Timestamp_OtherDateFnsStillRejectHistograms
-// guards the fix's scope: `timestamp()` is the ONLY date-component
-// function whose value is independent of the sample's payload (reference
-// reads only Point.T). Every sibling (year/month/day_of_month/…) computes
-// its value FROM the sample's Value column via [valueAsDateTime], which a
-// native histogram sample never populates meaningfully — those must keep
-// hitting expHistogramSelectorRouting's rejection over a bare exp-histogram
-// selector, exactly as before this fix.
-func TestLower_ExpHistogram_Timestamp_OtherDateFnsStillRejectHistograms(t *testing.T) {
+// TestLower_ExpHistogram_Timestamp_OtherDateFnsDropInsteadOfReject guards
+// the boundary between `timestamp()` and its seven date-component
+// siblings: `timestamp()` is the ONLY one whose value is independent of
+// the sample's payload (reference reads only Point.T), so it ANSWERS over
+// a histogram-valued argument rather than dropping to empty. Every sibling
+// (year/month/day_of_month/…) computes its value FROM the sample's Value
+// column via [valueAsDateTime], which a native histogram sample never
+// populates meaningfully — reference Prometheus's shared dateWrapper
+// helper drops those samples instead of erroring (issue #2498), and those
+// siblings must keep doing the same rather than regressing to
+// `timestamp`'s answer-it posture. See
+// TestLower_ExpHistogram_DateComponentFunctionsDropSamples
+// (histogram_native_date_fns_test.go) for the drop-semantics coverage
+// itself.
+func TestLower_ExpHistogram_Timestamp_OtherDateFnsDropInsteadOfReject(t *testing.T) {
 	t.Parallel()
 
 	s := schema.DefaultOTelMetrics()
@@ -158,13 +163,11 @@ func TestLower_ExpHistogram_Timestamp_OtherDateFnsStillRejectHistograms(t *testi
 			if err != nil {
 				t.Fatalf("ParseExpr(%q): %v", query, err)
 			}
-			_, err = promql.LowerAt(context.Background(), expr, s, at, at)
-			if err == nil {
-				t.Fatalf("LowerAt(%q): expected the exponential-histogram routing rejection, got nil error", query)
-			}
-			if !strings.Contains(err.Error(), "is an exponential histogram metric") {
+			plan, err := promql.LowerAt(context.Background(), expr, s, at, at)
+			if err != nil {
 				t.Fatalf("LowerAt(%q): unexpected error: %v", query, err)
 			}
+			assertEmptyFloatProjection(t, plan)
 		})
 	}
 }

--- a/test/rejection-parity/catalogue/internal__promql__lower.go.json
+++ b/test/rejection-parity/catalogue/internal__promql__lower.go.json
@@ -94,8 +94,8 @@
       "site": "internal/promql/lower.go:expHistogramSelectorRouting#bf746b59",
       "message": "promql: %q is an exponential histogram metric; only a bare %q selector, sum()/avg()/count() over one, rate()/increase()/delta()/irate()/idelta()/sum_over_time()/avg_over_time()/resets()/changes() over one, histogram_quantile(), histogram_count(), histogram_sum(), and the %q/%q companion selectors are supported",
       "class": "divergence",
-      "trigger_query": "year(demo_latency_exp_hist)",
-      "tracking_issue": 2498,
+      "trigger_query": "info(demo_latency_exp_hist)",
+      "tracking_issue": 2509,
       "evidence": {
         "guard": [
           "past returning if bare, col, hasCompanion := s.HistogramCompanionColumn(metricName); hasCompanion \u0026\u0026 s.IsExpHistogramMetric(bare) \u0026\u0026 s.ExpHistogramTable != \"\"",


### PR DESCRIPTION
## Summary

- Applies Prometheus's `dateWrapper` semantics (drop histogram-valued samples,
  answer only over floats) to the eight date-component functions —
  `year`/`month`/`day_of_month`/`day_of_year`/`day_of_week`/`days_in_month`/
  `hour`/`minute` — which previously fell through to
  `expHistogramSelectorRouting`'s catch-all rejection instead of Prometheus's
  drop-and-answer-empty behavior. `timestamp()` is left untouched since it
  already answers over histogram arguments (#2474/#2478).
- Rotates the rejection-parity catalogue's `expHistogramSelectorRouting` entry
  trigger off `year(...)` (now lowers successfully) onto
  `info(demo_latency_exp_hist)`, and files the `info()` join/preserve
  divergence separately as #2509 since it needs a different fix shape.

Closes #2498

## Test plan

- [x] New direct coverage for all eight date-component functions plus a
      range-mode case (`internal/promql`)
- [x] Rewrote `TestLower_ExpHistogram_Timestamp_OtherDateFnsStillRejectHistograms`
      to assert the drop instead of the stale rejection
- [x] `TestRejectionTriggersExerciseSites` passes with the rotated trigger query
- [x] `just test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
