### PR TITLE
fix(promql): drop float-only range-vector fns to empty over a native-histogram subquery

### DIFF
--- a/internal/promql/histogram_native_subquery_select_test.go
+++ b/internal/promql/histogram_native_subquery_select_test.go
@@ -142,11 +142,11 @@ func TestLower_ExpHistogram_DropFamilyEmptyOverSubquery(t *testing.T) {
 				t.Errorf("lower(%q) range RowShape = %s, want %s", tc.query, got, chplan.SampleRowShape)
 			}
 
-			pinned := fmt.Sprintf(`%s @ %s`, tc.query, pinnedAt)
 			// predict_linear / quantile_over_time / holt_winters carry the
 			// subquery as an inner argument rather than the whole call, so
 			// `@` cannot pin the whole expression the way the select-family
 			// test above does; pin the subquery itself instead.
+			var pinned string
 			switch tc.name {
 			case "predict_linear":
 				pinned = fmt.Sprintf(`predict_linear((latency_exp_hist)[5m:1m] @ %s, 60)`, pinnedAt)

--- a/internal/promql/histogram_native_subquery_select_test.go
+++ b/internal/promql/histogram_native_subquery_select_test.go
@@ -83,50 +83,110 @@ func TestLower_ExpHistogram_SelectFamilyOverSubquery(t *testing.T) {
 	}
 }
 
