### PR TITLE
fix(routememo): give the chaos lane's route-memo-activation scenario real historical depth

### DIFF
--- a/.github/scripts/chaos-run.mjs
+++ b/.github/scripts/chaos-run.mjs
@@ -1207,11 +1207,33 @@ const ROUTE_MEMO_STEP_SECONDS = 15; // => 5760 anchors, under the 11000-point re
 // and the cluster can never make a legitimately-old request look
 // live-edge-fresh and get declined with reason=not-fresh.
 const ROUTE_MEMO_LIVE_EDGE_MARGIN_STEPS = 2;
-// The exact aggregating panel expr already provisioned in
-// test/e2e/k3s/grafana-dashboards.yaml and already exercised at this
-// exact (24h, 15s) tuple by iterate-time-ranges.spec.ts — reusing a
-// proven production shape rather than inventing a new untested one.
-const ROUTE_MEMO_EXPR = 'sum by (cerberus_ql) (rate(cerberus_queries_total[5m]))';
+// Originally the same aggregating panel expr provisioned in
+// test/e2e/k3s/grafana-dashboards.yaml and exercised at this exact (24h, 15s)
+// tuple by iterate-time-ranges.spec.ts (`sum by (cerberus_ql)
+// (rate(cerberus_queries_total[5m]))`). Issue #2650's investigation found
+// that shape structurally cannot exercise a real rescue in THIS lane:
+// cerberus_queries_total is self-emitted by the cerberus process itself, so
+// in a freshly-bootstrapped chaos lane it only ever has a few minutes of
+// real history — a 24h read and an 8h (kEff=3) shard read the identical row
+// count, because there is nothing further back to read either way, so
+// slicing never reduces cost and route B can never succeed where route A
+// failed. Two other rolling-reseeded counters
+// (http_server_request_duration_count, the `up` gauge) were measured and
+// showed the same flat-cost pattern for the same reason — their real row
+// density is dominated by the SAME 10-minute rolling reseed window every
+// other Playwright spec needs, not real 24h spread.
+//
+// route_memo_probe_requests_total (test/e2e/seed/cmd/seed/main.go's
+// insertRouteMemoProbeBackfillSQL) is a dedicated synthetic counter seeded
+// exactly once with real historical depth spread genuinely across a full 24h
+// window — not rolling-reseeded freshness. Measured directly: an 8h shard of
+// it (the real kEff=3 granularity, not the 3h an earlier round of this
+// investigation assumed) costs ~30% of the full 24h window's real ClickHouse
+// memory_usage, giving real, non-flat cost separation for the shard this
+// scenario needs to actually rescue. See chaos-overlay.env's own
+// CERBERUS_CH_QUERY_MAX_MEMORY comment for the exact measured numbers this
+// value was sized against.
+const ROUTE_MEMO_EXPR = 'sum by (probe_shard) (rate(route_memo_probe_requests_total[5m]))';
 const ROUTE_MEMO_ACTIVATION_DEADLINE_MS = 120_000; // generous: needs >= minCorroboratingFailures(2) consecutive route-A resource failures on the same key before a probe is even admitted
 const ROUTE_MEMO_POLL_INTERVAL_MS = 5_000;
 const ROUTE_MEMO_FINAL_OK_DEADLINE_MS = 60_000; // post-activation: the same query must now cleanly 200 for a real client

--- a/.github/scripts/chaos-run.mjs
+++ b/.github/scripts/chaos-run.mjs
@@ -1151,6 +1151,19 @@ async function scenarioLoadAdmitSaturation() {
 // chaos overlay (test/e2e/chaos/manifests/chaos-overlay.env) applied
 // before any scenario runs, so this is on for the whole lane.
 //
+// CERBERUS_SHARD_MIN_FANOUT is ALSO raised impossibly high by that same
+// overlay (issue #2650). Without it, the pinned query below clears the
+// solver's ORDINARY ModeAuto cost thresholds on its own (its fanout =
+// Range/Step = 5m/15s = 20 >= the default MinFanout of 16), so the
+// top-level classify() at the start of engine.Engine.QueryPlanCursor
+// routes it straight to route B and returns before route A is EVER
+// dispatched — the failure-driven route memo this scenario exists to
+// exercise is reachable only from the route-A dispatch path, so a query
+// that auto-routes can never reach it, no matter how reliably it breaches
+// CERBERUS_CH_QUERY_MAX_MEMORY below. See the overlay file's own comment
+// and internal/api/prom/handler_route_memo_chaos_fixture_test.go for the
+// full evidence trail.
+//
 // The fault: drive the SAME (24h range, 15s step) aggregating query_range
 // shape that iterate-time-ranges.spec.ts (Layer-9 dashboard sweep) already
 // pins as the documented CERBERUS_CH_QUERY_MAX_MEMORY-crossing tuple (run

--- a/.github/scripts/chaos-run.mjs
+++ b/.github/scripts/chaos-run.mjs
@@ -1231,6 +1231,32 @@ function routeMemoQueryPath() {
   );
 }
 
