### PR TITLE
fix(chaudit,solver,ci): apply the v1.18.0 pre-release audit findings

### DIFF
--- a/.github/scripts/assert-gate-suites-wired.mjs
+++ b/.github/scripts/assert-gate-suites-wired.mjs
@@ -1,0 +1,97 @@
+// assert-gate-suites-wired — every `.github/scripts/**/*.test.mjs` must be
+// invoked by at least one workflow.
+//
+// WHY THIS EXISTS. A test suite no workflow runs is indistinguishable, from the
+// outside, from one that passes: the file is there, it is well written, and
+// nothing reports that it never executed. It reads as coverage in a review and
+// provides none. That is the same failure mode as a gate that cannot fail —
+// the green means something other than what a reader takes it to mean.
+//
+// It had happened three times before this gate existed, silently:
+// `gremlins-threshold.test.mjs` (added with the timed-out/nothing-completed
+// gate in this very release cycle), `merge-crawl-slices.test.mjs` and
+// `property-fanout.test.mjs`. Each was written, committed, reviewed and never
+// run. Wiring those three fixed the instance; this fixes the class.
+//
+// The check is deliberately structural rather than a list: it enumerates the
+// suites on disk and the `node --test <path>` invocations across the workflow
+// files, and reports the difference. There is no allow-list — a suite that
+// genuinely should not run in CI has no reason to exist.
+//
+// ENV CONTRACT
+//   REPO_ROOT     — repository root. Default `process.cwd()`.
+//   SCRIPTS_DIR   — suites to require. Default `.github/scripts`.
+//   WORKFLOW_DIR  — workflows to scan. Default `.github/workflows`.
+//
+// Exit: 0 when every suite is invoked, 1 otherwise.
+
+import { readFileSync, readdirSync, statSync } from 'node:fs';
+import { isAbsolute, join, relative } from 'node:path';
+import process from 'node:process';
+import { pathToFileURL } from 'node:url';
+
+import { error, log, notice } from './lib/gh.mjs';
+
+const suiteSuffix = '.test.mjs';
+
+// walk — every file under dir, recursively, as repo-relative paths.
+function walk(dir, root, out = []) {
+  for (const entry of readdirSync(dir)) {
+    const full = join(dir, entry);
+    if (statSync(full).isDirectory()) walk(full, root, out);
+    else out.push(relative(root, full));
+  }
+  return out;
+}
+
+// invokedSuites — every path named by a `node --test <path>` in the workflows.
+// Matched on the literal path because that is what a workflow actually runs; a
+// glob or a variable would make this gate unable to answer its own question,
+// and is worth failing on rather than guessing about.
+export function invokedSuites(workflowText) {
+  const found = new Set();
+  for (const m of workflowText.matchAll(/node\s+--test\s+(\S+\.test\.mjs)/g)) {
+    found.add(m[1]);
+  }
+  return found;
+}
+
+export function scan({ root = process.cwd(), scriptsDir = '.github/scripts', workflowDir = '.github/workflows' } = {}) {
+  const abs = (p) => (isAbsolute(p) ? p : join(root, p));
+
+  const suites = walk(abs(scriptsDir), root).filter((p) => p.endsWith(suiteSuffix));
+
+  const invoked = new Set();
+  for (const file of readdirSync(abs(workflowDir))) {
+    if (!file.endsWith('.yml') && !file.endsWith('.yaml')) continue;
+    for (const p of invokedSuites(readFileSync(join(abs(workflowDir), file), 'utf8'))) invoked.add(p);
+  }
+
+  return { suites, invoked: [...invoked], unwired: suites.filter((s) => !invoked.has(s)) };
+}
+
+function main() {
+  const { suites, unwired } = scan();
+  if (suites.length === 0) {
+    // A gate that passes because it found nothing to check reports the same
+    // green as a satisfied one.
+    error('assert-gate-suites-wired: found no *.test.mjs suites at all — the scan is broken, not the tree');
+    return 1;
+  }
+  if (unwired.length > 0) {
+    error(
+      `${unwired.length} gate test suite(s) are never invoked by any workflow:\n` +
+        unwired.map((s) => `  - ${s}`).join('\n') +
+        `\n\nAdd a \`node --test <path>\` step for each. A suite nothing runs reads as coverage ` +
+        `in review and provides none.`,
+    );
+    return 1;
+  }
+  log(`assert-gate-suites-wired: ${suites.length} suite(s), all invoked by a workflow.`);
+  notice(`${suites.length} gate test suites wired`);
+  return 0;
+}
+
+if (process.argv[1] !== undefined && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  process.exit(main());
+}

--- a/.github/scripts/assert-gate-suites-wired.test.mjs
+++ b/.github/scripts/assert-gate-suites-wired.test.mjs
@@ -1,0 +1,76 @@
+// Tests for the gate-suite wiring check.
+//
+// This suite has to exist for the gate to be honest about itself: a checker
+// that requires every suite to be wired, while shipping without one, would be
+// the first violation of its own rule.
+
+import assert from 'node:assert/strict';
+import { mkdtempSync, mkdirSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import test from 'node:test';
+
+import { invokedSuites, scan } from './assert-gate-suites-wired.mjs';
+
+// tree builds a throwaway repo with the given scripts and workflow contents.
+function tree({ scripts = {}, workflows = {} }) {
+  const root = mkdtempSync(join(tmpdir(), 'gate-wiring-'));
+  mkdirSync(join(root, '.github/scripts/lib'), { recursive: true });
+  mkdirSync(join(root, '.github/workflows'), { recursive: true });
+  for (const [name, body] of Object.entries(scripts)) {
+    writeFileSync(join(root, '.github/scripts', name), body);
+  }
+  for (const [name, body] of Object.entries(workflows)) {
+    writeFileSync(join(root, '.github/workflows', name), body);
+  }
+  return root;
+}
+
+test('a suite no workflow invokes is reported', () => {
+  const root = tree({
+    scripts: { 'a.test.mjs': '', 'b.test.mjs': '' },
+    workflows: { 'ci.yml': 'steps:\n  - run: node --test .github/scripts/a.test.mjs\n' },
+  });
+  const { unwired } = scan({ root });
+  assert.deepEqual(unwired, ['.github/scripts/b.test.mjs']);
+});
+
+test('a fully wired tree is clean', () => {
+  const root = tree({
+    scripts: { 'a.test.mjs': '' },
+    workflows: { 'ci.yml': 'steps:\n  - run: node --test .github/scripts/a.test.mjs\n' },
+  });
+  assert.deepEqual(scan({ root }).unwired, []);
+});
+
+test('suites in subdirectories are covered', () => {
+  // lib/ carries its own suites; a scan that only read the top level would
+  // report a satisfied-looking zero while missing them.
+  const root = tree({ scripts: {}, workflows: { 'ci.yml': '' } });
+  writeFileSync(join(root, '.github/scripts/lib/x.test.mjs'), '');
+  const { suites, unwired } = scan({ root });
+  assert.deepEqual(suites, ['.github/scripts/lib/x.test.mjs']);
+  assert.deepEqual(unwired, ['.github/scripts/lib/x.test.mjs']);
+});
+
+test('an invocation in any workflow file counts', () => {
+  const root = tree({
+    scripts: { 'a.test.mjs': '' },
+    workflows: {
+      'ci.yml': 'steps:\n  - run: echo nothing\n',
+      'coverage.yml': 'steps:\n  - run: node --test .github/scripts/a.test.mjs\n',
+    },
+  });
+  assert.deepEqual(scan({ root }).unwired, []);
+});
+
+test('invokedSuites reads multiple invocations from one run block', () => {
+  const found = invokedSuites(
+    'run: |\n  node --test .github/scripts/a.test.mjs\n  node --test .github/scripts/lib/b.test.mjs\n',
+  );
+  assert.deepEqual([...found].sort(), ['.github/scripts/a.test.mjs', '.github/scripts/lib/b.test.mjs']);
+});
+
+test('invokedSuites does not credit a non-suite node --test target', () => {
+  assert.deepEqual([...invokedSuites('run: node --test somewhere/else.mjs\n')], []);
+});

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -475,6 +475,25 @@ jobs:
       - name: release-preflight self-test (required-set guard)
         run: node --test .github/scripts/release-preflight.test.mjs
 
+      # Three gate suites that existed but ran nowhere. A .test.mjs no workflow
+      # invokes is the same failure as a gate that cannot fail: the file reads
+      # as coverage, the logic it guards is unverified, and nothing says so.
+      # `gate suites are wired` below keeps the list from drifting again — it is
+      # the ratchet, these three lines are the backfill.
+      - name: unwired gate self-tests
+        run: |
+          node --test .github/scripts/gremlins-threshold.test.mjs
+          node --test .github/scripts/merge-crawl-slices.test.mjs
+          node --test .github/scripts/property-fanout.test.mjs
+
+      # Every .github/scripts/**/*.test.mjs must be invoked by some workflow.
+      # Adding a suite and forgetting to wire it is silent — and was, three
+      # times over, including for a gate added in this same release cycle.
+      - name: gate suites are wired
+        run: |
+          node --test .github/scripts/assert-gate-suites-wired.test.mjs
+          node .github/scripts/assert-gate-suites-wired.mjs
+
       # The source-PR resolver release-preflight.mjs now consults
       # (tsouza/cerberus#2394) — same "pure logic only ever exercised during
       # a real release" rationale as the suite above. Its exact-match

--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -155,9 +155,12 @@ jobs:
       # We install gremlins directly via `go install` so we don't
       # depend on a third-party Action's release-download path.
       # The setup-go composite's module cache keeps subsequent runs fast.
-      # Use `--output` for structured JSON (gremlins exits 0 even
-      # when `--threshold-efficacy` is violated in v0.6.0, so we
-      # do the gating ourselves against the parsed JSON below).
+      # Use `--output` for structured JSON: the lane withholds
+      # `--threshold-efficacy` from gremlins and gates on the parsed report
+      # below. The pinned fork DOES exit non-zero on a violation — it just
+      # does so mid-run, before the report is written and uploaded, leaving an
+      # opaque `gremlins exited N` with no artifact and no measured-vs-threshold
+      # numbers.
       #
       # We consume gremlins via the tsouza/gremlins fork, which carries two
       # fixes cerberus needs:

--- a/cmd/cerberus/chopt_reprobe.go
+++ b/cmd/cerberus/chopt_reprobe.go
@@ -7,6 +7,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/tsouza/cerberus/internal/api/health"
 	"github.com/tsouza/cerberus/internal/api/info"
 	"github.com/tsouza/cerberus/internal/api/prom"
 	"github.com/tsouza/cerberus/internal/chopt"
@@ -252,4 +253,26 @@ func resolveCHOptimizationsOnce(ctx context.Context, logger *slog.Logger, cfg co
 		ResolvedVersion: resolvedVersion,
 		VersionFallback: versionFallback,
 	}, true
+}
+
+// capabilitiesResolved is the /readyz condition that holds a pod out of its
+// Service while the capability set in force is a floor fallback.
+//
+// The process is reachable and its schema is present — every other readiness
+// condition says ready — but a failed probe means every native lowering is
+// off, and a wide panel served on the fan-out fallback runs long enough to
+// exceed a dashboard proxy's timeout. Waiting costs seconds, because the
+// re-probe runs at chOptFloorRetryInterval while on the floor; admitting
+// traffic costs a red panel.
+//
+// Reads the LIVE resolution, not the boot one, so the condition clears the
+// moment a probe answers rather than on the next restart.
+func capabilitiesResolved(live *chOptLive) health.CapabilitiesResolvedFunc {
+	return func() (bool, string) {
+		if !live.get().VersionFallback {
+			return true, ""
+		}
+		return false, "clickhouse version probe has not succeeded; " +
+			"optimizations resolved against the supported floor"
+	}
 }

--- a/cmd/cerberus/chopt_reprobe_floor_test.go
+++ b/cmd/cerberus/chopt_reprobe_floor_test.go
@@ -45,3 +45,26 @@ func TestNextReprobeDelay_NeverWaitsLongerThanTheSteadyCadence(t *testing.T) {
 			tiny, chOptFloorRetryInterval, got)
 	}
 }
+
+// TestCapabilitiesResolved_TracksTheLiveResolution pins that the readiness
+// condition reads the LIVE resolution, not the boot one — the whole point is
+// that it clears when a probe answers, without a restart.
+func TestCapabilitiesResolved_TracksTheLiveResolution(t *testing.T) {
+	t.Parallel()
+
+	live := newCHOptLive(chOptResolution{VersionFallback: true})
+	cond := capabilitiesResolved(live)
+
+	resolved, reason := cond()
+	if resolved {
+		t.Fatal("a floor fallback must hold readiness")
+	}
+	if reason == "" {
+		t.Error("the /readyz body needs a reason, not a bare false")
+	}
+
+	live.store(chOptResolution{VersionFallback: false})
+	if resolved, _ := cond(); !resolved {
+		t.Error("readiness must clear once a probe answers, without a restart")
+	}
+}

--- a/cmd/cerberus/main.go
+++ b/cmd/cerberus/main.go
@@ -596,22 +596,11 @@ func run() error {
 	// deployed to serve" in every deployment mode — including the split mode
 	// where one Deployment serves a single head.
 	healthHandler := health.New(health.Options{
-		Pinger:        client.ForHead(chclient.HeadProbe),
-		SchemaReady:   schemaReady,
-		SchemaPresent: schemaPresent,
-		HeadBreakers:  enabledHeadBreakers(client, cfg),
-		// Hold readiness while the capability set is a floor fallback — the
-		// process is reachable but every native lowering is off, and a wide
-		// panel on the fan-out path outruns a dashboard proxy's timeout. The
-		// re-probe clears it within seconds; see the field's own doc.
-		CapabilitiesResolved: func() (bool, string) {
-			res := chOpts.get()
-			if !res.VersionFallback {
-				return true, ""
-			}
-			return false, "clickhouse version probe has not succeeded; " +
-				"optimizations resolved against the supported floor"
-		},
+		Pinger:               client.ForHead(chclient.HeadProbe),
+		SchemaReady:          schemaReady,
+		SchemaPresent:        schemaPresent,
+		HeadBreakers:         enabledHeadBreakers(client, cfg),
+		CapabilitiesResolved: capabilitiesResolved(chOpts),
 	})
 
 	// /info is cerberus's own metadata/health/connection fingerprint — a

--- a/cmd/cerberus/main.go
+++ b/cmd/cerberus/main.go
@@ -600,6 +600,18 @@ func run() error {
 		SchemaReady:   schemaReady,
 		SchemaPresent: schemaPresent,
 		HeadBreakers:  enabledHeadBreakers(client, cfg),
+		// Hold readiness while the capability set is a floor fallback — the
+		// process is reachable but every native lowering is off, and a wide
+		// panel on the fan-out path outruns a dashboard proxy's timeout. The
+		// re-probe clears it within seconds; see the field's own doc.
+		CapabilitiesResolved: func() (bool, string) {
+			res := chOpts.get()
+			if !res.VersionFallback {
+				return true, ""
+			}
+			return false, "clickhouse version probe has not succeeded; " +
+				"optimizations resolved against the supported floor"
+		},
 	})
 
 	// /info is cerberus's own metadata/health/connection fingerprint — a

--- a/compatibility/prometheus/scripts/run-prometheus-compatibility.sh
+++ b/compatibility/prometheus/scripts/run-prometheus-compatibility.sh
@@ -193,6 +193,36 @@ echo "==> bringing up compatibility stack"
 # failure still fails on the first attempt.
 node "$REPO_ROOT/.github/scripts/build-with-registry-retry.mjs" \
     docker compose up -d --build --wait clickhouse prometheus cerberus
+
+# `--wait` above only satisfies each service's own healthcheck, and cerberus's
+# is `cerberus --version` — the distroless image carries no shell, wget or
+# curl, so the compose probe can only prove the BINARY runs. It says healthy
+# before the process has resolved anything about the server it fronts.
+#
+# That gap is not cosmetic. A cerberus that reaches ClickHouse before the
+# native-protocol port accepts connections resolves its capability set against
+# the supported FLOOR, which turns off every native lowering; the fan-out
+# fallback is slow enough that `resets(...[5m])` over an exponential histogram
+# exceeds the tester's per-query deadline. The harness then records
+# `context deadline exceeded` as an `unexpectedFailure`, which the ratchet
+# reports as REGRESSED parity — a timeout wearing a divergence's clothes, on a
+# gate whose whole job is to mean what it says (tsouza/cerberus#2707).
+#
+# The host has curl, so poll the real readiness endpoint here rather than
+# teaching the container to probe itself.
+echo "==> waiting for cerberus /readyz"
+readyz_deadline=$((SECONDS + 120))
+until curl -fsS -o /dev/null "http://localhost:29091/readyz"; do
+    if (( SECONDS >= readyz_deadline )); then
+        echo "cerberus did not become ready within 120s; last /readyz body:" >&2
+        curl -sS "http://localhost:29091/readyz" >&2 || true
+        docker compose logs --tail 50 cerberus >&2 || true
+        exit 1
+    fi
+    sleep 1
+done
+echo "==> cerberus ready"
+
 echo "==> running seeder (go run ./cmd/seed)"
 (cd "$ROOT_DIR/../.." && go run ./compatibility/prometheus/cmd/seed/)
 

--- a/internal/api/health/health.go
+++ b/internal/api/health/health.go
@@ -30,6 +30,12 @@ type SchemaReadyFunc func() bool
 // process crash-looping. When nil the schema is treated as present.
 type SchemaPresentFunc func() (present bool, reason string)
 
+// CapabilitiesResolvedFunc reports whether the ClickHouse capability set in
+// force came from a SUCCESSFUL probe, plus a reason for the /readyz body when
+// it did not. See Options.CapabilitiesResolved for why a floor fallback holds
+// readiness. When nil the capabilities are treated as resolved.
+type CapabilitiesResolvedFunc func() (resolved bool, reason string)
+
 // HeadBreakersFunc reports the circuit-breaker phase of every query head THIS
 // process actually serves, keyed by head name ("prom" / "loki" / "tempo") and
 // valued with the stable phase vocabulary "closed" / "open" / "half-open".
