### PR TITLE
feat(chclient,api/info,docs): S3 remote-fs read tuning audit + filesystem cache observability

### DIFF
--- a/cmd/cerberus/main.go
+++ b/cmd/cerberus/main.go
@@ -1214,6 +1214,27 @@ func infoOptions(
 			hits, misses := chclient.ResultCacheStats()
 			return info.ResultCacheState{Hits: hits, Misses: misses}
 		},
+		// FilesystemCache reports the server-side filesystem cache reading
+		// (cerberus issue #2780), read over the SAME probe head as
+		// Reachable/Ready. A query failure (server unreachable, or too old
+		// to carry system.filesystem_cache_settings — the table has existed
+		// well below cerberus's own 24.8 floor, but a query error is
+		// possible on ANY live poll) degrades to the honest all-zero
+		// Configured=false reading rather than surfacing a transient error
+		// on a metadata endpoint that always returns 200.
+		FilesystemCache: func(ctx context.Context) info.FilesystemCacheState {
+			state, err := probe.QueryFilesystemCacheState(ctx)
+			if err != nil {
+				return info.FilesystemCacheState{}
+			}
+			return info.FilesystemCacheState{
+				Configured:       state.Configured,
+				Caches:           state.Caches,
+				MaxSizeBytes:     state.MaxSizeBytes,
+				CurrentSizeBytes: state.CurrentSizeBytes,
+				CurrentElements:  state.CurrentElements,
+			}
+		},
 		StartTime:   startTime,
 		Reachable:   func(ctx context.Context) bool { return probe.Ping(ctx) == nil },
 		Breaker:     probe.PeekBreakerState,

--- a/docs/clickhouse-optimizations.md
+++ b/docs/clickhouse-optimizations.md
@@ -638,6 +638,65 @@ Notes:
   `sum_over_time` (`increase`, `delta`, `irate`, `idelta`), continues to lower
   through the existing array-expression fan-out unchanged.
 
