### PR TITLE
fix(promql): recognize limitk/limit_ratio over exp-histogram as a preserved shape

### DIFF
--- a/internal/promql/histogram_native_float_fn.go
+++ b/internal/promql/histogram_native_float_fn.go
@@ -58,6 +58,24 @@ func lowerExpHistogramValuedShape(expr parser.Expr, s schema.Metrics, ctx lowerC
 		plan, err := lowerExpHistogramScalarBinop(histSide, op, scale, s, ctx, false)
 		return plan, true, err
 	}
+	// limitk(K, <exp-hist shape>) / limit_ratio(R, <exp-hist shape>)
+	// (cerberus issue #2575) — see [limitKOrRatioOverExpHistogram]'s doc
+	// for why this dispatch is needed even though [lowerLimitKInput]
+	// already preserves the histogram shape on its own. Delegating to
+	// [lowerLimitK]/[lowerLimitRatio] reuses that exact preserving
+	// lowering unchanged — a query where limitk/limit_ratio is itself the
+	// root, or reached through [lowerAggregate]'s own op-specific
+	// dispatch, lowers byte-for-byte the same way it always has.
+	if agg, ok := limitKOrRatioOverExpHistogram(expr, s, ctx); ok {
+		var plan chplan.Node
+		var err error
+		if agg.Op == parser.LIMITK {
+			plan, err = lowerLimitK(agg, s, ctx)
+		} else {
+			plan, err = lowerLimitRatio(agg, s, ctx)
+		}
+		return plan, true, err
+	}
 	// The vector-scaling sibling of the literal-scalar case just above
 	// (cerberus issue #2540, widening #2339/#2342/#2537's own recognizer
 	// into this shared dispatch table): threading it in here is what lets

--- a/internal/promql/histogram_native_scalar_binop.go
+++ b/internal/promql/histogram_native_scalar_binop.go
@@ -180,6 +180,15 @@ func isExpHistogramValuedShape(expr parser.Expr, s schema.Metrics, ctx lowerCtx)
 	if agg, ok := mergeableExpHistogramAggregate(expr); ok {
 		return isExpHistogramValuedShape(agg.Expr, s, ctx)
 	}
+	// `limitk(K, <exp-hist shape>)` / `limit_ratio(R, <exp-hist shape>)`
+	// (cerberus issue #2575) — limitk/limit_ratio, unlike topk/bottomk,
+	// PRESERVE a histogram-valued operand ([lowerLimitKInput], cerberus
+	// issue #2518), so a further wrapper around either needs to see that
+	// here too. [limitKOrRatioOverExpHistogram] (lower.go) already checks
+	// the operand recursively, so no further recursion is needed.
+	if _, ok := limitKOrRatioOverExpHistogram(expr, s, ctx); ok {
+		return true
+	}
 	// `<exp-hist shape> (*|/) <float-VECTOR shape>` — the vector-scaling
 	// sibling of the compile-time-literal case just below (cerberus issue
 	// #2540), answered by [expHistogramFloatVectorScalingBinop]

