### PR TITLE
fix(promql): compose sum/avg-wrapped mixed-or subqueries for 11 of 15 fns

### DIFF
--- a/internal/promql/histogram_native_mixed_or_subquery_aggregate_range_fn.go
+++ b/internal/promql/histogram_native_mixed_or_subquery_aggregate_range_fn.go
@@ -1,0 +1,382 @@
+package promql
+
+import (
+	"fmt"
+
+	"github.com/prometheus/prometheus/promql/parser"
+
+	"github.com/tsouza/cerberus/internal/chplan"
+	"github.com/tsouza/cerberus/internal/schema"
+)
+
+// histogram_native_mixed_or_subquery_aggregate_range_fn.go composes a
+// SELECT/FOLD-family outer function over a subquery whose own inner is
+// `sum`/`avg` [by/without] wrapping a mixed float/histogram `or` —
+// `<fn>((sum by (series) ((a) or (b)))[range:step])` — cerberus issue
+// #2581's own remaining gap, the one
+// [wrapMixedOrSubqueryInner]'s doc names as deliberately unattempted by
+// this file's sibling (histogram_native_mixed_or_subquery_range_fn.go)
+// because naively DISTRIBUTING the outer function per `or` ARM and
+// recombining does not reproduce reference's sum/avg drop-on-collision
+// semantics (a `by`/`without` clause can put rows from BOTH arms into the
+// SAME output group, and reference drops that group entirely rather than
+// picking a side).
+//
+// # Why this composes soundly after all
+//
+// Two independent findings, both verified directly against this repo and
+// against the vendored tsouza/prometheus fork, make a SOUND composition
+// possible without touching the "distribute per arm" idea at all:
+//
+//  1. Reference Prometheus's `sum`/`avg` drop-on-collision rule is ALREADY
+//     correctly implemented in this codebase — [combineMixedAggregateBranches]
+//     (histogram_native_mixed_or_aggregate.go, cerberus issue #2346),
+//     reduces the histogram arm and the float arm SEPARATELY and combines
+//     them with a drop-on-group-collision rule (two UNLESSes + a Mixed
+//     `or`), not a naive per-arm distribute. And it is ALREADY reachable at
+//     a subquery's own per-anchor grid: [lowerSubquery] tries
+//     [lowerHistogramNativeSubqueryInner] first, which runs
+//     [lowerHistogramNativeRoot] — [sumOrAvgOverMixedExpHistogramSetOp] /
+//     [lowerSumOrAvgOverMixedExpHistogramSetOp] included — against the
+//     subquery's own inner expression at the subquery's own grid
+//     ([subqueryGridCtx]). So `sub.Expr` in
+//     `<fn>((sum by (series) ((a) or (b)))[range:step])` ALREADY lowers to
+//     a genuinely collision-correct [chplan.MixedRowShape] relation, one
+//     row per (output group, subquery anchor) — [lowerOuterRangeFnOverSubquery]
+//     just unconditionally REJECTS a [chplan.MixedRowShape] `inner` today
+//     (its own histogramSubqueryFloatOnlyDropFunc exception aside), which
+//     is the actual, narrower gap this file closes.
+//
+//  2. Reference's own SELECT/FOLD-family window reducers (tsouza/prometheus's
+//     promql/functions.go) already define exactly what to do with a
+//     per-anchor relation whose TYPE can differ from one subquery anchor to
+//     the next for the SAME output group — which is exactly the shape the
+//     per-anchor Mixed relation above can produce, because a `by`/`without`
+//     clause's grouping can pick up float rows at one anchor and histogram
+//     rows at another for what reference treats as one output series:
+//
+//     - The nine names whose result preserves the operand's own value type
+//     (rate/increase/delta/irate/idelta/sum_over_time/avg_over_time,
+//     minus last_over_time/first_over_time — see the scope note below)
+//     check `len(samples.Histograms) > 0 && len(samples.Floats) > 0` for
+//     the WHOLE window and DROP the series entirely
+//     (NewMixedFloatsHistogramsWarning) when both are present —
+//     extrapolatedRate (rate/increase/delta/irate/idelta) and
+//     funcSumOverTime/funcAvgOverTime all do this identical check. This is
+//     the SAME "drop on collision" shape [combineMixedAggregateBranches]
+//     already implements one level down, just keyed by (output group)
+//     across the WHOLE window instead of (output group, one anchor).
+//     [windowPurityUnless] below reproduces it with the identical
+//     UNLESS-pair idiom, StepAligned forced false so the match spans every
+//     subquery anchor in the window rather than one.
+//     - count_over_time / present_over_time / ts_of_first_over_time /
+//     ts_of_last_over_time read no per-sample value at all beyond its
+//     existence or its timestamp (funcCountOverTime/funcPresentOverTime/
+//     funcTsOfFirstOverTime/funcTsOfLastOverTime never branch on
+//     samples.Histograms vs samples.Floats) — no window-purity test
+//     applies; they consume the already-correct per-anchor Mixed relation
+//     directly.
+//
+// # Scope
+//
+// Composes for eleven of the fifteen SELECT/FOLD-family names:
+// count_over_time, present_over_time, ts_of_first_over_time,
+// ts_of_last_over_time (type-blind, [lowerSumOrAvgMixedOrSubquerySelectFn])
+// and rate, increase, delta, irate, idelta, sum_over_time, avg_over_time
+// (window-purity-filtered, [lowerSumOrAvgMixedOrSubqueryFoldFn]).
+//
+// Four names deliberately stay on the pre-existing rejection, for two
+// distinct reasons documented at their own exclusion points:
+//
+//   - last_over_time / first_over_time select ONE raw sample verbatim
+//     (whichever type it happens to be) rather than folding a window, so
+//     they need a MIXED-shaped (not Histogram-shaped) "pick the newest/
+//     oldest row" reduction that also carries the discriminator and Value
+//     columns through the same argMax/argMin selection
+//     ([nativeExpHistBareAggsDirectional] only carries the nine histogram
+//     columns today) — real new machinery, not a two-line extension.
+//   - resets / changes genuinely interleave-merge the window's float and
+//     histogram samples by timestamp in reference (funcResets/funcChanges),
+//     counting a type FLIP between consecutive samples as an automatic
+//     reset — they do not drop on window mix at all. That needs a
+//     type-aware sequential comparison this file's existing
+//     [expHistogramPairCountAggs] machinery (built for an all-histogram
+//     window only) does not have.
+//
+// The FOLD family's window-purity test ([windowPurityUnless]) is sound
+// today only for a SINGLE window per output series — an instant query, or
+// an `@`-pinned subquery broadcast across a query_range grid
+// ([sumOrAvgMixedOrSubqueryOuterFn]'s own gate excludes true query_range
+// fan-out for these seven names): a genuine fan-out evaluates each output
+// step's own [range] window independently, and the purity test would need
+// to be scoped PER OUTER ANCHOR rather than once across the whole subquery
+// grid — real new machinery ([chplan.RangeBucketFanout] has no primitive
+// for a cross-relation per-window EXISTS test today), not a limitation of
+// the approach itself.
+func sumOrAvgMixedOrSubqueryOuterFnRecognized(c *parser.Call, s schema.Metrics, ctx lowerCtx) (sumOrAvgMixedOrSubqueryShape, bool) {
+	if s.ExpHistogramTable == "" || ctx.metadataFullRange {
+		return sumOrAvgMixedOrSubqueryShape{}, false
+	}
+	if len(c.Args) != 1 {
+		return sumOrAvgMixedOrSubqueryShape{}, false
+	}
+	sub, ok := peelWrappers(c.Args[0]).(*parser.SubqueryExpr)
+	if !ok || sub.Range <= 0 || !subqueryHasEvalAnchor(sub, ctx) {
+		return sumOrAvgMixedOrSubqueryShape{}, false
+	}
+	agg, b, ok := sumOrAvgOverMixedExpHistogramSetOp(sub.Expr, s, ctx)
+	if !ok {
+		return sumOrAvgMixedOrSubqueryShape{}, false
+	}
+	switch c.Func.Name {
+	case countOverTimeWindowFn, presentOverTimeWindowFn, tsOfFirstOverTimeExpHistFn, tsOfLastOverTimeExpHistFn:
+		return sumOrAvgMixedOrSubqueryShape{sub: sub, agg: agg, b: b, windowFn: c.Func.Name}, true
+	case rateWindowFn, increaseWindowFn, deltaWindowFn, irateWindowFn, ideltaWindowFn, sumOverTimeWindowFn, avgOverTimeWindowFn:
+		// See this file's own top-level doc, "Scope": the window-purity
+		// drop test is not yet sound for a true query_range fan-out (a
+		// non-pinned subquery under query_range), so that specific
+		// sub-shape stays unmatched here and falls through to the
+		// pre-existing rejection unchanged.
+		if ctx.rangeMode() && !subqueryPinned(sub) {
+			return sumOrAvgMixedOrSubqueryShape{}, false
+		}
+		return sumOrAvgMixedOrSubqueryShape{sub: sub, agg: agg, b: b, windowFn: c.Func.Name}, true
+	default:
+		return sumOrAvgMixedOrSubqueryShape{}, false
+	}
+}
+
+// sumOrAvgMixedOrSubqueryShape is the shape
+// [sumOrAvgMixedOrSubqueryOuterFnRecognized] matched: sub's own inner is
+// agg (`sum`/`avg` [by/without]) wrapping b, a mixed float/histogram `or`
+// ([sumOrAvgOverMixedExpHistogramSetOp]'s own shape), reached under an
+// outer SELECT/FOLD-family call named windowFn.
+type sumOrAvgMixedOrSubqueryShape struct {
+	sub      *parser.SubqueryExpr
+	agg      *parser.AggregateExpr
+	b        *parser.BinaryExpr
+	windowFn string
+}
+
+// lowerSumOrAvgMixedOrSubqueryOuterFn lowers the shape
+// [sumOrAvgMixedOrSubqueryOuterFnRecognized] matched. Both branches below
+// share the identical subquery grid resolution and `bool`-modifier guard;
+// they diverge only in whether the window-purity drop test applies.
+func lowerSumOrAvgMixedOrSubqueryOuterFn(shape sumOrAvgMixedOrSubqueryShape, s schema.Metrics, ctx lowerCtx) (chplan.Node, error) {
+	sub := shape.sub
+	step := sub.Step
+	if step == 0 {
+		step = defaultSubqueryStep
+	}
+	if step < 0 {
+		return nil, fmt.Errorf("promql: subquery step must be positive, got %s", sub.Step)
+	}
+	gridCtx, ok, err := subqueryGridCtx(sub, step, ctx)
+	if err != nil {
+		return nil, err
+	}
+	if !ok {
+		return nil, fmt.Errorf("promql: histogram-valued subquery requires query eval-time context (use LowerAt)")
+	}
+	if shape.b.ReturnBool {
+		return nil, fmt.Errorf("promql: 'bool' modifier is only allowed on comparison binary ops")
+	}
+
+	switch shape.windowFn {
+	case countOverTimeWindowFn, presentOverTimeWindowFn, tsOfFirstOverTimeExpHistFn, tsOfLastOverTimeExpHistFn:
+		return lowerSumOrAvgMixedOrSubquerySelectFn(shape, gridCtx, s, ctx)
+	default:
+		return lowerSumOrAvgMixedOrSubqueryFoldFn(shape, gridCtx, s, ctx)
+	}
+}
+
+// lowerSumOrAvgMixedOrSubquerySelectFn answers the four type-blind names —
+// see this file's own top-level doc. mixedRel, the subquery's own inner
+// aggregation lowered ONCE across the whole grid via the EXACT existing
+// root-only composer ([lowerSumOrAvgOverMixedExpHistogramSetOp]), is
+// already the correct per-(group, subquery anchor) Mixed relation these
+// functions fold over — no window-purity filtering needed, so it is
+// handed directly to [selectFnOverSubqueryWindowed] /
+// [lowerSelectFnOverSubqueryRange] / [capSelectFnOverSubquery], the SAME
+// three-mode reduction cerberus issue #2545/#2569 already built for a
+// PURE histogram-native subquery inner — those three functions only ever
+// read the Attributes/Timestamp/Value columns for this four-name subset
+// (never the nine Histogram*Column payload fields), so a Mixed-shaped
+// input reduces identically to a Histogram-shaped one.
+func lowerSumOrAvgMixedOrSubquerySelectFn(shape sumOrAvgMixedOrSubqueryShape, gridCtx lowerCtx, s schema.Metrics, ctx lowerCtx) (chplan.Node, error) {
+	sub := shape.sub
+	mixedRel, err := lowerSumOrAvgOverMixedExpHistogramSetOp(shape.agg, shape.b, s, gridCtx)
+	if err != nil {
+		return nil, err
+	}
+	if chplan.RowShapeOf(mixedRel) != chplan.MixedRowShape {
+		return nil, fmt.Errorf("promql: internal invariant violated: sum/avg-mixed-or subquery input is %T with %s row shape", mixedRel, chplan.RowShapeOf(mixedRel))
+	}
+
+	anchor, err := subqueryAnchor(sub, ctx)
+	if err != nil {
+		return nil, err
+	}
+	histSchema := histogramProjectionSchema(s)
+	histSchema.AggregationTemporalityColumn = ""
+
+	if ctx.rangeMode() && subqueryPinned(sub) {
+		windowed := selectFnOverSubqueryWindowed(shape.windowFn, mixedRel, histSchema)
+		grid := &chplan.StepGrid{Start: ctx.start.UTC(), End: ctx.end.UTC(), Step: ctx.step}
+		return capSelectFnOverSubquery(
+			shape.windowFn,
+			&chplan.CrossJoin{Left: grid, Right: windowed},
+			&chplan.ColumnRef{Name: stepGridAnchorColumn},
+			histSchema,
+		), nil
+	}
+	if ctx.rangeMode() {
+		return lowerSelectFnOverSubqueryRange(shape.windowFn, mixedRel, sub.Range, anchor.Offset, histSchema, ctx), nil
+	}
+	windowed := selectFnOverSubqueryWindowed(shape.windowFn, mixedRel, histSchema)
+	tsExpr := chplan.NowNano()
+	if !anchor.End.IsZero() {
+		tsExpr = windowRightBoundExpr(evalAnchor{End: anchor.End})
+	}
+	return capSelectFnOverSubquery(shape.windowFn, windowed, tsExpr, histSchema), nil
+}
+
+// lowerSumOrAvgMixedOrSubqueryFoldFn answers the seven type-preserving
+// FOLD-family names — see this file's own top-level doc. Unlike the
+// type-blind siblings above, this rebuilds the subquery's own inner
+// aggregation from [shadowResolveMixedExpHistogramOperands]'s two
+// per-anchor branches directly (rather than calling the combined
+// [lowerSumOrAvgOverMixedExpHistogramSetOp]) so [windowPurityUnless] can
+// filter EACH branch to its window-pure groups BEFORE either one reaches
+// its own window fold — the collision-drop test reference's
+// extrapolatedRate / funcSumOverTime / funcAvgOverTime apply for the
+// WHOLE window, not per subquery anchor.
+func lowerSumOrAvgMixedOrSubqueryFoldFn(shape sumOrAvgMixedOrSubqueryShape, gridCtx lowerCtx, s schema.Metrics, ctx lowerCtx) (chplan.Node, error) {
+	sub := shape.sub
+	histForAgg, floatForAgg, err := shadowResolveMixedExpHistogramOperands(shape.b, s, gridCtx)
+	if err != nil {
+		return nil, err
+	}
+	histBranch, err := lowerExpHistogramSumOrAvgOverPlan(shape.agg, histForAgg, s)
+	if err != nil {
+		return nil, err
+	}
+	floatBranch, err := lowerPlainAggOverMixedFloatArm(shape.agg, floatForAgg, s, gridCtx)
+	if err != nil {
+		return nil, err
+	}
+
+	histPure := windowPurityUnless(histBranch, floatBranch, true, s)
+	floatPure := windowPurityUnless(floatBranch, histBranch, false, s)
+
+	anchor, err := subqueryAnchor(sub, ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	histFolded, err := lowerHistFoldOverPureSubqueryBranch(shape, histPure, anchor, s, ctx)
+	if err != nil {
+		return nil, err
+	}
+	floatFolded := lowerFloatFoldOverPureSubqueryBranch(shape, floatPure, anchor, s, ctx)
+
+	// histFolded/floatFolded are already disjoint by group construction
+	// (windowPurityUnless above excludes any group with both a histogram
+	// AND a float row anywhere in the window from BOTH pure branches, so
+	// the SAME group cannot resurface in both folds) — the identical
+	// "structural no-op" reuse [combineMixedAggregateBranches]'s own doc
+	// describes for its ROOT-only caller applies here too, one level up.
+	return combineMixedAggregateBranches(histFolded, floatFolded, s, ctx), nil
+}
+
+// windowPurityUnless keeps left's rows whose Attributes signature never
+// appears ANYWHERE in right — StepAligned forced false so the match
+// spans every subquery anchor in the window, unlike
+// [mixedOrShadowUnless]'s identical-shaped per-anchor test one level up
+// (StepAligned there follows ctx.step, matching one anchor at a time).
+// This is the WINDOW-level collision-drop test this file's own doc
+// derives from reference's extrapolatedRate / funcSumOverTime /
+// funcAvgOverTime: a group with a row of BOTH types anywhere in the
+// window loses every one of its rows on BOTH sides, so neither side's
+// window fold ever sees it and neither produces an output row for it —
+// the fold-level equivalent of reference dropping the whole series.
+func windowPurityUnless(left, right chplan.Node, leftIsHistogram bool, s schema.Metrics) chplan.Node {
+	return &chplan.VectorSetOp{
+		Left:             left,
+		Right:            right,
+		Op:               chplan.VectorSetUnless,
+		Match:            chplan.VectorMatch{},
+		StepAligned:      false,
+		Histogram:        leftIsHistogram,
+		MetricNameColumn: s.MetricNameColumn,
+		AttributesColumn: s.AttributesColumn,
+		TimestampColumn:  s.TimestampColumn,
+		ValueColumn:      s.ValueColumn,
+	}
+}
+
+// lowerHistFoldOverPureSubqueryBranch folds input — histPure, already
+// window-purity-filtered — with shape.windowFn over sub.Range, reusing
+// [expHistogramValuedSubqueryWindowStage] / [aggregatedHistogramProjection]
+// unchanged: the SAME per-anchor-input window fold
+// [lowerExpHistogramRangeFnOverSubquery] applies to a pure histogram-native
+// subquery inner, since histPure already carries the identical
+// (Attributes, Timestamp, thirteen-column HistogramProjection) contract
+// that function's own `input` does. Only the two single-window grid modes
+// [sumOrAvgMixedOrSubqueryOuterFnRecognized] admits (instant, `@`-pinned
+// broadcast) are built here — see this file's own "Scope" doc for the
+// true fan-out exclusion.
+func lowerHistFoldOverPureSubqueryBranch(shape sumOrAvgMixedOrSubqueryShape, input chplan.Node, anchor evalAnchor, s schema.Metrics, ctx lowerCtx) (chplan.Node, error) {
+	sub := shape.sub
+	histSchema := histogramProjectionSchema(s)
+	histSchema.AggregationTemporalityColumn = ""
+	windowShape := histogramAggShape{windowRange: sub.Range, windowFn: shape.windowFn}
+
+	if ctx.rangeMode() && subqueryPinned(sub) {
+		windowed := expHistogramValuedSubqueryWindowStage(input, windowShape, anchor, histSchema)
+		grid := &chplan.StepGrid{Start: ctx.start.UTC(), End: ctx.end.UTC(), Step: ctx.step}
+		return aggregatedHistogramProjection(
+			&chplan.CrossJoin{Left: grid, Right: windowed},
+			&chplan.ColumnRef{Name: stepGridAnchorColumn},
+			histSchema,
+		), nil
+	}
+	windowed := expHistogramValuedSubqueryWindowStage(input, windowShape, anchor, histSchema)
+	tsExpr := chplan.NowNano()
+	if !anchor.End.IsZero() {
+		tsExpr = windowRightBoundExpr(evalAnchor{End: anchor.End})
+	}
+	return aggregatedHistogramProjection(windowed, tsExpr, histSchema), nil
+}
+
+// lowerFloatFoldOverPureSubqueryBranch folds input — floatPure, already
+// window-purity-filtered — with shape.windowFn over sub.Range using the
+// ordinary, non-histogram [chplan.RangeWindow] reducer
+// [lowerRangeVectorCall] / [lowerOuterRangeFnOverSubquery] already use for
+// every plain-float range/subquery composition. input's own Timestamp
+// column is already s.TimestampColumn (both
+// [shadowResolveMixedExpHistogramOperands]'s branches publish under that
+// name, and [windowPurityUnless] forwards it unchanged), so RangeWindow's
+// own windowing needs no spine-widening pass: gridCtx already bounded
+// input to exactly the window this reduction needs, unlike the generic
+// [lowerSubquery] path's own unbounded convention.
+func lowerFloatFoldOverPureSubqueryBranch(shape sumOrAvgMixedOrSubqueryShape, input chplan.Node, anchor evalAnchor, s schema.Metrics, ctx lowerCtx) chplan.Node {
+	sub := shape.sub
+	rw := &chplan.RangeWindow{
+		Input:           input,
+		Func:            shape.windowFn,
+		Range:           sub.Range,
+		Offset:          anchor.Offset,
+		TimestampColumn: s.TimestampColumn,
+		ValueColumn:     s.ValueColumn,
+		GroupBy:         []chplan.Expr{&chplan.ColumnRef{Name: s.AttributesColumn}},
+	}
+	if ctx.rangeMode() && subqueryPinned(sub) {
+		rw.End = anchor.End
+		return wrapRangeWindowAtBroadcast(rw, ctx, s, nil, &chplan.ColumnRef{Name: s.ValueColumn})
+	}
+	if !anchor.End.IsZero() {
+		rw.End = anchor.End
+	}
+	return rw
+}

--- a/internal/promql/histogram_native_mixed_or_subquery_aggregate_range_fn_chdb_test.go
+++ b/internal/promql/histogram_native_mixed_or_subquery_aggregate_range_fn_chdb_test.go
@@ -1,0 +1,150 @@
+//go:build chdb
+
+// chDB-backed proof that cerberus issue #2581's `sum`/`avg`-wrapped mixed
+// float/histogram `or` subquery composition
+// (histogram_native_mixed_or_subquery_aggregate_range_fn.go) actually
+// executes correctly against real ClickHouse for the ORDINARY, no-collision
+// case: a histogram-only group ("h") and a float-only group ("f") both fold
+// correctly through the new eleven-name composition. The window-purity
+// collision-DROP semantics get their own dedicated fixture and doc —
+// histogram_native_mixed_or_subquery_aggregate_range_fn_window_purity_chdb_test.go
+// — because reproducing it cleanly needs samples spaced beyond the default
+// 5-minute staleness lookback (subqueryStalenessLookback), which would
+// otherwise let one series' carried-forward sample smear across several
+// subquery anchors and make this file's own h/f arithmetic much harder to
+// hand-verify.
+package promql_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/tsouza/cerberus/internal/schema"
+)
+
+const (
+	sumAvgMixedExpHistMetric = "sav_mor_exp_hist"
+	sumAvgMixedGaugeMetric   = "sav_mor_gauge"
+)
+
+// sumAvgMixedOrSeed backs every case in this file: series "h" gets the
+// same two-sample histogram history subqSelectHistFixture's own baseline
+// uses; series "f" gets two plain gauge samples at the same two anchors on
+// a disjoint metric, so the mixed `or` never has to resolve a same-series
+// shadow.
+var sumAvgMixedOrSeed = subqHistDDL +
+	"INSERT INTO otel_metrics_exponential_histogram " +
+	"(MetricName, Attributes, TimeUnix, Count, Sum, Scale, ZeroCount, PositiveOffset, PositiveBucketCounts, NegativeOffset, NegativeBucketCounts) VALUES\n" +
+	"    ('" + sumAvgMixedExpHistMetric + "', map('series', 'h'), toDateTime64('2026-01-01 00:01:00', 9), 2, 4.0, 0, 0, 0, [6], 0, []),\n" +
+	"    ('" + sumAvgMixedExpHistMetric + "', map('series', 'h'), toDateTime64('2026-01-01 00:02:00', 9), 3, 9.0, 0, 0, 0, [12], 0, []);\n" +
+	swapGaugeSeedDDL +
+	"INSERT INTO otel_metrics_gauge (MetricName, Attributes, TimeUnix, Value) VALUES\n" +
+	"    ('" + sumAvgMixedGaugeMetric + "', map('series', 'f'), toDateTime64('2026-01-01 00:01:00', 9), 10.0),\n" +
+	"    ('" + sumAvgMixedGaugeMetric + "', map('series', 'f'), toDateTime64('2026-01-01 00:02:00', 9), 20.0);\n"
+
+var sumAvgMixedOrEvalTS = time.Date(2026, 1, 1, 0, 2, 0, 0, time.UTC)
+
+// sumAvgMixedOrQuery builds `<fn>((sum by (series) ((h) or (f)))[2m:1m])`
+// — the issue's own trigger shape, with this file's own metric names and
+// window.
+func sumAvgMixedOrQuery(fn string) string {
+	inner := "sum by (series) ((" + sumAvgMixedExpHistMetric + ") or (" + sumAvgMixedGaugeMetric + "))"
+	return fn + "((" + inner + ")[2m:1m])"
+}
+
+// TestSumOrAvgMixedOrSubqueryCountOverTime_ChDB proves count_over_time
+// composes over the sum/avg-wrapped mixed-or subquery for both the
+// histogram-only and float-only groups.
+func TestSumOrAvgMixedOrSubqueryCountOverTime_ChDB(t *testing.T) {
+	fixture := newChDBFixture(t, sumAvgMixedOrSeed)
+	s := schema.DefaultOTelMetrics()
+
+	sqlStr, args := lowerAndEmit(t, sumAvgMixedOrQuery("count_over_time"), s, sumAvgMixedOrEvalTS)
+	got := sampleValueRows(t, fixture, sqlStr, args)
+	if got["h"] != 2 {
+		t.Errorf("count_over_time: series h = %v, want 2", got["h"])
+	}
+	if got["f"] != 2 {
+		t.Errorf("count_over_time: series f = %v, want 2", got["f"])
+	}
+}
+
+// TestSumOrAvgMixedOrSubquerySumOverTime_ChDB proves sum_over_time — a
+// window-purity-filtered FOLD-family member — folds the histogram-only
+// group ("h") through the exact same arithmetic
+// subquery_select_histogram_chdb_test.go's own pure-histogram baseline
+// pins (Count=5, Sum=13, Bucket1=18 — 2+3, 4+9, 6+12) and the float-only
+// group ("f") through an ordinary float sum (10+20=30) — the ordinary,
+// no-collision path.
+func TestSumOrAvgMixedOrSubquerySumOverTime_ChDB(t *testing.T) {
+	fixture := newChDBFixture(t, sumAvgMixedOrSeed)
+	s := schema.DefaultOTelMetrics()
+
+	sqlStr, args := lowerAndEmit(t, sumAvgMixedOrQuery("sum_over_time"), s, sumAvgMixedOrEvalTS)
+
+	histRows := subqHistQueryRows(t, fixture, sqlStr, args)
+	var gotHist bool
+	for _, r := range histRows {
+		if r.series == "h" {
+			gotHist = true
+			if r.cnt != 5 || r.sum != 13.0 || r.bucket1 != 18 {
+				t.Errorf("sum_over_time, histogram arm series h = %+v, want Count=5 Sum=13 Bucket1=18 (2+3, 4+9, 6+12)", r)
+			}
+		}
+	}
+	if !gotHist {
+		t.Fatalf("sum_over_time: no histogram-arm row for series h; got %+v", histRows)
+	}
+
+	got := sampleValueRows(t, fixture, sqlStr, args)
+	if got["f"] != 30 {
+		t.Errorf("sum_over_time, float arm series f = %v, want 30 (10+20)", got["f"])
+	}
+}
+
+// TestSumOrAvgMixedOrSubqueryRate_ChDB proves rate — the issue's own
+// second FOLD-family evidence shape — folds "h"/"f" to a positive rate.
+func TestSumOrAvgMixedOrSubqueryRate_ChDB(t *testing.T) {
+	fixture := newChDBFixture(t, sumAvgMixedOrSeed)
+	s := schema.DefaultOTelMetrics()
+
+	sqlStr, args := lowerAndEmit(t, sumAvgMixedOrQuery("rate"), s, sumAvgMixedOrEvalTS)
+
+	histRows := subqHistQueryRows(t, fixture, sqlStr, args)
+	var gotHist bool
+	for _, r := range histRows {
+		if r.series == "h" {
+			gotHist = true
+			if r.cnt <= 0 {
+				t.Errorf("rate, histogram arm series h = %+v, want a positive Count", r)
+			}
+		}
+	}
+	if !gotHist {
+		t.Fatalf("rate: no histogram-arm row for series h; got %+v", histRows)
+	}
+
+	got := sampleValueRows(t, fixture, sqlStr, args)
+	if got["f"] <= 0 {
+		t.Errorf("rate, float arm series f = %v, want a positive rate", got["f"])
+	}
+}
+
+// TestSumOrAvgMixedOrSubqueryTsOfLastOverTime_ChDB proves
+// ts_of_last_over_time — a type-blind name that reads no per-sample value
+// at all — reports the correct latest-sample timestamp for both groups.
+func TestSumOrAvgMixedOrSubqueryTsOfLastOverTime_ChDB(t *testing.T) {
+	fixture := newChDBFixture(t, sumAvgMixedOrSeed)
+	s := schema.DefaultOTelMetrics()
+
+	sqlStr, args := lowerAndEmit(t, sumAvgMixedOrQuery("ts_of_last_over_time"), s, sumAvgMixedOrEvalTS)
+	got := sampleValueRows(t, fixture, sqlStr, args)
+
+	want := float64(time.Date(2026, 1, 1, 0, 2, 0, 0, time.UTC).Unix())
+	if got["h"] != want {
+		t.Errorf("ts_of_last_over_time: series h = %v, want %v (00:02:00)", got["h"], want)
+	}
+	if got["f"] != want {
+		t.Errorf("ts_of_last_over_time: series f = %v, want %v (00:02:00)", got["f"], want)
+	}
+}

