### PR TITLE
fix(promql): compose histogram_quantile/aggregations over a nested topk/bottomk drop

### DIFF
--- a/internal/promql/histogram_native_drop_aggregation.go
+++ b/internal/promql/histogram_native_drop_aggregation.go
@@ -21,11 +21,19 @@ import (
 //
 // A selector that can match both float and histogram series already follows
 // the generic lowering: regex routing contributes the ordinary float arms and
-// deliberately contributes no bare native-histogram arm. This root-only path
+// deliberately contributes no bare native-histogram arm. This path
 // supplies the missing histogram-only half. It lowers the histogram selector
 // through its canonical native-histogram path and caps it with a false filter,
 // preserving instant/range/@ evaluation validation while publishing no
 // samples.
+//
+// droppingAggregationOverExpHistogram is reached from two callsites — both
+// [lowerHistogramNativeRoot] (when the aggregation is the query's own root)
+// and, since cerberus issue #2562, the top of [lowerAggregate] via
+// [lowerExpHistogramDroppingShape] (when it is NESTED under a further
+// wrapper, e.g. `histogram_quantile(0.5, topk(1, demo_latency_exp_hist))`)
+// — the same root+nested threading [lowerExpHistogramCountFamily] already
+// has for count()/group().
 
 // droppingAggregationOverExpHistogram recognizes a histogram-dropping
 // aggregation directly over a bare exponential-histogram selector.

--- a/internal/promql/histogram_native_drop_aggregation_test.go
+++ b/internal/promql/histogram_native_drop_aggregation_test.go
@@ -109,3 +109,77 @@ func TestLower_ExpHistogram_DroppingTopKPreservesParameterDomain(t *testing.T) {
 		t.Fatalf("guards = %#v, want one bottomk K guard", guards)
 	}
 }
+
+// TestLower_ExpHistogram_DroppingAggregationComposesUnderWrappers pins
+// cerberus issue #2562: a "dropping" aggregation (min/max/stddev/stdvar/
+// quantile/topk/bottomk) directly over a histogram-VALUED shape — not
+// merely one of [droppingAggregationOverExpHistogram]'s ROOT-only matches,
+// but NESTED as the argument of a further wrapper —
+// `histogram_quantile(0.5, topk(1, demo_latency_exp_hist))`,
+// `sum(min(demo_latency_exp_hist))`, `abs(stddev(rate(...)))`. Before this
+// issue's fix, [lowerTopK] (topk/bottomk) and the five other ops' own
+// generic `lower(a.Expr, ...)` fallback in [lowerAggregate] reached the
+// histogram selector underneath without ANY histogram-aware recognizer,
+// hard-rejecting via expHistogramSelectorRouting's catch-all instead of
+// reference's real "drop the sample, evaluate to empty" answer — the same
+// class TestLower_ExpHistogram_DroppingAggregationsAreEmpty already pins
+// for the query-ROOT case.
+func TestLower_ExpHistogram_DroppingAggregationComposesUnderWrappers(t *testing.T) {
+	t.Parallel()
+
+	s := schema.DefaultOTelMetrics()
+	p := parser.NewParser(parser.Options{EnableExperimentalFunctions: true})
+	at := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+
+	queries := []string{
+		// The issue's own trigger query.
+		`histogram_quantile(0.5, topk(1, latency_exp_hist))`,
+		`histogram_quantile(0.9, bottomk(2, latency_exp_hist))`,
+		// Every dropping op, nested under an ordinary wrapper.
+		`sum(topk(3, latency_exp_hist))`,
+		`sum(bottomk(3, latency_exp_hist))`,
+		`abs(min(latency_exp_hist))`,
+		`abs(max(latency_exp_hist))`,
+		`sort(stddev(latency_exp_hist))`,
+		`sort(stdvar(latency_exp_hist))`,
+		`ceil(quantile(0.9, latency_exp_hist))`,
+		// Two levels of composition, and a range-vector operand under the
+		// dropping aggregation.
+		`histogram_quantile(0.5, topk(1, rate(latency_exp_hist[5m])))`,
+		`abs(sum(topk(3, latency_exp_hist)))`,
+	}
+
+	for _, query := range queries {
+		query := query
+		t.Run(query, func(t *testing.T) {
+			t.Parallel()
+			expr, err := p.ParseExpr(query)
+			if err != nil {
+				t.Fatalf("ParseExpr(%q): %v", query, err)
+			}
+			plan, err := promql.LowerAt(context.Background(), expr, s, at, at)
+			if err != nil {
+				t.Fatalf("LowerAt(%q): unexpected error (this exact shape hard-rejected via expHistogramSelectorRouting's catch-all before cerberus issue #2562's fix): %v", query, err)
+			}
+			if shape := chplan.RowShapeOf(plan); shape != chplan.SampleRowShape {
+				t.Fatalf("LowerAt(%q) row shape = %s, want sample (canonical float)", query, shape)
+			}
+			// The plan must actually be empty (a constant-false Filter
+			// reachable somewhere in the tree), not merely float-shaped —
+			// distinguishing "recognised and dropped" from a lowering
+			// that accidentally answers a non-empty float result.
+			foundEmptyFilter := false
+			chplan.Walk(plan, func(n chplan.Node) bool {
+				if f, ok := n.(*chplan.Filter); ok {
+					if lit, ok := f.Predicate.(*chplan.LitBool); ok && !lit.V {
+						foundEmptyFilter = true
+					}
+				}
+				return true
+			})
+			if !foundEmptyFilter {
+				t.Fatalf("LowerAt(%q) plan has no constant-false Filter; want a dropped (empty) result:\n%#v", query, plan)
+			}
+		})
+	}
+}

