### PR TITLE
fix(promql): read a histogram-valued nested argument in native value functions

### DIFF
--- a/internal/promql/histogram_quantile.go
+++ b/internal/promql/histogram_quantile.go
@@ -295,21 +295,8 @@ func lowerHistogramQuantile(c *parser.Call, s schema.Metrics, ctx lowerCtx) (chp
 		// carry a real merged distribution for histogram_quantile to walk
 		// — not the "provably no bucket data" float pipeline the
 		// fallback below assumes (cerberus issue #2554).
-		if hist, matched, err := lowerExpHistogramValuedShape(c.Args[1], s, ctx); matched {
-			if err != nil {
-				return nil, err
-			}
-			// RowShapeOf, not a *chplan.HistogramProjection type
-			// assertion: a set-op operand (histogram_native_set_op.go)
-			// answers histogram-valued as a *chplan.VectorSetOp with
-			// Histogram=true, publishing the identical nine-column
-			// contract under a different node type. RowShapeOf is this
-			// package's own shared test for "is this the thirteen-column
-			// histogram row shape" across every such producer.
-			if chplan.RowShapeOf(hist) != chplan.HistogramRowShape {
-				return nil, fmt.Errorf("promql: internal invariant violated: exp-histogram lowering did not produce a histogram-shaped plan, got %T", hist)
-			}
-			return lowerHistogramQuantileNativeOverProjection(hist, phi, s), nil
+		if node, matched, err := lowerHistogramQuantileHistogramValuedArg(c.Args[1], phi, s, ctx); matched {
+			return node, err
 		}
 
 		// Unrecognised inner shape — `histogram_quantile(0.9, sum(up))`,
@@ -1868,6 +1855,40 @@ func lowerHistogramQuantileNative(vs *parser.VectorSelector, phi phiArg, s schem
 			{Expr: &chplan.ColumnRef{Name: s.ValueColumn}, Alias: s.ValueColumn},
 		},
 	}, nil
+}
+
+// lowerHistogramQuantileHistogramValuedArg is lowerHistogramQuantile's own
+// "try the HISTOGRAM-VALUED retry" opt-in for its non-bare, non-agg-idiom
+// argument, factored out to keep that branch a single flat check —
+// mirroring the `if node, ok, err := lowerExpHistogramArgAsCanonicalFloat(...);
+// ok { … }` shape every float-only wrapper in this package already uses at
+// its own callsite — rather than nesting the match/error/shape checks
+// inline, which golangci-lint's nestif gate flags past a threshold.
+// matched=false leaves the caller's own "unrecognised inner shape" empty
+// fallback untouched.
+func lowerHistogramQuantileHistogramValuedArg(
+	arg parser.Expr,
+	phi phiArg,
+	s schema.Metrics,
+	ctx lowerCtx,
+) (node chplan.Node, matched bool, err error) {
+	hist, matched, err := lowerExpHistogramValuedShape(arg, s, ctx)
+	if !matched {
+		return nil, false, nil
+	}
+	if err != nil {
+		return nil, true, err
+	}
+	// RowShapeOf, not a *chplan.HistogramProjection type assertion: a
+	// set-op operand (histogram_native_set_op.go) answers histogram-valued
+	// as a *chplan.VectorSetOp with Histogram=true, publishing the
+	// identical nine-column contract under a different node type.
+	// RowShapeOf is this package's own shared test for "is this the
+	// thirteen-column histogram row shape" across every such producer.
+	if chplan.RowShapeOf(hist) != chplan.HistogramRowShape {
+		return nil, true, fmt.Errorf("promql: internal invariant violated: exp-histogram lowering did not produce a histogram-shaped plan, got %T", hist)
+	}
+	return lowerHistogramQuantileNativeOverProjection(hist, phi, s), true, nil
 }
 
 // lowerHistogramQuantileNativeOverProjection is the nested-argument

--- a/internal/promql/histogram_quantile.go
+++ b/internal/promql/histogram_quantile.go
@@ -286,6 +286,32 @@ func lowerHistogramQuantile(c *parser.Call, s schema.Metrics, ctx lowerCtx) (chp
 	}
 
 	if !isBare {
+		// The argument may still be a native-histogram MERGE shape that
+		// matchHistogramAggIdiom's walker does not recognise —
+		// `hist_a + hist_b`, `2 * hist`, an on()/ignoring() sum, … . Those
+		// answer histogram-valued under reference Prometheus (the binop /
+		// scalar-scaling machinery composes with sum()/avg() exactly the
+		// way [isExpHistogramValuedShape]'s own doc describes), so they
+		// carry a real merged distribution for histogram_quantile to walk
+		// — not the "provably no bucket data" float pipeline the
+		// fallback below assumes (cerberus issue #2554).
+		if hist, matched, err := lowerExpHistogramValuedShape(c.Args[1], s, ctx); matched {
+			if err != nil {
+				return nil, err
+			}
+			// RowShapeOf, not a *chplan.HistogramProjection type
+			// assertion: a set-op operand (histogram_native_set_op.go)
+			// answers histogram-valued as a *chplan.VectorSetOp with
+			// Histogram=true, publishing the identical nine-column
+			// contract under a different node type. RowShapeOf is this
+			// package's own shared test for "is this the thirteen-column
+			// histogram row shape" across every such producer.
+			if chplan.RowShapeOf(hist) != chplan.HistogramRowShape {
+				return nil, fmt.Errorf("promql: internal invariant violated: exp-histogram lowering did not produce a histogram-shaped plan, got %T", hist)
+			}
+			return lowerHistogramQuantileNativeOverProjection(hist, phi, s), nil
+		}
+
 		// Unrecognised inner shape — `histogram_quantile(0.9, sum(up))`,
 		// `histogram_quantile(0.9, vector(1))`, … . Reference Prometheus
 		// accepts any instant-vector second argument: classic-histogram
@@ -1842,6 +1868,68 @@ func lowerHistogramQuantileNative(vs *parser.VectorSelector, phi phiArg, s schem
 			{Expr: &chplan.ColumnRef{Name: s.ValueColumn}, Alias: s.ValueColumn},
 		},
 	}, nil
