### PR TITLE
fix(promql): compose SELECT/FOLD-family fns over a label_replace-wrapped mixed-or subquery inner

### DIFF
--- a/internal/promql/histogram_native_mixed_or_subquery_range_fn.go
+++ b/internal/promql/histogram_native_mixed_or_subquery_range_fn.go
@@ -69,32 +69,93 @@ import (
 //     [mixedExpHistogramSetOp] itself builds for a bare `(a) or (b))`, one
 //     level up.
 //
-// Deliberately narrower than #2569's own pure-histogram-inner sibling in
-// one respect: this recognizer only admits sub.Expr shaped exactly as
-// [mixedExpHistogramSetOp] itself matches — a BARE `X or Y` with exactly
-// one side histogram-valued (or forwarded through and/unless, cerberus
-// issue #2571). A subquery inner that is some OTHER mixed-or composition
-// (wrapped in sum()/avg(), label_replace/label_join, or nested under a
-// further and/or/unless — histogram_native_mixed_or_aggregate.go /
-// _label.go / [mixedExpHistogramSetOp]'s own doc) stays unrecognised here
-// and continues to reject through [lowerOuterRangeFnOverSubquery]'s
-// existing guard, exactly as it did before this file existed.
-func mixedOrSubqueryOuterFn(c *parser.Call, s schema.Metrics, ctx lowerCtx) (*parser.SubqueryExpr, *parser.BinaryExpr, bool) {
+// Widened by cerberus issue #2581 to also admit sub.Expr shaped as
+// label_replace/label_join DIRECTLY wrapping [mixedExpHistogramSetOp]'s own
+// bare shape — `<fn>((label_replace((a) or (b), ...))[range:step])` — via
+// [wrapMixedOrSubqueryInner]'s rebuild closure, below. Still narrower than
+// #2569's own pure-histogram-inner sibling in one respect: a subquery inner
+// wrapped in sum()/avg() or nested under a further and/or/unless
+// (histogram_native_mixed_or_aggregate.go / [mixedExpHistogramSetOp]'s own
+// doc) stays unrecognised here and continues to reject through
+// [lowerOuterRangeFnOverSubquery]'s existing guard — deliberately, not an
+// oversight: see [wrapMixedOrSubqueryInner]'s own doc for why a sum/avg
+// wrapper cannot be admitted through this same distribute-then-recombine
+// mechanism without silently disagreeing with reference on a colliding
+// group. Tracked as an open divergence under #2581 in
+// test/rejection-parity/catalogue.
+func mixedOrSubqueryOuterFn(c *parser.Call, s schema.Metrics, ctx lowerCtx) (*parser.SubqueryExpr, *parser.BinaryExpr, func(parser.Expr) parser.Expr, bool) {
 	if s.ExpHistogramTable == "" || ctx.metadataFullRange {
-		return nil, nil, false
+		return nil, nil, nil, false
 	}
 	if len(c.Args) != 1 || !isHistogramSubqueryOuterFnName(c.Func.Name) {
-		return nil, nil, false
+		return nil, nil, nil, false
 	}
 	sub, ok := peelWrappers(c.Args[0]).(*parser.SubqueryExpr)
 	if !ok || sub.Range <= 0 || !subqueryHasEvalAnchor(sub, ctx) {
-		return nil, nil, false
+		return nil, nil, nil, false
 	}
-	b, ok := mixedExpHistogramSetOp(sub.Expr, s, ctx)
+	b, rebuild, ok := wrapMixedOrSubqueryInner(sub.Expr, s, ctx)
 	if !ok {
-		return nil, nil, false
+		return nil, nil, nil, false
 	}
-	return sub, b, true
+	return sub, b, rebuild, true
+}
+
+// wrapMixedOrSubqueryInner recognises inner — a subquery's own Expr — as
+// EITHER a bare mixed float/histogram `or` ([mixedExpHistogramSetOp]'s own
+// shape) OR that same shape wrapped in a DIRECT label_replace/label_join
+// call ([labelCallOverMixedExpHistogramSetOp]'s shape, cerberus issue
+// #2449) — the first of the three wrapper families
+// histogram_native_mixed_or.go's own doc comment names that cerberus issue
+// #2581 threads through this file's subquery composition. rebuild takes one
+// of b's two operands and re-applies whatever wrapper matched (identity for
+// the bare case, the SAME label_replace/label_join call with its first
+// argument replaced for the wrapped case) — [lowerMixedOrSubqueryOuterFn]
+// calls it once per synthetic arm so each arm keeps the wrapper the
+// original expression had.
+//
+// label_replace/label_join is a sound choice for this distribute-then-
+// recombine mechanism because it is a per-ROW rewrite that never reads or
+// combines across rows: `<fn>((label_replace((a) or (b), args))[5m:1m])`
+// distributes to `<fn>((label_replace(a, args))[5m:1m]) or
+// <fn>((label_replace(b, args))[5m:1m])` for the identical reason the bare
+// (unwrapped) case already does — inserting a stateless label rewrite
+// inside each per-anchor evaluation commutes with both the subquery's own
+// per-anchor re-evaluation and the outer window fold. `sum`/`avg`
+// [by/without] (histogram_native_mixed_or_aggregate.go, cerberus issue
+// #2346) is deliberately NOT admitted here despite being the OTHER
+// wrapper family with an existing root-only recognizer: distributing a
+// GROUPING aggregate per arm and recombining with `mixedExpHistogramSetOp`'s
+// ordinary shadow-priority `or` (LHS wins on a shared group) does not
+// reproduce reference's own `sum`/`avg` semantics — a group that receives
+// contributions from BOTH the histogram arm and the float arm at the SAME
+// subquery anchor must be DROPPED entirely (a
+// `MixedFloatsHistogramsAggWarning`, [combineMixedAggregateBranches]'s own
+// doc), not resolved by picking one side, and a `series`-only (or any
+// non-injective) `by`/`without` clause can absolutely put histogram- and
+// float-typed rows from the two DIFFERENT source metrics into the same
+// group despite the two metrics never sharing a full label signature. A
+// correct composition needs the outer window fold to run directly over the
+// already-per-anchor-correct Mixed relation [lowerHistogramNativeSubqueryInner]
+// already builds via [lowerSumOrAvgOverMixedExpHistogramSetOp], not a
+// second, independent per-arm aggregation — real new machinery, not a cheap
+// extension of this file's existing mechanism, so it stays an open
+// divergence under cerberus issue #2581 rather than a silently-wrong
+// recognizer.
+func wrapMixedOrSubqueryInner(inner parser.Expr, s schema.Metrics, ctx lowerCtx) (*parser.BinaryExpr, func(parser.Expr) parser.Expr, bool) {
+	if b, ok := mixedExpHistogramSetOp(inner, s, ctx); ok {
+		return b, func(operand parser.Expr) parser.Expr { return operand }, true
+	}
+	if call, b, ok := labelCallOverMixedExpHistogramSetOp(inner, s, ctx); ok {
+		return b, func(operand parser.Expr) parser.Expr {
+			rebuilt := *call
+			args := append(parser.Expressions(nil), call.Args...)
+			args[0] = operand
+			rebuilt.Args = args
+			return &rebuilt
+		}, true
+	}
+	return nil, nil, false
 }
 
 // isHistogramSubqueryOuterFnName reports whether name is one of the
@@ -119,22 +180,24 @@ func isHistogramSubqueryOuterFnName(name string) bool {
 
 // lowerMixedOrSubqueryOuterFn lowers the shape [mixedOrSubqueryOuterFn]
 // recognised: c applied to a subquery whose own inner is b, a mixed
-// float/histogram `or`. It rewrites the expression into
-// `<fn>(<subquery over b.LHS>) or <fn>(<subquery over b.RHS>)` — a
-// synthetic AST, never seen by the parser — and hands it to the SAME
-// recombination logic [mixedExpHistogramSetOp] /
-// [lowerMixedExpHistogramSetOp] use for a bare mixed `or`, deriving
-// "which side is histogram" the identical way: from the ACTUAL
-// [chplan.RowShapeOf] of each arm's own lowering, not a second static
-// judgement that could disagree with the first. b.LHS / b.RHS keep their
-// SOURCE order (not reordered by which side is histogram) so a genuine
-// same-series overlap between the two arms resolves through the shadow
-// rule exactly as the un-rewritten expression would.
-func lowerMixedOrSubqueryOuterFn(c *parser.Call, sub *parser.SubqueryExpr, b *parser.BinaryExpr, s schema.Metrics, ctx lowerCtx) (chplan.Node, error) {
+// float/histogram `or`, optionally wrapped by rebuild (identity for the
+// bare case; re-applies label_replace/label_join for the wrapped case,
+// cerberus issue #2581 — see [wrapMixedOrSubqueryInner]'s own doc). It
+// rewrites the expression into `<fn>(<subquery over
+// rebuild(b.LHS)>) or <fn>(<subquery over rebuild(b.RHS)>)` — a synthetic
+// AST, never seen by the parser — and hands it to the SAME recombination
+// logic [mixedExpHistogramSetOp] / [lowerMixedExpHistogramSetOp] use for a
+// bare mixed `or`, deriving "which side is histogram" the identical way:
+// from the ACTUAL [chplan.RowShapeOf] of each arm's own lowering, not a
+// second static judgement that could disagree with the first. b.LHS / b.RHS
+// keep their SOURCE order (not reordered by which side is histogram) so a
+// genuine same-series overlap between the two arms resolves through the
+// shadow rule exactly as the un-rewritten expression would.
+func lowerMixedOrSubqueryOuterFn(c *parser.Call, sub *parser.SubqueryExpr, b *parser.BinaryExpr, rebuild func(parser.Expr) parser.Expr, s schema.Metrics, ctx lowerCtx) (chplan.Node, error) {
 	synthetic := &parser.BinaryExpr{
 		Op:             parser.LOR,
-		LHS:            &parser.Call{Func: c.Func, Args: parser.Expressions{subqueryWithExpr(sub, b.LHS)}},
-		RHS:            &parser.Call{Func: c.Func, Args: parser.Expressions{subqueryWithExpr(sub, b.RHS)}},
+		LHS:            &parser.Call{Func: c.Func, Args: parser.Expressions{subqueryWithExpr(sub, rebuild(b.LHS))}},
+		RHS:            &parser.Call{Func: c.Func, Args: parser.Expressions{subqueryWithExpr(sub, rebuild(b.RHS))}},
 		VectorMatching: b.VectorMatching,
 	}
 	if mb, ok := mixedExpHistogramSetOp(synthetic, s, ctx); ok {

--- a/internal/promql/histogram_native_mixed_or_subquery_wrapped_inner_chdb_test.go
+++ b/internal/promql/histogram_native_mixed_or_subquery_wrapped_inner_chdb_test.go
@@ -1,0 +1,120 @@
+//go:build chdb
+
+// chDB-backed proof that cerberus issue #2581's fix actually executes
+// correctly against real ClickHouse: `<fn>((label_replace((h) or (f),
+// ...))[range:step])` for a SELECT-family member (count_over_time) and a
+// FOLD-family member (sum_over_time) — the label_replace-wrapped-inner
+// sibling of #2577's own bare-inner proof
+// (histogram_native_mixed_or_subquery_range_fn_chdb_test.go), reusing that
+// file's own seed/fixture/helpers so the assertions can be checked against
+// the identical baseline numbers.
+package promql_test
+
+import (
+	"testing"
+
+	"github.com/tsouza/cerberus/internal/schema"
+)
+
+// wrappedMorQuery builds `<outer>(<fn>((label_replace((h) or (f), "extra",
+// "yes", "", ""))[2m:1m]))` — morQuery's own label_replace-wrapped-inner
+// sibling (histogram_native_mixed_or_subquery_range_fn_chdb_test.go). The
+// label_replace call adds a constant "extra" label without touching
+// "series", so every assertion below reads back against the SAME per-series
+// values morQuery's own tests pin.
+func wrappedMorQuery(outerFmt, fn string) string {
+	subExpr := `(label_replace((` + morExpHistMetric + `) or (` + morGaugeMetric + `), "extra", "yes", "", ""))`
+	inner := fn + "(" + subExpr + "[2m:1m])"
+	if outerFmt == "" {
+		return inner
+	}
+	return outerFmt + "(" + inner + ")"
+}
+
+// TestMixedOrSubqueryCountOverTimeWrappedInner_ChDB proves count_over_time
+// (a SELECT-family, always-float-output member) composes over a subquery
+// whose own inner is a mixed float/histogram `or` DIRECTLY wrapped in
+// label_replace — cerberus issue #2581's own evidence shape. Both arms'
+// windows hold exactly two in-window samples, matching
+// TestMixedOrSubqueryCountOverTimeNestedUnderSum_ChDB's own bare-inner
+// baseline.
+func TestMixedOrSubqueryCountOverTimeWrappedInner_ChDB(t *testing.T) {
+	fixture := newChDBFixture(t, morSeed)
+	s := schema.DefaultOTelMetrics()
+
+	query := wrappedMorQuery("", "count_over_time")
+	sqlStr, args := lowerAndEmit(t, query, s, morEvalTS)
+	got := sampleValueRows(t, fixture, sqlStr, args)
+	if got["h"] != 2 {
+		t.Errorf("count_over_time over label_replace-wrapped mixed-or subquery: series h = %v, want 2", got["h"])
+	}
+	if got["f"] != 2 {
+		t.Errorf("count_over_time over label_replace-wrapped mixed-or subquery: series f = %v, want 2", got["f"])
+	}
+}
+
+// TestMixedOrSubquerySumOverTimeWrappedInner_ChDB proves sum_over_time — a
+// FOLD-family, histogram-preserving member whose output is a genuinely
+// [chplan.MixedRowShape] node — composes correctly over the same
+// label_replace-wrapped inner, reading back BOTH arms: the histogram-arm
+// series ("h") folds its two published histograms exactly as
+// TestMixedOrSubquerySumOverTimeNestedUnderLabelReplace_ChDB's own
+// bare-inner baseline does (Count=5, Sum=13, Bucket1=18); the float-arm
+// series ("f") sums its two plain gauge samples (10+20=30).
+func TestMixedOrSubquerySumOverTimeWrappedInner_ChDB(t *testing.T) {
+	fixture := newChDBFixture(t, morSeed)
+	s := schema.DefaultOTelMetrics()
+
+	query := wrappedMorQuery("", "sum_over_time")
+	sqlStr, args := lowerAndEmit(t, query, s, morEvalTS)
+
+	histRows := subqHistQueryRows(t, fixture, sqlStr, args)
+	var gotHist bool
+	for _, r := range histRows {
+		if r.series == "h" {
+			gotHist = true
+			if r.cnt != 5 || r.sum != 13.0 || r.bucket1 != 18 {
+				t.Errorf("sum_over_time over label_replace-wrapped mixed-or subquery, histogram arm = %+v, want Count=5 Sum=13 Bucket1=18", r)
+			}
+		}
+	}
+	if !gotHist {
+		t.Fatalf("sum_over_time over label_replace-wrapped mixed-or subquery: no histogram-arm row for series h; got %+v", histRows)
+	}
+
+	got := sampleValueRows(t, fixture, sqlStr, args)
+	if got["f"] != 30 {
+		t.Errorf("sum_over_time over label_replace-wrapped mixed-or subquery, float arm: series f = %v, want 30 (10+20)", got["f"])
+	}
+}
+
+// TestMixedOrSubqueryRateWrappedInner_ChDB proves rate — the FOLD family's
+// boundary-extrapolated member — composes over the label_replace-wrapped
+// inner at the query root (unwrapped), mirroring
+// TestMixedOrSubqueryRate_ChDB's own bare-inner assertions.
+func TestMixedOrSubqueryRateWrappedInner_ChDB(t *testing.T) {
+	fixture := newChDBFixture(t, morSeed)
+	s := schema.DefaultOTelMetrics()
+
+	query := wrappedMorQuery("", "rate")
+	sqlStr, args := lowerAndEmit(t, query, s, morEvalTS)
+
+	histRows := subqHistQueryRows(t, fixture, sqlStr, args)
+	var gotHist bool
+	for _, r := range histRows {
+		if r.series == "h" {
+			gotHist = true
+			if r.cnt <= 0 {
+				t.Errorf("rate over label_replace-wrapped mixed-or subquery, histogram arm = %+v, want a positive Count", r)
+			}
+		}
+	}
+	if !gotHist {
+		t.Fatalf("rate over label_replace-wrapped mixed-or subquery: no histogram-arm row for series h; got %+v", histRows)
+	}
+
+	got := sampleValueRows(t, fixture, sqlStr, args)
+	if got["f"] <= 0 {
+		t.Errorf("rate over label_replace-wrapped mixed-or subquery, float arm: series f = %v, want a positive rate", got["f"])
+	}
+}

--- a/internal/promql/histogram_native_mixed_or_subquery_wrapped_inner_test.go
+++ b/internal/promql/histogram_native_mixed_or_subquery_wrapped_inner_test.go
@@ -1,0 +1,130 @@
+package promql_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/tsouza/cerberus/internal/chplan"
+	"github.com/tsouza/cerberus/internal/promql"
+	"github.com/tsouza/cerberus/internal/schema"
+)
+
+// TestLower_ExpHistogram_MixedOrSubqueryOuterFn_WrappedInner pins cerberus
+// issue #2581, the narrower sibling of #2577
+// (TestLower_ExpHistogram_MixedOrSubqueryOuterFn, this package): every one
+// of the fifteen SELECT/FOLD-family names also lowers — without error, and
+// to the correct [chplan.RowShapeOf] — when the subquery's own inner is a
+// mixed float/histogram `or` DIRECTLY wrapped in label_replace, rather than
+// a bare `X or Y` node ([wrapMixedOrSubqueryInner],
+// histogram_native_mixed_or_subquery_range_fn.go).
+//
+// Same wantMixed split as #2577's own test: the six always-float-output
+// names publish a plain [chplan.SampleRowShape] (both synthetic arms agree
+// in shape); the remaining nine publish [chplan.MixedRowShape].
+func TestLower_ExpHistogram_MixedOrSubqueryOuterFn_WrappedInner(t *testing.T) {
+	t.Parallel()
+
+	s := schema.DefaultOTelMetrics()
+	start := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	end := start.Add(time.Hour)
+	pinnedAt := "1767225600" // 2026-01-01T00:00:00Z, matches `start`
+
+	for _, tc := range []struct {
+		fn        string
+		wantMixed bool // histogram-preserving names publish a Mixed union
+	}{
+		{fn: "count_over_time"},
+		{fn: "present_over_time"},
+		{fn: "last_over_time", wantMixed: true},
+		{fn: "first_over_time", wantMixed: true},
+		{fn: "resets"},
+		{fn: "changes"},
+		{fn: "ts_of_first_over_time"},
+		{fn: "ts_of_last_over_time"},
+		{fn: "rate", wantMixed: true},
+		{fn: "increase", wantMixed: true},
+		{fn: "delta", wantMixed: true},
+		{fn: "irate", wantMixed: true},
+		{fn: "idelta", wantMixed: true},
+		{fn: "sum_over_time", wantMixed: true},
+		{fn: "avg_over_time", wantMixed: true},
+	} {
+		t.Run(tc.fn, func(t *testing.T) {
+			t.Parallel()
+			wantShape := chplan.SampleRowShape
+			if tc.wantMixed {
+				wantShape = chplan.MixedRowShape
+			}
+
+			instant := fmt.Sprintf(
+				`%s((label_replace((latency_exp_hist) or (num_cpus), "extra", "yes", "", ""))[5m:1m])`,
+				tc.fn,
+			)
+			expr := parseExprExp(t, instant)
+			plan, err := promql.LowerAt(context.Background(), expr, s, end, end)
+			if err != nil {
+				t.Fatalf("lower(%q) instant: %v", instant, err)
+			}
+			if got := chplan.RowShapeOf(plan); got != wantShape {
+				t.Errorf("lower(%q) instant RowShape = %s, want %s", instant, got, wantShape)
+			}
+
+			rplan, err := promql.LowerAtRange(context.Background(), expr, s, start, end, time.Minute)
+			if err != nil {
+				t.Fatalf("lower(%q) range: %v", instant, err)
+			}
+			if got := chplan.RowShapeOf(rplan); got != wantShape {
+				t.Errorf("lower(%q) range RowShape = %s, want %s", instant, got, wantShape)
+			}
+
+			pinned := fmt.Sprintf(
+				`%s((label_replace((latency_exp_hist) or (num_cpus), "extra", "yes", "", ""))[5m:1m] @ %s)`,
+				tc.fn, pinnedAt,
+			)
+			pexpr := parseExprExp(t, pinned)
+			pplan, err := promql.LowerAtRange(context.Background(), pexpr, s, start, end, time.Minute)
+			if err != nil {
+				t.Fatalf("lower(%q) pinned: %v", pinned, err)
+			}
+			if got := chplan.RowShapeOf(pplan); got != wantShape {
+				t.Errorf("lower(%q) pinned RowShape = %s, want %s", pinned, got, wantShape)
+			}
+
+			// Nested under a further wrapper on the OUTER side too (sum by),
+			// the same double-composition #2577's own test pins for its own
+			// bare-inner shape: the wrapped-inner recognizer must also work
+			// through the generic lower() path when the whole `<fn>(subquery)`
+			// call itself is nested, not only at the query root.
+			wrapped := fmt.Sprintf(`sum by (series) (%s)`, instant)
+			wexpr := parseExprExp(t, wrapped)
+			if _, err := promql.LowerAt(context.Background(), wexpr, s, end, end); err != nil {
+				t.Fatalf("lower(%q) sum-wrapped: %v", wrapped, err)
+			}
+		})
+	}
+}
+
+// TestLower_ExpHistogram_MixedOrSubqueryOuterFn_LabelJoinWrappedInner pins
+// the label_join half of the same wrapper family alongside label_replace's
+// own dedicated test above — [labelCallOverMixedExpHistogramSetOp] (and by
+// extension [wrapMixedOrSubqueryInner]) recognises both names identically,
+// this only checks label_join's own distinct arg-count/shape parsing didn't
+// regress.
+func TestLower_ExpHistogram_MixedOrSubqueryOuterFn_LabelJoinWrappedInner(t *testing.T) {
+	t.Parallel()
+
+	s := schema.DefaultOTelMetrics()
+	end := time.Date(2026, 1, 1, 1, 0, 0, 0, time.UTC)
+
+	instant := `count_over_time((label_join((latency_exp_hist) or (num_cpus), "extra", ",", "job"))[5m:1m])`
+	expr := parseExprExp(t, instant)
+	plan, err := promql.LowerAt(context.Background(), expr, s, end, end)
+	if err != nil {
+		t.Fatalf("lower(%q): %v", instant, err)
+	}
+	if got := chplan.RowShapeOf(plan); got != chplan.SampleRowShape {
+		t.Errorf("lower(%q) RowShape = %s, want %s", instant, got, chplan.SampleRowShape)
+	}
+}

--- a/internal/promql/lower.go
+++ b/internal/promql/lower.go
@@ -2749,9 +2749,11 @@ func lowerCallOverSubquery(c *parser.Call, sq *parser.SubqueryExpr, s schema.Met
 	// rather than a pure histogram-native shape — see
 	// histogram_native_mixed_or_subquery_range_fn.go's own doc for why
 	// this is a genuinely different recognizer/lowering rather than a
-	// widening of the two calls just above.
-	if sub, b, ok := mixedOrSubqueryOuterFn(c, s, ctx); ok {
-		return lowerMixedOrSubqueryOuterFn(c, sub, b, s, ctx)
+	// widening of the two calls just above. Since cerberus issue #2581,
+	// also matches when that mixed `or` is itself directly wrapped in
+	// label_replace/label_join.
+	if sub, b, rebuild, ok := mixedOrSubqueryOuterFn(c, s, ctx); ok {
+		return lowerMixedOrSubqueryOuterFn(c, sub, b, rebuild, s, ctx)
 	}
 	// `<range-vector-fn>(<subquery>)` — the canonical Grafana shape
 	// `max_over_time(rate(m[5m])[1h:5m])`. Lowers to a chained RangeWindow:


### PR DESCRIPTION
## Summary

- Extends cerberus issue #2577's own `mixedOrSubqueryOuterFn` recognizer (`internal/promql/histogram_native_mixed_or_subquery_range_fn.go`) so the SELECT/FOLD-family composition (`count_over_time`, `present_over_time`, `last_over_time`, `first_over_time`, `resets`, `changes`, `ts_of_first_over_time`, `ts_of_last_over_time`, `rate`, `increase`, `delta`, `irate`, `idelta`, `sum_over_time`, `avg_over_time`) also works when a subquery's own inner is a mixed float/histogram `or` **directly wrapped in `label_replace`/`label_join`** — `<fn>((label_replace((a) or (b), ...))[range:step])` — not only a bare `(a) or (b)` node.
- New `wrapMixedOrSubqueryInner` helper recognizes either shape and returns a `rebuild` closure that re-applies the matched wrapper (identity for the bare case) to each of the mixed `or`'s two operands before the existing distribute-then-recombine mechanism runs. No new lowering machinery: both synthetic per-arm subqueries route through entirely pre-existing composition (#2545/#2569's histogram-native subquery machinery, the ordinary float path, and #2577's own recombination).
- `sum`/`avg` `[by/without]` and a further `and`/`or`/`unless` wrapping the same mixed `or` (the issue's other two named wrapper families) are **deliberately not covered** by this PR — see "What's left" below. The issue stays open.

## Why label_replace/label_join and not sum/avg (the issue's own evidence shape)

`label_replace`/`label_join` are stateless per-ROW rewrites with no cross-row interaction, so the same algebraic identity #2577 already proved sound for the bare shape —

```
<fn>((W(a) or W(b))[5m:1m]) == <fn>((W(a))[5m:1m]) or <fn>((W(b))[5m:1m])
```

— holds for `W = label_replace(_, args)` too: inserting a stateless label rewrite inside each per-anchor evaluation commutes with both the subquery's own per-anchor re-evaluation and the outer window fold.

`sum`/`avg` `[by/without]` is a **grouping** operation, and the identity does **not** hold for it in general: `sum by (series)` can put a histogram-arm row and a float-arm row from the two *different* source metrics into the *same* output group whenever their `series` (or whatever `by`/`without` selects) label values coincide, even though the two metrics never share a full label signature. Reference Prometheus drops such a mixed-type group entirely at that anchor (`combineMixedAggregateBranches`'s own doc, cerberus issue #2346, already implements this correctly for the query-root case). Naively distributing `sum by(series)(a)` and `sum by(series)(b)` into two independent subqueries and recombining with the ordinary shadow-priority `or` (LHS wins on a shared group) does **not** reproduce that drop rule — it would silently keep one side's value for a group reference says should vanish entirely. That's a real, reachable divergence (not a corner case), not a cheap AST-level fix, so it's left as an explicit tracked divergence rather than shipped silently wrong. The "further `and`/`or`/`unless`" wrapper family carries an analogous joining/grouping risk and is left tracked for the same reason.

The still-open rejection-parity catalogue entry `internal/promql/subquery.go:lowerOuterRangeFnOverSubquery#087c3810` (`trigger_query`: `count_over_time((sum by (series) ((demo_latency_exp_hist) or (demo_num_cpus)))[5m:1m])`) continues to track the `sum`/`avg` case under issue #2581, unchanged by this PR — confirmed via `CERBERUS_UPDATE_INVENTORY=1 go test -run TestCatalogueIsRegenerable ./test/rejection-parity/...`, which produced **zero diff**.

## What's left (issue #2581 stays open)

- `sum`/`avg` `[by/without]` wrapping a mixed `or` subquery inner: still rejects, tracked by the existing catalogue entry above.
- A further `and`/`or`/`unless` wrapping a mixed `or` subquery inner: still rejects via the ordinary path (verified — see below).

## A new, separate bug found while probing post-fix

While probing broadly for the next live gap (per the task's own instruction), I found that `<fn>((<histogram-or-mixed> and/or/unless <float>)[range:step])` — the subquery's own inner shaped as `and`/`or`/`unless` between mismatched value types — does **not** cleanly reject the way the `sum`/`avg` case does. It silently lowers to a plan that reads a placeholder `Value` column instead of the real histogram payload, with no error at all: `lowerSubqueryOverBinary` (`internal/promql/subquery.go`) unconditionally reprojects through the lossy `subqueryAnchorShape` four-column quartet even when the underlying `chplan.VectorSetOp` it built is genuinely `HistogramRowShape`/`MixedRowShape` — unlike its sibling `lowerHistogramNativeSubqueryInner` right above it, which has an explicit guard for exactly this. Verified via direct `chplan` tree inspection (not just the absence of an error): the `VectorSetOp` correctly resolves `RowShapeOf == HistogramRowShape`/`MixedRowShape`, and the wrapping `Project` still discards it.

This is broader than #2581 (it also affects the pure-histogram-vs-float `and` case, unrelated to a mixed `or`) and is a different root cause (`lowerSubqueryOverBinary`'s own lossy wrap, not `mixedOrSubqueryOuterFn`'s AST distribution), so it's filed separately: tsouza/cerberus#2589.

## Test plan

- [x] `TestLower_ExpHistogram_MixedOrSubqueryOuterFn_WrappedInner` (new) — all fifteen SELECT/FOLD-family names lower without error to the correct `chplan.RowShapeOf` (instant, range, pinned, and nested under `sum by (series)` on the OUTER side) for a `label_replace`-wrapped mixed-or subquery inner.
- [x] `TestLower_ExpHistogram_MixedOrSubqueryOuterFn_LabelJoinWrappedInner` (new) — `label_join` half of the same wrapper family.
- [x] `TestMixedOrSubqueryCountOverTimeWrappedInner_ChDB` / `TestMixedOrSubquerySumOverTimeWrappedInner_ChDB` / `TestMixedOrSubqueryRateWrappedInner_ChDB` (new, chDB-backed, mirrors #2577's own real-execution proof) — real ClickHouse execution confirms both arms' correct values.
- [x] `go build ./...`, `go vet ./...`, `gofumpt -extra -w .`, `goimports -local github.com/tsouza/cerberus -w .` — clean.
- [x] `go test -race ./internal/promql/...` — pass.
- [x] `node .github/scripts/forbid-sql-raw.mjs` — clean (no chsql touched, ran anyway).
- [x] `CERBERUS_UPDATE_INVENTORY=1 go test -run TestCatalogueIsRegenerable ./test/rejection-parity/...` — zero diff (the fixed shape was never separately catalogued; the still-open `sum by (series)` entry is unchanged).
- [x] `TestRejectionTriggersExerciseSites`, `TestInternalRationalesRestOnCurrentEvidence`, `TestCatalogueIsRegenerable`, `TestPromQLRejectionTriggersUseSeededMetrics` — all pass.