--- a/internal/promql/histogram_native_mixed_or_subquery_aggregate_range_fn_test.go
+++ b/internal/promql/histogram_native_mixed_or_subquery_aggregate_range_fn_test.go
@@ -1,0 +1,155 @@
+package promql_test
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/tsouza/cerberus/internal/promql"
+	"github.com/tsouza/cerberus/internal/schema"
+)
+
+// sumOrAvgMixedOrSubqueryQuery builds `<fn>((sum by (series) ((<hist>) or
+// (<float>)))[5m:1m])` — cerberus issue #2581's own remaining evidence
+// shape, the `sum`/`avg`-wrapped sibling of
+// histogram_native_mixed_or_subquery_further_setop_test.go's
+// [furtherSetOpQuery].
+func sumOrAvgMixedOrSubqueryQuery(fn, aggOp string) string {
+	return fn + "((" + aggOp + " by (series) ((latency_exp_hist) or (num_cpus)))[5m:1m])"
+}
+
+// sumOrAvgMixedOrSelectFnNames / sumOrAvgMixedOrFoldFnNames partition
+// [selectFoldFamilyNames] into the eleven names this file's own
+// production code (histogram_native_mixed_or_subquery_aggregate_range_fn.go)
+// now composes and the four that deliberately still reject — see that
+// file's own "Scope" doc.
+var (
+	sumOrAvgMixedOrSelectFnNames = []string{
+		"count_over_time", "present_over_time", "ts_of_first_over_time", "ts_of_last_over_time",
+	}
+	sumOrAvgMixedOrFoldFnNames = []string{
+		"rate", "increase", "delta", "irate", "idelta", "sum_over_time", "avg_over_time",
+	}
+	sumOrAvgMixedOrStillRejectedNames = []string{
+		"last_over_time", "first_over_time", "resets", "changes",
+	}
+)
+
+// TestSumOrAvgMixedOrSubquery_Composes proves `<fn>((sum by (series)
+// ((h) or (f)))[5m:1m])` lowers successfully — no error — for every one
+// of the eleven names this file's own production code now composes, for
+// both `sum` and `avg`.
+func TestSumOrAvgMixedOrSubquery_Composes(t *testing.T) {
+	t.Parallel()
+
+	s := schema.DefaultOTelMetrics()
+	end := time.Date(2026, 1, 1, 1, 0, 0, 0, time.UTC)
+
+	names := append(append([]string{}, sumOrAvgMixedOrSelectFnNames...), sumOrAvgMixedOrFoldFnNames...)
+	for _, aggOp := range []string{"sum", "avg"} {
+		for _, fn := range names {
+			t.Run(aggOp+"/"+fn, func(t *testing.T) {
+				t.Parallel()
+				query := sumOrAvgMixedOrSubqueryQuery(fn, aggOp)
+				expr := parseExprExp(t, query)
+				node, err := promql.LowerAt(context.Background(), expr, s, end, end)
+				if err != nil {
+					t.Fatalf("lower(%q): want success, got error: %v", query, err)
+				}
+				if node == nil {
+					t.Fatalf("lower(%q): want a non-nil plan", query)
+				}
+			})
+		}
+	}
+}
+
+// TestSumOrAvgMixedOrSubquery_StillRejects pins that the four names this
+// file's own production code deliberately does not compose
+// (last_over_time / first_over_time / resets / changes — see
+// histogram_native_mixed_or_subquery_aggregate_range_fn.go's own "Scope"
+// doc) still reject with the SAME pre-existing message, unchanged by this
+// composition.
+func TestSumOrAvgMixedOrSubquery_StillRejects(t *testing.T) {
+	t.Parallel()
+
+	s := schema.DefaultOTelMetrics()
+	end := time.Date(2026, 1, 1, 1, 0, 0, 0, time.UTC)
+	const wantErrSubstr = "wrapping a native-histogram-valued shape is unsupported"
+
+	for _, aggOp := range []string{"sum", "avg"} {
+		for _, fn := range sumOrAvgMixedOrStillRejectedNames {
+			t.Run(aggOp+"/"+fn, func(t *testing.T) {
+				t.Parallel()
+				query := sumOrAvgMixedOrSubqueryQuery(fn, aggOp)
+				expr := parseExprExp(t, query)
+				_, err := promql.LowerAt(context.Background(), expr, s, end, end)
+				if err == nil {
+					t.Fatalf("lower(%q): want a clean rejection, got none", query)
+				}
+				if !strings.Contains(err.Error(), wantErrSubstr) {
+					t.Errorf("lower(%q) error = %v, want it to contain %q", query, err, wantErrSubstr)
+				}
+			})
+		}
+	}
+}
+
+// TestSumOrAvgMixedOrSubquery_RangeFanoutStillRejects pins the FOLD
+// family's own residual scope gap: a true query_range fan-out (no `@`
+// pin on the subquery) still rejects for the seven window-purity-filtered
+// names, because the collision-drop test is not yet scoped per outer
+// anchor — see histogram_native_mixed_or_subquery_aggregate_range_fn.go's
+// own "Scope" doc for exactly why.
+func TestSumOrAvgMixedOrSubquery_RangeFanoutStillRejects(t *testing.T) {
+	t.Parallel()
+
+	s := schema.DefaultOTelMetrics()
+	start := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	end := time.Date(2026, 1, 1, 1, 0, 0, 0, time.UTC)
+	const wantErrSubstr = "wrapping a native-histogram-valued shape is unsupported"
+
+	for _, fn := range sumOrAvgMixedOrFoldFnNames {
+		t.Run(fn, func(t *testing.T) {
+			t.Parallel()
+			query := sumOrAvgMixedOrSubqueryQuery(fn, "sum")
+			expr := parseExprExp(t, query)
+			_, err := promql.LowerAtRange(context.Background(), expr, s, start, end, time.Minute)
+			if err == nil {
+				t.Fatalf("lower(%q) over query_range: want a clean rejection, got none", query)
+			}
+			if !strings.Contains(err.Error(), wantErrSubstr) {
+				t.Errorf("lower(%q) over query_range error = %v, want it to contain %q", query, err, wantErrSubstr)
+			}
+		})
+	}
+}
+
+// TestSumOrAvgMixedOrSubquery_PinnedRangeComposes proves the FOLD family
+// DOES still compose under query_range when the subquery carries an `@`
+// pin — the single-window broadcast case
+// [sumOrAvgMixedOrSubqueryOuterFnRecognized] admits alongside plain
+// instant eval.
+func TestSumOrAvgMixedOrSubquery_PinnedRangeComposes(t *testing.T) {
+	t.Parallel()
+
+	s := schema.DefaultOTelMetrics()
+	start := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	end := time.Date(2026, 1, 1, 1, 0, 0, 0, time.UTC)
+
+	for _, fn := range sumOrAvgMixedOrFoldFnNames {
+		t.Run(fn, func(t *testing.T) {
+			t.Parallel()
+			query := fn + "((sum by (series) ((latency_exp_hist) or (num_cpus)))[5m:1m] @ end())"
+			expr := parseExprExp(t, query)
+			node, err := promql.LowerAtRange(context.Background(), expr, s, start, end, time.Minute)
+			if err != nil {
+				t.Fatalf("lower(%q): want success, got error: %v", query, err)
+			}
+			if node == nil {
+				t.Fatalf("lower(%q): want a non-nil plan", query)
+			}
+		})
+	}
+}

