### PR TITLE
fix(promql): compose date/time functions over a mixed float/histogram or

### DIFF
--- a/internal/promql/date_fns.go
+++ b/internal/promql/date_fns.go
@@ -98,6 +98,21 @@ func lowerDateFn(c *parser.Call, s schema.Metrics, ctx lowerCtx) (chplan.Node, e
 		}
 	}
 
+	// `or` between a float-valued operand and a histogram-valued operand
+	// (cerberus issue #2330) directly wrapped by one of the eight
+	// value-reading date functions, reached from ANY nesting depth since
+	// [lowerCall] is the single generic dispatch point for this function
+	// regardless of whether it sits at the query root or nested under
+	// another wrapper (cerberus issue #2609). See
+	// histogram_native_mixed_or_datefn.go's own doc comment for why
+	// reference's dateWrapper drop rule composes with no reduction
+	// machinery at all — just the shadow-resolved float arm fed into the
+	// same value projection this function's own non-mixed path builds
+	// below.
+	if b, ok := dateFnOverMixedExpHistogramSetOp(c, s, ctx); ok {
+		return lowerDateFnOverMixedExpHistogramSetOp(c, b, s, ctx)
+	}
+
 	// The argument is lowered under an ARGUMENT ctx rather than the caller's
 	// own, because `timestamp(<vector-selector>)` needs the selector seam to
 	// publish a column no other consumer asks for. Every other function/shape

