### PR TITLE
fix(e2e): narrow the chaos lane's CH memory cap so route-memo-activation fires

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1609,6 +1609,37 @@ jobs:
       - name: Wait for real OTel data from the collector pipeline
         run: just e2e-wait-otel
 
+      # TEMPORARY DIAGNOSTIC — the previous diagnostic (still further below,
+      # AFTER the overlay) proved the loki HEAD_PROBES query
+      # ({service_name=~".+"}&limit=1) deterministically trips
+      # CERBERUS_CH_QUERY_MAX_MEMORY=2Mi every attempt (31/31, verbatim CH
+      # error "maximum memory usage (2097152 bytes) reached"), while the prom
+      # (`up`) and tempo (limit=1 search) probes both succeed on their FIRST
+      # attempt. This step fires that SAME loki query BEFORE the overlay
+      # lands, while the deployment still runs the 1GiB production default
+      # (functionally uncapped for this query), and reads its real
+      # memory_usage from system.query_log -- the number needed to size a
+      # cap that sits above this query's real cost and below the ~5.5 MiB
+      # measured route-memo-activation cost. Removed once the real number is
+      # captured; not part of the shipped fix.
+      - name: DIAGNOSTIC loki head-probe real cost at the 1GiB default
+        run: |
+          set -eu
+          now_before=$(date -u +"%Y-%m-%d %H:%M:%S")
+          code=$(curl -s -o /tmp/loki-uncapped.json -w "%{http_code}" \
+            'http://localhost:8080/loki/api/v1/query?query=%7Bservice_name%3D~%22.%2B%22%7D&limit=1' || echo "000")
+          echo "== [loki-uncapped] http_code=$code"
+          head -c 300 /tmp/loki-uncapped.json 2>/dev/null || echo "(no response body captured)"; echo
+          sleep 3
+          kubectl -n cerberus exec deploy/clickhouse -- clickhouse-client --user cerberus --password cerberus --database otel --query "
+            SELECT type, memory_usage, formatReadableSize(memory_usage) AS mem, exception_code, substring(exception,1,200) AS exc
+            FROM system.query_log
+            WHERE event_time >= '${now_before}' AND type != 'QueryStart'
+            ORDER BY event_time_microseconds DESC
+            LIMIT 3
+            FORMAT PrettySpace
+          " || true
+
       # Apply the chaos overlay (low breaker threshold + small
       # CERBERUS_QUERY_TIMEOUT + small admit/pool caps) so faults trip
       # FAST + DETERMINISTICALLY within the per-scenario budget.

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1622,17 +1622,40 @@ jobs:
       # HEAD_PROBES shapes chaos-run.mjs preflight uses, records their HTTP
       # status, and reads system.query_log for the real memory_usage/
       # exception each one costs under the 2Mi cap — so the real fix can be
-      # sized against the ACTUAL floor instead of guessed. Removed once the
-      # real number is captured; not part of the shipped fix.
+      # sized against the ACTUAL floor instead of guessed.
+      #
+      # POLLS rather than firing once: a first attempt immediately after
+      # `kubectl rollout status` reports success got curl's own http_code=000
+      # (connection refused — never reached cerberus at all) in an earlier
+      # version of this step, because the localhost:8080 path needs a beat
+      # to catch up with the rollout. Mirrors chaos-run.mjs's own pollUntil
+      # budget EXACTLY (POLL_INTERVAL_MS=2000, PREFLIGHT_DEADLINE_MS=60000 —
+      # .github/scripts/chaos-run.mjs:96,1386) so a probe that only succeeds
+      # because it waited LONGER than the real preflight would allow is
+      # itself a finding, not a false pass. Removed once the real number is
+      # captured; not part of the shipped fix.
       - name: DIAGNOSTIC head-probe query cost under the 2Mi cap
         run: |
           set -eu
