### PR TITLE
fix(spec): give the 4 mixed-or parity fixtures a real chDB round-trip

### DIFF
--- a/test/perf/cardinality-baseline/promql/absent_mixed_or.json
+++ b/test/perf/cardinality-baseline/promql/absent_mixed_or.json
@@ -1,0 +1,11 @@
+{
+  "fixture": "promql/absent_mixed_or",
+  "fan_factor": 1,
+  "scan_rows": 2,
+  "peak_intermediate": 2,
+  "has_cross_join": false,
+  "has_array_join": false,
+  "has_recursive_cte": false,
+  "max_recursion_depth": 0,
+  "uncountable_levels": 0
+}

--- a/test/perf/cardinality-baseline/promql/limit_ratio_mixed_or.json
+++ b/test/perf/cardinality-baseline/promql/limit_ratio_mixed_or.json
@@ -1,0 +1,11 @@
+{
+  "fixture": "promql/limit_ratio_mixed_or",
+  "fan_factor": 1,
+  "scan_rows": 2,
+  "peak_intermediate": 2,
+  "has_cross_join": false,
+  "has_array_join": false,
+  "has_recursive_cte": false,
+  "max_recursion_depth": 0,
+  "uncountable_levels": 0
+}

--- a/test/perf/cardinality-baseline/promql/unary_minus_mixed_or.json
+++ b/test/perf/cardinality-baseline/promql/unary_minus_mixed_or.json
@@ -1,0 +1,11 @@
+{
+  "fixture": "promql/unary_minus_mixed_or",
+  "fan_factor": 1,
+  "scan_rows": 2,
+  "peak_intermediate": 2,
+  "has_cross_join": false,
+  "has_array_join": false,
+  "has_recursive_cte": false,
+  "max_recursion_depth": 0,
+  "uncountable_levels": 0
+}

--- a/test/perf/cardinality-baseline/promql/unary_plus_mixed_or.json
+++ b/test/perf/cardinality-baseline/promql/unary_plus_mixed_or.json
@@ -1,0 +1,11 @@
+{
+  "fixture": "promql/unary_plus_mixed_or",
+  "fan_factor": 1,
+  "scan_rows": 2,
+  "peak_intermediate": 2,
+  "has_cross_join": false,
+  "has_array_join": false,
+  "has_recursive_cte": false,
+  "max_recursion_depth": 0,
+  "uncountable_levels": 0
+}

--- a/test/spec/promql/absent_mixed_or.txtar
+++ b/test/spec/promql/absent_mixed_or.txtar
@@ -4,6 +4,24 @@ absent(demo_latency_exp_hist or histogram_quantile(0.5, demo_latency_exp_hist))
 oracle: prometheus
 endpoint: /api/v1/query
 scope: full
+-- seed --
+CREATE TABLE otel_metrics_exponential_histogram (
+    MetricName String,
+    Attributes Map(String, String),
+    TimeUnix DateTime64(9),
+    Count UInt64,
+    Sum Float64,
+    Scale Int32,
+    ZeroCount UInt64,
+    PositiveOffset Int32,
+    PositiveBucketCounts Array(UInt64),
+    NegativeOffset Int32,
+    NegativeBucketCounts Array(UInt64)
+) ENGINE = MergeTree ORDER BY (MetricName, Attributes, TimeUnix);
+INSERT INTO otel_metrics_exponential_histogram VALUES
+    ('demo_latency_exp_hist', map('service', 'web'), toDateTime64('2026-01-01 00:00:00', 9), 10, 20.0, 0, 0, 0, [1, 2, 3, 4], 0, []);
+-- expected_rows --
+[]
 -- args --
 [0] string = ""
 [1] string = "Map(String,String)"

