### PR TITLE
fix(ci): give coverage-chdb real headroom over its actual runtime

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -203,9 +203,14 @@ jobs:
     if: needs.coverage-plan.outputs.run_heavy == 'true'
     runs-on: ubuntu-latest
     # Same reasoning as coverage-default's timeout: `just coverage-chdb`'s
-    # `go test` is capped at `-timeout 40m`, plus the ratchet fan-out
+    # `go test` is capped at `-timeout 60m`, plus the ratchet fan-out
     # (perf-coverage-fanout.mjs) it also runs.
-    timeout-minutes: 50
+    #
+    # Bumped from 50 to 75 on 2026-08-26 alongside the Justfile recipe's own
+    # 40m->60m bump: the first real push-to-main run after this job existed
+    # hit the old 50m wrapper exactly, the same corpus growth already
+    # documented on the recipe itself.
+    timeout-minutes: 75
     steps:
       - uses: actions/checkout@v7
 

--- a/Justfile
+++ b/Justfile
@@ -585,11 +585,20 @@ coverage-chdb:
     @if [ -e "{{CHDB_INSTALL_PATH}}" ]; then \
         echo "==> chdb-tagged coverage"; \
         COVERPKG="$(go list -tags chdb,agpl_oracle,chdb_agpl_oracle ./... | paste -sd, -)"; \
-        PERF_SHARD_INDEX=1 PERF_SHARD_COUNT=3 go test -timeout 40m -tags chdb,agpl_oracle,chdb_agpl_oracle -coverpkg="$COVERPKG" -coverprofile=cover-chdb.out ./... | awk '{ sub(/of statements in github\.com\/.*/, "of statements"); print; fflush() }'; \
+        PERF_SHARD_INDEX=1 PERF_SHARD_COUNT=3 go test -timeout 60m -tags chdb,agpl_oracle,chdb_agpl_oracle -coverpkg="$COVERPKG" -coverprofile=cover-chdb.out ./... | awk '{ sub(/of statements in github\.com\/.*/, "of statements"); print; fflush() }'; \
         TAGS=chdb,agpl_oracle,chdb_agpl_oracle COVERPKG="$COVERPKG" node .github/scripts/perf-coverage-fanout.mjs; \
     else \
         echo "==> libchdb.so not found, skipping chdb lane"; \
     fi
+    # Bumped from 40m to 60m on 2026-08-26: the first real push-to-main run
+    # after coverage.yml split into parallel coverage-default/coverage-chdb
+    # jobs (#2639) hit coverage-chdb's job-level 50-minute wrapper exactly
+    # ("The job has exceeded the maximum execution time of 50m0s") — the same
+    # fixture/corpus growth already documented below, regrown past the
+    # PERF_SHARD_COUNT=3 split's own headroom. The job-level timeout in
+    # coverage.yml moved with it (50m -> 75m) so the wrapper still has real
+    # margin over this internal hang detector, not just a matching ceiling.
+    #
     # This lane's `go test` used to sweep ./... with no shard env, timed out
     # at 40m, the same shape as the default-tag lane above. It stopped
     # fitting that budget once TestCardinalityRatchet's corpus walk


### PR DESCRIPTION
## Summary

The first real push-to-main run after `coverage.yml` split into parallel `coverage-default`/
`coverage-chdb` jobs (#2639) hit `coverage-chdb`'s job-level 50-minute wrapper exactly:

```
The job has exceeded the maximum execution time of 50m0s
```

Same corpus/fixture growth already documented on the recipe itself (a prior fix split
`TestCardinalityRatchet`'s corpus walk across `PERF_SHARD_COUNT=3` shards after it outgrew a
single 40-minute sweep) — that split's own headroom has now regrown past 50 minutes total.

## Fix

- `Justfile`'s `coverage-chdb` recipe: internal `go test -timeout` 40m → 60m.
- `coverage.yml`'s `coverage-chdb` job: `timeout-minutes` 50 → 75, keeping real margin over the
  internal hang detector rather than a matching ceiling.

## Test plan

- [x] `go test -run '^TestCoverageRecipeFailsClosedOnGoTestFailure$' ./test/regression/...` —
      still pins exactly 2 `go test -timeout` invocations in the recipe.
- [x] `just lint-actions` clean.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
