### PR TITLE
fix(ci): bump roundtrip's per-leg go-test timeout from 12 to 25 minutes

### DIFF
--- a/.github/scripts/chdb-roundtrip.mjs
+++ b/.github/scripts/chdb-roundtrip.mjs
@@ -87,12 +87,17 @@ const FANOUT = {
  * strictly below chdb.yml's `timeout-minutes`, and
  * chdb-roundtrip.test.mjs asserts that ordering against the workflow file.
  *
- * Twelve minutes is ~5x the ~250s a fanned-out promql leg should take and ~2x
- * the ~700s an UNFANNED leg takes today, so it stays a hang detector rather
- * than a throughput ceiling even if the fan-out is reduced to 1, while leaving
- * the 20-minute job cap several minutes of room to publish the dump.
+ * Bumped from 12 to 25 on 2026-08-25: the promql leg's fixture corpus grew
+ * past 700 TXTAR files (the #2624 audit-fix batch alone added dozens of new
+ * histogram_native / mixed-or fixtures), pushing real per-leg runtime past
+ * the old 12-minute bound — observed as a genuine `test timed out after
+ * 12m0s` panic on a real push-to-main run, not a wedged libchdb call (the
+ * goroutine dump showed ordinary tests still progressing, not one frame
+ * stuck). 25 restores real headroom over actual leg runtime while staying
+ * well below chdb.yml's 35-minute job cap (see the assertion below), so it
+ * stays a hang detector rather than a throughput ceiling.
  */
-export const GO_TEST_TIMEOUT_MINUTES = 12;
+export const GO_TEST_TIMEOUT_MINUTES = 25;
 
 /** The env pair spec.ShardFromEnv reads. Contract with test/spec/shard.go. */
 const SPEC_SHARD_INDEX_ENV = 'SPEC_SHARD_INDEX';


### PR DESCRIPTION
## Summary
- Same root cause as the recently-merged #2627's job-level `timeout-minutes` bump, but a different layer: `chdb-roundtrip.mjs`'s internal `GO_TEST_TIMEOUT_MINUTES` (per-leg `go test -timeout`, a hang detector distinct from the job-level cap) was still 12 minutes.
- Main's push CI (commit 93ce859a, after #2627 merged) hit a genuine `test timed out after 12m0s` panic on the promql roundtrip leg — the goroutine dump showed ordinary tests still progressing, not one frame wedged in a libchdb call, confirming this is the fixture corpus (now 700+ TXTAR files) outgrowing the bound, not the #2096 hang class the bound exists to catch.
- Bumped to 25 minutes, staying well below chdb.yml's 35-minute job cap so `chdb-roundtrip.test.mjs`'s ordering assertion still passes.

## Test plan
- [x] `node --test .github/scripts/chdb-roundtrip.test.mjs` — all 11 tests pass, including the job-cap ordering assertion
- [ ] CI