### PR TITLE
test(promql): cover the vector-vector operand path #2534's nested-binop fix added

### DIFF
--- a/internal/promql/binary.go
+++ b/internal/promql/binary.go
@@ -141,11 +141,11 @@ func lowerVectorVector(b *parser.BinaryExpr, s schema.Metrics, op chplan.BinaryO
 		// emitter's "many" aggregation handles by construction).
 	}
 
-	left, err := lower(b.LHS, s, ctx)
+	left, err := lowerVectorVectorOperand(b.LHS, s, ctx)
 	if err != nil {
 		return nil, err
 	}
-	right, err := lower(b.RHS, s, ctx)
+	right, err := lowerVectorVectorOperand(b.RHS, s, ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -651,6 +651,82 @@ func tryScalarLiteral(e parser.Expr) (float64, bool) {
 	return TryFoldScalar(e)
 }
 
+// lowerScalarBinopOperand lowers [lowerVectorScalar]'s vec argument,
+// trying the exp-histogram "preserve"/"drop" family opt-in first — exactly
+// as every wrapper callsite in this package already does (a Call's single
+// vector argument, an AggregateExpr's Expr — cerberus issues
+// #2221/#2345/#2456/#2498/#2528) — before falling back to the plain
+// [lower] dispatcher.
+//
+// This closes a structurally different gap from those wrapper callsites
+// (cerberus issue #2534): [lowerVectorScalar] is reached from lowerRoot's
+// own final `lower(expr, s, ctx)` fallback only after every dedicated
+// histogram/scalar recogniser — lowerRoot's own dispatch chain, and
+// [lowerExpHistogramValuedShape]'s own [expHistogramScalarBinop] entry —
+// has already failed to match the WHOLE outer expression. Both that
+// recogniser and its drop-family sibling [expHistogramDroppingScalarBinop]
+// match unconditionally whenever vec is directly histogram-valued (there
+// is no vector-matching mode for a scalar operand to gate on), so by
+// construction vec can never be DIRECTLY one of those shapes here — an
+// outer recogniser would already have claimed the whole expression first.
+// What escapes undetected is a NESTED composition vec happens to be — a
+// drop-family (or preserve-family) binop as ANOTHER binop's own operand,
+// e.g. `(demo_latency_exp_hist + 0) * 2` — which none of the outer
+// recognisers look inside far enough to see, because they only ever
+// inspect the binop's own immediate LHS/RHS, not a further nested
+// sub-expression's OWN operand structure.
+// [lowerExpHistogramArgAsCanonicalFloat] already tries both families and
+// reprojects either to the canonical (MetricName, Attributes, TimeUnix,
+// Value) quartet [lowerVectorScalar]'s own arithmetic already expects from
+// a plain [lower] result, so no further plumbing is needed once matched.
+//
+// Deliberately NOT reused for [lowerVectorVector]'s two operands — see
+// [lowerVectorVectorOperand]'s own doc for why the vector-vector case
+// needs a narrower opt-in.
+func lowerScalarBinopOperand(expr parser.Expr, s schema.Metrics, ctx lowerCtx) (chplan.Node, error) {
+	if node, ok, err := lowerExpHistogramArgAsCanonicalFloat(expr, s, ctx); ok {
+		return node, err
+	}
+	return lower(expr, s, ctx)
+}
+
+// lowerVectorVectorOperand lowers one operand of [lowerVectorVector]
+// (LHS or RHS), trying ONLY the exp-histogram "drop" family's nested-
+// composition opt-in before falling back to the generic [lower]
+// dispatcher — unlike [lowerScalarBinopOperand] (the scalar-operand
+// sibling this mirrors for cerberus issue #2534), it deliberately does
+// NOT also try the "preserve" family.
+//
+// A drop-family match answers reference's genuinely, unconditionally
+// EMPTY result: composing an already-empty vector under ANY further
+// vector-vector op or matching mode is still empty, regardless of whether
+// cerberus's join machinery happens to support that op/matching-mode
+// combination for a NON-empty histogram operand — so resolving it eagerly
+// here can never disagree with a matching-mode-aware outer recogniser.
+//
+// The "preserve" family cannot take the same shortcut: a histogram-valued
+// operand is a real, non-empty value that must still flow through the
+// correct vector-vector JOIN — and matching-mode-sensitive recognisers
+// like [expHistogramFloatVectorScalingBinop]
+// (histogram_native_float_vector_scaling_binop.go) deliberately decline
+// some on()/group_left()/group_right() combinations that shape does not
+// yet support, in which case the query must keep hard-rejecting rather
+// than silently discarding the join and answering an empty result.
+// Because a DIRECTLY-valued V-V operand is otherwise always claimed by
+// one of lowerRoot's own exhaustive, matching-mode-aware dispatches
+// before [lowerVectorVector]'s generic fallback is ever reached, trying
+// the "preserve" family here would only ever fire on exactly those
+// deliberately-unsupported combinations — silently downgrading a correct
+// rejection into a wrong empty answer. See
+// TestLower_ExpHistogram_FloatVectorScalingBinopStillRejected for the
+// regression this scoping avoids.
+func lowerVectorVectorOperand(expr parser.Expr, s schema.Metrics, ctx lowerCtx) (chplan.Node, error) {
+	if dropped, ok, err := lowerExpHistogramDroppingShape(expr, s, ctx); ok {
+		return dropped, err
+	}
+	return lower(expr, s, ctx)
+}
+
 // lowerVectorScalar lowers a binary expression mixing a vector and a
 // scalar. Arithmetic ops are mapped through a Project that replaces
 // `Value` with `(scalar OP Value)` or `(Value OP scalar)`. Comparison ops
@@ -661,7 +737,7 @@ func tryScalarLiteral(e parser.Expr) (float64, bool) {
 // scalarOnLeft flips the operand order — important for non-commutative
 // ops like SUB and DIV and for comparisons (`5 > up` vs `up > 5`).
 func lowerVectorScalar(vec parser.Expr, s schema.Metrics, op chplan.BinaryOp, scalar float64, scalarOnLeft, returnBool bool, ctx lowerCtx) (chplan.Node, error) {
-	inner, err := lower(vec, s, ctx)
+	inner, err := lowerScalarBinopOperand(vec, s, ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/promql/histogram_native_dropping_nested_binop_chdb_test.go
+++ b/internal/promql/histogram_native_dropping_nested_binop_chdb_test.go
@@ -1,0 +1,116 @@
+//go:build chdb
+
+// chDB-backed proof that a drop-family exp-histogram binop nested as
+// ANOTHER binop's own operand (cerberus issue #2534) now lowers to valid
+// SQL and EXECUTES against real ClickHouse — not merely that a Go-level
+// lowering error stopped being raised.
+//
+// binary.go's lowerScalarBinopOperand / lowerVectorVectorOperand and
+// histogram_native_set_op.go's lowerVectorSetOpOperand are the new
+// per-operand opt-ins this issue's fix threads into the generic recursive
+// binop lowering; TestLower_ExpHistogram_DroppingShapeComposesUnderWrappers
+// (histogram_native_dropping_shape_test.go) already pins the SAME leaf
+// composed under a WRAPPER's own argument position (cerberus issue #2528)
+// at the Go-plan-shape level — this file is that fixture's chDB-executed,
+// binop-nested sibling, using the issue's own four trigger queries
+// verbatim.
+//
+// The metric is seeded with a REAL, non-empty row so a returned zero-row
+// result can only mean the drop actually fired — not that no data was
+// ever scanned.
+package promql_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/prometheus/prometheus/promql/parser"
+
+	"github.com/tsouza/cerberus/internal/chsql"
+	"github.com/tsouza/cerberus/internal/promql"
+	"github.com/tsouza/cerberus/internal/schema"
+	"github.com/tsouza/cerberus/internal/testsql"
+)
+
+const nestedBinopDropMetric = "nested_binop_drop_probe_exp_hist"
+
+var nestedBinopDropSeed = "" +
+	"CREATE OR REPLACE TABLE otel_metrics_exponential_histogram (" +
+	"`MetricName` String, `Attributes` Map(String, String), " +
+	"`ResourceAttributes` Map(String, String) DEFAULT map(), `ServiceName` LowCardinality(String) DEFAULT '', " +
+	"`TimeUnix` DateTime64(9), " +
+	"`Count` UInt64, `Sum` Float64, `Scale` Int32, `ZeroCount` UInt64, " +
+	"`PositiveOffset` Int32, `PositiveBucketCounts` Array(UInt64), " +
+	"`NegativeOffset` Int32, `NegativeBucketCounts` Array(UInt64)" +
+	") ENGINE = MergeTree ORDER BY (`MetricName`, `Attributes`, `TimeUnix`);\n" +
+	"INSERT INTO otel_metrics_exponential_histogram " +
+	"(MetricName, Attributes, TimeUnix, Count, Sum, Scale, ZeroCount, PositiveOffset, PositiveBucketCounts, NegativeOffset, NegativeBucketCounts) VALUES\n" +
+	"    ('" + nestedBinopDropMetric + "', map('service', 'checkout'), toDateTime64('2026-01-01 00:00:00', 9), 5, 10.0, 0, 0, 0, [5], 0, []);\n"
+
+var nestedBinopDropEvalTS = time.Date(2026, 1, 1, 0, 0, 1, 0, time.UTC)
+
+// TestLower_ExpHistogram_DroppingShapeNestedInBinop_ChDB pins cerberus
+// issue #2534's own four trigger queries: a drop-family binop
+// (`<metric> + 0`) nested as the operand of a further scalar binop
+// ([lowerScalarBinopOperand]), a further vector-vector binop reached
+// through an aggregation wrapper ([lowerVectorVectorOperand]), and a
+// vector set op ([lowerVectorSetOpOperand]'s own drop-family opt-in).
+// Every one of these previously hard-rejected via
+// expHistogramSelectorRouting's catch-all before ever reaching SQL.
+func TestLower_ExpHistogram_DroppingShapeNestedInBinop_ChDB(t *testing.T) {
+	fixture := newChDBFixture(t, nestedBinopDropSeed)
+	s := schema.DefaultOTelMetrics()
+	p := parser.NewParser(parser.Options{EnableExperimentalFunctions: true})
+
+	queries := []string{
+		// lowerVectorScalar's operand opt-in (a scalar on the outer
+		// binop's RHS).
+		"(" + nestedBinopDropMetric + " + 0) * 2",
+		"(" + nestedBinopDropMetric + " + 0) + 5",
+		// lowerVectorScalar's operand opt-in again, this time over an
+		// AggregateExpr wrapping the drop-family leaf (composes
+		// [lowerExpHistogramDroppingShape]'s own aggregation recursion,
+		// cerberus issue #2528, one level deeper).
+		"sum(" + nestedBinopDropMetric + " + 0) + 1",
+		// lowerVectorSetOpOperand's drop-family opt-in.
+		"(" + nestedBinopDropMetric + " + 0) or (" + nestedBinopDropMetric + " + 0)",
+	}
+
+	for _, query := range queries {
+		query := query
+		t.Run(query, func(t *testing.T) {
+			expr, err := p.ParseExpr(query)
+			if err != nil {
+				t.Fatalf("ParseExpr(%q): %v", query, err)
+			}
+			plan, err := promql.LowerAt(context.Background(), expr, s, nestedBinopDropEvalTS, nestedBinopDropEvalTS)
+			if err != nil {
+				t.Fatalf("LowerAt(%q): unexpected error (this exact shape hard-rejected via expHistogramSelectorRouting's catch-all before cerberus issue #2534's fix): %v", query, err)
+			}
+			sqlStr, args, err := chsql.Emit(context.Background(), plan)
+			if err != nil {
+				t.Fatalf("Emit(%q): %v", query, err)
+			}
+
+			rows := fixture.queryOverEmitted(t, "count() AS n", sqlStr, args)
+			defer func() { _ = rows.Close() }()
+			if !rows.Next() {
+				t.Fatalf("count() query returned no rows")
+			}
+			var n int64
+			if err := rows.Scan(&n); err != nil {
+				t.Fatalf("scan count(): %v", err)
+			}
+			if err := testsql.TolerantRowsErr(rows.Err()); err != nil {
+				t.Fatalf("rows.Err: %v", err)
+			}
+			if n != 0 {
+				t.Fatalf(
+					"query %q returned count()=%d, want 0 — reference drops every sample through an incompatible-type histogram/scalar (or histogram/histogram) binop; the metric was seeded with a REAL non-empty row, so a non-zero count would mean the drop never actually fired at execution",
+					query, n,
+				)
+			}
+		})
+	}
+}

--- a/internal/promql/histogram_native_dropping_nested_binop_chdb_test.go
+++ b/internal/promql/histogram_native_dropping_nested_binop_chdb_test.go
@@ -12,12 +12,63 @@
 // (histogram_native_dropping_shape_test.go) already pins the SAME leaf
 // composed under a WRAPPER's own argument position (cerberus issue #2528)
 // at the Go-plan-shape level — this file is that fixture's chDB-executed,
-// binop-nested sibling, using the issue's own four trigger queries
-// verbatim.
+// binop-nested sibling.
 //
-// The metric is seeded with a REAL, non-empty row so a returned zero-row
-// result can only mean the drop actually fired — not that no data was
-// ever scanned.
+// Two metrics are seeded with REAL, non-empty rows — nestedBinopDropMetric
+// and nestedBinopDropMetric2 — so a returned zero-row result can only mean
+// a drop actually fired, never that no data was ever scanned. The second
+// series exists solely for the two-operand cases below, where a single
+// metric would let the query collapse to a self-join and hide a
+// mismatched-series bug.
+//
+// Per-query routing (verified by tracing lowerBinary's actual dispatch,
+// not assumed from the shape of the query — see the per-query comments in
+// TestLower_ExpHistogram_DroppingShapeNestedInBinop_ChDB below):
+//   - `(m1 + 0) * 2`, `(m1 + 0) + 5`, `sum(m1 + 0) + 1`: all three route
+//     through lowerVectorScalar → lowerScalarBinopOperand, because the
+//     scalar literal on one side is exactly what routes lowerBinary away
+//     from lowerVectorVector. None of these three reach
+//     lowerVectorVectorOperand — a prior version of this file's header
+//     incorrectly claimed the third one did.
+//   - `(m1 + 0) or (m1 + 0)`: a set operator, routes through
+//     lowerVectorSetOp → lowerVectorSetOpOperand, not lowerVectorVectorOperand
+//     either — set operators never reach lowerVectorVector at all
+//     (lowerBinary branches on b.Op.IsSetOperator() before ever computing
+//     which of lowerVectorScalar / lowerVectorVector applies).
+//   - `(m1 < m2) * (m1 < m2)`: the genuine vector-vector case, and the one
+//     this file's original four queries never actually reached. `m1 < m2`
+//     (no `bool`) is expHistogramDroppingHistogramBinop's own leaf shape
+//     (a comparison between two BARE histogram-valued selectors, an
+//     unsupported histogram/histogram combo reference drops) — nested as
+//     the operand of a further, real vector-vector `*`. Neither outer
+//     operand is a scalar literal, so lowerBinary falls to the default
+//     lowerVectorVector branch, and BOTH operands separately hit
+//     lowerVectorVectorOperand's drop-family match. This is deliberately
+//     NOT `(m1 + 0) * (m2 + 0)` (this file's own first draft): that shape,
+//     while it DOES route through lowerVectorVectorOperand, would still
+//     resolve correctly even with lowerVectorVectorOperand's drop-family
+//     check ripped out — `m1 + 0` recurses back into lowerBinary on its
+//     own via the generic [lower] fallback and gets caught a second time by
+//     the already-covered lowerScalarBinopOperand, silently laundering a
+//     hollow test. `m1 < m2` has no such redundant path: with
+//     lowerVectorVectorOperand's drop check removed, lowering this exact
+//     query regresses to a hard LowerAt error ("... is an exponential
+//     histogram metric; only a bare ... selector ... are supported") —
+//     verified directly against this worktree before writing this comment,
+//     not assumed.
+//   - `(m1 == m2) + 1`: exercises lowerScalarBinopOperand's OTHER half —
+//     the "preserve" family opt-in (lowerExpHistogramArgAsCanonicalFloat's
+//     first branch, lowerExpHistogramValuedShape) rather than the "drop"
+//     family. `m1 == m2` (no `bool`) is recognised by
+//     expHistogramHistogramCompareBinop as histogram-VALUED, but that
+//     recogniser is (deliberately) absent from isExpHistogramValuedShape's
+//     own predicate, so lowerRoot's top-level dispatch never claims the
+//     WHOLE `(m1 == m2) + 1` expression — it only escapes to
+//     lowerVectorScalar → lowerScalarBinopOperand(`m1 == m2`), which then
+//     matches via the preserve-family branch and reprojects to the
+//     canonical empty float quartet, exactly the way ADD over a real
+//     histogram sample must (reference drops the sample; there is no
+//     scalar Value to add 1 to).
 package promql_test
 
 import (
@@ -33,7 +84,10 @@ import (
 	"github.com/tsouza/cerberus/internal/testsql"
 )
 
-const nestedBinopDropMetric = "nested_binop_drop_probe_exp_hist"
+const (
+	nestedBinopDropMetric  = "nested_binop_drop_probe_exp_hist"
+	nestedBinopDropMetric2 = "nested_binop_drop_probe2_exp_hist"
+)
 
 var nestedBinopDropSeed = "" +
 	"CREATE OR REPLACE TABLE otel_metrics_exponential_histogram (" +
@@ -46,18 +100,20 @@ var nestedBinopDropSeed = "" +
 	") ENGINE = MergeTree ORDER BY (`MetricName`, `Attributes`, `TimeUnix`);\n" +
 	"INSERT INTO otel_metrics_exponential_histogram " +
 	"(MetricName, Attributes, TimeUnix, Count, Sum, Scale, ZeroCount, PositiveOffset, PositiveBucketCounts, NegativeOffset, NegativeBucketCounts) VALUES\n" +
-	"    ('" + nestedBinopDropMetric + "', map('service', 'checkout'), toDateTime64('2026-01-01 00:00:00', 9), 5, 10.0, 0, 0, 0, [5], 0, []);\n"
+	"    ('" + nestedBinopDropMetric + "', map('service', 'checkout'), toDateTime64('2026-01-01 00:00:00', 9), 5, 10.0, 0, 0, 0, [5], 0, []),\n" +
+	"    ('" + nestedBinopDropMetric2 + "', map('service', 'checkout'), toDateTime64('2026-01-01 00:00:00', 9), 7, 14.0, 0, 0, 0, [7], 0, []);\n"
 
 var nestedBinopDropEvalTS = time.Date(2026, 1, 1, 0, 0, 1, 0, time.UTC)
 
 // TestLower_ExpHistogram_DroppingShapeNestedInBinop_ChDB pins cerberus
-// issue #2534's own four trigger queries: a drop-family binop
-// (`<metric> + 0`) nested as the operand of a further scalar binop
-// ([lowerScalarBinopOperand]), a further vector-vector binop reached
-// through an aggregation wrapper ([lowerVectorVectorOperand]), and a
-// vector set op ([lowerVectorSetOpOperand]'s own drop-family opt-in).
-// Every one of these previously hard-rejected via
-// expHistogramSelectorRouting's catch-all before ever reaching SQL.
+// issue #2534's own four trigger queries plus two follow-on cases that
+// close a coverage gap an adversarial review found in this file's
+// original four: none of them actually reached lowerVectorVectorOperand
+// (the function this issue added specifically for a drop-family binop
+// nested as a genuine vector-vector op's operand), and the "preserve"
+// family half of lowerScalarBinopOperand's opt-in was likewise never
+// exercised nested. See the per-query routing notes in this file's own
+// header comment.
 func TestLower_ExpHistogram_DroppingShapeNestedInBinop_ChDB(t *testing.T) {
 	fixture := newChDBFixture(t, nestedBinopDropSeed)
 	s := schema.DefaultOTelMetrics()
@@ -65,16 +121,31 @@ func TestLower_ExpHistogram_DroppingShapeNestedInBinop_ChDB(t *testing.T) {
 
 	queries := []string{
 		// lowerVectorScalar's operand opt-in (a scalar on the outer
-		// binop's RHS).
+		// binop's RHS) — routes through lowerScalarBinopOperand's drop
+		// family.
 		"(" + nestedBinopDropMetric + " + 0) * 2",
 		"(" + nestedBinopDropMetric + " + 0) + 5",
 		// lowerVectorScalar's operand opt-in again, this time over an
 		// AggregateExpr wrapping the drop-family leaf (composes
 		// [lowerExpHistogramDroppingShape]'s own aggregation recursion,
-		// cerberus issue #2528, one level deeper).
+		// cerberus issue #2528, one level deeper) — still
+		// lowerScalarBinopOperand, not lowerVectorVectorOperand.
 		"sum(" + nestedBinopDropMetric + " + 0) + 1",
 		// lowerVectorSetOpOperand's drop-family opt-in.
 		"(" + nestedBinopDropMetric + " + 0) or (" + nestedBinopDropMetric + " + 0)",
+		// lowerVectorVectorOperand's drop-family opt-in — the genuine
+		// vector-vector case, previously untested. Two DISTINCT series so
+		// this can't accidentally pass via a self-join, and a comparison
+		// (not `+0`) so this can't accidentally pass via the redundant
+		// lowerScalarBinopOperand path — see this file's header comment.
+		"(" + nestedBinopDropMetric + " < " + nestedBinopDropMetric2 + ") * (" + nestedBinopDropMetric + " < " + nestedBinopDropMetric2 + ")",
+		// lowerScalarBinopOperand's PRESERVE-family opt-in, nested — the
+		// sibling gap to the drop-family cases above. `m1 == m2` (no
+		// `bool`) is histogram-valued but invisible to
+		// isExpHistogramValuedShape, so it only resolves via
+		// lowerExpHistogramArgAsCanonicalFloat's first branch, reached
+		// through lowerScalarBinopOperand.
+		"(" + nestedBinopDropMetric + " == " + nestedBinopDropMetric2 + ") + 1",
 	}
 
 	for _, query := range queries {
@@ -107,7 +178,7 @@ func TestLower_ExpHistogram_DroppingShapeNestedInBinop_ChDB(t *testing.T) {
 			}
 			if n != 0 {
 				t.Fatalf(
-					"query %q returned count()=%d, want 0 — reference drops every sample through an incompatible-type histogram/scalar (or histogram/histogram) binop; the metric was seeded with a REAL non-empty row, so a non-zero count would mean the drop never actually fired at execution",
+					"query %q returned count()=%d, want 0 — reference drops every sample through an incompatible-type histogram/scalar (or histogram/histogram) binop; the metric(s) were seeded with REAL non-empty rows, so a non-zero count would mean the drop never actually fired at execution",
 					query, n,
 				)
 			}

--- a/internal/promql/histogram_native_set_op.go
+++ b/internal/promql/histogram_native_set_op.go
@@ -182,6 +182,14 @@ func lowerExpHistogramSetOpOperand(expr parser.Expr, s schema.Metrics, ctx lower
 // [expHistogramSelectorRouting]'s catch-all rejection — the exact bug
 // #2325 reports.
 //
+// A drop-family operand — `(demo_latency_exp_hist + 0) or ...` (cerberus
+// issue #2534, the set-op sibling of the same gap
+// [lowerVectorVectorOperand] (binary.go) closes for arithmetic/comparison
+// V-V binops) — reprojects to the canonical empty float quartet via
+// [lowerExpHistogramDroppingShape], which already produces exactly the
+// Sample row shape a plain float operand would; no set-op-specific
+// wrapping is needed.
+//
 // Every other operand — including a FLOAT-valued function that merely
 // reads a histogram selector as its own argument, like
 // histogram_quantile(), or an operand with no histogram involvement at
@@ -191,6 +199,9 @@ func lowerExpHistogramSetOpOperand(expr parser.Expr, s schema.Metrics, ctx lower
 func lowerVectorSetOpOperand(expr parser.Expr, s schema.Metrics, ctx lowerCtx) (chplan.Node, error) {
 	if isExpHistogramValuedShape(expr, s, ctx) {
 		return lowerExpHistogramSetOpOperand(expr, s, ctx)
+	}
+	if dropped, ok, err := lowerExpHistogramDroppingShape(expr, s, ctx); ok {
+		return dropped, err
 	}
 	return lower(expr, s, ctx)
 }

--- a/test/rejection-parity/catalogue/internal__promql__lower.go.json
+++ b/test/rejection-parity/catalogue/internal__promql__lower.go.json
@@ -94,8 +94,8 @@
       "site": "internal/promql/lower.go:expHistogramSelectorRouting#bf746b59",
       "message": "promql: %q is an exponential histogram metric; only a bare %q selector, sum()/avg()/count() over one, rate()/increase()/delta()/irate()/idelta()/sum_over_time()/avg_over_time()/resets()/changes() over one, histogram_quantile(), histogram_count(), histogram_sum(), and the %q/%q companion selectors are supported",
       "class": "divergence",
-      "trigger_query": "(demo_latency_exp_hist + 0) * 2",
-      "tracking_issue": 2534,
+      "trigger_query": "histogram_quantile(0.5, demo_latency_exp_hist) * on(service) demo_latency_exp_hist",
+      "tracking_issue": 2537,
       "evidence": {
         "guard": [
           "past returning if bare, col, hasCompanion := s.HistogramCompanionColumn(metricName); hasCompanion \u0026\u0026 s.IsExpHistogramMetric(bare) \u0026\u0026 s.ExpHistogramTable != \"\"",
@@ -129,7 +129,7 @@
       "site": "internal/promql/lower.go:lower#d33d0084",
       "message": "promql: unsupported expression %T",
       "class": "internal",
-      "rationale": "Every expression shape reaching lower() through the HTTP handlers is dispatched (top-level matrix selectors included). The remaining inhabitants — NumberLiteral and StringLiteral, answered by the handler's constant fold / string shortcut before the engine runs, and StepInvariantExpr, which only parser.PreprocessExpr mints and cerberus never calls — cannot arrive here from the wire. The query entry points now reach this switch through lowerRoot, which peels off exactly one shape (a bare exp-histogram selector, answered by a histogram-valued lowering) and otherwise delegates unchanged, so it narrows the set of expressions that arrive rather than widening it. Re-verified across the in-package callers that re-enter lower() with a sub-expression, lowerHistogramQuantileClassicFloat included: each passes an operand of an already-parsed query whose position the upstream typechecker constrains to a vector, so no caller widens the set of shapes that reach the default arm. lowerExpHistogramDroppingVectorBinop (cerberus issue #2331) and lowerMixedExpHistogramOperands (cerberus issue #2330, split out of the former lowerMixedExpHistogramSetOp so histogram_native_mixed_or_aggregate.go's sum/avg-wrapped lowering — cerberus issue #2346 — can share the same operand lowering) re-enter lower() for one BinaryExpr operand of an already-parsed vector-vector query apiece, likewise typechecker-constrained to a vector, so neither widens the set either; the #2346 split adds lowerSumOrAvgOverMixedExpHistogramSetOp as a second CALLER of lowerMixedExpHistogramOperands, but not a new re-entry into lower() itself — the operand it forwards is unchanged. lowerVectorSetOpOperand (cerberus issue #2325) replaces binary.go's lowerVectorSetOp as the direct caller: lowerVectorSetOp no longer calls lower() itself, routing both its and/or/unless operands through this helper instead, which forwards to lower() only the operand it has itself confirmed is NOT exp-histogram-valued — the same already-parsed, typechecker-constrained-to-vector expr lowerVectorSetOp used to pass straight through — so it narrows rather than widens too. lowerExpHistogramFloatVectorScalingBinop (cerberus issue #2339) re-enters lower() only for the float-valued operand of an already-parsed MUL/DIV BinaryExpr, likewise typechecker-constrained to a vector, so it doesn't widen the set either. lowerScalarVectorArg (cerberus issue #2515) replaces lowerScalarArg's own direct lower() call for scalar()'s vector argument: it recognises a histogram-valued argument via lowerExpHistogramValuedShape first and answers via dropExpHistogramSamples, forwarding to lower() only when that check comes back unmatched — the same already-parsed, typechecker-constrained-to-vector scalar() argument lowerScalarArg used to pass straight through — so it narrows rather than widens too. lowerLimitKInput (cerberus issue #2518) replaces lowerLimitK's and lowerLimitRatio's own direct lower() calls for their vector argument: it recognises a histogram-valued argument via lowerExpHistogramValuedShape first and forwards the input unchanged, calling lower() only when that check comes back unmatched — the same already-parsed, typechecker-constrained-to-vector aggregate argument lowerLimitK/lowerLimitRatio used to pass straight through — so it narrows rather than widens too. lowerTopKComputed's own direct lower() call is unchanged for topk/bottomk (a purely histogram-valued input is intercepted upstream by droppingAggregationOverExpHistogram before ever reaching it); for limitk it now routes through lowerLimitKInput exactly as the literal-K path does.",
+      "rationale": "Every expression shape reaching lower() through the HTTP handlers is dispatched (top-level matrix selectors included). The remaining inhabitants — NumberLiteral and StringLiteral, answered by the handler's constant fold / string shortcut before the engine runs, and StepInvariantExpr, which only parser.PreprocessExpr mints and cerberus never calls — cannot arrive here from the wire. The query entry points now reach this switch through lowerRoot, which peels off exactly one shape (a bare exp-histogram selector, answered by a histogram-valued lowering) and otherwise delegates unchanged, so it narrows the set of expressions that arrive rather than widening it. Re-verified across the in-package callers that re-enter lower() with a sub-expression, lowerHistogramQuantileClassicFloat included: each passes an operand of an already-parsed query whose position the upstream typechecker constrains to a vector, so no caller widens the set of shapes that reach the default arm. lowerExpHistogramDroppingVectorBinop (cerberus issue #2331) and lowerMixedExpHistogramOperands (cerberus issue #2330, split out of the former lowerMixedExpHistogramSetOp so histogram_native_mixed_or_aggregate.go's sum/avg-wrapped lowering — cerberus issue #2346 — can share the same operand lowering) re-enter lower() for one BinaryExpr operand of an already-parsed vector-vector query apiece, likewise typechecker-constrained to a vector, so neither widens the set either; the #2346 split adds lowerSumOrAvgOverMixedExpHistogramSetOp as a second CALLER of lowerMixedExpHistogramOperands, but not a new re-entry into lower() itself — the operand it forwards is unchanged. lowerVectorSetOpOperand (cerberus issue #2325) replaces binary.go's lowerVectorSetOp as the direct caller: lowerVectorSetOp no longer calls lower() itself, routing both its and/or/unless operands through this helper instead, which forwards to lower() only the operand it has itself confirmed is NOT exp-histogram-valued — the same already-parsed, typechecker-constrained-to-vector expr lowerVectorSetOp used to pass straight through — so it narrows rather than widens too. lowerExpHistogramFloatVectorScalingBinop (cerberus issue #2339) re-enters lower() only for the float-valued operand of an already-parsed MUL/DIV BinaryExpr, likewise typechecker-constrained to a vector, so it doesn't widen the set either. lowerScalarVectorArg (cerberus issue #2515) replaces lowerScalarArg's own direct lower() call for scalar()'s vector argument: it recognises a histogram-valued argument via lowerExpHistogramValuedShape first and answers via dropExpHistogramSamples, forwarding to lower() only when that check comes back unmatched — the same already-parsed, typechecker-constrained-to-vector scalar() argument lowerScalarArg used to pass straight through — so it narrows rather than widens too. lowerLimitKInput (cerberus issue #2518) replaces lowerLimitK's and lowerLimitRatio's own direct lower() calls for their vector argument: it recognises a histogram-valued argument via lowerExpHistogramValuedShape first and forwards the input unchanged, calling lower() only when that check comes back unmatched — the same already-parsed, typechecker-constrained-to-vector aggregate argument lowerLimitK/lowerLimitRatio used to pass straight through — so it narrows rather than widens too. lowerTopKComputed's own direct lower() call is unchanged for topk/bottomk (a purely histogram-valued input is intercepted upstream by droppingAggregationOverExpHistogram before ever reaching it); for limitk it now routes through lowerLimitKInput exactly as the literal-K path does. lowerScalarBinopOperand and lowerVectorVectorOperand (cerberus issue #2534, binary.go) replace lowerVectorScalar's and lowerVectorVector's own direct lower() calls for their vector operand(s): lowerScalarBinopOperand recognises an exp-histogram preserve- or drop-family argument via lowerExpHistogramArgAsCanonicalFloat first, forwarding to lower() only when that check comes back unmatched, and lowerVectorVectorOperand recognises a drop-family argument via lowerExpHistogramDroppingShape first — deliberately not the preserve family, since a directly-valued vector-vector operand is always already claimed by one of lowerRoot's own matching-mode-aware dispatches before lowerVectorVector's generic fallback runs, see lowerVectorVectorOperand's own doc comment — forwarding to lower() only when that check comes back unmatched too. In both cases the argument lower() ultimately receives is the identical already-parsed, typechecker-constrained-to-vector operand lowerVectorScalar/lowerVectorVector used to pass straight through before this issue's fix, so neither widens the set either.",
       "evidence": {
         "guard": [
           "default of switch e := expr.(type) over [case *parser.VectorSelector; case *parser.Call; case *parser.AggregateExpr; case *parser.ParenExpr; case *parser.BinaryExpr; case *parser.SubqueryExpr; case *parser.MatrixSelector; case *parser.UnaryExpr; default]"
@@ -156,20 +156,22 @@
           "lowerMixedExpHistogramOperands",
           "lowerRoot",
           "lowerRoundToNearest",
+          "lowerScalarBinopOperand",
           "lowerScalarVectorArg",
           "lowerSort",
           "lowerSortByLabel",
           "lowerTopK",
           "lowerTopKComputed",
           "lowerUnary",
-          "lowerVectorScalar",
           "lowerVectorSetOpOperand",
-          "lowerVectorVector"
+          "lowerVectorVectorOperand"
         ],
         "cited": [
           "dropExpHistogramSamples",
           "droppingAggregationOverExpHistogram",
           "lower",
+          "lowerExpHistogramArgAsCanonicalFloat",
+          "lowerExpHistogramDroppingShape",
           "lowerExpHistogramDroppingVectorBinop",
           "lowerExpHistogramFloatVectorScalingBinop",
           "lowerExpHistogramValuedShape",
@@ -181,11 +183,15 @@
           "lowerMixedExpHistogramSetOp",
           "lowerRoot",
           "lowerScalarArg",
+          "lowerScalarBinopOperand",
           "lowerScalarVectorArg",
           "lowerSumOrAvgOverMixedExpHistogramSetOp",
           "lowerTopKComputed",
+          "lowerVectorScalar",
           "lowerVectorSetOp",
-          "lowerVectorSetOpOperand"
+          "lowerVectorSetOpOperand",
+          "lowerVectorVector",
+          "lowerVectorVectorOperand"
         ]
       }
     },


### PR DESCRIPTION
## Summary
- An adversarial review of #2538 found `internal/promql/histogram_native_dropping_nested_binop_chdb_test.go`'s original four cases all routed through `lowerScalarBinopOperand` / `lowerVectorSetOpOperand`, leaving `lowerVectorVectorOperand` — the function #2534 added specifically for a drop-family binop nested as a real vector-vector op's operand — completely untested, and the file's own header comment falsely claimed one of the four already covered it.
- Adds two non-redundant cases (verified by tracing `lowerBinary`'s actual dispatch, and by neutering each opt-in in turn and confirming lowering regresses to a hard rejection): a comparison-shaped drop-family leaf nested under a real vector-vector `*` reaches `lowerVectorVectorOperand`'s own match, and a histogram-histogram compare nested under a scalar `+` reaches `lowerScalarBinopOperand`'s preserve-family half.
- Fixes the header comment to describe each case's real routing.

## Test plan
- [ ] CI (unit + spec + chdb-tagged lanes)