### PR TITLE
test(chsql): close 32 mutation-coverage gaps + fix roundtrip CI timeout

### DIFF
--- a/.github/workflows/chdb.yml
+++ b/.github/workflows/chdb.yml
@@ -303,7 +303,14 @@ jobs:
     name: roundtrip (${{ matrix.ql }})
     needs: changes
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    # Bumped from 20: the promql leg's fixture corpus grew past 700 TXTAR
+    # files (the #2624 audit-fix batch alone added dozens of new
+    # histogram_native / mixed-or fixtures), and a real push-to-main run —
+    # where this release-gate lane does its actual chDB work instead of the
+    # docs-only/ordinary-PR no-op — now needs just over 20 minutes,
+    # observed timing out at ~20.5min on 2026-08-25. 35 gives real headroom
+    # for further corpus growth rather than chasing this again at 21min.
+    timeout-minutes: 35
     strategy:
       fail-fast: false
       matrix:

--- a/internal/chsql/aggregate_range_lwr_fusion_eligibility_test.go
+++ b/internal/chsql/aggregate_range_lwr_fusion_eligibility_test.go
@@ -272,3 +272,27 @@ func TestEmitAggregateRangeLWRFused_DeclinedShapeStillEmits(t *testing.T) {
 		t.Errorf("declined avg() shape did not render avg():\n%s", sql)
 	}
 }
+
+// TestGroupBySelectFrags_BucketKeyContinuesLoop kills the INVERT_LOOPCTRL
+// mutant at aggregate_range_lwr_fusion.go:259 (`continue` -> `break`) inside
+// groupBySelectFrags. rangeLWRFusionTestAggregate puts the anchor/bucket key
+// LAST in GroupBy, which makes a `break` mutant a no-op there (nothing
+// follows it to skip) — this reorders the bucket key to FIRST so a `break`
+// mutant stops the loop right after handling it, silently dropping every
+// GroupBy entry that follows (here, the label key) from the fused SELECT
+// list.
+func TestGroupBySelectFrags_BucketKeyContinuesLoop(t *testing.T) {
+	lwr := rangeLWRFusionTestLWR()
+	a := rangeLWRFusionTestAggregate(chplan.FnSum, lwr)
+	// Default order: [label, bucket]. Reorder to [bucket, label].
+	a.GroupBy = []chplan.Expr{a.GroupBy[1], a.GroupBy[0]}
+	a.GroupByAliases = []string{a.GroupByAliases[1], a.GroupByAliases[0]}
+
+	sql, _, err := Emit(context.Background(), a)
+	if err != nil {
+		t.Fatalf("emit: %v", err)
+	}
+	if !strings.Contains(sql, "AS `gkey_0`") {
+		t.Errorf("label group key (gkey_0) missing from fused SELECT list — loop stopped early after the bucket key?\n%s", sql)
+	}
+}

--- a/internal/chsql/aggregate_range_lwr_fusion_eligibility_test.go
+++ b/internal/chsql/aggregate_range_lwr_fusion_eligibility_test.go
@@ -178,6 +178,30 @@ func TestMatchRangeLWRFusion_Declines(t *testing.T) {
 				return a
 			},
 		},
+		{
+			// Combinators alone (Params still empty) must decline on its
+			// own — proves the `||` between the two checks, not just their
+			// conjunction: an `&&` mutant would let this shape through
+			// (Params empty makes the second half of the OR false), since
+			// only Combinators is non-empty here.
+			name: "AggFunc has a combinator, no params",
+			make: func() *chplan.Aggregate {
+				a := rangeLWRFusionTestAggregate(chplan.FnSum, rangeLWRFusionTestLWR())
+				a.AggFuncs[0].Combinators = []chplan.AggCombinator{chplan.CombIf}
+				return a
+			},
+		},
+		{
+			// Params alone (Combinators still empty) must decline on its
+			// own — the OR's other side, proven independently of the
+			// Combinators case above.
+			name: "AggFunc has a param, no combinators",
+			make: func() *chplan.Aggregate {
+				a := rangeLWRFusionTestAggregate(chplan.FnSum, rangeLWRFusionTestLWR())
+				a.AggFuncs[0].Params = []chplan.Expr{&chplan.LitInt{V: 1}}
+				return a
+			},
+		},
 	}
 
 	for _, tc := range cases {

--- a/internal/chsql/gremlins_kill_test.go
+++ b/internal/chsql/gremlins_kill_test.go
@@ -4158,3 +4158,183 @@ func TestAnchorGridCeilIdxFrag_ShiftsAddNSDownByOne(t *testing.T) {
 		t.Errorf("anchorGridCeilIdxFrag(dist, %d, step) unexpectedly matches the +1 shift (line 1812 flipped?): %s", addNS, got)
 	}
 }
