### PR TITLE
fix(promql): support unary minus/plus over an exp-histogram-valued operand

### DIFF
--- a/internal/promql/histogram_native_float_fn.go
+++ b/internal/promql/histogram_native_float_fn.go
@@ -16,6 +16,16 @@ func lowerExpHistogramValuedShape(expr parser.Expr, s schema.Metrics, ctx lowerC
 		plan, err := lowerLabelCallOverExpHistogram(call, s, ctx)
 		return plan, true, err
 	}
+	// Unary `+`/`-` over an already histogram-valued operand (cerberus
+	// issue #2583) — see histogram_native_unary.go's own doc comment for
+	// why registering the producer here, rather than patching
+	// unary.go's lowerUnary directly, is what makes it compose under
+	// every wrapper that already threads its own argument through this
+	// function.
+	if operand, op, ok := unaryOverExpHistogram(expr, s, ctx); ok {
+		plan, err := lowerUnaryOverExpHistogram(operand, op, s, ctx)
+		return plan, true, err
+	}
 	if vs, ok := bareExpHistogramSelector(expr, s, ctx); ok {
 		plan, err := lowerExpHistogramBare(vs, s, ctx)
 		return plan, true, err

--- a/internal/promql/histogram_native_scalar_binop.go
+++ b/internal/promql/histogram_native_scalar_binop.go
@@ -157,6 +157,11 @@ func isExpHistogramValuedShape(expr parser.Expr, s schema.Metrics, ctx lowerCtx)
 	if call, ok := labelCallOverExpHistogram(expr, s, ctx); ok {
 		return isExpHistogramValuedShape(call.Args[0], s, ctx)
 	}
+	// `-<exp-hist shape>` / `+<exp-hist shape>` (cerberus issue #2583) —
+	// see histogram_native_unary.go.
+	if _, _, ok := unaryOverExpHistogram(expr, s, ctx); ok {
+		return true
+	}
 	if _, ok := bareExpHistogramSelector(expr, s, ctx); ok {
 		return true
 	}

--- a/internal/promql/histogram_native_unary.go
+++ b/internal/promql/histogram_native_unary.go
@@ -1,0 +1,99 @@
+package promql
+
+import (
+	"fmt"
+
+	"github.com/prometheus/prometheus/promql/parser"
+
+	"github.com/tsouza/cerberus/internal/chplan"
+	"github.com/tsouza/cerberus/internal/schema"
+)
+
+// histogram_native_unary.go answers PromQL unary `+`/`-` over an
+// already histogram-VALUED operand (cerberus issue #2583) —
+// `-demo_latency_exp_hist`, `+sum(demo_latency_exp_hist)`, and so on.
+//
+// Reference Prometheus's UnaryExpr evaluator (promql/engine.go) treats
+// unary `+` as the identity — it returns the operand's own sample
+// unchanged, histogram pointer included — and unary `-` as
+// `FloatHistogram.Mul(-1)`:
+//
+//	for j := range mat[i].Histograms {
+//	    mat[i].Histograms[j].H = mat[i].Histograms[j].H.Copy().Mul(-1)
+//	}
+//
+// `Mul` (github.com/tsouza/prometheus's
+// model/histogram/float_histogram.go) scales exactly the five
+// COUNT-bearing fields — Count, Sum, ZeroCount, and BOTH signed bucket
+// ladders — and leaves Scale, ZeroThreshold and both bucket offsets
+// untouched (those describe where the buckets SIT on the value axis, not
+// how much fell into them):
+//
+//	func (h *FloatHistogram) Mul(factor float64) *FloatHistogram {
+//	    h.ZeroCount *= factor
+//	    h.Count *= factor
+//	    h.Sum *= factor
+//	    for i := range h.PositiveBuckets { h.PositiveBuckets[i] *= factor }
+//	    for i := range h.NegativeBuckets { h.NegativeBuckets[i] *= factor }
+//	    ...
+//	}
+//
+// That is exactly the five-field split [scaleHistogramProjection]
+// (histogram_native_scalar_binop.go, cerberus issue #2087) already
+// applies for the scalar `histogram * <literal>` shape — ZeroCount
+// included, confirmed against the vendored fork above rather than
+// assumed. Unary minus over a histogram-valued operand is therefore
+// literally "MUL by the compile-time literal scalar -1", so this file
+// recognises the AST shape and reuses [lowerExpHistogramScalarBinop]
+// for the fold instead of duplicating it.
+//
+// [unaryOverExpHistogram] is registered directly inside
+// [lowerExpHistogramValuedShape] (histogram_native_float_fn.go) as a
+// PRODUCER, the same way [labelCallOverExpHistogram] is: that is what
+// makes `-hist` compose under every wrapper that already threads its own
+// argument through [lowerExpHistogramValuedShape] first — `sum(-hist)`
+// resolves via [mergeableExpHistogramAggregate]'s own recursive call,
+// `label_replace(-hist, ...)` via [labelCallOverExpHistogram]'s own
+// argument check, `-hist * 2` via [isExpHistogramValuedShape]'s widening
+// below — without touching any of those files. [lowerRoot] itself
+// resolves the reported top-level shape the identical way, through
+// [lowerHistogramNativeRoot]'s own direct call to
+// [lowerExpHistogramValuedShape]. `internal/promql/unary.go`'s
+// `lowerUnary` — the plain generic dispatcher `*parser.UnaryExpr`
+// otherwise falls through to — is consequently never reached for a
+// histogram-valued operand at all; it keeps handling only the ordinary
+// float-Value case it always has.
+func unaryOverExpHistogram(expr parser.Expr, s schema.Metrics, ctx lowerCtx) (operand parser.Expr, op parser.ItemType, ok bool) {
+	if s.ExpHistogramTable == "" || ctx.metadataFullRange {
+		return nil, 0, false
+	}
+	u, isUnary := peelWrappers(expr).(*parser.UnaryExpr)
+	if !isUnary || (u.Op != parser.SUB && u.Op != parser.ADD) {
+		return nil, 0, false
+	}
+	if !isExpHistogramValuedShape(u.Expr, s, ctx) {
+		return nil, 0, false
+	}
+	return u.Expr, u.Op, true
+}
+
+// lowerUnaryOverExpHistogram lowers the shape [unaryOverExpHistogram]
+// accepted. Unary `+` defers to the operand's own histogram-valued
+// lowering unchanged (reference's identity case); unary `-` scales it by
+// the literal -1 through the SAME fold the scalar `*` shape uses, which
+// negates Count/Sum/ZeroCount/PositiveBucketCounts/NegativeBucketCounts
+// and leaves Scale/ZeroThreshold/both offsets untouched — see this
+// file's own doc comment for the reference-semantics citation.
+func lowerUnaryOverExpHistogram(operand parser.Expr, op parser.ItemType, s schema.Metrics, ctx lowerCtx) (chplan.Node, error) {
+	if op == parser.ADD {
+		node, matched, err := lowerExpHistogramValuedShape(operand, s, ctx)
+		if err != nil {
+			return nil, err
+		}
+		if !matched {
+			return nil, fmt.Errorf("promql: internal invariant violated: unary + histogram operand matched no known histogram-valued shape for %v", operand)
+		}
+		return node, nil
+	}
+	return lowerExpHistogramScalarBinop(operand, chplan.OpMul, &chplan.LitFloat{V: -1}, s, ctx, false)
+}

--- a/internal/promql/histogram_native_unary_chdb_test.go
+++ b/internal/promql/histogram_native_unary_chdb_test.go
@@ -1,0 +1,197 @@
+//go:build chdb
+
+// chDB-backed proof that unary `-`/`+` over a native (OTel exponential)
+// histogram selector actually negates / passes through the row's nine
+// Histogram*Column fields at real ClickHouse execution (cerberus issue
+// #2583) — not merely that the emitted plan's Go shape looks right.
+//
+// Before this fix, `-demo_latency_exp_hist` hard-rejected via
+// expHistogramSelectorRouting's catch-all: unary.go's lowerUnary called
+// the generic lower() dispatcher on its operand with no histogram-aware
+// opt-in, so a bare exp-histogram selector under a UnaryExpr fell
+// straight through to lowerVectorSelector's rejection.
+//
+// The seed deliberately gives every one of the nine structural/count
+// fields a DISTINCT, non-degenerate value (Count=5, Sum=12.5, Scale=3,
+// ZeroCount=2, PositiveOffset=1, PositiveBucketCounts=[4,6],
+// NegativeOffset=2, NegativeBucketCounts=[3]) so a lowering that negates
+// the wrong subset — e.g. scaling Scale/offsets too (which reference's
+// FloatHistogram.Mul leaves untouched — they describe where the buckets
+// SIT, not how much fell into them) or forgetting ZeroCount (which
+// reference's Mul DOES negate, confirmed by reading
+// github.com/tsouza/prometheus's model/histogram/float_histogram.go
+// directly rather than assumed) — is caught rather than passing by
+// coincidence.
+package promql_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/prometheus/prometheus/promql/parser"
+
+	"github.com/tsouza/cerberus/internal/chsql"
+	"github.com/tsouza/cerberus/internal/promql"
+	"github.com/tsouza/cerberus/internal/schema"
+)
+
+const unaryExpHistMetric = "unary_wrapped_exp_hist"
+
+var unaryExpHistSeed = "" +
+	"CREATE OR REPLACE TABLE otel_metrics_exponential_histogram (" +
+	"`MetricName` String, `Attributes` Map(String, String), " +
+	"`ResourceAttributes` Map(String, String) DEFAULT map(), `ServiceName` LowCardinality(String) DEFAULT '', " +
+	"`TimeUnix` DateTime64(9), " +
+	"`Count` UInt64, `Sum` Float64, `Scale` Int32, `ZeroCount` UInt64, " +
+	"`PositiveOffset` Int32, `PositiveBucketCounts` Array(UInt64), " +
+	"`NegativeOffset` Int32, `NegativeBucketCounts` Array(UInt64)" +
+	") ENGINE = MergeTree ORDER BY (`MetricName`, `Attributes`, `TimeUnix`);\n" +
+	"INSERT INTO otel_metrics_exponential_histogram " +
+	"(MetricName, Attributes, TimeUnix, Count, Sum, Scale, ZeroCount, PositiveOffset, PositiveBucketCounts, NegativeOffset, NegativeBucketCounts) VALUES\n" +
+	"    ('" + unaryExpHistMetric + "', map('series', 'a'), toDateTime64('2026-01-01 00:00:00', 9), 5, 12.5, 3, 2, 1, [4, 6], 2, [3]);\n"
+
+var unaryExpHistEvalTS = time.Date(2026, 1, 1, 0, 0, 1, 0, time.UTC)
+
+// TestUnaryMinusExpHistogram_ChDB proves `-<exp-hist selector>` negates
+// exactly the five COUNT-bearing fields — Count, Sum, ZeroCount, and both
+// signed bucket ladders element-wise — and leaves Scale and both bucket
+// offsets untouched, matching reference Prometheus's
+// FloatHistogram.Mul(-1).
+func TestUnaryMinusExpHistogram_ChDB(t *testing.T) {
+	fixture := newChDBFixture(t, unaryExpHistSeed)
+
+	s := schema.DefaultOTelMetrics()
+	p := parser.NewParser(parser.Options{EnableExperimentalFunctions: true})
+
+	query := "-" + unaryExpHistMetric
+	expr, err := p.ParseExpr(query)
+	if err != nil {
+		t.Fatalf("ParseExpr(%q): %v", query, err)
+	}
+	plan, err := promql.LowerAt(context.Background(), expr, s, unaryExpHistEvalTS, unaryExpHistEvalTS)
+	if err != nil {
+		t.Fatalf("LowerAt(%q): %v", query, err)
+	}
+	sqlStr, args, err := chsql.Emit(context.Background(), plan)
+	if err != nil {
+		t.Fatalf("Emit(%q): %v", query, err)
+	}
+
+	projection := "`Attributes`['series'] AS series, " +
+		"`HistogramCount` AS cnt, `HistogramSum` AS sum, `HistogramZeroCount` AS zc, " +
+		"`HistogramScale` AS scale, " +
+		"`HistogramPositiveOffset` AS posoff, `HistogramPositiveBucketCounts`[1] AS pos1, `HistogramPositiveBucketCounts`[2] AS pos2, " +
+		"`HistogramNegativeOffset` AS negoff, `HistogramNegativeBucketCounts`[1] AS neg1"
+	rows := fixture.queryOverEmitted(t, projection, sqlStr, args)
+	defer func() { _ = rows.Close() }()
+
+	gotRows := 0
+	for rows.Next() {
+		gotRows++
+		var series string
+		var cnt, sum, zc, pos1, pos2, neg1 float64
+		var scale, posoff, negoff int64
+		if err := rows.Scan(&series, &cnt, &sum, &zc, &scale, &posoff, &pos1, &pos2, &negoff, &neg1); err != nil {
+			t.Fatalf("scan: %v", err)
+		}
+		if series != "a" {
+			t.Errorf("series = %q, want %q", series, "a")
+		}
+		// Negated: the five COUNT-bearing fields.
+		if cnt != -5 {
+			t.Errorf("HistogramCount = %v, want -5 (raw seeded value is 5)", cnt)
+		}
+		if sum != -12.5 {
+			t.Errorf("HistogramSum = %v, want -12.5 (raw seeded value is 12.5)", sum)
+		}
+		if zc != -2 {
+			t.Errorf("HistogramZeroCount = %v, want -2 (raw seeded value is 2 — reference's FloatHistogram.Mul negates ZeroCount too)", zc)
+		}
+		if pos1 != -4 || pos2 != -6 {
+			t.Errorf("HistogramPositiveBucketCounts = [%v, %v], want [-4, -6] (raw seeded values are [4, 6])", pos1, pos2)
+		}
+		if neg1 != -3 {
+			t.Errorf("HistogramNegativeBucketCounts[1] = %v, want -3 (raw seeded value is 3)", neg1)
+		}
+		// Untouched: the structural fields describing where the buckets
+		// SIT on the value axis, not how much fell into them.
+		if scale != 3 {
+			t.Errorf("HistogramScale = %v, want 3 unchanged (unary minus must not rescale bucket boundaries)", scale)
+		}
+		if posoff != 1 {
+			t.Errorf("HistogramPositiveOffset = %v, want 1 unchanged", posoff)
+		}
+		if negoff != 2 {
+			t.Errorf("HistogramNegativeOffset = %v, want 2 unchanged", negoff)
+		}
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatalf("rows.Err: %v", err)
+	}
+	if gotRows != 1 {
+		t.Fatalf("%s: got %d rows, want 1", query, gotRows)
+	}
+}
+
+// TestUnaryPlusExpHistogram_ChDB proves `+<exp-hist selector>` is the
+// identity — reference Prometheus's UnaryExpr evaluator returns the
+// operand's own histogram sample unchanged for `+` — over a real chDB
+// execution.
+func TestUnaryPlusExpHistogram_ChDB(t *testing.T) {
+	fixture := newChDBFixture(t, unaryExpHistSeed)
+
+	s := schema.DefaultOTelMetrics()
+	p := parser.NewParser(parser.Options{EnableExperimentalFunctions: true})
+
+	query := "+" + unaryExpHistMetric
+	expr, err := p.ParseExpr(query)
+	if err != nil {
+		t.Fatalf("ParseExpr(%q): %v", query, err)
+	}
+	plan, err := promql.LowerAt(context.Background(), expr, s, unaryExpHistEvalTS, unaryExpHistEvalTS)
+	if err != nil {
+		t.Fatalf("LowerAt(%q): %v", query, err)
+	}
+	sqlStr, args, err := chsql.Emit(context.Background(), plan)
+	if err != nil {
+		t.Fatalf("Emit(%q): %v", query, err)
+	}
+
+	projection := "`Attributes`['series'] AS series, " +
+		"`HistogramCount` AS cnt, `HistogramSum` AS sum, `HistogramZeroCount` AS zc, " +
+		"`HistogramScale` AS scale, " +
+		"`HistogramPositiveOffset` AS posoff, `HistogramPositiveBucketCounts`[1] AS pos1, `HistogramPositiveBucketCounts`[2] AS pos2, " +
+		"`HistogramNegativeOffset` AS negoff, `HistogramNegativeBucketCounts`[1] AS neg1"
+	rows := fixture.queryOverEmitted(t, projection, sqlStr, args)
+	defer func() { _ = rows.Close() }()
+
+	gotRows := 0
+	for rows.Next() {
+		gotRows++
+		var series string
+		var cnt, sum, zc, pos1, pos2, neg1 float64
+		var scale, posoff, negoff int64
+		if err := rows.Scan(&series, &cnt, &sum, &zc, &scale, &posoff, &pos1, &pos2, &negoff, &neg1); err != nil {
+			t.Fatalf("scan: %v", err)
+		}
+		if series != "a" {
+			t.Errorf("series = %q, want %q", series, "a")
+		}
+		if cnt != 5 || sum != 12.5 || zc != 2 {
+			t.Errorf("Count/Sum/ZeroCount = %v/%v/%v, want 5/12.5/2 unchanged (unary + is the identity)", cnt, sum, zc)
+		}
+		if pos1 != 4 || pos2 != 6 || neg1 != 3 {
+			t.Errorf("bucket ladders = pos[%v,%v] neg[%v], want pos[4,6] neg[3] unchanged", pos1, pos2, neg1)
+		}
+		if scale != 3 || posoff != 1 || negoff != 2 {
+			t.Errorf("Scale/PositiveOffset/NegativeOffset = %v/%v/%v, want 3/1/2 unchanged", scale, posoff, negoff)
+		}
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatalf("rows.Err: %v", err)
+	}
+	if gotRows != 1 {
+		t.Fatalf("%s: got %d rows, want 1", query, gotRows)
+	}
+}

