### PR TITLE
fix(promql): compose SELECT/FOLD-family fns over a nested histogram subquery

### DIFF
--- a/internal/promql/histogram_native_float_fn.go
+++ b/internal/promql/histogram_native_float_fn.go
@@ -32,6 +32,18 @@ func lowerExpHistogramValuedShape(expr parser.Expr, s schema.Metrics, ctx lowerC
 		plan, err := lowerExpHistogramRangeFnOverSubquery(shape, s, ctx)
 		return plan, true, err
 	}
+	// last_over_time / first_over_time over a subquery whose inner
+	// resolves histogram-native (cerberus issue #2569) — the histogram-
+	// PRESERVING half of [selectFnOverExpHistogramSubquery]'s eight-
+	// function match; the other six answer a plain float and are threaded
+	// through the generic [lowerCall] composition path instead (see that
+	// recognizer's own doc for the split). Composing this here, alongside
+	// [rangeFnOverExpHistogramSubquery] just above, gives it the identical
+	// recursive reach.
+	if shape, ok := selectFnHistogramPreservingSubquery(expr, s, ctx); ok {
+		plan, err := lowerSelectFnOverExpHistogramSubquery(shape, s, ctx)
+		return plan, true, err
+	}
 	if agg, ok := mergeableExpHistogramAggregate(expr); ok {
 		input, matched, err := lowerExpHistogramValuedShape(agg.Expr, s, ctx)
 		if err != nil {

--- a/internal/promql/histogram_native_scalar_binop.go
+++ b/internal/promql/histogram_native_scalar_binop.go
@@ -169,6 +169,14 @@ func isExpHistogramValuedShape(expr parser.Expr, s schema.Metrics, ctx lowerCtx)
 	if _, ok := rangeFnOverExpHistogramSubquery(expr, s, ctx); ok {
 		return true
 	}
+	// last_over_time / first_over_time over a subquery whose inner
+	// resolves histogram-native (cerberus issue #2569) — see
+	// [selectFnHistogramPreservingSubquery]'s own doc for why only these
+	// two of [selectFnOverExpHistogramSubquery]'s eight names belong in
+	// this predicate.
+	if _, ok := selectFnHistogramPreservingSubquery(expr, s, ctx); ok {
+		return true
+	}
 	if agg, ok := mergeableExpHistogramAggregate(expr); ok {
 		return isExpHistogramValuedShape(agg.Expr, s, ctx)
 	}

--- a/internal/promql/histogram_native_subquery_nested_composition_test.go
+++ b/internal/promql/histogram_native_subquery_nested_composition_test.go
@@ -1,0 +1,149 @@
+package promql_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/tsouza/cerberus/internal/chplan"
+	"github.com/tsouza/cerberus/internal/promql"
+	"github.com/tsouza/cerberus/internal/schema"
+)
+
+// TestLower_ExpHistogram_SelectFoldFamilyOverSubquery_Nested pins cerberus
+// issue #2569: `<fn>((h)[5m:1m])`, for every name #2545 already handles
+// when that expression is the query's own ROOT
+// (TestLower_ExpHistogram_SelectFamilyOverSubquery /
+// [rangeFnOverExpHistogramSubquery]'s own FOLD-family coverage), now also
+// lowers successfully when NESTED under a further wrapper — an
+// aggregation, an instant math function, or label_replace — matching
+// reference Prometheus, which evaluates the inner expression identically
+// regardless of what wraps it.
+func TestLower_ExpHistogram_SelectFoldFamilyOverSubquery_Nested(t *testing.T) {
+	t.Parallel()
+
+	s := schema.DefaultOTelMetrics()
+	end := time.Date(2026, 1, 1, 1, 0, 0, 0, time.UTC)
+
+	for _, tc := range []struct {
+		fn          string
+		wantHistRow bool // last_over_time/first_over_time/the FOLD family preserve a histogram sample
+	}{
+		// SELECT/COUNT family (cerberus issue #2545) — float-valued.
+		{fn: "count_over_time"},
+		{fn: "present_over_time"},
+		{fn: "resets"},
+		{fn: "changes"},
+		{fn: "ts_of_first_over_time"},
+		{fn: "ts_of_last_over_time"},
+		// SELECT family — histogram-preserving.
+		{fn: "last_over_time", wantHistRow: true},
+		{fn: "first_over_time", wantHistRow: true},
+		// FOLD family (cerberus issue #2545) — all histogram-preserving.
+		{fn: "rate", wantHistRow: true},
+		{fn: "increase", wantHistRow: true},
+		{fn: "delta", wantHistRow: true},
+		{fn: "irate", wantHistRow: true},
+		{fn: "idelta", wantHistRow: true},
+		{fn: "sum_over_time", wantHistRow: true},
+		{fn: "avg_over_time", wantHistRow: true},
+	} {
+		t.Run(tc.fn, func(t *testing.T) {
+			t.Parallel()
+			wantShape := chplan.SampleRowShape
+			if tc.wantHistRow {
+				wantShape = chplan.HistogramRowShape
+			}
+			inner := tc.fn + `((latency_exp_hist)[5m:1m])`
+
+			// Nested under an aggregation — the issue's own trigger_query
+			// shape (`sum(count_over_time((h)[5m:1m]))`).
+			t.Run("sum", func(t *testing.T) {
+				t.Parallel()
+				query := "sum by (job) (" + inner + ")"
+				expr := parseExprExp(t, query)
+				plan, err := promql.LowerAt(context.Background(), expr, s, end, end)
+				if err != nil {
+					t.Fatalf("lower(%q): %v", query, err)
+				}
+				if got := chplan.RowShapeOf(plan); got != wantShape {
+					t.Errorf("lower(%q) RowShape = %s, want %s", query, got, wantShape)
+				}
+			})
+
+			// Nested under an instant math function.
+			t.Run("abs", func(t *testing.T) {
+				t.Parallel()
+				query := "abs(" + inner + ")"
+				expr := parseExprExp(t, query)
+				plan, err := promql.LowerAt(context.Background(), expr, s, end, end)
+				if err != nil {
+					t.Fatalf("lower(%q): %v", query, err)
+				}
+				// Prometheus's simpleFloatFunc family (abs included) skips
+				// every histogram sample and answers an ordinary EMPTY
+				// float vector for a histogram-valued argument — abs()
+				// never itself preserves a histogram regardless of what
+				// wraps it, so the drop-family shape is the correct
+				// answer for the histogram-preserving names here, exactly
+				// as it is for the bare (non-nested) shape
+				// (TestLower_ExpHistogram_DropFamilyEmptyOverSubquery).
+				wantAbsShape := wantShape
+				if tc.wantHistRow {
+					wantAbsShape = chplan.SampleRowShape
+				}
+				if got := chplan.RowShapeOf(plan); got != wantAbsShape {
+					t.Errorf("lower(%q) RowShape = %s, want %s", query, got, wantAbsShape)
+				}
+			})
+
+			// Nested under label_replace — a non-aggregation wrapper that
+			// forwards the payload unchanged.
+			t.Run("label_replace", func(t *testing.T) {
+				t.Parallel()
+				query := `label_replace(` + inner + `, "extra", "yes", "", "")`
+				expr := parseExprExp(t, query)
+				plan, err := promql.LowerAt(context.Background(), expr, s, end, end)
+				if err != nil {
+					t.Fatalf("lower(%q): %v", query, err)
+				}
+				if got := chplan.RowShapeOf(plan); got != wantShape {
+					t.Errorf("lower(%q) RowShape = %s, want %s", query, got, wantShape)
+				}
+			})
+		})
+	}
+}
+
+// TestLower_ExpHistogram_DropFamilyEmptyOverSubquery_Nested pins that the
+// eleven float-only range-vector reducers (cerberus issue #2563) still
+// answer their canonical empty-float drop shape — never an error, and
+// never regressed by #2569's own composition threading — when nested under
+// a further wrapper.
+func TestLower_ExpHistogram_DropFamilyEmptyOverSubquery_Nested(t *testing.T) {
+	t.Parallel()
+
+	s := schema.DefaultOTelMetrics()
+	end := time.Date(2026, 1, 1, 1, 0, 0, 0, time.UTC)
+
+	for _, tc := range []struct {
+		name  string
+		query string
+	}{
+		{name: "max_over_time", query: `sum(max_over_time((latency_exp_hist)[5m:1m]))`},
+		{name: "min_over_time", query: `abs(min_over_time((latency_exp_hist)[5m:1m]))`},
+		{name: "quantile_over_time", query: `sum(quantile_over_time(0.5, (latency_exp_hist)[5m:1m]))`},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			expr := parseExprExp(t, tc.query)
+			plan, err := promql.LowerAt(context.Background(), expr, s, end, end)
+			if err != nil {
+				t.Fatalf("lower(%q): %v", tc.query, err)
+			}
+			if got := chplan.RowShapeOf(plan); got != chplan.SampleRowShape {
+				t.Errorf("lower(%q) RowShape = %s, want %s", tc.query, got, chplan.SampleRowShape)
+			}
+		})
+	}
+}

