### PR TITLE
docs(test-strategy): document chdb regression-pin/untagged-companion pairing

### DIFF
--- a/docs/test-strategy.md
+++ b/docs/test-strategy.md
@@ -426,6 +426,46 @@ does round-trip, so the marker cannot decay into a blanket exemption. No
 fixture currently needs it — the pinned chDB substrate clears every floor
 the corpus exercises.
 
+#### Pairing a chdb-only regression pin with an untagged companion
+
+A `chdb`-tagged test runs only on the release gate — the `roundtrip` /
+`probe` lanes on push-to-main, nightly, manual dispatch, or a
+`release/*`-headed PR (see "CI gates" above) — never on an ordinary PR's
+own required `check` lane. So when a real production incident is
+root-caused to a bug that only a real ClickHouse execution can reproduce,
+the direct regression pin for that incident is necessarily `chdb`-tagged
+too, and a future PR that reintroduces the SAME regression is not blocked
+at review time — it only surfaces after merge, on the next push to main
+or the next release PR's full matrix (#2654).
+
+Where the underlying invariant is expressible without a real ClickHouse,
+pair the `chdb`-tagged direct reproduction with a second, plain-`go test`
+companion that pins the same invariant in pure Go — no `chdb` build tag,
+so it runs in every `go test -race ./...` invocation and blocks the
+required `check` gate at PR time. #2651's fix (PR #2653) is the worked
+example: `range_bucket_grid_native_bound_test.go`'s
+`TestRangeBucketGridNativeBound_PassesNearProductionReferenceCardinalityOrdinaryWindow`
+is the `chdb`-tagged direct reproduction — a real ClickHouse execution at
+the exact production shape that tripped the resource bound. Its companion,
+`range_bucket_grid_native_bound_headroom_test.go`'s
+`TestRangeBucketGridNativeBound_AxisOneHasSentinelHeadroom`, asserts the
+same underlying invariant — the calibrated constant
+(`maxRangeBucketGridNativeRows`) keeps a minimum multiple of headroom
+above a reference cardinality — as pure integer division, with no chDB
+dependency at all.
+
+This pairing is not universal. Most chDB-only tests — TXTAR roundtrip
+fixtures, live reference parity, the compat corpora — assert row-level or
+wire-level correctness that genuinely needs a real ClickHouse execution
+and has no untagged equivalent. The pattern applies narrowly, to a
+resource-bound or calibration-constant regression whose invariant is
+itself pure arithmetic (a constant's ratio to a reference value, a
+threshold's distance from a measured cliff) — #2651's class, not the
+general case. It is a convention enforced by reviewer discipline, not a
+CI gate: #2654 evaluated a structural check in the spirit of
+`forbid-skip.mjs` and concluded the signal is not precise enough to be
+worth one — see that issue's closing PR for the reasoning.
+
 #### The chdb lane and the race detector
 
 Every chdb-tagged test binary loads libchdb.so — an embedded ClickHouse —


### PR DESCRIPTION
## What

Documents the pairing convention #2654 identified: when a real production
incident is root-caused to a `chdb`-tagged test — the only kind that can
reproduce it, because it needs a real ClickHouse execution — the direct
regression pin for that incident is necessarily `chdb`-tagged too, and
`chdb`-tagged tests only run on the release gate (push-to-main, nightly,
dispatch, or a `release/*`-headed PR), never on an ordinary PR's own
required `check` lane. A future PR reintroducing the same regression
therefore surfaces only after merge unless the fix also pins the invariant
in a plain-`go test` companion.

PR #2653 (closes #2651) did exactly that as its own author's judgment call,
not because any convention required it: alongside the necessarily
`chdb`-tagged direct reproduction
(`TestRangeBucketGridNativeBound_PassesNearProductionReferenceCardinalityOrdinaryWindow`),
it added a second, plain-`go test` companion
(`TestRangeBucketGridNativeBound_AxisOneHasSentinelHeadroom`,
`internal/chsql/range_bucket_grid_native_bound_headroom_test.go`) asserting
the same underlying invariant — the calibrated constant keeps real headroom
above the reference sample — as pure integer arithmetic, no chDB needed.
That companion runs in the required `check` gate and genuinely blocks a
future PR from reintroducing this exact class of miscalibration.

This PR adds a new `#### Pairing a chdb-only regression pin with an
untagged companion` subsection to `docs/test-strategy.md`'s Layer 6 (chDB
roundtrip) guidance, next to the layer's other test-authoring notes,
citing #2653's pairing as the worked example and stating the expectation
plainly: pair a chDB-only regression pin with an untagged companion
wherever the invariant is expressible without a real ClickHouse.

## Structural check: evaluated, not built

#2654 also asked to evaluate a lightweight script (in the spirit of
`forbid-skip.mjs`'s registry-scanning approach) that flags a PR adding or
modifying a `//go:build chdb` test file that touches a
resource-bound/calibration constant with no untagged companion touching
the same constant. Two problems make the signal too imprecise to be worth
a gate:

1. **"Resource-bound/calibration constant" is not syntactically
   identifiable.** Invariant 13 (no magic constants) means every
   meaning-bearing numeric literal in the repository is already a named
   `const`, most with `max*`/`min*`-style names, for reasons that have
   nothing to do with chDB calibration (timeouts, batch sizes, iteration
   caps, buffer sizes). A name-pattern heuristic broad enough to catch
   `maxRangeBucketGridNativeRows` would also catch most of the codebase's
   ordinary constants; a heuristic narrow enough to avoid that would just
   be an allowlist of the one file this issue already found.
2. **Even given a correctly identified constant, "no untagged test
   touches it" doesn't mean one is missing.** The overwhelming majority
   of `chdb`-tagged tests — the TXTAR roundtrip corpus, live reference
   parity, the compatibility harnesses — assert row-level or wire-level
   correctness that genuinely needs a real ClickHouse execution and has
   no untagged equivalent by construction. Only the narrow class #2651
   exemplifies — a resource bound whose invariant reduces to pure
   arithmetic (a constant's ratio to a reference value, a threshold's
   distance from a measured cliff) — has a natural cheap companion at
   all. Distinguishing "this chdb test's invariant IS expressible in
   plain Go" from "this chdb test fundamentally needs a live engine"
   requires understanding what's being tested, not just its syntax or
   its build tag — exactly the judgment call #2653's author made by hand.

A broad heuristic would mostly flag legitimate chDB-only tests that have
no sensible untagged equivalent; a narrow one would provide negligible
value beyond the documentation change itself. So this PR ships the
documentation only.

## Test plan

- [x] `just lint-md` — clean
- [x] `node .github/scripts/doc-counts.mjs` — layer count still 14, all
      doc-stated counts match source
- [x] `node .github/scripts/doc-refs.mjs` — all cited code paths exist
- [x] Verified the new prose contains no `forbid-deferral` marker matches

Closes #2654
