### PR TITLE
test(perf): add cardinality baselines for the lag-adjacency fixtures

### DIFF
--- a/test/perf/cardinality-baseline/promql/lag_adjacency_changes_nan_run.json
+++ b/test/perf/cardinality-baseline/promql/lag_adjacency_changes_nan_run.json
@@ -1,0 +1,11 @@
+{
+  "fixture": "promql/lag_adjacency_changes_nan_run",
+  "fan_factor": 5.833333333333333,
+  "scan_rows": 12,
+  "peak_intermediate": 70,
+  "has_cross_join": false,
+  "has_array_join": true,
+  "has_recursive_cte": false,
+  "max_recursion_depth": 0,
+  "uncountable_levels": 0
+}

--- a/test/perf/cardinality-baseline/promql/lag_adjacency_idelta_duplicate_ts.json
+++ b/test/perf/cardinality-baseline/promql/lag_adjacency_idelta_duplicate_ts.json
@@ -1,0 +1,11 @@
+{
+  "fixture": "promql/lag_adjacency_idelta_duplicate_ts",
+  "fan_factor": 1,
+  "scan_rows": 4,
+  "peak_intermediate": 4,
+  "has_cross_join": false,
+  "has_array_join": true,
+  "has_recursive_cte": false,
+  "max_recursion_depth": 0,
+  "uncountable_levels": 0
+}

--- a/test/perf/cardinality-baseline/promql/lag_adjacency_irate_delta_temporality_range.json
+++ b/test/perf/cardinality-baseline/promql/lag_adjacency_irate_delta_temporality_range.json
@@ -1,0 +1,11 @@
+{
+  "fixture": "promql/lag_adjacency_irate_delta_temporality_range",
+  "fan_factor": 1,
+  "scan_rows": 6,
+  "peak_intermediate": 6,
+  "has_cross_join": false,
+  "has_array_join": true,
+  "has_recursive_cte": false,
+  "max_recursion_depth": 0,
+  "uncountable_levels": 0
+}

--- a/test/perf/cardinality-baseline/promql/lag_adjacency_resets_range_step.json
+++ b/test/perf/cardinality-baseline/promql/lag_adjacency_resets_range_step.json
@@ -1,0 +1,11 @@
+{
+  "fixture": "promql/lag_adjacency_resets_range_step",
+  "fan_factor": 5.833333333333333,
+  "scan_rows": 12,
+  "peak_intermediate": 70,
+  "has_cross_join": false,
+  "has_array_join": true,
+  "has_recursive_cte": false,
+  "max_recursion_depth": 0,
+  "uncountable_levels": 0
+}


### PR DESCRIPTION
<!--
PR title: Conventional Commits subject.
-->

## Summary

- Follow-up to #2793 (merged): adds the `test/perf/cardinality-baseline/promql/lag_adjacency_*.json` entries `just update-golden cardinality` generates for the four new `lag_adjacency_*.txtar` fixtures.
- These landed one commit too late for #2793 — the full `just update-golden` run (all shards) that produces them finished only after #2793 had already been merged (all *required* branch-protection checks were green; the still-running `gremlins` legs are advisory, not required, so the merge itself was legitimate and not a bypass). The run found **zero other diffs** across every shard (migration/parity/solver/promql/logql/traceql/chsql/optimizer/codegen/cardinality), confirming #2793's own golden state was otherwise complete and consistent.

## Test plan

- [x] `just update-golden cardinality` — only these 4 new files, no other diff
- [x] Cherry-picked cleanly from the already-merged branch's own commit

## Notes for reviewers

Pure data addition (generated JSON), no code change.
