### PR TITLE
fix(solver,promql): let the classic-histogram ladder route predictively

### DIFF
--- a/internal/engine/routed_corpus_observe_test.go
+++ b/internal/engine/routed_corpus_observe_test.go
@@ -195,7 +195,10 @@ func wantParallelism(eng *Engine, d *solver.Decision) int {
 // slicing this plan into a single shard, the whole route-B observation family
 // would still pass while testing no fan-out at all. Pinning the number here
 // turns that degeneration into a failure at the one place it originates.
-const fixtureShardCount = 8
+// Was 8 until #2685 raised the MaxK backstop from 8 to 32: this fixture's K is
+// derived from its own grid (N/MinAnchorsPerSlice) and was previously clipped
+// by that ceiling, so the number moved without the fixture changing.
+const fixtureShardCount = 12
 
 // routedDecision classifies the eligible fixture plan into the routed decision
 // the engine's own route-B paths take.

--- a/internal/promql/histogram_quantile_classic_native.go
+++ b/internal/promql/histogram_quantile_classic_native.go
@@ -138,7 +138,7 @@ func (n NativeClassicHistogramWindowLowerer) LowerClassicHistogramWindow(in clas
 	delta.pred = andPredicate(in.pred, temporalityPredicate(in.s.AggregationTemporalityColumn, chplan.OpEq))
 	return &chplan.UnionAll{Inputs: []chplan.Node{
 		cumulative,
-		n.Fallback.LowerClassicHistogramWindow(delta),
+		clearPeakIndependentOfGrid(n.Fallback.LowerClassicHistogramWindow(delta)),
 	}}
 }
 
@@ -239,4 +239,42 @@ func andPredicate(left, right chplan.Expr) chplan.Expr {
 		return right
 	}
 	return &chplan.Binary{Op: chplan.OpAnd, Left: left, Right: right}
+}
+
+// clearPeakIndependentOfGrid unsets chplan.RangeBucketFanout.PeakIndependentOfGrid
+// on the DELTA-complement arm the native lowerer builds, and returns n.
+//
+// That flag is documented as a per-CONSTRUCTION-SITE declaration, not a
+// property of the node kind: "only a site that has MEASURED route A to fit
+// sets it true", and its zero value is the safe one. The measurement behind it
+// (2.84 GB on an APM-style panel, where slicing recovered 8.7% of peak for 23x
+// the ClickHouse work) was taken on the FAN-OUT-ONLY lowering, where the
+// fan-out is the whole plan and processes every row.
+//
+// This site is a different one. Here the fan-out is one arm of a complementary
+// union — it sees only AggregationTemporality == DELTA rows, while the native
+// ladder takes the rest — so the measured profile does not transfer, and this
+// site has never been measured. It inherited the flag purely by reusing the
+// fallback constructor.
+//
+// Leaving it set is not neutral. The solver reads it as
+// AnchorGridDivides() == false, raises sawIndivisibleAnchorGrid, and refuses
+// the WHOLE plan — including the native arm, whose peak genuinely does divide
+// with the anchor grid. On an all-cumulative deployment (the common case, and
+// the one in issue #2677's production incident) this arm matches zero rows, so
+// the plan was being refused on the cost characteristics of an arm doing no
+// work at all (#2688).
+//
+// Clearing it does not assert that slicing the delta arm is profitable; it
+// restores the documented default of "assume slicing helps" for a site with no
+// measurement behind it, which is what lets the arm that DOES benefit be
+// considered on its own merits.
+func clearPeakIndependentOfGrid(n chplan.Node) chplan.Node {
+	chplan.Walk(n, func(node chplan.Node) bool {
+		if f, ok := node.(*chplan.RangeBucketFanout); ok {
+			f.PeakIndependentOfGrid = false
+		}
+		return true
+	})
+	return n
 }