--- a/internal/promql/histogram_native_mixed_or_subquery_aggregate_range_fn_window_purity_chdb_test.go
+++ b/internal/promql/histogram_native_mixed_or_subquery_aggregate_range_fn_window_purity_chdb_test.go
@@ -1,0 +1,123 @@
+//go:build chdb
+
+// chDB-backed proof of the window-purity collision-DROP semantics
+// histogram_native_mixed_or_subquery_aggregate_range_fn.go's own doc
+// derives from reference Prometheus's extrapolatedRate /
+// funcSumOverTime / funcAvgOverTime (tsouza/prometheus's own
+// promql/functions.go): a `sum by (series) (...)` output group whose
+// window holds a histogram-typed sample at ONE subquery anchor and a
+// float-typed sample at ANOTHER — never colliding at the SAME anchor, so
+// the EXISTING per-anchor [combineMixedAggregateBranches] drop never
+// fires — must still be dropped ENTIRELY by a window-purity-filtered
+// FOLD-family function (sum_over_time here), while a type-blind function
+// (count_over_time) keeps counting both sightings.
+//
+// Reproducing that shape cleanly needs the histogram sample and the float
+// sample separated by MORE than the default five-minute staleness lookback
+// ([subqueryStalenessLookback] / [instantLookback], modifiers.go) — samples
+// closer together than that would have one carry FORWARD into the other's
+// own subquery anchor, producing a genuine SAME-anchor collision the
+// existing per-anchor mechanism would already resolve (by keeping the
+// mixed `or`'s syntactic-LHS side and shadowing the other, per the `or`
+// shadow rule cerberus issue #2337 already ships) — a different, already-
+// covered shape, not this file's own window-level one.
+//
+// series "x" seeds a histogram sample at 00:01 and a gauge sample at
+// 00:11 (a ten-minute gap) inside a thirteen-minute subquery window
+// (00:01..00:13, evaluated at 00:13): the histogram sample is visible via
+// carry-forward at anchors 00:01-00:05 (it expires once an anchor is five
+// minutes past its own timestamp: `ts > anchor - 5m` fails from 00:06
+// onward) and the gauge sample at anchors 00:11-00:13 (capped by the
+// window's own end) — five histogram sightings, three float sightings,
+// zero anchors where both are present at once.
+package promql_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/tsouza/cerberus/internal/schema"
+)
+
+const (
+	sumAvgPurityExpHistMetric = "sav_purity_exp_hist"
+	sumAvgPurityGaugeMetric   = "sav_purity_gauge"
+)
+
+var sumAvgPuritySeed = subqHistDDL +
+	"INSERT INTO otel_metrics_exponential_histogram " +
+	"(MetricName, Attributes, TimeUnix, Count, Sum, Scale, ZeroCount, PositiveOffset, PositiveBucketCounts, NegativeOffset, NegativeBucketCounts) VALUES\n" +
+	"    ('" + sumAvgPurityExpHistMetric + "', map('series', 'x'), toDateTime64('2026-01-01 00:01:00', 9), 1, 1.0, 0, 0, 0, [1], 0, []);\n" +
+	swapGaugeSeedDDL +
+	"INSERT INTO otel_metrics_gauge (MetricName, Attributes, TimeUnix, Value) VALUES\n" +
+	"    ('" + sumAvgPurityGaugeMetric + "', map('series', 'x'), toDateTime64('2026-01-01 00:11:00', 9), 99.0);\n"
+
+var sumAvgPurityEvalTS = time.Date(2026, 1, 1, 0, 13, 0, 0, time.UTC)
+
+func sumAvgPurityQuery(fn string) string {
+	inner := "sum by (series) ((" + sumAvgPurityExpHistMetric + ") or (" + sumAvgPurityGaugeMetric + "))"
+	return fn + "((" + inner + ")[13m:1m])"
+}
+
+// TestSumOrAvgMixedOrSubqueryWindowPurity_CountOverTime_ChDB proves
+// count_over_time — type-blind, no window-purity filtering — reports
+// EVERY sighting of series "x" across the window, summing the five
+// histogram-typed anchors and the three float-typed ones: reference's own
+// funcCountOverTime never inspects sample type.
+func TestSumOrAvgMixedOrSubqueryWindowPurity_CountOverTime_ChDB(t *testing.T) {
+	fixture := newChDBFixture(t, sumAvgPuritySeed)
+	s := schema.DefaultOTelMetrics()
+
+	sqlStr, args := lowerAndEmit(t, sumAvgPurityQuery("count_over_time"), s, sumAvgPurityEvalTS)
+	got := sampleValueRows(t, fixture, sqlStr, args)
+	if got["x"] != 8 {
+		t.Errorf("count_over_time: series x = %v, want 8 (5 histogram-typed sightings + 3 float-typed, type-blind)", got["x"])
+	}
+}
+
+// TestSumOrAvgMixedOrSubqueryWindowPurity_SumOverTime_ChDB proves
+// sum_over_time — a window-purity-filtered FOLD-family member — DROPS
+// series "x" entirely: this is the collision-drop semantics PR
+// #2592/#2610 found the naive per-arm-distribute approach could not
+// reproduce, now verified against real ClickHouse execution for a group
+// whose two types never collide at the same subquery anchor.
+func TestSumOrAvgMixedOrSubqueryWindowPurity_SumOverTime_ChDB(t *testing.T) {
+	fixture := newChDBFixture(t, sumAvgPuritySeed)
+	s := schema.DefaultOTelMetrics()
+
+	sqlStr, args := lowerAndEmit(t, sumAvgPurityQuery("sum_over_time"), s, sumAvgPurityEvalTS)
+
+	histRows := subqHistQueryRows(t, fixture, sqlStr, args)
+	for _, r := range histRows {
+		if r.series == "x" {
+			t.Errorf("sum_over_time: series x has a histogram-arm row %+v, want it DROPPED (window holds both a histogram and a float sample)", r)
+		}
+	}
+
+	got := sampleValueRows(t, fixture, sqlStr, args)
+	if _, present := got["x"]; present {
+		t.Errorf("sum_over_time: series x has a float-arm row (value %v), want it DROPPED (window holds both a histogram and a float sample)", got["x"])
+	}
+}
+
+// TestSumOrAvgMixedOrSubqueryWindowPurity_Rate_ChDB is the identical
+// window-purity drop proof for rate, the issue's own second FOLD-family
+// evidence shape.
+func TestSumOrAvgMixedOrSubqueryWindowPurity_Rate_ChDB(t *testing.T) {
+	fixture := newChDBFixture(t, sumAvgPuritySeed)
+	s := schema.DefaultOTelMetrics()
+
+	sqlStr, args := lowerAndEmit(t, sumAvgPurityQuery("rate"), s, sumAvgPurityEvalTS)
+
+	histRows := subqHistQueryRows(t, fixture, sqlStr, args)
+	for _, r := range histRows {
+		if r.series == "x" {
+			t.Errorf("rate: series x has a histogram-arm row %+v, want it DROPPED", r)
+		}
+	}
+
+	got := sampleValueRows(t, fixture, sqlStr, args)
+	if _, present := got["x"]; present {
+		t.Errorf("rate: series x has a float-arm row (value %v), want it DROPPED", got["x"])
+	}
+}