--- a/internal/promql/histogram_native_subquery_select.go
+++ b/internal/promql/histogram_native_subquery_select.go
@@ -74,11 +74,30 @@ type histogramSubquerySelectShape struct {
 // ts_of_first_over_time / ts_of_last_over_time over a subquery whose inner
 // expression is already histogram-valued. Mirrors
 // [rangeFnOverExpHistogramSubquery]'s own recognizer shape rung for rung,
-// differing only in which function names it admits and that its match
-// composes with [lowerHistogramNativeRoot] rather than
-// [lowerExpHistogramValuedShape] — see this file's own doc for why: unlike
-// the FOLD family, none of these eight functions' bare (non-subquery)
-// siblings are wired for further recursive composition either.
+// differing only in which function names it admits.
+//
+// Its match composes two different ways depending on the matched name's
+// OWN output shape (cerberus issue #2569, the generic-composition sibling
+// of #2545's original root-only fix):
+//
+//   - The six names whose output is an ordinary FLOAT sample
+//     (count_over_time, present_over_time, resets, changes,
+//     ts_of_first_over_time, ts_of_last_over_time) need no histogram-aware
+//     downstream handling at all once matched — any wrapper that reaches
+//     this shape through the generic `lower()` → [lowerCall] path (an
+//     aggregation's own generic fallback, a scalar math function, …) gets
+//     back a plain [chplan.SampleRowShape] node it already knows how to
+//     consume. [lowerCall] retries this recognizer directly for exactly
+//     that reason.
+//   - The two names whose output PRESERVES the window's own histogram
+//     sample (last_over_time, first_over_time) must never reach a
+//     consumer that lowers generically without a histogram-shape guard —
+//     see [selectFnHistogramPreservingSubquery], which narrows this same
+//     match to those two names and is threaded into
+//     [lowerExpHistogramValuedShape] / [isExpHistogramValuedShape]
+//     instead, mirroring how [rangeFnOverExpHistogramSubquery] (the FOLD
+//     family, entirely histogram-preserving) is threaded there rather than
+//     into [lowerCall].
 func selectFnOverExpHistogramSubquery(expr parser.Expr, s schema.Metrics, ctx lowerCtx) (histogramSubquerySelectShape, bool) {
 	if s.ExpHistogramTable == "" || ctx.metadataFullRange {
 		return histogramSubquerySelectShape{}, false
@@ -100,6 +119,39 @@ func selectFnOverExpHistogramSubquery(expr parser.Expr, s schema.Metrics, ctx lo
 		return histogramSubquerySelectShape{}, false
 	}
 	return histogramSubquerySelectShape{sub: sub, windowFn: call.Func.Name}, true
+}
+
+// selectFnHistogramPreservingSubquery narrows [selectFnOverExpHistogramSubquery]'s
+// eight-function match to last_over_time / first_over_time — the two names
+// whose result is itself a published histogram sample rather than a float
+// (cerberus issue #2569). Threaded into [lowerExpHistogramValuedShape] /
+// [isExpHistogramValuedShape] rather than [lowerCall]: unlike the other six
+// names in that switch, a caller reaching either of these through the fully
+// generic `lower()` path with no histogram-shape awareness (for example
+// [lowerLabelReplace]'s own inner lowering, or an ordinary
+// [chplan.Aggregate]'s AggFunc, both of which read `Value` unconditionally)
+// would either read the wrong column or hit
+// [projectAttributesOverInner]'s histogram-shape guard — see that
+// function's own doc for the ClickHouse-level failure this narrowing
+// avoids. Every existing [lowerExpHistogramValuedShape] consumer already
+// knows how to carry a [chplan.HistogramRowShape] node forward (that is
+// the whole point of the shared recognizer), so matching there instead
+// gives last_over_time/first_over_time-over-subquery the SAME recursive
+// reach [rangeFnOverExpHistogramSubquery] already has for the FOLD family
+// — nested under sum()/avg() via [mergeableExpHistogramAggregate],
+// label_replace/label_join via [labelCallOverExpHistogram], and every
+// other consumer this file's own package documents.
+func selectFnHistogramPreservingSubquery(expr parser.Expr, s schema.Metrics, ctx lowerCtx) (histogramSubquerySelectShape, bool) {
+	shape, ok := selectFnOverExpHistogramSubquery(expr, s, ctx)
+	if !ok {
+		return histogramSubquerySelectShape{}, false
+	}
+	switch shape.windowFn {
+	case lastOverTimeWindowFn, firstOverTimeWindowFn:
+		return shape, true
+	default:
+		return histogramSubquerySelectShape{}, false
+	}
 }
 
 // lowerSelectFnOverExpHistogramSubquery lowers the recognised shape. The

--- a/internal/promql/histogram_native_subquery_select_fold_nested_chdb_test.go
+++ b/internal/promql/histogram_native_subquery_select_fold_nested_chdb_test.go
@@ -1,0 +1,134 @@
+//go:build chdb
+
+// chDB-backed proof that cerberus issue #2569's fix actually executes
+// correctly against real ClickHouse — not merely that the emitted plan's Go
+// shape looks right (the same discipline
+// histogram_native_subquery_select_chdb_test.go's own sibling file
+// established for #2545's root-only fix).
+//
+// #2545 gave `<fn>((h)[range:step])` its own dedicated lowering for the
+// SELECT/COUNT family (count_over_time, present_over_time, last_over_time,
+// first_over_time, resets, changes, ts_of_first_over_time,
+// ts_of_last_over_time) and the FOLD family (rate, increase, delta, irate,
+// idelta, sum_over_time, avg_over_time), but only reachable when that whole
+// expression is the query's own ROOT — [lowerHistogramNativeRoot]'s
+// dispatch table. The moment the SAME shape is nested under a further
+// wrapper (an aggregation, label_replace, …), lowering used to fall through
+// the generic `lower()` → [lowerCall] path straight to
+// [lowerOuterRangeFnOverSubquery]'s histogram-shape guard and reject.
+// Cerberus issue #2569 threads the identical recognizers into that generic
+// path (lower.go's [lowerCall], for the six float-shaped SELECT-family
+// names) and into [lowerExpHistogramValuedShape] /
+// [isExpHistogramValuedShape] (histogram_native_float_fn.go /
+// histogram_native_scalar_binop.go, for the two histogram-preserving
+// SELECT-family names last_over_time/first_over_time — the FOLD family was
+// already threaded there for cerberus issue #2545).
+//
+// Each case reuses subquery_select_histogram_chdb_test.go's own
+// subqSelectHistFixture: a SINGLE series ("a") with two published samples,
+// (00:01:00, Count=2, Sum=4.0, Bucket1=6) and (00:02:00, Count=3, Sum=9.0,
+// Bucket1=12). A single-series `sum by (series) (...)` is therefore an
+// identity transform — the wrapped answer must equal the un-wrapped
+// baseline the sibling file already pins — which is exactly the property
+// each assertion below checks.
+package promql_test
+
+import (
+	"testing"
+
+	"github.com/tsouza/cerberus/internal/schema"
+)
+
+// TestSubqueryHistogramSelectFamilyNestedUnderSum_ChDB proves
+// count_over_time (a float-valued SELECT-family member) still answers
+// correctly when nested under `sum by (series) (...)` rather than being the
+// query's own root — the issue's own trigger_query shape.
+func TestSubqueryHistogramSelectFamilyNestedUnderSum_ChDB(t *testing.T) {
+	fixture, metric, evalTS := subqSelectHistFixture(t)
+	s := schema.DefaultOTelMetrics()
+
+	sqlStr, args := lowerAndEmit(t, "sum by (series) (count_over_time(("+metric+")[2m:1m]))", s, evalTS)
+	got := sampleValueRows(t, fixture, sqlStr, args)
+	if got["a"] != 2 {
+		t.Errorf("sum by (series) (count_over_time(...)): series a = %v, want 2 (single-series sum is an identity)", got["a"])
+	}
+}
+
+// TestSubqueryHistogramSelectFamilyNestedUnderLabelReplace_ChDB proves the
+// same count_over_time shape composes under label_replace — a
+// non-aggregation wrapper, the issue's other named example.
+func TestSubqueryHistogramSelectFamilyNestedUnderLabelReplace_ChDB(t *testing.T) {
+	fixture, metric, evalTS := subqSelectHistFixture(t)
+	s := schema.DefaultOTelMetrics()
+
+	sqlStr, args := lowerAndEmit(t, `label_replace(count_over_time((`+metric+`)[2m:1m]), "extra", "yes", "", "")`, s, evalTS)
+	got := sampleValueRows(t, fixture, sqlStr, args)
+	if got["a"] != 2 {
+		t.Errorf("label_replace(count_over_time(...)): series a = %v, want 2", got["a"])
+	}
+}
+
+// TestSubqueryHistogramFoldFamilyNestedUnderSum_ChDB proves sum_over_time
+// (a histogram-PRESERVING FOLD-family member) still folds the subquery's
+// two published histograms correctly when nested under `sum by (series)
+// (...)`.
+func TestSubqueryHistogramFoldFamilyNestedUnderSum_ChDB(t *testing.T) {
+	fixture, metric, evalTS := subqSelectHistFixture(t)
+	s := schema.DefaultOTelMetrics()
+
+	sqlStr, args := lowerAndEmit(t, "sum by (series) (sum_over_time(("+metric+")[2m:1m]))", s, evalTS)
+	rows := subqHistQueryRows(t, fixture, sqlStr, args)
+	if len(rows) != 1 {
+		t.Fatalf("sum by (series) (sum_over_time(...)): got %d rows, want 1: %+v", len(rows), rows)
+	}
+	if got := subqHistRowAt(t, rows, "a", evalTS); got.cnt != 5 || got.sum != 13.0 || got.bucket1 != 18 {
+		t.Errorf("sum by (series) (sum_over_time(...)) = %+v, want Count=5 Sum=13 Bucket1=18 (2+3, 4+9, 6+12)", got)
+	}
+}
+
+// TestSubqueryHistogramFoldFamilyNestedUnderLabelReplace_ChDB proves the
+// same sum_over_time shape composes under label_replace, preserving the
+// folded histogram payload verbatim under the rewritten labels.
+func TestSubqueryHistogramFoldFamilyNestedUnderLabelReplace_ChDB(t *testing.T) {
+	fixture, metric, evalTS := subqSelectHistFixture(t)
+	s := schema.DefaultOTelMetrics()
+
+	sqlStr, args := lowerAndEmit(t, `label_replace(sum_over_time((`+metric+`)[2m:1m]), "extra", "yes", "", "")`, s, evalTS)
+	rows := subqHistQueryRows(t, fixture, sqlStr, args)
+	if len(rows) != 1 {
+		t.Fatalf("label_replace(sum_over_time(...)): got %d rows, want 1: %+v", len(rows), rows)
+	}
+	if got := subqHistRowAt(t, rows, "a", evalTS); got.cnt != 5 || got.sum != 13.0 || got.bucket1 != 18 {
+		t.Errorf("label_replace(sum_over_time(...)) = %+v, want Count=5 Sum=13 Bucket1=18", got)
+	}
+}
+
+// TestSubqueryHistogramLastOverTimeNestedUnderSumAndLabelReplace_ChDB
+// proves last_over_time — the histogram-PRESERVING half of the SELECT
+// family, threaded through [lowerExpHistogramValuedShape] /
+// [isExpHistogramValuedShape] rather than [lowerCall] (see
+// [selectFnHistogramPreservingSubquery]'s own doc) — composes under both a
+// `sum by (series)` wrapper and label_replace without hitting
+// [projectAttributesOverInner]'s histogram-shape guard.
+func TestSubqueryHistogramLastOverTimeNestedUnderSumAndLabelReplace_ChDB(t *testing.T) {
+	fixture, metric, evalTS := subqSelectHistFixture(t)
+	s := schema.DefaultOTelMetrics()
+
+	sqlStr, args := lowerAndEmit(t, "sum by (series) (last_over_time(("+metric+")[2m:1m]))", s, evalTS)
+	rows := subqHistQueryRows(t, fixture, sqlStr, args)
+	if len(rows) != 1 {
+		t.Fatalf("sum by (series) (last_over_time(...)): got %d rows, want 1: %+v", len(rows), rows)
+	}
+	if got := subqHistRowAt(t, rows, "a", evalTS); got.cnt != 3 || got.sum != 9.0 || got.bucket1 != 12 {
+		t.Errorf("sum by (series) (last_over_time(...)) = %+v, want Count=3 Sum=9 Bucket1=12 (the 00:02 sample)", got)
+	}
+
+	sqlStr, args = lowerAndEmit(t, `label_replace(last_over_time((`+metric+`)[2m:1m]), "extra", "yes", "", "")`, s, evalTS)
+	rows = subqHistQueryRows(t, fixture, sqlStr, args)
+	if len(rows) != 1 {
+		t.Fatalf("label_replace(last_over_time(...)): got %d rows, want 1: %+v", len(rows), rows)
+	}
+	if got := subqHistRowAt(t, rows, "a", evalTS); got.cnt != 3 || got.sum != 9.0 || got.bucket1 != 12 {
+		t.Errorf("label_replace(last_over_time(...)) = %+v, want Count=3 Sum=9 Bucket1=12", got)
+	}
+}

--- a/internal/promql/lower.go
+++ b/internal/promql/lower.go
@@ -2617,6 +2617,42 @@ func lowerCall(c *parser.Call, s schema.Metrics, ctx lowerCtx) (chplan.Node, err
 			return lowerRangeVectorCall(c, s, ctx)
 		}
 		if sq, ok := arg0.(*parser.SubqueryExpr); ok {
+			// The histogram-native SELECT/FOLD-family composition
+			// (cerberus issue #2569): `<fn>((h)[5m:1m])` for the SELECT/
+			// COUNT family (count_over_time, present_over_time,
+			// last_over_time, first_over_time, resets, changes,
+			// ts_of_first_over_time, ts_of_last_over_time — cerberus issue
+			// #2545) and the FOLD family (rate, increase, delta, irate,
+			// idelta, sum_over_time, avg_over_time) already lowers
+			// correctly when that whole expression is the query ROOT (or a
+			// subquery's own inner, cerberus issue #2543) —
+			// [lowerHistogramNativeRoot]'s dispatch table tries
+			// [selectFnOverExpHistogramSubquery] /
+			// [rangeFnOverExpHistogramSubquery] ahead of `lower()`/
+			// lowerCall, but ONLY at those two entry points. The identical
+			// shape reached via a wrapper's own operand lowering —
+			// `sum(count_over_time((h)[5m:1m]))`, `abs(rate((h)[5m:1m]))`,
+			// `label_replace(last_over_time((h)[5m:1m]), ...)` — comes
+			// through here directly, bypassing that table entirely and
+			// falling into [lowerOuterRangeFnOverSubquery]'s own
+			// histogram-shape guard below. Retrying both recognizers here,
+			// before that guard, closes the gap for EVERY wrapper in one
+			// place rather than needing a bespoke retry per wrapper site —
+			// mirroring how [lowerAggregate] / [lowerRangeVectorCall]
+			// already retry [lowerExpHistogramCountFamily] /
+			// [resetsOrChangesOverExpHistogram] for their own nested
+			// equivalents (cerberus issue #2549). Neither recognizer
+			// depends on being called from a root: both gate purely on
+			// `s.ExpHistogramTable`, the call's own function name and
+			// argument shape, and the subquery's inner already resolving
+			// histogram-native, so retrying them here is sound regardless
+			// of what wraps this call.
+			if shape, ok := selectFnOverExpHistogramSubquery(c, s, ctx); ok {
+				return lowerSelectFnOverExpHistogramSubquery(shape, s, ctx)
+			}
+			if shape, ok := rangeFnOverExpHistogramSubquery(c, s, ctx); ok {
+				return lowerExpHistogramRangeFnOverSubquery(shape, s, ctx)
+			}
 			// `<range-vector-fn>(<subquery>)` — the canonical Grafana
 			// shape `max_over_time(rate(m[5m])[1h:5m])`. Lowers to a
 			// chained RangeWindow: outer reducer over the inner matrix.

--- a/internal/promql/lower.go
+++ b/internal/promql/lower.go
@@ -2617,46 +2617,7 @@ func lowerCall(c *parser.Call, s schema.Metrics, ctx lowerCtx) (chplan.Node, err
 			return lowerRangeVectorCall(c, s, ctx)
 		}
 		if sq, ok := arg0.(*parser.SubqueryExpr); ok {
-			// The histogram-native SELECT/FOLD-family composition
-			// (cerberus issue #2569): `<fn>((h)[5m:1m])` for the SELECT/
-			// COUNT family (count_over_time, present_over_time,
-			// last_over_time, first_over_time, resets, changes,
-			// ts_of_first_over_time, ts_of_last_over_time — cerberus issue
-			// #2545) and the FOLD family (rate, increase, delta, irate,
-			// idelta, sum_over_time, avg_over_time) already lowers
-			// correctly when that whole expression is the query ROOT (or a
-			// subquery's own inner, cerberus issue #2543) —
-			// [lowerHistogramNativeRoot]'s dispatch table tries
-			// [selectFnOverExpHistogramSubquery] /
-			// [rangeFnOverExpHistogramSubquery] ahead of `lower()`/
-			// lowerCall, but ONLY at those two entry points. The identical
-			// shape reached via a wrapper's own operand lowering —
-			// `sum(count_over_time((h)[5m:1m]))`, `abs(rate((h)[5m:1m]))`,
-			// `label_replace(last_over_time((h)[5m:1m]), ...)` — comes
-			// through here directly, bypassing that table entirely and
-			// falling into [lowerOuterRangeFnOverSubquery]'s own
-			// histogram-shape guard below. Retrying both recognizers here,
-			// before that guard, closes the gap for EVERY wrapper in one
-			// place rather than needing a bespoke retry per wrapper site —
-			// mirroring how [lowerAggregate] / [lowerRangeVectorCall]
-			// already retry [lowerExpHistogramCountFamily] /
-			// [resetsOrChangesOverExpHistogram] for their own nested
-			// equivalents (cerberus issue #2549). Neither recognizer
-			// depends on being called from a root: both gate purely on
-			// `s.ExpHistogramTable`, the call's own function name and
-			// argument shape, and the subquery's inner already resolving
-			// histogram-native, so retrying them here is sound regardless
-			// of what wraps this call.
-			if shape, ok := selectFnOverExpHistogramSubquery(c, s, ctx); ok {
-				return lowerSelectFnOverExpHistogramSubquery(shape, s, ctx)
-			}
-			if shape, ok := rangeFnOverExpHistogramSubquery(c, s, ctx); ok {
-				return lowerExpHistogramRangeFnOverSubquery(shape, s, ctx)
-			}
-			// `<range-vector-fn>(<subquery>)` — the canonical Grafana
-			// shape `max_over_time(rate(m[5m])[1h:5m])`. Lowers to a
-			// chained RangeWindow: outer reducer over the inner matrix.
-			return lowerOuterRangeFnOverSubquery(c, sq, s, ctx)
+			return lowerCallOverSubquery(c, sq, s, ctx)
 		}
 	}
 	switch c.Func.Name {
@@ -2729,6 +2690,50 @@ func lowerCall(c *parser.Call, s schema.Metrics, ctx lowerCtx) (chplan.Node, err
 		return lowerInstantFn(c, s, chFn, ctx)
 	}
 	return nil, fmt.Errorf("promql: function %s is not a recognized lowering target", c.Func.Name)
+}
+
+// lowerCallOverSubquery lowers `<fn>(<subquery>)` — c's single argument is
+// sq. Split out of [lowerCall] itself (cerberus issue #2569) purely to keep
+// that function's own golangci-lint `nestif` complexity score under the
+// repo's floor; the dispatch order and every recognizer's own rationale
+// below are unchanged from when this block lived inline there.
+//
+// The histogram-native SELECT/FOLD-family composition (cerberus issue
+// #2569): `<fn>((h)[5m:1m])` for the SELECT/COUNT family (count_over_time,
+// present_over_time, last_over_time, first_over_time, resets, changes,
+// ts_of_first_over_time, ts_of_last_over_time — cerberus issue #2545) and
+// the FOLD family (rate, increase, delta, irate, idelta, sum_over_time,
+// avg_over_time) already lowers correctly when that whole expression is
+// the query ROOT (or a subquery's own inner, cerberus issue #2543) —
+// [lowerHistogramNativeRoot]'s dispatch table tries
+// [selectFnOverExpHistogramSubquery] / [rangeFnOverExpHistogramSubquery]
+// ahead of `lower()`/[lowerCall], but ONLY at those two entry points. The
+// identical shape reached via a wrapper's own operand lowering —
+// `sum(count_over_time((h)[5m:1m]))`, `abs(rate((h)[5m:1m]))`,
+// `label_replace(last_over_time((h)[5m:1m]), ...)` — comes through here
+// directly, bypassing that table entirely and falling into
+// [lowerOuterRangeFnOverSubquery]'s own histogram-shape guard below.
+// Retrying both recognizers here, before that guard, closes the gap for
+// EVERY wrapper in one place rather than needing a bespoke retry per
+// wrapper site — mirroring how [lowerAggregate] / [lowerRangeVectorCall]
+// already retry [lowerExpHistogramCountFamily] /
+// [resetsOrChangesOverExpHistogram] for their own nested equivalents
+// (cerberus issue #2549). Neither recognizer depends on being called from
+// a root: both gate purely on `s.ExpHistogramTable`, the call's own
+// function name and argument shape, and the subquery's inner already
+// resolving histogram-native, so retrying them here is sound regardless of
+// what wraps this call.
+func lowerCallOverSubquery(c *parser.Call, sq *parser.SubqueryExpr, s schema.Metrics, ctx lowerCtx) (chplan.Node, error) {
+	if shape, ok := selectFnOverExpHistogramSubquery(c, s, ctx); ok {
+		return lowerSelectFnOverExpHistogramSubquery(shape, s, ctx)
+	}
+	if shape, ok := rangeFnOverExpHistogramSubquery(c, s, ctx); ok {
+		return lowerExpHistogramRangeFnOverSubquery(shape, s, ctx)
+	}
+	// `<range-vector-fn>(<subquery>)` — the canonical Grafana shape
+	// `max_over_time(rate(m[5m])[1h:5m])`. Lowers to a chained RangeWindow:
+	// outer reducer over the inner matrix.
+	return lowerOuterRangeFnOverSubquery(c, sq, s, ctx)
 }
 
 // matrixSelectorArg validates that c carries exactly one range-vector

--- a/test/rejection-parity/catalogue/internal__promql__histogram_native_range_fn.go__lowerExpHistogramRangeFnOverSubquery.json
+++ b/test/rejection-parity/catalogue/internal__promql__histogram_native_range_fn.go__lowerExpHistogramRangeFnOverSubquery.json
@@ -11,6 +11,7 @@
           "if step \u003c 0"
         ],
         "callers": [
+          "lowerCall",
           "lowerExpHistogramValuedShape"
         ]
       }
