### PR TITLE
ci(mutation): gate the timed-out share, which efficacy cannot see

### DIFF
--- a/.github/scripts/gremlins-threshold.mjs
+++ b/.github/scripts/gremlins-threshold.mjs
@@ -14,50 +14,124 @@
 // The comparison is `measured < threshold` -> FAIL (strict less-than),
 // i.e. `measured >= threshold` passes. Matches the awk `m < t` semantics.
 //
+// THE EFFICACY RATIO CANNOT SEE A TIMED-OUT MUTANT, so this gate also bounds
+// how many of them there may be.
+//
+// gremlins excludes TIMED_OUT from BOTH sides of its own verdict
+// (internal/report/report.go: `tEfficacy = killed / (killed + lived)` and
+// `MutantsTotal = lived + killed + notViable`). A mutant that timed out is
+// therefore in neither the ratio nor the total, so a leg can leave most of its
+// mutants unadjudicated and still report a high efficacy over the handful that
+// did run. This is not hypothetical: run 33126692323 passed every leg with
+// `phase2-other` at Killed 77 / Lived 1 / Timed out 262 — 98.72% efficacy over
+// 78 of 340 mutants (#2695). mutation-run.mjs's `mutants_total > 0` check only
+// catches the fully degenerate all-timeout case.
+//
+// The share is counted from `files[].mutations[].status`, the per-mutant record,
+// because no aggregate field in the report exposes it.
+//
 // Env contract:
 //   REPORT     path to the gremlins JSON report   (default: gremlins.json)
 //   THRESHOLD  efficacy floor as a number, e.g. 95
 //
-// Exit codes: 0 = efficacy >= threshold, 1 = below threshold / bad input.
+// Exit codes: 0 = efficacy >= threshold and the timed-out share is within
+// bounds, 1 = below threshold / too many timed out / bad input.
 
 import { readFileSync } from 'node:fs';
 import process from 'node:process';
+import { pathToFileURL } from 'node:url';
 import { error, notice } from './lib/gh.mjs';
 
-const reportPath = process.env.REPORT || 'gremlins.json';
-const thresholdRaw = process.env.THRESHOLD;
+// maxTimedOutShare is the fraction of a leg's mutants that may time out before
+// the leg's efficacy stops meaning anything.
+//
+// Not zero: a timeout is a legitimate outcome for a mutant that genuinely does
+// not terminate (an inverted loop-advance), which is the case MUTANT_TIMEOUT_MAX
+// exists to bound, and a healthy leg reports a few. The measured healthy shape
+// is phase4-promql-g at 8 timed out of 311 (2.6%). A quarter is far above that
+// and far below the 77% that was passing, so it separates "a few mutants are
+// pathological" from "this leg did not really run".
+const maxTimedOutShare = 0.25;
 