--- a/internal/promql/histogram_native_mixed_or_datefn.go
+++ b/internal/promql/histogram_native_mixed_or_datefn.go
@@ -1,0 +1,86 @@
+package promql
+
+import (
+	"fmt"
+
+	"github.com/prometheus/prometheus/promql/parser"
+
+	"github.com/tsouza/cerberus/internal/chplan"
+	"github.com/tsouza/cerberus/internal/schema"
+)
+
+// histogram_native_mixed_or_datefn.go lowers the eight VALUE-READING
+// date-component functions (`year`/`month`/`day_of_month`/`day_of_week`/
+// `day_of_year`/`days_in_month`/`hour`/`minute` — NOT `timestamp`, which
+// reads a sample's own TIME column rather than its Value and already has
+// its own histogram-valued lowering in histogram_native_timestamp.go)
+// wrapping a mixed float/histogram `or` — cerberus issue #2609, the
+// date-function-family sibling of sort()/sort_desc()'s own composition
+// (histogram_native_mixed_or_sort.go, cerberus issue #2605).
+//
+// Reference Prometheus (promql/functions.go's dateWrapper, the shared
+// helper year/month/day_of_month/day_of_week/day_of_year/days_in_month/
+// hour/minute all route through) skips every sample whose `.H` field is
+// set before computing the date component from `.V` — the identical
+// "process only float samples, drop the rest" rule sort()/sort_desc()
+// and the float-only aggregate family already mirror against a mixed
+// `or`. date_fns.go's own package doc already cites this exact rule for
+// the non-mixed (all-histogram) argument case (cerberus issue #2498).
+//
+// Like sort()/sort_desc() and unlike the REDUCE-family aggregates, a
+// date function is a per-row transform: it keeps every surviving row (no
+// grouping, no K-selection), so composing it over a mixed `or` needs
+// nothing beyond the shadow-resolved FLOAT arm
+// [shadowResolveMixedExpHistogramOperands] already builds for every
+// sibling composition in this file group, fed through the SAME
+// [guardedValueProjection] / [dateFnExpr] pipeline [lowerDateFn]'s
+// non-mixed path already builds for an ordinary (non-histogram)
+// argument. The histogram-valued return is unused for the identical
+// reason topk/bottomk/sort's own headers give: dateWrapper drops every
+// `.H`-set sample unconditionally, so a histogram row can never survive
+// into the output regardless of which side of the `or` it
+// shadow-resolved to keep.
+//
+// Checked directly inside [lowerDateFn]
+// ([dateFnOverMixedExpHistogramSetOp] below) rather than as a root-only
+// recognizer registered in [lowerMixedExpHistogramFamily]: date
+// functions are ordinary [lowerCall] dispatch targets reached from EVERY
+// nesting depth, exactly like sort()/sort_desc() — see
+// histogram_native_mixed_or_sort.go's header for the full argument,
+// which applies here unchanged.
+//
+// `timestamp` is excluded by name: it reads tsRef (the argument's own
+// TIME, not its Value) and reference's `funcTimestamp`/
+// `rangeEvalTimestampFunctionOverVectorSelector` never inspect `.H` at
+// all, so it needs no drop rule — and it is not one of the eight
+// functions cerberus issue #2609 scopes.
+func dateFnOverMixedExpHistogramSetOp(c *parser.Call, s schema.Metrics, ctx lowerCtx) (*parser.BinaryExpr, bool) {
+	if len(c.Args) != 1 || c.Func.Name == "timestamp" {
+		return nil, false
+	}
+	return mixedExpHistogramSetOp(c.Args[0], s, ctx)
+}
+
+// lowerDateFnOverMixedExpHistogramSetOp lowers the shape
+// [dateFnOverMixedExpHistogramSetOp] recognised. See this file's header
+// for why the shadow-resolved float arm alone, fed through the ordinary
+// date-component value projection, already answers reference's
+// semantics.
+func lowerDateFnOverMixedExpHistogramSetOp(c *parser.Call, b *parser.BinaryExpr, s schema.Metrics, ctx lowerCtx) (chplan.Node, error) {
+	if b.ReturnBool {
+		return nil, fmt.Errorf("promql: 'bool' modifier is only allowed on comparison binary ops")
+	}
+
+	_, floatForAgg, err := shadowResolveMixedExpHistogramOperands(b, s, ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	// tsRef is nil: [dateFnExpr] only consults it for "timestamp", which
+	// [dateFnOverMixedExpHistogramSetOp] never recognises.
+	newValue := dateFnExpr(c.Func.Name, valueAsDateTime(s), nil)
+	if newValue == nil {
+		return nil, fmt.Errorf("promql: unknown date function %s", c.Func.Name)
+	}
+	return guardedValueProjection(floatForAgg, c.Args[0], s, asFloat64(newValue)), nil
+}

--- a/internal/promql/histogram_native_mixed_or_datefn_chdb_test.go
+++ b/internal/promql/histogram_native_mixed_or_datefn_chdb_test.go
@@ -1,0 +1,228 @@
+//go:build chdb
+
+// chDB-backed proof that the eight value-reading date-component functions
+// (`year`/`month`/`day_of_month`/`day_of_week`/`day_of_year`/
+// `days_in_month`/`hour`/`minute`), directly wrapping a mixed
+// float/histogram `or` (cerberus issue #2609,
+// histogram_native_mixed_or_datefn.go's
+// [dateFnOverMixedExpHistogramSetOp] /
+// [lowerDateFnOverMixedExpHistogramSetOp]) actually DROP every
+// histogram-shaped row and compute the date component from the
+// float-shaped rows alone at real ClickHouse execution — including the
+// `or`'s own LHS-wins shadow rule when a histogram row and a float row
+// share the identical label signature, and that the composition still
+// applies when the date function is reached NESTED under a further
+// wrapper rather than only at the query root.
+//
+// Reuses foSeed / foHistMetric / foFloatMetric / foEvalTS from
+// histogram_native_mixed_or_aggregate_float_only_chdb_test.go and
+// tkShadowSeed / tkShadowHistMetric / tkShadowFloatMetric from
+// histogram_native_mixed_or_aggregate_topk_chdb_test.go (same package,
+// same build tag).
+package promql_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/prometheus/prometheus/promql/parser"
+
+	"github.com/tsouza/cerberus/internal/chplan"
+	"github.com/tsouza/cerberus/internal/chsql"
+	"github.com/tsouza/cerberus/internal/promql"
+	"github.com/tsouza/cerberus/internal/schema"
+	"github.com/tsouza/cerberus/internal/testsql"
+)
+
+// dfSeriesValues runs query and returns the `series` label -> `Value`
+// column of every output row.
+func dfSeriesValues(t *testing.T, fixture *chdbFixture, s schema.Metrics, p parser.Parser, query string) map[string]float64 {
+	t.Helper()
+	expr, err := p.ParseExpr(query)
+	if err != nil {
+		t.Fatalf("ParseExpr(%q): %v", query, err)
+	}
+	plan, err := promql.LowerAt(context.Background(), expr, s, foEvalTS, foEvalTS)
+	if err != nil {
+		t.Fatalf("LowerAt(%q): %v", query, err)
+	}
+	if shape := chplan.RowShapeOf(plan); shape != chplan.SampleRowShape {
+		t.Fatalf("lower(%q): plan root publishes %s, want %s (a date function always drops to a plain float vector over a mixed or)", query, shape, chplan.SampleRowShape)
+	}
+	sqlStr, args, err := chsql.Emit(context.Background(), plan)
+	if err != nil {
+		t.Fatalf("Emit(%q): %v", query, err)
+	}
+	rows := fixture.queryOverEmitted(t, "`Attributes`['series'] AS series, `Value` AS val", sqlStr, args)
+	defer func() { _ = rows.Close() }()
+
+	got := map[string]float64{}
+	for rows.Next() {
+		var series string
+		var val float64
+		if err := rows.Scan(&series, &val); err != nil {
+			t.Fatalf("scan: %v", err)
+		}
+		got[series] = val
+	}
+	if err := testsql.TolerantRowsErr(rows.Err()); err != nil {
+		t.Fatalf("rows.Err: %v", err)
+	}
+	return got
+}
+
+// dfPromDayOfWeek mirrors PromQL's day_of_week (Sun=0..Sat=6), the one
+// function among the eight whose numbering diverges from Go's own
+// time.Weekday (which already happens to agree: Sunday==0).
+func dfPromDayOfWeek(tm time.Time) float64 { return float64(tm.Weekday()) }
+
+// dfDaysInMonth returns the day count of tm's month — the day-of-month of
+// that month's last day, matching [dateFnExpr]'s own
+// toDayOfMonth(toLastDayOfMonth(...)) lowering.
+func dfDaysInMonth(tm time.Time) float64 {
+	firstOfNextMonth := time.Date(tm.Year(), tm.Month()+1, 1, 0, 0, 0, 0, time.UTC)
+	lastOfMonth := firstOfNextMonth.Add(-24 * time.Hour)
+	return float64(lastOfMonth.Day())
+}
+
+// TestDateComponentFnsOverMixedSetOpOr_ChDB proves each of the eight
+// date-component functions, wrapped directly around a mixed `or`,
+// computes its component from the three float-shaped rows (f1=3s, f2=9s,
+// f3=1s past the Unix epoch) alone and drops the two histogram-shaped
+// rows (h1, h2) entirely — for both source-AST operand orders, since the
+// mixed `or`'s shadow rule depends on which side is LHS.
+func TestDateComponentFnsOverMixedSetOpOr_ChDB(t *testing.T) {
+	fixture := newChDBFixture(t, foSeed)
+	s := schema.DefaultOTelMetrics()
+	p := parser.NewParser(parser.Options{})
+
+	floats := map[string]float64{"f1": 3, "f2": 9, "f3": 1}
+
+	fns := []struct {
+		name string
+		want func(time.Time) float64
+	}{
+		{"year", func(tm time.Time) float64 { return float64(tm.Year()) }},
+		{"month", func(tm time.Time) float64 { return float64(tm.Month()) }},
+		{"day_of_month", func(tm time.Time) float64 { return float64(tm.Day()) }},
+		{"day_of_year", func(tm time.Time) float64 { return float64(tm.YearDay()) }},
+		{"day_of_week", dfPromDayOfWeek},
+		{"days_in_month", dfDaysInMonth},
+		{"hour", func(tm time.Time) float64 { return float64(tm.Hour()) }},
+		{"minute", func(tm time.Time) float64 { return float64(tm.Minute()) }},
+	}
+
+	for _, fn := range fns {
+		fn := fn
+		t.Run(fn.name, func(t *testing.T) {
+			want := map[string]float64{}
+			for series, v := range floats {
+				want[series] = fn.want(time.Unix(int64(v), 0).UTC())
+			}
+
+			for _, order := range []struct {
+				name  string
+				query string
+			}{
+				{"histLHS", fn.name + "(" + foHistMetric + " or " + foFloatMetric + ")"},
+				{"floatLHS", fn.name + "(" + foFloatMetric + " or " + foHistMetric + ")"},
+			} {
+				order := order
+				t.Run(order.name, func(t *testing.T) {
+					got := dfSeriesValues(t, fixture, s, p, order.query)
+					if len(got) != len(want) {
+						t.Fatalf("query %q: got %d series %v, want %d series %v (a histogram-blind bug would leak h1/h2 into the output)", order.query, len(got), got, len(want), want)
+					}
+					for series, w := range want {
+						g, ok := got[series]
+						if !ok {
+							t.Fatalf("query %q: missing series %q, got %v", order.query, series, got)
+						}
+						if g != w {
+							t.Errorf("query %q: series %q = %v, want %v", order.query, series, g, w)
+						}
+					}
+				})
+			}
+		})
+	}
+}
+
+// TestDateComponentFnOverMixedSetOpOr_ShadowCollision_ChDB proves the
+// `or`'s own LHS-wins shadow rule composes correctly with a date
+// function's histogram drop: when the histogram side is the source-AST
+// LHS, the colliding float row is shadowed out of the `or`'s own output
+// entirely, so it can never appear in the date function's output. When
+// the float side is LHS instead, its own row is never shadowed.
+// Reuses tkShadowSeed / tkShadowHistMetric / tkShadowFloatMetric from
+// histogram_native_mixed_or_aggregate_topk_chdb_test.go.
+func TestDateComponentFnOverMixedSetOpOr_ShadowCollision_ChDB(t *testing.T) {
+	fixture := newChDBFixture(t, tkShadowSeed)
+	s := schema.DefaultOTelMetrics()
+	p := parser.NewParser(parser.Options{})
+
+	cases := []struct {
+		name  string
+		query string
+		want  []string
+	}{
+		{
+			"histLHS_dupShadowedOut",
+			"day_of_month(" + tkShadowHistMetric + " or " + tkShadowFloatMetric + ")",
+			[]string{"solo"},
+		},
+		{
+			"floatLHS_dupSurvives",
+			"day_of_month(" + tkShadowFloatMetric + " or " + tkShadowHistMetric + ")",
+			[]string{"solo", "dup"},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := dfSeriesValues(t, fixture, s, p, tc.query)
+			if len(got) != len(tc.want) {
+				t.Fatalf("query %q: got series %v, want %v", tc.query, got, tc.want)
+			}
+			for _, series := range tc.want {
+				if _, ok := got[series]; !ok {
+					t.Errorf("query %q: missing series %q, got %v", tc.query, series, got)
+				}
+			}
+		})
+	}
+}
+
+// TestDateComponentFnOverMixedSetOpOr_NestedUnderWrapper_ChDB proves the
+// composition applies when a date function is reached NESTED under a
+// further wrapper, not only at the query root — the "nested wrappers"
+// half of the sort()/sort_desc() precedent
+// (histogram_native_mixed_or_sort.go, cerberus issue #2605) applied to
+// this family. abs() is an arbitrary instant-math wrapper chosen because
+// it reads the shadow-resolved float arm's own (already date-transformed)
+// Value column, so a histogram row wrongly surviving into it would surface
+// as a wrong count or a wrong value.
+func TestDateComponentFnOverMixedSetOpOr_NestedUnderWrapper_ChDB(t *testing.T) {
+	fixture := newChDBFixture(t, foSeed)
+	s := schema.DefaultOTelMetrics()
+	p := parser.NewParser(parser.Options{})
+
+	query := "abs(days_in_month(" + foHistMetric + " or " + foFloatMetric + "))"
+	got := dfSeriesValues(t, fixture, s, p, query)
+
+	// f1=3s, f2=9s, f3=1s past the Unix epoch are all still within
+	// 1970-01-01 UTC, so every surviving row reports January's 31 days.
+	want := map[string]float64{"f1": 31, "f2": 31, "f3": 31}
+	if len(got) != len(want) {
+		t.Fatalf("query %q: got %v, want %v (a histogram-blind bug would leak h1/h2 into the output)", query, got, want)
+	}
+	for series, w := range want {
+		g, ok := got[series]
+		if !ok {
+			t.Fatalf("query %q: missing series %q, got %v", query, series, got)
+		}
+		if g != w {
+			t.Errorf("query %q: series %q = %v, want %v", query, series, g, w)
+		}
+	}
+}