@@ -30,6 +31,7 @@
           "if !matched || chplan.RowShapeOf(input) != chplan.HistogramRowShape"
         ],
         "callers": [
+          "lowerCall",
           "lowerExpHistogramValuedShape"
         ],
         "cited": [
@@ -51,6 +53,7 @@
           "if !ok"
         ],
         "callers": [
+          "lowerCall",
           "lowerExpHistogramValuedShape"
         ],
         "cited": [

--- a/test/rejection-parity/catalogue/internal__promql__histogram_native_range_fn.go__lowerExpHistogramRangeFnOverSubquery.json
+++ b/test/rejection-parity/catalogue/internal__promql__histogram_native_range_fn.go__lowerExpHistogramRangeFnOverSubquery.json
@@ -11,7 +11,7 @@
           "if step \u003c 0"
         ],
         "callers": [
-          "lowerCall",
+          "lowerCallOverSubquery",
           "lowerExpHistogramValuedShape"
         ]
       }
@@ -31,7 +31,7 @@
           "if !matched || chplan.RowShapeOf(input) != chplan.HistogramRowShape"
         ],
         "callers": [
-          "lowerCall",
+          "lowerCallOverSubquery",
           "lowerExpHistogramValuedShape"
         ],
         "cited": [
@@ -53,7 +53,7 @@
           "if !ok"
         ],
         "callers": [
-          "lowerCall",
+          "lowerCallOverSubquery",
           "lowerExpHistogramValuedShape"
         ],
         "cited": [

--- a/test/rejection-parity/catalogue/internal__promql__histogram_native_subquery_select.go__lowerSelectFnOverExpHistogramSubquery.json
+++ b/test/rejection-parity/catalogue/internal__promql__histogram_native_subquery_select.go__lowerSelectFnOverExpHistogramSubquery.json
@@ -11,7 +11,7 @@
           "if step \u003c 0"
         ],
         "callers": [
-          "lowerCall",
+          "lowerCallOverSubquery",
           "lowerExpHistogramValuedShape",
           "lowerHistogramNativeRoot"
         ]
