### PR TITLE
feat(api): emit .keys subcolumn for label/tag key enumeration (#2775)

### DIFF
--- a/internal/api/loki/labels.go
+++ b/internal/api/loki/labels.go
@@ -23,8 +23,8 @@ import (
 //     ResourceAttributes key space across the time range is returned.
 //   - start / end (optional): time range, defaults to last hour / now.
 //
-// The SQL groups distinct map keys via arrayJoin(mapKeys(...)) on the
-// resource-attributes column.
+// The SQL groups distinct map keys via arrayJoin(<col>.keys) on the
+// resource-attributes column's virtual keys subcolumn.
 func (h *Handler) handleLabels(w http.ResponseWriter, r *http.Request) {
 	start, end, err := parseStartEnd(r)
 	if err != nil {
@@ -70,7 +70,7 @@ func (h *Handler) handleLabels(w http.ResponseWriter, r *http.Request) {
 
 // buildLabelsSQL renders:
 //
-//	SELECT DISTINCT arrayJoin(mapKeys(`ResourceAttributes`)) AS k
+//	SELECT DISTINCT arrayJoin(`ResourceAttributes`.`keys`) AS k
 //	FROM `otel_logs`
 //	WHERE <matchers> AND `Timestamp` >= ? AND `Timestamp` <= ?
 //	ORDER BY k
@@ -93,16 +93,19 @@ func buildLabelsSQL(s schema.Logs, matchers []*labels.Matcher, start, end time.T
 
 // distinctMapKeysFrag emits
 //
-//	DISTINCT arrayJoin(mapKeys(`<col>`))
+//	DISTINCT arrayJoin(`<col>`.`keys`)
 //
 // — the CH idiom for flattening a Map column's key array into the row
-// stream and de-duping. Used by /labels (the per-row key set) and is the
-// shape Grafana's label autocomplete expects. The arrayJoin / mapKeys
-// function calls compose through the typed Call constructor wrapping
-// Builder.MapKeys for the inner mapKeys(col) call.
+// stream and de-duping, spelled against the column's virtual `.keys`
+// subcolumn rather than mapKeys(<col>) so the key-only decode is explicit
+// rather than depending on the server-side optimize_functions_to_subcolumns
+// rewrite (cerberus issue #2775). Used by /labels (the per-row key set)
+// and is the shape Grafana's label autocomplete expects. Safe
+// unconditionally, with no version gate: DISTINCT/arrayJoin key
+// enumeration never consults a skip index, so there is no index-matching
+// risk to weigh the way there is for a keyed-existence WHERE predicate.
 func distinctMapKeysFrag(col string) chsql.Frag {
-	mapKeys := func(b *chsql.Builder) { b.MapKeys(col) }
-	return chsql.Distinct(chsql.Call("arrayJoin", mapKeys))
+	return chsql.Distinct(chsql.Call("arrayJoin", chsql.Qual(col, "keys")))
 }
 
 // dedupeAndSort drops empty strings, removes duplicates, and sorts the

--- a/internal/api/loki/labels_test.go
+++ b/internal/api/loki/labels_test.go
@@ -49,10 +49,10 @@ func TestLabels_HappyPath(t *testing.T) {
 		}
 	}
 
-	// SQL sanity: arrayJoin(mapKeys(...)) must be present.
+	// SQL sanity: arrayJoin(<col>.keys) must be present (cerberus issue #2775).
 	lastSQL := q.LastSQL()
-	if !strings.Contains(lastSQL, "arrayJoin(mapKeys(`ResourceAttributes`))") {
-		t.Errorf("missing arrayJoin(mapKeys()) in SQL: %q", lastSQL)
+	if !strings.Contains(lastSQL, "arrayJoin(`ResourceAttributes`.`keys`)") {
+		t.Errorf("missing arrayJoin(<col>.keys) in SQL: %q", lastSQL)
 	}
 	if !strings.Contains(lastSQL, "toDateTime64(") {
 		t.Errorf("missing time bounds in SQL: %q", lastSQL)

--- a/internal/api/prom/metadata.go
+++ b/internal/api/prom/metadata.go
@@ -999,7 +999,7 @@ func (h *Handler) fetchLabelNamesMatched(
 	// collapses into ONE combined query (chunked under CH's max_query_size
 	// when broad). Each variant lowers to its inner matcher SELECT; the
 	// arms UNION-ALL into the FROM source of a single
-	// `SELECT DISTINCT arrayJoin(mapKeys(Attributes))` — N round-trips → 1
+	// `SELECT DISTINCT arrayJoin(Attributes.keys)` — N round-trips → 1
 	// (⌈N/K⌉ for a pathologically broad probe), same distinct key set the
 	// per-arm loop collected. start/end bound the closed metadata window
 	// each variant scans (zero = whole table).
@@ -1596,17 +1596,23 @@ func (h *Handler) resourceLabelValueArmActive(promLabel string) bool {
 // `arrayJoin(mapKeys(Attributes)) ... GROUP BY MetricName, Attributes HAVING
 // max(TimeUnix) >= start`, so the key fan-out routes onto the proj_series
 // aggregating projection (Attributes is a grouping key, the time bound an
-// aggregate predicate). A user-supplied finite window keeps the exact
-// WHERE-bounded scan.
+// aggregate predicate) — see arrayJoinMapKeysLegacyFrag's doc for why this
+// ONE shape keeps the mapKeys(...) spelling rather than the <col>.keys
+// subcolumn form arrayJoinMapKeysFrag uses everywhere else. A user-supplied
+// finite window keeps the exact WHERE-bounded scan.
 func (h *Handler) unionLabelNamesSQL(tables []string, start, end time.Time, nowAnchored bool) string {
 	attrsCol := h.Schema.AttributesColumn
 	metricCol := h.Schema.MetricNameColumn
 	tsCol := h.Schema.TimestampColumn
 	pred := h.metadataWindowPred(start, end)
+	nameFrag := arrayJoinMapKeysFrag(attrsCol)
+	if nowAnchored {
+		nameFrag = arrayJoinMapKeysLegacyFrag(attrsCol)
+	}
 	parts := make([]chsql.Frag, 0, len(tables))
 	for _, t := range tables {
 		arm := chsql.NewQuery().
-			Select(chsql.As(arrayJoinMapKeysFrag(attrsCol), "name")).
+			Select(chsql.As(nameFrag, "name")).
 			From(chsql.Col(t))
 		if nowAnchored {
 			arm = arm.GroupBy(chsql.Col(metricCol), chsql.Col(attrsCol))
@@ -1961,9 +1967,32 @@ func (h *Handler) existingTables(ctx context.Context, candidates []string) ([]st
 	return h.Client.QueryStrings(ctx, sql, args...)
 }
 
-// arrayJoinMapKeysFrag emits `arrayJoin(mapKeys(<col>))` — the CH idiom
-// for fanning out a Map column's key set as one row per key.
+// arrayJoinMapKeysFrag emits `arrayJoin(<col>.keys)` — the CH idiom for
+// fanning out a Map column's key set as one row per key, spelled against
+// the column's virtual `.keys` subcolumn rather than mapKeys(<col>) so the
+// key-only decode is explicit rather than depending on the server-side
+// optimize_functions_to_subcolumns rewrite (cerberus issue #2775). Safe
+// unconditionally, with no version gate, for a plain WHERE-bounded scan:
+// key enumeration never consults a skip index. NOT safe under a
+// `GROUP BY ..., <col>` SELECT list — use arrayJoinMapKeysLegacyFrag
+// there instead; see its doc for why.
 func arrayJoinMapKeysFrag(col string) chsql.Frag {
+	return chsql.Call("arrayJoin", chsql.Qual(col, "keys"))
+}
+
+// arrayJoinMapKeysLegacyFrag emits `arrayJoin(mapKeys(<col>))` — kept
+// verbatim (not arrayJoinMapKeysFrag's <col>.keys subcolumn spelling,
+// cerberus issue #2775) for the ONE shape that needs it: a SELECT list
+// under `GROUP BY ..., <col>`. ClickHouse's GROUP BY validity check
+// recognizes mapKeys(<col>) as a pure function of the grouped <col> (so a
+// non-aggregate SELECT expression is still legal), but does NOT extend
+// that recognition through the <col>.keys subcolumn spelling — confirmed
+// empirically (chDB 26.5.1.1): `SELECT arrayJoin(Attributes.keys) ...
+// GROUP BY MetricName, Attributes` throws NOT_AN_AGGREGATE ("Attributes.keys
+// is not under aggregate function and not in GROUP BY keys") on the exact
+// query the mapKeys(...) spelling accepts unchanged. unionLabelNamesSQL's
+// windowless (nowAnchored) arm is the only caller.
+func arrayJoinMapKeysLegacyFrag(col string) chsql.Frag {
 	return chsql.Call("arrayJoin", chsql.Call("mapKeys", chsql.Col(col)))
 }
 

--- a/internal/api/prom/metadata_test.go
+++ b/internal/api/prom/metadata_test.go
@@ -70,8 +70,14 @@ func TestLabels_Endpoint(t *testing.T) {
 		}
 	}
 
-	if !strings.Contains(q.lastSQL, "mapKeys") {
-		t.Errorf("expected SQL to use mapKeys; got %q", q.lastSQL)
+	// lastSQL is the LAST query fetchLabelNames issues — the
+	// ResourceAttributes union (fetchResourceLabelNames), which always
+	// uses the <col>.keys subcolumn form (cerberus issue #2775); the
+	// Attributes union that ran before it keeps the legacy mapKeys(...)
+	// spelling under its windowless GROUP BY (see
+	// arrayJoinMapKeysLegacyFrag's doc) and is not captured here.
+	if !strings.Contains(q.lastSQL, ".`keys`") {
+		t.Errorf("expected SQL to use the .keys subcolumn; got %q", q.lastSQL)
 	}
 }
 

--- a/internal/api/tempo/query_guard_test.go
+++ b/internal/api/tempo/query_guard_test.go
@@ -26,7 +26,7 @@ const unwindowedRecursiveSpansSQL = "WITH RECURSIVE c AS (" +
 
 // windowedSpansSQL is the negative control: a Timestamp range sitting directly
 // on the otel_traces scan prunes partitions, so the guard passes it through.
-const windowedSpansSQL = "SELECT DISTINCT arrayJoin(mapKeys(`SpanAttributes`)) AS `tag` " +
+const windowedSpansSQL = "SELECT DISTINCT arrayJoin(`SpanAttributes`.`keys`) AS `tag` " +
 	"FROM `otel_traces` " +
 	"WHERE `Timestamp` >= fromUnixTimestamp64Nano(1782571392000000000) AND `Timestamp` <= fromUnixTimestamp64Nano(1782573192000000000)"
 

--- a/internal/api/tempo/search_tag_values.go
+++ b/internal/api/tempo/search_tag_values.go
@@ -438,6 +438,20 @@ func mapContainsAnyFrag(attrCol, resCol, key string) chsql.Frag {
 // mapContainsFrag emits "mapContains(`<col>`, ?)" with key bound as a
 // positional argument. Composes through the typed Call constructor;
 // column / key operands flow through Col / Lit.
+//
+// Deliberately NOT spelled as the explicit has(<col>.keys, ?) subcolumn
+// form: cerberus issue #2775 verified (chDB 26.5.1.1, EXPLAIN QUERY TREE)
+// that ClickHouse's analyzer already rewrites mapContains(<col>, ?) into
+// exactly that has(<col>.keys, ?) shape internally, AND — unlike a
+// hand-written has(<col>.keys, ?) — the analyzer-rewritten form is the
+// ONLY one confirmed (via EXPLAIN indexes=1) to still match a
+// conventionally-declared `INDEX ... mapKeys(<col>) TYPE bloom_filter`
+// skip index; a directly-authored has(<col>.keys, ?) showed NO Skip
+// section at all against that same index. So mapContains(<col>, ?) is
+// strictly no worse (same key-only decode once the default-on
+// optimize_functions_to_subcolumns fires) and strictly safer
+// (index-compatible) than the subcolumn spelling the issue originally
+// proposed — see the issue for the full investigation.
 func mapContainsFrag(col, key string) chsql.Frag {
 	return chsql.Call("mapContains", chsql.Col(col), chsql.Lit(key))
 }

--- a/internal/api/tempo/search_tags.go
+++ b/internal/api/tempo/search_tags.go
@@ -134,7 +134,7 @@ const nestedAttributesSubfield = "Attributes"
 //
 // SQL shape — one query per scope bucket, e.g. for `span`:
 //
-//	SELECT DISTINCT arrayJoin(mapKeys(`SpanAttributes`))
+//	SELECT DISTINCT arrayJoin(`SpanAttributes`.`keys`)
 //	FROM `otel_traces`
 //	WHERE `Timestamp` >= ? AND `Timestamp` <= ?
 //
@@ -382,19 +382,18 @@ func buildSearchTagsSQL(s schema.Traces, keys, filter chsql.Frag, start, end tim
 	return sb.Build()
 }
 
-// distinctMapKeysFrag emits "DISTINCT arrayJoin(mapKeys(`<col>`))" — the
-// CH idiom for "every distinct attribute key seen". DISTINCT is part of
-// the SELECT list (CH's flavour), not a separate keyword, so it folds
-// into the Frag for the QueryBuilder slot. `arrayJoin` + `mapKeys` are
-// CH functions composed through the typed Call constructor; the column
-// operand flows through chsql.Col.
+// distinctMapKeysFrag emits "DISTINCT arrayJoin(`<col>`.`keys`)" — the CH
+// idiom for "every distinct attribute key seen", spelled against the
+// column's virtual `.keys` subcolumn rather than mapKeys(<col>) so the
+// key-only decode is explicit rather than depending on the server-side
+// optimize_functions_to_subcolumns rewrite (cerberus issue #2775). DISTINCT
+// is part of the SELECT list (CH's flavour), not a separate keyword, so it
+// folds into the Frag for the QueryBuilder slot. `arrayJoin` composes
+// through the typed Call constructor; the `.keys` subcolumn operand flows
+// through chsql.Qual. Safe unconditionally, with no version gate: key
+// enumeration never consults a skip index.
 func distinctMapKeysFrag(col string) chsql.Frag {
-	return chsql.Distinct(
-		chsql.Call(
-			"arrayJoin",
-			chsql.Call("mapKeys", chsql.Col(col)),
-		),
-	)
+	return chsql.Distinct(chsql.Call("arrayJoin", chsql.Qual(col, "keys")))
 }
 
 // distinctNestedMapKeysFrag is the same idea one nesting level up:

--- a/internal/api/tempo/search_tags_test.go
+++ b/internal/api/tempo/search_tags_test.go
@@ -72,8 +72,9 @@ func TestSearchTags_UnionsDynamicAttributes(t *testing.T) {
 
 // TestSearchTags_SQLShape — pins the SQL the handler emits so the
 // no-fmt-Sprintf-on-SQL rule (CLAUDE.md) doesn't quietly regress.
-// Builder must emit a parameterised `arrayJoin(mapKeys(<col>))`
-// SELECT — never a raw concatenated table name or column literal.
+// Builder must emit a parameterised `arrayJoin(<col>.keys)` SELECT
+// (cerberus issue #2775) — never a raw concatenated table name or
+// column literal.
 func TestSearchTags_SQLShape(t *testing.T) {
 	t.Parallel()
 	q := &stubQuerier{strings: []string{"a"}}
@@ -88,7 +89,7 @@ func TestSearchTags_SQLShape(t *testing.T) {
 	for _, want := range []string{
 		"SELECT DISTINCT",
 		"arrayJoin(",
-		"mapKeys(`SpanAttributes`)",
+		"`SpanAttributes`.`keys`",
 		"FROM `otel_traces`",
 	} {
 		if !strings.Contains(q.lastSQL, want) {
@@ -159,9 +160,10 @@ func TestSearchTags_TimeBounds(t *testing.T) {
 
 // TestSearchTags_WindowlessDefaultsToRecentBound — a request with no
 // `start`/`end` must NOT emit a windowless `SELECT DISTINCT
-// arrayJoin(mapKeys(...)) FROM otel_traces`: that full-scans the fact
-// table and explodes the attribute Map, the multi-minute / timeout
-// failure observed in prod. The handler defaults to the recent
+// arrayJoin(<col>.keys) FROM otel_traces`: that full-scans the fact
+// table and decodes the attribute Map's key stream over every row, the
+// multi-minute / timeout failure observed in prod. The handler defaults
+// to the recent
 // DefaultSearchLookback window so the scan part-prunes by partition,
 // which shows up as a `Timestamp` WHERE bound in the emitted SQL.
 func TestSearchTags_WindowlessDefaultsToRecentBound(t *testing.T) {

--- a/internal/api/tempo/time.go
+++ b/internal/api/tempo/time.go
@@ -35,7 +35,7 @@ func parseTempoStartEnd(r *http.Request) (time.Time, time.Time, error) {
 
 // boundDiscoveryWindow defaults a windowless tag / tag-value discovery
 // request to the most recent DefaultSearchLookback. The discovery SQL
-// (`SELECT DISTINCT arrayJoin(mapKeys(ResourceAttributes))` and the
+// (`SELECT DISTINCT arrayJoin(ResourceAttributes.keys)` and the
 // tag-value `mapContains` lookups) only emits a `Timestamp` predicate
 // when start/end are non-zero; with no predicate the scan reads every
 // row of otel_traces and explodes the Map column, running for minutes

--- a/internal/chsql/map_keys_subcolumn_chdb_test.go
+++ b/internal/chsql/map_keys_subcolumn_chdb_test.go
@@ -1,0 +1,181 @@
+//go:build chdb
+
+// chDB-backed proof for the key-enumeration half of cerberus issue #2775:
+// the three label-name / tag-name discovery endpoints (Loki
+// internal/api/loki/labels.go, Prom internal/api/prom/metadata.go, Tempo
+// internal/api/tempo/search_tags.go) now emit `arrayJoin(<col>.keys)`
+// instead of `arrayJoin(mapKeys(<col>))`. All three funnel through the
+// SAME chsql.Qual(col, "keys") construction this file exercises directly,
+// so one test covers the shared mechanism rather than three near-identical
+// per-package copies.
+//
+// The existence-pre-filter half of #2775 (mapContains(<col>, ?) ->
+// has(<col>.keys, ?)) is DELIBERATELY NOT implemented — see
+// search_tag_values.go's mapContainsFrag doc comment for the chDB
+// investigation (EXPLAIN QUERY TREE + EXPLAIN indexes=1 on a real
+// ClickHouse 26.5.1.1) that found the subcolumn spelling loses
+// skip-index-match compatibility with a conventionally-declared
+// `INDEX ... mapKeys(<col>) TYPE bloom_filter` index, with no
+// confirmed read-cost win to offset that regression.
+package chsql_test
+
+import (
+	"database/sql"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/tsouza/cerberus/internal/chsql"
+	"github.com/tsouza/cerberus/internal/chsqltest"
+)
+
+// TestMapKeysSubcolumn_MatchesMapKeys_ChDB seeds a Map column with several
+// distinct keys and asserts arrayJoin(<col>.keys) returns the EXACT same
+// distinct key set as the arrayJoin(mapKeys(<col>)) idiom it replaces —
+// the semantics-preservation half of #2775's "definitionally identical"
+// claim, proven against a real ClickHouse engine rather than asserted.
+func TestMapKeysSubcolumn_MatchesMapKeys_ChDB(t *testing.T) {
+	db := chsqltest.OpenIsolatedChDB(t)
+	if _, err := db.Exec(`CREATE TABLE t (
+		Key        String,
+		Attributes Map(String, String)
+	) ENGINE = MergeTree ORDER BY Key`); err != nil {
+		t.Fatalf("create table: %v", err)
+	}
+	if _, err := db.Exec(`INSERT INTO t VALUES
+		('r1', map('service.name', 'api', 'env', 'prod')),
+		('r2', map('service.name', 'api', 'region', 'us')),
+		('r3', map())`); err != nil {
+		t.Fatalf("seed rows: %v", err)
+	}
+
+	oldForm := mustDistinctKeys(t, db, "arrayJoin(mapKeys(Attributes))")
+	newForm := mustDistinctKeys(t, db, "arrayJoin(Attributes.keys)")
+
+	if len(oldForm) == 0 {
+		t.Fatal("sanity: expected at least one key from the seeded rows")
+	}
+	if !equalStrings(oldForm, newForm) {
+		t.Fatalf("arrayJoin(Attributes.keys) = %v; want the same set as arrayJoin(mapKeys(Attributes)) = %v", newForm, oldForm)
+	}
+}
+
+// TestMapKeysSubcolumn_ReadsOnlyKeysStream_ChDB proves the read-cost claim
+// (cerberus issue #2775's motivating win): on a default-configured server
+// (optimize_functions_to_subcolumns and the analyzer both default-on),
+// ClickHouse's ReadFromMergeTree step for arrayJoin(mapKeys(<col>)) ALREADY
+// projects down to the same `<col>.keys Array(String)` physical subcolumn
+// arrayJoin(<col>.keys) requests directly — so the explicit spelling is
+// execution-cost-neutral on a healthy default deployment, and its value is
+// exactly the issue's own framing: the win becomes UNCONDITIONAL (no longer
+// contingent on that setting) rather than a new win on top of it. Unlike
+// the query-tree rewrite mapContains(<col>, ?) receives (which this file's
+// package doc explains does NOT carry through to a matching ReadFromMergeTree
+// projection — see search_tag_values.go), the mapKeys(<col>) form's
+// subcolumn projection is confirmed end-to-end here.
+func TestMapKeysSubcolumn_ReadsOnlyKeysStream_ChDB(t *testing.T) {
+	db := chsqltest.OpenIsolatedChDB(t)
+	if _, err := db.Exec(`CREATE TABLE t (
+		Key        String,
+		Attributes Map(String, String)
+	) ENGINE = MergeTree ORDER BY Key`); err != nil {
+		t.Fatalf("create table: %v", err)
+	}
+	if _, err := db.Exec(`INSERT INTO t VALUES ('r1', map('alpha', 'v'))`); err != nil {
+		t.Fatalf("seed rows: %v", err)
+	}
+
+	oldHeader := mustReadHeader(t, db, "arrayJoin(mapKeys(Attributes))")
+	newHeader := mustReadHeader(t, db, "arrayJoin(Attributes.keys)")
+
+	const wantSubstring = "Attributes.keys Array(String)"
+	if !strings.Contains(oldHeader, wantSubstring) {
+		t.Errorf("arrayJoin(mapKeys(Attributes)) ReadFromMergeTree header = %q; want it to contain %q (the analyzer's own subcolumn projection)", oldHeader, wantSubstring)
+	}
+	if !strings.Contains(newHeader, wantSubstring) {
+		t.Errorf("arrayJoin(Attributes.keys) ReadFromMergeTree header = %q; want it to contain %q", newHeader, wantSubstring)
+	}
+}
+
+// mustDistinctKeys runs `SELECT DISTINCT <keysExpr> AS k FROM t ORDER BY k`
+// and returns the sorted key list.
+func mustDistinctKeys(t *testing.T, db *sql.DB, keysExpr string) []string {
+	t.Helper()
+	rows, err := db.Query("SELECT DISTINCT " + keysExpr + " AS k FROM t ORDER BY k")
+	if err != nil {
+		t.Fatalf("query %s: %v", keysExpr, err)
+	}
+	defer func() { _ = rows.Close() }()
+	var out []string
+	for rows.Next() {
+		var k string
+		if err := rows.Scan(&k); err != nil {
+			t.Fatalf("scan: %v", err)
+		}
+		out = append(out, k)
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatalf("rows: %v", err)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// mustReadHeader runs `EXPLAIN PLAN header = 1 SELECT DISTINCT <keysExpr>
+// FROM t` and returns the ReadFromMergeTree step's declared Header line —
+// the physical column projection ClickHouse's storage layer pulls off
+// disk, which chsql.Qual(col, "keys")'s doc comment cites as the direct
+// (non-optimizer-dependent) proof of the keys-only decode.
+func mustReadHeader(t *testing.T, db *sql.DB, keysExpr string) string {
+	t.Helper()
+	rows, err := db.Query("EXPLAIN PLAN header = 1 SELECT DISTINCT " + keysExpr + " FROM t")
+	if err != nil {
+		t.Fatalf("explain %s: %v", keysExpr, err)
+	}
+	defer func() { _ = rows.Close() }()
+	var plan strings.Builder
+	for rows.Next() {
+		var line string
+		if err := rows.Scan(&line); err != nil {
+			t.Fatalf("scan: %v", err)
+		}
+		plan.WriteString(line)
+		plan.WriteByte('\n')
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatalf("rows: %v", err)
+	}
+	return plan.String()
+}
+
+// equalStrings reports whether a and b hold the same elements in the same
+// order (both inputs are pre-sorted by the caller).
+func equalStrings(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+// TestMapKeysSubcolumnQual_RendersDottedIdentifier pins the exact SQL
+// chsql.Qual(col, "keys") produces — a backtick-quoted qualifier.name pair
+// — without a live database, guarding the emitter shape the two chDB tests
+// above exercise end-to-end.
+func TestMapKeysSubcolumnQual_RendersDottedIdentifier(t *testing.T) {
+	frag := chsql.Call("arrayJoin", chsql.Qual("ResourceAttributes", "keys"))
+	b := chsql.NewBuilder()
+	frag(b)
+	got, _, err := b.Build()
+	if err != nil {
+		t.Fatalf("build: %v", err)
+	}
+	want := "arrayJoin(`ResourceAttributes`.`keys`)"
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}


### PR DESCRIPTION
## Summary

- Closes the key-enumeration half of #2775: Loki `/labels`, Prom label-name discovery, and Tempo `/search/tags` now emit `arrayJoin(<col>.keys)` instead of `arrayJoin(mapKeys(<col>))`, so the key-only decode no longer depends on the server having `optimize_functions_to_subcolumns` enabled (default-on since 24.8, but never asserted).
- The windowed metric-label enumeration path (`unionLabelNamesSQL`'s `GROUP BY MetricName, Attributes` shape) keeps the `mapKeys(...)` spelling — a real ClickHouse limitation the chDB suite caught before merge (see below).
- The keyed-existence half of #2775 (`mapContains(<col>, ?)` → `has(<col>.keys, ?)`) is **deliberately not implemented** — the empirical investigation found it would be a regression, not a robustness improvement. Details below.

## Investigation and scope decision (please read before reviewing)

The issue proposed two rewrites, split by risk: an unconditional key-enumeration rewrite, and a version-gated (`chopt`, floor 25.2, tied to ClickHouse/ClickHouse#75081) keyed-existence rewrite. I implemented the first and verified the second doesn't hold up:

- **Key enumeration — implemented, verified safe and beneficial.** chDB 26.5.1.1: `arrayJoin(mapKeys(Attributes))` and `arrayJoin(Attributes.keys)` return identical result sets, and `EXPLAIN PLAN header=1` shows the `ReadFromMergeTree` step already projects to `Attributes.keys Array(String)` for *both* spellings on a default-configured server. So the rewrite is execution-cost-neutral where the setting is already on, and becomes the sole source of the win (no full-map decode) on a hardened profile that disabled it — exactly the issue's own "robustness/insurance" framing, now unconditionally true rather than contingent.
- **Keyed existence — investigated, not implemented.** `EXPLAIN QUERY TREE run_passes=1` on chDB 26.5.1.1 shows ClickHouse's analyzer *already* rewrites `mapContains(Attributes, 'x')` into `has(Attributes.keys, 'x')` internally (default settings, no gate needed). Crucially, `EXPLAIN indexes=1` against a table carrying `INDEX idx mapKeys(Attributes) TYPE bloom_filter` shows:
  - `mapContains(Attributes, ?)` → the analyzer-rewritten form → **skip index matched, correctly prunes granules**.
  - A hand-written `has(Attributes.keys, ?)` (what cerberus would emit under the issue's proposal) → **no Skip section in the plan at all** — the index is never even consulted.

  This holds on chDB 26.5.1.1, well past the `#75081` floor the issue's `chopt` gate would have used — so the version floor doesn't fix it; the analyzer-produced `has()` and a hand-authored `has()` are treated differently by ClickHouse's index-matching regardless of version. Emitting `has(<col>.keys, ?)` directly would therefore be a **strict regression** against any conventionally-declared `mapKeys(<col>)` bloom filter index, for **no confirmed benefit** (the analyzer already does the equivalent rewrite for `mapContains` on any qualifying server). `mapContains(<col>, ?)` stays as-is; `search_tag_values.go`'s `mapContainsFrag` doc comment records the investigation.
- The issue's optional "warn when `optimize_functions_to_subcolumns=0`" `chaudit` addition is also skipped: with the keyed-existence rewrite off the table, the only remaining beneficiary would be the key-enumeration paths, and I couldn't get a clean signal that the read-cost claim generalizes cleanly enough (via chDB, which has no `system.query_log`) to justify a new boot-audit surface for a genuinely optional, low-severity concern.

## Bug found and fixed along the way

The windowless `/api/v1/labels` path (`unionLabelNamesSQL`'s now-anchored arm) groups by `MetricName, Attributes` with `arrayJoin(mapKeys(Attributes))` in the SELECT list — legal because ClickHouse's GROUP BY validity check recognizes `mapKeys(<col>)` as a pure function of the grouped `<col>`. Swapping in `Attributes.keys` broke this: `NOT_AN_AGGREGATE ("Attributes.keys is not under aggregate function and not in GROUP BY keys")`. The chDB test suite (`just test-chdb`) caught this before it could reach `main`. Fixed by keeping the `mapKeys(...)` spelling for that one GROUP BY shape (`arrayJoinMapKeysLegacyFrag`, `internal/api/prom/metadata.go`) while the rest of the endpoint keeps the subcolumn form.

## Test plan

- [x] `just lint` clean (`golangci-lint run ./...` + `--build-tags cerberus_untagged_build` + `--build-tags chdb`, all `0 issues`)
- [x] `just test` (`test-unit` + `vet-tagged`) passes
- [x] `just test-chdb` passes — includes a new chDB suite (`internal/chsql/map_keys_subcolumn_chdb_test.go`) proving: (1) `arrayJoin(mapKeys(<col>))` and `arrayJoin(<col>.keys)` return identical result sets, (2) both read only the `<col>.keys` physical subcolumn per `EXPLAIN PLAN header=1`, (3) `chsql.Qual(col, "keys")` renders the exact expected SQL
- [x] No TXTAR fixtures touched (these 3 endpoints build SQL directly via `chsql.Builder`, not through the `chplan` lowering pipeline `just update-golden` covers)
- [x] CI green (will confirm after push)

## Notes for reviewers

- No new `chopt` feature, no `internal/chplan` changes — the shipped rewrite is a pure `chsql.Builder`-level SQL-shape substitution (`chsql.Qual(col, "keys")`), same risk class as any other emitter-level fix.
- Left `distinctNestedMapKeysFrag` (Tempo's Events/Links nested-Attributes key scan) untouched, as the issue specified: its lambda parameter is a map *value*, not a column, so `.keys` subcolumn syntax doesn't apply.
