### PR TITLE
test(promql): kill 29 phase4-promql-i mutants missed by an original CI flake

### DIFF
--- a/internal/promql/gremlins_kill_binary_lower_mixed_test.go
+++ b/internal/promql/gremlins_kill_binary_lower_mixed_test.go
@@ -1,0 +1,590 @@
+// Tests in this file kill the LIVED gremlins mutants assigned to the
+// binary.go / lower_strategy.go / histogram_native_mixed_or_{math_fn,
+// aggregate_count_values,aggregate_presence,datefn}.go cluster from a
+// phase4-promql-* mutation run (mutation.yml). Each test constructs an
+// input that observably differentiates the original code from the
+// mutated branch. See gremlins_kill_test.go's header for the shared
+// conventions (mutant IDs in each test's doc comment are gremlins's
+// `file:line:col`).
+package promql
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/prometheus/prometheus/promql/parser"
+
+	"github.com/tsouza/cerberus/internal/chplan"
+	"github.com/tsouza/cerberus/internal/schema"
+)
+
+// mustParseExperimental parses q with experimental PromQL functions
+// enabled (double_exponential_smoothing and friends aren't needed here,
+// but the mixed-or fixtures in this file mirror the
+// EnableExperimentalFunctions setting the sibling
+// histogram_native_mixed_or_*_test.go files already use).
+func mustParseExperimental(t *testing.T, q string) parser.Expr {
+	t.Helper()
+	p := parser.NewParser(parser.Options{EnableExperimentalFunctions: true})
+	expr, err := p.ParseExpr(q)
+	if err != nil {
+		t.Fatalf("ParseExpr(%q): %v", q, err)
+	}
+	return expr
+}
+
+// lowerMixedOrAt lowers q at a fixed instant via the public LowerAt entry
+// point against the default OTel schema — the same shape the sibling
+// histogram_native_mixed_or_*_test.go files use.
+func lowerMixedOrAt(t *testing.T, q string) chplan.Node {
+	t.Helper()
+	expr := mustParseExperimental(t, q)
+	s := schema.DefaultOTelMetrics()
+	at := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	plan, err := LowerAt(context.Background(), expr, s, at, at)
+	if err != nil {
+		t.Fatalf("LowerAt(%q): unexpected error: %v", q, err)
+	}
+	return plan
+}
+
+// clampFamilyNewValue lowers a clamp-family call directly wrapping a
+// mixed float/histogram `or` and returns the Value projection's
+// expression — the last of the four canonical projections
+// [projectCanonicalFloatValue] builds.
+func clampFamilyNewValue(t *testing.T, q string) chplan.Expr {
+	t.Helper()
+	plan := lowerMixedOrAt(t, q)
+	proj, ok := plan.(*chplan.Project)
+	if !ok {
+		t.Fatalf("lower(%q): plan = %T, want *chplan.Project", q, plan)
+	}
+	if len(proj.Projections) == 0 {
+		t.Fatalf("lower(%q): Project has no projections", q)
+	}
+	return proj.Projections[len(proj.Projections)-1].Expr
+}
+
+// ---------------------------------------------------------------------
+// binary.go
+// ---------------------------------------------------------------------
+
+// TestIsVectorTypedSyntheticOperand_ConjunctsAndGuard kills two mutants
+// on the same line, binary.go:289:
+//
+//	return ok && call.Func != nil && call.Func.Name == "vector"
+//
+// INVERT_LOGICAL at col 14 flips the first `&&` to `||`. Go's `&&`/`||`
+// precedence is equal-left-to-right for this expression's grouping
+// ((ok && x) && y vs ok || (x && y)), so the mutant becomes
+// `ok || (call.Func != nil && call.Func.Name == "vector")`. When e is
+// NOT a *parser.Call (the `ok=false` default-case branch), `call` is a
+// nil *parser.Call; evaluating `call.Func` under the mutant's OR
+// (which does not short-circuit on ok=false the way the original AND
+// does) panics on the nil pointer dereference. The original code never
+// evaluates call.Func in that case and safely returns false.
+//
+// CONDITIONALS_NEGATION at col 27 flips `call.Func != nil` to
+// `call.Func == nil`, which makes the whole expression always false for
+// any real *parser.Call (since Func is always set on a parsed call) —
+// killed by asserting `vector(1)` reports true.
+func TestIsVectorTypedSyntheticOperand_ConjunctsAndGuard(t *testing.T) {
+	t.Parallel()
+
+	// Not a *parser.Call at all: hits the `ok=false` default branch.
+	// Must return false WITHOUT panicking.
+	numLit := mustParse(t, `5`)
+	if isVectorTypedSyntheticOperand(numLit) {
+		t.Fatalf("isVectorTypedSyntheticOperand(NumberLiteral) = true, want false")
+	}
+
+	// A *parser.Call to a function OTHER than "vector" — Func is always
+	// non-nil for any real call, so this must not panic and must report
+	// false via the Name comparison, not the nil-guard.
+	timeCall := mustParse(t, `time()`)
+	if isVectorTypedSyntheticOperand(timeCall) {
+		t.Fatalf("isVectorTypedSyntheticOperand(time()) = true, want false")
+	}
+
+	// The genuine positive case: vector(1) must report true. A
+	// CONDITIONALS_NEGATION mutant flipping `!=` to `==` at col 27 would
+	// make this false unconditionally.
+	vectorCall := mustParse(t, `vector(1)`)
+	if !isVectorTypedSyntheticOperand(vectorCall) {
+		t.Fatalf("isVectorTypedSyntheticOperand(vector(1)) = false, want true (mutant `!=`→`==` at binary.go:289:27 would always return false)")
+	}
+}
+
+// TestFoldSyntheticVectorBinary_ReturnBoolOnlyWrapsComparisons kills the
+// INVERT_LOGICAL mutant at binary.go:423:22:
+//
+//	if isComparison(op) && returnBool {
+//	    newValue = &chplan.FuncCall{Fn: chplan.FnToFloat64, Args: ...}
+//	}
+//
+// Every REAL caller reaches this line only after the early return on
+// line 418 (`isComparison(op) && !returnBool` already handled) combined
+// with PromQL's grammar-level invariant that `bool` only parses after a
+// comparison operator (returnBool=true implies isComparison(op)=true).
+// Together those two facts mean the only states reachable via normal
+// parsing are (isComparison=true, returnBool=true) and
+// (isComparison=false, returnBool=false) — for both, `&&` and `||`
+// agree. Killing the mutant requires calling foldSyntheticVectorBinary
+// directly with the combination the real call sites can never produce:
+// an arithmetic op with returnBool=true.
+func TestFoldSyntheticVectorBinary_ReturnBoolOnlyWrapsComparisons(t *testing.T) {
+	t.Parallel()
+
+	s := schema.DefaultOTelMetrics()
+	ctx := lowerCtx{}
+	synth, err := lowerVectorVectorOperand(mustParse(t, `time()`), s, ctx)
+	if err != nil {
+		t.Fatalf("lowerVectorVectorOperand(time()): %v", err)
+	}
+	vec, err := lowerVectorVectorOperand(mustParse(t, `up`), s, ctx)
+	if err != nil {
+		t.Fatalf("lowerVectorVectorOperand(up): %v", err)
+	}
+	vecExpr := mustParse(t, `up`)
+
+	// op=OpAdd (arithmetic) with returnBool=true never occurs via
+	// lowerVectorVector's real call path. Original:
+	// isComparison(false) && returnBool(true) = false, so newValue stays
+	// the raw Binary. Mutant `&&`→`||` at binary.go:423:22 would wrap it
+	// in toFloat64 regardless.
+	plan := foldSyntheticVectorBinary(synth, vec, vecExpr, chplan.OpAdd, true, true, s)
+	proj, ok := plan.(*chplan.Project)
+	if !ok {
+		t.Fatalf("foldSyntheticVectorBinary result = %T, want *chplan.Project", plan)
+	}
+	if len(proj.Projections) == 0 {
+		t.Fatalf("foldSyntheticVectorBinary result Project has no projections")
+	}
+	valueExpr := proj.Projections[len(proj.Projections)-1].Expr
+	if _, wrapped := valueExpr.(*chplan.FuncCall); wrapped {
+		t.Fatalf("Value = %#v, want *chplan.Binary (mutant `&&`→`||` at binary.go:423:22 wraps arithmetic ops in toFloat64 too when returnBool=true)", valueExpr)
+	}
+	if _, ok := valueExpr.(*chplan.Binary); !ok {
+		t.Fatalf("Value = %T, want *chplan.Binary", valueExpr)
+	}
+}
+
+// TestLowerVectorScalar_ReturnBoolOnlyWrapsComparisons is the
+// vector-scalar sibling of the synthetic-vector-binary test above,
+// killing the INVERT_LOGICAL mutant at binary.go:856:22. The same
+// reachability argument applies: line 842's early return plus PromQL's
+// grammar invariant means `isComparison(op) && returnBool` only ever
+// observes (true,true) or (false,false) via real parsing, so the kill
+// calls lowerVectorScalar directly with the otherwise-unreachable
+// (arithmetic op, returnBool=true) combination.
+func TestLowerVectorScalar_ReturnBoolOnlyWrapsComparisons(t *testing.T) {
+	t.Parallel()
+
+	s := schema.DefaultOTelMetrics()
+	plan, err := lowerVectorScalar(mustParse(t, `up`), s, chplan.OpAdd, 5, true, true, lowerCtx{})
+	if err != nil {
+		t.Fatalf("lowerVectorScalar: %v", err)
+	}
+	proj, ok := plan.(*chplan.Project)
+	if !ok {
+		t.Fatalf("lowerVectorScalar result = %T, want *chplan.Project", plan)
+	}
+	if len(proj.Projections) == 0 {
+		t.Fatalf("lowerVectorScalar result Project has no projections")
+	}
+	valueExpr := proj.Projections[len(proj.Projections)-1].Expr
+	if _, wrapped := valueExpr.(*chplan.FuncCall); wrapped {
+		t.Fatalf("Value = %#v, want *chplan.Binary (mutant `&&`→`||` at binary.go:856:22 wraps arithmetic ops in toFloat64 too when returnBool=true)", valueExpr)
+	}
+	if _, ok := valueExpr.(*chplan.Binary); !ok {
+		t.Fatalf("Value = %T, want *chplan.Binary", valueExpr)
+	}
+}
+
+// TestLowerVectorSetOp_MixedOr_StepAlignedTracksStep kills the
+// CONDITIONALS_BOUNDARY (`>`→`>=`) and CONDITIONALS_NEGATION (`>`→`<=`)
+// mutants at binary.go:593:32:
+//
+//	StepAligned: ctx.step > 0,
+//
+// This line sits inside lowerVectorSetOp's `case leftMixed ||
+// rightMixed` arm (binary.go:578), reached only when at least one
+// operand of the `or` is ITSELF already a Mixed VectorSetOp (cerberus
+// issue #2555) — a bare `<histogram> or <float>` lands in the sibling
+// `leftHistogram != rightHistogram` case instead. The query below
+// nests a mixed-or inside another `or` so the left operand is already
+// Mixed when the outer lowerVectorSetOp call runs.
+//
+// At step=0 (instant mode) the original is false; both mutants (`>=`
+// making 0>=0 true, `<=` making 0<=0 true) would set it true. At
+// step>0 (range mode) the original is true; the negation mutant (`<=`
+// making step<=0 false) would set it false. The instant-mode assertion
+// alone already kills both mutants; the range-mode assertion pins the
+// positive direction too.
+func TestLowerVectorSetOp_MixedOr_StepAlignedTracksStep(t *testing.T) {
+	t.Parallel()
+
+	query := `(latency_exp_hist or histogram_quantile(0.5, latency_exp_hist)) or up`
+	expr := mustParseExperimental(t, query)
+	s := schema.DefaultOTelMetrics()
+	start := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+
+	instantPlan, err := LowerAt(context.Background(), expr, s, start, start)
+	if err != nil {
+		t.Fatalf("LowerAt(%q): %v", query, err)
+	}
+	instantSetOp, ok := instantPlan.(*chplan.VectorSetOp)
+	if !ok {
+		t.Fatalf("lower(%q) instant plan = %T, want *chplan.VectorSetOp", query, instantPlan)
+	}
+	if instantSetOp.StepAligned {
+		t.Fatalf("instant-mode (step=0) StepAligned = true, want false (mutants at binary.go:593:32 would set true)")
+	}
+
+	end := start.Add(5 * time.Minute)
+	rangePlan, err := LowerAtRange(context.Background(), expr, s, start, end, time.Minute)
+	if err != nil {
+		t.Fatalf("LowerAtRange(%q): %v", query, err)
+	}
+	rangeSetOp, ok := rangePlan.(*chplan.VectorSetOp)
+	if !ok {
+		t.Fatalf("lower(%q) range plan = %T, want *chplan.VectorSetOp", query, rangePlan)
+	}
+	if !rangeSetOp.StepAligned {
+		t.Fatalf("range-mode (step=1m) StepAligned = false, want true (CONDITIONALS_NEGATION mutant `>`→`<=` at binary.go:593:32 would set false)")
+	}
+}
+
+// ---------------------------------------------------------------------
+// lower_strategy.go
+// ---------------------------------------------------------------------
+
+// TestNativeTemporalityFilter_ProjectionsCapacityIsTight kills the two
+// adjacent mutants at lower_strategy.go:349:81 inside
+// nativeTemporalityFilter's slice-capacity hint:
+//
+//	projectCopy.Projections = make([]chplan.Projection, 0, len(project.Projections)-1)
+//
+// ARITHMETIC_BASE (`-`→`+`) and INVERT_NEGATIVES (`-1`→`+1`) both
+// enlarge the capacity by 2 relative to the tight fit (removing exactly
+// one column — the temporality column itself — always leaves
+// len(Projections)-1 survivors). append silently uses the extra
+// headroom, so the resulting slice's CONTENTS are identical under both
+// branches; only cap() differs, mirroring
+// TestLowerLabelJoin_SrcsSliceCapacityIsTight's approach in
+// gremlins_kill_test.go.
+func TestNativeTemporalityFilter_ProjectionsCapacityIsTight(t *testing.T) {
+	t.Parallel()
+
+	input := &chplan.Project{
+		Projections: []chplan.Projection{
+			{Expr: &chplan.ColumnRef{Name: "a"}, Alias: "a"},
+			{Expr: &chplan.ColumnRef{Name: "temporality"}, Alias: "temporality"},
+			{Expr: &chplan.ColumnRef{Name: "b"}, Alias: "b"},
+		},
+	}
+	got := nativeTemporalityFilter(input, "temporality")
+	proj, ok := got.(*chplan.Project)
+	if !ok {
+		t.Fatalf("nativeTemporalityFilter result = %T, want *chplan.Project", got)
+	}
+
+	const wantLen = 2 // "a", "b" survive; "temporality" is dropped.
+	if len(proj.Projections) != wantLen {
+		t.Fatalf("len(Projections) = %d, want %d", len(proj.Projections), wantLen)
+	}
+	// Original: cap == len(project.Projections)-1 == 3-1 == 2.
+	// Both mutants: cap == 3+1 == 4.
+	if got := cap(proj.Projections); got != wantLen {
+		t.Fatalf("cap(Projections) = %d, want %d (mutants `-`→`+` and `-1`→`+1` at lower_strategy.go:349:81 would yield cap=4)", got, wantLen)
+	}
+}
+
+// TestNativePredictLinearHorizonEligible_GuardIsDisjunctive kills the
+// INVERT_LOGICAL mutant at lower_strategy.go:581:30:
+//
+//	if len(rw.ScalarExprs) != 0 || len(rw.Scalars) != 1 {
+//	    return false
+//	}
+//
+// Each case below satisfies exactly one disjunct while leaving the
+// other false, so `||` (short-circuit: reject) and `&&` (mutant: only
+// reject when BOTH conditions hold) disagree.
+func TestNativePredictLinearHorizonEligible_GuardIsDisjunctive(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		rw   *chplan.RangeWindow
+		want bool
+	}{
+		{
+			name: "ScalarExprs set disqualifies even with exactly one Scalars entry",
+			rw:   &chplan.RangeWindow{ScalarExprs: []chplan.Expr{&chplan.LitFloat{V: 1}}, Scalars: []float64{5}},
+			want: false,
+		},
+		{
+			name: "two Scalars entries disqualify even with no ScalarExprs",
+			rw:   &chplan.RangeWindow{Scalars: []float64{5, 6}},
+			want: false,
+		},
+		{
+			name: "eligible: no ScalarExprs, exactly one non-negative whole Scalars entry",
+			rw:   &chplan.RangeWindow{Scalars: []float64{5}},
+			want: true,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if got := nativePredictLinearHorizonEligible(tc.rw); got != tc.want {
+				t.Fatalf("nativePredictLinearHorizonEligible(ScalarExprs=%d, Scalars=%v) = %v, want %v (mutant `||`→`&&` at lower_strategy.go:581:30 would flip the first two cases)",
+					len(tc.rw.ScalarExprs), tc.rw.Scalars, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestNativePredictLinearHorizonEligible_ZeroHorizonIsEligible kills the
+// CONDITIONALS_BOUNDARY mutant at lower_strategy.go:585:11:
+//
+//	return t >= 0 && t == math.Trunc(t)
+//
+// t=0 sits exactly on the boundary: `>= 0` is true (0 is a valid
+// non-negative horizon — `predict_linear(m[5m], 0)` is legal PromQL),
+// but a `>=`→`>` mutant would reject it.
+func TestNativePredictLinearHorizonEligible_ZeroHorizonIsEligible(t *testing.T) {
+	t.Parallel()
+
+	rw := &chplan.RangeWindow{Scalars: []float64{0}}
+	if !nativePredictLinearHorizonEligible(rw) {
+		t.Fatalf("nativePredictLinearHorizonEligible(t=0) = false, want true (mutant `>=`→`>` at lower_strategy.go:585:11 would reject t=0)")
+	}
+}
+
+// ---------------------------------------------------------------------
+// histogram_native_mixed_or_math_fn.go
+// ---------------------------------------------------------------------
+
+// TestLowerClampOverMixedExpHistogramSetOp_ClampMinMaxPickCorrectFn kills
+// the CONDITIONALS_NEGATION mutant at
+// histogram_native_mixed_or_math_fn.go:270:21:
+//
+//	fnName := chplan.FnLeast
+//	if call.Func.Name == "clamp_min" {
+//	    fnName = chplan.FnGreatest
+//	}
+//
+// clamp_min must pick FnGreatest; a `==`→`!=` mutant would leave fnName
+// at its FnLeast default for clamp_min (and would wrongly flip it to
+// FnGreatest for clamp_max, covered by the second assertion below).
+func TestLowerClampOverMixedExpHistogramSetOp_ClampMinMaxPickCorrectFn(t *testing.T) {
+	t.Parallel()
+
+	minValue := clampFamilyNewValue(t, `clamp_min(latency_exp_hist or histogram_quantile(0.5, latency_exp_hist), 5)`)
+	fc, ok := minValue.(*chplan.FuncCall)
+	if !ok || fc.Fn != chplan.FnGreatest {
+		t.Fatalf("clamp_min newValue = %#v, want FuncCall{Fn: FnGreatest} (mutant `==`→`!=` at histogram_native_mixed_or_math_fn.go:270:21 would pick FnLeast)", minValue)
+	}
+
+	maxValue := clampFamilyNewValue(t, `clamp_max(latency_exp_hist or histogram_quantile(0.5, latency_exp_hist), 5)`)
+	fc, ok = maxValue.(*chplan.FuncCall)
+	if !ok || fc.Fn != chplan.FnLeast {
+		t.Fatalf("clamp_max newValue = %#v, want FuncCall{Fn: FnLeast} (mutant `==`→`!=` at histogram_native_mixed_or_math_fn.go:270:21 would pick FnGreatest)", maxValue)
+	}
+}
+
+// TestLowerClampOverMixedExpHistogramSetOp_MixedBoundsTakeRuntimePath
+// kills the INVERT_LOGICAL mutant at
+// histogram_native_mixed_or_math_fn.go:293:12:
+//
+//	if okMin && okMax {
+//
+// With one literal bound (minB=5) and one computed bound
+// (scalar(sum(up))), okMin=true and okMax=false. The original AND
+// routes to the runtime FnIf-guarded path (checked below via the
+// FuncCall{Fn: FnIf} shape). A `&&`→`||` mutant would instead enter the
+// literal-only branch with maxB defaulting to its zero value (okMax was
+// false), and 0 < 5 trips the degenerate empty-clamp fold.
+func TestLowerClampOverMixedExpHistogramSetOp_MixedBoundsTakeRuntimePath(t *testing.T) {
+	t.Parallel()
+
+	newValue := clampFamilyNewValue(t, `clamp(latency_exp_hist or histogram_quantile(0.5, latency_exp_hist), 5, scalar(sum(up)))`)
+	fc, ok := newValue.(*chplan.FuncCall)
+	if !ok || fc.Fn != chplan.FnIf {
+		t.Fatalf("mixed literal/computed clamp newValue = %#v, want FuncCall{Fn: FnIf} (runtime-bounds path; mutant `&&`→`||` at histogram_native_mixed_or_math_fn.go:293:12 would take the literal degenerate-fold path instead)", newValue)
+	}
+}
+
+// TestLowerClampOverMixedExpHistogramSetOp_EqualLiteralBoundsNonDegenerate
+// kills both mutants at histogram_native_mixed_or_math_fn.go:298:12:
+//
+//	if maxB < minB {
+//
+// minB == maxB == 5: equality is NOT less-than, so the original takes
+// the non-degenerate literal path (FuncCall{Fn: FnGreatest}).
+// CONDITIONALS_BOUNDARY (`<`→`<=`) and CONDITIONALS_NEGATION (`<`→`>=`)
+// both evaluate 5<=5 / 5>=5 as true, wrongly taking the degenerate
+// empty-clamp fold (a bare ColumnRef, no FuncCall).
+func TestLowerClampOverMixedExpHistogramSetOp_EqualLiteralBoundsNonDegenerate(t *testing.T) {
+	t.Parallel()
+
+	newValue := clampFamilyNewValue(t, `clamp(latency_exp_hist or histogram_quantile(0.5, latency_exp_hist), 5, 5)`)
+	fc, ok := newValue.(*chplan.FuncCall)
+	if !ok || fc.Fn != chplan.FnGreatest {
+		t.Fatalf("equal-bounds clamp newValue = %#v, want FuncCall{Fn: FnGreatest} (mutants `<`→`<=` and `<`→`>=` at histogram_native_mixed_or_math_fn.go:298:12 would take the degenerate empty-clamp fold)", newValue)
+	}
+}
+
+// TestLowerClampOverMixedExpHistogramSetOp_DegenerateLiteralBoundsAreEmpty
+// complements the equal-bounds test above with the genuinely degenerate
+// direction: minB=10 > maxB=5. Prom's clamp() short-circuits to an empty
+// vector rather than clamping to minB, so newValue is the bare
+// passed-through Value column, not a FuncCall.
+func TestLowerClampOverMixedExpHistogramSetOp_DegenerateLiteralBoundsAreEmpty(t *testing.T) {
+	t.Parallel()
+
+	newValue := clampFamilyNewValue(t, `clamp(latency_exp_hist or histogram_quantile(0.5, latency_exp_hist), 10, 5)`)
+	if _, ok := newValue.(*chplan.FuncCall); ok {
+		t.Fatalf("degenerate clamp newValue = %#v, want a bare *chplan.ColumnRef (empty-clamp fold), not a FuncCall", newValue)
+	}
+	ref, ok := newValue.(*chplan.ColumnRef)
+	if !ok || ref.Name != schema.DefaultOTelMetrics().ValueColumn {
+		t.Fatalf("degenerate clamp newValue = %#v, want *chplan.ColumnRef{Name: %q}", newValue, schema.DefaultOTelMetrics().ValueColumn)
+	}
+}
+
+// ---------------------------------------------------------------------
+// histogram_native_mixed_or_aggregate_count_values.go
+// ---------------------------------------------------------------------
+
+// TestCountValuesOverMixedExpHistogramSetOp_RecognizesOnlyCountValues
+// kills the CONDITIONALS_NEGATION mutant at
+// histogram_native_mixed_or_aggregate_count_values.go:76:19:
+//
+//	if !ok || agg.Op != parser.COUNT_VALUES {
+//	    return nil, nil, false
+//	}
+//
+// A `!=`→`==` mutant inverts the recognizer entirely: it would reject
+// genuine count_values() calls and accept every OTHER aggregate wrapping
+// a mixed `or` (here, sum()).
+func TestCountValuesOverMixedExpHistogramSetOp_RecognizesOnlyCountValues(t *testing.T) {
+	t.Parallel()
+
+	s := schema.DefaultOTelMetrics()
+	mixedOrQuery := `latency_exp_hist or histogram_quantile(0.5, latency_exp_hist)`
+
+	cvExpr := mustParseExperimental(t, `count_values("v", `+mixedOrQuery+`)`)
+	if _, _, ok := countValuesOverMixedExpHistogramSetOp(cvExpr, s, lowerCtx{}); !ok {
+		t.Fatalf("count_values(...) over mixed-or not recognized (mutant `!=`→`==` at histogram_native_mixed_or_aggregate_count_values.go:76:19 would reject it)")
+	}
+
+	sumExpr := mustParseExperimental(t, `sum(`+mixedOrQuery+`)`)
+	if _, _, ok := countValuesOverMixedExpHistogramSetOp(sumExpr, s, lowerCtx{}); ok {
+		t.Fatalf("sum(...) over mixed-or wrongly recognized as count_values (mutant `!=`→`==` at histogram_native_mixed_or_aggregate_count_values.go:76:19 would accept any non-count_values aggregate)")
+	}
+}
+
+// ---------------------------------------------------------------------
+// histogram_native_mixed_or_aggregate_presence.go
+// ---------------------------------------------------------------------
+
+// TestCountOrGroupOverMixedExpHistogramSetOp_RecognizesCountAndGroup
+// kills the three CONDITIONALS_NEGATION mutants on
+// histogram_native_mixed_or_aggregate_presence.go:66:
+//
+//	if !ok || (agg.Op != parser.COUNT && agg.Op != parser.GROUP) || agg.Param != nil {
+//	    return nil, nil, false
+//	}
+//
+// col 20 (`agg.Op != parser.COUNT` → `==`): with Op=COUNT, the mutated
+// first conjunct becomes true, and (true && (COUNT != GROUP = true)) =
+// true — the whole OR chain trips and count(...) is wrongly rejected.
+// Killed by the count(...) assertion.
+//
+// col 46 (`agg.Op != parser.GROUP` → `==`): symmetric — with Op=GROUP,
+// ((GROUP != COUNT = true) && true) = true trips the OR chain and
+// group(...) is wrongly rejected. Killed by the group(...) assertion.
+//
+// col 76 (`agg.Param != nil` → `==`): with Param genuinely nil (both
+// count(...) and group(...) never carry a Param), the mutated third
+// disjunct becomes true unconditionally, tripping the OR chain and
+// rejecting BOTH normal calls. Killed by either assertion.
+func TestCountOrGroupOverMixedExpHistogramSetOp_RecognizesCountAndGroup(t *testing.T) {
+	t.Parallel()
+
+	s := schema.DefaultOTelMetrics()
+	mixedOrQuery := `latency_exp_hist or histogram_quantile(0.5, latency_exp_hist)`
+
+	countExpr := mustParseExperimental(t, `count(`+mixedOrQuery+`)`)
+	if _, _, ok := countOrGroupOverMixedExpHistogramSetOp(countExpr, s, lowerCtx{}); !ok {
+		t.Fatalf("count(...) over mixed-or not recognized (mutants at histogram_native_mixed_or_aggregate_presence.go:66:20 / :66:76 would reject it)")
+	}
+
+	groupExpr := mustParseExperimental(t, `group(`+mixedOrQuery+`)`)
+	if _, _, ok := countOrGroupOverMixedExpHistogramSetOp(groupExpr, s, lowerCtx{}); !ok {
+		t.Fatalf("group(...) over mixed-or not recognized (mutants at histogram_native_mixed_or_aggregate_presence.go:66:46 / :66:76 would reject it)")
+	}
+
+	// Negative control: an aggregate op that is neither COUNT nor GROUP
+	// must still be rejected.
+	sumExpr := mustParseExperimental(t, `sum(`+mixedOrQuery+`)`)
+	if _, _, ok := countOrGroupOverMixedExpHistogramSetOp(sumExpr, s, lowerCtx{}); ok {
+		t.Fatalf("sum(...) over mixed-or wrongly recognized by the count/group recognizer")
+	}
+}
+
+// ---------------------------------------------------------------------
+// histogram_native_mixed_or_datefn.go
+// ---------------------------------------------------------------------
+
+// TestDateFnOverMixedExpHistogramSetOp_ArgCountAndTimestampExclusion
+// kills the three mutants on histogram_native_mixed_or_datefn.go:58:
+//
+//	if len(c.Args) != 1 || c.Func.Name == "timestamp" {
+//	    return nil, false
+//	}
+//
+// col 17 (`!=`→`==`): with exactly 1 arg (the normal, only-valid shape
+// for these date fns), the mutated first disjunct becomes true and
+// wrongly rejects. Killed by the year(...) assertion.
+//
+// col 37 (`==`→`!=`): with Func.Name="year" (not "timestamp"), the
+// mutated second disjunct ("year" != "timestamp") becomes true and
+// wrongly rejects EVERY normal date-fn call. Also killed by the
+// year(...) assertion.
+//
+// col 22 (`||`→`&&`): with Func.Name="timestamp" and exactly 1 arg, the
+// original OR trips on the second disjunct alone and correctly rejects
+// (timestamp is explicitly excluded by name). The mutated AND requires
+// BOTH disjuncts, and the first (len!=1) is false here, so the mutant
+// wrongly accepts "timestamp". Killed by the timestamp(...) assertion.
+//
+// timestamp() isn't reachable through this recognizer via the normal
+// lowerCall dispatch (which excludes it by name before ever calling
+// here per this file's own doc comment), so the kill constructs the
+// *parser.Call by hand and calls the recognizer directly — same pattern
+// gremlins_kill_test.go's label_join tests use for otherwise-unreachable
+// argument shapes.
+func TestDateFnOverMixedExpHistogramSetOp_ArgCountAndTimestampExclusion(t *testing.T) {
+	t.Parallel()
+
+	s := schema.DefaultOTelMetrics()
+	mixedOr := mustParseExperimental(t, `latency_exp_hist or histogram_quantile(0.5, latency_exp_hist)`)
+	binExpr, ok := mixedOr.(*parser.BinaryExpr)
+	if !ok {
+		t.Fatalf("parsed mixed-or query = %T, want *parser.BinaryExpr", mixedOr)
+	}
+
+	yearCall := &parser.Call{Func: parser.MustGetFunction("year"), Args: parser.Expressions{binExpr}}
+	if _, ok := dateFnOverMixedExpHistogramSetOp(yearCall, s, lowerCtx{}); !ok {
+		t.Fatalf("year(<mixed or>) not recognized (mutants `!=`→`==` at histogram_native_mixed_or_datefn.go:58:17 or `==`→`!=` at :58:37 would reject it)")
+	}
+
+	tsCall := &parser.Call{Func: parser.MustGetFunction("timestamp"), Args: parser.Expressions{binExpr}}
+	if _, ok := dateFnOverMixedExpHistogramSetOp(tsCall, s, lowerCtx{}); ok {
+		t.Fatalf("timestamp(<mixed or>) wrongly recognized (mutant `||`→`&&` at histogram_native_mixed_or_datefn.go:58:22, or `==`→`!=` at :58:37, would accept it)")
+	}
+}

--- a/internal/promql/gremlins_kill_histogram_binop_count_test.go
+++ b/internal/promql/gremlins_kill_histogram_binop_count_test.go
@@ -1,0 +1,429 @@
+// Tests in this file kill the LIVED gremlins mutants assigned to the
+// histogram_native_binop_eq.go / histogram_native_count.go /
+// histogram_native_count_values.go cluster from a phase4-promql-i mutation
+// run (mutation.yml, cerberus issue #2636 — the leg whose original run
+// crashed on a network flake before any mutant ran). See gremlins_kill_test.go
+// for the shared file-header convention this file follows.
+//
+// Two INVERT_LOGICAL mutants are NOT addressed with a dedicated test here —
+// both are provably equivalent, not coverage gaps:
+//
+//   - histogram_native_binop_eq.go:119:31 (`s.ExpHistogramTable == "" ||
+//     ctx.metadataFullRange` -> `&&` inside expHistogramHistogramCompareBinop).
+//   - histogram_native_binop_eq.go:191:31 (the FIRST `||` of the three-way
+//     `s.ExpHistogramTable == "" || ctx.metadataFullRange || !b.ReturnBool`
+//     inside expHistogramHistogramCompareBoolBinop).
+//
+// Both functions re-validate the identical table/metadataFullRange
+// condition one level down, via isExpHistogramValuedShape(b.LHS/b.RHS, s,
+// ctx) a few lines later (line 140 / line 197) — and EVERY leaf recognizer
+// isExpHistogramValuedShape dispatches to (bareExpHistogramSelector,
+// sumOrAvgOverExpHistogram, rangeFnOverExpHistogram, and so on) carries the
+// exact same `s.ExpHistogramTable == "" || ctx.metadataFullRange` guard.
+// So whenever that condition holds, isExpHistogramValuedShape is
+// UNCONDITIONALLY false regardless of which branch of the outer OR/AND
+// mutation let control reach it — and both functions' every rejection path
+// returns the SAME literal zero-value tuple (`nil, nil, false, nil, false`),
+// never a partially-populated one. There is no way for the AND mutant to
+// produce a tuple the OR original could not also produce, on ANY input:
+// verified by manually applying each mutation and confirming
+// `go test ./internal/promql/...` (this package) stays green.
+package promql
+
+import (
+	"testing"
+
+	"github.com/prometheus/prometheus/promql/parser"
+
+	"github.com/tsouza/cerberus/internal/chplan"
+	"github.com/tsouza/cerberus/internal/schema"
+)
+
+// TestExpHistogramHistogramCompareBoolBinop_RequiresReturnBool kills the
+// CONDITIONALS_BOUNDARY... no — INVERT_LOGICAL mutant at
+// histogram_native_binop_eq.go:191:56, the SECOND `||` of
+//
+//	if s.ExpHistogramTable == "" || ctx.metadataFullRange || !b.ReturnBool {
+//
+// (parsed left-associatively as `(A || B) || C`, so this is the outer
+// `||` joining `(A || B)` with `C = !b.ReturnBool`). With a normal schema
+// and ctx (A = B = false), the guard's truth rests entirely on C: a
+// non-bool comparison (`b.ReturnBool == false`, so C == true) must be
+// rejected — this recognizer is exclusively the `bool`-modifier variant;
+// `expHistogramHistogramCompareBinop` (this file's own non-bool sibling)
+// answers the shape without `bool`. Flipping the outer `||` to `&&` makes
+// the guard depend on BOTH `(A||B)` and `C` — with A and B both false,
+// `(A||B) && C` is false regardless of C, so the guard never fires and a
+// non-bool `==`/`!=` between two histograms is wrongly recognised here too.
+//
+// Unlike the two EQUIVALENT `||`s this file's header documents, this
+// mutation is NOT masked by the later isExpHistogramValuedShape re-check:
+// A and B are both false in this test (a normal schema, no
+// metadataFullRange), so that later check genuinely passes on real
+// histogram-valued operands — nothing downstream catches the wrongly
+// bypassed ReturnBool guard.
+func TestExpHistogramHistogramCompareBoolBinop_RequiresReturnBool(t *testing.T) {
+	t.Parallel()
+
+	s := schema.DefaultOTelMetrics()
+	b, ok := mustParse(t, `latency_exp_hist == other_exp_hist`).(*parser.BinaryExpr)
+	if !ok {
+		t.Fatalf("parsed %T, want *parser.BinaryExpr", mustParse(t, `latency_exp_hist == other_exp_hist`))
+	}
+	if _, _, _, _, ok := expHistogramHistogramCompareBoolBinop(b, s, lowerCtx{}); ok {
+		t.Fatalf("expected a non-bool histogram/histogram comparison to be rejected by the " +
+			"bool-modifier-only recognizer; got ok=true (mutant `||`->`&&` at " +
+			"histogram_native_binop_eq.go:191:56 would accept it despite ReturnBool=false)")
+	}
+}
+
+// TestExpHistogramHistogramCompareBoolBinop_BothSidesMustBeHistogramValued
+// kills the INVERT_LOGICAL mutant at histogram_native_binop_eq.go:197:47:
+//
+//	if !isExpHistogramValuedShape(b.LHS, s, ctx) || !isExpHistogramValuedShape(b.RHS, s, ctx) {
+//
+// Reference rejects a `bool`-modified `==`/`!=` between a histogram and a
+// float operand outright (NewIncompatibleTypesInBinOpInfo). The original
+// `||` rejects whenever EITHER side is not histogram-valued. Flipping to
+// `&&` rejects only when BOTH sides are not histogram-valued — accepting a
+// mismatched histogram/float pair as long as at least one side qualifies.
+//
+// latency_exp_hist (histogram) == bool other_metric (float, no
+// _exp_hist suffix) exercises exactly that asymmetric case.
+func TestExpHistogramHistogramCompareBoolBinop_BothSidesMustBeHistogramValued(t *testing.T) {
+	t.Parallel()
+
+	s := schema.DefaultOTelMetrics()
+	expr := mustParse(t, `latency_exp_hist == bool other_metric`)
+	b, ok := expr.(*parser.BinaryExpr)
+	if !ok {
+		t.Fatalf("parsed %T, want *parser.BinaryExpr", expr)
+	}
+	if _, _, _, _, ok := expHistogramHistogramCompareBoolBinop(b, s, lowerCtx{}); ok {
+		t.Fatalf("expected a histogram/float mismatched bool-compare to be rejected; got ok=true " +
+			"(mutant `||`->`&&` at histogram_native_binop_eq.go:197:47 would accept it as long as " +
+			"ONE side is histogram-valued)")
+	}
+}
+
+// TestProjectHistogramCompareSide_ProjectionsCapacityIsTight kills the
+// ARITHMETIC_BASE mutant at histogram_native_binop_eq.go:353:49 inside
+// projectHistogramCompareSide's slice-capacity hint:
+//
+//	projs := make([]chplan.Projection, 0, len(cols)+1)
+//
+// The function appends exactly one projection per `cols` entry plus one
+// more for the [histEqSideAlias] discriminator — len(cols)+1 appends total
+// — so the original capacity is an exact fit. Flipping `+` to `-` shrinks
+// the hint to len(cols)-1, forcing `append`'s growth path to reallocate,
+// which lands on a capacity other than len(cols)+1 (mirrors
+// TestLowerLabelJoin_SrcsSliceCapacityIsTight's own strategy,
+// gremlins_kill_test.go).
+func TestProjectHistogramCompareSide_ProjectionsCapacityIsTight(t *testing.T) {
+	t.Parallel()
+
+	s := schema.DefaultOTelMetrics()
+	histSchema := histogramProjectionSchema(s)
+	hp := &chplan.Scan{Table: s.ExpHistogramTable}
+
+	got := projectHistogramCompareSide(hp, histEqSideLHS, histSchema, true /* stepAligned */)
+
+	cols := []string{histSchema.MetricNameColumn, histSchema.AttributesColumn, histSchema.TimestampColumn}
+	cols = append(cols, histogramCompareFieldColumns(histSchema)...)
+	wantLen := len(cols) + 1
+
+	if gotLen := len(got.Projections); gotLen != wantLen {
+		t.Fatalf("len(Projections) = %d, want %d", gotLen, wantLen)
+	}
+	if gotCap := cap(got.Projections); gotCap != wantLen {
+		t.Fatalf("cap(Projections) = %d, want %d (mutant `+`->`-` at "+
+			"histogram_native_binop_eq.go:353:49 would yield a different cap via forced regrowth)",
+			gotCap, wantLen)
+	}
+}
+
+// TestCountOverExpHistogram_MetadataFullRangeShortCircuits kills the
+// INVERT_LOGICAL mutant at histogram_native_count.go:73:31, where
+//
+//	if s.ExpHistogramTable == "" || ctx.metadataFullRange {
+//
+// must reject on EITHER condition. countOverExpHistogram has no downstream
+// call that independently re-checks this same guard (unwrapAggregateExpr,
+// unwrapVectorSelector and IsExpHistogramMetric are all guard-free leaf
+// checks — unlike countOrGroupOverExpHistogramValue just below, which
+// delegates to isExpHistogramValuedShape), so metadataFullRange alone is a
+// clean, unmasked differentiator — mirrors
+// TestCountPresentOverExpHistogram_MetadataFullRangeShortCircuits
+// (histogram_native_range_family_gremlins_test.go).
+func TestCountOverExpHistogram_MetadataFullRangeShortCircuits(t *testing.T) {
+	t.Parallel()
+
+	s := schema.DefaultOTelMetrics()
+	expr := mustParse(t, `count(latency_exp_hist)`)
+	if _, _, ok := countOverExpHistogram(expr, s, lowerCtx{metadataFullRange: true}); ok {
+		t.Fatalf("expected metadataFullRange to reject recognition; got ok=true " +
+			"(mutant `||`->`&&` at histogram_native_count.go:73:31)")
+	}
+}
+
+// TestCountOrGroupOverExpHistogramValue_MetadataFullRangeRejectsBeforeParsing
+// kills the INVERT_LOGICAL mutant at histogram_native_count.go:98:31.
+//
+// Unlike countOverExpHistogram above, countOrGroupOverExpHistogramValue
+// DOES re-validate the identical guard one level down: its own tail
+// `return agg, isExpHistogramValuedShape(agg.Expr, s, ctx)` calls a
+// function whose every leaf recognizer (bareExpHistogramSelector and
+// friends) carries the same `s.ExpHistogramTable == "" ||
+// ctx.metadataFullRange` guard, so with metadataFullRange=true the
+// returned `ok` is false either way — the `bool` return alone cannot
+// differentiate the mutant (this is the SAME masking
+// TestExpHistogramHistogramCompareBoolBinop's file-header documents as
+// equivalent for histogram_native_binop_eq.go's guards).
+//
+// The difference IS observable through the OTHER return value, though:
+// the original guard returns literal `nil, false` — agg is never parsed.
+// The `&&` mutant, with the guard bypassed, proceeds to
+// `unwrapAggregateExpr` and returns a REAL, non-nil `*parser.AggregateExpr`
+// alongside the (still-false, via the masked recursive check) `ok`. This
+// test pins `agg == nil` on the rejection path, which the mutant cannot
+// produce once it has fallen through to parse a real aggregate.
+func TestCountOrGroupOverExpHistogramValue_MetadataFullRangeRejectsBeforeParsing(t *testing.T) {
+	t.Parallel()
+
+	s := schema.DefaultOTelMetrics()
+	expr := mustParse(t, `count(latency_exp_hist)`)
+	agg, ok := countOrGroupOverExpHistogramValue(expr, s, lowerCtx{metadataFullRange: true})
+	if ok {
+		t.Fatalf("expected metadataFullRange to reject recognition; got ok=true")
+	}
+	if agg != nil {
+		t.Fatalf("expected countOrGroupOverExpHistogramValue to short-circuit BEFORE parsing the "+
+			"aggregate under metadataFullRange (agg == nil); got %#v — the mutant `||`->`&&` at "+
+			"histogram_native_count.go:98:31 would fall through to unwrapAggregateExpr and return a "+
+			"non-nil agg even though ok stays false via the recursive isExpHistogramValuedShape guard",
+			agg)
+	}
+}
+
+// TestCountValuesOverExpHistogramValue_MetadataFullRangeRejectsBeforeParsing
+// kills the INVERT_LOGICAL mutant at histogram_native_count_values.go:18:31
+// — the SAME "agg persists past the masked guard" shape
+// TestCountOrGroupOverExpHistogramValue_MetadataFullRangeRejectsBeforeParsing
+// kills above, for countValuesOverExpHistogramValue's identical
+// `return agg, isExpHistogramValuedShape(agg.Expr, s, ctx)` tail.
+func TestCountValuesOverExpHistogramValue_MetadataFullRangeRejectsBeforeParsing(t *testing.T) {
+	t.Parallel()
+
+	s := schema.DefaultOTelMetrics()
+	expr := mustParse(t, `count_values("val", latency_exp_hist)`)
+	agg, ok := countValuesOverExpHistogramValue(expr, s, lowerCtx{metadataFullRange: true})
+	if ok {
+		t.Fatalf("expected metadataFullRange to reject recognition; got ok=true")
+	}
+	if agg != nil {
+		t.Fatalf("expected countValuesOverExpHistogramValue to short-circuit BEFORE parsing the "+
+			"aggregate under metadataFullRange (agg == nil); got %#v — the mutant `||`->`&&` at "+
+			"histogram_native_count_values.go:18:31 would fall through and return a non-nil agg "+
+			"even though ok stays false via the recursive isExpHistogramValuedShape guard", agg)
+	}
+}
+
+// TestNativeHistogramBucketStrings_NegativeBoundsAreSignFlipped kills the
+// two adjacent mutants at histogram_native_count_values.go:116:79 and
+// :117:55 (ARITHMETIC_BASE `-`->`+` and INVERT_NEGATIVES `-1`->`1` — both
+// produce the identical observable effect, the multiplier flips from -1 to
+// 1) inside nativeHistogramBucketStrings's negative-bucket sign flip:
+//
+//	if !positive {
+//		lowerBound, upperBound = histStringBinary(chplan.OpMul, &chplan.LitFloat{V: -1}, upperBound),
+//			histStringBinary(chplan.OpMul, &chplan.LitFloat{V: -1}, lowerBound)
+//	}
+//
+// Negative-side bucket boundaries are stored as positive magnitudes and
+// must be negated (and swapped) to render the actual negative-valued
+// bounds FloatHistogram.String prints. Rather than rendering the full SQL
+// (a deep arrayMap/hqLet nest), this test descends the returned
+// chplan.Expr tree directly to the two multiply nodes and asserts each
+// multiplier is exactly -1 — the mutation's only observable effect.
+func TestNativeHistogramBucketStrings_NegativeBoundsAreSignFlipped(t *testing.T) {
+	t.Parallel()
+
+	buckets := &chplan.ColumnRef{Name: "neg_bucket_counts"}
+	offset := &chplan.ColumnRef{Name: "neg_offset"}
+	scale := &chplan.ColumnRef{Name: "scale"}
+
+	got := nativeHistogramBucketStrings(buckets, offset, scale, false /* positive */)
+
+	reverseCall, ok := got.(*chplan.FuncCall)
+	if !ok || reverseCall.Fn != chplan.FnArrayReverse {
+		t.Fatalf("nativeHistogramBucketStrings(..., positive=false) = %#v, want outer "+
+			"arrayReverse(...) FuncCall", got)
+	}
+	if len(reverseCall.Args) != 1 {
+		t.Fatalf("arrayReverse args = %#v, want exactly 1", reverseCall.Args)
+	}
+	mappedCall, ok := reverseCall.Args[0].(*chplan.FuncCall)
+	if !ok || mappedCall.Fn != chplan.FnArrayMap {
+		t.Fatalf("arrayReverse's arg = %#v, want arrayMap(...) FuncCall", reverseCall.Args[0])
+	}
+	if len(mappedCall.Args) != 2 {
+		t.Fatalf("arrayMap args = %#v, want exactly 2", mappedCall.Args)
+	}
+	lambda, ok := mappedCall.Args[0].(*chplan.Lambda)
+	if !ok {
+		t.Fatalf("arrayMap's first arg = %#v, want *chplan.Lambda", mappedCall.Args[0])
+	}
+	body, ok := lambda.Body.(*chplan.FuncCall)
+	if !ok || body.Fn != chplan.FnConcat {
+		t.Fatalf("lambda body = %#v, want concat(...) FuncCall", lambda.Body)
+	}
+	const lowerBoundArgIdx, upperBoundArgIdx = 1, 3
+	if len(body.Args) <= upperBoundArgIdx {
+		t.Fatalf("concat has %d args, want more than %d", len(body.Args), upperBoundArgIdx)
+	}
+
+	assertNegatedBound := func(label string, e chplan.Expr) {
+		t.Helper()
+		val := unwrapHqLetBoundValue(t, e)
+		mul, ok := val.(*chplan.Binary)
+		if !ok || mul.Op != chplan.OpMul {
+			t.Fatalf("%s = %#v, want the `-1 * <bound>` Binary the negative-bucket sign flip builds", label, val)
+		}
+		lit, ok := mul.Left.(*chplan.LitFloat)
+		if !ok || lit.V != -1 {
+			t.Fatalf("%s multiplier = %#v, want LitFloat{-1} (mutants at "+
+				"histogram_native_count_values.go:116:79 and :117:55 would flip this to 1, "+
+				"dropping the negative-bucket sign flip)", label, mul.Left)
+		}
+	}
+	assertNegatedBound("lowerBound (rendered from the swapped upperBound expr)", body.Args[lowerBoundArgIdx])
+	assertNegatedBound("upperBound (rendered from the swapped lowerBound expr)", body.Args[upperBoundArgIdx])
+}
+
+// TestNativeHistogramBucketStrings_PositiveBoundsAreNotSignFlipped is the
+// positive-side control for the test above: with positive=true, the `if
+// !positive` swap never runs, so neither bound is wrapped in a `-1 *`
+// Binary — it stays the bare nativeHistogramBoundExpr call. This confirms
+// the assertion above genuinely distinguishes the two branches rather than
+// vacuously matching any expression shape.
+func TestNativeHistogramBucketStrings_PositiveBoundsAreNotSignFlipped(t *testing.T) {
+	t.Parallel()
+
+	buckets := &chplan.ColumnRef{Name: "pos_bucket_counts"}
+	offset := &chplan.ColumnRef{Name: "pos_offset"}
+	scale := &chplan.ColumnRef{Name: "scale"}
+
+	got := nativeHistogramBucketStrings(buckets, offset, scale, true /* positive */)
+
+	mappedCall, ok := got.(*chplan.FuncCall)
+	if !ok || mappedCall.Fn != chplan.FnArrayMap {
+		t.Fatalf("nativeHistogramBucketStrings(..., positive=true) = %#v, want arrayMap(...) FuncCall", got)
+	}
+	lambda, ok := mappedCall.Args[0].(*chplan.Lambda)
+	if !ok {
+		t.Fatalf("arrayMap's first arg = %#v, want *chplan.Lambda", mappedCall.Args[0])
+	}
+	body, ok := lambda.Body.(*chplan.FuncCall)
+	if !ok || body.Fn != chplan.FnConcat {
+		t.Fatalf("lambda body = %#v, want concat(...) FuncCall", lambda.Body)
+	}
+	const lowerBoundArgIdx = 1
+	val := unwrapHqLetBoundValue(t, body.Args[lowerBoundArgIdx])
+	if _, isMul := val.(*chplan.Binary); isMul {
+		t.Fatalf("positive-side lowerBound = %#v, want the bare nativeHistogramBoundExpr call "+
+			"(no sign-flip multiply) — got a Binary instead", val)
+	}
+	if _, isPow := val.(*chplan.FuncCall); !isPow {
+		t.Fatalf("positive-side lowerBound = %#v, want a pow(...) FuncCall "+
+			"(nativeHistogramBoundExpr's own shape)", val)
+	}
+}
+
+// unwrapHqLetBoundValue recovers the raw value hqLet bound, given the
+// result of nativeHistogramFloatString(value) — hqLet renders
+// `arrayMap(<param> -> <body>, array(<val>))[1]`, so `val` sits at
+// Container.(*FuncCall).Args[1].(*FuncCall /* array */).Args[0].
+func unwrapHqLetBoundValue(t *testing.T, e chplan.Expr) chplan.Expr {
+	t.Helper()
+	sub, ok := e.(*chplan.Subscript)
+	if !ok {
+		t.Fatalf("expected *chplan.Subscript (hqLet's own shape), got %T: %#v", e, e)
+	}
+	fm, ok := sub.Container.(*chplan.FuncCall)
+	if !ok || fm.Fn != chplan.FnArrayMap {
+		t.Fatalf("hqLet Container = %#v, want an arrayMap(...) FuncCall", sub.Container)
+	}
+	if len(fm.Args) != 2 {
+		t.Fatalf("hqLet arrayMap args = %#v, want exactly 2", fm.Args)
+	}
+	arrayCall, ok := fm.Args[1].(*chplan.FuncCall)
+	if !ok || arrayCall.Fn != chplan.FnArray {
+		t.Fatalf("hqLet's second arrayMap arg = %#v, want an array(...) FuncCall", fm.Args[1])
+	}
+	if len(arrayCall.Args) != 1 {
+		t.Fatalf("hqLet's array(...) call has %d args, want exactly 1", len(arrayCall.Args))
+	}
+	return arrayCall.Args[0]
+}
+
+// TestNativeHistogramBoundExpr_ScaleExponentIsNegated kills the two
+// adjacent mutants at histogram_native_count_values.go:187:107
+// (ARITHMETIC_BASE `-`->`+` and INVERT_NEGATIVES `-1`->`1`, the same
+// observable-effect pair as the 116/117 kill above) inside
+// nativeHistogramBoundExpr's growth-factor base:
+//
+//	base := histStringCall(chplan.FnPow, &chplan.LitFloat{V: 2},
+//		histStringCall(chplan.FnPow, &chplan.LitFloat{V: 2},
+//			histStringBinary(chplan.OpMul, &chplan.LitFloat{V: -1}, scale)))
+//
+// base = 2^(2^-scale) — the OTel exponential-histogram growth factor.
+// Flipping the exponent's sign inverts growth vs. shrinkage as scale
+// increases, silently misrendering every bucket boundary. Asserted
+// structurally (no chsql rendering needed): descend to the `-1 * scale`
+// Binary and check the multiplier.
+func TestNativeHistogramBoundExpr_ScaleExponentIsNegated(t *testing.T) {
+	t.Parallel()
+
+	index := &chplan.ColumnRef{Name: "idx"}
+	scale := &chplan.ColumnRef{Name: "scale"}
+
+	got := nativeHistogramBoundExpr(index, scale)
+
+	outer, ok := got.(*chplan.FuncCall)
+	if !ok || outer.Fn != chplan.FnPow {
+		t.Fatalf("nativeHistogramBoundExpr(...) = %#v, want the outer pow(base, index) FuncCall", got)
+	}
+	if len(outer.Args) != 2 {
+		t.Fatalf("outer pow args = %#v, want exactly 2", outer.Args)
+	}
+	if !outer.Args[1].Equal(index) {
+		t.Fatalf("outer pow's second arg = %#v, want the index expr unchanged", outer.Args[1])
+	}
+	base, ok := outer.Args[0].(*chplan.FuncCall)
+	if !ok || base.Fn != chplan.FnPow {
+		t.Fatalf("base = %#v, want the inner pow(2, pow(2, -scale)) FuncCall", outer.Args[0])
+	}
+	if len(base.Args) != 2 {
+		t.Fatalf("base pow args = %#v, want exactly 2", base.Args)
+	}
+	innerPow, ok := base.Args[1].(*chplan.FuncCall)
+	if !ok || innerPow.Fn != chplan.FnPow {
+		t.Fatalf("base.Args[1] = %#v, want the pow(2, -scale) FuncCall", base.Args[1])
+	}
+	if len(innerPow.Args) != 2 {
+		t.Fatalf("innerPow args = %#v, want exactly 2", innerPow.Args)
+	}
+	mul, ok := innerPow.Args[1].(*chplan.Binary)
+	if !ok || mul.Op != chplan.OpMul {
+		t.Fatalf("innerPow.Args[1] = %#v, want the `-1 * scale` Binary", innerPow.Args[1])
+	}
+	lit, ok := mul.Left.(*chplan.LitFloat)
+	if !ok || lit.V != -1 {
+		t.Fatalf("mul.Left = %#v, want LitFloat{-1} (mutants at "+
+			"histogram_native_count_values.go:187:107 would flip this to 1, negating the "+
+			"exponent's sign)", mul.Left)
+	}
+	if !mul.Right.Equal(scale) {
+		t.Fatalf("mul.Right = %#v, want the scale expr unchanged", mul.Right)
+	}
+}

--- a/internal/promql/gremlins_kill_histogram_mixed_or_test.go
+++ b/internal/promql/gremlins_kill_histogram_mixed_or_test.go
@@ -1,0 +1,186 @@
+// Tests in this file kill the LIVED gremlins mutants assigned to the
+// histogram_native_mixed_or_label.go / histogram_native_mixed_or_vector_
+// comparison.go / histogram_native_value_producing_call.go cluster from a
+// phase4-promql-i mutation run (mutation.yml, cerberus issue #2636 — the
+// leg whose original run crashed on a network flake before any mutant
+// ran). See gremlins_kill_test.go for the shared file-header convention
+// this file follows.
+//
+// One CONDITIONALS_BOUNDARY mutant is NOT addressed with a dedicated test
+// here — it is provably equivalent, not a coverage gap:
+//
+//   - histogram_native_mixed_or_vector_comparison.go:163:36
+//     (`len(b.VectorMatching.Include) > 0` -> `>= 0`, inside
+//     comparisonVectorVectorOverMixedExpHistogramSetOp).
+//
+// The guarded statement is `include = append([]string(nil),
+// b.VectorMatching.Include...)`. Go's append, given zero elements to
+// append (whether the source is nil or a non-nil empty slice), always
+// returns its destination UNCHANGED — verified directly:
+// `append([]string(nil))` and `append([]string(nil), []string{}...)` both
+// evaluate to nil. So whenever len(Include) == 0 (the only value the `>
+// 0` vs `>= 0` boundary can possibly disagree on), running the append
+// unconditionally (mutant) or skipping it (original) produces the exact
+// same `include == nil` result either way; for len(Include) > 0 both
+// branches run the identical copy. No input can make the two branches
+// disagree. Confirmed by manually applying the mutation and running
+// `go test ./internal/promql/...`: green.
+package promql
+
+import (
+	"testing"
+
+	"github.com/prometheus/prometheus/promql/parser"
+
+	"github.com/tsouza/cerberus/internal/chplan"
+	"github.com/tsouza/cerberus/internal/schema"
+)
+
+// TestLabelCallOverMixedExpHistogramSetOp_LabelJoinMinArity kills the
+// CONDITIONALS_BOUNDARY mutant at histogram_native_mixed_or_label.go:61:21
+// (`len(call.Args) < 3` -> `<= 3`) inside labelCallOverMixedExpHistogramSetOp's
+// label_join arm. The minimum valid label_join call has exactly 3 args
+// (vector, dst, separator, zero src labels) — label_fns.go's own arity
+// error confirms 3 is the floor. The parser itself refuses this degenerate
+// shape (real label_join calls always carry at least one src label in
+// practice, but nothing in the grammar requires it), so the Call is built
+// by hand — mirrors
+// TestLabelCallOverExpHistogramDroppingShape_LabelJoinMinArity's identical
+// technique for the (non-mixed) drop-family sibling
+// (histogram_native_range_family_gremlins_test.go).
+func TestLabelCallOverMixedExpHistogramSetOp_LabelJoinMinArity(t *testing.T) {
+	t.Parallel()
+
+	s := schema.DefaultOTelMetrics()
+	call := &parser.Call{
+		Func: parser.MustGetFunction("label_join"),
+		Args: parser.Expressions{
+			mustParse(t, `latency_exp_hist or other_metric`),
+			&parser.StringLiteral{Val: "dst"},
+			&parser.StringLiteral{Val: "-"},
+		},
+	}
+	if _, _, ok := labelCallOverMixedExpHistogramSetOp(call, s, lowerCtx{}); !ok {
+		t.Fatalf("expected minimum-arity (3-arg) label_join wrapping a mixed histogram/float `or` " +
+			"to be recognised; got ok=false (mutant `<`->`<=` at " +
+			"histogram_native_mixed_or_label.go:61:21)")
+	}
+}
+
+// TestLowerMixedVVCompareBool_HistCmpNegationMatchesOp kills the
+// CONDITIONALS_NEGATION mutant at
+// histogram_native_mixed_or_vector_comparison.go:357:44
+// (`op == chplan.OpNe` -> `!=`) inside lowerMixedVVCompareBool's
+// histogram,histogram branch:
+//
+//	histCmp := mixedVVHistogramFieldsExpr(op == chplan.OpNe)
+//
+// mixedVVHistogramFieldsExpr(ne) combines its nine per-field comparisons
+// with AND (ne=false, `==`) or OR (ne=true, `!=`) — the top-level Binary's
+// Op after the fold is exactly that combine operator. Flipping the `==` to
+// `!=` at the call site swaps which literal op value (Eq vs Ne) drives
+// ne=true, so an actual `==` would wrongly use OR-of-unequal and an actual
+// `!=` would wrongly use AND-of-equal.
+//
+// Driven directly against lowerMixedVVCompareBool (a zero-value
+// *chplan.MixedVectorJoin is safe here — every helper it calls reads only
+// Match/Card/Include, never Left/Right) rather than through a full lower(),
+// so the structural check ties to the exact call site without depending on
+// [chplan.MixedVectorJoin]'s own JOIN semantics.
+func TestLowerMixedVVCompareBool_HistCmpNegationMatchesOp(t *testing.T) {
+	t.Parallel()
+
+	s := schema.DefaultOTelMetrics()
+	join := &chplan.MixedVectorJoin{Card: chplan.CardOneToOne}
+
+	histCmpCombine := func(t *testing.T, op chplan.BinaryOp) chplan.BinaryOp {
+		t.Helper()
+		plan := lowerMixedVVCompareBool(join, op, s)
+		proj, ok := plan.(*chplan.Project)
+		if !ok {
+			t.Fatalf("lowerMixedVVCompareBool(op=%s) = %T, want *chplan.Project", op, plan)
+		}
+		const valueProjIdx = 3
+		if len(proj.Projections) <= valueProjIdx {
+			t.Fatalf("Projections has %d entries, want more than %d", len(proj.Projections), valueProjIdx)
+		}
+		fc, ok := proj.Projections[valueProjIdx].Expr.(*chplan.FuncCall)
+		if !ok || fc.Fn != chplan.FnIf {
+			t.Fatalf("Projections[%d].Expr = %#v, want an if(bothFloat, floatCmp, histCmp) FuncCall",
+				valueProjIdx, proj.Projections[valueProjIdx].Expr)
+		}
+		const histArgIdx = 2
+		if len(fc.Args) <= histArgIdx {
+			t.Fatalf("if(...) has %d args, want more than %d", len(fc.Args), histArgIdx)
+		}
+		histWrap, ok := fc.Args[histArgIdx].(*chplan.FuncCall)
+		if !ok || histWrap.Fn != chplan.FnToFloat64 {
+			t.Fatalf("if(...)'s hist-branch arg = %#v, want a toFloat64(...) FuncCall", fc.Args[histArgIdx])
+		}
+		if len(histWrap.Args) != 1 {
+			t.Fatalf("toFloat64(...) has %d args, want exactly 1", len(histWrap.Args))
+		}
+		bin, ok := histWrap.Args[0].(*chplan.Binary)
+		if !ok {
+			t.Fatalf("toFloat64's arg = %#v, want a top-level *chplan.Binary (the field-comparison fold)", histWrap.Args[0])
+		}
+		return bin.Op
+	}
+
+	if got := histCmpCombine(t, chplan.OpEq); got != chplan.OpAnd {
+		t.Fatalf("op=EQ: histCmp top combine = %s, want AND (ne=false) — mutant `==`->`!=` at "+
+			"histogram_native_mixed_or_vector_comparison.go:357:44 would pass ne=true here and use OR",
+			got)
+	}
+	if got := histCmpCombine(t, chplan.OpNe); got != chplan.OpOr {
+		t.Fatalf("op=NE: histCmp top combine = %s, want OR (ne=true) — mutant `==`->`!=` at "+
+			"histogram_native_mixed_or_vector_comparison.go:357:44 would pass ne=false here and use AND",
+			got)
+	}
+}
+
+// TestHistogramValuedProducerCall_InfoAcceptsTwoArgs kills the
+// CONDITIONALS_BOUNDARY mutant at
+// histogram_native_value_producing_call.go:41:43 (`len(call.Args) > 2` ->
+// `>= 2`) inside histogramValuedProducerCall's info() arm. info() accepts
+// 1 or 2 arguments; exactly 2 is the valid upper boundary and must NOT be
+// rejected.
+func TestHistogramValuedProducerCall_InfoAcceptsTwoArgs(t *testing.T) {
+	t.Parallel()
+
+	s := schema.DefaultOTelMetrics()
+	call := &parser.Call{
+		Func: parser.MustGetFunction("info"),
+		Args: parser.Expressions{
+			mustParseVectorSelector(t, "latency_exp_hist"),
+			&parser.StringLiteral{Val: "service"},
+		},
+	}
+	if _, ok := histogramValuedProducerCall(call, s, lowerCtx{}); !ok {
+		t.Fatalf("expected info() with exactly 2 args over a histogram-valued base to be " +
+			"recognised; got ok=false (mutant `>`->`>=` at " +
+			"histogram_native_value_producing_call.go:41:43 would reject the 2-arg boundary)")
+	}
+}
+
+// TestHistogramValuedProducerCall_SortByLabelAcceptsSingleArg kills the
+// CONDITIONALS_BOUNDARY mutant at
+// histogram_native_value_producing_call.go:45:21 (`len(call.Args) < 1` ->
+// `<= 1`) inside histogramValuedProducerCall's sort_by_label(_desc) arm.
+// sort_by_label accepts the vector argument alone (zero label names); the
+// parser's own grammar allows this shape (no minimum label-name count),
+// and the boundary — exactly 1 argument — must NOT be rejected.
+func TestHistogramValuedProducerCall_SortByLabelAcceptsSingleArg(t *testing.T) {
+	t.Parallel()
+
+	s := schema.DefaultOTelMetrics()
+	call := &parser.Call{
+		Func: parser.MustGetFunction("sort_by_label"),
+		Args: parser.Expressions{mustParseVectorSelector(t, "latency_exp_hist")},
+	}
+	if _, ok := histogramValuedProducerCall(call, s, lowerCtx{}); !ok {
+		t.Fatalf("expected sort_by_label() with exactly 1 arg (no label names) over a " +
+			"histogram-valued base to be recognised; got ok=false (mutant `<`->`<=` at " +
+			"histogram_native_value_producing_call.go:45:21 would reject the 1-arg boundary)")
+	}
+}

--- a/internal/promql/gremlins_kill_histogram_subquery_select_test.go
+++ b/internal/promql/gremlins_kill_histogram_subquery_select_test.go
@@ -1,0 +1,245 @@
+// Tests in this file kill the LIVED gremlins mutants assigned to the
+// histogram_native_subquery_select.go / histogram_native_bare.go cluster
+// from a phase4-promql-i mutation run (mutation.yml, cerberus issue #2636 —
+// the leg whose original run crashed on a network flake before any mutant
+// ran). See gremlins_kill_test.go for the shared file-header convention
+// this file follows.
+//
+// Three mutants are NOT addressed with a dedicated test here — all three
+// are provably equivalent, not coverage gaps:
+//
+//   - histogram_native_subquery_select.go:102:31 (INVERT_LOGICAL,
+//     `s.ExpHistogramTable == "" || ctx.metadataFullRange` -> `&&` inside
+//     selectFnOverExpHistogramSubquery). This function re-validates the
+//     identical condition one level down at line 118's
+//     `!isExpHistogramValuedShape(sub.Expr, s, ctx)` — and EVERY leaf
+//     recognizer isExpHistogramValuedShape dispatches to carries the same
+//     guard, so whenever the top guard's condition holds,
+//     isExpHistogramValuedShape is unconditionally false regardless of
+//     which branch of the mutation let control reach it. Unlike
+//     countOrGroupOverExpHistogramValue (gremlins_kill_histogram_binop_
+//     count_test.go), no "did it even try to parse" tuple survives here:
+//     EVERY rejection path in this function returns the literal zero-value
+//     `histogramSubquerySelectShape{}, false` — never a partially built
+//     one — so the two branches converge on the exact same return value on
+//     every input.
+//   - histogram_native_subquery_select.go:170:10 (CONDITIONALS_BOUNDARY,
+//     `step < 0` -> `<= 0`). Two lines above, `if step == 0 { step =
+//     defaultSubqueryStep }` (defaultSubqueryStep = time.Minute, a positive
+//     constant) already eliminates step == 0 as a reachable value by the
+//     time line 170 runs — step is either the caller's own non-zero
+//     sub.Step or the positive default. `<` and `<=` decide identically
+//     over every value except exactly 0, so no reachable input can make
+//     the two operators disagree (the same reasoning
+//     gremlins_kill_subquery_test.go's header gives for subquery.go:37:10).
+//   - histogram_native_subquery_select.go:185:14 (INVERT_LOGICAL, `!matched
+//     || chplan.RowShapeOf(input) != chplan.HistogramRowShape` -> `&&`).
+//     lowerExpHistogramValuedShape's own contract (histogram_native_float_
+//     fn.go) guarantees `matched == false` if and only if its very last
+//     fallback ran, which always returns `input == nil` — and
+//     chplan.RowShapeOf(nil) (no `case nil` in its type switch) always
+//     falls through to its non-Histogram default. So `!matched` and
+//     `RowShapeOf(input) != Histogram` are always EQUAL on every reachable
+//     input: both true together (an unmatched sub-expression) or both false
+//     together (every histogram-preserving recognizer this dispatch reaches
+//     is documented to publish HistogramRowShape whenever it returns a nil
+//     error, and a non-nil error already returns two lines above this
+//     guard). OR and AND compute the same boolean whenever their two
+//     operands are always equal.
+//
+// All three are confirmed by manually applying the mutation and running
+// `go test ./internal/promql/...`: green.
+package promql
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/prometheus/prometheus/promql/parser"
+
+	"github.com/tsouza/cerberus/internal/chplan"
+	"github.com/tsouza/cerberus/internal/chsql"
+	"github.com/tsouza/cerberus/internal/schema"
+)
+
+// TestSelectFnOverExpHistogramSubquery_ZeroRangeRejected kills the
+// CONDITIONALS_BOUNDARY mutant at histogram_native_subquery_select.go:
+// 118:22 (`sub.Range <= 0` -> `< 0`). A zero-duration subquery with an
+// otherwise valid histogram-native inner and a resolvable eval anchor
+// isolates the Range check alone: subqueryGridCtx tolerates a zero Range
+// via its own sub-step-window clamp, so subqueryHasEvalAnchor genuinely
+// returns true here — the same isolation strategy
+// TestRangeFnOverExpHistogramSubquery_ZeroRangeRejected
+// (histogram_native_range_family_gremlins_test.go) uses for its own
+// sibling guard.
+func TestSelectFnOverExpHistogramSubquery_ZeroRangeRejected(t *testing.T) {
+	t.Parallel()
+
+	s := schema.DefaultOTelMetrics()
+	at := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	sub := &parser.SubqueryExpr{
+		Expr:  mustParseVectorSelector(t, "latency_exp_hist"),
+		Range: 0,
+		Step:  time.Minute,
+	}
+	call := &parser.Call{
+		Func: parser.MustGetFunction("count_over_time"),
+		Args: parser.Expressions{sub},
+	}
+	ctx := lowerCtx{start: at, end: at}
+	if _, ok := selectFnOverExpHistogramSubquery(call, s, ctx); ok {
+		t.Fatalf("expected zero-range subquery to be rejected; got ok=true " +
+			"(mutant `<=`->`<` at histogram_native_subquery_select.go:118:22)")
+	}
+}
+
+// TestLowerSelectFnOverExpHistogramSubquery_ZeroStepDefaults kills the
+// CONDITIONALS_NEGATION mutant at histogram_native_subquery_select.go:
+// 167:10 (`step == 0` -> `step != 0`). A subquery with no explicit step
+// (`[5m:]`) must fall back to defaultSubqueryStep. With the negation, step
+// stays 0 and flows into subqueryGridCtx -> epochFloor, which divides by
+// the step duration — a genuine divide-by-zero panic, not merely a wrong
+// answer (the same signature
+// TestLowerExpHistogramRangeFnOverSubquery_ZeroStepDefaults pins for its
+// own sibling in histogram_native_range_fn.go). The original code lowers
+// this query cleanly; the mutant panics.
+func TestLowerSelectFnOverExpHistogramSubquery_ZeroStepDefaults(t *testing.T) {
+	t.Parallel()
+
+	s := schema.DefaultOTelMetrics()
+	at := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	expr := mustParse(t, `count_over_time((latency_exp_hist)[5m:])`)
+	if _, err := LowerAt(context.Background(), expr, s, at, at); err != nil {
+		t.Fatalf("LowerAt: %v", err)
+	}
+}
+
+// TestLowerSelectFnOverExpHistogramSubquery_InstantPinDoesNotBroadcast
+// kills the INVERT_LOGICAL mutant at histogram_native_subquery_select.go:
+// 200:21 (`ctx.rangeMode() && subqueryPinned(sub)` -> `||`). An
+// `@`-pinned histogram-preserving subquery (last_over_time) reached via a
+// plain instant LowerAt (ctx.rangeMode() == false) must take the ordinary
+// single-window branch. With OR, subqueryPinned(sub) alone satisfies the
+// condition and routes through the CrossJoin-over-StepGrid broadcast
+// branch with ctx.step == 0 — a shape that must never appear outside real
+// query_range lowering (mirrors
+// TestLowerSumOrAvgMixedOrSubquerySelectFn_InstantPinDoesNotBroadcast's
+// identical strategy for its own sibling guard).
+func TestLowerSelectFnOverExpHistogramSubquery_InstantPinDoesNotBroadcast(t *testing.T) {
+	t.Parallel()
+
+	s := schema.DefaultOTelMetrics()
+	at := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	expr := mustParse(t, `last_over_time((latency_exp_hist)[5m:1m] @ 1700000000)`)
+	plan, err := LowerAt(context.Background(), expr, s, at, at)
+	if err != nil {
+		t.Fatalf("LowerAt: %v", err)
+	}
+	assertNoCrossJoin(t, plan, "last_over_time instant query over an @-pinned histogram-native subquery")
+}
+
+// TestBareExpHistogramMatrixSelector_MetadataFullRangeShortCircuits kills
+// the INVERT_LOGICAL mutant at histogram_native_bare.go:225:31, where
+//
+//	if s.ExpHistogramTable == "" || ctx.metadataFullRange {
+//
+// must reject on EITHER condition. bareExpHistogramMatrixSelector has no
+// downstream call that independently re-checks this same guard (a plain
+// type assertion plus IsExpHistogramMetric, both guard-free), so
+// metadataFullRange alone is a clean, unmasked differentiator — mirrors
+// TestRangeFnOverExpHistogram_MetadataFullRangeShortCircuits
+// (histogram_native_range_family_gremlins_test.go).
+func TestBareExpHistogramMatrixSelector_MetadataFullRangeShortCircuits(t *testing.T) {
+	t.Parallel()
+
+	s := schema.DefaultOTelMetrics()
+	expr := mustParse(t, `latency_exp_hist[5m]`)
+	if _, _, ok := bareExpHistogramMatrixSelector(expr, s, lowerCtx{metadataFullRange: true}); ok {
+		t.Fatalf("expected metadataFullRange to reject recognition; got ok=true " +
+			"(mutant `||`->`&&` at histogram_native_bare.go:225:31)")
+	}
+}
+
+// TestLowerExpHistogramBareMatrix_PinnedAtNotOverwrittenByQueryEnd kills
+// the INVERT_LOGICAL mutant at histogram_native_bare.go:265:25
+// (`anchor.End.IsZero() && !ctx.end.IsZero()` -> `||`).
+//
+// The original AND only back-fills anchor.End from ctx.end when the
+// selector carries NO pin of its own. An `@`-pinned top-level matrix
+// selector already has a non-zero anchor.End; with the flip to OR, a
+// non-zero ctx.end (any instant query reached via LowerAt) alone satisfies
+// the condition and OVERWRITES the pin with the query's own eval time —
+// silently answering the wrong window. Mirrors
+// TestExpHistogramRangeFnWindowed_PinnedAtNotOverwrittenByQueryEnd's
+// identical technique for its own sibling guard
+// (histogram_native_range_family_gremlins_test.go).
+func TestLowerExpHistogramBareMatrix_PinnedAtNotOverwrittenByQueryEnd(t *testing.T) {
+	t.Parallel()
+
+	s := schema.DefaultOTelMetrics()
+	// 1767225600 == 2026-01-01T00:00:00Z.
+	expr := mustParse(t, `latency_exp_hist[5m] @ 1767225600`)
+	queryEnd := time.Date(2030, 5, 5, 0, 0, 0, 0, time.UTC)
+
+	plan, err := LowerAt(context.Background(), expr, s, queryEnd, queryEnd)
+	if err != nil {
+		t.Fatalf("LowerAt: %v", err)
+	}
+	sql, params, err := chsql.Emit(context.Background(), plan)
+	if err != nil {
+		t.Fatalf("Emit: %v", err)
+	}
+	var paramsText strings.Builder
+	for _, p := range params {
+		fmt.Fprintf(&paramsText, "%v;", p)
+	}
+	got := paramsText.String()
+	if !strings.Contains(got, "2026-01-01") {
+		t.Fatalf("expected the pinned @ timestamp (2026-01-01) among the emitted parameters, got:\n%s\nSQL:\n%s", got, sql)
+	}
+	if strings.Contains(got, "2030-05-05") {
+		t.Fatalf("emitted parameters leaked the query end (2030-05-05) instead of the pinned @ "+
+			"timestamp (mutant `&&`->`||` at histogram_native_bare.go:265:25 overwrites the pin "+
+			"with ctx.end):\n%s", got)
+	}
+}
+
+// TestLowerExpHistogramBareMatrix_PredicateAppliesFilter kills the
+// CONDITIONALS_NEGATION mutant at histogram_native_bare.go:277:10 (`pred
+// != nil` -> `== nil`) inside lowerExpHistogramBareMatrix:
+//
+//	if pred != nil {
+//		input = &chplan.Filter{Input: scan, Predicate: pred}
+//	}
+//
+// pred is built from buildPredicate(vs.LabelMatchers, s) andExpr'd with
+// two time-bound predicates — for any real selector (at least the
+// `__name__` matcher, plus the window bounds) pred is always non-nil, so
+// the original code always wraps the scan in a Filter. The mutant flips
+// the condition, wrapping in a Filter only when pred IS nil — leaving a
+// real query's scan completely UNFILTERED, reading the whole
+// exp-histogram table.
+func TestLowerExpHistogramBareMatrix_PredicateAppliesFilter(t *testing.T) {
+	t.Parallel()
+
+	s := schema.DefaultOTelMetrics()
+	vs := mustParseVectorSelector(t, "latency_exp_hist")
+	ms := &parser.MatrixSelector{VectorSelector: vs, Range: 5 * time.Minute}
+
+	plan, err := lowerExpHistogramBareMatrix(ms, vs, s, lowerCtx{})
+	if err != nil {
+		t.Fatalf("lowerExpHistogramBareMatrix: %v", err)
+	}
+	hp, ok := plan.(*chplan.HistogramProjection)
+	if !ok {
+		t.Fatalf("plan = %T, want *chplan.HistogramProjection", plan)
+	}
+	if _, ok := hp.Input.(*chplan.Filter); !ok {
+		t.Fatalf("HistogramProjection.Input = %T, want *chplan.Filter (mutant `!=`->`==` at "+
+			"histogram_native_bare.go:277:10 would leave the scan unfiltered whenever a real "+
+			"predicate exists)", hp.Input)
+	}
+}

--- a/internal/promql/gremlins_kill_subquery_test.go
+++ b/internal/promql/gremlins_kill_subquery_test.go
@@ -1,0 +1,499 @@
+// Tests in this file pin behaviour that the gremlins mutation suite had
+// reported as LIVED on internal/promql/subquery.go — each one constructs
+// an input that observably differentiates the original code from the
+// mutated branch, so the test fails when the mutant is applied and the
+// mutant is reported KILLED. See gremlins_kill_test.go's own header for
+// the file:line:col convention.
+//
+// Two CONDITIONALS_BOUNDARY mutants reported for this file are NOT
+// addressed here (subquery.go:37:10 and subquery.go:408:26): both are
+// mathematically equivalent mutants, not coverage gaps. At subquery.go:37
+// (`if step < 0`), `step` is reassigned to the positive
+// `defaultSubqueryStep` constant whenever it was zero (lines 33-36), so
+// `step` can never be exactly 0 by the time the boundary check runs —
+// `<` and `<=` decide identically over every reachable value. At
+// subquery.go:408:26 (`if ns%stepNS != 0 && ns < 0`), the `<`/`<=`
+// boundary sits at ns==0, but ns==0 forces `ns%stepNS == 0` for any
+// nonzero stepNS, which makes the left `&&` operand false and
+// short-circuits the whole expression regardless of the right operand's
+// boundary — so no input can ever reach a state where the two operators
+// disagree. No test can kill either mutant without the underlying code
+// changing shape.
+package promql
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/prometheus/prometheus/promql/parser"
+
+	"github.com/tsouza/cerberus/internal/chplan"
+	"github.com/tsouza/cerberus/internal/schema"
+)
+
+// TestLowerOuterRangeFnOverSubquery_PinnedRangeModeWidensByOffsetPlusRange
+// kills the ARITHMETIC_BASE + INVERT_NEGATIVES pair at subquery.go:1034:44
+// — the `-rw.Offset` term inside the `@`-pinned + range-mode arm's
+// `widenSubquerySpine(inner, anchor.End.Add(-rw.Offset-sub.Range), anchor.End)`
+// call. Both mutants flip the Offset term's sign (one by swapping the
+// arithmetic operator, one by inverting the unary negation — the
+// observable effect is identical: the inner spine gets widened starting
+// `+rw.Offset` early instead of `-rw.Offset` late).
+//
+// TestLowerOuterRangeFnOverSubquery_WidensInnerByOffsetPlusRange
+// (subquery_time_offset_test.go) already pins the neighbouring
+// "range mode, not pinned" arm; this test is its `@`-pinned sibling,
+// the one branch that actually reaches line 1034.
+func TestLowerOuterRangeFnOverSubquery_PinnedRangeModeWidensByOffsetPlusRange(t *testing.T) {
+	t.Parallel()
+
+	const query = `max_over_time(rate(demo_cpu[5m])[1h:5m] offset 10m @ 1700010000)`
+	offset := 10 * time.Minute
+	subRange := time.Hour
+	pinnedTS := time.Unix(1700010000, 0).UTC()
+	s := schema.DefaultOTelMetrics()
+
+	expr, err := parser.NewParser(parser.Options{}).ParseExpr(query)
+	if err != nil {
+		t.Fatalf("ParseExpr(%q): %v", query, err)
+	}
+
+	start := time.Unix(1_700_000_000, 0).UTC()
+	end := start.Add(2 * time.Hour)
+	plan, err := LowerAtRange(context.Background(), expr, s, start, end, time.Minute)
+	if err != nil {
+		t.Fatalf("LowerAtRange(%q): %v", query, err)
+	}
+	outerProj, ok := plan.(*chplan.Project)
+	if !ok {
+		t.Fatalf("plan = %T, want *chplan.Project (wrapRangeWindowAtBroadcast)", plan)
+	}
+	joined, ok := outerProj.Input.(*chplan.CrossJoin)
+	if !ok {
+		t.Fatalf("Project.Input = %T, want *chplan.CrossJoin", outerProj.Input)
+	}
+	rw, ok := joined.Right.(*chplan.RangeWindow)
+	if !ok {
+		t.Fatalf("CrossJoin.Right = %T, want *chplan.RangeWindow", joined.Right)
+	}
+	inner := firstRangeWindow(rw.Input)
+	if inner == nil {
+		t.Fatal("no inner RangeWindow found under the outer reducer's Input")
+	}
+	wantStart := pinnedTS.Add(-offset).Add(-subRange)
+	if !inner.Start.Equal(wantStart) {
+		t.Errorf("inner.Start = %s, want %s (pinnedTS - offset - subRange) — "+
+			"mutants at subquery.go:1034:44 would yield %s (pinnedTS + offset - subRange)",
+			inner.Start, wantStart, pinnedTS.Add(offset).Add(-subRange))
+	}
+}
+
+// TestLowerAbsentOverTimeOverSubquery_RangeModeWidensByOffsetPlusRange
+// kills the ARITHMETIC_BASE + INVERT_NEGATIVES pair at subquery.go:1980:45
+// — the `-a.Offset` term in the range-mode (not pinned) arm of
+// lowerAbsentOverTimeOverSubquery's widenSubquerySpine call.
+func TestLowerAbsentOverTimeOverSubquery_RangeModeWidensByOffsetPlusRange(t *testing.T) {
+	t.Parallel()
+
+	const query = `absent_over_time(demo_cpu[5m:1m] offset 10m)`
+	offset := 10 * time.Minute
+	subRange := 5 * time.Minute
+	s := schema.DefaultOTelMetrics()
+
+	expr, err := parser.NewParser(parser.Options{}).ParseExpr(query)
+	if err != nil {
+		t.Fatalf("ParseExpr(%q): %v", query, err)
+	}
+
+	start := time.Unix(1_700_000_000, 0).UTC()
+	end := start.Add(2 * time.Hour)
+	plan, err := LowerAtRange(context.Background(), expr, s, start, end, time.Minute)
+	if err != nil {
+		t.Fatalf("LowerAtRange(%q): %v", query, err)
+	}
+	a := firstAbsentOverTime(plan)
+	if a == nil {
+		t.Fatalf("no chplan.AbsentOverTime under the lowered %q", query)
+	}
+	inner := firstRangeWindow(a.Input)
+	if inner == nil {
+		t.Fatal("no RangeWindow found under AbsentOverTime.Input")
+	}
+	wantStart := start.Add(-offset).Add(-subRange)
+	if !inner.Start.Equal(wantStart) {
+		t.Errorf("inner.Start = %s, want %s (ctx.start - offset - subRange) — "+
+			"mutants at subquery.go:1980:45 would yield %s (ctx.start + offset - subRange)",
+			inner.Start, wantStart, start.Add(offset).Add(-subRange))
+	}
+}
+
+// TestLowerAbsentOverTimeOverSubquery_InstantModeWidensByOffsetPlusRange
+// kills the ARITHMETIC_BASE + INVERT_NEGATIVES pair at subquery.go:1986:42
+// — the `-a.Offset` term in the default (instant-mode) arm's
+// widenSubquerySpine call.
+func TestLowerAbsentOverTimeOverSubquery_InstantModeWidensByOffsetPlusRange(t *testing.T) {
+	t.Parallel()
+
+	const query = `absent_over_time(demo_cpu[5m:1m] offset 7m)`
+	offset := 7 * time.Minute
+	subRange := 5 * time.Minute
+	evalTS := time.Unix(1_700_010_000, 0).UTC()
+	s := schema.DefaultOTelMetrics()
+
+	expr, err := parser.NewParser(parser.Options{}).ParseExpr(query)
+	if err != nil {
+		t.Fatalf("ParseExpr(%q): %v", query, err)
+	}
+
+	plan, err := LowerAt(context.Background(), expr, s, evalTS, evalTS)
+	if err != nil {
+		t.Fatalf("LowerAt(%q): %v", query, err)
+	}
+	a := firstAbsentOverTime(plan)
+	if a == nil {
+		t.Fatalf("no chplan.AbsentOverTime under the lowered %q", query)
+	}
+	inner := firstRangeWindow(a.Input)
+	if inner == nil {
+		t.Fatal("no RangeWindow found under AbsentOverTime.Input")
+	}
+	wantStart := evalTS.Add(-offset).Add(-subRange)
+	if !inner.Start.Equal(wantStart) {
+		t.Errorf("inner.Start = %s, want %s (a.End - offset - subRange) — "+
+			"mutants at subquery.go:1986:42 would yield %s (a.End + offset - subRange)",
+			inner.Start, wantStart, evalTS.Add(offset).Add(-subRange))
+	}
+}
+
+// TestLowerAbsentOverTimeOverSubquery_InstantModeKeepsExistingPin kills the
+// INVERT_LOGICAL mutant at subquery.go:1982:21 — the `&&` in
+// `if a.End.IsZero() && !ctx.end.IsZero()`. That guard only fills a.End
+// from ctx.end when a.End was NOT already set (i.e. the subquery has no
+// `@` pin of its own). Flipping `&&` to `||` makes the guard fire whenever
+// ctx.end is merely non-zero, unconditionally overwriting an existing `@`
+// pin with the query's own eval timestamp.
+//
+// The query pins the subquery at a timestamp deliberately different from
+// the instant query's own eval time, so an overwrite is observable.
+func TestLowerAbsentOverTimeOverSubquery_InstantModeKeepsExistingPin(t *testing.T) {
+	t.Parallel()
+
+	const query = `absent_over_time(demo_cpu[5m:1m] @ 1700000000)`
+	pinnedTS := time.Unix(1_700_000_000, 0).UTC()
+	evalTS := time.Unix(1_700_010_000, 0).UTC() // deliberately different from the pin
+	s := schema.DefaultOTelMetrics()
+
+	expr, err := parser.NewParser(parser.Options{}).ParseExpr(query)
+	if err != nil {
+		t.Fatalf("ParseExpr(%q): %v", query, err)
+	}
+
+	plan, err := LowerAt(context.Background(), expr, s, evalTS, evalTS)
+	if err != nil {
+		t.Fatalf("LowerAt(%q): %v", query, err)
+	}
+	a := firstAbsentOverTime(plan)
+	if a == nil {
+		t.Fatalf("no chplan.AbsentOverTime under the lowered %q", query)
+	}
+	if !a.End.Equal(pinnedTS) {
+		t.Errorf("AbsentOverTime.End = %s, want %s (the `@` pin) — mutant `&&`->`||` at subquery.go:1982:21 "+
+			"would overwrite the pin with the eval timestamp %s", a.End, pinnedTS, evalTS)
+	}
+}
+
+// TestLowerSubqueryOverCall_UnsafeInstantTransformSkipsIdentityWrap kills
+// the INVERT_LOGICAL mutant at subquery.go:487:34 — the `&&` in
+// `if isInstantTransformCall(call) && subqueryInstantSafe(call)`. abs() is
+// an instant-transform call, but its argument here is rate(...), which is
+// NOT sample-preserving, so subqueryInstantSafe must be false and the
+// conjunction must skip the Identity-wrap branch. Flipping `&&` to `||`
+// would take the Identity-wrap branch anyway (since isInstantTransformCall
+// alone is true), returning a *chplan.RangeWindow instead of the
+// *chplan.Project the per-anchor fallback (subqueryAnchorShape) builds.
+func TestLowerSubqueryOverCall_UnsafeInstantTransformSkipsIdentityWrap(t *testing.T) {
+	t.Parallel()
+
+	s := schema.DefaultOTelMetrics()
+	expr := mustParse(t, `abs(rate(demo_cpu[1m]))[5m:1m]`)
+	sub, ok := expr.(*parser.SubqueryExpr)
+	if !ok {
+		t.Fatalf("parsed %T, want *parser.SubqueryExpr", expr)
+	}
+	call, ok := sub.Expr.(*parser.Call)
+	if !ok {
+		t.Fatalf("sub.Expr = %T, want *parser.Call", sub.Expr)
+	}
+
+	evalTS := time.Date(2026, time.January, 1, 0, 10, 0, 0, time.UTC)
+	ctx := lowerCtx{end: evalTS, lowerers: RangeLowerers{}.withDefaults()}
+	plan, err := lowerSubqueryOverCall(sub, call, sub.Step, s, ctx)
+	if err != nil {
+		t.Fatalf("lowerSubqueryOverCall(%q): %v", `abs(rate(demo_cpu[1m]))[5m:1m]`, err)
+	}
+	if _, isRW := plan.(*chplan.RangeWindow); isRW {
+		t.Fatalf("plan = *chplan.RangeWindow (the Identity wrap); want the per-anchor *chplan.Project " +
+			"fallback (subqueryInstantSafe must be false for abs(rate(...)), so the && must skip the " +
+			"Identity branch — mutant `&&`->`||` at subquery.go:487:34 would take it anyway)")
+	}
+	if _, isProj := plan.(*chplan.Project); !isProj {
+		t.Fatalf("plan = %T, want *chplan.Project (subqueryAnchorShape's per-anchor fallback)", plan)
+	}
+}
+
+// TestNodeCarriesMetricName_VectorSetOp_OrChecksBothSidesAndUnlessDoesNot
+// kills the CONDITIONALS_NEGATION mutant at subquery.go:1373:11 — the
+// `==` in `if v.Op == chplan.VectorSetOr && !nodeCarriesMetricName(v.Right, s)`.
+// `or` must check BOTH arms (it unions rows from both); `and`/`unless`
+// must check ONLY the left arm (they only ever emit LHS rows). Flipping
+// `==` to `!=` swaps which operator gets the Right-arm check.
+func TestNodeCarriesMetricName_VectorSetOp_OrChecksBothSidesAndUnlessDoesNot(t *testing.T) {
+	t.Parallel()
+
+	s := schema.DefaultOTelMetrics()
+	named := &chplan.Scan{}
+	unnamed := &chplan.StepGrid{}
+
+	orOp := &chplan.VectorSetOp{Op: chplan.VectorSetOr, Left: named, Right: unnamed}
+	if nodeCarriesMetricName(orOp, s) {
+		t.Fatalf("or: Left carries a name but Right does not; `or` must check BOTH sides and answer " +
+			"false (mutant `==`->`!=` at subquery.go:1373:11 would only check Left here)")
+	}
+
+	andOp := &chplan.VectorSetOp{Op: chplan.VectorSetAnd, Left: named, Right: unnamed}
+	if !nodeCarriesMetricName(andOp, s) {
+		t.Fatalf("and: Left carries a name; `and`/`unless` must ignore Right and answer true " +
+			"(mutant `==`->`!=` at subquery.go:1373:11 would incorrectly also check Right here)")
+	}
+}
+
+// TestSubqueryInstantSafe_PiExceptionNotRejected kills the
+// CONDITIONALS_NEGATION mutant at subquery.go:1744:49 — the `!=` in
+// `if !isInstantTransformCall(v) && v.Func.Name != "pi"`. pi() is the
+// documented parse-time-constant exception: a zero-arg call that is not
+// itself an instant-transform call, but must still be treated as safe.
+// Flipping `!=` to `==` rejects any call subtree containing pi().
+func TestSubqueryInstantSafe_PiExceptionNotRejected(t *testing.T) {
+	t.Parallel()
+
+	call, ok := mustParse(t, `clamp_min(demo_cpu, pi())`).(*parser.Call)
+	if !ok {
+		t.Fatalf("expected *parser.Call")
+	}
+	if !subqueryInstantSafe(call) {
+		t.Fatalf("subqueryInstantSafe(clamp_min(demo_cpu, pi())) = false, want true — pi() is the " +
+			"documented exception (mutant `!=`->`==` at subquery.go:1744:49 would reject any call " +
+			"tree containing pi())")
+	}
+}
+
+// TestLowerSubqueryOverBinary_PlainShapeSucceedsWithNoEvalAnchor kills the
+// CONDITIONALS_NEGATION mutant at subquery.go:793:83 — the second `==` in
+// `if shape := chplan.RowShapeOf(inner); shape == chplan.HistogramRowShape || shape == chplan.MixedRowShape`.
+// A plain (non-histogram, non-mixed) `or` composition must lower
+// successfully even with no query eval-time context threaded through
+// (the same !ok fallback TestSubqueryOverBinary_HistogramSetOp_NoEvalAnchorRejects,
+// subquery_and_unless_mixed_histogram_outer_test.go, pins the REJECT half
+// of). Flipping `==` to `!=` on the Mixed comparison turns the guard into
+// `shape == Histogram || shape != Mixed`, which is true for every ordinary
+// shape and wrongly rejects this query.
+func TestLowerSubqueryOverBinary_PlainShapeSucceedsWithNoEvalAnchor(t *testing.T) {
+	t.Parallel()
+
+	s := schema.DefaultOTelMetrics()
+	expr := mustParse(t, `(demo_cpu or demo_mem)[5m:1m]`)
+	sub, ok := expr.(*parser.SubqueryExpr)
+	if !ok {
+		t.Fatalf("parsed %T, want *parser.SubqueryExpr", expr)
+	}
+	plan, err := lowerSubquery(sub, s, lowerCtx{lowerers: RangeLowerers{}.withDefaults()})
+	if err != nil {
+		t.Fatalf("bare lowerSubquery(%q) with no eval anchor: %v (want success — the shape is plain, "+
+			"not histogram/mixed)", `(demo_cpu or demo_mem)[5m:1m]`, err)
+	}
+	if plan == nil {
+		t.Fatal("lowerSubquery returned nil plan with nil error")
+	}
+}
+
+// TestSubqueryOffsetCtx_NonZeroOffsetShiftsBothBounds kills the
+// CONDITIONALS_NEGATION mutant at subquery.go:804:24 — the `==` in
+// `if sub.OriginalOffset == 0 { return ctx }`. With a non-zero offset and
+// non-zero start/end bounds, the function must shift both bounds by
+// -offset. Flipping `==` to `!=` returns ctx UNSHIFTED whenever the
+// offset is non-zero — the one case where a shift is actually required.
+func TestSubqueryOffsetCtx_NonZeroOffsetShiftsBothBounds(t *testing.T) {
+	t.Parallel()
+
+	sub := &parser.SubqueryExpr{OriginalOffset: 10 * time.Minute}
+	start := time.Date(2026, time.January, 1, 0, 0, 0, 0, time.UTC)
+	end := start.Add(time.Hour)
+	got := subqueryOffsetCtx(sub, lowerCtx{start: start, end: end})
+
+	wantStart := start.Add(-10 * time.Minute)
+	wantEnd := end.Add(-10 * time.Minute)
+	if !got.start.Equal(wantStart) {
+		t.Errorf("start = %s, want %s (mutant `==`->`!=` at subquery.go:804:24 would leave it at %s)",
+			got.start, wantStart, start)
+	}
+	if !got.end.Equal(wantEnd) {
+		t.Errorf("end = %s, want %s (mutant `==`->`!=` at subquery.go:804:24 would leave it at %s)",
+			got.end, wantEnd, end)
+	}
+}
+
+// TestProjectCarriesMetricName_ContinuesPastNonMatchingProjections kills
+// the INVERT_LOOPCTRL mutant at subquery.go:1408:4 — the `continue` inside
+// projectCarriesMetricName's loop over p.Projections. The MetricName
+// projection is deliberately placed SECOND so the loop must skip past a
+// non-matching first entry to find it. Flipping `continue` to `break`
+// stops at the first non-matching projection and falls through to
+// `return false`, regardless of what a later projection carries.
+func TestProjectCarriesMetricName_ContinuesPastNonMatchingProjections(t *testing.T) {
+	t.Parallel()
+
+	s := schema.DefaultOTelMetrics()
+	p := &chplan.Project{
+		Projections: []chplan.Projection{
+			{Expr: &chplan.ColumnRef{Name: s.AttributesColumn}, Alias: s.AttributesColumn},
+			{Expr: &chplan.LitString{V: "http_requests_total"}, Alias: s.MetricNameColumn},
+		},
+	}
+	if !projectCarriesMetricName(p, s) {
+		t.Fatalf("projectCarriesMetricName = false, want true — the MetricName projection is the " +
+			"SECOND entry and carries a real name; mutant `continue`->`break` at subquery.go:1408:4 " +
+			"would stop at the first (non-matching) entry and answer false")
+	}
+}
+
+// TestLowerSubqueryOverCountValues_MapArgsCapacityIsTight kills the
+// ARITHMETIC_BASE mutant at subquery.go:2546:58 inside
+// lowerSubqueryOverCountValues's `by(...)` capacity hint:
+//
+//	mapArgs := make([]chplan.Expr, 0, (len(agg.Grouping)+1)*2)
+//
+// With 2 grouping labels, the original pre-allocates exactly enough room
+// for all 6 appends (2 labels * 2 + the synthetic value-as-label pair),
+// so no reallocation ever happens and cap stays at 6. The `*` -> `/`
+// mutant starts at cap (2+1)/2 = 1, forcing append's growth path to
+// reallocate — empirically verified (via a standalone simulation) to
+// settle at cap 8, not 6, for this specific grouping count.
+func TestLowerSubqueryOverCountValues_MapArgsCapacityIsTight(t *testing.T) {
+	t.Parallel()
+
+	s := schema.DefaultOTelMetrics()
+	expr := mustParse(t, `count_values("val", demo_cpu) by (job, instance)[5m:1m]`)
+	sub, ok := expr.(*parser.SubqueryExpr)
+	if !ok {
+		t.Fatalf("parsed %T, want *parser.SubqueryExpr", expr)
+	}
+	plan, err := lowerSubquery(sub, s, lowerCtx{lowerers: RangeLowerers{}.withDefaults()})
+	if err != nil {
+		t.Fatalf("lowerSubquery: %v", err)
+	}
+	proj, ok := plan.(*chplan.Project)
+	if !ok {
+		t.Fatalf("plan = %T, want *chplan.Project", plan)
+	}
+	if len(proj.Projections) == 0 {
+		t.Fatal("no projections")
+	}
+	mw, ok := proj.Projections[0].Expr.(*chplan.MapWithoutEmptyValues)
+	if !ok {
+		t.Fatalf("Projections[0].Expr = %T, want *chplan.MapWithoutEmptyValues", proj.Projections[0].Expr)
+	}
+	fc, ok := mw.Map.(*chplan.FuncCall)
+	if !ok || fc.Fn != chplan.FnMap {
+		t.Fatalf("MapWithoutEmptyValues.Map = %#v, want a Map FuncCall", mw.Map)
+	}
+	const wantArgs = 6 // 2 labels * 2 + (value literal, cv_val column ref)
+	if got := len(fc.Args); got != wantArgs {
+		t.Fatalf("len(Args) = %d, want %d", got, wantArgs)
+	}
+	if got := cap(fc.Args); got != wantArgs {
+		t.Fatalf("cap(Args) = %d, want %d (mutant `*`->`/` at subquery.go:2546:58 would yield a "+
+			"different cap via append's reallocation growth path)", got, wantArgs)
+	}
+}
+
+// TestBuildAttributesFromAggregate_ArgsCapacityIsTight kills the
+// ARITHMETIC_BASE mutant at subquery.go:2725:50 inside
+// buildAttributesFromAggregate's `by(...)` capacity hint:
+//
+//	args := make([]chplan.Expr, 0, len(agg.Grouping)*2)
+//
+// With 3 grouping labels, the original pre-allocates exactly enough room
+// for all 6 appends, so cap stays at 6. The `*` -> `/` mutant starts at
+// cap 3/2 = 1, forcing append's growth path to reallocate — empirically
+// verified to settle at cap 8, not 6, for this specific grouping count.
+func TestBuildAttributesFromAggregate_ArgsCapacityIsTight(t *testing.T) {
+	t.Parallel()
+
+	s := schema.DefaultOTelMetrics()
+	expr := mustParse(t, `(sum by (job, instance, region) (demo_cpu))[5m:1m]`)
+	sub, ok := expr.(*parser.SubqueryExpr)
+	if !ok {
+		t.Fatalf("parsed %T, want *parser.SubqueryExpr", expr)
+	}
+	plan, err := lowerSubquery(sub, s, lowerCtx{lowerers: RangeLowerers{}.withDefaults()})
+	if err != nil {
+		t.Fatalf("lowerSubquery: %v", err)
+	}
+	proj, ok := plan.(*chplan.Project)
+	if !ok {
+		t.Fatalf("plan = %T, want *chplan.Project", plan)
+	}
+	if len(proj.Projections) == 0 {
+		t.Fatal("no projections")
+	}
+	fc, ok := proj.Projections[0].Expr.(*chplan.FuncCall)
+	if !ok || fc.Fn != chplan.FnMap {
+		t.Fatalf("Projections[0].Expr = %#v, want a Map FuncCall (buildAttributesFromAggregate's "+
+			"by-clause branch)", proj.Projections[0].Expr)
+	}
+	const wantArgs = 6 // 3 labels * 2
+	if got := len(fc.Args); got != wantArgs {
+		t.Fatalf("len(Args) = %d, want %d", got, wantArgs)
+	}
+	if got := cap(fc.Args); got != wantArgs {
+		t.Fatalf("cap(Args) = %d, want %d (mutant `*`->`/` at subquery.go:2725:50 would yield a "+
+			"different cap via append's reallocation growth path)", got, wantArgs)
+	}
+}
+
+// TestLowerSubqueryOverCallSubquery_WidensToSumOfBothRanges kills the
+// ARITHMETIC_BASE mutant at subquery.go:2871:28 — the `+` in
+// `widened.Range = sub.Range + innerSub.Range`. The nested-subquery shape
+// `max_over_time(rate(m[1m])[5m:30s])[1h:5m]` must widen the inner
+// subquery's own matrix to cover the OUTER range PLUS the inner range,
+// which surfaces as the widened RangeWindow's OuterRange field. Flipping
+// `+` to `-` would shrink it instead (1h - 5m = 55m rather than 65m).
+func TestLowerSubqueryOverCallSubquery_WidensToSumOfBothRanges(t *testing.T) {
+	t.Parallel()
+
+	s := schema.DefaultOTelMetrics()
+	expr := mustParse(t, `max_over_time(rate(demo_cpu[1m])[5m:30s])[1h:5m]`)
+	topSub, ok := expr.(*parser.SubqueryExpr)
+	if !ok {
+		t.Fatalf("parsed %T, want *parser.SubqueryExpr", expr)
+	}
+
+	plan, err := lowerSubquery(topSub, s, lowerCtx{lowerers: RangeLowerers{}.withDefaults()})
+	if err != nil {
+		t.Fatalf("lowerSubquery: %v", err)
+	}
+	rw, ok := plan.(*chplan.RangeWindow)
+	if !ok {
+		t.Fatalf("plan = %T, want *chplan.RangeWindow", plan)
+	}
+	wideInner, ok := rw.Input.(*chplan.RangeWindow)
+	if !ok {
+		t.Fatalf("rw.Input = %T, want *chplan.RangeWindow (the widened nested subquery)", rw.Input)
+	}
+	const want = time.Hour + 5*time.Minute
+	if wideInner.OuterRange != want {
+		t.Fatalf("wideInner.OuterRange = %s, want %s (sub.Range + innerSub.Range) — mutant `+`->`-` "+
+			"at subquery.go:2871:28 would yield %s", wideInner.OuterRange, want, time.Hour-5*time.Minute)
+	}
+}

--- a/internal/promql/gremlins_kill_test.go
+++ b/internal/promql/gremlins_kill_test.go
@@ -21,6 +21,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/promql/parser"
 
 	"github.com/tsouza/cerberus/internal/chplan"
@@ -584,5 +585,466 @@ func TestLowerLabelJoin_NonLiteralSrcErrorIndexesParamName_FirstSlot(t *testing.
 	}
 	if strings.Contains(msg, "src_label_5") {
 		t.Fatalf("error %q contains the mutant param name %q", msg, "src_label_5")
+	}
+}
+
+// TestAbsentAttrsMap_ArgsSliceCapacityIsTight kills the ARITHMETIC_BASE
+// mutant at absent.go:473:43 inside absentAttrsMap's slice-capacity
+// hint:
+//
+//	args := make([]chplan.Expr, 0, len(pairs)*2)
+//
+// Each of the len(pairs) iterations below appends exactly 2 elements
+// (one LitString per key, one per value), so len(args) after the loop
+// is always len(pairs)*2 — matching the pre-allocated capacity exactly
+// (no growth). Flipping `*` to `/` shrinks the hint to len(pairs)/2,
+// forcing `append` to grow past it, which — per Go's amortized growth
+// schedule — lands on a capacity other than len(pairs)*2. Semantic-
+// level assertions (the emitted Map() args) pass under both branches;
+// only cap() distinguishes them, mirroring
+// TestLowerLabelJoin_SrcsSliceCapacityIsTight's own strategy for the
+// analogous label_fns.go:81:39 pair.
+func TestAbsentAttrsMap_ArgsSliceCapacityIsTight(t *testing.T) {
+	t.Parallel()
+
+	matchers := []*labels.Matcher{
+		labels.MustNewMatcher(labels.MatchEqual, "job", "a"),
+		labels.MustNewMatcher(labels.MatchEqual, "instance", "b"),
+		labels.MustNewMatcher(labels.MatchEqual, "env", "c"),
+	}
+	got := absentAttrsMap(matchers)
+	fc, ok := got.(*chplan.FuncCall)
+	if !ok || fc.Fn != chplan.FnMap {
+		t.Fatalf("absentAttrsMap(3 equality matchers) = %#v, want a Map() FuncCall", got)
+	}
+
+	const wantPairs = 3
+	if got := len(fc.Args); got != wantPairs*2 {
+		t.Fatalf("len(Args) = %d; want %d (3 pairs * 2)", got, wantPairs*2)
+	}
+	// Original: cap == len(pairs)*2 == 6, exact fit.
+	// `/` mutant: cap starts at len(pairs)/2 == 1, then grows past it
+	// while appending 6 elements — never lands back on 6.
+	if got := cap(fc.Args); got != wantPairs*2 {
+		t.Fatalf("cap(Args) = %d; want %d (mutant `*` -> `/` at absent.go:473:43 would yield a different cap via forced regrowth)",
+			got, wantPairs*2)
+	}
+}
+
+// TestLowerSortByLabel_KeysSliceCapacityIsTight kills the two adjacent
+// mutants at sort.go:192:48 inside lowerSortByLabel's slice-capacity
+// hint:
+//
+//	keys := make([]chplan.OrderKey, 0, len(c.Args)-1)
+//
+// The `-` is ARITHMETIC_BASE (`-` -> `+`) and the literal `1` is the
+// INVERT_NEGATIVES sibling (`-1` -> `+1`) — both produce the identical
+// observable effect: cap == len(c.Args)+1 instead of len(c.Args)-1. The
+// loop appends exactly len(c.Args)-1 keys (one per label argument), so
+// the original capacity is an exact fit; both mutants over-allocate by
+// 2, and — because 0 <= len(c.Args)-1 <= len(c.Args)+1 — no growth is
+// ever triggered to mask the difference the way the absent.go case
+// above relies on regrowth to detect. cap() is checked directly.
+func TestLowerSortByLabel_KeysSliceCapacityIsTight(t *testing.T) {
+	t.Parallel()
+
+	// sort_by_label is experimental in the reference parser, unlike the
+	// double_exponential_smoothing call mustParseHoltWintersCall parses —
+	// but that helper's own EnableExperimentalFunctions parser covers it
+	// identically, so it is reused here instead of a third near-duplicate
+	// parser construction.
+	call := mustParseHoltWintersCall(t, `sort_by_label(up, "a", "b", "c")`)
+	s := schema.DefaultOTelMetrics()
+
+	plan, err := lowerSortByLabel(call, s, lowerCtx{})
+	if err != nil {
+		t.Fatalf("lowerSortByLabel: %v", err)
+	}
+	ob, ok := plan.(*chplan.OrderBy)
+	if !ok {
+		t.Fatalf("plan = %T, want *chplan.OrderBy", plan)
+	}
+
+	const wantKeys = 3 // "a", "b", "c"
+	if got := len(ob.Keys); got != wantKeys {
+		t.Fatalf("len(Keys) = %d; want %d", got, wantKeys)
+	}
+	// Original: cap == len(c.Args)-1 == 4-1 == 3, exact fit.
+	// Both mutants: cap == 4+1 == 5.
+	if got := cap(ob.Keys); got != wantKeys {
+		t.Fatalf("cap(Keys) = %d; want %d (mutants at sort.go:192:48 would yield cap=%d)",
+			got, wantKeys, len(call.Args)+1)
+	}
+}
+
+// TestLowerClamp_SingleArgHistogramShortcutTakesHistogramPath kills the
+// CONDITIONALS_BOUNDARY mutant at instant_fns.go:202:17, which flips
+//
+//	if len(c.Args) >= 1 {
+//
+// to `> 1`. Every VALID clamp/clamp_max/clamp_min call the parser
+// accepts always carries at least 2 arguments, so a real query can
+// never observe the boundary — the only way to reach it with exactly 1
+// argument is to hand-build the *parser.Call the way this test does,
+// bypassing the parser's own arity check (the same technique
+// TestLowerLabelJoin_NonLiteralSrcErrorIndexesParamName uses just
+// above).
+//
+// With exactly 1 histogram-valued argument: the original `>= 1` routes
+// through lowerExpHistogramArgAsCanonicalFloat and returns successfully
+// (ok=true short-circuits before the switch's own arg-count check ever
+// runs). The `> 1` mutant evaluates false for len==1, skips the
+// histogram routing entirely, and falls into the switch's
+// `len(c.Args) != 2` guard, erroring "clamp_max expects 2 arguments,
+// got 1" instead.
+func TestLowerClamp_SingleArgHistogramShortcutTakesHistogramPath(t *testing.T) {
+	t.Parallel()
+
+	histArg := mustParse(t, `demo_latency_exp_hist`)
+	call := &parser.Call{
+		Func: parser.MustGetFunction("clamp_max"),
+		Args: parser.Expressions{histArg},
+	}
+	s := schema.DefaultOTelMetrics()
+
+	plan, err := lowerClamp(call, s, lowerCtx{})
+	if err != nil {
+		t.Fatalf("lowerClamp(clamp_max(<1 histogram arg>)): unexpected error %v "+
+			"(mutant `>= 1` -> `> 1` at instant_fns.go:202:17 would skip the histogram "+
+			"shortcut and fail the switch's arg-count check instead)", err)
+	}
+	if plan == nil {
+		t.Fatalf("lowerClamp returned a nil plan alongside a nil error")
+	}
+}
+
+// TestLowerClamp_EqualLiteralBoundsTakeComputedPath kills the
+// CONDITIONALS_BOUNDARY mutant at instant_fns.go:271:12, which flips
+//
+//	if maxB < minB {
+//
+// to `<= `. Prom's funcClamp only short-circuits to an empty vector
+// when max is STRICTLY less than min; `clamp(v, 5, 5)` (equal bounds)
+// is a normal, non-degenerate clamp that pins every sample to exactly
+// 5 via greatest(min, least(max, v)). The `<=` mutant would treat the
+// equal-bounds case as degenerate too, returning the zero-row
+// `Filter{Predicate: false}` shape instead of the computed
+// greatest/least projection.
+func TestLowerClamp_EqualLiteralBoundsTakeComputedPath(t *testing.T) {
+	t.Parallel()
+
+	expr := mustParse(t, `clamp(up, 5, 5)`)
+	s := schema.DefaultOTelMetrics()
+	plan, err := lower(expr, s, lowerCtx{})
+	if err != nil {
+		t.Fatalf("lower(clamp(up, 5, 5)): %v", err)
+	}
+
+	// The degenerate-bounds shape is a *chplan.Filter with a literal
+	// `false` predicate sitting directly at the root (see the maxB <
+	// minB branch in instant_fns.go). The non-degenerate path instead
+	// returns whatever guardedValueProjection built (a *chplan.Project
+	// for a plain single-name selector like `up`), never a bare
+	// constant-false Filter.
+	if f, ok := plan.(*chplan.Filter); ok {
+		if lb, ok := f.Predicate.(*chplan.LitBool); ok && !lb.V {
+			t.Fatalf("clamp(up, 5, 5) lowered to the degenerate-bounds empty Filter %#v; "+
+				"want the computed greatest/least projection (mutant `<` -> `<=` at "+
+				"instant_fns.go:271:12 would treat equal bounds as degenerate)", f)
+		}
+	}
+	if _, ok := plan.(*chplan.Project); !ok {
+		t.Fatalf("plan = %T, want *chplan.Project (guardedValueProjection's shape for a "+
+			"plain single-name selector)", plan)
+	}
+}
+
+// TestLowerInfo_ArgCountRejectsOutOfRange kills the INVERT_LOGICAL
+// mutant at info_fn.go:83:21, which flips
+//
+//	if len(c.Args) < 1 || len(c.Args) > 2 {
+//
+// to `&&`. No integer argument count can be simultaneously < 1 AND >
+// 2, so the mutant's conjunction is always false — it would accept
+// ANY argument count, including 0, silently skipping the validation
+// that guards `c.Args[0]` from an out-of-range index a few lines
+// below. A 0-argument info() call can only be constructed by hand
+// (the parser itself enforces info()'s 1-or-2-argument signature), so
+// this test bypasses the parser the same way the other hand-built-AST
+// tests in this file do.
+func TestLowerInfo_ArgCountRejectsOutOfRange(t *testing.T) {
+	t.Parallel()
+
+	call := &parser.Call{
+		Func: parser.MustGetFunction("info"),
+		Args: parser.Expressions{},
+	}
+	s := schema.DefaultOTelMetrics()
+
+	_, err := lowerInfo(call, s, lowerCtx{})
+	if err == nil {
+		t.Fatalf("expected info() with 0 arguments to error; got nil " +
+			"(mutant `||` -> `&&` at info_fn.go:83:21 can never be true, so " +
+			"validation never fires and c.Args[0] would index out of range)")
+	}
+	if !strings.Contains(err.Error(), "got 0") {
+		t.Fatalf("error %q does not mention the actual arg count", err.Error())
+	}
+}
+
+// TestScalarGuardPlan_LoweringErrorPropagates kills the
+// CONDITIONALS_NEGATION mutant at scalar_guard.go:92:9, which flips
+//
+//	if err != nil {
+//		return nil, err
+//	}
+//
+// to `err == nil`. When the inner lowerScalarArg call fails, the
+// original code propagates the error and returns a nil plan. The
+// mutant's flipped condition is false on a real error, so control
+// falls through to `return syntheticScalarVector(value, nil, s, ctx),
+// nil` — building a synthetic vector out of value (nil, since lowering
+// failed) and swallowing the error entirely.
+//
+// `scalar()` called with 0 arguments is a lowerScalarArg error the
+// parser itself would normally reject at parse time, so the *parser.Call
+// is hand-built the same way the other arity-bypass tests in this file
+// are.
+func TestScalarGuardPlan_LoweringErrorPropagates(t *testing.T) {
+	t.Parallel()
+
+	e := &parser.Call{
+		Func: parser.MustGetFunction("scalar"),
+		Args: parser.Expressions{},
+	}
+	s := schema.DefaultOTelMetrics()
+
+	plan, err := scalarGuardPlan(e, s, lowerCtx{})
+	if err == nil {
+		t.Fatalf("expected scalarGuardPlan to propagate lowerScalarArg's error; got nil err, "+
+			"plan=%#v (mutant `!=` -> `==` at scalar_guard.go:92:9 would swallow the error "+
+			"and build a synthetic vector from a nil value instead)", plan)
+	}
+	if plan != nil {
+		t.Fatalf("expected a nil plan alongside the propagated error; got %#v", plan)
+	}
+}
+
+// TestHoltWintersFactors_MixedLiteralComputedTakesComputedPath kills
+// the INVERT_LOGICAL mutant at range_fns.go:246:10, which flips
+//
+//	if okSf && okTf {
+//		return sf, tf, nil, nil, nil
+//	}
+//
+// to `||`. With one literal factor and one computed factor (okSf !=
+// okTf), the original code must fall through to the computed path,
+// returning `(0, 0, sfExpr, tfExpr, nil)` — both expression slots
+// populated, both float slots zeroed, because [chplan.RangeWindow]'s
+// positional ScalarExprs pair must stay complete. The `||` mutant's
+// condition is true whenever EITHER factor is literal, so it takes the
+// early-return literal path instead, returning the literal factor's own
+// float value with both expression slots left nil — dropping the
+// computed factor's expression entirely.
+func TestHoltWintersFactors_MixedLiteralComputedTakesComputedPath(t *testing.T) {
+	t.Parallel()
+
+	call := mustParseHoltWintersCall(t, `double_exponential_smoothing(up[5m], 0.5, time())`)
+	s := schema.DefaultOTelMetrics()
+
+	sf, tf, sfExpr, tfExpr, err := holtWintersFactors(call.Args[1], call.Args[2], s, lowerCtx{})
+	if err != nil {
+		t.Fatalf("holtWintersFactors: %v", err)
+	}
+	if sfExpr == nil || tfExpr == nil {
+		t.Fatalf("expected both sfExpr and tfExpr populated on the computed path "+
+			"(sfExpr=%v tfExpr=%v sf=%v tf=%v); mutant `&&` -> `||` at range_fns.go:246:10 "+
+			"would take the literal-only fast path and leave them nil",
+			sfExpr, tfExpr, sf, tf)
+	}
+	if sf != 0 || tf != 0 {
+		t.Fatalf("expected sf=0 tf=0 on the computed path (the real values ride in "+
+			"sfExpr/tfExpr instead); got sf=%v tf=%v", sf, tf)
+	}
+}
+
+// TestSynthLabelsFromMatchers_NameSkipContinuesPastLaterMatchers kills
+// the INVERT_LOOPCTRL mutant at absent.go:390:4, where
+//
+//	if m.Name == model.MetricNameLabel {
+//		continue
+//	}
+//
+// flips to `break`. With only ONE matcher in the list, `continue` and
+// `break` are indistinguishable (both end the loop). The kill requires
+// a `__name__` matcher followed by further equality matchers: the
+// original `continue` skips just the `__name__` entry and keeps
+// processing the rest, while `break` would abandon the loop the moment
+// it sees `__name__`, silently dropping every matcher positioned after
+// it.
+func TestSynthLabelsFromMatchers_NameSkipContinuesPastLaterMatchers(t *testing.T) {
+	t.Parallel()
+
+	matchers := []*labels.Matcher{
+		labels.MustNewMatcher(labels.MatchEqual, "__name__", "demo_metric"),
+		labels.MustNewMatcher(labels.MatchEqual, "job", "a"),
+		labels.MustNewMatcher(labels.MatchEqual, "instance", "b"),
+	}
+	got := synthLabelsFromMatchers(matchers)
+
+	want := map[string]string{"job": "a", "instance": "b"}
+	if len(got) != len(want) {
+		t.Fatalf("synthLabelsFromMatchers = %#v; want %d labels (mutant `continue` -> "+
+			"`break` at absent.go:390:4 would abandon the loop at __name__ and drop "+
+			"every matcher after it, yielding 0)", got, len(want))
+	}
+	for _, sl := range got {
+		if wantV, ok := want[sl.Key]; !ok || wantV != sl.Value {
+			t.Fatalf("unexpected label %+v in result %#v", sl, got)
+		}
+	}
+}
+
+// TestAbsentAttrsMap_NameSkipContinuesPastLaterMatchers kills the
+// INVERT_LOOPCTRL mutant at absent.go:440:4 — absentAttrsMap's own
+// `__name__`-skip, the mirror of synthLabelsFromMatchers' loop just
+// above (see that test's doc comment for why a single-matcher list
+// cannot distinguish `continue` from `break`).
+func TestAbsentAttrsMap_NameSkipContinuesPastLaterMatchers(t *testing.T) {
+	t.Parallel()
+
+	matchers := []*labels.Matcher{
+		labels.MustNewMatcher(labels.MatchEqual, "__name__", "demo_metric"),
+		labels.MustNewMatcher(labels.MatchEqual, "job", "a"),
+		labels.MustNewMatcher(labels.MatchEqual, "instance", "b"),
+	}
+	got := absentAttrsMap(matchers)
+	fc, ok := got.(*chplan.FuncCall)
+	if !ok || fc.Fn != chplan.FnMap {
+		t.Fatalf("absentAttrsMap = %#v; want a Map() FuncCall over the surviving pairs "+
+			"(mutant `continue` -> `break` at absent.go:440:4 would abandon the loop at "+
+			"__name__ and drop every matcher after it, yielding the empty-map literal)", got)
+	}
+	// 2 surviving pairs (job, instance) * 2 args each.
+	const wantArgs = 4
+	if got := len(fc.Args); got != wantArgs {
+		t.Fatalf("len(Args) = %d; want %d", got, wantArgs)
+	}
+}
+
+// mixedDiscriminatorMarkerProject is a *chplan.Project whose single
+// projection publishes chplan.MixedDiscriminatorColumn — the one shape
+// [chplan.RowShapeOf] recognises as chplan.MixedRowShape (see that
+// function's own doc comment). Used below purely to make
+// guardLabelRewriteCollision's `mixed` local report true without
+// depending on a real mixed-`or` lowering.
+func mixedDiscriminatorMarkerProject(input chplan.Node) *chplan.Project {
+	return &chplan.Project{
+		Input: input,
+		Projections: []chplan.Projection{
+			{Expr: &chplan.ColumnRef{Name: chplan.MixedDiscriminatorColumn}, Alias: chplan.MixedDiscriminatorColumn},
+		},
+	}
+}
+
+// TestGuardLabelRewriteCollision_MixedPayloadSkipContinuesLoop kills
+// the INVERT_LOOPCTRL mutant at duplicate_labelset_guard.go:391:5,
+// inside guardLabelRewriteCollision's per-projection switch:
+//
+//	default:
+//		if mixed && mixedPayload[name] {
+//			continue
+//		}
+//
+// flips to `break`. A single qualifying projection cannot distinguish
+// `continue` from `break` (the loop would end either way), so the
+// fixture needs a mixed-payload column FOLLOWED by another projection
+// that must still be reachable. This test forces `keyOnStep = true`
+// (via an Aggregate input whose GroupByAliases already names the
+// timestamp column, see guardKeysOnTimestamp) so the trailing
+// projection lands in the group key, then asserts its alias survived.
+func TestGuardLabelRewriteCollision_MixedPayloadSkipContinuesLoop(t *testing.T) {
+	t.Parallel()
+
+	s := schema.DefaultOTelMetrics()
+	stepKeyedAgg := &chplan.Aggregate{GroupByAliases: []string{s.TimestampColumn}}
+	mixedMarker := mixedDiscriminatorMarkerProject(stepKeyedAgg)
+
+	const extraStepCol = "extra_step_col"
+	rewritten := &chplan.Project{
+		Input: mixedMarker,
+		Projections: []chplan.Projection{
+			{Expr: &chplan.ColumnRef{Name: chplan.HistogramCountColumn}, Alias: chplan.HistogramCountColumn},
+			{Expr: &chplan.ColumnRef{Name: extraStepCol}, Alias: extraStepCol},
+		},
+	}
+
+	plan := guardLabelRewriteCollision(rewritten, s)
+	agg, ok := plan.(*chplan.Aggregate)
+	if !ok {
+		t.Fatalf("plan = %T, want *chplan.Aggregate (rewritten publishes none of the four "+
+			"canonical columns, so guardLabelRewriteCollision must return the raw guard)", plan)
+	}
+
+	found := false
+	for _, alias := range agg.GroupByAliases {
+		if alias == extraStepCol {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("GroupByAliases = %#v; want %q present (mutant `continue` -> `break` at "+
+			"duplicate_labelset_guard.go:391:5 would abandon the loop at the mixed-payload "+
+			"histogram column and never reach the projection after it)", agg.GroupByAliases, extraStepCol)
+	}
+}
+
+// TestGuardLabelRewriteCollision_KeyOnStepSkipContinuesLoop kills the
+// INVERT_LOOPCTRL mutant at duplicate_labelset_guard.go:400:5:
+//
+//	if keyOnStep {
+//		groupBy = append(groupBy, &chplan.ColumnRef{Name: name})
+//		aliases = append(aliases, name)
+//		continue
+//	}
+//
+// flips to `break`. Two non-payload, non-canonical projections in a
+// row.Input needs `keyOnStep = true` (this test's Aggregate input
+// already names the timestamp column) so BOTH hit this branch; the
+// second is reachable only if the first's `continue` doesn't end the
+// loop.
+func TestGuardLabelRewriteCollision_KeyOnStepSkipContinuesLoop(t *testing.T) {
+	t.Parallel()
+
+	s := schema.DefaultOTelMetrics()
+	stepKeyedAgg := &chplan.Aggregate{GroupByAliases: []string{s.TimestampColumn}}
+
+	const colA, colB = "col_a", "col_b"
+	rewritten := &chplan.Project{
+		Input: stepKeyedAgg,
+		Projections: []chplan.Projection{
+			{Expr: &chplan.ColumnRef{Name: colA}, Alias: colA},
+			{Expr: &chplan.ColumnRef{Name: colB}, Alias: colB},
+		},
+	}
+
+	plan := guardLabelRewriteCollision(rewritten, s)
+	agg, ok := plan.(*chplan.Aggregate)
+	if !ok {
+		t.Fatalf("plan = %T, want *chplan.Aggregate", plan)
+	}
+
+	wantAliases := map[string]bool{colA: true, colB: true}
+	gotAliases := map[string]bool{}
+	for _, alias := range agg.GroupByAliases {
+		gotAliases[alias] = true
+	}
+	for name := range wantAliases {
+		if !gotAliases[name] {
+			t.Fatalf("GroupByAliases = %#v; want both %q and %q present (mutant `continue` "+
+				"-> `break` at duplicate_labelset_guard.go:400:5 would abandon the loop after "+
+				"the first key-on-step projection and never reach the second)",
+				agg.GroupByAliases, colA, colB)
+		}
 	}
 }

--- a/internal/promql/histogram_native_mixed_or_vector_arithmetic_internal_test.go
+++ b/internal/promql/histogram_native_mixed_or_vector_arithmetic_internal_test.go
@@ -1,0 +1,115 @@
+package promql
+
+import (
+	"testing"
+
+	"github.com/tsouza/cerberus/internal/chplan"
+	"github.com/tsouza/cerberus/internal/schema"
+)
+
+// TestMixedVVHistMergeInputProjections_SubtractionNegatesByMinusOne pins
+// [mixedVVHistMergeInputProjections]'s own doc: for `-`, R's count-bearing
+// fields enter the merge array pre-negated via a literal `* -1` scale —
+// NOT `* 1` (a sign bug that would silently turn subtraction into
+// addition for the merged Count/Sum/ZeroCount fields).
+func TestMixedVVHistMergeInputProjections_SubtractionNegatesByMinusOne(t *testing.T) {
+	t.Parallel()
+
+	s := schema.DefaultOTelMetrics()
+	projs := mixedVVHistMergeInputProjections(chplan.OpSub, s)
+
+	var countsExpr chplan.Expr
+	for _, p := range projs {
+		if p.Alias == hqMergeCountsArrayAlias {
+			countsExpr = p.Expr
+			break
+		}
+	}
+	if countsExpr == nil {
+		t.Fatalf("no projection aliased %q found", hqMergeCountsArrayAlias)
+	}
+	call, ok := countsExpr.(*chplan.FuncCall)
+	if !ok || call.Fn != chplan.FnArray || len(call.Args) != 2 {
+		t.Fatalf("%s projection = %#v, want a two-arg array() FuncCall", hqMergeCountsArrayAlias, countsExpr)
+	}
+	negated, ok := call.Args[1].(*chplan.Binary)
+	if !ok || negated.Op != chplan.OpMul {
+		t.Fatalf("R's own array() element = %#v, want a Mul Binary (the negation fold)", call.Args[1])
+	}
+	lit, ok := negated.Right.(*chplan.LitFloat)
+	if !ok || lit.V != -1 {
+		t.Fatalf("negation scalar = %#v, want LitFloat{-1} (subtraction must negate, not double, R's own counts)", negated.Right)
+	}
+}
+
+// TestMixedVVHistMergeInputProjections_AdditionForwardsUnnegated pins the
+// `+` complement: R's own fields enter the merge array UNCHANGED (no Mul
+// wrapper at all), so a mistaken op check can't silently negate an
+// addition either.
+func TestMixedVVHistMergeInputProjections_AdditionForwardsUnnegated(t *testing.T) {
+	t.Parallel()
+
+	s := schema.DefaultOTelMetrics()
+	projs := mixedVVHistMergeInputProjections(chplan.OpAdd, s)
+
+	var countsExpr chplan.Expr
+	for _, p := range projs {
+		if p.Alias == hqMergeCountsArrayAlias {
+			countsExpr = p.Expr
+			break
+		}
+	}
+	if countsExpr == nil {
+		t.Fatalf("no projection aliased %q found", hqMergeCountsArrayAlias)
+	}
+	call, ok := countsExpr.(*chplan.FuncCall)
+	if !ok || call.Fn != chplan.FnArray || len(call.Args) != 2 {
+		t.Fatalf("%s projection = %#v, want a two-arg array() FuncCall", hqMergeCountsArrayAlias, countsExpr)
+	}
+	if _, wrapped := call.Args[1].(*chplan.Binary); wrapped {
+		t.Fatalf("R's own array() element = %#v, want the bare column ref unwrapped (addition must not negate)", call.Args[1])
+	}
+}
+
+// TestMixedVVOneSide pins the Card->side mapping [mixedVVOneSide] (the
+// counterpart of the "many" side, mixedVVOneSide's own doc): CardOneToMany
+// keeps L as the "one" side; every other Card (CardManyToOne here) keeps R.
+func TestMixedVVOneSide(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		card chplan.VectorCard
+		want string
+	}{
+		{"one_to_many", chplan.CardOneToMany, mixedVVJoinSideL},
+		{"many_to_one", chplan.CardManyToOne, mixedVVJoinSideR},
+	}
+	for _, tc := range cases {
+		if got := mixedVVOneSide(tc.card); got != tc.want {
+			t.Errorf("mixedVVOneSide(%v) = %q, want %q", tc.card, got, tc.want)
+		}
+	}
+}
+
+// TestMixedVVOutputAttributesExpr_IncludeBranch pins the `len(include) ==
+// 0` fork for a non-one-to-one Card: no Include labels forwards the many
+// side's Attributes column bare; any Include labels wrap it in the
+// mapMerge/mapFilter overlay instead.
+func TestMixedVVOutputAttributesExpr_IncludeBranch(t *testing.T) {
+	t.Parallel()
+
+	s := schema.DefaultOTelMetrics()
+	match := chplan.VectorMatch{}
+
+	bare := mixedVVOutputAttributesExpr(match, chplan.CardManyToOne, nil, s.AttributesColumn)
+	if _, ok := bare.(*chplan.ColumnRef); !ok {
+		t.Fatalf("mixedVVOutputAttributesExpr(no Include) = %#v, want a bare *chplan.ColumnRef", bare)
+	}
+
+	overlaid := mixedVVOutputAttributesExpr(match, chplan.CardManyToOne, []string{"region"}, s.AttributesColumn)
+	call, ok := overlaid.(*chplan.FuncCall)
+	if !ok || call.Fn != chplan.FnMapMerge {
+		t.Fatalf("mixedVVOutputAttributesExpr(Include=[region]) = %#v, want a mapMerge FuncCall", overlaid)
+	}
+}

--- a/internal/promql/histogram_native_mixed_or_vector_plain_arithmetic_test.go
+++ b/internal/promql/histogram_native_mixed_or_vector_plain_arithmetic_test.go
@@ -269,3 +269,80 @@ func assertMixedJoinSides(t *testing.T, query string, join *chplan.MixedVectorJo
 		t.Fatalf("lower(%q): widened plain side's discriminator = %#v, want a LitInt{0}", query, last.Expr)
 	}
 }
