### PR TITLE
fix(deltaprefix): detect and warn on backfill days already past the aggregate table's TTL

### DIFF
--- a/cmd/cerberus/cmd_schema.go
+++ b/cmd/cerberus/cmd_schema.go
@@ -15,6 +15,7 @@ import (
 	"github.com/tsouza/cerberus/internal/config"
 	"github.com/tsouza/cerberus/internal/deltaprefix"
 	"github.com/tsouza/cerberus/internal/migrateverify"
+	"github.com/tsouza/cerberus/internal/schemaboot"
 )
 
 // errNoSchemaSubcommand is returned when `cerberus schema` is invoked bare.
@@ -139,7 +140,13 @@ func newSchemaDeltaPrefixBackfillCmd() *cobra.Command {
 			"a calendar day: since an MV is almost always created mid-day, day-\n" +
 			"rounding would leave every row between midnight and the MV's real\n" +
 			"creation instant uncaptured by both this backfill and the live MV — see\n" +
-			"docs/operations.md's DELTA-prefix backfill runbook.",
+			"docs/operations.md's DELTA-prefix backfill runbook. Run this AS SOON AS\n" +
+			"POSSIBLE after creating the table/MV: a day already past the target\n" +
+			"table's own TTL (CERBERUS_SCHEMA_TTL_METRICS) as of the moment this runs\n" +
+			"is written, then reaped by ClickHouse's own background merge almost\n" +
+			"immediately — permanently unrecoverable by any re-run. This command\n" +
+			"detects that case and prints a WARNING (not an error) listing the\n" +
+			"affected day(s) rather than succeeding silently.",
 		Example:       "  cerberus schema delta-prefix-backfill --before 2026-08-20T14:32:10Z",
 		Args:          cobra.NoArgs,
 		SilenceUsage:  true,
@@ -181,18 +188,45 @@ func runDeltaPrefixBackfill(cmd *cobra.Command, in deltaPrefixBackfillInputs) er
 		return nil
 	}
 
+	retention := schemaboot.MetricsRetention(cfg)
+
 	client, err := chclient.New(cfg.ClickHouse)
 	if err != nil {
 		return fmt.Errorf("connect ClickHouse: %w", err)
 	}
 	defer func() { _ = client.Close() }()
 
-	if err := deltaprefix.Backfill(context.Background(), client.Conn(), cols, before); err != nil {
+	result, err := deltaprefix.Backfill(context.Background(), client.Conn(), cols, before, retention)
+	if err != nil {
 		return err
 	}
 	fmt.Fprintf(cmd.OutOrStdout(), "backfilled %s from %s (rows strictly before %s)\n",
 		cols.DeltaPrefixTable, cols.SumTable, before.Format(time.RFC3339))
+	if len(result.OutsideRetentionDays) > 0 {
+		writeOutsideRetentionWarning(cmd.OutOrStdout(), cols.DeltaPrefixTable, result.OutsideRetentionDays)
+	}
 	return nil
+}
+
+// writeOutsideRetentionWarning prints a loud, explicit warning (cerberus
+// issue #2652) when Backfill detects it wrote — or is about to have
+// written — rows for a day already outside the target table's own TTL:
+// ClickHouse's background merge reaps rows like these almost immediately,
+// often before delta-prefix-verify even runs, and no re-run of the
+// backfill can ever recover them. This is deliberately NOT surfaced as an
+// error (runDeltaPrefixBackfill still returns nil): the operator may have
+// already accepted the loss for these days, or be intentionally
+// re-running to pick up the still-recoverable ones — but silent success
+// with zero signal, the behavior before this fix, is never acceptable.
+func writeOutsideRetentionWarning(w io.Writer, table string, days []time.Time) {
+	fmt.Fprintf(w, "\nWARNING: %d day(s) backfilled into %s are ALREADY outside its own retention TTL "+
+		"as of now — ClickHouse's background merge will reap these rows almost immediately, likely before "+
+		"delta-prefix-verify runs. This is NOT fixable by re-running the backfill: the constraint is the "+
+		"row's own age, not the write path. See docs/operations.md's DELTA-prefix backfill runbook.\n",
+		len(days), table)
+	for _, d := range days {
+		fmt.Fprintf(w, "  - %s\n", d.Format(time.DateOnly))
+	}
 }
 
 // deltaPrefixVerifyInputs carries newSchemaDeltaPrefixVerifyCmd's resolved
@@ -231,7 +265,12 @@ func newSchemaDeltaPrefixVerifyCmd() *cobra.Command {
 			"CERBERUS_SCHEMA_DELTA_PREFIX_ENABLED=true. This is a per-metric\n" +
 			"COMPLETENESS check (did every DELTA row get backfilled), not a per-series\n" +
 			"identity-alignment check — see internal/deltaprefix's package doc for the\n" +
-			"scope boundary against cerberus issue #2389's still-open read-side task.",
+			"scope boundary against cerberus issue #2389's still-open read-side task.\n" +
+			"Any day already past the target table's own TTL\n" +
+			"(CERBERUS_SCHEMA_TTL_METRICS) as of this run is EXCLUDED from the\n" +
+			"comparison and reported separately as a labeled NOTE, never as an\n" +
+			"unexplained FAIL: that day's data cannot be backfilled by any means —\n" +
+			"see docs/operations.md's DELTA-prefix backfill runbook.",
 		Example:       "  cerberus schema delta-prefix-verify --before 2026-08-20T14:32:10Z",
 		Args:          cobra.NoArgs,
 		SilenceUsage:  true,
@@ -281,7 +320,8 @@ func runDeltaPrefixVerify(cmd *cobra.Command, in deltaPrefixVerifyInputs) error 
 		return err
 	}
 
-	rep, err := deltaprefix.Verify(context.Background(), client.Conn(), cols, before, in.tolerance)
+	retention := schemaboot.MetricsRetention(cfg)
+	rep, err := deltaprefix.Verify(context.Background(), client.Conn(), cols, before, in.tolerance, retention)
 	if err != nil {
 		return err
 	}
