### PR TITLE
fix(ci): widen the compat comparer's per-query deadline for the floor lane

### DIFF
--- a/.github/workflows/compatibility.yml
+++ b/.github/workflows/compatibility.yml
@@ -602,20 +602,33 @@ jobs:
         # TESTER_QUERY_PARALLELISM=2: below the ts_grid_* / native-rate
         # floor (25.9, #1500) the fallback SQL does real per-row
         # rate/quantile/reset aggregation, which is genuinely slower than
-        # the native-function path every other lane exercises. The
-        # upstream tester hardcodes a 10s deadline per comparison
-        # (upstream/promql/comparer/comparer.go) with no flag to raise
-        # it, so at its default -query-parallelism=20 enough
-        # genuinely-slower floor queries queue behind each other that
-        # some miss that shared deadline on pure contention, not a real
-        # divergence (report.json shows empty diffs, just "context
-        # deadline exceeded"). Measured directly against this same image
-        # under a 2-vCPU cap (this runner class): every affected query
-        # answers in under 3s alone; concurrency 20 reproduces >10s
-        # response times, concurrency 2 stays under ~4s with comfortable
-        # margin. Lowering parallelism is the honest fix — it changes
-        # only how much load the floor lane offers at once, not which
-        # SQL cerberus emits or what the ratchet compares.
+        # the native-function path every other lane exercises. That is
+        # queueing contention, not correctness, so lowering parallelism
+        # keeps the floor lane from offering more concurrent load than a
+        # 2-vCPU runner can serve — the corpus this was originally
+        # measured against (#1699) answered every affected query in
+        # under 3s alone with comfortable margin under concurrency 2.
+        #
+        # #2112 later added resets()/changes() over an exponential
+        # histogram to that same fallback family, and it does NOT have
+        # that margin: measured alone, with zero contention, it costs
+        # 9-13s — already at or past the upstream tester's hardcoded
+        # per-comparison deadline (upstream/promql/comparer/comparer.go,
+        # `context.WithTimeout(..., 10*time.Second)`, no flag to raise
+        # it) before parallelism enters into it at all. That is why
+        # resets(demo_latency_exp_hist[5m]) and
+        # resets(demo_shifting_latency_exp_hist[5m]) flipped between
+        # REGRESSED and passing on an unchanged tree — every captured
+        # report carried an empty diff, just "context deadline
+        # exceeded" — and no amount of lowering -query-parallelism can
+        # fix it, because that knob bounds queueing, not the per-call
+        # budget a single unqueued call has already spent
+        # (tsouza/cerberus#2707). The actual fix widens that deadline:
+        # run-prometheus-compatibility.sh build-time patches
+        # comparer.go's timeout past every measured floor-lane cost,
+        # the same way it already patches the comparer's matrix-sort
+        # bug. Parallelism stays low here regardless, since it is still
+        # the right lever for genuine queueing contention.
         env:
           TESTER_END_TIME: "2026-05-11T01:00:00Z"
           TESTER_RANGE: "3600"

--- a/compatibility/prometheus/scripts/run-prometheus-compatibility.sh
+++ b/compatibility/prometheus/scripts/run-prometheus-compatibility.sh
@@ -103,7 +103,13 @@
 #                      window fold, 14% across-series bucket merge, 22%
 #                      quantile value expression. Cerberus issue #2267
 #                      owns making that arithmetic cheaper; this knob is
-#                      not the lever.
+#                      not the lever. `resets()`/`changes()` over an
+#                      exponential histogram (#2112) joined this family
+#                      after these numbers were taken, at 9-13s alone —
+#                      see the comparer-timeout patch below
+#                      (tsouza/cerberus#2707) for the fix that actually
+#                      keeps a legitimately-slow floor-lane answer from
+#                      being reported as a divergence.
 #
 # Upstream tester invocation (post-PR #298 / #300 audit):
 #   The upstream `promql-compliance-tester` only accepts `-config-file`
@@ -255,6 +261,43 @@ if ! grep -q 'sort.Sort(refResult.(model.Matrix))' "$COMPARER"; then
     perl -0pi -e 's/(\tsort\.Sort\(testResult\.\(model\.Matrix\)\)\n)/$1\tsort.Sort(refResult.(model.Matrix))\n/' "$COMPARER"
     if ! grep -q 'sort.Sort(refResult.(model.Matrix))' "$COMPARER"; then
         echo "ERROR: failed to patch comparer.go symmetric sort (upstream layout changed?)" >&2