+}
+
+// lowerHistogramQuantileNativeOverProjection is the nested-argument
+// counterpart to lowerHistogramQuantileNative / …NativeAgg: hp is an
+// ALREADY-lowered histogram-valued plan (sum()/avg()/rate()/a
+// histogram-histogram binop/a set-op/…) whose own lowering already resolved
+// instant-vs-range mode, the newest-sample collapse, and (for a merging
+// shape) the cross-series distribution add. HistogramQuantileNative's
+// Input contract is purely per-row (see its chplan doc: "Input produces
+// rows surfacing the exp-histogram columns … Typically Scan or Filter"),
+// so hp — already one row per (series[, anchor]) — composes directly
+// without re-deriving the merge lowerHistogramQuantileNativeAgg's own
+// Aggregate + Project stages build for the `sum by(le) (rate(...))`
+// idiom. Both Attributes and Timestamp are threaded through GroupBy so a
+// range-mode hp's own per-anchor timestamp survives into the wrapping
+// Sample projection instead of being overwritten by a hardcoded
+// now64(9), unlike the instant-only …NativeAgg scaffold above (cerberus
+// issue #2554).
+//
+// hp's nine structural columns are read under [histogramProjectionSchema],
+// not s directly: every [chplan.HistogramRowShape] producer (a
+// HistogramProjection, a Histogram-flagged VectorSetOp, …) publishes
+// them under the FIXED chplan.Histogram*Column aliases rather than the
+// schema's own raw names (see chsql's emitHistogramProjection /
+// emitVectorSetOp) — s's own names would resolve to columns hp never
+// publishes. Attributes/Timestamp stay under s's own names: those come
+// from hp's GroupByAliases, which every histogram-valued lowering
+// threads from the ORIGINAL schema unchanged (nativeHistogramProjection).
+func lowerHistogramQuantileNativeOverProjection(hp chplan.Node, phi phiArg, s schema.Metrics) chplan.Node {
+	histSchema := histogramProjectionSchema(s)
+	hq := &chplan.HistogramQuantileNative{
+		Input:                      hp,
+		Phi:                        phi.lit,
+		PhiExpr:                    phi.expr,
+		ScaleColumn:                histSchema.ScaleColumn,
+		ZeroCountColumn:            histSchema.ZeroCountColumn,
+		ZeroThresholdColumn:        histSchema.ZeroThresholdColumn,
+		PositiveOffsetColumn:       histSchema.PositiveOffsetColumn,
+		PositiveBucketCountsColumn: histSchema.PositiveBucketCountsColumn,
+		NegativeOffsetColumn:       histSchema.NegativeOffsetColumn,
+		NegativeBucketCountsColumn: histSchema.NegativeBucketCountsColumn,
+		CountColumn:                histSchema.CountColumn,
+		SumColumn:                  histSchema.SumColumn,
+		GroupBy: []chplan.Expr{
+			&chplan.ColumnRef{Name: s.AttributesColumn},
+			&chplan.ColumnRef{Name: s.TimestampColumn},
+		},
+		GroupByAliases:   []string{s.AttributesColumn, s.TimestampColumn},
+		MetricNameColumn: s.MetricNameColumn,
+		AttributesColumn: s.AttributesColumn,
+		TimestampColumn:  s.TimestampColumn,
+	}
+
+	return &chplan.Project{
+		Input: hq,
+		Projections: []chplan.Projection{
+			{Expr: &chplan.LitString{V: ""}, Alias: s.MetricNameColumn},
+			{Expr: &chplan.ColumnRef{Name: s.AttributesColumn}, Alias: s.AttributesColumn},
+			{Expr: &chplan.ColumnRef{Name: s.TimestampColumn}, Alias: s.TimestampColumn},
+			{Expr: &chplan.ColumnRef{Name: s.ValueColumn}, Alias: s.ValueColumn},
+		},
+	}
 }
 
 // Aliases used by lowerHistogramQuantileNativeAgg to thread per-row