@@ -303,16 +343,42 @@ func writeDeltaPrefixVerifyReport(w io.Writer, rep deltaprefix.Report, asJSON bo
 	if rep.Pass() {
 		fmt.Fprintf(w, "PASS: %d metric(s) matched within tolerance %g (before %s)\n",
 			len(rep.AggregateTotals), rep.Tolerance, rep.Before.Format(time.RFC3339))
-		return nil
+	} else {
+		fmt.Fprintf(w, "FAIL: %d of %d metric(s) mismatched (tolerance %g, before %s)\n\n",
+			len(rep.Mismatches), len(unionMetricNames(rep)), rep.Tolerance, rep.Before.Format(time.RFC3339))
+		tw := tabwriter.NewWriter(w, 0, 2, 2, ' ', 0)
+		fmt.Fprintln(tw, "METRIC\tAGGREGATE\tBASE\tDIFF")
+		for _, m := range rep.Mismatches {
+			fmt.Fprintf(tw, "%s\t%g\t%g\t%g\n", m.MetricName, m.Aggregate, m.Base, m.Diff())
+		}
+		if err := tw.Flush(); err != nil {
+			return err
+		}
 	}
-	fmt.Fprintf(w, "FAIL: %d of %d metric(s) mismatched (tolerance %g, before %s)\n\n",
-		len(rep.Mismatches), len(unionMetricNames(rep)), rep.Tolerance, rep.Before.Format(time.RFC3339))
-	tw := tabwriter.NewWriter(w, 0, 2, 2, ' ', 0)
-	fmt.Fprintln(tw, "METRIC\tAGGREGATE\tBASE\tDIFF")
-	for _, m := range rep.Mismatches {
-		fmt.Fprintf(tw, "%s\t%g\t%g\t%g\n", m.MetricName, m.Aggregate, m.Base, m.Diff())
+	writeOutsideRetentionNote(w, rep)
+	return nil
+}
+
+// writeOutsideRetentionNote appends a clearly LABELED, separate notice —
+// never folded into the PASS/FAIL line or the mismatch table above — when
+// Verify excluded one or more days from the comparison because they are
+// already outside the DeltaPrefixTable's own retention window as of the
+// check's run time (cerberus issue #2652). An "outside retention, cannot
+// be backfilled" day is categorically different from a genuine
+// completeness gap: it can never be turned into a PASS by any backfill
+// re-run, so reporting it as an unexplained mismatch would be actively
+// misleading. See docs/operations.md's DELTA-prefix backfill runbook.
+func writeOutsideRetentionNote(w io.Writer, rep deltaprefix.Report) {
+	if len(rep.OutsideRetentionDays) == 0 {
+		return
 	}
-	return tw.Flush()
+	fmt.Fprintf(w, "\nNOTE: %d day(s) already outside the aggregate table's retention window "+
+		"(retention %s, boundary %s), cannot be backfilled — see docs/operations.md's DELTA-prefix "+
+		"backfill runbook. EXCLUDED from the comparison above (not counted as a mismatch):\n",
+		len(rep.OutsideRetentionDays), rep.Retention, rep.RetentionBoundary.Format(time.RFC3339))
+	for _, d := range rep.OutsideRetentionDays {
+		fmt.Fprintf(w, "  - %s\n", d.Format(time.DateOnly))
+	}
 }
 
 // unionMetricNames is the total distinct metric-name population Verify

--- a/cmd/cerberus/cmd_schema_test.go
+++ b/cmd/cerberus/cmd_schema_test.go
@@ -2,8 +2,12 @@ package main
 
 import (
 	"bytes"
+	"encoding/json"
 	"strings"
 	"testing"
+	"time"
+
+	"github.com/tsouza/cerberus/internal/deltaprefix"
 )
 
 // TestSchema_BareInvocationIsError pins that `cerberus schema` with no verb
@@ -177,5 +181,137 @@ func TestDeltaPrefixBackfill_NotOptedInIsError(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "DeltaPrefixTable") {
 		t.Errorf("error should name the missing DeltaPrefixTable, got: %v", err)
+	}
+}
+
+// testVerifyReport builds a deltaprefix.Report with an outside-retention
+// day, so writeDeltaPrefixVerifyReport's tests below can drive both the
+// PASS and FAIL branches with the SAME excluded-day shape.
+func testVerifyReport(mismatches []deltaprefix.Mismatch, aggregate, base map[string]float64) deltaprefix.Report {
+	return deltaprefix.Report{
+		Before:               time.Date(2026, 8, 20, 12, 0, 0, 0, time.UTC),
+		Tolerance:            0.01,
+		AggregateTotals:      aggregate,
+		BaseTotals:           base,
+		Mismatches:           mismatches,
+		Retention:            24 * time.Hour,
+		RetentionBoundary:    time.Date(2026, 8, 25, 12, 0, 0, 0, time.UTC),
+		OutsideRetentionDays: []time.Time{time.Date(2026, 8, 20, 0, 0, 0, 0, time.UTC)},
+	}
+}
+
+// TestWriteDeltaPrefixVerifyReport_PassWithOutsideRetentionNote confirms
+// cerberus issue #2652's core CLI requirement: a PASS report that excluded
+// an outside-retention day prints a clearly LABELED, separate NOTE — never
+// folded into an unexplained FAIL, and never silently dropped either.
+func TestWriteDeltaPrefixVerifyReport_PassWithOutsideRetentionNote(t *testing.T) {
+	rep := testVerifyReport(nil, map[string]float64{"m": 10}, map[string]float64{"m": 10})
+	var buf bytes.Buffer
+	if err := writeDeltaPrefixVerifyReport(&buf, rep, false); err != nil {
+		t.Fatalf("writeDeltaPrefixVerifyReport: %v", err)
+	}
+	got := buf.String()
+	if !strings.Contains(got, "PASS:") {
+		t.Errorf("expected a PASS line, got: %q", got)
+	}
+	if strings.Contains(got, "FAIL") {
+		t.Errorf("an outside-retention day must never fold into an unexplained FAIL, got: %q", got)
+	}
+	if !strings.Contains(got, "NOTE:") || !strings.Contains(got, "outside the aggregate table's retention window") {
+		t.Errorf("expected a separate outside-retention NOTE, got: %q", got)
+	}
+	if !strings.Contains(got, "cannot be backfilled") || !strings.Contains(got, "docs/operations.md") {
+		t.Errorf("NOTE should point the operator at the runbook, got: %q", got)
+	}
+	if !strings.Contains(got, "2026-08-20") {
+		t.Errorf("NOTE should list the excluded day, got: %q", got)
+	}
+}
+
+// TestWriteDeltaPrefixVerifyReport_FailKeepsOutsideRetentionNoteSeparate
+// confirms a GENUINE mismatch still prints the ordinary FAIL table, with
+// the outside-retention NOTE appended afterward as a visibly distinct
+// section rather than mixed into the mismatch rows.
+func TestWriteDeltaPrefixVerifyReport_FailKeepsOutsideRetentionNoteSeparate(t *testing.T) {
+	rep := testVerifyReport(
+		[]deltaprefix.Mismatch{{MetricName: "missed_metric", Aggregate: 0, Base: 5}},
+		map[string]float64{"m": 10},
+		map[string]float64{"m": 10, "missed_metric": 5},
+	)
+	var buf bytes.Buffer
+	if err := writeDeltaPrefixVerifyReport(&buf, rep, false); err != nil {
+		t.Fatalf("writeDeltaPrefixVerifyReport: %v", err)
+	}
+	got := buf.String()
+	if !strings.Contains(got, "FAIL: 1 of") {
+		t.Errorf("expected the ordinary FAIL summary line, got: %q", got)
+	}
+	if !strings.Contains(got, "missed_metric") {
+		t.Errorf("expected the mismatch table to list missed_metric, got: %q", got)
+	}
+	if !strings.Contains(got, "NOTE:") {
+		t.Errorf("expected the outside-retention NOTE to still appear alongside a real FAIL, got: %q", got)
+	}
+}
+
+// TestWriteDeltaPrefixVerifyReport_NoNoteWhenNothingExcluded confirms an
+// ordinary PASS/FAIL report — no outside-retention days at all — prints no
+// NOTE section, so the common case's output is unchanged from before this
+// fix.
+func TestWriteDeltaPrefixVerifyReport_NoNoteWhenNothingExcluded(t *testing.T) {
+	rep := deltaprefix.Diff(map[string]float64{"m": 10}, map[string]float64{"m": 10}, time.Now(), 0.01)
+	var buf bytes.Buffer
+	if err := writeDeltaPrefixVerifyReport(&buf, rep, false); err != nil {
+		t.Fatalf("writeDeltaPrefixVerifyReport: %v", err)
+	}
+	if got := buf.String(); strings.Contains(got, "NOTE:") {
+		t.Errorf("expected no NOTE section with zero excluded days, got: %q", got)
+	}
+}
+
+// TestWriteDeltaPrefixVerifyReport_JSONIncludesRetentionFields confirms the
+// machine-readable --json form carries the new Retention /
+// RetentionBoundary / OutsideRetentionDays fields, not just the text
+// renderer.
+func TestWriteDeltaPrefixVerifyReport_JSONIncludesRetentionFields(t *testing.T) {
+	rep := testVerifyReport(nil, map[string]float64{"m": 10}, map[string]float64{"m": 10})
+	var buf bytes.Buffer
+	if err := writeDeltaPrefixVerifyReport(&buf, rep, true); err != nil {
+		t.Fatalf("writeDeltaPrefixVerifyReport: %v", err)
+	}
+	var decoded deltaprefix.Report
+	if err := json.Unmarshal(buf.Bytes(), &decoded); err != nil {
+		t.Fatalf("json.Unmarshal: %v (output: %s)", err, buf.String())
+	}
+	if decoded.Retention != rep.Retention {
+		t.Errorf("decoded Retention = %v; want %v", decoded.Retention, rep.Retention)
+	}
+	if len(decoded.OutsideRetentionDays) != 1 {
+		t.Errorf("decoded OutsideRetentionDays = %v; want exactly 1 entry", decoded.OutsideRetentionDays)
+	}
+}
+
+// TestWriteOutsideRetentionWarning_BackfillCLI pins
+// delta-prefix-backfill's own post-Backfill warning text (cerberus issue
+// #2652): loud, names the table, explains WHY re-running cannot fix it,
+// and lists every affected day.
+func TestWriteOutsideRetentionWarning_BackfillCLI(t *testing.T) {
+	var buf bytes.Buffer
+	days := []time.Time{time.Date(2026, 8, 20, 0, 0, 0, 0, time.UTC), time.Date(2026, 8, 21, 0, 0, 0, 0, time.UTC)}
+	writeOutsideRetentionWarning(&buf, "otel_metrics_sum_delta_prefix", days)
+	got := buf.String()
+	if !strings.Contains(got, "WARNING") {
+		t.Errorf("expected a WARNING marker, got: %q", got)
+	}
+	if !strings.Contains(got, "otel_metrics_sum_delta_prefix") {
+		t.Errorf("expected the warning to name the target table, got: %q", got)
+	}
+	if !strings.Contains(got, "NOT fixable by re-running") {
+		t.Errorf("expected the warning to explain re-running cannot fix this, got: %q", got)
+	}
+	for _, d := range days {
+		if !strings.Contains(got, d.Format(time.DateOnly)) {
+			t.Errorf("expected the warning to list day %s, got: %q", d.Format(time.DateOnly), got)
+		}
 	}
 }

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -1223,6 +1223,29 @@ under-count. Backfilling by the exact instant closes that gap: everything
 strictly older than it is backfilled, and the live MV captures everything
 from that instant onward, so the two windows meet exactly.
 