-// TestLower_ExpHistogram_DropFamilyStillRejectedOverSubquery pins cerberus
-// issue #2545's category (b): reference Prometheus's own range-vector
-// functions that read ONLY `matrixVal[0].Floats` (max_over_time,
-// min_over_time, stddev_over_time, stdvar_over_time, quantile_over_time,
-// mad_over_time, deriv, predict_linear, double_exponential_smoothing aka
-// holt_winters, ts_of_max_over_time, ts_of_min_over_time — each function's
-// own doc in tsouza/prometheus's promql/functions.go) have no real
-// histogram semantics to give an all-histogram subquery matrix, so
-// [lowerOuterRangeFnOverSubquery]'s pre-existing histogram-shape guard
-// (cerberus issue #2543) must keep rejecting every one of them, unchanged.
-func TestLower_ExpHistogram_DropFamilyStillRejectedOverSubquery(t *testing.T) {
+// TestLower_ExpHistogram_DropFamilyEmptyOverSubquery pins cerberus issue
+// #2563: reference Prometheus's own range-vector functions that read ONLY
+// `matrixVal[0].Floats` (max_over_time, min_over_time, stddev_over_time,
+// stdvar_over_time, quantile_over_time, mad_over_time, deriv,
+// predict_linear, double_exponential_smoothing aka holt_winters,
+// ts_of_max_over_time, ts_of_min_over_time — each function's own doc in
+// tsouza/prometheus's promql/functions.go) have no real histogram
+// semantics to give an all-histogram subquery matrix, so reference itself
+// answers an ordinary EMPTY float vector — never an error — the same
+// "no data in the window" case any other function sees over an empty
+// lookback. [lowerOuterRangeFnOverSubquery]'s histogram-shape guard
+// (cerberus issue #2543) used to raise a hard promql-level error for this
+// shape instead; #2563 replaced that with the canonical
+// [dropExpHistogramSamples] empty-float lowering, gated on
+// [histogramSubqueryFloatOnlyDropFunc].
+func TestLower_ExpHistogram_DropFamilyEmptyOverSubquery(t *testing.T) {
+	t.Parallel()
+
+	s := schema.DefaultOTelMetrics()
+	start := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	end := start.Add(time.Hour)
+	pinnedAt := "1767225600" // 2026-01-01T00:00:00Z, matches `start`
+
+	for _, tc := range []struct {
+		name  string
+		query string
+	}{
+		{name: "max_over_time", query: `max_over_time((latency_exp_hist)[5m:1m])`},
+		{name: "min_over_time", query: `min_over_time((latency_exp_hist)[5m:1m])`},
+		{name: "stddev_over_time", query: `stddev_over_time((latency_exp_hist)[5m:1m])`},
+		{name: "stdvar_over_time", query: `stdvar_over_time((latency_exp_hist)[5m:1m])`},
+		{name: "mad_over_time", query: `mad_over_time((latency_exp_hist)[5m:1m])`},
+		{name: "deriv", query: `deriv((latency_exp_hist)[5m:1m])`},
+		{name: "ts_of_max_over_time", query: `ts_of_max_over_time((latency_exp_hist)[5m:1m])`},
+		{name: "ts_of_min_over_time", query: `ts_of_min_over_time((latency_exp_hist)[5m:1m])`},
+		{name: "quantile_over_time", query: `quantile_over_time(0.5, (latency_exp_hist)[5m:1m])`},
+		{name: "predict_linear", query: `predict_linear((latency_exp_hist)[5m:1m], 60)`},
+		{name: "holt_winters", query: `double_exponential_smoothing((latency_exp_hist)[5m:1m], 0.5, 0.5)`},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			expr := parseExprExp(t, tc.query)
+
+			plan, err := promql.LowerAt(context.Background(), expr, s, end, end)
+			if err != nil {
+				t.Fatalf("lower(%q) instant: %v", tc.query, err)
+			}
+			if got := chplan.RowShapeOf(plan); got != chplan.SampleRowShape {
+				t.Errorf("lower(%q) instant RowShape = %s, want %s", tc.query, got, chplan.SampleRowShape)
+			}
+
+			rplan, err := promql.LowerAtRange(context.Background(), expr, s, start, end, time.Minute)
+			if err != nil {
+				t.Fatalf("lower(%q) range: %v", tc.query, err)
+			}
+			if got := chplan.RowShapeOf(rplan); got != chplan.SampleRowShape {
+				t.Errorf("lower(%q) range RowShape = %s, want %s", tc.query, got, chplan.SampleRowShape)
+			}
+
+			pinned := fmt.Sprintf(`%s @ %s`, tc.query, pinnedAt)
+			// predict_linear / quantile_over_time / holt_winters carry the
+			// subquery as an inner argument rather than the whole call, so
+			// `@` cannot pin the whole expression the way the select-family
+			// test above does; pin the subquery itself instead.
+			switch tc.name {
+			case "predict_linear":
+				pinned = fmt.Sprintf(`predict_linear((latency_exp_hist)[5m:1m] @ %s, 60)`, pinnedAt)
+			case "quantile_over_time":
+				pinned = fmt.Sprintf(`quantile_over_time(0.5, (latency_exp_hist)[5m:1m] @ %s)`, pinnedAt)
+			case "holt_winters":
+				pinned = fmt.Sprintf(`double_exponential_smoothing((latency_exp_hist)[5m:1m] @ %s, 0.5, 0.5)`, pinnedAt)
+			default:
+				pinned = fmt.Sprintf(`%s((latency_exp_hist)[5m:1m] @ %s)`, tc.name, pinnedAt)
+			}
+			pexpr := parseExprExp(t, pinned)
+			pplan, err := promql.LowerAtRange(context.Background(), pexpr, s, start, end, time.Minute)
+			if err != nil {
+				t.Fatalf("lower(%q) pinned: %v", pinned, err)
+			}
+			if got := chplan.RowShapeOf(pplan); got != chplan.SampleRowShape {
+				t.Errorf("lower(%q) pinned RowShape = %s, want %s", pinned, got, chplan.SampleRowShape)
+			}
+		})
+	}
+}
+
+// TestLower_ExpHistogram_DropFamilyOverSubquery_ScalarParamStillValidated
+// pins the param-before-drop discipline [lowerOuterRangeFnOverSubquery]'s
+// empty-drop branch owes reference Prometheus: holt_winters/
+// double_exponential_smoothing validates its smoothing factors' (0, 1)
+// domain BEFORE ever walking the window's samples, so an out-of-domain
+// factor must still surface as a lowering error even though the window
+// this query's subquery resolves to is all-histogram and would otherwise
+// answer empty.
+func TestLower_ExpHistogram_DropFamilyOverSubquery_ScalarParamStillValidated(t *testing.T) {
 	t.Parallel()
 
 	s := schema.DefaultOTelMetrics()
 	end := time.Date(2026, 1, 1, 1, 0, 0, 0, time.UTC)
 
-	for _, tc := range []struct {
-		name  string
-		query string
-		fn    string
-	}{
-		{name: "max_over_time", query: `max_over_time((latency_exp_hist)[5m:1m])`, fn: "max_over_time"},
-		{name: "min_over_time", query: `min_over_time((latency_exp_hist)[5m:1m])`, fn: "min_over_time"},
-		{name: "stddev_over_time", query: `stddev_over_time((latency_exp_hist)[5m:1m])`, fn: "stddev_over_time"},
-		{name: "stdvar_over_time", query: `stdvar_over_time((latency_exp_hist)[5m:1m])`, fn: "stdvar_over_time"},
-		{name: "mad_over_time", query: `mad_over_time((latency_exp_hist)[5m:1m])`, fn: "mad_over_time"},
-		{name: "deriv", query: `deriv((latency_exp_hist)[5m:1m])`, fn: "deriv"},
-		{name: "ts_of_max_over_time", query: `ts_of_max_over_time((latency_exp_hist)[5m:1m])`, fn: "ts_of_max_over_time"},
-		{name: "ts_of_min_over_time", query: `ts_of_min_over_time((latency_exp_hist)[5m:1m])`, fn: "ts_of_min_over_time"},
-		{name: "quantile_over_time", query: `quantile_over_time(0.5, (latency_exp_hist)[5m:1m])`, fn: "quantile_over_time"},
-		{name: "predict_linear", query: `predict_linear((latency_exp_hist)[5m:1m], 60)`, fn: "predict_linear"},
-		{name: "holt_winters", query: `double_exponential_smoothing((latency_exp_hist)[5m:1m], 0.5, 0.5)`, fn: "double_exponential_smoothing"},
-	} {
-		t.Run(tc.name, func(t *testing.T) {
-			t.Parallel()
-			expr := parseExprExp(t, tc.query)
-			_, err := promql.LowerAt(context.Background(), expr, s, end, end)
-			if err == nil {
-				t.Fatalf("lower(%q): got nil error, want the native-histogram-valued-subquery rejection", tc.query)
-			}
-			wantMsg := fmt.Sprintf("promql: %s over a subquery wrapping a native-histogram-valued shape is unsupported", tc.fn)
-			if err.Error() != wantMsg {
-				t.Errorf("lower(%q) error = %q, want %q", tc.query, err.Error(), wantMsg)
-			}
-		})
+	query := `double_exponential_smoothing((latency_exp_hist)[5m:1m], 1.5, 0.5)`
+	expr := parseExprExp(t, query)
+	_, err := promql.LowerAt(context.Background(), expr, s, end, end)
+	if err == nil {
+		t.Fatalf("lower(%q): got nil error, want an out-of-domain smoothing-factor rejection", query)
 	}
 }

--- a/internal/promql/subquery.go
+++ b/internal/promql/subquery.go
@@ -790,41 +790,64 @@ func lowerOuterRangeFnOverSubquery(
 		return nil, err
 	}
 	// A subquery whose OWN inner expression resolved histogram-native
-	// (cerberus issue #2543, [lowerHistogramNativeSubqueryInner]) is a
-	// deliberately unsupported composition for the functions that reach
-	// this point: this reducer's RangeWindow below folds over
-	// TimestampColumn "anchor_ts" / ValueColumn s.ValueColumn, and a
-	// histogram-shaped row publishes neither meaningfully — Value is only
-	// the placeholder [chplan.HistogramProjection] always carries
-	// alongside its real nine Histogram*Column fields (see that type's own
-	// doc comment). Rejecting explicitly here, rather than letting the
-	// RangeWindow below reference a column the histogram-shaped relation
-	// never publishes, turns what would otherwise be a ClickHouse "Unknown
-	// identifier" 502 into a clear promql-level error.
+	// (cerberus issue #2543, [lowerHistogramNativeSubqueryInner]) reaches
+	// this reducer's RangeWindow below, which folds over TimestampColumn
+	// "anchor_ts" / ValueColumn s.ValueColumn — columns a histogram-shaped
+	// row publishes neither meaningfully (Value is only the placeholder
+	// [chplan.HistogramProjection] always carries alongside its real nine
+	// Histogram*Column fields; see that type's own doc comment). The
+	// RangeWindow below must never be built over one, on pain of a
+	// ClickHouse "Unknown identifier" 502.
 	//
-	// This is reachable ONLY for the functions reference Prometheus itself
-	// defines no real histogram semantics for — max_over_time,
-	// min_over_time, stddev_over_time, stdvar_over_time,
+	// max_over_time, min_over_time, stddev_over_time, stdvar_over_time,
 	// quantile_over_time, mad_over_time, deriv, predict_linear,
 	// double_exponential_smoothing (holt_winters), ts_of_max_over_time,
-	// ts_of_min_over_time — each of which reads only
+	// ts_of_min_over_time are the functions reference Prometheus itself
+	// defines no real histogram semantics for — each reads only
 	// `matrixVal[0].Floats` in reference (tsouza/prometheus's
 	// promql/functions.go), so an all-histogram window has nothing for
-	// them to answer. Cerberus issue #2545 gave the REMAINING functions
-	// that do have real histogram semantics — count_over_time,
-	// present_over_time, last_over_time, first_over_time, resets, changes,
+	// them to answer and reference itself answers EMPTY (annotated with a
+	// "histogram(s) ignored" warning cerberus has no wire channel for),
+	// never an error. [histogramSubqueryFloatOnlyDropFunc] names exactly
+	// this eleven-function set — cerberus issue #2563, the
+	// subquery-composition sibling of [rangeVectorFloatOnlyDropFuncs] /
+	// [dropExpHistogramSamplesForRangeVector]'s identical plain
+	// MatrixSelector coverage (range_fns.go) — and this branch answers the
+	// canonical drop-and-empty plan [dropExpHistogramSamples] builds,
+	// after validating the outer call's own scalar parameter(s) exactly as
+	// the plain-matrix siblings do: reference validates predict_linear's
+	// horizon / holt_winters' smoothing factors / quantile_over_time's phi
+	// BEFORE ever walking the window's samples, so an invalid parameter
+	// must still surface as an error even though every window is about to
+	// answer empty (mirrors
+	// [validateHistogramDroppingAggregationParam]'s identical
+	// param-before-drop discipline, histogram_native_drop_aggregation.go).
+	// A throwaway RangeWindow absorbs [threadOuterRangeFnScalars]'s
+	// mutations since nothing downstream ever reads them: an empty result
+	// has no row for any Value expression — original or phi-folded — to
+	// appear on.
+	//
+	// Cerberus issue #2545 gave the REMAINING functions that DO have real
+	// histogram semantics — count_over_time, present_over_time,
+	// last_over_time, first_over_time, resets, changes,
 	// ts_of_first_over_time, ts_of_last_over_time — their own dedicated
 	// lowering ([selectFnOverExpHistogramSubquery] /
 	// [lowerSelectFnOverExpHistogramSubquery],
 	// histogram_native_subquery_select.go), dispatched from
 	// [lowerHistogramNativeRoot] ahead of the generic `lower()` path that
 	// reaches this function, so none of those eight names can reach this
-	// guard any more. rate/increase/delta/irate/idelta/sum_over_time/
+	// branch any more. rate/increase/delta/irate/idelta/sum_over_time/
 	// avg_over_time are intercepted the same way, one level earlier
 	// still, by [rangeFnOverExpHistogramSubquery] /
 	// [lowerExpHistogramRangeFnOverSubquery] (histogram_native_range_fn.go).
 	if shape := chplan.RowShapeOf(inner); shape == chplan.HistogramRowShape || shape == chplan.MixedRowShape {
-		return nil, fmt.Errorf("promql: %s over a subquery wrapping a native-histogram-valued shape is unsupported", outer.Func.Name)
+		if !histogramSubqueryFloatOnlyDropFunc(outer.Func.Name) {
+			return nil, fmt.Errorf("promql: %s over a subquery wrapping a native-histogram-valued shape is unsupported", outer.Func.Name)
+		}
+		if _, _, err := threadOuterRangeFnScalars(outer, &chplan.RangeWindow{}, s, ctx); err != nil {
+			return nil, err
+		}
+		return dropExpHistogramSamples(inner, s), nil
 	}
 
 	anchor, err := subqueryAnchor(sub, ctx)
@@ -1295,6 +1318,37 @@ func canonicalRangeWindowFunc(name string) string {
 		return "holt_winters"
 	}
 	return name
+}
+
+// histogramSubqueryFloatOnlyDropFunc answers whether outerFn is one of the
+// eleven range-vector reducers reference Prometheus defines no real
+// histogram semantics for — the subquery-composition sibling of
+// [rangeVectorFloatOnlyDropFuncs] (range_fns.go), which names the identical
+// vocabulary for the plain-MatrixSelector shape (cerberus issue #2563).
+//
+// Eight names (deriv, mad_over_time, stddev_over_time, stdvar_over_time,
+// min_over_time, max_over_time, ts_of_max_over_time, ts_of_min_over_time)
+// are exactly [rangeVectorFloatOnlyDropFuncs]'s own vocabulary, reused
+// directly rather than duplicated. The remaining three — predict_linear,
+// holt_winters (and its `double_exponential_smoothing` parse spelling,
+// hence the [canonicalRangeWindowFunc] normalisation), quantile_over_time —
+// are excluded from that map only because they resolve their own
+// MatrixSelector argument at their own dedicated call site rather than
+// through lowerRangeVectorCall's generic fallthrough (see that map's own
+// doc); range_fns.go's own [dropExpHistogramSamplesForRangeVector] call
+// sites for those three establish the identical Floats-only read for their
+// plain-matrix-selector form, which this widens to the
+// subquery-wraps-subquery composition.
+func histogramSubqueryFloatOnlyDropFunc(outerFn string) bool {
+	if rangeVectorFloatOnlyDropFuncs[outerFn] {
+		return true
+	}
+	switch canonicalRangeWindowFunc(outerFn) {
+	case "predict_linear", "holt_winters", "quantile_over_time":
+		return true
+	default:
+		return false
+	}
 }
 
 // threadOuterRangeFnScalars extracts and validates the extra scalar