+
+// findMixedVectorJoin walks n's Input chain looking for the
+// *chplan.MixedVectorJoin every mixed `or` vs. plain-vector wrapper
+// eventually builds, failing the test if none is found. Shared by this
+// file and histogram_native_mixed_or_vector_plain_comparison_test.go (same
+// promql_test package) — the plan shape between the two differs (an extra
+// merge-input Project for `+`/`-`, none for comparisons/`*`//), so a
+// recursive search is needed rather than hardcoding a fixed Input depth.
+func findMixedVectorJoin(t *testing.T, query string, n chplan.Node) *chplan.MixedVectorJoin {
+	t.Helper()
+	var walk func(chplan.Node) *chplan.MixedVectorJoin
+	walk = func(cur chplan.Node) *chplan.MixedVectorJoin {
+		if cur == nil {
+			return nil
+		}
+		if j, ok := cur.(*chplan.MixedVectorJoin); ok {
+			return j
+		}
+		for _, c := range cur.Children() {
+			if j := walk(c); j != nil {
+				return j
+			}
+		}
+		return nil
+	}
+	join := walk(n)
+	if join == nil {
+		t.Fatalf("lower(%q): no *chplan.MixedVectorJoin found in plan rooted at %#v", query, n)
+	}
+	return join
+}
+
+// TestLower_ExpHistogram_MixedSetOpOr_VectorPlainArithmetic_StepAligned
+// pins [chplan.MixedVectorJoin].StepAligned: true for a materialised
+// range-mode grid (Step > 0), false for an instant query (Step == 0) —
+// the same `ctx.step > 0` boundary
+// [TestLower_ExpHistogram_MixedSetOpOr_VectorVectorAdditiveArithmetic] and
+// its siblings never actually assert (they only check plan SHAPE, not this
+// field), so this is the one place StepAligned's own boundary is pinned
+// for the mixed-`or`-vs-plain-vector wrapper family.
+func TestLower_ExpHistogram_MixedSetOpOr_VectorPlainArithmetic_StepAligned(t *testing.T) {
+	t.Parallel()
+
+	s := schema.DefaultOTelMetrics()
+	p := parser.NewParser(parser.Options{EnableExperimentalFunctions: true})
+	start := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	end := start.Add(time.Hour)
+
+	query := mixedOrExpr + " * " + mvpPlainVector
+	expr, err := p.ParseExpr(query)
+	if err != nil {
+		t.Fatalf("ParseExpr(%q): %v", query, err)
+	}
+
+	t.Run("instant", func(t *testing.T) {
+		t.Parallel()
+		plan, err := promql.LowerAt(context.Background(), expr, s, end, end)
+		if err != nil {
+			t.Fatalf("LowerAt(%q): unexpected error: %v", query, err)
+		}
+		join := findMixedVectorJoin(t, query, plan)
+		if join.StepAligned {
+			t.Fatalf("lower(%q) instant: MixedVectorJoin.StepAligned = true, want false (Step == 0)", query)
+		}
+	})
+	t.Run("range", func(t *testing.T) {
+		t.Parallel()
+		plan, err := promql.LowerAtRange(context.Background(), expr, s, start, end, 30*time.Second)
+		if err != nil {
+			t.Fatalf("LowerAtRange(%q): unexpected error: %v", query, err)
+		}
+		join := findMixedVectorJoin(t, query, plan)
+		if !join.StepAligned {
+			t.Fatalf("lower(%q) range: MixedVectorJoin.StepAligned = false, want true (Step > 0)", query)
+		}
+	})
+}

