### PR TITLE
fix(spec): add seed/expected_rows to the #2613 mixed-or parity fixtures

### DIFF
--- a/test/perf/cardinality-baseline/promql/absent_mixed_or.json
+++ b/test/perf/cardinality-baseline/promql/absent_mixed_or.json
@@ -1,0 +1,11 @@
+{
+  "fixture": "promql/absent_mixed_or",
+  "fan_factor": 1,
+  "scan_rows": 2,
+  "peak_intermediate": 2,
+  "has_cross_join": false,
+  "has_array_join": false,
+  "has_recursive_cte": false,
+  "max_recursion_depth": 0,
+  "uncountable_levels": 0
+}

--- a/test/perf/cardinality-baseline/promql/limit_ratio_mixed_or.json
+++ b/test/perf/cardinality-baseline/promql/limit_ratio_mixed_or.json
@@ -1,0 +1,11 @@
+{
+  "fixture": "promql/limit_ratio_mixed_or",
+  "fan_factor": 1,
+  "scan_rows": 2,
+  "peak_intermediate": 2,
+  "has_cross_join": false,
+  "has_array_join": false,
+  "has_recursive_cte": false,
+  "max_recursion_depth": 0,
+  "uncountable_levels": 0
+}

--- a/test/perf/cardinality-baseline/promql/unary_minus_mixed_or.json
+++ b/test/perf/cardinality-baseline/promql/unary_minus_mixed_or.json
@@ -1,0 +1,11 @@
+{
+  "fixture": "promql/unary_minus_mixed_or",
+  "fan_factor": 1,
+  "scan_rows": 2,
+  "peak_intermediate": 2,
+  "has_cross_join": false,
+  "has_array_join": false,
+  "has_recursive_cte": false,
+  "max_recursion_depth": 0,
+  "uncountable_levels": 0
+}

--- a/test/perf/cardinality-baseline/promql/unary_plus_mixed_or.json
+++ b/test/perf/cardinality-baseline/promql/unary_plus_mixed_or.json
@@ -1,0 +1,11 @@
+{
+  "fixture": "promql/unary_plus_mixed_or",
+  "fan_factor": 1,
+  "scan_rows": 2,
+  "peak_intermediate": 2,
+  "has_cross_join": false,
+  "has_array_join": false,
+  "has_recursive_cte": false,
+  "max_recursion_depth": 0,
+  "uncountable_levels": 0
+}

--- a/test/spec/promql/absent_mixed_or.txtar
+++ b/test/spec/promql/absent_mixed_or.txtar
@@ -4,6 +4,24 @@ absent(demo_latency_exp_hist or histogram_quantile(0.5, demo_latency_exp_hist))
 oracle: prometheus
 endpoint: /api/v1/query
 scope: full
+-- seed --
+CREATE TABLE otel_metrics_exponential_histogram (
+    MetricName String,
+    Attributes Map(String, String),
+    TimeUnix DateTime64(9),
+    Count UInt64,
+    Sum Float64,
+    Scale Int32,
+    ZeroCount UInt64,
+    PositiveOffset Int32,
+    PositiveBucketCounts Array(UInt64),
+    NegativeOffset Int32,
+    NegativeBucketCounts Array(UInt64)
+) ENGINE = MergeTree ORDER BY (MetricName, Attributes, TimeUnix);
+INSERT INTO otel_metrics_exponential_histogram VALUES
+    ('demo_latency_exp_hist', map('service', 'api'), toDateTime64('2026-01-01 00:00:00', 9), 6, 42.5, 0, 0, 0, [1, 2, 3], 0, []);
+-- expected_rows --
+[]
 -- args --
 [0] string = ""
 [1] string = "Map(String,String)"

