### PR TITLE
chore(release): support the current minor line only, retire the rest

### DIFF
--- a/.github/scripts/README.md
+++ b/.github/scripts/README.md
@@ -1102,16 +1102,16 @@ what actually runs.
   moves while a release waits on CI. The publish jobs guard
   `needs.preflight.result == 'success'` with no `|| skipped` disjunction, since
   the preflight now fires on every publishing run. It ALSO enforces
-  the **release support-window / EOL policy** (`SUPPORTED_MINOR_LINES = 3`): the
-  pushed line must be within the latest 3 minor lines (current + the two prior);
-  a push to a line 3+ minors behind the current minor (derived from the stable
+  the **release support-window / EOL policy** (`SUPPORTED_MINOR_LINES = 1`): the
+  pushed line must be the current minor line — no prior minor is supported;
+  a push to a line 1+ minor(s) behind the current minor (derived from the stable
   `v*` tag set, listed via the API so no fetch-depth is needed) is REFUSED
   before any artifact publishes, independent of how green the commit is. See
   `docs/operations.md` "Release support window / EOL policy". The SAME module
   also drives the **active** half of the EOL policy via the `eol-retire-line`
   command (the `eol-retire` job in `release.yml`): post-publish, it computes the
   line that just fell out of the window with `retireLineForPublish` (the same
-  `SUPPORTED_MINOR_LINES` math — publishing `1.6.0` retires `release/1.3.x`) and
+  `SUPPORTED_MINOR_LINES` math — publishing `1.6.0` retires `release/1.5.x`) and
   DELETES that `release/X.W.x` branch via the Git refs API iff it exists.
   Conservative + fail-open: it retires at most one line, only on a minor open
   (`X.Y.0`, `Y>0`) — patches / major bumps / backports / prereleases retire

--- a/.github/scripts/release-preflight.mjs
+++ b/.github/scripts/release-preflight.mjs
@@ -107,10 +107,10 @@
 //      older/side commit. (For a branch push GITHUB_SHA is normally already the
 //      tip; the check defends against a stale re-drive racing a newer push.)
 //      MAINTENANCE only.
-//   4. The maintenance line must be INSIDE the support window — the latest
-//      SUPPORTED_MINOR_LINES minor lines (current + the two prior). A push to a
-//      line that is end-of-life (3+ minors behind the highest released minor)
-//      is REFUSED: an EOL line gets no further hotfixes. See the "Release
+//   4. The maintenance line must be INSIDE the support window — the current
+//      minor only (SUPPORTED_MINOR_LINES). A push to a line that is
+//      end-of-life (1+ minor(s) behind the highest released minor) is
+//      REFUSED: an EOL line gets no further hotfixes. See the "Release
 //      support window / EOL policy" subsection of docs/operations.md.
 //      MAINTENANCE only.
 //
@@ -219,11 +219,11 @@ export const REUSABLE_JOB_SEPARATOR = ' / ';
 // Conclusions that count as a settled, non-blocking check-run.
 const GREEN_CONCLUSIONS = new Set(['success', 'skipped', 'neutral']);
 
-// Cerberus supports the latest N minor release lines: the current minor plus
-// the two prior. A maintenance line that falls 3+ minors behind the highest
-// released minor is end-of-life — no further hotfixes. See the "Release support
-// window / EOL policy" subsection of docs/operations.md.
-export const SUPPORTED_MINOR_LINES = 3;
+// Cerberus supports exactly ONE minor release line: the current minor. A
+// maintenance line that falls 1+ minor(s) behind the highest released minor
+// is end-of-life — no further hotfixes. See the "Release support window /
+// EOL policy" subsection of docs/operations.md.
+export const SUPPORTED_MINOR_LINES = 1;
 
 // A released app tag, `v<major>.<minor>.<patch>` (stable only — a prerelease
 // suffix like `-rc.1` does NOT establish a new supported line).
