### PR TITLE
fix(chsql): bound emitted SQL at ClickHouse's own max_query_size (#2733)

### DIFF
--- a/.github/scripts/mutation-phases.mjs
+++ b/.github/scripts/mutation-phases.mjs
@@ -100,7 +100,7 @@ export const PHASES = [
     // lwr_fanout_bound(2). range_window.go alone is the package's single
     // largest file; the rest of this leg is greedy-balance filler, not theme.
     exclude_files:
-      '^(absent_over_time|builder|chaos_sleep|chaos_sleep_stub|ddl|doc|emit|emit_node|exemplars|histogram_float_vector_join|histogram_over_time|histogram_projection|histogram_quantile|histogram_quantile_native|histogram_vector_join|info_join|metrics_compare|metrics_second_stage|mixed_vector_join|nary_vector_set_op|nested_set_annotate|prewhere|query_exemplars|range_bucket_grid_native|range_bucket_grid_native_bound|range_lwr|range_window_fused|range_window_grid_native|range_window_variants|rate_window_fanout_bound|scan_resource_bound|search_trace_limit|set_op|structural_join|tableshape|vector_join|vector_set_op)\\.go$',
+      '^(absent_over_time|builder|chaos_sleep|chaos_sleep_stub|ddl|doc|emit|emit_node|emit_size_bound|exemplars|histogram_float_vector_join|histogram_over_time|histogram_projection|histogram_quantile|histogram_quantile_native|histogram_vector_join|info_join|metrics_compare|metrics_second_stage|mixed_vector_join|nary_vector_set_op|nested_set_annotate|prewhere|query_exemplars|range_bucket_grid_native|range_bucket_grid_native_bound|range_lwr|range_window_fused|range_window_grid_native|range_window_variants|rate_window_fanout_bound|scan_resource_bound|search_trace_limit|set_op|structural_join|tableshape|vector_join|vector_set_op)\\.go$',
   },
   {
     phase: 'phase2-builder',
@@ -112,7 +112,7 @@ export const PHASES = [
     // range_lwr(24) + vector_set_op(10) +
     // nary_vector_set_op(6) + rate_window_fanout_bound(2).
     exclude_files:
-      '^(absent_over_time|aggregate_range_lwr_fusion|chaos_sleep|chaos_sleep_stub|ddl|doc|emit|emit_node|exemplars|fnresolution|histogram_float_vector_join|histogram_over_time|histogram_projection|histogram_quantile|histogram_quantile_native|histogram_vector_join|info_join|late_mat|lwr_fanout_bound|metrics_compare|metrics_second_stage|mixed_vector_join|prewhere|query_exemplars|range_bucket_fanout|range_bucket_grid_native|range_bucket_grid_native_bound|range_window|range_window_fused|range_window_grid_native|range_window_stale_resample|scan_resource_bound|search_trace_limit|set_op|structural_join|tableshape)\\.go$',
+      '^(absent_over_time|aggregate_range_lwr_fusion|chaos_sleep|chaos_sleep_stub|ddl|doc|emit|emit_node|emit_size_bound|exemplars|fnresolution|histogram_float_vector_join|histogram_over_time|histogram_projection|histogram_quantile|histogram_quantile_native|histogram_vector_join|info_join|late_mat|lwr_fanout_bound|metrics_compare|metrics_second_stage|mixed_vector_join|prewhere|query_exemplars|range_bucket_fanout|range_bucket_grid_native|range_bucket_grid_native_bound|range_window|range_window_fused|range_window_grid_native|range_window_stale_resample|scan_resource_bound|search_trace_limit|set_op|structural_join|tableshape)\\.go$',
   },
   {
     phase: 'phase2-compare',
@@ -125,7 +125,7 @@ export const PHASES = [
     // histogram_projection(21) + emit(12) +
     // metrics_second_stage(10).
     exclude_files:
-      '^(absent_over_time|aggregate_range_lwr_fusion|builder|chaos_sleep|chaos_sleep_stub|ddl|doc|fnresolution|histogram_float_vector_join|histogram_quantile|histogram_vector_join|info_join|late_mat|lwr_fanout_bound|mixed_vector_join|nary_vector_set_op|nested_set_annotate|prewhere|query_exemplars|range_bucket_fanout|range_bucket_grid_native|range_bucket_grid_native_bound|range_lwr|range_window|range_window_grid_native|range_window_stale_resample|range_window_variants|rate_window_fanout_bound|scan_resource_bound|search_trace_limit|set_op|structural_join|tableshape|vector_join|vector_set_op)\\.go$',
+      '^(absent_over_time|aggregate_range_lwr_fusion|builder|chaos_sleep|chaos_sleep_stub|ddl|doc|emit_size_bound|fnresolution|histogram_float_vector_join|histogram_quantile|histogram_vector_join|info_join|late_mat|lwr_fanout_bound|mixed_vector_join|nary_vector_set_op|nested_set_annotate|prewhere|query_exemplars|range_bucket_fanout|range_bucket_grid_native|range_bucket_grid_native_bound|range_lwr|range_window|range_window_grid_native|range_window_stale_resample|range_window_variants|rate_window_fanout_bound|scan_resource_bound|search_trace_limit|set_op|structural_join|tableshape|vector_join|vector_set_op)\\.go$',
   },
   {
     phase: 'phase2-other',
@@ -133,8 +133,9 @@ export const PHASES = [
     efficacy: EFFICACY,
     workers: DEFAULT_WORKERS,
     // catch-all leg: prewhere + ddl + structural_join + set_op +
-    // range_window_grid_native + scan_resource_bound + query_exemplars +
-    // histogram_quantile + tableshape, plus every file no other leg claims (the
+    // range_window_grid_native + scan_resource_bound + emit_size_bound +
+    // query_exemplars + histogram_quantile + tableshape, plus every file no
+    // other leg claims (the
     // zero-mutant/uncovered files: absent_over_time, chaos_sleep,
     // chaos_sleep_stub, doc, histogram_float_vector_join, histogram_vector_join,
     // info_join, mixed_vector_join, range_bucket_grid_native,

--- a/cmd/cerberus/cmd_configdocs.go
+++ b/cmd/cerberus/cmd_configdocs.go
@@ -421,8 +421,9 @@ elsewhere, so they are enumerated here:
 - **` + "`CERBERUS_SHARD_MAX_OUTPUT_ROWS`" + `** (int64, default ` + "`2000000`" + `) -
   the per-request output-row ceiling across all shards combined.
 
-Five further resource-bound safety ceilings (issue #2667) are resolved by
-` + "`internal/chsql`" + ` and ` + "`internal/promql`" + ` rather than by the loader
+Six further resource-bound safety ceilings (five from issue #2667, the last
+from issue #2733) are resolved by ` + "`internal/chsql`" + ` and
+` + "`internal/promql`" + ` rather than by the loader
 documented above - those two packages may not import ` + "`internal/config`" + `
 (` + "`.go-arch-lint.yml`" + `), so each owns a small, self-contained env-parsing file
 instead (` + "`internal/engine/resource_bound_env.go`" + `,
@@ -444,8 +445,16 @@ instead (` + "`internal/engine/resource_bound_env.go`" + `,
   ` + "`10000000`" + `) - the classic-histogram across-series bucket-merge cost ceiling
   (` + "`internal/promql/classic_bucket_merge_bound.go`" + `,
   ` + "`maxClassicBucketMergeCostUnits`" + `).
+- **` + "`CERBERUS_CH_MAX_EMITTED_SQL_BYTES`" + `** (int64, default ` + "`262144`" + `) -
+  the bytes of SQL cerberus will emit for one statement
+  (` + "`internal/chsql/emit_size_bound.go`" + `, ` + "`maxEmittedSQLBytes`" + `).
+  Applies to all three heads. Its default is ClickHouse's own
+  ` + "`max_query_size`" + ` default rather than a cerberus calibration: a statement
+  past it is one the server refuses to parse anyway, so the bound turns a raw
+  driver ` + "`code 62`" + ` into a cerberus error naming the query shape. Raise it
+  only alongside ` + "`max_query_size`" + ` on the server itself.
 
-All five reject a malformed or non-positive override at startup rather than
+All six reject a malformed or non-positive override at startup rather than
 silently falling back to the default or admitting every query; see each
 constant's own doc for the calibration its shipped default protects.
 

--- a/cmd/cerberus/main.go
+++ b/cmd/cerberus/main.go
@@ -131,18 +131,21 @@ type apiHeads struct {
 	consumers  chOptConsumers
 }
 
-// resolveIssue2667BoundOverrides resolves the five issue #2667
-// resource-bound safety-ceiling overrides run() threads into mountAPIHeads:
+// resolveBoundOverrides resolves the six resource-bound safety-ceiling
+// overrides run() threads into mountAPIHeads:
 // the three chsql sample-fanout knobs (CERBERUS_CH_RANGE_BUCKET_FANOUT_MAX_ROWS
 // / CERBERUS_CH_RANGE_LWR_FANOUT_MAX_ROWS / CERBERUS_CH_RATE_WINDOW_FANOUT_MAX_ROWS)
 // and the two PromQL-only histogram-merge cost-unit knobs
 // (CERBERUS_PROMQL_HISTOGRAM_MERGE_MAX_COST_UNITS /
 // CERBERUS_PROMQL_CLASSIC_BUCKET_MERGE_MAX_COST_UNITS, wired only onto the
 // prom head's Handler.ResourceBounds — see newPromHandler's own doc for why
-// LogQL/TraceQL never see it). Both resolutions share the same fail-fast
-// contract as buildSolver's own solver.ConfigFromEnv() above: a typo'd or
-// non-positive override aborts startup rather than silently falling back.
-func resolveIssue2667BoundOverrides() (engine.ResourceBoundOverrides, promql.ResourceBounds, error) {
+// LogQL/TraceQL never see it), all five from issue #2667, plus issue #2733's
+// head-agnostic emitted-SQL statement-size bound
+// (CERBERUS_CH_MAX_EMITTED_SQL_BYTES). Both resolutions share the same
+// fail-fast contract as buildSolver's own solver.ConfigFromEnv() above: a
+// typo'd or non-positive override aborts startup rather than silently falling
+// back.
+func resolveBoundOverrides() (engine.ResourceBoundOverrides, promql.ResourceBounds, error) {
 	resourceBounds, err := engine.ResourceBoundsFromEnv()
 	if err != nil {
 		return engine.ResourceBoundOverrides{}, promql.ResourceBounds{}, err
@@ -230,6 +233,11 @@ func mountAPIHeads(
 		// silently inert, which is how a compare() grid 108x over the configured
 		// budget was still served.
 		tempoHandler.Engine.MaxQuerySamples = tempoClient.MaxQuerySamples()
+		// Issue #2733's emitted-SQL size bound, wired here for the same reason
+		// it is wired onto the prom and loki heads: it bounds a property every
+		// head has (the bytes of one emitted statement), unlike the row-fanout
+		// ceilings, which gate node kinds only some heads lower.
+		tempoHandler.Engine.MaxEmittedSQLBytes = resourceBounds.MaxEmittedSQLBytes
 		tempoHandler.Mount(traceMux)
 		engines = append(engines, tempoHandler.Engine)
 
@@ -559,7 +567,7 @@ func run() error {
 	// (one process = one OOM kills all heads today). The Tempo gRPC server is
 	// likewise nil when tempo is off. /healthz + /readyz are mounted below,
 	// unconditionally, in every mode.
-	resourceBounds, promResourceBounds, err := resolveIssue2667BoundOverrides()
+	resourceBounds, promResourceBounds, err := resolveBoundOverrides()
 	if err != nil {
 		return err
 	}
@@ -774,6 +782,10 @@ func newPromHandler(client *chclient.Client, cfg config.Config, optSet chopt.Ena
 		RangeBucketFanoutMaxRows: resourceBounds.RangeBucketFanoutMaxRows,
 		RangeLWRFanoutMaxRows:    resourceBounds.RangeLWRFanoutMaxRows,
 		RateWindowFanoutMaxRows:  resourceBounds.RateWindowFanoutMaxRows,
+		// Head-AGNOSTIC, unlike the three above: every head emits statements,
+		// so issue #2733's emitted-SQL size bound is wired onto all three
+		// engines — see engine.Engine.MaxEmittedSQLBytes' own doc.
+		MaxEmittedSQLBytes: resourceBounds.MaxEmittedSQLBytes,
 		// PromQL-only, same inertness reasoning: chplan.RangeBucketGridNative
 		// only ever comes from PromQL's classic-histogram_quantile lowering —
 		// see engine.Engine.RangeBucketGridNativeMaxRows's doc.
@@ -971,6 +983,10 @@ func newLokiHandler(client *chclient.Client, cfg config.Config, optSet chopt.Ena
 	// head — see newPromHandler's own doc for why RangeBucketFanoutMaxRows /
 	// RangeLWRFanoutMaxRows stay prom-only.
 	h.Engine.RateWindowFanoutMaxRows = resourceBounds.RateWindowFanoutMaxRows
+	// Issue #2733's emitted-SQL size bound is head-agnostic — every head emits
+	// statements — so unlike the row-fanout ceilings it is wired onto this head
+	// as well as prom and tempo. See engine.Engine.MaxEmittedSQLBytes' own doc.
+	h.Engine.MaxEmittedSQLBytes = resourceBounds.MaxEmittedSQLBytes
 	return h
 }
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -446,8 +446,9 @@ elsewhere, so they are enumerated here:
 - **`CERBERUS_SHARD_MAX_OUTPUT_ROWS`** (int64, default `2000000`) -
   the per-request output-row ceiling across all shards combined.
 
-Five further resource-bound safety ceilings (issue #2667) are resolved by
-`internal/chsql` and `internal/promql` rather than by the loader
+Six further resource-bound safety ceilings (five from issue #2667, the last
+from issue #2733) are resolved by `internal/chsql` and
+`internal/promql` rather than by the loader
 documented above - those two packages may not import `internal/config`
 (`.go-arch-lint.yml`), so each owns a small, self-contained env-parsing file
 instead (`internal/engine/resource_bound_env.go`,
@@ -469,8 +470,16 @@ instead (`internal/engine/resource_bound_env.go`,
   `10000000`) - the classic-histogram across-series bucket-merge cost ceiling
   (`internal/promql/classic_bucket_merge_bound.go`,
   `maxClassicBucketMergeCostUnits`).
+- **`CERBERUS_CH_MAX_EMITTED_SQL_BYTES`** (int64, default `262144`) -
+  the bytes of SQL cerberus will emit for one statement
+  (`internal/chsql/emit_size_bound.go`, `maxEmittedSQLBytes`).
+  Applies to all three heads. Its default is ClickHouse's own
+  `max_query_size` default rather than a cerberus calibration: a statement
+  past it is one the server refuses to parse anyway, so the bound turns a raw
+  driver `code 62` into a cerberus error naming the query shape. Raise it
+  only alongside `max_query_size` on the server itself.
 
-All five reject a malformed or non-positive override at startup rather than
+All six reject a malformed or non-positive override at startup rather than
 silently falling back to the default or admitting every query; see each
 constant's own doc for the calibration its shipped default protects.
 

--- a/internal/api/prom/handler.go
+++ b/internal/api/prom/handler.go
@@ -1377,6 +1377,18 @@ func classifyEngineError(err error) error {
 	if ae := classifyThrowIfGuardError(err); ae != nil {
 		return ae
 	}
+	// A query whose plan composes to more SQL than ClickHouse will parse
+	// (issue #2733). Nothing is broken — the shape is valid and lowers
+	// cleanly, the emitter simply cannot express it in one statement the
+	// server would accept — so it belongs in the same 422 errorType=execution
+	// "cannot be served" class as the resource-bound guards above rather than
+	// in the emit-stage 500 bucket below, which would report a user's exotic
+	// query as a cerberus fault. It is also the status this exact query had
+	// before issue #2728 opened the composition arm it now rides: back then it
+	// was refused at LOWERING, which this function already maps to 422.
+	if errors.Is(err, chsql.ErrEmittedSQLTooLarge) {
+		return &apiError{Kind: ErrExecution, Err: err, Status: http.StatusUnprocessableEntity}
+	}
 	msg := err.Error()
 	switch {
 	case errContainsStage(msg, "emit"):

--- a/internal/api/prom/handler_emit_size_error_test.go
+++ b/internal/api/prom/handler_emit_size_error_test.go
@@ -1,0 +1,66 @@
+package prom
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/tsouza/cerberus/internal/chsql"
+)
+
+// TestClassifyEngineError_EmittedSQLTooLargeIs422 pins the wire status of
+// cerberus issue #2733's rejection: a query whose plan composes to more SQL
+// than ClickHouse will parse is 422 errorType=execution — the "valid query,
+// cannot be served" class the sample budget, the memory-limit abort and every
+// throwIf resource guard already land in — not the 500 the emit stage's
+// catch-all would otherwise give it.
+//
+// 500 would be wrong twice over: it reports a user's exotic query as a
+// cerberus fault (paging an operator, and counting against the error-rate
+// SLO), and it contradicts the status this same query returned before issue
+// #2728 opened the composition arm it now rides, when the identical shape was
+// refused at lowering — a 422.
+func TestClassifyEngineError_EmittedSQLTooLargeIs422(t *testing.T) {
+	t.Parallel()
+
+	// The engine tags each stage's failure with an "engine: <stage>:" prefix;
+	// this is exactly what a chsql.Emit rejection arrives as.
+	err := classifyEngineError(fmt.Errorf("engine: emit: %w", chsql.ErrEmittedSQLTooLarge))
+
+	var ae *apiError
+	if !errors.As(err, &ae) {
+		t.Fatalf("classifyEngineError returned %T (%v), want *apiError", err, err)
+	}
+	if ae.Status != http.StatusUnprocessableEntity {
+		t.Errorf("status = %d, want %d (422 execution — the query is valid but unserveable)",
+			ae.Status, http.StatusUnprocessableEntity)
+	}
+	if ae.Kind != ErrExecution {
+		t.Errorf("errorType = %q, want %q", ae.Kind, ErrExecution)
+	}
+	if !errors.Is(ae.Err, chsql.ErrEmittedSQLTooLarge) {
+		t.Errorf("the wire error dropped the sentinel, so the message no longer names the "+
+			"composition that was refused: %v", ae.Err)
+	}
+}
+
+// TestClassifyEngineError_OtherEmitFailuresStay500 is the other half of the
+// pin: only the size bound moves. An emit failure that is a genuine cerberus
+// defect — an unsupported node the emitter cannot render — must keep reporting
+// itself as one, or the new 422 arm would quietly reclassify every emitter bug
+// as a user error.
+func TestClassifyEngineError_OtherEmitFailuresStay500(t *testing.T) {
+	t.Parallel()
+
+	err := classifyEngineError(fmt.Errorf("engine: emit: %w: some node", chsql.ErrUnsupported))
+
+	var ae *apiError
+	if !errors.As(err, &ae) {
+		t.Fatalf("classifyEngineError returned %T (%v), want *apiError", err, err)
+	}
+	if ae.Status != http.StatusInternalServerError {
+		t.Errorf("status = %d, want %d — an unsupported-node emit failure is a cerberus defect",
+			ae.Status, http.StatusInternalServerError)
+	}
+}

--- a/internal/chsql/emit.go
+++ b/internal/chsql/emit.go
@@ -160,6 +160,9 @@ func Emit(ctx context.Context, n chplan.Node) (string, []any, error) {
 
 		rangeBucketGridNativeMaxRows:         rangeBucketGridNativeMaxRowsFromCtx(ctx),
 		rangeBucketGridNativeMaxDensityUnits: rangeBucketGridNativeMaxDensityUnitsFromCtx(ctx),
+
+		emittedSQLMaxBytes: maxEmittedSQLBytesFromCtx(ctx),
+		rootPlan:           n,
 	}
 	// Collapse a structure-tab plan's repeated top-N trace-id gates onto one
 	// single-evaluation scalar binding hoisted to the outermost statement
@@ -172,6 +175,17 @@ func Emit(ctx context.Context, n chplan.Node) (string, []any, error) {
 	}
 	sql := e.b.String()
 	if err := GuardEmittedSQL(ctx, sql); err != nil {
+		span.RecordError(err)
+		return "", nil, err
+	}
+	// Reject a statement ClickHouse would refuse to parse (issue #2733,
+	// emit_size_bound.go) with a cerberus error that names the composition,
+	// rather than handing the driver a statement past max_query_size and
+	// letting a code 62 "failed at position 262145" reach the user. The
+	// per-sub-statement check in renderNode has usually fired first for a
+	// deeply-composed plan; this is the site that catches a statement whose
+	// size is in the assembly rather than in any one of its parts.
+	if err := e.requireEmittedSQLBounded(n, sql); err != nil {
 		span.RecordError(err)
 		return "", nil, err
 	}
@@ -342,6 +356,25 @@ type emitter struct {
 	// why these are ctx-threaded rather than plain package consts.
 	rangeBucketGridNativeMaxRows         int64
 	rangeBucketGridNativeMaxDensityUnits int64
+
+	// emittedSQLMaxBytes is the ceiling on the bytes of SQL one statement may
+	// render to before the emitter refuses it (issue #2733,
+	// emit_size_bound.go), seeded here once per Emit call from
+	// maxEmittedSQLBytesFromCtx — the operator's
+	// CERBERUS_CH_MAX_EMITTED_SQL_BYTES override threaded via internal/engine
+	// (WithMaxEmittedSQLBytes) or, when none was threaded, ClickHouse's own
+	// max_query_size default. Read only through emittedSQLByteBound(), never
+	// directly, for the same zero-value reason the three fanout bounds above
+	// document: a direct &emitter{} — which many tests in this package build —
+	// leaves it 0, and 0 read literally would reject every statement.
+	emittedSQLMaxBytes int64
+
+	// rootPlan is the whole plan this emitter was started on, stamped once by
+	// Emit purely so an emitted-SQL-size rejection can name the composition the
+	// USER wrote rather than whichever sub-statement happened to cross the
+	// ceiling first (see requireEmittedSQLBounded). Nothing reads it on the
+	// success path, and an emitter built outside Emit leaves it nil.
+	rootPlan chplan.Node
 
 	// cteSeq is a monotonic counter handed out to every emitter that
 	// registers a named CTE, so each one gets a unique name: the

--- a/internal/chsql/emit_node.go
+++ b/internal/chsql/emit_node.go
@@ -31,6 +31,14 @@ func (e *emitter) renderNode(n chplan.Node) (string, []any, error) {
 	if err != nil {
 		return "", nil, err
 	}
+	// The enclosing statement embeds this text verbatim, so a sub-statement
+	// already past the emitted-SQL byte bound proves the whole statement is
+	// past it too. Checking here rather than only on the finished statement is
+	// what keeps rejecting a deeply-composed plan cheap — see
+	// emit_size_bound.go's "The two call sites".
+	if err := e.requireEmittedSQLBounded(n, sql); err != nil {
+		return "", nil, err
+	}
 	return sql, args, nil
 }
 

--- a/internal/chsql/emit_size_bound.go
+++ b/internal/chsql/emit_size_bound.go
@@ -1,0 +1,268 @@
+package chsql
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/tsouza/cerberus/internal/chplan"
+)
+
+// emit_size_bound.go closes cerberus issue #2733.
+//
+// # The failure this converts
+//
+// A FOURTH bracket level of subquery composition over a mixed
+// float/histogram inner — one more than issue #2728 answers — lowers
+// correctly and emits correct SQL, but emits so MUCH of it that ClickHouse
+// refuses to parse the statement at all:
+//
+//	Code: 62. DB::Exception: Max query size exceeded (can be increased with
+//	the `max_query_size` setting): Syntax error: failed at position 262145
+//
+// Nothing is silently wrong and nothing hangs — the query fails immediately,
+// truthfully, at the database. What it lacks is a cerberus-side name for the
+// shape that cannot be served: before #2728 the same query was refused by
+// lowerHistogramOrMixedSubqueryOuterFnInput's own gate with an error naming
+// the unsupported composition, and #2728 opening that arm (correctly, for the
+// one extra level that IS serveable) moved the deeper levels' failure from
+// "cerberus says no" to "ClickHouse says no".
+//
+// # Why the SQL grows the way it does
+//
+// splitMixedRelByDiscriminator (internal/promql) partitions a Mixed relation
+// into a histogram half and a float half and folds each, so a FOLD-family
+// level names the relation beneath it twice. Stacking those levels compounds.
+// Measured over `((m_exp_hist) or (m_gauge))`, emitted placeholder SQL, at an
+// instant eval (the query_range fan-out runs ~1.5x larger, and the size is
+// independent of the anchor count either way):
+//
+//	bracket levels   emitted SQL   plan nodes (DAG expanded)
+//	             1        26,480                          16
+//	             2       140,319                          67
+//	             3       588,295                         147
+//	             4     1,786,077                         306
+//
+// # Why the bound measures rendered bytes rather than predicting them
+//
+// A plan-side prediction was the first design tried, and the numbers above
+// are what refuted it: the DAG-expanded plan-node count grows ~2.1x per
+// level while the emitted SQL grows ~3-4x, because the emitter itself
+// duplicates text the plan does not duplicate (rateWindowFanoutBoundedSourceFrag
+// and lwrFanoutBoundedSourceFrag each render their fan-out source a second
+// time for the truncation probe, and the histogram fold expressions render
+// far more text per node than a float one). Bytes-per-plan-node therefore
+// ranges from ~0.75KB (a plain `rate(<counter>[5m])`) to ~5.7KB (the level-4
+// composition) across the shapes this package already serves — a spread no
+// single node-count threshold can split into "fits" and "does not fit"
+// without rejecting shapes ClickHouse would have parsed happily. Measuring
+// the rendered statement is exact, and it costs one integer comparison.
+//
+// # Why the measure is the placeholder SQL, and why that is the safe direction
+//
+// The bytes ClickHouse's max_query_size counts are the statement AFTER
+// clickhouse-go/v2 inlines every positional arg client-side — the native
+// protocol has no bound-parameter channel (see internal/api/prom/metadata.go's
+// boundQueryBytes and the #799 incident it records). So the wire statement is
+// always at least as long as the `?`-carrying text this guard measures: every
+// `?` is replaced by a literal of one byte or more. Measuring the placeholder
+// text therefore UNDERCOUNTS, deliberately:
+//
+//   - every statement this guard rejects is one ClickHouse would also have
+//     rejected, so the guard adds no restriction of its own — it only replaces
+//     a driver-level code 62 with a cerberus error that names the shape;
+//   - a statement it admits may still be refused by ClickHouse (the arg
+//     literals push it over), which is exactly today's behaviour and no worse.
+//
+// The alternative — reusing metadata.go's deliberate OVER-approximation of the
+// inlined size — would invert that: the issue #2728 level-2 composition renders
+// 209,182 placeholder bytes with 1,442 args, which the over-approximation
+// scores at 255,052 and a realistic inlining puts at 215,430. Add a handful of
+// label matchers and the over-approximation crosses 262,144 while the real
+// statement does not, and a shipping, chDB-proven shape would start being
+// refused. Undercounting cannot make that mistake.
+//
+// # The two call sites
+//
+// Emit checks the finished statement, which is the whole point. renderNode
+// checks each isolated sub-statement as it is produced, and that second site
+// is what bounds the COST of rejecting: the final statement contains every
+// rendered sub-statement verbatim, so a sub-statement already over the bound
+// proves the whole is over it, and stopping there caps the emitter's peak
+// allocation at roughly one bound's worth of text instead of building the
+// whole thing first. Without it a query that simply stacks more brackets —
+// a short string to type — walks the 4x-per-level curve: ~12MB of SQL at five
+// levels, ~45MB at six, ~700MB at eight, all built and then thrown away.
+
+// maxEmittedSQLBytes is the default ceiling on the bytes of SQL cerberus will
+// emit for one statement. It is ClickHouse's own `max_query_size` default
+// (256KiB), not a cerberus-chosen figure, and that identity is the whole
+// argument for the guard being safe to apply to every plan of every head: a
+// statement past this length is one the server will refuse to parse anyway
+// (the measure undercounts the wire bytes — see this file's doc comment), so
+// the guard changes the ERROR a user sees, never whether the query could have
+// run.
+//
+// For scale: the largest statement in this repo's entire golden corpus (1,216
+// `-- sql --` sections across all three heads) is 40,475 bytes, and the
+// largest deliberately-shipping exotic shape — issue #2728's level-2
+// composition under query_range — is 209,182. An operator whose server raises
+// max_query_size raises this alongside it via
+// CERBERUS_CH_MAX_EMITTED_SQL_BYTES (see WithMaxEmittedSQLBytes), rather than
+// waiting for a release, exactly as issue #2667 made the three sample-fanout
+// ceilings overridable.
+const maxEmittedSQLBytes int64 = 262144
+
+// ErrEmittedSQLTooLarge is the sentinel Emit / renderNode return for a
+// statement past the emitted-SQL byte bound. It wraps ErrUnsupported so the
+// existing emit-error handling (and the HTTP error mapping behind it) treats
+// it as an ordinary unsupported-shape failure — which is what it is: the shape
+// is correct, the emitter simply cannot express it in a statement ClickHouse
+// will parse.
+var ErrEmittedSQLTooLarge = fmt.Errorf("%w: emitted SQL exceeds the statement-size bound", ErrUnsupported)
+
+// maxEmittedSQLBytesKey is the unexported context key carrying an
+// operator-configured override for maxEmittedSQLBytes — see
+// WithMaxEmittedSQLBytes / maxEmittedSQLBytesFromCtx below.
+type maxEmittedSQLBytesKey struct{}
+
+// WithMaxEmittedSQLBytes returns ctx carrying n as the operator override for
+// the emitted-SQL byte bound (otherwise maxEmittedSQLBytes). The caller —
+// internal/engine's emitForHead / routeBExecCtx — only threads this when
+// CERBERUS_CH_MAX_EMITTED_SQL_BYTES is actually set: a statement-size bound of
+// zero is never a legitimate operator intent (it would reject every query), so
+// "never threaded" — not "threaded as zero" — is what selects the compiled-in
+// default. Mirrors WithRateWindowFanoutMaxRows exactly.
+func WithMaxEmittedSQLBytes(ctx context.Context, n int64) context.Context {
+	return context.WithValue(ctx, maxEmittedSQLBytesKey{}, n)
+}
+
+// maxEmittedSQLBytesFromCtx recovers the bound WithMaxEmittedSQLBytes set, or
+// maxEmittedSQLBytes (ClickHouse's own default) when the caller never threaded
+// one.
+func maxEmittedSQLBytesFromCtx(ctx context.Context) int64 {
+	if n, ok := ctx.Value(maxEmittedSQLBytesKey{}).(int64); ok {
+		return n
+	}
+	return maxEmittedSQLBytes
+}
+
+// emittedSQLByteBound returns e's own resolved bound — e.emittedSQLMaxBytes,
+// seeded once from ctx inside Emit — falling back to maxEmittedSQLBytes
+// whenever the field reads as its Go zero value. The fallback is load-bearing
+// for the same reason rateWindowFanoutRowBound's is: many round-trip tests in
+// this package construct &emitter{} directly, bypassing Emit's ctx seeding
+// entirely, and a bound of 0 read literally would reject every statement they
+// render.
+func (e *emitter) emittedSQLByteBound() int64 {
+	if e.emittedSQLMaxBytes > 0 {
+		return e.emittedSQLMaxBytes
+	}
+	return maxEmittedSQLBytes
+}
+
+// requireEmittedSQLBounded rejects sql — the statement rendered for n — when it
+// is longer than e's resolved bound, naming the composition that produced it so
+// the message says which query shape to change rather than only how many bytes
+// it took.
+//
+// The shape named is the WHOLE plan (e.rootPlan, stamped once by Emit) even
+// when the statement measured is one of its sub-statements, because that is the
+// shape whose author can act on the message; "at least" in the wording is what
+// keeps the byte figure honest in that case, since a sub-statement's length is
+// a lower bound on the finished one's. An emitter built without going through
+// Emit (EmitCompareRootLeg, and this package's own round-trip tests) carries no
+// root, so it describes the node it was handed.
+func (e *emitter) requireEmittedSQLBounded(n chplan.Node, sql string) error {
+	maxBytes := e.emittedSQLByteBound()
+	if int64(len(sql)) <= maxBytes {
+		return nil
+	}
+	described := e.rootPlan
+	if described == nil {
+		described = n
+	}
+	return fmt.Errorf(
+		"%w: %s renders at least %d bytes, past the %d-byte ceiling (ClickHouse's own "+
+			"max_query_size); reduce the query's composition, or raise max_query_size and "+
+			"CERBERUS_CH_MAX_EMITTED_SQL_BYTES together",
+		ErrEmittedSQLTooLarge, planCompositionSummary(described), len(sql), maxBytes,
+	)
+}
+
+// planCompositionSummary names n's shape in the two terms that actually drive
+// the emitted size, so a rejection tells a user what to change:
+//
+//   - how many range-vector levels are stacked, counted as the longest chain of
+//     [chplan.GridCarrier] nodes from the root to a leaf. GridCarrier is the
+//     IR's own "this node owns an eval grid" declaration, closed by a
+//     completeness ratchet (chplan/grid_carrier_completeness_test.go), so this
+//     count cannot drift as node kinds are added the way an enumeration here
+//     would;
+//   - whether any level sits over a MIXED float/histogram relation, which is
+//     what makes a level cost ~4x rather than ~2x (splitMixedRelByDiscriminator
+//     names the relation beneath it once per half).
+//
+// The count is of PLAN levels, not of brackets in the query text: an
+// innermost selector that is itself resolved as a range vector carries a grid
+// of its own, so a three-bracket query reads here as four levels. The wording
+// says "a plan stacking N range-vector levels" for exactly that reason.
+func planCompositionSummary(n chplan.Node) string {
+	levels, mixed := gridCarrierNesting(n)
+	switch {
+	case levels > 1 && mixed:
+		return fmt.Sprintf("a plan stacking %d range-vector levels over a mixed float/histogram relation", levels)
+	case levels > 1:
+		return fmt.Sprintf("a plan stacking %d range-vector levels", levels)
+	case mixed:
+		return "a plan over a mixed float/histogram relation"
+	default:
+		return "this query's plan"
+	}
+}
+
+// gridCarrierNesting returns the longest root-to-leaf chain of
+// [chplan.GridCarrier] nodes in n, and whether n contains a Mixed
+// [chplan.VectorSetOp] anywhere.
+//
+// The traversal follows Node.Children AND the plan subtrees embedded in Expr
+// slots (the reach [chplan.WalkDeep] has and [chplan.Walk] does not), because
+// the emitter renders both and a composition hidden inside a scalar subquery
+// is no cheaper than one on the spine.
+//
+// It is memoised on node identity, which is not an optimisation but a
+// requirement: a plan is a DAG, not a tree — splitMixedRelByDiscriminator hands
+// the SAME relation to both of its halves — so an unmemoised descent is
+// exponential in the nesting depth this function exists to describe.
+func gridCarrierNesting(n chplan.Node) (levels int, mixed bool) {
+	depth := map[chplan.Node]int{}
+	var walk func(chplan.Node) int
+	walk = func(n chplan.Node) int {
+		if n == nil {
+			return 0
+		}
+		if d, seen := depth[n]; seen {
+			return d
+		}
+		if v, ok := n.(*chplan.VectorSetOp); ok && v.Mixed {
+			mixed = true
+		}
+		deepest := 0
+		descend := func(c chplan.Node) {
+			if d := walk(c); d > deepest {
+				deepest = d
+			}
+		}
+		for _, c := range n.Children() {
+			descend(c)
+		}
+		chplan.InspectNodeExprs(n, func(e chplan.Expr) {
+			chplan.InspectExprNodes(e, func(chplan.Expr) bool { return true }, descend)
+		})
+		if _, ok := n.(chplan.GridCarrier); ok {
+			deepest++
+		}
+		depth[n] = deepest
+		return deepest
+	}
+	return walk(n), mixed
+}

--- a/internal/chsql/emit_size_bound_test.go
+++ b/internal/chsql/emit_size_bound_test.go
@@ -1,0 +1,285 @@
+package chsql
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/tsouza/cerberus/internal/chplan"
+)
+
+// Unit pins for the emitted-SQL statement-size bound (cerberus issue #2733,
+// emit_size_bound.go). The end-to-end proof — issue #2728's level-2
+// composition still emits, its level-3 sibling is refused — lives next to the
+// shapes themselves in internal/promql; what this file pins is the guard's own
+// arithmetic, its fallbacks, and the composition summary its message carries,
+// each of which is a one-line decision no end-to-end assertion would localise.
+
+// TestRequireEmittedSQLBounded_Boundary pins the ceiling EXACTLY: a statement
+// of precisely the bound's length is admitted, one byte more is refused. The
+// bound is a `<=`, and the whole value of naming ClickHouse's own
+// max_query_size as the default rests on that comparison being inclusive —
+// a statement of exactly 262144 bytes is one ClickHouse parses (its own check
+// fires at position 262145), so rejecting it would be cerberus refusing a
+// query the server would have run.
+func TestRequireEmittedSQLBounded_Boundary(t *testing.T) {
+	t.Parallel()
+
+	e := &emitter{}
+	if got := e.emittedSQLByteBound(); got != maxEmittedSQLBytes {
+		t.Fatalf("emittedSQLByteBound() = %d on a zero emitter, want the compiled-in default %d", got, maxEmittedSQLBytes)
+	}
+
+	atBound := strings.Repeat("x", int(maxEmittedSQLBytes))
+	if err := e.requireEmittedSQLBounded(nil, atBound); err != nil {
+		t.Errorf("a statement of exactly %d bytes was refused: %v — the bound must be inclusive, "+
+			"since ClickHouse's own max_query_size check fires at position %d",
+			maxEmittedSQLBytes, err, maxEmittedSQLBytes+1)
+	}
+
+	overBound := atBound + "x"
+	err := e.requireEmittedSQLBounded(nil, overBound)
+	if err == nil {
+		t.Fatalf("a statement of %d bytes was admitted, want a rejection at %d + 1", len(overBound), maxEmittedSQLBytes)
+	}
+	if !errors.Is(err, ErrEmittedSQLTooLarge) {
+		t.Errorf("error %v does not wrap ErrEmittedSQLTooLarge", err)
+	}
+	if !errors.Is(err, ErrUnsupported) {
+		t.Errorf("error %v does not wrap ErrUnsupported — the HTTP error mapping keys on that", err)
+	}
+	for _, want := range []string{"262145", "262144", "max_query_size", "CERBERUS_CH_MAX_EMITTED_SQL_BYTES"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("rejection message %q does not mention %q", err.Error(), want)
+		}
+	}
+}
+
+// TestEmittedSQLByteBound_Override pins both directions of the operator knob:
+// a threaded override replaces the default, and a bound that would be read as
+// the Go zero value falls back to the default rather than rejecting every
+// statement. The fallback is what protects the many tests in this package that
+// build &emitter{} directly, bypassing Emit's ctx seeding.
+func TestEmittedSQLByteBound_Override(t *testing.T) {
+	t.Parallel()
+
+	const override int64 = 4096
+	ctx := WithMaxEmittedSQLBytes(context.Background(), override)
+	if got := maxEmittedSQLBytesFromCtx(ctx); got != override {
+		t.Errorf("maxEmittedSQLBytesFromCtx = %d, want the threaded override %d", got, override)
+	}
+	if got := maxEmittedSQLBytesFromCtx(context.Background()); got != maxEmittedSQLBytes {
+		t.Errorf("maxEmittedSQLBytesFromCtx = %d on an unthreaded ctx, want the default %d", got, maxEmittedSQLBytes)
+	}
+
+	e := &emitter{emittedSQLMaxBytes: override}
+	if got := e.emittedSQLByteBound(); got != override {
+		t.Errorf("emittedSQLByteBound() = %d, want the seeded %d", got, override)
+	}
+	if err := e.requireEmittedSQLBounded(nil, strings.Repeat("x", int(override)+1)); err == nil {
+		t.Error("a statement past the OVERRIDE was admitted — the override is not being read")
+	}
+	if err := e.requireEmittedSQLBounded(nil, strings.Repeat("x", int(override))); err != nil {
+		t.Errorf("a statement at exactly the override was refused: %v", err)
+	}
+}
+
+// sizeBoundRangeWindow builds one grid-carrying level over input. RangeWindow
+// is a chplan.GridCarrier, which is what gridCarrierNesting counts.
+func sizeBoundRangeWindow(input chplan.Node) *chplan.RangeWindow {
+	return &chplan.RangeWindow{Input: input, Func: "rate", TimestampColumn: "TimeUnix", ValueColumn: "Value"}
+}
+
+// TestGridCarrierNesting counts the LONGEST chain of grid carriers, sees the
+// carriers hidden inside an Expr slot, and reports a Mixed set op wherever it
+// sits. Each of the three is a separate way the summary could understate a
+// composition and so name the wrong shape in a rejection.
+func TestGridCarrierNesting(t *testing.T) {
+	t.Parallel()
+
+	scan := &chplan.Scan{Table: "otel_metrics_gauge"}
+
+	t.Run("chain length", func(t *testing.T) {
+		t.Parallel()
+		if levels, mixed := gridCarrierNesting(scan); levels != 0 || mixed {
+			t.Errorf("bare scan = (%d, %v), want (0, false)", levels, mixed)
+		}
+		one := sizeBoundRangeWindow(scan)
+		if levels, _ := gridCarrierNesting(one); levels != 1 {
+			t.Errorf("one carrier = %d levels, want 1", levels)
+		}
+		three := sizeBoundRangeWindow(sizeBoundRangeWindow(one))
+		if levels, _ := gridCarrierNesting(three); levels != 3 {
+			t.Errorf("three stacked carriers = %d levels, want 3", levels)
+		}
+		// A non-carrier between two carriers does not break the chain: what
+		// costs SQL is how many grids are stacked, not how they are spelled.
+		spaced := sizeBoundRangeWindow(&chplan.Filter{Input: one, Predicate: &chplan.LitBool{V: true}})
+		if levels, _ := gridCarrierNesting(spaced); levels != 2 {
+			t.Errorf("two carriers with a Filter between = %d levels, want 2", levels)
+		}
+	})
+
+	t.Run("longest branch wins over a shared DAG child", func(t *testing.T) {
+		t.Parallel()
+		// splitMixedRelByDiscriminator hands the SAME relation to both halves,
+		// so the plan is a DAG. The count is a DEPTH, not a total: two arms
+		// over one shared two-level child is still three levels, not five.
+		shared := sizeBoundRangeWindow(sizeBoundRangeWindow(scan))
+		setOp := &chplan.VectorSetOp{
+			Left:  sizeBoundRangeWindow(shared),
+			Right: shared,
+			Op:    chplan.VectorSetOr,
+			Mixed: true,
+		}
+		levels, mixed := gridCarrierNesting(setOp)
+		if levels != 3 {
+			t.Errorf("shared-child DAG = %d levels, want 3 (the deepest branch)", levels)
+		}
+		if !mixed {
+			t.Error("mixed = false, want true — the set op is Mixed")
+		}
+	})
+
+	t.Run("carriers inside an Expr slot", func(t *testing.T) {
+		t.Parallel()
+		// A composition nested in a scalar subquery renders just as much SQL
+		// as one on the spine, so Node.Children alone is not enough reach.
+		hidden := &chplan.Filter{
+			Input: scan,
+			Predicate: &chplan.Binary{
+				Op:    chplan.OpGt,
+				Left:  &chplan.ColumnRef{Name: "Value"},
+				Right: &chplan.ScalarSubquery{Input: sizeBoundRangeWindow(sizeBoundRangeWindow(scan))},
+			},
+		}
+		if levels, _ := gridCarrierNesting(hidden); levels != 2 {
+			t.Errorf("carriers reachable only through an Expr slot = %d levels, want 2", levels)
+		}
+	})
+}
+
+// TestPlanCompositionSummary pins all four arms of the sentence a rejection
+// carries. The message is the entire deliverable of this bound — the query
+// already failed before it existed, just with ClickHouse's own wording — so a
+// summary that stopped naming the composition would silently undo the fix.
+func TestPlanCompositionSummary(t *testing.T) {
+	t.Parallel()
+
+	scan := &chplan.Scan{Table: "otel_metrics_gauge"}
+	mixedOver := func(n chplan.Node) chplan.Node {
+		return &chplan.VectorSetOp{Left: n, Right: scan, Op: chplan.VectorSetOr, Mixed: true}
+	}
+
+	cases := []struct {
+		name string
+		plan chplan.Node
+		want string
+	}{
+		{
+			name: "stacked levels over a mixed relation",
+			plan: sizeBoundRangeWindow(sizeBoundRangeWindow(mixedOver(scan))),
+			want: "a plan stacking 2 range-vector levels over a mixed float/histogram relation",
+		},
+		{
+			name: "stacked levels, no mixed relation",
+			plan: sizeBoundRangeWindow(sizeBoundRangeWindow(scan)),
+			want: "a plan stacking 2 range-vector levels",
+		},
+		{
+			name: "mixed relation, one level",
+			plan: sizeBoundRangeWindow(mixedOver(scan)),
+			want: "a plan over a mixed float/histogram relation",
+		},
+		{
+			name: "neither",
+			plan: scan,
+			want: "this query's plan",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if got := planCompositionSummary(tc.plan); got != tc.want {
+				t.Errorf("planCompositionSummary = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestRequireEmittedSQLBounded_NamesTheRootPlan pins which plan the message
+// describes when a SUB-statement is what crossed the ceiling: the whole query's
+// shape, not the fragment's. A user can only act on the shape they wrote, and
+// "at least" is what keeps the byte figure truthful in that case.
+func TestRequireEmittedSQLBounded_NamesTheRootPlan(t *testing.T) {
+	t.Parallel()
+
+	scan := &chplan.Scan{Table: "otel_metrics_gauge"}
+	fragment := sizeBoundRangeWindow(scan)
+	root := sizeBoundRangeWindow(sizeBoundRangeWindow(fragment))
+
+	e := &emitter{rootPlan: root}
+	err := e.requireEmittedSQLBounded(fragment, strings.Repeat("x", int(maxEmittedSQLBytes)+1))
+	if err == nil {
+		t.Fatal("an over-bound sub-statement was admitted")
+	}
+	if want := "a plan stacking 3 range-vector levels"; !strings.Contains(err.Error(), want) {
+		t.Errorf("message %q does not describe the ROOT plan (%q) — it named the fragment instead", err.Error(), want)
+	}
+	if !strings.Contains(err.Error(), "at least") {
+		t.Errorf("message %q drops the \"at least\" qualifier, which is what makes a sub-statement's "+
+			"byte count an honest figure for the whole statement", err.Error())
+	}
+
+	// With no root stamped (EmitCompareRootLeg, and this package's own
+	// round-trip tests), the node actually handed to the guard is described.
+	bare := &emitter{}
+	err = bare.requireEmittedSQLBounded(fragment, strings.Repeat("x", int(maxEmittedSQLBytes)+1))
+	if err == nil {
+		t.Fatal("an over-bound statement was admitted by a rootless emitter")
+	}
+	if want := "a plan over"; strings.Contains(err.Error(), want) {
+		t.Errorf("message %q describes a mixed relation the fragment does not carry", err.Error())
+	}
+	if !strings.Contains(err.Error(), "this query's plan") {
+		t.Errorf("message %q does not fall back to describing the node it was handed", err.Error())
+	}
+}
+
+// TestEmitRejectsAnOversizeStatement drives the guard through the real
+// chsql.Emit chokepoint rather than the helper, so the wiring — the ctx
+// seeding, the emitter field, the call site — is proven, not just the
+// arithmetic. A deliberately tiny override stands in for a 588KB composition
+// so the test stays cheap; the real shape's rejection is pinned in
+// internal/promql.
+func TestEmitRejectsAnOversizeStatement(t *testing.T) {
+	t.Parallel()
+
+	plan := &chplan.Project{
+		Input:       &chplan.Scan{Table: "otel_metrics_gauge"},
+		Projections: []chplan.Projection{{Expr: &chplan.ColumnRef{Name: "Value"}, Alias: "Value"}},
+	}
+
+	sql, _, err := Emit(context.Background(), plan)
+	if err != nil {
+		t.Fatalf("Emit under the default bound: %v", err)
+	}
+	if len(sql) == 0 {
+		t.Fatal("Emit returned empty SQL")
+	}
+
+	// One byte under what this plan actually renders: the smallest override
+	// that must reject it, so the assertion cannot pass on a guard that only
+	// fires for absurd values.
+	tight := WithMaxEmittedSQLBytes(context.Background(), int64(len(sql)-1))
+	if _, _, err := Emit(tight, plan); !errors.Is(err, ErrEmittedSQLTooLarge) {
+		t.Errorf("Emit with a %d-byte bound over %d bytes of SQL returned %v, want ErrEmittedSQLTooLarge",
+			len(sql)-1, len(sql), err)
+	}
+	// Exactly what it renders: admitted, the inclusive-bound half of the pin.
+	exact := WithMaxEmittedSQLBytes(context.Background(), int64(len(sql)))
+	if _, _, err := Emit(exact, plan); err != nil {
+		t.Errorf("Emit with a bound of exactly the rendered %d bytes returned %v, want success", len(sql), err)
+	}
+}

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -196,10 +196,11 @@ func emitForHead(
 	return chsql.Emit(ctx, plan)
 }
 
-// applyResourceBoundOverrides threads onto ctx only the CERBERUS_CH_*_MAX_ROWS
-// overrides bounds actually carries (issue #2667) — a zero field means the
-// operator never set that one (see ResourceBoundOverrides' own doc: a
-// fanout row bound of zero is never a legitimate override), so it is left
+// applyResourceBoundOverrides threads onto ctx only the CERBERUS_CH_*
+// overrides bounds actually carries (issue #2667, plus issue #2733's
+// MaxEmittedSQLBytes) — a zero field means the operator never set that one
+// (see ResourceBoundOverrides' own doc: neither a fanout row bound nor a
+// statement-size bound of zero is a legitimate override), so it is left
 // unthreaded and chsql's own *FromCtx readers fall back to that bound's
 // compiled-in, calibrated default exactly as if this function were never
 // called. Shared by emitForHead (route A) and routeBExecCtx (route B) so
@@ -213,6 +214,9 @@ func applyResourceBoundOverrides(ctx context.Context, bounds ResourceBoundOverri
 	}
 	if bounds.RateWindowFanoutMaxRows > 0 {
 		ctx = chsql.WithRateWindowFanoutMaxRows(ctx, bounds.RateWindowFanoutMaxRows)
+	}
+	if bounds.MaxEmittedSQLBytes > 0 {
+		ctx = chsql.WithMaxEmittedSQLBytes(ctx, bounds.MaxEmittedSQLBytes)
 	}
 	return ctx
 }
@@ -229,6 +233,7 @@ func (e *Engine) resourceBoundOverrides() ResourceBoundOverrides {
 		RangeBucketFanoutMaxRows: e.RangeBucketFanoutMaxRows,
 		RangeLWRFanoutMaxRows:    e.RangeLWRFanoutMaxRows,
 		RateWindowFanoutMaxRows:  e.RateWindowFanoutMaxRows,
+		MaxEmittedSQLBytes:       e.MaxEmittedSQLBytes,
 	}
 }
 
@@ -915,6 +920,30 @@ type Engine struct {
 	RangeBucketFanoutMaxRows int64
 	RangeLWRFanoutMaxRows    int64
 	RateWindowFanoutMaxRows  int64
+
+	// MaxEmittedSQLBytes mirrors the operator override for chsql's
+	// emitted-SQL statement-size bound (issue #2733,
+	// internal/chsql/emit_size_bound.go): CERBERUS_CH_MAX_EMITTED_SQL_BYTES,
+	// wired from the same engine.ResourceBoundsFromEnv ResourceBoundOverrides
+	// in cmd/cerberus, threaded through the same applyResourceBoundOverrides
+	// seam, and carrying the same "0 means the operator set nothing" sentinel
+	// as the three fields above.
+	//
+	// Unlike those three it is wired onto EVERY head's Engine, because it
+	// bounds a property every head has: the bytes of one emitted statement.
+	// The default it falls back to is ClickHouse's own max_query_size default,
+	// so a deployment that has not touched either setting sees a cerberus
+	// rejection exactly where it would otherwise have seen the server's own
+	// code 62 — and a deployment that raised max_query_size raises this to
+	// match.
+	//
+	// The Tempo head's two non-Engine emit paths (root_lookup.go and
+	// structural_two_phase.go call chsql.Emit directly, off the request context
+	// rather than through emitForHead) never see this field and so always run
+	// on chsql's compiled-in default. Neither renders a composed metrics plan —
+	// they are a trace-by-id lookup and a bounded structural phase A — so
+	// neither approaches the ceiling; the override is simply not threaded there.
+	MaxEmittedSQLBytes int64
 
 	// RangeBucketGridNativeMaxRows / RangeBucketGridNativeMaxDensityUnits
 	// mirror config.Config's own fields of the same name (CERBERUS_RANGE_

--- a/internal/engine/resource_bound_env.go
+++ b/internal/engine/resource_bound_env.go
@@ -19,6 +19,13 @@ import (
 //     emitWindowedArrayExtrapolatedMatrix's regroup GROUP BY
 //     (internal/chsql/rate_window_fanout_bound.go, maxRateWindowFanoutRows,
 //     default 2,800,000).
+//   - CERBERUS_CH_MAX_EMITTED_SQL_BYTES — the bytes of SQL one statement may
+//     render to (internal/chsql/emit_size_bound.go, maxEmittedSQLBytes,
+//     default 262,144). Unlike the three above this one is not a row-count
+//     ceiling but a statement-size one, and its default is ClickHouse's own
+//     max_query_size default rather than a cerberus calibration: an operator
+//     who raises max_query_size on the server raises this alongside it, and
+//     nobody else needs to touch it. Issue #2733.
 //
 // Each constant is a compile-time resource-bound safety ceiling gating
 // query execution/plan shape that has already cost this repo two real
@@ -52,15 +59,18 @@ const (
 	EnvRangeLWRFanoutMaxRows = "CERBERUS_CH_RANGE_LWR_FANOUT_MAX_ROWS"
 	// EnvRateWindowFanoutMaxRows overrides maxRateWindowFanoutRows.
 	EnvRateWindowFanoutMaxRows = "CERBERUS_CH_RATE_WINDOW_FANOUT_MAX_ROWS"
+	// EnvMaxEmittedSQLBytes overrides maxEmittedSQLBytes.
+	EnvMaxEmittedSQLBytes = "CERBERUS_CH_MAX_EMITTED_SQL_BYTES"
 )
 
-// ResourceBoundOverrides is the resolved operator override for the three
+// ResourceBoundOverrides is the resolved operator override for the four
 // env vars above. A zero field means "the operator did not set this one" —
 // the caller (emitForHead / routeBExecCtx) leaves the corresponding chsql
 // ctx value unthreaded so chsql falls back to its own compiled-in,
 // calibrated default. Unlike CERBERUS_DELTA_PREFIX_LOOKBACK, where 0 is a
-// meaningful explicit opt-out, a fanout row bound of 0 is never a
-// legitimate operator intent (it would reject every query outright), so
+// meaningful explicit opt-out, neither a fanout row bound nor a statement-size
+// bound of 0 is a legitimate operator intent (either would reject every query
+// outright), so
 // reserving 0 as the "unset" sentinel loses no real configuration and
 // ResourceBoundsFromEnv rejects an explicit 0 or negative override as a
 // startup error instead of silently accepting it.
@@ -68,9 +78,10 @@ type ResourceBoundOverrides struct {
 	RangeBucketFanoutMaxRows int64
 	RangeLWRFanoutMaxRows    int64
 	RateWindowFanoutMaxRows  int64
+	MaxEmittedSQLBytes       int64
 }
 
-// ResourceBoundsFromEnv reads the three CERBERUS_CH_*_MAX_ROWS knobs above.
+// ResourceBoundsFromEnv reads the four CERBERUS_CH_* knobs above.
 // An unset var resolves its field to 0 (see ResourceBoundOverrides' own
 // doc); a set var is parsed as a base-10 int64 and must be strictly
 // positive. A parse failure or a non-positive value is returned as an
@@ -87,6 +98,9 @@ func ResourceBoundsFromEnv() (ResourceBoundOverrides, error) {
 		return ResourceBoundOverrides{}, err
 	}
 	if overrides.RateWindowFanoutMaxRows, err = envPositiveInt64(EnvRateWindowFanoutMaxRows); err != nil {
+		return ResourceBoundOverrides{}, err
+	}
+	if overrides.MaxEmittedSQLBytes, err = envPositiveInt64(EnvMaxEmittedSQLBytes); err != nil {
 		return ResourceBoundOverrides{}, err
 	}
 	return overrides, nil

--- a/internal/engine/resource_bound_env_test.go
+++ b/internal/engine/resource_bound_env_test.go
@@ -1,12 +1,17 @@
 package engine
 
 import (
+	"context"
+	"errors"
 	"strings"
 	"testing"
+
+	"github.com/tsouza/cerberus/internal/chplan"
+	"github.com/tsouza/cerberus/internal/chsql"
 )
 
 // TestResourceBoundsFromEnv_DefaultsToZeroUnset pins the "operator did not
-// override" sentinel: with none of the three CERBERUS_CH_*_MAX_ROWS vars
+// override" sentinel: with none of the four CERBERUS_CH_* vars
 // set, every field resolves to 0 — the value applyResourceBoundOverrides
 // treats as "thread nothing onto ctx, let chsql fall back to its own
 // compiled-in default" (see ResourceBoundOverrides' own doc).
@@ -14,6 +19,7 @@ func TestResourceBoundsFromEnv_DefaultsToZeroUnset(t *testing.T) {
 	t.Setenv(EnvRangeBucketFanoutMaxRows, "")
 	t.Setenv(EnvRangeLWRFanoutMaxRows, "")
 	t.Setenv(EnvRateWindowFanoutMaxRows, "")
+	t.Setenv(EnvMaxEmittedSQLBytes, "")
 
 	got, err := ResourceBoundsFromEnv()
 	if err != nil {
@@ -26,13 +32,15 @@ func TestResourceBoundsFromEnv_DefaultsToZeroUnset(t *testing.T) {
 }
 
 // TestResourceBoundsFromEnv_OverridesEachIndependently confirms each of the
-// three env vars maps onto its own field, independent of the other two —
+// four env vars maps onto its own field, independent of the others —
 // the exact "an operator override actually reaches the resolved config"
-// contract issue #2667 exists to establish.
+// contract issue #2667 exists to establish, extended to issue #2733's
+// statement-size bound.
 func TestResourceBoundsFromEnv_OverridesEachIndependently(t *testing.T) {
 	t.Setenv(EnvRangeBucketFanoutMaxRows, "123")
 	t.Setenv(EnvRangeLWRFanoutMaxRows, "456")
 	t.Setenv(EnvRateWindowFanoutMaxRows, "789")
+	t.Setenv(EnvMaxEmittedSQLBytes, "1048576")
 
 	got, err := ResourceBoundsFromEnv()
 	if err != nil {
@@ -42,6 +50,7 @@ func TestResourceBoundsFromEnv_OverridesEachIndependently(t *testing.T) {
 		RangeBucketFanoutMaxRows: 123,
 		RangeLWRFanoutMaxRows:    456,
 		RateWindowFanoutMaxRows:  789,
+		MaxEmittedSQLBytes:       1048576,
 	}
 	if got != want {
 		t.Fatalf("ResourceBoundsFromEnv() = %+v, want %+v", got, want)
@@ -53,11 +62,14 @@ func TestResourceBoundsFromEnv_OverridesEachIndependently(t *testing.T) {
 // falling back to 0 (which would silently discard the operator's actual
 // intent to override).
 func TestResourceBoundsFromEnv_RejectsMalformedValue(t *testing.T) {
-	for _, key := range []string{EnvRangeBucketFanoutMaxRows, EnvRangeLWRFanoutMaxRows, EnvRateWindowFanoutMaxRows} {
+	for _, key := range []string{
+		EnvRangeBucketFanoutMaxRows, EnvRangeLWRFanoutMaxRows, EnvRateWindowFanoutMaxRows, EnvMaxEmittedSQLBytes,
+	} {
 		t.Run(key, func(t *testing.T) {
 			t.Setenv(EnvRangeBucketFanoutMaxRows, "")
 			t.Setenv(EnvRangeLWRFanoutMaxRows, "")
 			t.Setenv(EnvRateWindowFanoutMaxRows, "")
+			t.Setenv(EnvMaxEmittedSQLBytes, "")
 			t.Setenv(key, "not-a-number")
 
 			_, err := ResourceBoundsFromEnv()
@@ -73,26 +85,30 @@ func TestResourceBoundsFromEnv_RejectsMalformedValue(t *testing.T) {
 
 // TestResourceBoundsFromEnv_RejectsNonPositiveValue confirms 0 and a
 // negative value are both rejected as startup errors rather than silently
-// accepted as "0 rows" or "-1 rows" — a fanout row bound that low would
-// reject every query outright, which is never a legitimate operator
-// intent (see ResourceBoundOverrides' own doc).
+// accepted as "0 rows" or "-1 rows" — a fanout row bound (or a statement-size
+// bound) that low would reject every query outright, which is never a
+// legitimate operator intent (see ResourceBoundOverrides' own doc).
 func TestResourceBoundsFromEnv_RejectsNonPositiveValue(t *testing.T) {
-	for _, v := range []string{"0", "-1", "-1000000"} {
-		t.Run(v, func(t *testing.T) {
-			t.Setenv(EnvRangeBucketFanoutMaxRows, v)
-			t.Setenv(EnvRangeLWRFanoutMaxRows, "")
-			t.Setenv(EnvRateWindowFanoutMaxRows, "")
+	for _, key := range []string{EnvRangeBucketFanoutMaxRows, EnvMaxEmittedSQLBytes} {
+		for _, v := range []string{"0", "-1", "-1000000"} {
+			t.Run(key+"="+v, func(t *testing.T) {
+				t.Setenv(EnvRangeBucketFanoutMaxRows, "")
+				t.Setenv(EnvRangeLWRFanoutMaxRows, "")
+				t.Setenv(EnvRateWindowFanoutMaxRows, "")
+				t.Setenv(EnvMaxEmittedSQLBytes, "")
+				t.Setenv(key, v)
 
-			_, err := ResourceBoundsFromEnv()
-			if err == nil {
-				t.Fatalf("ResourceBoundsFromEnv() with %s=%s: error = nil, want an error", EnvRangeBucketFanoutMaxRows, v)
-			}
-		})
+				_, err := ResourceBoundsFromEnv()
+				if err == nil {
+					t.Fatalf("ResourceBoundsFromEnv() with %s=%s: error = nil, want an error", key, v)
+				}
+			})
+		}
 	}
 }
 
 // TestEngine_ResourceBoundOverrides confirms the Engine method that feeds
-// emitForHead / routeBExecCtx packages exactly the three Engine fields, so a
+// emitForHead / routeBExecCtx packages exactly the four Engine fields, so a
 // production wiring bug (mixing up which field maps to which knob) would
 // show up here rather than only via an end-to-end chDB query.
 func TestEngine_ResourceBoundOverrides(t *testing.T) {
@@ -100,12 +116,14 @@ func TestEngine_ResourceBoundOverrides(t *testing.T) {
 		RangeBucketFanoutMaxRows: 111,
 		RangeLWRFanoutMaxRows:    222,
 		RateWindowFanoutMaxRows:  333,
+		MaxEmittedSQLBytes:       444,
 	}
 	got := e.resourceBoundOverrides()
 	want := ResourceBoundOverrides{
 		RangeBucketFanoutMaxRows: 111,
 		RangeLWRFanoutMaxRows:    222,
 		RateWindowFanoutMaxRows:  333,
+		MaxEmittedSQLBytes:       444,
 	}
 	if got != want {
 		t.Fatalf("resourceBoundOverrides() = %+v, want %+v", got, want)
@@ -113,13 +131,48 @@ func TestEngine_ResourceBoundOverrides(t *testing.T) {
 }
 
 // TestEngine_ResourceBoundOverrides_ZeroValue confirms an Engine built
-// without these fields wired (e.g. Engine{} in a test, or the Tempo head,
-// which never lowers any of the three guarded node kinds) packages the
-// zero ResourceBoundOverrides — the "thread nothing" sentinel.
+// without these fields wired (e.g. Engine{} in a test) packages the zero
+// ResourceBoundOverrides — the "thread nothing" sentinel.
 func TestEngine_ResourceBoundOverrides_ZeroValue(t *testing.T) {
 	e := &Engine{}
 	got := e.resourceBoundOverrides()
 	if got != (ResourceBoundOverrides{}) {
 		t.Fatalf("resourceBoundOverrides() on a zero Engine = %+v, want the zero value", got)
+	}
+}
+
+// TestApplyResourceBoundOverrides_ThreadsTheEmittedSQLByteBound pins the
+// engine→chsql seam for issue #2733's statement-size bound: an operator value
+// that reached ResourceBoundOverrides but never reached the emit context would
+// be a silently inert knob, which is the exact failure mode issue #2055 found
+// on MaxQuerySamples and issue #2667 was filed to prevent repeating.
+//
+// It asserts behaviourally, through chsql.Emit, because the ctx key chsql reads
+// is unexported: a bound one byte under what the plan actually renders must
+// refuse it, and a zero field must thread nothing and leave chsql on its own
+// compiled-in default.
+func TestApplyResourceBoundOverrides_ThreadsTheEmittedSQLByteBound(t *testing.T) {
+	plan := &chplan.Project{
+		Input:       &chplan.Scan{Table: "otel_metrics_gauge"},
+		Projections: []chplan.Projection{{Expr: &chplan.ColumnRef{Name: "Value"}, Alias: "Value"}},
+	}
+
+	sql, _, err := chsql.Emit(context.Background(), plan)
+	if err != nil {
+		t.Fatalf("Emit with no override: %v", err)
+	}
+
+	tight := applyResourceBoundOverrides(context.Background(), ResourceBoundOverrides{
+		MaxEmittedSQLBytes: int64(len(sql) - 1),
+	})
+	if _, _, err := chsql.Emit(tight, plan); !errors.Is(err, chsql.ErrEmittedSQLTooLarge) {
+		t.Errorf("Emit under a %d-byte override of %d bytes of SQL = %v, want ErrEmittedSQLTooLarge — "+
+			"the override never reached the emit context", len(sql)-1, len(sql), err)
+	}
+
+	unset := applyResourceBoundOverrides(context.Background(), ResourceBoundOverrides{})
+	if _, _, err := chsql.Emit(unset, plan); err != nil {
+		t.Errorf("Emit with a zero MaxEmittedSQLBytes = %v, want success: a zero field must thread "+
+			"nothing rather than a zero-byte ceiling", err)
 	}
 }

--- a/internal/promql/histogram_native_subquery_call_subquery_emit_size_test.go
+++ b/internal/promql/histogram_native_subquery_call_subquery_emit_size_test.go
@@ -1,0 +1,227 @@
+package promql
+
+import (
+	"context"
+	"errors"
+	"regexp"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/tsouza/cerberus/internal/chplan"
+	"github.com/tsouza/cerberus/internal/chsql"
+	"github.com/tsouza/cerberus/internal/schema"
+)
+
+// Default-lane pins for cerberus issue #2733: where the mixed float/histogram
+// subquery composition stops being serveable, and what a query past that point
+// is told.
+//
+// The composition's emitted SQL grows ~4x per bracket level, because each
+// Mixed FOLD-family level partitions its input through
+// [splitMixedRelByDiscriminator] and so names the relation beneath it twice.
+// Measured over `((m_exp_hist) or (m_gauge))` at an instant eval: 26KB at one
+// level, 140KB at two, 588KB at three, 1.8MB at four. Levels one and two are
+// what cerberus issues #2726 and #2728 answer, and both are chDB-proven in
+// histogram_native_subquery_call_subquery_chdb_test.go /
+// …_outer_fn_chdb_test.go. Level three is past ClickHouse's own
+// max_query_size, so the server refuses to parse it — and before this bound
+// existed that refusal reached the user as a raw driver `Code: 62 … failed at
+// position 262145`.
+//
+// These tests pin both halves of the fix at once, and deliberately in one
+// file: the SEPARATION is the whole claim. A bound that admitted level three
+// would not fix anything, and one that refused level two would break a
+// shipping, chDB-proven shape — the far worse of the two failures.
+
+const (
+	// emitSizeInnerRange / emitSizeMidRange / emitSizeOuterRange / emitSizeTopRange
+	// are the four brackets the queries below stack, innermost first.
+	emitSizeInnerRange = "[2m:1m]"
+	emitSizeMidRange   = "[3m:1m]"
+	emitSizeOuterRange = "[4m:1m]"
+	emitSizeTopRange   = "[5m:1m]"
+)
+
+// emitSizeLevel1 … emitSizeLevel4 are the four bracket depths issue #2733
+// measured, over the same mixed `or` the #2728 default-lane tests use.
+func emitSizeLevel1() string {
+	return "rate(" + outerFn2TestMixedInner + emitSizeMidRange + ")"
+}
+
+func emitSizeLevel2() string {
+	// Identical to outerFn2TestQuery("sum_over_time", …) — spelled through it
+	// so the shape this admits stays the shape #2728's own tests exercise.
+	return outerFn2TestQuery("sum_over_time", outerFn2TestMixedInner, "")
+}
+
+func emitSizeLevel3() string {
+	return "sum_over_time(rate(rate(" + outerFn2TestMixedInner + emitSizeInnerRange + ")" +
+		emitSizeMidRange + ")" + emitSizeOuterRange + ")"
+}
+
+func emitSizeLevel4() string {
+	return "rate(" + emitSizeLevel3() + emitSizeTopRange + ")"
+}
+
+// emitSizeLowerAndEmit lowers q at a fixed anchor — instant, or over a
+// query_range grid — and emits it, returning whatever emit produced. Lowering
+// itself is asserted to succeed in every case: the bound this file pins sits at
+// the EMIT chokepoint, so a query it refuses must still lower cleanly, and a
+// lowering-time failure here would mean the test is measuring something else.
+func emitSizeLowerAndEmit(t *testing.T, q string, rangeMode bool) (string, error) {
+	t.Helper()
+
+	s := schema.DefaultOTelMetrics()
+	at := time.Date(2026, 1, 1, 12, 0, 0, 0, time.UTC)
+	expr := mustParseExperimental(t, q)
+
+	var plan chplan.Node
+	var err error
+	if rangeMode {
+		plan, err = LowerAtRange(context.Background(), expr, s, at.Add(-10*time.Minute), at, time.Minute)
+	} else {
+		plan, err = LowerAt(context.Background(), expr, s, at, at)
+	}
+	if err != nil {
+		t.Fatalf("lower %s: %v", q, err)
+	}
+	sql, _, err := chsql.Emit(context.Background(), plan)
+	return sql, err
+}
+
+// TestMixedSubqueryComposition_LevelsOneAndTwoStillEmit is the regression half
+// of issue #2733's fix, and the more important half: the two composition
+// depths cerberus already answers must keep emitting. Level two under
+// query_range renders 209,182 bytes — 80% of the ceiling — so this is not a
+// theoretical margin, and a bound placed on any estimate that OVER-counts the
+// wire size (metadata.go's deliberately conservative boundQueryBytes, say)
+// would refuse it outright.
+func TestMixedSubqueryComposition_LevelsOneAndTwoStillEmit(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name string
+		q    string
+	}{
+		{"level 1", emitSizeLevel1()},
+		{"level 2", emitSizeLevel2()},
+	} {
+		for _, rangeMode := range []bool{false, true} {
+			name := tc.name + "/instant"
+			if rangeMode {
+				name = tc.name + "/query_range"
+			}
+			t.Run(name, func(t *testing.T) {
+				t.Parallel()
+				sql, err := emitSizeLowerAndEmit(t, tc.q, rangeMode)
+				if err != nil {
+					t.Fatalf("%s no longer emits: %v\n\nThis shape is chDB-proven "+
+						"(cerberus issues #2726 / #2728) and shipping. If the "+
+						"emitted-SQL size bound refused it, the bound is wrong; if the "+
+						"composition grew past ClickHouse's max_query_size, the "+
+						"emitter regressed and the query is now unserveable.", tc.q, err)
+				}
+				t.Logf("%s: %d bytes of SQL", tc.q, len(sql))
+			})
+		}
+	}
+}
+
+// emitSizeReportedBytes pulls the rejection message's own two figures — the
+// bytes the statement rendered to, and the ceiling it passed — out of it, so
+// the assertions below compare the guard against its own reported bound rather
+// than against a second copy of ClickHouse's max_query_size default.
+var emitSizeReportedBytes = regexp.MustCompile(`renders at least (\d+) bytes, past the (\d+)-byte ceiling`)
+
+// TestMixedSubqueryComposition_LevelThreeAndDeeperRejectedCleanly pins the
+// other half: the depths ClickHouse will not parse are refused by cerberus, by
+// name, before any statement reaches a querier.
+func TestMixedSubqueryComposition_LevelThreeAndDeeperRejectedCleanly(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name       string
+		q          string
+		wantLevels string
+	}{
+		{"level 3", emitSizeLevel3(), "a plan stacking 4 range-vector levels over a mixed float/histogram relation"},
+		{"level 4", emitSizeLevel4(), "a plan stacking 5 range-vector levels over a mixed float/histogram relation"},
+	} {
+		for _, rangeMode := range []bool{false, true} {
+			name := tc.name + "/instant"
+			if rangeMode {
+				name = tc.name + "/query_range"
+			}
+			t.Run(name, func(t *testing.T) {
+				t.Parallel()
+				sql, err := emitSizeLowerAndEmit(t, tc.q, rangeMode)
+				if err == nil {
+					t.Fatalf("%s emitted %d bytes of SQL with no error — ClickHouse would "+
+						"refuse to parse it (max_query_size), so the user gets a raw driver "+
+						"code 62 instead of a cerberus rejection naming the shape", tc.q, len(sql))
+				}
+				if !errors.Is(err, chsql.ErrEmittedSQLTooLarge) {
+					t.Fatalf("%s was refused by something other than the emitted-SQL size bound: %v", tc.q, err)
+				}
+				if sql != "" {
+					t.Errorf("a refused emit returned %d bytes of SQL; it must return none", len(sql))
+				}
+				msg := err.Error()
+				if !strings.Contains(msg, tc.wantLevels) {
+					t.Errorf("rejection does not name the composition.\n got: %s\nwant it to contain: %s", msg, tc.wantLevels)
+				}
+			})
+		}
+	}
+}
+
+// TestMixedSubqueryComposition_RejectionStopsAtTheFirstOversizeSubStatement
+// pins the emitter's per-sub-statement check (renderNode), which is what keeps
+// a rejection CHEAP. The four-level composition's finished statement is ~1.8MB
+// (~3.5MB under query_range) and each further bracket multiplies that by ~4, so
+// a guard that only measured the finished statement would build the whole thing
+// before refusing it — ~45MB at six levels, ~700MB at eight, all from a query
+// short enough to type.
+//
+// The rejection's own byte figure is the observable: it reports the sub-
+// statement that crossed the ceiling, which for this shape is ~290KB — barely
+// over the bound, and an order of magnitude below the finished statement the
+// late-only guard would have had to render first.
+func TestMixedSubqueryComposition_RejectionStopsAtTheFirstOversizeSubStatement(t *testing.T) {
+	t.Parallel()
+
+	_, err := emitSizeLowerAndEmit(t, emitSizeLevel4(), true)
+	if err == nil {
+		t.Fatal("the four-level composition emitted with no error")
+	}
+	m := emitSizeReportedBytes.FindStringSubmatch(err.Error())
+	if m == nil {
+		t.Fatalf("rejection carries no byte figure to read: %v", err)
+	}
+	reported, convErr := strconv.Atoi(m[1])
+	if convErr != nil {
+		t.Fatalf("byte figure %q is not a number: %v", m[1], convErr)
+	}
+	ceiling, convErr := strconv.Atoi(m[2])
+	if convErr != nil {
+		t.Fatalf("ceiling figure %q is not a number: %v", m[2], convErr)
+	}
+
+	// The statement that tripped the bound must genuinely be over it, or the
+	// figure is measuring something other than what was refused.
+	if reported <= ceiling {
+		t.Errorf("the rejection reports %d bytes, which is within its own %d-byte ceiling", reported, ceiling)
+	}
+	// The finished query_range statement for this shape is ~3.5MB — more than
+	// four times the ceiling. Anything near that means the emitter rendered the
+	// whole composition before refusing it, i.e. the per-sub-statement check no
+	// longer fires. The observed figure is ~290KB, barely over the ceiling.
+	const stoppedEarlyCeilingMultiple = 4
+	if limit := ceiling * stoppedEarlyCeilingMultiple; reported >= limit {
+		t.Errorf("the rejection reports %d bytes, at or past %dx the %d-byte ceiling — the emitter "+
+			"rendered the whole composition before refusing it instead of stopping at the first "+
+			"over-bound sub-statement", reported, stoppedEarlyCeilingMultiple, ceiling)
+	}
+}


### PR DESCRIPTION
## The gap

A fourth bracket level of subquery composition over a mixed float/histogram
inner — one more than cerberus issue #2728 answers — lowers correctly and emits
correct SQL, but emits more of it than ClickHouse will parse. The query failed
at the database with a raw driver error:

```
Code: 62. DB::Exception: Max query size exceeded (can be increased with the
`max_query_size` setting): Syntax error: failed at position 262145
```

Nothing was silently wrong and nothing hung. What was missing was a
cerberus-side name for the shape that cannot be served: before #2728 the same
query was refused at lowering with an error naming the composition, and #2728
opening that arm (correctly, for the one extra level that IS serveable) moved
the deeper levels' failure from "cerberus says no" to "ClickHouse says no".

## The bound

`chsql.Emit` and `renderNode` now refuse a statement longer than the
emitted-SQL byte bound (`internal/chsql/emit_size_bound.go`), with a message
that names the composition:

```
chsql: unsupported: emitted SQL exceeds the statement-size bound: a plan
stacking 5 range-vector levels over a mixed float/histogram relation renders at
least 289759 bytes, past the 262144-byte ceiling (ClickHouse's own
max_query_size); reduce the query's composition, or raise max_query_size and
CERBERUS_CH_MAX_EMITTED_SQL_BYTES together
```

Three decisions carry the design.

**The default is ClickHouse's own `max_query_size` default (262144), not a
cerberus calibration.** That identity is what makes the bound safe to apply to
every plan of every head: a statement past it is one the server refuses to
parse anyway, so the guard changes the error a user sees, never whether the
query could have run.

**The measure is the placeholder SQL, a deliberate UNDERCOUNT.** clickhouse-go
inlines every positional arg client-side (the native protocol has no
bound-parameter channel — see `internal/api/prom/metadata.go`'s `boundQueryBytes`
and the #799 incident it records), so the wire statement is always at least as
long as the `?`-carrying text measured here. Undercounting means every
statement the bound refuses is one ClickHouse would also refuse; a statement it
admits may still be refused by the server, which is exactly today's behaviour.
Reusing metadata.go's deliberate OVER-approximation would have inverted that
and refused #2728's shipping level-2 shape once a handful of label matchers
were added.

**Two call sites, because the second is what keeps refusing cheap.** The
finished statement embeds every rendered sub-statement verbatim, so a
sub-statement already over the bound proves the whole is over it. Stopping
there caps the emitter's peak allocation at roughly one bound's worth of text:
the four-level composition is refused after rendering ~290KB rather than after
building its full 3.5MB, and a query that simply stacks more brackets — a short
string to type — stops at the same point instead of walking the 4x-per-level
curve to ~45MB at six levels and ~700MB at eight.

## Why not a plan-side prediction

Tried first, and refuted by measurement. The DAG-expanded plan-node count grows
~2.1x per level while the emitted SQL grows ~3-4x, because the emitter
duplicates text the plan does not (`rateWindowFanoutBoundedSourceFrag` and
`lwrFanoutBoundedSourceFrag` each render their fan-out source a second time for
the truncation probe; histogram fold expressions render far more text per node
than float ones). Bytes-per-plan-node ranges from ~0.75KB for a plain
`rate(<counter>[5m])` to ~5.7KB for the level-4 composition — a spread no single
node-count threshold splits into "fits" and "does not fit" without refusing
shapes ClickHouse parses happily. Measuring the rendered statement is exact and
costs one integer comparison.

## Measured

Emitted placeholder SQL over `((m_exp_hist) or (m_gauge))`, instant eval:

| bracket levels | emitted SQL | plan nodes (DAG expanded) | verdict |
| --- | --- | --- | --- |
| 1 | 26,480 | 16 | emits |
| 2 | 140,319 (209,182 under query_range) | 67 | emits |
| 3 | 588,295 | 147 | refused |
| 4 | 1,786,077 | 306 | refused |

The FAMILY sensitivity the issue asked for falls out for free rather than being
special-cased: `count_over_time(count_over_time(rate(<mixed>[2m:1m])[3m:1m])[4m:1m])`
is a SELECT-family sibling at the same depth, renders 135KB, and still emits.

## Status code

The prom head maps the rejection to **422 errorType=execution**, the class the
sample budget, the memory-limit abort and every throwIf resource guard already
land in — not the emit stage's catch-all 500, which would report a user's
exotic query as a cerberus fault. 422 is also the status this exact query had
before #2728, when it was refused at lowering.

## Operator override

`CERBERUS_CH_MAX_EMITTED_SQL_BYTES` raises the ceiling for a deployment that
raised `max_query_size` on the server itself, wired through the same
`ResourceBoundOverrides` seam as issue #2667's three fanout ceilings and onto
all three heads' engines (the bound applies to a property every head has).
Unset leaves the compiled-in default; a malformed or non-positive value aborts
startup.

## Verification

- `internal/promql/histogram_native_subquery_call_subquery_emit_size_test.go` —
  levels 1 and 2 still emit in both grid modes (the regression half, and the
  more important one: level 2 under query_range sits at 80% of the ceiling);
  levels 3 and 4 are refused with a message naming the composition; the
  rejection's own byte figure proves the emitter stopped at the first
  over-bound sub-statement rather than rendering the whole thing.
- `internal/chsql/emit_size_bound_test.go` — the ceiling is pinned EXACTLY
  (a statement of precisely 262144 bytes is admitted, 262145 refused, because
  ClickHouse's own check fires at position 262145), plus the override, the
  zero-value fallback, the DAG-memoised nesting count and all four arms of the
  composition summary.
- `internal/engine/resource_bound_env_test.go` — the env var and the
  engine→chsql ctx seam, so the knob cannot be silently inert.
- `internal/api/prom/handler_emit_size_error_test.go` — 422 for the size bound,
  500 still for a genuine unsupported-node emit failure.
- chDB lanes green: `internal/promql` (#2726 / #2728 composition suites),
  `internal/chsql`, `test/spec/...`, `test/perf/scaling`. No golden churn —
  no emitted SQL changed.

Closes #2733
