### PR TITLE
fix(promql): retry the drop-family recognizer for a subquery's own inner

### DIFF
--- a/internal/promql/histogram_native_subquery_drop_family_inner_test.go
+++ b/internal/promql/histogram_native_subquery_drop_family_inner_test.go
@@ -1,0 +1,97 @@
+package promql_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/tsouza/cerberus/internal/chplan"
+	"github.com/tsouza/cerberus/internal/promql"
+	"github.com/tsouza/cerberus/internal/schema"
+)
+
+// TestLower_ExpHistogram_DropFamilyEmptyOverSubqueryInner pins cerberus
+// issue #2590: the eleven float-only range-vector reducers
+// [dropExpHistogramSamplesForRangeVector] (range_fns.go, cerberus issue
+// #2528) already answers empty for over a BARE histogram selector
+// (`max_over_time(latency_exp_hist[5m])`) hard-rejected instead when the
+// SAME call became a bare subquery's own inner expression
+// (`max_over_time(latency_exp_hist[5m])[10m:1m]`).
+// [lowerHistogramNativeSubqueryInner] (subquery.go, cerberus issue #2543)
+// gave a subquery's inner the same first-chance histogram-native routing a
+// query's root gets, but only ever retried the PRESERVE family
+// ([lowerHistogramNativeRoot]) — the DROP family's range-vector-Call shape
+// never had a matching recogniser in that chain, so
+// [lowerSubqueryOverCall]'s own generic RangeWindow-reducer path took over
+// and called lowerVectorSelector directly on the bare exp-histogram
+// selector, which expHistogramSelectorRouting's catch-all rejects. This is
+// the SUBQUERY-INNER sibling of cerberus issue #2563's mirror-image
+// "outer wraps subquery" fix pinned by
+// TestLower_ExpHistogram_DropFamilyEmptyOverSubquery just above.
+func TestLower_ExpHistogram_DropFamilyEmptyOverSubqueryInner(t *testing.T) {
+	t.Parallel()
+
+	s := schema.DefaultOTelMetrics()
+	start := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	end := start.Add(time.Hour)
+
+	for _, tc := range []struct {
+		name  string
+		query string
+	}{
+		{name: "max_over_time", query: `max_over_time(latency_exp_hist[5m])[10m:1m]`},
+		{name: "min_over_time", query: `min_over_time(latency_exp_hist[5m])[10m:1m]`},
+		{name: "stddev_over_time", query: `stddev_over_time(latency_exp_hist[5m])[10m:1m]`},
+		{name: "stdvar_over_time", query: `stdvar_over_time(latency_exp_hist[5m])[10m:1m]`},
+		{name: "mad_over_time", query: `mad_over_time(latency_exp_hist[5m])[10m:1m]`},
+		{name: "deriv", query: `deriv(latency_exp_hist[5m])[10m:1m]`},
+		{name: "ts_of_max_over_time", query: `ts_of_max_over_time(latency_exp_hist[5m])[10m:1m]`},
+		{name: "ts_of_min_over_time", query: `ts_of_min_over_time(latency_exp_hist[5m])[10m:1m]`},
+		{name: "quantile_over_time", query: `quantile_over_time(0.5, latency_exp_hist[5m])[10m:1m]`},
+		{name: "predict_linear", query: `predict_linear(latency_exp_hist[5m], 60)[10m:1m]`},
+		{name: "holt_winters", query: `double_exponential_smoothing(latency_exp_hist[5m], 0.5, 0.5)[10m:1m]`},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			expr := parseExprExp(t, tc.query)
+
+			plan, err := promql.LowerAt(context.Background(), expr, s, end, end)
+			if err != nil {
+				t.Fatalf("lower(%q) instant: %v", tc.query, err)
+			}
+			if got := chplan.RowShapeOf(plan); got != chplan.SampleRowShape {
+				t.Errorf("lower(%q) instant RowShape = %s, want %s", tc.query, got, chplan.SampleRowShape)
+			}
+
+			rplan, err := promql.LowerAtRange(context.Background(), expr, s, start, end, time.Minute)
+			if err != nil {
+				t.Fatalf("lower(%q) range: %v", tc.query, err)
+			}
+			if got := chplan.RowShapeOf(rplan); got != chplan.SampleRowShape {
+				t.Errorf("lower(%q) range RowShape = %s, want %s", tc.query, got, chplan.SampleRowShape)
+			}
+		})
+	}
+}
+
+// TestLower_ExpHistogram_DropFamilyInnerOverSubquery_ScalarParamStillValidated
+// mirrors TestLower_ExpHistogram_DropFamilyOverSubquery_ScalarParamStillValidated
+// for the subquery-INNER composition: holt_winters /
+// double_exponential_smoothing validates its smoothing factors' (0, 1)
+// domain BEFORE ever walking the window's samples, so an out-of-domain
+// factor must still surface as a lowering error even though the window
+// this query's subquery inner resolves to is all-histogram and would
+// otherwise answer empty.
+func TestLower_ExpHistogram_DropFamilyInnerOverSubquery_ScalarParamStillValidated(t *testing.T) {
+	t.Parallel()
+
+	s := schema.DefaultOTelMetrics()
+	end := time.Date(2026, 1, 1, 1, 0, 0, 0, time.UTC)
+
+	query := `double_exponential_smoothing(latency_exp_hist[5m], 1.5, 0.5)[10m:1m]`
+	expr := parseExprExp(t, query)
+	_, err := promql.LowerAt(context.Background(), expr, s, end, end)
+	if err == nil {
+		t.Fatalf("lower(%q): got nil error, want an out-of-domain smoothing-factor rejection", query)
+	}
+}

