### PR TITLE
test(e2e): bound the time-ranges sweep fan-out below the Prom admission cap

### DIFF
--- a/test/e2e/playwright/iterate-time-ranges.spec.ts
+++ b/test/e2e/playwright/iterate-time-ranges.spec.ts
@@ -1,5 +1,5 @@
 /**
- * Phase-5 variable / time-range matrix sweep — nightly-only.
+ * Phase-5 variable / time-range matrix sweep — dashboard-lane gating.
  *
  * Iterates every provisioned dashboard, every aggregating or
  * histogram_quantile panel, and re-runs the phase-1 label-shape +
@@ -30,14 +30,22 @@
  *     surfaces as a missing-final-sample shape on a step≥panel-window
  *     run.
  *
- * Gate posture: this spec is NIGHTLY-ONLY (Q2 decision in
- * `/home/thiago/.claude/plans/e2e-enhance.md` §9) and runs from the
- * `dashboard` job in `.github/workflows/e2e.yml`, NOT from
- * `compose-smoke.yml`. The variable / time-range iteration is the
- * highest flake-risk family per §8.2 of the plan (a 24h range against
- * a freshly-started compose stack can legitimately return empty), so
- * it stays informational on push-to-main + nightly + manual dispatch
- * until the flake rate is observed < 1% over a fix cycle.
+ * Gate posture: this spec runs from the k3d `dashboard` lane in
+ * `.github/workflows/e2e.yml`, NOT from `compose-smoke.yml`, and it
+ * does not run on an ordinary pull request (that lane short-circuits
+ * there). Everywhere it DOES run — push-to-main, `release/*.x`
+ * pushes, the nightly schedule, a `release/*` PR, manual dispatch —
+ * it is GATING, not informational: `.github/scripts/
+ * dashboard-matrix.mjs` assigns it to `shard-smoke-b`, dispatched by
+ * the gating `dashboard-shard` matrix and NOT by the de-gated
+ * `dashboard-shard-info` matrix that carries the crawl coverage
+ * shard. Any non-success shard makes the `dashboard` roll-up job
+ * exit 1; `release.yml`'s preflight reads that check-run before it
+ * will publish, and on the nightly schedule `nightly-health-notify`
+ * files an issue. A red tuple here therefore costs a release gate and
+ * an issue, so every assertion below is load-bearing — and the spec
+ * must never fail on load it generated itself (see
+ * MATRIX_FAN_OUT_CONCURRENCY).
  *
  * Flake handling: empty frames are an ANNOTATION, not a failure (the
  * same gating pattern phase-1 uses for cerberus placeholder
@@ -163,6 +171,34 @@ const CH_QUERY_MAX_MEMORY_BYTES = 1_073_741_824;
 // tuple receiving this rejection is a PINNED-CONTRACT outcome, not a
 // tolerated error.
 const MEMORY_LIMIT_MESSAGE = `query processing would use too much memory in query execution (ClickHouse memory limit exceeded; per-query cap ${CH_QUERY_MAX_MEMORY_BYTES} bytes)`;
+
+// Ceiling on how many matrix tuples this spec has in flight at once.
+//
+// Why the CLIENT bounds itself: cerberus's Prom head admits at most
+// DefaultAdmitProm (internal/config/config.go) concurrent requests per
+// process, and the limiter is a NON-blocking TryAcquire
+// (internal/api/admit/admit.go) — request cap+1 is not queued, it is
+// shed instantly with 503 `admission control: server saturated`. The
+// matrix is (eligible targets × TIME_RANGES × STEP_SIZES), so firing
+// it through a bare `Promise.all(entries.map(...))` put 84 concurrent
+// query_range calls against a 64-slot pod, two of them came back 503,
+// and the spec failed on load it had generated itself (#2674).
+//
+// Why an ABSOLUTE number rather than a derived one: neither the matrix
+// size nor `cap - epsilon` is safe. Scaling with the matrix re-crosses
+// the cap the moment a maintainer adds a panel to a provisioned
+// dashboard, and tracking the server's cap turns every future change
+// to DefaultAdmitProm into a silent renegotiation of what this spec
+// exercises. A fixed small number cannot drift into the shed no matter
+// how the dashboards or the cap move. 8 leaves the rest of the shard's
+// traffic ample admission headroom and keeps the drained sweep far
+// inside this test's 15-minute budget.
+//
+// This bounds the ASSERTION phase only. The saturation path stays
+// covered deliberately and separately by the warmup's own burst
+// (ADMIT_BURST_CONCURRENCY in helpers/sweep.ts), which exists to make
+// the "Admission rejections" panel non-empty.
+const MATRIX_FAN_OUT_CONCURRENCY = 8;
 
 /**
  * Prometheus `/api/v1/query_range` response shape (the subset we
@@ -332,7 +368,7 @@ test('time-ranges: every aggregating / histogram panel re-asserts under (range, 
 
   testInfo.annotations.push({
     type: 'time-ranges',
-    description: `swept ${entries.length} (panel × range × step) iteration(s) across ${dashboards.length} dashboard(s) — ${aggregatingPanels} aggregating target(s), ${histogramPanels} histogram_quantile target(s), ${TIME_RANGES.length} range(s), ${STEP_SIZES.length} step(s)`,
+    description: `swept ${entries.length} (panel × range × step) iteration(s) across ${dashboards.length} dashboard(s) — ${aggregatingPanels} aggregating target(s), ${histogramPanels} histogram_quantile target(s), ${TIME_RANGES.length} range(s), ${STEP_SIZES.length} step(s), drained at most ${MATRIX_FAN_OUT_CONCURRENCY} tuple(s) in flight (fan-out ceiling)`,
   });
 
   // Per-dashboard iteration count — surfaces in the test output so a
@@ -371,174 +407,193 @@ test('time-ranges: every aggregating / histogram panel re-asserts under (range, 
 
   const now = Math.floor(Date.now() / 1000);
 
-  await Promise.all(
-    entries.map(async (e) => {
-      const start = now - e.range.windowSeconds;
-      const end = now;
-      const surface = `${e.dashboardTitle} :: ${e.panelTitle} :: ${e.refId} :: range=${e.range.label} step=${e.step.label}`;
+  // Bounded worker-pool drain (see MATRIX_FAN_OUT_CONCURRENCY). Each
+  // worker pulls the next index off a shared cursor until `entries` is
+  // exhausted, so the sweep never has more than the ceiling's worth of
+  // query_range calls in flight and cannot provoke the Prom head's
+  // admission shed. ONLY the scheduling changes: `sweepEntry` is the
+  // same per-tuple body the previous unbounded `Promise.all(entries.
+  // map(...))` ran, tuple for tuple, so no assertion is weakened by the
+  // bound — every tuple still gets fired and still gets asserted.
+  const sweepEntry = async (e: MatrixEntry) => {
+    const start = now - e.range.windowSeconds;
+    const end = now;
+    const surface = `${e.dashboardTitle} :: ${e.panelTitle} :: ${e.refId} :: range=${e.range.label} step=${e.step.label}`;
 
-      const queryURL = `${baseURL}${e.proxyURL}/api/v1/query_range?query=${encodeURIComponent(
-        e.expr,
-      )}&start=${start}&end=${end}&step=${e.step.stepSeconds}`;
+    const queryURL = `${baseURL}${e.proxyURL}/api/v1/query_range?query=${encodeURIComponent(
+      e.expr,
+    )}&start=${start}&end=${end}&step=${e.step.stepSeconds}`;
 
-      // Tuples whose grid exceeds the Prometheus resolution cap MUST
-      // be rejected with the upstream-parity 400 — assert that shape
-      // and stop; the 2xx shape rules below don't apply to a tuple
-      // upstream Prometheus itself would refuse to evaluate.
-      const gridPoints = Math.floor(
-        e.range.windowSeconds / e.step.stepSeconds,
-      );
-      if (gridPoints > MAX_RESOLUTION_POINTS) {
-        try {
-          const resp = await request.get(queryURL);
-          const body = await resp.text().catch(() => '<unreadable>');
-          if (resp.status() !== 400) {
-            failures.push(
-              `[${surface}] grid of ${gridPoints} points exceeds the ${MAX_RESOLUTION_POINTS}-point Prometheus resolution cap but query_range returned ${resp.status()} (want 400)\n  url: ${queryURL}\n  body: ${body.slice(0, 600)}`,
-            );
-            return;
-          }
-          if (!body.includes(RESOLUTION_CAP_MESSAGE)) {
-            failures.push(
-              `[${surface}] over-cap query_range returned 400 but without the upstream resolution-cap message ${JSON.stringify(RESOLUTION_CAP_MESSAGE)}\n  url: ${queryURL}\n  body: ${body.slice(0, 600)}`,
-            );
-          }
-        } catch (err) {
-          failures.push(
-            `[${surface}] resolution-cap probe threw: ${(err as Error).message}\n  url: ${queryURL}`,
-          );
-        }
-        return;
-      }
-
+    // Tuples whose grid exceeds the Prometheus resolution cap MUST
+    // be rejected with the upstream-parity 400 — assert that shape
+    // and stop; the 2xx shape rules below don't apply to a tuple
+    // upstream Prometheus itself would refuse to evaluate.
+    const gridPoints = Math.floor(
+      e.range.windowSeconds / e.step.stepSeconds,
+    );
+    if (gridPoints > MAX_RESOLUTION_POINTS) {
       try {
         const resp = await request.get(queryURL);
-
-        // Memory-limit dual contract (see file header): a 422 is
-        // acceptable IFF it is exactly cerberus's pinned
-        // resource-exhausted rejection — errorType=execution with the
-        // byte-for-byte MEMORY_LIMIT_MESSAGE. That outcome is asserted
-        // precisely (a 422 with any other body remains a hard
-        // failure) and logged loudly so the nightly report shows
-        // which tuples took the rejection branch.
-        if (resp.status() === 422) {
-          const body = await resp.text().catch(() => '<unreadable>');
-          let parsed: PromErrorEnvelope | null = null;
-          try {
-            parsed = JSON.parse(body) as PromErrorEnvelope;
-          } catch {
-            parsed = null;
-          }
-          if (
-            parsed?.status === 'error' &&
-            parsed?.errorType === 'execution' &&
-            parsed?.error === MEMORY_LIMIT_MESSAGE
-          ) {
-            memoryLimitCount++;
-            testInfo.annotations.push({
-              type: 'time-ranges-memory-limit',
-              description: `[${surface}] tuple took the 422 memory-limit pinned-contract branch (ClickHouse per-query cap ${CH_QUERY_MAX_MEMORY_BYTES} bytes; run-27277793810 class) for expr: ${e.expr}`,
-            });
-            return;
-          }
+        const body = await resp.text().catch(() => '<unreadable>');
+        if (resp.status() !== 400) {
           failures.push(
-            `[${surface}] query_range returned 422 but NOT the pinned memory-limit contract (want errorType=execution + exact message ${JSON.stringify(MEMORY_LIMIT_MESSAGE)})\n  url: ${queryURL}\n  body: ${body.slice(0, 600)}`,
+            `[${surface}] grid of ${gridPoints} points exceeds the ${MAX_RESOLUTION_POINTS}-point Prometheus resolution cap but query_range returned ${resp.status()} (want 400)\n  url: ${queryURL}\n  body: ${body.slice(0, 600)}`,
           );
           return;
         }
-
-        if (resp.status() < 200 || resp.status() > 299) {
-          const body = await resp.text().catch(() => '<unreadable>');
+        if (!body.includes(RESOLUTION_CAP_MESSAGE)) {
           failures.push(
-            `[${surface}] cerberus query_range → ${resp.status()}\n  url: ${queryURL}\n  body: ${body.slice(0, 600)}`,
+            `[${surface}] over-cap query_range returned 400 but without the upstream resolution-cap message ${JSON.stringify(RESOLUTION_CAP_MESSAGE)}\n  url: ${queryURL}\n  body: ${body.slice(0, 600)}`,
           );
-          return;
-        }
-
-        const prom = (await resp.json()) as PromQueryRangeResponse;
-        if (prom.status !== 'success') {
-          failures.push(
-            `[${surface}] cerberus query_range returned status=${prom.status ?? '<missing>'}\n  expr: ${e.expr}`,
-          );
-          return;
-        }
-
-        const frameCount = (prom.data?.result ?? []).length;
-        const envelope = promToDsEnvelope(e.refId, prom);
-
-        if (frameCount === 0) {
-          // Empty frames on this (range, step) — annotate, don't
-          // fail. The 24h range against a freshly-started compose
-          // stack legitimately returns empty (the seed only spans
-          // ~60s); the same applies to histogram panels whose
-          // underlying _bucket series haven't been emitted yet at
-          // the very-small-range end.
-          emptyFrameCount++;
-          testInfo.annotations.push({
-            type: 'time-ranges-empty',
-            description: `[${surface}] no series returned for expr: ${e.expr} — (range × step) iteration excluded from shape rules (empty-frame flake gate)`,
-          });
-          return;
-        }
-        okFrameCount++;
-
-        // Aggregating-target assertions. Mirrors phase-1
-        // (iterate-panel-shape.spec.ts) — every `by(...)` key MUST
-        // appear on at least one returned frame; every `without(...)`
-        // key MUST be absent from every frame.
-        if (e.byKeys.length > 0) {
-          try {
-            assertLabelShape(envelope, e.byKeys);
-          } catch (err) {
-            failures.push(
-              `[${surface}] ${(err as Error).message}\n  expr: ${e.expr}`,
-            );
-          }
-        }
-        if (e.withoutKeys.length > 0) {
-          try {
-            assertLabelAbsent(envelope, e.withoutKeys);
-          } catch (err) {
-            failures.push(
-              `[${surface}] ${(err as Error).message}\n  expr: ${e.expr}`,
-            );
-          }
-        }
-
-        // Histogram-target assertions. Mirrors phase-2
-        // (iterate-histogram-completeness.spec.ts) — the matrix here
-        // does NOT re-probe `/api/v1/series` for _bucket presence
-        // (phase-2 already pins that at the short range; doing it
-        // per-(range, step) would 12× the probe count for no extra
-        // signal). Instead we apply the two branches based on the
-        // expression's structure alone:
-        //   - histogram_quantile over a `_bucket`-named root → the
-        //     response MUST be non-empty (assertHistogramComplete).
-        //   - histogram_quantile over a non-bucket root → the
-        //     response MUST be empty (assertNoFabricatedValue).
-        if (e.isHistogram) {
-          if (e.histogramName === null) {
-            try {
-              assertNoFabricatedValue(envelope, e.expr);
-            } catch (err) {
-              failures.push(
-                `[${surface}] ${(err as Error).message}\n  expr: ${e.expr}`,
-              );
-            }
-          } else {
-            try {
-              assertHistogramComplete(envelope, e.histogramName);
-            } catch (err) {
-              failures.push(
-                `[${surface}] ${(err as Error).message}\n  expr: ${e.expr}`,
-              );
-            }
-          }
         }
       } catch (err) {
         failures.push(
-          `[${surface}] time-ranges probe threw: ${(err as Error).message}\n  url: ${queryURL}`,
+          `[${surface}] resolution-cap probe threw: ${(err as Error).message}\n  url: ${queryURL}`,
         );
+      }
+      return;
+    }
+
+    try {
+      const resp = await request.get(queryURL);
+
+      // Memory-limit dual contract (see file header): a 422 is
+      // acceptable IFF it is exactly cerberus's pinned
+      // resource-exhausted rejection — errorType=execution with the
+      // byte-for-byte MEMORY_LIMIT_MESSAGE. That outcome is asserted
+      // precisely (a 422 with any other body remains a hard
+      // failure) and logged loudly so the nightly report shows
+      // which tuples took the rejection branch.
+      if (resp.status() === 422) {
+        const body = await resp.text().catch(() => '<unreadable>');
+        let parsed: PromErrorEnvelope | null = null;
+        try {
+          parsed = JSON.parse(body) as PromErrorEnvelope;
+        } catch {
+          parsed = null;
+        }
+        if (
+          parsed?.status === 'error' &&
+          parsed?.errorType === 'execution' &&
+          parsed?.error === MEMORY_LIMIT_MESSAGE
+        ) {
+          memoryLimitCount++;
+          testInfo.annotations.push({
+            type: 'time-ranges-memory-limit',
+            description: `[${surface}] tuple took the 422 memory-limit pinned-contract branch (ClickHouse per-query cap ${CH_QUERY_MAX_MEMORY_BYTES} bytes; run-27277793810 class) for expr: ${e.expr}`,
+          });
+          return;
+        }
+        failures.push(
+          `[${surface}] query_range returned 422 but NOT the pinned memory-limit contract (want errorType=execution + exact message ${JSON.stringify(MEMORY_LIMIT_MESSAGE)})\n  url: ${queryURL}\n  body: ${body.slice(0, 600)}`,
+        );
+        return;
+      }
+
+      if (resp.status() < 200 || resp.status() > 299) {
+        const body = await resp.text().catch(() => '<unreadable>');
+        failures.push(
+          `[${surface}] cerberus query_range → ${resp.status()}\n  url: ${queryURL}\n  body: ${body.slice(0, 600)}`,
+        );
+        return;
+      }
+
+      const prom = (await resp.json()) as PromQueryRangeResponse;
+      if (prom.status !== 'success') {
+        failures.push(
+          `[${surface}] cerberus query_range returned status=${prom.status ?? '<missing>'}\n  expr: ${e.expr}`,
+        );
+        return;
+      }
+
+      const frameCount = (prom.data?.result ?? []).length;
+      const envelope = promToDsEnvelope(e.refId, prom);
+
+      if (frameCount === 0) {
+        // Empty frames on this (range, step) — annotate, don't
+        // fail. The 24h range against a freshly-started compose
+        // stack legitimately returns empty (the seed only spans
+        // ~60s); the same applies to histogram panels whose
+        // underlying _bucket series haven't been emitted yet at
+        // the very-small-range end.
+        emptyFrameCount++;
+        testInfo.annotations.push({
+          type: 'time-ranges-empty',
+          description: `[${surface}] no series returned for expr: ${e.expr} — (range × step) iteration excluded from shape rules (empty-frame flake gate)`,
+        });
+        return;
+      }
+      okFrameCount++;
+
+      // Aggregating-target assertions. Mirrors phase-1
+      // (iterate-panel-shape.spec.ts) — every `by(...)` key MUST
+      // appear on at least one returned frame; every `without(...)`
+      // key MUST be absent from every frame.
+      if (e.byKeys.length > 0) {
+        try {
+          assertLabelShape(envelope, e.byKeys);
+        } catch (err) {
+          failures.push(
+            `[${surface}] ${(err as Error).message}\n  expr: ${e.expr}`,
+          );
+        }
+      }
+      if (e.withoutKeys.length > 0) {
+        try {
+          assertLabelAbsent(envelope, e.withoutKeys);
+        } catch (err) {
+          failures.push(
+            `[${surface}] ${(err as Error).message}\n  expr: ${e.expr}`,
+          );
+        }
+      }
+
+      // Histogram-target assertions. Mirrors phase-2
+      // (iterate-histogram-completeness.spec.ts) — the matrix here
+      // does NOT re-probe `/api/v1/series` for _bucket presence
+      // (phase-2 already pins that at the short range; doing it
+      // per-(range, step) would 12× the probe count for no extra
+      // signal). Instead we apply the two branches based on the
+      // expression's structure alone:
+      //   - histogram_quantile over a `_bucket`-named root → the
+      //     response MUST be non-empty (assertHistogramComplete).
+      //   - histogram_quantile over a non-bucket root → the
+      //     response MUST be empty (assertNoFabricatedValue).
+      if (e.isHistogram) {
+        if (e.histogramName === null) {
+          try {
+            assertNoFabricatedValue(envelope, e.expr);
+          } catch (err) {
+            failures.push(
+              `[${surface}] ${(err as Error).message}\n  expr: ${e.expr}`,
+            );
+          }
+        } else {
+          try {
+            assertHistogramComplete(envelope, e.histogramName);
+          } catch (err) {
+            failures.push(
+              `[${surface}] ${(err as Error).message}\n  expr: ${e.expr}`,
+            );
+          }
+        }
+      }
+    } catch (err) {
+      failures.push(
+        `[${surface}] time-ranges probe threw: ${(err as Error).message}\n  url: ${queryURL}`,
+      );
+    }
+  };
+
+  // Shared cursor. JavaScript's run-to-completion semantics make the
+  // post-increment atomic with respect to the other workers, so no two
+  // workers can claim the same entry and none can be skipped.
+  let nextEntryIndex = 0;
+  const workerCount = Math.min(MATRIX_FAN_OUT_CONCURRENCY, entries.length);
+  await Promise.all(
+    Array.from({ length: workerCount }, async () => {
+      for (let i = nextEntryIndex++; i < entries.length; i = nextEntryIndex++) {
+        await sweepEntry(entries[i]);
       }
     }),
   );

--- a/test/regression/e2e_time_ranges_fan_out_bound_test.go
+++ b/test/regression/e2e_time_ranges_fan_out_bound_test.go
@@ -1,0 +1,162 @@
+package regression
+
+import (
+	"os"
+	"regexp"
+	"strconv"
+	"testing"
+)
+
+// Paths this test reads. The whole point is that the three files stay in
+// lock-step, so each is named once and cited in every failure message.
+const (
+	timeRangesSpecPath = "../e2e/playwright/iterate-time-ranges.spec.ts"
+	sweepHelperPath    = "../e2e/playwright/helpers/sweep.ts"
+	admitConfigPath    = "../../internal/config/config.go"
+)
+
+// tsBlockCommentRE and tsLineCommentRE strip TypeScript comments so a
+// code-shape scan cannot match the spec's own prose about that shape. The
+// line-comment pattern also bites inside string literals containing `//`
+// (a URL, say), which is harmless here: it can only ever remove text, so
+// it cannot manufacture a match that the code does not contain.
+var (
+	tsBlockCommentRE = regexp.MustCompile(`(?s)/\*.*?\*/`)
+	tsLineCommentRE  = regexp.MustCompile(`(?m)//.*$`)
+)
+
+// stripTSComments returns src with its comments removed.
+func stripTSComments(src string) string {
+	return tsLineCommentRE.ReplaceAllString(tsBlockCommentRE.ReplaceAllString(src, ""), "")
+}
+
+// TestTimeRangesSweepBoundsItsFanOutBelowTheAdmissionCap pins the fix for
+// tsouza/cerberus#2674.
+//
+// The failure it guards: iterate-time-ranges.spec.ts fired its whole
+// matrix through an unbounded `await Promise.all(entries.map(...))`. The
+// matrix is (eligible Prometheus targets × TIME_RANGES × STEP_SIZES), and
+// the k3d dashboard's 7 aggregating/histogram targets made that 7 × 4 × 3
+// = 84 simultaneous /api/v1/query_range calls. cerberus's Prom head admits
+// DefaultAdmitProm concurrent requests per process and its limiter is a
+// NON-blocking TryAcquire (internal/api/admit/admit.go) — overflow is not
+// queued, it is shed instantly with 503 `admission control: server
+// saturated`. Two tuples came back 503, the spec's own "any non-2xx other
+// than the pinned 422 is a hard failure" rule fired, and
+// `failOnFlakyTests` turned the pass-on-retry into a red gating
+// `dashboard-shard` job (nightly run 33080842708).
+//
+// The spec is not runnable outside a k3d cluster, so this static pin is
+// what keeps the class from recurring on an ordinary PR. It asserts:
+//
+//  1. The spec declares a fan-out ceiling and that ceiling fits inside
+//     DefaultAdmitProm, read from internal/config/config.go rather than
+//     restated here — a future cap reduction must break this test, not the
+//     nightly.
+//  2. The ceiling is actually referenced by the scheduling code, not just
+//     declared (a declared-but-unused const is a decorative fix).
+//  3. The unbounded `Promise.all(entries.map(...))` shape is gone.
+//  4. The bound is not vacuous: TIME_RANGES × STEP_SIZES alone already
+//     exceeds it, so the pool throttles even a one-panel dashboard.
+//  5. The warmup's deliberate saturation burst (ADMIT_BURST_CONCURRENCY in
+//     helpers/sweep.ts) still EXCEEDS the cap. That burst is what covers
+//     the admission-shed path on purpose; bounding the assertion phase is
+//     only legitimate while the saturation path stays covered elsewhere,
+//     so "fixing" #2674 by shrinking the burst must fail here.
+func TestTimeRangesSweepBoundsItsFanOutBelowTheAdmissionCap(t *testing.T) {
+	t.Parallel()
+
+	specBytes, err := os.ReadFile(timeRangesSpecPath)
+	if err != nil {
+		t.Fatalf("read %s: %v", timeRangesSpecPath, err)
+	}
+	spec := string(specBytes)
+
+	configBytes, err := os.ReadFile(admitConfigPath)
+	if err != nil {
+		t.Fatalf("read %s: %v", admitConfigPath, err)
+	}
+
+	// (1) The server's cap, read from the source of truth.
+	admitCapRE := regexp.MustCompile(`DefaultAdmitProm\s*=\s*(\d+)`)
+	capMatch := admitCapRE.FindStringSubmatch(string(configBytes))
+	if capMatch == nil {
+		t.Fatalf("%s no longer declares `DefaultAdmitProm = <n>` — this test's premise (a fixed per-process Prom admission cap the e2e client must stay under) is gone; re-derive the cap before dropping the assertion", admitConfigPath)
+	}
+	admitCap, err := strconv.Atoi(capMatch[1])
+	if err != nil {
+		t.Fatalf("parse DefaultAdmitProm from %s: %v", admitConfigPath, err)
+	}
+
+	// The client's ceiling.
+	ceilingRE := regexp.MustCompile(`(?m)^const MATRIX_FAN_OUT_CONCURRENCY = (\d+);`)
+	ceilingMatch := ceilingRE.FindStringSubmatch(spec)
+	if ceilingMatch == nil {
+		t.Fatalf("%s declares no `const MATRIX_FAN_OUT_CONCURRENCY = <n>;` — the matrix sweep must bound its own fan-out, or it fires (targets × ranges × steps) query_range calls at a %d-slot Prom head and fails on the 503 shed it provoked itself (#2674)", timeRangesSpecPath, admitCap)
+	}
+	ceiling, err := strconv.Atoi(ceilingMatch[1])
+	if err != nil {
+		t.Fatalf("parse MATRIX_FAN_OUT_CONCURRENCY from %s: %v", timeRangesSpecPath, err)
+	}
+	if ceiling < 1 {
+		t.Fatalf("%s sets MATRIX_FAN_OUT_CONCURRENCY = %d — a non-positive ceiling drains nothing and the sweep would assert on zero tuples", timeRangesSpecPath, ceiling)
+	}
+	if ceiling > admitCap {
+		t.Errorf("%s sets MATRIX_FAN_OUT_CONCURRENCY = %d, above the %d-slot Prom admission cap (DefaultAdmitProm in %s). cerberus's limiter is a non-blocking TryAcquire, so the overflow is shed with 503 `admission control: server saturated` and the spec fails on its own load (#2674)", timeRangesSpecPath, ceiling, admitCap, admitConfigPath)
+	}
+
+	// Checks (2) and (3) are about the code, not the prose. The spec
+	// documents both the ceiling and the unbounded shape it replaced, so
+	// scanning the raw text would match its own explanation.
+	specCode := stripTSComments(spec)
+
+	// (2) Declared AND used. A ceiling the scheduler never reads is a
+	// decorative fix that leaves the unbounded burst in place.
+	usageRE := regexp.MustCompile(`MATRIX_FAN_OUT_CONCURRENCY`)
+	if got := len(usageRE.FindAllString(specCode, -1)); got < 2 {
+		t.Errorf("%s mentions MATRIX_FAN_OUT_CONCURRENCY %d time(s) — the ceiling is declared but never read, so nothing actually bounds the sweep's fan-out (#2674)", timeRangesSpecPath, got)
+	}
+
+	// (3) The unbounded shape must be gone. `Promise.all` over a map of
+	// the whole `entries` array schedules every tuple at once regardless
+	// of any ceiling declared elsewhere in the file.
+	unboundedRE := regexp.MustCompile(`Promise\.all\(\s*entries\.map\(`)
+	if unboundedRE.MatchString(specCode) {
+		t.Errorf("%s still fires the matrix through `Promise.all(entries.map(...))` — that schedules every (panel × range × step) tuple simultaneously against a %d-slot Prom head and reintroduces the 503 shed of #2674; drain `entries` through the bounded worker pool instead", timeRangesSpecPath, admitCap)
+	}
+
+	// (4) Non-vacuity: the ceiling has to actually throttle something. The
+	// per-panel tuple count (ranges × steps) is the floor of what the
+	// matrix produces, so if even that fits under the ceiling the pool
+	// never limits anything and this whole guard is inert.
+	rangeRE := regexp.MustCompile(`(?m)^\s+\{ label: '[^']*', windowSeconds: `)
+	stepRE := regexp.MustCompile(`(?m)^\s+\{ label: '[^']*', stepSeconds: `)
+	rangeCount := len(rangeRE.FindAllString(spec, -1))
+	stepCount := len(stepRE.FindAllString(spec, -1))
+	if rangeCount == 0 || stepCount == 0 {
+		t.Fatalf("%s: parsed %d TIME_RANGES entr(ies) and %d STEP_SIZES entr(ies) — the matrix literals no longer match the expected shape, so this test cannot tell whether the fan-out ceiling throttles anything; fix the pattern rather than dropping the check", timeRangesSpecPath, rangeCount, stepCount)
+	}
+	if perPanelTuples := rangeCount * stepCount; perPanelTuples <= ceiling {
+		t.Errorf("%s: a single panel target yields %d tuple(s) (%d range(s) × %d step(s)), which is not above the MATRIX_FAN_OUT_CONCURRENCY ceiling of %d — the worker pool never throttles and the guard is inert", timeRangesSpecPath, perPanelTuples, rangeCount, stepCount, ceiling)
+	}
+
+	// (5) The deliberate saturation path must survive. Bounding the
+	// assertion phase is only honest while something else still drives the
+	// limiter past its cap on purpose.
+	sweepBytes, err := os.ReadFile(sweepHelperPath)
+	if err != nil {
+		t.Fatalf("read %s: %v", sweepHelperPath, err)
+	}
+	burstRE := regexp.MustCompile(`(?m)^const ADMIT_BURST_CONCURRENCY = (\d+);`)
+	burstMatch := burstRE.FindStringSubmatch(string(sweepBytes))
+	if burstMatch == nil {
+		t.Fatalf("%s declares no `const ADMIT_BURST_CONCURRENCY = <n>;` — that burst is what covers the admission-shed path on purpose, and it is the reason %s may bound its own fan-out at all (#2674)", sweepHelperPath, timeRangesSpecPath)
+	}
+	burst, err := strconv.Atoi(burstMatch[1])
+	if err != nil {
+		t.Fatalf("parse ADMIT_BURST_CONCURRENCY from %s: %v", sweepHelperPath, err)
+	}
+	if burst <= admitCap {
+		t.Errorf("%s sets ADMIT_BURST_CONCURRENCY = %d, which no longer exceeds the %d-slot Prom admission cap (DefaultAdmitProm in %s) — nothing in the e2e lane drives the limiter past its cap any more, so the shed path and the `Admission rejections` panel go uncovered", sweepHelperPath, burst, admitCap, admitConfigPath)
+	}
+}


