### PR TITLE
fix(promql): recognise the scaling-join shape as histogram-valued for aggregation

### DIFF
--- a/internal/promql/histogram_native_agg_over_float_vector_scaling_chdb_test.go
+++ b/internal/promql/histogram_native_agg_over_float_vector_scaling_chdb_test.go
@@ -1,0 +1,207 @@
+//go:build chdb
+
+// chDB-backed proof for cerberus issue #2540: sum()/avg() wrapping the
+// exp-histogram/float-vector SCALING join shape
+// (expHistogramFloatVectorScalingBinop, cerberus issues #2339/#2342/
+// #2537) now execute correctly against real ClickHouse data — each
+// histogram series is scaled by its joined float row FIRST, and only
+// THEN merged across series by the aggregation — not merely lower
+// without erroring.
+package promql_test
+
+import (
+	"context"
+	"math"
+	"testing"
+	"time"
+
+	"github.com/prometheus/prometheus/promql/parser"
+
+	"github.com/tsouza/cerberus/internal/chplan"
+	"github.com/tsouza/cerberus/internal/chsql"
+	"github.com/tsouza/cerberus/internal/promql"
+	"github.com/tsouza/cerberus/internal/schema"
+	"github.com/tsouza/cerberus/internal/testsql"
+)
+
+// aggScaleSumHistMetric/aggScaleSumFloatMetric back
+// TestSumOverFloatVectorScalingBinop_ChDB: TWO histogram series sharing
+// job="api" but distinguished by "az" (outside the on(job) match key,
+// so group_left() must keep BOTH — group_left() preserves the "many"
+// side's own full label set, unlike plain on()/ignoring() one-to-one
+// matching, which reduces to the match key), joined many-to-one against
+// ONE float row via group_left().
+const (
+	aggScaleSumHistMetric  = "agg_scale_sum_hist_exp_hist"
+	aggScaleSumFloatMetric = "agg_scale_sum_float_gauge"
+)
+
+var aggScaleEvalTS = time.Date(2026, 1, 1, 0, 0, 1, 0, time.UTC)
+
+var aggScaleSumSeed = "" +
+	"CREATE OR REPLACE TABLE otel_metrics_exponential_histogram (" +
+	"`MetricName` String, `Attributes` Map(String, String), " +
+	"`ResourceAttributes` Map(String, String) DEFAULT map(), `ServiceName` LowCardinality(String) DEFAULT '', " +
+	"`TimeUnix` DateTime64(9), " +
+	"`Count` UInt64, `Sum` Float64, `Scale` Int32, `ZeroCount` UInt64, " +
+	"`PositiveOffset` Int32, `PositiveBucketCounts` Array(UInt64), " +
+	"`NegativeOffset` Int32, `NegativeBucketCounts` Array(UInt64)" +
+	") ENGINE = MergeTree ORDER BY (`MetricName`, `Attributes`, `TimeUnix`);\n" +
+	"INSERT INTO otel_metrics_exponential_histogram " +
+	"(MetricName, Attributes, TimeUnix, Count, Sum, Scale, ZeroCount, PositiveOffset, PositiveBucketCounts, NegativeOffset, NegativeBucketCounts) VALUES\n" +
+	"    ('" + aggScaleSumHistMetric + "', map('job', 'api', 'az', 'us'), toDateTime64('2026-01-01 00:00:00', 9), 3, 6.0, 0, 0, 0, [9], 0, []),\n" +
+	"    ('" + aggScaleSumHistMetric + "', map('job', 'api', 'az', 'eu'), toDateTime64('2026-01-01 00:00:00', 9), 5, 10.0, 0, 0, 0, [20], 0, []);\n" +
+	swapGaugeSeedDDL +
+	"INSERT INTO otel_metrics_gauge (MetricName, Attributes, TimeUnix, Value) VALUES\n" +
+	"    ('" + aggScaleSumFloatMetric + "', map('job', 'api'), toDateTime64('2026-01-01 00:00:00', 9), 2.0);\n"
+
+// TestSumOverFloatVectorScalingBinop_ChDB proves
+// `sum(hist * on(job) group_left() float)` scales each histogram series
+// by the SAME joined float value (2.0) BEFORE merging across series:
+// hist(3,6.0,[9])*2 + hist(5,10.0,[20])*2 = (6,12.0,[18]) + (10,20.0,[40])
+// = (16,32.0,[58]) — not the unscaled merge (8,16.0,[29]), which is what
+// a bug that dropped the scale before merging would produce instead.
+func TestSumOverFloatVectorScalingBinop_ChDB(t *testing.T) {
+	fixture := newChDBFixture(t, aggScaleSumSeed)
+
+	s := schema.DefaultOTelMetrics()
+	p := parser.NewParser(parser.Options{EnableExperimentalFunctions: true})
+
+	query := "sum(" + aggScaleSumHistMetric + " * on(job) group_left() " + aggScaleSumFloatMetric + ")"
+	expr, err := p.ParseExpr(query)
+	if err != nil {
+		t.Fatalf("ParseExpr(%q): %v", query, err)
+	}
+	plan, err := promql.LowerAt(context.Background(), expr, s, aggScaleEvalTS, aggScaleEvalTS)
+	if err != nil {
+		t.Fatalf("LowerAt(%q): %v", query, err)
+	}
+	if _, ok := plan.(*chplan.HistogramProjection); !ok {
+		t.Fatalf("LowerAt(%q): plan root is %T, want *chplan.HistogramProjection", query, plan)
+	}
+	sqlStr, args, err := chsql.Emit(context.Background(), plan)
+	if err != nil {
+		t.Fatalf("Emit(%q): %v", query, err)
+	}
+
+	projection := "length(mapKeys(`Attributes`)) AS numLabels, " +
+		"`HistogramCount` AS cnt, `HistogramSum` AS sum, `HistogramPositiveBucketCounts`[1] AS bucket1"
+	rows := fixture.queryOverEmitted(t, projection, sqlStr, args)
+	defer func() { _ = rows.Close() }()
+
+	n := 0
+	for rows.Next() {
+		n++
+		var numLabels int
+		var cnt, sum, bucket1 float64
+		if err := rows.Scan(&numLabels, &cnt, &sum, &bucket1); err != nil {
+			t.Fatalf("scan: %v", err)
+		}
+		// sum() with no by/without drops every label — the merged row
+		// speaks for the whole group, not one series.
+		if numLabels != 0 {
+			t.Errorf("numLabels = %d, want 0 (sum() with no by/without drops every label)", numLabels)
+		}
+		const wantCount, wantSum, wantBucket1 = 16, 32.0, 58
+		if math.Abs(cnt-wantCount) > 1e-9 {
+			t.Errorf("HistogramCount = %v, want %v", cnt, wantCount)
+		}
+		if math.Abs(sum-wantSum) > 1e-9 {
+			t.Errorf("HistogramSum = %v, want %v", sum, wantSum)
+		}
+		if math.Abs(bucket1-wantBucket1) > 1e-9 {
+			t.Errorf("HistogramPositiveBucketCounts[1] = %v, want %v", bucket1, wantBucket1)
+		}
+	}
+	if err := testsql.TolerantRowsErr(rows.Err()); err != nil {
+		t.Fatalf("rows.Err: %v", err)
+	}
+	if n != 1 {
+		t.Fatalf("got %d rows, want exactly 1 (both scaled series merge into one group)", n)
+	}
+}
+
+// aggScaleAvgHistMetric/aggScaleAvgFloatMetric back
+// TestAvgOverFloatVectorScalingBinop_ChDB — kept distinct from the sum()
+// scenario's metrics so the two seeds never collide in the
+// process-shared chDB session (see fixture_chdb_test.go's own package
+// doc).
+const (
+	aggScaleAvgHistMetric  = "agg_scale_avg_hist_exp_hist"
+	aggScaleAvgFloatMetric = "agg_scale_avg_float_gauge"
+)
+
+var aggScaleAvgSeed = "" +
+	"CREATE OR REPLACE TABLE otel_metrics_exponential_histogram (" +
+	"`MetricName` String, `Attributes` Map(String, String), " +
+	"`ResourceAttributes` Map(String, String) DEFAULT map(), `ServiceName` LowCardinality(String) DEFAULT '', " +
+	"`TimeUnix` DateTime64(9), " +
+	"`Count` UInt64, `Sum` Float64, `Scale` Int32, `ZeroCount` UInt64, " +
+	"`PositiveOffset` Int32, `PositiveBucketCounts` Array(UInt64), " +
+	"`NegativeOffset` Int32, `NegativeBucketCounts` Array(UInt64)" +
+	") ENGINE = MergeTree ORDER BY (`MetricName`, `Attributes`, `TimeUnix`);\n" +
+	"INSERT INTO otel_metrics_exponential_histogram " +
+	"(MetricName, Attributes, TimeUnix, Count, Sum, Scale, ZeroCount, PositiveOffset, PositiveBucketCounts, NegativeOffset, NegativeBucketCounts) VALUES\n" +
+	"    ('" + aggScaleAvgHistMetric + "', map('job', 'api', 'az', 'us'), toDateTime64('2026-01-01 00:00:00', 9), 3, 6.0, 0, 0, 0, [9], 0, []),\n" +
+	"    ('" + aggScaleAvgHistMetric + "', map('job', 'api', 'az', 'eu'), toDateTime64('2026-01-01 00:00:00', 9), 5, 10.0, 0, 0, 0, [20], 0, []);\n" +
+	swapGaugeSeedDDL +
+	"INSERT INTO otel_metrics_gauge (MetricName, Attributes, TimeUnix, Value) VALUES\n" +
+	"    ('" + aggScaleAvgFloatMetric + "', map('job', 'api'), toDateTime64('2026-01-01 00:00:00', 9), 2.0);\n"
+
+// TestAvgOverFloatVectorScalingBinop_ChDB proves `avg(hist * on(job)
+// group_left() float)` scales each series by the joined float value
+// FIRST, merges across series SECOND, and only THEN divides by the
+// group's member count (2): the sum() scenario's own (16,32.0,[58])
+// merge divided by 2 = (8,16.0,[29]).
+func TestAvgOverFloatVectorScalingBinop_ChDB(t *testing.T) {
+	fixture := newChDBFixture(t, aggScaleAvgSeed)
+
+	s := schema.DefaultOTelMetrics()
+	p := parser.NewParser(parser.Options{EnableExperimentalFunctions: true})
+
+	query := "avg(" + aggScaleAvgHistMetric + " * on(job) group_left() " + aggScaleAvgFloatMetric + ")"
+	expr, err := p.ParseExpr(query)
+	if err != nil {
+		t.Fatalf("ParseExpr(%q): %v", query, err)
+	}
+	plan, err := promql.LowerAt(context.Background(), expr, s, aggScaleEvalTS, aggScaleEvalTS)
+	if err != nil {
+		t.Fatalf("LowerAt(%q): %v", query, err)
+	}
+	if _, ok := plan.(*chplan.HistogramProjection); !ok {
+		t.Fatalf("LowerAt(%q): plan root is %T, want *chplan.HistogramProjection", query, plan)
+	}
+	sqlStr, args, err := chsql.Emit(context.Background(), plan)
+	if err != nil {
+		t.Fatalf("Emit(%q): %v", query, err)
+	}
+
+	projection := "`HistogramCount` AS cnt, `HistogramSum` AS sum, `HistogramPositiveBucketCounts`[1] AS bucket1"
+	rows := fixture.queryOverEmitted(t, projection, sqlStr, args)
+	defer func() { _ = rows.Close() }()
+
+	n := 0
+	for rows.Next() {
+		n++
+		var cnt, sum, bucket1 float64
+		if err := rows.Scan(&cnt, &sum, &bucket1); err != nil {
+			t.Fatalf("scan: %v", err)
+		}
+		const wantCount, wantSum, wantBucket1 = 8, 16.0, 29
+		if math.Abs(cnt-wantCount) > 1e-9 {
+			t.Errorf("HistogramCount = %v, want %v", cnt, wantCount)
+		}
+		if math.Abs(sum-wantSum) > 1e-9 {
+			t.Errorf("HistogramSum = %v, want %v", sum, wantSum)
+		}
+		if math.Abs(bucket1-wantBucket1) > 1e-9 {
+			t.Errorf("HistogramPositiveBucketCounts[1] = %v, want %v", bucket1, wantBucket1)
+		}
+	}
+	if err := testsql.TolerantRowsErr(rows.Err()); err != nil {
+		t.Fatalf("rows.Err: %v", err)
+	}
+	if n != 1 {
+		t.Fatalf("got %d rows, want exactly 1", n)
+	}
+}