+
+// --- range_window.go prefixAnchorIndexFrag arithmetic (1733:37) ---
+
+// TestPrefixAnchorIndexFrag_NegatesRangeNS kills both the INVERT_NEGATIVES
+// and ARITHMETIC_BASE mutants at range_window.go:1733:37 (the `-rangeNS`
+// unary expression passed as anchorGridFloorIdxFrag's addNS argument). A
+// mutant that drops or otherwise flips that sign feeds anchorGridFloorIdxFrag
+// a POSITIVE offset instead — its own `addNS > 0` branch then renders an
+// ADDITION (`dist + rangeNS`) instead of the correct SUBTRACTION
+// (`dist - rangeNS`), a different SQL shape whenever rangeNS != 0.
+func TestPrefixAnchorIndexFrag_NegatesRangeNS(t *testing.T) {
+	t.Parallel()
+	render := func(f Frag) string {
+		b := &Builder{}
+		f(b)
+		return b.String()
+	}
+
+	end := BareIdent("end_ts")
+	ts := BareIdent("ts")
+	const stepNS = int64(60_000_000_000)   // 1m
+	const rangeNS = int64(300_000_000_000) // 5m
+	const numAnchors = int64(11)
+
+	got := render(prefixAnchorIndexFrag(end, ts, stepNS, rangeNS, numAnchors))
+
+	// A mutant that removes (or otherwise flips) the negation on rangeNS
+	// collapses to the POSITIVE-offset floor index instead.
+	dist := distBehindAnchorFrag(ts, end)
+	positiveOffset := render(Call(
+		"least", InlineLit(numAnchors-1),
+		Call("greatest", InlineLit(int64(0)),
+			Sub(anchorGridFloorIdxFrag(dist, rangeNS, stepNS), InlineLit(int64(1)))),
+	))
+	if got == positiveOffset {
+		t.Errorf("prefixAnchorIndexFrag matches the POSITIVE-rangeNS form (line 1733 sign flipped?): %s", got)
+	}
+}
+
+// --- range_window.go instantDeltaPrefixSource guard + join dispatch (3562:11, 3574:23) ---
+
+// instantDeltaPrefixSourceStubWindow builds a syntactically valid (but
+// otherwise semantically opaque) *QueryBuilder standing in for the
+// caller-supplied "w" side of instantDeltaPrefixSource's join — the emitter
+// only ever splices it as an aliased subquery, never inspects its content at
+// emit time.
+func instantDeltaPrefixSourceStubWindow() *QueryBuilder {
+	return NewQuery().Select(Star()).From(verbatim("`otel_metrics_sum`"))
+}
+
+// TestInstantDeltaPrefixSource_GuardNilBranch kills the CONDITIONALS_NEGATION
+// mutant at range_window.go:3562:11 (`guard != nil` -> `== nil`). Production
+// never reaches instantDeltaPrefixSource with an empty TemporalityColumn
+// (emitWindowedArrayExtrapolated's needsDeltaFirstLevel gate requires
+// hasTemporality), so this calls it directly to force
+// deltaPresenceGuardFrag's nil branch (range_window.go:3498-3499) and
+// exercise the guard==nil path the mutant inverts. A `== nil` mutant would
+// instead call prefix.Where(nil) here, and that nil Frag panics the moment
+// it is invoked during Build() — a difference this test would catch as a
+// test failure (panic) even though it does not assert on the panic
+// directly.
+func TestInstantDeltaPrefixSource_GuardNilBranch(t *testing.T) {
+	t.Parallel()
+	e := &emitter{}
+	r := &chplan.RangeWindow{
+		Input:           &chplan.Scan{Table: "otel_metrics_sum"},
+		TimestampColumn: "TimeUnix",
+		ValueColumn:     "Value",
+		// Intentionally empty: forces deltaPresenceGuardFrag to return nil.
+		TemporalityColumn: "",
+		GroupBy:           []chplan.Expr{&chplan.ColumnRef{Name: "Attributes"}},
+	}
+	groupFrags, err := e.collectGroupByFrags(r.GroupBy)
+	if err != nil {
+		t.Fatalf("collectGroupByFrags: %v", err)
+	}
+	frag, err := e.instantDeltaPrefixSource(
+		r, instantDeltaPrefixSourceStubWindow(), groupFrags,
+		InlineLit(int64(0)), InlineLit(int64(0)), 0,
+	)
+	if err != nil {
+		t.Fatalf("instantDeltaPrefixSource: %v", err)
+	}
+	b := &Builder{}
+	frag(b)
+	if _, _, err := b.Build(); err != nil {
+		t.Fatalf("build: %v", err)
+	}
+}
+
+// TestInstantDeltaPrefixSource_JoinDispatch kills the CONDITIONALS_NEGATION
+// mutant at range_window.go:3574:23 (`len(groupColumns) == 0` -> `!= 0`). A
+// grouped call must LEFT JOIN the prefix scan back keyed on the group
+// columns; an ungrouped call must CROSS JOIN it (there is nothing to key
+// on). The mutant swaps which shape each case takes.
+func TestInstantDeltaPrefixSource_JoinDispatch(t *testing.T) {
+	t.Parallel()
+	build := func(groupBy []chplan.Expr) string {
+		e := &emitter{}
+		r := &chplan.RangeWindow{
+			Input:             &chplan.Scan{Table: "otel_metrics_sum"},
+			TimestampColumn:   "TimeUnix",
+			ValueColumn:       "Value",
+			TemporalityColumn: "AggregationTemporality",
+			GroupBy:           groupBy,
+		}
+		groupFrags, err := e.collectGroupByFrags(r.GroupBy)
+		if err != nil {
+			t.Fatalf("collectGroupByFrags: %v", err)
+		}
+		frag, err := e.instantDeltaPrefixSource(
+			r, instantDeltaPrefixSourceStubWindow(), groupFrags,
+			InlineLit(int64(0)), InlineLit(int64(0)), 0,
+		)
+		if err != nil {
+			t.Fatalf("instantDeltaPrefixSource: %v", err)
+		}
+		b := &Builder{}
+		frag(b)
+		sql, _, err := b.Build()
+		if err != nil {
+			t.Fatalf("build: %v", err)
+		}
+		return sql
+	}
+
+	t.Run("grouped -> LEFT JOIN", func(t *testing.T) {
+		t.Parallel()
+		sql := build([]chplan.Expr{&chplan.ColumnRef{Name: "Attributes"}})
+		if !strings.Contains(sql, "LEFT JOIN") {
+			t.Errorf("grouped call must LEFT JOIN; got:\n%s", sql)
+		}
+		if strings.Contains(sql, "CROSS JOIN") {
+			t.Errorf("grouped call must not CROSS JOIN; got:\n%s", sql)
+		}
+	})
+	t.Run("ungrouped -> CROSS JOIN", func(t *testing.T) {
+		t.Parallel()
+		sql := build(nil)
+		if !strings.Contains(sql, "CROSS JOIN") {
+			t.Errorf("ungrouped call must CROSS JOIN; got:\n%s", sql)
+		}
+		if strings.Contains(sql, "LEFT JOIN") {
+			t.Errorf("ungrouped call must not LEFT JOIN; got:\n%s", sql)
+		}
+	})
+}
+
+// --- range_window.go plainGroupColumnNames validation (5104:10, 5104:33) ---
+
+// TestPlainGroupColumnNames_EmptyNameRejected kills the INVERT_LOGICAL
+// mutant at range_window.go:5104:33 (the outer `||` between
+// `ref.Qualifier != ""` and `ref.Name == ""`). A bare ColumnRef with an
+// empty Name is otherwise well-formed (ok==true, Qualifier==""), so only
+// the third disjunct can catch it; an `&&` mutant there requires the first
+// two (already-false) disjuncts to ALSO hold, letting the empty name
+// through silently as a blank column identity.
+func TestPlainGroupColumnNames_EmptyNameRejected(t *testing.T) {
+	t.Parallel()
+	_, err := plainGroupColumnNames([]chplan.Expr{&chplan.ColumnRef{Name: ""}})
+	if !errors.Is(err, ErrUnsupported) {
+		t.Errorf("expected ErrUnsupported for an empty-Name ColumnRef, got %v", err)
+	}
+}
+
+// TestPlainGroupColumnNames_NonColumnRefNoPanic kills the INVERT_LOGICAL
+// mutant at range_window.go:5104:10 (the inner `||` between `!ok` and
+// `ref.Qualifier != ""`). When the group key is not a *chplan.ColumnRef at
+// all, `ref` is a nil *chplan.ColumnRef and only short-circuit evaluation
+// (the original `||`) keeps `ref.Qualifier` from ever being dereferenced.
+// An `&&` mutant forces evaluation of the second operand whenever `!ok` is
+// true, dereferencing the nil pointer and panicking instead of returning
+// the documented ErrUnsupported.
+func TestPlainGroupColumnNames_NonColumnRefNoPanic(t *testing.T) {
+	t.Parallel()
+	_, err := plainGroupColumnNames([]chplan.Expr{&chplan.LitInt{V: 1}})
+	if !errors.Is(err, ErrUnsupported) {
+		t.Errorf("expected ErrUnsupported for a non-ColumnRef group key, got %v", err)
+	}
+}

