### PR TITLE
fix(promql): retry resets()/changes()/count()/group() when nested over an exp-histogram

### DIFF
--- a/internal/promql/exp_histogram_float_reductions_test.go
+++ b/internal/promql/exp_histogram_float_reductions_test.go
@@ -35,6 +35,21 @@ import (
 // function result and every aggregation result alike, so the quartet's
 // first slot must be an EMPTY literal rather than the MetricName column
 // the bare selector carries up.
+//
+// The "wrapped" queries below pin cerberus issue #2549: resets() /
+// changes() / count() / group() over a bare exp-histogram selector used
+// to reject the instant the call was itself wrapped by a further scalar
+// op, aggregation or instant math function — the wrapper's own operand
+// lowering fell back to the generic descent, which hit
+// [lowerVectorSelector]'s ordinary rejection on the histogram selector
+// underneath, never reaching the recognisers pinned by the bare cases
+// above. See [lowerRangeVectorCall] and [lowerExpHistogramCountFamily]'s
+// own doc for the fix. The shape assertions below are identical to the
+// bare cases' — the wrapper composes with an already float-valued
+// result, so nothing about the row shape or the dropped `__name__`
+// changes; TestLower_ExpHistogram_ResetsChangesCountNested_ChDB (chdb
+// build tag) is what pins the actual numeric answer through the
+// wrapper's own arithmetic.
 func TestLower_ExpHistogram_ResetsChangesCountAreFloatValued(t *testing.T) {
 	t.Parallel()
 
@@ -54,6 +69,19 @@ func TestLower_ExpHistogram_ResetsChangesCountAreFloatValued(t *testing.T) {
 		`count by (service) (latency_exp_hist)`,
 		`count without (pod) (latency_exp_hist{service="api"})`,
 		`(count(latency_exp_hist))`,
+
+		// Wrapped shapes (cerberus issue #2549) — this issue's own four
+		// trigger queries, plus the count()/group() family the issue's
+		// architectural note names alongside them.
+		`resets(latency_exp_hist[5m]) * 2`,
+		`sum(resets(latency_exp_hist[5m]))`,
+		`changes(latency_exp_hist[5m]) + 1`,
+		`abs(changes(latency_exp_hist[5m]))`,
+		`count(latency_exp_hist) + 1`,
+		`count(count(latency_exp_hist))`,
+		`group(latency_exp_hist) * 2`,
+		`abs(group(latency_exp_hist))`,
+		`sum(resets(latency_exp_hist[5m]) * 2)`,
 	}
 	modes := []struct {
 		name  string
@@ -96,7 +124,7 @@ func TestLower_ExpHistogram_ResetsChangesCountAreFloatValued(t *testing.T) {
 						q, len(proj.Projections), len(wantAliases))
 				}
 				for i, want := range wantAliases {
-					if got := proj.Projections[i].Alias; got != want {
+					if got := projectionColumnName(proj.Projections[i]); got != want {
 						t.Fatalf("lower(%q): output column %d is %q, want %q", q, i, got, want)
 					}
 				}
@@ -112,6 +140,27 @@ func TestLower_ExpHistogram_ResetsChangesCountAreFloatValued(t *testing.T) {
 			})
 		}
 	}
+}
+
+// projectionColumnName reports the SQL-visible name of a projection: its
+// own Alias when the lowering set one explicitly, or the underlying
+// ColumnRef's Name when it did not. A pass-through projection built by
+// [guardedValueProjection] (the scalar-binop / instant-fn wrapper path a
+// [chplan.Project] taking this shortcut) leaves Alias empty for a column
+// it forwards unchanged — the emitter's own SQL still names the output
+// column after the ref, so an empty Alias is not a missing column, only
+// an unaliased one. The dedicated exp-histogram Projects this test also
+// covers (expHistogramPairCountProjection, lowerExpHistogramCount's own
+// projection) always set Alias explicitly, so this fallback never masks
+// a genuinely wrong column there.
+func projectionColumnName(p chplan.Projection) string {
+	if p.Alias != "" {
+		return p.Alias
+	}
+	if ref, ok := p.Expr.(*chplan.ColumnRef); ok {
+		return ref.Name
+	}
+	return ""
 }
 
 // TestLower_ExpHistogram_ResetsAndChangesUseDifferentKernels pins the one

