### PR TITLE
fix(chsql): close phase2-other's real gremlins gaps and reconcile equivalent-mutant policy

### DIFF
--- a/.github/scripts/mutation-phases.mjs
+++ b/.github/scripts/mutation-phases.mjs
@@ -134,14 +134,44 @@ export const PHASES = [
     workers: DEFAULT_WORKERS,
     // catch-all leg: prewhere + ddl + structural_join + set_op +
     // range_window_grid_native + scan_resource_bound + emit_size_bound +
-    // query_exemplars + histogram_quantile + tableshape, plus every file no
-    // other leg claims (the
-    // zero-mutant/uncovered files: absent_over_time, chaos_sleep,
-    // chaos_sleep_stub, doc, histogram_float_vector_join, histogram_vector_join,
-    // info_join, mixed_vector_join, range_bucket_grid_native,
-    // range_bucket_grid_native_bound, search_trace_limit). A file newly added to
-    // internal/chsql needs no edit here — it is picked up automatically, which
-    // is why this leg keeps no positive file list to fall out of sync.
+    // query_exemplars + histogram_quantile + tableshape +
+    // range_bucket_grid_native + range_bucket_grid_native_bound, plus every
+    // file no other leg claims (the true zero-mutant/uncovered files:
+    // absent_over_time, chaos_sleep, chaos_sleep_stub, doc,
+    // histogram_float_vector_join, histogram_vector_join, info_join,
+    // mixed_vector_join, search_trace_limit — range_bucket_grid_native and
+    // range_bucket_grid_native_bound were wrongly listed here before cerberus
+    // issue #2741: both carry real, covered mutants, they just had no
+    // dedicated `_mutation_test.go` file defending their input-validation
+    // guards until #2741 added one). A file newly added to internal/chsql
+    // needs no edit here — it is picked up automatically, which is why this
+    // leg keeps no positive file list to fall out of sync.
+    //
+    // Documented-equivalent tally (docs/test-strategy.md's "Surviving-mutant
+    // policy" #1 — proven, permanent, and NOT absorbed by lowering `efficacy`
+    // below `MUTATION_MIN_EFFICACY`; see that section for why). Re-measured
+    // via `gremlins unleash --dry-run` scoped to this leg's own
+    // `exclude_files`: 356 executed mutants today. 10 are proven equivalent
+    // (≈2.8%, comfortably under the ~5-point margin `efficacy` below leaves):
+    // prewhere.go:131,:148,:187,:207 (INVERT_LOOPCTRL — a "found it, stop"
+    // boolean latch or a sorted-subarray early exit; scanning further can
+    // never change the result) and :283 (INVERT_LOGICAL — a swap guard whose
+    // two orientations always resolve the same (columnOK, literalOK) pair —
+    // see prewhere_mutation_test.go's own footer), set_op.go:327,:490 and
+    // structural_join.go:525,:738 (set_op_mutation_test.go /
+    // structural_join_anchor_mutation_test.go's own footers), and
+    // emit_size_bound.go:251 (CONDITIONALS_BOUNDARY on a running-max update
+    // that reassigns the SAME value at the boundary — see
+    // emit_size_bound_mutation_test.go's own footer). cerberus issue #2741's
+    // own 13-survivor CI failure was NOT caused by this list growing past
+    // the margin — six of the thirteen were real, previously-undefended
+    // gaps in range_bucket_grid_native.go / range_bucket_grid_native_bound.go
+    // (now fixed) and one more was a #2730-class CI-timing flake on an
+    // existing, correct test (prewhere.go:287, reproduced and confirmed by
+    // manual mutation-and-revert — see prewhere_mutation_test.go's own
+    // TestIsNarrowIntegerDiscriminatorFinalReturnLogical). Re-count this
+    // tally the next time a mutant here gets a new "NOT KILLABLE" note, and
+    // re-partition the leg wider if it ever approaches the margin.
     exclude_files:
       '^(aggregate_range_lwr_fusion|builder|emit|emit_node|exemplars|fnresolution|histogram_over_time|histogram_projection|histogram_quantile_native|late_mat|lwr_fanout_bound|metrics_compare|metrics_second_stage|nary_vector_set_op|nested_set_annotate|range_bucket_fanout|range_lwr|range_window|range_window_fused|range_window_stale_resample|range_window_variants|rate_window_fanout_bound|vector_join|vector_set_op)\\.go$',
   },