--- a/internal/promql/histogram_native_agg_over_float_vector_scaling_test.go
+++ b/internal/promql/histogram_native_agg_over_float_vector_scaling_test.go
@@ -1,0 +1,154 @@
+package promql_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/prometheus/prometheus/promql/parser"
+
+	"github.com/tsouza/cerberus/internal/chplan"
+	"github.com/tsouza/cerberus/internal/promql"
+	"github.com/tsouza/cerberus/internal/schema"
+)
+
+// TestLower_ExpHistogram_AggregationOverFloatVectorScalingBinop pins
+// cerberus issue #2540: every aggregation family that gates on
+// isExpHistogramValuedShape / lowerExpHistogramValuedShape (the shared
+// recognizer/lowering pair histogram_native_scalar_binop.go's own
+// isExpHistogramValuedShape and histogram_native_float_fn.go's own
+// lowerExpHistogramValuedShape form) now recognises and lowers the
+// exp-histogram/float-vector SCALING join shape
+// expHistogramFloatVectorScalingBinop answers (cerberus issues
+// #2339/#2342/#2537) as histogram-valued, instead of falling through to
+// lowerRoot's generic lower() dispatch and hitting
+// expHistogramSelectorRouting's catch-all rejection on the bare
+// histogram operand underneath.
+//
+// Probing before this fix (see the issue) found the SAME catch-all
+// rejection for every aggregation op tried — sum()/avg() (the
+// histogram-VALUED merge family), count()/group() (the value-blind
+// family), and min()/topk() (the histogram-DROPPING family) — which is
+// why the fix widens the ONE shared gate rather than patching each
+// aggregation recognizer separately, and why this test asserts across
+// that same spread rather than only sum()/avg().
+//
+// It also pins the SAME root cause's chained/nested-scaling variant
+// `(hist * float) * float2` (one of the issue's two explicitly open
+// questions): once the inner MUL is recognised as histogram-valued, the
+// OUTER MUL's own expHistogramFloatVectorScalingBinop recognizer (which
+// itself calls isExpHistogramValuedShape on its LHS) resolves
+// transitively, with no separate fix needed. The SUBQUERY-wrapping
+// variant (the issue's other open question) is deliberately NOT covered
+// here — probing found it is a genuinely separate, broader root cause
+// (lowerSubquery's own per-inner-type dispatch calls the generic
+// lowerBinary/lowerAggregate/lowerVectorSelector directly rather than
+// lowerRoot's histogram-native dispatch, so even a BARE histogram
+// selector loses native routing under a subquery) — tracked by its own
+// issue, not this one.
+func TestLower_ExpHistogram_AggregationOverFloatVectorScalingBinop(t *testing.T) {
+	t.Parallel()
+
+	s := schema.DefaultOTelMetrics()
+	p := parser.NewParser(parser.Options{EnableExperimentalFunctions: true})
+	start := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	end := start.Add(time.Hour)
+
+	// The exact shape cerberus issue #2540 names, wrapped by the
+	// aggregations below.
+	const scalingShape = `demo_latency_exp_hist * on(service) group_left() histogram_quantile(0.5, demo_latency_exp_hist)`
+
+	cases := []struct {
+		name      string
+		query     string
+		wantShape chplan.RowShape
+	}{
+		{name: "sum", query: `sum(` + scalingShape + `)`, wantShape: chplan.HistogramRowShape},
+		{name: "avg", query: `avg(` + scalingShape + `)`, wantShape: chplan.HistogramRowShape},
+		{name: "count", query: `count(` + scalingShape + `)`, wantShape: chplan.SampleRowShape},
+		{name: "group", query: `group(` + scalingShape + `)`, wantShape: chplan.SampleRowShape},
+		{name: "count_values", query: `count_values("le", ` + scalingShape + `)`, wantShape: chplan.SampleRowShape},
+		{name: "min", query: `min(` + scalingShape + `)`, wantShape: chplan.SampleRowShape},
+		{name: "max", query: `max(` + scalingShape + `)`, wantShape: chplan.SampleRowShape},
+		{name: "stddev", query: `stddev(` + scalingShape + `)`, wantShape: chplan.SampleRowShape},
+		{name: "stdvar", query: `stdvar(` + scalingShape + `)`, wantShape: chplan.SampleRowShape},
+		{name: "quantile", query: `quantile(0.9, ` + scalingShape + `)`, wantShape: chplan.SampleRowShape},
+		{name: "topk", query: `topk(3, ` + scalingShape + `)`, wantShape: chplan.SampleRowShape},
+		{name: "bottomk", query: `bottomk(3, ` + scalingShape + `)`, wantShape: chplan.SampleRowShape},
+		{
+			// Chained/nested scaling (open question 2): the outer MUL's
+			// LHS is itself a scaling-join shape, not a bare selector.
+			name:      "chained scaling",
+			query:     `(demo_latency_exp_hist * on(service) histogram_quantile(0.5, demo_latency_exp_hist)) * on(service) histogram_quantile(0.9, demo_latency_exp_hist)`,
+			wantShape: chplan.HistogramRowShape,
+		},
+		{
+			// Same chained shape, wrapped by sum() — both open questions
+			// (aggregation + chaining) composed together.
+			name:      "sum over chained scaling",
+			query:     `sum((demo_latency_exp_hist * on(service) histogram_quantile(0.5, demo_latency_exp_hist)) * on(service) histogram_quantile(0.9, demo_latency_exp_hist))`,
+			wantShape: chplan.HistogramRowShape,
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			expr, err := p.ParseExpr(tc.query)
+			if err != nil {
+				t.Fatalf("ParseExpr(%q): %v", tc.query, err)
+			}
+
+			instant, err := promql.LowerAt(context.Background(), expr, s, end, end)
+			if err != nil {
+				t.Fatalf("LowerAt(%q): %v", tc.query, err)
+			}
+			if got := chplan.RowShapeOf(instant); got != tc.wantShape {
+				t.Errorf("LowerAt(%q): row shape = %v, want %v", tc.query, got, tc.wantShape)
+			}
+
+			rangeExpr, err := p.ParseExpr(tc.query)
+			if err != nil {
+				t.Fatalf("ParseExpr(%q): %v", tc.query, err)
+			}
+			ranged, err := promql.LowerAtRange(context.Background(), rangeExpr, s, start, end, 30*time.Second)
+			if err != nil {
+				t.Fatalf("LowerAtRange(%q): %v", tc.query, err)
+			}
+			if got := chplan.RowShapeOf(ranged); got != tc.wantShape {
+				t.Errorf("LowerAtRange(%q): row shape = %v, want %v", tc.query, got, tc.wantShape)
+			}
+		})
+	}
+}
+
+// TestLower_ExpHistogram_SubqueryOverFloatVectorScalingBinopStillRejected
+// documents the boundary the test above deliberately stays inside of: a
+// subquery wrapping the SAME scaling-join shape (cerberus issue #2540's
+// own "subquery-wrapping variant" open question) still hits the
+// identical expHistogramSelectorRouting catch-all after this fix — not
+// because the scaling-join recognizer regressed, but because
+// lowerSubquery's own per-inner-type dispatch never consults lowerRoot
+// (or isExpHistogramValuedShape) for ANY histogram-native shape, not
+// only this one (probing also found a BARE `(demo_latency_exp_hist)
+// [5m:1m]` and `sum(demo_latency_exp_hist)[5m:1m]` still rejected the
+// same way). That is a separate, broader root cause, tracked by its own
+// issue rather than folded into this one.
+func TestLower_ExpHistogram_SubqueryOverFloatVectorScalingBinopStillRejected(t *testing.T) {
+	t.Parallel()
+
+	s := schema.DefaultOTelMetrics()
+	p := parser.NewParser(parser.Options{EnableExperimentalFunctions: true})
+	start := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	end := start.Add(time.Hour)
+
+	const query = `(demo_latency_exp_hist * on(service) group_left() histogram_quantile(0.5, demo_latency_exp_hist))[5m:1m]`
+	expr, err := p.ParseExpr(query)
+	if err != nil {
+		t.Fatalf("ParseExpr(%q): %v", query, err)
+	}
+	if _, err := promql.LowerAtRange(context.Background(), expr, s, start, end, 30*time.Second); err == nil {
+		t.Fatalf("LowerAtRange(%q): got no error, want the subquery-wrapping gap to still be open (tracked separately)", query)
+	}
+}