--- a/internal/promql/histogram_native_mixed_or_vector_plain_comparison_test.go
+++ b/internal/promql/histogram_native_mixed_or_vector_plain_comparison_test.go
@@ -104,3 +104,94 @@ func TestLower_ExpHistogram_MixedSetOpOr_VectorPlainCompareBool(t *testing.T) {
 		t.Fatalf("lower(%q): Filter.Input is %T, want *chplan.MixedVectorJoin", query, filter.Input)
 	}
 }
+
+// TestLower_ExpHistogram_MixedSetOpOr_VectorPlainCompare_GroupLeftInclude
+// pins group_left()/group_right() cardinality AND Include labels composing
+// with a plain-vector comparison operand — mirrors
+// [TestLower_ExpHistogram_MixedSetOpOr_VectorPlainGroupLeftRight]'s
+// arithmetic-file sibling, but this shape's own recognizer
+// ([comparisonVectorPlainOverMixedExpHistogramSetOp]) had no such test:
+// this is what actually exercises `b.VectorMatching != nil` on a
+// non-nil VectorMatching (every plain-comparison test before this one used
+// DEFAULT matching, so VectorMatching's own Card/Include never mattered)
+// and `len(b.VectorMatching.Include) > 0` on a genuinely non-empty Include.
+func TestLower_ExpHistogram_MixedSetOpOr_VectorPlainCompare_GroupLeftInclude(t *testing.T) {
+	t.Parallel()
+
+	s := schema.DefaultOTelMetrics()
+	p := parser.NewParser(parser.Options{EnableExperimentalFunctions: true})
+	at := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+
+	query := mixedOrExpr + ` > on(job) group_left(region) ` + mvpPlainVector
+	expr, err := p.ParseExpr(query)
+	if err != nil {
+		t.Fatalf("ParseExpr(%q): %v", query, err)
+	}
+	plan, err := promql.LowerAt(context.Background(), expr, s, at, at)
+	if err != nil {
+		t.Fatalf("LowerAt(%q): unexpected error: %v", query, err)
+	}
+	proj, ok := plan.(*chplan.Project)
+	if !ok {
+		t.Fatalf("lower(%q): plan root is %T, want *chplan.Project", query, plan)
+	}
+	filter, ok := proj.Input.(*chplan.Filter)
+	if !ok {
+		t.Fatalf("lower(%q): Project.Input is %T, want *chplan.Filter", query, proj.Input)
+	}
+	join, ok := filter.Input.(*chplan.MixedVectorJoin)
+	if !ok {
+		t.Fatalf("lower(%q): Filter.Input is %T, want *chplan.MixedVectorJoin", query, filter.Input)
+	}
+	if join.Card != chplan.CardManyToOne {
+		t.Fatalf("lower(%q): join.Card = %v, want CardManyToOne (b.VectorMatching must be read, not skipped)", query, join.Card)
+	}
+	if len(join.Include) != 1 || join.Include[0] != "region" {
+		t.Fatalf("lower(%q): join.Include = %v, want [region]", query, join.Include)
+	}
+}
+
+// TestLower_ExpHistogram_MixedSetOpOr_VectorPlainCompare_StepAligned pins
+// [chplan.MixedVectorJoin].StepAligned for the plain-comparison wrapper:
+// true for a materialised range-mode grid, false for an instant query —
+// mirrors
+// [TestLower_ExpHistogram_MixedSetOpOr_VectorPlainArithmetic_StepAligned]
+// in histogram_native_mixed_or_vector_plain_arithmetic_test.go for this
+// file's own StepAligned wiring.
+func TestLower_ExpHistogram_MixedSetOpOr_VectorPlainCompare_StepAligned(t *testing.T) {
+	t.Parallel()
+
+	s := schema.DefaultOTelMetrics()
+	p := parser.NewParser(parser.Options{EnableExperimentalFunctions: true})
+	start := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	end := start.Add(time.Hour)
+
+	query := mixedOrExpr + " > " + mvpPlainVector
+	expr, err := p.ParseExpr(query)
+	if err != nil {
+		t.Fatalf("ParseExpr(%q): %v", query, err)
+	}
+
+	t.Run("instant", func(t *testing.T) {
+		t.Parallel()
+		plan, err := promql.LowerAt(context.Background(), expr, s, end, end)
+		if err != nil {
+			t.Fatalf("LowerAt(%q): unexpected error: %v", query, err)
+		}
+		join := findMixedVectorJoin(t, query, plan)
+		if join.StepAligned {
+			t.Fatalf("lower(%q) instant: MixedVectorJoin.StepAligned = true, want false (Step == 0)", query)
+		}
+	})
+	t.Run("range", func(t *testing.T) {
+		t.Parallel()
+		plan, err := promql.LowerAtRange(context.Background(), expr, s, start, end, 30*time.Second)
+		if err != nil {
+			t.Fatalf("LowerAtRange(%q): unexpected error: %v", query, err)
+		}
+		join := findMixedVectorJoin(t, query, plan)
+		if !join.StepAligned {
+			t.Fatalf("lower(%q) range: MixedVectorJoin.StepAligned = false, want true (Step > 0)", query)
+		}
+	})
+}

