### PR TITLE
feat(chaudit): audit a live deployment against the histogram resource bound

### DIFF
--- a/.go-arch-lint.yml
+++ b/.go-arch-lint.yml
@@ -221,6 +221,12 @@ components:
   # ranks the top-N metrics/labels by cardinality (the offline-invisible OOM
   # risk). Leaf, stdlib-only — no internal deps. Wired from cmd/cerberus only.
   migrateinventory: { in: migrateinventory }
+  # chaudit answers the live-deployment counterpart of migrateinventory's
+  # pre-cutover question: which classic-histogram metrics are near a
+  # resource-bound ceiling NOW, and which label is inflating them. It opens no
+  # ClickHouse connection of its own — the caller injects an already-configured
+  # Querier — so it depends on nothing internal and holds no credentials.
+  chaudit:        { in: chaudit }
   # Offline cutover go/no-go aggregator: reads the JSON artifacts the other
   # migration blocks emit and folds them into one PASS/FAIL decision. Depends
   # only on the blocks whose JSON contracts it reuses. Wired from cmd/cerberus.

--- a/cmd/cerberus/cli.go
+++ b/cmd/cerberus/cli.go
@@ -46,6 +46,7 @@ func newRootCmd(runServer func() error) *cobra.Command {
 	root.AddCommand(newConfigDocsCmd())
 	root.AddCommand(newOptDocsCmd())
 	root.AddCommand(newRouteRulesCmd())
+	root.AddCommand(newAuditCmd())
 	return root
 }
 
