### PR TITLE
fix(chaos): recalibrate route-memo-activation's memory cap with real margin

### DIFF
--- a/.github/scripts/chaos-run.mjs
+++ b/.github/scripts/chaos-run.mjs
@@ -1214,7 +1214,7 @@ const ROUTE_MEMO_LIVE_EDGE_MARGIN_STEPS = 2;
 // that shape structurally cannot exercise a real rescue in THIS lane:
 // cerberus_queries_total is self-emitted by the cerberus process itself, so
 // in a freshly-bootstrapped chaos lane it only ever has a few minutes of
-// real history — a 24h read and an 8h (kEff=3) shard read the identical row
+// real history — a 24h read and ANY K-way shard read the identical row
 // count, because there is nothing further back to read either way, so
 // slicing never reduces cost and route B can never succeed where route A
 // failed. Two other rolling-reseeded counters
@@ -1226,28 +1226,24 @@ const ROUTE_MEMO_LIVE_EDGE_MARGIN_STEPS = 2;
 // route_memo_probe_requests_total (test/e2e/seed/cmd/seed/main.go's
 // insertRouteMemoProbeBackfillSQL) is a dedicated synthetic counter seeded
 // exactly once with real historical depth spread genuinely across a full 24h
-// window — not rolling-reseeded freshness. Measured directly: an 8h shard of
-// it (the real kEff=3 granularity, not the 3h an earlier round of this
-// investigation assumed) costs ~30% of the full 24h window's real ClickHouse
-// memory_usage, giving real, non-flat cost separation for the shard this
-// scenario needs to actually rescue. See chaos-overlay.env's own
-// CERBERUS_CH_QUERY_MAX_MEMORY comment for the exact measured numbers this
-// value was sized against.
+// window — not rolling-reseeded freshness, giving real, non-flat cost
+// separation between the full query and a shard of it. See chaos-overlay.
+// env's own CERBERUS_CH_QUERY_MAX_MEMORY comment (issue #2670) for the real
+// measured numbers this scenario's cap was sized against — including why
+// the real shard granularity (k=8, from internal/solver/planner.go's own
+// N/MinAnchorsPerSlice/MaxK arithmetic) and the real per-shard memory
+// apportionment (this overlay's small CERBERUS_CH_MAX_OPEN_CONNS clamps it
+// to kEff=1, the FULL cap per shard) are both different from what
+// CERBERUS_SHARD_PARALLEL's default might suggest.
 const ROUTE_MEMO_EXPR = 'sum by (probe_shard) (rate(route_memo_probe_requests_total[5m]))';
-// 180s, not the original 120s: a real run (2026-08-26, main push
-// 1b71d06c5's own chaos job) exhausted a 120s budget at ~123s with
-// no-preferb=17 / probe-not-admitted=1 on the decline-reason dump, then the
-// SEPARATE post-loop client corroboration below (its own independent
-// pollUntil) got a clean 200 within 0.4s of the deadline firing — proving
-// the underlying route-B rescue mechanism was already working and this
-// scenario's own primary-detection budget was simply too tight against the
-// real wall-clock variance of accumulating minCorroboratingFailures(2)
-// CONSECUTIVE route-A failures under CERBERUS_CH_QUERY_MAX_MEMORY's
-// deliberately narrow ~4.5% margin (chaos-overlay.env) — an occasional
-// under-cap route-A success resets that streak and costs a full retry
-// cycle. 180s gives real headroom over the observed ~123s instead of
-// guessing at a wider number.
-const ROUTE_MEMO_ACTIVATION_DEADLINE_MS = 180_000;
+// 60s: issue #2670's real cap recalibration (chaos-overlay.env) made route A
+// fail RELIABLY instead of sporadically, so minCorroboratingFailures(2)
+// consecutive failures now lands within the first two ~5s polls — two
+// independent real dispatches activated in ~19-27s each. 60s keeps
+// generous (~2x) headroom over that observed range without carrying
+// forward the original 180s budget the OLD, mis-calibrated cap needed to
+// paper over sporadic (non-consecutive) 422s.
+const ROUTE_MEMO_ACTIVATION_DEADLINE_MS = 60_000;
 const ROUTE_MEMO_POLL_INTERVAL_MS = 5_000;
 const ROUTE_MEMO_FINAL_OK_DEADLINE_MS = 60_000; // post-activation: the same query must now cleanly 200 for a real client
 
