### PR TITLE
fix(solver,engine): gate the per-rung predictive bypass on observed evidence

### DIFF
--- a/cmd/cerberus/main.go
+++ b/cmd/cerberus/main.go
@@ -753,12 +753,13 @@ func newPromHandler(client *chclient.Client, cfg config.Config, optSet chopt.Ena
 	h := prom.New(client, cfg.Schema, logger.With("api", "prom"))
 	h.ResourceBounds = promResourceBounds
 	h.Engine = &engine.Engine{
-		Optimizer:       h.Optimizer,
-		Client:          client,
-		Solver:          evalSolver,
-		Settings:        settingsRules(cfg, optSet),
-		MaxQuerySamples: client.MaxQuerySamples(),
-		RouteMemo:       buildRouteMemo(evalSolver, logger),
+		Optimizer:        h.Optimizer,
+		Client:           client,
+		Solver:           evalSolver,
+		Settings:         settingsRules(cfg, optSet),
+		MaxQuerySamples:  client.MaxQuerySamples(),
+		RouteMemo:        buildRouteMemo(evalSolver, logger),
+		PerRungAdmission: buildPerRungAdmission(evalSolver),
 		// PromQL-only: TraceQL / LogQL plans never carry a
 		// chplan.RangeWindow.TemporalityColumn (the OTel Sum
 		// AggregationTemporality concept), so this is inert for the other
@@ -825,6 +826,22 @@ func buildRouteMemo(evalSolver *solver.Solver, logger *slog.Logger) *routememo.M
 		"revalidation_fraction", evalSolver.Cfg.RouteMemoReValidationFraction,
 	)
 	return memo
+}
+
+// buildPerRungAdmission wires the evidence-based per-rung admission
+// refinement (internal/engine/per_rung_admission.go, issue #2709). Gated
+// identically to buildRouteMemo — CERBERUS_SOLVER_ADAPTIVE_ENABLED, default
+// TRUE — because it is the same family of mechanism (routing informed by
+// what actually happened, not just by plan-time geometry), so the SAME knob
+// that turns adaptive routing off turns this off too rather than adding a
+// second, independently-configured flag for a narrower slice of the same
+// idea. Returns nil (the engine's byte-unchanged, feature-off default) under
+// the same conditions buildRouteMemo does.
+func buildPerRungAdmission(evalSolver *solver.Solver) *engine.PerRungAdmissionLearner {
+	if evalSolver == nil || !evalSolver.Cfg.AdaptiveEnabled {
+		return nil
+	}
+	return engine.NewPerRungAdmissionLearner()
 }
 
 // nativeRangeLowerers builds the BOOT-WIRED polymorphic lowering dispatch table

--- a/docs/solver.md
+++ b/docs/solver.md
@@ -596,6 +596,38 @@ wall-clock-duration guess, and it applies independent of, and in addition to,
 the Planner's own eligibility signals. Pinned in
 `internal/solver/avb_chdb_lane_test.go`'s `TestSolver_AvsB_ChDB_LiveEdgeBoundary`.
 