--- a/internal/promql/lower.go
+++ b/internal/promql/lower.go
@@ -2828,6 +2828,15 @@ func lowerCallOverSubquery(c *parser.Call, sq *parser.SubqueryExpr, s schema.Met
 	if sub, b, rebuild, ok := mixedOrSubqueryOuterFn(c, s, ctx); ok {
 		return lowerMixedOrSubqueryOuterFn(c, sub, b, rebuild, s, ctx)
 	}
+	// The `sum`/`avg`-wrapped sibling of the mixed-or-subquery composition
+	// just above (cerberus issue #2581) — see
+	// histogram_native_mixed_or_subquery_aggregate_range_fn.go's own doc for
+	// why this needs a genuinely different lowering (window-purity
+	// collision drop) rather than the distribute-and-recombine
+	// [lowerMixedOrSubqueryOuterFn] uses.
+	if shape, ok := sumOrAvgMixedOrSubqueryOuterFnRecognized(c, s, ctx); ok {
+		return lowerSumOrAvgMixedOrSubqueryOuterFn(shape, s, ctx)
+	}
 	// `<range-vector-fn>(<subquery>)` — the canonical Grafana shape
 	// `max_over_time(rate(m[5m])[1h:5m])`. Lowers to a chained RangeWindow:
 	// outer reducer over the inner matrix.

--- a/test/rejection-parity/catalogue/internal__promql__histogram_native_mixed_or_aggregate.go__lowerSumOrAvgOverMixedExpHistogramSetOp.json
+++ b/test/rejection-parity/catalogue/internal__promql__histogram_native_mixed_or_aggregate.go__lowerSumOrAvgOverMixedExpHistogramSetOp.json
@@ -5,19 +5,22 @@
       "site": "internal/promql/histogram_native_mixed_or_aggregate.go:lowerSumOrAvgOverMixedExpHistogramSetOp#6cdf660e",
       "message": "promql: 'bool' modifier is only allowed on comparison binary ops",
       "class": "internal",
-      "rationale": "the parser rejects `bool` on non-comparison operators (\"bool modifier can only be used on comparison operators\"), same as lowerMixedExpHistogramSetOp's identical check for the leaf mixed-or case (histogram_native_mixed_or.go), lowerVectorSetOp's identical check for the float case, and lowerExpHistogramSetOp's identical check for the both-histogram case. Since cerberus issue #2528, lowerMixedExpHistogramFamily replaces lowerRoot as the direct caller (split out of lowerRoot's own body purely to keep that function's golangci-lint maintainability-index score over the repo's floor) — the same mixedExpHistogramSetOp-matched `or` BinaryExpr flows through unchanged, so the claim is unaffected.",
+      "rationale": "the parser rejects `bool` on non-comparison operators (\"bool modifier can only be used on comparison operators\"), same as lowerMixedExpHistogramSetOp's identical check for the leaf mixed-or case (histogram_native_mixed_or.go), lowerVectorSetOp's identical check for the float case, and lowerExpHistogramSetOp's identical check for the both-histogram case. Since cerberus issue #2528, lowerMixedExpHistogramFamily replaces lowerRoot as the direct caller (split out of lowerRoot's own body purely to keep that function's golangci-lint maintainability-index score over the repo's floor) — the same mixedExpHistogramSetOp-matched `or` BinaryExpr flows through unchanged, so the claim is unaffected. Cerberus issue #2581 added a second caller, lowerSumOrAvgMixedOrSubquerySelectFn (histogram_native_mixed_or_subquery_aggregate_range_fn.go) — reached only after lowerSumOrAvgMixedOrSubqueryOuterFn's own identical `if shape.b.ReturnBool` guard already rejected the same BinaryExpr earlier in the same call chain, so this guard stays unreachable via that path too.",
       "evidence": {
         "guard": [
           "if b.ReturnBool"
         ],
         "callers": [
-          "lowerMixedExpHistogramFamily"
+          "lowerMixedExpHistogramFamily",
+          "lowerSumOrAvgMixedOrSubquerySelectFn"
         ],
         "cited": [
           "lowerExpHistogramSetOp",
           "lowerMixedExpHistogramFamily",
           "lowerMixedExpHistogramSetOp",
           "lowerRoot",
+          "lowerSumOrAvgMixedOrSubqueryOuterFn",
+          "lowerSumOrAvgMixedOrSubquerySelectFn",
           "lowerVectorSetOp",
           "mixedExpHistogramSetOp"
         ]

--- a/test/rejection-parity/catalogue/internal__promql__histogram_native_mixed_or_subquery_aggregate_range_fn.go__lowerSumOrAvgMixedOrSubqueryOuterFn.json
+++ b/test/rejection-parity/catalogue/internal__promql__histogram_native_mixed_or_subquery_aggregate_range_fn.go__lowerSumOrAvgMixedOrSubqueryOuterFn.json
@@ -1,0 +1,66 @@
+{
+  "entries": [
+    {
+      "head": "promql",
+      "site": "internal/promql/histogram_native_mixed_or_subquery_aggregate_range_fn.go:lowerSumOrAvgMixedOrSubqueryOuterFn#6cdf660e",
+      "message": "promql: 'bool' modifier is only allowed on comparison binary ops",
+      "class": "internal",
+      "rationale": "the parser rejects `bool` on non-comparison operators (\"bool modifier can only be used on comparison operators\"), same as lowerSumOrAvgOverMixedExpHistogramSetOp's identical check for the root-only sibling composition (histogram_native_mixed_or_aggregate.go) and lowerMixedExpHistogramSetOp's identical check for the leaf mixed-or case — shape.b is the SAME sumOrAvgOverMixedExpHistogramSetOp-matched `or` BinaryExpr, which the parser can never hand a `bool` modifier.",
+      "evidence": {
+        "guard": [
+          "past returning if step \u003c 0",
+          "past returning if err != nil",
+          "past returning if !ok",
+          "if shape.b.ReturnBool"
+        ],
+        "callers": [
+          "lowerCallOverSubquery"
+        ],
+        "cited": [
+          "lowerMixedExpHistogramSetOp",
+          "lowerSumOrAvgOverMixedExpHistogramSetOp",
+          "sumOrAvgOverMixedExpHistogramSetOp"
+        ]
+      }
+    },
+    {
+      "head": "promql",
+      "site": "internal/promql/histogram_native_mixed_or_subquery_aggregate_range_fn.go:lowerSumOrAvgMixedOrSubqueryOuterFn#91084197",
+      "message": "promql: subquery step must be positive, got %s",
+      "class": "internal",
+      "rationale": "the PromQL parser rejects negative subquery steps; zero is the valid default handled before this guard",
+      "evidence": {
+        "guard": [
+          "if step \u003c 0"
+        ],
+        "callers": [
+          "lowerCallOverSubquery"
+        ]
+      }
+    },
+    {
+      "head": "promql",
+      "site": "internal/promql/histogram_native_mixed_or_subquery_aggregate_range_fn.go:lowerSumOrAvgMixedOrSubqueryOuterFn#d4ecb9e5",
+      "message": "promql: histogram-valued subquery requires query eval-time context (use LowerAt)",
+      "class": "internal",
+      "rationale": "query handlers always supply evaluation context through LowerAt or LowerAtRange; only the raw test and tooling Lower entry can omit it, and sumOrAvgMixedOrSubqueryOuterFnRecognized's own subqueryHasEvalAnchor check already declines to match in that case, so this branch is unreachable even from that entry point",
+      "evidence": {
+        "guard": [
+          "past returning if step \u003c 0",
+          "past returning if err != nil",
+          "if !ok"
+        ],
+        "callers": [
+          "lowerCallOverSubquery"
+        ],
+        "cited": [
+          "Lower",
+          "LowerAt",
+          "LowerAtRange",
+          "subqueryHasEvalAnchor",
+          "sumOrAvgMixedOrSubqueryOuterFnRecognized"
+        ]
+      }
+    }
+  ]
+}

--- a/test/rejection-parity/catalogue/internal__promql__histogram_native_mixed_or_subquery_aggregate_range_fn.go__lowerSumOrAvgMixedOrSubquerySelectFn.json
+++ b/test/rejection-parity/catalogue/internal__promql__histogram_native_mixed_or_subquery_aggregate_range_fn.go__lowerSumOrAvgMixedOrSubquerySelectFn.json
@@ -1,0 +1,24 @@
+{
+  "entries": [
+    {
+      "head": "promql",
+      "site": "internal/promql/histogram_native_mixed_or_subquery_aggregate_range_fn.go:lowerSumOrAvgMixedOrSubquerySelectFn#2bdaf2b5",
+      "message": "promql: internal invariant violated: sum/avg-mixed-or subquery input is %T with %s row shape",
+      "class": "internal",
+      "rationale": "mixedRel is lowerSumOrAvgOverMixedExpHistogramSetOp's own return value, and that function's only successful return path is combineMixedAggregateBranches's chplan.VectorSetOp{Mixed: true, Op: VectorSetOr} — which chplan.RowShapeOf always reports as MixedRowShape — so a non-error return can never fail this check; the guard exists to fail loudly rather than silently if that postcondition is ever broken by a future change to either function.",
+      "evidence": {
+        "guard": [
+          "past returning if err != nil",
+          "if chplan.RowShapeOf(mixedRel) != chplan.MixedRowShape"
+        ],
+        "callers": [
+          "lowerSumOrAvgMixedOrSubqueryOuterFn"
+        ],
+        "cited": [
+          "combineMixedAggregateBranches",
+          "lowerSumOrAvgOverMixedExpHistogramSetOp"
+        ]
+      }
+    }
+  ]
+}

--- a/test/rejection-parity/catalogue/internal__promql__histogram_native_sum.go__lowerExpHistogramSumOrAvgOverPlan.json
+++ b/test/rejection-parity/catalogue/internal__promql__histogram_native_sum.go__lowerExpHistogramSumOrAvgOverPlan.json
@@ -5,21 +5,24 @@
       "site": "internal/promql/histogram_native_sum.go:lowerExpHistogramSumOrAvgOverPlan#7a3163a0",
       "message": "promql: internal invariant violated: nested native-histogram aggregation input is %T with %s row shape",
       "class": "internal",
-      "rationale": "mergeableExpHistogramAggregate plus recursive histogram recognition admits lowerExpHistogramValuedShape's call only over the HistogramRowShape it itself returned. lowerSumOrAvgOverMixedExpHistogramSetOp (cerberus issue #2346, histogram_native_mixed_or_aggregate.go) is the second caller: it passes either histNode directly — lowerExpHistogramSetOpOperand's own postcondition already guarantees HistogramRowShape — or mixedOrShadowUnless's chplan.VectorSetOp{Histogram: true} wrapping it, which chplan.RowShapeOf also reports as HistogramRowShape, so this guard stays unreachable via that path too",
+      "rationale": "mergeableExpHistogramAggregate plus recursive histogram recognition admits lowerExpHistogramValuedShape's call only over the HistogramRowShape it itself returned. lowerSumOrAvgOverMixedExpHistogramSetOp (cerberus issue #2346, histogram_native_mixed_or_aggregate.go) is the second caller: it passes either histNode directly — lowerExpHistogramSetOpOperand's own postcondition already guarantees HistogramRowShape — or mixedOrShadowUnless's chplan.VectorSetOp{Histogram: true} wrapping it, which chplan.RowShapeOf also reports as HistogramRowShape, so this guard stays unreachable via that path too. Cerberus issue #2581 added a third caller, lowerSumOrAvgMixedOrSubqueryFoldFn (histogram_native_mixed_or_subquery_aggregate_range_fn.go): it calls shadowResolveMixedExpHistogramOperands directly — the SAME helper lowerSumOrAvgOverMixedExpHistogramSetOp calls internally — and passes its histForAgg return value straight through, so the identical HistogramRowShape postcondition holds for this caller too.",
       "evidence": {
         "guard": [
           "if chplan.RowShapeOf(input) != chplan.HistogramRowShape"
         ],
         "callers": [
           "lowerExpHistogramValuedShape",
+          "lowerSumOrAvgMixedOrSubqueryFoldFn",
           "lowerSumOrAvgOverMixedExpHistogramSetOp"
         ],
         "cited": [
           "lowerExpHistogramSetOpOperand",
           "lowerExpHistogramValuedShape",
+          "lowerSumOrAvgMixedOrSubqueryFoldFn",
           "lowerSumOrAvgOverMixedExpHistogramSetOp",
           "mergeableExpHistogramAggregate",
-          "mixedOrShadowUnless"
+          "mixedOrShadowUnless",
+          "shadowResolveMixedExpHistogramOperands"
         ]
       }
     }

--- a/test/rejection-parity/catalogue/internal__promql__subquery.go__lowerOuterRangeFnOverSubquery.json
+++ b/test/rejection-parity/catalogue/internal__promql__subquery.go__lowerOuterRangeFnOverSubquery.json
@@ -5,8 +5,8 @@
       "site": "internal/promql/subquery.go:lowerOuterRangeFnOverSubquery#087c3810",
       "message": "promql: %s over a subquery wrapping a native-histogram-valued shape is unsupported",
       "class": "divergence",
-      "trigger_query": "count_over_time((sum by (series) ((demo_latency_exp_hist) or (demo_num_cpus)))[5m:1m])",
-      "tracking_issue": 2581,
+      "trigger_query": "last_over_time((sum by (series) ((demo_latency_exp_hist) or (demo_num_cpus)))[5m:1m])",
+      "tracking_issue": 2615,
       "evidence": {
         "guard": [
           "past returning if outer.Func.Name == \"absent_over_time\"",

--- a/test/rejection-parity/catalogue/internal__promql__subquery.go__subqueryAnchor.json
+++ b/test/rejection-parity/catalogue/internal__promql__subquery.go__subqueryAnchor.json
@@ -5,7 +5,7 @@
       "site": "internal/promql/subquery.go:subqueryAnchor#1306ccfc",
       "message": "promql: subquery `@ start()` modifier requires query range context (use LowerAt)",
       "class": "internal",
-      "rationale": "the query endpoints always lower through LowerAtRange with the request window, so range context is present",
+      "rationale": "the query endpoints always lower through LowerAtRange with the request window, so range context is present. Cerberus issue #2581 added two new callers, lowerSumOrAvgMixedOrSubqueryFoldFn and lowerSumOrAvgMixedOrSubquerySelectFn (histogram_native_mixed_or_subquery_aggregate_range_fn.go) — both reached only from the same query-endpoint entry points as every other caller in this list, so the claim is unaffected.",
       "evidence": {
         "guard": [
           "case parser.START of switch e.StartOrEnd",
@@ -22,11 +22,15 @@
           "lowerSubqueryOverCallSubquery",
           "lowerSubqueryOverSubquery",
           "lowerSubqueryOverVectorSelector",
+          "lowerSumOrAvgMixedOrSubqueryFoldFn",
+          "lowerSumOrAvgMixedOrSubquerySelectFn",
           "subqueryGridCtx",
           "wrapSubqueryIdentity"
         ],
         "cited": [
-          "LowerAtRange"
+          "LowerAtRange",
+          "lowerSumOrAvgMixedOrSubqueryFoldFn",
+          "lowerSumOrAvgMixedOrSubquerySelectFn"
         ]
       }
     },
@@ -35,7 +39,7 @@
       "site": "internal/promql/subquery.go:subqueryAnchor#92800419",
       "message": "promql: subquery `@ end()` modifier requires query range context (use LowerAt)",
       "class": "internal",
-      "rationale": "the query endpoints always lower through LowerAtRange with the request window, so range context is present",
+      "rationale": "the query endpoints always lower through LowerAtRange with the request window, so range context is present. Cerberus issue #2581 added two new callers, lowerSumOrAvgMixedOrSubqueryFoldFn and lowerSumOrAvgMixedOrSubquerySelectFn (histogram_native_mixed_or_subquery_aggregate_range_fn.go) — both reached only from the same query-endpoint entry points as every other caller in this list, so the claim is unaffected.",
       "evidence": {
         "guard": [
           "case parser.END of switch e.StartOrEnd",
@@ -52,11 +56,15 @@
           "lowerSubqueryOverCallSubquery",
           "lowerSubqueryOverSubquery",
           "lowerSubqueryOverVectorSelector",
+          "lowerSumOrAvgMixedOrSubqueryFoldFn",
+          "lowerSumOrAvgMixedOrSubquerySelectFn",
           "subqueryGridCtx",
           "wrapSubqueryIdentity"
         ],
         "cited": [
-          "LowerAtRange"
+          "LowerAtRange",
+          "lowerSumOrAvgMixedOrSubqueryFoldFn",
+          "lowerSumOrAvgMixedOrSubquerySelectFn"
         ]
       }
     },
@@ -65,7 +73,7 @@
       "site": "internal/promql/subquery.go:subqueryAnchor#a34bee25",
       "message": "promql: unexpected subquery StartOrEnd token %v",
       "class": "internal",
-      "rationale": "the PromQL parser yields only START, END, or zero in StartOrEnd",
+      "rationale": "the PromQL parser yields only START, END, or zero in StartOrEnd. Cerberus issue #2581 added two new callers, lowerSumOrAvgMixedOrSubqueryFoldFn and lowerSumOrAvgMixedOrSubquerySelectFn (histogram_native_mixed_or_subquery_aggregate_range_fn.go), both threading the same parser-produced SubqueryExpr through unchanged, so the claim is unaffected.",
       "evidence": {
         "guard": [
           "default of switch e.StartOrEnd over [case parser.START; case parser.END; case 0; default]"
@@ -81,8 +89,14 @@
           "lowerSubqueryOverCallSubquery",
           "lowerSubqueryOverSubquery",
           "lowerSubqueryOverVectorSelector",
+          "lowerSumOrAvgMixedOrSubqueryFoldFn",
+          "lowerSumOrAvgMixedOrSubquerySelectFn",
           "subqueryGridCtx",
           "wrapSubqueryIdentity"
+        ],
+        "cited": [
+          "lowerSumOrAvgMixedOrSubqueryFoldFn",
+          "lowerSumOrAvgMixedOrSubquerySelectFn"
         ]
       }
     }