@@ -1312,6 +1308,15 @@ async function scenarioRouteMemoActivation() {
         return false; // route A hit the cap; keep polling for the memo's A->B rescue
       }
       if (r.status !== 200) return false;
+      // Ground truth for the K (shard count) a real route-B dispatch used,
+      // straight off the response header engine.go's executeRouted /
+      // executeRoutedCursor stamp (X-Cerberus-Route-Decision: sharded-
+      // timeslice;k=<K>;reason=<via>) — cheap (no extra ClickHouse
+      // round-trip) and, per issue #2670, the fastest way to catch a future
+      // K/kEff drift (e.g. a planner or CERBERUS_SHARD_* default change)
+      // before it silently reopens this scenario's calibration.
+      const routeDecision = r.headers['x-cerberus-route-decision'];
+      if (routeDecision) log(`    [route-b] X-Cerberus-Route-Decision: ${routeDecision}`);
       const successB = await queryBreakerMetric(
         'cerberus_route_ab_success_total{cerberus_route_choice="b"}',
       );

--- a/test/e2e/chaos/manifests/chaos-overlay.env
+++ b/test/e2e/chaos/manifests/chaos-overlay.env
@@ -72,7 +72,7 @@
 #     must never trip CH health). Kept >= the admit cap so admission, not
 #     the pool, is the first-order shed signal.
 #
-#   CERBERUS_CH_QUERY_MAX_MEMORY=65Mi
+#   CERBERUS_CH_QUERY_MAX_MEMORY=64Mi
 #     Default 1GiB (1073741824 bytes). An earlier round of this
 #     investigation found the pinned 24h/15s route-memo-activation query
 #     (ROUTE_MEMO_EXPR, then cerberus_queries_total) cost ~5.5 MiB and sized
@@ -81,40 +81,68 @@
 #     A->B rescue could never succeed at that cap: cerberus_queries_total is
 #     self-emitted by the cerberus process itself, so in this freshly-
 #     bootstrapped lane it only ever has a few minutes of real history — a
-#     24h read and an 8h (kEff=3, CERBERUS_SHARD_PARALLEL default) shard read
-#     the identical row count and cost, because there is nothing further
-#     back to read either way. No memory cap can separate "full query fails,
-#     shard succeeds" when both cost the same.
+#     24h read and ANY K-way shard read the identical row count and cost,
+#     because there is nothing further back to read either way. No memory
+#     cap can separate "full query fails, shard succeeds" when both cost
+#     the same.
 #
 #     ROUTE_MEMO_EXPR now targets route_memo_probe_requests_total
 #     (test/e2e/seed/cmd/seed/main.go's insertRouteMemoProbeBackfillSQL) — a
 #     dedicated synthetic counter seeded exactly once with 480 series x 288
 #     samples genuinely spread across a real 24h window, not rolling-
-#     reseeded freshness. Measured directly against real ClickHouse
-#     system.query_log: the full 24h window costs ~68.24 MiB; an 8h shard
-#     (the real kEff=3 granularity) costs ~20.73 MiB — a real ~30% ratio,
-#     giving a genuine separable window (cap must exceed 3 x 20.73 = 62.2
-#     MiB for a shard to succeed, and stay under 68.24 MiB for the full
-#     query to still fail). 65Mi sits centered in that ~6 MiB window
-#     (~4.5% margin on both sides) — the control probe
-#     (cerberus_queries_total, unrelated to this metric) measured
-#     essentially identical memory_usage across three independent runs
-#     (<0.05% variance), giving confidence this environment's real
-#     ClickHouse costs are deterministic enough for a ~4.5% margin to hold,
-#     not a coin-flip.
+#     reseeded freshness.
 #
