### PR TITLE
feat(actuals,chclient,engine,solver): query-actuals drift detection (#2789)

### DIFF
--- a/.go-arch-lint.yml
+++ b/.go-arch-lint.yml
@@ -126,6 +126,16 @@ components:
   # only chplan (to build the Key) and the standard library. Importable by
   # engine (which classifies dispatch outcomes through it) and cmd only.
   routememo: { in: routememo }
+  # Bounded predicted-vs-actual drift tracker for query resource usage
+  # (issue #2789): records EXPLAIN ESTIMATE's advisory row prediction per
+  # plan-shape id and the REAL read_rows/read_bytes/peak-memory a dispatch
+  # actually consumed (native-protocol progress/ProfileEvents packets, or
+  # system.query_log as the batch fallback), and reports a bounded
+  # calibration factor plus a drift-alert verdict. Pure leaf — stdlib only
+  # (no chplan: it is keyed by the ALREADY-computed literal-free shape-id
+  # string, not a plan tree) — so it is importable by chclient (the packet
+  # capture site), engine (the query_log fallback + every consumer) and cmd.
+  actuals:   { in: actuals }
   config:    { in: config }
   api-loki:  { in: api/loki }
   api-prom:  { in: api/prom }
@@ -281,6 +291,16 @@ deps:
     mayDependOn:
       - chplan
 
+  # actuals is a true leaf (stdlib only) — no entry needed here (see the
+  # chplan comment above for why an omitted entry is correct, not an
+  # oversight). chclient depends on it to feed the native-protocol packet
+  # capture site (internal/chclient/progress.go); engine depends on it for
+  # every consumer (calibration, route-memo magnitude, per-rung admission,
+  # the query_log fallback reconciler, and the drift alert itself).
+  chclient:
+    mayDependOn:
+      - actuals
+
   # QL layers parse upstream syntax and lower to chplan. The LogQL
   # adapter has migrated to the engine.Lang interface, so it depends
   # on `engine` for the typed contracts (engine.Meta etc); promql and
@@ -380,6 +400,7 @@ deps:
       - optimizer
       - solver
       - routememo
+      - actuals
 
   # solver is the sharded-pushdown query-solver framework (off by
   # default — Mode="single"). The Planner/Slicer classify + re-anchor

--- a/cmd/cerberus/cmd_configdocs.go
+++ b/cmd/cerberus/cmd_configdocs.go
@@ -458,6 +458,44 @@ All six reject a malformed or non-positive override at startup rather than
 silently falling back to the default or admitting every query; see each
 constant's own doc for the calibration its shipped default protects.
 
+The query-actuals predicted-vs-actual drift tracker (issue #2789) is
+likewise resolved by ` + "`internal/actuals`" + ` rather than the loader documented
+above (` + "`internal/actuals/config_env.go`" + `) - the same "kept in its own package
+to avoid an import cycle" reasoning ` + "`CERBERUS_SOLVER_*`" + ` uses above. It is a
+plain solver-policy config knob, **not** a ` + "`CERBERUS_CH_OPTIMIZATIONS`" + ` chopt
+feature: ProfileEvents on the native protocol and ` + "`system.query_log`" + ` are
+both ancient, always-available ClickHouse surfaces with no version floor to
+probe. ` + "`CERBERUS_QUERY_ACTUALS_ENABLED`" + ` is the master switch (default
+` + "`false`" + ` - the feature ships dark); every other knob below is inert while it
+is unset:
+
+- **` + "`CERBERUS_QUERY_ACTUALS_ENABLED`" + `** (bool, default ` + "`false`" + `) - master
+  switch. Records EXPLAIN ESTIMATE / cardinality-probe predictions against
+  the REAL read_rows/read_bytes/peak-memory a dispatch actually consumed
+  (native-protocol progress/ProfileEvents packets, or ` + "`system.query_log`" + ` as
+  the batch fallback), and alerts when a plan shape's predicted-vs-actual
+  ratio drifts beyond ` + "`CERBERUS_QUERY_ACTUALS_DRIFT_LOWER_RATIO`" + ` /
+  ` + "`_UPPER_RATIO`" + ` - see [` + "`solver.md`" + `](solver.md) for the full mechanism.
+  Prom-only: the feature keys off the solver's own plan-shape-id / K-clamp
+  machinery.
+- **` + "`CERBERUS_QUERY_ACTUALS_DRIFT_LOWER_RATIO`" + `** / **` + "`_UPPER_RATIO`" + `** (float,
+  default ` + "`0.1`" + ` / ` + "`3.0`" + `) - the "expected" band for actual-EMA/predicted.
+  EXPLAIN ESTIMATE is a granule-resolution UPPER BOUND, so the band is
+  deliberately asymmetric around 1.0 rather than a symmetric +/-X%.
+- **` + "`CERBERUS_QUERY_ACTUALS_MIN_OBSERVATIONS`" + `** (int, default ` + "`2`" + `) - the
+  corroboration floor before a shape's drift verdict is trusted at all.
+- **` + "`CERBERUS_QUERY_ACTUALS_EMA_ALPHA`" + `** (float, default ` + "`0.2`" + `) - the bounded
+  exponential-moving-average smoothing factor for the tracked actual-rows
+  side; caps how far a single anomalous observation can move it.
+- **` + "`CERBERUS_QUERY_ACTUALS_ENTRY_TTL`" + `** (duration, default ` + "`30m`" + `) - how long
+  a shape's tracked state is trusted before it ages out.
+- **` + "`CERBERUS_QUERY_ACTUALS_QUERY_LOG_POLL_INTERVAL`" + `** (duration, default
+  ` + "`60s`" + `) - how often the ` + "`system.query_log`" + ` batch/fallback reconciler polls.
+- **` + "`CERBERUS_QUERY_ACTUALS_QUERY_LOG_LOOKBACK`" + `** (duration, default ` + "`180s`" + `)
+  - the overlap margin the reconciler's first poll (and any recovery poll)
+  looks back by, sized well above the poll interval so a slow query_log
+  flush never drops a row between two polls.
+
 ## Dependency matrix
 
 Most knobs are validated in isolation (unknown enum, out-of-range buffer,

--- a/cmd/cerberus/main.go
+++ b/cmd/cerberus/main.go
@@ -22,6 +22,7 @@ import (
 	"golang.org/x/sync/semaphore"
 	"google.golang.org/grpc"
 
+	"github.com/tsouza/cerberus/internal/actuals"
 	"github.com/tsouza/cerberus/internal/api/admit"
 	"github.com/tsouza/cerberus/internal/api/health"
 	"github.com/tsouza/cerberus/internal/api/info"
@@ -201,7 +202,18 @@ func mountAPIHeads(
 		if err != nil {
 			return apiHeads{}, fmt.Errorf("configure solver: %w", err)
 		}
-		promHandler = newPromHandler(promClient, cfg, optSet, evalSolver, limiters.prom, logger, resourceBounds, promResourceBounds)
+		// Issue #2789: same fail-fast contract as buildSolver's own
+		// solver.ConfigFromEnv() above — a malformed CERBERUS_QUERY_ACTUALS_*
+		// knob refuses to boot rather than silently running on an unintended
+		// value. Prom-only, mirroring evalSolver/RouteMemo/PerRungAdmission's
+		// own scope: the actuals hooks all key off the solver's own
+		// plan-shape-id / K-clamp machinery, which is PromQL-only
+		// (solver.RequestMeta.Lang's own doc).
+		actualsTracker, err := buildActualsTracker(ctx, logger, promClient)
+		if err != nil {
+			return apiHeads{}, fmt.Errorf("configure query actuals: %w", err)
+		}
+		promHandler = newPromHandler(promClient, cfg, optSet, evalSolver, limiters.prom, logger, resourceBounds, promResourceBounds, actualsTracker)
 		promHandler.Mount(traceMux)
 		engines = append(engines, promHandler.Engine)
 	}
@@ -762,7 +774,11 @@ const gracefulShutdownTimeout = 10 * time.Second
 // chplan.RangeWindow for rate()/increase()/etc — and independently onto the
 // Loki head below, since LogQL's own range aggregations lower to the same
 // node kind.
-func newPromHandler(client *chclient.Client, cfg config.Config, optSet chopt.EnabledSet, evalSolver *solver.Solver, limiter *admit.Limiter, logger *slog.Logger, resourceBounds engine.ResourceBoundOverrides, promResourceBounds promql.ResourceBounds) *prom.Handler {
+func newPromHandler(
+	client *chclient.Client, cfg config.Config, optSet chopt.EnabledSet, evalSolver *solver.Solver,
+	limiter *admit.Limiter, logger *slog.Logger, resourceBounds engine.ResourceBoundOverrides,
+	promResourceBounds promql.ResourceBounds, actualsTracker *actuals.Tracker,
+) *prom.Handler {
 	h := prom.New(client, cfg.Schema, logger.With("api", "prom"))
 	h.ResourceBounds = promResourceBounds
 	// Constructed once and threaded into BOTH Engine fields below —
@@ -779,6 +795,12 @@ func newPromHandler(client *chclient.Client, cfg config.Config, optSet chopt.Ena
 		PerRungAdmission:        perRungAdmission,
 		ScanEstimateAdvisor:     buildScanEstimateAdvisor(client, optSet, evalSolver, perRungAdmission),
 		CardinalityProbeAdvisor: buildCardinalityProbeAdvisor(client, optSet, evalSolver, perRungAdmission),
+		// The OPTIONAL predicted-vs-actual drift tracker (issue #2789),
+		// gated on CERBERUS_QUERY_ACTUALS_ENABLED (mountAPIHeads's own
+		// wiring) rather than a chopt feature — see actuals.Config.Enabled's
+		// own doc for why. nil (the default) leaves every hook in
+		// internal/engine/actuals_wiring.go inert.
+		Actuals: actualsTracker,
 		// PromQL-only: TraceQL / LogQL plans never carry a
 		// chplan.RangeWindow.TemporalityColumn (the OTel Sum
 		// AggregationTemporality concept), so this is inert for the other
@@ -925,6 +947,73 @@ func buildCardinalityProbeAdvisor(
 		return nil
 	}
 	return engine.NewCardinalityProbeAdvisor(client, perRungAdmission)
+}
+
+// buildActualsTracker wires issue #2789's predicted-vs-actual drift tracker
+// (internal/actuals), gated on CERBERUS_QUERY_ACTUALS_ENABLED — a plain
+// solver-policy config knob, NOT a chopt feature (actuals.Config.Enabled's
+// own doc explains why: ProfileEvents on the native protocol and
+// system.query_log are both ancient, always-available ClickHouse surfaces
+// with no version floor to probe). Returns (nil, nil) — the engine's
+// byte-unchanged, feature-off default — when the operator has not opted in;
+// returns a non-nil error only on a malformed CERBERUS_QUERY_ACTUALS_* env
+// var, the same fail-fast contract buildSolver's own solver.ConfigFromEnv()
+// uses.
+//
+// When enabled, this ALSO starts the query_log fallback reconciler
+// (query_log_actuals.go) on its own goroutine, bound to ctx — mirroring
+// startOptCorpus's own goroutine-launch-and-log shape, independently
+// implemented (see query_log_actuals.go's own doc for why this package
+// cannot import internal/optcorpus).
+func buildActualsTracker(ctx context.Context, logger *slog.Logger, promClient *chclient.Client) (*actuals.Tracker, error) {
+	cfg, err := actuals.ConfigFromEnv()
+	if err != nil {
+		return nil, err
+	}
+	if err := cfg.Validate(); err != nil {
+		return nil, err
+	}
+	if !cfg.Enabled {
+		return nil, nil
+	}
+	tracker := actuals.NewTracker(cfg)
+	rec := engine.NewQueryLogActualsReconciler(queryLogQuerierAdapter{promClient}, tracker, cfg, logger.With("component", "query_actuals"))
+	go rec.Run(ctx)
+	logger.Info(
+		"query actuals predicted-vs-actual drift tracker started",
+		"query_log_poll_interval", cfg.QueryLogPollInterval.String(),
+		"drift_band", fmt.Sprintf("[%g, %g]", cfg.DriftLowerRatio, cfg.DriftUpperRatio),
+	)
+	return tracker, nil
+}
+
+// queryLogQuerierAdapter adapts *chclient.Client to engine.QueryLogQuerier.
+// The two QueryLogActualRow types (chclient's transport type,
+// engine.QueryLogActualRow's package-local stand-in — see that type's own
+// doc) are field-for-field identical; this is the one-line conversion that
+// doc promises, kept here rather than in internal/engine so that package
+// depends only on its own narrow interface, never chclient's concrete type
+// (mirrors every other Estimator-style seam in this codebase).
+type queryLogQuerierAdapter struct {
+	client *chclient.Client
+}
+
+func (a queryLogQuerierAdapter) QueryLogActuals(ctx context.Context, since time.Time, shapeIDPrefix string, limit int) ([]engine.QueryLogActualRow, error) {
+	rows, err := a.client.QueryLogActuals(ctx, since, shapeIDPrefix, limit)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]engine.QueryLogActualRow, len(rows))
+	for i, r := range rows {
+		out[i] = engine.QueryLogActualRow{
+			LogComment:  r.LogComment,
+			ReadRows:    r.ReadRows,
+			ReadBytes:   r.ReadBytes,
+			MemoryUsage: r.MemoryUsage,
+			EventTime:   r.EventTime,
+		}
+	}
+	return out, nil
 }
 
 // nativeRangeLowerers builds the BOOT-WIRED polymorphic lowering dispatch table

--- a/cmd/cerberus/prom_metadata_lookback_test.go
+++ b/cmd/cerberus/prom_metadata_lookback_test.go
@@ -51,7 +51,7 @@ func newPromHandlerForTest(t *testing.T) *promHandlerUnderTest {
 
 	logger := slog.New(slog.NewTextHandler(httptestDiscard{}, &slog.HandlerOptions{Level: slog.LevelError}))
 	limiters := newAdmitLimiters(cfg, logger)
-	h := newPromHandler(client, cfg, chopt.EnabledSet{}, nil, limiters.prom, logger, engine.ResourceBoundOverrides{}, promql.ResourceBounds{})
+	h := newPromHandler(client, cfg, chopt.EnabledSet{}, nil, limiters.prom, logger, engine.ResourceBoundOverrides{}, promql.ResourceBounds{}, nil)
 	return &promHandlerUnderTest{cfg: cfg, lookback: h.MetadataLookback}
 }
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -488,6 +488,44 @@ All six reject a malformed or non-positive override at startup rather than
 silently falling back to the default or admitting every query; see each
 constant's own doc for the calibration its shipped default protects.
 
+The query-actuals predicted-vs-actual drift tracker (issue #2789) is
+likewise resolved by `internal/actuals` rather than the loader documented
+above (`internal/actuals/config_env.go`) - the same "kept in its own package
+to avoid an import cycle" reasoning `CERBERUS_SOLVER_*` uses above. It is a
+plain solver-policy config knob, **not** a `CERBERUS_CH_OPTIMIZATIONS` chopt
+feature: ProfileEvents on the native protocol and `system.query_log` are
+both ancient, always-available ClickHouse surfaces with no version floor to
+probe. `CERBERUS_QUERY_ACTUALS_ENABLED` is the master switch (default
+`false` - the feature ships dark); every other knob below is inert while it
+is unset:
+
+- **`CERBERUS_QUERY_ACTUALS_ENABLED`** (bool, default `false`) - master
+  switch. Records EXPLAIN ESTIMATE / cardinality-probe predictions against
+  the REAL read_rows/read_bytes/peak-memory a dispatch actually consumed
+  (native-protocol progress/ProfileEvents packets, or `system.query_log` as
+  the batch fallback), and alerts when a plan shape's predicted-vs-actual
+  ratio drifts beyond `CERBERUS_QUERY_ACTUALS_DRIFT_LOWER_RATIO` /
+  `_UPPER_RATIO` - see [`solver.md`](solver.md) for the full mechanism.
+  Prom-only: the feature keys off the solver's own plan-shape-id / K-clamp
+  machinery.
+- **`CERBERUS_QUERY_ACTUALS_DRIFT_LOWER_RATIO`** / **`_UPPER_RATIO`** (float,
+  default `0.1` / `3.0`) - the "expected" band for actual-EMA/predicted.
+  EXPLAIN ESTIMATE is a granule-resolution UPPER BOUND, so the band is
+  deliberately asymmetric around 1.0 rather than a symmetric +/-X%.
+- **`CERBERUS_QUERY_ACTUALS_MIN_OBSERVATIONS`** (int, default `2`) - the
+  corroboration floor before a shape's drift verdict is trusted at all.
+- **`CERBERUS_QUERY_ACTUALS_EMA_ALPHA`** (float, default `0.2`) - the bounded
+  exponential-moving-average smoothing factor for the tracked actual-rows
+  side; caps how far a single anomalous observation can move it.
+- **`CERBERUS_QUERY_ACTUALS_ENTRY_TTL`** (duration, default `30m`) - how long
+  a shape's tracked state is trusted before it ages out.
+- **`CERBERUS_QUERY_ACTUALS_QUERY_LOG_POLL_INTERVAL`** (duration, default
+  `60s`) - how often the `system.query_log` batch/fallback reconciler polls.
+- **`CERBERUS_QUERY_ACTUALS_QUERY_LOG_LOOKBACK`** (duration, default `180s`)
+  - the overlap margin the reconciler's first poll (and any recovery poll)
+  looks back by, sized well above the poll interval so a slow query_log
+  flush never drops a row between two polls.
+
 ## Dependency matrix
 
 Most knobs are validated in isolation (unknown enum, out-of-range buffer,

--- a/docs/solver.md
+++ b/docs/solver.md
@@ -959,6 +959,151 @@ fixed Go constants pending real-world calibration evidence, mirroring
 `per_rung_admission.go`'s own unexported constants (`perRungCheapRowsPerAnchor`
 et al.) rather than growing a `Config` surface ahead of that evidence.
 
+## Query actuals: predicted-vs-actual drift detection (issue #2789)
+
+Both advisory pre-flight signals above — `EXPLAIN ESTIMATE` and the
+cardinality pre-probe — predict a plan's scan cost BEFORE dispatch and are
+never checked against what the query actually consumed. `internal/actuals`
+closes that loop: a bounded, in-process `Tracker`, keyed by the SAME
+literal-free plan-shape id `SettingsRules` stamps into ClickHouse's
+`log_comment` (`internal/engine/plan_shape_id.go`), records the most recent
+advisory prediction and a bounded exponential moving average of the REAL
+resource usage a dispatch of that shape actually consumed.
+
+**Not a chopt registry entry.** ProfileEvents on the native protocol and
+`system.query_log` are both ancient, always-available ClickHouse surfaces
+with no version floor to probe — this is a plain solver-policy config knob
+(`CERBERUS_QUERY_ACTUALS_ENABLED`, default `false`), mirroring
+`CERBERUS_SOLVER_ADAPTIVE_ENABLED`'s own posture rather than
+`CERBERUS_CH_OPTIMIZATIONS`'s AutoSelect/version-floor machinery.
+
+**Anti-autotune stance**, inherited from the cardinality pre-probe's own
+precedent above: the tracker is a bounded, ADVISORY input to existing
+policies, never a new fitting loop. Every EMA update moves at most
+`EMAAlpha` (default 0.2) of the way toward a single new observation, and
+`CalibrationFactor` clamps its output to `[0.5, 2.0]` — a burst of
+anomalous actuals can shift a shape's tracked state gradually, never
+violently in one request. This is the same boundary the retired
+threshold-fitting autotune (issue #1273) crossed and cerberus does not
+repeat.
+
+### Two capture sources
+
+1. **Native-protocol packets** (`internal/chclient/progress.go`, the FAST
+   path) — free, since the production deployment's driver already streams
+   both `Progress` (rows/bytes) and `ProfileEvents` packets for every
+   query; cerberus previously parsed only the former.
+   `MemoryTrackerPeakUsage`, a real ClickHouse `ProfileEvents` counter
+   (verified against a live ClickHouse 26.6 server; not documented on
+   ClickHouse's own reference, only in `system.query_log`'s column docs),
+   supplies peak memory. Registering the `WithProfileEvents` callback adds
+   no extra round trip — only the (already-flowing) packet's parse cost —
+   so it is wired ONLY when the actuals feature is on (`WithActualsCapture`),
+   never unconditionally.
+2. **`system.query_log`** (`internal/engine/query_log_actuals.go`, the SLOW
+   batch/fallback path) — a background reconciler polls for
+   `log_comment LIKE 'cerb:%'` `QueryFinish` rows, for the dispatches the
+   packet path could not observe (one that failed before completing, or a
+   deployment mode where packet capture is not wired). Genuinely slow by
+   construction: `system.query_log`'s own async flush lag means a row
+   surfaces well after the query that produced it finished, so the
+   reconciler is watermark-based (retries from the same point on a query
+   failure, never advances past unread rows) rather than assumed
+   synchronous.
+
+`log_comment` is stamped onto every dispatch the actuals feature covers
+REGARDLESS of `SettingsRules.LogCommentShape` — that flag governs a
+separate, purely-observability concern (an operator manually clustering
+`system.query_log` by hand); actuals capture needs the correlation key
+whether or not the operator separately opted into it.
+
+### Four consumers
+
+1. **Drift-detection core** (the issue's primary ask): every `RecordActual`
+   call computes `actualEMA / predicted` and flags the shape ALERTING once
+   `MinObservations` (default 2) is reached and the ratio falls outside
+   `[DriftLowerRatio, DriftUpperRatio]` (default `[0.1, 3.0]` — deliberately
+   asymmetric: `EXPLAIN ESTIMATE` is a granule-resolution UPPER BOUND, so
+   the actual is EXPECTED to run well below the prediction most of the
+   time; the dangerous direction is the actual EXCEEDING it). Every
+   observation — alerting or not — is recorded on the
+   `cerberus_solver_estimate_drift_ratio` histogram and
+   `cerberus_solver_estimate_drift_alerts_total` counter (attribute
+   `cerberus.actuals_source`, `"packet"` / `"query_log"`), so an operator
+   graphs `rate(cerberus_solver_estimate_drift_alerts_total[5m])` rather
+   than polling the tracker out of process.
+2. **Carrier-geometry cost-model calibration** (`internal/engine/actuals_wiring.go`'s
+   `calibrateEstimate`): before an advisory `solver.ScanEstimate` reaches
+   the K clamp, its `Rows` field is multiplied by the shape's own bounded
+   `CalibrationFactor` — a real correction to `classify()`'s existing
+   `EstimateNearEmptyRowFloor` / `MaxKWithEstimate` arithmetic, not a new
+   threshold.
+3. **Per-rung admission tightening** (`maybeSeedPerRungAdmissionFromActuals`):
+   reuses `PerRungAdmissionLearner.SeedPriorFromEstimate` — the SAME
+   one-directional (`cheap=true` only) seeding mechanism issue #2787's own
+   `maybeSeedPerRungPrior` uses for a live `EXPLAIN ESTIMATE` round trip —
+   applied to a ZERO-I/O read of a shape's tracked actuals instead. Same
+   safety argument as that mechanism's own doc: it can only ever DOWNGRADE
+   an already-`PerRungPredictive` route, never promote or block one.
+4. **Route-memo priors with real magnitudes** (`internal/routememo/magnitude.go`,
+   `RecordActualMagnitude` / `MagnitudeFor`): a deliberately THIN hook —
+   see "Why the failure-driven route memo is NOT seeded" above for why the
+   memo's routing VERDICT is never touched by an advisory or actuals
+   signal. This hook adds a second, purely OBSERVATIONAL axis on top of an
+   ALREADY-LIVE verdict (it never creates, deletes, or changes
+   `LookupState`, eviction order, or TTL) — wired from
+   `per_rung_admission.go`'s existing `perRungObservingCursor.Close()`,
+   which already computes the identical `routememo.Key` for a per-rung
+   predictive route-B dispatch's own clean drain. Architecture the memo
+   supports for a future routing use; this landing makes no routing
+   decision from it.
+
+### Verified against a live server, not assumed
+
+`system.query_log`'s column shape was checked against a live ClickHouse
+26.6 server before relying on it (the same discipline issue #2789's own
+risk note calls out — issue #2770's Loki catalog PR caught a real bug from
+an unverified assumption about `system.view_refreshes`'s columns):
+`log_comment` is `String`, `read_rows`/`read_bytes`/`memory_usage` are all
+`UInt64`, `event_time` is `DateTime`, `type` is the expected
+`Enum8('QueryStart'=1,'QueryFinish'=2,...)` — exactly as expected.
+
+A realistic drift scenario was also reproduced live, rather than
+constructed synthetically: `EXPLAIN ESTIMATE` was run against a MergeTree
+table holding 1,000 rows (`Rows: 1000`, the "cached admission-time
+estimate" `ScanEstimateAdvisor`'s own 30-minute TTL would hold); 1,000,000
+more matching rows were then inserted (a realistic traffic burst landing
+between the cached estimate and the real dispatch); the identical query
+was dispatched for real and `system.query_log` reported
+`read_rows = 1,001,000` for it — a **1001x** predicted-vs-actual ratio, far
+outside the default `[0.1, 3.0]` band. Replayed through the real
+`internal/actuals.Tracker` (two corroborating observations, reaching
+`MinObservations`): `DriftReport.Alerting = true`, and
+`CalibrationFactor` correctly clamped to its `2.0` ceiling rather than
+propagating the raw 1001x multiplier — proving the bounded-influence
+property holds even on a genuine, large real-world divergence, not only on
+a small synthetic one.
+
+A second, cleaner comparison — `EXPLAIN ESTIMATE` vs. real `read_rows` for
+the SAME query against a STABLE (non-growing) table, no `PREWHERE`, no
+skip index — landed within noise of each other (8,192 predicted vs. 8,192
+actual on a `minmax`-prunable `PREWHERE` range; 5,000,000 vs. 5,000,000 on
+a full-table `PREWHERE` scan), confirming the mechanism does NOT
+false-alarm on the common case where nothing has actually drifted: the two
+independent probes (`EXPLAIN ESTIMATE`'s no-execution index analysis and a
+real dispatch's own storage-layer read) agree closely when the underlying
+data is stable between them. The dominant real driver of drift this
+sandbox reproduces is TEMPORAL — a cached advisory estimate going stale
+relative to data that grew after it was taken — rather than a structural
+`PREWHERE`/skip-index mismatch in row-count terms specifically; both are
+covered by the SAME mechanism regardless of which one produced the
+divergence.
+
+### Configuration
+
+See [`configuration.md`](configuration.md#schema-overrides-and-prometheus-resource-labels)
+for the full `CERBERUS_QUERY_ACTUALS_*` knob table.
+
 ## Routing-decision calibration corpus (measurement-only)
 
 The router (`Planner.Plan`) is a **pure** classifier: a query routes A (single

--- a/internal/actuals/config.go
+++ b/internal/actuals/config.go
@@ -1,0 +1,220 @@
+// Package actuals implements the bounded predicted-vs-actual drift tracker
+// for cerberus issue #2789: it closes the loop EXPLAIN ESTIMATE's pre-flight
+// advisor (issue #2787) and the cardinality pre-probe (issue #2788) leave
+// open — both predict a plan's scan cost before dispatch, and neither is
+// ever checked against what the query actually consumed. Without that check,
+// EXPLAIN ESTIMATE's marks-level bias under PREWHERE, skip indexes, and the
+// filesystem cache is invisible, and mis-admission is silent.
+//
+// A Tracker records, per literal-free plan-shape id (the SAME "cerb:..." id
+// internal/engine's SettingsRules already stamps into ClickHouse's
+// log_comment — see internal/engine/plan_shape_id.go), the most recent
+// advisory prediction and a BOUNDED exponential moving average of the real
+// resource usage actually observed for that shape. Two independent sources
+// feed the actual side: the native-protocol progress/ProfileEvents packets
+// (internal/chclient/progress.go, the fast path — free, since the
+// production deployment's driver already streams them) and
+// system.query_log (internal/engine's query-log reconciler, the slow
+// batch/fallback path for a query packet capture missed — a query that
+// failed before completing, or a deployment mode where packet capture is
+// not wired).
+//
+// Package is a pure, dependency-free leaf (stdlib only, exactly like
+// internal/routememo) so it is importable from both chclient (the packet
+// capture site, BELOW engine in the layering) and engine (every consumer)
+// without an import cycle — see .go-arch-lint.yml's own comment on this
+// component.
+//
+// Anti-autotune stance (issue #2788's own precedent, restated here because
+// this package inherits it): a Tracker is a bounded, advisory INPUT to
+// existing policies — the calibration factor it reports is clamped
+// (minCalibrationFactor/maxCalibrationFactor) and every EMA update is capped
+// per-observation influence (Config.EMAAlpha) — never a new curve-fitting
+// loop. It does not decide anything itself; it only tells an existing
+// mechanism (the K clamp, the per-rung admission learner, the route memo,
+// an operator's dashboard) that a shape's prior looks wrong. This is the
+// same anti-autotune boundary the retired threshold-fitting autotune
+// (issue #1273) crossed and cerberus does not repeat.
+package actuals
+
+import (
+	"fmt"
+	"time"
+)
+
+// Config tunes the Tracker. Every field maps to a CERBERUS_QUERY_ACTUALS_*
+// env var parsed by ConfigFromEnv (config_env.go) — kept in this package
+// rather than internal/config, mirroring internal/solver's own Config
+// (solver/config.go: "kept in this package rather than internal/config to
+// avoid an import cycle; this package owns the defaults and the
+// invariants").
+//
+// Enabled is the master kill switch (CERBERUS_QUERY_ACTUALS_ENABLED,
+// DEFAULT FALSE): this is a brand-new, unvalidated advisory layer over
+// mechanisms that already work correctly without it (the EXPLAIN ESTIMATE
+// advisor, the cardinality pre-probe, the failure-driven route memo, the
+// per-rung admission learner all remain reachable and correct with Enabled
+// false — see cmd/cerberus's wiring). It is NOT a chopt registry entry —
+// ProfileEvents on the native protocol and system.query_log are both
+// ancient, always-available ClickHouse surfaces with no version floor to
+// probe — so this is a plain solver-policy config knob, mirroring
+// solver.Config.AdaptiveEnabled's own CERBERUS_SOLVER_ADAPTIVE_ENABLED
+// pattern rather than an chopt.EnabledSet feature.
+type Config struct {
+	// Enabled is the master switch. See this type's own doc.
+	Enabled bool
+
+	// DriftLowerRatio / DriftUpperRatio (CERBERUS_QUERY_ACTUALS_DRIFT_LOWER_RATIO
+	// / CERBERUS_QUERY_ACTUALS_DRIFT_UPPER_RATIO) bound the "expected" band for
+	// actualEMA/predicted. A ratio outside [DriftLowerRatio, DriftUpperRatio]
+	// after MinObservations flags the shape as drift-alerting (see
+	// DriftReport.Alerting). EXPLAIN ESTIMATE is a granule-resolution UPPER
+	// BOUND (internal/chclient/explain_estimate.go's own doc), so the actual is
+	// EXPECTED to run below the prediction most of the time — the band is
+	// deliberately asymmetric around 1.0 rather than a symmetric +/-X%.
+	DriftLowerRatio float64
+	DriftUpperRatio float64
+
+	// MinObservations (CERBERUS_QUERY_ACTUALS_MIN_OBSERVATIONS) is the
+	// corroboration floor before a shape's drift verdict is trusted at all —
+	// mirroring internal/engine's own perRungEvidenceMinObservations /
+	// routememo's minCorroboratingFailures: a single anomalous actual must
+	// never, by itself, flip a shape's verdict. This is the anti-autotune
+	// bound on OBSERVATION COUNT; EMAAlpha below is the matching bound on
+	// per-observation INFLUENCE.
+	MinObservations int
+
+	// EMAAlpha (CERBERUS_QUERY_ACTUALS_EMA_ALPHA) is the exponential moving
+	// average's smoothing factor for the actual-rows side: each new
+	// observation moves the tracked average by at most EMAAlpha of the
+	// distance to that single sample
+	// (emaRows += EMAAlpha * (observedRows - emaRows)). Bounding this below
+	// 1.0 is what makes a burst of anomalous actuals unable to swing the
+	// tracked state violently in one shot — the issue's own "keep feedback
+	// advisory with BOUNDED influence" requirement, applied at the
+	// per-observation level.
+	EMAAlpha float64
+
+	// EntryTTL (CERBERUS_QUERY_ACTUALS_ENTRY_TTL) bounds how long a shape's
+	// tracked state is trusted before it ages out — mirroring
+	// routememo.memoEntryTTL / the per-rung admission learner's
+	// perRungEvidenceTTL: a shape's real cardinality can grow, and a verdict
+	// computed against a stale window must not silently suppress recalibration
+	// forever once that has happened.
+	EntryTTL time.Duration
+
+	// QueryLogPollInterval (CERBERUS_QUERY_ACTUALS_QUERY_LOG_POLL_INTERVAL) is
+	// how often internal/engine's QueryLogActualsReconciler polls
+	// system.query_log for the batch/fallback actuals source — mirroring
+	// optcorpus's own CERBERUS_CH_OPT_CORPUS_INTERVAL default (60s).
+	// query_log's own async flush lag (docs/operations.md) makes this
+	// inherently a slow path; the reconciler is designed for that latency, not
+	// for actuals to arrive synchronously with the query that produced them.
+	QueryLogPollInterval time.Duration
+
+	// QueryLogLookback (CERBERUS_QUERY_ACTUALS_QUERY_LOG_LOOKBACK) is how far
+	// back the FIRST poll looks before any watermark exists, and the overlap
+	// margin used if a poll ever needs to recover after an error — sized well
+	// above QueryLogPollInterval so a slow query_log flush (or one missed poll
+	// tick) never drops a row between two polls.
+	QueryLogLookback time.Duration
+}
+
+// Default tuning constants (this package's own calibration surface — no
+// production measurement exists yet for THIS feature, unlike
+// solver.defaultMaxK's measured history, because the feature does not exist
+// before this issue; these are conservative starting points an operator
+// tunes from real deployment data via the env vars above).
+const (
+	// defaultDriftLowerRatio: an actual EMA at or below 10% of the EXPLAIN
+	// ESTIMATE prediction is ordinary, not alerting — EXPLAIN ESTIMATE is a
+	// granule-resolution upper bound (typically 8192-row granules), so a
+	// tight predicate or an effective skip index routinely prunes far more
+	// than a granule-only estimate can see. Below this floor the estimate is
+	// still "in the right direction" (a real overestimate), just imprecise —
+	// exactly the class of drift the issue says is expected and not the
+	// dangerous direction.
+	defaultDriftLowerRatio = 0.1
+
+	// defaultDriftUpperRatio: an actual EMA at or above 3x the prediction is
+	// the DANGEROUS direction — EXPLAIN ESTIMATE was supposed to be an upper
+	// bound and real work exceeded it, which is exactly the "silent
+	// mis-admission" the issue exists to surface. 3x is deliberately much
+	// tighter than the lower band's 10x-in-the-safe-direction slack, because
+	// this is the side that actually costs an incident.
+	defaultDriftUpperRatio = 3.0
+
+	// defaultMinObservations mirrors internal/engine's own
+	// perRungEvidenceMinObservations and routememo's minCorroboratingFailures
+	// (both 2): a single observation is never enough evidence to flip a
+	// shape's advisory verdict.
+	defaultMinObservations = 2
+
+	// defaultEMAAlpha: each new observation moves the tracked average at most
+	// 20% of the way toward that single sample, so a lone wildly-anomalous
+	// actual can shift the EMA by at most 1/5 of the gap in one step —
+	// several corroborating observations are needed to move it far, which is
+	// the bounded-influence property the issue's anti-autotune stance
+	// requires.
+	defaultEMAAlpha = 0.2
+
+	// defaultEntryTTL mirrors routememo.memoEntryTTL / the per-rung admission
+	// learner's perRungEvidenceTTL (both 30m).
+	defaultEntryTTL = 30 * time.Minute
+
+	// defaultQueryLogPollInterval mirrors optcorpus's own
+	// CERBERUS_CH_OPT_CORPUS_INTERVAL default (60s) — the established cadence
+	// for a system.query_log background reconciler in this codebase.
+	defaultQueryLogPollInterval = 60 * time.Second
+
+	// defaultQueryLogLookback: 3x the poll interval gives two full missed
+	// polls of overlap margin before a row could be dropped between two
+	// watermarks — generous against query_log's own flush lag
+	// (docs/operations.md), which is measured in seconds, not minutes.
+	defaultQueryLogLookback = 3 * defaultQueryLogPollInterval
+)
+
+// DefaultConfig returns the conservative library defaults. Enabled is false
+// — the feature ships dark, mirroring solver.DefaultConfig's Mode ==
+// ModeSingle — so DefaultConfig is safe to wire as the in-process default
+// without turning the feature on.
+func DefaultConfig() Config {
+	return Config{
+		Enabled:              false,
+		DriftLowerRatio:      defaultDriftLowerRatio,
+		DriftUpperRatio:      defaultDriftUpperRatio,
+		MinObservations:      defaultMinObservations,
+		EMAAlpha:             defaultEMAAlpha,
+		EntryTTL:             defaultEntryTTL,
+		QueryLogPollInterval: defaultQueryLogPollInterval,
+		QueryLogLookback:     defaultQueryLogLookback,
+	}
+}
+
+// Validate fail-fast checks the invariants Tracker depends on. Mirrors
+// solver.Config.Validate's split: ConfigFromEnv does not call this itself,
+// the caller (cmd/cerberus) does, at startup.
+func (c Config) Validate() error {
+	if c.DriftLowerRatio <= 0 {
+		return fmt.Errorf("actuals: DriftLowerRatio must be > 0, got %g", c.DriftLowerRatio)
+	}
+	if c.DriftUpperRatio <= c.DriftLowerRatio {
+		return fmt.Errorf("actuals: DriftUpperRatio (%g) must be > DriftLowerRatio (%g)", c.DriftUpperRatio, c.DriftLowerRatio)
+	}
+	if c.MinObservations < 1 {
+		return fmt.Errorf("actuals: MinObservations must be >= 1, got %d", c.MinObservations)
+	}
+	if c.EMAAlpha <= 0 || c.EMAAlpha > 1 {
+		return fmt.Errorf("actuals: EMAAlpha must be in (0, 1], got %g", c.EMAAlpha)
+	}
+	if c.EntryTTL <= 0 {
+		return fmt.Errorf("actuals: EntryTTL must be > 0, got %s", c.EntryTTL)
+	}
+	if c.QueryLogPollInterval <= 0 {
+		return fmt.Errorf("actuals: QueryLogPollInterval must be > 0, got %s", c.QueryLogPollInterval)
+	}
+	if c.QueryLogLookback <= 0 {
+		return fmt.Errorf("actuals: QueryLogLookback must be > 0, got %s", c.QueryLogLookback)
+	}
+	return nil
+}

--- a/internal/actuals/config_env.go
+++ b/internal/actuals/config_env.go
@@ -1,0 +1,109 @@
+package actuals
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// Env var names for the actuals tuning surface (issue #2789). Mirrors
+// internal/solver/config_env.go's own layout: one const block, one
+// ConfigFromEnv, shared envInt/envFloat/envDuration/envBool parsers local to
+// this package (solver's own helpers are unexported and this package must
+// not import solver — see .go-arch-lint.yml).
+const (
+	EnvEnabled              = "CERBERUS_QUERY_ACTUALS_ENABLED"
+	EnvDriftLowerRatio      = "CERBERUS_QUERY_ACTUALS_DRIFT_LOWER_RATIO"
+	EnvDriftUpperRatio      = "CERBERUS_QUERY_ACTUALS_DRIFT_UPPER_RATIO"
+	EnvMinObservations      = "CERBERUS_QUERY_ACTUALS_MIN_OBSERVATIONS"
+	EnvEMAAlpha             = "CERBERUS_QUERY_ACTUALS_EMA_ALPHA"
+	EnvEntryTTL             = "CERBERUS_QUERY_ACTUALS_ENTRY_TTL"
+	EnvQueryLogPollInterval = "CERBERUS_QUERY_ACTUALS_QUERY_LOG_POLL_INTERVAL"
+	EnvQueryLogLookback     = "CERBERUS_QUERY_ACTUALS_QUERY_LOG_LOOKBACK"
+)
+
+// ConfigFromEnv builds a Config from the CERBERUS_QUERY_ACTUALS_* environment,
+// starting from DefaultConfig (Enabled=false) and overriding each field from
+// its env var when set. Mirrors solver.ConfigFromEnv's own contract: does NOT
+// call Validate (the caller runs that at startup), and a parse failure on any
+// knob is returned so a typo never silently changes behavior.
+func ConfigFromEnv() (Config, error) {
+	cfg := DefaultConfig()
+
+	var err error
+	if cfg.Enabled, err = envBool(EnvEnabled, cfg.Enabled); err != nil {
+		return Config{}, err
+	}
+	if cfg.DriftLowerRatio, err = envFloat(EnvDriftLowerRatio, cfg.DriftLowerRatio); err != nil {
+		return Config{}, err
+	}
+	if cfg.DriftUpperRatio, err = envFloat(EnvDriftUpperRatio, cfg.DriftUpperRatio); err != nil {
+		return Config{}, err
+	}
+	if cfg.MinObservations, err = envInt(EnvMinObservations, cfg.MinObservations); err != nil {
+		return Config{}, err
+	}
+	if cfg.EMAAlpha, err = envFloat(EnvEMAAlpha, cfg.EMAAlpha); err != nil {
+		return Config{}, err
+	}
+	if cfg.EntryTTL, err = envDuration(EnvEntryTTL, cfg.EntryTTL); err != nil {
+		return Config{}, err
+	}
+	if cfg.QueryLogPollInterval, err = envDuration(EnvQueryLogPollInterval, cfg.QueryLogPollInterval); err != nil {
+		return Config{}, err
+	}
+	if cfg.QueryLogLookback, err = envDuration(EnvQueryLogLookback, cfg.QueryLogLookback); err != nil {
+		return Config{}, err
+	}
+	return cfg, nil
+}
+
+func envInt(key string, def int) (int, error) {
+	v := strings.TrimSpace(os.Getenv(key))
+	if v == "" {
+		return def, nil
+	}
+	n, err := strconv.Atoi(v)
+	if err != nil {
+		return 0, fmt.Errorf("actuals: %s: invalid integer %q: %w", key, v, err)
+	}
+	return n, nil
+}
+
+func envFloat(key string, def float64) (float64, error) {
+	v := strings.TrimSpace(os.Getenv(key))
+	if v == "" {
+		return def, nil
+	}
+	f, err := strconv.ParseFloat(v, 64)
+	if err != nil {
+		return 0, fmt.Errorf("actuals: %s: invalid float %q: %w", key, v, err)
+	}
+	return f, nil
+}
+
+func envBool(key string, def bool) (bool, error) {
+	v := strings.TrimSpace(os.Getenv(key))
+	if v == "" {
+		return def, nil
+	}
+	b, err := strconv.ParseBool(v)
+	if err != nil {
+		return false, fmt.Errorf("actuals: %s: invalid boolean %q: %w", key, v, err)
+	}
+	return b, nil
+}
+
+func envDuration(key string, def time.Duration) (time.Duration, error) {
+	v := strings.TrimSpace(os.Getenv(key))
+	if v == "" {
+		return def, nil
+	}
+	d, err := time.ParseDuration(v)
+	if err != nil {
+		return 0, fmt.Errorf("actuals: %s: invalid duration %q: %w", key, v, err)
+	}
+	return d, nil
+}

--- a/internal/actuals/config_env_test.go
+++ b/internal/actuals/config_env_test.go
@@ -1,0 +1,49 @@
+package actuals
+
+import "testing"
+
+func TestConfigFromEnv_Defaults(t *testing.T) {
+	cfg, err := ConfigFromEnv()
+	if err != nil {
+		t.Fatalf("ConfigFromEnv: %v", err)
+	}
+	want := DefaultConfig()
+	if cfg != want {
+		t.Fatalf("expected DefaultConfig when unset, got %+v want %+v", cfg, want)
+	}
+	if cfg.Enabled {
+		t.Fatal("the feature must ship dark: Enabled must default to false")
+	}
+}
+
+func TestConfigFromEnv_Overrides(t *testing.T) {
+	t.Setenv(EnvEnabled, "true")
+	t.Setenv(EnvDriftLowerRatio, "0.05")
+	t.Setenv(EnvDriftUpperRatio, "5")
+	t.Setenv(EnvMinObservations, "3")
+	t.Setenv(EnvEMAAlpha, "0.5")
+	t.Setenv(EnvEntryTTL, "10m")
+	t.Setenv(EnvQueryLogPollInterval, "30s")
+	t.Setenv(EnvQueryLogLookback, "2m")
+
+	cfg, err := ConfigFromEnv()
+	if err != nil {
+		t.Fatalf("ConfigFromEnv: %v", err)
+	}
+	if !cfg.Enabled || cfg.DriftLowerRatio != 0.05 || cfg.DriftUpperRatio != 5 ||
+		cfg.MinObservations != 3 || cfg.EMAAlpha != 0.5 ||
+		cfg.EntryTTL.String() != "10m0s" || cfg.QueryLogPollInterval.String() != "30s" ||
+		cfg.QueryLogLookback.String() != "2m0s" {
+		t.Fatalf("unexpected config from overrides: %+v", cfg)
+	}
+	if err := cfg.Validate(); err != nil {
+		t.Fatalf("expected the overridden config to validate, got %v", err)
+	}
+}
+
+func TestConfigFromEnv_InvalidValueFailsFast(t *testing.T) {
+	t.Setenv(EnvMinObservations, "not-a-number")
+	if _, err := ConfigFromEnv(); err == nil {
+		t.Fatal("expected a malformed CERBERUS_QUERY_ACTUALS_MIN_OBSERVATIONS to fail fast")
+	}
+}

--- a/internal/actuals/config_test.go
+++ b/internal/actuals/config_test.go
@@ -1,0 +1,36 @@
+package actuals
+
+import "testing"
+
+func TestConfig_ValidateAcceptsDefault(t *testing.T) {
+	if err := DefaultConfig().Validate(); err != nil {
+		t.Fatalf("DefaultConfig should validate, got %v", err)
+	}
+}
+
+func TestConfig_ValidateRejectsBadFields(t *testing.T) {
+	base := DefaultConfig()
+
+	cases := []struct {
+		name string
+		mut  func(*Config)
+	}{
+		{"non-positive lower ratio", func(c *Config) { c.DriftLowerRatio = 0 }},
+		{"upper not above lower", func(c *Config) { c.DriftUpperRatio = c.DriftLowerRatio }},
+		{"zero min observations", func(c *Config) { c.MinObservations = 0 }},
+		{"zero ema alpha", func(c *Config) { c.EMAAlpha = 0 }},
+		{"ema alpha above one", func(c *Config) { c.EMAAlpha = 1.5 }},
+		{"non-positive entry ttl", func(c *Config) { c.EntryTTL = 0 }},
+		{"non-positive poll interval", func(c *Config) { c.QueryLogPollInterval = 0 }},
+		{"non-positive lookback", func(c *Config) { c.QueryLogLookback = 0 }},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := base
+			tc.mut(&cfg)
+			if err := cfg.Validate(); err == nil {
+				t.Fatalf("expected Validate to reject %+v", cfg)
+			}
+		})
+	}
+}

--- a/internal/actuals/tracker.go
+++ b/internal/actuals/tracker.go
@@ -1,0 +1,354 @@
+package actuals
+
+import (
+	"sync"
+	"time"
+)
+
+// trackerCapacity bounds the Tracker's resident size, mirroring
+// internal/engine's own scanEstimateCacheCapacity / perRungLearnerCapacity
+// (both 4096): a bounded map with coarse (any-single-entry) eviction, whose
+// worst case is only ever "this shape re-learns its calibration a little
+// sooner than it otherwise would have" — the always-safe direction for an
+// advisory-only signal, exactly like those two caches' own eviction.
+const trackerCapacity = 4096
+
+// minCalibrationFactor / maxCalibrationFactor bound CalibrationFactor's
+// output: even when a shape's actual EMA and predicted rows disagree
+// wildly, the returned multiplier can move the EXPLAIN ESTIMATE-derived
+// row count no further than 2x up or down in one request. This is the
+// bounded-influence property applied to Hook 1 (carrier-geometry cost-model
+// calibration, engine's calibrateEstimate) — a single request's advisory
+// estimate can nudge classify()'s K clamp, never swing it by an order of
+// magnitude off one shape's noisy history.
+const (
+	minCalibrationFactor = 0.5
+	maxCalibrationFactor = 2.0
+)
+
+// Source identifies which capture path produced an Actual observation.
+type Source int
+
+const (
+	// SourcePacket is the native-protocol progress/ProfileEvents packet fast
+	// path (internal/chclient/progress.go) — free, since the production
+	// deployment's driver already streams these packets for every query; no
+	// extra round trip.
+	SourcePacket Source = iota
+	// SourceQueryLog is the system.query_log batch/fallback path
+	// (internal/engine's QueryLogActualsReconciler) — used for a query the
+	// packet path missed (one that failed before completing, or a deployment
+	// mode where packet capture is not wired) and inherently a SLOW path:
+	// query_log's own async flush lag means a row surfaces here well after
+	// the query that produced it finished.
+	SourceQueryLog
+)
+
+// String renders Source for logs/metrics labels.
+func (s Source) String() string {
+	switch s {
+	case SourcePacket:
+		return "packet"
+	case SourceQueryLog:
+		return "query_log"
+	default:
+		return "unknown"
+	}
+}
+
+// Actual is one query's measured resource usage, from either capture path.
+type Actual struct {
+	// ReadRows / ReadBytes are the query's total scanned rows/bytes — the
+	// SAME quantities system.query_log.read_rows/read_bytes report, and the
+	// packet path's rows/bytes running totals converge to (see
+	// internal/chclient/progress.go's own doc on why the LATEST progress
+	// packet, not a sum, is the query total).
+	ReadRows  uint64
+	ReadBytes uint64
+	// PeakMemory is the query's peak memory usage in bytes. The packet path
+	// reads it from the ProfileEvents "MemoryTrackerPeakUsage" counter
+	// (verified against a live ClickHouse 26.6 server — see
+	// internal/chclient/progress.go); the query_log path reads it straight
+	// from system.query_log.memory_usage. Zero when unknown.
+	PeakMemory uint64
+}
+
+// DriftReport is a point-in-time read-out of one plan shape's tracked state.
+type DriftReport struct {
+	ShapeID string
+
+	// HasPredicted / PredictedRows are the most recently recorded advisory
+	// EXPLAIN ESTIMATE / cardinality-probe row prediction for this shape
+	// (RecordPredicted's last call), or HasPredicted=false when no
+	// prediction has been recorded yet.
+	HasPredicted  bool
+	PredictedRows uint64
+
+	// ActualEMARows is the bounded exponential moving average of ReadRows
+	// across every RecordActual call for this shape (see Config.EMAAlpha).
+	ActualEMARows float64
+	Observations  int
+	LastSource    Source
+	LastObserved  time.Time
+
+	// Ratio is ActualEMARows / PredictedRows, or 0 when there is no
+	// prediction to compare against (HasPredicted false) or PredictedRows is
+	// zero (a "the index pruned everything" prediction — see
+	// driftRatio's own doc for why that is never treated as alerting).
+	Ratio float64
+
+	// Alerting is true when Observations has reached Config.MinObservations
+	// AND Ratio falls outside [Config.DriftLowerRatio, Config.DriftUpperRatio]
+	// — the drift-detection core's own verdict (issue #2789's primary
+	// deliverable). False whenever there is no prediction, too few
+	// observations, or the ratio is inside the expected band.
+	Alerting bool
+}
+
+// state is one plan-shape's tracked predicted/actual pair.
+type state struct {
+	hasPredicted  bool
+	predictedRows uint64
+
+	hasActual    bool
+	emaRows      float64
+	observations int
+	lastSource   Source
+	lastObserved time.Time
+}
+
+// Tracker is the bounded, in-process predicted-vs-actual drift tracker (this
+// package's own doc). Safe for concurrent use. The zero value is not usable;
+// construct with NewTracker.
+type Tracker struct {
+	cfg Config
+
+	mu     sync.Mutex
+	states map[string]*state
+
+	now func() time.Time // overridable by tests
+}
+
+// NewTracker constructs a Tracker from cfg. Every method on a nil *Tracker is
+// a safe no-op (mirrors routememo's own "nil behaves like off" convention
+// for every optional Engine-level mechanism), so callers do not need a
+// separate nil check before every call site.
+func NewTracker(cfg Config) *Tracker {
+	return &Tracker{
+		cfg:    cfg,
+		states: make(map[string]*state),
+		now:    time.Now,
+	}
+}
+
+// SetNowForTest overrides the Tracker's time source — production code must
+// never call this. Mirrors routememo.Memo.SetNowForTest's own doc.
+func (t *Tracker) SetNowForTest(now func() time.Time) {
+	if t == nil {
+		return
+	}
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.now = now
+}
+
+// RecordPredicted records shapeID's most recent advisory row prediction
+// (from EXPLAIN ESTIMATE or the cardinality pre-probe — see
+// solver.ScanEstimate.Rows's own doc for which producer supplied it). A
+// later call OVERWRITES the previous prediction for the same shape rather
+// than averaging: unlike the actual side, a fresh prediction is a
+// synchronous re-derivation of the SAME advisory signal classify() is about
+// to consume for THIS request, not a noisy repeated sample to smooth. No-op
+// on a nil Tracker or an empty shapeID.
+func (t *Tracker) RecordPredicted(shapeID string, rows uint64) {
+	if t == nil || shapeID == "" {
+		return
+	}
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	st := t.getOrCreateLocked(shapeID)
+	st.hasPredicted = true
+	st.predictedRows = rows
+}
+
+// RecordActual records one dispatch's measured resource usage for shapeID,
+// updating the bounded EMA (Config.EMAAlpha) and returning the resulting
+// DriftReport. No-op (zero DriftReport, false) on a nil Tracker or an empty
+// shapeID.
+func (t *Tracker) RecordActual(shapeID string, a Actual, source Source) (DriftReport, bool) {
+	if t == nil || shapeID == "" {
+		return DriftReport{}, false
+	}
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	st := t.getOrCreateLocked(shapeID)
+	if !st.hasActual {
+		st.emaRows = float64(a.ReadRows)
+	} else {
+		st.emaRows += t.cfg.EMAAlpha * (float64(a.ReadRows) - st.emaRows)
+	}
+	st.hasActual = true
+	st.observations++
+	st.lastSource = source
+	st.lastObserved = t.now()
+	return t.reportLocked(shapeID, st), true
+}
+
+// CalibrationFactor returns a BOUNDED multiplier (see
+// minCalibrationFactor/maxCalibrationFactor) for shapeID's advisory row
+// prediction, derived from how far the tracked actual EMA has drifted from
+// the last prediction, or ok=false when there is not enough evidence yet
+// (no prediction recorded, no actual recorded, or Observations below
+// Config.MinObservations — the SAME corroboration floor DriftReport.Alerting
+// uses, so a factor is never handed out on less evidence than an alert
+// would need). Consumed by internal/engine's calibrateEstimate (Hook 1: the
+// solver's carrier-geometry cost-model calibration) to nudge a FUTURE
+// request's EXPLAIN ESTIMATE-derived row count toward what this shape has
+// actually been costing, bounded so one noisy shape can never swing a
+// single request's K clamp by more than 2x.
+func (t *Tracker) CalibrationFactor(shapeID string) (factor float64, ok bool) {
+	if t == nil || shapeID == "" {
+		return 0, false
+	}
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	st, exists := t.states[shapeID]
+	if !exists || t.expiredLocked(st) {
+		return 0, false
+	}
+	if !st.hasPredicted || !st.hasActual || st.observations < t.cfg.MinObservations {
+		return 0, false
+	}
+	if st.predictedRows == 0 {
+		return 0, false
+	}
+	factor = st.emaRows / float64(st.predictedRows)
+	if factor < minCalibrationFactor {
+		factor = minCalibrationFactor
+	}
+	if factor > maxCalibrationFactor {
+		factor = maxCalibrationFactor
+	}
+	return factor, true
+}
+
+// Snapshot returns shapeID's current DriftReport, or ok=false when no live
+// (unexpired) state exists for it.
+func (t *Tracker) Snapshot(shapeID string) (DriftReport, bool) {
+	if t == nil || shapeID == "" {
+		return DriftReport{}, false
+	}
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	st, exists := t.states[shapeID]
+	if !exists || t.expiredLocked(st) {
+		return DriftReport{}, false
+	}
+	return t.reportLocked(shapeID, st), true
+}
+
+// Stats is a point-in-time snapshot of the Tracker's resident state, for
+// observability.
+type Stats struct {
+	Entries  int
+	Alerting int
+}
+
+// Stats returns a snapshot of the Tracker's current size and how many
+// tracked shapes are currently drift-alerting. Expired entries are excluded
+// from both counts without being evicted (eviction is lazy, on next touch —
+// mirroring routememo.Memo.getLiveLocked's own posture).
+func (t *Tracker) Stats() Stats {
+	if t == nil {
+		return Stats{}
+	}
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	var s Stats
+	for id, st := range t.states {
+		if t.expiredLocked(st) {
+			continue
+		}
+		s.Entries++
+		if t.reportLocked(id, st).Alerting {
+			s.Alerting++
+		}
+	}
+	return s
+}
+
+// getOrCreateLocked returns shapeID's state, creating (or resetting, if
+// expired) it as needed and evicting one arbitrary entry at capacity —
+// coarser than a true LRU, mirroring internal/engine's own
+// ScanEstimateAdvisor.store / PerRungAdmissionLearner.record: the cost of
+// evicting the wrong entry here is trivial (one shape re-learns its
+// calibration a little sooner), so a full LRU buys nothing worth its own
+// bookkeeping. Caller holds t.mu.
+func (t *Tracker) getOrCreateLocked(shapeID string) *state {
+	st, exists := t.states[shapeID]
+	if exists && !t.expiredLocked(st) {
+		return st
+	}
+	if !exists && len(t.states) >= trackerCapacity {
+		for k := range t.states {
+			delete(t.states, k)
+			break
+		}
+	}
+	st = &state{}
+	t.states[shapeID] = st
+	return st
+}
+
+// expiredLocked reports whether st has aged past Config.EntryTTL. A state
+// with no actual observation yet (freshly seeded by RecordPredicted alone)
+// never expires on that basis — LastObserved is the zero time.Time until
+// the first RecordActual, so treat it as fresh; the predicted-only window
+// between an advisory estimate and the request's own dispatch is always far
+// shorter than any reasonable TTL. Caller holds t.mu.
+func (t *Tracker) expiredLocked(st *state) bool {
+	if !st.hasActual {
+		return false
+	}
+	return t.now().Sub(st.lastObserved) >= t.cfg.EntryTTL
+}
+
+// reportLocked builds the DriftReport for shapeID's current state. Caller
+// holds t.mu.
+func (t *Tracker) reportLocked(shapeID string, st *state) DriftReport {
+	r := DriftReport{
+		ShapeID:       shapeID,
+		HasPredicted:  st.hasPredicted,
+		PredictedRows: st.predictedRows,
+		ActualEMARows: st.emaRows,
+		Observations:  st.observations,
+		LastSource:    st.lastSource,
+		LastObserved:  st.lastObserved,
+	}
+	r.Ratio, r.Alerting = t.driftLocked(st)
+	return r
+}
+
+// driftLocked computes the ratio + alerting verdict for st. Caller holds
+// t.mu.
+//
+// A zero PredictedRows (the index analysis pruned the scan to nothing) is
+// deliberately NEVER alerting regardless of the actual: EXPLAIN ESTIMATE's
+// own doc (internal/chclient/explain_estimate.go) already treats a
+// near-zero estimate as strong, one-directional evidence — a scan-side
+// upper bound of zero says the scan reads nothing, and if the actual EMA
+// disagrees the interesting fact IS the ratio being undefined (division by
+// zero), not a number this function should invent. A caller needing to flag
+// "predicted zero, actual nonzero" reads HasPredicted + PredictedRows == 0
+// directly.
+func (t *Tracker) driftLocked(st *state) (ratio float64, alerting bool) {
+	if !st.hasPredicted || !st.hasActual || st.predictedRows == 0 {
+		return 0, false
+	}
+	if st.observations < t.cfg.MinObservations {
+		return st.emaRows / float64(st.predictedRows), false
+	}
+	ratio = st.emaRows / float64(st.predictedRows)
+	alerting = ratio < t.cfg.DriftLowerRatio || ratio > t.cfg.DriftUpperRatio
+	return ratio, alerting
+}

--- a/internal/actuals/tracker_test.go
+++ b/internal/actuals/tracker_test.go
@@ -1,0 +1,269 @@
+package actuals
+
+import (
+	"testing"
+	"time"
+)
+
+func testConfig() Config {
+	cfg := DefaultConfig()
+	cfg.Enabled = true
+	return cfg
+}
+
+func TestTracker_NilSafe(t *testing.T) {
+	var tr *Tracker
+	tr.RecordPredicted("cerb:agg;rw", 1000)
+	if _, ok := tr.RecordActual("cerb:agg;rw", Actual{ReadRows: 1000}, SourcePacket); ok {
+		t.Fatal("RecordActual on nil Tracker must report ok=false")
+	}
+	if _, ok := tr.Snapshot("cerb:agg;rw"); ok {
+		t.Fatal("Snapshot on nil Tracker must report ok=false")
+	}
+	if factor, ok := tr.CalibrationFactor("cerb:agg;rw"); ok || factor != 0 {
+		t.Fatalf("CalibrationFactor on nil Tracker must report ok=false, got (%v, %v)", factor, ok)
+	}
+	if s := tr.Stats(); s != (Stats{}) {
+		t.Fatalf("Stats on nil Tracker must be zero, got %+v", s)
+	}
+}
+
+func TestTracker_EmptyShapeIDNoOp(t *testing.T) {
+	tr := NewTracker(testConfig())
+	tr.RecordPredicted("", 1000)
+	if _, ok := tr.RecordActual("", Actual{ReadRows: 1000}, SourcePacket); ok {
+		t.Fatal("RecordActual with empty shapeID must be a no-op")
+	}
+	if s := tr.Stats(); s.Entries != 0 {
+		t.Fatalf("expected no entries recorded for empty shapeID, got %+v", s)
+	}
+}
+
+// TestTracker_NoDriftWithinBand exercises the common case: EXPLAIN
+// ESTIMATE's granule-resolution upper bound overestimates a real,
+// index-pruned scan (the expected direction), and the ratio stays within
+// the configured band — never alerting.
+func TestTracker_NoDriftWithinBand(t *testing.T) {
+	tr := NewTracker(testConfig())
+	const shape = "cerb:agg;rw"
+	tr.RecordPredicted(shape, 100_000)
+	// Two corroborating observations, both close to the prediction.
+	for i := 0; i < 2; i++ {
+		report, ok := tr.RecordActual(shape, Actual{ReadRows: 90_000}, SourcePacket)
+		if !ok {
+			t.Fatal("RecordActual should succeed")
+		}
+		if i == 1 && report.Alerting {
+			t.Fatalf("expected no drift alert for a 0.9 ratio, got %+v", report)
+		}
+	}
+}
+
+// TestTracker_AlertsOnUnderPrediction is the DANGEROUS direction the issue
+// exists to catch: real read_rows repeatedly exceeds EXPLAIN ESTIMATE's own
+// upper bound by more than DriftUpperRatio, which should never happen if
+// the estimate were a true bound — this is exactly the silent
+// mis-admission case the drift alert surfaces.
+func TestTracker_AlertsOnUnderPrediction(t *testing.T) {
+	tr := NewTracker(testConfig())
+	const shape = "cerb:agg;rw;rbf"
+	tr.RecordPredicted(shape, 10_000)
+
+	// First observation: not enough evidence yet even though the ratio is
+	// already outside the band (MinObservations=2 by default).
+	report, ok := tr.RecordActual(shape, Actual{ReadRows: 100_000}, SourcePacket)
+	if !ok {
+		t.Fatal("RecordActual should succeed")
+	}
+	if report.Alerting {
+		t.Fatalf("must not alert before MinObservations is reached, got %+v", report)
+	}
+
+	// Second corroborating observation: now it alerts.
+	report, ok = tr.RecordActual(shape, Actual{ReadRows: 100_000}, SourcePacket)
+	if !ok {
+		t.Fatal("RecordActual should succeed")
+	}
+	if !report.Alerting {
+		t.Fatalf("expected a drift alert once corroborated, got %+v", report)
+	}
+	if report.Ratio <= testConfig().DriftUpperRatio {
+		t.Fatalf("expected ratio above the upper band, got %v", report.Ratio)
+	}
+}
+
+// TestTracker_ZeroPredictionNeverAlerts pins driftLocked's own documented
+// exception: a zero prediction (the index analysis pruned the scan to
+// nothing) never alerts, regardless of the actual — the ratio is undefined,
+// not "infinite drift".
+func TestTracker_ZeroPredictionNeverAlerts(t *testing.T) {
+	tr := NewTracker(testConfig())
+	const shape = "cerb:filter"
+	tr.RecordPredicted(shape, 0)
+	for i := 0; i < 5; i++ {
+		report, ok := tr.RecordActual(shape, Actual{ReadRows: 1_000_000}, SourcePacket)
+		if !ok {
+			t.Fatal("RecordActual should succeed")
+		}
+		if report.Alerting {
+			t.Fatalf("a zero prediction must never alert, got %+v", report)
+		}
+		if report.Ratio != 0 {
+			t.Fatalf("a zero prediction must report ratio 0, got %v", report.Ratio)
+		}
+	}
+}
+
+// TestTracker_EMABoundedInfluence pins the anti-autotune bounded-influence
+// property: a single wildly anomalous observation cannot swing the tracked
+// EMA past EMAAlpha's own fraction of the gap.
+func TestTracker_EMABoundedInfluence(t *testing.T) {
+	tr := NewTracker(testConfig())
+	const shape = "cerb:agg;rw"
+	tr.RecordPredicted(shape, 100_000)
+	if _, ok := tr.RecordActual(shape, Actual{ReadRows: 100_000}, SourcePacket); !ok {
+		t.Fatal("RecordActual should succeed")
+	}
+	// A wild single anomaly: 100x the established baseline.
+	report, ok := tr.RecordActual(shape, Actual{ReadRows: 10_000_000}, SourcePacket)
+	if !ok {
+		t.Fatal("RecordActual should succeed")
+	}
+	// EMA after one 0.2-alpha step from 100,000 toward 10,000,000:
+	// 100,000 + 0.2*(10,000,000-100,000) = 2,080,000.
+	const wantEMA = 100_000 + defaultEMAAlpha*(10_000_000-100_000)
+	if report.ActualEMARows != wantEMA {
+		t.Fatalf("expected bounded EMA step to %v, got %v", wantEMA, report.ActualEMARows)
+	}
+	if report.ActualEMARows >= 10_000_000 {
+		t.Fatalf("a single anomalous observation must not fully move the EMA, got %v", report.ActualEMARows)
+	}
+}
+
+func TestTracker_CalibrationFactor_BoundedAndGated(t *testing.T) {
+	tr := NewTracker(testConfig())
+	const shape = "cerb:agg;rw"
+
+	// No prediction yet: not ok.
+	if _, ok := tr.CalibrationFactor(shape); ok {
+		t.Fatal("CalibrationFactor must be ok=false with no prediction recorded")
+	}
+
+	tr.RecordPredicted(shape, 100_000)
+	// Prediction only, no actual yet: still not ok.
+	if _, ok := tr.CalibrationFactor(shape); ok {
+		t.Fatal("CalibrationFactor must be ok=false with no actual recorded")
+	}
+
+	// One observation: below MinObservations (2), still not ok.
+	if _, ok := tr.RecordActual(shape, Actual{ReadRows: 1_000_000}, SourcePacket); !ok {
+		t.Fatal("RecordActual should succeed")
+	}
+	if _, ok := tr.CalibrationFactor(shape); ok {
+		t.Fatal("CalibrationFactor must be ok=false below MinObservations")
+	}
+
+	// Second observation reaches MinObservations: now ok, and the factor is
+	// clamped to maxCalibrationFactor even though the raw ratio (~9.5x) is
+	// far larger.
+	if _, ok := tr.RecordActual(shape, Actual{ReadRows: 1_000_000}, SourcePacket); !ok {
+		t.Fatal("RecordActual should succeed")
+	}
+	factor, ok := tr.CalibrationFactor(shape)
+	if !ok {
+		t.Fatal("expected CalibrationFactor to be ok once corroborated")
+	}
+	if factor != maxCalibrationFactor {
+		t.Fatalf("expected the calibration factor clamped to %v, got %v", maxCalibrationFactor, factor)
+	}
+
+	// Symmetric clamp: a shape whose actual is far BELOW its prediction
+	// clamps to minCalibrationFactor.
+	const underShape = "cerb:agg;rw;lwr"
+	tr.RecordPredicted(underShape, 1_000_000)
+	for i := 0; i < 2; i++ {
+		if _, ok := tr.RecordActual(underShape, Actual{ReadRows: 100}, SourcePacket); !ok {
+			t.Fatal("RecordActual should succeed")
+		}
+	}
+	factor, ok = tr.CalibrationFactor(underShape)
+	if !ok {
+		t.Fatal("expected CalibrationFactor to be ok once corroborated")
+	}
+	if factor != minCalibrationFactor {
+		t.Fatalf("expected the calibration factor clamped to %v, got %v", minCalibrationFactor, factor)
+	}
+}
+
+func TestTracker_EntryTTLExpiry(t *testing.T) {
+	tr := NewTracker(testConfig())
+	now := time.Date(2026, 8, 31, 0, 0, 0, 0, time.UTC)
+	tr.SetNowForTest(func() time.Time { return now })
+
+	const shape = "cerb:agg;rw"
+	tr.RecordPredicted(shape, 100_000)
+	for i := 0; i < 2; i++ {
+		if _, ok := tr.RecordActual(shape, Actual{ReadRows: 90_000}, SourcePacket); !ok {
+			t.Fatal("RecordActual should succeed")
+		}
+	}
+	if _, ok := tr.Snapshot(shape); !ok {
+		t.Fatal("expected a live entry before the TTL elapses")
+	}
+
+	now = now.Add(testConfig().EntryTTL + time.Minute)
+	if _, ok := tr.Snapshot(shape); ok {
+		t.Fatal("expected the entry to have expired past EntryTTL")
+	}
+	if _, ok := tr.CalibrationFactor(shape); ok {
+		t.Fatal("expected CalibrationFactor to refuse an expired entry")
+	}
+}
+
+func TestTracker_StatsCountsAlerting(t *testing.T) {
+	tr := NewTracker(testConfig())
+
+	tr.RecordPredicted("cerb:agg;rw", 100_000)
+	for i := 0; i < 2; i++ {
+		if _, ok := tr.RecordActual("cerb:agg;rw", Actual{ReadRows: 90_000}, SourcePacket); !ok {
+			t.Fatal("RecordActual should succeed")
+		}
+	}
+	tr.RecordPredicted("cerb:agg;rw;rbf", 10_000)
+	for i := 0; i < 2; i++ {
+		if _, ok := tr.RecordActual("cerb:agg;rw;rbf", Actual{ReadRows: 100_000}, SourcePacket); !ok {
+			t.Fatal("RecordActual should succeed")
+		}
+	}
+
+	stats := tr.Stats()
+	if stats.Entries != 2 {
+		t.Fatalf("expected 2 entries, got %d", stats.Entries)
+	}
+	if stats.Alerting != 1 {
+		t.Fatalf("expected exactly 1 alerting shape, got %d", stats.Alerting)
+	}
+}
+
+func TestTracker_CapacityEviction(t *testing.T) {
+	tr := NewTracker(testConfig())
+	for i := 0; i < trackerCapacity+10; i++ {
+		tr.RecordPredicted(shapeIDForTest(i), 1000)
+	}
+	stats := tr.Stats()
+	if stats.Entries > trackerCapacity {
+		t.Fatalf("expected the resident size to stay bounded at %d, got %d", trackerCapacity, stats.Entries)
+	}
+}
+
+func shapeIDForTest(i int) string {
+	// A closed, deterministic id vocabulary — mirrors the real plan-shape id
+	// format ("cerb:<root>;<modifier>...") without pulling in chplan/engine.
+	const alphabet = "abcdefghijklmnopqrstuvwxyz0123456789"
+	b := []byte("cerb:test;")
+	for i > 0 {
+		b = append(b, alphabet[i%len(alphabet)])
+		i /= len(alphabet)
+	}
+	return string(b)
+}

--- a/internal/chclient/progress.go
+++ b/internal/chclient/progress.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/ClickHouse/clickhouse-go/v2"
 
+	"github.com/tsouza/cerberus/internal/actuals"
 	"github.com/tsouza/cerberus/internal/telemetry"
 )
 
@@ -37,8 +38,94 @@ import (
 // flush captures it once at end-of-query.
 func WithProgressFor(ctx context.Context, ql string) context.Context {
 	rec := &progressRecorder{ql: ql, ctx: ctx}
+	// Issue #2789: a route-B dispatch calls WithProgressFor TWICE on the
+	// SAME logical request — once in routeBExecCtx (the outer ctx every
+	// shard's own dispatch context derives from) and once more per shard,
+	// inside internal/solver/executor.go's runShard ("Per-shard progress
+	// recorder (one per ctx key)" — its own doc explains why a FRESH
+	// recorder per shard is mandatory: sharing one would corrupt the
+	// rows/bytes histograms across concurrent shards). That second call
+	// would otherwise silently DISCARD whatever WithActualsCapture wired
+	// onto the outer recorder — a NEW progressRecorder starts with
+	// shapeID=="" regardless of what an ancestor ctx carried. actualsIntent
+	// closes that gap: WithActualsCapture stores the (tracker, shapeID)
+	// pair under its OWN, separate context key — a value that (unlike the
+	// recorder itself) survives being shadowed, because nothing here
+	// overwrites it — and EVERY WithProgressFor call, including a later
+	// per-shard one, re-applies it to whichever fresh recorder it just
+	// created. Route A never exercises the second read (it calls
+	// WithProgressFor exactly once), so this is purely additive there.
+	if intent, ok := actualsIntentFromContext(ctx); ok {
+		rec.tracker = intent.tracker
+		rec.shapeID = intent.shapeID
+	}
 	ctx = withRecorder(ctx, rec)
-	return clickhouse.Context(ctx, clickhouse.WithProgress(rec.onProgress))
+	opts := []clickhouse.QueryOption{clickhouse.WithProgress(rec.onProgress)}
+	if rec.shapeID != "" {
+		opts = append(opts, clickhouse.WithProfileEvents(rec.onProfileEvents))
+	}
+	return clickhouse.Context(ctx, opts...)
+}
+
+// actualsIntent is the (tracker, shapeID) pair WithActualsCapture stores on
+// ctx — see WithProgressFor's own doc for why this rides as a SEPARATE,
+// non-recorder-bound context value.
+type actualsIntent struct {
+	tracker *actuals.Tracker
+	shapeID string
+}
+
+type actualsIntentKeyType struct{}
+
+var actualsIntentKey = actualsIntentKeyType{}
+
+func actualsIntentFromContext(ctx context.Context) (actualsIntent, bool) {
+	intent, ok := ctx.Value(actualsIntentKey).(actualsIntent)
+	return intent, ok
+}
+
+// WithActualsCapture extends ctx to capture this dispatch's peak memory
+// (via the native protocol's ProfileEvents packets) and record the whole
+// (rows, bytes, peak-memory) observation into tracker, keyed by shapeID,
+// once the dispatch completes (issue #2789's ProfileEvents/progress-packet
+// fast path). A nil tracker or an empty shapeID leaves ctx UNCHANGED —
+// fail-open, exactly like every other optional dispatch annotation in this
+// package (WithResponseShape, WithTSGridSetting, ...).
+//
+// Does TWO things, not one, and both are needed:
+//
+//  1. wires the CURRENT recorder directly, when ctx already carries one
+//     from an earlier WithProgressFor call (the route-A shape — one
+//     WithProgressFor call, no later one to inherit anything); a no-op
+//     when none exists yet.
+//  2. stamps actualsIntent onto ctx unconditionally, so a LATER
+//     WithProgressFor call (the route-B per-shard shape — see that
+//     function's own doc) re-applies it to its own fresh recorder even
+//     though this call could not touch one directly.
+//
+// Every real call site in internal/engine calls WithProgressFor BEFORE this
+// (mirroring chclient.WithResponseShape(chclient.WithProgressFor(ctx, ql))
+// immediately above this file's own doc), so (1) is what actually fires in
+// production; (2) is what makes route B's later, per-shard WithProgressFor
+// call correct regardless.
+//
+// clickhouse.Context MERGES the new WithProfileEvents option onto whatever
+// QueryOptions ctx already carries (client.go's own queryContext doc: "so
+// stacking is safe and the existing options are preserved") — it does not
+// replace the WithProgress callback WithProgressFor already installed, so
+// both packet types keep flowing to the SAME recorder.
+func WithActualsCapture(ctx context.Context, tracker *actuals.Tracker, shapeID string) context.Context {
+	if tracker == nil || shapeID == "" {
+		return ctx
+	}
+	ctx = context.WithValue(ctx, actualsIntentKey, actualsIntent{tracker: tracker, shapeID: shapeID})
+	rec := recorderFromContext(ctx)
+	if rec == nil {
+		return ctx
+	}
+	rec.tracker = tracker
+	rec.shapeID = shapeID
+	return clickhouse.Context(ctx, clickhouse.WithProfileEvents(rec.onProfileEvents))
 }
 
 // progressRecorder latches the most recent Progress snapshot for a
@@ -53,6 +140,15 @@ type progressRecorder struct {
 	ctx   context.Context
 	rows  uint64
 	bytes uint64
+
+	// peakMemory, shapeID and tracker are set only when WithActualsCapture
+	// (issue #2789) was layered on top of this recorder's ctx — see that
+	// function's own doc. shapeID == "" (the zero value) means actuals
+	// capture is off for this dispatch, matching the recorder's usual
+	// zero-value-means-off posture.
+	peakMemory uint64
+	shapeID    string
+	tracker    *actuals.Tracker
 }
 
 // onProgress is the driver-facing callback. It overwrites the latched
@@ -69,13 +165,65 @@ func (r *progressRecorder) onProgress(p *clickhouse.Progress) {
 	}
 }
 
-// flush records the latched (rows, bytes) on the histograms. Safe to
-// call with a nil-progress recorder (no-op).
+// profileEventMemoryTrackerPeakUsage is the ClickHouse ProfileEvents counter
+// name carrying a query's peak memory usage in bytes — verified against a
+// live ClickHouse 26.6 server (native protocol, WithProfileEvents): a plain
+// `SELECT count() FROM ... WHERE ...` over an 8,192-row granule reported
+// MemoryTrackerPeakUsage=301166 alongside MemoryTrackerUsage=174904 (the
+// CURRENT, not peak, tracker reading at the time of that particular event —
+// several ProfileEvents packets can arrive over a query's lifetime, one per
+// server-side flush, so onProfileEvents latches the MAXIMUM seen across all
+// of them, mirroring onProgress's own latch-the-running-total posture for
+// rows/bytes). Neither name is documented in ClickHouse's own reference
+// (docs/README.md's own citation for this feature only points at
+// system.query_log), so this was confirmed empirically rather than assumed.
+const profileEventMemoryTrackerPeakUsage = "MemoryTrackerPeakUsage"
+
+// onProfileEvents is the driver-facing callback for the native protocol's
+// ProfileEvents packets (issue #2789's ProfileEvents/progress-packet
+// capture). Registered ONLY when WithActualsCapture has been layered onto
+// this recorder's ctx — see that function's own doc for why this is not
+// unconditional like onProgress: parsing ~80 named counters per packet has a
+// real (if small) CPU/allocation cost the kill-switch-off default must not
+// pay. The packets themselves are already streamed by the server for every
+// query regardless (verified live: ClickHouse sends ServerProfileEvents
+// whether or not the client registers a callback for it — see
+// clickhouse-go/v2's WithoutProfileEvents, an explicit opt-OUT that only
+// exists because the packets are on-by-default), so registering the
+// callback adds no extra round trip — only the (already-flowing) packet's
+// parse cost.
+func (r *progressRecorder) onProfileEvents(events []clickhouse.ProfileEvent) {
+	for _, e := range events {
+		if e.Name != profileEventMemoryTrackerPeakUsage || e.Value < 0 {
+			continue
+		}
+		v := uint64(e.Value) //nolint:gosec // G115 -- guarded by the e.Value < 0 check above; ClickHouse never reports a negative memory counter in practice, but the guard makes the conversion provably safe rather than merely assumed
+		if v > r.peakMemory {
+			r.peakMemory = v
+		}
+	}
+}
+
+// flush records the latched (rows, bytes) on the histograms and, when
+// WithActualsCapture wired a tracker onto this dispatch, feeds the same
+// observation (plus the latched peak memory) into it as the SourcePacket
+// fast path (issue #2789). Safe to call with a nil-progress recorder
+// (no-op).
 func (r *progressRecorder) flush() {
 	if r == nil {
 		return
 	}
 	telemetry.RecordClickHouseProgress(r.ctx, r.ql, r.rows, r.bytes)
+	if r.shapeID != "" {
+		report, ok := r.tracker.RecordActual(r.shapeID, actuals.Actual{
+			ReadRows:   r.rows,
+			ReadBytes:  r.bytes,
+			PeakMemory: r.peakMemory,
+		}, actuals.SourcePacket)
+		if ok && report.HasPredicted {
+			telemetry.RecordEstimateDrift(r.ctx, report.Ratio, report.Alerting, actuals.SourcePacket.String())
+		}
+	}
 }
 
 // recorderFromContext digs the progressRecorder out of ctx by the

--- a/internal/chclient/progress_test.go
+++ b/internal/chclient/progress_test.go
@@ -1,0 +1,173 @@
+package chclient
+
+import (
+	"context"
+	"testing"
+
+	"github.com/ClickHouse/clickhouse-go/v2"
+
+	"github.com/tsouza/cerberus/internal/actuals"
+)
+
+func TestProgressRecorder_OnProgressLatchesMax(t *testing.T) {
+	rec := &progressRecorder{ql: "promql", ctx: context.Background()}
+	rec.onProgress(&clickhouse.Progress{Rows: 10, Bytes: 100})
+	rec.onProgress(&clickhouse.Progress{Rows: 5, Bytes: 50})
+	rec.onProgress(&clickhouse.Progress{Rows: 20, Bytes: 200})
+	if rec.rows != 20 || rec.bytes != 200 {
+		t.Fatalf("expected the latched snapshot to be the max seen, got rows=%d bytes=%d", rec.rows, rec.bytes)
+	}
+	// A nil packet must never panic.
+	rec.onProgress(nil)
+}
+
+func TestProgressRecorder_OnProfileEventsLatchesPeakMemory(t *testing.T) {
+	rec := &progressRecorder{ql: "promql", ctx: context.Background()}
+	rec.onProfileEvents([]clickhouse.ProfileEvent{
+		{Name: "Query", Value: 1},
+		{Name: profileEventMemoryTrackerPeakUsage, Value: 100},
+	})
+	rec.onProfileEvents([]clickhouse.ProfileEvent{
+		{Name: profileEventMemoryTrackerPeakUsage, Value: 50},
+	})
+	rec.onProfileEvents([]clickhouse.ProfileEvent{
+		{Name: profileEventMemoryTrackerPeakUsage, Value: 301166},
+	})
+	if rec.peakMemory != 301166 {
+		t.Fatalf("expected the latched peak memory to be the max seen, got %d", rec.peakMemory)
+	}
+	// A negative counter value (never seen in practice, per the driver's
+	// own encoding, but defensively guarded) must never underflow into a
+	// huge uint64.
+	rec.onProfileEvents([]clickhouse.ProfileEvent{
+		{Name: profileEventMemoryTrackerPeakUsage, Value: -1},
+	})
+	if rec.peakMemory != 301166 {
+		t.Fatalf("a negative ProfileEvent value must be ignored, got %d", rec.peakMemory)
+	}
+}
+
+// TestWithActualsCapture_StoresIntentEvenWithoutAnExistingRecorder pins the
+// (unusual, but correct) ordering where WithActualsCapture is called BEFORE
+// any WithProgressFor: there is no recorder yet to wire directly, but the
+// intent must still be stored so the NEXT WithProgressFor call picks it up
+// — see WithProgressFor's own doc for why this is a separate, non-recorder-
+// bound context value. Every real call site in this codebase calls
+// WithProgressFor first (this ordering never occurs in production), but the
+// function must not assume that.
+func TestWithActualsCapture_StoresIntentEvenWithoutAnExistingRecorder(t *testing.T) {
+	tracker := actuals.NewTracker(actuals.DefaultConfig())
+	const shape = "cerb:agg;rw"
+
+	ctx := WithActualsCapture(context.Background(), tracker, shape) // no WithProgressFor yet
+	if recorderFromContext(ctx) != nil {
+		t.Fatal("expected no recorder to exist yet")
+	}
+
+	// A LATER WithProgressFor call must still pick up the intent.
+	ctx = WithProgressFor(ctx, "promql")
+	rec := recorderFromContext(ctx)
+	if rec == nil || rec.shapeID != shape || rec.tracker != tracker {
+		t.Fatalf("expected the later recorder to inherit the stored intent, got %+v", rec)
+	}
+}
+
+func TestWithActualsCapture_NoOpWithNilTrackerOrEmptyShapeID(t *testing.T) {
+	ctx := WithProgressFor(context.Background(), "promql")
+	if got := WithActualsCapture(ctx, nil, "cerb:agg;rw"); got != ctx {
+		t.Fatal("WithActualsCapture must be a no-op with a nil tracker")
+	}
+	tracker := actuals.NewTracker(actuals.DefaultConfig())
+	if got := WithActualsCapture(ctx, tracker, ""); got != ctx {
+		t.Fatal("WithActualsCapture must be a no-op with an empty shapeID")
+	}
+}
+
+func TestWithActualsCapture_WiresRecorderAndFlushRecordsIntoTracker(t *testing.T) {
+	tracker := actuals.NewTracker(actuals.DefaultConfig())
+	const shape = "cerb:agg;rw"
+	tracker.RecordPredicted(shape, 1000)
+
+	ctx := WithProgressFor(context.Background(), "promql")
+	ctx = WithActualsCapture(ctx, tracker, shape)
+
+	rec := recorderFromContext(ctx)
+	if rec == nil {
+		t.Fatal("expected a recorder on ctx")
+	}
+	if rec.shapeID != shape || rec.tracker != tracker {
+		t.Fatalf("expected WithActualsCapture to wire shapeID/tracker onto the SAME recorder, got shapeID=%q tracker=%v", rec.shapeID, rec.tracker)
+	}
+
+	rec.onProgress(&clickhouse.Progress{Rows: 900, Bytes: 9000})
+	rec.onProfileEvents([]clickhouse.ProfileEvent{{Name: profileEventMemoryTrackerPeakUsage, Value: 12345}})
+	rec.flush()
+
+	report, ok := tracker.Snapshot(shape)
+	if !ok {
+		t.Fatal("expected flush to record an actual into the tracker")
+	}
+	if report.ActualEMARows != 900 || report.Observations != 1 {
+		t.Fatalf("unexpected recorded actual: %+v", report)
+	}
+}
+
+// TestWithProgressFor_SecondCallInheritsActualsIntent pins the route-B fix:
+// internal/solver/executor.go's runShard calls WithProgressFor a SECOND
+// time, on a descendant of the ctx routeBExecCtx already ran
+// WithActualsCapture over — a fresh recorder must still inherit the
+// (tracker, shapeID) pair, or the packet fast path silently does nothing
+// for every route-B shard.
+func TestWithProgressFor_SecondCallInheritsActualsIntent(t *testing.T) {
+	tracker := actuals.NewTracker(actuals.DefaultConfig())
+	const shape = "cerb:agg;rw"
+
+	outer := WithProgressFor(context.Background(), "promql")
+	outer = WithActualsCapture(outer, tracker, shape)
+	outerRec := recorderFromContext(outer)
+
+	// Simulate runShard's own second WithProgressFor call on a descendant
+	// ctx — a NEW recorder, but the SAME intent.
+	shardCtx := WithProgressFor(outer, "promql")
+	shardRec := recorderFromContext(shardCtx)
+
+	if shardRec == outerRec {
+		t.Fatal("expected a FRESH recorder per WithProgressFor call (sharing one would corrupt concurrent shards' histograms)")
+	}
+	if shardRec.shapeID != shape || shardRec.tracker != tracker {
+		t.Fatalf("expected the shard's fresh recorder to inherit the actuals intent, got shapeID=%q tracker=%v", shardRec.shapeID, shardRec.tracker)
+	}
+
+	// And it actually records into the tracker on flush.
+	shardRec.onProgress(&clickhouse.Progress{Rows: 111, Bytes: 222})
+	shardRec.flush()
+	report, ok := tracker.Snapshot(shape)
+	if !ok || report.ActualEMARows != 111 {
+		t.Fatalf("expected the shard's flush to record into the tracker, got %+v (ok=%v)", report, ok)
+	}
+}
+
+func TestWithProgressFor_NoIntentLeavesFreshRecorderInert(t *testing.T) {
+	// A plain WithProgressFor call with no preceding WithActualsCapture
+	// (every existing call site, and every dispatch with the feature off)
+	// must produce a recorder with no ProfileEvents registration at all —
+	// the kill-switch-off byte-unchanged contract.
+	ctx := WithProgressFor(context.Background(), "promql")
+	rec := recorderFromContext(ctx)
+	if rec.shapeID != "" || rec.tracker != nil {
+		t.Fatalf("expected an inert recorder with no prior actuals intent, got shapeID=%q tracker=%v", rec.shapeID, rec.tracker)
+	}
+}
+
+func TestProgressRecorder_FlushWithoutActualsCaptureIsANoOpOnTracker(t *testing.T) {
+	// flush() on a recorder that never had WithActualsCapture applied must
+	// not touch any tracker — pins the kill-switch-off byte-unchanged
+	// contract for a dispatch that never opted in.
+	rec := &progressRecorder{ql: "promql", ctx: context.Background(), rows: 42, bytes: 4200}
+	rec.flush() // must not panic even though rec.tracker is nil
+}
+
+func TestProgressRecorder_FlushNilReceiverIsSafe(t *testing.T) {
+	var rec *progressRecorder
+	rec.flush() // must not panic
+}

--- a/internal/chclient/query_log_actuals.go
+++ b/internal/chclient/query_log_actuals.go
@@ -1,0 +1,104 @@
+package chclient
+
+import (
+	"context"
+	"fmt"
+	"time"
+)
+
+// query_log_actuals.go closes issue #2789's batch/fallback actuals source:
+// system.query_log, read for the queries the native-protocol packet fast
+// path (progress.go) could not observe — a query that failed before
+// completing (a partial dispatch never reaches flush()'s success path), or
+// a deployment mode where packet capture is not wired. internal/engine's
+// QueryLogActualsReconciler is the polling half; this file is the transport
+// half, mirroring explain_estimate.go's own "internal/chclient/X.go is the
+// transport half, internal/engine/X_wiring.go is the engine-side half" split.
+//
+// The column list is VERIFIED against a live ClickHouse 26.6 server (via
+// `SELECT name, type FROM system.columns WHERE database='system' AND
+// table='query_log'`), not assumed from the upstream docs the issue itself
+// links — the same discipline issue #2789's own risk note calls out (#2770's
+// Loki catalog PR caught a real bug from an unverified assumption about
+// system.view_refreshes's columns; this is the same class of check applied
+// here): log_comment is String, read_rows/read_bytes/memory_usage are all
+// UInt64, event_time is DateTime, and type is
+// Enum8('QueryStart'=1,'QueryFinish'=2,'ExceptionBeforeStart'=3,'ExceptionWhileProcessing'=4)
+// — exactly as expected, so no defensive re-typing was needed here.
+//
+// startsWith(log_comment, ?), not a LIKE pattern: the caller
+// (internal/engine) owns the "cerb:" shape-id prefix constant
+// (plan_shape_id.go's shapeIDPrefix) — chclient must not import engine — so
+// the prefix is passed in as a bound parameter rather than this file
+// duplicating the constant or fighting LIKE's own '%'/'_' escaping rules for
+// a literal prefix match.
+const queryLogActualsSQL = `SELECT log_comment, read_rows, read_bytes, memory_usage, event_time
+FROM system.query_log
+WHERE type = 'QueryFinish' AND event_time > ? AND startsWith(log_comment, ?)
+ORDER BY event_time ASC
+LIMIT ?`
+
+// QueryLogActualRow is one system.query_log row for a cerberus-stamped
+// query (log_comment carrying a plan-shape id).
+type QueryLogActualRow struct {
+	// LogComment is the plan-shape id verbatim, e.g. "cerb:agg;rw" —
+	// internal/engine's SettingsRules stamped it via
+	// chclient.WithQuerySetting(ctx, "log_comment", shapeID).
+	LogComment string
+	ReadRows   uint64
+	ReadBytes  uint64
+	// MemoryUsage is ClickHouse's own peak-memory-usage column for the
+	// query, matching the packet path's ProfileEvents
+	// "MemoryTrackerPeakUsage" reading (progress.go's own doc) — the two
+	// sources report the SAME quantity by two different transports.
+	MemoryUsage uint64
+	EventTime   time.Time
+}
+
+// QueryLogActuals reads system.query_log for every QueryFinish row whose
+// log_comment starts with shapeIDPrefix and event_time is strictly after
+// since, oldest first, capped at limit rows. UNKNOWN_TABLE (query_log
+// disabled, or a deployment that has never enabled it) degrades to an empty
+// slice, nil error — the same honest degrade
+// QueryViewRefreshState/FilesystemCacheState apply to an optional
+// system-table dependency, rather than failing the whole reconciler poll
+// over an operator choice this feature does not require.
+//
+// Guarded by the circuit breaker (see [Client] doc), exactly like every
+// other query method here: a struggling ClickHouse server does not get an
+// extra query per reconciler tick on top of everything else already backing
+// off.
+func (c *Client) QueryLogActuals(ctx context.Context, since time.Time, shapeIDPrefix string, limit int) ([]QueryLogActualRow, error) {
+	if !c.br.allow() {
+		return nil, c.br.openErr("chclient: query log actuals")
+	}
+	ctx = c.queryContext(ctx)
+	ctx, span := startExecuteSpan(ctx, queryLogActualsSQL, c.addr)
+	defer span.End()
+	defer flushProgress(ctx)
+	rows, err := c.queryOpen(ctx, queryLogActualsSQL, since, shapeIDPrefix, limit)
+	c.br.record(ctx, err)
+	if err != nil {
+		if IsUnknownTable(err) {
+			return nil, nil
+		}
+		span.RecordError(err)
+		return nil, fmt.Errorf("chclient: query log actuals: %w", c.classifyDriverErr(ctx, err))
+	}
+	defer func() {
+		_ = rows.Close()
+	}()
+
+	var out []QueryLogActualRow
+	for rows.Next() {
+		var row QueryLogActualRow
+		if err := rows.Scan(&row.LogComment, &row.ReadRows, &row.ReadBytes, &row.MemoryUsage, &row.EventTime); err != nil {
+			return nil, fmt.Errorf("chclient: query log actuals scan: %w", err)
+		}
+		out = append(out, row)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("chclient: query log actuals rows.Err: %w", c.classifyDriverErr(ctx, err))
+	}
+	return out, nil
+}

--- a/internal/engine/actuals_per_rung_test.go
+++ b/internal/engine/actuals_per_rung_test.go
@@ -1,0 +1,108 @@
+package engine
+
+import (
+	"testing"
+
+	"github.com/tsouza/cerberus/internal/actuals"
+)
+
+func TestMaybeSeedPerRungAdmissionFromActuals_NoOpWithoutBothWired(t *testing.T) {
+	plan := perRungTestPlan()
+	decision := perRungTestDecision()
+
+	// Neither wired.
+	e := &Engine{}
+	e.maybeSeedPerRungAdmissionFromActuals(plan, "cerb:agg", decision)
+
+	// Only PerRungAdmission wired.
+	e = &Engine{PerRungAdmission: NewPerRungAdmissionLearner()}
+	e.maybeSeedPerRungAdmissionFromActuals(plan, "cerb:agg", decision)
+	if e.PerRungAdmission.ShouldDeclineBypass(perRungTestKey()) {
+		t.Fatal("expected no seeding with Actuals nil")
+	}
+
+	// Only Actuals wired.
+	tracker := actuals.NewTracker(actuals.DefaultConfig())
+	tracker.RecordPredicted("cerb:agg", 100)
+	e = &Engine{Actuals: tracker}
+	e.maybeSeedPerRungAdmissionFromActuals(plan, "cerb:agg", decision) // must not panic; nothing to seed
+}
+
+func TestMaybeSeedPerRungAdmissionFromActuals_SeedsOnLowCorroboratedActuals(t *testing.T) {
+	plan := perRungTestPlan()
+	decision := perRungTestDecision() // NAnchors=1441
+
+	tracker := actuals.NewTracker(actuals.DefaultConfig())
+	const shape = "cerb:agg"
+	// Two corroborating observations, both well under
+	// NAnchors*perRungCheapRowsPerAnchor = 1441*20 = 28820.
+	for i := 0; i < perRungEvidenceMinObservations; i++ {
+		if _, ok := tracker.RecordActual(shape, actuals.Actual{ReadRows: 100}, actuals.SourcePacket); !ok {
+			t.Fatal("RecordActual should succeed")
+		}
+	}
+
+	e := &Engine{PerRungAdmission: NewPerRungAdmissionLearner(), Actuals: tracker}
+	key := shapeKey(plan, decision)
+
+	// A single seed call is one observation's worth (SeedPriorFromEstimate's
+	// own doc) — it does not immediately decline the bypass, but it DOES
+	// register a fresh entry, exactly like a single EXPLAIN ESTIMATE seed
+	// would (explain_estimate_wiring_test.go's own assertion style).
+	e.maybeSeedPerRungAdmissionFromActuals(plan, shape, decision)
+	if !e.PerRungAdmission.hasFreshEntry(key) {
+		t.Fatal("expected a fresh entry after seeding from a corroborated cheap actuals reading")
+	}
+	if e.PerRungAdmission.ShouldDeclineBypass(key) {
+		t.Fatal("a single seed must not immediately decline the bypass")
+	}
+
+	// A second seed call (mirroring a second request for the same shape)
+	// reaches perRungEvidenceMinObservations and declines the bypass.
+	e.maybeSeedPerRungAdmissionFromActuals(plan, shape, decision)
+	if !e.PerRungAdmission.ShouldDeclineBypass(key) {
+		t.Fatal("expected the per-rung bypass to be declined after two corroborating seeds")
+	}
+}
+
+func TestMaybeSeedPerRungAdmissionFromActuals_NoSeedBelowMinObservations(t *testing.T) {
+	plan := perRungTestPlan()
+	decision := perRungTestDecision()
+
+	tracker := actuals.NewTracker(actuals.DefaultConfig())
+	const shape = "cerb:agg"
+	// Only ONE observation — below perRungEvidenceMinObservations.
+	if _, ok := tracker.RecordActual(shape, actuals.Actual{ReadRows: 100}, actuals.SourcePacket); !ok {
+		t.Fatal("RecordActual should succeed")
+	}
+
+	e := &Engine{PerRungAdmission: NewPerRungAdmissionLearner(), Actuals: tracker}
+	e.maybeSeedPerRungAdmissionFromActuals(plan, shape, decision)
+
+	key := shapeKey(plan, decision)
+	if e.PerRungAdmission.ShouldDeclineBypass(key) {
+		t.Fatal("expected no seeding below the corroboration floor")
+	}
+}
+
+func TestMaybeSeedPerRungAdmissionFromActuals_NoSeedWhenNotCheap(t *testing.T) {
+	plan := perRungTestPlan()
+	decision := perRungTestDecision() // NAnchors=1441, cheap floor = 28820
+
+	tracker := actuals.NewTracker(actuals.DefaultConfig())
+	const shape = "cerb:agg"
+	for i := 0; i < perRungEvidenceMinObservations; i++ {
+		// Well ABOVE the cheap floor.
+		if _, ok := tracker.RecordActual(shape, actuals.Actual{ReadRows: 1_000_000}, actuals.SourcePacket); !ok {
+			t.Fatal("RecordActual should succeed")
+		}
+	}
+
+	e := &Engine{PerRungAdmission: NewPerRungAdmissionLearner(), Actuals: tracker}
+	e.maybeSeedPerRungAdmissionFromActuals(plan, shape, decision)
+
+	key := shapeKey(plan, decision)
+	if e.PerRungAdmission.ShouldDeclineBypass(key) {
+		t.Fatal("expected no seeding when the actual EMA is not cheap relative to anchor count")
+	}
+}

--- a/internal/engine/actuals_wiring.go
+++ b/internal/engine/actuals_wiring.go
@@ -1,0 +1,154 @@
+package engine
+
+import (
+	"context"
+
+	"github.com/tsouza/cerberus/internal/actuals"
+	"github.com/tsouza/cerberus/internal/chclient"
+	"github.com/tsouza/cerberus/internal/chplan"
+	"github.com/tsouza/cerberus/internal/solver"
+	"github.com/tsouza/cerberus/internal/telemetry"
+)
+
+// actuals_wiring.go is the engine-side half of cerberus issue #2789: it
+// closes the loop the EXPLAIN ESTIMATE advisor (issue #2787,
+// explain_estimate_wiring.go) and the cardinality pre-probe (issue #2788,
+// cardinality_probe_wiring.go) leave open by feeding each advisory
+// prediction, and every dispatch's real measured resource usage, into an
+// Engine.Actuals tracker (internal/actuals) — the drift-detection core plus
+// three thinner consumer hooks:
+//
+//  1. calibrateEstimate: a bounded correction to the K-clamp's advisory
+//     estimate, folded into RequestMeta.Estimate at the SAME point
+//     ScanEstimateAdvisor/CardinalityProbeAdvisor already populate it
+//     (engine.go's classify) — "calibrate the solver's carrier-geometry
+//     cost model" without solver itself needing to import actuals at all.
+//  2. Route-memo priors with real magnitudes: routememo.Memo.
+//     RecordActualMagnitude (internal/routememo/magnitude.go), wired from
+//     per_rung_admission.go's existing perRungObservingCursor — see that
+//     file's own doc.
+//  3. Per-rung admission tightening: reuses PerRungAdmissionLearner.
+//     SeedPriorFromEstimate (per_rung_admission.go, issue #2787's own
+//     seeding mechanism) with a verdict derived from this shape's OWN
+//     measured drift, one-directional exactly like the EXPLAIN ESTIMATE
+//     seeding it sits beside — see maybeSeedPerRungAdmissionFromDrift.
+//  4. The drift-detection core itself: applyActualsCapture tags every
+//     dispatch so internal/chclient's packet fast path
+//     (WithActualsCapture) and query_log_actuals.go's batch fallback both
+//     feed the SAME Tracker, which alerts via
+//     telemetry.RecordEstimateDrift whenever a shape's real usage diverges
+//     from its EXPLAIN ESTIMATE prediction beyond the configured band.
+//
+// Every hook is reached ONLY through Engine.Actuals' own nil guard (the
+// functions below), so an Engine that never wires a Tracker (the default —
+// see actuals.Config.Enabled's own doc) is byte-unchanged, exactly like
+// every other OPTIONAL mechanism in this package (RouteMemo,
+// PerRungAdmission, ScanEstimateAdvisor, CardinalityProbeAdvisor).
+
+// applyActualsCapture tags ctx for issue #2789's actuals capture: it
+// records decision's advisory prediction (if any) into tracker, forces
+// ClickHouse's log_comment to carry decision.ShapeID (independent of
+// SettingsRules.LogCommentShape — see below), and layers
+// chclient.WithActualsCapture so the native-protocol packet fast path can
+// record the real observation once the dispatch completes.
+//
+// A no-op (ctx returned unchanged) when tracker is nil, decision is nil, or
+// decision.ShapeID is empty (engine.classify never set RequestMeta.ShapeID
+// because Actuals was nil at classification time) — every existing
+// dispatch path is reachable and byte-identical with the feature off.
+//
+// log_comment is stamped here REGARDLESS of SettingsRules.LogCommentShape:
+// that flag governs a SEPARATE, purely-observability concern (an operator
+// manually clustering system.query_log by log_comment), while actuals
+// capture's OWN query_log fallback path (query_log_actuals.go) needs
+// log_comment populated to correlate a row back to its shape whether or not
+// the operator separately opted into the observability flag. Both write
+// through the same chclient.WithQuerySetting key, so an operator who has
+// BOTH flags on pays no double-stamp cost — the second write is an
+// idempotent overwrite with the identical value (SettingsRules.apply always
+// derives the SAME planShapeID for the SAME plan).
+func applyActualsCapture(ctx context.Context, tracker *actuals.Tracker, decision *solver.Decision) context.Context {
+	if tracker == nil || decision == nil || decision.ShapeID == "" {
+		return ctx
+	}
+	if decision.HasPredictedEstimate {
+		tracker.RecordPredicted(decision.ShapeID, decision.PredictedRows)
+	}
+	ctx = chclient.WithQuerySetting(ctx, settingLogComment, decision.ShapeID)
+	return chclient.WithActualsCapture(ctx, tracker, decision.ShapeID)
+}
+
+// calibrateEstimate applies Hook 1 (this file's own doc) to est: a bounded
+// correction (actuals.Tracker.CalibrationFactor's own [0.5, 2.0] clamp)
+// derived from shapeID's tracked predicted-vs-actual history, folded into a
+// COPY of est (the caller's original is never mutated) before it reaches
+// the K clamp.
+//
+// Returns est UNCHANGED (same pointer, not even a copy) when e.Actuals is
+// nil, est is nil, est.Rows is already zero (nothing to scale), or the
+// shape has not yet accumulated enough evidence for a factor
+// (CalibrationFactor's own ok=false) — the overwhelmingly common case,
+// exactly like every other advisory signal in this file staying inert
+// until the feature is both wired AND has real evidence to act on.
+func (e *Engine) calibrateEstimate(shapeID string, est *solver.ScanEstimate) *solver.ScanEstimate {
+	if e.Actuals == nil || est == nil || est.Rows == 0 {
+		return est
+	}
+	factor, ok := e.Actuals.CalibrationFactor(shapeID)
+	if !ok {
+		return est
+	}
+	// factor is always in [0.5, 2.0] (CalibrationFactor's own clamp) and
+	// est.Rows is unsigned, so the product can never go negative — no
+	// defensive floor needed before the conversion below.
+	calibrated := *est
+	calibrated.Rows = uint64(float64(est.Rows) * factor)
+	return &calibrated
+}
+
+// maybeSeedPerRungAdmissionFromActuals applies Hook 3 (this file's own
+// doc): seeds e.PerRungAdmission with a prior derived from shapeID's OWN
+// tracked actual-rows EMA, reusing PerRungAdmissionLearner.
+// SeedPriorFromEstimate's existing one-directional (cheap=true only)
+// contract — the SAME mechanism explain_estimate_wiring.go's own
+// maybeSeedPerRungPrior already uses for a live EXPLAIN ESTIMATE round
+// trip, applied here to a ZERO-I/O read of state a PAST dispatch already
+// recorded. The comparison mirrors PerRungAdmissionLearner.Observe's own
+// (outputRows < nAnchors*perRungCheapRowsPerAnchor) — same threshold, same
+// "cheap relative to anchor count" reasoning — but against the tracked
+// ACTUAL scan-rows EMA rather than a freshly-drained composed-output count,
+// so it can fire on the shape's FIRST request of a session instead of
+// waiting for that same shape to drain cleanly through the per-rung bypass
+// at all.
+//
+// No-op when e.PerRungAdmission or e.Actuals is nil, baseline carries no
+// anchor count, or the shape's actuals snapshot has not yet reached
+// perRungEvidenceMinObservations (the SAME corroboration floor
+// Observe/ShouldDeclineBypass already require) — a single anomalous
+// actuals reading must never seed a prior any more than a single real
+// drain would.
+func (e *Engine) maybeSeedPerRungAdmissionFromActuals(plan chplan.Node, shapeID string, baseline *solver.Decision) {
+	if e.PerRungAdmission == nil || e.Actuals == nil || shapeID == "" || baseline == nil || baseline.NAnchors <= 0 {
+		return
+	}
+	report, ok := e.Actuals.Snapshot(shapeID)
+	if !ok || report.Observations < perRungEvidenceMinObservations {
+		return
+	}
+	// Real actual-rows EMAs never approach int64 overflow (~9.2e18).
+	if int64(report.ActualEMARows) >= int64(baseline.NAnchors)*perRungCheapRowsPerAnchor { //nolint:gosec // G115
+		return
+	}
+	e.PerRungAdmission.SeedPriorFromEstimate(shapeKey(plan, baseline), true)
+}
+
+// recordEstimateDriftFromQueryLog forwards one query_log-sourced
+// DriftReport to telemetry.RecordEstimateDrift, tagged
+// actuals.SourceQueryLog — the slow-path counterpart to
+// internal/chclient/progress.go's own packet-path call, kept as a tiny
+// named wrapper (rather than inlined at query_log_actuals.go's own call
+// site) purely so both drift-emission call sites read as the SAME one-line
+// shape.
+func recordEstimateDriftFromQueryLog(ctx context.Context, report actuals.DriftReport) {
+	telemetry.RecordEstimateDrift(ctx, report.Ratio, report.Alerting, actuals.SourceQueryLog.String())
+}

--- a/internal/engine/actuals_wiring_test.go
+++ b/internal/engine/actuals_wiring_test.go
@@ -1,0 +1,133 @@
+package engine
+
+import (
+	"context"
+	"testing"
+
+	"github.com/tsouza/cerberus/internal/actuals"
+	"github.com/tsouza/cerberus/internal/chclient"
+	"github.com/tsouza/cerberus/internal/solver"
+)
+
+func TestApplyActualsCapture_NoOpWhenTrackerNil(t *testing.T) {
+	decision := &solver.Decision{ShapeID: "cerb:agg;rw"}
+	ctx := context.Background()
+	got := applyActualsCapture(ctx, nil, decision)
+	if got != ctx {
+		t.Fatal("expected ctx unchanged with a nil tracker")
+	}
+}
+
+func TestApplyActualsCapture_NoOpWhenDecisionNilOrEmptyShapeID(t *testing.T) {
+	tracker := actuals.NewTracker(actuals.DefaultConfig())
+	ctx := context.Background()
+
+	if got := applyActualsCapture(ctx, tracker, nil); got != ctx {
+		t.Fatal("expected ctx unchanged with a nil decision")
+	}
+	if got := applyActualsCapture(ctx, tracker, &solver.Decision{}); got != ctx {
+		t.Fatal("expected ctx unchanged with an empty ShapeID")
+	}
+}
+
+func TestApplyActualsCapture_StampsLogCommentRegardlessOfSettingsRulesFlag(t *testing.T) {
+	tracker := actuals.NewTracker(actuals.DefaultConfig())
+	decision := &solver.Decision{ShapeID: "cerb:agg;rw"}
+
+	ctx := applyActualsCapture(context.Background(), tracker, decision)
+	settings := chclient.QuerySettingsFromContext(ctx)
+	if got := settings[settingLogComment]; got != "cerb:agg;rw" {
+		t.Fatalf("expected log_comment stamped to the shape id, got %v", got)
+	}
+}
+
+func TestApplyActualsCapture_RecordsPredictedOnlyWhenPresent(t *testing.T) {
+	tracker := actuals.NewTracker(actuals.DefaultConfig())
+
+	// No predicted estimate on this Decision: RecordPredicted must not be
+	// called (no snapshot yet).
+	applyActualsCapture(context.Background(), tracker, &solver.Decision{ShapeID: "cerb:agg;rw"})
+	if _, ok := tracker.Snapshot("cerb:agg;rw"); ok {
+		t.Fatal("expected no tracked state without a predicted estimate")
+	}
+
+	applyActualsCapture(context.Background(), tracker, &solver.Decision{
+		ShapeID: "cerb:agg;rw;rbf", HasPredictedEstimate: true, PredictedRows: 12345,
+	})
+	report, ok := tracker.Snapshot("cerb:agg;rw;rbf")
+	if !ok {
+		t.Fatal("expected a tracked prediction")
+	}
+	if !report.HasPredicted || report.PredictedRows != 12345 {
+		t.Fatalf("unexpected report: %+v", report)
+	}
+}
+
+func TestApplyActualsCapture_WiresPacketCaptureOnAlreadyProgressTrackedCtx(t *testing.T) {
+	tracker := actuals.NewTracker(actuals.DefaultConfig())
+	decision := &solver.Decision{ShapeID: "cerb:agg;rw"}
+
+	ctx := chclient.WithProgressFor(context.Background(), "promql")
+	ctx = applyActualsCapture(ctx, tracker, decision)
+
+	// Simulate the dispatch completing: the SAME shapeID must reach the
+	// tracker via the packet path once flush() runs downstream — pinned
+	// indirectly here by asserting WithActualsCapture actually wired the
+	// recorder (chclient's own test suite pins flush()'s own behavior in
+	// detail; this test only pins that applyActualsCapture composes the two
+	// calls correctly).
+	if got := chclient.QuerySettingsFromContext(ctx)[settingLogComment]; got != "cerb:agg;rw" {
+		t.Fatalf("expected log_comment stamped, got %v", got)
+	}
+}
+
+func TestCalibrateEstimate_NoOpWithoutActualsOrEstimate(t *testing.T) {
+	e := &Engine{}
+	if got := e.calibrateEstimate("cerb:agg;rw", nil); got != nil {
+		t.Fatalf("expected nil estimate to pass through nil, got %+v", got)
+	}
+
+	e.Actuals = actuals.NewTracker(actuals.DefaultConfig())
+	zero := &solver.ScanEstimate{Rows: 0}
+	if got := e.calibrateEstimate("cerb:agg;rw", zero); got != zero {
+		t.Fatal("expected a zero-Rows estimate to pass through unchanged (same pointer)")
+	}
+
+	est := &solver.ScanEstimate{Rows: 1000}
+	// No calibration evidence recorded yet: CalibrationFactor is not ok, so
+	// the SAME pointer must come back unchanged.
+	if got := e.calibrateEstimate("cerb:agg;rw", est); got != est {
+		t.Fatal("expected the estimate to pass through unchanged with no calibration evidence")
+	}
+}
+
+func TestCalibrateEstimate_AppliesBoundedCorrection(t *testing.T) {
+	e := &Engine{Actuals: actuals.NewTracker(actuals.DefaultConfig())}
+	const shape = "cerb:agg;rw"
+
+	e.Actuals.RecordPredicted(shape, 100_000)
+	for i := 0; i < 2; i++ {
+		if _, ok := e.Actuals.RecordActual(shape, actuals.Actual{ReadRows: 1_000_000}, actuals.SourcePacket); !ok {
+			t.Fatal("RecordActual should succeed")
+		}
+	}
+
+	original := &solver.ScanEstimate{Rows: 100_000, Parts: 3, Marks: 12}
+	calibrated := e.calibrateEstimate(shape, original)
+	if calibrated == original {
+		t.Fatal("expected a NEW ScanEstimate value, not the same pointer, once calibration applies")
+	}
+	// The raw ratio (10x) is clamped to maxCalibrationFactor (2.0), so Rows
+	// doubles rather than growing 10x.
+	if calibrated.Rows != 200_000 {
+		t.Fatalf("expected Rows calibrated to 200000 (2x, clamped), got %d", calibrated.Rows)
+	}
+	// Every other field is preserved verbatim.
+	if calibrated.Parts != original.Parts || calibrated.Marks != original.Marks {
+		t.Fatalf("expected Parts/Marks preserved, got %+v", calibrated)
+	}
+	// The original must never be mutated.
+	if original.Rows != 100_000 {
+		t.Fatalf("expected the original estimate untouched, got %+v", original)
+	}
+}

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -34,6 +34,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/tsouza/cerberus/internal/actuals"
 	"github.com/tsouza/cerberus/internal/cerbtrace"
 	"github.com/tsouza/cerberus/internal/chclient"
 	"github.com/tsouza/cerberus/internal/chplan"
@@ -297,6 +298,12 @@ func (e *Engine) execContext(ctx context.Context, plan chplan.Node, language str
 	// result-equivalent, like the compare() bound above.
 	ctx = applyNativeHistogramAnalyzerFix(ctx, plan)
 	ctx = e.settings().apply(ctx, plan)
+	// Issue #2789: tag this route-A dispatch for actuals capture — see
+	// applyActualsCapture's own doc. No-op (ctx unchanged) whenever Actuals
+	// is nil or decision carries no ShapeID (either because Actuals was nil
+	// back when classify() ran, or classify() never ran at all — the
+	// non-classified heads).
+	ctx = applyActualsCapture(ctx, e.Actuals, decision)
 	// Fix the per-dispatch ClickHouse query_id ONCE here, on the ctx that
 	// flows into the chclient dispatch, so the corpus reconciler records the
 	// exact same id the chclient query path later stamps via WithQueryID. The
@@ -998,6 +1005,23 @@ type Engine struct {
 	// for why the two are kept as independent advisors sharing one merge
 	// point rather than one combined mechanism.
 	CardinalityProbeAdvisor *CardinalityProbeAdvisor
+
+	// Actuals is the OPTIONAL predicted-vs-actual drift tracker (issue
+	// #2789, actuals_wiring.go). Nil unless wired from cmd/cerberus
+	// (buildActualsTracker, gated on CERBERUS_QUERY_ACTUALS_ENABLED — a
+	// plain config knob, NOT a chopt feature: see actuals.Config's own doc
+	// for why), so the default path is byte-unchanged: every dispatch that
+	// currently reaches ScanEstimateAdvisor / CardinalityProbeAdvisor /
+	// RouteMemo / PerRungAdmission stays reachable and correct exactly as
+	// before this field existed. When non-nil, classify records every
+	// advisory prediction it produces (Hook: drift-detection core) and
+	// applies a bounded calibration correction to it (Hook 1:
+	// carrier-geometry cost-model calibration, calibrateEstimate), and
+	// execContext / routeBExecCtx tag every dispatch's ctx so the
+	// native-protocol packet fast path (internal/chclient/progress.go) can
+	// record the real (rows, bytes, peak-memory) actual once the query
+	// completes.
+	Actuals *actuals.Tracker
 }
 
 // SetSettings installs rules as the per-query settings the engine evaluates
@@ -1533,13 +1557,14 @@ func (e *Engine) QueryPlan(ctx context.Context, lang Lang, plan chplan.Node, met
 // is off OR the head is not PromQL — both cases make the engine omit the
 // shadow header and stay byte-identical to the pre-solver path.
 //
-// When e.ScanEstimateAdvisor and/or e.CardinalityProbeAdvisor are wired AND
-// the deployment routes in solver.ModeAuto, classify runs a first,
-// no-estimate classification pass (pure, no I/O — see the Advise call
-// sites' own comments on why redoing it is free) purely to hand each
-// advisor a baseline Decision and let it decide, per its own doc, whether
-// the request is worth its advisory round trip. Both advisors are threaded
-// through the SAME rm.Estimate value — CardinalityProbeAdvisor.Advise folds
+// When e.ScanEstimateAdvisor and/or e.CardinalityProbeAdvisor are wired, OR
+// e.PerRungAdmission and e.Actuals are BOTH wired (issue #2789's Hook 3,
+// independent of either advisor — see perRungActualsHook below), AND the
+// deployment routes in solver.ModeAuto, classify runs a first, no-estimate
+// classification pass (pure, no I/O — see the Advise call sites' own
+// comments on why redoing it is free) purely to hand each advisor (and Hook
+// 3) a baseline Decision. Both advisors are threaded through the SAME
+// rm.Estimate value — CardinalityProbeAdvisor.Advise folds
 // its own result on top of whatever ScanEstimateAdvisor.Advise already
 // produced (nil when that one is unwired or itself skipped) — so a shape
 // needing both signals gets one merged solver.ScanEstimate, never two
@@ -1557,7 +1582,24 @@ func (e *Engine) classify(ctx context.Context, plan chplan.Node, lang Lang) (*so
 		End:   end,
 		Step:  step,
 	}
-	if (e.ScanEstimateAdvisor != nil || e.CardinalityProbeAdvisor != nil) && e.Solver.Cfg.Mode == solver.ModeAuto {
+	// Issue #2789: the shape id is threaded onto RequestMeta unconditionally
+	// whenever Actuals is wired (a pure, no-I/O plan walk — see
+	// planShapeID's own doc), independent of Mode, so withGrid (planner.go)
+	// carries it onto EVERY Decision this classify() call produces,
+	// including a non-ModeAuto one. Nil Actuals (the default) leaves
+	// rm.ShapeID at its zero value, exactly as before this field existed.
+	if e.Actuals != nil {
+		rm.ShapeID = planShapeID(plan)
+	}
+	// Hook 3 (below) needs a baseline classification pass exactly like the
+	// two advisors do, so it is folded into the SAME gate — widened here to
+	// admit "PerRungAdmission + Actuals wired, neither advisor is" as a
+	// legitimate independent configuration (the two mechanisms are gated on
+	// different knobs: ScanEstimateAdvisor/CardinalityProbeAdvisor on the
+	// chopt feature set, PerRungAdmission/Actuals on
+	// solver.Cfg.AdaptiveEnabled / CERBERUS_QUERY_ACTUALS_ENABLED).
+	perRungActualsHook := e.PerRungAdmission != nil && e.Actuals != nil
+	if (e.ScanEstimateAdvisor != nil || e.CardinalityProbeAdvisor != nil || perRungActualsHook) && e.Solver.Cfg.Mode == solver.ModeAuto {
 		baseline, _ := e.Solver.Classify(plan, rm)
 		if e.ScanEstimateAdvisor != nil {
 			emit := func(ctx context.Context, lang Lang, plan chplan.Node) (string, []any, error) {
@@ -1573,6 +1615,18 @@ func (e *Engine) classify(ctx context.Context, plan chplan.Node, lang Lang) (*so
 		if e.CardinalityProbeAdvisor != nil {
 			rm.Estimate = e.CardinalityProbeAdvisor.Advise(ctx, e.RouteMemo, plan, baseline, rm.Estimate)
 		}
+		// Hook 1 (issue #2789): calibrate the advisory estimate against this
+		// shape's OWN measured drift history before it ever reaches the K
+		// clamp — a bounded correction (actuals.CalibrationFactor's own
+		// [0.5, 2.0] clamp), never a new fitting loop. No-op (rm.Estimate
+		// unchanged) whenever Actuals is nil, rm.Estimate is nil, or the
+		// shape has not yet accumulated enough evidence.
+		rm.Estimate = e.calibrateEstimate(rm.ShapeID, rm.Estimate)
+		// Hook 3 (issue #2789): seed the per-rung admission learner from
+		// this shape's OWN tracked actuals history — see
+		// maybeSeedPerRungAdmissionFromActuals's own doc. No-op unless both
+		// PerRungAdmission and Actuals are wired.
+		e.maybeSeedPerRungAdmissionFromActuals(plan, rm.ShapeID, baseline)
 	}
 	return e.Solver.Classify(plan, rm)
 }
@@ -1680,8 +1734,16 @@ func routeBExecCtx(
 	deltaPrefixLookback time.Duration, deltaPrefixReadEnabled bool,
 	bounds ResourceBoundOverrides,
 	rangeBucketGridNativeMaxRows, rangeBucketGridNativeMaxDensityUnits int64,
+	actualsTracker *actuals.Tracker,
 ) context.Context {
 	ctx = chclient.WithResponseShape(chclient.WithProgressFor(ctx, langName), responseShape)
+	// Issue #2789: tag this route-B dispatch for actuals capture — see
+	// applyActualsCapture's own doc. Threaded here (rather than assumed
+	// already on ctx) because route B is the SAME funnel every
+	// non-baseline dispatch site shares (this function's own doc: "the
+	// four of them: executeRouted, ... the route-memo hit and the A->B
+	// retry"), so wiring it here covers all four in one place.
+	ctx = applyActualsCapture(ctx, actualsTracker, decision)
 	if decisionHasTSGridNative(decision) {
 		ctx = chclient.WithTSGridSetting(ctx)
 	}
@@ -1765,7 +1827,10 @@ func (e *Engine) executeRouted(
 	execT := telemetry.ObserveStage(telemetry.StageExecute, lang.Name())
 	start := time.Now()
 	cursor, info, err := e.Solver.Executor.Execute(
-		routeBExecCtx(ctx, lang.Name(), meta.ResponseShape, decision, e.DeltaPrefixLookback, e.DeltaPrefixReadEnabled, e.resourceBoundOverrides(), e.RangeBucketGridNativeMaxRows, e.RangeBucketGridNativeMaxDensityUnits), lang.Name(), decision, chclient.SampleBudgetFromContext(ctx),
+		routeBExecCtx(
+			ctx, lang.Name(), meta.ResponseShape, decision, e.DeltaPrefixLookback, e.DeltaPrefixReadEnabled,
+			e.resourceBoundOverrides(), e.RangeBucketGridNativeMaxRows, e.RangeBucketGridNativeMaxDensityUnits, e.Actuals,
+		), lang.Name(), decision, chclient.SampleBudgetFromContext(ctx),
 	)
 	if err != nil {
 		execT.Done(ctx)
@@ -2270,7 +2335,10 @@ func (e *Engine) executeRoutedCursor(
 	execT := telemetry.ObserveStage(telemetry.StageExecute, lang.Name())
 	start := time.Now()
 	cursor, info, err := e.Solver.Executor.Execute(
-		routeBExecCtx(ctx, lang.Name(), meta.ResponseShape, decision, e.DeltaPrefixLookback, e.DeltaPrefixReadEnabled, e.resourceBoundOverrides(), e.RangeBucketGridNativeMaxRows, e.RangeBucketGridNativeMaxDensityUnits), lang.Name(), decision, chclient.SampleBudgetFromContext(ctx),
+		routeBExecCtx(
+			ctx, lang.Name(), meta.ResponseShape, decision, e.DeltaPrefixLookback, e.DeltaPrefixReadEnabled,
+			e.resourceBoundOverrides(), e.RangeBucketGridNativeMaxRows, e.RangeBucketGridNativeMaxDensityUnits, e.Actuals,
+		), lang.Name(), decision, chclient.SampleBudgetFromContext(ctx),
 	)
 	execT.Done(ctx)
 	if err != nil {
@@ -2282,7 +2350,7 @@ func (e *Engine) executeRoutedCursor(
 	// evidence-based per-rung refinement, which supplies its OWN drain-time
 	// site by wrapping the cursor below.
 	e.observeRoutedQuery(info, plan, lang.Name(), decision)
-	cursor = wrapPerRungObserver(cursor, e.PerRungAdmission, plan, decision)
+	cursor = wrapPerRungObserver(cursor, e.PerRungAdmission, e.RouteMemo, plan, decision)
 
 	nodes := cerbtrace.CountNodes(plan)
 	strategy := strategyFor(meta)

--- a/internal/engine/per_rung_admission.go
+++ b/internal/engine/per_rung_admission.go
@@ -167,13 +167,16 @@ func (l *PerRungAdmissionLearner) record(key routememo.Key, cheap bool) {
 // same always-safe direction a wrong REAL observation already costs.
 //
 // cheap accepts either value for the same reason Observe does (this method
-// is a general building block, not itself the policy), but the ONE caller
-// (explain_estimate_wiring.go's maybeSeedPerRungPrior) only ever passes
-// true: a scan-side estimate is safe evidence FOR near-empty (an aggregate
-// cannot emit a meaningful value from samples it never read) but not
-// reliable evidence AGAINST it (dense raw data can still collapse to a
-// small composed result) — see that call site's own doc for why treating a
-// large estimate as cheap=false would risk resetting real accumulated
+// is a general building block, not itself the policy), but BOTH callers —
+// explain_estimate_wiring.go's maybeSeedPerRungPrior (issue #2787, a live
+// EXPLAIN ESTIMATE round trip) and actuals_wiring.go's
+// maybeSeedPerRungAdmissionFromActuals (issue #2789, a zero-I/O read of a
+// PAST dispatch's tracked actuals) — only ever pass true: a near-empty
+// scan-side signal is safe evidence FOR near-empty (an aggregate cannot
+// emit a meaningful value from samples it never read) but not reliable
+// evidence AGAINST it (dense raw data can still collapse to a small
+// composed result) — see either call site's own doc for why treating a
+// large reading as cheap=false would risk resetting real accumulated
 // evidence on an imprecise proxy. A single seed only ever advances
 // consecutiveCheap by one observation's worth (never jumps straight past
 // perRungEvidenceMinObservations), so a shape whose estimate is wrong once
@@ -272,12 +275,24 @@ func (e *Engine) refinePerRungAdmission(plan chplan.Node, decision *solver.Decis
 // wrapper IS that site — it changes no behavior the caller observes (every
 // method but Close delegates straight through the embedded Cursor) and only
 // ever reads Err()/Inspected() after Close(), never influencing either.
+//
+// routeMemo is issue #2789's hook 2 (routememo.Memo.RecordActualMagnitude's
+// own doc): OPTIONAL and independent of learner — either, both, or neither
+// may be nil, and each is fed from the SAME clean drain independently. A
+// per-rung predictive dispatch's routememo.Key (perRungAdmissionKey) is
+// computed with the identical routememo.KeyFor(plan, decision.NAnchors,
+// decision.Fanout, decision.Step) formula route_memo_wiring.go's own
+// deriveRouteMemoDispatch uses for the SAME plan/decision, so a magnitude
+// recorded here lands on the SAME Key the route memo's own routing state
+// already tracks — without this wrapper needing to touch
+// route_memo_wiring.go's own dispatch call graph at all.
 type perRungObservingCursor struct {
 	chclient.Cursor
-	learner  *PerRungAdmissionLearner
-	key      routememo.Key
-	nAnchors int64
-	once     sync.Once
+	learner   *PerRungAdmissionLearner
+	routeMemo *routememo.Memo
+	key       routememo.Key
+	nAnchors  int64
+	once      sync.Once
 }
 
 // Close delegates to the wrapped cursor first (this must never change teardown
@@ -286,28 +301,35 @@ type perRungObservingCursor struct {
 // caller, and a second observation must not double-count. Only a CLEAN drain
 // (Err() == nil) is trusted evidence — see PerRungAdmissionLearner.Observe's
 // own doc for why a cancelled/truncated drain must never be recorded as
-// "cheap".
+// "cheap"; the same reasoning applies to routeMemo's magnitude reading.
 func (c *perRungObservingCursor) Close() error {
 	err := c.Cursor.Close()
 	c.once.Do(func() {
-		if c.Err() == nil {
+		if c.Err() != nil {
+			return
+		}
+		if c.learner != nil {
 			c.learner.Observe(c.key, c.Inspected(), c.nAnchors)
+		}
+		if c.routeMemo != nil && c.Inspected() >= 0 {
+			c.routeMemo.RecordActualMagnitude(c.key, uint64(c.Inspected())) //nolint:gosec // G115 -- guarded by the >= 0 check above
 		}
 	})
 	return err
 }
 
-// wrapPerRungObserver returns cursor unchanged when learner is nil or the
-// dispatch was not a per-rung predictive route — every other route-B cursor
-// stays exactly what Executor.Execute returned.
-func wrapPerRungObserver(cursor chclient.Cursor, learner *PerRungAdmissionLearner, plan chplan.Node, decision *solver.Decision) chclient.Cursor {
-	if learner == nil || decision == nil || !decision.PerRungPredictive {
+// wrapPerRungObserver returns cursor unchanged when BOTH learner and
+// routeMemo are nil, or the dispatch was not a per-rung predictive route —
+// every other route-B cursor stays exactly what Executor.Execute returned.
+func wrapPerRungObserver(cursor chclient.Cursor, learner *PerRungAdmissionLearner, routeMemo *routememo.Memo, plan chplan.Node, decision *solver.Decision) chclient.Cursor {
+	if (learner == nil && routeMemo == nil) || decision == nil || !decision.PerRungPredictive {
 		return cursor
 	}
 	return &perRungObservingCursor{
-		Cursor:   cursor,
-		learner:  learner,
-		key:      perRungAdmissionKey(plan, decision),
-		nAnchors: int64(decision.NAnchors),
+		Cursor:    cursor,
+		learner:   learner,
+		routeMemo: routeMemo,
+		key:       perRungAdmissionKey(plan, decision),
+		nAnchors:  int64(decision.NAnchors),
 	}
 }

--- a/internal/engine/per_rung_admission_test.go
+++ b/internal/engine/per_rung_admission_test.go
@@ -227,14 +227,14 @@ func TestWrapPerRungObserver_PassesThroughWhenNotApplicable(t *testing.T) {
 	t.Parallel()
 	fake := &perRungFakeCursor{}
 
-	if got := wrapPerRungObserver(fake, nil, perRungTestPlan(), perRungTestDecision()); got != chclient.Cursor(fake) {
+	if got := wrapPerRungObserver(fake, nil, nil, perRungTestPlan(), perRungTestDecision()); got != chclient.Cursor(fake) {
 		t.Error("a nil learner must return the cursor unchanged")
 	}
 
 	notPerRung := perRungTestDecision()
 	notPerRung.PerRungPredictive = false
 	l := NewPerRungAdmissionLearner()
-	if got := wrapPerRungObserver(fake, l, perRungTestPlan(), notPerRung); got != chclient.Cursor(fake) {
+	if got := wrapPerRungObserver(fake, l, nil, perRungTestPlan(), notPerRung); got != chclient.Cursor(fake) {
 		t.Error("a non-PerRungPredictive decision must return the cursor unchanged")
 	}
 }
@@ -250,7 +250,7 @@ func TestWrapPerRungObserver_RecordsOnlyOnACleanDrain(t *testing.T) {
 	// cancel after 19s), which would otherwise teach the learner the
 	// opposite of the truth.
 	cancelled := &perRungFakeCursor{err: errors.New("context canceled"), inspected: 1}
-	wrapped := wrapPerRungObserver(cancelled, l, plan, decision)
+	wrapped := wrapPerRungObserver(cancelled, l, nil, plan, decision)
 	if err := wrapped.Close(); err != nil {
 		t.Fatalf("Close returned an unexpected error: %v", err)
 	}
@@ -262,7 +262,7 @@ func TestWrapPerRungObserver_RecordsOnlyOnACleanDrain(t *testing.T) {
 	// mirroring two distinct requests) accumulate toward the decline.
 	for i := 0; i < perRungEvidenceMinObservations; i++ {
 		clean := &perRungFakeCursor{inspected: 1}
-		wrapped := wrapPerRungObserver(clean, l, plan, decision)
+		wrapped := wrapPerRungObserver(clean, l, nil, plan, decision)
 		if err := wrapped.Close(); err != nil {
 			t.Fatalf("Close returned an unexpected error: %v", err)
 		}
@@ -280,7 +280,7 @@ func TestWrapPerRungObserver_DoubleCloseRecordsOnce(t *testing.T) {
 	key := routememo.KeyFor(plan, decision.NAnchors, decision.Fanout, decision.Step)
 
 	clean := &perRungFakeCursor{inspected: 1}
-	wrapped := wrapPerRungObserver(clean, l, plan, decision)
+	wrapped := wrapPerRungObserver(clean, l, nil, plan, decision)
 	_ = wrapped.Close()
 	_ = wrapped.Close()
 

--- a/internal/engine/query_log_actuals.go
+++ b/internal/engine/query_log_actuals.go
@@ -1,0 +1,153 @@
+package engine
+
+import (
+	"context"
+	"log/slog"
+	"time"
+
+	"github.com/tsouza/cerberus/internal/actuals"
+)
+
+// query_log_actuals.go is issue #2789's batch/fallback actuals source: it
+// polls system.query_log for cerberus-stamped queries (log_comment carrying
+// a "cerb:..." plan-shape id — see plan_shape_id.go's shapeIDPrefix) and
+// feeds their (read_rows, read_bytes, memory_usage) into an
+// actuals.Tracker as SourceQueryLog, for the queries the native-protocol
+// packet fast path (internal/chclient/progress.go) could not observe: one
+// that failed before completing (flush() never runs on that path), or a
+// deployment mode where packet capture is not wired.
+//
+// Genuinely a SLOW path by construction — system.query_log's own async
+// flush lag (docs/operations.md) means a row surfaces here well after the
+// query that produced it finished — so QueryLogActualsReconciler is
+// designed around a poll interval and a watermark, never assumed to arrive
+// synchronously with the query it describes. Mirrors
+// internal/optcorpus.Reconciler's own Run(ctx)/ticker shape (the
+// established pattern in this codebase for a background system.query_log
+// poller), independently implemented rather than shared: optcorpus reads a
+// DIFFERENT row shape for a different purpose (the whole performance
+// corpus, joined on query_id) and this package must not import optcorpus
+// (.go-arch-lint.yml: optcorpus is wired from cmd only, and importing it
+// here would pull its own sink/ring machinery for a feature that needs
+// none of it).
+
+// queryLogActualsBatchLimit bounds how many rows a single poll tick reads
+// from system.query_log — a hard ceiling on ONE round trip's result size,
+// independent of how long the tracker's own resident capacity
+// (actuals.trackerCapacity) is, so a burst of cerberus-stamped traffic
+// between two polls cannot make one tick's query unboundedly large.
+const queryLogActualsBatchLimit = 1000
+
+// QueryLogQuerier is the narrow chclient seam
+// QueryLogActualsReconciler depends on — *chclient.Client in production,
+// faked in tests so this file's polling/watermark logic is testable
+// without a live ClickHouse. Mirrors explain_estimate_wiring.go's own
+// Estimator interface.
+type QueryLogQuerier interface {
+	QueryLogActuals(ctx context.Context, since time.Time, shapeIDPrefix string, limit int) ([]QueryLogActualRow, error)
+}
+
+// QueryLogActualRow mirrors chclient.QueryLogActualRow field-for-field —
+// declared locally so this package's polling logic depends only on the
+// narrow QueryLogQuerier interface, never chclient's concrete type,
+// exactly like explain_estimate_wiring.go's Estimator seam. cmd/cerberus's
+// wiring adapts *chclient.Client's real return type to this one (the two
+// structs are identical; the adapter is a one-line type conversion — see
+// buildQueryLogActualsReconciler in cmd/cerberus/main.go).
+type QueryLogActualRow struct {
+	LogComment  string
+	ReadRows    uint64
+	ReadBytes   uint64
+	MemoryUsage uint64
+	EventTime   time.Time
+}
+
+// QueryLogActualsReconciler is the OPTIONAL background poller backing this
+// file's own doc. Construct with NewQueryLogActualsReconciler; the zero
+// value is not usable.
+type QueryLogActualsReconciler struct {
+	client   QueryLogQuerier
+	tracker  *actuals.Tracker
+	interval time.Duration
+	lookback time.Duration
+	logger   *slog.Logger
+
+	now func() time.Time // overridable by tests
+}
+
+// NewQueryLogActualsReconciler constructs a reconciler. logger may be nil
+// (a poll failure is then silently swallowed rather than logged — see
+// poll's own doc for why a failure is never fatal either way).
+func NewQueryLogActualsReconciler(client QueryLogQuerier, tracker *actuals.Tracker, cfg actuals.Config, logger *slog.Logger) *QueryLogActualsReconciler {
+	return &QueryLogActualsReconciler{
+		client:   client,
+		tracker:  tracker,
+		interval: cfg.QueryLogPollInterval,
+		lookback: cfg.QueryLogLookback,
+		logger:   logger,
+		now:      time.Now,
+	}
+}
+
+// Run polls until ctx is cancelled — the caller's background-goroutine
+// lifecycle owns when this returns (cmd/cerberus wires it into the same
+// graceful-shutdown group every other background reconciler in this
+// process uses). Mirrors internal/optcorpus.Reconciler.Run's own
+// ticker/select shape.
+func (r *QueryLogActualsReconciler) Run(ctx context.Context) {
+	if r.client == nil || r.tracker == nil {
+		<-ctx.Done()
+		return
+	}
+	since := r.now().Add(-r.lookback)
+	ticker := time.NewTicker(r.interval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			since = r.poll(ctx, since)
+		}
+	}
+}
+
+// poll reads every cerberus-stamped system.query_log row with
+// event_time > since, feeds each into the tracker as SourceQueryLog, emits
+// the drift-alert telemetry for any row with enough prediction history to
+// compute a ratio, and returns the new watermark: the latest EventTime seen,
+// or the UNCHANGED since on any query failure (retry from the same
+// watermark next tick, rather than either advancing past unread rows or
+// re-reading the whole lookback window forever). A query failure is never
+// fatal — this is a best-effort fallback path layered on top of the packet
+// fast path, so an operator's query_log misconfiguration (not enabled,
+// insufficient permissions) must never crash the process, only leave this
+// ONE source degraded — logged when a logger is wired, silently swallowed
+// otherwise.
+func (r *QueryLogActualsReconciler) poll(ctx context.Context, since time.Time) time.Time {
+	rows, err := r.client.QueryLogActuals(ctx, since, shapeIDPrefix, queryLogActualsBatchLimit)
+	if err != nil {
+		if r.logger != nil {
+			r.logger.Warn("query_log actuals poll failed", "err", err)
+		}
+		return since
+	}
+	next := since
+	for _, row := range rows {
+		if row.LogComment == "" {
+			continue
+		}
+		report, ok := r.tracker.RecordActual(row.LogComment, actuals.Actual{
+			ReadRows:   row.ReadRows,
+			ReadBytes:  row.ReadBytes,
+			PeakMemory: row.MemoryUsage,
+		}, actuals.SourceQueryLog)
+		if ok && report.HasPredicted {
+			recordEstimateDriftFromQueryLog(ctx, report)
+		}
+		if row.EventTime.After(next) {
+			next = row.EventTime
+		}
+	}
+	return next
+}

--- a/internal/engine/query_log_actuals_test.go
+++ b/internal/engine/query_log_actuals_test.go
@@ -1,0 +1,130 @@
+package engine
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/tsouza/cerberus/internal/actuals"
+)
+
+type fakeQueryLogQuerier struct {
+	rows []QueryLogActualRow
+	err  error
+
+	calls      int
+	lastSince  time.Time
+	lastPrefix string
+	lastLimit  int
+}
+
+func (f *fakeQueryLogQuerier) QueryLogActuals(_ context.Context, since time.Time, shapeIDPrefix string, limit int) ([]QueryLogActualRow, error) {
+	f.calls++
+	f.lastSince = since
+	f.lastPrefix = shapeIDPrefix
+	f.lastLimit = limit
+	if f.err != nil {
+		return nil, f.err
+	}
+	return f.rows, nil
+}
+
+func testActualsConfig() actuals.Config {
+	cfg := actuals.DefaultConfig()
+	cfg.Enabled = true
+	return cfg
+}
+
+func TestQueryLogActualsReconciler_PollFeedsTrackerAndAdvancesWatermark(t *testing.T) {
+	t1 := time.Date(2026, 8, 31, 0, 0, 0, 0, time.UTC)
+	t2 := t1.Add(time.Minute)
+	fake := &fakeQueryLogQuerier{rows: []QueryLogActualRow{
+		{LogComment: "cerb:agg;rw", ReadRows: 1000, ReadBytes: 8000, MemoryUsage: 500, EventTime: t1},
+		{LogComment: "cerb:agg;rw;rbf", ReadRows: 2000, ReadBytes: 16000, MemoryUsage: 900, EventTime: t2},
+	}}
+	tracker := actuals.NewTracker(testActualsConfig())
+	r := NewQueryLogActualsReconciler(fake, tracker, testActualsConfig(), nil)
+
+	since := time.Time{}
+	next := r.poll(context.Background(), since)
+
+	if next != t2 {
+		t.Fatalf("expected the watermark to advance to the latest EventTime %v, got %v", t2, next)
+	}
+	if fake.lastPrefix != shapeIDPrefix {
+		t.Fatalf("expected the shape id prefix %q, got %q", shapeIDPrefix, fake.lastPrefix)
+	}
+	if fake.lastLimit != queryLogActualsBatchLimit {
+		t.Fatalf("expected the batch limit %d, got %d", queryLogActualsBatchLimit, fake.lastLimit)
+	}
+
+	report, ok := tracker.Snapshot("cerb:agg;rw")
+	if !ok || report.ActualEMARows != 1000 || report.LastSource != actuals.SourceQueryLog {
+		t.Fatalf("expected the first row recorded as SourceQueryLog, got %+v (ok=%v)", report, ok)
+	}
+	report, ok = tracker.Snapshot("cerb:agg;rw;rbf")
+	if !ok || report.ActualEMARows != 2000 {
+		t.Fatalf("expected the second row recorded, got %+v (ok=%v)", report, ok)
+	}
+}
+
+func TestQueryLogActualsReconciler_PollFailureKeepsWatermark(t *testing.T) {
+	fake := &fakeQueryLogQuerier{err: errors.New("query_log disabled")}
+	tracker := actuals.NewTracker(testActualsConfig())
+	r := NewQueryLogActualsReconciler(fake, tracker, testActualsConfig(), nil)
+
+	since := time.Date(2026, 8, 31, 0, 0, 0, 0, time.UTC)
+	next := r.poll(context.Background(), since)
+	if !next.Equal(since) {
+		t.Fatalf("expected the watermark to stay unchanged on a query failure, got %v want %v", next, since)
+	}
+}
+
+func TestQueryLogActualsReconciler_SkipsRowsWithNoLogComment(t *testing.T) {
+	fake := &fakeQueryLogQuerier{rows: []QueryLogActualRow{
+		{LogComment: "", ReadRows: 999, EventTime: time.Now()},
+	}}
+	tracker := actuals.NewTracker(testActualsConfig())
+	r := NewQueryLogActualsReconciler(fake, tracker, testActualsConfig(), nil)
+
+	r.poll(context.Background(), time.Time{})
+	if stats := tracker.Stats(); stats.Entries != 0 {
+		t.Fatalf("expected an empty log_comment row to be skipped, got %+v", stats)
+	}
+}
+
+func TestQueryLogActualsReconciler_RunStopsOnContextCancel(t *testing.T) {
+	fake := &fakeQueryLogQuerier{}
+	tracker := actuals.NewTracker(testActualsConfig())
+	cfg := testActualsConfig()
+	cfg.QueryLogPollInterval = time.Millisecond
+	r := NewQueryLogActualsReconciler(fake, tracker, cfg, nil)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() {
+		r.Run(ctx)
+		close(done)
+	}()
+
+	// Let it poll at least once, then stop it.
+	time.Sleep(10 * time.Millisecond)
+	cancel()
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("Run did not stop within 1s of ctx cancellation")
+	}
+	if fake.calls == 0 {
+		t.Fatal("expected at least one poll before cancellation")
+	}
+}
+
+func TestQueryLogActualsReconciler_RunNoOpWithoutClientOrTracker(t *testing.T) {
+	r := NewQueryLogActualsReconciler(nil, nil, testActualsConfig(), nil)
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Millisecond)
+	defer cancel()
+	r.Run(ctx) // must return once ctx is done, not hang or panic
+}

--- a/internal/engine/route_b_tsgrid_setting_test.go
+++ b/internal/engine/route_b_tsgrid_setting_test.go
@@ -117,7 +117,7 @@ func TestRouteBExecCtx_StampsTSGridSettingForNativeShards(t *testing.T) {
 			t.Parallel()
 
 			ctx := routeBExecCtx(context.Background(), "promql",
-				chclient.ResponseShapeMatrix, tsGridRouteBDecision(tc.wrap), 0, false, ResourceBoundOverrides{}, 0, 0)
+				chclient.ResponseShapeMatrix, tsGridRouteBDecision(tc.wrap), 0, false, ResourceBoundOverrides{}, 0, 0, nil)
 
 			settings := chclient.QuerySettingsFromContext(ctx)
 			_, got := settings[chclient.SettingExperimentalTSGridAggregate]
@@ -144,7 +144,7 @@ func TestRouteBExecCtx_StampsTSGridSettingForNativeShards(t *testing.T) {
 func TestRouteBExecCtx_NilDecisionStampsNothing(t *testing.T) {
 	t.Parallel()
 
-	ctx := routeBExecCtx(context.Background(), "promql", chclient.ResponseShapeMatrix, nil, 0, false, ResourceBoundOverrides{}, 0, 0)
+	ctx := routeBExecCtx(context.Background(), "promql", chclient.ResponseShapeMatrix, nil, 0, false, ResourceBoundOverrides{}, 0, 0, nil)
 	if settings := chclient.QuerySettingsFromContext(ctx); len(settings) != 0 {
 		t.Fatalf("nil decision stamped settings %v", settings)
 	}

--- a/internal/engine/route_memo_wiring.go
+++ b/internal/engine/route_memo_wiring.go
@@ -175,7 +175,7 @@ func (e *Engine) tryRouteMemoHit(
 	defer dispatchDone()
 
 	cur, execInfo, err := e.Solver.Executor.Execute(
-		routeBExecCtx(ctx, langName, responseShape, d.decision, e.DeltaPrefixLookback, e.DeltaPrefixReadEnabled, e.resourceBoundOverrides(), e.RangeBucketGridNativeMaxRows, e.RangeBucketGridNativeMaxDensityUnits), langName, d.decision, budget,
+		routeBExecCtx(ctx, langName, responseShape, d.decision, e.DeltaPrefixLookback, e.DeltaPrefixReadEnabled, e.resourceBoundOverrides(), e.RangeBucketGridNativeMaxRows, e.RangeBucketGridNativeMaxDensityUnits, e.Actuals), langName, d.decision, budget,
 	)
 	if err != nil {
 		// A pre-flight failure (breaker/emit/gate/now64) classifies
@@ -304,7 +304,7 @@ func (e *Engine) retryOnRouteAResourceFailure(
 	dispatchDone := telemetry.ObserveRoutedDispatchInflight(ctx)
 
 	cur, execInfo, dispatchErr := e.Solver.Executor.Execute(
-		routeBExecCtx(ctx, langName, responseShape, d.decision, e.DeltaPrefixLookback, e.DeltaPrefixReadEnabled, e.resourceBoundOverrides(), e.RangeBucketGridNativeMaxRows, e.RangeBucketGridNativeMaxDensityUnits), langName, d.decision, budget,
+		routeBExecCtx(ctx, langName, responseShape, d.decision, e.DeltaPrefixLookback, e.DeltaPrefixReadEnabled, e.resourceBoundOverrides(), e.RangeBucketGridNativeMaxRows, e.RangeBucketGridNativeMaxDensityUnits, e.Actuals), langName, d.decision, budget,
 	)
 	if dispatchErr != nil {
 		// A pre-flight failure classifies NoEvidence by construction —

--- a/internal/routememo/magnitude.go
+++ b/internal/routememo/magnitude.go
@@ -1,0 +1,85 @@
+package routememo
+
+import "time"
+
+// magnitude.go closes issue #2789's route-memo consumer, hook 2: refresh the
+// route memo's priors with REAL MAGNITUDES, not just the success/failure
+// bits Verdict already carries. The memo's existing state (Verdict.state,
+// Verdict.corroboration) answers "should route B be tried for this Key" —
+// a pure outcome bit — and says nothing about HOW MUCH data a successful
+// route-B dispatch for that Key actually moved. RecordActualMagnitude adds
+// that second, purely OBSERVATIONAL axis without touching the outcome
+// axis at all: it never creates, deletes, or changes a Key's LookupState,
+// eviction order, or TTL, and no existing method's behavior changes by one
+// bit. Deliberately a THIN hook (this file's own doc names it as such,
+// mirroring issue #2789's own "the others can be thinner initial hooks"
+// allowance for its three non-primary consumers): the magnitude is recorded
+// for observability today (Stats-style callers, an operator dashboard,
+// internal/engine's actuals wiring), and is architecture the memo already
+// supports for a future routing use — but this file itself makes no routing
+// decision based on it.
+//
+// Only a LIVE (unexpired) entry is updated — RecordActualMagnitude never
+// CREATES an entry, unlike every state-transition method in memo.go. A
+// magnitude reading is meaningless without an existing verdict to annotate:
+// there is no routing state for it to describe otherwise.
+
+// magnitudeEMAAlpha bounds the per-observation influence of a fresh
+// magnitude reading on a Key's tracked average rows, mirroring
+// internal/actuals.Config's own EMAAlpha default (0.2) and its
+// bounded-influence rationale (issue #2789's anti-autotune stance,
+// restated here because this is a second, independent implementation of
+// the same bound rather than a shared helper — routememo must not import
+// internal/actuals, see .go-arch-lint.yml).
+const magnitudeEMAAlpha = 0.2
+
+// RecordActualMagnitude records outputRows as one fresh observation of how
+// much data a route-B dispatch for k actually produced, updating a bounded
+// exponential moving average — the same bounded-influence shape
+// internal/actuals.Tracker.RecordActual uses for its own EMA, applied here
+// to route memo's Key granularity instead of a plan-shape-id string. No-op
+// when k has no live (unexpired) entry: see this file's own doc for why a
+// magnitude never creates one.
+func (m *Memo) RecordActualMagnitude(k Key, outputRows uint64) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	v, live := m.getLiveLocked(k, m.now())
+	if !live {
+		return
+	}
+	if v.magnitudeObservations == 0 {
+		v.magnitudeEMARows = float64(outputRows)
+	} else {
+		v.magnitudeEMARows += magnitudeEMAAlpha * (float64(outputRows) - v.magnitudeEMARows)
+	}
+	v.magnitudeObservations++
+	v.magnitudeObservedAt = m.now()
+}
+
+// MagnitudeFor returns k's tracked actual-magnitude EMA, or ok=false when
+// k has no live entry or no magnitude has ever been recorded for it (the
+// overwhelmingly common case today: RecordActualMagnitude has exactly one
+// caller, per_rung_admission.go's perRungObservingCursor, so most Keys
+// carry no magnitude reading at all).
+func (m *Memo) MagnitudeFor(k Key) (rows float64, observations int, ok bool) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	v, live := m.getLiveLocked(k, m.now())
+	if !live || v.magnitudeObservations == 0 {
+		return 0, 0, false
+	}
+	return v.magnitudeEMARows, v.magnitudeObservations, true
+}
+
+// magnitudeObservedAtFor is a test-only accessor for
+// Verdict.magnitudeObservedAt, so magnitude_test.go can assert the
+// bookkeeping timestamp without exporting the field itself.
+func (m *Memo) magnitudeObservedAtFor(k Key) time.Time {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	v, live := m.getLiveLocked(k, m.now())
+	if !live {
+		return time.Time{}
+	}
+	return v.magnitudeObservedAt
+}

--- a/internal/routememo/magnitude_test.go
+++ b/internal/routememo/magnitude_test.go
@@ -1,0 +1,101 @@
+package routememo
+
+import (
+	"testing"
+	"time"
+)
+
+func TestRecordActualMagnitude_NoOpWithoutLiveEntry(t *testing.T) {
+	m := New(testPressureWindow)
+	k := testKey("agg")
+
+	// No entry at all yet.
+	m.RecordActualMagnitude(k, 1000)
+	if _, _, ok := m.MagnitudeFor(k); ok {
+		t.Fatal("RecordActualMagnitude must not create an entry")
+	}
+}
+
+func TestRecordActualMagnitude_UpdatesLiveEntryOnly(t *testing.T) {
+	m := New(testPressureWindow)
+	k := testKey("agg")
+
+	// Establish a live PreferB entry the normal way.
+	m.Observe(k, RouteB, OutcomeSuccess)
+	if state, _ := m.Lookup(k); state != PreferB {
+		t.Fatalf("expected PreferB after a route-B success, got %v", state)
+	}
+
+	m.RecordActualMagnitude(k, 500)
+	rows, obs, ok := m.MagnitudeFor(k)
+	if !ok {
+		t.Fatal("expected a magnitude reading on a live entry")
+	}
+	if rows != 500 || obs != 1 {
+		t.Fatalf("expected (500, 1), got (%v, %d)", rows, obs)
+	}
+
+	// A second, wildly different observation moves the EMA but does not
+	// jump straight to it (bounded influence — magnitudeEMAAlpha < 1).
+	m.RecordActualMagnitude(k, 50_000)
+	rows, obs, ok = m.MagnitudeFor(k)
+	if !ok {
+		t.Fatal("expected a magnitude reading after the second observation")
+	}
+	if obs != 2 {
+		t.Fatalf("expected 2 observations, got %d", obs)
+	}
+	wantEMA := 500 + magnitudeEMAAlpha*(50_000-500)
+	if rows != wantEMA {
+		t.Fatalf("expected the bounded EMA step to %v, got %v", wantEMA, rows)
+	}
+	if rows >= 50_000 {
+		t.Fatalf("a single new observation must not fully move the EMA, got %v", rows)
+	}
+}
+
+func TestRecordActualMagnitude_NeverChangesRoutingState(t *testing.T) {
+	m := New(testPressureWindow)
+	k := testKey("agg")
+	m.Observe(k, RouteB, OutcomeSuccess)
+
+	stateBefore, staleBefore := m.Lookup(k)
+	statsBefore := m.Stats()
+
+	m.RecordActualMagnitude(k, 1)
+	m.RecordActualMagnitude(k, 1_000_000)
+
+	stateAfter, staleAfter := m.Lookup(k)
+	statsAfter := m.Stats()
+
+	if stateBefore != stateAfter || staleBefore != staleAfter {
+		t.Fatalf("RecordActualMagnitude must never change LookupState: before=(%v,%v) after=(%v,%v)",
+			stateBefore, staleBefore, stateAfter, staleAfter)
+	}
+	if statsBefore != statsAfter {
+		t.Fatalf("RecordActualMagnitude must never change Stats: before=%+v after=%+v", statsBefore, statsAfter)
+	}
+}
+
+func TestMagnitudeFor_NoReadingIsOK(t *testing.T) {
+	m := New(testPressureWindow)
+	k := testKey("agg")
+	m.Observe(k, RouteB, OutcomeSuccess)
+
+	if _, _, ok := m.MagnitudeFor(k); ok {
+		t.Fatal("expected MagnitudeFor to report ok=false before any magnitude is ever recorded")
+	}
+}
+
+func TestRecordActualMagnitude_StampsObservedAt(t *testing.T) {
+	m := New(testPressureWindow)
+	k := testKey("agg")
+	now := time.Date(2026, 8, 31, 0, 0, 0, 0, time.UTC)
+	m.SetNowForTest(func() time.Time { return now })
+
+	m.Observe(k, RouteB, OutcomeSuccess)
+	m.RecordActualMagnitude(k, 42)
+	if got := m.magnitudeObservedAtFor(k); !got.Equal(now) {
+		t.Fatalf("expected magnitudeObservedAt to be stamped to %v, got %v", now, got)
+	}
+}

--- a/internal/routememo/memo.go
+++ b/internal/routememo/memo.go
@@ -110,6 +110,16 @@ type Verdict struct {
 	// corroboration is the consecutive route-A ResourceFailure count with
 	// no intervening Success, for an Unknown (not-yet-probed) entry only.
 	corroboration int
+
+	// magnitudeEMARows / magnitudeObservations / magnitudeObservedAt are the
+	// OBSERVATIONAL (never routing-decision-affecting) real-magnitude axis
+	// issue #2789 adds — see magnitude.go's own doc. Untouched by every
+	// state-transition method in this file; only RecordActualMagnitude ever
+	// writes them, and only Lookup/eviction ever clear them (implicitly,
+	// by replacing or deleting the Verdict itself).
+	magnitudeEMARows      float64
+	magnitudeObservations int
+	magnitudeObservedAt   time.Time
 }
 
 // Memo is the bounded, in-process failure-driven route memo (docs/solver.md

--- a/internal/solver/decision.go
+++ b/internal/solver/decision.go
@@ -51,6 +51,21 @@ type RequestMeta struct {
 	// round trip itself: the I/O already happened, by the caller, before
 	// Plan/Classify/Eligible ever runs.
 	Estimate *ScanEstimate
+
+	// ShapeID is the literal-free plan-shape id the engine adapter already
+	// computed for this request (internal/engine/plan_shape_id.go's
+	// planShapeID — the SAME "cerb:..." id SettingsRules stamps into
+	// ClickHouse's log_comment), threaded through PURELY so
+	// Decision.ShapeID (withGrid, below) can carry it onto the routing
+	// output without solver recomputing a plan-shape fingerprint of its
+	// own (it already has routememo.KeyFor for the memo's own coarser
+	// key — see that package's doc for why the two fingerprints are
+	// deliberately not the same granularity). Empty when the caller has no
+	// actuals tracker wired (issue #2789's own kill switch) — every
+	// existing Planner behavior is unaffected either way, since neither
+	// Plan nor Eligible ever reads this field for a routing decision, only
+	// withGrid copies it through.
+	ShapeID string
 }
 
 // ScanEstimate is the package-local advisory read-out of a ClickHouse scan
@@ -153,6 +168,29 @@ type Decision struct {
 	// evidence-based scrutiny only to the latter population. False on every
 	// other route and on every non-route.
 	PerRungPredictive bool
+
+	// ShapeID is a pure, additive readout of RequestMeta.ShapeID (see that
+	// field's own doc), copied through by withGrid onto EVERY Decision —
+	// routed or not — exactly like NAnchors/Fanout/CumulativeD/OuterRange/
+	// Step above. Empty when the caller left RequestMeta.ShapeID unset
+	// (issue #2789's kill switch off, the default). Consumed by
+	// internal/engine's actuals wiring (both route-A's execContext and
+	// route-B's routeBExecCtx) to tag a dispatch's ctx for the
+	// native-protocol packet capture, and by the query_log fallback
+	// reconciler as the correlation key back to system.query_log's
+	// log_comment column.
+	ShapeID string
+
+	// HasPredictedEstimate / PredictedRows mirror RequestMeta.Estimate.Rows
+	// (see that field's own doc) onto the Decision that was actually routed
+	// on, for the SAME "pure readout, changes no routing behavior" reason
+	// every other withGrid field exists: internal/engine's actuals wiring
+	// needs the EXACT prediction the K clamp saw for THIS decision, not a
+	// second, possibly-stale read of RequestMeta after Plan/Eligible
+	// returns. HasPredictedEstimate is false (and PredictedRows 0) whenever
+	// meta.Estimate was nil — the overwhelmingly common case.
+	HasPredictedEstimate bool
+	PredictedRows        uint64
 }
 
 // StrategyShardedTimeslice is the only decomposition strategy emitted:

--- a/internal/solver/planner.go
+++ b/internal/solver/planner.go
@@ -382,8 +382,10 @@ func notRouted(reason string) *Decision {
 }
 
 // withGrid stamps the RAW classifier cost scalars (N/F/D/OuterRange/Step)
-// onto the Decision from the eligibility-pass signals plus the request grid.
-// It is a pure readout of values analyze already computed — it changes no
+// onto the Decision from the eligibility-pass signals plus the request grid,
+// plus meta's ShapeID and advisory Estimate (issue #2789's actuals wiring —
+// see Decision.ShapeID / Decision.HasPredictedEstimate's own docs). It is a
+// pure readout of values analyze/the caller already computed — it changes no
 // routing behavior — and is applied to BOTH routed and not-routed decisions
 // so the calibration corpus can compare route-A and route-B cost
 // distributions at equal (N, F, D). Returns the receiver for chaining.
@@ -393,6 +395,11 @@ func (d *Decision) withGrid(sig signals, meta RequestMeta) *Decision {
 	d.CumulativeD = sig.cumulativeD
 	d.OuterRange = sig.outerRange
 	d.Step = meta.Step
+	d.ShapeID = meta.ShapeID
+	if meta.Estimate != nil {
+		d.HasPredictedEstimate = true
+		d.PredictedRows = meta.Estimate.Rows
+	}
 	return d
 }
 

--- a/internal/solver/shape_id_propagation_test.go
+++ b/internal/solver/shape_id_propagation_test.go
@@ -1,0 +1,71 @@
+package solver
+
+import "testing"
+
+// TestWithGrid_PropagatesShapeIDAndEstimate pins issue #2789's own additive
+// readout: withGrid copies RequestMeta.ShapeID and RequestMeta.Estimate.Rows
+// onto EVERY Decision it stamps — routed or not — exactly like the existing
+// N/F/D/OuterRange/Step cost-grid fields, so internal/engine's actuals
+// wiring can read them off the SAME Decision the caller already has without
+// a second lookup.
+func TestWithGrid_PropagatesShapeIDAndEstimate(t *testing.T) {
+	meta := oomMeta()
+	meta.ShapeID = "cerb:agg;rw"
+	meta.Estimate = &ScanEstimate{Rows: 12345}
+
+	p := &Planner{Cfg: autoCfg()}
+	decision, routed := p.Plan(oomWindow(), meta)
+	if !routed {
+		t.Fatalf("expected the OOM fixture to route, got Reason=%q", decision.Reason)
+	}
+	if decision.ShapeID != "cerb:agg;rw" {
+		t.Fatalf("expected ShapeID to propagate onto a routed Decision, got %q", decision.ShapeID)
+	}
+	if !decision.HasPredictedEstimate || decision.PredictedRows != 12345 {
+		t.Fatalf("expected the Estimate to propagate onto a routed Decision, got HasPredictedEstimate=%v PredictedRows=%d",
+			decision.HasPredictedEstimate, decision.PredictedRows)
+	}
+}
+
+// TestWithGrid_PropagatesShapeIDOnNonRoutedDecision pins the same
+// propagation for a plan that does NOT route — ModeSingle refuses every
+// plan with ReasonRoutingDisabled, but withGrid still runs on that refusal
+// (planner.go's own doc: "applied to BOTH routed and not-routed
+// decisions").
+func TestWithGrid_PropagatesShapeIDOnNonRoutedDecision(t *testing.T) {
+	meta := oomMeta()
+	meta.ShapeID = "cerb:agg;rw"
+
+	cfg := DefaultConfig() // Mode == ModeSingle
+	p := &Planner{Cfg: cfg}
+	decision, routed := p.Plan(oomWindow(), meta)
+	if routed {
+		t.Fatal("expected ModeSingle to never route")
+	}
+	if decision.Reason != ReasonRoutingDisabled {
+		t.Fatalf("expected ReasonRoutingDisabled, got %q", decision.Reason)
+	}
+	if decision.ShapeID != "cerb:agg;rw" {
+		t.Fatalf("expected ShapeID to propagate onto a non-routed Decision too, got %q", decision.ShapeID)
+	}
+}
+
+// TestWithGrid_EmptyShapeIDAndNilEstimateByDefault pins the kill-switch-off
+// byte-unchanged contract: a caller that never sets RequestMeta.ShapeID /
+// Estimate (every existing caller, and any caller with issue #2789's
+// actuals feature off) gets a Decision with an empty ShapeID and
+// HasPredictedEstimate=false, exactly as before this field existed.
+func TestWithGrid_EmptyShapeIDAndNilEstimateByDefault(t *testing.T) {
+	p := &Planner{Cfg: autoCfg()}
+	decision, routed := p.Plan(oomWindow(), oomMeta())
+	if !routed {
+		t.Fatalf("expected the OOM fixture to route, got Reason=%q", decision.Reason)
+	}
+	if decision.ShapeID != "" {
+		t.Fatalf("expected an empty ShapeID by default, got %q", decision.ShapeID)
+	}
+	if decision.HasPredictedEstimate || decision.PredictedRows != 0 {
+		t.Fatalf("expected no predicted estimate by default, got HasPredictedEstimate=%v PredictedRows=%d",
+			decision.HasPredictedEstimate, decision.PredictedRows)
+	}
+}

--- a/internal/telemetry/metrics.go
+++ b/internal/telemetry/metrics.go
@@ -64,6 +64,12 @@ const (
 	// construction: derived from the status code's family, never from
 	// the code itself.
 	AttrStatusClass = attribute.Key("cerberus.status_class")
+	// AttrActualsSource is which capture path (issue #2789) produced an
+	// actuals observation — "packet" (native-protocol progress/
+	// ProfileEvents, the fast path) or "query_log" (the batch/fallback
+	// path). Bounded by construction: mirrors actuals.Source.String()'s own
+	// closed two-value vocabulary, never a raw string.
+	AttrActualsSource = attribute.Key("cerberus.actuals_source")
 )
 
 // RouteMemoDecline label values for AttrReason on RouteMemoHitSkippedTotal —
@@ -218,6 +224,25 @@ type Instruments struct {
 	// signal of a systematic exemplar outage; without it the failure
 	// is indistinguishable from "no exemplars in this window" (#1460).
 	ExemplarFailuresTotal metric.Int64Counter
+
+	// EstimateDriftRatio is the distribution of actuals.DriftReport.Ratio
+	// (actual-EMA-rows / predicted-rows) recorded on every RecordActual call
+	// that had enough corroborating evidence to compute a ratio at all
+	// (issue #2789's drift-detection core). Attribute:
+	// cerberus.actuals_source. This is the primary dogfooding surface for
+	// "the EXPLAIN-ESTIMATE bias never silently rots" — an operator graphs
+	// this alongside EstimateDriftAlertsTotal rather than needing to poll
+	// Tracker.Stats() out of process.
+	EstimateDriftRatio metric.Float64Histogram
+
+	// EstimateDriftAlertsTotal counts every RecordActual call whose
+	// resulting DriftReport.Alerting was true — the predicted-vs-actual
+	// ratio fell outside the configured band after enough observations to
+	// trust it. Attribute: cerberus.actuals_source. This is the alert
+	// surface issue #2789 exists to add: `rate(...)` over this counter on a
+	// dashboard/alert rule is how an operator learns a shape's EXPLAIN
+	// ESTIMATE prior has drifted, instead of it silently rotting.
+	EstimateDriftAlertsTotal metric.Int64Counter
 }
 
 // Histogram bucket boundaries, one ladder per instrument, matched to the
@@ -274,6 +299,16 @@ var (
 	// BytesReadBoundaries covers ClickHouse bytes read per query —
 	// decade-exponential from 10KB to 10GB.
 	BytesReadBoundaries = []float64{1e4, 1e5, 1e6, 1e7, 1e8, 1e9, 1e10}
+
+	// EstimateDriftRatioBoundaries covers actuals.DriftReport.Ratio
+	// (actual/predicted) — log-shaped around 1.0 since EXPLAIN ESTIMATE's
+	// own upper-bound bias (internal/actuals's own doc) means the
+	// EXPECTED mass sits well below 1.0, with the dangerous tail extending
+	// above it. Matches the default drift band
+	// (actuals.defaultDriftLowerRatio=0.1, defaultDriftUpperRatio=3.0) with
+	// enough resolution on both sides to see how close to the band edge a
+	// shape sits before it actually crosses into alerting.
+	EstimateDriftRatioBoundaries = []float64{0.01, 0.05, 0.1, 0.2, 0.5, 1, 2, 3, 5, 10, 50, 100}
 )
 
 var (
@@ -413,6 +448,23 @@ func mustBuild(meter metric.Meter) *Instruments {
 	if err != nil {
 		panic("telemetry: build tempo_exemplar_failures_total: " + err.Error())
 	}
+	estimateDriftRatio, err := meter.Float64Histogram(
+		"cerberus_solver_estimate_drift_ratio",
+		metric.WithDescription("actual/predicted rows ratio per recorded actuals observation, by capture source (issue #2789)."),
+		metric.WithUnit("1"),
+		metric.WithExplicitBucketBoundaries(EstimateDriftRatioBoundaries...),
+	)
+	if err != nil {
+		panic("telemetry: build solver_estimate_drift_ratio: " + err.Error())
+	}
+	estimateDriftAlerts, err := meter.Int64Counter(
+		"cerberus_solver_estimate_drift_alerts_total",
+		metric.WithDescription("Actuals observations whose predicted-vs-actual ratio fell outside the configured band, by capture source (issue #2789)."),
+		metric.WithUnit("{alert}"),
+	)
+	if err != nil {
+		panic("telemetry: build solver_estimate_drift_alerts_total: " + err.Error())
+	}
 	return &Instruments{
 		QueriesTotal:             queriesTotal,
 		QueryDuration:            queryDuration,
@@ -426,6 +478,8 @@ func mustBuild(meter metric.Meter) *Instruments {
 		RoutedDispatchInflight:   routedDispatchInflight,
 		RouteABSuccessTotal:      routeABSuccess,
 		ExemplarFailuresTotal:    exemplarFailures,
+		EstimateDriftRatio:       estimateDriftRatio,
+		EstimateDriftAlertsTotal: estimateDriftAlerts,
 	}
 }
 
@@ -618,4 +672,28 @@ func RecordRouteABSuccess(ctx context.Context, route string) {
 // shared by both the HTTP and gRPC Tempo metrics entrypoints.
 func RecordTempoExemplarFailure(ctx context.Context, stage string) {
 	Get().ExemplarFailuresTotal.Add(ctx, 1, metric.WithAttributes(AttrStage.String(stage)))
+}
+
+// RecordEstimateDrift records one predicted-vs-actual drift ratio (issue
+// #2789's drift-detection core, internal/actuals.Tracker.RecordActual's own
+// DriftReport) onto EstimateDriftRatio, and additionally increments
+// EstimateDriftAlertsTotal when alerting — the ALERT surface an operator
+// graphs `rate(cerberus_solver_estimate_drift_alerts_total[..])` against so
+// the EXPLAIN-ESTIMATE bias never silently rots.
+//
+// Takes the ratio/alerting verdict as plain values rather than
+// internal/actuals's own DriftReport type: telemetry is a commonComponent
+// every layer may import (.go-arch-lint.yml), and pulling a specific
+// feature package's type in here would invert that — actuals stays the one
+// importing telemetry, never the reverse. Caller is internal/chclient's
+// packet-path flush() and internal/engine's query_log fallback reconciler
+// (source distinguishing the two), both of which already have a
+// DriftReport in hand and pass its Ratio/Alerting fields through.
+func RecordEstimateDrift(ctx context.Context, ratio float64, alerting bool, source string) {
+	attrs := metric.WithAttributes(AttrActualsSource.String(source))
+	inst := Get()
+	inst.EstimateDriftRatio.Record(ctx, ratio, attrs)
+	if alerting {
+		inst.EstimateDriftAlertsTotal.Add(ctx, 1, attrs)
+	}
 }

--- a/test/coverage-floor/internal__actuals.json
+++ b/test/coverage-floor/internal__actuals.json
@@ -1,0 +1,3 @@
+{
+  "internal/actuals": 89.2
+}


### PR DESCRIPTION
## Summary

Closes #2789.

Closes the loop the EXPLAIN ESTIMATE pre-flight advisor (#2787, PR #2836) and the cardinality pre-probe (#2788, PR #2841) leave open: both predict a plan's scan cost before dispatch, and nothing anywhere in `internal/solver` was ever checked against what the query actually consumed.

- `internal/actuals` (new package): a bounded, in-process `Tracker` keyed by the same literal-free plan-shape id `SettingsRules` stamps into ClickHouse's `log_comment`. Records the most recent advisory prediction and a bounded exponential moving average of the real `(read_rows, read_bytes, peak_memory)` a dispatch of that shape actually consumed, and computes a predicted-vs-actual `DriftReport` (ratio + `Alerting`) once enough corroborating observations exist. Pure leaf (stdlib only, like `internal/routememo`), so it's importable from both `chclient` (below `engine` in the layering) and `engine`.
- `internal/chclient`: `progress.go` now also registers the native protocol's `ProfileEvents` packets (`WithActualsCapture`) — `MemoryTrackerPeakUsage` supplies peak memory, verified live against ClickHouse 26.6 (not documented on ClickHouse's own reference). These packets already stream for every query regardless (`WithoutProfileEvents` is the only reason the driver exposes an opt-**out**), so this adds no round trip, only the already-flowing packet's parse cost — which is why it's wired only when the feature is on, never unconditionally. A real bug surfaced and got fixed here: route B's per-shard dispatch (`internal/solver/executor.go`'s `runShard`) calls `WithProgressFor` a **second** time per shard, which used to silently discard whatever the outer `WithActualsCapture` had wired — an `actualsIntent` context value (independent of the mutable recorder) now survives that re-derivation, so every shard's fresh recorder still reports into the tracker.
- `internal/engine`:
  - `plan_shape_id`/`query_settings_rules` unchanged; `actuals_wiring.go` (new) ties everything together: `applyActualsCapture` tags every dispatch (route A via `execContext`, route B via `routeBExecCtx` — the single funnel all four route-B call sites share), forcing `log_comment` regardless of `SettingsRules.LogCommentShape` (a separate, purely-observability flag) so the query_log fallback can always correlate.
  - `query_log_actuals.go` (new): a watermark-based background reconciler polling `system.query_log` for `log_comment LIKE 'cerb:%'` `QueryFinish` rows — the batch/fallback source for a query the packet path missed (failed before completing, or packet capture not wired). Column shapes verified against a live ClickHouse 26.6 server, not assumed (`log_comment` String, `read_rows`/`read_bytes`/`memory_usage` UInt64, `event_time` DateTime, `type` the expected `Enum8`).
  - Four consumers: **(1) drift-detection core** — `telemetry.RecordEstimateDrift` records every ratio on `cerberus_solver_estimate_drift_ratio` and increments `cerberus_solver_estimate_drift_alerts_total` when alerting (attribute `cerberus.actuals_source`); **(2) carrier-geometry calibration** — `calibrateEstimate` applies a bounded `[0.5, 2.0]`-clamped correction to the advisory `ScanEstimate.Rows` before it reaches the K clamp; **(3) per-rung admission tightening** — `maybeSeedPerRungAdmissionFromActuals` reuses `PerRungAdmissionLearner.SeedPriorFromEstimate` (issue #2787's own one-directional seeding) with a zero-I/O read of tracked actuals instead of a live round trip; **(4) route-memo magnitude** — `internal/routememo/magnitude.go`'s `RecordActualMagnitude`/`MagnitudeFor` add a purely observational axis (never touches `LookupState`, eviction, or TTL — see "Why the failure-driven route memo is NOT seeded" in `docs/solver.md`), wired from `per_rung_admission.go`'s existing `perRungObservingCursor.Close()`.
- `internal/solver`: `RequestMeta` gains `ShapeID`; `Decision` gains `ShapeID`/`HasPredictedEstimate`/`PredictedRows`, all copied through by `withGrid` (the single funnel every `Decision` — routed or not — already passes through), mirroring exactly how #2787 added `Estimate`. Solver itself never imports `internal/actuals` — it only carries the id/estimate through so `engine`'s dispatch-context wiring can tag the ctx.
- `cmd/cerberus`: `buildActualsTracker` wires the feature (Prom-only, like `RouteMemo`/`PerRungAdmission`/`ScanEstimateAdvisor` — the solver is PromQL-only) and starts the query_log reconciler goroutine, mirroring `startOptCorpus`'s own shape.
- `docs/solver.md` / `docs/configuration.md` (regenerated via `cmd_configdocs.go`'s template — hand-editing the generated file doesn't stick): new sections with the real measurements below.

## Not a chopt registry entry

Per the issue's own framing: ProfileEvents on the native protocol and `system.query_log` are both ancient, always-available ClickHouse surfaces with no version floor to probe. `CERBERUS_QUERY_ACTUALS_ENABLED` (default `false`) is a plain solver-policy config knob living in `internal/actuals`'s own `Config`/`ConfigFromEnv`, mirroring `solver.Config.AdaptiveEnabled`'s own posture rather than `chopt.EnabledSet`.

## Anti-autotune stance (issue #2788's own precedent)

Every EMA update moves at most `EMAAlpha` (default 0.2) of the way toward a single new observation; `CalibrationFactor` clamps to `[0.5, 2.0]`; every alert requires `MinObservations` (default 2) corroborating readings. This is an input to existing policies (the K clamp, the per-rung learner), never a new fitting loop — the same boundary the retired threshold-fitting autotune (#1273) crossed.

## Kill-switch / backward compatibility

`CERBERUS_QUERY_ACTUALS_ENABLED` defaults to `false`. With it off, `Engine.Actuals` is `nil` and every new call site (`applyActualsCapture`, `calibrateEstimate`, `maybeSeedPerRungAdmissionFromActuals`, `WithActualsCapture`, `RecordActualMagnitude`'s only caller) short-circuits to a no-op — every existing routing/admission path (the failure-driven route memo, the per-rung admission learner, the EXPLAIN ESTIMATE advisor, the cardinality pre-probe) is byte-unchanged.

## Scope (deliberately narrow — filed #2853 for the rest)

- Per-rung admission only ever **tightens** (declines the bypass), never **relaxes** one already declined — mirrors `PerRungAdmissionLearner`'s existing one-directional seeding for EXPLAIN ESTIMATE.
- Route-memo magnitude tracking is observation-only; nothing reads `MagnitudeFor` back into a routing decision yet.
- `actuals.Tracker` is in-process/ephemeral (resets on restart) — no durable sink like `optcorpus`'s.
- Each route-B shard records its own actual independently into the tracked EMA rather than the executor folding K shard totals into one per-request observation first.

All four tracked in [#2853](https://github.com/tsouza/cerberus/issues/2853).

## Measured (real data against a live ClickHouse 26.6 server, not assumed)

`system.query_log`'s column shapes were verified live before relying on them (`log_comment` String, `read_rows`/`read_bytes`/`memory_usage` UInt64, `event_time` DateTime, `type` the expected `Enum8('QueryStart'=1,'QueryFinish'=2,...)`).

A realistic drift scenario was reproduced live rather than constructed synthetically: `EXPLAIN ESTIMATE` against a 1,000-row table (`Rows: 1000` — the "cached admission-time estimate" `ScanEstimateAdvisor`'s 30-minute TTL would hold), then 1,000,000 more matching rows inserted (a traffic burst landing between the cached estimate and the real dispatch), then the identical query dispatched for real: `system.query_log` reported `read_rows = 1,001,000` — a **1001x** predicted-vs-actual ratio. Replayed through the real `internal/actuals.Tracker` (two corroborating observations): `DriftReport.Alerting = true`, and `CalibrationFactor` correctly clamped to its `2.0` ceiling rather than propagating the raw 1001x multiplier.

A second, cleaner comparison (stable table, no growth) landed within noise: 8,192 predicted vs. 8,192 actual on a `minmax`-prunable `PREWHERE` range; 5,000,000 vs. 5,000,000 on a full-table `PREWHERE` scan — confirming no false-alarming when nothing has actually drifted. Full tables and discussion in `docs/solver.md`'s new "Query actuals" section.

`ProfileEvents`'s `MemoryTrackerPeakUsage` counter was also confirmed live (not documented on ClickHouse's own reference): a `SELECT count()` over one granule reported `MemoryTrackerPeakUsage=301166`, matching `system.query_log.memory_usage=301166` for the identical query — the two independent capture paths agree.

## Test plan

- [x] `internal/actuals`: unit tests for the EMA bound, the drift band (including the "zero prediction never alerts" and TTL-expiry edge cases), and the bounded `CalibrationFactor` clamp in both directions.
- [x] `internal/chclient`: unit tests for `onProgress`/`onProfileEvents` latching, `WithActualsCapture`'s composition with `WithProgressFor` in both orderings, and — the real bug found during implementation — a test pinning that a **second** `WithProgressFor` call (route B's per-shard shape) inherits the actuals intent onto its own fresh recorder.
- [x] `internal/engine`: unit tests for `applyActualsCapture`, `calibrateEstimate`, `maybeSeedPerRungAdmissionFromActuals` (including the corroboration-floor and not-cheap negative cases), and the `query_log_actuals.go` reconciler (poll success/failure/empty-log_comment, watermark advance, `Run` stopping on ctx cancel).
- [x] `internal/routememo`: unit tests for `RecordActualMagnitude`/`MagnitudeFor` pinning that they never change `LookupState`, eviction, or `Stats`.
- [x] `internal/solver`: unit tests pinning that `withGrid` propagates `ShapeID`/`PredictedRows`/`HasPredictedEstimate` onto both routed and non-routed `Decision`s, and stays empty/false by default.
- [x] Live ClickHouse 26.6 verification (standalone container, not the shared compose stack) for: `system.query_log` real column shapes, the real `MemoryTrackerPeakUsage` ProfileEvents counter, the `chclient.QueryLogActuals` SQL end-to-end, and the reproduced drift scenario above.
- [x] `go build ./...`, `go test -race ./internal/actuals/... ./internal/chclient/... ./internal/engine/... ./internal/solver/... ./internal/routememo/... ./internal/telemetry/... ./cmd/...` — green.
- [x] `just test-unit` (full repo) — green.
- [x] `just vet-tagged` — clean.
- [x] `just lint` (both untagged and tagged build) — 0 issues.
- [x] `go-arch-lint check` — clean (`actuals` declared as a new leaf component; `chclient`/`engine` gain an edge to it).
- [x] `node .github/scripts/forbid-sql-raw.mjs` — clean (`chclient.QueryLogActuals`'s SQL follows the same hand-written-literal-for-infra-probes pattern as `explain_estimate.go`/`view_refresh_state.go`).
- [x] `just gen-config-docs` / `just lint-md` — regenerated cleanly, 0 markdown lint errors.
- [x] Filed [#2853](https://github.com/tsouza/cerberus/issues/2853) for the four scoped-down extensions before opening this PR.