--- a/internal/promql/histogram_value_fn_nested_arg_chdb_test.go
+++ b/internal/promql/histogram_value_fn_nested_arg_chdb_test.go
@@ -1,0 +1,317 @@
+//go:build chdb
+
+// chDB-backed proof that histogram_count()/histogram_sum()/histogram_avg()/
+// histogram_quantile() actually read a real, correctly-merged distribution
+// at real ClickHouse execution when their argument is itself a
+// HISTOGRAM-VALUED shape rather than a bare selector — sum(m), avg(m),
+// rate(m[5m]), a histogram-histogram binop, a set-op — not merely that the
+// emitted plan's Go shape lowers without error (cerberus issue #2554).
+//
+// Before this fix, lowerHistogramValueFn's (histogram_value_fns.go) and
+// lowerHistogramQuantile's (histogram_quantile.go) non-bare-selector
+// fallbacks assumed any such argument provably carried no native-histogram
+// samples and folded to an empty result — silently wrong for every shape
+// below, which all answer histogram-valued under reference Prometheus.
+// Threading isExpHistogramValuedShape / lowerExpHistogramValuedShape ahead
+// of that fallback (mirroring every other wrapper in this package) fixes
+// the routing; these tests additionally caught a second, genuinely silent
+// bug the routing fix alone did not: a histogram-valued plan's raw
+// structural columns publish under the FIXED chplan.Histogram*Column
+// aliases (HistogramCount, HistogramSum, …), not the schema's own raw
+// names — reading them via the raw schema.Metrics would reference columns
+// hp never emits (UNKNOWN_IDENTIFIER at real ClickHouse execution, not a
+// Go-level lowering error), which is exactly the class of bug a
+// Go-only "does it lower" probe cannot catch.
+package promql_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/prometheus/prometheus/promql/parser"
+
+	"github.com/tsouza/cerberus/internal/chsql"
+	"github.com/tsouza/cerberus/internal/promql"
+	"github.com/tsouza/cerberus/internal/schema"
+	"github.com/tsouza/cerberus/internal/testsql"
+)
+
+// hvfnNestedRateDDL is subqHistDDL's shape (subquery_histogram_native_chdb_test.go)
+// widened with AggregationTemporality — rate()'s DELTA-vs-CUMULATIVE branch
+// (schema.AggregationTemporalityColumn) reads that column unconditionally,
+// unlike every other shape this file seeds against subqHistDDL directly.
+const hvfnNestedRateDDL = "CREATE OR REPLACE TABLE otel_metrics_exponential_histogram (" +
+	"`MetricName` String, `Attributes` Map(String, String), " +
+	"`ResourceAttributes` Map(String, String) DEFAULT map(), `ServiceName` LowCardinality(String) DEFAULT '', " +
+	"`TimeUnix` DateTime64(9), " +
+	"`Count` UInt64, `Sum` Float64, `Scale` Int32, `ZeroCount` UInt64, " +
+	"`PositiveOffset` Int32, `PositiveBucketCounts` Array(UInt64), " +
+	"`NegativeOffset` Int32, `NegativeBucketCounts` Array(UInt64), " +
+	"`AggregationTemporality` Int32 DEFAULT 2" +
+	") ENGINE = MergeTree ORDER BY (`MetricName`, `Attributes`, `TimeUnix`);\n"
+
+// hvfnRunScalar lowers query at evalTS, emits it, and returns the single
+// `Value` its Sample row carries — failing the test if the query does not
+// produce exactly one row.
+func hvfnRunScalar(t *testing.T, fixture *chdbFixture, s schema.Metrics, query string, evalTS time.Time) float64 {
+	t.Helper()
+	p := parser.NewParser(parser.Options{EnableExperimentalFunctions: true})
+	expr, err := p.ParseExpr(query)
+	if err != nil {
+		t.Fatalf("ParseExpr(%q): %v", query, err)
+	}
+	plan, err := promql.LowerAt(context.Background(), expr, s, evalTS, evalTS)
+	if err != nil {
+		t.Fatalf("LowerAt(%q): %v", query, err)
+	}
+	sqlStr, args, err := chsql.Emit(context.Background(), plan)
+	if err != nil {
+		t.Fatalf("Emit(%q): %v", query, err)
+	}
+	rows := fixture.queryOverEmitted(t, "`Value` AS val", sqlStr, args)
+	defer func() { _ = rows.Close() }()
+	var got float64
+	var n int
+	for rows.Next() {
+		if err := rows.Scan(&got); err != nil {
+			t.Fatalf("%s: scan: %v", query, err)
+		}
+		n++
+	}
+	if err := testsql.TolerantRowsErr(rows.Err()); err != nil {
+		t.Fatalf("%s: rows.Err: %v", query, err)
+	}
+	if n != 1 {
+		t.Fatalf("%s: got %d rows, want exactly 1", query, n)
+	}
+	return got
+}
+
+// TestHistogramValueFnNestedSum_ChDB proves histogram_count()/
+// histogram_sum() over sum() and histogram_avg() over avg() — the
+// issue's first and third trigger queries — merge two series' Count/Sum
+// scalars correctly before the value function reads them.
+//
+// sum(m): Count=2+5=7, Sum=4.0+1.0=5.0.
+// avg(m): the same merge divided by the group's member count (2):
+// Count=3.5, Sum=2.5, so histogram_avg = Sum/Count = 2.5/3.5.
+func TestHistogramValueFnNestedSum_ChDB(t *testing.T) {
+	const metric = "hvfn_nested_sum_exp_hist"
+	seed := subqHistDDL +
+		"INSERT INTO otel_metrics_exponential_histogram " +
+		"(MetricName, Attributes, TimeUnix, Count, Sum, Scale, ZeroCount, PositiveOffset, PositiveBucketCounts, NegativeOffset, NegativeBucketCounts) VALUES\n" +
+		"    ('" + metric + "', map('job', 'a'), toDateTime64('2026-01-01 00:01:00', 9), 2, 4.0, 0, 0, 0, [6], 0, []),\n" +
+		"    ('" + metric + "', map('job', 'b'), toDateTime64('2026-01-01 00:01:00', 9), 5, 1.0, 0, 0, 0, [3], 0, []);\n"
+	fixture := newChDBFixture(t, seed)
+
+	s := schema.DefaultOTelMetrics()
+	evalTS := time.Date(2026, 1, 1, 0, 1, 0, 0, time.UTC)
+
+	cases := []struct {
+		query string
+		want  float64
+	}{
+		{"histogram_count(sum(" + metric + "))", 7},
+		{"histogram_sum(sum(" + metric + "))", 5.0},
+		{"histogram_avg(avg(" + metric + "))", 2.5 / 3.5},
+	}
+	for _, tc := range cases {
+		t.Run(tc.query, func(t *testing.T) {
+			got := hvfnRunScalar(t, fixture, s, tc.query, evalTS)
+			if got != tc.want {
+				t.Errorf("%s = %v, want %v", tc.query, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestHistogramValueFnNestedRate_ChDB proves histogram_sum(rate(m[5m])) —
+// the issue's second trigger query — reads the SAME Sum/Count rate()'s own
+// native lowering computes, rather than hand-deriving the rate
+// extrapolation arithmetic here: the oracle independently lowers the bare
+// `rate(m[5m])` HistogramProjection (already exercised by
+// histogram_native_range_fn.go's own test suite) and reads its
+// HistogramSum/HistogramCount columns directly.
+func TestHistogramValueFnNestedRate_ChDB(t *testing.T) {
+	const metric = "hvfn_nested_rate_exp_hist"
+	seed := hvfnNestedRateDDL +
+		"INSERT INTO otel_metrics_exponential_histogram " +
+		"(MetricName, Attributes, TimeUnix, Count, Sum, Scale, ZeroCount, PositiveOffset, PositiveBucketCounts, NegativeOffset, NegativeBucketCounts) VALUES\n" +
+		"    ('" + metric + "', map('job', 'a'), toDateTime64('2026-01-01 00:00:00', 9), 2, 4.0, 0, 0, 0, [6], 0, []),\n" +
+		"    ('" + metric + "', map('job', 'a'), toDateTime64('2026-01-01 00:04:00', 9), 10, 20.0, 0, 0, 0, [30], 0, []);\n"
+	fixture := newChDBFixture(t, seed)
+
+	s := schema.DefaultOTelMetrics()
+	evalTS := time.Date(2026, 1, 1, 0, 4, 0, 0, time.UTC)
+
+	oracleSumQuery := "rate(" + metric + "[5m])"
+	p := parser.NewParser(parser.Options{EnableExperimentalFunctions: true})
+	oracleExpr, err := p.ParseExpr(oracleSumQuery)
+	if err != nil {
+		t.Fatalf("ParseExpr(oracle): %v", err)
+	}
+	oraclePlan, err := promql.LowerAt(context.Background(), oracleExpr, s, evalTS, evalTS)
+	if err != nil {
+		t.Fatalf("LowerAt(oracle): %v", err)
+	}
+	oracleSQL, oracleArgs, err := chsql.Emit(context.Background(), oraclePlan)
+	if err != nil {
+		t.Fatalf("Emit(oracle): %v", err)
+	}
+	oracleRows := fixture.queryOverEmitted(t, "`HistogramSum` AS sum, `HistogramCount` AS cnt", oracleSQL, oracleArgs)
+	var oracleSum, oracleCount float64
+	var oracleN int
+	for oracleRows.Next() {
+		if err := oracleRows.Scan(&oracleSum, &oracleCount); err != nil {
+			t.Fatalf("scan oracle: %v", err)
+		}
+		oracleN++
+	}
+	if err := testsql.TolerantRowsErr(oracleRows.Err()); err != nil {
+		t.Fatalf("oracle rows.Err: %v", err)
+	}
+	_ = oracleRows.Close()
+	if oracleN != 1 {
+		t.Fatalf("oracle rate() probe: got %d rows, want 1", oracleN)
+	}
+	if oracleSum == 0 || oracleCount == 0 {
+		t.Fatalf("oracle values are degenerate zero — seed data does not exercise rate(): sum=%v count=%v", oracleSum, oracleCount)
+	}
+
+	gotSum := hvfnRunScalar(t, fixture, s, "histogram_sum(rate("+metric+"[5m]))", evalTS)
+	gotCount := hvfnRunScalar(t, fixture, s, "histogram_count(rate("+metric+"[5m]))", evalTS)
+	if gotSum != oracleSum {
+		t.Errorf("histogram_sum(rate(...)) = %v, want %v (rate()'s own HistogramSum)", gotSum, oracleSum)
+	}
+	if gotCount != oracleCount {
+		t.Errorf("histogram_count(rate(...)) = %v, want %v (rate()'s own HistogramCount)", gotCount, oracleCount)
+	}
+}
+
+// TestHistogramQuantileNestedBinop_ChDB proves histogram_quantile(0.5, m1 +
+// m2) — the issue's fourth trigger query — walks the merged bucket ladder
+// the `+` binop produces. The oracle seeds a THIRD metric with the
+// hand-computed merge result (Count/Sum/buckets summed elementwise, same
+// Scale/offset so no scale-fold is needed) as a bare selector, and asserts
+// histogram_quantile over the binop returns the identical value
+// histogram_quantile over the already-merged bare selector does — reusing
+// the extensively-tested bare-selector native quantile path as the oracle
+// rather than hand-deriving the interpolation arithmetic here.
+func TestHistogramQuantileNestedBinop_ChDB(t *testing.T) {
+	const (
+		metricA     = "hvfn_nested_quantile_a_exp_hist"
+		metricB     = "hvfn_nested_quantile_b_exp_hist"
+		premerged   = "hvfn_nested_quantile_merged_exp_hist"
+		queryBinop  = "histogram_quantile(0.5, " + metricA + " + " + metricB + ")"
+		queryOracle = "histogram_quantile(0.5, " + premerged + ")"
+	)
+	seed := subqHistDDL +
+		"INSERT INTO otel_metrics_exponential_histogram " +
+		"(MetricName, Attributes, TimeUnix, Count, Sum, Scale, ZeroCount, PositiveOffset, PositiveBucketCounts, NegativeOffset, NegativeBucketCounts) VALUES\n" +
+		"    ('" + metricA + "', map('svc', 'x'), toDateTime64('2026-01-01 00:01:00', 9), 10, 10.0, 0, 0, 0, [2,3,5], 0, []),\n" +
+		"    ('" + metricB + "', map('svc', 'x'), toDateTime64('2026-01-01 00:01:00', 9), 6, 6.0, 0, 0, 0, [1,2,3], 0, []),\n" +
+		"    ('" + premerged + "', map('svc', 'x'), toDateTime64('2026-01-01 00:01:00', 9), 16, 16.0, 0, 0, 0, [3,5,8], 0, []);\n"
+	fixture := newChDBFixture(t, seed)
+
+	s := schema.DefaultOTelMetrics()
+	evalTS := time.Date(2026, 1, 1, 0, 1, 0, 0, time.UTC)
+
+	gotBinop := hvfnRunScalar(t, fixture, s, queryBinop, evalTS)
+	gotOracle := hvfnRunScalar(t, fixture, s, queryOracle, evalTS)
+	if gotBinop != gotOracle {
+		t.Fatalf("%s = %v, want %v (== %s over the hand-pre-merged distribution)", queryBinop, gotBinop, gotOracle, queryOracle)
+	}
+	// The bucket walk over [3,5,8] (16 observations) at phi=0.5 must land
+	// strictly inside the populated range rather than degenerating to 0 —
+	// pins the oracle itself against a silently-degenerate false-positive
+	// equality (both sides empty/zero would also satisfy gotBinop==gotOracle).
+	if gotBinop <= 0 {
+		t.Fatalf("%s = %v, want a strictly positive quantile", queryBinop, gotBinop)
+	}
+}
+
+// TestHistogramValueFnNestedSetOp_ChDB proves histogram_count(m1 and m2) —
+// a boundary variant beyond the issue's own four named triggers, found
+// while probing this gap's true extent — reads the LHS's own Count for a
+// matched series. Reference Prometheus's `and` never inspects a matched
+// sample's value, so the merged/reduced distribution to read is simply
+// the LHS's own, unlike `+`/sum()/avg()/rate() which combine both sides.
+func TestHistogramValueFnNestedSetOp_ChDB(t *testing.T) {
+	const (
+		metricA = "hvfn_nested_setop_a_exp_hist"
+		metricB = "hvfn_nested_setop_b_exp_hist"
+	)
+	seed := subqHistDDL +
+		"INSERT INTO otel_metrics_exponential_histogram " +
+		"(MetricName, Attributes, TimeUnix, Count, Sum, Scale, ZeroCount, PositiveOffset, PositiveBucketCounts, NegativeOffset, NegativeBucketCounts) VALUES\n" +
+		"    ('" + metricA + "', map('svc', 'x'), toDateTime64('2026-01-01 00:01:00', 9), 9, 9.0, 0, 0, 0, [9], 0, []),\n" +
+		"    ('" + metricB + "', map('svc', 'x'), toDateTime64('2026-01-01 00:01:00', 9), 100, 100.0, 0, 0, 0, [100], 0, []);\n"
+	fixture := newChDBFixture(t, seed)
+
+	s := schema.DefaultOTelMetrics()
+	evalTS := time.Date(2026, 1, 1, 0, 1, 0, 0, time.UTC)
+
+	got := hvfnRunScalar(t, fixture, s, "histogram_count("+metricA+" and "+metricB+")", evalTS)
+	if got != 9 {
+		t.Fatalf("histogram_count(a and b) = %v, want 9 (LHS's own Count, `and` never touches Value)", got)
+	}
+}
+
+// TestHistogramValueFnNestedSumRange_ChDB proves the range-mode fan-out:
+// two distinct grid anchors, each merging a distinct pair of samples,
+// produce two DISTINCT correctly-summed totals rather than one value
+// broadcast across the matrix or every step collapsing onto a single
+// (wrong) timestamp — the regression this fix's Attributes+Timestamp
+// GroupBy threading through lowerHistogramValueFnOverProjection /
+// lowerHistogramQuantileNativeOverProjection guards against.
+func TestHistogramValueFnNestedSumRange_ChDB(t *testing.T) {
+	const metric = "hvfn_nested_sum_range_exp_hist"
+	seed := subqHistDDL +
+		"INSERT INTO otel_metrics_exponential_histogram " +
+		"(MetricName, Attributes, TimeUnix, Count, Sum, Scale, ZeroCount, PositiveOffset, PositiveBucketCounts, NegativeOffset, NegativeBucketCounts) VALUES\n" +
+		"    ('" + metric + "', map('job', 'a'), toDateTime64('2026-01-01 00:01:00', 9), 2, 2.0, 0, 0, 0, [2], 0, []),\n" +
+		"    ('" + metric + "', map('job', 'b'), toDateTime64('2026-01-01 00:01:00', 9), 5, 5.0, 0, 0, 0, [5], 0, []),\n" +
+		"    ('" + metric + "', map('job', 'a'), toDateTime64('2026-01-01 00:02:00', 9), 10, 10.0, 0, 0, 0, [10], 0, []),\n" +
+		"    ('" + metric + "', map('job', 'b'), toDateTime64('2026-01-01 00:02:00', 9), 20, 20.0, 0, 0, 0, [20], 0, []);\n"
+	fixture := newChDBFixture(t, seed)
+
+	s := schema.DefaultOTelMetrics()
+	p := parser.NewParser(parser.Options{EnableExperimentalFunctions: true})
+	start := time.Date(2026, 1, 1, 0, 1, 0, 0, time.UTC)
+	end := time.Date(2026, 1, 1, 0, 2, 0, 0, time.UTC)
+
+	query := "histogram_count(sum(" + metric + "))"
+	expr, err := p.ParseExpr(query)
+	if err != nil {
+		t.Fatalf("ParseExpr(%q): %v", query, err)
+	}
+	plan, err := promql.LowerAtRange(context.Background(), expr, s, start, end, time.Minute)
+	if err != nil {
+		t.Fatalf("LowerAtRange(%q): %v", query, err)
+	}
+	sqlStr, args, err := chsql.Emit(context.Background(), plan)
+	if err != nil {
+		t.Fatalf("Emit(%q): %v", query, err)
+	}
+	rows := fixture.queryOverEmitted(t, "toUnixTimestamp(`TimeUnix`) AS ts, `Value` AS val", sqlStr, args)
+	defer func() { _ = rows.Close() }()
+	got := map[int64]float64{}
+	for rows.Next() {
+		var ts int64
+		var v float64
+		if err := rows.Scan(&ts, &v); err != nil {
+			t.Fatalf("scan: %v", err)
+		}
+		got[ts] = v
+	}
+	if err := testsql.TolerantRowsErr(rows.Err()); err != nil {
+		t.Fatalf("rows.Err: %v", err)
+	}
+	if want := 7.0; got[start.Unix()] != want {
+		t.Errorf("%s: anchor %v = %v, want %v (2+5)", query, start, got[start.Unix()], want)
+	}
+	if want := 30.0; got[end.Unix()] != want {
+		t.Errorf("%s: anchor %v = %v, want %v (10+20)", query, end, got[end.Unix()], want)
+	}
+}

--- a/internal/promql/histogram_value_fns.go
+++ b/internal/promql/histogram_value_fns.go
@@ -99,23 +99,8 @@ func lowerHistogramValueFn(c *parser.Call, s schema.Metrics, ctx lowerCtx) (chpl
 		// selector's own newest-sample collapse does, rather than
 		// treating it as a provably-float pipeline (cerberus issue
 		// #2554).
-		if hist, matched, err := lowerExpHistogramValuedShape(c.Args[vecIdx], s, ctx); matched {
-			if err != nil {
-				return nil, err
-			}
-			// RowShapeOf, not a *chplan.HistogramProjection type
-			// assertion: a set-op operand (histogram_native_set_op.go)
-			// answers histogram-valued as a *chplan.VectorSetOp with
-			// Histogram=true, publishing the identical nine-column
-			// contract under a different node type, and RowShapeOf is
-			// this package's own shared test for "is this the
-			// thirteen-column histogram row shape" across every such
-			// producer (mirrors lowerExpHistogramCountOrGroupOverPlan's
-			// identical check).
-			if chplan.RowShapeOf(hist) != chplan.HistogramRowShape {
-				return nil, fmt.Errorf("promql: internal invariant violated: exp-histogram lowering did not produce a histogram-shaped plan, got %T", hist)
-			}
-			return lowerHistogramValueFnOverProjection(c, hist, s, ctx)
+		if node, matched, err := lowerHistogramValueFnHistogramValuedArg(c, c.Args[vecIdx], s, ctx); matched {
+			return node, err
 		}
 
 		// Float pipelines (aggregations, arithmetic, vector(), …)
@@ -242,6 +227,42 @@ func lowerHistogramValueFnPerSample(
 			{Expr: value, Alias: s.ValueColumn},
 		},
 	}
+}
+
+// lowerHistogramValueFnHistogramValuedArg is lowerHistogramValueFn's own
+// "try the HISTOGRAM-VALUED retry" opt-in, factored out of that function's
+// non-bare-selector branch to keep it a single flat check — mirroring the
+// `if node, ok, err := lowerExpHistogramArgAsCanonicalFloat(...); ok { … }`
+// shape every float-only wrapper in this package already uses at its own
+// callsite (e.g. lowerInstantFn in instant_fns.go) — rather than nesting
+// the match/error/shape checks inline, which golangci-lint's nestif gate
+// flags past a threshold. matched=false leaves the caller's own
+// float-pipeline fallback untouched.
+func lowerHistogramValueFnHistogramValuedArg(
+	c *parser.Call,
+	arg parser.Expr,
+	s schema.Metrics,
+	ctx lowerCtx,
+) (node chplan.Node, matched bool, err error) {
+	hist, matched, err := lowerExpHistogramValuedShape(arg, s, ctx)
+	if !matched {
+		return nil, false, nil
+	}
+	if err != nil {
+		return nil, true, err
+	}
+	// RowShapeOf, not a *chplan.HistogramProjection type assertion: a
+	// set-op operand (histogram_native_set_op.go) answers histogram-valued
+	// as a *chplan.VectorSetOp with Histogram=true, publishing the
+	// identical nine-column contract under a different node type, and
+	// RowShapeOf is this package's own shared test for "is this the
+	// thirteen-column histogram row shape" across every such producer
+	// (mirrors lowerExpHistogramCountOrGroupOverPlan's identical check).
+	if chplan.RowShapeOf(hist) != chplan.HistogramRowShape {
+		return nil, true, fmt.Errorf("promql: internal invariant violated: exp-histogram lowering did not produce a histogram-shaped plan, got %T", hist)
+	}
+	node, err = lowerHistogramValueFnOverProjection(c, hist, s, ctx)
+	return node, true, err
 }
 
 // lowerHistogramValueFnOverProjection is the nested-argument counterpart

--- a/internal/promql/histogram_value_fns.go
+++ b/internal/promql/histogram_value_fns.go
@@ -87,6 +87,37 @@ func lowerHistogramValueFn(c *parser.Call, s schema.Metrics, ctx lowerCtx) (chpl
 	arg := unwrapParens(c.Args[vecIdx])
 	vs, ok := arg.(*parser.VectorSelector)
 	if !ok {
+		// The argument may itself be one of the HISTOGRAM-VALUED shapes
+		// this package already knows how to lower — sum()/avg() over a
+		// native histogram, rate()/increase() over one, a
+		// histogram-histogram binop, a scalar-scaled histogram, …
+		// (isExpHistogramValuedShape / lowerExpHistogramValuedShape,
+		// histogram_native_float_fn.go). Those shapes carry exactly the
+		// merged distribution a bare selector does — sum(m), avg(m),
+		// rate(m[5m]) all answer histogram-valued under reference
+		// Prometheus — so this function reads it the same way a bare
+		// selector's own newest-sample collapse does, rather than
+		// treating it as a provably-float pipeline (cerberus issue
+		// #2554).
+		if hist, matched, err := lowerExpHistogramValuedShape(c.Args[vecIdx], s, ctx); matched {
+			if err != nil {
+				return nil, err
+			}
+			// RowShapeOf, not a *chplan.HistogramProjection type
+			// assertion: a set-op operand (histogram_native_set_op.go)
+			// answers histogram-valued as a *chplan.VectorSetOp with
+			// Histogram=true, publishing the identical nine-column
+			// contract under a different node type, and RowShapeOf is
+			// this package's own shared test for "is this the
+			// thirteen-column histogram row shape" across every such
+			// producer (mirrors lowerExpHistogramCountOrGroupOverPlan's
+			// identical check).
+			if chplan.RowShapeOf(hist) != chplan.HistogramRowShape {
+				return nil, fmt.Errorf("promql: internal invariant violated: exp-histogram lowering did not produce a histogram-shaped plan, got %T", hist)
+			}
+			return lowerHistogramValueFnOverProjection(c, hist, s, ctx)
+		}
+
 		// Float pipelines (aggregations, arithmetic, vector(), …)
 		// provably carry no native-histogram samples; the reference
 		// skips float samples, so fold to the empty vector while
@@ -211,6 +242,43 @@ func lowerHistogramValueFnPerSample(
 			{Expr: value, Alias: s.ValueColumn},
 		},
 	}
+}
+
+// lowerHistogramValueFnOverProjection is the nested-argument counterpart
+// to lowerHistogramValueFnInstant / lowerHistogramValueFnRange: hp is an
+// ALREADY-lowered histogram-valued plan (sum()/avg()/rate()/a
+// histogram-histogram binop/a set-op/…), whose own lowering already
+// resolved instant-vs-range mode, the newest-sample collapse, and (for a
+// merging shape) the cross-series distribution add. Every
+// [chplan.HistogramRowShape] producer (HistogramProjection, a
+// Histogram-flagged VectorSetOp, …) publishes its nine structural
+// columns under the FIXED chplan.Histogram*Column aliases rather than
+// the schema's own raw column names (see chsql's emitHistogramProjection
+// / emitVectorSetOp) — so histogramValueExpr's column references must
+// resolve against [histogramProjectionSchema], not s itself, or they'd
+// name columns hp never publishes. MetricName/Attributes/Timestamp/Value
+// stay under s's own names: those come from hp's GroupByAliases, which
+// every histogram-valued lowering threads from the ORIGINAL schema
+// unchanged (see nativeHistogramProjection).
+func lowerHistogramValueFnOverProjection(
+	c *parser.Call,
+	hp chplan.Node,
+	s schema.Metrics,
+	ctx lowerCtx,
+) (chplan.Node, error) {
+	value, err := histogramValueExpr(c, histogramProjectionSchema(s), ctx)
+	if err != nil {
+		return nil, err
+	}
+	return &chplan.Project{
+		Input: hp,
+		Projections: []chplan.Projection{
+			{Expr: &chplan.LitString{V: ""}, Alias: s.MetricNameColumn},
+			{Expr: &chplan.ColumnRef{Name: s.AttributesColumn}, Alias: s.AttributesColumn},
+			{Expr: &chplan.ColumnRef{Name: s.TimestampColumn}, Alias: s.TimestampColumn},
+			{Expr: value, Alias: s.ValueColumn},
+		},
+	}, nil
 }
 
 // histogramValueLatestAggs renders the per-series newest-sample

--- a/test/rejection-parity/catalogue/internal__promql__histogram_quantile.go.json
+++ b/test/rejection-parity/catalogue/internal__promql__histogram_quantile.go.json
@@ -2,6 +2,31 @@
   "entries": [
     {
       "head": "promql",
+      "site": "internal/promql/histogram_quantile.go:lowerHistogramQuantile#9dc0372b",
+      "message": "promql: internal invariant violated: exp-histogram lowering did not produce a histogram-shaped plan, got %T",
+      "class": "internal",
+      "rationale": "lowerExpHistogramValuedShape's every matched branch (histogram_native_float_fn.go) answers with a producer whose chplan.RowShapeOf is HistogramRowShape — a *chplan.HistogramProjection directly, or a *chplan.VectorSetOp/*chplan.NaryVectorSetOp/*chplan.InfoJoin/*chplan.TopK with its own Histogram flag set, each of which chplan.RowShapeOf recognises as HistogramRowShape by construction (internal/chplan/row_shape.go). matched=true therefore guarantees the shape check below it, so this arm cannot fire for any currently-matched shape.",
+      "evidence": {
+        "guard": [
+          "past returning if len(c.Args) != 2",
+          "past returning if matched \u0026\u0026 histogramAggShapeLowerable(shape, s)",
+          "past returning if matched \u0026\u0026 !s.IsExpHistogramMetric(shape.selector.Name)",
+          "if !isBare",
+          "if hist, matched, err := lowerExpHistogramValuedShape(c.Args[1], s, ctx); matched",
+          "past returning if err != nil",
+          "if chplan.RowShapeOf(hist) != chplan.HistogramRowShape"
+        ],
+        "callers": [
+          "lowerCall",
+          "lowerHistogramQuantiles"
+        ],
+        "cited": [
+          "lowerExpHistogramValuedShape"
+        ]
+      }
+    },
+    {
+      "head": "promql",
       "site": "internal/promql/histogram_quantile.go:lowerHistogramQuantile#afa8cb1f",
       "message": "promql: histogram_quantile expects 2 arguments, got %d",
       "class": "internal",

--- a/test/rejection-parity/catalogue/internal__promql__histogram_quantile.go.json
+++ b/test/rejection-parity/catalogue/internal__promql__histogram_quantile.go.json
@@ -2,31 +2,6 @@
   "entries": [
     {
       "head": "promql",
-      "site": "internal/promql/histogram_quantile.go:lowerHistogramQuantile#9dc0372b",
-      "message": "promql: internal invariant violated: exp-histogram lowering did not produce a histogram-shaped plan, got %T",
-      "class": "internal",
-      "rationale": "lowerExpHistogramValuedShape's every matched branch (histogram_native_float_fn.go) answers with a producer whose chplan.RowShapeOf is HistogramRowShape — a *chplan.HistogramProjection directly, or a *chplan.VectorSetOp/*chplan.NaryVectorSetOp/*chplan.InfoJoin/*chplan.TopK with its own Histogram flag set, each of which chplan.RowShapeOf recognises as HistogramRowShape by construction (internal/chplan/row_shape.go). matched=true therefore guarantees the shape check below it, so this arm cannot fire for any currently-matched shape.",
-      "evidence": {
-        "guard": [
-          "past returning if len(c.Args) != 2",
-          "past returning if matched \u0026\u0026 histogramAggShapeLowerable(shape, s)",
-          "past returning if matched \u0026\u0026 !s.IsExpHistogramMetric(shape.selector.Name)",
-          "if !isBare",
-          "if hist, matched, err := lowerExpHistogramValuedShape(c.Args[1], s, ctx); matched",
-          "past returning if err != nil",
-          "if chplan.RowShapeOf(hist) != chplan.HistogramRowShape"
-        ],
-        "callers": [
-          "lowerCall",
-          "lowerHistogramQuantiles"
-        ],
-        "cited": [
-          "lowerExpHistogramValuedShape"
-        ]
-      }
-    },
-    {
-      "head": "promql",
       "site": "internal/promql/histogram_quantile.go:lowerHistogramQuantile#afa8cb1f",
       "message": "promql: histogram_quantile expects 2 arguments, got %d",
       "class": "internal",
@@ -38,6 +13,26 @@
         "callers": [
           "lowerCall",
           "lowerHistogramQuantiles"
+        ]
+      }
+    },
+    {
+      "head": "promql",
+      "site": "internal/promql/histogram_quantile.go:lowerHistogramQuantileHistogramValuedArg#9dc0372b",
+      "message": "promql: internal invariant violated: exp-histogram lowering did not produce a histogram-shaped plan, got %T",
+      "class": "internal",
+      "rationale": "lowerExpHistogramValuedShape's every matched branch (histogram_native_float_fn.go) answers with a producer whose chplan.RowShapeOf is HistogramRowShape — a *chplan.HistogramProjection directly, or a *chplan.VectorSetOp/*chplan.NaryVectorSetOp/*chplan.InfoJoin/*chplan.TopK with its own Histogram flag set, each of which chplan.RowShapeOf recognises as HistogramRowShape by construction (internal/chplan/row_shape.go). matched=true therefore guarantees the shape check below it, so this arm cannot fire for any currently-matched shape.",
+      "evidence": {
+        "guard": [
+          "past returning if !matched",
+          "past returning if err != nil",
+          "if chplan.RowShapeOf(hist) != chplan.HistogramRowShape"
+        ],
+        "callers": [
+          "lowerHistogramQuantile"
+        ],
+        "cited": [
+          "lowerExpHistogramValuedShape"
         ]
       }
     },

--- a/test/rejection-parity/catalogue/internal__promql__histogram_value_fns.go.json
+++ b/test/rejection-parity/catalogue/internal__promql__histogram_value_fns.go.json
@@ -5,16 +5,18 @@
       "site": "internal/promql/histogram_value_fns.go:histogramValueExpr#1a671757",
       "message": "promql: %s is not a native-histogram value function",
       "class": "internal",
-      "rationale": "Dispatch invariant: lowerCall routes exactly the six native-histogram value-function names here, so the default arm cannot fire from a parseable query.",
+      "rationale": "Dispatch invariant: lowerCall routes exactly the six native-histogram value-function names here, so the default arm cannot fire from a parseable query. lowerHistogramValueFnOverProjection (cerberus issue #2554) is a second caller as of this change, but it receives the identical *parser.Call c the bare-selector path already threads through the same lowerCall dispatch — it does not widen the set of Func.Name values that reach this switch.",
       "evidence": {
         "guard": [
           "past exhaustive switch c.Func.Name over [case \"histogram_count\"; case \"histogram_sum\"; case \"histogram_avg\"; case \"histogram_stddev\"; case \"histogram_stdvar\"; case \"histogram_fraction\"]"
         ],
         "callers": [
-          "lowerHistogramValueFn"
+          "lowerHistogramValueFn",
+          "lowerHistogramValueFnOverProjection"
         ],
         "cited": [
-          "lowerCall"
+          "lowerCall",
+          "lowerHistogramValueFnOverProjection"
         ]
       }
     },
@@ -47,6 +49,27 @@
         ],
         "callers": [
           "lowerCall"
+        ]
+      }
+    },
+    {
+      "head": "promql",
+      "site": "internal/promql/histogram_value_fns.go:lowerHistogramValueFn#9dc0372b",
+      "message": "promql: internal invariant violated: exp-histogram lowering did not produce a histogram-shaped plan, got %T",
+      "class": "internal",
+      "rationale": "lowerExpHistogramValuedShape's every matched branch (histogram_native_float_fn.go) answers with a producer whose chplan.RowShapeOf is HistogramRowShape — a *chplan.HistogramProjection directly, or a *chplan.VectorSetOp/*chplan.NaryVectorSetOp/*chplan.InfoJoin/*chplan.TopK with its own Histogram flag set, each of which chplan.RowShapeOf recognises as HistogramRowShape by construction (internal/chplan/row_shape.go). matched=true therefore guarantees the shape check below it, so this arm cannot fire for any currently-matched shape.",
+      "evidence": {
+        "guard": [
+          "if !ok",
+          "if hist, matched, err := lowerExpHistogramValuedShape(c.Args[vecIdx], s, ctx); matched",
+          "past returning if err != nil",
+          "if chplan.RowShapeOf(hist) != chplan.HistogramRowShape"
+        ],
+        "callers": [
+          "lowerCall"
+        ],
+        "cited": [
+          "lowerExpHistogramValuedShape"
         ]
       }
     }

--- a/test/rejection-parity/catalogue/internal__promql__histogram_value_fns.go.json
+++ b/test/rejection-parity/catalogue/internal__promql__histogram_value_fns.go.json
@@ -54,19 +54,18 @@
     },
     {
       "head": "promql",
-      "site": "internal/promql/histogram_value_fns.go:lowerHistogramValueFn#9dc0372b",
+      "site": "internal/promql/histogram_value_fns.go:lowerHistogramValueFnHistogramValuedArg#9dc0372b",
       "message": "promql: internal invariant violated: exp-histogram lowering did not produce a histogram-shaped plan, got %T",
       "class": "internal",
       "rationale": "lowerExpHistogramValuedShape's every matched branch (histogram_native_float_fn.go) answers with a producer whose chplan.RowShapeOf is HistogramRowShape — a *chplan.HistogramProjection directly, or a *chplan.VectorSetOp/*chplan.NaryVectorSetOp/*chplan.InfoJoin/*chplan.TopK with its own Histogram flag set, each of which chplan.RowShapeOf recognises as HistogramRowShape by construction (internal/chplan/row_shape.go). matched=true therefore guarantees the shape check below it, so this arm cannot fire for any currently-matched shape.",
       "evidence": {
         "guard": [
-          "if !ok",
-          "if hist, matched, err := lowerExpHistogramValuedShape(c.Args[vecIdx], s, ctx); matched",
+          "past returning if !matched",
           "past returning if err != nil",
           "if chplan.RowShapeOf(hist) != chplan.HistogramRowShape"
         ],
         "callers": [
-          "lowerCall"
+          "lowerHistogramValueFn"
         ],
         "cited": [
           "lowerExpHistogramValuedShape"


### PR DESCRIPTION
## Summary

- `histogram_count()`/`histogram_sum()`/`histogram_avg()`/`histogram_quantile()` only recognised a
  bare exponential-histogram selector as their own argument. `sum(m)`, `avg(m)`, `rate(m[5m])`, a
  histogram-histogram binop, and a set-op all answer histogram-valued under reference Prometheus,
  but fell into the generic float-pipeline fallback in `lowerHistogramValueFn`
  (`internal/promql/histogram_value_fns.go`) and `lowerHistogramQuantile`
  (`internal/promql/histogram_quantile.go`), which hit `expHistogramSelectorRouting`'s catch-all
  rejection on the bare selector underneath.
- Threaded `isExpHistogramValuedShape` / `lowerExpHistogramValuedShape` ahead of both fallbacks,
  mirroring the retry every other histogram-aware wrapper in this package already performs, and
  added `lowerHistogramValueFnOverProjection` / `lowerHistogramQuantileNativeOverProjection` to feed
  the already-lowered histogram-shaped plan into the existing value/quantile machinery.
- A histogram-valued plan's nine structural columns publish under the FIXED
  `chplan.Histogram*Column` aliases, not the schema's own raw column names — reading them via the raw
  schema would reference columns the plan never emits (a real `UNKNOWN_IDENTIFIER` at ClickHouse
  execution, invisible to a Go-only lowering check). Both new helpers read through
  `histogramProjectionSchema` instead.
- The type of the already-lowered plan isn't always `*chplan.HistogramProjection` — a set-op operand
  (`histogram_native_set_op.go`) answers histogram-valued as a `*chplan.VectorSetOp` with
  `Histogram=true`, publishing the identical nine-column contract under a different node type — so
  both new callsites check `chplan.RowShapeOf(hist) == chplan.HistogramRowShape` instead of a
  `*chplan.HistogramProjection` type assertion.

## Probing the boundary

All four of the issue's own trigger queries were confirmed rejecting on `origin/main`, and are fixed:

- `histogram_count(sum(demo_latency_exp_hist))`
- `histogram_sum(rate(demo_latency_exp_hist[5m]))`
- `histogram_avg(avg(demo_latency_exp_hist))`
- `histogram_quantile(0.5, demo_latency_exp_hist + demo_latency_exp_hist2)`

Further boundary probing found:

- `histogram_count(<hist> * 2)` / `histogram_count(2 * <hist>)` were previously silently WRONG (not
  rejecting, but folding to an empty result instead of the correctly-scaled count) — now fixed as a
  side effect of the same routing change.
- `histogram_count(<histA> and <histB>)` (a set-op operand) is now also correctly answered — this
  is what surfaced the `RowShapeOf` vs. type-assertion issue above.
- `(<histA> and <histB>) * 2` still hits a genuine, PRE-EXISTING "internal invariant violated" panic
  in `histogram_native_scalar_binop.go`'s `lowerExpHistogramScalarBinop` — confirmed unaffected by
  this PR (reproduces identically on `origin/main`); out of scope here.
- `histogram_count(count(<hist>))`, `histogram_count(resets(<hist>[5m]))`,
  `histogram_count(changes(<hist>[5m]))` still reject — these are `count()`/`resets()`/`changes()`
  nested-recognition gaps tracked by issue #2549 (in flight), not this issue's `isExpHistogramValuedShape`
  gap; confirmed the rejection-parity catalogue's `expHistogramSelectorRouting#bf746b59` entry (trigger
  `resets(demo_latency_exp_hist[5m]) * 2`, `tracking_issue: 2549`) is unaffected by this change —
  `TestRejectionTriggersExerciseSites` still reproduces it at the same site, so no rotation was made
  here; #2549's own PR is what rotates that entry.

## Testing

- New chDB-backed tests (`internal/promql/histogram_value_fn_nested_arg_chdb_test.go`) prove all four
  trigger queries — plus the range-mode fan-out and the set-op case above — against real ClickHouse
  execution with hand-computed or independently-oracle-verified numeric results (not just "no error"):
  `TestHistogramValueFnNestedSum_ChDB`, `TestHistogramValueFnNestedRate_ChDB`,
  `TestHistogramQuantileNestedBinop_ChDB`, `TestHistogramValueFnNestedSetOp_ChDB`,
  `TestHistogramValueFnNestedSumRange_ChDB`.
- Rotated the two rejection-parity catalogue entries this diff's error sites introduced
  (`internal__promql__histogram_value_fns.go.json`, `internal__promql__histogram_quantile.go.json`)
  via `CERBERUS_UPDATE_INVENTORY=1 go test -run TestCatalogueIsRegenerable ./test/rejection-parity/...`,
  curated both as `class: internal` (unreachable defensive guards — every `lowerExpHistogramValuedShape`
  match answers `HistogramRowShape` by construction), and confirmed
  `TestCatalogueEntriesAreClassified` / `TestInternalRationalesRestOnCurrentEvidence` /
  `TestRejectionTriggersExerciseSites` / `TestParityCorpusMatchesCatalogue` all still pass.
- `go build ./...`, `go vet ./internal/promql/... ./test/rejection-parity/...`, `go test -race
  ./internal/promql/...`, and the relevant `test/spec/promql` histogram fixtures (35 fixtures, chDB
  round-trip) all pass unchanged — no golden regeneration was needed.
- `node .github/scripts/forbid-sql-raw.mjs` passes.

Closes #2554
