### PR TITLE
fix(promql): compose topk/bottomk/quantile over a mixed float/histogram or

### DIFF
--- a/internal/promql/histogram_native_mixed_or_aggregate_float_only.go
+++ b/internal/promql/histogram_native_mixed_or_aggregate_float_only.go
@@ -10,17 +10,22 @@ import (
 )
 
 // histogram_native_mixed_or_aggregate_float_only.go lowers
-// `min`/`max`/`stddev`/`stdvar` [by/without] wrapping a mixed
+// `min`/`max`/`stddev`/`stdvar`/`quantile` [by/without] wrapping a mixed
 // float/histogram `or` — cerberus issue #2595, the second of the
 // sum/avg-wrapped composition's (histogram_native_mixed_or_aggregate.go,
-// cerberus issue #2346) deliberately-unattempted sibling aggregation ops.
-// `quantile()` shares the identical reference behaviour these four ops
-// have (see below) but takes a Param, so it is out of THIS issue's scope
-// (its own Acceptance section names only these four plus `count`/`group`/
-// `count_values`, which the two sibling files in this package answer).
+// cerberus issue #2346) deliberately-unattempted sibling aggregation ops,
+// plus `quantile()` (cerberus issue #2600 — #2595's own Acceptance
+// section named only the first four plus `count`/`group`/`count_values`,
+// deliberately leaving `quantile`/`topk`/`bottomk` open because every
+// #2595 recognizer required `agg.Param == nil` to stay disjoint from the
+// parameterised aggregations; #2600 found that `quantile` shares this
+// exact float-only shape once that guard is relaxed for it specifically,
+// while `topk`/`bottomk` are RANK/SELECT operators needing the bespoke
+// K-selection machinery histogram_native_mixed_or_aggregate_topk.go
+// builds instead).
 //
 // Reference Prometheus (promql/engine.go's aggregation()) DROPS a
-// histogram sample outright for every one of these four ops, with an
+// histogram sample outright for every one of these five ops, with an
 // info-level annotation rather than an error or a whole-group drop:
 //
 //	case parser.MIN, parser.MAX:
