### PR TITLE
fix(promql): compose sort()/sort_desc() over a mixed float/histogram or

### DIFF
--- a/internal/promql/histogram_native_mixed_or_sort.go
+++ b/internal/promql/histogram_native_mixed_or_sort.go
@@ -1,0 +1,97 @@
+package promql
+
+import (
+	"fmt"
+
+	"github.com/prometheus/prometheus/promql/parser"
+
+	"github.com/tsouza/cerberus/internal/chplan"
+	"github.com/tsouza/cerberus/internal/schema"
+)
+
+// histogram_native_mixed_or_sort.go lowers `sort`/`sort_desc` wrapping a
+// mixed float/histogram `or` — cerberus issue #2605, the sort-specific
+// sibling of the topk/bottomk/quantile composition
+// (histogram_native_mixed_or_aggregate_topk.go, cerberus issue #2600) and
+// the min/max/stddev/stdvar/quantile float-only family
+// (histogram_native_mixed_or_aggregate_float_only.go, cerberus issues
+// #2595/#2600).
+//
+// Reference Prometheus (promql/functions.go's funcSort / funcSortDesc)
+// starts from `filterFloats(vectorVals[0])` — every sample whose `.H`
+// field is set is dropped BEFORE the stable value sort runs, the same
+// "process only float samples" rule the clamp family, the instant-math
+// functions and the five REDUCE-family aggregates
+// (histogram_native_mixed_or_aggregate_float_only.go) already apply
+// against a mixed `or`. [lowerSort]'s own doc comment already cites this
+// exact rule for the NON-mixed (all-histogram) case — see #2456.
+//
+// sort()/sort_desc() are neither a REDUCE operator (they don't fold a
+// group to one row) nor a RANK/SELECT operator (they keep every
+// surviving row, only reordering them) — so, like the float-only family
+// and unlike topk/bottomk's own [chplan.TopK] node, they need no
+// reduction or K-selection machinery at all, just the shadow-resolved
+// FLOAT arm [shadowResolveMixedExpHistogramOperands] already builds for
+// every sibling composition in this file group, fed straight into the
+// SAME `ORDER BY Value [DESC]` plan [lowerSort]'s non-mixed path already
+// builds for an ordinary (non-histogram) argument:
+//
+//  1. [shadowResolveMixedExpHistogramOperands] resolves the `or`'s own
+//     shadow rule for both arms. The histogram-valued return is unused —
+//     filterFloats drops every `.H`-set sample unconditionally, so a
+//     histogram row can never survive into sort()'s output regardless of
+//     which side of the `or` it shadow-resolved to keep (identical
+//     reasoning to topk/bottomk's own header).
+//  2. An ordinary [chplan.OrderBy] over `s.ValueColumn`, ascending for
+//     `sort`/descending for `sort_desc` — the exact node [lowerSort]'s
+//     non-mixed path already emits for a plain instant-vector argument.
+//
+// Checked directly inside [lowerSort] ([sortOverMixedExpHistogramSetOp]
+// below) rather than as a sibling root-only recognizer registered in
+// [lowerMixedExpHistogramFamily]: `sort`/`sort_desc` are ordinary
+// [lowerCall] dispatch targets reached from EVERY nesting depth — the
+// query root, via [lowerRoot]'s own fallthrough to the generic [lower]
+// when [lowerHistogramNativeRoot] finds no root-only recognizer for a
+// bare Call node, AND any wrapper's own recursive [lower] call on one of
+// its own operands (`abs(sort(<mixed or>))`,
+// `label_replace(sort(<mixed or>), ...)`, `sum(sort(<mixed or>))`, …) —
+// not only from [lowerRoot] directly. A root-only registration in
+// [lowerMixedExpHistogramFamily] would therefore have composed the bare
+// root case but left every one of those nested shapes rejected, since
+// nothing else in the histogram-native dispatch tables recurses into a
+// generic Call node's own arguments looking for this shape. Mirrors
+// [lowerVectorSetOpOperand]'s own precedent
+// (histogram_native_mixed_or.go's header, cerberus issue #2555) of
+// checking [mixedExpHistogramSetOp] directly at the one call site that
+// reaches every nesting depth of ITS OWN wrapper, rather than trying to
+// thread a recognizer through [lowerHistogramNativeRoot]'s root-only
+// table.
+func sortOverMixedExpHistogramSetOp(c *parser.Call, s schema.Metrics, ctx lowerCtx) (*parser.BinaryExpr, bool) {
+	if len(c.Args) != 1 {
+		return nil, false
+	}
+	return mixedExpHistogramSetOp(c.Args[0], s, ctx)
+}
+
+// lowerSortOverMixedExpHistogramSetOp lowers the shape
+// [sortOverMixedExpHistogramSetOp] recognised. See this file's header for
+// why the shadow-resolved float arm alone, fed through an ordinary
+// ORDER BY, already answers reference's semantics.
+func lowerSortOverMixedExpHistogramSetOp(c *parser.Call, b *parser.BinaryExpr, s schema.Metrics, ctx lowerCtx) (chplan.Node, error) {
+	if b.ReturnBool {
+		return nil, fmt.Errorf("promql: 'bool' modifier is only allowed on comparison binary ops")
+	}
+
+	_, floatForAgg, err := shadowResolveMixedExpHistogramOperands(b, s, ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	desc := c.Func.Name == "sort_desc"
+	return &chplan.OrderBy{
+		Input: floatForAgg,
+		Keys: []chplan.OrderKey{
+			{Expr: &chplan.ColumnRef{Name: s.ValueColumn}, Desc: desc},
+		},
+	}, nil
+}

--- a/internal/promql/histogram_native_mixed_or_sort_chdb_test.go
+++ b/internal/promql/histogram_native_mixed_or_sort_chdb_test.go
@@ -1,0 +1,209 @@
+//go:build chdb
+
+// chDB-backed proof that `sort()`/`sort_desc()` directly wrapping a mixed
+// float/histogram `or` (cerberus issue #2605,
+// histogram_native_mixed_or_sort.go's [sortOverMixedExpHistogramSetOp] /
+// [lowerSortOverMixedExpHistogramSetOp]) actually DROP every
+// histogram-shaped row and order the float-shaped rows alone at real
+// ClickHouse execution — including the `or`'s own LHS-wins shadow rule
+// when a histogram row and a float row share the identical label
+// signature, and that the composition still applies when `sort()` is
+// reached NESTED under a further wrapper rather than only at the query
+// root.
+//
+// Reuses foSeed / foHistMetric / foFloatMetric / foEvalTS from
+// histogram_native_mixed_or_aggregate_float_only_chdb_test.go and
+// tkShadowSeed / tkShadowHistMetric / tkShadowFloatMetric from
+// histogram_native_mixed_or_aggregate_topk_chdb_test.go (same package,
+// same build tag).
+package promql_test
+
+import (
+	"context"
+	"reflect"
+	"testing"
+
+	"github.com/prometheus/prometheus/promql/parser"
+
+	"github.com/tsouza/cerberus/internal/chplan"
+	"github.com/tsouza/cerberus/internal/chsql"
+	"github.com/tsouza/cerberus/internal/promql"
+	"github.com/tsouza/cerberus/internal/schema"
+	"github.com/tsouza/cerberus/internal/testsql"
+)
+
+// srSeriesOrder runs query and returns the `series` label of every output
+// row IN THE ORDER the emitted SQL returns them, for queries expected to
+// preserve row order (sort()/sort_desc()'s whole point).
+func srSeriesOrder(t *testing.T, fixture *chdbFixture, s schema.Metrics, p parser.Parser, query string) []string {
+	t.Helper()
+	expr, err := p.ParseExpr(query)
+	if err != nil {
+		t.Fatalf("ParseExpr(%q): %v", query, err)
+	}
+	plan, err := promql.LowerAt(context.Background(), expr, s, foEvalTS, foEvalTS)
+	if err != nil {
+		t.Fatalf("LowerAt(%q): %v", query, err)
+	}
+	if shape := chplan.RowShapeOf(plan); shape != chplan.SampleRowShape {
+		t.Fatalf("lower(%q): plan root publishes %s, want %s (sort/sort_desc always drop to a plain float vector over a mixed or)", query, shape, chplan.SampleRowShape)
+	}
+	sqlStr, args, err := chsql.Emit(context.Background(), plan)
+	if err != nil {
+		t.Fatalf("Emit(%q): %v", query, err)
+	}
+	rows := fixture.queryOverEmitted(t, "`Attributes`['series'] AS series", sqlStr, args)
+	defer func() { _ = rows.Close() }()
+
+	var order []string
+	for rows.Next() {
+		var series string
+		if err := rows.Scan(&series); err != nil {
+			t.Fatalf("scan: %v", err)
+		}
+		order = append(order, series)
+	}
+	if err := testsql.TolerantRowsErr(rows.Err()); err != nil {
+		t.Fatalf("rows.Err: %v", err)
+	}
+	return order
+}
+
+// TestSortSortDescOverMixedSetOpOr_ChDB proves sort()/sort_desc(), wrapped
+// directly around a mixed `or`, order the three float-shaped rows
+// (f1=3, f2=9, f3=1) alone by Value and drop the two histogram-shaped
+// rows (h1, h2) entirely — for both source-AST operand orders, since the
+// mixed `or`'s shadow rule depends on which side is LHS.
+func TestSortSortDescOverMixedSetOpOr_ChDB(t *testing.T) {
+	fixture := newChDBFixture(t, foSeed)
+	s := schema.DefaultOTelMetrics()
+	p := parser.NewParser(parser.Options{EnableExperimentalFunctions: true})
+
+	cases := []struct {
+		name  string
+		query string
+		want  []string
+	}{
+		{
+			"sort_histLHS",
+			"sort(" + foHistMetric + " or " + foFloatMetric + ")",
+			[]string{"f3", "f1", "f2"},
+		},
+		{
+			"sort_floatLHS",
+			"sort(" + foFloatMetric + " or " + foHistMetric + ")",
+			[]string{"f3", "f1", "f2"},
+		},
+		{
+			"sort_desc_histLHS",
+			"sort_desc(" + foHistMetric + " or " + foFloatMetric + ")",
+			[]string{"f2", "f1", "f3"},
+		},
+		{
+			"sort_desc_floatLHS",
+			"sort_desc(" + foFloatMetric + " or " + foHistMetric + ")",
+			[]string{"f2", "f1", "f3"},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := srSeriesOrder(t, fixture, s, p, tc.query)
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Errorf("query %q: order = %v, want %v (a histogram-blind bug would include h1/h2's placeholder 0.0 in the ordering)", tc.query, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestSortOverMixedSetOpOr_ShadowCollision_ChDB proves the `or`'s own
+// LHS-wins shadow rule composes correctly with sort()'s histogram drop:
+// when the histogram side is the source-AST LHS, the colliding float row
+// ("dup"=42) is shadowed out of the `or`'s own output entirely, so it can
+// never appear in sort()'s output. When the float side is LHS instead,
+// its own "dup" row is never shadowed and sort() ranks it normally.
+// Reuses tkShadowSeed / tkShadowHistMetric / tkShadowFloatMetric from
+// histogram_native_mixed_or_aggregate_topk_chdb_test.go.
+func TestSortOverMixedSetOpOr_ShadowCollision_ChDB(t *testing.T) {
+	fixture := newChDBFixture(t, tkShadowSeed)
+	s := schema.DefaultOTelMetrics()
+	p := parser.NewParser(parser.Options{EnableExperimentalFunctions: true})
+
+	cases := []struct {
+		name  string
+		query string
+		want  []string
+	}{
+		{
+			"histLHS_dupShadowedOut",
+			"sort(" + tkShadowHistMetric + " or " + tkShadowFloatMetric + ")",
+			[]string{"solo"},
+		},
+		{
+			"floatLHS_dupSurvives",
+			"sort(" + tkShadowFloatMetric + " or " + tkShadowHistMetric + ")",
+			[]string{"solo", "dup"},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := srSeriesOrder(t, fixture, s, p, tc.query)
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Errorf("query %q: order = %v, want %v", tc.query, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestSortOverMixedSetOpOr_NestedUnderWrapper_ChDB proves the composition
+// applies when sort()/sort_desc() is reached NESTED under a further
+// wrapper, not only at the query root — the "nested wrappers" half of
+// cerberus issue #2605's title. abs() is an arbitrary instant-math
+// wrapper chosen because it reads the shadow-resolved float arm's own
+// Value column, so a histogram row wrongly surviving into it would
+// surface as a wrong count or a wrong value rather than merely a wrong
+// order.
+func TestSortOverMixedSetOpOr_NestedUnderWrapper_ChDB(t *testing.T) {
+	fixture := newChDBFixture(t, foSeed)
+	s := schema.DefaultOTelMetrics()
+	p := parser.NewParser(parser.Options{EnableExperimentalFunctions: true})
+
+	query := "abs(sort_desc(" + foHistMetric + " or " + foFloatMetric + "))"
+	expr, err := p.ParseExpr(query)
+	if err != nil {
+		t.Fatalf("ParseExpr(%q): %v", query, err)
+	}
+	plan, err := promql.LowerAt(context.Background(), expr, s, foEvalTS, foEvalTS)
+	if err != nil {
+		t.Fatalf("LowerAt(%q): %v", query, err)
+	}
+	sqlStr, args, err := chsql.Emit(context.Background(), plan)
+	if err != nil {
+		t.Fatalf("Emit(%q): %v", query, err)
+	}
+	rows := fixture.queryOverEmitted(t, "`Attributes`['series'] AS series, `Value` AS val", sqlStr, args)
+	defer func() { _ = rows.Close() }()
+
+	got := map[string]float64{}
+	var order []string
+	for rows.Next() {
+		var series string
+		var val float64
+		if err := rows.Scan(&series, &val); err != nil {
+			t.Fatalf("scan: %v", err)
+		}
+		got[series] = val
+		order = append(order, series)
+	}
+	if err := testsql.TolerantRowsErr(rows.Err()); err != nil {
+		t.Fatalf("rows.Err: %v", err)
+	}
+
+	wantOrder := []string{"f2", "f1", "f3"}
+	if !reflect.DeepEqual(order, wantOrder) {
+		t.Errorf("query %q: order = %v, want %v", query, order, wantOrder)
+	}
+	want := map[string]float64{"f1": 3, "f2": 9, "f3": 1}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("query %q: values = %v, want %v (a histogram-blind bug would include h1/h2's placeholder 0.0)", query, got, want)
+	}
+}

--- a/internal/promql/sort.go
+++ b/internal/promql/sort.go
@@ -70,6 +70,19 @@ func lowerSort(c *parser.Call, s schema.Metrics, ctx lowerCtx) (chplan.Node, err
 		}
 		return dropped, nil
 	}
+	// `or` between a float-valued operand and a histogram-valued operand
+	// (cerberus issue #2330) directly wrapped by sort()/sort_desc(),
+	// reached from ANY nesting depth since [lowerCall] is the single
+	// generic dispatch point for this function regardless of whether it
+	// sits at the query root or nested under another wrapper (cerberus
+	// issue #2605). See histogram_native_mixed_or_sort.go's own doc
+	// comment for why reference's filterFloats rule composes with no
+	// reduction machinery at all — just the shadow-resolved float arm fed
+	// into the same OrderBy this function's own non-mixed path builds
+	// below.
+	if b, ok := sortOverMixedExpHistogramSetOp(c, s, ctx); ok {
+		return lowerSortOverMixedExpHistogramSetOp(c, b, s, ctx)
+	}
 	inner, err := lower(c.Args[0], s, ctx)
 	if err != nil {
 		return nil, err

--- a/test/rejection-parity/catalogue/internal__promql__binary.go__lowerVectorSetOp.json
+++ b/test/rejection-parity/catalogue/internal__promql__binary.go__lowerVectorSetOp.json
@@ -5,7 +5,7 @@
       "site": "internal/promql/binary.go:lowerVectorSetOp#4924e0ba",
       "message": "promql: 'or' between a float-valued and a histogram-valued operand is not supported; 'and'/'unless' support mixing them",
       "class": "divergence",
-      "trigger_query": "sort(demo_latency_exp_hist or histogram_quantile(0.5, demo_latency_exp_hist))",
+      "trigger_query": "days_in_month(demo_latency_exp_hist or histogram_quantile(0.5, demo_latency_exp_hist))",
       "tracking_issue": 2605,
       "evidence": {
         "guard": [

--- a/test/rejection-parity/catalogue/internal__promql__histogram_native_mixed_or_sort.go__lowerSortOverMixedExpHistogramSetOp.json
+++ b/test/rejection-parity/catalogue/internal__promql__histogram_native_mixed_or_sort.go__lowerSortOverMixedExpHistogramSetOp.json
@@ -1,0 +1,24 @@
+{
+  "entries": [
+    {
+      "head": "promql",
+      "site": "internal/promql/histogram_native_mixed_or_sort.go:lowerSortOverMixedExpHistogramSetOp#6cdf660e",
+      "message": "promql: 'bool' modifier is only allowed on comparison binary ops",
+      "class": "internal",
+      "rationale": "the parser rejects `bool` on non-comparison operators (\"bool modifier can only be used on comparison operators\"), same as lowerSumOrAvgOverMixedExpHistogramSetOp's identical check (histogram_native_mixed_or_aggregate.go, cerberus issue #2346) and its histogram_native_mixed_or_aggregate_presence.go / histogram_native_mixed_or_aggregate_count_values.go / histogram_native_mixed_or_aggregate_float_only.go / histogram_native_mixed_or_aggregate_topk.go siblings (cerberus issue #2595 / #2600). sortOverMixedExpHistogramSetOp only ever matches b via mixedExpHistogramSetOp, which requires b.Op == parser.LOR — `or` is a set operator, never a comparison, so the parser can never have set ReturnBool on it.",
+      "evidence": {
+        "guard": [
+          "if b.ReturnBool"
+        ],
+        "callers": [
+          "lowerSort"
+        ],
+        "cited": [
+          "lowerSumOrAvgOverMixedExpHistogramSetOp",
+          "mixedExpHistogramSetOp",
+          "sortOverMixedExpHistogramSetOp"
+        ]
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

- `sort()`/`sort_desc()` rejected when wrapping a mixed float/histogram `or` (#2330), regardless of
  nesting depth — at the query root or nested under another already-composed wrapper alike — since
  neither was on `lowerMixedExpHistogramFamily`'s root-only recognizer list.
- Reference Prometheus's `funcSort`/`funcSortDesc` (`promql/functions.go`) start from
  `filterFloats(vectorVals[0])`, dropping every histogram-valued sample before the value sort runs —
  the identical drop rule the `min`/`max`/`stddev`/`stdvar`/`quantile` float-only family already
  composes (#2595/#2600). Unlike that REDUCE family and unlike `topk`/`bottomk`'s RANK/SELECT
  machinery, `sort`/`sort_desc` need neither: the shadow-resolved float arm
  (`shadowResolveMixedExpHistogramOperands`) fed straight into the same `OrderBy`
  `lowerSort`'s non-mixed path already builds is the whole answer
  (`internal/promql/histogram_native_mixed_or_sort.go`, new).
- Checked directly inside `lowerSort` rather than as a root-only registration in
  `lowerMixedExpHistogramFamily`: `lowerCall` is the single generic dispatch point `sort`/`sort_desc`
  reach from **any** nesting depth, so fixing the recognizer there composes both the root case and
  every nested case (`abs(sort(...))`, `label_replace(sort(...), ...)`, `sum(sort(...))`, ...) in one
  fix — mirroring `lowerVectorSetOpOperand`'s own precedent (#2555) for threading a recognizer
  through a non-root-only call site instead of `lowerHistogramNativeRoot`'s root-only table.
- Verified against real ClickHouse execution via a chDB parity test
  (`internal/promql/histogram_native_mixed_or_sort_chdb_test.go`): correct ordering for both operand
  orders, the `or`'s own LHS-wins shadow-collision rule, and composition when `sort_desc()` is nested
  under a further `abs()` wrapper.

## Deliberately left open

`sort_by_label()`/`sort_by_label_desc()` are **not** drop-family: reference Prometheus's
`funcSortByLabel`/`funcSortByLabelDesc` never touch `.H`/`.F` at all, so a histogram sample sorts (and
survives) right alongside float samples — the opposite composition from `sort`/`sort_desc`, needing a
preserve-both-arms mechanism this PR doesn't build. Left open, tracked by the rejection-parity
catalogue rotation below (the next found-still-rejecting trigger was `days_in_month(...)`, not
`sort_by_label`, but `sort_by_label(<mixed or>)` still rejects too — a systematic sweep over PromQL's
function table applied to the mixed-or shape found it alongside the date/time family).

## Rejection-parity catalogue

Rotates `internal/promql/binary.go:lowerVectorSetOp#4924e0ba`'s `trigger_query` forward from
`sort(...)` (now composes) to `days_in_month(demo_latency_exp_hist or histogram_quantile(0.5,
demo_latency_exp_hist))` — the issue's own evidence section already named the date/time family as
still-rejecting, and a systematic sweep (date/time functions, `sort_by_label`, double-nested
wrappers, `limitk`/`limit_ratio`) confirmed `days_in_month` genuinely still hits this exact site.
Regenerated via `CERBERUS_UPDATE_INVENTORY=1 go test -run TestCatalogueIsRegenerable
./test/rejection-parity/...`, run twice (idempotent) since `class`/`rationale` on the new
`lowerSortOverMixedExpHistogramSetOp`'s own `bool`-modifier-guard entry were hand-curated to match
its `topk`/`bottomk` sibling's.

## Test plan

- [x] `go test -tags chdb -race ./internal/promql/...` narrowed to the new/touched tests — all pass
      (`TestSortSortDescOverMixedSetOpOr_ChDB`, `TestSortOverMixedSetOpOr_ShadowCollision_ChDB`,
      `TestSortOverMixedSetOpOr_NestedUnderWrapper_ChDB`, plus the existing sort/sort_by_label spec
      fixtures and the sibling min/max/topk/quantile mixed-or suites, to confirm no regression).
- [x] `go test -race ./internal/promql/...` (non-chdb) — pass.
- [x] `go test -race ./test/rejection-parity/...` — pass.
- [x] CI (lint, coverage, strict-scan, compat-promql, etc.) — pending on this PR.

Closes #2605
