### PR TITLE
fix(promql): let absent()'s subquery form skip the exp-histogram check

### DIFF
--- a/docs/coverage.md
+++ b/docs/coverage.md
@@ -86,7 +86,7 @@ single canonical probe, so a function that lowers `sort_by_label(v, "l")` and
 rejects `sort_by_label(v)` still counts as one supported symbol.
 
 Shape-level wrong-rejections are measured separately, by the rejection-parity
-catalogue: across all three heads it records **5** open argument-shape
+catalogue: across all three heads it records **4** open argument-shape
 divergences — queries the reference backend answers and cerberus rejects. Each
 is one `class: "divergence"` row in
 [`test/rejection-parity/catalogue/`](../test/rejection-parity/catalogue),

--- a/internal/promql/absent_subquery_exp_histogram_chdb_test.go
+++ b/internal/promql/absent_subquery_exp_histogram_chdb_test.go
@@ -1,0 +1,143 @@
+//go:build chdb
+
+// chDB-backed proof that `absent(<exp-histogram selector>)[<range>:<step>]`
+// (cerberus issue #2602) lowers to valid SQL and EXECUTES against real
+// ClickHouse, instead of hard-rejecting via expHistogramSelectorRouting's
+// catch-all — the subquery sibling of #2443 (instant absent()) and #2226
+// (absent_over_time()), both of which already had chdb-free structural
+// coverage before this fix; this file adds the execution-level proof the
+// composition never had.
+//
+// Two arms:
+//   - "densely_present": the series has a sample every minute across the
+//     whole subquery window, so every anchor's 5-minute staleness lookback
+//     finds a match — absent() must report NOTHING (zero output rows).
+//   - "genuinely_absent": the series has zero rows anywhere in the table,
+//     so every anchor's lookback comes up empty — absent() must report a
+//     synthesised `1` row at EVERY anchor of the subquery grid.
+package promql_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/prometheus/prometheus/promql/parser"
+
+	"github.com/tsouza/cerberus/internal/chsql"
+	"github.com/tsouza/cerberus/internal/promql"
+	"github.com/tsouza/cerberus/internal/schema"
+	"github.com/tsouza/cerberus/internal/testsql"
+)
+
+const absentSubqueryPresentMetric = "absent_subquery_present_probe_exp_hist"
+
+// absentSubqueryEvalTS anchors the [10m:1m] subquery grid at
+// [00:10:00, 00:20:00] (11 anchors, one per minute).
+var (
+	absentSubqueryEvalTS   = time.Date(2026, 1, 1, 0, 20, 0, 0, time.UTC)
+	absentSubqueryGridSize = 11 // (10m / 1m) + 1, inclusive of both grid ends
+)
+
+// absentSubquerySeed seeds one series (job="api") with a sample every
+// minute from 00:00:00 through 00:25:00 — comfortably covering the
+// [00:05:00, 00:20:00] span every one of the grid's 11 anchors' own 5m
+// staleness lookback reads from.
+var absentSubquerySeed = "" +
+	"CREATE OR REPLACE TABLE otel_metrics_exponential_histogram (" +
+	"`MetricName` String, `Attributes` Map(String, String), " +
+	"`ResourceAttributes` Map(String, String) DEFAULT map(), `ServiceName` LowCardinality(String) DEFAULT '', " +
+	"`TimeUnix` DateTime64(9), " +
+	"`Count` UInt64, `Sum` Float64, `Scale` Int32, `ZeroCount` UInt64, " +
+	"`PositiveOffset` Int32, `PositiveBucketCounts` Array(UInt64), " +
+	"`NegativeOffset` Int32, `NegativeBucketCounts` Array(UInt64)" +
+	") ENGINE = MergeTree ORDER BY (`MetricName`, `Attributes`, `TimeUnix`);\n" +
+	absentSubqueryPresentInserts()
+
+func absentSubqueryPresentInserts() string {
+	out := "INSERT INTO otel_metrics_exponential_histogram " +
+		"(MetricName, Attributes, TimeUnix, Count, Sum, Scale, ZeroCount, PositiveOffset, PositiveBucketCounts, NegativeOffset, NegativeBucketCounts) VALUES\n"
+	base := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	for i := 0; i <= 25; i++ {
+		ts := base.Add(time.Duration(i) * time.Minute)
+		sep := ",\n"
+		if i == 25 {
+			sep = ";\n"
+		}
+		out += "    ('" + absentSubqueryPresentMetric + "', map('job', 'api'), toDateTime64('" +
+			ts.Format("2006-01-02 15:04:05") + "', 9), 1, 1.0, 0, 0, 0, [1], 0, [])" + sep
+	}
+	return out
+}
+
+func TestLower_ExpHistogram_AbsentSubquery_ChDB(t *testing.T) {
+	fixture := newChDBFixture(t, absentSubquerySeed)
+	s := schema.DefaultOTelMetrics()
+	p := parser.NewParser(parser.Options{EnableExperimentalFunctions: true})
+
+	cases := []struct {
+		name      string
+		query     string
+		wantRows  int
+		wantValue float64
+	}{
+		// The fixed composition, executed over a series with a matching
+		// sample inside every anchor's 5m lookback: absent() must find
+		// the series present at every one of the 11 anchors and emit
+		// nothing.
+		{
+			name:     "densely_present",
+			query:    `absent(` + absentSubqueryPresentMetric + `{job="api"})[10m:1m]`,
+			wantRows: 0,
+		},
+		// The genuinely-empty case: a selector matching zero rows
+		// anywhere in the exp-histogram table. Every anchor's lookback
+		// comes up empty, so absent() must emit the synthesised `1` row
+		// at each of the grid's 11 anchors.
+		{
+			name:      "genuinely_absent",
+			query:     `absent(` + absentSubqueryPresentMetric + `{job="nonexistent"})[10m:1m]`,
+			wantRows:  absentSubqueryGridSize,
+			wantValue: 1.0,
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			expr, err := p.ParseExpr(tc.query)
+			if err != nil {
+				t.Fatalf("ParseExpr(%q): %v", tc.query, err)
+			}
+			plan, err := promql.LowerAt(context.Background(), expr, s, absentSubqueryEvalTS, absentSubqueryEvalTS)
+			if err != nil {
+				t.Fatalf("LowerAt(%q): unexpected error (this exact composition was hard-rejected via expHistogramSelectorRouting's catch-all before cerberus issue #2602's fix): %v", tc.query, err)
+			}
+			sqlStr, args, err := chsql.Emit(context.Background(), plan)
+			if err != nil {
+				t.Fatalf("Emit(%q): %v", tc.query, err)
+			}
+
+			rows := fixture.queryOverEmitted(t, "Value", sqlStr, args)
+			defer func() { _ = rows.Close() }()
+
+			n := 0
+			for rows.Next() {
+				n++
+				var v float64
+				if err := rows.Scan(&v); err != nil {
+					t.Fatalf("scan Value: %v", err)
+				}
+				if tc.wantRows > 0 && v != tc.wantValue {
+					t.Errorf("query %q: row %d Value = %v, want %v", tc.query, n, v, tc.wantValue)
+				}
+			}
+			if err := testsql.TolerantRowsErr(rows.Err()); err != nil {
+				t.Fatalf("rows.Err: %v", err)
+			}
+			if n != tc.wantRows {
+				t.Fatalf("query %q: got %d rows, want %d", tc.query, n, tc.wantRows)
+			}
+		})
+	}
+}