--- a/test/rejection-parity/divergence-ceiling.json
+++ b/test/rejection-parity/divergence-ceiling.json
@@ -1,3 +1,3 @@
 {
-  "max_entries": 5
+  "max_entries": 4
 }


### PR DESCRIPTION
## Summary

Closes cerberus issue #2581 for the `sum`/`avg`-wrapped mixed float/histogram `or` subquery
composition — `<fn>((sum by (series) ((a) or (b)))[range:step])` — for eleven of the fifteen
SELECT/FOLD-family names. This was previously investigated across PR #2592 and PR #2610 and both
times documented as unsound because a naive "distribute the outer function per `or` ARM, then
recombine" approach cannot reproduce reference Prometheus's `sum`/`avg` drop-on-collision semantics
(a `by`/`without` clause can put rows from BOTH arms into the same output group, and reference
drops that group entirely rather than picking a side).

This PR does not use that distribute-per-arm approach at all. Two findings made a sound
composition possible instead:

1. **The collision-drop mechanism already exists and is already reachable here.** cerberus issue
   #2346's `combineMixedAggregateBranches` (`histogram_native_mixed_or_aggregate.go`) already
   reduces the histogram arm and the float arm of `sum by (series) ((a) or (b))` SEPARATELY and
   recombines with a real drop-on-group-collision rule — not a naive distribute. And
   `lowerSubquery` already runs the full histogram-native recognizer chain (including this exact
   function) against a subquery's own inner expression, at the subquery's own per-anchor grid. So
   the subquery's inner already lowers to a genuinely collision-correct `chplan.MixedRowShape`
   relation today — `lowerOuterRangeFnOverSubquery` just unconditionally rejected it. That's the
   actual, much narrower gap this PR closes.
