### PR TITLE
fix(promql): thread histogram-aware count_values into lowerCountValues

### DIFF
--- a/internal/promql/histogram_native_count_values_nested_chdb_test.go
+++ b/internal/promql/histogram_native_count_values_nested_chdb_test.go
@@ -1,0 +1,136 @@
+//go:build chdb
+
+// chDB-backed proof that `count_values("label", <exp-histogram operand>)`,
+// NESTED as the argument of a further wrapper such as histogram_quantile()
+// or sum() (cerberus issue #2568), now lowers to valid SQL and EXECUTES
+// against real ClickHouse, returning the real answer reference Prometheus
+// gives there — not merely that a Go-level lowering error stopped being
+// raised.
+//
+// Bare `count_values("label", <exp-histogram selector>)` already lowered
+// cleanly via [lowerHistogramNativeRoot]'s own root-only dispatch to
+// [countValuesOverExpHistogramValue]; the bug this file exercises is that
+// any wrapper around that shape reached the histogram selector underneath
+// through [lowerAggregate]'s generic `lower(a.Expr, ...)` fallback instead,
+// which hits [expHistogramSelectorRouting]'s hard rejection. Same bug
+// class as #2562 (histogram_native_topk_dropping_nested_chdb_test.go is
+// that issue's own chDB sibling), but count_values belongs to the
+// "preserve" family rather than the "dropping" one, so the fix threads
+// [countValuesOverExpHistogramValue] into [lowerCountValues] itself.
+//
+// The metric is seeded with REAL, non-empty rows so a returned row count
+// can only mean the fix actually executed against real data, never that no
+// data was ever scanned.
+package promql_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/prometheus/prometheus/promql/parser"
+
+	"github.com/tsouza/cerberus/internal/chsql"
+	"github.com/tsouza/cerberus/internal/promql"
+	"github.com/tsouza/cerberus/internal/schema"
+	"github.com/tsouza/cerberus/internal/testsql"
+)
+
+const countValuesNestedMetric = "count_values_nested_probe_exp_hist"
+
+var countValuesNestedSeed = "" +
+	"CREATE OR REPLACE TABLE otel_metrics_exponential_histogram (" +
+	"`MetricName` String, `Attributes` Map(String, String), " +
+	"`ResourceAttributes` Map(String, String) DEFAULT map(), `ServiceName` LowCardinality(String) DEFAULT '', " +
+	"`TimeUnix` DateTime64(9), " +
+	"`Count` UInt64, `Sum` Float64, `Scale` Int32, `ZeroCount` UInt64, " +
+	"`PositiveOffset` Int32, `PositiveBucketCounts` Array(UInt64), " +
+	"`NegativeOffset` Int32, `NegativeBucketCounts` Array(UInt64)" +
+	") ENGINE = MergeTree ORDER BY (`MetricName`, `Attributes`, `TimeUnix`);\n" +
+	"INSERT INTO otel_metrics_exponential_histogram " +
+	"(MetricName, Attributes, TimeUnix, Count, Sum, Scale, ZeroCount, PositiveOffset, PositiveBucketCounts, NegativeOffset, NegativeBucketCounts) VALUES\n" +
+	"    ('" + countValuesNestedMetric + "', map('service', 'checkout'), toDateTime64('2026-01-01 00:00:00', 9), 5, 10.0, 0, 0, 0, [5], 0, []),\n" +
+	"    ('" + countValuesNestedMetric + "', map('service', 'cart'), toDateTime64('2026-01-01 00:00:00', 9), 9, 20.0, 0, 0, 0, [9], 0, []);\n"
+
+var countValuesNestedEvalTS = time.Date(2026, 1, 1, 0, 0, 1, 0, time.UTC)
+
+// TestLower_ExpHistogram_CountValuesNestedUnderWrapper_ChDB pins cerberus
+// issue #2568's own trigger query (`histogram_quantile(0.5, count_values("v",
+// <exp-histogram selector>))`) plus a non-histogram_quantile wrapper, both
+// executed against real ClickHouse.
+func TestLower_ExpHistogram_CountValuesNestedUnderWrapper_ChDB(t *testing.T) {
+	fixture := newChDBFixture(t, countValuesNestedSeed)
+	s := schema.DefaultOTelMetrics()
+	p := parser.NewParser(parser.Options{EnableExperimentalFunctions: true})
+
+	lower := func(t *testing.T, query string) (string, []any) {
+		t.Helper()
+		expr, err := p.ParseExpr(query)
+		if err != nil {
+			t.Fatalf("ParseExpr(%q): %v", query, err)
+		}
+		plan, err := promql.LowerAt(context.Background(), expr, s, countValuesNestedEvalTS, countValuesNestedEvalTS)
+		if err != nil {
+			t.Fatalf("LowerAt(%q): unexpected error (this exact shape hard-rejected via expHistogramSelectorRouting's catch-all before cerberus issue #2568's fix): %v", query, err)
+		}
+		sqlStr, args, err := chsql.Emit(context.Background(), plan)
+		if err != nil {
+			t.Fatalf("Emit(%q): %v", query, err)
+		}
+		return sqlStr, args
+	}
+
+	// The issue's own trigger query. Reference Prometheus's classic
+	// histogram_quantile requires an `le` label on every sample it
+	// buckets; count_values's own synthetic label ("v") never carries
+	// one, so every group is dropped and the correct real answer is an
+	// EMPTY result — proving the query executes cleanly against
+	// non-empty seed data is what distinguishes "the fix actually ran"
+	// from "there was nothing to scan".
+	t.Run("histogram_quantile(0.5, count_values(...)) is empty (no le label)", func(t *testing.T) {
+		query := `histogram_quantile(0.5, count_values("v", ` + countValuesNestedMetric + `))`
+		sqlStr, args := lower(t, query)
+		rows := fixture.queryOverEmitted(t, "count() AS n", sqlStr, args)
+		defer func() { _ = rows.Close() }()
+		if !rows.Next() {
+			t.Fatalf("count() query returned no rows")
+		}
+		var n int64
+		if err := rows.Scan(&n); err != nil {
+			t.Fatalf("scan count(): %v", err)
+		}
+		if err := testsql.TolerantRowsErr(rows.Err()); err != nil {
+			t.Fatalf("rows.Err: %v", err)
+		}
+		if n != 0 {
+			t.Fatalf("query %q returned count()=%d, want 0 (no `le` label survives count_values)", query, n)
+		}
+	})
+
+	// A non-histogram_quantile wrapper (sum()) around the identical
+	// count_values(...) shape: reference Prometheus's count_values emits
+	// one row per distinct stringified value, and summing collapses that
+	// back down to the total number of underlying series — proving the
+	// nested lowering produces a REAL, non-empty, numerically correct
+	// result rather than merely avoiding an error.
+	t.Run("sum(count_values(...)) totals the underlying series", func(t *testing.T) {
+		query := `sum(count_values("v", ` + countValuesNestedMetric + `))`
+		sqlStr, args := lower(t, query)
+		rows := fixture.queryOverEmitted(t, "`Value` AS val", sqlStr, args)
+		defer func() { _ = rows.Close() }()
+		if !rows.Next() {
+			t.Fatalf("query %q returned no rows", query)
+		}
+		var val float64
+		if err := rows.Scan(&val); err != nil {
+			t.Fatalf("scan Value: %v", err)
+		}
+		if err := testsql.TolerantRowsErr(rows.Err()); err != nil {
+			t.Fatalf("rows.Err: %v", err)
+		}
+		const wantTotal = 2.0 // two seeded series (checkout, cart)
+		if val != wantTotal {
+			t.Fatalf("query %q returned Value=%v, want %v (total seeded series)", query, val, wantTotal)
+		}
+	})
+}

