### PR TITLE
feat(engine,chclient,solver,chopt): bounded cardinality pre-probe for routing (#2788)

### DIFF
--- a/cmd/cerberus/main.go
+++ b/cmd/cerberus/main.go
@@ -765,14 +765,15 @@ func newPromHandler(client *chclient.Client, cfg config.Config, optSet chopt.Ena
 	// estimate must seed THIS SAME instance rather than a second one.
 	perRungAdmission := buildPerRungAdmission(evalSolver)
 	h.Engine = &engine.Engine{
-		Optimizer:           h.Optimizer,
-		Client:              client,
-		Solver:              evalSolver,
-		Settings:            settingsRules(cfg, optSet),
-		MaxQuerySamples:     client.MaxQuerySamples(),
-		RouteMemo:           buildRouteMemo(evalSolver, logger),
-		PerRungAdmission:    perRungAdmission,
-		ScanEstimateAdvisor: buildScanEstimateAdvisor(client, optSet, evalSolver, perRungAdmission),
+		Optimizer:               h.Optimizer,
+		Client:                  client,
+		Solver:                  evalSolver,
+		Settings:                settingsRules(cfg, optSet),
+		MaxQuerySamples:         client.MaxQuerySamples(),
+		RouteMemo:               buildRouteMemo(evalSolver, logger),
+		PerRungAdmission:        perRungAdmission,
+		ScanEstimateAdvisor:     buildScanEstimateAdvisor(client, optSet, evalSolver, perRungAdmission),
+		CardinalityProbeAdvisor: buildCardinalityProbeAdvisor(client, optSet, evalSolver, perRungAdmission),
 		// PromQL-only: TraceQL / LogQL plans never carry a
 		// chplan.RangeWindow.TemporalityColumn (the OTel Sum
 		// AggregationTemporality concept), so this is inert for the other
@@ -892,6 +893,33 @@ func buildScanEstimateAdvisor(
 		return nil
 	}
 	return engine.NewScanEstimateAdvisor(client, perRungAdmission)
+}
+
+// buildCardinalityProbeAdvisor wires the advisory bounded cardinality
+// pre-probe (internal/engine/cardinality_probe_wiring.go, issue #2788),
+// gated on the chopt FeatureCardinalityProbe feature — an operator-opt-in
+// rollout / kill switch, exactly mirroring buildScanEstimateAdvisor's own
+// gating posture (that function's own doc explains the full reasoning:
+// AlwaysAvailable + AutoSelect=false pending real-world calibration).
+// Returns nil (the engine's byte-unchanged, feature-off default) when the
+// feature is not listed in CERBERUS_CH_OPTIMIZATIONS or evalSolver is nil.
+//
+// perRungAdmission is threaded straight through so a near-empty advisory
+// cardinality reading can seed that SAME learner's priors
+// (PerRungAdmissionLearner.SeedPriorFromEstimate) — the SAME instance
+// buildPerRungAdmission constructed and buildScanEstimateAdvisor also
+// threads, never a third one, so all three mechanisms' state cannot
+// diverge.
+func buildCardinalityProbeAdvisor(
+	client *chclient.Client,
+	optSet chopt.EnabledSet,
+	evalSolver *solver.Solver,
+	perRungAdmission *engine.PerRungAdmissionLearner,
+) *engine.CardinalityProbeAdvisor {
+	if evalSolver == nil || !optSet.Has(chopt.FeatureCardinalityProbe) {
+		return nil
+	}
+	return engine.NewCardinalityProbeAdvisor(client, perRungAdmission)
 }
 
 // nativeRangeLowerers builds the BOOT-WIRED polymorphic lowering dispatch table

--- a/docs/clickhouse-optimizations.md
+++ b/docs/clickhouse-optimizations.md
@@ -150,6 +150,7 @@ table.
 | `result_cache`                   | 24.8       | stable       | yes        |
 | `lazy_materialization`           | 25.11      | experimental | yes        |
 | `explain_estimate`               | none       | experimental | no         |
+| `cardinality_probe`              | none       | experimental | no         |
 <!-- END GENERATED: chopt-feature-table -->
 
 The rich, hand-authored columns below stay OUTSIDE the generated block: they

--- a/docs/solver.md
+++ b/docs/solver.md
@@ -828,6 +828,137 @@ governs `MinFanout` / `MinAnchorPairs` today.
 | `CERBERUS_SHARD_MAX_K_WITH_ESTIMATE`                     | int   | 32      | `Config.MaxKWithEstimate`. Must be `>= CERBERUS_SHARD_MAX_K`.                                                            |
 | `CERBERUS_SHARD_ESTIMATE_MIN_ROWS_PER_ADDITIONAL_SHARD`  | int64 | 50,000  | `Config.EstimateMinRowsPerAdditionalShard`.                                                                              |
 
+## Bounded cardinality pre-probe (issue #2788)
+
+`EXPLAIN ESTIMATE` (above) answers "how many marks did the index analysis
+fail to prune" — a granule-resolution SCAN-side upper bound. It has no
+comparable answer for a different, equally real question: how many DISTINCT
+SERIES actually back a window. Issue #2788 closes that gap with a second,
+independent advisory input — a bounded, REAL aggregate (`count()`,
+`uniqUpTo(100)(...)`) run over the plan's already-pruned scan window, gated
+and cached by `internal/engine/cardinality_probe_wiring.go`'s
+`CardinalityProbeAdvisor`, exactly the way `ScanEstimateAdvisor` gates and
+caches `EXPLAIN ESTIMATE`.
+
+**Real execution, not estimation — and that is the whole point.** Unlike
+`EXPLAIN ESTIMATE`, this probe DOES read data: `count()` is an exact row
+count, and `uniqUpTo(100)(...)` is an exact distinct-series count up to 100
+(ClickHouse's own hard cap on `uniqUpTo`'s parameter — issue #2788 verified
+`uniqUpTo(K_max*16)` throws rather than saturating past it — see
+`chplan.FnUniqUpTo`'s own doc for the "reports 101" saturation contract).
+Both advisors are wired as two SEPARATE `*Engine` fields
+(`ScanEstimateAdvisor`, `CardinalityProbeAdvisor`) whose results merge into
+one `solver.ScanEstimate` at the `Engine.classify` call site: the
+cardinality probe's real `count()` overwrites `Rows` when it runs (strictly
+more precise than the granule upper bound for the SAME K-clamp arithmetic
+below), and its `DistinctSeries` is a field only this probe ever populates.
+
+### What it feeds
+
+1. **K clamping, for free.** `planner.go`'s existing `Rows`-based near-empty
+   skip and `MaxKWithEstimate` raise (documented above) already consume
+   `RequestMeta.Estimate.Rows` — no new code, no new `Config` knob, no new
+   `Reason` token. Feeding it a REAL count when the probe ran is strictly an
+   accuracy improvement over the granule-resolution upper bound
+   `EXPLAIN ESTIMATE` alone would have supplied.
+2. **Per-rung admission priors, answered more directly.**
+   `CardinalityProbeAdvisor.maybeSeedPerRungPrior` mirrors
+   `ScanEstimateAdvisor.maybeSeedPerRungPrior`'s one-directional contract (only
+   ever seeds `cheap=true`, comparing against the SAME
+   `perRungCheapRowsPerAnchor` threshold `PerRungAdmissionLearner.Observe`
+   itself uses) — but compares `DistinctSeries`, not a raw scan-row upper
+   bound. A per-rung carrier fans a classic-histogram bucket ladder out per
+   SERIES, so the composed output `Observe()` measures scales with distinct
+   series far more directly than with raw scanned rows — issue #2788's own
+   "answer per-rung admission's rows/anchor question directly" phrase.
+3. **Route memo corroboration — deliberately NOT wired**, for the identical
+   reason `EXPLAIN ESTIMATE` is not: see "Why the failure-driven route memo
+   is NOT seeded" above. A real bounded aggregate is still one non-drain
+   observation, not the repeated real-traffic corroboration
+   `minCorroboratingFailures` + the pressure damper exist to require.
+
+### Cost bound and scope (deliberately narrow)
+
+Gated identically to `ScanEstimateAdvisor`'s own three narrowings (ModeAuto
+AND reached-cost-grid only; cached per shape; skipped once the route memo or
+per-rung admission already holds a verdict) — reusing that file's own
+`reachedCostGrid` / `shapeKey` / `hasExistingVerdict` helpers rather than
+re-deriving them. Two further narrowings are specific to this probe, both
+documented at length on `cardinality_probe_wiring.go`'s own top-level doc:
+
+- **Carrier kind:** only `*chplan.RangeWindow` (the "matrix" family — by far
+  the most common ModeAuto shape, and the one issue #2709's own incident and
+  this issue's own dashboard-panel example both concern). Every other
+  routable carrier kind (`RangeLWR`, `RangeBucketFanout`,
+  `RangeBucketGridNative`, `RangeWindowGridNative`) fails open — no probe,
+  exactly as if the feature did not exist for that shape. Extending the
+  probe to them, and adding the issue's own bracketed-optional third stat
+  (`avg(length(ExplicitBounds))`, a classic-histogram bucket-width bias
+  signal neither consumer above needs), are tracked as separate follow-up
+  work (issue #2840) rather than folded into this narrower landing.
+- **Metric identity:** the probe's cache key is `(routememo.Key, metric)` —
+  the ONE literal this signal cannot do without, because cardinality is
+  fundamentally metric-specific in a way a literal-free structural shape
+  alone cannot capture. It fires only when the carrier's nearest `Filter`
+  gates on exactly one literal `MetricName = '...'` equality; a regex
+  `__name__` matcher or a multi-metric selector has no single metric to key
+  on and is skipped.
+
+The bound (`Start - Offset - Range, End - Offset]`) the probe scans is the
+EXACT window `chsql`'s own `maybePushInnerScanTimeBounds` pushes down for
+this SAME `RangeWindow`'s real matrix emission — the probe reads precisely
+the rows the real dispatch would read, no more.
+
+A probe failure (breaker-open, transport error, emission error, or the
+probe's own strict `cardinalityProbeTimeout` firing) is treated as "no
+signal" and never surfaces as a query failure — advisory-only, fail-open by
+construction, same as `EXPLAIN ESTIMATE`.
+
+### Measurement
+
+Measured with `buildCardinalityProbePlan`'s own real chplan tree, executed
+via chDB against `test/perf/smoke/testdata/samples/svc_http_requests_total.parquet`
+(the SAME corpus `EXPLAIN ESTIMATE` above was calibrated against) and
+`kube_pod_status_reason.parquet` (the set's highest-cardinality sample, up
+to ~4,800 series in a single window per its own `README.md`):
+
+| window                                                          | rows    | distinct_series  |
+| --------------------------------------------------------------- | ------- | ---------------- |
+| 1h over `svc_http_requests_total`'s densest real hour           | 596,424 | 101 (saturated)  |
+| 6h spanning that hour                                           | 895,858 | 101 (saturated)  |
+| 6h a year outside the sample's captured span (empty)            | 0       | 0                |
+| 1h over `kube_pod_status_reason`'s densest real hour            | 567,360 | 101 (saturated)  |
+
+The 6h row count (895,858) lands EXACTLY on `EXPLAIN ESTIMATE`'s own
+measurement for the identical window (the "Calibration" table above) — the
+two probes independently scanning the same real data agree, cross-validating
+that this probe's `(Start - Offset - Range, End - Offset]` bound is the
+same window the granule-upper-bound probe already reasons about. Every dense
+real window this sample carries saturates `uniqUpTo(100)` at 101 — this
+sample's own real per-panel cardinality already exceeds the cap throughout
+its captured span, confirming issue #2788's own verified constraint (a K
+above 100 throws rather than silently under-counting) matters in practice,
+not only in theory: a deployment probing production traffic at this
+sample's own density needs `uniqCombined`/`uniqCombined64` (issue #2788's
+own named alternative) to see past 100 distinct series, not `uniqUpTo`
+alone — left for the same follow-up (issue #2840) that widens the carrier
+scope, since neither of this landing's two consumers (K-clamp `Rows`,
+per-rung `cheap` seeding) needs an exact count above the 100-series
+threshold either already answers.
+
+### Configuration
+
+| Variable                                      | Type | Default | Description                                                                                                               |
+| --------------------------------------------- | ---- | ------- | ------------------------------------------------------------------------------------------------------------------------- |
+| `CERBERUS_CH_OPTIMIZATIONS=cardinality_probe` | flag | off     | Enables the chopt `cardinality_probe` feature (opt-in only, `AutoSelect=false` — see `docs/clickhouse-optimizations.md`). |
+
+No numeric knobs: `cardinalityProbeUniqUpToCap` (ClickHouse's own hard
+`uniqUpTo` ceiling, not a tuning value), `cardinalityProbeTimeout`, and the
+cache capacity/TTL (reused from `ScanEstimateAdvisor`'s own constants) are
+fixed Go constants pending real-world calibration evidence, mirroring
+`per_rung_admission.go`'s own unexported constants (`perRungCheapRowsPerAnchor`
+et al.) rather than growing a `Config` surface ahead of that evidence.
+
 ## Routing-decision calibration corpus (measurement-only)
 
 The router (`Planner.Plan`) is a **pure** classifier: a query routes A (single

--- a/internal/chclient/cardinality_probe.go
+++ b/internal/chclient/cardinality_probe.go
@@ -1,0 +1,109 @@
+package chclient
+
+import (
+	"context"
+	"fmt"
+)
+
+// cardinality_probe.go closes the chclient half of cerberus issue #2788: the
+// round-trip helper the engine calls, for a ModeAuto-eligible candidate ONLY,
+// to learn what a REAL (not estimated) bounded aggregate over the plan's
+// already-pruned scan window reports about its row count and series
+// cardinality, before committing to a fan-out factor K or a per-rung
+// admission verdict. internal/engine's cardinality_probe_wiring.go is the
+// other half — it gates, caches per (plan shape, metric), and skips the call
+// entirely once the route memo or the per-rung admission learner already
+// holds a verdict, mirroring explain_estimate_wiring.go's own three
+// narrowings for the identical "no new live round-trip on every per-rung
+// request" cost constraint per_rung_admission.go itself documents.
+//
+// Unlike EXPLAIN ESTIMATE (internal/chclient/explain_estimate.go), this DOES
+// execute against real data — count() and uniqUpTo(100)(...) over the
+// caller-bounded scan window — so it answers a question EXPLAIN ESTIMATE's
+// granule-resolution upper bound cannot: how many DISTINCT series actually
+// back the window, not merely how many granules the index analysis could not
+// prune. See docs/solver.md's "Bounded cardinality pre-probe" section for the
+// two mechanisms' full division of labour.
+
+// CardinalityEstimate is the parsed result of one bounded cardinality-probe
+// statement: a real row count plus a real (up to the uniqUpTo cap) distinct
+// series count over the plan's already-pruned scan window.
+type CardinalityEstimate struct {
+	// Rows is the exact count() of rows the probe's bounded window scanned —
+	// unlike chclient.ScanEstimate.Rows (EXPLAIN ESTIMATE's granule-resolution
+	// UPPER BOUND), this is a real post-execution count.
+	Rows uint64
+	// DistinctSeries is uniqUpTo(100)(...)'s exact distinct-series count, up
+	// to 100 — see chplan.FnUniqUpTo's own doc for the saturation behaviour
+	// above that cap (reported as 101, never silently wrong).
+	DistinctSeries uint64
+}
+
+// ProbeCardinality runs sql — a bounded count()/uniqUpTo(100)(...) aggregate
+// internal/engine's cardinality_probe_wiring.go builds via chsql.Emit over
+// the plan's already-pruned scan window — and returns the single summary row
+// it produces. sql MUST already be a chsql.Emit-rendered statement (checked
+// against chsql's own emit_size_bound ceiling), exactly like
+// [Client.ExplainEstimate]'s own contract.
+//
+// Guarded by the circuit breaker (see [Client] doc) like every other query
+// method here. Unlike ExplainEstimate, this DOES read data parts — it is a
+// real, if narrowly bounded, execution — so callers MUST thread a strict
+// per-call deadline (internal/engine's own cardinalityProbeTimeout) via
+// [WithQueryTimeout] and a context deadline, so a slow or loaded cluster
+// cannot stall an admission decision waiting on this optional signal.
+//
+// A probe whose bounded window matched no rows returns a zero-value
+// CardinalityEstimate with a nil error — the caller (maybeSeedPerRungPrior's
+// sibling in cardinality_probe_wiring.go) treats that identically to a
+// genuinely near-empty window, which is the correct reading: no rows means
+// no rows, whichever aggregate discovered it.
+func (c *Client) ProbeCardinality(ctx context.Context, sql string, args ...any) (CardinalityEstimate, error) {
+	if !c.br.allow() {
+		return CardinalityEstimate{}, c.br.openErr("chclient: probe cardinality")
+	}
+	ctx = c.queryContext(ctx)
+	ctx, span := startExecuteSpan(ctx, sql, c.addr)
+	defer span.End()
+	defer flushProgress(ctx)
+	rows, err := c.queryOpen(ctx, sql, args...)
+	c.br.record(ctx, err)
+	if err != nil {
+		span.RecordError(err)
+		return CardinalityEstimate{}, fmt.Errorf("chclient: probe cardinality: %w", c.classifyDriverErr(ctx, err))
+	}
+	defer func() {
+		_ = rows.Close()
+	}()
+
+	var out CardinalityEstimate
+	var found bool
+	for rows.Next() {
+		// rowsFloat: chsql's emitAggregate wraps count() in toFloat64(...)
+		// (internal/chsql/emit_node.go's intReturningAggregates) — the SAME
+		// UInt64→Float64 guard every other count()-family column this plan
+		// emitter produces already carries, so the `rows` column arrives as
+		// Float64 here too. uniqUpTo is NOT in that set (it is not the
+		// column-scan case the guard exists for), so `distinct_series`
+		// arrives as ClickHouse's native UInt64. A real row count never
+		// approaches float64's 2^53 exact-integer ceiling.
+		var rowsFloat float64
+		if err := rows.Scan(&rowsFloat, &out.DistinctSeries); err != nil {
+			return CardinalityEstimate{}, fmt.Errorf("chclient: probe cardinality scan: %w", err)
+		}
+		out.Rows = uint64(rowsFloat)
+		found = true
+	}
+	if err := rows.Err(); err != nil {
+		return CardinalityEstimate{}, fmt.Errorf("chclient: probe cardinality rows.Err: %w", c.classifyDriverErr(ctx, err))
+	}
+	if !found {
+		// The probe's own guarded-aggregate shape (chplan.Aggregate with
+		// DropEmptyOnNoGroup) emits ZERO rows for an empty window rather than
+		// ClickHouse's default one-row-of-zeros — see
+		// cardinality_probe_wiring.go's buildCardinalityProbePlan doc. The
+		// zero CardinalityEstimate is already the correct reading.
+		return CardinalityEstimate{}, nil
+	}
+	return out, nil
+}

--- a/internal/chopt/registry.go
+++ b/internal/chopt/registry.go
@@ -731,6 +731,33 @@ const (
 	// choice pending that evidence, not a version-gated pure win.
 	FeatureExplainEstimate = "explain_estimate"
 
+	// FeatureCardinalityProbe gates a SECOND, independent advisory pre-flight
+	// (cerberus issue #2788) that complements FeatureExplainEstimate: a
+	// bounded REAL aggregate — `count()`, `uniqUpTo(100)(...)` — over a
+	// ModeAuto RangeWindow candidate's already-pruned scan window, answering
+	// the distinct-series fan-out question EXPLAIN ESTIMATE's marks-level
+	// upper bound cannot. Gated identically to FeatureExplainEstimate: once
+	// per distinct (plan shape, metric) pair for a candidate whose baseline
+	// classification reached the cost-grid section, never on every request
+	// (internal/engine's cardinality_probe_wiring.go — same round-trip
+	// constraint per_rung_admission.go's own doc requires, and the same
+	// route-memo / per-rung-admission skip narrowing
+	// explain_estimate_wiring.go established first).
+	//
+	// VERSION FLOOR: registered AlwaysAvailable — uniqUpTo / uniqCombined are
+	// old, universally-available ClickHouse aggregate functions (unlike
+	// EXPLAIN ESTIMATE, this is not even a metadata-analysis feature; it is
+	// an ordinary bounded aggregate query), so there is no real version gate
+	// to express.
+	//
+	// NOT auto-selected (AutoSelect=false), same posture and same reasoning
+	// as FeatureExplainEstimate: advisory only, real-world value on
+	// cerberus's own production query mix is a calibration question pending
+	// operator opt-in evidence — and unlike EXPLAIN ESTIMATE this probe DOES
+	// execute against real data, so enabling it by default would add
+	// unmeasured query volume without an operator's explicit choice.
+	FeatureCardinalityProbe = "cardinality_probe"
+
 	// FeatureColumnStatistics gates the curated `ADD STATISTICS IF NOT
 	// EXISTS` ALTER registry (cerberus issue #2766) that installs ClickHouse
 	// column statistics on the metrics/logs/traces fact tables' highest-value
@@ -1521,6 +1548,13 @@ var registry = []Feature{
 		AutoSelect: false,
 		Doc:        "advisory EXPLAIN ESTIMATE pre-flight for solver K clamping and per-rung admission priors (no version floor — available since 21.9 — opt-in via CERBERUS_CH_OPTIMIZATIONS; auto never picks it pending real-world calibration)",
 	},
+	{
+		ID:         FeatureCardinalityProbe,
+		MinVersion: AlwaysAvailable,
+		Stability:  Experimental,
+		AutoSelect: false,
+		Doc:        "advisory bounded count()/uniqUpTo(100) cardinality pre-probe complementing explain_estimate's marks-level estimate with real distinct-series fan-out (no version floor; opt-in via CERBERUS_CH_OPTIMIZATIONS; auto never picks it pending real-world calibration)",
+	},
 }
 
 // Registry returns a copy of the seeded feature registry
@@ -1532,9 +1566,10 @@ var registry = []Feature{
 // sorted_slab_over_time, map_bucketed_serialization, ts_grid_last_over_time,
 // column_statistics, classic_bucket_merge_summap, exp_histogram_merge_summap,
 // join_spill, trace_id_projection, trace_id_bitmap_filter, arg_and_max_fusion,
-// result_cache, lazy_materialization, explain_estimate). The copy keeps the
-// canonical entries immutable from the caller's side. Exposed so tests can
-// enumerate the gates and the docs generator can render the table.
+// result_cache, lazy_materialization, explain_estimate, cardinality_probe).
+// The copy keeps the canonical entries immutable from the caller's side.
+// Exposed so tests can enumerate the gates and the docs generator can
+// render the table.
 func Registry() []Feature {
 	out := make([]Feature, len(registry))
 	copy(out, registry)

--- a/internal/chopt/resolve_test.go
+++ b/internal/chopt/resolve_test.go
@@ -652,6 +652,7 @@ func TestRegistry_SeededEntries(t *testing.T) {
 		FeatureResultCache:                  {ID: FeatureResultCache, MinVersion: v(24, 8), Stability: Stable, AutoSelect: true, RequiresResultCacheCapability: true},
 		FeatureLazyMaterialization:          {ID: FeatureLazyMaterialization, MinVersion: v(25, 11), Stability: Experimental, AutoSelect: true, RequiresExperimentalTSGrid: false},
 		FeatureExplainEstimate:              {ID: FeatureExplainEstimate, MinVersion: AlwaysAvailable, Stability: Experimental, AutoSelect: false, RequiresExperimentalTSGrid: false},
+		FeatureCardinalityProbe:             {ID: FeatureCardinalityProbe, MinVersion: AlwaysAvailable, Stability: Experimental, AutoSelect: false, RequiresExperimentalTSGrid: false},
 	}
 	if len(reg) != len(want) {
 		t.Fatalf("registry has %d entries; want %d", len(reg), len(want))

--- a/internal/chplan/fn.go
+++ b/internal/chplan/fn.go
@@ -609,6 +609,16 @@ const (
 	// (no sketch approximation).
 	FnUniqExact Fn = "uniqExact"
 
+	// uniqUpTo(N)(x) aggregate — the exact count of distinct x values in the
+	// group, up to N; returns N+1 once the group holds more than N distinct
+	// values rather than continuing to count exactly. N is a compile-time
+	// parameter capped at 100 by ClickHouse itself (issue #2788: a K above 100
+	// throws, not saturates) — cerberus's own cardinality pre-probe is the only
+	// caller and always parameterises with exactly 100, so a probed group's
+	// distinct-value count above that many is reported as "101", a deliberate,
+	// documented saturation rather than an exact count past the cap.
+	FnUniqUpTo Fn = "uniqUpTo"
+
 	// varPop(x) aggregate — the population variance of x in the group.
 	FnVarPop Fn = "varPop"
 )

--- a/internal/chsql/fnresolution.go
+++ b/internal/chsql/fnresolution.go
@@ -209,6 +209,7 @@ var fnResolutions = map[chplan.Fn]fnResolution{
 	chplan.FnSumForEach: {Name: "sumForEach"},
 	chplan.FnSumMap:     {Name: "sumMap"},
 	chplan.FnUniqExact:  {Name: "uniqExact"},
+	chplan.FnUniqUpTo:   {Name: "uniqUpTo"},
 	chplan.FnVarPop:     {Name: "varPop"},
 }
 

--- a/internal/engine/cardinality_probe_wiring.go
+++ b/internal/engine/cardinality_probe_wiring.go
@@ -1,0 +1,545 @@
+package engine
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"github.com/tsouza/cerberus/internal/chclient"
+	"github.com/tsouza/cerberus/internal/chplan"
+	"github.com/tsouza/cerberus/internal/chsql"
+	"github.com/tsouza/cerberus/internal/routememo"
+	"github.com/tsouza/cerberus/internal/schema"
+	"github.com/tsouza/cerberus/internal/solver"
+)
+
+// cardinality_probe_wiring.go closes cerberus issue #2788: it complements
+// explain_estimate_wiring.go's EXPLAIN ESTIMATE advisor (issue #2787, PR
+// #2836) with a SECOND, independent advisory input the marks-level estimate
+// cannot answer — real distinct-series fan-out — by running one bounded,
+// REAL aggregate (`count()`, `uniqUpTo(100)(...)`) over the plan's
+// already-pruned scan window.
+//
+// Both advisors gate on the EXACT SAME boundary explain_estimate_wiring.go's
+// own doc names (ModeAuto candidates whose baseline classification reached
+// the cost-grid section), reuse the SAME per-shape cache key
+// (routememo.Key, via this package's own shapeKey/reachedCostGrid/
+// hasExistingVerdict helpers — see below for why those are reused rather
+// than re-derived), and share the identical "no new live round-trip on
+// every per-rung request" cost constraint per_rung_admission.go's own doc
+// established first. They are deliberately kept as two SEPARATE advisors
+// rather than folded into one: reusing ScanEstimateAdvisor's own cache would
+// mean stretching its routememo.Key-only cache to also carry a metric name,
+// which this file's own cache needs (cardinality varies by WHICH metric is
+// being scanned, in a way a plan's literal-free structural shape alone
+// cannot capture — see cardinalityProbeKey's own doc) and routememo.Key
+// explicitly promises never to (routememo/key.go: "never a metric name,
+// label name, label value"). Two advisors with two narrow, purpose-built
+// keys is simpler and more honest than one advisor whose key type lies
+// about what it is keyed on.
+//
+// SCOPE (deliberately narrow, matching this repository's culture of
+// evidence-first landings — see #2787's own "what was scoped down"):
+//
+//  1. Carrier kind: only the *chplan.RangeWindow "matrix" family — the
+//     carrier #2709's own incident and this issue's own dashboard-panel
+//     example both concern, and by far the most common ModeAuto shape.
+//     findCardinalityProbeCarrier fails open (no probe) for every other
+//     [chplan.GridCarrier] kind (RangeLWR, RangeBucketFanout,
+//     RangeBucketGridNative, RangeWindowGridNative); extending to them is
+//     tracked in issue #2840 (see this package's
+//     cardinality_probe_wiring_test.go for the corresponding fail-open
+//     coverage).
+//  2. Metric identity: the probe only fires when the carrier's scan is
+//     gated by exactly one literal `MetricName = '...'` equality anywhere
+//     in its nearest Filter's predicate (cardinalityProbeMetricName). A
+//     regex `__name__` matcher, a multi-metric selector, or no Filter at
+//     all skips the probe — there is no single "metric" to key the cache on.
+//  3. Payload: only `count()` and `uniqUpTo(100)(...)`. The issue's own SQL
+//     sketch brackets a third, OPTIONAL `avg(length(ExplicitBounds))` term
+//     (a classic-histogram bucket-width bias signal) — omitted here because
+//     neither of this file's two consumers (the K-clamp's Rows input, the
+//     per-rung seeding below) needs it; also tracked in issue #2840.
+//
+// A probe failure — emission error, breaker-open, transport error, timeout —
+// is treated as "no signal" and never surfaces to the caller, exactly like
+// explain_estimate_wiring.go's own fail-open contract: this is advisory-only
+// and must never become a reason a query fails that would otherwise have
+// succeeded.
+
+const (
+	// cardinalityProbeUniqUpToCap is the uniqUpTo(N) parameter this probe
+	// always uses. ClickHouse's own uniqUpTo caps N at 100 — issue #2788
+	// verified that uniqUpTo(100*16) throws rather than saturating — so this
+	// is not a tuning knob but the documented hard ceiling; DistinctSeries
+	// reports 101 (never a false exact count) once a probed window's true
+	// cardinality exceeds it (chplan.FnUniqUpTo's own doc).
+	cardinalityProbeUniqUpToCap = 100
+
+	// cardinalityProbeTimeout is the strict, probe-specific deadline this
+	// file applies to every round trip — both server-side (chclient.
+	// WithQueryTimeout, min'd against the operator's own configured
+	// CERBERUS_QUERY_TIMEOUT so this only ever TIGHTENS it) and client-side
+	// (a context.WithTimeout wrapping the call), so a slow or loaded cluster
+	// cannot stall an admission decision waiting on this optional signal —
+	// the issue's own risk boundary. Unlike EXPLAIN ESTIMATE (a no-execution
+	// metadata operation), this probe DOES read data, so it is the one
+	// cardinality-probe-specific round trip that needs its own bound rather
+	// than inheriting whatever the real request's deadline happens to be.
+	// Generous relative to the issue's own "milliseconds on indexed
+	// predicates" expectation for a granule-pruned window, so a healthy but
+	// momentarily busy cluster still gets an answer.
+	cardinalityProbeTimeout = 2 * time.Second
+)
+
+// cardinalityProbeRowsAlias / cardinalityProbeDistinctSeriesAlias name the
+// probe's two output columns. chclient.Client.ProbeCardinality scans them
+// POSITIONALLY (rows, then distinct_series) — buildCardinalityProbePlan's
+// AggFuncs order is what that positional contract actually binds; these
+// aliases only make the emitted SQL self-describing, they are not
+// themselves load-bearing for the scan order.
+const (
+	cardinalityProbeRowsAlias           = "rows"
+	cardinalityProbeDistinctSeriesAlias = "distinct_series"
+)
+
+// cardinalityProbeMetricNameColumn / cardinalityProbeAttributeMapColumns
+// resolve the OTel-CH metrics schema DEFAULTS once, mirroring
+// internal/chsql/emit.go's own attributeMapColumns var and its own doc for
+// why: this file's gating runs before any per-request schema is in hand
+// (the emit chokepoint has none either), and a deployment that RENAMES a
+// column is covered by its head's lowering being schema-aware — this is
+// defence-in-depth advisory machinery, not a correctness path, so the
+// bounded blast radius of the default-schema assumption is "probe skipped
+// or mis-keyed on a renamed deployment", never a wrong answer.
+var (
+	cardinalityProbeMetricNameColumn    = schema.DefaultOTelMetrics().MetricNameColumn
+	cardinalityProbeAttributeMapColumns = func() chplan.AttributeMapColumns {
+		m := schema.DefaultOTelMetrics()
+		return chplan.NewAttributeMapColumns(m.AttributesColumn, m.ResourceAttributesColumn, m.ScopeAttributesColumn)
+	}()
+)
+
+// cardinalityProbeCacheCapacity / cardinalityProbeCacheTTL mirror
+// scanEstimateCacheCapacity / scanEstimateCacheTTL (explain_estimate_wiring.go)
+// exactly — the same bounded-resident-cache-with-coarse-eviction posture,
+// reused by name rather than re-derived so the two advisors' caching
+// contracts cannot silently drift apart.
+const (
+	cardinalityProbeCacheCapacity = scanEstimateCacheCapacity
+	cardinalityProbeCacheTTL      = scanEstimateCacheTTL
+)
+
+// cardinalityProbeKey is this file's cache key: a plan SHAPE
+// (routememo.Key, the same literal-free fingerprint the route memo, the
+// per-rung admission learner, and ScanEstimateAdvisor all already key on)
+// paired with the ONE literal this signal cannot do without — the metric
+// name. See this file's own top-level doc for why that pairing cannot live
+// inside routememo.Key itself.
+type cardinalityProbeKey struct {
+	shape  routememo.Key
+	metric string
+}
+
+// cardinalityProbeCacheEntry is one cached probe result.
+type cardinalityProbeCacheEntry struct {
+	estimate chclient.CardinalityEstimate
+	cachedAt time.Time
+}
+
+// CardinalityProbe is the narrow chclient seam CardinalityProbeAdvisor
+// depends on — *chclient.Client in production, faked in tests, mirroring
+// Estimator's own role for ScanEstimateAdvisor.
+type CardinalityProbe interface {
+	ProbeCardinality(ctx context.Context, sql string, args ...any) (chclient.CardinalityEstimate, error)
+}
+
+// CardinalityProbeAdvisor is the OPTIONAL, per-Engine-instance cache and
+// gate implementing this file's own doc. A nil *CardinalityProbeAdvisor
+// behaves exactly like a nil Engine.ScanEstimateAdvisor: every call site is
+// reached only through Engine.classify's own nil guard, so an Engine that
+// never wires one is byte-unchanged.
+type CardinalityProbeAdvisor struct {
+	client CardinalityProbe
+	// perRungAdmission is OPTIONAL, exactly like ScanEstimateAdvisor's own
+	// field of the same name: when set, a probe proving the window carries
+	// too few distinct series to matter per anchor also seeds a prior into
+	// it — see maybeSeedPerRungPrior.
+	perRungAdmission *PerRungAdmissionLearner
+
+	mu      sync.Mutex
+	entries map[cardinalityProbeKey]cardinalityProbeCacheEntry
+}
+
+// NewCardinalityProbeAdvisor constructs an advisor bound to client.
+// perRungAdmission may be nil.
+func NewCardinalityProbeAdvisor(client CardinalityProbe, perRungAdmission *PerRungAdmissionLearner) *CardinalityProbeAdvisor {
+	return &CardinalityProbeAdvisor{
+		client:           client,
+		perRungAdmission: perRungAdmission,
+		entries:          make(map[cardinalityProbeKey]cardinalityProbeCacheEntry),
+	}
+}
+
+// Advise returns an updated *solver.ScanEstimate folding this probe's
+// result into current (ScanEstimateAdvisor's own return value, or nil when
+// that advisor is unwired or itself skipped) — see mergeCardinalityEstimate
+// for the merge rule. It returns current UNCHANGED whenever the round trip
+// is skipped or fails, so a caller can always chain this after
+// ScanEstimateAdvisor.Advise regardless of whether that one fired.
+func (a *CardinalityProbeAdvisor) Advise(
+	ctx context.Context,
+	routeMemo *routememo.Memo,
+	plan chplan.Node,
+	baseline *solver.Decision,
+	current *solver.ScanEstimate,
+) *solver.ScanEstimate {
+	if a == nil || baseline == nil {
+		return current
+	}
+	// Narrowing (1) — reuses explain_estimate_wiring.go's own gate: only a
+	// plan whose baseline classification reached the cost-grid section is
+	// worth probing at all.
+	if !reachedCostGrid(baseline.Reason) {
+		return current
+	}
+	rw, ok := findCardinalityProbeCarrier(plan)
+	if !ok {
+		return current
+	}
+	metric, ok := cardinalityProbeMetricName(rw, cardinalityProbeMetricNameColumn)
+	if !ok {
+		return current
+	}
+	// Reuses explain_estimate_wiring.go's own shapeKey/hasExistingVerdict —
+	// narrowing (3): the route memo or the per-rung admission learner
+	// already knows what to do with this shape, so an advisory signal would
+	// buy nothing.
+	shape := shapeKey(plan, baseline)
+	if hasExistingVerdict(routeMemo, a.perRungAdmission, shape) {
+		return current
+	}
+	key := cardinalityProbeKey{shape: shape, metric: metric}
+	// Narrowing (2): per-(shape, metric) cache, ahead of the round trip.
+	if cached, ok := a.cached(key); ok {
+		return mergeCardinalityEstimate(current, cached)
+	}
+
+	probePlan, ok := buildCardinalityProbePlan(rw)
+	if !ok {
+		return current
+	}
+	sql, args, err := chsql.Emit(ctx, probePlan)
+	if err != nil {
+		// Fail open: the real dispatch path will hit and report the SAME
+		// emission error momentarily if it is a genuine problem.
+		return current
+	}
+	probeCtx := chclient.WithQueryTimeout(ctx, cardinalityProbeTimeout)
+	probeCtx, cancel := context.WithTimeout(probeCtx, cardinalityProbeTimeout)
+	defer cancel()
+	est, err := a.client.ProbeCardinality(probeCtx, sql, args...)
+	if err != nil {
+		// Advisory-only, fail-open: breaker-open, transport error, or the
+		// deadline above firing must never turn into a query failure for a
+		// signal that was never a correctness gate.
+		return current
+	}
+
+	a.store(key, est)
+	a.maybeSeedPerRungPrior(shape, est, baseline)
+	return mergeCardinalityEstimate(current, est)
+}
+
+// cached returns key's cached estimate when present and still fresh.
+func (a *CardinalityProbeAdvisor) cached(key cardinalityProbeKey) (chclient.CardinalityEstimate, bool) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	entry, ok := a.entries[key]
+	if !ok || time.Since(entry.cachedAt) > cardinalityProbeCacheTTL {
+		return chclient.CardinalityEstimate{}, false
+	}
+	return entry.estimate, true
+}
+
+// store records key's estimate, evicting one arbitrary entry at capacity —
+// the same coarse-eviction posture ScanEstimateAdvisor.store and
+// PerRungAdmissionLearner.record already document: the cost of evicting the
+// wrong entry here is trivial (one shape probes again a little sooner).
+func (a *CardinalityProbeAdvisor) store(key cardinalityProbeKey, est chclient.CardinalityEstimate) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	if _, ok := a.entries[key]; !ok && len(a.entries) >= cardinalityProbeCacheCapacity {
+		for k := range a.entries {
+			delete(a.entries, k)
+			break
+		}
+	}
+	a.entries[key] = cardinalityProbeCacheEntry{estimate: est, cachedAt: time.Now()}
+}
+
+// maybeSeedPerRungPrior seeds a.perRungAdmission with a prior derived from
+// est, mirroring explain_estimate_wiring.go's own maybeSeedPerRungPrior —
+// same one-directional-only contract (only ever cheap=true, never
+// cheap=false; see that method's own doc for the full argument), same
+// reused perRungCheapRowsPerAnchor threshold (per_rung_admission.go), and
+// the SAME reason the failure-driven route memo is deliberately NOT seeded
+// here either: routememo's minCorroboratingFailures + pressure damper exist
+// specifically to reject single-shot, non-corroborated evidence, and this
+// probe — real execution though it is — is still one non-drain observation,
+// not the repeated real-traffic corroboration the memo's own design
+// requires (docs/solver.md's "Why the failure-driven route memo is NOT
+// seeded", written for #2787, applies unchanged to this probe).
+//
+// est.DistinctSeries is a MORE DIRECT proxy for per-rung admission's own
+// question than EXPLAIN ESTIMATE's raw scan-row upper bound: per-rung
+// carriers fan a classic-histogram bucket ladder out per SERIES, so the
+// composed output row count Observe() measures scales with distinct series,
+// not raw scanned rows. Comparing it against the SAME
+// perRungCheapRowsPerAnchor-per-anchor threshold Observe applies to real
+// composed output is therefore "answer the rows/anchor question directly"
+// (issue #2788's own phrase), not a new, independently-tuned threshold.
+func (a *CardinalityProbeAdvisor) maybeSeedPerRungPrior(key routememo.Key, est chclient.CardinalityEstimate, baseline *solver.Decision) {
+	if a.perRungAdmission == nil || baseline.NAnchors <= 0 {
+		return
+	}
+	// Real probe distinct-series / anchor counts never approach int64 overflow.
+	if int64(est.DistinctSeries) >= int64(baseline.NAnchors)*perRungCheapRowsPerAnchor { //nolint:gosec // G115
+		return
+	}
+	a.perRungAdmission.SeedPriorFromEstimate(key, true)
+}
+
+// mergeCardinalityEstimate folds a cardinality-probe result into base
+// (ScanEstimateAdvisor's own return value, or nil). Rows is OVERWRITTEN
+// with the probe's real count() — strictly more precise than EXPLAIN
+// ESTIMATE's granule-resolution upper bound for the SAME K-clamp arithmetic
+// planner.go already applies (solver.ScanEstimate.Rows' own doc) — while
+// Parts/Marks (EXPLAIN-ESTIMATE-only, unread by classify()) pass through
+// untouched. DistinctSeries is always set from the probe: base never
+// carries one (ScanEstimateAdvisor has no comparable per-series signal).
+func mergeCardinalityEstimate(base *solver.ScanEstimate, est chclient.CardinalityEstimate) *solver.ScanEstimate {
+	merged := solver.ScanEstimate{}
+	if base != nil {
+		merged = *base
+	}
+	merged.Rows = est.Rows
+	merged.DistinctSeries = est.DistinctSeries
+	return &merged
+}
+
+// findCardinalityProbeCarrier locates plan's OUTERMOST [chplan.GridCarrier]
+// — the exact same stop condition solver.GridOf itself uses (first carrier
+// whose EvalGrid reports a positive step) — and reports it only when that
+// carrier is a *chplan.RangeWindow carrying at least one GroupBy key and a
+// non-nil Input. Every other carrier kind (RangeLWR, RangeBucketFanout,
+// RangeBucketGridNative, RangeWindowGridNative) — and a RangeWindow with no
+// series-identity keys or Input at all — reports ok=false: this file's own
+// top-level doc names this the deliberate carrier-kind scope narrowing.
+func findCardinalityProbeCarrier(plan chplan.Node) (*chplan.RangeWindow, bool) {
+	var found chplan.Node
+	chplan.Walk(plan, func(n chplan.Node) bool {
+		if found != nil {
+			return false
+		}
+		if gc, ok := n.(chplan.GridCarrier); ok {
+			if _, _, step := gc.EvalGrid(); step > 0 {
+				found = n
+				return false
+			}
+		}
+		return true
+	})
+	rw, ok := found.(*chplan.RangeWindow)
+	if !ok || len(rw.GroupBy) == 0 || rw.Input == nil {
+		return nil, false
+	}
+	return rw, true
+}
+
+// cardinalityProbeMetricName reports the single literal metric name gating
+// rw's scan — the equality operand of a `<metricNameColumn> = '<name>'`
+// (or reversed) Binary leaf anywhere in the nearest enclosing Filter's
+// predicate below rw.Input. Reports ok=false when rw.Input carries no
+// Filter, the Filter's predicate carries no such equality, or it carries
+// more than one DIFFERENT literal for metricNameColumn (an ambiguous /
+// regex-backed multi-metric selector) — this file's own top-level doc names
+// this the deliberate metric-identity scope narrowing: the probe only ever
+// keys its cache on an unambiguous single metric.
+func cardinalityProbeMetricName(rw *chplan.RangeWindow, metricNameColumn string) (string, bool) {
+	var pred chplan.Expr
+	chplan.Walk(rw.Input, func(n chplan.Node) bool {
+		if pred != nil {
+			return false
+		}
+		if f, ok := n.(*chplan.Filter); ok {
+			pred = f.Predicate
+			return false
+		}
+		return true
+	})
+	if pred == nil {
+		return "", false
+	}
+	var name string
+	var found, ambiguous bool
+	chplan.InspectExpr(pred, func(e chplan.Expr) bool {
+		if ambiguous {
+			return false
+		}
+		b, ok := e.(*chplan.Binary)
+		if !ok || b.Op != chplan.OpEq {
+			return true
+		}
+		lit, matched := cardinalityProbeMetricEqLiteral(b, metricNameColumn)
+		if !matched {
+			return true
+		}
+		if found && lit != name {
+			ambiguous = true
+			return false
+		}
+		name, found = lit, true
+		return true
+	})
+	if ambiguous || !found {
+		return "", false
+	}
+	return name, true
+}
+
+// cardinalityProbeMetricEqLiteral checks both operand orders of an Eq
+// Binary for a `<metricNameColumn> = <string literal>` shape.
+func cardinalityProbeMetricEqLiteral(b *chplan.Binary, metricNameColumn string) (string, bool) {
+	if lit, ok := cardinalityProbeMetricLiteral(b.Left, b.Right, metricNameColumn); ok {
+		return lit, true
+	}
+	return cardinalityProbeMetricLiteral(b.Right, b.Left, metricNameColumn)
+}
+
+// cardinalityProbeMetricLiteral reports whether colSide is a bare reference
+// to metricNameColumn and litSide is a string literal, returning that
+// literal's value.
+func cardinalityProbeMetricLiteral(colSide, litSide chplan.Expr, metricNameColumn string) (string, bool) {
+	col, ok := colSide.(*chplan.ColumnRef)
+	if !ok || col.Name != metricNameColumn {
+		return "", false
+	}
+	lit, ok := litSide.(*chplan.LitString)
+	if !ok {
+		return "", false
+	}
+	return lit.V, true
+}
+
+// buildCardinalityProbePlan builds the bounded aggregate this file's own doc
+// describes — `count()`, `uniqUpTo(100)(...)` over rw's already-pruned scan
+// window — as a chplan tree, rendered through the ordinary chsql.Emit
+// pipeline (invariant 10: no raw SQL). Reports ok=false when rw carries no
+// usable Start/End/TimestampColumn (defensive: every caller already gates
+// on a routed baseline, so this should not fire in practice — mirrors
+// chsql's own maybePushInnerScanTimeBounds "gated on BOTH Start and End
+// being set" posture).
+//
+// Shape:
+//
+//	SELECT rows, distinct_series
+//	FROM (
+//	    SELECT toFloat64(count()) AS rows, uniqUpTo(?)(<series key>) AS distinct_series,
+//	           count() AS _cerb_n
+//	    FROM (
+//	        SELECT * FROM (<rw.Input>)
+//	        WHERE <TimestampColumn> > (Start - Offset - Range)
+//	          AND <TimestampColumn> <= (End - Offset)
+//	    )
+//	) WHERE _cerb_n > 0
+//
+// `count()` renders wrapped in toFloat64(...) — chsql's ordinary
+// intReturningAggregates guard (internal/chsql/emit_node.go), the SAME
+// UInt64→Float64 coercion every other count()-family column this emitter
+// produces already carries — and `uniqUpTo`'s cap renders as a bound `?`
+// parameter (chplan.AggFunc.Params), the same parametric-aggregate shape
+// production's own quantile(phi)(...) lowering already uses
+// (internal/promql/lower.go). chclient.Client.ProbeCardinality's own doc
+// explains the resulting scan shape.
+//
+// The (Start - Offset - Range, End - Offset] bound is the EXACT window
+// chsql's own maybePushInnerScanTimeBounds pushes down for this SAME
+// RangeWindow's real matrix emission (internal/chsql/range_window.go) — so
+// the probe scans PRECISELY the rows the real dispatch would scan, no more,
+// no less. The outer `_cerb_n > 0` guard (chplan.Aggregate's own
+// DropEmptyOnNoGroup path, emitAggregateNoGroup) is what makes an empty
+// window return ZERO rows rather than ClickHouse's default one-row-of-zeros
+// — chclient.Client.ProbeCardinality's own doc explains why that already IS
+// the correct "near empty" reading, with no special-casing needed here.
+//
+// The series-identity key is rw.GroupBy, canonicalised via
+// chplan.CanonicalizeSeriesKeyExprs exactly like chsql/exemplars.go's own
+// call site — so a raw attribute-Map key's ClickHouse key-order variance
+// cannot inflate the uniqUpTo count — collapsed into one uniqUpTo argument
+// via chplan.FnTuple when rw carries more than one key.
+func buildCardinalityProbePlan(rw *chplan.RangeWindow) (chplan.Node, bool) {
+	if rw.Start.IsZero() || rw.End.IsZero() || rw.TimestampColumn == "" {
+		return nil, false
+	}
+	groupBy := chplan.CanonicalizeSeriesKeyExprs(rw.GroupBy, []chplan.Node{rw.Input}, cardinalityProbeAttributeMapColumns)
+	filtered := &chplan.Filter{Input: rw.Input, Predicate: cardinalityProbeTimeBound(rw)}
+	return &chplan.Aggregate{
+		Input:              filtered,
+		DropEmptyOnNoGroup: true,
+		AggFuncs: []chplan.AggFunc{
+			{Fn: chplan.FnCount, Alias: cardinalityProbeRowsAlias},
+			{
+				Fn:     chplan.FnUniqUpTo,
+				Params: []chplan.Expr{&chplan.LitInt{V: cardinalityProbeUniqUpToCap}},
+				Args:   []chplan.Expr{cardinalityProbeSeriesKeyExpr(groupBy)},
+				Alias:  cardinalityProbeDistinctSeriesAlias,
+			},
+		},
+	}, true
+}
+
+// cardinalityProbeSeriesKeyExpr collapses groupBy (already canonicalised by
+// the caller) into the single Expr uniqUpTo needs: the bare key itself when
+// there is exactly one, else a tuple(...) of all of them.
+func cardinalityProbeSeriesKeyExpr(groupBy []chplan.Expr) chplan.Expr {
+	if len(groupBy) == 1 {
+		return groupBy[0]
+	}
+	return &chplan.FuncCall{Fn: chplan.FnTuple, Args: groupBy}
+}
+
+// cardinalityProbeTimeBound builds rw's own (Start - Offset - Range, End -
+// Offset] scan bound as a chplan Filter predicate — see
+// buildCardinalityProbePlan's own doc for why this exact interval mirrors
+// chsql's real emitter, and cardinalityProbeTimeLit's doc for the literal
+// shape.
+func cardinalityProbeTimeBound(rw *chplan.RangeWindow) chplan.Expr {
+	lower := rw.Start.Add(-rw.Offset).Add(-rw.Range)
+	upper := rw.End.Add(-rw.Offset)
+	tsCol := &chplan.ColumnRef{Name: rw.TimestampColumn}
+	return &chplan.Binary{
+		Op:   chplan.OpAnd,
+		Left: &chplan.Binary{Op: chplan.OpGt, Left: tsCol, Right: cardinalityProbeTimeLit(lower)},
+		Right: &chplan.Binary{
+			Op:    chplan.OpLe,
+			Left:  &chplan.ColumnRef{Name: rw.TimestampColumn},
+			Right: cardinalityProbeTimeLit(upper),
+		},
+	}
+}
+
+// cardinalityProbeTimeLit renders t as a `toDateTime64('YYYY-MM-DD
+// HH:MM:SS.fffffffff', 9)` literal — the exact same shape
+// internal/promql/lower.go's metadataBoundExpr already uses for an absolute
+// window bound, reused here (not re-derived) so this file introduces no new
+// literal-time idiom for a reviewer to separately trust.
+func cardinalityProbeTimeLit(t time.Time) chplan.Expr {
+	return &chplan.FuncCall{
+		Fn: chplan.FnToDateTime64,
+		Args: []chplan.Expr{
+			&chplan.LitString{V: t.UTC().Format("2006-01-02 15:04:05.000000000")},
+			&chplan.LitInt{V: chplan.NanoScale},
+		},
+	}
+}

--- a/internal/engine/cardinality_probe_wiring_test.go
+++ b/internal/engine/cardinality_probe_wiring_test.go
@@ -1,0 +1,429 @@
+package engine
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/tsouza/cerberus/internal/chclient"
+	"github.com/tsouza/cerberus/internal/chplan"
+	"github.com/tsouza/cerberus/internal/chsql"
+	"github.com/tsouza/cerberus/internal/routememo"
+	"github.com/tsouza/cerberus/internal/solver"
+)
+
+// --- fixtures ---------------------------------------------------------------
+
+// cardinalityProbeTestStart / cardinalityProbeTestEnd give buildCardinalityProbePlan
+// a stable, non-zero Start/End pair.
+var (
+	cardinalityProbeTestStart = time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	cardinalityProbeTestEnd   = cardinalityProbeTestStart.Add(24 * time.Hour)
+)
+
+// cardinalityProbeTestMetric is the literal metric name cardinalityProbeTestPlan's
+// Filter gates on.
+const cardinalityProbeTestMetric = "http_requests_total"
+
+// cardinalityProbeTestFilter builds a Filter(Scan) with a single literal
+// MetricName equality predicate — the shape cardinalityProbeMetricName
+// resolves unambiguously.
+func cardinalityProbeTestFilter(metric string) *chplan.Filter {
+	return &chplan.Filter{
+		Input: &chplan.Scan{Table: "otel_metrics_sum"},
+		Predicate: &chplan.Binary{
+			Op:    chplan.OpEq,
+			Left:  &chplan.ColumnRef{Name: cardinalityProbeMetricNameColumn},
+			Right: &chplan.LitString{V: metric},
+		},
+	}
+}
+
+// cardinalityProbeTestPlan is a minimal *chplan.RangeWindow carrier over a
+// single-metric Filter(Scan) — the one carrier shape this file's own scope
+// narrowing (findCardinalityProbeCarrier) recognizes.
+func cardinalityProbeTestPlan() chplan.Node {
+	return &chplan.RangeWindow{
+		Input:           cardinalityProbeTestFilter(cardinalityProbeTestMetric),
+		Func:            "rate",
+		Range:           5 * time.Minute,
+		Step:            15 * time.Second,
+		OuterRange:      24 * time.Hour,
+		Start:           cardinalityProbeTestStart,
+		End:             cardinalityProbeTestEnd,
+		TimestampColumn: "TimeUnix",
+		ValueColumn:     "Value",
+		GroupBy:         []chplan.Expr{&chplan.ColumnRef{Name: "Attributes"}},
+	}
+}
+
+const cardinalityProbeTestNAnchors = 241
+
+func cardinalityProbeTestBaseline(reason string) *solver.Decision {
+	return &solver.Decision{
+		Reason:   reason,
+		NAnchors: cardinalityProbeTestNAnchors,
+		Fanout:   20,
+		Step:     15 * time.Second,
+	}
+}
+
+func cardinalityProbeTestKey() routememo.Key {
+	d := cardinalityProbeTestBaseline(solver.ReasonRouted)
+	return shapeKey(cardinalityProbeTestPlan(), d)
+}
+
+// countingCardinalityProbe is a fake CardinalityProbe that counts every
+// ProbeCardinality call and returns a fixed result (or a fixed error).
+type countingCardinalityProbe struct {
+	calls    int
+	estimate chclient.CardinalityEstimate
+	err      error
+}
+
+func (c *countingCardinalityProbe) ProbeCardinality(_ context.Context, _ string, _ ...any) (chclient.CardinalityEstimate, error) {
+	c.calls++
+	return c.estimate, c.err
+}
+
+// --- CardinalityProbeAdvisor.Advise ------------------------------------------
+
+func TestCardinalityProbeAdvisor_SkipsSecondProbeForSameShapeAndMetric(t *testing.T) {
+	t.Parallel()
+	probe := &countingCardinalityProbe{estimate: chclient.CardinalityEstimate{Rows: 500_000, DistinctSeries: 40}}
+	a := NewCardinalityProbeAdvisor(probe, nil)
+	plan := cardinalityProbeTestPlan()
+	baseline := cardinalityProbeTestBaseline(solver.ReasonRouted)
+
+	first := a.Advise(context.Background(), nil, plan, baseline, nil)
+	if first == nil || first.Rows != 500_000 || first.DistinctSeries != 40 {
+		t.Fatalf("first probe: got %+v, want Rows=500000, DistinctSeries=40", first)
+	}
+	if probe.calls != 1 {
+		t.Fatalf("first probe issued %d round trips, want 1", probe.calls)
+	}
+
+	second := a.Advise(context.Background(), nil, plan, baseline, nil)
+	if second == nil || second.Rows != 500_000 || second.DistinctSeries != 40 {
+		t.Fatalf("second probe (cached): got %+v, want Rows=500000, DistinctSeries=40", second)
+	}
+	if probe.calls != 1 {
+		t.Fatalf("second probe for the SAME (shape, metric) issued %d round trips, want 1 (cache hit)", probe.calls)
+	}
+}
+
+func TestCardinalityProbeAdvisor_SkipsStructurallyIneligiblePlan(t *testing.T) {
+	t.Parallel()
+	probe := &countingCardinalityProbe{estimate: chclient.CardinalityEstimate{Rows: 1}}
+	a := NewCardinalityProbeAdvisor(probe, nil)
+	baseline := cardinalityProbeTestBaseline(solver.ReasonNow64)
+
+	got := a.Advise(context.Background(), nil, cardinalityProbeTestPlan(), baseline, nil)
+	if got != nil {
+		t.Fatalf("got %+v, want nil (structurally ineligible)", got)
+	}
+	if probe.calls != 0 {
+		t.Fatalf("issued %d round trips for a structurally ineligible plan, want 0", probe.calls)
+	}
+}
+
+func TestCardinalityProbeAdvisor_SkipsWhenRouteMemoHasVerdict(t *testing.T) {
+	t.Parallel()
+	probe := &countingCardinalityProbe{estimate: chclient.CardinalityEstimate{Rows: 1}}
+	a := NewCardinalityProbeAdvisor(probe, nil)
+	plan := cardinalityProbeTestPlan()
+	baseline := cardinalityProbeTestBaseline(solver.ReasonRouted)
+	key := cardinalityProbeTestKey()
+
+	memo := routememo.New(time.Hour)
+	memo.Observe(key, routememo.RouteA, routememo.OutcomeResourceFailure)
+	memo.Observe(key, routememo.RouteA, routememo.OutcomeResourceFailure)
+	release, ok := memo.BeginProbe(key)
+	if !ok {
+		t.Fatalf("BeginProbe declined admission for a corroborated key")
+	}
+	memo.Observe(key, routememo.RouteB, routememo.OutcomeSuccess)
+	release()
+	if state, _ := memo.Lookup(key); state != routememo.PreferB {
+		t.Fatalf("fixture failed to establish PreferB; got %v", state)
+	}
+
+	got := a.Advise(context.Background(), memo, plan, baseline, nil)
+	if got != nil {
+		t.Fatalf("got %+v, want nil (route memo already holds a verdict)", got)
+	}
+	if probe.calls != 0 {
+		t.Fatalf("issued %d round trips despite an existing route memo verdict, want 0", probe.calls)
+	}
+}
+
+func TestCardinalityProbeAdvisor_SkipsWhenPerRungAdmissionHasVerdict(t *testing.T) {
+	t.Parallel()
+	probe := &countingCardinalityProbe{estimate: chclient.CardinalityEstimate{Rows: 1}}
+	learner := NewPerRungAdmissionLearner()
+	a := NewCardinalityProbeAdvisor(probe, learner)
+	plan := cardinalityProbeTestPlan()
+	baseline := cardinalityProbeTestBaseline(solver.ReasonRouted)
+	key := cardinalityProbeTestKey()
+
+	learner.Observe(key, 10, cardinalityProbeTestNAnchors) // any real observation seeds a fresh entry
+
+	got := a.Advise(context.Background(), nil, plan, baseline, nil)
+	if got != nil {
+		t.Fatalf("got %+v, want nil (per-rung admission already holds a verdict)", got)
+	}
+	if probe.calls != 0 {
+		t.Fatalf("issued %d round trips despite an existing per-rung admission entry, want 0", probe.calls)
+	}
+}
+
+func TestCardinalityProbeAdvisor_ProbeFailureIsAdvisoryUnchanged(t *testing.T) {
+	t.Parallel()
+	probe := &countingCardinalityProbe{err: errors.New("boom")}
+	a := NewCardinalityProbeAdvisor(probe, nil)
+	baseline := cardinalityProbeTestBaseline(solver.ReasonRouted)
+	current := &solver.ScanEstimate{Rows: 42, Parts: 3, Marks: 9}
+
+	got := a.Advise(context.Background(), nil, cardinalityProbeTestPlan(), baseline, current)
+	if got != current {
+		t.Fatalf("got %+v, want the SAME current pointer unchanged (probe failure must fail open)", got)
+	}
+	if probe.calls != 1 {
+		t.Fatalf("probe called %d times, want exactly 1", probe.calls)
+	}
+}
+
+func TestCardinalityProbeAdvisor_NilAdvisorAndNilBaseline(t *testing.T) {
+	t.Parallel()
+	probe := &countingCardinalityProbe{estimate: chclient.CardinalityEstimate{Rows: 1}}
+
+	var nilAdvisor *CardinalityProbeAdvisor
+	current := &solver.ScanEstimate{Rows: 7}
+	if got := nilAdvisor.Advise(context.Background(), nil, cardinalityProbeTestPlan(), cardinalityProbeTestBaseline(solver.ReasonRouted), current); got != current {
+		t.Fatalf("nil advisor: got %+v, want current unchanged", got)
+	}
+
+	a := NewCardinalityProbeAdvisor(probe, nil)
+	if got := a.Advise(context.Background(), nil, cardinalityProbeTestPlan(), nil, current); got != current {
+		t.Fatalf("nil baseline: got %+v, want current unchanged", got)
+	}
+	if probe.calls != 0 {
+		t.Fatalf("issued %d round trips for a nil advisor/baseline, want 0", probe.calls)
+	}
+}
+
+func TestCardinalityProbeAdvisor_SkipsNonRangeWindowCarrier(t *testing.T) {
+	t.Parallel()
+	probe := &countingCardinalityProbe{estimate: chclient.CardinalityEstimate{Rows: 1}}
+	a := NewCardinalityProbeAdvisor(probe, nil)
+	baseline := cardinalityProbeTestBaseline(solver.ReasonRouted)
+
+	// A RangeLWR carrier — outside this file's deliberate carrier-kind
+	// scope narrowing (this file's own top-level doc, point 1).
+	plan := &chplan.RangeLWR{
+		Input:        cardinalityProbeTestFilter(cardinalityProbeTestMetric),
+		Start:        cardinalityProbeTestStart,
+		End:          cardinalityProbeTestEnd,
+		Step:         15 * time.Second,
+		TimestampCol: "TimeUnix",
+	}
+
+	got := a.Advise(context.Background(), nil, plan, baseline, nil)
+	if got != nil {
+		t.Fatalf("got %+v, want nil (RangeLWR carrier is out of this feature's scope)", got)
+	}
+	if probe.calls != 0 {
+		t.Fatalf("issued %d round trips for an out-of-scope carrier kind, want 0", probe.calls)
+	}
+}
+
+func TestCardinalityProbeAdvisor_SkipsAmbiguousMetricSelector(t *testing.T) {
+	t.Parallel()
+	probe := &countingCardinalityProbe{estimate: chclient.CardinalityEstimate{Rows: 1}}
+	a := NewCardinalityProbeAdvisor(probe, nil)
+	baseline := cardinalityProbeTestBaseline(solver.ReasonRouted)
+
+	plan := &chplan.RangeWindow{
+		Input: &chplan.Filter{
+			Input: &chplan.Scan{Table: "otel_metrics_sum"},
+			Predicate: &chplan.Binary{
+				Op:    chplan.OpMatch, // a regex __name__ matcher, not a literal Eq
+				Left:  &chplan.ColumnRef{Name: cardinalityProbeMetricNameColumn},
+				Right: &chplan.LitString{V: "http_.*"},
+			},
+		},
+		Func:            "rate",
+		Range:           5 * time.Minute,
+		Step:            15 * time.Second,
+		OuterRange:      24 * time.Hour,
+		Start:           cardinalityProbeTestStart,
+		End:             cardinalityProbeTestEnd,
+		TimestampColumn: "TimeUnix",
+		GroupBy:         []chplan.Expr{&chplan.ColumnRef{Name: "Attributes"}},
+	}
+
+	got := a.Advise(context.Background(), nil, plan, baseline, nil)
+	if got != nil {
+		t.Fatalf("got %+v, want nil (no single literal metric to key the cache on)", got)
+	}
+	if probe.calls != 0 {
+		t.Fatalf("issued %d round trips for an ambiguous metric selector, want 0", probe.calls)
+	}
+}
+
+func TestCardinalityProbeAdvisor_MergesWithExistingEstimate(t *testing.T) {
+	t.Parallel()
+	probe := &countingCardinalityProbe{estimate: chclient.CardinalityEstimate{Rows: 900_000, DistinctSeries: 12}}
+	a := NewCardinalityProbeAdvisor(probe, nil)
+	baseline := cardinalityProbeTestBaseline(solver.ReasonRouted)
+	current := &solver.ScanEstimate{Parts: 3, Marks: 61, Rows: 500_000} // as if ScanEstimateAdvisor ran first
+
+	got := a.Advise(context.Background(), nil, cardinalityProbeTestPlan(), baseline, current)
+	if got == nil {
+		t.Fatal("got nil, want a merged estimate")
+	}
+	if got.Parts != 3 || got.Marks != 61 {
+		t.Fatalf("got %+v, want Parts/Marks preserved from the EXPLAIN ESTIMATE producer", got)
+	}
+	if got.Rows != 900_000 {
+		t.Fatalf("got Rows=%d, want the REAL probe count (900000) to supersede the granule upper bound", got.Rows)
+	}
+	if got.DistinctSeries != 12 {
+		t.Fatalf("got DistinctSeries=%d, want 12", got.DistinctSeries)
+	}
+	if current.Rows != 500_000 {
+		t.Fatalf("merge must not mutate the caller's current estimate in place; got Rows=%d", current.Rows)
+	}
+}
+
+// --- per-rung admission seeding ----------------------------------------------
+
+func TestCardinalityProbeAdvisor_SeedsPerRungPriorOnLowCardinality(t *testing.T) {
+	t.Parallel()
+	// Well under cardinalityProbeTestNAnchors(241) * perRungCheapRowsPerAnchor(20).
+	probe := &countingCardinalityProbe{estimate: chclient.CardinalityEstimate{Rows: 1_000, DistinctSeries: 100}}
+	learner := NewPerRungAdmissionLearner()
+	a := NewCardinalityProbeAdvisor(probe, learner)
+	plan := cardinalityProbeTestPlan()
+	baseline := cardinalityProbeTestBaseline(solver.ReasonRouted)
+	key := cardinalityProbeTestKey()
+
+	if a.Advise(context.Background(), nil, plan, baseline, nil) == nil {
+		t.Fatal("expected a non-nil advisory estimate")
+	}
+	if !learner.hasFreshEntry(key) {
+		t.Fatal("a low-distinct-series probe did not seed the per-rung admission learner")
+	}
+}
+
+func TestCardinalityProbeAdvisor_HighCardinalityDoesNotResetPerRungPrior(t *testing.T) {
+	t.Parallel()
+	// Well OVER cardinalityProbeTestNAnchors(241) * perRungCheapRowsPerAnchor(20).
+	learner := NewPerRungAdmissionLearner()
+	baseline := cardinalityProbeTestBaseline(solver.ReasonRouted)
+	key := cardinalityProbeTestKey()
+
+	// Real accumulated evidence: one real clean-and-cheap drain, one
+	// observation short of ShouldDeclineBypass's own threshold.
+	learner.Observe(key, 10, cardinalityProbeTestNAnchors)
+	if learner.ShouldDeclineBypass(key) {
+		t.Fatal("fixture: a single real observation must not already decline the bypass")
+	}
+
+	// Directly exercise maybeSeedPerRungPrior's own one-directional
+	// contract (a dense DistinctSeries reading must never call
+	// SeedPriorFromEstimate with cheap=false).
+	a := NewCardinalityProbeAdvisor(nil, learner)
+	a.maybeSeedPerRungPrior(key, chclient.CardinalityEstimate{DistinctSeries: 10_000}, baseline)
+	learner.Observe(key, 10, cardinalityProbeTestNAnchors) // the second REAL cheap observation
+	if !learner.ShouldDeclineBypass(key) {
+		t.Fatal("a dense probe reading reset the real accumulated evidence — two real cheap " +
+			"observations must still decline the bypass")
+	}
+}
+
+// --- helper functions ---------------------------------------------------------
+
+func TestFindCardinalityProbeCarrier(t *testing.T) {
+	t.Parallel()
+	if rw, ok := findCardinalityProbeCarrier(cardinalityProbeTestPlan()); !ok || rw == nil {
+		t.Fatalf("expected the fixture's own RangeWindow carrier to be found, got ok=%v", ok)
+	}
+
+	lwr := &chplan.RangeLWR{Input: cardinalityProbeTestFilter("x"), Start: cardinalityProbeTestStart, End: cardinalityProbeTestEnd, Step: time.Minute}
+	if _, ok := findCardinalityProbeCarrier(lwr); ok {
+		t.Fatal("expected ok=false for a non-RangeWindow carrier")
+	}
+
+	noGroupBy := &chplan.RangeWindow{
+		Input: cardinalityProbeTestFilter("x"), Func: "rate", Range: time.Minute, Step: time.Minute,
+		OuterRange: time.Hour, Start: cardinalityProbeTestStart, End: cardinalityProbeTestEnd, TimestampColumn: "TimeUnix",
+	}
+	if _, ok := findCardinalityProbeCarrier(noGroupBy); ok {
+		t.Fatal("expected ok=false for a RangeWindow with no GroupBy series-identity keys")
+	}
+}
+
+func TestCardinalityProbeMetricName(t *testing.T) {
+	t.Parallel()
+	rw := cardinalityProbeTestPlan().(*chplan.RangeWindow)
+	name, ok := cardinalityProbeMetricName(rw, cardinalityProbeMetricNameColumn)
+	if !ok || name != cardinalityProbeTestMetric {
+		t.Fatalf("got (%q, %v), want (%q, true)", name, ok, cardinalityProbeTestMetric)
+	}
+
+	noFilter := &chplan.RangeWindow{
+		Input: &chplan.Scan{Table: "otel_metrics_sum"}, Func: "rate", Range: time.Minute, Step: time.Minute,
+		OuterRange: time.Hour, Start: cardinalityProbeTestStart, End: cardinalityProbeTestEnd, TimestampColumn: "TimeUnix",
+		GroupBy: []chplan.Expr{&chplan.ColumnRef{Name: "Attributes"}},
+	}
+	if _, ok := cardinalityProbeMetricName(noFilter, cardinalityProbeMetricNameColumn); ok {
+		t.Fatal("expected ok=false with no Filter at all")
+	}
+}
+
+// TestBuildCardinalityProbePlan_EmitsExpectedShape pins the probe SQL's shape
+// end-to-end through the real chsql.Emit pipeline (invariant 10: only a
+// chplan tree reaches Emit, never a hand-written string).
+func TestBuildCardinalityProbePlan_EmitsExpectedShape(t *testing.T) {
+	t.Parallel()
+	rw := cardinalityProbeTestPlan().(*chplan.RangeWindow)
+	plan, ok := buildCardinalityProbePlan(rw)
+	if !ok {
+		t.Fatal("buildCardinalityProbePlan reported ok=false for a well-formed carrier")
+	}
+	sql, args, err := chsql.Emit(context.Background(), plan)
+	if err != nil {
+		t.Fatalf("chsql.Emit: %v", err)
+	}
+	// count() renders wrapped in toFloat64(...) (chsql's own
+	// intReturningAggregates guard) and uniqUpTo's cap renders as a bound
+	// `?` parameter, not an inline literal — see buildCardinalityProbePlan's
+	// own doc for why. cardinalityProbeUniqUpToCap must still reach CH as an
+	// arg.
+	for _, want := range []string{"toFloat64(count())", "uniqUpTo(?)", "otel_metrics_sum", "toDateTime64"} {
+		if !strings.Contains(sql, want) {
+			t.Errorf("emitted SQL missing %q:\n%s", want, sql)
+		}
+	}
+	foundCap := false
+	for _, a := range args {
+		if n, ok := a.(int64); ok && n == cardinalityProbeUniqUpToCap {
+			foundCap = true
+		}
+	}
+	if !foundCap {
+		t.Errorf("args %+v does not carry the uniqUpTo cap (%d) as a bound parameter", args, cardinalityProbeUniqUpToCap)
+	}
+}
+
+func TestBuildCardinalityProbePlan_ZeroStartOrEndFailsOpen(t *testing.T) {
+	t.Parallel()
+	rw := cardinalityProbeTestPlan().(*chplan.RangeWindow)
+	rw.Start = time.Time{}
+	if _, ok := buildCardinalityProbePlan(rw); ok {
+		t.Fatal("expected ok=false for a zero Start")
+	}
+}

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -985,6 +985,17 @@ type Engine struct {
 	// threads the result onto solver.RequestMeta.Estimate as an advisory
 	// input to the K clamp (internal/solver/planner.go).
 	ScanEstimateAdvisor *ScanEstimateAdvisor
+
+	// CardinalityProbeAdvisor is the OPTIONAL advisory bounded cardinality
+	// pre-probe (issue #2788, cardinality_probe_wiring.go). Nil unless wired
+	// from cmd/cerberus (buildCardinalityProbeAdvisor, gated on the chopt
+	// FeatureCardinalityProbe feature AND evalSolver.Cfg.Mode ==
+	// solver.ModeAuto), so the default path is byte-unchanged. When non-nil,
+	// classify runs it AFTER ScanEstimateAdvisor (if that is also wired) and
+	// folds its result on top — see cardinality_probe_wiring.go's own doc
+	// for why the two are kept as independent advisors sharing one merge
+	// point rather than one combined mechanism.
+	CardinalityProbeAdvisor *CardinalityProbeAdvisor
 }
 
 // SetSettings installs rules as the per-query settings the engine evaluates
@@ -1520,13 +1531,17 @@ func (e *Engine) QueryPlan(ctx context.Context, lang Lang, plan chplan.Node, met
 // is off OR the head is not PromQL — both cases make the engine omit the
 // shadow header and stay byte-identical to the pre-solver path.
 //
-// When e.ScanEstimateAdvisor is wired AND the deployment routes in
-// solver.ModeAuto, classify runs a first, no-estimate classification pass
-// (pure, no I/O — see the Advise call site's own comment on why redoing it
-// is free) purely to hand ScanEstimateAdvisor.Advise a baseline Decision and
-// let it decide, per explain_estimate_wiring.go's own doc, whether the
-// request is worth an advisory EXPLAIN ESTIMATE round trip. A nil
-// ScanEstimateAdvisor (the default) or a non-auto Mode skips this
+// When e.ScanEstimateAdvisor and/or e.CardinalityProbeAdvisor are wired AND
+// the deployment routes in solver.ModeAuto, classify runs a first,
+// no-estimate classification pass (pure, no I/O — see the Advise call
+// sites' own comments on why redoing it is free) purely to hand each
+// advisor a baseline Decision and let it decide, per its own doc, whether
+// the request is worth its advisory round trip. Both advisors are threaded
+// through the SAME rm.Estimate value — CardinalityProbeAdvisor.Advise folds
+// its own result on top of whatever ScanEstimateAdvisor.Advise already
+// produced (nil when that one is unwired or itself skipped) — so a shape
+// needing both signals gets one merged solver.ScanEstimate, never two
+// competing ones. Neither wired (the default) or a non-auto Mode skips this
 // entirely — the single Classify call below is byte-identical to the
 // pre-#2787 path.
 func (e *Engine) classify(ctx context.Context, plan chplan.Node, lang Lang) (*solver.Decision, bool) {
@@ -1540,17 +1555,22 @@ func (e *Engine) classify(ctx context.Context, plan chplan.Node, lang Lang) (*so
 		End:   end,
 		Step:  step,
 	}
-	if e.ScanEstimateAdvisor != nil && e.Solver.Cfg.Mode == solver.ModeAuto {
+	if (e.ScanEstimateAdvisor != nil || e.CardinalityProbeAdvisor != nil) && e.Solver.Cfg.Mode == solver.ModeAuto {
 		baseline, _ := e.Solver.Classify(plan, rm)
-		emit := func(ctx context.Context, lang Lang, plan chplan.Node) (string, []any, error) {
-			return emitForHead(
-				ctx, lang, plan,
-				e.DeltaPrefixLookback, e.DeltaPrefixReadEnabled,
-				e.resourceBoundOverrides(),
-				e.RangeBucketGridNativeMaxRows, e.RangeBucketGridNativeMaxDensityUnits,
-			)
+		if e.ScanEstimateAdvisor != nil {
+			emit := func(ctx context.Context, lang Lang, plan chplan.Node) (string, []any, error) {
+				return emitForHead(
+					ctx, lang, plan,
+					e.DeltaPrefixLookback, e.DeltaPrefixReadEnabled,
+					e.resourceBoundOverrides(),
+					e.RangeBucketGridNativeMaxRows, e.RangeBucketGridNativeMaxDensityUnits,
+				)
+			}
+			rm.Estimate = e.ScanEstimateAdvisor.Advise(ctx, e.RouteMemo, plan, lang, baseline, emit)
 		}
-		rm.Estimate = e.ScanEstimateAdvisor.Advise(ctx, e.RouteMemo, plan, lang, baseline, emit)
+		if e.CardinalityProbeAdvisor != nil {
+			rm.Estimate = e.CardinalityProbeAdvisor.Advise(ctx, e.RouteMemo, plan, baseline, rm.Estimate)
+		}
 	}
 	return e.Solver.Classify(plan, rm)
 }

--- a/internal/solver/decision.go
+++ b/internal/solver/decision.go
@@ -33,15 +33,17 @@ type RequestMeta struct {
 	// time-slice routed.
 	Step time.Duration
 
-	// Estimate is the OPTIONAL advisory EXPLAIN ESTIMATE read-out for this
-	// plan's inner scan (issue #2787), or nil when no estimate was fetched —
-	// the overwhelmingly common case: internal/engine's
-	// explain_estimate_wiring.go only probes a ModeAuto-eligible candidate,
-	// caches the result per plan shape, and skips the round trip entirely
-	// once the route memo or the per-rung admission learner already holds a
-	// verdict for that shape. A nil Estimate leaves classify's K derivation
-	// byte-identical to the pre-#2787 pure-geometry formula — see
-	// planner.go's own doc on where and how a non-nil Estimate is consulted.
+	// Estimate is the OPTIONAL advisory scan read-out for this plan's inner
+	// scan, or nil when no estimate was fetched — the overwhelmingly common
+	// case: internal/engine's explain_estimate_wiring.go and
+	// cardinality_probe_wiring.go each only probe a ModeAuto-eligible
+	// candidate, cache the result per plan shape (the cardinality probe keyed
+	// additionally on metric — see that file's own doc), and skip their round
+	// trip entirely once the route memo or the per-rung admission learner
+	// already holds a verdict for that shape. A nil Estimate leaves
+	// classify's K derivation byte-identical to the pre-#2787 pure-geometry
+	// formula — see planner.go's own doc on where and how a non-nil Estimate
+	// is consulted.
 	//
 	// Keeping Planner pure (its own doc: "no per-request mutable state, no
 	// RNG... a pure function of (plan, meta, Cfg)") is exactly why this rides
@@ -51,22 +53,47 @@ type RequestMeta struct {
 	Estimate *ScanEstimate
 }
 
-// ScanEstimate is the package-local advisory read-out of a ClickHouse
-// EXPLAIN ESTIMATE probe (internal/chclient.ScanEstimate is the transport
-// counterpart internal/engine converts from — see RequestMeta.Estimate's own
-// doc for why solver does not import chclient's type directly, mirroring
-// this whole struct's "package-local stand-in for engine.Meta" convention).
-//
-// Every field is a GRANULE-RESOLUTION UPPER BOUND (marks times the table's
-// granule size, typically 8192), not selectivity-aware — never a count of
-// rows that actually match the query's predicates. classify() therefore
-// consumes it only as a bias input to the K clamp, never as a threshold a
-// plan must clear to be eligible at all: every structural/correctness gate
-// above runs unconditionally, with or without an Estimate.
+// ScanEstimate is the package-local advisory read-out of a ClickHouse scan
+// probe — EXPLAIN ESTIMATE (issue #2787, internal/chclient.ScanEstimate) or
+// the bounded cardinality pre-probe (issue #2788,
+// internal/chclient.CardinalityEstimate) — the transport counterparts
+// internal/engine converts from (see RequestMeta.Estimate's own doc for why
+// solver does not import chclient's types directly, mirroring this whole
+// struct's "package-local stand-in for engine.Meta" convention). classify()
+// consumes every field only as a bias input to the K clamp, never as a
+// threshold a plan must clear to be eligible at all: every structural/
+// correctness gate above runs unconditionally, with or without an Estimate.
 type ScanEstimate struct {
+	// Parts / Marks are EXPLAIN ESTIMATE-only: the number of parts / granules
+	// the index analysis selected. Left zero when only the cardinality
+	// pre-probe populated this Estimate — classify() never reads either
+	// field, so a zero here changes no routing outcome; they exist for
+	// telemetry/corpus readers.
 	Parts uint64
-	Rows  uint64
 	Marks uint64
+
+	// Rows is a row-count bias input to the K clamp (planner.go's own doc).
+	// EXPLAIN ESTIMATE populates it as a GRANULE-RESOLUTION UPPER BOUND
+	// (selected marks times the table's granule size, typically 8192), never
+	// selectivity-aware. The cardinality pre-probe populates it with a REAL
+	// count() over the plan's already-pruned scan window instead — strictly
+	// more precise for the same K-clamp arithmetic — and internal/engine's
+	// cardinality_probe_wiring.go prefers that real count whenever both
+	// probes ran for the same request (see its own mergeCardinalityEstimate
+	// doc).
+	Rows uint64
+
+	// DistinctSeries is the cardinality pre-probe's uniqUpTo(100)(...)
+	// read-out (issue #2788) — the number of distinct series backing the
+	// scan window, up to the uniqUpTo(100) cap (see chplan.FnUniqUpTo's own
+	// doc for the saturation behaviour above it). Zero when the cardinality
+	// pre-probe did not run (EXPLAIN ESTIMATE alone never populates this
+	// field — it has no comparable per-series signal). classify() does not
+	// read this field at all: it exists solely for
+	// internal/engine/cardinality_probe_wiring.go's own per-rung admission
+	// seeding, which needs the fan-out signal EXPLAIN ESTIMATE's row-only
+	// upper bound cannot provide.
+	DistinctSeries uint64
 }
 
 // Decision is the routing output. Slices are ordered oldest-first

--- a/test/spec/chplan_print.go
+++ b/test/spec/chplan_print.go
@@ -982,6 +982,7 @@ var fnGoNames = map[chplan.Fn]string{
 	chplan.FnSumForEach:                      "FnSumForEach",
 	chplan.FnSumMap:                          "FnSumMap",
 	chplan.FnUniqExact:                       "FnUniqExact",
+	chplan.FnUniqUpTo:                        "FnUniqUpTo",
 	chplan.FnVarPop:                          "FnVarPop",
 }
 


### PR DESCRIPTION
## Summary

Closes #2788.

Complements the just-merged EXPLAIN ESTIMATE advisory pre-flight (#2787, PR
#2836) with a SECOND, independent advisory input the marks-level estimate
cannot answer: a bounded, REAL aggregate — `count()`, `uniqUpTo(100)(...)` —
over a ModeAuto `RangeWindow` candidate's already-pruned scan window,
answering the distinct-series fan-out question EXPLAIN ESTIMATE's
granule-resolution upper bound has no comparable signal for.

- `internal/chplan`: `FnUniqUpTo` constant + `chsql` resolution (the closed
  aggregate vocabulary both packages already enforce for every other
  function).
- `internal/chclient`: `CardinalityEstimate` + `Client.ProbeCardinality`,
  mirroring `ExplainEstimate`'s own transport shape and breaker/span
  posture.
- `internal/solver`: `ScanEstimate` gains `DistinctSeries`; `Rows` is now
  either producer's read-out — the cardinality probe's REAL `count()`
  supersedes EXPLAIN ESTIMATE's granule upper bound whenever both ran for
  the same request (strictly more precise for the SAME K-clamp arithmetic).
  **No new `Config` knob, no new `Reason` token** — `classify()`'s existing
  `Rows`-based near-empty skip / `MaxKWithEstimate` raise is fed unchanged.
- `internal/engine`: `CardinalityProbeAdvisor` gates the round trip
  (ModeAuto + reached the cost-grid section; per-`(shape, metric)` cache;
  skipped once the route memo or per-rung admission already holds a
  verdict — **reusing** `explain_estimate_wiring.go`'s own
  `reachedCostGrid` / `shapeKey` / `hasExistingVerdict` helpers rather than
  re-deriving them), builds the probe's `chplan` tree from the
  `RangeWindow` carrier's own `Input` plus the EXACT `(Start-Offset-Range,
  End-Offset]` bound `chsql`'s real matrix emission already pushes down for
  that same carrier, and seeds `PerRungAdmissionLearner` one-directionally
  on a low distinct-series reading — the SAME `cheap=true`-only contract
  `explain_estimate_wiring.go`'s own seeding uses, comparing against the
  SAME `perRungCheapRowsPerAnchor` threshold real drains already use. The
  route memo is deliberately **NOT** seeded, for the identical reason
  `docs/solver.md`'s existing "Why the failure-driven route memo is NOT
  seeded" section (written for #2787) already gives — a real bounded
  aggregate is still one non-drain observation, not the repeated
  real-traffic corroboration `minCorroboratingFailures` + the pressure
  damper exist to require.
- `internal/chopt`: `FeatureCardinalityProbe` (`AlwaysAvailable`,
  `AutoSelect=false`, opt-in via `CERBERUS_CH_OPTIMIZATIONS`) — same
  posture as `explain_estimate`.
- `docs/solver.md` / `docs/clickhouse-optimizations.md`: new "Bounded
  cardinality pre-probe (issue #2788)" section + regenerated feature table
  (`just gen-opt-docs`).

## Scope (deliberately narrow — filed #2840 for the rest)

- **Carrier kind**: only `*chplan.RangeWindow` (the "matrix" family — by far
  the most common ModeAuto shape, and the one #2709's own incident and this
  issue's own dashboard-panel example both concern). The other routable
  carrier kinds (`RangeLWR`, `RangeBucketFanout`, `RangeBucketGridNative`,
  `RangeWindowGridNative`) fail open — no probe, exactly as if the feature
  did not exist for that shape.
- **Metric identity**: fires only when the carrier's nearest `Filter` gates
  on exactly one literal `MetricName = '...'` equality. A regex `__name__`
  matcher or a multi-metric selector has no single metric to key the cache
  on and is skipped.
- **Payload**: only `count()` / `uniqUpTo(100)(...)`. The issue's own SQL
  sketch brackets a third, OPTIONAL `avg(length(ExplicitBounds))` term (a
  classic-histogram bucket-width bias signal) — omitted because neither of
  this PR's two consumers needs it.

All three are tracked in
[#2840](https://github.com/tsouza/cerberus/issues/2840) rather than folded
into this narrower landing.

## Not redundant with #2787 (checked, not assumed)

#2787's `EXPLAIN ESTIMATE` is a no-execution, granule-resolution UPPER BOUND
on scanned rows — it has no per-series signal at all. This probe is a REAL,
bounded execution answering a genuinely different question (distinct-series
fan-out), which is exactly why the two are wired as two independent
`*Engine` advisors sharing one merge point (`mergeCardinalityEstimate`)
rather than one combined mechanism or a redundant reimplementation.

## Measured (real data, not assumption)

Measured with `buildCardinalityProbePlan`'s own real `chplan` tree, executed
via chDB against `test/perf/smoke/testdata/samples/svc_http_requests_total.parquet`
(the same corpus #2787 used) and `kube_pod_status_reason.parquet` (the
set's highest-cardinality sample, up to ~4,800 series in a single window
per its own `README.md`):

| window | rows | distinct_series |
| --- | --- | --- |
| 1h over `svc_http_requests_total`'s densest real hour | 596,424 | 101 (saturated) |
| 6h spanning that hour | 895,858 | 101 (saturated) |
| 6h a year outside the sample's captured span (empty) | 0 | 0 |
| 1h over `kube_pod_status_reason`'s densest real hour | 567,360 | 101 (saturated) |

The 6h row count (895,858) lands **exactly** on EXPLAIN ESTIMATE's own
measurement of the identical window (#2787's PR table) — the two probes
independently scanning the same real data agree, cross-validating that this
probe's time bound is the same window the granule-upper-bound probe already
reasons about. Every dense real window in this corpus saturates
`uniqUpTo(100)` at 101 — confirming the issue's own verified constraint (a K
above 100 throws rather than under-counting) matters in practice at this
sample's real cardinality, not only in theory. `docs/solver.md`'s new
section has the full table and discussion.

## Test plan

- [x] `internal/engine/cardinality_probe_wiring_test.go` — pure unit tests
      (mocks/fakes, no live ClickHouse): cache-hit skip, structural
      ineligibility skip, route-memo/per-rung-admission-verdict skip,
      probe-failure fail-open, nil-advisor/nil-baseline no-ops, out-of-scope
      carrier-kind skip, ambiguous-metric-selector skip, merge-with-existing
      estimate, per-rung prior seeding (both directions), plus direct unit
      tests of `findCardinalityProbeCarrier` / `cardinalityProbeMetricName`
      / `buildCardinalityProbePlan` (including a real `chsql.Emit`
      end-to-end shape assertion).
- [x] chDB-backed measurement against real sample data (table above) —
      ad hoc, not committed as a new test file, mirroring how #2787's own
      PR validated its probe's SQL shape (no new chDB test file added
      either; only the pure Go unit tests were committed).
- [x] `go build ./...`, `go test -race ./internal/... ./cmd/...` — full
      repo, green.
- [x] `just vet-tagged` — clean.
- [x] `node .github/scripts/forbid-sql-raw.mjs` — clean (the probe's SQL is
      built entirely through typed `chplan` nodes + `chsql.Emit`, invariant
      10).
- [x] `go-arch-lint check` — clean.
- [x] `golangci-lint run` on every touched package — clean.
- [x] `just gen-opt-docs` — regenerated, no drift beyond the new feature
      row.
- [x] `markdownlint-cli2` on every touched doc — clean.
- [x] Filed [#2840](https://github.com/tsouza/cerberus/issues/2840) for the
      three scoped-down extensions before opening this PR (`forbid-deferral`
      has nothing to catch — no deferral marker phrase is used — but the
      issue is filed anyway per this repo's own culture).