+**Run this backfill AS SOON AS POSSIBLE after creating the table/MV — this
+warning is as load-bearing as the `--before` bound above.** The DELTA-prefix
+table shares its `TTL toDateTime(BucketStart) + <retention>` shape
+(`CERBERUS_SCHEMA_TTL_METRICS`) with the base metrics tables — correct for
+STEADY STATE, where both tables age out their oldest day together because
+both are populated continuously, but not correct for this one-time backfill.
+If an operator runs `delta-prefix-backfill` any time *after* the earliest
+available historical day has already crossed its own `BucketStart +
+<retention>` instant, the resulting `INSERT ... SELECT` writes rows for that
+day that are **already past their own TTL the moment they land**. Because
+this table is small and merges frequently, ClickHouse's routine background
+TTL cleanup reaps those rows almost immediately — often within seconds to
+minutes, well before an operator gets a chance to run `delta-prefix-verify`
+and see a clean state. **This is unrecoverable**: no sequence of backfill
+re-runs, with or without narrowing to just the affected day, with or without
+dropping and recreating the table/MV, can bring that day back — the
+constraint is the row's own age relative to "now", not anything about the
+write path. Run the backfill (and `delta-prefix-verify` right after it)
+*before* the earliest day in your history reaches that boundary; once it has
+passed, that day's completeness is permanently gone, and both CLI verbs below
+detect and report this case explicitly rather than leaving the operator to
+diagnose an unexplained failure.
+
 `delta-prefix-backfill` runs a single `INSERT INTO ... SELECT` — the same
 `GROUP BY (MetricName, Attributes, ResourceAttributes, ServiceName,
 toStartOfDay(TimeUnix))` shape the MV itself uses — filtered to
@@ -1233,7 +1256,15 @@ DELTA-temporality slice of the base table's history (empirically well under 1%
 of real `otel_metrics_sum` rows — see `Config.DeltaPrefixLookback`'s doc
 comment) plus one aggregate write per distinct `(MetricName, raw attribute
 tuple, day)` — materially cheaper than the projection back-fill above despite
-reading a wider column set.
+reading a wider column set. Before issuing that INSERT, it also checks — against
+the base table, using the resolved `CERBERUS_SCHEMA_TTL_METRICS` retention —
+whether any day within `--before`'s scope is already outside the target
+table's own TTL as of right now (the unrecoverable case described above); if
+so it prints a loud `WARNING` naming the affected day(s) after a successful
+run rather than succeeding with zero signal. This is a warning, not an
+error — the command still exits `0`, since the operator may already have
+accepted the loss for those days or be intentionally re-running to pick up
+the still-recoverable ones.
 
 `delta-prefix-verify` compares the aggregate table's per-metric-name totals
 (`sum(PartialSum)`, grouped by `MetricName` only) against the base table's own
@@ -1254,6 +1285,21 @@ backfills is not broken — it simply keeps running today's bounded
 `CERBERUS_DELTA_PREFIX_LOOKBACK` approximation indefinitely, a legitimate
 permanent choice for an operator who doesn't need exact boundary-correction
 precision.
+
+**A day already outside the target table's own retention is never reported
+as a bare, unexplained mismatch.** `delta-prefix-verify` resolves the same
+`CERBERUS_SCHEMA_TTL_METRICS` retention `delta-prefix-backfill` checks and,
+for each day in its comparison window, detects whether that day's
+`BucketStart + <retention>` has already elapsed as of the check's own run
+time (the unrecoverable case described above). Any such day is EXCLUDED from
+`AggregateTotals` / `BaseTotals` / the mismatch table — it can never be
+turned into a PASS by any backfill re-run, so folding it into the same FAIL
+as a genuine completeness gap would be indistinguishable from a real bug —
+and instead surfaced as a separate, clearly labeled `NOTE` naming the
+excluded day(s), auto-detected with no flag required (a real completeness
+gap must never be silently hidden, so this is safe-by-default: it always
+runs, and it is always visually distinct from the PASS/FAIL verdict above
+it, in both the text and `--json` report forms).
 
 #### Read-side mechanism and its measured PK-pruning cost
 

--- a/internal/deltaprefix/deltaprefix.go
+++ b/internal/deltaprefix/deltaprefix.go
@@ -157,13 +157,115 @@ func BackfillSQL(c Columns, before time.Time) (string, []any) {
 	).Build()
 }
 