--- a/internal/promql/lower.go
+++ b/internal/promql/lower.go
@@ -3978,6 +3978,31 @@ func lowerCountValues(a *parser.AggregateExpr, s schema.Metrics, ctx lowerCtx) (
 		return nil, fmt.Errorf("promql: count_values requires a non-empty label name")
 	}
 
+	// count_values over an expression whose result has already crossed the
+	// native-histogram row boundary, NESTED under a further wrapper
+	// (cerberus issue #2568) — `histogram_quantile(0.5, count_values("v",
+	// <exp-histogram selector>))`. [lowerHistogramNativeRoot] only tries
+	// [countValuesOverExpHistogramValue] when count_values IS the query's
+	// own root; every wrapper reaches count_values through this function's
+	// own generic `lower(a.Expr, ...)` fallback below, which would
+	// otherwise hit [lowerVectorSelector]'s ordinary path and
+	// [expHistogramSelectorRouting]'s hard rejection instead of the real
+	// answer bare `count_values("v", <exp-histogram selector>)` gets — the
+	// same bug class as #2562, but count_values belongs to the "preserve"
+	// family ([lowerExpHistogramValuedShape]) rather than the "drop" one
+	// ([lowerExpHistogramDroppingShape]), so it is threaded here rather
+	// than through [lowerAggregate]'s own drop-family dispatch.
+	if agg, ok := countValuesOverExpHistogramValue(a, s, ctx); ok {
+		input, matched, err := lowerExpHistogramValuedShape(agg.Expr, s, ctx)
+		if err != nil {
+			return nil, err
+		}
+		if !matched {
+			return nil, fmt.Errorf("promql: internal invariant violated: count_values input is not histogram-valued: %v", agg.Expr)
+		}
+		return lowerExpHistogramCountValuesOverPlan(agg, input, s, ctx)
+	}
+
 	input, err := lower(a.Expr, s, ctx)
 	if err != nil {
 		return nil, err

--- a/test/rejection-parity/catalogue/internal__promql__histogram_native_count_values.go__lowerExpHistogramCountValuesOverPlan.json
+++ b/test/rejection-parity/catalogue/internal__promql__histogram_native_count_values.go__lowerExpHistogramCountValuesOverPlan.json
@@ -5,7 +5,7 @@
       "site": "internal/promql/histogram_native_count_values.go:lowerExpHistogramCountValuesOverPlan#30cc8718",
       "message": "promql: internal invariant violated: count_values native-histogram input is %T with %s row shape",
       "class": "internal",
-      "rationale": "countValuesOverExpHistogramValue admits a histogram-valued operand and lowerHistogramNativeRoot (reached from lowerRoot for a query's own root, and from lowerHistogramNativeSubqueryInner for a bare subquery's own inner expression as of cerberus issue #2543) lowers that same operand through lowerExpHistogramValuedShape and its histogram-row contract.",
+      "rationale": "countValuesOverExpHistogramValue admits only an operand isExpHistogramValuedShape agrees is histogram-valued, and both callers lower that same operand through lowerExpHistogramValuedShape immediately before this call: lowerHistogramNativeRoot (reached from lowerRoot for a query's own root, and from lowerHistogramNativeSubqueryInner for a bare subquery's own inner expression, cerberus issue #2543) and lowerCountValues (reached from lowerAggregate's COUNT_VALUES dispatch for count_values(...) NESTED under a further wrapper, cerberus issue #2568). lowerExpHistogramValuedShape's own contract is to return the thirteen-column histogram row shape whenever it reports a match, so this guard can never actually fire.",
       "evidence": {
         "guard": [
           "past returning if !ok",
@@ -13,10 +13,14 @@
           "if chplan.RowShapeOf(input) != chplan.HistogramRowShape"
         ],
         "callers": [
+          "lowerCountValues",
           "lowerHistogramNativeRoot"
         ],
         "cited": [
           "countValuesOverExpHistogramValue",
+          "isExpHistogramValuedShape",
+          "lowerAggregate",
+          "lowerCountValues",
           "lowerExpHistogramValuedShape",
           "lowerHistogramNativeRoot",
           "lowerHistogramNativeSubqueryInner",
@@ -29,15 +33,19 @@
       "site": "internal/promql/histogram_native_count_values.go:lowerExpHistogramCountValuesOverPlan#49c20b7b",
       "message": "promql: count_values requires a string-literal label name as the first arg",
       "class": "internal",
-      "rationale": "the PromQL typechecker admits only a string literal as count_values' parameter; this holds identically regardless of whether the enclosing count_values(...) reached this lowerer via lowerRoot (a query's own root) or lowerHistogramNativeSubqueryInner (a bare subquery's own inner expression, cerberus issue #2543), since the typechecker runs during parsing, before either entry point is reached.",
+      "rationale": "the PromQL typechecker admits only a string literal as count_values' parameter; this holds identically regardless of which caller reaches this lowerer — lowerRoot / lowerHistogramNativeSubqueryInner via lowerHistogramNativeRoot, or lowerAggregate's COUNT_VALUES dispatch via lowerCountValues (cerberus issue #2568) — since the typechecker runs during parsing, before any lowering entry point is reached.",
       "evidence": {
         "guard": [
           "if !ok"
         ],
         "callers": [
+          "lowerCountValues",
           "lowerHistogramNativeRoot"
         ],
         "cited": [
+          "lowerAggregate",
+          "lowerCountValues",
+          "lowerHistogramNativeRoot",
           "lowerHistogramNativeSubqueryInner",
           "lowerRoot"
         ]
@@ -55,6 +63,7 @@
           "if label == \"\""
         ],
         "callers": [
+          "lowerCountValues",
           "lowerHistogramNativeRoot"
         ]
       }

--- a/test/rejection-parity/catalogue/internal__promql__lower.go__expHistogramSelectorRouting.json
+++ b/test/rejection-parity/catalogue/internal__promql__lower.go__expHistogramSelectorRouting.json
@@ -5,8 +5,8 @@
       "site": "internal/promql/lower.go:expHistogramSelectorRouting#bf746b59",
       "message": "promql: %q is an exponential histogram metric; only a bare %q selector, sum()/avg()/count() over one, rate()/increase()/delta()/irate()/idelta()/sum_over_time()/avg_over_time()/resets()/changes() over one, histogram_quantile(), histogram_count(), histogram_sum(), and the %q/%q companion selectors are supported",
       "class": "divergence",
-      "trigger_query": "histogram_quantile(0.5, count_values(\"v\", demo_latency_exp_hist))",
-      "tracking_issue": 2568,
+      "trigger_query": "info(demo_http_requests_total, {__name__=\"demo_latency_exp_hist\"})",
+      "tracking_issue": 2574,
       "evidence": {
         "guard": [
           "past returning if bare, col, hasCompanion := s.HistogramCompanionColumn(metricName); hasCompanion \u0026\u0026 s.IsExpHistogramMetric(bare) \u0026\u0026 s.ExpHistogramTable != \"\"",
@@ -16,7 +16,7 @@
           "resolveSelectorRouting"
         ]
       },
-      "since": "2026-08-24"
+      "since": "2026-08-25"
     }
   ]
 }

