### PR TITLE
feat(schema,chopt,engine): add proj_trace_id lookup projection

### DIFF
--- a/cmd/cerberus/cmd_migrate.go
+++ b/cmd/cerberus/cmd_migrate.go
@@ -215,6 +215,10 @@ func newMigrateSchemaCmd() *cobra.Command {
 			// #2766) — also AutoSelect=false, so the same explicit-listing-only
 			// reasoning applies.
 			cfg.SchemaColumnStatistics = chopt.ExplicitlyRequested(cfg.CHOptimizations, chopt.FeatureColumnStatistics)
+			// Same best-effort preview for trace_id_projection (cerberus issue
+			// #2767) — also AutoSelect=false, so the same explicit-listing-only
+			// reasoning applies.
+			cfg.SchemaTraceIDProjection = chopt.ExplicitlyRequested(cfg.CHOptimizations, chopt.FeatureTraceIDProjection)
 			return writeSchema(cmd.OutOrStdout(), cfg)
 		},
 	}

--- a/cmd/cerberus/main.go
+++ b/cmd/cerberus/main.go
@@ -1142,8 +1142,9 @@ func newLokiHandler(client *chclient.Client, cfg config.Config, optSet chopt.Ena
 
 // settingsRules builds the per-query ClickHouse settings rules from the
 // resolved optimization EnabledSet plus the CERBERUS_* config. The
-// aggregation-in-order, condition-cache, join-spill and result-cache rules
-// are all driven by the frozen EnabledSet (set.Has(...)), not raw env flags:
+// aggregation-in-order, condition-cache, join-spill, trace-id-bitmap-filter
+// and result-cache rules are all driven by the frozen EnabledSet (set.Has(...)),
+// not raw env flags:
 // under the default `auto` the stable 24.8-safe aggregation_in_order is on,
 // condition_cache is on when the probed server is >= 25.3, join_spill is on
 // when the probed server is >= 26.4, and result_cache is on when the boot
@@ -1163,6 +1164,7 @@ func settingsRules(cfg config.Config, set chopt.EnabledSet) engine.SettingsRules
 		OptimizeAggregationInOrder: set.Has(chopt.FeatureAggregationInOrder),
 		ConditionCache:             set.Has(chopt.FeatureConditionCache),
 		JoinSpill:                  set.Has(chopt.FeatureJoinSpill),
+		TraceIDBitmapFilter:        set.Has(chopt.FeatureTraceIDBitmapFilter),
 		LogCommentShape:            cfg.LogCommentShape,
 		ResultCache:                set.Has(chopt.FeatureResultCache),
 		ResultCacheIngestLag:       cfg.ResultCacheIngestLag,
@@ -1388,6 +1390,11 @@ func resolveCHOptimizations(ctx context.Context, logger *slog.Logger, client *ch
 	// map_bucketed_serialization comment immediately above for why this runs
 	// here rather than being threaded as an EnabledSet parameter.
 	cfg.SchemaColumnStatistics = set.Has(chopt.FeatureColumnStatistics)
+
+	// Same back-fill for trace_id_projection (cerberus issue #2767) — see
+	// the map_bucketed_serialization comment above for why this runs here
+	// rather than being threaded as an EnabledSet parameter.
+	cfg.SchemaTraceIDProjection = set.Has(chopt.FeatureTraceIDProjection)
 
 	// Install the client-side columnar matrix decode when the resolved set
 	// enables it. columnar_result_decode is a chopt feature (opt-in, never

--- a/docs/clickhouse-optimizations.md
+++ b/docs/clickhouse-optimizations.md
@@ -143,6 +143,8 @@ table.
 | `column_statistics`              | 26.3       | experimental | no         |
 | `classic_bucket_merge_summap`    | none       | experimental | no         |
 | `join_spill`                     | 26.4       | experimental | yes        |
+| `trace_id_projection`            | 25.5       | experimental | no         |
+| `trace_id_bitmap_filter`         | 25.11      | experimental | yes        |
 | `arg_and_max_fusion`             | 25.11      | experimental | yes        |
 | `result_cache`                   | 24.8       | stable       | yes        |
 <!-- END GENERATED: chopt-feature-table -->

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -1316,6 +1316,87 @@ maintenance window, not the boot path. Track progress in `system.mutations`
 (the `is_done` / `parts_to_do` columns), same as the projection and index
 runbooks above.
 
+### TraceId lookup projection (cerberus issue #2767)
+
+Trace-by-id lookups and logs<->traces correlation hops filter on `TraceId`,
+but neither `otel_traces` (`ORDER BY (ServiceName, SpanName, Timestamp)`) nor
+`otel_logs` (`ORDER BY (toStartOfFiveMinutes(Timestamp), ServiceName,
+Timestamp)`) sorts on it — today these lookups are served only by the
+`idx_trace_id` bloom_filter skip index, a probabilistic, GRANULARITY-coarse
+filter, not exact row addressing.
+
+Auto-create can install a lightweight **TraceId lookup projection** — an
+opt-in feature gated behind `CERBERUS_CH_OPTIMIZATIONS=trace_id_projection`
+(server `>= 25.5`, the first release accepting `_part_offset` inside a
+normal projection's `SELECT` list; see `docs/clickhouse-optimizations.md`'s
+`trace_id_projection` entry). Enabled, it appends one curated statement per
+table after each signal's other DDL:
+
+```sql
+ALTER TABLE <db>.otel_traces ADD PROJECTION IF NOT EXISTS proj_trace_id (SELECT TraceId, _part_offset ORDER BY TraceId)
+ALTER TABLE <db>.otel_logs   ADD PROJECTION IF NOT EXISTS proj_trace_id (SELECT TraceId, _part_offset ORDER BY TraceId)
+```
+
+Unlike the metrics catalog projections above, this one carries no `GROUP
+BY`: it re-sorts two columns — the sort key plus ClickHouse's per-part
+virtual row-offset column, `_part_offset` — rather than pre-aggregating
+them, so the merge engine stores only that pair per row, not a second full
+copy of the table. That is what makes it usable as a lightweight secondary
+index: ClickHouse can binary-search the projection's own TraceId-ordered
+part for a seek, then dereference `_part_offset` back into the base part for
+the matching rows, on ClickHouse `>= 25.5`. On `>= 25.11` the optimizer can
+additionally route an eligible `TraceId` predicate onto a row-precise
+PREWHERE **bitmap filter** via this same projection — see the
+`trace_id_bitmap_filter` feature below.
+
+**Both tables carry it, not traces alone.** The issue's own motivation names
+logs<->traces correlation as well as trace-by-id, and
+`trace_id_index_probe_chdb_test.go`'s own bar already requires both sides
+index-served for `Consistent() == true` — `otel_logs` has no more `TraceId`
+locality than `otel_traces` does, so scoping the projection to traces alone
+would leave the logs side of every correlation hop on the bloom filter.
+
+`ADD PROJECTION IF NOT EXISTS` is metadata-only and idempotent, so the
+auto-create hook (re)applies it safely on every boot. **New parts written
+after the ALTER carry the projection automatically; existing parts are not
+back-filled by `ADD PROJECTION` alone.**
+
+#### One-time `MATERIALIZE PROJECTION` back-fill runbook
+
+To back-fill existing parts immediately on a deployment that predates the
+projection, run the one-time materialize per table (a background mutation,
+non-blocking for reads — see the metrics catalog projections' own
+write-amplification discussion above for what this costs on a large table):
+
+```sql
+ALTER TABLE <db>.otel_traces MATERIALIZE PROJECTION proj_trace_id;
+ALTER TABLE <db>.otel_logs   MATERIALIZE PROJECTION proj_trace_id;
+```
+
+`MATERIALIZE` is intentionally **not** issued by the auto-create hook, same
+as every other projection/index/statistics runbook above. Track progress in
+`system.mutations`.
+
+#### The `trace_id_bitmap_filter` query-time setting (server >= 25.11)
+
+Independently of the projection's own version floor, `CERBERUS_CH_OPTIMIZATIONS`
+also carries a second, auto-enabled feature: `trace_id_bitmap_filter`. On a
+server `>= 25.11` (upstream PR
+[#81021](https://github.com/ClickHouse/ClickHouse/pull/81021)), cerberus
+stamps `min_table_rows_to_use_projection_index=0` on any query plan carrying
+a `TraceId`-keyed predicate or join — a top-level equality, a flat or
+subquery membership test, or a TraceQL structural join's recursive closure
+(see `internal/engine.eligibleForTraceIDBitmapFilter`). ClickHouse's own
+default for that setting (1,000,000 rows) is cleared trivially by any real
+production `otel_traces`/`otel_logs` table, but stamping it to 0 makes the
+bitmap-filter path reachable regardless of table size rather than leaving it
+contingent on production scale — and, unlike the projection itself, this
+setting is a pure query-time knob with no DDL and no version floor below
+25.11 to opt into: it stamps automatically once the server clears that
+floor, the same way `aggregation_in_order` / `condition_cache` do for their
+own floors. It is harmless (a no-op) on a table that carries no
+`proj_trace_id` projection at all.
+
 ### Curated column compression codecs (cerberus issue #2768)
 
 Auto-create also installs two curated `MODIFY COLUMN` codec ALTERs, retuning

--- a/internal/chopt/registry.go
+++ b/internal/chopt/registry.go
@@ -831,6 +831,55 @@ const (
 	// TestClassicBucketMergeSumMapDifferential's NaN case, not glossed over.
 	FeatureClassicBucketMergeSumMap = "classic_bucket_merge_summap"
 
+	// FeatureTraceIDProjection gates the curated `ADD PROJECTION IF NOT
+	// EXISTS proj_trace_id (SELECT TraceId, _part_offset ORDER BY TraceId)`
+	// ALTER (cerberus issue #2767) on the otel_traces and otel_logs tables.
+	// Neither table's own ORDER BY carries TraceId — otel_traces sorts
+	// (ServiceName, SpanName, Timestamp) and otel_logs sorts
+	// (toStartOfFiveMinutes(Timestamp), ServiceName, Timestamp) — so a
+	// trace-by-id lookup or a logs<->traces correlation hop has no primary-key
+	// locality on either side; today it is served only by the idx_trace_id
+	// bloom_filter skip index (trace_id_index_probe_chdb_test.go's bar),
+	// which grants probabilistic GRANULARITY-coarse pruning, not exact row
+	// addressing. proj_trace_id stores only the sort key plus the
+	// _part_offset pointer back into the base part — a lightweight
+	// "secondary index" projection, not a full column copy — so ClickHouse
+	// can resolve a TraceId predicate to exact rows once the query optimizer
+	// (>= 25.11, see FeatureTraceIDBitmapFilter) or an explicit query targets
+	// it.
+	//
+	// VERSION FLOOR: 25.5 — the first release accepting `_part_offset` inside
+	// a normal projection's SELECT list (upstream PR #78429, "Projection
+	// Index Step 1: Support _part_offset in normal projections"); ADD
+	// PROJECTION with this shape is rejected outright below it. cerberus's
+	// supported floor is 24.8 (versions.yaml), so unlike every projection in
+	// metricCatalogProjections (unconditional today) this ALTER needs the
+	// version-conditional DDL gate internal/schema/ddl.Config.
+	// TraceIDProjectionEnabled threads — the boot resolver here supplies the
+	// verdict the SAME way it already does for FeatureColumnStatistics
+	// (internal/schemaboot.DDLConfig, cmd/cerberus's chOptResolution),
+	// reusing the SAME probed-version detection rather than adding a second
+	// one.
+	//
+	// BOTH otel_traces and otel_logs carry the projection, not traces alone:
+	// the issue's own motivation names logs<->traces correlation, not just
+	// trace-by-id, and TraceIDIndexProbe (trace_id_index_probe_chdb_test.go)
+	// already requires BOTH sides index-served for Consistent()==true —
+	// otel_logs' ORDER BY has no more TraceId locality than otel_traces'
+	// does, so scoping the projection to traces alone would leave the logs
+	// side of every correlation hop on the bloom filter.
+	//
+	// NOT auto-selected (AutoSelect=false), mirroring FeatureColumnStatistics'
+	// posture on a fresh floor-raising DDL feature: the MATERIALIZE
+	// PROJECTION backfill cost for existing parts and the steady-state
+	// merge-time maintenance cost on new parts are real (if the issue's own
+	// Risks section correctly calls them "tiny") but unmeasured at production
+	// data volumes beyond this PR's own synthetic benchmark — an operator
+	// opt-in via CERBERUS_CH_OPTIMIZATIONS=trace_id_projection until that
+	// evidence accumulates, exactly the posture column_statistics and
+	// map_bucketed_serialization already took on their own new floors.
+	FeatureTraceIDProjection = "trace_id_projection"
+
 	// FeatureJoinSpill stamps max_bytes_before_external_join = cap/2 (the
 	// SAME cap-relative arithmetic internal/engine/spill.go's unconditional
 	// group_by/sort stamps use, keyed off CERBERUS_CH_QUERY_MAX_MEMORY) on
@@ -885,6 +934,53 @@ const (
 	// OOM abort is an availability bug, not an optimisation opportunity — so
 	// it does not change the AutoSelect posture.
 	FeatureJoinSpill = "join_spill"
+
+	// FeatureTraceIDBitmapFilter stamps
+	// min_table_rows_to_use_projection_index=0 (internal/engine's
+	// settingMinTableRowsToUseProjectionIndex) on a query plan carrying a
+	// TraceId-keyed predicate or join (cerberus issue #2767) — a top-level
+	// equality (the Tempo trace-by-id GET), a flat or subquery membership
+	// test (the /api/search root-lookup and structure-tab top-N gate), or a
+	// chplan.StructuralJoin's recursive closure (every TraceQL structural
+	// query). See internal/engine.eligibleForTraceIDBitmapFilter for the
+	// exact plan shapes matched.
+	//
+	// VERSION FLOOR: 25.11 — upstream PR #81021 ("Projection Index Step 3:
+	// ... allow using projections (that use SELECT of _part_offset and a
+	// different ORDER BY) as a secondary index. When enabled, certain query
+	// predicates can be used to read from projection parts and generate
+	// bitmaps to filter rows efficiently during the PREWHERE stage"), the
+	// changelog's own "when enabled" phrasing. The gate the changelog names
+	// is NOT a single boolean toggle — verified against the PR's own diff of
+	// src/Core/Settings.cpp / SettingsChangesHistory.cpp, not assumed from
+	// the changelog prose — but the pair of UInt64 thresholds the same PR
+	// introduces alongside it: min_table_rows_to_use_projection_index (only
+	// consider the projection index once the scanned table clears this row
+	// count; default 1,000,000) and max_projection_rows_to_use_projection_index
+	// (only apply it once the estimated projection read is under this row
+	// count; default 1,000,000, left untouched — a TraceId point lookup's
+	// estimated projection read is a handful of rows regardless of table
+	// size, so the default never blocks it). A real production otel_traces/
+	// otel_logs table clears the row-count default on its own, but a small
+	// or synthetic table — every chdb-tagged test fixture included — does
+	// not, which would silently leave the bitmap path unreachable exactly
+	// where this issue's own EXPLAIN acceptance test needs to prove it fires;
+	// stamping the threshold to 0 makes the path deterministic regardless of
+	// table size rather than relying on production scale to clear a default
+	// that was never meant to gate correctness.
+	//
+	// AutoSelect is true: the stamp is RESULT-EQUIVALENT (it only widens
+	// which physical path the optimizer is allowed to consider; a table
+	// carrying no proj_trace_id projection at all is unaffected either way)
+	// and strictly protective in the same sense FeatureJoinSpill and
+	// FeatureArgAndMaxFusion are — there is no server on which lowering this
+	// threshold produces a different query result, only a different (never
+	// worse, per ClickHouse's own cost-based projection selection) physical
+	// plan. Independent of FeatureTraceIDProjection: a server can satisfy
+	// this floor (25.11) without satisfying that one (25.5) only if it
+	// regressed version, which preflight already rejects, and the stamp is a
+	// harmless no-op on any table that carries no proj_trace_id projection.
+	FeatureTraceIDBitmapFilter = "trace_id_bitmap_filter"
 
 	// FeatureArgAndMaxFusion opts two narrow chsql emission sites off the
 	// `argMax(Value, TimeUnix)` + separate `max(TimeUnix)` two-aggregate
@@ -1257,6 +1353,20 @@ var registry = []Feature{
 		Doc:        "stamp max_bytes_before_external_join=cap/2 on join-bearing plans (server >= 26.4, auto-enabled) — mirrors the group_by/sort spill stamps; explicit, not the 26.5+ ratio default, silently ignored with no memory limit configured (cf. ClickHouse#76740)",
 	},
 	{
+		ID:         FeatureTraceIDProjection,
+		MinVersion: Version{Major: 25, Minor: 5},
+		Stability:  Experimental,
+		AutoSelect: false,
+		Doc:        "curated ADD PROJECTION proj_trace_id (TraceId, _part_offset) on otel_traces/otel_logs for exact-row trace lookups (server >= 25.5, opt-in via CERBERUS_CH_OPTIMIZATIONS — backfill/merge cost unmeasured at production volume pending real-world calibration)",
+	},
+	{
+		ID:         FeatureTraceIDBitmapFilter,
+		MinVersion: Version{Major: 25, Minor: 11},
+		Stability:  Experimental,
+		AutoSelect: true,
+		Doc:        "stamp min_table_rows_to_use_projection_index=0 on TraceId-keyed predicates/joins so the projection-index bitmap PREWHERE path (server >= 25.11) is reachable regardless of table size (result-equivalent, auto-enabled)",
+	},
+	{
 		ID:         FeatureArgAndMaxFusion,
 		MinVersion: Version{Major: 25, Minor: 11},
 		Stability:  Experimental,
@@ -1281,9 +1391,10 @@ var registry = []Feature{
 // ts_grid_idelta, laginframe_adjacency, fixed_accumulator_extrapolated,
 // sorted_slab_over_time, map_bucketed_serialization, ts_grid_last_over_time,
 // column_statistics, classic_bucket_merge_summap, join_spill,
-// arg_and_max_fusion, result_cache). The copy keeps the canonical entries
-// immutable from the caller's side. Exposed so tests can enumerate the gates
-// and the docs generator can render the table.
+// trace_id_projection, trace_id_bitmap_filter, arg_and_max_fusion,
+// result_cache). The copy keeps the canonical entries immutable from the
+// caller's side. Exposed so tests can enumerate the gates and the docs
+// generator can render the table.
 func Registry() []Feature {
 	out := make([]Feature, len(registry))
 	copy(out, registry)

--- a/internal/chopt/resolve_test.go
+++ b/internal/chopt/resolve_test.go
@@ -645,6 +645,8 @@ func TestRegistry_SeededEntries(t *testing.T) {
 		FeatureColumnStatistics:             {ID: FeatureColumnStatistics, MinVersion: v(26, 3), Stability: Experimental, AutoSelect: false, RequiresExperimentalTSGrid: false},
 		FeatureClassicBucketMergeSumMap:     {ID: FeatureClassicBucketMergeSumMap, MinVersion: AlwaysAvailable, Stability: Experimental, AutoSelect: false, RequiresExperimentalTSGrid: false},
 		FeatureJoinSpill:                    {ID: FeatureJoinSpill, MinVersion: v(26, 4), Stability: Experimental, AutoSelect: true, RequiresExperimentalTSGrid: false},
+		FeatureTraceIDProjection:            {ID: FeatureTraceIDProjection, MinVersion: v(25, 5), Stability: Experimental, AutoSelect: false, RequiresExperimentalTSGrid: false},
+		FeatureTraceIDBitmapFilter:          {ID: FeatureTraceIDBitmapFilter, MinVersion: v(25, 11), Stability: Experimental, AutoSelect: true, RequiresExperimentalTSGrid: false},
 		FeatureArgAndMaxFusion:              {ID: FeatureArgAndMaxFusion, MinVersion: v(25, 11), Stability: Experimental, AutoSelect: true, RequiresExperimentalTSGrid: false},
 		FeatureResultCache:                  {ID: FeatureResultCache, MinVersion: v(24, 8), Stability: Stable, AutoSelect: true, RequiresResultCacheCapability: true},
 	}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -368,6 +368,16 @@ type Config struct {
 	// traces tables (see internal/schema/ddl.Config.ColumnStatisticsEnabled).
 	SchemaColumnStatistics bool
 
+	// SchemaTraceIDProjection is the resolved chopt trace_id_projection
+	// verdict (cerberus issue #2767), back-filled the SAME way as
+	// SchemaColumnStatistics immediately above — including the offline
+	// `migrate schema` preview's chopt.ExplicitlyRequested fallback, since
+	// trace_id_projection is also AutoSelect=false. internal/schemaboot.
+	// DDLConfig is the only reader: true adds the curated `ADD PROJECTION IF
+	// NOT EXISTS proj_trace_id` ALTER to the traces and logs tables (see
+	// internal/schema/ddl.Config.TraceIDProjectionEnabled).
+	SchemaTraceIDProjection bool
+
 	// CHOptCorpus configures the async system.query_log performance-corpus
 	// reconciler (disabled by default; production-only — chDB has no
 	// query_log).

--- a/internal/engine/query_settings_rules.go
+++ b/internal/engine/query_settings_rules.go
@@ -115,6 +115,13 @@ type SettingsRules struct {
 	// set, so this flag is false and nothing is stamped (a no-op on every
 	// older server). The stamp is harmless even on a table that carries no
 	// proj_trace_id projection at all (cerberus issue #2767).
+	//
+	// No memory-bounding sentinel (test/perf/{smoke,nightly}/sentinels.go)
+	// covers this rule: min_table_rows_to_use_projection_index is a
+	// query-optimizer index-SELECTION threshold, not a memory cap — it
+	// cannot increase peak memory versus not stamping it at all, so it is
+	// not the #2364-class regression that sentinel corpus exists to catch.
+	// See issue #2832 (PERF-SENTINEL-WAIVER: #2832).
 	TraceIDBitmapFilter bool
 
 	// LogCommentShape, when true, stamps log_comment with a compact cerberus

--- a/internal/engine/query_settings_rules.go
+++ b/internal/engine/query_settings_rules.go
@@ -43,6 +43,26 @@ const settingEnableAnalyzer = "enable_analyzer"
 // so stamping it is version-safe and result-neutral.
 const settingLogComment = "log_comment"
 
+// settingMinTableRowsToUseProjectionIndex is the ClickHouse setting (>= 25.11,
+// upstream PR #81021) that gates whether the optimizer will even CONSIDER a
+// lightweight (`_part_offset`-only) projection as a secondary index for
+// exact-row PREWHERE bitmap filtering: only once the scanned table's own
+// estimated row count clears this threshold. It is RESULT-EQUIVALENT — it
+// only widens which physical plan the optimizer is allowed to pick, never
+// which rows a query returns.
+const settingMinTableRowsToUseProjectionIndex = "min_table_rows_to_use_projection_index"
+
+// traceIDBitmapFilterMinTableRows is the value cerberus stamps for
+// settingMinTableRowsToUseProjectionIndex. ClickHouse's own default (1,000,000)
+// is cleared trivially by any real production otel_traces/otel_logs table, but
+// NOT by a small or synthetic one — every chdb-tagged test fixture included —
+// which would leave the bitmap-filter path silently unreachable exactly where
+// cerberus's own EXPLAIN acceptance test (internal/schema/ddl) needs to prove
+// it fires. 0 makes "table rows >= threshold" trivially true regardless of
+// table size, so the path is deterministic rather than contingent on
+// production scale.
+const traceIDBitmapFilterMinTableRows = 0
+
 // SettingsRules holds the DARK-by-default, plan-shape-gated per-query
 // ClickHouse settings rules the engine evaluates at the execute seam. The
 // zero value applies NOTHING: with both flags false the ctx is returned
@@ -84,6 +104,18 @@ type SettingsRules struct {
 	// OptimizeAggregationInOrder/ConditionCache it also needs the live
 	// per-query memory cap — see engine.go's execContext.
 	JoinSpill bool
+
+	// TraceIDBitmapFilter, when true, stamps
+	// min_table_rows_to_use_projection_index=0 on a plan carrying a
+	// TraceId-keyed predicate or join (see eligibleForTraceIDBitmapFilter)
+	// so the ClickHouse >= 25.11 projection-index bitmap PREWHERE path stays
+	// reachable regardless of the scanned table's row count. Driven by the
+	// trace_id_bitmap_filter registry feature, which only resolves in on
+	// server >= 25.11; below that the feature is absent from the resolved
+	// set, so this flag is false and nothing is stamped (a no-op on every
+	// older server). The stamp is harmless even on a table that carries no
+	// proj_trace_id projection at all (cerberus issue #2767).
+	TraceIDBitmapFilter bool
 
 	// LogCommentShape, when true, stamps log_comment with a compact cerberus
 	// shape id (planShapeID) carrying the emit-root node kind plus key
@@ -148,6 +180,9 @@ func (r SettingsRules) enabledOpts() []string {
 	if r.JoinSpill {
 		opts = append(opts, "join_spill")
 	}
+	if r.TraceIDBitmapFilter {
+		opts = append(opts, "trace_id_bitmap_filter")
+	}
 	if r.ResultCache {
 		opts = append(opts, "result_cache")
 	}
@@ -177,6 +212,9 @@ func (r SettingsRules) apply(ctx context.Context, plan chplan.Node) context.Cont
 		// disabled the analyzer. Result-equivalent and version-safe on the
 		// >= 25.3 servers this rule resolves on.
 		ctx = chclient.WithQuerySetting(ctx, settingEnableAnalyzer, 1)
+	}
+	if r.TraceIDBitmapFilter && r.eligibleForTraceIDBitmapFilter(plan) {
+		ctx = chclient.WithQuerySetting(ctx, settingMinTableRowsToUseProjectionIndex, traceIDBitmapFilterMinTableRows)
 	}
 	if r.LogCommentShape {
 		if id := planShapeID(plan); id != "" {
@@ -425,6 +463,90 @@ func predicateStableForConditionCache(plan chplan.Node) bool {
 		return true
 	})
 	return hasFilter && hasScan
+}
+
+// eligibleForTraceIDBitmapFilter reports whether plan carries a predicate or
+// join keyed on the TraceId column ANYWHERE in its tree — cerberus's real
+// emitted shapes (cerberus issue #2767), not merely a synthetic top-level
+// equality:
+//
+//   - a top-level equality (chplan.Binary{Op: OpEq}) against TraceId, the
+//     Tempo trace-by-id GET handler's shape (internal/api/tempo/handler.go);
+//   - a flat membership test (chplan.InList), the /api/search root-lookup's
+//     `TraceId IN (<literal ids>)` shape (internal/api/tempo/root_lookup.go);
+//   - a subquery membership test (chplan.InSubquery) or the structure-tab's
+//     top-N gate (chplan.BoundedTraceScope), both `TraceId IN (<subquery>)`
+//     shapes (internal/chplan/bounded_trace_scope.go);
+//   - a chplan.StructuralJoin, whose recursive closure walks the spans table
+//     keyed on TraceIDColumn by construction even though (per walk_deep.go's
+//     nodeExprs) it carries no Expr-typed field to inspect — every TraceQL
+//     structural query (`>`, `<`, `>>`, `<<`) lowers to one, and its emitted
+//     SQL is the `WITH RECURSIVE` shape the issue calls out by name.
+//
+// The sweep composes WalkDeep with InspectNodeExprs + InspectExpr, mirroring
+// planHasNowExpr, so a predicate buried inside an InSubquery's own Subquery
+// plan — invisible to a plain [chplan.Walk] — is still found.
+func (r SettingsRules) eligibleForTraceIDBitmapFilter(plan chplan.Node) bool {
+	traceIDColumn := r.Traces.TraceIDColumn
+	if traceIDColumn == "" {
+		return false
+	}
+	found := false
+	chplan.WalkDeep(plan, func(n chplan.Node) bool {
+		if found {
+			return false
+		}
+		if _, ok := n.(*chplan.StructuralJoin); ok {
+			found = true
+			return false
+		}
+		chplan.InspectNodeExprs(n, func(e chplan.Expr) {
+			if found {
+				return
+			}
+			chplan.InspectExpr(e, func(sub chplan.Expr) bool {
+				if found {
+					return false
+				}
+				if traceIDPredicateExpr(sub, traceIDColumn) {
+					found = true
+					return false
+				}
+				return true
+			})
+		})
+		return true
+	})
+	return found
+}
+
+// traceIDPredicateExpr reports whether e itself (not its children — the
+// caller's InspectExpr walk already visits those independently) is a
+// predicate that tests traceIDColumn for equality or membership.
+func traceIDPredicateExpr(e chplan.Expr, traceIDColumn string) bool {
+	switch v := e.(type) {
+	case *chplan.Binary:
+		return v.Op == chplan.OpEq && (isTraceIDColumnRef(v.Left, traceIDColumn) || isTraceIDColumnRef(v.Right, traceIDColumn))
+	case *chplan.InList:
+		return isTraceIDColumnRef(v.Left, traceIDColumn)
+	case *chplan.InSubquery:
+		return isTraceIDColumnRef(v.Left, traceIDColumn)
+	case *chplan.BoundedTraceScope:
+		return v.TraceIDColumn == traceIDColumn
+	default:
+		return false
+	}
+}
+
+// isTraceIDColumnRef reports whether e is a bare (unqualified) column
+// reference to traceIDColumn. A qualified reference (e.g. `R.TraceId` off a
+// join side) is deliberately excluded: it never appears as a raw
+// TraceId-only predicate cerberus emits for a lookup or membership test,
+// only inside StructuralJoin's own recursive step, which this function's
+// caller matches by NODE TYPE instead (see eligibleForTraceIDBitmapFilter).
+func isTraceIDColumnRef(e chplan.Expr, traceIDColumn string) bool {
+	ref, ok := e.(*chplan.ColumnRef)
+	return ok && ref.Qualifier == "" && ref.Name == traceIDColumn
 }
 
 // singleAggregate returns the sole Aggregate in plan, or ok=false when there

--- a/internal/engine/trace_id_bitmap_filter_test.go
+++ b/internal/engine/trace_id_bitmap_filter_test.go
@@ -1,0 +1,159 @@
+package engine
+
+import (
+	"context"
+	"testing"
+
+	"github.com/tsouza/cerberus/internal/chplan"
+	"github.com/tsouza/cerberus/internal/schema"
+)
+
+// traceIDBitmapFilterRules returns SettingsRules with TraceIDBitmapFilter ON
+// and the default schema wired (so the eligibility check runs against a live
+// TraceIDColumn), mirroring conditionCacheRules in condition_cache_test.go.
+func traceIDBitmapFilterRules() SettingsRules {
+	return SettingsRules{
+		TraceIDBitmapFilter: true,
+		Metrics:             schema.DefaultOTelMetrics(),
+		Traces:              schema.DefaultOTelTraces(),
+		Logs:                schema.DefaultOTelLogs(),
+	}
+}
+
+// traceIDEqualityFilter builds Filter(TraceId = 'x') over Scan(otel_traces) —
+// the Tempo trace-by-id GET handler's shape (internal/api/tempo/handler.go).
+func traceIDEqualityFilter() chplan.Node {
+	return &chplan.Filter{
+		Input: &chplan.Scan{Table: "otel_traces"},
+		Predicate: &chplan.Binary{
+			Op:    chplan.OpEq,
+			Left:  &chplan.ColumnRef{Name: "TraceId"},
+			Right: &chplan.LitString{V: "0123456789abcdef0123456789abcdef"},
+		},
+	}
+}
+
+// TestApply_StampsTraceIDBitmapFilter_OnEquality confirms that with the rule
+// on (which only resolves in on server >= 25.11) and a top-level TraceId
+// equality predicate, apply stamps min_table_rows_to_use_projection_index=0.
+func TestApply_StampsTraceIDBitmapFilter_OnEquality(t *testing.T) {
+	ctx := traceIDBitmapFilterRules().apply(context.Background(), traceIDEqualityFilter())
+	if got := settingValue(ctx, settingMinTableRowsToUseProjectionIndex); got != traceIDBitmapFilterMinTableRows {
+		t.Errorf("TraceIDBitmapFilter on + TraceId equality: setting = %v; want %v", got, traceIDBitmapFilterMinTableRows)
+	}
+}
+
+// TestApply_TraceIDBitmapFilter_OffByDefault confirms the rule is DARK when
+// the feature did not resolve in (e.g. server < 25.11): nothing is stamped
+// even though the plan shape is eligible.
+func TestApply_TraceIDBitmapFilter_OffByDefault(t *testing.T) {
+	off := SettingsRules{Traces: schema.DefaultOTelTraces()}.apply(context.Background(), traceIDEqualityFilter())
+	if got := settingValue(off, settingMinTableRowsToUseProjectionIndex); got != nil {
+		t.Errorf("TraceIDBitmapFilter off (server < 25.11): setting = %v; want absent", got)
+	}
+}
+
+// TestApply_TraceIDBitmapFilter_NotStampedWithoutTraceIDPredicate confirms
+// the conservative gate: a plan touching neither TraceId nor a structural
+// join gains nothing from the setting, so it is not stamped even with the
+// rule on.
+func TestApply_TraceIDBitmapFilter_NotStampedWithoutTraceIDPredicate(t *testing.T) {
+	plan := &chplan.Filter{
+		Input: &chplan.Scan{Table: "otel_traces"},
+		Predicate: &chplan.Binary{
+			Op:    chplan.OpEq,
+			Left:  &chplan.ColumnRef{Name: "SpanName"},
+			Right: &chplan.LitString{V: "GET /home"},
+		},
+	}
+	ctx := traceIDBitmapFilterRules().apply(context.Background(), plan)
+	if got := settingValue(ctx, settingMinTableRowsToUseProjectionIndex); got != nil {
+		t.Errorf("no TraceId predicate: setting = %v; want absent (conservative gate)", got)
+	}
+}
+
+// TestEligibleForTraceIDBitmapFilter covers the plan-shape gate directly
+// against cerberus's real emitted shapes (cerberus issue #2767), not a
+// synthetic top-level equality alone: a flat IN list (the /api/search
+// root-lookup), an IN-subquery, the structure-tab's BoundedTraceScope gate,
+// and a StructuralJoin's recursive closure — none of which chplan.Walk alone
+// would reach for the subquery-bearing cases (see eligibleForTraceIDBitmapFilter's
+// own doc comment).
+func TestEligibleForTraceIDBitmapFilter(t *testing.T) {
+	rules := traceIDBitmapFilterRules()
+
+	tests := []struct {
+		name string
+		plan chplan.Node
+		want bool
+	}{
+		{"top-level equality", traceIDEqualityFilter(), true},
+		{
+			"flat IN list (/api/search root-lookup shape)",
+			&chplan.Filter{
+				Input: &chplan.Scan{Table: "otel_traces"},
+				Predicate: &chplan.InList{
+					Left: &chplan.ColumnRef{Name: "TraceId"},
+					List: []chplan.Expr{&chplan.LitString{V: "aa"}, &chplan.LitString{V: "bb"}},
+				},
+			},
+			true,
+		},
+		{
+			"IN-subquery",
+			&chplan.Filter{
+				Input: &chplan.Scan{Table: "otel_traces"},
+				Predicate: &chplan.InSubquery{
+					Left:     &chplan.ColumnRef{Name: "TraceId"},
+					Subquery: &chplan.Scan{Table: "otel_traces"},
+				},
+			},
+			true,
+		},
+		{
+			"BoundedTraceScope (structure-tab top-N gate)",
+			&chplan.Filter{
+				Input: &chplan.Scan{Table: "otel_traces"},
+				Predicate: &chplan.BoundedTraceScope{
+					SpansTable:         "otel_traces",
+					TraceIDColumn:      "TraceId",
+					ParentSpanIDColumn: "ParentSpanId",
+					TraceLimit:         20,
+				},
+			},
+			true,
+		},
+		{
+			"StructuralJoin (recursive closure, no Expr-typed TraceId field)",
+			&chplan.StructuralJoin{
+				Left:               &chplan.Scan{Table: "otel_traces"},
+				Right:              &chplan.Scan{Table: "otel_traces"},
+				Op:                 chplan.StructuralDescendant,
+				TraceIDColumn:      "TraceId",
+				SpanIDColumn:       "SpanId",
+				ParentSpanIDColumn: "ParentSpanId",
+			},
+			true,
+		},
+		{"bare scan, no predicate", &chplan.Scan{Table: "otel_traces"}, false},
+		{
+			"predicate on an unrelated column",
+			&chplan.Filter{
+				Input: &chplan.Scan{Table: "otel_traces"},
+				Predicate: &chplan.Binary{
+					Op:    chplan.OpEq,
+					Left:  &chplan.ColumnRef{Name: "SpanName"},
+					Right: &chplan.LitString{V: "GET /home"},
+				},
+			},
+			false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := rules.eligibleForTraceIDBitmapFilter(tt.plan); got != tt.want {
+				t.Errorf("eligibleForTraceIDBitmapFilter() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/schema/ddl/ddl.go
+++ b/internal/schema/ddl/ddl.go
@@ -175,6 +175,20 @@ type Config struct {
 	// tolerates that specific refusal instead of failing the whole apply; see
 	// isColumnStatisticsUnsupported.
 	ColumnStatisticsEnabled bool
+
+	// TraceIDProjectionEnabled gates the curated `ADD PROJECTION IF NOT
+	// EXISTS proj_trace_id (SELECT TraceId, _part_offset ORDER BY TraceId)`
+	// ALTER (cerberus issue #2767) on the traces spans table and the logs
+	// table. False (the default) renders no projection statements at all —
+	// an operator on today's schema sees byte-identical DDL. The chopt
+	// trace_id_projection feature (version-gated at ClickHouse >= 25.5, the
+	// first release accepting `_part_offset` inside a normal projection's
+	// SELECT list) resolves this bit at boot — see
+	// internal/schemaboot.DDLConfig — mirroring exactly how
+	// ColumnStatisticsEnabled is threaded from its own chopt verdict; a
+	// deployment below the floor never sees the statement rendered at all,
+	// not a statement that is rendered and then refused.
+	TraceIDProjectionEnabled bool
 }
 
 // DatabaseEngine selects the ClickHouse database engine for the
@@ -726,6 +740,13 @@ func renderSignal(cfg Config, s Signal) ([]string, error) {
 		// same way every other curated ALTER in this package trails its
 		// table's CREATE — see renderLogsCodecs' doc comment.
 		stmts := append([]string{logs}, renderLogsCodecs(cfg)...)
+		// The curated proj_trace_id projection (issue #2767) trails the CREATE
+		// + codec ALTERs the same way every other curated ALTER in this
+		// package trails its table's CREATE — see TraceIDProjectionEnabled's
+		// doc comment on why the logs table carries it too, not traces alone.
+		if cfg.TraceIDProjectionEnabled {
+			stmts = append(stmts, renderAddTraceIDProjection(cfg, cfg.Tables.Logs))
+		}
 		if cfg.ColumnStatisticsEnabled {
 			stmts = append(stmts, renderLogsColumnStatistics(cfg)...)
 		}
@@ -740,6 +761,11 @@ func renderSignal(cfg Config, s Signal) ([]string, error) {
 		// table the first statement above just created — see
 		// renderTracesCodecs' doc comment.
 		stmts = append(stmts, renderTracesCodecs(cfg)...)
+		// The curated proj_trace_id projection (issue #2767) targets the
+		// spans table too — see TraceIDProjectionEnabled's doc comment.
+		if cfg.TraceIDProjectionEnabled {
+			stmts = append(stmts, renderAddTraceIDProjection(cfg, cfg.Tables.Traces))
+		}
 		if cfg.ColumnStatisticsEnabled {
 			stmts = append(stmts, renderTracesColumnStatistics(cfg)...)
 		}
@@ -874,6 +900,50 @@ var metricCatalogProjections = []metricProjection{
 // both freshly-created and pre-existing tables.
 func renderAddMetricProjection(cfg Config, table string, p metricProjection, hasMonotonic bool) string {
 	stmt := chsql.AlterTableAddProjection(cfg.Database, table, p.name, p.body(hasMonotonic))
+	if cfg.Cluster != "" {
+		stmt.OnCluster(cfg.Cluster)
+	}
+	return stmt.SQL()
+}
+
+const (
+	// traceIDProjectionName is the ALTER TABLE ADD PROJECTION identifier for
+	// the exact-row TraceId lookup projection (cerberus issue #2767) — see
+	// TraceIDProjectionEnabled's doc comment.
+	traceIDProjectionName = "proj_trace_id"
+	// partOffsetColumn is ClickHouse's per-part virtual row-offset column.
+	// Selecting it (alongside the sort key) into a projection's body, rather
+	// than every column of the base table, is what makes the projection a
+	// lightweight secondary index — the merge engine stores only the sort
+	// key + this pointer, not a second copy of every row — instead of a full
+	// materialized copy of the table under a different sort order. Requires
+	// ClickHouse >= 25.5 (upstream PR #78429); see FeatureTraceIDProjection.
+	partOffsetColumn = "_part_offset"
+)
+
+// traceIDProjectionBody is the ADD PROJECTION body `SELECT TraceId,
+// _part_offset ORDER BY TraceId` — no GROUP BY, unlike
+// metricCatalogProjections' aggregating projections: this one re-sorts the
+// same two columns rather than pre-aggregating them, which is exactly what
+// makes it usable as a secondary index (ClickHouse can binary-search the
+// projection's own TraceId-ordered part for the seek, then dereference
+// _part_offset back into the base part for the matching rows).
+func traceIDProjectionBody() *chsql.QueryBuilder {
+	return chsql.NewQuery().
+		Select(chsql.Col(traceIdColumn), chsql.Col(partOffsetColumn)).
+		OrderBy(chsql.Col(traceIdColumn), false)
+}
+
+// renderAddTraceIDProjection builds the idempotent ADD PROJECTION ALTER
+// installing proj_trace_id on table (otel_traces or otel_logs). ON CLUSTER is
+// threaded so the ALTER replicates the same way the CREATE statements do; ADD
+// PROJECTION IF NOT EXISTS is metadata-only and idempotent, so the same Apply
+// path covers both freshly-created and pre-existing tables — mirroring
+// renderAddMetricProjection / renderAddTemporalityIndex. Unlike ADD
+// STATISTICS, ADD PROJECTION is supported on ClickHouse Cloud (see
+// applySignal's own comment), so this needs no unsupported-server tolerance.
+func renderAddTraceIDProjection(cfg Config, table string) string {
+	stmt := chsql.AlterTableAddProjection(cfg.Database, table, traceIDProjectionName, traceIDProjectionBody())
 	if cfg.Cluster != "" {
 		stmt.OnCluster(cfg.Cluster)
 	}

--- a/internal/schema/ddl/trace_id_bitmap_filter_probe_chdb_test.go
+++ b/internal/schema/ddl/trace_id_bitmap_filter_probe_chdb_test.go
@@ -1,0 +1,363 @@
+//go:build chdb
+
+// This is the acceptance gate cerberus issue #2767 itself specifies: an
+// EXPLAIN-based proof, against the package's own rendered production DDL
+// (renderSignal, the same entry point trace_id_index_probe_chdb_test.go's
+// bloom-filter bar and column_statistics_chdb_test.go's statistics probe
+// both use), that the ClickHouse >= 25.5 proj_trace_id projection — stamped
+// eligible for the >= 25.11 bitmap-filter path by
+// internal/engine.settingMinTableRowsToUseProjectionIndex — is actually
+// picked by the query optimizer for cerberus's REAL emitted query shapes,
+// not a synthetic top-level `TraceId = ?` alone. The issue's own warning is
+// the reason this file exists: cerberus's real TraceId predicates arrive
+// inside a structure-tab IN-subquery (chplan.BoundedTraceScope) and a
+// TraceQL structural join's recursive CTE (chplan.StructuralJoin) at least
+// as often as a bare top-level equality, and a test that only proved the
+// synthetic shape would pass even if the recursive/subquery shapes never
+// touched the projection at all.
+//
+// Every plan below is the SAME chplan tree cerberus's own production code
+// builds — the Tempo trace-by-id GET handler's equality Filter
+// (internal/api/tempo/handler.go), the structure-tab top-N gate
+// (internal/chplan/bounded_trace_scope.go), and a TraceQL structural join
+// (internal/chplan/structural_join.go) — rendered through the real
+// chsql.Emit production emitter, never a hand-copied SQL string. Only the
+// EXPLAIN wrapper and the SETTINGS tail are test-only raw SQL, the same
+// test-only raw-SQL convention trace_id_index_probe_chdb_test.go's own
+// header comment documents.
+package ddl
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"strconv"
+	"strings"
+	"testing"
+
+	_ "github.com/chdb-io/chdb-go/chdb/driver"
+
+	"github.com/tsouza/cerberus/internal/chplan"
+	"github.com/tsouza/cerberus/internal/chsql"
+)
+
+// traceIDProjectionSeedCount is the number of distinct traces seeded into
+// otel_traces before each EXPLAIN probe below. It exists (rather than a
+// single-row fixture, like trace_id_index_probe_chdb_test.go's probe) for
+// TWO reasons: min_table_rows_to_use_projection_index is stamped to 0
+// specifically because a real production table cannot be relied on to clear
+// ClickHouse's own 1,000,000-row default inside a test — see
+// internal/engine.traceIDBitmapFilterMinTableRows — and, more fundamentally,
+// the 25.11 bitmap-filter mechanism PRUNES GRANULES: with a single granule
+// (the default index_granularity is 8192 rows/part) there is nothing to
+// prune and the optimizer has no reason to route through the projection at
+// all regardless of any setting, the same way an EXPLAIN indexes=1 on one
+// row shows "Granules: 1/1" for idx_trace_id too. traceIDProjectionSeedCount
+// clears several granules' worth of rows so the plan has something to
+// choose between.
+const traceIDProjectionSeedCount = 50000
+
+// openTraceIDProjectionChDB opens a fresh ephemeral chDB session and applies
+// the package's own real production DDL for the logs and traces tables (via
+// renderSignal) with TraceIDProjectionEnabled=true, mirroring
+// openColumnStatisticsChDB / applyColumnStatisticsSignal's shape in
+// column_statistics_chdb_test.go.
+func openTraceIDProjectionChDB(t *testing.T) (db *sql.DB, cfg Config) {
+	t.Helper()
+
+	db, err := sql.Open("chdb", "")
+	if err != nil {
+		t.Fatalf("open chdb: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	if err := db.Ping(); err != nil {
+		t.Fatalf("ping chdb: %v", err)
+	}
+
+	cfg = Config{TraceIDProjectionEnabled: true}.withDefaults()
+	for _, s := range []Signal{Logs, Traces} {
+		stmts, err := renderSignal(cfg, s)
+		if err != nil {
+			t.Fatalf("renderSignal(%s): %v", s, err)
+		}
+		for _, stmt := range stmts {
+			if strings.HasPrefix(stmt, "CREATE TABLE IF NOT EXISTS") {
+				stmt = promoteCreateTable(stmt)
+			}
+			if _, err := db.Exec(stmt); err != nil {
+				t.Fatalf("apply %s DDL:\n%s\nerr: %v", s, stmt, err)
+			}
+		}
+	}
+	return db, cfg
+}
+
+// seedTraces bulk-inserts traceIDProjectionSeedCount distinct traces into
+// cfg.Tables.Traces via a single `INSERT ... SELECT ... FROM numbers(...)` —
+// row-at-a-time db.Exec would be prohibitively slow at this fixture size —
+// each a single root span (ParentSpanId = ”) so the structure-tab's
+// BoundedTraceScope subquery (which ranks root spans) and the StructuralJoin
+// recursive closure (which walks from a root) both have real rows to find
+// rather than resolving against an empty table. The LAST trace ID
+// (numerically highest, so it is deterministic across runs) is returned for
+// the equality-lookup probe.
+func seedTraces(t *testing.T, db *sql.DB, table string) (lastTraceID string) {
+	t.Helper()
+	insert := fmt.Sprintf(
+		"INSERT INTO %s (Timestamp, TraceId, SpanId, ParentSpanId, ServiceName, SpanName) "+
+			"SELECT now64(9), lower(leftPad(hex(number + 1), 32, '0')), lower(leftPad(hex(number + 1), 16, '0')), "+
+			"'', 'probe-svc', 'probe-op' FROM numbers(%d)",
+		table, traceIDProjectionSeedCount,
+	)
+	if _, err := db.Exec(insert); err != nil {
+		t.Fatalf("bulk seed %d trace rows:\n%s\nerr: %v", traceIDProjectionSeedCount, insert, err)
+	}
+	if _, err := db.Exec("OPTIMIZE TABLE " + table + " FINAL"); err != nil {
+		t.Fatalf("optimize final: %v", err)
+	}
+	return fmt.Sprintf("%032x", traceIDProjectionSeedCount)
+}
+
+// explainUsesTraceIDProjection runs `EXPLAIN indexes = 1, projections = 1
+// <sql>` against db with args bound, appending the SETTINGS tail that stamps
+// min_table_rows_to_use_projection_index=0 the SAME way
+// internal/engine.SettingsRules.apply stamps it in production, and reports
+// whether traceIDProjectionName appears anywhere in the plan text.
+//
+// The `projections = 1` toggle is load-bearing, verified empirically against
+// this exact chDB build (not assumed from docs): `EXPLAIN indexes = 1` ALONE
+// — the flag trace_id_index_probe_chdb_test.go uses for the bloom_filter skip
+// index, which IS unconditionally listed under "Indexes:" — renders NO
+// "Projections:" section at all, even when the optimizer genuinely picks
+// proj_trace_id, because a used PROJECTION is reported under a separate
+// EXPLAIN toggle a plain skip-index probe never needed. Without `projections
+// = 1` this test would silently prove nothing and still show a green
+// diff — the exact false-positive risk the issue's own acceptance-gate
+// instruction warns about, just one level lower (a missing EXPLAIN flag
+// rather than a missing query shape).
+func explainUsesTraceIDProjection(t *testing.T, db *sql.DB, sql string, args []any) (plan string) {
+	t.Helper()
+	explainQuery := "EXPLAIN indexes = 1, projections = 1 " + sql +
+		" SETTINGS " + settingMinTableRowsToUseProjectionIndexForTest + " = " + strconv.Itoa(traceIDBitmapFilterMinTableRowsForTest)
+	rows, err := db.Query(explainQuery, args...)
+	if err != nil {
+		t.Fatalf("explain:\n%s\nerr: %v", explainQuery, err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	var b strings.Builder
+	for rows.Next() {
+		var line string
+		if err := rows.Scan(&line); err != nil {
+			t.Fatalf("explain scan: %v", err)
+		}
+		b.WriteString(line)
+		b.WriteByte('\n')
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatalf("explain rows: %v", err)
+	}
+	return b.String()
+}
+
+// settingMinTableRowsToUseProjectionIndexForTest /
+// traceIDBitmapFilterMinTableRowsForTest mirror
+// internal/engine.settingMinTableRowsToUseProjectionIndex /
+// traceIDBitmapFilterMinTableRows exactly. Both are unexported — every
+// setting-name constant in query_settings_rules.go is package-private, the
+// same posture settingUseQueryConditionCache / settingOptimizeAggregationInOrder
+// already take — so this test cannot import and reference them directly; it
+// pins the same literal name and value instead. Keeping the two pairs
+// byte-identical is this test's whole point: it is proving THAT specific
+// production stamp actually moves the optimizer, not a stand-in value, so a
+// future rename of either constant in internal/engine without a matching
+// update here would make this test assert something cerberus no longer
+// stamps.
+const (
+	settingMinTableRowsToUseProjectionIndexForTest = "min_table_rows_to_use_projection_index"
+	traceIDBitmapFilterMinTableRowsForTest         = 0
+)
+
+// TestTraceIDProjection_IdempotentReapply pins that re-applying the SAME
+// curated ADD PROJECTION ALTERs a second time — the boot-every-time behavior
+// applySignal exercises for every signal — is a genuine no-op against a real
+// server (IF NOT EXISTS), not merely idempotent by construction of the
+// rendered SQL text, mirroring
+// column_statistics_chdb_test.go's TestColumnStatistics_IdempotentReapply.
+func TestTraceIDProjection_IdempotentReapply(t *testing.T) {
+	db, cfg := openTraceIDProjectionChDB(t)
+	for _, s := range []Signal{Logs, Traces} {
+		stmts, err := renderSignal(cfg, s)
+		if err != nil {
+			t.Fatalf("renderSignal(%s): %v", s, err)
+		}
+		for _, stmt := range stmts {
+			if !strings.Contains(stmt, traceIDProjectionName) {
+				continue
+			}
+			if _, err := db.Exec(stmt); err != nil {
+				t.Fatalf("second apply of %q: %v", stmt, err)
+			}
+		}
+	}
+}
+
+// TestTraceIDProjection_BelowFloorAppliesCleanly proves the version-gate-off
+// path directly against a real server, not just at the render layer
+// (TestRenderSignal_TraceIDProjectionEnabled/disabled in
+// trace_id_projection_test.go): with TraceIDProjectionEnabled=false — a
+// deployment below the 25.5 floor, or the feature simply off — the full DDL
+// applies without error and system.projections carries no proj_trace_id row
+// afterward. There is nothing to half-apply because nothing referencing the
+// projection is ever sent.
+func TestTraceIDProjection_BelowFloorAppliesCleanly(t *testing.T) {
+	db, err := sql.Open("chdb", "")
+	if err != nil {
+		t.Fatalf("open chdb: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	if err := db.Ping(); err != nil {
+		t.Fatalf("ping chdb: %v", err)
+	}
+
+	cfg := Config{TraceIDProjectionEnabled: false}.withDefaults()
+	for _, s := range []Signal{Logs, Traces} {
+		stmts, err := renderSignal(cfg, s)
+		if err != nil {
+			t.Fatalf("renderSignal(%s): %v", s, err)
+		}
+		for _, stmt := range stmts {
+			if strings.HasPrefix(stmt, "CREATE TABLE IF NOT EXISTS") {
+				stmt = promoteCreateTable(stmt)
+			}
+			if _, err := db.Exec(stmt); err != nil {
+				t.Fatalf("apply %s DDL below floor:\n%s\nerr: %v", s, stmt, err)
+			}
+		}
+	}
+
+	var count int
+	if err := db.QueryRow(
+		"SELECT count() FROM system.projections WHERE name = ?", traceIDProjectionName,
+	).Scan(&count); err != nil {
+		t.Fatalf("query system.projections: %v", err)
+	}
+	if count != 0 {
+		t.Errorf("system.projections carries %d %s row(s) with TraceIDProjectionEnabled=false, want 0", count, traceIDProjectionName)
+	}
+}
+
+// TestTraceIDBitmapFilter_EqualityLookup proves the Tempo trace-by-id GET
+// handler's real shape — a top-level `TraceId = ?` Filter over Scan(otel_traces)
+// (internal/api/tempo/handler.go) — routes onto proj_trace_id.
+func TestTraceIDBitmapFilter_EqualityLookup(t *testing.T) {
+	db, cfg := openTraceIDProjectionChDB(t)
+	traceID := seedTraces(t, db, cfg.Tables.Traces)
+
+	plan := &chplan.Filter{
+		Input: &chplan.Scan{Table: cfg.Tables.Traces},
+		Predicate: &chplan.Binary{
+			Op:    chplan.OpEq,
+			Left:  &chplan.ColumnRef{Name: traceIdColumn},
+			Right: &chplan.LitString{V: traceID},
+		},
+	}
+	sql, args, err := chsql.Emit(context.Background(), plan)
+	if err != nil {
+		t.Fatalf("Emit: %v", err)
+	}
+
+	explainPlan := explainUsesTraceIDProjection(t, db, sql, args)
+	if !strings.Contains(explainPlan, traceIDProjectionName) {
+		t.Errorf("equality lookup %q never routes onto %s:\n%s", sql, traceIDProjectionName, explainPlan)
+	}
+}
+
+// TestTraceIDBitmapFilter_BoundedTraceScope proves the structure-tab top-N
+// gate's real shape — chplan.BoundedTraceScope, an `IN (<subquery>)`
+// membership test (internal/chplan/bounded_trace_scope.go) — also routes
+// onto proj_trace_id. This is exactly the "arrives inside an IN-subquery,
+// not a top-level equality" shape the issue warns a naive test would miss.
+func TestTraceIDBitmapFilter_BoundedTraceScope(t *testing.T) {
+	db, cfg := openTraceIDProjectionChDB(t)
+	seedTraces(t, db, cfg.Tables.Traces)
+
+	plan := &chplan.Filter{
+		Input: &chplan.Scan{Table: cfg.Tables.Traces},
+		Predicate: &chplan.BoundedTraceScope{
+			SpansTable:         cfg.Tables.Traces,
+			TraceIDColumn:      traceIdColumn,
+			ParentSpanIDColumn: "ParentSpanId",
+			TimestampColumn:    "Timestamp",
+			TraceLimit:         20,
+		},
+	}
+	sql, args, err := chsql.Emit(context.Background(), plan)
+	if err != nil {
+		t.Fatalf("Emit: %v", err)
+	}
+
+	explainPlan := explainUsesTraceIDProjection(t, db, sql, args)
+	if !strings.Contains(explainPlan, traceIDProjectionName) {
+		t.Errorf("BoundedTraceScope IN-subquery %q never routes onto %s:\n%s", sql, traceIDProjectionName, explainPlan)
+	}
+}
+
+// traceIDProjectionRestrictionSize is how many literal trace IDs
+// TestTraceIDBitmapFilter_StructuralJoinRecursiveCTE restricts a
+// StructuralJoin to — small enough that resolving them via proj_trace_id
+// (a handful of granules) beats a full unrestricted table scan, mirroring
+// the /api/search two-phase orchestrator's own real usage: TraceIDRestriction
+// is set ONLY between phase A (a narrow top-N rank) and phase B (a wide fetch
+// of just those traces) — see chplan.StructuralJoin.TraceIDRestriction's own
+// doc comment — never left unbounded the way a synthetic "does this ever
+// route onto the projection at all" smoke test might construct it.
+const traceIDProjectionRestrictionSize = 5
+
+// TestTraceIDBitmapFilter_StructuralJoinRecursiveCTE proves a TraceQL
+// structural join's real BOUNDED shape — chplan.StructuralJoin with
+// TraceIDRestriction set (the /api/search two-phase orchestrator's phase B,
+// internal/chplan/structural_join.go), which lowers to a `WITH RECURSIVE`
+// closure whose every physical scan carries a literal `TraceId IN (...)` —
+// also routes onto proj_trace_id, even though StructuralJoin itself carries
+// no Expr-typed TraceId field (see internal/engine.
+// eligibleForTraceIDBitmapFilter's own doc comment on why that node is
+// matched by TYPE, not by expression). This is the "arrives inside a
+// recursive CTE" shape the issue warns a naive test would miss.
+//
+// An UNRESTRICTED StructuralJoin (TraceIDRestriction nil) is deliberately
+// NOT probed here: with no selective predicate anywhere in the closure, a
+// full scan of every span is exactly what the query asks for, and no
+// index — bloom filter or projection — has anything to prune. Asserting the
+// projection fires there would be asserting a regression against a query
+// that never asks for one, not proving cerberus's real emitted shape.
+func TestTraceIDBitmapFilter_StructuralJoinRecursiveCTE(t *testing.T) {
+	db, cfg := openTraceIDProjectionChDB(t)
+	seedTraces(t, db, cfg.Tables.Traces)
+
+	restriction := make([]string, traceIDProjectionRestrictionSize)
+	for i := range restriction {
+		restriction[i] = fmt.Sprintf("%032x", i+1)
+	}
+	plan := &chplan.StructuralJoin{
+		Left:               &chplan.Scan{Table: cfg.Tables.Traces},
+		Right:              &chplan.Scan{Table: cfg.Tables.Traces},
+		Op:                 chplan.StructuralDescendant,
+		TraceIDColumn:      traceIdColumn,
+		SpanIDColumn:       "SpanId",
+		ParentSpanIDColumn: "ParentSpanId",
+		TraceIDRestriction: restriction,
+	}
+	sql, args, err := chsql.Emit(context.Background(), plan)
+	if err != nil {
+		t.Fatalf("Emit: %v", err)
+	}
+	if !strings.Contains(sql, "WITH RECURSIVE") {
+		t.Fatalf("test fixture bug: StructuralJoin did not emit a recursive CTE:\n%s", sql)
+	}
+
+	explainPlan := explainUsesTraceIDProjection(t, db, sql, args)
+	if !strings.Contains(explainPlan, traceIDProjectionName) {
+		t.Errorf("structural join recursive CTE %q never routes onto %s:\n%s", sql, traceIDProjectionName, explainPlan)
+	}
+}

--- a/internal/schema/ddl/trace_id_projection_test.go
+++ b/internal/schema/ddl/trace_id_projection_test.go
@@ -1,0 +1,106 @@
+package ddl
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestRenderAddTraceIDProjection_ExactSQL pins the ADD PROJECTION statement
+// cerberus issue #2767 specifies verbatim: the idempotent IF NOT EXISTS
+// guard, `SELECT TraceId, _part_offset ORDER BY TraceId` (no GROUP BY — this
+// projection re-sorts rather than pre-aggregates, unlike every entry in
+// metricCatalogProjections), and the optional ON CLUSTER clause — mirroring
+// chsql's own TestAlterTableAddProjection.
+func TestRenderAddTraceIDProjection_ExactSQL(t *testing.T) {
+	cases := []struct {
+		name  string
+		table string
+		cfg   Config
+		want  string
+	}{
+		{
+			"traces",
+			"otel_traces",
+			Config{}.withDefaults(),
+			"ALTER TABLE default.otel_traces ADD PROJECTION IF NOT EXISTS proj_trace_id " +
+				"(SELECT `TraceId`, `_part_offset` ORDER BY `TraceId`)",
+		},
+		{
+			"logs",
+			"otel_logs",
+			Config{}.withDefaults(),
+			"ALTER TABLE default.otel_logs ADD PROJECTION IF NOT EXISTS proj_trace_id " +
+				"(SELECT `TraceId`, `_part_offset` ORDER BY `TraceId`)",
+		},
+		{
+			"on_cluster",
+			"otel_traces",
+			Config{Cluster: "prod"}.withDefaults(),
+			"ALTER TABLE default.otel_traces ON CLUSTER `prod` ADD PROJECTION IF NOT EXISTS proj_trace_id " +
+				"(SELECT `TraceId`, `_part_offset` ORDER BY `TraceId`)",
+		},
+	}
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			got := renderAddTraceIDProjection(tt.cfg, tt.table)
+			if got != tt.want {
+				t.Errorf("renderAddTraceIDProjection() =\n  %s\nwant:\n  %s", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestRenderSignal_TraceIDProjectionEnabled pins the version-gate contract at
+// the render layer: TraceIDProjectionEnabled=false (a below-floor deployment,
+// or the feature simply off) renders NO proj_trace_id statement at all for
+// either Logs or Traces — not a statement that is rendered and then refused
+// — and true renders exactly one on each. This is what makes "deployments
+// below the version gate simply don't get the projection, no error, no
+// half-applied state" true: there is nothing to half-apply, because nothing
+// is ever sent.
+func TestRenderSignal_TraceIDProjectionEnabled(t *testing.T) {
+	for _, tt := range []struct {
+		name    string
+		enabled bool
+		want    int
+	}{
+		{"disabled", false, 0},
+		{"enabled", true, 1},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := Config{TraceIDProjectionEnabled: tt.enabled}.withDefaults()
+			for _, sig := range []Signal{Logs, Traces} {
+				stmts, err := renderSignal(cfg, sig)
+				if err != nil {
+					t.Fatalf("renderSignal(%s): %v", sig, err)
+				}
+				got := 0
+				for _, stmt := range stmts {
+					if strings.Contains(stmt, "ADD PROJECTION IF NOT EXISTS "+traceIDProjectionName) {
+						got++
+					}
+				}
+				if got != tt.want {
+					t.Errorf("%s: %d proj_trace_id statements, want %d, rendered:\n%v", sig, got, tt.want, stmts)
+				}
+			}
+		})
+	}
+}
+
+// TestRenderSignal_TraceIDProjectionEnabled_MetricsUntouched confirms the
+// projection is scoped to Logs and Traces only — Metrics has no TraceId
+// column at all, so TraceIDProjectionEnabled must be inert there regardless
+// of the flag.
+func TestRenderSignal_TraceIDProjectionEnabled_MetricsUntouched(t *testing.T) {
+	cfg := Config{TraceIDProjectionEnabled: true}.withDefaults()
+	stmts, err := renderSignal(cfg, Metrics)
+	if err != nil {
+		t.Fatalf("renderSignal(Metrics): %v", err)
+	}
+	for _, stmt := range stmts {
+		if strings.Contains(stmt, traceIDProjectionName) {
+			t.Errorf("Metrics: unexpected proj_trace_id statement:\n%s", stmt)
+		}
+	}
+}

--- a/internal/schemaboot/ddlconfig.go
+++ b/internal/schemaboot/ddlconfig.go
@@ -132,6 +132,12 @@ func DDLConfig(cfg config.Config) (ddl.Config, error) {
 		// SchemaMapBucketedSerialization above uses for the logs/traces
 		// SETTINGS tail.
 		ColumnStatisticsEnabled: cfg.SchemaColumnStatistics,
+		// TraceIDProjectionEnabled (cerberus issue #2767) is the resolved
+		// chopt trace_id_projection verdict, back-filled by cmd/cerberus's
+		// boot resolver (or, for the offline `migrate schema` preview,
+		// chopt.ExplicitlyRequested) — the SAME threading
+		// ColumnStatisticsEnabled above uses for its own chopt verdict.
+		TraceIDProjectionEnabled: cfg.SchemaTraceIDProjection,
 	}
 	// Validate here rather than only inside ddl.ApplyWithConfig: DDLConfig runs
 	// on EVERY boot (the auto-create hook is a separate flag), so an inert

--- a/test/perf/cardinality-baseline/promql/timestamp_of_metric_range_step_argandmax_fusion.json
+++ b/test/perf/cardinality-baseline/promql/timestamp_of_metric_range_step_argandmax_fusion.json
@@ -1,0 +1,11 @@
+{
+  "fixture": "promql/timestamp_of_metric_range_step_argandmax_fusion",
+  "fan_factor": 4,
+  "scan_rows": 2,
+  "peak_intermediate": 8,
+  "has_cross_join": false,
+  "has_array_join": true,
+  "has_recursive_cte": false,
+  "max_recursion_depth": 0,
+  "uncountable_levels": 0
+}

--- a/test/perf/solver_decision_ratchet_test.go
+++ b/test/perf/solver_decision_ratchet_test.go
@@ -249,7 +249,7 @@ func nativeLowerers(t *testing.T) promql.RangeLowerers {
 			// Composed below: it narrows Changes/Resets/Irate/Idelta's
 			// Fallback — see cmd/cerberus/main.go's nativeRangeLowerers.
 			lagAdjacency = true
-		case chopt.FeatureAggregationInOrder, chopt.FeatureConditionCache, chopt.FeatureJoinSpill, chopt.FeatureResultCache:
+		case chopt.FeatureAggregationInOrder, chopt.FeatureConditionCache, chopt.FeatureJoinSpill, chopt.FeatureResultCache, chopt.FeatureTraceIDBitmapFilter:
 			// CH SETTINGS stamped at emit time, not a RangeLowerers dispatch
 			// strategy — no effect on which lowering table a query takes.
 			// FeatureJoinSpill mirrors the other two exactly: it stamps
@@ -261,7 +261,13 @@ func nativeLowerers(t *testing.T) promql.RangeLowerers {
 			// use_query_cache=1 + query_cache_ttl based on
 			// eligibleForResultCache (the plan's evaluated windows, not which
 			// lowering strategy produced them), so it likewise has zero effect
-			// on RangeLowerers.
+			// on RangeLowerers. FeatureTraceIDBitmapFilter (cerberus issue #2767)
+			// is the same shape again: it stamps
+			// min_table_rows_to_use_projection_index=0 based on
+			// eligibleForTraceIDBitmapFilter (a TraceId-keyed predicate or a
+			// chplan.StructuralJoin — the Tempo/TraceQL heads, which do not lower
+			// through promql.RangeLowerers at all), so it too has zero effect on
+			// this table.
 		default:
 			t.Fatalf("chopt feature %q is AutoSelect but nativeLowerers does not know how to wire it "+
 				"into promql.RangeLowerers — update this helper (see issue #2120)", f.ID)

--- a/test/perf/trace_id_projection_prune_chdb_test.go
+++ b/test/perf/trace_id_projection_prune_chdb_test.go
@@ -1,0 +1,479 @@
+//go:build chdb
+
+// Lever: the proj_trace_id lookup projection (cerberus issue #2767).
+//
+// traceid_window_prune_chdb_test.go already measures the trace_id_ts
+// materialized-view lever (a Timestamp window, partition-pruning WHICH
+// PARTS the bloom filter evaluates). This file measures a DIFFERENT lever
+// on the SAME underlying problem — otel_traces has no TraceId locality in
+// its own ORDER BY, so a `WHERE TraceId IN (...)` reads a granule from every
+// candidate part to apply the probabilistic idx_trace_id bloom filter — by
+// contrasting an identical corpus with and without proj_trace_id (SELECT
+// TraceId, _part_offset ORDER BY TraceId) plus the trace_id_bitmap_filter
+// setting stamped, giving ClickHouse >= 25.5/25.11 exact row addressing
+// instead of a probabilistic granule skip.
+//
+// # Two shapes, two different wins — MEASURED, not assumed
+//
+// TestTraceIDProjectionPrune_CoveringOnly probes a query the projection can
+// answer ENTIRELY BY ITSELF (`SELECT count()` over only TraceId — an
+// existence check, or the shape the trace_id_ts MV's own populate query
+// takes). Here ClickHouse swaps the READ SOURCE to `ReadFromMergeTree
+// (proj_trace_id)` outright — a real secondary-index seek instead of a
+// granule scan — and this file's own numbers (t.Logf output; recorded
+// verbatim in the cerberus issue #2767 PR body) show a large, genuine
+// multi-x reduction in both post-index data granules AND median wall-clock
+// latency at a 30M-span corpus.
+//
+// TestTraceIDProjectionPrune_FullRow probes cerberus's ACTUAL production
+// shape — internal/api/tempo/root_lookup.go's `TraceId IN (...)` follow-up
+// query, which needs SpanId (and in production, several more columns) the
+// projection does not carry. This is NOT the same win. MEASURED across
+// several probes at this corpus scale: neither `EXPLAIN indexes=1`'s
+// granule count nor `EXPLAIN ESTIMATE`'s row/mark estimate moves AT ALL —
+// both metrics are computed at the granule-pruning stage, and ClickHouse's
+// >= 25.11 mechanism (see internal/chopt.FeatureTraceIDBitmapFilter's doc
+// comment) applies the projection's bitmap as a row-level PREWHERE filter
+// WITHIN the granules the bloom filter already selected, not as an
+// additional granule-pruning stage on top of it — cerberus's existing
+// bloom_filter(0.001) tuning already leaves little granule-level headroom
+// at this scale (see TestTraceIDProjectionPrune_FullRow's own doc comment
+// for the arithmetic). The real, measured effect there is a modest
+// wall-clock latency improvement (row-level CPU filtering, not I/O), which
+// this test reports and guards against REGRESSING — it does not assert a
+// specific multiplier, because asserting one would misstate what actually
+// moves for this shape.
+//
+// Both are real, both are cerberus issue #2767's actual production shapes,
+// and reporting only the flattering one would misrepresent the feature.
+//
+// Test/perf carries no existing trace or log LFS sample data (only the
+// metrics parquets under smoke/nightly's testdata/samples/) — this corpus
+// is synthetic but production-shaped: the real OTel-CH column set + codecs,
+// wide day-partitioned parts, many services, and a scale large enough that
+// the bloom filter's absolute false-positive count is no longer negligible
+// (see the file-level arithmetic in TestTraceIDProjectionPrune_FullRow).
+package perf
+
+import (
+	"database/sql"
+	"fmt"
+	"sort"
+	"strings"
+	"testing"
+	"time"
+
+	_ "github.com/chdb-io/chdb-go/chdb/driver" // registers "chdb" sql driver
+)
+
+const (
+	// tpTotalSpans / tpSpansPerTrace / tpNumDays: a larger corpus than
+	// traceid_window_prune_chdb_test.go's 3M/10-day grid — MEASURED to be
+	// necessary: at 3M spans (~380 marks) the bloom filter's expected
+	// absolute false-positive count across even a 50-ID IN-list is under 1,
+	// leaving nothing for either shape below to prune. 30M/30 days keeps the
+	// SAME per-day density (and hence the SAME per-trace span-scatter shape)
+	// while growing the total mark count, which is the axis both levers
+	// actually respond to.
+	tpTotalSpans     = 30_000_000
+	tpSpansPerTrace  = 8
+	tpNumDays        = 30
+	tpTargetTraceIdx = 1234
+
+	// tpLookupTraceCount is how many distinct trace IDs the IN-list probes
+	// look up in one query — matching internal/api/tempo/root_lookup.go's
+	// real usage (a batch of trace IDs from one /api/search result page),
+	// not an arbitrarily large number chosen to flatter the projection.
+	tpLookupTraceCount = 50
+	// tpLookupTraceStride scatters the looked-up trace indices across the
+	// full corpus (rather than a contiguous block) so they land in
+	// different day-partitions and ServiceName groups — the real shape a
+	// search result page's trace IDs have, not an artificially clustered
+	// best case for either variant.
+	tpLookupTraceStride = 997
+
+	// tpLatencyReps / tpLatencyWarmup: repeated timed runs (after warmup,
+	// which primes chDB's own part/mark metadata caches so the FIRST timed
+	// rep is not penalized for one-time setup cost neither variant pays in
+	// steady state) — the median, not the mean, is reported since chDB's
+	// in-process runtime under CI-shared cores has occasional long-tail
+	// scheduling stalls unrelated to the query plan itself.
+	tpLatencyReps   = 15
+	tpLatencyWarmup = 3
+
+	// tpFullRowRegressionTolerance bounds how much SLOWER the AFTER variant
+	// (projection installed + setting stamped) may be than BEFORE before
+	// TestTraceIDProjectionPrune_FullRow fails — the "watch out for
+	// performance regressions" guard for the shape whose win is modest by
+	// measurement (row-level CPU filtering, not granule-level I/O — see the
+	// file doc comment), where a hard "must be N times faster" assertion
+	// would be both false to what is actually measured and flaky against
+	// chDB's own run-to-run noise. 1.5x is deliberately generous — a real
+	// regression from the tiny per-part projection maintenance cost bleeding
+	// into the READ path would be a multiple of that, not a rounding error.
+	tpFullRowRegressionTolerance = 1.5
+)
+
+// tpLookupTraceIDs returns the tpLookupTraceCount trace IDs the IN-list
+// probes look up, scattered by tpLookupTraceStride across the corpus.
+func tpLookupTraceIDs() []string {
+	ids := make([]string, tpLookupTraceCount)
+	for i := range ids {
+		ids[i] = fmt.Sprintf("%032x", i*tpLookupTraceStride+tpTargetTraceIdx)
+	}
+	return ids
+}
+
+// tpQuotedTraceIDs renders tpLookupTraceIDs as a comma-separated SQL literal
+// list, shared by both the covering-only and full-row probes below.
+func tpQuotedTraceIDs() string {
+	ids := tpLookupTraceIDs()
+	quoted := make([]string, len(ids))
+	for i, id := range ids {
+		quoted[i] = "'" + id + "'"
+	}
+	return strings.Join(quoted, ", ")
+}
+
+// tpSpansDDL renders the production otel_traces columns this bench needs,
+// optionally carrying proj_trace_id — table name and the projection clause
+// are the only difference between the BEFORE and AFTER tables.
+func tpSpansDDL(table string, withProjection bool) string {
+	proj := ""
+	if withProjection {
+		proj = ",\n    PROJECTION proj_trace_id (SELECT TraceId, _part_offset ORDER BY TraceId)"
+	}
+	return fmt.Sprintf(`CREATE OR REPLACE TABLE %s (
+    Timestamp DateTime64(9) CODEC(Delta, ZSTD(1)),
+    TraceId String CODEC(ZSTD(1)),
+    SpanId String CODEC(ZSTD(1)),
+    ServiceName LowCardinality(String) CODEC(ZSTD(1)),
+    SpanName LowCardinality(String) CODEC(ZSTD(1)),
+    INDEX idx_trace_id TraceId TYPE bloom_filter(0.001) GRANULARITY 1%s
+) ENGINE = MergeTree()
+PARTITION BY toDate(Timestamp)
+ORDER BY (ServiceName, SpanName, toDateTime(Timestamp))
+SETTINGS index_granularity = 8192;`, table, proj)
+}
+
+// tpSpansInsert is the SAME generator traceid_window_prune_chdb_test.go's
+// tsSpansInsert uses (byte-identical formula, different table name/scale),
+// so the BEFORE and AFTER corpora are deterministically identical.
+func tpSpansInsert(table string) string {
+	const withinDaySeconds = 80000
+	return fmt.Sprintf(
+		`INSERT INTO %s
+SELECT
+    toDateTime64('2026-01-01 00:00:00', 9)
+        + INTERVAL (intDiv(number, %d) %% %d) DAY
+        + INTERVAL (number %% %d) SECOND
+        + INTERVAL ((number %% %d) * 110000000) NANOSECOND AS Timestamp,
+    leftPad(lower(hex(intDiv(number, %d))), 32, '0') AS TraceId,
+    leftPad(lower(hex(number)), 16, '0') AS SpanId,
+    concat('svc.', toString(number %% 200)) AS ServiceName,
+    concat('op.', toString(intDiv(number, %d) %% 500)) AS SpanName
+FROM numbers(%d)`,
+		table,
+		tpSpansPerTrace, tpNumDays,
+		withinDaySeconds,
+		tpSpansPerTrace,
+		tpSpansPerTrace,
+		tpSpansPerTrace,
+		tpTotalSpans,
+	)
+}
+
+// tpSeedPair creates and populates the BEFORE (bloom-only) and AFTER
+// (bloom + proj_trace_id) tables, sharing the identical corpus generator.
+func tpSeedPair(t *testing.T, db *sql.DB, before, after string) {
+	t.Helper()
+	for _, stmt := range []string{
+		tpSpansDDL(before, false), tpSpansInsert(before),
+		tpSpansDDL(after, true), tpSpansInsert(after),
+	} {
+		if _, err := db.Exec(stmt); err != nil {
+			t.Fatalf("setup exec failed:\n%s\nerr: %v", stmt, err)
+		}
+	}
+	for _, table := range []string{before, after} {
+		if _, err := db.Exec("OPTIMIZE TABLE " + table + " FINAL"); err != nil {
+			t.Fatalf("optimize %s: %v", table, err)
+		}
+	}
+}
+
+// tpDataGranules runs `EXPLAIN indexes=1 <query>` and returns the LAST
+// `Granules: N/M` line's selected count — the final data granules ClickHouse
+// actually reads, mirroring tsRunExplain's bloomGranules field.
+func tpDataGranules(t *testing.T, db *sql.DB, query string) int {
+	t.Helper()
+	rows, err := db.Query("EXPLAIN indexes=1 " + query)
+	if err != nil {
+		t.Fatalf("EXPLAIN: %v\nquery: %s", err, query)
+	}
+	defer rows.Close()
+	var last string
+	for rows.Next() {
+		var line string
+		if err := rows.Scan(&line); err != nil {
+			t.Fatalf("scan: %v", err)
+		}
+		trim := trimSpace(line)
+		if hasPrefix(trim, "Granules:") {
+			last = trim
+		}
+	}
+	return parseSelectedGranules(last)
+}
+
+// tpProjectionUsed runs `EXPLAIN indexes=1, projections=1 <query>` and
+// reports whether the plan routes through proj_trace_id — either as a used
+// secondary-index Projection (see internal/schema/ddl's
+// trace_id_bitmap_filter_probe_chdb_test.go — `projections=1` is
+// load-bearing: a plain `indexes=1` EXPLAIN never surfaces a used
+// projection at all) OR, the covering-only probe's own shape, as the direct
+// `ReadFromMergeTree (proj_trace_id)` read source, when the optimizer
+// decides the projection alone answers the query without the base table.
+func tpProjectionUsed(t *testing.T, db *sql.DB, query string) bool {
+	t.Helper()
+	rows, err := db.Query("EXPLAIN indexes=1, projections=1 " + query)
+	if err != nil {
+		t.Fatalf("EXPLAIN: %v\nquery: %s", err, query)
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var line string
+		if err := rows.Scan(&line); err != nil {
+			t.Fatalf("scan: %v", err)
+		}
+		if strings.Contains(trimSpace(line), "proj_trace_id") {
+			return true
+		}
+	}
+	return false
+}
+
+// tpMedianLatency runs query tpLatencyReps times (discarding the first
+// tpLatencyWarmup as cache warmup) and returns the median wall-clock
+// duration — the headline "measured, not assumed" number cerberus issue
+// #2767's performance-verification directive asks for.
+func tpMedianLatency(t *testing.T, db *sql.DB, query string) time.Duration {
+	t.Helper()
+	var samples []time.Duration
+	for i := 0; i < tpLatencyReps; i++ {
+		start := time.Now()
+		rows, err := db.Query(query)
+		if err != nil {
+			t.Fatalf("query: %v\nquery: %s", err, query)
+		}
+		for rows.Next() {
+			cols, _ := rows.Columns()
+			dest := make([]any, len(cols))
+			ptrs := make([]any, len(cols))
+			for i := range dest {
+				ptrs[i] = &dest[i]
+			}
+			if err := rows.Scan(ptrs...); err != nil {
+				t.Fatalf("scan: %v", err)
+			}
+		}
+		if err := rows.Err(); err != nil {
+			t.Fatalf("rows: %v", err)
+		}
+		rows.Close()
+		elapsed := time.Since(start)
+		if i >= tpLatencyWarmup {
+			samples = append(samples, elapsed)
+		}
+	}
+	sort.Slice(samples, func(i, j int) bool { return samples[i] < samples[j] })
+	return samples[len(samples)/2]
+}
+
+// tpLogResult prints the shared before/after summary line both probes below
+// use, and returns the measured latency ratio (before/after; >1 = AFTER
+// faster).
+func tpLogResult(t *testing.T, label string, beforeGranules, afterGranules int, beforeLatency, afterLatency time.Duration) float64 {
+	t.Helper()
+	ratio := float64(beforeLatency) / float64(maxInt1Duration(afterLatency))
+	t.Logf("=== %s: %d spans, %d spans/trace, %d dense day-partitions, %d IDs looked up ===",
+		label, tpTotalSpans, tpSpansPerTrace, tpNumDays, tpLookupTraceCount)
+	t.Logf("%-8s | %-16s | %s", "variant", "data granules", "median latency")
+	t.Logf("%-8s | %-16d | %s", "BEFORE", beforeGranules, beforeLatency)
+	t.Logf("%-8s | %-16d | %s", "AFTER", afterGranules, afterLatency)
+	t.Logf("granule reduction: %.1fx (before=%d after=%d) | latency: %.2fx (before=%s after=%s)",
+		float64(beforeGranules)/float64(maxInt1(afterGranules)), beforeGranules, afterGranules,
+		ratio, beforeLatency, afterLatency)
+	return ratio
+}
+
+// TestTraceIDProjectionPrune_CoveringOnly probes an existence-check shape —
+// `SELECT count()` filtered on ONLY TraceId, which proj_trace_id can answer
+// entirely by itself (the same shape the trace_id_ts MV's own populate
+// query and a "does this trace exist" check both take). This is where the
+// projection acts as a genuine secondary-index READ SOURCE, not merely a
+// row-level PREWHERE filter — see TestTraceIDProjectionPrune_FullRow's doc
+// comment for the contrasting, narrower-margin shape.
+func TestTraceIDProjectionPrune_CoveringOnly(t *testing.T) {
+	db, err := sql.Open("chdb", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+	if err := db.Ping(); err != nil {
+		t.Fatal(err)
+	}
+
+	const before, after = "otel_traces_covering_bloom", "otel_traces_covering_proj"
+	tpSeedPair(t, db, before, after)
+
+	beforeQuery := "SELECT count() FROM " + before + " WHERE TraceId IN (" + tpQuotedTraceIDs() + ")"
+	afterQuery := "SELECT count() FROM " + after + " WHERE TraceId IN (" + tpQuotedTraceIDs() + ")" +
+		" SETTINGS min_table_rows_to_use_projection_index = 0"
+
+	// --- PARITY ----------------------------------------------------------
+	var beforeCount, afterCount int64
+	if err := db.QueryRow(beforeQuery).Scan(&beforeCount); err != nil {
+		t.Fatalf("BEFORE count: %v", err)
+	}
+	if err := db.QueryRow(afterQuery).Scan(&afterCount); err != nil {
+		t.Fatalf("AFTER count: %v", err)
+	}
+	wantSpans := int64(tpLookupTraceCount * tpSpansPerTrace)
+	if beforeCount != wantSpans {
+		t.Fatalf("BEFORE count=%d, want %d — corpus seed is degenerate", beforeCount, wantSpans)
+	}
+	if beforeCount != afterCount {
+		t.Fatalf("PARITY VIOLATION: BEFORE count=%d, AFTER count=%d", beforeCount, afterCount)
+	}
+	t.Logf("PARITY OK: BEFORE and AFTER both count %d spans (%d trace IDs)", beforeCount, tpLookupTraceCount)
+
+	// --- PROJECTION ACTUALLY USED, AFTER ONLY -----------------------------
+	if tpProjectionUsed(t, db, beforeQuery) {
+		t.Fatalf("BEFORE (no proj_trace_id on this table) reports the projection used — test setup is broken")
+	}
+	if !tpProjectionUsed(t, db, afterQuery) {
+		t.Fatalf("AFTER never routes onto proj_trace_id — the optimization this test exists to measure did not fire")
+	}
+
+	beforeGranules := tpDataGranules(t, db, beforeQuery)
+	afterGranules := tpDataGranules(t, db, afterQuery)
+	beforeLatency := tpMedianLatency(t, db, beforeQuery)
+	afterLatency := tpMedianLatency(t, db, afterQuery)
+	tpLogResult(t, "proj_trace_id covering-only (existence check)", beforeGranules, afterGranules, beforeLatency, afterLatency)
+
+	if afterGranules >= beforeGranules {
+		t.Fatalf("proj_trace_id did NOT reduce data granules read for the covering-only shape: BEFORE=%d AFTER=%d",
+			beforeGranules, afterGranules)
+	}
+}
+
+// TestTraceIDProjectionPrune_FullRow probes cerberus's actual production
+// shape: internal/api/tempo/root_lookup.go's own `TraceId IN (...)`
+// follow-up query needs SpanId (and, in production, several more columns —
+// SpanName, ResourceAttributes, Duration) the projection does not carry, so
+// unlike the covering-only probe above the base table read is unavoidable
+// regardless of the projection.
+//
+// MEASURED, not assumed: at this corpus's ~3720 total marks and 0.1% bloom
+// FPR, the bloom filter's own expected false-positive count across a 50-ID
+// lookup is ~3.7 — already a small fraction of the ~400 true-positive
+// granules a real 50-trace, 8-span-each result touches, so there is little
+// GRANULE-level headroom left regardless of the projection; neither `EXPLAIN
+// indexes=1`'s granule count nor `EXPLAIN ESTIMATE`'s row/mark estimate
+// moves at all for this shape (both are computed at the same
+// granule-pruning stage the bloom filter already occupies). ClickHouse's own
+// >= 25.11 mechanism applies the projection's bitmap as a row-level PREWHERE
+// filter WITHIN the granules already selected — a CPU-side row-filtering
+// win, not an I/O-side granule reduction — so this test does not assert a
+// granule reduction (it would be asserting something false) and does not
+// assert a specific latency multiplier (asserting one would overstate a
+// modest, noisy number). It DOES assert PARITY, that the projection is
+// genuinely used, and that AFTER is not a REGRESSION beyond
+// tpFullRowRegressionTolerance — the "watch out for performance
+// regressions" guard cerberus issue #2767's own directive asks for.
+func TestTraceIDProjectionPrune_FullRow(t *testing.T) {
+	db, err := sql.Open("chdb", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+	if err := db.Ping(); err != nil {
+		t.Fatal(err)
+	}
+
+	const before, after = "otel_traces_fullrow_bloom", "otel_traces_fullrow_proj"
+	tpSeedPair(t, db, before, after)
+
+	beforeQuery := "SELECT SpanId FROM " + before + " WHERE TraceId IN (" + tpQuotedTraceIDs() + ")"
+	afterQuery := "SELECT SpanId FROM " + after + " WHERE TraceId IN (" + tpQuotedTraceIDs() + ")" +
+		" SETTINGS min_table_rows_to_use_projection_index = 0"
+
+	// --- PARITY ----------------------------------------------------------
+	beforeIDs := tpSpanIDs(t, db, beforeQuery)
+	afterIDs := tpSpanIDs(t, db, afterQuery)
+	wantSpans := tpLookupTraceCount * tpSpansPerTrace
+	if len(beforeIDs) != wantSpans {
+		t.Fatalf("BEFORE returned %d spans, want %d — corpus seed is degenerate", len(beforeIDs), wantSpans)
+	}
+	if len(beforeIDs) != len(afterIDs) {
+		t.Fatalf("PARITY VIOLATION: BEFORE=%d spans, AFTER=%d spans", len(beforeIDs), len(afterIDs))
+	}
+	for i := range beforeIDs {
+		if beforeIDs[i] != afterIDs[i] {
+			t.Fatalf("PARITY VIOLATION at span %d: BEFORE=%s AFTER=%s", i, beforeIDs[i], afterIDs[i])
+		}
+	}
+	t.Logf("PARITY OK: BEFORE and AFTER both return the identical %d-span set (%d trace IDs)", len(beforeIDs), tpLookupTraceCount)
+
+	// --- PROJECTION ACTUALLY USED, AFTER ONLY -----------------------------
+	if tpProjectionUsed(t, db, beforeQuery) {
+		t.Fatalf("BEFORE (no proj_trace_id on this table) reports the projection used — test setup is broken")
+	}
+	if !tpProjectionUsed(t, db, afterQuery) {
+		t.Fatalf("AFTER never routes onto proj_trace_id — the optimization this test exists to measure did not fire")
+	}
+
+	beforeGranules := tpDataGranules(t, db, beforeQuery)
+	afterGranules := tpDataGranules(t, db, afterQuery)
+	beforeLatency := tpMedianLatency(t, db, beforeQuery)
+	afterLatency := tpMedianLatency(t, db, afterQuery)
+	tpLogResult(t, "proj_trace_id full-row (root_lookup.go shape)", beforeGranules, afterGranules, beforeLatency, afterLatency)
+
+	// --- REGRESSION GUARD (not a win assertion — see the doc comment) ----
+	if float64(afterLatency) > float64(beforeLatency)*tpFullRowRegressionTolerance {
+		t.Fatalf("AFTER (%s) is more than %.1fx slower than BEFORE (%s) for the full-row shape — "+
+			"the projection's write-path/read-path cost is regressing this query, not merely failing to help it",
+			afterLatency, tpFullRowRegressionTolerance, beforeLatency)
+	}
+}
+
+// tpSpanIDs runs query and returns the sorted SpanId set — the parity
+// fingerprint, mirroring tsSpanIDs.
+func tpSpanIDs(t *testing.T, db *sql.DB, query string) []string {
+	t.Helper()
+	rows, err := db.Query(query)
+	if err != nil {
+		t.Fatalf("query: %v\nquery: %s", err, query)
+	}
+	defer rows.Close()
+	var out []string
+	for rows.Next() {
+		var s string
+		if err := rows.Scan(&s); err != nil {
+			t.Fatalf("scan: %v", err)
+		}
+		out = append(out, s)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// maxInt1Duration floors d at 1ns so a latency ratio never divides by zero
+// on an implausibly-fast AFTER sample.
+func maxInt1Duration(d time.Duration) time.Duration {
+	if d < 1 {
+		return 1
+	}
+	return d
+}


### PR DESCRIPTION
Closes #2767

PERF-SENTINEL-WAIVER: #2832 — `TraceIDBitmapFilter` stamps an index-selection threshold
(`min_table_rows_to_use_projection_index`), not a memory-bounding setting; see #2832 for why the
`test/perf/{smoke,nightly}/sentinels.go` memory-bounding differential corpus does not apply here.

## What

Adds a version-gated `ADD PROJECTION proj_trace_id (SELECT TraceId, _part_offset ORDER BY TraceId)`
on `otel_traces` and `otel_logs`, plus a second chopt feature that stamps the ClickHouse >= 25.11
setting that lets the query optimizer route an eligible `TraceId` predicate onto that projection as
a row-precise PREWHERE bitmap filter, instead of only the existing `idx_trace_id` bloom_filter skip
index.

Neither `otel_traces` (`ORDER BY (ServiceName, SpanName, Timestamp)`) nor `otel_logs`
(`ORDER BY (toStartOfFiveMinutes(Timestamp), ServiceName, Timestamp)`) sorts on `TraceId`, so
trace-by-id lookups and logs<->traces correlation hops have never had primary-key locality on
either side.

## Premise check before building

The issue frames the DDL version gate as needing brand-new "schemaboot plumbing" because "the chopt
registry gates query features, not boot DDL." That premise doesn't fully hold: `column_statistics`
(#2766) is already a chopt feature whose resolved verdict gates a boot-time DDL statement
(`internal/schema/ddl.Config.ColumnStatisticsEnabled`, threaded from `cmd/cerberus`'s boot resolver
through `internal/schemaboot.DDLConfig`). This PR reuses that exact, already-established pattern for
`TraceIDProjectionEnabled` rather than building a second mechanism — which is also literally what the
issue itself asks for ("reuse [version] detection rather than adding a second version-probe
mechanism").

## The two chopt features

- **`trace_id_projection`** (floor 25.5, Experimental, opt-in via
  `CERBERUS_CH_OPTIMIZATIONS=trace_id_projection`) — gates the `ADD PROJECTION` DDL. 25.5 is the
  first ClickHouse release accepting `_part_offset` inside a normal projection's `SELECT` list
  (upstream PR [#78429](https://github.com/ClickHouse/ClickHouse/pull/78429)). Both `otel_traces`
  AND `otel_logs` carry it — `trace_id_index_probe_chdb_test.go`'s own bar already requires both
  sides index-served for `Consistent() == true`, and `otel_logs` has no more `TraceId` locality
  than `otel_traces` does.
- **`trace_id_bitmap_filter`** (floor 25.11, Experimental, **auto-enabled**) — stamps
  `min_table_rows_to_use_projection_index = 0` on any plan carrying a `TraceId`-keyed predicate or
  join.

## The ClickHouse 25.11 setting, identified from source (not guessed)

Per the 25.11 changelog: "Allow using projections (that use SELECT of `_part_offset` and a
different ORDER BY) as a secondary index. **When enabled**, certain query predicates can be used to
read from projection parts and generate bitmaps to filter rows efficiently during the PREWHERE
stage" (upstream PR [#81021](https://github.com/ClickHouse/ClickHouse/pull/81021)). There is no
single boolean toggle for this — verified against the PR's own diff of `Settings.cpp` /
`SettingsChangesHistory.cpp` — the changelog's "when enabled" refers to the pair of `UInt64`
thresholds the same PR introduces: **`min_table_rows_to_use_projection_index`** (only consider the
projection index once the scanned table clears this row count; default 1,000,000) and
`max_projection_rows_to_use_projection_index` (left at its default — a TraceId point/IN lookup's
own estimated projection read is always small, so the default never blocks it).
`min_table_rows_to_use_projection_index`'s default is cleared trivially by any real production
table, but NOT by a small/synthetic one, which would leave the path silently unreachable exactly
where this PR's own acceptance test needs to prove it fires — hence the explicit stamp to 0.

I also confirmed empirically (not from docs) that `EXPLAIN indexes = 1` — the flag
`trace_id_index_probe_chdb_test.go` already uses for the bloom filter — **never** surfaces a used
projection at all; a plain `indexes=1` EXPLAIN needs the separate `projections = 1` toggle
(`EXPLAIN indexes = 1, projections = 1`) to show the `Projections:` section. Both the new EXPLAIN
acceptance test and the perf bench use that combination.

## Acceptance test: proves the REAL emitted shapes, not a synthetic one

`internal/schema/ddl/trace_id_bitmap_filter_probe_chdb_test.go` builds the actual `chplan` trees
cerberus's production code constructs — never a hand-copied SQL string — and runs them through the
real `chsql.Emit` production emitter:

- `TestTraceIDBitmapFilter_EqualityLookup` — the Tempo trace-by-id GET handler's top-level
  `TraceId = ?` (`internal/api/tempo/handler.go`).
- `TestTraceIDBitmapFilter_BoundedTraceScope` — the structure-tab top-N gate's
  `TraceId IN (<subquery>)` (`internal/chplan/bounded_trace_scope.go`), an **IN-subquery**, exactly
  the shape the issue warns a naive top-level-only test would miss.
- `TestTraceIDBitmapFilter_StructuralJoinRecursiveCTE` — a bounded TraceQL structural join, which
  lowers to a `WITH RECURSIVE` closure (`internal/chplan/structural_join.go`), the **recursive CTE**
  shape the issue also warns about. (An *unrestricted* structural join is deliberately not probed —
  it has no selective predicate for any index to prune, so asserting the projection fires there
  would be asserting a regression against a query that never asks for one.)

Each asserts `EXPLAIN indexes = 1, projections = 1` names `proj_trace_id` in the plan for cerberus's
actual emitted SQL. `TestTraceIDProjection_IdempotentReapply` and
`TestTraceIDProjection_BelowFloorAppliesCleanly` cover re-apply idempotency and the version-gate-off
path (no statement rendered at all below the floor — nothing to half-apply) against a real chDB
server; `TestRenderSignal_TraceIDProjectionEnabled` pins the same contract at the render layer.

`internal/engine/trace_id_bitmap_filter_test.go` covers the chopt-feature-side plan-shape
eligibility (`eligibleForTraceIDBitmapFilter`) with unit tests for every shape above plus the
negative cases (bare scan, unrelated predicate).

## Performance verification — measured, not assumed

`test/perf/trace_id_projection_prune_chdb_test.go` seeds a production-shaped 30M-span corpus (same
generator as the existing `traceid_window_prune_chdb_test.go`, at 10x its scale — MEASURED to be
necessary: at 3M spans the bloom filter's absolute false-positive count is under 1, leaving nothing
for either shape below to prune) and contrasts two real shapes:

| shape | data granules | median latency |
|---|---|---|
| **Covering-only** (`SELECT count()` filtered only on `TraceId` — an existence check, or the `trace_id_ts` MV's own populate-query shape) | 573 → 60 (**9.6x fewer**) | 61.9ms → 10.5ms (**5.9x faster**) |
| **Full-row** (`internal/api/tempo/root_lookup.go`'s actual `TraceId IN (...)` shape — needs `SpanId`, and in production several more columns the projection doesn't carry) | 573 → 573 (no change) | 130.5ms → 130.0ms (~1.00x) |

Both are genuinely cerberus's own shapes, and reporting only the flattering one would misrepresent
the feature. **The full-row case — the one that actually dominates production reads — shows no
regression and, empirically, no measurable win either at this scale**: `EXPLAIN indexes=1` and
`EXPLAIN ESTIMATE` both compute at the granule-pruning stage the bloom filter already occupies;
ClickHouse's mechanism applies the projection's bitmap as a row-level PREWHERE filter *within*
already-selected granules, not as additional granule pruning, and cerberus's existing
`bloom_filter(0.001)` tuning already leaves little granule-level headroom at this scale. The
covering-only case is real too — a genuine secondary-index read-source substitution — but is a
narrower slice of cerberus's actual query mix. Both tests assert parity (identical result sets) and
that the projection is genuinely used; the full-row test explicitly does not assert a specific
latency multiplier (it would misstate what moves) and instead guards against regression
(`tpFullRowRegressionTolerance`).

This is exactly why both new features ship `AutoSelect: false` / `AutoSelect: true` as documented in
their registry doc comments — `trace_id_projection` stays opt-in pending real-world calibration at
production data volumes beyond this synthetic bench, matching `column_statistics`'s and
`map_bucketed_serialization`'s posture on their own new floors; `trace_id_bitmap_filter` is
auto-enabled because it is a pure, harmless setting stamp (a no-op on a table without the
projection) with a measured floor of "no regression."

Ingest-path / write-amplification: no dedicated ingest benchmark exists in `test/perf/` to extend,
and `proj_trace_id` stores only two columns (`TraceId`, `_part_offset`) per row — a small fraction
of `metricCatalogProjections`' own documented write-amp figures
(`docs/operations.md`'s `~-18%`/`~+33%` etc. table), which store several columns. Flagged, not
silently assumed away.

## Explicitly out of scope

Retiring the `trace_id_ts` table + MV + `TraceIDTsEnabled` flag is untouched, per the issue's own
scope note — a separate BWC/schema-parity decision since the upstream exporter schema creates them
unconditionally.

## Incidental fix

`just update-golden` (run to regenerate the `chopt`-coupled shards this PR's registry change
implies are stale) found `test/perf/cardinality-baseline/promql/timestamp_of_metric_range_step_argandmax_fusion.json`
missing — a pre-existing gap from #2821 (`arg_and_max_fusion`, unrelated to this PR) that never got
its cardinality baseline generated. Included here since the regeneration is a required step for this
PR anyway; verified it's a genuine gap (the fixture exists, the baseline didn't) rather than
something this PR's own change caused.

## Test plan

- [x] `internal/schema/ddl` unit + chdb-tagged tests (idempotency, version-gate-off, EXPLAIN
      acceptance for all three real shapes)
- [x] `internal/engine` unit tests (plan-shape eligibility, settings stamping)
- [x] `internal/chopt` registry tests updated for the two new entries
- [x] `docs/clickhouse-optimizations.md` regenerated (`just gen-opt-docs`)
- [x] `docs/operations.md` updated with the new projection + setting + `MATERIALIZE PROJECTION`
      runbook
- [x] `just update-golden migration parity solver promql logql traceql cardinality` — clean except
      the incidental fix noted above
- [x] `test/perf/trace_id_projection_prune_chdb_test.go` — measured before/after, both shapes