--- a/internal/promql/limitk_wrapped_exp_histogram_chdb_test.go
+++ b/internal/promql/limitk_wrapped_exp_histogram_chdb_test.go
@@ -1,0 +1,141 @@
+//go:build chdb
+
+// chDB-backed proof that `limitk`/`limit_ratio` over an exp-histogram
+// operand, wrapped by a further float-only function (cerberus issue
+// #2575), now lowers to valid SQL and EXECUTES against real ClickHouse —
+// answering the real empty result reference Prometheus's float-only
+// functions give for a native-histogram sample, rather than panicking
+// with "promql: projectValueOverInner received a histogram-shaped
+// input: ...".
+//
+// TestLower_ExpHistogram_LimitKAndLimitRatioComposeUnderFloatOnlyWrappers
+// (limitk_wrapped_exp_histogram_test.go) already pins the SAME shapes at
+// the Go-plan-shape level; this file is that fixture's chDB-executed
+// sibling, following the pattern
+// TestLower_ExpHistogram_DroppingAggregationNestedUnderWrapper_ChDB
+// (histogram_native_topk_dropping_nested_chdb_test.go) established for
+// the sibling "dropping op nested under a wrapper" issue (#2562).
+//
+// The metric is seeded with THREE series' worth of REAL, non-empty rows
+// so a returned row count can only mean the lowering actually preserved
+// (K=2 of 3) or dropped (every row) the sample — never that no data was
+// ever scanned.
+package promql_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/prometheus/prometheus/promql/parser"
+
+	"github.com/tsouza/cerberus/internal/chsql"
+	"github.com/tsouza/cerberus/internal/promql"
+	"github.com/tsouza/cerberus/internal/schema"
+	"github.com/tsouza/cerberus/internal/testsql"
+)
+
+const limitkWrappedMetric = "limitk_wrapped_probe_exp_hist"
+
+var limitkWrappedSeed = "" +
+	"CREATE OR REPLACE TABLE otel_metrics_exponential_histogram (" +
+	"`MetricName` String, `Attributes` Map(String, String), " +
+	"`ResourceAttributes` Map(String, String) DEFAULT map(), `ServiceName` LowCardinality(String) DEFAULT '', " +
+	"`TimeUnix` DateTime64(9), " +
+	"`Count` UInt64, `Sum` Float64, `Scale` Int32, `ZeroCount` UInt64, " +
+	"`PositiveOffset` Int32, `PositiveBucketCounts` Array(UInt64), " +
+	"`NegativeOffset` Int32, `NegativeBucketCounts` Array(UInt64)" +
+	") ENGINE = MergeTree ORDER BY (`MetricName`, `Attributes`, `TimeUnix`);\n" +
+	"INSERT INTO otel_metrics_exponential_histogram " +
+	"(MetricName, Attributes, TimeUnix, Count, Sum, Scale, ZeroCount, PositiveOffset, PositiveBucketCounts, NegativeOffset, NegativeBucketCounts) VALUES\n" +
+	"    ('" + limitkWrappedMetric + "', map('service', 'checkout'), toDateTime64('2026-01-01 00:00:00', 9), 5, 10.0, 0, 0, 0, [5], 0, []),\n" +
+	"    ('" + limitkWrappedMetric + "', map('service', 'cart'), toDateTime64('2026-01-01 00:00:00', 9), 9, 20.0, 0, 0, 0, [9], 0, []),\n" +
+	"    ('" + limitkWrappedMetric + "', map('service', 'search'), toDateTime64('2026-01-01 00:00:00', 9), 3, 6.0, 0, 0, 0, [3], 0, []);\n"
+
+var limitkWrappedEvalTS = time.Date(2026, 1, 1, 0, 0, 1, 0, time.UTC)
+
+// countRowsOverEmitted lowers query, emits it, and returns the row count
+// the emitted SQL produces against fixture. Isolated here so both tests
+// below share the exact same execution path.
+func countRowsOverEmitted(t *testing.T, fixture *chdbFixture, s schema.Metrics, query string) int64 {
+	t.Helper()
+	p := parser.NewParser(parser.Options{EnableExperimentalFunctions: true})
+	expr, err := p.ParseExpr(query)
+	if err != nil {
+		t.Fatalf("ParseExpr(%q): %v", query, err)
+	}
+	plan, err := promql.LowerAt(context.Background(), expr, s, limitkWrappedEvalTS, limitkWrappedEvalTS)
+	if err != nil {
+		t.Fatalf("LowerAt(%q): unexpected error (this exact shape panicked or was rejected before cerberus issue #2575's fix): %v", query, err)
+	}
+	sqlStr, args, err := chsql.Emit(context.Background(), plan)
+	if err != nil {
+		t.Fatalf("Emit(%q): %v", query, err)
+	}
+
+	rows := fixture.queryOverEmitted(t, "count() AS n", sqlStr, args)
+	defer func() { _ = rows.Close() }()
+	if !rows.Next() {
+		t.Fatalf("count() query for %q returned no rows", query)
+	}
+	var n int64
+	if err := rows.Scan(&n); err != nil {
+		t.Fatalf("scan count() for %q: %v", query, err)
+	}
+	if err := testsql.TolerantRowsErr(rows.Err()); err != nil {
+		t.Fatalf("rows.Err for %q: %v", query, err)
+	}
+	return n
+}
+
+// TestLower_ExpHistogram_LimitKWrappedByFloatOnlyFn_ChDB pins cerberus
+// issue #2575's own trigger query (`abs(limitk(2, <exp-hist selector>))`)
+// plus its siblings, executed against real ClickHouse: every one must
+// answer count()=0 — reference's float-only functions drop every
+// native-histogram sample — never panic and never forward a non-empty
+// histogram-shaped result.
+func TestLower_ExpHistogram_LimitKWrappedByFloatOnlyFn_ChDB(t *testing.T) {
+	fixture := newChDBFixture(t, limitkWrappedSeed)
+	s := schema.DefaultOTelMetrics()
+
+	queries := []string{
+		// The issue's own trigger query.
+		"abs(limitk(2, " + limitkWrappedMetric + "))",
+		"ceil(limitk(2, " + limitkWrappedMetric + "))",
+		"sqrt(limitk(2, " + limitkWrappedMetric + "))",
+		"limitk(2, " + limitkWrappedMetric + ") + 0",
+		// limit_ratio reproduces identically.
+		"abs(limit_ratio(0.5, " + limitkWrappedMetric + "))",
+	}
+
+	for _, query := range queries {
+		query := query
+		t.Run(query, func(t *testing.T) {
+			n := countRowsOverEmitted(t, fixture, s, query)
+			if n != 0 {
+				t.Fatalf(
+					"query %q returned count()=%d, want 0 — reference drops every native-histogram sample under a float-only wrapper; the metric was seeded with THREE REAL non-empty series, so a non-zero count would mean the drop never actually fired at execution",
+					query, n,
+				)
+			}
+		})
+	}
+}
+
+// TestLower_ExpHistogram_LimitKUnwrapped_ChDB is the contrasting
+// regression guard, executed against the SAME seed and fixture: the
+// UNWRAPPED case cerberus issue #2518 shipped must keep preserving K of
+// the 3 seeded series' histogram rows, end to end — not silently regress
+// to 0 (over-dropping) or 3 (K never applied) once the wrapped-composition
+// fix above lands.
+func TestLower_ExpHistogram_LimitKUnwrapped_ChDB(t *testing.T) {
+	fixture := newChDBFixture(t, limitkWrappedSeed)
+	s := schema.DefaultOTelMetrics()
+
+	const k = 2
+	query := "limitk(2, " + limitkWrappedMetric + ")"
+	n := countRowsOverEmitted(t, fixture, s, query)
+	if n != k {
+		t.Fatalf("query %q returned count()=%d, want %d — unwrapped limitk must keep preserving exactly K of the 3 seeded series' histogram rows (cerberus issue #2518 must not regress)", query, n, k)
+	}
+}