--- a/internal/promql/subquery.go
+++ b/internal/promql/subquery.go
@@ -149,18 +149,91 @@ func lowerHistogramNativeSubqueryInner(sub *parser.SubqueryExpr, step time.Durat
 	}
 
 	plan, matched, herr := lowerHistogramNativeRoot(innerExpr, s, grid)
+	if matched {
+		if herr != nil {
+			return nil, true, herr
+		}
+		switch chplan.RowShapeOf(plan) {
+		case chplan.HistogramRowShape, chplan.MixedRowShape:
+			return plan, true, nil
+		default:
+			return subqueryAnchorShape(plan, s), true, nil
+		}
+	}
+	// The eleven-function drop-family range-vector reducer vocabulary
+	// (max_over_time, min_over_time, deriv, predict_linear,
+	// double_exponential_smoothing, quantile_over_time, stddev_over_time,
+	// stdvar_over_time, mad_over_time, ts_of_max_over_time,
+	// ts_of_min_over_time) whose OWN MatrixSelector argument is a bare
+	// exp-histogram selector never reaches [lowerHistogramNativeRoot]'s
+	// chain above — none of its recognisers key off a bare *parser.Call
+	// wrapping a MatrixSelector, only [lowerRangeVectorCall] and the
+	// three dedicated range_fns.go lowerers do, via
+	// dropExpHistogramSamplesForRangeVector, and neither is reached from
+	// here. Without this second check, `max_over_time(demo_latency_exp_hist[5m])[10m:1m]`
+	// fell through to [lowerSubqueryOverCall]'s own generic
+	// RangeWindow-reducer path, which calls lowerVectorSelector directly
+	// on the bare selector with no histogram opt-in and hits
+	// expHistogramSelectorRouting's catch-all rejection (cerberus issue
+	// #2590) — the SUBQUERY-INNER sibling of cerberus issue #2563's
+	// [lowerOuterRangeFnOverSubquery] handling for the mirror-image
+	// "outer wraps subquery" composition.
+	if plan, matched, err := dropFamilyRangeVectorCallOverExpHistogramSubqueryInner(innerExpr, s, grid); matched {
+		if err != nil {
+			return nil, true, err
+		}
+		return subqueryAnchorShape(plan, s), true, nil
+	}
+	return nil, false, nil
+}
+
+// dropFamilyRangeVectorCallOverExpHistogramSubqueryInner recognises a
+// SUBQUERY's own inner expression as a bare Call to one of
+// [histogramSubqueryFloatOnlyDropFunc]'s eleven float-only range-vector
+// reducers, wrapping a MatrixSelector argument whose selector is itself
+// a bare exp-histogram metric — see
+// [lowerHistogramNativeSubqueryInner]'s own doc for why this needs a
+// dedicated check rather than composing through
+// [lowerHistogramNativeRoot] (cerberus issue #2590).
+//
+// matched is false whenever expr is not such a Call, its argument count
+// doesn't match the function's own arity (the caller's ordinary
+// [lowerSubqueryOverCall] path then raises the identical arity error
+// itself), or its MatrixSelector argument's selector is not
+// exp-histogram-valued — in every case the caller falls through to its
+// own unchanged lowering.
+func dropFamilyRangeVectorCallOverExpHistogramSubqueryInner(expr parser.Expr, s schema.Metrics, ctx lowerCtx) (chplan.Node, bool, error) {
+	call, ok := peelWrappers(expr).(*parser.Call)
+	if !ok || !histogramSubqueryFloatOnlyDropFunc(call.Func.Name) {
+		return nil, false, nil
+	}
+	arity, matrixArg := subqueryInnerRangeFnShape(call.Func.Name)
+	if len(call.Args) != arity {
+		return nil, false, nil
+	}
+	ms, ok := peelWrappers(call.Args[matrixArg]).(*parser.MatrixSelector)
+	if !ok {
+		return nil, false, nil
+	}
+	node, matched, err := dropExpHistogramSamplesForRangeVector(ms, s, ctx)
 	if !matched {
 		return nil, false, nil
 	}
-	if herr != nil {
-		return nil, true, herr
+	if err != nil {
+		return nil, true, err
 	}
-	switch chplan.RowShapeOf(plan) {
-	case chplan.HistogramRowShape, chplan.MixedRowShape:
-		return plan, true, nil
-	default:
-		return subqueryAnchorShape(plan, s), true, nil
+	// Validate the call's own scalar parameter(s) — predict_linear's
+	// horizon, holt_winters' smoothing factors, quantile_over_time's phi
+	// — before answering empty: reference validates them BEFORE ever
+	// walking the window's samples, mirroring
+	// [lowerOuterRangeFnOverSubquery]'s identical param-before-drop
+	// discipline for the mirror-image composition. A throwaway
+	// RangeWindow absorbs the mutation since nothing downstream reads it
+	// — the result is unconditionally empty either way.
+	if _, _, err := threadOuterRangeFnScalars(call, &chplan.RangeWindow{}, s, ctx); err != nil {
+		return nil, true, err
 	}
+	return node, true, nil
 }
 
 // lowerSubqueryOverUnary — `(-<expr>)[range:step]` / `(+<expr>)[range:step]`.

--- a/internal/promql/subquery_drop_family_histogram_inner_chdb_test.go
+++ b/internal/promql/subquery_drop_family_histogram_inner_chdb_test.go
@@ -1,0 +1,62 @@
+//go:build chdb
+
+// chDB-backed proof that cerberus issue #2590's eleven float-only
+// range-vector functions — max_over_time, min_over_time, stddev_over_time,
+// stdvar_over_time, quantile_over_time, mad_over_time, deriv,
+// predict_linear, double_exponential_smoothing (holt_winters),
+// ts_of_max_over_time, ts_of_min_over_time — execute successfully against
+// real ClickHouse and answer an EMPTY result, rather than
+// expHistogramSelectorRouting's hard rejection, when the function call
+// itself is a bare SUBQUERY's own inner expression
+// (`max_over_time(m[2m])[2m:1m]`) rather than the OUTER wrapper around an
+// already-histogram-native subquery
+// (`max_over_time((m)[2m:1m])`, subquery_drop_family_histogram_chdb_test.go,
+// cerberus issue #2563).
+//
+// Reuses the identical two-sample, histogram-only fixture
+// subqSelectHistFixture already seeds for the SELECT family
+// (subquery_select_histogram_chdb_test.go) and the sibling OUTER-wraps
+// test above — no float samples at all — so every anchor the outer `[2m:1m]`
+// subquery grid evaluates the inner function's own 2m lookback window
+// against is exclusively histogram-valued.
+package promql_test
+
+import (
+	"testing"
+
+	"github.com/tsouza/cerberus/internal/schema"
+)
+
+// TestSubqueryHistogramDropFamilyInner_ChDB executes every one of the
+// eleven float-only reducers as a bare subquery's own inner expression
+// over the shared histogram-only fixture and asserts each answers zero
+// rows rather than a query error.
+func TestSubqueryHistogramDropFamilyInner_ChDB(t *testing.T) {
+	fixture, metric, evalTS := subqSelectHistFixture(t)
+	s := schema.DefaultOTelMetrics()
+
+	for _, tc := range []struct {
+		name  string
+		query string
+	}{
+		{name: "max_over_time", query: "max_over_time(" + metric + "[2m])[2m:1m]"},
+		{name: "min_over_time", query: "min_over_time(" + metric + "[2m])[2m:1m]"},
+		{name: "stddev_over_time", query: "stddev_over_time(" + metric + "[2m])[2m:1m]"},
+		{name: "stdvar_over_time", query: "stdvar_over_time(" + metric + "[2m])[2m:1m]"},
+		{name: "mad_over_time", query: "mad_over_time(" + metric + "[2m])[2m:1m]"},
+		{name: "deriv", query: "deriv(" + metric + "[2m])[2m:1m]"},
+		{name: "ts_of_max_over_time", query: "ts_of_max_over_time(" + metric + "[2m])[2m:1m]"},
+		{name: "ts_of_min_over_time", query: "ts_of_min_over_time(" + metric + "[2m])[2m:1m]"},
+		{name: "quantile_over_time", query: "quantile_over_time(0.5, " + metric + "[2m])[2m:1m]"},
+		{name: "predict_linear", query: "predict_linear(" + metric + "[2m], 60)[2m:1m]"},
+		{name: "holt_winters", query: "double_exponential_smoothing(" + metric + "[2m], 0.5, 0.5)[2m:1m]"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			sqlStr, args := lowerAndEmit(t, tc.query, s, evalTS)
+			got := sampleValueRows(t, fixture, sqlStr, args)
+			if len(got) != 0 {
+				t.Errorf("%s: got %d rows %+v, want 0 (all-histogram window has no float data for reference to answer)", tc.name, len(got), got)
+			}
+		})
+	}
+}

--- a/test/rejection-parity/catalogue/internal__promql__lower.go__expHistogramSelectorRouting.json
+++ b/test/rejection-parity/catalogue/internal__promql__lower.go__expHistogramSelectorRouting.json
@@ -5,7 +5,7 @@
       "site": "internal/promql/lower.go:expHistogramSelectorRouting#bf746b59",
       "message": "promql: %q is an exponential histogram metric; only a bare %q selector, sum()/avg()/count() over one, rate()/increase()/delta()/irate()/idelta()/sum_over_time()/avg_over_time()/resets()/changes() over one, histogram_quantile(), histogram_count(), histogram_sum(), and the %q/%q companion selectors are supported",
       "class": "divergence",
-      "trigger_query": "absent(latency_exp_hist)[10m:1m]",
+      "trigger_query": "absent(demo_latency_exp_hist)[10m:1m]",
       "tracking_issue": 2602,
       "evidence": {
         "guard": [

--- a/test/rejection-parity/catalogue/internal__promql__lower.go__expHistogramSelectorRouting.json
+++ b/test/rejection-parity/catalogue/internal__promql__lower.go__expHistogramSelectorRouting.json
@@ -5,8 +5,8 @@
       "site": "internal/promql/lower.go:expHistogramSelectorRouting#bf746b59",
       "message": "promql: %q is an exponential histogram metric; only a bare %q selector, sum()/avg()/count() over one, rate()/increase()/delta()/irate()/idelta()/sum_over_time()/avg_over_time()/resets()/changes() over one, histogram_quantile(), histogram_count(), histogram_sum(), and the %q/%q companion selectors are supported",
       "class": "divergence",
-      "trigger_query": "max_over_time(demo_latency_exp_hist[5m])[10m:1m]",
-      "tracking_issue": 2590,
+      "trigger_query": "absent(latency_exp_hist)[10m:1m]",
+      "tracking_issue": 2602,
       "evidence": {
         "guard": [
           "past returning if bare, col, hasCompanion := s.HistogramCompanionColumn(metricName); hasCompanion \u0026\u0026 s.IsExpHistogramMetric(bare) \u0026\u0026 s.ExpHistogramTable != \"\"",

--- a/test/rejection-parity/catalogue/internal__promql__subquery.go__threadOuterRangeFnScalars.json
+++ b/test/rejection-parity/catalogue/internal__promql__subquery.go__threadOuterRangeFnScalars.json
@@ -5,13 +5,14 @@
       "site": "internal/promql/subquery.go:threadOuterRangeFnScalars#2b0de462",
       "message": "promql: predict_linear expects 2 arguments, got %d",
       "class": "internal",
-      "rationale": "parser-enforced arity: predict_linear is pinned at two arguments, so the subquery-argument lowering path can never observe a call with a different count",
+      "rationale": "parser-enforced arity: predict_linear is pinned at two arguments, so every one of this site's callers — each gated on the identical arity check before reaching it — can never observe a call with a different count",
       "evidence": {
         "guard": [
           "case \"predict_linear\" of switch outer.Func.Name",
           "if len(outer.Args) != 2"
         ],
         "callers": [
+          "dropFamilyRangeVectorCallOverExpHistogramSubqueryInner",
           "lowerOuterRangeFnOverSubquery",
           "lowerSubqueryOverCall",
           "lowerSubqueryOverCallSubquery"
@@ -23,13 +24,14 @@
       "site": "internal/promql/subquery.go:threadOuterRangeFnScalars#682124f4",
       "message": "promql: quantile_over_time expects 2 arguments, got %d",
       "class": "internal",
-      "rationale": "parser-enforced arity: quantile_over_time is pinned at two arguments, so the subquery-argument lowering path can never observe a call with a different count",
+      "rationale": "parser-enforced arity: quantile_over_time is pinned at two arguments, so every one of this site's callers — each gated on the identical arity check before reaching it — can never observe a call with a different count",
       "evidence": {
         "guard": [
           "case \"quantile_over_time\" of switch outer.Func.Name",
           "if len(outer.Args) != 2"
         ],
         "callers": [
+          "dropFamilyRangeVectorCallOverExpHistogramSubqueryInner",
           "lowerOuterRangeFnOverSubquery",
           "lowerSubqueryOverCall",
           "lowerSubqueryOverCallSubquery"
@@ -41,13 +43,14 @@
       "site": "internal/promql/subquery.go:threadOuterRangeFnScalars#ceef5c3b",
       "message": "promql: holt_winters expects 3 arguments, got %d",
       "class": "internal",
-      "rationale": "parser-enforced arity: double_exponential_smoothing is pinned at three arguments, so the subquery-argument lowering path can never observe a call with a different count",
+      "rationale": "parser-enforced arity: double_exponential_smoothing is pinned at three arguments, so every one of this site's callers — each gated on the identical arity check before reaching it — can never observe a call with a different count",
       "evidence": {
         "guard": [
           "case \"holt_winters\", \"double_exponential_smoothing\" of switch outer.Func.Name",
           "if len(outer.Args) != 3"
         ],
         "callers": [
+          "dropFamilyRangeVectorCallOverExpHistogramSubqueryInner",
           "lowerOuterRangeFnOverSubquery",
           "lowerSubqueryOverCall",
           "lowerSubqueryOverCallSubquery"


### PR DESCRIPTION
## Summary

`lowerHistogramNativeSubqueryInner` gave a bare subquery's own inner expression the
same first-chance histogram-native routing a query's root gets, but only ever
retried the PRESERVE family (`lowerHistogramNativeRoot`). The eleven float-only
drop-family range-vector reducers (`max_over_time`, `min_over_time`, `deriv`,
`predict_linear`, `double_exponential_smoothing`, `quantile_over_time`,
`stddev_over_time`, `stdvar_over_time`, `mad_over_time`, `ts_of_max_over_time`,
`ts_of_min_over_time`) never had a matching recogniser in that chain, so
`max_over_time(demo_latency_exp_hist[5m])[10m:1m]` fell through to the generic
RangeWindow-reducer path and hit `expHistogramSelectorRouting`'s catch-all
rejection.

Adds `dropFamilyRangeVectorCallOverExpHistogramSubqueryInner`, mirroring
`dropExpHistogramSamplesForRangeVector`'s own drop-to-empty semantics and
validating each function's own scalar parameters (`predict_linear`'s horizon,
`holt_winters`'/`double_exponential_smoothing`'s smoothing factors,
`quantile_over_time`'s phi) before answering empty — matching
`lowerOuterRangeFnOverSubquery`'s identical param-before-drop discipline for the
mirror-image "outer wraps subquery" composition (#2563).

Rotates the rejection-parity catalogue's `expHistogramSelectorRouting` entry to
its next live trigger, `absent(latency_exp_hist)[10m:1m]` (tracked separately as
#2602) — found via a systematic sweep of the vendored parser's entire function
table, since this fix and the already-merged #2591 both closed the entry's
previous two triggers.

## Test plan

- [x] New chDB round-trip test: `TestSubqueryHistogramDropFamilyInner_ChDB` — all
      eleven drop-family functions over a bare subquery inner, verified empty
- [x] New unit tests: `TestLower_ExpHistogram_DropFamilyEmptyOverSubqueryInner`,
      `TestLower_ExpHistogram_DropFamilyInnerOverSubquery_ScalarParamStillValidated`
- [x] `TestRejectionTriggersExerciseSites` / `TestCatalogueIsRegenerable` pass with
      the rotated catalogue entry
- [x] `go build ./...`, `gofumpt -extra`, `goimports -local`,
      `node .github/scripts/forbid-sql-raw.mjs` all clean

Closes #2590