--- a/internal/promql/histogram_native_topk_dropping_nested_chdb_test.go
+++ b/internal/promql/histogram_native_topk_dropping_nested_chdb_test.go
@@ -1,0 +1,115 @@
+//go:build chdb
+
+// chDB-backed proof that a "dropping" aggregation (topk/bottomk, and their
+// five drop-family siblings min/max/stddev/stdvar/quantile) directly over a
+// histogram-VALUED shape, NESTED as the argument of a further wrapper such
+// as histogram_quantile() or sum() (cerberus issue #2562), now lowers to
+// valid SQL and EXECUTES against real ClickHouse, returning the real empty
+// result reference Prometheus answers there — not merely that a Go-level
+// lowering error stopped being raised.
+//
+// TestLower_ExpHistogram_DroppingAggregationComposesUnderWrappers
+// (histogram_native_drop_aggregation_test.go) already pins the SAME shapes
+// at the Go-plan-shape level; this file is that fixture's chDB-executed
+// sibling, following the pattern
+// TestLower_ExpHistogram_DroppingShapeNestedInBinop_ChDB
+// (histogram_native_dropping_nested_binop_chdb_test.go) established for the
+// sibling "dropping binop nested under a wrapper" issue (#2534).
+//
+// The metric is seeded with REAL, non-empty rows so a returned zero-row
+// result can only mean the drop actually fired, never that no data was ever
+// scanned.
+package promql_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/prometheus/prometheus/promql/parser"
+
+	"github.com/tsouza/cerberus/internal/chsql"
+	"github.com/tsouza/cerberus/internal/promql"
+	"github.com/tsouza/cerberus/internal/schema"
+	"github.com/tsouza/cerberus/internal/testsql"
+)
+
+const topkDroppingNestedMetric = "topk_dropping_nested_probe_exp_hist"
+
+var topkDroppingNestedSeed = "" +
+	"CREATE OR REPLACE TABLE otel_metrics_exponential_histogram (" +
+	"`MetricName` String, `Attributes` Map(String, String), " +
+	"`ResourceAttributes` Map(String, String) DEFAULT map(), `ServiceName` LowCardinality(String) DEFAULT '', " +
+	"`TimeUnix` DateTime64(9), " +
+	"`Count` UInt64, `Sum` Float64, `Scale` Int32, `ZeroCount` UInt64, " +
+	"`PositiveOffset` Int32, `PositiveBucketCounts` Array(UInt64), " +
+	"`NegativeOffset` Int32, `NegativeBucketCounts` Array(UInt64)" +
+	") ENGINE = MergeTree ORDER BY (`MetricName`, `Attributes`, `TimeUnix`);\n" +
+	"INSERT INTO otel_metrics_exponential_histogram " +
+	"(MetricName, Attributes, TimeUnix, Count, Sum, Scale, ZeroCount, PositiveOffset, PositiveBucketCounts, NegativeOffset, NegativeBucketCounts) VALUES\n" +
+	"    ('" + topkDroppingNestedMetric + "', map('service', 'checkout'), toDateTime64('2026-01-01 00:00:00', 9), 5, 10.0, 0, 0, 0, [5], 0, []),\n" +
+	"    ('" + topkDroppingNestedMetric + "', map('service', 'cart'), toDateTime64('2026-01-01 00:00:00', 9), 9, 20.0, 0, 0, 0, [9], 0, []);\n"
+
+var topkDroppingNestedEvalTS = time.Date(2026, 1, 1, 0, 0, 1, 0, time.UTC)
+
+// TestLower_ExpHistogram_DroppingAggregationNestedUnderWrapper_ChDB pins
+// cerberus issue #2562's own trigger query
+// (`histogram_quantile(0.5, topk(1, <exp-histogram selector>))`) plus five
+// sibling shapes covering the rest of the "dropping" op family and a
+// non-histogram_quantile wrapper, executed against real ClickHouse.
+func TestLower_ExpHistogram_DroppingAggregationNestedUnderWrapper_ChDB(t *testing.T) {
+	fixture := newChDBFixture(t, topkDroppingNestedSeed)
+	s := schema.DefaultOTelMetrics()
+	p := parser.NewParser(parser.Options{EnableExperimentalFunctions: true})
+
+	queries := []string{
+		// The issue's own trigger query.
+		"histogram_quantile(0.5, topk(1, " + topkDroppingNestedMetric + "))",
+		"histogram_quantile(0.9, bottomk(1, " + topkDroppingNestedMetric + "))",
+		// The other five dropping ops, nested under a non-histogram_quantile
+		// wrapper — sum() reduces the (already-empty) result, so this also
+		// proves the reshaped output composes under further aggregation.
+		"sum(min(" + topkDroppingNestedMetric + "))",
+		"sum(max(" + topkDroppingNestedMetric + "))",
+		"sum(stddev(" + topkDroppingNestedMetric + "))",
+		"sum(stdvar(" + topkDroppingNestedMetric + "))",
+		"sum(quantile(0.9, " + topkDroppingNestedMetric + "))",
+	}
+
+	for _, query := range queries {
+		query := query
+		t.Run(query, func(t *testing.T) {
+			expr, err := p.ParseExpr(query)
+			if err != nil {
+				t.Fatalf("ParseExpr(%q): %v", query, err)
+			}
+			plan, err := promql.LowerAt(context.Background(), expr, s, topkDroppingNestedEvalTS, topkDroppingNestedEvalTS)
+			if err != nil {
+				t.Fatalf("LowerAt(%q): unexpected error (this exact shape hard-rejected via expHistogramSelectorRouting's catch-all before cerberus issue #2562's fix): %v", query, err)
+			}
+			sqlStr, args, err := chsql.Emit(context.Background(), plan)
+			if err != nil {
+				t.Fatalf("Emit(%q): %v", query, err)
+			}
+
+			rows := fixture.queryOverEmitted(t, "count() AS n", sqlStr, args)
+			defer func() { _ = rows.Close() }()
+			if !rows.Next() {
+				t.Fatalf("count() query returned no rows")
+			}
+			var n int64
+			if err := rows.Scan(&n); err != nil {
+				t.Fatalf("scan count(): %v", err)
+			}
+			if err := testsql.TolerantRowsErr(rows.Err()); err != nil {
+				t.Fatalf("rows.Err: %v", err)
+			}
+			if n != 0 {
+				t.Fatalf(
+					"query %q returned count()=%d, want 0 — reference drops every native-histogram sample under min/max/stddev/stdvar/quantile/topk/bottomk; the metric was seeded with REAL non-empty rows, so a non-zero count would mean the drop never actually fired at execution",
+					query, n,
+				)
+			}
+		})
+	}
+}