+        exit 2
+    fi
+fi
+
+# Patch a second upstream limitation: Compare() wraps the ref+test
+# QueryRange pair — run SEQUENTIALLY against the SAME ctx, so the two
+# calls share one budget rather than getting 10s each — in one hardcoded
+# `context.WithTimeout(..., 10*time.Second)`, with no flag to raise it.
+#
+# tsouza/cerberus#2707: `resets(demo_latency_exp_hist[5m])` and
+# `resets(demo_shifting_latency_exp_hist[5m])` flipped between REGRESSED
+# and passing on an UNCHANGED tree. The uploaded report's diff was empty
+# every time; the failure was always `context deadline exceeded`. Below
+# 25.9 (#1500) every ts_grid_* native-rate feature resolves OFF, so the
+# floor lane deliberately measures cerberus's un-optimized per-row
+# fallback SQL — genuinely slower than the native path every other lane
+# exercises, not incorrect. Timed one query at a time against this
+# lane's own CH_IMAGE with this script's own seed fixture, on an
+# otherwise idle host: resets()/changes() over an exponential histogram
+# already sits at 9-13s alone (see the TESTER_QUERY_PARALLELISM doc
+# above for the sibling histogram_quantile / count_values numbers), so a
+# shared 10s ref+test budget was always going to flip on nothing but
+# runner-speed noise — the pair the flag was set low to protect against
+# in the first place. Lowering -query-parallelism controls how many
+# comparisons QUEUE, not how long any single one is given, so it cannot
+# buy back a budget one unqueued call has already spent; only widening
+# the deadline itself can. Widening it doesn't weaken what the gate
+# proves: Compare() still returns the moment both calls do, so a genuine
+# semantic divergence is caught exactly as fast as before — this only
+# changes how long a legitimately slow floor-lane answer is given before
+# being mistaken for one.
+echo "==> patching promql-compliance-tester comparer (widen the per-comparison deadline)"
+COMPAT_COMPARE_TIMEOUT_SECONDS=45
+if ! grep -q "${COMPAT_COMPARE_TIMEOUT_SECONDS}\*time\.Second" "$COMPARER"; then
+    perl -pi -e "s/\Q10*time.Second\E/${COMPAT_COMPARE_TIMEOUT_SECONDS}*time.Second/" "$COMPARER"
+    if ! grep -q "${COMPAT_COMPARE_TIMEOUT_SECONDS}\*time\.Second" "$COMPARER"; then
+        echo "ERROR: failed to patch comparer.go compare timeout (upstream layout changed?)" >&2
         exit 2
     fi
 fi

