### PR TITLE
fix(engine): apportion route-B's RangeBucketGridNative bounds by shard count

### DIFF
--- a/internal/chsql/range_bucket_grid_native_bound.go
+++ b/internal/chsql/range_bucket_grid_native_bound.go
@@ -673,6 +673,22 @@ func rangeBucketGridNativeMaxRowsFromCtx(ctx context.Context) int64 {
 	if n, ok := ctx.Value(rangeBucketGridNativeMaxRowsKey{}).(int64); ok && n > 0 {
 		return n
 	}
+	return ResolveRangeBucketGridNativeMaxRows(0)
+}
+
+// ResolveRangeBucketGridNativeMaxRows answers the SAME "override-or-default"
+// question rangeBucketGridNativeMaxRowsFromCtx answers off a context, without
+// needing one — for a caller (internal/engine's routeBExecCtx, issue #2705)
+// that must resolve the effective whole-query bound BEFORE apportioning it by
+// a shard count, which a ctx-keyed lookup cannot do: stamping override/K
+// through WithRangeBucketGridNativeMaxRows when override is 0 would divide
+// down to 0, and 0 means "absent, use the default" here — the OPPOSITE of an
+// apportioned bound. override <= 0 answers the real-evidence-calibrated
+// default; override > 0 is returned unchanged.
+func ResolveRangeBucketGridNativeMaxRows(override int64) int64 {
+	if override > 0 {
+		return override
+	}
 	return maxRangeBucketGridNativeRows
 }
 
@@ -689,6 +705,17 @@ func WithRangeBucketGridNativeMaxDensityUnits(ctx context.Context, n int64) cont
 func rangeBucketGridNativeMaxDensityUnitsFromCtx(ctx context.Context) int64 {
 	if n, ok := ctx.Value(rangeBucketGridNativeMaxDensityUnitsKey{}).(int64); ok && n > 0 {
 		return n
+	}
+	return ResolveRangeBucketGridNativeMaxDensityUnits(0)
+}
+
+// ResolveRangeBucketGridNativeMaxDensityUnits is
+// ResolveRangeBucketGridNativeMaxRows's own twin for axis2 — see that
+// function's doc for why a caller apportioning the bound by a shard count
+// needs this rather than the ctx-keyed lookup.
+func ResolveRangeBucketGridNativeMaxDensityUnits(override int64) int64 {
+	if override > 0 {
+		return override
 	}
 	return maxRangeBucketGridNativeDensityUnits
 }

--- a/internal/chsql/range_bucket_grid_native_bound_override_test.go
+++ b/internal/chsql/range_bucket_grid_native_bound_override_test.go
@@ -132,3 +132,45 @@ func TestRangeBucketGridNativeBound_MaxDensityUnitsOverride_NonPositiveIsIgnored
 		t.Errorf("a negative override should fall back to the real default (400000000), got: %s", sqlStr)
 	}
 }