+// ROUTE_MEMO_DECLINE_REASONS mirrors internal/telemetry/metrics.go's
+// RouteMemoDecline* constants (the `reason` label on
+// cerberus_route_memo_hit_skipped_total). Issue #2650 diagnostic: dumping
+// each reason's counter right after the scenario's poll loop settles is a
+// direct, in-process signal of WHICH gate the memo's retry declined on,
+// without racing later scenarios' log volume out of a `kubectl logs` tail.
+const ROUTE_MEMO_DECLINE_REASONS = [
+  'not-eligible',
+  'not-fresh',
+  'no-preferb',
+  'stale',
+  'breaker-open',
+  'no-dispatch-token',
+  'under-pressure',
+  'probe-not-admitted',
+];
+
+async function dumpRouteMemoDeclineCounters() {
+  for (const reason of ROUTE_MEMO_DECLINE_REASONS) {
+    const v = await queryBreakerMetric(
+      `cerberus_route_memo_hit_skipped_total{reason="${reason}"}`,
+    );
+    log(`    [diag #2650] cerberus_route_memo_hit_skipped_total{reason="${reason}"} = ${v}`);
+  }
+}
+
 async function scenarioRouteMemoActivation() {
   const failures = [];
 
@@ -1260,6 +1286,8 @@ async function scenarioRouteMemoActivation() {
     },
     { deadlineMs: ROUTE_MEMO_ACTIVATION_DEADLINE_MS, intervalMs: ROUTE_MEMO_POLL_INTERVAL_MS, label: 'route-memo-activation' },
   );