--- a/test/rejection-parity/catalogue/internal__promql__binary.go__lowerVectorSetOp.json
+++ b/test/rejection-parity/catalogue/internal__promql__binary.go__lowerVectorSetOp.json
@@ -5,8 +5,8 @@
       "site": "internal/promql/binary.go:lowerVectorSetOp#4924e0ba",
       "message": "promql: 'or' between a float-valued and a histogram-valued operand is not supported; 'and'/'unless' support mixing them",
       "class": "divergence",
-      "trigger_query": "days_in_month(demo_latency_exp_hist or histogram_quantile(0.5, demo_latency_exp_hist))",
-      "tracking_issue": 2605,
+      "trigger_query": "timestamp(demo_latency_exp_hist or histogram_quantile(0.5, demo_latency_exp_hist))",
+      "tracking_issue": 2611,
       "evidence": {
         "guard": [
           "past returning if err != nil",

--- a/test/rejection-parity/catalogue/internal__promql__date_fns.go__lowerDateFn.json
+++ b/test/rejection-parity/catalogue/internal__promql__date_fns.go__lowerDateFn.json
@@ -5,11 +5,12 @@
       "site": "internal/promql/date_fns.go:lowerDateFn#2f3ea020",
       "message": "promql: unknown date function %s",
       "class": "internal",
-      "rationale": "internal dispatch: lowerCall routes only the known date-function names here",
+      "rationale": "internal dispatch: lowerCall routes only the known date-function names here, and dateFnOverMixedExpHistogramSetOp (cerberus issue #2609) matches only when c.Func.Name is one of the same known names minus \"timestamp\" (its own guard excludes that one by name) — neither path can hand dateFnExpr a name it does not recognise",
       "evidence": {
         "guard": [
           "past returning if len(c.Args) \u003e 1",
           "past returning if len(c.Args) == 0",
+          "past returning if b, ok := dateFnOverMixedExpHistogramSetOp(c, s, ctx); ok",
           "past returning if err != nil",
           "if newValue == nil"
         ],
@@ -17,6 +18,8 @@
           "lowerCall"
         ],
         "cited": [
+          "dateFnExpr",
+          "dateFnOverMixedExpHistogramSetOp",
           "lowerCall"
         ]
       }

--- a/test/rejection-parity/catalogue/internal__promql__histogram_native_mixed_or_datefn.go__lowerDateFnOverMixedExpHistogramSetOp.json
+++ b/test/rejection-parity/catalogue/internal__promql__histogram_native_mixed_or_datefn.go__lowerDateFnOverMixedExpHistogramSetOp.json
@@ -1,0 +1,47 @@
+{
+  "entries": [
+    {
+      "head": "promql",
+      "site": "internal/promql/histogram_native_mixed_or_datefn.go:lowerDateFnOverMixedExpHistogramSetOp#2f3ea020",
+      "message": "promql: unknown date function %s",
+      "class": "internal",
+      "rationale": "dateFnOverMixedExpHistogramSetOp only matches when c.Func.Name is one of the eight known date-component names lowerCall already filtered to reach lowerDateFn, minus \"timestamp\" (excluded by its own guard) — dateFnExpr always recognises the remainder, same reasoning as lowerDateFn's own identical dead branch (date_fns.go, cerberus issue #2498)",
+      "evidence": {
+        "guard": [
+          "past returning if b.ReturnBool",
+          "past returning if err != nil",
+          "if newValue == nil"
+        ],
+        "callers": [
+          "lowerDateFn"
+        ],
+        "cited": [
+          "dateFnExpr",
+          "dateFnOverMixedExpHistogramSetOp",
+          "lowerCall",
+          "lowerDateFn"
+        ]
+      }
+    },
+    {
+      "head": "promql",
+      "site": "internal/promql/histogram_native_mixed_or_datefn.go:lowerDateFnOverMixedExpHistogramSetOp#6cdf660e",
+      "message": "promql: 'bool' modifier is only allowed on comparison binary ops",
+      "class": "internal",
+      "rationale": "the parser rejects `bool` on non-comparison operators (\"bool modifier can only be used on comparison operators\"), same as lowerSortOverMixedExpHistogramSetOp's identical check (histogram_native_mixed_or_sort.go, cerberus issue #2605) and its sibling compositions (cerberus issues #2346/#2595/#2600). dateFnOverMixedExpHistogramSetOp only ever matches b via mixedExpHistogramSetOp, which requires b.Op == parser.LOR — `or` is a set operator, never a comparison, so the parser can never have set ReturnBool on it.",
+      "evidence": {
+        "guard": [
+          "if b.ReturnBool"
+        ],
+        "callers": [
+          "lowerDateFn"
+        ],
+        "cited": [
+          "dateFnOverMixedExpHistogramSetOp",
+          "lowerSortOverMixedExpHistogramSetOp",
+          "mixedExpHistogramSetOp"
+        ]
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Closes the full scope of #2609: all eight value-reading date/time functions —
`year()`, `month()`, `day_of_month()`, `day_of_week()`, `day_of_year()`, `days_in_month()`,
`hour()`, `minute()` — now compose over a mixed float/histogram `or` (#2330), matching how
`sort()`/`sort_desc()` (#2605) already do.

Reference Prometheus (`promql/functions.go`'s shared `dateWrapper` helper, which all eight
route through) skips every sample whose `.H` field is set before computing the date
component from `.V` — the same "process only float samples, drop the rest" rule
`sort()`/`sort_desc()` and the float-only aggregate family already mirror against a mixed
`or`. `internal/promql/date_fns.go`'s own package doc already documented this exact rule
for the non-mixed (all-histogram) argument case (#2498); this PR closes the gap for the
mixed-`or` shape specifically.

Like `sort()`/`sort_desc()` and unlike the REDUCE-family aggregates, a date function is a
per-row transform (no grouping, no K-selection), so composing it needs nothing beyond the
shadow-resolved FLOAT arm `shadowResolveMixedExpHistogramOperands` already builds for every
sibling composition in this file group, fed through the same value-projection pipeline
`lowerDateFn`'s non-mixed path already builds
(`internal/promql/histogram_native_mixed_or_datefn.go`).

`timestamp()` is deliberately excluded — it reads the argument's own TIME column rather
than its Value, and reference's `dateWrapper` never applies to it (it already has its own
separate histogram-valued lowering, `histogram_native_timestamp.go`, #2474). It is not one
of the eight functions #2609 scopes.

## Verification

A new chDB test suite (`histogram_native_mixed_or_datefn_chdb_test.go`) proves, against
real ClickHouse execution, that all eight functions:

- compute the date component from the float-shaped rows alone and drop every
  histogram-shaped row, for both source-AST operand orders of the `or`
  (`TestDateComponentFnsOverMixedSetOpOr_ChDB`) — expected values computed independently
  via Go's own `time` package, not hand-derived constants;
- respect the `or`'s own LHS-wins shadow rule when a histogram row and a float row share
  the identical label signature (`TestDateComponentFnOverMixedSetOpOr_ShadowCollision_ChDB`);
- compose correctly when reached NESTED under a further wrapper, not only at the query root
  (`TestDateComponentFnOverMixedSetOpOr_NestedUnderWrapper_ChDB`).

## Rejection-parity catalogue rotation

`internal/promql/binary.go:lowerVectorSetOp#4924e0ba`'s catch-all no longer triggers on
`days_in_month(...)` after this fix (confirmed via `TestRejectionTriggersExerciseSites`,
which failed against the stale trigger before this rotation). Three other live triggers for
the same catch-all remain — `timestamp(...)`, `scalar(...)`, `sort_by_label(...)` wrapping a
mixed `or` — none of which this PR closes, so the catalogue entry rotates forward to
`timestamp(...)` and its `tracking_issue` now cites **#2611** (filed for the remainder),
**not #2609** which this PR closes.

`internal/promql/lower.go:expHistogramSelectorRouting#bf746b59` is untouched by this PR
(verified via `git diff`).

Closes #2609

## Test plan

- [x] `go test -race ./internal/promql/...`
- [x] `go test -tags chdb -run 'TestDateComponentFns|TestDateComponentFnOverMixedSetOpOr' ./internal/promql/... -v`
- [x] `go test ./test/rejection-parity/...` (full suite, incl. `TestRejectionTriggersExerciseSites`,
      `TestCatalogueEntriesAreClassified`, `TestInternalRationalesRestOnCurrentEvidence`)
- [x] `node .github/scripts/forbid-sql-raw.mjs`
- [x] `CERBERUS_UPDATE_INVENTORY=1 go test -run TestCatalogueIsRegenerable ./test/rejection-parity/...`
      run twice (hand-curated `rationale`/`class` for the new/changed internal entries)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