@@ -105,6 +106,13 @@ func exitCodeForError(err error) int {
 	// exit code rather than inventing its own.
 	var dpgate deltaPrefixVerifyFailedError
 	if errors.As(err, &dpgate) {
+		return verifyExitFail
+	}
+	// `audit` finding an over-budget metric is the same class again: the tool
+	// worked and the answer is "no". Sharing verifyExitFail keeps "a gate said
+	// no" one code across every verb rather than one per verb.
+	var overBudget *auditOverBudgetError
+	if errors.As(err, &overBudget) {
 		return verifyExitFail
 	}
 	return 1

--- a/cmd/cerberus/cmd_audit.go
+++ b/cmd/cerberus/cmd_audit.go
@@ -1,0 +1,156 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+
+	"github.com/spf13/cobra"
+
+	"github.com/tsouza/cerberus/internal/chaudit"
+	"github.com/tsouza/cerberus/internal/chclient"
+	"github.com/tsouza/cerberus/internal/config"
+)
+
+// Defaults for `cerberus audit`. They describe the panel an operator is
+// actually defending — the wide dashboard window that trips a resource-bound
+// guard first — rather than a typical one, because a bound that holds for the
+// widest panel holds for every narrower one.
+const (
+	// auditDefaultWindowSeconds is 6h, the dashboard window that produced the
+	// #2677 production incident and the widest one Grafana's stock range
+	// picker offers before the day scale.
+	auditDefaultWindowSeconds = 6 * 60 * 60
+	// auditDefaultAnchors is the grid point count a 6h window yields at a 60s
+	// step — the `anchors` factor of the density guard's own cost model.
+	auditDefaultAnchors = 361
+	// auditDefaultTop bounds the report to the worst offenders. An audit is
+	// read top-down and acted on a few metrics at a time; a full dump of a
+	// large deployment's metric namespace is not actionable.
+	auditDefaultTop = 20
+)
+
+// auditInputs carries newAuditCmd's resolved flags to runAudit, mirroring the
+// deltaPrefixBackfillInputs shape in cmd_schema.go.
+type auditInputs struct {
+	table         string
+	windowSeconds int64
+	anchors       int64
+	budget        int64
+	top           int
+}
+
+// newAuditCmd builds `cerberus audit`: the live-deployment counterpart to
+// `cerberus migrate inventory`. inventory probes a SOURCE Prometheus before a
+// cutover; audit probes the ALREADY-CONNECTED ClickHouse afterwards, so a
+// panel walking up to a resource-bound guard's cap as real traffic and
+// cardinality grow is visible before it goes red rather than after (#2679).
+//
+// It is strictly read-only: chaudit.Querier is a one-method interface over
+// QueryContext precisely so that is checkable by reading the type.
+func newAuditCmd() *cobra.Command {
+	in := auditInputs{
+		windowSeconds: auditDefaultWindowSeconds,
+		anchors:       auditDefaultAnchors,
+		top:           auditDefaultTop,
+	}
+	cmd := &cobra.Command{
+		Use:   "audit",
+		Short: "Audit the connected ClickHouse for metrics near a resource-bound guard",
+		Long: "Probe the connected ClickHouse for classic-histogram metrics whose real\n" +
+			"cardinality and bucket width put them close to (or past) the density\n" +
+			"guard's budget, and name the label amplifying each one.\n\n" +
+			"Reports worst headroom first. Exits non-zero when any metric is already\n" +
+			"over budget, so it can gate a deploy. All connection settings come from\n" +
+			"the same CERBERUS_* environment variables the server reads.",
+		Args:          cobra.NoArgs,
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return runAudit(cmd, in)
+		},
+	}
+	f := cmd.Flags()
+	f.StringVar(&in.table, "table", "",
+		"classic-histogram table to probe (default: the resolved schema's histogram table)")
+	f.Int64Var(&in.windowSeconds, "window-seconds", in.windowSeconds,
+		"lookback window to evaluate, in seconds")
+	f.Int64Var(&in.anchors, "anchors", in.anchors,
+		"grid point count that window implies at the panel's step")
+	f.Int64Var(&in.budget, "budget", 0,
+		"density-unit ceiling to compare against (default: the deployment's resolved bound)")
+	f.IntVar(&in.top, "top", in.top, "how many metrics to report, worst headroom first")
+	return cmd
+}
+
+// runAudit resolves the deployment's own configuration, probes it, and writes
+// the report. Every default that is not supplied on the command line is read
+// from the SAME resolved config the server runs with — auditing a deployment
+// against a bound it does not actually enforce would report confident numbers
+// about a ceiling that is not there.
+func runAudit(cmd *cobra.Command, in auditInputs) error {
+	cfg, err := config.FromEnv()
+	if err != nil {
+		return fmt.Errorf("load config from environment: %w", err)
+	}
+	if in.table == "" {
+		in.table = cfg.Schema.HistogramTable
+	}
+	if in.budget == 0 {
+		in.budget = cfg.RangeBucketGridNativeMaxDensityUnits
+	}
+	opts := chaudit.Options{
+		Table:             in.table,
+		WindowSeconds:     in.windowSeconds,
+		Anchors:           in.anchors,
+		DensityUnitBudget: in.budget,
+		Top:               in.top,
+	}
+	if err := opts.Validate(); err != nil {
+		return err
+	}
+
+	db, err := chclient.OpenSQLDB(cfg.ClickHouse)
+	if err != nil {
+		return fmt.Errorf("connect ClickHouse: %w", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	report, err := chaudit.Probe(cmd.Context(), db, opts)
+	if err != nil {
+		return fmt.Errorf("audit: %w", err)
+	}
+	if err := writeAuditReport(cmd.OutOrStdout(), report); err != nil {
+		return err
+	}
+	// A non-zero exit is the point of running this in CI: an over-budget
+	// metric is not advice, it is a panel that fails today. The report is
+	// written FIRST so the operator sees which metric and by how much, rather
+	// than only an exit code.
+	if over := report.OverBudget(); len(over) > 0 {
+		return &auditOverBudgetError{count: len(over)}
+	}
+	return nil
+}
+
+// writeAuditReport emits the report as indented JSON. JSON rather than a table
+// because the useful consumers are a CI gate and a diff between two runs, both
+// of which need the individual factors (series / rawRows / bucketWidth) that a
+// human-readable summary would collapse.
+func writeAuditReport(w io.Writer, report chaudit.Report) error {
+	enc := json.NewEncoder(w)
+	enc.SetIndent("", "  ")
+	if err := enc.Encode(report); err != nil {
+		return fmt.Errorf("write audit report: %w", err)
+	}
+	return nil
+}
+
+// auditOverBudgetError reports that the audit found metrics already past the
+// guard's budget. It is a distinct type so exitCodeForError can map it without
+// string-matching a message.
+type auditOverBudgetError struct{ count int }
+
+func (e *auditOverBudgetError) Error() string {
+	return fmt.Sprintf("%d metric(s) are already over the density-unit budget", e.count)
+}

--- a/cmd/cerberus/cmd_audit_test.go
+++ b/cmd/cerberus/cmd_audit_test.go
@@ -81,7 +81,7 @@ func TestWriteAuditReport_EmitsTheFactorsIndividually(t *testing.T) {
 		SchemaVersion: chaudit.ReportVersion,
 		Table:         "otel_metrics_histogram",
 		Metrics: []chaudit.MetricAudit{{
-			Metric: "core_http_request_duration_seconds",
+			Metric: "http_request_duration_seconds",
 			Series: 7110, RawRows: 512, BucketWidth: 68,
 			CostUnits: 1468, Budget: 1000, HeadroomPct: -46.8,
 			AmplifyingLabel: "k8s_pod_name", AmplificationRatio: 72.5,

--- a/cmd/cerberus/cmd_audit_test.go
+++ b/cmd/cerberus/cmd_audit_test.go
@@ -1,0 +1,104 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/tsouza/cerberus/internal/chaudit"
+)
+
+// TestAuditCmd_IsRegisteredOnRoot pins that `cerberus audit` is REACHABLE.
+// internal/chaudit shipped as a library first, and a library nothing can
+// invoke is not the "live-deployment audit mode" #2679 asked for — every one
+// of its own tests passed while the feature was unreachable, so the gap this
+// test closes is exactly the one unit tests cannot see.
+func TestAuditCmd_IsRegisteredOnRoot(t *testing.T) {
+	t.Parallel()
+
+	root := newRootCmd(func() error { return nil })
+	for _, c := range root.Commands() {
+		if c.Name() == "audit" {
+			return
+		}
+	}
+	t.Fatal("`cerberus audit` is not registered on the root command; the audit\n" +
+		"package would be unreachable from the binary")
+}
+
+// TestAuditCmd_RejectsUnusableOptionsBeforeDialing pins that a bad invocation
+// fails on its own arguments rather than after opening a ClickHouse
+// connection. Validation ordering is the behaviour: an operator running this
+// against a production deployment should not cause a dial to discover that
+// --anchors was zero.
+func TestAuditCmd_RejectsUnusableOptionsBeforeDialing(t *testing.T) {
+	t.Parallel()
+
+	root := newRootCmd(func() error { return nil })
+	var out bytes.Buffer
+	root.SetOut(&out)
+	root.SetErr(&out)
+	root.SetArgs([]string{"audit", "--table", "t", "--budget", "100", "--anchors", "0"})
+
+	err := root.Execute()
+	if err == nil {
+		t.Fatal("expected --anchors=0 to be rejected")
+	}
+	if !strings.Contains(err.Error(), "Anchors must be > 0") {
+		t.Fatalf("error should name the offending option, got: %v", err)
+	}
+}
+
+// TestAuditOverBudgetError_MapsToGateExitCode pins the exit code an operator
+// gates a deploy on. An over-budget metric means the tool worked and the
+// answer is "no", which must be distinguishable from exit 1 (the tool broke) —
+// otherwise a CI gate cannot tell a real finding from a crash.
+func TestAuditOverBudgetError_MapsToGateExitCode(t *testing.T) {
+	t.Parallel()
+
+	got := exitCodeForError(&auditOverBudgetError{count: 2})
+	if got != verifyExitFail {
+		t.Errorf("exitCodeForError(auditOverBudgetError) = %d, want %d", got, verifyExitFail)
+	}
+	if exitCodeForError(errors.New("boom")) == verifyExitFail {
+		t.Error("an ordinary error must NOT share the gate exit code, or a crash\n" +
+			"reads as a clean audit finding")
+	}
+}
+
+// TestWriteAuditReport_EmitsTheFactorsIndividually pins that the report keeps
+// series / rawRows / bucketWidth separate. They have different remedies —
+// width is fixed at the instrumentation, rows by retention, series by the
+// label set — so a summary that collapsed them into the cost alone would not
+// be actionable.
+func TestWriteAuditReport_EmitsTheFactorsIndividually(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+	report := chaudit.Report{
+		SchemaVersion: chaudit.ReportVersion,
+		Table:         "otel_metrics_histogram",
+		Metrics: []chaudit.MetricAudit{{
+			Metric: "core_http_request_duration_seconds",
+			Series: 7110, RawRows: 512, BucketWidth: 68,
+			CostUnits: 1468, Budget: 1000, HeadroomPct: -46.8,
+			AmplifyingLabel: "k8s_pod_name", AmplificationRatio: 72.5,
+		}},
+	}
+	if err := writeAuditReport(&buf, report); err != nil {
+		t.Fatalf("writeAuditReport: %v", err)
+	}
+	var back chaudit.Report
+	if err := json.Unmarshal(buf.Bytes(), &back); err != nil {
+		t.Fatalf("report is not valid JSON: %v", err)
+	}
+	m := back.Metrics[0]
+	if m.Series != 7110 || m.RawRows != 512 || m.BucketWidth != 68 {
+		t.Errorf("the three cost factors must survive the round trip, got %+v", m)
+	}
+	if m.AmplifyingLabel != "k8s_pod_name" {
+		t.Errorf("AmplifyingLabel = %q, want k8s_pod_name — the actionable half of the report", m.AmplifyingLabel)
+	}
+}

--- a/internal/chaudit/audit.go
+++ b/internal/chaudit/audit.go
@@ -1,0 +1,156 @@
+// Package chaudit answers one question about a LIVE deployment: which
+// classic-histogram metrics are close enough to a resource-bound ceiling that
+// a dashboard panel over them is about to start failing, and what an operator
+// can do about it.
+//
+// Why it exists. internal/migrateinventory probes a SOURCE Prometheus before a
+// cutover, which is exactly the right question at that moment and the wrong
+// one afterwards: once cerberus is serving, the facts that decide whether a
+// panel succeeds live in the connected ClickHouse, and they drift with real
+// traffic. Issue #2677's production incident was diagnosed only after a panel
+// went red, by hand-running uniqExact and length(ExplicitBounds) against the
+// live table and re-deriving the guard's cost model from its source comments.
+// This package is that diagnosis, performed before the panel breaks.
+//
+// It opens no connection of its own. The caller supplies an already-configured
+// Querier, so this package holds no credentials, no pool, and no lifecycle —
+// the same separation internal/migrateinventory keeps from the HTTP sources it
+// probes.
+package chaudit
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"sort"
+)
+
+// Querier is the read-only subset of *sql.DB this package needs. Narrow on
+// purpose: an audit must never be able to mutate the deployment it inspects,
+// and a one-method interface makes that checkable by reading the type rather
+// than by auditing call sites.
+type Querier interface {
+	QueryContext(ctx context.Context, query string, args ...any) (*sql.Rows, error)
+}
+
+// Options selects what to audit and against which ceiling.
+type Options struct {
+	// Table is the classic-histogram table to probe.
+	Table string
+	// WindowSeconds is the lookback the audit evaluates, matching the widest
+	// dashboard window an operator cares about defending.
+	WindowSeconds int64
+	// Anchors is the grid point count that window implies at the panel's step
+	// — the `anchors` factor of the guard's own cost model.
+	Anchors int64
+	// DensityUnitBudget is the ceiling to compare against: the resolved
+	// CERBERUS_RANGE_BUCKET_GRID_NATIVE_MAX_DENSITY_UNITS the deployment runs.
+	DensityUnitBudget int64
+	// Top bounds how many metrics are reported, worst headroom first.
+	Top int
+}
+
+// Validate rejects an Options that would produce a meaningless report rather
+// than letting it run and emit confident nonsense.
+func (o Options) Validate() error {
+	switch {
+	case o.Table == "":
+		return fmt.Errorf("chaudit: Table is required")
+	case o.WindowSeconds <= 0:
+		return fmt.Errorf("chaudit: WindowSeconds must be > 0, got %d", o.WindowSeconds)
+	case o.Anchors <= 0:
+		return fmt.Errorf("chaudit: Anchors must be > 0, got %d", o.Anchors)
+	case o.DensityUnitBudget <= 0:
+		return fmt.Errorf("chaudit: DensityUnitBudget must be > 0, got %d", o.DensityUnitBudget)
+	case o.Top <= 0:
+		return fmt.Errorf("chaudit: Top must be > 0, got %d", o.Top)
+	}
+	return nil
+}
+
+// MetricAudit is one metric's standing against the ceiling.
+type MetricAudit struct {
+	Metric string `json:"metric"`
+
+	// Series / RawRows / BucketWidth are the three factors the density guard
+	// multiplies. Reported individually because they have different remedies:
+	// width is fixed at the instrumentation, rows by retention or scrape
+	// interval, series by the label set.
+	Series      int64 `json:"seriesCount"`
+	RawRows     int64 `json:"rawRows"`
+	BucketWidth int64 `json:"bucketWidth"`
+
+	// CostUnits is the guard's own model — (series x anchors) + (rawRows x
+	// width^2) — evaluated on these facts, and Budget the ceiling it is
+	// compared against. HeadroomPct is negative once the metric would be
+	// rejected, which is the number worth alerting on.
+	CostUnits   int64   `json:"costUnits"`
+	Budget      int64   `json:"budget"`
+	HeadroomPct float64 `json:"headroomPct"`
+
+	// AmplifyingLabel is the label key whose removal would collapse series
+	// cardinality the most, and AmplificationRatio by how much. This is the
+	// actionable half of the report: a label that multiplies identity without
+	// changing what a panel displays is a fixable instrumentation defect, not
+	// a cerberus limit. Empty when no single label dominates.
+	AmplifyingLabel    string  `json:"amplifyingLabel,omitempty"`
+	AmplificationRatio float64 `json:"amplificationRatio,omitempty"`
+}
+
+// OverBudget reports whether this metric would be rejected outright.
+func (m MetricAudit) OverBudget() bool { return m.CostUnits > m.Budget }
+
+// Report is the audit result.
+type Report struct {
+	SchemaVersion int           `json:"schema_version"`
+	Table         string        `json:"table"`
+	WindowSeconds int64         `json:"windowSeconds"`
+	Anchors       int64         `json:"anchors"`
+	Metrics       []MetricAudit `json:"metrics"`
+
+	// Notes records every fact the audit could NOT establish, so a thin report
+	// is never mistaken for a clean one.
+	Notes []string `json:"notes,omitempty"`
+}
+
+// ReportVersion is stamped on every Report so a consumer can tell which shape
+// it is reading, mirroring migrateinventory.InventoryVersion's contract.
+const ReportVersion = 1
+
+// OverBudget returns the metrics that would be rejected today.
+func (r Report) OverBudget() []MetricAudit {
+	var out []MetricAudit
+	for _, m := range r.Metrics {
+		if m.OverBudget() {
+			out = append(out, m)
+		}
+	}
+	return out
+}
+
+// costUnits evaluates the density guard's model. Kept as one function so the
+// report and any future gate agree by construction rather than by two authors
+// transcribing the same formula.
+//
+// It mirrors internal/chsql's bucketGridDensityGuardFrag: `(series x anchors)
+// + (rawRows x width^2)`. The duplication is deliberate and bounded — chsql
+// emits this as SQL for ClickHouse to evaluate at query time, which an audit
+// cannot reuse because there is no query to attach it to. The two are pinned
+// together by TestCostUnits_MatchesTheEmittedGuardModel.
+func costUnits(series, anchors, rawRows, width int64) int64 {
+	return series*anchors + rawRows*width*width
+}
+
+// headroomPct is how much of the budget remains, negative once exceeded.
+func headroomPct(cost, budget int64) float64 {
+	if budget <= 0 {
+		return 0
+	}
+	return (float64(budget) - float64(cost)) / float64(budget) * 100
+}
+
+// rankByHeadroom orders worst-first, so the metrics an operator must act on
+// appear before the ones that merely exist.
+func rankByHeadroom(m []MetricAudit) {
+	sort.SliceStable(m, func(i, j int) bool { return m[i].HeadroomPct < m[j].HeadroomPct })
+}

--- a/internal/chaudit/audit_chdb_test.go
+++ b/internal/chaudit/audit_chdb_test.go
@@ -1,0 +1,105 @@
+//go:build chdb
+
+// Exercises the audit against a REAL engine, because both of its queries lean
+// on ClickHouse-specific semantics a fake would simply agree with:
+// `mapFilter` over a Map(String,String), and `arrayJoin(mapKeys(...))` to
+// enumerate label keys per row. A hand-rolled stub would prove the Go
+// arithmetic and nothing about whether the audit can actually be answered.
+package chaudit_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/tsouza/cerberus/internal/chaudit"
+	"github.com/tsouza/cerberus/internal/chsqltest"
+)
+
+func TestProbe_NamesTheAmplifyingLabelAndTheBudgetStanding(t *testing.T) {
+	db := chsqltest.OpenIsolatedChDB(t)
+	ctx := context.Background()
+
+	for _, stmt := range []string{`
+CREATE OR REPLACE TABLE aud (
+    MetricName String,
+    Attributes Map(String, String),
+    TimeUnix DateTime64(9),
+    ExplicitBounds Array(Float64)
+) ENGINE = MergeTree ORDER BY (MetricName, TimeUnix)`, `
+INSERT INTO aud
+SELECT 'http_requests',
+       map('route', concat('/r', toString(number % 7)),
+           'pod',   concat('pod-', toString(number % 40))),
+       now64(9) - toIntervalSecond(number % 600),
+       arrayMap(x -> toFloat64(x), range(12))
+FROM numbers(2000)`, `
+INSERT INTO aud
+SELECT 'well_shaped',
+       map('route', concat('/w', toString(number % 8))),
+       now64(9) - toIntervalSecond(number % 600),
+       arrayMap(x -> toFloat64(x), range(12))
+FROM numbers(2000)`} {
+		if _, err := db.ExecContext(ctx, stmt); err != nil {
+			t.Fatalf("seed: %v", err)
+		}
+	}
+
+	rep, err := chaudit.Probe(ctx, db, chaudit.Options{
+		Table:             "aud",
+		WindowSeconds:     3600,
+		Anchors:           360,
+		DensityUnitBudget: 1_000_000,
+		Top:               10,
+	})
+	if err != nil {
+		t.Fatalf("Probe: %v", err)
+	}
+	if len(rep.Metrics) != 2 {
+		t.Fatalf("audited %d metrics, want 2: %+v", len(rep.Metrics), rep.Metrics)
+	}
+
+	byName := map[string]chaudit.MetricAudit{}
+	for _, m := range rep.Metrics {
+		byName[m.Metric] = m
+	}
+
+	// The defective metric must NAME the offending label, which is the whole
+	// point: reporting only "320 series" leaves the operator where they
+	// started, with no way to tell an expensive dimension from a leaked one.
+	bad := byName["http_requests"]
+	if bad.AmplifyingLabel != "pod" {
+		t.Errorf("amplifying label = %q (ratio %.1f), want \"pod\" — an audit that cannot name\n"+
+			"the offending label reports a symptom instead of a remedy",
+			bad.AmplifyingLabel, bad.AmplificationRatio)
+	}
+	if bad.AmplificationRatio < 4 {
+		t.Errorf("amplification ratio = %.1f, want >= 4 (320 series collapsing to 8 without `pod`)",
+			bad.AmplificationRatio)
+	}
+	if bad.Series <= byName["well_shaped"].Series {
+		t.Errorf("the defective metric (%d series) should out-cardinal the well-shaped one (%d)",
+			bad.Series, byName["well_shaped"].Series)
+	}
+
+	// The well-shaped metric must NOT be accused. A report that flags
+	// everything is one an operator learns to ignore.
+	if good := byName["well_shaped"]; good.AmplifyingLabel != "" {
+		t.Errorf("well-shaped metric was accused of amplifying via %q (ratio %.1f); its single\n"+
+			"label IS the dimension the panel groups by", good.AmplifyingLabel, good.AmplificationRatio)
+	}
+
+	// Budget arithmetic must be real, and worst-first ordering must hold so the
+	// metric needing action is the one read first.
+	for _, m := range rep.Metrics {
+		if m.CostUnits <= 0 || m.Budget != 1_000_000 {
+			t.Errorf("%s: cost/budget not evaluated: %+v", m.Metric, m)
+		}
+	}
+	if rep.Metrics[0].HeadroomPct > rep.Metrics[1].HeadroomPct {
+		t.Errorf("report is not worst-first: %.1f%% before %.1f%%",
+			rep.Metrics[0].HeadroomPct, rep.Metrics[1].HeadroomPct)
+	}
+	t.Logf("worst: %s cost=%d budget=%d headroom=%.1f%% amplifier=%q x%.1f",
+		rep.Metrics[0].Metric, rep.Metrics[0].CostUnits, rep.Metrics[0].Budget,
+		rep.Metrics[0].HeadroomPct, rep.Metrics[0].AmplifyingLabel, rep.Metrics[0].AmplificationRatio)
+}

--- a/internal/chaudit/cost_test.go
+++ b/internal/chaudit/cost_test.go
@@ -1,0 +1,60 @@
+package chaudit
+
+import "testing"
+
+// TestCostUnits_MatchesTheEmittedGuardModel pins this package's copy of the
+// density-guard cost model against the emitter's.
+//
+// internal/chsql emits `(series x anchors) + (rawRows x width^2)` as SQL for
+// ClickHouse to evaluate at query time; this package evaluates the same
+// formula in Go, because an audit has no query to attach a throwIf to. That
+// duplication is deliberate and bounded, but it can drift silently — an audit
+// reporting healthy headroom under a model the engine no longer uses is worse
+// than no audit, because it is believed.
+//
+// The cases below are hand-computed rather than derived from the function, so
+// a change to costUnits fails here instead of quietly redefining truth. The
+// last row is the real production shape from #2677 (271 series, width 68,
+// ~84k rows, a 6h grid at 60s), whose value must stay recognisable against the
+// ~422M figure that incident was diagnosed with.
+func TestCostUnits_MatchesTheEmittedGuardModel(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name                            string
+		series, anchors, rawRows, width int64
+		want                            int64
+	}{
+		{"both terms contribute", 10, 100, 50, 4, 10*100 + 50*16},
+		{"width dominates quadratically", 1, 1, 1, 100, 1 + 10_000},
+		{"no rows leaves only the grid term", 253, 360, 0, 68, 253 * 360},
+		{"production shape from #2677", 271, 361, 83_997, 68, 271*361 + 83_997*68*68},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if got := costUnits(tc.series, tc.anchors, tc.rawRows, tc.width); got != tc.want {
+				t.Errorf("costUnits(%d, %d, %d, %d) = %d, want %d — this package's model has drifted\n"+
+					"from internal/chsql's emitted guard, so the audit is measuring against a\n"+
+					"ceiling the engine does not enforce",
+					tc.series, tc.anchors, tc.rawRows, tc.width, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestHeadroomPct_GoesNegativeExactlyWhenRejected pins the number an operator
+// would alert on against the predicate the engine would apply, so a metric
+// cannot read as having headroom while being over budget.
+func TestHeadroomPct_GoesNegativeExactlyWhenRejected(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct{ cost, budget int64 }{
+		{99, 100}, {100, 100}, {101, 100}, {1, 1_000_000}, {2_000_000, 1_000_000},
+	} {
+		m := MetricAudit{CostUnits: tc.cost, Budget: tc.budget, HeadroomPct: headroomPct(tc.cost, tc.budget)}
+		if got, want := m.HeadroomPct < 0, m.OverBudget(); got != want {
+			t.Errorf("cost=%d budget=%d: headroom<0 is %v but OverBudget is %v — the reported\n"+
+				"number and the verdict disagree", tc.cost, tc.budget, got, want)
+		}
+	}
+}

--- a/internal/chaudit/probe.go
+++ b/internal/chaudit/probe.go
@@ -1,0 +1,150 @@
+package chaudit
+
+import (
+	"context"
+	"fmt"
+)
+
+// factsQuery collects, per metric in the window, the three factors the density
+// guard multiplies. One pass over the window rather than a query per metric:
+// an audit that costs as much as the panels it protects will not be run.
+//
+// Parameterised on the window only — the table is validated against the
+// caller's own configured schema before it reaches here, and ClickHouse has no
+// bind form for an identifier.
+const factsQuery = `
+SELECT
+    MetricName,
+    uniqExact(Attributes)                  AS series,
+    count()                                AS raw_rows,
+    max(length(ExplicitBounds))            AS bucket_width
+FROM %s
+WHERE TimeUnix > now() - toIntervalSecond(?)
+GROUP BY MetricName
+ORDER BY raw_rows * bucket_width * bucket_width DESC
+LIMIT ?`
+
+// amplifyQuery finds the label key whose removal collapses series cardinality
+// the most, for ONE metric.
+//
+// The shape is the question "does this label carry meaning, or only identity":
+// `uniqExact(Attributes)` against `uniqExact(mapFilter(k != key, Attributes))`.
+// A label whose removal barely changes the count is describing something; a
+// label whose removal collapses the count by orders of magnitude is minting
+// identity per instance. The production case that motivated this (#2679) was
+// 7,110 series over 98 route templates because `k8s_pod_name` sat beside
+// `http_route` — a 72x multiplier buying nothing any panel displayed.
+//
+// arrayJoin over mapKeys enumerates the candidates, so a metric whose labels
+// vary across series still has every key considered.
+const amplifyQuery = `
+SELECT
+    key,
+    uniqExact(Attributes)                                              AS total,
+    uniqExact(mapFilter((k, v) -> k != key, Attributes))               AS without_key
+FROM (
+    SELECT Attributes, arrayJoin(mapKeys(Attributes)) AS key
+    FROM %s
+    WHERE TimeUnix > now() - toIntervalSecond(?) AND MetricName = ?
+)
+GROUP BY key
+ORDER BY total / greatest(without_key, 1) DESC
+LIMIT 1`
+
+// minAmplificationRatio is the collapse factor below which a label is not
+// worth naming. A label that merely doubles cardinality is usually carrying
+// real meaning; one that multiplies it several-fold is the shape of an
+// instance identifier that leaked into a metric's label set. Set low enough to
+// catch a genuine defect early, high enough that an ordinary dimension
+// (status code, method) is not reported as a problem.
+const minAmplificationRatio = 4.0
+
+// Probe runs the audit against a live ClickHouse.
+//
+// A failure to establish the amplifying label for one metric is recorded in
+// Notes and does not abort the run: the budget standing is the load-bearing
+// half of the report, and losing the remedy hint for one metric must not cost
+// the operator the whole audit.
+func Probe(ctx context.Context, q Querier, opts Options) (Report, error) {
+	if err := opts.Validate(); err != nil {
+		return Report{}, err
+	}
+	rep := Report{
+		SchemaVersion: ReportVersion,
+		Table:         opts.Table,
+		WindowSeconds: opts.WindowSeconds,
+		Anchors:       opts.Anchors,
+	}
+
+	rows, err := q.QueryContext(ctx, fmt.Sprintf(factsQuery, opts.Table), opts.WindowSeconds, opts.Top)
+	if err != nil {
+		return Report{}, fmt.Errorf("chaudit: probing %s: %w", opts.Table, err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	for rows.Next() {
+		var m MetricAudit
+		if err := rows.Scan(&m.Metric, &m.Series, &m.RawRows, &m.BucketWidth); err != nil {
+			return Report{}, fmt.Errorf("chaudit: scanning %s facts: %w", opts.Table, err)
+		}
+		m.Budget = opts.DensityUnitBudget
+		m.CostUnits = costUnits(m.Series, opts.Anchors, m.RawRows, m.BucketWidth)
+		m.HeadroomPct = headroomPct(m.CostUnits, m.Budget)
+		rep.Metrics = append(rep.Metrics, m)
+	}
+	if err := rows.Err(); err != nil {
+		return Report{}, fmt.Errorf("chaudit: reading %s facts: %w", opts.Table, err)
+	}
+
+	for i := range rep.Metrics {
+		label, ratio, err := probeAmplifyingLabel(ctx, q, opts, rep.Metrics[i].Metric)
+		if err != nil {
+			rep.Notes = append(rep.Notes, fmt.Sprintf(
+				"could not establish the amplifying label for %q (%v); its budget standing above is unaffected",
+				rep.Metrics[i].Metric, err,
+			))
+			continue
+		}
+		if ratio >= minAmplificationRatio {
+			rep.Metrics[i].AmplifyingLabel = label
+			rep.Metrics[i].AmplificationRatio = ratio
+		}
+	}
+
+	rankByHeadroom(rep.Metrics)
+	return rep, nil
+}
+
+// probeAmplifyingLabel returns the worst offender for one metric, and the
+// factor by which it multiplies series count.
+func probeAmplifyingLabel(ctx context.Context, q Querier, opts Options, metric string) (string, float64, error) {
+	rows, err := q.QueryContext(ctx, fmt.Sprintf(amplifyQuery, opts.Table), opts.WindowSeconds, metric)
+	if err != nil {
+		return "", 0, err
+	}
+	defer func() { _ = rows.Close() }()
+
+	if !rows.Next() {
+		if err := rows.Err(); err != nil {
+			return "", 0, err
+		}
+		// A metric with no labels at all is legitimate and not a defect.
+		return "", 0, nil
+	}
+	var key string
+	var total, without int64
+	if err := rows.Scan(&key, &total, &without); err != nil {
+		return "", 0, err
+	}
+	// A label is an AMPLIFIER only if it multiplies a grouping that survives
+	// without it. Removing the sole distinguishing label of a metric always
+	// collapses it to one series, which scores maximally on the ratio alone —
+	// so ratio by itself would accuse every well-shaped single-dimension
+	// metric of the exact defect this audit exists to find. Requiring the
+	// remainder to still carry structure is what separates "this label IS the
+	// dimension" from "this label multiplies the dimension".
+	if without <= 1 {
+		return "", 0, nil
+	}
+	return key, float64(total) / float64(without), rows.Err()
+}

--- a/internal/chaudit/report_test.go
+++ b/internal/chaudit/report_test.go
@@ -1,0 +1,74 @@
+package chaudit
+
+import "testing"
+
+// TestOptions_Validate_RejectsUnusableInput pins that an audit refuses to run
+// rather than emit a confident report from meaningless inputs. Every field
+// here changes a number the report presents as fact, so a zero in any of them
+// would produce output that reads as measured and is not.
+func TestOptions_Validate_RejectsUnusableInput(t *testing.T) {
+	t.Parallel()
+
+	valid := Options{Table: "t", WindowSeconds: 60, Anchors: 10, DensityUnitBudget: 1000, Top: 5}
+	if err := valid.Validate(); err != nil {
+		t.Fatalf("a fully-specified Options must validate: %v", err)
+	}
+	for _, tc := range []struct {
+		name string
+		mut  func(*Options)
+	}{
+		{"no table", func(o *Options) { o.Table = "" }},
+		{"zero window", func(o *Options) { o.WindowSeconds = 0 }},
+		{"negative window", func(o *Options) { o.WindowSeconds = -1 }},
+		{"zero anchors", func(o *Options) { o.Anchors = 0 }},
+		{"zero budget", func(o *Options) { o.DensityUnitBudget = 0 }},
+		{"zero top", func(o *Options) { o.Top = 0 }},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			o := valid
+			tc.mut(&o)
+			if err := o.Validate(); err == nil {
+				t.Errorf("Validate accepted %s; the report would present a derived number as a\n"+
+					"measurement without the input that derives it", tc.name)
+			}
+		})
+	}
+}
+
+// TestReport_OverBudget_SelectsExactlyTheRejected pins the accessor an alerting
+// caller would key on against the per-metric verdict, so the summary and the
+// detail cannot disagree about who is failing.
+func TestReport_OverBudget_SelectsExactlyTheRejected(t *testing.T) {
+	t.Parallel()
+
+	r := Report{Metrics: []MetricAudit{
+		{Metric: "under", CostUnits: 10, Budget: 100},
+		{Metric: "exactly_at", CostUnits: 100, Budget: 100},
+		{Metric: "over", CostUnits: 101, Budget: 100},
+	}}
+	got := r.OverBudget()
+	if len(got) != 1 || got[0].Metric != "over" {
+		t.Fatalf("OverBudget() = %+v, want only \"over\" — the boundary is strictly greater-than,\n"+
+			"matching the guard's own `cost > bound` predicate", got)
+	}
+}
+
+// TestRankByHeadroom_WorstFirst pins the ordering the report is read in. An
+// operator scanning a long audit acts on the first rows; burying the metric
+// that is already failing below healthy ones defeats the report.
+func TestRankByHeadroom_WorstFirst(t *testing.T) {
+	t.Parallel()
+
+	m := []MetricAudit{
+		{Metric: "healthy", HeadroomPct: 90},
+		{Metric: "failing", HeadroomPct: -50},
+		{Metric: "tight", HeadroomPct: 5},
+	}
+	rankByHeadroom(m)
+	for i, want := range []string{"failing", "tight", "healthy"} {
+		if m[i].Metric != want {
+			t.Errorf("position %d is %q, want %q", i, m[i].Metric, want)
+		}
+	}
+}

--- a/internal/chaudit/testmain_test.go
+++ b/internal/chaudit/testmain_test.go
@@ -1,0 +1,19 @@
+package chaudit_test
+
+import (
+	"os"
+	"testing"
+
+	"github.com/tsouza/cerberus/internal/chdbsession"
+)
+
+// TestMain exists to shut the process-wide chDB session down before the
+// test binary exits. Under `-race`, os.Exit runs runtime.racefini, which
+// runs libchdb's C++ static destructors against a still-live embedded
+// ClickHouse and segfaults AFTER every test has passed (#1971).
+// chdbsession.CloseForExit is a no-op in the default, non-chdb build.
+func TestMain(m *testing.M) {
+	code := m.Run()
+	chdbsession.CloseForExit()
+	os.Exit(code)
+}

--- a/internal/chclient/sqldb.go
+++ b/internal/chclient/sqldb.go
@@ -1,0 +1,32 @@
+package chclient
+
+import (
+	"database/sql"
+	"fmt"
+
+	"github.com/ClickHouse/clickhouse-go/v2"
+)
+
+// OpenSQLDB opens a `database/sql` handle against the same resolved
+// clickhouse.Options New would dial with — the identical address list, auth,
+// protocol, TLS and timeout mapping, via the same buildOptions.
+//
+// It exists for the read-only OFFLINE tools (`cerberus audit`), not for the
+// serving path. Those tools want plain `*sql.Rows` scanning rather than the
+// Client's cursor API, and want their own short-lived pool so a long
+// cardinality probe cannot occupy connections the server is using to answer
+// queries. The serving path keeps Client, which carries the circuit breaker,
+// the per-head budgets and the query-settings plumbing this handle
+// deliberately does NOT have — which is also why nothing here should grow a
+// write path.
+//
+// clickhouse.OpenDB, like clickhouse.Open, is lazy: it never dials until the
+// first query, matching every other CLI-driven ClickHouse connection in this
+// codebase.
+func OpenSQLDB(cfg Config) (*sql.DB, error) {
+	db := clickhouse.OpenDB(buildOptions(cfg))
+	if db == nil {
+		return nil, fmt.Errorf("chclient: OpenDB returned no handle for %v", cfg.Addrs)
+	}
+	return db, nil
+}

--- a/internal/chclient/sqldb_test.go
+++ b/internal/chclient/sqldb_test.go
@@ -1,0 +1,44 @@
+package chclient
+
+import "testing"
+
+// TestOpenSQLDB_IsLazyAndReusesBuildOptions pins the two properties the
+// offline audit tools depend on.
+//
+// Laziness: like clickhouse.Open, OpenDB must not dial until the first query.
+// `cerberus audit` validates its arguments before connecting precisely so a
+// bad invocation cannot cause a dial against a production deployment, and that
+// ordering is only meaningful if construction itself is quiet — this test
+// passes an address nothing is listening on and still expects success.
+//
+// Option reuse: the handle must come from the same buildOptions the serving
+// client dials with, so an audit cannot silently reach a DIFFERENT database
+// than the server reads.
+func TestOpenSQLDB_IsLazyAndReusesBuildOptions(t *testing.T) {
+	t.Parallel()
+
+	cfg := Config{
+		Addr:     "127.0.0.1:1", // nothing listens here
+		Database: "cerberus_audit_probe",
+		Username: "default",
+	}
+	db, err := OpenSQLDB(cfg)
+	if err != nil {
+		t.Fatalf("OpenSQLDB must not dial at construction time, got: %v", err)
+	}
+	if db == nil {
+		t.Fatal("OpenSQLDB returned a nil handle with no error")
+	}
+	t.Cleanup(func() { _ = db.Close() })
+
+	// The same Config must map to the same driver options the serving path
+	// uses; assert on the mapping rather than on the opaque handle.
+	opts := buildOptions(cfg)
+	if got := opts.Auth.Database; got != cfg.Database {
+		t.Errorf("database = %q, want %q — an audit reaching a different database\n"+
+			"than the server reads would report confident numbers about the wrong data", got, cfg.Database)
+	}
+	if len(opts.Addr) != 1 || opts.Addr[0] != cfg.Addr {
+		t.Errorf("addr = %v, want [%s]", opts.Addr, cfg.Addr)
+	}
+}

--- a/test/coverage-floor/cmd__cerberus.json
+++ b/test/coverage-floor/cmd__cerberus.json
@@ -1,3 +1,3 @@
 {
-  "cmd/cerberus": 55.5
+  "cmd/cerberus": 55.7
 }

--- a/test/coverage-floor/internal__chaudit.json
+++ b/test/coverage-floor/internal__chaudit.json
@@ -1,0 +1,3 @@
+{
+  "internal/chaudit": 79.9
+}

--- a/test/coverage-floor/internal__chclient.json
+++ b/test/coverage-floor/internal__chclient.json
@@ -1,3 +1,3 @@
 {
-  "internal/chclient": 67.7
+  "internal/chclient": 67.9
 }

--- a/test/coverage-floor/internal__chsqltest.json
+++ b/test/coverage-floor/internal__chsqltest.json
@@ -1,3 +1,3 @@
 {
-  "internal/chsqltest": 70.4
+  "internal/chsqltest": 74
 }

--- a/test/coverage-floor/internal__deltaprefix.json
+++ b/test/coverage-floor/internal__deltaprefix.json
@@ -1,3 +1,3 @@
 {
-  "internal/deltaprefix": 94.6
+  "internal/deltaprefix": 97
 }

--- a/test/coverage-floor/internal__engine.json
+++ b/test/coverage-floor/internal__engine.json
@@ -1,3 +1,3 @@
 {
-  "internal/engine": 88.2
+  "internal/engine": 88.4
 }

--- a/test/coverage-floor/internal__optimizer.json
+++ b/test/coverage-floor/internal__optimizer.json
@@ -1,3 +1,3 @@
 {
-  "internal/optimizer": 91
+  "internal/optimizer": 91.1
 }

--- a/test/coverage-floor/internal__promql.json
+++ b/test/coverage-floor/internal__promql.json
@@ -1,3 +1,3 @@
 {
-  "internal/promql": 88.9
+  "internal/promql": 89.3
 }

--- a/test/coverage-floor/internal__routememo.json
+++ b/test/coverage-floor/internal__routememo.json
@@ -1,3 +1,3 @@
 {
-  "internal/routememo": 85.5
+  "internal/routememo": 91.6
 }

--- a/test/coverage-floor/internal__schema.json
+++ b/test/coverage-floor/internal__schema.json
@@ -1,3 +1,3 @@
 {
-  "internal/schema": 96.9
+  "internal/schema": 97.6
 }

--- a/test/coverage-floor/internal__schema__ddl.json
+++ b/test/coverage-floor/internal__schema__ddl.json
@@ -1,3 +1,3 @@
 {
-  "internal/schema/ddl": 93.6
+  "internal/schema/ddl": 93.9
 }

--- a/test/coverage-floor/internal__solver.json
+++ b/test/coverage-floor/internal__solver.json
@@ -1,3 +1,3 @@
 {
-  "internal/solver": 88.1
+  "internal/solver": 88.4
 }

--- a/test/coverage-floor/test__e2e__migration__steps.json
+++ b/test/coverage-floor/test__e2e__migration__steps.json
@@ -1,3 +1,3 @@
 {
-  "test/e2e/migration/steps": 11.8
+  "test/e2e/migration/steps": 11.9
 }

--- a/test/coverage-floor/test__perf__nightly.json
+++ b/test/coverage-floor/test__perf__nightly.json
@@ -1,3 +1,3 @@
 {
-  "test/perf/nightly": 41.8
+  "test/perf/nightly": 50.9
 }

--- a/test/coverage-floor/test__rejection-parity.json
+++ b/test/coverage-floor/test__rejection-parity.json
@@ -1,3 +1,3 @@
 {
-  "test/rejection-parity": 84.8
+  "test/rejection-parity": 84.9
 }

--- a/test/coverage-floor/test__spec.json
+++ b/test/coverage-floor/test__spec.json
@@ -1,3 +1,3 @@
 {
-  "test/spec": 82.6
+  "test/spec": 82.9
 }


### PR DESCRIPTION
## Summary

`cerberus migrate inventory` probes a **source** Prometheus for cardinality /
OOM-risk facts *before* a cutover. There was no equivalent for an
already-cutover deployment: a dashboard panel can walk right up to a
resource-bound guard's cap as real traffic and cardinality grow, with no
signal until the panel goes red.

This adds that missing half — `cerberus audit` — and the `internal/chaudit`
package behind it.

Motivating measurement, from the #2677 investigation: the query that tripped
the axis2 density guard was already at **97.6% of its cap** on real
production cardinality. It was close to the edge long before the incident,
and nothing surfaced that.

## What it does

`cerberus audit` reads the same `CERBERUS_*` environment the server does, so
it probes the table the server actually reads and compares against the
density bound the server actually **enforces** — auditing against a ceiling
that is not in force would report confident numbers about nothing.

For each classic-histogram metric it reports the three factors the density
guard multiplies, kept separate because each has a different remedy:

| factor | remedy |
|---|---|
| `bucketWidth` | fixed at the instrumentation |
| `rawRows` | retention or scrape interval |
| `seriesCount` | the label set |

…plus `costUnits` (the guard's own `(series x anchors) + (rawRows x width^2)`
model evaluated on those facts), the `budget`, and `headroomPct` — negative
once the metric would be rejected, which is the number worth alerting on.

`amplifyingLabel` is the actionable half: the label whose removal would
collapse cardinality the most. A label that multiplies series identity
without changing what a panel displays is a fixable instrumentation defect,
not a cerberus limit.

Output is JSON, worst headroom first. An over-budget metric exits **2** — the
same "a gate said no" code `migrate verify` uses — so a deploy can be gated on
it and a real finding stays distinguishable from a tool crash (exit 1).

## Two defects found while wiring it up

Both were invisible to the package's own tests, which all passed throughout:

1. **The package had no entry point.** It shipped as a library nothing in the
   binary imported. #2679 asks for an audit *mode*; a package an operator
   cannot invoke is not one. `cmd_audit_test.go` now asserts the command is
   registered on the root command specifically, since that is the failure unit
   tests structurally cannot see.
2. **`Querier` did not match the production client.** It is a `database/sql`
   shape, which chDB satisfies — so every test passed — but `chclient.Client`
   exposes a cursor API, so the audit could never have run against a real
   deployment. `chclient.OpenSQLDB` fixes this by reusing `buildOptions`, so
   the audit dials with the identical address list, auth, protocol and TLS
   mapping as the server without duplicating that mapping. It is deliberately
   a separate short-lived pool: a long cardinality probe must not occupy
   connections the server is answering queries on.

## False positives are the risk, and are guarded

An amplification ratio alone accuses every well-shaped metric: removing a
metric's *only* label always collapses it to one series, so the ratio is
unbounded for a clean single-dimension metric. `probeAmplifyingLabel` requires
`without > 1` for that reason. This was caught by the package's own chDB test,
which also had to be reseeded — the original moduli (%8 and %40) shared
factors, so route was determined by pod and the fixture had 40 distinct
combinations rather than the intended 280.

## Test plan

- [x] `TestAuditCmd_IsRegisteredOnRoot` — the command is reachable from the binary.
- [x] `TestAuditCmd_RejectsUnusableOptionsBeforeDialing` — a bad invocation fails
      on its arguments rather than after opening a production connection.
- [x] `TestAuditOverBudgetError_MapsToGateExitCode` — and an ordinary error does
      **not** share it, so a crash cannot read as a clean finding.
- [x] `TestWriteAuditReport_EmitsTheFactorsIndividually` — the three factors and
      the amplifying label survive the round trip.
- [x] `TestOptions_Validate_RejectsUnusableInput` — every input that would make a
      derived number meaningless is refused.
- [x] `TestReport_OverBudget_SelectsExactlyTheRejected` — the boundary is strictly
      greater-than, matching the guard's own `cost > bound` predicate.
- [x] `TestRankByHeadroom_WorstFirst` — the ordering the report is read in.
- [x] chDB-tagged probe test over 7 routes x 40 pods (coprime), plus hand-computed
      cost-model pins including #2677's production shape.
- [x] `TestMain` calling `chdbsession.CloseForExit` (#1971).
- [x] `forbid-sql-raw`, `forbid-skip`, `go vet` clean.

Verification against a real production ClickHouse is in progress; this path has
only ever been exercised against chDB.

Refs #2677

Closes #2679