--- a/internal/promql/histogram_native_range_family_gremlins_test.go
+++ b/internal/promql/histogram_native_range_family_gremlins_test.go
@@ -1,0 +1,556 @@
+// Tests in this file pin behaviour that a gremlins mutation run over
+// internal/promql reported as LIVED against the exponential-histogram
+// range-function family: histogram_native_range_fn.go,
+// histogram_native_reset.go, histogram_native_count_present_over_time.go,
+// histogram_native_dropping_shape.go,
+// histogram_native_mixed_or_subquery_aggregate_range_fn.go and
+// histogram_native_mixed_or_subquery_range_fn.go.
+//
+// See gremlins_kill_test.go for the shared convention this file follows:
+// one Test... per mutant (or per tightly-related cluster of mutants), with
+// the gremlins `file:line:col` id named in the doc comment and in the
+// failure message.
+package promql
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/prometheus/prometheus/promql/parser"
+
+	"github.com/tsouza/cerberus/internal/chplan"
+	"github.com/tsouza/cerberus/internal/chsql"
+	"github.com/tsouza/cerberus/internal/schema"
+)
+
+// mustParseVectorSelector parses name as a bare selector and returns its
+// *parser.VectorSelector, whose LabelMatchers (unlike a hand-built
+// &parser.VectorSelector{Name: ...}) carry the `__name__` matcher every
+// exp-histogram recognizer's IsExpHistogramMetric(metricNameFromMatchers(...))
+// check needs to resolve the metric name at all.
+func mustParseVectorSelector(t *testing.T, name string) *parser.VectorSelector {
+	t.Helper()
+	expr := mustParse(t, name)
+	vs, ok := expr.(*parser.VectorSelector)
+	if !ok {
+		t.Fatalf("mustParse(%q) = %T, want *parser.VectorSelector", name, expr)
+	}
+	return vs
+}
+
+// gremlinsMixedOrPinnedQuery builds `<fn>((sum by (service) ((a) or
+// (b)))[5m:1m] @ <pin>)` — the canonical shape
+// sumOrAvgMixedOrSubqueryOuterFnRecognized admits, with sub.Timestamp set
+// so subqueryPinned(sub) is true regardless of whether the OUTER query is
+// itself instant or range mode.
+func gremlinsMixedOrPinnedQuery(fn string) string {
+	return fn + `((sum by (service) ((latency_exp_hist) or (other_metric)))[5m:1m] @ 1700000000)`
+}
+
+// assertNoCrossJoin fails the test if plan contains a *chplan.CrossJoin
+// anywhere. A CrossJoin against a StepGrid is the range/broadcast fan-out
+// shape; a plain instant query with no query_range context has no grid to
+// fan across and must never build one.
+func assertNoCrossJoin(t *testing.T, plan chplan.Node, label string) {
+	t.Helper()
+	found := false
+	chplan.Walk(plan, func(n chplan.Node) bool {
+		if _, ok := n.(*chplan.CrossJoin); ok {
+			found = true
+		}
+		return true
+	})
+	if found {
+		t.Fatalf("%s: plan unexpectedly contains a *chplan.CrossJoin for an instant (non-range) query", label)
+	}
+}
+
+// TestSelectExpHistogramWindowSamples_ProjectionCapacityIsTight kills the
+// ARITHMETIC_BASE mutant at histogram_native_range_fn.go:546:65 inside
+// selectExpHistogramWindowSamples's slice-capacity hint:
+//
+//	projs := make([]chplan.Projection, 0, len(keyAliases)+len(aggs)+1)
+//
+// The function always appends exactly len(keyAliases) + 1 (the times
+// alias) + len(aggs) projections — one per keyAlias, one for
+// hqWindowAllTsListAlias, one per agg — so the original arithmetic gives
+// an EXACT capacity: no append ever triggers a reallocation, and cap()
+// stays at the requested value. Flipping the trailing `+1` to `-1`
+// under-allocates by 2, forcing growslice to run during the last two
+// appends; Go's growth rounding does not land back on the original exact
+// value, so cap() differs from the original construction.
+func TestSelectExpHistogramWindowSamples_ProjectionCapacityIsTight(t *testing.T) {
+	t.Parallel()
+
+	keyAliases := []string{"attrs_alias"}
+	aggs := []chplan.AggFunc{{Fn: chplan.FnAny, Alias: "agg_alias"}}
+	input := &chplan.Scan{Table: "otel_metrics_exponential_histogram"}
+
+	// selection must NOT be histogramWindowAllSamples — that branch
+	// returns input unchanged before ever reaching the mutated line.
+	node := selectExpHistogramWindowSamples(input, aggs, keyAliases, histogramWindowEndpoints)
+
+	proj, ok := node.(*chplan.Project)
+	if !ok {
+		t.Fatalf("selectExpHistogramWindowSamples returned %T, want *chplan.Project", node)
+	}
+
+	const want = 3 // len(keyAliases)=1 + len(aggs)=1 + 1 (the times alias)
+	if got := len(proj.Projections); got != want {
+		t.Fatalf("len(Projections) = %d, want %d", got, want)
+	}
+	if got := cap(proj.Projections); got != want {
+		t.Fatalf("cap(Projections) = %d, want %d (mutant `+`->`-` at histogram_native_range_fn.go:546:65 under-allocates and forces a reallocation, leaving cap != %d)",
+			got, want, want)
+	}
+}
+
+// TestExpHistogramResetMaskStage_ProjectionCapacityIsTight is the sibling
+// of the test above for the ARITHMETIC_BASE mutant at
+// histogram_native_reset.go:156:65 inside expHistogramResetMaskStage's
+// identically-shaped capacity hint. The function appends exactly
+// len(keyAliases) + len(aggs) + 1 (the reset-mask column) projections, so
+// the same exact-capacity argument applies.
+func TestExpHistogramResetMaskStage_ProjectionCapacityIsTight(t *testing.T) {
+	t.Parallel()
+
+	keyAliases := []string{"attrs_alias"}
+	aggs := []chplan.AggFunc{{Fn: chplan.FnAny, Alias: "agg_alias"}}
+	input := &chplan.Scan{Table: "otel_metrics_exponential_histogram"}
+
+	node := expHistogramResetMaskStage(input, aggs, keyAliases)
+
+	proj, ok := node.(*chplan.Project)
+	if !ok {
+		t.Fatalf("expHistogramResetMaskStage returned %T, want *chplan.Project", node)
+	}
+
+	const want = 3 // len(keyAliases)=1 + len(aggs)=1 + 1 (the reset-mask column)
+	if got := len(proj.Projections); got != want {
+		t.Fatalf("len(Projections) = %d, want %d", got, want)
+	}
+	if got := cap(proj.Projections); got != want {
+		t.Fatalf("cap(Projections) = %d, want %d (mutant `+`->`-` at histogram_native_reset.go:156:65 under-allocates and forces a reallocation, leaving cap != %d)",
+			got, want, want)
+	}
+}
+
+// TestCountPresentOverExpHistogram_MetadataFullRangeShortCircuits kills
+// the INVERT_LOGICAL mutant at
+// histogram_native_count_present_over_time.go:65:31, where
+//
+//	if s.ExpHistogramTable == "" || ctx.metadataFullRange {
+//
+// must reject on EITHER condition. countPresentOverExpHistogram has no
+// downstream call that independently re-checks this same guard (unlike
+// its subquery-composing siblings), so metadataFullRange alone —
+// unaccompanied by an empty ExpHistogramTable — is a clean differentiator:
+// flipping `||` to `&&` would let a metadata-driven lowering (which must
+// never apply the instant-query LWR semantics this recognizer's lowering
+// assumes) fall through to a "recognized" answer.
+func TestCountPresentOverExpHistogram_MetadataFullRangeShortCircuits(t *testing.T) {
+	t.Parallel()
+
+	s := schema.DefaultOTelMetrics()
+	expr := mustParse(t, `count_over_time(latency_exp_hist[5m])`)
+	if _, _, _, ok := countPresentOverExpHistogram(expr, s, lowerCtx{metadataFullRange: true}); ok {
+		t.Fatalf("expected metadataFullRange to reject recognition; got ok=true (mutant `||`->`&&` at histogram_native_count_present_over_time.go:65:31)")
+	}
+}
+
+// TestCountPresentOverExpHistogram_ZeroRangeRejected kills the
+// CONDITIONALS_BOUNDARY mutant at
+// histogram_native_count_present_over_time.go:73:21 (`ms.Range <= 0` ->
+// `ms.Range < 0`). A zero-duration matrix selector is built by hand — the
+// PromQL grammar refuses a literal `[0s]` — and must still be rejected.
+func TestCountPresentOverExpHistogram_ZeroRangeRejected(t *testing.T) {
+	t.Parallel()
+
+	s := schema.DefaultOTelMetrics()
+	call := &parser.Call{
+		Func: parser.MustGetFunction("count_over_time"),
+		Args: parser.Expressions{
+			&parser.MatrixSelector{Range: 0, VectorSelector: mustParseVectorSelector(t, "latency_exp_hist")},
+		},
+	}
+	if _, _, _, ok := countPresentOverExpHistogram(call, s, lowerCtx{}); ok {
+		t.Fatalf("expected zero-range matrix selector to be rejected; got ok=true (mutant `<=`->`<` at histogram_native_count_present_over_time.go:73:21)")
+	}
+}
+
+// TestRangeFnOverExpHistogram_MetadataFullRangeShortCircuits kills the
+// INVERT_LOGICAL mutant at histogram_native_range_fn.go:157:31. Like
+// countPresentOverExpHistogram above, rangeFnOverExpHistogram has no
+// downstream call re-checking the same guard, so this is a clean,
+// unmasked differentiator.
+func TestRangeFnOverExpHistogram_MetadataFullRangeShortCircuits(t *testing.T) {
+	t.Parallel()
+
+	s := schema.DefaultOTelMetrics()
+	expr := mustParse(t, `rate(latency_exp_hist[5m])`)
+	if _, ok := rangeFnOverExpHistogram(expr, s, lowerCtx{metadataFullRange: true}); ok {
+		t.Fatalf("expected metadataFullRange to reject recognition; got ok=true (mutant `||`->`&&` at histogram_native_range_fn.go:157:31)")
+	}
+}
+
+// TestRangeFnOverExpHistogram_ZeroRangeRejected kills the
+// CONDITIONALS_BOUNDARY mutant at histogram_native_range_fn.go:170:21
+// (`ms.Range <= 0` -> `ms.Range < 0`).
+func TestRangeFnOverExpHistogram_ZeroRangeRejected(t *testing.T) {
+	t.Parallel()
+
+	s := schema.DefaultOTelMetrics()
+	call := &parser.Call{
+		Func: parser.MustGetFunction("rate"),
+		Args: parser.Expressions{
+			&parser.MatrixSelector{Range: 0, VectorSelector: mustParseVectorSelector(t, "latency_exp_hist")},
+		},
+	}
+	if _, ok := rangeFnOverExpHistogram(call, s, lowerCtx{}); ok {
+		t.Fatalf("expected zero-range matrix selector to be rejected; got ok=true (mutant `<=`->`<` at histogram_native_range_fn.go:170:21)")
+	}
+}
+
+// TestRangeFnOverExpHistogramSubquery_ZeroRangeRejected kills the
+// CONDITIONALS_BOUNDARY mutant at histogram_native_range_fn.go:223:22
+// (`sub.Range <= 0` -> `sub.Range < 0`). Unlike the guard-clause
+// INVERT_LOGICAL mutant on this same function's first line (masked by
+// isExpHistogramValuedShape's own identical guard — see this file's
+// header note in the final report), the Range boundary is examined only
+// here, so a zero-range subquery with an otherwise valid histogram-native
+// inner cleanly differentiates.
+func TestRangeFnOverExpHistogramSubquery_ZeroRangeRejected(t *testing.T) {
+	t.Parallel()
+
+	s := schema.DefaultOTelMetrics()
+	at := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	sub := &parser.SubqueryExpr{
+		Expr:  mustParseVectorSelector(t, "latency_exp_hist"),
+		Range: 0,
+		Step:  time.Minute,
+	}
+	call := &parser.Call{
+		Func: parser.MustGetFunction("sum_over_time"),
+		Args: parser.Expressions{sub},
+	}
+	ctx := lowerCtx{start: at, end: at}
+	if _, ok := rangeFnOverExpHistogramSubquery(call, s, ctx); ok {
+		t.Fatalf("expected zero-range subquery to be rejected; got ok=true (mutant `<=`->`<` at histogram_native_range_fn.go:223:22)")
+	}
+}
+
+// TestLowerExpHistogramRangeFnOverSubquery_ZeroStepDefaults kills the
+// CONDITIONALS_NEGATION mutant at histogram_native_range_fn.go:266:10
+// (`step == 0` -> `step != 0`) inside lowerExpHistogramRangeFnOverSubquery.
+//
+// A subquery with no explicit step (`[5m:]`) must fall back to
+// defaultSubqueryStep. With the negation, step stays 0 and flows into
+// subqueryGridCtx -> epochFloor, which divides by the step duration —
+// a genuine divide-by-zero panic, not merely a wrong answer. The original
+// code lowers this query cleanly; the mutant panics.
+func TestLowerExpHistogramRangeFnOverSubquery_ZeroStepDefaults(t *testing.T) {
+	t.Parallel()
+
+	s := schema.DefaultOTelMetrics()
+	at := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	expr := mustParse(t, `sum_over_time((latency_exp_hist)[5m:])`)
+	if _, err := LowerAt(context.Background(), expr, s, at, at); err != nil {
+		t.Fatalf("LowerAt: %v", err)
+	}
+}
+
+// TestExpHistogramRangeFnWindowed_PinnedAtNotOverwrittenByQueryEnd kills
+// the INVERT_LOGICAL mutant at histogram_native_range_fn.go:427:25
+// (`anchor.End.IsZero() && !ctx.end.IsZero()` -> `||`) inside
+// expHistogramRangeFnWindowed.
+//
+// The original AND only back-fills anchor.End from ctx.end when the
+// selector carries NO pin of its own. An `@`-pinned selector already has
+// a non-zero anchor.End; with the flip to OR, a non-zero ctx.end (any
+// instant query reached via LowerAt) alone satisfies the condition and
+// OVERWRITES the pin with the query's own eval time — silently answering
+// the wrong window.
+func TestExpHistogramRangeFnWindowed_PinnedAtNotOverwrittenByQueryEnd(t *testing.T) {
+	t.Parallel()
+
+	s := schema.DefaultOTelMetrics()
+	// 1767225600 == 2026-01-01T00:00:00Z.
+	expr := mustParse(t, `rate(latency_exp_hist[5m] @ 1767225600)`)
+	queryEnd := time.Date(2030, 5, 5, 0, 0, 0, 0, time.UTC)
+
+	plan, err := LowerAt(context.Background(), expr, s, queryEnd, queryEnd)
+	if err != nil {
+		t.Fatalf("LowerAt: %v", err)
+	}
+	sql, params, err := chsql.Emit(context.Background(), plan)
+	if err != nil {
+		t.Fatalf("Emit: %v", err)
+	}
+	// Values are emitted as `?` placeholders (invariant 10 — typed Frags
+	// only), so the anchor's rendered date lands in the parameter list,
+	// not in the SQL text itself.
+	var paramsText strings.Builder
+	for _, p := range params {
+		fmt.Fprintf(&paramsText, "%v;", p)
+	}
+	got := paramsText.String()
+	if !strings.Contains(got, "2026-01-01") {
+		t.Fatalf("expected the pinned @ timestamp (2026-01-01) among the emitted parameters, got:\n%s\nSQL:\n%s", got, sql)
+	}
+	if strings.Contains(got, "2030-05-05") {
+		t.Fatalf("emitted parameters leaked the query end (2030-05-05) instead of the pinned @ timestamp (mutant `&&`->`||` at histogram_native_range_fn.go:427:25 overwrites the pin with ctx.end):\n%s", got)
+	}
+}
+
+// TestLabelCallOverExpHistogramDroppingShape_LabelReplaceExactArity kills
+// two mutants at once, both on histogram_native_dropping_shape.go:213:
+//   - CONDITIONALS_NEGATION at :204:25 (`s.ExpHistogramTable == ""` ->
+//     `!= ""`): with the negation, ANY non-empty ExpHistogramTable — the
+//     normal, default schema — makes the guard bail, so this test's
+//     ordinary DefaultOTelMetrics() schema alone differentiates.
+//   - CONDITIONALS_NEGATION at :213:21 (`len(call.Args) != 5` -> `== 5`):
+//     with the negation, exactly-5-args (the only valid label_replace
+//     shape) is rejected instead of accepted.
+//
+// The original code recognises the shape under the standard schema with a
+// well-formed 5-arg label_replace call; either mutant makes it reject.
+func TestLabelCallOverExpHistogramDroppingShape_LabelReplaceExactArity(t *testing.T) {
+	t.Parallel()
+
+	s := schema.DefaultOTelMetrics()
+	expr := mustParse(t, `label_replace(latency_exp_hist + 1, "copy", "$1", "service", "(.*)")`)
+	call, ok := labelCallOverExpHistogramDroppingShape(expr, s, lowerCtx{})
+	if !ok {
+		t.Fatalf("expected 5-arg label_replace wrapping a drop-family binop to be recognised under the default schema; got ok=false (mutants at histogram_native_dropping_shape.go:204:25 and :213:21)")
+	}
+	if call.Func.Name != fnLabelReplace {
+		t.Fatalf("call.Func.Name = %q, want %q", call.Func.Name, fnLabelReplace)
+	}
+}
+
+// TestLabelCallOverExpHistogramDroppingShape_LabelJoinMinArity kills the
+// CONDITIONALS_BOUNDARY mutant at histogram_native_dropping_shape.go:217:21
+// (`len(call.Args) < 3` -> `<= 3`). The minimum valid label_join call has
+// exactly 3 args (vector, dst, separator, zero src labels) — the parser
+// itself refuses this degenerate shape, so the Call is built by hand.
+func TestLabelCallOverExpHistogramDroppingShape_LabelJoinMinArity(t *testing.T) {
+	t.Parallel()
+
+	s := schema.DefaultOTelMetrics()
+	binExpr := mustParse(t, `latency_exp_hist + 1`)
+	call := &parser.Call{
+		Func: parser.MustGetFunction("label_join"),
+		Args: parser.Expressions{binExpr, &parser.StringLiteral{Val: "copy"}, &parser.StringLiteral{Val: "-"}},
+	}
+	if _, ok := labelCallOverExpHistogramDroppingShape(call, s, lowerCtx{}); !ok {
+		t.Fatalf("expected minimum-arity (3-arg) label_join wrapping a drop-family binop to be recognised; got ok=false (mutant `<`->`<=` at histogram_native_dropping_shape.go:217:21)")
+	}
+}
+
+// TestSumOrAvgMixedOrSubqueryOuterFnRecognized_ZeroRangeRejected kills two
+// mutants on histogram_native_mixed_or_subquery_aggregate_range_fn.go's
+// line 124 at once:
+//   - CONDITIONALS_BOUNDARY at :124:22 (`sub.Range <= 0` -> `< 0`).
+//   - INVERT_LOGICAL at :124:27 (the second `||`, between the Range check
+//     and `!subqueryHasEvalAnchor(sub, ctx)`, flipped to `&&`).
+//
+// sub.Range = 0 with everything else valid (a real mixed-or inner,
+// eval-anchor-resolvable ctx) makes the ORIGINAL code reject via the
+// Range check alone (short-circuiting subqueryHasEvalAnchor away
+// entirely). subqueryGridCtx tolerates a zero Range via its own
+// sub-step-window clamp, so subqueryHasEvalAnchor(sub, ctx) genuinely
+// returns true here — which is exactly what lets the :124:27 AND-mutant
+// (needing BOTH operands true) fall through to a false "not rejected"
+// verdict, and what lets the :124:22 boundary-mutant do the same once the
+// Range check alone no longer rejects.
+func TestSumOrAvgMixedOrSubqueryOuterFnRecognized_ZeroRangeRejected(t *testing.T) {
+	t.Parallel()
+
+	s := schema.DefaultOTelMetrics()
+	at := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	sub := &parser.SubqueryExpr{
+		Expr:  mustParse(t, `sum by (service) ((latency_exp_hist) or (other_metric))`),
+		Range: 0,
+		Step:  time.Minute,
+	}
+	call := &parser.Call{
+		Func: parser.MustGetFunction("count_over_time"),
+		Args: parser.Expressions{sub},
+	}
+	ctx := lowerCtx{start: at, end: at}
+	if _, ok := sumOrAvgMixedOrSubqueryOuterFnRecognized(call, s, ctx); ok {
+		t.Fatalf("expected zero-range subquery to be rejected; got ok=true (mutants at histogram_native_mixed_or_subquery_aggregate_range_fn.go:124:22 and :124:27)")
+	}
+}
+
+// TestSumOrAvgMixedOrSubqueryOuterFnRecognized_NonSubqueryArgNoPanic kills
+// the INVERT_LOGICAL mutant at
+// histogram_native_mixed_or_subquery_aggregate_range_fn.go:124:9 — the
+// FIRST `||` on that line (`!ok || sub.Range <= 0 ...`), flipped to `&&`.
+//
+// When c.Args[0] is not a *parser.SubqueryExpr, the failed type assertion
+// leaves `sub` nil. The original `||` short-circuits on `!ok` and never
+// evaluates `sub.Range`. `&&`, given precedence (`&&` binds tighter than
+// `||`), regroups the expression as `(!ok && sub.Range <= 0) ||
+// !subqueryHasEvalAnchor(...)`, and `&&` evaluates its second operand
+// whenever the first is true — dereferencing the nil `sub` and panicking.
+// The original code returns ok=false cleanly; the mutant crashes the test.
+func TestSumOrAvgMixedOrSubqueryOuterFnRecognized_NonSubqueryArgNoPanic(t *testing.T) {
+	t.Parallel()
+
+	s := schema.DefaultOTelMetrics()
+	call := &parser.Call{
+		Func: parser.MustGetFunction("count_over_time"),
+		Args: parser.Expressions{&parser.VectorSelector{Name: "latency_exp_hist"}},
+	}
+	if _, ok := sumOrAvgMixedOrSubqueryOuterFnRecognized(call, s, lowerCtx{}); ok {
+		t.Fatalf("expected non-subquery argument to be rejected; got ok=true")
+	}
+}
+
+// TestLowerSumOrAvgMixedOrSubqueryOuterFn_ZeroStepDefaults kills the
+// CONDITIONALS_NEGATION mutant at
+// histogram_native_mixed_or_subquery_aggregate_range_fn.go:168:10
+// (`step == 0` -> `step != 0`), the sibling of the range_fn.go:266:10
+// kill above but inside lowerSumOrAvgMixedOrSubqueryOuterFn. Same
+// divide-by-zero-in-epochFloor signature: the original lowers cleanly,
+// the mutant panics.
+func TestLowerSumOrAvgMixedOrSubqueryOuterFn_ZeroStepDefaults(t *testing.T) {
+	t.Parallel()
+
+	s := schema.DefaultOTelMetrics()
+	at := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	expr := mustParse(t, `count_over_time((sum by (service) ((latency_exp_hist) or (other_metric)))[5m:])`)
+	if _, err := LowerAt(context.Background(), expr, s, at, at); err != nil {
+		t.Fatalf("LowerAt: %v", err)
+	}
+}
+
+// TestLowerSumOrAvgMixedOrSubquerySelectFn_InstantPinDoesNotBroadcast
+// kills the INVERT_LOGICAL mutant at
+// histogram_native_mixed_or_subquery_aggregate_range_fn.go:223:21
+// (`ctx.rangeMode() && subqueryPinned(sub)` -> `||`) inside
+// lowerSumOrAvgMixedOrSubquerySelectFn.
+//
+// An `@`-pinned mixed-or subquery reached via a plain instant LowerAt
+// (ctx.rangeMode() == false) must take the ordinary single-window branch.
+// With OR, subqueryPinned(sub) alone satisfies the condition and routes
+// through the CrossJoin-over-StepGrid broadcast branch with ctx.step == 0
+// — a shape that must never appear outside real query_range lowering.
+func TestLowerSumOrAvgMixedOrSubquerySelectFn_InstantPinDoesNotBroadcast(t *testing.T) {
+	t.Parallel()
+
+	s := schema.DefaultOTelMetrics()
+	at := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	expr := mustParse(t, gremlinsMixedOrPinnedQuery("count_over_time"))
+	plan, err := LowerAt(context.Background(), expr, s, at, at)
+	if err != nil {
+		t.Fatalf("LowerAt: %v", err)
+	}
+	assertNoCrossJoin(t, plan, "count_over_time instant query over an @-pinned mixed-or subquery")
+}
+
+// TestLowerSumOrAvgMixedOrSubqueryFoldFn_InstantPinDoesNotBroadcast kills
+// two mutants at once, both `ctx.rangeMode() && subqueryPinned(sub)` ->
+// `||` guards reached from lowerSumOrAvgMixedOrSubqueryFoldFn for the
+// SAME query:
+//   - :335:21 inside lowerHistFoldOverPureSubqueryBranch (the histogram
+//     arm).
+//   - :374:21 inside lowerFloatFoldOverPureSubqueryBranch (the float arm).
+//
+// sum_over_time reaches the FOLD family (as opposed to the SELECT family
+// count_over_time exercises above), which runs BOTH arms and recombines
+// them — so a single instant, `@`-pinned query exercises both sites in
+// one lowering, and a CrossJoin surfacing from EITHER arm's own mutated
+// guard is caught by the same assertion.
+func TestLowerSumOrAvgMixedOrSubqueryFoldFn_InstantPinDoesNotBroadcast(t *testing.T) {
+	t.Parallel()
+
+	s := schema.DefaultOTelMetrics()
+	at := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	expr := mustParse(t, gremlinsMixedOrPinnedQuery("sum_over_time"))
+	plan, err := LowerAt(context.Background(), expr, s, at, at)
+	if err != nil {
+		t.Fatalf("LowerAt: %v", err)
+	}
+	assertNoCrossJoin(t, plan, "sum_over_time instant query over an @-pinned mixed-or subquery")
+}
+
+// TestMixedOrSubqueryOuterFn_ArgCountVsNameGuard kills the INVERT_LOGICAL
+// mutant at histogram_native_mixed_or_subquery_range_fn.go:116:22
+// (`len(c.Args) != 1 || !isHistogramSubqueryOuterFnName(c.Func.Name)` ->
+// `&&`).
+//
+// A 2-arg call to a recognised name (count_over_time takes exactly 1
+// argument) must reject on arity alone. With AND, a recognised name
+// (`!isHistogramSubqueryOuterFnName(...)` == false) makes the whole
+// conjunction false regardless of arity, so the mutant proceeds to index
+// c.Args[0] as if it were the sole argument and can recognise the shape
+// anyway.
+func TestMixedOrSubqueryOuterFn_ArgCountVsNameGuard(t *testing.T) {
+	t.Parallel()
+
+	s := schema.DefaultOTelMetrics()
+	at := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	sub := &parser.SubqueryExpr{
+		Expr:  mustParse(t, `(latency_exp_hist) or (other_metric)`),
+		Range: 5 * time.Minute,
+		Step:  time.Minute,
+	}
+	call := &parser.Call{
+		Func: parser.MustGetFunction("count_over_time"),
+		Args: parser.Expressions{sub, &parser.NumberLiteral{Val: 1}},
+	}
+	ctx := lowerCtx{start: at, end: at}
+	if _, _, _, ok := mixedOrSubqueryOuterFn(call, s, ctx); ok {
+		t.Fatalf("expected a 2-arg call to a 1-arg function to be rejected; got ok=true (mutant `||`->`&&` at histogram_native_mixed_or_subquery_range_fn.go:116:22)")
+	}
+}
+
+// TestMixedOrSubqueryOuterFn_ZeroRangeRejected is the
+// histogram_native_mixed_or_subquery_range_fn.go sibling of
+// TestSumOrAvgMixedOrSubqueryOuterFnRecognized_ZeroRangeRejected above,
+// killing:
+//   - CONDITIONALS_BOUNDARY at :120:22 (`sub.Range <= 0` -> `< 0`).
+//   - INVERT_LOGICAL at :120:27 (the second `||` -> `&&`).
+func TestMixedOrSubqueryOuterFn_ZeroRangeRejected(t *testing.T) {
+	t.Parallel()
+
+	s := schema.DefaultOTelMetrics()
+	at := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	sub := &parser.SubqueryExpr{
+		Expr:  mustParse(t, `(latency_exp_hist) or (other_metric)`),
+		Range: 0,
+		Step:  time.Minute,
+	}
+	call := &parser.Call{
+		Func: parser.MustGetFunction("count_over_time"),
+		Args: parser.Expressions{sub},
+	}
+	ctx := lowerCtx{start: at, end: at}
+	if _, _, _, ok := mixedOrSubqueryOuterFn(call, s, ctx); ok {
+		t.Fatalf("expected zero-range subquery to be rejected; got ok=true (mutants at histogram_native_mixed_or_subquery_range_fn.go:120:22 and :120:27)")
+	}
+}
+
+// TestMixedOrSubqueryOuterFn_NonSubqueryArgNoPanic is the
+// histogram_native_mixed_or_subquery_range_fn.go sibling of
+// TestSumOrAvgMixedOrSubqueryOuterFnRecognized_NonSubqueryArgNoPanic
+// above, killing the INVERT_LOGICAL mutant at :120:9 (the first `||` on
+// that line -> `&&`, causing a nil-pointer panic on `sub.Range` when
+// c.Args[0] is not a subquery).
+func TestMixedOrSubqueryOuterFn_NonSubqueryArgNoPanic(t *testing.T) {
+	t.Parallel()
+
+	s := schema.DefaultOTelMetrics()
+	call := &parser.Call{
+		Func: parser.MustGetFunction("count_over_time"),
+		Args: parser.Expressions{&parser.VectorSelector{Name: "latency_exp_hist"}},
+	}
+	if _, _, _, ok := mixedOrSubqueryOuterFn(call, s, lowerCtx{}); ok {
+		t.Fatalf("expected non-subquery argument to be rejected; got ok=true")
+	}
+}