@@ -32,7 +32,7 @@
           "if !matched || chplan.RowShapeOf(input) != chplan.HistogramRowShape"
         ],
         "callers": [
-          "lowerCall",
+          "lowerCallOverSubquery",
           "lowerExpHistogramValuedShape",
           "lowerHistogramNativeRoot"
         ],
@@ -56,7 +56,7 @@
           "if !ok"
         ],
         "callers": [
-          "lowerCall",
+          "lowerCallOverSubquery",
           "lowerExpHistogramValuedShape",
           "lowerHistogramNativeRoot"
         ],

--- a/test/rejection-parity/catalogue/internal__promql__histogram_native_subquery_select.go__lowerSelectFnOverExpHistogramSubquery.json
+++ b/test/rejection-parity/catalogue/internal__promql__histogram_native_subquery_select.go__lowerSelectFnOverExpHistogramSubquery.json
@@ -11,6 +11,8 @@
           "if step \u003c 0"
         ],
         "callers": [
+          "lowerCall",
+          "lowerExpHistogramValuedShape",
           "lowerHistogramNativeRoot"
         ]
       }
@@ -30,6 +32,8 @@
           "if !matched || chplan.RowShapeOf(input) != chplan.HistogramRowShape"
         ],
         "callers": [
+          "lowerCall",
+          "lowerExpHistogramValuedShape",
           "lowerHistogramNativeRoot"
         ],
         "cited": [
@@ -52,6 +56,8 @@
           "if !ok"
         ],
         "callers": [
+          "lowerCall",
+          "lowerExpHistogramValuedShape",
           "lowerHistogramNativeRoot"
         ],
         "cited": [

--- a/test/rejection-parity/catalogue/internal__promql__subquery.go__lowerOuterRangeFnOverSubquery.json
+++ b/test/rejection-parity/catalogue/internal__promql__subquery.go__lowerOuterRangeFnOverSubquery.json
@@ -5,8 +5,8 @@
       "site": "internal/promql/subquery.go:lowerOuterRangeFnOverSubquery#087c3810",
       "message": "promql: %s over a subquery wrapping a native-histogram-valued shape is unsupported",
       "class": "divergence",
-      "trigger_query": "sum(count_over_time((demo_latency_exp_hist)[5m:1m]))",
-      "tracking_issue": 2569,
+      "trigger_query": "count_over_time(((demo_latency_exp_hist) or (demo_num_cpus))[5m:1m])",
+      "tracking_issue": 2577,
       "evidence": {
         "guard": [
           "past returning if outer.Func.Name == \"absent_over_time\"",
@@ -19,7 +19,7 @@
           "lowerCall"
         ]
       },
-      "since": "2026-08-24"
+      "since": "2026-08-25"
     },
     {
       "head": "promql",

--- a/test/rejection-parity/catalogue/internal__promql__subquery.go__lowerOuterRangeFnOverSubquery.json
+++ b/test/rejection-parity/catalogue/internal__promql__subquery.go__lowerOuterRangeFnOverSubquery.json
@@ -16,7 +16,8 @@
           "if !histogramSubqueryFloatOnlyDropFunc(outer.Func.Name)"
         ],
         "callers": [
-          "lowerCall"
+          "lowerCall",
+          "lowerCallOverSubquery"
         ]
       },
       "since": "2026-08-25"
