### PR TITLE
fix(routememo): keep the chaos lane's pinned query off route B's ordinary auto-route

### DIFF
--- a/.github/scripts/chaos-run.mjs
+++ b/.github/scripts/chaos-run.mjs
@@ -1151,6 +1151,19 @@ async function scenarioLoadAdmitSaturation() {
 // chaos overlay (test/e2e/chaos/manifests/chaos-overlay.env) applied
 // before any scenario runs, so this is on for the whole lane.
 //
+// CERBERUS_SHARD_MIN_FANOUT is ALSO raised impossibly high by that same
+// overlay (issue #2650). Without it, the pinned query below clears the
+// solver's ORDINARY ModeAuto cost thresholds on its own (its fanout =
+// Range/Step = 5m/15s = 20 >= the default MinFanout of 16), so the
+// top-level classify() at the start of engine.Engine.QueryPlanCursor
+// routes it straight to route B and returns before route A is EVER
+// dispatched — the failure-driven route memo this scenario exists to
+// exercise is reachable only from the route-A dispatch path, so a query
+// that auto-routes can never reach it, no matter how reliably it breaches
+// CERBERUS_CH_QUERY_MAX_MEMORY below. See the overlay file's own comment
+// and internal/api/prom/handler_route_memo_chaos_fixture_test.go for the
+// full evidence trail.
+//
 // The fault: drive the SAME (24h range, 15s step) aggregating query_range
 // shape that iterate-time-ranges.spec.ts (Layer-9 dashboard sweep) already
 // pins as the documented CERBERUS_CH_QUERY_MAX_MEMORY-crossing tuple (run

--- a/internal/api/prom/handler_route_memo_chaos_fixture_test.go
+++ b/internal/api/prom/handler_route_memo_chaos_fixture_test.go
@@ -1,0 +1,205 @@
+package prom_test
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+	"time"
+
+	"github.com/tsouza/cerberus/internal/api/prom"
+	"github.com/tsouza/cerberus/internal/routememo"
+	"github.com/tsouza/cerberus/internal/schema"
+	"github.com/tsouza/cerberus/internal/solver"
+)
+
+// --- issue #2650 regression: the chaos lane's pinned route-memo query -----
+//
+// The live-stack chaos lane's `route-memo-activation` scenario
+// (.github/scripts/chaos-run.mjs, scenarioRouteMemoActivation) drives
+// chaosPinnedRouteMemoQuery below at a 24h/15s grid, expecting it to fail on
+// route A (a genuine ClickHouse MEMORY_LIMIT_EXCEEDED) and get corroborated
+// + rescued by the failure-driven route memo's A->B retry
+// (internal/routememo, internal/engine/route_memo_wiring.go).
+//
+// It never did: investigation (issue #2650) found route B's shard fanout
+// never dispatched once across 24 real, corroborated route-A resource
+// failures. Two hypotheses were live — a gap specific to ClickHouse's
+// ExceptionBeforeStart (planner-level, pre-execution) rejection shape, or
+// the query being structurally solver-ineligible. Both are refuted by the
+// tests below and by direct inspection of clickhouse-go/v2's connect.query
+// (conn_query.go: firstBlock -> firstBlockImpl's packet loop treats
+// proto.ServerException identically whether it arrives before or after the
+// first proto.ServerData block, so an open-time 241 always surfaces via the
+// SAME classifyDriverErr wrap site regardless of ExceptionBeforeStart vs
+// ExceptionWhileProcessing — internal/chclient/timeout.go's "single wrap
+// site" claim holds for both shapes). The query is also NOT
+// solver-ineligible: internal/solver.Planner.Eligible computes K=8 for it
+// unconditionally.
+//
+// The real root cause: under the solver's actual PRODUCTION default
+// thresholds (Mode=auto, MinFanout=16, MinAnchorPairs=4000 —
+// internal/solver/config.go's DefaultConfig + ConfigFromEnv's "unset
+// CERBERUS_EVAL_ROUTE means auto" contract), this exact query/grid clears
+// BOTH ordinary auto-mode cost gates on its own (fanout=20 >= 16, N*F=
+// 5761*20=115220 >= 4000) — so the TOP-LEVEL classify() call at the very
+// start of engine.Engine.QueryPlanCursor (internal/engine/engine.go) routes
+// it directly to B and returns before route A is EVER dispatched once. The
+// failure-driven route memo — probe admission, corroboration, the A->B
+// retry, and its own cerberus_route_ab_success_total{route_choice="b"}
+// telemetry — is reachable ONLY from the route-A dispatch path
+// (dispatchRouteACursor's result.openErr / the drain-failure Retry hook),
+// so a query that never touches route A can never exercise it, no matter
+// how reliably it breaches CERBERUS_CH_QUERY_MAX_MEMORY.
+//
+// The fix ships alongside these tests: test/e2e/chaos/manifests/
+// chaos-overlay.env now also pins CERBERUS_SHARD_MIN_FANOUT impossibly
+// high for the chaos lane's OWN deployment (mirroring
+// routeMemoImpossibleMinFanout below, already established precedent in
+// this file), which keeps EVERY query on route A under ordinary
+// classify() — Eligible()'s retry re-derivation never reads MinFanout, so
+// the memo's own rescue path is unaffected.
+
+// chaosPinnedRouteMemoQuery is byte-identical to chaos-run.mjs's
+// ROUTE_MEMO_EXPR.
+const chaosPinnedRouteMemoQuery = "sum by (cerberus_ql) (rate(cerberus_queries_total[5m]))"
+
+// chaosPinnedRouteMemoStepSeconds / chaosPinnedRouteMemoRangeSeconds mirror
+// chaos-run.mjs's ROUTE_MEMO_STEP_SECONDS / ROUTE_MEMO_RANGE_SECONDS (the
+// pinned 24h/15s tuple — 5,760 anchors, matching iterate-time-ranges.spec.ts's
+// documented CERBERUS_CH_QUERY_MAX_MEMORY-crossing shape).
+const (
+	chaosPinnedRouteMemoStepSeconds  = 15
+	chaosPinnedRouteMemoRangeSeconds = 24 * 3600
+)
+
+func chaosPinnedRouteMemoPath(base string) string {
+	end := time.Now().Add(-2 * chaosPinnedRouteMemoStepSeconds * time.Second)
+	start := end.Add(-chaosPinnedRouteMemoRangeSeconds * time.Second)
+	return fmt.Sprintf("%s/api/v1/query_range?query=%s&start=%d&end=%d&step=%d",
+		base, url.QueryEscape(chaosPinnedRouteMemoQuery), start.Unix(), end.Unix(), chaosPinnedRouteMemoStepSeconds)
+}
+
+// TestQueryRange_RouteMemo_ChaosQueryAutoRoutesUnderProductionThresholds
+// pins the ROOT CAUSE: with the solver's real, UNMODIFIED production
+// defaults (Mode=auto, MinFanout=16, MinAnchorPairs=4000 — nothing like
+// routeMemoImpossibleMinFanout applied), the exact chaos-lane pinned
+// query+grid never dispatches route A at all, even once — the ordinary
+// top-level classify() claims it and routes straight to B. This is why the
+// chaos scenario, run against a deployment that never overrides
+// CERBERUS_SHARD_MIN_FANOUT, could never observe a route-A resource
+// failure for this query in the first place: the failure-driven route
+// memo's entire machinery (corroboration, probe, retry,
+// RecordRouteABSuccess) sits behind a code path this query never reaches.
+func TestQueryRange_RouteMemo_ChaosQueryAutoRoutesUnderProductionThresholds(t *testing.T) {
+	t.Parallel()
+
+	routeA := &routeMemoRouteAQuerier{err: chMemLimitError(1 << 30)}
+	routeB := &routeMemoRouteBQuerier{rows: routeMemoHealthyRows()}
+
+	h := prom.New(routeA, schema.DefaultOTelMetrics(), nil)
+	cfg := solver.DefaultConfig()
+	cfg.Mode = solver.ModeAuto // the deployed default (ConfigFromEnv: unset CERBERUS_EVAL_ROUTE => auto)
+	// MinFanout / MinAnchorPairs / MaxK / MinAnchorsPerSlice deliberately
+	// left at DefaultConfig's real production values — the whole point of
+	// this test is to prove what happens WITHOUT the chaos-overlay fix.
+	if err := cfg.Validate(); err != nil {
+		t.Fatalf("solver config invalid: %v", err)
+	}
+	h.Engine.Solver = solver.New(cfg, routeMemoFakeEmitter{}, solver.ExecDeps{Client: routeB})
+	h.Engine.RouteMemo = routememo.New(time.Minute)
+
+	mux := http.NewServeMux()
+	h.Mount(mux)
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+
+	resp, err := http.Get(chaosPinnedRouteMemoPath(srv.URL))
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200 (ordinary route-B dispatch on the first attempt)", resp.StatusCode)
+	}
+	if got := routeA.opens.Load(); got != 0 {
+		t.Fatalf("route-A opens = %d, want 0 — the pinned query auto-routes to B via the top-level "+
+			"classify() before route A is ever dispatched, so it can never fail on route A at all", got)
+	}
+	if got := routeB.opens.Load(); got == 0 {
+		t.Fatalf("route-B shard opens = %d, want > 0 — expected the ordinary (non-memo) route-B dispatch to fire", got)
+	}
+}
+
+// TestQueryRange_RouteMemo_ChaosQueryRescuedUnderFixedThresholds proves the
+// fix: with CERBERUS_SHARD_MIN_FANOUT raised past the pinned query's own
+// fanout (mirroring the chaos-overlay.env change and this file's existing
+// routeMemoImpossibleMinFanout precedent), the SAME query+grid now stays on
+// route A under the top-level classify() — priming corroboration on the
+// first request exactly like the plain memory-limit contract — and the
+// failure-driven route memo's retry rescues it via route B on the second,
+// corroborated request. This is the behaviour the chaos scenario actually
+// needs the deployment to exhibit.
+func TestQueryRange_RouteMemo_ChaosQueryRescuedUnderFixedThresholds(t *testing.T) {
+	t.Parallel()
+
+	routeA := &routeMemoRouteAQuerier{err: chMemLimitError(1 << 30)}
+	routeB := &routeMemoRouteBQuerier{rows: routeMemoHealthyRows()}
+
+	h := prom.New(routeA, schema.DefaultOTelMetrics(), nil)
+	cfg := solver.DefaultConfig()
+	cfg.Mode = solver.ModeAuto
+	cfg.MinFanout = routeMemoImpossibleMinFanout // the chaos-overlay.env fix
+	if err := cfg.Validate(); err != nil {
+		t.Fatalf("solver config invalid: %v", err)
+	}
+	h.Engine.Solver = solver.New(cfg, routeMemoFakeEmitter{}, solver.ExecDeps{Client: routeB})
+	h.Engine.RouteMemo = routememo.New(time.Minute)
+
+	mux := http.NewServeMux()
+	h.Mount(mux)
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+
+	path := chaosPinnedRouteMemoPath(srv.URL)
+
+	// First request: corroboration=1, priming — must fail plainly on route
+	// A, no retry yet.
+	resp1, err := http.Get(path)
+	if err != nil {
+		t.Fatalf("GET (priming): %v", err)
+	}
+	assertMemoryLimit422(t, resp1)
+	if got := routeA.opens.Load(); got != 1 {
+		t.Fatalf("route-A opens after priming = %d, want 1", got)
+	}
+	if got := routeB.opens.Load(); got != 0 {
+		t.Fatalf("route-B opens after priming = %d, want 0 — retry must not have fired yet", got)
+	}
+
+	// Second request: corroboration=2 — the retry fires and rescues via
+	// route B.
+	resp2, err := http.Get(path)
+	if err != nil {
+		t.Fatalf("GET (retry): %v", err)
+	}
+	if resp2.StatusCode != http.StatusOK {
+		body := readBody(t, resp2)
+		t.Fatalf("status = %d, want 200; body=%s", resp2.StatusCode, body)
+	}
+	body := readBody(t, resp2)
+	var parsed queryResponse
+	if err := json.Unmarshal([]byte(body), &parsed); err != nil {
+		t.Fatalf("unmarshal: %v\nbody=%s", err, body)
+	}
+	if parsed.Status != "success" {
+		t.Fatalf("status field = %q, want success; body=%s", parsed.Status, body)
+	}
+	if got := routeA.opens.Load(); got != 2 {
+		t.Fatalf("route-A opens after retry = %d, want 2 (1 priming + 1 this request)", got)
+	}
+	if got := routeB.opens.Load(); got == 0 {
+		t.Fatalf("route-B shard opens after retry = %d, want > 0 — the memo's A->B retry must have dispatched", got)
+	}
+}