--- a/internal/chsql/histogram_quantile_test.go
+++ b/internal/chsql/histogram_quantile_test.go
@@ -1,6 +1,8 @@
 package chsql
 
 import (
+	"context"
+	"errors"
 	"strings"
 	"testing"
 
@@ -84,4 +86,75 @@ func TestHistogramQuantileValueFrag_PhiExprGating(t *testing.T) {
 			t.Errorf("computed phi must lead with the isNaN(phi) guard (line 266 flipped?):\n%s", sql)
 		}
 	})
+}
+
+// TestEmitHistogramQuantile_RequiredColumns kills the INVERT_LOGICAL mutant
+// at histogram_quantile.go:92:32 (`h.BucketCountsColumn == "" ||
+// h.ExplicitBoundsColumn == ""` -> `&&`). Each column empty ALONE must
+// still error; an `&&` mutant would require BOTH to be empty
+// simultaneously, letting a plan missing just one of the two through.
+func TestEmitHistogramQuantile_RequiredColumns(t *testing.T) {
+	t.Parallel()
+	base := func() *chplan.HistogramQuantile {
+		return &chplan.HistogramQuantile{
+			Input:                &chplan.Scan{Table: "otel_metrics_histogram"},
+			Phi:                  0.5,
+			BucketCountsColumn:   "BucketCounts",
+			ExplicitBoundsColumn: "ExplicitBounds",
+		}
+	}
+	cases := []struct {
+		name   string
+		mutate func(*chplan.HistogramQuantile)
+	}{
+		{"BucketCountsColumn empty", func(h *chplan.HistogramQuantile) { h.BucketCountsColumn = "" }},
+		{"ExplicitBoundsColumn empty", func(h *chplan.HistogramQuantile) { h.ExplicitBoundsColumn = "" }},
+	}
+	for _, c := range cases {
+		c := c
+		t.Run(c.name, func(t *testing.T) {
+			t.Parallel()
+			h := base()
+			c.mutate(h)
+			_, _, err := Emit(context.Background(), h)
+			if !errors.Is(err, ErrUnsupported) {
+				t.Errorf("expected ErrUnsupported, got %v", err)
+			}
+		})
+	}
+}
+
+// TestEmitHistogramQuantile_GroupByAliasFallback kills both the
+// CONDITIONALS_BOUNDARY (`<` -> `<=`) and CONDITIONALS_NEGATION (`<` ->
+// `>=`) mutants at histogram_quantile.go:152:8 (`i <
+// len(h.GroupByAliases)`). Placing the alias slice ONE ENTRY SHORT of
+// GroupBy hits the exact boundary index (i == len(h.GroupByAliases)):
+// under either mutant that index tries h.GroupByAliases[i], which is out
+// of range and panics; under the original code it falls back to an
+// unaliased projection.
+func TestEmitHistogramQuantile_GroupByAliasFallback(t *testing.T) {
+	t.Parallel()
+	h := &chplan.HistogramQuantile{
+		Input:                &chplan.Scan{Table: "otel_metrics_histogram"},
+		Phi:                  0.5,
+		BucketCountsColumn:   "BucketCounts",
+		ExplicitBoundsColumn: "ExplicitBounds",
+		GroupBy: []chplan.Expr{
+			&chplan.ColumnRef{Name: "ServiceName"},
+			&chplan.ColumnRef{Name: "SpanName"},
+		},
+		// One alias only — the second group key must render unaliased
+		// without panicking.
+		GroupByAliases: []string{"service"},
+	}
+	sql, _, err := Emit(context.Background(), h)
+	if err != nil {
+		t.Fatalf("Emit: %v", err)
+	}
+	if !strings.Contains(sql, "`ServiceName` AS `service`") {
+		t.Errorf("expected `ServiceName AS service`, SQL=%s", sql)
+	}
+	if !strings.Contains(sql, "`SpanName`") {
+		t.Errorf("expected bare `SpanName` group key, SQL=%s", sql)
+	}
 }