### PR DESCRIPTION
## The failure

Nightly run 33080842708 went red on `dashboard-shard (shard-smoke-b-split)` → `iterate-time-ranges.spec.ts`, with two matrix tuples getting `HTTP 503` / `admission control: server saturated`. That was filed as tsouza/cerberus#2674.

The product behaved exactly as designed. The e2e client was the defect.

`iterate-time-ranges.spec.ts` fired its whole matrix through an unbounded `await Promise.all(entries.map(...))`. The matrix is (eligible Prometheus targets × `TIME_RANGES` × `STEP_SIZES`); the k3d dashboard carries 7 aggregating/histogram targets, all of which pass the spec's gate, so that is **7 × 4 × 3 = 84 simultaneous `/api/v1/query_range` calls**. cerberus's Prom head admits `DefaultAdmitProm = 64` concurrent requests per process (`internal/config/config.go`) and its limiter is a **non-blocking** `TryAcquire` (`internal/api/admit/admit.go`) — request 65 is not queued, it is shed instantly with a 503. The spec then treats any non-2xx other than its pinned 422 as a hard failure, and `failOnFlakyTests` turns the pass-on-retry into a red job.

Every sibling sweep (`iterate-panel-shape`, `iterate-filter-drill`) uses the same `Promise.all` but with a ×1 fan-out (~7 concurrent), which is why only this spec sheds.