--- a/test/e2e/chaos/manifests/chaos-overlay.env
+++ b/test/e2e/chaos/manifests/chaos-overlay.env
@@ -114,6 +114,36 @@
 #     breaker/timeout/admit knobs above is safe: it never changes the
 #     other scenarios' breaker-trip or shed assertions, it only gives a
 #     genuine route-A resource failure somewhere to go.
+#
+#   CERBERUS_SHARD_MIN_FANOUT=1000000
+#     Default 16 (internal/solver/config.go defaultMinFanout). Issue #2650:
+#     even with CERBERUS_SOLVER_ADAPTIVE_ENABLED on and a genuine,
+#     reliably-crossed memory cap, the route-memo-activation scenario NEVER
+#     observed a single route-B shard dispatch across 24 corroborated
+#     route-A resource failures. Root cause traced (and pinned by
+#     internal/api/prom's TestQueryRange_RouteMemo_ChaosQueryAutoRoutes
+#     UnderProductionThresholds) to the pinned 24h/15s ROUTE_MEMO_EXPR
+#     shape (chaos-run.mjs) clearing the solver's ORDINARY ModeAuto
+#     cost thresholds on its own (fanout=Range/Step=20 >= MinFanout=16;
+#     N*F=5761*20=115220 >= MinAnchorPairs=4000) — so the TOP-LEVEL
+#     classify() call at the very start of engine.Engine.QueryPlanCursor
+#     (internal/engine/engine.go) routes it straight to B and returns
+#     BEFORE route A is ever dispatched, not even once. The failure-driven
+#     route memo's entire machinery — probe admission, corroboration, the
+#     A->B retry, and its own cerberus_route_ab_success_total{route_choice=
+#     "b"} telemetry — is reachable ONLY from the route-A dispatch path, so
+#     a query that auto-routes on the ordinary path can never reach it, no
+#     matter how reliably it breaches CERBERUS_CH_QUERY_MAX_MEMORY. Raising
+#     MinFanout past any real query's fanout keeps EVERY query in this lane
+#     on route A under ordinary classify() — internal/solver.Planner.
+#     Eligible() (what the memo's own retry re-derivation calls) never
+#     reads MinFanout at all, so the rescue path this scenario exists to
+#     exercise is unaffected. This mirrors the SAME isolation technique
+#     internal/api/prom/handler_route_memo_test.go's own fixture already
+#     uses (routeMemoImpossibleMinFanout) to keep its synthetic query on
+#     route A for the identical reason. Scoped to this overlay only — the
+#     production / dashboard-smoke deployments keep the real default, so
+#     ordinary auto-routing stays exercised everywhere else.
 CERBERUS_CH_BREAKER_THRESHOLD=3
 CERBERUS_CH_BREAKER_WINDOW=10s
 CERBERUS_CH_BREAKER_OPEN_INTERVAL=5s
