### PR TITLE
docs: document the solver-tuning env vars, fix two stale doc refs

### DIFF
--- a/cmd/cerberus/cmd_configdocs.go
+++ b/cmd/cerberus/cmd_configdocs.go
@@ -396,9 +396,30 @@ as everything else does (` + "`schema.metrics.gaugeTable`" + `, ` + "`schema.log
   keys (dotted form, e.g. ` + "`k8s.namespace.name`" + `) projected as Prometheus labels.
   Empty / unset promotes **every** resource key.
 
-The solver-tuning surface (` + "`CERBERUS_EVAL_ROUTE`" + `, ` + "`CERBERUS_SHARD_*`" + `,
-` + "`CERBERUS_SOLVER_TIMEOUT`" + `) is likewise resolved by ` + "`internal/solver`" + ` and is
-documented in [` + "`solver.md`" + `](solver.md).
+The solver-tuning surface is likewise resolved by ` + "`internal/solver`" + ` rather
+than the loader documented above (` + "`internal/solver/config_env.go`" + `).
+` + "`CERBERUS_EVAL_ROUTE`" + ` is the master switch (default ` + "`auto`" + `; see
+[` + "`operations.md`" + `](operations.md#sharded-pushdown-solver) for its three modes)
+and ` + "`CERBERUS_SOLVER_ADAPTIVE_ENABLED`" + ` / the route-memo knobs are covered in
+[` + "`solver.md`" + `](solver.md). The remaining seven tuning knobs default to
+` + "`DefaultConfig`" + `'s conservative values and are otherwise undocumented
+elsewhere, so they are enumerated here:
+
+- **` + "`CERBERUS_SHARD_MIN_FANOUT`" + `** (int, default ` + "`16`" + `) - the minimum
+  fan-out a plan must clear before the Planner even considers routing it.
+- **` + "`CERBERUS_SHARD_MIN_ANCHOR_PAIRS`" + `** (int, default ` + "`4000`" + `) - the
+  minimum anchor-pair count a plan must clear before routing.
+- **` + "`CERBERUS_SHARD_MAX_K`" + `** (int, default ` + "`8`" + `) - the hard ceiling on
+  how many shards a single request may be split into.
+- **` + "`CERBERUS_SHARD_MIN_ANCHORS_PER_SLICE`" + `** (int, default ` + "`16`" + `) - the
+  minimum anchors a slice must carry, so K never grows past what the anchor
+  set can meaningfully divide.
+- **` + "`CERBERUS_SHARD_PARALLEL`" + `** (int, default ` + "`3`" + `) - how many shards
+  execute concurrently per request.
+- **` + "`CERBERUS_SOLVER_TIMEOUT`" + `** (duration, default ` + "`60s`" + `) - the
+  per-request deadline for the whole route-B fan-out.
+- **` + "`CERBERUS_SHARD_MAX_OUTPUT_ROWS`" + `** (int64, default ` + "`2000000`" + `) -
+  the per-request output-row ceiling across all shards combined.
 
 Five further resource-bound safety ceilings (issue #2667) are resolved by
 ` + "`internal/chsql`" + ` and ` + "`internal/promql`" + ` rather than by the loader

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -421,9 +421,30 @@ as everything else does (`schema.metrics.gaugeTable`, `schema.logs.table`,
   keys (dotted form, e.g. `k8s.namespace.name`) projected as Prometheus labels.
   Empty / unset promotes **every** resource key.
 
-The solver-tuning surface (`CERBERUS_EVAL_ROUTE`, `CERBERUS_SHARD_*`,
-`CERBERUS_SOLVER_TIMEOUT`) is likewise resolved by `internal/solver` and is
-documented in [`solver.md`](solver.md).
+The solver-tuning surface is likewise resolved by `internal/solver` rather
+than the loader documented above (`internal/solver/config_env.go`).
+`CERBERUS_EVAL_ROUTE` is the master switch (default `auto`; see
+[`operations.md`](operations.md#sharded-pushdown-solver) for its three modes)
+and `CERBERUS_SOLVER_ADAPTIVE_ENABLED` / the route-memo knobs are covered in
+[`solver.md`](solver.md). The remaining seven tuning knobs default to
+`DefaultConfig`'s conservative values and are otherwise undocumented
+elsewhere, so they are enumerated here:
+
+- **`CERBERUS_SHARD_MIN_FANOUT`** (int, default `16`) - the minimum
+  fan-out a plan must clear before the Planner even considers routing it.
+- **`CERBERUS_SHARD_MIN_ANCHOR_PAIRS`** (int, default `4000`) - the
+  minimum anchor-pair count a plan must clear before routing.
+- **`CERBERUS_SHARD_MAX_K`** (int, default `8`) - the hard ceiling on
+  how many shards a single request may be split into.
+- **`CERBERUS_SHARD_MIN_ANCHORS_PER_SLICE`** (int, default `16`) - the
+  minimum anchors a slice must carry, so K never grows past what the anchor
+  set can meaningfully divide.
+- **`CERBERUS_SHARD_PARALLEL`** (int, default `3`) - how many shards
+  execute concurrently per request.
+- **`CERBERUS_SOLVER_TIMEOUT`** (duration, default `60s`) - the
+  per-request deadline for the whole route-B fan-out.
+- **`CERBERUS_SHARD_MAX_OUTPUT_ROWS`** (int64, default `2000000`) -
+  the per-request output-row ceiling across all shards combined.
 
 Five further resource-bound safety ceilings (issue #2667) are resolved by
 `internal/chsql` and `internal/promql` rather than by the loader

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -227,8 +227,10 @@ did (under `auto`) without changing the wire body.
 typed error (first-error-wins, cause-threaded), never a partial body. The
 solver re-emits and re-executes per request — it never caches.
 
-The remaining `CERBERUS_SHARD_*` / `CERBERUS_SOLVER_TIMEOUT` knobs in the
-table above tune the shard count, concurrency, per-request output cap, and
+The remaining `CERBERUS_SHARD_*` / `CERBERUS_SOLVER_TIMEOUT` knobs — enumerated
+with their defaults in
+[`configuration.md`](configuration.md#schema-overrides-and-prometheus-resource-labels) —
+tune the shard count, concurrency, per-request output cap, and
 per-shard memory apportionment; their defaults are deliberately conservative
 against over-routing (Grafana's auto-step makes `rate[5m] @ 15s` hit `F=20`,
 which must NOT route at the default thresholds unless the total expansion is
@@ -1696,8 +1698,8 @@ selection between them:
   `config-docs`, `pr-body`, `link-check`, `forbid-skip` (which subsumes the
   soft-assert / escape-hatch / feature-discipline / should-skip scans),
   `forbid-deferral`, `forbid-sql-raw` and `forbid-chplan-fn-literal` (both
-  steps of `forbid-skip`), `quickstart`, `probe`, `chart-validate`,
-  `coverage`, `property`, and `strict-scan`. It is small and fast by
+  steps of `forbid-skip`), `update-golden-guard`, `quickstart`, `probe`,
+  `chart-validate`, `coverage`, `property`, and `strict-scan`. It is small and fast by
   construction: build/correctness basics and the discipline scans, with the
   substrate smoke lanes and every other cost-dominating lane deferred to the
   release gate below.


### PR DESCRIPTION
## Summary

Two documentation gaps surfaced during the pre-1.17 release-ritual delta audit
(docs/operations.md step 3), same bug class as `#2672`:

1. **`internal/solver`'s 7 shard/timeout tuning knobs were undocumented
   anywhere.** They bypass `internal/config`'s loader for the same reason as
   issue #2667's chsql/promql bounds (`internal/solver` can't import
   `internal/config` per `.go-arch-lint.yml`), and `docs/operations.md`
   claimed they lived "in the table above" — no such table exists in that
   section, and `git blame` shows it never has since that line was written
   in 2026-06-13.
2. **`docs/operations.md`'s "Two-tier test fence" merge-gate list omitted
   `update-golden-guard`** — a real required branch-protection check, and
   already correctly listed in `docs/test-strategy.md`.

## What changed

- `cmd/cerberus/cmd_configdocs.go` — enumerates `CERBERUS_SHARD_MIN_FANOUT`,
  `CERBERUS_SHARD_MIN_ANCHOR_PAIRS`, `CERBERUS_SHARD_MAX_K`,
  `CERBERUS_SHARD_MIN_ANCHORS_PER_SLICE`, `CERBERUS_SHARD_PARALLEL`,
  `CERBERUS_SOLVER_TIMEOUT`, `CERBERUS_SHARD_MAX_OUTPUT_ROWS` with their real
  `DefaultConfig` defaults; regenerated `docs/configuration.md` via
  `go run ./cmd/cerberus config-docs -out docs/configuration.md`.
- `docs/operations.md` — points the shard-knob line at `configuration.md`
  instead of a nonexistent table, and adds `update-golden-guard` to the
  merge-gate list (verified against `gh api .../branches/main/protection`:
  all 17 real required contexts are now listed).

## Test plan

- [x] `go build ./cmd/cerberus/...`, `go vet ./cmd/cerberus/...`
- [x] `gofumpt -l` / `goimports -local` clean
- [x] regenerated `docs/configuration.md` deterministically (idempotent on
      a second run)
- [x] `lychee --offline --include-fragments` (the exact `link-check` CI
      invocation) clean on the touched docs and the whole tree
- [x] `markdownlint-cli2` clean