--- a/internal/promql/histogram_native_unary_internal_test.go
+++ b/internal/promql/histogram_native_unary_internal_test.go
@@ -1,0 +1,96 @@
+package promql
+
+import (
+	"testing"
+
+	"github.com/prometheus/prometheus/promql/parser"
+
+	"github.com/tsouza/cerberus/internal/schema"
+)
+
+// TestUnaryOverExpHistogram_GuardHappyPath pins the ordinary, fully-enabled
+// case: a real ExpHistogramTable, no metadataFullRange. This is the only
+// input combination that can actually observe the guard's own comparison
+// operator (`s.ExpHistogramTable == ""`) rather than a downstream,
+// independently-gated recognizer masking it — see this file's other test
+// for why the table-empty / metadataFullRange=true combinations cannot.
+func TestUnaryOverExpHistogram_GuardHappyPath(t *testing.T) {
+	t.Parallel()
+
+	p := parser.NewParser(parser.Options{EnableExperimentalFunctions: true})
+	s := schema.DefaultOTelMetrics()
+
+	mustParse := func(q string) parser.Expr {
+		e, err := p.ParseExpr(q)
+		if err != nil {
+			t.Fatalf("ParseExpr(%q): %v", q, err)
+		}
+		return e
+	}
+
+	cases := []struct {
+		name   string
+		query  string
+		wantOp parser.ItemType
+	}{
+		{"minus", "-latency_exp_hist", parser.SUB},
+		{"plus", "+latency_exp_hist", parser.ADD},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			operand, op, ok := unaryOverExpHistogram(mustParse(tc.query), s, lowerCtx{})
+			if !ok {
+				t.Fatalf("unaryOverExpHistogram(%q) ok = false, want true", tc.query)
+			}
+			if op != tc.wantOp {
+				t.Errorf("unaryOverExpHistogram(%q) op = %v, want %v", tc.query, op, tc.wantOp)
+			}
+			if operand == nil {
+				t.Errorf("unaryOverExpHistogram(%q) operand = nil, want the wrapped expression", tc.query)
+			}
+		})
+	}
+}
+
+// TestUnaryOverExpHistogram_RejectsNonAddSubUnary pins that the operator
+// check only ever accepts SUB (`-`) and ADD (`+`) — PromQL's own parser
+// never actually produces a unary `*`/`/`/etc, so this calls the
+// recognizer directly with a hand-built AST node to exercise the branch a
+// real query can't reach, pinning `u.Op != parser.SUB && u.Op != parser.ADD`
+// as a genuine two-way AND: SUB alone must pass the first clause and MUL
+// must fail neither is negated away.
+func TestUnaryOverExpHistogram_RejectsNonAddSubUnary(t *testing.T) {
+	t.Parallel()
+
+	p := parser.NewParser(parser.Options{EnableExperimentalFunctions: true})
+	s := schema.DefaultOTelMetrics()
+
+	expr, err := p.ParseExpr("latency_exp_hist")
+	if err != nil {
+		t.Fatalf("ParseExpr: %v", err)
+	}
+
+	bogus := &parser.UnaryExpr{Op: parser.MUL, Expr: expr}
+	if _, _, ok := unaryOverExpHistogram(bogus, s, lowerCtx{}); ok {
+		t.Fatalf("unaryOverExpHistogram(unary MUL) ok = true, want false (only SUB/ADD are unary ops)")
+	}
+}
+
+// TestUnaryOverExpHistogram_NotUnaryRejects pins that a non-unary
+// expression (no `+`/`-` prefix at all) is rejected outright.
+func TestUnaryOverExpHistogram_NotUnaryRejects(t *testing.T) {
+	t.Parallel()
+
+	p := parser.NewParser(parser.Options{EnableExperimentalFunctions: true})
+	s := schema.DefaultOTelMetrics()
+
+	expr, err := p.ParseExpr("latency_exp_hist")
+	if err != nil {
+		t.Fatalf("ParseExpr: %v", err)
+	}
+	if _, _, ok := unaryOverExpHistogram(expr, s, lowerCtx{}); ok {
+		t.Fatalf("unaryOverExpHistogram(bare selector) ok = true, want false")
+	}
+}