## The change

`test/e2e/playwright/iterate-time-ranges.spec.ts` — three edits.

**1. Bounded worker-pool drain.** `entries` is now drained by `MATRIX_FAN_OUT_CONCURRENCY` workers pulling off a shared cursor. **Only the scheduling changes**: the per-tuple body — the resolution-cap branch, the 422 memory-limit dual contract, every shape assertion, every tally — moves verbatim into `sweepEntry`, so every tuple is still fired and still asserted. `git diff -w` shows the body as pure indentation.

The bound is an **absolute** small number (8), not the matrix size and not `cap - epsilon`. Scaling with the matrix re-crosses 64 the moment a panel is added to a provisioned dashboard, and tracking the server's cap would turn any change to `DefaultAdmitProm` into a silent renegotiation of what this spec exercises. A fixed number cannot drift into the shed no matter how the dashboards or the cap move.

**2. Annotation.** The `time-ranges` annotation now reports the fan-out ceiling, so the nightly report shows the concurrency the sweep actually ran at.

**3. Stale posture claim corrected.** The header said the spec "stays informational". It does not: `.github/scripts/dashboard-matrix.mjs` assigns it to `shard-smoke-b`, dispatched by the gating `dashboard-shard` matrix and **not** by the de-gated `dashboard-shard-info` matrix that carries the crawl coverage shard. Any non-success shard makes the `dashboard` roll-up job `exit 1`, `release.yml`'s preflight reads that check-run, and `nightly-health-notify` files an issue. The header now describes the gate it actually rides.