--- a/internal/promql/exp_histogram_absent_subquery_test.go
+++ b/internal/promql/exp_histogram_absent_subquery_test.go
@@ -1,0 +1,118 @@
+package promql_test
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/prometheus/prometheus/promql/parser"
+
+	"github.com/tsouza/cerberus/internal/chplan"
+	"github.com/tsouza/cerberus/internal/chsql"
+	"github.com/tsouza/cerberus/internal/promql"
+	"github.com/tsouza/cerberus/internal/schema"
+)
+
+// TestLower_ExpHistogram_AbsentSubqueryIsPresenceOnly pins issue #2602:
+// absent()/absent_over_time() are value-agnostic (they only ever ask
+// whether ANY sample existed, never what it was), so
+// `absent(<exp-histogram selector>)[<range>:<step>]` must lower
+// successfully the same way the un-wrapped instant `absent(v)` already
+// does (#2443) and `absent_over_time(v[range])` already does (#2226).
+//
+// Before this fix, lowerSubqueryOverAbsent's bare-VectorSelector branch
+// called lowerVectorSelector directly — the full Sample-shape pipeline a
+// value-reading consumer needs — which hits expHistogramSelectorRouting's
+// catch-all rejection for an exp-histogram metric even though
+// chplan.AbsentOverTime never reads the scan's Value column.
+func TestLower_ExpHistogram_AbsentSubqueryIsPresenceOnly(t *testing.T) {
+	t.Parallel()
+
+	s := schema.DefaultOTelMetrics()
+	p := parser.NewParser(parser.Options{EnableExperimentalFunctions: true})
+	start := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	end := start.Add(20 * time.Minute)
+
+	cases := []struct {
+		name  string
+		query string
+		lower func(parser.Expr) (chplan.Node, error)
+	}{
+		{
+			name:  "instant",
+			query: `absent(latency_exp_hist{job="api"})[10m:1m]`,
+			lower: func(e parser.Expr) (chplan.Node, error) {
+				return promql.LowerAt(context.Background(), e, s, end, end)
+			},
+		},
+		{
+			name:  "range",
+			query: `absent(latency_exp_hist{job="api"})[10m:1m]`,
+			lower: func(e parser.Expr) (chplan.Node, error) {
+				return promql.LowerAtRange(context.Background(), e, s, start, end, time.Minute)
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			expr, err := p.ParseExpr(tc.query)
+			if err != nil {
+				t.Fatalf("ParseExpr(%q): %v", tc.query, err)
+			}
+			plan, err := tc.lower(expr)
+			if err != nil {
+				t.Fatalf("Lower(%q): %v (this exact composition was rejected via expHistogramSelectorRouting's catch-all before cerberus issue #2602's fix)", tc.query, err)
+			}
+
+			var absent *chplan.AbsentOverTime
+			chplan.Walk(plan, func(n chplan.Node) bool {
+				if a, ok := n.(*chplan.AbsentOverTime); ok {
+					absent = a
+				}
+				return true
+			})
+			if absent == nil {
+				t.Fatalf("Lower(%q): no *chplan.AbsentOverTime in plan", tc.query)
+			}
+
+			var scan *chplan.Scan
+			chplan.Walk(absent.Input, func(n chplan.Node) bool {
+				if candidate, ok := n.(*chplan.Scan); ok {
+					scan = candidate
+				}
+				return true
+			})
+			if scan == nil || scan.Table != s.ExpHistogramTable {
+				t.Fatalf("presence scan = %#v, want table %q", scan, s.ExpHistogramTable)
+			}
+
+			// The presence stream must never reference the exp-histogram
+			// table's absent scalar Value column: AbsentOverTime.Input only
+			// needs the row's existence, so a Value reference would mean
+			// the lowering fell back onto the ordinary float selector
+			// pipeline this fix bypasses.
+			chplan.Walk(absent.Input, func(n chplan.Node) bool {
+				chplan.InspectNodeExprs(n, func(e chplan.Expr) {
+					chplan.InspectExpr(e, func(inner chplan.Expr) bool {
+						if col, ok := inner.(*chplan.ColumnRef); ok && col.Name == s.ValueColumn {
+							t.Errorf("presence-only input references nonexistent float column %q", s.ValueColumn)
+						}
+						return true
+					})
+				})
+				return true
+			})
+
+			sqlText, _, err := chsql.Emit(context.Background(), plan)
+			if err != nil {
+				t.Fatalf("Emit(%q): %v", tc.query, err)
+			}
+			if strings.Contains(sqlText, "`Value` AS `Value` FROM (SELECT * FROM `"+s.ExpHistogramTable+"`") {
+				t.Fatalf("native-histogram scan was routed through a float Value projection:\n%s", sqlText)
+			}
+		})
+	}
+}