2. **Reference's own window reducers already define what to do with a per-anchor-mixed-type
   relation.** `tsouza/prometheus`'s `promql/functions.go` — `extrapolatedRate`
   (rate/increase/delta/irate/idelta) and `funcSumOverTime`/`funcAvgOverTime` — all check
   `len(samples.Histograms) > 0 && len(samples.Floats) > 0` for the WHOLE window and drop the
   series entirely when both are present. This is the same "drop on collision" shape
   `combineMixedAggregateBranches` already implements one level down, just keyed by (output group)
   across the whole window instead of (output group, one anchor). The four type-blind names
   (`count_over_time`, `present_over_time`, `ts_of_first_over_time`, `ts_of_last_over_time`) never
   branch on sample type in reference at all, so no window-purity test applies to them.

`internal/promql/histogram_native_mixed_or_subquery_aggregate_range_fn.go` (new file) implements
both: the four type-blind names reuse `lowerSumOrAvgOverMixedExpHistogramSetOp` (unchanged)
directly; the seven type-preserving FOLD names re-derive the histogram/float branches via
`shadowResolveMixedExpHistogramOperands`, apply a new `windowPurityUnless` collision-drop filter
(the identical `chplan.VectorSetOp` UNLESS idiom `combineMixedAggregateBranches` already uses, with
`StepAligned` forced false so the match spans every subquery anchor rather than one), fold each
pure branch through the existing per-type window-fold machinery, and recombine via
`combineMixedAggregateBranches` unchanged.

