### PR TITLE
fix(ci): gitignore the patches/ CI artifact-staging directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -97,3 +97,12 @@ test/e2e/playwright/playwright-report/
 /bench-report
 /cerberus
 /perf-profile
+
+# CI-only artifact staging directories: update-golden.yml downloads each
+# shard's uploaded patch here before applying it (and cardinality-seal's own
+# leg patches under the same name), and post-merge-drift.yml's
+# cardinality-seal job does the identical download-and-apply. Left untracked
+# and unignored, these showed up as spurious "no shard declares this path"
+# drift in post-merge-golden-drift.mjs's own untracked-file scan.
+/patches/
+/patches-out/


### PR DESCRIPTION
## Summary

`cardinality-seal` (`post-merge-drift.yml`, mirroring the identical step in `update-golden.yml`)
downloads every leg's uploaded patch into `patches/` and applies them before running the closing
`TestCardinalityBaselineCoversTheCorpus` assertion. That directory was never `.gitignore`d, so
`post-merge-golden-drift.mjs`'s own untracked-file scan (`git status --porcelain
--untracked-files=all`) picked it up as apparent drift on the very first real run after #2640
merged:

```
error: regenerating cardinality wrote 8 path(s) no shard declares as its own:
         patches/cardinality-leg-patch-1/cardinality-leg-1.patch
         ...
```

Nothing was actually wrong with the regenerated cardinality baseline — the failure was entirely
an artifact of the download-and-apply staging directory being visible to a check whose whole job
is to flag exactly this shape of surprise.

## Fix

Add `/patches/` and `/patches-out/` to `.gitignore` — both are pure CI artifact-staging
directories used only by `update-golden.yml` and `post-merge-drift.yml`, never meant to be
tracked or diffed.

## Test plan

- [x] Verified locally: an untracked `patches/` subtree no longer appears in `git status
      --porcelain --untracked-files=all`.
- [x] `just lint-actions` clean.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
