### PR TITLE
fix(promql): retry exp-histogram preserve/drop recognizers on a binop operand

### DIFF
--- a/internal/promql/binary.go
+++ b/internal/promql/binary.go
@@ -141,11 +141,11 @@ func lowerVectorVector(b *parser.BinaryExpr, s schema.Metrics, op chplan.BinaryO
 		// emitter's "many" aggregation handles by construction).
 	}
 
-	left, err := lower(b.LHS, s, ctx)
+	left, err := lowerVectorVectorOperand(b.LHS, s, ctx)
 	if err != nil {
 		return nil, err
 	}
-	right, err := lower(b.RHS, s, ctx)
+	right, err := lowerVectorVectorOperand(b.RHS, s, ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -651,6 +651,82 @@ func tryScalarLiteral(e parser.Expr) (float64, bool) {
 	return TryFoldScalar(e)
 }
 
+// lowerScalarBinopOperand lowers [lowerVectorScalar]'s vec argument,
+// trying the exp-histogram "preserve"/"drop" family opt-in first — exactly
+// as every wrapper callsite in this package already does (a Call's single
+// vector argument, an AggregateExpr's Expr — cerberus issues
+// #2221/#2345/#2456/#2498/#2528) — before falling back to the plain
+// [lower] dispatcher.
+//
+// This closes a structurally different gap from those wrapper callsites
+// (cerberus issue #2534): [lowerVectorScalar] is reached from lowerRoot's
+// own final `lower(expr, s, ctx)` fallback only after every dedicated
+// histogram/scalar recogniser — lowerRoot's own dispatch chain, and
+// [lowerExpHistogramValuedShape]'s own [expHistogramScalarBinop] entry —
+// has already failed to match the WHOLE outer expression. Both that
+// recogniser and its drop-family sibling [expHistogramDroppingScalarBinop]
+// match unconditionally whenever vec is directly histogram-valued (there
+// is no vector-matching mode for a scalar operand to gate on), so by
+// construction vec can never be DIRECTLY one of those shapes here — an
+// outer recogniser would already have claimed the whole expression first.
+// What escapes undetected is a NESTED composition vec happens to be — a
+// drop-family (or preserve-family) binop as ANOTHER binop's own operand,
+// e.g. `(demo_latency_exp_hist + 0) * 2` — which none of the outer
+// recognisers look inside far enough to see, because they only ever
+// inspect the binop's own immediate LHS/RHS, not a further nested
+// sub-expression's OWN operand structure.
+// [lowerExpHistogramArgAsCanonicalFloat] already tries both families and
+// reprojects either to the canonical (MetricName, Attributes, TimeUnix,
+// Value) quartet [lowerVectorScalar]'s own arithmetic already expects from
+// a plain [lower] result, so no further plumbing is needed once matched.
+//
+// Deliberately NOT reused for [lowerVectorVector]'s two operands — see
+// [lowerVectorVectorOperand]'s own doc for why the vector-vector case
+// needs a narrower opt-in.
+func lowerScalarBinopOperand(expr parser.Expr, s schema.Metrics, ctx lowerCtx) (chplan.Node, error) {
+	if node, ok, err := lowerExpHistogramArgAsCanonicalFloat(expr, s, ctx); ok {
+		return node, err
+	}
+	return lower(expr, s, ctx)
+}
+
+// lowerVectorVectorOperand lowers one operand of [lowerVectorVector]
+// (LHS or RHS), trying ONLY the exp-histogram "drop" family's nested-
+// composition opt-in before falling back to the generic [lower]
+// dispatcher — unlike [lowerScalarBinopOperand] (the scalar-operand
+// sibling this mirrors for cerberus issue #2534), it deliberately does
+// NOT also try the "preserve" family.
+//
+// A drop-family match answers reference's genuinely, unconditionally
+// EMPTY result: composing an already-empty vector under ANY further
+// vector-vector op or matching mode is still empty, regardless of whether
+// cerberus's join machinery happens to support that op/matching-mode
+// combination for a NON-empty histogram operand — so resolving it eagerly
+// here can never disagree with a matching-mode-aware outer recogniser.
+//
+// The "preserve" family cannot take the same shortcut: a histogram-valued
+// operand is a real, non-empty value that must still flow through the
+// correct vector-vector JOIN — and matching-mode-sensitive recognisers
+// like [expHistogramFloatVectorScalingBinop]
+// (histogram_native_float_vector_scaling_binop.go) deliberately decline
+// some on()/group_left()/group_right() combinations that shape does not
+// yet support, in which case the query must keep hard-rejecting rather
+// than silently discarding the join and answering an empty result.
+// Because a DIRECTLY-valued V-V operand is otherwise always claimed by
+// one of lowerRoot's own exhaustive, matching-mode-aware dispatches
+// before [lowerVectorVector]'s generic fallback is ever reached, trying
+// the "preserve" family here would only ever fire on exactly those
+// deliberately-unsupported combinations — silently downgrading a correct
+// rejection into a wrong empty answer. See
+// TestLower_ExpHistogram_FloatVectorScalingBinopStillRejected for the
+// regression this scoping avoids.
+func lowerVectorVectorOperand(expr parser.Expr, s schema.Metrics, ctx lowerCtx) (chplan.Node, error) {
+	if dropped, ok, err := lowerExpHistogramDroppingShape(expr, s, ctx); ok {
+		return dropped, err
+	}
+	return lower(expr, s, ctx)
+}
+
 // lowerVectorScalar lowers a binary expression mixing a vector and a
 // scalar. Arithmetic ops are mapped through a Project that replaces
 // `Value` with `(scalar OP Value)` or `(Value OP scalar)`. Comparison ops
@@ -661,7 +737,7 @@ func tryScalarLiteral(e parser.Expr) (float64, bool) {
 // scalarOnLeft flips the operand order — important for non-commutative
 // ops like SUB and DIV and for comparisons (`5 > up` vs `up > 5`).
 func lowerVectorScalar(vec parser.Expr, s schema.Metrics, op chplan.BinaryOp, scalar float64, scalarOnLeft, returnBool bool, ctx lowerCtx) (chplan.Node, error) {
-	inner, err := lower(vec, s, ctx)
+	inner, err := lowerScalarBinopOperand(vec, s, ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/promql/histogram_native_dropping_nested_binop_chdb_test.go
+++ b/internal/promql/histogram_native_dropping_nested_binop_chdb_test.go
@@ -1,0 +1,116 @@
+//go:build chdb
+
+// chDB-backed proof that a drop-family exp-histogram binop nested as
+// ANOTHER binop's own operand (cerberus issue #2534) now lowers to valid
+// SQL and EXECUTES against real ClickHouse — not merely that a Go-level
+// lowering error stopped being raised.
+//
+// binary.go's lowerScalarBinopOperand / lowerVectorVectorOperand and
+// histogram_native_set_op.go's lowerVectorSetOpOperand are the new
+// per-operand opt-ins this issue's fix threads into the generic recursive
+// binop lowering; TestLower_ExpHistogram_DroppingShapeComposesUnderWrappers
+// (histogram_native_dropping_shape_test.go) already pins the SAME leaf
+// composed under a WRAPPER's own argument position (cerberus issue #2528)
+// at the Go-plan-shape level — this file is that fixture's chDB-executed,
+// binop-nested sibling, using the issue's own four trigger queries
+// verbatim.
+//
+// The metric is seeded with a REAL, non-empty row so a returned zero-row
+// result can only mean the drop actually fired — not that no data was
+// ever scanned.
+package promql_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/prometheus/prometheus/promql/parser"
+
+	"github.com/tsouza/cerberus/internal/chsql"
+	"github.com/tsouza/cerberus/internal/promql"
+	"github.com/tsouza/cerberus/internal/schema"
+	"github.com/tsouza/cerberus/internal/testsql"
+)
+
+const nestedBinopDropMetric = "nested_binop_drop_probe_exp_hist"
+
+var nestedBinopDropSeed = "" +
+	"CREATE OR REPLACE TABLE otel_metrics_exponential_histogram (" +
+	"`MetricName` String, `Attributes` Map(String, String), " +
+	"`ResourceAttributes` Map(String, String) DEFAULT map(), `ServiceName` LowCardinality(String) DEFAULT '', " +
+	"`TimeUnix` DateTime64(9), " +
+	"`Count` UInt64, `Sum` Float64, `Scale` Int32, `ZeroCount` UInt64, " +
+	"`PositiveOffset` Int32, `PositiveBucketCounts` Array(UInt64), " +
+	"`NegativeOffset` Int32, `NegativeBucketCounts` Array(UInt64)" +
+	") ENGINE = MergeTree ORDER BY (`MetricName`, `Attributes`, `TimeUnix`);\n" +
+	"INSERT INTO otel_metrics_exponential_histogram " +
+	"(MetricName, Attributes, TimeUnix, Count, Sum, Scale, ZeroCount, PositiveOffset, PositiveBucketCounts, NegativeOffset, NegativeBucketCounts) VALUES\n" +
+	"    ('" + nestedBinopDropMetric + "', map('service', 'checkout'), toDateTime64('2026-01-01 00:00:00', 9), 5, 10.0, 0, 0, 0, [5], 0, []);\n"
+
+var nestedBinopDropEvalTS = time.Date(2026, 1, 1, 0, 0, 1, 0, time.UTC)
+
+// TestLower_ExpHistogram_DroppingShapeNestedInBinop_ChDB pins cerberus
+// issue #2534's own four trigger queries: a drop-family binop
+// (`<metric> + 0`) nested as the operand of a further scalar binop
+// ([lowerScalarBinopOperand]), a further vector-vector binop reached
+// through an aggregation wrapper ([lowerVectorVectorOperand]), and a
+// vector set op ([lowerVectorSetOpOperand]'s own drop-family opt-in).
+// Every one of these previously hard-rejected via
+// expHistogramSelectorRouting's catch-all before ever reaching SQL.
+func TestLower_ExpHistogram_DroppingShapeNestedInBinop_ChDB(t *testing.T) {
+	fixture := newChDBFixture(t, nestedBinopDropSeed)
+	s := schema.DefaultOTelMetrics()
+	p := parser.NewParser(parser.Options{EnableExperimentalFunctions: true})
+
+	queries := []string{
+		// lowerVectorScalar's operand opt-in (a scalar on the outer
+		// binop's RHS).
+		"(" + nestedBinopDropMetric + " + 0) * 2",
+		"(" + nestedBinopDropMetric + " + 0) + 5",
+		// lowerVectorScalar's operand opt-in again, this time over an
+		// AggregateExpr wrapping the drop-family leaf (composes
+		// [lowerExpHistogramDroppingShape]'s own aggregation recursion,
+		// cerberus issue #2528, one level deeper).
+		"sum(" + nestedBinopDropMetric + " + 0) + 1",
+		// lowerVectorSetOpOperand's drop-family opt-in.
+		"(" + nestedBinopDropMetric + " + 0) or (" + nestedBinopDropMetric + " + 0)",
+	}
+
+	for _, query := range queries {
+		query := query
+		t.Run(query, func(t *testing.T) {
+			expr, err := p.ParseExpr(query)
+			if err != nil {
+				t.Fatalf("ParseExpr(%q): %v", query, err)
+			}
+			plan, err := promql.LowerAt(context.Background(), expr, s, nestedBinopDropEvalTS, nestedBinopDropEvalTS)
+			if err != nil {
+				t.Fatalf("LowerAt(%q): unexpected error (this exact shape hard-rejected via expHistogramSelectorRouting's catch-all before cerberus issue #2534's fix): %v", query, err)
+			}
+			sqlStr, args, err := chsql.Emit(context.Background(), plan)
+			if err != nil {
+				t.Fatalf("Emit(%q): %v", query, err)
+			}
+
+			rows := fixture.queryOverEmitted(t, "count() AS n", sqlStr, args)
+			defer func() { _ = rows.Close() }()
+			if !rows.Next() {
+				t.Fatalf("count() query returned no rows")
+			}
+			var n int64
+			if err := rows.Scan(&n); err != nil {
+				t.Fatalf("scan count(): %v", err)
+			}
+			if err := testsql.TolerantRowsErr(rows.Err()); err != nil {
+				t.Fatalf("rows.Err: %v", err)
+			}
+			if n != 0 {
+				t.Fatalf(
+					"query %q returned count()=%d, want 0 — reference drops every sample through an incompatible-type histogram/scalar (or histogram/histogram) binop; the metric was seeded with a REAL non-empty row, so a non-zero count would mean the drop never actually fired at execution",
+					query, n,
+				)
+			}
+		})
+	}
+}

--- a/internal/promql/histogram_native_set_op.go
+++ b/internal/promql/histogram_native_set_op.go
@@ -182,6 +182,14 @@ func lowerExpHistogramSetOpOperand(expr parser.Expr, s schema.Metrics, ctx lower
 // [expHistogramSelectorRouting]'s catch-all rejection — the exact bug
 // #2325 reports.
 //
+// A drop-family operand — `(demo_latency_exp_hist + 0) or ...` (cerberus
+// issue #2534, the set-op sibling of the same gap
+// [lowerVectorVectorOperand] (binary.go) closes for arithmetic/comparison
+// V-V binops) — reprojects to the canonical empty float quartet via
+// [lowerExpHistogramDroppingShape], which already produces exactly the
+// Sample row shape a plain float operand would; no set-op-specific
+// wrapping is needed.
+//
 // Every other operand — including a FLOAT-valued function that merely
 // reads a histogram selector as its own argument, like
 // histogram_quantile(), or an operand with no histogram involvement at
@@ -191,6 +199,9 @@ func lowerExpHistogramSetOpOperand(expr parser.Expr, s schema.Metrics, ctx lower
 func lowerVectorSetOpOperand(expr parser.Expr, s schema.Metrics, ctx lowerCtx) (chplan.Node, error) {
 	if isExpHistogramValuedShape(expr, s, ctx) {
 		return lowerExpHistogramSetOpOperand(expr, s, ctx)
+	}
+	if dropped, ok, err := lowerExpHistogramDroppingShape(expr, s, ctx); ok {
+		return dropped, err
 	}
 	return lower(expr, s, ctx)
 }

--- a/test/rejection-parity/catalogue/internal__promql__lower.go.json
+++ b/test/rejection-parity/catalogue/internal__promql__lower.go.json
@@ -94,8 +94,8 @@
       "site": "internal/promql/lower.go:expHistogramSelectorRouting#bf746b59",
       "message": "promql: %q is an exponential histogram metric; only a bare %q selector, sum()/avg()/count() over one, rate()/increase()/delta()/irate()/idelta()/sum_over_time()/avg_over_time()/resets()/changes() over one, histogram_quantile(), histogram_count(), histogram_sum(), and the %q/%q companion selectors are supported",
       "class": "divergence",
-      "trigger_query": "(demo_latency_exp_hist + 0) * 2",
-      "tracking_issue": 2534,
+      "trigger_query": "histogram_quantile(0.5, demo_latency_exp_hist) * on(service) demo_latency_exp_hist",
+      "tracking_issue": 2537,
       "evidence": {
         "guard": [
           "past returning if bare, col, hasCompanion := s.HistogramCompanionColumn(metricName); hasCompanion \u0026\u0026 s.IsExpHistogramMetric(bare) \u0026\u0026 s.ExpHistogramTable != \"\"",
@@ -129,7 +129,7 @@
       "site": "internal/promql/lower.go:lower#d33d0084",
       "message": "promql: unsupported expression %T",
       "class": "internal",
-      "rationale": "Every expression shape reaching lower() through the HTTP handlers is dispatched (top-level matrix selectors included). The remaining inhabitants — NumberLiteral and StringLiteral, answered by the handler's constant fold / string shortcut before the engine runs, and StepInvariantExpr, which only parser.PreprocessExpr mints and cerberus never calls — cannot arrive here from the wire. The query entry points now reach this switch through lowerRoot, which peels off exactly one shape (a bare exp-histogram selector, answered by a histogram-valued lowering) and otherwise delegates unchanged, so it narrows the set of expressions that arrive rather than widening it. Re-verified across the in-package callers that re-enter lower() with a sub-expression, lowerHistogramQuantileClassicFloat included: each passes an operand of an already-parsed query whose position the upstream typechecker constrains to a vector, so no caller widens the set of shapes that reach the default arm. lowerExpHistogramDroppingVectorBinop (cerberus issue #2331) and lowerMixedExpHistogramOperands (cerberus issue #2330, split out of the former lowerMixedExpHistogramSetOp so histogram_native_mixed_or_aggregate.go's sum/avg-wrapped lowering — cerberus issue #2346 — can share the same operand lowering) re-enter lower() for one BinaryExpr operand of an already-parsed vector-vector query apiece, likewise typechecker-constrained to a vector, so neither widens the set either; the #2346 split adds lowerSumOrAvgOverMixedExpHistogramSetOp as a second CALLER of lowerMixedExpHistogramOperands, but not a new re-entry into lower() itself — the operand it forwards is unchanged. lowerVectorSetOpOperand (cerberus issue #2325) replaces binary.go's lowerVectorSetOp as the direct caller: lowerVectorSetOp no longer calls lower() itself, routing both its and/or/unless operands through this helper instead, which forwards to lower() only the operand it has itself confirmed is NOT exp-histogram-valued — the same already-parsed, typechecker-constrained-to-vector expr lowerVectorSetOp used to pass straight through — so it narrows rather than widens too. lowerExpHistogramFloatVectorScalingBinop (cerberus issue #2339) re-enters lower() only for the float-valued operand of an already-parsed MUL/DIV BinaryExpr, likewise typechecker-constrained to a vector, so it doesn't widen the set either. lowerScalarVectorArg (cerberus issue #2515) replaces lowerScalarArg's own direct lower() call for scalar()'s vector argument: it recognises a histogram-valued argument via lowerExpHistogramValuedShape first and answers via dropExpHistogramSamples, forwarding to lower() only when that check comes back unmatched — the same already-parsed, typechecker-constrained-to-vector scalar() argument lowerScalarArg used to pass straight through — so it narrows rather than widens too. lowerLimitKInput (cerberus issue #2518) replaces lowerLimitK's and lowerLimitRatio's own direct lower() calls for their vector argument: it recognises a histogram-valued argument via lowerExpHistogramValuedShape first and forwards the input unchanged, calling lower() only when that check comes back unmatched — the same already-parsed, typechecker-constrained-to-vector aggregate argument lowerLimitK/lowerLimitRatio used to pass straight through — so it narrows rather than widens too. lowerTopKComputed's own direct lower() call is unchanged for topk/bottomk (a purely histogram-valued input is intercepted upstream by droppingAggregationOverExpHistogram before ever reaching it); for limitk it now routes through lowerLimitKInput exactly as the literal-K path does.",
+      "rationale": "Every expression shape reaching lower() through the HTTP handlers is dispatched (top-level matrix selectors included). The remaining inhabitants — NumberLiteral and StringLiteral, answered by the handler's constant fold / string shortcut before the engine runs, and StepInvariantExpr, which only parser.PreprocessExpr mints and cerberus never calls — cannot arrive here from the wire. The query entry points now reach this switch through lowerRoot, which peels off exactly one shape (a bare exp-histogram selector, answered by a histogram-valued lowering) and otherwise delegates unchanged, so it narrows the set of expressions that arrive rather than widening it. Re-verified across the in-package callers that re-enter lower() with a sub-expression, lowerHistogramQuantileClassicFloat included: each passes an operand of an already-parsed query whose position the upstream typechecker constrains to a vector, so no caller widens the set of shapes that reach the default arm. lowerExpHistogramDroppingVectorBinop (cerberus issue #2331) and lowerMixedExpHistogramOperands (cerberus issue #2330, split out of the former lowerMixedExpHistogramSetOp so histogram_native_mixed_or_aggregate.go's sum/avg-wrapped lowering — cerberus issue #2346 — can share the same operand lowering) re-enter lower() for one BinaryExpr operand of an already-parsed vector-vector query apiece, likewise typechecker-constrained to a vector, so neither widens the set either; the #2346 split adds lowerSumOrAvgOverMixedExpHistogramSetOp as a second CALLER of lowerMixedExpHistogramOperands, but not a new re-entry into lower() itself — the operand it forwards is unchanged. lowerVectorSetOpOperand (cerberus issue #2325) replaces binary.go's lowerVectorSetOp as the direct caller: lowerVectorSetOp no longer calls lower() itself, routing both its and/or/unless operands through this helper instead, which forwards to lower() only the operand it has itself confirmed is NOT exp-histogram-valued — the same already-parsed, typechecker-constrained-to-vector expr lowerVectorSetOp used to pass straight through — so it narrows rather than widens too. lowerExpHistogramFloatVectorScalingBinop (cerberus issue #2339) re-enters lower() only for the float-valued operand of an already-parsed MUL/DIV BinaryExpr, likewise typechecker-constrained to a vector, so it doesn't widen the set either. lowerScalarVectorArg (cerberus issue #2515) replaces lowerScalarArg's own direct lower() call for scalar()'s vector argument: it recognises a histogram-valued argument via lowerExpHistogramValuedShape first and answers via dropExpHistogramSamples, forwarding to lower() only when that check comes back unmatched — the same already-parsed, typechecker-constrained-to-vector scalar() argument lowerScalarArg used to pass straight through — so it narrows rather than widens too. lowerLimitKInput (cerberus issue #2518) replaces lowerLimitK's and lowerLimitRatio's own direct lower() calls for their vector argument: it recognises a histogram-valued argument via lowerExpHistogramValuedShape first and forwards the input unchanged, calling lower() only when that check comes back unmatched — the same already-parsed, typechecker-constrained-to-vector aggregate argument lowerLimitK/lowerLimitRatio used to pass straight through — so it narrows rather than widens too. lowerTopKComputed's own direct lower() call is unchanged for topk/bottomk (a purely histogram-valued input is intercepted upstream by droppingAggregationOverExpHistogram before ever reaching it); for limitk it now routes through lowerLimitKInput exactly as the literal-K path does. lowerScalarBinopOperand and lowerVectorVectorOperand (cerberus issue #2534, binary.go) replace lowerVectorScalar's and lowerVectorVector's own direct lower() calls for their vector operand(s): lowerScalarBinopOperand recognises an exp-histogram preserve- or drop-family argument via lowerExpHistogramArgAsCanonicalFloat first, forwarding to lower() only when that check comes back unmatched, and lowerVectorVectorOperand recognises a drop-family argument via lowerExpHistogramDroppingShape first — deliberately not the preserve family, since a directly-valued vector-vector operand is always already claimed by one of lowerRoot's own matching-mode-aware dispatches before lowerVectorVector's generic fallback runs, see lowerVectorVectorOperand's own doc comment — forwarding to lower() only when that check comes back unmatched too. In both cases the argument lower() ultimately receives is the identical already-parsed, typechecker-constrained-to-vector operand lowerVectorScalar/lowerVectorVector used to pass straight through before this issue's fix, so neither widens the set either.",
       "evidence": {
         "guard": [
           "default of switch e := expr.(type) over [case *parser.VectorSelector; case *parser.Call; case *parser.AggregateExpr; case *parser.ParenExpr; case *parser.BinaryExpr; case *parser.SubqueryExpr; case *parser.MatrixSelector; case *parser.UnaryExpr; default]"
@@ -156,20 +156,22 @@
           "lowerMixedExpHistogramOperands",
           "lowerRoot",
           "lowerRoundToNearest",
+          "lowerScalarBinopOperand",
           "lowerScalarVectorArg",
           "lowerSort",
           "lowerSortByLabel",
           "lowerTopK",
           "lowerTopKComputed",
           "lowerUnary",
-          "lowerVectorScalar",
           "lowerVectorSetOpOperand",
-          "lowerVectorVector"
+          "lowerVectorVectorOperand"
         ],
         "cited": [
           "dropExpHistogramSamples",
           "droppingAggregationOverExpHistogram",
           "lower",
+          "lowerExpHistogramArgAsCanonicalFloat",
+          "lowerExpHistogramDroppingShape",
           "lowerExpHistogramDroppingVectorBinop",
           "lowerExpHistogramFloatVectorScalingBinop",
           "lowerExpHistogramValuedShape",
@@ -181,11 +183,15 @@
           "lowerMixedExpHistogramSetOp",
           "lowerRoot",
           "lowerScalarArg",
+          "lowerScalarBinopOperand",
           "lowerScalarVectorArg",
           "lowerSumOrAvgOverMixedExpHistogramSetOp",
           "lowerTopKComputed",
+          "lowerVectorScalar",
           "lowerVectorSetOp",
-          "lowerVectorSetOpOperand"
+          "lowerVectorSetOpOperand",
+          "lowerVectorVector",
+          "lowerVectorVectorOperand"
         ]
       }
     },


### PR DESCRIPTION
## Problem

A drop-family exp-histogram binop nested as the **operand** of another binary
expression still hard-rejected via `expHistogramSelectorRouting`'s catch-all,
even though the identical shape lowers cleanly on its own or as a wrapper's
direct argument (cerberus issue #2528):

```text
(demo_latency_exp_hist + 0) * 2
(demo_latency_exp_hist + 0) + 5
sum(demo_latency_exp_hist + 0) + 1
(demo_latency_exp_hist + 0) or (demo_latency_exp_hist + 0)
```

Verified empirically against current `main` before touching any code — all
four fail with `expHistogramSelectorRouting`'s catch-all message.

## Root cause

`lowerVectorScalar`/`lowerVectorVector` (`internal/promql/binary.go`) and
`lowerVectorSetOpOperand` (`internal/promql/histogram_native_set_op.go`)
recursed into their operands via the plain `lower()` dispatcher, with no
per-operand opt-in analogous to the ~12 wrapper callsites #2528 patched (a
Call's single vector argument, an AggregateExpr's `Expr`). The core
recursive binop lowering itself never got a chance to retry
`lowerExpHistogramValuedShape`/`lowerExpHistogramDroppingShape` on a nested
sub-expression.

## Fix

- **`lowerScalarBinopOperand`** (new, `binary.go`) — threaded into
  `lowerVectorScalar`'s vec argument. Tries both the "preserve" and "drop"
  families via `lowerExpHistogramArgAsCanonicalFloat`. Safe to try both:
  a scalar operand carries no vector-matching mode to lose, and the two
  scalar-binop recognizers (`expHistogramScalarBinop` /
  `expHistogramDroppingScalarBinop`) match unconditionally whenever the
  operand is directly one of those shapes, so by construction this only
  ever fires on a genuinely NESTED composition.
- **`lowerVectorVectorOperand`** (new, `binary.go`) — threaded into
  `lowerVectorVector`'s two operands. Tries **only** the "drop" family.
  Composing an already-empty vector under any further V-V op or matching
  mode is unconditionally still empty, so this can never disagree with a
  matching-mode-aware outer recognizer. The "preserve" family is
  deliberately **excluded** here: eagerly resolving it would silently
  downgrade a matching-mode combination
  `expHistogramFloatVectorScalingBinop` deliberately still rejects (the
  histogram operand can't always play `HistogramFloatVectorJoin`'s `Left`
  role) into a wrong *empty* answer instead of the correct hard-reject.
  `TestLower_ExpHistogram_FloatVectorScalingBinopStillRejected` caught this
  exact regression during development — see the two new functions' doc
  comments for the full reasoning.
- **`lowerVectorSetOpOperand`** gets the same drop-family opt-in for
  `and`/`or`/`unless`.

## Tests

- `internal/promql/histogram_native_dropping_nested_binop_chdb_test.go`
  (new, chdb-tagged): seeds a real, non-empty exp-histogram row and runs
  the issue's own four trigger queries through `promql.LowerAt` →
  `chsql.Emit` → real ClickHouse (chDB), asserting each returns exactly
  zero rows — proving the SQL is valid and the drop is the reference-
  correct answer, not merely that the Go-level lowering error stopped
  firing.
- Full `internal/promql` suite (race + chdb-tagged, excluding the CI-only
  sharded `TestLower` spec-corpus round-trip, which needs
  `chdb-roundtrip.mjs`'s own timeout/sharding — a bare `go test` run of it
  outgrows the 10-minute default, unrelated to this change) passes,
  including `TestLower_ExpHistogram_FloatVectorScalingBinopStillRejected`.

## Rejection-parity catalogue

Rotated `internal/promql/lower.go:expHistogramSelectorRouting#bf746b59`'s
`trigger_query` from `(demo_latency_exp_hist + 0) * 2` to the next
reachable trigger, found by re-probing the guard chain post-fix:

```text
histogram_quantile(0.5, demo_latency_exp_hist) * on(service) demo_latency_exp_hist
```

`tracking_issue` now points at **#2537** (new, filed this PR): the
`HistogramFloatVectorJoin.Left`-must-be-histogram scaling boundary
`TestLower_ExpHistogram_FloatVectorScalingBinopStillRejected` already
documents but was never tracked by its own issue.

Also re-curated `internal/promql/lower.go:lower#d33d0084`'s `internal`
rationale, which this change's new callers (`lowerScalarBinopOperand`,
`lowerVectorVectorOperand`) moved the evidence under — regenerated twice
with `CERBERUS_UPDATE_INVENTORY=1 go test -run TestCatalogueIsRegenerable
./test/rejection-parity/...` per the repo's own hand-edit discipline.

## Verification

- `go build ./...`
- `go test -race ./internal/promql/... ./test/rejection-parity/...`
- `go test -tags chdb -count=1 -skip '^TestLower$' ./internal/promql/...`
  (the excluded `TestLower` is the CI-only sharded spec-corpus lane)
- `go test -race ./test/spec/... ./internal/optimizer/... ./internal/chplan/...`
- `node .github/scripts/forbid-sql-raw.mjs`
- `gofumpt -l` / `goimports -l` clean

No emitted SQL/chplan shape changed for any previously-succeeding query —
this only adds a new success path where lowering used to hard-reject — so
no golden regeneration was needed.

Closes #2534
