### PR TITLE
fix(promql): accept a set-op operand in the exp-histogram +/-/==/!= binops

### DIFF
--- a/internal/promql/histogram_native_binop.go
+++ b/internal/promql/histogram_native_binop.go
@@ -163,9 +163,25 @@ func lowerExpHistogramHistogramBinop(lhsExpr, rhsExpr parser.Expr, sub bool, vm 
 }
 
 // lowerExpHistogramValuedOperand lowers one binop operand through its own
-// histogram-valued recogniser and asserts the shared HistogramProjection
-// cap every such lowering publishes.
-func lowerExpHistogramValuedOperand(expr parser.Expr, s schema.Metrics, ctx lowerCtx) (*chplan.HistogramProjection, error) {
+// histogram-valued recogniser and asserts the shared histogram-shaped
+// output contract every such lowering publishes.
+//
+// This accepts any histogram-shaped [chplan.Node] — not literally a
+// *chplan.HistogramProjection — mirroring
+// [lowerExpHistogramSetOpOperand] (histogram_native_set_op.go): an
+// operand can itself be a *chplan.VectorSetOp (a nested `and`/`or`/
+// `unless`, cerberus issue #2324) or, for the scalar-vector scaling
+// family, a *chplan.HistogramFloatVectorJoin, and every consumer below
+// this call (mergeTwoHistogramProjections and its Card sibling,
+// compareTwoHistogramProjections and its Card/bool siblings,
+// applyVectorMatchToHistogramOperand, the two drop-family lowerings)
+// only ever reads its operands by the canonical Sample column names
+// plus the fixed Histogram*Column aliases — never by Go type — so a
+// concrete *chplan.HistogramProjection was never required, merely
+// assumed (cerberus issue #2559: `(<histA> and <histB>) + (<histC> and
+// <histD>)` used to leak this assumption as an "internal invariant
+// violated" error instead of lowering correctly).
+func lowerExpHistogramValuedOperand(expr parser.Expr, s schema.Metrics, ctx lowerCtx) (chplan.Node, error) {
 	node, matched, err := lowerExpHistogramValuedShape(expr, s, ctx)
 	if err != nil {
 		return nil, err
@@ -173,11 +189,13 @@ func lowerExpHistogramValuedOperand(expr parser.Expr, s schema.Metrics, ctx lowe
 	if !matched {
 		return nil, fmt.Errorf("promql: internal invariant violated: exp-histogram binop operand matched no known histogram-valued shape for %v", expr)
 	}
-	hp, ok := node.(*chplan.HistogramProjection)
-	if !ok {
-		return nil, fmt.Errorf("promql: internal invariant violated: exp-histogram binop operand lowering did not cap with *chplan.HistogramProjection, got %T", node)
+	if chplan.RowShapeOf(node) != chplan.HistogramRowShape {
+		return nil, fmt.Errorf(
+			"promql: internal invariant violated: exp-histogram binop operand lowering published %s row shape (%T), want %s",
+			chplan.RowShapeOf(node), node, chplan.HistogramRowShape,
+		)
 	}
-	return hp, nil
+	return node, nil
 }
 
 // expHistogramDroppingHistogramBinop recognises `<exp-hist shape> OP
@@ -230,10 +248,11 @@ func expHistogramHistogramBinopDrops(op parser.ItemType) bool {
 // unmodified, exactly as [lowerExpHistogramHistogramBinop] does for the
 // merge shape — so a nested lowering error in either operand still
 // surfaces normally rather than being silently swallowed by the drop.
-// Only the LHS's HistogramProjection caps the resulting constant-false
-// Filter; which side is chosen is arbitrary; since every row is filtered
-// out, cerberus never uses the RHS lowering's rows, but the RHS lowering
-// still runs so its own errors are still caught before the drop applies.
+// Only the LHS's histogram-shaped lowering caps the resulting
+// constant-false Filter; which side is chosen is arbitrary; since every
+// row is filtered out, cerberus never uses the RHS lowering's rows, but
+// the RHS lowering still runs so its own errors are still caught before
+// the drop applies.
 func lowerExpHistogramDroppingHistogramBinop(lhsExpr, rhsExpr parser.Expr, s schema.Metrics, ctx lowerCtx) (chplan.Node, error) {
 	hpL, err := lowerExpHistogramValuedOperand(lhsExpr, s, ctx)
 	if err != nil {
@@ -255,7 +274,15 @@ func lowerExpHistogramDroppingHistogramBinop(lhsExpr, rhsExpr parser.Expr, s sch
 // reconciliation the cross-series merges apply. See this file's doc for
 // why the join collapses to a `having count() = 2` guard rather than a
 // VectorJoin.
-func mergeTwoHistogramProjections(hpL, hpR *chplan.HistogramProjection, s schema.Metrics, ctx lowerCtx) chplan.Node {
+//
+// hpL/hpR are typed as plain chplan.Node — not *chplan.HistogramProjection —
+// because [lowerExpHistogramValuedOperand] now accepts any histogram-shaped
+// operand (cerberus issue #2559); every reference to either operand below
+// reads it by the fixed Histogram*Column aliases through the UnionAll's
+// column-name-matched output, never via a Go struct field, so a
+// *chplan.VectorSetOp operand composes exactly like a
+// *chplan.HistogramProjection one.
+func mergeTwoHistogramProjections(hpL, hpR chplan.Node, s schema.Metrics, ctx lowerCtx) chplan.Node {
 	histSchema := histogramProjectionSchema(s)
 	groupBy, groupByAliases, attrsRebuild := histogramAggGroupBy(
 		nil, &chplan.ColumnRef{Name: histSchema.AttributesColumn}, histSchema,

--- a/internal/promql/histogram_native_binop_card.go
+++ b/internal/promql/histogram_native_binop_card.go
@@ -120,8 +120,13 @@ func histogramCardFromVectorMatching(vm *parser.VectorMatching) chplan.VectorCar
 }
 
 // newHistogramVectorJoin builds the chplan.HistogramVectorJoin both the
-// merge and compare card paths share.
-func newHistogramVectorJoin(hpL, hpR *chplan.HistogramProjection, vm *parser.VectorMatching, s schema.Metrics, ctx lowerCtx) *chplan.HistogramVectorJoin {
+// merge and compare card paths share. hpL/hpR are plain chplan.Node —
+// [chplan.HistogramVectorJoin.Left]/[.Right] are typed Node themselves, and
+// its own emitter reads both sides by column name through a subquery
+// boundary (internal/chsql's histogramFieldsJoinSideFrag), so a set-op
+// operand (*chplan.VectorSetOp, cerberus issue #2559) composes exactly like
+// a *chplan.HistogramProjection one.
+func newHistogramVectorJoin(hpL, hpR chplan.Node, vm *parser.VectorMatching, s schema.Metrics, ctx lowerCtx) *chplan.HistogramVectorJoin {
 	return &chplan.HistogramVectorJoin{
 		Left:             hpL,
 		Right:            hpR,
@@ -163,7 +168,7 @@ func histJoinArrayPair(col string) chplan.Expr {
 // wrapping Project, so histogramBinopMergeProjections needs no changes at
 // all — it cannot tell the difference between a two-row aggregation and a
 // two-element array literal.
-func mergeTwoHistogramProjectionsCard(hpL, hpR *chplan.HistogramProjection, vm *parser.VectorMatching, s schema.Metrics, ctx lowerCtx) chplan.Node {
+func mergeTwoHistogramProjectionsCard(hpL, hpR chplan.Node, vm *parser.VectorMatching, s schema.Metrics, ctx lowerCtx) chplan.Node {
 	histSchema := histogramProjectionSchema(s)
 	join := newHistogramVectorJoin(hpL, hpR, vm, s, ctx)
 	stepAligned := ctx.step > 0
@@ -263,7 +268,7 @@ func histogramCompareOutputProjectionsCard(s schema.Metrics) []chplan.Projection
 // function's doc for the returnBool branch's genuinely different output
 // shape (float-valued 1.0/0.0 vs. the non-bool structural filter's
 // histogram-valued LHS passthrough) — both apply identically here.
-func compareTwoHistogramProjectionsCard(hpL, hpR *chplan.HistogramProjection, vm *parser.VectorMatching, ne, returnBool bool, s schema.Metrics, ctx lowerCtx) chplan.Node {
+func compareTwoHistogramProjectionsCard(hpL, hpR chplan.Node, vm *parser.VectorMatching, ne, returnBool bool, s schema.Metrics, ctx lowerCtx) chplan.Node {
 	histSchema := histogramProjectionSchema(s)
 	join := newHistogramVectorJoin(hpL, hpR, vm, s, ctx)
 	stepAligned := ctx.step > 0

--- a/internal/promql/histogram_native_binop_eq.go
+++ b/internal/promql/histogram_native_binop_eq.go
@@ -261,7 +261,13 @@ const (
 //     dropped to "", matching reference's dropMetricName rule for a
 //     `bool`-modified V-V binop) rather than a HistogramProjection: the
 //     result is FLOAT-valued, not histogram-valued.
-func compareTwoHistogramProjections(hpL, hpR *chplan.HistogramProjection, ne, returnBool bool, s schema.Metrics, ctx lowerCtx) chplan.Node {
+//
+// hpL/hpR are typed as plain chplan.Node — not *chplan.HistogramProjection
+// — so a set-op operand (*chplan.VectorSetOp, cerberus issue #2559)
+// composes here too: [projectHistogramCompareSide] reads every field off
+// each side by its fixed Histogram*Column alias, never via a Go struct
+// field.
+func compareTwoHistogramProjections(hpL, hpR chplan.Node, ne, returnBool bool, s schema.Metrics, ctx lowerCtx) chplan.Node {
 	histSchema := histogramProjectionSchema(s)
 	stepAligned := ctx.step > 0
 
@@ -337,7 +343,7 @@ func compareTwoHistogramProjections(hpL, hpR *chplan.HistogramProjection, ne, re
 // mode), and every field [histogramCompareFieldColumns] names — plus the
 // literal [histEqSideAlias] discriminator, so both operands expose an
 // IDENTICAL column set/order for the UnionAll below to combine.
-func projectHistogramCompareSide(hp *chplan.HistogramProjection, side int64, histSchema schema.Metrics, stepAligned bool) *chplan.Project {
+func projectHistogramCompareSide(hp chplan.Node, side int64, histSchema schema.Metrics, stepAligned bool) *chplan.Project {
 	cols := []string{histSchema.MetricNameColumn, histSchema.AttributesColumn}
 	if stepAligned {
 		cols = append(cols, histSchema.TimestampColumn)

--- a/internal/promql/histogram_native_binop_match.go
+++ b/internal/promql/histogram_native_binop_match.go
@@ -18,8 +18,9 @@ import (
 // histogram_native_binop_card.go (cerberus issue #2328).
 //
 // Both callers already collapse each operand to one row per FULL
-// Attributes key ([lowerExpHistogramValuedOperand]'s
-// *chplan.HistogramProjection cap) before merging/comparing the two
+// Attributes key ([lowerExpHistogramValuedOperand]'s histogram-shaped
+// cap — a *chplan.HistogramProjection, or since cerberus issue #2559 a
+// nested *chplan.VectorSetOp) before merging/comparing the two
 // sides via a `UnionAll` + single `Aggregate` grouped on the (by
 // default, full) Attributes column with a `having count() = 2` guard
 // standing in for VectorJoin's INNER JOIN (see histogram_native_binop.go's
@@ -80,7 +81,16 @@ func histogramMatchKeyAggExpr(vm *parser.VectorMatching) *parser.AggregateExpr {
 // "guard-then-any" pattern [duplicate_labelset_guard.go] and
 // [duplicateLabelsetGuardExpr] apply for the unrelated name-drop /
 // label-rewrite collision guards.
-func applyVectorMatchToHistogramOperand(hp *chplan.HistogramProjection, vm *parser.VectorMatching, s schema.Metrics, ctx lowerCtx) *chplan.HistogramProjection {
+//
+// hp is typed as a plain chplan.Node — not *chplan.HistogramProjection —
+// so a set-op operand (*chplan.VectorSetOp, cerberus issue #2559) composes
+// here too: every field this function reads off hp is read by its fixed
+// Histogram*Column alias through the wrapping Aggregate's Input, never via
+// a Go struct field, so hp's concrete type never mattered structurally,
+// only its published column shape (chplan.HistogramRowShape) does — the
+// same contract [lowerExpHistogramValuedOperand] now enforces on every
+// caller's behalf.
+func applyVectorMatchToHistogramOperand(hp chplan.Node, vm *parser.VectorMatching, s schema.Metrics, ctx lowerCtx) chplan.Node {
 	if isDefaultMatching(vm) {
 		return hp
 	}

--- a/internal/promql/histogram_native_binop_match_test.go
+++ b/internal/promql/histogram_native_binop_match_test.go
@@ -40,8 +40,12 @@ func TestApplyVectorMatchToHistogramOperand_AddsAmbiguityGuard(t *testing.T) {
 	hp := &chplan.HistogramProjection{Input: &chplan.Scan{Table: s.ExpHistogramTable}}
 	vm := &parser.VectorMatching{Card: parser.CardOneToOne, On: true, MatchingLabels: []string{"service"}}
 
-	prepHP := applyVectorMatchToHistogramOperand(hp, vm, s, lowerCtx{})
+	prepared := applyVectorMatchToHistogramOperand(hp, vm, s, lowerCtx{})
 
+	prepHP, ok := prepared.(*chplan.HistogramProjection)
+	if !ok {
+		t.Fatalf("applyVectorMatchToHistogramOperand(...) = %T, want *chplan.HistogramProjection", prepared)
+	}
 	reshape, ok := prepHP.Input.(*chplan.Project)
 	if !ok {
 		t.Fatalf("prepared HistogramProjection.Input is %T, want *chplan.Project", prepHP.Input)

--- a/internal/promql/histogram_native_binop_setop_operand_chdb_test.go
+++ b/internal/promql/histogram_native_binop_setop_operand_chdb_test.go
@@ -1,0 +1,288 @@
+//go:build chdb
+
+// chDB-backed proof that cerberus issue #2559's fix — accepting a
+// *chplan.VectorSetOp operand in the `+`/`-`/`==`/`!=` exp-histogram
+// binop lowerings, not just a literal *chplan.HistogramProjection — is
+// not merely a Go-level type-check loosening: the emitted SQL actually
+// EXECUTES against real ClickHouse and produces the correct values.
+//
+// TestExpHistogramBinopSetOpOperand_MergeDifferentLayout_ChDB mirrors
+// histogram_native_mixed_or_vector_hist_merge_chdb_test.go's own
+// different-Scale / different-PositiveOffset fixture (reusing the exact
+// same numbers) — that file proves the `+`/`-` merge reconciles two
+// different bucket layouts when the operands are MIXED float/histogram
+// `or` arms; this file proves the same reconciliation when the operands
+// are pure (non-mixed) `and` set-ops, the shape #2559 reports.
+package promql_test
+
+import (
+	"context"
+	"fmt"
+	"math"
+	"testing"
+	"time"
+
+	"github.com/prometheus/prometheus/promql/parser"
+
+	"github.com/tsouza/cerberus/internal/chsql"
+	"github.com/tsouza/cerberus/internal/promql"
+	"github.com/tsouza/cerberus/internal/schema"
+	"github.com/tsouza/cerberus/internal/testsql"
+)
+
+const setOpOperandBinopSeedDDL = "" +
+	"CREATE OR REPLACE TABLE otel_metrics_exponential_histogram (" +
+	"`MetricName` String, `Attributes` Map(String, String), " +
+	"`ResourceAttributes` Map(String, String) DEFAULT map(), `ServiceName` LowCardinality(String) DEFAULT '', " +
+	"`TimeUnix` DateTime64(9), " +
+	"`Count` UInt64, `Sum` Float64, `Scale` Int32, `ZeroCount` UInt64, " +
+	"`PositiveOffset` Int32, `PositiveBucketCounts` Array(UInt64), " +
+	"`NegativeOffset` Int32, `NegativeBucketCounts` Array(UInt64)" +
+	") ENGINE = MergeTree ORDER BY (`MetricName`, `Attributes`, `TimeUnix`);\n"
+
+var setOpOperandBinopEvalTS = time.Date(2026, 1, 1, 0, 0, 1, 0, time.UTC)
+
+// setOpOperandBinopRow renders one INSERT VALUES tuple.
+func setOpOperandBinopRow(metric, series string, scale int, zeroCount, count int64, sum float64, offset int, buckets string) string {
+	return fmt.Sprintf(
+		"('%s', map('series', '%s'), toDateTime64('2026-01-01 00:00:00', 9), %d, %s, %d, %d, %d, %s, 0, [])",
+		metric, series, count, ftoaLit(sum), scale, zeroCount, offset, buckets,
+	)
+}
+
+// ftoaLit renders a float64 as a ClickHouse-parseable numeric literal
+// with a decimal point, matching the other exp-histogram chDB fixtures'
+// own inline `10.0` / `50.0` style.
+func ftoaLit(v float64) string {
+	return fmt.Sprintf("%g", v)
+}
+
+// TestExpHistogramBinopSetOpOperand_MergeDifferentLayout_ChDB seeds two
+// `and`-composed operands — `(lhs1 and lhs2) + (rhs1 and rhs2)` — whose
+// SURVIVING rows (lhs1's own, rhs1's own — `and` never merges values,
+// only filters by label signature) sit at DIFFERENT Scale AND different
+// PositiveOffset, so the assertions below only pass if the binop merge
+// actually downscales the finer operand's bucket indices onto the
+// coarser one's scale before summing.
+func TestExpHistogramBinopSetOpOperand_MergeDifferentLayout_ChDB(t *testing.T) {
+	const (
+		lhs1 = "hb_so_merge_lhs1_exp_hist"
+		lhs2 = "hb_so_merge_lhs2_exp_hist"
+		rhs1 = "hb_so_merge_rhs1_exp_hist"
+		rhs2 = "hb_so_merge_rhs2_exp_hist"
+	)
+	var seed string
+	seed += setOpOperandBinopSeedDDL
+	seed += "INSERT INTO otel_metrics_exponential_histogram " +
+		"(MetricName, Attributes, TimeUnix, Count, Sum, Scale, ZeroCount, PositiveOffset, PositiveBucketCounts, NegativeOffset, NegativeBucketCounts) VALUES\n" +
+		// LHS `and` pair, series "x": lhs1's own row survives (Scale=0,
+		// PositiveOffset=1, buckets=[10,20], matching mvvMergeSeed's LHS).
+		"    " + setOpOperandBinopRow(lhs1, "x", 0, 3, 30, 100.0, 1, "[10, 20]") + ",\n" +
+		"    " + setOpOperandBinopRow(lhs2, "x", 0, 0, 1, 1.0, 0, "[1]") + ",\n" +
+		// RHS `and` pair, series "x": rhs1's own row survives (Scale=1,
+		// PositiveOffset=2, buckets=[5,7,9], matching mvvMergeSeed's RHS).
+		"    " + setOpOperandBinopRow(rhs1, "x", 1, 4, 21, 50.0, 2, "[5, 7, 9]") + ",\n" +
+		"    " + setOpOperandBinopRow(rhs2, "x", 1, 0, 1, 1.0, 0, "[1]") + ";\n"
+
+	fixture := newChDBFixture(t, seed)
+	s := schema.DefaultOTelMetrics()
+	p := parser.NewParser(parser.Options{EnableExperimentalFunctions: true})
+
+	lhsExpr := "(" + lhs1 + " and " + lhs2 + ")"
+	rhsExpr := "(" + rhs1 + " and " + rhs2 + ")"
+
+	run := func(t *testing.T, query string) setOpOperandMergeRow {
+		t.Helper()
+		expr, err := p.ParseExpr(query)
+		if err != nil {
+			t.Fatalf("ParseExpr(%q): %v", query, err)
+		}
+		plan, err := promql.LowerAt(context.Background(), expr, s, setOpOperandBinopEvalTS, setOpOperandBinopEvalTS)
+		if err != nil {
+			t.Fatalf("LowerAt(%q): unexpected error (this exact shape used to leak \"internal invariant violated\" — cerberus issue #2559): %v", query, err)
+		}
+		sqlStr, args, err := chsql.Emit(context.Background(), plan)
+		if err != nil {
+			t.Fatalf("Emit(%q): %v", query, err)
+		}
+
+		projection := "`HistogramCount` AS cnt, `HistogramSum` AS sum, `HistogramScale` AS scale, " +
+			"`HistogramZeroCount` AS zero_count, " +
+			"`HistogramPositiveOffset` AS pos_offset, " +
+			"`HistogramPositiveBucketCounts`[1] AS pos_b1, `HistogramPositiveBucketCounts`[2] AS pos_b2, " +
+			"`HistogramNegativeOffset` AS neg_offset, length(`HistogramNegativeBucketCounts`) AS neg_len"
+
+		rows := fixture.queryOverEmitted(t, projection, sqlStr, args)
+		defer func() { _ = rows.Close() }()
+		if !rows.Next() {
+			t.Fatalf("query(%q): no rows, want exactly one merged row for series \"x\"", query)
+		}
+		var r setOpOperandMergeRow
+		if err := rows.Scan(&r.cnt, &r.sum, &r.scale, &r.zeroCount, &r.posOffset, &r.posBucket1, &r.posBucket2, &r.negOffset, &r.negBucketsLen); err != nil {
+			t.Fatalf("scan: %v", err)
+		}
+		if rows.Next() {
+			t.Fatalf("query(%q): got more than one row, want exactly one", query)
+		}
+		if err := testsql.TolerantRowsErr(rows.Err()); err != nil {
+			t.Fatalf("rows.Err: %v", err)
+		}
+		return r
+	}
+
+	t.Run("+", func(t *testing.T) {
+		r := run(t, lhsExpr+" + "+rhsExpr)
+		assertFloatEq(t, "HistogramCount", r.cnt, 30.0+21.0)
+		assertFloatEq(t, "HistogramSum", r.sum, 100.0+50.0)
+		if r.scale != 0 {
+			t.Errorf("HistogramScale = %d, want 0 (min(0,1), the coarser operand's scale)", r.scale)
+		}
+		assertFloatEq(t, "HistogramZeroCount", r.zeroCount, 3.0+4.0)
+		if r.posOffset != 1 {
+			t.Errorf("HistogramPositiveOffset = %d, want 1", r.posOffset)
+		}
+		// index1 = lhs1[1]=10 + rhs1 downscaled (idx2,idx3 -> idx1)=5+7=12 -> 22.
+		assertFloatEq(t, "HistogramPositiveBucketCounts[1]", r.posBucket1, 22.0)
+		// index2 = lhs1[2]=20 + rhs1 downscaled (idx4 -> idx2)=9 -> 29.
+		assertFloatEq(t, "HistogramPositiveBucketCounts[2]", r.posBucket2, 29.0)
+		if r.negOffset != 0 || r.negBucketsLen != 0 {
+			t.Errorf("negative ladder = (offset=%d, len=%d), want (0, 0)", r.negOffset, r.negBucketsLen)
+		}
+	})
+
+	t.Run("-", func(t *testing.T) {
+		r := run(t, lhsExpr+" - "+rhsExpr)
+		assertFloatEq(t, "HistogramCount", r.cnt, 30.0-21.0)
+		assertFloatEq(t, "HistogramSum", r.sum, 100.0-50.0)
+		if r.scale != 0 {
+			t.Errorf("HistogramScale = %d, want 0", r.scale)
+		}
+		assertFloatEq(t, "HistogramZeroCount", r.zeroCount, 3.0-4.0)
+		if r.posOffset != 1 {
+			t.Errorf("HistogramPositiveOffset = %d, want 1", r.posOffset)
+		}
+		// index1 = lhs1[1]=10 - rhs1 downscaled(idx2,idx3->idx1)=5+7=12 -> -2.
+		assertFloatEq(t, "HistogramPositiveBucketCounts[1]", r.posBucket1, -2.0)
+		// index2 = lhs1[2]=20 - rhs1 downscaled(idx4->idx2)=9 -> 11.
+		assertFloatEq(t, "HistogramPositiveBucketCounts[2]", r.posBucket2, 11.0)
+	})
+}
+
+type setOpOperandMergeRow struct {
+	cnt, sum      float64
+	scale         int64
+	zeroCount     float64
+	posOffset     int64
+	posBucket1    float64
+	posBucket2    float64
+	negOffset     int64
+	negBucketsLen int64
+}
+
+func assertFloatEq(t *testing.T, name string, got, want float64) {
+	t.Helper()
+	if math.Abs(got-want) > 1e-9 {
+		t.Errorf("%s = %v, want %v", name, got, want)
+	}
+}
+
+// TestExpHistogramBinopSetOpOperand_Equality_ChDB proves the `==`/`!=`
+// structural-equality filter over two `and`-composed operands correctly
+// keeps/drops each series and forwards the LHS's OWN histogram value
+// (not a merge) — pinning both cerberus issue #2559 (the lowering no
+// longer errors) and the pre-existing #2273 structural-equality contract
+// still holds when the operand is a set-op.
+func TestExpHistogramBinopSetOpOperand_Equality_ChDB(t *testing.T) {
+	const (
+		lhs1 = "hb_so_eq_lhs1_exp_hist"
+		lhs2 = "hb_so_eq_lhs2_exp_hist"
+		rhs1 = "hb_so_eq_rhs1_exp_hist"
+		rhs2 = "hb_so_eq_rhs2_exp_hist"
+	)
+	var seed string
+	seed += setOpOperandBinopSeedDDL
+	seed += "INSERT INTO otel_metrics_exponential_histogram " +
+		"(MetricName, Attributes, TimeUnix, Count, Sum, Scale, ZeroCount, PositiveOffset, PositiveBucketCounts, NegativeOffset, NegativeBucketCounts) VALUES\n" +
+		// series "same": lhs1 and rhs1 publish BIT-IDENTICAL rows.
+		"    " + setOpOperandBinopRow(lhs1, "same", 0, 0, 5, 10.0, 0, "[5]") + ",\n" +
+		"    " + setOpOperandBinopRow(lhs2, "same", 0, 0, 1, 1.0, 0, "[1]") + ",\n" +
+		"    " + setOpOperandBinopRow(rhs1, "same", 0, 0, 5, 10.0, 0, "[5]") + ",\n" +
+		"    " + setOpOperandBinopRow(rhs2, "same", 0, 0, 1, 1.0, 0, "[1]") + ",\n" +
+		// series "diff": lhs1 and rhs1 disagree (different Count/Sum/bucket).
+		"    " + setOpOperandBinopRow(lhs1, "diff", 0, 0, 5, 10.0, 0, "[5]") + ",\n" +
+		"    " + setOpOperandBinopRow(lhs2, "diff", 0, 0, 1, 1.0, 0, "[1]") + ",\n" +
+		"    " + setOpOperandBinopRow(rhs1, "diff", 0, 0, 7, 14.0, 0, "[7]") + ",\n" +
+		"    " + setOpOperandBinopRow(rhs2, "diff", 0, 0, 1, 1.0, 0, "[1]") + ";\n"
+
+	fixture := newChDBFixture(t, seed)
+	s := schema.DefaultOTelMetrics()
+	p := parser.NewParser(parser.Options{EnableExperimentalFunctions: true})
+
+	lhsExpr := "(" + lhs1 + " and " + lhs2 + ")"
+	rhsExpr := "(" + rhs1 + " and " + rhs2 + ")"
+
+	// series label survives as a Map value, which chdb-go's parquet
+	// driver cannot decode directly — read it back via toJSONString, the
+	// same workaround emitVectorSetOp's own doc comment describes.
+	projection := "`HistogramCount` AS cnt, `HistogramSum` AS sum, " +
+		"`HistogramPositiveBucketCounts`[1] AS pos_b1, toJSONString(Attributes) AS attrs_json"
+
+	type row struct {
+		cnt, sum float64
+		posB1    float64
+		attrs    string
+	}
+	runRows := func(t *testing.T, query string) []row {
+		t.Helper()
+		expr, err := p.ParseExpr(query)
+		if err != nil {
+			t.Fatalf("ParseExpr(%q): %v", query, err)
+		}
+		plan, err := promql.LowerAt(context.Background(), expr, s, setOpOperandBinopEvalTS, setOpOperandBinopEvalTS)
+		if err != nil {
+			t.Fatalf("LowerAt(%q): unexpected error: %v", query, err)
+		}
+		sqlStr, args, err := chsql.Emit(context.Background(), plan)
+		if err != nil {
+			t.Fatalf("Emit(%q): %v", query, err)
+		}
+		rows := fixture.queryOverEmitted(t, projection, sqlStr, args)
+		defer func() { _ = rows.Close() }()
+		var out []row
+		for rows.Next() {
+			var r row
+			if err := rows.Scan(&r.cnt, &r.sum, &r.posB1, &r.attrs); err != nil {
+				t.Fatalf("scan: %v", err)
+			}
+			out = append(out, r)
+		}
+		if err := testsql.TolerantRowsErr(rows.Err()); err != nil {
+			t.Fatalf("rows.Err: %v", err)
+		}
+		return out
+	}
+
+	t.Run("==", func(t *testing.T) {
+		rows := runRows(t, lhsExpr+" == "+rhsExpr)
+		if len(rows) != 1 {
+			t.Fatalf("== returned %d rows, want exactly 1 (only series \"same\" structurally matches)", len(rows))
+		}
+		r := rows[0]
+		assertFloatEq(t, "HistogramCount", r.cnt, 5.0)
+		assertFloatEq(t, "HistogramSum", r.sum, 10.0)
+		assertFloatEq(t, "HistogramPositiveBucketCounts[1]", r.posB1, 5.0)
+	})
+
+	t.Run("!=", func(t *testing.T) {
+		rows := runRows(t, lhsExpr+" != "+rhsExpr)
+		if len(rows) != 1 {
+			t.Fatalf("!= returned %d rows, want exactly 1 (only series \"diff\" structurally mismatches)", len(rows))
+		}
+		r := rows[0]
+		// != forwards the LHS's own row unchanged, NOT the RHS's — even
+		// though the two disagree.
+		assertFloatEq(t, "HistogramCount", r.cnt, 5.0)
+		assertFloatEq(t, "HistogramSum", r.sum, 10.0)
+		assertFloatEq(t, "HistogramPositiveBucketCounts[1]", r.posB1, 5.0)
+	})
+}

--- a/internal/promql/histogram_native_binop_setop_operand_test.go
+++ b/internal/promql/histogram_native_binop_setop_operand_test.go
@@ -1,0 +1,190 @@
+package promql_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/prometheus/prometheus/promql/parser"
+
+	"github.com/tsouza/cerberus/internal/chplan"
+	"github.com/tsouza/cerberus/internal/promql"
+	"github.com/tsouza/cerberus/internal/schema"
+)
+
+// TestLower_ExpHistogram_BinopAcceptsSetOpOperand pins cerberus issue
+// #2559: `+`/`-`/`==`/`!=` between two exp-histogram shapes used to
+// require BOTH operands to lower to a literal *chplan.HistogramProjection
+// ([lowerExpHistogramValuedOperand]'s old type assertion), but
+// [isExpHistogramValuedShape] — the very recogniser these binops gate on
+// to decide an operand is even eligible — reports true for a
+// `and`/`or`/`unless` set-op result too (cerberus issue #2324), which
+// lowers to a *chplan.VectorSetOp instead. A query like
+// `(<histA> and <histB>) + (<histC> and <histD>)` therefore leaked an
+// "internal invariant violated" Go type name to the API caller instead of
+// lowering correctly.
+//
+// [lowerExpHistogramValuedOperand] now accepts any histogram-shaped
+// [chplan.Node] (checked via [chplan.RowShapeOf], mirroring
+// [lowerExpHistogramSetOpOperand]'s existing looser contract) — this test
+// pins that every downstream consumer that assumption threads through
+// (mergeTwoHistogramProjections, compareTwoHistogramProjections,
+// applyVectorMatchToHistogramOperand, the two "drop family" lowerings,
+// and the float-vector scaling join) now composes with a set-op operand
+// on EITHER side, not just a bare selector / sum() / range-function
+// operand.
+func TestLower_ExpHistogram_BinopAcceptsSetOpOperand(t *testing.T) {
+	t.Parallel()
+
+	s := schema.DefaultOTelMetrics()
+	p := parser.NewParser(parser.Options{EnableExperimentalFunctions: true})
+	at := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+
+	const setOpLHS = "(hist_a_exp_hist and hist_b_exp_hist)"
+	const setOpRHS = "(hist_c_exp_hist and hist_d_exp_hist)"
+
+	cases := []struct {
+		name      string
+		query     string
+		wantShape chplan.RowShape
+		wantPlan  func(t *testing.T, plan chplan.Node)
+	}{
+		{
+			name:      "addition, both operands set-ops",
+			query:     setOpLHS + " + " + setOpRHS,
+			wantShape: chplan.HistogramRowShape,
+		},
+		{
+			name:      "subtraction, both operands set-ops",
+			query:     setOpLHS + " - " + setOpRHS,
+			wantShape: chplan.HistogramRowShape,
+		},
+		{
+			name:      "equality, both operands set-ops",
+			query:     setOpLHS + " == " + setOpRHS,
+			wantShape: chplan.HistogramRowShape,
+		},
+		{
+			name:      "inequality, both operands set-ops",
+			query:     setOpLHS + " != " + setOpRHS,
+			wantShape: chplan.HistogramRowShape,
+		},
+		{
+			name:      "bool equality, both operands set-ops",
+			query:     setOpLHS + " == bool " + setOpRHS,
+			wantShape: chplan.SampleRowShape,
+		},
+		{
+			name:      "mixed: set-op on the left, bare selector on the right",
+			query:     setOpLHS + " + hist_e_exp_hist",
+			wantShape: chplan.HistogramRowShape,
+		},
+		{
+			name:      "mixed: bare selector on the left, set-op on the right",
+			query:     "hist_e_exp_hist - " + setOpRHS,
+			wantShape: chplan.HistogramRowShape,
+		},
+		{
+			name:      "on()/ignoring() default-cardinality merge with a set-op operand",
+			query:     setOpLHS + " + on(service) " + setOpRHS,
+			wantShape: chplan.HistogramRowShape,
+		},
+		{
+			// lowerExpHistogramDroppingHistogramBinop caps its
+			// constant-false Filter WITHOUT setting Filter.Histogram (see
+			// TestLower_ExpHistogram_IncompatibleHistogramBinopDropsSamples,
+			// histogram_native_binop_test.go, for the pre-existing
+			// non-set-op case this mirrors) — the top-level plan therefore
+			// publishes SampleRowShape, and it's the wrapped Filter.Input
+			// that must still publish histogram.
+			name:      "incompatible-type drop family (MUL) with set-op operands",
+			query:     setOpLHS + " * " + setOpRHS,
+			wantShape: chplan.SampleRowShape,
+			wantPlan: func(t *testing.T, plan chplan.Node) {
+				t.Helper()
+				filter, ok := plan.(*chplan.Filter)
+				if !ok {
+					t.Fatalf("plan root is %T, want *chplan.Filter", plan)
+				}
+				if shape := chplan.RowShapeOf(filter.Input); shape != chplan.HistogramRowShape {
+					t.Fatalf("filter.Input publishes %s, want histogram", shape)
+				}
+			},
+		},
+		{
+			name:      "mixed float-vector drop family (ADD) with a set-op operand",
+			query:     setOpLHS + " + some_float_vector",
+			wantShape: chplan.SampleRowShape,
+		},
+		{
+			name:      "float-vector scaling (MUL) with a set-op operand",
+			query:     setOpLHS + " * some_float_vector",
+			wantShape: chplan.HistogramRowShape,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			expr, err := p.ParseExpr(tc.query)
+			if err != nil {
+				t.Fatalf("ParseExpr(%q): %v", tc.query, err)
+			}
+			plan, err := promql.LowerAt(context.Background(), expr, s, at, at)
+			if err != nil {
+				t.Fatalf("LowerAt(%q): unexpected error (this exact shape used to leak \"internal invariant violated\" — cerberus issue #2559): %v", tc.query, err)
+			}
+			if shape := chplan.RowShapeOf(plan); shape != tc.wantShape {
+				t.Fatalf("lower(%q): plan root publishes %s, want %s", tc.query, shape, tc.wantShape)
+			}
+			if tc.wantPlan != nil {
+				tc.wantPlan(t, plan)
+			}
+		})
+	}
+}
+
+// TestLower_ExpHistogram_BinopAcceptsSetOpOperand_GroupLeftRight pins the
+// same #2559 fix for the group_left()/group_right() (Card) siblings —
+// mergeTwoHistogramProjectionsCard / compareTwoHistogramProjectionsCard —
+// which route through a real chplan.HistogramVectorJoin instead of the
+// one-to-one UnionAll+Aggregate shape. A set-op operand on either side
+// must still reach a HistogramVectorJoin, not the old type-asserting
+// panic-adjacent error.
+func TestLower_ExpHistogram_BinopAcceptsSetOpOperand_GroupLeftRight(t *testing.T) {
+	t.Parallel()
+
+	s := schema.DefaultOTelMetrics()
+	p := parser.NewParser(parser.Options{EnableExperimentalFunctions: true})
+	at := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+
+	const setOpLHS = "(hist_a_exp_hist and hist_b_exp_hist)"
+	const setOpRHS = "(hist_c_exp_hist and hist_d_exp_hist)"
+
+	queries := []string{
+		setOpLHS + " + on(service) group_left() " + setOpRHS,
+		setOpLHS + " - on(service) group_right() " + setOpRHS,
+		setOpLHS + " == on(service) group_left() " + setOpRHS,
+		setOpLHS + " != on(service) group_right() " + setOpRHS,
+	}
+
+	for _, query := range queries {
+		t.Run(query, func(t *testing.T) {
+			t.Parallel()
+			expr, err := p.ParseExpr(query)
+			if err != nil {
+				t.Fatalf("ParseExpr(%q): %v", query, err)
+			}
+			plan, err := promql.LowerAt(context.Background(), expr, s, at, at)
+			if err != nil {
+				t.Fatalf("LowerAt(%q): unexpected error: %v", query, err)
+			}
+			if shape := chplan.RowShapeOf(plan); shape != chplan.HistogramRowShape {
+				t.Fatalf("lower(%q): plan root publishes %s, want histogram", query, shape)
+			}
+			if _, ok := plan.(*chplan.HistogramProjection); !ok {
+				t.Fatalf("lower(%q): plan root is %T, want *chplan.HistogramProjection", query, plan)
+			}
+		})
+	}
+}

--- a/internal/promql/histogram_native_set_op_test.go
+++ b/internal/promql/histogram_native_set_op_test.go
@@ -132,10 +132,11 @@ func TestLower_ExpHistogram_MixedSetOp_AndUnless(t *testing.T) {
 // operand of an OUTER set op (a chain, `a or b or c`, parsed left-assoc
 // as `(a or b) or c`) and it can be wrapped in a further `sum`/`avg` —
 // both routes go through [lowerExpHistogramValuedShape]'s recursive
-// dispatch rather than [lowerExpHistogramSetOp]'s stricter sibling
-// [lowerExpHistogramValuedOperand] (which requires a literal
-// *chplan.HistogramProjection operand and would reject a nested
-// *chplan.VectorSetOp).
+// dispatch. [lowerExpHistogramValuedOperand] (the +/-/==/!= binop sibling
+// of [lowerExpHistogramSetOpOperand]) also accepts a nested
+// *chplan.VectorSetOp operand since cerberus issue #2559 — see
+// histogram_native_binop_test.go's own set-op-operand coverage for that
+// path.
 func TestLower_ExpHistogram_SetOpComposes(t *testing.T) {
 	t.Parallel()
 

--- a/test/perf/cardinality-baseline/promql/exp_histogram_binop_add_setop_operand.json
+++ b/test/perf/cardinality-baseline/promql/exp_histogram_binop_add_setop_operand.json
@@ -1,0 +1,11 @@
+{
+  "fixture": "promql/exp_histogram_binop_add_setop_operand",
+  "fan_factor": 1,
+  "scan_rows": 2,
+  "peak_intermediate": 2,
+  "has_cross_join": false,
+  "has_array_join": false,
+  "has_recursive_cte": false,
+  "max_recursion_depth": 0,
+  "uncountable_levels": 0
+}

--- a/test/perf/solver-decision-baseline/exp_histogram_binop_add_setop_operand/fanout.json
+++ b/test/perf/solver-decision-baseline/exp_histogram_binop_add_setop_operand/fanout.json
@@ -1,0 +1,11 @@
+{
+  "query": "exp_histogram_binop_add_setop_operand/fanout",
+  "lowering": "fanout",
+  "routed": false,
+  "k": 0,
+  "reason": "not-sliceable",
+  "n_anchors": 241,
+  "fanout": 20,
+  "cumulative_d": "20m0s",
+  "outer_range": "1h0m0s"
+}

--- a/test/perf/solver-decision-baseline/exp_histogram_binop_add_setop_operand/native.json
+++ b/test/perf/solver-decision-baseline/exp_histogram_binop_add_setop_operand/native.json
@@ -1,0 +1,11 @@
+{
+  "query": "exp_histogram_binop_add_setop_operand/native",
+  "lowering": "native",
+  "routed": false,
+  "k": 0,
+  "reason": "not-sliceable",
+  "n_anchors": 241,
+  "fanout": 20,
+  "cumulative_d": "20m0s",
+  "outer_range": "1h0m0s"
+}

--- a/test/regression/parity-enrolment-baselines/promql/baseline.txt
+++ b/test/regression/parity-enrolment-baselines/promql/baseline.txt
@@ -143,6 +143,7 @@ exp_histogram_binop_add_group_left.txtar
 exp_histogram_binop_add_group_right.txtar
 exp_histogram_binop_add_on_matching.txtar
 exp_histogram_binop_add_range.txtar
+exp_histogram_binop_add_setop_operand.txtar
 exp_histogram_binop_eq.txtar
 exp_histogram_binop_eq_bool.txtar
 exp_histogram_binop_eq_bool_group_right.txtar

--- a/test/rejection-parity/catalogue/internal__promql__histogram_native_binop.go.json
+++ b/test/rejection-parity/catalogue/internal__promql__histogram_native_binop.go.json
@@ -33,15 +33,15 @@
     },
     {
       "head": "promql",
-      "site": "internal/promql/histogram_native_binop.go:lowerExpHistogramValuedOperand#f7926a05",
-      "message": "promql: internal invariant violated: exp-histogram binop operand lowering did not cap with *chplan.HistogramProjection, got %T",
+      "site": "internal/promql/histogram_native_binop.go:lowerExpHistogramValuedOperand#38446a20",
+      "message": "promql: internal invariant violated: exp-histogram binop operand lowering published %s row shape (%T), want %s",
       "class": "internal",
-      "rationale": "lowerExpHistogramValuedShape's producer contract ends in *chplan.HistogramProjection for every shape it reports matched=true for — the same contract histogram_native_scalar_binop.go's lowerExpHistogramScalarBinop, and now all six of lowerExpHistogramHistogramBinop, lowerExpHistogramHistogramCompareBinop, lowerExpHistogramHistogramCompareBoolBinop, lowerExpHistogramDroppingHistogramBinop, lowerExpHistogramDroppingVectorBinop (cerberus issue #2331), and lowerExpHistogramFloatVectorScalingBinop (cerberus issue #2339), already rely on",
+      "rationale": "lowerExpHistogramValuedShape's producer contract publishes chplan.HistogramRowShape (per chplan.RowShapeOf) for every shape it reports matched=true for — every dispatch arm either caps with nativeHistogramProjection (a *chplan.HistogramProjection, chplan.RowShapeOf's own HistogramProjection case) or, for its expHistogramSetOp arm, with lowerExpHistogramSetOp's *chplan.VectorSetOp{Histogram: true} (chplan.RowShapeOf's own VectorSetOp case) — the widened contract cerberus issue #2559 gave lowerExpHistogramValuedOperand (replacing a literal *chplan.HistogramProjection type assertion with this chplan.RowShapeOf check) so all six callers (lowerExpHistogramHistogramBinop for +/-, lowerExpHistogramHistogramCompareBinop for ==/!=, lowerExpHistogramHistogramCompareBoolBinop for == bool/!= bool, lowerExpHistogramDroppingHistogramBinop for the histogram/histogram incompatible-type drop family, lowerExpHistogramDroppingVectorBinop for the float-vector/histogram incompatible-type drop family (cerberus issue #2331), and lowerExpHistogramFloatVectorScalingBinop for the MUL / histogram-left-DIV float-vector scaling shape (cerberus issue #2339)) — the first four on both operands, the last two on the single histSide operand each recogniser already verified isExpHistogramValuedShape against — accept a *chplan.VectorSetOp operand (cerberus issue #2324's nested and/or/unless) exactly as they already accepted a *chplan.HistogramProjection one",
       "evidence": {
         "guard": [
           "past returning if err != nil",
           "past returning if !matched",
-          "if !ok"
+          "if chplan.RowShapeOf(node) != chplan.HistogramRowShape"
         ],
         "callers": [
           "lowerExpHistogramDroppingHistogramBinop",
@@ -52,14 +52,18 @@
           "lowerExpHistogramHistogramCompareBoolBinop"
         ],
         "cited": [
+          "expHistogramSetOp",
+          "isExpHistogramValuedShape",
           "lowerExpHistogramDroppingHistogramBinop",
           "lowerExpHistogramDroppingVectorBinop",
           "lowerExpHistogramFloatVectorScalingBinop",
           "lowerExpHistogramHistogramBinop",
           "lowerExpHistogramHistogramCompareBinop",
           "lowerExpHistogramHistogramCompareBoolBinop",
-          "lowerExpHistogramScalarBinop",
-          "lowerExpHistogramValuedShape"
+          "lowerExpHistogramSetOp",
+          "lowerExpHistogramValuedOperand",
+          "lowerExpHistogramValuedShape",
+          "nativeHistogramProjection"
         ]
       }
     }

--- a/test/rejection-parity/catalogue/internal__promql__lower.go.json
+++ b/test/rejection-parity/catalogue/internal__promql__lower.go.json
@@ -94,8 +94,8 @@
       "site": "internal/promql/lower.go:expHistogramSelectorRouting#bf746b59",
       "message": "promql: %q is an exponential histogram metric; only a bare %q selector, sum()/avg()/count() over one, rate()/increase()/delta()/irate()/idelta()/sum_over_time()/avg_over_time()/resets()/changes() over one, histogram_quantile(), histogram_count(), histogram_sum(), and the %q/%q companion selectors are supported",
       "class": "divergence",
-      "trigger_query": "histogram_count(sum(demo_latency_exp_hist))",
-      "tracking_issue": 2554,
+      "trigger_query": "histogram_quantile(0.5, topk(1, demo_latency_exp_hist))",
+      "tracking_issue": 2562,
       "evidence": {
         "guard": [
           "past returning if bare, col, hasCompanion := s.HistogramCompanionColumn(metricName); hasCompanion \u0026\u0026 s.IsExpHistogramMetric(bare) \u0026\u0026 s.ExpHistogramTable != \"\"",

--- a/test/spec/promql/exp_histogram_binop_add_setop_operand.txtar
+++ b/test/spec/promql/exp_histogram_binop_add_setop_operand.txtar
@@ -36,4 +36,251 @@ INSERT INTO otel_metrics_exponential_histogram VALUES
     ('hist_setop_b1_exp_hist', map('series', 'shared'), toDateTime64('2026-01-01 00:00:00', 9), 15, 2.0, 0, 0, 0, [5, 10],       0, []),
     ('hist_setop_b2_exp_hist', map('series', 'shared'), toDateTime64('2026-01-01 00:00:00', 9), 1,  0.1, 0, 0, 0, [1],           0, []);
 -- expected_rows --
-[]
+[
+  ["", {"series": "shared"}, "2026-01-01T00:00:01Z", 0, 25, 3, 0, 0, 0, 0, [8,17], 0, []]
+]
+-- args --
+[0] string = ""
+[1] int64 = 9
+[2] float64 = 0
+[3] int64 = 1
+[4] int64 = 1
+[5] int64 = 1
+[6] int64 = 1
+[7] int64 = 0
+[8] int64 = 1
+[9] int64 = 1
+[10] int64 = 1
+[11] int64 = 1
+[12] int64 = 1
+[13] int64 = 1
+[14] int64 = 0
+[15] int64 = 1
+[16] int64 = 1
+[17] int64 = 1
+[18] int64 = 1
+[19] int64 = 1
+[20] int64 = 1
+[21] int64 = 1
+[22] int64 = 0
+[23] int64 = 1
+[24] int64 = 1
+[25] int64 = 1
+[26] int64 = 1
+[27] int64 = 1
+[28] int64 = 1
+[29] int64 = 0
+[30] int64 = 1
+[31] int64 = 1
+[32] int64 = 1
+[33] int64 = 9
+[34] float64 = 0
+[35] string = "service_name"
+[36] string = "service.name"
+[37] string = "service_name"
+[38] string = "service.name"
+[39] string = "service_name"
+[40] string = ""
+[41] string = "service_name"
+[42] string = "hist_setop_a1_exp_hist"
+[43] string = "hist.setop.a1.exp.hist"
+[44] string = "hist.setop.a1.exp/hist"
+[45] string = "hist.setop.a1.exp_hist"
+[46] string = "hist.setop.a1/exp/hist"
+[47] string = "hist.setop.a1/exp_hist"
+[48] string = "hist.setop.a1_exp.hist"
+[49] string = "hist.setop.a1_exp_hist"
+[50] string = "hist.setop/a1/exp/hist"
+[51] string = "hist.setop/a1/exp_hist"
+[52] string = "hist.setop/a1_exp_hist"
+[53] string = "hist.setop_a1.exp.hist"
+[54] string = "hist.setop_a1.exp_hist"
+[55] string = "hist.setop_a1_exp.hist"
+[56] string = "hist.setop_a1_exp_hist"
+[57] string = "hist/setop/a1/exp/hist"
+[58] string = "hist/setop/a1/exp_hist"
+[59] string = "hist/setop/a1_exp_hist"
+[60] string = "hist/setop_a1_exp_hist"
+[61] string = "hist_setop.a1.exp.hist"
+[62] string = "hist_setop.a1.exp_hist"
+[63] string = "hist_setop.a1_exp.hist"
+[64] string = "hist_setop.a1_exp_hist"
+[65] string = "hist_setop_a1.exp.hist"
+[66] string = "hist_setop_a1.exp_hist"
+[67] string = "hist_setop_a1_exp.hist"
+[68] string = "2026-01-01 00:00:01.000000000"
+[69] int64 = 9
+[70] string = "2026-01-01 00:00:01.000000000"
+[71] int64 = 9
+[72] int64 = 300000000000
+[73] int64 = 9
+[74] float64 = 0
+[75] string = "service_name"
+[76] string = "service.name"
+[77] string = "service_name"
+[78] string = "service.name"
+[79] string = "service_name"
+[80] string = ""
+[81] string = "service_name"
+[82] string = "hist_setop_a2_exp_hist"
+[83] string = "hist.setop.a2.exp.hist"
+[84] string = "hist.setop.a2.exp/hist"
+[85] string = "hist.setop.a2.exp_hist"
+[86] string = "hist.setop.a2/exp/hist"
+[87] string = "hist.setop.a2/exp_hist"
+[88] string = "hist.setop.a2_exp.hist"
+[89] string = "hist.setop.a2_exp_hist"
+[90] string = "hist.setop/a2/exp/hist"
+[91] string = "hist.setop/a2/exp_hist"
+[92] string = "hist.setop/a2_exp_hist"
+[93] string = "hist.setop_a2.exp.hist"
+[94] string = "hist.setop_a2.exp_hist"
+[95] string = "hist.setop_a2_exp.hist"
+[96] string = "hist.setop_a2_exp_hist"
+[97] string = "hist/setop/a2/exp/hist"
+[98] string = "hist/setop/a2/exp_hist"
+[99] string = "hist/setop/a2_exp_hist"
+[100] string = "hist/setop_a2_exp_hist"
+[101] string = "hist_setop.a2.exp.hist"
+[102] string = "hist_setop.a2.exp_hist"
+[103] string = "hist_setop.a2_exp.hist"
+[104] string = "hist_setop.a2_exp_hist"
+[105] string = "hist_setop_a2.exp.hist"
+[106] string = "hist_setop_a2.exp_hist"
+[107] string = "hist_setop_a2_exp.hist"
+[108] string = "2026-01-01 00:00:01.000000000"
+[109] int64 = 9
+[110] string = "2026-01-01 00:00:01.000000000"
+[111] int64 = 9
+[112] int64 = 300000000000
+[113] int64 = 9
+[114] float64 = 0
+[115] string = "service_name"
+[116] string = "service.name"
+[117] string = "service_name"
+[118] string = "service.name"
+[119] string = "service_name"
+[120] string = ""
+[121] string = "service_name"
+[122] string = "hist_setop_b1_exp_hist"
+[123] string = "hist.setop.b1.exp.hist"
+[124] string = "hist.setop.b1.exp/hist"
+[125] string = "hist.setop.b1.exp_hist"
+[126] string = "hist.setop.b1/exp/hist"
+[127] string = "hist.setop.b1/exp_hist"
+[128] string = "hist.setop.b1_exp.hist"
+[129] string = "hist.setop.b1_exp_hist"
+[130] string = "hist.setop/b1/exp/hist"
+[131] string = "hist.setop/b1/exp_hist"
+[132] string = "hist.setop/b1_exp_hist"
+[133] string = "hist.setop_b1.exp.hist"
+[134] string = "hist.setop_b1.exp_hist"
+[135] string = "hist.setop_b1_exp.hist"
+[136] string = "hist.setop_b1_exp_hist"
+[137] string = "hist/setop/b1/exp/hist"
+[138] string = "hist/setop/b1/exp_hist"
+[139] string = "hist/setop/b1_exp_hist"
+[140] string = "hist/setop_b1_exp_hist"
+[141] string = "hist_setop.b1.exp.hist"
+[142] string = "hist_setop.b1.exp_hist"
+[143] string = "hist_setop.b1_exp.hist"
+[144] string = "hist_setop.b1_exp_hist"
+[145] string = "hist_setop_b1.exp.hist"
+[146] string = "hist_setop_b1.exp_hist"
+[147] string = "hist_setop_b1_exp.hist"
+[148] string = "2026-01-01 00:00:01.000000000"
+[149] int64 = 9
+[150] string = "2026-01-01 00:00:01.000000000"
+[151] int64 = 9
+[152] int64 = 300000000000
+[153] int64 = 9
+[154] float64 = 0
+[155] string = "service_name"
+[156] string = "service.name"
+[157] string = "service_name"
+[158] string = "service.name"
+[159] string = "service_name"
+[160] string = ""
+[161] string = "service_name"
+[162] string = "hist_setop_b2_exp_hist"
+[163] string = "hist.setop.b2.exp.hist"
+[164] string = "hist.setop.b2.exp/hist"
+[165] string = "hist.setop.b2.exp_hist"
+[166] string = "hist.setop.b2/exp/hist"
+[167] string = "hist.setop.b2/exp_hist"
+[168] string = "hist.setop.b2_exp.hist"
+[169] string = "hist.setop.b2_exp_hist"
+[170] string = "hist.setop/b2/exp/hist"
+[171] string = "hist.setop/b2/exp_hist"
+[172] string = "hist.setop/b2_exp_hist"
+[173] string = "hist.setop_b2.exp.hist"
+[174] string = "hist.setop_b2.exp_hist"
+[175] string = "hist.setop_b2_exp.hist"
+[176] string = "hist.setop_b2_exp_hist"
+[177] string = "hist/setop/b2/exp/hist"
+[178] string = "hist/setop/b2/exp_hist"
+[179] string = "hist/setop/b2_exp_hist"
+[180] string = "hist/setop_b2_exp_hist"
+[181] string = "hist_setop.b2.exp.hist"
+[182] string = "hist_setop.b2.exp_hist"
+[183] string = "hist_setop.b2_exp.hist"
+[184] string = "hist_setop.b2_exp_hist"
+[185] string = "hist_setop_b2.exp.hist"
+[186] string = "hist_setop_b2.exp_hist"
+[187] string = "hist_setop_b2_exp.hist"
+[188] string = "2026-01-01 00:00:01.000000000"
+[189] int64 = 9
+[190] string = "2026-01-01 00:00:01.000000000"
+[191] int64 = 9
+[192] int64 = 300000000000
+[193] int64 = 2
+[194] int64 = 2
+[195] int64 = 4096
+[196] int64 = 2
+[197] int64 = 0
+[198] int64 = 1
+[199] int64 = 1
+[200] int64 = 1
+[201] int64 = 100000
+[202] int64 = 0
+[203] int64 = 1
+[204] int64 = 1
+[205] int64 = 1
+[206] int64 = 100000
+[207] int64 = 0
+[208] int64 = 1
+[209] int64 = 1
+[210] int64 = 1
+[211] int64 = 100000
+[212] int64 = 0
+[213] int64 = 1
+[214] int64 = 1
+[215] int64 = 1
+[216] int64 = 100000
+[217] int64 = 60000000
+[218] int64 = 0
+-- chplan --
+HistogramProjection project=["" AS MetricName, Attributes AS Attributes, FnNow64(9) AS TimeUnix, 0 AS Value]
+  Project [gkey_0 AS Attributes, FnArraySum(_hq_merge_counts) AS HistogramCount, FnArraySum(_hq_merge_sums) AS HistogramSum, _hq_merged_scale AS HistogramScale, FnArraySum(_hq_merge_zero_counts) AS HistogramZeroCount, HistogramZeroThreshold AS HistogramZeroThreshold, FnArrayMin(FnArrayMap((s, off) -> FnBitShiftRight(off, (s - _hq_merged_scale)), _hq_scales, _hq_pos_offsets)) AS HistogramPositiveOffset, FnArrayMap(mst -> FnArrayMap(t -> FnArraySum(FnArrayMap((s, off, arr) -> FnArraySum(FnArraySlice(arr, FnLeast(FnGreatest(((FnGreatest(off, ((mst + t) * FnBitShiftLeft(1, (s - _hq_merged_scale)))) - off) + 1), 1), (FnLength(arr) + 1)), FnGreatest(0, ((FnLeast(((off + FnLength(arr)) - 1), ((((mst + t) + 1) * FnBitShiftLeft(1, (s - _hq_merged_scale))) - 1)) - FnGreatest(off, ((mst + t) * FnBitShiftLeft(1, (s - _hq_merged_scale))))) + 1)))), _hq_scales, _hq_pos_offsets, _hq_pos_buckets)), FnRange(FnToUInt64(FnGreatest(0, ((FnArrayMax(FnArrayMap((sm, om, am) -> FnBitShiftRight((om + (FnLength(am) - 1)), (sm - _hq_merged_scale)), _hq_scales, _hq_pos_offsets, _hq_pos_buckets)) - mst) + 1))))), FnArray(FnArrayMin(FnArrayMap((sm, om) -> FnBitShiftRight(om, (sm - _hq_merged_scale)), _hq_scales, _hq_pos_offsets))))[1] AS HistogramPositiveBucketCounts, FnArrayMin(FnArrayMap((s, off) -> FnBitShiftRight(off, (s - _hq_merged_scale)), _hq_scales, _hq_neg_offsets)) AS HistogramNegativeOffset, FnArrayMap(mst -> FnArrayMap(t -> FnArraySum(FnArrayMap((s, off, arr) -> FnArraySum(FnArraySlice(arr, FnLeast(FnGreatest(((FnGreatest(off, ((mst + t) * FnBitShiftLeft(1, (s - _hq_merged_scale)))) - off) + 1), 1), (FnLength(arr) + 1)), FnGreatest(0, ((FnLeast(((off + FnLength(arr)) - 1), ((((mst + t) + 1) * FnBitShiftLeft(1, (s - _hq_merged_scale))) - 1)) - FnGreatest(off, ((mst + t) * FnBitShiftLeft(1, (s - _hq_merged_scale))))) + 1)))), _hq_scales, _hq_neg_offsets, _hq_neg_buckets)), FnRange(FnToUInt64(FnGreatest(0, ((FnArrayMax(FnArrayMap((sm, om, am) -> FnBitShiftRight((om + (FnLength(am) - 1)), (sm - _hq_merged_scale)), _hq_scales, _hq_neg_offsets, _hq_neg_buckets)) - mst) + 1))))), FnArray(FnArrayMin(FnArrayMap((sm, om) -> FnBitShiftRight(om, (sm - _hq_merged_scale)), _hq_scales, _hq_neg_offsets))))[1] AS HistogramNegativeBucketCounts]
+    Aggregate groupBy=[Attributes AS gkey_0] funcs=[FnGroupArray(HistogramCount) AS _hq_merge_counts, FnGroupArray(HistogramSum) AS _hq_merge_sums, FnMin(HistogramScale) AS _hq_merged_scale, FnGroupArray(HistogramZeroCount) AS _hq_merge_zero_counts, FnMax(HistogramZeroThreshold) AS HistogramZeroThreshold, FnGroupArray(HistogramScale) AS _hq_scales, FnGroupArray(HistogramPositiveOffset) AS _hq_pos_offsets, FnGroupArray(HistogramPositiveBucketCounts) AS _hq_pos_buckets, FnGroupArray(HistogramNegativeOffset) AS _hq_neg_offsets, FnGroupArray(HistogramNegativeBucketCounts) AS _hq_neg_buckets] having=((FnCount() = 2) AND (FnThrowIf(((2 > 4096) OR ((2 * ((FnLeast(FnArrayMap(mst -> FnGreatest(0, ((FnArrayMax(FnArrayMap((sm, om, am) -> FnBitShiftRight((om + (FnLength(am) - 1)), (sm - _hq_merged_scale)), _hq_scales, _hq_pos_offsets, _hq_pos_buckets)) - mst) + 1)), FnArray(FnArrayMin(FnArrayMap((sm, om) -> FnBitShiftRight(om, (sm - _hq_merged_scale)), _hq_scales, _hq_pos_offsets))))[1], 100000) * FnLeast(FnArrayMap(mst -> FnGreatest(0, ((FnArrayMax(FnArrayMap((sm, om, am) -> FnBitShiftRight((om + (FnLength(am) - 1)), (sm - _hq_merged_scale)), _hq_scales, _hq_pos_offsets, _hq_pos_buckets)) - mst) + 1)), FnArray(FnArrayMin(FnArrayMap((sm, om) -> FnBitShiftRight(om, (sm - _hq_merged_scale)), _hq_scales, _hq_pos_offsets))))[1], 100000)) + (FnLeast(FnArrayMap(mst -> FnGreatest(0, ((FnArrayMax(FnArrayMap((sm, om, am) -> FnBitShiftRight((om + (FnLength(am) - 1)), (sm - _hq_merged_scale)), _hq_scales, _hq_neg_offsets, _hq_neg_buckets)) - mst) + 1)), FnArray(FnArrayMin(FnArrayMap((sm, om) -> FnBitShiftRight(om, (sm - _hq_merged_scale)), _hq_scales, _hq_neg_offsets))))[1], 100000) * FnLeast(FnArrayMap(mst -> FnGreatest(0, ((FnArrayMax(FnArrayMap((sm, om, am) -> FnBitShiftRight((om + (FnLength(am) - 1)), (sm - _hq_merged_scale)), _hq_scales, _hq_neg_offsets, _hq_neg_buckets)) - mst) + 1)), FnArray(FnArrayMin(FnArrayMap((sm, om) -> FnBitShiftRight(om, (sm - _hq_merged_scale)), _hq_scales, _hq_neg_offsets))))[1], 100000)))) > 60000000)), "native histogram merge exceeds the series-per-group or merged-bucket-width resource bound") = 0))
+      UnionAll arms=2
+        VectorSetOp op=and match=default
+          HistogramProjection project=[MetricName AS MetricName, Attributes AS Attributes, FnNow64(9) AS TimeUnix, 0 AS Value]
+            Aggregate groupBy=[FnMapSort(FnMapMerge(FnMapFilter((k, v) -> (k NOT IN ("service_name")), FnMapUpdate(FnMapFromArrays(FnArrayMap(k -> FnRegexReplaceAll(k, "[^a-zA-Z0-9_]", "_"), FnMapKeys(FnMapFilter((k, v) -> (k NOT IN ("service.name", "service_name")), ResourceAttributes))), FnMapValues(FnMapFilter((k, v) -> (k NOT IN ("service.name", "service_name")), ResourceAttributes))), FnMapFromArrays(FnArrayMap(k -> FnRegexReplaceAll(k, "[^a-zA-Z0-9_]", "_"), FnMapKeys(Attributes)), FnMapValues(Attributes)))), FnMapFilter((k, v) -> (v != ""), FnMap("service_name", FnToString(ServiceName))))) AS Attributes] funcs=[FnArgMax(MetricName, TimeUnix) AS MetricName, FnArgMax(Count, TimeUnix) AS Count, FnArgMax(Sum, TimeUnix) AS Sum, FnArgMax(Scale, TimeUnix) AS Scale, FnArgMax(ZeroCount, TimeUnix) AS ZeroCount, FnArgMax(PositiveOffset, TimeUnix) AS PositiveOffset, FnArgMax(PositiveBucketCounts, TimeUnix) AS PositiveBucketCounts, FnArgMax(NegativeOffset, TimeUnix) AS NegativeOffset, FnArgMax(NegativeBucketCounts, TimeUnix) AS NegativeBucketCounts]
+              Filter predicate=(((MetricName IN ("hist_setop_a1_exp_hist", "hist.setop.a1.exp.hist", "hist.setop.a1.exp/hist", "hist.setop.a1.exp_hist", "hist.setop.a1/exp/hist", "hist.setop.a1/exp_hist", "hist.setop.a1_exp.hist", "hist.setop.a1_exp_hist", "hist.setop/a1/exp/hist", "hist.setop/a1/exp_hist", "hist.setop/a1_exp_hist", "hist.setop_a1.exp.hist", "hist.setop_a1.exp_hist", "hist.setop_a1_exp.hist", "hist.setop_a1_exp_hist", "hist/setop/a1/exp/hist", "hist/setop/a1/exp_hist", "hist/setop/a1_exp_hist", "hist/setop_a1_exp_hist", "hist_setop.a1.exp.hist", "hist_setop.a1.exp_hist", "hist_setop.a1_exp.hist", "hist_setop.a1_exp_hist", "hist_setop_a1.exp.hist", "hist_setop_a1.exp_hist", "hist_setop_a1_exp.hist")) AND (TimeUnix <= FnToDateTime64("2026-01-01 00:00:01.000000000", 9))) AND (TimeUnix > (FnToDateTime64("2026-01-01 00:00:01.000000000", 9) - FnToIntervalNanosecond(300000000000))))
+                Scan(otel_metrics_exponential_histogram)
+          HistogramProjection project=[MetricName AS MetricName, Attributes AS Attributes, FnNow64(9) AS TimeUnix, 0 AS Value]
+            Aggregate groupBy=[FnMapSort(FnMapMerge(FnMapFilter((k, v) -> (k NOT IN ("service_name")), FnMapUpdate(FnMapFromArrays(FnArrayMap(k -> FnRegexReplaceAll(k, "[^a-zA-Z0-9_]", "_"), FnMapKeys(FnMapFilter((k, v) -> (k NOT IN ("service.name", "service_name")), ResourceAttributes))), FnMapValues(FnMapFilter((k, v) -> (k NOT IN ("service.name", "service_name")), ResourceAttributes))), FnMapFromArrays(FnArrayMap(k -> FnRegexReplaceAll(k, "[^a-zA-Z0-9_]", "_"), FnMapKeys(Attributes)), FnMapValues(Attributes)))), FnMapFilter((k, v) -> (v != ""), FnMap("service_name", FnToString(ServiceName))))) AS Attributes] funcs=[FnArgMax(MetricName, TimeUnix) AS MetricName, FnArgMax(Count, TimeUnix) AS Count, FnArgMax(Sum, TimeUnix) AS Sum, FnArgMax(Scale, TimeUnix) AS Scale, FnArgMax(ZeroCount, TimeUnix) AS ZeroCount, FnArgMax(PositiveOffset, TimeUnix) AS PositiveOffset, FnArgMax(PositiveBucketCounts, TimeUnix) AS PositiveBucketCounts, FnArgMax(NegativeOffset, TimeUnix) AS NegativeOffset, FnArgMax(NegativeBucketCounts, TimeUnix) AS NegativeBucketCounts]
+              Filter predicate=(((MetricName IN ("hist_setop_a2_exp_hist", "hist.setop.a2.exp.hist", "hist.setop.a2.exp/hist", "hist.setop.a2.exp_hist", "hist.setop.a2/exp/hist", "hist.setop.a2/exp_hist", "hist.setop.a2_exp.hist", "hist.setop.a2_exp_hist", "hist.setop/a2/exp/hist", "hist.setop/a2/exp_hist", "hist.setop/a2_exp_hist", "hist.setop_a2.exp.hist", "hist.setop_a2.exp_hist", "hist.setop_a2_exp.hist", "hist.setop_a2_exp_hist", "hist/setop/a2/exp/hist", "hist/setop/a2/exp_hist", "hist/setop/a2_exp_hist", "hist/setop_a2_exp_hist", "hist_setop.a2.exp.hist", "hist_setop.a2.exp_hist", "hist_setop.a2_exp.hist", "hist_setop.a2_exp_hist", "hist_setop_a2.exp.hist", "hist_setop_a2.exp_hist", "hist_setop_a2_exp.hist")) AND (TimeUnix <= FnToDateTime64("2026-01-01 00:00:01.000000000", 9))) AND (TimeUnix > (FnToDateTime64("2026-01-01 00:00:01.000000000", 9) - FnToIntervalNanosecond(300000000000))))
+                Scan(otel_metrics_exponential_histogram)
+        VectorSetOp op=and match=default
+          HistogramProjection project=[MetricName AS MetricName, Attributes AS Attributes, FnNow64(9) AS TimeUnix, 0 AS Value]
+            Aggregate groupBy=[FnMapSort(FnMapMerge(FnMapFilter((k, v) -> (k NOT IN ("service_name")), FnMapUpdate(FnMapFromArrays(FnArrayMap(k -> FnRegexReplaceAll(k, "[^a-zA-Z0-9_]", "_"), FnMapKeys(FnMapFilter((k, v) -> (k NOT IN ("service.name", "service_name")), ResourceAttributes))), FnMapValues(FnMapFilter((k, v) -> (k NOT IN ("service.name", "service_name")), ResourceAttributes))), FnMapFromArrays(FnArrayMap(k -> FnRegexReplaceAll(k, "[^a-zA-Z0-9_]", "_"), FnMapKeys(Attributes)), FnMapValues(Attributes)))), FnMapFilter((k, v) -> (v != ""), FnMap("service_name", FnToString(ServiceName))))) AS Attributes] funcs=[FnArgMax(MetricName, TimeUnix) AS MetricName, FnArgMax(Count, TimeUnix) AS Count, FnArgMax(Sum, TimeUnix) AS Sum, FnArgMax(Scale, TimeUnix) AS Scale, FnArgMax(ZeroCount, TimeUnix) AS ZeroCount, FnArgMax(PositiveOffset, TimeUnix) AS PositiveOffset, FnArgMax(PositiveBucketCounts, TimeUnix) AS PositiveBucketCounts, FnArgMax(NegativeOffset, TimeUnix) AS NegativeOffset, FnArgMax(NegativeBucketCounts, TimeUnix) AS NegativeBucketCounts]
+              Filter predicate=(((MetricName IN ("hist_setop_b1_exp_hist", "hist.setop.b1.exp.hist", "hist.setop.b1.exp/hist", "hist.setop.b1.exp_hist", "hist.setop.b1/exp/hist", "hist.setop.b1/exp_hist", "hist.setop.b1_exp.hist", "hist.setop.b1_exp_hist", "hist.setop/b1/exp/hist", "hist.setop/b1/exp_hist", "hist.setop/b1_exp_hist", "hist.setop_b1.exp.hist", "hist.setop_b1.exp_hist", "hist.setop_b1_exp.hist", "hist.setop_b1_exp_hist", "hist/setop/b1/exp/hist", "hist/setop/b1/exp_hist", "hist/setop/b1_exp_hist", "hist/setop_b1_exp_hist", "hist_setop.b1.exp.hist", "hist_setop.b1.exp_hist", "hist_setop.b1_exp.hist", "hist_setop.b1_exp_hist", "hist_setop_b1.exp.hist", "hist_setop_b1.exp_hist", "hist_setop_b1_exp.hist")) AND (TimeUnix <= FnToDateTime64("2026-01-01 00:00:01.000000000", 9))) AND (TimeUnix > (FnToDateTime64("2026-01-01 00:00:01.000000000", 9) - FnToIntervalNanosecond(300000000000))))
+                Scan(otel_metrics_exponential_histogram)
+          HistogramProjection project=[MetricName AS MetricName, Attributes AS Attributes, FnNow64(9) AS TimeUnix, 0 AS Value]
+            Aggregate groupBy=[FnMapSort(FnMapMerge(FnMapFilter((k, v) -> (k NOT IN ("service_name")), FnMapUpdate(FnMapFromArrays(FnArrayMap(k -> FnRegexReplaceAll(k, "[^a-zA-Z0-9_]", "_"), FnMapKeys(FnMapFilter((k, v) -> (k NOT IN ("service.name", "service_name")), ResourceAttributes))), FnMapValues(FnMapFilter((k, v) -> (k NOT IN ("service.name", "service_name")), ResourceAttributes))), FnMapFromArrays(FnArrayMap(k -> FnRegexReplaceAll(k, "[^a-zA-Z0-9_]", "_"), FnMapKeys(Attributes)), FnMapValues(Attributes)))), FnMapFilter((k, v) -> (v != ""), FnMap("service_name", FnToString(ServiceName))))) AS Attributes] funcs=[FnArgMax(MetricName, TimeUnix) AS MetricName, FnArgMax(Count, TimeUnix) AS Count, FnArgMax(Sum, TimeUnix) AS Sum, FnArgMax(Scale, TimeUnix) AS Scale, FnArgMax(ZeroCount, TimeUnix) AS ZeroCount, FnArgMax(PositiveOffset, TimeUnix) AS PositiveOffset, FnArgMax(PositiveBucketCounts, TimeUnix) AS PositiveBucketCounts, FnArgMax(NegativeOffset, TimeUnix) AS NegativeOffset, FnArgMax(NegativeBucketCounts, TimeUnix) AS NegativeBucketCounts]
+              Filter predicate=(((MetricName IN ("hist_setop_b2_exp_hist", "hist.setop.b2.exp.hist", "hist.setop.b2.exp/hist", "hist.setop.b2.exp_hist", "hist.setop.b2/exp/hist", "hist.setop.b2/exp_hist", "hist.setop.b2_exp.hist", "hist.setop.b2_exp_hist", "hist.setop/b2/exp/hist", "hist.setop/b2/exp_hist", "hist.setop/b2_exp_hist", "hist.setop_b2.exp.hist", "hist.setop_b2.exp_hist", "hist.setop_b2_exp.hist", "hist.setop_b2_exp_hist", "hist/setop/b2/exp/hist", "hist/setop/b2/exp_hist", "hist/setop/b2_exp_hist", "hist/setop_b2_exp_hist", "hist_setop.b2.exp.hist", "hist_setop.b2.exp_hist", "hist_setop.b2_exp.hist", "hist_setop.b2_exp_hist", "hist_setop_b2.exp.hist", "hist_setop_b2.exp_hist", "hist_setop_b2_exp.hist")) AND (TimeUnix <= FnToDateTime64("2026-01-01 00:00:01.000000000", 9))) AND (TimeUnix > (FnToDateTime64("2026-01-01 00:00:01.000000000", 9) - FnToIntervalNanosecond(300000000000))))
+                Scan(otel_metrics_exponential_histogram)
+-- sql --
+SELECT ? AS `MetricName`, `Attributes` AS `Attributes`, now64(?) AS `TimeUnix`, toFloat64(?) AS `Value`, toFloat64(`HistogramCount`) AS `HistogramCount`, toFloat64(`HistogramSum`) AS `HistogramSum`, toInt32(`HistogramScale`) AS `HistogramScale`, toFloat64(`HistogramZeroThreshold`) AS `HistogramZeroThreshold`, toFloat64(`HistogramZeroCount`) AS `HistogramZeroCount`, toInt32(`HistogramPositiveOffset`) AS `HistogramPositiveOffset`, arrayMap(x -> toFloat64(x), `HistogramPositiveBucketCounts`) AS `HistogramPositiveBucketCounts`, toInt32(`HistogramNegativeOffset`) AS `HistogramNegativeOffset`, arrayMap(x -> toFloat64(x), `HistogramNegativeBucketCounts`) AS `HistogramNegativeBucketCounts` FROM (SELECT `gkey_0` AS `Attributes`, arraySum(`_hq_merge_counts`) AS `HistogramCount`, arraySum(`_hq_merge_sums`) AS `HistogramSum`, `_hq_merged_scale` AS `HistogramScale`, arraySum(`_hq_merge_zero_counts`) AS `HistogramZeroCount`, `HistogramZeroThreshold` AS `HistogramZeroThreshold`, arrayMin(arrayMap((s, off) -> bitShiftRight(off, (s - `_hq_merged_scale`)), `_hq_scales`, `_hq_pos_offsets`)) AS `HistogramPositiveOffset`, arrayMap(mst -> arrayMap(t -> arraySum(arrayMap((s, off, arr) -> arraySum(arraySlice(arr, least(greatest(((greatest(off, ((mst + t) * bitShiftLeft(?, (s - `_hq_merged_scale`)))) - off) + ?), ?), (length(arr) + ?)), greatest(?, ((least(((off + length(arr)) - ?), ((((mst + t) + ?) * bitShiftLeft(?, (s - `_hq_merged_scale`))) - ?)) - greatest(off, ((mst + t) * bitShiftLeft(?, (s - `_hq_merged_scale`))))) + ?)))), `_hq_scales`, `_hq_pos_offsets`, `_hq_pos_buckets`)), range(toUInt64(greatest(?, ((arrayMax(arrayMap((sm, om, am) -> bitShiftRight((om + (length(am) - ?)), (sm - `_hq_merged_scale`)), `_hq_scales`, `_hq_pos_offsets`, `_hq_pos_buckets`)) - mst) + ?))))), array(arrayMin(arrayMap((sm, om) -> bitShiftRight(om, (sm - `_hq_merged_scale`)), `_hq_scales`, `_hq_pos_offsets`))))[?] AS `HistogramPositiveBucketCounts`, arrayMin(arrayMap((s, off) -> bitShiftRight(off, (s - `_hq_merged_scale`)), `_hq_scales`, `_hq_neg_offsets`)) AS `HistogramNegativeOffset`, arrayMap(mst -> arrayMap(t -> arraySum(arrayMap((s, off, arr) -> arraySum(arraySlice(arr, least(greatest(((greatest(off, ((mst + t) * bitShiftLeft(?, (s - `_hq_merged_scale`)))) - off) + ?), ?), (length(arr) + ?)), greatest(?, ((least(((off + length(arr)) - ?), ((((mst + t) + ?) * bitShiftLeft(?, (s - `_hq_merged_scale`))) - ?)) - greatest(off, ((mst + t) * bitShiftLeft(?, (s - `_hq_merged_scale`))))) + ?)))), `_hq_scales`, `_hq_neg_offsets`, `_hq_neg_buckets`)), range(toUInt64(greatest(?, ((arrayMax(arrayMap((sm, om, am) -> bitShiftRight((om + (length(am) - ?)), (sm - `_hq_merged_scale`)), `_hq_scales`, `_hq_neg_offsets`, `_hq_neg_buckets`)) - mst) + ?))))), array(arrayMin(arrayMap((sm, om) -> bitShiftRight(om, (sm - `_hq_merged_scale`)), `_hq_scales`, `_hq_neg_offsets`))))[?] AS `HistogramNegativeBucketCounts` FROM (SELECT `Attributes` AS `gkey_0`, groupArray(`HistogramCount`) AS `_hq_merge_counts`, groupArray(`HistogramSum`) AS `_hq_merge_sums`, min(`HistogramScale`) AS `_hq_merged_scale`, groupArray(`HistogramZeroCount`) AS `_hq_merge_zero_counts`, max(`HistogramZeroThreshold`) AS `HistogramZeroThreshold`, groupArray(`HistogramScale`) AS `_hq_scales`, groupArray(`HistogramPositiveOffset`) AS `_hq_pos_offsets`, groupArray(`HistogramPositiveBucketCounts`) AS `_hq_pos_buckets`, groupArray(`HistogramNegativeOffset`) AS `_hq_neg_offsets`, groupArray(`HistogramNegativeBucketCounts`) AS `_hq_neg_buckets` FROM ((SELECT `MetricName`, `Attributes`, `TimeUnix`, `Value`, `HistogramCount`, `HistogramSum`, `HistogramScale`, `HistogramZeroThreshold`, `HistogramZeroCount`, `HistogramPositiveOffset`, `HistogramPositiveBucketCounts`, `HistogramNegativeOffset`, `HistogramNegativeBucketCounts` FROM (SELECT `MetricName`, `Attributes`, `TimeUnix`, `Value`, `HistogramCount`, `HistogramSum`, `HistogramScale`, `HistogramZeroThreshold`, `HistogramZeroCount`, `HistogramPositiveOffset`, `HistogramPositiveBucketCounts`, `HistogramNegativeOffset`, `HistogramNegativeBucketCounts` FROM (SELECT `MetricName`, `Attributes`, `TimeUnix`, `Value`, `HistogramCount`, `HistogramSum`, `HistogramScale`, `HistogramZeroThreshold`, `HistogramZeroCount`, `HistogramPositiveOffset`, `HistogramPositiveBucketCounts`, `HistogramNegativeOffset`, `HistogramNegativeBucketCounts` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, now64(?) AS `TimeUnix`, toFloat64(?) AS `Value`, toFloat64(`Count`) AS `HistogramCount`, toFloat64(`Sum`) AS `HistogramSum`, toInt32(`Scale`) AS `HistogramScale`, toFloat64(0.) AS `HistogramZeroThreshold`, toFloat64(`ZeroCount`) AS `HistogramZeroCount`, toInt32(`PositiveOffset`) AS `HistogramPositiveOffset`, arrayMap(x -> toFloat64(x), `PositiveBucketCounts`) AS `HistogramPositiveBucketCounts`, toInt32(`NegativeOffset`) AS `HistogramNegativeOffset`, arrayMap(x -> toFloat64(x), `NegativeBucketCounts`) AS `HistogramNegativeBucketCounts` FROM (SELECT mapSort(mapConcat(mapFilter((k, v) -> (k NOT IN (?)), mapUpdate(mapFromArrays(arrayMap(k -> replaceRegexpAll(k, '[^a-zA-Z0-9_]', '_'), mapKeys(mapFilter((k, v) -> (k NOT IN (?, ?)), `ResourceAttributes`))), mapValues(mapFilter((k, v) -> (k NOT IN (?, ?)), `ResourceAttributes`))), mapFromArrays(arrayMap(k -> replaceRegexpAll(k, '[^a-zA-Z0-9_]', '_'), mapKeys(`Attributes`)), mapValues(`Attributes`)))), mapFilter((k, v) -> (v != ?), map(?, toString(`ServiceName`))))) AS `Attributes`, argMax(`MetricName`, `TimeUnix`) AS `MetricName`, argMax(`Count`, `TimeUnix`) AS `Count`, argMax(`Sum`, `TimeUnix`) AS `Sum`, argMax(`Scale`, `TimeUnix`) AS `Scale`, argMax(`ZeroCount`, `TimeUnix`) AS `ZeroCount`, argMax(`PositiveOffset`, `TimeUnix`) AS `PositiveOffset`, argMax(`PositiveBucketCounts`, `TimeUnix`) AS `PositiveBucketCounts`, argMax(`NegativeOffset`, `TimeUnix`) AS `NegativeOffset`, argMax(`NegativeBucketCounts`, `TimeUnix`) AS `NegativeBucketCounts` FROM (SELECT * FROM `otel_metrics_exponential_histogram` PREWHERE (`MetricName` IN (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)) WHERE (`TimeUnix` <= toDateTime64(?, ?)) AND (`TimeUnix` > (toDateTime64(?, ?) - toIntervalNanosecond(?)))) GROUP BY `Attributes`))) WHERE mapSort(`Attributes`) IN ((SELECT DISTINCT mapSort(`Attributes`) FROM (SELECT `MetricName`, `Attributes`, `TimeUnix`, `Value`, `HistogramCount`, `HistogramSum`, `HistogramScale`, `HistogramZeroThreshold`, `HistogramZeroCount`, `HistogramPositiveOffset`, `HistogramPositiveBucketCounts`, `HistogramNegativeOffset`, `HistogramNegativeBucketCounts` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, now64(?) AS `TimeUnix`, toFloat64(?) AS `Value`, toFloat64(`Count`) AS `HistogramCount`, toFloat64(`Sum`) AS `HistogramSum`, toInt32(`Scale`) AS `HistogramScale`, toFloat64(0.) AS `HistogramZeroThreshold`, toFloat64(`ZeroCount`) AS `HistogramZeroCount`, toInt32(`PositiveOffset`) AS `HistogramPositiveOffset`, arrayMap(x -> toFloat64(x), `PositiveBucketCounts`) AS `HistogramPositiveBucketCounts`, toInt32(`NegativeOffset`) AS `HistogramNegativeOffset`, arrayMap(x -> toFloat64(x), `NegativeBucketCounts`) AS `HistogramNegativeBucketCounts` FROM (SELECT mapSort(mapConcat(mapFilter((k, v) -> (k NOT IN (?)), mapUpdate(mapFromArrays(arrayMap(k -> replaceRegexpAll(k, '[^a-zA-Z0-9_]', '_'), mapKeys(mapFilter((k, v) -> (k NOT IN (?, ?)), `ResourceAttributes`))), mapValues(mapFilter((k, v) -> (k NOT IN (?, ?)), `ResourceAttributes`))), mapFromArrays(arrayMap(k -> replaceRegexpAll(k, '[^a-zA-Z0-9_]', '_'), mapKeys(`Attributes`)), mapValues(`Attributes`)))), mapFilter((k, v) -> (v != ?), map(?, toString(`ServiceName`))))) AS `Attributes`, argMax(`MetricName`, `TimeUnix`) AS `MetricName`, argMax(`Count`, `TimeUnix`) AS `Count`, argMax(`Sum`, `TimeUnix`) AS `Sum`, argMax(`Scale`, `TimeUnix`) AS `Scale`, argMax(`ZeroCount`, `TimeUnix`) AS `ZeroCount`, argMax(`PositiveOffset`, `TimeUnix`) AS `PositiveOffset`, argMax(`PositiveBucketCounts`, `TimeUnix`) AS `PositiveBucketCounts`, argMax(`NegativeOffset`, `TimeUnix`) AS `NegativeOffset`, argMax(`NegativeBucketCounts`, `TimeUnix`) AS `NegativeBucketCounts` FROM (SELECT * FROM `otel_metrics_exponential_histogram` PREWHERE (`MetricName` IN (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)) WHERE (`TimeUnix` <= toDateTime64(?, ?)) AND (`TimeUnix` > (toDateTime64(?, ?) - toIntervalNanosecond(?)))) GROUP BY `Attributes`))))))) UNION ALL (SELECT `MetricName`, `Attributes`, `TimeUnix`, `Value`, `HistogramCount`, `HistogramSum`, `HistogramScale`, `HistogramZeroThreshold`, `HistogramZeroCount`, `HistogramPositiveOffset`, `HistogramPositiveBucketCounts`, `HistogramNegativeOffset`, `HistogramNegativeBucketCounts` FROM (SELECT `MetricName`, `Attributes`, `TimeUnix`, `Value`, `HistogramCount`, `HistogramSum`, `HistogramScale`, `HistogramZeroThreshold`, `HistogramZeroCount`, `HistogramPositiveOffset`, `HistogramPositiveBucketCounts`, `HistogramNegativeOffset`, `HistogramNegativeBucketCounts` FROM (SELECT `MetricName`, `Attributes`, `TimeUnix`, `Value`, `HistogramCount`, `HistogramSum`, `HistogramScale`, `HistogramZeroThreshold`, `HistogramZeroCount`, `HistogramPositiveOffset`, `HistogramPositiveBucketCounts`, `HistogramNegativeOffset`, `HistogramNegativeBucketCounts` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, now64(?) AS `TimeUnix`, toFloat64(?) AS `Value`, toFloat64(`Count`) AS `HistogramCount`, toFloat64(`Sum`) AS `HistogramSum`, toInt32(`Scale`) AS `HistogramScale`, toFloat64(0.) AS `HistogramZeroThreshold`, toFloat64(`ZeroCount`) AS `HistogramZeroCount`, toInt32(`PositiveOffset`) AS `HistogramPositiveOffset`, arrayMap(x -> toFloat64(x), `PositiveBucketCounts`) AS `HistogramPositiveBucketCounts`, toInt32(`NegativeOffset`) AS `HistogramNegativeOffset`, arrayMap(x -> toFloat64(x), `NegativeBucketCounts`) AS `HistogramNegativeBucketCounts` FROM (SELECT mapSort(mapConcat(mapFilter((k, v) -> (k NOT IN (?)), mapUpdate(mapFromArrays(arrayMap(k -> replaceRegexpAll(k, '[^a-zA-Z0-9_]', '_'), mapKeys(mapFilter((k, v) -> (k NOT IN (?, ?)), `ResourceAttributes`))), mapValues(mapFilter((k, v) -> (k NOT IN (?, ?)), `ResourceAttributes`))), mapFromArrays(arrayMap(k -> replaceRegexpAll(k, '[^a-zA-Z0-9_]', '_'), mapKeys(`Attributes`)), mapValues(`Attributes`)))), mapFilter((k, v) -> (v != ?), map(?, toString(`ServiceName`))))) AS `Attributes`, argMax(`MetricName`, `TimeUnix`) AS `MetricName`, argMax(`Count`, `TimeUnix`) AS `Count`, argMax(`Sum`, `TimeUnix`) AS `Sum`, argMax(`Scale`, `TimeUnix`) AS `Scale`, argMax(`ZeroCount`, `TimeUnix`) AS `ZeroCount`, argMax(`PositiveOffset`, `TimeUnix`) AS `PositiveOffset`, argMax(`PositiveBucketCounts`, `TimeUnix`) AS `PositiveBucketCounts`, argMax(`NegativeOffset`, `TimeUnix`) AS `NegativeOffset`, argMax(`NegativeBucketCounts`, `TimeUnix`) AS `NegativeBucketCounts` FROM (SELECT * FROM `otel_metrics_exponential_histogram` PREWHERE (`MetricName` IN (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)) WHERE (`TimeUnix` <= toDateTime64(?, ?)) AND (`TimeUnix` > (toDateTime64(?, ?) - toIntervalNanosecond(?)))) GROUP BY `Attributes`))) WHERE mapSort(`Attributes`) IN ((SELECT DISTINCT mapSort(`Attributes`) FROM (SELECT `MetricName`, `Attributes`, `TimeUnix`, `Value`, `HistogramCount`, `HistogramSum`, `HistogramScale`, `HistogramZeroThreshold`, `HistogramZeroCount`, `HistogramPositiveOffset`, `HistogramPositiveBucketCounts`, `HistogramNegativeOffset`, `HistogramNegativeBucketCounts` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, now64(?) AS `TimeUnix`, toFloat64(?) AS `Value`, toFloat64(`Count`) AS `HistogramCount`, toFloat64(`Sum`) AS `HistogramSum`, toInt32(`Scale`) AS `HistogramScale`, toFloat64(0.) AS `HistogramZeroThreshold`, toFloat64(`ZeroCount`) AS `HistogramZeroCount`, toInt32(`PositiveOffset`) AS `HistogramPositiveOffset`, arrayMap(x -> toFloat64(x), `PositiveBucketCounts`) AS `HistogramPositiveBucketCounts`, toInt32(`NegativeOffset`) AS `HistogramNegativeOffset`, arrayMap(x -> toFloat64(x), `NegativeBucketCounts`) AS `HistogramNegativeBucketCounts` FROM (SELECT mapSort(mapConcat(mapFilter((k, v) -> (k NOT IN (?)), mapUpdate(mapFromArrays(arrayMap(k -> replaceRegexpAll(k, '[^a-zA-Z0-9_]', '_'), mapKeys(mapFilter((k, v) -> (k NOT IN (?, ?)), `ResourceAttributes`))), mapValues(mapFilter((k, v) -> (k NOT IN (?, ?)), `ResourceAttributes`))), mapFromArrays(arrayMap(k -> replaceRegexpAll(k, '[^a-zA-Z0-9_]', '_'), mapKeys(`Attributes`)), mapValues(`Attributes`)))), mapFilter((k, v) -> (v != ?), map(?, toString(`ServiceName`))))) AS `Attributes`, argMax(`MetricName`, `TimeUnix`) AS `MetricName`, argMax(`Count`, `TimeUnix`) AS `Count`, argMax(`Sum`, `TimeUnix`) AS `Sum`, argMax(`Scale`, `TimeUnix`) AS `Scale`, argMax(`ZeroCount`, `TimeUnix`) AS `ZeroCount`, argMax(`PositiveOffset`, `TimeUnix`) AS `PositiveOffset`, argMax(`PositiveBucketCounts`, `TimeUnix`) AS `PositiveBucketCounts`, argMax(`NegativeOffset`, `TimeUnix`) AS `NegativeOffset`, argMax(`NegativeBucketCounts`, `TimeUnix`) AS `NegativeBucketCounts` FROM (SELECT * FROM `otel_metrics_exponential_histogram` PREWHERE (`MetricName` IN (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)) WHERE (`TimeUnix` <= toDateTime64(?, ?)) AND (`TimeUnix` > (toDateTime64(?, ?) - toIntervalNanosecond(?)))) GROUP BY `Attributes`)))))))) GROUP BY `gkey_0` HAVING ((count() = ?) AND (throwIf(((? > ?) OR ((? * ((least(arrayMap(mst -> greatest(?, ((arrayMax(arrayMap((sm, om, am) -> bitShiftRight((om + (length(am) - ?)), (sm - `_hq_merged_scale`)), `_hq_scales`, `_hq_pos_offsets`, `_hq_pos_buckets`)) - mst) + ?)), array(arrayMin(arrayMap((sm, om) -> bitShiftRight(om, (sm - `_hq_merged_scale`)), `_hq_scales`, `_hq_pos_offsets`))))[?], ?) * least(arrayMap(mst -> greatest(?, ((arrayMax(arrayMap((sm, om, am) -> bitShiftRight((om + (length(am) - ?)), (sm - `_hq_merged_scale`)), `_hq_scales`, `_hq_pos_offsets`, `_hq_pos_buckets`)) - mst) + ?)), array(arrayMin(arrayMap((sm, om) -> bitShiftRight(om, (sm - `_hq_merged_scale`)), `_hq_scales`, `_hq_pos_offsets`))))[?], ?)) + (least(arrayMap(mst -> greatest(?, ((arrayMax(arrayMap((sm, om, am) -> bitShiftRight((om + (length(am) - ?)), (sm - `_hq_merged_scale`)), `_hq_scales`, `_hq_neg_offsets`, `_hq_neg_buckets`)) - mst) + ?)), array(arrayMin(arrayMap((sm, om) -> bitShiftRight(om, (sm - `_hq_merged_scale`)), `_hq_scales`, `_hq_neg_offsets`))))[?], ?) * least(arrayMap(mst -> greatest(?, ((arrayMax(arrayMap((sm, om, am) -> bitShiftRight((om + (length(am) - ?)), (sm - `_hq_merged_scale`)), `_hq_scales`, `_hq_neg_offsets`, `_hq_neg_buckets`)) - mst) + ?)), array(arrayMin(arrayMap((sm, om) -> bitShiftRight(om, (sm - `_hq_merged_scale`)), `_hq_scales`, `_hq_neg_offsets`))))[?], ?)))) > ?)), 'native histogram merge exceeds the series-per-group or merged-bucket-width resource bound') = ?))))

--- a/test/spec/promql/exp_histogram_binop_add_setop_operand.txtar
+++ b/test/spec/promql/exp_histogram_binop_add_setop_operand.txtar
@@ -1,0 +1,39 @@
+-- query.promql --
+(hist_setop_a1_exp_hist and hist_setop_a2_exp_hist) + (hist_setop_b1_exp_hist and hist_setop_b2_exp_hist)
+-- parity --
+oracle: prometheus
+endpoint: /api/v1/query
+scope: full
+-- seed --
+CREATE TABLE otel_metrics_exponential_histogram (
+    MetricName String,
+    Attributes Map(String, String),
+    TimeUnix DateTime64(9),
+    Count UInt64,
+    Sum Float64,
+    Scale Int32,
+    ZeroCount UInt64,
+    PositiveOffset Int32,
+    PositiveBucketCounts Array(UInt64),
+    NegativeOffset Int32,
+    NegativeBucketCounts Array(UInt64)
+) ENGINE = MergeTree ORDER BY (MetricName, Attributes, TimeUnix);
+-- Binary `+` between two `and` SET-OP results (cerberus issue #2559): each
+-- operand — `(a1 and a2)` / `(b1 and b2)` — lowers to a *chplan.VectorSetOp,
+-- not a literal *chplan.HistogramProjection, and used to hit
+-- lowerExpHistogramValuedOperand's old type assertion with an
+-- "internal invariant violated" error leaking that Go type name to the API
+-- caller. `and` never merges values — it keeps the LHS row unchanged when
+-- the RHS shares its label signature — so a1's own row (Scale=1,
+-- PositiveOffset=0, [1,2,3,4]) and b1's own row (Scale=0, PositiveOffset=0,
+-- [5,10]) are what the outer `+` actually reconciles, matching
+-- exp_histogram_binop_add.txtar's own downscale fold: server=[1,2,3,4]@
+-- Scale1 downscales to Scale0 as [3,7]; merged with [5,10] = [8,17].
+-- a2/b2 exist purely to keep a1/b1's rows alive through their own `and`.
+INSERT INTO otel_metrics_exponential_histogram VALUES
+    ('hist_setop_a1_exp_hist', map('series', 'shared'), toDateTime64('2026-01-01 00:00:00', 9), 10, 1.0, 1, 0, 0, [1, 2, 3, 4], 0, []),
+    ('hist_setop_a2_exp_hist', map('series', 'shared'), toDateTime64('2026-01-01 00:00:00', 9), 1,  0.1, 0, 0, 0, [1],           0, []),
+    ('hist_setop_b1_exp_hist', map('series', 'shared'), toDateTime64('2026-01-01 00:00:00', 9), 15, 2.0, 0, 0, 0, [5, 10],       0, []),
+    ('hist_setop_b2_exp_hist', map('series', 'shared'), toDateTime64('2026-01-01 00:00:00', 9), 1,  0.1, 0, 0, 0, [1],           0, []);
+-- expected_rows --
+[]


### PR DESCRIPTION
## Summary

`(<histA> and <histB>) + (<histC> and <histD>)` — and the same shape under `-`, `==`, `!=` — hit a
clean HTTP 422 whose body leaked an internal Go type name and "invariant violated" wording:

```text
promql: internal invariant violated: exp-histogram binop operand lowering did not cap with
*chplan.HistogramProjection, got *chplan.VectorSetOp
```

`lowerExpHistogramValuedOperand` (`internal/promql/histogram_native_binop.go`) required its operand
to lower to literally a `*chplan.HistogramProjection`, but `isExpHistogramValuedShape` — the
recognizer the `+`/`-`/`==`/`!=` exp-histogram binops (and their `group_left()`/`group_right()` Card
siblings, the incompatible-type drop family, and the float-vector scaling family) all gate on to
decide an operand is even eligible — also reports `true` for an `and`/`or`/`unless` set-op result
(#2324), which lowers to a `*chplan.VectorSetOp` instead.

## Root-cause scope, confirmed by probing

`lowerExpHistogramValuedOperand` is the single choke point for **six** callers, not the two the issue
names:

- `lowerExpHistogramHistogramBinop` (`+`/`-`)
- `lowerExpHistogramHistogramCompareBinop` (`==`/`!=`)
- `lowerExpHistogramHistogramCompareBoolBinop` (`== bool`/`!= bool`)
- `lowerExpHistogramDroppingHistogramBinop` (the `*`/`/`/`^`/`%`/comparison/`atan2`
  incompatible-type drop family between two histograms, #2277)
- `lowerExpHistogramDroppingVectorBinop` (histogram vs. plain float-vector incompatible-type drop,
  #2331)
- `lowerExpHistogramFloatVectorScalingBinop` (histogram scaled by a float vector, #2339/#2342)

All six threaded a `*chplan.HistogramProjection`-typed operand through their own signatures
(`mergeTwoHistogramProjections`/`Card`, `compareTwoHistogramProjections`/`Card`,
`applyVectorMatchToHistogramOperand`, `newHistogramVectorJoin`), so a set-op operand hit the same
error on every one of them — not just `+`/`-`/`==`/`!=`.

## Why approach (a) was tractable, not a large redesign

Every one of those "type-narrow" functions already reads its operands **by column name** through the
wrapping `UnionAll`/`Aggregate`/`HistogramVectorJoin`/`Project` — never via a Go struct field on
`*chplan.HistogramProjection`. `chplan.HistogramVectorJoin.Left`/`.Right` are already typed
`chplan.Node`, and `chplan.VectorSetOp{Histogram: true}` publishes the byte-identical
thirteen-column output shape (`chplan.RowShapeOf` already answers `HistogramRowShape` for it) that
`*chplan.HistogramProjection` does. So the fix is a straightforward generalization, mirroring the
existing `lowerExpHistogramSetOpOperand` contract:

- `lowerExpHistogramValuedOperand` now returns `chplan.Node` and checks
  `chplan.RowShapeOf(node) == chplan.HistogramRowShape` instead of a literal type assertion.
- `mergeTwoHistogramProjections`/`Card`, `compareTwoHistogramProjections`/`Card`,
  `applyVectorMatchToHistogramOperand`, and `newHistogramVectorJoin` all widen their `hpL`/`hpR`/`hp`
  parameters from `*chplan.HistogramProjection` to `chplan.Node` — no behavioral change for the
  existing shapes, since every one of them already only referenced columns by name.

## Verification

- `TestLower_ExpHistogram_BinopAcceptsSetOpOperand` / `..._GroupLeftRight`
  (`internal/promql/histogram_native_binop_setop_operand_test.go`): plan-shape coverage for `+`, `-`,
  `==`, `!=`, `== bool`, mixed set-op/bare-selector operands, `on()`/`ignoring()`, the drop family, the
  mixed float-vector drop family, float-vector scaling, and both Card variants.
- `TestExpHistogramBinopSetOpOperand_MergeDifferentLayout_ChDB` /
  `..._Equality_ChDB` (`internal/promql/histogram_native_binop_setop_operand_chdb_test.go`): real
  chDB-executed proof that `+`/`-` correctly reconciles two DIFFERENT bucket layouts surfaced through
  a set-op operand, and that `==`/`!=` correctly keeps/drops and forwards the LHS's own (not merged)
  value.
- `test/spec/promql/exp_histogram_binop_add_setop_operand.txtar`: a new TXTAR fixture pinning the
  chplan/SQL shape for the reported query.
- `test/rejection-parity/catalogue/internal__promql__histogram_native_binop.go.json`: regenerated
  (`CERBERUS_UPDATE_INVENTORY=1 go test -run TestCatalogueIsRegenerable ./test/rejection-parity/...`,
  run twice — once to demote the site whose evidence moved, once more after hand-writing its
  rationale) — the site's message text changed from the old type-assertion wording to the new
  `RowShapeOf` mismatch wording.
- Golden regeneration dispatched via `update-golden.yml` (auto-expanded by the workflow's own DAG
  planner beyond the requested `promql` shard).

Closes #2559
