### PR TITLE
fix(promql): allow the histogram operand on either side of a scaling join

### DIFF
--- a/internal/chplan/histogram_float_vector_join.go
+++ b/internal/chplan/histogram_float_vector_join.go
@@ -5,8 +5,10 @@ import "slices"
 // HistogramFloatVectorJoin implements MUL (either operand order) and
 // histogram-left DIV histogram-SCALING by a genuine per-series float-
 // VECTOR operand (cerberus issue #2339), widened to on()/ignoring()
-// reduced-key matching and the "histogram is the many side"
-// group_left()/group_right() broadcast (cerberus issue #2342).
+// reduced-key matching and group_left()/group_right() broadcast in
+// either direction — histogram-many or histogram-one — regardless of
+// which side of the PromQL expression the histogram operand was written
+// on (cerberus issue #2342, further widened by #2537).
 // [expHistogramScalarBinop]'s scaling machinery
 // (internal/promql/histogram_native_scalar_binop.go, #2087) already
 // folds a compile-time scalar LITERAL scale factor into every histogram
@@ -42,30 +44,51 @@ import "slices"
 // CardManyToOne keeps Left (the histogram side) at full per-series
 // granularity — the "many" — while Right (the float side) collapses to
 // one row per matching key — the "one" — with Include copying named
