### PR TITLE
fix(chaos): widen route-memo-activation's detection deadline to 180s

### DIFF
--- a/.github/scripts/chaos-run.mjs
+++ b/.github/scripts/chaos-run.mjs
@@ -1234,7 +1234,20 @@ const ROUTE_MEMO_LIVE_EDGE_MARGIN_STEPS = 2;
 // CERBERUS_CH_QUERY_MAX_MEMORY comment for the exact measured numbers this
 // value was sized against.
 const ROUTE_MEMO_EXPR = 'sum by (probe_shard) (rate(route_memo_probe_requests_total[5m]))';
-const ROUTE_MEMO_ACTIVATION_DEADLINE_MS = 120_000; // generous: needs >= minCorroboratingFailures(2) consecutive route-A resource failures on the same key before a probe is even admitted
+// 180s, not the original 120s: a real run (2026-08-26, main push
+// 1b71d06c5's own chaos job) exhausted a 120s budget at ~123s with
+// no-preferb=17 / probe-not-admitted=1 on the decline-reason dump, then the
+// SEPARATE post-loop client corroboration below (its own independent
+// pollUntil) got a clean 200 within 0.4s of the deadline firing — proving
+// the underlying route-B rescue mechanism was already working and this
+// scenario's own primary-detection budget was simply too tight against the
+// real wall-clock variance of accumulating minCorroboratingFailures(2)
+// CONSECUTIVE route-A failures under CERBERUS_CH_QUERY_MAX_MEMORY's
+// deliberately narrow ~4.5% margin (chaos-overlay.env) — an occasional
+// under-cap route-A success resets that streak and costs a full retry
+// cycle. 180s gives real headroom over the observed ~123s instead of
+// guessing at a wider number.
+const ROUTE_MEMO_ACTIVATION_DEADLINE_MS = 180_000;
 const ROUTE_MEMO_POLL_INTERVAL_MS = 5_000;
 const ROUTE_MEMO_FINAL_OK_DEADLINE_MS = 60_000; // post-activation: the same query must now cleanly 200 for a real client
 


### PR DESCRIPTION
## Summary

Main's own push-triggered `chaos` job just failed `route-memo-activation` (run
https://github.com/tsouza/cerberus/actions/runs/33014468027, commit 1b71d06c5) with:

> route-memo did not activate: last query status=200, a 422 memory-limit rejection WAS observed,
> but cerberus_route_ab_success_total{cerberus_route_choice="b"} never climbed within budget

The decline-reason dump at that moment showed `no-preferb=17` / `probe-not-admitted=1` — the memo
was still accumulating `minCorroboratingFailures(2)` CONSECUTIVE route-A failures when the 120s
primary-detection deadline expired. The separate post-loop client corroboration check (its own
independent poll) then got a clean `200` within 0.4s of that deadline firing, proving the
underlying route-B rescue mechanism was already working — this was a detection-budget timing
issue, not a mechanism regression.

`CERBERUS_CH_QUERY_MAX_MEMORY` is deliberately sized with only a ~4.5% margin
(`chaos-overlay.env`), so an occasional under-cap route-A success is expected and resets the
consecutive-failure streak, costing a full retry cycle. 120s didn't leave enough room for that
real-world variance. Widened `ROUTE_MEMO_ACTIVATION_DEADLINE_MS` to 180s (60s of headroom over the
observed ~123s), well within the `chaos` job's 40-minute budget.

`chaos` is an informational, push/nightly/dispatch-only lane (never a PR gate, per `e2e.yml`'s own
documented policy), so this doesn't block anything mechanically — fixing it now because it's the
exact scenario #2650's fix chain just spent this whole investigation making reliable, and shipping
it with a known race would undermine that.

## Test plan

- [x] `node --check .github/scripts/chaos-run.mjs`
- [ ] Manual `gh workflow run e2e.yml --ref fix/route-memo-activation-deadline-headroom` dispatch to
      re-confirm `chaos` passes cleanly with real headroom this time (chaos can't be verified
      locally — needs a live k3d cluster).
