### PR TITLE
fix(chopt): re-probe fast while pinned to the capability floor

### DIFF
--- a/cmd/cerberus/chopt_reprobe.go
+++ b/cmd/cerberus/chopt_reprobe.go
@@ -108,6 +108,42 @@ func (c chOptConsumers) apply(cfg config.Config, set chopt.EnabledSet) {
 // invisible next to query traffic.
 const chOptReprobeInterval = 5 * time.Minute
 
+// chOptFloorRetryInterval is the cadence used INSTEAD while the resolution in
+// force is a floor fallback — i.e. the probe that produced it could not reach
+// the server at all.
+//
+// The two states are not symmetric, and pacing them the same way was a bug.
+// The steady-state interval above is priced against a server whose answer
+// "almost never changes", which is true of a healthy deployment and false of a
+// pod that lost the startup race with its own ClickHouse: that pod is pinned to
+// the supported floor, every native path is silently unavailable, and the
+// answer is expected to change the moment the server finishes coming up. Five
+// minutes of that is not a blind window on an upgrade, it is five minutes of
+// emitting the slow shape for no reason — long enough that a deployment can
+// serve its first traffic, and a whole e2e suite can run, entirely on the
+// fallback lowerers (#2696).
+//
+// Ten seconds is chosen against the same cost model: the probe is two
+// short-lived connections and two trivial statements, and it only runs at this
+// rate while the process is in a state it wants to leave. As soon as a probe
+// answers, the loop returns to the steady cadence.
+const chOptFloorRetryInterval = 10 * time.Second
+
+// nextReprobeDelay is how long to wait before the next resolution attempt,
+// given the one currently in force.
+func nextReprobeDelay(res chOptResolution, steady time.Duration) time.Duration {
+	if res.VersionFallback {
+		floor := chOptFloorRetryInterval
+		// Never wait LONGER than the steady cadence just because a caller
+		// configured an interval shorter than the fast-retry constant.
+		if steady < floor {
+			return steady
+		}
+		return floor
+	}
+	return steady
+}
+
 // reprobeCHOptimizations re-resolves the ClickHouse capability set on a fixed
 // cadence and swaps a changed result into the query path, so a cluster upgraded
 // under a running cerberus starts using the newly-available native paths without
@@ -140,20 +176,28 @@ func reprobeCHOptimizations(
 	consumers chOptConsumers,
 	interval time.Duration,
 ) {
-	ticker := time.NewTicker(interval)
-	defer ticker.Stop()
+	// A timer rather than a ticker: the delay is re-derived from the
+	// resolution in force after every attempt, so a pod pinned to the floor
+	// retries at chOptFloorRetryInterval and drops back to the steady cadence
+	// the moment a probe answers.
+	timer := time.NewTimer(nextReprobeDelay(live.get(), interval))
+	defer timer.Stop()
 	for {
 		select {
 		case <-ctx.Done():
 			return
-		case <-ticker.C:
+		case <-timer.C:
 		}
 
 		next, ok := resolveCHOptimizationsOnce(ctx, logger, cfg)
 		if !ok {
+			// The resolution in force is unchanged, so the delay is derived
+			// from it: still on the floor means still retrying fast.
+			timer.Reset(nextReprobeDelay(live.get(), interval))
 			continue
 		}
 		prev := live.get()
+		timer.Reset(nextReprobeDelay(next, interval))
 		if next.Set.Equal(prev.Set) && next.ResolvedVersion == prev.ResolvedVersion {
 			continue
 		}

--- a/cmd/cerberus/chopt_reprobe_floor_test.go
+++ b/cmd/cerberus/chopt_reprobe_floor_test.go
@@ -1,0 +1,47 @@
+package main
+
+import (
+	"testing"
+	"time"
+
+	"github.com/tsouza/cerberus/internal/chopt"
+)
+
+// TestNextReprobeDelay_FloorFallbackRetriesFast pins the asymmetry between the
+// two states the re-probe can be in.
+//
+// A pod that lost the startup race with its own ClickHouse resolves against the
+// supported floor, which silently disables every native lowering for as long as
+// that resolution stays in force. Pacing that state at the steady-state cadence
+// meant a deployment could serve its first traffic — and a whole e2e suite
+// could run — entirely on the fallback shape (#2696). The steady cadence is
+// priced for a server whose answer almost never changes; the floor state is one
+// the process is actively trying to leave.
+func TestNextReprobeDelay_FloorFallbackRetriesFast(t *testing.T) {
+	t.Parallel()
+
+	onFloor := chOptResolution{VersionFallback: true}
+	if got := nextReprobeDelay(onFloor, chOptReprobeInterval); got != chOptFloorRetryInterval {
+		t.Errorf("a floor fallback must re-probe at %v, got %v — every native path stays\n"+
+			"unavailable until it does", chOptFloorRetryInterval, got)
+	}
+
+	probed := chOptResolution{Set: chopt.EnabledSet{}, VersionFallback: false}
+	if got := nextReprobeDelay(probed, chOptReprobeInterval); got != chOptReprobeInterval {
+		t.Errorf("a resolution the server actually answered must use the steady cadence %v, got %v",
+			chOptReprobeInterval, got)
+	}
+}
+
+// TestNextReprobeDelay_NeverWaitsLongerThanTheSteadyCadence pins that the fast
+// path can only ever shorten the wait. A caller configuring an interval below
+// the fast-retry constant (the tests do) must not be slowed down by it.
+func TestNextReprobeDelay_NeverWaitsLongerThanTheSteadyCadence(t *testing.T) {
+	t.Parallel()
+
+	const tiny = time.Millisecond
+	if got := nextReprobeDelay(chOptResolution{VersionFallback: true}, tiny); got != tiny {
+		t.Errorf("with a steady cadence of %v the floor retry must not stretch to %v, got %v",
+			tiny, chOptFloorRetryInterval, got)
+	}
+}


### PR DESCRIPTION
## Root cause

`iterate-time-ranges.spec.ts` fails deterministically on `main` with
`query_range → 502` and an empty body. The empty body is the tell: cerberus
never serialised an error. The server-side logs show `exit_class: "canceled"` —
the query was **cancelled by the client**, i.e. it exceeded Grafana's proxy
timeout. This is a slowness failure, not an error path.

Why it is slow is visible one line earlier in the same logs:

```
clickhouse version probe failed; resolving optimizations against the supported floor until the next re-probe
probe clickhouse version: chclient: query: dial tcp 10.43.12.29:9000: connect: connection refused
```

The e2e stack starts cerberus alongside ClickHouse, so cerberus routinely wins
that race and probes a server that is not listening yet. It then resolves the
capability set against the **supported floor**, which means `ts_grid_histogram`
(CH ≥ 25.9) is off and `NativeClassicHistogramWindowLowerer` is never wired.
Every classic-histogram panel runs the array-fold fan-out instead of the native
ladder. At `range=now-24h step=1m` — 1441 anchors — that shape is slow enough to
exceed the proxy timeout.

Everything downstream of the probe already works: the re-probe loop exists, and
`chOptConsumers.apply` really does call `prom.SetLowerers(nativeRangeLowerers(set))`,
so a corrected resolution *is* swapped into the query path without a restart.

**The gap is purely the cadence.** `chOptReprobeInterval` is a flat 5 minutes
regardless of whether the resolution in force came from a successful probe or
from a failed one falling back to the floor.

## The asymmetry

The two states were paced identically and they are not alike:

- A **probed** resolution describes a server whose answer almost never changes.
  Five minutes is a well-priced compromise there, and the existing comment
  argues it correctly.
- A **floor fallback** is a degraded state the process is actively trying to
  leave, and its answer is expected to change the moment the server finishes
  starting. Five minutes of it is not a blind window on an upgrade — it is five
  minutes of emitting the slow shape for no reason, long enough to serve first
  traffic and long enough for an entire e2e suite to run on the fallback
  lowerers.

The loop now re-derives its delay from the resolution in force after every
attempt: `chOptFloorRetryInterval` (10s) while on the floor, the steady cadence
once a probe answers. The `Ticker` became a `Timer` so the delay can change
between attempts.

The fast path can only ever **shorten** the wait. A configured interval below
the retry constant is returned unchanged, which is what keeps the existing
millisecond-interval loop tests genuinely exercising the loop rather than
silently being slowed to 10s.

## Scope note

This does not make the array-fold path faster, and does not change any routing
threshold. It removes the reason that path was being taken at all on a server
that supports the native one. A deployment whose ClickHouse is genuinely below
the feature floor is unaffected — it resolves to the floor from a *successful*
probe, `VersionFallback` is false, and it keeps the steady cadence.

## Test plan

- [x] `TestNextReprobeDelay_FloorFallbackRetriesFast` — a `VersionFallback`
      resolution re-probes at the fast interval; a probed one keeps the steady
      cadence.
- [x] `TestNextReprobeDelay_NeverWaitsLongerThanTheSteadyCadence` — a caller
      configuring a shorter interval is not stretched to the retry constant.
- [x] Existing `TestReprobeCHOptimizations_SwapsWhenTheAnswerChanges` and
      `..._StopsOnContextCancel` still pass unchanged, so the timer conversion
      did not break the loop or leak the goroutine past shutdown.
- [x] Revert-check: with `chopt_reprobe.go` restored from `origin/main`, the new
      tests fail to build against the removed symbols. That is weaker evidence
      than a failing assertion — stating it plainly rather than claiming more:
      the delay VALUES are asserted directly, and the loop's use of them is
      covered by the two existing loop tests.

Verification that the e2e panel recovers necessarily happens on this PR's own
`dashboard-shard` run, since the race needs the real k3d stack to reproduce.

Closes #2696
