### PR TITLE
ci: warm the Go module cache through a shared setup-go composite with fetch retry

### DIFF
--- a/.github/actions/setup-go/action.yml
+++ b/.github/actions/setup-go/action.yml
@@ -57,6 +57,14 @@ inputs:
       go.sum. Setting it to `false` opts a job out of the SHARED cache — it
       does not opt out of the warm step, because the modules still have to be
       fetched and that fetch still deserves a retry.
+
+      A job whose `cache: false` is part of a TRUST BOUNDARY should not use
+      this input: routed through here the value reaches the Action as
+      `${{ inputs.cache }}`, which no static analysis can resolve, and CodeQL's
+      cache-poisoning query stops being able to see that the job cannot write
+      the cache at all. update-golden.yml's three regenerating jobs spell the
+      literal out and pair it with their own warm step instead;
+      assert-go-setup-hardened.mjs requires exactly that pairing.
     required: false
     default: 'true'
 

--- a/.github/actions/setup-go/action.yml
+++ b/.github/actions/setup-go/action.yml
@@ -59,14 +59,27 @@ inputs:
       fetched and that fetch still deserves a retry.
 
       A job whose `cache: false` is part of a TRUST BOUNDARY should not use
-      this input: routed through here the value reaches the Action as
-      `${{ inputs.cache }}`, which no static analysis can resolve, and CodeQL's
-      cache-poisoning query stops being able to see that the job cannot write
-      the cache at all. update-golden.yml's three regenerating jobs spell the
-      literal out and pair it with their own warm step instead;
-      assert-go-setup-hardened.mjs requires exactly that pairing.
+      this input at all. Routed through here the value reaches the Action as an
+      unresolved input expression, and CodeQL's cache-poisoning query stops
+      being able to see that the job cannot write the cache — see the note
+      below the inputs block.
     required: false
     default: 'true'
+
+# THE `cache: false` TRUST-BOUNDARY EXCEPTION, spelled out here rather than in
+# the input description above — a description is template-evaluated by the
+# runner, so an expression written inside one fails the action to load.
+#
+# update-golden.yml's three regenerating jobs check out TARGET-BRANCH code under
+# the default branch's privileges, and their `cache: false` is what stops that
+# code persisting bytes into later workflows. Passed through the input below,
+# that value reaches `actions/setup-go` as an unresolved `inputs.cache`
+# expression, which no static analysis can resolve to false — and CodeQL's
+# `actions/cache-poisoning/poisonable-step` query reported all three jobs as
+# poisonable the moment they were routed through here. So those three name the
+# Action directly with the literal, and run the warm step below themselves.
+# `assert-go-setup-hardened.mjs` requires exactly that pairing (R1 + R2), which
+# is what keeps it a narrower path rather than an escape hatch.
 
 runs:
   using: composite

--- a/.github/actions/setup-go/action.yml
+++ b/.github/actions/setup-go/action.yml
@@ -1,0 +1,79 @@
+name: Setup Go
+description: >
+  Install the Go toolchain, restore setup-go's module cache, and then WARM
+  GOMODCACHE through the retrying module fetch — so no job can ever save an
+  empty cache, and a transient module-proxy fault never fails a job on an
+  unretried first attempt.
+
+# WHY A COMPOSITE ACTION, and why the warm step is UNCONDITIONAL.
+#
+# `actions/setup-go` saves its module cache in a post-job step, keyed on the
+# module's go.sum, and it saves only when the primary key MISSED. It does not
+# check that there is anything to save. So a job that runs setup-go with
+# `cache: true` and then runs no Go command at all archives an EMPTY
+# GOMODCACHE — and if it wins the race to finish first after a go.sum bump on
+# `refs/heads/main`, that empty archive becomes the entry every later job, and
+# every PR branch falling back to main's cache scope, restores. Nothing saves
+# over it, because from then on the primary key HITS. The poison is permanent
+# until go.sum changes again.
+#
+# That is not hypothetical: run 32705099037's `post-merge-drift` planning job —
+# a Go-less job whose only work step is `node …/post-merge-golden-drift.mjs` —
+# logged `Cache folder path is retrieved but doesn't exist on disk:
+# /home/runner/go/pkg/mod` immediately followed by `Cache saved with the key:
+# setup-go-Linux-x64-ubuntu24-go-1.26.2-29abba13…`, writing a 7,616-byte archive
+# on main. Every Go job in the repo then re-downloaded ~340 modules on every
+# run, and the ambient flakiness of a multi-minute proxy.golang.org stream
+# turned into seven job failures in one afternoon.
+#
+# The per-leg fix is `cache: false` on that one job. This is the root fix
+# instead: the warm step runs `go mod download` on EVERY path through this
+# action, so by the time setup-go's post step looks at GOMODCACHE it is never
+# empty — including for a job that runs no Go command of its own. Poisoning
+# stops being something a workflow author has to remember not to do and becomes
+# something the setup path cannot express. `assert-go-setup-hardened.mjs` is the
+# ratchet that keeps every call site on this path.
+#
+# The warm step is also the one place a cold fetch is retry-hardened. The Go
+# module resolver does not retry past a dropped HTTP/2 frame, so a single
+# `INTERNAL_ERROR; received from peer` in a ~340-module download stream kills a
+# job outright. Routing the bulk fetch through go-module-fetch.mjs means the
+# rest of the job — `go test`, `go list`, `go build`, `just`, `gremlins` — finds
+# its modules already on disk and is left free to fail on its FIRST attempt,
+# which is exactly where a real failure must fail. See that module's header for
+# the three layers that keep the retry from masking anything.
+
+inputs:
+  go-version-file:
+    description: >
+      The go.mod whose `go` directive selects the toolchain. Its DIRECTORY is
+      also where the warm step runs, so `target/go.mod` warms the module graph
+      of the checkout under `target/`.
+    required: false
+    default: go.mod
+  cache:
+    description: >
+      Restore and save setup-go's shared module cache, keyed on that module's
+      go.sum. Setting it to `false` opts a job out of the SHARED cache — it
+      does not opt out of the warm step, because the modules still have to be
+      fetched and that fetch still deserves a retry.
+    required: false
+    default: 'true'
+
+runs:
+  using: composite
+  steps:
+    - uses: actions/setup-go@v7
+      with:
+        go-version-file: ${{ inputs.go-version-file }}
+        cache: ${{ inputs.cache }}
+
+    # Unconditional by design — see the header. A condition here is exactly the
+    # hole this action exists to close.
+    - name: Warm the Go module cache
+      shell: bash
+      env:
+        GO_VERSION_FILE: ${{ inputs.go-version-file }}
+      run: |
+        cd "$(dirname "$GO_VERSION_FILE")"
+        node "$GITHUB_WORKSPACE/.github/scripts/go-module-fetch.mjs"

--- a/.github/scripts/README.md
+++ b/.github/scripts/README.md
@@ -2212,32 +2212,44 @@ what actually runs.
     fetch-only.
   - Gated by `go-module-fetch.test.mjs`, whose positive fixtures are the
     verbatim stderr of the runs above.
