### PR TITLE
feat(promql): lower delta() natively via ts_grid_delta

### DIFF
--- a/cmd/cerberus/main.go
+++ b/cmd/cerberus/main.go
@@ -870,6 +870,7 @@ func buildPerRungAdmission(evalSolver *solver.Solver) *engine.PerRungAdmissionLe
 //	resets    = enabled ? NativeResetsLowerer{Fallback: FanoutResetsLowerer{}} : FanoutResetsLowerer{}
 //	deriv     = enabled ? NativeDerivLowerer{Fallback: FanoutDerivLowerer{}} : FanoutDerivLowerer{}
 //	predict   = enabled ? NativePredictLinearLowerer{Fallback: FanoutPredictLinearLowerer{}} : FanoutPredictLinearLowerer{}
+//	delta     = enabled ? NativeDeltaLowerer{Fallback: FanoutDeltaLowerer{}} : FanoutDeltaLowerer{}
 //	classicHq = enabled ? NativeClassicHistogramWindowLowerer{Fallback: Fanout…{}} : Fanout…{}
 //	rankWalk  = enabled ? NativeQuantileRankWalkLowerer{} : FanoutQuantileRankWalkLowerer{}
 //
@@ -963,6 +964,11 @@ func nativeRangeLowerers(optSet chopt.EnabledSet) promql.RangeLowerers {
 		l.PredictLinear = promql.NativePredictLinearLowerer{Fallback: promql.FanoutPredictLinearLowerer{}}
 	} else {
 		l.PredictLinear = promql.FanoutPredictLinearLowerer{}
+	}
+	if optSet.Has(chopt.FeatureTSGridDelta) {
+		l.Delta = promql.NativeDeltaLowerer{Fallback: promql.FanoutDeltaLowerer{}}
+	} else {
+		l.Delta = promql.FanoutDeltaLowerer{}
 	}
 	// The anchor-injection window-slide mechanism (#2408 follow-up, #2493)
 	// was removed by #2511's root-cause investigation: its anchor-injection

--- a/docs/clickhouse-optimizations.md
+++ b/docs/clickhouse-optimizations.md
@@ -132,6 +132,7 @@ table.
 | `ts_grid_increase`        | 25.9       | experimental | yes        |
 | `ts_grid_histogram`       | 25.9       | experimental | yes        |
 | `quantile_prom_histogram` | 25.10      | experimental | no         |
+| `ts_grid_delta`           | 25.9       | experimental | yes        |
 | `laginframe_adjacency`    | none       | experimental | yes        |
 <!-- END GENERATED: chopt-feature-table -->
 

