### PR TITLE
fix(chaos): fix route-memo probe metric description and gate the decline dump

### DIFF
--- a/.github/scripts/chaos-run.mjs
+++ b/.github/scripts/chaos-run.mjs
@@ -1309,17 +1309,19 @@ async function scenarioRouteMemoActivation() {
     { deadlineMs: ROUTE_MEMO_ACTIVATION_DEADLINE_MS, intervalMs: ROUTE_MEMO_POLL_INTERVAL_MS, label: 'route-memo-activation' },
   );
 
-  await dumpRouteMemoDeclineCounters();
-
   if (activated) {
     log('    cerberus_route_ab_success_total{cerberus_route_choice="b"} climbed — a real route-A resource failure was rescued by a real route-B dispatch');
-  } else if (!sawMemoryLimit422) {
-    notice(
-      `${notApplicableMarker('route-memo-activation', 'memory-cap-not-crossed')} the pinned 24h/15s query never crossed CERBERUS_CH_QUERY_MAX_MEMORY this run (data-volume-dependent, same dual contract iterate-time-ranges.spec.ts documents) — the memo had no resource failure to rescue.`,
-      { title: NOT_APPLICABLE_TITLE },
-    );
-    return failures;
   } else {
+    await dumpRouteMemoDeclineCounters();
+
+    if (!sawMemoryLimit422) {
+      notice(
+        `${notApplicableMarker('route-memo-activation', 'memory-cap-not-crossed')} the pinned 24h/15s query never crossed CERBERUS_CH_QUERY_MAX_MEMORY this run (data-volume-dependent, same dual contract iterate-time-ranges.spec.ts documents) — the memo had no resource failure to rescue.`,
+        { title: NOT_APPLICABLE_TITLE },
+      );
+      return failures;
+    }
+
     failures.push(
       `route-memo did not activate: last query status=${lastStatus}, a 422 memory-limit rejection WAS observed, but cerberus_route_ab_success_total{cerberus_route_choice="b"} never climbed within budget — the memo was enabled and had a genuine resource failure to rescue and did not`,
     );

--- a/test/e2e/seed/cmd/seed/main.go
+++ b/test/e2e/seed/cmd/seed/main.go
@@ -742,7 +742,7 @@ SELECT
     map('service.name', 'route-memo-probe'),
     'route-memo-probe',
     'route_memo_probe_requests_total',
-    'Synthetic counter backfilled with real 24h-scale historical depth for the route-memo-activation chaos scenario (issue #2650) — see insertRouteMemoProbeBackfillSQL''s doc comment',
+    'Rolling short-window companion for the route-memo-activation chaos scenario''s deep 24h backfill — see insertRouteMemoProbeFreshnessSQL''s doc comment',
     '1',
     map('probe_shard', '0'),
     now64(9) + INTERVAL (number - 300) SECOND,


### PR DESCRIPTION
## Summary

Pre-release adversarial audit of everything merged since v1.16.0 (#2649, #2653, #2655, #2657,
#2658) turned up two small, real issues in #2658's chaos-lane probe-metric work, both fixed here:

- `insertRouteMemoProbeFreshnessSQL`'s `MetricDescription` was copy-pasted from
  `insertRouteMemoProbeBackfillSQL`, wrongly labelling the rolling short-window companion rows as
  the deep 24h backfill. A real client reading `/api/v1/metadata` for
  `route_memo_probe_requests_total` in the chaos cluster would see a misleading description.
- `dumpRouteMemoDeclineCounters()` in `.github/scripts/chaos-run.mjs` ran unconditionally after
  every `route-memo-activation` poll-loop settle, firing 8 unused metric queries even when the memo
  already activated cleanly. Now gated to only run on the non-activated path, where the diagnostic
  is actually useful.

Everything else in the audited diff checked out clean — no correctness bugs, no invariant
violations, no untracked deferral markers in the new code.

## Test plan

- [x] `node --check .github/scripts/chaos-run.mjs`
- [x] `go build ./test/e2e/seed/...`
- [x] `gofmt -l` clean on the touched Go file