## Scope

Four names — and one grid mode — deliberately stay on the pre-existing rejection, each for a
distinct, documented reason (see the new file's own "Scope" doc): `last_over_time`/`first_over_time`
(need a Mixed-shaped, not Histogram-shaped, verbatim-selection reduction), `resets`/`changes` (need
a type-aware interleaved merge, since reference does NOT drop on window-mix for these two — a type
flip just counts as an automatic reset), and true `query_range` fan-out (non-`@`-pinned) for the
seven FOLD names, since the window-purity test is only sound today for a single window per output
series. Filed as cerberus issue #2615 with the rejection-parity catalogue's
`internal/promql/subquery.go:lowerOuterRangeFnOverSubquery#087c3810` entry rotated to a live trigger
in that narrower remaining scope (`last_over_time`).

## Test plan

- [x] `TestSumOrAvgMixedOrSubquery_Composes` — all eleven names lower successfully for both `sum`
  and `avg`, instant mode.
- [x] `TestSumOrAvgMixedOrSubquery_PinnedRangeComposes` — the seven FOLD names also compose under
  query_range when the subquery carries an `@` pin.
- [x] `TestSumOrAvgMixedOrSubquery_StillRejects` / `_RangeFanoutStillRejects` — the four
  unimplemented names, and true (non-pinned) query_range fan-out for the FOLD family, still reject
  with the pre-existing message.
- [x] chDB-backed: `TestSumOrAvgMixedOrSubqueryCountOverTime_ChDB` /
  `_SumOverTime_ChDB` / `_Rate_ChDB` / `_TsOfLastOverTime_ChDB` — ordinary (no-collision)
  correctness against real ClickHouse.
- [x] chDB-backed: `TestSumOrAvgMixedOrSubqueryWindowPurity_CountOverTime_ChDB` /
  `_SumOverTime_ChDB` / `_Rate_ChDB` — the collision-drop proof itself, against real ClickHouse: a
  group whose window holds a histogram-typed sample at one subquery anchor and a float-typed sample
  at another (samples spaced beyond the default 5-minute staleness lookback, so the two never
  collide at the same anchor and the pre-existing per-anchor drop never fires) is counted
  type-blindly by `count_over_time` (8 sightings) but DROPPED entirely by `sum_over_time`/`rate`.
- [x] `go build ./...`, `go vet ./internal/promql/...`, `gofumpt -extra -l .` /
  `goimports -local github.com/tsouza/cerberus -l .` — clean.
- [x] `go test -race ./internal/promql/...` — pass.
- [x] `node .github/scripts/forbid-sql-raw.mjs` — clean.
- [x] `go test ./test/spec/...` — pass.
- [x] rejection-parity catalogue regenerated (`just update-golden parity`) and
  `TestRejectionTriggersExerciseSites` / `TestCatalogueIsRegenerable` pass.

Closes #2581