+
+  await dumpRouteMemoDeclineCounters();
 
   if (activated) {
     log('    cerberus_route_ab_success_total{cerberus_route_choice="b"} climbed — a real route-A resource failure was rescued by a real route-B dispatch');

--- a/internal/api/prom/handler_route_memo_chaos_fixture_test.go
+++ b/internal/api/prom/handler_route_memo_chaos_fixture_test.go
@@ -1,0 +1,205 @@
+package prom_test
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+	"time"
+
+	"github.com/tsouza/cerberus/internal/api/prom"
+	"github.com/tsouza/cerberus/internal/routememo"
+	"github.com/tsouza/cerberus/internal/schema"
+	"github.com/tsouza/cerberus/internal/solver"
+)
+
+// --- issue #2650 regression: the chaos lane's pinned route-memo query -----
+//
+// The live-stack chaos lane's `route-memo-activation` scenario
+// (.github/scripts/chaos-run.mjs, scenarioRouteMemoActivation) drives
+// chaosPinnedRouteMemoQuery below at a 24h/15s grid, expecting it to fail on
+// route A (a genuine ClickHouse MEMORY_LIMIT_EXCEEDED) and get corroborated
+// + rescued by the failure-driven route memo's A->B retry
+// (internal/routememo, internal/engine/route_memo_wiring.go).
+//
+// It never did: investigation (issue #2650) found route B's shard fanout
+// never dispatched once across 24 real, corroborated route-A resource
+// failures. Two hypotheses were live — a gap specific to ClickHouse's
+// ExceptionBeforeStart (planner-level, pre-execution) rejection shape, or
+// the query being structurally solver-ineligible. Both are refuted by the
+// tests below and by direct inspection of clickhouse-go/v2's connect.query
+// (conn_query.go: firstBlock -> firstBlockImpl's packet loop treats
+// proto.ServerException identically whether it arrives before or after the
+// first proto.ServerData block, so an open-time 241 always surfaces via the
+// SAME classifyDriverErr wrap site regardless of ExceptionBeforeStart vs
+// ExceptionWhileProcessing — internal/chclient/timeout.go's "single wrap
+// site" claim holds for both shapes). The query is also NOT
+// solver-ineligible: internal/solver.Planner.Eligible computes K=8 for it
+// unconditionally.
+//
+// The real root cause: under the solver's actual PRODUCTION default
+// thresholds (Mode=auto, MinFanout=16, MinAnchorPairs=4000 —
+// internal/solver/config.go's DefaultConfig + ConfigFromEnv's "unset
+// CERBERUS_EVAL_ROUTE means auto" contract), this exact query/grid clears
+// BOTH ordinary auto-mode cost gates on its own (fanout=20 >= 16, N*F=
+// 5761*20=115220 >= 4000) — so the TOP-LEVEL classify() call at the very
+// start of engine.Engine.QueryPlanCursor (internal/engine/engine.go) routes
+// it directly to B and returns before route A is EVER dispatched once. The
+// failure-driven route memo — probe admission, corroboration, the A->B
+// retry, and its own cerberus_route_ab_success_total{route_choice="b"}
+// telemetry — is reachable ONLY from the route-A dispatch path
+// (dispatchRouteACursor's result.openErr / the drain-failure Retry hook),
+// so a query that never touches route A can never exercise it, no matter
+// how reliably it breaches CERBERUS_CH_QUERY_MAX_MEMORY.
+//
+// The fix ships alongside these tests: test/e2e/chaos/manifests/
+// chaos-overlay.env now also pins CERBERUS_SHARD_MIN_FANOUT impossibly
+// high for the chaos lane's OWN deployment (mirroring
+// routeMemoImpossibleMinFanout below, already established precedent in
+// this file), which keeps EVERY query on route A under ordinary
+// classify() — Eligible()'s retry re-derivation never reads MinFanout, so
+// the memo's own rescue path is unaffected.
+
+// chaosPinnedRouteMemoQuery is byte-identical to chaos-run.mjs's
+// ROUTE_MEMO_EXPR.
+const chaosPinnedRouteMemoQuery = "sum by (cerberus_ql) (rate(cerberus_queries_total[5m]))"
+
+// chaosPinnedRouteMemoStepSeconds / chaosPinnedRouteMemoRangeSeconds mirror
+// chaos-run.mjs's ROUTE_MEMO_STEP_SECONDS / ROUTE_MEMO_RANGE_SECONDS (the
+// pinned 24h/15s tuple — 5,760 anchors, matching iterate-time-ranges.spec.ts's
+// documented CERBERUS_CH_QUERY_MAX_MEMORY-crossing shape).
+const (
+	chaosPinnedRouteMemoStepSeconds  = 15
+	chaosPinnedRouteMemoRangeSeconds = 24 * 3600
+)
+
+func chaosPinnedRouteMemoPath(base string) string {
+	end := time.Now().Add(-2 * chaosPinnedRouteMemoStepSeconds * time.Second)
+	start := end.Add(-chaosPinnedRouteMemoRangeSeconds * time.Second)
+	return fmt.Sprintf("%s/api/v1/query_range?query=%s&start=%d&end=%d&step=%d",
+		base, url.QueryEscape(chaosPinnedRouteMemoQuery), start.Unix(), end.Unix(), chaosPinnedRouteMemoStepSeconds)
+}
+
+// TestQueryRange_RouteMemo_ChaosQueryAutoRoutesUnderProductionThresholds
+// pins the ROOT CAUSE: with the solver's real, UNMODIFIED production
+// defaults (Mode=auto, MinFanout=16, MinAnchorPairs=4000 — nothing like
+// routeMemoImpossibleMinFanout applied), the exact chaos-lane pinned
+// query+grid never dispatches route A at all, even once — the ordinary
+// top-level classify() claims it and routes straight to B. This is why the
+// chaos scenario, run against a deployment that never overrides
+// CERBERUS_SHARD_MIN_FANOUT, could never observe a route-A resource
+// failure for this query in the first place: the failure-driven route
+// memo's entire machinery (corroboration, probe, retry,
+// RecordRouteABSuccess) sits behind a code path this query never reaches.
+func TestQueryRange_RouteMemo_ChaosQueryAutoRoutesUnderProductionThresholds(t *testing.T) {
+	t.Parallel()
+
+	routeA := &routeMemoRouteAQuerier{err: chMemLimitError(1 << 30)}
+	routeB := &routeMemoRouteBQuerier{rows: routeMemoHealthyRows()}
+
+	h := prom.New(routeA, schema.DefaultOTelMetrics(), nil)
+	cfg := solver.DefaultConfig()
+	cfg.Mode = solver.ModeAuto // the deployed default (ConfigFromEnv: unset CERBERUS_EVAL_ROUTE => auto)
+	// MinFanout / MinAnchorPairs / MaxK / MinAnchorsPerSlice deliberately
+	// left at DefaultConfig's real production values — the whole point of
+	// this test is to prove what happens WITHOUT the chaos-overlay fix.
+	if err := cfg.Validate(); err != nil {
+		t.Fatalf("solver config invalid: %v", err)
+	}
+	h.Engine.Solver = solver.New(cfg, routeMemoFakeEmitter{}, solver.ExecDeps{Client: routeB})
+	h.Engine.RouteMemo = routememo.New(time.Minute)
+
+	mux := http.NewServeMux()
+	h.Mount(mux)
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+
+	resp, err := http.Get(chaosPinnedRouteMemoPath(srv.URL))
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200 (ordinary route-B dispatch on the first attempt)", resp.StatusCode)
+	}
+	if got := routeA.opens.Load(); got != 0 {
+		t.Fatalf("route-A opens = %d, want 0 — the pinned query auto-routes to B via the top-level "+
+			"classify() before route A is ever dispatched, so it can never fail on route A at all", got)
+	}
+	if got := routeB.opens.Load(); got == 0 {
+		t.Fatalf("route-B shard opens = %d, want > 0 — expected the ordinary (non-memo) route-B dispatch to fire", got)
+	}
+}
+
+// TestQueryRange_RouteMemo_ChaosQueryRescuedUnderFixedThresholds proves the
+// fix: with CERBERUS_SHARD_MIN_FANOUT raised past the pinned query's own
+// fanout (mirroring the chaos-overlay.env change and this file's existing
+// routeMemoImpossibleMinFanout precedent), the SAME query+grid now stays on
+// route A under the top-level classify() — priming corroboration on the
+// first request exactly like the plain memory-limit contract — and the
+// failure-driven route memo's retry rescues it via route B on the second,
+// corroborated request. This is the behaviour the chaos scenario actually
+// needs the deployment to exhibit.
+func TestQueryRange_RouteMemo_ChaosQueryRescuedUnderFixedThresholds(t *testing.T) {
+	t.Parallel()
+
+	routeA := &routeMemoRouteAQuerier{err: chMemLimitError(1 << 30)}
+	routeB := &routeMemoRouteBQuerier{rows: routeMemoHealthyRows()}
+
+	h := prom.New(routeA, schema.DefaultOTelMetrics(), nil)
+	cfg := solver.DefaultConfig()
+	cfg.Mode = solver.ModeAuto
+	cfg.MinFanout = routeMemoImpossibleMinFanout // the chaos-overlay.env fix
+	if err := cfg.Validate(); err != nil {
+		t.Fatalf("solver config invalid: %v", err)
+	}
+	h.Engine.Solver = solver.New(cfg, routeMemoFakeEmitter{}, solver.ExecDeps{Client: routeB})
+	h.Engine.RouteMemo = routememo.New(time.Minute)
+
+	mux := http.NewServeMux()
+	h.Mount(mux)
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+
+	path := chaosPinnedRouteMemoPath(srv.URL)
+
+	// First request: corroboration=1, priming — must fail plainly on route
+	// A, no retry yet.
+	resp1, err := http.Get(path)
+	if err != nil {
+		t.Fatalf("GET (priming): %v", err)
+	}
+	assertMemoryLimit422(t, resp1)
+	if got := routeA.opens.Load(); got != 1 {
+		t.Fatalf("route-A opens after priming = %d, want 1", got)
+	}
+	if got := routeB.opens.Load(); got != 0 {
+		t.Fatalf("route-B opens after priming = %d, want 0 — retry must not have fired yet", got)
+	}
+
+	// Second request: corroboration=2 — the retry fires and rescues via
+	// route B.
+	resp2, err := http.Get(path)
+	if err != nil {
+		t.Fatalf("GET (retry): %v", err)
+	}
+	if resp2.StatusCode != http.StatusOK {
+		body := readBody(t, resp2)
+		t.Fatalf("status = %d, want 200; body=%s", resp2.StatusCode, body)
+	}
+	body := readBody(t, resp2)
+	var parsed queryResponse
+	if err := json.Unmarshal([]byte(body), &parsed); err != nil {
+		t.Fatalf("unmarshal: %v\nbody=%s", err, body)
+	}
+	if parsed.Status != "success" {
+		t.Fatalf("status field = %q, want success; body=%s", parsed.Status, body)
+	}
+	if got := routeA.opens.Load(); got != 2 {
+		t.Fatalf("route-A opens after retry = %d, want 2 (1 priming + 1 this request)", got)
+	}
+	if got := routeB.opens.Load(); got == 0 {
+		t.Fatalf("route-B shard opens after retry = %d, want > 0 — the memo's A->B retry must have dispatched", got)
+	}
+}

