### PR TITLE
fix(promql): route a subquery's inner expression through histogram-native lowering

### DIFF
--- a/docs/coverage.md
+++ b/docs/coverage.md
@@ -86,7 +86,7 @@ single canonical probe, so a function that lowers `sort_by_label(v, "l")` and
 rejects `sort_by_label(v)` still counts as one supported symbol.
 
 Shape-level wrong-rejections are measured separately, by the rejection-parity
-catalogue: across all three heads it records **4** open argument-shape
+catalogue: across all three heads it records **5** open argument-shape
 divergences — queries the reference backend answers and cerberus rejects. Each
 is one `class: "divergence"` row in
 [`test/rejection-parity/catalogue/`](../test/rejection-parity/catalogue),

--- a/internal/promql/histogram_native_agg_over_float_vector_scaling_test.go
+++ b/internal/promql/histogram_native_agg_over_float_vector_scaling_test.go
@@ -123,19 +123,24 @@ func TestLower_ExpHistogram_AggregationOverFloatVectorScalingBinop(t *testing.T)
 	}
 }
 
+// TestLower_ExpHistogram_SubqueryOverFloatVectorScalingBinop documents the
+// boundary the test above deliberately stayed inside of when it was
+// written: a subquery wrapping the SAME scaling-join shape (cerberus
+// issue #2540's own "subquery-wrapping variant" open question, split out
+// as cerberus issue #2543 since it turned out to be a genuinely separate,
+// broader root cause — lowerSubquery's own per-inner-type dispatch never
+// consulted lowerRoot's histogram-native table for ANY histogram-native
+// shape, not only this one, so a BARE `(demo_latency_exp_hist)[5m:1m]`
+// and `sum(demo_latency_exp_hist)[5m:1m]` rejected the identical way).
+// #2543's own fix taught lowerSubquery to try that table against a
+// subquery's own inner expression, so this shape now lowers successfully
+// too — this test was
 // TestLower_ExpHistogram_SubqueryOverFloatVectorScalingBinopStillRejected