-- **`assert-go-setup-hardened.mjs`** — the required `check` lane. Fails when any
-  workflow step, or any composite action other than the wrapper itself, `uses:`
-  `actions/setup-go` directly. `actions/setup-go` saves its module cache keyed on
-  go.sum, only on a primary-key MISS, and without checking that there is anything
-  to save — so a Go-less job with `cache: true` can archive an EMPTY GOMODCACHE
-  on `refs/heads/main`, after which every job (and every PR ref falling back to
+- **`assert-go-setup-hardened.mjs`** — the required `check` lane. No job may
+  reach the point where setup-go's post-job step archives the module cache with
+  an EMPTY GOMODCACHE. `actions/setup-go` saves that cache keyed on go.sum, only
+  on a primary-key MISS, and without checking that there is anything to save —
+  so a Go-less job with `cache: true` can archive an empty one on
+  `refs/heads/main`, after which every job (and every PR ref falling back to
   main's scope) restores nothing, declines to save, and re-downloads the whole
   graph until the next go.sum bump. Run 32705099037 did exactly that, in 35
   seconds, with a 7,616-byte archive.
-  - The fix is `./.github/actions/setup-go`, which warms GOMODCACHE
-    unconditionally so the post-job save can never see it empty. This gate is the
-    ratchet: it also asserts the wrapper still delegates to `actions/setup-go`,
-    still runs `go-module-fetch.mjs`, and that the warm step carries no `if:` —
-    a conditional warm leaves the hole open.
-  - It says nothing about `cache:`. `false` is load-bearing on
-    `update-golden.yml`'s three jobs, which run target-branch code and must not
-    persist bytes into later workflows; the warm step runs either way.
-  - There is no allow-list. The one file permitted to name `actions/setup-go` is
-    permitted by identity — it is the wrapper's own `action.yml`, the definition
-    site, which cannot be a call site of itself.
+  - **R1** A step reaching `actions/setup-go` directly must set `cache: false`
+    as a LITERAL. The rule is keyed on the mechanism: a step that never saves
+    the shared cache cannot poison it, so it is outside the rule's subject
+    rather than exempted from it. Everything that CAN write that cache goes
+    through `./.github/actions/setup-go`, where the warm step is unconditional.
+  - **R2** A job holding such a step must also run `go-module-fetch.mjs`.
+    Opting out of the cache is not opting out of the fetch.
+  - **R3** No composite action other than the wrapper may use the Action at all
+    — there is no job scope there in which R2 could be satisfied.
+  - **R4** The wrapper exists, delegates, warms, and its warm step carries no
+    `if:`. A conditional warm leaves the hole open.
+  - **R5** At least one step actually uses the wrapper.
+  - Why R1 takes a literal rather than an input: `update-golden.yml`'s three
+    regenerating jobs check out target-branch code under the default branch's
+    privileges, and `cache: false` is what stops that code persisting bytes into
+    later workflows. Routed through the composite the value reaches the Action
+    as `${{ inputs.cache }}`, which no static analysis can resolve, and CodeQL's
+    `actions/cache-poisoning/poisonable-step` query then reports all three jobs
+    as poisonable. A trust boundary has to be legible to a reader and to a
+    scanner. The gate never demands `cache: true`.
+  - There is no allow-list. The one file permitted to name `actions/setup-go`
+    unconditionally is permitted by identity — it is the wrapper's own
+    `action.yml`, the definition site, which cannot be a call site of itself.
   - Env: `WORKFLOW_DIR` / `ACTIONS_DIR` / `REPO_ROOT` (all optional).
   - Exit: `0` when every rule holds, `1` on a violation or when NO call site
     uses the wrapper at all.
-  - Gated by `assert-go-setup-hardened.test.mjs`, which reverts one call site in
-    the real workflow text, deletes the warm step, and makes it conditional, and
-    asserts each goes red.
+  - Gated by `assert-go-setup-hardened.test.mjs`, which reverts a call site in
+    the real workflow text, templates a `cache:` value, strips a warm step, and
+    makes the wrapper's warm step conditional, and asserts each goes red.
 - **`mirror-images.mjs`** — `mirror-images.yml` (daily cron, `workflow_dispatch`,
   and pushes to the mirror's own files). Copies every ref in `lib/mirror.mjs`'s
   inventory into cerberus's GHCR namespace with `docker buildx imagetools

--- a/.github/scripts/README.md
+++ b/.github/scripts/README.md
@@ -62,6 +62,19 @@ and `chart-kubeconform.mjs`'s image probe apply the same classification to
 commands rather than to a single ref. Everything hits the same quota bucket and
 fails the same way, so nothing re-derives the policy.
 
+`go-module-fetch.mjs` applies the same three-class classification one registry
+over, to the **Go module proxy**. `lib/registry.mjs`'s transport list already
+carried the Go-proxy signatures (`http2: stream error`, `INTERNAL_ERROR;
+received from peer`, a `proxy.golang.org`-scoped 403), because a `go mod
+download` inside a build stage fails exactly like a manifest fetch — so the Go
+path imports that policy rather than growing a second one. What it adds is the
+class registry.mjs has no analogue for: a **never-retryable** module answer —
+`SECURITY ERROR` / checksum mismatch, `404` / `410` / `unknown revision` /
+`invalid version` / `no matching versions`, `missing go.sum entry` — asked
+FIRST and winning outright, on the same reasoning that makes a rate limit win
+there. Retrying a checksum refusal is how a poisoned module eventually gets
+accepted.
+
 The pre-pull fetches with `docker pull`, never `docker compose pull`: the two
 paths do not share a credential source. Measured four seconds apart in one job,
 the CLI pull carried the runner's Docker Hub login while compose's was refused
@@ -2175,6 +2188,56 @@ what actually runs.
   - Gated by `assert-image-jobs-authenticate.test.mjs`, which strips a login
     step out of the real workflow text and asserts each rule goes red. A gate
     that cannot fail is a gap, not coverage.
+- **`go-module-fetch.mjs`** — the warm step inside `./.github/actions/setup-go`,
+  and `mutation.yml`'s `go install` of the gremlins fork. Runs ONE fetch-only Go
+  command under `lib/registry.mjs`'s retry policy, because the Go module
+  resolver does not retry past a dropped HTTP/2 frame: a single `INTERNAL_ERROR;
+  received from peer` in a ~340-module download stream kills the job (runs
+  33080257221 / 33084966918 / 33093118010).
+  - A bare invocation runs `go mod download` in the working directory. For a
+    `go 1.17`-or-later module that is exactly go.mod's explicit requirements,
+    `// indirect` entries included — verified to cover the three modules whose
+    fetch actually failed — so `all`, which adds the test dependencies OF
+    dependencies, buys nothing.
+  - It cannot mask a real failure, and each layer is asserted on the ATTEMPT
+    COUNT rather than the exit code. (a) `isFetchOnly()` refuses anything but
+    `go mod download` / `go install`, so `go test`, `go list`, `go build`,
+    `just` and `gremlins unleash` are unwrappable by construction and still fail
+    on attempt 1. (b) A retry requires an `isTransientRegistryFailure()` match,
+    which a Go compile error never gets. (c) The never-retry set above is asked
+    first and wins even when the output also names a transport fault.
+  - Args: nothing, or `-- <command>` to wrap an explicit fetch.
+  - Env: `GO_FETCH_BACKOFF_STEP_SECONDS` (optional; default `3`).
+  - Exit: the wrapped command's status; `1` when handed a command that is not
+    fetch-only.
+  - Gated by `go-module-fetch.test.mjs`, whose positive fixtures are the
+    verbatim stderr of the runs above.
+- **`assert-go-setup-hardened.mjs`** — the required `check` lane. Fails when any
+  workflow step, or any composite action other than the wrapper itself, `uses:`
+  `actions/setup-go` directly. `actions/setup-go` saves its module cache keyed on
+  go.sum, only on a primary-key MISS, and without checking that there is anything
+  to save — so a Go-less job with `cache: true` can archive an EMPTY GOMODCACHE
+  on `refs/heads/main`, after which every job (and every PR ref falling back to
+  main's scope) restores nothing, declines to save, and re-downloads the whole
+  graph until the next go.sum bump. Run 32705099037 did exactly that, in 35
+  seconds, with a 7,616-byte archive.
+  - The fix is `./.github/actions/setup-go`, which warms GOMODCACHE
+    unconditionally so the post-job save can never see it empty. This gate is the
+    ratchet: it also asserts the wrapper still delegates to `actions/setup-go`,
+    still runs `go-module-fetch.mjs`, and that the warm step carries no `if:` —
+    a conditional warm leaves the hole open.
+  - It says nothing about `cache:`. `false` is load-bearing on
+    `update-golden.yml`'s three jobs, which run target-branch code and must not
+    persist bytes into later workflows; the warm step runs either way.
+  - There is no allow-list. The one file permitted to name `actions/setup-go` is
+    permitted by identity — it is the wrapper's own `action.yml`, the definition
+    site, which cannot be a call site of itself.
+  - Env: `WORKFLOW_DIR` / `ACTIONS_DIR` / `REPO_ROOT` (all optional).
+  - Exit: `0` when every rule holds, `1` on a violation or when NO call site
+    uses the wrapper at all.
+  - Gated by `assert-go-setup-hardened.test.mjs`, which reverts one call site in
+    the real workflow text, deletes the warm step, and makes it conditional, and
+    asserts each goes red.
 - **`mirror-images.mjs`** — `mirror-images.yml` (daily cron, `workflow_dispatch`,
   and pushes to the mirror's own files). Copies every ref in `lib/mirror.mjs`'s
   inventory into cerberus's GHCR namespace with `docker buildx imagetools

--- a/.github/scripts/assert-go-setup-hardened.mjs
+++ b/.github/scripts/assert-go-setup-hardened.mjs
@@ -229,6 +229,26 @@ function stepRunsWarm(stepLines) {
   return stepLines.some((l) => !isComment(l) && l.includes(warmScript));
 }
 
+// expressionsOutsideRuns — every `${{ … }}` an action manifest writes ABOVE its
+// `runs:` block, in a non-comment line.
+//
+// GitHub template-evaluates the manifest's metadata, and `inputs` is not a valid
+// named-value there. An expression written into an input's DESCRIPTION as prose
+// therefore does not render: the manifest fails to LOAD with `Unrecognized
+// named-value: 'inputs'`, and every job using the action dies before its first
+// command. Comments are excluded because `#` lines are not evaluated, which is
+// exactly where such an explanation belongs.
+export function expressionsOutsideRuns(text) {
+  const lines = text.split('\n');
+  const out = [];
+  for (let i = 0; i < lines.length; i++) {
+    if (/^runs:\s*$/.test(lines[i])) break;
+    if (isComment(lines[i])) continue;
+    if (lines[i].includes('${{')) out.push({ line: i + 1, text: lines[i].trim() });
+  }
+  return out;
+}
+
 // ---------------------------------------------------------------------------
 // The scan.
 // ---------------------------------------------------------------------------
@@ -329,7 +349,18 @@ export function scan({
         'above would be satisfied by a setup path that sets nothing up.',
     );
   } else {
-    const steps = stepBlocks(readFileSync(wrapperFile, 'utf8')).flatMap((b) => b.steps);
+    const wrapperText = readFileSync(wrapperFile, 'utf8');
+    for (const hit of expressionsOutsideRuns(wrapperText)) {
+      violations.push(
+        `${wrapperFile}:${hit.line}: a \`\${{ … }}\` expression outside \`runs:\`. GitHub ` +
+          'template-evaluates an action manifest\'s metadata — including every input DESCRIPTION — in a ' +
+          'context where `inputs` is not a valid named-value, so the expression does not render as ' +
+          'prose: it fails the manifest to LOAD, and every job using this action dies on ' +
+          '"Unrecognized named-value: \'inputs\'" before its first Go command. 26 jobs went red that ' +
+          'way. Explain the input in a `#` comment instead.',
+      );
+    }
+    const steps = stepBlocks(wrapperText).flatMap((b) => b.steps);
     if (!steps.some((s) => isUpstreamSetupGo(stepUses(s) ?? ''))) {
       violations.push(
         `${wrapperFile}: does not delegate to \`${upstreamSetupGo}\` — the wrapper installs no Go ` +

--- a/.github/scripts/assert-go-setup-hardened.mjs
+++ b/.github/scripts/assert-go-setup-hardened.mjs
@@ -90,9 +90,12 @@ const wrapperRef = './.github/actions/setup-go';
 // fails this gate instead of quietly turning R2 and R4 vacuous.
 const warmScript = 'go-module-fetch.mjs';
 
-// The one `cache:` value that takes a step out of R1's subject, spelled exactly
-// as it must appear. `false` and nothing else: a quoted or templated value is
-// not something a reader or a scanner can resolve, which is the whole point.
+// The one `cache:` value that takes a step out of R1's subject. What matters is
+// that the value is STATICALLY RESOLVABLE — a reader and CodeQL's
+// cache-poisoning query must both be able to see that this step cannot write
+// the shared cache. `cache: false` and `cache: 'false'` both qualify, because
+// withEntry strips the quotes; a `${{ … }}` expression does not, and that is
+// the shape this rule exists to reject.
 const cacheDisabled = 'false';
 
 // ---------------------------------------------------------------------------
@@ -133,13 +136,43 @@ export function isUpstreamSetupGo(ref) {
 // One block per job in a workflow and one per composite action, which is
 // exactly the scope R2 asks about: "does the SAME job also warm the cache".
 // Deriving it from the `steps:` key rather than from a job-name parse means the
-// scope is the runtime one, and a workflow shape this reader cannot follow
-// yields no block rather than a wrong one.
-export function stepBlocks(text) {
+// scope is the runtime one.
+//
+// A `steps:` line this reader cannot follow is a HARD ERROR, never a skip.
+// Skipping is what made this gate hollow: `steps:` used to be matched as
+// `/^\s*steps:\s*$/`, so `steps: &dashboard_shard_steps` (e2e.yml) matched
+// nothing and BOTH dashboard-shard jobs — including their
+// `uses: ./.github/actions/setup-go` — went unscanned on a job that runs on
+// refs/heads/main. The gate reported "none able to archive an empty module
+// cache" while being structurally unable to see one of the call sites it
+// exists to police. A scanner that silently ignores what it cannot parse
+// reports clean for the wrong reason, so unparsed shapes now fail loudly.
+const stepsKey = /^\s*steps:\s*(?<tail>\S.*)?$/;
+// A YAML anchor declares the block here; the body follows and is scanned
+// normally. An alias re-uses that same body, so the anchor's own scan already
+// covers it and re-scanning would double-count every call site inside it.
+const stepsAnchor = /^&[A-Za-z0-9_-]+$/;
+const stepsAlias = /^\*[A-Za-z0-9_-]+$/;
+
+export function stepBlocks(text, file = '<text>') {
   const lines = text.split('\n');
   const blocks = [];
   for (let i = 0; i < lines.length; i++) {
-    if (isBlank(lines[i]) || !/^\s*steps:\s*$/.test(lines[i])) continue;
+    if (isBlank(lines[i])) continue;
+    const key = stepsKey.exec(lines[i]);
+    if (!key) continue;
+    const tail = (key.groups.tail || '').replace(/\s+#.*$/, '').trim();
+    if (tail) {
+      if (stepsAlias.test(tail)) continue;
+      if (!stepsAnchor.test(tail)) {
+        throw new Error(
+          `${file}:${i + 1}: cannot follow \`${lines[i].trim()}\` — this scanner understands ` +
+            '`steps:`, `steps: &anchor` and `steps: *alias` only. Teach it this shape rather ' +
+            'than letting the block go unscanned; an unreadable steps block is how a call site ' +
+            'hides from the gate.',
+        );
+      }
+    }
 
     const base = indentOf(lines[i]);
     const body = [];
@@ -294,7 +327,7 @@ export function scan({
   for (const file of yamlFilesIn(abs(workflowDir))) {
     scanned++;
     const text = readFileSync(file, 'utf8');
-    for (const block of stepBlocks(text)) {
+    for (const block of stepBlocks(text, file)) {
       const warms = block.steps.some(stepRunsWarm);
       for (const step of block.steps) {
         const ref = stepUses(step);
@@ -327,7 +360,7 @@ export function scan({
   for (const file of actionFilesIn(abs(actionsDir))) {
     scanned++;
     const text = readFileSync(file, 'utf8');
-    for (const block of stepBlocks(text)) {
+    for (const block of stepBlocks(text, file)) {
       for (const step of block.steps) {
         const ref = stepUses(step);
         if (ref === wrapperRef) wrapperCallSites++;

--- a/.github/scripts/assert-go-setup-hardened.mjs
+++ b/.github/scripts/assert-go-setup-hardened.mjs
@@ -1,0 +1,283 @@
+// assert-go-setup-hardened — every job that sets up Go must do it through
+// `./.github/actions/setup-go`, never through `actions/setup-go` directly.
+//
+// WHY THIS EXISTS. `actions/setup-go` saves its module cache keyed on go.sum,
+// only on a primary-key MISS, and without ever checking that there is anything
+// to save. A job that sets it up with `cache: true` and runs no Go command
+// therefore archives an EMPTY GOMODCACHE, and if it wins that race on
+// `refs/heads/main` after a go.sum bump, every later job — on main and on every
+// PR ref falling back to main's cache scope — restores nothing and then
+// declines to save, because from then on the key hits. Run 32705099037 did
+// exactly that: `Cache folder path is retrieved but doesn't exist on disk`
+// followed by `Cache saved with the key: setup-go-…-29abba13…`, a 7,616-byte
+// archive that made 51 call sites run cold until the next go.sum change.
+//
+// The composite action fixes that by construction — it always warms GOMODCACHE
+// before the post-job save can look at it. This gate is what keeps the fix from
+// decaying: the cheapest way to add a new Go job is to copy an
+// `actions/setup-go@v7` block out of some other repo, and that one step
+// silently re-arms the whole failure. "Does this workflow set Go up through the
+// hardened path" is a question about the shape of a workflow, so a gate can
+// answer it, and a question a gate can answer should not have to be
+// rediscovered from a poisoned cache.
+//
+// WHAT IT ASSERTS.
+//
+//   R1  No workflow step, and no composite action other than the wrapper
+//       itself, `uses:` `actions/setup-go` directly.
+//   R2  The wrapper exists and does delegate to `actions/setup-go` — otherwise
+//       R1 is satisfiable by an action that sets up nothing.
+//   R3  The wrapper's warm step runs `go-module-fetch.mjs` and carries no
+//       `if:`. An `if:` on that step is precisely the hole this closes: a
+//       conditional warm is a job that can still reach the post-save with an
+//       empty GOMODCACHE.
+//   R4  At least one workflow step actually uses the wrapper. A gate that
+//       passes because nothing sets Go up at all reports the same green as a
+//       gate that is satisfied.
+//
+// THERE IS NO ALLOW-LIST. The single file permitted to name `actions/setup-go`
+// is permitted by IDENTITY, not by name: it is the wrapper's own action.yml —
+// the definition site of the thing the rule is about, which cannot be a call
+// site of itself. That is the same structural distinction
+// `assert-image-jobs-authenticate.mjs` draws between declaring
+// `pullImageWithRetry` and calling it. Anything else that ever has to be
+// excluded must be excluded by a fact of that kind and not by a list of names.
+//
+// The gate deliberately says NOTHING about the `cache:` input. `false` is a
+// legitimate, load-bearing choice — update-golden.yml's three jobs run
+// target-branch code and must not persist bytes into later workflows — and the
+// warm step runs either way, so the poisoning this prevents is unrelated to the
+// value. Forcing `cache: true` would break that isolation for no gain.
+//
+// ENV CONTRACT
+//   REPO_ROOT     — repository root. Default `process.cwd()`.
+//   WORKFLOW_DIR  — workflows to scan. Default `.github/workflows`.
+//   ACTIONS_DIR   — composite actions to scan. Default `.github/actions`.
+//
+// Exit: 0 when every rule holds, 1 on any violation.
+
+import { existsSync, readFileSync, readdirSync, statSync } from 'node:fs';
+import { isAbsolute, join } from 'node:path';
+import process from 'node:process';
+import { pathToFileURL } from 'node:url';
+
+import { error, log, notice } from './lib/gh.mjs';
+
+// The Action this repo must never name directly, and the local wrapper that is
+// the one sanctioned way to reach it.
+const upstreamSetupGo = 'actions/setup-go';
+const wrapperDir = '.github/actions/setup-go';
+const wrapperRef = './.github/actions/setup-go';
+
+// The module the warm step has to run. Named rather than described, so a rename
+// fails this gate instead of quietly turning R3 vacuous.
+const warmScript = 'go-module-fetch.mjs';
+
+// ---------------------------------------------------------------------------
+// The narrow slice of YAML these files use. Only `node:` builtins are available
+// (see the repo rule on CI scripts), so structure is read by indentation.
+// ---------------------------------------------------------------------------
+
+const indentOf = (line) => line.length - line.trimStart().length;
+const isComment = (line) => line.trimStart().startsWith('#');
+const isBlank = (line) => line.trim() === '' || isComment(line);
+
+function unquote(value) {
+  const t = value.trim();
+  if ((t.startsWith('"') && t.endsWith('"')) || (t.startsWith("'") && t.endsWith("'"))) {
+    return t.slice(1, -1);
+  }
+  return t;
+}
+
+// usesValue — the Action a line references, or null when the line is not a
+// `uses:` key. Comment lines are excluded before matching, which is what keeps
+// compatibility.yml's header — a prose inventory of the Actions it runs — from
+// reading as a call site.
+export function usesValue(line) {
+  if (isComment(line)) return null;
+  const m = /^\s*(?:-\s+)?uses:\s*(\S.*?)\s*$/.exec(line);
+  if (m === null) return null;
+  // A trailing `  # v2.86.5` version comment is common on pinned SHAs.
+  return unquote(m[1].replace(/\s+#.*$/, ''));
+}
+
+// directSetupGoUses — every line in `text` that references the upstream Action.
+// Matched on the reference itself rather than anywhere in the line, so a
+// workflow that MENTIONS the name in a step title stays clean.
+export function directSetupGoUses(text) {
+  const out = [];
+  text.split('\n').forEach((line, i) => {
+    const ref = usesValue(line);
+    if (ref === null) return;
+    if (ref === upstreamSetupGo || ref.startsWith(`${upstreamSetupGo}@`)) {
+      out.push({ line: i + 1, ref });
+    }
+  });
+  return out;
+}
+
+export function wrapperUses(text) {
+  return text.split('\n').filter((line) => usesValue(line) === wrapperRef).length;
+}
+
+// compositeSteps — the `runs.steps:` items of a composite action, each as a
+// line array with the leading `- ` blanked so its keys form a plain mapping.
+export function compositeSteps(text) {
+  const lines = text.split('\n');
+  let stepsAt = -1;
+  for (let i = 0; i < lines.length; i++) {
+    if (!isBlank(lines[i]) && /^\s*steps:\s*$/.test(lines[i])) {
+      stepsAt = i;
+      break;
+    }
+  }
+  if (stepsAt === -1) return [];
+
+  const base = indentOf(lines[stepsAt]);
+  const block = [];
+  for (let i = stepsAt + 1; i < lines.length; i++) {
+    if (isBlank(lines[i])) {
+      block.push(lines[i]);
+      continue;
+    }
+    if (indentOf(lines[i]) <= base) break;
+    block.push(lines[i]);
+  }
+
+  const itemIndent = Math.min(...block.filter((l) => !isBlank(l)).map(indentOf));
+  const steps = [];
+  let current = null;
+  for (const line of block) {
+    if (!isBlank(line) && indentOf(line) === itemIndent && /^\s*-\s/.test(line)) {
+      if (current) steps.push(current);
+      current = [line.replace(/^(\s*)-(\s)/, '$1 $2')];
+      continue;
+    }
+    if (current) current.push(line);
+  }
+  if (current) steps.push(current);
+  return steps;
+}
+
+// hasKeyAtStepLevel — does this step declare `key:` as one of its own keys?
+// Used for `if:`, which must be absent from the warm step.
+function hasKeyAtStepLevel(stepLines, key) {
+  const keyIndent = Math.min(...stepLines.filter((l) => !isBlank(l)).map(indentOf));
+  return stepLines.some((l) => !isBlank(l) && indentOf(l) === keyIndent && new RegExp(`^\\s*${key}:(\\s|$)`).test(l));
+}
+
+// ---------------------------------------------------------------------------
+// The scan.
+// ---------------------------------------------------------------------------
+
+function yamlFilesIn(dir) {
+  if (!existsSync(dir)) return [];
+  return readdirSync(dir)
+    .sort()
+    .filter((f) => /\.ya?ml$/.test(f))
+    .map((f) => join(dir, f));
+}
+
+function actionFilesIn(dir) {
+  if (!existsSync(dir)) return [];
+  const out = [];
+  for (const entry of readdirSync(dir).sort()) {
+    const full = join(dir, entry);
+    if (!statSync(full).isDirectory()) continue;
+    for (const name of ['action.yml', 'action.yaml']) {
+      if (existsSync(join(full, name))) out.push(join(full, name));
+    }
+  }
+  return out;
+}
+
+export function scan({
+  root = process.cwd(),
+  workflowDir = '.github/workflows',
+  actionsDir = '.github/actions',
+  wrapperPath = wrapperDir,
+} = {}) {
+  const abs = (p) => (isAbsolute(p) ? p : join(root, p));
+  const violations = [];
+  let wrapperCallSites = 0;
+  let scanned = 0;
+
+  const wrapperFile = ['action.yml', 'action.yaml']
+    .map((n) => join(abs(wrapperPath), n))
+    .find((p) => existsSync(p));
+
+  // R1 — nothing but the wrapper names the upstream Action.
+  for (const file of [...yamlFilesIn(abs(workflowDir)), ...actionFilesIn(abs(actionsDir))]) {
+    scanned++;
+    const text = readFileSync(file, 'utf8');
+    wrapperCallSites += wrapperUses(text);
+    // The definition site cannot be a call site of itself.
+    if (wrapperFile !== undefined && file === wrapperFile) continue;
+    for (const hit of directSetupGoUses(text)) {
+      violations.push(
+        `${file}:${hit.line}: uses \`${hit.ref}\` directly. Go setup must go through ` +
+          `\`${wrapperRef}\`, which warms GOMODCACHE before setup-go's post-job step can archive an ` +
+          'empty one — the failure that made every Go job in the repo run cold until the next go.sum ' +
+          'bump. Pass `cache: false` to the wrapper if this job must stay off the shared cache.',
+      );
+    }
+  }
+
+  // R2 / R3 — the wrapper is the real thing, and its warm step is unconditional.
+  if (wrapperFile === undefined) {
+    violations.push(
+      `${wrapperPath}/action.yml does not exist — every call site would resolve to nothing, so R1 ` +
+        'would be satisfied by a setup path that sets nothing up.',
+    );
+  } else {
+    const text = readFileSync(wrapperFile, 'utf8');
+    if (directSetupGoUses(text).length === 0) {
+      violations.push(
+        `${wrapperFile}: does not delegate to \`${upstreamSetupGo}\` — the wrapper installs no Go ` +
+          'toolchain, so every caller would be silently Go-less.',
+      );
+    }
+    const warmSteps = compositeSteps(text).filter((step) => step.some((l) => !isComment(l) && l.includes(warmScript)));
+    if (warmSteps.length === 0) {
+      violations.push(
+        `${wrapperFile}: runs no \`${warmScript}\` step. Without it GOMODCACHE can still be empty when ` +
+          'setup-go archives it, which is the whole failure this path exists to make impossible.',
+      );
+    }
+    for (const step of warmSteps) {
+      if (hasKeyAtStepLevel(step, 'if')) {
+        violations.push(
+          `${wrapperFile}: the \`${warmScript}\` step carries an \`if:\`. A conditional warm leaves a ` +
+            'path on which a job reaches the post-job cache save with an empty GOMODCACHE — exactly ' +
+            'the hole the composite exists to close.',
+        );
+      }
+    }
+  }
+
+  // R4 — non-vacuity.
+  if (wrapperCallSites === 0) {
+    violations.push(
+      `no workflow or action uses \`${wrapperRef}\` at all — this gate is passing because nothing sets ` +
+        'Go up, which is the same green a satisfied gate reports.',
+    );
+  }
+
+  return { violations, wrapperCallSites, scanned };
+}
+
+function main() {
+  const root = process.env.REPO_ROOT || process.cwd();
+  const workflowDir = process.env.WORKFLOW_DIR || '.github/workflows';
+  const actionsDir = process.env.ACTIONS_DIR || '.github/actions';
+  const { violations, wrapperCallSites, scanned } = scan({ root, workflowDir, actionsDir });
+
+  log(`scanned ${scanned} workflow/action files; ${wrapperCallSites} steps set Go up through ${wrapperRef}`);
+  for (const v of violations) error(v);
+  if (violations.length > 0) process.exit(1);
+  notice(`${wrapperCallSites} Go setup call sites, all on the warming ${wrapperRef} path`);
+  process.exit(0);
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) main();

--- a/.github/scripts/assert-go-setup-hardened.mjs
+++ b/.github/scripts/assert-go-setup-hardened.mjs
@@ -1,10 +1,10 @@
-// assert-go-setup-hardened — every job that sets up Go must do it through
-// `./.github/actions/setup-go`, never through `actions/setup-go` directly.
+// assert-go-setup-hardened — no job may reach the point where setup-go's
+// post-job step archives the module cache with an EMPTY GOMODCACHE.
 //
 // WHY THIS EXISTS. `actions/setup-go` saves its module cache keyed on go.sum,
 // only on a primary-key MISS, and without ever checking that there is anything
 // to save. A job that sets it up with `cache: true` and runs no Go command
-// therefore archives an EMPTY GOMODCACHE, and if it wins that race on
+// therefore archives an empty GOMODCACHE, and if it wins that race on
 // `refs/heads/main` after a go.sum bump, every later job — on main and on every
 // PR ref falling back to main's cache scope — restores nothing and then
 // declines to save, because from then on the key hits. Run 32705099037 did
@@ -12,9 +12,9 @@
 // followed by `Cache saved with the key: setup-go-…-29abba13…`, a 7,616-byte
 // archive that made 51 call sites run cold until the next go.sum change.
 //
-// The composite action fixes that by construction — it always warms GOMODCACHE
-// before the post-job save can look at it. This gate is what keeps the fix from
-// decaying: the cheapest way to add a new Go job is to copy an
+// `./.github/actions/setup-go` fixes it by construction — it always warms
+// GOMODCACHE before the post-job save can look at it. This gate is what keeps
+// the fix from decaying: the cheapest way to add a new Go job is to copy an
 // `actions/setup-go@v7` block out of some other repo, and that one step
 // silently re-arms the whole failure. "Does this workflow set Go up through the
 // hardened path" is a question about the shape of a workflow, so a gate can
@@ -23,31 +23,48 @@
 //
 // WHAT IT ASSERTS.
 //
-//   R1  No workflow step, and no composite action other than the wrapper
-//       itself, `uses:` `actions/setup-go` directly.
-//   R2  The wrapper exists and does delegate to `actions/setup-go` — otherwise
-//       R1 is satisfiable by an action that sets up nothing.
-//   R3  The wrapper's warm step runs `go-module-fetch.mjs` and carries no
-//       `if:`. An `if:` on that step is precisely the hole this closes: a
-//       conditional warm is a job that can still reach the post-save with an
-//       empty GOMODCACHE.
-//   R4  At least one workflow step actually uses the wrapper. A gate that
+//   R1  A workflow step reaching `actions/setup-go` directly must set
+//       `cache: false` as a LITERAL in its own `with:`. The rule is keyed on
+//       the MECHANISM, not on the Action's name: a step that never saves the
+//       shared cache cannot poison it, so it is outside this rule's subject
+//       rather than exempted from it. Everything that CAN write that cache
+//       goes through the composite, where the warm step is unconditional.
+//   R2  A job holding such a step must also run `go-module-fetch.mjs`. Opting
+//       out of the shared cache is not opting out of fetching modules, and
+//       that fetch is the one the Go resolver will not retry.
+//   R3  No composite action other than the wrapper uses `actions/setup-go` at
+//       all. R1's escape has no meaning there: a composite has no job scope in
+//       which R2 could be satisfied, and it is reached from arbitrary callers.
+//   R4  The wrapper exists, delegates to `actions/setup-go`, runs
+//       `go-module-fetch.mjs`, and that warm step carries no `if:`. A
+//       conditional warm leaves a path on which a job reaches the post-job save
+//       with an empty GOMODCACHE, which is the hole the composite closes.
+//   R5  At least one workflow step actually uses the wrapper. A gate that
 //       passes because nothing sets Go up at all reports the same green as a
 //       gate that is satisfied.
 //
+// WHY R1 IS A LITERAL AND NOT AN INPUT. `update-golden.yml`'s three
+// regenerating jobs check out TARGET-BRANCH code under the default branch's
+// privileges, and `cache: false` is what keeps that code from persisting bytes
+// into later workflows. Routed through the composite the value reaches the
+// Action as `${{ inputs.cache }}`, which no static analysis can resolve — and
+// CodeQL's `actions/cache-poisoning/poisonable-step` query then reports this
+// repository's most privileged workflow as poisonable in all three jobs. A
+// trust boundary has to be legible to a reader and to a scanner, so those three
+// spell the value out and pair it with their own warm step, which is exactly
+// what R1 and R2 together require.
+//
 // THERE IS NO ALLOW-LIST. The single file permitted to name `actions/setup-go`
-// is permitted by IDENTITY, not by name: it is the wrapper's own action.yml —
-// the definition site of the thing the rule is about, which cannot be a call
-// site of itself. That is the same structural distinction
+// unconditionally is permitted by IDENTITY, not by name: it is the wrapper's
+// own action.yml — the definition site of the thing the rule is about, which
+// cannot be a call site of itself. That is the same structural distinction
 // `assert-image-jobs-authenticate.mjs` draws between declaring
 // `pullImageWithRetry` and calling it. Anything else that ever has to be
 // excluded must be excluded by a fact of that kind and not by a list of names.
 //
-// The gate deliberately says NOTHING about the `cache:` input. `false` is a
-// legitimate, load-bearing choice — update-golden.yml's three jobs run
-// target-branch code and must not persist bytes into later workflows — and the
-// warm step runs either way, so the poisoning this prevents is unrelated to the
-// value. Forcing `cache: true` would break that isolation for no gain.
+// The gate never demands `cache: true`. Forcing it would break update-golden's
+// read-only isolation for no gain, because the warm step — not the cache — is
+// what makes an empty archive impossible.
 //
 // ENV CONTRACT
 //   REPO_ROOT     — repository root. Default `process.cwd()`.
@@ -57,21 +74,26 @@
 // Exit: 0 when every rule holds, 1 on any violation.
 
 import { existsSync, readFileSync, readdirSync, statSync } from 'node:fs';
-import { isAbsolute, join } from 'node:path';
+import { basename, isAbsolute, join } from 'node:path';
 import process from 'node:process';
 import { pathToFileURL } from 'node:url';
 
 import { error, log, notice } from './lib/gh.mjs';
 
-// The Action this repo must never name directly, and the local wrapper that is
-// the one sanctioned way to reach it.
+// The Action this repo may only reach under R1's conditions, and the local
+// wrapper that is the sanctioned way to reach it otherwise.
 const upstreamSetupGo = 'actions/setup-go';
 const wrapperDir = '.github/actions/setup-go';
 const wrapperRef = './.github/actions/setup-go';
 
 // The module the warm step has to run. Named rather than described, so a rename
-// fails this gate instead of quietly turning R3 vacuous.
+// fails this gate instead of quietly turning R2 and R4 vacuous.
 const warmScript = 'go-module-fetch.mjs';
+
+// The one `cache:` value that takes a step out of R1's subject, spelled exactly
+// as it must appear. `false` and nothing else: a quoted or templated value is
+// not something a reader or a scanner can resolve, which is the whole point.
+const cacheDisabled = 'false';
 
 // ---------------------------------------------------------------------------
 // The narrow slice of YAML these files use. Only `node:` builtins are available
@@ -102,53 +124,58 @@ export function usesValue(line) {
   return unquote(m[1].replace(/\s+#.*$/, ''));
 }
 
-// directSetupGoUses — every line in `text` that references the upstream Action.
-// Matched on the reference itself rather than anywhere in the line, so a
-// workflow that MENTIONS the name in a step title stays clean.
-export function directSetupGoUses(text) {
-  const out = [];
-  text.split('\n').forEach((line, i) => {
-    const ref = usesValue(line);
-    if (ref === null) return;
-    if (ref === upstreamSetupGo || ref.startsWith(`${upstreamSetupGo}@`)) {
-      out.push({ line: i + 1, ref });
-    }
-  });
-  return out;
+export function isUpstreamSetupGo(ref) {
+  return ref === upstreamSetupGo || String(ref).startsWith(`${upstreamSetupGo}@`);
 }
 
-export function wrapperUses(text) {
-  return text.split('\n').filter((line) => usesValue(line) === wrapperRef).length;
-}
-
-// compositeSteps — the `runs.steps:` items of a composite action, each as a
-// line array with the leading `- ` blanked so its keys form a plain mapping.
-export function compositeSteps(text) {
+// stepBlocks — every `steps:` sequence in a file, split into its steps.
+//
+// One block per job in a workflow and one per composite action, which is
+// exactly the scope R2 asks about: "does the SAME job also warm the cache".
+// Deriving it from the `steps:` key rather than from a job-name parse means the
+// scope is the runtime one, and a workflow shape this reader cannot follow
+// yields no block rather than a wrong one.
+export function stepBlocks(text) {
   const lines = text.split('\n');
-  let stepsAt = -1;
+  const blocks = [];
   for (let i = 0; i < lines.length; i++) {
-    if (!isBlank(lines[i]) && /^\s*steps:\s*$/.test(lines[i])) {
-      stepsAt = i;
-      break;
-    }
-  }
-  if (stepsAt === -1) return [];
+    if (isBlank(lines[i]) || !/^\s*steps:\s*$/.test(lines[i])) continue;
 
-  const base = indentOf(lines[stepsAt]);
-  const block = [];
-  for (let i = stepsAt + 1; i < lines.length; i++) {
-    if (isBlank(lines[i])) {
-      block.push(lines[i]);
-      continue;
+    const base = indentOf(lines[i]);
+    const body = [];
+    for (let j = i + 1; j < lines.length; j++) {
+      if (isBlank(lines[j])) {
+        body.push(lines[j]);
+        continue;
+      }
+      if (indentOf(lines[j]) <= base) break;
+      body.push(lines[j]);
     }
-    if (indentOf(lines[i]) <= base) break;
-    block.push(lines[i]);
+    blocks.push({ label: enclosingKey(lines, i, base), steps: splitSteps(body) });
   }
+  return blocks;
+}
 
-  const itemIndent = Math.min(...block.filter((l) => !isBlank(l)).map(indentOf));
+// enclosingKey — the nearest preceding mapping key at a shallower indent, used
+// only to name the job in an error message.
+function enclosingKey(lines, at, indent) {
+  for (let i = at - 1; i >= 0; i--) {
+    if (isBlank(lines[i]) || indentOf(lines[i]) >= indent) continue;
+    const m = /^\s*([A-Za-z0-9_-]+):\s*$/.exec(lines[i]);
+    if (m) return m[1];
+  }
+  return 'steps';
+}
+
+// splitSteps — a `steps:` body into one line-array per step, with the leading
+// `- ` blanked so each step's keys form a plain mapping.
+function splitSteps(body) {
+  const present = body.filter((l) => !isBlank(l));
+  if (present.length === 0) return [];
+  const itemIndent = Math.min(...present.map(indentOf));
   const steps = [];
   let current = null;
-  for (const line of block) {
+  for (const line of body) {
     if (!isBlank(line) && indentOf(line) === itemIndent && /^\s*-\s/.test(line)) {
       if (current) steps.push(current);
       current = [line.replace(/^(\s*)-(\s)/, '$1 $2')];
@@ -160,11 +187,46 @@ export function compositeSteps(text) {
   return steps;
 }
 
-// hasKeyAtStepLevel — does this step declare `key:` as one of its own keys?
-// Used for `if:`, which must be absent from the warm step.
-function hasKeyAtStepLevel(stepLines, key) {
-  const keyIndent = Math.min(...stepLines.filter((l) => !isBlank(l)).map(indentOf));
-  return stepLines.some((l) => !isBlank(l) && indentOf(l) === keyIndent && new RegExp(`^\\s*${key}:(\\s|$)`).test(l));
+function stepIndent(stepLines) {
+  const present = stepLines.filter((l) => !isBlank(l));
+  return present.length === 0 ? 0 : Math.min(...present.map(indentOf));
+}
+
+// hasKeyAtStepLevel — does this step declare `key:` as one of its OWN keys?
+export function hasKeyAtStepLevel(stepLines, key) {
+  const indent = stepIndent(stepLines);
+  const re = new RegExp(`^\\s*${key}:(\\s|$)`);
+  return stepLines.some((l) => !isBlank(l) && indentOf(l) === indent && re.test(l));
+}
+
+// withEntry — the literal value a step passes for one `with:` input, or null
+// when the step does not set it or sets it to something non-literal.
+export function withEntry(stepLines, name) {
+  const indent = stepIndent(stepLines);
+  let inWith = false;
+  for (const line of stepLines) {
+    if (isBlank(line)) continue;
+    if (indentOf(line) === indent) {
+      inWith = /^\s*with:\s*$/.test(line);
+      continue;
+    }
+    if (!inWith) continue;
+    const m = new RegExp(`^\\s*${name}:\\s*(.*)$`).exec(line);
+    if (m) return unquote(m[1].replace(/\s+#.*$/, ''));
+  }
+  return null;
+}
+
+export function stepUses(stepLines) {
+  for (const line of stepLines) {
+    const ref = usesValue(line);
+    if (ref !== null && indentOf(line) === stepIndent(stepLines)) return ref;
+  }
+  return null;
+}
+
+function stepRunsWarm(stepLines) {
+  return stepLines.some((l) => !isComment(l) && l.includes(warmScript));
 }
 
 // ---------------------------------------------------------------------------
@@ -201,44 +263,80 @@ export function scan({
   const abs = (p) => (isAbsolute(p) ? p : join(root, p));
   const violations = [];
   let wrapperCallSites = 0;
+  let directCallSites = 0;
   let scanned = 0;
 
   const wrapperFile = ['action.yml', 'action.yaml']
     .map((n) => join(abs(wrapperPath), n))
     .find((p) => existsSync(p));
 
-  // R1 — nothing but the wrapper names the upstream Action.
-  for (const file of [...yamlFilesIn(abs(workflowDir)), ...actionFilesIn(abs(actionsDir))]) {
+  // R1 / R2 — the workflows.
+  for (const file of yamlFilesIn(abs(workflowDir))) {
     scanned++;
     const text = readFileSync(file, 'utf8');
-    wrapperCallSites += wrapperUses(text);
-    // The definition site cannot be a call site of itself.
-    if (wrapperFile !== undefined && file === wrapperFile) continue;
-    for (const hit of directSetupGoUses(text)) {
-      violations.push(
-        `${file}:${hit.line}: uses \`${hit.ref}\` directly. Go setup must go through ` +
-          `\`${wrapperRef}\`, which warms GOMODCACHE before setup-go's post-job step can archive an ` +
-          'empty one — the failure that made every Go job in the repo run cold until the next go.sum ' +
-          'bump. Pass `cache: false` to the wrapper if this job must stay off the shared cache.',
-      );
+    for (const block of stepBlocks(text)) {
+      const warms = block.steps.some(stepRunsWarm);
+      for (const step of block.steps) {
+        const ref = stepUses(step);
+        if (ref === wrapperRef) wrapperCallSites++;
+        if (ref === null || !isUpstreamSetupGo(ref)) continue;
+        directCallSites++;
+
+        const cache = withEntry(step, 'cache');
+        if (cache !== cacheDisabled) {
+          violations.push(
+            `${basename(file)}:${block.label}: uses \`${ref}\` with \`cache: ${cache ?? '(unset)'}\`. A ` +
+              `step that can SAVE the shared module cache must go through \`${wrapperRef}\`, which warms ` +
+              'GOMODCACHE before the post-job step can archive an empty one — the failure that made every ' +
+              'Go job in the repo run cold until the next go.sum bump. Only a literal `cache: false`, which ' +
+              'saves nothing and so cannot poison anything, may reach the Action directly.',
+          );
+        } else if (!warms) {
+          violations.push(
+            `${basename(file)}:${block.label}: opts out of the shared cache but never runs ` +
+              `\`${warmScript}\`. Skipping the cache is not skipping the FETCH, and that fetch is the one ` +
+              'the Go module resolver will not retry past a dropped HTTP/2 frame. Add the warm step to ' +
+              'this job.',
+          );
+        }
+      }
     }
   }
 
-  // R2 / R3 — the wrapper is the real thing, and its warm step is unconditional.
+  // R3 — no other composite action may reach the Action at all.
+  for (const file of actionFilesIn(abs(actionsDir))) {
+    scanned++;
+    const text = readFileSync(file, 'utf8');
+    for (const block of stepBlocks(text)) {
+      for (const step of block.steps) {
+        const ref = stepUses(step);
+        if (ref === wrapperRef) wrapperCallSites++;
+        if (ref === null || !isUpstreamSetupGo(ref)) continue;
+        // The definition site cannot be a call site of itself.
+        if (wrapperFile !== undefined && file === wrapperFile) continue;
+        violations.push(
+          `${file}: uses \`${ref}\`. A composite action has no job scope in which the warm step could be ` +
+            `required, and it is reached from arbitrary callers, so it must use \`${wrapperRef}\` instead.`,
+        );
+      }
+    }
+  }
+
+  // R4 — the wrapper is the real thing, and its warm step is unconditional.
   if (wrapperFile === undefined) {
     violations.push(
-      `${wrapperPath}/action.yml does not exist — every call site would resolve to nothing, so R1 ` +
-        'would be satisfied by a setup path that sets nothing up.',
+      `${wrapperPath}/action.yml does not exist — every call site would resolve to nothing, so the rules ` +
+        'above would be satisfied by a setup path that sets nothing up.',
     );
   } else {
-    const text = readFileSync(wrapperFile, 'utf8');
-    if (directSetupGoUses(text).length === 0) {
+    const steps = stepBlocks(readFileSync(wrapperFile, 'utf8')).flatMap((b) => b.steps);
+    if (!steps.some((s) => isUpstreamSetupGo(stepUses(s) ?? ''))) {
       violations.push(
         `${wrapperFile}: does not delegate to \`${upstreamSetupGo}\` — the wrapper installs no Go ` +
           'toolchain, so every caller would be silently Go-less.',
       );
     }
-    const warmSteps = compositeSteps(text).filter((step) => step.some((l) => !isComment(l) && l.includes(warmScript)));
+    const warmSteps = steps.filter(stepRunsWarm);
     if (warmSteps.length === 0) {
       violations.push(
         `${wrapperFile}: runs no \`${warmScript}\` step. Without it GOMODCACHE can still be empty when ` +
@@ -256,27 +354,30 @@ export function scan({
     }
   }
 
-  // R4 — non-vacuity.
+  // R5 — non-vacuity.
   if (wrapperCallSites === 0) {
     violations.push(
       `no workflow or action uses \`${wrapperRef}\` at all — this gate is passing because nothing sets ` +
-        'Go up, which is the same green a satisfied gate reports.',
+        'Go up through it, which is the same green a satisfied gate reports.',
     );
   }
 
-  return { violations, wrapperCallSites, scanned };
+  return { violations, wrapperCallSites, directCallSites, scanned };
 }
 
 function main() {
   const root = process.env.REPO_ROOT || process.cwd();
   const workflowDir = process.env.WORKFLOW_DIR || '.github/workflows';
   const actionsDir = process.env.ACTIONS_DIR || '.github/actions';
-  const { violations, wrapperCallSites, scanned } = scan({ root, workflowDir, actionsDir });
+  const { violations, wrapperCallSites, directCallSites, scanned } = scan({ root, workflowDir, actionsDir });
 
-  log(`scanned ${scanned} workflow/action files; ${wrapperCallSites} steps set Go up through ${wrapperRef}`);
+  log(
+    `scanned ${scanned} workflow/action files; ${wrapperCallSites} steps set Go up through ${wrapperRef}, ` +
+      `${directCallSites} reach ${upstreamSetupGo} directly under a literal \`cache: ${cacheDisabled}\``,
+  );
   for (const v of violations) error(v);
   if (violations.length > 0) process.exit(1);
-  notice(`${wrapperCallSites} Go setup call sites, all on the warming ${wrapperRef} path`);
+  notice(`${wrapperCallSites + directCallSites} Go setup call sites, none able to archive an empty module cache`);
   process.exit(0);
 }
 

--- a/.github/scripts/assert-go-setup-hardened.test.mjs
+++ b/.github/scripts/assert-go-setup-hardened.test.mjs
@@ -24,6 +24,7 @@ import { join } from 'node:path';
 import test from 'node:test';
 
 import {
+  expressionsOutsideRuns,
   hasKeyAtStepLevel,
   isUpstreamSetupGo,
   scan,
@@ -239,6 +240,31 @@ test('a warm step made conditional fails the gate', () => {
   );
   assert.equal(violations.length, 1, violations.join('\n'));
   assert.match(violations[0], /carries an `if:`/);
+});
+
+test('an expression in the wrapper metadata fails the gate', () => {
+  // Not a style rule. GitHub template-evaluates an action manifest's metadata,
+  // and `inputs` is not a valid named-value there — so a `${{ inputs.cache }}`
+  // written into an input DESCRIPTION as prose does not render, it fails the
+  // manifest to LOAD. That is not hypothetical: it took 26 jobs red on this
+  // very branch with `Unrecognized named-value: 'inputs'`, every one of them
+  // dying before its first Go command.
+  const { violations } = scanWithWrapper((t) =>
+    t.replace(
+      '      go.sum. Setting it to `false` opts a job out of the SHARED cache',
+      '      go.sum, i.e. `${{ inputs.cache }}`. Setting it to `false` opts out',
+    ),
+  );
+  assert.equal(violations.length, 1, violations.join('\n'));
+  assert.match(violations[0], /outside `runs:`/);
+
+  // And the reader itself: an expression BELOW `runs:` is the ordinary,
+  // required way to forward an input, and must never be reported.
+  assert.deepEqual(expressionsOutsideRuns(readFileSync(wrapperFile, 'utf8')), []);
+  assert.ok(
+    readFileSync(wrapperFile, 'utf8').includes('cache: ${{ inputs.cache }}'),
+    'the wrapper must still forward the input below `runs:`',
+  );
 });
 
 test('a wrapper that installs no Go toolchain fails the gate', () => {

--- a/.github/scripts/assert-go-setup-hardened.test.mjs
+++ b/.github/scripts/assert-go-setup-hardened.test.mjs
@@ -4,24 +4,34 @@
 // right reason. "The tree is clean" is not evidence on its own: it is equally
 // consistent with a scanner that never read the workflows. So each rule is
 // proved against the REAL text of this repository with exactly one thing broken
-// in it — a call site reverted to `actions/setup-go@v7`, the warm step deleted,
-// the warm step made conditional — rather than against a hand-written fixture
-// that merely resembles a workflow.
+// in it — a call site reverted to `actions/setup-go@v7`, a `cache: false` step
+// stripped of its warm step, the wrapper's warm step deleted or made
+// conditional — rather than against a hand-written fixture that merely
+// resembles a workflow.
 //
-// The one case that runs the other way is `cache: false`. update-golden.yml's
-// three jobs run target-branch code and must not persist bytes into later
-// workflows, so the value is load-bearing; a gate that forced `cache: true`
-// would break that isolation. That it stays green is asserted directly, because
-// "the gate does not overreach" is as easy to lose in an edit as "the gate
-// fires".
+// The cases that run the other way matter just as much. `update-golden.yml`'s
+// three jobs reach the Action directly, on purpose: they check out
+// target-branch code under the default branch's privileges, and a literal
+// `cache: false` is what keeps that code from persisting bytes into later
+// workflows — legibly enough for CodeQL's cache-poisoning query to agree. A
+// gate that forced them through the composite would break that boundary, so
+// "the gate does not overreach" is asserted directly, twice.
 
 import assert from 'node:assert/strict';
-import { cpSync, mkdtempSync, readFileSync, readdirSync, writeFileSync } from 'node:fs';
+import { cpSync, mkdtempSync, readFileSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import test from 'node:test';
 
-import { compositeSteps, directSetupGoUses, scan, usesValue, wrapperUses } from './assert-go-setup-hardened.mjs';
+import {
+  hasKeyAtStepLevel,
+  isUpstreamSetupGo,
+  scan,
+  stepBlocks,
+  stepUses,
+  usesValue,
+  withEntry,
+} from './assert-go-setup-hardened.mjs';
 
 const repoRoot = process.cwd();
 const workflows = join(repoRoot, '.github/workflows');
@@ -31,6 +41,9 @@ const wrapperFile = join(actions, 'setup-go/action.yml');
 // A workflow whose Go setup is unconditional and whose `with:` block was
 // dropped as default — the ordinary shape, and so the honest specimen.
 const specimenWorkflow = 'ci.yml';
+
+// The one workflow that reaches the Action directly, under R1's conditions.
+const directWorkflow = 'update-golden.yml';
 
 function realScan() {
   return scan({ root: repoRoot, workflowDir: workflows, actionsDir: actions, wrapperPath: join(actions, 'setup-go') });
@@ -66,66 +79,120 @@ function scanWithWrapper(edit) {
 // ---------------------------------------------------------------------------
 
 test('the repository as it stands passes every rule', () => {
-  const { violations, wrapperCallSites } = realScan();
+  const { violations, wrapperCallSites, directCallSites } = realScan();
   assert.deepEqual(violations, []);
-  assert.ok(wrapperCallSites > 0, 'no call site was found — the gate is not reading the workflows');
+  assert.ok(wrapperCallSites >= 45, `expected the whole fleet of call sites, saw ${wrapperCallSites}`);
+  assert.equal(directCallSites, 3, 'only update-golden.yml may reach the Action directly');
 });
 
-test('every Go setup in the tree goes through the wrapper', () => {
+test('no Go setup in the tree can archive an empty module cache', () => {
   // Counted independently of the gate's own bookkeeping, so a scanner that
   // silently stopped reading files would fail here rather than report a
   // satisfied-looking zero.
+  let cacheWriters = 0;
   let direct = 0;
-  let wrapped = 0;
-  for (const file of readdirSync(workflows).filter((f) => /\.ya?ml$/.test(f))) {
-    const text = readFileSync(join(workflows, file), 'utf8');
-    direct += directSetupGoUses(text).length;
-    wrapped += wrapperUses(text);
+  for (const file of ['ci.yml', 'chdb.yml', 'coverage.yml', 'e2e.yml', directWorkflow]) {
+    for (const block of stepBlocks(readFileSync(join(workflows, file), 'utf8'))) {
+      for (const step of block.steps) {
+        if (!isUpstreamSetupGo(stepUses(step) ?? '')) continue;
+        direct++;
+        if (withEntry(step, 'cache') !== 'false') cacheWriters++;
+      }
+    }
   }
-  assert.equal(direct, 0);
-  assert.ok(wrapped >= 50, `expected the whole fleet of call sites, saw ${wrapped}`);
-});
-
-test('`cache: false` is permitted — the gate never inspects the input', () => {
-  // update-golden.yml keeps `cache: false` on all three of its jobs. If the
-  // gate ever started demanding `true`, this is the assertion that says so
-  // before the isolation those jobs depend on is broken.
-  const text = readFileSync(join(workflows, 'update-golden.yml'), 'utf8');
-  assert.ok(/cache: false/.test(text), 'the specimen no longer carries the value under test');
-  assert.ok(wrapperUses(text) >= 3, 'update-golden should reach Go setup through the wrapper');
-
-  const { violations } = scanWithWorkflow('update-golden.yml', (t) => `${t}\n# doctored: no change of substance\n`);
-  assert.deepEqual(violations, []);
+  assert.equal(cacheWriters, 0);
+  assert.equal(direct, 3);
 });
 
 // ---------------------------------------------------------------------------
-// R1 — the direct call site.
+// R1 — a step that can SAVE the cache must go through the composite.
 // ---------------------------------------------------------------------------
 
-test('a call site reverted to actions/setup-go fails the gate', () => {
+test('a call site reverted to actions/setup-go with caching fails the gate', () => {
   const { violations } = scanWithWorkflow(specimenWorkflow, (t) =>
-    t.replace('uses: ./.github/actions/setup-go', 'uses: actions/setup-go@v7'),
+    t.replace(
+      '      - uses: ./.github/actions/setup-go\n',
+      "      - uses: actions/setup-go@v7\n        with:\n          go-version-file: 'go.mod'\n          cache: true\n",
+    ),
   );
   assert.equal(violations.length, 1, violations.join('\n'));
-  assert.match(violations[0], /uses `actions\/setup-go@v7` directly/);
+  assert.match(violations[0], /uses `actions\/setup-go@v7` with `cache: true`/);
 });
 
-test('an unversioned actions/setup-go is caught too', () => {
+test('a bare actions/setup-go with no `with:` at all fails the gate', () => {
   const { violations } = scanWithWorkflow(specimenWorkflow, (t) =>
-    t.replace('uses: ./.github/actions/setup-go', 'uses: actions/setup-go'),
+    t.replace('      - uses: ./.github/actions/setup-go\n', '      - uses: actions/setup-go@v7\n'),
   );
   assert.equal(violations.length, 1, violations.join('\n'));
+  assert.match(violations[0], /`cache: \(unset\)`/);
 });
+
+test('a templated cache value does not satisfy the literal rule', () => {
+  // The exact shape that made CodeQL report update-golden as poisonable: a
+  // value no static reader can resolve to false.
+  const { violations } = scanWithWorkflow(directWorkflow, (t) =>
+    t.replace('          cache: false\n', '          cache: ${{ inputs.cache }}\n'),
+  );
+  assert.ok(violations.length >= 1, 'a non-literal cache value must not pass');
+  assert.match(violations[0], /cache-poisoning|must go through/);
+});
+
+// ---------------------------------------------------------------------------
+// R2 — opting out of the cache is not opting out of the fetch.
+// ---------------------------------------------------------------------------
+
+test('a direct, cache-less setup with no warm step in its job fails the gate', () => {
+  const { violations } = scanWithWorkflow(directWorkflow, (t) =>
+    t.replaceAll('        run: node "$GITHUB_WORKSPACE/.github/scripts/go-module-fetch.mjs"\n', '        run: true\n'),
+  );
+  // Three jobs, three violations. (The scan also reports R5, because this
+  // single-file scan contains no wrapper call site at all — that is the
+  // vacuity rule doing its job, and it is asserted on its own below.)
+  const unwarmed = violations.filter((v) => /never runs `go-module-fetch\.mjs`/.test(v));
+  assert.equal(unwarmed.length, 3, violations.join('\n'));
+  for (const label of ['regenerate', 'cardinality-leg', 'cardinality-seal']) {
+    assert.ok(
+      unwarmed.some((v) => v.includes(`:${label}:`)),
+      `${label} was not reported: ${unwarmed.join('\n')}`,
+    );
+  }
+});
+
+test('update-golden pairs every direct setup with a warm step in the same job', () => {
+  // The over-reach control, asserted on the real text: three direct call
+  // sites, each in a job that also warms. A gate that forced these through the
+  // composite would take the literal `cache: false` away from the repository's
+  // most privileged workflow.
+  const text = readFileSync(join(workflows, directWorkflow), 'utf8');
+  let paired = 0;
+  for (const block of stepBlocks(text)) {
+    const direct = block.steps.filter((s) => isUpstreamSetupGo(stepUses(s) ?? ''));
+    if (direct.length === 0) continue;
+    assert.equal(withEntry(direct[0], 'cache'), 'false', `${block.label} must opt out of the shared cache`);
+    assert.ok(
+      block.steps.some((s) => s.some((l) => l.includes('go-module-fetch.mjs'))),
+      `${block.label} must warm the module cache itself`,
+    );
+    paired++;
+  }
+  assert.equal(paired, 3);
+  assert.deepEqual(realScan().violations, []);
+});
+
+// ---------------------------------------------------------------------------
+// R3 — composite actions have no job scope, so they get no escape.
+// ---------------------------------------------------------------------------
 
 test('a composite action that reaches for setup-go directly fails the gate', () => {
   // The wrapper is exempt by IDENTITY, not by name: any OTHER action.yml under
   // .github/actions/ naming the upstream Action reopens the hole, so the gate
-  // has to read that tree as well as the workflows.
+  // has to read that tree as well as the workflows. Even `cache: false` does
+  // not save it — there is no job here in which R2 could be satisfied.
   const dir = mkdtempSync(join(tmpdir(), 'go-setup-gate-sibling-'));
   cpSync(actions, dir, { recursive: true });
   const sibling = join(dir, 'free-disk-space/action.yml');
   const text = readFileSync(sibling, 'utf8');
-  writeFileSync(sibling, `${text}\n    - uses: actions/setup-go@v7\n`);
+  writeFileSync(sibling, `${text}\n    - uses: actions/setup-go@v7\n      with:\n        cache: false\n`);
 
   const { violations } = scan({
     root: repoRoot,
@@ -138,24 +205,26 @@ test('a composite action that reaches for setup-go directly fails the gate', () 
 });
 
 test('a prose mention of the Action is not a call site', () => {
-  // compatibility.yml's header lists the Actions it runs. A grep would read
-  // that inventory as a violation, and a gate that fired on a comment is a gate
-  // somebody writes an exemption for.
+  // compatibility.yml's header lists the Actions it runs, and update-golden's
+  // own comment explains why it names the Action. A grep would read both as
+  // violations, and a gate that fired on a comment is a gate somebody writes an
+  // exemption for.
   assert.equal(usesValue('#   * actions/setup-go@v7           — driver builds.'), null);
-  assert.equal(directSetupGoUses('# uses: actions/setup-go@v7\n').length, 0);
-  assert.equal(directSetupGoUses('      - name: replace actions/setup-go@v7\n').length, 0);
-  assert.equal(directSetupGoUses('      - uses: actions/setup-go@v7\n').length, 1);
+  assert.equal(usesValue('      - name: replace actions/setup-go@v7'), null);
+  assert.equal(usesValue('      - uses: actions/setup-go@v7'), 'actions/setup-go@v7');
+  assert.equal(isUpstreamSetupGo('actions/setup-go'), true);
+  assert.equal(isUpstreamSetupGo('./.github/actions/setup-go'), false);
 });
 
 // ---------------------------------------------------------------------------
-// R2 / R3 — the wrapper is real, and its warm step is unconditional.
+// R4 — the wrapper is real, and its warm step is unconditional.
 // ---------------------------------------------------------------------------
 
 test('a wrapper that no longer warms the module cache fails the gate', () => {
   // Only the RUN line, not the header prose that also names the module: the
   // rule is about what the step executes.
   const { violations } = scanWithWrapper((t) =>
-    t.replace('node "$GITHUB_WORKSPACE/.github/scripts/go-module-fetch.mjs"', 'echo skipped'),
+    t.replace('node "$GITHUB_WORKSPACE/.github/scripts/go-module-fetch.mjs"', 'echo nothing'),
   );
   assert.equal(violations.length, 1, violations.join('\n'));
   assert.match(violations[0], /runs no `go-module-fetch\.mjs` step/);
@@ -163,7 +232,10 @@ test('a wrapper that no longer warms the module cache fails the gate', () => {
 
 test('a warm step made conditional fails the gate', () => {
   const { violations } = scanWithWrapper((t) =>
-    t.replace('    - name: Warm the Go module cache', "    - if: inputs.cache == 'true'\n      name: Warm the Go module cache"),
+    t.replace(
+      '    - name: Warm the Go module cache',
+      "    - if: inputs.cache == 'true'\n      name: Warm the Go module cache",
+    ),
   );
   assert.equal(violations.length, 1, violations.join('\n'));
   assert.match(violations[0], /carries an `if:`/);
@@ -188,7 +260,7 @@ test('a missing wrapper fails the gate rather than passing vacuously', () => {
 });
 
 // ---------------------------------------------------------------------------
-// R4 — vacuity.
+// R5 — vacuity.
 // ---------------------------------------------------------------------------
 
 test('a tree where nothing sets Go up fails rather than reporting clean', () => {
@@ -205,12 +277,28 @@ test('a tree where nothing sets Go up fails rather than reporting clean', () => 
 });
 
 // ---------------------------------------------------------------------------
-// The step reader, pinned directly.
+// The readers, pinned directly.
 // ---------------------------------------------------------------------------
 
 test('the wrapper parses into its two steps, in order', () => {
-  const steps = compositeSteps(readFileSync(wrapperFile, 'utf8'));
+  const steps = stepBlocks(readFileSync(wrapperFile, 'utf8')).flatMap((b) => b.steps);
   assert.equal(steps.length, 2);
-  assert.ok(steps[0].some((l) => l.includes('actions/setup-go@v7')));
+  assert.equal(stepUses(steps[0]), 'actions/setup-go@v7');
   assert.ok(steps[1].some((l) => l.includes('go-module-fetch.mjs')));
+  assert.equal(hasKeyAtStepLevel(steps[1], 'if'), false);
+});
+
+test('a step block is scoped to its own job', () => {
+  // R2 asks "does the SAME job warm", so a reader that merged two jobs into one
+  // block would let a warm step in job A satisfy a direct setup in job B.
+  const blocks = stepBlocks(readFileSync(join(workflows, directWorkflow), 'utf8'));
+  assert.ok(blocks.length >= 5, `expected one block per job, saw ${blocks.length}`);
+  assert.ok(blocks.some((b) => b.label === 'regenerate'));
+  assert.ok(blocks.some((b) => b.label === 'plan'));
+  // `plan` sets Go up not at all, so it must contribute no direct call site.
+  const plan = blocks.find((b) => b.label === 'plan');
+  assert.equal(
+    plan.steps.filter((s) => isUpstreamSetupGo(stepUses(s) ?? '')).length,
+    0,
+  );
 });

--- a/.github/scripts/assert-go-setup-hardened.test.mjs
+++ b/.github/scripts/assert-go-setup-hardened.test.mjs
@@ -18,7 +18,7 @@
 // "the gate does not overreach" is asserted directly, twice.
 
 import assert from 'node:assert/strict';
-import { cpSync, mkdtempSync, readFileSync, writeFileSync } from 'node:fs';
+import { cpSync, mkdtempSync, readFileSync, readdirSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import test from 'node:test';
@@ -82,8 +82,69 @@ function scanWithWrapper(edit) {
 test('the repository as it stands passes every rule', () => {
   const { violations, wrapperCallSites, directCallSites } = realScan();
   assert.deepEqual(violations, []);
-  assert.ok(wrapperCallSites >= 45, `expected the whole fleet of call sites, saw ${wrapperCallSites}`);
+  // Counted from the tree rather than asserted as a loose floor. A `>= 45`
+  // bound passed for months while the scanner could not see the call site
+  // inside e2e.yml's anchored `steps:` block — the gate reported 47 where the
+  // tree holds 48, and the slack hid exactly the discrepancy that mattered.
+  const onDisk = wrapperCallSitesInTree();
+  assert.equal(
+    wrapperCallSites,
+    onDisk,
+    `the gate sees ${wrapperCallSites} wrapper call sites but the tree holds ${onDisk}; ` +
+      'a call site the scanner cannot reach is a call site it cannot police',
+  );
   assert.equal(directCallSites, 3, 'only update-golden.yml may reach the Action directly');
+});
+
+// wrapperCallSitesInTree — grep, deliberately naive, as an independent second
+// opinion on the gate's own bookkeeping. It must not share the gate's YAML
+// reader, or a blind spot in that reader would silence both sides at once.
+function wrapperCallSitesInTree() {
+  let n = 0;
+  for (const file of readdirSync(join(repoRoot, '.github/workflows'))) {
+    if (!file.endsWith('.yml') && !file.endsWith('.yaml')) continue;
+    const text = readFileSync(join(repoRoot, '.github/workflows', file), 'utf8');
+    for (const line of text.split('\n')) {
+      if (line.trimStart().startsWith('#')) continue;
+      if (/^\s*(?:-\s+)?uses:\s*\.\/\.github\/actions\/setup-go\s*$/.test(line)) n++;
+    }
+  }
+  return n;
+}
+
+test('an anchored steps block is scanned, not skipped', () => {
+  // e2e.yml declares `steps: &dashboard_shard_steps` and re-uses it via
+  // `steps: *dashboard_shard_steps`. The anchor form carries the body, so it
+  // must be read; the alias form re-uses that same body, so reading it again
+  // would double-count every call site inside it.
+  const anchored = [
+    'jobs:',
+    '  shard:',
+    '    steps: &shared',
+    '      - uses: ./.github/actions/setup-go',
+    '  shard-info:',
+    '    steps: *shared',
+  ].join('\n');
+
+  const blocks = stepBlocks(anchored, 'anchored.yml');
+  assert.equal(blocks.length, 1, 'the anchor contributes its body exactly once');
+  assert.equal(
+    blocks[0].steps.flat().filter((l) => stepUses([l]) === './.github/actions/setup-go').length ||
+      blocks[0].steps.filter((s) => stepUses(s) === './.github/actions/setup-go').length,
+    1,
+    'the call site inside the anchored block must be visible to the scanner',
+  );
+});
+
+test('a steps: shape the scanner cannot follow fails loudly', () => {
+  // The failure mode this gate had: an unreadable `steps:` line yielded no
+  // block and the whole job went unscanned, so the gate reported clean for the
+  // wrong reason. Anything unrecognised must now stop the run instead.
+  assert.throws(
+    () => stepBlocks(['jobs:', '  a:', '    steps: !!weird', '      - run: x'].join('\n'), 'odd.yml'),
+    /cannot follow/,
+    'an unparsed steps block must fail the gate rather than silently vanish',
+  );
 });
 
 test('no Go setup in the tree can archive an empty module cache', () => {

--- a/.github/scripts/assert-go-setup-hardened.test.mjs
+++ b/.github/scripts/assert-go-setup-hardened.test.mjs
@@ -1,0 +1,216 @@
+// Tests for the Go-setup ratchet.
+//
+// The point of every case below is that the gate CAN FAIL, and fails for the
+// right reason. "The tree is clean" is not evidence on its own: it is equally
+// consistent with a scanner that never read the workflows. So each rule is
+// proved against the REAL text of this repository with exactly one thing broken
+// in it — a call site reverted to `actions/setup-go@v7`, the warm step deleted,
+// the warm step made conditional — rather than against a hand-written fixture
+// that merely resembles a workflow.
+//
+// The one case that runs the other way is `cache: false`. update-golden.yml's
+// three jobs run target-branch code and must not persist bytes into later
+// workflows, so the value is load-bearing; a gate that forced `cache: true`
+// would break that isolation. That it stays green is asserted directly, because
+// "the gate does not overreach" is as easy to lose in an edit as "the gate
+// fires".
+
+import assert from 'node:assert/strict';
+import { cpSync, mkdtempSync, readFileSync, readdirSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import test from 'node:test';
+
+import { compositeSteps, directSetupGoUses, scan, usesValue, wrapperUses } from './assert-go-setup-hardened.mjs';
+
+const repoRoot = process.cwd();
+const workflows = join(repoRoot, '.github/workflows');
+const actions = join(repoRoot, '.github/actions');
+const wrapperFile = join(actions, 'setup-go/action.yml');
+
+// A workflow whose Go setup is unconditional and whose `with:` block was
+// dropped as default — the ordinary shape, and so the honest specimen.
+const specimenWorkflow = 'ci.yml';
+
+function realScan() {
+  return scan({ root: repoRoot, workflowDir: workflows, actionsDir: actions, wrapperPath: join(actions, 'setup-go') });
+}
+
+// scanWithWorkflow — the real tree, with ONE workflow replaced by a doctored
+// copy. The actions directory and the wrapper still resolve against the real
+// tree, so what is under test is the real gate reading real text.
+function scanWithWorkflow(file, edit) {
+  const dir = mkdtempSync(join(tmpdir(), 'go-setup-gate-wf-'));
+  const original = readFileSync(join(workflows, file), 'utf8');
+  const doctored = edit(original);
+  assert.notEqual(doctored, original, 'the negative control did not change the workflow text');
+  writeFileSync(join(dir, file), doctored);
+  return scan({ root: repoRoot, workflowDir: dir, actionsDir: actions, wrapperPath: join(actions, 'setup-go') });
+}
+
+// scanWithWrapper — the real workflows, with the wrapper's own action.yml
+// doctored in a copy of the actions tree.
+function scanWithWrapper(edit) {
+  const dir = mkdtempSync(join(tmpdir(), 'go-setup-gate-actions-'));
+  cpSync(actions, dir, { recursive: true });
+  const target = join(dir, 'setup-go/action.yml');
+  const original = readFileSync(target, 'utf8');
+  const doctored = edit(original);
+  assert.notEqual(doctored, original, 'the negative control did not change the action text');
+  writeFileSync(target, doctored);
+  return scan({ root: repoRoot, workflowDir: workflows, actionsDir: dir, wrapperPath: join(dir, 'setup-go') });
+}
+
+// ---------------------------------------------------------------------------
+// The tree as it stands.
+// ---------------------------------------------------------------------------
+
+test('the repository as it stands passes every rule', () => {
+  const { violations, wrapperCallSites } = realScan();
+  assert.deepEqual(violations, []);
+  assert.ok(wrapperCallSites > 0, 'no call site was found — the gate is not reading the workflows');
+});
+
+test('every Go setup in the tree goes through the wrapper', () => {
+  // Counted independently of the gate's own bookkeeping, so a scanner that
+  // silently stopped reading files would fail here rather than report a
+  // satisfied-looking zero.
+  let direct = 0;
+  let wrapped = 0;
+  for (const file of readdirSync(workflows).filter((f) => /\.ya?ml$/.test(f))) {
+    const text = readFileSync(join(workflows, file), 'utf8');
+    direct += directSetupGoUses(text).length;
+    wrapped += wrapperUses(text);
+  }
+  assert.equal(direct, 0);
+  assert.ok(wrapped >= 50, `expected the whole fleet of call sites, saw ${wrapped}`);
+});
+
+test('`cache: false` is permitted — the gate never inspects the input', () => {
+  // update-golden.yml keeps `cache: false` on all three of its jobs. If the
+  // gate ever started demanding `true`, this is the assertion that says so
+  // before the isolation those jobs depend on is broken.
+  const text = readFileSync(join(workflows, 'update-golden.yml'), 'utf8');
+  assert.ok(/cache: false/.test(text), 'the specimen no longer carries the value under test');
+  assert.ok(wrapperUses(text) >= 3, 'update-golden should reach Go setup through the wrapper');
+
+  const { violations } = scanWithWorkflow('update-golden.yml', (t) => `${t}\n# doctored: no change of substance\n`);
+  assert.deepEqual(violations, []);
+});
+
+// ---------------------------------------------------------------------------
+// R1 — the direct call site.
+// ---------------------------------------------------------------------------
+
+test('a call site reverted to actions/setup-go fails the gate', () => {
+  const { violations } = scanWithWorkflow(specimenWorkflow, (t) =>
+    t.replace('uses: ./.github/actions/setup-go', 'uses: actions/setup-go@v7'),
+  );
+  assert.equal(violations.length, 1, violations.join('\n'));
+  assert.match(violations[0], /uses `actions\/setup-go@v7` directly/);
+});
+
+test('an unversioned actions/setup-go is caught too', () => {
+  const { violations } = scanWithWorkflow(specimenWorkflow, (t) =>
+    t.replace('uses: ./.github/actions/setup-go', 'uses: actions/setup-go'),
+  );
+  assert.equal(violations.length, 1, violations.join('\n'));
+});
+
+test('a composite action that reaches for setup-go directly fails the gate', () => {
+  // The wrapper is exempt by IDENTITY, not by name: any OTHER action.yml under
+  // .github/actions/ naming the upstream Action reopens the hole, so the gate
+  // has to read that tree as well as the workflows.
+  const dir = mkdtempSync(join(tmpdir(), 'go-setup-gate-sibling-'));
+  cpSync(actions, dir, { recursive: true });
+  const sibling = join(dir, 'free-disk-space/action.yml');
+  const text = readFileSync(sibling, 'utf8');
+  writeFileSync(sibling, `${text}\n    - uses: actions/setup-go@v7\n`);
+
+  const { violations } = scan({
+    root: repoRoot,
+    workflowDir: workflows,
+    actionsDir: dir,
+    wrapperPath: join(dir, 'setup-go'),
+  });
+  assert.equal(violations.length, 1, violations.join('\n'));
+  assert.match(violations[0], /free-disk-space\/action\.yml/);
+});
+
+test('a prose mention of the Action is not a call site', () => {
+  // compatibility.yml's header lists the Actions it runs. A grep would read
+  // that inventory as a violation, and a gate that fired on a comment is a gate
+  // somebody writes an exemption for.
+  assert.equal(usesValue('#   * actions/setup-go@v7           — driver builds.'), null);
+  assert.equal(directSetupGoUses('# uses: actions/setup-go@v7\n').length, 0);
+  assert.equal(directSetupGoUses('      - name: replace actions/setup-go@v7\n').length, 0);
+  assert.equal(directSetupGoUses('      - uses: actions/setup-go@v7\n').length, 1);
+});
+
+// ---------------------------------------------------------------------------
+// R2 / R3 — the wrapper is real, and its warm step is unconditional.
+// ---------------------------------------------------------------------------
+
+test('a wrapper that no longer warms the module cache fails the gate', () => {
+  // Only the RUN line, not the header prose that also names the module: the
+  // rule is about what the step executes.
+  const { violations } = scanWithWrapper((t) =>
+    t.replace('node "$GITHUB_WORKSPACE/.github/scripts/go-module-fetch.mjs"', 'echo skipped'),
+  );
+  assert.equal(violations.length, 1, violations.join('\n'));
+  assert.match(violations[0], /runs no `go-module-fetch\.mjs` step/);
+});
+
+test('a warm step made conditional fails the gate', () => {
+  const { violations } = scanWithWrapper((t) =>
+    t.replace('    - name: Warm the Go module cache', "    - if: inputs.cache == 'true'\n      name: Warm the Go module cache"),
+  );
+  assert.equal(violations.length, 1, violations.join('\n'));
+  assert.match(violations[0], /carries an `if:`/);
+});
+
+test('a wrapper that installs no Go toolchain fails the gate', () => {
+  const { violations } = scanWithWrapper((t) => t.replace('    - uses: actions/setup-go@v7', '    - name: nothing'));
+  assert.equal(violations.length, 1, violations.join('\n'));
+  assert.match(violations[0], /does not delegate/);
+});
+
+test('a missing wrapper fails the gate rather than passing vacuously', () => {
+  const empty = mkdtempSync(join(tmpdir(), 'go-setup-gate-empty-'));
+  const { violations } = scan({
+    root: repoRoot,
+    workflowDir: workflows,
+    actionsDir: empty,
+    wrapperPath: empty,
+  });
+  assert.equal(violations.length, 1, violations.join('\n'));
+  assert.match(violations[0], /does not exist/);
+});
+
+// ---------------------------------------------------------------------------
+// R4 — vacuity.
+// ---------------------------------------------------------------------------
+
+test('a tree where nothing sets Go up fails rather than reporting clean', () => {
+  const dir = mkdtempSync(join(tmpdir(), 'go-setup-gate-vacuous-'));
+  writeFileSync(join(dir, 'nothing.yml'), 'jobs:\n  x:\n    steps:\n      - run: echo hi\n');
+  const { violations } = scan({
+    root: repoRoot,
+    workflowDir: dir,
+    actionsDir: mkdtempSync(join(tmpdir(), 'go-setup-gate-noactions-')),
+    wrapperPath: join(actions, 'setup-go'),
+  });
+  assert.equal(violations.length, 1, violations.join('\n'));
+  assert.match(violations[0], /no workflow or action uses/);
+});
+
+// ---------------------------------------------------------------------------
+// The step reader, pinned directly.
+// ---------------------------------------------------------------------------
+
+test('the wrapper parses into its two steps, in order', () => {
+  const steps = compositeSteps(readFileSync(wrapperFile, 'utf8'));
+  assert.equal(steps.length, 2);
+  assert.ok(steps[0].some((l) => l.includes('actions/setup-go@v7')));
+  assert.ok(steps[1].some((l) => l.includes('go-module-fetch.mjs')));
+});

--- a/.github/scripts/go-module-fetch.mjs
+++ b/.github/scripts/go-module-fetch.mjs
@@ -1,0 +1,226 @@
+// go-module-fetch — run one FETCH-ONLY Go command under the repository's
+// single transient-failure retry policy.
+//
+// WHY THIS EXISTS. Every Go job in this repo pulls its dependency graph from
+// proxy.golang.org, and the Go module resolver does not retry past a dropped
+// HTTP/2 frame: one `stream error: stream ID 523; INTERNAL_ERROR; received from
+// peer` anywhere in a multi-minute, ~340-module download stream kills the job.
+// That killed seven jobs in one afternoon (runs 33080257221, 33084966918,
+// 33093118010), and the reason the ambient flakiness became visible at all was
+// a POISONED module cache: a Go-less job saved a 7,616-byte archive under the
+// go.sum-keyed primary key on refs/heads/main, so every job in the repo
+// restored nothing and re-fetched the whole graph. The cache half is fixed
+// structurally by `.github/actions/setup-go`, which calls this module as its
+// unconditional warm step; this module is the residual cover for the run that
+// is GENUINELY cold — the first one after every go.sum bump, which is exactly
+// when the whole graph has to come down the wire.
+//
+// WHY IT CANNOT MASK A REAL FAILURE. Three independent layers, each asserted by
+// go-module-fetch.test.mjs against the ATTEMPT COUNT rather than the exit code
+// — a wrapper that retried a real error and then failed would look identical on
+// the exit code alone.
+//
+//   (a) SCOPE. Only a fetch-only command may be wrapped at all, and that is
+//       enforced here rather than trusted to the call sites: `isFetchOnly()`
+//       accepts `go mod download` and `go install <pkg>@<version>` and refuses
+//       everything else. `go test`, `go list`, `go build`, `just <recipe>` and
+//       `gremlins unleash` are therefore unwrappable by construction and still
+//       fail on their first attempt — they simply stop needing the network,
+//       because the warm step has already fetched what they read.
+//   (b) CLASSIFY. An attempt is retried only when the merged output matches
+//       lib/registry.mjs's `isTransientRegistryFailure()`, whose pattern list
+//       already carries the exact Go-proxy signatures (`http2: stream error`,
+//       `INTERNAL_ERROR; received from peer`, `connection reset by peer`, `i/o
+//       timeout`, `TLS handshake timeout`, a proxy.golang.org-scoped 403). A Go
+//       compile error — the one thing `go install` can produce that
+//       `go mod download` cannot — matches nothing on that list and exits after
+//       one attempt.
+//   (c) NEVER-RETRY, evaluated FIRST and winning outright even when the output
+//       also names a transport fault. This mirrors the rate-limit rule in
+//       lib/registry.mjs, and for the same reason: retrying a `SECURITY ERROR`
+//       or a checksum mismatch is the one behaviour that would be actively
+//       dangerous, because a second attempt against a different proxy replica
+//       is precisely how a poisoned module would eventually be accepted.
+//
+// The policy itself is IMPORTED, not re-derived. lib/registry.mjs owns the
+// attempt budget, the linear backoff and the transport classification for every
+// network fetch this CI performs; a second helper would be a second place for
+// the answer to drift.
+//
+// USAGE
+//   node .github/scripts/go-module-fetch.mjs
+//       Warm mode: `go mod download` in the working directory. No arguments,
+//       because for a `go 1.17`-or-later module that downloads exactly the
+//       modules go.mod explicitly requires — which includes every `// indirect`
+//       requirement, so the three modules whose fetch failed in the runs above
+//       (go-sqlbuilder, autoexport, stdoutlog) are all covered. `all` would add
+//       the test dependencies OF dependencies, which nothing here builds.
+//
+//   node .github/scripts/go-module-fetch.mjs -- go install <pkg>@<version>
+//       Passthrough mode, for a tool that is not in go.mod and so is not
+//       covered by `go mod download` at all.
+//
+// ENV CONTRACT
+//   GO_FETCH_BACKOFF_STEP_SECONDS — linear backoff step in seconds; attempt N
+//                                   sleeps N × this. Default below.
+//
+// Exit: the wrapped command's status once it has succeeded or run out of
+// attempts; 1 when the command handed in is not fetch-only.
+
+import process from 'node:process';
+import { pathToFileURL } from 'node:url';
+
+import { capture, error, log, notice } from './lib/gh.mjs';
+import {
+  isTransientRegistryFailure,
+  readBackoffStepSeconds,
+  registryAttempts,
+  sleepSeconds,
+} from './lib/registry.mjs';
+
+// Attempt N sleeps N × this. Shorter than the image-build wrapper's step
+// because a module fetch has no `FROM`-resolution tail behind it: a proxy blip
+// clears in seconds or is not a blip. Overridable so a lane that wants to ride
+// out a longer incident can, without a second policy.
+export const goFetchBackoffStepSeconds = 3;
+const goFetchBackoffStepEnvVar = 'GO_FETCH_BACKOFF_STEP_SECONDS';
+
+// The command prefixes this wrapper will run — layer (a) above, written as a
+// property of the wrapper's INPUT rather than as trust in its call sites.
+//
+// This is not an exemption list: it is the opposite of one. It does not excuse
+// any failure; it narrows what is eligible to be retried at all, so that a
+// command whose failure carries real information can never reach the loop.
+const fetchOnlyCommandPrefixes = [
+  ['go', 'mod', 'download'],
+  ['go', 'install'],
+];
+
+export function isFetchOnly(argv) {
+  return fetchOnlyCommandPrefixes.some((prefix) => prefix.every((token, i) => argv[i] === token));
+}
+
+// The failures a second attempt cannot fix and must not be given.
+//
+//   * `SECURITY ERROR` / `checksum mismatch` — the checksum database and the
+//     bytes disagree. Retrying is how a poisoned module eventually gets
+//     accepted, so this class wins over every transport signature.
+//   * `404 Not Found` / `410 Gone` / `unknown revision` / `invalid version` /
+//     `no matching versions` — the proxy answered, definitively, that the
+//     version does not exist. A retyped tag is the fix; time is not.
+//   * `missing go.sum entry` — the module graph in the tree is inconsistent
+//     with go.sum. `go mod tidy` is the fix; the network is not involved.
+const goFetchNeverRetryablePatterns = [
+  /SECURITY ERROR/,
+  /checksum mismatch/i,
+  /\b404 Not Found\b/i,
+  /\b410 Gone\b/i,
+  /unknown revision/i,
+  /invalid version/i,
+  /no matching versions/i,
+  /missing go\.sum entry/i,
+];
+
+export function goFetchNeverRetryable(text) {
+  const haystack = String(text ?? '');
+  return goFetchNeverRetryablePatterns.some((re) => re.test(haystack));
+}
+
+// runWithRetry — the loop, with every collaborator injectable so the tests can
+// assert the ATTEMPT COUNT rather than only the exit status.
+//
+// Returns { status, attempts, verdict }:
+//   verdict `succeeded`       the command exited 0.
+//   verdict `never-retryable` layer (c) refused another attempt.
+//   verdict `not-transient`   layer (b) found no transport signature.
+//   verdict `exhausted`       every attempt hit a transport fault.
+export function runWithRetry(options) {
+  const {
+    argv,
+    attempts = registryAttempts,
+    backoffStepSeconds = goFetchBackoffStepSeconds,
+    spawn = (program, args) => capture(program, args),
+    sleep = sleepSeconds,
+    onLog = log,
+  } = options;
+
+  let used = 0;
+  let status = 1;
+  for (let attempt = 1; attempt <= attempts; attempt++) {
+    used = attempt;
+    onLog(`    ${argv.join(' ')} (attempt ${attempt}/${attempts})`);
+    const res = spawn(argv[0], argv.slice(1));
+    status = res.status;
+    if (status === 0) return { status, attempts: used, verdict: 'succeeded' };
+
+    const output = `${res.stdout ?? ''}${res.stderr ?? ''}`;
+    if (goFetchNeverRetryable(output)) {
+      return { status, attempts: used, verdict: 'never-retryable' };
+    }
+    if (!isTransientRegistryFailure(output)) {
+      return { status, attempts: used, verdict: 'not-transient' };
+    }
+    if (attempt < attempts) sleep(attempt * backoffStepSeconds);
+  }
+  return { status, attempts: used, verdict: 'exhausted' };
+}
+
+// The command a bare invocation runs. Spelled once so the warm step in
+// .github/actions/setup-go and the tests below agree on what "warm" means.
+export const warmCommand = ['go', 'mod', 'download'];
+
+// commandFrom — the argv a CLI invocation asks for. Everything after a `--`
+// separator, or the warm command when there is none.
+export function commandFrom(argv) {
+  const sep = argv.indexOf('--');
+  if (sep === -1) return [...warmCommand];
+  return argv.slice(sep + 1);
+}
+
+const verdictExplanations = {
+  'never-retryable': (cmd) =>
+    `${cmd} failed with an error no retry can fix — a checksum/security refusal, or a version the ` +
+    'proxy definitively does not have. Retrying a checksum refusal is how a poisoned module gets ' +
+    'accepted, so this class is refused another attempt by design. Fix the version or run `go mod tidy`.',
+  'not-transient': (cmd) =>
+    `${cmd} failed for a reason that is not a network fault, so it was not retried. The output above ` +
+    'is the real error.',
+  exhausted: (cmd, attempts) =>
+    `${cmd} failed ${attempts} times on module-proxy transport faults. That is a genuinely unreachable ` +
+    'proxy rather than a blip: check https://status.golang.org and the runner network before re-running.',
+};
+
+function main() {
+  const argv = commandFrom(process.argv.slice(2));
+
+  if (argv.length === 0 || !isFetchOnly(argv)) {
+    error(
+      `go-module-fetch refuses to run \`${argv.join(' ')}\`: it wraps FETCH-ONLY commands only ` +
+        `(${fetchOnlyCommandPrefixes.map((p) => `\`${p.join(' ')}\``).join(', ')}). A command that ` +
+        'compiles, tests or runs anything must fail on its first attempt, because retrying it would ' +
+        'hide the failure it is reporting.',
+    );
+    process.exit(1);
+  }
+
+  const result = runWithRetry({
+    argv,
+    backoffStepSeconds: readBackoffStepSeconds(goFetchBackoffStepEnvVar, goFetchBackoffStepSeconds),
+    spawn: (program, args) => {
+      const res = capture(program, args);
+      if (res.stdout) process.stdout.write(res.stdout);
+      if (res.stderr) process.stderr.write(res.stderr);
+      return res;
+    },
+  });
+
+  const printable = argv.join(' ');
+  if (result.status === 0) {
+    notice(`${printable} succeeded on attempt ${result.attempts}/${registryAttempts}`);
+    process.exit(0);
+  }
+  error(verdictExplanations[result.verdict](printable, result.attempts));
+  process.exit(result.status);
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) main();

--- a/.github/scripts/go-module-fetch.test.mjs
+++ b/.github/scripts/go-module-fetch.test.mjs
@@ -1,0 +1,255 @@
+// Tests for the Go module-fetch retry wrapper.
+//
+// Every assertion here is about the ATTEMPT COUNT, not merely the exit code,
+// and that is the whole point. "Retry does not mask a real failure" is a claim
+// about how many times the command ran: a wrapper that dutifully retried a
+// compile error five times and then reported it would be indistinguishable, on
+// the exit status alone, from one that refused to retry it at all. Asserting
+// the count is what turns the claim into a test.
+//
+// The positive fixtures are the VERBATIM stderr captured from the runs that
+// motivated this wrapper — 33080257221 (coverage-plan), 33084966918 (mutation:
+// `install gremlins` and two `gremlins unleash` legs) and 33093118010 (chdb
+// `probe`). They are quoted rather than paraphrased so a future edit to the
+// classification in lib/registry.mjs that stopped matching the real text would
+// fail here rather than silently stop retrying the only failure this exists for.
+
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { isTransientRegistryFailure } from './lib/registry.mjs';
+import {
+  commandFrom,
+  goFetchBackoffStepSeconds,
+  goFetchNeverRetryable,
+  isFetchOnly,
+  runWithRetry,
+  warmCommand,
+} from './go-module-fetch.mjs';
+
+// ---------------------------------------------------------------------------
+// The four failures this wrapper was built for, exactly as CI printed them.
+// ---------------------------------------------------------------------------
+
+const gremlinsInstallFailure =
+  'go: github.com/tsouza/gremlins/cmd/gremlins@v0.6.0-cerberus-timeout-max-consume: verifying module: ' +
+  'github.com/tsouza/gremlins@v0.6.0-cerberus-timeout-max-consume: reading ' +
+  'https://sum.golang.org/tile/8/0/x227/070: stream error: stream ID 3; INTERNAL_ERROR; received from peer\n';
+
+const autoexportModFailure =
+  'go: go.opentelemetry.io/contrib/exporters/autoexport@v0.70.0: read ' +
+  '"https://proxy.golang.org/go.opentelemetry.io/contrib/exporters/autoexport/@v/v0.70.0.mod": ' +
+  'stream error: stream ID 523; INTERNAL_ERROR; received from peer\n';
+
+const stdoutlogZipFailure =
+  'go: go.opentelemetry.io/otel/exporters/stdout/stdoutlog@v0.21.0: read ' +
+  '"https://proxy.golang.org/go.opentelemetry.io/otel/exporters/stdout/stdoutlog/@v/v0.21.0.zip": ' +
+  'stream error: stream ID 2319; INTERNAL_ERROR; received from peer\n';
+
+const sqlbuilderZipFailure =
+  '../../../go/pkg/mod/github.com/chdb-io/chdb-go@v1.12.0/chdb/driver/driver.go:15:2: ' +
+  'github.com/huandu/go-sqlbuilder@v1.27.3: read ' +
+  '"https://proxy.golang.org/github.com/huandu/go-sqlbuilder/@v/v1.27.3.zip": ' +
+  'stream error: stream ID 115; INTERNAL_ERROR; received from peer\n';
+
+const transportFailures = {
+  'gremlins install (run 33084966918)': gremlinsInstallFailure,
+  'autoexport .mod (run 33084966918)': autoexportModFailure,
+  'stdoutlog .zip (run 33084966918)': stdoutlogZipFailure,
+  'go-sqlbuilder .zip (run 33093118010)': sqlbuilderZipFailure,
+};
+
+// ---------------------------------------------------------------------------
+// The failures that must NOT be retried.
+// ---------------------------------------------------------------------------
+
+const notFound =
+  'go: github.com/tsouza/nonexistent@v1.2.3: reading ' +
+  'https://proxy.golang.org/github.com/tsouza/nonexistent/@v/v1.2.3.info: 404 Not Found\n';
+
+const gone =
+  'go: github.com/tsouza/withdrawn@v1.2.3: reading ' +
+  'https://proxy.golang.org/github.com/tsouza/withdrawn/@v/v1.2.3.info: 410 Gone\n';
+
+const unknownRevision =
+  'go: github.com/tsouza/cerberus@v9.9.9: invalid version: unknown revision v9.9.9\n';
+
+const noMatchingVersions = 'go: github.com/tsouza/cerberus@v9: no matching versions for query "v9"\n';
+
+const checksumMismatch =
+  'go: downloading github.com/huandu/go-sqlbuilder v1.27.3\n' +
+  'verifying github.com/huandu/go-sqlbuilder@v1.27.3: checksum mismatch\n' +
+  '\tdownloaded: h1:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=\n' +
+  '\tgo.sum:     h1:BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB=\n' +
+  'SECURITY ERROR\n' +
+  'This download does NOT match the one reported by the checksum server.\n';
+
+const missingGoSumEntry =
+  'go: github.com/tsouza/cerberus/internal/promql: no required module provides package ' +
+  'github.com/huandu/go-sqlbuilder; missing go.sum entry for module providing package ' +
+  'github.com/huandu/go-sqlbuilder\n';
+
+const goCompileError = './internal/chsql/builder.go:31:2: undefined: notAFunction\n';
+
+const neverRetried = {
+  '404 Not Found': notFound,
+  '410 Gone': gone,
+  'unknown revision': unknownRevision,
+  'no matching versions': noMatchingVersions,
+  'checksum mismatch / SECURITY ERROR': checksumMismatch,
+  'missing go.sum entry': missingGoSumEntry,
+};
+
+// ---------------------------------------------------------------------------
+// A recording spawn, so every assertion below is about how many times the
+// command actually ran.
+// ---------------------------------------------------------------------------
+
+function recorder({ stderr = '', failFor = Infinity } = {}) {
+  const calls = [];
+  const spawn = (program, args) => {
+    calls.push([program, ...args]);
+    if (calls.length > failFor) return { status: 0, stdout: 'ok\n', stderr: '' };
+    return { status: 1, stdout: '', stderr };
+  };
+  return { calls, spawn };
+}
+
+const silent = () => {};
+
+function run(argv, options) {
+  const { calls, spawn } = recorder(options);
+  const result = runWithRetry({ argv, spawn, sleep: silent, onLog: silent });
+  return { ...result, calls };
+}
+
+// ---------------------------------------------------------------------------
+// Layer (b): a transport fault is retried, and the retry is what rescues it.
+// ---------------------------------------------------------------------------
+
+for (const [label, stderr] of Object.entries(transportFailures)) {
+  test(`a module-proxy transport fault retries and then succeeds — ${label}`, () => {
+    // lib/registry.mjs is the classifier; if its pattern list ever stops
+    // matching the real text, this is the assertion that says so directly
+    // rather than through a count that happens to be 1 for two reasons.
+    assert.equal(isTransientRegistryFailure(stderr), true, 'the shared classifier no longer matches this failure');
+
+    const result = run(['go', 'mod', 'download'], { stderr, failFor: 2 });
+    assert.equal(result.status, 0);
+    assert.equal(result.verdict, 'succeeded');
+    assert.equal(result.attempts, 3, 'the third attempt is the one that succeeded');
+    assert.equal(result.calls.length, 3);
+    assert.deepEqual(result.calls[0], ['go', 'mod', 'download']);
+  });
+
+  test(`a persistent transport fault spends the whole budget and still fails — ${label}`, () => {
+    const result = run(['go', 'mod', 'download'], { stderr });
+    assert.notEqual(result.status, 0);
+    assert.equal(result.verdict, 'exhausted');
+    assert.equal(result.attempts, 5, 'the shared attempt budget is five');
+    assert.equal(result.calls.length, 5);
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Layer (c): the never-retry set, and layer (b)'s floor for anything unmatched.
+// ---------------------------------------------------------------------------
+
+for (const [label, stderr] of Object.entries(neverRetried)) {
+  test(`${label} exits non-zero after exactly one attempt`, () => {
+    assert.equal(goFetchNeverRetryable(stderr), true, `${label} is not in the never-retry set`);
+
+    const result = run(['go', 'mod', 'download'], { stderr });
+    assert.notEqual(result.status, 0);
+    assert.equal(result.verdict, 'never-retryable');
+    assert.equal(result.attempts, 1, `${label} was retried — a retry cannot fix it and must not be spent`);
+    assert.equal(result.calls.length, 1);
+  });
+}
+
+test('a Go compile error exits non-zero after exactly one attempt', () => {
+  // Deliberately NOT in the never-retry set: it is refused by layer (b),
+  // because nothing on the transport list describes it. Both floors are
+  // asserted so a compile error cannot slip through by being neither.
+  assert.equal(goFetchNeverRetryable(goCompileError), false);
+  assert.equal(isTransientRegistryFailure(goCompileError), false);
+
+  const result = run(['go', 'install', 'example.com/tool@v1.0.0'], { stderr: goCompileError });
+  assert.notEqual(result.status, 0);
+  assert.equal(result.verdict, 'not-transient');
+  assert.equal(result.attempts, 1);
+});
+
+test('a checksum refusal that ALSO names a transport fault is still refused outright', () => {
+  // The ordering rule, mirroring lib/registry.mjs's rate-limit-wins rule. A
+  // second attempt against a different proxy replica is precisely how a
+  // poisoned module would eventually be accepted, so the dangerous class has
+  // to win even when the text would otherwise look retryable.
+  const mixed = `${checksumMismatch}${autoexportModFailure}`;
+  assert.equal(isTransientRegistryFailure(mixed), true, 'the fixture must genuinely look transient too');
+
+  const result = run(['go', 'mod', 'download'], { stderr: mixed });
+  assert.equal(result.verdict, 'never-retryable');
+  assert.equal(result.attempts, 1);
+});
+
+test('a fault reported on stdout rather than stderr is classified the same way', () => {
+  const seen = [];
+  const result = runWithRetry({
+    argv: ['go', 'mod', 'download'],
+    spawn: () => {
+      seen.push(1);
+      return { status: 1, stdout: autoexportModFailure, stderr: '' };
+    },
+    sleep: silent,
+    onLog: silent,
+  });
+  assert.equal(result.verdict, 'exhausted');
+  assert.equal(seen.length, 5);
+});
+
+// ---------------------------------------------------------------------------
+// Layer (a): what may be wrapped at all.
+// ---------------------------------------------------------------------------
+
+test('only fetch-only commands are eligible for the retry loop', () => {
+  assert.equal(isFetchOnly(['go', 'mod', 'download']), true);
+  assert.equal(isFetchOnly(['go', 'install', 'github.com/tsouza/gremlins/cmd/gremlins@v0.6.0']), true);
+
+  // The commands whose failure carries real information. Each one must be
+  // unwrappable by construction, so it can only ever fail on attempt 1.
+  for (const argv of [
+    ['go', 'test', './...'],
+    ['go', 'build', './...'],
+    ['go', 'list', '-tags', 'chdb', './...'],
+    ['go', 'vet', './...'],
+    ['go', 'mod', 'tidy'],
+    ['just', 'test'],
+    ['gremlins', 'unleash'],
+    ['node', '.github/scripts/coverage-package-floor.mjs'],
+  ]) {
+    assert.equal(isFetchOnly(argv), false, `${argv.join(' ')} must not be wrappable`);
+  }
+});
+
+test('backoff is a linear multiple of the named step', () => {
+  const slept = [];
+  runWithRetry({
+    argv: ['go', 'mod', 'download'],
+    spawn: () => ({ status: 1, stdout: '', stderr: autoexportModFailure }),
+    sleep: (s) => slept.push(s),
+    onLog: silent,
+  });
+  // Four sleeps for five attempts: the last failure is not followed by a wait.
+  assert.deepEqual(slept, [1, 2, 3, 4].map((n) => n * goFetchBackoffStepSeconds));
+});
+
+test('a bare invocation warms the module cache; `--` hands over an explicit command', () => {
+  assert.deepEqual(commandFrom([]), warmCommand);
+  assert.deepEqual(warmCommand, ['go', 'mod', 'download']);
+  assert.deepEqual(commandFrom(['--', 'go', 'install', 'example.com/tool@v1.0.0']), [
+    'go',
+    'install',
+    'example.com/tool@v1.0.0',
+  ]);
+});

--- a/.github/workflows/agpl-oracle.yml
+++ b/.github/workflows/agpl-oracle.yml
@@ -149,11 +149,8 @@ jobs:
       - uses: actions/checkout@v7
         if: needs.changes.outputs.docs_only != 'true'
 
-      - uses: actions/setup-go@v7
+      - uses: ./.github/actions/setup-go
         if: needs.changes.outputs.docs_only != 'true'
-        with:
-          go-version-file: 'go.mod'
-          cache: true
 
       - uses: taiki-e/install-action@ba47c86ac325773530516bb756137ac718732518  # v2.86.5
         if: needs.changes.outputs.docs_only != 'true'

--- a/.github/workflows/chart-ci.yml
+++ b/.github/workflows/chart-ci.yml
@@ -83,10 +83,7 @@ jobs:
       # yet, and the cargo-binstall fallback fails (kubeconform isn't a crate).
       # go install is the canonical, version-pinned, checksum-verified path.
       - if: steps.changes.outputs.chart == 'true'
-        uses: actions/setup-go@v7
-        with:
-          go-version-file: go.mod
-          cache: true
+        uses: ./.github/actions/setup-go
 
       - name: Install kubeconform
         if: steps.changes.outputs.chart == 'true'

--- a/.github/workflows/chdb.yml
+++ b/.github/workflows/chdb.yml
@@ -222,10 +222,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
-      - uses: actions/setup-go@v7
-        with:
-          go-version-file: 'go.mod'
-          cache: true
+      - uses: ./.github/actions/setup-go
 
       - uses: taiki-e/install-action@ba47c86ac325773530516bb756137ac718732518  # v2.86.5
         with:
@@ -260,10 +257,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
-      - uses: actions/setup-go@v7
-        with:
-          go-version-file: 'go.mod'
-          cache: true
+      - uses: ./.github/actions/setup-go
 
       - uses: taiki-e/install-action@ba47c86ac325773530516bb756137ac718732518  # v2.86.5
         with:
@@ -349,11 +343,8 @@ jobs:
       - uses: actions/checkout@v7
         if: needs.changes.outputs.docs_only != 'true' && needs.changes.outputs.run_heavy == 'true'
 
-      - uses: actions/setup-go@v7
+      - uses: ./.github/actions/setup-go
         if: needs.changes.outputs.docs_only != 'true' && needs.changes.outputs.run_heavy == 'true'
-        with:
-          go-version-file: 'go.mod'
-          cache: true
 
       - uses: taiki-e/install-action@ba47c86ac325773530516bb756137ac718732518  # v2.86.5
         if: needs.changes.outputs.docs_only != 'true' && needs.changes.outputs.run_heavy == 'true'
@@ -486,10 +477,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
-      - uses: actions/setup-go@v7
-        with:
-          go-version-file: 'go.mod'
-          cache: true
+      - uses: ./.github/actions/setup-go
 
       - uses: taiki-e/install-action@ba47c86ac325773530516bb756137ac718732518  # v2.86.5
         with:
@@ -664,10 +652,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
-      - uses: actions/setup-go@v7
-        with:
-          go-version-file: 'go.mod'
-          cache: true
+      - uses: ./.github/actions/setup-go
 
       - uses: taiki-e/install-action@ba47c86ac325773530516bb756137ac718732518  # v2.86.5
         with:
@@ -757,10 +742,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
-      - uses: actions/setup-go@v7
-        with:
-          go-version-file: 'go.mod'
-          cache: true
+      - uses: ./.github/actions/setup-go
 
       - uses: taiki-e/install-action@ba47c86ac325773530516bb756137ac718732518  # v2.86.5
         with:
@@ -796,10 +778,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
-      - uses: actions/setup-go@v7
-        with:
-          go-version-file: 'go.mod'
-          cache: true
+      - uses: ./.github/actions/setup-go
 
       - uses: taiki-e/install-action@ba47c86ac325773530516bb756137ac718732518  # v2.86.5
         with:
@@ -835,10 +814,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
-      - uses: actions/setup-go@v7
-        with:
-          go-version-file: 'go.mod'
-          cache: true
+      - uses: ./.github/actions/setup-go
 
       - uses: taiki-e/install-action@ba47c86ac325773530516bb756137ac718732518  # v2.86.5
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -122,10 +122,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
-      - uses: actions/setup-go@v7
-        with:
-          go-version-file: 'go.mod'
-          cache: true
+      - uses: ./.github/actions/setup-go
 
       - uses: taiki-e/install-action@ba47c86ac325773530516bb756137ac718732518  # v2.86.5
         with:
@@ -148,10 +145,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
-      - uses: actions/setup-go@v7
-        with:
-          go-version-file: 'go.mod'
-          cache: true
+      - uses: ./.github/actions/setup-go
 
       - uses: taiki-e/install-action@ba47c86ac325773530516bb756137ac718732518  # v2.86.5
         with:
@@ -251,10 +245,7 @@ jobs:
         with:
           fetch-depth: 0  # commitlint needs full history
 
-      - uses: actions/setup-go@v7
-        with:
-          go-version-file: 'go.mod'
-          cache: true
+      - uses: ./.github/actions/setup-go
 
       - name: golangci-lint (tagged build configuration)
         # v7+ is required for golangci-lint v2; v6 caps at v1.
@@ -955,6 +946,23 @@ jobs:
           node --test .github/scripts/assert-image-jobs-authenticate.test.mjs
           node .github/scripts/assert-image-jobs-authenticate.mjs
 
+      # The same shape one registry over. `actions/setup-go` saves its module
+      # cache without checking that there is anything to save, so a Go-less job
+      # with `cache: true` can archive an EMPTY GOMODCACHE under the go.sum key
+      # on main — after which every job restores nothing, declines to save, and
+      # re-downloads ~340 modules until the next go.sum bump (run 32705099037).
+      # ./.github/actions/setup-go makes that impossible by warming the cache
+      # unconditionally; this gate is what stops a new job from copying an
+      # `actions/setup-go@v7` block back in and silently re-arming it. The tests
+      # run first: they prove the gate still FAILS on the real workflow text
+      # with one call site reverted and with the warm step deleted or made
+      # conditional.
+      - name: Assert every Go setup goes through the warming composite
+        run: |
+          node --test .github/scripts/go-module-fetch.test.mjs
+          node --test .github/scripts/assert-go-setup-hardened.test.mjs
+          node .github/scripts/assert-go-setup-hardened.mjs
+
       # The two auto-labelers, same discipline: neither is a required check,
       # so a broken mapping never turns anything red — it just quietly stops
       # labeling, which is exactly how 62 issues ended up bare. The issue
@@ -1232,10 +1240,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
-      - uses: actions/setup-go@v7
-        with:
-          go-version-file: 'go.mod'
-          cache: true
+      - uses: ./.github/actions/setup-go
 
       - name: AGPL clean-build gate
         run: node .github/scripts/agpl-clean.mjs

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -68,11 +68,8 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
-      - uses: actions/setup-go@v7
+      - uses: ./.github/actions/setup-go
         if: matrix.language == 'go'
-        with:
-          go-version-file: 'go.mod'
-          cache: true
 
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v4

--- a/.github/workflows/compatibility.yml
+++ b/.github/workflows/compatibility.yml
@@ -17,7 +17,9 @@ name: compatibility
 # Per ~/.claude/CI_STEPS.md, every step uses an official / well-known
 # Action — no `curl | sh` installs. Actions used here:
 #   * actions/checkout@v7           — stdlib.
-#   * actions/setup-go@v7           — `go run ./cmd/seed` + driver builds.
+#   * ./.github/actions/setup-go    — `go run ./cmd/seed` + driver builds. Wraps
+#     actions/setup-go@v7 and warms GOMODCACHE, so the cache is never saved
+#     empty and the cold module fetch is retried.
 #   * ./.github/actions/setup-buildx — buildkit-backed compose build, with
 #     the BuildKit bootstrap image acquired through a retry.
 #   * taiki-e/install-action@v2.85.5     — installs `just`.
@@ -210,10 +212,7 @@ jobs:
           # both refs reachable (mirrors ci.yml's forbid-skip checkout).
           fetch-depth: 0
 
-      - uses: actions/setup-go@v7
-        with:
-          go-version-file: 'go.mod'
-          cache: true
+      - uses: ./.github/actions/setup-go
 
       # Every discipline scan (pure `git grep` / `perl`, no Go toolchain),
       # run first because they are the cheapest and the most common cause
@@ -270,10 +269,7 @@ jobs:
       # only ships @main; repo CI rule: pin explicitly, no HEAD).
       - uses: ./.github/actions/free-disk-space
 
-      - uses: actions/setup-go@v7
-        with:
-          go-version-file: 'go.mod'
-          cache: true
+      - uses: ./.github/actions/setup-go
 
       - uses: taiki-e/install-action@ba47c86ac325773530516bb756137ac718732518  # v2.86.5
         with:
@@ -449,10 +445,7 @@ jobs:
       # to a commit SHA (action only ships @main).
       - uses: ./.github/actions/free-disk-space
 
-      - uses: actions/setup-go@v7
-        with:
-          go-version-file: 'go.mod'
-          cache: true
+      - uses: ./.github/actions/setup-go
 
       - uses: taiki-e/install-action@ba47c86ac325773530516bb756137ac718732518  # v2.86.5
         with:
@@ -589,10 +582,7 @@ jobs:
       # Same compose stack + same DiskPressure risk as compatibility/prometheus.
       - uses: ./.github/actions/free-disk-space
 
-      - uses: actions/setup-go@v7
-        with:
-          go-version-file: 'go.mod'
-          cache: true
+      - uses: ./.github/actions/setup-go
 
       - uses: taiki-e/install-action@ba47c86ac325773530516bb756137ac718732518  # v2.86.5
         with:
@@ -914,10 +904,7 @@ jobs:
       # The run script does `go run ./cmd/seed` + `go test -c` of the
       # vendored bench driver, so we need a Go toolchain. setup-go
       # honours go.mod's `go` directive and pulls the matching toolchain.
-      - uses: actions/setup-go@v7
-        with:
-          go-version-file: 'go.mod'
-          cache: true
+      - uses: ./.github/actions/setup-go
 
       - uses: ./.github/actions/registry-login
         with:

--- a/.github/workflows/config-docs.yml
+++ b/.github/workflows/config-docs.yml
@@ -35,10 +35,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
-      - uses: actions/setup-go@v7
-        with:
-          go-version-file: go.mod
-          cache: true
+      - uses: ./.github/actions/setup-go
 
       # The coverage test fails first (and with a clearer message) if a new
       # CERBERUS_* env var was added with no EnvDoc metadata: the doc gate

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -136,10 +136,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
-      - uses: actions/setup-go@v7
-        with:
-          go-version-file: 'go.mod'
-          cache: true
+      - uses: ./.github/actions/setup-go
 
       - name: Test coverage gates
         run: |
@@ -188,10 +185,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
-      - uses: actions/setup-go@v7
-        with:
-          go-version-file: 'go.mod'
-          cache: true
+      - uses: ./.github/actions/setup-go
 
       - uses: taiki-e/install-action@ba47c86ac325773530516bb756137ac718732518  # v2.86.5
         with:
@@ -234,10 +228,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
-      - uses: actions/setup-go@v7
-        with:
-          go-version-file: 'go.mod'
-          cache: true
+      - uses: ./.github/actions/setup-go
 
       - uses: taiki-e/install-action@ba47c86ac325773530516bb756137ac718732518  # v2.86.5
         with:
@@ -322,10 +313,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
-      - uses: actions/setup-go@v7
-        with:
-          go-version-file: 'go.mod'
-          cache: true
+      - uses: ./.github/actions/setup-go
 
       - uses: taiki-e/install-action@ba47c86ac325773530516bb756137ac718732518  # v2.86.5
         with:

--- a/.github/workflows/dependabot-tidy-nested-modules.yml
+++ b/.github/workflows/dependabot-tidy-nested-modules.yml
@@ -54,11 +54,8 @@ jobs:
           ref: ${{ github.event.pull_request.head.ref }}
           token: ${{ secrets.RELEASE_PAT || github.token }}
 
-      - uses: actions/setup-go@v7
+      - uses: ./.github/actions/setup-go
         if: steps.meta.outputs.package-ecosystem == 'go_modules'
-        with:
-          go-version-file: 'go.mod'
-          cache: true
 
       - name: go mod tidy nested modules + push fixup if needed
         if: steps.meta.outputs.package-ecosystem == 'go_modules'

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -975,11 +975,8 @@ jobs:
         if: env.RUN_SHARD == 'true'
         uses: ./.github/actions/free-disk-space
 
-      - uses: actions/setup-go@v7
+      - uses: ./.github/actions/setup-go
         if: env.RUN_SHARD == 'true'
-        with:
-          go-version-file: 'go.mod'
-          cache: true
 
       - uses: actions/setup-node@v7
         if: env.RUN_SHARD == 'true'
@@ -1459,10 +1456,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
-      - uses: actions/setup-go@v7
-        with:
-          go-version-file: 'go.mod'
-          cache: true
+      - uses: ./.github/actions/setup-go
 
       - uses: taiki-e/install-action@ba47c86ac325773530516bb756137ac718732518  # v2.86.5
         with:
@@ -1560,10 +1554,7 @@ jobs:
       # (action only ships @main).
       - uses: ./.github/actions/free-disk-space
 
-      - uses: actions/setup-go@v7
-        with:
-          go-version-file: 'go.mod'
-          cache: true
+      - uses: ./.github/actions/setup-go
 
       # node for chaos-run.mjs (node: builtins only — no npm install).
       - uses: actions/setup-node@v7
@@ -1725,10 +1716,7 @@ jobs:
       # SHA (action only ships @main).
       - uses: ./.github/actions/free-disk-space
 
-      - uses: actions/setup-go@v7
-        with:
-          go-version-file: 'go.mod'
-          cache: true
+      - uses: ./.github/actions/setup-go
 
       # node for .github/scripts/e2e-bwc-verify-placement.mjs (node: builtins
       # only — no npm install).

--- a/.github/workflows/migration-e2e.yml
+++ b/.github/workflows/migration-e2e.yml
@@ -104,10 +104,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
-      - uses: actions/setup-go@v7
-        with:
-          go-version-file: 'go.mod'
-          cache: true
+      - uses: ./.github/actions/setup-go
 
       - name: enumerate migration scenarios
         run: |
@@ -159,10 +156,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
-      - uses: actions/setup-go@v7
-        with:
-          go-version-file: 'go.mod'
-          cache: true
+      - uses: ./.github/actions/setup-go
 
       - name: download migration scenarios enumeration
         uses: actions/download-artifact@v8
@@ -254,10 +248,7 @@ jobs:
       # reclaim, pinned to a commit SHA (the action only ships @main).
       - uses: ./.github/actions/free-disk-space
 
-      - uses: actions/setup-go@v7
-        with:
-          go-version-file: 'go.mod'
-          cache: true
+      - uses: ./.github/actions/setup-go
 
       - uses: taiki-e/install-action@ba47c86ac325773530516bb756137ac718732518  # v2.86.5
         with:
@@ -412,10 +403,7 @@ jobs:
       # superset of that one, so the disk pressure is strictly worse.
       - uses: ./.github/actions/free-disk-space
 
-      - uses: actions/setup-go@v7
-        with:
-          go-version-file: 'go.mod'
-          cache: true
+      - uses: ./.github/actions/setup-go
 
       - uses: taiki-e/install-action@ba47c86ac325773530516bb756137ac718732518  # v2.86.5
         with:

--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -150,13 +150,10 @@ jobs:
           # #2286+ passed only because later phases happened not to need the
           # diff path, not because the checkout was sufficient).
           fetch-depth: 0
-      - uses: actions/setup-go@v7
-        with:
-          go-version-file: 'go.mod'
-          cache: true
+      - uses: ./.github/actions/setup-go
       # We install gremlins directly via `go install` so we don't
       # depend on a third-party Action's release-download path.
-      # setup-go's module cache keeps subsequent runs fast.
+      # The setup-go composite's module cache keeps subsequent runs fast.
       # Use `--output` for structured JSON (gremlins exits 0 even
       # when `--threshold-efficacy` is violated in v0.6.0, so we
       # do the gating ourselves against the parsed JSON below).
@@ -171,8 +168,19 @@ jobs:
       #
       #   --timeout-max                  an absolute ceiling on a single
       #     mutant's test run. See the `gremlins unleash` step below.
+      # Routed through go-module-fetch.mjs because gremlins is NOT in go.mod, so
+      # the warm step in ./.github/actions/setup-go — which runs
+      # `go mod download` over the main module's own requirements — does not
+      # cover it. This is the one `go install` in the tree, and it fetches from
+      # sum.golang.org and proxy.golang.org exactly like any other module fetch:
+      # run 33084966918 died on `reading https://sum.golang.org/tile/8/0/x227/070:
+      # stream error: stream ID 3; INTERNAL_ERROR; received from peer` before a
+      # single mutant ran. The wrapper's never-retry set is what keeps a bad
+      # version pin, or gremlins failing to COMPILE, from being retried.
       - name: install gremlins
-        run: go install github.com/tsouza/gremlins/cmd/gremlins@v0.6.0-cerberus-timeout-max-consume
+        run: >
+          node .github/scripts/go-module-fetch.mjs --
+          go install github.com/tsouza/gremlins/cmd/gremlins@v0.6.0-cerberus-timeout-max-consume
       # `workers: 0` keeps gremlins' default (runtime.NumCPU()); a
       # non-zero value caps the parallel `go test` fan-out per the
       # comment above the matrix entry.

--- a/.github/workflows/perf-benchmark.yml
+++ b/.github/workflows/perf-benchmark.yml
@@ -83,10 +83,7 @@ jobs:
           fetch-depth: 0
 
       - if: env.RUN_HEAVY == 'true'
-        uses: actions/setup-go@v7
-        with:
-          go-version-file: 'go.mod'
-          cache: true
+        uses: ./.github/actions/setup-go
 
       - name: install benchstat
         if: env.RUN_HEAVY == 'true'

--- a/.github/workflows/perf-nightly-selfcheck.yml
+++ b/.github/workflows/perf-nightly-selfcheck.yml
@@ -65,10 +65,7 @@ jobs:
           # SAME `just perf-nightly-integration` recipe.
           lfs: true
 
-      - uses: actions/setup-go@v7
-        with:
-          go-version-file: 'go.mod'
-          cache: true
+      - uses: ./.github/actions/setup-go
 
       - uses: taiki-e/install-action@ba47c86ac325773530516bb756137ac718732518  # v2.86.5
         with:

--- a/.github/workflows/perf-nightly.yml
+++ b/.github/workflows/perf-nightly.yml
@@ -66,10 +66,7 @@ jobs:
           # `lfs: true` on every checkout.
           lfs: true
 
-      - uses: actions/setup-go@v7
-        with:
-          go-version-file: 'go.mod'
-          cache: true
+      - uses: ./.github/actions/setup-go
 
       - uses: taiki-e/install-action@ba47c86ac325773530516bb756137ac718732518  # v2.86.5
         with:

--- a/.github/workflows/perf-profile.yml
+++ b/.github/workflows/perf-profile.yml
@@ -188,10 +188,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
-      - uses: actions/setup-go@v7
-        with:
-          go-version-file: 'go.mod'
-          cache: true
+      - uses: ./.github/actions/setup-go
 
       - uses: taiki-e/install-action@ba47c86ac325773530516bb756137ac718732518  # v2.86.5
         with:
@@ -267,10 +264,7 @@ jobs:
           SHARDS_RESULT: ${{ needs.profile-shard.result }}
 
       - if: env.RUN_HEAVY == 'true'
-        uses: actions/setup-go@v7
-        with:
-          go-version-file: 'go.mod'
-          cache: true
+        uses: ./.github/actions/setup-go
 
       - name: Download shard profiles
         if: env.RUN_HEAVY == 'true'

--- a/.github/workflows/post-merge-drift.yml
+++ b/.github/workflows/post-merge-drift.yml
@@ -71,10 +71,7 @@ jobs:
           # change set at all.
           fetch-depth: 0
 
-      - uses: actions/setup-go@v7
-        with:
-          go-version-file: 'go.mod'
-          cache: true
+      - uses: ./.github/actions/setup-go
 
       - name: Derive the shards this merge implies
         id: plan
@@ -123,10 +120,7 @@ jobs:
           # so a shallow checkout would leave a real drift unable to name it.
           fetch-depth: 0
 
-      - uses: actions/setup-go@v7
-        with:
-          go-version-file: 'go.mod'
-          cache: true
+      - uses: ./.github/actions/setup-go
 
       - uses: taiki-e/install-action@ba47c86ac325773530516bb756137ac718732518  # v2.86.5
         with:
@@ -206,10 +200,7 @@ jobs:
         with:
           ref: ${{ github.sha }}
 
-      - uses: actions/setup-go@v7
-        with:
-          go-version-file: 'go.mod'
-          cache: true
+      - uses: ./.github/actions/setup-go
 
       - uses: taiki-e/install-action@ba47c86ac325773530516bb756137ac718732518  # v2.86.5
         with:
@@ -279,10 +270,7 @@ jobs:
           # baseline's inputs.
           fetch-depth: 0
 
-      - uses: actions/setup-go@v7
-        with:
-          go-version-file: 'go.mod'
-          cache: true
+      - uses: ./.github/actions/setup-go
 
       - uses: taiki-e/install-action@ba47c86ac325773530516bb756137ac718732518  # v2.86.5
         with:

--- a/.github/workflows/property.yml
+++ b/.github/workflows/property.yml
@@ -142,10 +142,7 @@ jobs:
         run: node .github/scripts/property-run-heavy.mjs
 
       - if: steps.run_heavy.outputs.run_heavy == 'true'
-        uses: actions/setup-go@v7
-        with:
-          go-version-file: 'go.mod'
-          cache: true
+        uses: ./.github/actions/setup-go
 
       - if: steps.run_heavy.outputs.run_heavy == 'true'
         uses: taiki-e/install-action@ba47c86ac325773530516bb756137ac718732518  # v2.86.5

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -387,10 +387,7 @@ jobs:
           # stable computation below see the full tag history.
           fetch-depth: 0
 
-      - uses: actions/setup-go@v7
-        with:
-          go-version-file: 'go.mod'
-          cache: true
+      - uses: ./.github/actions/setup-go
 
       - uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8  # v4
 

--- a/.github/workflows/schema-integration.yml
+++ b/.github/workflows/schema-integration.yml
@@ -105,10 +105,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
-      - uses: actions/setup-go@v7
-        with:
-          go-version-file: 'go.mod'
-          cache: true
+      - uses: ./.github/actions/setup-go
 
       - uses: taiki-e/install-action@ba47c86ac325773530516bb756137ac718732518  # v2.86.5
         with:

--- a/.github/workflows/strict-scan.yml
+++ b/.github/workflows/strict-scan.yml
@@ -107,10 +107,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
-      - uses: actions/setup-go@v7
-        with:
-          go-version-file: 'go.mod'
-          cache: true
+      - uses: ./.github/actions/setup-go
 
       - uses: taiki-e/install-action@ba47c86ac325773530516bb756137ac718732518  # v2.86.5
         with:

--- a/.github/workflows/update-golden.yml
+++ b/.github/workflows/update-golden.yml
@@ -137,7 +137,7 @@ jobs:
           persist-credentials: false
           path: target
 
-      - uses: actions/setup-go@v7
+      - uses: ./.github/actions/setup-go
         with:
           go-version-file: target/go.mod
           # Target-branch code runs below. A shared dependency cache would let
@@ -266,7 +266,7 @@ jobs:
           persist-credentials: false
           path: target
 
-      - uses: actions/setup-go@v7
+      - uses: ./.github/actions/setup-go
         with:
           go-version-file: target/go.mod
           cache: false
@@ -370,7 +370,7 @@ jobs:
           persist-credentials: false
           path: target
 
-      - uses: actions/setup-go@v7
+      - uses: ./.github/actions/setup-go
         with:
           go-version-file: target/go.mod
           cache: false

--- a/.github/workflows/update-golden.yml
+++ b/.github/workflows/update-golden.yml
@@ -137,13 +137,35 @@ jobs:
           persist-credentials: false
           path: target
 
-      - uses: ./.github/actions/setup-go
+      # Deliberately NOT ./.github/actions/setup-go, and the only three jobs in
+      # the repository that reach the Action directly. Target-branch code runs
+      # below under the default branch's privileges, so this job is a trust
+      # boundary and every step after that checkout has to be legible as one.
+      #
+      # `cache: false` is the load-bearing half: a shared dependency cache would
+      # let target-branch code persist bytes into later workflows, crossing the
+      # read-only boundary this job exists to provide. Written as a LITERAL, and
+      # that is what the composite cannot offer — routed through it the value
+      # arrives at the Action as `${{ inputs.cache }}`, which no static analysis
+      # can resolve to false, and CodeQL's cache-poisoning query then reports
+      # this repository's most privileged workflow as poisonable in all three of
+      # its regenerating jobs. A job that cannot write the cache cannot poison
+      # it, and saying so in a way a reader and a scanner both see is worth more
+      # here than the indirection.
+      #
+      # The composite's OTHER half is kept, explicitly: the warm step below runs
+      # the same retry-hardened fetch, in the target checkout whose go.mod
+      # selected the toolchain. `assert-go-setup-hardened.mjs` requires exactly
+      # this pairing of a direct, cache-less setup with a warm step in the same
+      # job.
+      - uses: actions/setup-go@v7
         with:
           go-version-file: target/go.mod
-          # Target-branch code runs below. A shared dependency cache would let
-          # that code persist bytes into later workflows, crossing the exact
-          # read-only boundary this job is meant to provide.
           cache: false
+
+      - name: Warm the Go module cache
+        working-directory: target
+        run: node "$GITHUB_WORKSPACE/.github/scripts/go-module-fetch.mjs"
 
       - uses: taiki-e/install-action@ba47c86ac325773530516bb756137ac718732518  # v2.86.5
         with:
@@ -266,10 +288,17 @@ jobs:
           persist-credentials: false
           path: target
 
-      - uses: ./.github/actions/setup-go
+      # Direct, cache-less, warmed — see the `regenerate` job above for why
+      # this trust boundary spells the value out instead of routing it through
+      # ./.github/actions/setup-go.
+      - uses: actions/setup-go@v7
         with:
           go-version-file: target/go.mod
           cache: false
+
+      - name: Warm the Go module cache
+        working-directory: target
+        run: node "$GITHUB_WORKSPACE/.github/scripts/go-module-fetch.mjs"
 
       - uses: taiki-e/install-action@ba47c86ac325773530516bb756137ac718732518  # v2.86.5
         with:
@@ -370,10 +399,17 @@ jobs:
           persist-credentials: false
           path: target
 
-      - uses: ./.github/actions/setup-go
+      # Direct, cache-less, warmed — see the `regenerate` job above for why
+      # this trust boundary spells the value out instead of routing it through
+      # ./.github/actions/setup-go.
+      - uses: actions/setup-go@v7
         with:
           go-version-file: target/go.mod
           cache: false
+
+      - name: Warm the Go module cache
+        working-directory: target
+        run: node "$GITHUB_WORKSPACE/.github/scripts/go-module-fetch.mjs"
 
       - uses: taiki-e/install-action@ba47c86ac325773530516bb756137ac718732518  # v2.86.5
         with:

--- a/docs/migration-testing.md
+++ b/docs/migration-testing.md
@@ -995,7 +995,7 @@ jobs:
     outputs: { tiers: ${{ steps.emit.outputs.tiers }} }
     steps:
       - uses: actions/checkout@v7
-      - uses: actions/setup-go@v7
+      - uses: ./.github/actions/setup-go
       - run: go run ./test/e2e/migration/cmd/scenarios --out build/migration-scenarios.json
       - run: node .github/scripts/migration-e2e.mjs   # story <-> scenario cover
         env: { MODE: verify, SCENARIOS_JSON: build/migration-scenarios.json }
@@ -1010,7 +1010,7 @@ jobs:
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@v7
-      - uses: actions/setup-go@v7
+      - uses: ./.github/actions/setup-go
       - run: node .github/scripts/migration-artifact.mjs   # resolve the CLI under test
       - run: node .github/scripts/migration-e2e.mjs
         env: { MODE: run, SCENARIOS_JSON: build/migration-scenarios.json, TIER: tier0, STORY: ${{ inputs.story }} }

--- a/test/regression/coverage_pr_gate_test.go
+++ b/test/regression/coverage_pr_gate_test.go
@@ -12,10 +12,14 @@ const (
 	// plus the parallel `coverage-default`/`coverage-chdb` lane jobs and a
 	// `coverage` aggregator. The structural checks this test pins moved to
 	// coverage-plan with them.
-	coverageJobName    = "coverage-plan"
-	coverageGateTest   = "node --test .github/scripts/coverage-package-floor.test.mjs"
-	coverageGateRun    = "node .github/scripts/coverage-package-floor.mjs"
-	coverageSetupGo    = "uses: actions/setup-go@v7"
+	coverageJobName  = "coverage-plan"
+	coverageGateTest = "node --test .github/scripts/coverage-package-floor.test.mjs"
+	coverageGateRun  = "node .github/scripts/coverage-package-floor.mjs"
+	// Go setup reaches the upstream Action only through the local composite
+	// (tsouza/cerberus#2676), which warms GOMODCACHE so no job can archive an
+	// empty module cache. `assert-go-setup-hardened.mjs` is what keeps every
+	// call site on that path; this constant just has to name the same one.
+	coverageSetupGo    = "uses: ./.github/actions/setup-go"
 	coverageHeavyGuard = "if: steps.run_heavy.outputs.run_heavy == 'true'"
 )
 


### PR DESCRIPTION
## The failure

`actions/setup-go` saves its module cache keyed on go.sum, **only on a primary-key MISS**, and
without ever checking that there is anything to save.

`post-merge-drift.yml`'s `plan` job set it up with `cache: true`, ran no Go command at all, and won
the save race on `refs/heads/main` after #2525's go.sum bump. Run
[32705099037](https://github.com/tsouza/cerberus/actions/runs/32705099037) says it verbatim:

```text
[warning]Cache folder path is retrieved but doesn't exist on disk: /home/runner/go/pkg/mod
Cache saved with the key: setup-go-Linux-x64-ubuntu24-go-1.26.2-29abba13…
```

That wrote a **7,616-byte** archive under the go.sum-keyed primary key on main. From that moment
every job in the repo — on main, and on every PR ref that falls back to main's cache scope — got an
exact hit on the empty entry, restored nothing, and declined to save ("Cache hit occurred on the
primary key …, not saving cache"). Permanent until go.sum changed again.

Consequence: all 51 setup-go call sites ran cold and re-fetched ~340 modules per job. The Go module
resolver does not retry past a dropped HTTP/2 frame, so one
`INTERNAL_ERROR; received from peer` in a five-minute download stream killed the job. Seven died in
one afternoon:

| run | job | failure |
| --- | --- | --- |
| 33080257221 | `coverage-plan` | `go list -tags chdb,agpl_oracle` after 5m21s of `go: downloading` |
| 33084966918 | `install gremlins` | `reading https://sum.golang.org/tile/8/0/x227/070: stream error: stream ID 3` |
| 33084966918 | `gremlins unleash` ×3 | `autoexport@v0.70.0` `.mod`, `stdoutlog@v0.21.0` `.zip` |
| 33093118010 | `probe` | `go-sqlbuilder@v1.27.3` `.zip`, stream ID 115 |

Every one of them logged `Cache Size: ~0 MB (7616 B)` first.

## The fix — one mechanism at the root

`cache: false` on the one offending job was rejected deliberately: it is the per-leg patch this repo
does not take. The next Go-less job with `cache: true` re-poisons silently, and nothing would assert
otherwise.

1. **`.github/actions/setup-go`** — a composite wrapping `actions/setup-go@v7` followed by an
   **unconditional** warm step. By the time the post-job save looks at GOMODCACHE it is never empty,
   so no job can poison the cache **by construction** — Go-less jobs included. 47 call sites move to
   it; `go-version-file` also selects the directory the warm step runs in. `update-golden.yml`'s
   three jobs are the deliberate exception — see below.
2. **`.github/scripts/go-module-fetch.mjs`** — the single retry wrapper, importing the **existing**
   policy from `lib/registry.mjs` (`registryAttempts`, `readBackoffStepSeconds`, `sleepSeconds`,
   `isTransientRegistryFailure`, whose pattern list already carried the exact Go-proxy signatures).
   No second helper. It adds only the class `registry.mjs` has no analogue for:
   `goFetchNeverRetryable()` — `SECURITY ERROR` / checksum mismatch, `404`, `410`,
   `unknown revision`, `invalid version`, `no matching versions`, `missing go.sum entry` — asked
   **first** and winning outright, on the same reasoning that makes a rate limit win there.
3. **`.github/scripts/assert-go-setup-hardened.mjs`** — the ratchet, modelled on
   `assert-image-jobs-authenticate.mjs`. It parses every workflow into per-job step blocks and every
   composite action, and asserts five rules. Wired into `ci.yml`'s existing `forbid-skip` gate job.

   - **R1** a step reaching `actions/setup-go` directly sets `cache: false` as a **literal**
   - **R2** the job holding such a step also runs `go-module-fetch.mjs`
   - **R3** no composite action other than the wrapper uses the Action at all
   - **R4** the wrapper delegates, warms, its warm step carries **no `if:`**, and its metadata holds
     no `${{ … }}`
   - **R5** at least one step actually uses the wrapper (non-vacuity)

   R1 is keyed on the **mechanism**, not on the Action's name: a step that never saves the shared
   cache cannot poison it, so it is outside the rule's subject rather than exempted from it. The
   gate never demands `cache: true`.
4. **`mutation.yml`** — the `go install` of the gremlins fork routes through the wrapper. A tool
   outside go.mod is not covered by `go mod download`, and that is the exact step run 33084966918
   died on.

There is **no allow-list**. The one file permitted to name `actions/setup-go` *unconditionally* is
permitted by *identity*: it is the wrapper's own `action.yml`, the definition site of the thing the
rule is about, which cannot be a call site of itself — the same structural distinction
`assert-image-jobs-authenticate.mjs` draws between declaring `pullImageWithRetry` and calling it.

## Why update-golden.yml keeps the Action directly

The first push routed its three regenerating jobs through the composite too. CodeQL immediately
reported **3 new high alerts** — `actions/cache-poisoning/poisonable-step`, one per job. It was
right to: those jobs check out **target-branch code under the default branch's privileges**, and
`cache: false` is the trust boundary that stops that code persisting bytes into later workflows.
Routed through the composite the value reaches the Action as `${{ inputs.cache }}`, which no static
analysis can resolve — so the boundary became invisible to the scanner.

A trust boundary has to be legible to a reader and to a scanner alike, so those three spell the
literal out and keep the composite's *other* half explicitly:

```yaml
      - uses: actions/setup-go@v7
        with:
          go-version-file: target/go.mod
          cache: false

      - name: Warm the Go module cache
        working-directory: target
        run: node "$GITHUB_WORKSPACE/.github/scripts/go-module-fetch.mjs"
```

R1 + R2 above are exactly that pairing, so it is required rather than tolerated.

### And one self-inflicted lesson, now gated

The commit that added that explanation put it in the input's own `description:`, quoting the
expression the value arrives as. GitHub **template-evaluates an action manifest's metadata**, and
`inputs` is not a valid named-value there — so the quotation did not render as prose, it failed the
manifest to *load*:

```text
Unrecognized named-value: 'inputs'. Located at position 1 within expression: inputs.cache
```

26 jobs died on it before their first Go command. The explanation moved to a `#` comment, and the
ratchet grew a rule: **no `${{ … }}` above the wrapper's `runs:` block**. Its test doctors the real
manifest with exactly the description that broke CI, and asserts in the same breath that an
expression *below* `runs:` — the required way to forward an input — is never reported.

## Why retry cannot mask a real failure

Three independent layers, each testable, each asserted on the **attempt count** rather than the exit
code — a wrapper that retried a real error five times and then failed would look identical on the
exit code alone.

- **(a) Scope.** Only a fetch-only command may be wrapped, enforced in `isFetchOnly()` rather than
  trusted to the call sites. `go test`, `go list`, `go build`, `just <recipe>` and
  `gremlins unleash` are unwrappable by construction and still fail on attempt 1 — they simply stop
  needing the network.
- **(b) Classify.** A retry requires an `isTransientRegistryFailure()` match. A Go compile error
  matches nothing on that list.
- **(c) Never-retry**, evaluated first and winning even when the output also names a transport
  fault. Retrying a checksum refusal is the one behaviour that would be actively dangerous.

## Two things settled inside the PR, not after

- **Does plain `go mod download` reach the three modules that actually failed?** Yes, verified by
  running it: `go mod download -json` covers **337** modules and all three —
  `github.com/huandu/go-sqlbuilder`, `go.opentelemetry.io/contrib/exporters/autoexport`,
  `go.opentelemetry.io/otel/exporters/stdout/stdoutlog` — are among them. A `go 1.17`-or-later
  module downloads every explicit requirement, `// indirect` entries included. `all` would add the
  test dependencies OF dependencies and is not needed.
- **The poisoned entry is deleted.** `gh api -X DELETE .../actions/caches?key=…29abba13…&ref=refs/heads/main`
  removed it; `refs/heads/main` now holds one setup-go entry, 228,436,082 bytes. main repopulates a
  real cache on its next run instead of waiting for the next go.sum bump.

## Test plan

Two new `node --test` suites, both revert-checked.

**`go-module-fetch.test.mjs`** — 20 cases. Positive fixtures are the **verbatim** stderr from runs
33080257221 / 33084966918 / 33093118010; negatives are 404, 410, unknown revision, no matching
versions, checksum mismatch, missing go.sum entry, and a Go compile error.

- With the fix: `tests 20, pass 20, fail 0`.
- Revert-check 1 — retry neutralised (`attempts = 1`): `pass 10, fail 10`. Every transport-fault
  case and the backoff case go red.
- Revert-check 2 — layer (c) disabled (`if (false && goFetchNeverRetryable(...))`): `pass 13,
  fail 7`. All six never-retry fixtures plus the "checksum refusal that also names a transport
  fault" ordering case go red.

**`assert-go-setup-hardened.test.mjs`** — 17 cases, each doctoring the **real** workflow/action text
rather than a hand-written fixture.

- With the fix: `tests 17, pass 17, fail 0`.
- Revert-check — `post-merge-drift.yml` restored to its pre-fix state
  (`git show HEAD:… > …`): the gate itself exits **1** with four `::error::` annotations naming
  lines 74/126/209/282, and the suite goes `pass 6, fail 7`. Restored, back to green.
- Negative controls: a call site reverted to `actions/setup-go@v7` with `cache: true`, a bare
  `actions/setup-go` with no `with:` at all, a **templated** `cache:` value (the exact shape CodeQL
  could not read), all three `cache: false` jobs stripped of their warm step, a sibling composite
  action reaching for the Action directly even with `cache: false`, the wrapper's warm step deleted,
  the warm step made conditional, the wrapper not delegating, the wrapper missing, and a tree where
  nothing sets Go up at all, and a `${{ … }}` written into the wrapper's input description.
- Over-reach controls: `update-golden.yml`'s three direct call sites stay green, and the per-job
  step-block scoping is pinned so a warm step in one job cannot satisfy a direct setup in another.

**Existing gates re-run, all green:**

- `node .github/scripts/assert-image-jobs-authenticate.mjs` — 22 image-acquiring jobs, unchanged.
- `node .github/scripts/assert-go-setup-hardened.mjs` — 47 call sites on the warming path, 3 direct
  under a literal `cache: false`.
- `node .github/scripts/doc-refs.mjs`, `doc-counts.mjs`, `ci-lane-contract.mjs`.
- `CHECK=all node .github/scripts/forbid-skip.mjs`.
- `just lint-actions` (actionlint).
- `go test ./test/regression/` — `ok`, including
  `TestCoveragePRGateIsNotConditionedOnHeavyCoverage`, whose pinned constant moved to the composite.
- `markdownlint-cli2` on the two touched Markdown files.

Closes #2676
