### PR TITLE
docs(config): document issue #2667's 5 resource-bound env vars

### DIFF
--- a/cmd/cerberus/cmd_configdocs.go
+++ b/cmd/cerberus/cmd_configdocs.go
@@ -400,6 +400,34 @@ The solver-tuning surface (` + "`CERBERUS_EVAL_ROUTE`" + `, ` + "`CERBERUS_SHARD
 ` + "`CERBERUS_SOLVER_TIMEOUT`" + `) is likewise resolved by ` + "`internal/solver`" + ` and is
 documented in [` + "`solver.md`" + `](solver.md).
 
+Five further resource-bound safety ceilings (issue #2667) are resolved by
+` + "`internal/chsql`" + ` and ` + "`internal/promql`" + ` rather than by the loader
+documented above - those two packages may not import ` + "`internal/config`" + `
+(` + "`.go-arch-lint.yml`" + `), so each owns a small, self-contained env-parsing file
+instead (` + "`internal/engine/resource_bound_env.go`" + `,
+` + "`internal/promql/resource_bounds_env.go`" + `):
+
+- **` + "`CERBERUS_CH_RANGE_BUCKET_FANOUT_MAX_ROWS`" + `** (int64, default ` + "`4000000`" + `) -
+  RangeBucketFanout's collapse GROUP BY row ceiling
+  (` + "`internal/chsql/lwr_fanout_bound.go`" + `, ` + "`maxRangeBucketFanoutRows`" + `).
+- **` + "`CERBERUS_CH_RANGE_LWR_FANOUT_MAX_ROWS`" + `** (int64, default ` + "`40000000`" + `) -
+  RangeLWR's collapse GROUP BY row ceiling (same file, ` + "`maxRangeLWRFanoutRows`" + `).
+- **` + "`CERBERUS_CH_RATE_WINDOW_FANOUT_MAX_ROWS`" + `** (int64, default ` + "`2800000`" + `) -
+  the windowed-array-extrapolated-matrix regroup GROUP BY row ceiling
+  (` + "`internal/chsql/rate_window_fanout_bound.go`" + `, ` + "`maxRateWindowFanoutRows`" + `).
+- **` + "`CERBERUS_PROMQL_HISTOGRAM_MERGE_MAX_COST_UNITS`" + `** (int64, default
+  ` + "`60000000`" + `) - the native-histogram across-series merge cost ceiling that
+  closed issue #2385 after 19 real production OOMs
+  (` + "`internal/promql/histogram_merge_bound.go`" + `, ` + "`maxHistogramMergeCostUnits`" + `).
+- **` + "`CERBERUS_PROMQL_CLASSIC_BUCKET_MERGE_MAX_COST_UNITS`" + `** (int64, default
+  ` + "`10000000`" + `) - the classic-histogram across-series bucket-merge cost ceiling
+  (` + "`internal/promql/classic_bucket_merge_bound.go`" + `,
+  ` + "`maxClassicBucketMergeCostUnits`" + `).
+
+All five reject a malformed or non-positive override at startup rather than
+silently falling back to the default or admitting every query; see each
+constant's own doc for the calibration its shipped default protects.
+
 ## Dependency matrix
 
 Most knobs are validated in isolation (unknown enum, out-of-range buffer,

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -425,6 +425,34 @@ The solver-tuning surface (`CERBERUS_EVAL_ROUTE`, `CERBERUS_SHARD_*`,
 `CERBERUS_SOLVER_TIMEOUT`) is likewise resolved by `internal/solver` and is
 documented in [`solver.md`](solver.md).
 
+Five further resource-bound safety ceilings (issue #2667) are resolved by
+`internal/chsql` and `internal/promql` rather than by the loader
+documented above - those two packages may not import `internal/config`
+(`.go-arch-lint.yml`), so each owns a small, self-contained env-parsing file
+instead (`internal/engine/resource_bound_env.go`,
+`internal/promql/resource_bounds_env.go`):
+
+- **`CERBERUS_CH_RANGE_BUCKET_FANOUT_MAX_ROWS`** (int64, default `4000000`) -
+  RangeBucketFanout's collapse GROUP BY row ceiling
+  (`internal/chsql/lwr_fanout_bound.go`, `maxRangeBucketFanoutRows`).
+- **`CERBERUS_CH_RANGE_LWR_FANOUT_MAX_ROWS`** (int64, default `40000000`) -
+  RangeLWR's collapse GROUP BY row ceiling (same file, `maxRangeLWRFanoutRows`).
+- **`CERBERUS_CH_RATE_WINDOW_FANOUT_MAX_ROWS`** (int64, default `2800000`) -
+  the windowed-array-extrapolated-matrix regroup GROUP BY row ceiling
+  (`internal/chsql/rate_window_fanout_bound.go`, `maxRateWindowFanoutRows`).
+- **`CERBERUS_PROMQL_HISTOGRAM_MERGE_MAX_COST_UNITS`** (int64, default
+  `60000000`) - the native-histogram across-series merge cost ceiling that
+  closed issue #2385 after 19 real production OOMs
+  (`internal/promql/histogram_merge_bound.go`, `maxHistogramMergeCostUnits`).
+- **`CERBERUS_PROMQL_CLASSIC_BUCKET_MERGE_MAX_COST_UNITS`** (int64, default
+  `10000000`) - the classic-histogram across-series bucket-merge cost ceiling
+  (`internal/promql/classic_bucket_merge_bound.go`,
+  `maxClassicBucketMergeCostUnits`).
+
+All five reject a malformed or non-positive override at startup rather than
+silently falling back to the default or admitting every query; see each
+constant's own doc for the calibration its shipped default protects.
+
 ## Dependency matrix
 
 Most knobs are validated in isolation (unknown enum, out-of-range buffer,


### PR DESCRIPTION
## Summary

Pre-1.17 release-ritual delta audit (docs/operations.md step 3) surfaced one
real finding: `#2668`'s 5 new operator-facing resource-bound env vars
(`CERBERUS_CH_RANGE_BUCKET_FANOUT_MAX_ROWS`, `CERBERUS_CH_RANGE_LWR_FANOUT_MAX_ROWS`,
`CERBERUS_CH_RATE_WINDOW_FANOUT_MAX_ROWS`, `CERBERUS_PROMQL_HISTOGRAM_MERGE_MAX_COST_UNITS`,
`CERBERUS_PROMQL_CLASSIC_BUCKET_MERGE_MAX_COST_UNITS`) were undocumented anywhere.

They're parsed by bespoke `internal/engine/resource_bound_env.go` /
`internal/promql/resource_bounds_env.go` files rather than through
`internal/config`'s viper loader — `internal/chsql` and `internal/promql`
can't import `internal/config` per `.go-arch-lint.yml`. That's also exactly
why the `config-docs` generator/gate never saw them: it only knows about
`internal/config`'s own `EnvDoc` registry.

## What changed

`cmd/cerberus/cmd_configdocs.go` — added a short paragraph to the generator's
static preamble/footer text listing all 5 vars with their default and a
one-line description, mirroring the existing schema-shape / solver-tuning
redirect blocks in the same section. Regenerated `docs/configuration.md` via
`go run ./cmd/cerberus config-docs -out docs/configuration.md` (the canonical
recipe — never hand-edit the generated file).

## Test plan

- [x] `go build ./cmd/cerberus/...`
- [x] `gofumpt -l` / `goimports -local` clean on the touched file
- [x] `go vet ./cmd/cerberus/...`
- [x] regenerated `docs/configuration.md` deterministically via the recipe
- [x] `markdownlint-cli2 docs/configuration.md` clean