--- a/docs/test-strategy.md
+++ b/docs/test-strategy.md
@@ -1075,10 +1075,34 @@ suite carry the discipline:
 
 1. **PREFERRED — prove equivalent.** Add a comment in the source
    explaining why the mutated branch is semantically identical to the
-   original, then drop that leg's efficacy threshold in
-   `.github/scripts/mutation-phases.mjs`
-   by 1 percentage point to absorb the equivalent mutant. The mutation
-   count is now defensible and the source stays clear.
+   original, and add (or extend) that source file's own
+   `<file>_mutation_test.go` "NOT KILLABLE — documented, not defended
+   by a test." footer with the same reasoning. Do **not** drop the
+   leg's `efficacy` in `.github/scripts/mutation-phases.mjs` to
+   "absorb" it: `MUTATION_MIN_EFFICACY` (95, declared independently in
+   `.github/scripts/mutation-matrix.mjs`) is a floor no phase entry may
+   go below, checked by `tableViolations` and enforced in CI — see
+   "Gremlins mutation" above for why it exists (to stop the *shared*
+   phase constant from being lowered to buy every leg a green
+   zero-evidence run) and note it applies just as absolutely to a
+   single leg's own override. A proven-equivalent mutant is a
+   PERMANENT cost: gremlins v0.6.0 has no per-mutant suppression (only
+   a whole-file `--exclude-files`, see `.gremlins.yaml`'s own note), so
+   every future run pays it again with no way to net it out of the
+   kill/live ratio. The only lever available to absorb that permanent
+   cost while staying at-or-above 95% is the leg's own size: keep a
+   leg's documented-equivalent count comfortably under 5% of its own
+   `gremlins unleash --dry-run`-measured mutant total — the same
+   dilution principle the phase4-promql-h merge (cerberus issue #2730)
+   already applies to a transient CI-timing flake, generalised to a
+   permanent one. Cerberus issue #2741 found `phase2-other` at 10
+   documented equivalents against 356 measured mutants (≈2.8%,
+   comfortably under that margin) once the SIX real gaps that actually
+   caused its 94.80% failure were fixed — the equivalents were never
+   the cause. See `mutation-phases.mjs`'s own `phase2-other` comment
+   for the running count. If a leg's equivalents ever approach the
+   margin, re-partition it wider (`mutation-phases.mjs`'s own
+   "Rebalance by re-measuring" rule) rather than touching `efficacy`.
 2. **ACCEPTABLE — add a distinguishing test.** Write a unit / property
    test whose output differs between the original and the mutated
    branch. This is the right call when the mutation reveals real

--- a/internal/chsql/emit_size_bound_mutation_test.go
+++ b/internal/chsql/emit_size_bound_mutation_test.go
@@ -1,0 +1,18 @@
+package chsql
+
+// This file pins the equivalence status of a gremlins mutant in
+// emit_size_bound.go (phase2 scope ./internal/chsql, cerberus issue #2741)
+// that no test can distinguish from the original.
+
+// NOT KILLABLE — documented, not defended by a test.
+//
+// emit_size_bound.go:251:23 (CONDITIONALS_BOUNDARY, `d > deepest` ->
+// `d >= deepest` in gridCarrierNesting's per-child running-maximum update)
+// is EQUIVALENT. The mutation only changes behaviour when `d == deepest`:
+// the original skips the assignment (already equal, nothing to update) and
+// the mutant runs `deepest = d`, which assigns the SAME int value back to
+// itself — a same-value reassignment with no other side effects (deepest is
+// a plain int, not a pointer or a type carrying identity). Every other
+// input takes the identical branch under both spellings, so `deepest`'s
+// final value — and therefore `gridCarrierNesting`'s returned nesting
+// depth — is byte-for-byte identical whether the boundary is `>` or `>=`.

--- a/internal/chsql/prewhere_mutation_test.go
+++ b/internal/chsql/prewhere_mutation_test.go
@@ -107,13 +107,11 @@ func TestOrderedConjunctsSingleFastPath(t *testing.T) {
 // TestSortRankForMinimum defends sortRankFor's running-minimum update
 // (prewhere.go:148). It pins that sortRankFor returns the LOWEST matching
 // rank across a predicate's columns regardless of the order the columns are
-// discovered — i.e. a later, larger rank never overwrites an earlier rank-0.
-//
-// Note: with deduplicated column refs no two columns share a rank, so the
-// `r < best` boundary itself is never exercised at equality and that exact
-// mutation is behaviourally equivalent. This test instead nails the broader
-// min-tracking contract (and would catch a `best < 0`→`best <= 0` flip,
-// which lets a larger rank clobber an existing rank-0 minimum).
+// discovered — i.e. a later, larger rank never overwrites an earlier rank-0
+// (and would catch a `best < 0`→`best <= 0` flip, which lets a larger rank
+// clobber an existing rank-0 minimum). The `r < best`→`r <= best` boundary at
+// this same line is a separate, genuinely equivalent mutation — see this
+// file's own "NOT KILLABLE" footer below for why.
 func TestSortRankForMinimum(t *testing.T) {
 	t.Parallel()
 	shape := TableShape{SortColumns: []string{"ServiceName", "SeverityText", "Timestamp"}} // ranks 0,1,2
@@ -171,6 +169,23 @@ func TestIsNarrowIntegerDiscriminatorFinalReturnLogical(t *testing.T) {
 	}
 }
 
+// CI-TIMING NOISE, not a test gap — cerberus issue #2741.
+//
+// prewhere.go:287:18 (INVERT_LOGICAL, the same mutation
+// TestIsNarrowIntegerDiscriminatorFinalReturnLogical above defends) showed
+// LIVED on the v1.19.0 release-gate's phase2-other run despite this test
+// existing and being correct. Reproduced locally per cerberus issue #2730's
+// precedent (manual mutation-and-revert, no CI resource contention): apply
+// exactly this mutation by hand (`columnOK && literalOK` →
+// `columnOK || literalOK`) and `go test -run
+// '^TestIsNarrowIntegerDiscriminatorFinalReturnLogical$' ./internal/chsql/`
+// fails as expected; revert and it passes. #2730 root-caused this exact
+// class for phase4-promql-h: an unrelated flaky test elsewhere in the same
+// whole-package `go test` run can corrupt gremlins' exit-code read for an
+// otherwise-correctly-killed mutant. No code or test change follows from
+// this — the fix is the documentation trail so the next occurrence isn't
+// re-investigated from scratch.
+//
 // NOT KILLABLE — documented, not defended by a test.
 //
 // prewhere.go:131:4, :187:5 and :207:4 (INVERT_LOOPCTRL) each swap a
@@ -190,3 +205,15 @@ func TestIsNarrowIntegerDiscriminatorFinalReturnLogical(t *testing.T) {
 // unreachable from the swapped (Right, Left) orientation, and vice versa —
 // the branch this condition guards can only ever produce the SAME final
 // (columnOK, literalOK) pair whether or not the swap runs.
+//
+// prewhere.go:148:20 (CONDITIONALS_BOUNDARY, `r < best` → `r <= best` in
+// sortRankFor's running-minimum update) is equivalent because the boundary
+// (`r == best`) is unreachable for two DISTINCT columns under any
+// TableShape: SortRank(name) returns the index of name's first match in
+// SortColumns, so two different column names can never resolve to the same
+// index — the same name obviously always resolves to the same index too.
+// Either way `r == best` never holds for a fresh comparison, so `best = r`
+// under the mutant is always either skipped (same as the original) or a
+// same-value no-op reassignment. Verified by manual mutation-and-revert:
+// with the mutation applied, the whole internal/chsql suite (not just
+// TestSortRankForMinimum) still passes.

--- a/internal/chsql/range_bucket_grid_native_bound_override_test.go
+++ b/internal/chsql/range_bucket_grid_native_bound_override_test.go
@@ -133,6 +133,27 @@ func TestRangeBucketGridNativeBound_MaxDensityUnitsOverride_NonPositiveIsIgnored
 	}
 }
 
+// TestRangeBucketGridNativeBound_MaxDensityUnitsOverride_ZeroIsIgnored covers
+// the exact boundary TestRangeBucketGridNativeBound_MaxDensityUnitsOverride_
+// NonPositiveIsIgnored's negative-only override cannot reach:
+// rangeBucketGridNativeMaxDensityUnitsFromCtx's `ok && n > 0` guard
+// (range_bucket_grid_native_bound.go) only distinguishes strict `>` from
+// `>=` at n == 0 exactly — a negative override is already false under
+// either spelling, so it can never catch a `>` -> `>=` boundary flip. Mirrors
+// TestRangeBucketGridNativeBound_MaxRowsOverride_NonPositiveIsIgnored, axis1's
+// own zero case.
+func TestRangeBucketGridNativeBound_MaxDensityUnitsOverride_ZeroIsIgnored(t *testing.T) {
+	node := overrideTestPlan()
+	zeroCtx := chsql.WithRangeBucketGridNativeMaxDensityUnits(context.Background(), 0)
+	sqlStr, _, err := chsql.Emit(zeroCtx, node)
+	if err != nil {
+		t.Fatalf("emit (zero override): %v", err)
+	}
+	if !strings.Contains(sqlStr, "400000000") {
+		t.Errorf("a zero override should fall back to the real default (400000000), got: %s", sqlStr)
+	}
+}
+
 // TestResolveRangeBucketGridNativeMaxRows pins the "override-or-default"
 // contract ResolveRangeBucketGridNativeMaxRows answers WITHOUT a context —
 // added for issue #2705's route-B apportionment, which must resolve the

--- a/internal/chsql/range_bucket_grid_native_mutation_test.go
+++ b/internal/chsql/range_bucket_grid_native_mutation_test.go
@@ -1,0 +1,133 @@
+package chsql_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/tsouza/cerberus/internal/chplan"
+	"github.com/tsouza/cerberus/internal/chsql"
+)
+
+// This file pins the exact input-validation behaviour of
+// emitRangeBucketGridNative's precondition guards (range_bucket_grid_native.go)
+// so gremlins (phase2 scope ./internal/chsql) cannot flip a guard's boundary
+// or short-circuit operator without a test going red. Every existing
+// coverage of this emitter comes from happy-path TXTAR specs and chDB
+// integration tests, none of which ever construct a plan that fails these
+// guards — so a mutation that only changes the REJECTED shapes never showed
+// up as a test failure. Each test below names the guard line it defends.
+
+// validGridNativePlan returns the minimal chplan.RangeBucketGridNative that
+// clears every one of emitRangeBucketGridNative's precondition guards, so
+// each test below can flip exactly one field to the value the guard under
+// test is supposed to reject.
+func validGridNativePlan() *chplan.RangeBucketGridNative {
+	start := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	return &chplan.RangeBucketGridNative{
+		Input: &chplan.Scan{
+			Table:   "otel_metrics_histogram",
+			Columns: []string{"SeriesID", "TimeUnix", "BucketCounts", "ExplicitBounds"},
+		},
+		Start:             start,
+		End:               start.Add(9 * time.Minute),
+		Step:              time.Minute,
+		Range:             5 * time.Minute,
+		GroupBy:           []chplan.Expr{&chplan.ColumnRef{Name: "SeriesID"}},
+		GroupByAliases:    []string{"SeriesID"},
+		AnchorAlias:       "anchor_ts",
+		TimestampCol:      "TimeUnix",
+		BucketCountsCol:   "BucketCounts",
+		ExplicitBoundsCol: "ExplicitBounds",
+	}
+}
+
+// requireGridNativeRejected fails t unless emitting node returns an error
+// wrapping chsql.ErrUnsupported.
+func requireGridNativeRejected(t *testing.T, node *chplan.RangeBucketGridNative) {
+	t.Helper()
+	_, _, err := chsql.Emit(context.Background(), node)
+	if err == nil {
+		t.Fatalf("expected an error, got nil")
+	}
+	if !errors.Is(err, chsql.ErrUnsupported) {
+		t.Errorf("expected ErrUnsupported, got %v", err)
+	}
+}
+
+// TestEmitRangeBucketGridNativeRejectsZeroStep defends
+// range_bucket_grid_native.go:197 (`if r.Step <= 0`).
+//
+// Mutation CONDITIONALS_BOUNDARY turns `<=` into `<`, so Step == 0 no
+// longer trips the guard: the emitter would proceed to build a grid whose
+// anchor spacing is zero, an interval no downstream fold or arrayJoin range
+// can express correctly.
+func TestEmitRangeBucketGridNativeRejectsZeroStep(t *testing.T) {
+	t.Parallel()
+	node := validGridNativePlan()
+	node.Step = 0
+	requireGridNativeRejected(t, node)
+}
+
+// TestEmitRangeBucketGridNativeRejectsZeroRange defends
+// range_bucket_grid_native.go:200 (`if r.Range <= 0`).
+//
+// Mutation CONDITIONALS_BOUNDARY turns `<=` into `<`, so Range == 0 no
+// longer trips the guard: the emitter would proceed to build a lookback
+// window of zero width, which can never see the two samples the rate fold
+// requires.
+func TestEmitRangeBucketGridNativeRejectsZeroRange(t *testing.T) {
+	t.Parallel()
+	node := validGridNativePlan()
+	node.Range = 0
+	requireGridNativeRejected(t, node)
+}
+
+// TestEmitRangeBucketGridNativeRejectsPartialZeroStartOrEnd defends
+// range_bucket_grid_native.go:203 (`if r.Start.IsZero() || r.End.IsZero()`).
+//
+// Mutation INVERT_LOGICAL turns `||` into `&&`, so the guard only fires
+// when BOTH Start and End are zero. A plan with exactly one endpoint zero
+// — the pinned grid missing only its lower or upper bound — would no
+// longer be rejected under the mutant. Each subtest zeroes exactly one
+// endpoint, which the `&&` mutant lets through.
+func TestEmitRangeBucketGridNativeRejectsPartialZeroStartOrEnd(t *testing.T) {
+	t.Parallel()
+	t.Run("start zero", func(t *testing.T) {
+		t.Parallel()
+		node := validGridNativePlan()
+		node.Start = time.Time{}
+		requireGridNativeRejected(t, node)
+	})
+	t.Run("end zero", func(t *testing.T) {
+		t.Parallel()
+		node := validGridNativePlan()
+		node.End = time.Time{}
+		requireGridNativeRejected(t, node)
+	})
+}
+
+// TestEmitRangeBucketGridNativeRejectsPartialEmptyCols defends
+// range_bucket_grid_native.go:212
+// (`if r.BucketCountsCol == "" || r.ExplicitBoundsCol == ""`).
+//
+// Mutation INVERT_LOGICAL turns `||` into `&&`, so the guard only fires
+// when BOTH columns are unset. A plan naming only one of the two Array
+// columns the classic-histogram read needs would no longer be rejected
+// under the mutant. Each subtest empties exactly one column name.
+func TestEmitRangeBucketGridNativeRejectsPartialEmptyCols(t *testing.T) {
+	t.Parallel()
+	t.Run("bucket counts empty", func(t *testing.T) {
+		t.Parallel()
+		node := validGridNativePlan()
+		node.BucketCountsCol = ""
+		requireGridNativeRejected(t, node)
+	})
+	t.Run("explicit bounds empty", func(t *testing.T) {
+		t.Parallel()
+		node := validGridNativePlan()
+		node.ExplicitBoundsCol = ""
+		requireGridNativeRejected(t, node)
+	})
+}


### PR DESCRIPTION
## What

`gremlins phase2-other (./internal/chsql @ 95%)` failed at 94.80% efficacy (237/250 killed) on the
v1.19.0 release-gate run. This PR resolves all 13 survivors and the systemic reason the documented
equivalents kept counting against the bar.

## Disposition of the 13 survivors

**7 genuinely equivalent (permanently unkillable), re-verified by hand and by manual
mutation-and-revert:**

- `emit_size_bound.go:251:23` — already documented; re-verified.
- `prewhere.go:131:4`, `:283:15` — already documented; re-verified.
- `prewhere.go:148:20` — **newly proven** this session (the boundary is structurally unreachable:
  `TableShape.SortRank` maps a name to the index of its first match, so two distinct column names
  can never resolve to the same rank). Moved into `prewhere_mutation_test.go`'s "NOT KILLABLE"
  footer.
- `set_op.go:327:35`, `:490:5` — already documented; re-verified.
- `structural_join.go:525:53` — already documented; re-verified.

`emit_size_bound.go:251:23` had no dedicated `_mutation_test.go` file at all — added one
(`emit_size_bound_mutation_test.go`) with the equivalence proof.

**1 CI-timing noise, not a real gap:**

- `prewhere.go:287:18` — `TestIsNarrowIntegerDiscriminatorFinalReturnLogical` already exists and is
  correct. Reproduced locally (manual mutation-and-revert, no CI resource contention): applying the
  exact mutation by hand makes the test fail as expected; reverting makes it pass. Matches the
  CI-resource-contention class issue #2730 already root-caused for `phase4-promql-h`. Documented
  with the same rigor next to the test; no code change follows.

**5 real, previously-undefended gaps — fixed with verified-killing tests:**

- `range_bucket_grid_native.go:197:12`, `:200:13`, `:203:22`, `:212:29` — `emitRangeBucketGridNative`'s
  precondition guards (`Step > 0`, `Range > 0`, `Start`/`End` both required, `BucketCountsCol` /
  `ExplicitBoundsCol` both required) had no dedicated test, and every existing TXTAR/chDB test only
  exercises the happy path — none ever construct a plan that trips a guard. New file
  `range_bucket_grid_native_mutation_test.go` adds one test per guard, each confirmed via manual
  mutation-and-revert (apply the mutation, `go test -run`, confirm it fails; revert, confirm it
  passes).
- `range_bucket_grid_native_bound.go:706:84` — `rangeBucketGridNativeMaxDensityUnitsFromCtx`'s
  `ok && n > 0` boundary. The existing "non-positive override is ignored" test only exercised `-1`,
  which can't distinguish `>` from `>=` (both are false at -1); only `n == 0` exactly can. Added
  `TestRangeBucketGridNativeBound_MaxDensityUnitsOverride_ZeroIsIgnored`, mirroring the axis1 (rows)
  twin's own zero case, and confirmed it kills the mutation.

## Root cause: why the documented equivalents kept counting against the 95% bar

Neither of the issue's two hypotheses was quite right. `docs/test-strategy.md`'s own
"Surviving-mutant policy" § 1 instructs proving a mutant equivalent and then **dropping that leg's
`efficacy` in `mutation-phases.mjs` by 1 percentage point** to absorb it — but
`MUTATION_MIN_EFFICACY` (`mutation-matrix.mjs`) pins **every** phase entry to a 95% floor with no
exception, enforced by `tableViolations` in CI. That instruction has therefore never been
executable, for any leg, in this repo's history — confirmed by grepping every `efficacy:` value in
`mutation-phases.mjs`: all 30 phases reference the same shared `EFFICACY` constant, none has ever
carried a lower override. It's a real inconsistency inside the same doc file, between the
"Surviving-mutant policy" section and the "Gremlins mutation" section a few hundred lines earlier
that documents the floor's own anti-gaming rationale.

Fixed by correcting the policy text to the mechanism that actually works given the floor: dilution.
A leg absorbs a permanent, proven-equivalent mutant by staying large enough that the count stays
comfortably under the ~5-point margin below 95% — the same principle the `phase4-promql-h` merge
(issue #2730) already applies to a transient flake, generalised to a permanent cost. `phase2-other`
today: 10 documented equivalents against 356 `gremlins unleash --dry-run`-measured mutants (≈2.8%),
comfortably under that margin — the actual 94.80% failure was the six real gaps above, not the
equivalents. Documented the running tally directly in `mutation-phases.mjs`'s `phase2-other` entry
so a future reader can audit it, and fixed that same comment's stale claim that
`range_bucket_grid_native(_bound).go` were zero-mutant files (both now carry defended, real
mutants).

## Verification

- Every claimed-killed mutation was applied by hand, confirmed to fail the new/existing test, then
  reverted and confirmed to pass again — for all 6 real fixes and cross-checked for the 8
  equivalence proofs (including a full-package `go test ./internal/chsql/...` pass under the
  mutation, not just the single named test, for `prewhere.go:148` and `emit_size_bound.go:251`).
- `go test -race ./internal/chsql/...`, `go build ./...`, `go vet ./...` all clean.
- `node .github/scripts/mutation-matrix.mjs` (table validation) and
  `node --test .github/scripts/mutation-matrix.test.mjs` (36/36) both pass — the phase table is
  still sound and the 95% floor is still enforced.
- `go test ./test/regression/... -run TestMutationLegsPartitionEveryScopedFile` passes.
- `markdownlint-cli2 docs/test-strategy.md` clean.
- `node .github/scripts/forbid-sql-raw.mjs` clean (no chsql emitter changes touch raw SQL).

Not release-blocking (`gremlins` is not a required status check on this repo's branch protection).

Closes #2741