+
+// TestResolveRangeBucketGridNativeMaxRows pins the "override-or-default"
+// contract ResolveRangeBucketGridNativeMaxRows answers WITHOUT a context —
+// added for issue #2705's route-B apportionment, which must resolve the
+// whole-query bound BEFORE dividing it by a shard count, and a ctx-keyed
+// lookup cannot do that (see the function's own doc for why).
+func TestResolveRangeBucketGridNativeMaxRows(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		override int64
+		want     int64
+	}{
+		{"positive override wins", 10, 10},
+		{"zero falls back to the real default", 0, 25_000_000},
+		{"negative falls back to the real default", -1, 25_000_000},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := chsql.ResolveRangeBucketGridNativeMaxRows(tc.override); got != tc.want {
+				t.Errorf("ResolveRangeBucketGridNativeMaxRows(%d) = %d, want %d", tc.override, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestResolveRangeBucketGridNativeMaxDensityUnits is the axis2 twin.
+func TestResolveRangeBucketGridNativeMaxDensityUnits(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		override int64
+		want     int64
+	}{
+		{"positive override wins", 10, 10},
+		{"zero falls back to the real default", 0, 400_000_000},
+		{"negative falls back to the real default", -1, 400_000_000},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := chsql.ResolveRangeBucketGridNativeMaxDensityUnits(tc.override); got != tc.want {
+				t.Errorf("ResolveRangeBucketGridNativeMaxDensityUnits(%d) = %d, want %d", tc.override, got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -1555,6 +1555,37 @@ func (e *Engine) classify(plan chplan.Node, lang Lang) (*solver.Decision, bool) 
 // meaningful: the guard's cost model reads the anchors and raw rows of the
 // plan it is emitted for, so on a shard it bounds that shard's real cost —
 // which is the per-query-cap question route B exists to answer here.
+//
+// APPORTIONED BY decision.K (issue #2705), not threaded verbatim. Every
+// shard used to receive the WHOLE-QUERY ceiling unchanged while running
+// against only 1/kEff of the memory (executor.go's perShardMemoryBytes
+// divides that cap by kEff before stamping it per-shard) — so a shard's
+// density guard could be up to K times too permissive relative to what the
+// shard is actually allowed to use, and a shard could pass its own
+// pre-flight guard and still be aborted by ClickHouse's real memory limit:
+// the exact "sailed past the guard and died on ClickHouse's own limit" mode
+// #2677/#2681 closed for route A, reopened here for route B.
+//
+// decision.K rather than the executor's exact kEff: kEff is computed inside
+// solver.Executor strictly AFTER the emit loop that needs the apportioned
+// ceiling (internal/solver cannot import internal/chsql to cross that
+// boundary earlier), while decision.K is already materialized on the
+// Decision this function receives — and K is always >= kEff (kEff =
+// min(K, pEff, gate/2)), so dividing by K is a SAFE, never-looser-than-
+// correct apportionment: it can only make the guard MORE conservative than
+// the shard's real allowance, never less. The residual cost is a possible
+// over-rejection when admission throttles pEff/gate below K, which falls
+// back through the failure-driven route memo exactly as a real resource
+// rejection does — acceptable for a guard whose whole purpose is refusing
+// early rather than dying mid-scan.
+//
+// Resolved via chsql.ResolveRangeBucketGridNativeMaxRows/
+// …MaxDensityUnits BEFORE dividing, not divided raw: a caller's 0 means
+// "no override, use chsql's compiled-in default" (see those constants' own
+// doc), not "unlimited" — unlike the memory cap's genuine unlimited-at-0
+// sentinel (executor.go's own comment), so dividing 0 by K here would
+// silently ask WithRangeBucketGridNativeMax{Rows,DensityUnits} to fall
+// back to the FULL, un-apportioned default instead of an apportioned one.
 func routeBExecCtx(
 	ctx context.Context, langName, responseShape string, decision *solver.Decision,
 	deltaPrefixLookback time.Duration, deltaPrefixReadEnabled bool,
@@ -1571,9 +1602,42 @@ func routeBExecCtx(
 	// doc and emitForHead's matching call.
 	ctx = chsql.WithDeltaPrefixReadEnabled(ctx, deltaPrefixReadEnabled)
 	ctx = applyResourceBoundOverrides(ctx, bounds)
-	ctx = chsql.WithRangeBucketGridNativeMaxRows(ctx, rangeBucketGridNativeMaxRows)
-	ctx = chsql.WithRangeBucketGridNativeMaxDensityUnits(ctx, rangeBucketGridNativeMaxDensityUnits)
+	apportionedRows, apportionedDensityUnits := apportionRangeBucketGridNativeBounds(
+		rangeBucketGridNativeMaxRows, rangeBucketGridNativeMaxDensityUnits, decisionK(decision),
+	)
+	ctx = chsql.WithRangeBucketGridNativeMaxRows(ctx, apportionedRows)
+	ctx = chsql.WithRangeBucketGridNativeMaxDensityUnits(ctx, apportionedDensityUnits)
 	return ctx
+}
+
+// decisionK is decision.K, defensively floored to 1 — routeBExecCtx is only
+// ever reached on an already-routed Decision (K >= 2 by construction, see
+// solver.Planner.classify), but a nil-or-zero-K Decision must not become a
+// division by zero here.
+func decisionK(decision *solver.Decision) int64 {
+	if decision == nil || decision.K < 1 {
+		return 1
+	}
+	return int64(decision.K)
+}
+
+// apportionRangeBucketGridNativeBounds divides the resolved (override-or-
+// default, see chsql.ResolveRangeBucketGridNativeMaxRows's own doc)
+// whole-query RangeBucketGridNative ceilings by k, flooring each at 1 so a
+// pathological k > ceiling configuration stamps a real (if tiny) bound
+// rather than 0 — which chsql's own ctx lookup would read back as "absent,
+// use the un-apportioned default" (see WithRangeBucketGridNativeMaxRows's
+// doc), the opposite of what apportioning means.
+func apportionRangeBucketGridNativeBounds(rows, densityUnits, k int64) (int64, int64) {
+	apportion := func(resolved int64) int64 {
+		v := resolved / k
+		if v < 1 {
+			v = 1
+		}
+		return v
+	}
+	return apportion(chsql.ResolveRangeBucketGridNativeMaxRows(rows)),
+		apportion(chsql.ResolveRangeBucketGridNativeMaxDensityUnits(densityUnits))
 }
 
 // decisionHasTSGridNative reports whether ANY shard plan of decision carries a

--- a/internal/engine/route_b_density_guard_apportion_test.go
+++ b/internal/engine/route_b_density_guard_apportion_test.go
@@ -1,0 +1,78 @@
+package engine
+
+import (
+	"testing"
+
+	"github.com/tsouza/cerberus/internal/solver"
+)
+
+// TestDecisionK pins the K-vs-kEff choice: routeBExecCtx apportions by the
+// structural shard count on the Decision, which is available at ctx-build
+// time, never by kEff (min(K, pEff, gate/2)), which the executor only
+// derives after the emit loop this ctx feeds. A nil or sub-1 K (a wiring
+// bug — see decisionK's own doc) must floor to 1, never divide by zero.
+func TestDecisionK(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		decision *solver.Decision
+		want     int64
+	}{
+		{name: "nil decision floors to 1", decision: nil, want: 1},
+		{name: "zero K floors to 1", decision: &solver.Decision{K: 0}, want: 1},
+		{name: "negative K floors to 1", decision: &solver.Decision{K: -1}, want: 1},
+		{name: "normal K passes through", decision: &solver.Decision{K: 4}, want: 4},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := decisionK(tc.decision); got != tc.want {
+				t.Errorf("decisionK(%+v) = %d, want %d", tc.decision, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestApportionRangeBucketGridNativeBounds pins the resolve-then-divide
+// contract: a zero/negative override must resolve to the compiled default
+// BEFORE dividing by k (dividing the raw override would read a caller's "no
+// override" as an apportioned near-zero bound instead of the un-apportioned
+// default), and each axis floors at 1 independently so a pathological
+// k > resolved configuration still stamps a real, if tiny, bound rather than
+// 0 — which chsql's own ctx lookup treats as "absent" (see
+// apportionRangeBucketGridNativeBounds's own doc).
+func TestApportionRangeBucketGridNativeBounds(t *testing.T) {
+	for _, tc := range []struct {
+		name             string
+		rows, du, k      int64
+		wantRows, wantDU int64
+	}{
+		{
+			name: "positive overrides divide evenly by k",
+			rows: 100, du: 200, k: 4,
+			wantRows: 25, wantDU: 50,
+		},
+		{
+			name: "zero overrides resolve to the compiled default before dividing",
+			rows: 0, du: 0, k: 5,
+			wantRows: 25_000_000 / 5, wantDU: 400_000_000 / 5,
+		},
+		{
+			name: "negative overrides resolve to the compiled default before dividing",
+			rows: -1, du: -1, k: 5,
+			wantRows: 25_000_000 / 5, wantDU: 400_000_000 / 5,
+		},
+		{
+			name: "k larger than the resolved bound floors each axis at 1",
+			rows: 2, du: 3, k: 10,
+			wantRows: 1, wantDU: 1,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			gotRows, gotDU := apportionRangeBucketGridNativeBounds(tc.rows, tc.du, tc.k)
+			if gotRows != tc.wantRows {
+				t.Errorf("rows = %d, want %d", gotRows, tc.wantRows)
+			}
+			if gotDU != tc.wantDU {
+				t.Errorf("densityUnits = %d, want %d", gotDU, tc.wantDU)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

`routeBExecCtx` threaded the deployment's resolved `RangeBucketGridNativeMaxRows`
/ `MaxDensityUnits` into every route-B shard un-apportioned, while the same
dispatch gives each shard only `cap / kEff` bytes. With `defaultMaxK` at 32 that
density ceiling could be up to 32x too permissive relative to what a shard is
actually allowed to use — the same "sailed past the guard and died on
ClickHouse's own `max_memory_usage`" failure mode #2677/#2681 already closed
for route A, still open on route B.

## Fix

Divide both ceilings by `decision.K` before stamping them onto the shard
dispatch ctx, floored at 1 per axis so a pathological `k > ceiling`
configuration still stamps a real (if tiny) bound rather than 0.

The apportionment resolves each override *before* dividing, via two new
exported `chsql.ResolveRangeBucketGridNativeMax{Rows,DensityUnits}` functions,
rather than dividing the raw override: a caller's `0` means "no override, use
chsql's compiled default" (chsql's own ctx-keyed reader treats `0` the same
way), not "unlimited" — unlike the memory cap's genuine unlimited-at-`0`
sentinel apportioned elsewhere in `routeBExecCtx`. Dividing a raw `0` by `K`
would still read back as `0`, which the ctx-keyed reader interprets as
"absent, use the un-apportioned default" — silently defeating the
apportionment for every caller that never set an override, the common case.

Apportions by `decision.K` (the structural shard count, available at
ctx-build time), not `kEff` (`min(K, pEff, gate/2)`), which the executor only
derives after the emit loop this ctx feeds — `K` is never smaller than
`kEff`, so dividing by `K` is always a safe, never-looser-than-correct bound.

## Verification

- New unit tests for `chsql.ResolveRangeBucketGridNativeMax{Rows,DensityUnits}`
  (override wins; zero/negative resolve to the compiled default).
- New unit tests for `decisionK` (nil/zero/negative K floors to 1) and
  `apportionRangeBucketGridNativeBounds` (even division, zero/negative
  override resolves before dividing, per-axis floor at 1 when
  `resolved/k < 1`).
- Existing `internal/engine/route_b_tsgrid_setting_test.go` suite (5 tests)
  still passes — no regression to the pre-existing TS-grid setting stamping.
- `just update-golden migration parity solver promql logql traceql chsql
  optimizer codegen cardinality` dispatched via CI on this branch: zero diff
  across every shard, confirming the change is purely additive to route-B's
  ctx-build path and touches no emitted SQL or chplan shape.

## Test plan

- [x] New unit tests pass locally
- [x] Existing route-B ctx tests pass (no regression)
- [x] Golden regen produced zero diff (confirmed via CI dispatch)

Closes #2705