-#     Two other rolling-reseeded counters (http_server_request_duration_count,
-#     the `up` gauge) were also measured and showed the same flat-cost
-#     pattern cerberus_queries_total did — their real row density is
-#     dominated by the SAME 10-minute rolling reseed window every other
-#     Playwright spec needs, not real 24h spread; neither could ever
-#     separate a full-vs-shard cost either. This cap still keeps the routine
-#     health-probe queries every scenario's heal-gate depends on comfortably
-#     clear: the loki HEAD_PROBES smoke query (chaos-run.mjs,
-#     `{service_name=~".+"}&limit=1`, an INSTANT query — qlcommon.
-#     InstantLookback, internal/api/loki/handler.go:330 — not a full-table
-#     scan) measured only ~1.4-2.1 MiB in earlier rounds of this same
-#     investigation, far below 65Mi.
+#     65Mi (the value this line carried until issue #2670) was sized
+#     against a SINGLE, imprecise measurement claiming the full 24h window
+#     costs ~68.24 MiB and an 8h shard (assumed kEff=3, CERBERUS_SHARD_
+#     PARALLEL's default) costs ~20.73 MiB. Both halves of that estimate
+#     were wrong, confirmed by real repeated system.query_log measurement
+#     across FIVE independent real chaos dispatches (issue #2670):
+#
+#       1. The real full-query cost is NOT ~68.24 MiB — it is stable at
+#          67,989,223-68,030,343 bytes (~64.84-64.88 MiB, <0.06% spread
+#          across all five runs). The OLD 65Mi cap (68,157,440 bytes) sat
+#          ABOVE that real cost by only ~0.12-0.16 MiB (<0.25%), so route A
+#          almost never organically exceeded it — the scenario's rare 422s
+#          never landed two-in-a-row, and minCorroboratingFailures(2) was
+#          essentially never satisfied. This alone explains the flake.
+#
+#       2. The real per-shard granularity is NOT kEff=3 / 8h. The X-
+#          Cerberus-Route-Decision response header (ground truth, straight
+#          from internal/engine's dispatch) showed a REAL route-B dispatch
+#          uses k=8 (from internal/solver/planner.go's own N/
+#          MinAnchorsPerSlice/MaxK arithmetic for this query's N=5761,
+#          MaxK=8 — nothing here raises MinAnchorsPerSlice or MaxK above
+#          their binary defaults), not 3 — CERBERUS_SHARD_PARALLEL(=3
+#          default) governs DISPATCH CONCURRENCY (P), a different quantity
+#          from K (shard count). More importantly, internal/solver/
+#          executor.go's Execute apportions each shard's own max_memory_
+#          usage to CERBERUS_CH_QUERY_MAX_MEMORY / kEff, where kEff =
+#          min(K, P_eff, GateCap/2) — and THIS overlay's OWN
+#          CERBERUS_CH_MAX_OPEN_CONNS=4 (picked below for the unrelated
+#          pool-saturation scenario) makes GateCap = MaxOpenConns -
+#          solverGateReserve(2) = 2, so half = 1 and kEff clamps to 1 in
+#          this specific environment regardless of K or CERBERUS_SHARD_
+#          PARALLEL: every shard gets the FULL cap as its own budget, not
+#          cap/3 or cap/8. Apportionment is not the bottleneck here at all.
+#          Measured real per-shard memory_usage of completed route-B shards
+#          (system.query_log, post-activation): ~11.9-13.5 MiB — comfortably
+#          (>4x) under any cap in a wide, reasonable range.
+#
+#     With apportionment out of the way, the calibration only needs the cap
+#     BELOW the real, stable full-query cost floor (67,989,223 bytes) with
+#     real margin, and it already sits enormously (>4x) above real shard
+#     cost regardless of the exact value chosen. 64Mi (67,108,864 bytes)
+#     gives ~880 KiB (~1.3%, >20x the <0.06% measured cross-run jitter)
+#     of margin below the observed floor — proven by two additional, clean,
+#     independent real chaos dispatches (route-memo-activation activated in
+#     ~19-27s both times) after this value replaced 65Mi. This cap still
+#     keeps the routine health-probe queries every scenario's heal-gate
+#     depends on comfortably clear: the loki HEAD_PROBES smoke query
+#     (chaos-run.mjs, `{service_name=~".+"}&limit=1`, an INSTANT query —
+#     qlcommon.InstantLookback, internal/api/loki/handler.go:330 — not a
+#     full-table scan) measured only ~1.4-2.1 MiB in an earlier round of
+#     this investigation, far below 64Mi.
 #
 #   CERBERUS_SOLVER_ADAPTIVE_ENABLED=true
 #     Default true (internal/solver/config.go DefaultConfig). The
@@ -167,6 +195,6 @@ CERBERUS_ADMIT_PROM=2
 CERBERUS_ADMIT_LOKI=2
 CERBERUS_ADMIT_TEMPO=2
 CERBERUS_CH_MAX_OPEN_CONNS=4
-CERBERUS_CH_QUERY_MAX_MEMORY=65Mi
+CERBERUS_CH_QUERY_MAX_MEMORY=64Mi
 CERBERUS_SOLVER_ADAPTIVE_ENABLED=true
 CERBERUS_SHARD_MIN_FANOUT=1000000