--- a/internal/chsql/range_lwr_test.go
+++ b/internal/chsql/range_lwr_test.go
@@ -105,3 +105,41 @@ func TestEmitRangeLWR_RejectsZeroStep(t *testing.T) {
 		t.Errorf("RangeLWR with Step=0 should error")
 	}
 }
+
+// TestEmitRangeLWR_FanoutLimitIsMaxRowsPlusOne kills the two ARITHMETIC_BASE
+// mutants at lwr_fanout_bound.go:213:24 and :224:22 (`maxRows + 1`, in
+// lwrFanoutBoundedSourceFrag's bounded-read LIMIT and its independent
+// truncation-probe LIMIT). The "+1" is the whole truncation-detection
+// mechanism: a returned probe count landing exactly on maxRows+1 can only
+// happen if the true fanned-out row count reached or exceeded that LIMIT. A
+// `+`->`-` flip renders `maxRows - 1` instead, a directly observable
+// literal change in the emitted SQL (maxRangeLWRFanoutRows = 40_000_000, so
+// the correct literal is 40000001, not 39999999).
+func TestEmitRangeLWR_FanoutLimitIsMaxRowsPlusOne(t *testing.T) {
+	t.Parallel()
+	start := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	plan := &chplan.RangeLWR{
+		Input:         &chplan.Scan{Table: "otel_metrics_gauge"},
+		Start:         start,
+		End:           start.Add(5 * time.Minute),
+		Step:          30 * time.Second,
+		Lookback:      5 * time.Minute,
+		MetricNameCol: "MetricName",
+		AttributesCol: "Attributes",
+		TimestampCol:  "TimeUnix",
+		ValueCol:      "Value",
+	}
+	sql, _, err := chsql.Emit(context.Background(), plan)
+	if err != nil {
+		t.Fatalf("Emit: %v", err)
+	}
+	const wantLimit = "LIMIT 40000001"
+	if got := strings.Count(sql, wantLimit); got != 2 {
+		t.Errorf("expected %q exactly twice (bounded read + truncation probe), got %d occurrences; SQL:\n%s", wantLimit, got, sql)
+	}
+	for _, bad := range []string{"LIMIT 39999999", "LIMIT 40000000"} {
+		if strings.Contains(sql, bad) {
+			t.Errorf("unexpected %q in SQL (maxRows+1 arithmetic flipped?):\n%s", bad, sql)
+		}
+	}
+}