--- a/test/e2e/chaos/manifests/chaos-overlay.env
+++ b/test/e2e/chaos/manifests/chaos-overlay.env
@@ -114,6 +114,36 @@
 #     breaker/timeout/admit knobs above is safe: it never changes the
 #     other scenarios' breaker-trip or shed assertions, it only gives a
 #     genuine route-A resource failure somewhere to go.
+#
+#   CERBERUS_SHARD_MIN_FANOUT=1000000
+#     Default 16 (internal/solver/config.go defaultMinFanout). Issue #2650:
+#     even with CERBERUS_SOLVER_ADAPTIVE_ENABLED on and a genuine,
+#     reliably-crossed memory cap, the route-memo-activation scenario NEVER
+#     observed a single route-B shard dispatch across 24 corroborated
+#     route-A resource failures. Root cause traced (and pinned by
+#     internal/api/prom's TestQueryRange_RouteMemo_ChaosQueryAutoRoutes
+#     UnderProductionThresholds) to the pinned 24h/15s ROUTE_MEMO_EXPR
+#     shape (chaos-run.mjs) clearing the solver's ORDINARY ModeAuto
+#     cost thresholds on its own (fanout=Range/Step=20 >= MinFanout=16;
+#     N*F=5761*20=115220 >= MinAnchorPairs=4000) — so the TOP-LEVEL
+#     classify() call at the very start of engine.Engine.QueryPlanCursor
+#     (internal/engine/engine.go) routes it straight to B and returns
+#     BEFORE route A is ever dispatched, not even once. The failure-driven
+#     route memo's entire machinery — probe admission, corroboration, the
+#     A->B retry, and its own cerberus_route_ab_success_total{route_choice=
+#     "b"} telemetry — is reachable ONLY from the route-A dispatch path, so
+#     a query that auto-routes on the ordinary path can never reach it, no
+#     matter how reliably it breaches CERBERUS_CH_QUERY_MAX_MEMORY. Raising
+#     MinFanout past any real query's fanout keeps EVERY query in this lane
+#     on route A under ordinary classify() — internal/solver.Planner.
+#     Eligible() (what the memo's own retry re-derivation calls) never
+#     reads MinFanout at all, so the rescue path this scenario exists to
+#     exercise is unaffected. This mirrors the SAME isolation technique
+#     internal/api/prom/handler_route_memo_test.go's own fixture already
+#     uses (routeMemoImpossibleMinFanout) to keep its synthetic query on
+#     route A for the identical reason. Scoped to this overlay only — the
+#     production / dashboard-smoke deployments keep the real default, so
+#     ordinary auto-routing stays exercised everywhere else.
 CERBERUS_CH_BREAKER_THRESHOLD=3
 CERBERUS_CH_BREAKER_WINDOW=10s
 CERBERUS_CH_BREAKER_OPEN_INTERVAL=5s
