### PR TITLE
fix(promql): retry count_over_time/present_over_time exp-histogram recognizer under nested wrappers

### DIFF
--- a/internal/promql/histogram_native_count_present_unary_chdb_test.go
+++ b/internal/promql/histogram_native_count_present_unary_chdb_test.go
@@ -1,0 +1,134 @@
+//go:build chdb
+
+// chDB-backed proof that count_over_time()/present_over_time() over an
+// exp-histogram selector, when wrapped by unary `-`/`+` (cerberus issue
+// #2591) — or by any other wrapper that reaches the call through the
+// generic [promql.lower] dispatcher rather than as the literal query root —
+// lower to valid SQL and EXECUTE against real ClickHouse reporting the
+// correct FLOAT value, rather than hard-rejecting via
+// expHistogramSelectorRouting's catch-all.
+//
+// One series (service="checkout") carries three samples inside the [5m]
+// window evaluated at nestedCountPresentEvalTS, so:
+//   - count_over_time(...) answers 3 (a genuine in-window row count).
+//   - present_over_time(...) answers 1 (reference never counts beyond
+//     existence).
+//
+// Each case pins the SAME per-series count/presence answer a bare,
+// unwrapped count_over_time()/present_over_time() query already answers
+// correctly (cerberus issue #2480; this issue's fix does not touch that
+// path) run through the wrapper's own arithmetic — mirroring
+// histogram_native_resets_changes_count_nested_chdb_test.go's own template
+// for the sibling count()/group() nested-retry fix (cerberus issue #2549).
+package promql_test
+
+import (
+	"context"
+	"math"
+	"testing"
+	"time"
+
+	"github.com/prometheus/prometheus/promql/parser"
+
+	"github.com/tsouza/cerberus/internal/chsql"
+	"github.com/tsouza/cerberus/internal/promql"
+	"github.com/tsouza/cerberus/internal/schema"
+	"github.com/tsouza/cerberus/internal/testsql"
+)
+
+const (
+	nestedCountPresentMetric = "nested_count_present_probe_exp_hist"
+)
+
+var nestedCountPresentSeed = "" +
+	"CREATE OR REPLACE TABLE otel_metrics_exponential_histogram (" +
+	"`MetricName` String, `Attributes` Map(String, String), " +
+	"`ResourceAttributes` Map(String, String) DEFAULT map(), `ServiceName` LowCardinality(String) DEFAULT '', " +
+	"`TimeUnix` DateTime64(9), " +
+	"`Count` UInt64, `Sum` Float64, `Scale` Int32, `ZeroCount` UInt64, " +
+	"`PositiveOffset` Int32, `PositiveBucketCounts` Array(UInt64), " +
+	"`NegativeOffset` Int32, `NegativeBucketCounts` Array(UInt64)" +
+	") ENGINE = MergeTree ORDER BY (`MetricName`, `Attributes`, `TimeUnix`);\n" +
+	"INSERT INTO otel_metrics_exponential_histogram " +
+	"(MetricName, Attributes, TimeUnix, Count, Sum, Scale, ZeroCount, PositiveOffset, PositiveBucketCounts, NegativeOffset, NegativeBucketCounts) VALUES\n" +
+	"    ('" + nestedCountPresentMetric + "', map('service', 'checkout'), toDateTime64('2026-01-01 00:00:00', 9), 5, 10.0, 0, 0, 0, [5], 0, []),\n" +
+	"    ('" + nestedCountPresentMetric + "', map('service', 'checkout'), toDateTime64('2026-01-01 00:01:00', 9), 8, 16.0, 0, 0, 0, [8], 0, []),\n" +
+	"    ('" + nestedCountPresentMetric + "', map('service', 'checkout'), toDateTime64('2026-01-01 00:02:00', 9), 3, 6.0, 0, 0, 0, [3], 0, []);\n"
+
+// nestedCountPresentEvalTS sits just after the window's last sample
+// (00:02:00), with the [5m] range comfortably covering all three samples.
+var nestedCountPresentEvalTS = time.Date(2026, 1, 1, 0, 2, 5, 0, time.UTC)
+
+func TestLower_ExpHistogram_CountPresentUnaryNested_ChDB(t *testing.T) {
+	fixture := newChDBFixture(t, nestedCountPresentSeed)
+	s := schema.DefaultOTelMetrics()
+	p := parser.NewParser(parser.Options{EnableExperimentalFunctions: true})
+
+	countQ := "count_over_time(" + nestedCountPresentMetric + "{service=\"checkout\"}[5m])"
+	presentQ := "present_over_time(" + nestedCountPresentMetric + "{service=\"checkout\"}[5m])"
+
+	cases := []struct {
+		name  string
+		query string
+		want  float64
+	}{
+		// This issue's own two trigger queries, reproduced against the
+		// seeded fixture (the issue's own body uses demo_latency_exp_hist,
+		// only representative — this package's chdb tests seed their own
+		// per-file metric).
+		{"unary_minus_count_over_time", "-" + countQ, -3},
+		{"unary_minus_present_over_time", "-" + presentQ, -1},
+		// Unary `+` is the identity case (cerberus issue #2583's own
+		// unaryOverExpHistogram doc) — proves the retry serves BOTH
+		// UnaryExpr operators, not just SUB.
+		{"unary_plus_count_over_time", "+" + countQ, 3},
+		{"unary_plus_present_over_time", "+" + presentQ, 1},
+		// A double wrapper (unary minus THEN scalar arithmetic) and a
+		// non-unary wrapper (sum/abs), proving [lowerRangeVectorCall]'s
+		// retry — added generically, not unary-specifically — closes the
+		// gap for every wrapper that reaches the call through the generic
+		// dispatcher, exactly as the issue's own root-cause note predicts.
+		{"unary_minus_count_times_2", "-" + countQ + " * 2", -6},
+		{"sum_unary_minus_present", "sum(-" + presentQ + ")", -1},
+		{"abs_unary_minus_count", "abs(-" + countQ + ")", 3},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			expr, err := p.ParseExpr(tc.query)
+			if err != nil {
+				t.Fatalf("ParseExpr(%q): %v", tc.query, err)
+			}
+			plan, err := promql.LowerAt(context.Background(), expr, s, nestedCountPresentEvalTS, nestedCountPresentEvalTS)
+			if err != nil {
+				t.Fatalf("LowerAt(%q): unexpected error (this exact nested shape hard-rejected via expHistogramSelectorRouting's catch-all before cerberus issue #2591's fix): %v", tc.query, err)
+			}
+			sqlStr, args, err := chsql.Emit(context.Background(), plan)
+			if err != nil {
+				t.Fatalf("Emit(%q): %v", tc.query, err)
+			}
+
+			rows := fixture.queryOverEmitted(t, "Value", sqlStr, args)
+			defer func() { _ = rows.Close() }()
+
+			n := 0
+			for rows.Next() {
+				n++
+				var v float64
+				if err := rows.Scan(&v); err != nil {
+					t.Fatalf("scan Value: %v", err)
+				}
+				if math.Abs(v-tc.want) > 1e-9 {
+					t.Errorf("query %q: Value = %v, want %v", tc.query, v, tc.want)
+				}
+			}
+			if err := testsql.TolerantRowsErr(rows.Err()); err != nil {
+				t.Fatalf("rows.Err: %v", err)
+			}
+			if n != 1 {
+				t.Fatalf("query %q: got %d rows, want exactly 1", tc.query, n)
+			}
+		})
+	}
+}

