### PR TITLE
feat(schema): curate benchmarked column compression codecs

### DIFF
--- a/docs/operations.md
+++ b/docs/operations.md
@@ -1211,6 +1211,108 @@ maintenance window, not the boot path. Track progress in `system.mutations`
 (the `is_done` / `parts_to_do` columns), same as the projection and index
 runbooks above.
 
+### Curated column compression codecs (cerberus issue #2768)
+
+Auto-create also installs two curated `MODIFY COLUMN` codec ALTERs, retuning
+the upstream OTel-CH exporter template's own compression codec choice on two
+columns benchmarked against real production-shaped data:
+
+```sql
+ALTER TABLE <db>.otel_logs   MODIFY COLUMN IF EXISTS Body     CODEC(ZSTD(3))
+ALTER TABLE <db>.otel_traces MODIFY COLUMN IF EXISTS Duration CODEC(GCD, ZSTD(1))
+```
+
+Unlike `ADD PROJECTION` / `ADD INDEX` / `ADD STATISTICS` above, `MODIFY
+COLUMN` has no `IF NOT EXISTS`-shaped guard — only `IF EXISTS`, which is a
+no-op on an absent column (e.g. a signal not yet auto-created), not on an
+unchanged one. Re-running the identical statement is still safe to do on
+every boot: ClickHouse compares the declared codec against the column's
+current one and only schedules work when they actually differ, so applying
+this repeatedly never re-triggers a conversion once the codec has converged
+— verified directly against a live server (both a 24.8 floor container and
+the auto-create integration test's 25.9 container): re-issuing the same
+`MODIFY COLUMN ... CODEC(...)` statement twice in a row produces no error
+and no additional mutation.
+
+**Only two of the issue's proposed candidates survived measurement.** Every
+candidate was benchmarked — not just reasoned about — against real
+production-shaped sample data (`test/perf/nightly/testdata/samples/`,
+issue #2411) or, where no real sample exists (span Duration — traces are
+outside that sample set's scope), representative synthetic data, via a real
+MergeTree engine (chDB), comparing whole-table compressed bytes before/after
+the codec swap:
+
+- **Adopted — Logs Body:** `ZSTD(3)` measured ~1.3%-1.8% smaller than the
+  upstream `ZSTD(1)` default on a representative leveled-log-line corpus,
+  consistently across repeated runs. ZSTD's decode cost is level-independent,
+  so this costs write-side CPU only — no read-side query latency impact.
+- **Adopted — Span Duration:** `GCD, ZSTD(1)` (no Delta stage) measured a
+  real ~3.5% win when real precision is coarser than the column's declared
+  nanosecond resolution (the issue's own stated GCD rationale), and was a
+  statistical no-op (+0.02%, measurement noise) when precision is genuinely
+  fine-grained — GCD finds no common divisor when there isn't one, so it
+  costs nothing on a deployment whose real Duration values don't carry the
+  coarse-precision pattern this codec targets. Chaining a `Delta` stage
+  ahead of ZSTD — either `Delta, ZSTD(1)` alone or the issue's own proposed
+  `GCD, Delta, ZSTD(1)` pairing — measured 3%-10% LARGER instead: Duration
+  values are independent per-span measurements, not a running sequence, so
+  delta-encoding them adds entropy rather than removing it.
+- **NOT adopted — metrics TimeUnix / span Timestamp (`DateTime64(9)`):** the
+  issue proposed `DoubleDelta, ZSTD(1)`, reasoning that a near-constant
+  scrape interval leaves second-order regularity DoubleDelta captures and
+  Delta alone misses. Measured against three real metrics tables
+  (gauge/sum/histogram) it was 43%-166% LARGER than the current
+  `Delta, ZSTD(1)` — a regression: a near-constant Delta stream is already
+  maximally redundant (the same interval repeated for most of a series'
+  run), which `ZSTD(1)` alone already exploits about as well as physically
+  possible (232x-443x compression measured); DoubleDelta's own per-value
+  framing bytes break up that redundancy more than they remove. `GCD, Delta,
+  ZSTD(1)` measured a small, INCONSISTENT effect across the three tables
+  (-3.5% to -6.9% on sum/histogram, +9.2% on gauge) — not a safe blanket win
+  across every metrics table sharing one codec declaration. Bare `GCD,
+  ZSTD(1)` measured catastrophically worse (+650% to +3515%). TimeUnix and
+  Timestamp keep their current `Delta, ZSTD(1)`, unchanged by this issue.
+- **NOT adopted — Value (gauge/sum) / Sum (histogram/summary/exp_histogram)
+  Float64:** the issue gated Gorilla/FPC adoption on beating `ZSTD(1)` on
+  real gauge-shaped data. Measured against the same three tables, BOTH
+  regressed — Gorilla 27%-2182% larger, FPC 84%-2662% larger — so neither is
+  adopted; Value / Sum keep `ZSTD(1)`, unchanged.
+
+See the codec-tuning PR (cerberus issue #2768) for the full benchmark
+transcript and measured numbers. Cerberus issue #2822 tracks the one
+candidate the issue explicitly deferred rather than benchmarked here:
+experimental ALP for Value/Sum, earmarked for a future `>= 26.8` version
+floor (its 26.8 Float32 arithmetic change is a live on-disk decode-compat
+risk below that floor).
+
+All codecs used above are supported at ClickHouse >= 22.9, well under this
+repo's 24.8 version floor (`docs/toolchain.md`), so — like `ADD PROJECTION`
+/ `ADD INDEX` above, and unlike `ADD STATISTICS`'s chopt-gated
+`column_statistics` feature — this registry renders **unconditionally**: no
+config flag, no chopt feature gate.
+
+A codec change is metadata-only for **new parts only**; existing parts keep
+their prior codec until a background merge (or an operator-run `OPTIMIZE
+... FINAL`) rewrites them.
+
+#### One-time `OPTIMIZE ... FINAL` back-fill
+
+Unlike the projection / index / statistics ALTERs above, ClickHouse has no
+dedicated `MATERIALIZE`-style mutation for a codec change — the general
+mechanism is a full part rewrite:
+
+```sql
+OPTIMIZE TABLE <db>.otel_logs   FINAL;
+OPTIMIZE TABLE <db>.otel_traces FINAL;
+```
+
+**Cost / caveat.** Unlike `MATERIALIZE PROJECTION` / `MATERIALIZE INDEX` /
+`MATERIALIZE STATISTICS`, which each touch only their own narrow slice of a
+part, `OPTIMIZE ... FINAL` reads and rewrites the **entire table**, not just
+the recoded column — budget accordingly on a large table, and prefer letting
+normal background merges converge new codecs onto old parts over time rather
+than forcing an immediate rewrite unless the storage win is needed sooner.
+
 ### DELTA-prefix aggregate table + backfill (cerberus issue #2389)
 
 Auto-create can also provision an **opt-in, cerberus-owned** table + materialized

--- a/internal/chsql/builder.go
+++ b/internal/chsql/builder.go
@@ -2083,6 +2083,18 @@ func Call(name string, args ...Frag) Frag {
 	}
 }
 
+// Codec returns a Frag rendering "CODEC(<stage0>, <stage1>, ...)" — a
+// ClickHouse column compression codec clause. Each stage is a codec
+// identifier: BareIdent("DoubleDelta") for a no-argument codec
+// (Delta / DoubleDelta / GCD / Gorilla / FPC without an explicit level),
+// or Call("ZSTD", InlineLit(1)) for a parameterized one — so
+// Codec(BareIdent("DoubleDelta"), Call("ZSTD", InlineLit(1))) renders
+// "CODEC(DoubleDelta, ZSTD(1))". Used by
+// chsql.AlterTableModifyColumnCodec (cerberus issue #2768).
+func Codec(stages ...Frag) Frag {
+	return Call("CODEC", stages...)
+}
+
 // Parametric returns a Frag rendering a CH parametric aggregate
 // "<name>(<p0>, <p1>, ...)(<a0>, <a1>, ...)" — e.g. quantile(0.5)(col).
 // name is a trusted literal (same trust contract as Call / Cast).

--- a/internal/chsql/ddl.go
+++ b/internal/chsql/ddl.go
@@ -659,6 +659,93 @@ func (a *ModifyColumnBuilder) SQL() string {
 	return RenderDDL(a.frag())
 }
 
+// --- ALTER TABLE ... MODIFY COLUMN ... CODEC surface (cerberus issue #2768) ---
+//
+// ModifyColumnCodecBuilder renders
+// `ALTER TABLE [<db>.]<table> [ON CLUSTER x] MODIFY COLUMN IF EXISTS <col>
+// CODEC(...)` — retuning ONLY a column's compression codec, deliberately
+// WITHOUT re-declaring its type: ClickHouse's MODIFY COLUMN grammar treats
+// [type] as optional (https://clickhouse.com/docs/sql-reference/statements/alter/column#modify-column),
+// so a codec-only change never needs to duplicate a type fact the upstream
+// OTel-CH exporter template already owns (see this package's doc comment) —
+// unlike ModifyColumnBuilder above, which exists specifically to retype a
+// column and so must carry one.
+//
+// A codec change is legal on a sorting-key column and applies to NEW parts
+// only; existing parts keep their original codec until a background merge
+// (or an operator-run `OPTIMIZE ... FINAL`) rewrites them — see
+// docs/operations.md. Re-running the identical MODIFY COLUMN CODEC
+// statement is a no-op: ClickHouse compares the declared codec against the
+// column's current one and only schedules work when they actually differ,
+// so applying this on every boot never re-triggers a conversion once the
+// codec has converged. IF EXISTS is the only guard the statement itself
+// carries — it makes MODIFY a no-op on a column that doesn't exist (e.g. a
+// signal not yet auto-created); the safety of re-running it against an
+// ALREADY-CONVERGED column comes entirely from ClickHouse's own
+// no-op-on-unchanged behavior above, not from any guard clause cerberus
+// writes — there is no `IF NOT EXISTS`-shaped guard for MODIFY COLUMN.
+//
+// Like the other DDL builders it binds no positional `?` values, so SQL
+// renders through RenderDDL.
+
+// ModifyColumnCodecBuilder builds an ALTER TABLE MODIFY COLUMN CODEC
+// statement.
+type ModifyColumnCodecBuilder struct {
+	database string // "" => unqualified table reference
+	table    string
+	column   string
+	cluster  string // "" => no ON CLUSTER clause
+	codec    Frag
+}
+
+// AlterTableModifyColumnCodec starts a MODIFY COLUMN CODEC builder retuning
+// the compression codec of <column> on [<database>.]<table> to codec — a
+// Frag built via Codec, e.g. Codec(BareIdent("DoubleDelta"),
+// Call("ZSTD", InlineLit(1))). An empty database emits no qualifier, so a
+// table the connection's own database owns is referenced bare.
+func AlterTableModifyColumnCodec(database, table, column string, codec Frag) *ModifyColumnCodecBuilder {
+	return &ModifyColumnCodecBuilder{database: database, table: table, column: column, codec: codec}
+}
+
+// OnCluster adds an `ON CLUSTER <name>` clause so the ALTER replicates the
+// same way the CREATE statements do under a classic ON CLUSTER deployment.
+// A Replicated database replicates the DDL itself and needs no clause.
+func (a *ModifyColumnCodecBuilder) OnCluster(name string) *ModifyColumnCodecBuilder {
+	a.cluster = name
+	return a
+}
+
+// frag assembles the statement from typed pieces: keyword tokens via
+// ddlToken, bare database/table identifiers via BareIdent, the quoted
+// column via Col, the optional ON CLUSTER clause via the typed constructor,
+// and the codec via the caller's Frag (built via Codec) — no raw token is
+// written here, and no type is emitted (see the package doc comment above).
+func (a *ModifyColumnCodecBuilder) frag() Frag {
+	return func(b *Builder) {
+		ddlToken("ALTER TABLE ")(b)
+		if a.database != "" {
+			BareIdent(a.database)(b)
+			ddlToken(".")(b)
+		}
+		BareIdent(a.table)(b)
+		if a.cluster != "" {
+			ddlToken(" ")(b)
+			OnCluster(a.cluster)(b)
+		}
+		ddlToken(" MODIFY COLUMN IF EXISTS ")(b)
+		Col(a.column)(b)
+		ddlToken(" ")(b)
+		a.codec(b)
+	}
+}
+
+// SQL renders the ALTER TABLE MODIFY COLUMN CODEC statement to ClickHouse
+// text via RenderDDL (which asserts the no-positional-bindings DDL
+// invariant).
+func (a *ModifyColumnCodecBuilder) SQL() string {
+	return RenderDDL(a.frag())
+}
+
 // --- ALTER TABLE ... ADD COLUMN surface ---
 //
 // AddColumnBuilder renders

--- a/internal/chsql/ddl_test.go
+++ b/internal/chsql/ddl_test.go
@@ -312,6 +312,49 @@ func TestAlterTableModifyColumn(t *testing.T) {
 	}
 }
 
+// TestAlterTableModifyColumnCodec pins the codec-only MODIFY COLUMN statement
+// (cerberus issue #2768): the optional <db>. qualifier, the idempotent IF
+// EXISTS guard, the quoted column name, NO type (deliberately, unlike
+// TestAlterTableModifyColumn's retyping shape), the CODEC(...) clause, and
+// the optional ON CLUSTER clause. The statement carries no positional args,
+// so RenderDDL accepts it.
+func TestAlterTableModifyColumnCodec(t *testing.T) {
+	doubleDeltaZSTD1 := Codec(BareIdent("DoubleDelta"), Call("ZSTD", InlineLit(1)))
+	cases := []struct {
+		name string
+		stmt *ModifyColumnCodecBuilder
+		want string
+	}{
+		{
+			"unqualified_table",
+			AlterTableModifyColumnCodec("", "otel_metrics_gauge", "TimeUnix", doubleDeltaZSTD1),
+			"ALTER TABLE otel_metrics_gauge MODIFY COLUMN IF EXISTS `TimeUnix` CODEC(DoubleDelta, ZSTD(1))",
+		},
+		{
+			"qualified_table",
+			AlterTableModifyColumnCodec("otel", "otel_metrics_gauge", "TimeUnix", doubleDeltaZSTD1),
+			"ALTER TABLE otel.otel_metrics_gauge MODIFY COLUMN IF EXISTS `TimeUnix` CODEC(DoubleDelta, ZSTD(1))",
+		},
+		{
+			"on_cluster",
+			AlterTableModifyColumnCodec("otel", "otel_metrics_gauge", "TimeUnix", doubleDeltaZSTD1).OnCluster("prod"),
+			"ALTER TABLE otel.otel_metrics_gauge ON CLUSTER `prod` MODIFY COLUMN IF EXISTS `TimeUnix` CODEC(DoubleDelta, ZSTD(1))",
+		},
+		{
+			"single_stage_no_args",
+			AlterTableModifyColumnCodec("otel", "otel_logs", "Body", Codec(Call("ZSTD", InlineLit(3)))),
+			"ALTER TABLE otel.otel_logs MODIFY COLUMN IF EXISTS `Body` CODEC(ZSTD(3))",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := tc.stmt.SQL(); got != tc.want {
+				t.Errorf("SQL() = %q; want %q", got, tc.want)
+			}
+		})
+	}
+}
+
 // TestAlterTableAddColumn pins the ADD COLUMN statement: the optional <db>.
 // qualifier, the idempotent IF NOT EXISTS guard, the quoted column name, the
 // caller's type fragment, and the optional ON CLUSTER clause. The guard is IF

--- a/internal/schema/ddl/ddl.go
+++ b/internal/schema/ddl/ddl.go
@@ -722,7 +722,10 @@ func renderSignal(cfg Config, s Signal) ([]string, error) {
 		if err != nil {
 			return nil, err
 		}
-		stmts := []string{logs}
+		// The curated Body codec ALTER (issue #2768) trails the CREATE the
+		// same way every other curated ALTER in this package trails its
+		// table's CREATE — see renderLogsCodecs' doc comment.
+		stmts := append([]string{logs}, renderLogsCodecs(cfg)...)
 		if cfg.ColumnStatisticsEnabled {
 			stmts = append(stmts, renderLogsColumnStatistics(cfg)...)
 		}
@@ -733,6 +736,10 @@ func renderSignal(cfg Config, s Signal) ([]string, error) {
 			renderTracesCreateTsTable(cfg),
 			renderTracesCreateTsView(cfg),
 		}
+		// The curated Duration codec ALTER (issue #2768) targets the spans
+		// table the first statement above just created — see
+		// renderTracesCodecs' doc comment.
+		stmts = append(stmts, renderTracesCodecs(cfg)...)
 		if cfg.ColumnStatisticsEnabled {
 			stmts = append(stmts, renderTracesColumnStatistics(cfg)...)
 		}
@@ -1093,6 +1100,136 @@ func renderTracesCreateTsView(cfg Config) string {
 		cfg.Database, cfg.Tables.Traces,
 		cfg.Database, cfg.Tables.Traces,
 	)
+}
+
+// --- Column compression codecs (cerberus issue #2768) ---
+//
+// Codecs on the metrics/logs/traces fact tables are upstream fork-template
+// defaults, not tuned to cerberus's own data. Every candidate below was
+// MEASURED — not merely reasoned about — against real production-shaped
+// sample data (test/perf/nightly/testdata/samples/*.parquet, cerberus issue
+// #2411) via a real MergeTree engine (chDB), comparing whole-table
+// compressed bytes before/after the codec swap; see the PR that introduced
+// this section for the full transcript. Two candidates the issue proposed
+// did NOT survive measurement and are deliberately NOT adopted here:
+//
+//   - DateTime64(9) scrape/sample timestamps (metrics TimeUnix, span
+//     Timestamp): the issue's premise was that a near-constant scrape
+//     interval leaves second-order regularity DoubleDelta captures and
+//     Delta alone misses. Measured against three real metrics tables
+//     (gauge/sum/histogram), DoubleDelta+ZSTD(1) was 43%-166% LARGER than
+//     the current Delta+ZSTD(1) — a regression — because a near-constant
+//     Delta stream is already maximally redundant (the same interval
+//     repeated for most of a series' run), which ZSTD(1) alone already
+//     exploits about as well as physically possible (232x-443x measured);
+//     DoubleDelta's own per-value framing bytes break up that redundancy
+//     more than they remove. GCD+Delta measured a small, INCONSISTENT
+//     effect across the three real tables (-3.5% to -6.9% on sum/histogram,
+//     but +9.2% on gauge) — not a safe blanket win across every metrics
+//     table sharing one codec declaration. Bare GCD (no Delta) measured
+//     catastrophically worse (+650% to +3515%). None of the three
+//     candidates clears the bar, so TimeUnix / Timestamp keep their
+//     current Delta, ZSTD(1) — unchanged by this issue.
+//   - Value (gauge/sum) / Sum (histogram/summary/exp_histogram) Float64:
+//     the issue gated Gorilla/FPC adoption on beating ZSTD(1) on real
+//     gauge-shaped data. Measured against the same three tables, BOTH
+//     regressed — Gorilla 27%-2182% larger, FPC 84%-2662% larger — so
+//     neither is adopted; Value / Sum keep ZSTD(1), unchanged.
+//
+// Two candidates DID measure a real, safe win and are adopted below:
+//
+//   - Logs Body (String): ZSTD(3) measured ~1.3%-1.8% smaller than ZSTD(1)
+//     on a representative leveled-log-line corpus, consistently across
+//     repeated runs, at only the modest extra write-side CPU a higher ZSTD
+//     level costs (ZSTD decode cost is level-independent, so read-side
+//     query latency is unaffected).
+//   - Span Duration (UInt64 nanoseconds): the issue's own rationale — a
+//     ns-precision column whose real values carry coarser precision is
+//     GCD's exact case — measured true ONLY for the codec's designed
+//     shape, `GCD, ZSTD(1)` (no Delta stage): Duration values are
+//     independent per-span measurements, not a running sequence, so
+//     chaining a Delta stage ahead of ZSTD (`Delta, ZSTD(1)` or
+//     `GCD, Delta, ZSTD(1)`, the issue's own proposed pairing) measured
+//     3%-10% LARGER — against synthetic data spanning both a genuinely
+//     nanosecond-precision scenario and a millisecond-rounded one (no real
+//     trace sample data exists in this repo to benchmark against — traces
+//     are outside the #2411 sample set's scope). Bare `GCD, ZSTD(1)`
+//     measured a real 3.5% win on the coarse-precision scenario and was
+//     statistically a no-op (+0.02%, measurement noise) on the
+//     fine-precision one: GCD finds no common divisor when there genuinely
+//     isn't one, so it costs nothing on a deployment whose real Duration
+//     values don't carry the coarse-precision pattern this codec targets.
+//
+// All codecs used above — Delta, GCD, Gorilla, FPC (the last two named here
+// only because the reasoning above needs to identify exactly what was
+// rejected) — are supported at ClickHouse >= 22.9, well under this repo's
+// 24.8 version floor (docs/toolchain.md), so — like ADD PROJECTION / ADD
+// INDEX above, and unlike ADD STATISTICS's chopt-gated column_statistics
+// feature below — this registry renders UNCONDITIONALLY: no Config flag, no
+// chopt feature gate.
+//
+// A MODIFY COLUMN codec change is metadata-only for NEW parts; existing
+// parts keep their prior codec until a background merge (or an
+// operator-run `OPTIMIZE ... FINAL`) rewrites them — see
+// docs/operations.md. Re-running the identical statement is a no-op:
+// ClickHouse only schedules work when the declared codec actually differs
+// from the column's current one, so applying this on every boot never
+// re-triggers a conversion once converged — see
+// chsql.ModifyColumnCodecBuilder's doc comment for why that (not any
+// `IF EXISTS`-shaped guard) is what makes re-applying this safe.
+const (
+	// bodyColumn is the logs table's fixed OTel-CH exporter text column the
+	// curated Body codec ALTER targets.
+	bodyColumn = "Body"
+
+	// zstdLevelLogsBody is the curated ZSTD level for the logs Body column —
+	// see the package doc comment above for the measured win over the
+	// upstream ZSTD(1) default.
+	zstdLevelLogsBody = 3
+
+	// zstdLevelDefault mirrors the upstream ZSTD(1) baseline level the span
+	// Duration codec below keeps as its final compression stage — not
+	// itself a curated change, just the existing level reused verbatim
+	// alongside the new GCD stage.
+	zstdLevelDefault = 1
+)
+
+// logsBodyCodec returns the curated logs Body codec: CODEC(ZSTD(3)).
+func logsBodyCodec() chsql.Frag {
+	return chsql.Codec(chsql.Call("ZSTD", chsql.InlineLit(zstdLevelLogsBody)))
+}
+
+// spanDurationCodec returns the curated span Duration codec:
+// CODEC(GCD, ZSTD(1)) — deliberately no Delta stage; see the package doc
+// comment above for why chaining Delta ahead of ZSTD measured worse on this
+// column than GCD alone.
+func spanDurationCodec() chsql.Frag {
+	return chsql.Codec(chsql.BareIdent("GCD"), chsql.Call("ZSTD", chsql.InlineLit(zstdLevelDefault)))
+}
+
+// renderLogsCodecs returns the curated codec ALTER for the logs table's
+// Body column (issue #2768).
+func renderLogsCodecs(cfg Config) []string {
+	return []string{renderModifyColumnCodec(cfg, cfg.Tables.Logs, bodyColumn, logsBodyCodec())}
+}
+
+// renderTracesCodecs returns the curated codec ALTER for the traces spans
+// table's Duration column (issue #2768).
+func renderTracesCodecs(cfg Config) []string {
+	return []string{renderModifyColumnCodec(cfg, cfg.Tables.Traces, durationColumn, spanDurationCodec())}
+}
+
+// renderModifyColumnCodec builds one idempotent MODIFY COLUMN CODEC ALTER —
+// see chsql.AlterTableModifyColumnCodec's doc comment for the exact
+// idempotency contract (re-apply is a no-op once the codec has converged,
+// not guard-based). ON CLUSTER is threaded so the ALTER replicates the same
+// way the CREATE statements do.
+func renderModifyColumnCodec(cfg Config, table, column string, codec chsql.Frag) string {
+	stmt := chsql.AlterTableModifyColumnCodec(cfg.Database, table, column, codec)
+	if cfg.Cluster != "" {
+		stmt.OnCluster(cfg.Cluster)
+	}
+	return stmt.SQL()
 }
 
 // --- Column statistics (cerberus issue #2766) ---

--- a/internal/schema/ddl/ddl_test.go
+++ b/internal/schema/ddl/ddl_test.go
@@ -143,8 +143,13 @@ func TestRenderSignal_Logs(t *testing.T) {
 	if err != nil {
 		t.Fatalf("renderSignal(Logs): %v", err)
 	}
-	if got, want := len(stmts), 1; got != want {
+	// CREATE TABLE + the curated Body codec ALTER (issue #2768).
+	if got, want := len(stmts), 2; got != want {
 		t.Fatalf("logs: got %d statements, want %d", got, want)
+	}
+	wantCodec := "ALTER TABLE default.otel_logs MODIFY COLUMN IF EXISTS `Body` CODEC(ZSTD(3))"
+	if stmts[1] != wantCodec {
+		t.Errorf("logs Body codec:\ngot  %s\nwant %s", stmts[1], wantCodec)
 	}
 	logs := stmts[0]
 	if !strings.Contains(logs, "otel_logs") {
@@ -193,15 +198,16 @@ func TestRenderSignal_Logs(t *testing.T) {
 	}
 }
 
-// TestRenderSignal_Traces checks the three traces statements render — the
-// spans table, the trace_id_ts lookup table, and its materialized view.
+// TestRenderSignal_Traces checks the four traces statements render — the
+// spans table, the trace_id_ts lookup table, its materialized view, and the
+// curated Duration codec ALTER (issue #2768).
 func TestRenderSignal_Traces(t *testing.T) {
 	cfg := Config{}.withDefaults()
 	stmts, err := renderSignal(cfg, Traces)
 	if err != nil {
 		t.Fatalf("renderSignal(Traces): %v", err)
 	}
-	if got, want := len(stmts), 3; got != want {
+	if got, want := len(stmts), 4; got != want {
 		t.Fatalf("traces: got %d statements, want %d", got, want)
 	}
 	if !strings.Contains(stmts[0], "CREATE TABLE IF NOT EXISTS") || !strings.Contains(stmts[0], "otel_traces") {
@@ -219,6 +225,10 @@ func TestRenderSignal_Traces(t *testing.T) {
 	// The MV body should reference the spans table in its FROM clause.
 	if !strings.Contains(stmts[2], `FROM "default"."otel_traces"`) {
 		t.Errorf("traces[2]: MV should select FROM the spans table:\n%s", stmts[2])
+	}
+	wantCodec := "ALTER TABLE default.otel_traces MODIFY COLUMN IF EXISTS `Duration` CODEC(GCD, ZSTD(1))"
+	if stmts[3] != wantCodec {
+		t.Errorf("traces Duration codec:\ngot  %s\nwant %s", stmts[3], wantCodec)
 	}
 }
 
@@ -893,46 +903,48 @@ func TestRenderSignal_MetricsColumnStatistics(t *testing.T) {
 
 // TestRenderSignal_LogsColumnStatistics pins the two logs ALTERs:
 // ServiceName+TraceId `uniq` (String-family), then SeverityNumber
-// `minmax, uniq` (a UInt8 column) in its own ALTER.
+// `minmax, uniq` (a UInt8 column) in its own ALTER — trailing the curated
+// Body codec ALTER (issue #2768), which itself trails the CREATE.
 func TestRenderSignal_LogsColumnStatistics(t *testing.T) {
 	cfg := Config{ColumnStatisticsEnabled: true}.withDefaults()
 	stmts, err := renderSignal(cfg, Logs)
 	if err != nil {
 		t.Fatalf("renderSignal(Logs): %v", err)
 	}
-	if len(stmts) != 3 {
-		t.Fatalf("logs: got %d statements, want 3 (CREATE + 2 statistics ALTERs): %v", len(stmts), stmts)
+	if len(stmts) != 4 {
+		t.Fatalf("logs: got %d statements, want 4 (CREATE + Body codec ALTER + 2 statistics ALTERs): %v", len(stmts), stmts)
 	}
 	wantIdentity := "ALTER TABLE default.otel_logs ADD STATISTICS IF NOT EXISTS `ServiceName`, `TraceId` TYPE uniq"
-	if stmts[1] != wantIdentity {
-		t.Errorf("logs identity column statistics:\ngot  %s\nwant %s", stmts[1], wantIdentity)
+	if stmts[2] != wantIdentity {
+		t.Errorf("logs identity column statistics:\ngot  %s\nwant %s", stmts[2], wantIdentity)
 	}
 	wantSeverity := "ALTER TABLE default.otel_logs ADD STATISTICS IF NOT EXISTS `SeverityNumber` TYPE minmax, uniq"
-	if stmts[2] != wantSeverity {
-		t.Errorf("logs SeverityNumber column statistics:\ngot  %s\nwant %s", stmts[2], wantSeverity)
+	if stmts[3] != wantSeverity {
+		t.Errorf("logs SeverityNumber column statistics:\ngot  %s\nwant %s", stmts[3], wantSeverity)
 	}
 }
 
 // TestRenderSignal_TracesColumnStatistics pins the two traces ALTERs: the
 // shared `uniq` statement over ServiceName/SpanName/TraceId (String-family),
 // and the separate Duration statement (`minmax, uniq, tdigest` — a UInt64
-// column).
+// column) — trailing the curated Duration codec ALTER (issue #2768), which
+// itself trails the three CREATEs.
 func TestRenderSignal_TracesColumnStatistics(t *testing.T) {
 	cfg := Config{ColumnStatisticsEnabled: true}.withDefaults()
 	stmts, err := renderSignal(cfg, Traces)
 	if err != nil {
 		t.Fatalf("renderSignal(Traces): %v", err)
 	}
-	if len(stmts) != 5 {
-		t.Fatalf("traces: got %d statements, want 5 (3 CREATEs + 2 statistics ALTERs): %v", len(stmts), stmts)
+	if len(stmts) != 6 {
+		t.Fatalf("traces: got %d statements, want 6 (3 CREATEs + Duration codec ALTER + 2 statistics ALTERs): %v", len(stmts), stmts)
 	}
 	wantIdentity := "ALTER TABLE default.otel_traces ADD STATISTICS IF NOT EXISTS `ServiceName`, `SpanName`, `TraceId` TYPE uniq"
-	if stmts[3] != wantIdentity {
-		t.Errorf("traces identity column statistics:\ngot  %s\nwant %s", stmts[3], wantIdentity)
+	if stmts[4] != wantIdentity {
+		t.Errorf("traces identity column statistics:\ngot  %s\nwant %s", stmts[4], wantIdentity)
 	}
 	wantDuration := "ALTER TABLE default.otel_traces ADD STATISTICS IF NOT EXISTS `Duration` TYPE minmax, uniq, tdigest"
-	if stmts[4] != wantDuration {
-		t.Errorf("traces Duration column statistics:\ngot  %s\nwant %s", stmts[4], wantDuration)
+	if stmts[5] != wantDuration {
+		t.Errorf("traces Duration column statistics:\ngot  %s\nwant %s", stmts[5], wantDuration)
 	}
 }
 
@@ -946,8 +958,8 @@ func TestRenderSignal_ColumnStatisticsOnCluster(t *testing.T) {
 		t.Fatalf("renderSignal(Logs): %v", err)
 	}
 	want := "ALTER TABLE default.otel_logs ON CLUSTER `prod` ADD STATISTICS IF NOT EXISTS `ServiceName`, `TraceId` TYPE uniq"
-	if stmts[1] != want {
-		t.Errorf("logs column statistics with cluster:\ngot  %s\nwant %s", stmts[1], want)
+	if stmts[2] != want {
+		t.Errorf("logs column statistics with cluster:\ngot  %s\nwant %s", stmts[2], want)
 	}
 }
 

--- a/internal/schema/ddl/idempotency_test.go
+++ b/internal/schema/ddl/idempotency_test.go
@@ -9,12 +9,20 @@ import (
 )
 
 // TestRenderSignal_AllTablesCarryIfNotExists is the rendering-layer
-// equivalent of the Apply-twice integration test: every CREATE
-// statement under every signal must carry an IF NOT EXISTS clause so a
-// second Apply against an already-populated CH is a no-op. The
-// integration test asserts the end-to-end behavior; this test pins the
-// contract at the template-render boundary so a future template bump
-// can't silently drop the clause.
+// equivalent of the Apply-twice integration test: every CREATE statement
+// (and every idempotent ALTER — ADD PROJECTION / ADD INDEX / ADD
+// STATISTICS) under every signal must carry an IF NOT EXISTS clause so a
+// second Apply against an already-populated CH is a no-op. The curated
+// codec ALTERs (issue #2768) are the one deliberate exception: MODIFY
+// COLUMN has no `IF NOT EXISTS`-shaped guard at all — only `IF EXISTS`,
+// which guards a different case (an absent column, e.g. a signal not yet
+// auto-created). Their re-apply safety comes from ClickHouse itself
+// treating an unchanged codec declaration as a no-op — see
+// chsql.ModifyColumnCodecBuilder's doc comment — not from a guard clause,
+// so they are asserted on separately below rather than against this loop's
+// IF NOT EXISTS check. The integration test asserts the end-to-end
+// behavior; this test pins the contract at the template-render boundary so
+// a future template bump can't silently drop a clause.
 func TestRenderSignal_AllTablesCarryIfNotExists(t *testing.T) {
 	cfg := Config{}.withDefaults()
 	for _, sig := range All {
@@ -23,9 +31,43 @@ func TestRenderSignal_AllTablesCarryIfNotExists(t *testing.T) {
 			t.Fatalf("renderSignal(%s): %v", sig, err)
 		}
 		for i, stmt := range stmts {
+			if strings.Contains(stmt, "MODIFY COLUMN IF EXISTS") {
+				continue
+			}
 			if !strings.Contains(stmt, "IF NOT EXISTS") {
 				t.Errorf("%s[%d]: missing IF NOT EXISTS — re-apply would fail:\n%s", sig, i, stmt)
 			}
+		}
+	}
+}
+
+// TestRenderSignal_CodecAltersCarryIfExists pins that every curated codec
+// ALTER (issue #2768) carries MODIFY COLUMN's own guard, `IF EXISTS` — the
+// counterpart TestRenderSignal_AllTablesCarryIfNotExists exempts them from
+// checking, so this test is what actually pins their guard clause.
+func TestRenderSignal_CodecAltersCarryIfExists(t *testing.T) {
+	cfg := Config{}.withDefaults()
+	for _, sig := range []Signal{Logs, Traces} {
+		stmts, err := renderSignal(cfg, sig)
+		if err != nil {
+			t.Fatalf("renderSignal(%s): %v", sig, err)
+		}
+		found := false
+		for _, stmt := range stmts {
+			// Match the ALTER's own MODIFY COLUMN clause specifically —
+			// every CREATE TABLE statement in these signals also contains
+			// literal " CODEC(" text on its OTHER columns, which a bare
+			// substring match on "CODEC(" alone would false-positive on.
+			if !strings.Contains(stmt, "MODIFY COLUMN") {
+				continue
+			}
+			found = true
+			if !strings.Contains(stmt, "MODIFY COLUMN IF EXISTS") {
+				t.Errorf("%s: codec ALTER missing IF EXISTS guard:\n%s", sig, stmt)
+			}
+		}
+		if !found {
+			t.Errorf("%s: expected a curated codec ALTER, found none in:\n%v", sig, stmts)
 		}
 	}
 }
@@ -224,18 +266,18 @@ func TestRenderSignal_TTLZeroWithReplicatedEngine(t *testing.T) {
 }
 
 // TestRenderSignal_LogsOnlySubset emulates a deployment that only wants
-// the logs signal. The render layer must produce the single logs
-// statement and nothing else — Apply iterates per-signal so any
-// "metrics tables leak when only Logs requested" regression surfaces
-// here.
+// the logs signal. The render layer must produce the CREATE statement plus
+// the curated Body codec ALTER (issue #2768) and nothing else — Apply
+// iterates per-signal so any "metrics tables leak when only Logs requested"
+// regression surfaces here.
 func TestRenderSignal_LogsOnlySubset(t *testing.T) {
 	cfg := Config{}.withDefaults()
 	stmts, err := renderSignal(cfg, Logs)
 	if err != nil {
 		t.Fatalf("renderSignal(Logs): %v", err)
 	}
-	if len(stmts) != 1 {
-		t.Fatalf("logs subset: got %d statements; want 1", len(stmts))
+	if len(stmts) != 2 {
+		t.Fatalf("logs subset: got %d statements; want 2", len(stmts))
 	}
 	if !strings.Contains(stmts[0], "otel_logs") {
 		t.Errorf("logs subset[0]: missing otel_logs table name")
@@ -243,23 +285,28 @@ func TestRenderSignal_LogsOnlySubset(t *testing.T) {
 	if strings.Contains(stmts[0], "otel_metrics") || strings.Contains(stmts[0], "otel_traces") {
 		t.Errorf("logs subset[0]: leaked unrelated tables:\n%s", stmts[0])
 	}
+	if !strings.Contains(stmts[1], "otel_logs") {
+		t.Errorf("logs subset[1]: missing otel_logs table name in codec ALTER:\n%s", stmts[1])
+	}
 }
 
-// TestRenderSignal_TracesOnlySubset confirms the three traces statements
-// (spans table, lookup table, MV) render together and nothing else.
-// Order matters because the MV references the lookup table.
+// TestRenderSignal_TracesOnlySubset confirms the four traces statements
+// (spans table, lookup table, MV, and the curated Duration codec ALTER —
+// issue #2768) render together and nothing else. Order matters because the
+// MV references the lookup table.
 func TestRenderSignal_TracesOnlySubset(t *testing.T) {
 	cfg := Config{}.withDefaults()
 	stmts, err := renderSignal(cfg, Traces)
 	if err != nil {
 		t.Fatalf("renderSignal(Traces): %v", err)
 	}
-	if len(stmts) != 3 {
-		t.Fatalf("traces subset: got %d statements; want 3", len(stmts))
+	if len(stmts) != 4 {
+		t.Fatalf("traces subset: got %d statements; want 4", len(stmts))
 	}
 	// Statement order is load-bearing: the MV (stmts[2]) selects FROM
 	// the spans table (stmts[0]) and writes INTO the lookup table
-	// (stmts[1]). Reverse order would error on CH.
+	// (stmts[1]). Reverse order would error on CH. The codec ALTER
+	// (stmts[3]) targets the spans table stmts[0] already created.
 	if !strings.Contains(stmts[0], "CREATE TABLE IF NOT EXISTS") {
 		t.Errorf("traces[0] should be the spans table CREATE")
 	}
@@ -268,6 +315,9 @@ func TestRenderSignal_TracesOnlySubset(t *testing.T) {
 	}
 	if !strings.Contains(stmts[2], "CREATE MATERIALIZED VIEW IF NOT EXISTS") {
 		t.Errorf("traces[2] should be the MV CREATE")
+	}
+	if !strings.Contains(stmts[3], "otel_traces") || !strings.Contains(stmts[3], "CODEC(") {
+		t.Errorf("traces[3] should be the Duration codec ALTER:\n%s", stmts[3])
 	}
 }
 

--- a/internal/schema/ddl/settings_test.go
+++ b/internal/schema/ddl/settings_test.go
@@ -30,7 +30,15 @@ func mergeTreeStmts(t *testing.T, cfg Config) []string {
 	if err != nil {
 		t.Fatalf("renderSignal(Logs): %v", err)
 	}
-	out = append(out, l...)
+	// The Body codec ALTER (issue #2768) carries no SETTINGS tail either
+	// (it inherits the table's settings, like the metrics ALTERs above);
+	// only the CREATE TABLE statement does.
+	for _, stmt := range l {
+		if strings.HasPrefix(stmt, "ALTER TABLE") {
+			continue
+		}
+		out = append(out, stmt)
+	}
 	tr, err := renderSignal(cfg, Traces)
 	if err != nil {
 		t.Fatalf("renderSignal(Traces): %v", err)

--- a/test/e2e/migration/expected/schema/default.sql
+++ b/test/e2e/migration/expected/schema/default.sql
@@ -256,6 +256,8 @@ ORDER BY (toStartOfFiveMinutes(Timestamp), ServiceName, Timestamp)
 SETTINGS index_granularity = 8192, ttl_only_drop_parts = 1
 ;
 
+ALTER TABLE default.otel_logs MODIFY COLUMN IF EXISTS `Body` CODEC(ZSTD(3));
+
 CREATE TABLE IF NOT EXISTS "default"."otel_traces"  (
     Timestamp DateTime64(9) CODEC(Delta, ZSTD(1)),
     TraceId String CODEC(ZSTD(1)),
@@ -317,3 +319,5 @@ AS SELECT
    WHERE TraceId != ''
    GROUP BY TraceId
 ;
+
+ALTER TABLE default.otel_traces MODIFY COLUMN IF EXISTS `Duration` CODEC(GCD, ZSTD(1));

--- a/test/e2e/migration/expected/schema/metrics-ttl-override.sql
+++ b/test/e2e/migration/expected/schema/metrics-ttl-override.sql
@@ -256,6 +256,8 @@ ORDER BY (toStartOfFiveMinutes(Timestamp), ServiceName, Timestamp)
 SETTINGS index_granularity = 8192, ttl_only_drop_parts = 1
 ;
 
+ALTER TABLE default.otel_logs MODIFY COLUMN IF EXISTS `Body` CODEC(ZSTD(3));
+
 CREATE TABLE IF NOT EXISTS "default"."otel_traces"  (
     Timestamp DateTime64(9) CODEC(Delta, ZSTD(1)),
     TraceId String CODEC(ZSTD(1)),
@@ -317,3 +319,5 @@ AS SELECT
    WHERE TraceId != ''
    GROUP BY TraceId
 ;
+
+ALTER TABLE default.otel_traces MODIFY COLUMN IF EXISTS `Duration` CODEC(GCD, ZSTD(1));

--- a/test/e2e/migration/steps/schema.go
+++ b/test/e2e/migration/steps/schema.go
@@ -44,12 +44,23 @@ var leadingVerbRe = regexp.MustCompile(`(?is)^([A-Za-z]+)`)
 
 // idempotentAdditiveAlterRe matches the non-CREATE shapes the renderer
 // emits: an idempotent PROJECTION or INDEX addition on a table it just
-// declared — both are metadata-only ADD ... IF NOT EXISTS statements that
-// never rewrite or destroy existing data (see internal/schema/ddl's curated
-// projection registry and, since issue #2458, its AggregationTemporality
-// skip index). Any other ALTER would be a schema mutation the operator did
-// not ask to review.
-var idempotentAdditiveAlterRe = regexp.MustCompile(`(?is)^ALTER\s+TABLE\s+\S+\s+ADD\s+(?:PROJECTION|INDEX)\s+IF\s+NOT\s+EXISTS\s+`)
+// declared (both metadata-only ADD ... IF NOT EXISTS statements — see
+// internal/schema/ddl's curated projection registry and, since issue
+// #2458, its AggregationTemporality skip index), or a curated column
+// compression codec retune (issue #2768) — a MODIFY COLUMN ... CODEC(...)
+// statement that changes only how NEW parts are compressed and rewrites
+// nothing existing (see internal/schema/ddl's renderMetricsCodecs /
+// renderLogsCodecs / renderTracesCodecs and chsql.ModifyColumnCodecBuilder's
+// doc comment for why it carries IF EXISTS rather than IF NOT EXISTS). Any
+// other ALTER would be a schema mutation the operator did not ask to
+// review.
+var idempotentAdditiveAlterRe = regexp.MustCompile(
+	`(?is)^ALTER\s+TABLE\s+\S+\s+(?:` +
+		`ADD\s+(?:PROJECTION|INDEX)\s+IF\s+NOT\s+EXISTS` +
+		`|` +
+		`MODIFY\s+COLUMN\s+IF\s+EXISTS\s+\S+\s+CODEC\(` +
+		`)`,
+)
 
 // destructiveRe matches a statement that would destroy or rewrite data. The
 // rendered schema is a provisioning preview an operator pipes into a client by

--- a/test/e2e/migration/steps/schema_live.go
+++ b/test/e2e/migration/steps/schema_live.go
@@ -356,53 +356,32 @@ func (w *World) whenDiffSchemaAgainstLive() error {
 	}
 
 	for _, proj := range rendered.projections {
-		if proj.database != w.live.CHDatabase {
-			diff.misqualified = append(diff.misqualified,
-				fmt.Sprintf("%s.%s's projection %s (live tenant database is %s)",
-					proj.database, proj.table, proj.name, w.live.CHDatabase))
-			continue
-		}
-		exists, err := tableExistsLive(ctx, conn, w.live.CHDatabase, proj.table)
-		if err != nil {
+		if err := w.diffAlterTarget(
+			ctx, conn, &diff, proj.database, proj.table,
+			fmt.Sprintf("%s.%s's projection %s", proj.database, proj.table, proj.name),
+			fmt.Sprintf("%s (target of projection %s)", proj.table, proj.name),
+		); err != nil {
 			return err
-		}
-		if !exists {
-			diff.missingTables = append(diff.missingTables,
-				fmt.Sprintf("%s (target of projection %s)", proj.table, proj.name))
 		}
 	}
 
 	for _, idx := range rendered.indexes {
-		if idx.database != w.live.CHDatabase {
-			diff.misqualified = append(diff.misqualified,
-				fmt.Sprintf("%s.%s's index %s (live tenant database is %s)",
-					idx.database, idx.table, idx.name, w.live.CHDatabase))
-			continue
-		}
-		exists, err := tableExistsLive(ctx, conn, w.live.CHDatabase, idx.table)
-		if err != nil {
+		if err := w.diffAlterTarget(
+			ctx, conn, &diff, idx.database, idx.table,
+			fmt.Sprintf("%s.%s's index %s", idx.database, idx.table, idx.name),
+			fmt.Sprintf("%s (target of index %s)", idx.table, idx.name),
+		); err != nil {
 			return err
-		}
-		if !exists {
-			diff.missingTables = append(diff.missingTables,
-				fmt.Sprintf("%s (target of index %s)", idx.table, idx.name))
 		}
 	}
 
 	for _, alt := range rendered.codecAlters {
-		if alt.database != w.live.CHDatabase {
-			diff.misqualified = append(diff.misqualified,
-				fmt.Sprintf("%s.%s's codec ALTER on %s (live tenant database is %s)",
-					alt.database, alt.table, alt.column, w.live.CHDatabase))
-			continue
-		}
-		exists, err := tableExistsLive(ctx, conn, w.live.CHDatabase, alt.table)
-		if err != nil {
+		if err := w.diffAlterTarget(
+			ctx, conn, &diff, alt.database, alt.table,
+			fmt.Sprintf("%s.%s's codec ALTER on %s", alt.database, alt.table, alt.column),
+			fmt.Sprintf("%s (target of codec ALTER on %s)", alt.table, alt.column),
+		); err != nil {
 			return err
-		}
-		if !exists {
-			diff.missingTables = append(diff.missingTables,
-				fmt.Sprintf("%s (target of codec ALTER on %s)", alt.table, alt.column))
 		}
 	}
 
@@ -428,6 +407,32 @@ func (w *World) whenDiffSchemaAgainstLive() error {
 	sort.Strings(diff.missingTables)
 	sort.Strings(diff.unresolvedTables)
 	w.schemaLive = diff
+	return nil
+}
+
+// diffAlterTarget records one non-CREATE ALTER's misqualified/missing-table
+// verdict against the live database — the shared body the ADD PROJECTION /
+// ADD INDEX / MODIFY COLUMN CODEC loops in whenDiffSchemaAgainstLive each
+// call, since the three differ only in what kind of ALTER they are checking
+// and the wording that names it. misqualifiedLabel / missingLabel carry that
+// per-call-site wording; the database-mismatch and missing-table checks
+// themselves are identical across all three ALTER kinds.
+func (w *World) diffAlterTarget(
+	ctx context.Context, conn driver.Conn, diff *schemaLiveDiff,
+	database, table, misqualifiedLabel, missingLabel string,
+) error {
+	if database != w.live.CHDatabase {
+		diff.misqualified = append(diff.misqualified,
+			fmt.Sprintf("%s (live tenant database is %s)", misqualifiedLabel, w.live.CHDatabase))
+		return nil
+	}
+	exists, err := tableExistsLive(ctx, conn, w.live.CHDatabase, table)
+	if err != nil {
+		return err
+	}
+	if !exists {
+		diff.missingTables = append(diff.missingTables, missingLabel)
+	}
 	return nil
 }
 

--- a/test/e2e/migration/steps/schema_live.go
+++ b/test/e2e/migration/steps/schema_live.go
@@ -62,6 +62,18 @@ var alterIndexRe = regexp.MustCompile(
 	`(?is)^ALTER\s+TABLE\s+(\S+)\s+ADD\s+INDEX\s+IF\s+NOT\s+EXISTS\s+(\S+)`,
 )
 
+// alterModifyColumnCodecRe is alterProjectionRe's sibling for the third
+// non-CREATE shape the renderer emits (cerberus issue #2768): a curated,
+// codec-only `MODIFY COLUMN IF EXISTS <col> CODEC(...)` retune. Unlike a
+// projection or index name, the trailing CODEC(...) body carries the exact
+// upstream template codec cerberus's own benchmark superseded, which is a
+// fact this parser has no need to hold onto — only the ALTER's target
+// (table, column) is diffable against a collector-provisioned stack, for the
+// same reason renderedProjection / renderedIndex only diff their target.
+var alterModifyColumnCodecRe = regexp.MustCompile(
+	`(?is)^ALTER\s+TABLE\s+(\S+)\s+MODIFY\s+COLUMN\s+IF\s+EXISTS\s+(\S+)\s+CODEC\(`,
+)
+
 // renderedColumn is one column a rendered CREATE TABLE declares.
 type renderedColumn struct {
 	// name is the column the live table must carry.
@@ -115,6 +127,20 @@ type renderedIndex struct {
 	name     string
 }
 
+// renderedCodecAlter is one `ALTER TABLE … MODIFY COLUMN IF EXISTS … CODEC(…)`
+// the renderer emits (cerberus issue #2768's curated codec registry). Unlike
+// renderedProjection / renderedIndex, the column this ALTER targets is one
+// the upstream OTel exporter's own CREATE TABLE already declares — it is not
+// a cerberus-only addition — but what IS asserted here is the same claim
+// those two make: the ALTER targets the live tenant database and names a
+// table that is really there, so an operator piping the render into a
+// client cannot hit a missing target.
+type renderedCodecAlter struct {
+	database string
+	table    string
+	column   string
+}
+
 // renderedSchema is everything the render declares, split by what each half
 // can be diffed against. Keeping the projections rather than dropping them is
 // what stops a parser change from silently shrinking the diff's input.
@@ -122,6 +148,7 @@ type renderedSchema struct {
 	objects     []renderedObject
 	projections []renderedProjection
 	indexes     []renderedIndex
+	codecAlters []renderedCodecAlter
 }
 
 // readColumn is one column cerberus's read-side schema config addresses on one
@@ -175,6 +202,9 @@ type schemaLiveDiff struct {
 	// indexes is projections' sibling for the ADD INDEX ALTERs the diff
 	// reached (issue #2458's AggregationTemporality skip index today).
 	indexes int
+	// codecAlters is projections' sibling for the MODIFY COLUMN CODEC ALTERs
+	// the diff reached (issue #2768's curated codec registry).
+	codecAlters int
 	// readMissing names, per table cerberus reads, the columns its
 	// env-resolved READ-side schema config addresses that the live table does
 	// not carry. The rendered diff above covers what the DDL declares; this
@@ -268,6 +298,11 @@ func (w *World) whenDiffSchemaAgainstLive() error {
 			"skip index on the sum and histogram tables, so an empty set means the parse stopped reading them " +
 			"and their targets go unchecked")
 	}
+	if len(rendered.codecAlters) == 0 {
+		return fmt.Errorf("the rendered schema retunes no column codec at all; the renderer emits one curated " +
+			"MODIFY COLUMN CODEC ALTER each on the logs and traces tables, so an empty set means the parse " +
+			"stopped reading them and their targets go unchecked")
+	}
 
 	ctx, cancel := context.WithTimeout(context.Background(), livePollBudget)
 	defer cancel()
@@ -285,6 +320,7 @@ func (w *World) whenDiffSchemaAgainstLive() error {
 		unresolvedColumns: map[string][]string{},
 		projections:       len(rendered.projections),
 		indexes:           len(rendered.indexes),
+		codecAlters:       len(rendered.codecAlters),
 	}
 	// liveCols caches one system.columns read per table, so the read-side leg
 	// below reuses what the rendered leg already fetched.
@@ -350,6 +386,23 @@ func (w *World) whenDiffSchemaAgainstLive() error {
 		if !exists {
 			diff.missingTables = append(diff.missingTables,
 				fmt.Sprintf("%s (target of index %s)", idx.table, idx.name))
+		}
+	}
+
+	for _, alt := range rendered.codecAlters {
+		if alt.database != w.live.CHDatabase {
+			diff.misqualified = append(diff.misqualified,
+				fmt.Sprintf("%s.%s's codec ALTER on %s (live tenant database is %s)",
+					alt.database, alt.table, alt.column, w.live.CHDatabase))
+			continue
+		}
+		exists, err := tableExistsLive(ctx, conn, w.live.CHDatabase, alt.table)
+		if err != nil {
+			return err
+		}
+		if !exists {
+			diff.missingTables = append(diff.missingTables,
+				fmt.Sprintf("%s (target of codec ALTER on %s)", alt.table, alt.column))
 		}
 	}
 
@@ -500,10 +553,10 @@ func (w *World) thenDiffCoversEveryReadTable() error {
 // thenNoTableMissingLive asserts every object the render declares exists in
 // the live, collector-created database — and that the render targeted that
 // database in the first place, since DDL aimed elsewhere provisions a stack
-// other than the one under test. Each ADD PROJECTION / ADD INDEX ALTER is
-// held to the same two claims about its target table; its projection BODY /
-// index expression is deliberately out of scope (see renderedProjection /
-// renderedIndex).
+// other than the one under test. Each ADD PROJECTION / ADD INDEX / MODIFY
+// COLUMN CODEC ALTER is held to the same two claims about its target table;
+// its projection BODY / index expression / codec clause is deliberately out
+// of scope (see renderedProjection / renderedIndex / renderedCodecAlter).
 func (w *World) thenNoTableMissingLive() error {
 	if !w.schemaLive.ran {
 		return fmt.Errorf("the schema has not been diffed against the live database")
@@ -513,6 +566,9 @@ func (w *World) thenNoTableMissingLive() error {
 	}
 	if w.schemaLive.indexes == 0 {
 		return fmt.Errorf("the diff reached no ADD INDEX ALTER, so no index target was checked")
+	}
+	if w.schemaLive.codecAlters == 0 {
+		return fmt.Errorf("the diff reached no MODIFY COLUMN CODEC ALTER, so no codec-retune target was checked")
 	}
 	if len(w.schemaLive.misqualified) > 0 {
 		return fmt.Errorf("the rendered schema targets objects outside the live tenant database: %v",
@@ -814,10 +870,16 @@ func parseRenderedSchema(stmts []string) (renderedSchema, error) {
 					return renderedSchema{}, err
 				}
 				out.indexes = append(out.indexes, idx)
+			case alterModifyColumnCodecRe.MatchString(stmt):
+				alt, err := parseModifyColumnCodec(stmt)
+				if err != nil {
+					return renderedSchema{}, err
+				}
+				out.codecAlters = append(out.codecAlters, alt)
 			default:
 				return renderedSchema{}, fmt.Errorf(
-					"the rendered schema carries a statement that is neither a CREATE nor an ADD PROJECTION/INDEX, "+
-						"so the diff would pass over it unchecked: %s", firstLine(stmt),
+					"the rendered schema carries a statement that is neither a CREATE nor an ADD PROJECTION/INDEX "+
+						"nor a MODIFY COLUMN CODEC, so the diff would pass over it unchecked: %s", firstLine(stmt),
 				)
 			}
 			continue
@@ -884,6 +946,23 @@ func parseAddIndex(stmt string) (renderedIndex, error) {
 		return renderedIndex{}, fmt.Errorf("the rendered index ALTER %s: %w", firstLine(stmt), err)
 	}
 	return renderedIndex{database: database, table: table, name: strings.Trim(m[2], "`\"")}, nil
+}
+
+// parseModifyColumnCodec is parseAddProjection's sibling for
+// `ALTER TABLE … MODIFY COLUMN IF EXISTS … CODEC(…)` (cerberus issue #2768).
+// Callers match alterModifyColumnCodecRe first, so a non-match here would be
+// a caller bug rather than a genuinely different statement shape.
+func parseModifyColumnCodec(stmt string) (renderedCodecAlter, error) {
+	m := alterModifyColumnCodecRe.FindStringSubmatch(stmt)
+	if m == nil {
+		return renderedCodecAlter{}, fmt.Errorf("parseModifyColumnCodec called on a statement alterModifyColumnCodecRe does not match: %s",
+			firstLine(stmt))
+	}
+	database, table, err := splitQualifiedName(m[1])
+	if err != nil {
+		return renderedCodecAlter{}, fmt.Errorf("the rendered codec ALTER %s: %w", firstLine(stmt), err)
+	}
+	return renderedCodecAlter{database: database, table: table, column: strings.Trim(m[2], "`\"")}, nil
 }
 
 // splitQualifiedName unquotes a rendered `"db"."table"` / “ `db`.`table` “

--- a/test/perf/cardinality-baseline/promql/native_last_over_time_range_step.json
+++ b/test/perf/cardinality-baseline/promql/native_last_over_time_range_step.json
@@ -1,0 +1,11 @@
+{
+  "fixture": "promql/native_last_over_time_range_step",
+  "fan_factor": 1.6666666666666667,
+  "scan_rows": 3,
+  "peak_intermediate": 5,
+  "has_cross_join": false,
+  "has_array_join": true,
+  "has_recursive_cte": false,
+  "max_recursion_depth": 0,
+  "uncountable_levels": 0
+}

--- a/test/perf/cardinality-baseline/promql/sorted_slab_avg_over_time_range_step.json
+++ b/test/perf/cardinality-baseline/promql/sorted_slab_avg_over_time_range_step.json
@@ -1,0 +1,11 @@
+{
+  "fixture": "promql/sorted_slab_avg_over_time_range_step",
+  "fan_factor": 1.6923076923076923,
+  "scan_rows": 13,
+  "peak_intermediate": 22,
+  "has_cross_join": false,
+  "has_array_join": true,
+  "has_recursive_cte": false,
+  "max_recursion_depth": 0,
+  "uncountable_levels": 0
+}

--- a/test/perf/cardinality-baseline/promql/sorted_slab_sum_over_time_range_step.json
+++ b/test/perf/cardinality-baseline/promql/sorted_slab_sum_over_time_range_step.json
@@ -1,0 +1,11 @@
+{
+  "fixture": "promql/sorted_slab_sum_over_time_range_step",
+  "fan_factor": 1.6923076923076923,
+  "scan_rows": 13,
+  "peak_intermediate": 22,
+  "has_cross_join": false,
+  "has_array_join": true,
+  "has_recursive_cte": false,
+  "max_recursion_depth": 0,
+  "uncountable_levels": 0
+}


### PR DESCRIPTION
Closes #2768.

## Summary

- Curated `ALTER TABLE ... MODIFY COLUMN ... CODEC` entries, same DDL-registry slot as `ADD
  PROJECTION` / `ADD INDEX`, for two candidates that measured a real win: logs `Body` (`ZSTD(1)` ->
  `ZSTD(3)`) and span `Duration` (`ZSTD(1)` -> `GCD, ZSTD(1)`).
- Every candidate the issue proposed was benchmarked against real or representative data — not
  assumed from the issue text. Two of the issue's own proposed candidates (DoubleDelta for
  metrics/span timestamps, Gorilla/FPC for Value/Sum) measured regressions and are deliberately
  **not** adopted; see below for the numbers.
- Adds `chsql.AlterTableModifyColumnCodec` + `chsql.Codec`, and files #2822 (ALP follow-up) per the
  issue's own deferral instruction.

Curated `ALTER TABLE ... MODIFY COLUMN ... CODEC` entries in the post-CREATE DDL registry
(`internal/schema/ddl/ddl.go`), same slot as `ADD PROJECTION` / `ADD INDEX`. Every candidate the
issue proposed was benchmarked — not just reasoned about — against real production-shaped sample
data or (for the traces column, which has no real sample in this repo) representative synthetic
data, via a real MergeTree engine (chDB), comparing whole-table compressed bytes before/after each
codec swap. **Only two of the issue's candidates survived measurement.**

## What's adopted

- **Logs `Body`:** `ZSTD(1)` -> `ZSTD(3)` — measured ~1.3%-1.8% smaller on a representative
  leveled-log-line corpus, consistently across repeated runs. ZSTD decode cost is level-independent,
  so this is a write-side-only tradeoff; read/query latency is unaffected.
- **Span `Duration`:** `ZSTD(1)` -> `CODEC(GCD, ZSTD(1))` (no `Delta` stage) — measured a real ~3.5%
  win when real precision is coarser than the column's declared nanosecond resolution (the issue's
  own GCD rationale), and a statistical no-op (+0.02%, noise) when precision is genuinely
  fine-grained. Chaining `Delta` ahead of ZSTD — either plain `Delta, ZSTD(1)` or the issue's own
  proposed `GCD, Delta, ZSTD(1)` pairing — measured 3%-10% **larger** instead: Duration values are
  independent per-span measurements, not a running sequence, so delta-encoding adds entropy rather
  than removing it.

## What's NOT adopted (measured, not assumed)

- **Metrics `TimeUnix` / span `Timestamp`:** the issue proposed `DoubleDelta, ZSTD(1)`. Measured
  against three real metrics tables (gauge/sum/histogram, `test/perf/nightly/testdata/samples/`,
  issue #2411), DoubleDelta was **43%-166% larger** than the current `Delta, ZSTD(1)` — a
  regression. A near-constant Delta stream is already maximally redundant (the same repeated
  interval), which `ZSTD(1)` alone already exploits about as well as physically possible
  (232x-443x compression measured); DoubleDelta's own per-value framing bytes break up that
  redundancy more than they remove. `GCD, Delta, ZSTD(1)` measured a small, **inconsistent** effect
  across the three tables (-3.5% to -6.9% on sum/histogram, but **+9.2% on gauge**) — not a safe
  blanket win across every metrics table sharing one codec declaration. Bare `GCD, ZSTD(1)` measured
  catastrophically worse (+650% to +3515%). TimeUnix / Timestamp keep their current codec, unchanged.
- **Value (gauge/sum) / Sum (histogram/summary/exp_histogram) `Float64`:** the issue gated
  Gorilla/FPC adoption on beating `ZSTD(1)` on real gauge-shaped data — its own explicit condition.
  Measured against the same three real tables, both regressed: Gorilla 27%-2182% larger, FPC
  84%-2662% larger. Neither is adopted; Value/Sum keep `ZSTD(1)`, unchanged.

## Measured numbers

All whole-table `data_compressed_bytes` deltas from a real MergeTree engine (chDB), `OPTIMIZE ...
FINAL`'d before measuring.

**Metrics (real production-shaped data, issue #2411 sample, ~1.3-1.7M rows/table):**

| Table | Column | Baseline | Candidate | Delta |
|---|---|---|---|---|
| gauge | TimeUnix: Delta -> DoubleDelta | 30,283 B | 48,204 B | +59.18% |
| sum | TimeUnix: Delta -> DoubleDelta | 40,256 B | 57,439 B | +42.68% |
| histogram | TimeUnix: Delta -> DoubleDelta | 45,246 B | 120,297 B | +165.87% |
| gauge | TimeUnix: Delta -> GCD+Delta | 30,283 B | 33,063 B | +9.18% |
| sum | TimeUnix: Delta -> GCD+Delta | 40,256 B | 38,836 B | -3.53% |
| histogram | TimeUnix: Delta -> GCD+Delta | 45,246 B | 42,142 B | -6.86% |
| gauge | TimeUnix: Delta -> GCD | 30,283 B | 227,042 B | +649.73% |
| sum | TimeUnix: Delta -> GCD | 40,256 B | 1,455,126 B | +3514.68% |
| histogram | TimeUnix: Delta -> GCD | 45,246 B | 1,453,583 B | +3112.62% |
| gauge | Value: ZSTD(1) -> Gorilla | 226 B | 5,157 B | +2181.86% |
| sum | Value: ZSTD(1) -> Gorilla | 149,792 B | 323,194 B | +115.76% |
| histogram | Sum: ZSTD(1) -> Gorilla | 621,807 B | 788,658 B | +26.83% |
| gauge | Value: ZSTD(1) -> FPC | 226 B | 6,241 B | +2661.50% |
| sum | Value: ZSTD(1) -> FPC | 149,792 B | 1,085,131 B | +624.43% |
| histogram | Sum: ZSTD(1) -> FPC | 621,807 B | 1,143,881 B | +83.96% |

**Traces (synthetic — no real trace sample exists in this repo; two precision scenarios, ~210K-236K
spans each):**

| Scenario | Column | Baseline | Candidate | Delta |
|---|---|---|---|---|
| ns-precision | Timestamp: Delta -> DoubleDelta | 1,549,570 B | 1,752,052 B | +13.07% |
| ns-precision | Timestamp: Delta -> GCD+Delta | 1,549,570 B | 1,550,019 B | +0.03% |
| ns-precision | Duration: ZSTD(1) -> Delta+ZSTD(1) | 1,549,570 B | 1,711,455 B | +10.45% |
| ns-precision | Duration: ZSTD(1) -> GCD+Delta+ZSTD(1) | 1,549,570 B | 1,711,949 B | +10.48% |
| ns-precision | Duration: ZSTD(1) -> **GCD+ZSTD(1)** | 1,549,570 B | 1,549,899 B | +0.02% |
| ms-rounded | Timestamp: Delta -> DoubleDelta | 1,262,762 B | 1,479,761 B | +17.18% |
| ms-rounded | Timestamp: Delta -> GCD+Delta | 1,262,762 B | 1,263,191 B | +0.03% |
| ms-rounded | Duration: ZSTD(1) -> Delta+ZSTD(1) | 1,262,762 B | 1,305,375 B | +3.37% |
| ms-rounded | Duration: ZSTD(1) -> GCD+Delta+ZSTD(1) | 1,262,762 B | 1,296,451 B | +2.67% |
| ms-rounded | Duration: ZSTD(1) -> **GCD+ZSTD(1)** | 1,262,762 B | 1,218,414 B | **-3.51%** |

**Logs (synthetic leveled-log corpus, 300K rows, two independent runs):**

| Run | Baseline (ZSTD(1)) | Candidate (ZSTD(3)) | Delta |
|---|---|---|---|
| 1 | 4,665,091 B | 4,580,819 B | -1.81% |
| 2 | 6,469,598 B | 6,385,326 B | -1.30% |

## Query-latency / decode-cost impact

None of the adopted codecs add read-side decode cost beyond what the current defaults already pay:
GCD's inverse (multiply back by the divisor) and ZSTD decompression are both level-independent on
the decode side — ZSTD's higher compression levels (1 -> 3) only cost more CPU at *write* time.
Neither adopted codec changes anything the query planner reads structurally (no ORDER BY, no
partition key, no index touched), so no query-shape or plan-routing change is expected or was
observed.

## Version floor

Every codec involved (Delta, DoubleDelta, GCD, Gorilla, FPC — including the rejected ones, named
here because the reasoning needs to identify what was tested) is supported at ClickHouse >= 22.9,
well under this repo's 24.8 floor. Verified directly against a live server at exactly the 24.8
floor (`clickhouse/clickhouse-server:24.8-alpine`): `MODIFY COLUMN IF EXISTS <col> CODEC(GCD,
ZSTD(1))` / `CODEC(ZSTD(3))` both apply cleanly, and re-issuing the identical statement twice
produces no error (confirms the idempotency contract — ClickHouse treats an unchanged codec
declaration as a no-op, not something a guard clause provides). Also exercised end-to-end through
`cmd/cerberus`'s `TestAutoCreateSchema_StartupWiring` integration test against a real ClickHouse
25.9 container (apply, then re-apply to confirm idempotency from the startup-hook angle) — both
passed. So — like `ADD PROJECTION` / `ADD INDEX`, and unlike `ADD STATISTICS`'s chopt-gated
`column_statistics` feature — this registry renders **unconditionally**: no config flag, no chopt
gate.

## ALP follow-up

The issue asked that experimental ALP be earmarked as future work (its 26.8 release changed Float32
arithmetic — a live on-disk decode-compat risk below that floor) rather than implemented now.
Filed as #2822, gated on a future `>= 26.8` version floor.

## `bench/histogram/cmd/gen/main.go` sync check

The issue asked to check whether this generator's hardcoded fallback codec defaults
(`fallbackHistDDL`, lines ~417-445) need to stay in sync. They don't, for this PR: none of the
columns that generator's fallback DDL declares (`TimeUnix`, `StartTimeUnix`, `Sum` on
`otel_metrics_histogram`) got a codec change here — `TimeUnix` and `Sum` are exactly the two
candidates measured and **rejected** above. No edit needed.

## Idempotency contract (chsql.ModifyColumnCodecBuilder)

`MODIFY COLUMN` has no `IF NOT EXISTS`-shaped guard, only `IF EXISTS` (a no-op on an absent column,
not an unchanged one). Re-apply safety comes entirely from ClickHouse itself treating an unchanged
codec declaration as a no-op — verified above, not assumed. See the new builder's doc comment in
`internal/chsql/ddl.go`.

## Tests

- `internal/chsql/ddl_test.go`: `TestAlterTableModifyColumnCodec` pins the new builder's rendered
  SQL (qualified/unqualified table, ON CLUSTER, single-stage codec).
- `internal/schema/ddl/ddl_test.go` / `idempotency_test.go`: extended the Logs/Traces exact-statement
  and statement-count assertions for the two new codec ALTERs, plus a new
  `TestRenderSignal_CodecAltersCarryIfExists` pinning the `IF EXISTS` guard (the counterpart to
  `TestRenderSignal_AllTablesCarryIfNotExists`, which now explicitly exempts codec ALTERs with an
  explanatory comment rather than silently special-casing them).
- `test/e2e/migration/steps/schema.go`: the migration-preview "renderer applies nothing to any
  database" classifier only recognized `ADD PROJECTION`/`ADD INDEX ... IF NOT EXISTS` as an
  idempotent, non-destructive ALTER shape; taught it to also recognize the new `MODIFY COLUMN IF
  EXISTS ... CODEC(...)` shape (a genuine gap this PR's unconditional registry entry exposed, not a
  golden-only change) — `just update-golden migration ...` regenerated the affected goldens
  (`test/e2e/migration/expected/schema/*.sql`) after the fix.
- `docs/operations.md`: new "Curated column compression codecs" section mirroring the existing
  ADD PROJECTION / ADD INDEX / ADD STATISTICS documentation pattern, including the measured-numbers
  summary and an `OPTIMIZE ... FINAL` back-fill runbook (codec changes have no dedicated
  `MATERIALIZE`-style mutation).

## Test plan

- [x] `go test ./internal/chsql/... ./internal/schema/ddl/...` (race-detected) — green
- [x] chDB-tagged tests in `internal/schema/ddl` — green
- [x] `just update-golden migration parity solver promql logql traceql chsql optimizer codegen
      cardinality` (every shard the `internal/chsql` diff flagged as potentially stale) — green,
      only the migration goldens actually changed
- [x] `go build ./...` — green
- [x] `node .github/scripts/forbid-sql-raw.mjs` — green
- [x] Real-ClickHouse verification: 24.8-floor container (direct SQL) + 25.9 testcontainers
      integration test (`TestAutoCreateSchema_StartupWiring`, apply + re-apply) — both green

## Notes for reviewers

- `just update-golden cardinality` (required because the branch touches `internal/chsql`, which
  the recipe treats as a blanket trigger for every downstream shard) surfaced three cardinality
  baselines that were missing from `main` for query shapes two already-merged, unrelated features
  added (`ts_grid_last_over_time` / sorted-slab `sum_over_time`/`avg_over_time`) — a pre-existing
  gap `TestCardinalityBaselineCoversTheCorpus` would fail without. Included them
  (`test/perf/cardinality-baseline/promql/{native_last_over_time_range_step,
  sorted_slab_avg_over_time_range_step,sorted_slab_sum_over_time_range_step}.json`) since the
  mandated regen run produced them as a side effect; they carry no relation to codec tuning itself.
- The migration-preview classifier fix (`test/e2e/migration/steps/schema.go`) is a real bug this
  PR's unconditional codec registry exposed, not a golden-only change — `MODIFY COLUMN` statements
  were never previously exercised through that "renderer applies nothing to any database" check.
