### PR TITLE
ci(mutation): pin the gremlins per-mutant budget to the declared ceiling

### DIFF
--- a/.github/scripts/gremlins-threshold.mjs
+++ b/.github/scripts/gremlins-threshold.mjs
@@ -1,9 +1,18 @@
 // gremlins-threshold.mjs — mutation-efficacy gate, extracted from the
 // "enforce efficacy threshold" step in .github/workflows/mutation.yml.
 //
-// gremlins v0.6.0 exits 0 even when --threshold-efficacy is violated, so
-// the gate is done here against the parsed report JSON. Reproduces the
-// original bash exactly:
+// The lane deliberately does NOT hand gremlins a threshold, and gates here
+// instead, against the parsed report JSON.
+//
+// Not because gremlins would ignore one: the pinned fork DOES exit non-zero on
+// a violation (report.go assess -> execution.NewExitErr(EfficacyThreshold) ->
+// main.go exitCode). That is exactly why the flag is withheld. gremlins exits
+// mid-run, before the report is read and uploaded, so the failure surfaces as an
+// opaque `gremlins exited N` from runGremlins() with no artifact to inspect and
+// no measured-vs-threshold numbers. Gating after the report is written keeps
+// both. Do not "simplify" this by passing --threshold-efficacy.
+//
+// Reproduces the original bash exactly:
 //
 //   measured=$(jq -r '.test_efficacy' gremlins.json)
 //   if awk 'BEGIN { exit (m < t) ? 1 : 0 }'; then  # m < t  -> fail

--- a/.github/scripts/mutation-phases.mjs
+++ b/.github/scripts/mutation-phases.mjs
@@ -15,10 +15,11 @@
 //
 // node: builtins only — no npm deps, no setup-node needed.
 
-// Every leg clears the same bar. `.gremlins.yaml`'s threshold (currently 95) is
-// the floor for the unscoped whole-repo `just mutate` invocation only; the
-// per-phase bar is set here so one weak package cannot hide behind a strong one
-// in a repo-wide average.
+// Every leg clears the same bar, and this is the only place a bar is declared.
+// `.gremlins.yaml` carries none: its former top-level `threshold-efficacy` was
+// a key gremlins never read, so the whole-repo floor it advertised for `just
+// mutate` never existed. The bar is per-leg so one weak package cannot hide
+// behind a strong one in a repo-wide average.
 const EFFICACY = 95;
 
 // gremlins' default fan-out is runtime.NumCPU(). DEFAULT_WORKERS keeps it;

--- a/.github/scripts/mutation-run.mjs
+++ b/.github/scripts/mutation-run.mjs
@@ -7,6 +7,9 @@
 // If that report contains zero executable mutants, the script deletes it and
 // reruns the phase without --diff. This makes comment-only or otherwise
 // mutation-free edits conservative full checks instead of hollow greens.
+//
+// Both invocations pin --timeout-coefficient so MUTANT_TIMEOUT_MAX is the sole
+// per-mutant budget; see perMutantBudgetIsTheCeilingCoefficient below.
 
 import { spawnSync } from 'node:child_process';
 import { existsSync, readFileSync, unlinkSync } from 'node:fs';
@@ -14,10 +17,47 @@ import process from 'node:process';
 
 import { error, notice } from './lib/gh.mjs';
 