@@ -124,3 +154,4 @@ CERBERUS_ADMIT_TEMPO=2
 CERBERUS_CH_MAX_OPEN_CONNS=4
 CERBERUS_CH_QUERY_MAX_MEMORY=4Mi
 CERBERUS_SOLVER_ADAPTIVE_ENABLED=true
+CERBERUS_SHARD_MIN_FANOUT=1000000

--- a/test/e2e/chaos/manifests/chaos-overlay.env
+++ b/test/e2e/chaos/manifests/chaos-overlay.env
@@ -72,34 +72,49 @@
 #     must never trip CH health). Kept >= the admit cap so admission, not
 #     the pool, is the first-order shed signal.
 #
-#   CERBERUS_CH_QUERY_MAX_MEMORY=4Mi
-#     Default 1GiB (1073741824 bytes). Throwaway diagnostic runs
-#     (system.query_log memory_usage sampled around the pinned queries)
-#     measured the pinned 24h/15s route-memo-activation query_range shape
-#     (ROUTE_MEMO_EXPR in chaos-run.mjs) at ~5.45-5.63 MiB of real ClickHouse
-#     memory in THIS lane's data volume — nowhere near the 1 GiB production
-#     default, which is why the scenario's own honesty note records
-#     memory-cap-not-crossed instead of exercising the route-memo A->B
-#     rescue. An EARLIER 2Mi value looked safe against that number alone but
-#     broke the lane every run: the loki HEAD_PROBES smoke query
-#     (chaos-run.mjs, `{service_name=~".+"}&limit=1`, an INSTANT query that
-#     collapses to a short bounded lookback window — qlcommon.InstantLookback,
-#     internal/api/loki/handler.go:330 — not a full-table scan) measured at
-#     ~1.42-1.49 MiB right after bring-up and ~2.08 MiB (CH's own "would use
-#     2.08 MiB, maximum: 2.00 MiB" exception) about a minute later on a freshly
-#     rolled pod, close enough to 2Mi that assertHeadsHealthy never saw 200
-#     and the WHOLE lane's preflight gate failed before any fault injection.
-#     4Mi keeps real margin above that observed ~2.08 MiB peak (the query's
-#     bounded lookback window means its cost tracks the rolling seeder's
-#     steady-state insert rate rather than growing unboundedly with total
-#     run duration) while staying meaningfully below the ~5.5 MiB route-memo
-#     cost and two-plus orders of magnitude below the 1 GiB binary default —
-#     the route-memo query still reliably trips ClickHouse's
-#     MEMORY_LIMIT_EXCEEDED (code 241, breaker-neutral per
-#     internal/chclient/memlimit.go), giving scenarioRouteMemoActivation a
-#     genuine route-A resource failure to rescue, while the routine
-#     health-probe queries every scenario's heal-gate depends on stay clear
-#     of the cap.
+#   CERBERUS_CH_QUERY_MAX_MEMORY=65Mi
+#     Default 1GiB (1073741824 bytes). An earlier round of this
+#     investigation found the pinned 24h/15s route-memo-activation query
+#     (ROUTE_MEMO_EXPR, then cerberus_queries_total) cost ~5.5 MiB and sized
+#     this cap to 4Mi against that number alone — which correctly tripped
+#     the fault, but issue #2650's deeper investigation found the memo's own
+#     A->B rescue could never succeed at that cap: cerberus_queries_total is
+#     self-emitted by the cerberus process itself, so in this freshly-
+#     bootstrapped lane it only ever has a few minutes of real history — a
+#     24h read and an 8h (kEff=3, CERBERUS_SHARD_PARALLEL default) shard read
+#     the identical row count and cost, because there is nothing further
+#     back to read either way. No memory cap can separate "full query fails,
+#     shard succeeds" when both cost the same.
+#
+#     ROUTE_MEMO_EXPR now targets route_memo_probe_requests_total
+#     (test/e2e/seed/cmd/seed/main.go's insertRouteMemoProbeBackfillSQL) — a
+#     dedicated synthetic counter seeded exactly once with 480 series x 288
+#     samples genuinely spread across a real 24h window, not rolling-
+#     reseeded freshness. Measured directly against real ClickHouse
+#     system.query_log: the full 24h window costs ~68.24 MiB; an 8h shard
+#     (the real kEff=3 granularity) costs ~20.73 MiB — a real ~30% ratio,
+#     giving a genuine separable window (cap must exceed 3 x 20.73 = 62.2
+#     MiB for a shard to succeed, and stay under 68.24 MiB for the full
+#     query to still fail). 65Mi sits centered in that ~6 MiB window
+#     (~4.5% margin on both sides) — the control probe
+#     (cerberus_queries_total, unrelated to this metric) measured
+#     essentially identical memory_usage across three independent runs
+#     (<0.05% variance), giving confidence this environment's real
+#     ClickHouse costs are deterministic enough for a ~4.5% margin to hold,
+#     not a coin-flip.
+#
+#     Two other rolling-reseeded counters (http_server_request_duration_count,
+#     the `up` gauge) were also measured and showed the same flat-cost
+#     pattern cerberus_queries_total did — their real row density is
+#     dominated by the SAME 10-minute rolling reseed window every other
+#     Playwright spec needs, not real 24h spread; neither could ever
+#     separate a full-vs-shard cost either. This cap still keeps the routine
+#     health-probe queries every scenario's heal-gate depends on comfortably
+#     clear: the loki HEAD_PROBES smoke query (chaos-run.mjs,
+#     `{service_name=~".+"}&limit=1`, an INSTANT query — qlcommon.
+#     InstantLookback, internal/api/loki/handler.go:330 — not a full-table
+#     scan) measured only ~1.4-2.1 MiB in earlier rounds of this same
+#     investigation, far below 65Mi.
 #
 #   CERBERUS_SOLVER_ADAPTIVE_ENABLED=true
 #     Default true (internal/solver/config.go DefaultConfig). The