@@ -72,6 +78,29 @@ type Options struct {
 	// When nil the schema is treated as present.
 	SchemaPresent SchemaPresentFunc
 
+	// CapabilitiesResolved is consulted on every readiness check. When it
+	// reports unresolved the probe returns 503 with the reason.
+	//
+	// This models the SAME startup race SchemaPresent does, one layer up: a
+	// cerberus that boots beside its ClickHouse can win, probe a server that
+	// is not listening yet, and resolve its capability set against the
+	// supported floor. It is reachable and its schema is present, so every
+	// other condition here says ready — but every native lowering is
+	// unavailable, and a wide panel served on the fan-out fallback is slow
+	// enough to exceed a dashboard proxy's timeout. Admitting traffic in that
+	// window means answering with 502s the deployment could simply have waited
+	// out: the re-probe lifts the process off the floor within seconds.
+	//
+	// Only a FAILED probe holds readiness. A server that genuinely predates a
+	// feature floor answers its probe, resolves honestly to a lower version,
+	// and is ready — the condition is "we could not ask", not "the answer was
+	// small". And it cannot strand a pod that the ClickHouse ping above would
+	// not already have stranded, since a probe fails only when the server is
+	// unreachable.
+	//
+	// When nil the capability set is treated as resolved.
+	CapabilitiesResolved CapabilitiesResolvedFunc
+
 	// PingTimeout caps the per-probe ClickHouse ping. Defaults to 1s.
 	PingTimeout time.Duration
 
@@ -112,6 +141,7 @@ type Handler struct {
 	pinger        Pinger
 	schemaReady   SchemaReadyFunc
 	schemaPresent SchemaPresentFunc
+	capsResolved  CapabilitiesResolvedFunc
 	headBreakers  HeadBreakersFunc
 	pingTimeout   time.Duration
 	cacheTTL      time.Duration
@@ -127,6 +157,10 @@ type Handler struct {
 type readyResponse struct {
 	ClickHouse string `json:"clickhouse"`
 	Schema     string `json:"schema"`
+	// Capabilities is set only when the ClickHouse capability set could not be
+	// resolved from a live probe, so a ready body stays byte-identical to what
+	// it was before this condition existed.
+	Capabilities string `json:"capabilities,omitempty"`
 	// Heads maps each served head name to its circuit-breaker phase. Omitted
 	// when no HeadBreakersFunc is wired (the probe then reports only the
 	// aggregate ClickHouse + schema conditions).
@@ -141,6 +175,7 @@ func New(opts Options) *Handler {
 		pinger:        opts.Pinger,
 		schemaReady:   opts.SchemaReady,
 		schemaPresent: opts.SchemaPresent,
+		capsResolved:  opts.CapabilitiesResolved,
 		headBreakers:  opts.HeadBreakers,
 		pingTimeout:   opts.PingTimeout,
 		cacheTTL:      opts.CacheTTL,
@@ -259,6 +294,21 @@ func (h *Handler) runCheck(ctx context.Context) (readyResponse, int) {
 				ClickHouse: "ok",
 				Schema:     schema,
 				Heads:      heads,
+			}, http.StatusServiceUnavailable
+		}
+	}
+
+	if h.capsResolved != nil {
+		if resolved, reason := h.capsResolved(); !resolved {
+			caps := "unresolved"
+			if reason != "" {
+				caps = "unresolved: " + reason
+			}
+			return readyResponse{
+				ClickHouse:   "ok",
+				Schema:       "ok",
+				Capabilities: caps,
+				Heads:        heads,
 			}, http.StatusServiceUnavailable
 		}
 	}

--- a/internal/api/health/health_test.go
+++ b/internal/api/health/health_test.go
@@ -330,3 +330,60 @@ func serveReadyz(t *testing.T, h *Handler) *httptest.ResponseRecorder {
 	mux.ServeHTTP(rec, req)
 	return rec
 }
+
+// TestReadyz_CapabilitiesUnresolved: a process whose ClickHouse capability
+// probe never succeeded is NOT ready, even though it is reachable and its
+// schema is present.
+//
+// This is the startup race that produced 502s in the e2e dashboard sweep: a
+// cerberus that boots beside its ClickHouse can win, probe a server that is
+// not listening yet, and pin itself to the supported floor. Every native
+// lowering is then unavailable, and a wide panel served on the fan-out
+// fallback takes long enough to exceed the dashboard proxy's timeout. Holding
+// readiness costs a few seconds; admitting traffic costs a red panel.
+func TestReadyz_CapabilitiesUnresolved(t *testing.T) {
+	const reason = "clickhouse version probe has not succeeded"
+	h := New(Options{
+		Pinger:               &stubPinger{},
+		CapabilitiesResolved: func() (bool, string) { return false, reason },
+		CacheTTL:             -1,
+	})
+
+	rec := serveReadyz(t, h)
+
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Fatalf("status = %d; want 503 — a floor-pinned process serves the slow shape", rec.Code)
+	}
+	var resp map[string]string
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal body: %v", err)
+	}
+	if resp["clickhouse"] != "ok" {
+		t.Errorf("clickhouse = %q; want ok — the server IS reachable, that is the point", resp["clickhouse"])
+	}
+	if !strings.Contains(resp["capabilities"], reason) {
+		t.Errorf("capabilities = %q; want the probe reason embedded", resp["capabilities"])
+	}
+}
+
+// TestReadyz_CapabilitiesResolvedIsReady: the condition is "we could not ask",
+// not "the answer was small". A ClickHouse that genuinely predates a feature
+// floor answers its probe and must not hold the pod out of its Service — and a
+// ready body carries no `capabilities` key at all, so the readiness surface is
+// unchanged for every deployment that was already healthy.
+func TestReadyz_CapabilitiesResolvedIsReady(t *testing.T) {
+	h := New(Options{
+		Pinger:               &stubPinger{},
+		CapabilitiesResolved: func() (bool, string) { return true, "" },
+		CacheTTL:             -1,
+	})
+
+	rec := serveReadyz(t, h)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d; want 200", rec.Code)
+	}
+	if strings.Contains(rec.Body.String(), "capabilities") {
+		t.Errorf("a ready body must not mention capabilities, got %s", rec.Body.String())
+	}
+}

--- a/internal/chaudit/audit.go
+++ b/internal/chaudit/audit.go
@@ -22,8 +22,14 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"regexp"
 	"sort"
 )
+
+// plainIdentifier is what Options.Table must match: a ClickHouse identifier,
+// optionally database-qualified. Anchored at both ends so nothing rides along
+// behind a valid-looking prefix.
+var plainIdentifier = regexp.MustCompile(`^[A-Za-z_][A-Za-z0-9_]*(\.[A-Za-z_][A-Za-z0-9_]*)?$`)
 
 // Querier is the read-only subset of *sql.DB this package needs. Narrow on
 // purpose: an audit must never be able to mutate the deployment it inspects,