-// documents the boundary the test above deliberately stays inside of: a
-// subquery wrapping the SAME scaling-join shape (cerberus issue #2540's
-// own "subquery-wrapping variant" open question) still hits the
-// identical expHistogramSelectorRouting catch-all after this fix — not
-// because the scaling-join recognizer regressed, but because
-// lowerSubquery's own per-inner-type dispatch never consults lowerRoot
-// (or isExpHistogramValuedShape) for ANY histogram-native shape, not
-// only this one (probing also found a BARE `(demo_latency_exp_hist)
-// [5m:1m]` and `sum(demo_latency_exp_hist)[5m:1m]` still rejected the
-// same way). That is a separate, broader root cause, tracked by its own
-// issue rather than folded into this one.
-func TestLower_ExpHistogram_SubqueryOverFloatVectorScalingBinopStillRejected(t *testing.T) {
+// before that fix landed. TestSubqueryHistogramFloatVectorScalingJoin_ChDB
+// (subquery_histogram_native_chdb_test.go) covers the same shape with real
+// chDB execution and numeric verification; this sibling stays as the fast,
+// no-chDB row-shape pin the rest of this file's cases already use.
+func TestLower_ExpHistogram_SubqueryOverFloatVectorScalingBinop(t *testing.T) {
 	t.Parallel()
 
 	s := schema.DefaultOTelMetrics()
@@ -148,7 +153,11 @@ func TestLower_ExpHistogram_SubqueryOverFloatVectorScalingBinopStillRejected(t *
 	if err != nil {
 		t.Fatalf("ParseExpr(%q): %v", query, err)
 	}
-	if _, err := promql.LowerAtRange(context.Background(), expr, s, start, end, 30*time.Second); err == nil {
-		t.Fatalf("LowerAtRange(%q): got no error, want the subquery-wrapping gap to still be open (tracked separately)", query)
+	plan, err := promql.LowerAtRange(context.Background(), expr, s, start, end, 30*time.Second)
+	if err != nil {
+		t.Fatalf("LowerAtRange(%q): %v", query, err)
+	}
+	if got := chplan.RowShapeOf(plan); got != chplan.HistogramRowShape {
+		t.Errorf("LowerAtRange(%q): row shape = %v, want %v", query, got, chplan.HistogramRowShape)
 	}
 }

--- a/internal/promql/lower.go
+++ b/internal/promql/lower.go
@@ -168,15 +168,46 @@ func LowerMetadataRange(ctx context.Context, expr parser.Expr, s schema.Metrics,
 	return plan, nil
 }
 
-// lowerRoot lowers the ROOT of a query expression. It is [lower] plus the
-// dispatches that can only be decided at the root: the shapes over an
-// exponential (native) histogram that return a HISTOGRAM-VALUED sample —
-// a bare selector, `sum`/`avg` `[by/without] (<selector>)`, and
-// histogram-valued range functions over a range-vector selector — plus scalar binary
-// operations that preserve or drop that value and histogram-aware wrappers
-// such as label_replace that preserve the payload. Their answers have a wire
-// representation only when the histogram-valued shape (possibly under such
-// a wrapper) is the whole query.
+// lowerRoot lowers the ROOT of a query expression. It is [lower] plus
+// [lowerHistogramNativeRoot]'s histogram-native dispatch table — see that
+// function's own doc for what it recognises and why the distinction has
+// to happen at a root rather than inside [lowerVectorSelector].
+//
+// Metadata lowering ([LowerMetadataRange]) deliberately does NOT route
+// through here: it enumerates series and labels rather than evaluating an
+// expression, consumes no Value column, and already has its own
+// full-range bare-selector path.
+func lowerRoot(expr parser.Expr, s schema.Metrics, ctx lowerCtx) (chplan.Node, error) {
+	if plan, ok, err := lowerHistogramNativeRoot(expr, s, ctx); ok {
+		return plan, err
+	}
+	return lower(expr, s, ctx)
+}
+
+// lowerHistogramNativeRoot is [lowerRoot]'s histogram-native dispatch
+// table: the shapes over an exponential (native) histogram that return a
+// HISTOGRAM-VALUED sample — a bare selector, `sum`/`avg`
+// `[by/without] (<selector>)`, and histogram-valued range functions over
+// a range-vector selector — plus scalar binary operations that preserve
+// or drop that value and histogram-aware wrappers such as label_replace
+// that preserve the payload. Their answers have a wire representation
+// only when the histogram-valued shape (possibly under such a wrapper) is
+// the whole query — or, since cerberus issue #2543, the whole INNER
+// expression of a bare top-level subquery ([lowerHistogramNativeSubqueryInner],
+// subquery.go): a subquery's inner is re-evaluated at every anchor of its
+// own grid exactly the way a query's root is evaluated once, so the
+// identical recognizer chain applies, just against a different grid.
+//
+// It is factored out of [lowerRoot] itself for exactly that reuse:
+// lowerRoot was the sole caller until #2543, because `lower`'s
+// `*parser.SubqueryExpr` case calls [lowerSubquery] directly and every
+// `lowerSubqueryOver*` helper called its own generic lowering entry point
+// (lowerVectorSelector / lowerBinary / lowerAggregate) unconditionally,
+// never lowerRoot's table — so a subquery's inner never got the same
+// chance a query's root always has. ok is false when expr matched none of
+// the recognizers below; lowerRoot's caller falls through to [lower], and
+// lowerHistogramNativeSubqueryInner's caller falls through to its own
+// per-shape generic lowering, unchanged from before #2543.
 //
 // The distinction cannot be made inside [lowerVectorSelector], because the
 // selector in `sum(m_exp_hist)` and the selector in `m_exp_hist` arrive
@@ -252,17 +283,13 @@ func LowerMetadataRange(ctx context.Context, expr parser.Expr, s schema.Metrics,
 // #2449) still falls through to internal/promql/binary.go's
 // lowerVectorSetOp rejection, tracked as an open divergence in
 // test/rejection-parity/catalogue under #2449.
-//
-// Metadata lowering ([LowerMetadataRange]) deliberately does NOT route
-// through here: it enumerates series and labels rather than evaluating an
-// expression, consumes no Value column, and already has its own
-// full-range bare-selector path.
-func lowerRoot(expr parser.Expr, s schema.Metrics, ctx lowerCtx) (chplan.Node, error) {
+func lowerHistogramNativeRoot(expr parser.Expr, s schema.Metrics, ctx lowerCtx) (chplan.Node, bool, error) {
 	if call, ok := labelReplaceOverExpHistogram(expr, s, ctx); ok {
-		return lowerLabelReplaceOverExpHistogram(call, s, ctx)
+		plan, err := lowerLabelReplaceOverExpHistogram(call, s, ctx)
+		return plan, true, err
 	}
 	if plan, ok, err := lowerExpHistogramValuedShape(expr, s, ctx); ok {
-		return plan, err
+		return plan, true, err
 	}
 	// `or` between a float-valued operand and a histogram-valued operand
 	// (cerberus issue #2330), and every wrapper composition around that
@@ -272,7 +299,7 @@ func lowerRoot(expr parser.Expr, s schema.Metrics, ctx lowerCtx) (chplan.Node, e
 	// dispatch order and semantics are unchanged, see that function's own
 	// doc for the per-recognizer rationale each check used to carry here.
 	if plan, ok, err := lowerMixedExpHistogramFamily(expr, s, ctx); ok {
-		return plan, err
+		return plan, true, err
 	}
 	// Vector-vector `==`/`!=`/`<`/`<=`/`>`/`>=`, with or without `bool`,
 	// where BOTH operands are themselves a mixed `or` — neither side a
@@ -291,13 +318,16 @@ func lowerRoot(expr parser.Expr, s schema.Metrics, ctx lowerCtx) (chplan.Node, e
 	// every matched pair regardless of type compatibility, contrary to
 	// what the arithmetic pass's own header had assumed.
 	if lhs, rhs, op, match, card, include, returnBool, ok := comparisonVectorVectorOverMixedExpHistogramSetOp(expr, s, ctx); ok {
-		return lowerComparisonVectorVectorOverMixedExpHistogramSetOp(lhs, rhs, op, match, card, include, returnBool, s, ctx)
+		plan, err := lowerComparisonVectorVectorOverMixedExpHistogramSetOp(lhs, rhs, op, match, card, include, returnBool, s, ctx)
+		return plan, true, err
 	}
 	if shape, ok := overTimeOverExpHistogram(expr, s, ctx); ok {
-		return lowerExpHistogramOverTime(shape, s, ctx)
+		plan, err := lowerExpHistogramOverTime(shape, s, ctx)
+		return plan, true, err
 	}
 	if shape, ok := resetsOrChangesOverExpHistogram(expr, s, ctx); ok {
-		return lowerExpHistogramResetsOrChanges(shape, s, ctx)
+		plan, err := lowerExpHistogramResetsOrChanges(shape, s, ctx)
+		return plan, true, err
 	}
 	// count_over_time() / present_over_time() (cerberus issue #2480): the
 	// window-counting sibling of sum_over_time / avg_over_time just above
@@ -306,7 +336,8 @@ func lowerRoot(expr parser.Expr, s schema.Metrics, ctx lowerCtx) (chplan.Node, e
 	// (rangeVectorFloatOnlyDropFuncs) or the fold treatment
 	// (overTimeOverExpHistogram) applies.
 	if fn, ms, vs, ok := countPresentOverExpHistogram(expr, s, ctx); ok {
-		return lowerCountPresentOverExpHistogram(fn, ms, vs, s, ctx)
+		plan, err := lowerCountPresentOverExpHistogram(fn, ms, vs, s, ctx)
+		return plan, true, err
 	}
 	// last_over_time() / first_over_time() (cerberus issue #2480): the
 	// histogram-PRESERVING sibling of count_over_time / present_over_time
@@ -314,7 +345,8 @@ func lowerRoot(expr parser.Expr, s schema.Metrics, ctx lowerCtx) (chplan.Node, e
 	// for why reference selects (rather than drops or counts) the
 	// window's newest/oldest sample.
 	if fn, ms, vs, ok := lastFirstOverExpHistogram(expr, s, ctx); ok {
-		return lowerLastFirstOverExpHistogram(fn, ms, vs, s, ctx)
+		plan, err := lowerLastFirstOverExpHistogram(fn, ms, vs, s, ctx)
+		return plan, true, err
 	}
 	// ts_of_first_over_time() / ts_of_last_over_time() (cerberus issue
 	// #2482): the timestamp-reporting siblings of last_over_time /
@@ -323,45 +355,54 @@ func lowerRoot(expr parser.Expr, s schema.Metrics, ctx lowerCtx) (chplan.Node, e
 	// they need their own lowering (the output is a float TIMESTAMP
 	// value with `__name__` DROPPED, not a preserved histogram sample).
 	if fn, ms, vs, ok := tsOfFirstLastOverExpHistogram(expr, s, ctx); ok {
-		return lowerTsOfFirstLastOverExpHistogram(fn, ms, vs, s, ctx)
+		plan, err := lowerTsOfFirstLastOverExpHistogram(fn, ms, vs, s, ctx)
+		return plan, true, err
 	}
 	if agg, vs, ok := countOverExpHistogram(expr, s, ctx); ok {
-		return lowerExpHistogramCount(agg, vs, s, ctx)
+		plan, err := lowerExpHistogramCount(agg, vs, s, ctx)
+		return plan, true, err
 	}
 	if agg, ok := countOrGroupOverExpHistogramValue(expr, s, ctx); ok {
 		input, matched, err := lowerExpHistogramValuedShape(agg.Expr, s, ctx)
 		if err != nil {
-			return nil, err
+			return nil, true, err
 		}
 		if !matched {
-			return nil, fmt.Errorf("promql: internal invariant violated: count/group input is not histogram-valued: %v", agg.Expr)
+			return nil, true, fmt.Errorf("promql: internal invariant violated: count/group input is not histogram-valued: %v", agg.Expr)
 		}
-		return lowerExpHistogramCountOrGroupOverPlan(agg, input, s)
+		plan, err := lowerExpHistogramCountOrGroupOverPlan(agg, input, s)
+		return plan, true, err
 	}
 	if agg, ok := countValuesOverExpHistogramValue(expr, s, ctx); ok {
 		input, matched, err := lowerExpHistogramValuedShape(agg.Expr, s, ctx)
 		if err != nil {
-			return nil, err
+			return nil, true, err
 		}
 		if !matched {
-			return nil, fmt.Errorf("promql: internal invariant violated: count_values input is not histogram-valued: %v", agg.Expr)
+			return nil, true, fmt.Errorf("promql: internal invariant violated: count_values input is not histogram-valued: %v", agg.Expr)
 		}
-		return lowerExpHistogramCountValuesOverPlan(agg, input, s, ctx)
+		plan, err := lowerExpHistogramCountValuesOverPlan(agg, input, s, ctx)
+		return plan, true, err
 	}
 	if agg, vs, ok := droppingAggregationOverExpHistogram(expr, s, ctx); ok {
-		return lowerExpHistogramDroppingAggregation(agg, vs, s, ctx)
+		plan, err := lowerExpHistogramDroppingAggregation(agg, vs, s, ctx)
+		return plan, true, err
 	}
 	if histSide, ok := expHistogramDroppingScalarBinop(expr, s, ctx); ok {
-		return lowerExpHistogramScalarBinop(histSide, "", nil, s, ctx, true)
+		plan, err := lowerExpHistogramScalarBinop(histSide, "", nil, s, ctx, true)
+		return plan, true, err
 	}
 	if lhs, rhs, ok := expHistogramDroppingHistogramBinop(expr, s, ctx); ok {
-		return lowerExpHistogramDroppingHistogramBinop(lhs, rhs, s, ctx)
+		plan, err := lowerExpHistogramDroppingHistogramBinop(lhs, rhs, s, ctx)
+		return plan, true, err
 	}
 	if histSide, floatSide, op, match, card, include, ok := expHistogramFloatVectorScalingBinop(expr, s, ctx); ok {
-		return lowerExpHistogramFloatVectorScalingBinop(histSide, floatSide, op, match, card, include, s, ctx)
+		plan, err := lowerExpHistogramFloatVectorScalingBinop(histSide, floatSide, op, match, card, include, s, ctx)
+		return plan, true, err
 	}
 	if histSide, floatSide, ok := expHistogramDroppingVectorBinop(expr, s, ctx); ok {
-		return lowerExpHistogramDroppingVectorBinop(histSide, floatSide, s, ctx)
+		plan, err := lowerExpHistogramDroppingVectorBinop(histSide, floatSide, s, ctx)
+		return plan, true, err
 	}
 	// A wrapper around a NESTED drop-family shape (cerberus issue #2528):
 	// an aggregation of ANY operator, or label_replace/label_join, whose
@@ -378,9 +419,9 @@ func lowerRoot(expr parser.Expr, s schema.Metrics, ctx lowerCtx) (chplan.Node, e
 	// result composes under further wrapping without needing a bespoke
 	// recogniser per wrapper.
 	if plan, ok, err := lowerExpHistogramDroppingShape(expr, s, ctx); ok {
-		return plan, err
+		return plan, true, err
 	}
-	return lower(expr, s, ctx)
+	return nil, false, nil
 }
 
 // lowerMixedExpHistogramFamily dispatches `or` between a float-valued

--- a/internal/promql/subquery.go
+++ b/internal/promql/subquery.go
@@ -38,6 +38,18 @@ func lowerSubquery(e *parser.SubqueryExpr, s schema.Metrics, ctx lowerCtx) (chpl
 		return nil, fmt.Errorf("promql: subquery step must be positive, got %s", e.Step)
 	}
 
+	// A subquery's inner expression is re-evaluated at every one of its own
+	// grid anchors — the identical thing a query's own root is evaluated
+	// once at — so it gets the identical first chance at histogram-native
+	// routing lowerRoot gives a query's root, before any of the
+	// lowerSubqueryOver* helpers below fall back to their own generic
+	// lowering entry point (cerberus issue #2543). See
+	// [lowerHistogramNativeSubqueryInner]'s own doc for the shapes this
+	// covers and why none of them needed a per-helper change.
+	if plan, matched, err := lowerHistogramNativeSubqueryInner(e, step, s, ctx); matched {
+		return plan, err
+	}
+
 	switch inner := e.Expr.(type) {
 	case *parser.VectorSelector:
 		return lowerSubqueryOverVectorSelector(e, inner, step, s, ctx)
@@ -60,6 +72,95 @@ func lowerSubquery(e *parser.SubqueryExpr, s schema.Metrics, ctx lowerCtx) (chpl
 		return lowerSubqueryOverSubquery(e, inner, step, s, ctx)
 	}
 	return nil, fmt.Errorf("promql: subquery over %T is unsupported", e.Expr)
+}
+
+// lowerHistogramNativeSubqueryInner tries [lowerHistogramNativeRoot]'s
+// entire histogram-native recognizer chain against sub's OWN inner
+// expression, evaluated at the subquery's own per-anchor grid
+// ([subqueryGridCtx]) rather than the raw sample stream every
+// lowerSubqueryOver* helper otherwise falls back to (cerberus issue
+// #2543).
+//
+// It composes with the SAME machinery a non-subquery histogram-native
+// query already uses in range mode: every histogram-native lowering
+// ([lowerExpHistogramBare] and its siblings) fans its own output across
+// ctx.start/ctx.end/ctx.step whenever they are set ([rangeGridShapeFor]),
+// and [subqueryGridCtx] sets exactly those three fields to the
+// subquery's OWN anchor grid. The histogram-native result therefore
+// already carries one row per (series, subquery anchor) with no further
+// RangeWindow wrap needed — unlike the Sample-shape siblings
+// [wrapSubqueryIdentity] windows, which start from an UNBOUNDED raw
+// selector and need the wrapper to do the per-anchor windowing itself.
+// This mirrors [lowerExpHistogramRangeFnOverSubquery]'s own existing use
+// of the identical subqueryGridCtx + histogram-lowering pattern for
+// `rate(<histogram-valued-subquery>)` — the OUTER-wraps-subquery
+// composition; this function is its BARE (no outer wrapper) sibling.
+//
+// matched is false whenever sub's inner is not one of the recognized
+// shapes (the caller keeps its own per-shape lowering unchanged) or when
+// no eval anchor is available at all ([subqueryGridCtx] returns ok=false
+// — only reachable from a bare [Lower] call with no query time threaded
+// through at all; every real HTTP entry point uses [LowerAt] /
+// [LowerAtRange] and always has one). A [subqueryGridCtx] error is
+// likewise treated as "not matched" rather than surfaced directly: the
+// caller's own per-shape lowering recomputes the identical anchor below
+// and will raise the same error itself, so there is exactly one place
+// that error message is spelled.
+//
+// When matched, plan is returned exactly as the histogram-native
+// recognizer built it EXCEPT for its own row shape:
+//
+//   - [chplan.HistogramRowShape] / [chplan.MixedRowShape] (a
+//     histogram-valued or mixed-`or` result) is returned AS-IS.
+//     Re-projecting it through [subqueryAnchorShape]'s four-column
+//     Sample quartet would silently drop the nine Histogram*Column
+//     outputs (or the mixed shape's discriminator column) — the exact
+//     hazard [chplan.HistogramRowShape]'s own doc comment warns every
+//     generic forwarder about.
+//   - Anything else (the "drop" family's always-empty float quartet, a
+//     [chplan.SampleRowShape] result) gets the SAME [subqueryAnchorShape]
+//     wrap the non-histogram arithmetic siblings already apply, so a
+//     wrapping outer range-vector function can still read the
+//     `anchor_ts` alias.
+//
+// A histogram-native shape reached from an OUTER range-vector function
+// wrapping this subquery (`max_over_time((m_exp_hist)[5m:1m])`) is a
+// separate, deliberately unsupported composition:
+// [lowerOuterRangeFnOverSubquery] rejects a [chplan.HistogramRowShape] /
+// [chplan.MixedRowShape] result from this function explicitly, because
+// its own RangeWindow wrapper reduces over the placeholder `Value`
+// column a histogram-shaped row does not meaningfully carry.
+func lowerHistogramNativeSubqueryInner(sub *parser.SubqueryExpr, step time.Duration, s schema.Metrics, ctx lowerCtx) (chplan.Node, bool, error) {
+	grid, ok, err := subqueryGridCtx(sub, step, ctx)
+	if err != nil || !ok {
+		return nil, false, nil
+	}
+
+	innerExpr := sub.Expr
+	// The subquery's own modifiers shadow a directly-nested selector's —
+	// mirrors lowerSubqueryOverVectorSelector's identical strip, applied
+	// here so a bare histogram selector under a subquery sees the same
+	// anchor its Sample-shape sibling does rather than double-applying
+	// its own `@`/`offset` on top of the grid subqueryGridCtx already
+	// derived from the subquery's modifiers.
+	if vs, ok := unwrapVectorSelector(innerExpr); ok {
+		vsNoModifier, _ := stripSelectorModifierForRangeVector(vs, grid)
+		innerExpr = &vsNoModifier
+	}
+
+	plan, matched, herr := lowerHistogramNativeRoot(innerExpr, s, grid)
+	if !matched {
+		return nil, false, nil
+	}
+	if herr != nil {
+		return nil, true, herr
+	}
+	switch chplan.RowShapeOf(plan) {
+	case chplan.HistogramRowShape, chplan.MixedRowShape:
+		return plan, true, nil
+	default:
+		return subqueryAnchorShape(plan, s), true, nil
+	}
 }
 
 // lowerSubqueryOverUnary — `(-<expr>)[range:step]` / `(+<expr>)[range:step]`.
@@ -687,6 +788,21 @@ func lowerOuterRangeFnOverSubquery(
 	inner, err := lowerSubquery(sub, s, ctx)
 	if err != nil {
 		return nil, err
+	}
+	// A subquery whose OWN inner expression resolved histogram-native
+	// (cerberus issue #2543, [lowerHistogramNativeSubqueryInner]) is a
+	// deliberately unsupported composition here: this reducer's
+	// RangeWindow below folds over TimestampColumn "anchor_ts" /
+	// ValueColumn s.ValueColumn, and a histogram-shaped row publishes
+	// neither meaningfully — Value is only the placeholder
+	// [chplan.HistogramProjection] always carries alongside its real
+	// nine Histogram*Column fields (see that type's own doc comment).
+	// Rejecting explicitly here, rather than letting the RangeWindow
+	// below reference a column the histogram-shaped relation never
+	// publishes, turns what would otherwise be a ClickHouse "Unknown
+	// identifier" 502 into a clear promql-level error.
+	if shape := chplan.RowShapeOf(inner); shape == chplan.HistogramRowShape || shape == chplan.MixedRowShape {
+		return nil, fmt.Errorf("promql: %s over a subquery wrapping a native-histogram-valued shape is unsupported", outer.Func.Name)
 	}
 
 	anchor, err := subqueryAnchor(sub, ctx)

--- a/internal/promql/subquery_histogram_native_chdb_test.go
+++ b/internal/promql/subquery_histogram_native_chdb_test.go
@@ -1,0 +1,402 @@
+//go:build chdb
+
+// chDB-backed proof that a bare top-level subquery wrapping a
+// native-histogram-valued shape (`(<expr>)[range:step]`, no outer
+// range-vector function) actually routes through histogram-native
+// lowering at real ClickHouse execution — not merely that the emitted
+// plan's Go shape looks right (cerberus issue #2543).
+//
+// Before this fix, lowerSubquery never consulted lowerRoot's
+// histogram-native dispatch table for a subquery's OWN inner expression
+// ([lowerHistogramNativeSubqueryInner] / [lowerHistogramNativeRoot],
+// lower.go / subquery.go). Every shape below either hard-rejected under
+// LowerAtRange (bare selector, sum(), the +/- merge, the group_left()
+// scaling join) or — the genuinely silent half of #2543 — lowered
+// WITHOUT error to an EMPTY float result via
+// lowerExpHistogramArgAsCanonicalFloat's "preserve family, reproject to
+// empty float" branch (the `* 2` scale shape,
+// TestSubqueryHistogramScale_ChDB below). Every case here proves the
+// FIXED behaviour: a real, non-empty, correctly-valued matrix at
+// multiple distinct subquery anchors, read back from a real chDB
+// execution.
+package promql_test
+
+import (
+	"context"
+	"math"
+	"testing"
+	"time"
+
+	"github.com/prometheus/prometheus/promql/parser"
+
+	"github.com/tsouza/cerberus/internal/chsql"
+	"github.com/tsouza/cerberus/internal/promql"
+	"github.com/tsouza/cerberus/internal/schema"
+	"github.com/tsouza/cerberus/internal/testsql"
+)
+
+// subqHistDDL is the OTel exponential-histogram table layout every case
+// in this file seeds against — byte-for-byte the same columns
+// histogram_native_mixed_or_scale_chdb_test.go's own seed uses.
+const subqHistDDL = "CREATE OR REPLACE TABLE otel_metrics_exponential_histogram (" +
+	"`MetricName` String, `Attributes` Map(String, String), " +
+	"`ResourceAttributes` Map(String, String) DEFAULT map(), `ServiceName` LowCardinality(String) DEFAULT '', " +
+	"`TimeUnix` DateTime64(9), " +
+	"`Count` UInt64, `Sum` Float64, `Scale` Int32, `ZeroCount` UInt64, " +
+	"`PositiveOffset` Int32, `PositiveBucketCounts` Array(UInt64), " +
+	"`NegativeOffset` Int32, `NegativeBucketCounts` Array(UInt64)" +
+	") ENGINE = MergeTree ORDER BY (`MetricName`, `Attributes`, `TimeUnix`);\n"
+
+// subqHistProjection reads back the per-anchor matrix contract every case
+// below emits: the wall-clock anchor (`TimeUnix`), plus the three
+// scalar/first-bucket histogram fields the assertions need. `[1]` on
+// HistogramPositiveBucketCounts sidesteps chdb-go's Array(Float64)
+// decode the same way histogram_native_mixed_or_scale_chdb_test.go's own
+// projection does.
+const subqHistProjection = "`Attributes`['series'] AS series, toUnixTimestamp(`TimeUnix`) AS ts, " +
+	"`HistogramCount` AS cnt, `HistogramSum` AS sum, `HistogramPositiveBucketCounts`[1] AS bucket1"
+
+type subqHistRow struct {
+	series  string
+	ts      int64
+	cnt     float64
+	sum     float64
+	bucket1 float64
+}
+
+func subqHistQueryRows(t *testing.T, fixture *chdbFixture, sqlStr string, args []any) []subqHistRow {
+	t.Helper()
+	rows := fixture.queryOverEmitted(t, subqHistProjection, sqlStr, args)
+	defer func() { _ = rows.Close() }()
+	var out []subqHistRow
+	for rows.Next() {
+		var r subqHistRow
+		if err := rows.Scan(&r.series, &r.ts, &r.cnt, &r.sum, &r.bucket1); err != nil {
+			t.Fatalf("scan: %v", err)
+		}
+		out = append(out, r)
+	}
+	if err := testsql.TolerantRowsErr(rows.Err()); err != nil {
+		t.Fatalf("rows.Err: %v", err)
+	}
+	return out
+}
+
+func subqHistRowAt(t *testing.T, rows []subqHistRow, series string, ts time.Time) subqHistRow {
+	t.Helper()
+	for _, r := range rows {
+		if r.series == series && r.ts == ts.Unix() {
+			return r
+		}
+	}
+	t.Fatalf("no row for series %q at ts %v; got rows %+v", series, ts, rows)
+	return subqHistRow{}
+}
+
+// TestSubqueryHistogramBareSelector_ChDB proves `(<bare exp-hist
+// selector>)[range:step]` — the issue's own first example, and the
+// shape that "accidentally" looks like it should work at the top level
+// because lowerVectorSelector has its own histogram routing, but still
+// hard-rejected under a subquery before this fix (expHistogramSelectorRouting's
+// catch-all: a selector nested under anything other than the bare-root
+// case it is asked from). Two distinct anchors read back two distinct
+// seeded samples, proving genuine per-anchor windowing rather than one
+// value broadcast across the matrix.
+func TestSubqueryHistogramBareSelector_ChDB(t *testing.T) {
+	const metric = "subq_bare_exp_hist"
+	seed := subqHistDDL +
+		"INSERT INTO otel_metrics_exponential_histogram " +
+		"(MetricName, Attributes, TimeUnix, Count, Sum, Scale, ZeroCount, PositiveOffset, PositiveBucketCounts, NegativeOffset, NegativeBucketCounts) VALUES\n" +
+		"    ('" + metric + "', map('series', 'a'), toDateTime64('2026-01-01 00:01:00', 9), 2, 4.0, 0, 0, 0, [6], 0, []),\n" +
+		"    ('" + metric + "', map('series', 'a'), toDateTime64('2026-01-01 00:02:00', 9), 3, 9.0, 0, 0, 0, [12], 0, []);\n"
+	fixture := newChDBFixture(t, seed)
+
+	s := schema.DefaultOTelMetrics()
+	p := parser.NewParser(parser.Options{EnableExperimentalFunctions: true})
+	evalTS := time.Date(2026, 1, 1, 0, 2, 0, 0, time.UTC)
+
+	query := "(" + metric + ")[2m:1m]"
+	expr, err := p.ParseExpr(query)
+	if err != nil {
+		t.Fatalf("ParseExpr(%q): %v", query, err)
+	}
+	plan, err := promql.LowerAt(context.Background(), expr, s, evalTS, evalTS)
+	if err != nil {
+		t.Fatalf("LowerAt(%q): %v", query, err)
+	}
+	sqlStr, args, err := chsql.Emit(context.Background(), plan)
+	if err != nil {
+		t.Fatalf("Emit(%q): %v", query, err)
+	}
+
+	rows := subqHistQueryRows(t, fixture, sqlStr, args)
+	if len(rows) != 2 {
+		t.Fatalf("%s: got %d rows, want 2 (one per subquery anchor): %+v", query, len(rows), rows)
+	}
+	anchor1 := subqHistRowAt(t, rows, "a", time.Date(2026, 1, 1, 0, 1, 0, 0, time.UTC))
+	if anchor1.cnt != 2 || anchor1.sum != 4.0 || anchor1.bucket1 != 6 {
+		t.Errorf("%s: anchor 00:01 = %+v, want Count=2 Sum=4 Bucket1=6", query, anchor1)
+	}
+	anchor2 := subqHistRowAt(t, rows, "a", time.Date(2026, 1, 1, 0, 2, 0, 0, time.UTC))
+	if anchor2.cnt != 3 || anchor2.sum != 9.0 || anchor2.bucket1 != 12 {
+		t.Errorf("%s: anchor 00:02 = %+v, want Count=3 Sum=9 Bucket1=12", query, anchor2)
+	}
+}
+
+// TestSubqueryHistogramSumOverTime_ChDB proves `sum(<exp-hist
+// selector>)[range:step]` — the issue's fourth example — merges two
+// series' bucket ladders at each subquery anchor.
+func TestSubqueryHistogramSumOverTime_ChDB(t *testing.T) {
+	const metric = "subq_sum_exp_hist"
+	seed := subqHistDDL +
+		"INSERT INTO otel_metrics_exponential_histogram " +
+		"(MetricName, Attributes, TimeUnix, Count, Sum, Scale, ZeroCount, PositiveOffset, PositiveBucketCounts, NegativeOffset, NegativeBucketCounts) VALUES\n" +
+		"    ('" + metric + "', map('job', 'a'), toDateTime64('2026-01-01 00:01:00', 9), 2, 4.0, 0, 0, 0, [6], 0, []),\n" +
+		"    ('" + metric + "', map('job', 'b'), toDateTime64('2026-01-01 00:01:00', 9), 5, 1.0, 0, 0, 0, [3], 0, []);\n"
+	fixture := newChDBFixture(t, seed)
+
+	s := schema.DefaultOTelMetrics()
+	p := parser.NewParser(parser.Options{EnableExperimentalFunctions: true})
+	evalTS := time.Date(2026, 1, 1, 0, 1, 0, 0, time.UTC)
+
+	query := "(sum(" + metric + "))[1m:1m]"
+	expr, err := p.ParseExpr(query)
+	if err != nil {
+		t.Fatalf("ParseExpr(%q): %v", query, err)
+	}
+	plan, err := promql.LowerAt(context.Background(), expr, s, evalTS, evalTS)
+	if err != nil {
+		t.Fatalf("LowerAt(%q): %v", query, err)
+	}
+	sqlStr, args, err := chsql.Emit(context.Background(), plan)
+	if err != nil {
+		t.Fatalf("Emit(%q): %v", query, err)
+	}
+
+	// sum() drops __name__ and every input label — the merged row's own
+	// "series" attribute read by subqHistProjection is therefore absent,
+	// so this case reads the row directly rather than through
+	// subqHistQueryRows/subqHistRowAt (which key off it).
+	projection := "toUnixTimestamp(`TimeUnix`) AS ts, `HistogramCount` AS cnt, `HistogramSum` AS sum, `HistogramPositiveBucketCounts`[1] AS bucket1"
+	rows := fixture.queryOverEmitted(t, projection, sqlStr, args)
+	defer func() { _ = rows.Close() }()
+	var got int
+	for rows.Next() {
+		var ts int64
+		var cnt, sum, bucket1 float64
+		if err := rows.Scan(&ts, &cnt, &sum, &bucket1); err != nil {
+			t.Fatalf("scan: %v", err)
+		}
+		got++
+		if ts != evalTS.Unix() {
+			continue
+		}
+		if cnt != 7 || sum != 5.0 || bucket1 != 9 {
+			t.Errorf("%s: sum() merge = Count=%v Sum=%v Bucket1=%v, want Count=7 Sum=5 Bucket1=9 (2+5, 4.0+1.0, 6+3)", query, cnt, sum, bucket1)
+		}
+	}
+	if err := testsql.TolerantRowsErr(rows.Err()); err != nil {
+		t.Fatalf("rows.Err: %v", err)
+	}
+	if got == 0 {
+		t.Fatalf("%s: got no rows at all", query)
+	}
+}
+
+// TestSubqueryHistogramAddMerge_ChDB proves `(<exp-hist> + <exp-hist>)[range:step]`
+// — the issue's third example, the ADD/SUB merge shape — under a bare
+// top-level subquery.
+func TestSubqueryHistogramAddMerge_ChDB(t *testing.T) {
+	const metric = "subq_addmerge_exp_hist"
+	seed := subqHistDDL +
+		"INSERT INTO otel_metrics_exponential_histogram " +
+		"(MetricName, Attributes, TimeUnix, Count, Sum, Scale, ZeroCount, PositiveOffset, PositiveBucketCounts, NegativeOffset, NegativeBucketCounts) VALUES\n" +
+		"    ('" + metric + "', map('series', 'a'), toDateTime64('2026-01-01 00:01:00', 9), 2, 4.0, 0, 0, 0, [6], 0, []);\n"
+	fixture := newChDBFixture(t, seed)
+
+	s := schema.DefaultOTelMetrics()
+	p := parser.NewParser(parser.Options{EnableExperimentalFunctions: true})
+	evalTS := time.Date(2026, 1, 1, 0, 1, 0, 0, time.UTC)
+
+	query := "(" + metric + " + " + metric + ")[1m:1m]"
+	expr, err := p.ParseExpr(query)
+	if err != nil {
+		t.Fatalf("ParseExpr(%q): %v", query, err)
+	}
+	plan, err := promql.LowerAt(context.Background(), expr, s, evalTS, evalTS)
+	if err != nil {
+		t.Fatalf("LowerAt(%q): %v", query, err)
+	}
+	sqlStr, args, err := chsql.Emit(context.Background(), plan)
+	if err != nil {
+		t.Fatalf("Emit(%q): %v", query, err)
+	}
+
+	rows := subqHistQueryRows(t, fixture, sqlStr, args)
+	if len(rows) == 0 {
+		t.Fatalf("%s: got no rows", query)
+	}
+	got := subqHistRowAt(t, rows, "a", evalTS)
+	if got.cnt != 4 || got.sum != 8.0 || got.bucket1 != 12 {
+		t.Errorf("%s: merged = %+v, want Count=4 Sum=8 Bucket1=12 (a series added to itself)", query, got)
+	}
+}
+
+// TestSubqueryHistogramScale_ChDB is the SILENT correctness bug the
+// issue reports as the priority half of #2543: before this fix,
+// `(<exp-hist> * 2)[range:step]` lowered WITHOUT error — through
+// lowerBinary -> lowerScalarBinopOperand -> lowerExpHistogramArgAsCanonicalFloat,
+// which treated the histogram-valued LHS as the "preserve family,
+// reproject to empty float" case (dropExpHistogramSamples) — to an
+// EMPTY result at every subquery anchor, instead of routing through
+// expHistogramScalarBinop's actual SCALE semantics. This test asserts
+// the scaled, non-empty histogram at TWO distinct subquery anchors.
+func TestSubqueryHistogramScale_ChDB(t *testing.T) {
+	const metric = "subq_scale_exp_hist"
+	seed := subqHistDDL +
+		"INSERT INTO otel_metrics_exponential_histogram " +
+		"(MetricName, Attributes, TimeUnix, Count, Sum, Scale, ZeroCount, PositiveOffset, PositiveBucketCounts, NegativeOffset, NegativeBucketCounts) VALUES\n" +
+		"    ('" + metric + "', map('series', 'a'), toDateTime64('2026-01-01 00:01:00', 9), 2, 4.0, 0, 0, 0, [6], 0, []),\n" +
+		"    ('" + metric + "', map('series', 'a'), toDateTime64('2026-01-01 00:02:00', 9), 3, 9.0, 0, 0, 0, [12], 0, []);\n"
+	fixture := newChDBFixture(t, seed)
+
+	s := schema.DefaultOTelMetrics()
+	p := parser.NewParser(parser.Options{EnableExperimentalFunctions: true})
+	evalTS := time.Date(2026, 1, 1, 0, 2, 0, 0, time.UTC)
+
+	for _, query := range []string{
+		"(" + metric + " * 2)[2m:1m]",
+		"(2 * " + metric + ")[2m:1m]",
+	} {
+		t.Run(query, func(t *testing.T) {
+			expr, err := p.ParseExpr(query)
+			if err != nil {
+				t.Fatalf("ParseExpr(%q): %v", query, err)
+			}
+			plan, err := promql.LowerAt(context.Background(), expr, s, evalTS, evalTS)
+			if err != nil {
+				t.Fatalf("LowerAt(%q): %v", query, err)
+			}
+			sqlStr, args, err := chsql.Emit(context.Background(), plan)
+			if err != nil {
+				t.Fatalf("Emit(%q): %v", query, err)
+			}
+
+			rows := subqHistQueryRows(t, fixture, sqlStr, args)
+			if len(rows) != 2 {
+				t.Fatalf("%s: got %d rows, want 2 (one per subquery anchor) — a still-silently-empty result would report 0 rows here", query, len(rows))
+			}
+			anchor1 := subqHistRowAt(t, rows, "a", time.Date(2026, 1, 1, 0, 1, 0, 0, time.UTC))
+			if anchor1.cnt != 4 || anchor1.sum != 8.0 || anchor1.bucket1 != 12 {
+				t.Errorf("%s: anchor 00:01 = %+v, want Count=4 Sum=8 Bucket1=12 (raw Count=2 Sum=4 Bucket1=6, scaled *2)", query, anchor1)
+			}
+			anchor2 := subqHistRowAt(t, rows, "a", time.Date(2026, 1, 1, 0, 2, 0, 0, time.UTC))
+			if anchor2.cnt != 6 || anchor2.sum != 18.0 || anchor2.bucket1 != 24 {
+				t.Errorf("%s: anchor 00:02 = %+v, want Count=6 Sum=18 Bucket1=24 (raw Count=3 Sum=9 Bucket1=12, scaled *2)", query, anchor2)
+			}
+		})
+	}
+}
+
+// TestSubqueryHistogramFloatVectorScalingJoin_ChDB proves the issue's
+// own second (and most involved) example: a histogram-valued selector
+// scaled by a `group_left()`-joined FLOAT vector — here
+// `histogram_quantile(0.5, ...)` over the same metric, mirroring the
+// issue's literal trigger query — under a bare top-level subquery.
+//
+// The expected scale factor is computed by independently lowering and
+// executing the plain (non-subquery) `histogram_quantile(0.5, ...)`
+// scalar at the SAME eval anchor, rather than hand-deriving the native
+// quantile interpolation arithmetic here — any drift between the join's
+// own per-row factor and that independently-computed scalar would fail
+// the comparison below.
+func TestSubqueryHistogramFloatVectorScalingJoin_ChDB(t *testing.T) {
+	const metric = "subq_scalejoin_exp_hist"
+	seed := subqHistDDL +
+		"INSERT INTO otel_metrics_exponential_histogram " +
+		"(MetricName, Attributes, TimeUnix, Count, Sum, Scale, ZeroCount, PositiveOffset, PositiveBucketCounts, NegativeOffset, NegativeBucketCounts) VALUES\n" +
+		"    ('" + metric + "', map('service', 'svc'), toDateTime64('2026-01-01 00:01:00', 9), 10, 10.0, 0, 0, 0, [1, 2, 3, 4], 0, []);\n"
+	fixture := newChDBFixture(t, seed)
+
+	s := schema.DefaultOTelMetrics()
+	p := parser.NewParser(parser.Options{EnableExperimentalFunctions: true})
+	evalTS := time.Date(2026, 1, 1, 0, 1, 0, 0, time.UTC)
+
+	// Independently compute the expected scale factor: the plain scalar
+	// histogram_quantile(0.5, ...) at the same eval anchor, no subquery.
+	quantileExpr, err := p.ParseExpr("histogram_quantile(0.5, " + metric + ")")
+	if err != nil {
+		t.Fatalf("ParseExpr(quantile probe): %v", err)
+	}
+	quantilePlan, err := promql.LowerAt(context.Background(), quantileExpr, s, evalTS, evalTS)
+	if err != nil {
+		t.Fatalf("LowerAt(quantile probe): %v", err)
+	}
+	quantileSQL, quantileArgs, err := chsql.Emit(context.Background(), quantilePlan)
+	if err != nil {
+		t.Fatalf("Emit(quantile probe): %v", err)
+	}
+	quantileRows := fixture.queryOverEmitted(t, "`Value` AS val", quantileSQL, quantileArgs)
+	var wantFactor float64
+	var gotQuantile bool
+	for quantileRows.Next() {
+		if err := quantileRows.Scan(&wantFactor); err != nil {
+			t.Fatalf("scan quantile probe: %v", err)
+		}
+		gotQuantile = true
+	}
+	if err := testsql.TolerantRowsErr(quantileRows.Err()); err != nil {
+		t.Fatalf("quantile probe rows.Err: %v", err)
+	}
+	_ = quantileRows.Close()
+	if !gotQuantile {
+		t.Fatalf("quantile probe returned no rows")
+	}
+
+	query := "(" + metric + " * on(service) group_left() histogram_quantile(0.5, " + metric + "))[1m:1m]"
+	expr, err := p.ParseExpr(query)
+	if err != nil {
+		t.Fatalf("ParseExpr(%q): %v", query, err)
+	}
+	plan, err := promql.LowerAt(context.Background(), expr, s, evalTS, evalTS)
+	if err != nil {
+		t.Fatalf("LowerAt(%q): %v", query, err)
+	}
+	sqlStr, args, err := chsql.Emit(context.Background(), plan)
+	if err != nil {
+		t.Fatalf("Emit(%q): %v", query, err)
+	}
+
+	// The join's match key is the `service` label, not `series` —
+	// subqHistProjection's hardcoded `Attributes['series']` lookup
+	// (every other case in this file seeds under the `series` key)
+	// would read an absent map entry here, so this case projects
+	// `Attributes['service']` directly instead.
+	projection := "`Attributes`['service'] AS series, toUnixTimestamp(`TimeUnix`) AS ts, " +
+		"`HistogramCount` AS cnt, `HistogramSum` AS sum, `HistogramPositiveBucketCounts`[1] AS bucket1"
+	joinRows := fixture.queryOverEmitted(t, projection, sqlStr, args)
+	defer func() { _ = joinRows.Close() }()
+	var rows []subqHistRow
+	for joinRows.Next() {
+		var r subqHistRow
+		if err := joinRows.Scan(&r.series, &r.ts, &r.cnt, &r.sum, &r.bucket1); err != nil {
+			t.Fatalf("scan: %v", err)
+		}
+		rows = append(rows, r)
+	}
+	if err := testsql.TolerantRowsErr(joinRows.Err()); err != nil {
+		t.Fatalf("rows.Err: %v", err)
+	}
+	if len(rows) == 0 {
+		t.Fatalf("%s: got no rows", query)
+	}
+	got := subqHistRowAt(t, rows, "svc", evalTS)
+	wantCount := 10 * wantFactor
+	wantSum := 10.0 * wantFactor
+	wantBucket1 := 1 * wantFactor
+	const tol = 1e-9
+	if math.Abs(got.cnt-wantCount) > tol || math.Abs(got.sum-wantSum) > tol || math.Abs(got.bucket1-wantBucket1) > tol {
+		t.Errorf("%s: scaled = %+v, want Count=%v Sum=%v Bucket1=%v (raw Count=10 Sum=10 Bucket1=1 scaled by the joined quantile %v)",
+			query, got, wantCount, wantSum, wantBucket1, wantFactor)
+	}
+}

--- a/test/rejection-parity/catalogue/internal__promql__histogram_native_count.go.json
+++ b/test/rejection-parity/catalogue/internal__promql__histogram_native_count.go.json
@@ -5,17 +5,19 @@
       "site": "internal/promql/histogram_native_count.go:lowerExpHistogramCountOrGroupOverPlan#6724a38c",
       "message": "promql: internal invariant violated: nested native-histogram count/group input is %T with %s row shape",
       "class": "internal",
-      "rationale": "countOrGroupOverExpHistogramValue admits only histogram-valued operands; lowerRoot lowers that same operand through lowerExpHistogramValuedShape, whose matched contract is HistogramRowShape",
+      "rationale": "countOrGroupOverExpHistogramValue admits only histogram-valued operands; lowerHistogramNativeRoot (reached from lowerRoot for a query's own root, and from lowerHistogramNativeSubqueryInner for a bare subquery's own inner expression as of cerberus issue #2543) lowers that same operand through lowerExpHistogramValuedShape, whose matched contract is HistogramRowShape.",
       "evidence": {
         "guard": [
           "if chplan.RowShapeOf(input) != chplan.HistogramRowShape"
         ],
         "callers": [
-          "lowerRoot"
+          "lowerHistogramNativeRoot"
         ],
         "cited": [
           "countOrGroupOverExpHistogramValue",
           "lowerExpHistogramValuedShape",
+          "lowerHistogramNativeRoot",
+          "lowerHistogramNativeSubqueryInner",
           "lowerRoot"
         ]
       }
@@ -25,17 +27,20 @@
       "site": "internal/promql/histogram_native_count.go:lowerExpHistogramCountOrGroupOverPlan#9c86789a",
       "message": "promql: internal invariant violated: %s is not count/group",
       "class": "internal",
-      "rationale": "the sole caller arrives only through countOrGroupOverExpHistogramValue, which admits only COUNT or GROUP",
+      "rationale": "the sole caller arrives only through countOrGroupOverExpHistogramValue, which admits only COUNT or GROUP; this holds identically whether that caller is lowerHistogramNativeRoot's lowerRoot entry point or its lowerHistogramNativeSubqueryInner entry point (cerberus issue #2543), since both reach this lowerer through the same countOrGroupOverExpHistogramValue-gated call.",
       "evidence": {
         "guard": [
           "past returning if chplan.RowShapeOf(input) != chplan.HistogramRowShape",
           "default of switch agg.Op over [case parser.COUNT; case parser.GROUP; default]"
         ],
         "callers": [
-          "lowerRoot"
+          "lowerHistogramNativeRoot"
         ],
         "cited": [
-          "countOrGroupOverExpHistogramValue"
+          "countOrGroupOverExpHistogramValue",
+          "lowerHistogramNativeRoot",
+          "lowerHistogramNativeSubqueryInner",
+          "lowerRoot"
         ]
       }
     }

--- a/test/rejection-parity/catalogue/internal__promql__histogram_native_count_values.go.json
+++ b/test/rejection-parity/catalogue/internal__promql__histogram_native_count_values.go.json
@@ -5,7 +5,7 @@
       "site": "internal/promql/histogram_native_count_values.go:lowerExpHistogramCountValuesOverPlan#30cc8718",
       "message": "promql: internal invariant violated: count_values native-histogram input is %T with %s row shape",
       "class": "internal",
-      "rationale": "countValuesOverExpHistogramValue admits a histogram-valued operand and lowerRoot lowers that same operand through lowerExpHistogramValuedShape and its histogram-row contract",
+      "rationale": "countValuesOverExpHistogramValue admits a histogram-valued operand and lowerHistogramNativeRoot (reached from lowerRoot for a query's own root, and from lowerHistogramNativeSubqueryInner for a bare subquery's own inner expression as of cerberus issue #2543) lowers that same operand through lowerExpHistogramValuedShape and its histogram-row contract.",
       "evidence": {
         "guard": [
           "past returning if !ok",
@@ -13,11 +13,13 @@
           "if chplan.RowShapeOf(input) != chplan.HistogramRowShape"
         ],
         "callers": [
-          "lowerRoot"
+          "lowerHistogramNativeRoot"
         ],
         "cited": [
           "countValuesOverExpHistogramValue",
           "lowerExpHistogramValuedShape",
+          "lowerHistogramNativeRoot",
+          "lowerHistogramNativeSubqueryInner",
           "lowerRoot"
         ]
       }
@@ -27,12 +29,16 @@
       "site": "internal/promql/histogram_native_count_values.go:lowerExpHistogramCountValuesOverPlan#49c20b7b",
       "message": "promql: count_values requires a string-literal label name as the first arg",
       "class": "internal",
-      "rationale": "the PromQL typechecker admits only a string literal as count_values' parameter",
+      "rationale": "the PromQL typechecker admits only a string literal as count_values' parameter; this holds identically regardless of whether the enclosing count_values(...) reached this lowerer via lowerRoot (a query's own root) or lowerHistogramNativeSubqueryInner (a bare subquery's own inner expression, cerberus issue #2543), since the typechecker runs during parsing, before either entry point is reached.",
       "evidence": {
         "guard": [
           "if !ok"
         ],
         "callers": [
+          "lowerHistogramNativeRoot"
+        ],
+        "cited": [
+          "lowerHistogramNativeSubqueryInner",
           "lowerRoot"
         ]
       }
@@ -49,7 +55,7 @@
           "if label == \"\""
         ],
         "callers": [
-          "lowerRoot"
+          "lowerHistogramNativeRoot"
         ]
       }
     }

--- a/test/rejection-parity/catalogue/internal__promql__histogram_native_drop_aggregation.go.json
+++ b/test/rejection-parity/catalogue/internal__promql__histogram_native_drop_aggregation.go.json
@@ -5,7 +5,7 @@
       "site": "internal/promql/histogram_native_drop_aggregation.go:lowerExpHistogramDroppingAggregation#c2a441b1",
       "message": "promql: internal invariant violated: histogram-dropping aggregation input is not histogram-valued: %v",
       "class": "internal",
-      "rationale": "droppingAggregationOverExpHistogram already proves agg.Expr histogram-valued; this lowerer reuses lowerExpHistogramValuedShape for that same expression. Since cerberus issue #2528, lowerExpHistogramDroppingShape joins lowerRoot as a second caller, but it calls this lowerer only immediately after its own droppingAggregationOverExpHistogram(expr, s, ctx) check has returned ok, the identical precondition lowerRoot already established, so the claim is unaffected by the new caller.",
+      "rationale": "droppingAggregationOverExpHistogram already proves agg.Expr histogram-valued; this lowerer reuses lowerExpHistogramValuedShape for that same expression. Since cerberus issue #2528, lowerExpHistogramDroppingShape joins lowerHistogramNativeRoot as a second caller, but it calls this lowerer only immediately after its own droppingAggregationOverExpHistogram(expr, s, ctx) check has returned ok, the identical precondition lowerHistogramNativeRoot already established, so the claim is unaffected by that caller. lowerHistogramNativeSubqueryInner (cerberus issue #2543) is a third caller of lowerHistogramNativeRoot as of this change, reached for a bare subquery's own inner expression; it reaches this lowerer through the identical droppingAggregationOverExpHistogram-gated dispatch inside lowerHistogramNativeRoot, so it does not affect the claim either.",
       "evidence": {
         "guard": [
           "past returning if err := validateHistogramDroppingAggregationParam(agg, s, ctx); err != nil",
@@ -14,13 +14,14 @@
         ],
         "callers": [
           "lowerExpHistogramDroppingShape",
-          "lowerRoot"
+          "lowerHistogramNativeRoot"
         ],
         "cited": [
           "droppingAggregationOverExpHistogram",
           "lowerExpHistogramDroppingShape",
           "lowerExpHistogramValuedShape",
-          "lowerRoot"
+          "lowerHistogramNativeRoot",
+          "lowerHistogramNativeSubqueryInner"
         ]
       }
     }

--- a/test/rejection-parity/catalogue/internal__promql__histogram_native_scalar_binop.go.json
+++ b/test/rejection-parity/catalogue/internal__promql__histogram_native_scalar_binop.go.json
@@ -5,7 +5,7 @@
       "site": "internal/promql/histogram_native_scalar_binop.go:lowerExpHistogramScalarBinop#03401a30",
       "message": "promql: internal invariant violated: exp-histogram lowering did not cap with *chplan.HistogramProjection, got %T",
       "class": "internal",
-      "rationale": "expHistogramScalarBinop and expHistogramDroppingScalarBinop admit only isExpHistogramValuedShape operands, whose lowerExpHistogramValuedShape producer contract ends in HistogramProjection. Since cerberus issue #2528, lowerExpHistogramDroppingShape joins lowerRoot as a second caller of the drop path (drop=true), but it calls lowerExpHistogramScalarBinop only immediately after its own expHistogramDroppingScalarBinop(expr, s, ctx) check has returned ok — the same isExpHistogramValuedShape-gated histSide lowerRoot already passes — so the claim is unaffected by the new caller.",
+      "rationale": "expHistogramScalarBinop and expHistogramDroppingScalarBinop admit only isExpHistogramValuedShape operands, whose lowerExpHistogramValuedShape producer contract ends in HistogramProjection. Since cerberus issue #2528, lowerExpHistogramDroppingShape joins lowerHistogramNativeRoot as a second caller of the drop path (drop=true), but it calls lowerExpHistogramScalarBinop only immediately after its own expHistogramDroppingScalarBinop(expr, s, ctx) check has returned ok — the same isExpHistogramValuedShape-gated histSide lowerHistogramNativeRoot already passes — so the claim is unaffected by that caller. lowerHistogramNativeSubqueryInner (cerberus issue #2543) is a third caller of lowerHistogramNativeRoot as of this change, reached for a bare subquery's own inner expression; it reaches this lowerer through the identical isExpHistogramValuedShape-gated dispatch, so it does not affect the claim either.",
       "evidence": {
         "guard": [
           "past returning if !matched",
@@ -15,7 +15,7 @@
         "callers": [
           "lowerExpHistogramDroppingShape",
           "lowerExpHistogramValuedShape",
-          "lowerRoot"
+          "lowerHistogramNativeRoot"
         ],
         "cited": [
           "expHistogramDroppingScalarBinop",
@@ -24,7 +24,8 @@
           "lowerExpHistogramDroppingShape",
           "lowerExpHistogramScalarBinop",
           "lowerExpHistogramValuedShape",
-          "lowerRoot"
+          "lowerHistogramNativeRoot",
+          "lowerHistogramNativeSubqueryInner"
         ]
       }
     },
@@ -33,7 +34,7 @@
       "site": "internal/promql/histogram_native_scalar_binop.go:lowerExpHistogramScalarBinop#d112d97a",
       "message": "promql: internal invariant violated: exp-histogram scalar-binop matched no known histogram-valued shape for %v",
       "class": "internal",
-      "rationale": "the scalar-binop recognizers and lowerExpHistogramValuedShape share isExpHistogramValuedShape for the identical histogram operand. Since cerberus issue #2528, lowerExpHistogramDroppingShape joins lowerRoot as a second caller of the drop path, but — same as the sibling site just above — it only reaches this lowerer via expHistogramDroppingScalarBinop's own isExpHistogramValuedShape-gated histSide, so the claim is unaffected by the new caller.",
+      "rationale": "the scalar-binop recognizers and lowerExpHistogramValuedShape share isExpHistogramValuedShape for the identical histogram operand. Since cerberus issue #2528, lowerExpHistogramDroppingShape joins lowerHistogramNativeRoot as a second caller of the drop path, but — same as the sibling site just above — it only reaches this lowerer via expHistogramDroppingScalarBinop's own isExpHistogramValuedShape-gated histSide, so the claim is unaffected by that caller. lowerHistogramNativeSubqueryInner (cerberus issue #2543) is a third caller of lowerHistogramNativeRoot as of this change, reached for a bare subquery's own inner expression, and reaches this lowerer through the identical gated dispatch, so it does not affect the claim either.",
       "evidence": {
         "guard": [
           "if !matched"
@@ -41,14 +42,15 @@
         "callers": [
           "lowerExpHistogramDroppingShape",
           "lowerExpHistogramValuedShape",
-          "lowerRoot"
+          "lowerHistogramNativeRoot"
         ],
         "cited": [
           "expHistogramDroppingScalarBinop",
           "isExpHistogramValuedShape",
           "lowerExpHistogramDroppingShape",
           "lowerExpHistogramValuedShape",
-          "lowerRoot"
+          "lowerHistogramNativeRoot",
+          "lowerHistogramNativeSubqueryInner"
         ]
       }
     }

--- a/test/rejection-parity/catalogue/internal__promql__lower.go.json
+++ b/test/rejection-parity/catalogue/internal__promql__lower.go.json
@@ -94,8 +94,8 @@
       "site": "internal/promql/lower.go:expHistogramSelectorRouting#bf746b59",
       "message": "promql: %q is an exponential histogram metric; only a bare %q selector, sum()/avg()/count() over one, rate()/increase()/delta()/irate()/idelta()/sum_over_time()/avg_over_time()/resets()/changes() over one, histogram_quantile(), histogram_count(), histogram_sum(), and the %q/%q companion selectors are supported",
       "class": "divergence",
-      "trigger_query": "(demo_latency_exp_hist * on(service) group_left() histogram_quantile(0.5, demo_latency_exp_hist))[5m:1m]",
-      "tracking_issue": 2543,
+      "trigger_query": "demo_latency_exp_hist[5m]",
+      "tracking_issue": 2548,
       "evidence": {
         "guard": [
           "past returning if bare, col, hasCompanion := s.HistogramCompanionColumn(metricName); hasCompanion \u0026\u0026 s.IsExpHistogramMetric(bare) \u0026\u0026 s.ExpHistogramTable != \"\"",
@@ -105,7 +105,7 @@
           "resolveSelectorRouting"
         ]
       },
-      "since": "2026-08-23"
+      "since": "2026-08-24"
     },
     {
       "head": "promql",
@@ -268,25 +268,10 @@
     },
     {
       "head": "promql",
-      "site": "internal/promql/lower.go:lowerMatrixSelector#5fccc59e",
-      "message": "promql: matrix selector's inner must be a VectorSelector, got %T",
-      "class": "internal",
-      "rationale": "The PromQL parser only constructs MatrixSelector nodes whose VectorSelector field is a *parser.VectorSelector; the guard exists for programmatically-built ASTs.",
-      "evidence": {
-        "guard": [
-          "if !ok"
-        ],
-        "callers": [
-          "lower"
-        ]
-      }
-    },
-    {
-      "head": "promql",
-      "site": "internal/promql/lower.go:lowerRoot#53e0f9b3",
+      "site": "internal/promql/lower.go:lowerHistogramNativeRoot#53e0f9b3",
       "message": "promql: internal invariant violated: count_values input is not histogram-valued: %v",
       "class": "internal",
-      "rationale": "countValuesOverExpHistogramValue already ran isExpHistogramValuedShape to decide ok=true, so the immediately following lowerExpHistogramValuedShape call on the same agg.Expr cannot come back unmatched. lowerMixedExpHistogramFamily, checked earlier in lowerRoot's chain (cerberus issues #2330/#2346/#2449, split out of lowerRoot's own body as of cerberus issue #2528 purely to keep lowerRoot's maintainability-index score over golangci-lint's floor — see its own doc comment for the per-recognizer detail this paragraph used to carry inline here), only recognises mixedExpHistogramSetOp's own `or` VectorSetOp BinaryExpr with exactly one histogram-valued operand, or a *parser.Call/*parser.BinaryExpr shape wrapping one — count_values's top-level expr is an *parser.AggregateExpr with Op=COUNT_VALUES, which is none of those shapes, so no branch inside it can intercept this shape either, and does not affect this claim. countPresentOverExpHistogram and lastFirstOverExpHistogram (cerberus issue #2480), checked immediately after that, each type-assert peelWrappers(expr) as a *parser.Call named count_over_time/present_over_time or last_over_time/first_over_time before doing anything else — count_values's top-level expr is an *parser.AggregateExpr, which peelWrappers never turns into a Call, so neither can intercept this shape either. tsOfFirstLastOverExpHistogram (cerberus issue #2482), checked immediately after that, likewise type-asserts peelWrappers(expr) as a *parser.Call named ts_of_first_over_time/ts_of_last_over_time before doing anything else — count_values's top-level expr is an *parser.AggregateExpr, which peelWrappers never turns into a Call, so it cannot intercept this shape either.",
+      "rationale": "countValuesOverExpHistogramValue already ran isExpHistogramValuedShape to decide ok=true, so the immediately following lowerExpHistogramValuedShape call on the same agg.Expr cannot come back unmatched. lowerMixedExpHistogramFamily, checked earlier in lowerHistogramNativeRoot's chain (cerberus issues #2330/#2346/#2449, split out of lowerRoot's own body as of cerberus issue #2528 purely to keep lowerRoot's maintainability-index score over golangci-lint's floor, then re-homed onto lowerHistogramNativeRoot as of cerberus issue #2543 when lowerRoot's own histogram-native dispatch table was factored out so a subquery's inner expression could reuse it — see that function's own doc comment for the per-recognizer detail this paragraph used to carry inline here), only recognises mixedExpHistogramSetOp's own `or` VectorSetOp BinaryExpr with exactly one histogram-valued operand, or a *parser.Call/*parser.BinaryExpr shape wrapping one — count_values's top-level expr is an *parser.AggregateExpr with Op=COUNT_VALUES, which is none of those shapes, so no branch inside it can intercept this shape either, and does not affect this claim. countPresentOverExpHistogram and lastFirstOverExpHistogram (cerberus issue #2480), checked immediately after that, each type-assert peelWrappers(expr) as a *parser.Call named count_over_time/present_over_time or last_over_time/first_over_time before doing anything else — count_values's top-level expr is an *parser.AggregateExpr, which peelWrappers never turns into a Call, so neither can intercept this shape either. tsOfFirstLastOverExpHistogram (cerberus issue #2482), checked immediately after that, likewise type-asserts peelWrappers(expr) as a *parser.Call named ts_of_first_over_time/ts_of_last_over_time before doing anything else — count_values's top-level expr is an *parser.AggregateExpr, which peelWrappers never turns into a Call, so it cannot intercept this shape either. lowerHistogramNativeSubqueryInner (cerberus issue #2543) is a second direct caller as of this change, reached when a bare top-level subquery's own inner expression matches this same recognizer chain; it supplies a different `expr` value (the subquery's inner) but the claim above reasons only about the SHAPE of whatever `expr` reaches this guard, not about which entry point supplied it, so the new caller does not affect it.",
       "evidence": {
         "guard": [
           "past returning if call, ok := labelReplaceOverExpHistogram(expr, s, ctx); ok",
@@ -305,8 +290,8 @@
           "if !matched"
         ],
         "callers": [
-          "Lower",
-          "LowerAtRangeOpts"
+          "lowerHistogramNativeSubqueryInner",
+          "lowerRoot"
         ],
         "cited": [
           "countPresentOverExpHistogram",
@@ -314,6 +299,8 @@
           "isExpHistogramValuedShape",
           "lastFirstOverExpHistogram",
           "lowerExpHistogramValuedShape",
+          "lowerHistogramNativeRoot",
+          "lowerHistogramNativeSubqueryInner",
           "lowerMixedExpHistogramFamily",
           "lowerRoot",
           "mixedExpHistogramSetOp",
@@ -324,10 +311,10 @@
     },
     {
       "head": "promql",
-      "site": "internal/promql/lower.go:lowerRoot#c7dbd629",
+      "site": "internal/promql/lower.go:lowerHistogramNativeRoot#c7dbd629",
       "message": "promql: internal invariant violated: count/group input is not histogram-valued: %v",
       "class": "internal",
-      "rationale": "countOrGroupOverExpHistogramValue already ran isExpHistogramValuedShape to decide ok=true, so the immediately following lowerExpHistogramValuedShape call on the same agg.Expr cannot come back unmatched. lowerMixedExpHistogramFamily, checked earlier in lowerRoot's chain (cerberus issues #2330/#2346/#2449, split out of lowerRoot's own body as of cerberus issue #2528 purely to keep lowerRoot's maintainability-index score over golangci-lint's floor — see its own doc comment for the per-recognizer detail this paragraph used to carry inline here), only recognises mixedExpHistogramSetOp's own `or` VectorSetOp BinaryExpr with exactly one histogram-valued operand, or a *parser.Call/*parser.BinaryExpr shape wrapping one — count/group's top-level expr is an *parser.AggregateExpr with Op=COUNT or GROUP, which is none of those shapes, so no branch inside it can intercept this shape either, and does not affect this claim. countPresentOverExpHistogram and lastFirstOverExpHistogram (cerberus issue #2480), checked immediately after that, each type-assert peelWrappers(expr) as a *parser.Call named count_over_time/present_over_time or last_over_time/first_over_time before doing anything else — count/group's top-level expr is an *parser.AggregateExpr, which peelWrappers never turns into a Call, so neither can intercept this shape either. tsOfFirstLastOverExpHistogram (cerberus issue #2482), checked immediately after that, likewise type-asserts peelWrappers(expr) as a *parser.Call named ts_of_first_over_time/ts_of_last_over_time before doing anything else — count/group's top-level expr is an *parser.AggregateExpr, which peelWrappers never turns into a Call, so it cannot intercept this shape either.",
+      "rationale": "countOrGroupOverExpHistogramValue already ran isExpHistogramValuedShape to decide ok=true, so the immediately following lowerExpHistogramValuedShape call on the same agg.Expr cannot come back unmatched. lowerMixedExpHistogramFamily, checked earlier in lowerHistogramNativeRoot's chain (cerberus issues #2330/#2346/#2449, split out of lowerRoot's own body as of cerberus issue #2528 purely to keep lowerRoot's maintainability-index score over golangci-lint's floor, then re-homed onto lowerHistogramNativeRoot as of cerberus issue #2543 when lowerRoot's own histogram-native dispatch table was factored out so a subquery's inner expression could reuse it — see that function's own doc comment for the per-recognizer detail this paragraph used to carry inline here), only recognises mixedExpHistogramSetOp's own `or` VectorSetOp BinaryExpr with exactly one histogram-valued operand, or a *parser.Call/*parser.BinaryExpr shape wrapping one — count/group's top-level expr is an *parser.AggregateExpr with Op=COUNT or GROUP, which is none of those shapes, so no branch inside it can intercept this shape either, and does not affect this claim. countPresentOverExpHistogram and lastFirstOverExpHistogram (cerberus issue #2480), checked immediately after that, each type-assert peelWrappers(expr) as a *parser.Call named count_over_time/present_over_time or last_over_time/first_over_time before doing anything else — count/group's top-level expr is an *parser.AggregateExpr, which peelWrappers never turns into a Call, so neither can intercept this shape either. tsOfFirstLastOverExpHistogram (cerberus issue #2482), checked immediately after that, likewise type-asserts peelWrappers(expr) as a *parser.Call named ts_of_first_over_time/ts_of_last_over_time before doing anything else — count/group's top-level expr is an *parser.AggregateExpr, which peelWrappers never turns into a Call, so it cannot intercept this shape either. lowerHistogramNativeSubqueryInner (cerberus issue #2543) is a second direct caller as of this change, reached when a bare top-level subquery's own inner expression matches this same recognizer chain; it supplies a different `expr` value (the subquery's inner) but the claim above reasons only about the SHAPE of whatever `expr` reaches this guard, not about which entry point supplied it, so the new caller does not affect it.",
       "evidence": {
         "guard": [
           "past returning if call, ok := labelReplaceOverExpHistogram(expr, s, ctx); ok",
@@ -345,8 +332,8 @@
           "if !matched"
         ],
         "callers": [
-          "Lower",
-          "LowerAtRangeOpts"
+          "lowerHistogramNativeSubqueryInner",
+          "lowerRoot"
         ],
         "cited": [
           "countOrGroupOverExpHistogramValue",
@@ -354,11 +341,28 @@
           "isExpHistogramValuedShape",
           "lastFirstOverExpHistogram",
           "lowerExpHistogramValuedShape",
+          "lowerHistogramNativeRoot",
+          "lowerHistogramNativeSubqueryInner",
           "lowerMixedExpHistogramFamily",
           "lowerRoot",
           "mixedExpHistogramSetOp",
           "peelWrappers",
           "tsOfFirstLastOverExpHistogram"
+        ]
+      }
+    },
+    {
+      "head": "promql",
+      "site": "internal/promql/lower.go:lowerMatrixSelector#5fccc59e",
+      "message": "promql: matrix selector's inner must be a VectorSelector, got %T",
+      "class": "internal",
+      "rationale": "The PromQL parser only constructs MatrixSelector nodes whose VectorSelector field is a *parser.VectorSelector; the guard exists for programmatically-built ASTs.",
+      "evidence": {
+        "guard": [
+          "if !ok"
+        ],
+        "callers": [
+          "lower"
         ]
       }
     },

--- a/test/rejection-parity/catalogue/internal__promql__subquery.go.json
+++ b/test/rejection-parity/catalogue/internal__promql__subquery.go.json
@@ -35,6 +35,26 @@
     },
     {
       "head": "promql",
+      "site": "internal/promql/subquery.go:lowerOuterRangeFnOverSubquery#087c3810",
+      "message": "promql: %s over a subquery wrapping a native-histogram-valued shape is unsupported",
+      "class": "divergence",
+      "trigger_query": "max_over_time((demo_latency_exp_hist)[5m:1m])",
+      "tracking_issue": 2545,
+      "evidence": {
+        "guard": [
+          "past returning if outer.Func.Name == \"absent_over_time\"",
+          "past returning if !chplan.IsPromQLRangeWindowFunc(canonicalRangeWindowFunc(outer.Func.Name))",
+          "past returning if err != nil",
+          "if shape := chplan.RowShapeOf(inner); shape == chplan.HistogramRowShape || shape == chplan.MixedRowShape"
+        ],
+        "callers": [
+          "lowerCall"
+        ]
+      },
+      "since": "2026-08-24"
+    },
+    {
+      "head": "promql",
       "site": "internal/promql/subquery.go:lowerOuterRangeFnOverSubquery#b8fba661",
       "message": "promql: %s does not accept a subquery argument",
       "class": "internal",
@@ -99,11 +119,12 @@
       "site": "internal/promql/subquery.go:lowerSubquery#a374d4b2",
       "message": "promql: subquery over %T is unsupported",
       "class": "internal",
-      "rationale": "SubqueryExpr.Expr must type-check as an instant vector, and every instant-vector AST shape is dispatched (selector, call, paren, aggregate, binary, unary, plus the parser-impossible nested SubqueryExpr handled defensively); scalar- and string-typed inners are parse-time type errors.",
+      "rationale": "SubqueryExpr.Expr must type-check as an instant vector, and every instant-vector AST shape is dispatched (selector, call, paren, aggregate, binary, unary, plus the parser-impossible nested SubqueryExpr handled defensively); scalar- and string-typed inners are parse-time type errors. The lowerHistogramNativeSubqueryInner call added ahead of the switch by cerberus issue #2543 does not narrow that exhaustiveness claim: when it returns matched=false control falls through to the identical switch this rationale already covers, over the identical e.Expr value.",
       "evidence": {
         "guard": [
           "past returning if e.Range \u003c= 0",
           "past returning if step \u003c 0",
+          "past returning if plan, matched, err := lowerHistogramNativeSubqueryInner(e, step, s, ctx); matched",
           "past exhaustive switch inner := e.Expr.(type) over [case *parser.VectorSelector; case *parser.Call; case *parser.ParenExpr; case *parser.AggregateExpr; case *parser.BinaryExpr; case *parser.UnaryExpr; case *parser.SubqueryExpr]"
         ],
         "callers": [
@@ -113,6 +134,9 @@
           "lowerSubquery",
           "lowerSubqueryOverCallSubquery",
           "lowerSubqueryOverSubquery"
+        ],
+        "cited": [
+          "lowerHistogramNativeSubqueryInner"
         ]
       }
     },

--- a/test/rejection-parity/divergence-ceiling.json
+++ b/test/rejection-parity/divergence-ceiling.json
@@ -1,3 +1,3 @@
 {
-  "max_entries": 4
+  "max_entries": 5
 }


### PR DESCRIPTION
## Summary

Fixes #2543 — a subquery wrapping any native-histogram-valued shape lost
histogram-native routing entirely, and one shape did so **silently**.

- **The priority fix (silent correctness bug):** `(demo_latency_exp_hist *
  2)[5m:1m]` lowered without error, through
  `lowerScalarBinopOperand` → `lowerExpHistogramArgAsCanonicalFloat`'s
  "preserve family, reproject to empty float" path — answering an **empty
  result** at every subquery step instead of the scaled histogram. Verified
  against real chDB execution both ways: pre-fix the emitted SQL has no
  `HistogramCount`/`HistogramSum`/bucket columns at all (an always-`WHERE
  false`-filtered float placeholder); post-fix it returns the correctly
  scaled histogram at every subquery anchor.
- **The broader routing gap:** a bare top-level subquery
  (`(<expr>)[range:step]`, no outer range-vector function) never reached
  `lowerRoot`'s histogram-native recognizer table for its own inner
  expression — `lower`'s `*parser.SubqueryExpr` case calls `lowerSubquery`
  directly, and every `lowerSubqueryOver*` helper called its generic
  lowering entry point (`lowerVectorSelector` / `lowerBinary` /
  `lowerAggregate`) unconditionally. A bare selector, `sum()`/`avg()`, the
  `+`/`-` merge, the `group_left()` scaling join, `and`/`or`/`unless` set
  ops, `rate()`/`increase()`, and `last_over_time()`/`first_over_time()` all
  hard-rejected under a subquery.

### Fix

`lowerRoot`'s histogram-native dispatch chain is factored out, unchanged in
order or logic, into `lowerHistogramNativeRoot` (`internal/promql/lower.go`).
`lowerSubquery` (`internal/promql/subquery.go`) now tries the identical
chain against the subquery's own inner expression — evaluated at the
subquery's own per-anchor grid via the existing `subqueryGridCtx` helper —
before falling back to the generic per-shape lowering. Every histogram-native
lowering already fans its own output across a range-mode grid
(`rangeGridShapeFor`), so the result already carries one row per (series,
subquery anchor) with no extra `RangeWindow` wrap needed; only the
non-histogram "drop family" shapes still get the pre-existing
`subqueryAnchorShape` wrap.

An outer range-vector function wrapping a histogram-native subquery
(`max_over_time((m_exp_hist)[5m:1m])`) is explicitly rejected with a clear
promql-level error rather than letting the reducer silently fold over the
placeholder `Value` column a histogram-shaped row does not meaningfully
carry (previously this would have surfaced as a ClickHouse "Unknown
identifier" 502). That remaining composition is tracked as a follow-up in
#2545, filed alongside this PR.

### Broad probing (per the issue's own instruction)

Every native-histogram shape category was probed wrapped bare in a subquery,
not only the issue's four listed examples: bare selector, `sum()`/`avg()`,
`+`/`-` merge, `*`/`/` scale (both operand orders), the `group_left()`
scaling join, `and`/`or` set ops, `count()`, `topk()`,
`last_over_time()`/`rate()`/`resets()` over a matrix arg, `label_replace()`,
and the drop family (`+ 1`). All now lower correctly (histogram-valued,
correctly-typed drop, or a real value as appropriate) except the
outer-range-fn composition noted above, which rejects cleanly.

## Test plan

- [x] `go build ./...`
- [x] `go test ./internal/promql/...` and `go test -tags chdb
      ./internal/promql/...` — full package, no regressions
- [x] New chDB tests
      (`internal/promql/subquery_histogram_native_chdb_test.go`) seed real
      exp-histogram rows and assert correct `HistogramCount`/`HistogramSum`/
      bucket values at multiple distinct subquery anchors for: bare
      selector, `sum()`, `+` merge, the `* 2` / `2 *` scale (the silent-bug
      case), and the `group_left()` scaling join (verified against an
      independently-computed `histogram_quantile` scalar)
- [x] Confirmed the scale-shape silent bug reproduces pre-fix (`git stash`
      of the lowering changes) and is fixed post-fix, both against real chDB
      execution
- [x] `go test ./test/spec/...` and `go test -tags chdb ./test/spec/...` —
      no golden drift
- [x] `go test ./test/rejection-parity/...` — catalogue regenerated
      (`CERBERUS_UPDATE_INVENTORY=1`, run twice per the hand-edited-rationale
      convention), all classification/drift gates pass; divergence ceiling
      bumped 4→5 for the new #2545 entry
- [x] `node .github/scripts/forbid-sql-raw.mjs` — clean
- [x] `gofumpt -extra` / `goimports -local` — no diff

Closes #2543

🤖 Generated with [Claude Code](https://claude.com/claude-code)