--- a/test/spec/promql/limit_ratio_mixed_or.txtar
+++ b/test/spec/promql/limit_ratio_mixed_or.txtar
@@ -4,6 +4,26 @@ limit_ratio(1, demo_latency_exp_hist or histogram_quantile(0.5, demo_latency_exp
 oracle: prometheus
 endpoint: /api/v1/query
 scope: full
+-- seed --
+CREATE TABLE otel_metrics_exponential_histogram (
+    MetricName String,
+    Attributes Map(String, String),
+    TimeUnix DateTime64(9),
+    Count UInt64,
+    Sum Float64,
+    Scale Int32,
+    ZeroCount UInt64,
+    PositiveOffset Int32,
+    PositiveBucketCounts Array(UInt64),
+    NegativeOffset Int32,
+    NegativeBucketCounts Array(UInt64)
+) ENGINE = MergeTree ORDER BY (MetricName, Attributes, TimeUnix);
+INSERT INTO otel_metrics_exponential_histogram VALUES
+    ('demo_latency_exp_hist', map('service', 'api'), toDateTime64('2026-01-01 00:00:00', 9), 6, 42.5, 0, 0, 0, [1, 2, 3], 0, []);
+-- expected_rows --
+[
+  ["demo_latency_exp_hist", {"service": "api"}, "2026-01-01T00:00:01Z", 0, 6, 42.5, 0, 0, 0, 0, [1,2,3], 0, [], 1]
+]
 -- args --
 [0] int64 = 9
 [1] float64 = 0

--- a/test/spec/promql/unary_minus_mixed_or.txtar
+++ b/test/spec/promql/unary_minus_mixed_or.txtar
@@ -4,6 +4,26 @@
 oracle: prometheus
 endpoint: /api/v1/query
 scope: full
+-- seed --
+CREATE TABLE otel_metrics_exponential_histogram (
+    MetricName String,
+    Attributes Map(String, String),
+    TimeUnix DateTime64(9),
+    Count UInt64,
+    Sum Float64,
+    Scale Int32,
+    ZeroCount UInt64,
+    PositiveOffset Int32,
+    PositiveBucketCounts Array(UInt64),
+    NegativeOffset Int32,
+    NegativeBucketCounts Array(UInt64)
+) ENGINE = MergeTree ORDER BY (MetricName, Attributes, TimeUnix);
+INSERT INTO otel_metrics_exponential_histogram VALUES
+    ('demo_latency_exp_hist', map('service', 'api'), toDateTime64('2026-01-01 00:00:00', 9), 6, 42.5, 0, 0, 0, [1, 2, 3], 0, []);
+-- expected_rows --
+[
+  ["", {"service": "api"}, "2026-01-01T00:00:01Z", -0, -6, -42.5, 0, 0, -0, 0, [-1,-2,-3], 0, [], 1]
+]
 -- args --
 [0] string = ""
 [1] float64 = -1

--- a/test/spec/promql/unary_plus_mixed_or.txtar
+++ b/test/spec/promql/unary_plus_mixed_or.txtar
@@ -4,6 +4,26 @@
 oracle: prometheus
 endpoint: /api/v1/query
 scope: full
+-- seed --
+CREATE TABLE otel_metrics_exponential_histogram (
+    MetricName String,
+    Attributes Map(String, String),
+    TimeUnix DateTime64(9),
+    Count UInt64,
+    Sum Float64,
+    Scale Int32,
+    ZeroCount UInt64,
+    PositiveOffset Int32,
+    PositiveBucketCounts Array(UInt64),
+    NegativeOffset Int32,
+    NegativeBucketCounts Array(UInt64)
+) ENGINE = MergeTree ORDER BY (MetricName, Attributes, TimeUnix);
+INSERT INTO otel_metrics_exponential_histogram VALUES
+    ('demo_latency_exp_hist', map('service', 'api'), toDateTime64('2026-01-01 00:00:00', 9), 6, 42.5, 0, 0, 0, [1, 2, 3], 0, []);
+-- expected_rows --
+[
+  ["demo_latency_exp_hist", {"service": "api"}, "2026-01-01T00:00:01Z", 0, 6, 42.5, 0, 0, 0, 0, [1,2,3], 0, [], 1]
+]
 -- args --
 [0] int64 = 9
 [1] float64 = 0


### PR DESCRIPTION
## Summary

Follow-up to #2613 (PR #2711). That PR enrolled four new mixed-or fixtures
(`absent_mixed_or`, `limit_ratio_mixed_or`, `unary_minus_mixed_or`,
`unary_plus_mixed_or`) in a real `parity:` block (`oracle: prometheus`)
without also adding the `seed:`/`expected_rows:` pair a real round-trip
needs. `TestLower`'s parity-section guard caught it on the v1.18.1 release
PR (#2719): *"fixture X carries a `parity:` section but no executable
round-trip."*

## Fix

Adds a single-row `otel_metrics_exponential_histogram` seed (matching the
`demo_latency_exp_hist` selector these fixtures already query) to all four
fixtures. `histogram_quantile(0.5, demo_latency_exp_hist)` derives its value
from that same seeded series, so PromQL's `or` drops the RHS row (identical
label set already present on the LHS) — the fixtures end up exercising
exactly the histogram-row-survives shape their own `absent()`/unary/
`limit_ratio` lowering is meant to prove.

`expected_rows:` was filled in by the real chDB round-trip
(`GOLDEN_UPDATE=1 go test -run ^TestRoundTripChDB$ ./test/spec/promql/`),
not hand-derived — the pre-existing chDB tests for these same lowerings
(`histogram_native_mixed_or_{absent,unary}_chdb_test.go`) already establish
the same negation/preservation semantics this pins for the seeded row.

## Verification

- Local `just update-golden parity solver promql cardinality`: the
  `promql` shard's real chDB round-trip passed clean and wrote the actual
  `expected_rows:` values for all four fixtures.
- The `cardinality` shard hit local resource contention (this machine was
  under severe unrelated load — swap fully exhausted, load average 20+) and
  three of its eight legs timed out; that's an environment artifact, not a
  correctness issue with this change (cardinality only profiles a fixture's
  *cost*, not its correctness). Dispatching the full required shard set via
  CI (`update-golden.yml`) to finish it on unrelated GitHub-hosted runners.

Closes nothing on its own — this is a correctness follow-up to #2613, which
is already closed.