--- a/internal/promql/lower.go
+++ b/internal/promql/lower.go
@@ -3770,6 +3770,35 @@ const rangeBucketAlias = "bucket_ts"
 // aggregations drop `__name__`, so the projected MetricName is the empty
 // string; the projected Attributes is built from the group-key columns.
 func lowerAggregate(a *parser.AggregateExpr, s schema.Metrics, ctx lowerCtx) (chplan.Node, error) {
+	// min/max/stddev/stdvar/quantile/topk/bottomk over a histogram-VALUED
+	// argument (or over an already-dropped nested shape), NESTED under a
+	// further wrapper (cerberus issue #2562) —
+	// `histogram_quantile(0.5, topk(1, demo_latency_exp_hist))`,
+	// `sum(min(demo_latency_exp_hist))`, `abs(stddev(rate(demo_latency_exp_hist[5m])))`,
+	// … . [lowerHistogramNativeRoot] only tries this dispatch when the
+	// aggregation IS the query's own root; every wrapper reaches its
+	// operand through this function's own op-specific dispatch below —
+	// TOPK/BOTTOMK straight to [lowerTopK], the rest through the generic
+	// `lower(a.Expr, ...)` fallback further down — both of which would
+	// otherwise reach [lowerVectorSelector]'s ordinary path and
+	// [expHistogramSelectorRouting]'s hard rejection on the histogram
+	// selector underneath, rather than the reference "drop the sample,
+	// evaluate to empty" answer these ops get at the query root.
+	// [lowerExpHistogramDroppingShape] is the same reusable recogniser
+	// [lowerHistogramNativeRoot] itself calls (histogram_native_dropping_
+	// shape.go) — reusing it here, rather than only
+	// [droppingAggregationOverExpHistogram], also reshapes the result to
+	// the composable canonical float shape (floatShapedExpHistogramDrop)
+	// so a further wrapper around THIS aggregation keeps working, and
+	// picks up `topk(3, hist + 1)`-style nested-drop-family arguments too.
+	// Checked first, ahead of every op-specific branch, so it closes the
+	// nested gap for the five non-early-dispatched ops (min/max/stddev/
+	// stdvar/quantile) that reach the generic `lower(a.Expr, ...)` path as
+	// well — mirroring how [lowerExpHistogramCountFamily] is threaded both
+	// here and in lowerHistogramNativeRoot for count()/group().
+	if plan, ok, err := lowerExpHistogramDroppingShape(a, s, ctx); ok {
+		return plan, err
+	}
 	if a.Op == parser.TOPK || a.Op == parser.BOTTOMK {
 		return lowerTopK(a, s, ctx)
 	}
@@ -4785,8 +4814,10 @@ func lowerTopKComputed(a *parser.AggregateExpr, s schema.Metrics, ctx lowerCtx) 
 
 	// Only limitk ever preserves a histogram-valued input (see
 	// [lowerLimitKInput]'s doc comment) — topk/bottomk's histogram-only
-	// case is always intercepted upstream, ahead of lowerAggregate, by
-	// droppingAggregationOverExpHistogram (histogram_native_drop_
+	// case is always intercepted upstream, at the top of lowerAggregate
+	// (root OR nested, cerberus issue #2562) or, when this aggregation is
+	// itself the query's root, even earlier by lowerHistogramNativeRoot,
+	// by droppingAggregationOverExpHistogram (histogram_native_drop_
 	// aggregation.go), so `input` here is never histogram-valued for
 	// them and the plain [lower] dispatch is unchanged for that path.
 	var input chplan.Node

--- a/test/rejection-parity/catalogue/internal__promql__lower.go__expHistogramSelectorRouting.json
+++ b/test/rejection-parity/catalogue/internal__promql__lower.go__expHistogramSelectorRouting.json
@@ -5,8 +5,8 @@
       "site": "internal/promql/lower.go:expHistogramSelectorRouting#bf746b59",
       "message": "promql: %q is an exponential histogram metric; only a bare %q selector, sum()/avg()/count() over one, rate()/increase()/delta()/irate()/idelta()/sum_over_time()/avg_over_time()/resets()/changes() over one, histogram_quantile(), histogram_count(), histogram_sum(), and the %q/%q companion selectors are supported",
       "class": "divergence",
-      "trigger_query": "histogram_quantile(0.5, topk(1, demo_latency_exp_hist))",
-      "tracking_issue": 2562,
+      "trigger_query": "histogram_quantile(0.5, count_values(\"v\", demo_latency_exp_hist))",
+      "tracking_issue": 2568,
       "evidence": {
         "guard": [
           "past returning if bare, col, hasCompanion := s.HistogramCompanionColumn(metricName); hasCompanion \u0026\u0026 s.IsExpHistogramMetric(bare) \u0026\u0026 s.ExpHistogramTable != \"\"",


### PR DESCRIPTION
## Summary

- `histogram_quantile(phi, topk(N, <exp-histogram selector>))` hard-rejected via
  `expHistogramSelectorRouting`'s catch-all, even though `topk(N, <exp-histogram selector>)` alone
  already lowers cleanly through the "dropping" family (empty float result, matching cerberus's
  existing treatment of `topk`/`bottomk` over a native-histogram operand).
- Root cause: `lowerExpHistogramDroppingShape` was threaded only into `lowerHistogramNativeRoot`
  (query root / subquery inner), never into `lowerAggregate`'s own dispatch, so any wrapper nesting
  a dropping aggregation (`topk`, `bottomk`, `min`, `max`, `stddev`, `stdvar`, `quantile`) fell
  through to the generic selector-routing rejection.
- Fix: thread `lowerExpHistogramDroppingShape` into the top of `lowerAggregate`, mirroring the
  existing root+nested pattern `lowerExpHistogramCountFamily` already uses for `count()`/`group()`.
  Closes the gap for all seven dropping ops at once, not just `topk`/`bottomk`.
- Probed broadly post-fix and found `histogram_quantile(0.5, count_values("v", <exp-hist
  selector>))` still hard-rejects — a related but distinct bug (`count_values` is a "preserve"
  family case, not "dropping"). Filed as #2568 and rotated the rejection-parity catalogue's
  `expHistogramSelectorRouting` entry to track it.

Closes #2562

## Test plan

- [x] Go-level shape test: `TestLower_ExpHistogram_DroppingAggregationComposesUnderWrappers`
- [x] Real chDB round-trip: `TestLower_ExpHistogram_DroppingAggregationNestedUnderWrapper_ChDB`
      (seeded non-empty rows, proves the empty result actually fires against real ClickHouse)
- [x] Rejection-parity catalogue regenerated and rotated to #2568;
      `TestCatalogueIsRegenerable` / `TestInternalRationalesRestOnCurrentEvidence` /
      `TestRejectionTriggersExerciseSites` all green
- [x] `go build ./...` and `-tags chdb` clean
- [x] `go vet ./...`, `gofumpt -extra`, `goimports -local` clean
- [x] `node .github/scripts/forbid-sql-raw.mjs` clean
- [x] `go test -race ./internal/promql/...` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)
