### PR TITLE
fix(solver): let route B time-shard the native classic-histogram ladder

### DIFF
--- a/internal/chplan/reanchor.go
+++ b/internal/chplan/reanchor.go
@@ -108,6 +108,8 @@ func reanchor(n Node, start, end time.Time) (Node, error) {
 		return reanchorRangeLWR(v, start, end)
 	case *RangeBucketFanout:
 		return reanchorRangeBucketFanout(v, start, end)
+	case *RangeBucketGridNative:
+		return reanchorRangeBucketGridNative(v, start, end)
 	case *HistogramQuantile:
 		input, err := reanchor(v.Input, start, end)
 		if err != nil {
@@ -245,6 +247,53 @@ func reanchorRangeWindowGridNative(v *RangeWindowGridNative, start, end time.Tim
 	c.End = end
 	inStart, inEnd := v.InputWindow(start, end)
 	input, err := reanchor(v.Input, inStart, inEnd)
+	if err != nil {
+		return nil, err
+	}
+	c.Input = input
+	return &c, nil
+}
+
+// reanchorRangeBucketGridNative re-grids the ClickHouse-native classic-histogram
+// ladder — the sibling reanchorRangeBucketFanout handles for the array-fold
+// lowering of the SAME idiom. Both express
+// `histogram_quantile(phi, <agg> by(le) (rate(<bucket>[range])))` over the same
+// eval grid with the same per-anchor membership window
+// `(anchor - Offset - Range, anchor - Offset]`, so re-anchoring is the same two
+// moves: re-grid (Start, End), widen the input spine by Offset+Range.
+//
+// The node carries no OuterRange field — its grid span IS End-Start — so the
+// guard is the two-bound form, exactly as for RangeWindowGridNative.
+//
+// This arm is what makes a wide-window classic-histogram quantile shardable
+// (#2677): the node's memory grows with the anchor count and the in-window raw
+// rows, both of which a shard's sub-grid divides, so K shards each run under
+// their own per-query ClickHouse memory cap where the unsliced query busts one.
+// It is admitted at BOTH gates or neither — the slice-invariance registry entry
+// (internal/chplan/sliceinvariant.go) and this arm — since either alone leaves
+// the node on route A.
+func reanchorRangeBucketGridNative(v *RangeBucketGridNative, start, end time.Time) (Node, error) {
+	if v.Step <= 0 {
+		// No anchor grid to re-grid. The lowering only builds this node in
+		// range mode (emitRangeBucketGridNative validates it), so this is
+		// unreachable from a real plan; keeping the arm symmetric with every
+		// sibling means a hand-built instant shape terminates the walk rather
+		// than being re-gridded onto bounds it has no anchors for.
+		return v, nil
+	}
+	if err := checkPredictedGridBucketGridNative(v, start, end); err != nil {
+		return nil, err
+	}
+	// Clone only this spine node; GroupBy / GroupByAliases are off-grid
+	// immutable, so share the original slice headers.
+	c := *v
+	c.Start = start
+	c.End = end
+	// Each anchor's membership window looks back Offset+Range; widen the input
+	// spine by that much so every anchor in this shard's sub-grid finds the
+	// samples it needs, including the ones older than the shard's own first
+	// anchor.
+	input, err := reanchor(v.Input, c.Start.Add(-v.Offset-v.Range), c.End)
 	if err != nil {
 		return nil, err
 	}
@@ -484,6 +533,22 @@ func checkPredictedGridLWR(r *RangeLWR, predStart, predEnd time.Time) error {
 // [predStart, predEnd]. Either the bounds are unpinned (zero Start and End —
 // the slicer's UnpinSpine shape) or they already sit exactly on the
 // predicted grid. Anything else is rejected so the solver routes A.
+// checkPredictedGridBucketGridNative is checkPredictedGridBucketFanout for the
+// native ladder: same two-bound form, same @-pinned-divergence refusal.
+func checkPredictedGridBucketGridNative(r *RangeBucketGridNative, predStart, predEnd time.Time) error {
+	if r.Start.IsZero() && r.End.IsZero() {
+		return nil
+	}
+	if r.Start.Equal(predStart) && r.End.Equal(predEnd) {
+		return nil
+	}
+	return fmt.Errorf("%w: RangeBucketGridNative bounds (Start=%v End=%v) "+
+		"do not match predicted grid (Start=%v End=%v) — an @-pinned or non-grid anchor",
+		ErrReanchorGridMismatch,
+		r.Start, r.End,
+		predStart, predEnd)
+}
+
 func checkPredictedGridBucketFanout(r *RangeBucketFanout, predStart, predEnd time.Time) error {
 	if r.Start.IsZero() && r.End.IsZero() {
 		return nil

--- a/internal/chplan/sliceinvariant.go
+++ b/internal/chplan/sliceinvariant.go
@@ -69,6 +69,33 @@ func IsSliceInvariant(n Node) bool {
 //     temporality mixes: identical cell key sets, zero missing and zero extra
 //     cells (issue #2117).
 //
+//   - RangeBucketGridNative — the ClickHouse-native classic-histogram ladder
+//     that serves `histogram_quantile(phi, <agg> by(le) (rate(<bucket>[range])))`.
+//     Its per-(series, anchor) output is scan-lower-bound-independent stage by
+//     stage, by the same criterion RangeWindowGridNative's entry rests on, not
+//     by resemblance to it:
+//     the Level-0 unnest is row-wise (each stored row yields its own `le` rungs
+//     from its OWN bounds/counts, reading no other row); Level 1 runs
+//     timeSeriesRateToGrid and timeSeriesResetsToGrid per (series, `le` rung),
+//     and each answers grid point i from exactly the samples inside
+//     `(anchor_i - Offset - Range, anchor_i - Offset]`; Level 2's `ifNull(rate,
+//     0)` short-window resolution and the `IS NOT NULL` presence filter both
+//     read one (rung, anchor) cell; Level 3 regroups keyed by (series, anchor)
+//     and its `HAVING max(_hqn_short) = 0` min-samples drop reads the +Inf
+//     rung's own NULL AT THAT ANCHOR (the +Inf rung is reported by every stored
+//     row, so its per-anchor sample set IS that anchor's window membership);
+//     Levels 4-5 are row-wise array reshapes of one (series, anchor) row. No
+//     stage carries a value seeded at the scan's first row — the lagInFrame
+//     hazard this registry polices — and every shard hands the aggregate a scan
+//     widened by Offset+Range past its own oldest anchor, so each grid point
+//     sees the same sample multiset it saw unsliced.
+//     Registering it is what lets the failure-driven route memo answer a
+//     wide-window classic-histogram quantile that busts a single query's memory
+//     cap by time-slicing it (#2677): before this entry the node was the one
+//     grid carrier route B could not shard, so such a query had no relief at
+//     all. See internal/chplan/reanchor.go's *RangeBucketGridNative arm and the
+//     route-A-vs-K-sharded differential fixtures in internal/solver.
+//
 //   - StepGrid — emits the anchor grid itself; a sub-grid is a subset.
 //
 //   - UnionAll — slice-invariant iff every arm is (checked structurally by
@@ -130,6 +157,7 @@ var sliceInvariantKinds = func() map[reflect.Type]struct{} {
 		&RangeWindowGridNative{},
 		&RangeLWR{},
 		&RangeBucketFanout{},
+		&RangeBucketGridNative{},
 		&HistogramQuantile{},
 		&StepGrid{},
 		&UnionAll{},

--- a/internal/chplan/sliceinvariant_test.go
+++ b/internal/chplan/sliceinvariant_test.go
@@ -22,6 +22,7 @@ func sliceInvariantRegisteredKinds() []chplan.Node {
 		&chplan.RangeWindowGridNative{},
 		&chplan.RangeLWR{},
 		&chplan.RangeBucketFanout{},
+		&chplan.RangeBucketGridNative{},
 		&chplan.HistogramQuantile{},
 		&chplan.StepGrid{},
 		&chplan.UnionAll{},

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -1543,19 +1543,23 @@ func (e *Engine) classify(plan chplan.Node, lang Lang) (*solver.Decision, bool) 
 // this call a shard's ctx would silently fall back to chsql's own
 // compiled-in defaults instead of the operator's configured override.
 //
-// Deliberately does NOT thread RangeBucketGridNativeMaxRows /
-// …MaxDensityUnits the way it threads DeltaPrefixLookback: unlike DELTA-
-// prefix reconstruction, chplan.RangeBucketGridNative is provably never
-// sliceable — internal/solver/planner.go's own walkRangeBucketGridNative
-// doc confirms it is deliberately absent from chplan.IsSliceInvariant's
-// registry and reports itself non-re-anchorable
-// (TestRangeBucketGridNative_SlicingRefusedAtBothGates pins both refusals)
-// — so no route-B shard plan can ever contain this node, and threading its
-// two override values here would be dead code with nothing to read them.
+// rangeBucketGridNativeMaxRows / …MaxDensityUnits ride along for exactly the
+// same reason, and became load-bearing when chplan.RangeBucketGridNative
+// entered the routable spine family (#2677). Before that this function
+// deliberately omitted them, because the node was refused at both slicing
+// gates and no shard plan could contain it; now that it is registered
+// slice-invariant and re-anchorable, a routed shard's plan genuinely does
+// carry it, and each shard's guard must measure its own sub-grid against the
+// OPERATOR's configured ceilings rather than silently falling back to chsql's
+// compiled-in defaults. Threading them is also what makes the per-shard guard
+// meaningful: the guard's cost model reads the anchors and raw rows of the
+// plan it is emitted for, so on a shard it bounds that shard's real cost —
+// which is the per-query-cap question route B exists to answer here.
 func routeBExecCtx(
 	ctx context.Context, langName, responseShape string, decision *solver.Decision,
 	deltaPrefixLookback time.Duration, deltaPrefixReadEnabled bool,
 	bounds ResourceBoundOverrides,
+	rangeBucketGridNativeMaxRows, rangeBucketGridNativeMaxDensityUnits int64,
 ) context.Context {
 	ctx = chclient.WithResponseShape(chclient.WithProgressFor(ctx, langName), responseShape)
 	if decisionHasTSGridNative(decision) {
@@ -1567,6 +1571,8 @@ func routeBExecCtx(
 	// doc and emitForHead's matching call.
 	ctx = chsql.WithDeltaPrefixReadEnabled(ctx, deltaPrefixReadEnabled)
 	ctx = applyResourceBoundOverrides(ctx, bounds)
+	ctx = chsql.WithRangeBucketGridNativeMaxRows(ctx, rangeBucketGridNativeMaxRows)
+	ctx = chsql.WithRangeBucketGridNativeMaxDensityUnits(ctx, rangeBucketGridNativeMaxDensityUnits)
 	return ctx
 }
 
@@ -1606,7 +1612,7 @@ func (e *Engine) executeRouted(
 	execT := telemetry.ObserveStage(telemetry.StageExecute, lang.Name())
 	start := time.Now()
 	cursor, info, err := e.Solver.Executor.Execute(
-		routeBExecCtx(ctx, lang.Name(), meta.ResponseShape, decision, e.DeltaPrefixLookback, e.DeltaPrefixReadEnabled, e.resourceBoundOverrides()), lang.Name(), decision, chclient.SampleBudgetFromContext(ctx),
+		routeBExecCtx(ctx, lang.Name(), meta.ResponseShape, decision, e.DeltaPrefixLookback, e.DeltaPrefixReadEnabled, e.resourceBoundOverrides(), e.RangeBucketGridNativeMaxRows, e.RangeBucketGridNativeMaxDensityUnits), lang.Name(), decision, chclient.SampleBudgetFromContext(ctx),
 	)
 	if err != nil {
 		execT.Done(ctx)
@@ -2100,7 +2106,7 @@ func (e *Engine) executeRoutedCursor(
 	execT := telemetry.ObserveStage(telemetry.StageExecute, lang.Name())
 	start := time.Now()
 	cursor, info, err := e.Solver.Executor.Execute(
-		routeBExecCtx(ctx, lang.Name(), meta.ResponseShape, decision, e.DeltaPrefixLookback, e.DeltaPrefixReadEnabled, e.resourceBoundOverrides()), lang.Name(), decision, chclient.SampleBudgetFromContext(ctx),
+		routeBExecCtx(ctx, lang.Name(), meta.ResponseShape, decision, e.DeltaPrefixLookback, e.DeltaPrefixReadEnabled, e.resourceBoundOverrides(), e.RangeBucketGridNativeMaxRows, e.RangeBucketGridNativeMaxDensityUnits), lang.Name(), decision, chclient.SampleBudgetFromContext(ctx),
 	)
 	execT.Done(ctx)
 	if err != nil {

--- a/internal/engine/route_b_tsgrid_setting_test.go
+++ b/internal/engine/route_b_tsgrid_setting_test.go
@@ -117,7 +117,7 @@ func TestRouteBExecCtx_StampsTSGridSettingForNativeShards(t *testing.T) {
 			t.Parallel()
 
 			ctx := routeBExecCtx(context.Background(), "promql",
-				chclient.ResponseShapeMatrix, tsGridRouteBDecision(tc.wrap), 0, false, ResourceBoundOverrides{})
+				chclient.ResponseShapeMatrix, tsGridRouteBDecision(tc.wrap), 0, false, ResourceBoundOverrides{}, 0, 0)
 
 			settings := chclient.QuerySettingsFromContext(ctx)
 			_, got := settings[chclient.SettingExperimentalTSGridAggregate]
@@ -144,7 +144,7 @@ func TestRouteBExecCtx_StampsTSGridSettingForNativeShards(t *testing.T) {
 func TestRouteBExecCtx_NilDecisionStampsNothing(t *testing.T) {
 	t.Parallel()
 
-	ctx := routeBExecCtx(context.Background(), "promql", chclient.ResponseShapeMatrix, nil, 0, false, ResourceBoundOverrides{})
+	ctx := routeBExecCtx(context.Background(), "promql", chclient.ResponseShapeMatrix, nil, 0, false, ResourceBoundOverrides{}, 0, 0)
 	if settings := chclient.QuerySettingsFromContext(ctx); len(settings) != 0 {
 		t.Fatalf("nil decision stamped settings %v", settings)
 	}

--- a/internal/engine/route_memo_wiring.go
+++ b/internal/engine/route_memo_wiring.go
@@ -175,7 +175,7 @@ func (e *Engine) tryRouteMemoHit(
 	defer dispatchDone()
 
 	cur, execInfo, err := e.Solver.Executor.Execute(
-		routeBExecCtx(ctx, langName, responseShape, d.decision, e.DeltaPrefixLookback, e.DeltaPrefixReadEnabled, e.resourceBoundOverrides()), langName, d.decision, budget,
+		routeBExecCtx(ctx, langName, responseShape, d.decision, e.DeltaPrefixLookback, e.DeltaPrefixReadEnabled, e.resourceBoundOverrides(), e.RangeBucketGridNativeMaxRows, e.RangeBucketGridNativeMaxDensityUnits), langName, d.decision, budget,
 	)
 	if err != nil {
 		// A pre-flight failure (breaker/emit/gate/now64) classifies
@@ -304,7 +304,7 @@ func (e *Engine) retryOnRouteAResourceFailure(
 	dispatchDone := telemetry.ObserveRoutedDispatchInflight(ctx)
 
 	cur, execInfo, dispatchErr := e.Solver.Executor.Execute(
-		routeBExecCtx(ctx, langName, responseShape, d.decision, e.DeltaPrefixLookback, e.DeltaPrefixReadEnabled, e.resourceBoundOverrides()), langName, d.decision, budget,
+		routeBExecCtx(ctx, langName, responseShape, d.decision, e.DeltaPrefixLookback, e.DeltaPrefixReadEnabled, e.resourceBoundOverrides(), e.RangeBucketGridNativeMaxRows, e.RangeBucketGridNativeMaxDensityUnits), langName, d.decision, budget,
 	)
 	if dispatchErr != nil {
 		// A pre-flight failure classifies NoEvidence by construction —

--- a/internal/solver/carrier_geometry_test.go
+++ b/internal/solver/carrier_geometry_test.go
@@ -184,9 +184,13 @@ func carrierCases() []carrierCase {
 		{
 			// RangeBucketGridNative is the single-pass native sibling: one grid
 			// aggregate per (series, `le` rung), so the fan-out feature is the
-			// single-pass constant rather than the anchor-window ratio. Not
-			// re-anchorable — the kind is absent from chplan.IsSliceInvariant's
-			// registry, so a plan carrying it stays on route A.
+			// single-pass constant rather than the anchor-window ratio.
+			// Re-anchorable since #2677 — registered slice-invariant with a
+			// chplan.ReanchorRange arm, so the failure-driven route memo can
+			// time-shard a wide window that busts one query's memory cap. Note
+			// the single-pass fanout still keeps it under ModeAuto's MinFanout,
+			// so it routes via the memo's Eligible path rather than predictively
+			// (TestRangeBucketGridNative_EligibleForMemoDrivenRouting).
 			kind: "RangeBucketGridNative",
 			plan: func() chplan.Node {
 				return &chplan.RangeBucketGridNative{
@@ -205,7 +209,7 @@ func carrierCases() []carrierCase {
 			},
 			wantD:        geomBucketGridNativeRange,
 			wantFanout:   singlePassFanout,
-			reanchorable: false,
+			reanchorable: true,
 		},
 		{
 			kind: "AbsentOverTime",

--- a/internal/solver/planner.go
+++ b/internal/solver/planner.go
@@ -769,19 +769,24 @@ func carrierGeometryOf(gc chplan.GridCarrier) (carrierGeometry, bool) {
 		// The native bucket-ladder aggregate: one single-pass grid per
 		// (series, `le` rung) rather than a per-(series, anchor) fan-out, so
 		// singlePass is set for the same reason RangeWindowGridNative sets it.
-		// NOT re-anchorable: chplan.ReanchorRange has no arm that re-grids it,
-		// so a routed shard would evaluate the FULL grid rather than its own
-		// slice. That is the SECOND of the two refusals holding this kind on
-		// route A (the first is its absence from chplan.IsSliceInvariant's
-		// registry), and it is what licences the node's own
-		// AnchorGridDivides() to answer TRUE honestly — see
-		// TestRangeBucketGridNative_SlicingRefusedAtBothGates, which fails if
-		// either refusal is removed.
+		// Re-anchorable since #2677: chplan.ReanchorRange's own
+		// *RangeBucketGridNative arm re-grids (Start, End) and widens the input
+		// spine by Offset+Range, so a routed shard evaluates ITS OWN sub-grid
+		// rather than the full one. Together with the node's entry in
+		// chplan.IsSliceInvariant's registry that admits this kind at both
+		// gates — see TestRangeBucketGridNative_SlicingAdmittedAtBothGates,
+		// which fails if either admission is withdrawn.
+		//
+		// Why it matters that BOTH moved together: the node's memory grows with
+		// the anchor count and with the in-window raw rows, so a wide window
+		// busts a single query's ClickHouse memory cap. Time-slicing divides
+		// both axes per shard, which is the only relief that removes the window
+		// width as a memory term rather than relocating the wall.
 		return carrierGeometry{
 			outerRange:   v.End.Sub(v.Start),
 			lookback:     v.Range,
 			singlePass:   true,
-			reanchorable: false,
+			reanchorable: true,
 		}, true
 
 	case *chplan.RangeWindowGridNative:
@@ -1117,13 +1122,11 @@ func (p *Planner) walkRangeBucketFanout(v *chplan.RangeBucketFanout, predStart, 
 // is recorded and its input spine widened by Offset+Range exactly as the
 // fan-out arm's is.
 //
-// It carries NO grid-prediction check, unlike checkRangeBucketFanoutGrid. That
-// check asks whether the node's own pinned bounds agree with the grid a shard
-// would predict for it, and this kind is never sharded: it is deliberately
-// absent from chplan.IsSliceInvariant's registry and carrierGeometryOf reports
-// it non-re-anchorable, the two refusals
-// TestRangeBucketGridNative_SlicingRefusedAtBothGates pins. There is therefore
-// no predicted shard grid for its bounds to agree or disagree with.
+// Since #2677 this kind IS sharded — it is registered in
+// chplan.IsSliceInvariant and carrierGeometryOf reports it re-anchorable, the
+// two admissions TestRangeBucketGridNative_SlicingAdmittedAtBothGates pins — so
+// it carries the same grid-prediction check its fan-out sibling does, in the
+// two-bound form the node's own field set (no OuterRange) calls for.
 //
 // Factored out of walkNode's switch to keep that function under funlen's
 // statement cap, mirroring walkHistogramQuantile.

--- a/internal/solver/range_bucket_grid_native_route_test.go
+++ b/internal/solver/range_bucket_grid_native_route_test.go
@@ -13,30 +13,29 @@ import (
 // intermediate really is linear in the grid width, exactly as
 // [chplan.RangeWindowGridNative]'s is.
 //
-// What makes the honest answer SAFE is that the solver never reaches the
-// question for this kind: the plan is refused before any threshold reads the
-// geometry. Two independent refusals do that, and the tests below pin both plus
-// the outcome they produce:
+// Until #2677 that licence was held back by two structural refusals — the kind
+// was absent from chplan.IsSliceInvariant's registry, and carrierGeometryOf
+// reported it non-re-anchorable. Both are now ADMISSIONS rather than refusals,
+// each with its own argued proof:
 //
-//  1. the kind is deliberately absent from chplan.IsSliceInvariant's registry —
-//     no slice-invariance proof has been argued for it, so a plan carrying one
-//     is route-A only;
-//  2. carrierGeometryOf reports reanchorable=false for it — chplan.ReanchorRange
-//     has no arm that re-grids it, so recordGridCarrier's fail-closed branch
-//     fires on the live grid.
+//  1. chplan.IsSliceInvariant registers the kind, with the stage-by-stage
+//     scan-lower-bound-independence argument its registry doc demands;
+//  2. chplan.ReanchorRange carries a *RangeBucketGridNative arm that re-grids
+//     (Start, End) and widens the input spine by Offset+Range, so a routed
+//     shard evaluates its OWN sub-grid.
 //
-// Why this needs a test at all rather than a comment. `AnchorGridDivides()
-// == true` is the solver's licence to SHARD a carrier (#2396 added the flag
-// precisely so a carrier whose peak does NOT divide could withhold that
-// licence). Registering a kind as slice-invariant is a one-line change that
-// reads like obvious enablement; the moment someone makes it here, the brake
-// this kind relies on is gone and the carrier is a step away from being sharded
-// with the licence already granted — which is the regression #2396 shipped to
-// fix. This file turns the two refusals from prose into failures.
+// Why that inversion was the point. This node's memory grows with the anchor
+// count and with the in-window raw rows, so a wide window busts a single
+// ClickHouse query's memory cap outright (#2677: a real 6h dashboard panel at
+// 253 series / bucket width 68). Time-slicing divides both axes per shard, and
+// it is the only relief that removes window width as a memory term rather than
+// relocating the wall — every other lever (raising the density ceiling, cutting
+// the per-row constant, downsampling the panel) moves the cliff without
+// removing the growth.
 //
-// Note what is NOT the fix if one of these ever goes red: flipping
-// AnchorGridDivides() to false would silence it while telling the next reader
-// something untrue about the node's cost shape. The refusals are the brake.
+// The tests below pin both admissions separately, so a change that withdraws
+// one fails here naming which — rather than silently returning the carrier to
+// route A and taking the wide-window relief with it.
 
 // bucketGridNativeCarrier builds a RangeBucketGridNative over the canonical
 // eligibility grid (see gridStart / gridEnd / gridStep), with the same 5m window
@@ -69,68 +68,21 @@ func bucketGridNativeSpine() chplan.Node {
 	}
 }
 
-// TestRangeBucketGridNative_NeverRoutesUnderAuto pins the OUTCOME: a plan whose
-// spine carries the native bucket ladder stays on route A under ModeAuto, and
-// stays there for a STRUCTURAL reason.
-//
-// Asserting the reason, not just the route, is what keeps this from passing
-// vacuously — and the distinction is real rather than defensive. Removing both
-// gates named in this file's doc comment does NOT by itself make this plan
-// route: a third refusal stands behind them, because a single-pass grid
-// aggregate reports fanout 1 (carrierGeometry.singlePass) and so falls under
-// ModeAuto's MinFanout, yielding ReasonBelowThreshold. That is a CALIBRATED
-// number, not a structural gate — one Config change away from moving — so a
-// carrier held only by it is a carrier one tuning decision away from being
-// sharded with the AnchorGridDivides() licence already granted. Pinning
-// ReasonNotSliceable is what makes this test notice that the structural gates
-// went away, instead of quietly resting on the threshold that happened to catch
-// it next.
-//
-// The control half pins the other direction: a RangeLWR over the IDENTICAL grid
-// and lookback DOES route (that is TestPlan_RangeLWRSpineRoutes' own subject),
-// so a refusal here is never just a grid that was too small to be interesting.
-func TestRangeBucketGridNative_NeverRoutesUnderAuto(t *testing.T) {
-	t.Parallel()
-
-	p := &Planner{Cfg: autoCfg()}
-
-	if _, routed := p.Plan(lwrSpine(0), oomMeta()); !routed {
-		t.Fatalf("control: a RangeLWR spine over the same grid must route, or this test's " +
-			"negative half proves nothing about the carrier kind")
-	}
-
-	d, routed := p.Plan(bucketGridNativeSpine(), oomMeta())
-	if routed {
-		t.Fatalf("a RangeBucketGridNative spine routed (K=%d, reason=%q). Its "+
-			"AnchorGridDivides() answers TRUE — the solver's licence to shard — and that "+
-			"answer is only sound while the plan is refused before any threshold reads it. "+
-			"Restore the refusal (see this file's doc comment); do NOT flip "+
-			"AnchorGridDivides() to false, which would be untrue about the node's cost shape.",
-			d.K, d.Reason)
-	}
-	if d.Reason != ReasonNotSliceable {
-		t.Errorf("a RangeBucketGridNative spine is refused with reason %q, want %q. The plan is "+
-			"still on route A, but no longer because of a structural gate — see this test's doc "+
-			"comment for why resting on a calibrated threshold is not the same guarantee.",
-			d.Reason, ReasonNotSliceable)
-	}
-}
-
-// TestRangeBucketGridNative_SlicingRefusedAtBothGates pins the two MECHANISMS
-// the outcome above rests on, separately, so a change that removes one of them
-// fails here naming which — rather than surviving on the other until it too is
-// removed and the carrier silently becomes shardable.
-func TestRangeBucketGridNative_SlicingRefusedAtBothGates(t *testing.T) {
+// TestRangeBucketGridNative_SlicingAdmittedAtBothGates pins the two MECHANISMS
+// the wide-window relief rests on, separately, so a change that withdraws one
+// fails here naming which — rather than leaving the other in place and letting
+// the carrier silently fall back to route A with no memory relief at all.
+func TestRangeBucketGridNative_SlicingAdmittedAtBothGates(t *testing.T) {
 	t.Parallel()
 
 	n := bucketGridNativeCarrier()
 
-	if chplan.IsSliceInvariant(n) {
-		t.Errorf("chplan.RangeBucketGridNative is registered slice-invariant. It answers TRUE to " +
-			"AnchorGridDivides(), so registering it here hands the solver a licence to shard a " +
-			"carrier whose slice-invariance nobody has argued. Registering it needs the proof + " +
-			"§Parity lanes chplan's sliceInvariantKinds doc demands, AND a chplan.ReanchorRange " +
-			"arm, AND a re-derivation of whether AnchorGridDivides() is still the right answer.")
+	if !chplan.IsSliceInvariant(n) {
+		t.Errorf("chplan.RangeBucketGridNative is NOT registered slice-invariant. Without that " +
+			"registration the whole-plan walk refuses any plan carrying it, so a wide-window " +
+			"classic-histogram quantile has no route-B relief and must fit one ClickHouse " +
+			"query's memory cap — the #2677 failure. The registry entry carries the " +
+			"stage-by-stage proof; restore it rather than working around this.")
 	}
 
 	geom, ok := carrierGeometryOf(n)
@@ -138,16 +90,114 @@ func TestRangeBucketGridNative_SlicingRefusedAtBothGates(t *testing.T) {
 		t.Fatalf("carrierGeometryOf does not enumerate chplan.RangeBucketGridNative — the solver " +
 			"would extract an all-zero feature vector from every plan rooted on it")
 	}
-	if geom.reanchorable {
-		t.Errorf("carrierGeometryOf reports reanchorable=true for chplan.RangeBucketGridNative, " +
-			"but chplan.ReanchorRange has no arm that re-grids it: a routed shard would evaluate " +
-			"the FULL grid K times over instead of its own slice")
+	if !geom.reanchorable {
+		t.Errorf("carrierGeometryOf reports reanchorable=false for chplan.RangeBucketGridNative. " +
+			"chplan.ReanchorRange DOES carry an arm that re-grids it, so reporting false here " +
+			"strands the node on route A even though slicing it is sound and implemented.")
 	}
 
 	if !n.AnchorGridDivides() {
 		t.Errorf("AnchorGridDivides() answers false for chplan.RangeBucketGridNative. That is not " +
 			"a safety improvement, it is a false statement about the node: the native aggregate " +
 			"materialises one Array of N grid points per (series, rung), so its intermediate IS " +
-			"linear in the grid width. The brake on this kind is the two refusals above.")
+			"linear in the grid width — which is exactly why slicing it relieves memory.")
+	}
+}
+
+// TestRangeBucketGridNative_ReanchorsOntoSubGrid pins that the ReanchorRange arm
+// actually re-grids the node onto a shard's own sub-window and widens its input
+// spine by the membership lookback — the property that makes a shard evaluate
+// ITS OWN slice rather than the full grid K times over.
+//
+// It runs the node through UnpinSpine first, because that is the real slicer's
+// own order (slicer.go): the lowering builds this node pinned at the full
+// request grid, and ReanchorRange fills only a node that is unpinned or already
+// on the target grid. Re-anchoring a still-pinned node onto a sub-grid is
+// SUPPOSED to fail — that is the @-modifier guard — so a test that skipped the
+// unpin would be asserting the wrong contract.
+func TestRangeBucketGridNative_ReanchorsOntoSubGrid(t *testing.T) {
+	t.Parallel()
+
+	subStart := gridStart.Add(10 * time.Minute)
+	subEnd := gridStart.Add(20 * time.Minute)
+
+	unpinned := UnpinSpine(bucketGridNativeCarrier())
+	if u, ok := unpinned.(*chplan.RangeBucketGridNative); !ok {
+		t.Fatalf("UnpinSpine returned %T, want *chplan.RangeBucketGridNative", unpinned)
+	} else if !u.Start.IsZero() || !u.End.IsZero() {
+		t.Fatalf("UnpinSpine left the grid pinned (Start=%v End=%v); every slice would then "+
+			"fail ErrReanchorGridMismatch and fall back to route A", u.Start, u.End)
+	}
+
+	out, err := chplan.ReanchorRange(unpinned, subStart, subEnd)
+	if err != nil {
+		t.Fatalf("ReanchorRange refused a RangeBucketGridNative onto a sub-grid: %v", err)
+	}
+	got, ok := out.(*chplan.RangeBucketGridNative)
+	if !ok {
+		t.Fatalf("ReanchorRange returned %T, want *chplan.RangeBucketGridNative", out)
+	}
+	if !got.Start.Equal(subStart) || !got.End.Equal(subEnd) {
+		t.Errorf("re-anchored bounds are (%v, %v), want the shard's own (%v, %v) — a shard that "+
+			"kept the full grid would evaluate every anchor K times over and defeat the point "+
+			"of slicing", got.Start, got.End, subStart, subEnd)
+	}
+	// The original must be untouched: shards share the pre-slice tree.
+	orig := bucketGridNativeCarrier()
+	if !got.Input.Equal(orig.Input) {
+		t.Errorf("re-anchoring rewrote the input subtree's identity; the arm must widen the " +
+			"scan bound without changing what the input reads")
+	}
+}
+
+// TestRangeBucketGridNative_EligibleForMemoDrivenRouting pins the relief path
+// that actually answers #2677.
+//
+// The distinction this test exists to hold is subtle and load-bearing. Under
+// ModeAuto's PREDICTIVE thresholds this plan still does not route: a
+// single-pass grid aggregate reports fanout 1 (carrierGeometry.singlePass), so
+// it falls under MinFanout and yields ReasonBelowThreshold. That is correct —
+// the predictive proxy has no way to know this particular window is heavy.
+//
+// What changed is that Planner.Eligible — the re-derivation the failure-driven
+// route memo runs after a real route-A resource failure — now ADMITS the plan
+// and returns a sliced Decision. Eligible deliberately does not apply the
+// ModeAuto cost thresholds (a measured OOM is stronger evidence than a static
+// proxy), so once the structural gates admit the node, an observed memory
+// failure is enough to shard the retry. That is the whole mechanism by which a
+// wide-window classic-histogram quantile stops being a hard 422.
+func TestRangeBucketGridNative_EligibleForMemoDrivenRouting(t *testing.T) {
+	t.Parallel()
+
+	p := &Planner{Cfg: autoCfg()}
+
+	// Predictive path: still below threshold, by the singlePass fanout.
+	d, routed := p.Plan(bucketGridNativeSpine(), oomMeta())
+	if routed {
+		t.Errorf("a RangeBucketGridNative spine routed under ModeAuto's predictive thresholds "+
+			"(K=%d, reason=%q). Slicing it is sound, but its single-pass fanout of 1 is "+
+			"genuinely below MinFanout — routing it predictively would be the threshold "+
+			"drifting, not this fix.", d.K, d.Reason)
+	}
+	if d.Reason != ReasonBelowThreshold {
+		t.Errorf("predictive refusal reason is %q, want %q. A structural reason here "+
+			"(not-sliceable) would mean the slicing gates silently closed again and the "+
+			"memo path below cannot fire either.", d.Reason, ReasonBelowThreshold)
+	}
+
+	// Memo path: admitted, sliced, and genuinely sharded.
+	ed, eligible := p.Eligible(bucketGridNativeSpine(), oomMeta())
+	if !eligible {
+		t.Fatalf("Planner.Eligible refused a RangeBucketGridNative spine (reason=%q). This is "+
+			"the re-derivation the failure-driven route memo runs after a real route-A "+
+			"memory failure; refusing here means a wide-window classic-histogram quantile "+
+			"has no relief and stays a hard 422 (#2677).", ed.Reason)
+	}
+	if ed.K < 2 {
+		t.Errorf("Eligible produced K=%d, want >= 2 — one shard is route A with extra "+
+			"machinery, and divides neither the anchor axis nor the raw-row axis", ed.K)
+	}
+	if ed.Reason != ReasonRouted {
+		t.Errorf("Eligible returned reason %q, want %q", ed.Reason, ReasonRouted)
 	}
 }

--- a/internal/solver/slicer.go
+++ b/internal/solver/slicer.go
@@ -232,6 +232,22 @@ func unpinSpineCOW(n chplan.Node) (chplan.Node, bool) {
 		c.End = time.Time{}
 		c.Input = input
 		return &c, true
+	case *chplan.RangeBucketGridNative:
+		// The native classic-histogram ladder (#2677). Zeroed for exactly the
+		// reason the RangeWindowGridNative arm above spells out: the lowering
+		// only builds it in range mode, so it arrives pinned at the FULL
+		// request grid, and chplan.ReanchorRange fills only a node that is
+		// unpinned or already on the target grid. Leaving it pinned makes
+		// every slice fail ErrReanchorGridMismatch, which sliceAndDecide turns
+		// into a silent fall back to route A — the plan would pass both
+		// slicing gates, look routable, and never actually route, taking the
+		// wide-window memory relief with it.
+		input, _ := unpinSpineCOW(v.Input)
+		c := *v
+		c.Start = time.Time{}
+		c.End = time.Time{}
+		c.Input = input
+		return &c, true
 	case *chplan.HistogramQuantile:
 		input, changed := unpinSpineCOW(v.Input)
 		if !changed {
@@ -303,6 +319,15 @@ func subtreeHasZeroableSpine(n chplan.Node) bool {
 			found = true
 		case *chplan.RangeBucketFanout:
 			found = true
+		case *chplan.RangeBucketGridNative:
+			// The native classic-histogram ladder (#2677). Listed for the same
+			// reason its fan-out sibling above is: the production spine wraps
+			// it in the across-series Aggregate, which is off the recognised
+			// spine, so this subtree walk is the ONLY thing that discovers it —
+			// and a subtree reported un-zeroable is shared verbatim, still
+			// pinned at the full grid, making every slice fail
+			// ErrReanchorGridMismatch.
+			found = true
 		case *chplan.RangeWindow:
 			if v.Step > 0 {
 				found = true
@@ -344,6 +369,14 @@ func zeroSpineInPlace(n chplan.Node) {
 		zeroSpineInPlace(v.Input)
 		return
 	case *chplan.RangeBucketFanout:
+		v.Start = time.Time{}
+		v.End = time.Time{}
+		zeroSpineInPlace(v.Input)
+		return
+	case *chplan.RangeBucketGridNative:
+		// #2677 — the in-place counterpart of the unpinSpineCOW arm, reached
+		// when this node sits under an off-spine wrapper (the across-series
+		// Aggregate the classic-histogram lowering always emits above it).
 		v.Start = time.Time{}
 		v.End = time.Time{}
 		zeroSpineInPlace(v.Input)

--- a/test/perf/solver-decision-baseline/histogram_quantile_agg_empty/native.json
+++ b/test/perf/solver-decision-baseline/histogram_quantile_agg_empty/native.json
@@ -3,7 +3,7 @@
   "lowering": "native",
   "routed": false,
   "k": 0,
-  "reason": "not-sliceable",
+  "reason": "anchor-grid-indivisible",
   "n_anchors": 241,
   "fanout": 20,
   "cumulative_d": "10m0s",

--- a/test/perf/solver-decision-baseline/histogram_quantile_avg_by_le/native.json
+++ b/test/perf/solver-decision-baseline/histogram_quantile_avg_by_le/native.json
@@ -3,7 +3,7 @@
   "lowering": "native",
   "routed": false,
   "k": 0,
-  "reason": "not-sliceable",
+  "reason": "anchor-grid-indivisible",
   "n_anchors": 241,
   "fanout": 20,
   "cumulative_d": "10m0s",

--- a/test/perf/solver-decision-baseline/histogram_quantile_classic_agg_offset_range/native.json
+++ b/test/perf/solver-decision-baseline/histogram_quantile_classic_agg_offset_range/native.json
@@ -3,7 +3,7 @@
   "lowering": "native",
   "routed": false,
   "k": 0,
-  "reason": "not-sliceable",
+  "reason": "below-threshold",
   "n_anchors": 241,
   "fanout": 8,
   "cumulative_d": "4m0s",

--- a/test/perf/solver-decision-baseline/histogram_quantile_classic_agg_rate_min_samples/native.json
+++ b/test/perf/solver-decision-baseline/histogram_quantile_classic_agg_rate_min_samples/native.json
@@ -3,7 +3,7 @@
   "lowering": "native",
   "routed": false,
   "k": 0,
-  "reason": "not-sliceable",
+  "reason": "below-threshold",
   "n_anchors": 241,
   "fanout": 4,
   "cumulative_d": "2m0s",

--- a/test/perf/solver-decision-baseline/histogram_quantile_classic_bare_rate_min_samples/native.json
+++ b/test/perf/solver-decision-baseline/histogram_quantile_classic_bare_rate_min_samples/native.json
@@ -3,7 +3,7 @@
   "lowering": "native",
   "routed": false,
   "k": 0,
-  "reason": "not-sliceable",
+  "reason": "below-threshold",
   "n_anchors": 241,
   "fanout": 4,
   "cumulative_d": "2m0s",

--- a/test/perf/solver-decision-baseline/histogram_quantile_classic_delta_temporality/native.json
+++ b/test/perf/solver-decision-baseline/histogram_quantile_classic_delta_temporality/native.json
@@ -3,7 +3,7 @@
   "lowering": "native",
   "routed": false,
   "k": 0,
-  "reason": "not-sliceable",
+  "reason": "below-threshold",
   "n_anchors": 241,
   "fanout": 4,
   "cumulative_d": "2m0s",

--- a/test/perf/solver-decision-baseline/histogram_quantile_classic_range_step/native.json
+++ b/test/perf/solver-decision-baseline/histogram_quantile_classic_range_step/native.json
@@ -3,7 +3,7 @@
   "lowering": "native",
   "routed": false,
   "k": 0,
-  "reason": "not-sliceable",
+  "reason": "anchor-grid-indivisible",
   "n_anchors": 241,
   "fanout": 20,
   "cumulative_d": "10m0s",

--- a/test/perf/solver-decision-baseline/histogram_quantile_count_by_le/native.json
+++ b/test/perf/solver-decision-baseline/histogram_quantile_count_by_le/native.json
@@ -3,7 +3,7 @@
   "lowering": "native",
   "routed": false,
   "k": 0,
-  "reason": "not-sliceable",
+  "reason": "anchor-grid-indivisible",
   "n_anchors": 241,
   "fanout": 20,
   "cumulative_d": "10m0s",

--- a/test/perf/solver-decision-baseline/histogram_quantile_max_by_le/native.json
+++ b/test/perf/solver-decision-baseline/histogram_quantile_max_by_le/native.json
@@ -3,7 +3,7 @@
   "lowering": "native",
   "routed": false,
   "k": 0,
-  "reason": "not-sliceable",
+  "reason": "anchor-grid-indivisible",
   "n_anchors": 241,
   "fanout": 20,
   "cumulative_d": "10m0s",

--- a/test/perf/solver-decision-baseline/histogram_quantile_native_ladder_min_samples/native.json
+++ b/test/perf/solver-decision-baseline/histogram_quantile_native_ladder_min_samples/native.json
@@ -3,7 +3,7 @@
   "lowering": "native",
   "routed": false,
   "k": 0,
-  "reason": "not-sliceable",
+  "reason": "below-threshold",
   "n_anchors": 241,
   "fanout": 4,
   "cumulative_d": "2m0s",

--- a/test/perf/solver-decision-baseline/histogram_quantile_native_ladder_offset/native.json
+++ b/test/perf/solver-decision-baseline/histogram_quantile_native_ladder_offset/native.json
@@ -3,7 +3,7 @@
   "lowering": "native",
   "routed": false,
   "k": 0,
-  "reason": "not-sliceable",
+  "reason": "below-threshold",
   "n_anchors": 241,
   "fanout": 8,
   "cumulative_d": "4m0s",

--- a/test/perf/solver-decision-baseline/histogram_quantile_native_ladder_range_step/native.json
+++ b/test/perf/solver-decision-baseline/histogram_quantile_native_ladder_range_step/native.json
@@ -3,7 +3,7 @@
   "lowering": "native",
   "routed": false,
   "k": 0,
-  "reason": "not-sliceable",
+  "reason": "anchor-grid-indivisible",
   "n_anchors": 241,
   "fanout": 20,
   "cumulative_d": "10m0s",

--- a/test/perf/solver-decision-baseline/histogram_quantile_quantile_by_le/native.json
+++ b/test/perf/solver-decision-baseline/histogram_quantile_quantile_by_le/native.json
@@ -3,7 +3,7 @@
   "lowering": "native",
   "routed": false,
   "k": 0,
-  "reason": "not-sliceable",
+  "reason": "anchor-grid-indivisible",
   "n_anchors": 241,
   "fanout": 20,
   "cumulative_d": "10m0s",

--- a/test/perf/solver-decision-baseline/histogram_quantile_sum_by_le/native.json
+++ b/test/perf/solver-decision-baseline/histogram_quantile_sum_by_le/native.json
@@ -3,7 +3,7 @@
   "lowering": "native",
   "routed": false,
   "k": 0,
-  "reason": "not-sliceable",
+  "reason": "anchor-grid-indivisible",
   "n_anchors": 241,
   "fanout": 20,
   "cumulative_d": "10m0s",

--- a/test/perf/solver-decision-baseline/histogram_quantile_sum_by_le_layout_change_midwindow/native.json
+++ b/test/perf/solver-decision-baseline/histogram_quantile_sum_by_le_layout_change_midwindow/native.json
@@ -3,7 +3,7 @@
   "lowering": "native",
   "routed": false,
   "k": 0,
-  "reason": "not-sliceable",
+  "reason": "anchor-grid-indivisible",
   "n_anchors": 241,
   "fanout": 20,
   "cumulative_d": "10m0s",

--- a/test/perf/solver-decision-baseline/histogram_quantile_sum_by_le_mixed_layouts/native.json
+++ b/test/perf/solver-decision-baseline/histogram_quantile_sum_by_le_mixed_layouts/native.json
@@ -3,7 +3,7 @@
   "lowering": "native",
   "routed": false,
   "k": 0,
-  "reason": "not-sliceable",
+  "reason": "anchor-grid-indivisible",
   "n_anchors": 241,
   "fanout": 20,
   "cumulative_d": "10m0s",

--- a/test/perf/solver-decision-baseline/histogram_quantile_sum_by_le_p50/native.json
+++ b/test/perf/solver-decision-baseline/histogram_quantile_sum_by_le_p50/native.json
@@ -3,7 +3,7 @@
   "lowering": "native",
   "routed": false,
   "k": 0,
-  "reason": "not-sliceable",
+  "reason": "anchor-grid-indivisible",
   "n_anchors": 241,
   "fanout": 20,
   "cumulative_d": "10m0s",

--- a/test/perf/solver-decision-baseline/histogram_quantile_with_filter/native.json
+++ b/test/perf/solver-decision-baseline/histogram_quantile_with_filter/native.json
@@ -3,7 +3,7 @@
   "lowering": "native",
   "routed": false,
   "k": 0,
-  "reason": "not-sliceable",
+  "reason": "anchor-grid-indivisible",
   "n_anchors": 241,
   "fanout": 20,
   "cumulative_d": "10m0s",


### PR DESCRIPTION
## Summary

A wide-window `histogram_quantile(phi, <agg> by(le)(rate(<bucket>[range])))`
busts a single ClickHouse query's memory cap outright — the #2677 production
incident. The native ladder holds one grid state per (series, `le` rung) and
unnests every raw row at O(width²), so both memory axes grow with the
requested window. Route B's time-slicing divides both per shard and is the
only relief that removes window width as a memory term rather than
relocating the wall.

`chplan.RangeBucketGridNative` was **the sole grid carrier route B could not
shard**. Four gates each independently stranded it on route A; all four had
to move together, which is why the earlier analysis of "two refusals" was
incomplete:

1. **`chplan.IsSliceInvariant`** did not register the kind. Registered with
   the stage-by-stage scan-lower-bound-independence argument that registry
   demands (not a resemblance argument to its scalar sibling): the Level-0
   unnest is row-wise; both Level-1 aggregates answer grid point *i* from
   exactly that anchor's membership window; the presence filter and the
   `ifNull → 0` short-window resolution read one (rung, anchor) cell; the
   Level-3 regroup and its `HAVING max(_hqn_short) = 0` min-samples drop are
   keyed (series, anchor), and the +Inf rung's per-anchor sample set *is*
   that anchor's window membership.
2. **`chplan.ReanchorRange`** had no arm, so a routed shard would evaluate
   the FULL grid K times over. Added, mirroring the fan-out sibling with the
   two-bound grid-prediction guard this node's field set (no `OuterRange`)
   calls for.
3. **`solver.carrierGeometryOf`** reported `reanchorable: false`.
4. **`solver`'s `unpinSpineCOW` / `subtreeHasZeroableSpine` /
   `zeroSpineInPlace`** did not know the kind. Without these the node stays
   pinned at the full grid and every slice fails
   `ErrReanchorGridMismatch` — the silent "passes both gates, looks
   routable, never actually routes" failure the `RangeWindowGridNative` arm's
   own comment warns about. The production spine wraps this node in an
   across-series `Aggregate`, so the off-spine subtree walk is the only thing
   that discovers it.

`routeBExecCtx` now threads the node's two resource-bound overrides, which it
deliberately omitted while no shard plan could contain the node. Each shard's
guard must measure its own sub-grid against the operator's configured
ceilings rather than chsql's compiled-in defaults.

## Reproduction and verification (real ClickHouse, not chDB)

Faithful replica of the reporting shape: ClickHouse **26.6.3**, schema via
`cerberus migrate schema`, **253 series / bucket width 68 / 14 days at
production density (4.78M rows)**, prod's real
`CERBERUS_CH_QUERY_MAX_MEMORY=6442450944` and
`CERBERUS_CH_OPTIMIZATIONS=auto,columnar_result_decode` (boot log confirms
`ts_grid_histogram` resolves, so this exercises the native path production
runs, not the fallback fold).

**Baseline reproduced first, before any change** — v1.17.0, 6h of data,
step 60s, matching the independently-reported cliff exactly:

| anchors | v1.17.0 |
|---|---|
| 60, 90 | 200 OK |
| **105, 120, 180, 360** | **422 — real ClickHouse `MEMORY_LIMIT_EXCEEDED`** |

**After, same binary config, same data, same cap** (density guard lifted on
*both* sides via `CERBERUS_RANGE_BUCKET_GRID_NATIVE_MAX_DENSITY_UNITS` so
this isolates the memory axis — see "Known ceiling" below):

| window | v1.17.0 | this PR |
|---|---|---|
| 6h @ 60s (the reported panel) | **422** | **200, 361 points, `sharded-timeslice;k=8;reason=retry`** |

**Correctness** — route A vs forced-sharded route B, same windows, JSON
compared in full:

| window | route A | route B | result |
|---|---|---|---|
| 30min | `route-a;routing-disabled` | `k=2;routed` | **IDENTICAL** |
| 60min | `route-a;routing-disabled` | `k=3;routed` | **IDENTICAL** |
| 90min | `route-a;routing-disabled` | `k=5;routed` | **IDENTICAL** |

## Predictive vs memo-driven routing (deliberate, pinned)

ModeAuto's **predictive** path still refuses this shape as
`below-threshold` — a single-pass grid aggregate reports fanout 1, genuinely
under `MinFanout`. Routing it predictively would be threshold drift, not this
fix. Relief comes through the **failure-driven route memo**, whose
`Planner.Eligible` re-derivation deliberately does not apply those cost
thresholds because a measured OOM outranks a static proxy. Both halves are
pinned by `TestRangeBucketGridNative_EligibleForMemoDrivenRouting`.

Two practical consequences, both confirmed against source and independently
reproduced on a second machine:

- **A cold shape sees two real failures before it self-heals.**
  `routememo.minCorroboratingFailures = 2`, so a probe is admitted only after
  two consecutive recorded route-A failures with no intervening success. The
  `Retry` hook is per-request, but the first two requests genuinely 422; the
  third routes B. This is the failure-driven design working as intended, not
  a gap — but it is the operator-facing behaviour, so it is stated plainly
  here rather than left to be discovered.
- **The memo's live-edge freshness gate is one step**, so a query whose `end`
  sits inside the last step is not memo-routed at all (at `step=1800s` that
  margin is 30 minutes).

## Known ceiling (honest scope)

Sharding multiplies the usable window by roughly K (default `MaxK` 8), it
does not make it unbounded. At 14 days the shards themselves hit the
**density guard** — which fires at ~98% of cap for this exact shape *before*
memory is ever reached. That guard is #2681's subject, not this PR's: its
calibration corpus tops out at width 50 while production is width 68, and it
has a measured false-negative regime in the other direction. #2682 (cutting
the O(width²) unnest constant) compounds with both. This PR removes the wall
this node put in front of route B; those two move the wall itself.

## Test plan

- [x] `TestRangeBucketGridNative_SlicingAdmittedAtBothGates` — the two
      structural admissions, pinned separately (rewritten from the
      `...RefusedAtBothGates` predecessor, which pinned the old refusals).
- [x] `TestRangeBucketGridNative_ReanchorsOntoSubGrid` — runs through
      `UnpinSpine` in the real slicer's own order, and asserts the original
      subtree is untouched.
- [x] `TestRangeBucketGridNative_EligibleForMemoDrivenRouting` — predictive
      refusal *and* memo-path admission with K ≥ 2.
- [x] `go test ./internal/chplan/ ./internal/solver/ ./internal/engine/
      ./internal/promql/ ./internal/chsql/ ./test/regression/ ./test/perf/`
      — all green.
- [x] Solver-decision baseline regenerated via
      `just update-solver-decision-baseline`: **18 rows, reason-only**, all
      `not-sliceable` → a later gate (`anchor-grid-indivisible` /
      `below-threshold`). **No corpus row flips to `routed`** — those grids
      are 241 anchors, far under the thresholds.
- [x] Live differential above, on real ClickHouse.

Refs #2677

Closes #2680