## What was deliberately not done

- **503 is not accepted as a third outcome.** The spec's two-outcome contract (2xx, or the byte-for-byte 422 memory-limit rejection) stands unchanged.
- **No retry on `Retry-After`.**
- **`admit.prom` is not raised or disabled in the k3d values.**

Each of those is a tolerance for a shed the test provokes itself, and the last two would also destroy the lane's ability to see a real saturation regression.

Bounding the assertion phase is only honest while something still drives the limiter past its cap on purpose — and something does. The spec's own warmup, `generateSelfTraffic`, bursts at `ADMIT_BURST_CONCURRENCY = 128` (`helpers/sweep.ts`) precisely to make the "Admission rejections" panel non-empty. That coverage is deliberate and separate, and the new regression test pins that it survives.

## Test plan

The spec cannot run outside a k3d cluster, so the class is pinned statically in `test/regression/e2e_time_ranges_fan_out_bound_test.go`. It asserts five things:

1. The ceiling fits inside `DefaultAdmitProm`, **read from `internal/config/config.go`** rather than restated — a cap reduction breaks this test, not the nightly.
2. The ceiling is actually referenced by the scheduling code, not just declared (a declared-but-unused const is a decorative fix).
3. The unbounded `Promise.all(entries.map(...))` shape is gone. Comments are stripped before this scan, so the spec's own prose about the shape it replaced cannot satisfy or trip the check.
4. **Non-vacuity**: `TIME_RANGES × STEP_SIZES` alone (12) exceeds the ceiling (8), so the pool throttles even a one-panel dashboard.
5. `ADMIT_BURST_CONCURRENCY` still **exceeds** the cap, so "fixing" this by shrinking the deliberate saturation burst fails here.

