### PR TITLE
chore(release): cerberus v1.18.0 / chart 0.15.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,33 @@ All notable changes to cerberus will be documented in this file. The format roug
 
 ## [Unreleased]
 
+## [v1.18.0] — 2026-08-28
+
+### Added
+
+- **chaudit:** audit a live deployment against the histogram resource bound (#2691)
+- **chsql:** carry the guard's own numbers in its rejection message (#2693)
+
+### Fixed
+
+- **chaudit,solver,ci:** apply the v1.18.0 pre-release audit findings (#2706)
+- **routememo:** require corroboration before BothFail, and record why Key fuses group-by (#2701)
+- **chopt:** re-probe fast while pinned to the capability floor (#2702)
+- **solver,promql:** let the classic-histogram ladder route predictively (#2689)
+- **config,chclient,engine:** derive the histogram density bound from the query memory cap (#2686)
+- **solver:** let route B time-shard the native classic-histogram ladder (#2683)
+
+### Performance
+
+- **promql:** decide the DELTA arm's peak flag at construction, not by a walk (#2690)
+
+### CI
+
+- **mutation:** gate the timed-out share, which efficacy cannot see (#2703)
+- warm nested go modules, and gate that a built module is a warmed one (#2704)
+- **mutation:** pin the gremlins per-mutant budget to the declared ceiling (#2698)
+- warm the Go module cache through a shared setup-go composite with fetch retry (#2699)
+
 ## [v1.17.0] — 2026-08-27
 
 ### Added

--- a/deploy/helm/cerberus/Chart.yaml
+++ b/deploy/helm/cerberus/Chart.yaml
@@ -8,11 +8,11 @@ type: application
 # upgrade?" and is the publish trigger: a chart-only fix bumps this without an
 # app re-tag; an app-only release bumps appVersion + a PATCH here for the new
 # default image. Starts 0.x because the values contract is not yet frozen.
-version: 0.15.7
+version: 0.15.8
 
 # appVersion tracks the GA cerberus binary. Quoted so SemVer-shaped values
 # aren't coerced to floats. image.tag defaults from this when left empty.
-appVersion: "1.17.0"
+appVersion: "1.18.0"
 
 # autoscaling/v2 + policy/v1 (PDB) + networking/v1 (Ingress) are all GA from
 # 1.21+; 1.23 is the conservative floor matching the manifests this chart
@@ -45,13 +45,25 @@ annotations:
       url: https://github.com/tsouza/cerberus/blob/main/docs/operations.md
   artifacthub.io/images: |
     - name: cerberus
-      image: ghcr.io/tsouza/cerberus:v1.17.0
+      image: ghcr.io/tsouza/cerberus:v1.18.0
   # Bump the `1.0.0` floor here when the chart raises its minimum supported
   # cerberus release; informational for Artifact Hub's compatibility hints.
   artifacthub.io/changes: |
     - kind: added
-      description: "chsql,promql: make five more resource-bound safety ceilings configurable (#2668)"
+      description: "chaudit: audit a live deployment against the histogram resource bound (#2691)"
+    - kind: added
+      description: "chsql: carry the guard's own numbers in its rejection message (#2693)"
     - kind: fixed
-      description: "chaos: recalibrate route-memo-activation's memory cap with real margin (#2669)"
+      description: "chaudit,solver,ci: apply the v1.18.0 pre-release audit findings (#2706)"
     - kind: fixed
-      description: "chsql: recalibrate RangeBucketGridNative's density axis against real production spill settings (#2666)"
+      description: "routememo: require corroboration before BothFail, and record why Key fuses group-by (#2701)"
+    - kind: fixed
+      description: "chopt: re-probe fast while pinned to the capability floor (#2702)"
+    - kind: fixed
+      description: "solver,promql: let the classic-histogram ladder route predictively (#2689)"
+    - kind: fixed
+      description: "config,chclient,engine: derive the histogram density bound from the query memory cap (#2686)"
+    - kind: fixed
+      description: "solver: let route B time-shard the native classic-histogram ladder (#2683)"
+    - kind: changed
+      description: "promql: decide the DELTA arm's peak flag at construction, not by a walk (#2690)"

--- a/deploy/helm/cerberus/README.md
+++ b/deploy/helm/cerberus/README.md
@@ -5,7 +5,7 @@
      pipe-aligned, and the version footer adds a trailing blank — both are
      owned by helm-docs; realigning would fight the chart-ci drift check. -->
 
-![Version: 0.15.7](https://img.shields.io/badge/Version-0.15.7-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.17.0](https://img.shields.io/badge/AppVersion-1.17.0-informational?style=flat-square)
+![Version: 0.15.8](https://img.shields.io/badge/Version-0.15.8-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.18.0](https://img.shields.io/badge/AppVersion-1.18.0-informational?style=flat-square)
 
 Drop-in Prometheus / Loki / Tempo HTTP gateway for ClickHouse — a single stateless gateway that speaks three upstream query wire formats and lowers each to parameterised ClickHouse SQL.
 


### PR DESCRIPTION
Release-prep for **v1.18.0** (chart **0.15.8**), generated by `prepare-release.yml`.

- appVersion 1.17.0 -> 1.18.0, chart 0.15.7 -> 0.15.8

### Changes

### Added

- **chaudit:** audit a live deployment against the histogram resource bound (#2691)
- **chsql:** carry the guard's own numbers in its rejection message (#2693)

### Fixed

- **chaudit,solver,ci:** apply the v1.18.0 pre-release audit findings (#2706)
- **routememo:** require corroboration before BothFail, and record why Key fuses group-by (#2701)
- **chopt:** re-probe fast while pinned to the capability floor (#2702)
- **solver,promql:** let the classic-histogram ladder route predictively (#2689)
- **config,chclient,engine:** derive the histogram density bound from the query memory cap (#2686)
- **solver:** let route B time-shard the native classic-histogram ladder (#2683)

### Performance

- **promql:** decide the DELTA arm's peak flag at construction, not by a walk (#2690)

### CI

- **mutation:** gate the timed-out share, which efficacy cannot see (#2703)
- warm nested go modules, and gate that a built module is a warmed one (#2704)
- **mutation:** pin the gremlins per-mutant budget to the declared ceiling (#2698)
- warm the Go module cache through a shared setup-go composite with fetch retry (#2699)

Generated from the conventional commits since the last tag. Review and edit before merging; the tag is cut once this lands.