+## Audited, not adopted
+
+Not every settings family the audit epic (#2778) reviews earns a registry
+entry. Recording an audit that found nothing to stamp is itself the useful
+artifact — the alternative is the same family getting silently re-reviewed
+by a future pass with no memory of this one.
+
+### S3/remote-filesystem read tuning (cerberus issue #2780)
+
+Production is a single node with S3-backed storage, so the working
+hypothesis was that cerberus's cold dashboard scans need explicit tuning of
+ClickHouse's prefetch and remote-filesystem concurrent-read settings. Probed
+live via chDB (ClickHouse 26.5.1.1) rather than assumed from the settings'
+documented defaults — `system.settings` reports:
+
+| Setting                                                             | Live value | Live default |
+| ------------------------------------------------------------------- | ---------- | ------------ |
+| `remote_filesystem_read_prefetch`                                   | `1`        | `1`          |
+| `allow_prefetched_read_pool_for_remote_filesystem`                  | `1`        | `1`          |
+| `merge_tree_min_rows_for_concurrent_read_for_remote_filesystem`     | `0`        | `0`          |
+| `merge_tree_min_bytes_for_concurrent_read_for_remote_filesystem`    | `0`        | `0`          |
+
+Prefetch is already on. The remote-filesystem concurrent-read thresholds are
+already at `0` — the most aggressive setting available, meaning ClickHouse
+already runs EVERY remote-filesystem part read concurrently regardless of
+size, unlike the local-disk counterparts
+(`merge_tree_min_rows_for_concurrent_read` / `..._bytes_...`, which default
+to 163840 rows / 240 MiB — a real threshold, because a local read is cheap
+enough that a small part isn't worth parallelizing). ClickHouse's own
+defaults, on the exact deployment shape this issue targets, are already
+tuned past what a `chopt` stamp forcing `remote_filesystem_read_prefetch=1`
+or lowering an already-zero threshold could add — the entire premise
+"stamp only where the default is off or measurably wrong" resolves to
+neither being true. Per the audit-epic mandate (#2778) to verify a proposal
+against the live server rather than assume it from documentation alone, no
+`chopt` feature is registered for either family: it would be machinery
+duplicating what the server already does unconditionally.
+
+**A genuinely open question this audit surfaced, not resolved by it**: the
+issue's own "fan-out-heavy wide scans vs point lookups" framing implies the
+OPPOSITE tuning direction might pay off — deliberately RAISING the
+remote-filesystem concurrent-read thresholds (toward the local-disk
+defaults) on a detected narrow, highly-selective point-lookup shape, to
+avoid the coordination overhead of spinning up concurrent S3 fetches for a
+read that only touches a handful of granules. That is a real, plausible
+optimization, but — unlike the two settings families above — it needs an
+optcorpus A/B pass against representative point-lookup and wide-scan query
+shapes to earn adoption, the same bar `fixed_accumulator_extrapolated` and
+`sorted_slab_over_time` were held to before their own AutoSelect posture was
+decided. Tracked at
+[cerberus#2827](https://github.com/tsouza/cerberus/issues/2827), not
+attempted in this PR.
+
+**Local filesystem cache** (`enable_filesystem_cache` + the server-side
+cache disk) IS adopted by this issue, but as documented operator guidance
+plus `/info` reporting rather than a `chopt` stamp — it is a server-config /
+disk-sizing concern, not a per-query setting. See
+[`docs/operations.md`](operations.md)'s "Local filesystem cache" section.
+
 ## Runtime version probe
 
 At connection init the client issues `SELECT version()` once, parses the

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -922,6 +922,111 @@ the boot **requirements check** as a warning naming the exact fix. Those are
 warnings rather than boot failures because storage layout is a cost property of
 the tables, not a correctness property of the gateway.
 
+### Local filesystem cache (cerberus issue #2780)
+
+Production is explicitly a **single node with S3-backed storage** (see
+"Helm: bundled ClickHouse on object storage" above), so a cold dashboard scan
+is latency-dominated by object-store round trips, not CPU. ClickHouse's local
+filesystem cache — a disk-backed cache of the raw S3 byte ranges a MergeTree
+read touches, keyed by object path + offset — sits directly on that leverage:
+a part whose ranges are already cached serves from local disk instead of
+re-fetching from S3 on every scan, which matters most for cerberus's own
+access pattern of the same recent partitions being rescanned by every
+dashboard refresh.
+
+**This is a SERVER-CONFIG concern, not a `chopt` stamp.** The per-query
+toggle (`enable_filesystem_cache`) already defaults to `1` on every
+ClickHouse version cerberus supports — confirmed live via chDB (ClickHouse
+26.5.1.1) rather than assumed, see "Audited, not adopted" in
+[`docs/clickhouse-optimizations.md`](clickhouse-optimizations.md) — so there
+is nothing for cerberus to stamp per query. What the per-query default cannot
+do is create the cache: a `cache`-type disk has to exist in the server's
+`storage_configuration` before `enable_filesystem_cache=1` has anywhere to
+write, exactly the gap
+[ClickHouse's own "using local cache" doc](https://clickhouse.com/docs/operations/storing-data#using-local-cache)
+describes. That disk definition, and the operator work below, lives entirely
+in the ClickHouse server config cerberus does not template — cerberus's own
+knob is `CERBERUS_SCHEMA_STORAGE_POLICY` (see "Hot/cold storage tiering"
+above), which only SELECTS which already-defined server-side policy new
+tables use.
+
+**Wiring a cache disk over the S3 disk**, in the ClickHouse server's own
+`config.xml`/`config.d` — the shape the doc above walks through, wrapping
+whatever `<s3_disk>` the "bundled ClickHouse on object storage" section
+already defines:
+
+```xml
+<storage_configuration>
+  <disks>
+    <s3_cache>
+      <type>cache</type>
+      <disk>s3_disk</disk>
+      <path>/var/lib/clickhouse/disks/s3_cache/</path>
+      <max_size>107374182400</max_size> <!-- 100 GiB; see sizing below -->
+    </s3_cache>
+  </disks>
+  <policies>
+    <s3_main>
+      <volumes>
+        <main>
+          <disk>s3_cache</disk>
+        </main>
+      </volumes>
+    </s3_main>
+  </policies>
+</storage_configuration>
+```
+
+Point `CERBERUS_SCHEMA_STORAGE_POLICY` at the wrapping policy name (`s3_main`
+above) so cerberus's auto-created tables land on the cache-backed disk
+instead of the raw S3 one directly.
+
+**Sizing the cache disk for the single-node profile.** The cache only pays
+off across the "hot" window a dashboard actually rescans — sized past that
+window it just holds cold, never-revisited ranges. A first-pass estimate
+uses the same production figures already measured elsewhere in this doc
+("Metadata-enumeration projections", "Ongoing ingest cost"): ~2,824 rows/s
+sustained ingest against a measured ~4 billion rows / ~140 GiB on-disk
+(compressed) ratio is ~35 bytes/row, so:
+
+```text
+hot_window_bytes ≈ sustained_rows_per_sec × bytes_per_row × hot_window_seconds
+                ≈ 2,824 × 35 × hot_window_seconds
+```
+
+A 24-hour hot window (the busiest Grafana panels' typical lookback) is
+therefore ~**8.3 GiB/day**; a 7-day hot window (weekly comparisons, longer
+on-call lookback) is ~**58 GiB**. Recompute with the deployment's OWN
+sustained ingest rate and per-row size (`system.parts` on the live table) —
+the figures above are this doc's own measured production numbers, not a
+universal constant — and size the disk with headroom past the busiest
+window an operator's dashboards actually reissue, not the full retention
+window: cold, rarely-revisited history gains little from caching and would
+just evict the hot ranges that pay for themselves.
+
+**Warm-up for the hot recent window.** ClickHouse's cache metadata persists
+across a graceful restart (`load_metadata_threads` reloads it at startup), so
+a routine restart does not empty it. It DOES start genuinely cold the first
+time a cache disk is wired in, and a cache freshly resized larger has empty
+new capacity until something touches it. In either case the fastest path to
+a warm cache is deliberately re-issuing the query shapes that would
+otherwise warm it organically off real traffic: replay a representative
+sample of recent dashboard queries (or, simplest, a broad `SELECT count()`
+over the last `hot_window`'s worth of each fact table) once after standing
+up or resizing the cache, rather than letting the first wave of real user
+traffic pay the cold-scan cost.
+
+**Observability.** `GET /info`'s `filesystemCache` object reports whether a
+cache is configured at all (`configured`, `caches`) plus its aggregate
+configured capacity and live occupancy (`maxSizeBytes`, `currentSizeBytes`,
+`currentElements`), read live from `system.filesystem_cache_settings` on
+every poll — so "is the cache actually there, and how full is it" is
+answered without a ClickHouse shell. `configured: false` on a deployment that
+believes it wired a cache disk is the single most actionable signal this
+section can give: it means the `storage_configuration` above never took
+effect (a config-reload miss, a typo'd disk name in the policy, or the
+policy itself not yet applied via `CERBERUS_SCHEMA_STORAGE_POLICY`).
+
 ### Metadata-enumeration projections (curated registry)
 
 Auto-create installs a small **curated registry** of aggregating projections

--- a/internal/api/info/info.go
+++ b/internal/api/info/info.go
@@ -381,19 +381,15 @@ func (h *Handler) resultCacheNow() ResultCacheState {
 // state and renders it as the JSON-shaped filesystemCacheInfo. An unwired
 // closure yields the zero FilesystemCacheState (Configured=false, every
 // counter 0), the honest answer for a handler wired without
-// chclient.QueryFilesystemCacheState.
+// chclient.QueryFilesystemCacheState. FilesystemCacheState and
+// filesystemCacheInfo share an identical field set (only struct tags
+// differ), so this is a plain type conversion rather than a field-by-field
+// literal — the same shape resultCacheInfoNow uses.
 func (h *Handler) filesystemCacheInfoNow(ctx context.Context) filesystemCacheInfo {
 	if h.filesystemCache == nil {
 		return filesystemCacheInfo{}
 	}
-	s := h.filesystemCache(ctx)
-	return filesystemCacheInfo{
-		Configured:       s.Configured,
-		Caches:           s.Caches,
-		MaxSizeBytes:     s.MaxSizeBytes,
-		CurrentSizeBytes: s.CurrentSizeBytes,
-		CurrentElements:  s.CurrentElements,
-	}
+	return filesystemCacheInfo(h.filesystemCache(ctx))
 }
 
 func (h *Handler) reachableNow(ctx context.Context) bool {

--- a/internal/api/info/info.go
+++ b/internal/api/info/info.go
@@ -101,6 +101,36 @@ type ResultCacheState struct {
 	Misses uint64
 }
 
+// FilesystemCacheState is the current server-side filesystem cache reading
+// (cerberus issue #2780): whether an operator has configured a named
+// filesystem cache disk at all (see docs/operations.md's "Local filesystem
+// cache" section) plus its aggregate configured capacity and live
+// occupancy, read from chclient.QueryFilesystemCacheState. Configured is
+// the headline field — the per-query enable_filesystem_cache toggle already
+// defaults to on across every ClickHouse version cerberus supports
+// (verified live; see docs/clickhouse-optimizations.md), so the one thing
+// standing between "cerberus" and "cerberus with a warm S3 read cache" is
+// whether the operator has wired a cache disk into the server's
+// storage_configuration — this field answers that directly instead of
+// leaving it to be inferred from a zero byte count that could otherwise
+// mean either "no cache" or "an empty configured one".
+type FilesystemCacheState struct {
+	// Configured reports whether at least one named filesystem cache is
+	// configured on the connected server.
+	Configured bool
+	// Caches is the number of named filesystem caches configured.
+	Caches uint64
+	// MaxSizeBytes is the summed configured max_size across every
+	// configured cache.
+	MaxSizeBytes uint64
+	// CurrentSizeBytes is the summed current_size (live occupied bytes)
+	// across every configured cache.
+	CurrentSizeBytes uint64
+	// CurrentElements is the summed current_elements_num (live occupied
+	// file segments) across every configured cache.
+	CurrentElements uint64
+}
+
 // Options configure Handler.
 type Options struct {
 	// Snapshot is the static, boot-captured fingerprint. Required.
@@ -116,6 +146,16 @@ type Options struct {
 	// (cerberus issue #2781). When nil the body reports 0/0, the honest
 	// answer for a handler wired without chclient.ResultCacheStats.
 	ResultCache func() ResultCacheState
+
+	// FilesystemCache reports the CURRENT server-side filesystem cache
+	// state (cerberus issue #2780), read live under the handler's own ping
+	// budget the same way Reachable/Ready are — cache configuration and
+	// occupancy are properties of the connected server, not of cerberus's
+	// own process, so a rolling ClickHouse config change is reflected on
+	// the next poll without a restart. When nil the body reports
+	// Configured=false and every counter at 0, the honest answer for a
+	// handler wired without chclient.QueryFilesystemCacheState.
+	FilesystemCache func(ctx context.Context) FilesystemCacheState
 
 	// Reachable reports whether ClickHouse is reachable right now. It is the
 	// same ping the /readyz probe issues, but reported as a plain bool here.
@@ -147,15 +187,16 @@ type Options struct {
 
 // Handler serves GET /info. Construct via New and register via Mount.
 type Handler struct {
-	snap        Snapshot
-	opts        func() OptState
-	resultCache func() ResultCacheState
-	reachable   func(ctx context.Context) bool
-	breaker     func() string
-	schemaReady func() bool
-	ready       func(ctx context.Context) bool
-	start       time.Time
-	pingTimeout time.Duration
+	snap            Snapshot
+	opts            func() OptState
+	resultCache     func() ResultCacheState
+	filesystemCache func(ctx context.Context) FilesystemCacheState
+	reachable       func(ctx context.Context) bool
+	breaker         func() string
+	schemaReady     func() bool
+	ready           func(ctx context.Context) bool
+	start           time.Time
+	pingTimeout     time.Duration
 }
 
 // defaultPingTimeout bounds the live reachability/ready probes per request.
@@ -167,15 +208,16 @@ const defaultPingTimeout = time.Second
 // well-formed body.
 func New(opts Options) *Handler {
 	h := &Handler{
-		snap:        opts.Snapshot,
-		opts:        opts.Optimizations,
-		resultCache: opts.ResultCache,
-		reachable:   opts.Reachable,
-		breaker:     opts.Breaker,
-		schemaReady: opts.SchemaReady,
-		ready:       opts.Ready,
-		start:       opts.StartTime,
-		pingTimeout: opts.PingTimeout,
+		snap:            opts.Snapshot,
+		opts:            opts.Optimizations,
+		resultCache:     opts.ResultCache,
+		filesystemCache: opts.FilesystemCache,
+		reachable:       opts.Reachable,
+		breaker:         opts.Breaker,
+		schemaReady:     opts.SchemaReady,
+		ready:           opts.Ready,
+		start:           opts.StartTime,
+		pingTimeout:     opts.PingTimeout,
 	}
 	if h.pingTimeout <= 0 {
 		h.pingTimeout = defaultPingTimeout
@@ -215,19 +257,31 @@ type resultCacheInfo struct {
 	Misses uint64 `json:"misses"`
 }
 
+// filesystemCacheInfo is the nested "filesystemCache" object of the /info
+// body (cerberus issue #2780) — the server-side filesystem cache's
+// configured-vs-occupied state.
+type filesystemCacheInfo struct {
+	Configured       bool   `json:"configured"`
+	Caches           uint64 `json:"caches"`
+	MaxSizeBytes     uint64 `json:"maxSizeBytes"`
+	CurrentSizeBytes uint64 `json:"currentSizeBytes"`
+	CurrentElements  uint64 `json:"currentElements"`
+}
+
 // infoResponse is the single JSON fingerprint GET /info returns. Field casing
 // (lowerCamelCase) mirrors the health handler's JSON conventions.
 type infoResponse struct {
-	Service       string            `json:"service"`
-	Version       string            `json:"version"`
-	Revision      string            `json:"revision"`
-	GoVersion     string            `json:"goVersion"`
-	UptimeSeconds int64             `json:"uptimeSeconds"`
-	Heads         []string          `json:"heads"`
-	ClickHouse    clickHouseInfo    `json:"clickhouse"`
-	Optimizations optimizationsInfo `json:"optimizations"`
-	ResultCache   resultCacheInfo   `json:"resultCache"`
-	Ready         bool              `json:"ready"`
+	Service         string              `json:"service"`
+	Version         string              `json:"version"`
+	Revision        string              `json:"revision"`
+	GoVersion       string              `json:"goVersion"`
+	UptimeSeconds   int64               `json:"uptimeSeconds"`
+	Heads           []string            `json:"heads"`
+	ClickHouse      clickHouseInfo      `json:"clickhouse"`
+	Optimizations   optimizationsInfo   `json:"optimizations"`
+	ResultCache     resultCacheInfo     `json:"resultCache"`
+	FilesystemCache filesystemCacheInfo `json:"filesystemCache"`
+	Ready           bool                `json:"ready"`
 }
 
 // handleInfo writes the fingerprint. It always returns 200: /info is a
@@ -273,8 +327,9 @@ func (h *Handler) snapshotResponse(ctx context.Context) infoResponse {
 			ResolvedAgainstVersion: opts.ServerVersion,
 			Enabled:                opts.Enabled,
 		},
-		ResultCache: h.resultCacheInfoNow(),
-		Ready:       h.readyNow(pingCtx),
+		ResultCache:     h.resultCacheInfoNow(),
+		FilesystemCache: h.filesystemCacheInfoNow(pingCtx),
+		Ready:           h.readyNow(pingCtx),
 	}
 }
 
@@ -320,6 +375,25 @@ func (h *Handler) resultCacheNow() ResultCacheState {
 		return ResultCacheState{}
 	}
 	return h.resultCache()
+}
+
+// filesystemCacheInfoNow reads the current server-side filesystem cache
+// state and renders it as the JSON-shaped filesystemCacheInfo. An unwired
+// closure yields the zero FilesystemCacheState (Configured=false, every
+// counter 0), the honest answer for a handler wired without
+// chclient.QueryFilesystemCacheState.
+func (h *Handler) filesystemCacheInfoNow(ctx context.Context) filesystemCacheInfo {
+	if h.filesystemCache == nil {
+		return filesystemCacheInfo{}
+	}
+	s := h.filesystemCache(ctx)
+	return filesystemCacheInfo{
+		Configured:       s.Configured,
+		Caches:           s.Caches,
+		MaxSizeBytes:     s.MaxSizeBytes,
+		CurrentSizeBytes: s.CurrentSizeBytes,
+		CurrentElements:  s.CurrentElements,
+	}
 }
 
 func (h *Handler) reachableNow(ctx context.Context) bool {

--- a/internal/api/info/info_test.go
+++ b/internal/api/info/info_test.go
@@ -167,6 +167,56 @@ func TestInfo_ResultCacheNilFuncDefaultsToZero(t *testing.T) {
 	}
 }
 
+// TestInfo_FilesystemCacheConfigured (cerberus issue #2780) confirms a
+// configured server-side filesystem cache surfaces verbatim under
+// filesystemCache.{configured,caches,maxSizeBytes,currentSizeBytes,currentElements}.
+func TestInfo_FilesystemCacheConfigured(t *testing.T) {
+	h := New(Options{
+		Snapshot:      baseSnapshot(),
+		Optimizations: staticOpts(baseOptState()),
+		FilesystemCache: func(context.Context) FilesystemCacheState {
+			return FilesystemCacheState{
+				Configured:       true,
+				Caches:           1,
+				MaxSizeBytes:     10 << 30, // 10 GiB
+				CurrentSizeBytes: 6 << 30,  // 6 GiB
+				CurrentElements:  12345,
+			}
+		},
+	})
+	got, _ := decodeInfo(t, h)
+
+	if !got.FilesystemCache.Configured {
+		t.Errorf("filesystemCache.configured = false; want true")
+	}
+	if got.FilesystemCache.Caches != 1 {
+		t.Errorf("filesystemCache.caches = %d; want 1", got.FilesystemCache.Caches)
+	}
+	if got.FilesystemCache.MaxSizeBytes != 10<<30 {
+		t.Errorf("filesystemCache.maxSizeBytes = %d; want %d", got.FilesystemCache.MaxSizeBytes, 10<<30)
+	}
+	if got.FilesystemCache.CurrentSizeBytes != 6<<30 {
+		t.Errorf("filesystemCache.currentSizeBytes = %d; want %d", got.FilesystemCache.CurrentSizeBytes, 6<<30)
+	}
+	if got.FilesystemCache.CurrentElements != 12345 {
+		t.Errorf("filesystemCache.currentElements = %d; want 12345", got.FilesystemCache.CurrentElements)
+	}
+}
+
+// TestInfo_FilesystemCacheNilFuncDefaultsToZero confirms a handler wired
+// without Options.FilesystemCache reports Configured=false with every
+// counter at 0 rather than an absent field — the honest answer for a
+// handler wired without chclient.QueryFilesystemCacheState.
+func TestInfo_FilesystemCacheNilFuncDefaultsToZero(t *testing.T) {
+	h := New(Options{Snapshot: baseSnapshot()})
+	got, _ := decodeInfo(t, h)
+
+	want := filesystemCacheInfo{}
+	if got.FilesystemCache != want {
+		t.Errorf("filesystemCache with no resolver = %+v; want zero", got.FilesystemCache)
+	}
+}
+
 // TestInfo_ServerVersionSource verifies probe-vs-fallback round-trips
 // faithfully — the field that makes the 24.8-floor pin obvious.
 func TestInfo_ServerVersionSource(t *testing.T) {

--- a/internal/chclient/filesystem_cache_state.go
+++ b/internal/chclient/filesystem_cache_state.go
@@ -1,0 +1,101 @@
+package chclient
+
+import (
+	"context"
+	"fmt"
+)
+
+// filesystemCacheStateSQL reads the SERVER-CONFIGURED filesystem cache state
+// directly from system.filesystem_cache_settings (cerberus issue #2780): one
+// row per named cache an operator declared in the ClickHouse server config
+// (storage_configuration's `cache` disk type wrapping the S3 disk). Summing
+// across every configured cache — rather than reading a single named one —
+// means the query needs no cache-name parameter and degrades cleanly to the
+// all-zero row when no cache is configured at all (an aggregate over zero
+// input rows still returns exactly one row: count()=0, every sum()=0, never
+// NULL), so QueryFilesystemCacheState never needs nullable-column handling.
+//
+// This is DELIBERATELY not system.metrics' FilesystemCacheSize /
+// FilesystemCacheElements gauges: those report bytes/elements resident
+// across ALL caches process-wide with no per-cache breakdown and no
+// configured-max context, so they cannot answer "is a cache even
+// configured" — a zero reading is ambiguous between "no cache configured"
+// and "a configured cache that is currently empty". system.filesystem_cache_settings's
+// current_size/current_elements_num give the identical live counters WITH
+// that context, in the same query as the configured max, so this is the
+// single source of truth for the /info surface (see internal/api/info).
+const filesystemCacheStateSQL = `SELECT count(), sum(max_size), sum(max_elements), sum(current_size), sum(current_elements_num) FROM system.filesystem_cache_settings`
+
+// FilesystemCacheState is the live server-side filesystem cache reading
+// (cerberus issue #2780): whether any named cache is configured, its
+// aggregate configured capacity, and its aggregate current occupancy.
+// Configured is the headline field — operator guidance
+// (docs/operations.md's "Local filesystem cache" section) walks through
+// adding a `cache` disk to the S3 storage_configuration; until that is done
+// this reads Configured=false regardless of how many cerberus queries ran,
+// because `enable_filesystem_cache` (the per-query toggle, already 1 by
+// default on every ClickHouse version cerberus supports — verified live via
+// chDB, see docs/clickhouse-optimizations.md's audit note) has nothing to
+// cache into without a server-side cache disk.
+type FilesystemCacheState struct {
+	// Configured reports whether at least one named filesystem cache exists
+	// on the connected server (system.filesystem_cache_settings returned a
+	// non-zero row count).
+	Configured bool
+	// Caches is the number of named filesystem caches configured.
+	Caches uint64
+	// MaxSizeBytes is the summed configured max_size across every
+	// configured cache.
+	MaxSizeBytes uint64
+	// MaxElements is the summed configured max_elements across every
+	// configured cache.
+	MaxElements uint64
+	// CurrentSizeBytes is the summed current_size (live occupied bytes)
+	// across every configured cache.
+	CurrentSizeBytes uint64
+	// CurrentElements is the summed current_elements_num (live occupied
+	// file segments) across every configured cache.
+	CurrentElements uint64
+}
+
+// QueryFilesystemCacheState runs filesystemCacheStateSQL and decodes the
+// single aggregate row. Unlike the boot capability canaries (ProbeTSGridCapability,
+// ProbeResultCacheCapability) this is not a one-shot boot probe: internal/api/info
+// calls it on every GET /info request (under the handler's own bounded ping
+// timeout) because cache occupancy is live state an operator watches change
+// over the process lifetime, the same reason OptState's ServerVersion is a
+// live closure rather than a boot-captured Snapshot field.
+//
+// Guarded by the circuit breaker (see [Client] doc): a struggling ClickHouse
+// server does not get an extra query per /info poll on top of the readiness
+// ping.
+func (c *Client) QueryFilesystemCacheState(ctx context.Context) (FilesystemCacheState, error) {
+	if !c.br.allow() {
+		return FilesystemCacheState{}, c.br.openErr("chclient: query")
+	}
+	ctx = c.queryContext(ctx)
+	ctx, span := startExecuteSpan(ctx, filesystemCacheStateSQL, c.addr)
+	defer span.End()
+	defer flushProgress(ctx)
+	rows, err := c.queryOpen(ctx, filesystemCacheStateSQL)
+	c.br.record(ctx, err)
+	if err != nil {
+		span.RecordError(err)
+		return FilesystemCacheState{}, fmt.Errorf("chclient: query: %w", c.classifyDriverErr(ctx, err))
+	}
+	defer func() {
+		_ = rows.Close()
+	}()
+
+	var out FilesystemCacheState
+	if rows.Next() {
+		if err := rows.Scan(&out.Caches, &out.MaxSizeBytes, &out.MaxElements, &out.CurrentSizeBytes, &out.CurrentElements); err != nil {
+			return FilesystemCacheState{}, fmt.Errorf("chclient: scan: %w", err)
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return FilesystemCacheState{}, fmt.Errorf("chclient: rows.Err: %w", c.classifyDriverErr(ctx, err))
+	}
+	out.Configured = out.Caches > 0
+	return out, nil
+}

--- a/internal/chclient/filesystem_cache_state_chdb_test.go
+++ b/internal/chclient/filesystem_cache_state_chdb_test.go
@@ -1,0 +1,49 @@
+//go:build chdb
+
+package chclient
+
+import (
+	"database/sql"
+	"testing"
+
+	_ "github.com/chdb-io/chdb-go/chdb/driver"
+)
+
+// TestFilesystemCacheStateSQL_NoCacheConfigured pins filesystemCacheStateSQL's
+// all-zero baseline (cerberus issue #2780) against a real ClickHouse engine:
+// chDB's embedded engine carries no storage_configuration and therefore no
+// named filesystem cache at all, so system.filesystem_cache_settings is
+// empty and the query must decode to a single row of zeros — never an
+// error, since an aggregate over zero input rows is a well-formed one-row
+// result (count()=0, every sum()=0, never NULL — see the SQL constant's own
+// doc), not an empty result set QueryFilesystemCacheState would have to
+// special-case.
+//
+// Client wraps clickhouse-go/v2's native-protocol driver, which cannot dial
+// chDB's embedded engine, so this test runs the exact SQL constant over
+// database/sql + the chdb-go driver directly — the same shape-verification
+// pattern internal/chsql's *_chdb_test.go files use to validate emitted SQL
+// against a real engine without going through the production client.
+func TestFilesystemCacheStateSQL_NoCacheConfigured(t *testing.T) {
+	db, err := sql.Open("chdb", "")
+	if err != nil {
+		t.Fatalf("open chdb: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	if err := db.Ping(); err != nil {
+		t.Fatalf("ping chdb: %v", err)
+	}
+
+	var got FilesystemCacheState
+	err = db.QueryRow(filesystemCacheStateSQL).
+		Scan(&got.Caches, &got.MaxSizeBytes, &got.MaxElements, &got.CurrentSizeBytes, &got.CurrentElements)
+	if err != nil {
+		t.Fatalf("query filesystemCacheStateSQL: %v", err)
+	}
+	got.Configured = got.Caches > 0
+
+	want := FilesystemCacheState{}
+	if got != want {
+		t.Fatalf("filesystemCacheStateSQL on a cache-less server = %+v; want %+v", got, want)
+	}
+}

--- a/internal/chclient/filesystem_cache_state_integration_test.go
+++ b/internal/chclient/filesystem_cache_state_integration_test.go
@@ -1,0 +1,77 @@
+//go:build integration
+
+package chclient_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	tcclickhouse "github.com/testcontainers/testcontainers-go/modules/clickhouse"
+
+	"github.com/tsouza/cerberus/internal/chclient"
+)
+
+// TestQueryFilesystemCacheState_DefaultServerHasNoCacheConfigured runs
+// filesystemCacheStateSQL against a REAL ClickHouse server (cerberus issue
+// #2780), not chDB's embedded engine — a real server's aggregate-over-empty-
+// table NULL handling and system.filesystem_cache_settings availability are
+// worth pinning independently of the chdb-tagged unit test
+// (TestFilesystemCacheStateSQL_NoCacheConfigured), the same reasoning
+// TestProbeResultCacheCapability_HealthyServerIsAvailable's own doc gives for
+// re-running a chDB-proven query against real ClickHouse. The stock
+// testcontainers image carries no storage_configuration override, so — like
+// chDB — it has no named filesystem cache configured, and the expected
+// reading is the same all-zero Configured=false baseline. Gated by the
+// `integration` build tag (requires Docker); the E2E workflow runs it,
+// regular CI doesn't.
+func TestQueryFilesystemCacheState_DefaultServerHasNoCacheConfigured(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	defer cancel()
+
+	container, err := tcclickhouse.Run(
+		ctx,
+		"clickhouse/clickhouse-server:25.9-alpine",
+		tcclickhouse.WithUsername("cerberus"),
+		tcclickhouse.WithPassword("cerberus"),
+	)
+	if err != nil {
+		t.Fatalf("start clickhouse: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = container.Terminate(ctx)
+	})
+
+	host, err := container.Host(ctx)
+	if err != nil {
+		t.Fatalf("host: %v", err)
+	}
+	port, err := container.MappedPort(ctx, "9000/tcp")
+	if err != nil {
+		t.Fatalf("port: %v", err)
+	}
+
+	client, err := chclient.New(chclient.Config{
+		Addr:     host + ":" + port.Port(),
+		Username: "cerberus",
+		Password: "cerberus",
+		Database: "default",
+	})
+	if err != nil {
+		t.Fatalf("new default-bound client: %v", err)
+	}
+	t.Cleanup(func() { _ = client.Close() })
+
+	if _, err := client.ProbeVersion(ctx); err != nil {
+		t.Fatalf("ProbeVersion over healthy server failed: %v", err)
+	}
+
+	got, err := client.QueryFilesystemCacheState(ctx)
+	if err != nil {
+		t.Fatalf("QueryFilesystemCacheState: %v", err)
+	}
+	want := chclient.FilesystemCacheState{}
+	if got != want {
+		t.Fatalf("QueryFilesystemCacheState on a stock server = %+v; want %+v", got, want)
+	}
+}


### PR DESCRIPTION
## Summary

Audits the S3/remote-filesystem read tuning settings family for cerberus's
single-node, S3-backed production deployment.

**Prefetch + concurrent-read thresholds (issue bullets 2 and 3): audited,
not adopted.** Probed live via chDB (ClickHouse 26.5.1.1) rather than
assumed from documentation:

| Setting | Live value | Live default |
| --- | --- | --- |
| `remote_filesystem_read_prefetch` | `1` | `1` |
| `allow_prefetched_read_pool_for_remote_filesystem` | `1` | `1` |
| `merge_tree_min_rows_for_concurrent_read_for_remote_filesystem` | `0` | `0` |
| `merge_tree_min_bytes_for_concurrent_read_for_remote_filesystem` | `0` | `0` |

Prefetch is already on. The remote-filesystem concurrent-read thresholds are
already at `0` — the most aggressive value, meaning ClickHouse already runs
every remote-filesystem read concurrently regardless of part size (unlike
the local-disk counterparts, which default to a real, non-zero threshold).
Both settings families are already tuned past what a `chopt` stamp could add
for cerberus's exact deployment shape, so no chopt feature is registered for
either — the issue's own "stamp only where the default is off or measurably
wrong" condition does not hold. Documented as "Audited, not adopted" in
`docs/clickhouse-optimizations.md` with the measured values, per the
audit-epic's verify-don't-assume mandate.

**Filesystem cache (issue bullet 1): documented + observable, not a chopt
stamp**, per the issue's own split (it's server-config, not a per-query
setting):

- `docs/operations.md` — new "Local filesystem cache" section: why it
  matters for this deployment shape, the `storage_configuration` XML to wire
  a `cache` disk over the S3 disk, a sizing formula derived from this doc's
  own already-measured production ingest figures (~2,824 rows/s, ~35
  bytes/row), and cache warm-up guidance for the hot recent window.
- `internal/chclient/filesystem_cache_state.go` — new
  `QueryFilesystemCacheState`, reading `system.filesystem_cache_settings`
  (confirmed present via chDB 26.5.1.1 AND a real ClickHouse 25.9-alpine
  container).
- `GET /info` now reports a `filesystemCache` object
  (`configured`/`caches`/`maxSizeBytes`/`currentSizeBytes`/`currentElements`),
  read live on every poll — mirrors the `resultCache` reporting #2781 added.

**Follow-up filed, not attempted here**: the issue's "fan-out-heavy wide
scans vs point lookups" framing implies the opposite tuning direction might
pay off — raising the remote-filesystem concurrent-read thresholds on a
detected narrow point-lookup shape. That's a real perf tradeoff needing an
optcorpus A/B pass to justify, not something this audit's live-probing alone
can settle. Filed as
[cerberus#2827](https://github.com/tsouza/cerberus/issues/2827).

## Measured numbers

- Live settings probe: chDB (ClickHouse 26.5.1.1) — table above.
- `system.filesystem_cache_settings` availability + all-zero baseline (no
  cache configured): confirmed via chDB AND a real ClickHouse 25.9-alpine
  testcontainer (`internal/chclient/filesystem_cache_state_integration_test.go`).
- No cold/warm S3 latency benchmark is included: this PR adopts no per-query
  setting change (both probed families were already optimal, and the
  filesystem cache disk itself is server config this sandbox has no
  S3-backed ClickHouse deployment to benchmark against honestly). Zero
  per-query behavior changed, so there is zero regression risk to measure
  against — the "watch out for regressions" concern the issue raises
  doesn't apply to a change that stamps nothing.

## Test plan

- [x] `go build` + `go vet` on `internal/chclient`, `internal/api/info`,
      `cmd/cerberus`
- [x] `go test -race ./internal/chclient/... ./internal/api/info/...`
      (new unit + chdb-tagged tests)
- [x] `go test -tags integration` against a real ClickHouse 25.9-alpine
      testcontainer for `QueryFilesystemCacheState`
- [x] `markdownlint-cli2` on both touched docs files
- [x] lefthook pre-commit/pre-push hooks (gofumpt, goimports, markdownlint,
      forbid-sql-raw, forbid-skip, actionlint, etc.) — all green
- [ ] CI (this PR)

Closes #2780
