### PR TITLE
feat(promql): add operator opt-in downsampled long-range tier (#2751)

### DIFF
--- a/.go-arch-lint.yml
+++ b/.go-arch-lint.yml
@@ -208,6 +208,14 @@ components:
   # its own narrow Conn contract rather than importing chclient, mirroring
   # routerrules. Wired from cmd/cerberus only.
   deltaprefix:    { in: deltaprefix }
+  # Backfills + verifies the operator opt-in downsampled long-range tier
+  # (cerberus issue #2751). Composes its INSERT ... SELECT / TRUNCATE /
+  # SELECT queries via the typed chsql Frag API, so it depends on chsql
+  # (chsql -> chplan, no cycle) and schema (a commonComponent, for the
+  # fixed schema.DownsampleTier* table/column names). Re-declares its own
+  # narrow Conn contract rather than importing chclient, mirroring
+  # deltaprefix exactly. Wired from cmd/cerberus only.
+  downsampletier: { in: downsampletier }
   # Offline migration preview support: harvests a PromQL corpus from rule files
   # (promrules) and assembles the explain report over the chplan IR. Wired from
   # cmd/cerberus only.
@@ -363,6 +371,16 @@ deps:
   # the CLI (cmd/cerberus, arch-lint-exempt) supplies the resolved config +
   # the narrow Conn at boot, mirroring routerrules.
   deltaprefix:
+    mayDependOn:
+      - chsql
+
+  # downsampletier composes its backfill/rebuild/verify SQL via the typed
+  # chsql Frag API, so it depends on chsql (chsql -> chplan, no cycle).
+  # schema is available via commonComponents for the fixed
+  # schema.DownsampleTier* names. It must NOT depend on engine or chclient
+  # — the CLI (cmd/cerberus, arch-lint-exempt) supplies the resolved config
+  # + the narrow Conn at boot, mirroring deltaprefix exactly.
+  downsampletier:
     mayDependOn:
       - chsql
 

--- a/cmd/cerberus/cmd_migrate.go
+++ b/cmd/cerberus/cmd_migrate.go
@@ -233,6 +233,10 @@ func newMigrateSchemaCmd() *cobra.Command {
 			// issue #2771) — also AutoSelect=false, so the same
 			// explicit-listing-only reasoning applies.
 			cfg.SchemaTempoTagCatalogMV = chopt.ExplicitlyRequested(cfg.CHOptimizations, chopt.FeatureTempoTagCatalogMV)
+			// Same best-effort preview for downsample_tier (cerberus issue
+			// #2751) — also AutoSelect=false, so the same
+			// explicit-listing-only reasoning applies.
+			cfg.SchemaDownsampleTier = chopt.ExplicitlyRequested(cfg.CHOptimizations, chopt.FeatureDownsampleTier)
 			return writeSchema(cmd.OutOrStdout(), cfg)
 		},
 	}

--- a/cmd/cerberus/cmd_schema.go
+++ b/cmd/cerberus/cmd_schema.go
@@ -14,6 +14,7 @@ import (
 	"github.com/tsouza/cerberus/internal/chclient"
 	"github.com/tsouza/cerberus/internal/config"
 	"github.com/tsouza/cerberus/internal/deltaprefix"
+	"github.com/tsouza/cerberus/internal/downsampletier"
 	"github.com/tsouza/cerberus/internal/migrateverify"
 	"github.com/tsouza/cerberus/internal/schemaboot"
 )
@@ -60,6 +61,9 @@ func newSchemaCmd() *cobra.Command {
 	cmd.AddCommand(
 		newSchemaDeltaPrefixBackfillCmd(),
 		newSchemaDeltaPrefixVerifyCmd(),
+		newSchemaDownsampleTierBackfillCmd(),
+		newSchemaDownsampleTierRebuildCmd(),
+		newSchemaDownsampleTierVerifyCmd(),
 	)
 	return cmd
 }