@@ -33,7 +34,8 @@
           "if !chplan.IsPromQLRangeWindowFunc(canonicalRangeWindowFunc(outer.Func.Name))"
         ],
         "callers": [
-          "lowerCall"
+          "lowerCall",
+          "lowerCallOverSubquery"
         ],
         "cited": [
           "canonicalRangeWindowFunc",


### PR DESCRIPTION
## Summary

- `<fn>((h)[5m:1m])` — the SELECT/COUNT family (`count_over_time`, `present_over_time`,
  `last_over_time`, `first_over_time`, `resets`, `changes`, `ts_of_first_over_time`,
  `ts_of_last_over_time`) and the FOLD family (`rate`, `increase`, `delta`, `irate`, `idelta`,
  `sum_over_time`, `avg_over_time`) — already lowered correctly at the query's own root (#2545), but
  fell through to `lowerOuterRangeFnOverSubquery`'s histogram-shape rejection the moment the same
  shape was **nested** under a further wrapper (an aggregation, a scalar function, `label_replace`,
  …), because `lowerHistogramNativeRoot`'s dispatch table is consulted only at the root (or a
  subquery's own inner).
- `lowerCall` (`internal/promql/lower.go`) now retries `selectFnOverExpHistogramSubquery` /
  `rangeFnOverExpHistogramSubquery` before falling to `lowerOuterRangeFnOverSubquery` — closing the
  gap for the six SELECT-family names whose output is an ordinary float sample, reachable safely from
  any generic wrapper.
- `last_over_time` / `first_over_time` preserve a histogram sample instead of answering a float, so a
  caller that reaches them through a fully generic, non-histogram-aware lowering path (for example
  `label_replace`'s own inner lowering) would either read the wrong column or trip
  `projectAttributesOverInner`'s histogram-shape guard. They are threaded into
  `lowerExpHistogramValuedShape` / `isExpHistogramValuedShape` instead (alongside the FOLD family,
  which was already there), giving them the same recursive reach through every existing
  histogram-aware consumer (`sum`/`avg`, `label_replace`, …) that the FOLD family already has.
- All ~14 names now compose correctly nested under `sum(...)`, an instant math function, and
  `label_replace(...)` — verified in Go-shape unit tests and against real ClickHouse via chDB.

## Follow-up found while probing post-fix

Probing broadly after the fix, `<fn>(((a) or (b))[5m:1m])` — a SELECT/FOLD-family outer function over
a subquery whose own inner is a **mixed** float/histogram `or` shape, rather than a pure histogram —
still rejects, for all fifteen names. This is a genuinely different composability axis (the ongoing
mixed-or epic: #2330, #2346, #2449, #2558, #2573, …) that #2545 never covered either, so it's out of
this issue's scope. Filed as #2577 and the sole remaining `internal/promql/subquery.go:
lowerOuterRangeFnOverSubquery#087c3810` catalogue entry is narrowed to track it there (`trigger_query`
updated to the mixed-or-inner shape, `tracking_issue` moved to 2577).

Since #2569's own acceptance criteria (composition for a pure histogram-native subquery inner) is
fully met, this PR closes #2569.

## Test plan

- [x] `go build ./...`, `go vet ./...`, `gofumpt -extra`, `goimports -local` — clean
- [x] `go test -race ./internal/promql/...` — full suite green
- [x] New Go-shape unit test (`histogram_native_subquery_nested_composition_test.go`) covering all 15
      SELECT/FOLD-family names nested under `sum`, `abs`, and `label_replace`, plus a regression guard
      for the eleven float-only drop-family functions nested the same way
- [x] New chDB test (`histogram_native_subquery_select_fold_nested_chdb_test.go`) proving
      `count_over_time` (SELECT/float), `sum_over_time` (FOLD/histogram) and `last_over_time`
      (SELECT/histogram-preserving) execute correctly against real ClickHouse when nested under
      `sum by (series)` and `label_replace`
- [x] `node .github/scripts/forbid-sql-raw.mjs` — clean
- [x] Rejection-parity catalogue regenerated (`CERBERUS_UPDATE_INVENTORY=1 go test -run
      TestCatalogueIsRegenerable ./test/rejection-parity/...`, run twice — stable second pass) and
      `TestRejectionTriggersExerciseSites` / `TestInternalRationalesRestOnCurrentEvidence` pass
- [x] `go test -race ./test/rejection-parity/...` — full suite green

Closes #2569

🤖 Generated with [Claude Code](https://claude.com/claude-code)