-// Backfill executes BackfillSQL against conn.
-func Backfill(ctx context.Context, conn Conn, c Columns, before time.Time) error {
+// nowFunc is the retention-boundary clock — a package-level var (never a
+// direct time.Now() call in retentionBoundary/Backfill/Verify) so
+// deltaprefix_test.go can pin "now" and exercise the day-exclusion logic
+// deterministically, matching this package's doc-comment promise that the
+// SQL composition + result diffing stays unit testable without a live
+// ClickHouse connection (cerberus issue #2652).
+var nowFunc = time.Now
+
+// retentionBoundary computes the instant before which a day's own
+// BucketStart + retention has already elapsed as of now — the exact
+// unrecoverable-TTL-reap boundary Backfill and Verify must both respect
+// (cerberus issue #2652; see the package doc's "One-time backfill vs. the
+// aggregate table's own steady-state TTL" section). A non-positive
+// retention means the aggregate table has no TTL clause at all
+// (internal/schema/ddl's ttlExpr emits none for a zero duration), so
+// nothing can ever be reaped by age: active is false and boundary is the
+// zero time.
+func retentionBoundary(now time.Time, retention time.Duration) (boundary time.Time, active bool) {
+	if retention <= 0 {
+		return time.Time{}, false
+	}
+	return now.Add(-retention), true
+}
+
+// outsideRetentionDaysSQL renders the DISTINCT day-bucket read against the
+// base table's own DELTA history, restricted to Backfill/Verify's own
+// `[-inf, before)` scope AND already past the aggregate table's retention
+// as of boundary (BucketStart < boundary) — the exact set of days a
+// Backfill write, or a Verify comparison, must treat as structurally
+// unrecoverable rather than a real completeness gap (cerberus issue
+// #2652). Reads the BASE table, not the aggregate table: the base table
+// carries no TTL tied to this retention, so it stays a reliable source of
+// truth for "which days exist in scope" regardless of whether the
+// aggregate table's own rows for a doomed day have been reaped yet.
+func outsideRetentionDaysSQL(c Columns, before, boundary time.Time) (string, []any) {
+	bucket := dayBucket(c.TimestampColumn)
+	q := chsql.NewQuery().
+		Select(bucket).
+		From(chsql.Qual(c.Database, c.SumTable)).
+		Where(
+			chsql.Eq(chsql.Col(c.AggregationTemporalityColumn), chsql.InlineLit(schema.AggregationTemporalityDelta)),
+			chsql.Lt(chsql.Col(c.TimestampColumn), chsql.Lit(before)),
+			chsql.Lt(bucket, chsql.Lit(boundary)),
+		).
+		GroupBy(bucket).
+		OrderBy(bucket, false)
+	return q.Build()
+}
+
+// queryOutsideRetentionDays runs outsideRetentionDaysSQL against conn and
+// scans the resulting day-buckets, sorted ascending (ORDER BY in the SQL
+// itself).
+func queryOutsideRetentionDays(ctx context.Context, conn Conn, c Columns, before, boundary time.Time) ([]time.Time, error) {
+	sql, args := outsideRetentionDaysSQL(c, before, boundary)
+	rows, err := conn.Query(withCaps(ctx), sql, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = rows.Close() }()
+	var days []time.Time
+	for rows.Next() {
+		var day time.Time
+		if err := rows.Scan(&day); err != nil {
+			return nil, err
+		}
+		days = append(days, day)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return days, nil
+}
+
+// BackfillResult is what Backfill returns beyond a plain error: the days
+// (if any) it detected as already outside the DeltaPrefixTable's own
+// retention window as of now. Non-empty means this backfill wrote — or is
+// about to have written — rows ClickHouse's own background TTL merge will
+// reap almost immediately, often before an operator gets to run Verify
+// (cerberus issue #2652). This is a warning signal, not necessarily a
+// problem the caller must treat as fatal: the operator may have already
+// accepted the loss for those days, or be intentionally re-running for the
+// still-recoverable ones.
+type BackfillResult struct {
+	OutsideRetentionDays []time.Time
+}
+
+// Backfill executes BackfillSQL against conn. retention is the
+// DeltaPrefixTable's own resolved TTL (0 = no TTL, see retentionBoundary);
+// Backfill checks — against the base table, BEFORE issuing its own INSERT,
+// so the check cannot race the aggregate table's TTL reaping the very rows
+// it is about to write — whether any day within c's `[-inf, before)` scope
+// is already outside that retention, and reports it on the returned
+// BackfillResult rather than succeeding silently (cerberus issue #2652).
+func Backfill(ctx context.Context, conn Conn, c Columns, before time.Time, retention time.Duration) (BackfillResult, error) {
+	boundary, active := retentionBoundary(nowFunc(), retention)
+	var outsideDays []time.Time
+	if active {
+		var err error
+		outsideDays, err = queryOutsideRetentionDays(ctx, conn, c, before, boundary)
+		if err != nil {
+			return BackfillResult{}, fmt.Errorf("deltaprefix: check retention window against %s: %w", c.SumTable, err)
+		}
+	}
+
 	sql, args := BackfillSQL(c, before)
 	if err := conn.Exec(withCaps(ctx), sql, args...); err != nil {
-		return fmt.Errorf("deltaprefix: backfill %s: %w", c.DeltaPrefixTable, err)
+		return BackfillResult{}, fmt.Errorf("deltaprefix: backfill %s: %w", c.DeltaPrefixTable, err)
 	}
-	return nil
+	return BackfillResult{OutsideRetentionDays: outsideDays}, nil
 }
 
 // aggregateTotalsSQL renders the per-metric-name sum(PartialSum) read from
@@ -179,11 +281,20 @@ func Backfill(ctx context.Context, conn Conn, c Columns, before time.Time) error
 // a day-truncated column against an exact instant — that is fine: a bucket
 // whose day-start is before the instant is still "< before" even when the
 // instant itself falls partway through that same day.
-func aggregateTotalsSQL(c Columns, before time.Time) (string, []any) {
+//
+// When retentionActive, an additional `DeltaPrefixBucketColumn >= boundary`
+// bound excludes every day already outside the aggregate table's own TTL as
+// of now (cerberus issue #2652) — those days are reported separately via
+// queryOutsideRetentionDays, never folded into this total.
+func aggregateTotalsSQL(c Columns, before, boundary time.Time, retentionActive bool) (string, []any) {
+	conds := []chsql.Frag{chsql.Lt(chsql.Col(c.DeltaPrefixBucketColumn), chsql.Lit(before))}
+	if retentionActive {
+		conds = append(conds, chsql.Gte(chsql.Col(c.DeltaPrefixBucketColumn), chsql.Lit(boundary)))
+	}
 	q := chsql.NewQuery().
 		Select(chsql.Col(c.MetricNameColumn), chsql.Call("sum", chsql.Col(c.DeltaPrefixSumColumn))).
 		From(chsql.Qual(c.Database, c.DeltaPrefixTable)).
-		Where(chsql.Lt(chsql.Col(c.DeltaPrefixBucketColumn), chsql.Lit(before))).
+		Where(conds...).
 		GroupBy(chsql.Col(c.MetricNameColumn))
 	return q.Build()
 }
@@ -193,14 +304,26 @@ func aggregateTotalsSQL(c Columns, before time.Time) (string, []any) {
 // the exact population BackfillSQL writes into the DELTA-prefix table, so a
 // correct backfill makes this total and aggregateTotalsSQL's total agree per
 // metric name.
-func baseTotalsSQL(c Columns, before time.Time) (string, []any) {
+//
+// When retentionActive, an additional `toStartOfDay(TimestampColumn) >=
+// boundary` bound excludes the same already-outside-retention days
+// aggregateTotalsSQL excludes — compared at DAY granularity (not the exact
+// instant the `< before` bound uses), matching DeltaPrefixBucketColumn's own
+// day-granularity storage resolution and outsideRetentionDaysSQL's day list
+// exactly, so both sides of the comparison drop precisely the same days
+// (cerberus issue #2652).
+func baseTotalsSQL(c Columns, before, boundary time.Time, retentionActive bool) (string, []any) {
+	conds := []chsql.Frag{
+		chsql.Eq(chsql.Col(c.AggregationTemporalityColumn), chsql.InlineLit(schema.AggregationTemporalityDelta)),
+		chsql.Lt(chsql.Col(c.TimestampColumn), chsql.Lit(before)),
+	}
+	if retentionActive {
+		conds = append(conds, chsql.Gte(dayBucket(c.TimestampColumn), chsql.Lit(boundary)))
+	}
 	q := chsql.NewQuery().
 		Select(chsql.Col(c.MetricNameColumn), chsql.Call("sum", chsql.Col(c.ValueColumn))).
 		From(chsql.Qual(c.Database, c.SumTable)).
-		Where(
-			chsql.Eq(chsql.Col(c.AggregationTemporalityColumn), chsql.InlineLit(schema.AggregationTemporalityDelta)),
-			chsql.Lt(chsql.Col(c.TimestampColumn), chsql.Lit(before)),
-		).
+		Where(conds...).
 		GroupBy(chsql.Col(c.MetricNameColumn))
 	return q.Build()
 }
@@ -229,26 +352,78 @@ type Report struct {
 	AggregateTotals map[string]float64
 	BaseTotals      map[string]float64
 	Mismatches      []Mismatch
+
+	// Retention is the DeltaPrefixTable's own resolved TTL retention as of
+	// this Verify run (CERBERUS_SCHEMA_TTL_METRICS, inherited from
+	// CERBERUS_SCHEMA_TTL when unset — see internal/schemaboot.
+	// MetricsRetention). 0 means no TTL clause is emitted at all
+	// (internal/schema/ddl's ttlExpr), so no day can ever be structurally
+	// unrecoverable and OutsideRetentionDays is always empty.
+	Retention time.Duration
+
+	// RetentionBoundary is the instant this Report's own run computed as
+	// now - Retention (the zero time when Retention is 0). A day whose
+	// BucketStart falls strictly before this instant is already past its
+	// own TTL as of right now — see OutsideRetentionDays.
+	RetentionBoundary time.Time
+
+	// OutsideRetentionDays are day-buckets, within before's own scope,
+	// whose BucketStart + Retention has already elapsed as of this
+	// Report's run time (cerberus issue #2652): a one-time backfill
+	// writing rows for one of these days writes data ClickHouse's own
+	// background TTL merge reaps almost immediately, and no sequence of
+	// backfill re-runs can ever recover it — the constraint is the row's
+	// own age, not the write path. These days are EXCLUDED from
+	// AggregateTotals / BaseTotals / Mismatches above: folding an
+	// unrecoverable day into the same FAIL as a genuine completeness gap
+	// would be indistinguishable from a real bug. See docs/operations.md's
+	// DELTA-prefix backfill runbook.
+	OutsideRetentionDays []time.Time
 }
 
 // Pass reports whether every metric's totals agreed within tolerance.
+// OutsideRetentionDays does not affect Pass: those days are excluded from
+// the comparison entirely, not counted as failures (see the field's doc).
 func (r Report) Pass() bool { return len(r.Mismatches) == 0 }
 
 // Verify reads both per-metric totals and diffs them, returning a Report an
 // operator (or the `delta-prefix-verify` CLI verb) can render before
-// flipping CERBERUS_SCHEMA_DELTA_PREFIX_ENABLED=true.
-func Verify(ctx context.Context, conn Conn, c Columns, before time.Time, tolerance float64) (Report, error) {
-	aggSQL, aggArgs := aggregateTotalsSQL(c, before)
+// flipping CERBERUS_SCHEMA_DELTA_PREFIX_ENABLED=true. retention is the
+// DeltaPrefixTable's own resolved TTL (0 = no TTL); when non-zero, Verify
+// first detects any day already outside that retention as of now — see
+// retentionBoundary — excludes it from both totals reads, and reports it
+// separately on Report.OutsideRetentionDays rather than an unexplained
+// mismatch (cerberus issue #2652).
+func Verify(ctx context.Context, conn Conn, c Columns, before time.Time, tolerance float64, retention time.Duration) (Report, error) {
+	boundary, active := retentionBoundary(nowFunc(), retention)
+
+	var outsideDays []time.Time
+	if active {
+		var err error
+		outsideDays, err = queryOutsideRetentionDays(ctx, conn, c, before, boundary)
+		if err != nil {
+			return Report{}, fmt.Errorf("deltaprefix: check retention window against %s: %w", c.SumTable, err)
+		}
+	}
+
+	aggSQL, aggArgs := aggregateTotalsSQL(c, before, boundary, active)
 	agg, err := scanTotals(ctx, conn, aggSQL, aggArgs)
 	if err != nil {
 		return Report{}, fmt.Errorf("deltaprefix: read %s totals: %w", c.DeltaPrefixTable, err)
 	}
-	baseSQL, baseArgs := baseTotalsSQL(c, before)
+	baseSQL, baseArgs := baseTotalsSQL(c, before, boundary, active)
 	base, err := scanTotals(ctx, conn, baseSQL, baseArgs)
 	if err != nil {
 		return Report{}, fmt.Errorf("deltaprefix: read %s totals: %w", c.SumTable, err)
 	}
-	return Diff(agg, base, before, tolerance), nil
+
+	rep := Diff(agg, base, before, tolerance)
+	rep.Retention = retention
+	if active {
+		rep.RetentionBoundary = boundary
+	}
+	rep.OutsideRetentionDays = outsideDays
+	return rep, nil
 }
 
 // Diff compares two per-metric-name total maps and returns the Report —

--- a/internal/deltaprefix/deltaprefix_test.go
+++ b/internal/deltaprefix/deltaprefix_test.go
@@ -58,7 +58,7 @@ func TestBackfillSQL(t *testing.T) {
 func TestAggregateAndBaseTotalsSQL(t *testing.T) {
 	c := testColumns()
 
-	aggSQL, aggArgs := aggregateTotalsSQL(c, testBefore)
+	aggSQL, aggArgs := aggregateTotalsSQL(c, testBefore, time.Time{}, false)
 	wantAgg := "SELECT `MetricName`, sum(`PartialSum`) FROM `otel`.`otel_metrics_sum_delta_prefix` " +
 		"WHERE `BucketStart` < ? GROUP BY `MetricName`"
 	if aggSQL != wantAgg {
@@ -68,7 +68,7 @@ func TestAggregateAndBaseTotalsSQL(t *testing.T) {
 		t.Errorf("aggregateTotalsSQL args = %v; want [%v]", aggArgs, testBefore)
 	}
 
-	baseSQL, baseArgs := baseTotalsSQL(c, testBefore)
+	baseSQL, baseArgs := baseTotalsSQL(c, testBefore, time.Time{}, false)
 	wantBase := "SELECT `MetricName`, sum(`Value`) FROM `otel`.`otel_metrics_sum` " +
 		"WHERE `AggregationTemporality` = 1 AND `TimeUnix` < ? GROUP BY `MetricName`"
 	if baseSQL != wantBase {
@@ -76,6 +76,89 @@ func TestAggregateAndBaseTotalsSQL(t *testing.T) {
 	}
 	if len(baseArgs) != 1 || baseArgs[0] != testBefore {
 		t.Errorf("baseTotalsSQL args = %v; want [%v]", baseArgs, testBefore)
+	}
+}
+
+// TestAggregateAndBaseTotalsSQL_RetentionActive pins the additional lower
+// bound both totals reads gain when a retention boundary is active
+// (cerberus issue #2652): aggregateTotalsSQL bounds
+// DeltaPrefixBucketColumn >= boundary directly (it is already
+// day-granularity storage), baseTotalsSQL bounds
+// toStartOfDay(TimestampColumn) >= boundary (day-truncated, so it excludes
+// exactly the same set of days aggregateTotalsSQL excludes, even though
+// its OTHER bound — TimestampColumn < before — stays exact-instant).
+func TestAggregateAndBaseTotalsSQL_RetentionActive(t *testing.T) {
+	c := testColumns()
+	boundary := time.Date(2026, 8, 10, 0, 0, 0, 0, time.UTC)
+
+	aggSQL, aggArgs := aggregateTotalsSQL(c, testBefore, boundary, true)
+	wantAgg := "SELECT `MetricName`, sum(`PartialSum`) FROM `otel`.`otel_metrics_sum_delta_prefix` " +
+		"WHERE `BucketStart` < ? AND `BucketStart` >= ? GROUP BY `MetricName`"
+	if aggSQL != wantAgg {
+		t.Errorf("aggregateTotalsSQL sql =\n%s\nwant\n%s", aggSQL, wantAgg)
+	}
+	if len(aggArgs) != 2 || aggArgs[0] != testBefore || aggArgs[1] != boundary {
+		t.Errorf("aggregateTotalsSQL args = %v; want [%v %v]", aggArgs, testBefore, boundary)
+	}
+
+	baseSQL, baseArgs := baseTotalsSQL(c, testBefore, boundary, true)
+	wantBase := "SELECT `MetricName`, sum(`Value`) FROM `otel`.`otel_metrics_sum` " +
+		"WHERE `AggregationTemporality` = 1 AND `TimeUnix` < ? AND toStartOfDay(`TimeUnix`) >= ? GROUP BY `MetricName`"
+	if baseSQL != wantBase {
+		t.Errorf("baseTotalsSQL sql =\n%s\nwant\n%s", baseSQL, wantBase)
+	}
+	if len(baseArgs) != 2 || baseArgs[0] != testBefore || baseArgs[1] != boundary {
+		t.Errorf("baseTotalsSQL args = %v; want [%v %v]", baseArgs, testBefore, boundary)
+	}
+}
+
+// TestOutsideRetentionDaysSQL pins the DISTINCT-day read used both by
+// Backfill (pre-INSERT check against the base table) and Verify (to
+// populate Report.OutsideRetentionDays): DELTA-only, bounded by the same
+// exact-instant `before` BackfillSQL uses, plus the day-bucket `<
+// boundary` cut that defines "already outside retention" (cerberus issue
+// #2652), grouped (i.e. deduplicated) and ordered by day ascending.
+func TestOutsideRetentionDaysSQL(t *testing.T) {
+	c := testColumns()
+	boundary := time.Date(2026, 8, 10, 0, 0, 0, 0, time.UTC)
+	sql, args := outsideRetentionDaysSQL(c, testBefore, boundary)
+	want := "SELECT toStartOfDay(`TimeUnix`) FROM `otel`.`otel_metrics_sum` " +
+		"WHERE `AggregationTemporality` = 1 AND `TimeUnix` < ? AND toStartOfDay(`TimeUnix`) < ? " +
+		"GROUP BY toStartOfDay(`TimeUnix`) ORDER BY toStartOfDay(`TimeUnix`)"
+	if sql != want {
+		t.Errorf("outsideRetentionDaysSQL sql =\n%s\nwant\n%s", sql, want)
+	}
+	if len(args) != 2 || args[0] != testBefore || args[1] != boundary {
+		t.Errorf("outsideRetentionDaysSQL args = %v; want [%v %v]", args, testBefore, boundary)
+	}
+}
+
+// TestRetentionBoundary pins retentionBoundary's pure day-math: a
+// non-positive retention (no TTL clause emitted at all — see
+// internal/schema/ddl's ttlExpr) always reports inactive with a zero
+// boundary regardless of now; a positive retention reports active with
+// boundary = now - retention, exactly.
+func TestRetentionBoundary(t *testing.T) {
+	now := time.Date(2026, 8, 26, 12, 0, 0, 0, time.UTC)
+
+	for _, retention := range []time.Duration{0, -time.Hour} {
+		boundary, active := retentionBoundary(now, retention)
+		if active {
+			t.Errorf("retentionBoundary(%v, %v) active = true; want false (no TTL)", now, retention)
+		}
+		if !boundary.IsZero() {
+			t.Errorf("retentionBoundary(%v, %v) boundary = %v; want zero time", now, retention, boundary)
+		}
+	}
+
+	retention := 90 * 24 * time.Hour
+	boundary, active := retentionBoundary(now, retention)
+	if !active {
+		t.Fatalf("retentionBoundary(%v, %v) active = false; want true", now, retention)
+	}
+	wantBoundary := now.Add(-retention)
+	if !boundary.Equal(wantBoundary) {
+		t.Errorf("retentionBoundary(%v, %v) boundary = %v; want %v", now, retention, boundary, wantBoundary)
 	}
 }
 
@@ -332,12 +415,19 @@ func (c *twoCallConn) Query(context.Context, string, ...any) (driver.Rows, error
 
 // TestBackfill_ExecutesRenderedSQL confirms Backfill hands conn EXACTLY the
 // statement + args BackfillSQL renders, and wraps a real Exec failure with
-// enough context to identify which table failed.
+// enough context to identify which table failed. retention=0 (no TTL)
+// keeps the new outside-retention pre-check inactive, so it issues no
+// extra query — TestBackfill_DetectsOutsideRetentionDays below covers the
+// active path.
 func TestBackfill_ExecutesRenderedSQL(t *testing.T) {
 	c := testColumns()
 	conn := &fakeConn{}
-	if err := Backfill(context.Background(), conn, c, testBefore); err != nil {
+	result, err := Backfill(context.Background(), conn, c, testBefore, 0)
+	if err != nil {
 		t.Fatalf("Backfill: %v", err)
+	}
+	if len(result.OutsideRetentionDays) != 0 {
+		t.Errorf("OutsideRetentionDays = %v; want none with retention=0", result.OutsideRetentionDays)
 	}
 	wantSQL, wantArgs := BackfillSQL(c, testBefore)
 	if len(conn.execSQL) != 1 || conn.execSQL[0] != wantSQL {
@@ -348,7 +438,7 @@ func TestBackfill_ExecutesRenderedSQL(t *testing.T) {
 	}
 
 	failing := &fakeConn{execErr: errors.New("boom")}
-	err := Backfill(context.Background(), failing, c, testBefore)
+	_, err = Backfill(context.Background(), failing, c, testBefore, 0)
 	if err == nil {
 		t.Fatal("expected error from a failing Exec")
 	}
@@ -356,6 +446,119 @@ func TestBackfill_ExecutesRenderedSQL(t *testing.T) {
 		t.Errorf("Backfill error %q does not name the target table %q", got, c.DeltaPrefixTable)
 	}
 }
+
+// withFrozenNow pins nowFunc to now for the duration of the test, restoring
+// the real clock via t.Cleanup — the mechanism deltaprefix_test.go uses to
+// exercise the retention-boundary logic (cerberus issue #2652)
+// deterministically, per the package's "unit testable without a live
+// ClickHouse connection" doc-comment promise.
+func withFrozenNow(t *testing.T, now time.Time) {
+	t.Helper()
+	prev := nowFunc
+	nowFunc = func() time.Time { return now }
+	t.Cleanup(func() { nowFunc = prev })
+}
+
+// TestBackfill_DetectsOutsideRetentionDays confirms Backfill queries the
+// base table for outside-retention days BEFORE issuing its own INSERT
+// (order matters: the base table is not subject to this TTL and so cannot
+// race with it), still executes the INSERT regardless (a doomed day is a
+// warning, not a reason to abort — see BackfillResult's doc comment), and
+// surfaces the detected days on the returned BackfillResult.
+func TestBackfill_DetectsOutsideRetentionDays(t *testing.T) {
+	c := testColumns()
+	now := time.Date(2026, 8, 26, 12, 0, 0, 0, time.UTC)
+	withFrozenNow(t, now)
+	retention := 24 * time.Hour // boundary = 2026-08-25T12:00:00Z
+	doomedDay := time.Date(2026, 8, 20, 0, 0, 0, 0, time.UTC)
+
+	// outsideRetentionDaysSQL scans a single time.Time column, not
+	// (string, float64) like scanTotals — fakeConn/fakeRows above are
+	// wired for totals reads, so this test drives queryOutsideRetentionDays
+	// through a dedicated day-scanning fake rather than reusing fakeConn.
+	dconn := &dayFakeConn{days: []time.Time{doomedDay}}
+	result, err := Backfill(context.Background(), dconn, c, testBefore, retention)
+	if err != nil {
+		t.Fatalf("Backfill: %v", err)
+	}
+	if len(dconn.execSQL) != 1 {
+		t.Fatalf("expected exactly 1 Exec (the INSERT), got %d: %v", len(dconn.execSQL), dconn.execSQL)
+	}
+	if len(dconn.queries) != 1 {
+		t.Fatalf("expected exactly 1 Query (the outside-retention-days check), got %d: %v", len(dconn.queries), dconn.queries)
+	}
+	if len(result.OutsideRetentionDays) != 1 || !result.OutsideRetentionDays[0].Equal(doomedDay) {
+		t.Errorf("OutsideRetentionDays = %v; want [%v]", result.OutsideRetentionDays, doomedDay)
+	}
+}
+
+// TestBackfill_NoRetentionCheckWhenRetentionZero confirms Backfill issues
+// NO retention-boundary query at all when retention is 0 (no TTL clause is
+// ever emitted, so nothing can ever be "outside retention" — see
+// retentionBoundary) — a deployment without CERBERUS_SCHEMA_TTL_METRICS
+// set should not pay for a check that can never find anything.
+func TestBackfill_NoRetentionCheckWhenRetentionZero(t *testing.T) {
+	c := testColumns()
+	dconn := &dayFakeConn{days: []time.Time{time.Date(2026, 8, 20, 0, 0, 0, 0, time.UTC)}}
+	result, err := Backfill(context.Background(), dconn, c, testBefore, 0)
+	if err != nil {
+		t.Fatalf("Backfill: %v", err)
+	}
+	if len(dconn.queries) != 0 {
+		t.Errorf("expected no retention-boundary Query with retention=0, got %d: %v", len(dconn.queries), dconn.queries)
+	}
+	if len(result.OutsideRetentionDays) != 0 {
+		t.Errorf("OutsideRetentionDays = %v; want none with retention=0", result.OutsideRetentionDays)
+	}
+}
+
+// dayFakeConn is a scripted Conn whose Query always returns the configured
+// days as single-column time.Time rows (queryOutsideRetentionDays' scan
+// shape) and whose Exec always succeeds, recording every statement.
+type dayFakeConn struct {
+	days    []time.Time
+	queries []string
+	execSQL []string
+}
+
+func (c *dayFakeConn) Exec(_ context.Context, query string, _ ...any) error {
+	c.execSQL = append(c.execSQL, query)
+	return nil
+}
+
+func (c *dayFakeConn) Query(_ context.Context, query string, _ ...any) (driver.Rows, error) {
+	c.queries = append(c.queries, query)
+	return &dayFakeRows{days: c.days}, nil
+}
+
+// dayFakeRows is a canned driver.Rows over a single time.Time column,
+// mirroring fakeRows' shape but for outsideRetentionDaysSQL's one-column
+// result instead of scanTotals' (name, total) pair.
+type dayFakeRows struct {
+	driver.Rows
+	days []time.Time
+	pos  int
+}
+
+func (r *dayFakeRows) Next() bool {
+	if r.pos >= len(r.days) {
+		return false
+	}
+	r.pos++
+	return true
+}
+
+func (r *dayFakeRows) Scan(dest ...any) error {
+	tp, ok := dest[0].(*time.Time)
+	if !ok {
+		return fmt.Errorf("dayFakeRows: dest[0] is %T, want *time.Time", dest[0])
+	}
+	*tp = r.days[r.pos-1]
+	return nil
+}
+
+func (r *dayFakeRows) Err() error   { return nil }
+func (r *dayFakeRows) Close() error { return nil }
 
 // TestVerify_ReadsBothTotalsAndDiffs runs Verify end to end against a
 // scripted Conn returning canned per-metric totals for each of the two
@@ -372,9 +575,12 @@ func TestVerify_ReadsBothTotalsAndDiffs(t *testing.T) {
 			"`" + c.SumTable + "`":         {{"http_requests_total", 100.0}, {"missed_metric", 5.0}},
 		},
 	}
-	rep, err := Verify(context.Background(), conn, c, testBefore, 0.01)
+	rep, err := Verify(context.Background(), conn, c, testBefore, 0.01, 0)
 	if err != nil {
 		t.Fatalf("Verify: %v", err)
+	}
+	if len(rep.OutsideRetentionDays) != 0 {
+		t.Errorf("OutsideRetentionDays = %v; want none with retention=0", rep.OutsideRetentionDays)
 	}
 	if len(conn.queries) != 2 {
 		t.Fatalf("expected 2 queries (aggregate + base), got %d: %v", len(conn.queries), conn.queries)
@@ -392,7 +598,7 @@ func TestVerify_ReadsBothTotalsAndDiffs(t *testing.T) {
 func TestVerify_PropagatesQueryError(t *testing.T) {
 	c := testColumns()
 	conn := &fakeConn{rowsErr: errors.New("connection reset")}
-	if _, err := Verify(context.Background(), conn, c, testBefore, 0.01); err == nil {
+	if _, err := Verify(context.Background(), conn, c, testBefore, 0.01, 0); err == nil {
 		t.Fatal("expected an error from a failing Query")
 	}
 }
@@ -404,12 +610,142 @@ func TestVerify_PropagatesQueryError(t *testing.T) {
 func TestVerify_PropagatesBaseTableQueryError(t *testing.T) {
 	c := testColumns()
 	conn := &twoCallConn{err: errors.New("connection reset")}
-	_, err := Verify(context.Background(), conn, c, testBefore, 0.01)
+	_, err := Verify(context.Background(), conn, c, testBefore, 0.01, 0)
 	if err == nil {
 		t.Fatal("expected an error from the base-table read failing")
 	}
 	if !contains(err.Error(), c.SumTable) {
 		t.Errorf("Verify error %q does not name the base table %q", err.Error(), c.SumTable)
+	}
+}
+
+// TestVerify_PropagatesRetentionCheckQueryError confirms a Query failure on
+// the retention pre-check (the FIRST query Verify issues when retention is
+// active) surfaces as an error naming the base table, mirroring
+// TestVerify_PropagatesQueryError / TestVerify_PropagatesBaseTableQueryError's
+// per-read error-wrap coverage.
+func TestVerify_PropagatesRetentionCheckQueryError(t *testing.T) {
+	c := testColumns()
+	withFrozenNow(t, time.Date(2026, 8, 26, 12, 0, 0, 0, time.UTC))
+	conn := &fakeConn{rowsErr: errors.New("connection reset")}
+	_, err := Verify(context.Background(), conn, c, testBefore, 0.01, 24*time.Hour)
+	if err == nil {
+		t.Fatal("expected an error from the retention-check Query failing")
+	}
+	if !contains(err.Error(), c.SumTable) {
+		t.Errorf("Verify error %q does not name the base table %q", err.Error(), c.SumTable)
+	}
+}
+
+// mixedFakeConn extends fakeConn's (MetricName, total) totals-response
+// mechanism with a separate day-response for outsideRetentionDaysSQL's
+// distinct single-column shape, letting one Conn drive Verify's full
+// three-query path (day-scan + both totals reads) end to end.
+type mixedFakeConn struct {
+	fakeConn
+	days []time.Time
+}
+
+func (c *mixedFakeConn) Query(ctx context.Context, query string, args ...any) (driver.Rows, error) {
+	if contains(query, "ORDER BY toStartOfDay") {
+		c.queries = append(c.queries, query)
+		return &dayFakeRows{days: c.days}, nil
+	}
+	return c.fakeConn.Query(ctx, query, args...)
+}
+
+// TestVerify_ExcludesOutsideRetentionDaysFromMismatches is the core
+// cerberus issue #2652 regression: a day already past the aggregate
+// table's own retention is EXCLUDED from AggregateTotals / BaseTotals /
+// Mismatches (both totals responses agree once that day's rows are
+// dropped from both sides), and reported separately — with the resolved
+// Retention + RetentionBoundary — on Report.OutsideRetentionDays, never as
+// an unexplained FAIL.
+func TestVerify_ExcludesOutsideRetentionDaysFromMismatches(t *testing.T) {
+	c := testColumns()
+	now := time.Date(2026, 8, 26, 12, 0, 0, 0, time.UTC)
+	withFrozenNow(t, now)
+	retention := 24 * time.Hour // boundary = 2026-08-25T12:00:00Z
+	doomedDay := time.Date(2026, 8, 20, 0, 0, 0, 0, time.UTC)
+
+	conn := &mixedFakeConn{days: []time.Time{doomedDay}}
+	conn.respond = map[string][][2]any{
+		"`" + c.DeltaPrefixTable + "`": {{"http_requests_total", 100.0}},
+		"`" + c.SumTable + "`":         {{"http_requests_total", 100.0}},
+	}
+
+	rep, err := Verify(context.Background(), conn, c, testBefore, 0.01, retention)
+	if err != nil {
+		t.Fatalf("Verify: %v", err)
+	}
+	if !rep.Pass() {
+		t.Fatalf("expected Pass()=true (doomed day excluded, remaining totals match), got Mismatches=%+v", rep.Mismatches)
+	}
+	if rep.Retention != retention {
+		t.Errorf("Retention = %v; want %v", rep.Retention, retention)
+	}
+	wantBoundary := now.Add(-retention)
+	if !rep.RetentionBoundary.Equal(wantBoundary) {
+		t.Errorf("RetentionBoundary = %v; want %v", rep.RetentionBoundary, wantBoundary)
+	}
+	if len(rep.OutsideRetentionDays) != 1 || !rep.OutsideRetentionDays[0].Equal(doomedDay) {
+		t.Errorf("OutsideRetentionDays = %v; want [%v]", rep.OutsideRetentionDays, doomedDay)
+	}
+	if len(conn.queries) != 3 {
+		t.Fatalf("expected 3 queries (day-scan + aggregate + base), got %d: %v", len(conn.queries), conn.queries)
+	}
+}
+
+// TestVerify_RealMismatchSurvivesRetentionExclusion confirms a GENUINE
+// completeness gap (missed_metric, unrelated to the excluded day) is still
+// reported as a Mismatch even while an unrelated day is excluded for
+// being outside retention — the two mechanisms are independent, so
+// exclusion never masks a real bug.
+func TestVerify_RealMismatchSurvivesRetentionExclusion(t *testing.T) {
+	c := testColumns()
+	withFrozenNow(t, time.Date(2026, 8, 26, 12, 0, 0, 0, time.UTC))
+	retention := 24 * time.Hour
+	doomedDay := time.Date(2026, 8, 20, 0, 0, 0, 0, time.UTC)
+
+	conn := &mixedFakeConn{days: []time.Time{doomedDay}}
+	conn.respond = map[string][][2]any{
+		"`" + c.DeltaPrefixTable + "`": {{"http_requests_total", 100.0}},
+		"`" + c.SumTable + "`":         {{"http_requests_total", 100.0}, {"missed_metric", 5.0}},
+	}
+
+	rep, err := Verify(context.Background(), conn, c, testBefore, 0.01, retention)
+	if err != nil {
+		t.Fatalf("Verify: %v", err)
+	}
+	if rep.Pass() {
+		t.Fatal("expected a real mismatch (missed_metric) even with retention exclusion active")
+	}
+	if len(rep.Mismatches) != 1 || rep.Mismatches[0].MetricName != "missed_metric" {
+		t.Errorf("Mismatches = %+v; want exactly missed_metric", rep.Mismatches)
+	}
+	if len(rep.OutsideRetentionDays) != 1 {
+		t.Errorf("OutsideRetentionDays = %v; want exactly 1 excluded day", rep.OutsideRetentionDays)
+	}
+}
+
+// TestBackfill_PropagatesRetentionCheckQueryError confirms a Query failure
+// on Backfill's own pre-INSERT retention check surfaces as an error naming
+// the base table, and — critically — that Backfill does NOT proceed to
+// INSERT when the pre-check itself fails (an unknown retention state must
+// never be treated as "safe to write").
+func TestBackfill_PropagatesRetentionCheckQueryError(t *testing.T) {
+	c := testColumns()
+	withFrozenNow(t, time.Date(2026, 8, 26, 12, 0, 0, 0, time.UTC))
+	conn := &fakeConn{rowsErr: errors.New("connection reset")}
+	_, err := Backfill(context.Background(), conn, c, testBefore, 24*time.Hour)
+	if err == nil {
+		t.Fatal("expected an error from the retention-check Query failing")
+	}
+	if !contains(err.Error(), c.SumTable) {
+		t.Errorf("Backfill error %q does not name the base table %q", err.Error(), c.SumTable)
+	}
+	if len(conn.execSQL) != 0 {
+		t.Errorf("Backfill must not INSERT when the retention pre-check fails, got Exec calls: %v", conn.execSQL)
 	}
 }
 

--- a/internal/deltaprefix/doc.go
+++ b/internal/deltaprefix/doc.go
@@ -53,6 +53,63 @@
 // from that instant onward, so the two windows meet with no gap and no
 // overlap.
 //
+// # One-time backfill vs. the aggregate table's own steady-state TTL
+//
+// The DELTA-prefix table is provisioned with the SAME
+// `TTL toDateTime(BucketStart) + <retention>` shape the base metrics
+// tables use (internal/schema/ddl's renderDeltaPrefixTable), deliberately
+// kept in lockstep with the base table's own retention. That is correct
+// for STEADY STATE — once past the initial backfill, both tables age out
+// their oldest day together because both are populated continuously by
+// live traffic.
+//
+// It is NOT correct for the one-time backfill this package runs. If an
+// operator invokes Backfill with a `before` bound any time after the
+// earliest historical day has already crossed its own `BucketStart +
+// <retention>` instant, the resulting `INSERT ... SELECT` writes rows for
+// that day that are already past their own TTL the moment they land.
+// Because this table is small and merges frequently, ClickHouse's routine
+// background TTL cleanup reaps those rows almost immediately — often
+// within seconds to minutes, well before an operator gets a chance to run
+// Verify and see a clean state (cerberus issue #2652).
+//
+// This is NOT fixable by re-running Backfill, with or without narrowing to
+// just the affected day, with or without dropping and recreating the
+// table/MV: the constraint is the ROW'S OWN AGE relative to "now", not
+// anything about the write path. Any row for that day, however it is
+// inserted, is born already-expired.
+//
+// Both Backfill and Verify take an explicit `retention` duration (the
+// resolved CERBERUS_SCHEMA_TTL_METRICS value — see
+// internal/schemaboot.MetricsRetention, the same inherit-or-override rule
+// internal/schema/ddl's DDL rendering applies) precisely to detect this
+// case rather than mishandling it silently:
+//
+//   - Verify computes a retention boundary (now - retention, see
+//     retentionBoundary) and EXCLUDES any day whose BucketStart falls
+//     before it from AggregateTotals / BaseTotals / Mismatches — folding
+//     an unrecoverable day into the same FAIL as a genuine completeness
+//     gap would be indistinguishable from a real bug. Excluded days are
+//     reported separately, on Report.OutsideRetentionDays, with a clear
+//     notice rather than a bare unexplained FAIL.
+//   - Backfill runs the identical day-boundary check against the BASE
+//     table BEFORE its own INSERT — so the check cannot race the
+//     aggregate table's own TTL reaping the very rows it is about to
+//     write — and returns any doomed days on
+//     BackfillResult.OutsideRetentionDays: a clear warning, not
+//     necessarily an error, since the operator may already have accepted
+//     the loss or be intentionally re-running for the still-recoverable
+//     days.
+//
+// A retention of 0 (no TTL clause emitted at all — internal/schema/ddl's
+// ttlExpr) disables this check entirely: nothing can ever be reaped by
+// age, so no day is ever "outside retention". See docs/operations.md's
+// DELTA-prefix backfill runbook for the operator-facing warning: run the
+// backfill as soon as possible after creating the table/MV, and
+// definitely before the earliest available historical day crosses the
+// target table's own TTL boundary — after that point, that day can never
+// be recovered.
+//
 // # Scope: completeness, not series-identity alignment
 //
 // Verify compares aggregate totals GROUPED BY MetricName ONLY — a coarse,

--- a/internal/schemaboot/ddlconfig.go
+++ b/internal/schemaboot/ddlconfig.go
@@ -32,6 +32,22 @@ func resolveSignalDuration(global, override time.Duration) time.Duration {
 // deterministic regardless of any further Settings entries.
 const storagePolicySetting = "storage_policy"
 
+// MetricsRetention resolves the effective metrics-table retention TTL from
+// cfg's SchemaProvisioning knobs — CERBERUS_SCHEMA_TTL_METRICS overrides
+// CERBERUS_SCHEMA_TTL, the same inherit-or-override rule DDLConfig applies
+// to every per-signal TTL/tiering knob via resolveSignalDuration. Exported
+// so an operational tool that needs ONLY the effective metrics retention —
+// not the full auto-create DDL shape DDLConfig builds (which also demands
+// Validate() pass for tiering knobs unrelated to the caller's concern) —
+// doesn't have to duplicate the inherit rule: cmd/cerberus's
+// delta-prefix-backfill / delta-prefix-verify verbs use this to detect
+// when a backfilled day is already outside the DeltaPrefixTable's own TTL
+// as of the check's run time, a structurally unrecoverable state distinct
+// from a real completeness gap (cerberus issue #2652).
+func MetricsRetention(cfg config.Config) time.Duration {
+	return resolveSignalDuration(cfg.SchemaProvisioning.TTL, cfg.SchemaProvisioning.TTLMetrics)
+}
+
 // DDLConfig maps the runtime config into the typed internal/schema/ddl Config
 // the auto-create hook applies. The database name comes from the ClickHouse
 // connection config; the cluster / table-engine / TTL / Replicated
@@ -57,7 +73,7 @@ func DDLConfig(cfg config.Config) (ddl.Config, error) {
 		Cluster:  p.Cluster,
 		Engine:   p.TableEngine,
 		TTL: ddl.TTL{
-			Metrics: signalTTL(p.TTLMetrics),
+			Metrics: MetricsRetention(cfg),
 			Logs:    signalTTL(p.TTLLogs),
 			Traces:  signalTTL(p.TTLTraces),
 		},


### PR DESCRIPTION
## What

The DELTA-prefix aggregate table (`otel_metrics_sum_delta_prefix`) shares its
`TTL toDateTime(BucketStart) + <retention>` shape with the base metrics
tables — correct for steady state, but not for the one-time
`delta-prefix-backfill`: if an operator runs it any time after the earliest
available historical day has already crossed its own `BucketStart +
<retention>` instant, the resulting `INSERT ... SELECT` writes rows that are
already past their own TTL the moment they land. ClickHouse's background
merge reaps them almost immediately — often before `delta-prefix-verify`
even runs — and no sequence of backfill re-runs can ever recover that day.
`delta-prefix-verify` had no awareness of this and reported a permanent,
unexplained FAIL, indistinguishable from a real completeness bug.

This implements all three directions from #2652:

1. **Runbook warning** (`docs/operations.md`) — a security-review-grade
   warning, as prominent as the existing `--before` bound warning, to run
   the backfill as soon as possible after creating the table/MV and before
   the earliest historical day crosses the TTL boundary.
2. **`delta-prefix-verify`** now resolves the aggregate table's effective
   retention (`CERBERUS_SCHEMA_TTL_METRICS`, inheriting from
   `CERBERUS_SCHEMA_TTL`) and, for each day in its comparison window,
   detects whether it's already outside that retention as of the check's
   own run time. Such days are EXCLUDED from `AggregateTotals` /
   `BaseTotals` / the mismatch table (never folded into an unexplained
   FAIL) and reported separately on a new `Report.OutsideRetentionDays`
   field, rendered by the CLI as a clearly labeled `NOTE:` section. This is
   safe-by-default (always auto-detected, no flag) since silently hiding a
   real gap would be worse than an always-on, clearly-labeled notice.
3. **`delta-prefix-backfill`** now checks — against the base table, before
   issuing its own INSERT — whether any day in scope is already outside
   retention, and prints a loud `WARNING` (not an error; the command still
   exits `0`, since the operator may have already accepted the loss or be
   intentionally re-running for the recoverable days) instead of succeeding
   silently.

## Implementation notes

- `internal/deltaprefix`: `Verify` and `Backfill` both take a new
  `retention time.Duration` parameter. A package-level `nowFunc` var (not a
  bare `time.Now()`) keeps the day-boundary logic unit-testable without a
  live ClickHouse connection, per the package's own doc-comment promise.
  `aggregateTotalsSQL` / `baseTotalsSQL` gain an optional lower bound
  excluding already-expired days from both totals reads; a new
  `outsideRetentionDaysSQL` / `queryOutsideRetentionDays` reads the
  DISTINCT excluded days from the base table (not the aggregate table,
  which may have already had those very rows reaped).
- `internal/schemaboot`: new exported `MetricsRetention(cfg)` resolves the
  effective metrics TTL without duplicating `DDLConfig`'s inherit-or-override
  rule; `DDLConfig` itself now calls it too.
- `cmd/cerberus/cmd_schema.go`: both CLI verbs thread the resolved retention
  through and render the new distinction — `writeOutsideRetentionWarning`
  for the backfill verb, `writeOutsideRetentionNote` for the verify verb's
  report (both text and `--json` forms carry the new `Retention` /
  `RetentionBoundary` / `OutsideRetentionDays` fields).

## Test plan

- [x] `internal/deltaprefix`: new SQL-shape tests
      (`TestAggregateAndBaseTotalsSQL_RetentionActive`,
      `TestOutsideRetentionDaysSQL`, `TestRetentionBoundary`) plus
      end-to-end `Verify`/`Backfill` tests exercising the exclusion +
      warning paths against fake `Conn`s with a frozen clock
      (`TestVerify_ExcludesOutsideRetentionDaysFromMismatches`,
      `TestVerify_RealMismatchSurvivesRetentionExclusion`,
      `TestBackfill_DetectsOutsideRetentionDays`, and the
      retention-inactive / query-error counterparts) — all without chDB.
- [x] `cmd/cerberus`: new tests for the CLI report/warning rendering
      (`TestWriteDeltaPrefixVerifyReport_*`,
      `TestWriteOutsideRetentionWarning_BackfillCLI`).
- [x] `just test-unit` (whole tree, race-detected) — clean.
- [x] `just vet-tagged` — clean.
- [x] `node .github/scripts/forbid-sql-raw.mjs` — clean.
- [x] `markdownlint-cli2 docs/operations.md` — clean.

Closes #2652