--- a/test/spec/promql/limit_ratio_mixed_or.txtar
+++ b/test/spec/promql/limit_ratio_mixed_or.txtar
@@ -4,6 +4,26 @@ limit_ratio(1, demo_latency_exp_hist or histogram_quantile(0.5, demo_latency_exp
 oracle: prometheus
 endpoint: /api/v1/query
 scope: full
+-- seed --
+CREATE TABLE otel_metrics_exponential_histogram (
+    MetricName String,
+    Attributes Map(String, String),
+    TimeUnix DateTime64(9),
+    Count UInt64,
+    Sum Float64,
+    Scale Int32,
+    ZeroCount UInt64,
+    PositiveOffset Int32,
+    PositiveBucketCounts Array(UInt64),
+    NegativeOffset Int32,
+    NegativeBucketCounts Array(UInt64)
+) ENGINE = MergeTree ORDER BY (MetricName, Attributes, TimeUnix);
+INSERT INTO otel_metrics_exponential_histogram VALUES
+    ('demo_latency_exp_hist', map('service', 'web'), toDateTime64('2026-01-01 00:00:00', 9), 10, 20.0, 0, 0, 0, [1, 2, 3, 4], 0, []);
+-- expected_rows --
+[
+  ["demo_latency_exp_hist", {"service": "web"}, "2026-01-01T00:00:01Z", 0, 10, 20, 0, 0, 0, 0, [1,2,3,4], 0, [], 1]
+]
 -- args --
 [0] int64 = 9
 [1] float64 = 0

--- a/test/spec/promql/unary_minus_mixed_or.txtar
+++ b/test/spec/promql/unary_minus_mixed_or.txtar
@@ -4,6 +4,26 @@
 oracle: prometheus
 endpoint: /api/v1/query
 scope: full
+-- seed --
+CREATE TABLE otel_metrics_exponential_histogram (
+    MetricName String,
+    Attributes Map(String, String),
+    TimeUnix DateTime64(9),
+    Count UInt64,
+    Sum Float64,
+    Scale Int32,
+    ZeroCount UInt64,
+    PositiveOffset Int32,
+    PositiveBucketCounts Array(UInt64),
+    NegativeOffset Int32,
+    NegativeBucketCounts Array(UInt64)
+) ENGINE = MergeTree ORDER BY (MetricName, Attributes, TimeUnix);
+INSERT INTO otel_metrics_exponential_histogram VALUES
+    ('demo_latency_exp_hist', map('service', 'web'), toDateTime64('2026-01-01 00:00:00', 9), 10, 20.0, 0, 0, 0, [1, 2, 3, 4], 0, []);
+-- expected_rows --
+[
+  ["", {"service": "web"}, "2026-01-01T00:00:01Z", -0, -10, -20, 0, 0, -0, 0, [-1,-2,-3,-4], 0, [], 1]
+]
 -- args --
 [0] string = ""
 [1] float64 = -1

--- a/test/spec/promql/unary_plus_mixed_or.txtar
+++ b/test/spec/promql/unary_plus_mixed_or.txtar
@@ -4,6 +4,26 @@
 oracle: prometheus
 endpoint: /api/v1/query
 scope: full
+-- seed --
+CREATE TABLE otel_metrics_exponential_histogram (
+    MetricName String,
+    Attributes Map(String, String),
+    TimeUnix DateTime64(9),
+    Count UInt64,
+    Sum Float64,
+    Scale Int32,
+    ZeroCount UInt64,
+    PositiveOffset Int32,
+    PositiveBucketCounts Array(UInt64),
+    NegativeOffset Int32,
+    NegativeBucketCounts Array(UInt64)
+) ENGINE = MergeTree ORDER BY (MetricName, Attributes, TimeUnix);
+INSERT INTO otel_metrics_exponential_histogram VALUES
+    ('demo_latency_exp_hist', map('service', 'web'), toDateTime64('2026-01-01 00:00:00', 9), 10, 20.0, 0, 0, 0, [1, 2, 3, 4], 0, []);
+-- expected_rows --
+[
+  ["demo_latency_exp_hist", {"service": "web"}, "2026-01-01T00:00:01Z", 0, 10, 20, 0, 0, 0, 0, [1,2,3,4], 0, [], 1]
+]
 -- args --
 [0] int64 = 9
 [1] float64 = 0


### PR DESCRIPTION
## Summary

PR #2711 (issue #2613) enrolled `absent_mixed_or.txtar` / `limit_ratio_mixed_or.txtar` /
`unary_minus_mixed_or.txtar` / `unary_plus_mixed_or.txtar` in the PromQL parity corpus with a
`parity:` section, but none of them carried the `seed:`/`expected_rows:` opt-in `RunParity`
requires — the parity check reads the seeded rows back out of chDB rather than trusting a
hand-authored expectation, so a `parity:` section with no executable round-trip is a hard failure,
not a silent no-op.

Caught by the v1.18.1 release PR's `roundtrip-promql-shard`:

```
fixture absent_mixed_or carries a `parity:` section but no executable round-trip. The parity
check reads the seeded rows back out of chDB, so it needs the same `seed:` + `expected_rows:`
opt-in RunRoundTrip needs.
```

## Fix

Adds a self-contained `seed:` (one `otel_metrics_exponential_histogram` row) to each of the four
fixtures, matching the sibling `histogram_quantile_mixed_or.txtar` pattern, and regenerates
`expected_rows:` from real chDB execution via `GOLDEN_UPDATE=1` rather than a hand-derived guess.

`limitk_mixed_or.txtar` is unaffected — it correctly uses `parity_exempt` (nondeterministic
selection, same reason `limitk_by_job_truncates.txtar` already does), which `RunParity` never
requires a round-trip for.

## Verification

- `go test -tags chdb -run '^TestLower$/^(absent_mixed_or|limit_ratio_mixed_or|unary_minus_mixed_or|unary_plus_mixed_or|limitk_mixed_or)$' ./internal/promql/` — all 5 pass.
- `just update-golden parity solver promql cardinality` — clean, only the 4 fixture files plus
  their new cardinality-baseline entries changed.
- `forbid-sql-raw`, `forbid-skip` — clean.

Closes nothing on its own; unblocks the v1.18.1 release PR (#2719), which will pick this up once
merged.