--- a/internal/chsql/range_window_matrix_delta_prefix_guard_test.go
+++ b/internal/chsql/range_window_matrix_delta_prefix_guard_test.go
@@ -1,0 +1,295 @@
+package chsql
+
+import (
+	"context"
+	"regexp"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/tsouza/cerberus/internal/chplan"
+)
+
+// This file pins the DELTA-prefix aggregate MATRIX path's two presence
+// guards and their shared earliestAnchor arithmetic
+// (deltaMatrixLevelSourceAggregateDailyFanout, applyMatrixFanoutScanBound
+// Aggregate, matrixWindowScanBoundsFrags) at the emitted-SQL-TEXT level, no
+// chDB required. This complements — rather than duplicates — the
+// chdb-tagged behavioural coverage in
+// range_window_delta_prefix_aggregate_matrix_chdb_test.go: `just
+// mutate-pkg` runs `gremlins unleash` WITHOUT the `chdb` build tag (see
+// Justfile's `mutate-pkg` recipe and `mutate-chdb`'s own doc comment), so
+// every //go:build chdb test file is invisible to the standard mutation
+// gate and cannot kill a single mutant there, however good its assertions.
+// These tests exist specifically to be visible to that untagged run.
+//
+// matrixDeltaGuardTestWindow builds the same shape
+// range_window_delta_prefix_aggregate_matrix_chdb_test.go's
+// deltaPrefixCanonicalizedMatrixWindow does (a `rate()` RangeWindow with
+// DeltaPrefixAggregateInput set, hitting deltaMatrixLevelSourceAggregate),
+// with a 3-anchor grid (step 10s, outer range 20s) chosen so
+// (numAnchors-1)*stepNS = 20_000_000_000 and stepNS = 10_000_000_000 are
+// two distinct, easily-recognised nanosecond literals — an ARITHMETIC_BASE
+// flip of either the `-` or the `*` in
+// `(numAnchors-1)*stepNS` changes this value to something else entirely
+// (40e9 or 0), so asserting the exact literal is a direct kill.
+func matrixDeltaGuardTestWindow() (*chplan.RangeWindow, time.Time) {
+	end := time.Date(2026, 1, 15, 12, 0, 0, 0, time.UTC)
+	step := 10 * time.Second
+	start := end.Add(-2 * step)
+	r := &chplan.RangeWindow{
+		Input: matrixDeltaGuardShapedInput(
+			&chplan.Scan{Table: "otel_metrics_sum"},
+			chplan.Projection{Expr: &chplan.ColumnRef{Name: "TimeUnix"}, Alias: "TimeUnix"},
+			chplan.Projection{Expr: &chplan.ColumnRef{Name: "Value"}, Alias: "Value"},
+			chplan.Projection{Expr: &chplan.ColumnRef{Name: "AggregationTemporality"}, Alias: "AggregationTemporality"},
+		),
+		Func:              "rate",
+		Range:             time.Minute,
+		End:               end,
+		Start:             start,
+		Step:              step,
+		OuterRange:        end.Sub(start),
+		TimestampColumn:   "TimeUnix",
+		ValueColumn:       "Value",
+		TemporalityColumn: "AggregationTemporality",
+		GroupBy:           []chplan.Expr{&chplan.ColumnRef{Name: "Attributes"}},
+		DeltaPrefixAggregateInput: matrixDeltaGuardShapedInput(
+			&chplan.Scan{Table: "otel_metrics_sum_delta_prefix"},
+			chplan.Projection{Expr: &chplan.ColumnRef{Name: "BucketStart"}, Alias: "BucketStart"},
+			chplan.Projection{Expr: &chplan.ColumnRef{Name: "PartialSum"}, Alias: "PartialSum"},
+		),
+	}
+	return r, end
+}
+
+func matrixDeltaGuardShapedInput(scan *chplan.Scan, extra ...chplan.Projection) *chplan.Project {
+	projections := append([]chplan.Projection{
+		{Expr: chplan.CanonicalAttributesExpr(&chplan.ColumnRef{Name: "Attributes"}), Alias: "Attributes"},
+	}, extra...)
+	return &chplan.Project{Input: scan, Projections: projections}
+}
+
+func matrixDeltaGuardEmit(t *testing.T, r *chplan.RangeWindow) string {
+	t.Helper()
+	ctx := WithDeltaPrefixReadEnabled(context.Background(), true)
+	sqlText, _, err := Emit(ctx, r)
+	if err != nil {
+		t.Fatalf("Emit: %v", err)
+	}
+	return sqlText
+}
+
+// TestDeltaMatrixAggregateDailyFanout_GuardAppliedToAggregateTableScan kills
+// range_window.go:4067:11 (CONDITIONALS_NEGATION on `guard != nil` inside
+// deltaMatrixLevelSourceAggregateDailyFanout): for this window,
+// r.TemporalityColumn is always set, so deltaPresenceGuardFrag always
+// returns a non-nil guard — flipping the check to `guard == nil` means
+// aggDaily.Where(guard) is never called, silently dropping the guard from
+// the aggregate-table (otel_metrics_sum_delta_prefix) day-bucket scan. That
+// scan's own WHERE clause is bounded by `BucketStart` < ... on one side and
+// `GROUP BY \`Attributes\`, \`BucketStart\“ on the other — the guard
+// subquery must render somewhere inside that span.
+func TestDeltaMatrixAggregateDailyFanout_GuardAppliedToAggregateTableScan(t *testing.T) {
+	r, _ := matrixDeltaGuardTestWindow()
+	sqlText := matrixDeltaGuardEmit(t, r)
+
+	const startMarker = "`BucketStart` <"
+	const endMarker = "GROUP BY `Attributes`, `BucketStart`"
+	start := strings.Index(sqlText, startMarker)
+	if start == -1 {
+		t.Fatalf("aggregate-table day-bucket scan's own filter (%q) not found:\n%s", startMarker, sqlText)
+	}
+	end := strings.Index(sqlText[start:], endMarker)
+	if end == -1 {
+		t.Fatalf("aggregate-table day-bucket scan's own GROUP BY (%q) not found after its filter:\n%s", endMarker, sqlText)
+	}
+	segment := sqlText[start : start+end]
+	if !strings.Contains(segment, "SELECT max(") {
+		t.Errorf("aggregate-table day-bucket scan is missing its DELTA-presence guard "+
+			"(no \"SELECT max(\" between %q and %q) — deltaMatrixLevelSourceAggregateDailyFanout's "+
+			"`if guard != nil` gate is not adding it:\n%s", startMarker, endMarker, segment)
+	}
+}
+
+// TestApplyMatrixFanoutScanBoundAggregate_OrGuardAppliedToFanout kills BOTH
+// range_window.go:4324:9 (CONDITIONALS_NEGATION on `err != nil` — flipping it
+// to `err == nil` makes the error-free case return early, before the guard
+// clause is ever appended) and range_window.go:4327:11 (CONDITIONALS_NEGATION
+// on `guard != nil` — flipping it to `guard == nil` skips the same append,
+// since guard is always non-nil here). Either mutation removes the
+// `OR \`AggregationTemporality\` != 1` disjunct this PR's HIGH-severity fix
+// added to the raw sample fanout's own scan bound — see
+// applyMatrixFanoutScanBoundAggregate's doc for why ANDing the guard directly
+// onto the fanout (instead of OR'ing it against "this row isn't DELTA") used
+// to empty the whole matrix for an all-CUMULATIVE counter.
+func TestApplyMatrixFanoutScanBoundAggregate_OrGuardAppliedToFanout(t *testing.T) {
+	r, _ := matrixDeltaGuardTestWindow()
+	sqlText := matrixDeltaGuardEmit(t, r)
+
+	const orGuardMarker = "OR `AggregationTemporality` != 1))"
+	if !strings.Contains(sqlText, orGuardMarker) {
+		t.Errorf("raw sample fanout is missing its OR-guard disjunct (%q not found) — either "+
+			"applyMatrixFanoutScanBoundAggregate's `err != nil` early-return or its `guard != nil` "+
+			"gate is discarding the clause before it reaches fanout.Where:\n%s", orGuardMarker, sqlText)
+	}
+}
+
+// intervalNanosecondsAfter extracts the first n toIntervalNanosecond(...)
+// integer literals rendered in sqlText starting at the first occurrence of
+// marker, in source order. Used to pin arithmetic on Frags built from
+// InlineLit(int64) — the rendered literal IS the value, so an
+// ARITHMETIC_BASE / INVERT_NEGATIVES mutation that changes the computed
+// value changes what's asserted here directly.
+func intervalNanosecondsAfter(t *testing.T, sqlText, marker string, n int) []int64 {
+	t.Helper()
+	idx := strings.Index(sqlText, marker)
+	if idx == -1 {
+		t.Fatalf("marker %q not found in:\n%s", marker, sqlText)
+	}
+	const scanWindow = 300
+	end := idx + scanWindow
+	if end > len(sqlText) {
+		end = len(sqlText)
+	}
+	segment := sqlText[idx:end]
+	re := regexp.MustCompile(`toIntervalNanosecond\((\d+)\)`)
+	matches := re.FindAllStringSubmatch(segment, n)
+	if len(matches) < n {
+		t.Fatalf("expected %d toIntervalNanosecond(...) literals after marker %q, found %d in segment:\n%s",
+			n, marker, len(matches), segment)
+	}
+	out := make([]int64, n)
+	for i := 0; i < n; i++ {
+		v, err := strconv.ParseInt(matches[i][1], 10, 64)
+		if err != nil {
+			t.Fatalf("parse %q: %v", matches[i][1], err)
+		}
+		out[i] = v
+	}
+	return out
+}
+
+// TestMatrixWindowScanBoundsFrags_EarliestAnchorArithmetic kills
+// range_window.go:4239:79 (ARITHMETIC_BASE and INVERT_NEGATIVES on the `-`
+// in `numAnchors-1`) and 4239:82 (ARITHMETIC_BASE on the `*` in
+// `(numAnchors-1)*stepNS`). matrixWindowScanBoundsFrags computes
+// earliestAnchor = end - (numAnchors-1)*stepNS, consumed as the guard
+// subquery's own windowLo probe (`\`TimeUnix\` > <end literal> -
+// toIntervalNanosecond((numAnchors-1)*stepNS) - toIntervalNanosecond
+// (rangeNS) AND \`TimeUnix\` <= <end literal>` — anchored on
+// "`TimeUnix` > toDateTime64(" specifically (not just "`TimeUnix` > "),
+// since the regroup stage's own window_pairs construction ALSO uses a
+// strict `TimeUnix` > comparison, but against `anchor_ts`, not the end
+// literal, and renders earlier in the text). With numAnchors=3, stepNS=10s:
+// the correct value is (3-1)*10_000_000_000 = 20_000_000_000, distinct
+// from every mutated outcome (40_000_000_000 for either `-`->`+` or the
+// negation-of-1 shape, 0 for `*`->`/` since 2/10_000_000_000 truncates to
+// 0).
+func TestMatrixWindowScanBoundsFrags_EarliestAnchorArithmetic(t *testing.T) {
+	r, _ := matrixDeltaGuardTestWindow()
+	sqlText := matrixDeltaGuardEmit(t, r)
+
+	const windowLoMarker = "`TimeUnix` > toDateTime64("
+	const wantEarliestAnchorTerm = 20_000_000_000 // (numAnchors-1)*stepNS = (3-1)*10s
+	const wantRangeTerm = 60_000_000_000          // rangeNS = 1 minute
+
+	got := intervalNanosecondsAfter(t, sqlText, windowLoMarker, 2)
+	if got[0] != wantEarliestAnchorTerm {
+		t.Errorf("guard windowLo's first toIntervalNanosecond(...) = %d, want %d "+
+			"((numAnchors-1)*stepNS with numAnchors=3, stepNS=10s) — matrixWindowScanBoundsFrags' "+
+			"earliestAnchor arithmetic is wrong:\n%s", got[0], wantEarliestAnchorTerm, sqlText)
+	}
+	if got[1] != wantRangeTerm {
+		t.Errorf("guard windowLo's second toIntervalNanosecond(...) = %d, want %d (rangeNS = 1 minute):\n%s",
+			got[1], wantRangeTerm, sqlText)
+	}
+}
+
+// TestApplyMatrixFanoutScanBoundAggregate_EarliestDayArithmetic kills
+// range_window.go:4316:79 (ARITHMETIC_BASE and INVERT_NEGATIVES on the `-`
+// in `numAnchors-1`) and 4316:82 (ARITHMETIC_BASE on the `*`) —
+// applyMatrixFanoutScanBoundAggregate's OWN local earliestAnchor
+// (identical source shape to matrixWindowScanBoundsFrags', but a distinct
+// call site / distinct mutant), which derives the raw fanout's own
+// `\`TimeUnix\` >= toStartOfDay(...)` day-granularity scan bound —
+// textually distinguishable from the guard's own windowLo probe (that one
+// reads `> ... AND <=`; this one reads `>= toStartOfDay(...)`, the ONLY
+// such shape in the emitted matrix query).
+func TestApplyMatrixFanoutScanBoundAggregate_EarliestDayArithmetic(t *testing.T) {
+	r, _ := matrixDeltaGuardTestWindow()
+	sqlText := matrixDeltaGuardEmit(t, r)
+
+	const earliestDayMarker = "`TimeUnix` >= toStartOfDay("
+	const wantEarliestAnchorTerm = 20_000_000_000 // (numAnchors-1)*stepNS = (3-1)*10s
+	const wantRangeTerm = 60_000_000_000          // rangeNS = 1 minute
+
+	got := intervalNanosecondsAfter(t, sqlText, earliestDayMarker, 2)
+	if got[0] != wantEarliestAnchorTerm {
+		t.Errorf("fanout's earliestDay first toIntervalNanosecond(...) = %d, want %d "+
+			"((numAnchors-1)*stepNS with numAnchors=3, stepNS=10s) — applyMatrixFanoutScanBoundAggregate's "+
+			"own earliestAnchor arithmetic is wrong:\n%s", got[0], wantEarliestAnchorTerm, sqlText)
+	}
+	if got[1] != wantRangeTerm {
+		t.Errorf("fanout's earliestDay second toIntervalNanosecond(...) = %d, want %d (rangeNS = 1 minute):\n%s",
+			got[1], wantRangeTerm, sqlText)
+	}
+}
+
+// The four tests below are white-box unit tests directly against
+// deltaMatrixLevelSourceAggregateDailyFanout / deltaMatrixLevelSourceAggregate,
+// bypassing PromQL lowering entirely: a real query's RangeWindow.GroupBy is
+// always `[ColumnRef(AttributesColumn)]` (see chplan.RangeWindow.GroupBy's
+// own doc and internal/promql/lower.go's rangeFn lowering), so groupFrags
+// is never actually empty on the production path — the
+// `make([]Frag, 0, len(groupFrags)+1)` / `len(groupColumns)+1` capacity
+// hints at 4070/4100/4133/4180 are therefore unobservable through any
+// emitted-SQL assertion: a wrong non-negative capacity produces the exact
+// same final slice contents (append reallocates transparently), so the
+// mutation is behaviourally equivalent for every real query shape. It is
+// only observable when the capacity computation goes NEGATIVE — Go's
+// runtime panics on `make([]T, 0, -1)` — which requires an empty base
+// slice these functions never see end-to-end. Calling them directly with
+// groupFrags=nil (equivalently r.GroupBy=nil for groupColumns) is the only
+// way to exercise — and kill — those four ARITHMETIC_BASE mutants.
+func TestDeltaMatrixLevelSourceAggregateDailyFanout_EmptyGroupFragsDoesNotPanic(t *testing.T) {
+	e := &emitter{}
+	r := &chplan.RangeWindow{
+		DeltaPrefixAggregateInput: &chplan.Scan{Table: "agg_table"},
+	}
+	end := Col("end_ts")
+	// numAnchors=3, stepNS/rangeNS arbitrary but nonzero — only groupFrags'
+	// emptiness matters for the capacity hints under test (4070, 4100).
+	qb, keys, err := e.deltaMatrixLevelSourceAggregateDailyFanout(r, nil, end, 10_000_000_000, 60_000_000_000, 3)
+	if err != nil {
+		t.Fatalf("deltaMatrixLevelSourceAggregateDailyFanout with empty groupFrags: %v", err)
+	}
+	if qb == nil {
+		t.Fatal("deltaMatrixLevelSourceAggregateDailyFanout returned a nil QueryBuilder")
+	}
+	if len(keys) != 0 {
+		t.Fatalf("aggDailyKeys = %v, want empty for empty groupFrags", keys)
+	}
+}
+
+func TestDeltaMatrixLevelSourceAggregate_EmptyGroupFragsDoesNotPanic(t *testing.T) {
+	e := &emitter{}
+	r := &chplan.RangeWindow{
+		DeltaPrefixAggregateInput: &chplan.Scan{Table: "agg_table"},
+		// GroupBy left nil: plainGroupColumnNames(nil) returns an empty,
+		// non-error column slice, matching the empty groupFrags param below.
+	}
+	end := Col("end_ts")
+	regroupSource := verbatim("regroup_src")
+	// numAnchors=3, stepNS/rangeNS arbitrary but nonzero — only
+	// groupFrags'/groupColumns' emptiness matters for the capacity hints
+	// under test (4133, 4180).
+	frag, err := e.deltaMatrixLevelSourceAggregate(r, regroupSource, nil, end, 10_000_000_000, 60_000_000_000, 3)
+	if err != nil {
+		t.Fatalf("deltaMatrixLevelSourceAggregate with empty groupFrags/GroupBy: %v", err)
+	}
+	if frag == nil {
+		t.Fatal("deltaMatrixLevelSourceAggregate returned a nil Frag")
+	}
+}