--- a/internal/chopt/registry.go
+++ b/internal/chopt/registry.go
@@ -311,6 +311,62 @@ const (
 	// memory-vs-cardinality one).
 	FeatureQuantilePromHistogram = "quantile_prom_histogram"
 
+	// FeatureTSGridDelta opts eligible delta(<gauge>[<range>]) query_range
+	// shapes onto the native timeSeriesDeltaToGrid aggregate, retiring the
+	// arrayPopBack/arrayPopFront extrapolated-difference fan-out
+	// (internal/chsql.emitRangeWindowDelta, extrapolationKindDelta). The
+	// floor is 25.9, shared with the rest of the family: timeSeriesDeltaToGrid
+	// shipped in the same 25.6 release as timeSeriesRateToGrid and inherits
+	// the identical left-open/right-closed membership-window fix (PR #86588,
+	// ClickHouse 25.9) FeatureTSGridRange's own doc explains.
+	//
+	// cerberus issue #2745 ran the differential sweep #2744's own delta()
+	// TODO deferred (internal/promql/lower.go and internal/config/config.go
+	// both used to record it verbatim): a battery of chDB probes against
+	// timeSeriesDeltaToGrid directly, isolating each rule the doc
+	// (https://clickhouse.com/docs/sql-reference/aggregate-functions/reference/timeSeriesDeltaToGrid)
+	// leaves underspecified.
+	//
+	//   - DECISIVE counter-reset probe: two samples strictly inside the
+	//     window whose value DECREASES (100 -> 10). A counter-repairing
+	//     implementation (rate/increase's own extrapolatedRate(isCounter=true))
+	//     would add the pre-drop value back, yielding +30 after
+	//     extrapolation; the raw, non-repairing PromQL delta() answer is
+	//     -270. ClickHouse returned exactly -270 — proof the aggregate does
+	//     NOT counter-correct, matching PromQL's
+	//     extrapolatedRate(isCounter=false, isRate=false) exactly, the
+	//     central risk the issue named.
+	//   - Left-open window membership, the >= 2 samples NULL rule, and the
+	//     full Prometheus extrapolation formula INCLUDING the
+	//     averageDurationBetweenSamples/2 clamp branch (not just the common
+	//     "extrapolate fully" branch) were probed with hand-computed
+	//     reference values and matched exactly, to the same floating-point
+	//     bit pattern the closed-form arithmetic predicts.
+	//   - The doc's duplicate-timestamp "highest value wins, NaN loses
+	//     unless all NaN" rule matches for two real values. For a real-vs-NaN
+	//     duplicate pair it is ORDER-DEPENDENT: NaN loses when it is
+	//     inserted before the real sample, but WINS (propagates) when
+	//     inserted after — traced to ClickHouse's own greatest() being
+	//     asymmetric on NaN (greatest(nan, x) = x but greatest(x, nan) =
+	//     nan) and the aggregate's internal dedup folding pairwise in
+	//     encounter order. This is a genuine, reproducible divergence from
+	//     the documented contract, filed as
+	//     https://github.com/tsouza/cerberus/issues/2798 — but it is
+	//     FAMILY-WIDE, not delta-specific: the identical probe against the
+	//     already-shipped, auto-selected timeSeriesRateToGrid reproduces the
+	//     same order-dependence. It therefore does not single out delta()
+	//     for a different AutoSelect posture than its already-auto-selected
+	//     siblings; the narrow, pre-existing gap (a real sample and a NaN
+	//     sample sharing one series' exact timestamp) is tracked, not
+	//     hidden.
+	//
+	// AutoSelect is true: the sweep found no delta-specific divergence from
+	// PromQL — the one real gap it surfaced is a pre-existing, family-wide
+	// ClickHouse tie-break bug already accepted for the auto-selected
+	// rate/increase/resets/deriv/predict_linear siblings, not a reason to
+	// treat delta differently from them.
+	FeatureTSGridDelta = "ts_grid_delta"
+
 	// FeatureLagInFrameAdjacency opts eligible query_range
 	// changes()/resets()/irate()/idelta() matrix shapes onto a single sorted
 	// lagInFrame/leadInFrame annotation pass with fixed-size per-anchor
@@ -519,6 +575,14 @@ var registry = []Feature{
 		Doc:        "opt the classic histogram_quantile rank walk onto the native quantilePrometheusHistogram(phi)(le, cum) aggregate (server >= 25.10, opt-in only via CERBERUS_CH_OPTIMIZATIONS pending fielded validation of the new floor)",
 	},
 	{
+		ID:                         FeatureTSGridDelta,
+		MinVersion:                 Version{Major: 25, Minor: 9},
+		Stability:                  Experimental,
+		AutoSelect:                 true,
+		RequiresExperimentalTSGrid: true,
+		Doc:                        "opt eligible delta(<gauge>[<range>]) shapes onto native timeSeriesDeltaToGrid (experimental maturity, auto-enabled on server >= 25.9 — the left-open window fix; a chDB differential sweep proved no counter-reset correction, matching PromQL)",
+	},
+	{
 		ID:         FeatureLagInFrameAdjacency,
 		MinVersion: AlwaysAvailable,
 		Stability:  Experimental,
@@ -531,7 +595,8 @@ var registry = []Feature{
 // (aggregation_in_order, condition_cache, ts_grid_range, ts_grid_resample,
 // columnar_result_decode, ts_grid_changes, ts_grid_resets, ts_grid_deriv,
 // ts_grid_predict_linear, ts_grid_recollapse, ts_grid_increase,
-// ts_grid_histogram, quantile_prom_histogram, laginframe_adjacency). The copy
+// ts_grid_histogram, quantile_prom_histogram, ts_grid_delta,
+// laginframe_adjacency). The copy
 // keeps the canonical entries immutable from the caller's side. Exposed so
 // tests can enumerate the gates and the docs generator can render the table.
 func Registry() []Feature {

--- a/internal/chopt/resolve_test.go
+++ b/internal/chopt/resolve_test.go
@@ -126,7 +126,7 @@ func TestResolve_Auto_EnablesAutoSelectByVersion(t *testing.T) {
 		t.Fatalf("Resolve: %v", err)
 	}
 	assertSet(t, set, FeatureAggregationInOrder, FeatureConditionCache, FeatureLagInFrameAdjacency,
-		FeatureTSGridRange, FeatureTSGridIncrease, FeatureTSGridResample, FeatureTSGridResets,
+		FeatureTSGridRange, FeatureTSGridIncrease, FeatureTSGridResample, FeatureTSGridResets, FeatureTSGridDelta,
 		FeatureTSGridDeriv, FeatureTSGridPredictLinear, FeatureTSGridRecollapse,
 		FeatureTSGridHistogram)
 	if set.Has(FeatureColumnarResultDecode) {
@@ -163,7 +163,7 @@ func TestResolve_Auto_EmptySelectionDefaultsToAuto(t *testing.T) {
 		t.Fatalf("Resolve: %v", err)
 	}
 	assertSet(t, set, FeatureAggregationInOrder, FeatureConditionCache, FeatureLagInFrameAdjacency,
-		FeatureTSGridRange, FeatureTSGridIncrease, FeatureTSGridResample, FeatureTSGridResets,
+		FeatureTSGridRange, FeatureTSGridIncrease, FeatureTSGridResample, FeatureTSGridResets, FeatureTSGridDelta,
 		FeatureTSGridDeriv, FeatureTSGridPredictLinear, FeatureTSGridRecollapse,
 		FeatureTSGridHistogram)
 	if set.Has(FeatureTSGridChanges) {
@@ -206,11 +206,11 @@ func TestResolve_Auto_VersionBoundaries(t *testing.T) {
 			want:   []string{FeatureAggregationInOrder, FeatureConditionCache, FeatureLagInFrameAdjacency},
 		},
 		{
-			name:   "25.9 adds eight ts_grid_* features (left-open window; ts_grid_changes stays opt-in)",
+			name:   "25.9 adds nine ts_grid_* features (left-open window; ts_grid_changes stays opt-in)",
 			server: v(25, 9),
 			want: []string{
 				FeatureAggregationInOrder, FeatureConditionCache, FeatureLagInFrameAdjacency,
-				FeatureTSGridRange, FeatureTSGridIncrease, FeatureTSGridResample, FeatureTSGridResets,
+				FeatureTSGridRange, FeatureTSGridIncrease, FeatureTSGridResample, FeatureTSGridResets, FeatureTSGridDelta,
 				FeatureTSGridDeriv, FeatureTSGridPredictLinear, FeatureTSGridRecollapse,
 				FeatureTSGridHistogram,
 			},
@@ -354,7 +354,7 @@ func TestResolve_AutoPlusOptIn_UnionsBoth(t *testing.T) {
 	}
 	assertSet(t, set,
 		FeatureAggregationInOrder, FeatureConditionCache, FeatureLagInFrameAdjacency,
-		FeatureTSGridRange, FeatureTSGridIncrease, FeatureTSGridResample, FeatureTSGridResets,
+		FeatureTSGridRange, FeatureTSGridIncrease, FeatureTSGridResample, FeatureTSGridResets, FeatureTSGridDelta,
 		FeatureTSGridDeriv, FeatureTSGridPredictLinear, FeatureTSGridRecollapse,
 		FeatureTSGridHistogram,
 		FeatureColumnarResultDecode)
@@ -513,7 +513,7 @@ func TestResolve_LegacyUnset_NoEffect(t *testing.T) {
 		t.Fatalf("Resolve: %v", err)
 	}
 	assertSet(t, set, FeatureAggregationInOrder, FeatureConditionCache, FeatureLagInFrameAdjacency,
-		FeatureTSGridRange, FeatureTSGridIncrease, FeatureTSGridResample, FeatureTSGridResets,
+		FeatureTSGridRange, FeatureTSGridIncrease, FeatureTSGridResample, FeatureTSGridResets, FeatureTSGridDelta,
 		FeatureTSGridDeriv, FeatureTSGridPredictLinear, FeatureTSGridRecollapse,
 		FeatureTSGridHistogram)
 	if hasDeprecation(warns) {
@@ -529,11 +529,11 @@ func TestRegistry_SeededEntries(t *testing.T) {
 	// columnar_result_decode (a perf tradeoff) and ts_grid_changes (the native
 	// builtin diverges from reference Prometheus on NaN-adjacent windows,
 	// #1721).
-	// RequiresExperimentalTSGrid marks the nine native timeSeries*ToGrid
-	// features (the seven aggregates — rate, increase, resample, changes,
-	// resets, deriv, predict_linear — plus the ts_grid_recollapse shape knob
-	// that rides on the rate one and ts_grid_histogram); the stable/client-side
-	// features leave it false.
+	// RequiresExperimentalTSGrid marks the ten native timeSeries*ToGrid
+	// features (the eight aggregates — rate, increase, resample, changes,
+	// resets, deriv, predict_linear, delta — plus the ts_grid_recollapse shape
+	// knob that rides on the rate one and ts_grid_histogram); the
+	// stable/client-side features leave it false.
 	want := map[string]Feature{
 		FeatureAggregationInOrder:    {ID: FeatureAggregationInOrder, MinVersion: v(24, 8), Stability: Stable, AutoSelect: true, RequiresExperimentalTSGrid: false},
 		FeatureConditionCache:        {ID: FeatureConditionCache, MinVersion: v(25, 3), Stability: Stable, AutoSelect: true, RequiresExperimentalTSGrid: false},
@@ -548,6 +548,7 @@ func TestRegistry_SeededEntries(t *testing.T) {
 		FeatureTSGridRecollapse:      {ID: FeatureTSGridRecollapse, MinVersion: v(25, 9), Stability: Experimental, AutoSelect: true, RequiresExperimentalTSGrid: true},
 		FeatureTSGridHistogram:       {ID: FeatureTSGridHistogram, MinVersion: v(25, 9), Stability: Experimental, AutoSelect: true, RequiresExperimentalTSGrid: true},
 		FeatureQuantilePromHistogram: {ID: FeatureQuantilePromHistogram, MinVersion: v(25, 10), Stability: Experimental, AutoSelect: false, RequiresExperimentalTSGrid: false},
+		FeatureTSGridDelta:           {ID: FeatureTSGridDelta, MinVersion: v(25, 9), Stability: Experimental, AutoSelect: true, RequiresExperimentalTSGrid: true},
 		FeatureLagInFrameAdjacency:   {ID: FeatureLagInFrameAdjacency, MinVersion: AlwaysAvailable, Stability: Experimental, AutoSelect: true, RequiresExperimentalTSGrid: false},
 	}
 	if len(reg) != len(want) {
@@ -567,12 +568,12 @@ func TestRegistry_SeededEntries(t *testing.T) {
 
 func TestResolve_Auto_CapabilityForbidden_DropsNativeKeepsStable(t *testing.T) {
 	// A 25.9 server (every native floor met) whose boot verdict is FORBIDDEN:
-	// auto drops all nine native ts_grid_* features and keeps the non-experimental
-	// stable ones (aggregation_in_order, condition_cache). Eight of the nine are
+	// auto drops all ten native ts_grid_* features and keeps the non-experimental
+	// stable ones (aggregation_in_order, condition_cache). Nine of the ten are
 	// AutoSelect=true and each emits a boot WARN naming the experimental setting
 	// + the fan-out fallback (auto is silent on version skips, but NOT on a
 	// capability block — the operator should see a working deployment lost the
-	// native path). ts_grid_changes is the ninth: it is AutoSelect=false
+	// native path). ts_grid_changes is the tenth: it is AutoSelect=false
 	// (opt-in only, #1721), so auto never even considers it — it is absent from
 	// the resolved set for that reason alone, independent of the capability
 	// verdict, and produces no WARN of its own.
@@ -584,14 +585,14 @@ func TestResolve_Auto_CapabilityForbidden_DropsNativeKeepsStable(t *testing.T) {
 	for _, native := range []string{
 		FeatureTSGridRange, FeatureTSGridIncrease, FeatureTSGridResample, FeatureTSGridChanges, FeatureTSGridResets,
 		FeatureTSGridDeriv, FeatureTSGridPredictLinear, FeatureTSGridRecollapse,
-		FeatureTSGridHistogram,
+		FeatureTSGridHistogram, FeatureTSGridDelta,
 	} {
 		if set.Has(native) {
 			t.Errorf("auto enabled %q on a capability-forbidden server; want it dropped to fan-out", native)
 		}
 	}
-	if len(warns) != 8 {
-		t.Fatalf("want one WARN per capability-dropped AutoSelect=true native feature (8, excludes ts_grid_changes which is opt-in only); got %d: %v", len(warns), warns)
+	if len(warns) != 9 {
+		t.Fatalf("want one WARN per capability-dropped AutoSelect=true native feature (9, excludes ts_grid_changes which is opt-in only); got %d: %v", len(warns), warns)
 	}
 	for _, w := range warns {
 		if !strings.Contains(w, "allow_experimental_time_series_aggregate_functions") || !strings.Contains(w, "fan-out") {

--- a/internal/chopttest/lowerers.go
+++ b/internal/chopttest/lowerers.go
@@ -105,6 +105,11 @@ func BuildRangeLowerers(set chopt.EnabledSet) promql.RangeLowerers {
 	} else {
 		l.PredictLinear = promql.FanoutPredictLinearLowerer{}
 	}
+	if set.Has(chopt.FeatureTSGridDelta) {
+		l.Delta = promql.NativeDeltaLowerer{Fallback: promql.FanoutDeltaLowerer{}}
+	} else {
+		l.Delta = promql.FanoutDeltaLowerer{}
+	}
 
 	// The anchor-injection window-slide mechanism was removed by #2511's
 	// root-cause investigation (structural over-read, see main.go's

--- a/internal/chplan/range_window_grid_native.go
+++ b/internal/chplan/range_window_grid_native.go
@@ -20,13 +20,14 @@ import (
 //     RangeLowerers strategy — never read per query). Default off.
 //   - Func names a member of the timeSeries*ToGrid family a Native*Lowerer
 //     is wired for: "rate", "increase", "changes", "resets", "deriv",
-//     "predict_linear" (see internal/chsql.nativeTSGridFn). "increase"
-//     reuses rate's own timeSeriesRateToGrid aggregate, multiplied back by
-//     the window seconds at emit time — Prometheus's `increase()` IS
-//     `extrapolatedRate()` without the final `/range` divide. "delta" has
-//     no proven-equivalent timeSeries*ToGrid aggregate yet (the
-//     timeSeriesDeltaToGrid + reset-semantics mapping is unverified), so it
-//     stays on the fan-out.
+//     "predict_linear", "delta" (see internal/chsql.nativeTSGridFn).
+//     "increase" reuses rate's own timeSeriesRateToGrid aggregate,
+//     multiplied back by the window seconds at emit time — Prometheus's
+//     `increase()` IS `extrapolatedRate()` without the final `/range`
+//     divide. "delta" rides its own timeSeriesDeltaToGrid aggregate; a chDB
+//     differential sweep proved it applies NO counter-reset correction
+//     (matching PromQL's extrapolatedRate(isCounter=false, isRate=false) —
+//     see chopt.FeatureTSGridDelta's own doc for the sweep's findings).
 //   - The query is in range mode: Step > 0 and both Start and End are
 //     pinned (the materialised query_range grid). Instant queries
 //     (Step == 0) have no grid and are never eligible.
@@ -67,7 +68,7 @@ type RangeWindowGridNative struct {
 	Input Node
 
 	// Func is the PromQL range function ("rate", "increase", "changes",
-	// "resets", "deriv", or "predict_linear" today — see
+	// "resets", "deriv", "predict_linear", or "delta" today — see
 	// internal/chsql.nativeTSGridFn); the field is retained (rather than
 	// implied) so the emitter's per-Func aggregate-name map can generalise
 	// to the rest of the timeSeries*ToGrid family behind its own sibling

--- a/internal/chsql/range_window_grid_native.go
+++ b/internal/chsql/range_window_grid_native.go
@@ -81,6 +81,8 @@ type nativeTSGridAgg struct {
 //   - resets         -> timeSeriesResetsToGrid        (v25.9 — PR #86010, >= 1 sample/window)
 //   - deriv          -> timeSeriesDerivToGrid         (v25.8 — PR #84328, >= 2 samples/window)
 //   - predict_linear -> timeSeriesPredictLinearToGrid (v25.8 — PR #84328, >= 2 samples/window, +predict_offset)
+//   - delta          -> timeSeriesDeltaToGrid         (shipped v25.6, >= 2 samples/window, NO
+//     counter-reset correction — see this map's own "delta" entry doc)
 //
 // changes/resets are COUNT functions (Array(Nullable(Float64)) one count per
 // grid point, NULL where no in-window sample); rate/deriv/predict_linear return
@@ -129,6 +131,24 @@ var nativeTSGridFn = map[string]nativeTSGridAgg{
 	"resets":         {Fn: "timeSeriesResetsToGrid"},
 	"deriv":          {Fn: "timeSeriesDerivToGrid"},
 	"predict_linear": {Fn: "timeSeriesPredictLinearToGrid"},
+	// delta rides its own dedicated aggregate — unlike increase, there IS a
+	// dedicated timeSeriesDeltaToGrid upstream. A chDB differential sweep
+	// (cerberus issue #2745) proved it applies the SAME extrapolation
+	// arithmetic as rate/increase (left-open window membership, the >= 2
+	// samples rule, the Prometheus extrapolatedRate boundary-clamp formula)
+	// but — decisively — NO counter-reset correction: a two-sample window
+	// whose value strictly decreases within the (already window-filtered)
+	// pair returns the raw negative extrapolated difference, never a
+	// reset-repaired positive one, matching PromQL's
+	// extrapolatedRate(isCounter=false, isRate=false) exactly (see
+	// chopt.FeatureTSGridDelta's own doc for the full sweep). StateFn/MergeFn
+	// are deliberately left empty for the same reason increase's are: no
+	// Native*Lowerer sets Recollapse for delta (NativeDeltaLowerer always
+	// calls nativeTSGridMatrixNode with noRecollapse), so
+	// requireRecollapseEmittable rejects any Recollapse a future caller might
+	// mistakenly attach rather than silently re-collapsing a function this
+	// cut never validated the merge for.
+	"delta": {Fn: "timeSeriesDeltaToGrid"},
 }
 
 // nativeGridTsAxisFrag renders the timestamp axis fed as the FIRST aggregate
@@ -316,7 +336,7 @@ func (e *emitter) emitRangeWindowGridNative(r *chplan.RangeWindowGridNative) err
 	}
 	agg, ok := nativeTSGridFn[r.Func]
 	if !ok {
-		return fmt.Errorf("%w: RangeWindowGridNative func %q (supported: rate, increase, changes, resets, deriv, predict_linear)", ErrUnsupported, r.Func)
+		return fmt.Errorf("%w: RangeWindowGridNative func %q (supported: rate, increase, changes, resets, deriv, predict_linear, delta)", ErrUnsupported, r.Func)
 	}
 	// predict_linear threads its future-offset horizon t (whole seconds) as the
 	// 5th parametric arg of timeSeriesPredictLinearToGrid. The PromQL lowering

--- a/internal/chsql/range_window_grid_native_delta_chdb_test.go
+++ b/internal/chsql/range_window_grid_native_delta_chdb_test.go
@@ -1,0 +1,221 @@
+//go:build chdb
+
+// chDB-backed dual-emit parity pin for the experimental native `delta()`
+// lowering (chplan.RangeWindowGridNative, Func="delta"). Mirrors
+// range_window_grid_native_chdb_test.go's rate() proof exactly, swapping the
+// function: the native path renders timeSeriesDeltaToGrid directly (no
+// divide-then-multiply round trip the way increase() rides rate's own
+// aggregate), so this fixture's ULP budget is measured and pinned
+// independently rather than assumed to match rate()'s or increase()'s.
+//
+// Why this is the parity proof. The fan-out's expected_rows are already
+// Prometheus-pinned (test/spec/promql's corpus), so native == fan-out
+// transitively proves native == Prometheus. We compare the DECODED float64
+// (never a string render) at full precision.
+//
+// This is the DIFFERENTIAL half of cerberus issue #2745's sweep — the
+// standalone semantic probes (counter-reset non-correction, extrapolation
+// boundary/clamp, NaN propagation, duplicate-timestamp handling) live in
+// chopt.FeatureTSGridDelta's own doc; this test proves the two EMITTERS
+// agree on the SAME monotonic-counter-shaped seed rate()/increase() already
+// use, over the full query_range grid.
+package chsql_test
+
+import (
+	"context"
+	"database/sql"
+	"math"
+	"testing"
+	"time"
+
+	promparser "github.com/prometheus/prometheus/promql/parser"
+
+	"github.com/tsouza/cerberus/internal/chclient"
+	"github.com/tsouza/cerberus/internal/chsql"
+	"github.com/tsouza/cerberus/internal/chsqltest"
+	"github.com/tsouza/cerberus/internal/optimizer"
+	"github.com/tsouza/cerberus/internal/promql"
+	"github.com/tsouza/cerberus/internal/schema"
+	"github.com/tsouza/cerberus/internal/testsql"
+)
+
+// dualEmitDeltaQuery is the delta() sibling of dualEmitQuery (rate()) /
+// dualEmitIncreaseQuery (increase()), over the SAME seed dualEmitSeed
+// provisions.
+const dualEmitDeltaQuery = `sum by(cerberus_ql) (delta(cerberus_queries_total[5m]))`
+
+// maxDualEmitDeltaUlpDivergentCells / maxDualEmitDeltaUlp are the measured
+// ceilings on the dual-emit fixture: how many of the 18 grid cells (2 series
+// x 9 anchors) differ from the fan-out by any nonzero ULP amount, and the
+// ceiling on how many ULPs any SINGLE cell may diverge by. Measured against
+// the real chDB substrate: unlike rate() (1 ULP on 2/18 cells) and increase()
+// (the SAME 1 ULP on the SAME 2/18 cells — its divide-then-multiply round
+// trip happens to land on the identical rounding), delta()'s
+// timeSeriesDeltaToGrid renders NO divide step at all — it is a pure
+// extrapolated subtraction, the SAME shape the fan-out's own arithmetic
+// takes — and the measured result is 18/18 cells BIT-IDENTICAL, 0 ULP
+// divergence anywhere. The ceilings are pinned at the measured values (0
+// divergent cells; 1 ULP retained as the per-cell ceiling documenting how
+// much slack would be tolerated before failing, though none is used) rather
+// than loosened for headroom — a future divergence fails loudly as a real
+// regression, not silently inside an unused budget.
+const (
+	maxDualEmitDeltaUlp               = 1
+	maxDualEmitDeltaUlpDivergentCells = 0
+)
+
+func TestNativeTSGridDelta_DualEmitParity(t *testing.T) {
+	db := chsqltest.OpenIsolatedChDB(t)
+	if _, err := db.Exec("SET " + chclient.SettingExperimentalTSGridAggregate + " = 1"); err != nil {
+		t.Fatalf("enable experimental ts-grid: %v", err)
+	}
+	for _, stmt := range splitSeedStatements(dualEmitSeed) {
+		if _, err := db.Exec(stmt); err != nil {
+			t.Fatalf("seed: %v\n--- stmt ---\n%s", err, stmt)
+		}
+	}
+
+	hasFn := tsGridDeltaFnPresent(t, db)
+	fanout := runDualEmitDelta(t, db, false, false)
+	if !hasFn {
+		t.Logf("NOTICE: timeSeriesDeltaToGrid absent on this chDB substrate — " +
+			"native parity assertion bypassed (fan-out half still validated). " +
+			"Coverage is reduced but the always-on SQL-shape golden still pins the emit.")
+		return
+	}
+	native := runDualEmitDelta(t, db, true, false)
+
+	// Optimizer-narrowed native scan must be BIT-IDENTICAL to the wide native
+	// scan — same claim range_window_grid_native_chdb_test.go proves for
+	// rate(), re-proven here because delta() reaches ProjectionPushdown
+	// through the identical RangeWindowGridNative node type.
+	nativeOpt := runDualEmitDelta(t, db, true, true)
+	if len(nativeOpt) != len(native) {
+		t.Fatalf("optimized-native row-count divergence: opt=%d wide=%d cells", len(nativeOpt), len(native))
+	}
+	for cell, wv := range native {
+		ov, ok := nativeOpt[cell]
+		if !ok {
+			t.Errorf("cell %+v present in wide native but absent in optimized native (a column was dropped)", cell)
+			continue
+		}
+		if math.Float64bits(ov) != math.Float64bits(wv) {
+			t.Errorf("cell %+v: optimized-native=%.20g wide-native=%.20g NOT bit-identical — "+
+				"the scan narrowing changed a delta value (the narrowing is WRONG)", cell, ov, wv)
+		}
+	}
+	t.Logf("scan-narrowing parity: %d/%d optimized-native cells bit-identical to wide native.", len(native), len(native))
+
+	if len(native) != len(fanout) {
+		t.Fatalf("row-count divergence: native=%d fanout=%d cells", len(native), len(fanout))
+	}
+
+	var (
+		ulpDivergent int
+		maxSeenUlp   uint64
+	)
+	for cell, fv := range fanout {
+		nv, ok := native[cell]
+		if !ok {
+			t.Errorf("cell %+v present in fan-out but absent in native", cell)
+			continue
+		}
+		if math.Float64bits(nv) == math.Float64bits(fv) {
+			continue // bit-identical — allowed, not required
+		}
+		ulps := ulpDistance(nv, fv)
+		if ulps > maxSeenUlp {
+			maxSeenUlp = ulps
+		}
+		if ulps > maxDualEmitDeltaUlp {
+			t.Errorf("cell %+v: native=%.20g fanout=%.20g differ by %d ULP (> %d — arithmetic bug, not float-order noise)",
+				cell, nv, fv, ulps, maxDualEmitDeltaUlp)
+			continue
+		}
+		ulpDivergent++
+		t.Logf("cell %+v: native=%.20g fanout=%.20g differ by %d ULP (within budget %d)",
+			cell, nv, fv, ulps, maxDualEmitDeltaUlp)
+	}
+	if ulpDivergent > maxDualEmitDeltaUlpDivergentCells {
+		t.Errorf("ULP divergence grew to %d cells; documented bound is %d — "+
+			"the native arithmetic drifted further from the fan-out than expected, investigate",
+			ulpDivergent, maxDualEmitDeltaUlpDivergentCells)
+	}
+	t.Logf("dual-emit parity: %d/%d cells bit-identical, %d cells differ by at most %d ULP (max seen %d), "+
+		"within documented bounds (%d cells / %d ULP). native == fan-out == Prometheus to full observable precision.",
+		len(fanout)-ulpDivergent, len(fanout), ulpDivergent, maxDualEmitDeltaUlp, maxSeenUlp,
+		maxDualEmitDeltaUlpDivergentCells, maxDualEmitDeltaUlp)
+}
+
+// runDualEmitDelta mirrors runDualEmit (range_window_grid_native_chdb_test.go)
+// exactly, wiring RangeLowerers.Delta instead of .Rate.
+func runDualEmitDelta(t *testing.T, db *sql.DB, native, optimize bool) map[gridCell]float64 {
+	t.Helper()
+	p := promparser.NewParser(promparser.Options{EnableExperimentalFunctions: true})
+	expr, err := p.ParseExpr(dualEmitDeltaQuery)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	rangeStart := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	rangeEnd := rangeStart.Add(5 * time.Minute)
+	var lowerers promql.RangeLowerers
+	if native {
+		lowerers.Delta = promql.NativeDeltaLowerer{Fallback: promql.FanoutDeltaLowerer{}}
+	}
+	// AggregationTemporalityColumn cleared for the same reason runDualEmit
+	// clears it — though delta() itself never reads it (NativeDeltaLowerer
+	// carries no temporality union-split, unlike rate/increase), this keeps
+	// the seed schema identical across all three dual-emit siblings.
+	s := schema.DefaultOTelMetrics()
+	s.AggregationTemporalityColumn = ""
+	plan, err := promql.LowerAtRangeOpts(context.Background(), expr, s,
+		rangeStart, rangeEnd, 30*time.Second,
+		promql.LowerOpts{Lowerers: lowerers})
+	if err != nil {
+		t.Fatalf("lower (native=%v): %v", native, err)
+	}
+	if optimize {
+		plan = optimizer.Default().Run(context.Background(), plan)
+	}
+	sqlStr, args, err := chsql.Emit(context.Background(), plan)
+	if err != nil {
+		t.Fatalf("emit (native=%v): %v", native, err)
+	}
+	wrapped := "SELECT toJSONString(`Attributes`) AS ql_json, `TimeUnix`, `Value` FROM (" + sqlStr + ")"
+	rows, err := db.Query(wrapped, args...)
+	if err != nil {
+		t.Fatalf("query (native=%v): %v\nSQL: %s", native, err, wrapped)
+	}
+	defer func() { _ = rows.Close() }()
+
+	out := make(map[gridCell]float64)
+	for rows.Next() {
+		var qlJSON string
+		var ts time.Time
+		var v float64
+		if err := rows.Scan(&qlJSON, &ts, &v); err != nil {
+			t.Fatalf("scan (native=%v): %v", native, err)
+		}
+		out[gridCell{ql: extractQLLabel(qlJSON), anchor: ts.UTC().Format(time.RFC3339)}] = v
+	}
+	if err := testsql.TolerantRowsErr(rows.Err()); err != nil {
+		t.Fatalf("rows.Err (native=%v): %v", native, err)
+	}
+	if len(out) == 0 {
+		t.Fatalf("native=%v produced zero rows — the dual-emit fixture must yield a populated grid", native)
+	}
+	return out
+}
+
+// tsGridDeltaFnPresent feature-detects timeSeriesDeltaToGrid via
+// system.functions (the gating fact the native delta path depends on).
+func tsGridDeltaFnPresent(t *testing.T, db *sql.DB) bool {
+	t.Helper()
+	var n int
+	if err := db.QueryRow(
+		"SELECT count() FROM system.functions WHERE name = 'timeSeriesDeltaToGrid'",
+	).Scan(&n); err != nil {
+		t.Fatalf("feature-detect timeSeriesDeltaToGrid: %v", err)
+	}
+	return n > 0
+}

--- a/internal/chsql/range_window_grid_native_scan_bound_test.go
+++ b/internal/chsql/range_window_grid_native_scan_bound_test.go
@@ -96,6 +96,10 @@ var nativeScanBoundCases = map[string]nativeScanBoundCase{
 		query:    "predict_linear(queue_depth[5m], 600)",
 		lowerers: promql.RangeLowerers{PredictLinear: promql.NativePredictLinearLowerer{Fallback: promql.FanoutPredictLinearLowerer{}}},
 	},
+	"delta": {
+		query:    "delta(queue_depth[5m])",
+		lowerers: promql.RangeLowerers{Delta: promql.NativeDeltaLowerer{Fallback: promql.FanoutDeltaLowerer{}}},
+	},
 }
 
 // nativeScanBoundSchema is the default OTel-CH metrics schema with

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -274,9 +274,10 @@ type Config struct {
 	// auto-selected ts_grid_increase feature (reusing timeSeriesRateToGrid,
 	// multiplied back by the window seconds — see
 	// docs/clickhouse-optimizations.md), reachable only via
-	// CERBERUS_CH_OPTIMIZATIONS / auto, not this flag. delta stays on the
-	// fan-out until a dedicated chDB differential sweep proves the
-	// timeSeriesDeltaToGrid mapping.
+	// CERBERUS_CH_OPTIMIZATIONS / auto, not this flag. delta() likewise has
+	// its own auto-selected ts_grid_delta feature (timeSeriesDeltaToGrid,
+	// proven by a chDB differential sweep to apply no counter-reset
+	// correction — see chopt.FeatureTSGridDelta), reachable the same way.
 	ExperimentalTSGridRange bool
 
 	// LogCommentShape, when true, lets the engine stamp ClickHouse

--- a/internal/promql/lower.go
+++ b/internal/promql/lower.go
@@ -3188,37 +3188,39 @@ func lowerRangeVectorCall(c *parser.Call, s schema.Metrics, ctx lowerCtx) (chpla
 // ctx.lowerers.* impl — there is NO feature-flag / version read AND NO
 // nil/presence check here. Every strategy ALWAYS returns a valid lowering:
 // the native/annotation impl emits its own node for a shape-eligible window
-// (rate/changes/resets: timeSeries*ToGrid for a shape-eligible window;
-// changes/resets/irate/idelta: chplan.RangeWindow.LagAdjacency for a
-// shape-eligible window) and delegates to its embedded fan-out fallback for
-// any other shape; the fan-out impl returns this RangeWindow unchanged. All
-// intrinsic SHAPE / AST-node dispatch lives INSIDE the impl. A native node
-// carries the same Func/Range/Step/Start/End/Offset/columns/GroupBy as the
-// fan-out RangeWindow — only the emitter differs — and produces the
-// identical per-(series, anchor) row shape (proven byte-identical on the
-// chDB substrate; see test/spec/promql/native_rate_range_step.txtar and the
+// (rate/increase/changes/resets/deriv/delta: timeSeries*ToGrid for a
+// shape-eligible window; changes/resets/irate/idelta:
+// chplan.RangeWindow.LagAdjacency for a shape-eligible window) and delegates
+// to its embedded fan-out fallback for any other shape; the fan-out impl
+// returns this RangeWindow unchanged. All intrinsic SHAPE / AST-node
+// dispatch lives INSIDE the impl. A native node carries the same
+// Func/Range/Step/Start/End/Offset/columns/GroupBy as the fan-out
+// RangeWindow — only the emitter differs — and produces the identical
+// per-(series, anchor) row shape (proven byte-identical on the chDB
+// substrate; see test/spec/promql/native_rate_range_step.txtar and the
 // dual-emit parity tests).
 //
-// For a window with no dedicated strategy (delta / *_over_time / ...) the
-// Rate strategy's fan-out fallback returns rw unchanged, so the caller's
-// node stays rw and the last/first_over_time name-preservation wrap applies
-// exactly as before. For rate / increase the returned node IS the lowering
-// (native or fan-out RangeWindow); both drop `__name__`, so they never match
-// the name-preservation wrap and flow through as-is.
+// For a window with no dedicated strategy (the *_over_time family and
+// friends) the Rate strategy's fan-out fallback returns rw unchanged, so the
+// caller's node stays rw and the last/first_over_time name-preservation wrap
+// applies exactly as before. For rate / increase / delta the returned node
+// IS the lowering (native or fan-out RangeWindow); all three drop
+// `__name__`, so they never match the name-preservation wrap and flow
+// through as-is.
 //
 // The function family is selected by c.Func.Name — pure AST/func dispatch,
 // NOT a feature/version branch (that decision is baked into WHICH concrete
 // strategy boot wired into each field). Each strategy is always non-nil
 // (withDefaults) and keeps its own intrinsic shape-eligibility inside the
-// impl. rate / increase / changes / resets / irate / idelta each route to
-// their own boot-wired strategy (changes/resets/irate/idelta may resolve to
-// the lagInFrame annotation shape, chplan.RangeWindow.LagAdjacency, layered
-// beneath changes/resets' own native ts_grid strategy; increase reuses
-// rate's timeSeriesRateToGrid aggregate, multiplied back by the window
-// seconds); every other range fn (delta / *_over_time / ...) keeps the
-// fan-out rw via the rate strategy's pass-through (those funcs have no
-// native timeSeries*ToGrid aggregate or lagInFrame annotation proven
-// equivalent yet).
+// impl. rate / increase / changes / resets / deriv / delta / irate / idelta
+// each route to their own boot-wired strategy (changes/resets/irate/idelta
+// may resolve to the lagInFrame annotation shape,
+// chplan.RangeWindow.LagAdjacency, layered beneath changes/resets' own
+// native ts_grid strategy; increase reuses rate's timeSeriesRateToGrid
+// aggregate, multiplied back by the window seconds); every other range fn
+// (the *_over_time family and friends) keeps the fan-out rw via the rate
+// strategy's pass-through (those funcs have no native timeSeries*ToGrid
+// aggregate or lagInFrame annotation proven equivalent yet).
 func lowerRangeVectorCallFanout(c *parser.Call, s schema.Metrics, ctx lowerCtx, rw *chplan.RangeWindow) chplan.Node {
 	applyStepGridFanout(rw, ctx)
 	switch c.Func.Name {
@@ -3234,6 +3236,8 @@ func lowerRangeVectorCallFanout(c *parser.Call, s schema.Metrics, ctx lowerCtx, 
 		return ctx.lowerers.Irate.LowerIrate(rw, s)
 	case "idelta":
 		return ctx.lowerers.Idelta.LowerIdelta(rw, s)
+	case "delta":
+		return ctx.lowerers.Delta.LowerDelta(rw, s)
 	default:
 		return ctx.lowerers.Rate.LowerRate(rw, s)
 	}
@@ -3254,10 +3258,11 @@ func lowerRangeVectorCallFanout(c *parser.Call, s schema.Metrics, ctx lowerCtx, 
 //     (NativeIncreaseLowerer, via the shared nativeTSGridMatrixNode
 //     eligibility funnel — see its own doc), reusing this same
 //     timeSeriesRateToGrid aggregate multiplied back by the window
-//     seconds. delta has no proven-equivalent timeSeries*ToGrid aggregate
-//     yet (the timeSeriesDeltaToGrid + reset-semantics mapping is
-//     unverified), so it stays on the fan-out until a dedicated
-//     differential sweep lands.
+//     seconds. delta() rides its own dedicated lowerer too
+//     (NativeDeltaLowerer, same eligibility funnel, timeSeriesDeltaToGrid —
+//     a differential sweep proved the aggregate applies NO counter-reset
+//     correction, matching PromQL's extrapolatedRate(isCounter=false,
+//     isRate=false), see chopt.FeatureTSGridDelta's own doc).
 //   - The window must be the materialised range grid: Step > 0 and both
 //     Start and End pinned. (The caller only reaches this with rw in
 //     matrix shape, but the guard is explicit so the node's invariants

--- a/internal/promql/lower_strategy.go
+++ b/internal/promql/lower_strategy.go
@@ -178,6 +178,23 @@ type DerivLowerer interface {
 	LowerDeriv(rw *chplan.RangeWindow, s schema.Metrics) chplan.Node
 }
 
+// DeltaLowerer lowers a range-mode delta(<gauge>[range]) RangeWindow to a
+// chplan node, mirroring [ChangesLowerer]: the native impl emits a
+// RangeWindowGridNative (Func="delta" -> timeSeriesDeltaToGrid, the per-window
+// non-counter-corrected extrapolated difference) for an eligible window, the
+// fan-out fallback otherwise. Unlike Rate/Increase there is no
+// AggregationTemporality union-split: delta() is gauge-only in PromQL (it
+// never counter-repairs, matching Prom's extrapolatedRate(isCounter=false,
+// isRate=false) — see chsql.emitRangeWindowDelta / extrapolationKindDelta),
+// so the DELTA-vs-CUMULATIVE runtime branch rate/increase need never applies
+// here. It never returns nil.
+type DeltaLowerer interface {
+	// LowerDelta returns the chplan node for rw — the native RangeWindowGridNative
+	// for a shape the impl handles, or the fan-out lowering otherwise. It never
+	// returns nil.
+	LowerDelta(rw *chplan.RangeWindow, s schema.Metrics) chplan.Node
+}
+
 // PredictLinearLowerer lowers a range-mode predict_linear(<gauge>[range], t)
 // RangeWindow to a chplan node, mirroring [ChangesLowerer]: the native impl
 // emits a RangeWindowGridNative (Func="predict_linear" ->
@@ -230,6 +247,10 @@ type RangeLowerers struct {
 	// timeSeriesPredictLinearToGrid, server >= 25.9). Concrete fan-out impl when
 	// the native path is off; never nil on the lowering path.
 	PredictLinear PredictLinearLowerer
+	// Delta handles range-mode delta(...) shapes (native timeSeriesDeltaToGrid,
+	// server >= 25.9). Concrete fan-out impl when the native path is off; never
+	// nil on the lowering path.
+	Delta DeltaLowerer
 
 	// ClassicHistogram handles the per-series `rate` window stage under the
 	// range-mode classic-histogram quantile idiom (native ladder aggregate,
@@ -282,6 +303,9 @@ func (l RangeLowerers) withDefaults() RangeLowerers {
 	}
 	if l.PredictLinear == nil {
 		l.PredictLinear = FanoutPredictLinearLowerer{}
+	}
+	if l.Delta == nil {
+		l.Delta = FanoutDeltaLowerer{}
 	}
 	if l.ClassicHistogram == nil {
 		l.ClassicHistogram = FanoutClassicHistogramWindowLowerer{}
@@ -717,6 +741,44 @@ func nativePredictLinearHorizonEligible(rw *chplan.RangeWindow) bool {
 	}
 	t := rw.Scalars[0]
 	return t >= 0 && t == math.Trunc(t)
+}
+
+// FanoutDeltaLowerer is the concrete DEFAULT DeltaLowerer: it returns the
+// generic fan-out RangeWindow (emitWindowedArrayExtrapolated's non-counter-
+// corrected extrapolated difference) unchanged. It is the fallback the native
+// impl embeds AND the strategy a fan-out-only deployment wires directly.
+type FanoutDeltaLowerer struct{}
+
+// LowerDelta returns the fan-out RangeWindow rw unchanged.
+func (FanoutDeltaLowerer) LowerDelta(rw *chplan.RangeWindow, _ schema.Metrics) chplan.Node {
+	return rw
+}
+
+// NativeDeltaLowerer is the boot-wired DeltaLowerer that emits the native
+// timeSeriesDeltaToGrid lowering (a chplan.RangeWindowGridNative with
+// Func="delta") for shape-eligible delta range-windows. cmd/cerberus wires it
+// ONLY when chopt resolved the ts_grid_delta feature (server >= 25.9) at
+// boot. It embeds a concrete Fallback for shapes it cannot handle, so the
+// interface method always yields a valid lowering and the dispatch site
+// stays branch-free.
+type NativeDeltaLowerer struct {
+	// Fallback is the concrete lowerer for shapes the native path cannot
+	// handle. Boot wires it to FanoutDeltaLowerer{}.
+	Fallback DeltaLowerer
+}
+
+// LowerDelta returns a RangeWindowGridNative for an eligible range-mode delta
+// shape, or delegates to the embedded Fallback otherwise. Same intrinsic
+// SHAPE check as changes/resets/deriv (delta func, materialised grid, plain
+// Scan/Filter input) — delta takes no scalar, so no extra parameter gate
+// applies, and (like changes/resets/deriv) it carries no -State/-Merge
+// combinator pair, so nativeTSGridMatrixNode is always called with
+// noRecollapse.
+func (n NativeDeltaLowerer) LowerDelta(rw *chplan.RangeWindow, s schema.Metrics) chplan.Node {
+	if native := nativeTSGridMatrixNode(rw, "delta", s, noRecollapse); native != nil {
+		return native
+	}
+	return n.Fallback.LowerDelta(rw, s)
 }
 
 // This section wires the lagInFrame annotation shape (cerberus issue #2759):

--- a/internal/promql/native_strategy_coverage_test.go
+++ b/internal/promql/native_strategy_coverage_test.go
@@ -109,6 +109,13 @@ var nativeStrategies = []nativeStrategy{
 		},
 	},
 	{
+		field:   "Delta",
+		section: "experimental_ts_grid_delta",
+		wire: func(l *promql.RangeLowerers, _ func(string) bool) {
+			l.Delta = promql.NativeDeltaLowerer{Fallback: promql.FanoutDeltaLowerer{}}
+		},
+	},
+	{
 		field:   "Irate",
 		section: "experimental_lag_adjacency_irate",
 		wire: func(l *promql.RangeLowerers, _ func(string) bool) {

--- a/test/perf/cardinality-baseline/promql/native_delta_range_step.json
+++ b/test/perf/cardinality-baseline/promql/native_delta_range_step.json
@@ -1,0 +1,11 @@
+{
+  "fixture": "promql/native_delta_range_step",
+  "fan_factor": 2,
+  "scan_rows": 5,
+  "peak_intermediate": 10,
+  "has_cross_join": false,
+  "has_array_join": true,
+  "has_recursive_cte": false,
+  "max_recursion_depth": 0,
+  "uncountable_levels": 0
+}

--- a/test/perf/solver-decision-baseline/native_delta_range_step/fanout.json
+++ b/test/perf/solver-decision-baseline/native_delta_range_step/fanout.json
@@ -1,0 +1,11 @@
+{
+  "query": "native_delta_range_step/fanout",
+  "lowering": "fanout",
+  "routed": true,
+  "k": 8,
+  "reason": "routed",
+  "n_anchors": 241,
+  "fanout": 20,
+  "cumulative_d": "5m0s",
+  "outer_range": "1h0m0s"
+}

--- a/test/perf/solver-decision-baseline/native_delta_range_step/native.json
+++ b/test/perf/solver-decision-baseline/native_delta_range_step/native.json
@@ -1,0 +1,11 @@
+{
+  "query": "native_delta_range_step/native",
+  "lowering": "native",
+  "routed": false,
+  "k": 0,
+  "reason": "below-threshold",
+  "n_anchors": 241,
+  "fanout": 1,
+  "cumulative_d": "5m0s",
+  "outer_range": "1h0m0s"
+}

--- a/test/perf/solver_decision_ratchet_test.go
+++ b/test/perf/solver_decision_ratchet_test.go
@@ -220,6 +220,8 @@ func nativeLowerers(t *testing.T) promql.RangeLowerers {
 			l.Deriv = promql.NativeDerivLowerer{Fallback: promql.FanoutDerivLowerer{}}
 		case chopt.FeatureTSGridPredictLinear:
 			l.PredictLinear = promql.NativePredictLinearLowerer{Fallback: promql.FanoutPredictLinearLowerer{}}
+		case chopt.FeatureTSGridDelta:
+			l.Delta = promql.NativeDeltaLowerer{Fallback: promql.FanoutDeltaLowerer{}}
 		case chopt.FeatureTSGridHistogram:
 			// Matches cmd/cerberus/main.go's nativeRangeLowerers exactly.
 			l.ClassicHistogram = promql.NativeClassicHistogramWindowLowerer{

--- a/test/regression/parity-enrolment-baselines/promql/baseline.txt
+++ b/test/regression/parity-enrolment-baselines/promql/baseline.txt
@@ -441,6 +441,7 @@ month_default.txtar
 month_of_vector.txtar
 multiple_matchers.txtar
 native_changes_range_step.txtar
+native_delta_range_step.txtar
 native_deriv_range_step.txtar
 native_increase_range_step.txtar
 native_predict_linear_negative_horizon_fanout.txtar

--- a/test/spec/promql/native_delta_range_step.txtar
+++ b/test/spec/promql/native_delta_range_step.txtar
@@ -1,0 +1,97 @@
+# Experimental: ClickHouse-native timeSeriesDeltaToGrid lowering for
+# `sum by (X) (delta(gauge[range]))` in range mode (Step > 0). This is the
+# always-on SQL-shape coverage floor for the `ts_grid_delta` feature: the
+# `experimental_ts_grid_delta` section opts the fixture into
+# RangeLowerers.Delta = NativeDeltaLowerer, so the lowering emits a
+# chplan.RangeWindowGridNative (Func=delta -> timeSeriesDeltaToGrid parametric
+# aggregate + parallel timeSeriesRange axis + ARRAY JOIN + IS NOT NULL filter)
+# instead of the arrayPopBack/arrayPopFront extrapolated-difference fan-out
+# (emitRangeWindowDelta / extrapolationKindDelta). The wrapping outer-sum
+# Aggregate is byte-identical to the fan-out; only the windowed
+# per-grid-point subquery differs. Unlike rate()/increase() there is no
+# AggregationTemporality union split — delta() is gauge-only in PromQL, so
+# NativeDeltaLowerer never reads rw.TemporalityColumn (see its own doc).
+#
+# VERSION FLOOR 25.9 (registry-pinned). timeSeriesDeltaToGrid shipped in the
+# same 25.6 release as timeSeriesRateToGrid and inherits the identical
+# left-open/right-closed membership-window fix (PR #86588, ClickHouse 25.9) —
+# see FeatureTSGridRange's own doc. The native SQL below is a SHAPE golden
+# pinned unconditionally, and the `-- expected_rows --` cell EXECUTES it: the
+# pinned chDB substrate (CHDB_VERSION in the Justfile) clears the floor, so
+# the native emit is numerically asserted here rather than on shape alone.
+#
+# The seed DELIBERATELY dips (300 -> 150 at 00:01:00) so this golden itself
+# is evidence, not just prose, that timeSeriesDeltaToGrid does NOT
+# counter-reset-correct: a repairing implementation would add the drop back;
+# the pinned expected_rows are the raw, non-repaired extrapolated
+# differences (cerberus issue #2745's differential sweep — see
+# chopt.FeatureTSGridDelta's own doc for the full decisive probe). The
+# native==fan-out DIFFERENTIAL lives in the dual-emit parity test
+# (internal/chsql/range_window_grid_native_delta_chdb_test.go), which
+# feature-detects via system.functions so a sub-floor substrate degrades to
+# fan-out-only validation instead of reporting a false green.
+
+-- query.promql --
+sum by(host) (delta(disk_used_bytes[5m]))
+-- parity --
+oracle: prometheus
+endpoint: /api/v1/query_range
+scope: full
+-- range_step --
+30s
+-- experimental_ts_grid_delta --
+-- seed --
+CREATE TABLE otel_metrics_gauge (
+  MetricName String,
+  Attributes Map(String, String),
+  ResourceAttributes Map(String, String) DEFAULT map(),
+  TimeUnix DateTime64(9),
+  Value Float64
+) ENGINE = MergeTree ORDER BY (MetricName, Attributes, TimeUnix);
+-- dip: 100 -> 200 -> 300 -> 150 (dip, NOT a counter reset) -> 400.
+INSERT INTO otel_metrics_gauge (MetricName, Attributes, TimeUnix, Value) VALUES
+  ('disk_used_bytes', map('host', 'a'), toDateTime64('2026-01-01 00:00:00', 9), 100.0),
+  ('disk_used_bytes', map('host', 'a'), toDateTime64('2026-01-01 00:00:30', 9), 200.0),
+  ('disk_used_bytes', map('host', 'a'), toDateTime64('2026-01-01 00:01:00', 9), 300.0),
+  ('disk_used_bytes', map('host', 'a'), toDateTime64('2026-01-01 00:01:30', 9), 150.0),
+  ('disk_used_bytes', map('host', 'a'), toDateTime64('2026-01-01 00:02:00', 9), 400.0);
+-- expected_rows --
+[
+  ["", {"host": "a"}, "2026-01-01T00:00:30Z", 150],
+  ["", {"host": "a"}, "2026-01-01T00:01:00Z", 250],
+  ["", {"host": "a"}, "2026-01-01T00:01:30Z", 58.333333333333336],
+  ["", {"host": "a"}, "2026-01-01T00:02:00Z", 337.5],
+  ["", {"host": "a"}, "2026-01-01T00:02:30Z", 412.5],
+  ["", {"host": "a"}, "2026-01-01T00:03:00Z", 375],
+  ["", {"host": "a"}, "2026-01-01T00:03:30Z", 375],
+  ["", {"host": "a"}, "2026-01-01T00:04:00Z", 375],
+  ["", {"host": "a"}, "2026-01-01T00:04:30Z", 412.5],
+  ["", {"host": "a"}, "2026-01-01T00:05:00Z", 300]
+]
+-- args --
+[0] string = ""
+[1] string = "host"
+[2] string = "host"
+[3] string = "service_name"
+[4] string = "service.name"
+[5] string = "service_name"
+[6] string = "service.name"
+[7] string = "service_name"
+[8] string = ""
+[9] string = "service_name"
+[10] string = "disk_used_bytes"
+[11] string = "disk.used.bytes"
+[12] string = "disk.used/bytes"
+[13] string = "disk.used_bytes"
+[14] string = "disk/used/bytes"
+[15] string = "disk/used_bytes"
+[16] string = "disk_used.bytes"
+-- chplan --
+Project ["" AS MetricName, mapWithoutEmpty(FnMap("host", gkey_0)) AS Attributes, bucket_ts AS TimeUnix, Value AS Value]
+  Aggregate groupBy=[Attributes["host"] AS gkey_0, TimeUnix AS bucket_ts] funcs=[FnSum(Value) AS Value]
+    RangeWindowGridNative func=delta range=5m0s step=30s ts=TimeUnix value=Value groupBy=[Attributes] start=2026-01-01T00:00:00Z end=2026-01-01T00:05:00Z
+      Project [MetricName AS MetricName, FnMapSort(FnMapMerge(FnMapFilter((k, v) -> (k NOT IN ("service_name")), FnMapUpdate(FnMapFromArrays(FnArrayMap(k -> FnRegexReplaceAll(k, "[^a-zA-Z0-9_]", "_"), FnMapKeys(FnMapFilter((k, v) -> (k NOT IN ("service.name", "service_name")), ResourceAttributes))), FnMapValues(FnMapFilter((k, v) -> (k NOT IN ("service.name", "service_name")), ResourceAttributes))), FnMapFromArrays(FnArrayMap(k -> FnRegexReplaceAll(k, "[^a-zA-Z0-9_]", "_"), FnMapKeys(Attributes)), FnMapValues(Attributes)))), FnMapFilter((k, v) -> (v != ""), FnMap("service_name", FnToString(ServiceName))))) AS Attributes, TimeUnix AS TimeUnix, Value AS Value]
+        Filter predicate=(MetricName IN ("disk_used_bytes", "disk.used.bytes", "disk.used/bytes", "disk.used_bytes", "disk/used/bytes", "disk/used_bytes", "disk_used.bytes"))
+          Scan(merge(otel_metrics_gauge|otel_metrics_sum))
+-- sql --
+SELECT ? AS `MetricName`, mapFilter((k, v) -> v != '', map(?, `gkey_0`)) AS `Attributes`, `bucket_ts` AS `TimeUnix`, `Value` AS `Value` FROM (SELECT `Attributes`[?] AS `gkey_0`, `TimeUnix` AS `bucket_ts`, sum(`Value`) AS `Value` FROM (SELECT `Attributes`, toDateTime64(`anchor_ts`, 9) AS `anchor_ts`, toDateTime64(`anchor_ts`, 9) AS `TimeUnix`, toFloat64(assumeNotNull(`grid_val`)) AS `Value` FROM (SELECT `Attributes`, timeSeriesDeltaToGrid(toDateTime(1767225600, 'UTC'), toDateTime(1767225900, 'UTC'), 30, 300)(`TimeUnix`, `Value`) AS `grid`, timeSeriesRange(toDateTime(1767225600, 'UTC'), toDateTime(1767225900, 'UTC'), 30) AS `grid_ts` FROM (SELECT `MetricName` AS `MetricName`, mapSort(mapConcat(mapFilter((k, v) -> (k NOT IN (?)), mapUpdate(mapFromArrays(arrayMap(k -> replaceRegexpAll(k, '[^a-zA-Z0-9_]', '_'), mapKeys(mapFilter((k, v) -> (k NOT IN (?, ?)), `ResourceAttributes`))), mapValues(mapFilter((k, v) -> (k NOT IN (?, ?)), `ResourceAttributes`))), mapFromArrays(arrayMap(k -> replaceRegexpAll(k, '[^a-zA-Z0-9_]', '_'), mapKeys(`Attributes`)), mapValues(`Attributes`)))), mapFilter((k, v) -> (v != ?), map(?, toString(`ServiceName`))))) AS `Attributes`, `TimeUnix` AS `TimeUnix`, `Value` AS `Value` FROM (SELECT * FROM merge(currentDatabase(), '^(otel_metrics_gauge|otel_metrics_sum)$') WHERE (`MetricName` IN (?, ?, ?, ?, ?, ?, ?)))) WHERE `TimeUnix` > toDateTime64('2026-01-01 00:00:00.000000000', 9) - toIntervalNanosecond(300000000000) AND `TimeUnix` <= toDateTime64('2026-01-01 00:05:00.000000000', 9) GROUP BY `Attributes`) ARRAY JOIN `grid` AS `grid_val`, `grid_ts` AS `anchor_ts` WHERE `grid_val` IS NOT NULL) GROUP BY `gkey_0`, `bucket_ts`)


### PR DESCRIPTION
## Summary

- Completes the differential sweep internal/promql/lower.go and internal/config/config.go documented as the precondition for delta() to go native: proves `timeSeriesDeltaToGrid` applies **no counter-reset correction**, matching PromQL `delta()`'s `extrapolatedRate(isCounter=false, isRate=false)` exactly (decisive probe: a within-window decrease from 100 -> 10 returns the raw, non-repaired -270, not the counter-repaired +30).
- Adds chopt feature `ts_grid_delta` (floor 25.9, `AutoSelect: true`), `NativeDeltaLowerer`/`FanoutDeltaLowerer` mirroring `NativeChangesLowerer` (no `AggregationTemporality` union-split — delta is gauge-only; no `-State`/`-Merge` pair, matching the family's other non-recollapse members).
- Wires the feature through `internal/chopt/registry.go`, `internal/promql/lower.go` / `lower_strategy.go`, `cmd/cerberus/main.go`, `internal/chopttest/lowerers.go`, and the spec lane's native-strategy completeness ratchet (`internal/promql/native_strategy_coverage_test.go`).

## The sweep

Isolated `timeSeriesDeltaToGrid` probes against chDB (26.5.1.1), independent of the cerberus lowering machinery, then a dual-emit parity test through the real lowering:

- **Counter-reset (decisive):** two in-window samples decreasing 100 -> 10. Raw (delta) expectation: -270. Counter-repaired (rate/increase-style) expectation: +30. ClickHouse returned exactly -270.
- **Left-open window / >=2-samples / extrapolation formula** (including the `averageDurationBetweenSamples/2` clamp branch, not just the common case): matched Prometheus's `extrapolatedRate` bit-for-bit across every hand-computed scenario.
- **NaN propagation:** a genuine (non-dedup) NaN sample propagates to a NaN result rather than being dropped, matching Prometheus.
- **Duplicate-timestamp "highest value wins":** correct for two real values. For a real-vs-NaN duplicate pair it is **order-dependent** — NaN loses only when it's the first-encountered sample — traced to ClickHouse's own `greatest()` being asymmetric on NaN. This reproduces identically on the already-shipped, auto-selected `timeSeriesRateToGrid`, so it's a pre-existing family-wide gap, not delta-specific. Filed as #2798.
- **Dual-emit parity** (`internal/chsql/range_window_grid_native_delta_chdb_test.go`): native vs. fan-out over the query_range grid rate()/increase() already share — **18/18 cells bit-identical, 0 ULP divergence** (tighter than rate's/increase's own 1-ULP-on-2-cells).

## Testing

- `internal/chsql/range_window_grid_native_delta_chdb_test.go` — chDB dual-emit parity (native == fan-out, bit-identical).
- `test/spec/promql/native_delta_range_step.txtar` — TXTAR SQL-shape + chDB-executed golden, seeded with a deliberate dip (not a counter reset) so the golden itself is evidence of no reset-correction.
- `internal/chopt/resolve_test.go` — registry/auto-select coverage extended for the new feature.
- `just build`, `just lint`, targeted package tests all green locally (see CI for `lint`/`strict-scan`/compat lanes per invariant #5).

Closes #2745