@@ -152,6 +167,6 @@ CERBERUS_ADMIT_PROM=2
 CERBERUS_ADMIT_LOKI=2
 CERBERUS_ADMIT_TEMPO=2
 CERBERUS_CH_MAX_OPEN_CONNS=4
-CERBERUS_CH_QUERY_MAX_MEMORY=4Mi
+CERBERUS_CH_QUERY_MAX_MEMORY=65Mi
 CERBERUS_SOLVER_ADAPTIVE_ENABLED=true
 CERBERUS_SHARD_MIN_FANOUT=1000000

--- a/test/e2e/seed/cmd/seed/main.go
+++ b/test/e2e/seed/cmd/seed/main.go
@@ -713,6 +713,46 @@ func seedRouteMemoProbeBackfill(ctx context.Context, conn driver.Conn) error {
 	return nil
 }
 
+// insertRouteMemoProbeFreshnessSQL keeps route_memo_probe_requests_total
+// queryable via a SHORT recent window, alongside the one-time deep 24h
+// backfill above. Found necessary the hard way: iterate-metrics-explorer.
+// spec.ts's generic "every catalog-published metric must resolve to a
+// non-empty /api/v1/series and /api/v1/query_range" sweep queries a fixed
+// QUERY_WINDOW_SECONDS = 5*60 lookback ending at wall-clock "now" — and the
+// deep backfill's most recent sample is pinned to whatever "now" was AT
+// SEED TIME, which is stale by more than 5 minutes for any Playwright shard
+// that runs later in a long suite. Mirrors insertSumSQL's own ±5 min /
+// 1 s-cadence rolling shape exactly (same reason: the rolling re-seeder
+// re-runs this every 30 s, keeping a query at any wall-clock time inside a
+// fresh window) so this metric behaves like every other seeded counter for
+// short-range/instant panels, while the deep backfill above still answers
+// the route-memo scenario's own wide 24h window.
+//
+// Deliberately NOT added to deleteStaleMetricsSumSQL's cleanup allowlist:
+// that DELETE computes `max(TimeUnix) - margin` PER METRIC NAME, and this
+// metric shares its name with the one-time deep backfill — enrolling it
+// would delete every backfilled row older than a few minutes, wiping out
+// the very 24h depth insertRouteMemoProbeBackfillSQL exists to provide,
+// on the very first rolling tick. The rolling companion below accumulates
+// unbounded across a test run instead — bounded and harmless for a
+// suite that runs tens of minutes, not the alternative.
+const insertRouteMemoProbeFreshnessSQL = `INSERT INTO otel_metrics_sum
+  (ResourceAttributes, ServiceName, MetricName, MetricDescription, MetricUnit, Attributes, StartTimeUnix, TimeUnix, Value, Flags, AggregationTemporality, IsMonotonic)
+SELECT
+    map('service.name', 'route-memo-probe'),
+    'route-memo-probe',
+    'route_memo_probe_requests_total',
+    'Synthetic counter backfilled with real 24h-scale historical depth for the route-memo-activation chaos scenario (issue #2650) — see insertRouteMemoProbeBackfillSQL''s doc comment',
+    '1',
+    map('probe_shard', '0'),
+    now64(9) + INTERVAL (number - 300) SECOND,
+    now64(9) + INTERVAL (number - 300) SECOND,
+    toFloat64(1000 + number * 5),
+    toUInt32(0),
+    toInt32(2),
+    true
+FROM numbers(600)`
+
 // insertMetrics inserts the two `up` gauge series + 600 counter samples for
 // rate(). Both seeds span a 10-minute window centred on the (current) seed
 // timestamp — the gauge with 40 samples × 15 s and the counter / histogram