--- a/internal/promql/subquery.go
+++ b/internal/promql/subquery.go
@@ -1869,7 +1869,15 @@ func lowerSubqueryOverAbsent(
 	if len(call.Args) == 1 {
 		if vs, ok := unwrapParens(call.Args[0]).(*parser.VectorSelector); ok {
 			vsNoMod, rangeCtx := stripSelectorModifierForRangeVector(vs, ctx)
-			inner, err := lowerVectorSelector(&vsNoMod, s, rangeCtx)
+			// lowerAbsencePresenceSelector, not lowerVectorSelector: this
+			// AbsentOverTime.Input only ever needs the row's existence
+			// (its TimestampColumn), never s.ValueColumn, so an
+			// exponential-histogram selector — which has no Value column
+			// to route through the ordinary Sample-shape pipeline — must
+			// bypass expHistogramSelectorRouting the same way the instant
+			// absent() and absent_over_time() bare-selector arms already
+			// do (cerberus issue #2602, the subquery sibling of #2443).
+			inner, err := lowerAbsencePresenceSelector(&vsNoMod, s, rangeCtx)
 			if err != nil {
 				return nil, err
 			}

--- a/test/rejection-parity/catalogue/internal__promql__binary.go__lowerVectorSetOp.json
+++ b/test/rejection-parity/catalogue/internal__promql__binary.go__lowerVectorSetOp.json
@@ -6,7 +6,7 @@
       "message": "promql: 'or' between a float-valued and a histogram-valued operand is not supported; 'and'/'unless' support mixing them",
       "class": "divergence",
       "trigger_query": "days_in_month(demo_latency_exp_hist or histogram_quantile(0.5, demo_latency_exp_hist))",
-      "tracking_issue": 2605,
+      "tracking_issue": 2609,
       "evidence": {
         "guard": [
           "past returning if err != nil",

--- a/test/rejection-parity/catalogue/internal__promql__lower.go__expHistogramSelectorRouting.json
+++ b/test/rejection-parity/catalogue/internal__promql__lower.go__expHistogramSelectorRouting.json
@@ -4,9 +4,8 @@
       "head": "promql",
       "site": "internal/promql/lower.go:expHistogramSelectorRouting#bf746b59",
       "message": "promql: %q is an exponential histogram metric; only a bare %q selector, sum()/avg()/count() over one, rate()/increase()/delta()/irate()/idelta()/sum_over_time()/avg_over_time()/resets()/changes() over one, histogram_quantile(), histogram_count(), histogram_sum(), and the %q/%q companion selectors are supported",
-      "class": "divergence",
-      "trigger_query": "absent(demo_latency_exp_hist)[10m:1m]",
-      "tracking_issue": 2602,
+      "class": "internal",
+      "rationale": "this catch-all's own reachability is not disputed — every prior trigger this session (issue #2571, then #2578→#2583→#2590→#2591→#2602 in sequence) closed by teaching a new composability path, and each closure exposed the next live query that still hit it. After #2602's fix (absent() over a subquery-wrapped bare exp-histogram selector) closes the query that most recently triggered it, three independent systematic sweeps of the vendored PromQL parser's function table — roughly 700 combined probe queries across bare/subquery/nested/aggregation/binop/label-fn/@-modifier/offset combinations — found no remaining shape that reaches this site. That is a claim about current EXHAUSTION, not about PROVABLE unreachability: the guard is still live code on a still-reachable wire path, and a future PromQL feature or an uncomposed corner this sweep missed could resurrect a real trigger. Classified internal as the closest fit among this catalogue's three classes rather than fabricating a trigger_query; TestRejectionTriggersExerciseSites has no way to assert a negative (\"no query reaches this\"), so this entry stays honest by declaring the empirical state plainly instead of forcing a stale or contrived divergence.",
       "evidence": {
         "guard": [
           "past returning if bare, col, hasCompanion := s.HistogramCompanionColumn(metricName); hasCompanion \u0026\u0026 s.IsExpHistogramMetric(bare) \u0026\u0026 s.ExpHistogramTable != \"\"",
@@ -16,8 +15,7 @@
         "callers": [
           "resolveSelectorRouting"
         ]
-      },
-      "since": "2026-08-25"
+      }
     }
   ]
 }


### PR DESCRIPTION
## Summary

`lowerSubqueryOverAbsent`'s bare-selector branch called `lowerVectorSelector` directly on the
exp-histogram selector to build `chplan.AbsentOverTime`'s `Input`, routing through the full
Sample-shape pipeline and hitting `expHistogramSelectorRouting`'s catch-all rejection. The instant
`absent(v)` case (`internal/promql/absent.go`'s `lowerAbsent`) already special-cases a bare
`VectorSelector` argument to read only label matchers via `lowerAbsencePresenceSelector`, never
`Value` — presence is fundamentally value-agnostic. `lowerSubqueryOverAbsent` now reuses the same
helper, so `absent(<exp-histogram selector>)[range:step]` composes instead of rejecting.

## Catalogue reclassification

Rotates the rejection-parity catalogue's `expHistogramSelectorRouting` entry from
`class: "divergence"` to `class: "internal"`. Three independent systematic sweeps of the vendored
PromQL parser's function table this session — roughly 700 combined probe queries across
bare/subquery/nested/aggregation/binop/label-fn/`@`-modifier/offset combinations — found no
remaining query that still reaches this catch-all after this fix. The rationale documents this
honestly as empirical exhaustion at the time of writing, not provable unreachability: the guard is
still live code on a reachable wire path, and a future PromQL feature or an uncomposed corner this
sweep missed could resurrect a real trigger later.

## Test plan

- [x] New chDB round-trip test: `TestLower_ExpHistogram_AbsentSubquery_ChDB` (densely-present and
      genuinely-absent cases)
- [x] New unit test: `TestLower_ExpHistogram_AbsentSubqueryIsPresenceOnly` (instant + range)
- [x] `test/rejection-parity` and `test/regression`'s
      `TestPromQLRejectionTriggersUseSeededMetrics` pass with the reclassified entry
- [x] `go build ./...`, `gofumpt -extra`, `goimports -local`, `node .github/scripts/forbid-sql-raw.mjs`,
      `golangci-lint --enable-only=maintidx` all clean

Closes #2602
