### PR TITLE
ci: warm nested go modules, and gate that a built module is a warmed one

### DIFF
--- a/.github/actions/setup-go/action.yml
+++ b/.github/actions/setup-go/action.yml
@@ -51,6 +51,17 @@ inputs:
       of the checkout under `target/`.
     required: false
     default: go.mod
+  also-warm:
+    description: >
+      Additional go.mod paths to warm, whitespace-separated. A NESTED module
+      (its own go.mod under the checkout) is a separate module graph: the root
+      warm step never fetches it, and the root `go test ./...` stops at its
+      go.mod, so a job that builds one reaches the proxy for it cold and
+      unretried — the exact fetch this action exists to wrap. `go-version-file`
+      cannot cover both, because it also selects the toolchain and a job has
+      one. Name the nested module here instead.
+    required: false
+    default: ''
   cache:
     description: >
       Restore and save setup-go's shared module cache, keyed on that module's
@@ -95,6 +106,12 @@ runs:
       shell: bash
       env:
         GO_VERSION_FILE: ${{ inputs.go-version-file }}
+        ALSO_WARM: ${{ inputs.also-warm }}
       run: |
-        cd "$(dirname "$GO_VERSION_FILE")"
-        node "$GITHUB_WORKSPACE/.github/scripts/go-module-fetch.mjs"
+        set -euo pipefail
+        for mod in "$GO_VERSION_FILE" ${ALSO_WARM:-}; do
+          (
+            cd "$(dirname "$mod")"
+            node "$GITHUB_WORKSPACE/.github/scripts/go-module-fetch.mjs"
+          )
+        done

--- a/.github/scripts/assert-go-setup-hardened.mjs
+++ b/.github/scripts/assert-go-setup-hardened.mjs
@@ -42,6 +42,14 @@
 //   R5  At least one workflow step actually uses the wrapper. A gate that
 //       passes because nothing sets Go up at all reports the same green as a
 //       gate that is satisfied.
+//   R6  A job that BUILDS a nested module must also WARM it, via the wrapper's
+//       `also-warm` input or its own warm step in that directory. A nested
+//       go.mod is a separate module graph: the root warm step does not fetch
+//       it and the root `go test ./...` stops at it, so the job reaches the
+//       proxy for it cold and unretried — the one fetch this action exists to
+//       wrap, left uncovered. Keyed on `working-directory:` naming a directory
+//       that actually contains a go.mod, so a Node directory or a scratch
+//       checkout is outside the rule rather than exempted from it.
 //
 // WHY R1 IS A LITERAL AND NOT AN INPUT. `update-golden.yml`'s three
 // regenerating jobs check out TARGET-BRANCH code under the default branch's
@@ -262,6 +270,48 @@ function stepRunsWarm(stepLines) {
   return stepLines.some((l) => !isComment(l) && l.includes(warmScript));
 }
 
