### PR TITLE
fix(test/spec): add a 2-ULP tolerance for pow, same class as atan2

### DIFF
--- a/test/spec/parity_chdb.go
+++ b/test/spec/parity_chdb.go
@@ -266,22 +266,26 @@ const exponentialHistogramMetricSuffix = "_exp_hist"
 // compareValues selects the one comparator appropriate to the expression and
 // its actual seeded storage shape. Native exponential-histogram
 // interpolation and histogram_quantile over a rate()/increase()'d classic
-// bucket selector are the only classes besides atan2 with measured
+// bucket selector are the only classes besides atan2 and pow with measured
 // cross-implementation divergence.
 func compareValues(query, seed string) (func(a, b float64) bool, error) {
 	if atan2QueryPattern.MatchString(query) {
 		return oracle.EqualAtan2Values, nil
-	}
-	hasExponential := strings.Contains(seed, "CREATE TABLE "+exponentialHistogramSeedTable)
-	hasClassic := strings.Contains(seed, "CREATE TABLE "+classicHistogramTable)
-	if !hasExponential && !hasClassic {
-		return oracle.EqualValues, nil
 	}
 
 	p := parser.NewParser(parser.Options{EnableExperimentalFunctions: true})
 	expr, err := p.ParseExpr(query)
 	if err != nil {
 		return nil, fmt.Errorf("parse comparator query: %w", err)
+	}
+	if usesPowOperator(expr) {
+		return oracle.EqualPowValues, nil
+	}
+
+	hasExponential := strings.Contains(seed, "CREATE TABLE "+exponentialHistogramSeedTable)
+	hasClassic := strings.Contains(seed, "CREATE TABLE "+classicHistogramTable)
+	if !hasExponential && !hasClassic {
+		return oracle.EqualValues, nil
 	}
 	if hasExponential && isExponentialHistogramInterpolation(expr) {
 		return oracle.EqualExponentialHistogramInterpolationValues, nil
@@ -290,6 +294,35 @@ func compareValues(query, seed string) (func(a, b float64) bool, error) {
 		return oracle.EqualClassicHistogramRateQuantileValues, nil
 	}
 	return oracle.EqualValues, nil
+}
+
+// usesPowOperator reports whether expr contains PromQL's `^` (pow) binary
+// operator anywhere in its tree — the same "anywhere, at any nesting depth"
+// reach atan2QueryPattern gets from grepping the whole query text.
+//
+// This is detected from the PARSED expression rather than from
+// atan2QueryPattern's plain regexp.MustCompile(`\b...\b`) style, because `^`
+// is not a word: unlike "atan2", which cannot appear inside a PromQL string
+// literal by coincidence in any fixture this repo has, `^` is the standard
+// PromQL/RE2 regex anchor and appears routinely inside a label matcher's
+// regex value, e.g. `up{job=~"^api$"}`. A plain `\^` text match would fire
+// on that anchor and silently relax an unrelated float comparison that has
+// nothing to do with the pow operator — exactly the "broader heuristic"
+// issue #2598's own acceptance criteria says this exception must not
+// become. Walking the already-parsed AST for a `*parser.BinaryExpr` with
+// `Op == parser.POW` finds the actual operator and nothing else, while still
+// being driven purely by the query under evaluation, never by fixture
+// metadata — the same property that makes atan2QueryPattern's detection
+// narrow in the first place (see that var's own doc comment).
+func usesPowOperator(expr parser.Expr) bool {
+	found := false
+	parser.Inspect(expr, func(node parser.Node, _ []parser.Node) error {
+		if bin, ok := node.(*parser.BinaryExpr); ok && bin.Op == parser.POW {
+			found = true
+		}
+		return nil
+	})
+	return found
 }
 
 // isExponentialHistogramInterpolation proves that a complete query result is

--- a/test/spec/parity_comparator_chdb_test.go
+++ b/test/spec/parity_comparator_chdb_test.go
@@ -46,8 +46,11 @@ func TestCompareValues(t *testing.T) {
 		{"composed classic rate quantile stays exact", "histogram_quantile(0.5, rate(latency_bucket[5m])) + up", classicHistogramSeed, base, oneULP, false},
 		{"composed native quantile stays exact", "histogram_quantile(0.95, latency_exp_hist) + up", expHistogramSeed, base, oneULP, false},
 		{"ordinary log2 stays exact", "log2(up)", expHistogramSeed, base, oneULP, false},
-		{"ordinary power stays exact", "up ^ 2", expHistogramSeed, base, oneULP, false},
 		{"atan2 retains one ULP bound", "2 atan2 up", expHistogramSeed, base, twoULPs, false},
+		{"pow gets ULP tolerance", "up ^ 2", expHistogramSeed, base, twoULPs, true},
+		{"pow rejects beyond tolerance", "up ^ 2", expHistogramSeed, base, fiveULPs, false},
+		{"pow inside a nested expression still gets ULP tolerance", "up ^ 2 + 1", expHistogramSeed, base, twoULPs, true},
+		{"regex anchor caret is not the pow operator", `up{job=~"^api$"}`, expHistogramSeed, base, oneULP, false},
 	}
 
 	for _, tc := range cases {

--- a/test/spec/parityoracle/promql/oracle.go
+++ b/test/spec/parityoracle/promql/oracle.go
@@ -402,6 +402,15 @@ const nativeHistogramQuantileULPTolerance = 2
 // upstream of the interpolation arithmetic and not chaseable there.
 const classicHistogramRateQuantileULPTolerance = 2
 
+// powULPTolerance is the maximum ULP distance permitted between cerberus's
+// `^` (pow) answer and the reference engine's. It is the same class of
+// relaxation as [atan2ULPTolerance] — see [EqualPowValues]. Issue #2598's
+// own pinned pair (125061.4728613401 vs 125061.47286134012) measures TWO
+// ULPs apart, not the one the issue title's shorthand suggested; the ULP
+// count below is the one actually verified by ulpDistance on those two
+// values, not the issue's own characterization.
+const powULPTolerance = 2
+
 // EqualAtan2Values reports whether two float samples PRODUCED BY EVALUATING
 // PROMQL'S atan2 agree within [atan2ULPTolerance] ULPs. NaN==NaN is TRUE
 // here for the same reason it is in EqualValues.
@@ -453,6 +462,41 @@ func EqualAtan2Values(a, b float64) bool {
 		return false
 	}
 	return ulpDistance(a, b) <= atan2ULPTolerance
+}
+
+// EqualPowValues reports whether two float samples PRODUCED BY EVALUATING
+// PROMQL'S `^` (pow) binary operator agree within [powULPTolerance] ULPs.
+// NaN==NaN is TRUE here for the same reason it is in EqualValues.
+//
+// # Why pow gets the same treatment as atan2
+//
+// This is the same class of divergence [EqualAtan2Values] documents, and
+// earns its place the same way: a NAMED exception for a SINGLE operator,
+// adopted only after independent proof, not adopted speculatively.
+//
+// exp_histogram_set_op_or_mixed_vector_vector_pow.txtar (issue #2598)
+// evaluates `(histogram_quantile(...) or ...) ^ (histogram_quantile(...) or
+// ...)`, where both operands resolve to plain floats before `^` is applied.
+// The reference engine calls Go's math.Pow; cerberus lowers the
+// vector-involving case to ClickHouse's own SQL pow(), evaluated by
+// ClickHouse's libm. The two disagree near the last bit of the mantissa —
+// reference 125061.4728613401 versus cerberus 125061.47286134012, measured
+// as [powULPTolerance] ULPs apart — which is exactly the same "faithfully
+// rounded, not bit-identical" behaviour permitted between two independent
+// libm implementations of a transcendental function that atan2ULPTolerance's
+// doc comment explains. That is a fact about floating-point arithmetic, not
+// a lowering bug.
+//
+// Do not widen powULPTolerance's scope, and do not add a second named
+// tolerance without the same measured evidence this one has.
+func EqualPowValues(a, b float64) bool {
+	if math.IsNaN(a) && math.IsNaN(b) {
+		return true
+	}
+	if math.IsNaN(a) || math.IsNaN(b) {
+		return false
+	}
+	return ulpDistance(a, b) <= powULPTolerance
 }
 
 // EqualExponentialHistogramInterpolationValues reports whether two float

--- a/test/spec/parityoracle/promql/oracle_pow_test.go
+++ b/test/spec/parityoracle/promql/oracle_pow_test.go
@@ -1,0 +1,95 @@
+package promql
+
+import (
+	"math"
+	"testing"
+)
+
+// TestEqualPowValues_IssueValues pins the exact pair from issue #2598: the
+// real Prometheus engine (Go math.Pow) answered 125061.4728613401 for the
+// `^` (pow) operator over two histogram_quantile-derived floats, where
+// cerberus (ClickHouse's own pow()) answered 125061.47286134012. These are
+// two ULPs apart — verified directly via ulpDistance, not just eyeballed
+// from the issue's own "1 ULP" shorthand, which undercounts this pair — and
+// must compare equal under [EqualPowValues].
+func TestEqualPowValues_IssueValues(t *testing.T) {
+	t.Parallel()
+
+	const reference = 125061.4728613401
+	const cerberus = 125061.47286134012
+
+	if dist := ulpDistance(reference, cerberus); dist != powULPTolerance {
+		t.Fatalf(
+			"ulpDistance(%v, %v) = %d, want %d — the issue's own evidence claims these are "+
+				"within tolerance; if this fails, the issue's premise or this math is wrong",
+			reference, cerberus, dist, powULPTolerance,
+		)
+	}
+	if !EqualPowValues(reference, cerberus) {
+		t.Fatalf("EqualPowValues(%v, %v) = false, want true (%d ULPs apart)", reference, cerberus, powULPTolerance)
+	}
+	// Symmetry: the comparator must not depend on argument order.
+	if !EqualPowValues(cerberus, reference) {
+		t.Fatalf("EqualPowValues is not symmetric for %v, %v", cerberus, reference)
+	}
+}
+
+// TestEqualPowValues_RejectsBeyondTolerance constructs a value one ULP
+// beyond powULPTolerance away from a baseline and asserts EqualPowValues
+// rejects it. Without this, powULPTolerance could silently regress into
+// "always true" and no test would notice.
+func TestEqualPowValues_RejectsBeyondTolerance(t *testing.T) {
+	t.Parallel()
+
+	base := 125061.4728613401
+	v := base
+	for range powULPTolerance {
+		v = math.Nextafter(v, math.Inf(1))
+	}
+	if dist := ulpDistance(base, v); dist != powULPTolerance {
+		t.Fatalf("ulpDistance(base, v) = %d, want %d", dist, powULPTolerance)
+	}
+	if !EqualPowValues(base, v) {
+		t.Fatalf("EqualPowValues(base, %d ULPs) = false, want true", powULPTolerance)
+	}
+
+	v = math.Nextafter(v, math.Inf(1))
+	if EqualPowValues(base, v) {
+		t.Fatalf(
+			"EqualPowValues(base, %d ULPs) = true, want false — exceeds the tolerance",
+			powULPTolerance+1,
+		)
+	}
+}
+
+// TestEqualPowValues_NaN pins the same NaN==NaN carve-out EqualValues and
+// the other named tolerances make.
+func TestEqualPowValues_NaN(t *testing.T) {
+	t.Parallel()
+
+	nan := math.NaN()
+	if !EqualPowValues(nan, nan) {
+		t.Fatalf("EqualPowValues(NaN, NaN) = false, want true")
+	}
+	if EqualPowValues(nan, 1.0) || EqualPowValues(1.0, nan) {
+		t.Fatalf("EqualPowValues must not treat NaN as equal to a real number")
+	}
+}
+
+// TestEqualValues_UnaffectedByPowTolerance is the negative control: an
+// ordinary, non-pow comparison one ULP apart must still be EXACT under
+// EqualValues. This is what makes powULPTolerance a narrow exception rather
+// than a change to the package's default equality rule.
+func TestEqualValues_UnaffectedByPowTolerance(t *testing.T) {
+	t.Parallel()
+
+	base := 125061.4728613401
+	oneULP := math.Nextafter(base, math.Inf(1))
+
+	if EqualValues(base, oneULP) {
+		t.Fatalf(
+			"EqualValues(base, oneULP) = true, want false — EqualValues must stay exact for every " +
+				"fixture that is not pow; only EqualPowValues relaxes it",
+		)
+	}
+}


### PR DESCRIPTION
## Summary

- `exp_histogram_set_op_or_mixed_vector_vector_pow.txtar`'s `-- parity --` check diverges between
  Go's `math.Pow` (reference Prometheus) and ClickHouse's `pow()` (cerberus) on a
  native-histogram-quantile-derived input — the same class of libm disagreement
  `atan2QueryPattern`/`oracle.EqualAtan2Values` already tolerates.
- Added `oracle.EqualPowValues` in `test/spec/parityoracle/promql/oracle.go`, mirroring
  `EqualAtan2Values`'s ULP-tolerance shape. The issue's pinned pair
  (`125061.4728613401` vs `125061.47286134012`) measures **2 ULPs** apart when checked directly
  with `ulpDistance`, not the 1 ULP the issue title's shorthand suggested, so
  `powULPTolerance = 2`.
- `compareValues` in `test/spec/parity_chdb.go` now detects the `^` operator from the already
  **parsed AST** (`usesPowOperator`, walking for a `*parser.BinaryExpr` with `Op == parser.POW`),
  rather than a plain text regex like `atan2QueryPattern`. Unlike `atan2`, `^` collides with
  PromQL's regex-anchor syntax inside label matchers (e.g. `up{job=~"^api$"}`) — verified this is
  a real corpus pattern, not a hypothetical, via `test/spec/promql/binop_atan2_scalar_vector`-style
  greps — so a naive `\^` text match would have silently widened tolerance on unrelated,
  non-pow comparisons. The AST walk keeps the exception exactly as narrow as atan2's while avoiding
  that false positive.
- Added `test/spec/parityoracle/promql/oracle_pow_test.go` pinning the issue's exact pair, the
  boundary rejection at `powULPTolerance+1`, NaN handling, and that `EqualValues` itself stays
  exact — mirroring `oracle_atan2_test.go`'s structure.
- Extended `TestCompareValues` in `test/spec/parity_comparator_chdb_test.go` with pow dispatch
  cases, including one proving a regex-anchor caret does **not** trigger the pow comparator and
  one proving pow nested inside a larger expression still does.

## Test plan

- [x] `go test -tags chdb -run 'TestLower/exp_histogram_set_op_or_mixed_vector_vector_pow$' -v ./internal/promql/...` — was FAILing, now PASSes (re-ran with `-count=1` twice more to confirm determinism).
- [x] `go test ./test/spec/parityoracle/promql/...` — full package green, including the new `EqualPowValues` pinning tests.
- [x] `go test -tags chdb -run '^TestCompareValues$' ./test/spec/...` — all 16 dispatch cases green, including the new pow cases and the regex-anchor negative control.
- [x] `go vet -tags chdb ./test/spec/...` clean; `gofumpt -extra` / `goimports -local` clean on touched files.
- [x] `lefthook` pre-commit/commit-msg/pre-push all green on push (forbid-sql-raw, forbid-escape-hatch, actionlint, etc.).

Closes #2598

🤖 Generated with [Claude Code](https://claude.com/claude-code)