-// labels from Right onto the output Attributes. Left is ALWAYS the
-// histogram-valued operand regardless of which operand PromQL's
-// group_left()/group_right() syntax names as "many", so a caller that
-// recognises the mirror-image shape (float LHS, `group_right()`,
-// histogram RHS) still sets Card to CardManyToOne — the emitter's Card
-// vocabulary describes Left/Right roles, not PromQL's original operand
-// order. CardOneToMany (the histogram side broadcasting as the "one"
-// against many float rows) is not supported: the emitter rejects it
-// outright rather than silently mis-joining.
+// labels from Right onto the output Attributes. CardOneToMany is the
+// mirror image: Right (the float side) stays "many" while Left (the
+// histogram side) collapses to one row per matching key — broadcasting
+// that single matched histogram across every matching float row — with
+// Include copying named labels from Left onto the output Attributes
+// (cerberus issue #2537). Left is ALWAYS the histogram-valued operand
+// regardless of which operand PromQL's group_left()/group_right() syntax
+// names as "many", so a caller resolves its own PromQL cardinality
+// keyword against which operand carries the histogram: `group_left()`
+// with the histogram as the syntactic LHS, or `group_right()` with the
+// histogram as the syntactic RHS, both set Card to CardManyToOne (hist
+// many); the mirror-image operand orders — `group_left()` with the
+// histogram on the RHS, or `group_right()` with the histogram on the
+// LHS — set Card to CardOneToMany (hist one, broadcast) instead. The
+// emitter's Card vocabulary describes Left/Right roles, not PromQL's
+// original operand order.
+//
+// CardOneToOne needs no such Left/Right role bit, even though
+// Prometheus's own resultMetric reduces the SYNTACTIC LHS operand's
+// labels (Keep for on(), Del for ignoring()) while Left here is always
+// the histogram operand: the join's own ON-clause equality (see
+// internal/chsql's matchKeyPredicateFrag) already forces L's and R's
+// on()/ignoring()-reduced Attributes to be identical for any row that
+// joins at all — on() keeps only the named labels, whose VALUES the ON
+// clause requires equal per label; ignoring() keeps everything else, and
+// the ON clause requires that entire reduced map to be equal as a whole.
+// Either side therefore reduces to the byte-identical output, so the
+// emitter always reduces Left — see internal/chsql's
+// histogramFloatVectorJoinOutputAttributesFrag — without needing to know
+// which operand PromQL originally wrote first.
 type HistogramFloatVectorJoin struct {
 	Left  Node // *HistogramProjection, the histogram-valued operand.
 	Right Node // The plain float-valued operand.
 
 	Match VectorMatch
 
-	// Card is the cardinality modifier; default CardOneToOne. Only
-	// CardOneToOne and CardManyToOne are supported — see the type doc.
+	// Card is the cardinality modifier; default CardOneToOne.
+	// CardOneToOne, CardManyToOne, and CardOneToMany are all supported —
+	// see the type doc.
 	Card VectorCard
 	// Include is the group_left(<labels>)/group_right(<labels>) extra-
-	// label list, copied from Right (the float side, always the "one"
-	// under the only supported CardManyToOne shape) onto the output
-	// Attributes. Nil/empty when no Include was specified, or when
-	// Card is CardOneToOne (Include is a group_left/group_right-only
-	// modifier).
+	// label list, copied from the "one" side (Right under CardManyToOne,
+	// Left under CardOneToMany) onto the output Attributes. Nil/empty
+	// when no Include was specified, or when Card is CardOneToOne
+	// (Include is a group_left/group_right-only modifier).
 	Include []string
 
 	// StepAligned mirrors VectorJoin.StepAligned / HistogramVectorJoin.

--- a/internal/chsql/histogram_float_vector_join.go
+++ b/internal/chsql/histogram_float_vector_join.go
@@ -42,9 +42,13 @@ import (
 // sample" argMax / derived-shape / step-aligned logic emitVectorJoin's
 // own Right arm already exercises — so this file adds no new per-side
 // join mechanics of its own, only the histogram Left arm's field list,
-// the output-Attributes fold (CardOneToOne Keep/Del, sided by HistIsLHS,
-// or CardManyToOne/CardOneToMany Include overlay — [histogramFloat
-// VectorJoinOutputAttributesFrag]), and the outer SELECT/JOIN shape.
+// the output-Attributes fold (CardOneToOne Keep/Del, always reduced off
+// Left regardless of which side PromQL's on()/ignoring() named — sound
+// because the join's own ON-clause equality already forces both sides'
+// reduced Attributes to be byte-identical for any row that joins at all,
+// see [chplan.HistogramFloatVectorJoin]'s own doc — or CardManyToOne/
+// CardOneToMany Include overlay — [histogramFloatVectorJoinOutput
+// AttributesFrag]), and the outer SELECT/JOIN shape.
 func (e *emitter) emitHistogramFloatVectorJoin(j *chplan.HistogramFloatVectorJoin) error {
 	if err := e.validateHistogramFloatVectorJoinCols(j); err != nil {
 		return err

--- a/internal/chsql/histogram_float_vector_join.go
+++ b/internal/chsql/histogram_float_vector_join.go
@@ -8,7 +8,10 @@ import (
 
 // histogram_float_vector_join.go emits chplan.HistogramFloatVectorJoin
 // (cerberus issue #2339, widened to on()/ignoring()/group_left()/
-// group_right() by #2342): a real INNER JOIN between a histogram-valued
+// group_right() by #2342, further widened to the histogram operand
+// playing either the "many" or the "one" role under group_left()/
+// group_right() regardless of which side of the PromQL expression it was
+// written on by #2537): a real INNER JOIN between a histogram-valued
 // operand (Left, a *chplan.HistogramProjection) and a plain float-valued
 // operand (Right), keyed on Match.
 //
@@ -29,17 +32,19 @@ import (
 // CardOneToOne keeps both sides at roleMany (each already unique on the
 // full key by construction); an on()/ignoring() reduced key makes both
 // sides roleOne (collapse + ambiguity guard); CardManyToOne keeps Left
-// (the histogram side, always the "many" under the only cardinality this
-// node supports) at roleMany and collapses Right to roleOne. Left reuses
+// (the histogram side) at roleMany and collapses Right to roleOne;
+// CardOneToMany is the mirror image — Left (the histogram side)
+// collapses to roleOne, broadcasting the single matched histogram across
+// every matching Right (float) row at roleMany. Left reuses
 // [emitter.histogramFieldsJoinSideFrag] — the exact collapse-and-guard
 // logic emitHistogramVectorJoin's own roleOne arm already exercises.
 // Right reuses [emitter.joinSideFrag] — the exact per-side "latest
 // sample" argMax / derived-shape / step-aligned logic emitVectorJoin's
 // own Right arm already exercises — so this file adds no new per-side
 // join mechanics of its own, only the histogram Left arm's field list,
-// the output-Attributes fold (CardOneToOne Keep/Del or CardManyToOne
-// Include overlay — [histogramFloatVectorJoinOutputAttributesFrag]), and
-// the outer SELECT/JOIN shape.
+// the output-Attributes fold (CardOneToOne Keep/Del, sided by HistIsLHS,
+// or CardManyToOne/CardOneToMany Include overlay — [histogramFloat
+// VectorJoinOutputAttributesFrag]), and the outer SELECT/JOIN shape.
 func (e *emitter) emitHistogramFloatVectorJoin(j *chplan.HistogramFloatVectorJoin) error {
 	if err := e.validateHistogramFloatVectorJoinCols(j); err != nil {
 		return err
@@ -85,12 +90,8 @@ func (e *emitter) validateHistogramFloatVectorJoinCols(j *chplan.HistogramFloatV
 		return fmt.Errorf("%w: HistogramFloatVectorJoin.TimestampColumn unset", ErrUnsupported)
 	case j.ValueColumn == "":
 		return fmt.Errorf("%w: HistogramFloatVectorJoin.ValueColumn unset", ErrUnsupported)
-	case j.Card != chplan.CardOneToOne && j.Card != chplan.CardManyToOne:
-		// CardOneToMany would mean the histogram side plays the "one"
-		// role, broadcasting a single histogram across many float rows —
-		// not a shape this node supports (see its own doc comment).
-		// Reject outright rather than silently mis-joining.
-		return fmt.Errorf("%w: HistogramFloatVectorJoin.Card must be CardOneToOne or CardManyToOne", ErrUnsupported)
+	case j.Card != chplan.CardOneToOne && j.Card != chplan.CardManyToOne && j.Card != chplan.CardOneToMany:
+		return fmt.Errorf("%w: HistogramFloatVectorJoin.Card must be CardOneToOne, CardManyToOne, or CardOneToMany", ErrUnsupported)
 	}
 	return nil
 }
@@ -98,16 +99,21 @@ func (e *emitter) validateHistogramFloatVectorJoinCols(j *chplan.HistogramFloatV
 // histogramFloatVectorJoinRoles resolves the per-side aggregation roles,
 // mirroring [vectorJoinRoles] / [histogramVectorJoinRoles]:
 //
-//   - CardManyToOne → Left (histogram) is many, Right (float) is one —
-//     the only broadcast direction this node supports.
+//   - CardManyToOne → Left (histogram) is many, Right (float) is one.
+//   - CardOneToMany → Left (histogram) is one, Right (float) is many —
+//     the single matched histogram row broadcasts across every matching
+//     float row (cerberus issue #2537).
 //   - CardOneToOne with full-Attributes match → both sides are "many";
 //     the per-series aggregation already guarantees one row per
 //     matching key.
 //   - CardOneToOne with a subset (on()/ignoring()) match → both sides
 //     are "one" (uniqueness enforced at runtime on both).
 func histogramFloatVectorJoinRoles(j *chplan.HistogramFloatVectorJoin) (sideRole, sideRole) {
-	if j.Card == chplan.CardManyToOne {
+	switch j.Card {
+	case chplan.CardManyToOne:
 		return roleMany, roleOne
+	case chplan.CardOneToMany:
+		return roleOne, roleMany
 	}
 	if len(j.Match.Labels) == 0 && !j.Match.On {
 		return roleMany, roleMany
@@ -118,28 +124,45 @@ func histogramFloatVectorJoinRoles(j *chplan.HistogramFloatVectorJoin) (sideRole
 // histogramFloatVectorJoinOutputAttributesFrag returns the join's output
 // Attributes expression:
 //
-//   - CardOneToOne: the histogram (Left) side's own Attributes, reduced
-//     to the matching label set per Prometheus's resultMetric Keep/Del
-//     rule — [outputMatchSetFrag], the exact same reduction
-//     emitVectorJoin's own CardOneToOne output applies. Default matching
-//     is a no-op reduction, so this renders the identical bare `L.
-//     Attributes` the pre-#2342 code always emitted — byte-stable for
-//     every existing default-matching fixture.
-//   - CardManyToOne: the "many" side's (Left, the histogram operand)
-//     full Attributes, optionally overlaid with the "one" side's
-//     (Right, the float operand) Include labels via `mapConcat` — CH's
-//     later-argument-wins map merge, mirroring [outputAttributesFrag]'s
-//     identical group_left/right overlay for plain VectorJoin. Bare
-//     group_left/right (no Include labels) leaves Left's Attributes
-//     unchanged: Prometheus's CardOneToOne Keep/Del reduction does not
-//     apply to a many-to-one cardinality.
+//   - CardOneToOne: Left (the histogram operand)'s own Attributes,
+//     reduced to the matching label set per Prometheus's resultMetric
+//     Keep/Del rule ([outputMatchSetFrag], the exact same reduction
+//     emitVectorJoin's own CardOneToOne output applies). Prometheus
+//     reduces the SYNTACTIC LHS operand's own labels, which is not
+//     always Left here — but the join's own ON-clause equality already
+//     forces L's and R's reduced Attributes to be byte-identical for any
+//     row that joins at all (see [chplan.HistogramFloatVectorJoin]'s own
+//     doc), so reducing Left unconditionally is correct regardless of
+//     which side of `*`/`/` the histogram operand was written on.
+//     Default matching is a no-op reduction, so this renders the
+//     identical bare `L.Attributes` the pre-#2342 code always emitted —
+//     byte-stable for every existing default-matching fixture.
+//   - CardManyToOne / CardOneToMany: the "many" side's full Attributes
+//     (Left under CardManyToOne, Right under CardOneToMany), optionally
+//     overlaid with the "one" side's Include labels via `mapConcat` —
+//     CH's later-argument-wins map merge, mirroring
+//     [outputAttributesFrag]'s identical group_left/right overlay for
+//     plain VectorJoin. Bare group_left/right (no Include labels) leaves
+//     the "many" side's Attributes unchanged: Prometheus's CardOneToOne
+//     Keep/Del reduction does not apply to a many-to-one cardinality.
 func histogramFloatVectorJoinOutputAttributesFrag(j *chplan.HistogramFloatVectorJoin) Frag {
 	attrs := j.AttributesColumn
-	if j.Card != chplan.CardManyToOne {
+	manySide := ""
+	switch j.Card {
+	case chplan.CardManyToOne:
+		manySide = "L"
+	case chplan.CardOneToMany:
+		manySide = "R"
+	}
+	if manySide == "" {
 		return outputMatchSetFrag(j.Match, "L", attrs)
 	}
 	if len(j.Include) == 0 {
-		return qualColFrag("L", attrs)
+		return qualColFrag(manySide, attrs)
+	}
+	oneSide := "R"
+	if manySide == "R" {
+		oneSide = "L"
 	}
 	includes := make([]Frag, len(j.Include))
 	for i, lbl := range j.Include {
@@ -148,9 +171,9 @@ func histogramFloatVectorJoinOutputAttributesFrag(j *chplan.HistogramFloatVector
 	overlay := Call(
 		"mapFilter",
 		Lambda2("k", "v", In(BareIdent("k"), includes...)),
-		qualColFrag("R", attrs),
+		qualColFrag(oneSide, attrs),
 	)
-	return Call("mapConcat", qualColFrag("L", attrs), overlay)
+	return Call("mapConcat", qualColFrag(manySide, attrs), overlay)
 }
 
 // histogramFloatVectorJoinHistCols lists every field the join's Left

--- a/internal/promql/histogram_native_float_vector_scaling_binop.go
+++ b/internal/promql/histogram_native_float_vector_scaling_binop.go
@@ -35,14 +35,16 @@ import (
 // so the two recognisers stay disjoint without an explicit exclusion
 // here.
 //
-// on()/ignoring() reduced-key matching and the "histogram is the many
-// side" group_left()/group_right() broadcast are recognised as of
-// cerberus issue #2342, by threading vm's Match/Card/Include straight
-// onto [chplan.HistogramFloatVectorJoin] — that node's own Match field
-// and the chsql emitter's shared join-key helpers (matchKeyGroupExprFrag,
-// vectorMatchPredicateFrag, outputMatchSetFrag) already generalise over
-// chplan.VectorMatch / chplan.VectorCard, so widening needed no new
-// chplan/chsql join mechanics — see internal/chsql/histogram_float_
+// on()/ignoring() reduced-key matching and the group_left()/
+// group_right() broadcast — in EITHER direction, regardless of which
+// side of the PromQL expression the histogram operand was written on —
+// are recognised as of cerberus issues #2342 and #2537, by threading
+// vm's Match/Card/Include onto [chplan.HistogramFloatVectorJoin]. That
+// node's own Match field and the chsql emitter's shared join-key helpers
+// (matchKeyGroupExprFrag, vectorMatchPredicateFrag, outputMatchSetFrag)
+// already generalise over chplan.VectorMatch / chplan.VectorCard, so
+// this widening needed no new chplan/chsql join mechanics beyond the
+// CardOneToMany role split — see internal/chsql/histogram_float_
 // vector_join.go's own header doc for the per-side role split this
 // unlocks.
 //
@@ -50,32 +52,29 @@ import (
 // PromQL AST's actual LHS/RHS (`group_left()` keeps the syntactic LHS
 // many; `group_right()` keeps the syntactic RHS many), but
 // chplan.HistogramFloatVectorJoin.Left is ALWAYS the histogram operand
-// regardless of which side of `*`/`/` it was written on. The `histIsLHS`
-// check below resolves that: only the shape where the histogram operand is
-// the AST's "many" side is supported — `demo_latency_exp_hist * on(job)
-// group_left() float_vec` (hist LHS, group_left) and its mirror-image
-// operand order `float_vec * on(job) group_right() demo_latency_exp_hist`
-// (hist RHS, group_right) both map onto chplan.CardManyToOne (Left many,
-// Right one); the reverse cardinality — the histogram side broadcasting
-// as the "one" against many float rows — is not supported and falls
-// through to the pre-existing catch-all rejection rather than being
-// silently mis-joined.
+// regardless of which side of `*`/`/` it was written on. The `histLHS`
+// flag computed below resolves that mismatch by picking the chplan Card
+// that keeps the SAME physical role the PromQL cardinality keyword
+// names: `demo_latency_exp_hist * on(job) group_left() float_vec` (hist
+// LHS, group_left) and its mirror-image operand order `float_vec *
+// on(job) group_right() demo_latency_exp_hist` (hist RHS, group_right)
+// both keep the histogram "many", so both map onto chplan.CardManyToOne
+// (Left many, Right one); `float_vec * on(job) group_left()
+// demo_latency_exp_hist` (hist RHS, group_left) and `demo_latency_exp_hist
+// * on(job) group_right() float_vec` (hist LHS, group_right) both keep
+// the histogram "one" — broadcasting the single matched histogram across
+// every matching float row — so both map onto chplan.CardOneToMany (Left
+// one, Right many).
 //
-// CardOneToOne with an on()/ignoring() reduced key has the same
-// asymmetry for a different reason: Prometheus's resultMetric reduces
-// the ACTUAL SYNTACTIC LHS operand's own labels (Keep for on(),
-// Del for ignoring()), and chplan.HistogramFloatVectorJoin always
-// publishes the reduction over Left (the histogram side)'s own
-// Attributes — see internal/chsql's histogramFloatVectorJoinOutputAttributesFrag.
-// So a reduced-key CardOneToOne match is only recognised when the
-// histogram operand IS the syntactic LHS; the mirror MUL order (`float_vec
-// * on(job) demo_latency_exp_hist`, no group modifier) falls through to
-// the catch-all rejection rather than reducing the wrong operand's
-// labels. DEFAULT (full-Attributes) CardOneToOne matching is unaffected
-// by this restriction — Keep/Del is then a no-op, so it makes no
-// difference which operand's Attributes the (byte-identical) output
-// derives from, and both MUL orders stay supported exactly as #2339
-// shipped them.
+// CardOneToOne with an on()/ignoring() reduced key needs no such
+// operand-order tracking, even though Prometheus's resultMetric reduces
+// the ACTUAL SYNTACTIC LHS operand's own labels (Keep for on(), Del for
+// ignoring()) while chplan.HistogramFloatVectorJoin.Left is always the
+// histogram side: as [chplan.HistogramFloatVectorJoin]'s own doc proves,
+// the join's ON-clause equality already forces both sides' reduced
+// Attributes to be byte-identical for any row that joins at all, so the
+// emitter reduces Left unconditionally and both MUL/DIV operand orders
+// stay supported without the recognizer having to pick a side.
 //
 // Wired at [lowerRoot] ahead of [expHistogramDroppingVectorBinop] — the
 // same TOP-LEVEL-only dispatch point as its siblings, mirroring how the
@@ -125,7 +124,7 @@ func expHistogramFloatVectorScalingBinop(expr parser.Expr, s schema.Metrics, ctx
 	default:
 		return nil, nil, "", chplan.VectorMatch{}, chplan.CardOneToOne, nil, false
 	}
-	histIsLHS := hist == b.LHS
+	histLHS := hist == b.LHS
 
 	vm := b.VectorMatching
 	promCard := parser.CardOneToOne
@@ -135,13 +134,6 @@ func expHistogramFloatVectorScalingBinop(expr parser.Expr, s schema.Metrics, ctx
 
 	switch promCard {
 	case parser.CardOneToOne:
-		if vm != nil && (len(vm.MatchingLabels) > 0 || vm.On) && !histIsLHS {
-			// See this file's header doc: a reduced-key CardOneToOne
-			// match must reduce the syntactic LHS operand's own
-			// labels, which the emitter only knows how to do for the
-			// histogram (Left) side.
-			return nil, nil, "", chplan.VectorMatch{}, chplan.CardOneToOne, nil, false
-		}
 		m := chplan.VectorMatch{}
 		if vm != nil {
 			m.Labels = append([]string(nil), vm.MatchingLabels...)
@@ -149,29 +141,36 @@ func expHistogramFloatVectorScalingBinop(expr parser.Expr, s schema.Metrics, ctx
 		}
 		return hist, float, chOp, m, chplan.CardOneToOne, nil, true
 	case parser.CardManyToOne:
-		// group_left() keeps the syntactic LHS "many" — only supported
-		// when the histogram operand IS that LHS.
-		if !histIsLHS {
-			return nil, nil, "", chplan.VectorMatch{}, chplan.CardOneToOne, nil, false
+		// group_left() keeps the syntactic LHS "many". When the
+		// histogram operand IS that LHS, the histogram stays "many" —
+		// chplan.CardManyToOne (Left/histogram many, Right/float one).
+		// Otherwise the histogram operand is the RHS, which group_left()
+		// keeps as the "one" side — chplan.CardOneToMany (Left/histogram
+		// one, broadcasting across every matching Right/float row).
+		m := chplan.VectorMatch{Labels: append([]string(nil), vm.MatchingLabels...), On: vm.On}
+		inc := append([]string(nil), vm.Include...)
+		chCard := chplan.CardOneToMany
+		if histLHS {
+			chCard = chplan.CardManyToOne
 		}
+		return hist, float, chOp, m, chCard, inc, true
 	case parser.CardOneToMany:
-		// group_right() keeps the syntactic RHS "many" — only
-		// supported when the histogram operand IS that RHS.
-		if histIsLHS {
-			return nil, nil, "", chplan.VectorMatch{}, chplan.CardOneToOne, nil, false
+		// group_right() keeps the syntactic RHS "many". When the
+		// histogram operand is that RHS, the histogram stays "many" —
+		// chplan.CardManyToOne (Left/histogram many, Right/float one).
+		// Otherwise the histogram operand is the LHS, which
+		// group_right() keeps as the "one" side — chplan.CardOneToMany
+		// (Left/histogram one, broadcast).
+		m := chplan.VectorMatch{Labels: append([]string(nil), vm.MatchingLabels...), On: vm.On}
+		inc := append([]string(nil), vm.Include...)
+		chCard := chplan.CardManyToOne
+		if histLHS {
+			chCard = chplan.CardOneToMany
 		}
+		return hist, float, chOp, m, chCard, inc, true
 	default:
 		return nil, nil, "", chplan.VectorMatch{}, chplan.CardOneToOne, nil, false
 	}
-	// Both branches above land here only once confirmed hist-many:
-	// chplan.HistogramFloatVectorJoin.Left is ALWAYS the histogram
-	// operand, so CardManyToOne (hist LHS) and CardOneToMany (hist RHS)
-	// both map onto the SAME chplan.CardManyToOne (Left many, Right
-	// one) regardless of which PromQL cardinality keyword produced
-	// them.
-	m := chplan.VectorMatch{Labels: append([]string(nil), vm.MatchingLabels...), On: vm.On}
-	inc := append([]string(nil), vm.Include...)
-	return hist, float, chOp, m, chplan.CardManyToOne, inc, true
 }
 
 // lowerExpHistogramFloatVectorScalingBinop lowers the shape

--- a/internal/promql/histogram_native_float_vector_scaling_binop_swap_chdb_test.go
+++ b/internal/promql/histogram_native_float_vector_scaling_binop_swap_chdb_test.go
@@ -1,0 +1,279 @@
+//go:build chdb
+
+// chDB-backed proof for cerberus issue #2537: the two shapes
+// expHistogramFloatVectorScalingBinop used to reject because the
+// histogram operand could not play the join's Left role now execute
+// correctly against real ClickHouse data, not merely lower without
+// erroring.
+//
+//   - CardOneToOne with an on() reduced key and the histogram operand on
+//     the syntactic RHS: `histogram_quantile(0.5, hist) * on(job) hist`
+//     — the exact shape TestLower_ExpHistogram_
+//     FloatVectorScalingBinopStillRejected used to pin as a permanent
+//     rejection. [chplan.HistogramFloatVectorJoin]'s own header doc
+//     argues this needs no Left/Right role bit because the join's
+//     ON-clause equality already forces both sides' reduced Attributes
+//     to be identical — this test confirms that argument holds at real
+//     execution, not just on paper.
+//   - group_right() with the histogram operand on the syntactic LHS: the
+//     histogram then plays the "one" role, broadcasting a SINGLE matched
+//     histogram row across every one of several matching float rows —
+//     chplan.CardOneToMany, a genuinely new join shape #2537 adds (the
+//     pre-#2537 emitter only supported the histogram as CardOneToOne or
+//     CardManyToOne "many"). The seed deliberately matches the single
+//     histogram row against TWO float rows so a broken broadcast (e.g.
+//     one that silently drops to one output row, or joins the wrong
+//     histogram row) is visible as a missing/wrong row rather than a
+//     coincidentally-correct single-row answer.
+package promql_test
+
+import (
+	"context"
+	"math"
+	"testing"
+	"time"
+
+	"github.com/prometheus/prometheus/promql/parser"
+
+	"github.com/tsouza/cerberus/internal/chplan"
+	"github.com/tsouza/cerberus/internal/chsql"
+	"github.com/tsouza/cerberus/internal/promql"
+	"github.com/tsouza/cerberus/internal/schema"
+	"github.com/tsouza/cerberus/internal/testsql"
+)
+
+// swapHistMetric is the bare exp-histogram selector both scenarios below
+// scale; swapFloatMetric is an UNRELATED plain gauge metric standing in
+// for the genuine per-series float-vector operand, mirroring the
+// hist/gauge pairing test/spec/promql's own exp_histogram_float_vector_
+// scaling_*.txtar fixtures use.
+const (
+	swapHistMetric  = "swap_hist_side_exp_hist"
+	swapFloatMetric = "swap_float_side_gauge"
+)
+
+var swapEvalTS = time.Date(2026, 1, 1, 0, 0, 1, 0, time.UTC)
+
+// swapOneToOneSeed backs the CardOneToOne/on()/histogram-on-RHS
+// scenario: one histogram row and one float row sharing job="api",
+// distinguished by an extra label ("region"/"zone") outside the on(job)
+// match key so a reduction bug that leaked the WRONG side's extra label
+// into the output would be visible rather than accidentally passing.
+var swapOneToOneSeed = "" +
+	"CREATE OR REPLACE TABLE otel_metrics_exponential_histogram (" +
+	"`MetricName` String, `Attributes` Map(String, String), " +
+	"`ResourceAttributes` Map(String, String) DEFAULT map(), `ServiceName` LowCardinality(String) DEFAULT '', " +
+	"`TimeUnix` DateTime64(9), " +
+	"`Count` UInt64, `Sum` Float64, `Scale` Int32, `ZeroCount` UInt64, " +
+	"`PositiveOffset` Int32, `PositiveBucketCounts` Array(UInt64), " +
+	"`NegativeOffset` Int32, `NegativeBucketCounts` Array(UInt64)" +
+	") ENGINE = MergeTree ORDER BY (`MetricName`, `Attributes`, `TimeUnix`);\n" +
+	"INSERT INTO otel_metrics_exponential_histogram " +
+	"(MetricName, Attributes, TimeUnix, Count, Sum, Scale, ZeroCount, PositiveOffset, PositiveBucketCounts, NegativeOffset, NegativeBucketCounts) VALUES\n" +
+	"    ('" + swapHistMetric + "', map('job', 'api', 'region', 'hist-side'), toDateTime64('2026-01-01 00:00:00', 9), 3, 6.0, 0, 0, 0, [9], 0, []);\n" +
+	swapGaugeSeedDDL +
+	"INSERT INTO otel_metrics_gauge (MetricName, Attributes, TimeUnix, Value) VALUES\n" +
+	"    ('" + swapFloatMetric + "', map('job', 'api', 'zone', 'float-side'), toDateTime64('2026-01-01 00:00:00', 9), 2.0);\n"
+
+// swapGaugeSeedDDL declares otel_metrics_gauge (this file's own float
+// operand table) AND the empty otel_metrics_sum sibling the read path's
+// `merge(currentDatabase(), '^(otel_metrics_gauge|otel_metrics_sum)$')`
+// fan-out scans regardless of which one a query actually seeds —
+// mirrors limit_ratio_chdb_test.go's identical pairing.
+const swapGaugeSeedDDL = "" +
+	"CREATE OR REPLACE TABLE otel_metrics_gauge (`MetricName` String, `Attributes` Map(String, String), `ResourceAttributes` Map(String, String) DEFAULT map(), `ServiceName` LowCardinality(String) DEFAULT '', `TimeUnix` DateTime64(9), `Value` Float64) ENGINE = MergeTree ORDER BY (`MetricName`, `Attributes`, `TimeUnix`);\n" +
+	"CREATE OR REPLACE TABLE otel_metrics_sum (`MetricName` String, `Attributes` Map(String, String), `ResourceAttributes` Map(String, String) DEFAULT map(), `ServiceName` LowCardinality(String) DEFAULT '', `TimeUnix` DateTime64(9), `Value` Float64) ENGINE = MergeTree ORDER BY (`MetricName`, `Attributes`, `TimeUnix`);\n"
+
+// TestFloatVectorScalingBinop_HistOnRHS_ChDB proves
+// `histogram_quantile(0.5, hist) * on(job) hist` — hist on the syntactic
+// RHS, CardOneToOne, reduced on() key — scales the histogram correctly
+// and reduces the output Attributes to exactly the on() key.
+func TestFloatVectorScalingBinop_HistOnRHS_ChDB(t *testing.T) {
+	fixture := newChDBFixture(t, swapOneToOneSeed)
+
+	s := schema.DefaultOTelMetrics()
+	p := parser.NewParser(parser.Options{EnableExperimentalFunctions: true})
+
+	// Hist on the syntactic RHS, float on the LHS — the exact operand
+	// order the pre-#2537 recognizer rejected for a reduced-key
+	// CardOneToOne match.
+	query := swapFloatMetric + " * on(job) " + swapHistMetric
+
+	expr, err := p.ParseExpr(query)
+	if err != nil {
+		t.Fatalf("ParseExpr(%q): %v", query, err)
+	}
+	plan, err := promql.LowerAt(context.Background(), expr, s, swapEvalTS, swapEvalTS)
+	if err != nil {
+		t.Fatalf("LowerAt(%q): %v", query, err)
+	}
+	join := findHistogramFloatVectorJoin(plan)
+	if join == nil {
+		t.Fatalf("LowerAt(%q): plan does not root in a *chplan.HistogramFloatVectorJoin", query)
+	}
+	if join.Card != chplan.CardOneToOne {
+		t.Fatalf("LowerAt(%q): join.Card = %v, want CardOneToOne", query, join.Card)
+	}
+	sqlStr, args, err := chsql.Emit(context.Background(), plan)
+	if err != nil {
+		t.Fatalf("Emit(%q): %v", query, err)
+	}
+
+	projection := "`Attributes`['job'] AS job, `Attributes`['region'] AS region, `Attributes`['zone'] AS zone, " +
+		"`HistogramCount` AS cnt, `HistogramSum` AS sum, `HistogramPositiveBucketCounts`[1] AS bucket1"
+	rows := fixture.queryOverEmitted(t, projection, sqlStr, args)
+	defer func() { _ = rows.Close() }()
+
+	n := 0
+	for rows.Next() {
+		n++
+		var job, region, zone string
+		var cnt, sum, bucket1 float64
+		if err := rows.Scan(&job, &region, &zone, &cnt, &sum, &bucket1); err != nil {
+			t.Fatalf("scan: %v", err)
+		}
+		if job != "api" {
+			t.Errorf("job = %q, want %q", job, "api")
+		}
+		// on(job) keeps ONLY the on() labels: both the hist-side
+		// ("region") and float-side ("zone") extra labels must be
+		// dropped from the output regardless of which side the
+		// reduction actually ran over — this is the exact claim
+		// [chplan.HistogramFloatVectorJoin]'s own doc proves.
+		if region != "" {
+			t.Errorf("region = %q, want empty (on(job) must drop it)", region)
+		}
+		if zone != "" {
+			t.Errorf("zone = %q, want empty (on(job) must drop it)", zone)
+		}
+		const wantCount, wantSum, wantBucket1 = 6, 12.0, 18 // hist(Count=3,Sum=6,bucket=[9]) * float(Value=2)
+		if cnt != wantCount {
+			t.Errorf("HistogramCount = %v, want %v", cnt, wantCount)
+		}
+		if sum != wantSum {
+			t.Errorf("HistogramSum = %v, want %v", sum, wantSum)
+		}
+		if bucket1 != wantBucket1 {
+			t.Errorf("HistogramPositiveBucketCounts[1] = %v, want %v", bucket1, wantBucket1)
+		}
+	}
+	if err := testsql.TolerantRowsErr(rows.Err()); err != nil {
+		t.Fatalf("rows.Err: %v", err)
+	}
+	if n != 1 {
+		t.Fatalf("got %d rows, want exactly 1", n)
+	}
+}
+
+// swapBroadcastHistMetric/swapBroadcastFloatMetric back the
+// group_right()/histogram-as-"one" broadcast scenario, kept distinct
+// from swapHistMetric/swapFloatMetric above so the two scenarios' seeds
+// never collide in the process-shared chDB session (see fixture_chdb_
+// test.go's own package doc).
+const (
+	swapBroadcastHistMetric  = "swap_broadcast_hist_exp_hist"
+	swapBroadcastFloatMetric = "swap_broadcast_float_gauge"
+)
+
+// swapBroadcastSeed backs the group_right()/CardOneToMany scenario: ONE
+// histogram row (job="api") and TWO float rows sharing job="api" but
+// distinguished by "zone" — Include(region) then copies the histogram
+// row's own "region" label onto BOTH output rows, proving the single
+// matched histogram genuinely broadcasts rather than the join silently
+// collapsing to one row (a broken broadcast drops one of "z1"/"z2", or
+// answers the wrong Value multiplier for one of them).
+var swapBroadcastSeed = "" +
+	"CREATE OR REPLACE TABLE otel_metrics_exponential_histogram (" +
+	"`MetricName` String, `Attributes` Map(String, String), " +
+	"`ResourceAttributes` Map(String, String) DEFAULT map(), `ServiceName` LowCardinality(String) DEFAULT '', " +
+	"`TimeUnix` DateTime64(9), " +
+	"`Count` UInt64, `Sum` Float64, `Scale` Int32, `ZeroCount` UInt64, " +
+	"`PositiveOffset` Int32, `PositiveBucketCounts` Array(UInt64), " +
+	"`NegativeOffset` Int32, `NegativeBucketCounts` Array(UInt64)" +
+	") ENGINE = MergeTree ORDER BY (`MetricName`, `Attributes`, `TimeUnix`);\n" +
+	"INSERT INTO otel_metrics_exponential_histogram " +
+	"(MetricName, Attributes, TimeUnix, Count, Sum, Scale, ZeroCount, PositiveOffset, PositiveBucketCounts, NegativeOffset, NegativeBucketCounts) VALUES\n" +
+	"    ('" + swapBroadcastHistMetric + "', map('job', 'api', 'region', 'eu'), toDateTime64('2026-01-01 00:00:00', 9), 3, 6.0, 0, 0, 0, [9], 0, []);\n" +
+	swapGaugeSeedDDL +
+	"INSERT INTO otel_metrics_gauge (MetricName, Attributes, TimeUnix, Value) VALUES\n" +
+	"    ('" + swapBroadcastFloatMetric + "', map('job', 'api', 'zone', 'z1'), toDateTime64('2026-01-01 00:00:00', 9), 2.0),\n" +
+	"    ('" + swapBroadcastFloatMetric + "', map('job', 'api', 'zone', 'z2'), toDateTime64('2026-01-01 00:00:00', 9), 5.0);\n"
+
+// TestFloatVectorScalingBinop_GroupRightHistOne_ChDB proves
+// `hist * on(job) group_right(region) float` — histogram on the
+// syntactic LHS, group_right() keeping the RHS (float) "many" and the
+// histogram "one" — broadcasts the single matched histogram row's SAME
+// bucket layout across every matching float row, scaled by that row's
+// own Value, with Include(region) carrying the histogram's own "region"
+// label onto every broadcast output row.
+func TestFloatVectorScalingBinop_GroupRightHistOne_ChDB(t *testing.T) {
+	fixture := newChDBFixture(t, swapBroadcastSeed)
+
+	s := schema.DefaultOTelMetrics()
+	p := parser.NewParser(parser.Options{EnableExperimentalFunctions: true})
+
+	query := swapBroadcastHistMetric + " * on(job) group_right(region) " + swapBroadcastFloatMetric
+	expr, err := p.ParseExpr(query)
+	if err != nil {
+		t.Fatalf("ParseExpr(%q): %v", query, err)
+	}
+	plan, err := promql.LowerAt(context.Background(), expr, s, swapEvalTS, swapEvalTS)
+	if err != nil {
+		t.Fatalf("LowerAt(%q): %v", query, err)
+	}
+	join := findHistogramFloatVectorJoin(plan)
+	if join == nil {
+		t.Fatalf("LowerAt(%q): plan does not root in a *chplan.HistogramFloatVectorJoin", query)
+	}
+	if join.Card != chplan.CardOneToMany {
+		t.Fatalf("LowerAt(%q): join.Card = %v, want CardOneToMany", query, join.Card)
+	}
+	sqlStr, args, err := chsql.Emit(context.Background(), plan)
+	if err != nil {
+		t.Fatalf("Emit(%q): %v", query, err)
+	}
+
+	projection := "`Attributes`['job'] AS job, `Attributes`['zone'] AS zone, `Attributes`['region'] AS region, " +
+		"`HistogramCount` AS cnt, `HistogramSum` AS sum, `HistogramPositiveBucketCounts`[1] AS bucket1"
+	rows := fixture.queryOverEmitted(t, projection, sqlStr, args)
+	defer func() { _ = rows.Close() }()
+
+	wantByZone := map[string]struct{ cnt, sum, bucket1 float64 }{
+		"z1": {6, 12.0, 18},  // hist(3,6.0,[9]) * float(Value=2)
+		"z2": {15, 30.0, 45}, // hist(3,6.0,[9]) * float(Value=5)
+	}
+	seen := map[string]bool{}
+	for rows.Next() {
+		var job, zone, region string
+		var cnt, sum, bucket1 float64
+		if err := rows.Scan(&job, &zone, &region, &cnt, &sum, &bucket1); err != nil {
+			t.Fatalf("scan: %v", err)
+		}
+		if job != "api" {
+			t.Errorf("job = %q, want %q", job, "api")
+		}
+		if region != "eu" {
+			t.Errorf("zone %s: region = %q, want %q (Include must carry the histogram's own label onto the broadcast row)", zone, region, "eu")
+		}
+		want, ok := wantByZone[zone]
+		if !ok {
+			t.Fatalf("unexpected zone %q", zone)
+		}
+		seen[zone] = true
+		if math.Abs(cnt-want.cnt) > 1e-9 {
+			t.Errorf("zone %s: HistogramCount = %v, want %v", zone, cnt, want.cnt)
+		}
+		if math.Abs(sum-want.sum) > 1e-9 {
+			t.Errorf("zone %s: HistogramSum = %v, want %v", zone, sum, want.sum)
+		}
+		if math.Abs(bucket1-want.bucket1) > 1e-9 {
+			t.Errorf("zone %s: HistogramPositiveBucketCounts[1] = %v, want %v", zone, bucket1, want.bucket1)
+		}
+	}
+	if err := testsql.TolerantRowsErr(rows.Err()); err != nil {
+		t.Fatalf("rows.Err: %v", err)
+	}
+	if len(seen) != len(wantByZone) {
+		t.Fatalf("got rows for zones %v, want both %v present (a broken broadcast drops one matching float row)", seen, wantByZone)
+	}
+}

--- a/internal/promql/histogram_native_float_vector_scaling_binop_swap_chdb_test.go
+++ b/internal/promql/histogram_native_float_vector_scaling_binop_swap_chdb_test.go
@@ -165,6 +165,114 @@ func TestFloatVectorScalingBinop_HistOnRHS_ChDB(t *testing.T) {
 	}
 }
 
+// swapIgnoringHistMetric/swapIgnoringFloatMetric back the CardOneToOne/
+// ignoring()/histogram-on-RHS scenario — the mirror image of
+// TestFloatVectorScalingBinop_HistOnRHS_ChDB's on() case, proving the
+// Del-reduction rule (drop the ignored label, keep everything else) is
+// correct when the histogram plays Left via the same unconditional-
+// reduce-Left emitter path, not just the Keep rule the on() test covers.
+// Both rows carry a "region" label with DIFFERENT values so a reduction
+// bug that leaked either side's value into the output (instead of
+// dropping the label entirely) is visible rather than accidentally
+// passing.
+const (
+	swapIgnoringHistMetric  = "swap_ignoring_hist_side_exp_hist"
+	swapIgnoringFloatMetric = "swap_ignoring_float_side_gauge"
+)
+
+var swapIgnoringSeed = "" +
+	"CREATE OR REPLACE TABLE otel_metrics_exponential_histogram (" +
+	"`MetricName` String, `Attributes` Map(String, String), " +
+	"`ResourceAttributes` Map(String, String) DEFAULT map(), `ServiceName` LowCardinality(String) DEFAULT '', " +
+	"`TimeUnix` DateTime64(9), " +
+	"`Count` UInt64, `Sum` Float64, `Scale` Int32, `ZeroCount` UInt64, " +
+	"`PositiveOffset` Int32, `PositiveBucketCounts` Array(UInt64), " +
+	"`NegativeOffset` Int32, `NegativeBucketCounts` Array(UInt64)" +
+	") ENGINE = MergeTree ORDER BY (`MetricName`, `Attributes`, `TimeUnix`);\n" +
+	"INSERT INTO otel_metrics_exponential_histogram " +
+	"(MetricName, Attributes, TimeUnix, Count, Sum, Scale, ZeroCount, PositiveOffset, PositiveBucketCounts, NegativeOffset, NegativeBucketCounts) VALUES\n" +
+	"    ('" + swapIgnoringHistMetric + "', map('job', 'api', 'region', 'hist-side'), toDateTime64('2026-01-01 00:00:00', 9), 3, 6.0, 0, 0, 0, [9], 0, []);\n" +
+	swapGaugeSeedDDL +
+	"INSERT INTO otel_metrics_gauge (MetricName, Attributes, TimeUnix, Value) VALUES\n" +
+	"    ('" + swapIgnoringFloatMetric + "', map('job', 'api', 'region', 'float-side'), toDateTime64('2026-01-01 00:00:00', 9), 2.0);\n"
+
+// TestFloatVectorScalingBinop_HistOnRHS_IgnoringChDB proves
+// `float * ignoring(region) hist` — hist on the syntactic RHS,
+// CardOneToOne, ignoring() key — scales the histogram correctly and
+// drops the ignored "region" label from the output regardless of which
+// side's value it came from.
+func TestFloatVectorScalingBinop_HistOnRHS_IgnoringChDB(t *testing.T) {
+	fixture := newChDBFixture(t, swapIgnoringSeed)
+
+	s := schema.DefaultOTelMetrics()
+	p := parser.NewParser(parser.Options{EnableExperimentalFunctions: true})
+
+	// Hist on the syntactic RHS, float on the LHS — same operand order
+	// TestFloatVectorScalingBinop_HistOnRHS_ChDB exercises for on(), here
+	// with ignoring(region) instead.
+	query := swapIgnoringFloatMetric + " * ignoring(region) " + swapIgnoringHistMetric
+
+	expr, err := p.ParseExpr(query)
+	if err != nil {
+		t.Fatalf("ParseExpr(%q): %v", query, err)
+	}
+	plan, err := promql.LowerAt(context.Background(), expr, s, swapEvalTS, swapEvalTS)
+	if err != nil {
+		t.Fatalf("LowerAt(%q): %v", query, err)
+	}
+	join := findHistogramFloatVectorJoin(plan)
+	if join == nil {
+		t.Fatalf("LowerAt(%q): plan does not root in a *chplan.HistogramFloatVectorJoin", query)
+	}
+	if join.Card != chplan.CardOneToOne {
+		t.Fatalf("LowerAt(%q): join.Card = %v, want CardOneToOne", query, join.Card)
+	}
+	sqlStr, args, err := chsql.Emit(context.Background(), plan)
+	if err != nil {
+		t.Fatalf("Emit(%q): %v", query, err)
+	}
+
+	projection := "`Attributes`['job'] AS job, `Attributes`['region'] AS region, " +
+		"`HistogramCount` AS cnt, `HistogramSum` AS sum, `HistogramPositiveBucketCounts`[1] AS bucket1"
+	rows := fixture.queryOverEmitted(t, projection, sqlStr, args)
+	defer func() { _ = rows.Close() }()
+
+	n := 0
+	for rows.Next() {
+		n++
+		var job, region string
+		var cnt, sum, bucket1 float64
+		if err := rows.Scan(&job, &region, &cnt, &sum, &bucket1); err != nil {
+			t.Fatalf("scan: %v", err)
+		}
+		if job != "api" {
+			t.Errorf("job = %q, want %q", job, "api")
+		}
+		// ignoring(region) must DROP region from the output entirely,
+		// regardless of which side's value ("hist-side" or "float-side")
+		// the reduction actually ran over.
+		if region != "" {
+			t.Errorf("region = %q, want empty (ignoring(region) must drop it)", region)
+		}
+		const wantCount, wantSum, wantBucket1 = 6, 12.0, 18 // hist(Count=3,Sum=6,bucket=[9]) * float(Value=2)
+		if cnt != wantCount {
+			t.Errorf("HistogramCount = %v, want %v", cnt, wantCount)
+		}
+		if sum != wantSum {
+			t.Errorf("HistogramSum = %v, want %v", sum, wantSum)
+		}
+		if bucket1 != wantBucket1 {
+			t.Errorf("HistogramPositiveBucketCounts[1] = %v, want %v", bucket1, wantBucket1)
+		}
+	}
+	if err := testsql.TolerantRowsErr(rows.Err()); err != nil {
+		t.Fatalf("rows.Err: %v", err)
+	}
+	if n != 1 {
+		t.Fatalf("got %d rows, want exactly 1", n)
+	}
+}
+
 // swapBroadcastHistMetric/swapBroadcastFloatMetric back the
 // group_right()/histogram-as-"one" broadcast scenario, kept distinct
 // from swapHistMetric/swapFloatMetric above so the two scenarios' seeds

--- a/internal/promql/histogram_native_float_vector_scaling_binop_test.go
+++ b/internal/promql/histogram_native_float_vector_scaling_binop_test.go
@@ -13,16 +13,27 @@ import (
 )
 
 // TestLower_ExpHistogram_FloatVectorScalingBinopAnswersScaledHistogram
-// pins cerberus issues #2339 and #2342: MUL (either operand order) and
-// histogram-left DIV between a histogram-valued operand and a genuine
-// (non-literal) float-VECTOR operand — under default (full-Attributes)
-// one-to-one matching, on()/ignoring() reduced-key one-to-one matching,
-// and the "histogram is the many side" group_left()/group_right()
-// broadcast — now answer a scaled histogram — a
-// *chplan.HistogramProjection rooted in a *chplan.HistogramFloatVectorJoin
-// — rather than the pre-existing catch-all rejection
+// pins cerberus issues #2339, #2342, and #2537: MUL (either operand
+// order) and histogram-left DIV between a histogram-valued operand and a
+// genuine (non-literal) float-VECTOR operand — under default
+// (full-Attributes) one-to-one matching, on()/ignoring() reduced-key
+// one-to-one matching REGARDLESS of which side of the expression the
+// histogram operand is written on, and group_left()/group_right()
+// broadcast in EITHER direction (the histogram operand playing "many" or
+// "one") — now answer a scaled histogram — a *chplan.HistogramProjection
+// rooted in a *chplan.HistogramFloatVectorJoin — rather than the
+// pre-existing catch-all rejection
 // TestLower_ExpHistogram_FloatVectorScalingShapesStillRejected used to
 // pin (histogram_native_float_vector_binop_test.go, now superseded).
+//
+// The four `*/on(service) group_left/right()`, `on(service)` cases with
+// the histogram on the syntactic RHS were pinned as a permanent boundary
+// by this file's own former TestLower_ExpHistogram_
+// FloatVectorScalingBinopStillRejected — cerberus issue #2537 found and
+// closed that gap; probing broadly (see the issue) turned up no other
+// combination of operand order, on()/ignoring(), and group_left()/
+// group_right() this recognizer still rejects, so that test's coverage
+// moves here rather than being deleted.
 func TestLower_ExpHistogram_FloatVectorScalingBinopAnswersScaledHistogram(t *testing.T) {
 	t.Parallel()
 
@@ -32,34 +43,39 @@ func TestLower_ExpHistogram_FloatVectorScalingBinopAnswersScaledHistogram(t *tes
 	end := start.Add(time.Hour)
 
 	cases := []struct {
-		name  string
-		query string
-		lower func(parser.Expr) (chplan.Node, error)
+		name     string
+		query    string
+		wantCard chplan.VectorCard
+		lower    func(parser.Expr) (chplan.Node, error)
 	}{
 		{
-			name:  "histogram times float vector",
-			query: `latency_exp_hist * histogram_quantile(0.5, latency_exp_hist)`,
+			name:     "histogram times float vector",
+			query:    `latency_exp_hist * histogram_quantile(0.5, latency_exp_hist)`,
+			wantCard: chplan.CardOneToOne,
 			lower: func(e parser.Expr) (chplan.Node, error) {
 				return promql.LowerAt(context.Background(), e, s, end, end)
 			},
 		},
 		{
-			name:  "float vector times histogram (commutative)",
-			query: `histogram_quantile(0.5, latency_exp_hist) * latency_exp_hist`,
+			name:     "float vector times histogram (commutative)",
+			query:    `histogram_quantile(0.5, latency_exp_hist) * latency_exp_hist`,
+			wantCard: chplan.CardOneToOne,
 			lower: func(e parser.Expr) (chplan.Node, error) {
 				return promql.LowerAt(context.Background(), e, s, end, end)
 			},
 		},
 		{
-			name:  "histogram divided by float vector",
-			query: `latency_exp_hist / histogram_quantile(0.5, latency_exp_hist)`,
+			name:     "histogram divided by float vector",
+			query:    `latency_exp_hist / histogram_quantile(0.5, latency_exp_hist)`,
+			wantCard: chplan.CardOneToOne,
 			lower: func(e parser.Expr) (chplan.Node, error) {
 				return promql.LowerAt(context.Background(), e, s, end, end)
 			},
 		},
 		{
-			name:  "histogram times float vector, range",
-			query: `latency_exp_hist * histogram_quantile(0.5, latency_exp_hist)`,
+			name:     "histogram times float vector, range",
+			query:    `latency_exp_hist * histogram_quantile(0.5, latency_exp_hist)`,
+			wantCard: chplan.CardOneToOne,
 			lower: func(e parser.Expr) (chplan.Node, error) {
 				return promql.LowerAtRange(context.Background(), e, s, start, end, 30*time.Second)
 			},
@@ -67,8 +83,9 @@ func TestLower_ExpHistogram_FloatVectorScalingBinopAnswersScaledHistogram(t *tes
 		{
 			// cerberus issue #2342: on() reduced-key one-to-one
 			// matching, histogram on the syntactic LHS.
-			name:  "histogram times float vector, on()",
-			query: `latency_exp_hist * on(service) histogram_quantile(0.5, latency_exp_hist)`,
+			name:     "histogram times float vector, on()",
+			query:    `latency_exp_hist * on(service) histogram_quantile(0.5, latency_exp_hist)`,
+			wantCard: chplan.CardOneToOne,
 			lower: func(e parser.Expr) (chplan.Node, error) {
 				return promql.LowerAt(context.Background(), e, s, end, end)
 			},
@@ -76,17 +93,32 @@ func TestLower_ExpHistogram_FloatVectorScalingBinopAnswersScaledHistogram(t *tes
 		{
 			// cerberus issue #2342: ignoring() reduced-key one-to-one
 			// matching, histogram on the syntactic LHS.
-			name:  "histogram times float vector, ignoring()",
-			query: `latency_exp_hist * ignoring(service) histogram_quantile(0.5, latency_exp_hist)`,
+			name:     "histogram times float vector, ignoring()",
+			query:    `latency_exp_hist * ignoring(service) histogram_quantile(0.5, latency_exp_hist)`,
+			wantCard: chplan.CardOneToOne,
+			lower: func(e parser.Expr) (chplan.Node, error) {
+				return promql.LowerAt(context.Background(), e, s, end, end)
+			},
+		},
+		{
+			// cerberus issue #2537: on() reduced-key one-to-one
+			// matching, histogram on the syntactic RHS this time —
+			// TestLower_ExpHistogram_FloatVectorScalingBinopStillRejected
+			// used to pin this exact query as a permanent rejection.
+			name:     "float vector times histogram, on()",
+			query:    `histogram_quantile(0.5, latency_exp_hist) * on(service) latency_exp_hist`,
+			wantCard: chplan.CardOneToOne,
 			lower: func(e parser.Expr) (chplan.Node, error) {
 				return promql.LowerAt(context.Background(), e, s, end, end)
 			},
 		},
 		{
 			// cerberus issue #2342: group_left() broadcast, histogram
-			// on the syntactic LHS (the "many" side under group_left).
-			name:  "histogram times float vector, group_left()",
-			query: `latency_exp_hist * on(service) group_left() histogram_quantile(0.5, latency_exp_hist)`,
+			// on the syntactic LHS (the "many" side under group_left) —
+			// chplan.CardManyToOne (Left/histogram many).
+			name:     "histogram times float vector, group_left()",
+			query:    `latency_exp_hist * on(service) group_left() histogram_quantile(0.5, latency_exp_hist)`,
+			wantCard: chplan.CardManyToOne,
 			lower: func(e parser.Expr) (chplan.Node, error) {
 				return promql.LowerAt(context.Background(), e, s, end, end)
 			},
@@ -94,9 +126,41 @@ func TestLower_ExpHistogram_FloatVectorScalingBinopAnswersScaledHistogram(t *tes
 		{
 			// cerberus issue #2342: group_right() broadcast,
 			// mirror-image operand order — histogram on the syntactic
-			// RHS (the "many" side under group_right).
-			name:  "float vector times histogram, group_right()",
-			query: `histogram_quantile(0.5, latency_exp_hist) * on(service) group_right() latency_exp_hist`,
+			// RHS (the "many" side under group_right) — chplan.
+			// CardManyToOne (Left/histogram many, same physical role as
+			// the group_left() case above despite the opposite PromQL
+			// keyword).
+			name:     "float vector times histogram, group_right()",
+			query:    `histogram_quantile(0.5, latency_exp_hist) * on(service) group_right() latency_exp_hist`,
+			wantCard: chplan.CardManyToOne,
+			lower: func(e parser.Expr) (chplan.Node, error) {
+				return promql.LowerAt(context.Background(), e, s, end, end)
+			},
+		},
+		{
+			// cerberus issue #2537: group_right() broadcast with the
+			// histogram on the syntactic LHS — group_right() keeps the
+			// RHS (float) "many", so the histogram plays "one" and
+			// broadcasts across every matching float row —
+			// chplan.CardOneToMany (Left/histogram one). Formerly pinned
+			// as a permanent rejection by TestLower_ExpHistogram_
+			// FloatVectorScalingBinopStillRejected.
+			name:     "histogram times float vector, group_right()",
+			query:    `latency_exp_hist * on(service) group_right() histogram_quantile(0.5, latency_exp_hist)`,
+			wantCard: chplan.CardOneToMany,
+			lower: func(e parser.Expr) (chplan.Node, error) {
+				return promql.LowerAt(context.Background(), e, s, end, end)
+			},
+		},
+		{
+			// cerberus issue #2537: group_left() broadcast with the
+			// histogram on the syntactic RHS — group_left() keeps the
+			// LHS (float) "many", so the histogram plays "one" and
+			// broadcasts — chplan.CardOneToMany (Left/histogram one).
+			// Formerly pinned as a permanent rejection.
+			name:     "float vector times histogram, group_left()",
+			query:    `histogram_quantile(0.5, latency_exp_hist) * on(service) group_left() latency_exp_hist`,
+			wantCard: chplan.CardOneToMany,
 			lower: func(e parser.Expr) (chplan.Node, error) {
 				return promql.LowerAt(context.Background(), e, s, end, end)
 			},
@@ -104,9 +168,25 @@ func TestLower_ExpHistogram_FloatVectorScalingBinopAnswersScaledHistogram(t *tes
 		{
 			// cerberus issue #2342: histogram-left DIV + group_left(),
 			// histogram on the syntactic LHS (the only DIV shape this
-			// recognizer answers, per its own header doc).
-			name:  "histogram divided by float vector, group_left()",
-			query: `latency_exp_hist / on(service) group_left() histogram_quantile(0.5, latency_exp_hist)`,
+			// recognizer answers, per its own header doc) —
+			// chplan.CardManyToOne (Left/histogram many).
+			name:     "histogram divided by float vector, group_left()",
+			query:    `latency_exp_hist / on(service) group_left() histogram_quantile(0.5, latency_exp_hist)`,
+			wantCard: chplan.CardManyToOne,
+			lower: func(e parser.Expr) (chplan.Node, error) {
+				return promql.LowerAt(context.Background(), e, s, end, end)
+			},
+		},
+		{
+			// cerberus issue #2537: histogram-left DIV + group_right() —
+			// DIV only recognises the histogram-left shape, so the
+			// histogram operand is always the syntactic LHS here;
+			// group_right() keeps the RHS (float) "many", so the
+			// histogram plays "one" — chplan.CardOneToMany. Formerly
+			// pinned as a permanent rejection.
+			name:     "histogram divided by float vector, group_right()",
+			query:    `latency_exp_hist / on(service) group_right() histogram_quantile(0.5, latency_exp_hist)`,
+			wantCard: chplan.CardOneToMany,
 			lower: func(e parser.Expr) (chplan.Node, error) {
 				return promql.LowerAt(context.Background(), e, s, end, end)
 			},
@@ -135,74 +215,32 @@ func TestLower_ExpHistogram_FloatVectorScalingBinopAnswersScaledHistogram(t *tes
 			if !ok || name.V != "" {
 				t.Fatalf("lower(%q): metric-name projection is %#v, want empty literal", tc.query, hp.GroupBy[0])
 			}
-			if !planContainsHistogramFloatVectorJoin(hp) {
+			join := findHistogramFloatVectorJoin(hp)
+			if join == nil {
 				t.Fatalf("lower(%q): plan does not root in a *chplan.HistogramFloatVectorJoin", tc.query)
+			}
+			if join.Card != tc.wantCard {
+				t.Fatalf("lower(%q): join.Card = %v, want %v", tc.query, join.Card, tc.wantCard)
 			}
 		})
 	}
 }
 
-// planContainsHistogramFloatVectorJoin walks n's Input/Children chain
-// looking for a *chplan.HistogramFloatVectorJoin — confirming the
-// scaling lowering actually took the JOIN path rather than, say,
-// silently degenerating to the literal-scalar scaling machinery.
-func planContainsHistogramFloatVectorJoin(n chplan.Node) bool {
+// findHistogramFloatVectorJoin walks n's Input/Children chain looking
+// for a *chplan.HistogramFloatVectorJoin — confirming the scaling
+// lowering actually took the JOIN path rather than, say, silently
+// degenerating to the literal-scalar scaling machinery, and giving the
+// caller the join node itself to inspect (e.g. its Card).
+func findHistogramFloatVectorJoin(n chplan.Node) *chplan.HistogramFloatVectorJoin {
 	for cur := n; cur != nil; {
-		if _, ok := cur.(*chplan.HistogramFloatVectorJoin); ok {
-			return true
+		if j, ok := cur.(*chplan.HistogramFloatVectorJoin); ok {
+			return j
 		}
 		children := cur.Children()
 		if len(children) == 0 {
-			return false
+			return nil
 		}
 		cur = children[0]
 	}
-	return false
-}
-
-// TestLower_ExpHistogram_FloatVectorScalingBinopStillRejected pins the
-// residual boundary this file's header doc leaves in place now that
-// cerberus issue #2342 has widened on()/ignoring()/group_left()/
-// group_right() support: chplan.HistogramFloatVectorJoin.Left is ALWAYS
-// the histogram operand, so a cardinality/matching shape that would
-// require the histogram side to play the "one" role — broadcasting
-// against many float rows, or reducing an on()/ignoring() key off the
-// FLOAT operand's own Attributes rather than the histogram's — is not
-// supported and still hits the pre-existing catch-all rejection.
-func TestLower_ExpHistogram_FloatVectorScalingBinopStillRejected(t *testing.T) {
-	t.Parallel()
-
-	s := schema.DefaultOTelMetrics()
-	p := parser.NewParser(parser.Options{EnableExperimentalFunctions: true})
-	end := time.Date(2026, 1, 1, 1, 0, 0, 0, time.UTC)
-
-	queries := []string{
-		// CardOneToOne + on() with the histogram on the syntactic RHS:
-		// Prometheus's resultMetric reduces the syntactic LHS (here the
-		// float operand)'s own labels, which this recognizer does not
-		// support (see this file's header doc).
-		`histogram_quantile(0.5, latency_exp_hist) * on(service) latency_exp_hist`,
-		// group_right() keeps the syntactic RHS many; the histogram
-		// operand is on the LHS here, so it would play the "one" role.
-		`latency_exp_hist * on(service) group_right() histogram_quantile(0.5, latency_exp_hist)`,
-		// group_left() keeps the syntactic LHS many; the histogram
-		// operand is on the RHS here, so it would play the "one" role.
-		`histogram_quantile(0.5, latency_exp_hist) * on(service) group_left() latency_exp_hist`,
-		// DIV only recognises the histogram-left shape, so the
-		// histogram operand is always the syntactic LHS; group_right()
-		// here would make the histogram side the "one".
-		`latency_exp_hist / on(service) group_right() histogram_quantile(0.5, latency_exp_hist)`,
-	}
-	for _, q := range queries {
-		t.Run(q, func(t *testing.T) {
-			t.Parallel()
-			expr, err := p.ParseExpr(q)
-			if err != nil {
-				t.Fatalf("ParseExpr(%q): %v", q, err)
-			}
-			if _, err := promql.LowerAt(context.Background(), expr, s, end, end); err == nil {
-				t.Fatalf("LowerAt(%q): expected the pre-existing catch-all rejection, got success", q)
-			}
-		})
-	}
+	return nil
 }

--- a/test/rejection-parity/catalogue/internal__promql__lower.go.json
+++ b/test/rejection-parity/catalogue/internal__promql__lower.go.json
@@ -94,8 +94,8 @@
       "site": "internal/promql/lower.go:expHistogramSelectorRouting#bf746b59",
       "message": "promql: %q is an exponential histogram metric; only a bare %q selector, sum()/avg()/count() over one, rate()/increase()/delta()/irate()/idelta()/sum_over_time()/avg_over_time()/resets()/changes() over one, histogram_quantile(), histogram_count(), histogram_sum(), and the %q/%q companion selectors are supported",
       "class": "divergence",
-      "trigger_query": "histogram_quantile(0.5, demo_latency_exp_hist) * on(service) demo_latency_exp_hist",
-      "tracking_issue": 2537,
+      "trigger_query": "sum(demo_latency_exp_hist * on(service) group_left() histogram_quantile(0.5, demo_latency_exp_hist))",
+      "tracking_issue": 2540,
       "evidence": {
         "guard": [
           "past returning if bare, col, hasCompanion := s.HistogramCompanionColumn(metricName); hasCompanion \u0026\u0026 s.IsExpHistogramMetric(bare) \u0026\u0026 s.ExpHistogramTable != \"\"",


### PR DESCRIPTION
## Summary

`expHistogramFloatVectorScalingBinop` (`internal/promql/histogram_native_float_vector_scaling_binop.go`)
recognises MUL (either operand order) and histogram-left DIV between a histogram-valued operand
and a genuine float-vector operand, joining them via `chplan.HistogramFloatVectorJoin`. That
node's `Left` slot is always the histogram operand, but the recognizer used to reject any
matching/cardinality shape where the histogram operand couldn't play `Left`'s "many"/reduced-key
role from its own syntactic side — falling through to `expHistogramSelectorRouting`'s catch-all
rejection instead.

- Widens `chplan.HistogramFloatVectorJoin.Card` to also accept `CardOneToMany` — the histogram
  side collapsing to one row and broadcasting across every matching float row — mirroring the
  `roleOne`/`roleMany` split the emitter's shared join helpers already generalise over.
- The recognizer now picks whichever chplan `Card` keeps the *same physical role* PromQL's
  `group_left()`/`group_right()` keyword names, regardless of which side of the expression the
  histogram operand was written on.
- The reduced-key `CardOneToOne` (`on()`/`ignoring()`) case needed **no** operand-order tracking:
  the join's own ON-clause equality already forces both sides' reduced Attributes to be
  byte-identical for any row that actually joins, so the emitter keeps reducing `Left`
  unconditionally — documented with that proof directly on `chplan.HistogramFloatVectorJoin`.
- `TestLower_ExpHistogram_FloatVectorScalingBinopStillRejected`'s four permanently-pinned
  rejections all now succeed; that coverage moves into
  `TestLower_ExpHistogram_FloatVectorScalingBinopAnswersScaledHistogram` with `Card` assertions
  rather than being dropped, since probing broadly turned up no residual boundary in this
  recognizer's domain.
- Two new chDB tests prove real execution, not just successful lowering: a `CardOneToOne`/`on()`
  case with the histogram on the syntactic RHS, and a `CardOneToMany` broadcast (one histogram row
  matched against two float rows) with `Include()` label overlay.
- Rotates the rejection-parity catalogue's `expHistogramSelectorRouting` entry forward to the next
  reachable gap — an aggregation wrapping this same scaling-join shape — tracked as #2540.

## Test plan

- [x] `go build ./...`
- [x] `go test -race ./internal/promql/...`
- [x] `go test ./internal/chplan/... ./internal/chsql/...`
- [x] `go test -tags chdb ./internal/promql/ -run TestFloatVectorScalingBinop` (new chDB tests)
- [x] `go test -tags chdb -run TestEvalInstantWindowSweep ./test/spec/promql/...` (existing golden
      fixtures still pass — no golden regen needed, no emitted SQL changed for previously-passing
      shapes)
- [x] `go test ./test/rejection-parity/...`
- [x] `CERBERUS_UPDATE_INVENTORY=1 go test -run TestCatalogueIsRegenerable ./test/rejection-parity/...`
      (catalogue rotation regenerates clean)
- [x] `node .github/scripts/forbid-sql-raw.mjs`

Closes #2537