+          POLL_INTERVAL_S=2
+          DEADLINE_S=60
           probe() {
             label="$1"; path="$2"
             now_before=$(date -u +"%Y-%m-%d %H:%M:%S")
-            code=$(curl -s -o "/tmp/headprobe-$label.json" -w "%{http_code}" "http://localhost:8080$path" || echo "ERR")
-            echo "== [$label] path=$path http_code=$code"
-            head -c 300 "/tmp/headprobe-$label.json"; echo
+            start=$(date +%s)
+            code="000"
+            attempts=0
+            while :; do
+              attempts=$((attempts + 1))
+              code=$(curl -s -o "/tmp/headprobe-$label.json" -w "%{http_code}" "http://localhost:8080$path" || echo "000")
+              elapsed=$(( $(date +%s) - start ))
+              if [ "$code" = "200" ] || [ "$elapsed" -ge "$DEADLINE_S" ]; then
+                break
+              fi
+              sleep "$POLL_INTERVAL_S"
+            done
+            echo "== [$label] path=$path http_code=$code attempts=$attempts elapsed=${elapsed}s"
+            head -c 300 "/tmp/headprobe-$label.json" 2>/dev/null || echo "(no response body captured)"; echo
             sleep 3
             kubectl -n cerberus exec deploy/clickhouse -- clickhouse-client --user cerberus --password cerberus --database otel --query "
               SELECT type, memory_usage, formatReadableSize(memory_usage) AS mem, exception_code, substring(exception,1,200) AS exc

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1615,6 +1615,44 @@ jobs:
       - name: Apply chaos overlay (resilience knobs)
         run: just e2e-chaos-overlay
 
+      # TEMPORARY DIAGNOSTIC — measures the real ClickHouse memory_usage the
+      # route-memo-activation pinned 24h/15s query costs at chaos-lane-realistic
+      # process-uptime timing (t0/t60/t180 after the overlay lands), via
+      # system.query_log. Removed once the real number is captured; not part
+      # of the shipped fix.
+      - name: DIAGNOSTIC route-memo query memory cost over time
+        run: |
+          set -eu
+          fire_and_measure() {
+            label="$1"
+            now=$(date +%s)
+            step=15
+            margin=$((2*step))
+            end=$((now - margin))
+            start=$((end - 86400))
+            encoded="sum%20by%20(cerberus_ql)%20(rate(cerberus_queries_total%5B5m%5D))"
+            url="http://localhost:8080/api/v1/query_range?query=${encoded}&start=${start}&end=${end}&step=${step}"
+            echo "== [$label] firing $url"
+            t0=$(date -u +"%Y-%m-%d %H:%M:%S")
+            http_code=$(curl -s -o "/tmp/resp-$label.json" -w "%{http_code}" "$url" || echo "ERR")
+            echo "== [$label] http_code=$http_code"
+            head -c 300 "/tmp/resp-$label.json"; echo
+            sleep 10
+            kubectl -n cerberus exec deploy/clickhouse -- clickhouse-client --user cerberus --password cerberus --database otel --query "
+              SELECT type, memory_usage, formatReadableSize(memory_usage) AS mem, read_rows, exception_code, substring(exception,1,200) AS exc
+              FROM system.query_log
+              WHERE event_time >= '${t0}' AND positionCaseInsensitive(query, 'cerberus_queries_total') > 0 AND type != 'QueryStart'
+              ORDER BY event_time_microseconds DESC
+              LIMIT 5
+              FORMAT PrettySpace
+            " || true
+          }
+          fire_and_measure t0
+          sleep 60
+          fire_and_measure t60
+          sleep 120
+          fire_and_measure t180
+
       # Phase-1 scenarios sequentially with heal-between-each, ordered
       # non-destructive-first / destructive-last (see orderScenarios in
       # chaos-run.mjs): route-memo-activation (failure-driven route memo,

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1615,48 +1615,6 @@ jobs:
       - name: Apply chaos overlay (resilience knobs)
         run: just e2e-chaos-overlay
 
-      # TEMPORARY DIAGNOSTIC — the real verification run (32951277790) showed
-      # route-memo-activation's fault injection working (a genuine 422
-      # memory-limit rejection on route A, repeatedly), but
-      # cerberus_route_ab_success_total{route_choice="b"} never climbed: the
-      # A->B rescue never completed. Two competing explanations: (a) route B
-      # (a sharded fanout, decision.Slices in internal/engine/
-      # route_memo_wiring.go) never got DISPATCHED AT ALL (a real bug in
-      # routememo's corroboration/pressure/admission gates), or (b) route B
-      # WAS dispatched but its own per-shard queries ALSO tripped the 4Mi cap
-      # (a mechanical consequence of a blanket memory cap, not a routememo
-      # bug). This step fires the EXACT pinned 24h/15s query_range shape
-      # chaos-run.mjs's routeMemoQueryPath uses, repeatedly, for the same
-      # ~2 minutes the real scenario polls, then dumps EVERY ClickHouse query
-      # system.query_log recorded in that window (not just the last 3) so the
-      # shard fanout is visible if it happened. Removed once the real
-      # mechanism is understood; not part of the shipped fix.
-      - name: DIAGNOSTIC route-memo full query_log during fault injection
-        run: |
-          set -eu
-          window_start=$(date -u +"%Y-%m-%d %H:%M:%S")
-          end_ts=0
-          for i in $(seq 1 24); do
-            now=$(date +%s)
-            end_ts=$((now - 30))
-            start_ts=$((end_ts - 86400))
-            encoded="sum%20by%20(cerberus_ql)%20(rate(cerberus_queries_total%5B5m%5D))"
-            url="http://localhost:8080/api/v1/query_range?query=${encoded}&start=${start_ts}&end=${end_ts}&step=15"
-            code=$(curl -s -o /tmp/route-memo-fire.json -w "%{http_code}" "$url" || echo "000")
-            echo "== attempt $i http_code=$code"
-            sleep 5
-          done
-          echo "== dumping full system.query_log for the fault-injection window =="
-          kubectl -n cerberus exec deploy/clickhouse -- clickhouse-client --user cerberus --password cerberus --database otel --query "
-            SELECT event_time, type, memory_usage, formatReadableSize(memory_usage) AS mem, exception_code,
-                   left(query, 120) AS query_snippet
-            FROM system.query_log
-            WHERE event_time >= '${window_start}' AND type != 'QueryStart'
-              AND positionCaseInsensitive(query, 'cerberus_queries_total') > 0
-            ORDER BY event_time_microseconds ASC
-            FORMAT PrettySpace
-          " || true
-
       # Phase-1 scenarios sequentially with heal-between-each, ordered
       # non-destructive-first / destructive-last (see orderScenarios in
       # chaos-run.mjs): route-memo-activation (failure-driven route memo,

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1615,6 +1615,38 @@ jobs:
       - name: Apply chaos overlay (resilience knobs)
         run: just e2e-chaos-overlay
 
+      # TEMPORARY DIAGNOSTIC — bisecting the two consecutive preflight
+      # failures under CERBERUS_CH_QUERY_MAX_MEMORY=2Mi (both runs: /readyz
+      # green fast, but assertHeadsHealthy's 3 head-probe queries never
+      # returned 200 within the 60s preflight budget). Fires the EXACT 3
+      # HEAD_PROBES shapes chaos-run.mjs preflight uses, records their HTTP
+      # status, and reads system.query_log for the real memory_usage/
+      # exception each one costs under the 2Mi cap — so the real fix can be
+      # sized against the ACTUAL floor instead of guessed. Removed once the
+      # real number is captured; not part of the shipped fix.
+      - name: DIAGNOSTIC head-probe query cost under the 2Mi cap
+        run: |
+          set -eu
+          probe() {
+            label="$1"; path="$2"
+            now_before=$(date -u +"%Y-%m-%d %H:%M:%S")
+            code=$(curl -s -o "/tmp/headprobe-$label.json" -w "%{http_code}" "http://localhost:8080$path" || echo "ERR")
+            echo "== [$label] path=$path http_code=$code"
+            head -c 300 "/tmp/headprobe-$label.json"; echo
+            sleep 3
+            kubectl -n cerberus exec deploy/clickhouse -- clickhouse-client --user cerberus --password cerberus --database otel --query "
+              SELECT type, memory_usage, formatReadableSize(memory_usage) AS mem, exception_code, substring(exception,1,200) AS exc
+              FROM system.query_log
+              WHERE event_time >= '${now_before}' AND type != 'QueryStart'
+              ORDER BY event_time_microseconds DESC
+              LIMIT 3
+              FORMAT PrettySpace
+            " || true
+          }
+          probe prom '/api/v1/query?query=up'
+          probe loki '/loki/api/v1/query?query=%7Bservice_name%3D~%22.%2B%22%7D&limit=1'
+          probe tempo '/api/search?limit=1'
+
       # Phase-1 scenarios sequentially with heal-between-each, ordered
       # non-destructive-first / destructive-last (see orderScenarios in
       # chaos-run.mjs): route-memo-activation (failure-driven route memo,

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1609,97 +1609,11 @@ jobs:
       - name: Wait for real OTel data from the collector pipeline
         run: just e2e-wait-otel
 
-      # TEMPORARY DIAGNOSTIC — the previous diagnostic (still further below,
-      # AFTER the overlay) proved the loki HEAD_PROBES query
-      # ({service_name=~".+"}&limit=1) deterministically trips
-      # CERBERUS_CH_QUERY_MAX_MEMORY=2Mi every attempt (31/31, verbatim CH
-      # error "maximum memory usage (2097152 bytes) reached"), while the prom
-      # (`up`) and tempo (limit=1 search) probes both succeed on their FIRST
-      # attempt. This step fires that SAME loki query BEFORE the overlay
-      # lands, while the deployment still runs the 1GiB production default
-      # (functionally uncapped for this query), and reads its real
-      # memory_usage from system.query_log -- the number needed to size a
-      # cap that sits above this query's real cost and below the ~5.5 MiB
-      # measured route-memo-activation cost. Removed once the real number is
-      # captured; not part of the shipped fix.
-      - name: DIAGNOSTIC loki head-probe real cost at the 1GiB default
-        run: |
-          set -eu
-          now_before=$(date -u +"%Y-%m-%d %H:%M:%S")
-          code=$(curl -s -o /tmp/loki-uncapped.json -w "%{http_code}" \
-            'http://localhost:8080/loki/api/v1/query?query=%7Bservice_name%3D~%22.%2B%22%7D&limit=1' || echo "000")
-          echo "== [loki-uncapped] http_code=$code"
-          head -c 300 /tmp/loki-uncapped.json 2>/dev/null || echo "(no response body captured)"; echo
-          sleep 3
-          kubectl -n cerberus exec deploy/clickhouse -- clickhouse-client --user cerberus --password cerberus --database otel --query "
-            SELECT type, memory_usage, formatReadableSize(memory_usage) AS mem, exception_code, substring(exception,1,200) AS exc
-            FROM system.query_log
-            WHERE event_time >= '${now_before}' AND type != 'QueryStart'
-            ORDER BY event_time_microseconds DESC
-            LIMIT 3
-            FORMAT PrettySpace
-          " || true
-
       # Apply the chaos overlay (low breaker threshold + small
       # CERBERUS_QUERY_TIMEOUT + small admit/pool caps) so faults trip
       # FAST + DETERMINISTICALLY within the per-scenario budget.
       - name: Apply chaos overlay (resilience knobs)
         run: just e2e-chaos-overlay
-
-      # TEMPORARY DIAGNOSTIC — bisecting the two consecutive preflight
-      # failures under CERBERUS_CH_QUERY_MAX_MEMORY=2Mi (both runs: /readyz
-      # green fast, but assertHeadsHealthy's 3 head-probe queries never
-      # returned 200 within the 60s preflight budget). Fires the EXACT 3
-      # HEAD_PROBES shapes chaos-run.mjs preflight uses, records their HTTP
-      # status, and reads system.query_log for the real memory_usage/
-      # exception each one costs under the 2Mi cap — so the real fix can be
-      # sized against the ACTUAL floor instead of guessed.
-      #
-      # POLLS rather than firing once: a first attempt immediately after
-      # `kubectl rollout status` reports success got curl's own http_code=000
-      # (connection refused — never reached cerberus at all) in an earlier
-      # version of this step, because the localhost:8080 path needs a beat
-      # to catch up with the rollout. Mirrors chaos-run.mjs's own pollUntil
-      # budget EXACTLY (POLL_INTERVAL_MS=2000, PREFLIGHT_DEADLINE_MS=60000 —
-      # .github/scripts/chaos-run.mjs:96,1386) so a probe that only succeeds
-      # because it waited LONGER than the real preflight would allow is
-      # itself a finding, not a false pass. Removed once the real number is
-      # captured; not part of the shipped fix.
-      - name: DIAGNOSTIC head-probe query cost under the 2Mi cap
-        run: |
-          set -eu
-          POLL_INTERVAL_S=2
-          DEADLINE_S=60
-          probe() {
-            label="$1"; path="$2"
-            now_before=$(date -u +"%Y-%m-%d %H:%M:%S")
-            start=$(date +%s)
-            code="000"
-            attempts=0
-            while :; do
-              attempts=$((attempts + 1))
-              code=$(curl -s -o "/tmp/headprobe-$label.json" -w "%{http_code}" "http://localhost:8080$path" || echo "000")
-              elapsed=$(( $(date +%s) - start ))
-              if [ "$code" = "200" ] || [ "$elapsed" -ge "$DEADLINE_S" ]; then
-                break
-              fi
-              sleep "$POLL_INTERVAL_S"
-            done
-            echo "== [$label] path=$path http_code=$code attempts=$attempts elapsed=${elapsed}s"
-            head -c 300 "/tmp/headprobe-$label.json" 2>/dev/null || echo "(no response body captured)"; echo
-            sleep 3
-            kubectl -n cerberus exec deploy/clickhouse -- clickhouse-client --user cerberus --password cerberus --database otel --query "
-              SELECT type, memory_usage, formatReadableSize(memory_usage) AS mem, exception_code, substring(exception,1,200) AS exc
-              FROM system.query_log
-              WHERE event_time >= '${now_before}' AND type != 'QueryStart'
-              ORDER BY event_time_microseconds DESC
-              LIMIT 3
-              FORMAT PrettySpace
-            " || true
-          }
-          probe prom '/api/v1/query?query=up'
-          probe loki '/loki/api/v1/query?query=%7Bservice_name%3D~%22.%2B%22%7D&limit=1'
-          probe tempo '/api/search?limit=1'
 
       # Phase-1 scenarios sequentially with heal-between-each, ordered
       # non-destructive-first / destructive-last (see orderScenarios in

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1615,6 +1615,48 @@ jobs:
       - name: Apply chaos overlay (resilience knobs)
         run: just e2e-chaos-overlay
 
+      # TEMPORARY DIAGNOSTIC — the real verification run (32951277790) showed
+      # route-memo-activation's fault injection working (a genuine 422
+      # memory-limit rejection on route A, repeatedly), but
+      # cerberus_route_ab_success_total{route_choice="b"} never climbed: the
+      # A->B rescue never completed. Two competing explanations: (a) route B
+      # (a sharded fanout, decision.Slices in internal/engine/
+      # route_memo_wiring.go) never got DISPATCHED AT ALL (a real bug in
+      # routememo's corroboration/pressure/admission gates), or (b) route B
+      # WAS dispatched but its own per-shard queries ALSO tripped the 4Mi cap
+      # (a mechanical consequence of a blanket memory cap, not a routememo
+      # bug). This step fires the EXACT pinned 24h/15s query_range shape
+      # chaos-run.mjs's routeMemoQueryPath uses, repeatedly, for the same
+      # ~2 minutes the real scenario polls, then dumps EVERY ClickHouse query
+      # system.query_log recorded in that window (not just the last 3) so the
+      # shard fanout is visible if it happened. Removed once the real
+      # mechanism is understood; not part of the shipped fix.
+      - name: DIAGNOSTIC route-memo full query_log during fault injection
+        run: |
+          set -eu
+          window_start=$(date -u +"%Y-%m-%d %H:%M:%S")
+          end_ts=0
+          for i in $(seq 1 24); do
+            now=$(date +%s)
+            end_ts=$((now - 30))
+            start_ts=$((end_ts - 86400))
+            encoded="sum%20by%20(cerberus_ql)%20(rate(cerberus_queries_total%5B5m%5D))"
+            url="http://localhost:8080/api/v1/query_range?query=${encoded}&start=${start_ts}&end=${end_ts}&step=15"
+            code=$(curl -s -o /tmp/route-memo-fire.json -w "%{http_code}" "$url" || echo "000")
+            echo "== attempt $i http_code=$code"
+            sleep 5
+          done
+          echo "== dumping full system.query_log for the fault-injection window =="
+          kubectl -n cerberus exec deploy/clickhouse -- clickhouse-client --user cerberus --password cerberus --database otel --query "
+            SELECT event_time, type, memory_usage, formatReadableSize(memory_usage) AS mem, exception_code,
+                   left(query, 120) AS query_snippet
+            FROM system.query_log
+            WHERE event_time >= '${window_start}' AND type != 'QueryStart'
+              AND positionCaseInsensitive(query, 'cerberus_queries_total') > 0
+            ORDER BY event_time_microseconds ASC
+            FORMAT PrettySpace
+          " || true
+
       # Phase-1 scenarios sequentially with heal-between-each, ordered
       # non-destructive-first / destructive-last (see orderScenarios in
       # chaos-run.mjs): route-memo-activation (failure-driven route memo,

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1615,44 +1615,6 @@ jobs:
       - name: Apply chaos overlay (resilience knobs)
         run: just e2e-chaos-overlay
 
-      # TEMPORARY DIAGNOSTIC — measures the real ClickHouse memory_usage the
-      # route-memo-activation pinned 24h/15s query costs at chaos-lane-realistic
-      # process-uptime timing (t0/t60/t180 after the overlay lands), via
-      # system.query_log. Removed once the real number is captured; not part
-      # of the shipped fix.
-      - name: DIAGNOSTIC route-memo query memory cost over time
-        run: |
-          set -eu
-          fire_and_measure() {
-            label="$1"
-            now=$(date +%s)
-            step=15
-            margin=$((2*step))
-            end=$((now - margin))
-            start=$((end - 86400))
-            encoded="sum%20by%20(cerberus_ql)%20(rate(cerberus_queries_total%5B5m%5D))"
-            url="http://localhost:8080/api/v1/query_range?query=${encoded}&start=${start}&end=${end}&step=${step}"
-            echo "== [$label] firing $url"
-            t0=$(date -u +"%Y-%m-%d %H:%M:%S")
-            http_code=$(curl -s -o "/tmp/resp-$label.json" -w "%{http_code}" "$url" || echo "ERR")
-            echo "== [$label] http_code=$http_code"
-            head -c 300 "/tmp/resp-$label.json"; echo
-            sleep 10
-            kubectl -n cerberus exec deploy/clickhouse -- clickhouse-client --user cerberus --password cerberus --database otel --query "
-              SELECT type, memory_usage, formatReadableSize(memory_usage) AS mem, read_rows, exception_code, substring(exception,1,200) AS exc
-              FROM system.query_log
-              WHERE event_time >= '${t0}' AND positionCaseInsensitive(query, 'cerberus_queries_total') > 0 AND type != 'QueryStart'
-              ORDER BY event_time_microseconds DESC
-              LIMIT 5
-              FORMAT PrettySpace
-            " || true
-          }
-          fire_and_measure t0
-          sleep 60
-          fire_and_measure t60
-          sleep 120
-          fire_and_measure t180
-
       # Phase-1 scenarios sequentially with heal-between-each, ordered
       # non-destructive-first / destructive-last (see orderScenarios in
       # chaos-run.mjs): route-memo-activation (failure-driven route memo,

--- a/test/e2e/chaos/manifests/chaos-overlay.env
+++ b/test/e2e/chaos/manifests/chaos-overlay.env
@@ -72,6 +72,24 @@
 #     must never trip CH health). Kept >= the admit cap so admission, not
 #     the pool, is the first-order shed signal.
 #
+#   CERBERUS_CH_QUERY_MAX_MEMORY=2Mi
+#     Default 1GiB (1073741824 bytes). A throwaway diagnostic run
+#     (system.query_log memory_usage sampled at t0/t60/t180 after the chaos
+#     overlay lands) measured the pinned 24h/15s route-memo-activation
+#     query_range shape (ROUTE_MEMO_EXPR in chaos-run.mjs) at ~5.45-5.63 MiB
+#     of real ClickHouse memory in THIS lane's data volume — nowhere near the
+#     1 GiB production default, which is why the scenario's own honesty note
+#     records memory-cap-not-crossed instead of exercising the route-memo A->B
+#     rescue. 2 MiB sits comfortably below that measured range (real margin in
+#     both directions: never close enough to the ~5.5 MiB observed cost to
+#     flake short, and two-plus orders of magnitude below the 1 GiB binary
+#     default so this is unambiguously a test-only narrowing, not a
+#     production-shaped value) — the query now reliably trips ClickHouse's
+#     MEMORY_LIMIT_EXCEEDED (code 241, breaker-neutral per
+#     internal/chclient/memlimit.go) every run, giving
+#     scenarioRouteMemoActivation a genuine route-A resource failure to rescue
+#     instead of a data-volume coin flip.
+#
 #   CERBERUS_SOLVER_ADAPTIVE_ENABLED=true
 #     Default true (internal/solver/config.go DefaultConfig). The
 #     failure-driven route memo (internal/routememo, wired via
@@ -93,4 +111,5 @@ CERBERUS_ADMIT_PROM=2
 CERBERUS_ADMIT_LOKI=2
 CERBERUS_ADMIT_TEMPO=2
 CERBERUS_CH_MAX_OPEN_CONNS=4
+CERBERUS_CH_QUERY_MAX_MEMORY=2Mi
 CERBERUS_SOLVER_ADAPTIVE_ENABLED=true

--- a/test/e2e/chaos/manifests/chaos-overlay.env
+++ b/test/e2e/chaos/manifests/chaos-overlay.env
@@ -72,23 +72,34 @@
 #     must never trip CH health). Kept >= the admit cap so admission, not
 #     the pool, is the first-order shed signal.
 #
-#   CERBERUS_CH_QUERY_MAX_MEMORY=2Mi
-#     Default 1GiB (1073741824 bytes). A throwaway diagnostic run
-#     (system.query_log memory_usage sampled at t0/t60/t180 after the chaos
-#     overlay lands) measured the pinned 24h/15s route-memo-activation
-#     query_range shape (ROUTE_MEMO_EXPR in chaos-run.mjs) at ~5.45-5.63 MiB
-#     of real ClickHouse memory in THIS lane's data volume — nowhere near the
-#     1 GiB production default, which is why the scenario's own honesty note
-#     records memory-cap-not-crossed instead of exercising the route-memo A->B
-#     rescue. 2 MiB sits comfortably below that measured range (real margin in
-#     both directions: never close enough to the ~5.5 MiB observed cost to
-#     flake short, and two-plus orders of magnitude below the 1 GiB binary
-#     default so this is unambiguously a test-only narrowing, not a
-#     production-shaped value) — the query now reliably trips ClickHouse's
+#   CERBERUS_CH_QUERY_MAX_MEMORY=4Mi
+#     Default 1GiB (1073741824 bytes). Throwaway diagnostic runs
+#     (system.query_log memory_usage sampled around the pinned queries)
+#     measured the pinned 24h/15s route-memo-activation query_range shape
+#     (ROUTE_MEMO_EXPR in chaos-run.mjs) at ~5.45-5.63 MiB of real ClickHouse
+#     memory in THIS lane's data volume — nowhere near the 1 GiB production
+#     default, which is why the scenario's own honesty note records
+#     memory-cap-not-crossed instead of exercising the route-memo A->B
+#     rescue. An EARLIER 2Mi value looked safe against that number alone but
+#     broke the lane every run: the loki HEAD_PROBES smoke query
+#     (chaos-run.mjs, `{service_name=~".+"}&limit=1`, an INSTANT query that
+#     collapses to a short bounded lookback window — qlcommon.InstantLookback,
+#     internal/api/loki/handler.go:330 — not a full-table scan) measured at
+#     ~1.42-1.49 MiB right after bring-up and ~2.08 MiB (CH's own "would use
+#     2.08 MiB, maximum: 2.00 MiB" exception) about a minute later on a freshly
+#     rolled pod, close enough to 2Mi that assertHeadsHealthy never saw 200
+#     and the WHOLE lane's preflight gate failed before any fault injection.
+#     4Mi keeps real margin above that observed ~2.08 MiB peak (the query's
+#     bounded lookback window means its cost tracks the rolling seeder's
+#     steady-state insert rate rather than growing unboundedly with total
+#     run duration) while staying meaningfully below the ~5.5 MiB route-memo
+#     cost and two-plus orders of magnitude below the 1 GiB binary default —
+#     the route-memo query still reliably trips ClickHouse's
 #     MEMORY_LIMIT_EXCEEDED (code 241, breaker-neutral per
-#     internal/chclient/memlimit.go) every run, giving
-#     scenarioRouteMemoActivation a genuine route-A resource failure to rescue
-#     instead of a data-volume coin flip.
+#     internal/chclient/memlimit.go), giving scenarioRouteMemoActivation a
+#     genuine route-A resource failure to rescue, while the routine
+#     health-probe queries every scenario's heal-gate depends on stay clear
+#     of the cap.
 #
 #   CERBERUS_SOLVER_ADAPTIVE_ENABLED=true
 #     Default true (internal/solver/config.go DefaultConfig). The
@@ -111,5 +122,5 @@ CERBERUS_ADMIT_PROM=2
 CERBERUS_ADMIT_LOKI=2
 CERBERUS_ADMIT_TEMPO=2
 CERBERUS_CH_MAX_OPEN_CONNS=4
-CERBERUS_CH_QUERY_MAX_MEMORY=2Mi
+CERBERUS_CH_QUERY_MAX_MEMORY=4Mi
 CERBERUS_SOLVER_ADAPTIVE_ENABLED=true


### PR DESCRIPTION
## Summary

- The chaos lane's `route-memo-activation` scenario drives a pinned 24h/15s
  `query_range` shape meant to cross `CERBERUS_CH_QUERY_MAX_MEMORY` and force
  a real ClickHouse `MEMORY_LIMIT_EXCEEDED` (code 241) route-A resource
  failure, so the failure-driven route memo (`internal/routememo`) gets a
  genuine chance to rescue it via route B. In this lane's data volume it
  never actually crossed the 1 GiB production-shaped default, so the
  scenario always fell through to its `memory-cap-not-crossed` /
  not-applicable branch — the drought `chaos-not-applicable-rate.mjs` exists
  to catch (#1537) — instead of ever exercising the mechanism.
- `test/e2e/chaos/manifests/chaos-overlay.env` now pins
  `CERBERUS_CH_QUERY_MAX_MEMORY=4Mi` — sized from real measurements, not a
  guess (see Sizing below) — so the pinned query reliably trips the memory
  cap every run, giving `scenarioRouteMemoActivation`
  (`.github/scripts/chaos-run.mjs`) a genuine route-A resource failure to
  rescue instead of a data-volume coin flip.

Related: #1537 pinned the *rate* at which this scenario (and
`ch-network-partition`) fall through to not-applicable, so a drift to 100%
would be visible; this PR removes the non-determinism at the source for
`route-memo-activation` so the fault reliably fires in the common case. Not
closing that issue — it also covers `ch-network-partition`'s kube-router
enforcement gap, which is unrelated to this change.

## Sizing (measured, not guessed)

Two throwaway diagnostic workflow-dispatch runs (reverted before landing)
measured real `system.query_log` numbers rather than picking a cap value
blind:

- The pinned 24h/15s route-memo query costs **~5.45–5.63 MiB** of real
  ClickHouse memory in this lane's data volume.
- An earlier `2Mi` value looked safe against that number alone but broke the
  lane every run: the chaos lane's own `loki` `HEAD_PROBES` smoke query
  (`{service_name=~".+"}&limit=1`, an *instant* query bounded to a short
  lookback window — `internal/api/loki/handler.go:330` — not a full-table
  scan) measured at **~1.42–1.49 MiB** right after bring-up and ClickHouse
  itself reported *"would use 2.08 MiB, maximum: 2.00 MiB"* about a minute
  later on a freshly-rolled pod — close enough to `2Mi` that
  `assertHeadsHealthy` never saw 200 and the whole lane's preflight gate
  failed before any fault injection, twice, deterministically.
- `4Mi` keeps real margin above that observed ~2.08 MiB peak while staying
  meaningfully below the ~5.5 MiB route-memo cost and two-plus orders of
  magnitude below the 1 GiB production default — confirmed by a full,
  non-diagnostic verification run
  ([32951277790](https://github.com/tsouza/cerberus/actions/runs/32951277790)):
  preflight passed cleanly and every other scenario's own fault injection
  (`ch-slow-query-timeout`, `load-admit-saturation`, `ch-network-partition`,
  `ch-pod-kill`, `cerberus-pod-kill`) fired and asserted correctly.

## Outcome: the drought is fixed; it surfaces a real, separately-tracked bug

`route-memo-activation`'s fault injection now reliably fires a genuine
route-A resource failure every run — the actual point of this PR, and the
thing #1537's drought detector exists to keep honest. It does **not**
resolve to a clean `all resilience contracts held` pass, though: the same
verification run showed the route-B rescue never completes
(`cerberus_route_ab_success_total{route_choice="b"}` never climbs). A deep
dive (full trace + `system.query_log` evidence in the PR discussion) found
this is a real bug candidate in `internal/routememo`'s rescue path — not
something this cap value can fix, and not something this PR should carry —
filed as **#2650**.

That is the honest, better outcome here: before this PR, the lane was
silently green with nothing asserted (a `not-applicable` no-op). After this
PR, the fault reliably fires and the assertion reliably fails **for a real,
now-tracked reason** — never again a silent pass that could mask a real
regression. Chasing a fully-green `chaos` run is #2650's job, not this
PR's; `chaos` is informational (`.github/workflows/e2e.yml`'s own header:
"never a PR gate... caught at merge-to-main and reverted from main, not
blocked pre-merge"), not a branch-protection or release-gate required
check.

## Test plan

- [x] `chaos` job on a dedicated `e2e.yml` workflow-dispatch run against this
      branch's final commit shows `route-memo-activation`'s fault injection
      firing (a genuine 422 memory-limit rejection on route A, every
      attempt) instead of `memory-cap-not-crossed` — confirmed via
      [32951277790](https://github.com/tsouza/cerberus/actions/runs/32951277790)
      and a follow-up diagnostic
      ([32954131867](https://github.com/tsouza/cerberus/actions/runs/32954131867))
- [x] No other chaos scenario's own fault injection regresses under the
      `4Mi` cap (breaker-trip / shed / timeout contracts) — confirmed in the
      same verification run
- [x] The route-B rescue gap is filed as its own issue (#2650) with full
      evidence, not left as an unresolved PR comment
