### PR TITLE
fix(promql): accept a set-op operand in exp-histogram scalar binop lowering

### DIFF
--- a/internal/promql/histogram_native_scalar_binop.go
+++ b/internal/promql/histogram_native_scalar_binop.go
@@ -227,7 +227,30 @@ func isExpHistogramValuedShape(expr parser.Expr, s schema.Metrics, ctx lowerCtx)
 // shipped lowering — unmodified, so a query without the scalar wrapper
 // still lowers byte-for-byte the same way. drop selects reference's
 // keep=false incompatible-types result; otherwise the capping
-// HistogramProjection is rewritten to scale it.
+// histogram-shaped node is rewritten to scale it.
+//
+// The histogram side is asserted by ROW SHAPE
+// ([chplan.RowShapeOf] == [chplan.HistogramRowShape]), not by literal Go
+// type: [isExpHistogramValuedShape] — the very predicate
+// [expHistogramScalarBinop] / [expHistogramDroppingScalarBinop] gate on to
+// decide the histogram side is even eligible — reports true for a
+// `and`/`or`/`unless` set-op result too (cerberus issue #2324), which
+// [lowerExpHistogramValuedShape] lowers to a *chplan.VectorSetOp, not a
+// *chplan.HistogramProjection. A strict `node.(*chplan.HistogramProjection)`
+// type assertion here rejected that shape with an "internal invariant
+// violated" error despite the recognizer having just accepted it as
+// histogram-valued (cerberus issue #2557) — the recognizer and this
+// lowering disagreeing about which shapes are admissible is exactly what
+// this package's doc comment on [lowerExpHistogramValuedShape] says
+// pairing them is supposed to prevent. [scaleHistogramProjection] below
+// already reads its input by column NAME through a Project (see that
+// function's own doc for why it is typed `chplan.Node`, not
+// `*chplan.HistogramProjection`), and a histogram-shaped *chplan.VectorSetOp
+// publishes those same fixed Histogram*Column aliases
+// ([chplan.RowShapeOf]'s VectorSetOp doc), so accepting any
+// histogram-shaped node here — mirroring
+// [lowerExpHistogramSetOpOperand]'s identical widening in
+// histogram_native_set_op.go — is correct, not merely permissive.
 func lowerExpHistogramScalarBinop(histSide parser.Expr, op chplan.BinaryOp, scale chplan.Expr, s schema.Metrics, ctx lowerCtx, drop bool) (chplan.Node, error) {
 	node, matched, err := lowerExpHistogramValuedShape(histSide, s, ctx)
 	if !matched {
@@ -236,17 +259,19 @@ func lowerExpHistogramScalarBinop(histSide parser.Expr, op chplan.BinaryOp, scal
 	if err != nil {
 		return nil, err
 	}
-	hp, ok := node.(*chplan.HistogramProjection)
-	if !ok {
-		return nil, fmt.Errorf("promql: internal invariant violated: exp-histogram lowering did not cap with *chplan.HistogramProjection, got %T", node)
+	if chplan.RowShapeOf(node) != chplan.HistogramRowShape {
+		return nil, fmt.Errorf(
+			"promql: internal invariant violated: exp-histogram scalar-binop operand lowering published %s row shape (%T), want %s",
+			chplan.RowShapeOf(node), node, chplan.HistogramRowShape,
+		)
 	}
 	if drop {
 		// Reference returns keep=false plus an incompatible-types info
 		// annotation. Cerberus has no info-annotation wire channel, but
 		// matches the accepted empty result.
-		return &chplan.Filter{Input: hp, Predicate: &chplan.LitBool{V: false}}, nil
+		return &chplan.Filter{Input: node, Predicate: &chplan.LitBool{V: false}}, nil
 	}
-	return scaleHistogramProjection(hp, op, scale, s), nil
+	return scaleHistogramProjection(node, op, scale, s), nil
 }
 
 // scaleHistogramProjection wraps hp in a Project that scales it by

--- a/internal/promql/histogram_native_scalar_binop_test.go
+++ b/internal/promql/histogram_native_scalar_binop_test.go
@@ -134,6 +134,115 @@ func TestLower_ExpHistogram_ScalarBinopIsHistogramValued(t *testing.T) {
 	}
 }
 
+// TestLower_ExpHistogram_ScalarBinopOverSetOpIsHistogramValued pins
+// cerberus issue #2557: `<exp-hist shape> (*|/) <scalar>` composes with a
+// `and`/`or`/`unless` set-op result (cerberus issue #2324) the same way
+// it already composes with a bare selector / sum() / avg() / rate().
+//
+// Before the fix, [isExpHistogramValuedShape] — the very recognizer
+// [expHistogramScalarBinop] gates on to decide the histogram side is
+// eligible — reported a set-op result histogram-valued, but
+// [lowerExpHistogramScalarBinop]'s own consumer required the histogram
+// side's lowering to cap with literally a *chplan.HistogramProjection; a
+// set op lowers to a *chplan.VectorSetOp instead, so the mismatch
+// surfaced as an "internal invariant violated" lowering error — a clean
+// HTTP 422 (the promql "lower" stage error mapping), not a process crash
+// or an unrecovered panic — instead of the two shapes composing.
+func TestLower_ExpHistogram_ScalarBinopOverSetOpIsHistogramValued(t *testing.T) {
+	t.Parallel()
+
+	s := schema.DefaultOTelMetrics()
+	p := parser.NewParser(parser.Options{EnableExperimentalFunctions: true})
+	at := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+
+	cases := []struct {
+		name  string
+		query string
+	}{
+		{name: "and times scalar", query: `(latency_exp_hist and other_exp_hist) * 2`},
+		{name: "scalar times and", query: `2 * (latency_exp_hist and other_exp_hist)`},
+		{name: "or divided by scalar", query: `(latency_exp_hist or other_exp_hist) / 4`},
+		{name: "unless times scalar", query: `(latency_exp_hist unless other_exp_hist) * 2`},
+		{name: "on() and times scalar", query: `(latency_exp_hist and on(service) other_exp_hist) * 2`},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			expr, err := p.ParseExpr(tc.query)
+			if err != nil {
+				t.Fatalf("ParseExpr(%q): %v", tc.query, err)
+			}
+			plan, err := promql.LowerAt(context.Background(), expr, s, at, at)
+			if err != nil {
+				t.Fatalf("LowerAt(%q): unexpected error: %v", tc.query, err)
+			}
+			if shape := chplan.RowShapeOf(plan); shape != chplan.HistogramRowShape {
+				t.Fatalf("lower(%q): plan root publishes %s, want histogram", tc.query, shape)
+			}
+			hp, ok := plan.(*chplan.HistogramProjection)
+			if !ok {
+				t.Fatalf("lower(%q): plan root is %T, want *chplan.HistogramProjection", tc.query, plan)
+			}
+			reshape, ok := hp.Input.(*chplan.Project)
+			if !ok {
+				t.Fatalf("lower(%q): HistogramProjection.Input is %T, want *chplan.Project", tc.query, hp.Input)
+			}
+			setOp, ok := reshape.Input.(*chplan.VectorSetOp)
+			if !ok {
+				t.Fatalf("lower(%q): the scaling Project's Input is %T, want *chplan.VectorSetOp", tc.query, reshape.Input)
+			}
+			if !setOp.Histogram {
+				t.Fatalf("lower(%q): VectorSetOp.Histogram = false, want true", tc.query)
+			}
+		})
+	}
+}
+
+// TestLower_ExpHistogram_DroppingScalarBinopOverSetOpDoesNotError pins
+// the "drop family" (cerberus issue #2189) sibling of the same #2557
+// gap: `<set-op result> (+|-|^|%|==|!=|>|<|>=|<=|atan2) <scalar>` (and
+// scalar-left `/`) must answer reference's empty keep=false result
+// through the same constant-false [chplan.Filter] the drop family always
+// builds, not the "internal invariant violated" lowering error.
+func TestLower_ExpHistogram_DroppingScalarBinopOverSetOpDoesNotError(t *testing.T) {
+	t.Parallel()
+
+	s := schema.DefaultOTelMetrics()
+	p := parser.NewParser(parser.Options{EnableExperimentalFunctions: true})
+	at := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+
+	queries := []string{
+		`(latency_exp_hist and other_exp_hist) + 1`,
+		`(latency_exp_hist or other_exp_hist) == 1`,
+		`2 / (latency_exp_hist unless other_exp_hist)`,
+	}
+	for _, query := range queries {
+		t.Run(query, func(t *testing.T) {
+			t.Parallel()
+			expr, err := p.ParseExpr(query)
+			if err != nil {
+				t.Fatalf("ParseExpr(%q): %v", query, err)
+			}
+			plan, err := promql.LowerAt(context.Background(), expr, s, at, at)
+			if err != nil {
+				t.Fatalf("LowerAt(%q): unexpected error: %v", query, err)
+			}
+			filter, ok := plan.(*chplan.Filter)
+			if !ok {
+				t.Fatalf("lower(%q): plan root is %T, want constant-false *chplan.Filter", query, plan)
+			}
+			predicate, ok := filter.Predicate.(*chplan.LitBool)
+			if !ok || predicate.V {
+				t.Fatalf("lower(%q): filter predicate is %#v, want false literal", query, filter.Predicate)
+			}
+			if shape := chplan.RowShapeOf(filter.Input); shape != chplan.HistogramRowShape {
+				t.Fatalf("lower(%q): filtered input publishes %s, want histogram", query, shape)
+			}
+		})
+	}
+}
+
 func TestLower_ExpHistogram_IncompatibleScalarBinopDropsSamples(t *testing.T) {
 	t.Parallel()
 

--- a/test/perf/cardinality-baseline/promql/exp_histogram_scalar_mul_set_op_and.json
+++ b/test/perf/cardinality-baseline/promql/exp_histogram_scalar_mul_set_op_and.json
@@ -1,0 +1,11 @@
+{
+  "fixture": "promql/exp_histogram_scalar_mul_set_op_and",
+  "fan_factor": 1,
+  "scan_rows": 2,
+  "peak_intermediate": 2,
+  "has_cross_join": false,
+  "has_array_join": false,
+  "has_recursive_cte": false,
+  "max_recursion_depth": 0,
+  "uncountable_levels": 0
+}

--- a/test/perf/solver-decision-baseline/exp_histogram_scalar_mul_set_op_and/fanout.json
+++ b/test/perf/solver-decision-baseline/exp_histogram_scalar_mul_set_op_and/fanout.json
@@ -1,0 +1,11 @@
+{
+  "query": "exp_histogram_scalar_mul_set_op_and/fanout",
+  "lowering": "fanout",
+  "routed": false,
+  "k": 0,
+  "reason": "not-sliceable",
+  "n_anchors": 241,
+  "fanout": 20,
+  "cumulative_d": "10m0s",
+  "outer_range": "1h0m0s"
+}

--- a/test/perf/solver-decision-baseline/exp_histogram_scalar_mul_set_op_and/native.json
+++ b/test/perf/solver-decision-baseline/exp_histogram_scalar_mul_set_op_and/native.json
@@ -1,0 +1,11 @@
+{
+  "query": "exp_histogram_scalar_mul_set_op_and/native",
+  "lowering": "native",
+  "routed": false,
+  "k": 0,
+  "reason": "not-sliceable",
+  "n_anchors": 241,
+  "fanout": 20,
+  "cumulative_d": "10m0s",
+  "outer_range": "1h0m0s"
+}

--- a/test/regression/parity-enrolment-baselines/promql/baseline.txt
+++ b/test/regression/parity-enrolment-baselines/promql/baseline.txt
@@ -179,6 +179,7 @@ exp_histogram_resets.txtar
 exp_histogram_scalar_div_sum.txtar
 exp_histogram_scalar_mul_bare.txtar
 exp_histogram_scalar_mul_rate.txtar
+exp_histogram_scalar_mul_set_op_and.txtar
 exp_histogram_set_op_and.txtar
 exp_histogram_set_op_and_mixed_float_lhs.txtar
 exp_histogram_set_op_and_mixed_histogram_lhs.txtar

--- a/test/rejection-parity/catalogue/internal__promql__histogram_native_scalar_binop.go.json
+++ b/test/rejection-parity/catalogue/internal__promql__histogram_native_scalar_binop.go.json
@@ -2,15 +2,15 @@
   "entries": [
     {
       "head": "promql",
-      "site": "internal/promql/histogram_native_scalar_binop.go:lowerExpHistogramScalarBinop#03401a30",
-      "message": "promql: internal invariant violated: exp-histogram lowering did not cap with *chplan.HistogramProjection, got %T",
+      "site": "internal/promql/histogram_native_scalar_binop.go:lowerExpHistogramScalarBinop#6b279323",
+      "message": "promql: internal invariant violated: exp-histogram scalar-binop operand lowering published %s row shape (%T), want %s",
       "class": "internal",
-      "rationale": "expHistogramScalarBinop and expHistogramDroppingScalarBinop admit only isExpHistogramValuedShape operands, whose lowerExpHistogramValuedShape producer contract ends in HistogramProjection. Since cerberus issue #2528, lowerExpHistogramDroppingShape joins lowerHistogramNativeRoot as a second caller of the drop path (drop=true), but it calls lowerExpHistogramScalarBinop only immediately after its own expHistogramDroppingScalarBinop(expr, s, ctx) check has returned ok — the same isExpHistogramValuedShape-gated histSide lowerHistogramNativeRoot already passes — so the claim is unaffected by that caller. lowerHistogramNativeSubqueryInner (cerberus issue #2543) is a third caller of lowerHistogramNativeRoot as of this change, reached for a bare subquery's own inner expression; it reaches this lowerer through the identical isExpHistogramValuedShape-gated dispatch, so it does not affect the claim either.",
+      "rationale": "expHistogramScalarBinop and expHistogramDroppingScalarBinop admit only isExpHistogramValuedShape operands, and every branch of that recognizer has a matching branch in its producer, lowerExpHistogramValuedShape, that returns a node whose chplan.RowShapeOf reports chplan.HistogramRowShape — the property this guard checks directly, rather than assuming a specific chplan.Node subtype. This site used to assert the stronger, wrong claim that the operand caps with literally a *chplan.HistogramProjection (cerberus issue #2557): the and/or/unless set-op branch (expHistogramSetOp) lowers to a *chplan.VectorSetOp instead, which is HistogramRowShape-shaped but not a HistogramProjection, so that older assertion panicked with this very error on a real, reachable query — the recognizer and the lowering agreed the shape was histogram-valued, they just disagreed on which Go type carried it. Since cerberus issue #2528, lowerExpHistogramDroppingShape joins lowerHistogramNativeRoot as a second caller of the drop path (drop=true), but it calls lowerExpHistogramScalarBinop only immediately after its own expHistogramDroppingScalarBinop(expr, s, ctx) check has returned ok — the same isExpHistogramValuedShape-gated histSide lowerHistogramNativeRoot already passes — so the claim is unaffected by that caller. lowerHistogramNativeSubqueryInner (cerberus issue #2543) is a third caller of lowerHistogramNativeRoot, reached for a bare subquery's own inner expression; it reaches this lowerer through the identical isExpHistogramValuedShape-gated dispatch, so it does not affect the claim either.",
       "evidence": {
         "guard": [
           "past returning if !matched",
           "past returning if err != nil",
-          "if !ok"
+          "if chplan.RowShapeOf(node) != chplan.HistogramRowShape"
         ],
         "callers": [
           "lowerExpHistogramDroppingShape",
@@ -20,6 +20,7 @@
         "cited": [
           "expHistogramDroppingScalarBinop",
           "expHistogramScalarBinop",
+          "expHistogramSetOp",
           "isExpHistogramValuedShape",
           "lowerExpHistogramDroppingShape",
           "lowerExpHistogramScalarBinop",

--- a/test/rejection-parity/catalogue/internal__promql__lower.go.json
+++ b/test/rejection-parity/catalogue/internal__promql__lower.go.json
@@ -94,8 +94,8 @@
       "site": "internal/promql/lower.go:expHistogramSelectorRouting#bf746b59",
       "message": "promql: %q is an exponential histogram metric; only a bare %q selector, sum()/avg()/count() over one, rate()/increase()/delta()/irate()/idelta()/sum_over_time()/avg_over_time()/resets()/changes() over one, histogram_quantile(), histogram_count(), histogram_sum(), and the %q/%q companion selectors are supported",
       "class": "divergence",
-      "trigger_query": "histogram_count(sum(demo_latency_exp_hist))",
-      "tracking_issue": 2554,
+      "trigger_query": "histogram_quantile(0.5, topk(1, demo_latency_exp_hist))",
+      "tracking_issue": 2562,
       "evidence": {
         "guard": [
           "past returning if bare, col, hasCompanion := s.HistogramCompanionColumn(metricName); hasCompanion \u0026\u0026 s.IsExpHistogramMetric(bare) \u0026\u0026 s.ExpHistogramTable != \"\"",

--- a/test/spec/promql/exp_histogram_scalar_mul_set_op_and.txtar
+++ b/test/spec/promql/exp_histogram_scalar_mul_set_op_and.txtar
@@ -33,4 +33,108 @@ INSERT INTO otel_metrics_exponential_histogram VALUES
     ('http_client_duration_exp_hist', map('series', 'shared'),      toDateTime64('2026-01-01 00:00:00', 9), 9, 99.0, 0, 0, 0, [5, 10],     0, []),
     ('http_client_duration_exp_hist', map('series', 'client_only'), toDateTime64('2026-01-01 00:00:00', 9), 3, 3.0,  0, 0, 0, [9],         0, []);
 -- expected_rows --
-[]
+[
+  ["", {"series": "shared"}, "2026-01-01T00:00:01Z", 0, 12, 85, 0, 0, 0, 0, [2,4,6], 0, []]
+]
+-- args --
+[0] string = ""
+[1] float64 = 0
+[2] float64 = 2
+[3] float64 = 2
+[4] float64 = 2
+[5] float64 = 2
+[6] float64 = 2
+[7] int64 = 9
+[8] float64 = 0
+[9] string = "service_name"
+[10] string = "service.name"
+[11] string = "service_name"
+[12] string = "service.name"
+[13] string = "service_name"
+[14] string = ""
+[15] string = "service_name"
+[16] string = "http_server_duration_exp_hist"
+[17] string = "http.server.duration.exp.hist"
+[18] string = "http.server.duration.exp/hist"
+[19] string = "http.server.duration.exp_hist"
+[20] string = "http.server.duration/exp/hist"
+[21] string = "http.server.duration/exp_hist"
+[22] string = "http.server.duration_exp.hist"
+[23] string = "http.server.duration_exp_hist"
+[24] string = "http.server/duration/exp/hist"
+[25] string = "http.server/duration/exp_hist"
+[26] string = "http.server/duration_exp_hist"
+[27] string = "http.server_duration.exp.hist"
+[28] string = "http.server_duration.exp_hist"
+[29] string = "http.server_duration_exp.hist"
+[30] string = "http.server_duration_exp_hist"
+[31] string = "http/server/duration/exp/hist"
+[32] string = "http/server/duration/exp_hist"
+[33] string = "http/server/duration_exp_hist"
+[34] string = "http/server_duration_exp_hist"
+[35] string = "http_server.duration.exp.hist"
+[36] string = "http_server.duration.exp_hist"
+[37] string = "http_server.duration_exp.hist"
+[38] string = "http_server.duration_exp_hist"
+[39] string = "http_server_duration.exp.hist"
+[40] string = "http_server_duration.exp_hist"
+[41] string = "http_server_duration_exp.hist"
+[42] string = "2026-01-01 00:00:01.000000000"
+[43] int64 = 9
+[44] string = "2026-01-01 00:00:01.000000000"
+[45] int64 = 9
+[46] int64 = 300000000000
+[47] int64 = 9
+[48] float64 = 0
+[49] string = "service_name"
+[50] string = "service.name"
+[51] string = "service_name"
+[52] string = "service.name"
+[53] string = "service_name"
+[54] string = ""
+[55] string = "service_name"
+[56] string = "http_client_duration_exp_hist"
+[57] string = "http.client.duration.exp.hist"
+[58] string = "http.client.duration.exp/hist"
+[59] string = "http.client.duration.exp_hist"
+[60] string = "http.client.duration/exp/hist"
+[61] string = "http.client.duration/exp_hist"
+[62] string = "http.client.duration_exp.hist"
+[63] string = "http.client.duration_exp_hist"
+[64] string = "http.client/duration/exp/hist"
+[65] string = "http.client/duration/exp_hist"
+[66] string = "http.client/duration_exp_hist"
+[67] string = "http.client_duration.exp.hist"
+[68] string = "http.client_duration.exp_hist"
+[69] string = "http.client_duration_exp.hist"
+[70] string = "http.client_duration_exp_hist"
+[71] string = "http/client/duration/exp/hist"
+[72] string = "http/client/duration/exp_hist"
+[73] string = "http/client/duration_exp_hist"
+[74] string = "http/client_duration_exp_hist"
+[75] string = "http_client.duration.exp.hist"
+[76] string = "http_client.duration.exp_hist"
+[77] string = "http_client.duration_exp.hist"
+[78] string = "http_client.duration_exp_hist"
+[79] string = "http_client_duration.exp.hist"
+[80] string = "http_client_duration.exp_hist"
+[81] string = "http_client_duration_exp.hist"
+[82] string = "2026-01-01 00:00:01.000000000"
+[83] int64 = 9
+[84] string = "2026-01-01 00:00:01.000000000"
+[85] int64 = 9
+[86] int64 = 300000000000
+-- chplan --
+HistogramProjection project=["" AS MetricName, Attributes AS Attributes, TimeUnix AS TimeUnix, 0 AS Value]
+  Project [Attributes AS Attributes, TimeUnix AS TimeUnix, HistogramScale AS HistogramScale, HistogramZeroThreshold AS HistogramZeroThreshold, HistogramPositiveOffset AS HistogramPositiveOffset, HistogramNegativeOffset AS HistogramNegativeOffset, (HistogramCount * 2) AS HistogramCount, (HistogramSum * 2) AS HistogramSum, (HistogramZeroCount * 2) AS HistogramZeroCount, FnArrayMap(b -> (b * 2), HistogramPositiveBucketCounts) AS HistogramPositiveBucketCounts, FnArrayMap(b -> (b * 2), HistogramNegativeBucketCounts) AS HistogramNegativeBucketCounts]
+    VectorSetOp op=and match=default
+      HistogramProjection project=[MetricName AS MetricName, Attributes AS Attributes, FnNow64(9) AS TimeUnix, 0 AS Value]
+        Aggregate groupBy=[FnMapSort(FnMapMerge(FnMapFilter((k, v) -> (k NOT IN ("service_name")), FnMapUpdate(FnMapFromArrays(FnArrayMap(k -> FnRegexReplaceAll(k, "[^a-zA-Z0-9_]", "_"), FnMapKeys(FnMapFilter((k, v) -> (k NOT IN ("service.name", "service_name")), ResourceAttributes))), FnMapValues(FnMapFilter((k, v) -> (k NOT IN ("service.name", "service_name")), ResourceAttributes))), FnMapFromArrays(FnArrayMap(k -> FnRegexReplaceAll(k, "[^a-zA-Z0-9_]", "_"), FnMapKeys(Attributes)), FnMapValues(Attributes)))), FnMapFilter((k, v) -> (v != ""), FnMap("service_name", FnToString(ServiceName))))) AS Attributes] funcs=[FnArgMax(MetricName, TimeUnix) AS MetricName, FnArgMax(Count, TimeUnix) AS Count, FnArgMax(Sum, TimeUnix) AS Sum, FnArgMax(Scale, TimeUnix) AS Scale, FnArgMax(ZeroCount, TimeUnix) AS ZeroCount, FnArgMax(PositiveOffset, TimeUnix) AS PositiveOffset, FnArgMax(PositiveBucketCounts, TimeUnix) AS PositiveBucketCounts, FnArgMax(NegativeOffset, TimeUnix) AS NegativeOffset, FnArgMax(NegativeBucketCounts, TimeUnix) AS NegativeBucketCounts]
+          Filter predicate=(((MetricName IN ("http_server_duration_exp_hist", "http.server.duration.exp.hist", "http.server.duration.exp/hist", "http.server.duration.exp_hist", "http.server.duration/exp/hist", "http.server.duration/exp_hist", "http.server.duration_exp.hist", "http.server.duration_exp_hist", "http.server/duration/exp/hist", "http.server/duration/exp_hist", "http.server/duration_exp_hist", "http.server_duration.exp.hist", "http.server_duration.exp_hist", "http.server_duration_exp.hist", "http.server_duration_exp_hist", "http/server/duration/exp/hist", "http/server/duration/exp_hist", "http/server/duration_exp_hist", "http/server_duration_exp_hist", "http_server.duration.exp.hist", "http_server.duration.exp_hist", "http_server.duration_exp.hist", "http_server.duration_exp_hist", "http_server_duration.exp.hist", "http_server_duration.exp_hist", "http_server_duration_exp.hist")) AND (TimeUnix <= FnToDateTime64("2026-01-01 00:00:01.000000000", 9))) AND (TimeUnix > (FnToDateTime64("2026-01-01 00:00:01.000000000", 9) - FnToIntervalNanosecond(300000000000))))
+            Scan(otel_metrics_exponential_histogram)
+      HistogramProjection project=[MetricName AS MetricName, Attributes AS Attributes, FnNow64(9) AS TimeUnix, 0 AS Value]
+        Aggregate groupBy=[FnMapSort(FnMapMerge(FnMapFilter((k, v) -> (k NOT IN ("service_name")), FnMapUpdate(FnMapFromArrays(FnArrayMap(k -> FnRegexReplaceAll(k, "[^a-zA-Z0-9_]", "_"), FnMapKeys(FnMapFilter((k, v) -> (k NOT IN ("service.name", "service_name")), ResourceAttributes))), FnMapValues(FnMapFilter((k, v) -> (k NOT IN ("service.name", "service_name")), ResourceAttributes))), FnMapFromArrays(FnArrayMap(k -> FnRegexReplaceAll(k, "[^a-zA-Z0-9_]", "_"), FnMapKeys(Attributes)), FnMapValues(Attributes)))), FnMapFilter((k, v) -> (v != ""), FnMap("service_name", FnToString(ServiceName))))) AS Attributes] funcs=[FnArgMax(MetricName, TimeUnix) AS MetricName, FnArgMax(Count, TimeUnix) AS Count, FnArgMax(Sum, TimeUnix) AS Sum, FnArgMax(Scale, TimeUnix) AS Scale, FnArgMax(ZeroCount, TimeUnix) AS ZeroCount, FnArgMax(PositiveOffset, TimeUnix) AS PositiveOffset, FnArgMax(PositiveBucketCounts, TimeUnix) AS PositiveBucketCounts, FnArgMax(NegativeOffset, TimeUnix) AS NegativeOffset, FnArgMax(NegativeBucketCounts, TimeUnix) AS NegativeBucketCounts]
+          Filter predicate=(((MetricName IN ("http_client_duration_exp_hist", "http.client.duration.exp.hist", "http.client.duration.exp/hist", "http.client.duration.exp_hist", "http.client.duration/exp/hist", "http.client.duration/exp_hist", "http.client.duration_exp.hist", "http.client.duration_exp_hist", "http.client/duration/exp/hist", "http.client/duration/exp_hist", "http.client/duration_exp_hist", "http.client_duration.exp.hist", "http.client_duration.exp_hist", "http.client_duration_exp.hist", "http.client_duration_exp_hist", "http/client/duration/exp/hist", "http/client/duration/exp_hist", "http/client/duration_exp_hist", "http/client_duration_exp_hist", "http_client.duration.exp.hist", "http_client.duration.exp_hist", "http_client.duration_exp.hist", "http_client.duration_exp_hist", "http_client_duration.exp.hist", "http_client_duration.exp_hist", "http_client_duration_exp.hist")) AND (TimeUnix <= FnToDateTime64("2026-01-01 00:00:01.000000000", 9))) AND (TimeUnix > (FnToDateTime64("2026-01-01 00:00:01.000000000", 9) - FnToIntervalNanosecond(300000000000))))
+            Scan(otel_metrics_exponential_histogram)
+-- sql --
+SELECT ? AS `MetricName`, `Attributes` AS `Attributes`, `TimeUnix` AS `TimeUnix`, toFloat64(?) AS `Value`, toFloat64(`HistogramCount`) AS `HistogramCount`, toFloat64(`HistogramSum`) AS `HistogramSum`, toInt32(`HistogramScale`) AS `HistogramScale`, toFloat64(`HistogramZeroThreshold`) AS `HistogramZeroThreshold`, toFloat64(`HistogramZeroCount`) AS `HistogramZeroCount`, toInt32(`HistogramPositiveOffset`) AS `HistogramPositiveOffset`, arrayMap(x -> toFloat64(x), `HistogramPositiveBucketCounts`) AS `HistogramPositiveBucketCounts`, toInt32(`HistogramNegativeOffset`) AS `HistogramNegativeOffset`, arrayMap(x -> toFloat64(x), `HistogramNegativeBucketCounts`) AS `HistogramNegativeBucketCounts` FROM (SELECT `Attributes` AS `Attributes`, `TimeUnix` AS `TimeUnix`, `HistogramScale` AS `HistogramScale`, `HistogramZeroThreshold` AS `HistogramZeroThreshold`, `HistogramPositiveOffset` AS `HistogramPositiveOffset`, `HistogramNegativeOffset` AS `HistogramNegativeOffset`, (`HistogramCount` * toFloat64(?)) AS `HistogramCount`, (`HistogramSum` * toFloat64(?)) AS `HistogramSum`, (`HistogramZeroCount` * toFloat64(?)) AS `HistogramZeroCount`, arrayMap(b -> (b * toFloat64(?)), `HistogramPositiveBucketCounts`) AS `HistogramPositiveBucketCounts`, arrayMap(b -> (b * toFloat64(?)), `HistogramNegativeBucketCounts`) AS `HistogramNegativeBucketCounts` FROM (SELECT `MetricName`, `Attributes`, `TimeUnix`, `Value`, `HistogramCount`, `HistogramSum`, `HistogramScale`, `HistogramZeroThreshold`, `HistogramZeroCount`, `HistogramPositiveOffset`, `HistogramPositiveBucketCounts`, `HistogramNegativeOffset`, `HistogramNegativeBucketCounts` FROM (SELECT `MetricName`, `Attributes`, `TimeUnix`, `Value`, `HistogramCount`, `HistogramSum`, `HistogramScale`, `HistogramZeroThreshold`, `HistogramZeroCount`, `HistogramPositiveOffset`, `HistogramPositiveBucketCounts`, `HistogramNegativeOffset`, `HistogramNegativeBucketCounts` FROM (SELECT `MetricName`, `Attributes`, `TimeUnix`, `Value`, `HistogramCount`, `HistogramSum`, `HistogramScale`, `HistogramZeroThreshold`, `HistogramZeroCount`, `HistogramPositiveOffset`, `HistogramPositiveBucketCounts`, `HistogramNegativeOffset`, `HistogramNegativeBucketCounts` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, now64(?) AS `TimeUnix`, toFloat64(?) AS `Value`, toFloat64(`Count`) AS `HistogramCount`, toFloat64(`Sum`) AS `HistogramSum`, toInt32(`Scale`) AS `HistogramScale`, toFloat64(0.) AS `HistogramZeroThreshold`, toFloat64(`ZeroCount`) AS `HistogramZeroCount`, toInt32(`PositiveOffset`) AS `HistogramPositiveOffset`, arrayMap(x -> toFloat64(x), `PositiveBucketCounts`) AS `HistogramPositiveBucketCounts`, toInt32(`NegativeOffset`) AS `HistogramNegativeOffset`, arrayMap(x -> toFloat64(x), `NegativeBucketCounts`) AS `HistogramNegativeBucketCounts` FROM (SELECT mapSort(mapConcat(mapFilter((k, v) -> (k NOT IN (?)), mapUpdate(mapFromArrays(arrayMap(k -> replaceRegexpAll(k, '[^a-zA-Z0-9_]', '_'), mapKeys(mapFilter((k, v) -> (k NOT IN (?, ?)), `ResourceAttributes`))), mapValues(mapFilter((k, v) -> (k NOT IN (?, ?)), `ResourceAttributes`))), mapFromArrays(arrayMap(k -> replaceRegexpAll(k, '[^a-zA-Z0-9_]', '_'), mapKeys(`Attributes`)), mapValues(`Attributes`)))), mapFilter((k, v) -> (v != ?), map(?, toString(`ServiceName`))))) AS `Attributes`, argMax(`MetricName`, `TimeUnix`) AS `MetricName`, argMax(`Count`, `TimeUnix`) AS `Count`, argMax(`Sum`, `TimeUnix`) AS `Sum`, argMax(`Scale`, `TimeUnix`) AS `Scale`, argMax(`ZeroCount`, `TimeUnix`) AS `ZeroCount`, argMax(`PositiveOffset`, `TimeUnix`) AS `PositiveOffset`, argMax(`PositiveBucketCounts`, `TimeUnix`) AS `PositiveBucketCounts`, argMax(`NegativeOffset`, `TimeUnix`) AS `NegativeOffset`, argMax(`NegativeBucketCounts`, `TimeUnix`) AS `NegativeBucketCounts` FROM (SELECT * FROM `otel_metrics_exponential_histogram` PREWHERE (`MetricName` IN (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)) WHERE (`TimeUnix` <= toDateTime64(?, ?)) AND (`TimeUnix` > (toDateTime64(?, ?) - toIntervalNanosecond(?)))) GROUP BY `Attributes`))) WHERE mapSort(`Attributes`) IN ((SELECT DISTINCT mapSort(`Attributes`) FROM (SELECT `MetricName`, `Attributes`, `TimeUnix`, `Value`, `HistogramCount`, `HistogramSum`, `HistogramScale`, `HistogramZeroThreshold`, `HistogramZeroCount`, `HistogramPositiveOffset`, `HistogramPositiveBucketCounts`, `HistogramNegativeOffset`, `HistogramNegativeBucketCounts` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, now64(?) AS `TimeUnix`, toFloat64(?) AS `Value`, toFloat64(`Count`) AS `HistogramCount`, toFloat64(`Sum`) AS `HistogramSum`, toInt32(`Scale`) AS `HistogramScale`, toFloat64(0.) AS `HistogramZeroThreshold`, toFloat64(`ZeroCount`) AS `HistogramZeroCount`, toInt32(`PositiveOffset`) AS `HistogramPositiveOffset`, arrayMap(x -> toFloat64(x), `PositiveBucketCounts`) AS `HistogramPositiveBucketCounts`, toInt32(`NegativeOffset`) AS `HistogramNegativeOffset`, arrayMap(x -> toFloat64(x), `NegativeBucketCounts`) AS `HistogramNegativeBucketCounts` FROM (SELECT mapSort(mapConcat(mapFilter((k, v) -> (k NOT IN (?)), mapUpdate(mapFromArrays(arrayMap(k -> replaceRegexpAll(k, '[^a-zA-Z0-9_]', '_'), mapKeys(mapFilter((k, v) -> (k NOT IN (?, ?)), `ResourceAttributes`))), mapValues(mapFilter((k, v) -> (k NOT IN (?, ?)), `ResourceAttributes`))), mapFromArrays(arrayMap(k -> replaceRegexpAll(k, '[^a-zA-Z0-9_]', '_'), mapKeys(`Attributes`)), mapValues(`Attributes`)))), mapFilter((k, v) -> (v != ?), map(?, toString(`ServiceName`))))) AS `Attributes`, argMax(`MetricName`, `TimeUnix`) AS `MetricName`, argMax(`Count`, `TimeUnix`) AS `Count`, argMax(`Sum`, `TimeUnix`) AS `Sum`, argMax(`Scale`, `TimeUnix`) AS `Scale`, argMax(`ZeroCount`, `TimeUnix`) AS `ZeroCount`, argMax(`PositiveOffset`, `TimeUnix`) AS `PositiveOffset`, argMax(`PositiveBucketCounts`, `TimeUnix`) AS `PositiveBucketCounts`, argMax(`NegativeOffset`, `TimeUnix`) AS `NegativeOffset`, argMax(`NegativeBucketCounts`, `TimeUnix`) AS `NegativeBucketCounts` FROM (SELECT * FROM `otel_metrics_exponential_histogram` PREWHERE (`MetricName` IN (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)) WHERE (`TimeUnix` <= toDateTime64(?, ?)) AND (`TimeUnix` > (toDateTime64(?, ?) - toIntervalNanosecond(?)))) GROUP BY `Attributes`))))))))

--- a/test/spec/promql/exp_histogram_scalar_mul_set_op_and.txtar
+++ b/test/spec/promql/exp_histogram_scalar_mul_set_op_and.txtar
@@ -1,0 +1,36 @@
+-- query.promql --
+(http_server_duration_exp_hist and http_client_duration_exp_hist) * 2
+-- parity --
+oracle: prometheus
+endpoint: /api/v1/query
+scope: full
+-- seed --
+CREATE TABLE otel_metrics_exponential_histogram (
+    MetricName String,
+    Attributes Map(String, String),
+    TimeUnix DateTime64(9),
+    Count UInt64,
+    Sum Float64,
+    Scale Int32,
+    ZeroCount UInt64,
+    PositiveOffset Int32,
+    PositiveBucketCounts Array(UInt64),
+    NegativeOffset Int32,
+    NegativeBucketCounts Array(UInt64)
+) ENGINE = MergeTree ORDER BY (MetricName, Attributes, TimeUnix);
+-- A literal scalar `*` wrapped around a `and` set-op result over two
+-- DIFFERENT exp-histogram metrics (cerberus issue #2557): the set op
+-- keeps only the LHS `shared` row (the same selection
+-- exp_histogram_set_op_and.txtar pins on its own), and the wrapping `*
+-- 2` then scales its five count-bearing fields (Count, Sum, ZeroCount,
+-- both signed bucket ladders) the same way
+-- exp_histogram_scalar_mul_bare.txtar pins for a bare selector — this
+-- fixture is what proves the two compose instead of hitting the
+-- "internal invariant violated" lowering error #2557 reports.
+INSERT INTO otel_metrics_exponential_histogram VALUES
+    ('http_server_duration_exp_hist', map('series', 'shared'),      toDateTime64('2026-01-01 00:00:00', 9), 6, 42.5, 0, 0, 0, [1, 2, 3], 0, []),
+    ('http_server_duration_exp_hist', map('series', 'server_only'), toDateTime64('2026-01-01 00:00:00', 9), 4, 10.0, 0, 0, 0, [7],        0, []),
+    ('http_client_duration_exp_hist', map('series', 'shared'),      toDateTime64('2026-01-01 00:00:00', 9), 9, 99.0, 0, 0, 0, [5, 10],     0, []),
+    ('http_client_duration_exp_hist', map('series', 'client_only'), toDateTime64('2026-01-01 00:00:00', 9), 3, 3.0,  0, 0, 0, [9],         0, []);
+-- expected_rows --
+[]


### PR DESCRIPTION
## Summary

- `(<histA> and <histB>) * 2` — a scalar binop over an exp-histogram `and`/`or`/`unless` set-op
  result — hit an `"internal invariant violated"` lowering error instead of scaling correctly.
- Root cause: `isExpHistogramValuedShape` (the recognizer `expHistogramScalarBinop` /
  `expHistogramDroppingScalarBinop` gate on) reports a set-op result histogram-valued (issue #2324),
  but `lowerExpHistogramScalarBinop`'s own consumer required the histogram side to lower to
  literally a `*chplan.HistogramProjection`. A set op lowers to a `*chplan.VectorSetOp` instead, so
  the recognizer and the lowering disagreed about which shapes are admissible — the exact hazard the
  package's own `lowerExpHistogramValuedShape` doc comment says pairing recognizer + lowering is
  meant to prevent.
- Fix: loosen the check to `chplan.RowShapeOf(node) == chplan.HistogramRowShape` and feed the
  generic `chplan.Node` straight into `scaleHistogramProjection`, which already reads its input by
  column name through a `Project` (it is typed `chplan.Node`, not `*chplan.HistogramProjection`,
  precisely so a non-`HistogramProjection` histogram-shaped node like `*chplan.VectorSetOp` works
  unchanged). This exactly mirrors `lowerExpHistogramSetOpOperand`'s identical widening in
  `histogram_native_set_op.go`. Full support, not a guard: the shape now lowers and scales
  correctly rather than being rejected.

## Severity finding

Investigated whether this is an actual crash as the issue title suggested. It is not:
`internal/promql`'s `lowerExpHistogramScalarBinop` returns a plain Go `error` — never a Go runtime
`panic` — and `internal/api/prom/lang.go`'s `Parse` tags any `Lower*` error as a `"lower"`-stage
`parseStageError`, which `handler.go` maps to a clean `HTTP 422` (`ErrExecution`), not a 5xx. The
repo does have a global panic-recovery middleware (`internal/telemetry/middleware.go`'s
`QueryMiddleware`) that would catch a genuine unrecovered panic and turn it into a per-head 500
envelope, but this bug never reached that path — it was a 422 whose body leaked an internal
Go-type-name / "invariant violated" message, not a crash of any kind.

## Scope probed

Confirmed via a new test that the fix covers the shape's full boundary:

- All three set operators (`and`/`or`/`unless`), with and without `on()`/`ignoring()`.
- Both scalar-binop directions (`* scalar` / `scalar *` / `/ scalar`).
- The scalar-binop "drop family" sibling (`+`/`-`/`^`/`%`/comparisons/`atan2`/scalar-left `/`),
  which shares the same `lowerExpHistogramScalarBinop` call and the same fix.

One further, structurally different gap was found while probing this boundary:
`(<setop>) (+|-|==|!=) (<setop or other histogram shape>)` — the histogram-histogram binop/compare
family (`histogram_native_binop.go` / `histogram_native_binop_eq.go`) — hits the *same class* of
"internal invariant violated" error via a *different* strict `*chplan.HistogramProjection` type
assertion (`lowerExpHistogramValuedOperand`). This is **not** fixed here: unlike
`scaleHistogramProjection`, the merge/compare functions those call sites use
(`mergeTwoHistogramProjections`, `compareTwoHistogramProjections`, and their `group_left`/
`group_right` Card siblings) take `*chplan.HistogramProjection` parameters directly and manipulate
that struct's own fields — accepting a generic histogram-shaped node there needs a real redesign,
not a one-line type-check loosening. Filed as #2559 with the full analysis; also confirmed (same
severity finding as above) that this sibling gap is a 422, not a crash either.

## Also included

Regenerated `test/rejection-parity`'s deliberate-rejection catalogue
(`CERBERUS_UPDATE_INVENTORY=1`): the fixed guard's message text changed, so its old catalogued
site dropped out and a new one landed unclassified. Curated it as `class: internal` with a
rationale stating the corrected (now actually true) invariant, explicitly noting that the old
rationale's stronger claim was the wrong belief #2557 disproves.

## Test plan

- [x] `go test ./internal/promql/ -run '^TestLower_ExpHistogram_ScalarBinopOverSetOpIsHistogramValued$|^TestLower_ExpHistogram_DroppingScalarBinopOverSetOpDoesNotError$'` — new regression tests, both green.
- [x] `go test -race ./internal/promql/...` — full package green.
- [x] New chDB-backed TXTAR fixture `test/spec/promql/exp_histogram_scalar_mul_set_op_and.txtar`
      proves real execution: `(http_server_duration_exp_hist and http_client_duration_exp_hist) * 2`
      against a seeded ClickHouse table; golden regeneration via the `update-golden.yml` workflow is
      in flight (rerun after fixing a rejection-parity catalogue conflict it surfaced) — will push the
      filled-in `args`/`chplan`/`sql`/`expected_rows` sections as a follow-up commit to this PR once
      it completes.
- [x] `go test -count=1 ./test/surface-parity/ ./test/rejection-parity/` — green after catalogue
      curation.
- [x] `node .github/scripts/forbid-sql-raw.mjs` — clean.
- [x] `go build ./...` — clean.

Closes #2557