--- a/internal/promql/histogram_native_float_fn.go
+++ b/internal/promql/histogram_native_float_fn.go
@@ -46,6 +46,20 @@ func lowerExpHistogramValuedShape(expr parser.Expr, s schema.Metrics, ctx lowerC
 		plan, err := lowerExpHistogramScalarBinop(histSide, op, scale, s, ctx, false)
 		return plan, true, err
 	}
+	// The vector-scaling sibling of the literal-scalar case just above
+	// (cerberus issue #2540, widening #2339/#2342/#2537's own recognizer
+	// into this shared dispatch table): threading it in here is what lets
+	// [mergeableExpHistogramAggregate]'s recursion just above resolve
+	// `sum(hist * on(x) group_left() float)`'s inner MUL as
+	// histogram-valued, and lets every OTHER consumer of this function
+	// (count()/group(), count_values(), the drop-family aggregations, a
+	// histogram-histogram binop operand, a set-op operand) lower it the
+	// same way [isExpHistogramValuedShape]'s own sibling widening lets
+	// them recognise it.
+	if histSide, floatSide, op, match, card, include, ok := expHistogramFloatVectorScalingBinop(expr, s, ctx); ok {
+		plan, err := lowerExpHistogramFloatVectorScalingBinop(histSide, floatSide, op, match, card, include, s, ctx)
+		return plan, true, err
+	}
 	if lhs, rhs, sub, vm, ok := expHistogramHistogramBinop(expr, s, ctx); ok {
 		plan, err := lowerExpHistogramHistogramBinop(lhs, rhs, sub, vm, s, ctx)
 		return plan, true, err

--- a/internal/promql/histogram_native_scalar_binop.go
+++ b/internal/promql/histogram_native_scalar_binop.go
@@ -172,6 +172,24 @@ func isExpHistogramValuedShape(expr parser.Expr, s schema.Metrics, ctx lowerCtx)
 	if agg, ok := mergeableExpHistogramAggregate(expr); ok {
 		return isExpHistogramValuedShape(agg.Expr, s, ctx)
 	}
+	// `<exp-hist shape> (*|/) <float-VECTOR shape>` — the vector-scaling
+	// sibling of the compile-time-literal case just below (cerberus issue
+	// #2540), answered by [expHistogramFloatVectorScalingBinop]
+	// (histogram_native_float_vector_scaling_binop.go, cerberus issues
+	// #2339/#2342/#2537). Its result is a *chplan.HistogramProjection
+	// rooted in a *chplan.HistogramFloatVectorJoin — exactly as
+	// histogram-valued as the literal-scalar case below — so an
+	// aggregation wrapping it must see it here too, or every aggregation
+	// recognizer that gates on this predicate falls through to the
+	// generic lowering and hits [expHistogramSelectorRouting]'s catch-all
+	// rejection on the bare histogram operand underneath. Checked BEFORE
+	// the literal-scalar block below: that block's own `return scalar`
+	// hard-returns false the instant its LHS is histogram-valued,
+	// regardless of what the RHS is, which would shadow this shape (a
+	// non-literal, non-scalar RHS) before it is ever reached.
+	if _, _, _, _, _, _, ok := expHistogramFloatVectorScalingBinop(expr, s, ctx); ok {
+		return true
+	}
 	if b, ok := unwrapBinaryExpr(expr); ok {
 		if b.Op == parser.MUL {
 			if _, scalar := tryScalarLiteral(b.LHS); scalar && isExpHistogramValuedShape(b.RHS, s, ctx) {

--- a/test/rejection-parity/catalogue/internal__promql__lower.go.json
+++ b/test/rejection-parity/catalogue/internal__promql__lower.go.json
@@ -94,8 +94,8 @@
       "site": "internal/promql/lower.go:expHistogramSelectorRouting#bf746b59",
       "message": "promql: %q is an exponential histogram metric; only a bare %q selector, sum()/avg()/count() over one, rate()/increase()/delta()/irate()/idelta()/sum_over_time()/avg_over_time()/resets()/changes() over one, histogram_quantile(), histogram_count(), histogram_sum(), and the %q/%q companion selectors are supported",
       "class": "divergence",
-      "trigger_query": "sum(demo_latency_exp_hist * on(service) group_left() histogram_quantile(0.5, demo_latency_exp_hist))",
-      "tracking_issue": 2540,
+      "trigger_query": "(demo_latency_exp_hist * on(service) group_left() histogram_quantile(0.5, demo_latency_exp_hist))[5m:1m]",
+      "tracking_issue": 2543,
       "evidence": {
         "guard": [
           "past returning if bare, col, hasCompanion := s.HistogramCompanionColumn(metricName); hasCompanion \u0026\u0026 s.IsExpHistogramMetric(bare) \u0026\u0026 s.ExpHistogramTable != \"\"",


### PR DESCRIPTION
## Summary

- `isExpHistogramValuedShape` / `lowerExpHistogramValuedShape` (the shared recognizer/lowering
  pair every aggregation-over-histogram recognizer gates on) only recognised a histogram scaled
  by a compile-time scalar **literal**. Widened both halves of the pair to also recognise
  `expHistogramFloatVectorScalingBinop`'s vector-scaling shape (cerberus issues
  #2339/#2342/#2537), so `sum(hist * on(x) group_left() float)`'s inner `MUL` is now
  recognised as histogram-valued instead of falling through to the generic float aggregation
  path and hitting `expHistogramSelectorRouting`'s catch-all rejection.
- Probing broadly (mirroring #2508/#2509/#2515/#2518/#2528/#2534/#2537's own methodology, see
  test file doc comments for detail) resolved the issue's two explicit open questions:
  - **Does this apply to sum()/avg()/count() uniformly, or only a subset?** Uniformly, and
    further than just those three: `sum`/`avg` (the merge family), `count`/`group`/
    `count_values` (the value-blind family), and `min`/`max`/`stddev`/`stdvar`/`quantile`/
    `topk`/`bottomk` (the histogram-dropping family) all hit the identical catch-all before
    this change and all lower successfully after it — because they all key off the one shared
    gate this PR widens.
  - **Are the subquery-wrapping and chained/nested-scaling variants the same root cause, or
    separate gaps?** Split: the **chained-scaling** variant `(hist * float) * float2` is the
    **same** root cause (the outer `MUL`'s own recognizer calls `isExpHistogramValuedShape` on
    its LHS, which now resolves transitively — no separate fix needed). The
    **subquery-wrapping** variant `(hist * on(x) group_left() float)[5m:1m]` is a genuinely
    **separate, broader** root cause: `lowerSubquery`'s own per-inner-type dispatch calls
    `lowerBinary`/`lowerAggregate`/`lowerVectorSelector` directly rather than `lowerRoot`'s
    histogram-native dispatch, so even a **bare** histogram selector loses native routing under
    a subquery — and the scalar-literal case (`(hist * 2)[5m:1m]`) is silently WRONG (answers
    empty) rather than merely rejecting. Filed as #2543, not folded into this PR.
- Rotates the rejection-parity catalogue's `expHistogramSelectorRouting` entry forward to that
  next reachable gap, `tracking_issue` now #2543.

## Test plan

- [x] `TestLower_ExpHistogram_AggregationOverFloatVectorScalingBinop` — plan-shape assertions
      (instant + range) across the full aggregation surface (sum/avg/count/group/count_values/
      min/max/stddev/stdvar/quantile/topk/bottomk) plus the chained-scaling variant, confirmed
      to fail pre-fix and pass post-fix.
- [x] `TestLower_ExpHistogram_SubqueryOverFloatVectorScalingBinopStillRejected` — pins that the
      subquery-wrapping variant is deliberately still open, tracked by #2543.
- [x] `TestSumOverFloatVectorScalingBinop_ChDB` / `TestAvgOverFloatVectorScalingBinop_ChDB` —
      chDB-backed, seed two histogram series joined many-to-one against a float row via
      `group_left()`, assert the scaled-then-merged (`sum`) / scaled-then-merged-then-divided
      (`avg`) `HistogramCount`/`HistogramSum`/bucket values are numerically correct, not just
      error-free. Confirmed to fail pre-fix (hard rejection) and pass post-fix.
- [x] `go build ./...` and `go build -tags chdb ./...`
- [x] `go test -race ./internal/promql/...`
- [x] `node .github/scripts/forbid-sql-raw.mjs`
- [x] `CERBERUS_UPDATE_INVENTORY=1 go test -run TestCatalogueIsRegenerable ./test/rejection-parity/...` (run twice; diff is exactly the two hand-curated fields)

Closes #2540
