### PR TITLE
fix(ci): convert chsql's curated mutation legs to include_files allowlists

### DIFF
--- a/.github/scripts/mutation-matrix.mjs
+++ b/.github/scripts/mutation-matrix.mjs
@@ -116,32 +116,43 @@ export function tableViolations(phases) {
       problems.push(`phase "${name}" has a negative or non-integer \`workers\`: ${JSON.stringify(p.workers)}`);
     }
 
+    if (p.include_files !== undefined && p.exclude_files !== undefined) {
+      problems.push(
+        `phase "${name}" declares both \`include_files\` and \`exclude_files\` — a leg owns its file set ` +
+          `one way or the other, never both; the combination is ambiguous about which one gremlins would honour.`,
+      );
+    }
     if (p.exclude_files !== undefined) {
-      problems.push(...excludeViolations(name, p.exclude_files));
+      problems.push(...filePatternViolations(name, 'exclude_files', p.exclude_files));
+    }
+    if (p.include_files !== undefined) {
+      problems.push(...filePatternViolations(name, 'include_files', p.include_files));
     }
   }
 
   return problems;
 }
 
-function excludeViolations(name, pattern) {
+function filePatternViolations(name, field, pattern) {
   const problems = [];
   if (typeof pattern !== 'string' || pattern === '') {
-    problems.push(`phase "${name}" has an empty \`exclude_files\` — omit the key instead of excluding nothing.`);
+    problems.push(`phase "${name}" has an empty \`${field}\` — omit the key instead of matching nothing.`);
     return problems;
   }
   for (const { re, what } of NON_RE2_CONSTRUCTS) {
     if (re.test(pattern)) {
       problems.push(
-        `phase "${name}" \`exclude_files\` uses ${what}, which Go's RE2 engine rejects. gremlins would ` +
-          `error the leg out at run time, after the checkout and toolchain setup have already been paid for.`,
+        `phase "${name}" \`${field}\` uses ${what}, which Go's RE2 engine rejects. \`include_files\` is ` +
+          `resolved into an \`exclude_files\` for gremlins (see resolvePhases), so this check applies to ` +
+          `both fields identically — a non-RE2 construct would error the leg out at run time either way, ` +
+          `after the checkout and toolchain setup have already been paid for.`,
       );
     }
   }
   try {
     new RegExp(pattern);
   } catch (e) {
-    problems.push(`phase "${name}" \`exclude_files\` is not a valid regular expression: ${e.message}`);
+    problems.push(`phase "${name}" \`${field}\` is not a valid regular expression: ${e.message}`);
   }
   return problems;
 }
@@ -382,9 +393,50 @@ export function ownershipViolations({ phases, registryFiles, root = process.cwd(
 // direction for a gate.
 export function phaseClaims(phase, path) {
   if (!underPrefix(path, phase.scope)) return false;
-  if (!phase.exclude_files) return true;
   const rel = normalise(path).slice(normalise(phase.scope).length + 1);
+  if (phase.include_files) return new RegExp(phase.include_files).test(rel);
+  if (!phase.exclude_files) return true;
   return !new RegExp(phase.exclude_files).test(rel);
+}
+
+// resolvePhases — translate every `include_files` leg into an equivalent
+// `exclude_files` gremlins (and the Go partition test's `dump` reader) can
+// consume directly. RE2 has no way to express "match only this small set"
+// without negative lookahead (NON_RE2_CONSTRUCTS bans it), so an include-based
+// leg's real exclude pattern is computed by walking every mutable file
+// actually in its scope and excluding whichever ones `include_files` does NOT
+// match. The output never carries `include_files` — mutation.yml's
+// `matrix.exclude_files` interpolation and the Go test's JSON parse both stay
+// exactly as they are today.
+//
+// This is the one place a NEW file gets classified for free. Today, adding a
+// file to a directory shared by an include-based leg and its siblings means
+// walkMutableGoFiles sees it, it matches none of the static include patterns,
+// so it lands in every include-based leg's DERIVED exclude — i.e. it is
+// excluded from all of them — and falls through to whichever sibling in the
+// group has no `include_files` (the scope's catch-all), the same way a file
+// no exclude_files pattern names already falls through today. No hand edit
+// needed anywhere, closing the gap that let a new chsql file collide across
+// four legs until someone remembered to hand-patch three separate regexes.
+export function resolvePhases(phases, root = process.cwd(), problems = []) {
+  return phases.map((phase) => {
+    if (!phase.include_files) return phase;
+    const directory = normalise(phase.scope);
+    const includeRe = new RegExp(phase.include_files);
+    const excludedStems = [];
+    for (const file of walkMutableGoFiles(root, directory, problems)) {
+      const rel = file.slice(directory.length + 1);
+      if (includeRe.test(rel)) continue;
+      if (!rel.endsWith('.go')) {
+        problems.push(`phase "${phase.phase}": derived exclude cannot express non-.go mutable file "${rel}"`);
+        continue;
+      }
+      excludedStems.push(rel.slice(0, -3).replace(/[.*+?^${}()|[\]\\]/g, '\\$&'));
+    }
+    const { include_files: _includeFiles, ...rest } = phase;
+    if (excludedStems.length === 0) return rest; // this leg's include already claims everything in scope
+    return { ...rest, exclude_files: `^(${excludedStems.sort().join('|')})\\.go$` };
+  });
 }
 
 // selectPhases — the phases this event must run, plus the reason, plus any
@@ -531,14 +583,24 @@ function main() {
   if (problems.length === 0) {
     problems.push(...ownershipViolations({ phases: PHASES, registryFiles: surface.files }));
   }
+  // resolvePhases only produces a well-formed table once PHASES itself is
+  // sound (an include_files leg scoped to a non-directory, say, would make the
+  // walk below meaningless) — but its own derivation can independently fail
+  // (a non-.go mutable file the derived exclude cannot express), so its
+  // problems are validated regardless of ownership state and folded into the
+  // same fatal set.
+  const resolvedPhases = resolvePhases(PHASES, process.cwd(), problems);
   for (const p of problems) error(`mutation-matrix: ${p}`);
   if (problems.length > 0) process.exit(1);
 
   // dump puts the table on stdout and NOTHING else, because a consumer parses
   // that stream as JSON. Validation still runs first: a dump of a table that
-  // would have failed verify is worse than no dump at all.
+  // would have failed verify is worse than no dump at all. Resolved, not raw
+  // PHASES: the Go partition test (and gremlins itself, via emit below) only
+  // ever reads `exclude_files` — an include_files leg's derived equivalent
+  // must reach both the same way a hand-written one would.
   if (mode === 'dump') {
-    process.stdout.write(`${JSON.stringify(PHASES, null, 2)}\n`);
+    process.stdout.write(`${JSON.stringify(resolvedPhases, null, 2)}\n`);
 
     return;
   }
@@ -562,8 +624,13 @@ function main() {
           headSha: process.env.HEAD_SHA,
         });
 
+  // resolvedPhases, not PHASES: selectPhases' own claim-matching is identical
+  // either way (resolvePhases changes how a leg's ownership is EXPRESSED, not
+  // WHICH files it claims), but only the resolved form carries a real
+  // `exclude_files` for the matrix JSON below to interpolate into gremlins'
+  // own CLI invocation.
   const { phases, reason, gaps } = selectPhases({
-    phases: PHASES,
+    phases: resolvedPhases,
     harnessPaths: HARNESS_PATHS,
     registryGlobs: surface.globs,
     eventName,

--- a/.github/scripts/mutation-matrix.test.mjs
+++ b/.github/scripts/mutation-matrix.test.mjs
@@ -17,7 +17,8 @@
 
 import assert from 'node:assert/strict';
 import { execFileSync } from 'node:child_process';
-import { readFileSync } from 'node:fs';
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { basename, join } from 'node:path';
 import { test } from 'node:test';
 
 import {
@@ -32,6 +33,7 @@ import {
   ownershipViolations,
   phaseClaims,
   registryMutableFiles,
+  resolvePhases,
   selectPhases,
   tableViolations,
 } from './mutation-matrix.mjs';
@@ -409,6 +411,60 @@ test('the chsql legs partition the package by exclude_files, one leg per file', 
   // everything no sibling names.
   assert.deepEqual(names(select(['internal/chsql/range_window_grid_native.go'])), ['phase2-other']);
   assert.deepEqual(names(select(['internal/chsql/tableshape.go'])), ['phase2-other']);
+});
+
+test('resolvePhases derives an include_files leg\'s real exclude_files from a directory walk', () => {
+  // cerberus issue #2814: a new file under a scope shared by several
+  // exclude_files-shaped legs matched none of their hand-written patterns and
+  // was therefore claimed by ALL of them (a hard `ownershipViolations`
+  // failure), because an exclude-shaped leg claims anything it does not name.
+  // An include_files-shaped leg cannot make that mistake — a new file is
+  // never in its static allowlist — but gremlins itself only understands
+  // `--exclude-files`, so resolvePhases has to translate the allowlist into
+  // an equivalent denylist by actually walking the scope's real files. This
+  // test proves that translation against a real (temporary) directory, not
+  // just against mutation-phases.mjs's own hand-curated table.
+  // resolvePhases' own `walkMutableGoFiles` joins `root` (process.cwd() below)
+  // with the phase's `scope`, exactly as production scopes do — so the
+  // fixture has to live UNDER cwd, not under the OS tmpdir, or that join
+  // would silently walk the wrong (nonexistent) path.
+  const dir = mkdtempSync(join(process.cwd(), 'mutation-resolve-fixture-'));
+  const scope = `./${basename(dir)}`;
+  try {
+    for (const name of ['owned.go', 'sibling.go', 'shared_test.go']) {
+      writeFileSync(join(dir, name), '// fixture\n');
+    }
+    const phases = [
+      { phase: 'curated', scope, efficacy: 95, workers: 0, include_files: '^owned\\.go$' },
+      { phase: 'catchall', scope, efficacy: 95, workers: 0 },
+    ];
+
+    const resolved = resolvePhases(phases, process.cwd());
+    const curated = resolved.find((p) => p.phase === 'curated');
+    assert.equal(curated.include_files, undefined, 'the resolved leg must not still carry include_files');
+    assert.equal(curated.exclude_files, '^(sibling)\\.go$', 'sibling.go is the only OTHER real .go file in scope');
+
+    // The property under test: a file that exists in neither owned.go's
+    // include pattern NOR the derived exclude pattern (because it did not
+    // exist at derivation time) is claimed by exactly the catch-all — never
+    // by both, and never by neither.
+    writeFileSync(join(dir, 'brand_new.go'), '// added after resolution\n');
+    const reResolved = resolvePhases(phases, process.cwd());
+    const newFilePath = `${basename(dir)}/brand_new.go`;
+    const claimers = reResolved.filter((p) => phaseClaims(p, newFilePath));
+    assert.deepEqual(
+      claimers.map((p) => p.phase),
+      ['catchall'],
+    );
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('resolvePhases leaves an exclude_files (or bare) leg completely untouched', () => {
+  const [rangeLeg] = PHASES.filter((p) => p.phase === 'phase3-optimizer');
+  const [resolved] = resolvePhases([rangeLeg], process.cwd());
+  assert.deepEqual(resolved, rangeLeg);
 });
 
 test('the promql legs partition the package by exclude_files, one leg per file', () => {

--- a/.github/scripts/mutation-phases.mjs
+++ b/.github/scripts/mutation-phases.mjs
@@ -99,8 +99,19 @@ export const PHASES = [
     // range_window_stale_resample(11) + fnresolution(4) +
     // lwr_fanout_bound(2). range_window.go alone is the package's single
     // largest file; the rest of this leg is greedy-balance filler, not theme.
-    exclude_files:
-      '^(absent_over_time|builder|chaos_sleep|chaos_sleep_stub|ddl|doc|emit|emit_node|emit_size_bound|exemplars|histogram_float_vector_join|histogram_over_time|histogram_projection|histogram_quantile|histogram_quantile_native|histogram_quantile_rankwalk_native|histogram_vector_join|info_join|metrics_compare|metrics_second_stage|mixed_vector_join|nary_vector_set_op|nested_set_annotate|prewhere|query_exemplars|range_bucket_grid_native|range_bucket_grid_native_bound|range_lwr|range_window_fixed_accumulator|range_window_fused|range_window_grid_native|range_window_lag_adjacency|range_window_variants|rate_window_fanout_bound|scan_resource_bound|search_trace_limit|set_op|structural_join|tableshape|vector_join|vector_set_op)\\.go$',
+    //
+    // `include_files` (an allowlist), not `exclude_files`: this leg owns a
+    // small, curated set, and an exclude-shaped pattern would have to name
+    // every OTHER file in the package to express that — including files that
+    // do not exist yet. cerberus issue #2814: a new chsql file matched none of
+    // the four legs' hand-written exclude lists and was claimed by all of
+    // them until three separate regexes were hand-patched. An allowlist leg
+    // cannot make that mistake — a new file simply isn't in it — and
+    // resolvePhases (mutation-matrix.mjs) derives the real `exclude_files`
+    // gremlins runs against from this list plus a live directory walk, so a
+    // new file falls straight through to phase2-other's catch-all, exactly
+    // as an existing unclaimed file already does today.
+    include_files: '^(aggregate_range_lwr_fusion|fnresolution|late_mat|lwr_fanout_bound|range_bucket_fanout|range_window|range_window_stale_resample)\\.go$',
   },
   {
     phase: 'phase2-builder',
@@ -111,8 +122,10 @@ export const PHASES = [
     // range_window_variants(31) + vector_join(27) +
     // range_lwr(24) + vector_set_op(10) +
     // nary_vector_set_op(6) + rate_window_fanout_bound(2).
-    exclude_files:
-      '^(absent_over_time|aggregate_range_lwr_fusion|chaos_sleep|chaos_sleep_stub|ddl|doc|emit|emit_node|emit_size_bound|exemplars|fnresolution|histogram_float_vector_join|histogram_over_time|histogram_projection|histogram_quantile|histogram_quantile_native|histogram_quantile_rankwalk_native|histogram_vector_join|info_join|late_mat|lwr_fanout_bound|metrics_compare|metrics_second_stage|mixed_vector_join|prewhere|query_exemplars|range_bucket_fanout|range_bucket_grid_native|range_bucket_grid_native_bound|range_window|range_window_fixed_accumulator|range_window_fused|range_window_grid_native|range_window_lag_adjacency|range_window_stale_resample|scan_resource_bound|search_trace_limit|set_op|structural_join|tableshape)\\.go$',
+    //
+    // `include_files`, not `exclude_files` — see phase2-range's own comment
+    // for why (cerberus issue #2814).
+    include_files: '^(builder|nary_vector_set_op|nested_set_annotate|range_lwr|range_window_variants|rate_window_fanout_bound|vector_join|vector_set_op)\\.go$',
   },
   {
     phase: 'phase2-compare',
@@ -124,8 +137,10 @@ export const PHASES = [
     // range_window_fused(29) + histogram_over_time(25) +
     // histogram_projection(21) + emit(12) +
     // metrics_second_stage(10).
-    exclude_files:
-      '^(absent_over_time|aggregate_range_lwr_fusion|builder|chaos_sleep|chaos_sleep_stub|ddl|doc|emit_size_bound|fnresolution|histogram_float_vector_join|histogram_quantile|histogram_quantile_rankwalk_native|histogram_vector_join|info_join|late_mat|lwr_fanout_bound|mixed_vector_join|nary_vector_set_op|nested_set_annotate|prewhere|query_exemplars|range_bucket_fanout|range_bucket_grid_native|range_bucket_grid_native_bound|range_lwr|range_window|range_window_fixed_accumulator|range_window_grid_native|range_window_lag_adjacency|range_window_stale_resample|range_window_variants|rate_window_fanout_bound|scan_resource_bound|search_trace_limit|set_op|structural_join|tableshape|vector_join|vector_set_op)\\.go$',
+    //
+    // `include_files`, not `exclude_files` — see phase2-range's own comment
+    // for why (cerberus issue #2814).
+    include_files: '^(emit|emit_node|exemplars|histogram_over_time|histogram_projection|histogram_quantile_native|metrics_compare|metrics_second_stage|range_window_fused)\\.go$',
   },
   {
     phase: 'phase2-other',


### PR DESCRIPTION
## Summary

`internal/chsql`'s mutation-testing partition (`phase2-range`/`phase2-builder`/`phase2-compare`/`phase2-other`) used `exclude_files` denylists for the three curated legs: each pattern lists every file it does *not* own. A brand-new file in the directory matched none of those hand-written denylists, so it was claimed by all three curated legs simultaneously (plus the catch-all) — a hard `ownershipViolations`/`mutation-select` failure ("registry-owned but claimed by N mutation phases") that only surfaces once CI runs, requiring someone to hand-patch three separate RE2 alternations to fix. This happened twice tonight, on two different new `internal/chsql` emitter files added by two different feature PRs (#2760, #2761).

This PR converts `phase2-range`/`phase2-builder`/`phase2-compare` from `exclude_files` to `include_files` — an allowlist built directly from each leg's own doc-comment file breakdown (already curated, already documented; this just formalizes it). Since gremlins itself only understands `--exclude-files` (no include flag), a new `resolvePhases()` step in `mutation-matrix.mjs` derives the real `exclude_files` at `emit`/`dump` time by walking the scope's actual files and excluding whatever a leg's `include_files` does *not* match.

**Verified byte-identical**: the derived `exclude_files` for all three converted legs is character-for-character identical to the original hand-written patterns, checked against every one of the 48 real `internal/chsql` files today — zero selection-behavior change for anything that exists now.

**The actual fix**, proven directly: a synthetic brand-new file (not in any leg's pattern) is now claimed by exactly one leg — the catch-all — with zero manual edits, instead of colliding across all three curated legs the way `range_window_fixed_accumulator.go` and `range_window_sorted_slab.go` both did tonight.

## Scope

Converts only the `internal/chsql` phase2 group (the twice-proven concrete case tonight). `internal/promql` (`phase4-promql-a` through `-i`), `internal/logql`, and `internal/traceql` use the identical `exclude_files`-denylist shape and are equally exposed — tracked as follow-up in #2814, not bundled here, to keep this PR's equivalence proof (byte-identical derived patterns against every real file) tight to one scope.

## Test plan

- [x] `node .github/scripts/mutation-matrix.mjs verify` — table sound, 30 phases
- [x] `node --test .github/scripts/mutation-matrix.mjs` — all 38 tests pass, including 2 new ones:
  - `resolvePhases derives an include_files leg's real exclude_files from a directory walk` — proves the derivation against a real temp-directory fixture, including the exact new-file-safety property this PR exists to fix
  - `resolvePhases leaves an exclude_files (or bare) leg completely untouched`
- [x] Equivalence check (scratch script, not committed): every one of the 48 real `internal/chsql` files claims the identical leg set before and after this change; the three converted legs' derived `exclude_files` strings are byte-identical to the originals
- [x] Direct reproduction of the fix: a synthetic new file is claimed by exactly `phase2-other`, not all four legs
- [x] `go test -run '^TestMutationLegsPartitionEveryScopedFile$' ./test/regression/` — passes
- [x] `go test -run '^TestReleaseRequiredChecksAllHaveAMaintenanceTrigger$|^TestEveryRequiredContextPostsOnTheMergeGroup$' ./test/regression/` — passes
- [x] `go build ./...` clean
- [x] `node .github/scripts/forbid-sql-raw.mjs` clean (N/A to this change, run anyway)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