--- a/internal/promql/exp_histogram_guard_test.go
+++ b/internal/promql/exp_histogram_guard_test.go
@@ -47,6 +47,25 @@ import (
 // HistogramIgnoredInAggregation annotation, because counting a sample
 // never has to look at it. That is why it is answered
 // (histogram_native_count.go) while its five neighbours are not.
+//
+// `resets()` / `changes()` / `count()` / `group()` wrapped by a further
+// scalar op, aggregation or instant math function used to stay rejected
+// too — cerberus issue #2549 — even though their own answer is an
+// ordinary float sample nothing about the wrapper would object to; what
+// tripped the rejection was the ARGUMENT, which reached
+// [lowerVectorSelector] through the ordinary descent with no
+// histogram-aware retry. [lowerRangeVectorCall] (resets/changes) and
+// [lowerAggregate] (count/group) now retry those two recognisers at
+// every level of nesting the same way a query's own root always could,
+// so every case that moved out of this file's own rejection list lives
+// in TestLower_ExpHistogram_ResetsChangesCountAreFloatValued instead —
+// see that test's own "wrapped" cases.
+//
+// The subquery form (`resets(<selector>[range:step])`) is a genuinely
+// DIFFERENT shape from a wrapper — the selector's own outer range-vector
+// function IS resets()/changes() itself, routed through
+// lowerOuterRangeFnOverSubquery rather than lowerRangeVectorCall — and
+// stays rejected here: #2549's fix never touches that path.
 func TestLower_ExpHistogram_UnsupportedShapesRejectExplicitly(t *testing.T) {
 	t.Parallel()
 
@@ -62,23 +81,8 @@ func TestLower_ExpHistogram_UnsupportedShapesRejectExplicitly(t *testing.T) {
 		// TestLower_ExpHistogram_BareMatrixSelectorIsHistogramValued — so
 		// it is deliberately no longer a case here.
 		{name: "subquery", query: `max_over_time(latency_exp_hist[5m:1m])`},
-
-		// `resets()` / `changes()` / `count()` over a bare selector ARE
-		// answered (see TestLower_ExpHistogram_ResetsChangesCountAreFloatValued).
-		// Their answer is an ordinary float sample, so unlike the
-		// histogram-valued shapes above nothing about the RESULT stops a
-		// consumer from reading it. What keeps these rejected is the
-		// ARGUMENT: the selector nested under them still reaches
-		// lowerVectorSelector through the ordinary descent, where it is
-		// still an exp-histogram selector with no Value column.
-		{name: "resets under arithmetic", query: `resets(latency_exp_hist[5m]) * 2`},
-		{name: "resets under sum", query: `sum(resets(latency_exp_hist[5m]))`},
-		{name: "changes under arithmetic", query: `changes(latency_exp_hist[5m]) + 1`},
-		{name: "changes under abs", query: `abs(changes(latency_exp_hist[5m]))`},
 		{name: "resets over subquery", query: `resets(latency_exp_hist[5m:1m])`},
 		{name: "changes over subquery", query: `changes(latency_exp_hist[5m:1m])`},
-		{name: "count under arithmetic", query: `count(latency_exp_hist) + 1`},
-		{name: "count of count", query: `count(count(latency_exp_hist))`},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/internal/promql/histogram_native_count.go
+++ b/internal/promql/histogram_native_count.go
@@ -157,6 +157,44 @@ func lowerExpHistogramCountOrGroupOverPlan(agg *parser.AggregateExpr, input chpl
 	}, nil
 }
 
+// lowerExpHistogramCountFamily recognises and lowers `count()`/`group()`
+// over an exp-histogram shape — either a bare selector
+// ([countOverExpHistogram]) or any already histogram-valued expression
+// ([countOrGroupOverExpHistogramValue]) — trying the two recognisers in
+// the same order [lowerHistogramNativeRoot] always has.
+//
+// It is factored out purely so [lowerHistogramNativeRoot]'s own dispatch
+// table and [lowerAggregate]'s generic fallback can share one
+// recogniser/lowering pair rather than drifting apart: this closes
+// cerberus issue #2549's `count()`/`group()` half — `count(m_exp_hist) *
+// 2`, `group(m_exp_hist) * 2`, `count(rate(m_exp_hist[5m])) * 2` and
+// their aggregation-wrapper siblings (`sum(count(m_exp_hist))`,
+// `abs(count(m_exp_hist))`) previously fell through
+// [lowerAggregate]'s own `lower(a.Expr, ...)` fallback into the generic
+// descent, which lowers the inner selector via [lowerVectorSelector]'s
+// ordinary path and hard-rejects it via [expHistogramSelectorRouting] —
+// the exact gap class [resetsOrChangesOverExpHistogram] closes for
+// `resets()`/`changes()` (see [lowerRangeVectorCall]'s own nested-retry
+// check), just for an AggregateExpr root rather than a Call root.
+func lowerExpHistogramCountFamily(expr parser.Expr, s schema.Metrics, ctx lowerCtx) (chplan.Node, bool, error) {
+	if agg, vs, ok := countOverExpHistogram(expr, s, ctx); ok {
+		plan, err := lowerExpHistogramCount(agg, vs, s, ctx)
+		return plan, true, err
+	}
+	if agg, ok := countOrGroupOverExpHistogramValue(expr, s, ctx); ok {
+		input, matched, err := lowerExpHistogramValuedShape(agg.Expr, s, ctx)
+		if err != nil {
+			return nil, true, err
+		}
+		if !matched {
+			return nil, true, fmt.Errorf("promql: internal invariant violated: count/group input is not histogram-valued: %v", agg.Expr)
+		}
+		plan, err := lowerExpHistogramCountOrGroupOverPlan(agg, input, s)
+		return plan, true, err
+	}
+	return nil, false, nil
+}
+
 // lowerExpHistogramCount lowers the `count()` shape across the three
 // evaluation shapes [rangeGridShapeFor] distinguishes, the same three
 // its siblings handle — see [lowerExpHistogramBare] for what each means.

--- a/internal/promql/histogram_native_resets_changes_count_nested_chdb_test.go
+++ b/internal/promql/histogram_native_resets_changes_count_nested_chdb_test.go
@@ -1,0 +1,146 @@
+//go:build chdb
+
+// chDB-backed proof that resets()/changes()/count() over a NESTED
+// exp-histogram selector (cerberus issue #2549) not only lowers to valid
+// SQL but EXECUTES against real ClickHouse and reports the correct
+// FLOAT value — the reset/change/presence count reference Prometheus
+// itself would answer, put through the wrapper's own arithmetic.
+//
+// Two series are seeded for nestedResetsCountMetric:
+//   - service="checkout": three samples across the [5m] window. The
+//     first two GROW the histogram (Count 5 -> 8, buckets [5] -> [8]) —
+//     DetectReset sees no regression, so this pair is a `changes()` hit
+//     but not a `resets()` hit. The last pair SHRINKS it (Count 8 -> 3,
+//     buckets [8] -> [3]) — Count regressing is one of
+//     FloatHistogram.DetectReset's own conditions
+//     (histogram_native_reset.go's own doc lists it first), so this pair
+//     is both a `resets()` hit and a `changes()` hit. Net over the
+//     window: resets()=1, changes()=2.
+//   - service="checkout-2": a single sample, present only so count()
+//     over the instant vector has two series to count rather than one —
+//     a bare count() of 1 could not distinguish "the wrapper forwarded
+//     the inner count" from "the wrapper silently produced its own
+//     literal 1".
+//
+// Each query pins the SAME per-series reset/change/count answer a bare,
+// unwrapped resets()/changes()/count() query already answers correctly
+// (this issue's fix does not touch that path) run through the wrapper's
+// own arithmetic, so a wrong wrapper composition (rather than a wrong
+// resets/changes/count kernel) is what a failing assertion here would
+// mean.
+package promql_test
+
+import (
+	"context"
+	"math"
+	"testing"
+	"time"
+
+	"github.com/prometheus/prometheus/promql/parser"
+
+	"github.com/tsouza/cerberus/internal/chsql"
+	"github.com/tsouza/cerberus/internal/promql"
+	"github.com/tsouza/cerberus/internal/schema"
+	"github.com/tsouza/cerberus/internal/testsql"
+)
+
+const (
+	nestedResetsCountMetric = "nested_resets_count_probe_exp_hist"
+)
+
+var nestedResetsCountSeed = "" +
+	"CREATE OR REPLACE TABLE otel_metrics_exponential_histogram (" +
+	"`MetricName` String, `Attributes` Map(String, String), " +
+	"`ResourceAttributes` Map(String, String) DEFAULT map(), `ServiceName` LowCardinality(String) DEFAULT '', " +
+	"`TimeUnix` DateTime64(9), " +
+	"`Count` UInt64, `Sum` Float64, `Scale` Int32, `ZeroCount` UInt64, " +
+	"`PositiveOffset` Int32, `PositiveBucketCounts` Array(UInt64), " +
+	"`NegativeOffset` Int32, `NegativeBucketCounts` Array(UInt64)" +
+	") ENGINE = MergeTree ORDER BY (`MetricName`, `Attributes`, `TimeUnix`);\n" +
+	"INSERT INTO otel_metrics_exponential_histogram " +
+	"(MetricName, Attributes, TimeUnix, Count, Sum, Scale, ZeroCount, PositiveOffset, PositiveBucketCounts, NegativeOffset, NegativeBucketCounts) VALUES\n" +
+	"    ('" + nestedResetsCountMetric + "', map('service', 'checkout'), toDateTime64('2026-01-01 00:00:00', 9), 5, 10.0, 0, 0, 0, [5], 0, []),\n" +
+	"    ('" + nestedResetsCountMetric + "', map('service', 'checkout'), toDateTime64('2026-01-01 00:01:00', 9), 8, 16.0, 0, 0, 0, [8], 0, []),\n" +
+	"    ('" + nestedResetsCountMetric + "', map('service', 'checkout'), toDateTime64('2026-01-01 00:02:00', 9), 3, 6.0, 0, 0, 0, [3], 0, []),\n" +
+	"    ('" + nestedResetsCountMetric + "', map('service', 'checkout-2'), toDateTime64('2026-01-01 00:02:00', 9), 4, 8.0, 0, 0, 0, [4], 0, []);\n"
+
+// nestedResetsCountEvalTS sits just after the window's last sample
+// (00:02:00), with the [5m] range comfortably covering all three
+// checkout-service samples (00:00:00, 00:01:00, 00:02:00).
+var nestedResetsCountEvalTS = time.Date(2026, 1, 1, 0, 2, 5, 0, time.UTC)
+
+func TestLower_ExpHistogram_ResetsChangesCountNested_ChDB(t *testing.T) {
+	fixture := newChDBFixture(t, nestedResetsCountSeed)
+	s := schema.DefaultOTelMetrics()
+	p := parser.NewParser(parser.Options{EnableExperimentalFunctions: true})
+
+	resetsQ := "resets(" + nestedResetsCountMetric + "{service=\"checkout\"}[5m])"
+	changesQ := "changes(" + nestedResetsCountMetric + "{service=\"checkout\"}[5m])"
+	countQ := "count(" + nestedResetsCountMetric + ")"
+
+	cases := []struct {
+		name  string
+		query string
+		want  float64
+	}{
+		// This issue's own four trigger queries (against the shared
+		// nestedResetsCountMetric fixture rather than demo_latency_exp_hist,
+		// since the trigger queries themselves are only representative
+		// shapes — the issue's own text names them against a metric this
+		// package's chdb tests do not seed).
+		{"resets_times_2", resetsQ + " * 2", 2}, // resets()=1, *2 = 2
+		{"sum_resets", "sum(" + resetsQ + ")", 1},
+		{"changes_plus_1", changesQ + " + 1", 3}, // changes()=2, +1 = 3
+		{"abs_changes", "abs(" + changesQ + ")", 2},
+
+		// The issue's own architectural note names count() as the third
+		// member of the FLOAT-valued family alongside resets/changes.
+		{"count_times_2", countQ + " * 2", 4}, // count()=2 series, *2 = 4
+		{"sum_count", "sum(" + countQ + ")", 2},
+		{"abs_count", "abs(" + countQ + ")", 2},
+
+		// A double wrapper, and the aggregation-over-scaled-call shape:
+		// proves the fix composes rather than only matching a single
+		// level of nesting.
+		{"sum_resets_times_2", "sum(" + resetsQ + " * 2)", 2},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			expr, err := p.ParseExpr(tc.query)
+			if err != nil {
+				t.Fatalf("ParseExpr(%q): %v", tc.query, err)
+			}
+			plan, err := promql.LowerAt(context.Background(), expr, s, nestedResetsCountEvalTS, nestedResetsCountEvalTS)
+			if err != nil {
+				t.Fatalf("LowerAt(%q): unexpected error (this exact nested shape hard-rejected via expHistogramSelectorRouting's catch-all before cerberus issue #2549's fix): %v", tc.query, err)
+			}
+			sqlStr, args, err := chsql.Emit(context.Background(), plan)
+			if err != nil {
+				t.Fatalf("Emit(%q): %v", tc.query, err)
+			}
+
+			rows := fixture.queryOverEmitted(t, "Value", sqlStr, args)
+			defer func() { _ = rows.Close() }()
+
+			n := 0
+			for rows.Next() {
+				n++
+				var v float64
+				if err := rows.Scan(&v); err != nil {
+					t.Fatalf("scan Value: %v", err)
+				}
+				if math.Abs(v-tc.want) > 1e-9 {
+					t.Errorf("query %q: Value = %v, want %v", tc.query, v, tc.want)
+				}
+			}
+			if err := testsql.TolerantRowsErr(rows.Err()); err != nil {
+				t.Fatalf("rows.Err: %v", err)
+			}
+			if n != 1 {
+				t.Fatalf("query %q: got %d rows, want exactly 1", tc.query, n)
+			}
+		})
+	}
+}