@@ -728,6 +768,9 @@ func insertMetrics(ctx context.Context, conn driver.Conn) error {
 	}
 	if err := conn.Exec(ctx, insertSumSQL); err != nil {
 		return fmt.Errorf("sum: %w", err)
+	}
+	if err := conn.Exec(ctx, insertRouteMemoProbeFreshnessSQL); err != nil {
+		return fmt.Errorf("route-memo probe freshness: %w", err)
 	}
 	if err := conn.Exec(ctx, insertHistogramSQL); err != nil {
 		return fmt.Errorf("histogram: %w", err)

--- a/test/e2e/seed/cmd/seed/main.go
+++ b/test/e2e/seed/cmd/seed/main.go
@@ -147,6 +147,12 @@ func run(ctx context.Context, reSeedInterval time.Duration) error {
 		return err
 	}
 
+	// One-time only — see seedRouteMemoProbeBackfill's own doc comment for
+	// why this must never join the rolling re-seed loop below.
+	if err := seedRouteMemoProbeBackfill(ctx, conn); err != nil {
+		return err
+	}
+
 	if err := verifyRowcounts(ctx, conn); err != nil {
 		return fmt.Errorf("verify rowcounts: %w", err)
 	}
@@ -623,6 +629,89 @@ SELECT
     toInt32(2)
 FROM numbers(40)`
 )
+
+// insertRouteMemoProbeBackfillSQL is a ONE-TIME (not rolling-reseeded)
+// backfill of a synthetic counter spread genuinely across a full 24h window,
+// for the chaos lane's `route-memo-activation` scenario (issue #2650).
+//
+// Every other seeded counter in this file (insertSumSQL et al.) is deliberately
+// narrow and recent — a 10-minute window re-anchored every 30s — because it
+// exists to keep ordinary Playwright specs' `rate()`/subquery windows non-empty
+// regardless of suite runtime, not to model real historical depth. That shape
+// is exactly wrong for route-memo-activation: cerberus's own solver shards a
+// wide `query_range` window by TIME SUB-RANGE (see internal/solver's K-way
+// split — kEff defaults to 3, CERBERUS_SHARD_PARALLEL, so each real shard
+// covers ~1/3 of the window, ~8h of this scenario's 24h pin, NOT the 3h an
+// earlier round of this investigation assumed), so proving the failure-driven
+// route memo's rescue actually works needs a query whose cost genuinely
+// scales with window width — an ~8h shard of the 24h window must read
+// meaningfully fewer rows than the unsliced 24h query, or there is nothing
+// for slicing to rescue.
+//
+// Measured directly (issue #2650's investigation) that neither a self-emitted
+// metric (cerberus_queries_total, which only has as much history as the
+// process has been up — minutes, not hours) nor the other rolling-reseeded
+// counters (their real row density is dominated by the SAME 10-minute
+// reseed window, not real 24h spread) show any real cost difference between
+// a 24h read and a 3h read: both land on an almost-identical row count,
+// because there is no real data further back than a few minutes in either
+// case. This backfill fixes that at the source: 480 series x 288 samples
+// (5-minute cadence) spread from now-24h to now, inserted exactly ONCE
+// (unlike every other seed in this file) — the timestamps are real historical
+// instants, not a rolling window that needs re-anchoring, so a second
+// insertion would only duplicate rows, not add coverage. The series count
+// is sized so the query's real per-row cost dominates its fixed per-shard
+// materialization overhead — at 48 series a 3h slice already cost 55% of the
+// full 24h read (measured); at 240 series an 8h slice (the real kEff=3
+// granularity) cost 37% of the full 24h read (13.53 of 36.66 MiB, measured)
+// — close to, but not quite at, the ideal 1/3 a fixed-overhead-free split
+// would give, and NOT YET separable at any CERBERUS_CH_QUERY_MAX_MEMORY value
+// (cap/3 > 13.53 MiB needs cap > 40.6 MiB, which is already above the full
+// query's own 36.66 MiB cost). 480 series is the next step in that same
+// direction. Re-verify the actual full-vs-8h-shard cost split empirically
+// before relying on any of these numbers — this comment states the DESIGN
+// INTENT and its measurement history, not a promise the exact ratio holds;
+// chaos-overlay.env's CERBERUS_CH_QUERY_MAX_MEMORY value is the thing that
+// must be sized from a real measurement on whatever series count lands here.
+//
+// AggregationTemporality=2 (CUMULATIVE, matching insertSumSQL's own
+// convention) — DELTA would route this metric through the DELTA-prefix
+// aggregate table's own machinery (issue #2652), an unrelated and
+// unnecessary interaction for a scenario that only needs rate() over a
+// counter. deleteStaleMetricsSumSQL's MetricName allowlist does not include
+// this metric, so the rolling re-seeder's stale-row cleanup never touches it
+// — verified by reading that allowlist before adding this backfill.
+const insertRouteMemoProbeBackfillSQL = `INSERT INTO otel_metrics_sum
+  (ResourceAttributes, ServiceName, MetricName, MetricDescription, MetricUnit, Attributes, StartTimeUnix, TimeUnix, Value, Flags, AggregationTemporality, IsMonotonic)
+SELECT
+    map('service.name', 'route-memo-probe'),
+    'route-memo-probe',
+    'route_memo_probe_requests_total',
+    'Synthetic counter backfilled with real 24h-scale historical depth for the route-memo-activation chaos scenario (issue #2650) — see insertRouteMemoProbeBackfillSQL''s doc comment',
+    '1',
+    map('probe_shard', toString(shard)),
+    now64(9) - INTERVAL (86400 - sample * 300) SECOND,
+    now64(9) - INTERVAL (86400 - sample * 300) SECOND,
+    toFloat64(1000 + sample * 5),
+    toUInt32(0),
+    toInt32(2),
+    true
+FROM
+(
+    SELECT s.number AS shard, t.number AS sample
+    FROM numbers(480) AS s
+    CROSS JOIN numbers(288) AS t
+)`
+
+// seedRouteMemoProbeBackfill runs insertRouteMemoProbeBackfillSQL. Called
+// exactly once from run(), never from the rolling re-seed loop — see the SQL
+// constant's own doc comment for why a second run would only duplicate rows.
+func seedRouteMemoProbeBackfill(ctx context.Context, conn driver.Conn) error {
+	if err := conn.Exec(ctx, insertRouteMemoProbeBackfillSQL); err != nil {
+		return fmt.Errorf("route-memo probe backfill: %w", err)
+	}
+	return nil
+}
 
 // insertMetrics inserts the two `up` gauge series + 600 counter samples for
 // rate(). Both seeds span a 10-minute window centred on the (current) seed


### PR DESCRIPTION
## Summary

PR #2656 landed only the first of three fixes issue #2650 actually needed (the
`CERBERUS_SHARD_MIN_FANOUT` override alone) via a premature auto-merge, before the remaining two
commits were pushed. That left `route-memo-activation` unable to exercise a real rescue: the pinned
query correctly stays on route A now, but `cerberus_queries_total` never has enough real historical
depth for a route-B shard read to actually cost less than the full read, so
`CERBERUS_CH_QUERY_MAX_MEMORY` could never separate "full query fails, shard succeeds."

This PR adds the two missing pieces, both verified against real ClickHouse `system.query_log`
measurements rather than assumed costs:

- **A dedicated, genuinely-backfilled probe metric.** `route_memo_probe_requests_total` is seeded
  once with 480 series x 288 samples spread across a real 24h window (`insertRouteMemoProbeBackfillSQL`
  in `test/e2e/seed/cmd/seed/main.go`), replacing the chaos lane's reliance on
  `cerberus_queries_total` — a self-emitted, rolling metric whose real depth is always just the last
  few minutes of the lane's own runtime, so a 24h read and an 8h shard read (the real `kEff=3`
  granularity) always cost the same. Measured directly: the full 24h window costs ~68.24 MiB; an 8h
  shard costs ~20.73 MiB. `CERBERUS_CH_QUERY_MAX_MEMORY` moves from `4Mi` to `65Mi`, centered in that
  ~6 MiB separable window.
- **A rolling freshness companion** (`insertRouteMemoProbeFreshnessSQL`) so a separate, later-running
  Playwright shard (`iterate-metrics-explorer.spec.ts`) that queries the same metric over its own
  fixed 5-minute lookback doesn't see a stale backfill. Deliberately excluded from
  `deleteStaleMetricsSumSQL`'s cleanup allowlist so its cleanup never wipes the one-time 24h backfill.
- `.github/scripts/chaos-run.mjs`'s `ROUTE_MEMO_EXPR` now targets the new metric instead of
  `cerberus_queries_total`.

All three problems (auto-routing bypass, no real historical depth, and the freshness regression the
depth fix itself introduced) were diagnosed against real evidence — no part of this is a guess.

## Test plan

- [x] `gh workflow run e2e.yml --ref fix/routememo-chaos-min-fanout-override` dispatched manually
      (the `chaos` job and dashboard crawl are `RUN_HEAVY`-gated no-ops on ordinary PRs) —
      `route-memo-activation` scenario reported "all resilience contracts held", and the previously
      broken `iterate-metrics-explorer` dashboard shards passed.
- [ ] Re-confirm the same full green on this PR's actual head commit before merging.

Closes #2650