--- a/test/e2e/seed/cmd/seed/main.go
+++ b/test/e2e/seed/cmd/seed/main.go
@@ -640,13 +640,16 @@ FROM numbers(40)`
 // regardless of suite runtime, not to model real historical depth. That shape
 // is exactly wrong for route-memo-activation: cerberus's own solver shards a
 // wide `query_range` window by TIME SUB-RANGE (see internal/solver's K-way
-// split — kEff defaults to 3, CERBERUS_SHARD_PARALLEL, so each real shard
-// covers ~1/3 of the window, ~8h of this scenario's 24h pin, NOT the 3h an
-// earlier round of this investigation assumed), so proving the failure-driven
-// route memo's rescue actually works needs a query whose cost genuinely
-// scales with window width — an ~8h shard of the 24h window must read
-// meaningfully fewer rows than the unsliced 24h query, or there is nothing
-// for slicing to rescue.
+// split — K itself comes from planner.go's own N/MinAnchorsPerSlice/MaxK
+// arithmetic, NOT from CERBERUS_SHARD_PARALLEL, which governs dispatch
+// CONCURRENCY, a different quantity; issue #2670's real measurement found
+// K=8 for this scenario's pinned (24h, 15s) tuple, not the kEff=3 / ~8h-
+// shard figure an earlier round of this investigation assumed — see chaos-
+// overlay.env's own CERBERUS_CH_QUERY_MAX_MEMORY comment for the current
+// real numbers), so proving the failure-driven route memo's rescue
+// actually works needs a query whose cost genuinely scales with window
+// width — a shard of the 24h window must read meaningfully fewer rows than
+// the unsliced 24h query, or there is nothing for slicing to rescue.
 //
 // Measured directly (issue #2650's investigation) that neither a self-emitted
 // metric (cerberus_queries_total, which only has as much history as the
@@ -662,17 +665,18 @@ FROM numbers(40)`
 // insertion would only duplicate rows, not add coverage. The series count
 // is sized so the query's real per-row cost dominates its fixed per-shard
 // materialization overhead — at 48 series a 3h slice already cost 55% of the
-// full 24h read (measured); at 240 series an 8h slice (the real kEff=3
-// granularity) cost 37% of the full 24h read (13.53 of 36.66 MiB, measured)
-// — close to, but not quite at, the ideal 1/3 a fixed-overhead-free split
-// would give, and NOT YET separable at any CERBERUS_CH_QUERY_MAX_MEMORY value
-// (cap/3 > 13.53 MiB needs cap > 40.6 MiB, which is already above the full
-// query's own 36.66 MiB cost). 480 series is the next step in that same
-// direction. Re-verify the actual full-vs-8h-shard cost split empirically
-// before relying on any of these numbers — this comment states the DESIGN
-// INTENT and its measurement history, not a promise the exact ratio holds;
-// chaos-overlay.env's CERBERUS_CH_QUERY_MAX_MEMORY value is the thing that
-// must be sized from a real measurement on whatever series count lands here.
+// full 24h read (measured); at 240 series an 8h slice (assumed at the time
+// to be the real granularity — issue #2670 later found the real K for this
+// tuple is 8, not 3, and the memory apportionment kEff this overlay's own
+// small connection pool produces is 1, not K — see chaos-overlay.env's own
+// comment) cost 37% of the full 24h read (13.53 of 36.66 MiB, measured) —
+// close to, but not quite at, the ideal 1/3 a fixed-overhead-free split
+// would give. 480 series is the next step in that same direction. Re-verify
+// the actual full-vs-shard cost split empirically before relying on any of
+// these numbers — this comment states the DESIGN INTENT and its measurement
+// history, not a promise the exact ratio holds; chaos-overlay.env's
+// CERBERUS_CH_QUERY_MAX_MEMORY value is the thing that must be sized from a
+// real measurement on whatever series count lands here.
 //
 // AggregationTemporality=2 (CUMULATIVE, matching insertSumSQL's own
 // convention) — DELTA would route this metric through the DELTA-prefix


### PR DESCRIPTION
## Summary

`CERBERUS_CH_QUERY_MAX_MEMORY=65Mi` (`test/e2e/chaos/manifests/chaos-overlay.env`)
was sized against a single, imprecise measurement from issue #2650's
investigation, claiming the pinned 24h/15s `route-memo-activation` query costs
~68.24 MiB and an 8h shard (assumed `kEff=3`, `CERBERUS_SHARD_PARALLEL`'s
default) costs ~20.73 MiB. Both halves of that estimate were wrong — found by
real, repeated `system.query_log` measurement across five independent real
`chaos` job dispatches:

