### PR TITLE
fix(routememo): require corroboration before BothFail, and record why Key fuses group-by

### DIFF
--- a/internal/engine/route_memo_wiring_test.go
+++ b/internal/engine/route_memo_wiring_test.go
@@ -824,9 +824,25 @@ func TestTryRouteMemoHit_MidDrainResourceFailure_ObserveViaClassify(t *testing.T
 	// failure: classify the real error and Observe it.
 	memo.Observe(gotKey, routememo.RouteB, classifyRouteOutcome(routememo.RouteB, drainErr))
 
+	// One drained route-B resource failure must NOT reach BothFail: that
+	// verdict suppresses all further probing for the whole TTL and no route-A
+	// failure refreshes it, so it needs the same corroboration a route-A
+	// failure needs before it earns probe eligibility (#2684). The first
+	// failure demotes the seeded PreferB to Unknown carrying the count, which
+	// already stops the memo preferring route B — so this is not a licence to
+	// spend a second K-shard dispatch on the memo's say-so.
+	if state, _ := memo.Lookup(gotKey); state == routememo.BothFail {
+		t.Errorf("one drained route-B resource failure locked the key out (%v)", state)
+	}
+
+	// The classify-then-Observe wiring this test exists to exercise must still
+	// carry a resource failure all the way to the terminal verdict, so drive
+	// the second one and assert it lands.
+	memo.Observe(gotKey, routememo.RouteB, classifyRouteOutcome(routememo.RouteB, drainErr))
+
 	state, _ := memo.Lookup(gotKey)
 	if state != routememo.BothFail {
-		t.Errorf("verdict after the drained route-B resource failure = %v, want BothFail", state)
+		t.Errorf("verdict after two drained route-B resource failures = %v, want BothFail", state)
 	}
 }
 

