### PR TITLE
fix(ci): gate release PRs on CHANGELOG.md staying current with their own commits

### DIFF
--- a/.github/scripts/prepare-release.mjs
+++ b/.github/scripts/prepare-release.mjs
@@ -36,7 +36,11 @@ export function bumpSemver(version, level) {
 
 // type -> changelog section heading (order matters; unlisted types are dropped
 // from the user-facing changelog but still listed in the PR body's "Other").
-const SECTIONS = [
+// Exported: verify-changelog-fresh.mjs (cerberus#2739) needs the SAME
+// type-to-heading mapping to reconstruct the exact bullets this file itself
+// would generate, so it can check them against what actually landed in
+// CHANGELOG.md rather than trusting the file was regenerated.
+export const SECTIONS = [
   ['feat', 'Added'],
   ['fix', 'Fixed'],
   ['perf', 'Performance'],
@@ -64,7 +68,10 @@ export function parseCommits(subjects) {
   return { groups, breaking }
 }
 
-function bullets(entries) {
+// Exported for the same reason SECTIONS is: verify-changelog-fresh.mjs needs
+// the EXACT bullet text this file would render, not a re-derived
+// approximation that could silently drift from it.
+export function bullets(entries) {
   return entries.map((e) => `- ${e.scope ? `**${e.scope}:** ` : ''}${e.desc}`).join('\n')
 }
 
@@ -156,7 +163,11 @@ function git(args) {
   return execFileSync('git', args, { encoding: 'utf8' })
 }
 
-function commitsSinceLastTag() {
+// Exported: verify-changelog-fresh.mjs re-derives this SAME range at
+// verification time (potentially long after generation, with more commits
+// landed) rather than trusting whatever range produced the committed
+// CHANGELOG.md section still describes the branch's current tip.
+export function commitsSinceLastTag() {
   let range = 'HEAD'
   try {
     const last = git(['describe', '--tags', '--abbrev=0', '--match', 'v*']).trim()
@@ -282,5 +293,9 @@ function selfTest() {
   console.log('::notice::prepare-release --self-test: all assertions passed')
 }
 
-if (process.argv.includes('--self-test')) selfTest()
-else main()
+// Import-safe: verify-changelog-fresh.mjs (cerberus#2739) imports SECTIONS /
+// bullets / commitsSinceLastTag from this module without running it.
+if (process.argv[1] && process.argv[1].endsWith('prepare-release.mjs')) {
+  if (process.argv.includes('--self-test')) selfTest()
+  else main()
+}

--- a/.github/scripts/verify-changelog-fresh.mjs
+++ b/.github/scripts/verify-changelog-fresh.mjs
@@ -60,6 +60,15 @@ export function readAppVersion(chartText) {
   return m[1].trim();
 }
 
+// Escapes every regex metacharacter, not just `.` — appVersion is read from
+// Chart.yaml (readAppVersion), untrusted input as far as this function is
+// concerned, and a partial escape (the earlier `.replace(/\./g, ...)` this
+// replaced) still lets any OTHER metacharacter — a stray `\`, `(`, `*` — warp
+// the compiled pattern instead of matching literally.
+function escapeRegExp(s) {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
 /**
  * Extracts one `## [vX.Y.Z] — <date>` section's body out of a changelog: from
  * that exact heading (any date) to the next `## [` heading, or EOF. Returns
@@ -68,7 +77,7 @@ export function readAppVersion(chartText) {
  * a `## [vX]` section, or nothing was generated for it at all).
  */
 export function extractChangelogSection(text, appVersion) {
-  const headingRe = new RegExp(`^## \\[v${appVersion.replace(/\./g, '\\.')}\\].*$`, 'm');
+  const headingRe = new RegExp(`^## \\[v${escapeRegExp(appVersion)}\\].*$`, 'm');
   const m = headingRe.exec(text);
   if (!m) return null;
   const start = m.index + m[0].length;

--- a/.github/scripts/verify-changelog-fresh.mjs
+++ b/.github/scripts/verify-changelog-fresh.mjs
@@ -1,0 +1,133 @@
+// verify-changelog-fresh.mjs — the freshness half of cerberus#2739.
+//
+// prepare-release.mjs generates CHANGELOG.md's new `[vX.Y.Z]` section, the
+// chart's `artifacthub.io/changes` annotation, and the release PR's body
+// exactly ONCE, at PR-creation time, from the conventional commits between
+// the last tag and the branch tip at that moment. Nothing re-derives or
+// re-checks any of the three against the branch's ACTUAL final commit range
+// before the PR merges — so a commit landing on a release branch afterward
+// (a CI-timeout fix pushed directly, or a `main` merge pulling in an
+// unrelated fix) silently falls out of all three. That happened for real on
+// the v1.19.0 cycle: PR #2736's CHANGELOG section and PR body both omitted
+// two genuine `fix(ci):` commits that landed after the PR opened, caught only
+// because a human happened to notice the PR body looked stale.
+//
+// This script closes the CHANGELOG.md half of that gap: it re-derives the
+// SAME commit range prepare-release.mjs would (commitsSinceLastTag, the
+// identical `--no-merges` `git log` call), re-renders the SAME bullets
+// (parseCommits + bullets, the identical functions, not a re-implementation
+// that could drift from them), and asserts every one of those bullets is
+// present verbatim inside CHANGELOG.md's `[v<appVersion>]` section, where
+// appVersion is read from the release branch's own Chart.yaml. A commit
+// present in the range but absent from the section fails the run with the
+// missing bullet's exact text, so a late-landing fix is caught before merge
+// instead of silently shipping undocumented.
+//
+// Scope: CHANGELOG.md only, not the chart annotation or the PR body — both
+// mirror CHANGELOG.md's own generation and the PR body is free-form prose a
+// maintainer edits, so re-deriving a byte-exact expectation for either would
+// false-positive on legitimate hand-editing. CHANGELOG.md is the one of the
+// three with a stable, mechanically-checkable "commit -> bullet" contract.
+//
+// Wired into pr-hygiene.yml's existing `pr-body` job (a required check that
+// already re-triggers on `synchronize`, i.e. every push to an open PR) as an
+// additional step gated to `release/*` head branches — no new required
+// context to add to branch protection, and it re-runs on exactly the event
+// that can make the CHANGELOG stale again.
+//
+// Env:
+//   CHART_FILE      path to the chart being released; default
+//                    deploy/helm/cerberus/Chart.yaml
+//   CHANGELOG_FILE   path to the changelog; default CHANGELOG.md
+//
+// Exit: 0 when every commit-derived bullet is present; 1 otherwise, or on a
+// missing appVersion / changelog section.
+//
+// node: builtins only — no npm deps, no setup-node needed.
+
+import { readFileSync } from 'node:fs';
+import process from 'node:process';
+import { error, notice } from './lib/gh.mjs';
+import { parseCommits, bullets, SECTIONS, commitsSinceLastTag } from './prepare-release.mjs';
+
+const CHART_FILE = process.env.CHART_FILE || 'deploy/helm/cerberus/Chart.yaml';
+const CHANGELOG_FILE = process.env.CHANGELOG_FILE || 'CHANGELOG.md';
+
+/** Reads `appVersion:` out of a Chart.yaml, matching prepare-release.mjs's own regex. */
+export function readAppVersion(chartText) {
+  const m = /^appVersion:\s*"?([^"\n]+)"?$/m.exec(chartText);
+  if (!m) throw new Error(`${CHART_FILE}: no appVersion: field found`);
+  return m[1].trim();
+}
+
+/**
+ * Extracts one `## [vX.Y.Z] — <date>` section's body out of a changelog: from
+ * that exact heading (any date) to the next `## [` heading, or EOF. Returns
+ * null if the heading is absent — the caller decides whether that is an
+ * error (it always is here: a release branch staging appVersion X must have
+ * a `## [vX]` section, or nothing was generated for it at all).
+ */
+export function extractChangelogSection(text, appVersion) {
+  const headingRe = new RegExp(`^## \\[v${appVersion.replace(/\./g, '\\.')}\\].*$`, 'm');
+  const m = headingRe.exec(text);
+  if (!m) return null;
+  const start = m.index + m[0].length;
+  const rest = text.slice(start);
+  const next = rest.search(/\n## \[/);
+  return next === -1 ? rest : rest.slice(0, next);
+}
+
+/**
+ * Every bullet [renderChangelogSection] would emit for `parsed`, flattened
+ * into one array (not grouped by section) since presence — not position — is
+ * what this check verifies. Mirrors [renderChangelogSection]'s own type loop
+ * rather than importing it directly, because that function also renders the
+ * `### <heading>` lines this check does not need to assert on.
+ */
+export function expectedBullets(parsed) {
+  const out = [];
+  for (const [type] of SECTIONS) {
+    const entries = parsed.groups[type];
+    if (entries && entries.length) out.push(...bullets(entries).split('\n'));
+  }
+  return out;
+}
+
+/** The bullets `sectionText` is missing from `expected`, in `expected`'s own order. */
+export function missingBullets(expected, sectionText) {
+  return expected.filter((b) => !sectionText.includes(b));
+}
+
+function main() {
+  const chartText = readFileSync(CHART_FILE, 'utf8');
+  const appVersion = readAppVersion(chartText);
+
+  const changelogText = readFileSync(CHANGELOG_FILE, 'utf8');
+  const section = extractChangelogSection(changelogText, appVersion);
+  if (section === null) {
+    error(`${CHANGELOG_FILE}: no "## [v${appVersion}]" section — this release branch's own Chart.yaml ` +
+      `stages appVersion ${appVersion}, so a matching section must exist`);
+    process.exit(1);
+  }
+
+  const parsed = parseCommits(commitsSinceLastTag());
+  const expected = expectedBullets(parsed);
+  const missing = missingBullets(expected, section);
+
+  if (missing.length > 0) {
+    error(
+      `${CHANGELOG_FILE}'s [v${appVersion}] section is missing ${missing.length} commit(s) present in the ` +
+        `branch's actual history since the last tag — a commit landed after CHANGELOG.md was generated:\n` +
+        missing.map((b) => `  ${b}`).join('\n') +
+        `\nRegenerate by hand (or re-run prepare-release.yml) so the shipped notes match the shipped commits.`,
+    );
+    process.exit(1);
+  }
+
+  notice(`${CHANGELOG_FILE}: [v${appVersion}] accounts for every commit since the last tag (${expected.length} bullet(s))`);
+}
+
+// Import-safe: the tests import the helpers without running main().
+if (process.argv[1] && process.argv[1].endsWith('verify-changelog-fresh.mjs')) {
+  main();
+}

--- a/.github/scripts/verify-changelog-fresh.test.mjs
+++ b/.github/scripts/verify-changelog-fresh.test.mjs
@@ -53,6 +53,22 @@ test('extractChangelogSection does not cross-match a version that is a PREFIX of
   assert.equal(extractChangelogSection(cl, '1.19.0'), null);
 });
 
+test('extractChangelogSection treats every regex metacharacter in appVersion literally', () => {
+  // appVersion is read straight out of Chart.yaml (readAppVersion) with no
+  // format validation before reaching here, so a malformed value must never
+  // be able to warp the compiled heading pattern — each of these must match
+  // ONLY its own exact, literal heading text, and must not throw.
+  for (const version of ['1.1(9.0', '1.1*9.0', '1\\19.0', '1.19.0)', '1[9].0']) {
+    const heading = `## [v${version}] — 2026-08-30`;
+    const cl = `${heading}\n\n### Fixed\n\n- **x:** ok\n`;
+    assert.doesNotThrow(() => extractChangelogSection(cl, version), `version ${JSON.stringify(version)} must not throw`);
+    assert.match(extractChangelogSection(cl, version), /ok/, `version ${JSON.stringify(version)} must match its own heading`);
+    // A DIFFERENT literal string must not accidentally satisfy the pattern
+    // (e.g. if a metacharacter were left unescaped and matched too broadly).
+    assert.equal(extractChangelogSection(`## [vSOMETHING-ELSE] — 2026-08-30\n`, version), null);
+  }
+});
+
 test('expectedBullets renders exactly what SECTIONS-listed commits would produce, dropping unlisted types', () => {
   const parsed = parseCommits([
     'fix(ci): relieve contention',

--- a/.github/scripts/verify-changelog-fresh.test.mjs
+++ b/.github/scripts/verify-changelog-fresh.test.mjs
@@ -1,0 +1,132 @@
+// verify-changelog-fresh.test.mjs — pins cerberus#2739's freshness gate: a
+// commit landing on a release branch after CHANGELOG.md was generated must
+// be caught, not silently shipped undocumented.
+
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+
+import { parseCommits } from './prepare-release.mjs';
+import { readAppVersion, extractChangelogSection, expectedBullets, missingBullets } from './verify-changelog-fresh.mjs';
+
+test('readAppVersion reads the quoted appVersion Chart.yaml carries', () => {
+  const chart = 'version: 0.15.10\nappVersion: "1.19.0"\n';
+  assert.equal(readAppVersion(chart), '1.19.0');
+});
+
+test('readAppVersion throws when the field is absent', () => {
+  assert.throws(() => readAppVersion('version: 0.15.10\n'), /no appVersion/);
+});
+
+test('extractChangelogSection finds the exact version heading, any date', () => {
+  const cl = [
+    '# Changelog',
+    '',
+    '## [Unreleased]',
+    '',
+    '## [v1.19.0] — 2026-08-30',
+    '',
+    '### Fixed',
+    '',
+    '- **ci:** a fix',
+    '',
+    '## [v1.18.1] — 2026-08-29',
+    '',
+    '### Fixed',
+    '',
+    '- **x:** an older fix',
+  ].join('\n');
+  const section = extractChangelogSection(cl, '1.19.0');
+  assert.match(section, /- \*\*ci:\*\* a fix/);
+  assert.doesNotMatch(section, /an older fix/, 'must stop before the NEXT version heading');
+});
+
+test('extractChangelogSection returns null when the heading is absent', () => {
+  const cl = '# Changelog\n\n## [Unreleased]\n\n## [v1.18.1] — 2026-08-29\n\n### Fixed\n\n- x\n';
+  assert.equal(extractChangelogSection(cl, '1.19.0'), null);
+});
+
+test('extractChangelogSection does not cross-match a version that is a PREFIX of another', () => {
+  // v1.19.0 vs v1.19.0-something would never occur (semver has no such
+  // suffix here), but v1.9.0 vs v1.19.0 sharing "1.9.0" as a substring must
+  // not cross-match — the heading regex anchors the FULL bracketed version.
+  const cl = '## [v1.9.0] — 2026-01-01\n\n### Fixed\n\n- **x:** old\n';
+  assert.equal(extractChangelogSection(cl, '1.19.0'), null);
+});
+
+test('expectedBullets renders exactly what SECTIONS-listed commits would produce, dropping unlisted types', () => {
+  const parsed = parseCommits([
+    'fix(ci): relieve contention',
+    'test(chplan): cover a branch', // NOT in SECTIONS — must be dropped
+    'chore(release): bump versions', // NOT in SECTIONS — must be dropped
+    'docs(promql): fix a comment',
+  ]);
+  const got = expectedBullets(parsed);
+  assert.deepStrictEqual(got, ['- **ci:** relieve contention', '- **promql:** fix a comment']);
+});
+
+test('expectedBullets orders by SECTIONS (Fixed before Documentation), not commit order', () => {
+  const parsed = parseCommits(['docs(x): later doc', 'fix(y): earlier fix']);
+  const got = expectedBullets(parsed);
+  assert.deepStrictEqual(got, ['- **y:** earlier fix', '- **x:** later doc']);
+});
+
+test('missingBullets reports nothing when every expected bullet is present verbatim', () => {
+  const section = '### Fixed\n\n- **ci:** relieve contention\n- **promql:** fix a thing\n';
+  assert.deepStrictEqual(missingBullets(['- **ci:** relieve contention', '- **promql:** fix a thing'], section), []);
+});
+
+test('missingBullets reports the exact bullet a late-landing commit is missing', () => {
+  const section = '### Fixed\n\n- **ci:** relieve contention\n';
+  const missing = missingBullets(['- **ci:** relieve contention', '- **ci:** a SECOND fix that landed later'], section);
+  assert.deepStrictEqual(missing, ['- **ci:** a SECOND fix that landed later']);
+});
+
+test('missingBullets does a substring check, tolerating a trailing PR-number suffix already baked into the bullet', () => {
+  // desc already carries "(#2734)" verbatim (from the commit subject, per
+  // GitHub's squash-merge convention) — the bullet text is compared as one
+  // exact string, not word-by-word, so this is really asserting substring
+  // containment works for the common case, not a special "PR number" path.
+  const section = '### Fixed\n\n- **chsql:** bound emitted SQL at ClickHouse\'s own max_query_size (#2734)\n';
+  assert.deepStrictEqual(
+    missingBullets(["- **chsql:** bound emitted SQL at ClickHouse's own max_query_size (#2734)"], section),
+    [],
+  );
+});
+
+test('end-to-end: a commit added after generation is caught', () => {
+  // Simulates exactly the v1.19.0 incident: CHANGELOG.md generated from an
+  // earlier commit set, then a fix(ci) commit lands on the branch afterward.
+  const changelogAtGenerationTime = [
+    '## [v1.19.0] — 2026-08-30',
+    '',
+    '### Fixed',
+    '',
+    '- **chsql:** bound emitted SQL at ClickHouse\'s own max_query_size (#2734)',
+    '',
+  ].join('\n');
+  const actualCommitsNow = parseCommits([
+    'fix(chsql): bound emitted SQL at ClickHouse\'s own max_query_size (#2734)',
+    "fix(ci): relieve roundtrip-promql-shard's CPU contention and timeout budget",
+  ]);
+  const section = extractChangelogSection(changelogAtGenerationTime, '1.19.0');
+  const missing = missingBullets(expectedBullets(actualCommitsNow), section);
+  assert.deepStrictEqual(missing, ["- **ci:** relieve roundtrip-promql-shard's CPU contention and timeout budget"]);
+});
+
+test('end-to-end: a fully backfilled CHANGELOG passes clean', () => {
+  const changelogBackfilled = [
+    '## [v1.19.0] — 2026-08-30',
+    '',
+    '### Fixed',
+    '',
+    '- **ci:** relieve roundtrip-promql-shard\'s CPU contention and timeout budget',
+    '- **chsql:** bound emitted SQL at ClickHouse\'s own max_query_size (#2734)',
+    '',
+  ].join('\n');
+  const actualCommitsNow = parseCommits([
+    'fix(chsql): bound emitted SQL at ClickHouse\'s own max_query_size (#2734)',
+    "fix(ci): relieve roundtrip-promql-shard's CPU contention and timeout budget",
+  ]);
+  const section = extractChangelogSection(changelogBackfilled, '1.19.0');
+  assert.deepStrictEqual(missingBullets(expectedBullets(actualCommitsNow), section), []);
+});

--- a/.github/workflows/pr-hygiene.yml
+++ b/.github/workflows/pr-hygiene.yml
@@ -60,3 +60,20 @@ jobs:
           PR_BODY: ${{ github.event.pull_request.body }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: node .github/scripts/pr-body-check.mjs
+
+      # cerberus#2739: prepare-release.mjs generates CHANGELOG.md's new
+      # `[vX.Y.Z]` section exactly ONCE, at release-PR-creation time. A commit
+      # landing on the release branch afterward (a hotfix pushed directly, or
+      # a `main` merge) falls out of it silently — this job already re-runs on
+      # `synchronize`, i.e. every such push, so it is the natural place to
+      # catch it. Gated to a `release/` head branch only: an ordinary PR's
+      # CHANGELOG.md has no per-commit contract (only regenerated at release
+      # time — see editChangelog's own "Always-generated policy" comment), so
+      # running this off a release branch would fail on every routine commit.
+      - name: Pin the freshness-gate logic
+        if: startsWith(github.head_ref, 'release/')
+        run: node --test .github/scripts/verify-changelog-fresh.test.mjs
+
+      - name: CHANGELOG.md accounts for every commit since the last tag
+        if: startsWith(github.head_ref, 'release/')
+        run: node .github/scripts/verify-changelog-fresh.mjs


### PR DESCRIPTION
## Summary

Closes #2739, found during the v1.19.0 release ritual — CHANGELOG.md's `[v1.19.0]` section and PR #2736's own body both silently omitted two genuine `fix(ci)` commits that landed on the release branch after `prepare-release.yml` generated both artifacts once, at PR-creation time.

`prepare-release.mjs` never re-checks CHANGELOG.md against the branch's actual final commit range before merge — any release that needs a late-breaking fix (which the release ritual's own ACPR step explicitly anticipates finding) hits the identical gap.

- `verify-changelog-fresh.mjs` re-derives the exact commit range `commitsSinceLastTag()` would (now exported from `prepare-release.mjs`, alongside `SECTIONS` and `bullets`, so this reuses the real generator functions rather than a parallel implementation that could drift from them), re-renders the same bullets, and asserts every one is present verbatim inside CHANGELOG.md's `[v<appVersion>]` section.
- Wired into `pr-hygiene.yml`'s existing `pr-body` job — already a required check, already re-runs on every push to an open PR via `synchronize` — as two steps gated to a `release/` head branch. No new required context to add to branch protection, and it re-runs on exactly the event that can make CHANGELOG.md stale again.
- `prepare-release.mjs` needed one fix to become importable as a library: its bottom `if (--self-test) ... else main()` ran unconditionally at module load, with no import-safety guard (every sibling script in this family checks `process.argv[1]...endsWith(...)` first) — harmless while the file was only ever invoked directly, load-bearing now that another script imports it.

## Test plan

- [x] `node --test .github/scripts/verify-changelog-fresh.test.mjs` (12/12 new tests, including an end-to-end repro of the exact v1.19.0 incident)
- [x] `node --test .github/scripts/*.test.mjs` (953/953, no regressions)
- [x] `node .github/scripts/prepare-release.mjs --self-test` (still passes after the import-safety fix; direct invocation still works)
- [x] `just lint-actions` clean on the workflow change
- [x] Ran the gate against the actual (now-fixed) `release/v1.19.0-chart-0.15.10` branch — passes clean
- [x] merge gate
