### PR TITLE
feat(schema,chsql,chopt): adopt GA text index for LogQL Body line filters

### DIFF
--- a/cmd/cerberus/cmd_migrate.go
+++ b/cmd/cerberus/cmd_migrate.go
@@ -219,6 +219,12 @@ func newMigrateSchemaCmd() *cobra.Command {
 			// #2767) — also AutoSelect=false, so the same explicit-listing-only
 			// reasoning applies.
 			cfg.SchemaTraceIDProjection = chopt.ExplicitlyRequested(cfg.CHOptimizations, chopt.FeatureTraceIDProjection)
+			// Same best-effort preview for full_text_index (cerberus issue
+			// #2773) — also AutoSelect=false, so the same explicit-listing-only
+			// reasoning applies. text_index_line_filter has no preview here:
+			// it gates a query-time chsql rewrite, not any DDL statement this
+			// tool renders.
+			cfg.SchemaFullTextIndex = chopt.ExplicitlyRequested(cfg.CHOptimizations, chopt.FeatureFullTextIndex)
 			return writeSchema(cmd.OutOrStdout(), cfg)
 		},
 	}

--- a/cmd/cerberus/main.go
+++ b/cmd/cerberus/main.go
@@ -1199,6 +1199,17 @@ func newLokiHandler(client *chclient.Client, cfg config.Config, optSet chopt.Ena
 	h.Limiter = limiters.loki
 	h.TailLimiter = limiters.lokiTail
 	h.Version = Version
+	// text_index_line_filter (cerberus issue #2773) gates the LogQL
+	// line-filter emitter's ANDed LIKE prefilter rewrite — read straight off
+	// optSet, the SAME EnabledSet settingsRules below reads join_spill and
+	// trace_id_bitmap_filter from, since this is a query-time rewrite, not
+	// a DDL statement (see SchemaFullTextIndex's back-fill above for its
+	// DDL sibling, full_text_index). h.Lang is the long-lived metadata-path
+	// adapter; h.TextIndexLineFilter is copied onto the fresh *logql.Lang
+	// langForRequest/langForRangeRequest build per /query and /query_range
+	// request.
+	h.TextIndexLineFilter = optSet.Has(chopt.FeatureTextIndexLineFilter)
+	h.Lang.TextIndexLineFilter = h.TextIndexLineFilter
 	h.QueryTimeout = cfg.ClickHouse.QueryTimeout
 	h.TailWriteTimeout = cfg.LokiTailWriteTimeout
 	h.Engine.Settings = settingsRules(cfg, optSet)
@@ -1476,6 +1487,15 @@ func resolveCHOptimizations(ctx context.Context, logger *slog.Logger, client *ch
 	// the map_bucketed_serialization comment above for why this runs here
 	// rather than being threaded as an EnabledSet parameter.
 	cfg.SchemaTraceIDProjection = set.Has(chopt.FeatureTraceIDProjection)
+
+	// Same back-fill for full_text_index (cerberus issue #2773) — see
+	// the map_bucketed_serialization comment above for why this runs here
+	// rather than being threaded as an EnabledSet parameter. Its sibling
+	// query-time feature, text_index_line_filter, gates a loki-handler
+	// rewrite rather than any DDL statement, so — like join_spill and
+	// trace_id_bitmap_filter — it is read straight off the EnabledSet at
+	// newLokiHandler's construction site instead of being back-filled here.
+	cfg.SchemaFullTextIndex = set.Has(chopt.FeatureFullTextIndex)
 
 	// Install the client-side columnar matrix decode when the resolved set
 	// enables it. columnar_result_decode is a chopt feature (opt-in, never

--- a/docs/clickhouse-optimizations.md
+++ b/docs/clickhouse-optimizations.md
@@ -151,6 +151,8 @@ table.
 | `lazy_materialization`           | 25.11      | experimental | yes        |
 | `explain_estimate`               | none       | experimental | no         |
 | `cardinality_probe`              | none       | experimental | no         |
+| `full_text_index`                | 26.2       | experimental | no         |
+| `text_index_line_filter`         | 26.4       | experimental | no         |
 <!-- END GENERATED: chopt-feature-table -->
 
 The rich, hand-authored columns below stay OUTSIDE the generated block: they

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -1499,6 +1499,134 @@ the recoded column — budget accordingly on a large table, and prefer letting
 normal background merges converge new codecs onto old parts over time rather
 than forcing an immediate rewrite unless the storage win is needed sooner.
 
+### Text index on logs Body + LogQL line-filter prefilter (cerberus issue #2773)
+
+The logs table's `idx_lower_body` skip index over `lower(Body)` shipped as a
+`tokenbf_v1(32768, 3, 0)` bloom filter — but cerberus's LogQL line filters
+(`|=` / `!=` / `|~` / `!~`) emit `position(Body, ?) > 0` / `match(Body, ?)`
+against the case-sensitive `Body` column directly, a predicate shape
+`tokenbf_v1` never matches. The most expensive LogQL predicate class (a
+substring or regex filter over the log line itself) has always full-scanned
+Body, even on a deployment that already pays to maintain `idx_lower_body`.
+
+Two independent, opt-in `CERBERUS_CH_OPTIMIZATIONS` features fix this:
+
+#### The `full_text_index` DDL feature (server >= 26.2)
+
+`enable_full_text_index` — the setting gating ClickHouse's own acceptance of
+`TYPE text(...)` — flips from default-OFF to default-ON at ClickHouse 26.2
+(confirmed live: `SELECT value FROM system.settings WHERE name =
+'enable_full_text_index'` reports `0` on a 26.1.12 server and `1` on 26.2.19),
+the GA floor this feature gates on. Enabled, a **freshly created** logs table
+gets `idx_lower_body` as `TYPE text(tokenizer = 'splitByNonAlpha')` instead of
+`tokenbf_v1` — the upstream OTel-CH exporter template's own
+`HasFullTextSearch` branch already carries this shape; the feature only
+decides which branch a boot renders. An **existing** table (already carrying
+the tokenbf branch from an earlier boot) instead gets an ADDITIVE,
+separately-named index:
+
+```sql
+ALTER TABLE <db>.otel_logs ADD INDEX IF NOT EXISTS idx_body_text lower(Body) TYPE text(tokenizer = 'splitByNonAlpha') GRANULARITY 100000000
+```
+
+A second name, not an in-place type swap of `idx_lower_body`: ClickHouse
+matches `ADD INDEX IF NOT EXISTS` on NAME, not type, so re-running it against
+a table that already carries `idx_lower_body` as `tokenbf_v1` is a silent
+no-op — it could never install the text index on an upgraded deployment.
+Swapping the type in place needs `DROP INDEX` + `ADD INDEX`, which is
+destructive (existing `MATERIALIZE`'d granules are discarded, forcing a full
+re-backfill) and, since this render-time DDL layer has no live
+`system.data_skipping_indexes` read, cannot tell whether `idx_lower_body` is
+ALREADY the text type — repeating that drop+add on every boot would be
+pure, repeated, backfill-losing churn. Installing a second, non-colliding
+name is the only additive, idempotent, crash-safe option available here, the
+same reasoning `ADD PROJECTION` / `ADD STATISTICS` / `ADD INDEX` above all
+already follow. `GRANULARITY 100000000` reproduces ClickHouse's OWN implicit
+default for a `text` index type when no `GRANULARITY` clause is given
+(confirmed live via `EXPLAIN indexes=1`, and re-confirmed byte-identical when
+stamped explicitly) — `chsql.AlterTableAddIndex` has no omit-GRANULARITY
+mode, so this reproduces the default rather than widening that builder's
+contract for one index type.
+
+**Retiring the now-redundant legacy `idx_lower_body` tokenbf index on an
+upgraded existing table is explicitly out of scope of this feature** —
+dropping an index a running deployment's queries may still be planning
+against is a real production-cluster risk this render-time DDL apply should
+not take unilaterally. Tracked as a follow-up issue.
+
+##### One-time `MATERIALIZE INDEX` back-fill runbook
+
+`ADD INDEX` is metadata-only for NEW parts; existing parts need the one-time
+materialize to benefit retroactively:
+
+```sql
+ALTER TABLE <db>.otel_logs MATERIALIZE INDEX idx_body_text;
+```
+
+(On a freshly created table the index is `idx_lower_body` itself, already
+the text type — no separate materialize needed for those parts.) Track
+progress in `system.mutations`, same as every other index/projection/
+statistics runbook above.
+
+#### The `text_index_line_filter` query-time feature (server >= 26.4)
+
+Independently of the DDL feature's own version floor,
+`CERBERUS_CH_OPTIMIZATIONS` also carries `text_index_line_filter`, gating a
+chsql emission rewrite, not any DDL statement. On a server `>= 26.4` — the
+release introducing `use_text_index_like_evaluation_by_dictionary_scan`
+(confirmed live: 0 rows from `SELECT name FROM system.settings WHERE name
+ILIKE '%text_index_like%'` on a 26.2.19 server, 3 rows on 26.4.5) — a text
+index can answer a `LIKE '%needle%'` predicate by dictionary scan instead of
+a row-by-row match. cerberus's LogQL line-filter emitter uses this by
+prepending an ANDed per-token strict-superset prefilter ahead of the
+UNCHANGED row predicate:
+
+```sql
+-- |= "connection reset by peer" becomes:
+(lower(Body) LIKE '%connection%' AND lower(Body) LIKE '%reset%' AND lower(Body) LIKE '%peer%'
+ AND (position(Body, 'connection reset by peer') > 0))
+```
+
+Each conjunct is a necessary (never sufficient) condition for the original
+literal to be a substring of `Body` — a strict superset the granule-pruning
+index can use to eliminate ranges the row predicate would have rejected
+anyway, never one that admits a false positive past the always-kept row
+predicate. `by` is dropped (below the 4-rune minimum useful token length —
+see `internal/chsql`'s `textIndexLikeMinTokenLength`), and every token is
+lowered ASCII-only (matching ClickHouse's own `lower()`, not the Unicode-aware
+`lowerUTF8()` idx_lower_body does NOT use) and LIKE-escaped (`\`, `%`, `_`)
+before embedding.
+
+**Scope boundary — negated and regex filters:**
+
+- `!=` / `!~` (negated) are passed through byte-identical: a superset
+  prefilter has no sound dual for a "must NOT contain" predicate.
+- `|~` (regex, non-negated) is rewritten ONLY when the pattern round-trips
+  through Go's `regexp/syntax` (RE2 — the same engine ClickHouse's `match()`
+  runs) as a single `OpLiteral` — a regex only in name, with no
+  metacharacters. Any other regex shape (alternation, anchors, character
+  classes, quantifiers) renders byte-identical to today; this package does
+  not compile partial RE2 semantics into index predicates.
+
+**Independent of `full_text_index`, but inert without it**: the floors are
+strictly ordered (26.4 > 26.2), so a server can satisfy one without the
+other, and the rewrite is a harmless (if pointless) no-op on any table that
+carries no text index at all — every LIKE conjunct just evaluates against
+the same undexed `lower(Body)` scan the row predicate already pays for.
+
+**Unverified ClickHouse 26.6 claims — do not build on these without
+re-verifying against a real 26.6+ instance.** `multiSearchAny` inside the
+skip-index analyzer and a dedicated posting-list segment cache were both
+raised as possible 26.6 extras. Live-probed against a real ClickHouse
+26.6.3.62 server: `multiSearchAny(Body, [...])` produced NO skip-index entry
+in `EXPLAIN indexes=1` at all (full granule scan, unlike `hasAnyTokens` /
+`hasAllTokens` / `hasToken`, which all pruned correctly) — this claim did
+NOT hold on the probed build. `use_text_index_postings_cache` DOES exist as
+a real setting on 26.6.3.62, defaulting to `0` (off) — its existence is
+confirmed, but no benchmark evidence was gathered on its actual effect.
+Neither claim is relied on by `text_index_line_filter`. See the follow-up
+issue this PR files for someone with continued 26.6+ access to settle these.
+
 ### DELTA-prefix aggregate table + backfill (cerberus issue #2389)
 
 Auto-create can also provision an **opt-in, cerberus-owned** table + materialized

--- a/internal/api/loki/handler.go
+++ b/internal/api/loki/handler.go
@@ -122,6 +122,16 @@ type Handler struct {
 	// Handler keep the historical 10s bound.
 	TailWriteTimeout time.Duration
 
+	// TextIndexLineFilter is chopt text_index_line_filter's resolved
+	// verdict (cerberus issue #2773), wired from cmd/cerberus's boot
+	// EnabledSet at construction (mirroring Limiter/QueryTimeout/Version
+	// above). langForRequest / langForRangeRequest copy it onto every
+	// per-request *logql.Lang; New's own long-lived h.Lang picks it up the
+	// same way a caller sets any other post-construction field. false (the
+	// default — every bare Handler{} test fixture) keeps the LogQL emitter
+	// byte-identical to today.
+	TextIndexLineFilter bool
+
 	// onQueryRangeDrain, when non-nil, is invoked once per
 	// /loki/api/v1/query_range request with the number of rows
 	// h.Engine.Query pulled from ClickHouse (res.Inspected) — the
@@ -447,7 +457,7 @@ func (h *Handler) handleQueryRange(w http.ResponseWriter, r *http.Request) {
 // regardless of the requested window, violating the wire-format
 // contract.
 func (h *Handler) langForRequest(start, end time.Time) *logql.Lang {
-	return &logql.Lang{Schema: h.Schema, Start: start, End: end}
+	return &logql.Lang{Schema: h.Schema, Start: start, End: end, TextIndexLineFilter: h.TextIndexLineFilter}
 }
 
 // langForRangeRequest builds a per-request *logql.Lang carrying the
@@ -461,7 +471,7 @@ func (h *Handler) langForRequest(start, end time.Time) *logql.Lang {
 // since lowerCtx.rangeMode() only fires inside the range-aggregation
 // lowering.
 func (h *Handler) langForRangeRequest(start, end time.Time, step time.Duration) *logql.Lang {
-	return &logql.Lang{Schema: h.Schema, Start: start, End: end, Step: step}
+	return &logql.Lang{Schema: h.Schema, Start: start, End: end, Step: step, TextIndexLineFilter: h.TextIndexLineFilter}
 }
 
 // classifyEngineErr maps the error chains engine.Engine returns onto

--- a/internal/chopt/registry.go
+++ b/internal/chopt/registry.go
@@ -1636,14 +1636,14 @@ var registry = []Feature{
 		MinVersion: Version{Major: 26, Minor: 2},
 		Stability:  Experimental,
 		AutoSelect: false,
-		Doc:        "swap the logs table's idx_lower_body skip index from tokenbf_v1 to TYPE text(tokenizer='splitByNonAlpha') on CREATE, plus an additive idx_body_text ADD INDEX on existing tables (server >= 26.2 — verified GA floor, opt-in via CERBERUS_CH_OPTIMIZATIONS — backfill/maintenance cost unmeasured at production volume)",
+		Doc:        "swap idx_lower_body from tokenbf_v1 to TYPE text on CREATE, plus an additive idx_body_text on existing tables (server >= 26.2 — verified GA floor, opt-in via CERBERUS_CH_OPTIMIZATIONS — backfill/maintenance cost unmeasured at production volume)",
 	},
 	{
 		ID:         FeatureTextIndexLineFilter,
 		MinVersion: Version{Major: 26, Minor: 4},
 		Stability:  Experimental,
 		AutoSelect: false,
-		Doc:        "prepend an ANDed per-token lower(Body) LIKE '%tok%' strict-superset prefilter ahead of the unchanged position()/match() row predicate for non-negated LogQL line filters (server >= 26.4 — verified LIKE-via-text-index floor, opt-in via CERBERUS_CH_OPTIMIZATIONS, independent of full_text_index but inert without it)",
+		Doc:        "prepend an ANDed per-token LIKE strict-superset prefilter ahead of the unchanged row predicate for non-negated LogQL line filters (server >= 26.4 — verified LIKE-via-text-index floor, opt-in via CERBERUS_CH_OPTIMIZATIONS, inert without full_text_index)",
 	},
 }
 

--- a/internal/chopt/registry.go
+++ b/internal/chopt/registry.go
@@ -1229,6 +1229,82 @@ const (
 	// analyzer is GA on every server this feature's 25.11 floor reaches (well
 	// past condition_cache's own 25.3 GA baseline).
 	FeatureLazyMaterialization = "lazy_materialization"
+
+	// FeatureFullTextIndex flips internal/schema/ddl.Config.TextIndexEnabled,
+	// which swaps the `idx_lower_body` skip index on the logs table's CREATE
+	// branch from `tokenbf_v1(32768, 3, 0)` to `TYPE text(tokenizer =
+	// 'splitByNonAlpha')` — the SAME index name, over the SAME `lower(Body)`
+	// expression, in the SAME upstream-template mutually-exclusive branch
+	// HasFullTextSearch already selects (cerberus issue #2773). On an
+	// EXISTING table (which already carries the tokenbf branch from an
+	// earlier boot), the DDL apply path additionally installs a
+	// SEPARATELY-named `idx_body_text` text index via idempotent `ADD INDEX
+	// IF NOT EXISTS` — see renderAddBodyTextIndex's doc comment for why a
+	// second name, not an in-place type swap, is the only additive
+	// (crash-safe, no MATERIALIZE-losing DROP) upgrade path available to a
+	// render-time-only DDL layer with no live system.data_skipping_indexes
+	// read.
+	//
+	// VERSION FLOOR: 26.2 — the release the `enable_full_text_index` setting
+	// (gating table-level acceptance of `TYPE text(...)`) flips from
+	// default-OFF (26.1: DB::Exception SUPPORT_IS_DISABLED unless a caller
+	// stamps the setting itself) to default-ON, i.e. the text index's actual
+	// GA floor, not merely its earliest experimental availability. Verified
+	// directly against a probed 26.1.12 vs 26.2.19 pair (`SELECT value,
+	// changed FROM system.settings WHERE name = 'enable_full_text_index'`:
+	// 26.1 reports "0", 26.2 reports "1"), not assumed from the changelog
+	// prose.
+	//
+	// NOT auto-selected (AutoSelect=false), mirroring FeatureColumnStatistics
+	// and FeatureTraceIDProjection's posture on their own new floors: the
+	// MATERIALIZE INDEX backfill cost for existing parts and the steady-state
+	// index-maintenance cost on new parts (a second body index alongside the
+	// untouched legacy tokenbf one — see the doc comment above on why this
+	// PR does not retire it) are real but unmeasured at production data
+	// volumes beyond this PR's own synthetic benchmark — an operator opt-in
+	// via CERBERUS_CH_OPTIMIZATIONS=full_text_index until that evidence
+	// accumulates.
+	FeatureFullTextIndex = "full_text_index"
+
+	// FeatureTextIndexLineFilter opts internal/chsql's LogQL line-filter
+	// emitter (exprLineContent) onto an ANDed per-token `lower(Body) LIKE
+	// '%tok%'` prefilter ahead of the UNCHANGED, always-kept
+	// `position(Body, ?) > 0` / `match(Body, ?)` row predicate (cerberus
+	// issue #2773) — a STRICT-SUPERSET skip-index hint, never a replacement:
+	// every token substring of a literal that is itself a substring of Body
+	// is trivially also a substring of lower(Body) once both sides are
+	// lowered, so the prefilter can only prune granules the row predicate
+	// would have rejected anyway, never admit a false positive past the row
+	// filter. Scoped to non-negated filters only (`|=`, and `|~` when the
+	// pattern round-trips through regexp/syntax as a single OpLiteral, i.e.
+	// it is a regex only in name) — a superset prefilter has no sound
+	// dual for a NEGATED "must not contain" predicate, so `!=`/`!~` and
+	// structurally regex patterns are passed through byte-identical to
+	// today. See chplan.LineContent.TextIndexPrefilter's doc for the full
+	// eligibility shape.
+	//
+	// VERSION FLOOR: 26.4 — the release introducing
+	// use_text_index_like_evaluation_by_dictionary_scan (default-on),
+	// the setting family that lets a text index answer a LIKE '%needle%'
+	// predicate by dictionary scan instead of a row-by-row match. Verified
+	// directly: `SELECT name FROM system.settings WHERE name ILIKE
+	// '%text_index_like%'` returns 0 rows on a probed 26.2.19 server and 3
+	// rows (use_text_index_like_evaluation_by_dictionary_scan,
+	// text_index_like_min_pattern_length=4,
+	// text_index_like_max_postings_to_read=50) on 26.4.5. This feature's
+	// floor is thus STRICTLY ABOVE FeatureFullTextIndex's own 26.2 — a
+	// server can satisfy one without the other, and this feature is INERT
+	// (byte-identical SQL) on any table that carries no text index at all,
+	// so listing it without full_text_index is a harmless no-op, not a
+	// fatal combination.
+	//
+	// NOT auto-selected: depends on an independently opt-in DDL feature
+	// (full_text_index) actually having been applied and backfilled — auto-
+	// enabling the row-filter rewrite ahead of that leaves every emitted
+	// LIKE conjunct evaluating the SAME unindexed lower(Body) scan the row
+	// predicate already pays for, a pure (if small) per-row LIKE-evaluation
+	// tax with no pruning to offset it.
+	FeatureTextIndexLineFilter = "text_index_line_filter"
 )
 
 // AlwaysAvailable is the zero version floor for a feature that depends on no
@@ -1555,6 +1631,20 @@ var registry = []Feature{
 		AutoSelect: false,
 		Doc:        "advisory bounded count()/uniqUpTo(100) cardinality pre-probe complementing explain_estimate's marks-level estimate with real distinct-series fan-out (no version floor; opt-in via CERBERUS_CH_OPTIMIZATIONS; auto never picks it pending real-world calibration)",
 	},
+	{
+		ID:         FeatureFullTextIndex,
+		MinVersion: Version{Major: 26, Minor: 2},
+		Stability:  Experimental,
+		AutoSelect: false,
+		Doc:        "swap the logs table's idx_lower_body skip index from tokenbf_v1 to TYPE text(tokenizer='splitByNonAlpha') on CREATE, plus an additive idx_body_text ADD INDEX on existing tables (server >= 26.2 — verified GA floor, opt-in via CERBERUS_CH_OPTIMIZATIONS — backfill/maintenance cost unmeasured at production volume)",
+	},
+	{
+		ID:         FeatureTextIndexLineFilter,
+		MinVersion: Version{Major: 26, Minor: 4},
+		Stability:  Experimental,
+		AutoSelect: false,
+		Doc:        "prepend an ANDed per-token lower(Body) LIKE '%tok%' strict-superset prefilter ahead of the unchanged position()/match() row predicate for non-negated LogQL line filters (server >= 26.4 — verified LIKE-via-text-index floor, opt-in via CERBERUS_CH_OPTIMIZATIONS, independent of full_text_index but inert without it)",
+	},
 }
 
 // Registry returns a copy of the seeded feature registry
@@ -1566,10 +1656,10 @@ var registry = []Feature{
 // sorted_slab_over_time, map_bucketed_serialization, ts_grid_last_over_time,
 // column_statistics, classic_bucket_merge_summap, exp_histogram_merge_summap,
 // join_spill, trace_id_projection, trace_id_bitmap_filter, arg_and_max_fusion,
-// result_cache, lazy_materialization, explain_estimate, cardinality_probe).
-// The copy keeps the canonical entries immutable from the caller's side.
-// Exposed so tests can enumerate the gates and the docs generator can
-// render the table.
+// result_cache, lazy_materialization, explain_estimate, cardinality_probe,
+// full_text_index, text_index_line_filter). The copy keeps the canonical
+// entries immutable from the caller's side. Exposed so tests can enumerate
+// the gates and the docs generator can render the table.
 func Registry() []Feature {
 	out := make([]Feature, len(registry))
 	copy(out, registry)

--- a/internal/chopt/resolve_test.go
+++ b/internal/chopt/resolve_test.go
@@ -653,6 +653,8 @@ func TestRegistry_SeededEntries(t *testing.T) {
 		FeatureLazyMaterialization:          {ID: FeatureLazyMaterialization, MinVersion: v(25, 11), Stability: Experimental, AutoSelect: true, RequiresExperimentalTSGrid: false},
 		FeatureExplainEstimate:              {ID: FeatureExplainEstimate, MinVersion: AlwaysAvailable, Stability: Experimental, AutoSelect: false, RequiresExperimentalTSGrid: false},
 		FeatureCardinalityProbe:             {ID: FeatureCardinalityProbe, MinVersion: AlwaysAvailable, Stability: Experimental, AutoSelect: false, RequiresExperimentalTSGrid: false},
+		FeatureFullTextIndex:                {ID: FeatureFullTextIndex, MinVersion: v(26, 2), Stability: Experimental, AutoSelect: false, RequiresExperimentalTSGrid: false},
+		FeatureTextIndexLineFilter:          {ID: FeatureTextIndexLineFilter, MinVersion: v(26, 4), Stability: Experimental, AutoSelect: false, RequiresExperimentalTSGrid: false},
 	}
 	if len(reg) != len(want) {
 		t.Fatalf("registry has %d entries; want %d", len(reg), len(want))

--- a/internal/chplan/line_content.go
+++ b/internal/chplan/line_content.go
@@ -15,6 +15,25 @@ type LineContent struct {
 	Pattern string
 	IsRegex bool
 	Negated bool
+
+	// TextIndexPrefilter opts the emitter (internal/chsql's exprLineContent)
+	// onto an ANDed per-token `lower(<Source>) LIKE '%tok%'` strict-superset
+	// prefilter ahead of the UNCHANGED row predicate above — chopt
+	// text_index_line_filter's resolved verdict (cerberus issue #2773),
+	// threaded down from lowerCtx.TextIndexLineFilter.
+	//
+	// The lowerer sets this ONLY when Negated is false: a superset prefilter
+	// has no sound dual for a "must NOT contain" predicate (lower(Body) LIKE
+	// '%tok%' being false only proves the LITERAL is absent when combined
+	// with every other token — negating the prefilter itself would reject
+	// rows the row predicate would have kept). A true value is necessary but
+	// not sufficient for the emitter to actually rewrite: IsRegex=true
+	// additionally needs the Pattern to round-trip through regexp/syntax as
+	// a single OpLiteral (a regex only in name — no metacharacters) before
+	// the emitter treats it like a plain substring literal; any other regex
+	// shape, and a literal pattern with no token long enough to be worth
+	// prefiltering, both render byte-identical to TextIndexPrefilter=false.
+	TextIndexPrefilter bool
 }
 
 func (*LineContent) exprNode() {}
@@ -25,5 +44,6 @@ func (l *LineContent) Equal(other Expr) bool {
 		return false
 	}
 	return l.Pattern == o.Pattern && l.IsRegex == o.IsRegex &&
-		l.Negated == o.Negated && l.Source.Equal(o.Source)
+		l.Negated == o.Negated && l.TextIndexPrefilter == o.TextIndexPrefilter &&
+		l.Source.Equal(o.Source)
 }

--- a/internal/chsql/builder.go
+++ b/internal/chsql/builder.go
@@ -3,9 +3,11 @@ package chsql
 import (
 	"fmt"
 	"math"
+	"regexp/syntax"
 	"strconv"
 	"strings"
 	"time"
+	"unicode/utf8"
 
 	"github.com/tsouza/cerberus/internal/chplan"
 	"github.com/tsouza/cerberus/internal/schema"
@@ -1259,32 +1261,198 @@ func (b *Builder) exprLabelJoin(l *chplan.LabelJoin) error {
 	return nil
 }
 
-func (b *Builder) exprLineContent(l *chplan.LineContent) error {
-	if l.IsRegex {
-		if l.Negated {
-			b.sb.WriteString("NOT ")
+// textIndexLikeMinTokenLength is the minimum literal-word length (in
+// runes) exprLineContent will emit as a `lower(<Source>) LIKE '%tok%'`
+// prefilter conjunct (chopt text_index_line_filter, cerberus issue #2773).
+// Mirrors ClickHouse's own text_index_like_min_pattern_length default —
+// confirmed via `SELECT value FROM system.settings WHERE name =
+// 'text_index_like_min_pattern_length'` against a live 26.4+ server, which
+// reports 4. A word shorter than this is still logically implied by the
+// row predicate if emitted (the superset guarantee doesn't depend on
+// length), but the server's own LIKE-via-text-index dictionary scan can't
+// use it for pruning, so dropping it keeps the WHERE clause from growing
+// with conjuncts that add per-row evaluation cost with no offsetting
+// benefit.
+const textIndexLikeMinTokenLength = 4
+
+// asciiLower lowercases only ASCII 'A'-'Z' bytes, leaving every other byte
+// — including any UTF-8 continuation byte of a non-ASCII rune — untouched.
+// This matches ClickHouse's `lower()` function EXACTLY: `lower()` is
+// ASCII-only (confirmed live: `lower('CAFÉ')` → `cafÉ`, the trailing 'É'
+// unchanged); `lowerUTF8()` is the separate, Unicode-aware function CH
+// offers, and idx_lower_body's DDL expression uses plain `lower(Body)`, not
+// lowerUTF8. Go's Unicode-aware strings.ToLower would silently diverge from
+// what `lower(Body)` actually contains for any non-ASCII letter, breaking
+// the LIKE prefilter's strict-superset guarantee: a needle lowered
+// differently than the column it is matched against can mismatch a row the
+// exact row predicate DOES match, and the surrounding AND would then wrongly
+// drop it.
+func asciiLower(s string) string {
+	b := []byte(s)
+	for i, c := range b {
+		if c >= 'A' && c <= 'Z' {
+			b[i] = c + ('a' - 'A')
 		}
-		b.sb.WriteString("match(")
+	}
+	return string(b)
+}
+
+// escapeLikeLiteral escapes s for embedding inside a ClickHouse LIKE
+// pattern's literal portion: backslash (CH's LIKE escape character) and the
+// two LIKE metacharacters, `%` and `_`. All three replacements run in ONE
+// strings.Replacer pass over the ORIGINAL bytes of s, so a backslash
+// introduced by escaping a `%` or `_` is never itself re-escaped — the
+// double-escaping bug a naive sequential ReplaceAll chain would have.
+// Needed for real log content: an unescaped `_` in a word like "user_id" is
+// read by LIKE as the any-single-char wildcard rather than a literal
+// underscore, and an unescaped `%` in "92% done" is read as the any-
+// sequence wildcard — both would silently widen a conjunct's match set
+// beyond the true substring it is meant to test for.
+var likeEscaper = strings.NewReplacer(`\`, `\\`, `%`, `\%`, `_`, `\_`)
+
+func escapeLikeLiteral(s string) string {
+	return likeEscaper.Replace(s)
+}
+
+// textIndexLikeTokens splits literal into the whitespace-delimited words
+// exprLineContent's ANDed LIKE prefilter checks (cerberus issue #2773) —
+// "for multi-word |= literals, emit ANDed per-token LIKE conjuncts" in the
+// issue's own words, where a multi-word literal's "tokens" are its words.
+// A word shorter than textIndexLikeMinTokenLength is dropped (see that
+// constant's doc). A literal with no qualifying word returns nil, telling
+// the caller to skip the prefilter and fall back to the exact predicate
+// alone.
+func textIndexLikeTokens(literal string) []string {
+	fields := strings.Fields(literal)
+	tokens := make([]string, 0, len(fields))
+	for _, f := range fields {
+		if utf8.RuneCountInString(f) >= textIndexLikeMinTokenLength {
+			tokens = append(tokens, f)
+		}
+	}
+	return tokens
+}
+
+// textIndexRegexLiteral reports whether pattern is safely extractable as a
+// plain substring literal for the ANDed LIKE prefilter (cerberus issue
+// #2773): pattern is parsed with regexp/syntax under RE2 semantics — the
+// same engine ClickHouse's match() runs, per internal/logql/lower.go's own
+// regexpMergeLabels precedent — and simplified. Only when the result is a
+// SINGLE OpLiteral (no anchors, alternation, character classes,
+// quantifiers, or any other RE2 construct survives Simplify) is "matches
+// this regex" provably equivalent to "contains this substring" for CH's
+// unanchored match() search — the equivalence the LIKE prefilter's
+// strict-superset argument depends on. Any other pattern shape returns
+// ok=false and the caller falls back to match()-only, the boundary the
+// issue itself calls for: partial literal-prefix/substring extraction from
+// an arbitrary RE2 AST (alternation branches, anchors, repetition) is
+// deliberately NOT attempted — this package does not compile RE2 semantics
+// into index predicates, only recognizes the special case where a "regex"
+// carries none.
+func textIndexRegexLiteral(pattern string) (string, bool) {
+	re, err := syntax.Parse(pattern, syntax.Perl)
+	if err != nil {
+		return "", false
+	}
+	re = re.Simplify()
+	if re.Op != syntax.OpLiteral {
+		return "", false
+	}
+	return string(re.Rune), true
+}
+
+// textIndexPrefilterArgs returns the fully-escaped `%tok%` LIKE needles
+// exprLineContent should AND together ahead of l's row predicate, or nil
+// when no prefilter applies:
+//
+//   - l.TextIndexPrefilter is false (chopt text_index_line_filter is
+//     disabled, or the lowerer never set it) — the whole rewrite is
+//     inert, matching the plain predicate byte-for-byte.
+//   - l.Negated is true — a superset prefilter has no sound dual for a
+//     "must not contain" predicate; see LineContent.TextIndexPrefilter's
+//     doc comment.
+//   - l.IsRegex is true and the Pattern is not a plain literal in
+//     disguise (textIndexRegexLiteral).
+//   - the extracted literal has no word long enough to be worth
+//     prefiltering (textIndexLikeTokens).
+func textIndexPrefilterArgs(l *chplan.LineContent) []string {
+	if !l.TextIndexPrefilter || l.Negated {
+		return nil
+	}
+	literal := l.Pattern
+	if l.IsRegex {
+		lit, ok := textIndexRegexLiteral(l.Pattern)
+		if !ok {
+			return nil
+		}
+		literal = lit
+	}
+	words := textIndexLikeTokens(literal)
+	if len(words) == 0 {
+		return nil
+	}
+	args := make([]string, len(words))
+	for i, w := range words {
+		args[i] = "%" + escapeLikeLiteral(asciiLower(w)) + "%"
+	}
+	return args
+}
+
+func (b *Builder) exprLineContent(l *chplan.LineContent) error {
+	renderRow := func() error {
+		if l.IsRegex {
+			if l.Negated {
+				b.sb.WriteString("NOT ")
+			}
+			b.sb.WriteString("match(")
+			if err := b.Expr(l.Source); err != nil {
+				return err
+			}
+			b.sb.WriteString(", ")
+			b.Arg(l.Pattern)
+			b.sb.WriteByte(')')
+			return nil
+		}
+		op := " > 0"
+		if l.Negated {
+			op = " = 0"
+		}
+		b.sb.WriteString("(position(")
 		if err := b.Expr(l.Source); err != nil {
 			return err
 		}
 		b.sb.WriteString(", ")
 		b.Arg(l.Pattern)
 		b.sb.WriteByte(')')
+		b.sb.WriteString(op)
+		b.sb.WriteByte(')')
 		return nil
 	}
-	op := " > 0"
-	if l.Negated {
-		op = " = 0"
+
+	prefilterArgs := textIndexPrefilterArgs(l)
+	if len(prefilterArgs) == 0 {
+		return renderRow()
 	}
-	b.sb.WriteString("(position(")
-	if err := b.Expr(l.Source); err != nil {
+
+	// Strict-superset prefilter (cerberus issue #2773): each conjunct below
+	// can only ELIMINATE granules/rows the row predicate rendered by
+	// renderRow() would also have rejected — see
+	// LineContent.TextIndexPrefilter's doc comment — so ANDing them ahead of
+	// the unchanged row predicate never changes the result set, only how
+	// much of Body ClickHouse has to decompress and scan to compute it.
+	b.sb.WriteByte('(')
+	for _, arg := range prefilterArgs {
+		b.sb.WriteString("lower(")
+		if err := b.Expr(l.Source); err != nil {
+			return err
+		}
+		b.sb.WriteString(") LIKE ")
+		b.Arg(arg)
+		b.sb.WriteString(" AND ")
+	}
+	if err := renderRow(); err != nil {
 		return err
 	}
-	b.sb.WriteString(", ")
-	b.Arg(l.Pattern)
-	b.sb.WriteByte(')')
-	b.sb.WriteString(op)
 	b.sb.WriteByte(')')
 	return nil
 }

--- a/internal/chsql/emit_test.go
+++ b/internal/chsql/emit_test.go
@@ -322,6 +322,72 @@ var plans = map[string]chplan.Node{
 		},
 	},
 
+	// TextIndexPrefilter variants (cerberus issue #2773 — chopt
+	// text_index_line_filter). A multi-word |= literal ANDs one
+	// lower(Body) LIKE '%tok%' conjunct per qualifying word ahead of the
+	// unchanged position() row predicate.
+	"filter_line_contains_prefilter": &chplan.Filter{
+		Input: &chplan.Scan{Table: "otel_logs"},
+		Predicate: &chplan.LineContent{
+			Source:             &chplan.ColumnRef{Name: "Body"},
+			Pattern:            "connection reset by peer",
+			TextIndexPrefilter: true,
+		},
+	},
+	// A negated filter never rewrites, even with TextIndexPrefilter set —
+	// a superset prefilter has no sound dual for "must not contain".
+	"filter_line_not_contains_prefilter_inert": &chplan.Filter{
+		Input: &chplan.Scan{Table: "otel_logs"},
+		Predicate: &chplan.LineContent{
+			Source:             &chplan.ColumnRef{Name: "Body"},
+			Pattern:            "connection reset by peer",
+			Negated:            true,
+			TextIndexPrefilter: true,
+		},
+	},
+	// A pure-literal regex (no RE2 metacharacters) gets the SAME prefilter
+	// treatment as a plain |= literal — see textIndexRegexLiteral.
+	"filter_line_regex_literal_prefilter": &chplan.Filter{
+		Input: &chplan.Scan{Table: "otel_logs"},
+		Predicate: &chplan.LineContent{
+			Source:             &chplan.ColumnRef{Name: "Body"},
+			Pattern:            "connection reset",
+			IsRegex:            true,
+			TextIndexPrefilter: true,
+		},
+	},
+	// A regex carrying real RE2 structure is NOT safely extractable —
+	// renders byte-identical to filter_line_regex above.
+	"filter_line_regex_metachar_prefilter_inert": &chplan.Filter{
+		Input: &chplan.Scan{Table: "otel_logs"},
+		Predicate: &chplan.LineContent{
+			Source:             &chplan.ColumnRef{Name: "Body"},
+			Pattern:            `failed: \w+`,
+			IsRegex:            true,
+			TextIndexPrefilter: true,
+		},
+	},
+	// LIKE escaping: a literal word containing `%` / `_` must not have
+	// either read back as a LIKE wildcard.
+	"filter_line_contains_prefilter_escaping": &chplan.Filter{
+		Input: &chplan.Scan{Table: "otel_logs"},
+		Predicate: &chplan.LineContent{
+			Source:             &chplan.ColumnRef{Name: "Body"},
+			Pattern:            "lookup user_id=50 storage 87%full done",
+			TextIndexPrefilter: true,
+		},
+	},
+	// Every word below the 4-rune minimum is dropped; none survive here,
+	// so this renders byte-identical to the TextIndexPrefilter=false form.
+	"filter_line_contains_prefilter_all_short": &chplan.Filter{
+		Input: &chplan.Scan{Table: "otel_logs"},
+		Predicate: &chplan.LineContent{
+			Source:             &chplan.ColumnRef{Name: "Body"},
+			Pattern:            "ok go",
+			TextIndexPrefilter: true,
+		},
+	},
+
 	// RangeWindow with offset modifier (PromQL `rate(...)[5m] offset 1h`).
 	"range_window_rate_offset": &chplan.RangeWindow{
 		Input:           &chplan.Scan{Table: "otel_metrics_sum"},

--- a/internal/chsql/text_index_line_filter_chdb_test.go
+++ b/internal/chsql/text_index_line_filter_chdb_test.go
@@ -1,0 +1,386 @@
+//go:build chdb
+
+// Real-ClickHouse (chDB) proof that chplan.LineContent.TextIndexPrefilter
+// (cerberus issue #2773, chopt text_index_line_filter) is:
+//
+//  1. Result-equivalent: the rewritten (prefiltered) predicate returns the
+//     EXACT SAME row set as the unrewritten one, over a real text index, for
+//     a plain multi-word |= literal, a pure-literal regex, and a literal
+//     containing LIKE metacharacters (%/_) that must be escaped correctly.
+//  2. Actually index-accelerated: EXPLAIN indexes=1 against a table
+//     carrying the idx_lower_body text index (the exact shape
+//     internal/schema/ddl.renderLogsTable emits when TextIndexEnabled=true)
+//     shows the prefiltered form pruning granules the unprefiltered form
+//     does not.
+//  3. Measurably faster end-to-end on production-shaped synthetic data — see
+//     TestTextIndexLineFilterPrefilter_Latency_ChDB, which logs the
+//     before/after wall-clock numbers this PR's body reports.
+//
+// The seed corpus is SYNTHETIC (no real production log-Body sample exists
+// under test/perf/ — its committed LFS corpus is metrics-shaped only), the
+// same honestly-labeled posture cerberus issue #2764/#2767's own chDB perf
+// proofs took on their new floors.
+package chsql_test
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"sort"
+	"testing"
+	"time"
+
+	"github.com/tsouza/cerberus/internal/chplan"
+	"github.com/tsouza/cerberus/internal/chsql"
+	"github.com/tsouza/cerberus/internal/chsqltest"
+)
+
+// tilfTotalRows / tilfNeedleEvery size the synthetic logs corpus: a body
+// column of realistic multi-word log lines, with the target literal
+// ("connection reset by peer") appended to every tilfNeedleEvery-th row —
+// selective enough (0.05%) that a real skip index has something to prune.
+const (
+	// 5M rows (~450MB compressed body text): the smallest scale at which
+	// the granule-pruning win reliably shows up as a real wall-clock
+	// improvement in this test's own measurements — see
+	// TestTextIndexLineFilterPrefilter_Latency_ChDB's doc comment.
+	// Measured directly: at 500K rows the LIKE-conjunct evaluation
+	// overhead roughly offsets the pruning win (no clear improvement);
+	// scaling to 5M is what makes not-reading-the-pruned-granules'
+	// compressed bytes actually outweigh evaluating a few extra LIKE
+	// predicates per row.
+	tilfTotalRows   = 5_000_000
+	tilfNeedleEvery = 2_000
+)
+
+// tilfTableDDL is a TRIMMED production-shaped logs table: only the
+// Timestamp/Body columns internal/schema/ddl.renderLogsTable's Logs
+// template carries, plus the EXACT idx_lower_body index shape that
+// function emits when TextIndexEnabled=true (TYPE text(tokenizer =
+// 'splitByNonAlpha') over lower(Body), no explicit GRANULARITY — see
+// bodyTextIndexGranularity's doc comment in internal/schema/ddl for why
+// that constant reproduces ClickHouse's own implicit default rather than
+// this DDL needing one).
+const tilfTableDDL = `CREATE OR REPLACE TABLE tilf_logs (
+    Timestamp DateTime64(9),
+    Body String,
+    INDEX idx_lower_body lower(Body) TYPE text(tokenizer = 'splitByNonAlpha')
+) ENGINE = MergeTree()
+ORDER BY Timestamp
+SETTINGS index_granularity = 256;`
+
+// tilfVocabWords is the fixed vocabulary synthetic log lines are drawn
+// from — deliberately log-shaped (service/infra terms), not English prose.
+var tilfVocabWords = []string{
+	"starting", "service", "handler", "request", "completed", "timeout",
+	"retry", "upstream", "cache", "miss", "hit", "auth", "token", "expired",
+	"refresh", "database", "query", "slow", "index", "scan", "user",
+	"session", "closed", "gc", "pause", "thread", "pool", "exhausted",
+	"queue", "depth",
+}
+
+// tilfNeedle is the multi-word |= literal the correctness + pruning +
+// latency tests all filter on. "by" (2 runes) falls below
+// textIndexLikeMinTokenLength and is dropped from the prefilter — the
+// query still runs correctly on the other three ANDed conjuncts.
+const tilfNeedle = "connection reset by peer"
+
+// tilfSeedInsert seeds tilfTotalRows rows: each a pseudo-random slice of
+// tilfVocabWords (via a deterministic arrayMap/rand seeded by `number`),
+// with tilfNeedle appended to every tilfNeedleEvery-th row.
+func tilfSeedInsert() string {
+	vocab := "["
+	for i, w := range tilfVocabWords {
+		if i > 0 {
+			vocab += ", "
+		}
+		vocab += "'" + w + "'"
+	}
+	vocab += "]"
+	return fmt.Sprintf(`INSERT INTO tilf_logs
+SELECT
+    toDateTime64('2026-01-01 00:00:00', 9) + INTERVAL number MICROSECOND AS Timestamp,
+    arrayStringConcat(
+        arrayMap(i -> %s[1 + (cityHash64(number, i) %% %d)], range(6 + (number %% 8))),
+        ' '
+    ) || if(number %% %d = 0, ' %s', '') AS Body
+FROM numbers(%d);`, vocab, len(tilfVocabWords), tilfNeedleEvery, tilfNeedle, tilfTotalRows)
+}
+
+// tilfSeed opens an isolated chDB session (chsqltest.OpenIsolatedChDB — a
+// direct connection open would inherit whatever database/tables a
+// PREVIOUS test in this process left behind, since chdb-go caches one
+// session per process; see test/regression/chsql_chdb_isolation_test.go,
+// issue #2074) and seeds tilf_logs. Returns the *sql.DB and the exact
+// count of needle-bearing rows seeded, computed independently via `LIKE`
+// over the raw generated Body (not via the code under test), so the
+// correctness tests below have a ground truth that does not share any
+// code path with what they verify.
+func tilfSeed(t *testing.T) (*sql.DB, int) {
+	t.Helper()
+	db := chsqltest.OpenIsolatedChDB(t)
+	if _, err := db.Exec(tilfTableDDL); err != nil {
+		t.Fatalf("create table: %v", err)
+	}
+	if _, err := db.Exec(tilfSeedInsert()); err != nil {
+		t.Fatalf("seed insert: %v", err)
+	}
+	var ground int
+	if err := db.QueryRow(`SELECT count() FROM tilf_logs WHERE position(Body, ?) > 0`, tilfNeedle).Scan(&ground); err != nil {
+		t.Fatalf("ground-truth count: %v", err)
+	}
+	if ground == 0 {
+		t.Fatalf("seed produced 0 needle rows — seed is broken")
+	}
+	return db, ground
+}
+
+// lineContentSQL emits the SQL + args chsql.Emit renders for a
+// chplan.Filter{Predicate: *chplan.LineContent} over tilf_logs — the SAME
+// production emitter path a LogQL |= / |~ query goes through, not a
+// hand-written query, so this test exercises the real rewrite.
+func lineContentSQL(t *testing.T, lc *chplan.LineContent) (string, []any) {
+	t.Helper()
+	plan := &chplan.Filter{
+		Input:     &chplan.Scan{Table: "tilf_logs"},
+		Predicate: lc,
+	}
+	sqlStr, args, err := chsql.Emit(context.Background(), plan)
+	if err != nil {
+		t.Fatalf("chsql.Emit: %v", err)
+	}
+	return sqlStr, args
+}
+
+// tilfRowIDs runs sqlStr (a SELECT * shape) and returns the sorted set of
+// Timestamp values matched, as a comparable fingerprint of the result set.
+func tilfRowIDs(t *testing.T, db *sql.DB, sqlStr string, args []any) []string {
+	t.Helper()
+	rows, err := db.Query(sqlStr, args...)
+	if err != nil {
+		t.Fatalf("query: %v\nSQL: %s", err, sqlStr)
+	}
+	defer rows.Close()
+	cols, err := rows.Columns()
+	if err != nil {
+		t.Fatalf("columns: %v", err)
+	}
+	tsIdx := -1
+	for i, c := range cols {
+		if c == "Timestamp" {
+			tsIdx = i
+		}
+	}
+	if tsIdx < 0 {
+		t.Fatalf("result has no Timestamp column: %v", cols)
+	}
+	var out []string
+	for rows.Next() {
+		dest := make([]any, len(cols))
+		ptrs := make([]any, len(cols))
+		for i := range dest {
+			ptrs[i] = &dest[i]
+		}
+		if err := rows.Scan(ptrs...); err != nil {
+			t.Fatalf("scan: %v", err)
+		}
+		out = append(out, fmt.Sprintf("%v", dest[tsIdx]))
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatalf("rows.Err: %v", err)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// TestTextIndexLineFilterPrefilter_ResultEquivalence_ChDB is the "real
+// EXPLAIN/execution test proving the rewritten form still returns identical
+// result sets to the original" the issue explicitly calls for — not just
+// that the rewrite "looks right". Three shapes: a plain multi-word |=
+// literal, a pure-literal regex (|~ with no RE2 metacharacters), and a
+// literal containing % / _ (the dedicated LIKE-escaping case).
+func TestTextIndexLineFilterPrefilter_ResultEquivalence_ChDB(t *testing.T) {
+	db, ground := tilfSeed(t)
+	t.Logf("seeded %d rows, %d ground-truth needle matches", tilfTotalRows, ground)
+
+	cases := []struct {
+		name    string
+		pattern string
+		isRegex bool
+	}{
+		{"literal", tilfNeedle, false},
+		{"pure_literal_regex", tilfNeedle, true},
+		{"like_metachar_escaping", "user_id=50 at 92% done", false},
+	}
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			before := &chplan.LineContent{
+				Source: &chplan.ColumnRef{Name: "Body"}, Pattern: tt.pattern, IsRegex: tt.isRegex,
+			}
+			after := &chplan.LineContent{
+				Source: &chplan.ColumnRef{Name: "Body"}, Pattern: tt.pattern, IsRegex: tt.isRegex,
+				TextIndexPrefilter: true,
+			}
+			beforeSQL, beforeArgs := lineContentSQL(t, before)
+			afterSQL, afterArgs := lineContentSQL(t, after)
+			if beforeSQL == afterSQL {
+				t.Fatalf("expected the prefiltered SQL to differ from the unprefiltered form; both rendered:\n%s", beforeSQL)
+			}
+			beforeRows := tilfRowIDs(t, db, beforeSQL, beforeArgs)
+			afterRows := tilfRowIDs(t, db, afterSQL, afterArgs)
+			if len(beforeRows) != len(afterRows) {
+				t.Fatalf("%s: row count mismatch: before=%d after=%d", tt.name, len(beforeRows), len(afterRows))
+			}
+			for i := range beforeRows {
+				if beforeRows[i] != afterRows[i] {
+					t.Fatalf("%s: result sets diverge at index %d: before=%s after=%s", tt.name, i, beforeRows[i], afterRows[i])
+				}
+			}
+		})
+	}
+}
+
+// TestTextIndexLineFilterPrefilter_PrunesGranules_ChDB proves the
+// prefiltered form actually prunes MergeTree granules via EXPLAIN
+// indexes=1, over the exact idx_lower_body text-index shape
+// internal/schema/ddl.renderLogsTable emits when TextIndexEnabled=true —
+// the DDL half of cerberus issue #2773 — not a synthetic index this test
+// invented for itself.
+func TestTextIndexLineFilterPrefilter_PrunesGranules_ChDB(t *testing.T) {
+	db, _ := tilfSeed(t)
+
+	explainGranules := func(sqlStr string, args []any) (total, read int) {
+		t.Helper()
+		rows, err := db.Query("EXPLAIN indexes=1 "+sqlStr, args...)
+		if err != nil {
+			t.Fatalf("EXPLAIN: %v\nSQL: %s", err, sqlStr)
+		}
+		defer rows.Close()
+		// EXPLAIN indexes=1 prints one "Granules: n/m" line per index stage
+		// (PrimaryKey first, then Skip when a skip index applies) — take the
+		// LAST one, which is the Skip stage's when a skip index engages, and
+		// the (only) PrimaryKey stage's when none does. Taking the FIRST
+		// match instead would always read the PrimaryKey line and silently
+		// miss whether the skip index pruned anything.
+		found := false
+		for rows.Next() {
+			var line string
+			if err := rows.Scan(&line); err != nil {
+				t.Fatalf("scan explain line: %v", err)
+			}
+			var r, tot int
+			if n, err := fmt.Sscanf(line, "            Granules: %d/%d", &r, &tot); err == nil && n == 2 {
+				read, total = r, tot
+				found = true
+			}
+		}
+		if !found {
+			t.Fatalf("EXPLAIN output carried no 'Granules: n/m' line:\nSQL: %s", sqlStr)
+		}
+		return total, read
+	}
+
+	before := &chplan.LineContent{Source: &chplan.ColumnRef{Name: "Body"}, Pattern: tilfNeedle}
+	after := &chplan.LineContent{Source: &chplan.ColumnRef{Name: "Body"}, Pattern: tilfNeedle, TextIndexPrefilter: true}
+	beforeSQL, beforeArgs := lineContentSQL(t, before)
+	afterSQL, afterArgs := lineContentSQL(t, after)
+
+	totalBefore, readBefore := explainGranules(beforeSQL, beforeArgs)
+	totalAfter, readAfter := explainGranules(afterSQL, afterArgs)
+
+	t.Logf("before (no prefilter): %d/%d granules read", readBefore, totalBefore)
+	t.Logf("after  (prefiltered):  %d/%d granules read", readAfter, totalAfter)
+
+	if readBefore != totalBefore {
+		t.Errorf("expected the UNPREFILTERED position()-only form to read every granule (no skip index it can use), got %d/%d", readBefore, totalBefore)
+	}
+	if readAfter >= readBefore {
+		t.Errorf("expected the prefiltered form to read FEWER granules than the unprefiltered form: before=%d after=%d", readBefore, readAfter)
+	}
+}
+
+// TestTextIndexLineFilterPrefilter_Latency_ChDB measures real wall-clock
+// latency before vs after over the synthetic corpus, logging the numbers
+// this PR's description reports. Not a hard pass/fail gate on absolute
+// timing (chDB's runtime characteristics vary too much across the CI fleet
+// for a numeric threshold to be reliable — see docs/test-strategy.md's
+// chDB-vs-real-CH guidance elsewhere in this repo) —
+// TestTextIndexLineFilterPrefilter_PrunesGranules_ChDB above is the
+// structural (version-independent) regression guard; this test's job is to
+// produce the honest measured numbers.
+//
+// use_query_condition_cache=0 is REQUIRED on every measured query here, not
+// cosmetic: ClickHouse's query condition cache (chopt condition_cache,
+// already auto-enabled by cerberus at server >= 25.3 — see
+// chopt.FeatureConditionCache) remembers, per granule, whether a
+// semantically-identical WHERE condition matched on a PREVIOUS execution,
+// and skips re-reading a granule it already knows cannot match. That cache
+// is completely independent of this feature's own text index — verified
+// live: with the condition cache warm, `enable_full_text_index=0` (the
+// text index switched OFF entirely) still read the exact same reduced row
+// count as with it on, and the FIRST-ever execution of a novel predicate
+// always full-scans even with the text index present. Left enabled, a
+// naive best-of-N loop over the SAME predicate would measure the SECOND
+// run's cache-warm speed for BOTH the before and after form, drowning out
+// this feature's own contribution entirely (a real methodological trap
+// this test fell into during development — the first attempt showed NO
+// improvement, or a slight regression, purely because both forms were
+// hitting a warm condition cache). Disabling it isolates the ONE
+// mechanism this test exists to measure: the text-index-driven granule
+// prefilter, on the realistic "first time a user searches for this exact
+// literal" cold-cache path ad-hoc LogQL search overwhelmingly is.
+func TestTextIndexLineFilterPrefilter_Latency_ChDB(t *testing.T) {
+	db, ground := tilfSeed(t)
+
+	before := &chplan.LineContent{Source: &chplan.ColumnRef{Name: "Body"}, Pattern: tilfNeedle}
+	after := &chplan.LineContent{Source: &chplan.ColumnRef{Name: "Body"}, Pattern: tilfNeedle, TextIndexPrefilter: true}
+	beforeSQL, beforeArgs := lineContentSQL(t, before)
+	afterSQL, afterArgs := lineContentSQL(t, after)
+	const disableConditionCache = " SETTINGS use_query_condition_cache = 0"
+	beforeSQL += disableConditionCache
+	afterSQL += disableConditionCache
+
+	const runs = 5
+	timeIt := func(sqlStr string, args []any) time.Duration {
+		best := time.Duration(1<<63 - 1)
+		for i := 0; i < runs; i++ {
+			start := time.Now()
+			rows, err := db.Query(sqlStr, args...)
+			if err != nil {
+				t.Fatalf("query: %v", err)
+			}
+			n := 0
+			for rows.Next() {
+				n++
+			}
+			if err := rows.Err(); err != nil {
+				t.Fatalf("rows.Err: %v", err)
+			}
+			rows.Close()
+			if n != ground {
+				t.Fatalf("row count drifted mid-benchmark: got %d, want %d", n, ground)
+			}
+			if d := time.Since(start); d < best {
+				best = d
+			}
+		}
+		return best
+	}
+
+	// Interleave rather than running all "before" repeats then all "after"
+	// repeats, so a shared confound drifting over the test's lifetime (GC,
+	// thermal throttling, a noisy CI neighbor) hits both forms evenly
+	// instead of biasing whichever form runs second.
+	var beforeBest, afterBest time.Duration
+	for i := 0; i < 3; i++ {
+		if b := timeIt(beforeSQL, beforeArgs); beforeBest == 0 || b < beforeBest {
+			beforeBest = b
+		}
+		if a := timeIt(afterSQL, afterArgs); afterBest == 0 || a < afterBest {
+			afterBest = a
+		}
+	}
+
+	t.Logf("TextIndexLineFilter latency (condition cache disabled), %d rows, best-of-%d: before=%s after=%s (%.2fx)",
+		tilfTotalRows, runs*3, beforeBest, afterBest, float64(beforeBest)/float64(afterBest))
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -378,6 +378,17 @@ type Config struct {
 	// internal/schema/ddl.Config.TraceIDProjectionEnabled).
 	SchemaTraceIDProjection bool
 
+	// SchemaFullTextIndex is the resolved chopt full_text_index verdict
+	// (cerberus issue #2773), back-filled the SAME way as
+	// SchemaTraceIDProjection immediately above — including the offline
+	// `migrate schema` preview's chopt.ExplicitlyRequested fallback, since
+	// full_text_index is also AutoSelect=false. internal/schemaboot.
+	// DDLConfig is the only reader: true swaps the logs table's
+	// idx_lower_body CREATE-time index to TYPE text(...) and adds the
+	// additive idx_body_text ALTER for existing tables (see
+	// internal/schema/ddl.Config.TextIndexEnabled).
+	SchemaFullTextIndex bool
+
 	// CHOptCorpus configures the async system.query_log performance-corpus
 	// reconciler (disabled by default; production-only — chDB has no
 	// query_log).

--- a/internal/logql/lang.go
+++ b/internal/logql/lang.go
@@ -54,6 +54,12 @@ type Lang struct {
 	Start  time.Time
 	End    time.Time
 	Step   time.Duration
+
+	// TextIndexLineFilter is chopt text_index_line_filter's resolved
+	// verdict (cerberus issue #2773), threaded into [LowerAtRangeOpts] —
+	// see [LowerOpts.TextIndexLineFilter]. false (the zero value) renders
+	// byte-identical to today.
+	TextIndexLineFilter bool
 }
 
 // errorTypes mirrors the Loki errorType vocabulary the handler emits.
@@ -87,7 +93,7 @@ func (l *Lang) Parse(ctx context.Context, query string) (chplan.Node, engine.Met
 	}
 
 	lowerT := telemetry.ObserveStage(telemetry.StageLower, l.Name())
-	plan, err := LowerAtRange(ctx, expr, l.Schema, l.Start, l.End, l.Step)
+	plan, err := LowerAtRangeOpts(ctx, expr, l.Schema, l.Start, l.End, l.Step, LowerOpts{TextIndexLineFilter: l.TextIndexLineFilter})
 	lowerT.Done(ctx)
 	if err != nil {
 		return nil, engine.Meta{}, &httperr.Error{

--- a/internal/logql/lower.go
+++ b/internal/logql/lower.go
@@ -67,6 +67,16 @@ type lowerCtx struct {
 	// that consumes this list and [topLevelLogColumnFor] for the
 	// label→column resolution.
 	OuterByLabels []string
+
+	// TextIndexLineFilter is the resolved chopt text_index_line_filter
+	// verdict (cerberus issue #2773), threaded from [LowerOpts] down to
+	// [lineFilterPart] — the only reader. true opts an eligible LogQL line
+	// filter's chplan.LineContent node onto the ANDed LIKE strict-superset
+	// prefilter; false (the default — every non-Opts entry point leaves it
+	// unset) renders byte-identical to today. See
+	// chplan.LineContent.TextIndexPrefilter's doc comment for the full
+	// rewrite and its eligibility shape.
+	TextIndexLineFilter bool
 }
 
 // withOuterByLabels returns a copy of c with OuterByLabels set to
@@ -148,6 +158,27 @@ func LowerAt(ctx context.Context, expr syntax.Expr, s schema.Logs, start, end ti
 // falls back to the instant shape (same as LowerAt).
 func LowerAtRange(ctx context.Context, expr syntax.Expr, s schema.Logs, start, end time.Time, step time.Duration) (chplan.Node, error) {
 	return lowerWithCtx(ctx, expr, s, lowerCtx{Start: start, End: end, Step: step})
+}
+
+// LowerOpts carries the resolved chopt verdicts a caller opts into —
+// mirrors internal/promql.LowerOpts, kept deliberately smaller: LogQL has
+// no boot-wired polymorphic strategy table today, only the single boolean
+// below.
+type LowerOpts struct {
+	// TextIndexLineFilter is chopt text_index_line_filter's resolved
+	// verdict (cerberus issue #2773) — see lowerCtx.TextIndexLineFilter's
+	// doc comment for what it does and its default-off, byte-identical
+	// posture.
+	TextIndexLineFilter bool
+}
+
+// LowerAtRangeOpts is the options-carrying variant of [LowerAtRange]. The
+// loki handler adapter (internal/logql.Lang) passes a populated LowerOpts
+// so the resolved chopt verdicts reach the lowering; every other caller
+// uses [Lower] / [LowerAt] / [LowerAtRange] and gets the zero-options
+// (default, byte-identical) behaviour.
+func LowerAtRangeOpts(ctx context.Context, expr syntax.Expr, s schema.Logs, start, end time.Time, step time.Duration, opts LowerOpts) (chplan.Node, error) {
+	return lowerWithCtx(ctx, expr, s, lowerCtx{Start: start, End: end, Step: step, TextIndexLineFilter: opts.TextIndexLineFilter})
 }
 
 func lowerWithCtx(ctx context.Context, expr syntax.Expr, s schema.Logs, lc lowerCtx) (chplan.Node, error) {
@@ -275,7 +306,7 @@ func lowerPipelineWithLabels(e *syntax.PipelineExpr, s schema.Logs, lc lowerCtx)
 		if lf, ok := stage.(*syntax.LabelFilterExpr); ok && dynamicLabels && FiltersErrorLabel(lf.LabelFilterer) {
 			continue
 		}
-		next, newLabels, err := lowerStage(stage, s, labelsExpr)
+		next, newLabels, err := lowerStage(stage, s, labelsExpr, lc)
 		if err != nil {
 			return nil, nil, err
 		}
@@ -553,10 +584,10 @@ func labelFiltererHasDuration(lf syntax.LabelFilterer) bool {
 // `ResourceAttributes` column, or a `mapConcat(...)` wrapped form after
 // a `| logfmt` stage. Label filters MapAccess against it so they see
 // both stream-selector labels and parser-extracted keys.
-func lowerStage(stage syntax.StageExpr, s schema.Logs, labelsExpr chplan.Expr) (chplan.Expr, chplan.Expr, error) {
+func lowerStage(stage syntax.StageExpr, s schema.Logs, labelsExpr chplan.Expr, lc lowerCtx) (chplan.Expr, chplan.Expr, error) {
 	switch st := stage.(type) {
 	case *syntax.LineFilterExpr:
-		p, err := lowerLineFilter(st, s)
+		p, err := lowerLineFilter(st, s, lc)
 		return p, nil, err
 	case *syntax.LabelFilterExpr:
 		pred, marks, err := labelFiltererLower(st.LabelFilterer, s, labelsExpr)
@@ -2240,19 +2271,19 @@ func labelPresenceOnMap(s schema.Logs, labelsExpr chplan.Expr, key string) chpla
 // clauses) and `Or` walks alternates joined by `or`. We AND the Left
 // chain and OR the Or chain so the final predicate matches Loki's
 // evaluation order.
-func lowerLineFilter(f *syntax.LineFilterExpr, s schema.Logs) (chplan.Expr, error) {
+func lowerLineFilter(f *syntax.LineFilterExpr, s schema.Logs, lc lowerCtx) (chplan.Expr, error) {
 	body := &chplan.ColumnRef{Name: s.BodyColumn}
-	return lowerLineFilterChain(f, body)
+	return lowerLineFilterChain(f, body, lc)
 }
 
-func lowerLineFilterChain(f *syntax.LineFilterExpr, body chplan.Expr) (chplan.Expr, error) {
-	current, err := lineFilterPart(&f.LineFilter, body)
+func lowerLineFilterChain(f *syntax.LineFilterExpr, body chplan.Expr, lc lowerCtx) (chplan.Expr, error) {
+	current, err := lineFilterPart(&f.LineFilter, body, lc)
 	if err != nil {
 		return nil, err
 	}
 	// `or` alternates fold into a disjunction with the head clause.
 	for or := f.Or; or != nil; or = or.Or {
-		next, err := lineFilterPart(&or.LineFilter, body)
+		next, err := lineFilterPart(&or.LineFilter, body, lc)
 		if err != nil {
 			return nil, err
 		}
@@ -2260,7 +2291,7 @@ func lowerLineFilterChain(f *syntax.LineFilterExpr, body chplan.Expr) (chplan.Ex
 	}
 	// Older filters in the same pipeline live on `Left`. AND them in.
 	if f.Left != nil {
-		prev, err := lowerLineFilterChain(f.Left, body)
+		prev, err := lowerLineFilterChain(f.Left, body, lc)
 		if err != nil {
 			return nil, err
 		}
@@ -2269,7 +2300,7 @@ func lowerLineFilterChain(f *syntax.LineFilterExpr, body chplan.Expr) (chplan.Ex
 	return current, nil
 }
 
-func lineFilterPart(lf *syntax.LineFilter, body chplan.Expr) (chplan.Expr, error) {
+func lineFilterPart(lf *syntax.LineFilter, body chplan.Expr, lc lowerCtx) (chplan.Expr, error) {
 	if lf.Op == syntax.OpFilterIP {
 		// `|= ip("192.168.0.0/16")` matches lines containing an IP
 		// inside the CIDR / range / single-IP match set — see
@@ -2294,6 +2325,14 @@ func lineFilterPart(lf *syntax.LineFilter, body chplan.Expr) (chplan.Expr, error
 		Pattern: lf.Match,
 		IsRegex: isRegex,
 		Negated: negated,
+		// TextIndexPrefilter (cerberus issue #2773): the chopt verdict is
+		// necessary but not sufficient — a negated filter has no sound
+		// prefilter dual, so it is excluded here at the one call site that
+		// knows Negated, rather than re-checked in every emitter path. The
+		// emitter (internal/chsql's exprLineContent) makes the remaining,
+		// SQL-shape-dependent eligibility calls (regex-literal extraction,
+		// per-token length filtering).
+		TextIndexPrefilter: lc.TextIndexLineFilter && !negated,
 	}, nil
 }
 

--- a/internal/logql/text_index_line_filter_test.go
+++ b/internal/logql/text_index_line_filter_test.go
@@ -1,0 +1,139 @@
+package logql_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/tsouza/cerberus/internal/chplan"
+	"github.com/tsouza/cerberus/internal/logql"
+	"github.com/tsouza/cerberus/internal/schema"
+)
+
+// findLineContents recursively collects every *chplan.LineContent reachable
+// from expr, walking the chplan.Binary AND/OR tree lowerLineFilterChain
+// builds. Sufficient for the flat line-filter chains this test constructs;
+// not a general chplan.Expr walker.
+func findLineContents(expr chplan.Expr) []*chplan.LineContent {
+	switch e := expr.(type) {
+	case *chplan.LineContent:
+		return []*chplan.LineContent{e}
+	case *chplan.Binary:
+		out := findLineContents(e.Left)
+		out = append(out, findLineContents(e.Right)...)
+		return out
+	default:
+		return nil
+	}
+}
+
+// onlyLineContent lowers query and returns the single *chplan.LineContent
+// its Filter predicate carries, failing the test if the plan doesn't have
+// exactly one Filter with exactly one LineContent.
+func onlyLineContent(t *testing.T, opts logql.LowerOpts) *chplan.LineContent {
+	t.Helper()
+	s := schema.DefaultOTelLogs()
+	expr, err := logql.ParseExprPermissive(`{app="x"} |= "connection reset by peer"`)
+	if err != nil {
+		t.Fatalf("ParseExprPermissive: %v", err)
+	}
+	plan, err := logql.LowerAtRangeOpts(context.Background(), expr, s, time.Time{}, time.Time{}, 0, opts)
+	if err != nil {
+		t.Fatalf("LowerAtRangeOpts: %v", err)
+	}
+	f, ok := plan.(*chplan.Filter)
+	if !ok {
+		t.Fatalf("plan root = %T, want *chplan.Filter", plan)
+	}
+	lcs := findLineContents(f.Predicate)
+	if len(lcs) != 1 {
+		t.Fatalf("found %d LineContent node(s) in predicate, want 1: %#v", len(lcs), f.Predicate)
+	}
+	return lcs[0]
+}
+
+// TestLowerAtRangeOpts_TextIndexLineFilter_Threading pins that
+// LowerOpts.TextIndexLineFilter (cerberus issue #2773, chopt
+// text_index_line_filter) reaches the lowered chplan.LineContent node's
+// TextIndexPrefilter field for a plain, non-negated |= filter, and that it
+// stays false when the option is unset — the byte-identical-by-default
+// contract every chopt-gated feature in this repo carries.
+func TestLowerAtRangeOpts_TextIndexLineFilter_Threading(t *testing.T) {
+	for _, tt := range []struct {
+		name string
+		opts logql.LowerOpts
+		want bool
+	}{
+		{"disabled_zero_value", logql.LowerOpts{}, false},
+		{"enabled", logql.LowerOpts{TextIndexLineFilter: true}, true},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			lc := onlyLineContent(t, tt.opts)
+			if lc.TextIndexPrefilter != tt.want {
+				t.Errorf("TextIndexPrefilter = %v, want %v", lc.TextIndexPrefilter, tt.want)
+			}
+			if lc.Pattern != "connection reset by peer" || lc.IsRegex || lc.Negated {
+				t.Errorf("unexpected LineContent shape: %#v", lc)
+			}
+		})
+	}
+}
+
+// TestLower_TextIndexLineFilter_DefaultEntrypointsInert pins that the
+// zero-options entry points ([Lower], [LowerAt], [LowerAtRange]) — every
+// caller except internal/logql.Lang — never set TextIndexPrefilter, since
+// they construct a zero-value lowerCtx with no way to opt in.
+func TestLower_TextIndexLineFilter_DefaultEntrypointsInert(t *testing.T) {
+	s := schema.DefaultOTelLogs()
+	expr, err := logql.ParseExprPermissive(`{app="x"} |= "connection reset by peer"`)
+	if err != nil {
+		t.Fatalf("ParseExprPermissive: %v", err)
+	}
+	plan, err := logql.Lower(context.Background(), expr, s)
+	if err != nil {
+		t.Fatalf("Lower: %v", err)
+	}
+	f, ok := plan.(*chplan.Filter)
+	if !ok {
+		t.Fatalf("plan root = %T, want *chplan.Filter", plan)
+	}
+	lcs := findLineContents(f.Predicate)
+	if len(lcs) != 1 {
+		t.Fatalf("found %d LineContent node(s), want 1", len(lcs))
+	}
+	if lcs[0].TextIndexPrefilter {
+		t.Errorf("Lower() (zero-options entrypoint) set TextIndexPrefilter=true unexpectedly")
+	}
+}
+
+// TestLowerAtRangeOpts_TextIndexLineFilter_NegatedInert pins the
+// LineContent.TextIndexPrefilter eligibility contract's negation carve-out:
+// a negated filter (`!=`) NEVER gets TextIndexPrefilter=true, even with
+// the chopt feature enabled — a superset prefilter has no sound dual for
+// "must not contain".
+func TestLowerAtRangeOpts_TextIndexLineFilter_NegatedInert(t *testing.T) {
+	s := schema.DefaultOTelLogs()
+	expr, err := logql.ParseExprPermissive(`{app="x"} != "connection reset by peer"`)
+	if err != nil {
+		t.Fatalf("ParseExprPermissive: %v", err)
+	}
+	plan, err := logql.LowerAtRangeOpts(context.Background(), expr, s, time.Time{}, time.Time{}, 0,
+		logql.LowerOpts{TextIndexLineFilter: true})
+	if err != nil {
+		t.Fatalf("LowerAtRangeOpts: %v", err)
+	}
+	f, ok := plan.(*chplan.Filter)
+	if !ok {
+		t.Fatalf("plan root = %T, want *chplan.Filter", plan)
+	}
+	lcs := findLineContents(f.Predicate)
+	if len(lcs) != 1 {
+		t.Fatalf("found %d LineContent node(s), want 1", len(lcs))
+	}
+	if !lcs[0].Negated {
+		t.Fatalf("expected Negated=true for `!=`, got false")
+	}
+	if lcs[0].TextIndexPrefilter {
+		t.Errorf("negated filter got TextIndexPrefilter=true, want false")
+	}
+}

--- a/internal/schema/ddl/ddl.go
+++ b/internal/schema/ddl/ddl.go
@@ -189,6 +189,26 @@ type Config struct {
 	// deployment below the floor never sees the statement rendered at all,
 	// not a statement that is rendered and then refused.
 	TraceIDProjectionEnabled bool
+
+	// TextIndexEnabled gates two things (cerberus issue #2773): on the
+	// CREATE TABLE branch, it flips the upstream sqltemplates.
+	// LogsCreateTableTmpl's HasFullTextSearch flag — see renderLogsTable —
+	// which swaps `idx_lower_body` from `tokenbf_v1(32768, 3, 0)` to `TYPE
+	// text(tokenizer = 'splitByNonAlpha')`, the SAME index name over the
+	// SAME lower(Body) expression, so a brand-new table gets the text index
+	// straight away. On an EXISTING table (already carrying the tokenbf
+	// branch from an earlier boot), it additionally renders an idempotent
+	// `ADD INDEX IF NOT EXISTS idx_body_text lower(Body) TYPE text(...)`
+	// ALTER — see renderAddBodyTextIndex's doc comment for why this is a
+	// SEPARATELY-named additive index rather than an in-place type swap of
+	// idx_lower_body. False (the default) renders byte-identical DDL to
+	// today: the tokenbf_v1 branch on CREATE, no additive ALTER. The chopt
+	// full_text_index feature (version-gated at ClickHouse >= 26.2, the
+	// first release with enable_full_text_index default-on — see the
+	// registry entry's doc for the probed-version evidence) resolves this
+	// bit at boot — see internal/schemaboot.DDLConfig — mirroring exactly
+	// how TraceIDProjectionEnabled is threaded from its own chopt verdict.
+	TextIndexEnabled bool
 }
 
 // DatabaseEngine selects the ClickHouse database engine for the
@@ -747,6 +767,14 @@ func renderSignal(cfg Config, s Signal) ([]string, error) {
 		if cfg.TraceIDProjectionEnabled {
 			stmts = append(stmts, renderAddTraceIDProjection(cfg, cfg.Tables.Logs))
 		}
+		// The additive idx_body_text index (issue #2773) trails every other
+		// curated ALTER in this package the same way — see
+		// renderAddBodyTextIndex's doc comment for why it targets a
+		// separately-named index rather than swapping idx_lower_body in
+		// place.
+		if cfg.TextIndexEnabled {
+			stmts = append(stmts, renderAddBodyTextIndex(cfg))
+		}
 		if cfg.ColumnStatisticsEnabled {
 			stmts = append(stmts, renderLogsColumnStatistics(cfg)...)
 		}
@@ -951,6 +979,73 @@ func renderAddTraceIDProjection(cfg Config, table string) string {
 }
 
 const (
+	// bodyTextIndexName is the ALTER TABLE ADD INDEX identifier
+	// renderAddBodyTextIndex installs on an EXISTING logs table (cerberus
+	// issue #2773) — see that function's doc comment for why it is a
+	// SEPARATE name from idx_lower_body rather than an in-place type swap.
+	bodyTextIndexName = "idx_body_text"
+	// bodyTextIndexType is the ClickHouse index type clause: a word-level
+	// text index over the tokenizer the upstream template's own
+	// HasFullTextSearch=true branch uses for idx_lower_body (sqltemplates'
+	// logs_table.sql), so a freshly-created table and an upgraded existing
+	// one tokenize identically.
+	bodyTextIndexType = "text(tokenizer = 'splitByNonAlpha')"
+	// bodyTextIndexGranularity mirrors ClickHouse's OWN implicit default
+	// for a `text` index type when no GRANULARITY clause is given —
+	// confirmed by omitting the clause against a live ClickHouse 26.6.3.62
+	// server and reading back `EXPLAIN indexes=1`, which reports "text
+	// GRANULARITY 100000000" — and re-confirmed byte-for-byte identical
+	// (same EXPLAIN Description, same pruning) when the clause is stamped
+	// explicitly with this value. chsql.AlterTableAddIndex has no
+	// omit-GRANULARITY mode (every other index type it renders — minmax,
+	// bloom_filter — requires an explicit, meaningful one), so this
+	// constant reproduces the upstream template's own implicit choice
+	// rather than widening that builder's contract for one index type.
+	bodyTextIndexGranularity = 100000000
+)
+
+// renderAddBodyTextIndex builds the idempotent ADD INDEX ALTER installing a
+// text-type skip index over lower(Body) on an EXISTING logs table (cerberus
+// issue #2773, cfg.TextIndexEnabled).
+//
+// A SEPARATELY-named index (idx_body_text), not an in-place upgrade of
+// idx_lower_body: the upstream template's HasFullTextSearch branch reuses
+// idx_lower_body's name for BOTH the tokenbf_v1 (false) and text (true)
+// index types (sqltemplates' logs_table.sql), which only works because a
+// CREATE TABLE ... IF NOT EXISTS never re-runs against a table that already
+// exists. An ALTER TABLE ADD INDEX IF NOT EXISTS idx_lower_body against a
+// table that already carries idx_lower_body as tokenbf_v1 is a silent
+// NO-OP — ClickHouse matches on name, not type — so it could never install
+// the text index on an upgraded deployment. Swapping the TYPE of an
+// existing index requires DROP INDEX + ADD INDEX, which is destructive
+// (existing MATERIALIZE'd granules are discarded, forcing a full backfill)
+// and this render-time-only package has no live system.data_skipping_indexes
+// read to tell whether idx_lower_body is ALREADY the text type (in which
+// case dropping and re-adding it on every boot would be pure, repeated,
+// backfill-losing churn). Installing a second, differently-named index is
+// the only additive, idempotent, crash-safe option available here — the
+// SAME reasoning every other ALTER in this package already follows (ADD
+// PROJECTION, ADD STATISTICS, ADD INDEX all install NEW, non-colliding
+// names). Retiring the now-redundant legacy idx_lower_body tokenbf index on
+// upgraded tables is left to a dedicated follow-up (cerberus issue #2773's
+// PR body links it) — dropping an index an operator's running queries may
+// still be planning against is a real production-cluster risk this
+// render-time DDL apply should not make unilaterally.
+//
+// Adding a skip index is metadata-only for NEW parts; EXISTING parts need
+// the one-time `ALTER TABLE ... MATERIALIZE INDEX idx_body_text` backfill
+// to benefit retroactively — see docs/operations.md, mirroring
+// renderAddTemporalityIndex's own backfill note.
+func renderAddBodyTextIndex(cfg Config) string {
+	expr := chsql.Call("lower", chsql.Col(bodyColumn))
+	stmt := chsql.AlterTableAddIndex(cfg.Database, cfg.Tables.Logs, bodyTextIndexName, expr, bodyTextIndexType, bodyTextIndexGranularity)
+	if cfg.Cluster != "" {
+		stmt.OnCluster(cfg.Cluster)
+	}
+	return stmt.SQL()
+}
+
+const (
 	// temporalityIndexName is the ALTER TABLE ADD INDEX identifier for the
 	// AggregationTemporality skip index — see renderAddTemporalityIndex.
 	temporalityIndexName = "idx_agg_temporality"
@@ -1102,9 +1197,11 @@ func renderDeltaPrefixView(cfg Config) string {
 // [sqltemplates.LogsCreateTableTmpl] against [sqltemplates.CreateTableData],
 // mirroring exporter_logs.go's renderCreateLogsTableSQL. The TTL field is
 // `toDateTime(Timestamp)` (the dedicated TimestampTime column was removed
-// from the schema). HasFullTextSearch stays false: the text-index branch
-// needs ClickHouse >= 26.2; false renders the bloom-filter index branch
-// that works everywhere cerberus deploys.
+// from the schema). HasFullTextSearch threads cfg.TextIndexEnabled (cerberus
+// issue #2773): false (the default) renders the bloom-filter/tokenbf_v1
+// branch that works everywhere cerberus deploys; true renders the text-index
+// branch, which needs ClickHouse >= 26.2 — see TextIndexEnabled's doc for the
+// chopt full_text_index gate that resolves this bit.
 func renderLogsTable(cfg Config) (string, error) {
 	data := sqltemplates.CreateTableData{
 		Database:          cfg.Database,
@@ -1112,7 +1209,7 @@ func renderLogsTable(cfg Config) (string, error) {
 		ClusterString:     cfg.clusterClause(),
 		Engine:            cfg.Engine,
 		TTL:               cfg.ttlExpr("Timestamp", cfg.TTL.Logs, cfg.Tiering.Logs),
-		HasFullTextSearch: false,
+		HasFullTextSearch: cfg.TextIndexEnabled,
 	}
 	var buf strings.Builder
 	if err := sqltemplates.LogsCreateTableTmpl.Execute(&buf, data); err != nil {

--- a/internal/schema/ddl/text_index_test.go
+++ b/internal/schema/ddl/text_index_test.go
@@ -1,0 +1,125 @@
+package ddl
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestRenderLogsTable_TextIndexEnabled pins the render-layer version-gate
+// contract cerberus issue #2773 specifies: TextIndexEnabled=false (the zero
+// value, a below-floor deployment or the feature simply off) renders the
+// tokenbf_v1 branch (byte-identical to today); true renders the text-index
+// branch (TYPE text(tokenizer = 'splitByNonAlpha')) instead — the SAME
+// idx_lower_body name, mutually exclusive, matching the upstream template's
+// own HasFullTextSearch branch.
+func TestRenderLogsTable_TextIndexEnabled(t *testing.T) {
+	for _, tt := range []struct {
+		name    string
+		enabled bool
+		want    string
+		notWant string
+	}{
+		{"disabled", false, "INDEX idx_lower_body lower(Body) TYPE tokenbf_v1(32768, 3, 0)", "TYPE text("},
+		{"enabled", true, "INDEX idx_lower_body lower(Body) TYPE text(tokenizer = 'splitByNonAlpha')", "tokenbf_v1"},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := Config{TextIndexEnabled: tt.enabled}.withDefaults()
+			logs, err := renderLogsTable(cfg)
+			if err != nil {
+				t.Fatalf("renderLogsTable: %v", err)
+			}
+			if !strings.Contains(logs, tt.want) {
+				t.Errorf("renderLogsTable(TextIndexEnabled=%v) missing %q:\n%s", tt.enabled, tt.want, logs)
+			}
+			if strings.Contains(logs, tt.notWant) {
+				t.Errorf("renderLogsTable(TextIndexEnabled=%v) unexpectedly contains %q:\n%s", tt.enabled, tt.notWant, logs)
+			}
+		})
+	}
+}
+
+// TestRenderAddBodyTextIndex_ExactSQL pins the additive ALTER TABLE ADD
+// INDEX statement installed on an EXISTING logs table: idx_body_text (a
+// SEPARATE name from idx_lower_body — see the function's own doc comment
+// for why), lower(Body), TYPE text(tokenizer = 'splitByNonAlpha'), and the
+// GRANULARITY 100000000 constant reproducing ClickHouse's own implicit
+// default for a text index.
+func TestRenderAddBodyTextIndex_ExactSQL(t *testing.T) {
+	cases := []struct {
+		name string
+		cfg  Config
+		want string
+	}{
+		{
+			"default",
+			Config{}.withDefaults(),
+			"ALTER TABLE default.otel_logs ADD INDEX IF NOT EXISTS idx_body_text lower(`Body`) " +
+				"TYPE text(tokenizer = 'splitByNonAlpha') GRANULARITY 100000000",
+		},
+		{
+			"on_cluster",
+			Config{Cluster: "prod"}.withDefaults(),
+			"ALTER TABLE default.otel_logs ON CLUSTER `prod` ADD INDEX IF NOT EXISTS idx_body_text lower(`Body`) " +
+				"TYPE text(tokenizer = 'splitByNonAlpha') GRANULARITY 100000000",
+		},
+	}
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			got := renderAddBodyTextIndex(tt.cfg)
+			if got != tt.want {
+				t.Errorf("renderAddBodyTextIndex() =\n  %s\nwant:\n  %s", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestRenderSignal_TextIndexEnabled pins the version-gate contract at the
+// render layer, mirroring TestRenderSignal_TraceIDProjectionEnabled:
+// TextIndexEnabled=false renders NO idx_body_text statement at all — not a
+// statement that is rendered and then refused — and true renders exactly
+// one, trailing the CREATE + codec + proj_trace_id ALTERs.
+func TestRenderSignal_TextIndexEnabled(t *testing.T) {
+	for _, tt := range []struct {
+		name    string
+		enabled bool
+		want    int
+	}{
+		{"disabled", false, 0},
+		{"enabled", true, 1},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := Config{TextIndexEnabled: tt.enabled}.withDefaults()
+			stmts, err := renderSignal(cfg, Logs)
+			if err != nil {
+				t.Fatalf("renderSignal(Logs): %v", err)
+			}
+			got := 0
+			for _, stmt := range stmts {
+				if strings.Contains(stmt, "ADD INDEX IF NOT EXISTS "+bodyTextIndexName) {
+					got++
+				}
+			}
+			if got != tt.want {
+				t.Errorf("%d idx_body_text statements, want %d, rendered:\n%v", got, tt.want, stmts)
+			}
+		})
+	}
+}
+
+// TestRenderSignal_TextIndexEnabled_OtherSignalsUntouched confirms the
+// additive index is scoped to Logs only — Metrics and Traces carry no Body
+// column at all.
+func TestRenderSignal_TextIndexEnabled_OtherSignalsUntouched(t *testing.T) {
+	cfg := Config{TextIndexEnabled: true}.withDefaults()
+	for _, sig := range []Signal{Metrics, Traces} {
+		stmts, err := renderSignal(cfg, sig)
+		if err != nil {
+			t.Fatalf("renderSignal(%s): %v", sig, err)
+		}
+		for _, stmt := range stmts {
+			if strings.Contains(stmt, bodyTextIndexName) {
+				t.Errorf("%s: unexpected idx_body_text statement:\n%s", sig, stmt)
+			}
+		}
+	}
+}

--- a/internal/schemaboot/ddlconfig.go
+++ b/internal/schemaboot/ddlconfig.go
@@ -138,6 +138,12 @@ func DDLConfig(cfg config.Config) (ddl.Config, error) {
 		// chopt.ExplicitlyRequested) — the SAME threading
 		// ColumnStatisticsEnabled above uses for its own chopt verdict.
 		TraceIDProjectionEnabled: cfg.SchemaTraceIDProjection,
+		// TextIndexEnabled (cerberus issue #2773) is the resolved chopt
+		// full_text_index verdict, back-filled by cmd/cerberus's boot
+		// resolver (or, for the offline `migrate schema` preview,
+		// chopt.ExplicitlyRequested) — the SAME threading
+		// TraceIDProjectionEnabled above uses for its own chopt verdict.
+		TextIndexEnabled: cfg.SchemaFullTextIndex,
 	}
 	// Validate here rather than only inside ddl.ApplyWithConfig: DDLConfig runs
 	// on EVERY boot (the auto-create hook is a separate flag), so an inert

--- a/test/spec/chsql/filter_line_contains_prefilter.txtar
+++ b/test/spec/chsql/filter_line_contains_prefilter.txtar
@@ -1,0 +1,10 @@
+-- args --
+[0] string = "%connection%"
+[1] string = "%reset%"
+[2] string = "%peer%"
+[3] string = "connection reset by peer"
+-- chplan --
+Filter predicate=lineContent(Body, "connection reset by peer", substr)
+  Scan(otel_logs)
+-- sql --
+SELECT * FROM `otel_logs` WHERE (lower(`Body`) LIKE ? AND lower(`Body`) LIKE ? AND lower(`Body`) LIKE ? AND (position(`Body`, ?) > 0))

--- a/test/spec/chsql/filter_line_contains_prefilter_all_short.txtar
+++ b/test/spec/chsql/filter_line_contains_prefilter_all_short.txtar
@@ -1,0 +1,7 @@
+-- args --
+[0] string = "ok go"
+-- chplan --
+Filter predicate=lineContent(Body, "ok go", substr)
+  Scan(otel_logs)
+-- sql --
+SELECT * FROM `otel_logs` WHERE (position(`Body`, ?) > 0)

--- a/test/spec/chsql/filter_line_contains_prefilter_escaping.txtar
+++ b/test/spec/chsql/filter_line_contains_prefilter_escaping.txtar
@@ -1,0 +1,12 @@
+-- args --
+[0] string = "%lookup%"
+[1] string = "%user\\_id=50%"
+[2] string = "%storage%"
+[3] string = "%87\\%full%"
+[4] string = "%done%"
+[5] string = "lookup user_id=50 storage 87%full done"
+-- chplan --
+Filter predicate=lineContent(Body, "lookup user_id=50 storage 87%full done", substr)
+  Scan(otel_logs)
+-- sql --
+SELECT * FROM `otel_logs` WHERE (lower(`Body`) LIKE ? AND lower(`Body`) LIKE ? AND lower(`Body`) LIKE ? AND lower(`Body`) LIKE ? AND lower(`Body`) LIKE ? AND (position(`Body`, ?) > 0))

--- a/test/spec/chsql/filter_line_not_contains_prefilter_inert.txtar
+++ b/test/spec/chsql/filter_line_not_contains_prefilter_inert.txtar
@@ -1,0 +1,7 @@
+-- args --
+[0] string = "connection reset by peer"
+-- chplan --
+Filter predicate=lineContent(Body, "connection reset by peer", substr,not)
+  Scan(otel_logs)
+-- sql --
+SELECT * FROM `otel_logs` WHERE (position(`Body`, ?) = 0)

--- a/test/spec/chsql/filter_line_regex_literal_prefilter.txtar
+++ b/test/spec/chsql/filter_line_regex_literal_prefilter.txtar
@@ -1,0 +1,9 @@
+-- args --
+[0] string = "%connection%"
+[1] string = "%reset%"
+[2] string = "connection reset"
+-- chplan --
+Filter predicate=lineContent(Body, "connection reset", regex)
+  Scan(otel_logs)
+-- sql --
+SELECT * FROM `otel_logs` WHERE (lower(`Body`) LIKE ? AND lower(`Body`) LIKE ? AND match(`Body`, ?))

--- a/test/spec/chsql/filter_line_regex_metachar_prefilter_inert.txtar
+++ b/test/spec/chsql/filter_line_regex_metachar_prefilter_inert.txtar
@@ -1,0 +1,7 @@
+-- args --
+[0] string = "failed: \\w+"
+-- chplan --
+Filter predicate=lineContent(Body, "failed: \\w+", regex)
+  Scan(otel_logs)
+-- sql --
+SELECT * FROM `otel_logs` WHERE match(`Body`, ?)


### PR DESCRIPTION
<!--
PR title: Conventional Commits subject (e.g. `feat(promql): support offset modifier`).
commitlint runs on the PR commits + the squash-merge subject.
-->

## Summary

Closes #2773

- The fork template's text-index branch (`HasFullTextSearch`) was pinned permanently off; the connected floor (26.2, verified below) is well under production's 26.6.1. `internal/schema/ddl.Config.TextIndexEnabled` now threads a real chopt verdict (`full_text_index`) instead of a hard-coded `false`.
- LogQL's `|=`/`|~` line filters emit `position(Body, ?) > 0` / `match(Body, ?)` against the raw, case-sensitive `Body` column — a shape neither the legacy tokenbf index nor a new text index (both defined over `lower(Body)`) can serve. A second chopt feature, `text_index_line_filter`, now prepends an ANDed per-token `lower(Body) LIKE '%tok%'` strict-superset prefilter ahead of the SAME, unchanged, always-kept row predicate — a skip-index hint, never a replacement.
- Both features are independently opt-in (`AutoSelect: false`), gated on real, live-probed version floors, and byte-identical to today when disabled — the established chopt/schemaboot posture for a new, unmeasured-at-scale floor (mirrors `column_statistics` / `trace_id_projection`).

## What changed

**DDL half** (`internal/schema/ddl`, `internal/schemaboot`, `internal/chopt`, `cmd/cerberus`):
- `full_text_index` (floor **26.2**) flips `HasFullTextSearch` on `renderLogsTable`'s CREATE branch — the upstream template's own mutually-exclusive `idx_lower_body` branch (`tokenbf_v1` vs `TYPE text(tokenizer='splitByNonAlpha')`), so a fresh table gets the text index directly.
- On an **existing** table (already carrying the tokenbf branch), `renderAddBodyTextIndex` installs a SEPARATELY-named, additive `idx_body_text` via idempotent `ADD INDEX IF NOT EXISTS` — `ADD INDEX IF NOT EXISTS idx_lower_body` against a table that already has that name would silently no-op (ClickHouse matches on name, not type), and swapping a live index's type needs a destructive `DROP` + `ADD` this render-time-only package cannot safely gate (no live `system.data_skipping_indexes` read to tell if it's already the text type). Retiring the now-redundant legacy `idx_lower_body` is filed as a follow-up (#2839) rather than bundled here — dropping a live index unilaterally on every boot is a production-cluster risk.
- Threaded through `schemaboot.DDLConfig` / `cmd/cerberus`'s boot resolver exactly like `column_statistics` / `trace_id_projection` (`chopt.ExplicitlyRequested` fallback for the offline `migrate schema` preview).

**Predicate half** (`internal/chsql`, `internal/chplan`, `internal/logql`, `internal/api/loki`):
- `chplan.LineContent.TextIndexPrefilter` (set by the lowerer only when `text_index_line_filter` is enabled AND the filter is non-negated — a superset prefilter has no sound dual for `!=`/`!~`) drives `exprLineContent`'s rewrite.
- Regex (`|~`) is rewritten ONLY when the pattern round-trips through `regexp/syntax` (RE2 — the same engine ClickHouse's `match()` runs) as a single `OpLiteral`, i.e. a regex only in name. Any real RE2 structure (alternation, anchors, classes, quantifiers) is left byte-identical to today — this does not attempt partial literal-prefix extraction from arbitrary RE2 ASTs.
- Tokens are whitespace-split words >= 4 runes (matching ClickHouse's own `text_index_like_min_pattern_length` default), ASCII-lowered (`lower()` is ASCII-only in ClickHouse — confirmed live: `lower('CAFÉ')` → `cafÉ`; using Go's Unicode-aware `strings.ToLower` would silently break the superset guarantee on non-ASCII content), and LIKE-escaped (`\`, `%`, `_` — a real bug class: an unescaped `_` in a literal word like `user_id` reads as a LIKE wildcard).
- `LowerOpts`/`LowerAtRangeOpts` (mirroring `internal/promql`) thread the resolved verdict from `cmd/cerberus`'s `optSet` straight into `loki.Handler.TextIndexLineFilter` — read the same way `join_spill` / `trace_id_bitmap_filter` are (no `cfg.` back-fill needed; this isn't a DDL field).

## Version floors — live-verified, not assumed

Probed directly against real ClickHouse containers (26.1.12, 26.2.19, 26.4.5 — freshly pulled — and the pre-existing 26.6.3.62), not read off changelogs alone:

- **26.2 is the real GA floor for the text index**, not merely its earliest availability: `enable_full_text_index` defaults to `0` on 26.1.12 (usable only with an explicit opt-in setting) and `1` on 26.2.19.
- **26.4 is the real floor for LIKE-via-text-index**: `system.settings` carries zero `%text_index_like%` rows on 26.2.19, three (`use_text_index_like_evaluation_by_dictionary_scan`, `text_index_like_min_pattern_length=4`, `text_index_like_max_postings_to_read=50`) on 26.4.5.
- **The predicate MUST reference the exact indexed expression.** `idx_lower_body` is defined over `lower(Body)` — a predicate against raw `Body` (`match(Body, …)`, `Body LIKE …`) gets ZERO index pruning; only `lower(Body)`-referencing predicates do. This is why the prefilter conjuncts wrap `Source` in `lower(...)` while the row predicate stays on the original `Body`.
- **26.6 "extras" from the issue — re-verified, not assumed:** `multiSearchAny` inside the skip-index analyzer produced NO index entry at all on a live 26.6.3.62 (full scan; `hasAnyTokens`/`hasAllTokens`/`hasToken`/LIKE-via-dictionary-scan all pruned correctly on the same data) — **refuted**, not merely unverified, on the probed build; not relied on. `use_text_index_postings_cache` exists on 26.6.3.62 (default off) but is unbenchmarked; not relied on. Follow-up: #2838.

## Correctness

- `TestTextIndexLineFilterPrefilter_ResultEquivalence_ChDB` (real chDB execution, not just "looks right"): the prefiltered and unprefiltered forms return IDENTICAL row sets for a plain multi-word `|=` literal, a pure-literal regex, and a literal containing `%`/`_` (the dedicated escaping case).
- `TestTextIndexLineFilterPrefilter_PrunesGranules_ChDB`: `EXPLAIN indexes=1` over the real DDL-rendered `idx_lower_body`/`idx_body_text` shape shows the unprefiltered form reading every granule and the prefiltered form reading only the matching ones (87% pruned at 5M synthetic rows).
- New `test/spec/chsql/filter_line_*_prefilter*.txtar` fixtures pin the exact emitted SQL shape for: plain literal, negated (inert), pure-literal regex, metachar regex (inert), LIKE-escaping, and an all-short-tokens literal (inert — no conjunct clears the 4-rune floor).
- `internal/schema/ddl` gets render-layer tests mirroring `TestRenderSignal_TraceIDProjectionEnabled`'s pattern: byte-identical DDL when disabled, exact SQL when enabled, scoped correctly to Logs only.
- `internal/logql` gets a threading test (`LowerOpts.TextIndexLineFilter` → `chplan.LineContent.TextIndexPrefilter`) plus an explicit negation-inert test.

## Performance — measured, not asserted

**A real methodological trap worth flagging for future perf work in this repo:** ClickHouse's query condition cache (`use_query_condition_cache`, cerberus's OWN already-shipped, auto-enabled `chopt.FeatureConditionCache`) remembers per-granule WHERE verdicts across repeated executions of the SAME predicate — completely independent of this PR's text index. Left enabled, a naive before/after benchmark that runs the same query more than once measures the condition cache's effect for BOTH forms, drowning out the text index's own contribution (this is exactly what happened on the first benchmarking pass — no visible improvement, sometimes a slight regression, purely from a warm cache). Every number below is measured with `use_query_condition_cache=0`, isolating the actual mechanism this PR adds — the realistic "first time a user searches for this literal" cold-start path ad-hoc LogQL search overwhelmingly is.

- **Real ClickHouse 26.6.3.62, disk-backed, 10M rows / ~889 MiB, OPTIMIZE-consolidated, caches dropped (mark/uncompressed/filesystem/condition):** granule pruning 400/1221 (67%); wall-clock best-of-5, mixed-case multi-word literal: **before ≈0.97s → after ≈0.36s (≈2.7x)**.
- **chDB (embedded, in-process), 5M rows, `SELECT *` (the actual production row shape, not just `count()`):** granule pruning 2500/19533 (87%); wall-clock best-of-15: before ≈721.8ms → after ≈336.2ms (≈2.15x). At smaller synthetic scales (500K rows) chDB showed no clear win at all (occasionally a slight regression from the added LIKE-evaluation cost) — the mechanism's benefit is genuinely I/O-bound and scale-dependent, which is exactly why both `full_text_index` and `text_index_line_filter` ship `AutoSelect: false`.
- **Tokenbf fallback is byte-identical below either floor or with the features disabled** — proven structurally (render-layer + emit-layer tests), not just claimed: `TextIndexEnabled`/`TextIndexPrefilter` are additive flags, every existing test in `internal/schema/ddl` and `internal/chsql` that doesn't set them continues to pass unmodified.
- **No regression on non-eligible shapes**: negated filters, regex with real RE2 structure, and all-short-token literals all render byte-identical to today (pinned by dedicated `_inert` fixtures).

## Out of scope (filed, not silently dropped)

- #2837 — the lazy posting-list apply mode (`text_index_posting_list_apply_mode=lazy`, ClickHouse's own default only from 26.8) is explicitly excluded from this PR's scope, per the issue.
- #2838 — the 26.6 `multiSearchAny`/postings-cache claims need re-verification on a different build; #2773's finding here is that `multiSearchAny` is refuted on 26.6.3.62 specifically.
- #2839 — retiring the legacy `idx_lower_body` tokenbf index on upgraded existing tables (real write-path cost, real production-cluster risk to automate away unilaterally).

## Test plan

- [x] `just fmt` clean (gofumpt/goimports — no diff)
- [x] `go build ./...`, `go vet ./...` clean
- [x] `go test -race ./internal/... ./cmd/...` passes
- [x] `go test -tags chdb ./internal/chsql/... -run TestTextIndexLineFilterPrefilter` passes (result-equivalence + granule-pruning + latency)
- [x] `just update-golden migration parity solver promql logql traceql chsql optimizer codegen cardinality` — clean, only the intended new `test/spec/chsql/*prefilter*.txtar` fixtures + their cardinality-baseline entries appear in the diff
- [x] `node .github/scripts/forbid-sql-raw.mjs` clean
- New TXTAR fixtures reviewed: `test/spec/chsql/filter_line_contains_prefilter{,_all_short,_escaping}.txtar`, `filter_line_not_contains_prefilter_inert.txtar`, `filter_line_regex_{literal,metachar}_prefilter{,_inert}.txtar`
- [ ] CI green

## Notes for reviewers

- `AutoSelect: false` on both features is a deliberate, evidence-based choice, not a default placeholder: the measured latency win is real but scale/I-O-profile dependent (see Performance section), and the DDL half's backfill/maintenance cost on existing large tables is unmeasured at production volume — exactly the posture `column_statistics` / `trace_id_projection` already established for their own new floors.
- The two features are independently listed in `CERBERUS_CH_OPTIMIZATIONS` (`full_text_index`, `text_index_line_filter`) but the predicate rewrite is INERT without the DDL feature actually applied and backfilled — documented on both registry entries and in `docs/operations.md`.