+// nestedBuildDirs — the nested-module directories a step block builds in, read
+// from `working-directory:`. Returns a Set of directories, deduped, excluding
+// the repository root (which the ordinary warm step already covers).
+//
+// A directory only counts when it actually CONTAINS a go.mod in this checkout.
+// `working-directory:` is how a workflow says "run over there" for Node dirs
+// and scratch checkouts too, and neither has a module graph to warm — keying on
+// the declaration alone reported six false violations on this repository.
+//
+// Deliberately keyed on the workflow's own declaration rather than on a list of
+// known nested modules: a nested module added later is caught by the same rule,
+// and one that is never built needs no warming and is correctly silent.
+export function nestedBuildDirs(block, root) {
+  const dirs = new Set();
+  for (const step of block.steps) {
+    for (const line of step) {
+      if (isComment(line)) continue;
+      const m = /^\s*working-directory:\s*(\S.*?)\s*$/.exec(line);
+      if (m === null) continue;
+      const dir = unquote(m[1].replace(/\s+#.*$/, '')).replace(/\/+$/, '');
+      if (dir === '' || dir === '.' || dir.includes('${{')) continue;
+      if (!existsSync(join(root, dir, 'go.mod'))) continue;
+      dirs.add(dir);
+    }
+  }
+  return dirs;
+}
+
+// stepWarmsModule — whether this step warms the module rooted at dir, either by
+// passing it to the composite's `also-warm` or by running the warm script with
+// that directory as its own working-directory.
+export function stepWarmsModule(stepLines, dir) {
+  const also = withEntry(stepLines, 'also-warm');
+  if (also !== null && also.split(/\s+/).includes(`${dir}/go.mod`)) return true;
+  if (!stepRunsWarm(stepLines)) return false;
+  return stepLines.some((l) => {
+    if (isComment(l)) return false;
+    const m = /^\s*working-directory:\s*(\S.*?)\s*$/.exec(l);
+    return m !== null && unquote(m[1]).replace(/\/+$/, '') === dir;
+  });
+}
+
 // expressionsOutsideRuns — every `${{ … }}` an action manifest writes ABOVE its
 // `runs:` block, in a non-comment line.
 //
@@ -329,6 +379,26 @@ export function scan({
     const text = readFileSync(file, 'utf8');
     for (const block of stepBlocks(text, file)) {
       const warms = block.steps.some(stepRunsWarm);
+
+      // R6 — a job that BUILDS a nested module must also WARM it. A nested
+      // go.mod is its own module graph: the root warm step does not fetch it
+      // and the root `go test ./...` stops at it, so the job reaches the proxy
+      // for it cold and unretried — the one fetch this whole action exists to
+      // wrap, left uncovered (#2700). Keyed on `working-directory:`, which is
+      // how a workflow says "build over there".
+      for (const dir of nestedBuildDirs(block, abs('.'))) {
+        const warmed = block.steps.some((s) => stepWarmsModule(s, dir));
+        if (!warmed) {
+          violations.push(
+            `${file}: job "${block.label}" builds the nested module in ${dir}/ ` +
+              `(working-directory) but never warms it. Pass ` +
+              `\`also-warm: ${dir}/go.mod\` to ./.github/actions/setup-go in this job — ` +
+              `the root warm step covers the root module only, so this module's proxy ` +
+              `fetch runs cold and unretried.`,
+          );
+        }
+      }
+
       for (const step of block.steps) {
         const ref = stepUses(step);
         if (ref === wrapperRef) wrapperCallSites++;

--- a/.github/scripts/assert-go-setup-hardened.test.mjs
+++ b/.github/scripts/assert-go-setup-hardened.test.mjs
@@ -27,9 +27,11 @@ import {
   expressionsOutsideRuns,
   hasKeyAtStepLevel,
   isUpstreamSetupGo,
+  nestedBuildDirs,
   scan,
   stepBlocks,
   stepUses,
+  stepWarmsModule,
   usesValue,
   withEntry,
 } from './assert-go-setup-hardened.mjs';
@@ -387,5 +389,56 @@ test('a step block is scoped to its own job', () => {
   assert.equal(
     plan.steps.filter((s) => isUpstreamSetupGo(stepUses(s) ?? '')).length,
     0,
+  );
+});
+
+// ---------------------------------------------------------------------------
+// R6 — a job that builds a nested module must warm it.
+// ---------------------------------------------------------------------------
+
+test('a job building a nested module without warming it is a violation', () => {
+  // The real shape: ci.yml's agpl-oracle job runs `go test ./...` with
+  // working-directory: test/oracle, a module the root warm step never fetches.
+  const { violations } = scanWithWorkflow('ci.yml', (text) =>
+    text.replace(
+      '      - uses: ./.github/actions/setup-go\n        with:\n          also-warm: test/oracle/go.mod',
+      '      - uses: ./.github/actions/setup-go',
+    ),
+  );
+  assert.equal(violations.length, 1, `expected exactly one R6 violation, got ${JSON.stringify(violations)}`);
+  assert.match(violations[0], /builds the nested module in test\/oracle\//);
+});
+
+test('R6 ignores a working-directory with no go.mod in it', () => {
+  // `working-directory:` is also how a workflow runs in a Node directory or a
+  // scratch checkout. Keying on the declaration alone reported six false
+  // violations on this repository (test/e2e/playwright, target/).
+  const blocks = stepBlocks(
+    ['jobs:', '  a:', '    steps:', '      - run: npm ci', '        working-directory: test/e2e/playwright'].join('\n'),
+    'x.yml',
+  );
+  assert.equal(nestedBuildDirs(blocks[0], repoRoot).size, 0);
+});
+
+test('R6 accepts a warm step run directly in the nested directory', () => {
+  // also-warm is the ergonomic route, not the only one: a job that runs the
+  // warm script itself with that working-directory has covered the module.
+  const block = stepBlocks(
+    [
+      'jobs:',
+      '  a:',
+      '    steps:',
+      '      - run: node .github/scripts/go-module-fetch.mjs',
+      '        working-directory: test/oracle',
+      '      - run: go test ./...',
+      '        working-directory: test/oracle',
+    ].join('\n'),
+    'x.yml',
+  );
+  const dirs = [...nestedBuildDirs(block[0], repoRoot)];
+  assert.deepEqual(dirs, ['test/oracle']);
+  assert.equal(
+    block[0].steps.some((s) => stepWarmsModule(s, 'test/oracle')),
+    true,
   );
 });

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -145,7 +145,12 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
+      # The `test oracle module` step below runs `go test ./...` inside the
+      # nested test/oracle module, whose graph the root warm step never
+      # fetches — leaving that one proxy fetch cold and unretried (#2700).
       - uses: ./.github/actions/setup-go
+        with:
+          also-warm: test/oracle/go.mod
 
       - uses: taiki-e/install-action@ba47c86ac325773530516bb756137ac718732518  # v2.86.5
         with:


### PR DESCRIPTION
## Summary

`.github/actions/setup-go` warms `GOMODCACHE` in the directory of its
`go-version-file`. Every call site passes the root `go.mod`, so a **nested**
module is never warmed — its module graph is separate, the root warm step does
not fetch it, and the root `go test ./...` stops at its `go.mod`. A job that
builds one therefore reaches the proxy for it **cold and unretried**, which is
exactly the fetch `go-module-fetch.mjs` exists to wrap (#2676).

One job in the fleet does this: `ci.yml`'s `agpl-oracle` runs
`go test ./...` with `working-directory: test/oracle`.

## Correction to the issue as I filed it

I wrote that `bench/histogram` is "fetched by the perf lanes". **That is not
true.** No workflow runs it — it has a `run.sh` invoked locally and referenced
in docs, and `dependabot-tidy-nested-modules.yml` deliberately excludes it. The
tree has exactly two nested modules and only `test/oracle` is built in CI, so
only that one needed wiring. Stating it because the issue text will otherwise
mislead the next reader.

## The change

`also-warm` — a whitespace-separated list of additional `go.mod` paths the warm
step visits. `go-version-file` cannot serve here: it also selects the
toolchain, and a job has one.

`agpl-oracle` passes `also-warm: test/oracle/go.mod`.

## R6, so this cannot silently regress

The ratchet gains a rule: a job that BUILDS a nested module must also WARM it.
Keyed on `working-directory:` naming a directory that **actually contains a
go.mod** — the first cut keyed on the declaration alone and reported six false
violations (`test/e2e/playwright`, `target/`), which are a Node directory and a
scratch checkout with no module graph to warm. Those are outside the rule
rather than exempted from it, in keeping with this gate's existing "no
allow-list" stance.

`also-warm` is the ergonomic route but not the only one: a job that runs the
warm script itself with that `working-directory` satisfies R6 too.

## Test plan

- [x] `a job building a nested module without warming it is a violation` —
      built by removing the real `also-warm` wiring from `ci.yml`; asserts
      **exactly one** violation naming `test/oracle/`.
- [x] `R6 ignores a working-directory with no go.mod in it` — pins the
      false-positive fix directly.
- [x] `R6 accepts a warm step run directly in the nested directory`.
- [x] Full suite 22/22; `node .github/scripts/assert-go-setup-hardened.mjs`
      clean on the tree (48 wrapper call sites, 3 direct).
- [x] Manual revert-check: with the `also-warm` wiring removed the gate exits 1;
      restored, it exits 0.

Closes #2700
