### PR TITLE
chore(release): cerberus v1.18.1 / chart 0.15.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to cerberus will be documented in this file. The format roug
 
 ## [Unreleased]
 
+## [v1.18.1] — 2026-08-29
+
+### Fixed
+
+- **promql:** compose resets/changes over sum/avg-wrapped mixed-or subquery (#2718)
+- **solver,engine:** gate the per-rung predictive bypass on observed evidence (#2717)
+- **ci:** widen the compat comparer's per-query deadline for the floor lane (#2713)
+- **promql:** wire the mixed-or recognizer into absent()/limitk/limit_ratio/unary (#2711)
+- **engine:** apportion route-B's RangeBucketGridNative bounds by shard count (#2712)
+
 ## [v1.18.0] — 2026-08-28
 
 ### Added

--- a/deploy/helm/cerberus/Chart.yaml
+++ b/deploy/helm/cerberus/Chart.yaml
@@ -8,11 +8,11 @@ type: application
 # upgrade?" and is the publish trigger: a chart-only fix bumps this without an
 # app re-tag; an app-only release bumps appVersion + a PATCH here for the new
 # default image. Starts 0.x because the values contract is not yet frozen.
-version: 0.15.8
+version: 0.15.9
 
 # appVersion tracks the GA cerberus binary. Quoted so SemVer-shaped values
 # aren't coerced to floats. image.tag defaults from this when left empty.
-appVersion: "1.18.0"
+appVersion: "1.18.1"
 
 # autoscaling/v2 + policy/v1 (PDB) + networking/v1 (Ingress) are all GA from
 # 1.21+; 1.23 is the conservative floor matching the manifests this chart
@@ -45,25 +45,17 @@ annotations:
       url: https://github.com/tsouza/cerberus/blob/main/docs/operations.md
   artifacthub.io/images: |
     - name: cerberus
-      image: ghcr.io/tsouza/cerberus:v1.18.0
+      image: ghcr.io/tsouza/cerberus:v1.18.1
   # Bump the `1.0.0` floor here when the chart raises its minimum supported
   # cerberus release; informational for Artifact Hub's compatibility hints.
   artifacthub.io/changes: |
-    - kind: added
-      description: "chaudit: audit a live deployment against the histogram resource bound (#2691)"
-    - kind: added
-      description: "chsql: carry the guard's own numbers in its rejection message (#2693)"
     - kind: fixed
-      description: "chaudit,solver,ci: apply the v1.18.0 pre-release audit findings (#2706)"
+      description: "promql: compose resets/changes over sum/avg-wrapped mixed-or subquery (#2718)"
     - kind: fixed
-      description: "routememo: require corroboration before BothFail, and record why Key fuses group-by (#2701)"
+      description: "solver,engine: gate the per-rung predictive bypass on observed evidence (#2717)"
     - kind: fixed
-      description: "chopt: re-probe fast while pinned to the capability floor (#2702)"
+      description: "ci: widen the compat comparer's per-query deadline for the floor lane (#2713)"
     - kind: fixed
-      description: "solver,promql: let the classic-histogram ladder route predictively (#2689)"
+      description: "promql: wire the mixed-or recognizer into absent()/limitk/limit_ratio/unary (#2711)"
     - kind: fixed
-      description: "config,chclient,engine: derive the histogram density bound from the query memory cap (#2686)"
-    - kind: fixed
-      description: "solver: let route B time-shard the native classic-histogram ladder (#2683)"
-    - kind: changed
-      description: "promql: decide the DELTA arm's peak flag at construction, not by a walk (#2690)"
+      description: "engine: apportion route-B's RangeBucketGridNative bounds by shard count (#2712)"

--- a/deploy/helm/cerberus/README.md
+++ b/deploy/helm/cerberus/README.md
@@ -5,7 +5,7 @@
      pipe-aligned, and the version footer adds a trailing blank — both are
      owned by helm-docs; realigning would fight the chart-ci drift check. -->
 
-![Version: 0.15.8](https://img.shields.io/badge/Version-0.15.8-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.18.0](https://img.shields.io/badge/AppVersion-1.18.0-informational?style=flat-square)
+![Version: 0.15.9](https://img.shields.io/badge/Version-0.15.9-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.18.1](https://img.shields.io/badge/AppVersion-1.18.1-informational?style=flat-square)
 
 Drop-in Prometheus / Loki / Tempo HTTP gateway for ClickHouse — a single stateless gateway that speaks three upstream query wire formats and lowers each to parameterised ClickHouse SQL.
 


### PR DESCRIPTION
Release-prep for **v1.18.1** (chart **0.15.9**), generated by `prepare-release.yml`.

- appVersion 1.18.0 -> 1.18.1, chart 0.15.8 -> 0.15.9

### Changes

### Fixed

- **promql:** compose resets/changes over sum/avg-wrapped mixed-or subquery (#2718)
- **solver,engine:** gate the per-rung predictive bypass on observed evidence (#2717)
- **ci:** widen the compat comparer's per-query deadline for the floor lane (#2713)
- **promql:** wire the mixed-or recognizer into absent()/limitk/limit_ratio/unary (#2711)
- **engine:** apportion route-B's RangeBucketGridNative bounds by shard count (#2712)

Generated from the conventional commits since the last tag. Review and edit before merging; the tag is cut once this lands.
