### PR TITLE
test(chplan): cover the new Filter/TopK Mixed row-shape branches

### DIFF
--- a/internal/chplan/row_shape_test.go
+++ b/internal/chplan/row_shape_test.go
@@ -168,6 +168,31 @@ func TestRowShapeOf_VectorSetOpFlags(t *testing.T) {
 	}
 }
 
+// TestRowShapeOf_FilterAndTopKMixedFlag pins the same Mixed flag on
+// *Filter and *TopK (cerberus issue #2613): limitk/limit_ratio (TopK) and
+// limit_ratio's own Filter wrapper both preserve a mixed float/histogram
+// input's row shape unchanged, since their own SELECT is always a bare
+// passthrough of whatever Input publishes — see each case's own doc
+// comment in row_shape.go. allNodeKinds() only exercises the zero-value
+// instance of each (both flags false), so this is these two nodes' only
+// coverage of the Mixed branch, mirroring
+// TestRowShapeOf_VectorSetOpFlags's identical role for *VectorSetOp.
+func TestRowShapeOf_FilterAndTopKMixedFlag(t *testing.T) {
+	t.Parallel()
+
+	stubInput := &chplan.Scan{Table: "otel_metrics_sum"}
+
+	filter := &chplan.Filter{Input: stubInput, Mixed: true}
+	if got := chplan.RowShapeOf(filter); got != chplan.MixedRowShape {
+		t.Errorf("RowShapeOf(Filter{Mixed: true}) = %s, want %s", got, chplan.MixedRowShape)
+	}
+
+	topK := &chplan.TopK{Input: stubInput, K: 1, Mixed: true}
+	if got := chplan.RowShapeOf(topK); got != chplan.MixedRowShape {
+		t.Errorf("RowShapeOf(TopK{Mixed: true}) = %s, want %s", got, chplan.MixedRowShape)
+	}
+}
+
 // TestRowShapeString pins the names the failure messages above are written
 // against, including the answer for a value outside the declared set — a
 // forwarder reading a corrupt shape should say so rather than print an


### PR DESCRIPTION
## Summary

Follow-up to #2613 (PR #2711). That PR added a `Mixed bool` sibling to
`chplan.Filter` and `chplan.TopK`, each gating a new
`if v.Mixed { return MixedRowShape }` branch in `RowShapeOf` — mirroring
the identical, already-tested branch on `VectorSetOp`. Only the
`VectorSetOp` one had a direct unit test
(`TestRowShapeOf_VectorSetOpFlags`); `allNodeKinds()` only ever exercises
the zero-value instance of each node kind, so the two new branches were
never hit by any test.

Caught by the v1.18.1 release PR's `coverage` gate:

```
1 package(s) below their committed floor:
  - internal/chplan: 94.23% < floor 94.3%
```

## Fix

Adds `TestRowShapeOf_FilterAndTopKMixedFlag`, mirroring
`TestRowShapeOf_VectorSetOpFlags`'s exact pattern for the two new node
kinds.

## Verification

- `go test -run '^TestRowShapeOf_FilterAndTopKMixedFlag$' ./internal/chplan/` passes.
- `gofumpt`, `forbid-sql-raw`, `forbid-skip` clean.
- Not re-running the full repo-wide `-coverpkg` floor check locally (this
  machine is under heavy unrelated contention right now); CI's `coverage`
  job is the actual gate and will confirm the floor clears.

Closes nothing on its own — unblocks the v1.18.1 release PR (#2719).
