### PR TITLE
test(promql): cover the vector-vector operand path #2538's nested-binop fix added

### DIFF
--- a/internal/promql/histogram_native_dropping_nested_binop_chdb_test.go
+++ b/internal/promql/histogram_native_dropping_nested_binop_chdb_test.go
@@ -12,12 +12,63 @@
 // (histogram_native_dropping_shape_test.go) already pins the SAME leaf
 // composed under a WRAPPER's own argument position (cerberus issue #2528)
 // at the Go-plan-shape level — this file is that fixture's chDB-executed,
-// binop-nested sibling, using the issue's own four trigger queries
-// verbatim.
+// binop-nested sibling.
 //
-// The metric is seeded with a REAL, non-empty row so a returned zero-row
-// result can only mean the drop actually fired — not that no data was
-// ever scanned.
+// Two metrics are seeded with REAL, non-empty rows — nestedBinopDropMetric
+// and nestedBinopDropMetric2 — so a returned zero-row result can only mean
+// a drop actually fired, never that no data was ever scanned. The second
+// series exists solely for the two-operand cases below, where a single
+// metric would let the query collapse to a self-join and hide a
+// mismatched-series bug.
+//
+// Per-query routing (verified by tracing lowerBinary's actual dispatch,
+// not assumed from the shape of the query — see the per-query comments in
+// TestLower_ExpHistogram_DroppingShapeNestedInBinop_ChDB below):
+//   - `(m1 + 0) * 2`, `(m1 + 0) + 5`, `sum(m1 + 0) + 1`: all three route
+//     through lowerVectorScalar → lowerScalarBinopOperand, because the
+//     scalar literal on one side is exactly what routes lowerBinary away
+//     from lowerVectorVector. None of these three reach
+//     lowerVectorVectorOperand — a prior version of this file's header
+//     incorrectly claimed the third one did.
+//   - `(m1 + 0) or (m1 + 0)`: a set operator, routes through
+//     lowerVectorSetOp → lowerVectorSetOpOperand, not lowerVectorVectorOperand
+//     either — set operators never reach lowerVectorVector at all
+//     (lowerBinary branches on b.Op.IsSetOperator() before ever computing
+//     which of lowerVectorScalar / lowerVectorVector applies).
+//   - `(m1 < m2) * (m1 < m2)`: the genuine vector-vector case, and the one
+//     this file's original four queries never actually reached. `m1 < m2`
+//     (no `bool`) is expHistogramDroppingHistogramBinop's own leaf shape
+//     (a comparison between two BARE histogram-valued selectors, an
+//     unsupported histogram/histogram combo reference drops) — nested as
+//     the operand of a further, real vector-vector `*`. Neither outer
+//     operand is a scalar literal, so lowerBinary falls to the default
+//     lowerVectorVector branch, and BOTH operands separately hit
+//     lowerVectorVectorOperand's drop-family match. This is deliberately
+//     NOT `(m1 + 0) * (m2 + 0)` (this file's own first draft): that shape,
+//     while it DOES route through lowerVectorVectorOperand, would still
+//     resolve correctly even with lowerVectorVectorOperand's drop-family
+//     check ripped out — `m1 + 0` recurses back into lowerBinary on its
+//     own via the generic [lower] fallback and gets caught a second time by
+//     the already-covered lowerScalarBinopOperand, silently laundering a
+//     hollow test. `m1 < m2` has no such redundant path: with
+//     lowerVectorVectorOperand's drop check removed, lowering this exact
+//     query regresses to a hard LowerAt error ("... is an exponential
+//     histogram metric; only a bare ... selector ... are supported") —
+//     verified directly against this worktree before writing this comment,
+//     not assumed.
+//   - `(m1 == m2) + 1`: exercises lowerScalarBinopOperand's OTHER half —
+//     the "preserve" family opt-in (lowerExpHistogramArgAsCanonicalFloat's
+//     first branch, lowerExpHistogramValuedShape) rather than the "drop"
+//     family. `m1 == m2` (no `bool`) is recognised by
+//     expHistogramHistogramCompareBinop as histogram-VALUED, but that
+//     recogniser is (deliberately) absent from isExpHistogramValuedShape's
+//     own predicate, so lowerRoot's top-level dispatch never claims the
+//     WHOLE `(m1 == m2) + 1` expression — it only escapes to
+//     lowerVectorScalar → lowerScalarBinopOperand(`m1 == m2`), which then
+//     matches via the preserve-family branch and reprojects to the
+//     canonical empty float quartet, exactly the way ADD over a real
+//     histogram sample must (reference drops the sample; there is no
+//     scalar Value to add 1 to).
 package promql_test
 
 import (
@@ -33,7 +84,10 @@ import (
 	"github.com/tsouza/cerberus/internal/testsql"
 )
 
-const nestedBinopDropMetric = "nested_binop_drop_probe_exp_hist"
+const (
+	nestedBinopDropMetric  = "nested_binop_drop_probe_exp_hist"
+	nestedBinopDropMetric2 = "nested_binop_drop_probe2_exp_hist"
+)
 
 var nestedBinopDropSeed = "" +
 	"CREATE OR REPLACE TABLE otel_metrics_exponential_histogram (" +
@@ -46,18 +100,20 @@ var nestedBinopDropSeed = "" +
 	") ENGINE = MergeTree ORDER BY (`MetricName`, `Attributes`, `TimeUnix`);\n" +
 	"INSERT INTO otel_metrics_exponential_histogram " +
 	"(MetricName, Attributes, TimeUnix, Count, Sum, Scale, ZeroCount, PositiveOffset, PositiveBucketCounts, NegativeOffset, NegativeBucketCounts) VALUES\n" +
-	"    ('" + nestedBinopDropMetric + "', map('service', 'checkout'), toDateTime64('2026-01-01 00:00:00', 9), 5, 10.0, 0, 0, 0, [5], 0, []);\n"
+	"    ('" + nestedBinopDropMetric + "', map('service', 'checkout'), toDateTime64('2026-01-01 00:00:00', 9), 5, 10.0, 0, 0, 0, [5], 0, []),\n" +
+	"    ('" + nestedBinopDropMetric2 + "', map('service', 'checkout'), toDateTime64('2026-01-01 00:00:00', 9), 7, 14.0, 0, 0, 0, [7], 0, []);\n"
 
 var nestedBinopDropEvalTS = time.Date(2026, 1, 1, 0, 0, 1, 0, time.UTC)
 
 // TestLower_ExpHistogram_DroppingShapeNestedInBinop_ChDB pins cerberus
-// issue #2534's own four trigger queries: a drop-family binop
-// (`<metric> + 0`) nested as the operand of a further scalar binop
-// ([lowerScalarBinopOperand]), a further vector-vector binop reached
-// through an aggregation wrapper ([lowerVectorVectorOperand]), and a
-// vector set op ([lowerVectorSetOpOperand]'s own drop-family opt-in).
-// Every one of these previously hard-rejected via
-// expHistogramSelectorRouting's catch-all before ever reaching SQL.
+// issue #2534's own four trigger queries plus two follow-on cases that
+// close a coverage gap an adversarial review found in this file's
+// original four: none of them actually reached lowerVectorVectorOperand
+// (the function this issue added specifically for a drop-family binop
+// nested as a genuine vector-vector op's operand), and the "preserve"
+// family half of lowerScalarBinopOperand's opt-in was likewise never
+// exercised nested. See the per-query routing notes in this file's own
+// header comment.
 func TestLower_ExpHistogram_DroppingShapeNestedInBinop_ChDB(t *testing.T) {
 	fixture := newChDBFixture(t, nestedBinopDropSeed)
 	s := schema.DefaultOTelMetrics()
@@ -65,16 +121,31 @@ func TestLower_ExpHistogram_DroppingShapeNestedInBinop_ChDB(t *testing.T) {
 
 	queries := []string{
 		// lowerVectorScalar's operand opt-in (a scalar on the outer
-		// binop's RHS).
+		// binop's RHS) — routes through lowerScalarBinopOperand's drop
+		// family.
 		"(" + nestedBinopDropMetric + " + 0) * 2",
 		"(" + nestedBinopDropMetric + " + 0) + 5",
 		// lowerVectorScalar's operand opt-in again, this time over an
 		// AggregateExpr wrapping the drop-family leaf (composes
 		// [lowerExpHistogramDroppingShape]'s own aggregation recursion,
-		// cerberus issue #2528, one level deeper).
+		// cerberus issue #2528, one level deeper) — still
+		// lowerScalarBinopOperand, not lowerVectorVectorOperand.
 		"sum(" + nestedBinopDropMetric + " + 0) + 1",
 		// lowerVectorSetOpOperand's drop-family opt-in.
 		"(" + nestedBinopDropMetric + " + 0) or (" + nestedBinopDropMetric + " + 0)",
+		// lowerVectorVectorOperand's drop-family opt-in — the genuine
+		// vector-vector case, previously untested. Two DISTINCT series so
+		// this can't accidentally pass via a self-join, and a comparison
+		// (not `+0`) so this can't accidentally pass via the redundant
+		// lowerScalarBinopOperand path — see this file's header comment.
+		"(" + nestedBinopDropMetric + " < " + nestedBinopDropMetric2 + ") * (" + nestedBinopDropMetric + " < " + nestedBinopDropMetric2 + ")",
+		// lowerScalarBinopOperand's PRESERVE-family opt-in, nested — the
+		// sibling gap to the drop-family cases above. `m1 == m2` (no
+		// `bool`) is histogram-valued but invisible to
+		// isExpHistogramValuedShape, so it only resolves via
+		// lowerExpHistogramArgAsCanonicalFloat's first branch, reached
+		// through lowerScalarBinopOperand.
+		"(" + nestedBinopDropMetric + " == " + nestedBinopDropMetric2 + ") + 1",
 	}
 
 	for _, query := range queries {
@@ -107,7 +178,7 @@ func TestLower_ExpHistogram_DroppingShapeNestedInBinop_ChDB(t *testing.T) {
 			}
 			if n != 0 {
 				t.Fatalf(
-					"query %q returned count()=%d, want 0 — reference drops every sample through an incompatible-type histogram/scalar (or histogram/histogram) binop; the metric was seeded with a REAL non-empty row, so a non-zero count would mean the drop never actually fired at execution",
+					"query %q returned count()=%d, want 0 — reference drops every sample through an incompatible-type histogram/scalar (or histogram/histogram) binop; the metric(s) were seeded with REAL non-empty rows, so a non-zero count would mean the drop never actually fired at execution",
 					query, n,
 				)
 			}


### PR DESCRIPTION
## Summary

Follow-up to #2538 (#2534): adds real test coverage for lowerVectorVectorOperand's
matching branch, which #2538's own test suite did not actually exercise despite its
header comment's claim — found by this session's own adversarial review of #2538
before merge.

- Verified (by tracing lowerBinary's actual dispatch and by neutering each opt-in in
  turn and confirming lowering regresses to a hard rejection) that all four of
  #2538's original test queries route through `lowerScalarBinopOperand` or
  `lowerVectorSetOpOperand`, never through `lowerVectorVectorOperand` — the function
  #2538 added specifically for a drop-family exp-histogram binop nested as a real
  vector-vector op's operand.
- Adds a comparison-shaped drop-family leaf nested under a real vector-vector `*`
  (`(m1 < m2) * (m1 < m2)`, two distinct exp-histogram series) that genuinely reaches
  `lowerVectorVectorOperand`'s own drop-family match — confirmed non-redundant by
  neutering that opt-in and observing the query regress to a hard `LowerAt` rejection.
- Adds a histogram-histogram compare nested under a scalar `+`
  (`(m1 == m2) + 1`) that reaches `lowerScalarBinopOperand`'s "preserve" family half
  — likewise confirmed non-redundant the same way.
- Fixes the test file's header comment, which incorrectly claimed one of the original
  four queries already exercised `lowerVectorVectorOperand`.

Both new cases run a real chDB roundtrip (seeded non-empty exp-histogram rows,
asserting the emitted SQL executes and returns the correct zero-row result),
following the file's own existing pattern.

Not closing #2534 — that issue is already closed by #2538. This is pure
test-coverage follow-up.

## Test plan

- [x] `go build ./...`
- [x] `go test -tags chdb -run '^TestLower_ExpHistogram_DroppingShapeNestedInBinop_ChDB$' ./internal/promql/...` — all 6 subtests pass
- [x] `go test -race -run '^TestLower_ExpHistogram_FloatVectorScalingBinopStillRejected$' ./internal/promql/...` — still passes (the boundary this PR does not touch)
- [x] `gofumpt -extra -l` / `goimports -local` clean on the changed file
- [x] `git diff origin/main` on this branch is exactly the one test file's changes

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>