--- a/internal/promql/limitk_wrapped_exp_histogram_test.go
+++ b/internal/promql/limitk_wrapped_exp_histogram_test.go
@@ -1,0 +1,231 @@
+package promql_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/tsouza/cerberus/internal/chplan"
+	"github.com/tsouza/cerberus/internal/promql"
+	"github.com/tsouza/cerberus/internal/schema"
+)
+
+// TestLower_ExpHistogram_LimitKAndLimitRatioComposeUnderFloatOnlyWrappers
+// pins cerberus issue #2575: `limitk(K, <exp-hist selector>)` /
+// `limit_ratio(R, <exp-hist selector>)`, wrapped by a further float-only
+// function or arithmetic operator, used to PANIC inside
+// [chplan.RowShapeOf]'s consumer histogram_shape_guard.go's
+// assertValueShapedInput rather than either computing correctly or
+// cleanly rejecting.
+//
+// Root cause: [lowerLimitKInput] (cerberus issue #2518) already recognises
+// and PRESERVES a histogram-valued operand to limitk/limit_ratio, but
+// neither `isExpHistogramValuedShape` nor `isExpHistogramDroppingShape`
+// (histogram_native_scalar_binop.go / histogram_native_float_fn.go /
+// histogram_native_dropping_shape.go) had a limitk/limit_ratio entry, so a
+// float-only wrapper's own opt-in
+// ([lowerExpHistogramArgAsCanonicalFloat]) never recognised the operand as
+// histogram-shaped and fell through to the generic `lower()` dispatcher —
+// which produced the SAME histogram-shaped plan anyway, just without the
+// wrapper's own postprocessing ever expecting it.
+//
+// Reference Prometheus's float-only functions (abs/ceil/sqrt/…) and plain
+// arithmetic silently DROP a native-histogram sample rather than erroring
+// (see issue #2221's own "float-only functions" family) — so the fix
+// shape is the same "preserve-family recognizer, consumed and dropped by
+// the wrapper" pattern every other wrapper in
+// internal/promql/histogram_native_*.go already gets. This test covers
+// that DROP-family half; `label_replace`/`label_join` and `timestamp()`
+// — two of the issue's own named reproducers — are NOT float-only/drop
+// wrappers (they preserve the payload or answer a real derived value
+// respectively) and get their own tests just below.
+func TestLower_ExpHistogram_LimitKAndLimitRatioComposeUnderFloatOnlyWrappers(t *testing.T) {
+	t.Parallel()
+
+	s := schema.DefaultOTelMetrics()
+	at := time.Date(2026, 1, 1, 0, 0, 1, 0, time.UTC)
+
+	queries := []string{
+		// The issue's own trigger query, plus every other float-only
+		// wrapper the issue names.
+		`abs(limitk(2, latency_exp_hist))`,
+		`ceil(limitk(2, latency_exp_hist))`,
+		`sqrt(limitk(2, latency_exp_hist))`,
+		`round(limitk(2, latency_exp_hist))`,
+		`exp(limitk(2, latency_exp_hist))`,
+		`ln(limitk(2, latency_exp_hist))`,
+		`log2(limitk(2, latency_exp_hist))`,
+		`log10(limitk(2, latency_exp_hist))`,
+		`clamp(limitk(2, latency_exp_hist), 0, 1)`,
+		`clamp_min(limitk(2, latency_exp_hist), 0)`,
+		`clamp_max(limitk(2, latency_exp_hist), 1)`,
+		// Plain arithmetic.
+		`limitk(2, latency_exp_hist) + 0`,
+		// limit_ratio reproduces identically.
+		`abs(limit_ratio(0.5, latency_exp_hist))`,
+		`limit_ratio(0.5, latency_exp_hist) + 0`,
+		// Computed-K / by/without partitioning must compose too — these
+		// route limitk's input through [lowerTopKComputed] rather than
+		// [lowerLimitK] directly, but both share [lowerLimitKInput].
+		`abs(limitk(scalar(up), latency_exp_hist))`,
+		`abs(limitk(2, latency_exp_hist) by (job))`,
+	}
+
+	for _, query := range queries {
+		query := query
+		t.Run(query, func(t *testing.T) {
+			t.Parallel()
+
+			expr := parseExprExp(t, query)
+			plan, err := promql.LowerAt(context.Background(), expr, s, at, at)
+			if err != nil {
+				t.Fatalf("LowerAt(%q): unexpected error (this exact shape hard-rejected or panicking before cerberus issue #2575's fix): %v", query, err)
+			}
+			if shape := chplan.RowShapeOf(plan); shape != chplan.SampleRowShape {
+				t.Fatalf("LowerAt(%q) row shape = %s, want sample (canonical float, dropped) — a float-only wrapper must drop the histogram, not forward it", query, shape)
+			}
+			// The plan must actually be empty (a constant-false Filter
+			// reachable somewhere in the tree), matching reference's
+			// float-only-function drop semantics — not merely
+			// float-shaped by accident.
+			foundEmptyFilter := false
+			chplan.Walk(plan, func(n chplan.Node) bool {
+				if f, ok := n.(*chplan.Filter); ok {
+					if lit, ok := f.Predicate.(*chplan.LitBool); ok && !lit.V {
+						foundEmptyFilter = true
+					}
+				}
+				return true
+			})
+			if !foundEmptyFilter {
+				t.Fatalf("LowerAt(%q) plan has no constant-false Filter; want a dropped (empty) result:\n%#v", query, plan)
+			}
+		})
+	}
+}
+
+// TestLower_ExpHistogram_LimitKUnderLabelReplaceStillPreserves pins that
+// `label_replace`/`label_join` wrapping `limitk`/`limit_ratio` over an
+// exp-histogram operand — one of the issue's own named reproducers, via
+// `projectAttributesOverInner` — is a PRESERVE-family wrapper, not a
+// float-only DROP-family one: reference's evalLabelReplace/evalLabelJoin
+// rewrite only the series labels and carry the histogram sample through
+// unchanged (see [labelCallOverExpHistogram]'s own doc). So unlike
+// abs()/ceil()/…, the fix does not reproject to an empty float vector —
+// it routes through [lowerLabelCallOverExpHistogram] the exact way it
+// already does for a bare histogram selector, keeping the row
+// histogram-shaped with rewritten Attributes.
+func TestLower_ExpHistogram_LimitKUnderLabelReplaceStillPreserves(t *testing.T) {
+	t.Parallel()
+
+	s := schema.DefaultOTelMetrics()
+	at := time.Date(2026, 1, 1, 0, 0, 1, 0, time.UTC)
+
+	for _, query := range []string{
+		`label_replace(limitk(2, latency_exp_hist), "dst", "$1", "job", "(.*)")`,
+		`label_replace(limit_ratio(0.5, latency_exp_hist), "dst", "$1", "job", "(.*)")`,
+	} {
+		query := query
+		t.Run(query, func(t *testing.T) {
+			t.Parallel()
+
+			expr := parseExprExp(t, query)
+			plan, err := promql.LowerAt(context.Background(), expr, s, at, at)
+			if err != nil {
+				t.Fatalf("LowerAt(%q): unexpected error (this exact shape panicked via projectAttributesOverInner before cerberus issue #2575's fix): %v", query, err)
+			}
+			if shape := chplan.RowShapeOf(plan); shape != chplan.HistogramRowShape {
+				t.Fatalf("LowerAt(%q) plan publishes %s, want histogram — label_replace/label_join must PRESERVE the payload, not drop it", query, shape)
+			}
+		})
+	}
+}
+
+// TestLower_ExpHistogram_LimitKUnderTimestampStillAnswers pins that
+// `timestamp(limitk(...))` — another of the issue's own named
+// reproducers — is neither a drop-family wrapper NOR a preserve-family
+// one: reference's funcTimestamp reads only the selected sample's
+// Point.T, answering identically whether the sample is float- or
+// histogram-valued (see histogram_native_timestamp.go's own doc). So the
+// fix must not reproject this to an EMPTY result the way abs()/ceil()/…
+// do — [lowerTimestampOverExpHistogram] already handles any
+// histogram-valued shape via [projectExpHistogramEvalInstant], and with
+// this issue's fix that dispatch now reaches `limitk`/`limit_ratio` too,
+// answering a genuine (non-empty) float timestamp value per surviving
+// row rather than panicking or dropping every row.
+func TestLower_ExpHistogram_LimitKUnderTimestampStillAnswers(t *testing.T) {
+	t.Parallel()
+
+	s := schema.DefaultOTelMetrics()
+	at := time.Date(2026, 1, 1, 0, 0, 1, 0, time.UTC)
+
+	for _, query := range []string{
+		`timestamp(limitk(2, latency_exp_hist))`,
+		`timestamp(limit_ratio(0.5, latency_exp_hist))`,
+	} {
+		query := query
+		t.Run(query, func(t *testing.T) {
+			t.Parallel()
+
+			expr := parseExprExp(t, query)
+			plan, err := promql.LowerAt(context.Background(), expr, s, at, at)
+			if err != nil {
+				t.Fatalf("LowerAt(%q): unexpected error (this exact shape panicked via projectValueOverInner before cerberus issue #2575's fix): %v", query, err)
+			}
+			if shape := chplan.RowShapeOf(plan); shape != chplan.SampleRowShape {
+				t.Fatalf("LowerAt(%q) row shape = %s, want sample (timestamp() always answers a plain float value)", query, shape)
+			}
+			// Must NOT be a constant-false-filtered (dropped) result:
+			// timestamp() answers a real value for every surviving row,
+			// unlike the float-only DROP family above.
+			foundEmptyFilter := false
+			chplan.Walk(plan, func(n chplan.Node) bool {
+				if f, ok := n.(*chplan.Filter); ok {
+					if lit, ok := f.Predicate.(*chplan.LitBool); ok && !lit.V {
+						foundEmptyFilter = true
+					}
+				}
+				return true
+			})
+			if foundEmptyFilter {
+				t.Fatalf("LowerAt(%q) plan has a constant-false Filter; timestamp() must answer real rows, not drop them", query)
+			}
+		})
+	}
+}
+
+// TestLower_ExpHistogram_LimitKUnwrappedStillPreserves is a regression
+// guard sitting alongside the wrapped-composition fix above: the
+// UNWRAPPED case cerberus issue #2518 shipped —
+// `limitk(K, <exp-hist selector>)` evaluated on its own, with no further
+// wrapper — must keep answering histogram-shaped, not regress to the
+// wrapped-and-dropped behaviour the new recognizer adds for wrappers.
+// TestLower_ExpHistogram_LimitKAndLimitRatioPreserveSamples
+// (limitk_exp_histogram_test.go) already pins this at length; this is a
+// narrow sanity check living next to the new wrapped-composition test so
+// the two behaviours are visibly contrasted in one file.
+func TestLower_ExpHistogram_LimitKUnwrappedStillPreserves(t *testing.T) {
+	t.Parallel()
+
+	s := schema.DefaultOTelMetrics()
+	at := time.Date(2026, 1, 1, 0, 0, 1, 0, time.UTC)
+
+	for _, query := range []string{
+		`limitk(2, latency_exp_hist)`,
+		`limit_ratio(0.5, latency_exp_hist)`,
+	} {
+		query := query
+		t.Run(query, func(t *testing.T) {
+			t.Parallel()
+
+			expr := parseExprExp(t, query)
+			plan, err := promql.LowerAt(context.Background(), expr, s, at, at)
+			if err != nil {
+				t.Fatalf("LowerAt(%q): %v", query, err)
+			}
+			if shape := chplan.RowShapeOf(plan); shape != chplan.HistogramRowShape {
+				t.Fatalf("LowerAt(%q) plan publishes %s, want histogram — unwrapped limitk/limit_ratio must keep preserving the sample (cerberus issue #2518 must not regress)", query, shape)
+			}
+		})
+	}
+}