--- a/internal/promql/lower.go
+++ b/internal/promql/lower.go
@@ -368,19 +368,12 @@ func lowerHistogramNativeRoot(expr parser.Expr, s schema.Metrics, ctx lowerCtx) 
 		plan, err := lowerTsOfFirstLastOverExpHistogram(fn, ms, vs, s, ctx)
 		return plan, true, err
 	}
-	if agg, vs, ok := countOverExpHistogram(expr, s, ctx); ok {
-		plan, err := lowerExpHistogramCount(agg, vs, s, ctx)
-		return plan, true, err
-	}
-	if agg, ok := countOrGroupOverExpHistogramValue(expr, s, ctx); ok {
-		input, matched, err := lowerExpHistogramValuedShape(agg.Expr, s, ctx)
-		if err != nil {
-			return nil, true, err
-		}
-		if !matched {
-			return nil, true, fmt.Errorf("promql: internal invariant violated: count/group input is not histogram-valued: %v", agg.Expr)
-		}
-		plan, err := lowerExpHistogramCountOrGroupOverPlan(agg, input, s)
+	// count()/group() over a bare selector or any already histogram-valued
+	// expression — see [lowerExpHistogramCountFamily]'s own doc; factored
+	// out (cerberus issue #2549) so [lowerAggregate]'s generic fallback can
+	// retry the identical shape when it is NESTED under a further wrapper,
+	// rather than restating the two recognisers there.
+	if plan, ok, err := lowerExpHistogramCountFamily(expr, s, ctx); ok {
 		return plan, true, err
 	}
 	if agg, ok := countValuesOverExpHistogramValue(expr, s, ctx); ok {
@@ -2684,6 +2677,25 @@ func matrixSelectorArg(c *parser.Call) (*parser.MatrixSelector, *parser.VectorSe
 // and wrap the result in a RangeWindow capturing the function name +
 // range duration.
 func lowerRangeVectorCall(c *parser.Call, s schema.Metrics, ctx lowerCtx) (chplan.Node, error) {
+	// resets()/changes() over a NESTED exp-histogram selector (cerberus
+	// issue #2549): [lowerHistogramNativeRoot] only tries
+	// [resetsOrChangesOverExpHistogram] when the call IS the query's own
+	// root. The moment it is wrapped by anything else — scalar
+	// arithmetic (`resets(m[5m]) * 2`), an aggregation
+	// (`sum(resets(m[5m]))`), an instant math function
+	// (`abs(changes(m[5m]))`) — every such wrapper's own operand lowering
+	// falls back to the generic [lower] dispatcher, which reaches THIS
+	// function (every resets()/changes() call carries a MatrixSelector
+	// argument) before the switch below ever sees it. Both functions
+	// already answer a plain FLOAT sample once resolved
+	// (histogram_native_resets.go's own doc explains why nothing about
+	// them needs the histogram-VALUED family's
+	// [lowerExpHistogramArgAsCanonicalFloat] "preserve"/"drop" opt-in) —
+	// they just need the same chance to retry as histogram-native that a
+	// query's root always had.
+	if shape, ok := resetsOrChangesOverExpHistogram(c, s, ctx); ok {
+		return lowerExpHistogramResetsOrChanges(shape, s, ctx)
+	}
 	switch c.Func.Name {
 	case "predict_linear":
 		return lowerPredictLinear(c, s, ctx)
@@ -3730,6 +3742,21 @@ func lowerAggregate(a *parser.AggregateExpr, s schema.Metrics, ctx lowerCtx) (ch
 	}
 	if a.Op == parser.LIMIT_RATIO {
 		return lowerLimitRatio(a, s, ctx)
+	}
+	// count()/group() over an exp-histogram shape, NESTED under a further
+	// wrapper (cerberus issue #2549) — `count(m_exp_hist) * 2`,
+	// `sum(count(m_exp_hist))`, `abs(group(m_exp_hist))`,
+	// `count(rate(m_exp_hist[5m])) * 2`. [lowerHistogramNativeRoot] only
+	// tries [lowerExpHistogramCountFamily] when this aggregation IS the
+	// query's own root; every wrapper reaches its operand through this
+	// function's own generic `lower(a.Expr, ...)` fallback below, which
+	// would otherwise hit [lowerVectorSelector]'s ordinary path and
+	// [expHistogramSelectorRouting]'s hard rejection. See that function's
+	// own doc for why count()/group() need this rather than the
+	// histogram-VALUED family's [lowerExpHistogramArgAsCanonicalFloat]
+	// opt-in: their own OUTPUT is float-valued, not histogram-valued.
+	if plan, ok, err := lowerExpHistogramCountFamily(a, s, ctx); ok {
+		return plan, err
 	}
 
 	input, err := lower(a.Expr, s, ctx)

--- a/test/rejection-parity/catalogue/internal__promql__histogram_native_count.go.json
+++ b/test/rejection-parity/catalogue/internal__promql__histogram_native_count.go.json
@@ -2,23 +2,50 @@
   "entries": [
     {
       "head": "promql",
+      "site": "internal/promql/histogram_native_count.go:lowerExpHistogramCountFamily#c7dbd629",
+      "message": "promql: internal invariant violated: count/group input is not histogram-valued: %v",
+      "class": "internal",
+      "rationale": "countOrGroupOverExpHistogramValue's own return value IS isExpHistogramValuedShape(agg.Expr, s, ctx), so a true ok already proves the immediately following lowerExpHistogramValuedShape call on the same agg.Expr cannot come back unmatched. lowerExpHistogramCountFamily (cerberus issue #2549) is factored out of lowerHistogramNativeRoot's own body so lowerAggregate's generic fallback can retry the identical recogniser pair when a count()/group() over an exp-histogram shape is NESTED under a further wrapper rather than sitting at the query's own root; it gained a second caller by that factoring, but the invariant argument depends only on the SHAPE of whatever expr reaches this guard, not on which of the two callers supplied it, so the new caller does not affect it.",
+      "evidence": {
+        "guard": [
+          "past returning if agg, vs, ok := countOverExpHistogram(expr, s, ctx); ok",
+          "if agg, ok := countOrGroupOverExpHistogramValue(expr, s, ctx); ok",
+          "past returning if err != nil",
+          "if !matched"
+        ],
+        "callers": [
+          "lowerAggregate",
+          "lowerHistogramNativeRoot"
+        ],
+        "cited": [
+          "countOrGroupOverExpHistogramValue",
+          "isExpHistogramValuedShape",
+          "lowerAggregate",
+          "lowerExpHistogramCountFamily",
+          "lowerExpHistogramValuedShape",
+          "lowerHistogramNativeRoot"
+        ]
+      }
+    },
+    {
+      "head": "promql",
       "site": "internal/promql/histogram_native_count.go:lowerExpHistogramCountOrGroupOverPlan#6724a38c",
       "message": "promql: internal invariant violated: nested native-histogram count/group input is %T with %s row shape",
       "class": "internal",
-      "rationale": "countOrGroupOverExpHistogramValue admits only histogram-valued operands; lowerHistogramNativeRoot (reached from lowerRoot for a query's own root, and from lowerHistogramNativeSubqueryInner for a bare subquery's own inner expression as of cerberus issue #2543) lowers that same operand through lowerExpHistogramValuedShape, whose matched contract is HistogramRowShape.",
+      "rationale": "countOrGroupOverExpHistogramValue admits only histogram-valued operands; lowerExpHistogramCountFamily, its sole caller (cerberus issue #2549 factored this pairing out of lowerHistogramNativeRoot so lowerAggregate's own generic fallback could reuse it for a NESTED count()/group()), lowers that same operand through lowerExpHistogramValuedShape, whose matched contract is HistogramRowShape.",
       "evidence": {
         "guard": [
           "if chplan.RowShapeOf(input) != chplan.HistogramRowShape"
         ],
         "callers": [
-          "lowerHistogramNativeRoot"
+          "lowerExpHistogramCountFamily"
         ],
         "cited": [
           "countOrGroupOverExpHistogramValue",
+          "lowerAggregate",
+          "lowerExpHistogramCountFamily",
           "lowerExpHistogramValuedShape",
-          "lowerHistogramNativeRoot",
-          "lowerHistogramNativeSubqueryInner",
-          "lowerRoot"
+          "lowerHistogramNativeRoot"
         ]
       }
     },
@@ -27,20 +54,20 @@
       "site": "internal/promql/histogram_native_count.go:lowerExpHistogramCountOrGroupOverPlan#9c86789a",
       "message": "promql: internal invariant violated: %s is not count/group",
       "class": "internal",
-      "rationale": "the sole caller arrives only through countOrGroupOverExpHistogramValue, which admits only COUNT or GROUP; this holds identically whether that caller is lowerHistogramNativeRoot's lowerRoot entry point or its lowerHistogramNativeSubqueryInner entry point (cerberus issue #2543), since both reach this lowerer through the same countOrGroupOverExpHistogramValue-gated call.",
+      "rationale": "the sole caller arrives only through countOrGroupOverExpHistogramValue, which admits only COUNT or GROUP; this holds identically whichever of lowerExpHistogramCountFamily's two callers (lowerHistogramNativeRoot's own root dispatch, or lowerAggregate's generic fallback retrying a NESTED count()/group() as of cerberus issue #2549) supplied the original expr, since both reach this lowerer through the same countOrGroupOverExpHistogramValue-gated call.",
       "evidence": {
         "guard": [
           "past returning if chplan.RowShapeOf(input) != chplan.HistogramRowShape",
           "default of switch agg.Op over [case parser.COUNT; case parser.GROUP; default]"
         ],
         "callers": [
-          "lowerHistogramNativeRoot"
+          "lowerExpHistogramCountFamily"
         ],
         "cited": [
           "countOrGroupOverExpHistogramValue",
-          "lowerHistogramNativeRoot",
-          "lowerHistogramNativeSubqueryInner",
-          "lowerRoot"
+          "lowerAggregate",
+          "lowerExpHistogramCountFamily",
+          "lowerHistogramNativeRoot"
         ]
       }
     }

--- a/test/rejection-parity/catalogue/internal__promql__lower.go.json
+++ b/test/rejection-parity/catalogue/internal__promql__lower.go.json
@@ -94,8 +94,8 @@
       "site": "internal/promql/lower.go:expHistogramSelectorRouting#bf746b59",
       "message": "promql: %q is an exponential histogram metric; only a bare %q selector, sum()/avg()/count() over one, rate()/increase()/delta()/irate()/idelta()/sum_over_time()/avg_over_time()/resets()/changes() over one, histogram_quantile(), histogram_count(), histogram_sum(), and the %q/%q companion selectors are supported",
       "class": "divergence",
-      "trigger_query": "resets(demo_latency_exp_hist[5m]) * 2",
-      "tracking_issue": 2549,
+      "trigger_query": "histogram_count(sum(demo_latency_exp_hist))",
+      "tracking_issue": 2554,
       "evidence": {
         "guard": [
           "past returning if bare, col, hasCompanion := s.HistogramCompanionColumn(metricName); hasCompanion \u0026\u0026 s.IsExpHistogramMetric(bare) \u0026\u0026 s.ExpHistogramTable != \"\"",
@@ -271,7 +271,7 @@
       "site": "internal/promql/lower.go:lowerHistogramNativeRoot#53e0f9b3",
       "message": "promql: internal invariant violated: count_values input is not histogram-valued: %v",
       "class": "internal",
-      "rationale": "bareExpHistogramMatrixSelector, checked FIRST in lowerHistogramNativeRoot's chain as of cerberus issue #2548, type-asserts expr as *parser.MatrixSelector before doing anything else — count_values's top-level expr is an *parser.AggregateExpr, which is never a *parser.MatrixSelector, so it cannot intercept this shape either, and does not affect this claim. countValuesOverExpHistogramValue already ran isExpHistogramValuedShape to decide ok=true, so the immediately following lowerExpHistogramValuedShape call on the same agg.Expr cannot come back unmatched. lowerMixedExpHistogramFamily, checked earlier in lowerHistogramNativeRoot's chain (cerberus issues #2330/#2346/#2449, split out of lowerRoot's own body as of cerberus issue #2528 purely to keep lowerRoot's maintainability-index score over golangci-lint's floor, then re-homed onto lowerHistogramNativeRoot as of cerberus issue #2543 when lowerRoot's own histogram-native dispatch table was factored out so a subquery's inner expression could reuse it — see that function's own doc comment for the per-recognizer detail this paragraph used to carry inline here), only recognises mixedExpHistogramSetOp's own `or` VectorSetOp BinaryExpr with exactly one histogram-valued operand, or a *parser.Call/*parser.BinaryExpr shape wrapping one — count_values's top-level expr is an *parser.AggregateExpr with Op=COUNT_VALUES, which is none of those shapes, so no branch inside it can intercept this shape either, and does not affect this claim. countPresentOverExpHistogram and lastFirstOverExpHistogram (cerberus issue #2480), checked immediately after that, each type-assert peelWrappers(expr) as a *parser.Call named count_over_time/present_over_time or last_over_time/first_over_time before doing anything else — count_values's top-level expr is an *parser.AggregateExpr, which peelWrappers never turns into a Call, so neither can intercept this shape either. tsOfFirstLastOverExpHistogram (cerberus issue #2482), checked immediately after that, likewise type-asserts peelWrappers(expr) as a *parser.Call named ts_of_first_over_time/ts_of_last_over_time before doing anything else — count_values's top-level expr is an *parser.AggregateExpr, which peelWrappers never turns into a Call, so it cannot intercept this shape either. lowerHistogramNativeSubqueryInner (cerberus issue #2543) is a second direct caller as of this change, reached when a bare top-level subquery's own inner expression matches this same recognizer chain; it supplies a different `expr` value (the subquery's inner) but the claim above reasons only about the SHAPE of whatever `expr` reaches this guard, not about which entry point supplied it, so the new caller does not affect it.",
+      "rationale": "bareExpHistogramMatrixSelector, checked FIRST in lowerHistogramNativeRoot's chain as of cerberus issue #2548, type-asserts expr as *parser.MatrixSelector before doing anything else — count_values's top-level expr is an *parser.AggregateExpr, which is never a *parser.MatrixSelector, so it cannot intercept this shape either, and does not affect this claim. countValuesOverExpHistogramValue already ran isExpHistogramValuedShape to decide ok=true, so the immediately following lowerExpHistogramValuedShape call on the same agg.Expr cannot come back unmatched. lowerMixedExpHistogramFamily, checked earlier in lowerHistogramNativeRoot's chain (cerberus issues #2330/#2346/#2449, split out of lowerRoot's own body as of cerberus issue #2528 purely to keep lowerRoot's maintainability-index score over golangci-lint's floor, then re-homed onto lowerHistogramNativeRoot as of cerberus issue #2543 when lowerRoot's own histogram-native dispatch table was factored out so a subquery's inner expression could reuse it — see that function's own doc comment for the per-recognizer detail this paragraph used to carry inline here), only recognises mixedExpHistogramSetOp's own `or` VectorSetOp BinaryExpr with exactly one histogram-valued operand, or a *parser.Call/*parser.BinaryExpr shape wrapping one — count_values's top-level expr is an *parser.AggregateExpr with Op=COUNT_VALUES, which is none of those shapes, so no branch inside it can intercept this shape either, and does not affect this claim. countPresentOverExpHistogram and lastFirstOverExpHistogram (cerberus issue #2480), checked immediately after that, each type-assert peelWrappers(expr) as a *parser.Call named count_over_time/present_over_time or last_over_time/first_over_time before doing anything else — count_values's top-level expr is an *parser.AggregateExpr, which peelWrappers never turns into a Call, so neither can intercept this shape either. tsOfFirstLastOverExpHistogram (cerberus issue #2482), checked immediately after that, likewise type-asserts peelWrappers(expr) as a *parser.Call named ts_of_first_over_time/ts_of_last_over_time before doing anything else — count_values's top-level expr is an *parser.AggregateExpr, which peelWrappers never turns into a Call, so it cannot intercept this shape either. lowerExpHistogramCountFamily (cerberus issue #2549, replacing the two inline countOverExpHistogram / countOrGroupOverExpHistogramValue checks this site's guard used to spell directly), checked immediately after that, requires agg.Op to be COUNT or GROUP with a nil Param — count_values's top-level expr has Op=COUNT_VALUES and a non-nil Param (the target label), so neither of its two recognisers can intercept this shape either. lowerHistogramNativeSubqueryInner (cerberus issue #2543) is a second direct caller as of that change, reached when a bare top-level subquery's own inner expression matches this same recognizer chain; it supplies a different `expr` value (the subquery's inner) but the claim above reasons only about the SHAPE of whatever `expr` reaches this guard, not about which entry point supplied it, so the new caller does not affect it.",
       "evidence": {
         "guard": [
           "past returning if ms, vs, ok := bareExpHistogramMatrixSelector(expr, s, ctx); ok",
@@ -284,8 +284,7 @@
           "past returning if fn, ms, vs, ok := countPresentOverExpHistogram(expr, s, ctx); ok",
           "past returning if fn, ms, vs, ok := lastFirstOverExpHistogram(expr, s, ctx); ok",
           "past returning if fn, ms, vs, ok := tsOfFirstLastOverExpHistogram(expr, s, ctx); ok",
-          "past returning if agg, vs, ok := countOverExpHistogram(expr, s, ctx); ok",
-          "past returning if agg, ok := countOrGroupOverExpHistogramValue(expr, s, ctx); ok",
+          "past returning if plan, ok, err := lowerExpHistogramCountFamily(expr, s, ctx); ok",
           "if agg, ok := countValuesOverExpHistogramValue(expr, s, ctx); ok",
           "past returning if err != nil",
           "if !matched"
@@ -296,54 +295,13 @@
         ],
         "cited": [
           "bareExpHistogramMatrixSelector",
+          "countOrGroupOverExpHistogramValue",
+          "countOverExpHistogram",
           "countPresentOverExpHistogram",
           "countValuesOverExpHistogramValue",
           "isExpHistogramValuedShape",
           "lastFirstOverExpHistogram",
-          "lowerExpHistogramValuedShape",
-          "lowerHistogramNativeRoot",
-          "lowerHistogramNativeSubqueryInner",
-          "lowerMixedExpHistogramFamily",
-          "lowerRoot",
-          "mixedExpHistogramSetOp",
-          "peelWrappers",
-          "tsOfFirstLastOverExpHistogram"
-        ]
-      }
-    },
-    {
-      "head": "promql",
-      "site": "internal/promql/lower.go:lowerHistogramNativeRoot#c7dbd629",
-      "message": "promql: internal invariant violated: count/group input is not histogram-valued: %v",
-      "class": "internal",
-      "rationale": "bareExpHistogramMatrixSelector, checked FIRST in lowerHistogramNativeRoot's chain as of cerberus issue #2548, type-asserts expr as *parser.MatrixSelector before doing anything else — count/group's top-level expr is an *parser.AggregateExpr, which is never a *parser.MatrixSelector, so it cannot intercept this shape either, and does not affect this claim. countOrGroupOverExpHistogramValue already ran isExpHistogramValuedShape to decide ok=true, so the immediately following lowerExpHistogramValuedShape call on the same agg.Expr cannot come back unmatched. lowerMixedExpHistogramFamily, checked earlier in lowerHistogramNativeRoot's chain (cerberus issues #2330/#2346/#2449, split out of lowerRoot's own body as of cerberus issue #2528 purely to keep lowerRoot's maintainability-index score over golangci-lint's floor, then re-homed onto lowerHistogramNativeRoot as of cerberus issue #2543 when lowerRoot's own histogram-native dispatch table was factored out so a subquery's inner expression could reuse it — see that function's own doc comment for the per-recognizer detail this paragraph used to carry inline here), only recognises mixedExpHistogramSetOp's own `or` VectorSetOp BinaryExpr with exactly one histogram-valued operand, or a *parser.Call/*parser.BinaryExpr shape wrapping one — count/group's top-level expr is an *parser.AggregateExpr with Op=COUNT or GROUP, which is none of those shapes, so no branch inside it can intercept this shape either, and does not affect this claim. countPresentOverExpHistogram and lastFirstOverExpHistogram (cerberus issue #2480), checked immediately after that, each type-assert peelWrappers(expr) as a *parser.Call named count_over_time/present_over_time or last_over_time/first_over_time before doing anything else — count/group's top-level expr is an *parser.AggregateExpr, which peelWrappers never turns into a Call, so neither can intercept this shape either. tsOfFirstLastOverExpHistogram (cerberus issue #2482), checked immediately after that, likewise type-asserts peelWrappers(expr) as a *parser.Call named ts_of_first_over_time/ts_of_last_over_time before doing anything else — count/group's top-level expr is an *parser.AggregateExpr, which peelWrappers never turns into a Call, so it cannot intercept this shape either. lowerHistogramNativeSubqueryInner (cerberus issue #2543) is a second direct caller as of this change, reached when a bare top-level subquery's own inner expression matches this same recognizer chain; it supplies a different `expr` value (the subquery's inner) but the claim above reasons only about the SHAPE of whatever `expr` reaches this guard, not about which entry point supplied it, so the new caller does not affect it.",
-      "evidence": {
-        "guard": [
-          "past returning if ms, vs, ok := bareExpHistogramMatrixSelector(expr, s, ctx); ok",
-          "past returning if call, ok := labelReplaceOverExpHistogram(expr, s, ctx); ok",
-          "past returning if plan, ok, err := lowerExpHistogramValuedShape(expr, s, ctx); ok",
-          "past returning if plan, ok, err := lowerMixedExpHistogramFamily(expr, s, ctx); ok",
-          "past returning if lhs, rhs, op, match, card, include, returnBool, ok := comparisonVectorVectorOverMixedExpHistogramSetOp(expr, s, ctx); ok",
-          "past returning if shape, ok := overTimeOverExpHistogram(expr, s, ctx); ok",
-          "past returning if shape, ok := resetsOrChangesOverExpHistogram(expr, s, ctx); ok",
-          "past returning if fn, ms, vs, ok := countPresentOverExpHistogram(expr, s, ctx); ok",
-          "past returning if fn, ms, vs, ok := lastFirstOverExpHistogram(expr, s, ctx); ok",
-          "past returning if fn, ms, vs, ok := tsOfFirstLastOverExpHistogram(expr, s, ctx); ok",
-          "past returning if agg, vs, ok := countOverExpHistogram(expr, s, ctx); ok",
-          "if agg, ok := countOrGroupOverExpHistogramValue(expr, s, ctx); ok",
-          "past returning if err != nil",
-          "if !matched"
-        ],
-        "callers": [
-          "lowerHistogramNativeSubqueryInner",
-          "lowerRoot"
-        ],
-        "cited": [
-          "bareExpHistogramMatrixSelector",
-          "countOrGroupOverExpHistogramValue",
-          "countPresentOverExpHistogram",
-          "isExpHistogramValuedShape",
-          "lastFirstOverExpHistogram",
+          "lowerExpHistogramCountFamily",
           "lowerExpHistogramValuedShape",
           "lowerHistogramNativeRoot",
           "lowerHistogramNativeSubqueryInner",


### PR DESCRIPTION
## Summary

- `resets()` / `changes()` over a bare exponential-histogram selector already answered
  correctly on their own, but wrapping the call in anything else — scalar arithmetic
  (`resets(m[5m]) * 2`), an aggregation (`sum(resets(m[5m]))`), an instant math function
  (`abs(changes(m[5m]))`) — hard-rejected via `expHistogramSelectorRouting`'s catch-all.
  `lowerHistogramNativeRoot` only tried `resetsOrChangesOverExpHistogram` when the call
  was the query's own root; every wrapper's generic operand lowering fell back to the
  ordinary `lowerVectorSelector` path instead.
- Probing the same gap for `count()`/`group()` — named alongside resets/changes in the
  issue's own "float-valued family" — found the identical defect: `count(m) * 2`,
  `sum(count(m))`, `abs(group(m))`, and `count(rate(m[5m])) * 2` all hard-rejected too.
- Fix mirrors the histogram-VALUED family's existing nested-retry mechanism
  (`isExpHistogramValuedShape` / `lowerExpHistogramArgAsCanonicalFloat`), adapted for a
  float-valued output:
  - `lowerRangeVectorCall` (every `resets()`/`changes()` call reaches this function
    regardless of nesting, since it always carries a `MatrixSelector` argument) now tries
    `resetsOrChangesOverExpHistogram` before its per-function-name switch.
  - `lowerAggregate` now tries the new `lowerExpHistogramCountFamily` — factored out of
    `lowerHistogramNativeRoot`'s own `count()`/`group()` dispatch so the root and the
    generic fallback share one recogniser/lowering pair — before its generic operand
    descent.
- Regenerated `test/rejection-parity/catalogue/`: the `count()`/`group()`
  internal-invariant sites moved into the new shared `lowerExpHistogramCountFamily` and
  picked up `lowerAggregate` as a second caller; curated class/rationale for the moved
  entries. `expHistogramSelectorRouting`'s own catalogued trigger
  (`demo_latency_exp_hist[5m]`, tracked by #2548) is untouched — that bare top-level
  matrix-selector shape is a different, still-open gap this change does not close.

## Verification

- Confirmed against `origin/main` before the fix: all four of the issue's trigger
  queries, plus `count(m) * 2` / `sum(count(m))` / `abs(count(m))` /
  `count(rate(m[5m])) * 2` / `group(m) * 2`, hard-reject with
  `expHistogramSelectorRouting`'s message.
- Broad post-fix probing (topk/bottomk, vector-vector `+`, unary minus, comparisons,
  `count_values`, `clamp_max`, a bare-subquery wrapper, `label_replace`, `and`/`or`) found
  no further reachable gap in this family — no follow-on issue filed.
- New chDB test (`internal/promql/histogram_native_resets_changes_count_nested_chdb_test.go`)
  seeds real exponential-histogram rows with an actual reset, an actual change, and a
  two-series instant vector, and asserts the exact scalar `Value` for eight nested/wrapped
  queries — confirmed to fail (hard rejection) with the fix reverted and pass with it
  applied.
- Updated `TestLower_ExpHistogram_UnsupportedShapesRejectExplicitly` (removed the six
  cases that now correctly succeed; kept the subquery-form cases, which this fix does not
  touch) and `TestLower_ExpHistogram_ResetsChangesCountAreFloatValued` (added the newly
  supported wrapped shapes, asserting the same float sample-quartet row shape as the bare
  cases).
- `go build ./...`, `go test -race -count=1 ./internal/promql/...`,
  `go test ./test/rejection-parity/...` (incl. `TestCatalogueEntriesAreClassified`,
  `TestCatalogueIsRegenerable`, `TestInternalRationalesRestOnCurrentEvidence`,
  `TestInternalRationaleCitationsStillDispatch`, `TestRejectionTriggersExerciseSites`),
  `node .github/scripts/forbid-sql-raw.mjs`, `gofumpt -extra -l`, `go vet` all clean.
- No `test/spec/promql/*.txtar` fixture exercises a nested resets/changes/count/group
  shape, so no golden regeneration was needed — confirmed no existing fixture's `-- sql --`
  changed via the full non-chdb `TestLower` run.

Closes #2549