1. **The real full-query cost is stable at 67,989,223-68,030,343 bytes
   (~64.84-64.88 MiB, <0.06% spread)** across every measured run — the old
   65Mi cap (68,157,440 bytes) sat *above* that real cost by only ~0.12-0.16
   MiB (<0.25%), not comfortably above the ~68.24 MiB the original comment
   assumed. Route A almost never organically exceeded the cap, and the rare
   422s that did occur never landed two in a row, so
   `internal/routememo`'s `minCorroboratingFailures(2)` was essentially
   never satisfied and route B never fired. This alone accounts for the
   flake.

2. **The real per-shard granularity is `k=8`, not `kEff=3` / an 8h shard** —
   confirmed via the `X-Cerberus-Route-Decision` response header, ground
   truth straight from the dispatch site, rather than inferring it from
   ambiguous row counts. `internal/solver/planner.go`'s own
   `N`/`MinAnchorsPerSlice`/`MaxK` arithmetic produces `K=8` for this
   query's shape; `CERBERUS_SHARD_PARALLEL` governs dispatch *concurrency*
   (`P`), a different quantity from `K` (shard count) entirely.

   More importantly, this resolves the "why compare a single shard's cost
   against 3x itself" puzzle: `internal/solver/executor.go`'s `Execute`
   apportions each shard's own `max_memory_usage` to
   `CERBERUS_CH_QUERY_MAX_MEMORY / kEff`, where
   `kEff = min(K, P_eff, GateCap/2)`. This overlay's *own*
   `CERBERUS_CH_MAX_OPEN_CONNS=4` (set for the unrelated pool-saturation
   scenario) makes `GateCap = MaxOpenConns - solverGateReserve(2) = 2`, so
   `half = 1` and `kEff` clamps to `1` in this specific environment
   regardless of `K` or `CERBERUS_SHARD_PARALLEL` — every shard gets the
   *full* cap as its own budget, not `cap/3` or `cap/8`. Apportionment is
   not the bottleneck here at all. Real per-shard cost measured on
   completed route-B shards: ~11.9-13.5 MiB, comfortably (>4x) under any
   reasonable cap value.

## Fix

- Recalibrates `CERBERUS_CH_QUERY_MAX_MEMORY` to `64Mi` — ~880 KiB (~1.3%,
  >20x the measured cross-run jitter) below the observed real-cost floor.
  Proven by two additional clean real `chaos` job dispatches after this
  value replaced 65Mi (route-memo-activation activated in ~19-27s both
  times), plus a third dispatch against this PR's final squashed commit.
- Tightens `ROUTE_MEMO_ACTIVATION_DEADLINE_MS` from 180s back to 60s now
  that route A fails *reliably* instead of sporadically (2x headroom over
  the observed 19-27s activation time) — the 180s budget (#2660) existed
  only to paper over the old cap's sporadic-failure problem.
- Corrects the stale "kEff=3 / 8h shard" assumption everywhere it was
  documented (`chaos-run.mjs`, `chaos-overlay.env`,
  `test/e2e/seed/cmd/seed/main.go`) so a future investigator isn't misled
  by the same wrong mental model.
- Keeps a lightweight, permanent `X-Cerberus-Route-Decision` header log in
  the scenario (cheap — no extra ClickHouse round-trip) so a future K/kEff
  drift is visible directly in the chaos job log instead of requiring a
  fresh investigation to rediscover.

## Verification

Real `gh workflow run e2e.yml` dispatches against this branch, `chaos` job
green with `scenario route-memo-activation: all resilience contracts held`,
real evidence pulled from each job's own log (not guessed):

- Run [33071674962](https://github.com/tsouza/cerberus/actions/runs/33071674962) — first real dispatch at `CERBERUS_CH_QUERY_MAX_MEMORY=64Mi`, activated in ~27s.
- Run [33073381214](https://github.com/tsouza/cerberus/actions/runs/33073381214) — second independent dispatch, activated in ~19s, `X-Cerberus-Route-Decision: sharded-timeslice;k=8;reason=retry` confirming the real shard count.
- A third dispatch against this PR's final squashed commit (deadline tightened to 60s, diagnostic-only code removed) — see the PR's own checks / linked run for the result.

All other `chaos` scenarios (`ch-slow-query-timeout`, `load-admit-saturation`,
`ch-network-partition`, `ch-pod-kill`, `cerberus-pod-kill`) passed cleanly on
every dispatch.

Closes #2670