--- a/internal/promql/lower.go
+++ b/internal/promql/lower.go
@@ -2810,48 +2810,58 @@ func matrixSelectorArg(c *parser.Call) (*parser.MatrixSelector, *parser.VectorSe
 	return ms, vs, nil
 }
 
+// histogramNativeRangeVectorRetry gives a range-vector call reached through
+// the generic [lower] dispatcher — nested under a wrapper (scalar
+// arithmetic, an aggregation, an instant math function, unary minus...)
+// rather than being the query's own root — the same retry against the
+// native-histogram recognizers [lowerHistogramNativeRoot] already tries at
+// the root. matched reports whether a recognizer claimed the call; when it
+// did not, the caller falls through to its own generic dispatch.
+//
+// resets()/changes() (cerberus issue #2549): every such wrapper's own
+// operand lowering falls back to the generic dispatcher, which reaches
+// [lowerRangeVectorCall] (every resets()/changes() call carries a
+// MatrixSelector argument) before its own switch ever sees it. Both
+// functions already answer a plain FLOAT sample once resolved
+// (histogram_native_resets.go's own doc explains why nothing about them
+// needs the histogram-VALUED family's
+// [lowerExpHistogramArgAsCanonicalFloat] "preserve"/"drop" opt-in) — they
+// just need the same chance to retry as histogram-native that a query's
+// root always had.
+//
+// count_over_time()/present_over_time() (cerberus issue #2591):
+// [lowerHistogramNativeRoot] only tries [countPresentOverExpHistogram]
+// when the call IS the query's own root (or a subquery's own inner). The
+// moment it is wrapped by anything else — unary minus
+// (`-present_over_time(m[5m])`), an aggregation, an instant math function
+// — every such wrapper's own operand lowering falls back to the generic
+// dispatcher, which reaches [lowerRangeVectorCall] before its own switch
+// ever sees it, and that switch has no histogram-aware opt-in for either
+// name — it falls into the generic RangeWindow path and hits
+// [expHistogramSelectorRouting]'s catch-all rejection. Retrying the
+// recognizer here, exactly like [resetsOrChangesOverExpHistogram] above,
+// closes the gap the same way cerberus issue #2549 closed it for
+// count()/group().
+func histogramNativeRangeVectorRetry(c *parser.Call, s schema.Metrics, ctx lowerCtx) (chplan.Node, bool, error) {
+	if shape, ok := resetsOrChangesOverExpHistogram(c, s, ctx); ok {
+		node, err := lowerExpHistogramResetsOrChanges(shape, s, ctx)
+		return node, true, err
+	}
+	if fn, ms, vs, ok := countPresentOverExpHistogram(c, s, ctx); ok {
+		node, err := lowerCountPresentOverExpHistogram(fn, ms, vs, s, ctx)
+		return node, true, err
+	}
+	return nil, false, nil
+}
+
 // lowerRangeVectorCall handles range-vector functions: rate, increase,
 // delta, and the `*_over_time` family. The single argument is a
 // MatrixSelector wrapping a VectorSelector; we lower the VectorSelector
 // and wrap the result in a RangeWindow capturing the function name +
 // range duration.
 func lowerRangeVectorCall(c *parser.Call, s schema.Metrics, ctx lowerCtx) (chplan.Node, error) {
-	// resets()/changes() over a NESTED exp-histogram selector (cerberus
-	// issue #2549): [lowerHistogramNativeRoot] only tries
-	// [resetsOrChangesOverExpHistogram] when the call IS the query's own
-	// root. The moment it is wrapped by anything else — scalar
-	// arithmetic (`resets(m[5m]) * 2`), an aggregation
-	// (`sum(resets(m[5m]))`), an instant math function
-	// (`abs(changes(m[5m]))`) — every such wrapper's own operand lowering
-	// falls back to the generic [lower] dispatcher, which reaches THIS
-	// function (every resets()/changes() call carries a MatrixSelector
-	// argument) before the switch below ever sees it. Both functions
-	// already answer a plain FLOAT sample once resolved
-	// (histogram_native_resets.go's own doc explains why nothing about
-	// them needs the histogram-VALUED family's
-	// [lowerExpHistogramArgAsCanonicalFloat] "preserve"/"drop" opt-in) —
-	// they just need the same chance to retry as histogram-native that a
-	// query's root always had.
-	if shape, ok := resetsOrChangesOverExpHistogram(c, s, ctx); ok {
-		return lowerExpHistogramResetsOrChanges(shape, s, ctx)
-	}
-	// count_over_time()/present_over_time() over a NESTED exp-histogram
-	// selector (cerberus issue #2591): [lowerHistogramNativeRoot] only
-	// tries [countPresentOverExpHistogram] when the call IS the query's
-	// own root (or a subquery's own inner). The moment it is wrapped by
-	// anything else — unary minus (`-present_over_time(m[5m])`), an
-	// aggregation, an instant math function — every such wrapper's own
-	// operand lowering falls back to the generic [lower] dispatcher, which
-	// reaches THIS function (both functions carry a MatrixSelector
-	// argument) before the switch below ever sees it, and the switch has
-	// no histogram-aware opt-in for either name — it falls into the
-	// generic RangeWindow path below and hits
-	// [expHistogramSelectorRouting]'s catch-all rejection. Retrying the
-	// recognizer here, exactly like [resetsOrChangesOverExpHistogram] just
-	// above, closes the gap the same way cerberus issue #2549 closed it
-	// for count()/group().
-	if fn, ms, vs, ok := countPresentOverExpHistogram(c, s, ctx); ok {
-		return lowerCountPresentOverExpHistogram(fn, ms, vs, s, ctx)
+	if node, matched, err := histogramNativeRangeVectorRetry(c, s, ctx); matched {
+		return node, err
 	}
 	switch c.Func.Name {
 	case "predict_linear":

--- a/internal/promql/lower.go
+++ b/internal/promql/lower.go
@@ -2835,6 +2835,24 @@ func lowerRangeVectorCall(c *parser.Call, s schema.Metrics, ctx lowerCtx) (chpla
 	if shape, ok := resetsOrChangesOverExpHistogram(c, s, ctx); ok {
 		return lowerExpHistogramResetsOrChanges(shape, s, ctx)
 	}
+	// count_over_time()/present_over_time() over a NESTED exp-histogram
+	// selector (cerberus issue #2591): [lowerHistogramNativeRoot] only
+	// tries [countPresentOverExpHistogram] when the call IS the query's
+	// own root (or a subquery's own inner). The moment it is wrapped by
+	// anything else — unary minus (`-present_over_time(m[5m])`), an
+	// aggregation, an instant math function — every such wrapper's own
+	// operand lowering falls back to the generic [lower] dispatcher, which
+	// reaches THIS function (both functions carry a MatrixSelector
+	// argument) before the switch below ever sees it, and the switch has
+	// no histogram-aware opt-in for either name — it falls into the
+	// generic RangeWindow path below and hits
+	// [expHistogramSelectorRouting]'s catch-all rejection. Retrying the
+	// recognizer here, exactly like [resetsOrChangesOverExpHistogram] just
+	// above, closes the gap the same way cerberus issue #2549 closed it
+	// for count()/group().
+	if fn, ms, vs, ok := countPresentOverExpHistogram(c, s, ctx); ok {
+		return lowerCountPresentOverExpHistogram(fn, ms, vs, s, ctx)
+	}
 	switch c.Func.Name {
 	case "predict_linear":
 		return lowerPredictLinear(c, s, ctx)


### PR DESCRIPTION
## Summary

- `present_over_time()`/`count_over_time()` over an exp-histogram selector lowered correctly at the query root but hard-rejected via `expHistogramSelectorRouting`'s catch-all the moment they were wrapped by anything else — unary minus (`-present_over_time(m[5m])`), `sum()`, `abs()`, and so on — because `lowerHistogramNativeRoot` only tries `countPresentOverExpHistogram` when the call IS the query's own root (or a subquery's own inner), and nothing retried it when the generic `lower()` dispatcher reached `lowerRangeVectorCall` for a nested call.
- Retries `countPresentOverExpHistogram` inside `lowerRangeVectorCall`, mirroring the identical nested-retry that function already does for `resetsOrChangesOverExpHistogram` (cerberus issue #2549) — the same pattern, applied to the sibling recognizer this issue names.
- This is a general fix, not unary-specific: it closes the gap for every wrapper that reaches the call through the generic dispatcher (unary `+`/`-`, `sum()`, `abs()`, arithmetic, ...), matching the issue's own root-cause prediction.

## Test plan

- [x] New chDB-backed regression test `internal/promql/histogram_native_count_present_unary_chdb_test.go` (`TestLower_ExpHistogram_CountPresentUnaryNested_ChDB`) seeds a real exp-histogram series and asserts the correct FLOAT value for `-count_over_time(...)`, `-present_over_time(...)`, unary `+` (identity), a double wrapper (`-count_over_time(...) * 2`), `sum(-present_over_time(...))`, and `abs(-count_over_time(...))`.
- [x] Verified the test fails with the exact `expHistogramSelectorRouting` catch-all rejection when the `lower.go` fix is reverted (confirms it exercises the bug), and passes with the fix.
- [x] `go build ./internal/promql/...`
- [x] `go test ./internal/promql/...` (non-chdb lane)
- [x] `go test -tags chdb ./internal/promql/...` (full chdb-tagged package lane)
- [x] `gofumpt -l` clean on changed files
- [x] `node .github/scripts/forbid-sql-raw.mjs` clean
- [x] `CERBERUS_UPDATE_INVENTORY=1 go test -run TestCatalogueIsRegenerable ./test/rejection-parity/...` run twice — no catalogue drift (this fix adds a new success path ahead of an existing rejection site rather than altering any pinned rejection message)

Closes #2591

🤖 Generated with [Claude Code](https://claude.com/claude-code)