--- a/internal/chsql/range_window_variants_test.go
+++ b/internal/chsql/range_window_variants_test.go
@@ -346,6 +346,73 @@ func TestEmitFusedVariantsMatrix_AnchorCountArithmetic(t *testing.T) {
 	}
 }
 
+// TestGroupArrayVariantTupleFrag_EmptyValCols kills the ARITHMETIC_BASE
+// mutant at range_window_variants.go:129:39 (`len(valCols)+1`, the capacity
+// hint for the tuple-parts slice). With valCols empty, len(valCols)+1 == 1,
+// a harmless capacity; a `+`->`-` flip instead computes -1, which panics
+// make() immediately. Production never calls this with an empty valCols
+// (checkFusedVariants requires every arm to name a ValueColumn), so this
+// calls the helper directly to force the boundary.
+func TestGroupArrayVariantTupleFrag_EmptyValCols(t *testing.T) {
+	t.Parallel()
+	got := groupArrayVariantTupleFrag("Timestamp", nil)
+	b := &Builder{}
+	got(b)
+	sql, _, err := b.Build()
+	if err != nil {
+		t.Fatalf("build: %v", err)
+	}
+	if !strings.Contains(sql, "arraySort(groupArray(") {
+		t.Errorf("unexpected SQL: %s", sql)
+	}
+}
+
+// TestEmitFusedVariantsInstant_CompletesAllSteps kills the four
+// CONDITIONALS_NEGATION mutants at range_window_variants.go:232:9, 236:9,
+// 249:9 and 256:66 — the four `if err != nil { return err }` guards inside
+// emitRangeWindowVariantsInstant. Every one of those checks genuinely
+// succeeds on this well-formed plan, so a `!= nil` -> `== nil` mutant at any
+// one of them turns "keep going on success" into "return nil immediately
+// after this step succeeds" — the function would return before ever
+// reaching arrayJoinVariants (the ARRAY JOIN unpivot near the end), so its
+// absence from the SQL is the shared tripwire for all four sites.
+func TestEmitFusedVariantsInstant_CompletesAllSteps(t *testing.T) {
+	t.Parallel()
+	r := fusedTestWindow()
+	r.OuterRange = 0 // instant path
+	sql, _, err := Emit(context.Background(), r)
+	if err != nil {
+		t.Fatalf("Emit: %v", err)
+	}
+	if !strings.Contains(sql, "ARRAY JOIN") {
+		t.Errorf("instant fused variants SQL missing ARRAY JOIN unpivot — an early return before completion?\nSQL: %s", sql)
+	}
+	for _, v := range r.Variants {
+		if !strings.Contains(sql, v.ValueColumn) {
+			t.Errorf("missing arm value column %q — Emit returned early?\nSQL: %s", v.ValueColumn, sql)
+		}
+	}
+}
+
+// TestEmitFusedVariantsMatrix_UngroupedRegroupKeysCapacity kills the
+// ARITHMETIC_BASE mutant at range_window_variants.go:333:48
+// (`len(groupFrags)+1`, the capacity hint for regroupKeys). An ungrouped
+// fused matrix window has zero groupFrags, so len(groupFrags)+1 == 1 (the
+// anchor_ts key alone); a `+`->`-` flip computes -1, panicking make()
+// before the query can even be assembled.
+func TestEmitFusedVariantsMatrix_UngroupedRegroupKeysCapacity(t *testing.T) {
+	t.Parallel()
+	r := fusedTestWindow()
+	r.GroupBy = nil // OuterRange > 0 stays (matrix path)
+	sql, _, err := Emit(context.Background(), r)
+	if err != nil {
+		t.Fatalf("Emit: %v", err)
+	}
+	if !strings.Contains(sql, "ARRAY JOIN") {
+		t.Errorf("ungrouped matrix fused variants missing ARRAY JOIN\nSQL: %s", sql)
+	}
+}
+
 // TestEmitFusedVariantsReusesSingleArmReducers pins that each arm's reducer is
 // the SAME expression the single-arm path emits, over that arm's own values
 // array — the property that keeps the fused and unfused answers equal without