--- a/internal/promql/lower.go
+++ b/internal/promql/lower.go
@@ -4361,6 +4361,50 @@ func lowerLimitKInput(expr parser.Expr, s schema.Metrics, ctx lowerCtx) (chplan.
 	return input, false, nil
 }
 
+// limitKOrRatioOverExpHistogram recognises `limitk(K, <exp-hist shape>)` /
+// `limit_ratio(R, <exp-hist shape>)` as a shape whose OWN result is
+// histogram-valued — the gap cerberus issue #2575 reports as a panic.
+//
+// [lowerLimitKInput] (cerberus issue #2518) already preserves a
+// histogram-valued operand when limitk/limit_ratio is lowered — reachable
+// either as the query root (via [lowerHistogramNativeRoot]'s op-specific
+// dispatch) or nested under another wrapper's generic `lower(a.Expr, ...)`
+// fallback inside [lowerAggregate]. What it does NOT do is tell the
+// PREDICATE side — [isExpHistogramValuedShape] — that `limitk(K, m)` is
+// itself one of the shapes a FURTHER wrapper (`abs(limitk(2, m))`,
+// `limitk(2, m) + 0`, `label_replace(limitk(2, m), ...)`) needs to route
+// through the shared recognizer set instead of the generic dispatcher.
+// Without this recognizer, a float-only wrapper's own opt-in
+// ([lowerExpHistogramArgAsCanonicalFloat]) sees `isExpHistogramValuedShape`
+// answer false for a `limitk`/`limit_ratio` operand, falls through to the
+// plain `lower()` path, and receives the SAME histogram-shaped plan
+// [lowerLimitKInput] always produced — just without ever being told to
+// expect it, tripping [assertValueShapedInput]'s panic in
+// histogram_shape_guard.go instead of dropping the sample the way
+// reference's float-only functions do for every other histogram-valued
+// operand.
+//
+// The recursive [isExpHistogramValuedShape] check on agg.Expr is what
+// keeps this narrow to the PRESERVE case: when agg.Expr is instead one of
+// the drop family's shapes (`limitk(2, demo_latency_exp_hist + 0)`),
+// [lowerLimitKInput] already answers histogram=false — an ordinary
+// canonical float-Value plan needing no special routing here — so this
+// recognizer correctly reports false and leaves that shape to the
+// generic dispatcher, unchanged.
+func limitKOrRatioOverExpHistogram(expr parser.Expr, s schema.Metrics, ctx lowerCtx) (*parser.AggregateExpr, bool) {
+	if s.ExpHistogramTable == "" || ctx.metadataFullRange {
+		return nil, false
+	}
+	agg, ok := unwrapAggregateExpr(expr)
+	if !ok || (agg.Op != parser.LIMITK && agg.Op != parser.LIMIT_RATIO) {
+		return nil, false
+	}
+	if !isExpHistogramValuedShape(agg.Expr, s, ctx) {
+		return nil, false
+	}
+	return agg, true
+}
+
 // limitRatioPredicate builds the row predicate implementing
 // HashRatioSampler's keep rule for ratio expression `param`, given a
 // factory that mints a fresh per-series offset expression.