--- a/internal/promql/histogram_quantile_classic_native_internal_test.go
+++ b/internal/promql/histogram_quantile_classic_native_internal_test.go
@@ -1,0 +1,172 @@
+package promql
+
+import (
+	"testing"
+	"time"
+)
+
+// baseEligibleInput returns a classicHistogramWindowInput that
+// nativeClassicHistogramEligible accepts: a `rate` window, a materialised
+// (Step > 0, bounds pinned) grid, not step-aligned (not a subquery inner),
+// a positive lookback, and every duration a whole number of seconds — see
+// [nativeClassicHistogramEligible]'s own doc for why each clause is
+// required. Callers mutate one field at a time to probe each individual
+// guard clause.
+func baseEligibleInput() classicHistogramWindowInput {
+	at := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	return classicHistogramWindowInput{
+		shape: histogramAggShape{windowFn: rateWindowFn},
+		win:   histogramWindow{lookback: 5 * time.Minute, offset: 0},
+		ctx: lowerCtx{
+			start: at,
+			end:   at.Add(time.Hour),
+			step:  30 * time.Second,
+		},
+	}
+}
+
+// TestNativeClassicHistogramEligible_HappyPath pins that a fully
+// shape-eligible window (see [baseEligibleInput]) is accepted.
+func TestNativeClassicHistogramEligible_HappyPath(t *testing.T) {
+	t.Parallel()
+	if !nativeClassicHistogramEligible(baseEligibleInput()) {
+		t.Fatalf("nativeClassicHistogramEligible(base) = false, want true")
+	}
+}
+
+// TestNativeClassicHistogramEligible_WindowFnMustBeRate pins that only
+// `rate` is native-eligible — `increase`/`sum_over_time`/etc. stay on the
+// fan-out fallback.
+func TestNativeClassicHistogramEligible_WindowFnMustBeRate(t *testing.T) {
+	t.Parallel()
+	in := baseEligibleInput()
+	in.shape.windowFn = "increase"
+	if nativeClassicHistogramEligible(in) {
+		t.Fatalf("nativeClassicHistogramEligible(windowFn=increase) = true, want false")
+	}
+}
+
+// TestNativeClassicHistogramEligible_StepBoundary pins the `in.ctx.step <=
+// 0 || in.ctx.start.IsZero() || in.ctx.end.IsZero()` rejection at its exact
+// boundary: Step == 0 (instant mode, no materialised grid) must be
+// rejected — the aggregate takes (start, end, step) as constant
+// parameters, so there is nothing to hand it in instant mode. This single
+// case distinguishes:
+//   - CONDITIONALS_BOUNDARY on `step <= 0` (`<= 0` -> `< 0`): a mutant
+//     would read Step == 0 as NOT `< 0`, letting it through.
+//   - INVERT_LOGICAL on EITHER `||` in that same line (`&&` in place of
+//     either): with start/end both non-zero, the `step <= 0` clause is the
+//     ONLY one true, so replacing either `||` with `&&` swallows it and
+//     the mutant no longer rejects Step == 0 either.
+func TestNativeClassicHistogramEligible_StepBoundary(t *testing.T) {
+	t.Parallel()
+	in := baseEligibleInput()
+	in.ctx.step = 0
+	if nativeClassicHistogramEligible(in) {
+		t.Fatalf("nativeClassicHistogramEligible(step=0) = true, want false (instant mode has no materialised grid)")
+	}
+}
+
+// TestNativeClassicHistogramEligible_StartEndZero pins that a zero
+// start/end bound (the OTHER two disjuncts on the same line as the Step
+// boundary) also rejects, keeping the `||` chain honest at each of its
+// three terms rather than only the first.
+func TestNativeClassicHistogramEligible_StartEndZero(t *testing.T) {
+	t.Parallel()
+
+	t.Run("start_zero", func(t *testing.T) {
+		t.Parallel()
+		in := baseEligibleInput()
+		in.ctx.start = time.Time{}
+		if nativeClassicHistogramEligible(in) {
+			t.Fatalf("nativeClassicHistogramEligible(start=zero) = true, want false")
+		}
+	})
+	t.Run("end_zero", func(t *testing.T) {
+		t.Parallel()
+		in := baseEligibleInput()
+		in.ctx.end = time.Time{}
+		if nativeClassicHistogramEligible(in) {
+			t.Fatalf("nativeClassicHistogramEligible(end=zero) = true, want false")
+		}
+	})
+}
+
+// TestNativeClassicHistogramEligible_StepAlignedRejects pins that a
+// subquery inner's epoch-aligned grid (ctx.stepAligned) stays on the
+// fan-out: chplan.RangeBucketGridNative carries no StepAlign field.
+func TestNativeClassicHistogramEligible_StepAlignedRejects(t *testing.T) {
+	t.Parallel()
+	in := baseEligibleInput()
+	in.ctx.stepAligned = true
+	if nativeClassicHistogramEligible(in) {
+		t.Fatalf("nativeClassicHistogramEligible(stepAligned=true) = true, want false")
+	}
+}
+
+// TestNativeClassicHistogramEligible_LookbackBoundary pins the
+// `in.win.lookback <= 0` rejection at its exact boundary — lookback == 0
+// must be rejected (CONDITIONALS_BOUNDARY would read `<= 0` as `< 0`,
+// letting a zero lookback slip through as eligible).
+func TestNativeClassicHistogramEligible_LookbackBoundary(t *testing.T) {
+	t.Parallel()
+	in := baseEligibleInput()
+	in.win.lookback = 0
+	if nativeClassicHistogramEligible(in) {
+		t.Fatalf("nativeClassicHistogramEligible(lookback=0) = true, want false")
+	}
+}
+
+// TestNativeClassicHistogramEligible_WholeSecondsConjunction pins the
+// final `wholeSeconds(step) && wholeSeconds(lookback) && wholeSeconds(offset)`
+// return as a genuine three-way AND: a non-whole-second value on ANY ONE
+// of the three durations, with the other two whole-second, must reject —
+// covering both `&&` positions against an INVERT_LOGICAL flip to `||`. A
+// sub-second window would otherwise silently truncate to 0 in the native
+// aggregate's whole-second UInt32 parameters (see
+// [nativeClassicHistogramEligible]'s own doc).
+func TestNativeClassicHistogramEligible_WholeSecondsConjunction(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		mut  func(*classicHistogramWindowInput)
+	}{
+		{"step_sub_second", func(in *classicHistogramWindowInput) { in.ctx.step = 30*time.Second + 500*time.Millisecond }},
+		{"lookback_sub_second", func(in *classicHistogramWindowInput) { in.win.lookback = 90*time.Second + 500*time.Millisecond }},
+		{"offset_sub_second", func(in *classicHistogramWindowInput) { in.win.offset = 500 * time.Millisecond }},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			in := baseEligibleInput()
+			tc.mut(&in)
+			if nativeClassicHistogramEligible(in) {
+				t.Fatalf("nativeClassicHistogramEligible(%s) = true, want false (a sub-second duration must reject)", tc.name)
+			}
+		})
+	}
+}
+
+// TestWholeSeconds pins the exact-multiple-of-a-second predicate the
+// eligibility gate's final return composes three times over.
+func TestWholeSeconds(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		d    time.Duration
+		want bool
+	}{
+		{0, true},
+		{time.Second, true},
+		{30 * time.Second, true},
+		{5 * time.Minute, true},
+		{500 * time.Millisecond, false},
+		{30*time.Second + 500*time.Millisecond, false},
+	}
+	for _, tc := range cases {
+		if got := wholeSeconds(tc.d); got != tc.want {
+			t.Errorf("wholeSeconds(%v) = %v, want %v", tc.d, got, tc.want)
+		}
+	}
+}