@@ -35,11 +40,19 @@ import (
 //	        // Ignore histograms for STDVAR and STDDEV.
 //	        group.seen = false
 //	        annos.Add(annotations.NewHistogramIgnoredInAggregationInfo(...))
+//	...
+//	case parser.QUANTILE:
+//	    if h != nil {
+//	        group.seen = false
+//	        annos.Add(annotations.NewHistogramIgnoredInAggregationInfo("quantile", ...))
+//	    }
+//	    group.heap = make(vectorByValueHeap, 1)
+//	    group.heap[0] = Sample{F: f}
 //
 // Unlike SUM/AVG (which merge same-type histogram groups and drop only
 // the groups that mix types) and unlike COUNT/GROUP
 // (histogram_native_mixed_or_aggregate_presence.go's sibling file, which
-// never look at the sample's type at all), these four ops NEVER read a
+// never look at the sample's type at all), these five ops NEVER read a
 // histogram sample's value — every histogram-shaped row a mixed `or`
 // produces is unconditionally excluded from the result, at every group,
 // regardless of whether that group also has float members. So the
@@ -52,16 +65,30 @@ import (
 //  1. [shadowResolveMixedExpHistogramOperands] (histogram_native_mixed_or_
 //     aggregate.go) lowers the `or`'s two operands and resolves the shadow
 //     rule for both — the histogram-valued half is computed but simply
-//     discarded here, since these four ops have no use for it.
+//     discarded here, since these five ops have no use for it.
 //  2. [lowerPlainAggOverMixedFloatArm] applies the ordinary
-//     min/max/stddev/stdvar CH-native aggregate directly over the
-//     shadow-resolved float arm. A group whose only surviving member (post
-//     shadow-resolution) is the discarded histogram row never reaches this
-//     step, so it produces no output — matching reference's "group never
-//     seen" outcome for an all-histogram group under these four ops.
+//     min/max/stddev/stdvar/quantile CH-native aggregate directly over the
+//     shadow-resolved float arm ([buildAggFunc]'s QUANTILE branch reads
+//     `agg.Param` — the phi — independently of `input`, so it needs no
+//     change to accept this composition). A group whose only surviving
+//     member (post shadow-resolution) is the discarded histogram row
+//     never reaches this step, so it produces no output — matching
+//     reference's "group never seen" outcome for an all-histogram group
+//     under these five ops.
+//  3. `quantile()` alone needs one more step
+//     [lowerFloatOnlyAggOverMixedExpHistogramSetOp] applies on top:
+//     [wrapQuantilePhiGuard] (lower.go), the SAME out-of-[0,1]-phi ±Inf/NaN
+//     override the ordinary (non-mixed) quantile lowering applies —
+//     [lowerPlainAggOverMixedFloatArm]'s CH-native `quantile(phi)(Value)`
+//     alone cannot express phi<0 → -Inf / phi>1 → +Inf / phi=NaN → NaN, so
+//     skipping this step would silently return CH's clamped-phi sentinel
+//     value instead of reference's spec answer for an out-of-domain phi.
 func floatOnlyAggOverMixedExpHistogramSetOp(expr parser.Expr, s schema.Metrics, ctx lowerCtx) (*parser.AggregateExpr, *parser.BinaryExpr, bool) {
 	agg, ok := unwrapAggregateExpr(expr)
-	if !ok || !expHistogramAggDropsHistogramSamples(agg.Op) || agg.Param != nil {
+	if !ok || !expHistogramAggDropsHistogramSamples(agg.Op) {
+		return nil, nil, false
+	}
+	if agg.Op != parser.QUANTILE && agg.Param != nil {
 		return nil, nil, false
 	}
 	b, ok := mixedExpHistogramSetOp(agg.Expr, s, ctx)
@@ -72,19 +99,23 @@ func floatOnlyAggOverMixedExpHistogramSetOp(expr parser.Expr, s schema.Metrics, 
 }
 
 // expHistogramAggDropsHistogramSamples reports whether op is one of the
-// four aggregations reference Prometheus reduces by unconditionally
+// five aggregations reference Prometheus reduces by unconditionally
 // ignoring every histogram sample (ops which are the identical shape
 // [floatOnlyAggOverMixedExpHistogramSetOp] recognises over a mixed `or`
 // aggregand) — see this file's header for the citation. Distinct from
 // [expHistogramAggOpIsMergeable] (histogram_quantile.go): that predicate
 // answers "does this op MERGE same-type histogram groups" (true only for
 // SUM/AVG), a different question from "does this op drop every histogram
-// sample outright" (true for these four, false for COUNT/GROUP, which
+// sample outright" (true for these five, false for COUNT/GROUP, which
 // never inspect the sample's type at all —
-// histogram_native_mixed_or_aggregate_presence.go).
+// histogram_native_mixed_or_aggregate_presence.go). topk/bottomk share
+// the identical per-sample rule too but are RANK/SELECT operators, not
+// REDUCE operators, so they compose through a structurally different
+// path (histogram_native_mixed_or_aggregate_topk.go) rather than this
+// predicate.
 func expHistogramAggDropsHistogramSamples(op parser.ItemType) bool {
 	switch op {
-	case parser.MIN, parser.MAX, parser.STDDEV, parser.STDVAR:
+	case parser.MIN, parser.MAX, parser.STDDEV, parser.STDVAR, parser.QUANTILE:
 		return true
 	}
 	return false
@@ -102,5 +133,16 @@ func lowerFloatOnlyAggOverMixedExpHistogramSetOp(agg *parser.AggregateExpr, b *p
 	if err != nil {
 		return nil, err
 	}
-	return lowerPlainAggOverMixedFloatArm(agg, floatForAgg, s, ctx)
+	wrapped, err := lowerPlainAggOverMixedFloatArm(agg, floatForAgg, s, ctx)
+	if err != nil {
+		return nil, err
+	}
+	if agg.Op == parser.QUANTILE {
+		// See this file's header, step 3: the CH-native `quantile(phi)`
+		// aggregate alone cannot express reference's out-of-[0,1]-phi
+		// ±Inf/NaN answer, so the ordinary (non-mixed) quantile lowering's
+		// own post-aggregate guard applies here too.
+		return wrapQuantilePhiGuard(wrapped, agg, s, ctx)
+	}
+	return wrapped, nil
 }

--- a/internal/promql/histogram_native_mixed_or_aggregate_topk.go
+++ b/internal/promql/histogram_native_mixed_or_aggregate_topk.go
@@ -1,0 +1,106 @@
+package promql
+
+import (
+	"fmt"
+
+	"github.com/prometheus/prometheus/promql/parser"
+
+	"github.com/tsouza/cerberus/internal/chplan"
+	"github.com/tsouza/cerberus/internal/schema"
+)
+
+// histogram_native_mixed_or_aggregate_topk.go lowers `topk`/`bottomk`
+// [by/without] wrapping a mixed float/histogram `or` — cerberus issue
+// #2600, the last of cerberus issue #2595's three siblings
+// (histogram_native_mixed_or_aggregate_float_only.go's own doc comment
+// named `topk`/`bottomk`/`quantile` as needing bespoke K-selection
+// machinery rather than a small addition to the generic buildAggFunc
+// dispatch that file's four ops and #2595's other two sibling files
+// reuse). `quantile()` turned out to share the float-only family's exact
+// shape (see that file's doc comment) and was folded in there instead;
+// this file is topk/bottomk alone.
+//
+// Reference Prometheus (promql/engine.go's aggregationK) gives topk/
+// bottomk the IDENTICAL "drop every histogram sample" rule as min/max/
+// stddev/stdvar/quantile — verified directly against
+// github.com/tsouza/prometheus's promql/engine.go:
+//
+//	case parser.TOPK:
+//	    switch {
+//	    case s.H != nil:
+//	        // Ignore histogram sample and add info annotation.
+//	        annos.Add(annotations.NewHistogramIgnoredInAggregationInfo("topk", ...))
+//	    case int64(len(group.heap)) < k:
+//	        heap.Push(&group.heap, &s)
+//	    ...
+//
+// but topk/bottomk are RANK/SELECT operators, not REDUCE operators: they
+// pick K rows out of the input and forward those rows' own labels and
+// values unchanged, rather than folding every row down to one value per
+// group. That is exactly [chplan.TopK]'s own shape ([lowerTopK]'s CH
+// `LIMIT K BY <partition>` translation) — a plan node that reads an
+// arbitrary already-lowered `chplan.Node` as its Input, entirely
+// independent of how that Input was produced. So the correct composition
+// needs NO reduction machinery at all, and — unlike SUM/AVG's collision-
+// drop recombine or even the float-only family's single-arm reduce — it
+// does not need to build anything histogram-shaped either:
+//
+//  1. [shadowResolveMixedExpHistogramOperands] resolves the `or`'s own
+//     shadow rule for both arms exactly as every other mixed-or aggregate
+//     composition in this package does. The histogram-valued return
+//     (`_` below) is unused: reference's aggregationK drops every
+//     histogram sample from K-selection UNCONDITIONALLY, so a histogram
+//     row can never survive into the topk/bottomk output regardless of
+//     which side of the `or` it shadow-resolved to keep. Concretely: if a
+//     label signature collides across the `or`'s two arms, the SAME
+//     signature is absent from [floatForAgg] whichever side "wins" the
+//     collision — the LHS-histogram-wins case shadows the float row out
+//     of floatForAgg via the UNLESS below, and the LHS-float-wins case
+//     never had a competing histogram row in floatForAgg's own selector
+//     to begin with. A label signature present ONLY on the histogram
+//     side never appears in floatForAgg either way (it never had a float
+//     counterpart), matching reference dropping that row from K-selection
+//     with no candidate to replace it. So floatForAgg alone — with no
+//     histogram branch and no post-hoc recombine — already IS the set of
+//     rows topk/bottomk could ever select from.
+//  2. [buildTopKLiteral] / [buildTopKComputed] (lower.go) apply the
+//     ordinary topk/bottomk K-domain, partition and column-shape rules to
+//     floatForAgg exactly as they do for a freshly lowered `a.Expr` —
+//     these two functions were split out of [lowerTopK] /
+//     [lowerTopKComputed] for exactly this reuse.
+func topKOverMixedExpHistogramSetOp(expr parser.Expr, s schema.Metrics, ctx lowerCtx) (*parser.AggregateExpr, *parser.BinaryExpr, bool) {
+	agg, ok := unwrapAggregateExpr(expr)
+	if !ok || (agg.Op != parser.TOPK && agg.Op != parser.BOTTOMK) {
+		return nil, nil, false
+	}
+	b, ok := mixedExpHistogramSetOp(agg.Expr, s, ctx)
+	if !ok {
+		return nil, nil, false
+	}
+	return agg, b, true
+}
+
+// lowerTopKOverMixedExpHistogramSetOp lowers the shape
+// [topKOverMixedExpHistogramSetOp] recognised. See this file's header
+// for why the shadow-resolved float arm alone, fed through the ordinary
+// topk/bottomk K-selection, already answers reference's semantics.
+func lowerTopKOverMixedExpHistogramSetOp(agg *parser.AggregateExpr, b *parser.BinaryExpr, s schema.Metrics, ctx lowerCtx) (chplan.Node, error) {
+	if b.ReturnBool {
+		return nil, fmt.Errorf("promql: 'bool' modifier is only allowed on comparison binary ops")
+	}
+
+	_, floatForAgg, err := shadowResolveMixedExpHistogramOperands(b, s, ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	kF, ok := tryScalarLiteral(agg.Param)
+	if !ok {
+		return buildTopKComputed(agg, s, ctx, floatForAgg, false)
+	}
+	k, empty, err := topKDomain(kF)
+	if err != nil {
+		return nil, err
+	}
+	return buildTopKLiteral(agg, s, ctx, floatForAgg, k, empty), nil
+}

--- a/internal/promql/histogram_native_mixed_or_aggregate_topk_chdb_test.go
+++ b/internal/promql/histogram_native_mixed_or_aggregate_topk_chdb_test.go
@@ -1,0 +1,321 @@
+//go:build chdb
+
+// chDB-backed proof that `topk()`/`bottomk()` directly wrapping a mixed
+// float/histogram `or` (cerberus issue #2600,
+// histogram_native_mixed_or_aggregate_topk.go's
+// [topKOverMixedExpHistogramSetOp] / [lowerTopKOverMixedExpHistogramSetOp])
+// actually DROP every histogram-shaped row and rank the float-shaped rows
+// alone at real ClickHouse execution — including the `or`'s own
+// LHS-wins shadow rule when a histogram row and a float row share the
+// identical label signature, and the reference-faithful "no output row
+// at all" answer for a `by(...)` group whose only member is
+// histogram-shaped.
+//
+// Reuses foSeed / foHistMetric / foFloatMetric / foEvalTS from
+// histogram_native_mixed_or_aggregate_float_only_chdb_test.go (same
+// package, same build tag): two histogram series (h1 in bucket b1, h2
+// alone in bucket b2) and three float series (f1=3 and f2=9 in bucket
+// b1, f3=1 alone in bucket b3).
+package promql_test
+
+import (
+	"context"
+	"math"
+	"testing"
+
+	"github.com/prometheus/prometheus/promql/parser"
+
+	"github.com/tsouza/cerberus/internal/chplan"
+	"github.com/tsouza/cerberus/internal/chsql"
+	"github.com/tsouza/cerberus/internal/promql"
+	"github.com/tsouza/cerberus/internal/schema"
+	"github.com/tsouza/cerberus/internal/testsql"
+)
+
+// tkSeriesValues runs query and returns a map of the `series` label to
+// `Value`, for queries expected to preserve the topk/bottomk-selected
+// series' own labels (no `by`/`without` re-keying).
+func tkSeriesValues(t *testing.T, fixture *chdbFixture, s schema.Metrics, p parser.Parser, query string) map[string]float64 {
+	t.Helper()
+	expr, err := p.ParseExpr(query)
+	if err != nil {
+		t.Fatalf("ParseExpr(%q): %v", query, err)
+	}
+	plan, err := promql.LowerAt(context.Background(), expr, s, foEvalTS, foEvalTS)
+	if err != nil {
+		t.Fatalf("LowerAt(%q): %v", query, err)
+	}
+	sqlStr, args, err := chsql.Emit(context.Background(), plan)
+	if err != nil {
+		t.Fatalf("Emit(%q): %v", query, err)
+	}
+	rows := fixture.queryOverEmitted(t, "`Attributes`['series'] AS series, `Value` AS val", sqlStr, args)
+	defer func() { _ = rows.Close() }()
+
+	got := map[string]float64{}
+	for rows.Next() {
+		var series string
+		var val float64
+		if err := rows.Scan(&series, &val); err != nil {
+			t.Fatalf("scan: %v", err)
+		}
+		got[series] = val
+	}
+	if err := testsql.TolerantRowsErr(rows.Err()); err != nil {
+		t.Fatalf("rows.Err: %v", err)
+	}
+	return got
+}
+
+func assertSeriesValues(t *testing.T, query string, got, want map[string]float64) {
+	t.Helper()
+	for series, wantVal := range want {
+		gotVal, ok := got[series]
+		if !ok {
+			t.Errorf("query %q: no row for series %q, want Value=%v (got %v)", query, series, wantVal, got)
+			continue
+		}
+		if gotVal != wantVal {
+			t.Errorf("query %q: series %q Value=%v, want %v", query, series, gotVal, wantVal)
+		}
+	}
+	if len(got) != len(want) {
+		t.Errorf("query %q: got %d series %v, want %d series %v", query, len(got), got, len(want), want)
+	}
+}
+
+// TestTopKBottomKOverMixedSetOpOr_ChDB proves topk()/bottomk(), with no
+// `by`/`without` clause, ignore the two histogram-shaped rows (h1, h2)
+// entirely and rank the three float-shaped rows (f1=3, f2=9, f3=1) alone
+// — for both source-AST operand orders, since the mixed `or`'s shadow
+// rule (and this composition's shadow-resolution) depends on which side
+// is LHS.
+func TestTopKBottomKOverMixedSetOpOr_ChDB(t *testing.T) {
+	fixture := newChDBFixture(t, foSeed)
+	s := schema.DefaultOTelMetrics()
+	p := parser.NewParser(parser.Options{EnableExperimentalFunctions: true})
+
+	cases := []struct {
+		name  string
+		query string
+		want  map[string]float64
+	}{
+		{
+			"topk2_histLHS",
+			"topk(2, " + foHistMetric + " or " + foFloatMetric + ")",
+			map[string]float64{"f2": 9, "f1": 3},
+		},
+		{
+			"topk2_floatLHS",
+			"topk(2, " + foFloatMetric + " or " + foHistMetric + ")",
+			map[string]float64{"f2": 9, "f1": 3},
+		},
+		{
+			"bottomk2_histLHS",
+			"bottomk(2, " + foHistMetric + " or " + foFloatMetric + ")",
+			map[string]float64{"f3": 1, "f1": 3},
+		},
+		{
+			"bottomk2_floatLHS",
+			"bottomk(2, " + foFloatMetric + " or " + foHistMetric + ")",
+			map[string]float64{"f3": 1, "f1": 3},
+		},
+		// K >= the float-row count: every float row survives, still no
+		// histogram row.
+		{
+			"topk10_allFloats",
+			"topk(10, " + foHistMetric + " or " + foFloatMetric + ")",
+			map[string]float64{"f1": 3, "f2": 9, "f3": 1},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := tkSeriesValues(t, fixture, s, p, tc.query)
+			assertSeriesValues(t, tc.query, got, tc.want)
+		})
+	}
+}
+
+// TestTopKOverMixedSetOpOr_ByBucket_ChDB proves `topk(1, ...) by (bucket)`
+// partitions the K-selection per bucket, and that bucket b2 — whose ONLY
+// member is histogram-shaped (h2) — produces NO output row at all,
+// matching reference (aggregationK never adds a histogram sample to any
+// group's heap).
+func TestTopKOverMixedSetOpOr_ByBucket_ChDB(t *testing.T) {
+	fixture := newChDBFixture(t, foSeed)
+	s := schema.DefaultOTelMetrics()
+	p := parser.NewParser(parser.Options{EnableExperimentalFunctions: true})
+
+	query := "topk(1, " + foHistMetric + " or " + foFloatMetric + ") by (bucket)"
+	expr, err := p.ParseExpr(query)
+	if err != nil {
+		t.Fatalf("ParseExpr(%q): %v", query, err)
+	}
+	plan, err := promql.LowerAt(context.Background(), expr, s, foEvalTS, foEvalTS)
+	if err != nil {
+		t.Fatalf("LowerAt(%q): %v", query, err)
+	}
+	sqlStr, args, err := chsql.Emit(context.Background(), plan)
+	if err != nil {
+		t.Fatalf("Emit(%q): %v", query, err)
+	}
+	rows := fixture.queryOverEmitted(t, "`Attributes`['bucket'] AS bucket, `Value` AS val", sqlStr, args)
+	defer func() { _ = rows.Close() }()
+
+	seen := map[string]float64{}
+	for rows.Next() {
+		var bucket string
+		var val float64
+		if err := rows.Scan(&bucket, &val); err != nil {
+			t.Fatalf("scan: %v", err)
+		}
+		seen[bucket] = val
+	}
+	if err := testsql.TolerantRowsErr(rows.Err()); err != nil {
+		t.Fatalf("rows.Err: %v", err)
+	}
+
+	want := map[string]float64{
+		"b1": 9, // h1 (ignored) + f1(3) + f2(9) -> top1 = 9
+		"b3": 1, // f3 alone
+	}
+	for bucket, wantVal := range want {
+		gotVal, ok := seen[bucket]
+		if !ok {
+			t.Errorf("query %q: no row for bucket %q, want Value=%v", query, bucket, wantVal)
+			continue
+		}
+		if gotVal != wantVal {
+			t.Errorf("query %q: bucket %q Value=%v, want %v", query, bucket, gotVal, wantVal)
+		}
+	}
+	if val, ok := seen["b2"]; ok {
+		t.Errorf("query %q: got a row for bucket %q (Value = %v), want none (its only member is histogram-shaped, so reference never marks the group seen)", query, "b2", val)
+	}
+	if len(seen) != len(want) {
+		t.Errorf("query %q: got %d buckets %v, want %d buckets %v", query, len(seen), seen, len(want), want)
+	}
+}
+
+const (
+	tkShadowHistMetric  = "tk_shadow_hist_side_exp_hist"
+	tkShadowFloatMetric = "tk_shadow_float_side_gauge"
+)
+
+// tkShadowSeed keys a histogram series and a float series onto the
+// IDENTICAL label signature ("series"="dup") — the collision case the
+// `or`'s own shadow rule (mixedOrShadowUnless) resolves: whichever side
+// is the source-AST LHS keeps its "dup" row, and the RHS's "dup" row is
+// shadowed out entirely. A second, non-colliding float series ("solo")
+// is seeded on both metrics' sides so a non-empty topk always has at
+// least one row to select regardless of which arm wins the collision.
+var tkShadowSeed = "" +
+	"CREATE OR REPLACE TABLE otel_metrics_exponential_histogram (" +
+	"`MetricName` String, `Attributes` Map(String, String), " +
+	"`ResourceAttributes` Map(String, String) DEFAULT map(), `ServiceName` LowCardinality(String) DEFAULT '', " +
+	"`TimeUnix` DateTime64(9), " +
+	"`Count` UInt64, `Sum` Float64, `Scale` Int32, `ZeroCount` UInt64, " +
+	"`PositiveOffset` Int32, `PositiveBucketCounts` Array(UInt64), " +
+	"`NegativeOffset` Int32, `NegativeBucketCounts` Array(UInt64)" +
+	") ENGINE = MergeTree ORDER BY (`MetricName`, `Attributes`, `TimeUnix`);\n" +
+	"INSERT INTO otel_metrics_exponential_histogram " +
+	"(MetricName, Attributes, TimeUnix, Count, Sum, Scale, ZeroCount, PositiveOffset, PositiveBucketCounts, NegativeOffset, NegativeBucketCounts) VALUES\n" +
+	"    ('" + tkShadowHistMetric + "', map('series', 'dup'), toDateTime64('2026-01-01 00:00:00', 9), 2, 4.0, 0, 0, 0, [6], 0, []);\n" +
+	swapGaugeSeedDDL +
+	"INSERT INTO otel_metrics_gauge (MetricName, Attributes, TimeUnix, Value) VALUES\n" +
+	"    ('" + tkShadowFloatMetric + "', map('series', 'dup'), toDateTime64('2026-01-01 00:00:00', 9), 42.0),\n" +
+	"    ('" + tkShadowFloatMetric + "', map('series', 'solo'), toDateTime64('2026-01-01 00:00:00', 9), 7.0);\n"
+
+// TestTopKOverMixedSetOpOr_ShadowCollision_ChDB proves the `or`'s own
+// LHS-wins shadow rule composes correctly with topk/bottomk's histogram
+// drop: when the histogram side is the source-AST LHS, the colliding
+// float row ("dup"=42) is shadowed out of the `or`'s own output
+// entirely, so it can never appear in topk's ranking — matching
+// reference, where the `or`'s output vector contains ONLY the histogram
+// "dup" row for that label signature, which topk/bottomk then drops
+// unconditionally, leaving no candidate at all for "dup". When the float
+// side is LHS instead, its own "dup" row is never shadowed and topk
+// selects it normally.
+func TestTopKOverMixedSetOpOr_ShadowCollision_ChDB(t *testing.T) {
+	fixture := newChDBFixture(t, tkShadowSeed)
+	s := schema.DefaultOTelMetrics()
+	p := parser.NewParser(parser.Options{EnableExperimentalFunctions: true})
+
+	cases := []struct {
+		name  string
+		query string
+		want  map[string]float64
+	}{
+		{
+			"histLHS_dupShadowedOut",
+			"topk(10, " + tkShadowHistMetric + " or " + tkShadowFloatMetric + ")",
+			map[string]float64{"solo": 7},
+		},
+		{
+			"floatLHS_dupSurvives",
+			"topk(10, " + tkShadowFloatMetric + " or " + tkShadowHistMetric + ")",
+			map[string]float64{"solo": 7, "dup": 42},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := tkSeriesValues(t, fixture, s, p, tc.query)
+			assertSeriesValues(t, tc.query, got, tc.want)
+		})
+	}
+}
+
+// TestQuantileOverMixedSetOpOr_ChDB proves quantile(phi, ...) directly
+// wrapping a mixed `or` (cerberus issue #2600, folded into
+// histogram_native_mixed_or_aggregate_float_only.go's float-only family)
+// ignores the two histogram-shaped rows (h1, h2) and reduces the three
+// float-shaped rows (1, 3, 9) alone with reference's own quantile
+// semantics — including the out-of-[0,1]-phi ±Inf answer
+// [wrapQuantilePhiGuard] applies on top of the CH-native `quantile()`
+// aggregate.
+func TestQuantileOverMixedSetOpOr_ChDB(t *testing.T) {
+	fixture := newChDBFixture(t, foSeed)
+	s := schema.DefaultOTelMetrics()
+	p := parser.NewParser(parser.Options{EnableExperimentalFunctions: true})
+
+	orExpr := "(" + foHistMetric + " or " + foFloatMetric + ")"
+
+	cases := []struct {
+		name  string
+		query string
+		want  float64
+	}{
+		// sorted floats [1, 3, 9]; rank = phi*(n-1) = 0.5*2 = 1 -> index 1 -> 3.
+		{"median", "quantile(0.5, " + orExpr + ")", 3},
+		{"min_phi", "quantile(0, " + orExpr + ")", 1},
+		{"max_phi", "quantile(1, " + orExpr + ")", 9},
+		// PromQL spec (funcQuantile): phi < 0 -> -Inf, phi > 1 -> +Inf,
+		// regardless of the underlying values.
+		{"phi_below_domain", "quantile(-0.5, " + orExpr + ")", math.Inf(-1)},
+		{"phi_above_domain", "quantile(1.5, " + orExpr + ")", math.Inf(1)},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := foSingleValue(t, fixture, s, p, tc.query)
+			if math.IsInf(tc.want, 0) {
+				if got != tc.want {
+					t.Errorf("%s: Value = %v, want %v", tc.query, got, tc.want)
+				}
+				return
+			}
+			if math.Abs(got-tc.want) > 1e-9 {
+				t.Errorf("%s: Value = %v, want %v (a histogram-blind bug would include h1/h2's placeholder 0.0 in the reduction)", tc.query, got, tc.want)
+			}
+		})
+	}
+}
+
+// tkRowShapeSanity is a compile-time reminder that the mixed-or topk/
+// bottomk composition always publishes the canonical Sample row shape
+// (never Histogram or Mixed) — the same invariant
+// histogram_native_mixed_or_aggregate_float_only_chdb_test.go's foLower
+// checks explicitly; this file's tkSeriesValues/foSingleValue helpers
+// already lower successfully or fail loudly, so no separate assertion is
+// needed, but the referenced type keeps the import honest if that ever
+// changes.
+var _ = chplan.SampleRowShape

--- a/internal/promql/lower.go
+++ b/internal/promql/lower.go
@@ -505,6 +505,19 @@ func lowerMixedExpHistogramFamily(expr parser.Expr, s schema.Metrics, ctx lowerC
 		plan, err := lowerFloatOnlyAggOverMixedExpHistogramSetOp(agg, b, s, ctx)
 		return plan, true, err
 	}
+	// `topk`/`bottomk` [by/without] wrapping that same mixed shape
+	// (cerberus issue #2600, the last of #2595's three siblings). Checked
+	// here for the identical reason: a mixed `or` aggregand never
+	// resolves as purely histogram-valued, so nothing above this line can
+	// have consumed the shape yet. histogram_native_mixed_or_aggregate_
+	// topk.go has the composition's own doc comment for why the
+	// shadow-resolved float arm alone, with no histogram branch, already
+	// answers reference's per-sample "drop every histogram row from
+	// K-selection" rule.
+	if agg, b, ok := topKOverMixedExpHistogramSetOp(expr, s, ctx); ok {
+		plan, err := lowerTopKOverMixedExpHistogramSetOp(agg, b, s, ctx)
+		return plan, true, err
+	}
 	// `count_values` wrapping that same mixed shape (cerberus issue
 	// #2595's third and last sibling family). Checked here for the
 	// identical reason: a mixed `or` aggregand never resolves as purely
@@ -4798,6 +4811,18 @@ func lowerTopK(a *parser.AggregateExpr, s schema.Metrics, ctx lowerCtx) (chplan.
 	if err != nil {
 		return nil, err
 	}
+	return buildTopKLiteral(a, s, ctx, input, k, empty), nil
+}
+
+// buildTopKLiteral builds the literal-K topk/bottomk node over an
+// ALREADY-LOWERED input, given the K domain [topKDomain] already
+// resolved for it. Split out of [lowerTopK] so cerberus issue #2600's
+// mixed-or composition (histogram_native_mixed_or_aggregate_topk.go)
+// can reuse the identical K-domain / partition / column-shape rules over
+// the mixed `or`'s shadow-resolved float arm instead of a freshly
+// lowered `a.Expr` — the only difference between the two callers is
+// which chplan.Node `input` names.
+func buildTopKLiteral(a *parser.AggregateExpr, s schema.Metrics, ctx lowerCtx, input chplan.Node, k int64, empty bool) chplan.Node {
 	if empty {
 		// K < 1 → empty result per reference semantics (see
 		// topKDomain). Filter the lowered input to zero rows so the
@@ -4806,7 +4831,7 @@ func lowerTopK(a *parser.AggregateExpr, s schema.Metrics, ctx lowerCtx) (chplan.
 		return &chplan.Filter{
 			Input:     input,
 			Predicate: &chplan.LitBool{V: false},
-		}, nil
+		}
 	}
 
 	by := topKPartition(a, s, ctx)
@@ -4818,7 +4843,7 @@ func lowerTopK(a *parser.AggregateExpr, s schema.Metrics, ctx lowerCtx) (chplan.
 		SortExpr: &chplan.ColumnRef{Name: s.ValueColumn},
 		Desc:     a.Op == parser.TOPK,
 		Columns:  topKOutputColumns(input, s),
-	}, nil
+	}
 }
 
 // lowerLimitK lowers PromQL's experimental `limitk(K, expr) [by(g) |
@@ -5013,6 +5038,39 @@ func topKOutputColumns(input chplan.Node, s schema.Metrics) []string {
 // [topKDomainExpr] applies the runtime half of the K-domain rules the
 // literal path resolves in [topKDomain].
 func lowerTopKComputed(a *parser.AggregateExpr, s schema.Metrics, ctx lowerCtx) (chplan.Node, error) {
+	// Only limitk ever preserves a histogram-valued input (see
+	// [lowerLimitKInput]'s doc comment) — topk/bottomk's histogram-only
+	// case is always intercepted upstream, at the top of lowerAggregate
+	// (root OR nested, cerberus issue #2562) or, when this aggregation is
+	// itself the query's root, even earlier by lowerHistogramNativeRoot,
+	// by droppingAggregationOverExpHistogram (histogram_native_drop_
+	// aggregation.go), so `input` here is never histogram-valued for
+	// them and the plain [lower] dispatch is unchanged for that path.
+	var input chplan.Node
+	var histogram bool
+	var err error
+	if a.Op == parser.LIMITK {
+		input, histogram, err = lowerLimitKInput(a.Expr, s, ctx)
+	} else {
+		input, err = lower(a.Expr, s, ctx)
+	}
+	if err != nil {
+		return nil, err
+	}
+	return buildTopKComputed(a, s, ctx, input, histogram)
+}
+
+// buildTopKComputed builds the computed-K topk/bottomk/limitk node over
+// an ALREADY-LOWERED input. Split out of [lowerTopKComputed] so cerberus
+// issue #2600's mixed-or composition
+// (histogram_native_mixed_or_aggregate_topk.go) can reuse the identical
+// K-domain / partition / column-shape rules over the mixed `or`'s
+// shadow-resolved float arm instead of a freshly lowered `a.Expr` — the
+// only difference between the two callers is which chplan.Node `input`
+// names. `histogram` is always false for the mixed-or caller (topk/
+// bottomk never preserve a histogram-valued input — see
+// [lowerTopKComputed]'s own comment).
+func buildTopKComputed(a *parser.AggregateExpr, s schema.Metrics, ctx lowerCtx, input chplan.Node, histogram bool) (chplan.Node, error) {
 	// The K domain is reference Prometheus's, and reference applies it to
 	// the parameter's whole per-step value series before it aggregates
 	// anything. A computed K has no value until the query runs, and the
@@ -5043,25 +5101,6 @@ func lowerTopKComputed(a *parser.AggregateExpr, s schema.Metrics, ctx lowerCtx) 
 		Projections: []chplan.Projection{
 			{Expr: topKDomainExpr(kValue), Alias: s.ValueColumn},
 		},
-	}
-
-	// Only limitk ever preserves a histogram-valued input (see
-	// [lowerLimitKInput]'s doc comment) — topk/bottomk's histogram-only
-	// case is always intercepted upstream, at the top of lowerAggregate
-	// (root OR nested, cerberus issue #2562) or, when this aggregation is
-	// itself the query's root, even earlier by lowerHistogramNativeRoot,
-	// by droppingAggregationOverExpHistogram (histogram_native_drop_
-	// aggregation.go), so `input` here is never histogram-valued for
-	// them and the plain [lower] dispatch is unchanged for that path.
-	var input chplan.Node
-	var histogram bool
-	if a.Op == parser.LIMITK {
-		input, histogram, err = lowerLimitKInput(a.Expr, s, ctx)
-	} else {
-		input, err = lower(a.Expr, s, ctx)
-	}
-	if err != nil {
-		return nil, err
 	}
 
 	// See lowerLimitK's matching comment: a histogram-valued input always

--- a/test/rejection-parity/catalogue/internal__promql__binary.go__lowerVectorSetOp.json
+++ b/test/rejection-parity/catalogue/internal__promql__binary.go__lowerVectorSetOp.json
@@ -5,8 +5,8 @@
       "site": "internal/promql/binary.go:lowerVectorSetOp#4924e0ba",
       "message": "promql: 'or' between a float-valued and a histogram-valued operand is not supported; 'and'/'unless' support mixing them",
       "class": "divergence",
-      "trigger_query": "topk(3, demo_latency_exp_hist or histogram_quantile(0.5, demo_latency_exp_hist))",
-      "tracking_issue": 2600,
+      "trigger_query": "sort(demo_latency_exp_hist or histogram_quantile(0.5, demo_latency_exp_hist))",
+      "tracking_issue": 2605,
       "evidence": {
         "guard": [
           "past returning if err != nil",

--- a/test/rejection-parity/catalogue/internal__promql__histogram_native_mixed_or_aggregate_topk.go__lowerTopKOverMixedExpHistogramSetOp.json
+++ b/test/rejection-parity/catalogue/internal__promql__histogram_native_mixed_or_aggregate_topk.go__lowerTopKOverMixedExpHistogramSetOp.json
@@ -1,0 +1,24 @@
+{
+  "entries": [
+    {
+      "head": "promql",
+      "site": "internal/promql/histogram_native_mixed_or_aggregate_topk.go:lowerTopKOverMixedExpHistogramSetOp#6cdf660e",
+      "message": "promql: 'bool' modifier is only allowed on comparison binary ops",
+      "class": "internal",
+      "rationale": "the parser rejects `bool` on non-comparison operators (\"bool modifier can only be used on comparison operators\"), same as lowerSumOrAvgOverMixedExpHistogramSetOp's identical check (histogram_native_mixed_or_aggregate.go, cerberus issue #2346) and its histogram_native_mixed_or_aggregate_presence.go / histogram_native_mixed_or_aggregate_count_values.go / histogram_native_mixed_or_aggregate_float_only.go siblings (cerberus issue #2595 / #2600). topKOverMixedExpHistogramSetOp only ever matches b via mixedExpHistogramSetOp, which requires b.Op == parser.LOR — `or` is a set operator, never a comparison, so the parser can never have set ReturnBool on it.",
+      "evidence": {
+        "guard": [
+          "if b.ReturnBool"
+        ],
+        "callers": [
+          "lowerMixedExpHistogramFamily"
+        ],
+        "cited": [
+          "lowerSumOrAvgOverMixedExpHistogramSetOp",
+          "mixedExpHistogramSetOp",
+          "topKOverMixedExpHistogramSetOp"
+        ]
+      }
+    }
+  ]
+}

--- a/test/rejection-parity/catalogue/internal__promql__scalar_args.go__lowerScalarArg.json
+++ b/test/rejection-parity/catalogue/internal__promql__scalar_args.go__lowerScalarArg.json
@@ -15,6 +15,7 @@
         "callers": [
           "buildAggFunc",
           "buildSubqueryAggFunc",
+          "buildTopKComputed",
           "histogramFractionBound",
           "holtWintersFactors",
           "limitRatioPredicate",
@@ -29,7 +30,6 @@
           "lowerScalarArg",
           "lowerScalarTopLevel",
           "lowerSubqueryOverTopK",
-          "lowerTopKComputed",
           "lowerVector",
           "scalarGuardPlan",
           "threadOuterRangeFnScalars",
@@ -55,6 +55,7 @@
         "callers": [
           "buildAggFunc",
           "buildSubqueryAggFunc",
+          "buildTopKComputed",
           "histogramFractionBound",
           "holtWintersFactors",
           "limitRatioPredicate",
@@ -69,7 +70,6 @@
           "lowerScalarArg",
           "lowerScalarTopLevel",
           "lowerSubqueryOverTopK",
-          "lowerTopKComputed",
           "lowerVector",
           "scalarGuardPlan",
           "threadOuterRangeFnScalars",
@@ -94,6 +94,7 @@
         "callers": [
           "buildAggFunc",
           "buildSubqueryAggFunc",
+          "buildTopKComputed",
           "histogramFractionBound",
           "holtWintersFactors",
           "limitRatioPredicate",
@@ -108,7 +109,6 @@
           "lowerScalarArg",
           "lowerScalarTopLevel",
           "lowerSubqueryOverTopK",
-          "lowerTopKComputed",
           "lowerVector",
           "scalarGuardPlan",
           "threadOuterRangeFnScalars",

--- a/test/rejection-parity/catalogue/internal__promql__scalar_domain.go__aggregationParamDomain.json
+++ b/test/rejection-parity/catalogue/internal__promql__scalar_domain.go__aggregationParamDomain.json
@@ -11,8 +11,8 @@
           "case mx \u003e= aggParamMaxInt64 of switch"
         ],
         "callers": [
+          "buildTopKComputed",
           "lowerSubqueryOverTopK",
-          "lowerTopKComputed",
           "topKDomain"
         ]
       }
@@ -32,8 +32,8 @@
           "case mn \u003c= aggParamMinInt64 of switch"
         ],
         "callers": [
+          "buildTopKComputed",
           "lowerSubqueryOverTopK",
-          "lowerTopKComputed",
           "topKDomain"
         ]
       }
@@ -49,8 +49,8 @@
           "case hasAnyNaN(values) of switch"
         ],
         "callers": [
+          "buildTopKComputed",
           "lowerSubqueryOverTopK",
-          "lowerTopKComputed",
           "topKDomain"
         ]
       }


### PR DESCRIPTION
## Summary

Closes the full scope of #2600: `topk()`, `bottomk()`, and `quantile()` — the three ops PR #2601
(#2595) deliberately left open — now compose over a mixed float/histogram `or` (#2330), matching
how `sum`/`avg` (#2346) and `count`/`group`/`min`/`max`/`stddev`/`stdvar`/`count_values` (#2595)
already do.

## Reference semantics (verified against `promql/engine.go`, not just plausibility)

Read `github.com/tsouza/prometheus`'s (this repo's upstream fork) own `promql/engine.go` directly
rather than assuming:

- **`aggregationK`** (topk/bottomk's own evaluator) drops every histogram-valued sample
  unconditionally before it ever reaches the K-selection heap (`if s.H != nil { ... ignore, add
  info annotation ... }`), for both the "first sample in a group" and "subsequent sample" arms.
  topk/bottomk are RANK/SELECT operators, not REDUCE operators — they forward K rows' own labels
  and values unchanged rather than folding a group down to one value — so this composes through
  `chplan.TopK` (CH's `LIMIT K BY`) fed the mixed `or`'s shadow-resolved float arm ALONE, with no
  histogram-side branch needed at all: reference's per-sample "ignore this histogram row" and this
  composition's "never include the histogram arm's rows in TopK's input" answer the identical row
  set, and a colliding label signature shadowed out by the `or`'s own LHS-wins rule (a histogram
  row shadows a float row, or vice versa) drops out of TopK's candidate set on the float side either
  way — verified directly by chDB test `TestTopKOverMixedSetOpOr_ShadowCollision_ChDB`.
- **`aggregation`**'s `QUANTILE` case has the IDENTICAL "drop every histogram sample, reduce the
  float ones" rule #2595 already taught `min`/`max`/`stddev`/`stdvar`
  (`floatOnlyAggOverMixedExpHistogramSetOp`) — `quantile()` was excluded from that fix only because
  every #2595 recognizer required `agg.Param == nil` to stay disjoint from the parameterised ops.
  Relaxing that guard for `QUANTILE` specifically (its Param is phi, read independently of the
  aggregation's input by `buildAggFunc`) reuses the existing float-only reduction unchanged, plus
  one more step: `wrapQuantilePhiGuard`, the SAME out-of-`[0,1]`-phi ±Inf/NaN override the ordinary
  (non-mixed) quantile lowering already applies, so `quantile(1.5, <hist> or <float>)` still answers
  `+Inf` rather than CH's clamped-phi sentinel.

## Changes

- `internal/promql/histogram_native_mixed_or_aggregate_topk.go` (new) — the topk/bottomk
  recognizer + lowering, reusing `shadowResolveMixedExpHistogramOperands`
  (histogram_native_mixed_or_aggregate.go) for the `or`'s own shadow rule and two lower.go helpers
  extracted for reuse: `buildTopKLiteral` (out of `lowerTopK`) and `buildTopKComputed` (out of
  `lowerTopKComputed`) — both now take an already-lowered `input` instead of re-lowering `a.Expr`,
  so the mixed-or composition and the ordinary path share the identical K-domain, partition, and
  column-shape logic. Wired into `lowerMixedExpHistogramFamily` (`internal/promql/lower.go`) right
  after the float-only family.
- `internal/promql/histogram_native_mixed_or_aggregate_float_only.go` — extended to recognise
  `quantile()` alongside `min`/`max`/`stddev`/`stdvar`, and to apply `wrapQuantilePhiGuard` after
  the shared float-only reduction when the op is `QUANTILE`.

## Test plan

- [x] `TestTopKBottomKOverMixedSetOpOr_ChDB` (new, chDB-backed) — topk(2)/bottomk(2) with no
  `by`/`without`, both operand orders, ignore the two histogram rows entirely and rank the three
  float rows alone; also covers K exceeding the float-row count.
- [x] `TestTopKOverMixedSetOpOr_ByBucket_ChDB` (new, chDB-backed) — `by (bucket)` partitions the
  K-selection per bucket, and the all-histogram bucket produces no output row at all, matching
  reference.
- [x] `TestTopKOverMixedSetOpOr_ShadowCollision_ChDB` (new, chDB-backed) — a histogram row and a
  float row sharing the identical label signature: the `or`'s own LHS-wins shadow rule composes
  correctly with topk's histogram drop in both operand orders.
- [x] `TestQuantileOverMixedSetOpOr_ChDB` (new, chDB-backed) — quantile(phi) ignores the two
  histogram rows and reduces the three float rows with reference's own quantile math, including
  the out-of-`[0,1]`-phi ±Inf answer.
- [x] Existing `go test -race ./internal/promql/...` — pass, no regressions from the
  `lowerTopK`/`lowerTopKComputed` extraction (topk/bottomk/limitk/limit_ratio suites all still
  green).
- [x] `go build ./...`, `go vet ./...` (chdb-tagged too), `gofumpt -extra -l`, `goimports -local
  github.com/tsouza/cerberus -l` — clean.
- [x] `node .github/scripts/forbid-sql-raw.mjs` — clean (no chsql touched).
- [x] `CERBERUS_UPDATE_INVENTORY=1 go test -run TestCatalogueIsRegenerable
  ./test/rejection-parity/...` (run twice — the `lowerTopKComputed`→`buildTopKComputed` rename
  changed three unrelated `internal`-classified entries' caller lists, which
  `reclassifyOnEvidenceDrift` correctly demoted for re-review; re-curated their unchanged rationale
  on the second pass) plus `go test -tags chdb ./test/rejection-parity/...` — all gates pass
  (`TestCatalogueEntriesAreClassified`, `TestRejectionTriggersExerciseSites`,
  `TestInternalRationalesRestOnCurrentEvidence`, `TestInternalRationaleCitationsStillDispatch`,
  `TestParityCorpusMatchesCatalogue`, `TestShardNamesRoundTrip`).

## Rejection-parity catalogue rotation

`internal/promql/binary.go:lowerVectorSetOp#4924e0ba`'s trigger query is rotated forward from
`topk(3, ...)` (now composes) to `sort(demo_latency_exp_hist or histogram_quantile(0.5,
demo_latency_exp_hist))` — verified this still hits the identical rejection: `lowerMixedExpHistogramFamily`
is invoked only from the query root, and `sort()`/`sort_desc()`/`sort_by_label()` and the
date/time functions (`days_in_month()`, ...) — plus simply stacking two wrapper calls
(`abs(ceil(<mixed or>))`) — are not on its recognizer list, so those still hard-reject. Filed as
#2605, tracking the narrower remaining gap.

Closes #2600