### PR DESCRIPTION
## Summary
- Post-merge, `internal/chsql`'s mutation-test efficacy on PR #2624 measured 93.29% (445/477 covered mutants killed), below the required 95% threshold. This adds/strengthens tests to kill all 32 surviving mutants:
  - 14 in code PR #2624 itself added/changed (`deltaMatrixLevelSourceAggregate`/`deltaMatrixLevelSourceAggregateDailyFanout`, `applyMatrixFanoutScanBound`/`applyMatrixFanoutScanBoundAggregate`, `matchRangeLWRFusion`'s anchor-key precondition).
  - 18 in pre-existing code (`range_window.go`, `histogram_quantile.go`, `range_window_variants.go`, `lwr_fanout_bound.go`, `aggregate_range_lwr_fusion.go`) — genuine longstanding gaps, unrelated to #2624.
- Every mutant was individually verified: hand-apply the exact mutation, confirm the new/strengthened test fails, revert. No mutant was classified unkillable/equivalent — all 32 got real, falsifying tests.
- Also fixes an unrelated but release-blocking CI issue found while investigating: the `roundtrip` job's `timeout-minutes: 20` is now too tight for the promql leg on a real push-to-main run (the fixture corpus grew past 700 TXTAR files across #2620/#2624's work) — it was observed timing out at ~20.5min three times in a row on main's #2624 merge commit. Bumped to 35.

## Test plan
- [x] `go build ./...`, `go vet ./internal/chsql/...` — clean
- [x] `go test ./internal/chsql/...` — green
- [x] `go test -tags chdb ./internal/chsql/...` — green (verified per-branch before merge; both source branches ran this individually and the consolidated merge re-confirmed build/vet/untagged tests)
- [x] `just lint-actions` — clean on the workflow change
- [ ] CI (including a full gremlins re-measurement to confirm ≥95% efficacy)