+### Per-rung predictive admission refinement
+
+The classic-histogram native ladder (`chplan.RangeBucketGridNative`) reports a
+flat `F = 1` — its per-`(series, le rung)` amplification is unmeasurable at
+plan time (its own doc, `internal/solver/planner.go`'s
+`minAnchorsForPerRungShard`) — so `auto`'s per-rung branch admits it on the
+anchor axis alone, bypassing both `MinFanout` and `MinAnchorPairs`, whenever
+`N >= minAnchorsForPerRungShard`. Anchor count is pure grid geometry: it says
+nothing about how much data backs the grid, and issue #2709 found a real case
+where that bites — a 24h/1m dashboard panel over a low-cardinality metric
+clears the anchor floor by 10x+ and predictively shards a nearly-empty table,
+paying `K` concurrent ClickHouse queries' contention for no benefit. #2709
+also shows geometry alone cannot fix this: a genuine incident the bypass
+exists to catch (#2677) has FEWER anchors than that false positive, so no
+anchor-only threshold can separate the two populations.
+
+`internal/engine/per_rung_admission.go`'s `PerRungAdmissionLearner` closes the
+gap with evidence instead: it watches what a `Decision.PerRungPredictive`
+route's cursor ACTUALLY, CLEANLY drains (a cancelled/errored drain is never
+recorded — see the file's own doc for why), and once a plan shape has
+produced a small enough composed result on `perRungEvidenceMinObservations`
+consecutive clean dispatches, it downgrades that shape's FUTURE per-rung
+routes back to route A until a fresh, larger drain is observed or the
+evidence ages past `perRungEvidenceTTL`. It never refuses a plan the Planner
+judged eligible and never touches `ModeSharded` or the failure-driven memo
+above — it only ever downgrades an ALREADY-`PerRungPredictive` route once
+evidence says the shape does not need it, falling back to today's
+anchor-only default with no evidence. `Engine.PerRungAdmission` is nil
+(feature off, byte-unchanged) unless wired from `cmd/cerberus`
+(`buildPerRungAdmission`), gated by the same `CERBERUS_SOLVER_ADAPTIVE_ENABLED`
+flag as the route memo above.
+
 ### Configuration
 
 On by default. It is the only half of the routing decision that reacts to what

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -943,6 +943,19 @@ type Engine struct {
 	// symmetrically, when a route-A dispatch fails with a resource-exhaustion
 	// error (a retry on route B, at most once, see route_memo_wiring.go).
 	RouteMemo *routememo.Memo
+
+	// PerRungAdmission is the OPTIONAL evidence-based refinement of the
+	// per-rung predictive bypass (solver.Decision.PerRungPredictive,
+	// per_rung_admission.go, issue #2709). Nil unless wired from
+	// cmd/cerberus (buildPerRungAdmission, gated the same way RouteMemo is —
+	// evalSolver.Cfg.AdaptiveEnabled), so the default path is byte-unchanged.
+	// When non-nil, a Decision that routed ONLY because ModeAuto's per-rung
+	// anchor-axis bypass fired is re-checked against what past dispatches of
+	// the SAME plan shape actually drained, and downgraded to route A once
+	// that evidence says the shape does not need K-way sharding — see
+	// per_rung_admission.go's own package doc for the full mechanism and
+	// why anchor count alone cannot express this.
+	PerRungAdmission *PerRungAdmissionLearner
 }
 
 // SetSettings installs rules as the per-query settings the engine evaluates
@@ -1413,6 +1426,9 @@ func (e *Engine) QueryPlan(ctx context.Context, lang Lang, plan chplan.Node, met
 	// test-only force) drains the Executor's composed cursor instead — it is
 	// wired but dormant at the default config.
 	decision, routed := e.classify(plan, lang)
+	// See QueryPlanCursor's own call site for what this does (DARK when
+	// PerRungAdmission is nil).
+	decision, routed = e.refinePerRungAdmission(plan, decision, routed)
 	if routed {
 		return e.executeRouted(ctx, lang, meta, plan, decision)
 	}
@@ -1635,6 +1651,12 @@ func (e *Engine) executeRouted(
 		e.logQueryFailure(lang.Name(), plan, decision, time.Since(start), routedQueryID(info), cerr)
 		return Result{}, fmt.Errorf("engine: solver drain: %w", cerr)
 	}
+	// Eager path drains synchronously above, so — unlike the cursor path,
+	// which needs perRungObservingCursor — the clean-drain row count is
+	// already in hand here. See per_rung_admission.go.
+	if e.PerRungAdmission != nil && decision.PerRungPredictive {
+		e.PerRungAdmission.Observe(perRungAdmissionKey(plan, decision), int64(len(samples)), int64(decision.NAnchors))
+	}
 	chMillis := time.Since(start).Milliseconds()
 	execT.Done(ctx)
 
@@ -1803,6 +1825,11 @@ func (e *Engine) QueryPlanCursor(ctx context.Context, lang Lang, plan chplan.Nod
 	// header. The routed branch returns the Executor's composed cursor
 	// instead — wired but dormant at the default config.
 	decision, routed := e.classify(plan, lang)
+	// Evidence-based refinement of the per-rung predictive bypass (DARK —
+	// nil PerRungAdmission is a no-op, byte-unchanged below). Only ever
+	// downgrades a PerRungPredictive route to route A; every other route or
+	// non-route passes through untouched. See per_rung_admission.go.
+	decision, routed = e.refinePerRungAdmission(plan, decision, routed)
 	if routed {
 		return e.executeRoutedCursor(ctx, lang, meta, plan, decision)
 	}
@@ -2114,8 +2141,11 @@ func (e *Engine) executeRoutedCursor(
 		return CursorResult{}, fmt.Errorf("engine: solver execute: %w", err)
 	}
 	// Dispatch seam for the streaming route-B path (the caller owns the drain,
-	// so there is no later engine-side site to record from).
+	// so there is no later engine-side site to record from) — except for the
+	// evidence-based per-rung refinement, which supplies its OWN drain-time
+	// site by wrapping the cursor below.
 	e.observeRoutedQuery(info, plan, lang.Name(), decision)
+	cursor = wrapPerRungObserver(cursor, e.PerRungAdmission, plan, decision)
 
 	nodes := cerbtrace.CountNodes(plan)
 	strategy := strategyFor(meta)

--- a/internal/engine/per_rung_admission.go
+++ b/internal/engine/per_rung_admission.go
@@ -1,0 +1,257 @@
+package engine
+
+import (
+	"sync"
+	"time"
+
+	"github.com/tsouza/cerberus/internal/chclient"
+	"github.com/tsouza/cerberus/internal/chplan"
+	"github.com/tsouza/cerberus/internal/routememo"
+	"github.com/tsouza/cerberus/internal/solver"
+)
+
+// per_rung_admission.go closes issue #2709: internal/solver/planner.go's
+// ModeAuto per-rung bypass (minAnchorsForPerRungShard) admits a
+// RangeBucketGridNative-carrying plan onto route B on the ANCHOR AXIS alone,
+// because that carrier's F is unmeasurable at plan time (see that constant's
+// own doc). Anchor count is pure grid GEOMETRY — it says nothing about how
+// much DATA backs the grid — and #2709 found a real case where geometry alone
+// gets it wrong: a 24h/1m classic-histogram dashboard panel over a
+// low-cardinality metric (a few dozen to a couple hundred series) clears the
+// anchor floor by more than 10x, so it predictively routes B, but K
+// concurrent ClickHouse queries contending over a table with almost nothing
+// in it is pure overhead — one unsharded query would have finished first.
+//
+// #2709 itself establishes (see the issue and this package's own tests) that
+// no purely GEOMETRIC signal can fix this: a genuine production incident this
+// bypass exists to catch (issue #2677) has FEWER anchors (as few as ~90) than
+// this false-positive panel (1,441), so any anchor-only threshold that admits
+// the real incident also admits the false positive, and any threshold that
+// excludes the false positive also excludes the real incident. The two
+// populations are only separable by how much data the grid actually divides
+// — which requires evidence, not geometry.
+//
+// This file supplies that evidence the ONLY way it can be had without a new
+// live round-trip on every per-rung request: it watches what a per-rung
+// PREDICTIVE dispatch (solver.Decision.PerRungPredictive) ACTUALLY drained,
+// and once a plan SHAPE has repeatedly, cleanly produced a small composed
+// result despite clearing the anchor floor, it declines the bypass for
+// FUTURE requests of that same shape — falling back to the anchor-only
+// default (today's behavior, unchanged) until that evidence exists. This is
+// the "track observed per-shard cost, learn when a shape is worth splitting,
+// fall back to the conservative default with no evidence" escalation #2709
+// itself names as the correct one once geometry alone is shown insufficient.
+//
+// Deliberately narrow: it never REFUSES a plan the Planner judged eligible,
+// never promotes route A to route B, and never touches ModeSharded or
+// Eligible()'s failure-driven memo seam — Plan's own per-rung bypass, and
+// the geometry-only threshold it clears at, are completely unchanged. This
+// only ever downgrades an already-PerRungPredictive route B to route A, and
+// only once evidence says the shape does not need it.
+
+// perRungEvidenceMinObservations mirrors routememo's own
+// minCorroboratingFailures: a single clean-and-cheap drain cannot, by
+// itself, teach the learner anything — a low-traffic blip or an
+// unrepresentative first sample must not flip a shape's verdict alone.
+const perRungEvidenceMinObservations = 2
+
+// perRungCheapRowsPerAnchor bounds "cheap" RELATIVE to the anchor count
+// rather than as an absolute row count, because N is already part of the
+// routing Key (AnchorLg) and the false-positive class #2709 describes is a
+// WIDE grid over FEW underlying series — a fixed absolute floor would wrongly
+// call a genuinely wide, genuinely high-cardinality panel "cheap" just because
+// its anchor count inflates the total. A composed route-B result averaging
+// fewer than this many output rows per anchor is producing, at every anchor,
+// a small enough set of distinct series/label groups that no realistic
+// backing-table size behind it would have justified K-way contention to
+// answer it — sharding divides the anchor axis, not label cardinality, so a
+// query this narrow per anchor has few underlying series to scan regardless
+// of window width.
+const perRungCheapRowsPerAnchor = 20
+
+// perRungEvidenceTTL bounds how long a learned verdict is trusted, mirroring
+// routememo's own memoEntryTTL (30m): a metric's real cardinality can grow
+// (a new label value, a service scaling out), and a verdict computed against
+// yesterday's shape must not silently suppress predictive routing forever
+// once that has happened. An observation older than this resets the state as
+// if nothing had been learned yet, which is the ordinary "no evidence exists"
+// default, not a fresh strike against the shape.
+const perRungEvidenceTTL = 30 * time.Minute
+
+// perRungLearnerCapacity mirrors routememo's own memoMaxEntries: a bound
+// resident size so unbounded key cardinality cannot grow this cache without
+// limit. Eviction here is coarser than routememo's true LRU (any single
+// entry may be evicted once at capacity, not necessarily the oldest) because
+// the cost of evicting the wrong entry is trivial — it only resets that one
+// shape back to "no evidence yet", the always-safe default.
+const perRungLearnerCapacity = 4096
+
+// perRungAdmissionState is one plan-shape's rolling evidence.
+type perRungAdmissionState struct {
+	consecutiveCheap int
+	lastObserved     time.Time
+}
+
+// PerRungAdmissionLearner is the OPTIONAL, per-Engine-instance cache backing
+// this file's own doc. A nil *PerRungAdmissionLearner behaves exactly like a
+// nil Engine.RouteMemo: every method on it is written to be called only
+// through Engine.PerRungAdmission's own nil guard at the call sites in
+// engine.go, so the zero (unwired) Engine stays byte-unchanged — see
+// NewPerRungAdmissionLearner's caller, buildPerRungAdmission
+// (cmd/cerberus/main.go).
+type PerRungAdmissionLearner struct {
+	mu     sync.Mutex
+	states map[routememo.Key]*perRungAdmissionState
+}
+
+// NewPerRungAdmissionLearner constructs an empty learner.
+func NewPerRungAdmissionLearner() *PerRungAdmissionLearner {
+	return &PerRungAdmissionLearner{states: make(map[routememo.Key]*perRungAdmissionState)}
+}
+
+// Observe records one COMPLETED, CLEANLY-DRAINED per-rung predictive route-B
+// dispatch's total composed output row count for key's shape. The caller is
+// responsible for only calling this on a clean drain (Cursor.Err() == nil) —
+// see perRungObservingCursor and executeRouted's own eager-path call site —
+// because a CANCELLED or partially-drained dispatch (exactly #2709's own
+// reported symptom: a client cancel after 19s) reports a truncated row count
+// that looks artificially cheap. Recording that would teach the learner the
+// opposite of the truth: the dispatch was too slow to finish, not too small
+// to matter.
+func (l *PerRungAdmissionLearner) Observe(key routememo.Key, outputRows, nAnchors int64) {
+	if nAnchors <= 0 {
+		return
+	}
+	cheap := outputRows < nAnchors*perRungCheapRowsPerAnchor
+
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	st, ok := l.states[key]
+	if !ok {
+		if len(l.states) >= perRungLearnerCapacity {
+			for k := range l.states {
+				delete(l.states, k)
+				break
+			}
+		}
+		st = &perRungAdmissionState{}
+		l.states[key] = st
+	}
+	if cheap {
+		st.consecutiveCheap++
+	} else {
+		st.consecutiveCheap = 0
+	}
+	st.lastObserved = time.Now()
+}
+
+// ShouldDeclineBypass reports whether key's shape has accumulated enough
+// FRESH, consecutive cheap observations to decline the anchor-only per-rung
+// bypass on its next request. Returns false (the always-safe default: keep
+// today's geometry-only admission) when there is no entry, or the entry has
+// aged past perRungEvidenceTTL.
+func (l *PerRungAdmissionLearner) ShouldDeclineBypass(key routememo.Key) bool {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	st, ok := l.states[key]
+	if !ok {
+		return false
+	}
+	if time.Since(st.lastObserved) > perRungEvidenceTTL {
+		return false
+	}
+	return st.consecutiveCheap >= perRungEvidenceMinObservations
+}
+
+// perRungAdmissionKey computes the routememo.Key for decision's own grid
+// readout, reused for both the pre-dispatch admission lookup and the
+// post-drain observation that feeds it — the SAME shape must hash to the
+// SAME key on both sides or the learner never converges.
+func perRungAdmissionKey(plan chplan.Node, decision *solver.Decision) routememo.Key {
+	return routememo.KeyFor(plan, decision.NAnchors, decision.Fanout, decision.Step)
+}
+
+// declinePerRungBypass demotes decision to the non-route Plan's ModeAuto
+// branch would have produced had the per-rung bypass not fired on cost
+// grounds — Strategy/K/Slices/PerRungPredictive clear, Reason becomes
+// solver.ReasonBelowThreshold (the SAME token an anchor-only-insufficient
+// per-rung carrier already reports; this is that same cost gate, now
+// additionally informed by real evidence). The cost-grid fields
+// (NAnchors/Fanout/CumulativeD/OuterRange/Step) are left untouched: they are
+// a pure readout of the same plan and stay accurate on a declined route.
+func declinePerRungBypass(decision *solver.Decision) *solver.Decision {
+	declined := *decision
+	declined.Strategy = ""
+	declined.K = 0
+	declined.Slices = nil
+	declined.Reason = solver.ReasonBelowThreshold
+	declined.PerRungPredictive = false
+	return &declined
+}
+
+// refinePerRungAdmission re-checks a routed, PerRungPredictive Decision
+// against e.PerRungAdmission's own learned evidence before dispatch. Decision
+// and routed pass through byte-unchanged when PerRungAdmission is nil (the
+// default — see Engine.PerRungAdmission's own doc), when decision is nil, when
+// routed is already false, or when the route did not come from the per-rung
+// bypass (PerRungPredictive false) — every other route (an ordinary
+// MinFanout/MinAnchorPairs clearance, ModeSharded, or Eligible()'s
+// failure-driven memo escalation) is a real cost/evidence-based decision
+// already and is never second-guessed here.
+func (e *Engine) refinePerRungAdmission(plan chplan.Node, decision *solver.Decision, routed bool) (*solver.Decision, bool) {
+	if e.PerRungAdmission == nil || decision == nil || !routed || !decision.PerRungPredictive {
+		return decision, routed
+	}
+	key := perRungAdmissionKey(plan, decision)
+	if !e.PerRungAdmission.ShouldDeclineBypass(key) {
+		return decision, routed
+	}
+	return declinePerRungBypass(decision), false
+}
+
+// perRungObservingCursor wraps a route-B cursor for a per-rung PREDICTIVE
+// dispatch so its own Close() feeds the learner exactly what the CALLER
+// actually drained. QueryPlanCursor's caller owns the drain (executeRoutedCursor's
+// own doc: "there is no later engine-side site to record from"), so this
+// wrapper IS that site — it changes no behavior the caller observes (every
+// method but Close delegates straight through the embedded Cursor) and only
+// ever reads Err()/Inspected() after Close(), never influencing either.
+type perRungObservingCursor struct {
+	chclient.Cursor
+	learner  *PerRungAdmissionLearner
+	key      routememo.Key
+	nAnchors int64
+	once     sync.Once
+}
+
+// Close delegates to the wrapped cursor first (this must never change teardown
+// timing or behavior), then records the observation exactly once — guarded by
+// sync.Once because a cursor may be Closed more than once by a defensive
+// caller, and a second observation must not double-count. Only a CLEAN drain
+// (Err() == nil) is trusted evidence — see PerRungAdmissionLearner.Observe's
+// own doc for why a cancelled/truncated drain must never be recorded as
+// "cheap".
+func (c *perRungObservingCursor) Close() error {
+	err := c.Cursor.Close()
+	c.once.Do(func() {
+		if c.Cursor.Err() == nil {
+			c.learner.Observe(c.key, c.Cursor.Inspected(), c.nAnchors)
+		}
+	})
+	return err
+}
+
+// wrapPerRungObserver returns cursor unchanged when learner is nil or the
+// dispatch was not a per-rung predictive route — every other route-B cursor
+// stays exactly what Executor.Execute returned.
+func wrapPerRungObserver(cursor chclient.Cursor, learner *PerRungAdmissionLearner, plan chplan.Node, decision *solver.Decision) chclient.Cursor {
+	if learner == nil || decision == nil || !decision.PerRungPredictive {
+		return cursor
+	}
+	return &perRungObservingCursor{
+		Cursor:   cursor,
+		learner:  learner,
+		key:      perRungAdmissionKey(plan, decision),
+		nAnchors: int64(decision.NAnchors),
+	}
+}

--- a/internal/engine/per_rung_admission.go
+++ b/internal/engine/per_rung_admission.go
@@ -234,8 +234,8 @@ type perRungObservingCursor struct {
 func (c *perRungObservingCursor) Close() error {
 	err := c.Cursor.Close()
 	c.once.Do(func() {
-		if c.Cursor.Err() == nil {
-			c.learner.Observe(c.key, c.Cursor.Inspected(), c.nAnchors)
+		if c.Err() == nil {
+			c.learner.Observe(c.key, c.Inspected(), c.nAnchors)
 		}
 	})
 	return err

--- a/internal/engine/per_rung_admission_test.go
+++ b/internal/engine/per_rung_admission_test.go
@@ -1,0 +1,296 @@
+package engine
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/tsouza/cerberus/internal/chclient"
+	"github.com/tsouza/cerberus/internal/chplan"
+	"github.com/tsouza/cerberus/internal/routememo"
+	"github.com/tsouza/cerberus/internal/solver"
+)
+
+// --- fixtures --------------------------------------------------------------
+
+// perRungTestPlan is a minimal, stable chplan.Node — routememo.KeyFor only
+// needs a walkable tree, and every test in this file uses the SAME plan/N/F/
+// Step so its Key is stable across calls.
+func perRungTestPlan() chplan.Node {
+	return &chplan.Aggregate{
+		Input:    &chplan.Scan{Table: "otel_metrics_histogram"},
+		GroupBy:  []chplan.Expr{&chplan.ColumnRef{Name: "anchor_ts"}},
+		AggFuncs: []chplan.AggFunc{{Fn: chplan.FnGroupArray, Args: []chplan.Expr{&chplan.ColumnRef{Name: "BucketCounts"}}}},
+	}
+}
+
+// perRungTestNAnchors mirrors the #2709 failing panel's own grid (24h/1m).
+const perRungTestNAnchors = 1441
+
+func perRungTestKey() routememo.Key {
+	return routememo.KeyFor(perRungTestPlan(), perRungTestNAnchors, 1, time.Minute)
+}
+
+// perRungTestDecision is a routed, PerRungPredictive Decision over
+// perRungTestPlan/perRungTestKey's own grid — the shape refinePerRungAdmission
+// is meant to re-check.
+func perRungTestDecision() *solver.Decision {
+	return &solver.Decision{
+		Strategy:          solver.StrategyShardedTimeslice,
+		K:                 8,
+		Reason:            solver.ReasonRouted,
+		Slices:            []solver.Slice{{}},
+		NAnchors:          perRungTestNAnchors,
+		Fanout:            1,
+		Step:              time.Minute,
+		PerRungPredictive: true,
+	}
+}
+
+// --- PerRungAdmissionLearner -----------------------------------------------
+
+func TestPerRungAdmissionLearner_NoEvidenceKeepsTodaysBehavior(t *testing.T) {
+	t.Parallel()
+	l := NewPerRungAdmissionLearner()
+	if l.ShouldDeclineBypass(perRungTestKey()) {
+		t.Fatal("a never-observed shape must not decline the bypass — the always-safe default is " +
+			"today's unchanged anchor-only admission")
+	}
+}
+
+func TestPerRungAdmissionLearner_DeclinesAfterConsecutiveCheapDrains(t *testing.T) {
+	t.Parallel()
+	l := NewPerRungAdmissionLearner()
+	key := perRungTestKey()
+
+	// A cheap output well under perRungCheapRowsPerAnchor * N (1441*20).
+	const cheapRows = 100
+
+	l.Observe(key, cheapRows, perRungTestNAnchors)
+	if l.ShouldDeclineBypass(key) {
+		t.Fatal("a single cheap observation declined the bypass — " +
+			"perRungEvidenceMinObservations exists precisely so one reading cannot flip the verdict alone")
+	}
+
+	l.Observe(key, cheapRows, perRungTestNAnchors)
+	if !l.ShouldDeclineBypass(key) {
+		t.Fatalf("%d consecutive cheap drains did not decline the bypass", perRungEvidenceMinObservations)
+	}
+}
+
+func TestPerRungAdmissionLearner_ExpensiveDrainResetsTheStreak(t *testing.T) {
+	t.Parallel()
+	l := NewPerRungAdmissionLearner()
+	key := perRungTestKey()
+	const cheapRows = 100
+	// An output at/above perRungCheapRowsPerAnchor * N — genuinely wide output.
+	const expensiveRows = perRungTestNAnchors * perRungCheapRowsPerAnchor
+
+	l.Observe(key, cheapRows, perRungTestNAnchors)
+	l.Observe(key, expensiveRows, perRungTestNAnchors)
+	if l.ShouldDeclineBypass(key) {
+		t.Fatal("an expensive drain between two cheap ones must reset the streak, not just get ignored — " +
+			"a shape that started producing real output is exactly the case the streak exists to protect " +
+			"predictive routing for")
+	}
+
+	l.Observe(key, cheapRows, perRungTestNAnchors)
+	if l.ShouldDeclineBypass(key) {
+		t.Fatal("only one cheap observation followed the reset — must not decline yet")
+	}
+}
+
+func TestPerRungAdmissionLearner_StaleEvidenceIsIgnored(t *testing.T) {
+	t.Parallel()
+	l := NewPerRungAdmissionLearner()
+	key := perRungTestKey()
+	const cheapRows = 100
+
+	l.Observe(key, cheapRows, perRungTestNAnchors)
+	l.Observe(key, cheapRows, perRungTestNAnchors)
+	if !l.ShouldDeclineBypass(key) {
+		t.Fatal("fixture setup: expected the streak to already qualify before aging it")
+	}
+
+	// Same package as production code: reach in and age the entry past its
+	// TTL directly, exactly as routememo's own tests manipulate internal
+	// state rather than needing a clock-injection seam for a single test.
+	l.mu.Lock()
+	l.states[key].lastObserved = time.Now().Add(-perRungEvidenceTTL - time.Minute)
+	l.mu.Unlock()
+
+	if l.ShouldDeclineBypass(key) {
+		t.Fatal("evidence older than perRungEvidenceTTL must be treated as no-evidence — a metric's " +
+			"real cardinality can grow, and a stale cheap verdict must not suppress predictive " +
+			"routing forever")
+	}
+}
+
+func TestPerRungAdmissionLearner_CapacityEvictsRatherThanGrowsUnbounded(t *testing.T) {
+	t.Parallel()
+	l := NewPerRungAdmissionLearner()
+	for i := 0; i < perRungLearnerCapacity+8; i++ {
+		key := routememo.KeyFor(perRungTestPlan(), i+1, 1, time.Minute)
+		l.Observe(key, 1, int64(i+1))
+	}
+	l.mu.Lock()
+	n := len(l.states)
+	l.mu.Unlock()
+	if n > perRungLearnerCapacity {
+		t.Fatalf("learner grew to %d entries, want <= %d (perRungLearnerCapacity)", n, perRungLearnerCapacity)
+	}
+}
+
+// --- refinePerRungAdmission --------------------------------------------------
+
+func TestRefinePerRungAdmission_NilLearnerIsANoop(t *testing.T) {
+	t.Parallel()
+	e := &Engine{}
+	decision, routed := e.refinePerRungAdmission(perRungTestPlan(), perRungTestDecision(), true)
+	if !routed || decision.Reason != solver.ReasonRouted || decision.K != 8 {
+		t.Fatalf("nil PerRungAdmission must leave the decision byte-unchanged, got routed=%v reason=%q k=%d",
+			routed, decision.Reason, decision.K)
+	}
+}
+
+func TestRefinePerRungAdmission_OnlyTouchesPerRungPredictiveRoutes(t *testing.T) {
+	t.Parallel()
+	l := NewPerRungAdmissionLearner()
+	key := perRungTestKey()
+	l.Observe(key, 1, perRungTestNAnchors)
+	l.Observe(key, 1, perRungTestNAnchors)
+	if !l.ShouldDeclineBypass(key) {
+		t.Fatal("fixture setup: expected decline-worthy evidence")
+	}
+	e := &Engine{PerRungAdmission: l}
+
+	ordinary := perRungTestDecision()
+	ordinary.PerRungPredictive = false // an ordinary MinFanout/MinAnchorPairs clearance
+	decision, routed := e.refinePerRungAdmission(perRungTestPlan(), ordinary, true)
+	if !routed || decision.Reason != solver.ReasonRouted {
+		t.Fatalf("a non-PerRungPredictive route must never be second-guessed by this refinement, "+
+			"got routed=%v reason=%q", routed, decision.Reason)
+	}
+}
+
+func TestRefinePerRungAdmission_DowngradesOnceEvidenceSaysCheap(t *testing.T) {
+	t.Parallel()
+	l := NewPerRungAdmissionLearner()
+	key := perRungTestKey()
+	l.Observe(key, 1, perRungTestNAnchors)
+	l.Observe(key, 1, perRungTestNAnchors)
+	if !l.ShouldDeclineBypass(key) {
+		t.Fatal("fixture setup: expected decline-worthy evidence")
+	}
+	e := &Engine{PerRungAdmission: l}
+
+	decision, routed := e.refinePerRungAdmission(perRungTestPlan(), perRungTestDecision(), true)
+	if routed {
+		t.Fatal("evidence-declined per-rung route must not dispatch route B")
+	}
+	if decision.Strategy != "" || decision.K != 0 || decision.Slices != nil {
+		t.Errorf("declined decision must clear Strategy/K/Slices, got Strategy=%q K=%d Slices=%v",
+			decision.Strategy, decision.K, decision.Slices)
+	}
+	if decision.Reason != solver.ReasonBelowThreshold {
+		t.Errorf("declined decision reason = %q, want %q", decision.Reason, solver.ReasonBelowThreshold)
+	}
+	if decision.PerRungPredictive {
+		t.Error("declined decision must clear PerRungPredictive — it no longer describes a route")
+	}
+	if decision.NAnchors != perRungTestNAnchors {
+		t.Error("declined decision must keep the cost-grid readout (NAnchors) for the shadow header/corpus")
+	}
+}
+
+// --- wrapPerRungObserver / perRungObservingCursor ---------------------------
+
+// perRungFakeCursor is a minimal chclient.Cursor whose Err()/Inspected() are
+// fixed at construction, mirroring route_memo_wiring_test.go's own
+// fakeMemoWiringCursor fixture style.
+type perRungFakeCursor struct {
+	err       error
+	inspected int64
+	closes    int
+}
+
+func (c *perRungFakeCursor) Next() bool              { return false }
+func (c *perRungFakeCursor) Sample() chclient.Sample { return chclient.Sample{} }
+func (c *perRungFakeCursor) Err() error              { return c.err }
+func (c *perRungFakeCursor) Inspected() int64        { return c.inspected }
+func (c *perRungFakeCursor) Close() error {
+	c.closes++
+	return nil
+}
+
+func TestWrapPerRungObserver_PassesThroughWhenNotApplicable(t *testing.T) {
+	t.Parallel()
+	fake := &perRungFakeCursor{}
+
+	if got := wrapPerRungObserver(fake, nil, perRungTestPlan(), perRungTestDecision()); got != chclient.Cursor(fake) {
+		t.Error("a nil learner must return the cursor unchanged")
+	}
+
+	notPerRung := perRungTestDecision()
+	notPerRung.PerRungPredictive = false
+	l := NewPerRungAdmissionLearner()
+	if got := wrapPerRungObserver(fake, l, perRungTestPlan(), notPerRung); got != chclient.Cursor(fake) {
+		t.Error("a non-PerRungPredictive decision must return the cursor unchanged")
+	}
+}
+
+func TestWrapPerRungObserver_RecordsOnlyOnACleanDrain(t *testing.T) {
+	t.Parallel()
+	l := NewPerRungAdmissionLearner()
+	plan := perRungTestPlan()
+	decision := perRungTestDecision()
+
+	// A cancelled/errored drain with a SMALL Inspected() count must NOT be
+	// recorded as cheap — exactly #2709's own reported symptom (a client
+	// cancel after 19s), which would otherwise teach the learner the
+	// opposite of the truth.
+	cancelled := &perRungFakeCursor{err: errors.New("context canceled"), inspected: 1}
+	wrapped := wrapPerRungObserver(cancelled, l, plan, decision)
+	if err := wrapped.Close(); err != nil {
+		t.Fatalf("Close returned an unexpected error: %v", err)
+	}
+	if l.ShouldDeclineBypass(perRungTestKey()) {
+		t.Fatal("a cancelled drain must never contribute evidence, clean or not")
+	}
+
+	// Two SEPARATE clean, cheap dispatches (two distinct wrapped cursors,
+	// mirroring two distinct requests) accumulate toward the decline.
+	for i := 0; i < perRungEvidenceMinObservations; i++ {
+		clean := &perRungFakeCursor{inspected: 1}
+		wrapped := wrapPerRungObserver(clean, l, plan, decision)
+		if err := wrapped.Close(); err != nil {
+			t.Fatalf("Close returned an unexpected error: %v", err)
+		}
+	}
+	if !l.ShouldDeclineBypass(perRungTestKey()) {
+		t.Fatal("two clean, cheap drains did not accumulate evidence")
+	}
+}
+
+func TestWrapPerRungObserver_DoubleCloseRecordsOnce(t *testing.T) {
+	t.Parallel()
+	l := NewPerRungAdmissionLearner()
+	plan := perRungTestPlan()
+	decision := perRungTestDecision()
+	key := routememo.KeyFor(plan, decision.NAnchors, decision.Fanout, decision.Step)
+
+	clean := &perRungFakeCursor{inspected: 1}
+	wrapped := wrapPerRungObserver(clean, l, plan, decision)
+	_ = wrapped.Close()
+	_ = wrapped.Close()
+
+	if clean.closes != 2 {
+		t.Fatalf("fixture: expected the underlying cursor's own Close to be called twice, got %d", clean.closes)
+	}
+	l.mu.Lock()
+	streak := l.states[key].consecutiveCheap
+	l.mu.Unlock()
+	if streak != 1 {
+		t.Fatalf("double Close recorded %d observations, want exactly 1 (sync.Once must guard it)", streak)
+	}
+}

--- a/internal/solver/decision.go
+++ b/internal/solver/decision.go
@@ -75,6 +75,22 @@ type Decision struct {
 	CumulativeD time.Duration // D = Σ spine lookback (Range / Lookback)
 	OuterRange  time.Duration // OuterRange of the outermost spine
 	Step        time.Duration // the request grid step
+
+	// PerRungPredictive is true exactly when this route came from ModeAuto's
+	// per-rung bypass (planner.go's perRung branch, gated on
+	// minAnchorsForPerRungShard): F is unmeasurable for a per-rung carrier
+	// (carrierGeometry.perRungIntermediate), so admission read the anchor
+	// axis alone rather than MinFanout/MinAnchorPairs, which cannot see how
+	// much DATA backs the grid.
+	//
+	// This is a pure, additive readout of the SAME classification Plan
+	// already computed — it changes no routing behavior by itself. It exists
+	// so a caller (internal/engine's per-rung admission refinement) can tell
+	// "routed because a real cost threshold was cleared" apart from "routed
+	// because geometry alone cleared a bar that cannot see cost", and apply
+	// evidence-based scrutiny only to the latter population. False on every
+	// other route and on every non-route.
+	PerRungPredictive bool
 }
 
 // StrategyShardedTimeslice is the only decomposition strategy emitted:

--- a/internal/solver/planner.go
+++ b/internal/solver/planner.go
@@ -79,11 +79,12 @@ func (p *Planner) Plan(plan chplan.Node, meta RequestMeta) (*Decision, bool) {
 		if sig.sawIndivisibleAnchorGrid {
 			return notRouted(ReasonAnchorGridIndivisible).withGrid(sig, meta), false
 		}
+		return p.sliceAndDecide(plan, meta, sig, k, perRung)
 	}
 	// "sharded": thresholds drop to the floor — every eligible plan routes
 	// at K_min = 2 (k is already clamped to >= 2 by classify when upper >= 2).
 
-	return p.sliceAndDecide(plan, meta, sig, k)
+	return p.sliceAndDecide(plan, meta, sig, k, false)
 }
 
 // Eligible reports whether plan is STRUCTURALLY eligible to route B —
@@ -126,14 +127,21 @@ func (p *Planner) Eligible(plan chplan.Node, meta RequestMeta) (*Decision, bool)
 	if p.Cfg.Mode == ModeSingle {
 		return notRouted(ReasonRoutingDisabled).withGrid(sig, meta), false
 	}
-	return p.sliceAndDecide(plan, meta, sig, k)
+	// Eligible bypasses ModeAuto's cost thresholds entirely (its own doc),
+	// so a per-rung carrier reaching here did not pass through the anchor-axis
+	// bypass at all — real evidence (a route-A resource failure) is what
+	// admitted it, which outranks the geometry-only proxy PerRungPredictive
+	// exists to flag. false here, always.
+	return p.sliceAndDecide(plan, meta, sig, k, false)
 }
 
 // sliceAndDecide is the shared tail of Plan and Eligible once a mode-specific
 // gate (or none, for Eligible) has cleared k >= 2: slice the plan at k shards
 // and build the routed Decision, or fall back to a non-route Decision if
-// slicing fails or collapses to a single produced slice.
-func (p *Planner) sliceAndDecide(plan chplan.Node, meta RequestMeta, sig signals, k int64) (*Decision, bool) {
+// slicing fails or collapses to a single produced slice. perRungPredictive is
+// threaded straight onto the routed Decision's own field of that name — see
+// its doc for why only Plan's ModeAuto per-rung branch ever passes true.
+func (p *Planner) sliceAndDecide(plan chplan.Node, meta RequestMeta, sig signals, k int64, perRungPredictive bool) (*Decision, bool) {
 	slices, err := p.slice(plan, meta, int(k))
 	if err != nil {
 		// A slicing failure on a plan the Planner judged eligible is a
@@ -152,10 +160,11 @@ func (p *Planner) sliceAndDecide(plan chplan.Node, meta RequestMeta, sig signals
 	}
 
 	return (&Decision{
-		Strategy: StrategyShardedTimeslice,
-		K:        len(slices),
-		Reason:   ReasonRouted,
-		Slices:   slices,
+		Strategy:          StrategyShardedTimeslice,
+		K:                 len(slices),
+		Reason:            ReasonRouted,
+		Slices:            slices,
+		PerRungPredictive: perRungPredictive,
 	}).withGrid(sig, meta), true
 }
 

--- a/internal/solver/range_bucket_grid_native_route_test.go
+++ b/internal/solver/range_bucket_grid_native_route_test.go
@@ -182,6 +182,12 @@ func TestRangeBucketGridNative_PredictiveRoutingOnTheAnchorAxis(t *testing.T) {
 	if d.K < 2 {
 		t.Errorf("predictive route produced K=%d, want >= 2", d.K)
 	}
+	if !d.PerRungPredictive {
+		t.Errorf("predictive route did not set PerRungPredictive — issue #2709's evidence-based " +
+			"admission refinement (internal/engine's PerRungAdmissionLearner) keys off this field " +
+			"to tell a real MinFanout/MinAnchorPairs clearance apart from an anchor-only geometry " +
+			"bypass; leaving it false here would make that refinement silently inert")
+	}
 
 	// Below the floor: still declines, and on COST rather than structure.
 	narrow := bucketGridNativeCarrier()
@@ -217,5 +223,10 @@ func TestRangeBucketGridNative_EligibleStillBypassesThresholds(t *testing.T) {
 	}
 	if ed.K < 2 || ed.Reason != ReasonRouted {
 		t.Errorf("Eligible returned K=%d reason=%q, want K>=2 and %q", ed.K, ed.Reason, ReasonRouted)
+	}
+	if ed.PerRungPredictive {
+		t.Errorf("Eligible's route set PerRungPredictive — this route was admitted by REAL evidence " +
+			"(a route-A resource failure), not by the anchor-only geometry bypass, so it must not be " +
+			"flagged as the population issue #2709's evidence-based refinement should ever second-guess")
 	}
 }


### PR DESCRIPTION
## Summary

`internal/solver/planner.go`'s ModeAuto per-rung branch
(`minAnchorsForPerRungShard`) admits a `RangeBucketGridNative`-carrying plan
onto route B on the anchor axis alone — bypassing both `MinFanout` and
`MinAnchorPairs` entirely — because that carrier's `F` is unmeasurable at
plan time (its own doc). Anchor count is pure grid geometry: it says nothing
about how much data backs the grid.

**Confirmed mechanism** (not just suspected): the e2e failing tuple
(`Cerberus :: P95 latency by language :: A :: range=now-24h step=1m`) queries
`histogram_quantile(0.95, sum by (le, cerberus_ql)
(rate(cerberus_queries_duration_seconds_bucket[5m])))` — cerberus's own
self-telemetry histogram (a few dozen to a couple hundred series across all
three heads, per `internal/chsql/range_bucket_grid_native_bound.go`'s own
`#2522` calibration notes) — at 24h/1m = 1,441 anchors, comfortably above the
`120`-anchor floor. e2e's ClickHouse is `26.6-alpine` (>= 25.9), so the native
`RangeBucketGridNative` path is active. Reading `planner.go`'s `perRung`
branch directly (lines 65-71 pre-fix) shows this admits **unconditionally**
once `outerN >= minAnchorsForPerRungShard`, regardless of backing data — so
this panel predictively routes to `K`-way sharding, and `K` concurrent
ClickHouse queries contending over the e2e node's small fixture (rather than
one unsharded query finishing first) produces the reported 19s-then-canceled
timeout.

**Why no purely geometric fix exists.** The real production incident this
bypass exists to catch (#2677) hit its memory cliff at **~90-105 anchors**
(253 series, bucket width 68) — *fewer* anchors than this e2e false positive
(1,441). Any anchor-only threshold admitting the real incident (≤ ~90) also
admits the e2e panel (1,441 > 90); any threshold excluding the e2e panel also
excludes the real incident. The two populations are only separable by how
much data the grid actually divides, which anchor count cannot express.
`docs/solver.md` and the new `per_rung_admission.go` package doc both record
this reasoning.

## Fix

- `solver.Decision.PerRungPredictive` (new field) flags a route that came
  from the anchor-only bypass specifically, as opposed to an ordinary
  `MinFanout`/`MinAnchorPairs` clearance or the failure-driven memo's
  evidence-based escalation — both of which leave it `false`.
- `internal/engine/per_rung_admission.go`'s new `PerRungAdmissionLearner`
  watches what a `PerRungPredictive` route's cursor actually, **cleanly**
  drains (a cancelled/truncated drain — exactly this issue's own reported
  symptom — is never recorded, so it can't be misread as "cheap"). Once a
  plan shape has produced a small enough composed result on two consecutive
  clean dispatches, it downgrades that shape's *future* per-rung routes back
  to route A, falling back to today's anchor-only default whenever there is
  no evidence yet, and self-correcting via a 30-minute TTL if a shape's real
  cardinality later grows.
- Deliberately narrow: it never refuses a plan the Planner judged eligible,
  never promotes route A to route B, and never touches `ModeSharded` or the
  failure-driven route memo (`Eligible()`) — only an *already*-predictively-
  routed per-rung decision can ever be downgraded, and only once evidence
  says the shape doesn't need it.
- Wired only for the PromQL head (`cmd/cerberus/main.go`'s
  `buildPerRungAdmission`), gated by the existing
  `CERBERUS_SOLVER_ADAPTIVE_ENABLED` flag (same knob `RouteMemo` already
  uses) rather than a new config surface.

### Why not a purely reactive (memo) fix

The failure-driven route memo (`Eligible()`/`retryOnRouteAResourceFailure`)
cannot substitute here: it declines every request whose `End` sits within
`liveEdgeFreshnessMarginSteps` of "now" (`freshEnoughForRouteMemo`), and a
Grafana dashboard panel's `End` always does. That gate is exactly why #2689
made the per-rung bypass *predictive* in the first place (#2687) — a purely
reactive fix would silently regress live-dashboard support for the real
`#2677`-class incidents this bypass exists to serve. This fix keeps the
predictive path intact and only refines it with evidence gathered from
*completed* predictive dispatches, which carries no such freshness
constraint.

## Testing

- `internal/solver/range_bucket_grid_native_route_test.go`: extended the
  existing `TestRangeBucketGridNative_PredictiveRoutingOnTheAnchorAxis` /
  `TestRangeBucketGridNative_EligibleStillBypassesThresholds` to assert
  `Decision.PerRungPredictive` is `true` only for the anchor-only bypass
  route, never for `Eligible()`'s evidence-based route.
- `internal/engine/per_rung_admission_test.go` (new): unit tests for
  `PerRungAdmissionLearner` (no-evidence default, consecutive-cheap decline,
  expensive-drain streak reset, TTL expiry, bounded capacity),
  `refinePerRungAdmission` (nil-learner no-op, non-`PerRungPredictive` routes
  untouched, actual downgrade with the correct `Reason`/cleared
  `Strategy`/`K`/`Slices`), and `wrapPerRungObserver`/
  `perRungObservingCursor` (a cancelled drain records nothing even with a
  tiny row count, two clean cheap drains accumulate evidence, a
  double-`Close()` records only once).
- `go build ./...`, `go vet ./...`, `go test -race` on `internal/solver`,
  `internal/engine`, `internal/api/prom`, and `cmd/...` all green locally.
- `node .github/scripts/forbid-sql-raw.mjs` and
  `CHECK=all node .github/scripts/forbid-skip.mjs` both clean.
- `just fmt-md` clean on the `docs/solver.md` addition.

**Not run**: the full `just e2e-up && just e2e-seed && just e2e-run` lane —
budgeted against this session's remaining time after the investigation above,
which independently and mechanically confirms the route (not merely the
symptom) via direct source reading rather than a live repro. If CI's `e2e`
job still shows the previously-failing tuple red, the next step is reading
that run's `X-Cerberus-Route-Decision` header / server log for the tuple to
confirm the fix converges (it may take the shape's first ~2 dispatches to
accumulate evidence and downgrade, so a single cold run could still time out
once before self-correcting — see the "residual gap" note below).

## Residual gap (filed, not fixed here)

Because the learner needs `perRungEvidenceMinObservations` **completed**
clean dispatches before it downgrades a shape, a shape's very first
occurrence(s) in a fresh process are not protected — same as this bypass's
pre-existing behavior. On e2e specifically, prior sweep tuples exercise
smaller windows of the same panel first, but not necessarily enough to
qualify the exact 24h/1m Key before the failing tuple runs cold. Filed as
#2716 to track whether the e2e run still shows the tuple red after this PR
and, if so, size a cold-start mitigation.

Closes #2709