--- a/internal/solver/config.go
+++ b/internal/solver/config.go
@@ -69,7 +69,11 @@ type Config struct {
 	// pair count a plan must reach. The motivating spike had ~4820.
 	MinAnchorPairs int
 
-	// MaxK caps the shard count.
+	// MaxK caps the shard count. It is a BACKSTOP, not the primary sizing
+	// lever: K is already bounded above by N/MinAnchorsPerSlice (every slice
+	// owns at least that many anchors) and by the high-D clamp, so MaxK only
+	// binds on grids large enough that those two allow more. See
+	// defaultMaxK for why the default is what it is.
 	MaxK int
 
 	// MinAnchorsPerSlice is the grid quantum: each slice must own at least
@@ -137,9 +141,29 @@ type Config struct {
 
 // Default tuning constants (docs/solver.md).
 const (
-	defaultMinFanout          = 16
-	defaultMinAnchorPairs     = 4000
-	defaultMaxK               = 8
+	defaultMinFanout      = 16
+	defaultMinAnchorPairs = 4000
+	// defaultMaxK was raised from 8 to 32 for issue #2685. At 8 it was the
+	// BINDING constraint on wide-window relief rather than a backstop: a 6h
+	// dashboard panel at real production cardinality (253 series, bucket
+	// width 68, measured on ClickHouse 26.6) derives K = N/MinAnchorsPerSlice
+	// = 22 from its own grid, but was truncated to 8 — and at 8 each shard's
+	// scan, widened by the window lookback, lands at 53.8M density cost units
+	// against a 54M ceiling. Over by 0.4%, so the whole query failed while
+	// the sizing the solver had already computed for itself would have fit.
+	//
+	// 32 is chosen so the anchor-derived K governs across realistic dashboard
+	// windows instead of being clipped: at MinAnchorsPerSlice = 16 the derived
+	// K only reaches 32 at N >= 512 anchors, and the head caps a range query
+	// at format.MaxResolutionPoints (11000) regardless. The cost of the raise
+	// is bounded and predictable — K shards run CERBERUS_SHARD_PARALLEL (3) at
+	// a time, so K = 32 is ~11 sequential rounds rather than 3.
+	//
+	// It is still a real ceiling, deliberately: a window wide enough to need
+	// more than 32 shards is asking for more ClickHouse work than a single
+	// dashboard refresh should commit, and an operator who wants it raises
+	// CERBERUS_SHARD_MAX_K explicitly.
+	defaultMaxK               = 32
 	defaultMinAnchorsPerSlice = 16
 	defaultParallel           = 3
 	defaultTimeout            = 60 * time.Second

--- a/internal/solver/config_test.go
+++ b/internal/solver/config_test.go
@@ -14,7 +14,7 @@ func TestDefaultConfig_Valid(t *testing.T) {
 	if c.Mode != ModeSingle {
 		t.Fatalf("default Mode = %q, want %q (ship dark)", c.Mode, ModeSingle)
 	}
-	if c.MinFanout != 16 || c.MinAnchorPairs != 4000 || c.MaxK != 8 ||
+	if c.MinFanout != 16 || c.MinAnchorPairs != 4000 || c.MaxK != 32 ||
 		c.MinAnchorsPerSlice != 16 || c.Parallel != 3 || c.MaxOutputRows != 2_000_000 {
 		t.Fatalf("default tuning drifted: %+v", c)
 	}

--- a/internal/solver/planner.go
+++ b/internal/solver/planner.go
@@ -57,10 +57,16 @@ func (p *Planner) Plan(plan chplan.Node, meta RequestMeta) (*Decision, bool) {
 	if p.Cfg.Mode == ModeAuto {
 		// Cost thresholds gate the auto path. Below threshold → route A.
 		minFanout, minAnchorPairs := p.Cfg.MinFanout, p.Cfg.MinAnchorPairs
-		if sig.maxFanout < int64(minFanout) {
+		// A per-rung carrier's F is unmeasurable before the scan runs (see
+		// carrierGeometry.perRungIntermediate), so both F-derived comparisons
+		// below would be reading a placeholder rather than a cost. Gate it on
+		// the anchor axis instead — the axis that IS known at plan time, and
+		// the one slicing actually divides.
+		perRung := sig.sawPerRungCarrier && sig.outerN >= minAnchorsForPerRungShard
+		if !perRung && sig.maxFanout < int64(minFanout) {
 			return notRouted(ReasonBelowThreshold).withGrid(sig, meta), false
 		}
-		if int64(sig.outerN)*sig.maxFanout < int64(minAnchorPairs) {
+		if !perRung && int64(sig.outerN)*sig.maxFanout < int64(minAnchorPairs) {
 			return notRouted(ReasonBelowThreshold).withGrid(sig, meta), false
 		}
 		if k < 2 {
@@ -403,6 +409,10 @@ type signals struct {
 	// Eligible() deliberately ignores it, so a real route-A resource failure
 	// still routes through the failure-driven memo.
 	sawIndivisibleAnchorGrid bool
+	// sawPerRungCarrier records that some carrier amplifies per stored bucket
+	// rung, so maxFanout is not a usable cost proxy for this plan — see
+	// carrierGeometry.perRungIntermediate and minAnchorsForPerRungShard.
+	sawPerRungCarrier bool
 
 	// Cost grid, derived from the OUTERMOST windowed node (the spine root).
 	outerN      int           // N = OuterRange/Step + 1
@@ -721,6 +731,35 @@ type carrierGeometry struct {
 	// hold it.
 	singlePass bool
 
+	// perRungIntermediate marks a carrier whose F is NOT representable as a
+	// plan-time constant at all, because its amplification is per stored
+	// BUCKET RUNG rather than per sample or per anchor.
+	//
+	// Only [chplan.RangeBucketGridNative] sets it. Its Level-0 arrayJoin emits
+	// one intermediate row per (sample, `le` rung) and Level 1 holds one grid
+	// state per (series, rung), so by singlePass's own definition — peak
+	// intermediate rows per raw row — its F is the rung count. That count is
+	// the stored `length(ExplicitBounds)`: real data, ranging 34-136 across
+	// deployments measured for #2681, and unknowable before the scan runs.
+	//
+	// It reports singlePass too, which stays correct for what singlePass is
+	// used for elsewhere (the cumulative-D derivation): the carrier really
+	// does read each sample once. What it does NOT do is materialise one row
+	// per sample, which is the part the ModeAuto fanout gate reads — and that
+	// is the distinction this field exists to draw. Copying singlePass here
+	// from the scalar native carrier without it told the planner an
+	// arrayJoin-amplified shape costs the same as a flat-memory one, which is
+	// what kept the expensive shape under a threshold designed to catch
+	// expensive shapes (#2687).
+	//
+	// Guessing a constant F was rejected rather than left undone: real widths
+	// span 34-136 while Prometheus's own DefBuckets is 10, so any value large
+	// enough to clear MinFanout over-claims for a default-bucket histogram and
+	// would shard cheap queries — exactly the waste singlePass's doc warns
+	// about. The gate therefore switches axis instead of inventing a number;
+	// see minAnchorsForPerRungShard.
+	perRungIntermediate bool
+
 	// reanchorable reports whether [chplan.ReanchorRange] re-grids this kind.
 	// This is a CORRECTNESS bit, not a measurement one: a carrier
 	// ReanchorRange clones verbatim hands every shard the original full-grid
@@ -737,6 +776,32 @@ type carrierGeometry struct {
 // than 0 because the samples ARE read — a zero would say the carrier touches no
 // data, which is StepGrid's answer, not this family's.
 const singlePassFanout = int64(1)
+
+// minAnchorsForPerRungShard is the anchor count at or above which a per-rung
+// carrier (carrierGeometry.perRungIntermediate) is routed by ModeAuto without
+// consulting the fanout thresholds, whose input it cannot supply.
+//
+// Chosen from measurement, not from the threshold it replaces. Real-ClickHouse
+// 26.6 sweeps of the classic-histogram ladder at the bucket width production
+// actually carries (68) put the per-query memory cliff at ~94 anchors under a
+// 6 GiB cap and far lower under the 1 GiB default (issue #2681's calibration
+// table). 120 sits above the widest measured safe grid, so a panel small
+// enough to have never been observed to strain a per-query budget still runs
+// unsliced on route A — the K-scans-for-no-benefit waste singlePass's own doc
+// warns about — while the multi-hour dashboard windows that DO strain it
+// route.
+//
+// It is expressed in anchors rather than in cost units on purpose: the anchor
+// grid is the one axis of this carrier's cost that the planner can read before
+// any data is touched, and it is precisely the axis a shard divides. Rungs and
+// raw rows are the other two factors and both need the scan.
+//
+// Erring high is the safe direction. A per-rung carrier BELOW this line that
+// nevertheless exhausts memory is not stranded: it fails on route A, and the
+// failure-driven route memo escalates it to a sharded retry from real evidence
+// (internal/engine/route_outcome.go). Erring low has no such backstop — it
+// spends K scans on a query that never needed them.
+const minAnchorsForPerRungShard = 120
 
 // carrierGeometryOf derives the measurement geometry of one grid carrier,
 // enumerating every [chplan.GridCarrier] implementation.
@@ -783,10 +848,11 @@ func carrierGeometryOf(gc chplan.GridCarrier) (carrierGeometry, bool) {
 		// both axes per shard, which is the only relief that removes the window
 		// width as a memory term rather than relocating the wall.
 		return carrierGeometry{
-			outerRange:   v.End.Sub(v.Start),
-			lookback:     v.Range,
-			singlePass:   true,
-			reanchorable: true,
+			outerRange:          v.End.Sub(v.Start),
+			lookback:            v.Range,
+			singlePass:          true,
+			perRungIntermediate: true,
+			reanchorable:        true,
 		}, true
 
 	case *chplan.RangeWindowGridNative:
@@ -904,6 +970,9 @@ func (p *Planner) recordGridCarrier(gc chplan.GridCarrier, depth int, sig *signa
 		if fan > sig.maxFanout {
 			sig.maxFanout = fan
 		}
+	}
+	if geom.perRungIntermediate {
+		sig.sawPerRungCarrier = true
 	}
 	// D is per-slice SCAN redundancy, which is the window SPAN regardless of
 	// which emitter reads it — a single-pass carrier's shard widens its input

--- a/internal/solver/planner_test.go
+++ b/internal/solver/planner_test.go
@@ -55,7 +55,13 @@ func autoCfg() Config {
 }
 
 // TestPlan_OOMShapeRoutes pins the worked example from the doc: the OOM shape
-// routes under Mode=auto with K=8 and Reason=routed.
+// routes under Mode=auto with Reason=routed, at the K its own grid derives.
+//
+// K is N/MinAnchorsPerSlice (12 for this fixture), no longer clipped to MaxK:
+// #2685 raised that backstop from 8 to 32 precisely so the anchor-derived
+// sizing governs instead of being truncated. Asserting the derived value
+// rather than the old ceiling is what keeps this test measuring the sizing
+// rule instead of the cap.
 func TestPlan_OOMShapeRoutes(t *testing.T) {
 	t.Parallel()
 	p := &Planner{Cfg: autoCfg()}
@@ -66,14 +72,14 @@ func TestPlan_OOMShapeRoutes(t *testing.T) {
 	if d.Reason != ReasonRouted {
 		t.Fatalf("reason = %q, want %q", d.Reason, ReasonRouted)
 	}
-	if d.K != 8 {
-		t.Fatalf("K = %d, want 8", d.K)
+	if d.K != 12 {
+		t.Fatalf("K = %d, want 12 (N/MinAnchorsPerSlice, not the MaxK backstop)", d.K)
 	}
 	if d.Strategy != StrategyShardedTimeslice {
 		t.Fatalf("strategy = %q, want %q", d.Strategy, StrategyShardedTimeslice)
 	}
-	if len(d.Slices) != 8 {
-		t.Fatalf("len(Slices) = %d, want 8", len(d.Slices))
+	if len(d.Slices) != 12 {
+		t.Fatalf("len(Slices) = %d, want 12", len(d.Slices))
 	}
 }
 
@@ -821,8 +827,8 @@ func TestPlan_ScalarAnchorCompatibleRoutes(t *testing.T) {
 	if d.Reason != ReasonRouted {
 		t.Fatalf("reason = %q, want %q", d.Reason, ReasonRouted)
 	}
-	if d.K != 8 {
-		t.Fatalf("K = %d, want 8 (same OOM shape as TestPlan_OOMShapeRoutes)", d.K)
+	if d.K != 12 {
+		t.Fatalf("K = %d, want 12 (same OOM shape as TestPlan_OOMShapeRoutes)", d.K)
 	}
 }
 

--- a/internal/solver/range_bucket_grid_native_route_test.go
+++ b/internal/solver/range_bucket_grid_native_route_test.go
@@ -150,54 +150,72 @@ func TestRangeBucketGridNative_ReanchorsOntoSubGrid(t *testing.T) {
 	}
 }
 
-// TestRangeBucketGridNative_EligibleForMemoDrivenRouting pins the relief path
-// that actually answers #2677.
+// TestRangeBucketGridNative_PredictiveRoutingOnTheAnchorAxis pins the fix for
+// #2687, and both sides of it.
 //
-// The distinction this test exists to hold is subtle and load-bearing. Under
-// ModeAuto's PREDICTIVE thresholds this plan still does not route: a
-// single-pass grid aggregate reports fanout 1 (carrierGeometry.singlePass), so
-// it falls under MinFanout and yields ReasonBelowThreshold. That is correct —
-// the predictive proxy has no way to know this particular window is heavy.
+// This carrier's F is unmeasurable before the scan (its amplification is per
+// stored `le` rung), so ModeAuto gates it on the anchor axis instead —
+// minAnchorsForPerRungShard. That is what lets a multi-hour dashboard panel
+// route at PLAN time, which matters because the predictive path carries no
+// live-edge freshness gate: the failure-driven memo, the only other escalation
+// route, declines every request whose End sits in the last step, and a Grafana
+// panel always does.
 //
-// What changed is that Planner.Eligible — the re-derivation the failure-driven
-// route memo runs after a real route-A resource failure — now ADMITS the plan
-// and returns a sliced Decision. Eligible deliberately does not apply the
-// ModeAuto cost thresholds (a measured OOM is stronger evidence than a static
-// proxy), so once the structural gates admit the node, an observed memory
-// failure is enough to shard the retry. That is the whole mechanism by which a
-// wide-window classic-histogram quantile stops being a hard 422.
-func TestRangeBucketGridNative_EligibleForMemoDrivenRouting(t *testing.T) {
+// The negative half is the load-bearing one. Routing every classic-histogram
+// range query regardless of size would spend K scans on panels that never
+// needed them — the waste carrierGeometry.singlePass's own doc warns about —
+// so a grid below the floor must still decline, and decline for the COST
+// reason rather than a structural one.
+func TestRangeBucketGridNative_PredictiveRoutingOnTheAnchorAxis(t *testing.T) {
 	t.Parallel()
 
 	p := &Planner{Cfg: autoCfg()}
 
-	// Predictive path: still below threshold, by the singlePass fanout.
+	// The canonical fixture grid (1h at 15s = 241 anchors) is above the floor.
 	d, routed := p.Plan(bucketGridNativeSpine(), oomMeta())
-	if routed {
-		t.Errorf("a RangeBucketGridNative spine routed under ModeAuto's predictive thresholds "+
-			"(K=%d, reason=%q). Slicing it is sound, but its single-pass fanout of 1 is "+
-			"genuinely below MinFanout — routing it predictively would be the threshold "+
-			"drifting, not this fix.", d.K, d.Reason)
+	if !routed {
+		t.Fatalf("a RangeBucketGridNative spine did NOT route predictively (reason=%q). Its "+
+			"anchor grid is above minAnchorsForPerRungShard, and the predictive path is the "+
+			"only escalation a live-edge dashboard query can reach — the route memo declines "+
+			"those on freshness (#2687).", d.Reason)
 	}
-	if d.Reason != ReasonBelowThreshold {
-		t.Errorf("predictive refusal reason is %q, want %q. A structural reason here "+
-			"(not-sliceable) would mean the slicing gates silently closed again and the "+
-			"memo path below cannot fire either.", d.Reason, ReasonBelowThreshold)
+	if d.K < 2 {
+		t.Errorf("predictive route produced K=%d, want >= 2", d.K)
 	}
 
-	// Memo path: admitted, sliced, and genuinely sharded.
+	// Below the floor: still declines, and on COST rather than structure.
+	narrow := bucketGridNativeCarrier()
+	narrow.End = narrow.Start.Add(time.Duration(minAnchorsForPerRungShard/2) * gridStep)
+	small := &chplan.Aggregate{
+		Input:    narrow,
+		GroupBy:  []chplan.Expr{&chplan.ColumnRef{Name: "anchor_ts"}},
+		AggFuncs: []chplan.AggFunc{{Fn: chplan.FnGroupArray, Args: []chplan.Expr{&chplan.ColumnRef{Name: "BucketCounts"}}}},
+	}
+	meta := RequestMeta{Lang: LangPromQL, Start: narrow.Start, End: narrow.End, Step: narrow.Step}
+	sd, sRouted := p.Plan(small, meta)
+	if sRouted {
+		t.Errorf("a sub-floor anchor grid routed (K=%d) — sharding a panel small enough to run "+
+			"unsliced pays K scans for a memory problem it does not have", sd.K)
+	}
+	if sd.Reason != ReasonBelowThreshold {
+		t.Errorf("sub-floor refusal reason is %q, want %q — a structural reason here would mean "+
+			"the slicing gates closed rather than the cost gate declining", sd.Reason, ReasonBelowThreshold)
+	}
+}
+
+// TestRangeBucketGridNative_EligibleStillBypassesThresholds pins that the
+// failure-driven memo seam is unchanged by the predictive gate above: a real
+// route-A resource failure still escalates a plan of ANY size, including one
+// below the anchor floor, because measured evidence outranks a cost proxy.
+func TestRangeBucketGridNative_EligibleStillBypassesThresholds(t *testing.T) {
+	t.Parallel()
+
+	p := &Planner{Cfg: autoCfg()}
 	ed, eligible := p.Eligible(bucketGridNativeSpine(), oomMeta())
 	if !eligible {
-		t.Fatalf("Planner.Eligible refused a RangeBucketGridNative spine (reason=%q). This is "+
-			"the re-derivation the failure-driven route memo runs after a real route-A "+
-			"memory failure; refusing here means a wide-window classic-histogram quantile "+
-			"has no relief and stays a hard 422 (#2677).", ed.Reason)
+		t.Fatalf("Planner.Eligible refused a RangeBucketGridNative spine (reason=%q)", ed.Reason)
 	}
-	if ed.K < 2 {
-		t.Errorf("Eligible produced K=%d, want >= 2 — one shard is route A with extra "+
-			"machinery, and divides neither the anchor axis nor the raw-row axis", ed.K)
-	}
-	if ed.Reason != ReasonRouted {
-		t.Errorf("Eligible returned reason %q, want %q", ed.Reason, ReasonRouted)
+	if ed.K < 2 || ed.Reason != ReasonRouted {
+		t.Errorf("Eligible returned K=%d reason=%q, want K>=2 and %q", ed.K, ed.Reason, ReasonRouted)
 	}
 }

--- a/test/perf/solver-decision-baseline/abs_metric/fanout.json
+++ b/test/perf/solver-decision-baseline/abs_metric/fanout.json
@@ -2,7 +2,7 @@
   "query": "abs_metric/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 8,
+  "k": 12,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/agg_by_dotted_source/fanout.json
+++ b/test/perf/solver-decision-baseline/agg_by_dotted_source/fanout.json
@@ -2,7 +2,7 @@
   "query": "agg_by_dotted_source/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 8,
+  "k": 12,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/agg_by_service_name/fanout.json
+++ b/test/perf/solver-decision-baseline/agg_by_service_name/fanout.json
@@ -2,7 +2,7 @@
   "query": "agg_by_service_name/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 8,
+  "k": 12,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/agg_range_window_over_scalar_div/fanout.json
+++ b/test/perf/solver-decision-baseline/agg_range_window_over_scalar_div/fanout.json
@@ -2,7 +2,7 @@
   "query": "agg_range_window_over_scalar_div/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 8,
+  "k": 12,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/agg_range_window_over_scalar_div/native.json
+++ b/test/perf/solver-decision-baseline/agg_range_window_over_scalar_div/native.json
@@ -2,7 +2,7 @@
   "query": "agg_range_window_over_scalar_div/native",
   "lowering": "native",
   "routed": true,
-  "k": 8,
+  "k": 12,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/binop_atan2_scalar_vector/fanout.json
+++ b/test/perf/solver-decision-baseline/binop_atan2_scalar_vector/fanout.json
@@ -2,7 +2,7 @@
   "query": "binop_atan2_scalar_vector/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 8,
+  "k": 12,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/binop_atan2_vector_scalar/fanout.json
+++ b/test/perf/solver-decision-baseline/binop_atan2_vector_scalar/fanout.json
@@ -2,7 +2,7 @@
   "query": "binop_atan2_vector_scalar/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 8,
+  "k": 12,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/binop_metric_minus_time/fanout.json
+++ b/test/perf/solver-decision-baseline/binop_metric_minus_time/fanout.json
@@ -2,7 +2,7 @@
   "query": "binop_metric_minus_time/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 8,
+  "k": 12,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/binop_time_arith_range/fanout.json
+++ b/test/perf/solver-decision-baseline/binop_time_arith_range/fanout.json
@@ -2,7 +2,7 @@
   "query": "binop_time_arith_range/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 8,
+  "k": 12,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/binop_time_lt_bool_metric/fanout.json
+++ b/test/perf/solver-decision-baseline/binop_time_lt_bool_metric/fanout.json
@@ -2,7 +2,7 @@
   "query": "binop_time_lt_bool_metric/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 8,
+  "k": 12,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/binop_time_lt_metric/fanout.json
+++ b/test/perf/solver-decision-baseline/binop_time_lt_metric/fanout.json
@@ -2,7 +2,7 @@
   "query": "binop_time_lt_metric/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 8,
+  "k": 12,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/binop_time_plus_metric/fanout.json
+++ b/test/perf/solver-decision-baseline/binop_time_plus_metric/fanout.json
@@ -2,7 +2,7 @@
   "query": "binop_time_plus_metric/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 8,
+  "k": 12,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/bool_lt/fanout.json
+++ b/test/perf/solver-decision-baseline/bool_lt/fanout.json
@@ -2,7 +2,7 @@
   "query": "bool_lt/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 8,
+  "k": 12,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/bottomk_below_one_empty/fanout.json
+++ b/test/perf/solver-decision-baseline/bottomk_below_one_empty/fanout.json
@@ -2,7 +2,7 @@
   "query": "bottomk_below_one_empty/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 8,
+  "k": 12,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/ceil_duplicate_labelset/fanout.json
+++ b/test/perf/solver-decision-baseline/ceil_duplicate_labelset/fanout.json
@@ -2,7 +2,7 @@
   "query": "ceil_duplicate_labelset/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 8,
+  "k": 12,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/ceil_metric/fanout.json
+++ b/test/perf/solver-decision-baseline/ceil_metric/fanout.json
@@ -2,7 +2,7 @@
   "query": "ceil_metric/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 8,
+  "k": 12,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/chained_filter/fanout.json
+++ b/test/perf/solver-decision-baseline/chained_filter/fanout.json
@@ -2,7 +2,7 @@
   "query": "chained_filter/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 8,
+  "k": 12,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/changes_nan_run/fanout.json
+++ b/test/perf/solver-decision-baseline/changes_nan_run/fanout.json
@@ -2,7 +2,7 @@
   "query": "changes_nan_run/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 8,
+  "k": 12,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/changes_nan_run/native.json
+++ b/test/perf/solver-decision-baseline/changes_nan_run/native.json
@@ -2,7 +2,7 @@
   "query": "changes_nan_run/native",
   "lowering": "native",
   "routed": true,
-  "k": 8,
+  "k": 12,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/changes_oscillating/fanout.json
+++ b/test/perf/solver-decision-baseline/changes_oscillating/fanout.json
@@ -2,7 +2,7 @@
   "query": "changes_oscillating/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 8,
+  "k": 12,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/changes_oscillating/native.json
+++ b/test/perf/solver-decision-baseline/changes_oscillating/native.json
@@ -2,7 +2,7 @@
   "query": "changes_oscillating/native",
   "lowering": "native",
   "routed": true,
-  "k": 8,
+  "k": 12,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/clamp/fanout.json
+++ b/test/perf/solver-decision-baseline/clamp/fanout.json
@@ -2,7 +2,7 @@
   "query": "clamp/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 8,
+  "k": 12,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/clamp_max/fanout.json
+++ b/test/perf/solver-decision-baseline/clamp_max/fanout.json
@@ -2,7 +2,7 @@
   "query": "clamp_max/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 8,
+  "k": 12,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/clamp_max_scalar_bound/fanout.json
+++ b/test/perf/solver-decision-baseline/clamp_max_scalar_bound/fanout.json
@@ -2,7 +2,7 @@
   "query": "clamp_max_scalar_bound/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 8,
+  "k": 12,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/clamp_max_scalar_bound_range_per_step/fanout.json
+++ b/test/perf/solver-decision-baseline/clamp_max_scalar_bound_range_per_step/fanout.json
@@ -2,7 +2,7 @@
   "query": "clamp_max_scalar_bound_range_per_step/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 8,
+  "k": 12,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/clamp_min/fanout.json
+++ b/test/perf/solver-decision-baseline/clamp_min/fanout.json
@@ -2,7 +2,7 @@
   "query": "clamp_min/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 8,
+  "k": 12,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/clamp_min_scalar_bound/fanout.json
+++ b/test/perf/solver-decision-baseline/clamp_min_scalar_bound/fanout.json
@@ -2,7 +2,7 @@
   "query": "clamp_min_scalar_bound/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 8,
+  "k": 12,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/clamp_min_scalar_nan_bound/fanout.json
+++ b/test/perf/solver-decision-baseline/clamp_min_scalar_nan_bound/fanout.json
@@ -2,7 +2,7 @@
   "query": "clamp_min_scalar_nan_bound/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 8,
+  "k": 12,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/clamp_scalar_min_literal_max/fanout.json
+++ b/test/perf/solver-decision-baseline/clamp_scalar_min_literal_max/fanout.json
@@ -2,7 +2,7 @@
   "query": "clamp_scalar_min_literal_max/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 8,
+  "k": 12,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/comparison_arithmetic/fanout.json
+++ b/test/perf/solver-decision-baseline/comparison_arithmetic/fanout.json
@@ -2,7 +2,7 @@
   "query": "comparison_arithmetic/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 8,
+  "k": 12,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/count_agg_returns_float/fanout.json
+++ b/test/perf/solver-decision-baseline/count_agg_returns_float/fanout.json
@@ -2,7 +2,7 @@
   "query": "count_agg_returns_float/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 8,
+  "k": 12,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/count_no_group/fanout.json
+++ b/test/perf/solver-decision-baseline/count_no_group/fanout.json
@@ -2,7 +2,7 @@
   "query": "count_no_group/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 8,
+  "k": 12,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/count_over_time_exp_histogram/fanout.json
+++ b/test/perf/solver-decision-baseline/count_over_time_exp_histogram/fanout.json
@@ -2,7 +2,7 @@
   "query": "count_over_time_exp_histogram/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 8,
+  "k": 12,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/count_over_time_exp_histogram/native.json
+++ b/test/perf/solver-decision-baseline/count_over_time_exp_histogram/native.json
@@ -2,7 +2,7 @@
   "query": "count_over_time_exp_histogram/native",
   "lowering": "native",
   "routed": true,
-  "k": 8,
+  "k": 12,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/count_values_basic/fanout.json
+++ b/test/perf/solver-decision-baseline/count_values_basic/fanout.json
@@ -2,7 +2,7 @@
   "query": "count_values_basic/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 8,
+  "k": 12,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/count_values_without/fanout.json
+++ b/test/perf/solver-decision-baseline/count_values_without/fanout.json
@@ -2,7 +2,7 @@
   "query": "count_values_without/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 8,
+  "k": 12,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/count_values_without_empty/fanout.json
+++ b/test/perf/solver-decision-baseline/count_values_without_empty/fanout.json
@@ -2,7 +2,7 @@
   "query": "count_values_without_empty/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 8,
+  "k": 12,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/day_of_month_of_vector/fanout.json
+++ b/test/perf/solver-decision-baseline/day_of_month_of_vector/fanout.json
@@ -2,7 +2,7 @@
   "query": "day_of_month_of_vector/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 8,
+  "k": 12,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/day_of_week_offset/fanout.json
+++ b/test/perf/solver-decision-baseline/day_of_week_offset/fanout.json
@@ -2,7 +2,7 @@
   "query": "day_of_week_offset/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 8,
+  "k": 12,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/day_of_year_of_vector/fanout.json
+++ b/test/perf/solver-decision-baseline/day_of_year_of_vector/fanout.json
@@ -2,7 +2,7 @@
   "query": "day_of_year_of_vector/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 8,
+  "k": 12,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/days_in_month_of_vector/fanout.json
+++ b/test/perf/solver-decision-baseline/days_in_month_of_vector/fanout.json
@@ -2,7 +2,7 @@
   "query": "days_in_month_of_vector/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 8,
+  "k": 12,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/deg_metric/fanout.json
+++ b/test/perf/solver-decision-baseline/deg_metric/fanout.json
@@ -2,7 +2,7 @@
   "query": "deg_metric/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 8,
+  "k": 12,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/deriv_linear_increase/fanout.json
+++ b/test/perf/solver-decision-baseline/deriv_linear_increase/fanout.json
@@ -2,7 +2,7 @@
   "query": "deriv_linear_increase/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 8,
+  "k": 12,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/edge_abs_over_rate/fanout.json
+++ b/test/perf/solver-decision-baseline/edge_abs_over_rate/fanout.json
@@ -2,7 +2,7 @@
   "query": "edge_abs_over_rate/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 8,
+  "k": 12,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/edge_avg_over_time/fanout.json
+++ b/test/perf/solver-decision-baseline/edge_avg_over_time/fanout.json
@@ -2,7 +2,7 @@
   "query": "edge_avg_over_time/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 8,
+  "k": 12,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/edge_avg_over_time/native.json
+++ b/test/perf/solver-decision-baseline/edge_avg_over_time/native.json
@@ -2,7 +2,7 @@
   "query": "edge_avg_over_time/native",
   "lowering": "native",
   "routed": true,
-  "k": 8,
+  "k": 12,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/edge_bool_eq/fanout.json
+++ b/test/perf/solver-decision-baseline/edge_bool_eq/fanout.json
@@ -2,7 +2,7 @@
   "query": "edge_bool_eq/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 8,
+  "k": 12,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/edge_bool_ge/fanout.json
+++ b/test/perf/solver-decision-baseline/edge_bool_ge/fanout.json
@@ -2,7 +2,7 @@
   "query": "edge_bool_ge/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 8,
+  "k": 12,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/edge_bool_le/fanout.json
+++ b/test/perf/solver-decision-baseline/edge_bool_le/fanout.json
@@ -2,7 +2,7 @@
   "query": "edge_bool_le/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 8,
+  "k": 12,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/edge_bool_ne/fanout.json
+++ b/test/perf/solver-decision-baseline/edge_bool_ne/fanout.json
@@ -2,7 +2,7 @@
   "query": "edge_bool_ne/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 8,
+  "k": 12,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/edge_ceil_over_sum_by/fanout.json
+++ b/test/perf/solver-decision-baseline/edge_ceil_over_sum_by/fanout.json
@@ -2,7 +2,7 @@
   "query": "edge_ceil_over_sum_by/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 8,
+  "k": 12,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/edge_clamp_neg_to_pos/fanout.json
+++ b/test/perf/solver-decision-baseline/edge_clamp_neg_to_pos/fanout.json
@@ -2,7 +2,7 @@
   "query": "edge_clamp_neg_to_pos/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 8,
+  "k": 12,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/edge_count_over_time/fanout.json
+++ b/test/perf/solver-decision-baseline/edge_count_over_time/fanout.json
@@ -2,7 +2,7 @@
   "query": "edge_count_over_time/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 8,
+  "k": 12,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/edge_count_over_time/native.json
+++ b/test/perf/solver-decision-baseline/edge_count_over_time/native.json
@@ -2,7 +2,7 @@
   "query": "edge_count_over_time/native",
   "lowering": "native",
   "routed": true,
-  "k": 8,
+  "k": 12,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/edge_last_over_time/fanout.json
+++ b/test/perf/solver-decision-baseline/edge_last_over_time/fanout.json
@@ -2,7 +2,7 @@
   "query": "edge_last_over_time/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 8,
+  "k": 12,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/edge_last_over_time/native.json
+++ b/test/perf/solver-decision-baseline/edge_last_over_time/native.json
@@ -2,7 +2,7 @@
   "query": "edge_last_over_time/native",
   "lowering": "native",
   "routed": true,
-  "k": 8,
+  "k": 12,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/edge_log10_over_rate/fanout.json
+++ b/test/perf/solver-decision-baseline/edge_log10_over_rate/fanout.json
@@ -2,7 +2,7 @@
   "query": "edge_log10_over_rate/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 8,
+  "k": 12,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/edge_neg_scalar_minus_vector/fanout.json
+++ b/test/perf/solver-decision-baseline/edge_neg_scalar_minus_vector/fanout.json
@@ -2,7 +2,7 @@
   "query": "edge_neg_scalar_minus_vector/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 8,
+  "k": 12,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/edge_offset_zero/fanout.json
+++ b/test/perf/solver-decision-baseline/edge_offset_zero/fanout.json
@@ -2,7 +2,7 @@
   "query": "edge_offset_zero/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 8,
+  "k": 12,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/edge_paren_chain_arith/fanout.json
+++ b/test/perf/solver-decision-baseline/edge_paren_chain_arith/fanout.json
@@ -2,7 +2,7 @@
   "query": "edge_paren_chain_arith/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 8,
+  "k": 12,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/edge_rate_negative_offset/fanout.json
+++ b/test/perf/solver-decision-baseline/edge_rate_negative_offset/fanout.json
@@ -2,7 +2,7 @@
   "query": "edge_rate_negative_offset/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 8,
+  "k": 12,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/edge_round_step_half/fanout.json
+++ b/test/perf/solver-decision-baseline/edge_round_step_half/fanout.json
@@ -2,7 +2,7 @@
   "query": "edge_round_step_half/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 8,
+  "k": 12,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/edge_sqrt_over_aggregate/fanout.json
+++ b/test/perf/solver-decision-baseline/edge_sqrt_over_aggregate/fanout.json
@@ -2,7 +2,7 @@
   "query": "edge_sqrt_over_aggregate/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 8,
+  "k": 12,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/exp_histogram_changes/fanout.json
+++ b/test/perf/solver-decision-baseline/exp_histogram_changes/fanout.json
@@ -2,7 +2,7 @@
   "query": "exp_histogram_changes/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 8,
+  "k": 12,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/exp_histogram_changes/native.json
+++ b/test/perf/solver-decision-baseline/exp_histogram_changes/native.json
@@ -2,7 +2,7 @@
   "query": "exp_histogram_changes/native",
   "lowering": "native",
   "routed": true,
-  "k": 8,
+  "k": 12,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/exp_histogram_count/fanout.json
+++ b/test/perf/solver-decision-baseline/exp_histogram_count/fanout.json
@@ -2,7 +2,7 @@
   "query": "exp_histogram_count/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 8,
+  "k": 12,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/exp_histogram_count/native.json
+++ b/test/perf/solver-decision-baseline/exp_histogram_count/native.json
@@ -2,7 +2,7 @@
   "query": "exp_histogram_count/native",
   "lowering": "native",
   "routed": true,
-  "k": 8,
+  "k": 12,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/exp_histogram_count_by/fanout.json
+++ b/test/perf/solver-decision-baseline/exp_histogram_count_by/fanout.json
@@ -2,7 +2,7 @@
   "query": "exp_histogram_count_by/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 8,
+  "k": 12,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/exp_histogram_count_by/native.json
+++ b/test/perf/solver-decision-baseline/exp_histogram_count_by/native.json
@@ -2,7 +2,7 @@
   "query": "exp_histogram_count_by/native",
   "lowering": "native",
   "routed": true,
-  "k": 8,
+  "k": 12,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/exp_histogram_resets/fanout.json
+++ b/test/perf/solver-decision-baseline/exp_histogram_resets/fanout.json
@@ -2,7 +2,7 @@
   "query": "exp_histogram_resets/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 8,
+  "k": 12,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/exp_histogram_resets/native.json
+++ b/test/perf/solver-decision-baseline/exp_histogram_resets/native.json
@@ -2,7 +2,7 @@
   "query": "exp_histogram_resets/native",
   "lowering": "native",
   "routed": true,
-  "k": 8,
+  "k": 12,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/exp_histogram_sum_over_ts_of_first_over_time/fanout.json
+++ b/test/perf/solver-decision-baseline/exp_histogram_sum_over_ts_of_first_over_time/fanout.json
@@ -2,7 +2,7 @@
   "query": "exp_histogram_sum_over_ts_of_first_over_time/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 8,
+  "k": 12,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/exp_histogram_sum_over_ts_of_first_over_time/native.json
+++ b/test/perf/solver-decision-baseline/exp_histogram_sum_over_ts_of_first_over_time/native.json
@@ -2,7 +2,7 @@
   "query": "exp_histogram_sum_over_ts_of_first_over_time/native",
   "lowering": "native",
   "routed": true,
-  "k": 8,
+  "k": 12,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/exp_histogram_sum_over_ts_of_last_over_time/fanout.json
+++ b/test/perf/solver-decision-baseline/exp_histogram_sum_over_ts_of_last_over_time/fanout.json
@@ -2,7 +2,7 @@
   "query": "exp_histogram_sum_over_ts_of_last_over_time/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 8,
+  "k": 12,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/exp_histogram_sum_over_ts_of_last_over_time/native.json
+++ b/test/perf/solver-decision-baseline/exp_histogram_sum_over_ts_of_last_over_time/native.json
@@ -2,7 +2,7 @@
   "query": "exp_histogram_sum_over_ts_of_last_over_time/native",
   "lowering": "native",
   "routed": true,
-  "k": 8,
+  "k": 12,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/exp_metric/fanout.json
+++ b/test/perf/solver-decision-baseline/exp_metric/fanout.json
@@ -2,7 +2,7 @@
   "query": "exp_metric/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 8,
+  "k": 12,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/first_over_time/fanout.json
+++ b/test/perf/solver-decision-baseline/first_over_time/fanout.json
@@ -2,7 +2,7 @@
   "query": "first_over_time/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 8,
+  "k": 12,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/first_over_time/native.json
+++ b/test/perf/solver-decision-baseline/first_over_time/native.json
@@ -2,7 +2,7 @@
   "query": "first_over_time/native",
   "lowering": "native",
   "routed": true,
-  "k": 8,
+  "k": 12,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/floor_metric/fanout.json
+++ b/test/perf/solver-decision-baseline/floor_metric/fanout.json
@@ -2,7 +2,7 @@
   "query": "floor_metric/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 8,
+  "k": 12,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/group_basic/fanout.json
+++ b/test/perf/solver-decision-baseline/group_basic/fanout.json
@@ -2,7 +2,7 @@
   "query": "group_basic/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 8,
+  "k": 12,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/group_by_job/fanout.json
+++ b/test/perf/solver-decision-baseline/group_by_job/fanout.json
@@ -2,7 +2,7 @@
   "query": "group_by_job/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 8,
+  "k": 12,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/histogram_avg_exp/fanout.json
+++ b/test/perf/solver-decision-baseline/histogram_avg_exp/fanout.json
@@ -2,7 +2,7 @@
   "query": "histogram_avg_exp/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 8,
+  "k": 12,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/histogram_avg_exp/native.json
+++ b/test/perf/solver-decision-baseline/histogram_avg_exp/native.json
@@ -2,7 +2,7 @@
   "query": "histogram_avg_exp/native",
   "lowering": "native",
   "routed": true,
-  "k": 8,
+  "k": 12,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/histogram_avg_exp_latest_sample/fanout.json
+++ b/test/perf/solver-decision-baseline/histogram_avg_exp_latest_sample/fanout.json
@@ -2,7 +2,7 @@
   "query": "histogram_avg_exp_latest_sample/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 8,
+  "k": 12,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/histogram_avg_exp_latest_sample/native.json
+++ b/test/perf/solver-decision-baseline/histogram_avg_exp_latest_sample/native.json
@@ -2,7 +2,7 @@
   "query": "histogram_avg_exp_latest_sample/native",
   "lowering": "native",
   "routed": true,
-  "k": 8,
+  "k": 12,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/histogram_avg_exp_range_latest_sample/fanout.json
+++ b/test/perf/solver-decision-baseline/histogram_avg_exp_range_latest_sample/fanout.json
@@ -2,7 +2,7 @@
   "query": "histogram_avg_exp_range_latest_sample/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 8,
+  "k": 12,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/histogram_avg_exp_range_latest_sample/native.json
+++ b/test/perf/solver-decision-baseline/histogram_avg_exp_range_latest_sample/native.json
@@ -2,7 +2,7 @@
   "query": "histogram_avg_exp_range_latest_sample/native",
   "lowering": "native",
   "routed": true,
-  "k": 8,
+  "k": 12,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/histogram_bucket_companion/fanout.json
+++ b/test/perf/solver-decision-baseline/histogram_bucket_companion/fanout.json
@@ -2,7 +2,7 @@
   "query": "histogram_bucket_companion/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 8,
+  "k": 12,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/histogram_bucket_le_filter/fanout.json
+++ b/test/perf/solver-decision-baseline/histogram_bucket_le_filter/fanout.json
@@ -2,7 +2,7 @@
   "query": "histogram_bucket_le_filter/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 8,
+  "k": 12,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/histogram_count_exp/fanout.json
+++ b/test/perf/solver-decision-baseline/histogram_count_exp/fanout.json
@@ -2,7 +2,7 @@
   "query": "histogram_count_exp/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 8,
+  "k": 12,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/histogram_count_exp/native.json
+++ b/test/perf/solver-decision-baseline/histogram_count_exp/native.json
@@ -2,7 +2,7 @@
   "query": "histogram_count_exp/native",
   "lowering": "native",
   "routed": true,
-  "k": 8,
+  "k": 12,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/histogram_count_exp_bare_stale/fanout.json
+++ b/test/perf/solver-decision-baseline/histogram_count_exp_bare_stale/fanout.json
@@ -2,7 +2,7 @@
   "query": "histogram_count_exp_bare_stale/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 8,
+  "k": 12,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/histogram_count_exp_bare_stale/native.json
+++ b/test/perf/solver-decision-baseline/histogram_count_exp_bare_stale/native.json
@@ -2,7 +2,7 @@
   "query": "histogram_count_exp_bare_stale/native",
   "lowering": "native",
   "routed": true,
-  "k": 8,
+  "k": 12,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/histogram_count_exp_latest_sample/fanout.json
+++ b/test/perf/solver-decision-baseline/histogram_count_exp_latest_sample/fanout.json
@@ -2,7 +2,7 @@
   "query": "histogram_count_exp_latest_sample/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 8,
+  "k": 12,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/histogram_count_exp_latest_sample/native.json
+++ b/test/perf/solver-decision-baseline/histogram_count_exp_latest_sample/native.json
@@ -2,7 +2,7 @@
   "query": "histogram_count_exp_latest_sample/native",
   "lowering": "native",
   "routed": true,
-  "k": 8,
+  "k": 12,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/histogram_count_exp_range_latest_sample/fanout.json
+++ b/test/perf/solver-decision-baseline/histogram_count_exp_range_latest_sample/fanout.json
@@ -2,7 +2,7 @@
   "query": "histogram_count_exp_range_latest_sample/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 8,
+  "k": 12,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/histogram_count_exp_range_latest_sample/native.json
+++ b/test/perf/solver-decision-baseline/histogram_count_exp_range_latest_sample/native.json
@@ -2,7 +2,7 @@
   "query": "histogram_count_exp_range_latest_sample/native",
   "lowering": "native",
   "routed": true,
-  "k": 8,
+  "k": 12,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/histogram_count_float_metric_empty/fanout.json
+++ b/test/perf/solver-decision-baseline/histogram_count_float_metric_empty/fanout.json
@@ -2,7 +2,7 @@
   "query": "histogram_count_float_metric_empty/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 8,
+  "k": 12,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/histogram_count_float_metric_empty/native.json
+++ b/test/perf/solver-decision-baseline/histogram_count_float_metric_empty/native.json
@@ -2,7 +2,7 @@
   "query": "histogram_count_float_metric_empty/native",
   "lowering": "native",
   "routed": true,
-  "k": 8,
+  "k": 12,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/histogram_fraction_exp/fanout.json
+++ b/test/perf/solver-decision-baseline/histogram_fraction_exp/fanout.json
@@ -2,7 +2,7 @@
   "query": "histogram_fraction_exp/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 8,
+  "k": 12,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/histogram_fraction_exp/native.json
+++ b/test/perf/solver-decision-baseline/histogram_fraction_exp/native.json
@@ -2,7 +2,7 @@
   "query": "histogram_fraction_exp/native",
   "lowering": "native",
   "routed": true,
-  "k": 8,
+  "k": 12,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/histogram_fraction_exp_negative_bounds/fanout.json
+++ b/test/perf/solver-decision-baseline/histogram_fraction_exp_negative_bounds/fanout.json
@@ -2,7 +2,7 @@
   "query": "histogram_fraction_exp_negative_bounds/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 8,
+  "k": 12,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/histogram_fraction_exp_negative_bounds/native.json
+++ b/test/perf/solver-decision-baseline/histogram_fraction_exp_negative_bounds/native.json
@@ -2,7 +2,7 @@
   "query": "histogram_fraction_exp_negative_bounds/native",
   "lowering": "native",
   "routed": true,
-  "k": 8,
+  "k": 12,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/histogram_fraction_exp_negative_range/fanout.json
+++ b/test/perf/solver-decision-baseline/histogram_fraction_exp_negative_range/fanout.json
@@ -2,7 +2,7 @@
   "query": "histogram_fraction_exp_negative_range/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 8,
+  "k": 12,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/histogram_fraction_exp_negative_range/native.json
+++ b/test/perf/solver-decision-baseline/histogram_fraction_exp_negative_range/native.json
@@ -2,7 +2,7 @@
   "query": "histogram_fraction_exp_negative_range/native",
   "lowering": "native",
   "routed": true,
-  "k": 8,
+  "k": 12,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/histogram_quantile_agg_empty/native.json
+++ b/test/perf/solver-decision-baseline/histogram_quantile_agg_empty/native.json
@@ -1,9 +1,9 @@
 {
   "query": "histogram_quantile_agg_empty/native",
   "lowering": "native",
-  "routed": false,
-  "k": 0,
-  "reason": "anchor-grid-indivisible",
+  "routed": true,
+  "k": 6,
+  "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,
   "cumulative_d": "10m0s",

--- a/test/perf/solver-decision-baseline/histogram_quantile_avg_by_le/native.json
+++ b/test/perf/solver-decision-baseline/histogram_quantile_avg_by_le/native.json
@@ -1,9 +1,9 @@
 {
   "query": "histogram_quantile_avg_by_le/native",
   "lowering": "native",
-  "routed": false,
-  "k": 0,
-  "reason": "anchor-grid-indivisible",
+  "routed": true,
+  "k": 6,
+  "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,
   "cumulative_d": "10m0s",

--- a/test/perf/solver-decision-baseline/histogram_quantile_bare_name_unsatisfiable/fanout.json
+++ b/test/perf/solver-decision-baseline/histogram_quantile_bare_name_unsatisfiable/fanout.json
@@ -2,7 +2,7 @@
   "query": "histogram_quantile_bare_name_unsatisfiable/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 8,
+  "k": 12,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/histogram_quantile_bare_name_unsatisfiable/native.json
+++ b/test/perf/solver-decision-baseline/histogram_quantile_bare_name_unsatisfiable/native.json
@@ -2,7 +2,7 @@
   "query": "histogram_quantile_bare_name_unsatisfiable/native",
   "lowering": "native",
   "routed": true,
-  "k": 8,
+  "k": 12,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/histogram_quantile_classic_agg_offset_range/native.json
+++ b/test/perf/solver-decision-baseline/histogram_quantile_classic_agg_offset_range/native.json
@@ -1,9 +1,9 @@
 {
   "query": "histogram_quantile_classic_agg_offset_range/native",
   "lowering": "native",
-  "routed": false,
-  "k": 0,
-  "reason": "below-threshold",
+  "routed": true,
+  "k": 15,
+  "reason": "routed",
   "n_anchors": 241,
   "fanout": 8,
   "cumulative_d": "4m0s",

--- a/test/perf/solver-decision-baseline/histogram_quantile_classic_agg_plateau/fanout.json
+++ b/test/perf/solver-decision-baseline/histogram_quantile_classic_agg_plateau/fanout.json
@@ -2,7 +2,7 @@
   "query": "histogram_quantile_classic_agg_plateau/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 8,
+  "k": 12,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/histogram_quantile_classic_agg_plateau/native.json
+++ b/test/perf/solver-decision-baseline/histogram_quantile_classic_agg_plateau/native.json
@@ -2,7 +2,7 @@
   "query": "histogram_quantile_classic_agg_plateau/native",
   "lowering": "native",
   "routed": true,
-  "k": 8,
+  "k": 12,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/histogram_quantile_classic_agg_rate_min_samples/native.json
+++ b/test/perf/solver-decision-baseline/histogram_quantile_classic_agg_rate_min_samples/native.json
@@ -1,9 +1,9 @@
 {
   "query": "histogram_quantile_classic_agg_rate_min_samples/native",
   "lowering": "native",
-  "routed": false,
-  "k": 0,
-  "reason": "below-threshold",
+  "routed": true,
+  "k": 15,
+  "reason": "routed",
   "n_anchors": 241,
   "fanout": 4,
   "cumulative_d": "2m0s",

--- a/test/perf/solver-decision-baseline/histogram_quantile_classic_bare_rate_min_samples/native.json
+++ b/test/perf/solver-decision-baseline/histogram_quantile_classic_bare_rate_min_samples/native.json
@@ -1,9 +1,9 @@
 {
   "query": "histogram_quantile_classic_bare_rate_min_samples/native",
   "lowering": "native",
-  "routed": false,
-  "k": 0,
-  "reason": "below-threshold",
+  "routed": true,
+  "k": 15,
+  "reason": "routed",
   "n_anchors": 241,
   "fanout": 4,
   "cumulative_d": "2m0s",

--- a/test/perf/solver-decision-baseline/histogram_quantile_classic_count_values_by_le/fanout.json
+++ b/test/perf/solver-decision-baseline/histogram_quantile_classic_count_values_by_le/fanout.json
@@ -2,7 +2,7 @@
   "query": "histogram_quantile_classic_count_values_by_le/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 8,
+  "k": 12,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/histogram_quantile_classic_count_values_by_le/native.json
+++ b/test/perf/solver-decision-baseline/histogram_quantile_classic_count_values_by_le/native.json
@@ -2,7 +2,7 @@
   "query": "histogram_quantile_classic_count_values_by_le/native",
   "lowering": "native",
   "routed": true,
-  "k": 8,
+  "k": 12,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/histogram_quantile_classic_delta_temporality/native.json
+++ b/test/perf/solver-decision-baseline/histogram_quantile_classic_delta_temporality/native.json
@@ -1,9 +1,9 @@
 {
   "query": "histogram_quantile_classic_delta_temporality/native",
   "lowering": "native",
-  "routed": false,
-  "k": 0,
-  "reason": "below-threshold",
+  "routed": true,
+  "k": 15,
+  "reason": "routed",
   "n_anchors": 241,
   "fanout": 4,
   "cumulative_d": "2m0s",

--- a/test/perf/solver-decision-baseline/histogram_quantile_classic_duplicate_bounds/fanout.json
+++ b/test/perf/solver-decision-baseline/histogram_quantile_classic_duplicate_bounds/fanout.json
@@ -2,7 +2,7 @@
   "query": "histogram_quantile_classic_duplicate_bounds/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 8,
+  "k": 12,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/histogram_quantile_classic_duplicate_bounds/native.json
+++ b/test/perf/solver-decision-baseline/histogram_quantile_classic_duplicate_bounds/native.json
@@ -2,7 +2,7 @@
   "query": "histogram_quantile_classic_duplicate_bounds/native",
   "lowering": "native",
   "routed": true,
-  "k": 8,
+  "k": 12,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/histogram_quantile_classic_edge_p0/fanout.json
+++ b/test/perf/solver-decision-baseline/histogram_quantile_classic_edge_p0/fanout.json
@@ -2,7 +2,7 @@
   "query": "histogram_quantile_classic_edge_p0/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 8,
+  "k": 12,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/histogram_quantile_classic_edge_p0/native.json
+++ b/test/perf/solver-decision-baseline/histogram_quantile_classic_edge_p0/native.json
@@ -2,7 +2,7 @@
   "query": "histogram_quantile_classic_edge_p0/native",
   "lowering": "native",
   "routed": true,
-  "k": 8,
+  "k": 12,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/histogram_quantile_classic_edge_p100/fanout.json
+++ b/test/perf/solver-decision-baseline/histogram_quantile_classic_edge_p100/fanout.json
@@ -2,7 +2,7 @@
   "query": "histogram_quantile_classic_edge_p100/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 8,
+  "k": 12,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/histogram_quantile_classic_edge_p100/native.json
+++ b/test/perf/solver-decision-baseline/histogram_quantile_classic_edge_p100/native.json
@@ -2,7 +2,7 @@
   "query": "histogram_quantile_classic_edge_p100/native",
   "lowering": "native",
   "routed": true,
-  "k": 8,
+  "k": 12,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/histogram_quantile_classic_empty/fanout.json
+++ b/test/perf/solver-decision-baseline/histogram_quantile_classic_empty/fanout.json
@@ -2,7 +2,7 @@
   "query": "histogram_quantile_classic_empty/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 8,
+  "k": 12,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/histogram_quantile_classic_empty/native.json
+++ b/test/perf/solver-decision-baseline/histogram_quantile_classic_empty/native.json
@@ -2,7 +2,7 @@
   "query": "histogram_quantile_classic_empty/native",
   "lowering": "native",
   "routed": true,
-  "k": 8,
+  "k": 12,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/histogram_quantile_classic_latest_sample/fanout.json
+++ b/test/perf/solver-decision-baseline/histogram_quantile_classic_latest_sample/fanout.json
@@ -2,7 +2,7 @@
   "query": "histogram_quantile_classic_latest_sample/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 8,
+  "k": 12,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/histogram_quantile_classic_latest_sample/native.json
+++ b/test/perf/solver-decision-baseline/histogram_quantile_classic_latest_sample/native.json
@@ -2,7 +2,7 @@
   "query": "histogram_quantile_classic_latest_sample/native",
   "lowering": "native",
   "routed": true,
-  "k": 8,
+  "k": 12,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/histogram_quantile_classic_multi_series/fanout.json
+++ b/test/perf/solver-decision-baseline/histogram_quantile_classic_multi_series/fanout.json
@@ -2,7 +2,7 @@
   "query": "histogram_quantile_classic_multi_series/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 8,
+  "k": 12,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/histogram_quantile_classic_multi_series/native.json
+++ b/test/perf/solver-decision-baseline/histogram_quantile_classic_multi_series/native.json
@@ -2,7 +2,7 @@
   "query": "histogram_quantile_classic_multi_series/native",
   "lowering": "native",
   "routed": true,
-  "k": 8,
+  "k": 12,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/histogram_quantile_classic_negative_bound_upper_rank/fanout.json
+++ b/test/perf/solver-decision-baseline/histogram_quantile_classic_negative_bound_upper_rank/fanout.json
@@ -2,7 +2,7 @@
   "query": "histogram_quantile_classic_negative_bound_upper_rank/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 8,
+  "k": 12,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/histogram_quantile_classic_negative_bound_upper_rank/native.json
+++ b/test/perf/solver-decision-baseline/histogram_quantile_classic_negative_bound_upper_rank/native.json
@@ -2,7 +2,7 @@
   "query": "histogram_quantile_classic_negative_bound_upper_rank/native",
   "lowering": "native",
   "routed": true,
-  "k": 8,
+  "k": 12,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/histogram_quantile_classic_negative_lowest_bound/fanout.json
+++ b/test/perf/solver-decision-baseline/histogram_quantile_classic_negative_lowest_bound/fanout.json
@@ -2,7 +2,7 @@
   "query": "histogram_quantile_classic_negative_lowest_bound/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 8,
+  "k": 12,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/histogram_quantile_classic_negative_lowest_bound/native.json
+++ b/test/perf/solver-decision-baseline/histogram_quantile_classic_negative_lowest_bound/native.json
@@ -2,7 +2,7 @@
   "query": "histogram_quantile_classic_negative_lowest_bound/native",
   "lowering": "native",
   "routed": true,
-  "k": 8,
+  "k": 12,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/histogram_quantile_classic_plateau_overflow/fanout.json
+++ b/test/perf/solver-decision-baseline/histogram_quantile_classic_plateau_overflow/fanout.json
@@ -2,7 +2,7 @@
   "query": "histogram_quantile_classic_plateau_overflow/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 8,
+  "k": 12,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/histogram_quantile_classic_plateau_overflow/native.json
+++ b/test/perf/solver-decision-baseline/histogram_quantile_classic_plateau_overflow/native.json
@@ -2,7 +2,7 @@
   "query": "histogram_quantile_classic_plateau_overflow/native",
   "lowering": "native",
   "routed": true,
-  "k": 8,
+  "k": 12,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/histogram_quantile_classic_range_step/native.json
+++ b/test/perf/solver-decision-baseline/histogram_quantile_classic_range_step/native.json
@@ -1,9 +1,9 @@
 {
   "query": "histogram_quantile_classic_range_step/native",
   "lowering": "native",
-  "routed": false,
-  "k": 0,
-  "reason": "anchor-grid-indivisible",
+  "routed": true,
+  "k": 6,
+  "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,
   "cumulative_d": "10m0s",

--- a/test/perf/solver-decision-baseline/histogram_quantile_classic_range_step_bare/fanout.json
+++ b/test/perf/solver-decision-baseline/histogram_quantile_classic_range_step_bare/fanout.json
@@ -2,7 +2,7 @@
   "query": "histogram_quantile_classic_range_step_bare/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 8,
+  "k": 12,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/histogram_quantile_classic_range_step_bare/native.json
+++ b/test/perf/solver-decision-baseline/histogram_quantile_classic_range_step_bare/native.json
@@ -2,7 +2,7 @@
   "query": "histogram_quantile_classic_range_step_bare/native",
   "lowering": "native",
   "routed": true,
-  "k": 8,
+  "k": 12,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/histogram_quantile_classic_single_bucket/fanout.json
+++ b/test/perf/solver-decision-baseline/histogram_quantile_classic_single_bucket/fanout.json
@@ -2,7 +2,7 @@
   "query": "histogram_quantile_classic_single_bucket/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 8,
+  "k": 12,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/histogram_quantile_classic_single_bucket/native.json
+++ b/test/perf/solver-decision-baseline/histogram_quantile_classic_single_bucket/native.json
@@ -2,7 +2,7 @@
   "query": "histogram_quantile_classic_single_bucket/native",
   "lowering": "native",
   "routed": true,
-  "k": 8,
+  "k": 12,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/histogram_quantile_classic_zero_count_plateau/fanout.json
+++ b/test/perf/solver-decision-baseline/histogram_quantile_classic_zero_count_plateau/fanout.json
@@ -2,7 +2,7 @@
   "query": "histogram_quantile_classic_zero_count_plateau/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 8,
+  "k": 12,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/histogram_quantile_classic_zero_count_plateau/native.json
+++ b/test/perf/solver-decision-baseline/histogram_quantile_classic_zero_count_plateau/native.json
@@ -2,7 +2,7 @@
   "query": "histogram_quantile_classic_zero_count_plateau/native",
   "lowering": "native",
   "routed": true,
-  "k": 8,
+  "k": 12,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/histogram_quantile_count_by_le/native.json
+++ b/test/perf/solver-decision-baseline/histogram_quantile_count_by_le/native.json
@@ -1,9 +1,9 @@
 {
   "query": "histogram_quantile_count_by_le/native",
   "lowering": "native",
-  "routed": false,
-  "k": 0,
-  "reason": "anchor-grid-indivisible",
+  "routed": true,
+  "k": 6,
+  "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,
   "cumulative_d": "10m0s",

--- a/test/perf/solver-decision-baseline/histogram_quantile_le_not_in_by/fanout.json
+++ b/test/perf/solver-decision-baseline/histogram_quantile_le_not_in_by/fanout.json
@@ -2,7 +2,7 @@
   "query": "histogram_quantile_le_not_in_by/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 8,
+  "k": 12,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/histogram_quantile_le_not_in_by/native.json
+++ b/test/perf/solver-decision-baseline/histogram_quantile_le_not_in_by/native.json
@@ -2,7 +2,7 @@
   "query": "histogram_quantile_le_not_in_by/native",
   "lowering": "native",
   "routed": true,
-  "k": 8,
+  "k": 12,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/histogram_quantile_le_regex_bound_subset/fanout.json
+++ b/test/perf/solver-decision-baseline/histogram_quantile_le_regex_bound_subset/fanout.json
@@ -2,7 +2,7 @@
   "query": "histogram_quantile_le_regex_bound_subset/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 8,
+  "k": 12,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/histogram_quantile_le_regex_bound_subset/native.json
+++ b/test/perf/solver-decision-baseline/histogram_quantile_le_regex_bound_subset/native.json
@@ -2,7 +2,7 @@
   "query": "histogram_quantile_le_regex_bound_subset/native",
   "lowering": "native",
   "routed": true,
-  "k": 8,
+  "k": 12,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/histogram_quantile_max_by_le/native.json
+++ b/test/perf/solver-decision-baseline/histogram_quantile_max_by_le/native.json
@@ -1,9 +1,9 @@
 {
   "query": "histogram_quantile_max_by_le/native",
   "lowering": "native",
-  "routed": false,
-  "k": 0,
-  "reason": "anchor-grid-indivisible",
+  "routed": true,
+  "k": 6,
+  "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,
   "cumulative_d": "10m0s",

--- a/test/perf/solver-decision-baseline/histogram_quantile_native_ladder_min_samples/native.json
+++ b/test/perf/solver-decision-baseline/histogram_quantile_native_ladder_min_samples/native.json
@@ -1,9 +1,9 @@
 {
   "query": "histogram_quantile_native_ladder_min_samples/native",
   "lowering": "native",
-  "routed": false,
-  "k": 0,
-  "reason": "below-threshold",
+  "routed": true,
+  "k": 15,
+  "reason": "routed",
   "n_anchors": 241,
   "fanout": 4,
   "cumulative_d": "2m0s",

--- a/test/perf/solver-decision-baseline/histogram_quantile_native_ladder_offset/native.json
+++ b/test/perf/solver-decision-baseline/histogram_quantile_native_ladder_offset/native.json
@@ -1,9 +1,9 @@
 {
   "query": "histogram_quantile_native_ladder_offset/native",
   "lowering": "native",
-  "routed": false,
-  "k": 0,
-  "reason": "below-threshold",
+  "routed": true,
+  "k": 15,
+  "reason": "routed",
   "n_anchors": 241,
   "fanout": 8,
   "cumulative_d": "4m0s",

--- a/test/perf/solver-decision-baseline/histogram_quantile_native_ladder_range_step/native.json
+++ b/test/perf/solver-decision-baseline/histogram_quantile_native_ladder_range_step/native.json
@@ -1,9 +1,9 @@
 {
   "query": "histogram_quantile_native_ladder_range_step/native",
   "lowering": "native",
-  "routed": false,
-  "k": 0,
-  "reason": "anchor-grid-indivisible",
+  "routed": true,
+  "k": 6,
+  "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,
   "cumulative_d": "10m0s",

--- a/test/perf/solver-decision-baseline/histogram_quantile_non_bucket_empty/fanout.json
+++ b/test/perf/solver-decision-baseline/histogram_quantile_non_bucket_empty/fanout.json
@@ -2,7 +2,7 @@
   "query": "histogram_quantile_non_bucket_empty/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 8,
+  "k": 12,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/histogram_quantile_quantile_by_le/native.json
+++ b/test/perf/solver-decision-baseline/histogram_quantile_quantile_by_le/native.json
@@ -1,9 +1,9 @@
 {
   "query": "histogram_quantile_quantile_by_le/native",
   "lowering": "native",
-  "routed": false,
-  "k": 0,
-  "reason": "anchor-grid-indivisible",
+  "routed": true,
+  "k": 6,
+  "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,
   "cumulative_d": "10m0s",

--- a/test/perf/solver-decision-baseline/histogram_quantile_scalar_phi/fanout.json
+++ b/test/perf/solver-decision-baseline/histogram_quantile_scalar_phi/fanout.json
@@ -2,7 +2,7 @@
   "query": "histogram_quantile_scalar_phi/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 8,
+  "k": 12,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/histogram_quantile_sum_by_le/native.json
+++ b/test/perf/solver-decision-baseline/histogram_quantile_sum_by_le/native.json
@@ -1,9 +1,9 @@
 {
   "query": "histogram_quantile_sum_by_le/native",
   "lowering": "native",
-  "routed": false,
-  "k": 0,
-  "reason": "anchor-grid-indivisible",
+  "routed": true,
+  "k": 6,
+  "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,
   "cumulative_d": "10m0s",

--- a/test/perf/solver-decision-baseline/histogram_quantile_sum_by_le_layout_change_midwindow/native.json
+++ b/test/perf/solver-decision-baseline/histogram_quantile_sum_by_le_layout_change_midwindow/native.json
@@ -1,9 +1,9 @@
 {
   "query": "histogram_quantile_sum_by_le_layout_change_midwindow/native",
   "lowering": "native",
-  "routed": false,
-  "k": 0,
-  "reason": "anchor-grid-indivisible",
+  "routed": true,
+  "k": 6,
+  "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,
   "cumulative_d": "10m0s",

--- a/test/perf/solver-decision-baseline/histogram_quantile_sum_by_le_mixed_layouts/native.json
+++ b/test/perf/solver-decision-baseline/histogram_quantile_sum_by_le_mixed_layouts/native.json
@@ -1,9 +1,9 @@
 {
   "query": "histogram_quantile_sum_by_le_mixed_layouts/native",
   "lowering": "native",
-  "routed": false,
-  "k": 0,
-  "reason": "anchor-grid-indivisible",
+  "routed": true,
+  "k": 6,
+  "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,
   "cumulative_d": "10m0s",

--- a/test/perf/solver-decision-baseline/histogram_quantile_sum_by_le_p50/native.json
+++ b/test/perf/solver-decision-baseline/histogram_quantile_sum_by_le_p50/native.json
@@ -1,9 +1,9 @@
 {
   "query": "histogram_quantile_sum_by_le_p50/native",
   "lowering": "native",
-  "routed": false,
-  "k": 0,
-  "reason": "anchor-grid-indivisible",
+  "routed": true,
+  "k": 6,
+  "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,
   "cumulative_d": "10m0s",

--- a/test/perf/solver-decision-baseline/histogram_quantile_with_filter/native.json
+++ b/test/perf/solver-decision-baseline/histogram_quantile_with_filter/native.json
@@ -1,9 +1,9 @@
 {
   "query": "histogram_quantile_with_filter/native",
   "lowering": "native",
-  "routed": false,
-  "k": 0,
-  "reason": "anchor-grid-indivisible",
+  "routed": true,
+  "k": 6,
+  "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,
   "cumulative_d": "10m0s",

--- a/test/perf/solver-decision-baseline/histogram_quantiles_computed_phi/fanout.json
+++ b/test/perf/solver-decision-baseline/histogram_quantiles_computed_phi/fanout.json
@@ -2,7 +2,7 @@
   "query": "histogram_quantiles_computed_phi/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 8,
+  "k": 12,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/histogram_quantiles_computed_phi_sci/fanout.json
+++ b/test/perf/solver-decision-baseline/histogram_quantiles_computed_phi_sci/fanout.json
@@ -2,7 +2,7 @@
   "query": "histogram_quantiles_computed_phi_sci/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 8,
+  "k": 12,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/histogram_stddev_exp/fanout.json
+++ b/test/perf/solver-decision-baseline/histogram_stddev_exp/fanout.json
@@ -2,7 +2,7 @@
   "query": "histogram_stddev_exp/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 8,
+  "k": 12,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/histogram_stddev_exp/native.json
+++ b/test/perf/solver-decision-baseline/histogram_stddev_exp/native.json
@@ -2,7 +2,7 @@
   "query": "histogram_stddev_exp/native",
   "lowering": "native",
   "routed": true,
-  "k": 8,
+  "k": 12,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/histogram_stdvar_exp/fanout.json
+++ b/test/perf/solver-decision-baseline/histogram_stdvar_exp/fanout.json
@@ -2,7 +2,7 @@
   "query": "histogram_stdvar_exp/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 8,
+  "k": 12,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/histogram_stdvar_exp/native.json
+++ b/test/perf/solver-decision-baseline/histogram_stdvar_exp/native.json
@@ -2,7 +2,7 @@
   "query": "histogram_stdvar_exp/native",
   "lowering": "native",
   "routed": true,
-  "k": 8,
+  "k": 12,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/histogram_sum_aggregate_arg_empty/fanout.json
+++ b/test/perf/solver-decision-baseline/histogram_sum_aggregate_arg_empty/fanout.json
@@ -2,7 +2,7 @@
   "query": "histogram_sum_aggregate_arg_empty/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 8,
+  "k": 12,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/histogram_sum_exp/fanout.json
+++ b/test/perf/solver-decision-baseline/histogram_sum_exp/fanout.json
@@ -2,7 +2,7 @@
   "query": "histogram_sum_exp/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 8,
+  "k": 12,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/histogram_sum_exp/native.json
+++ b/test/perf/solver-decision-baseline/histogram_sum_exp/native.json
@@ -2,7 +2,7 @@
   "query": "histogram_sum_exp/native",
   "lowering": "native",
   "routed": true,
-  "k": 8,
+  "k": 12,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/histogram_sum_exp_latest_sample/fanout.json
+++ b/test/perf/solver-decision-baseline/histogram_sum_exp_latest_sample/fanout.json
@@ -2,7 +2,7 @@
   "query": "histogram_sum_exp_latest_sample/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 8,
+  "k": 12,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/histogram_sum_exp_latest_sample/native.json
+++ b/test/perf/solver-decision-baseline/histogram_sum_exp_latest_sample/native.json
@@ -2,7 +2,7 @@
   "query": "histogram_sum_exp_latest_sample/native",
   "lowering": "native",
   "routed": true,
-  "k": 8,
+  "k": 12,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/histogram_sum_exp_range_latest_sample/fanout.json
+++ b/test/perf/solver-decision-baseline/histogram_sum_exp_range_latest_sample/fanout.json
@@ -2,7 +2,7 @@
   "query": "histogram_sum_exp_range_latest_sample/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 8,
+  "k": 12,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/histogram_sum_exp_range_latest_sample/native.json
+++ b/test/perf/solver-decision-baseline/histogram_sum_exp_range_latest_sample/native.json
@@ -2,7 +2,7 @@
   "query": "histogram_sum_exp_range_latest_sample/native",
   "lowering": "native",
   "routed": true,
-  "k": 8,
+  "k": 12,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/hour_of_vector/fanout.json
+++ b/test/perf/solver-decision-baseline/hour_of_vector/fanout.json
@@ -2,7 +2,7 @@
   "query": "hour_of_vector/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 8,
+  "k": 12,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/info_ignores_base_info_series/fanout.json
+++ b/test/perf/solver-decision-baseline/info_ignores_base_info_series/fanout.json
@@ -2,7 +2,7 @@
   "query": "info_ignores_base_info_series/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 8,
+  "k": 12,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/info_ignores_base_info_series_multi_metric/fanout.json
+++ b/test/perf/solver-decision-baseline/info_ignores_base_info_series_multi_metric/fanout.json
@@ -2,7 +2,7 @@
   "query": "info_ignores_base_info_series_multi_metric/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 8,
+  "k": 12,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/instant_sum_over_suffixed_count_delta_sum/fanout.json
+++ b/test/perf/solver-decision-baseline/instant_sum_over_suffixed_count_delta_sum/fanout.json
@@ -2,7 +2,7 @@
   "query": "instant_sum_over_suffixed_count_delta_sum/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 8,
+  "k": 12,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/label_join_duplicate_labelset/fanout.json
+++ b/test/perf/solver-decision-baseline/label_join_duplicate_labelset/fanout.json
@@ -2,7 +2,7 @@
   "query": "label_join_duplicate_labelset/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 8,
+  "k": 12,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/label_join_two_labels/fanout.json
+++ b/test/perf/solver-decision-baseline/label_join_two_labels/fanout.json
@@ -2,7 +2,7 @@
   "query": "label_join_two_labels/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 8,
+  "k": 12,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/label_join_with_separator/fanout.json
+++ b/test/perf/solver-decision-baseline/label_join_with_separator/fanout.json
@@ -2,7 +2,7 @@
   "query": "label_join_with_separator/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 8,
+  "k": 12,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/label_replace_backref_above_ch_ceiling/fanout.json
+++ b/test/perf/solver-decision-baseline/label_replace_backref_above_ch_ceiling/fanout.json
@@ -2,7 +2,7 @@
   "query": "label_replace_backref_above_ch_ceiling/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 8,
+  "k": 12,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/label_replace_backref_above_group_count/fanout.json
+++ b/test/perf/solver-decision-baseline/label_replace_backref_above_group_count/fanout.json
@@ -2,7 +2,7 @@
   "query": "label_replace_backref_above_group_count/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 8,
+  "k": 12,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/label_replace_basic/fanout.json
+++ b/test/perf/solver-decision-baseline/label_replace_basic/fanout.json
@@ -2,7 +2,7 @@
   "query": "label_replace_basic/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 8,
+  "k": 12,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/label_replace_duplicate_labelset/fanout.json
+++ b/test/perf/solver-decision-baseline/label_replace_duplicate_labelset/fanout.json
@@ -2,7 +2,7 @@
   "query": "label_replace_duplicate_labelset/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 8,
+  "k": 12,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/label_replace_missing_src/fanout.json
+++ b/test/perf/solver-decision-baseline/label_replace_missing_src/fanout.json
@@ -2,7 +2,7 @@
   "query": "label_replace_missing_src/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 8,
+  "k": 12,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/label_replace_missing_src_overwrite/fanout.json
+++ b/test/perf/solver-decision-baseline/label_replace_missing_src_overwrite/fanout.json
@@ -2,7 +2,7 @@
   "query": "label_replace_missing_src_overwrite/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 8,
+  "k": 12,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/label_replace_named_capture/fanout.json
+++ b/test/perf/solver-decision-baseline/label_replace_named_capture/fanout.json
@@ -2,7 +2,7 @@
   "query": "label_replace_named_capture/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 8,
+  "k": 12,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/label_replace_negative_sibling_probe/fanout.json
+++ b/test/perf/solver-decision-baseline/label_replace_negative_sibling_probe/fanout.json
@@ -2,7 +2,7 @@
   "query": "label_replace_negative_sibling_probe/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 8,
+  "k": 12,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/label_replace_no_match/fanout.json
+++ b/test/perf/solver-decision-baseline/label_replace_no_match/fanout.json
@@ -2,7 +2,7 @@
   "query": "label_replace_no_match/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 8,
+  "k": 12,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/label_replace_nullable_shared_capture_name/fanout.json
+++ b/test/perf/solver-decision-baseline/label_replace_nullable_shared_capture_name/fanout.json
@@ -2,7 +2,7 @@
   "query": "label_replace_nullable_shared_capture_name/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 8,
+  "k": 12,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/label_replace_over_native_rate_range_step/fanout.json
+++ b/test/perf/solver-decision-baseline/label_replace_over_native_rate_range_step/fanout.json
@@ -2,7 +2,7 @@
   "query": "label_replace_over_native_rate_range_step/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 8,
+  "k": 12,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/label_replace_over_rate_range_step/fanout.json
+++ b/test/perf/solver-decision-baseline/label_replace_over_rate_range_step/fanout.json
@@ -2,7 +2,7 @@
   "query": "label_replace_over_rate_range_step/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 8,
+  "k": 12,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/label_replace_over_sum_by_range_step/fanout.json
+++ b/test/perf/solver-decision-baseline/label_replace_over_sum_by_range_step/fanout.json
@@ -2,7 +2,7 @@
   "query": "label_replace_over_sum_by_range_step/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 8,
+  "k": 12,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/label_replace_probed_shared_capture_name/fanout.json
+++ b/test/perf/solver-decision-baseline/label_replace_probed_shared_capture_name/fanout.json
@@ -2,7 +2,7 @@
   "query": "label_replace_probed_shared_capture_name/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 8,
+  "k": 12,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/label_replace_regex_capture/fanout.json
+++ b/test/perf/solver-decision-baseline/label_replace_regex_capture/fanout.json
@@ -2,7 +2,7 @@
   "query": "label_replace_regex_capture/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 8,
+  "k": 12,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/label_replace_shared_capture_name/fanout.json
+++ b/test/perf/solver-decision-baseline/label_replace_shared_capture_name/fanout.json
@@ -2,7 +2,7 @@
   "query": "label_replace_shared_capture_name/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 8,
+  "k": 12,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/label_replace_truncated_shared_capture_name/fanout.json
+++ b/test/perf/solver-decision-baseline/label_replace_truncated_shared_capture_name/fanout.json
@@ -2,7 +2,7 @@
   "query": "label_replace_truncated_shared_capture_name/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 8,
+  "k": 12,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/last_over_time_regex_name/fanout.json
+++ b/test/perf/solver-decision-baseline/last_over_time_regex_name/fanout.json
@@ -2,7 +2,7 @@
   "query": "last_over_time_regex_name/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 8,
+  "k": 12,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/last_over_time_regex_name/native.json
+++ b/test/perf/solver-decision-baseline/last_over_time_regex_name/native.json
@@ -2,7 +2,7 @@
   "query": "last_over_time_regex_name/native",
   "lowering": "native",
   "routed": true,
-  "k": 8,
+  "k": 12,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/limit_ratio_complement/fanout.json
+++ b/test/perf/solver-decision-baseline/limit_ratio_complement/fanout.json
@@ -2,7 +2,7 @@
   "query": "limit_ratio_complement/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 8,
+  "k": 12,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/limit_ratio_half/fanout.json
+++ b/test/perf/solver-decision-baseline/limit_ratio_half/fanout.json
@@ -2,7 +2,7 @@
   "query": "limit_ratio_half/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 8,
+  "k": 12,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/limitk_below_one_empty/fanout.json
+++ b/test/perf/solver-decision-baseline/limitk_below_one_empty/fanout.json
@@ -2,7 +2,7 @@
   "query": "limitk_below_one_empty/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 8,
+  "k": 12,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/ln_metric/fanout.json
+++ b/test/perf/solver-decision-baseline/ln_metric/fanout.json
@@ -2,7 +2,7 @@
   "query": "ln_metric/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 8,
+  "k": 12,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/log10_metric/fanout.json
+++ b/test/perf/solver-decision-baseline/log10_metric/fanout.json
@@ -2,7 +2,7 @@
   "query": "log10_metric/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 8,
+  "k": 12,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/log2_metric/fanout.json
+++ b/test/perf/solver-decision-baseline/log2_metric/fanout.json
@@ -2,7 +2,7 @@
   "query": "log2_metric/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 8,
+  "k": 12,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/lwr_bare_selector_eval_ts_boundary/fanout.json
+++ b/test/perf/solver-decision-baseline/lwr_bare_selector_eval_ts_boundary/fanout.json
@@ -2,7 +2,7 @@
   "query": "lwr_bare_selector_eval_ts_boundary/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 8,
+  "k": 12,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/lwr_bare_selector_latest_per_series/fanout.json
+++ b/test/perf/solver-decision-baseline/lwr_bare_selector_latest_per_series/fanout.json
@@ -2,7 +2,7 @@
   "query": "lwr_bare_selector_latest_per_series/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 8,
+  "k": 12,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/lwr_bare_selector_staleness_window/fanout.json
+++ b/test/perf/solver-decision-baseline/lwr_bare_selector_staleness_window/fanout.json
@@ -2,7 +2,7 @@
   "query": "lwr_bare_selector_staleness_window/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 8,
+  "k": 12,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/map_key_order_count/fanout.json
+++ b/test/perf/solver-decision-baseline/map_key_order_count/fanout.json
@@ -2,7 +2,7 @@
   "query": "map_key_order_count/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 8,
+  "k": 12,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/map_key_order_exp_histogram_count/fanout.json
+++ b/test/perf/solver-decision-baseline/map_key_order_exp_histogram_count/fanout.json
@@ -2,7 +2,7 @@
   "query": "map_key_order_exp_histogram_count/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 8,
+  "k": 12,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/map_key_order_exp_histogram_count/native.json
+++ b/test/perf/solver-decision-baseline/map_key_order_exp_histogram_count/native.json
@@ -2,7 +2,7 @@
   "query": "map_key_order_exp_histogram_count/native",
   "lowering": "native",
   "routed": true,
-  "k": 8,
+  "k": 12,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/map_key_order_histogram_quantile/fanout.json
+++ b/test/perf/solver-decision-baseline/map_key_order_histogram_quantile/fanout.json
@@ -2,7 +2,7 @@
   "query": "map_key_order_histogram_quantile/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 8,
+  "k": 12,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/map_key_order_histogram_quantile/native.json
+++ b/test/perf/solver-decision-baseline/map_key_order_histogram_quantile/native.json
@@ -2,7 +2,7 @@
   "query": "map_key_order_histogram_quantile/native",
   "lowering": "native",
   "routed": true,
-  "k": 8,
+  "k": 12,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/map_key_order_increase/fanout.json
+++ b/test/perf/solver-decision-baseline/map_key_order_increase/fanout.json
@@ -2,7 +2,7 @@
   "query": "map_key_order_increase/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 8,
+  "k": 12,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/map_key_order_increase/native.json
+++ b/test/perf/solver-decision-baseline/map_key_order_increase/native.json
@@ -2,7 +2,7 @@
   "query": "map_key_order_increase/native",
   "lowering": "native",
   "routed": true,
-  "k": 8,
+  "k": 12,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/map_key_order_sum_by_labels/fanout.json
+++ b/test/perf/solver-decision-baseline/map_key_order_sum_by_labels/fanout.json
@@ -2,7 +2,7 @@
   "query": "map_key_order_sum_by_labels/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 8,
+  "k": 12,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/map_key_order_sum_without_label/fanout.json
+++ b/test/perf/solver-decision-baseline/map_key_order_sum_without_label/fanout.json
@@ -2,7 +2,7 @@
   "query": "map_key_order_sum_without_label/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 8,
+  "k": 12,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/matcher_and_agg_by_service_name/fanout.json
+++ b/test/perf/solver-decision-baseline/matcher_and_agg_by_service_name/fanout.json
@@ -2,7 +2,7 @@
   "query": "matcher_and_agg_by_service_name/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 8,
+  "k": 12,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/matcher_dotted_source/fanout.json
+++ b/test/perf/solver-decision-baseline/matcher_dotted_source/fanout.json
@@ -2,7 +2,7 @@
   "query": "matcher_dotted_source/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 8,
+  "k": 12,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/matcher_service_name/fanout.json
+++ b/test/perf/solver-decision-baseline/matcher_service_name/fanout.json
@@ -2,7 +2,7 @@
   "query": "matcher_service_name/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 8,
+  "k": 12,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/metadata_label_names_leaf_projection/fanout.json
+++ b/test/perf/solver-decision-baseline/metadata_label_names_leaf_projection/fanout.json
@@ -2,7 +2,7 @@
   "query": "metadata_label_names_leaf_projection/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 8,
+  "k": 12,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/metadata_label_values_bucket_le/fanout.json
+++ b/test/perf/solver-decision-baseline/metadata_label_values_bucket_le/fanout.json
@@ -2,7 +2,7 @@
   "query": "metadata_label_values_bucket_le/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 8,
+  "k": 12,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/metadata_label_values_collides_on_sanitized_name/fanout.json
+++ b/test/perf/solver-decision-baseline/metadata_label_values_collides_on_sanitized_name/fanout.json
@@ -2,7 +2,7 @@
   "query": "metadata_label_values_collides_on_sanitized_name/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 8,
+  "k": 12,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/metadata_label_values_dotted_source_key/fanout.json
+++ b/test/perf/solver-decision-baseline/metadata_label_values_dotted_source_key/fanout.json
@@ -2,7 +2,7 @@
   "query": "metadata_label_values_dotted_source_key/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 8,
+  "k": 12,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/metadata_label_values_leaf_projection/fanout.json
+++ b/test/perf/solver-decision-baseline/metadata_label_values_leaf_projection/fanout.json
@@ -2,7 +2,7 @@
   "query": "metadata_label_values_leaf_projection/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 8,
+  "k": 12,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/minute_of_vector/fanout.json
+++ b/test/perf/solver-decision-baseline/minute_of_vector/fanout.json
@@ -2,7 +2,7 @@
   "query": "minute_of_vector/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 8,
+  "k": 12,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/mod_arithmetic/fanout.json
+++ b/test/perf/solver-decision-baseline/mod_arithmetic/fanout.json
@@ -2,7 +2,7 @@
   "query": "mod_arithmetic/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 8,
+  "k": 12,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/month_of_vector/fanout.json
+++ b/test/perf/solver-decision-baseline/month_of_vector/fanout.json
@@ -2,7 +2,7 @@
   "query": "month_of_vector/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 8,
+  "k": 12,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/multiple_matchers/fanout.json
+++ b/test/perf/solver-decision-baseline/multiple_matchers/fanout.json
@@ -2,7 +2,7 @@
   "query": "multiple_matchers/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 8,
+  "k": 12,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/native_changes_range_step/fanout.json
+++ b/test/perf/solver-decision-baseline/native_changes_range_step/fanout.json
@@ -2,7 +2,7 @@
   "query": "native_changes_range_step/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 8,
+  "k": 12,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/native_changes_range_step/native.json
+++ b/test/perf/solver-decision-baseline/native_changes_range_step/native.json
@@ -2,7 +2,7 @@
   "query": "native_changes_range_step/native",
   "lowering": "native",
   "routed": true,
-  "k": 8,
+  "k": 12,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/native_deriv_range_step/fanout.json
+++ b/test/perf/solver-decision-baseline/native_deriv_range_step/fanout.json
@@ -2,7 +2,7 @@
   "query": "native_deriv_range_step/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 8,
+  "k": 12,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/native_rate_range_step/fanout.json
+++ b/test/perf/solver-decision-baseline/native_rate_range_step/fanout.json
@@ -2,7 +2,7 @@
   "query": "native_rate_range_step/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 8,
+  "k": 12,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/native_rate_recollapse_collision/fanout.json
+++ b/test/perf/solver-decision-baseline/native_rate_recollapse_collision/fanout.json
@@ -2,7 +2,7 @@
   "query": "native_rate_recollapse_collision/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 8,
+  "k": 12,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/native_rate_recollapse_collision_two_level/fanout.json
+++ b/test/perf/solver-decision-baseline/native_rate_recollapse_collision_two_level/fanout.json
@@ -2,7 +2,7 @@
   "query": "native_rate_recollapse_collision_two_level/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 8,
+  "k": 12,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/native_rate_recollapse_histogram_companion/fanout.json
+++ b/test/perf/solver-decision-baseline/native_rate_recollapse_histogram_companion/fanout.json
@@ -2,7 +2,7 @@
   "query": "native_rate_recollapse_histogram_companion/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 8,
+  "k": 12,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/native_rate_recollapse_histogram_companion/native.json
+++ b/test/perf/solver-decision-baseline/native_rate_recollapse_histogram_companion/native.json
@@ -2,7 +2,7 @@
   "query": "native_rate_recollapse_histogram_companion/native",
   "lowering": "native",
   "routed": true,
-  "k": 8,
+  "k": 12,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/native_rate_recollapse_metric_name_isolation/fanout.json
+++ b/test/perf/solver-decision-baseline/native_rate_recollapse_metric_name_isolation/fanout.json
@@ -2,7 +2,7 @@
   "query": "native_rate_recollapse_metric_name_isolation/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 8,
+  "k": 12,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/native_rate_recollapse_range_step/fanout.json
+++ b/test/perf/solver-decision-baseline/native_rate_recollapse_range_step/fanout.json
@@ -2,7 +2,7 @@
   "query": "native_rate_recollapse_range_step/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 8,
+  "k": 12,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/native_rate_temporality_cumulative/fanout.json
+++ b/test/perf/solver-decision-baseline/native_rate_temporality_cumulative/fanout.json
@@ -2,7 +2,7 @@
   "query": "native_rate_temporality_cumulative/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 8,
+  "k": 12,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/native_rate_temporality_delta/fanout.json
+++ b/test/perf/solver-decision-baseline/native_rate_temporality_delta/fanout.json
@@ -2,7 +2,7 @@
   "query": "native_rate_temporality_delta/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 8,
+  "k": 12,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/native_rate_temporality_mixed/fanout.json
+++ b/test/perf/solver-decision-baseline/native_rate_temporality_mixed/fanout.json
@@ -2,7 +2,7 @@
   "query": "native_rate_temporality_mixed/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 8,
+  "k": 12,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/native_resample_offset/fanout.json
+++ b/test/perf/solver-decision-baseline/native_resample_offset/fanout.json
@@ -2,7 +2,7 @@
   "query": "native_resample_offset/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 8,
+  "k": 12,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/native_resample_range_step/fanout.json
+++ b/test/perf/solver-decision-baseline/native_resample_range_step/fanout.json
@@ -2,7 +2,7 @@
   "query": "native_resample_range_step/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 8,
+  "k": 12,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/native_resets_range_step/fanout.json
+++ b/test/perf/solver-decision-baseline/native_resets_range_step/fanout.json
@@ -2,7 +2,7 @@
   "query": "native_resets_range_step/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 8,
+  "k": 12,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/negative_offset/fanout.json
+++ b/test/perf/solver-decision-baseline/negative_offset/fanout.json
@@ -2,7 +2,7 @@
   "query": "negative_offset/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 8,
+  "k": 12,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/no_name_matcher_reaches_histogram_tables/fanout.json
+++ b/test/perf/solver-decision-baseline/no_name_matcher_reaches_histogram_tables/fanout.json
@@ -2,7 +2,7 @@
   "query": "no_name_matcher_reaches_histogram_tables/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 8,
+  "k": 12,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/not_regex_label/fanout.json
+++ b/test/perf/solver-decision-baseline/not_regex_label/fanout.json
@@ -2,7 +2,7 @@
   "query": "not_regex_label/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 8,
+  "k": 12,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/not_regex_name_matcher_excludes_dotted/fanout.json
+++ b/test/perf/solver-decision-baseline/not_regex_name_matcher_excludes_dotted/fanout.json
@@ -2,7 +2,7 @@
   "query": "not_regex_name_matcher_excludes_dotted/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 8,
+  "k": 12,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/offset_negative/fanout.json
+++ b/test/perf/solver-decision-baseline/offset_negative/fanout.json
@@ -2,7 +2,7 @@
   "query": "offset_negative/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 8,
+  "k": 12,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/paren_range_vector_double/fanout.json
+++ b/test/perf/solver-decision-baseline/paren_range_vector_double/fanout.json
@@ -2,7 +2,7 @@
   "query": "paren_range_vector_double/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 8,
+  "k": 12,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/paren_range_vector_quantile_over_time/fanout.json
+++ b/test/perf/solver-decision-baseline/paren_range_vector_quantile_over_time/fanout.json
@@ -2,7 +2,7 @@
   "query": "paren_range_vector_quantile_over_time/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 8,
+  "k": 12,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/paren_range_vector_quantile_over_time/native.json
+++ b/test/perf/solver-decision-baseline/paren_range_vector_quantile_over_time/native.json
@@ -2,7 +2,7 @@
   "query": "paren_range_vector_quantile_over_time/native",
   "lowering": "native",
   "routed": true,
-  "k": 8,
+  "k": 12,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/paren_range_vector_rate/fanout.json
+++ b/test/perf/solver-decision-baseline/paren_range_vector_rate/fanout.json
@@ -2,7 +2,7 @@
   "query": "paren_range_vector_rate/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 8,
+  "k": 12,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/pinned_name_selector_no_histogram_fanout/fanout.json
+++ b/test/perf/solver-decision-baseline/pinned_name_selector_no_histogram_fanout/fanout.json
@@ -2,7 +2,7 @@
   "query": "pinned_name_selector_no_histogram_fanout/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 8,
+  "k": 12,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/pow_arithmetic/fanout.json
+++ b/test/perf/solver-decision-baseline/pow_arithmetic/fanout.json
@@ -2,7 +2,7 @@
   "query": "pow_arithmetic/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 8,
+  "k": 12,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/power_op_basic/fanout.json
+++ b/test/perf/solver-decision-baseline/power_op_basic/fanout.json
@@ -2,7 +2,7 @@
   "query": "power_op_basic/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 8,
+  "k": 12,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/predict_linear_scalar_horizon/fanout.json
+++ b/test/perf/solver-decision-baseline/predict_linear_scalar_horizon/fanout.json
@@ -2,7 +2,7 @@
   "query": "predict_linear_scalar_horizon/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 8,
+  "k": 12,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/predict_linear_scalar_horizon/native.json
+++ b/test/perf/solver-decision-baseline/predict_linear_scalar_horizon/native.json
@@ -2,7 +2,7 @@
   "query": "predict_linear_scalar_horizon/native",
   "lowering": "native",
   "routed": true,
-  "k": 8,
+  "k": 12,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/predict_linear_simple/fanout.json
+++ b/test/perf/solver-decision-baseline/predict_linear_simple/fanout.json
@@ -2,7 +2,7 @@
   "query": "predict_linear_simple/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 8,
+  "k": 12,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/present_over_time_exp_histogram/fanout.json
+++ b/test/perf/solver-decision-baseline/present_over_time_exp_histogram/fanout.json
@@ -2,7 +2,7 @@
   "query": "present_over_time_exp_histogram/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 8,
+  "k": 12,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/present_over_time_exp_histogram/native.json
+++ b/test/perf/solver-decision-baseline/present_over_time_exp_histogram/native.json
@@ -2,7 +2,7 @@
   "query": "present_over_time_exp_histogram/native",
   "lowering": "native",
   "routed": true,
-  "k": 8,
+  "k": 12,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/present_over_time_with_data/fanout.json
+++ b/test/perf/solver-decision-baseline/present_over_time_with_data/fanout.json
@@ -2,7 +2,7 @@
   "query": "present_over_time_with_data/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 8,
+  "k": 12,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/present_over_time_with_data/native.json
+++ b/test/perf/solver-decision-baseline/present_over_time_with_data/native.json
@@ -2,7 +2,7 @@
   "query": "present_over_time_with_data/native",
   "lowering": "native",
   "routed": true,
-  "k": 8,
+  "k": 12,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/quantile_by_job/fanout.json
+++ b/test/perf/solver-decision-baseline/quantile_by_job/fanout.json
@@ -2,7 +2,7 @@
   "query": "quantile_by_job/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 8,
+  "k": 12,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/quantile_over_time_scalar_phi/fanout.json
+++ b/test/perf/solver-decision-baseline/quantile_over_time_scalar_phi/fanout.json
@@ -2,7 +2,7 @@
   "query": "quantile_over_time_scalar_phi/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 8,
+  "k": 12,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/quantile_over_time_scalar_phi/native.json
+++ b/test/perf/solver-decision-baseline/quantile_over_time_scalar_phi/native.json
@@ -2,7 +2,7 @@
   "query": "quantile_over_time_scalar_phi/native",
   "lowering": "native",
   "routed": true,
-  "k": 8,
+  "k": 12,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/quantile_q_above_one/fanout.json
+++ b/test/perf/solver-decision-baseline/quantile_q_above_one/fanout.json
@@ -2,7 +2,7 @@
   "query": "quantile_q_above_one/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 8,
+  "k": 12,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/quantile_q_negative/fanout.json
+++ b/test/perf/solver-decision-baseline/quantile_q_negative/fanout.json
@@ -2,7 +2,7 @@
   "query": "quantile_q_negative/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 8,
+  "k": 12,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/quantile_scalar_phi/fanout.json
+++ b/test/perf/solver-decision-baseline/quantile_scalar_phi/fanout.json
@@ -2,7 +2,7 @@
   "query": "quantile_scalar_phi/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 8,
+  "k": 12,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/quantile_scalar_phi_nan/fanout.json
+++ b/test/perf/solver-decision-baseline/quantile_scalar_phi_nan/fanout.json
@@ -2,7 +2,7 @@
   "query": "quantile_scalar_phi_nan/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 8,
+  "k": 12,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/rad_metric/fanout.json
+++ b/test/perf/solver-decision-baseline/rad_metric/fanout.json
@@ -2,7 +2,7 @@
   "query": "rad_metric/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 8,
+  "k": 12,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/range_window_func_over_scalar_div/fanout.json
+++ b/test/perf/solver-decision-baseline/range_window_func_over_scalar_div/fanout.json
@@ -2,7 +2,7 @@
   "query": "range_window_func_over_scalar_div/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 8,
+  "k": 12,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/range_window_func_over_scalar_div/native.json
+++ b/test/perf/solver-decision-baseline/range_window_func_over_scalar_div/native.json
@@ -2,7 +2,7 @@
   "query": "range_window_func_over_scalar_div/native",
   "lowering": "native",
   "routed": true,
-  "k": 8,
+  "k": 12,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/rate_multi_name_duplicate_labelset_guard/fanout.json
+++ b/test/perf/solver-decision-baseline/rate_multi_name_duplicate_labelset_guard/fanout.json
@@ -2,7 +2,7 @@
   "query": "rate_multi_name_duplicate_labelset_guard/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 8,
+  "k": 12,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/rate_multi_name_duplicate_labelset_guard/native.json
+++ b/test/perf/solver-decision-baseline/rate_multi_name_duplicate_labelset_guard/native.json
@@ -2,7 +2,7 @@
   "query": "rate_multi_name_duplicate_labelset_guard/native",
   "lowering": "native",
   "routed": true,
-  "k": 8,
+  "k": 12,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/regex_alternation/fanout.json
+++ b/test/perf/solver-decision-baseline/regex_alternation/fanout.json
@@ -2,7 +2,7 @@
   "query": "regex_alternation/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 8,
+  "k": 12,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/regex_anchored/fanout.json
+++ b/test/perf/solver-decision-baseline/regex_anchored/fanout.json
@@ -2,7 +2,7 @@
   "query": "regex_anchored/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 8,
+  "k": 12,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/regex_name_matcher_scans_exp_histogram_table/fanout.json
+++ b/test/perf/solver-decision-baseline/regex_name_matcher_scans_exp_histogram_table/fanout.json
@@ -2,7 +2,7 @@
   "query": "regex_name_matcher_scans_exp_histogram_table/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 8,
+  "k": 12,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/regex_name_matcher_scans_sum_table/fanout.json
+++ b/test/perf/solver-decision-baseline/regex_name_matcher_scans_sum_table/fanout.json
@@ -2,7 +2,7 @@
   "query": "regex_name_matcher_scans_sum_table/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 8,
+  "k": 12,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/regex_name_matcher_underscored_matches_dotted/fanout.json
+++ b/test/perf/solver-decision-baseline/regex_name_matcher_underscored_matches_dotted/fanout.json
@@ -2,7 +2,7 @@
   "query": "regex_name_matcher_underscored_matches_dotted/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 8,
+  "k": 12,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/regex_unanchored_no_overmatch/fanout.json
+++ b/test/perf/solver-decision-baseline/regex_unanchored_no_overmatch/fanout.json
@@ -2,7 +2,7 @@
   "query": "regex_unanchored_no_overmatch/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 8,
+  "k": 12,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/resets_counter/fanout.json
+++ b/test/perf/solver-decision-baseline/resets_counter/fanout.json
@@ -2,7 +2,7 @@
   "query": "resets_counter/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 8,
+  "k": 12,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/resource_attr_bare_selector/fanout.json
+++ b/test/perf/solver-decision-baseline/resource_attr_bare_selector/fanout.json
@@ -2,7 +2,7 @@
   "query": "resource_attr_bare_selector/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 8,
+  "k": 12,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/resource_attr_matcher/fanout.json
+++ b/test/perf/solver-decision-baseline/resource_attr_matcher/fanout.json
@@ -2,7 +2,7 @@
   "query": "resource_attr_matcher/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 8,
+  "k": 12,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/resource_attr_precedence_collision/fanout.json
+++ b/test/perf/solver-decision-baseline/resource_attr_precedence_collision/fanout.json
@@ -2,7 +2,7 @@
   "query": "resource_attr_precedence_collision/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 8,
+  "k": 12,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/resource_attr_sum_by/fanout.json
+++ b/test/perf/solver-decision-baseline/resource_attr_sum_by/fanout.json
@@ -2,7 +2,7 @@
   "query": "resource_attr_sum_by/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 8,
+  "k": 12,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/resource_attrs_allowlist_lookup_table/fanout.json
+++ b/test/perf/solver-decision-baseline/resource_attrs_allowlist_lookup_table/fanout.json
@@ -2,7 +2,7 @@
   "query": "resource_attrs_allowlist_lookup_table/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 8,
+  "k": 12,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/round_metric/fanout.json
+++ b/test/perf/solver-decision-baseline/round_metric/fanout.json
@@ -2,7 +2,7 @@
   "query": "round_metric/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 8,
+  "k": 12,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/round_scalar_to_nearest/fanout.json
+++ b/test/perf/solver-decision-baseline/round_scalar_to_nearest/fanout.json
@@ -2,7 +2,7 @@
   "query": "round_scalar_to_nearest/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 8,
+  "k": 12,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/round_to_nearest/fanout.json
+++ b/test/perf/solver-decision-baseline/round_to_nearest/fanout.json
@@ -2,7 +2,7 @@
   "query": "round_to_nearest/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 8,
+  "k": 12,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/scalar_lt_vector/fanout.json
+++ b/test/perf/solver-decision-baseline/scalar_lt_vector/fanout.json
@@ -2,7 +2,7 @@
   "query": "scalar_lt_vector/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 8,
+  "k": 12,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/scalar_minus_vector/fanout.json
+++ b/test/perf/solver-decision-baseline/scalar_minus_vector/fanout.json
@@ -2,7 +2,7 @@
   "query": "scalar_minus_vector/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 8,
+  "k": 12,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/scalar_mul_rate/fanout.json
+++ b/test/perf/solver-decision-baseline/scalar_mul_rate/fanout.json
@@ -2,7 +2,7 @@
   "query": "scalar_mul_rate/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 8,
+  "k": 12,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/scan_unions_gauge_for_suffixed_standalone_gauge/fanout.json
+++ b/test/perf/solver-decision-baseline/scan_unions_gauge_for_suffixed_standalone_gauge/fanout.json
@@ -2,7 +2,7 @@
   "query": "scan_unions_gauge_for_suffixed_standalone_gauge/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 8,
+  "k": 12,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/scan_unions_gauge_sum_for_unsuffixed_metric/fanout.json
+++ b/test/perf/solver-decision-baseline/scan_unions_gauge_sum_for_unsuffixed_metric/fanout.json
@@ -2,7 +2,7 @@
   "query": "scan_unions_gauge_sum_for_unsuffixed_metric/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 8,
+  "k": 12,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/scan_unions_histogram_sum_for_suffixed_metric/fanout.json
+++ b/test/perf/solver-decision-baseline/scan_unions_histogram_sum_for_suffixed_metric/fanout.json
@@ -2,7 +2,7 @@
   "query": "scan_unions_histogram_sum_for_suffixed_metric/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 8,
+  "k": 12,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/scientific_threshold/fanout.json
+++ b/test/perf/solver-decision-baseline/scientific_threshold/fanout.json
@@ -2,7 +2,7 @@
   "query": "scientific_threshold/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 8,
+  "k": 12,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/sgn_metric/fanout.json
+++ b/test/perf/solver-decision-baseline/sgn_metric/fanout.json
@@ -2,7 +2,7 @@
   "query": "sgn_metric/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 8,
+  "k": 12,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/sort_by_label_no_label/fanout.json
+++ b/test/perf/solver-decision-baseline/sort_by_label_no_label/fanout.json
@@ -2,7 +2,7 @@
   "query": "sort_by_label_no_label/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 8,
+  "k": 12,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/sqrt_metric/fanout.json
+++ b/test/perf/solver-decision-baseline/sqrt_metric/fanout.json
@@ -2,7 +2,7 @@
   "query": "sqrt_metric/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 8,
+  "k": 12,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/stddev_by_job/fanout.json
+++ b/test/perf/solver-decision-baseline/stddev_by_job/fanout.json
@@ -2,7 +2,7 @@
   "query": "stddev_by_job/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 8,
+  "k": 12,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/stdvar_no_group/fanout.json
+++ b/test/perf/solver-decision-baseline/stdvar_no_group/fanout.json
@@ -2,7 +2,7 @@
   "query": "stdvar_no_group/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 8,
+  "k": 12,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/stdvar_over_time_basic/fanout.json
+++ b/test/perf/solver-decision-baseline/stdvar_over_time_basic/fanout.json
@@ -2,7 +2,7 @@
   "query": "stdvar_over_time_basic/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 8,
+  "k": 12,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/stdvar_over_time_basic/native.json
+++ b/test/perf/solver-decision-baseline/stdvar_over_time_basic/native.json
@@ -2,7 +2,7 @@
   "query": "stdvar_over_time_basic/native",
   "lowering": "native",
   "routed": true,
-  "k": 8,
+  "k": 12,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/sum_by_job/fanout.json
+++ b/test/perf/solver-decision-baseline/sum_by_job/fanout.json
@@ -2,7 +2,7 @@
   "query": "sum_by_job/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 8,
+  "k": 12,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/sum_by_rate_dotted_source/fanout.json
+++ b/test/perf/solver-decision-baseline/sum_by_rate_dotted_source/fanout.json
@@ -2,7 +2,7 @@
   "query": "sum_by_rate_dotted_source/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 8,
+  "k": 12,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/sum_by_rate_range_offset/fanout.json
+++ b/test/perf/solver-decision-baseline/sum_by_rate_range_offset/fanout.json
@@ -2,7 +2,7 @@
   "query": "sum_by_rate_range_offset/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 8,
+  "k": 12,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/sum_by_rate_range_offset_negative/fanout.json
+++ b/test/perf/solver-decision-baseline/sum_by_rate_range_offset_negative/fanout.json
@@ -2,7 +2,7 @@
   "query": "sum_by_rate_range_offset_negative/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 8,
+  "k": 12,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/sum_by_rate_range_step/fanout.json
+++ b/test/perf/solver-decision-baseline/sum_by_rate_range_step/fanout.json
@@ -2,7 +2,7 @@
   "query": "sum_by_rate_range_step/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 8,
+  "k": 12,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/sum_by_underscored_otel_label/fanout.json
+++ b/test/perf/solver-decision-baseline/sum_by_underscored_otel_label/fanout.json
@@ -2,7 +2,7 @@
   "query": "sum_by_underscored_otel_label/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 8,
+  "k": 12,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/sum_without_empty/fanout.json
+++ b/test/perf/solver-decision-baseline/sum_without_empty/fanout.json
@@ -2,7 +2,7 @@
   "query": "sum_without_empty/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 8,
+  "k": 12,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/sum_without_instance/fanout.json
+++ b/test/perf/solver-decision-baseline/sum_without_instance/fanout.json
@@ -2,7 +2,7 @@
   "query": "sum_without_instance/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 8,
+  "k": 12,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/sum_without_two_labels/fanout.json
+++ b/test/perf/solver-decision-baseline/sum_without_two_labels/fanout.json
@@ -2,7 +2,7 @@
   "query": "sum_without_two_labels/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 8,
+  "k": 12,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/timestamp_of_exp_histogram_bare_selector/fanout.json
+++ b/test/perf/solver-decision-baseline/timestamp_of_exp_histogram_bare_selector/fanout.json
@@ -2,7 +2,7 @@
   "query": "timestamp_of_exp_histogram_bare_selector/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 8,
+  "k": 12,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/timestamp_of_exp_histogram_bare_selector/native.json
+++ b/test/perf/solver-decision-baseline/timestamp_of_exp_histogram_bare_selector/native.json
@@ -2,7 +2,7 @@
   "query": "timestamp_of_exp_histogram_bare_selector/native",
   "lowering": "native",
   "routed": true,
-  "k": 8,
+  "k": 12,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/timestamp_of_exp_histogram_bare_selector_range/fanout.json
+++ b/test/perf/solver-decision-baseline/timestamp_of_exp_histogram_bare_selector_range/fanout.json
@@ -2,7 +2,7 @@
   "query": "timestamp_of_exp_histogram_bare_selector_range/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 8,
+  "k": 12,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/timestamp_of_exp_histogram_bare_selector_range/native.json
+++ b/test/perf/solver-decision-baseline/timestamp_of_exp_histogram_bare_selector_range/native.json
@@ -2,7 +2,7 @@
   "query": "timestamp_of_exp_histogram_bare_selector_range/native",
   "lowering": "native",
   "routed": true,
-  "k": 8,
+  "k": 12,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/timestamp_of_metric/fanout.json
+++ b/test/perf/solver-decision-baseline/timestamp_of_metric/fanout.json
@@ -2,7 +2,7 @@
   "query": "timestamp_of_metric/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 8,
+  "k": 12,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/timestamp_of_metric/native.json
+++ b/test/perf/solver-decision-baseline/timestamp_of_metric/native.json
@@ -2,7 +2,7 @@
   "query": "timestamp_of_metric/native",
   "lowering": "native",
   "routed": true,
-  "k": 8,
+  "k": 12,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/timestamp_of_metric_range_step/fanout.json
+++ b/test/perf/solver-decision-baseline/timestamp_of_metric_range_step/fanout.json
@@ -2,7 +2,7 @@
   "query": "timestamp_of_metric_range_step/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 8,
+  "k": 12,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/timestamp_of_metric_range_step/native.json
+++ b/test/perf/solver-decision-baseline/timestamp_of_metric_range_step/native.json
@@ -2,7 +2,7 @@
   "query": "timestamp_of_metric_range_step/native",
   "lowering": "native",
   "routed": true,
-  "k": 8,
+  "k": 12,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/timestamp_of_metric_range_step_native_resample/fanout.json
+++ b/test/perf/solver-decision-baseline/timestamp_of_metric_range_step_native_resample/fanout.json
@@ -2,7 +2,7 @@
   "query": "timestamp_of_metric_range_step_native_resample/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 8,
+  "k": 12,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/timestamp_of_metric_range_step_native_resample/native.json
+++ b/test/perf/solver-decision-baseline/timestamp_of_metric_range_step_native_resample/native.json
@@ -2,7 +2,7 @@
   "query": "timestamp_of_metric_range_step_native_resample/native",
   "lowering": "native",
   "routed": true,
-  "k": 8,
+  "k": 12,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/timestamp_of_parenthesised_metric/fanout.json
+++ b/test/perf/solver-decision-baseline/timestamp_of_parenthesised_metric/fanout.json
@@ -2,7 +2,7 @@
   "query": "timestamp_of_parenthesised_metric/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 8,
+  "k": 12,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/timestamp_of_parenthesised_metric/native.json
+++ b/test/perf/solver-decision-baseline/timestamp_of_parenthesised_metric/native.json
@@ -2,7 +2,7 @@
   "query": "timestamp_of_parenthesised_metric/native",
   "lowering": "native",
   "routed": true,
-  "k": 8,
+  "k": 12,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/timestamp_of_transformed_metric/fanout.json
+++ b/test/perf/solver-decision-baseline/timestamp_of_transformed_metric/fanout.json
@@ -2,7 +2,7 @@
   "query": "timestamp_of_transformed_metric/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 8,
+  "k": 12,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/timestamp_staleness_age_range_step/fanout.json
+++ b/test/perf/solver-decision-baseline/timestamp_staleness_age_range_step/fanout.json
@@ -2,7 +2,7 @@
   "query": "timestamp_staleness_age_range_step/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 8,
+  "k": 12,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/timestamp_staleness_age_range_step/native.json
+++ b/test/perf/solver-decision-baseline/timestamp_staleness_age_range_step/native.json
@@ -2,7 +2,7 @@
   "query": "timestamp_staleness_age_range_step/native",
   "lowering": "native",
   "routed": true,
-  "k": 8,
+  "k": 12,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/topk_zero_empty/fanout.json
+++ b/test/perf/solver-decision-baseline/topk_zero_empty/fanout.json
@@ -2,7 +2,7 @@
   "query": "topk_zero_empty/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 8,
+  "k": 12,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/trig_acos_metric/fanout.json
+++ b/test/perf/solver-decision-baseline/trig_acos_metric/fanout.json
@@ -2,7 +2,7 @@
   "query": "trig_acos_metric/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 8,
+  "k": 12,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/trig_cos_metric/fanout.json
+++ b/test/perf/solver-decision-baseline/trig_cos_metric/fanout.json
@@ -2,7 +2,7 @@
   "query": "trig_cos_metric/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 8,
+  "k": 12,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/trig_sin_metric/fanout.json
+++ b/test/perf/solver-decision-baseline/trig_sin_metric/fanout.json
@@ -2,7 +2,7 @@
   "query": "trig_sin_metric/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 8,
+  "k": 12,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/trig_sinh_metric/fanout.json
+++ b/test/perf/solver-decision-baseline/trig_sinh_metric/fanout.json
@@ -2,7 +2,7 @@
   "query": "trig_sinh_metric/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 8,
+  "k": 12,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/unary_minus_binary_lhs/fanout.json
+++ b/test/perf/solver-decision-baseline/unary_minus_binary_lhs/fanout.json
@@ -2,7 +2,7 @@
   "query": "unary_minus_binary_lhs/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 8,
+  "k": 12,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/unary_minus_in_function/fanout.json
+++ b/test/perf/solver-decision-baseline/unary_minus_in_function/fanout.json
@@ -2,7 +2,7 @@
   "query": "unary_minus_in_function/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 8,
+  "k": 12,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/unary_minus_rate/fanout.json
+++ b/test/perf/solver-decision-baseline/unary_minus_rate/fanout.json
@@ -2,7 +2,7 @@
   "query": "unary_minus_rate/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 8,
+  "k": 12,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/unary_minus_vector/fanout.json
+++ b/test/perf/solver-decision-baseline/unary_minus_vector/fanout.json
@@ -2,7 +2,7 @@
   "query": "unary_minus_vector/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 8,
+  "k": 12,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/unary_plus_vector/fanout.json
+++ b/test/perf/solver-decision-baseline/unary_plus_vector/fanout.json
@@ -2,7 +2,7 @@
   "query": "unary_plus_vector/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 8,
+  "k": 12,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/up/fanout.json
+++ b/test/perf/solver-decision-baseline/up/fanout.json
@@ -2,7 +2,7 @@
   "query": "up/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 8,
+  "k": 12,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/up_gt_bool/fanout.json
+++ b/test/perf/solver-decision-baseline/up_gt_bool/fanout.json
@@ -2,7 +2,7 @@
   "query": "up_gt_bool/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 8,
+  "k": 12,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/up_gt_threshold/fanout.json
+++ b/test/perf/solver-decision-baseline/up_gt_threshold/fanout.json
@@ -2,7 +2,7 @@
   "query": "up_gt_threshold/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 8,
+  "k": 12,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/up_ne_zero/fanout.json
+++ b/test/perf/solver-decision-baseline/up_ne_zero/fanout.json
@@ -2,7 +2,7 @@
   "query": "up_ne_zero/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 8,
+  "k": 12,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/up_offset_5m/fanout.json
+++ b/test/perf/solver-decision-baseline/up_offset_5m/fanout.json
@@ -2,7 +2,7 @@
   "query": "up_offset_5m/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 8,
+  "k": 12,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/up_times_two/fanout.json
+++ b/test/perf/solver-decision-baseline/up_times_two/fanout.json
@@ -2,7 +2,7 @@
   "query": "up_times_two/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 8,
+  "k": 12,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/up_with_label/fanout.json
+++ b/test/perf/solver-decision-baseline/up_with_label/fanout.json
@@ -2,7 +2,7 @@
   "query": "up_with_label/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 8,
+  "k": 12,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/up_with_regex/fanout.json
+++ b/test/perf/solver-decision-baseline/up_with_regex/fanout.json
@@ -2,7 +2,7 @@
   "query": "up_with_regex/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 8,
+  "k": 12,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/vector_div_scalar/fanout.json
+++ b/test/perf/solver-decision-baseline/vector_div_scalar/fanout.json
@@ -2,7 +2,7 @@
   "query": "vector_div_scalar/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 8,
+  "k": 12,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/vector_mod_scalar/fanout.json
+++ b/test/perf/solver-decision-baseline/vector_mod_scalar/fanout.json
@@ -2,7 +2,7 @@
   "query": "vector_mod_scalar/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 8,
+  "k": 12,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/vector_pow_scalar/fanout.json
+++ b/test/perf/solver-decision-baseline/vector_pow_scalar/fanout.json
@@ -2,7 +2,7 @@
   "query": "vector_pow_scalar/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 8,
+  "k": 12,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/year_of_vector/fanout.json
+++ b/test/perf/solver-decision-baseline/year_of_vector/fanout.json
@@ -2,7 +2,7 @@
   "query": "year_of_vector/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 8,
+  "k": 12,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,


### PR DESCRIPTION
## Summary

`carrierGeometry` reported `singlePassFanout` (= 1) for
`chplan.RangeBucketGridNative`, copied from its scalar sibling
`RangeWindowGridNative` where it is true. **It is not true here.**
`singlePass`'s own definition is *"peak intermediate rows per raw row"*, and
this carrier's Level-0 `arrayJoin` emits one row per (sample, `le` rung) while
Level 1 holds one grid state per (series, rung). Its F is the rung count.

So the planner was told an arrayJoin-amplified shape costs the same as a
flat-memory one — which kept the expensive shape under thresholds that exist
to catch expensive shapes.

## Why not simply report a constant F

Considered and rejected. Real bucket widths span **34–136** across the
deployments measured for #2681, while Prometheus's own `DefBuckets` is 10. Any
constant large enough to clear `MinFanout` (16) over-claims for a
default-bucket histogram and would shard cheap panels — precisely the
K-scans-for-no-benefit waste `singlePass`'s doc warns about. Any constant
honest for the default case stays under the threshold and changes nothing.

The rung count is the stored `length(ExplicitBounds)` — real data, unknowable
before the scan. So the gate **switches axis** instead of inventing a number:
a per-rung carrier is gated on the anchor grid, the one factor of its cost the
planner can read before touching data, and precisely the factor a shard
divides.

`minAnchorsForPerRungShard` is set from measurement (#2681's calibration put
the per-query cliff near 94 anchors at width 68 under a 6 GiB cap), above the
widest measured safe grid so small panels still run unsliced, and errs high on
purpose: a per-rung carrier below the line that *does* exhaust memory is not
stranded — the failure-driven route memo escalates it from real evidence.

## Why the predictive path specifically

It carries no live-edge freshness gate. The memo — the only other escalation —
declines every request whose `End` sits in the last step, and a Grafana panel
always does. A live-edge dashboard can therefore only ever be helped here.

## Second commit: the DELTA-arm veto (#2688)

With the fanout fix in place the same windows moved from `below-threshold` to
`anchor-grid-indivisible` — past the cost misclassification, onto a structural
veto. The classic-histogram plan is a **complementary** union (native takes
`temporality != DELTA`, fan-out takes `== DELTA`), and the fan-out lowerer
sets `PeakIndependentOfGrid` on every fan-out it builds, so the delta arm
inherited it and vetoed the whole plan — including the native arm, whose peak
genuinely does divide.

On an all-cumulative deployment that arm matches **zero rows**. The flag's own
contract resolves it: a per-construction-site declaration where *"only a site
that has MEASURED route A to fit sets it true"*, with the zero value
documented as safe. The measurement behind it was taken on the fan-out-**only**
lowering; the complement arm is a different, never-measured site.

## Result: the production dashboard shape works

Real ClickHouse 26.6, 253 series, width 68, **fresh data**, **live-edge
`end=now`**, default config — the shape a Grafana panel actually sends, and
the one the failure-driven memo can never help (its End is always inside
`liveEdgeFreshnessMarginSteps`):

| window | before | after |
|---|---|---|
| 60 min (61 anchors) | 502 | 502 — correct, under the anchor floor |
| **180 min (181 anchors)** | 502 | **200**, 179 pts, `sharded-timeslice;k=8;reason=routed` |
| **360 min (361 anchors)** | 502 | **200**, 357 pts, `k=22;reason=routed` *(at `MaxK=24`)* |

## Third commit: the MaxK backstop (#2685)

360 min still failed at the **default `MaxK=8`**: each shard's scan is widened
by the window lookback, landing at 53.8M units against a 54M bound — over by
**0.4%**. Meanwhile the solver had already derived K = N/MinAnchorsPerSlice =
**22** from the grid itself and was clipping it to 8. MaxK is documented as a
*backstop*; at 8 it was the binding constraint.

Raised to 32, so the anchor-derived sizing governs across realistic dashboard
windows. At `MinAnchorsPerSlice=16` the derived K only reaches 32 at N ≥ 512
anchors, and the head caps a range query at `MaxResolutionPoints` regardless.
Shards run `CERBERUS_SHARD_PARALLEL` (3) at a time, so K=32 is ~11 sequential
rounds — bounded and predictable. It stays a real ceiling.

**Solver-decision baseline regenerated: 386 rows, all ADVANCEMENT.** Pure K
resizing (8 → 12) plus **18 rows that now route where they previously did
not** (12 `anchor-grid-indivisible`, 6 `below-threshold`) — this branch's first
two commits taking effect on the corpus. **Zero rows stopped routing; zero
flipped `routed` true → false.**

## Independently verified against real production ClickHouse

A second deployment (271 series, width 68, live edge, real prod data)
confirmed each step of the chain as it landed:

| test | result |
|---|---|
| 3h, default config | **200**, `sharded-timeslice;k=8;reason=routed`, first request, no warm-up |
| 6h, default config *(before the MaxK commit)* | 502 — the ceiling, on real cardinality |
| 6h, `CERBERUS_SHARD_MAX_K=24` | **200**, `k=22;reason=routed`, 361 points |

`reason=routed` rather than `retry`/`memo-hit` is the point: predictive
routing, so no corroborating failures, no memo warm-up, and no live-edge gate.

## Superseded note

Verified on real ClickHouse 26.6 (253 series, width 68, live-edge windows,
default config):

| window | before | after |
|---|---|---|
| 60 min | `below-threshold` | `below-threshold` (correct — under the floor) |
| 180 min | `below-threshold` | **`anchor-grid-indivisible`** |
| 360 min | `below-threshold` | **`anchor-grid-indivisible`** |

Independently reproduced against real production ClickHouse from a second
deployment, confirming the signature change on both windows. The second commit
then clears that veto — see above.

## Test plan

- [x] `TestRangeBucketGridNative_PredictiveRoutingOnTheAnchorAxis` — pins both
      sides: a grid above the floor routes at plan time; a sub-floor grid still
      declines, and declines on COST (`below-threshold`) rather than structure.
- [x] `TestRangeBucketGridNative_EligibleStillBypassesThresholds` — the memo
      seam is unchanged: measured evidence still escalates a plan of any size.
- [x] `go test ./internal/solver/ ./internal/chplan/ ./internal/engine/` green.
- [x] Live verification on real ClickHouse, table above.

Refs #2677

Closes #2687

Closes #2688

Closes #2685