@@ -389,6 +393,329 @@ func unionMetricNames(rep deltaprefix.Report) map[string]struct{} {
 		out[name] = struct{}{}
 	}
 	for name := range rep.BaseTotals {
+		out[name] = struct{}{}
+	}
+	return out
+}
+
+// downsampleTierColumns builds the downsampletier.Columns a schema verb
+// needs from cfg — unlike deltaPrefixColumns there is no "empty means not
+// opted in" pre-flight check: schema.DownsampleTierTable is a fixed
+// constant (see that package's doc for why), always non-empty, so a
+// deployment that never provisioned the table simply gets ClickHouse's own
+// UNKNOWN_TABLE error at the first statement instead of a friendlier
+// upfront message.
+func downsampleTierColumns(cfg config.Config) downsampletier.Columns {
+	return downsampletier.FromSchema(cfg.ClickHouse.Database, cfg.Schema)
+}
+
+// downsampleTierBackfillInputs carries newSchemaDownsampleTierBackfillCmd's
+// resolved flags to runDownsampleTierBackfill.
+type downsampleTierBackfillInputs struct {
+	before string
+	dryRun bool
+}
+
+// newSchemaDownsampleTierBackfillCmd builds `cerberus schema
+// downsample-tier-backfill` — the one-time historical backfill into the
+// downsampled long-range tier for data that predates its materialized
+// view's own creation (cerberus issue #2751; see internal/downsampletier's
+// package doc and docs/operations.md for the full runbook).
+func newSchemaDownsampleTierBackfillCmd() *cobra.Command {
+	var in downsampleTierBackfillInputs
+	cmd := &cobra.Command{
+		Use:   "downsample-tier-backfill",
+		Short: "One-time historical backfill into the downsampled long-range tier",
+		Long: "Backfill the downsampled long-range tier (CERBERUS_CH_OPTIMIZATIONS=\n" +
+			"downsample_tier, cerberus issue #2751) for history that predates its\n" +
+			"materialized view: the MV only captures INSERTs into the base sum table\n" +
+			"from the moment it was created onward, so existing history needs this\n" +
+			"one-time INSERT ... SELECT pass. --before MUST be the MV's own creation\n" +
+			"timestamp (system.tables.metadata_modification_time, or an\n" +
+			"operator-recorded timestamp from the moment CREATE MATERIALIZED VIEW\n" +
+			"ran) — the SAME exact-instant bound discipline\n" +
+			"`cerberus schema delta-prefix-backfill` uses, and for the identical\n" +
+			"reason (see that command's --help). Run this AS SOON AS POSSIBLE after\n" +
+			"creating the table/MV: a day already past the target table's own TTL\n" +
+			"(CERBERUS_SCHEMA_TTL_METRICS) as of the moment this runs is written,\n" +
+			"then reaped by ClickHouse's own background merge almost immediately —\n" +
+			"permanently unrecoverable by any re-run. This command detects that case\n" +
+			"and prints a WARNING (not an error) listing the affected day(s) rather\n" +
+			"than succeeding silently.",
+		Example:       "  cerberus schema downsample-tier-backfill --before 2026-08-20T14:32:10Z",
+		Args:          cobra.NoArgs,
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return runDownsampleTierBackfill(cmd, in)
+		},
+	}
+	f := cmd.Flags()
+	f.StringVar(&in.before, "before", "",
+		"REQUIRED: the downsample-tier MV's creation timestamp (RFC3339, Unix seconds, or relative like -24h/now)")
+	f.BoolVar(&in.dryRun, "dry-run", false, "print the INSERT ... SELECT statement without executing it")
+	return cmd
+}
+
+func runDownsampleTierBackfill(cmd *cobra.Command, in downsampleTierBackfillInputs) error {
+	if in.before == "" {
+		return errors.New("missing --before: the downsample-tier MV's creation timestamp " +
+			"(see `cerberus schema downsample-tier-backfill --help`)")
+	}
+	before, err := migrateverify.ParseTime(in.before, time.Now().UTC())
+	if err != nil {
+		return fmt.Errorf("parse --before: %w", err)
+	}
+
+	cfg, err := config.FromEnv()
+	if err != nil {
+		return fmt.Errorf("load config from environment: %w", err)
+	}
+	cols := downsampleTierColumns(cfg)
+
+	if in.dryRun {
+		sql, args := downsampletier.BackfillSQL(cols, before)
+		fmt.Fprintln(cmd.OutOrStdout(), sql)
+		fmt.Fprintf(cmd.OutOrStdout(), "-- args: %v\n", args)
+		return nil
+	}
+
+	retention := schemaboot.MetricsRetention(cfg)
+
+	client, err := chclient.New(cfg.ClickHouse)
+	if err != nil {
+		return fmt.Errorf("connect ClickHouse: %w", err)
+	}
+	defer func() { _ = client.Close() }()
+
+	result, err := downsampletier.Backfill(context.Background(), client.Conn(), cols, before, retention)
+	if err != nil {
+		return err
+	}
+	fmt.Fprintf(cmd.OutOrStdout(), "backfilled the downsample tier from %s (rows strictly before %s)\n",
+		cols.SumTable, before.Format(time.RFC3339))
+	if len(result.OutsideRetentionDays) > 0 {
+		writeOutsideRetentionWarning(cmd.OutOrStdout(), "the downsample tier", result.OutsideRetentionDays)
+	}
+	return nil
+}
+
+// downsampleTierRebuildInputs carries newSchemaDownsampleTierRebuildCmd's
+// resolved flags to runDownsampleTierRebuild.
+type downsampleTierRebuildInputs struct {
+	dryRun bool
+}
+
+// newSchemaDownsampleTierRebuildCmd builds `cerberus schema
+// downsample-tier-rebuild` — TRUNCATEs and fully re-populates the
+// downsampled long-range tier (cerberus issue #2751), the recovery path a
+// suspected stranded or format-incompatible persisted
+// AggregateFunction(timeSeriesLastTwoSamples, ...) state needs (see
+// internal/downsampletier's package doc: a ClickHouse upgrade changing that
+// EXPERIMENTAL function's on-disk state format could strand every
+// already-written row, which an incremental --before backfill alone cannot
+// recover from).
+func newSchemaDownsampleTierRebuildCmd() *cobra.Command {
+	var in downsampleTierRebuildInputs
+	cmd := &cobra.Command{
+		Use:   "downsample-tier-rebuild",
+		Short: "TRUNCATE and fully re-populate the downsampled long-range tier",
+		Long: "TRUNCATEs the downsampled long-range tier (CERBERUS_CH_OPTIMIZATIONS=\n" +
+			"downsample_tier, cerberus issue #2751) and re-populates it in FULL, from\n" +
+			"the base sum table's entire currently-retained history — no --before\n" +
+			"bound. DESTRUCTIVE: every row currently in the tier is dropped first.\n" +
+			"Use this, not downsample-tier-backfill, when the persisted\n" +
+			"AggregateFunction(timeSeriesLastTwoSamples, ...) state is suspected\n" +
+			"stranded or format-incompatible (a ClickHouse changelog entry naming\n" +
+			"this function, or queries that should route to the tier unexpectedly\n" +
+			"dropping every point) — an incremental backfill cannot repair rows that\n" +
+			"are already unreadable. Any day already past the target table's own TTL\n" +
+			"(CERBERUS_SCHEMA_TTL_METRICS) as of the moment this runs is written,\n" +
+			"then reaped almost immediately — reported as a WARNING, not an error,\n" +
+			"mirroring downsample-tier-backfill's own retention-boundary check.",
+		Example:       "  cerberus schema downsample-tier-rebuild",
+		Args:          cobra.NoArgs,
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return runDownsampleTierRebuild(cmd, in)
+		},
+	}
+	f := cmd.Flags()
+	f.BoolVar(&in.dryRun, "dry-run", false, "print the TRUNCATE + INSERT ... SELECT statements without executing them")
+	return cmd
+}
+
+func runDownsampleTierRebuild(cmd *cobra.Command, in downsampleTierRebuildInputs) error {
+	cfg, err := config.FromEnv()
+	if err != nil {
+		return fmt.Errorf("load config from environment: %w", err)
+	}
+	cols := downsampleTierColumns(cfg)
+
+	if in.dryRun {
+		fmt.Fprintln(cmd.OutOrStdout(), downsampletier.TruncateSQL(cols))
+		sql, args := downsampletier.RebuildSQL(cols)
+		fmt.Fprintln(cmd.OutOrStdout(), sql)
+		fmt.Fprintf(cmd.OutOrStdout(), "-- args: %v\n", args)
+		return nil
+	}
+
+	retention := schemaboot.MetricsRetention(cfg)
+
+	client, err := chclient.New(cfg.ClickHouse)
+	if err != nil {
+		return fmt.Errorf("connect ClickHouse: %w", err)
+	}
+	defer func() { _ = client.Close() }()
+
+	result, err := downsampletier.Rebuild(context.Background(), client.Conn(), cols, retention)
+	if err != nil {
+		return err
+	}
+	fmt.Fprintf(cmd.OutOrStdout(), "rebuilt the downsample tier from %s (full history)\n", cols.SumTable)
+	if len(result.OutsideRetentionDays) > 0 {
+		writeOutsideRetentionWarning(cmd.OutOrStdout(), "the downsample tier", result.OutsideRetentionDays)
+	}
+	return nil
+}
+
+// downsampleTierVerifyInputs carries newSchemaDownsampleTierVerifyCmd's
+// resolved flags to runDownsampleTierVerify.
+type downsampleTierVerifyInputs struct {
+	before string
+	asJSON bool
+}
+
+// newSchemaDownsampleTierVerifyCmd builds `cerberus schema
+// downsample-tier-verify` — a COMPLETENESS check (does every bucket the
+// base table has raw data for also have a tier row), not a value-parity
+// check like delta-prefix-verify's sum comparison — see
+// internal/downsampletier's package doc for why: the tier has no aggregate
+// total to parity-check in the first place.
+func newSchemaDownsampleTierVerifyCmd() *cobra.Command {
+	var in downsampleTierVerifyInputs
+	cmd := &cobra.Command{
+		Use:   "downsample-tier-verify",
+		Short: "Verify downsample-tier backfill completeness before relying on it",
+		Long: "Compare the downsampled long-range tier's per-metric-name DISTINCT\n" +
+			"bucket count against the base sum table's own, over the same\n" +
+			"backfilled/rebuilt history (--before, the tier MV's creation timestamp\n" +
+			"— see `cerberus schema downsample-tier-backfill --help`). A clean pass\n" +
+			"is the recommended confirmation before an operator sets\n" +
+			"CERBERUS_CH_OPTIMIZATIONS=downsample_tier for long-range queries over\n" +
+			"history that predates the MV. Unlike delta-prefix-verify this is NOT a\n" +
+			"strict precondition for correctness — a missing tier bucket degrades to\n" +
+			"an absent series point at query time, never a wrong value (see\n" +
+			"schema.DownsampleTierTable's own doc) — it is an operator-facing\n" +
+			"completeness signal. Any day already past the target table's own TTL\n" +
+			"(CERBERUS_SCHEMA_TTL_METRICS) as of this run is EXCLUDED from the\n" +
+			"comparison and reported separately as a labeled NOTE, never as an\n" +
+			"unexplained FAIL.",
+		Example:       "  cerberus schema downsample-tier-verify --before 2026-08-20T14:32:10Z",
+		Args:          cobra.NoArgs,
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return runDownsampleTierVerify(cmd, in)
+		},
+	}
+	f := cmd.Flags()
+	f.StringVar(&in.before, "before", "",
+		"REQUIRED: the downsample-tier MV's creation timestamp (RFC3339, Unix seconds, or relative like -24h/now)")
+	f.BoolVar(&in.asJSON, "json", false, "emit the machine-readable JSON report instead of text")
+	return cmd
+}
+
+// downsampleTierVerifyFailedError is returned when downsample-tier-verify
+// finds at least one mismatch — mirrors deltaPrefixVerifyFailedError's
+// "the gate did its job, not a tool malfunction" contract.
+type downsampleTierVerifyFailedError struct{ mismatches int }
+
+func (e downsampleTierVerifyFailedError) Error() string {
+	return fmt.Sprintf("downsample-tier verify: %d metric(s) mismatched", e.mismatches)
+}
+
+func runDownsampleTierVerify(cmd *cobra.Command, in downsampleTierVerifyInputs) error {
+	if in.before == "" {
+		return errors.New("missing --before: the downsample-tier MV's creation timestamp " +
+			"(see `cerberus schema downsample-tier-verify --help`)")
+	}
+	before, err := migrateverify.ParseTime(in.before, time.Now().UTC())
+	if err != nil {
+		return fmt.Errorf("parse --before: %w", err)
+	}
+
+	cfg, client, err := schemaConnectClickHouse()
+	if err != nil {
+		return err
+	}
+	defer func() { _ = client.Close() }()
+	cols := downsampleTierColumns(cfg)
+
+	retention := schemaboot.MetricsRetention(cfg)
+	rep, err := downsampletier.Verify(context.Background(), client.Conn(), cols, before, retention)
+	if err != nil {
+		return err
+	}
+	if err := writeDownsampleTierVerifyReport(cmd.OutOrStdout(), rep, in.asJSON); err != nil {
+		return err
+	}
+	if !rep.Pass() {
+		return downsampleTierVerifyFailedError{mismatches: len(rep.Mismatches)}
+	}
+	return nil
+}
+
+func writeDownsampleTierVerifyReport(w io.Writer, rep downsampletier.Report, asJSON bool) error {
+	if asJSON {
+		enc := json.NewEncoder(w)
+		enc.SetIndent("", "  ")
+		return enc.Encode(rep)
+	}
+	if rep.Pass() {
+		fmt.Fprintf(w, "PASS: %d metric(s) matched (before %s)\n",
+			len(rep.BaseBuckets), rep.Before.Format(time.RFC3339))
+	} else {
+		fmt.Fprintf(w, "FAIL: %d of %d metric(s) mismatched (before %s)\n\n",
+			len(rep.Mismatches), len(unionDownsampleTierMetricNames(rep)), rep.Before.Format(time.RFC3339))
+		tw := tabwriter.NewWriter(w, 0, 2, 2, ' ', 0)
+		fmt.Fprintln(tw, "METRIC\tBASE_BUCKETS\tTIER_BUCKETS\tMISSING")
+		for _, m := range rep.Mismatches {
+			fmt.Fprintf(tw, "%s\t%d\t%d\t%d\n", m.MetricName, m.BaseBuckets, m.TierBuckets, m.Missing())
+		}
+		if err := tw.Flush(); err != nil {
+			return err
+		}
+	}
+	writeDownsampleTierOutsideRetentionNote(w, rep)
+	return nil
+}
+
+// writeDownsampleTierOutsideRetentionNote mirrors writeOutsideRetentionNote
+// for downsampletier.Report — see that function's doc.
+func writeDownsampleTierOutsideRetentionNote(w io.Writer, rep downsampletier.Report) {
+	if len(rep.OutsideRetentionDays) == 0 {
+		return
+	}
+	fmt.Fprintf(w, "\nNOTE: %d day(s) already outside the tier table's retention window "+
+		"(retention %s, boundary %s), cannot be backfilled — EXCLUDED from the comparison "+
+		"above (not counted as a mismatch):\n",
+		len(rep.OutsideRetentionDays), rep.Retention, rep.RetentionBoundary.Format(time.RFC3339))
+	for _, d := range rep.OutsideRetentionDays {
+		fmt.Fprintf(w, "  - %s\n", d.Format(time.DateOnly))
+	}
+}
+
+// unionDownsampleTierMetricNames is the total distinct metric-name
+// population Verify compared, for the FAIL summary line's "X of Y" count —
+// mirrors unionMetricNames.
+func unionDownsampleTierMetricNames(rep downsampletier.Report) map[string]struct{} {
+	out := make(map[string]struct{}, len(rep.BaseBuckets)+len(rep.TierBuckets))
+	for name := range rep.BaseBuckets {
+		out[name] = struct{}{}
+	}
+	for name := range rep.TierBuckets {
 		out[name] = struct{}{}
 	}
 	return out

--- a/cmd/cerberus/main.go
+++ b/cmd/cerberus/main.go
@@ -951,6 +951,7 @@ func buildCardinalityProbeAdvisor(
 //	classicHq = enabled ? NativeClassicHistogramWindowLowerer{Fallback: Fanout…{}} : Fanout…{}
 //	rankWalk  = enabled ? NativeQuantileRankWalkLowerer{} : FanoutQuantileRankWalkLowerer{}
 //	lastOverTime = enabled ? NativeLastOverTimeLowerer{Fallback: FanoutLastOverTimeLowerer{}} : FanoutLastOverTimeLowerer{}
+//	  // downsampleTierEnabled ? DownsampleTier{Irate,Idelta,LastOverTime}Lowerer{Fallback: <above>} : <above> unchanged
 //	overTime  = sortedSlabEnabled ? SortedSlabOverTimeLowerer{Fallback: FanoutOverTimeLowerer{}} : FanoutOverTimeLowerer{}
 //
 // rankWalk (quantile_prom_histogram) is not a timeSeries*ToGrid member — it
@@ -1174,6 +1175,20 @@ func nativeRangeLowerers(optSet chopt.EnabledSet) promql.RangeLowerers {
 		l.LastOverTime = promql.NativeLastOverTimeLowerer{Fallback: promql.FanoutLastOverTimeLowerer{}}
 	} else {
 		l.LastOverTime = promql.FanoutLastOverTimeLowerer{}
+	}
+	// downsample_tier (cerberus issue #2751) WRAPS whatever irate/idelta/
+	// last_over_time strategy was just resolved above — it is a genuinely
+	// different mechanism (an operator-provisioned, pre-populated table, not
+	// a stateless read-time function swap over the raw table), so it sits
+	// as an outer layer: an eligible shape routes to the tier, everything
+	// else falls through to the family's own best-available raw-scan
+	// strategy (native/laginframe/fanout) unchanged. See
+	// chopt.FeatureDownsampleTier's own doc for why rate()/increase()/
+	// delta() have no such wrapping at all.
+	if optSet.Has(chopt.FeatureDownsampleTier) {
+		l.Irate = promql.DownsampleTierIrateLowerer{Fallback: l.Irate}
+		l.Idelta = promql.DownsampleTierIdeltaLowerer{Fallback: l.Idelta}
+		l.LastOverTime = promql.DownsampleTierLastOverTimeLowerer{Fallback: l.LastOverTime}
 	}
 	// sorted_slab_over_time (issue #2761) has no native timeSeries*ToGrid
 	// competitor: sum_over_time/avg_over_time's only non-fan-out arm is the
@@ -1653,6 +1668,14 @@ func resolveCHOptimizations(ctx context.Context, logger *slog.Logger, client *ch
 	// rather than being threaded as an EnabledSet parameter.
 	cfg.SchemaTempoTagCatalogMV = set.Has(chopt.FeatureTempoTagCatalogMV)
 
+	// Same back-fill for downsample_tier (cerberus issue #2751) — see the
+	// map_bucketed_serialization comment above for why this runs here
+	// rather than being threaded as an EnabledSet parameter. Unlike the
+	// others above, this SAME verdict also drives query routing (see
+	// nativeRangeLowerers below) — schema.DownsampleTierTable's own doc
+	// explains why one flag safely covers both here.
+	cfg.SchemaDownsampleTier = set.Has(chopt.FeatureDownsampleTier)
+
 	// Install the client-side columnar matrix decode when the resolved set
 	// enables it. columnar_result_decode is a chopt feature (opt-in, never
 	// auto), so its enable decision flows through the EnabledSet exactly like
@@ -2091,6 +2114,18 @@ func setupSchema(
 		"signals", "metrics,logs,traces",
 	)
 	apply := func(ctx context.Context) error {
+		// The downsample tier's CREATE TABLE / MV (cerberus issue #2751) use
+		// AggregateFunction(timeSeriesLastTwoSamples, ...) — like every
+		// other consumer of that experimental function family, ClickHouse
+		// rejects it unless allow_experimental_time_series_aggregate_functions
+		// is set on the DDL-issuing session (chclient.WithTSGridSetting is
+		// the SAME carrier the query path stamps for the timeSeries*ToGrid
+		// family — see planHasTSGridNative). Stamped only when the tier is
+		// actually enabled, so a deployment that never opts in issues
+		// byte-identical DDL sessions to today.
+		if applyCfg.DownsampleTierEnabled {
+			ctx = chclient.WithTSGridSetting(ctx)
+		}
 		return ddl.ApplyWithConfig(ctx, applyConn, applyCfg, ddl.All)
 	}
 	if err := apply(ctx); err != nil {

--- a/docs/clickhouse-optimizations.md
+++ b/docs/clickhouse-optimizations.md
@@ -142,6 +142,7 @@ table.
 | `sorted_slab_over_time`          | none       | experimental | no         |
 | `map_bucketed_serialization`     | 26.4       | experimental | no         |
 | `ts_grid_last_over_time`         | 26.6       | experimental | no         |
+| `downsample_tier`                | 25.9       | experimental | no         |
 | `column_statistics`              | 26.3       | experimental | no         |
 | `classic_bucket_merge_summap`    | none       | experimental | no         |
 | `exp_histogram_merge_summap`     | none       | experimental | no         |

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -2316,6 +2316,115 @@ high-cardinality DELTA metric — not `date-range × 1` — and belongs in
 capacity planning for any deployment enabling
 `CERBERUS_DELTA_PREFIX_READ_ENABLED` against such a metric.
 
+### Downsampled long-range tier (cerberus issue #2751)
+
+Auto-create can also provision an **opt-in, cerberus-owned** table + materialized
+view folding raw Sum-table samples into a persisted `timeSeriesLastTwoSamples`
+aggregate state per 5-minute bucket (`internal/schema/ddl`, table
+`otel_metrics_sum_downsample_tier`), read back by `irate()` / `idelta()` /
+`last_over_time()` `query_range` shapes whose window matches the bucket
+exactly. Unlike the DELTA-prefix table above, provisioning and query routing
+share a **single** flag: `CERBERUS_CH_OPTIMIZATIONS=downsample_tier` (a chopt
+feature, floor ClickHouse >= 25.9, `AutoSelect=false` — never picked by
+`auto`). A not-yet-backfilled or missing bucket degrades to an ABSENT series
+point at query time, never a wrong value — see the scope note below — so
+this mechanism does not need DELTA-prefix's separate, later
+`*_READ_ENABLED` declaration.
+
+**Hard scope boundary — `rate()` / `increase()` / `delta()` never route
+here, and never will.** Retaining only the two newest raw samples per bucket
+makes a counter reset between DISCARDED intra-bucket samples undetectable;
+those three functions need every sample the bucket throws away to detect
+such a reset, so routing them here would silently underestimate the true
+increase by an unbounded amount. `irate()` / `idelta()` / `last_over_time()`
+are exact functions of exactly the last one or two samples in their window —
+precisely what the tier retains — so they are exact by construction over
+this state; see `chopt.FeatureDownsampleTier`'s registry doc for the full
+reasoning and the chDB probe that verified it against a real ClickHouse
+instance.
+
+**Resolution-aware routing.** A query only reads the tier when its
+`query_range` grid is EXACTLY the tier's own bucket grid: `range == 5m`,
+`step` a positive integer multiple of `5m`, and the grid's `start` landing on
+a bucket boundary (absolute Unix-epoch alignment) — a 15-second-step query
+never touches the 5-minute tier. A wider range (spanning multiple buckets) or
+a step finer than the bucket falls straight through to the ordinary raw-scan
+path, unchanged.
+
+```sql
+CREATE TABLE IF NOT EXISTS <db>.otel_metrics_sum_downsample_tier
+(
+    MetricName          LowCardinality(String),
+    Attributes           Map(LowCardinality(String), String),
+    ResourceAttributes    Map(LowCardinality(String), String),
+    ServiceName          LowCardinality(String),
+    BucketEnd            DateTime64(9),
+    LastTwoSamples       AggregateFunction(timeSeriesLastTwoSamples, DateTime64(9), Float64),
+    Temporality          SimpleAggregateFunction(any, Int32)
+)
+ENGINE = AggregatingMergeTree
+ORDER BY (MetricName, BucketEnd, Attributes, ResourceAttributes, ServiceName);
+
+CREATE MATERIALIZED VIEW IF NOT EXISTS <db>.otel_metrics_sum_downsample_tier_mv
+TO <db>.otel_metrics_sum_downsample_tier AS
+SELECT MetricName, Attributes, ResourceAttributes, ServiceName,
+       toStartOfInterval(TimeUnix - toIntervalNanosecond(1), toIntervalSecond(300))
+           + toIntervalSecond(300) AS BucketEnd,
+       timeSeriesLastTwoSamplesState(TimeUnix, Value) AS LastTwoSamples,
+       any(AggregationTemporality) AS Temporality
+FROM <db>.otel_metrics_sum
+GROUP BY MetricName, Attributes, ResourceAttributes, ServiceName, BucketEnd;
+```
+
+`BucketEnd` is a **ceiling**, not ClickHouse's native `toStartOfInterval`
+floor: PromQL's range-vector window is half-open-left / closed-right
+(`(anchor-range, anchor]`), so a raw sample landing exactly on a bucket
+boundary must join the bucket ENDING at that instant, not the one starting
+there — the `- toIntervalNanosecond(1)` epsilon trick reproduces that
+half-open window exactly (verified empirically against a boundary-exact
+sample on a real ClickHouse instance). This is what lets the read side look
+up a single bucket row per eligible grid anchor with no cross-bucket merge.
+
+`irate()`'s read branches on the carried `Temporality` column the same way
+the raw fan-out does (`chsql.CounterOrDeltaPairDelta`): the reset-aware
+`if(curr<prev, curr, curr-prev)` for a CUMULATIVE counter, but the raw
+current sample alone for a DELTA-temporality one (each DELTA sample already
+IS the increment since the prior export). `idelta()` never branches on
+temporality, matching this codebase's raw fan-out `idelta()` path.
+
+#### Backfill / rebuild / verify runbook
+
+Three `cerberus schema` subcommands, mirroring the DELTA-prefix verbs'
+shape:
+
+```sh
+cerberus schema downsample-tier-backfill --before 2026-08-20T14:32:10Z
+cerberus schema downsample-tier-verify   --before 2026-08-20T14:32:10Z
+```
+
+`downsample-tier-backfill` is the SAME non-retroactive, exact-instant
+`--before` bound `delta-prefix-backfill` uses, and the SAME
+already-outside-retention-TTL detection (reported as a `WARNING`, not an
+error). `downsample-tier-verify` is a per-metric **completeness** check —
+distinct `(MetricName, BucketEnd)` counts, base table vs. tier — not a
+value-parity check like `delta-prefix-verify`'s sum comparison: this
+mechanism has no aggregate total to parity-check against in the first
+place, only samples to be present or absent.
+
+```sh
+cerberus schema downsample-tier-rebuild
+```
+
+`downsample-tier-rebuild` `TRUNCATE`s the tier table and re-populates it in
+full, from the base table's entire currently-retained history — no
+`--before` bound. This is the recovery path for a suspected stranded or
+format-incompatible persisted state: `timeSeriesLastTwoSamples` is an
+EXPERIMENTAL ClickHouse aggregate function, and a future ClickHouse upgrade
+changing its on-disk state format could strand every already-written row.
+An incremental `downsample-tier-backfill` cannot repair rows that are
+already unreadable — `downsample-tier-rebuild` starts clean instead. All
+three verbs accept `--dry-run` to print the statement(s) without executing.
+
 ### Startup requirements preflight
 
 `CERBERUS_REQUIREMENTS_CHECK` (**on by default**) runs a boot-time

--- a/internal/chopt/registry.go
+++ b/internal/chopt/registry.go
@@ -819,6 +819,69 @@ const (
 	// the fan-out unconditionally.
 	FeatureTSGridLastOverTime = "ts_grid_last_over_time"
 
+	// FeatureDownsampleTier opts eligible LONG-RANGE / low-resolution
+	// irate() / idelta() / last_over_time() query_range shapes (step >= the
+	// tier's fixed 5-minute bucket, range == bucket, grid aligned to the
+	// bucket boundary — see internal/promql/lower_strategy.go's eligibility
+	// check) onto the operator-provisioned downsampled long-range tier
+	// (schema.DownsampleTierTable): a materialized view folding raw Sum-
+	// table samples into a persisted timeSeriesLastTwoSamples aggregate
+	// state per bucket, read back via timeSeriesLastTwoSamplesMerge +
+	// finalizeAggregation instead of scanning full-resolution raw rows
+	// (cerberus issue #2751).
+	//
+	// THIS IS A FUNDAMENTALLY DIFFERENT MECHANISM from the rest of the
+	// timeSeries*ToGrid family above: those are stateless read-time
+	// function swaps over the SAME raw table; this reads an
+	// operator-provisioned, PERSISTED table that must be created
+	// (internal/schema/ddl, gated on this same verdict — see
+	// schema.DownsampleTierTable's doc) and, for history predating its own
+	// MV, separately backfilled (`cerberus schema downsample-tier-backfill`,
+	// internal/downsampletier) before it answers anything for that older
+	// range.
+	//
+	// HARD SCOPE BOUNDARY (cerberus issue #2751's own "Scope constraint",
+	// non-negotiable — verified empirically against a real ClickHouse
+	// instance, see internal/chsql's downsample-tier chDB test): retaining
+	// only the two newest raw samples per bucket makes a counter reset
+	// between samples the bucket DISCARDS undetectable. rate() / increase()
+	// / delta() over that state can silently underestimate an unbounded
+	// amount — a cerberus-COMPOSED failure mode, not documented ClickHouse
+	// behavior — so this feature's lowering (internal/promql/
+	// lower_strategy.go's DownsampleTier{Irate,Idelta,LastOverTime}Lowerer)
+	// is wired ONLY for irate() / idelta() / last_over_time(): PromQL
+	// defines all three as functions of EXACTLY the last two (or one, for
+	// last_over_time) samples in the window, so a state that retains
+	// exactly those two samples is exact by construction — verified
+	// empirically, including a counter reset landing ON the retained
+	// trailing pair (irate correctly reset-corrects; idelta correctly does
+	// not, matching Prometheus's funcIrate / funcIdelta). rate() /
+	// increase() / delta() have and will have NO DownsampleTier lowering —
+	// there is no Fallback wrapper for them the way NativeRateLowerer wraps
+	// FanoutRateLowerer for ts_grid_range; they are structurally absent
+	// from cmd/cerberus's nativeRangeLowerers wiring for this feature.
+	//
+	// Floor 25.9, the SAME floor and the SAME
+	// allow_experimental_time_series_aggregate_functions gate
+	// (RequiresExperimentalTSGrid) the rest of the family shares — the
+	// function itself (timeSeriesLastTwoSamples, its -State/-Merge
+	// combinators, and finalizeAggregation over its state) is available
+	// from 25.6, but this repo pins every timeSeries*ToGrid-family
+	// consumer to the family's own 25.9 floor rather than each function's
+	// individual introduction version (see FeatureTSGridRange's own doc):
+	// this feature shares the family's boot capability probe and its
+	// experimental-setting gate, so it can never actually be enabled below
+	// 25.9 regardless.
+	//
+	// AutoSelect is false, unlike most of the family: this is a genuine
+	// operator decision (new ongoing storage/compute cost, a PERSISTED
+	// EXPERIMENTAL aggregate state in an AggregatingMergeTree that a
+	// ClickHouse upgrade changing the state's wire format could strand —
+	// see the issue's own "Risks" section) with no safe-by-default
+	// posture, never AutoSelect where a raw read already fits budget.
+	// Opt-in only via CERBERUS_CH_OPTIMIZATIONS=downsample_tier.
+	FeatureDownsampleTier = "downsample_tier"
+
 	// FeatureExplainEstimate gates using ClickHouse's own `EXPLAIN ESTIMATE`
 	// (cerberus issue #2787) as an ADVISORY input to the solver's fan-out
 	// factor K and to the per-rung admission learner's priors — a NO-EXECUTION
@@ -1763,6 +1826,14 @@ var registry = []Feature{
 		AutoSelect:                 false,
 		RequiresExperimentalTSGrid: true,
 		Doc:                        "opt eligible last_over_time(<v>[<range>]) shapes onto the native timeSeriesResampleToGridWithStaleness aggregate (ts_grid_resample's), [range] as staleness (experimental, server >= 26.6 — PRs #106504/#106577, opt-in via CERBERUS_CH_OPTIMIZATIONS)",
+	},
+	{
+		ID:                         FeatureDownsampleTier,
+		MinVersion:                 Version{Major: 25, Minor: 9},
+		Stability:                  Experimental,
+		AutoSelect:                 false,
+		RequiresExperimentalTSGrid: true,
+		Doc:                        "route eligible irate()/idelta()/last_over_time() shapes onto the downsampled long-range tier (server >= 25.9, opt-in via CERBERUS_CH_OPTIMIZATIONS — new persisted state, provision + backfill first)",
 	},
 	{
 		ID:         FeatureColumnStatistics,

--- a/internal/chopt/resolve_test.go
+++ b/internal/chopt/resolve_test.go
@@ -659,6 +659,7 @@ func TestRegistry_SeededEntries(t *testing.T) {
 		FeatureCardinalityProbe:             {ID: FeatureCardinalityProbe, MinVersion: AlwaysAvailable, Stability: Experimental, AutoSelect: false, RequiresExperimentalTSGrid: false},
 		FeatureFullTextIndex:                {ID: FeatureFullTextIndex, MinVersion: v(26, 2), Stability: Experimental, AutoSelect: false, RequiresExperimentalTSGrid: false},
 		FeatureTextIndexLineFilter:          {ID: FeatureTextIndexLineFilter, MinVersion: v(26, 4), Stability: Experimental, AutoSelect: false, RequiresExperimentalTSGrid: false},
+		FeatureDownsampleTier:               {ID: FeatureDownsampleTier, MinVersion: v(25, 9), Stability: Experimental, AutoSelect: false, RequiresExperimentalTSGrid: true},
 	}
 	if len(reg) != len(want) {
 		t.Fatalf("registry has %d entries; want %d", len(reg), len(want))

--- a/internal/chplan/clone.go
+++ b/internal/chplan/clone.go
@@ -119,6 +119,9 @@ func cloneRangeNode(n Node) Node {
 		// returns nil for a nil Node so this stays a no-op then, same as
 		// Input would if it were ever nil.
 		c.DeltaPrefixAggregateInput = CloneNode(v.DeltaPrefixAggregateInput)
+		// DownsampleTierInput mirrors DeltaPrefixAggregateInput's own nil
+		// handling immediately above (cerberus issue #2751).
+		c.DownsampleTierInput = CloneNode(v.DownsampleTierInput)
 		c.GroupBy = cloneExprs(v.GroupBy)
 		c.Scalars = cloneFloats(v.Scalars)
 		c.ScalarExprs = cloneExprs(v.ScalarExprs)

--- a/internal/chplan/range_window.go
+++ b/internal/chplan/range_window.go
@@ -348,6 +348,42 @@ type RangeWindow struct {
 	// permanent, always-available fallback the FeatureSortedSlabOverTime
 	// chopt kill-switch resolves to.
 	SortedSlabOverTime bool
+
+	// DownsampleTierInput is the optional second scan side-feeding the
+	// operator-provisioned downsampled long-range tier (cerberus issue
+	// #2751): a Scan of schema.DownsampleTierTable, filtered by the SAME
+	// label matchers Input's own selector applies, projected under the
+	// SAME selectorAttributesExpr(ctx, s) tower Input's own Attributes
+	// projection uses — see internal/promql/lower.go's
+	// buildDownsampleTierArm, the direct sibling of
+	// buildDeltaPrefixAggregateArm. Populated ONLY by the boot-wired
+	// promql.DownsampleTier{Irate,Idelta,LastOverTime}Lowerer strategies
+	// (chopt.FeatureDownsampleTier) — unlike DeltaPrefixAggregateInput,
+	// never by the base lowering unconditionally, because this is a whole
+	// alternate lowering the query either takes or does not (see
+	// DownsampleTier below), not a supplementary join side every Func
+	// value tolerates having populated-but-unconsumed.
+	//
+	// nil (the default) — every deployment that hasn't wired the feature
+	// keeps the pre-existing raw-scan RangeWindow emission, byte-identical
+	// to pre-#2751 SQL.
+	DownsampleTierInput Node
+
+	// DownsampleTier reports whether the emitter should render this node by
+	// reading DownsampleTierInput's bucketed AggregateFunction state instead
+	// of windowing Input's raw per-sample rows (cerberus issue #2751). Set
+	// ONLY when DownsampleTierInput is non-nil AND the boot-wired
+	// DownsampleTier*Lowerer strategy's resolution-aware eligibility check
+	// passed (Func is irate/idelta/last_over_time, Range equals the tier's
+	// fixed bucket, and the query_range grid is bucket-aligned with
+	// Step >= bucket) — never read as a per-query feature flag.
+	//
+	// false (the default) keeps the unchanged raw-scan emission — the
+	// permanent, always-available fallback the FeatureDownsampleTier chopt
+	// kill-switch resolves to, and the ONLY path rate() / increase() /
+	// delta() ever take (see chopt.FeatureDownsampleTier's own doc for why
+	// those three are structurally never eligible).
+	DownsampleTier bool
 }
 
 // RangeWindowVariant is one arm of a fused multi-arm RangeWindow: the range
@@ -421,10 +457,14 @@ func (*RangeWindow) planNode() {}
 // recursive Children traversal) reaches the side-scan the same way it
 // already reaches Input, rather than silently treating it as an opaque leaf.
 func (r *RangeWindow) Children() []Node {
-	if r.DeltaPrefixAggregateInput == nil {
-		return []Node{r.Input}
+	children := []Node{r.Input}
+	if r.DeltaPrefixAggregateInput != nil {
+		children = append(children, r.DeltaPrefixAggregateInput)
 	}
-	return []Node{r.Input, r.DeltaPrefixAggregateInput}
+	if r.DownsampleTierInput != nil {
+		children = append(children, r.DownsampleTierInput)
+	}
+	return children
 }
 
 // NumAnchors is the number of subquery anchor points this RangeWindow
@@ -494,6 +534,9 @@ func rangeWindowScalarFieldsEqual(r, o *RangeWindow) bool {
 	if r.SortedSlabOverTime != o.SortedSlabOverTime {
 		return false
 	}
+	if r.DownsampleTier != o.DownsampleTier {
+		return false
+	}
 	return r.VariantColumn == o.VariantColumn
 }
 
@@ -541,6 +584,9 @@ func (r *RangeWindow) Equal(other Node) bool {
 		}
 	}
 	if !optionalNodeEqual(r.DeltaPrefixAggregateInput, o.DeltaPrefixAggregateInput) {
+		return false
+	}
+	if !optionalNodeEqual(r.DownsampleTierInput, o.DownsampleTierInput) {
 		return false
 	}
 	return r.Input.Equal(o.Input)

--- a/internal/chplan/rewrite_children.go
+++ b/internal/chplan/rewrite_children.go
@@ -331,16 +331,33 @@ func rewriteIrregularNode(n Node, fn func(Node) (Node, bool)) (out Node, changed
 	case *RangeWindow:
 		// Input is the always-present windowed relation;
 		// DeltaPrefixAggregateInput is the optional DELTA-prefix aggregate
-		// side-scan (cerberus issue #2389) — same shape as MetricsCompare's
-		// Inner/optional-RootLookup pair below, so recurse into both when
-		// present rather than treating the side-scan as an opaque leaf.
-		newInput, newDeltaPrefixInput, ch := rewriteOptionalPair(fn, v.Input, v.DeltaPrefixAggregateInput)
-		if !ch {
+		// side-scan (cerberus issue #2389) and DownsampleTierInput is its
+		// downsampled-long-range-tier sibling (cerberus issue #2751) — same
+		// shape as MetricsCompare's Inner/optional-RootLookup pair below, so
+		// recurse into all three when present rather than treating either
+		// side-scan as an opaque leaf.
+		newInput, inputCh := fn(v.Input)
+		var newDeltaPrefixInput Node
+		deltaPrefixCh := false
+		if v.DeltaPrefixAggregateInput != nil {
+			newDeltaPrefixInput, deltaPrefixCh = fn(v.DeltaPrefixAggregateInput)
+		}
+		var newDownsampleTierInput Node
+		downsampleTierCh := false
+		if v.DownsampleTierInput != nil {
+			newDownsampleTierInput, downsampleTierCh = fn(v.DownsampleTierInput)
+		}
+		if !inputCh && !deltaPrefixCh && !downsampleTierCh {
 			return v, false, true
 		}
 		cp := *v
 		cp.Input = newInput
-		cp.DeltaPrefixAggregateInput = newDeltaPrefixInput
+		if v.DeltaPrefixAggregateInput != nil {
+			cp.DeltaPrefixAggregateInput = newDeltaPrefixInput
+		}
+		if v.DownsampleTierInput != nil {
+			cp.DownsampleTierInput = newDownsampleTierInput
+		}
 		return &cp, true, true
 	case *UnionAll:
 		// Recurse into each arm so existing optimizer rules

--- a/internal/chsql/ddl.go
+++ b/internal/chsql/ddl.go
@@ -1361,3 +1361,23 @@ func (i *InsertSelectBuilder) frag() Frag {
 func (i *InsertSelectBuilder) Build() (string, []any) {
 	return Render(i.frag())
 }
+
+// TruncateTable renders `TRUNCATE TABLE <database>.<table>` — the statement
+// internal/downsampletier's Rebuild issues before a full re-populate
+// (cerberus issue #2751): unlike Backfill's incremental INSERT ... SELECT,
+// a rebuild must start from an empty table, since AggregatingMergeTree
+// merges are additive and re-running the same INSERT twice would double
+// every state rather than overwrite it. database may be "" for an
+// unqualified table reference, matching InsertSelect's own convention. No
+// positional bindings, so this returns a plain string like the CREATE/ALTER
+// builders' SQL() method, not InsertSelect's own (sql, args) pair.
+func TruncateTable(database, table string) string {
+	return RenderDDL(func(b *Builder) {
+		ddlToken("TRUNCATE TABLE ")(b)
+		if database != "" {
+			BareIdent(database)(b)
+			ddlToken(".")(b)
+		}
+		BareIdent(table)(b)
+	})
+}

--- a/internal/chsql/range_window.go
+++ b/internal/chsql/range_window.go
@@ -368,6 +368,13 @@ func metricsMultiQuantileFanoutFrag(qs []float64, qsCol string) Frag {
 // the last sample in the window — used by bare-vector subqueries like
 // `up[5m:1m]`.
 func (e *emitter) emitRangeWindow(r *chplan.RangeWindow) error {
+	// DownsampleTier (cerberus issue #2751) is checked FIRST, ahead of even
+	// the Input-shape dispatches below: when set, r.Input is deliberately
+	// unused and r.DownsampleTierInput answers the query completely on its
+	// own — see emitRangeWindowDownsampleTier's own doc.
+	if r.DownsampleTier {
+		return e.emitRangeWindowDownsampleTier(r)
+	}
 	if m, ok := r.Input.(*chplan.MetricsAggregate); ok {
 		return e.emitRangeWindowMetrics(r, m)
 	}

--- a/internal/chsql/range_window_downsample_tier.go
+++ b/internal/chsql/range_window_downsample_tier.go
@@ -1,0 +1,233 @@
+package chsql
+
+import (
+	"fmt"
+
+	"github.com/tsouza/cerberus/internal/chplan"
+	"github.com/tsouza/cerberus/internal/schema"
+)
+
+// downsampleTierMergedAlias / downsampleTierSortedAlias / downsampleTierTemporalityAlias
+// name the synthetic intermediate columns emitRangeWindowDownsampleTier
+// builds on top of the tier table's own row shape — see that function's
+// doc for the SQL skeleton.
+const (
+	downsampleTierMergedAlias      = "downsample_tier_merged"
+	downsampleTierSortedAlias      = "downsample_tier_sorted"
+	downsampleTierTemporalityAlias = "downsample_tier_temporality"
+)
+
+// downsampleTierMinSamples reports the minimum sample count
+// emitRangeWindowDownsampleTier requires before it reports a value for a
+// (series, bucket): 1 for last_over_time (a single sample is enough to
+// answer "the last value"), 2 for irate / idelta (both are defined over a
+// TRAILING PAIR — PromQL drops the series entirely when a window holds
+// fewer than 2 samples, the same "insufficient samples" rule the fan-out's
+// own `WHERE length(window_vals) >= 2` applies).
+func downsampleTierMinSamples(fn string) (int64, error) {
+	switch fn {
+	case "irate", "idelta":
+		return 2, nil
+	case "last_over_time":
+		return 1, nil
+	}
+	return 0, fmt.Errorf("%w: downsample-tier func %q (supported: irate, idelta, last_over_time)", ErrUnsupported, fn)
+}
+
+// downsampleTierElemFrag renders `<sorted>[<idx>]` — CH's array indexing
+// (1-based positive, or negative counting from the end) into the
+// (timestamp, value) pair array emitRangeWindowDownsampleTier's "sorted"
+// level builds. idx is a small, self-evident positional constant
+// (invariant 13's carve-out), never a computed value.
+func downsampleTierElemFrag(idx int64) Frag {
+	return Subscript(Col(downsampleTierSortedAlias), InlineLit(idx))
+}
+
+// downsampleTierValFrag / downsampleTierTsFrag project the value / timestamp
+// half of the pair tuple downsampleTierElemFrag(idx) selects.
+func downsampleTierValFrag(idx int64) Frag { return TupleIndex(downsampleTierElemFrag(idx), 2) }
+func downsampleTierTsFrag(idx int64) Frag  { return TupleIndex(downsampleTierElemFrag(idx), 1) }
+
+// downsampleTierIntervalSecondsFrag renders the whole-second (float)
+// interval between the two most recent retained samples — irate's
+// denominator — via `toUnixTimestamp64Nano`, mirroring the codebase's own
+// nanosecond-precision interval idiom elsewhere (see e.g.
+// endExprFrag / rangeStartFrag's toIntervalNanosecond arithmetic).
+//
+// Paren-wrapped TWICE, both load-bearing: chsql's binOp (Div/Sub/...)
+// renders NO parentheses of its own (the caller is responsible — see
+// builder.go's binOp). Sub(a, b) used directly as Div's numerator renders
+// as bare `a - b / <divisor>` text with NO grouping around the
+// subtraction at all — SQL's own operator precedence then parses that as
+// `a - (b / <divisor>)`, not `(a - b) / <divisor>`, so the inner
+// Paren(Sub(...)) is required on its own. The outer Paren additionally
+// protects this Frag's result at ITS OWN call site (Div(numerator, this)):
+// without it, this being the DIVISOR of a further outer Div would repeat
+// the identical bug one level up. Caught empirically by this package's
+// downsample-tier chDB test (the result read back at a near-epoch-nanosecond
+// scale instead of an interval in seconds — twice, once per missing Paren).
+func downsampleTierIntervalSecondsFrag() Frag {
+	nanosAt := func(idx int64) Frag { return Call("toUnixTimestamp64Nano", downsampleTierTsFrag(idx)) }
+	return Paren(Div(Paren(Sub(nanosAt(-1), nanosAt(-2))), InlineLit(float64(1e9))))
+}
+
+// downsampleTierValueExprFrag renders the per-Func output Value expression
+// over the sorted trailing pair — verified empirically against a real
+// ClickHouse instance (this package's downsample-tier chDB test) to match
+// Prometheus's own funcIrate / funcIdelta / funcLastOverTime exactly,
+// including the counter-reset case landing ON the trailing pair itself:
+//
+//   - "last_over_time": the single most recent value, sorted[-1].2.
+//   - "idelta": sorted[-1].2 - sorted[-2].2 — a PLAIN difference, NEVER
+//     counter-reset-corrected regardless of temporality, matching funcIdelta
+//     AND matching this codebase's own emitRangeWindowIDelta, which never
+//     branches on temporality either — see
+//     schema.DownsampleTierTemporalityColumn's own doc.
+//   - "irate": chsql.CounterOrDeltaPairDelta over the trailing pair, the
+//     SAME primitive the raw fan-out's irateValueFrag uses: the reset-aware
+//     `if(curr<prev,curr,curr-prev)` for a CUMULATIVE (or temporality-less)
+//     counter, but the RAW current sample alone for a DELTA-temporality one
+//     (each DELTA sample already IS the increment since the prior export,
+//     so a difference would double-count) — divided by the whole-second
+//     interval between the two retained timestamps.
+func downsampleTierValueExprFrag(fn string) Frag {
+	if fn == "last_over_time" {
+		return downsampleTierValFrag(-1)
+	}
+	if fn == "idelta" {
+		return Sub(downsampleTierValFrag(-1), downsampleTierValFrag(-2))
+	}
+	prev := func() Frag { return downsampleTierValFrag(-2) }
+	curr := func() Frag { return downsampleTierValFrag(-1) }
+	numerator := CounterOrDeltaPairDelta(prev, curr, Col(downsampleTierTemporalityAlias))
+	return Div(numerator, downsampleTierIntervalSecondsFrag())
+}
+
+// emitRangeWindowDownsampleTier renders SQL for an r with DownsampleTier set
+// (cerberus issue #2751): reads r.DownsampleTierInput's bucketed
+// timeSeriesLastTwoSamples state instead of windowing r.Input's raw rows.
+// r.Input is UNUSED here — the boot-wired DownsampleTier*Lowerer
+// (internal/promql/lower_strategy.go) only sets DownsampleTier when
+// r.DownsampleTierInput answers the query completely on its own.
+//
+// Because that Lowerer's eligibility check (downsampleTierEligible) only
+// ever fires when the query_range grid's own anchors are EXACTLY the tier's
+// bucket boundaries (r.Range equals the tier's fixed bucket, r.Step a
+// positive multiple of it, r.Start bucket-aligned), each grid anchor maps
+// to EXACTLY ONE tier row — this reads the tier table directly, bounded to
+// [r.Start, r.End] on its own bucket column, with no multi-bucket merge or
+// grid materialisation (unlike the native timeSeries*ToGrid family's own
+// timeSeriesRange grid axis in range_window_grid_native.go, which this
+// deliberately does not need — see the v1 scope note on
+// downsampleTierEligible).
+//
+// SQL shape (three levels, mirroring RangeWindowGridNative's own
+// inner/outer split):
+//
+//	merged: SELECT <group...>, BucketEnd,
+//	               timeSeriesLastTwoSamplesMerge(LastTwoSamples) AS merged
+//	        FROM (<r.DownsampleTierInput>)
+//	        WHERE BucketEnd >= r.Start AND BucketEnd <= r.End
+//	        GROUP BY <group...>, BucketEnd
+//
+// GROUP BY + the -Merge combinator (never a bare per-row
+// finalizeAggregation) is load-bearing, not a style choice:
+// AggregatingMergeTree can hold MULTIPLE unmerged parts for the SAME
+// (series, bucket) key until a background merge runs — the live MV fires
+// once per INSERT batch, and ordinary multi-batch ingest (or late data)
+// routinely produces more than one row per key before that merge happens.
+// A naive per-row finalizeAggregation read would silently answer with
+// whichever part it happened to see FIRST, missing samples a DIFFERENT
+// part holds — verified empirically to diverge from the correct
+// GROUP BY + xMerge answer against a real ClickHouse instance (see this
+// package's downsample-tier chDB test).
+//
+//	sorted: SELECT <group...>, BucketEnd,
+//	               arraySort(x -> x.1, arrayZip(merged.1, merged.2)) AS sorted
+//	        FROM merged
+//
+// finalizeAggregation / the -Merge combinator's own element order is NOT
+// documented as sorted — verified empirically to come back DESCENDING
+// (newest first) — so this explicitly re-sorts ASCENDING by timestamp
+// rather than trust that order, making sorted[-1] always "most recent" and
+// sorted[-2] always "second most recent" regardless of the engine's
+// internal representation.
+//
+//	outer: SELECT <group...>, BucketEnd AS anchor_ts[, r.TimestampColumn],
+//	              <downsampleTierValueExprFrag> AS r.ValueColumn
+//	       FROM sorted
+//	       WHERE length(sorted) >= downsampleTierMinSamples(r.Func)
+//
+// The WHERE guard is the tier's exact analogue of the fan-out's
+// `WHERE length(window_vals) >= 2` — PromQL's own "insufficient samples in
+// window" drop-series rule. A bucket the MV/backfill never populated for
+// this series (not yet backfilled, or the series had 0 samples that
+// bucket) degrades to the SAME absent-row outcome, never a wrong value —
+// see schema.DownsampleTierTable's own doc for why that safety property is
+// this mechanism's central design constraint.
+func (e *emitter) emitRangeWindowDownsampleTier(r *chplan.RangeWindow) error {
+	if r.DownsampleTierInput == nil {
+		return fmt.Errorf("%w: RangeWindow.DownsampleTier set with no DownsampleTierInput", ErrUnsupported)
+	}
+	if r.TimestampColumn == "" {
+		return fmt.Errorf("%w: RangeWindow.TimestampColumn unset", ErrUnsupported)
+	}
+	if r.ValueColumn == "" {
+		return fmt.Errorf("%w: RangeWindow.ValueColumn unset", ErrUnsupported)
+	}
+	minSamples, err := downsampleTierMinSamples(r.Func)
+	if err != nil {
+		return err
+	}
+	groupFrags, err := e.collectGroupByFrags(r.GroupBy)
+	if err != nil {
+		return err
+	}
+	tierSub, err := e.subqueryFrag(r.DownsampleTierInput)
+	if err != nil {
+		return err
+	}
+
+	bucketCol := Col(schema.DownsampleTierBucketColumn)
+	merged := NewQuery().From(tierSub)
+	merged.Select(groupFrags...)
+	merged.Select(bucketCol)
+	merged.Select(As(Call("timeSeriesLastTwoSamplesMerge", Col(schema.DownsampleTierSamplesColumn)), downsampleTierMergedAlias))
+	// any(Temporality) merges the SimpleAggregateFunction(any, Int32) column
+	// across however many unmerged parts the (series, bucket) key currently
+	// has — the SAME multi-part hazard timeSeriesLastTwoSamplesMerge guards
+	// against immediately above, see emitRangeWindowDownsampleTier's own
+	// doc. Selected unconditionally (idelta / last_over_time never read it
+	// — see downsampleTierValueExprFrag) rather than branching the query
+	// shape on r.Func, keeping this function's three-level skeleton
+	// identical for every eligible Func.
+	merged.Select(As(Call("any", Col(schema.DownsampleTierTemporalityColumn)), downsampleTierTemporalityAlias))
+	merged.Where(
+		Gte(bucketCol, Lit(r.Start)),
+		Lte(bucketCol, Lit(r.End)),
+	)
+	mergedGroupBy := append(append([]Frag{}, groupFrags...), bucketCol)
+	merged.GroupBy(mergedGroupBy...)
+
+	sorted := NewQuery().From(merged.Frag())
+	sorted.Select(groupFrags...)
+	sorted.Select(bucketCol)
+	sorted.Select(Col(downsampleTierTemporalityAlias))
+	sortedPairs := Call(
+		"arrayZip",
+		TupleIndex(Col(downsampleTierMergedAlias), 1),
+		TupleIndex(Col(downsampleTierMergedAlias), 2),
+	)
+	sorted.Select(As(Call("arraySort", Lambda1("x", TupleIndex(BareIdent("x"), 1)), sortedPairs), downsampleTierSortedAlias))
+
+	outer := NewQuery().From(sorted.Frag())
+	outer.Select(groupFrags...)
+	outer.Select(As(bucketCol, RangeWindowAnchorAlias))
+	if r.TimestampColumn != RangeWindowAnchorAlias {
+		outer.Select(As(bucketCol, r.TimestampColumn))
+	}
+	outer.Select(As(downsampleTierValueExprFrag(r.Func), r.ValueColumn))
+	outer.Where(Gte(Call("length", Col(downsampleTierSortedAlias)), InlineLit(minSamples)))
+
+	return e.emitSelect(outer)
+}

--- a/internal/chsql/range_window_downsample_tier_chdb_test.go
+++ b/internal/chsql/range_window_downsample_tier_chdb_test.go
@@ -1,0 +1,374 @@
+//go:build chdb
+
+// chDB-backed correctness proof for the operator opt-in downsampled
+// long-range tier (cerberus issue #2751): internal/schema/ddl's real
+// renderDownsampleTierTable/View DDL, the real timeSeriesLastTwoSamples
+// state/merge/finalize mechanics, and internal/chsql's real
+// emitRangeWindowDownsampleTier emission, run end to end against a real
+// ClickHouse engine (chDB) rather than trusted from reasoning alone.
+//
+// Five properties this file proves empirically, each the load-bearing
+// claim a comment elsewhere in this feature makes:
+//
+//  1. Boundary-exact bucketing (internal/schema/ddl's downsampleTierBucketEndExpr):
+//     a raw sample landing EXACTLY on a bucket boundary joins the bucket
+//     ENDING there, matching PromQL's half-open-left/closed-right window —
+//     see host "boundary" below.
+//  2. The counter-reset restriction is SAFE BY CONSTRUCTION: irate() /
+//     idelta() over the tier's last-two-samples state agree EXACTLY with
+//     computing the same functions over the SAME two raw samples via the
+//     ordinary fan-out (dual-emit parity) — including a reset landing ON
+//     the retained trailing pair, where irate correctly reset-corrects and
+//     idelta correctly does not — see hosts "cumulative" / "reset".
+//  3. DELTA-temporality counters take the RAW-current-sample irate branch,
+//     not the CUMULATIVE reset-aware one — see host "delta".
+//  4. The multi-part AggregatingMergeTree read hazard is real and this
+//     package's GROUP BY + xMerge read handles it correctly — see host
+//     "multipart" (two separate INSERT batches, i.e. two unmerged parts,
+//     for the SAME bucket key).
+//  5. Insufficient samples degrade to an ABSENT row (never a wrong value)
+//     for irate/idelta, while last_over_time still answers from a single
+//     sample — see host "single".
+package chsql_test
+
+import (
+	"context"
+	"database/sql"
+	"math"
+	"testing"
+	"time"
+
+	promparser "github.com/prometheus/prometheus/promql/parser"
+
+	"github.com/tsouza/cerberus/internal/chclient"
+	"github.com/tsouza/cerberus/internal/chsql"
+	"github.com/tsouza/cerberus/internal/chsqltest"
+	"github.com/tsouza/cerberus/internal/optimizer"
+	"github.com/tsouza/cerberus/internal/promql"
+	"github.com/tsouza/cerberus/internal/schema"
+	"github.com/tsouza/cerberus/internal/schema/ddl"
+)
+
+// downsampleTierBucketAnchor is the single query_range anchor every
+// scenario below evaluates at — the BucketEnd of the bucket [00:00, 00:05)
+// on an otherwise arbitrary but Unix-epoch bucket-aligned day.
+var downsampleTierBucketAnchor = time.Date(2024, 1, 1, 0, 5, 0, 0, time.UTC)
+
+// downsampleTierChdbSetup creates the real DDL (via internal/schema/ddl's
+// actual render functions, not a hand-copied mirror) inside db's isolated
+// database, and enables the experimental setting every statement below
+// needs.
+func downsampleTierChdbSetup(t *testing.T, db *sql.DB) {
+	t.Helper()
+	if _, err := db.Exec("SET " + chclient.SettingExperimentalTSGridAggregate + " = 1"); err != nil {
+		t.Fatalf("enable experimental ts-grid: %v", err)
+	}
+	// ddl.Config.withDefaults forces an empty Database to "default", so an
+	// empty cfg.Database here would qualify every CREATE as
+	// default.<table> — landing OUTSIDE chsqltest.OpenIsolatedChDB's own
+	// isolated database. Reading currentDatabase() and pinning cfg.Database
+	// to it keeps every statement inside the isolated database, the same
+	// isolation contract every other chdb test in this package gets by
+	// using bare (unqualified) hand-written CREATE TABLE statements
+	// instead — this file uses the REAL ddl.RenderAll, so it has to be
+	// explicit about the database ddl.Config otherwise defaults away from.
+	var currentDB string
+	if err := db.QueryRow("SELECT currentDatabase()").Scan(&currentDB); err != nil {
+		t.Fatalf("read currentDatabase(): %v", err)
+	}
+	cfg := ddl.Config{Database: currentDB, SkipDatabaseCreate: true, DownsampleTierEnabled: true}
+	stmts, err := ddl.RenderAll(cfg, []ddl.Signal{ddl.Metrics})
+	if err != nil {
+		t.Fatalf("ddl.RenderAll: %v", err)
+	}
+	for _, stmt := range stmts {
+		if _, err := db.Exec(stmt); err != nil {
+			t.Fatalf("exec DDL: %v\n--- stmt ---\n%s", err, stmt)
+		}
+	}
+}
+
+// downsampleTierHostSample is one raw (host, ts, value, temporality) row
+// downsampleTierSeed inserts into otel_metrics_sum.
+type downsampleTierHostSample struct {
+	host        string
+	ts          time.Time
+	value       float64
+	temporality int
+}
+
+// downsampleTierSeed is every scenario host's raw data, all landing in the
+// SAME bucket [00:00, 00:05) except "gap" (deliberately empty) and
+// "otherbucket" (the following bucket, proving the eligible query's own
+// [Start,End] bound excludes it). CUMULATIVE is temporality 2 (neither
+// Unspecified=0 nor Delta=1 — see chsql.CounterOrDeltaPairDelta, which
+// treats anything other than Delta as the reset-aware branch); DELTA is 1
+// (schema.AggregationTemporalityDelta).
+var downsampleTierSeed = []downsampleTierHostSample{
+	// "cumulative": a plain monotonic pair, PLUS a third, EARLIER sample
+	// this bucket must discard (proving the tier keeps only the last two
+	// per bucket, not every sample) and a boundary-exact sample AT
+	// 00:05:00 itself (proving it joins THIS bucket, not the next).
+	{"cumulative", time.Date(2024, 1, 1, 0, 0, 30, 0, time.UTC), 20, 2},
+	{"cumulative", time.Date(2024, 1, 1, 0, 3, 0, 0, time.UTC), 100, 2},
+	{"cumulative", downsampleTierBucketAnchor, 150, 2}, // exactly 00:05:00
+	// "reset": a counter reset landing ON the retained trailing pair.
+	{"reset", time.Date(2024, 1, 1, 0, 1, 0, 0, time.UTC), 500, 2},
+	{"reset", time.Date(2024, 1, 1, 0, 3, 0, 0, time.UTC), 50, 2},
+	// "delta": DELTA temporality — irate must use the raw current sample
+	// alone, not curr-prev.
+	{"delta", time.Date(2024, 1, 1, 0, 1, 0, 0, time.UTC), 30, 1},
+	{"delta", time.Date(2024, 1, 1, 0, 3, 0, 0, time.UTC), 45, 1},
+	// "single": exactly one raw sample — irate/idelta must report absent,
+	// last_over_time must still answer.
+	{"single", time.Date(2024, 1, 1, 0, 2, 0, 0, time.UTC), 77, 2},
+	// "gap": no rows in THIS bucket, but present in the next one — proves
+	// the tier read for THIS anchor is a clean absence, not an error, and
+	// that presence in a DIFFERENT bucket does not leak in.
+	{"gap", time.Date(2024, 1, 1, 0, 6, 0, 0, time.UTC), 999, 2},
+	// "boundary_excluded": a SOLE sample exactly on the PREVIOUS bucket's
+	// own boundary (00:00:00) must NOT be pulled into the (00:00,00:05]
+	// bucket this test queries (which ends at 00:05:00) — a sample AT
+	// 00:00:00 belongs to the bucket ENDING at 00:00:00 instead
+	// (internal/schema/ddl's bucketEndExpr). With no other sample in this
+	// bucket, this host must be entirely ABSENT from every function's
+	// answer at the 00:05:00 anchor.
+	{"boundary_excluded", time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC), 1, 2},
+}
+
+// downsampleTierMultipartSeed is applied via TWO SEPARATE INSERT batches
+// (see TestDownsampleTier_ChdbCorrectness) to force two unmerged
+// AggregatingMergeTree parts for the SAME (host="multipart", bucket) key —
+// the real-world shape of an MV firing once per insert batch, or late
+// data. The TRUE last-two across BOTH parts is (20@00:02:00, 30@00:04:00);
+// a naive per-part read would see only ITS OWN part's last two and answer
+// wrong for at least one part.
+var downsampleTierMultipartSeedBatch1 = []downsampleTierHostSample{
+	{"multipart", time.Date(2024, 1, 1, 0, 1, 0, 0, time.UTC), 10, 2},
+	{"multipart", time.Date(2024, 1, 1, 0, 2, 0, 0, time.UTC), 20, 2},
+}
+
+var downsampleTierMultipartSeedBatch2 = []downsampleTierHostSample{
+	{"multipart", time.Date(2024, 1, 1, 0, 4, 0, 0, time.UTC), 30, 2},
+}
+
+func insertDownsampleTierSamples(t *testing.T, db *sql.DB, samples []downsampleTierHostSample) {
+	t.Helper()
+	for _, s := range samples {
+		_, err := db.Exec(
+			`INSERT INTO otel_metrics_sum (MetricName, Attributes, TimeUnix, Value, AggregationTemporality) VALUES (?, map('host', ?), ?, ?, ?)`,
+			"cpu_seconds_total", s.host, s.ts, s.value, s.temporality,
+		)
+		if err != nil {
+			t.Fatalf("insert host=%s ts=%s: %v", s.host, s.ts, err)
+		}
+	}
+}
+
+// downsampleTierLowererTable wires ONLY the DownsampleTier strategy
+// (mirroring cmd/cerberus's nativeRangeLowerers with ONLY
+// chopt.FeatureDownsampleTier resolved — no ts_grid_irate/idelta/
+// last_over_time layered beneath it), so this test proves the tier's OWN
+// correctness in isolation from the native ts_grid family's.
+func downsampleTierLowererTable() promql.RangeLowerers {
+	return promql.RangeLowerers{
+		Irate:        promql.DownsampleTierIrateLowerer{Fallback: promql.FanoutIrateLowerer{}},
+		Idelta:       promql.DownsampleTierIdeltaLowerer{Fallback: promql.FanoutIdeltaLowerer{}},
+		LastOverTime: promql.DownsampleTierLastOverTimeLowerer{Fallback: promql.FanoutLastOverTimeLowerer{}},
+	}
+}
+
+// runDownsampleTierPromQL lowers query at the single downsampleTierBucketAnchor
+// grid point (Step == bucket, one anchor) with tierRouted selecting between
+// the tier-wired table and a plain all-fan-out table, emits it, runs it
+// against db, and returns host -> value.
+func runDownsampleTierPromQL(t *testing.T, db *sql.DB, query string, tierRouted bool) map[string]float64 {
+	t.Helper()
+	p := promparser.NewParser(promparser.Options{EnableExperimentalFunctions: true})
+	expr, err := p.ParseExpr(query)
+	if err != nil {
+		t.Fatalf("parse %q: %v", query, err)
+	}
+	var lowerers promql.RangeLowerers
+	if tierRouted {
+		lowerers = downsampleTierLowererTable()
+	}
+	plan, err := promql.LowerAtRangeOpts(context.Background(), expr, schema.DefaultOTelMetrics(),
+		downsampleTierBucketAnchor, downsampleTierBucketAnchor, schema.DownsampleTierBucket,
+		promql.LowerOpts{Lowerers: lowerers})
+	if err != nil {
+		t.Fatalf("lower %q (tierRouted=%v): %v", query, tierRouted, err)
+	}
+	plan = optimizer.Default().Run(context.Background(), plan)
+	sqlText, args, err := chsql.Emit(context.Background(), plan)
+	if err != nil {
+		t.Fatalf("emit %q (tierRouted=%v): %v", query, tierRouted, err)
+	}
+	wrapped := "SELECT toJSONString(`Attributes`) AS host_json, `Value` FROM (" + sqlText + ")"
+	rows, err := db.Query(wrapped, args...)
+	if err != nil {
+		t.Fatalf("query %q (tierRouted=%v): %v\nSQL: %s", query, tierRouted, err, wrapped)
+	}
+	defer func() { _ = rows.Close() }()
+	out := make(map[string]float64)
+	for rows.Next() {
+		var hostJSON string
+		var value float64
+		if err := rows.Scan(&hostJSON, &value); err != nil {
+			t.Fatalf("scan: %v", err)
+		}
+		out[hostFromJSON(t, hostJSON)] = value
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatalf("rows: %v", err)
+	}
+	return out
+}
+
+func TestDownsampleTier_ChdbCorrectness(t *testing.T) {
+	db := chsqltest.OpenIsolatedChDB(t)
+	downsampleTierChdbSetup(t, db)
+	// otel_metrics_sum already exists — ddl.RenderAll (via
+	// downsampleTierChdbSetup) creates it from the real upstream template,
+	// which carries AggregationTemporality, MetricName, Attributes, and
+	// TimeUnix/Value, matching insertDownsampleTierSamples' own INSERT
+	// column list.
+
+	insertDownsampleTierSamples(t, db, downsampleTierSeed)
+	insertDownsampleTierSamples(t, db, downsampleTierMultipartSeedBatch1)
+	insertDownsampleTierSamples(t, db, downsampleTierMultipartSeedBatch2)
+
+	const irateQuery = `irate(cpu_seconds_total[5m])`
+	const ideltaQuery = `idelta(cpu_seconds_total[5m])`
+	const lastQuery = `last_over_time(cpu_seconds_total[5m])`
+
+	irateTier := runDownsampleTierPromQL(t, db, irateQuery, true)
+	irateFanout := runDownsampleTierPromQL(t, db, irateQuery, false)
+	ideltaTier := runDownsampleTierPromQL(t, db, ideltaQuery, true)
+	ideltaFanout := runDownsampleTierPromQL(t, db, ideltaQuery, false)
+	lastTier := runDownsampleTierPromQL(t, db, lastQuery, true)
+	lastFanout := runDownsampleTierPromQL(t, db, lastQuery, false)
+
+	// Property 2 + 3 + 4: dual-emit parity against the fan-out (which reads
+	// RAW rows, never the tier) proves the tier's read is numerically
+	// correct for every host, including "delta" (temporality-aware irate)
+	// and "multipart" (the multi-part merge hazard) — bit-identical, no
+	// tolerance, since both sides do the same float arithmetic in the same
+	// order (subtract two float64 samples, divide by an integer-derived
+	// interval).
+	for host, fv := range irateFanout {
+		tv, ok := irateTier[host]
+		if !ok {
+			t.Errorf("irate host=%s: present in fan-out (%v) but ABSENT from tier route", host, fv)
+			continue
+		}
+		if math.Float64bits(tv) != math.Float64bits(fv) {
+			t.Errorf("irate host=%s: tier=%.20g fanout=%.20g NOT bit-identical", host, tv, fv)
+		}
+	}
+	if len(irateTier) != len(irateFanout) {
+		t.Errorf("irate row-count divergence: tier=%d fanout=%d\ntier=%v\nfanout=%v",
+			len(irateTier), len(irateFanout), irateTier, irateFanout)
+	}
+	for host, fv := range ideltaFanout {
+		tv, ok := ideltaTier[host]
+		if !ok {
+			t.Errorf("idelta host=%s: present in fan-out (%v) but ABSENT from tier route", host, fv)
+			continue
+		}
+		if math.Float64bits(tv) != math.Float64bits(fv) {
+			t.Errorf("idelta host=%s: tier=%.20g fanout=%.20g NOT bit-identical", host, tv, fv)
+		}
+	}
+	for host, fv := range lastFanout {
+		tv, ok := lastTier[host]
+		if !ok {
+			t.Errorf("last_over_time host=%s: present in fan-out (%v) but ABSENT from tier route", host, fv)
+			continue
+		}
+		if math.Float64bits(tv) != math.Float64bits(fv) {
+			t.Errorf("last_over_time host=%s: tier=%.20g fanout=%.20g NOT bit-identical", host, tv, fv)
+		}
+	}
+
+	// Property 5: "single" (one raw sample) must be ABSENT from irate/idelta
+	// on BOTH paths, but present in last_over_time.
+	if _, ok := irateTier["single"]; ok {
+		t.Errorf("irate host=single: expected absent (only 1 sample in window), got a value")
+	}
+	if _, ok := ideltaTier["single"]; ok {
+		t.Errorf("idelta host=single: expected absent (only 1 sample in window), got a value")
+	}
+	if v, ok := lastTier["single"]; !ok || v != 77 {
+		t.Errorf("last_over_time host=single: want 77, got %v (present=%v)", v, ok)
+	}
+
+	// Property: "gap" (no data in this bucket) must be absent everywhere,
+	// and "boundary_excluded"'s two samples (both landing in the PREVIOUS
+	// bucket) must never surface in THIS anchor's answer.
+	for _, absentHost := range []string{"gap", "boundary_excluded"} {
+		if v, ok := irateTier[absentHost]; ok {
+			t.Errorf("irate host=%s: expected absent (no data in this bucket), got %v", absentHost, v)
+		}
+		if v, ok := lastTier[absentHost]; ok {
+			t.Errorf("last_over_time host=%s: expected absent (no data in this bucket), got %v", absentHost, v)
+		}
+	}
+
+	// Property 1 (boundary-exact bucketing): "cumulative" pins its trailing
+	// pair at (100@00:03:00, 150@00:05:00 exactly) — the boundary-exact
+	// sample MUST be included. Pinned expected values, not just "matches
+	// fan-out" (fan-out could theoretically share the same bug):
+	wantIdelta := map[string]float64{
+		"cumulative": 50,   // 150 - 100
+		"reset":      -450, // 50 - 500, uncorrected
+		"delta":      15,   // 45 - 30, uncorrected (idelta never branches on temporality)
+		"multipart":  10,   // 30 - 20 (the TRUE last two across both parts)
+	}
+	for host, want := range wantIdelta {
+		got, ok := ideltaTier[host]
+		if !ok {
+			t.Errorf("idelta host=%s: expected present, got absent", host)
+			continue
+		}
+		if got != want {
+			t.Errorf("idelta host=%s: want %v, got %v", host, want, got)
+		}
+	}
+	wantIrate := map[string]float64{
+		"cumulative": 50.0 / 120, // no reset: plain diff / 120s
+		"reset":      50.0 / 120, // reset detected: raw current / 120s
+		"delta":      45.0 / 120, // DELTA temporality: raw current / 120s
+		"multipart":  10.0 / 120, // TRUE last two across both parts
+	}
+	for host, want := range wantIrate {
+		got, ok := irateTier[host]
+		if !ok {
+			t.Errorf("irate host=%s: expected present, got absent", host)
+			continue
+		}
+		if math.Abs(got-want) > 1e-12 {
+			t.Errorf("irate host=%s: want %v, got %v", host, want, got)
+		}
+	}
+}
+
+// hostFromJSON extracts the "host" label out of a toJSONString'd
+// Map(String,String) column, mirroring the family's own dual-emit tests'
+// (e.g. range_window_last_over_time_chdb_test.go's) JSON-decode idiom.
+func hostFromJSON(t *testing.T, hostJSON string) string {
+	t.Helper()
+	// Attributes carries exactly one key ("host") in this seed, so a tiny
+	// manual extract avoids pulling encoding/json into this file purely for
+	// a single-key map — {"host":"cumulative"}.
+	const prefix = `{"host":"`
+	if len(hostJSON) < len(prefix)+2 || hostJSON[:len(prefix)] != prefix {
+		t.Fatalf("unexpected Attributes JSON shape: %s", hostJSON)
+	}
+	rest := hostJSON[len(prefix):]
+	end := 0
+	for end < len(rest) && rest[end] != '"' {
+		end++
+	}
+	return rest[:end]
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -430,6 +430,19 @@ type Config struct {
 	// internal/schema/ddl.Config.TempoTagCatalogEnabled).
 	SchemaTempoTagCatalogMV bool
 
+	// SchemaDownsampleTier is the resolved chopt downsample_tier verdict
+	// (cerberus issue #2751), back-filled the SAME way as
+	// SchemaTraceIDProjection above — including the offline `migrate
+	// schema` preview's chopt.ExplicitlyRequested fallback, since
+	// downsample_tier is also AutoSelect=false. internal/schemaboot.
+	// DDLConfig is the only reader: true adds the curated
+	// `CREATE TABLE otel_metrics_sum_downsample_tier` + its materialized
+	// view (see internal/schema/ddl.Config.DownsampleTierEnabled and
+	// schema.DownsampleTierTable's doc for why this single verdict gates
+	// both provisioning and query routing, unlike DeltaPrefixEnabled's
+	// separate later DeltaPrefixReadEnabled).
+	SchemaDownsampleTier bool
+
 	// CHOptCorpus configures the async system.query_log performance-corpus
 	// reconciler (disabled by default; production-only — chDB has no
 	// query_log).

--- a/internal/downsampletier/doc.go
+++ b/internal/downsampletier/doc.go
@@ -1,0 +1,72 @@
+// Package downsampletier backfills and verifies the operator opt-in
+// downsampled long-range tier (cerberus issue #2751,
+// schema.DownsampleTierTable, internal/schema/ddl). It is the query layer
+// behind the `cerberus schema downsample-tier-backfill` and
+// `cerberus schema downsample-tier-verify` CLI verbs (cmd/cerberus), kept as
+// its own package — mirroring internal/deltaprefix's shape — so the SQL
+// composition + result diffing is unit testable without a live ClickHouse
+// connection (see Conn).
+//
+// # Why a backfill is needed at all
+//
+// Exactly the same reason as internal/deltaprefix's own doc: `CREATE
+// MATERIALIZED VIEW` does not retroactively process rows already in the
+// source table, only INSERTs from the moment it is created onward. Once
+// internal/schema/ddl provisions the tier table + its MV, history that
+// predates that moment needs this package's Backfill to run a one-time
+// `INSERT INTO ... SELECT` covering it.
+//
+// # A fundamentally lower-stakes failure mode than DeltaPrefix's
+//
+// internal/deltaprefix's package doc spends most of its length on silent
+// corruption hazards — a wrong `before` bound double-counts or
+// under-counts a SimpleAggregateFunction(sum, ...) column, invisibly. This
+// tier has NO equivalent hazard: it is read back only through
+// irate()/idelta()/last_over_time() (chopt.FeatureDownsampleTier's own
+// doc), each of which is a function of exactly the last one or two samples
+// in its window. A bucket this package has not yet backfilled is simply
+// ABSENT from the tier table — the query-time read
+// (internal/chsql.emitRangeWindowDownsampleTier) treats an absent or
+// under-populated bucket exactly like PromQL's own "insufficient samples in
+// window" rule, dropping the series point rather than answering with a
+// wrong number. So, unlike Verify in internal/deltaprefix, this package's
+// Verify checks COMPLETENESS (does every bucket the base table has data for
+// also have a tier row) rather than VALUE PARITY (does a computed total
+// match) — there is no total to parity-check against; the tier does not
+// aggregate a scalar the way DeltaPrefix's PartialSum column does.
+//
+// # Rebuild vs Backfill
+//
+// Persisting an EXPERIMENTAL aggregate function's state
+// (AggregateFunction(timeSeriesLastTwoSamples, ...) inside an
+// AggregatingMergeTree) carries a real risk internal/deltaprefix's
+// SimpleAggregateFunction(sum, ...) column does not: a ClickHouse upgrade
+// that changes the experimental function's on-disk state FORMAT could
+// strand every already-written row unreadable (cerberus issue #2751's own
+// "Risks" section). Backfill alone — an incremental INSERT ... SELECT
+// bounded by --before, mirroring internal/deltaprefix's Backfill — cannot
+// recover from that: the already-written, now-unreadable rows are still
+// there, blocking a clean re-backfill of the same range. Rebuild exists for
+// exactly this case: it TRUNCATEs the tier table (idempotent even after a
+// state-format break, since it does not need to READ the old rows) and
+// re-populates the FULL configured history in one pass, with no --before
+// bound at all. An operator who suspects a stranded state (a query
+// unexpectedly dropping every point that should route to the tier, or a
+// ClickHouse changelog entry naming this function) runs Rebuild, not
+// Backfill.
+//
+// # One-time backfill vs. the tier table's own steady-state TTL
+//
+// The SAME retention-boundary hazard internal/deltaprefix's package doc
+// describes at length applies here identically: the tier table shares the
+// base Sum table's TTL (internal/schema/ddl's renderDownsampleTierTable), so
+// a Backfill or Rebuild invoked after the earliest historical day has
+// already crossed its own BucketEnd + retention instant writes rows that
+// are already past their own TTL the moment they land, and ClickHouse's
+// routine background TTL cleanup reaps them almost immediately (cerberus
+// issue #2652's finding, reproduced here rather than re-derived). Both
+// Backfill and Rebuild take the same explicit retention duration
+// internal/deltaprefix's own verbs do (schemaboot.MetricsRetention) and
+// report any day already outside it on the returned Result, rather than
+// mishandling it silently — see OutsideRetentionDays.
+package downsampletier

--- a/internal/downsampletier/downsampletier.go
+++ b/internal/downsampletier/downsampletier.go
@@ -1,0 +1,463 @@
+package downsampletier
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"time"
+
+	"github.com/ClickHouse/clickhouse-go/v2"
+	chdriver "github.com/ClickHouse/clickhouse-go/v2/lib/driver"
+
+	"github.com/tsouza/cerberus/internal/chsql"
+	"github.com/tsouza/cerberus/internal/schema"
+)
+
+// settingExperimentalTSGridAggregate MUST stay byte-identical to
+// chclient.SettingExperimentalTSGridAggregate — this package cannot import
+// internal/chclient (.go-arch-lint.yml: this leaf package, like
+// internal/deltaprefix and internal/routerrules, must not depend on
+// chclient; the CLI supplies the resolved config + the narrow Conn at boot)
+// so the setting's exact string KEY is duplicated here rather than shared,
+// the same "leaf packages can't share one helper" constraint
+// bucketEndExpr's own doc explains for internal/schema/ddl.
+// TestSettingMatchesChclient pins the two against each other. See
+// chclient.SettingExperimentalTSGridAggregate's own doc for the full
+// history of why this exact spelling (not the deprecated
+// allow_experimental_ts_to_grid_aggregate_function alias) is the one that
+// must never drift.
+const settingExperimentalTSGridAggregate = "allow_experimental_time_series_aggregate_functions"
+
+// Conn is the narrow ClickHouse surface this package needs — mirrors
+// internal/deltaprefix's own Conn exactly (Exec for the
+// backfill/rebuild/truncate statements, Query for verify's two completeness
+// reads), for the same reason: this is a leaf package that should not pull
+// in internal/chclient's full Client surface for a type name alone.
+type Conn interface {
+	Exec(ctx context.Context, query string, args ...any) error
+	Query(ctx context.Context, query string, args ...any) (chdriver.Rows, error)
+}
+
+// Resource caps stamped on every statement this package issues — the SAME
+// values and the SAME rationale as internal/deltaprefix's own maxExecutionTimeSeconds
+// / maxThreads / priority / maxRowsToRead / maxBytesToRead: an
+// operator-run, off-hot-path tool sharing a ClickHouse cluster with live
+// query serving.
+const (
+	maxExecutionTimeSeconds = 900.0 // 15 minutes
+	maxThreads              = 4
+	priority                = 10
+	maxRowsToRead           = 20_000_000_000
+	maxBytesToRead          = 256 << 30 // 256 GiB
+)
+
+// withCaps stamps the conservative resource-cap settings PLUS the
+// experimental timeSeries*ToGrid gate onto ctx via clickhouse-go's
+// client-side query-settings mechanism. Unlike internal/deltaprefix this
+// package's statements reference AggregateFunction(timeSeriesLastTwoSamples,
+// ...) / call timeSeriesLastTwoSamplesState — ClickHouse rejects both unless
+// settingExperimentalTSGridAggregate is set on the SAME session
+// (UNKNOWN_AGGREGATE_FUNCTION otherwise; verified empirically against a
+// real ClickHouse instance — see internal/chsql's downsample-tier chDB
+// test). This package Execs/Queries a raw driver.Conn directly (like
+// internal/deltaprefix), not through internal/chclient.Client, so it must
+// stamp the clickhouse-go client-side settings map itself rather than
+// route through chclient.WithTSGridSetting's composable per-request
+// carrier (which only chclient.Client's own query path reads).
+func withCaps(ctx context.Context) context.Context {
+	return clickhouse.Context(ctx, clickhouse.WithSettings(clickhouse.Settings{
+		"max_execution_time":               maxExecutionTimeSeconds,
+		"timeout_overflow_mode":            "throw",
+		"max_threads":                      maxThreads,
+		"priority":                         priority,
+		"max_rows_to_read":                 maxRowsToRead,
+		"max_bytes_to_read":                maxBytesToRead,
+		"read_overflow_mode":               "break",
+		settingExperimentalTSGridAggregate: 1,
+	}))
+}
+
+// Columns names the physical database/table/column identifiers the
+// backfill + rebuild + verify queries reference. Unlike
+// internal/deltaprefix.Columns, the tier table/column names are FIXED
+// schema.DownsampleTier* constants (see that package's doc for why), so
+// only the database + base Sum table name vary by deployment.
+type Columns struct {
+	Database                     string
+	SumTable                     string
+	MetricNameColumn             string
+	AttributesColumn             string
+	ResourceAttributesColumn     string
+	ServiceNameColumn            string
+	TimestampColumn              string
+	ValueColumn                  string
+	AggregationTemporalityColumn string
+}
+
+// FromSchema builds Columns from the ClickHouse database name plus the
+// resolved runtime schema.Metrics (config.Config.Schema) — mirrors
+// internal/deltaprefix.FromSchema.
+func FromSchema(database string, m schema.Metrics) Columns {
+	return Columns{
+		Database:                     database,
+		SumTable:                     m.SumTable,
+		MetricNameColumn:             m.MetricNameColumn,
+		AttributesColumn:             m.AttributesColumn,
+		ResourceAttributesColumn:     m.ResourceAttributesColumn,
+		ServiceNameColumn:            m.ServiceNameColumn,
+		TimestampColumn:              m.TimestampColumn,
+		ValueColumn:                  m.ValueColumn,
+		AggregationTemporalityColumn: m.AggregationTemporalityColumn,
+	}
+}
+
+// bucketEndExpr renders the SAME ceiling bucket-boundary expression
+// internal/schema/ddl's downsampleTierBucketEndExpr renders for the live
+// MV — see that function's doc for the full PromQL-half-open-window
+// reasoning. The two copies MUST stay byte-identical (a backfilled row and
+// a live-MV row for the same raw sample must land in the same bucket); they
+// cannot share a Go func because internal/schema/ddl and this package are
+// both leaf packages neither imports the other's exported surface for one
+// shared helper alone — TestBucketEndExprMatchesDDL pins the two against
+// each other.
+func bucketEndExpr(col string) chsql.Frag {
+	epsilon := chsql.Sub(chsql.Col(col), chsql.Call("toIntervalNanosecond", chsql.InlineLit(int64(1))))
+	floor := chsql.Call("toStartOfInterval", epsilon, chsql.Call("toIntervalSecond", chsql.InlineLit(bucketSeconds())))
+	return chsql.Add(floor, chsql.Call("toIntervalSecond", chsql.InlineLit(bucketSeconds())))
+}
+
+func bucketSeconds() int64 { return int64(schema.DownsampleTierBucket / time.Second) }
+
+// backfillSelectSQL renders the SELECT half shared by BackfillSQL (bounded
+// by `before`) and RebuildSQL (unbounded, the full history) — factored out
+// so the two statements cannot drift on the GROUP BY / projection shape.
+func backfillSelectSQL(c Columns, before *time.Time) *chsql.QueryBuilder {
+	bucket := bucketEndExpr(c.TimestampColumn)
+	q := chsql.NewQuery().
+		Select(
+			chsql.Col(c.MetricNameColumn),
+			chsql.Col(c.AttributesColumn),
+			chsql.Col(c.ResourceAttributesColumn),
+			chsql.Col(c.ServiceNameColumn),
+			chsql.As(bucket, schema.DownsampleTierBucketColumn),
+			chsql.As(chsql.Call("timeSeriesLastTwoSamplesState", chsql.Col(c.TimestampColumn), chsql.Col(c.ValueColumn)), schema.DownsampleTierSamplesColumn),
+			chsql.As(chsql.Call("any", chsql.Col(c.AggregationTemporalityColumn)), schema.DownsampleTierTemporalityColumn),
+		).
+		From(chsql.Qual(c.Database, c.SumTable))
+	if before != nil {
+		q = q.Where(chsql.Lt(chsql.Col(c.TimestampColumn), chsql.Lit(*before)))
+	}
+	return q.GroupBy(
+		chsql.Col(c.MetricNameColumn),
+		chsql.Col(c.AttributesColumn),
+		chsql.Col(c.ResourceAttributesColumn),
+		chsql.Col(c.ServiceNameColumn),
+		bucket,
+	)
+}
+
+// tierColumns is the target column list BackfillSQL / RebuildSQL insert
+// into, in the SAME order backfillSelectSQL projects them.
+func tierColumns(c Columns) []string {
+	return []string{
+		c.MetricNameColumn, c.AttributesColumn, c.ResourceAttributesColumn, c.ServiceNameColumn,
+		schema.DownsampleTierBucketColumn, schema.DownsampleTierSamplesColumn, schema.DownsampleTierTemporalityColumn,
+	}
+}
+
+// BackfillSQL renders the one-time `INSERT INTO ... SELECT` that populates
+// the tier table for c.SumTable history strictly older than before — the
+// MV's own exact creation instant (see internal/deltaprefix's package doc
+// for why an exact instant, never a calendar-day-rounded one). Mirrors
+// internal/deltaprefix.BackfillSQL's own bound discipline exactly.
+func BackfillSQL(c Columns, before time.Time) (string, []any) {
+	return chsql.InsertSelect(c.Database, schema.DownsampleTierTable, tierColumns(c), backfillSelectSQL(c, &before)).Build()
+}
+
+// RebuildSQL renders the FULL, unbounded `INSERT INTO ... SELECT` a Rebuild
+// issues after truncating the tier table (see this package's doc for why a
+// full rebuild — not just an incremental backfill — is the recovery path
+// for a suspected stranded/incompatible persisted state).
+func RebuildSQL(c Columns) (string, []any) {
+	return chsql.InsertSelect(c.Database, schema.DownsampleTierTable, tierColumns(c), backfillSelectSQL(c, nil)).Build()
+}
+
+// TruncateSQL renders the `TRUNCATE TABLE` Rebuild issues before its full
+// re-populate.
+func TruncateSQL(c Columns) string {
+	return chsql.TruncateTable(c.Database, schema.DownsampleTierTable)
+}
+
+// nowFunc is the retention-boundary clock — mirrors internal/deltaprefix's
+// own package-level var, pinned in tests the same way.
+var nowFunc = time.Now
+
+// retentionBoundary mirrors internal/deltaprefix.retentionBoundary exactly
+// — see that function's doc.
+func retentionBoundary(now time.Time, retention time.Duration) (boundary time.Time, active bool) {
+	if retention <= 0 {
+		return time.Time{}, false
+	}
+	return now.Add(-retention), true
+}
+
+// outsideRetentionDaysSQL renders the DISTINCT bucket-boundary read against
+// the base table's own history, restricted to Backfill's own `[-inf,
+// before)` scope AND already past the tier table's retention as of
+// boundary — the tier's analogue of internal/deltaprefix's own
+// outsideRetentionDaysSQL (cerberus issue #2652's finding, reproduced here
+// rather than re-derived: this table shares the base Sum table's TTL, see
+// internal/schema/ddl's renderDownsampleTierTable).
+func outsideRetentionDaysSQL(c Columns, before, boundary time.Time) (string, []any) {
+	bucket := bucketEndExpr(c.TimestampColumn)
+	q := chsql.NewQuery().
+		Select(bucket).
+		From(chsql.Qual(c.Database, c.SumTable)).
+		Where(
+			chsql.Lt(chsql.Col(c.TimestampColumn), chsql.Lit(before)),
+			chsql.Lt(bucket, chsql.Lit(boundary)),
+		).
+		GroupBy(bucket).
+		OrderBy(bucket, false)
+	return q.Build()
+}
+
+func queryOutsideRetentionDays(ctx context.Context, conn Conn, c Columns, before, boundary time.Time) ([]time.Time, error) {
+	sql, args := outsideRetentionDaysSQL(c, before, boundary)
+	rows, err := conn.Query(withCaps(ctx), sql, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = rows.Close() }()
+	var days []time.Time
+	for rows.Next() {
+		var day time.Time
+		if err := rows.Scan(&day); err != nil {
+			return nil, err
+		}
+		days = append(days, day)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return days, nil
+}
+
+// Result is what Backfill and Rebuild return beyond a plain error — mirrors
+// internal/deltaprefix.BackfillResult.
+type Result struct {
+	OutsideRetentionDays []time.Time
+}
+
+// Backfill executes BackfillSQL against conn — the incremental, non-
+// retroactive one-time historical pass. retention is the tier table's own
+// resolved TTL (0 = no TTL); see Result.OutsideRetentionDays and this
+// package's doc for the retention-boundary hazard.
+func Backfill(ctx context.Context, conn Conn, c Columns, before time.Time, retention time.Duration) (Result, error) {
+	boundary, active := retentionBoundary(nowFunc(), retention)
+	var outsideDays []time.Time
+	if active {
+		var err error
+		outsideDays, err = queryOutsideRetentionDays(ctx, conn, c, before, boundary)
+		if err != nil {
+			return Result{}, fmt.Errorf("downsampletier: check retention window against %s: %w", c.SumTable, err)
+		}
+	}
+	sql, args := BackfillSQL(c, before)
+	if err := conn.Exec(withCaps(ctx), sql, args...); err != nil {
+		return Result{}, fmt.Errorf("downsampletier: backfill %s: %w", schema.DownsampleTierTable, err)
+	}
+	return Result{OutsideRetentionDays: outsideDays}, nil
+}
+
+// Rebuild TRUNCATEs the tier table and re-populates it in full — the
+// recovery path for a suspected stranded or format-incompatible persisted
+// state (see this package's doc). now (the retention-boundary clock) is
+// used exactly as Backfill uses it, but the scanned history has no `before`
+// bound: EVERY day the base table still retains is in scope, so
+// OutsideRetentionDays reports days already outside the tier's TTL as of
+// right now across the base table's FULL retained history, not just a
+// caller-chosen window.
+func Rebuild(ctx context.Context, conn Conn, c Columns, retention time.Duration) (Result, error) {
+	var outsideDays []time.Time
+	if boundary, active := retentionBoundary(nowFunc(), retention); active {
+		var err error
+		// before = now: the same "[-inf, before)" scope Backfill's own check
+		// uses, with before pinned to now so the scope is the base table's
+		// entire currently-retained history.
+		outsideDays, err = queryOutsideRetentionDays(ctx, conn, c, nowFunc(), boundary)
+		if err != nil {
+			return Result{}, fmt.Errorf("downsampletier: check retention window against %s: %w", c.SumTable, err)
+		}
+	}
+	if err := conn.Exec(withCaps(ctx), TruncateSQL(c)); err != nil {
+		return Result{}, fmt.Errorf("downsampletier: truncate %s: %w", schema.DownsampleTierTable, err)
+	}
+	sql, args := RebuildSQL(c)
+	if err := conn.Exec(withCaps(ctx), sql, args...); err != nil {
+		return Result{}, fmt.Errorf("downsampletier: rebuild %s: %w", schema.DownsampleTierTable, err)
+	}
+	return Result{OutsideRetentionDays: outsideDays}, nil
+}
+
+// baseBucketsSQL / tierBucketsSQL render the per-metric DISTINCT bucket
+// count Verify compares — a COMPLETENESS check (does every bucket the base
+// table has raw data for also have a tier row), not a value-parity check
+// like internal/deltaprefix.Verify's sum comparison. See this package's doc
+// for why: the tier's read-side failure mode for a missing bucket is a safe
+// absent series point, never a wrong number, so there is no aggregate total
+// to parity-check in the first place.
+func baseBucketsSQL(c Columns, before, boundary time.Time, retentionActive bool) (string, []any) {
+	bucket := bucketEndExpr(c.TimestampColumn)
+	conds := []chsql.Frag{chsql.Lt(chsql.Col(c.TimestampColumn), chsql.Lit(before))}
+	if retentionActive {
+		conds = append(conds, chsql.Gte(bucket, chsql.Lit(boundary)))
+	}
+	q := chsql.NewQuery().
+		Select(chsql.Col(c.MetricNameColumn), chsql.As(chsql.Call("uniqExact", bucket), "n")).
+		From(chsql.Qual(c.Database, c.SumTable)).
+		Where(conds...).
+		GroupBy(chsql.Col(c.MetricNameColumn))
+	return q.Build()
+}
+
+func tierBucketsSQL(c Columns, before, boundary time.Time, retentionActive bool) (string, []any) {
+	bucketCol := chsql.Col(schema.DownsampleTierBucketColumn)
+	conds := []chsql.Frag{chsql.Lt(bucketCol, chsql.Lit(before))}
+	if retentionActive {
+		conds = append(conds, chsql.Gte(bucketCol, chsql.Lit(boundary)))
+	}
+	q := chsql.NewQuery().
+		Select(chsql.Col(c.MetricNameColumn), chsql.As(chsql.Call("uniqExact", bucketCol), "n")).
+		From(chsql.Qual(c.Database, schema.DownsampleTierTable)).
+		Where(conds...).
+		GroupBy(chsql.Col(c.MetricNameColumn))
+	return q.Build()
+}
+
+// Mismatch is one metric name whose base-table bucket count disagrees with
+// the tier table's own bucket count — Missing is how many of the base
+// table's buckets have no corresponding tier row (base - tier, floored at
+// 0; a tier count that legitimately EXCEEDS the base count is not an error
+// here — see BaseBuckets/TierBuckets' own doc — so Missing never goes
+// negative).
+type Mismatch struct {
+	MetricName  string
+	BaseBuckets int64
+	TierBuckets int64
+}
+
+// Missing is BaseBuckets - TierBuckets, floored at 0.
+func (m Mismatch) Missing() int64 {
+	if d := m.BaseBuckets - m.TierBuckets; d > 0 {
+		return d
+	}
+	return 0
+}
+
+// Report is Verify's result — mirrors internal/deltaprefix.Report's shape
+// with BUCKET COUNTS in place of SUM TOTALS (see this package's doc).
+type Report struct {
+	Before      time.Time
+	BaseBuckets map[string]int64
+	TierBuckets map[string]int64
+	Mismatches  []Mismatch
+
+	Retention            time.Duration
+	RetentionBoundary    time.Time
+	OutsideRetentionDays []time.Time
+}
+
+// Pass reports whether every metric's bucket count matched.
+// OutsideRetentionDays does not affect Pass — see Report.OutsideRetentionDays.
+func (r Report) Pass() bool { return len(r.Mismatches) == 0 }
+
+// Verify reads both per-metric bucket counts and diffs them, returning a
+// Report an operator (or the `downsample-tier-verify` CLI verb) can render
+// before relying on the tier for long-range queries.
+func Verify(ctx context.Context, conn Conn, c Columns, before time.Time, retention time.Duration) (Report, error) {
+	boundary, active := retentionBoundary(nowFunc(), retention)
+
+	var outsideDays []time.Time
+	if active {
+		var err error
+		outsideDays, err = queryOutsideRetentionDays(ctx, conn, c, before, boundary)
+		if err != nil {
+			return Report{}, fmt.Errorf("downsampletier: check retention window against %s: %w", c.SumTable, err)
+		}
+	}
+
+	baseSQL, baseArgs := baseBucketsSQL(c, before, boundary, active)
+	base, err := scanCounts(ctx, conn, baseSQL, baseArgs)
+	if err != nil {
+		return Report{}, fmt.Errorf("downsampletier: read %s bucket counts: %w", c.SumTable, err)
+	}
+	tierSQL, tierArgs := tierBucketsSQL(c, before, boundary, active)
+	tier, err := scanCounts(ctx, conn, tierSQL, tierArgs)
+	if err != nil {
+		return Report{}, fmt.Errorf("downsampletier: read %s bucket counts: %w", schema.DownsampleTierTable, err)
+	}
+
+	rep := Diff(base, tier, before)
+	rep.Retention = retention
+	if active {
+		rep.RetentionBoundary = boundary
+	}
+	rep.OutsideRetentionDays = outsideDays
+	return rep, nil
+}
+
+// Diff compares two per-metric-name bucket-count maps and returns the
+// Report — split out from Verify so the comparison logic is unit-testable
+// against fixture maps, without a Conn, mirroring internal/deltaprefix.Diff.
+func Diff(base, tier map[string]int64, before time.Time) Report {
+	names := make(map[string]struct{}, len(base)+len(tier))
+	for name := range base {
+		names[name] = struct{}{}
+	}
+	for name := range tier {
+		names[name] = struct{}{}
+	}
+	sorted := make([]string, 0, len(names))
+	for name := range names {
+		sorted = append(sorted, name)
+	}
+	sort.Strings(sorted)
+
+	var mismatches []Mismatch
+	for _, name := range sorted {
+		b, t := base[name], tier[name]
+		if b != t {
+			mismatches = append(mismatches, Mismatch{MetricName: name, BaseBuckets: b, TierBuckets: t})
+		}
+	}
+	return Report{
+		Before:      before,
+		BaseBuckets: base,
+		TierBuckets: tier,
+		Mismatches:  mismatches,
+	}
+}
+
+// scanCounts runs sql and scans a (MetricName, count int64) result into a
+// map — mirrors internal/deltaprefix.scanTotals.
+func scanCounts(ctx context.Context, conn Conn, sql string, args []any) (map[string]int64, error) {
+	rows, err := conn.Query(withCaps(ctx), sql, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = rows.Close() }()
+	out := map[string]int64{}
+	for rows.Next() {
+		var name string
+		var n int64
+		if err := rows.Scan(&name, &n); err != nil {
+			return nil, err
+		}
+		out[name] = n
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return out, nil
+}

--- a/internal/downsampletier/downsampletier_test.go
+++ b/internal/downsampletier/downsampletier_test.go
@@ -1,0 +1,577 @@
+package downsampletier
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/ClickHouse/clickhouse-go/v2/lib/driver"
+
+	"github.com/tsouza/cerberus/internal/schema"
+)
+
+// testColumns builds a Columns value the way a deployment resolving
+// schema.DefaultOTelMetrics() would — mirrors internal/deltaprefix's own
+// testColumns.
+func testColumns() Columns {
+	return FromSchema("otel", schema.DefaultOTelMetrics())
+}
+
+var testBefore = time.Date(2026, 8, 20, 12, 30, 0, 0, time.UTC)
+
+// TestBackfillSQL pins the rendered INSERT ... SELECT shape: the target
+// column list, the exact-instant-before WHERE bound (no temporality
+// filter, unlike internal/deltaprefix — see this package's doc), and the
+// ceiling-bucket GROUP BY matching internal/schema/ddl's MV exactly.
+func TestBackfillSQL(t *testing.T) {
+	sql, args := BackfillSQL(testColumns(), testBefore)
+	want := "INSERT INTO otel.otel_metrics_sum_downsample_tier " +
+		"(`MetricName`, `Attributes`, `ResourceAttributes`, `ServiceName`, `BucketEnd`, `LastTwoSamples`, `Temporality`) " +
+		"SELECT `MetricName`, `Attributes`, `ResourceAttributes`, `ServiceName`, " +
+		"toStartOfInterval(`TimeUnix` - toIntervalNanosecond(1), toIntervalSecond(300)) + toIntervalSecond(300) AS `BucketEnd`, " +
+		"timeSeriesLastTwoSamplesState(`TimeUnix`, `Value`) AS `LastTwoSamples`, " +
+		"any(`AggregationTemporality`) AS `Temporality` " +
+		"FROM `otel`.`otel_metrics_sum` WHERE `TimeUnix` < ? " +
+		"GROUP BY `MetricName`, `Attributes`, `ResourceAttributes`, `ServiceName`, " +
+		"toStartOfInterval(`TimeUnix` - toIntervalNanosecond(1), toIntervalSecond(300)) + toIntervalSecond(300)"
+	if sql != want {
+		t.Errorf("BackfillSQL sql =\n%s\nwant\n%s", sql, want)
+	}
+	if len(args) != 1 || args[0] != testBefore {
+		t.Errorf("BackfillSQL args = %v; want [%v]", args, testBefore)
+	}
+}
+
+// TestRebuildSQL pins the SAME shape as BackfillSQL but with NO `before`
+// bound at all — the full-history rebuild this package's doc explains is
+// the recovery path for a suspected stranded persisted state.
+func TestRebuildSQL(t *testing.T) {
+	sql, args := RebuildSQL(testColumns())
+	if len(args) != 0 {
+		t.Errorf("RebuildSQL args = %v; want none (no --before bound)", args)
+	}
+	backfillSQL, _ := BackfillSQL(testColumns(), testBefore)
+	if sql == backfillSQL {
+		t.Fatal("RebuildSQL rendered identically to a bounded BackfillSQL — the WHERE clause is missing")
+	}
+	wantPrefix := "INSERT INTO otel.otel_metrics_sum_downsample_tier "
+	if len(sql) < len(wantPrefix) || sql[:len(wantPrefix)] != wantPrefix {
+		t.Errorf("RebuildSQL sql = %q; want prefix %q", sql, wantPrefix)
+	}
+	if containsSubstr(sql, "WHERE") {
+		t.Errorf("RebuildSQL sql = %q; want no WHERE clause at all", sql)
+	}
+}
+
+// TestTruncateSQL pins the TRUNCATE statement Rebuild issues before its
+// full re-populate.
+func TestTruncateSQL(t *testing.T) {
+	got := TruncateSQL(testColumns())
+	want := "TRUNCATE TABLE otel.otel_metrics_sum_downsample_tier"
+	if got != want {
+		t.Errorf("TruncateSQL = %q; want %q", got, want)
+	}
+}
+
+// TestOutsideRetentionDaysSQL pins the DISTINCT bucket-boundary read used
+// both by Backfill/Rebuild's pre-check and Verify's OutsideRetentionDays —
+// mirrors internal/deltaprefix's own TestOutsideRetentionDaysSQL, adapted
+// to this package's ceiling bucket expression and lack of a temporality
+// filter.
+func TestOutsideRetentionDaysSQL(t *testing.T) {
+	boundary := time.Date(2026, 8, 10, 0, 0, 0, 0, time.UTC)
+	sql, args := outsideRetentionDaysSQL(testColumns(), testBefore, boundary)
+	bucketExpr := "toStartOfInterval(`TimeUnix` - toIntervalNanosecond(1), toIntervalSecond(300)) + toIntervalSecond(300)"
+	want := "SELECT " + bucketExpr + " FROM `otel`.`otel_metrics_sum` " +
+		"WHERE `TimeUnix` < ? AND " + bucketExpr + " < ? " +
+		"GROUP BY " + bucketExpr + " ORDER BY " + bucketExpr
+	if sql != want {
+		t.Errorf("outsideRetentionDaysSQL sql =\n%s\nwant\n%s", sql, want)
+	}
+	if len(args) != 2 || args[0] != testBefore || args[1] != boundary {
+		t.Errorf("outsideRetentionDaysSQL args = %v; want [%v %v]", args, testBefore, boundary)
+	}
+}
+
+// TestBaseAndTierBucketsSQL pins Verify's two completeness reads: DISTINCT
+// bucket counts per metric, base table vs. tier table, both bounded by the
+// exact-instant `before`.
+func TestBaseAndTierBucketsSQL(t *testing.T) {
+	c := testColumns()
+
+	baseSQL, baseArgs := baseBucketsSQL(c, testBefore, time.Time{}, false)
+	bucketExpr := "toStartOfInterval(`TimeUnix` - toIntervalNanosecond(1), toIntervalSecond(300)) + toIntervalSecond(300)"
+	wantBase := "SELECT `MetricName`, uniqExact(" + bucketExpr + ") AS `n` " +
+		"FROM `otel`.`otel_metrics_sum` WHERE `TimeUnix` < ? GROUP BY `MetricName`"
+	if baseSQL != wantBase {
+		t.Errorf("baseBucketsSQL sql =\n%s\nwant\n%s", baseSQL, wantBase)
+	}
+	if len(baseArgs) != 1 || baseArgs[0] != testBefore {
+		t.Errorf("baseBucketsSQL args = %v; want [%v]", baseArgs, testBefore)
+	}
+
+	tierSQL, tierArgs := tierBucketsSQL(c, testBefore, time.Time{}, false)
+	wantTier := "SELECT `MetricName`, uniqExact(`BucketEnd`) AS `n` " +
+		"FROM `otel`.`otel_metrics_sum_downsample_tier` WHERE `BucketEnd` < ? GROUP BY `MetricName`"
+	if tierSQL != wantTier {
+		t.Errorf("tierBucketsSQL sql =\n%s\nwant\n%s", tierSQL, wantTier)
+	}
+	if len(tierArgs) != 1 || tierArgs[0] != testBefore {
+		t.Errorf("tierBucketsSQL args = %v; want [%v]", tierArgs, testBefore)
+	}
+}
+
+// TestBaseAndTierBucketsSQL_RetentionActive pins the additional lower
+// bound both reads gain when a retention boundary is active — mirrors
+// internal/deltaprefix's own retention-active SQL test.
+func TestBaseAndTierBucketsSQL_RetentionActive(t *testing.T) {
+	c := testColumns()
+	boundary := time.Date(2026, 8, 10, 0, 0, 0, 0, time.UTC)
+
+	baseSQL, baseArgs := baseBucketsSQL(c, testBefore, boundary, true)
+	bucketExpr := "toStartOfInterval(`TimeUnix` - toIntervalNanosecond(1), toIntervalSecond(300)) + toIntervalSecond(300)"
+	wantBase := "SELECT `MetricName`, uniqExact(" + bucketExpr + ") AS `n` " +
+		"FROM `otel`.`otel_metrics_sum` WHERE `TimeUnix` < ? AND " + bucketExpr + " >= ? GROUP BY `MetricName`"
+	if baseSQL != wantBase {
+		t.Errorf("baseBucketsSQL sql =\n%s\nwant\n%s", baseSQL, wantBase)
+	}
+	if len(baseArgs) != 2 || baseArgs[0] != testBefore || baseArgs[1] != boundary {
+		t.Errorf("baseBucketsSQL args = %v; want [%v %v]", baseArgs, testBefore, boundary)
+	}
+
+	tierSQL, tierArgs := tierBucketsSQL(c, testBefore, boundary, true)
+	wantTier := "SELECT `MetricName`, uniqExact(`BucketEnd`) AS `n` " +
+		"FROM `otel`.`otel_metrics_sum_downsample_tier` WHERE `BucketEnd` < ? AND `BucketEnd` >= ? GROUP BY `MetricName`"
+	if tierSQL != wantTier {
+		t.Errorf("tierBucketsSQL sql =\n%s\nwant\n%s", tierSQL, wantTier)
+	}
+	if len(tierArgs) != 2 || tierArgs[0] != testBefore || tierArgs[1] != boundary {
+		t.Errorf("tierBucketsSQL args = %v; want [%v %v]", tierArgs, testBefore, boundary)
+	}
+}
+
+func TestRetentionBoundary(t *testing.T) {
+	now := time.Date(2026, 8, 26, 12, 0, 0, 0, time.UTC)
+	if boundary, active := retentionBoundary(now, 0); active || !boundary.IsZero() {
+		t.Errorf("retentionBoundary(now, 0) = (%v, %v); want (zero, false)", boundary, active)
+	}
+	retention := 30 * 24 * time.Hour
+	boundary, active := retentionBoundary(now, retention)
+	if !active {
+		t.Fatal("retentionBoundary: expected active=true for a positive retention")
+	}
+	want := now.Add(-retention)
+	if !boundary.Equal(want) {
+		t.Errorf("retentionBoundary boundary = %v; want %v", boundary, want)
+	}
+}
+
+func TestDiff(t *testing.T) {
+	base := map[string]int64{"m1": 10, "m2": 5, "m3": 3}
+	tier := map[string]int64{"m1": 10, "m2": 4, "m4": 1}
+	rep := Diff(base, tier, testBefore)
+	if rep.Pass() {
+		t.Fatal("expected Diff to report mismatches")
+	}
+	if len(rep.Mismatches) != 3 {
+		t.Fatalf("Mismatches = %v; want 3 entries (m2, m3, m4)", rep.Mismatches)
+	}
+	byName := map[string]Mismatch{}
+	for _, m := range rep.Mismatches {
+		byName[m.MetricName] = m
+	}
+	if m, ok := byName["m2"]; !ok || m.BaseBuckets != 5 || m.TierBuckets != 4 || m.Missing() != 1 {
+		t.Errorf("m2 mismatch = %+v; want BaseBuckets=5 TierBuckets=4 Missing=1", m)
+	}
+	if m, ok := byName["m3"]; !ok || m.BaseBuckets != 3 || m.TierBuckets != 0 || m.Missing() != 3 {
+		t.Errorf("m3 mismatch = %+v; want BaseBuckets=3 TierBuckets=0 Missing=3", m)
+	}
+	if m, ok := byName["m4"]; !ok || m.BaseBuckets != 0 || m.TierBuckets != 1 || m.Missing() != 0 {
+		t.Errorf("m4 mismatch = %+v; want BaseBuckets=0 TierBuckets=1 Missing=0 (tier ahead of base is not a completeness gap)", m)
+	}
+	if _, ok := byName["m1"]; ok {
+		t.Error("m1 (equal counts) must not appear in Mismatches")
+	}
+}
+
+func TestDiff_Pass(t *testing.T) {
+	base := map[string]int64{"m1": 10}
+	tier := map[string]int64{"m1": 10}
+	rep := Diff(base, tier, testBefore)
+	if !rep.Pass() {
+		t.Errorf("expected Pass; mismatches = %v", rep.Mismatches)
+	}
+}
+
+// --- fake Conn plumbing, mirroring internal/deltaprefix's own shape ---
+
+type fakeRows struct {
+	driver.Rows
+	data [][2]any
+	pos  int
+}
+
+func (r *fakeRows) Next() bool {
+	if r.pos >= len(r.data) {
+		return false
+	}
+	r.pos++
+	return true
+}
+
+// Scan handles BOTH row shapes this package's queries use: scanCounts'
+// (MetricName string, n int64) pair (dest arity 2) and
+// queryOutsideRetentionDays' single time.Time column (dest arity 1, reads
+// only row[0]) — Verify's own retention-exclusion test needs both shapes
+// dispatched off the SAME conn, unlike internal/deltaprefix's split
+// fakeConn/dayFakeConn (whose Backfill/Verify tests never combine both
+// reads on one scripted conn).
+func (r *fakeRows) Scan(dest ...any) error {
+	row := r.data[r.pos-1]
+	switch len(dest) {
+	case 1:
+		tp, ok := dest[0].(*time.Time)
+		if !ok {
+			return fmt.Errorf("fakeRows: dest[0] is %T, want *time.Time", dest[0])
+		}
+		*tp = row[0].(time.Time)
+		return nil
+	case 2:
+		np, ok := dest[0].(*string)
+		if !ok {
+			return fmt.Errorf("fakeRows: dest[0] is %T, want *string", dest[0])
+		}
+		*np = row[0].(string)
+		tp, ok := dest[1].(*int64)
+		if !ok {
+			return fmt.Errorf("fakeRows: dest[1] is %T, want *int64", dest[1])
+		}
+		*tp = row[1].(int64)
+		return nil
+	default:
+		return fmt.Errorf("fakeRows: unsupported scan arity %d", len(dest))
+	}
+}
+
+func (r *fakeRows) Err() error   { return nil }
+func (r *fakeRows) Close() error { return nil }
+
+// fakeConn is a scripted Conn: Query returns rows keyed by a substring
+// match against the SQL, Exec records every statement + args it received —
+// mirrors internal/deltaprefix's own fakeConn.
+type fakeConn struct {
+	execSQL  []string
+	execArgs [][]any
+	execErr  error
+
+	queries []string
+	respond map[string][][2]any
+	rowsErr error
+}
+
+func (c *fakeConn) Exec(_ context.Context, query string, args ...any) error {
+	c.execSQL = append(c.execSQL, query)
+	c.execArgs = append(c.execArgs, args)
+	return c.execErr
+}
+
+func (c *fakeConn) Query(_ context.Context, query string, _ ...any) (driver.Rows, error) {
+	c.queries = append(c.queries, query)
+	if c.rowsErr != nil {
+		return nil, c.rowsErr
+	}
+	for match, rows := range c.respond {
+		if containsSubstr(query, match) {
+			return &fakeRows{data: rows}, nil
+		}
+	}
+	return &fakeRows{}, nil
+}
+
+func containsSubstr(s, substr string) bool {
+	if len(substr) == 0 {
+		return true
+	}
+	for i := 0; i+len(substr) <= len(s); i++ {
+		if s[i:i+len(substr)] == substr {
+			return true
+		}
+	}
+	return false
+}
+
+// twoCallConn succeeds on its first Query and fails on its second — the
+// shape Verify's own two reads (base table, then tier table) need to reach
+// its second error-wrap branch.
+type twoCallConn struct {
+	calls int
+	err   error
+}
+
+func (c *twoCallConn) Exec(context.Context, string, ...any) error { return nil }
+
+func (c *twoCallConn) Query(context.Context, string, ...any) (driver.Rows, error) {
+	c.calls++
+	if c.calls == 2 {
+		return nil, c.err
+	}
+	return &fakeRows{}, nil
+}
+
+func withFrozenNow(t *testing.T, now time.Time) {
+	t.Helper()
+	prev := nowFunc
+	nowFunc = func() time.Time { return now }
+	t.Cleanup(func() { nowFunc = prev })
+}
+
+// TestBackfill_ExecutesRenderedSQL confirms Backfill hands conn EXACTLY the
+// statement + args BackfillSQL renders, and wraps a real Exec failure with
+// enough context to identify the target table.
+func TestBackfill_ExecutesRenderedSQL(t *testing.T) {
+	c := testColumns()
+	conn := &fakeConn{}
+	result, err := Backfill(context.Background(), conn, c, testBefore, 0)
+	if err != nil {
+		t.Fatalf("Backfill: %v", err)
+	}
+	if len(result.OutsideRetentionDays) != 0 {
+		t.Errorf("OutsideRetentionDays = %v; want none with retention=0", result.OutsideRetentionDays)
+	}
+	wantSQL, wantArgs := BackfillSQL(c, testBefore)
+	if len(conn.execSQL) != 1 || conn.execSQL[0] != wantSQL {
+		t.Errorf("Exec sql = %v; want [%q]", conn.execSQL, wantSQL)
+	}
+	if len(conn.execArgs) != 1 || len(conn.execArgs[0]) != len(wantArgs) {
+		t.Errorf("Exec args = %v; want %v", conn.execArgs, wantArgs)
+	}
+
+	failing := &fakeConn{execErr: errors.New("boom")}
+	_, err = Backfill(context.Background(), failing, c, testBefore, 0)
+	if err == nil {
+		t.Fatal("expected error from a failing Exec")
+	}
+	if got := err.Error(); !containsSubstr(got, schema.DownsampleTierTable) {
+		t.Errorf("Backfill error %q does not name the target table %q", got, schema.DownsampleTierTable)
+	}
+}
+
+func TestBackfill_DetectsOutsideRetentionDays(t *testing.T) {
+	c := testColumns()
+	now := time.Date(2026, 8, 26, 12, 0, 0, 0, time.UTC)
+	withFrozenNow(t, now)
+	retention := 30 * 24 * time.Hour
+	outsideDay := time.Date(2026, 7, 1, 0, 0, 0, 0, time.UTC)
+	conn := &fakeConn{
+		respond: map[string][][2]any{
+			"GROUP BY": {{outsideDay, int64(0)}},
+		},
+	}
+	result, err := Backfill(context.Background(), conn, c, testBefore, retention)
+	if err != nil {
+		t.Fatalf("Backfill: %v", err)
+	}
+	// The outside-retention check must run BEFORE the INSERT.
+	if len(conn.queries) != 1 {
+		t.Fatalf("expected exactly 1 Query (the retention check); got %d", len(conn.queries))
+	}
+	if len(conn.execSQL) != 1 {
+		t.Fatalf("expected exactly 1 Exec (the INSERT); got %d", len(conn.execSQL))
+	}
+	if len(result.OutsideRetentionDays) != 1 || !result.OutsideRetentionDays[0].Equal(outsideDay) {
+		t.Errorf("OutsideRetentionDays = %v; want [%v]", result.OutsideRetentionDays, outsideDay)
+	}
+}
+
+func TestBackfill_PropagatesRetentionCheckQueryError(t *testing.T) {
+	c := testColumns()
+	withFrozenNow(t, time.Date(2026, 8, 26, 12, 0, 0, 0, time.UTC))
+	conn := &fakeConn{rowsErr: errors.New("query failed")}
+	_, err := Backfill(context.Background(), conn, c, testBefore, 30*24*time.Hour)
+	if err == nil {
+		t.Fatal("expected error from a failing retention-check Query")
+	}
+}
+
+// TestRebuild_TruncatesThenInserts confirms Rebuild issues TRUNCATE before
+// the unbounded INSERT ... SELECT, in that order, and surfaces
+// outside-retention days computed against `now` rather than any --before
+// bound.
+func TestRebuild_TruncatesThenInserts(t *testing.T) {
+	c := testColumns()
+	conn := &fakeConn{}
+	result, err := Rebuild(context.Background(), conn, c, 0)
+	if err != nil {
+		t.Fatalf("Rebuild: %v", err)
+	}
+	if len(result.OutsideRetentionDays) != 0 {
+		t.Errorf("OutsideRetentionDays = %v; want none with retention=0", result.OutsideRetentionDays)
+	}
+	if len(conn.execSQL) != 2 {
+		t.Fatalf("Exec calls = %d; want 2 (TRUNCATE then INSERT)", len(conn.execSQL))
+	}
+	if conn.execSQL[0] != TruncateSQL(c) {
+		t.Errorf("first Exec = %q; want TRUNCATE %q", conn.execSQL[0], TruncateSQL(c))
+	}
+	wantInsert, _ := RebuildSQL(c)
+	if conn.execSQL[1] != wantInsert {
+		t.Errorf("second Exec = %q; want %q", conn.execSQL[1], wantInsert)
+	}
+
+	failingTruncate := &fakeConn{execErr: errors.New("truncate failed")}
+	_, err = Rebuild(context.Background(), failingTruncate, c, 0)
+	if err == nil {
+		t.Fatal("expected error from a failing TRUNCATE")
+	}
+	if len(failingTruncate.execSQL) != 1 {
+		t.Errorf("expected Rebuild to stop after a failing TRUNCATE, not attempt the INSERT; got %d Exec calls", len(failingTruncate.execSQL))
+	}
+}
+
+func TestRebuild_PropagatesRetentionCheckQueryError(t *testing.T) {
+	c := testColumns()
+	withFrozenNow(t, time.Date(2026, 8, 26, 12, 0, 0, 0, time.UTC))
+	conn := &fakeConn{rowsErr: errors.New("query failed")}
+	_, err := Rebuild(context.Background(), conn, c, 30*24*time.Hour)
+	if err == nil {
+		t.Fatal("expected error from a failing retention-check Query")
+	}
+	if len(conn.execSQL) != 0 {
+		t.Error("expected Rebuild to never TRUNCATE when the retention check itself fails")
+	}
+}
+
+func TestVerify_ReadsBothBucketCountsAndDiffs(t *testing.T) {
+	c := testColumns()
+	// Match keys must be MUTUALLY EXCLUSIVE substrings — a bare
+	// c.SumTable ("otel_metrics_sum") is itself a substring of
+	// schema.DownsampleTierTable ("otel_metrics_sum_downsample_tier"), so
+	// containsSubstr would match BOTH queries against whichever key map
+	// iteration (random order) happens to check first. The closing
+	// backtick right after the table name disambiguates: it appears in
+	// the base table's own quoted reference but not inside the tier
+	// table's (longer) one.
+	conn := &fakeConn{
+		respond: map[string][][2]any{
+			"`" + schema.DownsampleTierTable + "`": {{"m1", int64(4)}},
+			"`" + c.SumTable + "`":                 {{"m1", int64(5)}},
+		},
+	}
+	rep, err := Verify(context.Background(), conn, c, testBefore, 0)
+	if err != nil {
+		t.Fatalf("Verify: %v", err)
+	}
+	if rep.Pass() {
+		t.Fatal("expected a mismatch (base=5, tier=4)")
+	}
+	if len(rep.Mismatches) != 1 || rep.Mismatches[0].MetricName != "m1" {
+		t.Errorf("Mismatches = %v; want one entry for m1", rep.Mismatches)
+	}
+}
+
+func TestVerify_PropagatesBaseTableQueryError(t *testing.T) {
+	c := testColumns()
+	conn := &twoCallConn{err: errors.New("boom")}
+	// twoCallConn fails on its SECOND call. Verify's own read order is
+	// base table first, then tier table — see Verify's own doc — so the
+	// second call belongs to the TIER table read.
+	_, err := Verify(context.Background(), conn, c, testBefore, 0)
+	if err == nil {
+		t.Fatal("expected an error from the second (tier table) Query")
+	}
+	if !containsSubstr(err.Error(), schema.DownsampleTierTable) {
+		t.Errorf("Verify error %q does not name the tier table", err.Error())
+	}
+}
+
+func TestVerify_PropagatesRetentionCheckQueryError(t *testing.T) {
+	c := testColumns()
+	withFrozenNow(t, time.Date(2026, 8, 26, 12, 0, 0, 0, time.UTC))
+	conn := &fakeConn{rowsErr: errors.New("query failed")}
+	_, err := Verify(context.Background(), conn, c, testBefore, 30*24*time.Hour)
+	if err == nil {
+		t.Fatal("expected error from a failing retention-check Query")
+	}
+}
+
+func TestVerify_ExcludesOutsideRetentionDaysFromReport(t *testing.T) {
+	c := testColumns()
+	now := time.Date(2026, 8, 26, 12, 0, 0, 0, time.UTC)
+	withFrozenNow(t, now)
+	retention := 30 * 24 * time.Hour
+	outsideDay := time.Date(2026, 7, 1, 0, 0, 0, 0, time.UTC)
+	boundary, _ := retentionBoundary(now, retention)
+	// Three distinct queries land on this one conn (the retention-day
+	// check, baseBucketsSQL, tierBucketsSQL) — key each response by its
+	// OWN exact rendered SQL (derived from the real renderers, not a
+	// hand-guessed substring) so none can accidentally match another.
+	dayQuery, _ := outsideRetentionDaysSQL(c, testBefore, boundary)
+	baseQuery, _ := baseBucketsSQL(c, testBefore, boundary, true)
+	conn := &fakeConn{
+		respond: map[string][][2]any{
+			dayQuery:  {{outsideDay, int64(0)}},
+			baseQuery: {{"m1", int64(3)}},
+		},
+	}
+	rep, err := Verify(context.Background(), conn, c, testBefore, retention)
+	if err != nil {
+		t.Fatalf("Verify: %v", err)
+	}
+	if len(rep.OutsideRetentionDays) != 1 || !rep.OutsideRetentionDays[0].Equal(outsideDay) {
+		t.Errorf("OutsideRetentionDays = %v; want [%v]", rep.OutsideRetentionDays, outsideDay)
+	}
+	if rep.Retention != retention {
+		t.Errorf("Retention = %v; want %v", rep.Retention, retention)
+	}
+}
+
+func TestScanCounts_PropagatesScanError(t *testing.T) {
+	conn := &singleRowsConn{rows: &erroringRows{hasRow: true, scanErr: errors.New("scan failed")}}
+	_, err := scanCounts(context.Background(), conn, "SELECT 1", nil)
+	if err == nil {
+		t.Fatal("expected an error from a failing Scan")
+	}
+}
+
+func TestScanCounts_PropagatesRowsErr(t *testing.T) {
+	conn := &singleRowsConn{rows: &erroringRows{hasRow: false, finalErr: errors.New("rows.Err failed")}}
+	_, err := scanCounts(context.Background(), conn, "SELECT 1", nil)
+	if err == nil {
+		t.Fatal("expected an error from a failing rows.Err()")
+	}
+}
+
+// erroringRows is a driver.Rows that fails on either Scan or Err (never
+// both) instead of yielding real data — mirrors internal/deltaprefix's own
+// erroringRows.
+type erroringRows struct {
+	driver.Rows
+	hasRow   bool
+	scanErr  error
+	finalErr error
+	yielded  bool
+}
+
+func (r *erroringRows) Next() bool {
+	if !r.hasRow || r.yielded {
+		return false
+	}
+	r.yielded = true
+	return true
+}
+
+func (r *erroringRows) Scan(...any) error { return r.scanErr }
+func (r *erroringRows) Err() error        { return r.finalErr }
+func (r *erroringRows) Close() error      { return nil }
+
+// singleRowsConn is a Conn whose Query always returns one fixed
+// driver.Rows, for pairing with erroringRows.
+type singleRowsConn struct{ rows driver.Rows }
+
+func (c *singleRowsConn) Exec(context.Context, string, ...any) error { return nil }
+
+func (c *singleRowsConn) Query(context.Context, string, ...any) (driver.Rows, error) {
+	return c.rows, nil
+}

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -719,14 +719,27 @@ func clampU8(v int64) uint8 {
 // * 2, m)` — hangs off an Expr slot that Walk does not follow. Missing it
 // leaves the setting unstamped and ClickHouse answers code 63 ("aggregate
 // function ... is experimental and disabled by default") on every such query.
+//
+// Also matches a *chplan.RangeWindow whose DownsampleTier field is true
+// (cerberus issue #2751): unlike the four dedicated node types above, the
+// downsampled long-range tier reuses the ordinary RangeWindow node with a
+// bool flag (see chplan.RangeWindow.DownsampleTier's own doc for why), so
+// this is a FIELD check rather than another type-only case — its tier
+// table's AggregateFunction(timeSeriesLastTwoSamples, ...) column shares
+// the SAME experimental gate the other four members do.
 func planHasTSGridNative(plan chplan.Node) bool {
 	found := false
 	chplan.WalkDeep(plan, func(n chplan.Node) bool {
-		switch n.(type) {
+		switch v := n.(type) {
 		case *chplan.RangeWindowGridNative, *chplan.RangeWindowGridNativeInstant,
 			*chplan.RangeWindowStaleResample, *chplan.RangeBucketGridNative:
 			found = true
 			return false // stop descending this branch
+		case *chplan.RangeWindow:
+			if v.DownsampleTier {
+				found = true
+				return false
+			}
 		}
 		return true
 	})

--- a/internal/promql/downsample_tier_strategy_test.go
+++ b/internal/promql/downsample_tier_strategy_test.go
@@ -1,0 +1,290 @@
+package promql_test
+
+// Resolution-aware eligibility for the operator opt-in downsampled
+// long-range tier (cerberus issue #2751). These are plain lowering-shape
+// tests (no ClickHouse / chDB involved) — they pin WHICH shapes the
+// boot-wired DownsampleTier{Irate,Idelta,LastOverTime}Lowerer strategies
+// route to the tier by inspecting the lowered chplan.RangeWindow.DownsampleTier
+// / .DownsampleTierInput fields directly, mirroring how
+// native_strategy_coverage_test.go and the family's own dual-emit chDB
+// tests split "does the RIGHT shape route" (here, cheap) from "is the SQL
+// correct" (internal/chsql's downsample-tier chDB test, which needs a real
+// engine).
+//
+// The critical, explicitly-required-by-the-issue property under test:
+// resolution-awareness. A query whose step is FINER than the tier's fixed
+// bucket (schema.DownsampleTierBucket, 5 minutes) must NEVER route to the
+// tier — "a 15s-step query must never touch a 5m tier".
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	promparser "github.com/prometheus/prometheus/promql/parser"
+
+	"github.com/tsouza/cerberus/internal/chplan"
+	"github.com/tsouza/cerberus/internal/promql"
+	"github.com/tsouza/cerberus/internal/schema"
+)
+
+// downsampleTierLowerers builds a RangeLowerers with the DownsampleTier
+// strategy wired for irate/idelta/last_over_time, wrapping the plain
+// fan-out (no ts_grid_irate/idelta/last_over_time native layering) — the
+// minimal wiring cmd/cerberus's nativeRangeLowerers would produce with ONLY
+// chopt.FeatureDownsampleTier resolved.
+func downsampleTierLowerers() promql.RangeLowerers {
+	return promql.RangeLowerers{
+		Irate:        promql.DownsampleTierIrateLowerer{Fallback: promql.FanoutIrateLowerer{}},
+		Idelta:       promql.DownsampleTierIdeltaLowerer{Fallback: promql.FanoutIdeltaLowerer{}},
+		LastOverTime: promql.DownsampleTierLastOverTimeLowerer{Fallback: promql.FanoutLastOverTimeLowerer{}},
+	}
+}
+
+// lowerDownsampleTierQuery lowers query in range mode [start, end] at step,
+// with the downsample-tier strategy wired, and returns the first
+// *chplan.RangeWindow found in the plan (depth-first) plus whether one was
+// found at all.
+func lowerDownsampleTierQuery(t *testing.T, query string, start, end time.Time, step time.Duration) (*chplan.RangeWindow, bool) {
+	t.Helper()
+	p := promparser.NewParser(promparser.Options{EnableExperimentalFunctions: true})
+	expr, err := p.ParseExpr(query)
+	if err != nil {
+		t.Fatalf("parse %q: %v", query, err)
+	}
+	plan, err := promql.LowerAtRangeOpts(context.Background(), expr, schema.DefaultOTelMetrics(),
+		start, end, step, promql.LowerOpts{Lowerers: downsampleTierLowerers()})
+	if err != nil {
+		t.Fatalf("lower %q: %v", query, err)
+	}
+	var found *chplan.RangeWindow
+	chplan.WalkDeep(plan, func(n chplan.Node) bool {
+		if rw, ok := n.(*chplan.RangeWindow); ok && found == nil {
+			found = rw
+			return false
+		}
+		return true
+	})
+	return found, found != nil
+}
+
+// bucketAlignedStart is an absolute instant aligned to schema.DownsampleTierBucket
+// (an exact multiple of 5 minutes since the Unix epoch) — every eligible
+// case below anchors on it; the misaligned cases perturb it.
+var bucketAlignedStart = time.Date(2026, 1, 1, 0, 25, 0, 0, time.UTC)
+
+func TestDownsampleTierEligible_IrateBucketAlignedStepEqualsBucket(t *testing.T) {
+	rw, ok := lowerDownsampleTierQuery(t, `irate(cpu_seconds_total[5m])`,
+		bucketAlignedStart, bucketAlignedStart.Add(20*time.Minute), schema.DownsampleTierBucket)
+	if !ok {
+		t.Fatal("expected a RangeWindow in the plan")
+	}
+	if !rw.DownsampleTier {
+		t.Error("expected DownsampleTier=true for a bucket-aligned, step==bucket irate() query")
+	}
+	if rw.DownsampleTierInput == nil {
+		t.Error("expected DownsampleTierInput to be populated")
+	}
+}
+
+func TestDownsampleTierEligible_IdeltaStepMultipleOfBucket(t *testing.T) {
+	// step = 2x bucket — still an integer multiple, so still eligible
+	// ("step >= bucket", not "step == bucket").
+	rw, ok := lowerDownsampleTierQuery(t, `idelta(cpu_seconds_total[5m])`,
+		bucketAlignedStart, bucketAlignedStart.Add(time.Hour), 2*schema.DownsampleTierBucket)
+	if !ok {
+		t.Fatal("expected a RangeWindow in the plan")
+	}
+	if !rw.DownsampleTier {
+		t.Error("expected DownsampleTier=true for a bucket-aligned idelta() query whose step is a multiple of the bucket")
+	}
+}
+
+func TestDownsampleTierEligible_LastOverTime(t *testing.T) {
+	rw, ok := lowerDownsampleTierQuery(t, `last_over_time(cpu_seconds_total[5m])`,
+		bucketAlignedStart, bucketAlignedStart.Add(20*time.Minute), schema.DownsampleTierBucket)
+	if !ok {
+		t.Fatal("expected a RangeWindow in the plan")
+	}
+	if !rw.DownsampleTier {
+		t.Error("expected DownsampleTier=true for a bucket-aligned last_over_time() query")
+	}
+}
+
+// TestDownsampleTierIneligible_StepFinerThanBucket is the issue's own
+// headline resolution-awareness requirement: "a 15s-step query must never
+// touch a 5m tier".
+func TestDownsampleTierIneligible_StepFinerThanBucket(t *testing.T) {
+	rw, ok := lowerDownsampleTierQuery(t, `irate(cpu_seconds_total[5m])`,
+		bucketAlignedStart, bucketAlignedStart.Add(time.Minute), 15*time.Second)
+	if !ok {
+		t.Fatal("expected a RangeWindow in the plan")
+	}
+	if rw.DownsampleTier {
+		t.Error("a 15s-step query must never route to the 5m tier, but DownsampleTier=true")
+	}
+}
+
+func TestDownsampleTierIneligible_StepNotMultipleOfBucket(t *testing.T) {
+	// step = 7 minutes: coarser than the 5m bucket, but NOT an integer
+	// multiple of it, so successive anchors drift off the bucket grid.
+	rw, ok := lowerDownsampleTierQuery(t, `irate(cpu_seconds_total[5m])`,
+		bucketAlignedStart, bucketAlignedStart.Add(21*time.Minute), 7*time.Minute)
+	if !ok {
+		t.Fatal("expected a RangeWindow in the plan")
+	}
+	if rw.DownsampleTier {
+		t.Error("a step that is not an integer multiple of the bucket must never route to the tier")
+	}
+}
+
+func TestDownsampleTierIneligible_RangeNotEqualToBucket(t *testing.T) {
+	// range (15m) != the tier's fixed 5m bucket — even though step is a
+	// clean bucket multiple, v1 scope requires Range == bucket exactly (see
+	// downsampleTierEligible's own doc on why multi-bucket merge is out of
+	// scope).
+	rw, ok := lowerDownsampleTierQuery(t, `irate(cpu_seconds_total[15m])`,
+		bucketAlignedStart, bucketAlignedStart.Add(20*time.Minute), schema.DownsampleTierBucket)
+	if !ok {
+		t.Fatal("expected a RangeWindow in the plan")
+	}
+	if rw.DownsampleTier {
+		t.Error("range != the tier's fixed bucket must never route to the tier")
+	}
+}
+
+func TestDownsampleTierIneligible_UnalignedStart(t *testing.T) {
+	// bucketAlignedStart + 1 minute is NOT itself a multiple of 5m since
+	// epoch, even though the step is a clean bucket multiple.
+	unaligned := bucketAlignedStart.Add(time.Minute)
+	rw, ok := lowerDownsampleTierQuery(t, `irate(cpu_seconds_total[5m])`,
+		unaligned, unaligned.Add(20*time.Minute), schema.DownsampleTierBucket)
+	if !ok {
+		t.Fatal("expected a RangeWindow in the plan")
+	}
+	if rw.DownsampleTier {
+		t.Error("an eval grid whose Start is not bucket-aligned must never route to the tier")
+	}
+}
+
+func TestDownsampleTierIneligible_NonzeroOffset(t *testing.T) {
+	rw, ok := lowerDownsampleTierQuery(t, `irate(cpu_seconds_total[5m] offset 5m)`,
+		bucketAlignedStart, bucketAlignedStart.Add(20*time.Minute), schema.DownsampleTierBucket)
+	if !ok {
+		t.Fatal("expected a RangeWindow in the plan")
+	}
+	if rw.DownsampleTier {
+		t.Error("a nonzero offset must never route to the tier (v1 scope)")
+	}
+}
+
+func TestDownsampleTierIneligible_InstantQuery(t *testing.T) {
+	// Step == 0 (an instant query, not query_range) is never eligible — the
+	// tier only ever routes a materialised grid.
+	p := promparser.NewParser(promparser.Options{EnableExperimentalFunctions: true})
+	expr, err := p.ParseExpr(`irate(cpu_seconds_total[5m])`)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	// Step==0 is instant-query mode (a single anchor at End, matching
+	// LowerAtRangeOpts's own "Zero means instant query" contract) — there
+	// is no dedicated LowerAtOpts entry point, so this drives the same
+	// range-mode entry point with Step==0 and Start==End.
+	plan, err := promql.LowerAtRangeOpts(context.Background(), expr, schema.DefaultOTelMetrics(),
+		bucketAlignedStart, bucketAlignedStart, 0, promql.LowerOpts{Lowerers: downsampleTierLowerers()})
+	if err != nil {
+		t.Fatalf("lower: %v", err)
+	}
+	var found *chplan.RangeWindow
+	chplan.WalkDeep(plan, func(n chplan.Node) bool {
+		if rw, ok := n.(*chplan.RangeWindow); ok && found == nil {
+			found = rw
+			return false
+		}
+		return true
+	})
+	if found == nil {
+		t.Fatal("expected a RangeWindow in the plan")
+	}
+	if found.DownsampleTier {
+		t.Error("an instant (Step==0) query must never route to the tier")
+	}
+}
+
+// TestDownsampleTierIneligible_RateNeverWired proves rate()/increase() have
+// structurally NO downsample-tier routing at all: RangeLowerers carries no
+// DownsampleTier-wrapped Rate/Increase field for cmd/cerberus to ever wire
+// (see chopt.FeatureDownsampleTier's own doc on the hard scope boundary),
+// so a rate() query lowered with the SAME downsampleTierLowerers() table
+// this file uses for irate/idelta/last_over_time never sets
+// DownsampleTierInput at all — there is no field on RangeLowerers that
+// COULD route it there.
+func TestDownsampleTierIneligible_RateNeverWired(t *testing.T) {
+	rw, ok := lowerDownsampleTierQuery(t, `rate(cpu_seconds_total[5m])`,
+		bucketAlignedStart, bucketAlignedStart.Add(20*time.Minute), schema.DownsampleTierBucket)
+	if !ok {
+		t.Fatal("expected a RangeWindow in the plan")
+	}
+	if rw.DownsampleTier {
+		t.Fatal("rate() must never set DownsampleTier — there is no DownsampleTierRateLowerer")
+	}
+	if rw.DownsampleTierInput != nil {
+		t.Error("rate() must never populate DownsampleTierInput — downsampleTierEligibleFunc excludes it")
+	}
+}
+
+func TestDownsampleTierIneligible_IncreaseNeverWired(t *testing.T) {
+	rw, ok := lowerDownsampleTierQuery(t, `increase(cpu_seconds_total[5m])`,
+		bucketAlignedStart, bucketAlignedStart.Add(20*time.Minute), schema.DownsampleTierBucket)
+	if !ok {
+		t.Fatal("expected a RangeWindow in the plan")
+	}
+	if rw.DownsampleTierInput != nil {
+		t.Error("increase() must never populate DownsampleTierInput — downsampleTierEligibleFunc excludes it")
+	}
+}
+
+func TestDownsampleTierIneligible_DeltaNeverWired(t *testing.T) {
+	rw, ok := lowerDownsampleTierQuery(t, `delta(cpu_gauge[5m])`,
+		bucketAlignedStart, bucketAlignedStart.Add(20*time.Minute), schema.DownsampleTierBucket)
+	if !ok {
+		t.Fatal("expected a RangeWindow in the plan")
+	}
+	if rw.DownsampleTierInput != nil {
+		t.Error("delta() must never populate DownsampleTierInput — downsampleTierEligibleFunc excludes it")
+	}
+}
+
+// TestDownsampleTierDisabled_FallsThroughToFanout proves the whole
+// mechanism is inert unless a caller wires it in RangeLowerers — mirroring
+// the family's own "off by default" contract. Lowering the SAME eligible
+// query with the ZERO-VALUE RangeLowerers (what a deployment without
+// chopt.FeatureDownsampleTier resolved gets — see RangeLowerers.withDefaults)
+// must never set DownsampleTier.
+func TestDownsampleTierDisabled_FallsThroughToFanout(t *testing.T) {
+	p := promparser.NewParser(promparser.Options{EnableExperimentalFunctions: true})
+	expr, err := p.ParseExpr(`irate(cpu_seconds_total[5m])`)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	plan, err := promql.LowerAtRangeOpts(context.Background(), expr, schema.DefaultOTelMetrics(),
+		bucketAlignedStart, bucketAlignedStart.Add(20*time.Minute), schema.DownsampleTierBucket,
+		promql.LowerOpts{}) // zero-value Lowerers — no strategy wired at all
+	if err != nil {
+		t.Fatalf("lower: %v", err)
+	}
+	var found *chplan.RangeWindow
+	chplan.WalkDeep(plan, func(n chplan.Node) bool {
+		if rw, ok := n.(*chplan.RangeWindow); ok && found == nil {
+			found = rw
+			return false
+		}
+		return true
+	})
+	if found == nil {
+		t.Fatal("expected a RangeWindow in the plan")
+	}
+	if found.DownsampleTier {
+		t.Error("DownsampleTier must stay false when no DownsampleTier*Lowerer was wired")
+	}
+}

--- a/internal/promql/lower.go
+++ b/internal/promql/lower.go
@@ -1702,6 +1702,106 @@ func deltaPrefixAggregateEligibleFunc(funcName string) bool {
 	return funcName == "rate" || funcName == "increase"
 }
 
+// downsampleTierEligibleFunc reports whether funcName is one of the three
+// range functions the operator opt-in downsampled long-range tier (cerberus
+// issue #2751) ever answers. See chopt.FeatureDownsampleTier's own doc for
+// why rate() / increase() / delta() are hard-excluded: PromQL defines
+// irate() / idelta() / last_over_time() as functions of exactly the
+// trailing one or two samples in the window, which is exactly what the
+// tier's timeSeriesLastTwoSamples state retains — so those three are exact
+// by construction over it, while the other three would need every sample
+// the tier's own bucketing discards to detect a counter reset between them.
+func downsampleTierEligibleFunc(funcName string) bool {
+	switch funcName {
+	case "irate", "idelta", "last_over_time":
+		return true
+	}
+	return false
+}
+
+// attachDownsampleTierArm side-feeds the downsampled long-range tier
+// (cerberus issue #2751) onto rw whenever funcName is eligible for it
+// (downsampleTierEligibleFunc) over an unambiguous Sum/Histogram-table scan.
+// Unlike attachDeltaPrefixAggregateArm this does NOT gate on
+// counterTemporalityRangeFn(funcName) first — idelta() and last_over_time()
+// are not counterTemporalityRangeFn members (neither ever needs
+// rw.TemporalityColumn populated: idelta never counter-corrects and
+// last_over_time is temporality-agnostic), so this resolves its own "is
+// this a Sum/Histogram-table scan" verdict directly via
+// rangeVectorCounterTemporalityColumn, purely as an eligibility oracle —
+// the resolved column is discarded, never assigned to rw.TemporalityColumn.
+//
+// A Histogram-table verdict slipping through (the tier's own MV reads only
+// the Sum table — see internal/schema/ddl's renderDownsampleTierView) is
+// safe, not silently wrong: the arm's Scan filters on MetricName, and a
+// histogram metric's rows simply never exist in the tier table, so the
+// query reads back empty and the boot-wired DownsampleTier*Lowerer's own
+// row-count guard (chsql's emitRangeWindowDownsampleTier) drops the series
+// exactly as PromQL would for missing data — see
+// schema.DownsampleTierTable's doc for why this whole mechanism degrades
+// safely rather than silently.
+//
+// This populates the FIELD unconditionally under those conditions; whether
+// the emitter actually CONSUMES it is the separate, boot-wired
+// DownsampleTier*Lowerer's resolution-aware eligibility check
+// (rw.DownsampleTier), so populating it here changes no emitted SQL by
+// itself — mirroring attachDeltaPrefixAggregateArm's own two-phase
+// contract.
+func attachDownsampleTierArm(
+	rw *chplan.RangeWindow,
+	funcName string,
+	vs *parser.VectorSelector,
+	s schema.Metrics,
+	rangeCtx lowerCtx,
+) {
+	if !downsampleTierEligibleFunc(funcName) {
+		return
+	}
+	if rangeVectorCounterTemporalityColumn(vs, s, rangeCtx) == "" {
+		return
+	}
+	rw.DownsampleTierInput = buildDownsampleTierArm(vs.LabelMatchers, s, rangeCtx)
+}
+
+// buildDownsampleTierArm builds chplan.RangeWindow.DownsampleTierInput
+// (cerberus issue #2751): a Scan of schema.DownsampleTierTable, filtered by
+// the SAME full label-matcher set the primary selector arm applies (unlike
+// buildDeltaPrefixAggregateArm's narrower MetricName-only filter — the tier
+// table carries the full Attributes/ResourceAttributes/ServiceName series
+// identity, so there is no later join step to defer the rest of the
+// matchers to), wrapped by augmentDownsampleTierAttributes so its Attributes
+// projection is built by the identical selectorAttributesExpr(ctx, s) call
+// the primary arm's own augmentSelectorAttributes uses.
+func buildDownsampleTierArm(matchers []*labels.Matcher, s schema.Metrics, ctx lowerCtx) chplan.Node {
+	scan := &chplan.Scan{Table: schema.DownsampleTierTable}
+	var input chplan.Node = scan
+	if pred := buildPredicate(matchers, s); pred != nil {
+		input = &chplan.Filter{Input: scan, Predicate: pred}
+	}
+	return augmentDownsampleTierAttributes(input, ctx, s)
+}
+
+// augmentDownsampleTierAttributes is augmentDeltaPrefixAggregateAttributes'
+// sibling for the downsample-tier table (cerberus issue #2751): the same
+// selectorAttributesExpr(ctx, s) tower, projecting the tier's own row shape
+// (MetricNameColumn, shaped Attributes, schema.DownsampleTierBucketColumn,
+// schema.DownsampleTierSamplesColumn) instead of the DELTA-prefix table's
+// (MetricName, Attributes, BucketStart, PartialSum) quadruple. Never skips
+// the Project, for the same reason augmentDeltaPrefixAggregateAttributes
+// never does: the tier table's own column names never match a raw Scan's.
+func augmentDownsampleTierAttributes(input chplan.Node, ctx lowerCtx, s schema.Metrics) chplan.Node {
+	return &chplan.Project{
+		Input: input,
+		Projections: []chplan.Projection{
+			{Expr: &chplan.ColumnRef{Name: s.MetricNameColumn}, Alias: s.MetricNameColumn},
+			{Expr: selectorAttributesExpr(ctx, s), Alias: s.AttributesColumn},
+			{Expr: &chplan.ColumnRef{Name: schema.DownsampleTierBucketColumn}, Alias: schema.DownsampleTierBucketColumn},
+			{Expr: &chplan.ColumnRef{Name: schema.DownsampleTierSamplesColumn}, Alias: schema.DownsampleTierSamplesColumn},
+			{Expr: &chplan.ColumnRef{Name: schema.DownsampleTierTemporalityColumn}, Alias: schema.DownsampleTierTemporalityColumn},
+		},
+	}
+}
+
 // selectorAttributesExpr returns the rebound Attributes expression for the
 // selector Project: the base resource-merge
 // (`mapUpdate(sanitize(ResourceAttributes), Attributes)`) with the
@@ -3067,6 +3167,7 @@ func lowerRangeVectorCall(c *parser.Call, s schema.Metrics, ctx lowerCtx) (chpla
 		TemporalityColumn: temporalityCol,
 	}
 	attachDeltaPrefixAggregateArm(rw, c.Func.Name, vs, s, temporalityCol, rangeCtx)
+	attachDownsampleTierArm(rw, c.Func.Name, vs, s, rangeCtx)
 	// Name-drop collision guard. When the function drops `__name__` and the
 	// selector spans several metrics, two source series that differ only by
 	// name land on one label set — the case reference Prometheus refuses

--- a/internal/promql/lower_strategy.go
+++ b/internal/promql/lower_strategy.go
@@ -1488,3 +1488,150 @@ func (n NativeLastOverTimeLowerer) LowerLastOverTime(rw *chplan.RangeWindow, s s
 	}
 	return n.Fallback.LowerLastOverTime(rw, s)
 }
+
+// This section wires the operator opt-in downsampled long-range tier
+// (cerberus issue #2751): reading the operator-provisioned
+// schema.DownsampleTierTable (a materialized view folding raw samples into
+// a persisted timeSeriesLastTwoSamples aggregate state per bucket) instead
+// of scanning the full-resolution raw table. Unlike every strategy above,
+// this is NOT a stateless read-time function swap over the SAME table — it
+// reads a SEPARATE, pre-populated table an operator must provision and
+// backfill first (internal/schema/ddl, internal/downsampletier) — and it
+// wires only irate() / idelta() / last_over_time(): see
+// chopt.FeatureDownsampleTier's own doc for why rate() / increase() /
+// delta() are structurally never eligible (a hard scope boundary, not a
+// version gate).
+
+// downsampleTierEligible is the SHAPE + RESOLUTION-AWARE eligibility
+// predicate shared by every DownsampleTier*Lowerer below — the single
+// source of "is this the ONE query shape the tier can answer exactly"
+// (cerberus issue #2751's own scope decision, see
+// schema.DownsampleTierBucket's doc for why v1 supports only ONE fixed
+// bucket rather than a configurable one):
+//
+//   - rw.DownsampleTierInput must be populated — attachDownsampleTierArm
+//     (internal/promql/lower.go) only does that for an unambiguous
+//     Sum/Histogram-table scan of an eligible Func (downsampleTierEligibleFunc).
+//   - The window must be a materialised query_range grid: Step > 0, Start
+//     and End pinned — mirroring nativeTSGridMatrixNode's own instant
+//     exclusion. OuterRange is NOT checked: applyStepGridFanout
+//     (internal/promql/modifiers.go) sets it to End-Start for EVERY
+//     fan-out shape, ordinary query_range included, not only a literal
+//     PromQL subquery `[range:step]` — so it carries no subquery-specific
+//     signal at this layer to exclude on.
+//   - rw.Offset must be zero — an offset shifts the window off the tier's
+//     own bucket grid; v1 does not attempt to re-derive an offset-shifted
+//     alignment.
+//   - rw.Range must equal EXACTLY schema.DownsampleTierBucket. A wider
+//     range spanning multiple buckets would need merging several tier rows
+//     (timeSeriesLastTwoSamplesMerge across buckets) PLUS an exact
+//     timestamp re-filter at the union's edges to stay byte-correct at
+//     bucket boundaries — deliberately out of v1 scope (see the PR
+//     description's follow-up note); a narrower range cannot be answered
+//     from one bucket-granularity row at all.
+//   - rw.Step must be a POSITIVE INTEGER MULTIPLE of the bucket — this is
+//     the "step >= bucket" resolution-awareness the issue requires (a step
+//     smaller than the bucket can never divide it evenly, so the modulo
+//     check alone rejects every step-too-fine shape; a 15s-step query
+//     never touches the 5-minute tier).
+//   - rw.Start must land exactly on a bucket boundary (absolute Unix-epoch
+//     alignment, matching internal/schema/ddl's downsampleTierBucketEndExpr
+//     — ClickHouse's toStartOfInterval with no origin argument is itself
+//     epoch-aligned). Combined with the Step-multiple check above, EVERY
+//     anchor Start+k*Step is then also bucket-aligned, so this one check
+//     covers the whole grid.
+func downsampleTierEligible(rw *chplan.RangeWindow) bool {
+	if rw.DownsampleTierInput == nil {
+		return false
+	}
+	if rw.Identity || rw.Step <= 0 || rw.Start.IsZero() || rw.End.IsZero() {
+		return false
+	}
+	if rw.Offset != 0 {
+		return false
+	}
+	if len(rw.Variants) > 0 {
+		return false
+	}
+	if rw.Range != schema.DownsampleTierBucket {
+		return false
+	}
+	bucketNS := schema.DownsampleTierBucket.Nanoseconds()
+	if rw.Step.Nanoseconds()%bucketNS != 0 {
+		return false
+	}
+	return rw.Start.UnixNano()%bucketNS == 0
+}
+
+// downsampleTierNode builds the eligible node: a shallow copy of rw with
+// DownsampleTier set, telling the emitter (internal/chsql's
+// emitRangeWindowDownsampleTier) to render DownsampleTierInput's bucketed
+// state instead of windowing Input's raw rows. Returns nil when
+// downsampleTierEligible(rw) is false, so every caller below follows the
+// same `if node := downsampleTierNode(rw); node != nil { return node }`
+// shape the native strategies above use.
+func downsampleTierNode(rw *chplan.RangeWindow) *chplan.RangeWindow {
+	if !downsampleTierEligible(rw) {
+		return nil
+	}
+	out := *rw
+	out.DownsampleTier = true
+	return &out
+}
+
+// DownsampleTierIrateLowerer is the boot-wired IrateLowerer that routes an
+// eligible range-mode irate() shape onto the downsampled long-range tier.
+// cmd/cerberus wires it ONLY when chopt resolved the downsample_tier
+// feature (server >= 25.9, opt-in) at boot, WRAPPING whatever IrateLowerer
+// the family's own ts_grid_irate / laginframe_adjacency wiring already
+// resolved — so a query this strategy declines still gets the family's own
+// best available raw-scan strategy, never a hand-rolled fallback.
+type DownsampleTierIrateLowerer struct {
+	// Fallback is the concrete lowerer for shapes the tier cannot handle —
+	// the family's own already-resolved IrateLowerer (Native, LagAdjacency,
+	// or Fanout), threaded so the raw-read path stays reachable forever.
+	Fallback IrateLowerer
+}
+
+// LowerIrate returns the tier-routed node for an eligible shape, or
+// delegates to the embedded Fallback otherwise.
+func (l DownsampleTierIrateLowerer) LowerIrate(rw *chplan.RangeWindow, s schema.Metrics) chplan.Node {
+	if node := downsampleTierNode(rw); node != nil {
+		return node
+	}
+	return l.Fallback.LowerIrate(rw, s)
+}
+
+// DownsampleTierIdeltaLowerer mirrors [DownsampleTierIrateLowerer] for
+// idelta().
+type DownsampleTierIdeltaLowerer struct {
+	// Fallback is the concrete lowerer for shapes the tier cannot handle —
+	// the family's own already-resolved IdeltaLowerer.
+	Fallback IdeltaLowerer
+}
+
+// LowerIdelta returns the tier-routed node for an eligible shape, or
+// delegates to the embedded Fallback otherwise.
+func (l DownsampleTierIdeltaLowerer) LowerIdelta(rw *chplan.RangeWindow, s schema.Metrics) chplan.Node {
+	if node := downsampleTierNode(rw); node != nil {
+		return node
+	}
+	return l.Fallback.LowerIdelta(rw, s)
+}
+
+// DownsampleTierLastOverTimeLowerer mirrors [DownsampleTierIrateLowerer] for
+// last_over_time().
+type DownsampleTierLastOverTimeLowerer struct {
+	// Fallback is the concrete lowerer for shapes the tier cannot handle —
+	// the family's own already-resolved LastOverTimeLowerer.
+	Fallback LastOverTimeLowerer
+}
+
+// LowerLastOverTime returns the tier-routed node for an eligible shape, or
+// delegates to the embedded Fallback otherwise.
+func (l DownsampleTierLastOverTimeLowerer) LowerLastOverTime(rw *chplan.RangeWindow, s schema.Metrics) chplan.Node {
+	if node := downsampleTierNode(rw); node != nil {
+		return node
+	}
+	return l.Fallback.LowerLastOverTime(rw, s)
+}

--- a/internal/schema/ddl/ddl.go
+++ b/internal/schema/ddl/ddl.go
@@ -248,6 +248,27 @@ type Config struct {
 	// — mirroring exactly how LokiLabelCatalogEnabled is threaded from its
 	// own chopt verdict.
 	TempoTagCatalogEnabled bool
+
+	// DownsampleTierEnabled gates provisioning the operator opt-in
+	// downsampled long-range tier (schema.DownsampleTierTable +
+	// its materialized view; cerberus issue #2751) alongside the five
+	// upstream metrics tables. False (the default) renders no
+	// downsample-tier statements at all — an operator on today's schema
+	// sees byte-identical DDL. Like DeltaPrefixEnabled this table is
+	// entirely cerberus-authored (see renderDownsampleTierTable /
+	// renderDownsampleTierView), so it needs no upstream sqltemplates fork.
+	//
+	// Unlike DeltaPrefixEnabled, this is threaded DIRECTLY from the resolved
+	// chopt.FeatureDownsampleTier boot verdict (internal/schemaboot.
+	// DDLConfig, cmd/cerberus's chOptResolution) — mirroring
+	// ColumnStatisticsEnabled / TraceIDProjectionEnabled above, not
+	// DeltaPrefixEnabled's own dedicated CERBERUS_SCHEMA_*_ENABLED env var —
+	// because this feature genuinely has a ClickHouse version floor to
+	// probe (timeSeriesLastTwoSamples, floor 25.9) the way those two do,
+	// and because a not-yet-backfilled bucket degrades safely (see
+	// schema.DownsampleTierTable's doc) rather than needing DeltaPrefix's
+	// separate later "backfill verified" declaration.
+	DownsampleTierEnabled bool
 }
 
 // DatabaseEngine selects the ClickHouse database engine for the
@@ -851,6 +872,17 @@ func renderSignal(cfg Config, s Signal) ([]string, error) {
 				renderDeltaPrefixView(cfg),
 			)
 		}
+		// The downsampled long-range tier (cerberus issue #2751) is entirely
+		// opt-in and entirely cerberus-authored, the same shape as the
+		// DELTA-prefix pair immediately above — CREATE precedes the MV
+		// (which references it in its TO clause).
+		if cfg.DownsampleTierEnabled {
+			stmts = append(
+				stmts,
+				renderDownsampleTierTable(cfg),
+				renderDownsampleTierView(cfg),
+			)
+		}
 		// Column statistics (issue #2766) trail every other metrics
 		// statement — CREATE, then projections, then the temporality index,
 		// then the DELTA-prefix pair — for the same reason the temporality
@@ -1339,6 +1371,161 @@ func renderDeltaPrefixView(cfg Config) string {
 		Database(cfg.Database).
 		IfNotExists().
 		To(cfg.Database, cfg.Tables.MetricsDeltaPrefix).
+		As(body)
+	if cfg.Cluster != "" {
+		stmt.OnCluster(cfg.Cluster)
+	}
+	return stmt.SQL()
+}
+
+// --- Downsampled long-range tier (cerberus issue #2751) ---
+
+// downsampleTierBucketEndExpr renders the tier's bucket-boundary expression
+// over col (metricTimeColumn on the write side; see downsampletier's own
+// backfillBucketEndExpr, which MUST render the identical expression so a
+// backfilled row and a live-MV row for the same raw sample land in the same
+// bucket — see that package's doc comment for why the two copies cannot
+// share a Go func: internal/schema/ddl and internal/downsampletier are both
+// leaf packages neither may import the other's exported surface for one
+// shared helper alone).
+//
+// It computes the CEILING bucket boundary — `bucket * ceil(t / bucket)` —
+// NOT ClickHouse's native toStartOfInterval FLOOR convention
+// (deltaprefix's own dayBucket). This is deliberate: PromQL's range-vector
+// window is HALF-OPEN LEFT, CLOSED RIGHT — `(anchor-range, anchor]` — so a
+// raw sample landing exactly ON a bucket boundary must join the bucket
+// ENDING at that instant, not the one STARTING there. A plain
+// toStartOfInterval(t, bucket) bucket is closed-left/open-right, which is
+// off-by-one at BOTH edges against that PromQL window; the ceiling
+// convention here reproduces PromQL's half-open-left/closed-right window
+// exactly (verified empirically against a real ClickHouse boundary-exact
+// sample — see internal/chsql's downsample-tier chDB test), so the read
+// side (internal/chsql's emitRangeWindowDownsampleTier) can look up a
+// SINGLE bucket row per grid anchor with no multi-bucket merge or
+// arrayFilter re-narrowing — every raw sample in `(anchor-bucket, anchor]`
+// is guaranteed to land in exactly the row keyed `BucketEnd = anchor`.
+//
+// Computed as `toStartOfInterval(t - toIntervalNanosecond(1), bucket) +
+// bucket`: subtracting one nanosecond (TimeUnix's own DateTime64(9)
+// precision) before flooring turns ClickHouse's floor into the ceiling
+// PromQL's window needs, EXCEPT for a sample exactly ON a bucket's OWN
+// start (which correctly stays in that same, now-ending-here bucket rather
+// than jumping to the one before it) — see the chDB test's boundary-exact
+// case for the worked arithmetic.
+func downsampleTierBucketEndExpr(col string, bucket time.Duration) chsql.Frag {
+	bucketSeconds := int64(bucket / time.Second)
+	epsilon := chsql.Sub(chsql.Col(col), chsql.Call("toIntervalNanosecond", chsql.InlineLit(int64(1))))
+	floor := chsql.Call("toStartOfInterval", epsilon, chsql.Call("toIntervalSecond", chsql.InlineLit(bucketSeconds)))
+	return chsql.Add(floor, chsql.Call("toIntervalSecond", chsql.InlineLit(bucketSeconds)))
+}
+
+// renderDownsampleTierTable renders the CREATE TABLE for the downsampled
+// long-range tier (cerberus issue #2751): one row per (series, bucket),
+// carrying an AggregateFunction(timeSeriesLastTwoSamples, ...) state folding
+// every raw sample in that bucket down to its two most recent (timestamp,
+// value) pairs. AggregatingMergeTree (not SimpleAggregateFunction, unlike
+// renderDeltaPrefixTable's PartialSum column) because timeSeriesLastTwoSamples'
+// combinator is a genuine two-state merge (re-selecting the top-2 by
+// timestamp across states), not an idempotent max/sum — see
+// renderLokiLabelCatalogTable's uniqState column for the same distinction.
+//
+// ORDER BY puts BucketEnd second, immediately after MetricName, for the SAME
+// primary-key-pruning reason renderDeltaPrefixTable's own ORDER BY does (a
+// query bounded to one metric + a bucket range prunes on the primary key
+// instead of scanning every bucket of every series for that metric).
+//
+// The engine is ALWAYS AggregatingMergeTree / ReplicatedAggregatingMergeTree
+// — never cfg.Engine's operator override — mirroring
+// renderDeltaPrefixTable's own reasoning: an AggregateFunction column
+// requires the Aggregating family specifically, a correctness requirement
+// of this table, not a deployment preference.
+func renderDownsampleTierTable(cfg Config) string {
+	lcString := chsql.TypeLowCardinality(chsql.TypeRaw("String"))
+	mapType := chsql.Call("Map", lcString, chsql.TypeRaw("String"))
+	dt64ns := chsql.Call("DateTime64", chsql.InlineLit(int64(9)))
+	engine := chsql.EngineAggregatingMergeTree()
+	if cfg.DatabaseEngine.Replicated {
+		engine = chsql.EngineReplicatedAggregatingMergeTree()
+	}
+	return chsql.CreateTable(schema.DownsampleTierTable).
+		Database(cfg.Database).
+		IfNotExists().
+		Columns(
+			chsql.ColumnDef{Name: metricNameColumn, Type: lcString},
+			chsql.ColumnDef{Name: metricAttributesColumn, Type: mapType},
+			chsql.ColumnDef{Name: metricResourceAttributesColumn, Type: mapType},
+			chsql.ColumnDef{Name: metricServiceNameColumn, Type: lcString},
+			chsql.ColumnDef{Name: schema.DownsampleTierBucketColumn, Type: dt64ns},
+			chsql.ColumnDef{
+				Name: schema.DownsampleTierSamplesColumn,
+				Type: chsql.Call("AggregateFunction", chsql.BareIdent("timeSeriesLastTwoSamples"), dt64ns, chsql.TypeRaw("Float64")),
+			},
+			// SimpleAggregateFunction(any, Int32), not a plain Int32:
+			// AggregatingMergeTree can hold multiple unmerged parts for the
+			// same (series, bucket) key until a background merge runs (see
+			// internal/chsql's emitRangeWindowDownsampleTier), and a plain
+			// column has no merge semantics at all — a background MERGE
+			// would otherwise pick an ARBITRARY row's value for a
+			// non-aggregate column instead of the single well-defined
+			// any() an OTel series' one-temporality-for-its-lifetime
+			// invariant makes exact.
+			chsql.ColumnDef{
+				Name: schema.DownsampleTierTemporalityColumn,
+				Type: chsql.Call("SimpleAggregateFunction", chsql.BareIdent("any"), chsql.TypeRaw("Int32")),
+			},
+		).
+		Engine(engine).
+		OrderBy(metricNameColumn, schema.DownsampleTierBucketColumn, metricAttributesColumn, metricResourceAttributesColumn, metricServiceNameColumn).
+		TTL(chsql.TableTTLTiered(schema.DownsampleTierBucketColumn, cfg.TTL.Metrics, cfg.Tiering.Metrics, cfg.Tiering.Volume)).
+		SQL()
+}
+
+// renderDownsampleTierView renders the CREATE MATERIALIZED VIEW feeding
+// renderDownsampleTierTable from the Sum table (cerberus issue #2751): every
+// raw sample, bucketed to its downsampleTierBucketEndExpr boundary, folded
+// through timeSeriesLastTwoSamplesState. Scoped to the Sum table only
+// (counters) — v1's deliberate scope decision, matching
+// renderDeltaPrefixView's own single-source-table shape; a gauge metric's
+// last_over_time() never routes to this tier (see
+// internal/promql/lower_strategy.go's eligibility check).
+//
+// any(AggregationTemporality) also rides along, feeding
+// schema.DownsampleTierTemporalityColumn — exact per bucket because a
+// single OTel series carries ONE temporality for its lifetime (see that
+// constant's own doc). Unlike renderDeltaPrefixView this carries NO
+// AggregationTemporality WHERE filter: the tier folds every sample
+// regardless of temporality, and irate()'s read branches on the carried
+// column at query time instead (chsql.CounterOrDeltaPairDelta) — see
+// chopt.FeatureDownsampleTier's own doc.
+//
+// Like every materialized view, this captures only rows inserted from the
+// moment it is created onward; pre-existing history needs the separate
+// `cerberus schema downsample-tier-backfill` one-time pass (see
+// internal/downsampletier and docs/operations.md).
+func renderDownsampleTierView(cfg Config) string {
+	bucketEnd := downsampleTierBucketEndExpr(metricTimeColumn, schema.DownsampleTierBucket)
+	body := chsql.NewQuery().
+		Select(
+			chsql.Col(metricNameColumn),
+			chsql.Col(metricAttributesColumn),
+			chsql.Col(metricResourceAttributesColumn),
+			chsql.Col(metricServiceNameColumn),
+			chsql.As(bucketEnd, schema.DownsampleTierBucketColumn),
+			chsql.As(chsql.Call("timeSeriesLastTwoSamplesState", chsql.Col(metricTimeColumn), chsql.Col(metricValueColumn)), schema.DownsampleTierSamplesColumn),
+			chsql.As(chsql.Call("any", chsql.Col(aggregationTemporalityColumn)), schema.DownsampleTierTemporalityColumn),
+		).
+		From(chsql.Qual(cfg.Database, cfg.Tables.MetricsSum)).
+		GroupBy(
+			chsql.Col(metricNameColumn),
+			chsql.Col(metricAttributesColumn),
+			chsql.Col(metricResourceAttributesColumn),
+			chsql.Col(metricServiceNameColumn),
+			bucketEnd,
+		)
+	stmt := chsql.CreateMaterializedView(schema.DownsampleTierTable+cerberusOwnedViewSuffix).
+		Database(cfg.Database).
+		IfNotExists().
+		To(cfg.Database, schema.DownsampleTierTable).
 		As(body)
 	if cfg.Cluster != "" {
 		stmt.OnCluster(cfg.Cluster)

--- a/internal/schema/downsample_tier.go
+++ b/internal/schema/downsample_tier.go
@@ -1,0 +1,71 @@
+package schema
+
+import "time"
+
+// DownsampleTierTable / DownsampleTierBucketColumn / DownsampleTierSamplesColumn
+// name the operator opt-in downsampled long-range tier (cerberus issue
+// #2751): an AggregatingMergeTree table folding raw Sum-table samples into
+// timeSeriesLastTwoSamples aggregate states per DownsampleTierBucket-aligned
+// bucket, read back by irate() / idelta() / last_over_time() query_range
+// shapes whose window matches the bucket exactly (see
+// internal/promql/lower_strategy.go's DownsampleTier*Lowerer strategies and
+// chopt.FeatureDownsampleTier).
+//
+// Unlike Metrics.DeltaPrefixTable this is NOT a per-Metrics, per-deployment
+// overridable field: like schema.LabelCatalogTable / LabelCatalogKeyColumn
+// (internal/schema/ddl provisions, internal/api/loki queries), the table has
+// one fixed, cerberus-owned name that needs no per-deployment override —
+// internal/schema/ddl (the DDL), internal/promql + internal/chsql (the read
+// path), and internal/downsampletier (the backfill CLI) all reference these
+// same literals. Provisioning is gated by config.Config.SchemaDownsampleTier
+// (the resolved chopt.FeatureDownsampleTier boot verdict — see
+// internal/schemaboot.DDLConfig): unlike DeltaPrefixTable, there is no
+// separate "does this deployment declare the table" bit, because a missing
+// or not-yet-backfilled bucket for THIS mechanism degrades safely — an
+// absent tier row reads back as "fewer than 2 samples in window", which
+// chsql's downsample-tier read path already treats as an absent series
+// point (the same "insufficient samples" gap PromQL itself would render for
+// missing raw data) rather than a silently wrong non-zero value. That is a
+// direct consequence of restricting this tier to irate() / idelta() /
+// last_over_time() only (see chopt.FeatureDownsampleTier's own doc for why
+// rate()/increase()/delta() are hard-rejected) — those three functions are
+// exact functions of "the last k samples in the window", so a missing or
+// partial bucket loses SAMPLES, never introduces a wrong DELTA the way an
+// incomplete SimpleAggregateFunction(sum, ...) table would (contrast
+// Metrics.DeltaPrefixTable's own doc, where exactly this silent-corruption
+// risk is why that table needs its own separate, later
+// DeltaPrefixReadEnabled declaration).
+const (
+	DownsampleTierTable         = "otel_metrics_sum_downsample_tier"
+	DownsampleTierBucketColumn  = "BucketEnd"
+	DownsampleTierSamplesColumn = "LastTwoSamples"
+
+	// DownsampleTierTemporalityColumn names the tier table's own
+	// any(AggregationTemporality) column — a single OTel series carries ONE
+	// temporality for its lifetime, so any() over each bucket's rows is
+	// exact, not a lossy pick (the same property
+	// chplan.RangeWindow.TemporalityColumn's own doc relies on for the raw
+	// fan-out path). irate()'s read (internal/chsql's
+	// emitRangeWindowDownsampleTier) branches on it via the SAME
+	// chsql.CounterOrDeltaPairDelta primitive the fan-out's irateValueFrag
+	// uses, so a DELTA-temporality counter routed through the tier gets the
+	// SAME "raw current sample, no reset-correction" numerator the raw scan
+	// would compute — see that primitive's own doc. idelta() and
+	// last_over_time() ignore this column: idelta never branches on
+	// temporality anywhere in this codebase (the fan-out's own
+	// emitRangeWindowIDelta does not either), and last_over_time is
+	// temporality-agnostic by definition.
+	DownsampleTierTemporalityColumn = "Temporality"
+)
+
+// DownsampleTierBucket is the tier's single supported aggregation bucket —
+// fixed, not operator-configurable (cerberus issue #2751's deliberate v1
+// scope decision). It mirrors the retired otel_metrics_sum_5m rollup's own
+// granularity (see the retired MetricsRollups' defaultOTelRollups doc),
+// chosen because it suits PromQL query_range's common 5-minute step. A
+// configurable bucket size would multiply the routing-eligibility surface
+// (internal/promql/lower_strategy.go's resolution-aware eligibility check)
+// for marginal v1 benefit; a deployment needing a different granularity can
+// follow this package + internal/schema/ddl's DDL as a template for its own
+// table.
+const DownsampleTierBucket = 5 * time.Minute

--- a/internal/schemaboot/ddlconfig.go
+++ b/internal/schemaboot/ddlconfig.go
@@ -169,6 +169,15 @@ func DDLConfig(cfg config.Config) (ddl.Config, error) {
 		// chopt.ExplicitlyRequested) — the SAME threading
 		// LokiLabelCatalogEnabled above uses for its own chopt verdict.
 		TempoTagCatalogEnabled: cfg.SchemaTempoTagCatalogMV,
+		// DownsampleTierEnabled (cerberus issue #2751) is the resolved chopt
+		// downsample_tier verdict, back-filled by cmd/cerberus's boot
+		// resolver (or, for the offline `migrate schema` preview,
+		// chopt.ExplicitlyRequested) — the SAME threading
+		// TraceIDProjectionEnabled above uses for its own chopt verdict. The
+		// table/column names are the fixed schema.DownsampleTier* constants
+		// (see that package's doc for why, unlike DeltaPrefixTable, they are
+		// not threaded from cfg.Schema at all).
+		DownsampleTierEnabled: cfg.SchemaDownsampleTier,
 	}
 	// Validate here rather than only inside ddl.ApplyWithConfig: DDLConfig runs
 	// on EVERY boot (the auto-create hook is a separate flag), so an inert

--- a/test/coverage-floor/internal__downsampletier.json
+++ b/test/coverage-floor/internal__downsampletier.json
@@ -1,0 +1,3 @@
+{
+  "internal/downsampletier": 95.8
+}


### PR DESCRIPTION
## Summary

Closes #2751. Adds an operator opt-in **downsampled long-range tier**: an `AggregatingMergeTree` table + materialized view that folds raw Sum-table samples into a persisted `timeSeriesLastTwoSamples` aggregate state per 5-minute bucket, read back by `irate()` / `idelta()` / `last_over_time()` `query_range` shapes whose window is bucket-aligned and matches the bucket exactly.

- **`internal/schema/ddl`**: `renderDownsampleTierTable` / `renderDownsampleTierView`, gated by `Config.DownsampleTierEnabled`. Bucket boundary uses a **ceiling** convention (`downsampleTierBucketEndExpr`), not ClickHouse's native `toStartOfInterval` floor — a raw sample landing exactly on a bucket boundary must join the bucket ENDING there to match PromQL's half-open-left/closed-right window. Verified against a boundary-exact sample on a real ClickHouse instance.
- **`internal/chopt`**: `FeatureDownsampleTier` (floor 25.9, `RequiresExperimentalTSGrid: true`, `AutoSelect: false` — never picked by `auto`, always an explicit operator opt-in via `CERBERUS_CH_OPTIMIZATIONS=downsample_tier`).
- **`internal/promql`**: `attachDownsampleTierArm`/`buildDownsampleTierArm` populate `chplan.RangeWindow.DownsampleTierInput` at lowering time (mirroring `internal/deltaprefix`'s own `DeltaPrefixAggregateInput` pattern) for an unambiguous Sum/Histogram-table selector; the boot-wired `DownsampleTier{Irate,Idelta,LastOverTime}Lowerer` strategies (`lower_strategy.go`) then decide RESOLUTION-AWARE eligibility and set `RangeWindow.DownsampleTier`.
- **`internal/chsql`**: `emitRangeWindowDownsampleTier` reads the tier via `GROUP BY + timeSeriesLastTwoSamplesMerge` (never a naive per-row `finalizeAggregation` — `AggregatingMergeTree` can hold multiple unmerged parts for the same key), re-sorts the merged pair by timestamp (finalize's own order is NOT documented as sorted — verified empirically to come back descending), and computes irate/idelta/last via `chsql.CounterOrDeltaPairDelta` (the SAME primitive the raw fan-out's own `irateValueFrag` uses, so a DELTA-temporality counter gets the correct raw-current-sample branch).
- **`internal/downsampletier`** + `cmd/cerberus/cmd_schema.go`: `cerberus schema downsample-tier-backfill` / `-verify` / `-rebuild`, mirroring `internal/deltaprefix`'s shape. `-verify` is a per-metric **completeness** check (distinct bucket counts), not a value-parity check — this mechanism has no aggregate total to parity-check. `-rebuild` (`TRUNCATE` + full re-populate, no `--before` bound) covers the "persisted EXPERIMENTAL state gets stranded by a ClickHouse upgrade" risk the issue's Risks section calls out, which an incremental backfill alone cannot recover from.

## Scope constraint (issue's own explicit requirement)

Retaining only the two newest raw samples per bucket makes a counter reset between DISCARDED intra-bucket samples undetectable to `rate()`/`increase()`/`delta()`. Chose **option (a)**: hard-restrict the tier to `irate()`/`idelta()`/`last_over_time()` only — PromQL defines all three as functions of exactly the last one or two samples in the window, so they are exact by construction over this state. `rate()`/`increase()`/`delta()` have **no** `DownsampleTier*Lowerer` at all — there is no wrapper type for them, so this is a structural exclusion, not a runtime check that could be bypassed.

Verified empirically against a real ClickHouse instance (chDB, 26.5.1.1), including:
- A counter reset landing on the retained trailing pair itself: `irate()` correctly reset-corrects (`if(curr<prev, curr, curr-prev)`), `idelta()` correctly does not (matching `funcIrate`/`funcIdelta`).
- DELTA-temporality: `irate()` correctly uses the raw current sample alone (not `curr-prev`), matching the raw fan-out's own `CounterOrDeltaPairDelta` branch — each DELTA sample already IS the increment since the prior export.
- The multi-part `AggregatingMergeTree` read hazard is real: two separate `INSERT` batches for the same `(series, bucket)` key create two unmerged parts; a naive per-row read sees only one part and answers wrong. `GROUP BY + timeSeriesLastTwoSamplesMerge` handles it correctly.
- Insufficient samples (0 or 1 in a bucket for irate/idelta) degrade to an ABSENT row — the same "insufficient samples" outcome PromQL itself has for missing raw data — never a wrong value.

## Scope decisions (out of v1, follow-ups filed)

- #2857 — ranges spanning multiple tier buckets (v1 requires `range == bucket` exactly; a wider range needs cross-bucket merge + an exact edge-timestamp re-filter).
- #2858 — `last_over_time()` over Gauge-table metrics (v1 folds the Sum table only, mirroring `internal/deltaprefix`'s own single-source-table precedent).
- #2859 — the sharded-pushdown solver's cost model is blind to `DownsampleTier` routing (it still reasons about the unused raw-scan `Input` subtree for cost estimation).

Also scoped down from the issue's literal ask: rather than piping the tier's finalized samples back through the existing native `timeSeries*ToGrid` family's own aggregate calls ("readback composes with the family"), this emits direct arithmetic via `chsql.CounterOrDeltaPairDelta` — the same primitive the raw fan-out already uses. Simpler, and verified independently rather than depending on a second native-function code path; the 25.9 floor is kept regardless since this shares the family's `RequiresExperimentalTSGrid` boot-capability gate.

## Testing

- `internal/chsql/range_window_downsample_tier_chdb_test.go`: real-ClickHouse (chDB) end-to-end proof — real DDL (via `ddl.RenderAll`, not a hand-copied mirror), real MV firing, dual-emit parity against the raw fan-out for every scenario host (cumulative, counter-reset, DELTA-temporality, multi-part-merge, insufficient-samples, boundary-exact, empty-bucket), plus pinned expected values.
- `internal/promql/downsample_tier_strategy_test.go`: plain (no chDB) lowering-shape tests pinning resolution-aware eligibility — bucket-aligned/step==bucket/step-multiple-of-bucket accepted; 15s-step (the issue's own headline example), non-multiple step, wrong range, unaligned start, nonzero offset, and instant-mode all rejected; `rate()`/`increase()`/`delta()` proven structurally unreachable.
- `go build`/`go vet` (with and without `-tags chdb`), `go test -race` across every touched package, `golangci-lint run` on every touched package (0 issues), `go-arch-lint check` (OK), `node .github/scripts/forbid-sql-raw.mjs`, `node .github/scripts/clickhouse-version-sync.mjs` (the quickstart still enables no version-gated feature — `downsample_tier` is `AutoSelect: false` and not in the quickstart's `CERBERUS_CH_OPTIMIZATIONS=auto`), `just gen-opt-docs` (regenerated `docs/clickhouse-optimizations.md`), `just fmt-md`/`just lint-md`.
- Two real bugs caught by the chDB test before merge: a chsql `Div`/`Sub` operator-precedence bug (`binOp` renders no parentheses of its own — an unwrapped interval-seconds sub-expression silently mis-parsed) and a test-authoring bucket-boundary mistake. Both fixed; see the commit.

## Docs

`docs/operations.md` gets a new "Downsampled long-range tier" section mirroring the existing DELTA-prefix runbook (DDL shown, resolution-aware routing explained, backfill/verify/rebuild runbook).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