@@ -56,6 +62,18 @@ func (o Options) Validate() error {
 	switch {
 	case o.Table == "":
 		return fmt.Errorf("chaudit: Table is required")
+	case !plainIdentifier.MatchString(o.Table):
+		// ClickHouse has no bind form for an identifier, so Table reaches the
+		// query through string interpolation. It arrives from a command-line
+		// flag, so "the caller configured it" is not the same as "the caller
+		// meant it" — a typo becomes a confusing ClickHouse parse error and a
+		// pasted fragment becomes something worse. Restricting it to a plain
+		// (optionally database-qualified) identifier is what lets the queries
+		// interpolate it without further ceremony.
+		return fmt.Errorf(
+			"chaudit: Table %q is not a plain identifier (letters, digits, underscore, "+
+				"optionally database-qualified)", o.Table,
+		)
 	case o.WindowSeconds <= 0:
 		return fmt.Errorf("chaudit: WindowSeconds must be > 0, got %d", o.WindowSeconds)
 	case o.Anchors <= 0:
@@ -132,13 +150,28 @@ func (r Report) OverBudget() []MetricAudit {
 // report and any future gate agree by construction rather than by two authors
 // transcribing the same formula.
 //
-// It mirrors internal/chsql's bucketGridDensityGuardFrag: `(series x anchors)
-// + (rawRows x width^2)`. The duplication is deliberate and bounded — chsql
-// emits this as SQL for ClickHouse to evaluate at query time, which an audit
-// cannot reuse because there is no query to attach it to. The two are pinned
-// together by TestCostUnits_MatchesTheEmittedGuardModel.
+// It mirrors internal/chsql's bucketGridDensityGuardFrag:
+// `(groups x anchors) + (rawRows x width^2)`.
+//
+// `groups` is NOT the series count. The emitter groups by the query's key
+// columns AND the `le` rung (range_bucket_grid_native_bound.go's
+// probeGroups.GroupBy(keyCols..., Col(bucketGridLeAlias))), because Level-0
+// unnests one row per (sample, rung) and Level-1 runs a grid per (series,
+// rung). That file's own header states it: "`groups` is series cardinality
+// times the number of distinct `le` rungs a series' own layout carries".
+//
+// Reading `groups` as `series` understated the first term by the rung count —
+// 12 to 16 on the calibrated production shapes — so the audit reported
+// headroom on metrics the engine would reject. That is the one failure this
+// package must not have: a clean audit that precedes an incident is worse than
+// no audit, because it was consulted and believed.
+//
+// The duplication is deliberate and bounded: chsql emits this as SQL for
+// ClickHouse to evaluate at query time, which an audit cannot reuse because
+// there is no query to attach it to. TestCostUnits_MatchesTheEmittedGuardModel
+// pins the two together.
 func costUnits(series, anchors, rawRows, width int64) int64 {
-	return series*anchors + rawRows*width*width
+	return series*width*anchors + rawRows*width*width
 }
 
 // headroomPct is how much of the budget remains, negative once exceeded.

--- a/internal/chaudit/cost_test.go
+++ b/internal/chaudit/cost_test.go
@@ -5,18 +5,24 @@ import "testing"
 // TestCostUnits_MatchesTheEmittedGuardModel pins this package's copy of the
 // density-guard cost model against the emitter's.
 //
-// internal/chsql emits `(series x anchors) + (rawRows x width^2)` as SQL for
+// internal/chsql emits `(groups x anchors) + (rawRows x width^2)` as SQL for
 // ClickHouse to evaluate at query time; this package evaluates the same
 // formula in Go, because an audit has no query to attach a throwIf to. That
 // duplication is deliberate and bounded, but it can drift silently — an audit
 // reporting healthy headroom under a model the engine no longer uses is worse
 // than no audit, because it is believed.
 //
-// The cases below are hand-computed rather than derived from the function, so
-// a change to costUnits fails here instead of quietly redefining truth. The
-// last row is the real production shape from #2677 (271 series, width 68,
-// ~84k rows, a 6h grid at 60s), whose value must stay recognisable against the
-// ~422M figure that incident was diagnosed with.
+// THE EXPECTED VALUES ARE DECIMAL LITERALS, not expressions. An earlier version
+// wrote them as `271*361 + 83_997*68*68` — costUnits' own body with the
+// operands substituted — so the test asserted the function against itself and
+// passed while the model was WRONG: it read the guard's `groups` factor as
+// `series`, when the emitter groups by the query's keys AND the `le` rung
+// (range_bucket_grid_native_bound.go's probeGroups.GroupBy(keyCols...,
+// Col(bucketGridLeAlias))). A literal cannot be rewritten by the same edit that
+// rewrites the code.
+//
+// The rung sensitivity is asserted directly below, because that is the specific
+// drift this package already suffered.
 func TestCostUnits_MatchesTheEmittedGuardModel(t *testing.T) {
 	t.Parallel()
 
@@ -25,36 +31,50 @@ func TestCostUnits_MatchesTheEmittedGuardModel(t *testing.T) {
 		series, anchors, rawRows, width int64
 		want                            int64
 	}{
-		{"both terms contribute", 10, 100, 50, 4, 10*100 + 50*16},
-		{"width dominates quadratically", 1, 1, 1, 100, 1 + 10_000},
-		{"no rows leaves only the grid term", 253, 360, 0, 68, 253 * 360},
-		{"production shape from #2677", 271, 361, 83_997, 68, 271*361 + 83_997*68*68},
+		// 10 series x 4 rungs x 100 anchors = 4,000; 50 rows x 4^2 = 800.
+		{"both terms contribute", 10, 100, 50, 4, 4_800},
+		// 1 x 100 x 1 = 100; 1 x 100^2 = 10,000.
+		{"width drives both terms", 1, 1, 1, 100, 10_100},
+		// 253 x 68 x 360 = 6,193,440; no rows, so no second term.
+		{"no rows leaves only the grid term", 253, 360, 0, 68, 6_193_440},
+		// The real production shape from #2677: 271 series, width 68, ~84k
+		// rows, a 6h grid at 60s. 271 x 68 x 361 = 6,652,508;
+		// 83,997 x 68^2 = 388,402,128.
+		{"production shape from #2677", 271, 361, 83_997, 68, 395_054_636},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			if got := costUnits(tc.series, tc.anchors, tc.rawRows, tc.width); got != tc.want {
-				t.Errorf("costUnits(%d, %d, %d, %d) = %d, want %d — this package's model has drifted\n"+
-					"from internal/chsql's emitted guard, so the audit is measuring against a\n"+
-					"ceiling the engine does not enforce",
+				t.Errorf("costUnits(%d, %d, %d, %d) = %d, want %d",
 					tc.series, tc.anchors, tc.rawRows, tc.width, got, tc.want)
 			}
 		})
 	}
 }
 
-// TestHeadroomPct_GoesNegativeExactlyWhenRejected pins the number an operator
-// would alert on against the predicate the engine would apply, so a metric
-// cannot read as having headroom while being over budget.
-func TestHeadroomPct_GoesNegativeExactlyWhenRejected(t *testing.T) {
+// TestCostUnits_GridTermScalesWithRungCount is the regression this package
+// actually had: the grid term read `groups` as `series`, dropping the `le`-rung
+// factor entirely and understating cost by the rung count (12-16 on the
+// calibrated production shapes).
+//
+// With rawRows at zero the second term vanishes, so the grid term is observed
+// alone. Under the old model it was `series x anchors` — independent of width —
+// and both cases below would have returned the same number. Any future edit
+// that drops the rung factor fails here rather than silently making the audit
+// optimistic again.
+func TestCostUnits_GridTermScalesWithRungCount(t *testing.T) {
 	t.Parallel()
 
-	for _, tc := range []struct{ cost, budget int64 }{
-		{99, 100}, {100, 100}, {101, 100}, {1, 1_000_000}, {2_000_000, 1_000_000},
-	} {
-		m := MetricAudit{CostUnits: tc.cost, Budget: tc.budget, HeadroomPct: headroomPct(tc.cost, tc.budget)}
-		if got, want := m.HeadroomPct < 0, m.OverBudget(); got != want {
-			t.Errorf("cost=%d budget=%d: headroom<0 is %v but OverBudget is %v — the reported\n"+
-				"number and the verdict disagree", tc.cost, tc.budget, got, want)
-		}
+	const series, anchors = 100, 360
+	narrow := costUnits(series, anchors, 0, 8)
+	wide := costUnits(series, anchors, 0, 16)
+
+	if narrow == wide {
+		t.Fatalf("the grid term ignored the rung count: width 8 and width 16 both cost %d.\n"+
+			"The emitter groups by (keys, le), so `groups` is series x rungs — reading it as\n"+
+			"series alone reports headroom on metrics the engine rejects", narrow)
+	}
+	if wide != narrow*2 {
+		t.Errorf("doubling the rungs must double the grid term: width 8 = %d, width 16 = %d", narrow, wide)
 	}
 }

--- a/internal/chaudit/probe.go
+++ b/internal/chaudit/probe.go
@@ -9,9 +9,10 @@ import (
 // guard multiplies. One pass over the window rather than a query per metric:
 // an audit that costs as much as the panels it protects will not be run.
 //
-// Parameterised on the window only — the table is validated against the
-// caller's own configured schema before it reaches here, and ClickHouse has no
-// bind form for an identifier.
+// Parameterised on the window only: ClickHouse has no bind form for an
+// identifier, so the table is interpolated. Options.Validate restricts it to a
+// plain, optionally database-qualified identifier before any query is built —
+// which is what makes that interpolation safe to write here.
 const factsQuery = `
 SELECT
     MetricName,
@@ -37,6 +38,23 @@ LIMIT ?`
 //
 // arrayJoin over mapKeys enumerates the candidates, so a metric whose labels
 // vary across series still has every key considered.
+//
+// THE COLLAPSE FACTOR ALONE CANNOT NAME THE CULPRIT, and an earlier version of
+// this query claimed it could. `total` is uniqExact(Attributes), which does not
+// reference `key` and is therefore the SAME for every row — so ordering by
+// `total / without_key` reduced to ordering by `without_key` ASCENDING, i.e. it
+// always named whichever label had the HIGHEST cardinality. On this package's
+// own motivating shape (98 `http_route` x 72 `k8s_pod_name`) that ranks
+// `http_route` at 49x above `k8s_pod_name` at 36x: it accuses the legitimate
+// dimension and exonerates the leaked instance identifier.
+//
+// The two are genuinely indistinguishable by cardinality: both are labels whose
+// removal divides the series count by their own value count. So the query now
+// returns the whole ranking and the caller names a label only when one collapse
+// factor stands clear of the runner-up — see probeAmplifyingLabel. A report
+// that lists the factors and declines to accuse is useful; one that confidently
+// names the wrong label is worse than silence, because it sends someone to
+// delete a dimension their panels need.
 const amplifyQuery = `
 SELECT
     key,
@@ -48,8 +66,7 @@ FROM (
     WHERE TimeUnix > now() - toIntervalSecond(?) AND MetricName = ?
 )
 GROUP BY key
-ORDER BY total / greatest(without_key, 1) DESC
-LIMIT 1`
+ORDER BY total / greatest(without_key, 1) DESC, key ASC`
 
 // minAmplificationRatio is the collapse factor below which a label is not
 // worth naming. A label that merely doubles cardinality is usually carrying
@@ -58,6 +75,18 @@ LIMIT 1`
 // catch a genuine defect early, high enough that an ordinary dimension
 // (status code, method) is not reported as a problem.
 const minAmplificationRatio = 4.0
+
+// minAmplifierSeparation is how far the top collapse factor must stand above
+// the runner-up before a label is named at all.
+//
+// Two labels of similar cardinality carry the same evidence: each divides the
+// series count by its own value count, whether it is an instance identifier or
+// a dimension a panel groups by. Naming the larger of two comparable factors is
+// not a finding, it is a coin toss with a byline — and on this package's own
+// motivating shape it lands on the wrong side (98 route templates outrank 72
+// pods). 2x demands the top label be minting identity at twice the rate of
+// anything else before the report points at it.
+const minAmplifierSeparation = 2.0
 
 // Probe runs the audit against a live ClickHouse.
 //
@@ -124,27 +153,47 @@ func probeAmplifyingLabel(ctx context.Context, q Querier, opts Options, metric s
 	}
 	defer func() { _ = rows.Close() }()
 
-	if !rows.Next() {
-		if err := rows.Err(); err != nil {
+	type candidate struct {
+		key   string
+		ratio float64
+	}
+	var ranked []candidate
+	for rows.Next() {
+		var key string
+		var total, without int64
+		if err := rows.Scan(&key, &total, &without); err != nil {
 			return "", 0, err
 		}
-		// A metric with no labels at all is legitimate and not a defect.
-		return "", 0, nil
+		// A label is an AMPLIFIER only if it multiplies a grouping that
+		// survives without it. Removing the sole distinguishing label of a
+		// metric always collapses it to one series, which scores maximally on
+		// the ratio alone — so ratio by itself would accuse every well-shaped
+		// single-dimension metric of the exact defect this audit exists to
+		// find. Requiring the remainder to still carry structure is what
+		// separates "this label IS the dimension" from "this label multiplies
+		// the dimension".
+		if without <= 1 {
+			continue
+		}
+		ranked = append(ranked, candidate{key: key, ratio: float64(total) / float64(without)})
 	}
-	var key string
-	var total, without int64
-	if err := rows.Scan(&key, &total, &without); err != nil {
+	if err := rows.Err(); err != nil {
 		return "", 0, err
 	}
-	// A label is an AMPLIFIER only if it multiplies a grouping that survives
-	// without it. Removing the sole distinguishing label of a metric always
-	// collapses it to one series, which scores maximally on the ratio alone —
-	// so ratio by itself would accuse every well-shaped single-dimension
-	// metric of the exact defect this audit exists to find. Requiring the
-	// remainder to still carry structure is what separates "this label IS the
-	// dimension" from "this label multiplies the dimension".
-	if without <= 1 {
+	if len(ranked) == 0 {
+		// No label multiplies a surviving grouping. Legitimate, not a defect.
 		return "", 0, nil
 	}
-	return key, float64(total) / float64(without), rows.Err()
+	// Name a label only when its collapse factor stands CLEAR of the runner-up.
+	// Two labels of comparable cardinality are indistinguishable on this
+	// evidence — an instance identifier and a real dimension both divide the
+	// series count by their own value count — and the ranking alone would
+	// simply name whichever has more values. Declining to accuse is the honest
+	// outcome there; the cost model above still reports the metric's headroom,
+	// which is the part that does not depend on guessing which label is at
+	// fault.
+	if len(ranked) > 1 && ranked[0].ratio < ranked[1].ratio*minAmplifierSeparation {
+		return "", 0, nil
+	}
+	return ranked[0].key, ranked[0].ratio, nil
 }

--- a/internal/chaudit/report_test.go
+++ b/internal/chaudit/report_test.go
@@ -72,3 +72,34 @@ func TestRankByHeadroom_WorstFirst(t *testing.T) {
 		}
 	}
 }
+
+// TestOptions_Validate_RejectsANonIdentifierTable pins the check that makes the
+// table safe to interpolate. ClickHouse has no bind form for an identifier, so
+// the queries build it with Sprintf; the doc used to claim the caller had
+// validated it against the configured schema, and nothing had.
+func TestOptions_Validate_RejectsANonIdentifierTable(t *testing.T) {
+	t.Parallel()
+
+	base := Options{WindowSeconds: 60, Anchors: 10, DensityUnitBudget: 1000, Top: 5}
+	for _, ok := range []string{"otel_metrics_histogram", "otel.otel_metrics_histogram", "_t1"} {
+		o := base
+		o.Table = ok
+		if err := o.Validate(); err != nil {
+			t.Errorf("Table %q is a plain identifier and must validate: %v", ok, err)
+		}
+	}
+	for _, bad := range []string{
+		"otel_metrics_histogram; DROP TABLE x",
+		"a b",
+		"`quoted`",
+		"db.schema.table",
+		"1_starts_with_digit",
+		"tbl WHERE 1=1 --",
+	} {
+		o := base
+		o.Table = bad
+		if err := o.Validate(); err == nil {
+			t.Errorf("Table %q must be rejected before it reaches a query", bad)
+		}
+	}
+}

--- a/internal/chclient/sqldb.go
+++ b/internal/chclient/sqldb.go
@@ -24,7 +24,28 @@ import (
 // first query, matching every other CLI-driven ClickHouse connection in this
 // codebase.
 func OpenSQLDB(cfg Config) (*sql.DB, error) {
-	db := clickhouse.OpenDB(buildOptions(cfg))
+	opts := buildOptions(cfg)
+	// buildOptions never populates Settings — the serving path applies its caps
+	// per query in Client.querySettings, which this handle does not go through.
+	// Left as-is an offline tool would run UNCAPPED against the deployment it is
+	// inspecting: `cerberus audit`'s probes are uniqExact and arrayJoin over a
+	// whole retention window, exactly the shape that costs a production server
+	// real memory. A read-only tool has no business being the query that
+	// destabilises what it came to measure, so the same two caps the server
+	// enforces are stamped on the connection here.
+	settings := clickhouse.Settings{}
+	if cfg.MaxQueryMemoryBytes > 0 {
+		settings["max_memory_usage"] = cfg.MaxQueryMemoryBytes
+	}
+	if cfg.QueryTimeout > 0 {
+		settings[settingMaxExecutionTime] = cfg.QueryTimeout.Seconds()
+		settings[settingTimeoutOverflowMode] = timeoutOverflowModeThrow
+	}
+	if len(settings) > 0 {
+		opts.Settings = settings
+	}
+
+	db := clickhouse.OpenDB(opts)
 	if db == nil {
 		return nil, fmt.Errorf("chclient: OpenDB returned no handle for %v", cfg.Addrs)
 	}

--- a/internal/engine/routed_corpus_observe_test.go
+++ b/internal/engine/routed_corpus_observe_test.go
@@ -195,10 +195,17 @@ func wantParallelism(eng *Engine, d *solver.Decision) int {
 // slicing this plan into a single shard, the whole route-B observation family
 // would still pass while testing no fan-out at all. Pinning the number here
 // turns that degeneration into a failure at the one place it originates.
-// Was 8 until #2685 raised the MaxK backstop from 8 to 32: this fixture's K is
-// derived from its own grid (N/MinAnchorsPerSlice) and was previously clipped
-// by that ceiling, so the number moved without the fixture changing.
-const fixtureShardCount = 12
+// Was 8 until #2685 raised the MaxK backstop from 8 to 32, then 12 until #2709
+// returned it to 8: this fixture's K is derived from its own grid
+// (N/MinAnchorsPerSlice = 12) and is clipped by that ceiling whenever the
+// ceiling sits below it, so the number moves with the backstop without the
+// fixture changing. It is back at the clipped value now.
+//
+// The number is what makes the guard bite, but the PROPERTY it protects is
+// "this fixture really fans out" — if a future change makes K derive below the
+// ceiling, update this constant rather than removing the check, or the whole
+// route-B observation family goes green while exercising a single shard.
+const fixtureShardCount = 8
 
 // routedDecision classifies the eligible fixture plan into the routed decision
 // the engine's own route-B paths take.

--- a/internal/solver/config.go
+++ b/internal/solver/config.go
@@ -143,27 +143,38 @@ type Config struct {
 const (
 	defaultMinFanout      = 16
 	defaultMinAnchorPairs = 4000
-	// defaultMaxK was raised from 8 to 32 for issue #2685. At 8 it was the
-	// BINDING constraint on wide-window relief rather than a backstop: a 6h
-	// dashboard panel at real production cardinality (253 series, bucket
-	// width 68, measured on ClickHouse 26.6) derives K = N/MinAnchorsPerSlice
-	// = 22 from its own grid, but was truncated to 8 — and at 8 each shard's
-	// scan, widened by the window lookback, lands at 53.8M density cost units
-	// against a 54M ceiling. Over by 0.4%, so the whole query failed while
-	// the sizing the solver had already computed for itself would have fit.
+	// defaultMaxK was raised 8 -> 32 for #2685 and returned to 8 for #2709.
+	// Both moves were right about the case in front of them, and the two cases
+	// pull in opposite directions — so this constant is a TRADE, not a tuning,
+	// and the next person to move it should know what they are giving up.
 	//
-	// 32 is chosen so the anchor-derived K governs across realistic dashboard
-	// windows instead of being clipped: at MinAnchorsPerSlice = 16 the derived
-	// K only reaches 32 at N >= 512 anchors, and the head caps a range query
-	// at format.MaxResolutionPoints (11000) regardless. The cost of the raise
-	// is bounded and predictable — K shards run CERBERUS_SHARD_PARALLEL (3) at
-	// a time, so K = 32 is ~11 sequential rounds rather than 3.
+	// WHY 32 (issue #2685). At 8 the ceiling was the BINDING constraint on
+	// wide-window relief rather than a backstop: a 6h dashboard panel at real
+	// production cardinality (253 series, bucket width 68, measured on
+	// ClickHouse 26.6) derives K = N/MinAnchorsPerSlice = 22 from its own grid,
+	// was truncated to 8, and at 8 each shard's scan — widened by the window
+	// lookback — lands at 53.8M density cost units against a 54M ceiling. Over
+	// by 0.4%, so the whole query failed while the sizing the solver had
+	// already computed for itself would have fit.
 	//
-	// It is still a real ceiling, deliberately: a window wide enough to need
-	// more than 32 shards is asking for more ClickHouse work than a single
-	// dashboard refresh should commit, and an operator who wants it raises
-	// CERBERUS_SHARD_MAX_K explicitly.
-	defaultMaxK               = 32
+	// WHY BACK TO 8 (issue #2709). K derives from grid geometry alone, and
+	// nothing in the decision looks at how much DATA sits behind the grid. A
+	// 24h/1m panel is 1441 anchors and takes the full ceiling whether the table
+	// holds a billion rows or almost none. Shards run CERBERUS_SHARD_PARALLEL
+	// (3) at a time, so K=32 is ~11 sequential rounds against ~3 at K=8 — and
+	// on a small or newly-provisioned deployment those eight extra rounds are
+	// pure round-trip overhead for a table with nothing to divide. The e2e
+	// dashboard sweep measured that panel at 19s and Grafana's proxy cut it,
+	// on exactly the wide-window shape #2677 set out to make usable.
+	//
+	// So #2685's failure mode returns at production cardinality: a panel whose
+	// own grid asks for K>8 is clipped again, and one of those was measured
+	// 0.4% over the density ceiling. An operator hitting it raises
+	// CERBERUS_SHARD_MAX_K, which is the knob that exists for exactly this.
+	// The durable fix is to bound K by the work available rather than by the
+	// grid quantum, so neither deployment size has to be traded for the other —
+	// tracked in #2709.
+	defaultMaxK               = 8
 	defaultMinAnchorsPerSlice = 16
 	defaultParallel           = 3
 	defaultTimeout            = 60 * time.Second

--- a/internal/solver/config_test.go
+++ b/internal/solver/config_test.go
@@ -14,7 +14,7 @@ func TestDefaultConfig_Valid(t *testing.T) {
 	if c.Mode != ModeSingle {
 		t.Fatalf("default Mode = %q, want %q (ship dark)", c.Mode, ModeSingle)
 	}
-	if c.MinFanout != 16 || c.MinAnchorPairs != 4000 || c.MaxK != 32 ||
+	if c.MinFanout != 16 || c.MinAnchorPairs != 4000 || c.MaxK != 8 ||
 		c.MinAnchorsPerSlice != 16 || c.Parallel != 3 || c.MaxOutputRows != 2_000_000 {
 		t.Fatalf("default tuning drifted: %+v", c)
 	}

--- a/internal/solver/planner.go
+++ b/internal/solver/planner.go
@@ -1259,7 +1259,7 @@ func (p *Planner) checkRangeBucketGridNativeGrid(v *chplan.RangeBucketGridNative
 		if startZero || endZero {
 			sig.sawUnpinnedBound = true
 		}
-		if !startZero && !endZero && !(v.Start.Equal(predStart) && v.End.Equal(predEnd)) {
+		if !startZero && !endZero && !rangeBucketGridNativeGridMatches(v, predStart, predEnd) {
 			sig.sawGridMismatch = true
 		}
 	} else if startZero != endZero {
@@ -1274,6 +1274,12 @@ func (p *Planner) checkRangeBucketGridNativeGrid(v *chplan.RangeBucketGridNative
 	if depth > 0 && v.Step > 0 {
 		sig.endPhasedResolutions = append(sig.endPhasedResolutions, v.Step)
 	}
+}
+
+// rangeBucketGridNativeGridMatches mirrors rangeBucketFanoutGridMatches: both
+// bounds are exactly the ones the caller predicted.
+func rangeBucketGridNativeGridMatches(v *chplan.RangeBucketGridNative, predStart, predEnd time.Time) bool {
+	return v.Start.Equal(predStart) && v.End.Equal(predEnd)
 }
 
 func rangeBucketFanoutGridMatches(v *chplan.RangeBucketFanout, predStart, predEnd time.Time) bool {

--- a/internal/solver/planner.go
+++ b/internal/solver/planner.go
@@ -1201,6 +1201,7 @@ func (p *Planner) walkRangeBucketFanout(v *chplan.RangeBucketFanout, predStart, 
 // statement cap, mirroring walkHistogramQuantile.
 func (p *Planner) walkRangeBucketGridNative(v *chplan.RangeBucketGridNative, predStart, predEnd time.Time, depth int, sig *signals) {
 	p.recordGridCarrier(v, depth, sig)
+	p.checkRangeBucketGridNativeGrid(v, predStart, predEnd, depth, sig)
 	for _, e := range v.GroupBy {
 		p.walkExpr(e, predStart, predEnd, v.Step, sig)
 	}
@@ -1230,6 +1231,46 @@ func (p *Planner) checkRangeBucketFanoutGrid(v *chplan.RangeBucketFanout, predSt
 	// A RangeBucketFanout's anchors are generated backward from End with no
 	// epoch snap (mirrors the plain RangeLWR case checkRangeLWRGrid handles),
 	// so a nested one always constrains the slice quantum.
+	if depth > 0 && v.Step > 0 {
+		sig.endPhasedResolutions = append(sig.endPhasedResolutions, v.Step)
+	}
+}
+
+// checkRangeBucketGridNativeGrid is the two-bound grid-prediction check for the
+// native ladder, mirroring checkRangeBucketFanoutGrid.
+//
+// It was DOCUMENTED as present from #2677 and was not: the doc paragraph above
+// walkRangeBucketGridNative was rewritten to claim the check while the body was
+// left byte-identical, in the same change that made this kind shardable. That
+// left slicer.go's UnpinSpine resting on "the lowering cannot produce that
+// shape" — which checkRangeWindowGridNativeGrid's own doc states is not a
+// property the slicer may rest correctness on. UnpinSpine zeroes Start/End on
+// this node unconditionally, and chplan's checkPredictedGridBucketGridNative
+// returns early once both bounds are zero, so nothing downstream re-derives
+// what the planner declined to reject.
+//
+// Two bounds rather than three: unlike RangeWindowGridNative this kind carries
+// no OuterRange, so its whole grid is (Start, End, Step) and a mismatch is
+// exactly "these bounds are not the ones the caller predicted".
+func (p *Planner) checkRangeBucketGridNativeGrid(v *chplan.RangeBucketGridNative, predStart, predEnd time.Time, depth int, sig *signals) {
+	startZero := v.Start.IsZero()
+	endZero := v.End.IsZero()
+	if depth == 0 {
+		if startZero || endZero {
+			sig.sawUnpinnedBound = true
+		}
+		if !startZero && !endZero && !(v.Start.Equal(predStart) && v.End.Equal(predEnd)) {
+			sig.sawGridMismatch = true
+		}
+	} else if startZero != endZero {
+		// A half-pinned nested grid is the shape recordGridCarrier's
+		// outerRange arithmetic cannot see: End.Sub(zero Start) saturates
+		// positive, so sawInstantWindow does not fire and the plan would be
+		// admitted on a bound nobody proved.
+		sig.sawUnpinnedBound = true
+	}
+	// Anchors are generated backward from End with no epoch snap, exactly as
+	// the fan-out sibling's are, so a nested one constrains the slice quantum.
 	if depth > 0 && v.Step > 0 {
 		sig.endPhasedResolutions = append(sig.endPhasedResolutions, v.Step)
 	}

--- a/internal/solver/planner_test.go
+++ b/internal/solver/planner_test.go
@@ -72,14 +72,21 @@ func TestPlan_OOMShapeRoutes(t *testing.T) {
 	if d.Reason != ReasonRouted {
 		t.Fatalf("reason = %q, want %q", d.Reason, ReasonRouted)
 	}
-	if d.K != 12 {
-		t.Fatalf("K = %d, want 12 (N/MinAnchorsPerSlice, not the MaxK backstop)", d.K)
+	// The OOM fixture's own grid derives K = N/MinAnchorsPerSlice = 12, but
+	// defaultMaxK returned to 8 for #2709, so the backstop CLIPS it. That
+	// clipping is the cost side of the trade recorded on defaultMaxK: it is
+	// what #2685 removed and #2709 put back, deliberately, to stop a small
+	// deployment paying ~11 sequential shard rounds for a grid with almost no
+	// data behind it. If this assertion ever reads 12 again, the ceiling moved
+	// and #2685's failure mode is the thing to re-check.
+	if d.K != 8 {
+		t.Fatalf("K = %d, want 8 (clipped by the MaxK backstop; derived K is 12)", d.K)
 	}
 	if d.Strategy != StrategyShardedTimeslice {
 		t.Fatalf("strategy = %q, want %q", d.Strategy, StrategyShardedTimeslice)
 	}
-	if len(d.Slices) != 12 {
-		t.Fatalf("len(Slices) = %d, want 12", len(d.Slices))
+	if len(d.Slices) != 8 {
+		t.Fatalf("len(Slices) = %d, want 8 (one per shard at the clipped K)", len(d.Slices))
 	}
 }
 
@@ -827,8 +834,8 @@ func TestPlan_ScalarAnchorCompatibleRoutes(t *testing.T) {
 	if d.Reason != ReasonRouted {
 		t.Fatalf("reason = %q, want %q", d.Reason, ReasonRouted)
 	}
-	if d.K != 12 {
-		t.Fatalf("K = %d, want 12 (same OOM shape as TestPlan_OOMShapeRoutes)", d.K)
+	if d.K != 8 {
+		t.Fatalf("K = %d, want 8 (same OOM shape as TestPlan_OOMShapeRoutes, clipped by MaxK)", d.K)
 	}
 }
 

--- a/test/perf/solver-decision-baseline/abs_metric/fanout.json
+++ b/test/perf/solver-decision-baseline/abs_metric/fanout.json
@@ -2,7 +2,7 @@
   "query": "abs_metric/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 12,
+  "k": 8,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/agg_by_dotted_source/fanout.json
+++ b/test/perf/solver-decision-baseline/agg_by_dotted_source/fanout.json
@@ -2,7 +2,7 @@
   "query": "agg_by_dotted_source/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 12,
+  "k": 8,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/agg_by_service_name/fanout.json
+++ b/test/perf/solver-decision-baseline/agg_by_service_name/fanout.json
@@ -2,7 +2,7 @@
   "query": "agg_by_service_name/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 12,
+  "k": 8,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/agg_range_window_over_scalar_div/fanout.json
+++ b/test/perf/solver-decision-baseline/agg_range_window_over_scalar_div/fanout.json
@@ -2,7 +2,7 @@
   "query": "agg_range_window_over_scalar_div/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 12,
+  "k": 8,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/agg_range_window_over_scalar_div/native.json
+++ b/test/perf/solver-decision-baseline/agg_range_window_over_scalar_div/native.json
@@ -2,7 +2,7 @@
   "query": "agg_range_window_over_scalar_div/native",
   "lowering": "native",
   "routed": true,
-  "k": 12,
+  "k": 8,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/binop_atan2_scalar_vector/fanout.json
+++ b/test/perf/solver-decision-baseline/binop_atan2_scalar_vector/fanout.json
@@ -2,7 +2,7 @@
   "query": "binop_atan2_scalar_vector/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 12,
+  "k": 8,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/binop_atan2_vector_scalar/fanout.json
+++ b/test/perf/solver-decision-baseline/binop_atan2_vector_scalar/fanout.json
@@ -2,7 +2,7 @@
   "query": "binop_atan2_vector_scalar/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 12,
+  "k": 8,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/binop_metric_minus_time/fanout.json
+++ b/test/perf/solver-decision-baseline/binop_metric_minus_time/fanout.json
@@ -2,7 +2,7 @@
   "query": "binop_metric_minus_time/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 12,
+  "k": 8,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/binop_time_arith_range/fanout.json
+++ b/test/perf/solver-decision-baseline/binop_time_arith_range/fanout.json
@@ -2,7 +2,7 @@
   "query": "binop_time_arith_range/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 12,
+  "k": 8,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/binop_time_lt_bool_metric/fanout.json
+++ b/test/perf/solver-decision-baseline/binop_time_lt_bool_metric/fanout.json
@@ -2,7 +2,7 @@
   "query": "binop_time_lt_bool_metric/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 12,
+  "k": 8,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/binop_time_lt_metric/fanout.json
+++ b/test/perf/solver-decision-baseline/binop_time_lt_metric/fanout.json
@@ -2,7 +2,7 @@
   "query": "binop_time_lt_metric/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 12,
+  "k": 8,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/binop_time_plus_metric/fanout.json
+++ b/test/perf/solver-decision-baseline/binop_time_plus_metric/fanout.json
@@ -2,7 +2,7 @@
   "query": "binop_time_plus_metric/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 12,
+  "k": 8,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/bool_lt/fanout.json
+++ b/test/perf/solver-decision-baseline/bool_lt/fanout.json
@@ -2,7 +2,7 @@
   "query": "bool_lt/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 12,
+  "k": 8,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/bottomk_below_one_empty/fanout.json
+++ b/test/perf/solver-decision-baseline/bottomk_below_one_empty/fanout.json
@@ -2,7 +2,7 @@
   "query": "bottomk_below_one_empty/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 12,
+  "k": 8,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/ceil_duplicate_labelset/fanout.json
+++ b/test/perf/solver-decision-baseline/ceil_duplicate_labelset/fanout.json
@@ -2,7 +2,7 @@
   "query": "ceil_duplicate_labelset/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 12,
+  "k": 8,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/ceil_metric/fanout.json
+++ b/test/perf/solver-decision-baseline/ceil_metric/fanout.json
@@ -2,7 +2,7 @@
   "query": "ceil_metric/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 12,
+  "k": 8,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/chained_filter/fanout.json
+++ b/test/perf/solver-decision-baseline/chained_filter/fanout.json
@@ -2,7 +2,7 @@
   "query": "chained_filter/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 12,
+  "k": 8,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/changes_nan_run/fanout.json
+++ b/test/perf/solver-decision-baseline/changes_nan_run/fanout.json
@@ -2,7 +2,7 @@
   "query": "changes_nan_run/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 12,
+  "k": 8,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/changes_nan_run/native.json
+++ b/test/perf/solver-decision-baseline/changes_nan_run/native.json
@@ -2,7 +2,7 @@
   "query": "changes_nan_run/native",
   "lowering": "native",
   "routed": true,
-  "k": 12,
+  "k": 8,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/changes_oscillating/fanout.json
+++ b/test/perf/solver-decision-baseline/changes_oscillating/fanout.json
@@ -2,7 +2,7 @@
   "query": "changes_oscillating/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 12,
+  "k": 8,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/changes_oscillating/native.json
+++ b/test/perf/solver-decision-baseline/changes_oscillating/native.json
@@ -2,7 +2,7 @@
   "query": "changes_oscillating/native",
   "lowering": "native",
   "routed": true,
-  "k": 12,
+  "k": 8,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/clamp/fanout.json
+++ b/test/perf/solver-decision-baseline/clamp/fanout.json
@@ -2,7 +2,7 @@
   "query": "clamp/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 12,
+  "k": 8,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/clamp_max/fanout.json
+++ b/test/perf/solver-decision-baseline/clamp_max/fanout.json
@@ -2,7 +2,7 @@
   "query": "clamp_max/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 12,
+  "k": 8,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/clamp_max_scalar_bound/fanout.json
+++ b/test/perf/solver-decision-baseline/clamp_max_scalar_bound/fanout.json
@@ -2,7 +2,7 @@
   "query": "clamp_max_scalar_bound/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 12,
+  "k": 8,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/clamp_max_scalar_bound_range_per_step/fanout.json
+++ b/test/perf/solver-decision-baseline/clamp_max_scalar_bound_range_per_step/fanout.json
@@ -2,7 +2,7 @@
   "query": "clamp_max_scalar_bound_range_per_step/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 12,
+  "k": 8,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/clamp_min/fanout.json
+++ b/test/perf/solver-decision-baseline/clamp_min/fanout.json
@@ -2,7 +2,7 @@
   "query": "clamp_min/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 12,
+  "k": 8,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/clamp_min_scalar_bound/fanout.json
+++ b/test/perf/solver-decision-baseline/clamp_min_scalar_bound/fanout.json
@@ -2,7 +2,7 @@
   "query": "clamp_min_scalar_bound/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 12,
+  "k": 8,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/clamp_min_scalar_nan_bound/fanout.json
+++ b/test/perf/solver-decision-baseline/clamp_min_scalar_nan_bound/fanout.json
@@ -2,7 +2,7 @@
   "query": "clamp_min_scalar_nan_bound/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 12,
+  "k": 8,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/clamp_scalar_min_literal_max/fanout.json
+++ b/test/perf/solver-decision-baseline/clamp_scalar_min_literal_max/fanout.json
@@ -2,7 +2,7 @@
   "query": "clamp_scalar_min_literal_max/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 12,
+  "k": 8,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/comparison_arithmetic/fanout.json
+++ b/test/perf/solver-decision-baseline/comparison_arithmetic/fanout.json
@@ -2,7 +2,7 @@
   "query": "comparison_arithmetic/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 12,
+  "k": 8,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/count_agg_returns_float/fanout.json
+++ b/test/perf/solver-decision-baseline/count_agg_returns_float/fanout.json
@@ -2,7 +2,7 @@
   "query": "count_agg_returns_float/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 12,
+  "k": 8,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/count_no_group/fanout.json
+++ b/test/perf/solver-decision-baseline/count_no_group/fanout.json
@@ -2,7 +2,7 @@
   "query": "count_no_group/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 12,
+  "k": 8,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/count_over_time_exp_histogram/fanout.json
+++ b/test/perf/solver-decision-baseline/count_over_time_exp_histogram/fanout.json
@@ -2,7 +2,7 @@
   "query": "count_over_time_exp_histogram/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 12,
+  "k": 8,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/count_over_time_exp_histogram/native.json
+++ b/test/perf/solver-decision-baseline/count_over_time_exp_histogram/native.json
@@ -2,7 +2,7 @@
   "query": "count_over_time_exp_histogram/native",
   "lowering": "native",
   "routed": true,
-  "k": 12,
+  "k": 8,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/count_values_basic/fanout.json
+++ b/test/perf/solver-decision-baseline/count_values_basic/fanout.json
@@ -2,7 +2,7 @@
   "query": "count_values_basic/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 12,
+  "k": 8,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/count_values_without/fanout.json
+++ b/test/perf/solver-decision-baseline/count_values_without/fanout.json
@@ -2,7 +2,7 @@
   "query": "count_values_without/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 12,
+  "k": 8,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/count_values_without_empty/fanout.json
+++ b/test/perf/solver-decision-baseline/count_values_without_empty/fanout.json
@@ -2,7 +2,7 @@
   "query": "count_values_without_empty/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 12,
+  "k": 8,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/day_of_month_of_vector/fanout.json
+++ b/test/perf/solver-decision-baseline/day_of_month_of_vector/fanout.json
@@ -2,7 +2,7 @@
   "query": "day_of_month_of_vector/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 12,
+  "k": 8,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/day_of_week_offset/fanout.json
+++ b/test/perf/solver-decision-baseline/day_of_week_offset/fanout.json
@@ -2,7 +2,7 @@
   "query": "day_of_week_offset/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 12,
+  "k": 8,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/day_of_year_of_vector/fanout.json
+++ b/test/perf/solver-decision-baseline/day_of_year_of_vector/fanout.json
@@ -2,7 +2,7 @@
   "query": "day_of_year_of_vector/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 12,
+  "k": 8,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/days_in_month_of_vector/fanout.json
+++ b/test/perf/solver-decision-baseline/days_in_month_of_vector/fanout.json
@@ -2,7 +2,7 @@
   "query": "days_in_month_of_vector/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 12,
+  "k": 8,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/deg_metric/fanout.json
+++ b/test/perf/solver-decision-baseline/deg_metric/fanout.json
@@ -2,7 +2,7 @@
   "query": "deg_metric/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 12,
+  "k": 8,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/deriv_linear_increase/fanout.json
+++ b/test/perf/solver-decision-baseline/deriv_linear_increase/fanout.json
@@ -2,7 +2,7 @@
   "query": "deriv_linear_increase/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 12,
+  "k": 8,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/edge_abs_over_rate/fanout.json
+++ b/test/perf/solver-decision-baseline/edge_abs_over_rate/fanout.json
@@ -2,7 +2,7 @@
   "query": "edge_abs_over_rate/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 12,
+  "k": 8,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/edge_avg_over_time/fanout.json
+++ b/test/perf/solver-decision-baseline/edge_avg_over_time/fanout.json
@@ -2,7 +2,7 @@
   "query": "edge_avg_over_time/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 12,
+  "k": 8,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/edge_avg_over_time/native.json
+++ b/test/perf/solver-decision-baseline/edge_avg_over_time/native.json
@@ -2,7 +2,7 @@
   "query": "edge_avg_over_time/native",
   "lowering": "native",
   "routed": true,
-  "k": 12,
+  "k": 8,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/edge_bool_eq/fanout.json
+++ b/test/perf/solver-decision-baseline/edge_bool_eq/fanout.json
@@ -2,7 +2,7 @@
   "query": "edge_bool_eq/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 12,
+  "k": 8,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/edge_bool_ge/fanout.json
+++ b/test/perf/solver-decision-baseline/edge_bool_ge/fanout.json
@@ -2,7 +2,7 @@
   "query": "edge_bool_ge/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 12,
+  "k": 8,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/edge_bool_le/fanout.json
+++ b/test/perf/solver-decision-baseline/edge_bool_le/fanout.json
@@ -2,7 +2,7 @@
   "query": "edge_bool_le/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 12,
+  "k": 8,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/edge_bool_ne/fanout.json
+++ b/test/perf/solver-decision-baseline/edge_bool_ne/fanout.json
@@ -2,7 +2,7 @@
   "query": "edge_bool_ne/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 12,
+  "k": 8,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/edge_ceil_over_sum_by/fanout.json
+++ b/test/perf/solver-decision-baseline/edge_ceil_over_sum_by/fanout.json
@@ -2,7 +2,7 @@
   "query": "edge_ceil_over_sum_by/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 12,
+  "k": 8,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/edge_clamp_neg_to_pos/fanout.json
+++ b/test/perf/solver-decision-baseline/edge_clamp_neg_to_pos/fanout.json
@@ -2,7 +2,7 @@
   "query": "edge_clamp_neg_to_pos/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 12,
+  "k": 8,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/edge_count_over_time/fanout.json
+++ b/test/perf/solver-decision-baseline/edge_count_over_time/fanout.json
@@ -2,7 +2,7 @@
   "query": "edge_count_over_time/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 12,
+  "k": 8,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/edge_count_over_time/native.json
+++ b/test/perf/solver-decision-baseline/edge_count_over_time/native.json
@@ -2,7 +2,7 @@
   "query": "edge_count_over_time/native",
   "lowering": "native",
   "routed": true,
-  "k": 12,
+  "k": 8,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/edge_last_over_time/fanout.json
+++ b/test/perf/solver-decision-baseline/edge_last_over_time/fanout.json
@@ -2,7 +2,7 @@
   "query": "edge_last_over_time/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 12,
+  "k": 8,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/edge_last_over_time/native.json
+++ b/test/perf/solver-decision-baseline/edge_last_over_time/native.json
@@ -2,7 +2,7 @@
   "query": "edge_last_over_time/native",
   "lowering": "native",
   "routed": true,
-  "k": 12,
+  "k": 8,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/edge_log10_over_rate/fanout.json
+++ b/test/perf/solver-decision-baseline/edge_log10_over_rate/fanout.json
@@ -2,7 +2,7 @@
   "query": "edge_log10_over_rate/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 12,
+  "k": 8,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/edge_neg_scalar_minus_vector/fanout.json
+++ b/test/perf/solver-decision-baseline/edge_neg_scalar_minus_vector/fanout.json
@@ -2,7 +2,7 @@
   "query": "edge_neg_scalar_minus_vector/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 12,
+  "k": 8,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/edge_offset_zero/fanout.json
+++ b/test/perf/solver-decision-baseline/edge_offset_zero/fanout.json
@@ -2,7 +2,7 @@
   "query": "edge_offset_zero/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 12,
+  "k": 8,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/edge_paren_chain_arith/fanout.json
+++ b/test/perf/solver-decision-baseline/edge_paren_chain_arith/fanout.json
@@ -2,7 +2,7 @@
   "query": "edge_paren_chain_arith/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 12,
+  "k": 8,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/edge_rate_negative_offset/fanout.json
+++ b/test/perf/solver-decision-baseline/edge_rate_negative_offset/fanout.json
@@ -2,7 +2,7 @@
   "query": "edge_rate_negative_offset/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 12,
+  "k": 8,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/edge_round_step_half/fanout.json
+++ b/test/perf/solver-decision-baseline/edge_round_step_half/fanout.json
@@ -2,7 +2,7 @@
   "query": "edge_round_step_half/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 12,
+  "k": 8,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/edge_sqrt_over_aggregate/fanout.json
+++ b/test/perf/solver-decision-baseline/edge_sqrt_over_aggregate/fanout.json
@@ -2,7 +2,7 @@
   "query": "edge_sqrt_over_aggregate/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 12,
+  "k": 8,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/exp_histogram_changes/fanout.json
+++ b/test/perf/solver-decision-baseline/exp_histogram_changes/fanout.json
@@ -2,7 +2,7 @@
   "query": "exp_histogram_changes/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 12,
+  "k": 8,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/exp_histogram_changes/native.json
+++ b/test/perf/solver-decision-baseline/exp_histogram_changes/native.json
@@ -2,7 +2,7 @@
   "query": "exp_histogram_changes/native",
   "lowering": "native",
   "routed": true,
-  "k": 12,
+  "k": 8,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/exp_histogram_count/fanout.json
+++ b/test/perf/solver-decision-baseline/exp_histogram_count/fanout.json
@@ -2,7 +2,7 @@
   "query": "exp_histogram_count/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 12,
+  "k": 8,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/exp_histogram_count/native.json
+++ b/test/perf/solver-decision-baseline/exp_histogram_count/native.json
@@ -2,7 +2,7 @@
   "query": "exp_histogram_count/native",
   "lowering": "native",
   "routed": true,
-  "k": 12,
+  "k": 8,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/exp_histogram_count_by/fanout.json
+++ b/test/perf/solver-decision-baseline/exp_histogram_count_by/fanout.json
@@ -2,7 +2,7 @@
   "query": "exp_histogram_count_by/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 12,
+  "k": 8,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/exp_histogram_count_by/native.json
+++ b/test/perf/solver-decision-baseline/exp_histogram_count_by/native.json
@@ -2,7 +2,7 @@
   "query": "exp_histogram_count_by/native",
   "lowering": "native",
   "routed": true,
-  "k": 12,
+  "k": 8,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/exp_histogram_resets/fanout.json
+++ b/test/perf/solver-decision-baseline/exp_histogram_resets/fanout.json
@@ -2,7 +2,7 @@
   "query": "exp_histogram_resets/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 12,
+  "k": 8,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/exp_histogram_resets/native.json
+++ b/test/perf/solver-decision-baseline/exp_histogram_resets/native.json
@@ -2,7 +2,7 @@
   "query": "exp_histogram_resets/native",
   "lowering": "native",
   "routed": true,
-  "k": 12,
+  "k": 8,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/exp_histogram_sum_over_ts_of_first_over_time/fanout.json
+++ b/test/perf/solver-decision-baseline/exp_histogram_sum_over_ts_of_first_over_time/fanout.json
@@ -2,7 +2,7 @@
   "query": "exp_histogram_sum_over_ts_of_first_over_time/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 12,
+  "k": 8,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/exp_histogram_sum_over_ts_of_first_over_time/native.json
+++ b/test/perf/solver-decision-baseline/exp_histogram_sum_over_ts_of_first_over_time/native.json
@@ -2,7 +2,7 @@
   "query": "exp_histogram_sum_over_ts_of_first_over_time/native",
   "lowering": "native",
   "routed": true,
-  "k": 12,
+  "k": 8,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/exp_histogram_sum_over_ts_of_last_over_time/fanout.json
+++ b/test/perf/solver-decision-baseline/exp_histogram_sum_over_ts_of_last_over_time/fanout.json
@@ -2,7 +2,7 @@
   "query": "exp_histogram_sum_over_ts_of_last_over_time/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 12,
+  "k": 8,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/exp_histogram_sum_over_ts_of_last_over_time/native.json
+++ b/test/perf/solver-decision-baseline/exp_histogram_sum_over_ts_of_last_over_time/native.json
@@ -2,7 +2,7 @@
   "query": "exp_histogram_sum_over_ts_of_last_over_time/native",
   "lowering": "native",
   "routed": true,
-  "k": 12,
+  "k": 8,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/exp_metric/fanout.json
+++ b/test/perf/solver-decision-baseline/exp_metric/fanout.json
@@ -2,7 +2,7 @@
   "query": "exp_metric/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 12,
+  "k": 8,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/first_over_time/fanout.json
+++ b/test/perf/solver-decision-baseline/first_over_time/fanout.json
@@ -2,7 +2,7 @@
   "query": "first_over_time/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 12,
+  "k": 8,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/first_over_time/native.json
+++ b/test/perf/solver-decision-baseline/first_over_time/native.json
@@ -2,7 +2,7 @@
   "query": "first_over_time/native",
   "lowering": "native",
   "routed": true,
-  "k": 12,
+  "k": 8,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/floor_metric/fanout.json
+++ b/test/perf/solver-decision-baseline/floor_metric/fanout.json
@@ -2,7 +2,7 @@
   "query": "floor_metric/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 12,
+  "k": 8,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/group_basic/fanout.json
+++ b/test/perf/solver-decision-baseline/group_basic/fanout.json
@@ -2,7 +2,7 @@
   "query": "group_basic/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 12,
+  "k": 8,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/group_by_job/fanout.json
+++ b/test/perf/solver-decision-baseline/group_by_job/fanout.json
@@ -2,7 +2,7 @@
   "query": "group_by_job/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 12,
+  "k": 8,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/histogram_avg_exp/fanout.json
+++ b/test/perf/solver-decision-baseline/histogram_avg_exp/fanout.json
@@ -2,7 +2,7 @@
   "query": "histogram_avg_exp/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 12,
+  "k": 8,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/histogram_avg_exp/native.json
+++ b/test/perf/solver-decision-baseline/histogram_avg_exp/native.json
@@ -2,7 +2,7 @@
   "query": "histogram_avg_exp/native",
   "lowering": "native",
   "routed": true,
-  "k": 12,
+  "k": 8,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/histogram_avg_exp_latest_sample/fanout.json
+++ b/test/perf/solver-decision-baseline/histogram_avg_exp_latest_sample/fanout.json
@@ -2,7 +2,7 @@
   "query": "histogram_avg_exp_latest_sample/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 12,
+  "k": 8,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/histogram_avg_exp_latest_sample/native.json
+++ b/test/perf/solver-decision-baseline/histogram_avg_exp_latest_sample/native.json
@@ -2,7 +2,7 @@
   "query": "histogram_avg_exp_latest_sample/native",
   "lowering": "native",
   "routed": true,
-  "k": 12,
+  "k": 8,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/histogram_avg_exp_range_latest_sample/fanout.json
+++ b/test/perf/solver-decision-baseline/histogram_avg_exp_range_latest_sample/fanout.json
@@ -2,7 +2,7 @@
   "query": "histogram_avg_exp_range_latest_sample/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 12,
+  "k": 8,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/histogram_avg_exp_range_latest_sample/native.json
+++ b/test/perf/solver-decision-baseline/histogram_avg_exp_range_latest_sample/native.json
@@ -2,7 +2,7 @@
   "query": "histogram_avg_exp_range_latest_sample/native",
   "lowering": "native",
   "routed": true,
-  "k": 12,
+  "k": 8,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/histogram_bucket_companion/fanout.json
+++ b/test/perf/solver-decision-baseline/histogram_bucket_companion/fanout.json
@@ -2,7 +2,7 @@
   "query": "histogram_bucket_companion/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 12,
+  "k": 8,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/histogram_bucket_le_filter/fanout.json
+++ b/test/perf/solver-decision-baseline/histogram_bucket_le_filter/fanout.json
@@ -2,7 +2,7 @@
   "query": "histogram_bucket_le_filter/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 12,
+  "k": 8,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/histogram_count_exp/fanout.json
+++ b/test/perf/solver-decision-baseline/histogram_count_exp/fanout.json
@@ -2,7 +2,7 @@
   "query": "histogram_count_exp/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 12,
+  "k": 8,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/histogram_count_exp/native.json
+++ b/test/perf/solver-decision-baseline/histogram_count_exp/native.json
@@ -2,7 +2,7 @@
   "query": "histogram_count_exp/native",
   "lowering": "native",
   "routed": true,
-  "k": 12,
+  "k": 8,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/histogram_count_exp_bare_stale/fanout.json
+++ b/test/perf/solver-decision-baseline/histogram_count_exp_bare_stale/fanout.json
@@ -2,7 +2,7 @@
   "query": "histogram_count_exp_bare_stale/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 12,
+  "k": 8,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/histogram_count_exp_bare_stale/native.json
+++ b/test/perf/solver-decision-baseline/histogram_count_exp_bare_stale/native.json
@@ -2,7 +2,7 @@
   "query": "histogram_count_exp_bare_stale/native",
   "lowering": "native",
   "routed": true,
-  "k": 12,
+  "k": 8,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/histogram_count_exp_latest_sample/fanout.json
+++ b/test/perf/solver-decision-baseline/histogram_count_exp_latest_sample/fanout.json
@@ -2,7 +2,7 @@
   "query": "histogram_count_exp_latest_sample/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 12,
+  "k": 8,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/histogram_count_exp_latest_sample/native.json
+++ b/test/perf/solver-decision-baseline/histogram_count_exp_latest_sample/native.json
@@ -2,7 +2,7 @@
   "query": "histogram_count_exp_latest_sample/native",
   "lowering": "native",
   "routed": true,
-  "k": 12,
+  "k": 8,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/histogram_count_exp_range_latest_sample/fanout.json
+++ b/test/perf/solver-decision-baseline/histogram_count_exp_range_latest_sample/fanout.json
@@ -2,7 +2,7 @@
   "query": "histogram_count_exp_range_latest_sample/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 12,
+  "k": 8,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/histogram_count_exp_range_latest_sample/native.json
+++ b/test/perf/solver-decision-baseline/histogram_count_exp_range_latest_sample/native.json
@@ -2,7 +2,7 @@
   "query": "histogram_count_exp_range_latest_sample/native",
   "lowering": "native",
   "routed": true,
-  "k": 12,
+  "k": 8,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/histogram_count_float_metric_empty/fanout.json
+++ b/test/perf/solver-decision-baseline/histogram_count_float_metric_empty/fanout.json
@@ -2,7 +2,7 @@
   "query": "histogram_count_float_metric_empty/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 12,
+  "k": 8,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/histogram_count_float_metric_empty/native.json
+++ b/test/perf/solver-decision-baseline/histogram_count_float_metric_empty/native.json
@@ -2,7 +2,7 @@
   "query": "histogram_count_float_metric_empty/native",
   "lowering": "native",
   "routed": true,
-  "k": 12,
+  "k": 8,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/histogram_fraction_exp/fanout.json
+++ b/test/perf/solver-decision-baseline/histogram_fraction_exp/fanout.json
@@ -2,7 +2,7 @@
   "query": "histogram_fraction_exp/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 12,
+  "k": 8,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/histogram_fraction_exp/native.json
+++ b/test/perf/solver-decision-baseline/histogram_fraction_exp/native.json
@@ -2,7 +2,7 @@
   "query": "histogram_fraction_exp/native",
   "lowering": "native",
   "routed": true,
-  "k": 12,
+  "k": 8,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/histogram_fraction_exp_negative_bounds/fanout.json
+++ b/test/perf/solver-decision-baseline/histogram_fraction_exp_negative_bounds/fanout.json
@@ -2,7 +2,7 @@
   "query": "histogram_fraction_exp_negative_bounds/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 12,
+  "k": 8,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/histogram_fraction_exp_negative_bounds/native.json
+++ b/test/perf/solver-decision-baseline/histogram_fraction_exp_negative_bounds/native.json
@@ -2,7 +2,7 @@
   "query": "histogram_fraction_exp_negative_bounds/native",
   "lowering": "native",
   "routed": true,
-  "k": 12,
+  "k": 8,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/histogram_fraction_exp_negative_range/fanout.json
+++ b/test/perf/solver-decision-baseline/histogram_fraction_exp_negative_range/fanout.json
@@ -2,7 +2,7 @@
   "query": "histogram_fraction_exp_negative_range/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 12,
+  "k": 8,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/histogram_fraction_exp_negative_range/native.json
+++ b/test/perf/solver-decision-baseline/histogram_fraction_exp_negative_range/native.json
@@ -2,7 +2,7 @@
   "query": "histogram_fraction_exp_negative_range/native",
   "lowering": "native",
   "routed": true,
-  "k": 12,
+  "k": 8,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/histogram_quantile_bare_name_unsatisfiable/fanout.json
+++ b/test/perf/solver-decision-baseline/histogram_quantile_bare_name_unsatisfiable/fanout.json
@@ -2,7 +2,7 @@
   "query": "histogram_quantile_bare_name_unsatisfiable/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 12,
+  "k": 8,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/histogram_quantile_bare_name_unsatisfiable/native.json
+++ b/test/perf/solver-decision-baseline/histogram_quantile_bare_name_unsatisfiable/native.json
@@ -2,7 +2,7 @@
   "query": "histogram_quantile_bare_name_unsatisfiable/native",
   "lowering": "native",
   "routed": true,
-  "k": 12,
+  "k": 8,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/histogram_quantile_classic_agg_offset_range/native.json
+++ b/test/perf/solver-decision-baseline/histogram_quantile_classic_agg_offset_range/native.json
@@ -2,7 +2,7 @@
   "query": "histogram_quantile_classic_agg_offset_range/native",
   "lowering": "native",
   "routed": true,
-  "k": 15,
+  "k": 8,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 8,

--- a/test/perf/solver-decision-baseline/histogram_quantile_classic_agg_plateau/fanout.json
+++ b/test/perf/solver-decision-baseline/histogram_quantile_classic_agg_plateau/fanout.json
@@ -2,7 +2,7 @@
   "query": "histogram_quantile_classic_agg_plateau/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 12,
+  "k": 8,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/histogram_quantile_classic_agg_plateau/native.json
+++ b/test/perf/solver-decision-baseline/histogram_quantile_classic_agg_plateau/native.json
@@ -2,7 +2,7 @@
   "query": "histogram_quantile_classic_agg_plateau/native",
   "lowering": "native",
   "routed": true,
-  "k": 12,
+  "k": 8,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/histogram_quantile_classic_agg_rate_min_samples/native.json
+++ b/test/perf/solver-decision-baseline/histogram_quantile_classic_agg_rate_min_samples/native.json
@@ -2,7 +2,7 @@
   "query": "histogram_quantile_classic_agg_rate_min_samples/native",
   "lowering": "native",
   "routed": true,
-  "k": 15,
+  "k": 8,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 4,

--- a/test/perf/solver-decision-baseline/histogram_quantile_classic_bare_rate_min_samples/native.json
+++ b/test/perf/solver-decision-baseline/histogram_quantile_classic_bare_rate_min_samples/native.json
@@ -2,7 +2,7 @@
   "query": "histogram_quantile_classic_bare_rate_min_samples/native",
   "lowering": "native",
   "routed": true,
-  "k": 15,
+  "k": 8,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 4,

--- a/test/perf/solver-decision-baseline/histogram_quantile_classic_count_values_by_le/fanout.json
+++ b/test/perf/solver-decision-baseline/histogram_quantile_classic_count_values_by_le/fanout.json
@@ -2,7 +2,7 @@
   "query": "histogram_quantile_classic_count_values_by_le/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 12,
+  "k": 8,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/histogram_quantile_classic_count_values_by_le/native.json
+++ b/test/perf/solver-decision-baseline/histogram_quantile_classic_count_values_by_le/native.json
@@ -2,7 +2,7 @@
   "query": "histogram_quantile_classic_count_values_by_le/native",
   "lowering": "native",
   "routed": true,
-  "k": 12,
+  "k": 8,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/histogram_quantile_classic_delta_temporality/native.json
+++ b/test/perf/solver-decision-baseline/histogram_quantile_classic_delta_temporality/native.json
@@ -2,7 +2,7 @@
   "query": "histogram_quantile_classic_delta_temporality/native",
   "lowering": "native",
   "routed": true,
-  "k": 15,
+  "k": 8,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 4,

--- a/test/perf/solver-decision-baseline/histogram_quantile_classic_duplicate_bounds/fanout.json
+++ b/test/perf/solver-decision-baseline/histogram_quantile_classic_duplicate_bounds/fanout.json
@@ -2,7 +2,7 @@
   "query": "histogram_quantile_classic_duplicate_bounds/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 12,
+  "k": 8,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/histogram_quantile_classic_duplicate_bounds/native.json
+++ b/test/perf/solver-decision-baseline/histogram_quantile_classic_duplicate_bounds/native.json
@@ -2,7 +2,7 @@
   "query": "histogram_quantile_classic_duplicate_bounds/native",
   "lowering": "native",
   "routed": true,
-  "k": 12,
+  "k": 8,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/histogram_quantile_classic_edge_p0/fanout.json
+++ b/test/perf/solver-decision-baseline/histogram_quantile_classic_edge_p0/fanout.json
@@ -2,7 +2,7 @@
   "query": "histogram_quantile_classic_edge_p0/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 12,
+  "k": 8,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/histogram_quantile_classic_edge_p0/native.json
+++ b/test/perf/solver-decision-baseline/histogram_quantile_classic_edge_p0/native.json
@@ -2,7 +2,7 @@
   "query": "histogram_quantile_classic_edge_p0/native",
   "lowering": "native",
   "routed": true,
-  "k": 12,
+  "k": 8,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/histogram_quantile_classic_edge_p100/fanout.json
+++ b/test/perf/solver-decision-baseline/histogram_quantile_classic_edge_p100/fanout.json
@@ -2,7 +2,7 @@
   "query": "histogram_quantile_classic_edge_p100/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 12,
+  "k": 8,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/histogram_quantile_classic_edge_p100/native.json
+++ b/test/perf/solver-decision-baseline/histogram_quantile_classic_edge_p100/native.json
@@ -2,7 +2,7 @@
   "query": "histogram_quantile_classic_edge_p100/native",
   "lowering": "native",
   "routed": true,
-  "k": 12,
+  "k": 8,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/histogram_quantile_classic_empty/fanout.json
+++ b/test/perf/solver-decision-baseline/histogram_quantile_classic_empty/fanout.json
@@ -2,7 +2,7 @@
   "query": "histogram_quantile_classic_empty/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 12,
+  "k": 8,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/histogram_quantile_classic_empty/native.json
+++ b/test/perf/solver-decision-baseline/histogram_quantile_classic_empty/native.json
@@ -2,7 +2,7 @@
   "query": "histogram_quantile_classic_empty/native",
   "lowering": "native",
   "routed": true,
-  "k": 12,
+  "k": 8,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/histogram_quantile_classic_latest_sample/fanout.json
+++ b/test/perf/solver-decision-baseline/histogram_quantile_classic_latest_sample/fanout.json
@@ -2,7 +2,7 @@
   "query": "histogram_quantile_classic_latest_sample/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 12,
+  "k": 8,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/histogram_quantile_classic_latest_sample/native.json
+++ b/test/perf/solver-decision-baseline/histogram_quantile_classic_latest_sample/native.json
@@ -2,7 +2,7 @@
   "query": "histogram_quantile_classic_latest_sample/native",
   "lowering": "native",
   "routed": true,
-  "k": 12,
+  "k": 8,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/histogram_quantile_classic_multi_series/fanout.json
+++ b/test/perf/solver-decision-baseline/histogram_quantile_classic_multi_series/fanout.json
@@ -2,7 +2,7 @@
   "query": "histogram_quantile_classic_multi_series/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 12,
+  "k": 8,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/histogram_quantile_classic_multi_series/native.json
+++ b/test/perf/solver-decision-baseline/histogram_quantile_classic_multi_series/native.json
@@ -2,7 +2,7 @@
   "query": "histogram_quantile_classic_multi_series/native",
   "lowering": "native",
   "routed": true,
-  "k": 12,
+  "k": 8,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/histogram_quantile_classic_negative_bound_upper_rank/fanout.json
+++ b/test/perf/solver-decision-baseline/histogram_quantile_classic_negative_bound_upper_rank/fanout.json
@@ -2,7 +2,7 @@
   "query": "histogram_quantile_classic_negative_bound_upper_rank/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 12,
+  "k": 8,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/histogram_quantile_classic_negative_bound_upper_rank/native.json
+++ b/test/perf/solver-decision-baseline/histogram_quantile_classic_negative_bound_upper_rank/native.json
@@ -2,7 +2,7 @@
   "query": "histogram_quantile_classic_negative_bound_upper_rank/native",
   "lowering": "native",
   "routed": true,
-  "k": 12,
+  "k": 8,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/histogram_quantile_classic_negative_lowest_bound/fanout.json
+++ b/test/perf/solver-decision-baseline/histogram_quantile_classic_negative_lowest_bound/fanout.json
@@ -2,7 +2,7 @@
   "query": "histogram_quantile_classic_negative_lowest_bound/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 12,
+  "k": 8,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/histogram_quantile_classic_negative_lowest_bound/native.json
+++ b/test/perf/solver-decision-baseline/histogram_quantile_classic_negative_lowest_bound/native.json
@@ -2,7 +2,7 @@
   "query": "histogram_quantile_classic_negative_lowest_bound/native",
   "lowering": "native",
   "routed": true,
-  "k": 12,
+  "k": 8,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/histogram_quantile_classic_plateau_overflow/fanout.json
+++ b/test/perf/solver-decision-baseline/histogram_quantile_classic_plateau_overflow/fanout.json
@@ -2,7 +2,7 @@
   "query": "histogram_quantile_classic_plateau_overflow/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 12,
+  "k": 8,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/histogram_quantile_classic_plateau_overflow/native.json
+++ b/test/perf/solver-decision-baseline/histogram_quantile_classic_plateau_overflow/native.json
@@ -2,7 +2,7 @@
   "query": "histogram_quantile_classic_plateau_overflow/native",
   "lowering": "native",
   "routed": true,
-  "k": 12,
+  "k": 8,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/histogram_quantile_classic_range_step_bare/fanout.json
+++ b/test/perf/solver-decision-baseline/histogram_quantile_classic_range_step_bare/fanout.json
@@ -2,7 +2,7 @@
   "query": "histogram_quantile_classic_range_step_bare/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 12,
+  "k": 8,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/histogram_quantile_classic_range_step_bare/native.json
+++ b/test/perf/solver-decision-baseline/histogram_quantile_classic_range_step_bare/native.json
@@ -2,7 +2,7 @@
   "query": "histogram_quantile_classic_range_step_bare/native",
   "lowering": "native",
   "routed": true,
-  "k": 12,
+  "k": 8,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/histogram_quantile_classic_single_bucket/fanout.json
+++ b/test/perf/solver-decision-baseline/histogram_quantile_classic_single_bucket/fanout.json
@@ -2,7 +2,7 @@
   "query": "histogram_quantile_classic_single_bucket/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 12,
+  "k": 8,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/histogram_quantile_classic_single_bucket/native.json
+++ b/test/perf/solver-decision-baseline/histogram_quantile_classic_single_bucket/native.json
@@ -2,7 +2,7 @@
   "query": "histogram_quantile_classic_single_bucket/native",
   "lowering": "native",
   "routed": true,
-  "k": 12,
+  "k": 8,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/histogram_quantile_classic_zero_count_plateau/fanout.json
+++ b/test/perf/solver-decision-baseline/histogram_quantile_classic_zero_count_plateau/fanout.json
@@ -2,7 +2,7 @@
   "query": "histogram_quantile_classic_zero_count_plateau/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 12,
+  "k": 8,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/histogram_quantile_classic_zero_count_plateau/native.json
+++ b/test/perf/solver-decision-baseline/histogram_quantile_classic_zero_count_plateau/native.json
@@ -2,7 +2,7 @@
   "query": "histogram_quantile_classic_zero_count_plateau/native",
   "lowering": "native",
   "routed": true,
-  "k": 12,
+  "k": 8,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/histogram_quantile_le_not_in_by/fanout.json
+++ b/test/perf/solver-decision-baseline/histogram_quantile_le_not_in_by/fanout.json
@@ -2,7 +2,7 @@
   "query": "histogram_quantile_le_not_in_by/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 12,
+  "k": 8,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/histogram_quantile_le_not_in_by/native.json
+++ b/test/perf/solver-decision-baseline/histogram_quantile_le_not_in_by/native.json
@@ -2,7 +2,7 @@
   "query": "histogram_quantile_le_not_in_by/native",
   "lowering": "native",
   "routed": true,
-  "k": 12,
+  "k": 8,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/histogram_quantile_le_regex_bound_subset/fanout.json
+++ b/test/perf/solver-decision-baseline/histogram_quantile_le_regex_bound_subset/fanout.json
@@ -2,7 +2,7 @@
   "query": "histogram_quantile_le_regex_bound_subset/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 12,
+  "k": 8,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/histogram_quantile_le_regex_bound_subset/native.json
+++ b/test/perf/solver-decision-baseline/histogram_quantile_le_regex_bound_subset/native.json
@@ -2,7 +2,7 @@
   "query": "histogram_quantile_le_regex_bound_subset/native",
   "lowering": "native",
   "routed": true,
-  "k": 12,
+  "k": 8,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/histogram_quantile_native_ladder_min_samples/native.json
+++ b/test/perf/solver-decision-baseline/histogram_quantile_native_ladder_min_samples/native.json
@@ -2,7 +2,7 @@
   "query": "histogram_quantile_native_ladder_min_samples/native",
   "lowering": "native",
   "routed": true,
-  "k": 15,
+  "k": 8,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 4,

--- a/test/perf/solver-decision-baseline/histogram_quantile_native_ladder_offset/native.json
+++ b/test/perf/solver-decision-baseline/histogram_quantile_native_ladder_offset/native.json
@@ -2,7 +2,7 @@
   "query": "histogram_quantile_native_ladder_offset/native",
   "lowering": "native",
   "routed": true,
-  "k": 15,
+  "k": 8,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 8,

--- a/test/perf/solver-decision-baseline/histogram_quantile_non_bucket_empty/fanout.json
+++ b/test/perf/solver-decision-baseline/histogram_quantile_non_bucket_empty/fanout.json
@@ -2,7 +2,7 @@
   "query": "histogram_quantile_non_bucket_empty/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 12,
+  "k": 8,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/histogram_quantile_scalar_phi/fanout.json
+++ b/test/perf/solver-decision-baseline/histogram_quantile_scalar_phi/fanout.json
@@ -2,7 +2,7 @@
   "query": "histogram_quantile_scalar_phi/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 12,
+  "k": 8,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/histogram_quantiles_computed_phi/fanout.json
+++ b/test/perf/solver-decision-baseline/histogram_quantiles_computed_phi/fanout.json
@@ -2,7 +2,7 @@
   "query": "histogram_quantiles_computed_phi/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 12,
+  "k": 8,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/histogram_quantiles_computed_phi_sci/fanout.json
+++ b/test/perf/solver-decision-baseline/histogram_quantiles_computed_phi_sci/fanout.json
@@ -2,7 +2,7 @@
   "query": "histogram_quantiles_computed_phi_sci/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 12,
+  "k": 8,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/histogram_stddev_exp/fanout.json
+++ b/test/perf/solver-decision-baseline/histogram_stddev_exp/fanout.json
@@ -2,7 +2,7 @@
   "query": "histogram_stddev_exp/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 12,
+  "k": 8,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/histogram_stddev_exp/native.json
+++ b/test/perf/solver-decision-baseline/histogram_stddev_exp/native.json
@@ -2,7 +2,7 @@
   "query": "histogram_stddev_exp/native",
   "lowering": "native",
   "routed": true,
-  "k": 12,
+  "k": 8,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/histogram_stdvar_exp/fanout.json
+++ b/test/perf/solver-decision-baseline/histogram_stdvar_exp/fanout.json
@@ -2,7 +2,7 @@
   "query": "histogram_stdvar_exp/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 12,
+  "k": 8,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/histogram_stdvar_exp/native.json
+++ b/test/perf/solver-decision-baseline/histogram_stdvar_exp/native.json
@@ -2,7 +2,7 @@
   "query": "histogram_stdvar_exp/native",
   "lowering": "native",
   "routed": true,
-  "k": 12,
+  "k": 8,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/histogram_sum_aggregate_arg_empty/fanout.json
+++ b/test/perf/solver-decision-baseline/histogram_sum_aggregate_arg_empty/fanout.json
@@ -2,7 +2,7 @@
   "query": "histogram_sum_aggregate_arg_empty/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 12,
+  "k": 8,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/histogram_sum_exp/fanout.json
+++ b/test/perf/solver-decision-baseline/histogram_sum_exp/fanout.json
@@ -2,7 +2,7 @@
   "query": "histogram_sum_exp/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 12,
+  "k": 8,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/histogram_sum_exp/native.json
+++ b/test/perf/solver-decision-baseline/histogram_sum_exp/native.json
@@ -2,7 +2,7 @@
   "query": "histogram_sum_exp/native",
   "lowering": "native",
   "routed": true,
-  "k": 12,
+  "k": 8,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/histogram_sum_exp_latest_sample/fanout.json
+++ b/test/perf/solver-decision-baseline/histogram_sum_exp_latest_sample/fanout.json
@@ -2,7 +2,7 @@
   "query": "histogram_sum_exp_latest_sample/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 12,
+  "k": 8,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/histogram_sum_exp_latest_sample/native.json
+++ b/test/perf/solver-decision-baseline/histogram_sum_exp_latest_sample/native.json
@@ -2,7 +2,7 @@
   "query": "histogram_sum_exp_latest_sample/native",
   "lowering": "native",
   "routed": true,
-  "k": 12,
+  "k": 8,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/histogram_sum_exp_range_latest_sample/fanout.json
+++ b/test/perf/solver-decision-baseline/histogram_sum_exp_range_latest_sample/fanout.json
@@ -2,7 +2,7 @@
   "query": "histogram_sum_exp_range_latest_sample/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 12,
+  "k": 8,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/histogram_sum_exp_range_latest_sample/native.json
+++ b/test/perf/solver-decision-baseline/histogram_sum_exp_range_latest_sample/native.json
@@ -2,7 +2,7 @@
   "query": "histogram_sum_exp_range_latest_sample/native",
   "lowering": "native",
   "routed": true,
-  "k": 12,
+  "k": 8,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/hour_of_vector/fanout.json
+++ b/test/perf/solver-decision-baseline/hour_of_vector/fanout.json
@@ -2,7 +2,7 @@
   "query": "hour_of_vector/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 12,
+  "k": 8,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/info_ignores_base_info_series/fanout.json
+++ b/test/perf/solver-decision-baseline/info_ignores_base_info_series/fanout.json
@@ -2,7 +2,7 @@
   "query": "info_ignores_base_info_series/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 12,
+  "k": 8,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/info_ignores_base_info_series_multi_metric/fanout.json
+++ b/test/perf/solver-decision-baseline/info_ignores_base_info_series_multi_metric/fanout.json
@@ -2,7 +2,7 @@
   "query": "info_ignores_base_info_series_multi_metric/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 12,
+  "k": 8,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/instant_sum_over_suffixed_count_delta_sum/fanout.json
+++ b/test/perf/solver-decision-baseline/instant_sum_over_suffixed_count_delta_sum/fanout.json
@@ -2,7 +2,7 @@
   "query": "instant_sum_over_suffixed_count_delta_sum/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 12,
+  "k": 8,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/label_join_duplicate_labelset/fanout.json
+++ b/test/perf/solver-decision-baseline/label_join_duplicate_labelset/fanout.json
@@ -2,7 +2,7 @@
   "query": "label_join_duplicate_labelset/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 12,
+  "k": 8,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/label_join_two_labels/fanout.json
+++ b/test/perf/solver-decision-baseline/label_join_two_labels/fanout.json
@@ -2,7 +2,7 @@
   "query": "label_join_two_labels/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 12,
+  "k": 8,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/label_join_with_separator/fanout.json
+++ b/test/perf/solver-decision-baseline/label_join_with_separator/fanout.json
@@ -2,7 +2,7 @@
   "query": "label_join_with_separator/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 12,
+  "k": 8,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/label_replace_backref_above_ch_ceiling/fanout.json
+++ b/test/perf/solver-decision-baseline/label_replace_backref_above_ch_ceiling/fanout.json
@@ -2,7 +2,7 @@
   "query": "label_replace_backref_above_ch_ceiling/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 12,
+  "k": 8,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/label_replace_backref_above_group_count/fanout.json
+++ b/test/perf/solver-decision-baseline/label_replace_backref_above_group_count/fanout.json
@@ -2,7 +2,7 @@
   "query": "label_replace_backref_above_group_count/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 12,
+  "k": 8,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/label_replace_basic/fanout.json
+++ b/test/perf/solver-decision-baseline/label_replace_basic/fanout.json
@@ -2,7 +2,7 @@
   "query": "label_replace_basic/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 12,
+  "k": 8,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/label_replace_duplicate_labelset/fanout.json
+++ b/test/perf/solver-decision-baseline/label_replace_duplicate_labelset/fanout.json
@@ -2,7 +2,7 @@
   "query": "label_replace_duplicate_labelset/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 12,
+  "k": 8,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/label_replace_missing_src/fanout.json
+++ b/test/perf/solver-decision-baseline/label_replace_missing_src/fanout.json
@@ -2,7 +2,7 @@
   "query": "label_replace_missing_src/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 12,
+  "k": 8,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/label_replace_missing_src_overwrite/fanout.json
+++ b/test/perf/solver-decision-baseline/label_replace_missing_src_overwrite/fanout.json
@@ -2,7 +2,7 @@
   "query": "label_replace_missing_src_overwrite/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 12,
+  "k": 8,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/label_replace_named_capture/fanout.json
+++ b/test/perf/solver-decision-baseline/label_replace_named_capture/fanout.json
@@ -2,7 +2,7 @@
   "query": "label_replace_named_capture/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 12,
+  "k": 8,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/label_replace_negative_sibling_probe/fanout.json
+++ b/test/perf/solver-decision-baseline/label_replace_negative_sibling_probe/fanout.json
@@ -2,7 +2,7 @@
   "query": "label_replace_negative_sibling_probe/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 12,
+  "k": 8,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/label_replace_no_match/fanout.json
+++ b/test/perf/solver-decision-baseline/label_replace_no_match/fanout.json
@@ -2,7 +2,7 @@
   "query": "label_replace_no_match/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 12,
+  "k": 8,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/label_replace_nullable_shared_capture_name/fanout.json
+++ b/test/perf/solver-decision-baseline/label_replace_nullable_shared_capture_name/fanout.json
@@ -2,7 +2,7 @@
   "query": "label_replace_nullable_shared_capture_name/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 12,
+  "k": 8,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/label_replace_over_native_rate_range_step/fanout.json
+++ b/test/perf/solver-decision-baseline/label_replace_over_native_rate_range_step/fanout.json
@@ -2,7 +2,7 @@
   "query": "label_replace_over_native_rate_range_step/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 12,
+  "k": 8,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/label_replace_over_rate_range_step/fanout.json
+++ b/test/perf/solver-decision-baseline/label_replace_over_rate_range_step/fanout.json
@@ -2,7 +2,7 @@
   "query": "label_replace_over_rate_range_step/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 12,
+  "k": 8,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/label_replace_over_sum_by_range_step/fanout.json
+++ b/test/perf/solver-decision-baseline/label_replace_over_sum_by_range_step/fanout.json
@@ -2,7 +2,7 @@
   "query": "label_replace_over_sum_by_range_step/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 12,
+  "k": 8,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/label_replace_probed_shared_capture_name/fanout.json
+++ b/test/perf/solver-decision-baseline/label_replace_probed_shared_capture_name/fanout.json
@@ -2,7 +2,7 @@
   "query": "label_replace_probed_shared_capture_name/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 12,
+  "k": 8,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/label_replace_regex_capture/fanout.json
+++ b/test/perf/solver-decision-baseline/label_replace_regex_capture/fanout.json
@@ -2,7 +2,7 @@
   "query": "label_replace_regex_capture/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 12,
+  "k": 8,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/label_replace_shared_capture_name/fanout.json
+++ b/test/perf/solver-decision-baseline/label_replace_shared_capture_name/fanout.json
@@ -2,7 +2,7 @@
   "query": "label_replace_shared_capture_name/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 12,
+  "k": 8,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/label_replace_truncated_shared_capture_name/fanout.json
+++ b/test/perf/solver-decision-baseline/label_replace_truncated_shared_capture_name/fanout.json
@@ -2,7 +2,7 @@
   "query": "label_replace_truncated_shared_capture_name/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 12,
+  "k": 8,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/last_over_time_regex_name/fanout.json
+++ b/test/perf/solver-decision-baseline/last_over_time_regex_name/fanout.json
@@ -2,7 +2,7 @@
   "query": "last_over_time_regex_name/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 12,
+  "k": 8,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/last_over_time_regex_name/native.json
+++ b/test/perf/solver-decision-baseline/last_over_time_regex_name/native.json
@@ -2,7 +2,7 @@
   "query": "last_over_time_regex_name/native",
   "lowering": "native",
   "routed": true,
-  "k": 12,
+  "k": 8,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/limit_ratio_complement/fanout.json
+++ b/test/perf/solver-decision-baseline/limit_ratio_complement/fanout.json
@@ -2,7 +2,7 @@
   "query": "limit_ratio_complement/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 12,
+  "k": 8,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/limit_ratio_half/fanout.json
+++ b/test/perf/solver-decision-baseline/limit_ratio_half/fanout.json
@@ -2,7 +2,7 @@
   "query": "limit_ratio_half/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 12,
+  "k": 8,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/limitk_below_one_empty/fanout.json
+++ b/test/perf/solver-decision-baseline/limitk_below_one_empty/fanout.json
@@ -2,7 +2,7 @@
   "query": "limitk_below_one_empty/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 12,
+  "k": 8,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/ln_metric/fanout.json
+++ b/test/perf/solver-decision-baseline/ln_metric/fanout.json
@@ -2,7 +2,7 @@
   "query": "ln_metric/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 12,
+  "k": 8,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/log10_metric/fanout.json
+++ b/test/perf/solver-decision-baseline/log10_metric/fanout.json
@@ -2,7 +2,7 @@
   "query": "log10_metric/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 12,
+  "k": 8,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/log2_metric/fanout.json
+++ b/test/perf/solver-decision-baseline/log2_metric/fanout.json
@@ -2,7 +2,7 @@
   "query": "log2_metric/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 12,
+  "k": 8,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/lwr_bare_selector_eval_ts_boundary/fanout.json
+++ b/test/perf/solver-decision-baseline/lwr_bare_selector_eval_ts_boundary/fanout.json
@@ -2,7 +2,7 @@
   "query": "lwr_bare_selector_eval_ts_boundary/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 12,
+  "k": 8,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/lwr_bare_selector_latest_per_series/fanout.json
+++ b/test/perf/solver-decision-baseline/lwr_bare_selector_latest_per_series/fanout.json
@@ -2,7 +2,7 @@
   "query": "lwr_bare_selector_latest_per_series/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 12,
+  "k": 8,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/lwr_bare_selector_staleness_window/fanout.json
+++ b/test/perf/solver-decision-baseline/lwr_bare_selector_staleness_window/fanout.json
@@ -2,7 +2,7 @@
   "query": "lwr_bare_selector_staleness_window/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 12,
+  "k": 8,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/map_key_order_count/fanout.json
+++ b/test/perf/solver-decision-baseline/map_key_order_count/fanout.json
@@ -2,7 +2,7 @@
   "query": "map_key_order_count/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 12,
+  "k": 8,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/map_key_order_exp_histogram_count/fanout.json
+++ b/test/perf/solver-decision-baseline/map_key_order_exp_histogram_count/fanout.json
@@ -2,7 +2,7 @@
   "query": "map_key_order_exp_histogram_count/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 12,
+  "k": 8,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/map_key_order_exp_histogram_count/native.json
+++ b/test/perf/solver-decision-baseline/map_key_order_exp_histogram_count/native.json
@@ -2,7 +2,7 @@
   "query": "map_key_order_exp_histogram_count/native",
   "lowering": "native",
   "routed": true,
-  "k": 12,
+  "k": 8,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/map_key_order_histogram_quantile/fanout.json
+++ b/test/perf/solver-decision-baseline/map_key_order_histogram_quantile/fanout.json
@@ -2,7 +2,7 @@
   "query": "map_key_order_histogram_quantile/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 12,
+  "k": 8,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/map_key_order_histogram_quantile/native.json
+++ b/test/perf/solver-decision-baseline/map_key_order_histogram_quantile/native.json
@@ -2,7 +2,7 @@
   "query": "map_key_order_histogram_quantile/native",
   "lowering": "native",
   "routed": true,
-  "k": 12,
+  "k": 8,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/map_key_order_increase/fanout.json
+++ b/test/perf/solver-decision-baseline/map_key_order_increase/fanout.json
@@ -2,7 +2,7 @@
   "query": "map_key_order_increase/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 12,
+  "k": 8,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/map_key_order_increase/native.json
+++ b/test/perf/solver-decision-baseline/map_key_order_increase/native.json
@@ -2,7 +2,7 @@
   "query": "map_key_order_increase/native",
   "lowering": "native",
   "routed": true,
-  "k": 12,
+  "k": 8,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/map_key_order_sum_by_labels/fanout.json
+++ b/test/perf/solver-decision-baseline/map_key_order_sum_by_labels/fanout.json
@@ -2,7 +2,7 @@
   "query": "map_key_order_sum_by_labels/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 12,
+  "k": 8,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/map_key_order_sum_without_label/fanout.json
+++ b/test/perf/solver-decision-baseline/map_key_order_sum_without_label/fanout.json
@@ -2,7 +2,7 @@
   "query": "map_key_order_sum_without_label/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 12,
+  "k": 8,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/matcher_and_agg_by_service_name/fanout.json
+++ b/test/perf/solver-decision-baseline/matcher_and_agg_by_service_name/fanout.json
@@ -2,7 +2,7 @@
   "query": "matcher_and_agg_by_service_name/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 12,
+  "k": 8,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/matcher_dotted_source/fanout.json
+++ b/test/perf/solver-decision-baseline/matcher_dotted_source/fanout.json
@@ -2,7 +2,7 @@
   "query": "matcher_dotted_source/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 12,
+  "k": 8,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/matcher_service_name/fanout.json
+++ b/test/perf/solver-decision-baseline/matcher_service_name/fanout.json
@@ -2,7 +2,7 @@
   "query": "matcher_service_name/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 12,
+  "k": 8,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/metadata_label_names_leaf_projection/fanout.json
+++ b/test/perf/solver-decision-baseline/metadata_label_names_leaf_projection/fanout.json
@@ -2,7 +2,7 @@
   "query": "metadata_label_names_leaf_projection/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 12,
+  "k": 8,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/metadata_label_values_bucket_le/fanout.json
+++ b/test/perf/solver-decision-baseline/metadata_label_values_bucket_le/fanout.json
@@ -2,7 +2,7 @@
   "query": "metadata_label_values_bucket_le/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 12,
+  "k": 8,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/metadata_label_values_collides_on_sanitized_name/fanout.json
+++ b/test/perf/solver-decision-baseline/metadata_label_values_collides_on_sanitized_name/fanout.json
@@ -2,7 +2,7 @@
   "query": "metadata_label_values_collides_on_sanitized_name/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 12,
+  "k": 8,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/metadata_label_values_dotted_source_key/fanout.json
+++ b/test/perf/solver-decision-baseline/metadata_label_values_dotted_source_key/fanout.json
@@ -2,7 +2,7 @@
   "query": "metadata_label_values_dotted_source_key/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 12,
+  "k": 8,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/metadata_label_values_leaf_projection/fanout.json
+++ b/test/perf/solver-decision-baseline/metadata_label_values_leaf_projection/fanout.json
@@ -2,7 +2,7 @@
   "query": "metadata_label_values_leaf_projection/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 12,
+  "k": 8,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/minute_of_vector/fanout.json
+++ b/test/perf/solver-decision-baseline/minute_of_vector/fanout.json
@@ -2,7 +2,7 @@
   "query": "minute_of_vector/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 12,
+  "k": 8,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/mod_arithmetic/fanout.json
+++ b/test/perf/solver-decision-baseline/mod_arithmetic/fanout.json
@@ -2,7 +2,7 @@
   "query": "mod_arithmetic/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 12,
+  "k": 8,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/month_of_vector/fanout.json
+++ b/test/perf/solver-decision-baseline/month_of_vector/fanout.json
@@ -2,7 +2,7 @@
   "query": "month_of_vector/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 12,
+  "k": 8,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/multiple_matchers/fanout.json
+++ b/test/perf/solver-decision-baseline/multiple_matchers/fanout.json
@@ -2,7 +2,7 @@
   "query": "multiple_matchers/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 12,
+  "k": 8,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/native_changes_range_step/fanout.json
+++ b/test/perf/solver-decision-baseline/native_changes_range_step/fanout.json
@@ -2,7 +2,7 @@
   "query": "native_changes_range_step/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 12,
+  "k": 8,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/native_changes_range_step/native.json
+++ b/test/perf/solver-decision-baseline/native_changes_range_step/native.json
@@ -2,7 +2,7 @@
   "query": "native_changes_range_step/native",
   "lowering": "native",
   "routed": true,
-  "k": 12,
+  "k": 8,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/native_deriv_range_step/fanout.json
+++ b/test/perf/solver-decision-baseline/native_deriv_range_step/fanout.json
@@ -2,7 +2,7 @@
   "query": "native_deriv_range_step/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 12,
+  "k": 8,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/native_rate_range_step/fanout.json
+++ b/test/perf/solver-decision-baseline/native_rate_range_step/fanout.json
@@ -2,7 +2,7 @@
   "query": "native_rate_range_step/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 12,
+  "k": 8,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/native_rate_recollapse_collision/fanout.json
+++ b/test/perf/solver-decision-baseline/native_rate_recollapse_collision/fanout.json
@@ -2,7 +2,7 @@
   "query": "native_rate_recollapse_collision/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 12,
+  "k": 8,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/native_rate_recollapse_collision_two_level/fanout.json
+++ b/test/perf/solver-decision-baseline/native_rate_recollapse_collision_two_level/fanout.json
@@ -2,7 +2,7 @@
   "query": "native_rate_recollapse_collision_two_level/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 12,
+  "k": 8,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/native_rate_recollapse_histogram_companion/fanout.json
+++ b/test/perf/solver-decision-baseline/native_rate_recollapse_histogram_companion/fanout.json
@@ -2,7 +2,7 @@
   "query": "native_rate_recollapse_histogram_companion/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 12,
+  "k": 8,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/native_rate_recollapse_histogram_companion/native.json
+++ b/test/perf/solver-decision-baseline/native_rate_recollapse_histogram_companion/native.json
@@ -2,7 +2,7 @@
   "query": "native_rate_recollapse_histogram_companion/native",
   "lowering": "native",
   "routed": true,
-  "k": 12,
+  "k": 8,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/native_rate_recollapse_metric_name_isolation/fanout.json
+++ b/test/perf/solver-decision-baseline/native_rate_recollapse_metric_name_isolation/fanout.json
@@ -2,7 +2,7 @@
   "query": "native_rate_recollapse_metric_name_isolation/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 12,
+  "k": 8,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/native_rate_recollapse_range_step/fanout.json
+++ b/test/perf/solver-decision-baseline/native_rate_recollapse_range_step/fanout.json
@@ -2,7 +2,7 @@
   "query": "native_rate_recollapse_range_step/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 12,
+  "k": 8,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/native_rate_temporality_cumulative/fanout.json
+++ b/test/perf/solver-decision-baseline/native_rate_temporality_cumulative/fanout.json
@@ -2,7 +2,7 @@
   "query": "native_rate_temporality_cumulative/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 12,
+  "k": 8,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/native_rate_temporality_delta/fanout.json
+++ b/test/perf/solver-decision-baseline/native_rate_temporality_delta/fanout.json
@@ -2,7 +2,7 @@
   "query": "native_rate_temporality_delta/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 12,
+  "k": 8,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/native_rate_temporality_mixed/fanout.json
+++ b/test/perf/solver-decision-baseline/native_rate_temporality_mixed/fanout.json
@@ -2,7 +2,7 @@
   "query": "native_rate_temporality_mixed/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 12,
+  "k": 8,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/native_resample_offset/fanout.json
+++ b/test/perf/solver-decision-baseline/native_resample_offset/fanout.json
@@ -2,7 +2,7 @@
   "query": "native_resample_offset/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 12,
+  "k": 8,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/native_resample_range_step/fanout.json
+++ b/test/perf/solver-decision-baseline/native_resample_range_step/fanout.json
@@ -2,7 +2,7 @@
   "query": "native_resample_range_step/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 12,
+  "k": 8,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/native_resets_range_step/fanout.json
+++ b/test/perf/solver-decision-baseline/native_resets_range_step/fanout.json
@@ -2,7 +2,7 @@
   "query": "native_resets_range_step/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 12,
+  "k": 8,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/negative_offset/fanout.json
+++ b/test/perf/solver-decision-baseline/negative_offset/fanout.json
@@ -2,7 +2,7 @@
   "query": "negative_offset/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 12,
+  "k": 8,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/no_name_matcher_reaches_histogram_tables/fanout.json
+++ b/test/perf/solver-decision-baseline/no_name_matcher_reaches_histogram_tables/fanout.json
@@ -2,7 +2,7 @@
   "query": "no_name_matcher_reaches_histogram_tables/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 12,
+  "k": 8,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/not_regex_label/fanout.json
+++ b/test/perf/solver-decision-baseline/not_regex_label/fanout.json
@@ -2,7 +2,7 @@
   "query": "not_regex_label/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 12,
+  "k": 8,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/not_regex_name_matcher_excludes_dotted/fanout.json
+++ b/test/perf/solver-decision-baseline/not_regex_name_matcher_excludes_dotted/fanout.json
@@ -2,7 +2,7 @@
   "query": "not_regex_name_matcher_excludes_dotted/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 12,
+  "k": 8,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/offset_negative/fanout.json
+++ b/test/perf/solver-decision-baseline/offset_negative/fanout.json
@@ -2,7 +2,7 @@
   "query": "offset_negative/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 12,
+  "k": 8,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/paren_range_vector_double/fanout.json
+++ b/test/perf/solver-decision-baseline/paren_range_vector_double/fanout.json
@@ -2,7 +2,7 @@
   "query": "paren_range_vector_double/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 12,
+  "k": 8,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/paren_range_vector_quantile_over_time/fanout.json
+++ b/test/perf/solver-decision-baseline/paren_range_vector_quantile_over_time/fanout.json
@@ -2,7 +2,7 @@
   "query": "paren_range_vector_quantile_over_time/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 12,
+  "k": 8,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/paren_range_vector_quantile_over_time/native.json
+++ b/test/perf/solver-decision-baseline/paren_range_vector_quantile_over_time/native.json
@@ -2,7 +2,7 @@
   "query": "paren_range_vector_quantile_over_time/native",
   "lowering": "native",
   "routed": true,
-  "k": 12,
+  "k": 8,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/paren_range_vector_rate/fanout.json
+++ b/test/perf/solver-decision-baseline/paren_range_vector_rate/fanout.json
@@ -2,7 +2,7 @@
   "query": "paren_range_vector_rate/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 12,
+  "k": 8,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/pinned_name_selector_no_histogram_fanout/fanout.json
+++ b/test/perf/solver-decision-baseline/pinned_name_selector_no_histogram_fanout/fanout.json
@@ -2,7 +2,7 @@
   "query": "pinned_name_selector_no_histogram_fanout/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 12,
+  "k": 8,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/pow_arithmetic/fanout.json
+++ b/test/perf/solver-decision-baseline/pow_arithmetic/fanout.json
@@ -2,7 +2,7 @@
   "query": "pow_arithmetic/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 12,
+  "k": 8,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/power_op_basic/fanout.json
+++ b/test/perf/solver-decision-baseline/power_op_basic/fanout.json
@@ -2,7 +2,7 @@
   "query": "power_op_basic/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 12,
+  "k": 8,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/predict_linear_scalar_horizon/fanout.json
+++ b/test/perf/solver-decision-baseline/predict_linear_scalar_horizon/fanout.json
@@ -2,7 +2,7 @@
   "query": "predict_linear_scalar_horizon/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 12,
+  "k": 8,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/predict_linear_scalar_horizon/native.json
+++ b/test/perf/solver-decision-baseline/predict_linear_scalar_horizon/native.json
@@ -2,7 +2,7 @@
   "query": "predict_linear_scalar_horizon/native",
   "lowering": "native",
   "routed": true,
-  "k": 12,
+  "k": 8,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/predict_linear_simple/fanout.json
+++ b/test/perf/solver-decision-baseline/predict_linear_simple/fanout.json
@@ -2,7 +2,7 @@
   "query": "predict_linear_simple/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 12,
+  "k": 8,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/present_over_time_exp_histogram/fanout.json
+++ b/test/perf/solver-decision-baseline/present_over_time_exp_histogram/fanout.json
@@ -2,7 +2,7 @@
   "query": "present_over_time_exp_histogram/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 12,
+  "k": 8,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/present_over_time_exp_histogram/native.json
+++ b/test/perf/solver-decision-baseline/present_over_time_exp_histogram/native.json
@@ -2,7 +2,7 @@
   "query": "present_over_time_exp_histogram/native",
   "lowering": "native",
   "routed": true,
-  "k": 12,
+  "k": 8,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/present_over_time_with_data/fanout.json
+++ b/test/perf/solver-decision-baseline/present_over_time_with_data/fanout.json
@@ -2,7 +2,7 @@
   "query": "present_over_time_with_data/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 12,
+  "k": 8,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/present_over_time_with_data/native.json
+++ b/test/perf/solver-decision-baseline/present_over_time_with_data/native.json
@@ -2,7 +2,7 @@
   "query": "present_over_time_with_data/native",
   "lowering": "native",
   "routed": true,
-  "k": 12,
+  "k": 8,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/quantile_by_job/fanout.json
+++ b/test/perf/solver-decision-baseline/quantile_by_job/fanout.json
@@ -2,7 +2,7 @@
   "query": "quantile_by_job/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 12,
+  "k": 8,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/quantile_over_time_scalar_phi/fanout.json
+++ b/test/perf/solver-decision-baseline/quantile_over_time_scalar_phi/fanout.json
@@ -2,7 +2,7 @@
   "query": "quantile_over_time_scalar_phi/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 12,
+  "k": 8,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/quantile_over_time_scalar_phi/native.json
+++ b/test/perf/solver-decision-baseline/quantile_over_time_scalar_phi/native.json
@@ -2,7 +2,7 @@
   "query": "quantile_over_time_scalar_phi/native",
   "lowering": "native",
   "routed": true,
-  "k": 12,
+  "k": 8,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/quantile_q_above_one/fanout.json
+++ b/test/perf/solver-decision-baseline/quantile_q_above_one/fanout.json
@@ -2,7 +2,7 @@
   "query": "quantile_q_above_one/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 12,
+  "k": 8,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/quantile_q_negative/fanout.json
+++ b/test/perf/solver-decision-baseline/quantile_q_negative/fanout.json
@@ -2,7 +2,7 @@
   "query": "quantile_q_negative/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 12,
+  "k": 8,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/quantile_scalar_phi/fanout.json
+++ b/test/perf/solver-decision-baseline/quantile_scalar_phi/fanout.json
@@ -2,7 +2,7 @@
   "query": "quantile_scalar_phi/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 12,
+  "k": 8,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/quantile_scalar_phi_nan/fanout.json
+++ b/test/perf/solver-decision-baseline/quantile_scalar_phi_nan/fanout.json
@@ -2,7 +2,7 @@
   "query": "quantile_scalar_phi_nan/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 12,
+  "k": 8,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/rad_metric/fanout.json
+++ b/test/perf/solver-decision-baseline/rad_metric/fanout.json
@@ -2,7 +2,7 @@
   "query": "rad_metric/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 12,
+  "k": 8,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/range_window_func_over_scalar_div/fanout.json
+++ b/test/perf/solver-decision-baseline/range_window_func_over_scalar_div/fanout.json
@@ -2,7 +2,7 @@
   "query": "range_window_func_over_scalar_div/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 12,
+  "k": 8,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/range_window_func_over_scalar_div/native.json
+++ b/test/perf/solver-decision-baseline/range_window_func_over_scalar_div/native.json
@@ -2,7 +2,7 @@
   "query": "range_window_func_over_scalar_div/native",
   "lowering": "native",
   "routed": true,
-  "k": 12,
+  "k": 8,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/rate_multi_name_duplicate_labelset_guard/fanout.json
+++ b/test/perf/solver-decision-baseline/rate_multi_name_duplicate_labelset_guard/fanout.json
@@ -2,7 +2,7 @@
   "query": "rate_multi_name_duplicate_labelset_guard/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 12,
+  "k": 8,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/rate_multi_name_duplicate_labelset_guard/native.json
+++ b/test/perf/solver-decision-baseline/rate_multi_name_duplicate_labelset_guard/native.json
@@ -2,7 +2,7 @@
   "query": "rate_multi_name_duplicate_labelset_guard/native",
   "lowering": "native",
   "routed": true,
-  "k": 12,
+  "k": 8,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/regex_alternation/fanout.json
+++ b/test/perf/solver-decision-baseline/regex_alternation/fanout.json
@@ -2,7 +2,7 @@
   "query": "regex_alternation/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 12,
+  "k": 8,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/regex_anchored/fanout.json
+++ b/test/perf/solver-decision-baseline/regex_anchored/fanout.json
@@ -2,7 +2,7 @@
   "query": "regex_anchored/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 12,
+  "k": 8,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/regex_name_matcher_scans_exp_histogram_table/fanout.json
+++ b/test/perf/solver-decision-baseline/regex_name_matcher_scans_exp_histogram_table/fanout.json
@@ -2,7 +2,7 @@
   "query": "regex_name_matcher_scans_exp_histogram_table/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 12,
+  "k": 8,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/regex_name_matcher_scans_sum_table/fanout.json
+++ b/test/perf/solver-decision-baseline/regex_name_matcher_scans_sum_table/fanout.json
@@ -2,7 +2,7 @@
   "query": "regex_name_matcher_scans_sum_table/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 12,
+  "k": 8,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/regex_name_matcher_underscored_matches_dotted/fanout.json
+++ b/test/perf/solver-decision-baseline/regex_name_matcher_underscored_matches_dotted/fanout.json
@@ -2,7 +2,7 @@
   "query": "regex_name_matcher_underscored_matches_dotted/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 12,
+  "k": 8,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/regex_unanchored_no_overmatch/fanout.json
+++ b/test/perf/solver-decision-baseline/regex_unanchored_no_overmatch/fanout.json
@@ -2,7 +2,7 @@
   "query": "regex_unanchored_no_overmatch/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 12,
+  "k": 8,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/resets_counter/fanout.json
+++ b/test/perf/solver-decision-baseline/resets_counter/fanout.json
@@ -2,7 +2,7 @@
   "query": "resets_counter/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 12,
+  "k": 8,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/resource_attr_bare_selector/fanout.json
+++ b/test/perf/solver-decision-baseline/resource_attr_bare_selector/fanout.json
@@ -2,7 +2,7 @@
   "query": "resource_attr_bare_selector/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 12,
+  "k": 8,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/resource_attr_matcher/fanout.json
+++ b/test/perf/solver-decision-baseline/resource_attr_matcher/fanout.json
@@ -2,7 +2,7 @@
   "query": "resource_attr_matcher/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 12,
+  "k": 8,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/resource_attr_precedence_collision/fanout.json
+++ b/test/perf/solver-decision-baseline/resource_attr_precedence_collision/fanout.json
@@ -2,7 +2,7 @@
   "query": "resource_attr_precedence_collision/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 12,
+  "k": 8,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/resource_attr_sum_by/fanout.json
+++ b/test/perf/solver-decision-baseline/resource_attr_sum_by/fanout.json
@@ -2,7 +2,7 @@
   "query": "resource_attr_sum_by/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 12,
+  "k": 8,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/resource_attrs_allowlist_lookup_table/fanout.json
+++ b/test/perf/solver-decision-baseline/resource_attrs_allowlist_lookup_table/fanout.json
@@ -2,7 +2,7 @@
   "query": "resource_attrs_allowlist_lookup_table/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 12,
+  "k": 8,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/round_metric/fanout.json
+++ b/test/perf/solver-decision-baseline/round_metric/fanout.json
@@ -2,7 +2,7 @@
   "query": "round_metric/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 12,
+  "k": 8,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/round_scalar_to_nearest/fanout.json
+++ b/test/perf/solver-decision-baseline/round_scalar_to_nearest/fanout.json
@@ -2,7 +2,7 @@
   "query": "round_scalar_to_nearest/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 12,
+  "k": 8,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/round_to_nearest/fanout.json
+++ b/test/perf/solver-decision-baseline/round_to_nearest/fanout.json
@@ -2,7 +2,7 @@
   "query": "round_to_nearest/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 12,
+  "k": 8,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/scalar_lt_vector/fanout.json
+++ b/test/perf/solver-decision-baseline/scalar_lt_vector/fanout.json
@@ -2,7 +2,7 @@
   "query": "scalar_lt_vector/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 12,
+  "k": 8,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/scalar_minus_vector/fanout.json
+++ b/test/perf/solver-decision-baseline/scalar_minus_vector/fanout.json
@@ -2,7 +2,7 @@
   "query": "scalar_minus_vector/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 12,
+  "k": 8,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/scalar_mul_rate/fanout.json
+++ b/test/perf/solver-decision-baseline/scalar_mul_rate/fanout.json
@@ -2,7 +2,7 @@
   "query": "scalar_mul_rate/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 12,
+  "k": 8,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/scan_unions_gauge_for_suffixed_standalone_gauge/fanout.json
+++ b/test/perf/solver-decision-baseline/scan_unions_gauge_for_suffixed_standalone_gauge/fanout.json
@@ -2,7 +2,7 @@
   "query": "scan_unions_gauge_for_suffixed_standalone_gauge/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 12,
+  "k": 8,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/scan_unions_gauge_sum_for_unsuffixed_metric/fanout.json
+++ b/test/perf/solver-decision-baseline/scan_unions_gauge_sum_for_unsuffixed_metric/fanout.json
@@ -2,7 +2,7 @@
   "query": "scan_unions_gauge_sum_for_unsuffixed_metric/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 12,
+  "k": 8,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/scan_unions_histogram_sum_for_suffixed_metric/fanout.json
+++ b/test/perf/solver-decision-baseline/scan_unions_histogram_sum_for_suffixed_metric/fanout.json
@@ -2,7 +2,7 @@
   "query": "scan_unions_histogram_sum_for_suffixed_metric/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 12,
+  "k": 8,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/scientific_threshold/fanout.json
+++ b/test/perf/solver-decision-baseline/scientific_threshold/fanout.json
@@ -2,7 +2,7 @@
   "query": "scientific_threshold/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 12,
+  "k": 8,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/sgn_metric/fanout.json
+++ b/test/perf/solver-decision-baseline/sgn_metric/fanout.json
@@ -2,7 +2,7 @@
   "query": "sgn_metric/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 12,
+  "k": 8,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/sort_by_label_no_label/fanout.json
+++ b/test/perf/solver-decision-baseline/sort_by_label_no_label/fanout.json
@@ -2,7 +2,7 @@
   "query": "sort_by_label_no_label/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 12,
+  "k": 8,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/sqrt_metric/fanout.json
+++ b/test/perf/solver-decision-baseline/sqrt_metric/fanout.json
@@ -2,7 +2,7 @@
   "query": "sqrt_metric/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 12,
+  "k": 8,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/stddev_by_job/fanout.json
+++ b/test/perf/solver-decision-baseline/stddev_by_job/fanout.json
@@ -2,7 +2,7 @@
   "query": "stddev_by_job/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 12,
+  "k": 8,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/stdvar_no_group/fanout.json
+++ b/test/perf/solver-decision-baseline/stdvar_no_group/fanout.json
@@ -2,7 +2,7 @@
   "query": "stdvar_no_group/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 12,
+  "k": 8,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/stdvar_over_time_basic/fanout.json
+++ b/test/perf/solver-decision-baseline/stdvar_over_time_basic/fanout.json
@@ -2,7 +2,7 @@
   "query": "stdvar_over_time_basic/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 12,
+  "k": 8,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/stdvar_over_time_basic/native.json
+++ b/test/perf/solver-decision-baseline/stdvar_over_time_basic/native.json
@@ -2,7 +2,7 @@
   "query": "stdvar_over_time_basic/native",
   "lowering": "native",
   "routed": true,
-  "k": 12,
+  "k": 8,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/sum_by_job/fanout.json
+++ b/test/perf/solver-decision-baseline/sum_by_job/fanout.json
@@ -2,7 +2,7 @@
   "query": "sum_by_job/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 12,
+  "k": 8,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/sum_by_rate_dotted_source/fanout.json
+++ b/test/perf/solver-decision-baseline/sum_by_rate_dotted_source/fanout.json
@@ -2,7 +2,7 @@
   "query": "sum_by_rate_dotted_source/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 12,
+  "k": 8,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/sum_by_rate_range_offset/fanout.json
+++ b/test/perf/solver-decision-baseline/sum_by_rate_range_offset/fanout.json
@@ -2,7 +2,7 @@
   "query": "sum_by_rate_range_offset/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 12,
+  "k": 8,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/sum_by_rate_range_offset_negative/fanout.json
+++ b/test/perf/solver-decision-baseline/sum_by_rate_range_offset_negative/fanout.json
@@ -2,7 +2,7 @@
   "query": "sum_by_rate_range_offset_negative/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 12,
+  "k": 8,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/sum_by_rate_range_step/fanout.json
+++ b/test/perf/solver-decision-baseline/sum_by_rate_range_step/fanout.json
@@ -2,7 +2,7 @@
   "query": "sum_by_rate_range_step/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 12,
+  "k": 8,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/sum_by_underscored_otel_label/fanout.json
+++ b/test/perf/solver-decision-baseline/sum_by_underscored_otel_label/fanout.json
@@ -2,7 +2,7 @@
   "query": "sum_by_underscored_otel_label/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 12,
+  "k": 8,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/sum_without_empty/fanout.json
+++ b/test/perf/solver-decision-baseline/sum_without_empty/fanout.json
@@ -2,7 +2,7 @@
   "query": "sum_without_empty/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 12,
+  "k": 8,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/sum_without_instance/fanout.json
+++ b/test/perf/solver-decision-baseline/sum_without_instance/fanout.json
@@ -2,7 +2,7 @@
   "query": "sum_without_instance/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 12,
+  "k": 8,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/sum_without_two_labels/fanout.json
+++ b/test/perf/solver-decision-baseline/sum_without_two_labels/fanout.json
@@ -2,7 +2,7 @@
   "query": "sum_without_two_labels/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 12,
+  "k": 8,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/timestamp_of_exp_histogram_bare_selector/fanout.json
+++ b/test/perf/solver-decision-baseline/timestamp_of_exp_histogram_bare_selector/fanout.json
@@ -2,7 +2,7 @@
   "query": "timestamp_of_exp_histogram_bare_selector/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 12,
+  "k": 8,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/timestamp_of_exp_histogram_bare_selector/native.json
+++ b/test/perf/solver-decision-baseline/timestamp_of_exp_histogram_bare_selector/native.json
@@ -2,7 +2,7 @@
   "query": "timestamp_of_exp_histogram_bare_selector/native",
   "lowering": "native",
   "routed": true,
-  "k": 12,
+  "k": 8,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/timestamp_of_exp_histogram_bare_selector_range/fanout.json
+++ b/test/perf/solver-decision-baseline/timestamp_of_exp_histogram_bare_selector_range/fanout.json
@@ -2,7 +2,7 @@
   "query": "timestamp_of_exp_histogram_bare_selector_range/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 12,
+  "k": 8,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/timestamp_of_exp_histogram_bare_selector_range/native.json
+++ b/test/perf/solver-decision-baseline/timestamp_of_exp_histogram_bare_selector_range/native.json
@@ -2,7 +2,7 @@
   "query": "timestamp_of_exp_histogram_bare_selector_range/native",
   "lowering": "native",
   "routed": true,
-  "k": 12,
+  "k": 8,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/timestamp_of_metric/fanout.json
+++ b/test/perf/solver-decision-baseline/timestamp_of_metric/fanout.json
@@ -2,7 +2,7 @@
   "query": "timestamp_of_metric/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 12,
+  "k": 8,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/timestamp_of_metric/native.json
+++ b/test/perf/solver-decision-baseline/timestamp_of_metric/native.json
@@ -2,7 +2,7 @@
   "query": "timestamp_of_metric/native",
   "lowering": "native",
   "routed": true,
-  "k": 12,
+  "k": 8,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/timestamp_of_metric_range_step/fanout.json
+++ b/test/perf/solver-decision-baseline/timestamp_of_metric_range_step/fanout.json
@@ -2,7 +2,7 @@
   "query": "timestamp_of_metric_range_step/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 12,
+  "k": 8,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/timestamp_of_metric_range_step/native.json
+++ b/test/perf/solver-decision-baseline/timestamp_of_metric_range_step/native.json
@@ -2,7 +2,7 @@
   "query": "timestamp_of_metric_range_step/native",
   "lowering": "native",
   "routed": true,
-  "k": 12,
+  "k": 8,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/timestamp_of_metric_range_step_native_resample/fanout.json
+++ b/test/perf/solver-decision-baseline/timestamp_of_metric_range_step_native_resample/fanout.json
@@ -2,7 +2,7 @@
   "query": "timestamp_of_metric_range_step_native_resample/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 12,
+  "k": 8,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/timestamp_of_metric_range_step_native_resample/native.json
+++ b/test/perf/solver-decision-baseline/timestamp_of_metric_range_step_native_resample/native.json
@@ -2,7 +2,7 @@
   "query": "timestamp_of_metric_range_step_native_resample/native",
   "lowering": "native",
   "routed": true,
-  "k": 12,
+  "k": 8,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/timestamp_of_parenthesised_metric/fanout.json
+++ b/test/perf/solver-decision-baseline/timestamp_of_parenthesised_metric/fanout.json
@@ -2,7 +2,7 @@
   "query": "timestamp_of_parenthesised_metric/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 12,
+  "k": 8,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/timestamp_of_parenthesised_metric/native.json
+++ b/test/perf/solver-decision-baseline/timestamp_of_parenthesised_metric/native.json
@@ -2,7 +2,7 @@
   "query": "timestamp_of_parenthesised_metric/native",
   "lowering": "native",
   "routed": true,
-  "k": 12,
+  "k": 8,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/timestamp_of_transformed_metric/fanout.json
+++ b/test/perf/solver-decision-baseline/timestamp_of_transformed_metric/fanout.json
@@ -2,7 +2,7 @@
   "query": "timestamp_of_transformed_metric/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 12,
+  "k": 8,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/timestamp_staleness_age_range_step/fanout.json
+++ b/test/perf/solver-decision-baseline/timestamp_staleness_age_range_step/fanout.json
@@ -2,7 +2,7 @@
   "query": "timestamp_staleness_age_range_step/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 12,
+  "k": 8,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/timestamp_staleness_age_range_step/native.json
+++ b/test/perf/solver-decision-baseline/timestamp_staleness_age_range_step/native.json
@@ -2,7 +2,7 @@
   "query": "timestamp_staleness_age_range_step/native",
   "lowering": "native",
   "routed": true,
-  "k": 12,
+  "k": 8,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/topk_zero_empty/fanout.json
+++ b/test/perf/solver-decision-baseline/topk_zero_empty/fanout.json
@@ -2,7 +2,7 @@
   "query": "topk_zero_empty/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 12,
+  "k": 8,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/trig_acos_metric/fanout.json
+++ b/test/perf/solver-decision-baseline/trig_acos_metric/fanout.json
@@ -2,7 +2,7 @@
   "query": "trig_acos_metric/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 12,
+  "k": 8,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/trig_cos_metric/fanout.json
+++ b/test/perf/solver-decision-baseline/trig_cos_metric/fanout.json
@@ -2,7 +2,7 @@
   "query": "trig_cos_metric/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 12,
+  "k": 8,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/trig_sin_metric/fanout.json
+++ b/test/perf/solver-decision-baseline/trig_sin_metric/fanout.json
@@ -2,7 +2,7 @@
   "query": "trig_sin_metric/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 12,
+  "k": 8,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/trig_sinh_metric/fanout.json
+++ b/test/perf/solver-decision-baseline/trig_sinh_metric/fanout.json
@@ -2,7 +2,7 @@
   "query": "trig_sinh_metric/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 12,
+  "k": 8,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/unary_minus_binary_lhs/fanout.json
+++ b/test/perf/solver-decision-baseline/unary_minus_binary_lhs/fanout.json
@@ -2,7 +2,7 @@
   "query": "unary_minus_binary_lhs/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 12,
+  "k": 8,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/unary_minus_in_function/fanout.json
+++ b/test/perf/solver-decision-baseline/unary_minus_in_function/fanout.json
@@ -2,7 +2,7 @@
   "query": "unary_minus_in_function/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 12,
+  "k": 8,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/unary_minus_rate/fanout.json
+++ b/test/perf/solver-decision-baseline/unary_minus_rate/fanout.json
@@ -2,7 +2,7 @@
   "query": "unary_minus_rate/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 12,
+  "k": 8,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/unary_minus_vector/fanout.json
+++ b/test/perf/solver-decision-baseline/unary_minus_vector/fanout.json
@@ -2,7 +2,7 @@
   "query": "unary_minus_vector/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 12,
+  "k": 8,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/unary_plus_vector/fanout.json
+++ b/test/perf/solver-decision-baseline/unary_plus_vector/fanout.json
@@ -2,7 +2,7 @@
   "query": "unary_plus_vector/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 12,
+  "k": 8,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/up/fanout.json
+++ b/test/perf/solver-decision-baseline/up/fanout.json
@@ -2,7 +2,7 @@
   "query": "up/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 12,
+  "k": 8,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/up_gt_bool/fanout.json
+++ b/test/perf/solver-decision-baseline/up_gt_bool/fanout.json
@@ -2,7 +2,7 @@
   "query": "up_gt_bool/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 12,
+  "k": 8,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/up_gt_threshold/fanout.json
+++ b/test/perf/solver-decision-baseline/up_gt_threshold/fanout.json
@@ -2,7 +2,7 @@
   "query": "up_gt_threshold/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 12,
+  "k": 8,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/up_ne_zero/fanout.json
+++ b/test/perf/solver-decision-baseline/up_ne_zero/fanout.json
@@ -2,7 +2,7 @@
   "query": "up_ne_zero/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 12,
+  "k": 8,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/up_offset_5m/fanout.json
+++ b/test/perf/solver-decision-baseline/up_offset_5m/fanout.json
@@ -2,7 +2,7 @@
   "query": "up_offset_5m/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 12,
+  "k": 8,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/up_times_two/fanout.json
+++ b/test/perf/solver-decision-baseline/up_times_two/fanout.json
@@ -2,7 +2,7 @@
   "query": "up_times_two/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 12,
+  "k": 8,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/up_with_label/fanout.json
+++ b/test/perf/solver-decision-baseline/up_with_label/fanout.json
@@ -2,7 +2,7 @@
   "query": "up_with_label/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 12,
+  "k": 8,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/up_with_regex/fanout.json
+++ b/test/perf/solver-decision-baseline/up_with_regex/fanout.json
@@ -2,7 +2,7 @@
   "query": "up_with_regex/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 12,
+  "k": 8,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/vector_div_scalar/fanout.json
+++ b/test/perf/solver-decision-baseline/vector_div_scalar/fanout.json
@@ -2,7 +2,7 @@
   "query": "vector_div_scalar/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 12,
+  "k": 8,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/vector_mod_scalar/fanout.json
+++ b/test/perf/solver-decision-baseline/vector_mod_scalar/fanout.json
@@ -2,7 +2,7 @@
   "query": "vector_mod_scalar/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 12,
+  "k": 8,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/vector_pow_scalar/fanout.json
+++ b/test/perf/solver-decision-baseline/vector_pow_scalar/fanout.json
@@ -2,7 +2,7 @@
   "query": "vector_pow_scalar/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 12,
+  "k": 8,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,

--- a/test/perf/solver-decision-baseline/year_of_vector/fanout.json
+++ b/test/perf/solver-decision-baseline/year_of_vector/fanout.json
@@ -2,7 +2,7 @@
   "query": "year_of_vector/fanout",
   "lowering": "fanout",
   "routed": true,
-  "k": 12,
+  "k": 8,
   "reason": "routed",
   "n_anchors": 241,
   "fanout": 20,


### PR DESCRIPTION
## What this is

The release ritual's **step 3 — audit the delta** for v1.18.0, over the full
`v1.17.0..main` change set (453 files, 13 commits). Six dimensions, every
finding adversarially verified at its cited `file:line` before being accepted.
33 findings confirmed, **7 major, no blockers**. Six majors are fixed here; the
seventh is #2705.

Per the ritual the audit is the last thing that merges — nothing lands between
it and the tag it clears.

## The majors, and what they were

**chaudit's cost model was wrong in the optimistic direction.** It read the
guard's `groups` factor as `series`, but the emitter groups by the query keys
**and** the `le` rung (`probeGroups.GroupBy(keyCols..., Col(bucketGridLeAlias))`);
`range_bucket_grid_native_bound.go`'s own header says so. The grid term was
understated by the rung count — 12 to 16 on the calibrated production shapes —
so the audit reported headroom on metrics the engine would reject. For a tool
whose whole purpose is warning before a rejection, that is the one failure mode
it must not have.

**Its pin could not have caught that.** The expected values were `costUnits`'
body re-typed with the operands substituted (`271*361 + 83_997*68*68`), so the
test asserted the function against itself. They are decimal literals now, and a
second test observes the grid term alone at two rung counts — under the old
model both cases returned the same number. Writing the literals also surfaced an
arithmetic slip of mine, which is the point.

**The amplifying-label heuristic named the wrong label.** `total` is
`uniqExact(Attributes)` and does not reference `key`, so `ORDER BY total /
without_key DESC` reduced to *order by cardinality descending*. On this
package's own motivating shape — 98 `http_route` values against 72
`k8s_pod_name` — it ranks the route template at 49x above the pod at 36x: it
accuses the legitimate dimension and exonerates the leaked identifier. The
auditor reproduced this against a real chDB engine, not on paper.

The two are genuinely indistinguishable by cardinality alone: each divides the
series count by its own value count. So the query returns the full ranking and a
label is named only when its collapse factor stands clear of the runner-up.
A report that lists factors and declines to accuse is useful; one that
confidently names the wrong label sends someone to delete a dimension their
panels need.

**`cerberus audit` ran uncapped against production.** `OpenSQLDB` never
populated `Settings` — the serving path applies its caps per query in
`Client.querySettings`, which this handle does not go through — so the probes'
`uniqExact` and `arrayJoin` over a retention window carried no memory or
execution-time bound. A read-only tool has no business destabilising what it
came to measure. It now stamps the same two caps the server enforces.

**`Options.Table` was interpolated on a false promise.** The comment claimed the
caller had validated it against the configured schema; nothing had, and it
arrives from a command-line flag. It is now restricted to a plain, optionally
database-qualified identifier — which is what makes the interpolation
defensible, since ClickHouse has no bind form for an identifier.

**A planner comment claimed a check that did not exist.** #2683 rewrote
`walkRangeBucketGridNative`'s doc to assert it "carries the same grid-prediction
check its fan-out sibling does" while leaving the body byte-identical — in the
same change that made the kind shardable, destroying the stated justification
for the omission. Rather than soften the comment, the check now exists.
`UnpinSpine` zeroes both bounds unconditionally and
`checkPredictedGridBucketGridNative` returns early once they are zero, so
nothing downstream re-derives what the planner declined to reject — and resting
on "the lowering cannot produce that shape today" is exactly what
`checkRangeWindowGridNativeGrid`'s own doc forbids.

**Three gate suites were never run by any workflow** —
`gremlins-threshold.test.mjs` (added in this very cycle),
`merge-crawl-slices.test.mjs`, `property-fanout.test.mjs`. A suite nothing
invokes is the same failure as a gate that cannot fail: it reads as coverage in
review and provides none. All three are wired, and
`assert-gate-suites-wired.mjs` now fails on any suite that is not — fixing the
class rather than the three instances. It has its own suite, or it would be its
own first violation.

## Filed, not fixed

**#2705** — route-B shards emit the density guard calibrated for the whole cap
while running under `cap / kEff` bytes, up to 32x too permissive relative to
their own allowance. Not a blocker and **not a regression**: before this delta
those shards used chsql's compiled-in 400M fallback, which is looser still, so
the delta tightened them and simply did not go all the way. Fixing it properly
needs an executor reorder (`kEff` is computed after the emit loop), which
deserves its own PR and its own test rather than a rush before a tag.

## Test plan

- [x] `TestCostUnits_MatchesTheEmittedGuardModel` — literals, not the body.
- [x] `TestCostUnits_GridTermScalesWithRungCount` — fails under the old model.
- [x] `TestOptions_Validate_RejectsANonIdentifierTable` — six rejected forms.
- [x] `assert-gate-suites-wired.test.mjs` — 6 cases including subdirectories and
      a non-suite `node --test` target that must not earn credit.
- [x] `go test ./internal/chaudit/ ./internal/chclient/ ./internal/solver/
      ./internal/chplan/ ./internal/engine/ ./cmd/cerberus/` green — the solver
      and chplan suites pass with the new grid check in place, so routing still
      admits the shapes the lowering produces.
- [x] `node .github/scripts/assert-gate-suites-wired.mjs` — 71 suites, all wired.
- [x] `actionlint` and `forbid-skip` clean.

Refs #2705
