### PR TITLE
chore(release): cerberus v1.17.0 / chart 0.15.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,22 @@ All notable changes to cerberus will be documented in this file. The format roug
 
 ## [Unreleased]
 
+## [v1.17.0] — 2026-08-27
+
+### Added
+
+- **chsql,promql:** make five more resource-bound safety ceilings configurable (#2668)
+
+### Fixed
+
+- **chaos:** recalibrate route-memo-activation's memory cap with real margin (#2669)
+- **chsql:** recalibrate RangeBucketGridNative's density axis against real production spill settings (#2666)
+
+### Documentation
+
+- document the solver-tuning env vars, fix two stale doc refs (#2673)
+- **config:** document issue #2667's 5 resource-bound env vars (#2672)
+
 ## [v1.16.1] — 2026-08-26
 
 ### Fixed

--- a/deploy/helm/cerberus/Chart.yaml
+++ b/deploy/helm/cerberus/Chart.yaml
@@ -8,11 +8,11 @@ type: application
 # upgrade?" and is the publish trigger: a chart-only fix bumps this without an
 # app re-tag; an app-only release bumps appVersion + a PATCH here for the new
 # default image. Starts 0.x because the values contract is not yet frozen.
-version: 0.15.6
+version: 0.15.7
 
 # appVersion tracks the GA cerberus binary. Quoted so SemVer-shaped values
 # aren't coerced to floats. image.tag defaults from this when left empty.
-appVersion: "1.16.1"
+appVersion: "1.17.0"
 
 # autoscaling/v2 + policy/v1 (PDB) + networking/v1 (Ingress) are all GA from
 # 1.21+; 1.23 is the conservative floor matching the manifests this chart
@@ -45,21 +45,13 @@ annotations:
       url: https://github.com/tsouza/cerberus/blob/main/docs/operations.md
   artifacthub.io/images: |
     - name: cerberus
-      image: ghcr.io/tsouza/cerberus:v1.16.1
+      image: ghcr.io/tsouza/cerberus:v1.17.0
   # Bump the `1.0.0` floor here when the chart raises its minimum supported
   # cerberus release; informational for Artifact Hub's compatibility hints.
   artifacthub.io/changes: |
+    - kind: added
+      description: "chsql,promql: make five more resource-bound safety ceilings configurable (#2668)"
     - kind: fixed
-      description: "chaos: widen route-memo-activation's detection deadline to 180s (#2660)"
+      description: "chaos: recalibrate route-memo-activation's memory cap with real margin (#2669)"
     - kind: fixed
-      description: "chaos: fix route-memo probe metric description and gate the decline dump (#2659)"
-    - kind: fixed
-      description: "routememo: give the chaos lane's route-memo-activation scenario real historical depth (#2658)"
-    - kind: fixed
-      description: "routememo: keep the chaos lane's pinned query off route B's ordinary auto-route (#2656)"
-    - kind: fixed
-      description: "deltaprefix: detect and warn on backfill days already past the aggregate table's TTL (#2657)"
-    - kind: fixed
-      description: "chsql: give RangeBucketGridNative's resource bound real production headroom (#2653)"
-    - kind: fixed
-      description: "e2e: narrow the chaos lane's CH memory cap so route-memo-activation fires (#2649)"
+      description: "chsql: recalibrate RangeBucketGridNative's density axis against real production spill settings (#2666)"

--- a/deploy/helm/cerberus/README.md
+++ b/deploy/helm/cerberus/README.md
@@ -5,7 +5,7 @@
      pipe-aligned, and the version footer adds a trailing blank — both are
      owned by helm-docs; realigning would fight the chart-ci drift check. -->
 
-![Version: 0.15.6](https://img.shields.io/badge/Version-0.15.6-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.16.1](https://img.shields.io/badge/AppVersion-1.16.1-informational?style=flat-square)
+![Version: 0.15.7](https://img.shields.io/badge/Version-0.15.7-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.17.0](https://img.shields.io/badge/AppVersion-1.17.0-informational?style=flat-square)
 
 Drop-in Prometheus / Loki / Tempo HTTP gateway for ClickHouse — a single stateless gateway that speaks three upstream query wire formats and lowers each to parameterised ClickHouse SQL.
 


### PR DESCRIPTION
Release-prep for **v1.17.0** (chart **0.15.7**), generated by `prepare-release.yml`.

- appVersion 1.16.1 -> 1.17.0, chart 0.15.6 -> 0.15.7

### Changes

### Added

- **chsql,promql:** make five more resource-bound safety ceilings configurable (#2668)

### Fixed

- **chaos:** recalibrate route-memo-activation's memory cap with real margin (#2669)
- **chsql:** recalibrate RangeBucketGridNative's density axis against real production spill settings (#2666)

### Documentation

- document the solver-tuning env vars, fix two stale doc refs (#2673)
- **config:** document issue #2667's 5 resource-bound env vars (#2672)

Generated from the conventional commits since the last tag. Review and edit before merging; the tag is cut once this lands.