### Revert-check evidence

With the fix in place:

```
$ go test -run '^TestTimeRangesSweepBoundsItsFanOutBelowTheAdmissionCap$' ./test/regression/
ok  	github.com/tsouza/cerberus/test/regression	0.012s
```

With the spec reverted to `origin/main` and the test kept:

```
--- FAIL: TestTimeRangesSweepBoundsItsFanOutBelowTheAdmissionCap (0.00s)
    ../e2e/playwright/iterate-time-ranges.spec.ts declares no
    `const MATRIX_FAN_OUT_CONCURRENCY = <n>;` — the matrix sweep must bound its
    own fan-out, or it fires (targets × ranges × steps) query_range calls at a
    64-slot Prom head and fails on the 503 shed it provoked itself (#2674)
```

Second revert-check, to prove assertion 3 is independently live rather than shadowed by assertion 1 — pre-fix spec plus a *decorative* `MATRIX_FAN_OUT_CONCURRENCY = 8` const that nothing schedules against:

```
--- FAIL: TestTimeRangesSweepBoundsItsFanOutBelowTheAdmissionCap (0.00s)
    ../e2e/playwright/iterate-time-ranges.spec.ts still fires the matrix through
    `Promise.all(entries.map(...))` — that schedules every (panel × range × step)
    tuple simultaneously against a 64-slot Prom head and reintroduces the 503
    shed of #2674; drain `entries` through the bounded worker pool instead
```

The spec's own typecheck gate also passes:

```
$ cd test/e2e/playwright && npm ci && npx --no -- tsc --noEmit -p tsconfig.json
(clean)
```

## Scope note

tsouza/cerberus#2674 is the nightly-health umbrella ("nightly e2e run did not reach a clean pass"), which self-closes on the next clean nightly. This change removes the 503 class only. `main` is separately and deterministically red on the same spec with `query_range -> 502` and an empty body on wide-window/fine-step tuples, first appearing in the push run for `157c1a6cc` (#2689) — that is filed as tsouza/cerberus#2696 with its own bisect table and evidence. A clean nightly needs both, so this PR does not claim to close #2674.

Refs #2674
Refs #2696