--- a/internal/promql/subquery_drop_family_histogram_chdb_test.go
+++ b/internal/promql/subquery_drop_family_histogram_chdb_test.go
@@ -1,0 +1,62 @@
+//go:build chdb
+
+// chDB-backed proof that cerberus issue #2563's eleven float-only
+// range-vector functions — max_over_time, min_over_time, stddev_over_time,
+// stdvar_over_time, quantile_over_time, mad_over_time, deriv,
+// predict_linear, double_exponential_smoothing (holt_winters),
+// ts_of_max_over_time, ts_of_min_over_time — over a subquery whose OWN
+// inner already resolves histogram-native execute successfully against real
+// ClickHouse and answer an EMPTY result, rather than the
+// "unsupported"/502-shaped failure [lowerOuterRangeFnOverSubquery] used to
+// raise for this shape (cerberus issue #2543's original guard). Reference
+// Prometheus's own functions.go reads only `matrixVal[0].Floats` for every
+// one of these, so an all-histogram window answers empty there too — this
+// file is the round-trip evidence that cerberus's emitted SQL is well
+// formed enough to actually reach and confirm that empty answer, not just
+// that the Go plan shape looks right (TestLower_ExpHistogram_DropFamilyEmptyOverSubquery,
+// histogram_native_subquery_select_test.go, pins the Go-shape half).
+//
+// Seeds the same two-sample histogram-only series
+// subqSelectHistFixture already uses for the SELECT family
+// (subquery_select_histogram_chdb_test.go) — no float samples at all — so
+// the window every case below reduces is exclusively histogram-valued.
+package promql_test
+
+import (
+	"testing"
+
+	"github.com/tsouza/cerberus/internal/schema"
+)
+
+// TestSubqueryHistogramDropFamily_ChDB executes every one of the eleven
+// float-only reducers over the shared histogram-only subquery fixture and
+// asserts each answers zero rows rather than a query error.
+func TestSubqueryHistogramDropFamily_ChDB(t *testing.T) {
+	fixture, metric, evalTS := subqSelectHistFixture(t)
+	s := schema.DefaultOTelMetrics()
+
+	for _, tc := range []struct {
+		name  string
+		query string
+	}{
+		{name: "max_over_time", query: "max_over_time((" + metric + ")[2m:1m])"},
+		{name: "min_over_time", query: "min_over_time((" + metric + ")[2m:1m])"},
+		{name: "stddev_over_time", query: "stddev_over_time((" + metric + ")[2m:1m])"},
+		{name: "stdvar_over_time", query: "stdvar_over_time((" + metric + ")[2m:1m])"},
+		{name: "mad_over_time", query: "mad_over_time((" + metric + ")[2m:1m])"},
+		{name: "deriv", query: "deriv((" + metric + ")[2m:1m])"},
+		{name: "ts_of_max_over_time", query: "ts_of_max_over_time((" + metric + ")[2m:1m])"},
+		{name: "ts_of_min_over_time", query: "ts_of_min_over_time((" + metric + ")[2m:1m])"},
+		{name: "quantile_over_time", query: "quantile_over_time(0.5, (" + metric + ")[2m:1m])"},
+		{name: "predict_linear", query: "predict_linear((" + metric + ")[2m:1m], 60)"},
+		{name: "holt_winters", query: "double_exponential_smoothing((" + metric + ")[2m:1m], 0.5, 0.5)"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			sqlStr, args := lowerAndEmit(t, tc.query, s, evalTS)
+			got := sampleValueRows(t, fixture, sqlStr, args)
+			if len(got) != 0 {
+				t.Errorf("%s: got %d rows %+v, want 0 (all-histogram window has no float data for reference to answer)", tc.name, len(got), got)
+			}
+		})
+	}
+}