--- a/internal/promql/unary.go
+++ b/internal/promql/unary.go
@@ -27,6 +27,14 @@ import (
 // quantile, the right-hand side of an arithmetic op, ...) is unwrapped by
 // `tryScalarLiteral`, which understands UnaryExpr ADD/SUB over a literal —
 // so this lowerer is never invoked for those.
+//
+// A histogram-VALUED operand (cerberus issue #2583, e.g.
+// `-demo_latency_exp_hist`) never reaches this function either:
+// [lowerHistogramNativeRoot] resolves it upstream through
+// [lowerExpHistogramValuedShape]'s own `*parser.UnaryExpr` producer
+// (histogram_native_unary.go), which composes under every wrapper that
+// already threads its argument through that same recogniser. This
+// lowerer keeps handling only the ordinary float-Value case below.
 func lowerUnary(u *parser.UnaryExpr, s schema.Metrics, ctx lowerCtx) (chplan.Node, error) {
 	switch u.Op {
 	case parser.ADD:

--- a/test/rejection-parity/catalogue/internal__promql__histogram_native_scalar_binop.go__lowerExpHistogramScalarBinop.json
+++ b/test/rejection-parity/catalogue/internal__promql__histogram_native_scalar_binop.go__lowerExpHistogramScalarBinop.json
@@ -5,7 +5,7 @@
       "site": "internal/promql/histogram_native_scalar_binop.go:lowerExpHistogramScalarBinop#6b279323",
       "message": "promql: internal invariant violated: exp-histogram scalar-binop operand lowering published %s row shape (%T), want %s",
       "class": "internal",
-      "rationale": "expHistogramScalarBinop and expHistogramDroppingScalarBinop admit only isExpHistogramValuedShape operands, and every branch of that recognizer has a matching branch in its producer, lowerExpHistogramValuedShape, that returns a node whose chplan.RowShapeOf reports chplan.HistogramRowShape — the property this guard checks directly, rather than assuming a specific chplan.Node subtype. This site used to assert the stronger, wrong claim that the operand caps with literally a *chplan.HistogramProjection (cerberus issue #2557): the and/or/unless set-op branch (expHistogramSetOp) lowers to a *chplan.VectorSetOp instead, which is HistogramRowShape-shaped but not a HistogramProjection, so that older assertion panicked with this very error on a real, reachable query — the recognizer and the lowering agreed the shape was histogram-valued, they just disagreed on which Go type carried it. Since cerberus issue #2528, lowerExpHistogramDroppingShape joins lowerHistogramNativeRoot as a second caller of the drop path (drop=true), but it calls lowerExpHistogramScalarBinop only immediately after its own expHistogramDroppingScalarBinop(expr, s, ctx) check has returned ok — the same isExpHistogramValuedShape-gated histSide lowerHistogramNativeRoot already passes — so the claim is unaffected by that caller. lowerHistogramNativeSubqueryInner (cerberus issue #2543) is a third caller of lowerHistogramNativeRoot, reached for a bare subquery's own inner expression; it reaches this lowerer through the identical isExpHistogramValuedShape-gated dispatch, so it does not affect the claim either.",
+      "rationale": "expHistogramScalarBinop and expHistogramDroppingScalarBinop admit only isExpHistogramValuedShape operands, and every branch of that recognizer has a matching branch in its producer, lowerExpHistogramValuedShape, that returns a node whose chplan.RowShapeOf reports chplan.HistogramRowShape — the property this guard checks directly, rather than assuming a specific chplan.Node subtype. This site used to assert the stronger, wrong claim that the operand caps with literally a *chplan.HistogramProjection (cerberus issue #2557): the and/or/unless set-op branch (expHistogramSetOp) lowers to a *chplan.VectorSetOp instead, which is HistogramRowShape-shaped but not a HistogramProjection, so that older assertion panicked with this very error on a real, reachable query — the recognizer and the lowering agreed the shape was histogram-valued, they just disagreed on which Go type carried it. Since cerberus issue #2528, lowerExpHistogramDroppingShape joins lowerHistogramNativeRoot as a second caller of the drop path (drop=true), but it calls lowerExpHistogramScalarBinop only immediately after its own expHistogramDroppingScalarBinop(expr, s, ctx) check has returned ok — the same isExpHistogramValuedShape-gated histSide lowerHistogramNativeRoot already passes — so the claim is unaffected by that caller. lowerHistogramNativeSubqueryInner (cerberus issue #2543) reaches this lowerer through the identical isExpHistogramValuedShape-gated dispatch inside lowerHistogramNativeRoot for a bare subquery's own inner expression, so it does not affect the claim either. lowerUnaryOverExpHistogram (cerberus issue #2583) is a fourth direct caller, reached from lowerExpHistogramValuedShape's own unaryOverExpHistogram producer branch for unary minus over a histogram-valued operand: it calls lowerExpHistogramScalarBinop(operand, chplan.OpMul, \u0026chplan.LitFloat{V: -1}, s, ctx, false) only after unaryOverExpHistogram's own isExpHistogramValuedShape(u.Expr, s, ctx) check has already matched that identical operand, so the claim is unaffected by this caller either.",
       "evidence": {
         "guard": [
           "past returning if !matched",
@@ -15,7 +15,8 @@
         "callers": [
           "lowerExpHistogramDroppingShape",
           "lowerExpHistogramValuedShape",
-          "lowerHistogramNativeRoot"
+          "lowerHistogramNativeRoot",
+          "lowerUnaryOverExpHistogram"
         ],
         "cited": [
           "expHistogramDroppingScalarBinop",
@@ -26,7 +27,9 @@
           "lowerExpHistogramScalarBinop",
           "lowerExpHistogramValuedShape",
           "lowerHistogramNativeRoot",
-          "lowerHistogramNativeSubqueryInner"
+          "lowerHistogramNativeSubqueryInner",
+          "lowerUnaryOverExpHistogram",
+          "unaryOverExpHistogram"
         ]
       }
     },
@@ -35,7 +38,7 @@
       "site": "internal/promql/histogram_native_scalar_binop.go:lowerExpHistogramScalarBinop#d112d97a",
       "message": "promql: internal invariant violated: exp-histogram scalar-binop matched no known histogram-valued shape for %v",
       "class": "internal",
-      "rationale": "the scalar-binop recognizers and lowerExpHistogramValuedShape share isExpHistogramValuedShape for the identical histogram operand. Since cerberus issue #2528, lowerExpHistogramDroppingShape joins lowerHistogramNativeRoot as a second caller of the drop path, but — same as the sibling site just above — it only reaches this lowerer via expHistogramDroppingScalarBinop's own isExpHistogramValuedShape-gated histSide, so the claim is unaffected by that caller. lowerHistogramNativeSubqueryInner (cerberus issue #2543) is a third caller of lowerHistogramNativeRoot as of this change, reached for a bare subquery's own inner expression, and reaches this lowerer through the identical gated dispatch, so it does not affect the claim either.",
+      "rationale": "the scalar-binop recognizers and lowerExpHistogramValuedShape share isExpHistogramValuedShape for the identical histogram operand. Since cerberus issue #2528, lowerExpHistogramDroppingShape joins lowerHistogramNativeRoot as a second caller of the drop path, but — same as the sibling site just above — it only reaches this lowerer via expHistogramDroppingScalarBinop's own isExpHistogramValuedShape-gated histSide, so the claim is unaffected by that caller. lowerHistogramNativeSubqueryInner (cerberus issue #2543) reaches this lowerer through the identical gated dispatch inside lowerHistogramNativeRoot for a bare subquery's own inner expression, so it does not affect the claim either. lowerUnaryOverExpHistogram (cerberus issue #2583) is a fourth direct caller: it invokes lowerExpHistogramScalarBinop(operand, chplan.OpMul, \u0026chplan.LitFloat{V: -1}, s, ctx, false) only after unaryOverExpHistogram's own isExpHistogramValuedShape(u.Expr, s, ctx) check has already matched that same operand, so the claim is unaffected by this caller either.",
       "evidence": {
         "guard": [
           "if !matched"
@@ -43,15 +46,19 @@
         "callers": [
           "lowerExpHistogramDroppingShape",
           "lowerExpHistogramValuedShape",
-          "lowerHistogramNativeRoot"
+          "lowerHistogramNativeRoot",
+          "lowerUnaryOverExpHistogram"
         ],
         "cited": [
           "expHistogramDroppingScalarBinop",
           "isExpHistogramValuedShape",
           "lowerExpHistogramDroppingShape",
+          "lowerExpHistogramScalarBinop",
           "lowerExpHistogramValuedShape",
           "lowerHistogramNativeRoot",
-          "lowerHistogramNativeSubqueryInner"
+          "lowerHistogramNativeSubqueryInner",
+          "lowerUnaryOverExpHistogram",
+          "unaryOverExpHistogram"
         ]
       }
     }

--- a/test/rejection-parity/catalogue/internal__promql__histogram_native_unary.go__lowerUnaryOverExpHistogram.json
+++ b/test/rejection-parity/catalogue/internal__promql__histogram_native_unary.go__lowerUnaryOverExpHistogram.json
@@ -1,0 +1,28 @@
+{
+  "entries": [
+    {
+      "head": "promql",
+      "site": "internal/promql/histogram_native_unary.go:lowerUnaryOverExpHistogram#3f85e848",
+      "message": "promql: internal invariant violated: unary + histogram operand matched no known histogram-valued shape for %v",
+      "class": "internal",
+      "rationale": "unaryOverExpHistogram admits the operand through isExpHistogramValuedShape and this lowerer consults lowerExpHistogramValuedShape for that same operand — the identical recognizer/producer pairing labelCallOverExpHistogram / lowerLabelCallOverExpHistogram already rely on for label_replace/label_join, so the two functions can never disagree about whether operand is histogram-valued.",
+      "evidence": {
+        "guard": [
+          "if op == parser.ADD",
+          "past returning if err != nil",
+          "if !matched"
+        ],
+        "callers": [
+          "lowerExpHistogramValuedShape"
+        ],
+        "cited": [
+          "isExpHistogramValuedShape",
+          "labelCallOverExpHistogram",
+          "lowerExpHistogramValuedShape",
+          "lowerLabelCallOverExpHistogram",
+          "unaryOverExpHistogram"
+        ]
+      }
+    }
+  ]
+}

--- a/test/rejection-parity/catalogue/internal__promql__lower.go__expHistogramSelectorRouting.json
+++ b/test/rejection-parity/catalogue/internal__promql__lower.go__expHistogramSelectorRouting.json
@@ -5,8 +5,8 @@
       "site": "internal/promql/lower.go:expHistogramSelectorRouting#bf746b59",
       "message": "promql: %q is an exponential histogram metric; only a bare %q selector, sum()/avg()/count() over one, rate()/increase()/delta()/irate()/idelta()/sum_over_time()/avg_over_time()/resets()/changes() over one, histogram_quantile(), histogram_count(), histogram_sum(), and the %q/%q companion selectors are supported",
       "class": "divergence",
-      "trigger_query": "-demo_latency_exp_hist",
-      "tracking_issue": 2583,
+      "trigger_query": "max_over_time(demo_latency_exp_hist[5m])[10m:1m]",
+      "tracking_issue": 2590,
       "evidence": {
         "guard": [
           "past returning if bare, col, hasCompanion := s.HistogramCompanionColumn(metricName); hasCompanion \u0026\u0026 s.IsExpHistogramMetric(bare) \u0026\u0026 s.ExpHistogramTable != \"\"",


### PR DESCRIPTION
## Summary

- `-<exp-histogram selector>` hard-rejected via `expHistogramSelectorRouting`'s
  catch-all: `unary.go`'s `lowerUnary` called the generic `lower()` dispatcher
  on its operand with no histogram-aware opt-in, unlike `label_replace`/
  `sort`/`clamp`/date functions, which all thread a histogram-valued check
  ahead of the generic fallback.
- Registers a new `*parser.UnaryExpr` producer inside
  `lowerExpHistogramValuedShape` (`internal/promql/histogram_native_unary.go`):
  unary minus reuses the existing scalar `*` fold via
  `lowerExpHistogramScalarBinop` with `scale=-1` — reference Prometheus's
  `FloatHistogram.Mul(-1)` scales exactly the same five fields
  (Count/Sum/ZeroCount and both signed bucket ladders), leaving
  Scale/ZeroThreshold/offsets untouched, confirmed by reading the vendored
  `tsouza/prometheus` fork directly; unary plus is the identity.
- Registering the producer inside the shared recognizer/lowering pair (rather
  than only patching `unary.go` directly) makes it compose under every
  wrapper that already threads its own argument through
  `lowerExpHistogramValuedShape` — `sum(-hist)`, `label_replace(-hist, ...)`,
  `-hist * 2`, `-(-hist)`, etc. — without touching any of those files.
- Rotates the rejection-parity catalogue's `expHistogramSelectorRouting`
  entry forward: the old trigger (`-demo_latency_exp_hist`) no longer
  reproduces the divergence now that it's fixed, so the entry's
  `trigger_query`/`tracking_issue` move to a freshly-probed live divergence,
  `max_over_time(demo_latency_exp_hist[5m])[10m:1m]`, tracked by #2590.

## Broad post-fix probe

Probed dozens of additional shapes (composition with `sum`/`rate`/
`label_replace`/`limitk`/set-ops/scalar arithmetic, plus a wide sweep of
otherwise-unrelated exp-histogram shapes) looking for the next live
divergence. Found two real, distinct gaps and filed them rather than folding
them into this PR:

- #2590 — a bare subquery wrapping a drop-family range function
  (`max_over_time`/`min_over_time`/`deriv`/…) rejects; root cause is
  `subquery.go`'s `lowerHistogramNativeSubqueryInner` only retrying the
  PRESERVE family, never the DROP family, unlike every other "try preserve,
  fall back to generic `lower()`" callsite. This is the catalogue's new
  tracked trigger.
- #2591 — `present_over_time()`/`count_over_time()` reject when wrapped in
  unary minus; root cause is a different one — their own recognizer
  (`countPresentOverExpHistogram`) is root-only with no nested-retry,
  unlike `sum()`/`avg()`/`count()`/`group()`.

## Test plan

- [x] New chDB test (`internal/promql/histogram_native_unary_chdb_test.go`,
      `//go:build chdb`) seeds a real exp-histogram row with a distinct value
      on all nine structural/count fields and asserts the exact negated
      values for `-<selector>` and the exact unchanged values for
      `+<selector>` against real ClickHouse execution — proving `ZeroCount`
      IS negated (matching reference) while `Scale`/offsets are NOT.
- [x] `go build ./...`, `go vet ./...`, `go build -tags chdb
      ./internal/promql/...`
- [x] `gofumpt -extra -w .` / `goimports -local github.com/tsouza/cerberus
      -w .` — no changes needed beyond the edit itself
- [x] `go test -race -count=1 ./internal/promql/...`
- [x] `node .github/scripts/forbid-sql-raw.mjs` — clean
- [x] `test/rejection-parity` full package:
      `TestRejectionTriggersExerciseSites`,
      `TestParityCorpusMatchesCatalogue`, `TestCatalogueEntriesAreClassified`,
      `TestInternalRationaleCitationsStillDispatch`,
      `TestCatalogueIsRegenerable` (run twice after hand-curating the new/
      touched `class`/`rationale` fields — stable on the second pass),
      `TestInternalRationalesRestOnCurrentEvidence` — all pass

Closes #2583