### PR DESCRIPTION
## Summary

- `limitk(K, <exp-hist selector>)` / `limit_ratio(R, <exp-hist selector>)`, wrapped by a further
  float-only function or arithmetic operator (`abs()`, `+ 0`, `label_replace()`, ...), panicked with
  `promql: projectValueOverInner received a histogram-shaped input: ...` instead of computing
  correctly or cleanly rejecting — a 500-class defect, not the usual 422-rejection class this
  exp-histogram bug family has been fixing.
- Root cause: `lowerLimitKInput` (#2518) already recognises and **preserves** a histogram-valued
  operand to `limitk`/`limit_ratio`, but neither `isExpHistogramValuedShape` nor its lowering
  counterpart (`histogram_native_scalar_binop.go` / `histogram_native_float_fn.go`) had a
  `limitk`/`limit_ratio` entry, so a wrapper's own opt-in (`lowerExpHistogramArgAsCanonicalFloat`)
  never recognised the operand and fell through to the generic `lower()` dispatcher — which produced
  the *same* histogram-shaped plan anyway, just without the wrapper's own postprocessing ever
  expecting it.
- Fix: add `limitKOrRatioOverExpHistogram` (`internal/promql/lower.go`) and wire it into both
  `isExpHistogramValuedShape` (histogram_native_scalar_binop.go) and `lowerExpHistogramValuedShape`
  (histogram_native_float_fn.go), delegating to the existing `lowerLimitK`/`lowerLimitRatio` so the
  unwrapped case (#2518) lowers byte-for-byte unchanged. Every consumer already built on that shared
  recognizer set — float-only wrappers (drop), `label_replace`/`label_join` (preserve),
  `timestamp()` (real derived value), `sum()`/`avg()`, and `topk`/`bottomk`'s own drop family via
  `droppingAggregationOverExpHistogram` — now composes correctly with zero further per-callsite
  changes.

## Verification

- Real chDB: `TestLower_ExpHistogram_LimitKWrappedByFloatOnlyFn_ChDB` /
  `TestLower_ExpHistogram_LimitKUnwrapped_ChDB` (`internal/promql/limitk_wrapped_exp_histogram_chdb_test.go`,
  `//go:build chdb`) seed 3 real exp-histogram series and execute the emitted SQL against ClickHouse.
  Confirmed by temporarily reverting the fix that the wrapped case reproduces the *exact* panic from
  the issue; with the fix, it answers `count()=0` for every float-only wrapper and `count()=2`
  (exactly K of 3 series preserved) for the unwrapped case.
- Go-plan-shape pins: `internal/promql/limitk_wrapped_exp_histogram_test.go` covers the drop-family
  wrappers, `label_replace`/`label_join` (preserve), `timestamp()` (real value, not dropped), and a
  regression guard that the unwrapped case still publishes `HistogramRowShape`.
- Probed broadly post-fix (`min`/`max`/`stddev`/`stdvar`/`quantile`/`bottomk` wrapping `limitk`,
  `sum_over_time` subquery wrapping `limitk`, `abs(limitk(...) or limitk(...))`,
  `histogram_quantile(0.5, limitk(...))`) — every composition lowers without error to the correct
  shape. No further gap found.
- `go build ./...`, `go vet ./...` (default and `-tags chdb`), `gofumpt -extra` / `goimports -local`
  (no changes needed), `go test -race ./internal/promql/...`, `node .github/scripts/forbid-sql-raw.mjs`
  (clean; no chsql touched) all pass.
- Rejection-parity catalogue: `CERBERUS_UPDATE_INVENTORY=1 go test -run TestCatalogueIsRegenerable
  ./test/rejection-parity/...` produces no diff — the existing `lower.go__lower.json` rationale
  ("lowerLimitKInput ... narrows rather than widens") still holds, since this fix makes MORE shapes
  resolve through the histogram-aware dispatch, not fewer. `TestRejectionTriggersExerciseSites` /
  `TestInternalRationalesRestOnCurrentEvidence` / `TestPromQLRejectionTriggersUseSeededMetrics` all
  pass.

Closes #2575