--- a/test/rejection-parity/catalogue/internal__promql__lower.go__lowerCountValues.json
+++ b/test/rejection-parity/catalogue/internal__promql__lower.go__lowerCountValues.json
@@ -17,6 +17,32 @@
     },
     {
       "head": "promql",
+      "site": "internal/promql/lower.go:lowerCountValues#53e0f9b3",
+      "message": "promql: internal invariant violated: count_values input is not histogram-valued: %v",
+      "class": "internal",
+      "rationale": "countValuesOverExpHistogramValue's own match predicate IS isExpHistogramValuedShape(agg.Expr, s, ctx) — the identical predicate lowerExpHistogramValuedShape's own dispatch table is built to answer matched=true for (cerberus issue #2568, threading the same countValuesOverExpHistogramValue / lowerExpHistogramValuedShape pairing lowerHistogramNativeRoot already uses into lowerCountValues so a count_values(...) NESTED under a further wrapper resolves too). So whenever the caller above reaches this branch, lowerExpHistogramValuedShape reporting matched=false here would mean the two predicates disagree about the same expression — an invariant this guard states explicitly rather than one that can actually be observed at runtime.",
+      "evidence": {
+        "guard": [
+          "past returning if !ok",
+          "past returning if label == \"\"",
+          "if agg, ok := countValuesOverExpHistogramValue(a, s, ctx); ok",
+          "past returning if err != nil",
+          "if !matched"
+        ],
+        "callers": [
+          "lowerAggregate"
+        ],
+        "cited": [
+          "countValuesOverExpHistogramValue",
+          "isExpHistogramValuedShape",
+          "lowerCountValues",
+          "lowerExpHistogramValuedShape",
+          "lowerHistogramNativeRoot"
+        ]
+      }
+    },
+    {
+      "head": "promql",
       "site": "internal/promql/lower.go:lowerCountValues#fc5b1a1a",
       "message": "promql: count_values requires a non-empty label name",
       "class": "rejection",


### PR DESCRIPTION
## Summary

- `count_values("v", <exp-histogram selector>)` already lowered cleanly at the query's own
  root via `lowerHistogramNativeRoot`'s `countValuesOverExpHistogramValue` dispatch, but any
  wrapper around it — most notably `histogram_quantile(0.5, count_values("v",
  <exp-histogram selector>))`, the issue's own reproduction — reached the histogram selector
  underneath through `lowerCountValues`'s generic `lower(a.Expr, ...)` fallback instead of a
  histogram-aware path, hitting `expHistogramSelectorRouting`'s hard-rejection catch-all.
- Thread the same `countValuesOverExpHistogramValue` / `lowerExpHistogramValuedShape` pairing
  directly into `lowerCountValues` (`internal/promql/lower.go`), so a nested
  `count_values(...)` resolves identically no matter what wraps it — mirroring how #2562
  threaded the sibling "dropping" family's recognizer into `lowerAggregate`.
- Added a chDB test (`internal/promql/histogram_native_count_values_nested_chdb_test.go`)
  proving the fix against real ClickHouse, seeded with non-empty rows: the issue's own trigger
  query now executes and correctly returns empty (no `le` label survives `count_values`), and
  a `sum(count_values(...))` wrapper correctly totals the underlying seeded series.
- Rotated the `expHistogramSelectorRouting#bf746b59` divergence catalogue entry
  (`test/rejection-parity/catalogue/internal__promql__lower.go__expHistogramSelectorRouting.json`)
  forward: after broad post-fix probing (every PromQL function against a bare/matrix
  exp-histogram selector, every pairwise aggregate/wrapper nesting combination, binary ops,
  subqueries, `@` modifiers, `info()`) turned up no other query still reaching that exact
  rejection except `info()`'s second-argument info-metric selector naming an exp-histogram
  metric — filed as #2574 and wired in as the entry's new trigger/tracking issue.
- The same probing also turned up a genuine, unrelated 500-class defect —
  `limitk()`/`limit_ratio()` over an exp-histogram, wrapped by a further float-only function,
  panics instead of cleanly rejecting or computing — filed as #2575 rather than fixed here, to
  keep this PR scoped to the count_values fix.

## Test plan

- [x] `internal/promql/histogram_native_count_values_nested_chdb_test.go` — real chDB
      round-trip: `histogram_quantile(0.5, count_values("v", ...))` executes and returns 0
      rows; `sum(count_values("v", ...))` executes and returns the correct total.
- [x] `go test -race ./internal/promql/...`
- [x] `go build ./...`, `go vet ./...`, `gofumpt -extra`, `goimports -local`
- [x] `node .github/scripts/forbid-sql-raw.mjs`
- [x] `CERBERUS_UPDATE_INVENTORY=1 go test -run TestCatalogueIsRegenerable ./test/rejection-parity/...`
      run twice (curated `rationale`/`class` fields hand-edited in between to recompute `cited`)
- [x] `go test ./test/rejection-parity/...` — full suite green, including
      `TestRejectionTriggersExerciseSites`, `TestInternalRationalesRestOnCurrentEvidence`,
      `TestInternalRationaleCitationsStillDispatch`, `TestDivergenceCeilingRatchet`

Closes #2568
