### PR TITLE
fix(promql): stop discarding a histogram/mixed subquery set-op payload

### DIFF
--- a/internal/promql/subquery.go
+++ b/internal/promql/subquery.go
@@ -653,6 +653,28 @@ func lowerSubqueryOverInstantCall(
 // only samples that satisfied the predicate — matching Prom's "drop
 // non-matching samples then take the latest" semantics for
 // `(up > 0.5)[5m:1m]`.
+//
+// A `b` shaped as `and`/`or`/`unless` between a histogram-valued (or
+// mixed float/histogram) operand and a plain float operand is NOT
+// caught by [lowerHistogramNativeSubqueryInner]'s own dispatch table
+// (cerberus issue #2589): [expHistogramSetOp] only recognises BOTH
+// operands histogram-valued, and [mixedExpHistogramSetOp] only
+// recognises `or` — neither covers a mixed-type `and`/`unless`. That
+// recognition lives only in [lowerVectorSetOpOperand]
+// (histogram_native_set_op.go), reachable exclusively through the
+// generic [lowerBinary] → [lowerVectorSetOp] path this function itself
+// calls below — so `lowerBinary(b, s, grid)` CAN and DOES return a
+// genuinely [chplan.HistogramRowShape] / [chplan.MixedRowShape] node
+// for that shape. Re-projecting such a node through
+// [subqueryAnchorShape]'s four-column Sample quartet would silently
+// discard its nine Histogram*Column outputs (or the Mixed
+// discriminator) and leave every consumer reading the meaningless
+// placeholder Value column instead — the exact silent-wrong-answer
+// class cerberus issue #2543 fixed for the bare-subquery-inner case.
+// The guard below is the same RowShapeOf dispatch
+// [lowerHistogramNativeSubqueryInner] already applies to its own
+// result, so a histogram/mixed-shaped set-op composes exactly like a
+// pure histogram-native subquery inner does.
 func lowerSubqueryOverBinary(
 	sub *parser.SubqueryExpr,
 	b *parser.BinaryExpr,
@@ -669,7 +691,12 @@ func lowerSubqueryOverBinary(
 		if err != nil {
 			return nil, err
 		}
-		return subqueryAnchorShape(inner, s), nil
+		switch chplan.RowShapeOf(inner) {
+		case chplan.HistogramRowShape, chplan.MixedRowShape:
+			return inner, nil
+		default:
+			return subqueryAnchorShape(inner, s), nil
+		}
 	}
 
 	// Synthetic operands such as time() materialize their own StepGrid.
@@ -681,6 +708,17 @@ func lowerSubqueryOverBinary(
 	inner, err := lowerBinary(b, s, rangeCtx)
 	if err != nil {
 		return nil, err
+	}
+	// No query eval-time context is threaded through (a bare [Lower] call,
+	// never a real HTTP entry point — see [subqueryHasEvalAnchor]'s doc):
+	// [wrapSubqueryIdentity] below re-projects through the same lossy
+	// Sample quartet [subqueryAnchorShape] does above, so a
+	// histogram/mixed-shaped result must be rejected rather than silently
+	// collapsed. This branch has no grid to evaluate a per-anchor
+	// composition against even in principle, so there is no sound
+	// alternative to offer here.
+	if shape := chplan.RowShapeOf(inner); shape == chplan.HistogramRowShape || shape == chplan.MixedRowShape {
+		return nil, fmt.Errorf("promql: histogram-valued subquery set operator requires query eval-time context (use LowerAt)")
 	}
 	return wrapSubqueryIdentity(sub, inner, step, s, ctx)
 }

--- a/internal/promql/subquery_and_unless_mixed_histogram_chdb_test.go
+++ b/internal/promql/subquery_and_unless_mixed_histogram_chdb_test.go
@@ -1,0 +1,162 @@
+//go:build chdb
+
+// chDB-backed proof that cerberus issue #2589's fix actually executes
+// correctly against real ClickHouse: a subquery whose own top-level inner
+// is `and`/`unless` between a histogram-valued (or mixed float/histogram)
+// operand and a plain float operand no longer discards the histogram
+// payload through [subqueryAnchorShape]'s lossy four-column reprojection.
+//
+// Before this fix, `lowerSubqueryOverBinary` unconditionally wrapped
+// `lowerBinary(b, s, grid)`'s result — which genuinely resolves to a
+// [chplan.HistogramRowShape] / [chplan.MixedRowShape] node for this shape,
+// via the generic [lowerVectorSetOp] / [lowerVectorSetOpOperand] path —
+// through [subqueryAnchorShape], silently dropping the nine
+// Histogram*Column outputs (or the Mixed discriminator) and leaving any
+// consumer reading the meaningless placeholder Value column instead, with
+// no error at all. Every case here proves the FIXED behaviour: real,
+// correctly-valued histogram data read back from a real chDB execution,
+// including a genuine per-anchor semantic difference (TestSubqueryUnless
+// below) that only a truly per-anchor-correct join can reproduce.
+package promql_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/tsouza/cerberus/internal/schema"
+)
+
+// subqSetOpGaugeDDL declares otel_metrics_gauge/otel_metrics_sum exactly
+// like histogram_native_float_vector_scaling_binop_swap_chdb_test.go's own
+// swapGaugeSeedDDL — duplicated under a distinct name only so this file has
+// no build-order dependency on that one.
+const subqSetOpGaugeDDL = "" +
+	"CREATE OR REPLACE TABLE otel_metrics_gauge (`MetricName` String, `Attributes` Map(String, String), `ResourceAttributes` Map(String, String) DEFAULT map(), `ServiceName` LowCardinality(String) DEFAULT '', `TimeUnix` DateTime64(9), `Value` Float64) ENGINE = MergeTree ORDER BY (`MetricName`, `Attributes`, `TimeUnix`);\n" +
+	"CREATE OR REPLACE TABLE otel_metrics_sum (`MetricName` String, `Attributes` Map(String, String), `ResourceAttributes` Map(String, String) DEFAULT map(), `ServiceName` LowCardinality(String) DEFAULT '', `TimeUnix` DateTime64(9), `Value` Float64) ENGINE = MergeTree ORDER BY (`MetricName`, `Attributes`, `TimeUnix`);\n"
+
+// TestSubqueryAndHistogramFloatBare_ChDB proves `(<exp-hist> and on(series)
+// <gauge>)[range:step]` — the issue's own pure-histogram-vs-float example
+// (cerberus issue #2337's semi-join shape) — under a bare top-level
+// subquery, with no outer range-vector function. `and` forwards the LHS
+// (histogram) row verbatim whenever the RHS also has a matching series at
+// the SAME anchor; the gauge series here is present at both seeded
+// anchors, so both histogram rows survive with their real payload intact.
+func TestSubqueryAndHistogramFloatBare_ChDB(t *testing.T) {
+	const histMetric = "subq_and_exp_hist"
+	const gaugeMetric = "subq_and_gauge"
+	seed := subqHistDDL +
+		"INSERT INTO otel_metrics_exponential_histogram " +
+		"(MetricName, Attributes, TimeUnix, Count, Sum, Scale, ZeroCount, PositiveOffset, PositiveBucketCounts, NegativeOffset, NegativeBucketCounts) VALUES\n" +
+		"    ('" + histMetric + "', map('series', 'a'), toDateTime64('2026-01-01 00:01:00', 9), 2, 4.0, 0, 0, 0, [6], 0, []),\n" +
+		"    ('" + histMetric + "', map('series', 'a'), toDateTime64('2026-01-01 00:02:00', 9), 3, 9.0, 0, 0, 0, [12], 0, []);\n" +
+		subqSetOpGaugeDDL +
+		"INSERT INTO otel_metrics_gauge (MetricName, Attributes, TimeUnix, Value) VALUES\n" +
+		"    ('" + gaugeMetric + "', map('series', 'a'), toDateTime64('2026-01-01 00:01:00', 9), 100.0),\n" +
+		"    ('" + gaugeMetric + "', map('series', 'a'), toDateTime64('2026-01-01 00:02:00', 9), 200.0);\n"
+	fixture := newChDBFixture(t, seed)
+	s := schema.DefaultOTelMetrics()
+	evalTS := time.Date(2026, 1, 1, 0, 2, 0, 0, time.UTC)
+
+	query := "(" + histMetric + " and on(series) " + gaugeMetric + ")[2m:1m]"
+	sqlStr, args := lowerAndEmit(t, query, s, evalTS)
+
+	rows := subqHistQueryRows(t, fixture, sqlStr, args)
+	if len(rows) != 2 {
+		t.Fatalf("%s: got %d rows, want 2 (one per subquery anchor, both matched by the gauge side) — a still-corrupted lowering would report the wrong shape or placeholder values here: %+v", query, len(rows), rows)
+	}
+	anchor1 := subqHistRowAt(t, rows, "a", time.Date(2026, 1, 1, 0, 1, 0, 0, time.UTC))
+	if anchor1.cnt != 2 || anchor1.sum != 4.0 || anchor1.bucket1 != 6 {
+		t.Errorf("%s: anchor 00:01 = %+v, want Count=2 Sum=4 Bucket1=6 (the histogram side's own real payload)", query, anchor1)
+	}
+	anchor2 := subqHistRowAt(t, rows, "a", time.Date(2026, 1, 1, 0, 2, 0, 0, time.UTC))
+	if anchor2.cnt != 3 || anchor2.sum != 9.0 || anchor2.bucket1 != 12 {
+		t.Errorf("%s: anchor 00:02 = %+v, want Count=3 Sum=9 Bucket1=12 (the histogram side's own real payload)", query, anchor2)
+	}
+}
+
+// TestSubqueryUnlessHistogramFloatPerAnchor_ChDB proves the join is
+// evaluated PER SUBQUERY ANCHOR, not once over the whole window: the gauge
+// side only has a sample at the SECOND anchor, so `<hist> unless on(series)
+// <gauge>` must keep the histogram row at the FIRST anchor (no matching
+// gauge sample there) and drop it at the SECOND (a matching gauge sample
+// exists). A silently-corrupted lowering that fell through to the raw
+// four-column Sample quartet could not reproduce this per-anchor split at
+// all — this is the "verify the ACTUAL data" proof, not merely "no error".
+func TestSubqueryUnlessHistogramFloatPerAnchor_ChDB(t *testing.T) {
+	const histMetric = "subq_unless_exp_hist"
+	const gaugeMetric = "subq_unless_gauge"
+	seed := subqHistDDL +
+		"INSERT INTO otel_metrics_exponential_histogram " +
+		"(MetricName, Attributes, TimeUnix, Count, Sum, Scale, ZeroCount, PositiveOffset, PositiveBucketCounts, NegativeOffset, NegativeBucketCounts) VALUES\n" +
+		"    ('" + histMetric + "', map('series', 'a'), toDateTime64('2026-01-01 00:01:00', 9), 2, 4.0, 0, 0, 0, [6], 0, []),\n" +
+		"    ('" + histMetric + "', map('series', 'a'), toDateTime64('2026-01-01 00:02:00', 9), 3, 9.0, 0, 0, 0, [12], 0, []);\n" +
+		subqSetOpGaugeDDL +
+		"INSERT INTO otel_metrics_gauge (MetricName, Attributes, TimeUnix, Value) VALUES\n" +
+		"    ('" + gaugeMetric + "', map('series', 'a'), toDateTime64('2026-01-01 00:02:00', 9), 200.0);\n"
+	fixture := newChDBFixture(t, seed)
+	s := schema.DefaultOTelMetrics()
+	evalTS := time.Date(2026, 1, 1, 0, 2, 0, 0, time.UTC)
+
+	query := "(" + histMetric + " unless on(series) " + gaugeMetric + ")[2m:1m]"
+	sqlStr, args := lowerAndEmit(t, query, s, evalTS)
+
+	rows := subqHistQueryRows(t, fixture, sqlStr, args)
+	if len(rows) != 1 {
+		t.Fatalf("%s: got %d rows, want exactly 1 (only the 00:01 anchor, where the gauge side has no matching sample): %+v", query, len(rows), rows)
+	}
+	got := subqHistRowAt(t, rows, "a", time.Date(2026, 1, 1, 0, 1, 0, 0, time.UTC))
+	if got.cnt != 2 || got.sum != 4.0 || got.bucket1 != 6 {
+		t.Errorf("%s: surviving anchor 00:01 = %+v, want Count=2 Sum=4 Bucket1=6", query, got)
+	}
+	for _, r := range rows {
+		if r.ts == time.Date(2026, 1, 1, 0, 2, 0, 0, time.UTC).Unix() {
+			t.Errorf("%s: anchor 00:02 must be DROPPED (gauge side has a matching series there) but a row survived: %+v", query, r)
+		}
+	}
+}
+
+// TestSubqueryMixedOrAndBare_ChDB proves the "third wrapper family" the
+// issue names: a subquery's own inner is a mixed float/histogram `or`
+// itself wrapped by a further `and` — `((<hist> or <other-gauge>) and
+// on(series) <filter-gauge>)[range:step]`. `filter-gauge` only has a
+// sample for the histogram side's series ("a"), so the outer `and` must
+// preserve the histogram-arm row (real payload intact) while dropping the
+// mixed-or's own float-arm row (series "b", no matching filter sample) —
+// proving a genuinely [chplan.MixedRowShape] subquery inner composes
+// through this shape without collapsing to the placeholder Value column.
+func TestSubqueryMixedOrAndBare_ChDB(t *testing.T) {
+	const histMetric = "subq_mixedand_exp_hist"
+	const orGaugeMetric = "subq_mixedand_or_gauge"
+	const filterGaugeMetric = "subq_mixedand_filter_gauge"
+	seed := subqHistDDL +
+		"INSERT INTO otel_metrics_exponential_histogram " +
+		"(MetricName, Attributes, TimeUnix, Count, Sum, Scale, ZeroCount, PositiveOffset, PositiveBucketCounts, NegativeOffset, NegativeBucketCounts) VALUES\n" +
+		"    ('" + histMetric + "', map('series', 'a'), toDateTime64('2026-01-01 00:01:00', 9), 2, 4.0, 0, 0, 0, [6], 0, []);\n" +
+		subqSetOpGaugeDDL +
+		"INSERT INTO otel_metrics_gauge (MetricName, Attributes, TimeUnix, Value) VALUES\n" +
+		"    ('" + orGaugeMetric + "', map('series', 'b'), toDateTime64('2026-01-01 00:01:00', 9), 50.0),\n" +
+		"    ('" + filterGaugeMetric + "', map('series', 'a'), toDateTime64('2026-01-01 00:01:00', 9), 1.0);\n"
+	fixture := newChDBFixture(t, seed)
+	s := schema.DefaultOTelMetrics()
+	evalTS := time.Date(2026, 1, 1, 0, 1, 0, 0, time.UTC)
+
+	query := "((" + histMetric + " or " + orGaugeMetric + ") and on(series) " + filterGaugeMetric + ")[1m:1m]"
+	sqlStr, args := lowerAndEmit(t, query, s, evalTS)
+
+	histRows := subqHistQueryRows(t, fixture, sqlStr, args)
+	var gotHist bool
+	for _, r := range histRows {
+		if r.series == "a" {
+			gotHist = true
+			if r.cnt != 2 || r.sum != 4.0 || r.bucket1 != 6 {
+				t.Errorf("%s: histogram-arm row = %+v, want Count=2 Sum=4 Bucket1=6 (the real payload, not the placeholder Value column)", query, r)
+			}
+		}
+		if r.series == "b" {
+			t.Errorf("%s: float-arm row for series b must be DROPPED by the outer `and` (no matching filter sample) but survived: %+v", query, r)
+		}
+	}
+	if !gotHist {
+		t.Fatalf("%s: no histogram-arm row for series a; got %+v", query, histRows)
+	}
+}

--- a/internal/promql/subquery_and_unless_mixed_histogram_outer_test.go
+++ b/internal/promql/subquery_and_unless_mixed_histogram_outer_test.go
@@ -1,0 +1,117 @@
+package promql_test
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/prometheus/prometheus/promql/parser"
+
+	"github.com/tsouza/cerberus/internal/promql"
+	"github.com/tsouza/cerberus/internal/schema"
+)
+
+// TestOuterRangeFnOverAndUnlessMixedSubquery_CleanRejection proves that
+// cerberus issue #2589's fix, once lowerSubqueryOverBinary stops
+// discarding a histogram/mixed-shaped `and`/`or`/`unless` subquery inner,
+// makes the PRE-EXISTING histogram-shape guard in
+// lowerOuterRangeFnOverSubquery newly REACHABLE for this shape — turning
+// what used to be a silent wrong answer (rate() folding over a meaningless
+// placeholder Value column with no error at all) into a clean, honest
+// rejection instead, for every outer range-vector function reference
+// itself defines no real histogram semantics for.
+//
+// Before this fix, lowerSubqueryOverBinary's unconditional
+// subqueryAnchorShape wrap meant this guard could never see a
+// Histogram/MixedRowShape node for this AST shape in the first place —
+// chplan.RowShapeOf(inner) always answered SampleRowShape (the corrupted
+// four-column reprojection), so the guard fell through silently.
+func TestOuterRangeFnOverAndUnlessMixedSubquery_CleanRejection(t *testing.T) {
+	s := schema.DefaultOTelMetrics()
+	p := parser.NewParser(parser.Options{EnableExperimentalFunctions: true})
+	evalTS := time.Date(2026, 1, 1, 0, 2, 0, 0, time.UTC)
+
+	// demo_latency_exp_hist / demo_num_cpus are the real seeded metric
+	// names (compatibility/prometheus/cmd/seed/main.go) — LowerAt performs
+	// no data access, but using the real names keeps this test's query
+	// shape identical to what a real compat-lane probe would send.
+	for _, tc := range []struct {
+		name  string
+		query string
+	}{
+		{"and", "rate((demo_latency_exp_hist and on(instance) demo_num_cpus)[5m:1m])"},
+		{"unless", "rate((demo_latency_exp_hist unless on(instance) demo_num_cpus)[5m:1m])"},
+		{"or_wrapped_by_and", "rate(((demo_latency_exp_hist or demo_num_cpus) and on(instance) demo_num_cpus)[5m:1m])"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			expr, err := p.ParseExpr(tc.query)
+			if err != nil {
+				t.Fatalf("ParseExpr(%q): %v", tc.query, err)
+			}
+			_, err = promql.LowerAt(context.Background(), expr, s, evalTS, evalTS)
+			if err == nil {
+				t.Fatalf("%s: LowerAt succeeded, want a clean rejection (rate has no real histogram semantics per reference Prometheus's own promql/functions.go)", tc.query)
+			}
+			const want = "rate over a subquery wrapping a native-histogram-valued shape is unsupported"
+			if !strings.Contains(err.Error(), want) {
+				t.Errorf("%s: error = %q, want it to contain %q", tc.query, err.Error(), want)
+			}
+		})
+	}
+}
+
+// TestOuterFloatOnlyDropFnOverAndUnlessMixedSubquery_Composes proves the
+// OTHER half of lowerOuterRangeFnOverSubquery's existing histogram-shape
+// guard also becomes reachable, and answers correctly (not merely
+// "doesn't error"): max_over_time is one of the eleven functions reference
+// Prometheus itself defines no histogram semantics for
+// (histogramSubqueryFloatOnlyDropFunc), so it already has a dedicated
+// dropExpHistogramSamples fold — this test proves that fold now actually
+// runs for the and/unless-mixed subquery-inner shape instead of the
+// generic-lower path being unreachable before this fix ever let it get
+// this far.
+func TestOuterFloatOnlyDropFnOverAndUnlessMixedSubquery_Composes(t *testing.T) {
+	s := schema.DefaultOTelMetrics()
+	p := parser.NewParser(parser.Options{EnableExperimentalFunctions: true})
+	evalTS := time.Date(2026, 1, 1, 0, 2, 0, 0, time.UTC)
+
+	query := "max_over_time((demo_latency_exp_hist and on(instance) demo_num_cpus)[5m:1m])"
+	expr, err := p.ParseExpr(query)
+	if err != nil {
+		t.Fatalf("ParseExpr(%q): %v", query, err)
+	}
+	plan, err := promql.LowerAt(context.Background(), expr, s, evalTS, evalTS)
+	if err != nil {
+		t.Fatalf("LowerAt(%q): %v (want a successful drop-and-empty composition, matching reference's own \"histogram(s) ignored\" behaviour for max_over_time)", query, err)
+	}
+	if plan == nil {
+		t.Fatalf("LowerAt(%q): got nil plan with nil error", query)
+	}
+}
+
+// TestSubqueryOverBinary_HistogramSetOp_NoEvalAnchorRejects proves the
+// symmetric guard in lowerSubqueryOverBinary's own !ok (no query eval-time
+// context) branch: a bare Lower() call — never a real HTTP entry point,
+// see subqueryHasEvalAnchor's doc — cannot resolve the per-anchor grid a
+// histogram/mixed-shaped and/or/unless composition needs, so it must
+// reject cleanly rather than fall through to wrapSubqueryIdentity's own
+// identical lossy Sample-quartet reprojection.
+func TestSubqueryOverBinary_HistogramSetOp_NoEvalAnchorRejects(t *testing.T) {
+	s := schema.DefaultOTelMetrics()
+	p := parser.NewParser(parser.Options{EnableExperimentalFunctions: true})
+
+	query := "(demo_latency_exp_hist and on(instance) demo_num_cpus)[5m:1m]"
+	expr, err := p.ParseExpr(query)
+	if err != nil {
+		t.Fatalf("ParseExpr(%q): %v", query, err)
+	}
+	_, err = promql.Lower(context.Background(), expr, s)
+	if err == nil {
+		t.Fatalf("%s: Lower (no eval anchor) succeeded, want a clean rejection", query)
+	}
+	const want = "requires query eval-time context"
+	if !strings.Contains(err.Error(), want) {
+		t.Errorf("%s: error = %q, want it to contain %q", query, err.Error(), want)
+	}
+}