--- a/internal/promql/histogram_wire_arms_test.go
+++ b/internal/promql/histogram_wire_arms_test.go
@@ -160,3 +160,31 @@ func TestWireArms_ResolveName(t *testing.T) {
 		})
 	}
 }
+
+// TestWireArms_FilterStopsAtFirstArmMatch pins filter's own `break`: a
+// matcher is classified into exactly ONE arm ([wireArms]'s switch is
+// mutually exclusive), so once filter finds the arm list entry matching
+// that one classification it must stop scanning the REST of the arm list
+// rather than keep comparing — otherwise a caller that (legitimately, per
+// filter's own doc: "the subset of w.Matchers classified into ANY of
+// arms") passes the SAME arm twice would see that matcher appended once
+// per duplicate entry instead of once per matcher. INVERT_LOOPCTRL
+// (break -> continue) turns the inner loop into "keep scanning the rest of
+// arms after a match", which is exactly the shape this duplicate-arms call
+// exposes: continue would re-match the second, identical arms[1] entry and
+// append the SAME matcher again.
+func TestWireArms_FilterStopsAtFirstArmMatch(t *testing.T) {
+	t.Parallel()
+
+	job := mustMatcher(t, labels.MatchEqual, "job", "api")
+	le := mustMatcher(t, labels.MatchEqual, "le", "0.5")
+	w := wireArms([]*labels.Matcher{job, le})
+
+	got := w.filter(WireArmStorage, WireArmStorage)
+	if len(got) != 1 {
+		t.Fatalf("filter(Storage, Storage) len = %d, want 1 (break must stop the inner loop at the first matching arm)", len(got))
+	}
+	if got[0] != job {
+		t.Errorf("filter(Storage, Storage)[0] = %v, want the job matcher", got[0])
+	}
+}


### PR DESCRIPTION
Follow-up to #2662, which merged before this second commit landed on the same branch. Closes the remaining `gremlins phase4-promql-i` gap (29 surviving mutants, invisible in the original consolidation since that leg's CI log had crashed on a network flake before ever running a single mutant). 21 killed with targeted tests, 8 proven equivalent (documented). No production code changed.

## Test plan

- [x] `go build ./internal/promql/...`
- [x] `go vet ./internal/promql/...`
- [x] `gofumpt -l` / `goimports -l` clean
- [x] `go test -count=1 ./internal/promql/...`