+// gremlins derives each mutant's deadline as
+// `min(timeout-coefficient * max(coverage_elapsed, 1s), timeout-max)`, and that
+// deadline wraps the WHOLE `go test` child — recompile, link and run. But
+// `coverage_elapsed` is the wall time of gremlins' own coverage pass, which is
+// dominated by COMPILATION, not by test time. So the derived budget tracks how
+// warm the Go build cache happened to be rather than anything about the tests:
+// the zero-mutant fallback below re-invokes gremlins in the same job with the
+// cache already warmed by the first invocation, the coverage pass collapses
+// from ~50s to ~0.4s, `baseTime` clamps to gremlins' own 1s floor, and the
+// budget silently drops to 5s — under `internal/promql`'s real ~6.6s
+// recompile+link+run cost, so every mutant times out and the leg reports 0.00%
+// efficacy. Declaring the coefficient as `ceil(ceiling / 1s floor)` makes
+// `coefficient * max(elapsed, 1s)` at least the ceiling for any elapsed time,
+// so the budget is exactly MUTANT_TIMEOUT_MAX on every invocation.
+const gremlinsCoverageBaselineFloorSeconds = 1;
+
+const goDurationUnitSeconds = { ns: 1e-9, us: 1e-6, ms: 1e-3, s: 1, m: 60, h: 3600 };
+
 function required(name) {
   const value = String(process.env[name] ?? '').trim();
   if (value === '') throw new Error(`${name} is required`);
   return value;
+}
+
+// Parses the subset of Go's duration grammar a timeout ceiling can use: one or
+// more unsigned `<number><unit>` terms, e.g. `15s` or `1m30s`.
+function goDurationSeconds(name, spec) {
+  const terms = spec.match(/[0-9]+(?:\.[0-9]+)?(?:ns|us|ms|s|m|h)/g);
+  if (terms === null || terms.join('') !== spec) {
+    throw new Error(`${name} is not a Go duration: ${spec}`);
+  }
+  return terms.reduce((total, term) => {
+    const [, value, unit] = /^([0-9]+(?:\.[0-9]+)?)([a-z]+)$/.exec(term);
+    return total + Number(value) * goDurationUnitSeconds[unit];
+  }, 0);
+}
+
+function perMutantBudgetIsTheCeilingCoefficient(name, ceiling) {
+  const seconds = goDurationSeconds(name, ceiling);
+  if (!(seconds > 0)) throw new Error(`${name} must be a positive duration: ${ceiling}`);
+  return String(Math.ceil(seconds / gremlinsCoverageBaselineFloorSeconds));
 }
 
 function reportTotal(path) {
@@ -34,13 +74,16 @@ function reportTotal(path) {
 }
 
 function runGremlins({ report, diffRef = '' }) {
+  const ceiling = required('MUTANT_TIMEOUT_MAX');
   const args = [
     'unleash',
     '--output',
     report,
     '--on-shutdown-status=not-run',
     '--timeout-max',
-    required('MUTANT_TIMEOUT_MAX'),
+    ceiling,
+    '--timeout-coefficient',
+    perMutantBudgetIsTheCeilingCoefficient('MUTANT_TIMEOUT_MAX', ceiling),
   ];
   const workers = String(process.env.WORKERS ?? '').trim();
   if (workers !== '' && workers !== '0') {

--- a/.github/scripts/mutation-run.test.mjs
+++ b/.github/scripts/mutation-run.test.mjs
@@ -73,6 +73,45 @@ test('zero mutants after full fallback fail closed', (t) => {
   assert.match(`${result.stdout}\n${result.stderr}`, /executed zero mutants after full fallback/);
 });
 
+// The per-mutant budget must be a DECLARED value, not an accident of build-cache
+// warmth. gremlins computes `min(coefficient * max(coverage_elapsed, 1s),
+// timeout-max)`, so unless the coefficient alone carries the whole ceiling
+// across gremlins' own 1s floor, the hot-cache fallback invocation silently gets
+// a smaller budget than the cold-cache first one.
+test('both invocations pin the per-mutant budget to the declared ceiling', (t) => {
+  const { root, calls } = fixture(t, [0, 7]);
+  const result = run(root, { DIFF_REF: 'a'.repeat(40), MUTANT_TIMEOUT_MAX: '15s' });
+  assert.equal(result.status, 0, result.stderr);
+  const invocations = readFileSync(calls, 'utf8').trim().split('\n').map(JSON.parse);
+  assert.equal(invocations.length, 2);
+  for (const args of invocations) {
+    assert.deepEqual(args.slice(args.indexOf('--timeout-max'), args.indexOf('--timeout-max') + 2), [
+      '--timeout-max',
+      '15s',
+    ]);
+    const at = args.indexOf('--timeout-coefficient');
+    assert.notEqual(at, -1, `--timeout-coefficient missing from ${JSON.stringify(args)}`);
+    // gremlins clamps its measured coverage time up to a 1s floor, so
+    // `coefficient * 1s` is the smallest budget the coefficient can yield; it
+    // must already reach the ceiling for the ceiling to be the sole budget.
+    assert.ok(Number(args[at + 1]) * 1 >= 15, `coefficient ${args[at + 1]} is below the ceiling`);
+  }
+});
+
+test('the declared coefficient rounds a compound ceiling up, and rejects a bad one', (t) => {
+  const { root, calls } = fixture(t, [4]);
+  let result = run(root, { DIFF_REF: '', MUTANT_TIMEOUT_MAX: '1m30s' });
+  assert.equal(result.status, 0, result.stderr);
+  const args = readFileSync(calls, 'utf8').trim().split('\n').map(JSON.parse)[0];
+  assert.equal(args[args.indexOf('--timeout-coefficient') + 1], '90');
+
+  const bad = fixture(t, [4]);
+  result = run(bad.root, { DIFF_REF: '', MUTANT_TIMEOUT_MAX: '15 seconds' });
+  assert.equal(result.status, 1);
+  assert.equal(readFileSync(bad.calls, 'utf8'), '');
+  assert.match(`${result.stdout}\n${result.stderr}`, /MUTANT_TIMEOUT_MAX is not a Go duration/);
+});
+
 test('invalid diff refs and stale reports fail before gremlins runs', (t) => {
   const { root, calls } = fixture(t, [3]);
   let result = run(root, { DIFF_REF: 'main' });

--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -114,10 +114,11 @@ jobs:
   mutate:
     # Per-phase mutation kill-zone. gremlins v0.6.0 has no per-package
     # threshold, so each phase runs as its own matrix entry scoped to a
-    # single package with its own --threshold-efficacy bar. The bar in
-    # `.gremlins.yaml` (currently 95) is the floor for the unscoped
-    # whole-repo `just mutate` invocation only — the phase table in
-    # .github/scripts/mutation-phases.mjs mirrors it per phase, and carries
+    # single package with its own --threshold-efficacy bar. `.gremlins.yaml`
+    # declares no bar at all (its former top-level `threshold-efficacy` /
+    # `threshold-mcover` keys were never read by gremlins, so the whole-repo
+    # floor they advertised for `just mutate` never existed) — the phase table
+    # in .github/scripts/mutation-phases.mjs is the only bar, and carries
     # the per-leg rationale (the logql/traceql OOM splits, the equivalent-mutant
     # analysis behind each bar) that used to live in this block.
     name: gremlins ${{ matrix.phase }} (${{ matrix.scope }} @ ${{ matrix.efficacy }}%)
@@ -177,16 +178,27 @@ jobs:
       # non-zero value caps the parallel `go test` fan-out per the
       # comment above the matrix entry.
       #
-      # MUTANT_TIMEOUT_MAX is the absolute ceiling on a single mutant's test
-      # run. gremlins otherwise derives that timeout as `timeout-coefficient x
-      # the package's baseline test duration`, which scales the leash by how
-      # SLOW a package's tests are — a quantity unrelated to how much damage a
-      # runaway mutant does in that time. A mutant that inverts a scanner's
-      # loop-advance (i++ -> i--) never terminates and allocates per iteration,
-      # so on a slow-baseline package it gets minutes to exhaust the runner's
-      # memory. The OOM killer then reaps the runner agent and the job dies
-      # with no verdict at all, which reads as flake rather than as a missing
-      # bound.
+      # MUTANT_TIMEOUT_MAX is the per-mutant budget, and — because
+      # mutation-run.mjs pins --timeout-coefficient to match it — it is the
+      # WHOLE budget, not merely a ceiling over some smaller derived value.
+      # That distinction is load-bearing. gremlins derives the timeout as
+      # `min(timeout-coefficient x the coverage run's wall time, timeout-max)`,
+      # which scales the leash by how long the package took to COMPILE for
+      # coverage — a quantity unrelated to how much damage a runaway mutant
+      # does in that time, and one that collapses to gremlins' 1s floor
+      # whenever the Go build cache is already warm (as it is for
+      # mutation-run.mjs's second, full-fallback invocation). Left alone, the
+      # ceiling therefore silently lowered itself to 5s on exactly the path a
+      # pull request takes, under internal/promql's real ~6.6s per-mutant
+      # recompile+link+run, and the leg reported 0.00% efficacy (#2692). With
+      # the coefficient pinned, both invocations get this declared value.
+      #
+      # The budget bounds the whole `go test` child, and a bound is needed at
+      # all because a mutant that inverts a scanner's loop-advance
+      # (i++ -> i--) never terminates and allocates per iteration, so an
+      # unbounded leash lets it exhaust the runner's memory. The OOM killer
+      # then reaps the runner agent and the job dies with no verdict at all,
+      # which reads as flake rather than as a missing bound.
       #
       # Do NOT "fix" a recurrence by excluding whichever file the log names:
       # that relocates the file's runaway mutants into whichever leg still owns

--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -193,6 +193,18 @@ jobs:
       # recompile+link+run, and the leg reported 0.00% efficacy (#2692). With
       # the coefficient pinned, both invocations get this declared value.
       #
+      # This is deliberately NOT budget-neutral on the single-invocation path
+      # that was already green. Any leg whose COLD coverage pass ran under
+      # 3s was silently below this ceiling on every event too, and now gets the
+      # full declared value: phase6-spansscan 1.19s -> 5.97s becomes 15s,
+      # phase5-qlcommon 2.82s -> 14.1s becomes 15s. That is the point — the
+      # budget is now the number written here rather than an artefact of
+      # compile time — but it does lengthen the OOM leash the paragraph below
+      # governs, by up to 2.5x on the fastest-compiling legs. 15s is the
+      # analysed value and those legs report `Timed out: 0`, so the exposure is
+      # bounded; deriving the ceiling from measurement behind a memory cap is
+      # tracked in #2694.
+      #
       # The budget bounds the whole `go test` child, and a bound is needed at
       # all because a mutant that inverts a scanner's loop-advance
       # (i++ -> i--) never terminates and allocates per iteration, so an
@@ -216,9 +228,11 @@ jobs:
           DIFF_REF: ${{ matrix.diff_ref }}
           REPORT: gremlins.json
         run: node .github/scripts/mutation-run.mjs
-      # gremlins v0.6.0 exits 0 even when --threshold-efficacy is
-      # violated, so the gate is done in gremlins-threshold.mjs against
-      # the parsed report JSON (measured < threshold -> fail).
+      # The lane withholds --threshold-efficacy from gremlins on purpose and
+      # gates in gremlins-threshold.mjs against the parsed report JSON
+      # (measured < threshold -> fail). The pinned fork DOES exit non-zero on a
+      # violation; it just does so mid-run, before the report is written and
+      # uploaded, leaving an opaque `gremlins exited N` and no artifact.
       - name: enforce efficacy threshold
         run: node .github/scripts/gremlins-threshold.mjs
         env:

--- a/.gremlins.yaml
+++ b/.gremlins.yaml
@@ -22,8 +22,6 @@ mutants:
     enabled: true
   remove-self-assignments:
     enabled: true
-test:
-  timeout-coefficient: 4
 # NOTE: there is deliberately no `excluded-files` key here. gremlins reads
 # exclusions from `unleash.exclude-files` (a single RE2 regex), so a
 # top-level `excluded-files:` list of globs is never read at all — this file
@@ -31,6 +29,26 @@ test:
 # exclusions live in `.github/workflows/mutation.yml` as the
 # `--exclude-files` CLI flag, which is bound correctly and is the only
 # mechanism that actually partitions files across legs.
+#
+# NOTE: there is deliberately no `timeout-coefficient` key here either, and
+# for the same dead-key reason: gremlins reads it as
+# `unleash.timeout-coefficient`, so the `test: timeout-coefficient: 4` this
+# file carried was never read and the effective coefficient was the built-in
+# default 5 throughout. It is not re-nested, it is gone: the per-mutant budget
+# is a DECLARED value, derived from the run's own ceiling by
+# `.github/scripts/mutation-run.mjs`, not a multiple of however long the Go
+# build cache made gremlins' coverage pass take. A file-level coefficient
+# would silently reinstate that compile-time-derived budget for every
+# invocation that does not pass the flag.
+#
+# NOTE: there are deliberately no `threshold-efficacy` / `threshold-mcover`
+# keys here — same dead-key class a third time (the real keys are
+# `unleash.threshold.efficacy` / `unleash.threshold.mutant-coverage`), so the
+# whole-repo floor this file advertised for `just mutate` never existed. The
+# floors that DO exist are per-leg, declared in
+# `.github/scripts/mutation-phases.mjs` and enforced against the report JSON
+# by `.github/scripts/gremlins-threshold.mjs`. `just mutate` is an unscoped,
+# informational local sweep and reports rather than gates.
 
 # Phased mutation-testing rollout. Each phase scopes gremlins to one
 # package with its own `--threshold-efficacy` bar enforced in
@@ -61,14 +79,8 @@ test:
 # Promotion to a required CI gate happens after all phases stay
 # stable for a week.
 #
-# The thresholds below are GLOBAL (gremlins v0.6.0 does not support
-# per-package thresholds — see `gremlins unleash --help`). The
-# per-phase bar is enforced in `.github/workflows/mutation.yml` via a
-# matrix that runs `gremlins unleash --threshold-efficacy <bar>
-# ./internal/<pkg>/...` once per phase, scoped to a single package
-# at a time so the slower packages don't drag the bar down. The
-# values below are the floor for the unscoped whole-repo
-# `just mutate` invocation; the per-phase matrix entries are
-# informational until all phases stay green for a week.
-threshold-efficacy: 95
-threshold-mcover: 50
+# A file-level threshold would in any case be GLOBAL (gremlins v0.6.0 has no
+# per-package threshold — see `gremlins unleash --help`), which is why the bar
+# is per-leg and lives outside this file: the matrix in
+# `.github/workflows/mutation.yml` runs one leg per package so the slower
+# packages do not drag a shared bar down.

--- a/docs/test-strategy.md
+++ b/docs/test-strategy.md
@@ -960,11 +960,17 @@ new shape before the generator publishes it, never the reverse.
 
 ## Gremlins mutation
 
-`.gremlins.yaml` carries the floor for an unscoped whole-repo `just
-mutate`; the per-phase table — scope, efficacy floor, worker cap,
-exclude set, and the rationale behind each — lives in
-`.github/scripts/mutation-phases.mjs`, and `.github/workflows/mutation.yml`
-expands it into the `mutate` job's matrix. The rolled-up `mutation` context is
+`.gremlins.yaml` carries the enabled mutator set and nothing else — no floor.
+Every efficacy floor is per-leg: the phase table — scope, efficacy floor, worker
+cap, exclude set, and the rationale behind each — lives in
+`.github/scripts/mutation-phases.mjs`, `.github/workflows/mutation.yml`
+expands it into the `mutate` job's matrix, and
+`.github/scripts/gremlins-threshold.mjs` enforces it against the report JSON.
+An unscoped whole-repo `just mutate` reports rather than gates; it used to
+advertise a 95% floor through top-level `threshold-efficacy` /
+`threshold-mcover` keys that gremlins never read (it reads
+`unleash.threshold.efficacy` / `unleash.threshold.mutant-coverage`), so that
+floor never existed and the keys are gone. The rolled-up `mutation` context is
 informational — not required by either the merge gate or the release gate
 (#2230) — but keeps a real, non-blanket per-PR selection (below) rather than a
 blanket no-op, for early author-time signal.
@@ -1028,6 +1034,33 @@ rejects any that reach for lookaround or a backreference — RE2 has
 neither, and a leg that only discovers this at run time has already
 spent its checkout and toolchain setup.
 
+### Per-mutant time budget
+
+Each mutant's `go test` child runs under a deadline, because a mutant that
+inverts a loop advance never terminates and allocates per iteration; without a
+deadline the OOM killer reaps the runner and the leg reports no verdict at all.
+
+That deadline is a declared value, not a measured one. gremlins computes it as
+`min(timeout-coefficient x max(coverage_elapsed, 1s), timeout-max)`, where
+`coverage_elapsed` is the wall time of its own coverage pass — a number
+dominated by COMPILATION, not by test time, and therefore a function of how warm
+the Go build cache happened to be. `.github/scripts/mutation-run.mjs` neutralises
+that input: it derives `--timeout-coefficient` from `MUTANT_TIMEOUT_MAX` as
+`ceil(ceiling / 1s)`, so `coefficient x max(elapsed, 1s)` is at least the ceiling
+for any elapsed time and the budget is exactly `MUTANT_TIMEOUT_MAX` on every
+invocation. `.github/workflows/mutation.yml` declares that ceiling.
+
+The coefficient is passed on BOTH of `mutation-run.mjs`'s invocations, and the
+second is why this matters. When the changed-line run finds zero executable
+mutants the script reruns the phase in full, in the same job, with the build
+cache already warmed by the first run: `coverage_elapsed` collapses from ~50s to
+~0.4s, clamps up to gremlins' 1s floor, and the derived budget drops to 5s —
+under `internal/promql`'s real ~6.6s recompile+link+run cost. Every mutant then
+times out, and because gremlins counts a timed-out mutant in neither the efficacy
+ratio nor `mutants_total`, the leg reported `Timed out: 295 / Test efficacy:
+0.00%` on pull requests while the identical leg on push-to-main — one
+cold-cache invocation, the intended budget — reported 99.65% (#2692).
+
 A surviving mutant is either (a) a legitimately weak assertion that
 needs strengthening, (b) a functionally-equivalent mutation (`<` vs
 `<=` on a boundary that's never hit, slice-cap arithmetic that
@@ -1042,7 +1075,8 @@ suite carry the discipline:
 
 1. **PREFERRED — prove equivalent.** Add a comment in the source
    explaining why the mutated branch is semantically identical to the
-   original, then drop the phase efficacy threshold in `.gremlins.yaml`
+   original, then drop that leg's efficacy threshold in
+   `.github/scripts/mutation-phases.mjs`
    by 1 percentage point to absorb the equivalent mutant. The mutation
    count is now defensible and the source stays clear.
 2. **ACCEPTABLE — add a distinguishing test.** Write a unit / property

--- a/test/regression/mutation_timeout_max_test.go
+++ b/test/regression/mutation_timeout_max_test.go
@@ -17,10 +17,17 @@ const mutationRunnerPath = "../../.github/scripts/mutation-run.mjs"
 // mutated package's own tests are.
 const timeoutMaxFlag = "--timeout-max"
 
+// The runner must pass the flag AND source its value from the env var. Pinned
+// as two independent substrings rather than as one adjacent `'--timeout-max',
+// required('MUTANT_TIMEOUT_MAX'),` phrase: that spelling broke the moment the
+// value was hoisted into a local to be reused by --timeout-coefficient, which
+// is a refactor this pin has no business rejecting. What it must still catch is
+// the flag disappearing, or its value coming from somewhere other than the
+// declared ceiling.
 const (
 	mutationRunnerInvocation = "run: node .github/scripts/mutation-run.mjs"
 	timeoutMaxArg            = "'--timeout-max',"
-	timeoutMaxValue          = "required('MUTANT_TIMEOUT_MAX'),"
+	timeoutMaxValue          = "required('MUTANT_TIMEOUT_MAX')"
 )
 
 // gremlinsForkTagPrefix is the fork tag family that supports timeoutMaxFlag.


### PR DESCRIPTION
## The root

The per-mutant deadline was an accident of build-cache warmth, not a declared value.

gremlins derives it as `min(timeout-coefficient * max(coverage_elapsed, 1s), timeout-max)` and applies it as a `context.WithTimeout` around the whole `go test` child, so it bounds recompile + link + run. But `coverage_elapsed` is the wall time of gremlins' own coverage pass, which is dominated by **compilation**, not by test time.

`mutation-run.mjs`'s zero-mutant fallback re-invokes gremlins a second time in the same job. By then the first invocation has warmed the Go build cache, so the second coverage pass measures **0.401s instead of ~50s**, clamps up to gremlins' 1s floor, and the budget collapses:

```
min(DefaultTimeoutCoefficient(5) * max(0.401s, 1s), 15s) = 5s
```

`internal/promql`'s real per-mutant cost is ~6.6s at the CI fan-out. So every mutant exceeded its deadline. And because gremlins counts a timed-out mutant in neither the efficacy ratio nor `mutants_total` (`report.go:95,179`), the leg reported `Timed out: 295 / Test efficacy: 0.00%` and then failed `mutation-run.mjs`'s zero-mutant check.

That is exactly why every failure was a `pull_request` run and every push-to-main run of the identical leg was green: on push-to-main `DIFF_REF` is empty, gremlins runs **once** with a cold cache, and the budget is the intended 15s.

Arithmetic closure on the CI numbers: 295 mutants x 5s / 4 workers = 369s; observed fallback wall time was 6m11s = 371s (0.5% error).

The prior hypothesis — that `internal/promql`'s baseline `go test` exceeds the 15s ceiling — is refuted by measurement: 1.8s wall, 0.35s test binary, no regression across #2689/#2690.

## The change

**`.github/scripts/mutation-run.mjs`** passes `--timeout-coefficient` on **both** invocations, derived from `MUTANT_TIMEOUT_MAX` as `ceil(ceiling / gremlins' 1s floor)`. That makes `coefficient * max(elapsed, 1s)` at least the ceiling for any elapsed time, so `MUTANT_TIMEOUT_MAX` is the sole budget and the fallback invocation gets the same budget as the first. The derivation is carried by `perMutantBudgetIsTheCeilingCoefficient`, with a comment stating that gremlins' own derivation measures compile time, not test time.

Deriving from the ceiling rather than hard-coding a number means whatever value #2694 lands on takes effect on both invocations automatically, with no second place to keep in step.

**`.gremlins.yaml`** — same diagnosis surfaced two more dead keys, the third instance of the class the file's own comment already documents for `excluded-files`. It set `test.timeout-coefficient: 4`, `threshold-efficacy: 95` and `threshold-mcover: 50`; gremlins reads those as `unleash.timeout-coefficient`, `unleash.threshold.efficacy` and `unleash.threshold.mutant-coverage`. None were ever read — the effective coefficient was the built-in default 5, and the whole-repo floor the file advertised for `just mutate` did not exist.

They are **deleted rather than re-nested**, and that is a deliberate call. Re-nesting the thresholds would make gremlins itself return a non-zero exit on a threshold violation (`report.go:229` -> `execution.NewExitErr`), which `mutation-run.mjs` would surface as an opaque `gremlins exited 1` — aborting the phase before the report is even read, and applying a global 95%/50% bar on top of the per-leg bars. The real floors are the per-leg bars in `mutation-phases.mjs`, enforced against the report JSON by `gremlins-threshold.mjs`; the coefficient is now declared per-invocation. A file-level coefficient would silently reinstate the compile-time-derived budget for any invocation that does not pass the flag.

**`.github/workflows/mutation.yml`** — the step comment asserted `MUTANT_TIMEOUT_MAX` was "the absolute ceiling on a single mutant's test run" while the coefficient path silently lowered it. It now states how the budget is derived, and keeps the runaway-mutant rationale for why a bound exists at all. The matrix comment claiming `.gremlins.yaml` carries a whole-repo floor is corrected too.

**`docs/test-strategy.md`** — new "Per-mutant time budget" subsection in the gremlins rollout stating the derivation; the stale "`.gremlins.yaml` carries the floor" and "drop the phase efficacy threshold in `.gremlins.yaml`" claims are corrected to point at `mutation-phases.mjs`.

## Test plan

New cases in `.github/scripts/mutation-run.test.mjs`, which drives the real `mutation-run.mjs` through its process boundary against a fake `gremlins` on `PATH` that records its argv:

- `both invocations pin the per-mutant budget to the declared ceiling` — forces the zero-mutant fallback and asserts **each** of the two invocations carries `--timeout-max 15s` and a `--timeout-coefficient` whose value times gremlins' 1s floor already reaches the ceiling.
- `the declared coefficient rounds a compound ceiling up, and rejects a bad one` — `1m30s` yields `90`; a non-duration `MUTANT_TIMEOUT_MAX` fails before gremlins is spawned (asserted by the recorded-argv file staying empty).

**Revert-check.** With the test kept and `mutation-run.mjs` restored to its `HEAD` content:

```
✔ changed-line execution stays incremental when it executes mutants
✔ zero changed-line mutants trigger one full fallback
✔ zero mutants after full fallback fail closed
✖ both invocations pin the per-mutant budget to the declared ceiling
✖ the declared coefficient rounds a compound ceiling up, and rejects a bad one
✔ invalid diff refs and stale reports fail before gremlins runs
ℹ tests 6 / pass 4 / fail 2
```

With the fix restored: `tests 6 / pass 6 / fail 0`. `node --test .github/scripts/mutation-run.test.mjs .github/scripts/mutation-matrix.test.mjs` -> 42/42.

**End-to-end, real gremlins.** `SCOPE=./internal/deltaprefix MUTANT_TIMEOUT_MAX=15s WORKERS=1 node .github/scripts/mutation-run.mjs` against the locally installed `v0.6.0-cerberus-timeout-max-consume` binary: the fork accepts `--timeout-coefficient 15` alongside `--timeout-max 15s`, the edited `.gremlins.yaml` parses, and the run completed `Killed: 25, Lived: 1, Not covered: 1 / Timed out: 0 / Test efficacy: 96.15%` -> `::notice::mutation phase executed 26 mutant(s) in full`.

`actionlint .github/workflows/mutation.yml` clean; `markdownlint-cli2 docs/test-strategy.md` 0 errors.

**The direct verification is this PR's own lane.** `phase4-promql-g` runs here as a `pull_request` — the exact path that produced `Timed out: 295 / Test efficacy: 0.00%` on #2689 and #2690. It must now report a non-zero `mutants_total` and an efficacy in line with the push-to-main run's 99.65%.

## Deliberately out of scope

Filed before this merges (invariant 3), because each is a distinct root with its own risk budget:

- #2694 — raising `MUTANT_TIMEOUT_MAX` above 15s. The fork tag is literally `v0.6.0-cerberus-timeout-max-consume`; raising the ceiling without a memory cap on the `go test` child re-opens the runaway-mutant OOM the ceiling exists to prevent, trading a clean timeout for a reaped runner.
- #2695 — timed-out mutants being excluded from both the efficacy ratio and `mutants_total`. Live today: `phase2-other` reported GREEN at 98.72% with 262 of 340 mutants never adjudicated. A reporting-hollowness root, not a budget root, and a gate for it flips several currently-green chsql legs red on first run.

Closes #2692
