### PR TITLE
fix(test/spec): let RunParity's comparator selection tolerate non-PromQL queries

### DIFF
--- a/test/spec/parity_chdb.go
+++ b/test/spec/parity_chdb.go
@@ -268,32 +268,38 @@ const exponentialHistogramMetricSuffix = "_exp_hist"
 // interpolation and histogram_quantile over a rate()/increase()'d classic
 // bucket selector are the only classes besides atan2 and pow with measured
 // cross-implementation divergence.
-func compareValues(query, seed string) (func(a, b float64) bool, error) {
+//
+// This selection runs for every head's RunParity call, not only PromQL's:
+// LogQL and TraceQL fixtures reach it too. A query that fails to parse as
+// PromQL is therefore not a comparator error — it is proof the query is not
+// PromQL, so none of the PromQL-specific tolerance shapes below can apply,
+// and the exact comparator is the correct answer.
+func compareValues(query, seed string) func(a, b float64) bool {
 	if atan2QueryPattern.MatchString(query) {
-		return oracle.EqualAtan2Values, nil
+		return oracle.EqualAtan2Values
 	}
 
 	p := parser.NewParser(parser.Options{EnableExperimentalFunctions: true})
 	expr, err := p.ParseExpr(query)
 	if err != nil {
-		return nil, fmt.Errorf("parse comparator query: %w", err)
+		return oracle.EqualValues
 	}
 	if usesPowOperator(expr) {
-		return oracle.EqualPowValues, nil
+		return oracle.EqualPowValues
 	}
 
 	hasExponential := strings.Contains(seed, "CREATE TABLE "+exponentialHistogramSeedTable)
 	hasClassic := strings.Contains(seed, "CREATE TABLE "+classicHistogramTable)
 	if !hasExponential && !hasClassic {
-		return oracle.EqualValues, nil
+		return oracle.EqualValues
 	}
 	if hasExponential && isExponentialHistogramInterpolation(expr) {
-		return oracle.EqualExponentialHistogramInterpolationValues, nil
+		return oracle.EqualExponentialHistogramInterpolationValues
 	}
 	if hasClassic && isClassicHistogramRateQuantile(expr) {
-		return oracle.EqualClassicHistogramRateQuantileValues, nil
+		return oracle.EqualClassicHistogramRateQuantileValues
 	}
-	return oracle.EqualValues, nil
+	return oracle.EqualValues
 }
 
 // usesPowOperator reports whether expr contains PromQL's `^` (pow) binary
@@ -943,10 +949,7 @@ func compareAgainstReference(
 		)
 	}
 
-	equalValues, err := compareValues(query, rt.Seed)
-	if err != nil {
-		t.Fatalf("fixture %s: %v", c.Name, err)
-	}
+	equalValues := compareValues(query, rt.Seed)
 
 	for i := range got {
 		g, w := got[i], want[i]

--- a/test/spec/parity_comparator_chdb_test.go
+++ b/test/spec/parity_comparator_chdb_test.go
@@ -51,16 +51,20 @@ func TestCompareValues(t *testing.T) {
 		{"pow rejects beyond tolerance", "up ^ 2", expHistogramSeed, base, fiveULPs, false},
 		{"pow inside a nested expression still gets ULP tolerance", "up ^ 2 + 1", expHistogramSeed, base, twoULPs, true},
 		{"regex anchor caret is not the pow operator", `up{job=~"^api$"}`, expHistogramSeed, base, oneULP, false},
+		// RunParity is shared across all three heads: a LogQL or TraceQL
+		// query is never valid PromQL syntax, so it must fall back to the
+		// exact comparator rather than erroring — a `bool`-modifier LogQL
+		// query used to hit the PromQL parser's own "bool modifier can only
+		// be used on comparison operators" and fail the whole comparison.
+		{"non-PromQL query (LogQL bool modifier) stays exact", `count_over_time({job="x"} | logfmt | code >= 500 [5m])`, expHistogramSeed, base, oneULP, false},
+		{"non-PromQL query (LogQL pipe stage) stays exact", `{job="x"} |= "error" | json`, expHistogramSeed, base, oneULP, false},
 	}
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			compare, err := compareValues(tc.query, tc.seed)
-			if err != nil {
-				t.Fatalf("compareValues: %v", err)
-			}
+			compare := compareValues(tc.query, tc.seed)
 			if got := compare(tc.a, tc.b); got != tc.want {
 				t.Fatalf("compareValues(%q)(%v, %v) = %v, want %v", tc.query, tc.a, tc.b, got, tc.want)
 			}


### PR DESCRIPTION
## Summary
- `compareValues` (`test/spec/parity_chdb.go`) unconditionally parses every fixture's query with the PromQL parser to detect a pow/atan2 float-tolerance case, but `RunParity` is shared across all three heads — LogQL and TraceQL fixtures reach it too.
- A LogQL query using `bool`, `|`, or a Loki-only function like `bytes_over_time` is not valid PromQL syntax, so the parser's real syntax error was propagated as a fatal comparator error instead of being treated as "not PromQL, none of these tolerance shapes apply."
- This is the root cause of `roundtrip (logql)` being red on every push to `main` since 2026-08-24T19:39 — see https://github.com/tsouza/cerberus/actions/runs/32841587924 — on 4 fixtures: `binop_vv_add_bool_ignored`, `range_agg_without_grouping_unwrap`, `sum_count_over_time_line_filter`, `variants_grouped`.
- A parse failure now falls back to the exact comparator, which is correct: a query that isn't PromQL cannot use PromQL's pow operator or `histogram_quantile` shapes, so no tolerance is ever warranted for it.
- Adds two regression cases to `TestCompareValues` covering the exact failure shapes (a bool-modifier LogQL query, a pipe-stage LogQL query).

## Test plan
- [x] `go test -tags chdb -run '^TestCompareValues$' ./test/spec/...` — all cases pass, including the two new non-PromQL regression cases
- [x] `go test -tags chdb,agpl_oracle,chdb_agpl_oracle -run '^TestLower$/^(binop_vv_add_bool_ignored|range_agg_without_grouping_unwrap|sum_count_over_time_line_filter|variants_grouped)$' ./internal/logql/...` — all 4 previously-failing fixtures now pass
- [x] `go test -tags chdb,agpl_oracle,chdb_agpl_oracle ./internal/logql/...` — full package green
- [ ] CI