@@ -434,7 +434,8 @@ export function supportWindowProblem({ branch, tags, windowSize = SUPPORTED_MINO
 // is the single source of truth. When a NEW minor opens (`Z == 0`), the window
 // slides forward by one and the line `SUPPORTED_MINOR_LINES` behind the new
 // minor drops off: publishing `X.Y.0` makes `X.(Y - SUPPORTED_MINOR_LINES).x`
-// end-of-life. With a 3-line window, shipping 1.6.0 retires release/1.3.x.
+// end-of-life. With a 1-line window, shipping 1.6.0 retires release/1.5.x —
+// the line it just superseded.
 //
 // Conservative by construction — retires AT MOST one line, and only when:
 //   - the version parses as a stable `X.Y.Z` (no prerelease suffix);
@@ -444,8 +445,8 @@ export function supportWindowProblem({ branch, tags, windowSize = SUPPORTED_MINO
 //     `X.0.0` is a bigger policy call, so this returns null and leaves those
 //     lines to the maintainer (the passive `supportWindowProblem` gate still
 //     refuses to PUBLISH on them). See docs/operations.md.
-//   - the computed minor index is >= 0 (early minors like 1.0/1.1/1.2 under a
-//     3-line window retire nothing — there is no line that far back yet);
+//   - the computed minor index is >= 0 (an early minor like 1.0 under a
+//     1-line window retires nothing — there is no line that far back yet);
 //   - the just-published minor is actually the (new) HIGHEST released minor.
 //     A stable BACKPORT cut after a newer minor — e.g. publishing 1.4.2 while
 //     1.6.0 is already out — must NOT slide the window or retire anything; the
@@ -834,8 +835,8 @@ function selfTest() {
   assert(r.problems.length === 1 && /GitGuardian: status failure/.test(r.problems[0]), 'legacy status red must block');
 
   // --- support-window / EOL gate -------------------------------------------
-  // Worked example from the policy: at v1.5.x current, 1.4.x and 1.3.x are
-  // supported; 1.2.x and older are EOL.
+  // Worked example from the policy: at v1.5.x current, ONLY 1.5.x is
+  // supported (window = 1); 1.4.x and everything older is EOL.
   const releasedTags = ['v1.5.0', 'v1.4.0', 'v1.4.1', 'v1.3.0', 'v1.2.0', 'v1.0.0', 'v1.5.0-rc.1'];
   assert(currentMinor(releasedTags)[0] === 1 && currentMinor(releasedTags)[1] === 5, 'current minor is 1.5');
   assert(currentMinor(['v1.5.0-rc.1', 'v1.4.0'])[1] === 4, 'prerelease does not advance the current minor');
@@ -843,8 +844,8 @@ function selfTest() {
 
   const sw = (b, tags = releasedTags) => supportWindowProblem({ branch: b, tags });
   assert(sw('release/1.5.x') === null, '1.5.x (current) is in-window');
-  assert(sw('release/1.4.x') === null, '1.4.x (current-1) is in-window');
-  assert(sw('release/1.3.x') === null, '1.3.x (current-2) is in-window');
+  assert(/end-of-life/.test(sw('release/1.4.x')), '1.4.x (current-1) is EOL under a 1-line window');
+  assert(/end-of-life/.test(sw('release/1.3.x')), '1.3.x (current-2) is EOL');
   assert(/end-of-life/.test(sw('release/1.2.x')), '1.2.x (current-3) is EOL');
   assert(/end-of-life/.test(sw('release/1.0.x')), '1.0.x (current-5) is EOL');
   assert(/end-of-life/.test(sw('release/0.9.x')), 'older major is EOL once a newer major exists');
@@ -870,7 +871,7 @@ function selfTest() {
     branchHead: 'abc',
     pushedSha: 'abc',
     selfJobs: self,
-    branchLabel: 'release/1.4.x',
+    branchLabel: 'release/1.5.x',
     tags: releasedTags,
     checkRuns: [cr('check', 'completed', 'success')],
     statuses: [],
@@ -883,22 +884,24 @@ function selfTest() {
   // so a minor open retires the line exactly SUPPORTED_MINOR_LINES behind it.
   const retire = (version, tags = []) => retireLineForPublish({ version, tags });
 
-  // Worked example from the brief: publish 1.6.0 -> retire release/1.3.x.
-  assert(retire('1.6.0', ['v1.6.0', 'v1.5.0', 'v1.4.0', 'v1.3.0']) === 'release/1.3.x', '1.6.0 retires release/1.3.x');
-  // 1.5.0 -> retire release/1.2.x (matches the docs worked example).
-  assert(retire('1.5.0', ['v1.5.0', 'v1.4.0', 'v1.3.0', 'v1.2.0']) === 'release/1.2.x', '1.5.0 retires release/1.2.x');
+  // Worked example from the brief: publish 1.6.0 -> retire release/1.5.x,
+  // the line it just superseded (window = 1: current minor only).
+  assert(retire('1.6.0', ['v1.6.0', 'v1.5.0', 'v1.4.0', 'v1.3.0']) === 'release/1.5.x', '1.6.0 retires release/1.5.x');
+  // 1.5.0 -> retire release/1.4.x (matches the docs worked example).
+  assert(retire('1.5.0', ['v1.5.0', 'v1.4.0', 'v1.3.0', 'v1.2.0']) === 'release/1.4.x', '1.5.0 retires release/1.4.x');
   // A patch release retires nothing — window unchanged.
   assert(retire('1.5.1', ['v1.5.1', 'v1.5.0', 'v1.4.0']) === null, '1.5.1 (patch) retires nothing');
-  // No prior line that far back yet (early minors under a 3-line window).
-  assert(retire('1.0.0', ['v1.0.0']) === null, '1.0.0 has no line 3 minors back -> noop');
-  assert(retire('1.2.0', ['v1.2.0', 'v1.1.0', 'v1.0.0']) === null, '1.2.0: would-be -1.x line does not exist -> noop');
+  // No prior line that far back yet (a 1-line window still needs ONE prior
+  // minor to exist before there is anything to retire).
+  assert(retire('1.0.0', ['v1.0.0']) === null, '1.0.0 has no prior line -> noop');
+  assert(retire('1.2.0', ['v1.2.0', 'v1.1.0', 'v1.0.0']) === 'release/1.1.x', '1.2.0 retires release/1.1.x');
   // A MAJOR bump is out of scope — conservative, retires nothing here.
   assert(retire('2.0.0', ['v2.0.0', 'v1.6.0', 'v1.5.0']) === null, 'major bump 2.0.0 retires nothing (scoped out)');
   // A stable BACKPORT cut after a newer minor must NOT slide the window.
   assert(retire('1.4.0', ['v1.6.0', 'v1.5.0', 'v1.4.0']) === null, 'backport 1.4.0 behind current 1.6 retires nothing');
   // The retire-line is idempotent at the helper level: same inputs, same name
   // (existence/deletion is the caller's job).
-  assert(retire('1.6.0', ['v1.6.0', 'v1.5.0']) === 'release/1.3.x', 'retire-line is deterministic regardless of branch presence');
+  assert(retire('1.6.0', ['v1.6.0', 'v1.5.0']) === 'release/1.5.x', 'retire-line is deterministic regardless of branch presence');
   // Non-stable / non-version inputs are ignored.
   assert(retire('1.6.0-rc.1', ['v1.6.0-rc.1']) === null, 'prerelease publish retires nothing');
   assert(retire('chart-v0.6.3', []) === null, 'chart version is not an app version -> noop');
@@ -909,7 +912,7 @@ function selfTest() {
     const tags = ['v1.6.0', 'v1.5.0', 'v1.4.0', 'v1.3.0'];
     const line = retireLineForPublish({ version: '1.6.0', tags });
     assert(/end-of-life/.test(supportWindowProblem({ branch: line, tags })), 'the retired line is EOL per supportWindowProblem');
-    assert(supportWindowProblem({ branch: 'release/1.4.x', tags }) === null, 'the line kept (1.4.x) is still in-window');
+    assert(supportWindowProblem({ branch: 'release/1.6.x', tags }) === null, 'the current line (1.6.x) is still in-window');
   }
 
   // --- the EXPECTED set: absence must FAIL ---------------------------------

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,7 +2,7 @@
 
 ## Supported versions
 
-Security fixes land on the latest tagged release. As the 1.x line grows we'll widen this to an N-1 support window; until there's more than one minor release to support, "latest release (or `main`)" is the supported surface.
+Security fixes land on the current minor release line only — see [`docs/operations.md` → Release support window / EOL policy](docs/operations.md#release-support-window--eol-policy). "Latest release (or `main`)" is the supported surface; an older minor line is end-of-life the moment a new minor ships.
 
 ## Reporting a vulnerability
 

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -1627,7 +1627,7 @@ ships only the compiled binary and root CA bundle.
 ### Release ritual (the ordered cycle)
 
 Publishing is machinery; deciding *what* ships — and in which order — is the
-release ritual. Every cycle runs these six steps top to bottom. The ordering
+release ritual. Every cycle runs these five steps top to bottom. The ordering
 carries as much weight as the steps themselves:
 
 1. **Drive everything merged first.** A cycle opens by draining the board: no
@@ -1635,14 +1635,14 @@ carries as much weight as the steps themselves:
    the whole delta since the previous one, never a subset.
 2. **Settle the retirement set before anything is cut.** When the cycle
    cuts a new minor — which a breaking change is by itself enough to force, see
-   below — the oldest supported line falls out of the window defined in
-   [release support window / EOL policy](#release-support-window--eol-policy).
-   Work out which line that is up front, because it takes **no backport and no
-   patch release** this cycle — spending a release on a line about to be retired
-   is wasted work. This step is a decision, not an action: the retirement itself
-   is automatic, with the `eol-retire` job deleting the out-of-window branch
-   after the new minor publishes. A patch-only cycle retires nothing and passes
-   straight through.
+   below — the line `main` is leaving falls out of the window defined in
+   [release support window / EOL policy](#release-support-window--eol-policy)
+   in that same cycle: with a one-line window, the departing line never
+   receives a backport of its own. This step is a decision, not an action: the
+   retirement itself is automatic, with the `eol-retire` job deleting the
+   out-of-window branch after the new minor publishes — a no-op if that branch
+   was never created (see step 4). A patch-only cycle retires nothing and
+   passes straight through.
 3. **Audit the delta.** One last pass over the complete diff since the previous
    release: code against comments against docs, DRY, KISS, soundness. This is
    the final gate — findings are fixed and merged onto `main` here, before any
@@ -1654,48 +1654,37 @@ carries as much weight as the steps themselves:
    `perf-nightly-selfcheck`'s weekly runs (#2437): a red run there means the
    nightly gate itself stopped catching an injected regression, which is a
    worse, quieter failure than the gate itself going red.
-4. **Backport everything to every line that stays supported.** Every fix that
-   landed on `main` since the previous release goes onto every
-   `release/<major>.<minor>.x` line that is still supported once this cycle
-   lands — step 2 settles which those are. "Everything" is the default rather
-   than a per-fix judgement call. A change is left out of a line only when the
-   backport is genuinely infeasible on that line, and a line that keeps
-   rejecting backports is a retirement candidate, not a standing exception. A
-   cycle that cuts a new minor also *adds* a line: the minor `main` is leaving
-   needs its own maintenance branch, created from the peeled tag of its last
-   release (`git push origin v<tag>^{}:refs/heads/release/<major>.<minor>.x` —
-   the ruleset carries no `creation` rule, so this needs no bypass). That branch
-   must exist before step 5 can publish a patch on it. See
-   [maintenance lines](#maintenance-lines-hotfix-backports) for the mechanics.
-5. **Publish the backport PATCH releases first.** Every still-supported older
-   line gets its patch tag before the new head release exists.
-6. **Publish the new MINOR (or patch) release last.** `main`'s release is always
-   the final publish of the cycle.
+4. **Backport within the current line only.** With a one-line support window
+   there is never more than one supported `release/<major>.<minor>.x` line at
+   once, so "backport" only ever means: a hotfix lands on `main` while `main`
+   is still on the current minor, and ships in that minor's next patch. A cycle
+   that cuts a new minor does **not** create a maintenance branch for the line
+   it is leaving — that line falls out of the window in the same cycle (step
+   2), so a branch created for it would have no window to ever receive a
+   backport. See [maintenance lines](#maintenance-lines-hotfix-backports) for
+   the branch mechanics, which exist for the general case but sit unused under
+   the current one-line policy.
+5. **Publish the new MINOR (or patch) release last.** `main`'s release is
+   always the final publish of the cycle — there is no backport-line publish
+   to sequence ahead of it, since step 4 never produces one under the current
+   one-line policy.
 
 **Breaking changes are accepted in a new minor.** On the cerberus version line
 (`appVersion` / the `v<major>.<minor>.<patch>` tags) a breaking change does
 **not** require a major bump — the minor is its vehicle. That makes "does this
 delta break anything?" a step-2 input: a breaking change is on its own
 sufficient reason for the cycle to cut a minor rather than a patch, and cutting
-a minor is what pushes the oldest line out of the support window and calls for
-a maintenance branch on the minor `main` is leaving. A cycle carrying neither a
-breaking change nor a new feature is a patch cycle: it retires nothing, creates
-no line, and passes step 2 straight through.
+a minor is what retires the line `main` is leaving in the same cycle. A cycle
+carrying neither a breaking change nor a new feature is a patch cycle: it
+retires nothing and passes step 2 straight through.
 
-Three properties follow from that order. The audit precedes the backport so
-that its findings reach every line: a fix merged onto `main` after the lines
-were cut would ship only in the head release, leaving each patch release to
-publish a defect `main` had already repaired. Auditing first also keeps the
-backport a single pass rather than one pass per round of findings. Publishing
-the older lines first means the newest tag is never the one users find while
-the older lines are still mid-flight: by the time the head release appears,
-every supported line already sits at its final version. And the audit is the
-last thing that merges — nothing lands between it and the tags it cleared, on
-any line.
+One property follows from that order: the audit is the last thing that
+merges — nothing lands between it and the tag it clears. A fix merged onto
+`main` after the audit would ship unaudited in the head release, defeating the
+point of auditing at all.
 
-Each individual publish in steps 5 and 6 runs through the machinery below — a
-backport by pushing its `release/*.x` branch, the head release by merging its
-release PR.
+The single publish in step 5 runs through the machinery below — the head
+release by merging its release PR.
 
 ### Two-tier test fence: merge gate vs. release gate
 
@@ -2046,9 +2035,9 @@ required lane that never runs on the branch would block every hotfix release.
 
 ### Release support window / EOL policy
 
-Cerberus maintains the **latest 3 minor release lines**: the current minor plus
-the two prior. When a new minor ships, the line that becomes **3 minors behind**
-the current minor reaches **end-of-life (EOL)**. An EOL line:
+Cerberus maintains **exactly one minor release line: the current minor**. When
+a new minor ships, the line it just superseded reaches **end-of-life (EOL)**
+immediately. An EOL line:
 
 - gets **no further hotfixes**;
 - has its `release/<major>.<minor>.x` maintenance branch **deleted
@@ -2060,10 +2049,10 @@ What stays: the **version tags and GitHub Releases** for EOL versions **remain
 available** — only the future-hotfix branch is removed. Already-published images,
 charts, and binaries are never unpublished.
 
-**Worked example.** At **v1.5.x** current, the supported lines are
-`release/1.5.x`, `release/1.4.x`, and `release/1.3.x`. Shipping v1.5.0 retired
-`1.2.x` and older: `release/1.2.x` was deleted, `v1.2.*` tags and Releases stay
-up. `1.4.x` and `1.3.x` remain supported and keep taking backports.
+**Worked example.** At **v1.6.x** current, the only supported line is
+`release/1.6.x`. Shipping v1.6.0 retired `1.5.x`: `release/1.5.x` was deleted,
+`v1.5.*` tags and Releases stay up. No older line was ever kept — a minor line's
+support ends the moment the next minor ships.
 
 **Enforcement.** The support window is enforced on both halves of the EOL
 policy, sharing one piece of window math
@@ -2072,7 +2061,7 @@ source of truth):
 
 - **Passive (publish refusal).** The maintenance-release `preflight`
   (`supportWindowProblem`) refuses a push to a `release/<major>.<minor>.x` line
-  that is 3+ minors behind the current minor (derived from the stable `v*` tag
+  that is 1+ minor(s) behind the current minor (derived from the stable `v*` tag
   set) — **before** any artifact publishes, independent of how green the commit
   is. An out-of-window line takes no further hotfixes.
 - **Active (branch retirement).** When a NEW minor actually ships, the
@@ -2080,8 +2069,9 @@ source of truth):
   fell out of the window **automatically** — no manual maintainer step. It runs
   only after a successful new-version publish, computes the line via
   `retireLineForPublish` (the same `SUPPORTED_MINOR_LINES` window: publishing
-  `1.6.0` retires `release/1.3.x`), and deletes that `release/X.W.x` branch iff
-  it exists. Guards: it retires **at most one** line and **only on a minor open**
+  `1.6.0` retires `release/1.5.x`, the line it just superseded), and deletes
+  that `release/X.W.x` branch iff it exists. Guards: it retires **at most one**
+  line and **only on a minor open**
   (`X.Y.0`, `Y>0`) — patches, major bumps, stable backports, and prereleases
   retire nothing; it deletes **only** a provably out-of-window branch that
   exists (idempotent — an already-absent branch is a clean no-op), with a


### PR DESCRIPTION
## Summary

Cerberus now supports exactly **one** minor release line at a time — the
current minor. Narrows `SUPPORTED_MINOR_LINES` (the single source of truth in
`.github/scripts/release-preflight.mjs`) from `3` to `1`.

A minor cut now retires the line it supersedes in the *same* cycle instead of
keeping it around for two more releases. Since a maintenance branch is only
ever created for a line `main` has already left, and that line is now
end-of-life the instant it's left, maintenance-branch creation and cross-line
backporting are dead paths under the current policy — `docs/operations.md`'s
release ritual is updated to describe this directly (five steps instead of
six; step 4 no longer creates a maintenance branch on a minor cut).

## What changed

- `.github/scripts/release-preflight.mjs` — `SUPPORTED_MINOR_LINES = 1`, doc
  comments, and the embedded `--self-test` block's assertions/worked examples
  recomputed for the new window (all still pass).
- `docs/operations.md` — "Release support window / EOL policy" section and the
  "Release ritual" section rewritten for a one-line window.
- `.github/scripts/README.md` — policy summary numbers updated.
- `SECURITY.md` — dropped the stale "we'll widen to an N-1 window" language;
  points at the documented policy instead.

## Test plan

- [x] `node .github/scripts/release-preflight.mjs --self-test` passes.
- [x] `node --test .github/scripts/release-preflight.test.mjs` — all 21 pass,
      including the EOL-window integration test.
- [x] `markdownlint-cli2` clean on the three changed docs.