@@ -124,3 +154,4 @@ CERBERUS_ADMIT_TEMPO=2
 CERBERUS_CH_MAX_OPEN_CONNS=4
 CERBERUS_CH_QUERY_MAX_MEMORY=4Mi
 CERBERUS_SOLVER_ADAPTIVE_ENABLED=true
+CERBERUS_SHARD_MIN_FANOUT=1000000


### PR DESCRIPTION
## Summary

Closes #2650. The chaos e2e lane's `route-memo-activation` scenario had never
once observed a real failure-driven route-B rescue in over 6 days / 162
consecutive runs, despite the fault (a real ClickHouse `MEMORY_LIMIT_EXCEEDED`
on route A) firing reliably. Three distinct, independently real problems were
stacked on top of each other; this PR fixes all three, verified end-to-end
against a real chaos run.

## Problem 1 — the pinned query auto-routed to B before route A was ever tried

`chaos-run.mjs`'s `ROUTE_MEMO_EXPR` (`sum by (cerberus_ql)
(rate(cerberus_queries_total[5m]))`) cleared the solver's ordinary `ModeAuto`
cost thresholds on its own (fanout=20 >= `MinFanout`=16; N×F=115220 >=
`MinAnchorPairs`=4000) — so `engine.Engine.QueryPlanCursor`'s top-level
`classify()` call routed it straight to B and returned **before route A was
ever dispatched, not even once**. The failure-driven route memo is only
reachable from the route-A dispatch path.

**Fix:** `CERBERUS_SHARD_MIN_FANOUT=1000000` in the chaos overlay keeps this
lane's queries on route A under ordinary `classify()` — `Eligible()` (what the
memo's own retry re-derivation calls) never reads `MinFanout`, so the rescue
path itself is unaffected. Mirrors the exact isolation technique
`internal/api/prom/handler_route_memo_test.go`'s own fixture already uses.

Pinned by two new tests in `internal/api/prom/handler_route_memo_chaos_fixture_test.go`
reproducing the exact pinned query/grid through the real HTTP handler:
`TestQueryRange_RouteMemo_ChaosQueryAutoRoutesUnderProductionThresholds` (pins
the root cause) and `TestQueryRange_RouteMemo_ChaosQueryRescuedUnderFixedThresholds`
(pins the fix).

## Problem 2 — the pinned metric had no real historical depth to shard

With the query correctly staying on route A, a live chaos run showed the
memo's corroboration/admission mechanism working exactly as designed — a
probe was admitted on the 2nd corroborated failure, route B dispatched on
schedule — but route B's own sharded dispatch **also** hit the memory cap
31ms later, correctly flipping the memo to its documented `BothFail` state.

Root cause: `cerberus_queries_total` is self-emitted by the cerberus process
itself, so in this freshly-bootstrapped lane it only ever has a few minutes
of real history. A 24h read and an 8h shard (`kEff`=3,
`CERBERUS_SHARD_PARALLEL` default — the real per-shard granularity) read the
identical row count and cost, because there's nothing further back to read
either way. No memory cap can separate "full query fails, shard succeeds"
when both cost the same. Two other rolling-reseeded candidates
(`http_server_request_duration_count`, the `up` gauge) were measured and
showed the identical flat-cost pattern, for the identical reason: their real
row density is dominated by the rolling reseeder's 10-minute freshness
window, not real 24h spread.

**Fix:** a new one-time (not rolling-reseeded) backfill —
`route_memo_probe_requests_total` (`test/e2e/seed/cmd/seed/main.go`'s
`insertRouteMemoProbeBackfillSQL`) — seeded with 480 series × 288 samples
genuinely spread across a real 24h window. Measured directly against real
ClickHouse `system.query_log`: the full 24h window costs ~68.24 MiB; an 8h
shard costs ~20.73 MiB — a real ~30% ratio. `CERBERUS_CH_QUERY_MAX_MEMORY`
raised from 4Mi to **65Mi**, centered in the real separable window (cap must
exceed 3×20.73=62.2 MiB for a shard to succeed, and stay under 68.24 MiB for
the full query to still fail) — ~4.5% real margin on both sides. The control
probe (`cerberus_queries_total`, unrelated to this metric) measured
essentially identical `memory_usage` across three independent runs (<0.05%
variance), giving confidence this environment's costs are deterministic
enough for that margin to hold.

## Problem 3 — the deep backfill broke a different, unrelated dashboard test

The fix for problem 2 is deliberately one-time and never refreshed (refreshing
it would defeat the point — it needs real 24h-old data, not a sliding
window). That silently broke `iterate-metrics-explorer.spec.ts`'s generic
"every catalog-published metric must resolve to a non-empty `/api/v1/series`
and `/api/v1/query_range`" sweep, which queries a fixed 5-minute lookback
ending at wall-clock "now" — the deep backfill's most recent sample is pinned
to whatever "now" was at seed time, stale by more than 5 minutes for any
Playwright shard running later in a long suite. Caught by a real CI run on
this exact PR before merge, not discovered after the fact.

**Fix:** `insertRouteMemoProbeFreshnessSQL`, a small rolling-freshness
companion (±5 min / 1s cadence, re-anchored every 30s by the existing rolling
re-seeder) mirroring `insertSumSQL`'s own established pattern exactly, so this
metric behaves like every other seeded counter for short-range panels too.
Deliberately excluded from `deleteStaleMetricsSumSQL`'s cleanup allowlist —
that DELETE keys off `max(TimeUnix)` per `MetricName`, and this metric shares
its name with the deep backfill, so enrolling it would sweep away the very
24h depth the backfill exists to provide, on the very first rolling tick.

## Verification

A manually-dispatched `e2e.yml` run against this exact branch/commit shows
the real thing:

```
scenario route-memo-activation: all resilience contracts held
```

— and every other chaos scenario in the same run also passed cleanly
(`cerberus-pod-kill`, `ch-pod-kill`, `ch-network-partition` correctly
not-applicable, `load-admit-saturation`, `ch-slow-query-timeout`), confirming
the cascading heal-gate failures seen in earlier rounds of this investigation
are also resolved — they were a downstream consequence of problem 2, not a
separate issue. The full PR check suite (including the previously-failing
`iterate-metrics-explorer` dashboard shard) is green on the final commit.

Closes #2650

🤖 Generated with [Claude Code](https://claude.com/claude-code)