--- a/test/rejection-parity/catalogue/internal__promql__subquery.go__lowerSubqueryOverBinary.json
+++ b/test/rejection-parity/catalogue/internal__promql__subquery.go__lowerSubqueryOverBinary.json
@@ -1,0 +1,28 @@
+{
+  "entries": [
+    {
+      "head": "promql",
+      "site": "internal/promql/subquery.go:lowerSubqueryOverBinary#1c929908",
+      "message": "promql: histogram-valued subquery set operator requires query eval-time context (use LowerAt)",
+      "class": "internal",
+      "rationale": "query handlers always supply evaluation context through LowerAt or LowerAtRange; only the raw test and tooling Lower entry can omit it, matching lowerExpHistogramRangeFnOverSubquery's identical eval-time guard",
+      "evidence": {
+        "guard": [
+          "past returning if err != nil",
+          "past returning if err != nil",
+          "if shape := chplan.RowShapeOf(inner); shape == chplan.HistogramRowShape || shape == chplan.MixedRowShape"
+        ],
+        "callers": [
+          "lowerSubquery",
+          "lowerSubqueryInnerMatrix"
+        ],
+        "cited": [
+          "Lower",
+          "LowerAt",
+          "LowerAtRange",
+          "lowerExpHistogramRangeFnOverSubquery"
+        ]
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

- `lowerSubqueryOverBinary` (`internal/promql/subquery.go`) unconditionally reprojected `(<vec> op <vec>)[range:step]` through `subqueryAnchorShape`'s lossy four-column Sample quartet — even when the inner `and`/`or`/`unless` between a histogram-valued (or mixed float/histogram) operand and a plain float operand had already lowered to a genuine `chplan.HistogramRowShape` / `chplan.MixedRowShape` node via the generic `lowerBinary` → `lowerVectorSetOp` → `lowerVectorSetOpOperand` path. An outer range-vector function (`rate(...)`, etc.) then folded over the resulting placeholder `Value` column with **no error at all** — silent wrong-answer data corruption, the same class #2543 fixed for the bare-subquery-inner case.
- Fix: give `lowerSubqueryOverBinary` the same `chplan.RowShapeOf`-gated guard `lowerHistogramNativeSubqueryInner` already applies to its own result — a Histogram/Mixed-shaped inner is returned as-is instead of being routed through the lossy reprojection. Applied symmetrically to the rare no-eval-anchor branch (`wrapSubqueryIdentity`), which has the identical hazard and no sound alternative (a bare `Lower()` call with no query eval-time context — never a real HTTP entry point).
- Net effect:
  - **Bare subquery, no outer wrapper** (`(<hist> and/or/unless <float>)[range:step]` posted directly, or nested under anything that already reads a Histogram/Mixed shape) — now composes **correctly end to end**, verified against real chDB execution including a genuine per-anchor `unless` filtering proof.
  - **Outer-wrapped by a range-vector function reference defines no real histogram semantics for** (`rate`, `increase`, `count_over_time`, etc.) — the pre-existing histogram-shape guard in `lowerOuterRangeFnOverSubquery` becomes newly *reachable* for this shape and now returns a clean, honest rejection instead of the silent corruption.
  - **Outer-wrapped by a float-only-drop function** (`max_over_time`, `min_over_time`, etc.) — composes correctly for free via the existing `dropExpHistogramSamples` fold, matching reference's own "histogram(s) ignored" empty-result semantics.

## Verification

- New chDB tests (`internal/promql/subquery_and_unless_mixed_histogram_chdb_test.go`) prove real data correctness against actual ClickHouse execution, not just "no error":
  - `TestSubqueryAndHistogramFloatBare_ChDB` — pure histogram-vs-float `and` (issue #2337 semi-join shape).
  - `TestSubqueryUnlessHistogramFloatPerAnchor_ChDB` — proves the join is evaluated **per subquery anchor**, not once over the whole window (the float side only matches at one of two anchors; the histogram row survives at exactly the other).
  - `TestSubqueryMixedOrAndBare_ChDB` — the "third wrapper family" the issue names: a mixed `or` itself wrapped by a further `and`.
- New unit tests (`internal/promql/subquery_and_unless_mixed_histogram_outer_test.go`):
  - Proves `rate(...)` over this shape now cleanly rejects with a clear message instead of silently succeeding.
  - Proves `max_over_time(...)` over this shape composes successfully (the float-only-drop family).
  - Proves the no-eval-anchor branch also rejects cleanly rather than falling through to the identical lossy reprojection hazard.
- Confirmed the new chDB tests actually catch the regression: reverted the fix locally and reran them — they fail (ClickHouse `Unknown expression identifier` against the discarded histogram columns) before the fix, pass after.
- Rejection-parity catalogue regenerated and curated (`CERBERUS_UPDATE_INVENTORY=1 go test -run TestCatalogueIsRegenerable ./test/rejection-parity/...`, run twice after hand-curating the new site's `class`/`rationale`) for the one new error-construction site in the no-eval-anchor branch; `go test ./test/rejection-parity/...` passes.
- `go build ./...`, `go vet ./...`, `gofumpt -extra -l .` / `goimports -local github.com/tsouza/cerberus -l .` clean, `node .github/scripts/forbid-sql-raw.mjs` clean.
- `go test -race ./internal/promql/...` passes; narrowed `TestLower/setop_or_subquery_name*` (the two existing spec fixtures nearest this code path) still pass byte-for-byte, confirming the plain-float subquery set-op shape is untouched.

Closes #2589
