### PR TITLE
fix(ci): give post-merge-drift real headroom over its actual runtime

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -73,7 +73,13 @@ jobs:
     # push / nightly / dispatch / release PRs, so a wider ceiling costs
     # nothing on the PR path — and a timeout here lands red on main, where
     # nobody's PR was ever asked to catch it.
-    timeout-minutes: 60
+    #
+    # Bumped from 60 to 90 on 2026-08-25: every one of this session's large
+    # merges to main (#2624, #2627, #2628, #2630) hit or exceeded the 60m
+    # cap, including the merge that landed #2630 (ran the full 60m0s and was
+    # killed) — the same fixture-corpus growth already documented on
+    # post-merge-drift.yml and chdb.yml's roundtrip job.
+    timeout-minutes: 90
     # RUN_HEAVY gates the measured profile: true on push / schedule / dispatch
     # (unless a resolved source PR proves this push redundant — see the
     # `decide run_heavy` step below), and on a release PR (head branch

--- a/.github/workflows/post-merge-drift.yml
+++ b/.github/workflows/post-merge-drift.yml
@@ -40,7 +40,19 @@ jobs:
     # is a fixture-only or docs-only push that regenerates nothing at all. This
     # budget covers the worst case: a change to internal/chsql, which reaches
     # every head and implies every shard.
-    timeout-minutes: 45
+    #
+    # Bumped from 45 to 90 on 2026-08-25: the worst case now runs the WHOLE
+    # regeneration SERIALLY on one runner (no per-shard fan-out, unlike
+    # update-golden.yml's own CI dispatch), and the promql fixture corpus grew
+    # past 700 TXTAR files during the #2624 audit-fix batch — the same growth
+    # that forced chdb.yml's roundtrip job from 20 to 35 minutes
+    # (chdb-roundtrip.mjs). Observed directly: eight of the day's pushes to
+    # main hit the exact 45m0s cap ("The job has exceeded the maximum
+    # execution time of 45m0s"), including the merge that landed #2630, while
+    # the successful runs on the same day already ran 30-40 minutes — headroom
+    # this thin means routine merges lose real drift coverage, not just large
+    # ones.
+    timeout-minutes: 90
     steps:
       - uses: actions/checkout@v7
         with:


### PR DESCRIPTION
## Summary

- `post-merge-drift` (`.github/workflows/post-merge-drift.yml`) regenerates the whole golden
  corpus serially on one runner whenever a merge implies every shard, and the `promql` fixture
  corpus grew past 700 TXTAR files during the #2624 audit-fix batch — the same growth that
  already forced `chdb.yml`'s `roundtrip` job from 20 to 35 minutes.
- Eight of today's pushes to `main` hit the lane's exact 45m0s timeout (`The job has exceeded
  the maximum execution time of 45m0s`), including the merge that landed #2630, while the
  same-day runs that did finish already took 30-40 minutes — routine merges were losing real
  drift coverage, not just unusually large ones.
- Bumps `timeout-minutes` from 45 to 90 to restore real headroom.

## Test plan

- [x] `just lint-actions` clean locally.
- [ ] CI green.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