--- a/test/regression/compat_prometheus_compare_timeout_test.go
+++ b/test/regression/compat_prometheus_compare_timeout_test.go
@@ -1,0 +1,126 @@
+package regression
+
+import (
+	"os"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+// compatHarnessScriptPath drives the prometheus differential harness for
+// every lane (compatibility/prometheus, -forced-route, -floor).
+const compatHarnessScriptPath = "../../compatibility/prometheus/scripts/run-prometheus-compatibility.sh"
+
+// compatComparerRelPath is the vendored upstream file the harness build-time
+// patches before compiling promql-compliance-tester.
+const compatComparerRelPath = "upstream/promql/comparer/comparer.go"
+
+// The patch must both target the file the tester actually builds from and
+// widen the deadline PAST the hardcoded 10s upstream ships — pinned as two
+// substrings rather than one exact block so a harmless reflow of the
+// surrounding comment cannot break this test, while the load-bearing pieces
+// (which file, and that the replacement second count exceeds 10) still can.
+const (
+	compatComparerTimeoutOriginal = "10*time.Second"
+	compatComparerPatchMarker     = `COMPARER="$ROOT_DIR/upstream/promql/comparer/comparer.go"`
+)
+
+// TestPrometheusCompatHarnessWidensCompareTimeout (#2707) pins the fix for
+// two resets() cases over exponential (native) histograms —
+// resets(demo_latency_exp_hist[5m]) and
+// resets(demo_shifting_latency_exp_hist[5m]) — that flipped between
+// REGRESSED and passing on an otherwise unchanged tree.
+//
+// Root cause, established by direct measurement (see the harness script's
+// own doc comment): promql-compliance-tester's comparer.go wraps EACH
+// comparison's reference+test QueryRange pair, run sequentially against one
+// shared context, in a hardcoded `context.WithTimeout(..., 10*time.Second)`
+// with no flag to raise it. Below ClickHouse 25.9 (#1500) every ts_grid_*
+// native-rate feature resolves OFF, so the floor lane deliberately measures
+// cerberus's un-optimized per-row fallback SQL for resets()/changes() over
+// an exponential histogram — genuinely slower than the native path every
+// other lane exercises, not incorrect — and that fallback alone already
+// costs 9-13s on an otherwise idle host. A shared 10s ref+test budget was
+// always going to flip on nothing but runner-speed noise: not a semantic
+// divergence (every captured report carried an EMPTY diff), not seed
+// nondeterminism (the fixture anchors to a fixed wall-clock timestamp), and
+// not a capability-floor race (a prior, unrelated readiness fix was
+// misattributed to this before direct measurement ruled it out).
+//
+// Lowering -query-parallelism further cannot fix this: that knob bounds how
+// many comparisons QUEUE, not how long any single one is given once it
+// runs, so it cannot buy back a budget a single unqueued call has already
+// spent. Only widening the deadline itself gives the floor lane's
+// legitimately-slower fallback SQL room to answer before being mistaken for
+// a divergence — invariant 7 forbids parking the two cases in an
+// allow-list, and a gate that decides on runner speed cannot mean what that
+// invariant needs it to mean.
+//
+// This does not weaken what the gate proves: Compare() still returns the
+// moment both calls do, so a genuine semantic divergence (a real diff, or a
+// hard error) is caught exactly as fast as before. Only the amount of time
+// a legitimately slow floor-lane answer is given before being mistaken for
+// one changes.
+func TestPrometheusCompatHarnessWidensCompareTimeout(t *testing.T) {
+	t.Parallel()
+
+	script, err := os.ReadFile(compatHarnessScriptPath)
+	if err != nil {
+		t.Fatalf("read %s: %v", compatHarnessScriptPath, err)
+	}
+	body := string(script)
+
+	if !strings.Contains(body, compatComparerPatchMarker) {
+		t.Fatalf("%s no longer resolves COMPARER to %s; the compare-timeout patch below "+
+			"targets that variable, so this pin can't tell whether it still hits the right file",
+			compatHarnessScriptPath, compatComparerRelPath)
+	}
+
+	if !strings.Contains(body, compatComparerTimeoutOriginal) {
+		t.Fatalf("%s no longer names the upstream literal %q it is meant to replace in %s. "+
+			"Without a build-time patch, promql-compliance-tester ships a single 10s deadline "+
+			"covering BOTH the reference and test QueryRange calls, which resets()/changes() over "+
+			"an exponential histogram already sits at or past on the floor lane (ClickHouse < 25.9, "+
+			"#1500) alone — a legitimately slow answer gets reported as a REGRESSED case at random, "+
+			"the exact tsouza/cerberus#2707 flip.",
+			compatHarnessScriptPath, compatComparerTimeoutOriginal, compatComparerRelPath)
+	}
+
+	replacement := findReplacementTimeoutSeconds(t, body)
+	const compatComparerMinTimeoutSeconds = 10
+	if replacement <= compatComparerMinTimeoutSeconds {
+		t.Fatalf("%s patches comparer.go's ref+test compare timeout to %ds, which is not wider "+
+			"than the %ds upstream already ships. The patch must give the floor lane's measured "+
+			"9-13s exponential-histogram resets()/changes() fallback (and the sibling "+
+			"histogram_quantile/count_values family documented above it in the script) real "+
+			"headroom, not just restate the same deadline that already flips at random.",
+			compatHarnessScriptPath, replacement, compatComparerMinTimeoutSeconds)
+	}
+}
+
+// findReplacementTimeoutSeconds extracts the N in "N*time.Second" from the
+// script's own COMPAT_COMPARE_TIMEOUT_SECONDS assignment, so this test fails
+// loudly — rather than silently passing on a stale marker — if that
+// assignment is ever renamed or removed without updating this pin.
+func findReplacementTimeoutSeconds(t *testing.T, scriptBody string) int {
+	t.Helper()
+
+	const assignPrefix = "COMPAT_COMPARE_TIMEOUT_SECONDS="
+	idx := strings.Index(scriptBody, assignPrefix)
+	if idx < 0 {
+		t.Fatalf("%s no longer assigns %s; the compare-timeout patch this test pins reads its "+
+			"replacement value from that variable", compatHarnessScriptPath, assignPrefix)
+	}
+	rest := scriptBody[idx+len(assignPrefix):]
+	end := strings.IndexByte(rest, '\n')
+	if end < 0 {
+		t.Fatalf("%s: %s assignment runs off the end of the file", compatHarnessScriptPath, assignPrefix)
+	}
+	value := strings.TrimSpace(rest[:end])
+
+	seconds, err := strconv.Atoi(value)
+	if err != nil {
+		t.Fatalf("%s: %s%q did not parse as an integer: %v", compatHarnessScriptPath, assignPrefix, value, err)
+	}
+	return seconds
+}


### PR DESCRIPTION
## Summary

`resets(demo_latency_exp_hist[5m])` and `resets(demo_shifting_latency_exp_hist[5m])`
flipped between REGRESSED and passing on an unchanged tree on the
`compatibility/prometheus-floor` lane (#2707). Every captured report carried an
**empty diff** — the failure was always `context deadline exceeded`.

## Root cause (measured, not guessed)

Brought up the floor-pinned stack (`CH_IMAGE=clickhouse/clickhouse-server:24.8`)
locally and timed both queries directly against cerberus with zero contention:

```
resets(demo_latency_exp_hist[5m])           ~10.9s
resets(demo_shifting_latency_exp_hist[5m])  ~11.9s
```

against the same query on the reference Prometheus: **16ms**.

Below ClickHouse 25.9 every `ts_grid_*` native-rate feature resolves OFF
(#1500), so the floor lane deliberately measures cerberus's un-optimized
per-row fallback SQL for `resets()`/`changes()` over an exponential
histogram — genuinely slower than the native path every other lane
exercises, not incorrect.

`promql-compliance-tester`'s comparer
(`upstream/promql/comparer/comparer.go`) wraps **each** comparison's
reference+test `QueryRange` pair — run **sequentially against one shared
`ctx`** — in a hardcoded `context.WithTimeout(..., 10*time.Second)`, with no
flag to raise it. At ~11-12s alone, cerberus's half of that pair was already
past the *combined* budget before the reference's own (fast) call is even
added, so an unchanged tree was always going to flip on nothing but
runner-speed noise around that boundary.

`resets()`/`changes()` over exponential histograms (#2112) joined this
family after the lane's original headroom measurement (#1699, which lowered
`-query-parallelism` to 2 for queueing contention on a *different* set of
queries) was taken, and was never re-measured against the fixed deadline.
`-query-parallelism` bounds how many comparisons **queue**, not the per-call
budget a single unqueued call has already spent, so it can't fix this no
matter how low it goes.

## Fix

`run-prometheus-compatibility.sh` now build-time patches the comparer's
timeout from 10s to 45s — the same technique it already uses to patch the
comparer's matrix-sort bug — giving every measured floor-lane cost (this
family and the sibling `histogram_quantile`/`count_values` one already
documented in the script) real headroom. This doesn't weaken what the gate
proves: `Compare()` still returns the moment both calls do, so a genuine
semantic divergence (a real diff, or a hard error) is caught exactly as fast
as before. Only how long a legitimately slow floor-lane answer is given
before being mistaken for one changes.

Also updates the stale `TESTER_QUERY_PARALLELISM=2` doc comment in
`compatibility.yml`'s `prometheus-floor` job, which predates `resets()`/
`changes()` over exponential histograms and no longer reflected reality.

## Test

`test/regression/compat_prometheus_compare_timeout_test.go` pins the patch
(target file, original literal, and that the replacement value is strictly
wider than 10s) so it can't silently regress back to the upstream default.
Verified the pin actually catches the regression by reverting the fix
locally and confirming the test fails, then restoring it and confirming the
test passes.

## Verification

- `go test -run '^TestPrometheusCompatHarnessWidensCompareTimeout$' ./test/regression/...` — pass
- `node .github/scripts/forbid-sql-raw.mjs` — clean
- `CHECK=all node .github/scripts/forbid-skip.mjs` — clean
- `actionlint .github/workflows/compatibility.yml` — clean
- Direct repro against the floor-pinned stack (`CH_IMAGE=24.8`), documented above

The three CI lanes that build this same patched tester (`compatibility/prometheus`,
`-forced-route`, `-floor`) are the three genuinely-cannot-settle-locally lanes per
the repo's own invariant 5 — this PR's own local verification is the
narrowed repro that invariant asks for; the lanes themselves confirm on CI.

Closes #2707