--- a/internal/routememo/key.go
+++ b/internal/routememo/key.go
@@ -95,10 +95,16 @@ const (
 // Key is comparable (usable as a Go map key): every field is a primitive,
 // a bool, or a string built only from closed query-language vocabulary
 // (function names, operator kinds) — never a metric name, label name,
-// label value, or timestamp. This is the same category of information
-// planShapeID (internal/engine/plan_shape_id.go) already exposes at a
-// coarser grain, and no coarser than ClickHouse's own normalized
-// query_log text.
+// label value, or timestamp. It carries the same CATEGORY of information
+// planShapeID (internal/engine/plan_shape_id.go) exposes, and no more than
+// ClickHouse's own normalized query_log text.
+//
+// It is NOT uniformly finer-grained than planShapeID, and on one axis it is
+// deliberately coarser: the group-by set contributes nothing. planShapeID
+// emits `agg=<arity>` and so separates `sum by(le)` from `sum by(le,uri)`;
+// this Key fuses them (see GroupBy under [keyWalker.walk]). That fusion is
+// intentional, not an oversight — the reasoning is recorded on the walker's
+// Aggregate arm, and it is the subject of #2684.
 type Key struct {
 	// RootKind is the plan root node's Go type name (e.g. "*chplan.Aggregate").
 	RootKind string
@@ -210,6 +216,33 @@ func (w *keyWalker) walk(n chplan.Node) {
 			for _, fn := range v.AggFuncs {
 				w.aggFuncs = append(w.aggFuncs, string(fn.Fn))
 			}
+			// v.GroupBy is READ DELIBERATELY NOT AT ALL, so `sum by(le)` and
+			// `sum by(le,uri)` share a Key (#2684).
+			//
+			// Route B's only decomposition is anchor-grid partitioning, and the
+			// bound it relieves is `(groups x anchors) + (rawRows x width^2)`.
+			// Slicing divides anchors and rawRows; it never divides groups. The
+			// group count is therefore a common factor that sharding relieves
+			// proportionally, so the verdict this memo actually records —
+			// "sharding relieves this bound for this cost geometry" — transfers
+			// across by() arity rather than being specific to it. Separating on
+			// grouping would add a term the routing decision does not depend on,
+			// and the cost of that is concrete: a rarely-refreshed expensive
+			// panel earns most of its benefit from a sibling shape priming the
+			// key first, which arity would cut.
+			//
+			// Arity would also be a poor proxy for the worry it answers:
+			// `by(uri)` and `by(pod)` are both arity 1 and can differ in
+			// cardinality by orders of magnitude, so they would still collide.
+			// It separates only the subset case.
+			//
+			// This is safe because the memo never decides alone.
+			// deriveRouteMemoDispatch re-derives Solver.Eligible on the ACTUAL
+			// plan at every dispatch, and the density guard is an emit-time
+			// throwIf measuring the real per-statement cost, so a memo hit
+			// cannot route a plan the solver rejects or slip a query past the
+			// bound. The blast radius of a wrong hit is a wasted route-B attempt
+			// that falls back to route A, never a wrong answer.
 		case *chplan.VectorJoin:
 			w.hasJoin = true
 		case *chplan.UnionAll:

--- a/internal/routememo/memo.go
+++ b/internal/routememo/memo.go
@@ -426,6 +426,28 @@ func (m *Memo) observeRouteBLocked(k Key, now time.Time, outcome Outcome) {
 	case OutcomeSuccess:
 		m.entries[k] = &Verdict{state: PreferB, createdAt: now}
 	case OutcomeResourceFailure:
+		// BothFail needs the SAME corroboration route-A failures need before
+		// they earn probe eligibility. Writing it on the first failure was the
+		// memo's one un-damped transition, and it is also its most destructive:
+		// BothFail suppresses all further probing and no route-A failure
+		// refreshes it, so a single route-B rejection cost every shape sharing
+		// this Key its working PreferB verdict for the whole TTL. That
+		// asymmetry bit hardest exactly where the Key is coarsest — the
+		// group-by fusion of #2684 — because the failing shape and the
+		// demoted one need not be the same query.
+		//
+		// A first failure demotes to Unknown carrying the count, so the next
+		// dispatch re-derives eligibility and may probe again; the second
+		// consecutive one locks out. A success anywhere resets by replacing
+		// the entry outright.
+		if v, ok := m.entries[k]; ok && v.state != BothFail && v.corroboration+1 < minCorroboratingFailures {
+			m.entries[k] = &Verdict{state: Unknown, createdAt: now, corroboration: v.corroboration + 1}
+			break
+		}
+		if _, ok := m.entries[k]; !ok && minCorroboratingFailures > 1 {
+			m.entries[k] = &Verdict{state: Unknown, createdAt: now, corroboration: 1}
+			break
+		}
 		m.entries[k] = &Verdict{state: BothFail, createdAt: now}
 	default:
 		return

--- a/internal/routememo/memo_test.go
+++ b/internal/routememo/memo_test.go
@@ -722,3 +722,51 @@ func TestSetEntryTTLAndSetReValidationFractionNoOpOnNonPositiveInput(t *testing.
 		}
 	}
 }
+
+// TestSingleRouteBFailureDoesNotLockOutTheKey pins the corroboration floor on
+// the BothFail transition (#2684).
+//
+// BothFail is the memo's most destructive verdict: it suppresses all further
+// probing and no route-A failure refreshes it, so it holds for the full TTL.
+// It used to be written on the FIRST route-B resource failure, while route-A
+// failures needed minCorroboratingFailures before they earned so much as probe
+// eligibility. Because the Key deliberately fuses group-by shapes, the query
+// that failed and the query that lost its verdict need not be the same one.
+func TestSingleRouteBFailureDoesNotLockOutTheKey(t *testing.T) {
+	t.Parallel()
+
+	m := New(time.Minute)
+	k := Key{RootKind: "*chplan.Aggregate", AggFuncs: "sum"}
+
+	m.Observe(k, RouteB, OutcomeResourceFailure)
+	if state, _ := m.Lookup(k); state == BothFail {
+		t.Fatal("one route-B resource failure locked the key out; BothFail must need the same\n" +
+			"corroboration a route-A failure needs, or a single transient rejection strips every\n" +
+			"shape sharing this Key of a working verdict for the whole TTL")
+	}
+
+	m.Observe(k, RouteB, OutcomeResourceFailure)
+	if state, _ := m.Lookup(k); state != BothFail {
+		t.Errorf("two consecutive route-B resource failures must reach BothFail, got %v", state)
+	}
+}
+
+// TestRouteBSuccessClearsAccumulatedFailure pins that the damping cannot strand
+// a key: a success resets the count rather than leaving it one failure from
+// lockout forever.
+func TestRouteBSuccessClearsAccumulatedFailure(t *testing.T) {
+	t.Parallel()
+
+	m := New(time.Minute)
+	k := Key{RootKind: "*chplan.Aggregate", AggFuncs: "sum"}
+
+	m.Observe(k, RouteB, OutcomeResourceFailure)
+	m.Observe(k, RouteB, OutcomeSuccess)
+	if state, _ := m.Lookup(k); state != PreferB {
+		t.Fatalf("a success must replace the accumulated failure, got %v", state)
+	}
+	m.Observe(k, RouteB, OutcomeResourceFailure)
+	if state, _ := m.Lookup(k); state == BothFail {
+		t.Error("the failure count survived a success, so the key locks out one failure early")
+	}
+}


### PR DESCRIPTION
## Summary

#2684 asked whether `KeyFor` ignoring the group-by set is a defect. Measurement
says the fusion is **deliberate and sound**, and that the real defect sits next
to it.

## The fusion is correct, and now says so

Route B's only decomposition is anchor-grid partitioning, and the bound it
relieves is `(groups x anchors) + (rawRows x width^2)`. Slicing divides
**anchors and rawRows, never groups**. Group count is therefore a common factor
that sharding relieves proportionally: if `sum by(le,uri)` busts the bound on
route A and K-way slicing fixes it, the same inference holds for `sum by(le)`.
The verdict this memo records — "sharding relieves this bound for this cost
geometry" — genuinely transfers across `by()` arity.

Separating on grouping would add a term the routing decision does not depend
on, which is the textbook way to make a memo too specific to hit. The cost is
concrete: a rarely-refreshed expensive panel earns most of its benefit from a
sibling shape priming its key first, and arity would cut exactly that. Arity is
a poor proxy regardless — `by(uri)` and `by(pod)` are both arity 1 and can
differ in cardinality by orders of magnitude.

It is also safe because the memo never decides alone.
`deriveRouteMemoDispatch` re-derives `Solver.Eligible` on the **actual** plan at
every dispatch, and the density guard is an emit-time `throwIf` measuring real
per-statement cost. A memo hit cannot route a plan the solver rejects, nor slip
a query past the bound. Worst case for a wrong hit is a wasted route-B attempt
that falls back to route A — never a wrong answer, never a query that fails
where it previously succeeded.

Two of the issue's three arguments do not survive checking. In particular
bullet 3 ("a route-A success on the cheap shape drops the entry") is
unreachable in production: both `Observe(k, RouteA, OutcomeSuccess)` call sites
are on paths that require a non-nil error.

## The real defect: an un-damped BothFail

`observeRouteBLocked` wrote `BothFail` on the **first** route-B resource
failure, while route-A failures need `minCorroboratingFailures` before they
earn so much as probe eligibility. That was the memo's one un-damped
transition, and also its most destructive: `BothFail` suppresses all further
probing and no route-A failure refreshes it, so it holds for the full TTL.

Because the Key fuses group-by shapes, **the query that failed and the query
that loses its verdict need not be the same one**. One transient route-B
rejection on an expensive shape stripped every shape sharing the Key of a
working `PreferB` verdict, reverting them to pre-memo route-A behaviour.

`BothFail` now requires the same corroboration, and a success resets the count.

## A false doc claim, corrected

`Key`'s doc said it carried `planShapeID`'s information at a finer grain. On
the grouping axis the opposite is true: `planShapeID` emits `agg=<arity>` and
separates exactly what this Key fuses. A reader reasoning from that sentence
would draw the wrong conclusion about what a shared Key implies. The reasoning
for the fusion now lives on the walker arm that makes the choice, where someone
changing it will see it.

## Test plan

- [x] `TestSingleRouteBFailureDoesNotLockOutTheKey` — one route-B resource
      failure must not reach `BothFail`; two consecutive ones must.
- [x] `TestRouteBSuccessClearsAccumulatedFailure` — a success resets the count,
      so damping cannot strand a key one failure from lockout forever.
- [x] **Revert-check**: with `internal/routememo/memo.go` restored from
      `origin/main` and the tests kept, **both new tests FAIL**; restored, the
      whole package passes. They are not hollow.
- [x] `go test ./internal/routememo/ ./internal/solver/` green.

Closes #2684