--- a/test/rejection-parity/catalogue/internal__promql__subquery.go__lowerOuterRangeFnOverSubquery.json
+++ b/test/rejection-parity/catalogue/internal__promql__subquery.go__lowerOuterRangeFnOverSubquery.json
@@ -5,14 +5,15 @@
       "site": "internal/promql/subquery.go:lowerOuterRangeFnOverSubquery#087c3810",
       "message": "promql: %s over a subquery wrapping a native-histogram-valued shape is unsupported",
       "class": "divergence",
-      "trigger_query": "max_over_time((demo_latency_exp_hist)[5m:1m])",
-      "tracking_issue": 2563,
+      "trigger_query": "sum(count_over_time((demo_latency_exp_hist)[5m:1m]))",
+      "tracking_issue": 2569,
       "evidence": {
         "guard": [
           "past returning if outer.Func.Name == \"absent_over_time\"",
           "past returning if !chplan.IsPromQLRangeWindowFunc(canonicalRangeWindowFunc(outer.Func.Name))",
           "past returning if err != nil",
-          "if shape := chplan.RowShapeOf(inner); shape == chplan.HistogramRowShape || shape == chplan.MixedRowShape"
+          "if shape := chplan.RowShapeOf(inner); shape == chplan.HistogramRowShape || shape == chplan.MixedRowShape",
+          "if !histogramSubqueryFloatOnlyDropFunc(outer.Func.Name)"
         ],
         "callers": [
           "lowerCall"


### PR DESCRIPTION
## Summary

- `max_over_time`/`min_over_time`/`stddev_over_time`/`stdvar_over_time`/`quantile_over_time`/
  `mad_over_time`/`deriv`/`predict_linear`/`holt_winters` (and its `double_exponential_smoothing`
  spelling)/`ts_of_max_over_time`/`ts_of_min_over_time` wrapping a subquery whose own inner already
  resolves histogram-native (`max_over_time((demo_latency_exp_hist)[5m:1m])`) now drop to an EMPTY
  result instead of raising `promql: %s over a subquery wrapping a native-histogram-valued shape is
  unsupported` — matching reference Prometheus, which reads only `matrixVal[0].Floats` for these
  eleven reducers and answers an ordinary "no data" empty vector for an all-histogram window, never
  an error.
- The gate is a single shared predicate, `histogramSubqueryFloatOnlyDropFunc`
  (`internal/promql/subquery.go`), reusing `rangeVectorFloatOnlyDropFuncs` (the identical vocabulary
  the plain-`MatrixSelector` shape already uses, `range_fns.go`) for eight names and adding the three
  scalar-argument reducers (`predict_linear`/`holt_winters`/`quantile_over_time`) that resolve their
  own matrix argument at their own call site. The scalar parameter(s) — predict_linear's horizon,
  holt_winters' smoothing factors, quantile_over_time's phi — are still validated before the empty
  drop, mirroring reference's param-before-drop evaluation order (an out-of-domain smoothing factor
  still errors even though the window is all-histogram).
- Rotated the rejection-parity catalogue entry
  `internal/promql/subquery.go:lowerOuterRangeFnOverSubquery#087c3810`. It stays open: while
  implementing this fix I found the SAME guard still rejects the SELECT/FOLD-family functions #2545
  already fixed at the query root (`count_over_time`, `rate`, …) once they are **nested** under a
  further wrapper (`sum(count_over_time((h)[5m:1m]))` still errors, even though
  `count_over_time((h)[5m:1m])` alone succeeds) — a genuine, pre-existing divergence outside this
  issue's scope. Filed as #2569 and the catalogue entry's `trigger_query`/`tracking_issue` now track
  that issue instead.

## Verification

- `TestLower_ExpHistogram_DropFamilyEmptyOverSubquery` (renamed from the old
  `...StillRejectedOverSubquery`) pins the Go plan shape (instant / range / `@`-pinned) for all
  eleven functions.
- `TestLower_ExpHistogram_DropFamilyOverSubquery_ScalarParamStillValidated` pins that an
  out-of-domain `holt_winters` smoothing factor still errors.
- `TestSubqueryHistogramDropFamily_ChDB` (new, `//go:build chdb`) executes all eleven functions
  against real ClickHouse (chDB) over a histogram-only seed and asserts each answers zero rows rather
  than a query error — real round-trip evidence, not just a Go-shape check.
- `go build ./...`, `go vet ./...`, `gofumpt -extra -l`, `goimports -local … -l` all clean.
- `go test -race ./internal/promql/...` and `go test -race -tags chdb ./internal/promql/...` both
  green.
- `node .github/scripts/forbid-sql-raw.mjs` clean.
- `CERBERUS_UPDATE_INVENTORY=1 go test -run TestCatalogueIsRegenerable ./test/rejection-parity/...`
  run twice; `go test ./test/rejection-parity/...` (including `TestRejectionTriggersExerciseSites`
  and `TestParityCorpusMatchesCatalogue`) green.

Closes #2563