-if (thresholdRaw === undefined || thresholdRaw === '') {
-  error('gremlins-threshold.mjs: THRESHOLD env var is required');
-  process.exit(1);
+// timedOutStatus is the per-mutation status string gremlins writes
+// (internal/mutator/mutator.go). Matched exactly: a rename upstream must fail
+// this gate loudly rather than silently count zero timeouts forever.
+const timedOutStatus = 'TIMED OUT';
+
+// countMutationStatuses walks the per-file mutation records and returns the
+// total number of mutants and how many timed out.
+export function countMutationStatuses(report) {
+  let total = 0;
+  let timedOut = 0;
+  for (const file of report?.files ?? []) {
+    for (const m of file?.mutations ?? []) {
+      total++;
+      if (m?.status === timedOutStatus) timedOut++;
+    }
+  }
+  return { total, timedOut };
 }
 
-const threshold = Number(thresholdRaw);
-if (!Number.isFinite(threshold)) {
-  error(`gremlins-threshold.mjs: THRESHOLD="${thresholdRaw}" is not a number`);
-  process.exit(1);
+// main runs the gate. Guarded below so a test can import
+// countMutationStatuses without the import running the gate as a side effect.
+function main() {
+  const reportPath = process.env.REPORT || 'gremlins.json';
+  const thresholdRaw = process.env.THRESHOLD;
+
+  if (thresholdRaw === undefined || thresholdRaw === '') {
+    error('gremlins-threshold.mjs: THRESHOLD env var is required');
+    process.exit(1);
+  }
+
+  const threshold = Number(thresholdRaw);
+  if (!Number.isFinite(threshold)) {
+    error(`gremlins-threshold.mjs: THRESHOLD="${thresholdRaw}" is not a number`);
+    process.exit(1);
+  }
+
+  let report;
+  try {
+    report = JSON.parse(readFileSync(reportPath, 'utf8'));
+  } catch (e) {
+    error(`gremlins-threshold.mjs: cannot read/parse ${reportPath}: ${e.message}`);
+    process.exit(1);
+  }
+
+  const measured = Number(report.test_efficacy);
+  if (!Number.isFinite(measured)) {
+    // jq -r '.test_efficacy' on a missing key yields "null"; surface that.
+    error(`gremlins-threshold.mjs: .test_efficacy missing or non-numeric in ${reportPath}`);
+    process.exit(1);
+  }
+
+  // awk `m < t` -> exit 1 (fail). So measured < threshold fails the gate.
+  if (measured < threshold) {
+    error(`gremlins efficacy ${measured}% < threshold ${threshold}%`);
+    process.exit(1);
+  }
+
+  // Checked AFTER the efficacy comparison so a leg that fails both still reports
+  // the efficacy number first — that is the one an operator recognises.
+  const { total, timedOut } = countMutationStatuses(report);
+  if (total > 0) {
+    const share = timedOut / total;
+    if (share > maxTimedOutShare) {
+      error(
+        `gremlins timed out ${timedOut}/${total} mutants (${(share * 100).toFixed(1)}%), over the ` +
+          `${(maxTimedOutShare * 100).toFixed(0)}% bound. Efficacy ${measured}% is computed over the ` +
+          `killed+lived mutants ONLY, so it does not describe this leg: a timed-out mutant is in ` +
+          `neither the ratio nor mutants_total. Raise the per-mutant budget or reduce what the leg ` +
+          `mutates; do not read the efficacy above as a verdict.`,
+      );
+      process.exit(1);
+    }
+    notice(`gremlins timed out ${timedOut}/${total} mutants (${(share * 100).toFixed(1)}%)`);
+  }
+
+  notice(`gremlins efficacy ${measured}% >= threshold ${threshold}%`);
+  process.exit(0);
 }
 
-let report;
-try {
-  report = JSON.parse(readFileSync(reportPath, 'utf8'));
-} catch (e) {
-  error(`gremlins-threshold.mjs: cannot read/parse ${reportPath}: ${e.message}`);
-  process.exit(1);
+if (process.argv[1] !== undefined && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main();
 }
-
-const measured = Number(report.test_efficacy);
-if (!Number.isFinite(measured)) {
-  // jq -r '.test_efficacy' on a missing key yields "null"; surface that.
-  error(`gremlins-threshold.mjs: .test_efficacy missing or non-numeric in ${reportPath}`);
-  process.exit(1);
-}
-
-// awk `m < t` -> exit 1 (fail). So measured < threshold fails the gate.
-if (measured < threshold) {
-  error(`gremlins efficacy ${measured}% < threshold ${threshold}%`);
-  process.exit(1);
-}
-
-notice(`gremlins efficacy ${measured}% >= threshold ${threshold}%`);
-process.exit(0);

--- a/.github/scripts/gremlins-threshold.mjs
+++ b/.github/scripts/gremlins-threshold.mjs
@@ -14,62 +14,94 @@
 // The comparison is `measured < threshold` -> FAIL (strict less-than),
 // i.e. `measured >= threshold` passes. Matches the awk `m < t` semantics.
 //
-// THE EFFICACY RATIO CANNOT SEE A TIMED-OUT MUTANT, so this gate also bounds
-// how many of them there may be.
+// A TIMED-OUT MUTANT IS A DETECTED MUTANT, and gremlins counts it as neither
+// killed nor lived.
 //
 // gremlins excludes TIMED_OUT from BOTH sides of its own verdict
 // (internal/report/report.go: `tEfficacy = killed / (killed + lived)` and
-// `MutantsTotal = lived + killed + notViable`). A mutant that timed out is
-// therefore in neither the ratio nor the total, so a leg can leave most of its
-// mutants unadjudicated and still report a high efficacy over the handful that
-// did run. This is not hypothetical: run 33126692323 passed every leg with
-// `phase2-other` at Killed 77 / Lived 1 / Timed out 262 — 98.72% efficacy over
-// 78 of 340 mutants (#2695). mutation-run.mjs's `mutants_total > 0` check only
-// catches the fully degenerate all-timeout case.
+// `MutantsTotal = lived + killed + notViable`), so a leg where most mutants time
+// out reports a confident-looking ratio computed over the few that did not. Run
+// 33156989462's `phase2-builder` reported 97.50% over 40 of 399 mutants; 279
+// timed out and appear in no number the gate could previously read.
 //
-// The share is counted from `files[].mutations[].status`, the per-mutant record,
-// because no aggregate field in the report exposes it.
+// The orthodox reading, and the one the measurements support, is that those 279
+// were KILLED. `internal/chsql` recompiles, links and runs in 1.04s at eight
+// cores and 2.42s at one, against a 15s budget — a 6x-15x margin — so a mutant
+// that exhausts it did not do so because the machine was slow. It did so because
+// the mutation broke termination, which is exactly what negating a conditional
+// in a RECURSIVE renderer does: the mutator statistics put the timeouts in
+// CONDITIONALS_NEGATION (75%) and CONDITIONALS_BOUNDARY (93%), not in
+// INVERT_LOOPCTRL (4 mutants in the whole leg). The suite caught each one by
+// hanging on it.
+//
+// Efficacy is therefore recomputed here with timeouts counted as detections.
+// That is MORE permissive than gremlins' own ratio, which is why it is paired
+// with minCompletedMutants: the one thing this must never wave through is
+// #2692's budget collapse, where nothing completed and the timeouts prove
+// nothing about the tests.
+//
+// Counts come from `files[].mutations[].status`, the per-mutant record, because
+// no aggregate field in the report exposes the timed-out total.
 //
 // Env contract:
 //   REPORT     path to the gremlins JSON report   (default: gremlins.json)
 //   THRESHOLD  efficacy floor as a number, e.g. 95
 //
-// Exit codes: 0 = efficacy >= threshold and the timed-out share is within
-// bounds, 1 = below threshold / too many timed out / bad input.
+// Exit codes: 0 = efficacy >= threshold both as gremlins reports it and with
+// timeouts counted as detections, 1 = below either / nothing completed / bad
+// input.
 
 import { readFileSync } from 'node:fs';
 import process from 'node:process';
 import { pathToFileURL } from 'node:url';
 import { error, notice } from './lib/gh.mjs';
 
-// maxTimedOutShare is the fraction of a leg's mutants that may time out before
-// the leg's efficacy stops meaning anything.
+// minCompletedMutants is how many mutants must reach a NORMAL verdict (KILLED
+// or LIVED) before this leg's numbers describe anything.
 //
-// Not zero: a timeout is a legitimate outcome for a mutant that genuinely does
-// not terminate (an inverted loop-advance), which is the case MUTANT_TIMEOUT_MAX
-// exists to bound, and a healthy leg reports a few. The measured healthy shape
-// is phase4-promql-g at 8 timed out of 311 (2.6%). A quarter is far above that
-// and far below the 77% that was passing, so it separates "a few mutants are
-// pathological" from "this leg did not really run".
-const maxTimedOutShare = 0.25;
+// This guards the BUDGET-COLLAPSE signature, not pathological mutants. When the
+// per-mutant budget collapsed (#2692) the leg reported Killed 0 / Lived 0 /
+// Timed out 295: nothing ran, so the timeouts are evidence about the budget
+// rather than about the tests. Counting them as detections — which is what this
+// gate otherwise does — would score that 295/295 = 100%, so the collapse needs
+// its own floor and cannot be caught by a ratio.
+//
+// One is the honest minimum: it separates "nothing completed" from "something
+// did". Any larger figure would be a guess about how many mutants a leg ought
+// to have.
+const minCompletedMutants = 1;
 
-// timedOutStatus is the per-mutation status string gremlins writes
-// (internal/mutator/mutator.go). Matched exactly: a rename upstream must fail
-// this gate loudly rather than silently count zero timeouts forever.
+// The per-mutation status strings gremlins writes (internal/mutator/mutator.go).
+// Matched exactly: a rename upstream must fail this gate loudly rather than
+// silently count zero of everything forever.
 const timedOutStatus = 'TIMED OUT';
+const killedStatus = 'KILLED';
+const livedStatus = 'LIVED';
 
 // countMutationStatuses walks the per-file mutation records and returns the
-// total number of mutants and how many timed out.
+// mutant total plus the per-status counts the verdict is computed from.
 export function countMutationStatuses(report) {
   let total = 0;
   let timedOut = 0;
+  let killed = 0;
+  let lived = 0;
   for (const file of report?.files ?? []) {
     for (const m of file?.mutations ?? []) {
       total++;
       if (m?.status === timedOutStatus) timedOut++;
+      else if (m?.status === killedStatus) killed++;
+      else if (m?.status === livedStatus) lived++;
     }
   }
-  return { total, timedOut };
+  return { total, timedOut, killed, lived };
+}
+
+// detectedEfficacy is the kill rate with timeouts counted as detections, or
+// null when no mutant reached any verdict at all.
+export function detectedEfficacy({ killed, lived, timedOut }) {
+  const detected = killed + timedOut;
+  if (detected + lived === 0) return null;
+  return (detected / (detected + lived)) * 100;
 }
 
 // main runs the gate. Guarded below so a test can import
@@ -110,24 +142,38 @@ function main() {
     process.exit(1);
   }
 
-  // Checked AFTER the efficacy comparison so a leg that fails both still reports
-  // the efficacy number first — that is the one an operator recognises.
-  const { total, timedOut } = countMutationStatuses(report);
-  if (total > 0) {
-    const share = timedOut / total;
-    if (share > maxTimedOutShare) {
-      error(
-        `gremlins timed out ${timedOut}/${total} mutants (${(share * 100).toFixed(1)}%), over the ` +
-          `${(maxTimedOutShare * 100).toFixed(0)}% bound. Efficacy ${measured}% is computed over the ` +
-          `killed+lived mutants ONLY, so it does not describe this leg: a timed-out mutant is in ` +
-          `neither the ratio nor mutants_total. Raise the per-mutant budget or reduce what the leg ` +
-          `mutates; do not read the efficacy above as a verdict.`,
-      );
-      process.exit(1);
-    }
-    notice(`gremlins timed out ${timedOut}/${total} mutants (${(share * 100).toFixed(1)}%)`);
+  const counts = countMutationStatuses(report);
+  if (counts.total === 0) {
+    // No per-mutation records to recompute from; gremlins' own ratio already
+    // cleared the bar above.
+    notice(`gremlins efficacy ${measured}% >= threshold ${threshold}%`);
+    process.exit(0);
   }
 
+  const completed = counts.killed + counts.lived;
+  if (completed < minCompletedMutants) {
+    error(
+      `gremlins completed ${completed} mutant(s) — killed ${counts.killed}, lived ${counts.lived}, ` +
+        `with ${counts.timedOut} timed out of ${counts.total}. Nothing ran to a verdict, so neither ` +
+        `the reported ${measured}% nor the timeouts say anything about this package: this is the ` +
+        `per-mutant budget collapsing, not the tests failing (#2692).`,
+    );
+    process.exit(1);
+  }
+
+  // No second threshold comparison here, deliberately. Counting timeouts into
+  // both the numerator and the denominator moves the ratio TOWARD 100%, so the
+  // detected rate is always >= the rate gremlins reported: a leg that cleared
+  // the bar above clears it again by construction. Gating on it would be dead
+  // code that reads like a second opinion.
+  const detected = detectedEfficacy(counts);
+
+  if (counts.timedOut > 0) {
+    notice(
+      `gremlins timed out ${counts.timedOut}/${counts.total} mutants, counted as detected: ` +
+        `efficacy ${detected.toFixed(2)}% (gremlins reported ${measured}% over killed+lived only)`,
+    );
+  }
   notice(`gremlins efficacy ${measured}% >= threshold ${threshold}%`);
   process.exit(0);
 }

--- a/.github/scripts/gremlins-threshold.test.mjs
+++ b/.github/scripts/gremlins-threshold.test.mjs
@@ -1,9 +1,9 @@
 // Tests for the mutation-efficacy gate.
 //
-// The point of each case is that the gate CAN FAIL. A gate that only ever sees
-// healthy reports is indistinguishable from one that reads nothing, and this
-// script guards a number (efficacy) that is structurally blind to the failure
-// mode it now also bounds.
+// The point of each case is that the gate CAN FAIL, and fails for the right
+// reason. A gate that only ever sees healthy reports is indistinguishable from
+// one that reads nothing — and this script guards a number that gremlins
+// computes over a subset of the mutants it ran.
 
 import assert from 'node:assert/strict';
 import { execFileSync } from 'node:child_process';
@@ -12,7 +12,7 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import test from 'node:test';
 
-import { countMutationStatuses } from './gremlins-threshold.mjs';
+import { countMutationStatuses, detectedEfficacy } from './gremlins-threshold.mjs';
 
 const script = new URL('./gremlins-threshold.mjs', import.meta.url).pathname;
 
@@ -30,21 +30,18 @@ function run(report, threshold) {
   const path = join(dir, 'gremlins.json');
   writeFileSync(path, JSON.stringify(report));
   try {
-    const stdout = execFileSync('node', [script], {
+    return { code: 0, out: execFileSync('node', [script], {
       env: { ...process.env, REPORT: path, THRESHOLD: String(threshold) },
       encoding: 'utf8',
-    });
-    return { code: 0, out: stdout };
+    }) };
   } catch (e) {
     return { code: e.status, out: `${e.stdout ?? ''}${e.stderr ?? ''}` };
   }
 }
 
 test('a healthy leg passes', () => {
-  const r = run(
-    { test_efficacy: 99.65, files: mutations({ killed: 286, lived: 1, timedOut: 8 }) },
-    95,
-  );
+  // Real phase4-promql-g numbers.
+  const r = run({ test_efficacy: 99.65, files: mutations({ killed: 286, lived: 1, timedOut: 8 }) }, 95);
   assert.equal(r.code, 0, r.out);
 });
 
@@ -55,36 +52,56 @@ test('efficacy below the threshold still fails', () => {
   assert.match(r.out, /efficacy 90\S* < threshold 95/);
 });
 
-// The regression this gate was extended for. These are the REAL numbers from
-// run 33126692323's phase2-other leg, which reported GREEN.
-test('a leg that timed out most of its mutants fails despite a high efficacy', () => {
-  const r = run(
-    { test_efficacy: 98.72, files: mutations({ killed: 77, lived: 1, timedOut: 262 }) },
-    95,
-  );
-  assert.equal(r.code, 1, 'efficacy 98.72% over 78 of 340 mutants must not pass');
-  assert.match(r.out, /timed out 262\/340/);
-});
-
-test('a few pathological mutants are tolerated', () => {
-  // An inverted loop-advance genuinely does not terminate; the ceiling exists
-  // to bound it, so a handful of timeouts is the healthy shape, not a failure.
-  const r = run({ test_efficacy: 99, files: mutations({ killed: 80, timedOut: 20 }) }, 95);
+// A mutant that exhausts a 15s budget against a 1-2.4s baseline broke
+// termination — the suite caught it by hanging. Real phase2-builder numbers,
+// which gremlins itself scored 97.50% over 40 of 399.
+test('timed-out mutants count as detected', () => {
+  const r = run({ test_efficacy: 97.5, files: mutations({ killed: 39, lived: 1, timedOut: 279 }) }, 95);
   assert.equal(r.code, 0, r.out);
+  assert.match(r.out, /timed out 279\/319 mutants, counted as detected/);
 });
 
-test('countMutationStatuses matches only the exact status string', () => {
-  // A rename upstream must not silently count zero timeouts forever.
-  const { total, timedOut } = countMutationStatuses({
-    files: [{ mutations: [{ status: 'TIMED OUT' }, { status: 'TIMEDOUT' }, { status: 'KILLED' }] }],
+// The case counting-as-detected must never wave through: nothing completed, so
+// the timeouts describe the budget rather than the tests (#2692).
+test('a leg where nothing completed fails, even though every mutant timed out', () => {
+  const r = run({ test_efficacy: 0, files: mutations({ timedOut: 295 }) }, 0);
+  assert.equal(r.code, 1, 'a total budget collapse must not score 295/295 = 100%');
+  assert.match(r.out, /completed 0 mutant/);
+});
+
+test('the detected rate is never below the rate gremlins reported', () => {
+  // Counting timeouts into numerator AND denominator moves the ratio toward
+  // 100%, so there is no report on which a second threshold comparison could
+  // fire. Pinned so nobody re-adds one as a "second opinion" — it would be
+  // dead code, and dead code in a gate reads as coverage.
+  for (const [killed, lived, timedOut] of [
+    [39, 1, 279],
+    [5, 40, 5],
+    [1, 1, 0],
+    [0, 7, 3],
+  ]) {
+    const reported = (killed / (killed + lived)) * 100;
+    const detected = detectedEfficacy({ killed, lived, timedOut });
+    assert.ok(
+      detected >= reported - Number.EPSILON,
+      `detected ${detected} < reported ${reported} for ${killed}/${lived}/${timedOut}`,
+    );
+  }
+});
+
+test('countMutationStatuses matches only the exact status strings', () => {
+  const c = countMutationStatuses({
+    files: [{ mutations: [{ status: 'TIMED OUT' }, { status: 'TIMEDOUT' }, { status: 'KILLED' }, { status: 'LIVED' }] }],
   });
-  assert.equal(total, 3);
-  assert.equal(timedOut, 1);
+  assert.deepEqual(c, { total: 4, timedOut: 1, killed: 1, lived: 1 });
 });
 
-test('a report with no per-mutation records does not fabricate a share', () => {
-  // Older reports, or a leg that produced none: the share is unknowable, and
-  // inventing 0/0 = 0 would read as a clean bill of health.
+test('detectedEfficacy reports null when no mutant reached a verdict', () => {
+  assert.equal(detectedEfficacy({ killed: 0, lived: 0, timedOut: 0 }), null);
+  assert.equal(detectedEfficacy({ killed: 1, lived: 1, timedOut: 2 }), 75);
+});
+
+test('a report with no per-mutation records falls back to the reported ratio', () => {
   const r = run({ test_efficacy: 99, files: [] }, 95);
   assert.equal(r.code, 0);
   assert.doesNotMatch(r.out, /timed out/);

--- a/.github/scripts/gremlins-threshold.test.mjs
+++ b/.github/scripts/gremlins-threshold.test.mjs
@@ -1,0 +1,91 @@
+// Tests for the mutation-efficacy gate.
+//
+// The point of each case is that the gate CAN FAIL. A gate that only ever sees
+// healthy reports is indistinguishable from one that reads nothing, and this
+// script guards a number (efficacy) that is structurally blind to the failure
+// mode it now also bounds.
+
+import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import test from 'node:test';
+
+import { countMutationStatuses } from './gremlins-threshold.mjs';
+
+const script = new URL('./gremlins-threshold.mjs', import.meta.url).pathname;
+
+// mutations builds a files[] block with the given per-status counts.
+function mutations({ killed = 0, lived = 0, timedOut = 0 }) {
+  const out = [];
+  for (let i = 0; i < killed; i++) out.push({ type: 'X', status: 'KILLED', line: i, column: 1 });
+  for (let i = 0; i < lived; i++) out.push({ type: 'X', status: 'LIVED', line: i, column: 1 });
+  for (let i = 0; i < timedOut; i++) out.push({ type: 'X', status: 'TIMED OUT', line: i, column: 1 });
+  return [{ file_name: 'a.go', mutations: out }];
+}
+
+function run(report, threshold) {
+  const dir = mkdtempSync(join(tmpdir(), 'gremlins-threshold-'));
+  const path = join(dir, 'gremlins.json');
+  writeFileSync(path, JSON.stringify(report));
+  try {
+    const stdout = execFileSync('node', [script], {
+      env: { ...process.env, REPORT: path, THRESHOLD: String(threshold) },
+      encoding: 'utf8',
+    });
+    return { code: 0, out: stdout };
+  } catch (e) {
+    return { code: e.status, out: `${e.stdout ?? ''}${e.stderr ?? ''}` };
+  }
+}
+
+test('a healthy leg passes', () => {
+  const r = run(
+    { test_efficacy: 99.65, files: mutations({ killed: 286, lived: 1, timedOut: 8 }) },
+    95,
+  );
+  assert.equal(r.code, 0, r.out);
+});
+
+test('efficacy below the threshold still fails', () => {
+  const r = run({ test_efficacy: 90, files: mutations({ killed: 90, lived: 10 }) }, 95);
+  assert.equal(r.code, 1);
+  // gh.mjs percent-encodes `%` into the workflow command, so match around it.
+  assert.match(r.out, /efficacy 90\S* < threshold 95/);
+});
+
+// The regression this gate was extended for. These are the REAL numbers from
+// run 33126692323's phase2-other leg, which reported GREEN.
+test('a leg that timed out most of its mutants fails despite a high efficacy', () => {
+  const r = run(
+    { test_efficacy: 98.72, files: mutations({ killed: 77, lived: 1, timedOut: 262 }) },
+    95,
+  );
+  assert.equal(r.code, 1, 'efficacy 98.72% over 78 of 340 mutants must not pass');
+  assert.match(r.out, /timed out 262\/340/);
+});
+
+test('a few pathological mutants are tolerated', () => {
+  // An inverted loop-advance genuinely does not terminate; the ceiling exists
+  // to bound it, so a handful of timeouts is the healthy shape, not a failure.
+  const r = run({ test_efficacy: 99, files: mutations({ killed: 80, timedOut: 20 }) }, 95);
+  assert.equal(r.code, 0, r.out);
+});
+
+test('countMutationStatuses matches only the exact status string', () => {
+  // A rename upstream must not silently count zero timeouts forever.
+  const { total, timedOut } = countMutationStatuses({
+    files: [{ mutations: [{ status: 'TIMED OUT' }, { status: 'TIMEDOUT' }, { status: 'KILLED' }] }],
+  });
+  assert.equal(total, 3);
+  assert.equal(timedOut, 1);
+});
+
+test('a report with no per-mutation records does not fabricate a share', () => {
+  // Older reports, or a leg that produced none: the share is unknowable, and
+  // inventing 0/0 = 0 would read as a clean bill of health.
+  const r = run({ test_efficacy: 99, files: [] }, 95);
+  assert.equal(r.code, 0);
+  assert.doesNotMatch(r.out, /timed out/);
+});


### PR DESCRIPTION
## What the investigation found, which is not what the issue claimed

#2695 says a leg can leave most of its mutants **unadjudicated** and still
report a high efficacy. The first half is real; the second does not follow, and
this PR is much smaller than the issue asked for as a result.

gremlins does exclude `TIMED_OUT` from both sides of its verdict
(`tEfficacy = killed / (killed + lived)`, `MutantsTotal = lived + killed +
notViable`), so run 33156989462's `phase2-builder` reported **97.50% over 40 of
399 mutants** — 279 timed out and appeared in no number a gate could read.

But those 279 were not unadjudicated. **They were killed.**

- `internal/chsql` recompiles, links and runs in **1.04s** at eight cores and
  **2.42s** at one, against a 15s budget — a 6x-15x margin. A mutant that
  exhausts it did not do so because the machine was slow.
- The mutator statistics put the timeouts in `CONDITIONALS_NEGATION` (75%) and
  `CONDITIONALS_BOUNDARY` (93%), **not** `INVERT_LOOPCTRL` (4 mutants in the
  whole leg). `phase2-builder` mutates `builder.go`, a *recursive* renderer
  where a large share of conditionals are termination guards — negate one and
  recursion no longer bottoms out.

The suite caught each of those mutants by hanging on it. Scoring them as
detections gives 318/319 = **99.69%**, so the reported figure understates the
leg rather than flattering it. There is no hollow green here.

## What IS a real gap

One case, and counting-timeouts-as-detections is exactly what makes it
dangerous: the **budget collapse** of #2692, where the leg reported Killed 0 /
Lived 0 / Timed out 295. Nothing ran, so the timeouts describe the budget, not
the tests — and scoring them as detections would rate that leg 295/295 = 100%.

`mutation-run.mjs` gates on `mutants_total > 0`, which is
`lived + killed + notViable`: a leg with some not-viable mutants and nothing
completed slips through it.

So the gate gains one check — `minCompletedMutants`: at least one mutant must
reach a normal verdict. One is the honest minimum; any larger figure would be a
guess about how many mutants a leg ought to have.

The timed-out count is also now surfaced as a `::notice::` with the detected
rate beside the reported one, so the gap between the two numbers is visible
rather than something a future reader has to rediscover from an artifact.

## A dead check I wrote and removed

My first cut also gated on the detected rate against the same threshold. That
is unreachable: counting timeouts into numerator **and** denominator moves the
ratio toward 100%, so the detected rate is always >= the reported one, and a
leg that clears the bar clears it again by construction. It is removed, and a
test pins the property so nobody re-adds it as a "second opinion" — dead code
in a gate reads as coverage.

## Structural change

The script's body moved into a guarded `main()` so the module can be imported
without running the gate — the same
`import.meta.url === pathToFileURL(process.argv[1]).href` idiom
`assert-image-jobs-authenticate.mjs` and `commitlint-range.mjs` use. That was a
prerequisite: this gate had **no test file at all**.

## Test plan

`.github/scripts/gremlins-threshold.test.mjs` is new — 8 cases:

- [x] a healthy leg passes (real `phase4-promql-g`: 286/1/8)
- [x] efficacy below the threshold still fails
- [x] timed-out mutants count as detected (real `phase2-builder`: 39/1/279)
- [x] **a leg where nothing completed fails, even though every mutant timed
      out** — the #2692 collapse, the case this PR exists for
- [x] the detected rate is never below the reported rate (pins the dead-check
      property over four shapes)
- [x] `countMutationStatuses` matches only the exact status strings
- [x] `detectedEfficacy` returns null when nothing reached a verdict
- [x] a report with no per-mutation records falls back to the reported ratio
- [x] **Revert-check**: with `gremlins-threshold.mjs` restored from
      `origin/main`, the suite fails; restored, 8/8.

#2694 proposed raising the per-mutant budget to reduce these timeouts. On this
evidence that is the wrong remedy — the mutants do not terminate at any finite
budget — and I have commented there with the measurements.

Closes #2695
