### PR TITLE
feat(promql,chsql): merge multiple buckets in the downsample tier (#2857)

### DIFF
--- a/docs/operations.md
+++ b/docs/operations.md
@@ -2316,14 +2316,16 @@ high-cardinality DELTA metric — not `date-range × 1` — and belongs in
 capacity planning for any deployment enabling
 `CERBERUS_DELTA_PREFIX_READ_ENABLED` against such a metric.
 
-### Downsampled long-range tier (cerberus issue #2751)
+### Downsampled long-range tier (cerberus issue #2751, #2857)
 
 Auto-create can also provision an **opt-in, cerberus-owned** table + materialized
 view folding raw Sum-table samples into a persisted `timeSeriesLastTwoSamples`
 aggregate state per 5-minute bucket (`internal/schema/ddl`, table
 `otel_metrics_sum_downsample_tier`), read back by `irate()` / `idelta()` /
-`last_over_time()` `query_range` shapes whose window matches the bucket
-exactly. Unlike the DELTA-prefix table above, provisioning and query routing
+`last_over_time()` `query_range` shapes whose window is a positive integer
+multiple of the bucket (one bucket exactly, or several merged via
+`timeSeriesLastTwoSamplesMerge` and re-filtered to the exact window, per
+issue #2857). Unlike the DELTA-prefix table above, provisioning and query routing
 share a **single** flag: `CERBERUS_CH_OPTIMIZATIONS=downsample_tier` (a chopt
 feature, floor ClickHouse >= 25.9, `AutoSelect=false` — never picked by
 `auto`). A not-yet-backfilled or missing bucket degrades to an ABSENT series

--- a/internal/chopt/registry.go
+++ b/internal/chopt/registry.go
@@ -821,14 +821,16 @@ const (
 
 	// FeatureDownsampleTier opts eligible LONG-RANGE / low-resolution
 	// irate() / idelta() / last_over_time() query_range shapes (step >= the
-	// tier's fixed 5-minute bucket, range == bucket, grid aligned to the
-	// bucket boundary — see internal/promql/lower_strategy.go's eligibility
-	// check) onto the operator-provisioned downsampled long-range tier
+	// tier's fixed 5-minute bucket, range a positive integer multiple of the
+	// bucket, grid aligned to the bucket boundary — see
+	// internal/promql/lower_strategy.go's eligibility check) onto the
+	// operator-provisioned downsampled long-range tier
 	// (schema.DownsampleTierTable): a materialized view folding raw Sum-
 	// table samples into a persisted timeSeriesLastTwoSamples aggregate
 	// state per bucket, read back via timeSeriesLastTwoSamplesMerge +
 	// finalizeAggregation instead of scanning full-resolution raw rows
-	// (cerberus issue #2751).
+	// (cerberus issue #2751; a range spanning several buckets merges them
+	// and re-filters to the exact window — issue #2857).
 	//
 	// THIS IS A FUNDAMENTALLY DIFFERENT MECHANISM from the rest of the
 	// timeSeries*ToGrid family above: those are stateless read-time

--- a/internal/chsql/range_window_downsample_tier.go
+++ b/internal/chsql/range_window_downsample_tier.go
@@ -104,31 +104,47 @@ func downsampleTierValueExprFrag(fn string) Frag {
 }
 
 // emitRangeWindowDownsampleTier renders SQL for an r with DownsampleTier set
-// (cerberus issue #2751): reads r.DownsampleTierInput's bucketed
-// timeSeriesLastTwoSamples state instead of windowing r.Input's raw rows.
-// r.Input is UNUSED here — the boot-wired DownsampleTier*Lowerer
-// (internal/promql/lower_strategy.go) only sets DownsampleTier when
-// r.DownsampleTierInput answers the query completely on its own.
+// (cerberus issue #2751, extended to cover N>1 covering buckets by issue
+// #2857): reads r.DownsampleTierInput's bucketed timeSeriesLastTwoSamples
+// state instead of windowing r.Input's raw rows. r.Input is UNUSED here —
+// the boot-wired DownsampleTier*Lowerer (internal/promql/lower_strategy.go)
+// only sets DownsampleTier when r.DownsampleTierInput answers the query
+// completely on its own.
 //
-// Because that Lowerer's eligibility check (downsampleTierEligible) only
-// ever fires when the query_range grid's own anchors are EXACTLY the tier's
-// bucket boundaries (r.Range equals the tier's fixed bucket, r.Step a
-// positive multiple of it, r.Start bucket-aligned), each grid anchor maps
-// to EXACTLY ONE tier row — this reads the tier table directly, bounded to
-// [r.Start, r.End] on its own bucket column, with no multi-bucket merge or
-// grid materialisation (unlike the native timeSeries*ToGrid family's own
-// timeSeriesRange grid axis in range_window_grid_native.go, which this
-// deliberately does not need — see the v1 scope note on
-// downsampleTierEligible).
+// downsampleTierEligible guarantees r.Range is a positive integer multiple
+// of schema.DownsampleTierBucket and every grid anchor (r.Start + k*r.Step)
+// is bucket-aligned, so each anchor's `(anchor-range, anchor]` window is
+// covered by an EXACT, non-overlapping, gap-free run of N =
+// r.Range/schema.DownsampleTierBucket whole tier buckets — the single-bucket
+// N==1 case #2751 shipped is this shape's degenerate case, not a special
+// one. This function answers the general N case directly (no separate N==1
+// fast path), so the two stay byte-identical on the exact-bucket shape by
+// construction rather than by parallel maintenance.
 //
-// SQL shape (three levels, mirroring RangeWindowGridNative's own
-// inner/outer split):
+// SQL shape (four levels):
 //
-//	merged: SELECT <group...>, BucketEnd,
-//	               timeSeriesLastTwoSamplesMerge(LastTwoSamples) AS merged
-//	        FROM (<r.DownsampleTierInput>)
-//	        WHERE BucketEnd >= r.Start AND BucketEnd <= r.End
-//	        GROUP BY <group...>, BucketEnd
+//	fan: SELECT <group...>, LastTwoSamples, Temporality,
+//	            arrayJoin(<covering anchors for this row's BucketEnd>) AS anchor_ts
+//	     FROM (<r.DownsampleTierInput>)
+//	     WHERE BucketEnd > r.Start - r.Range AND BucketEnd <= r.End
+//
+// The per-row covering-anchor set reuses sampleAnchorFanoutFrag — the SAME
+// bounded sample-side anchor fan-out every other matrix-shape RangeWindow
+// emitter fans raw sample timestamps through — treating each row's BucketEnd
+// as the "sample timestamp". That is sound because every raw sample the
+// write side ever folds into a bucket lands inside that bucket's OWN
+// `(BucketStart, BucketEnd]` half-open interval (downsampleTierBucketEndExpr
+// — internal/schema/ddl), so a bucket whose BucketEnd satisfies an anchor's
+// window test is, by construction, entirely covered by that anchor's
+// window: no bucket ever straddles an anchor boundary. At most
+// r.Range/r.Step + 1 anchors per bucket row, never the full [Start, End]
+// grid, mirroring sampleAnchorFanoutFrag's own doc.
+//
+//	merged: SELECT <group...>, anchor_ts,
+//	               timeSeriesLastTwoSamplesMerge(LastTwoSamples) AS merged,
+//	               any(Temporality) AS temporality
+//	        FROM fan
+//	        GROUP BY <group...>, anchor_ts
 //
 // GROUP BY + the -Merge combinator (never a bare per-row
 // finalizeAggregation) is load-bearing, not a style choice:
@@ -140,12 +156,22 @@ func downsampleTierValueExprFrag(fn string) Frag {
 // whichever part it happened to see FIRST, missing samples a DIFFERENT
 // part holds — verified empirically to diverge from the correct
 // GROUP BY + xMerge answer against a real ClickHouse instance (see this
-// package's downsample-tier chDB test).
+// package's downsample-tier chDB test). Grouping directly by anchor_ts
+// (rather than a separate per-bucket merge level feeding a second
+// per-anchor merge) folds that multi-part hazard and the cross-bucket
+// merge #2857 adds into ONE GROUP BY: -Merge is associative over however
+// many states — same bucket, different parts, or different buckets
+// entirely — a group holds.
 //
-//	sorted: SELECT <group...>, BucketEnd,
-//	               arraySort(x -> x.1, arrayZip(merged.1, merged.2)) AS sorted
+//	sorted: SELECT <group...>, anchor_ts, temporality,
+//	               arraySort(x -> x.1,
+//	                 arrayFilter(p -> p.1 > anchor_ts - range AND p.1 <= anchor_ts,
+//	                   arrayZip(merged.1, merged.2))) AS sorted
 //	        FROM merged
 //
+// The arrayFilter is downsampleTierExactWindowFilterFrag — see its own doc
+// for why a post-merge per-SAMPLE re-check is still required even though
+// the fan-out above is exact by construction over well-formed data.
 // finalizeAggregation / the -Merge combinator's own element order is NOT
 // documented as sorted — verified empirically to come back DESCENDING
 // (newest first) — so this explicitly re-sorts ASCENDING by timestamp
@@ -153,7 +179,7 @@ func downsampleTierValueExprFrag(fn string) Frag {
 // sorted[-2] always "second most recent" regardless of the engine's
 // internal representation.
 //
-//	outer: SELECT <group...>, BucketEnd AS anchor_ts[, r.TimestampColumn],
+//	outer: SELECT <group...>, anchor_ts[, r.TimestampColumn],
 //	              <downsampleTierValueExprFrag> AS r.ValueColumn
 //	       FROM sorted
 //	       WHERE length(sorted) >= downsampleTierMinSamples(r.Func)
@@ -189,45 +215,108 @@ func (e *emitter) emitRangeWindowDownsampleTier(r *chplan.RangeWindow) error {
 	}
 
 	bucketCol := Col(schema.DownsampleTierBucketColumn)
-	merged := NewQuery().From(tierSub)
+	rangeNS := r.Range.Nanoseconds()
+	stepNS := r.Step.Nanoseconds()
+	end := endExprFrag(r)
+	// End-inclusive anchor count over [r.Start, r.End] spaced by r.Step —
+	// r.Offset is always zero here (downsampleTierEligible), so this is the
+	// plain request grid, computed from Start/End directly rather than
+	// trusted from r.OuterRange (which downsampleTierEligible deliberately
+	// leaves unchecked — see that function's own doc).
+	numAnchors := r.End.Sub(r.Start).Nanoseconds()/stepNS + 1
+
+	// fan — one row per (tier row, covering grid anchor).
+	fan := NewQuery().From(tierSub)
+	fan.Select(groupFrags...)
+	fan.Select(Col(schema.DownsampleTierSamplesColumn))
+	fan.Select(Col(schema.DownsampleTierTemporalityColumn))
+	fan.Select(RawAs(sampleAnchorFanoutFrag(end, bucketCol, stepNS, rangeNS, numAnchors), RangeWindowAnchorAlias))
+	// Prune the scan to buckets that could feed ANY anchor in [r.Start,
+	// r.End]: the earliest anchor's own window reaches back to
+	// r.Start - r.Range. Shared with every other matrix-shape emitter's
+	// identical (Start - range, End] scan-prune bound.
+	maybePushInnerScanTimeBounds(fan, r, schema.DownsampleTierBucketColumn, rangeNS)
+
+	// merged — GROUP BY (series, anchor), -Merge across every covering
+	// bucket's state (and every unmerged part of each).
+	merged := NewQuery().From(fan.Frag())
 	merged.Select(groupFrags...)
-	merged.Select(bucketCol)
+	merged.Select(Col(RangeWindowAnchorAlias))
 	merged.Select(As(Call("timeSeriesLastTwoSamplesMerge", Col(schema.DownsampleTierSamplesColumn)), downsampleTierMergedAlias))
 	// any(Temporality) merges the SimpleAggregateFunction(any, Int32) column
-	// across however many unmerged parts the (series, bucket) key currently
-	// has — the SAME multi-part hazard timeSeriesLastTwoSamplesMerge guards
-	// against immediately above, see emitRangeWindowDownsampleTier's own
-	// doc. Selected unconditionally (idelta / last_over_time never read it
-	// — see downsampleTierValueExprFrag) rather than branching the query
-	// shape on r.Func, keeping this function's three-level skeleton
-	// identical for every eligible Func.
+	// across however many unmerged parts / covering buckets the (series,
+	// anchor) key currently has — the SAME multi-part hazard
+	// timeSeriesLastTwoSamplesMerge guards against immediately above, see
+	// emitRangeWindowDownsampleTier's own doc. Selected unconditionally
+	// (idelta / last_over_time never read it — see
+	// downsampleTierValueExprFrag) rather than branching the query shape on
+	// r.Func, keeping this function's skeleton identical for every eligible
+	// Func.
 	merged.Select(As(Call("any", Col(schema.DownsampleTierTemporalityColumn)), downsampleTierTemporalityAlias))
-	merged.Where(
-		Gte(bucketCol, Lit(r.Start)),
-		Lte(bucketCol, Lit(r.End)),
-	)
-	mergedGroupBy := append(append([]Frag{}, groupFrags...), bucketCol)
+	mergedGroupBy := append(append([]Frag{}, groupFrags...), Col(RangeWindowAnchorAlias))
 	merged.GroupBy(mergedGroupBy...)
 
 	sorted := NewQuery().From(merged.Frag())
 	sorted.Select(groupFrags...)
-	sorted.Select(bucketCol)
+	sorted.Select(Col(RangeWindowAnchorAlias))
 	sorted.Select(Col(downsampleTierTemporalityAlias))
 	sortedPairs := Call(
 		"arrayZip",
 		TupleIndex(Col(downsampleTierMergedAlias), 1),
 		TupleIndex(Col(downsampleTierMergedAlias), 2),
 	)
-	sorted.Select(As(Call("arraySort", Lambda1("x", TupleIndex(BareIdent("x"), 1)), sortedPairs), downsampleTierSortedAlias))
+	filteredPairs := downsampleTierExactWindowFilterFrag(sortedPairs, rangeNS)
+	sorted.Select(As(Call("arraySort", Lambda1("x", TupleIndex(BareIdent("x"), 1)), filteredPairs), downsampleTierSortedAlias))
 
 	outer := NewQuery().From(sorted.Frag())
 	outer.Select(groupFrags...)
-	outer.Select(As(bucketCol, RangeWindowAnchorAlias))
+	outer.Select(Col(RangeWindowAnchorAlias))
 	if r.TimestampColumn != RangeWindowAnchorAlias {
-		outer.Select(As(bucketCol, r.TimestampColumn))
+		outer.Select(As(Col(RangeWindowAnchorAlias), r.TimestampColumn))
 	}
 	outer.Select(As(downsampleTierValueExprFrag(r.Func), r.ValueColumn))
 	outer.Where(Gte(Call("length", Col(downsampleTierSortedAlias)), InlineLit(minSamples)))
 
 	return e.emitSelect(outer)
+}
+
+// downsampleTierExactWindowFilterFrag renders
+// `arrayFilter(p -> p.1 > anchor_ts - range AND p.1 <= anchor_ts, pairs)` —
+// the post-merge re-filter cerberus issue #2857 requires: every (timestamp,
+// value) pair the cross-bucket merge produced, re-checked against the
+// anchor's own exact `(anchor-range, anchor]` window before arraySort /
+// arraySlice pick the trailing pair.
+//
+// The upstream fan-out (sampleAnchorFanoutFrag over BucketEnd,
+// emitRangeWindowDownsampleTier's own doc) is exact BY CONSTRUCTION
+// whenever every retained sample's own timestamp genuinely falls inside its
+// OWN row's `(BucketStart, BucketEnd]` interval — which is what the write
+// side (renderDownsampleTierView's downsampleTierBucketEndExpr, and
+// internal/downsampletier's backfillBucketEndExpr, which MUST render the
+// identical expression) guarantees for every row either of them writes.
+// This filter is the READ side's own defense against that guarantee being
+// violated by data the read path did not itself write — a backfill bug, a
+// manual data correction, a replayed/mismatched insert — landing a state
+// whose retained sample timestamp sits outside its own row's canonical
+// bucket interval. Without this filter such a row would still be correctly
+// assigned to its covering anchors by BucketEnd, but could silently leak a
+// stale (or premature) sample into the merged trailing pair; with it, an
+// individual retained sample outside the anchor's own window is dropped
+// before the top-2 read regardless of why it ended up there. Verified
+// against exactly this scenario — a state manually written with a retained
+// sample timestamp outside its BucketEnd's canonical interval — by this
+// package's downsample-tier chDB test.
+//
+// Provably a no-op over every row either write path actually produces
+// (BucketEnd-exactness + bucket alignment together leave no room for a
+// bucket to partially overlap an anchor's window), so it costs nothing
+// correctness-relevant on the happy path — it is pure insurance against the
+// one input this function's OWN reasoning cannot verify: the data.
+func downsampleTierExactWindowFilterFrag(pairs Frag, rangeNS int64) Frag {
+	ts := func() Frag { return TupleIndex(BareIdent("p"), 1) }
+	inWindow := And(
+		Gt(ts(), rangeStartFrag(Col(RangeWindowAnchorAlias), rangeNS)),
+		Lte(ts(), Col(RangeWindowAnchorAlias)),
+	)
+	return Call("arrayFilter", Lambda1("p", inWindow), pairs)
 }

--- a/internal/chsql/range_window_downsample_tier_multibucket_chdb_test.go
+++ b/internal/chsql/range_window_downsample_tier_multibucket_chdb_test.go
@@ -1,0 +1,371 @@
+//go:build chdb
+
+// chDB-backed correctness proof for the multi-bucket extension to the
+// downsampled long-range tier (cerberus issue #2857): a range spanning
+// several tier buckets now routes to the tier, merging every covering
+// bucket's state via timeSeriesLastTwoSamplesMerge and re-filtering the
+// merged trailing pair to the exact `(anchor-range, anchor]` window before
+// computing the per-Func value (emitRangeWindowDownsampleTier /
+// downsampleTierExactWindowFilterFrag, internal/chsql).
+//
+// Three properties this file proves empirically, each the risky edge case
+// #2857's own issue body calls out:
+//
+//  1. Cross-bucket merge correctness: the trailing pair a query actually
+//     needs can span TWO DIFFERENT tier buckets (not just live inside the
+//     newest one), and a bucket with no relevant samples correctly
+//     contributes nothing — see TestDownsampleTier_ChdbCrossBucketMerge.
+//  2. A single tier bucket correctly feeds MULTIPLE overlapping anchors on
+//     a sliding (Step < Range) query_range grid, each anchor computing its
+//     OWN distinct trailing pair — see
+//     TestDownsampleTier_ChdbSlidingWindowMultiAnchor.
+//  3. The post-merge exact-window re-filter
+//     (downsampleTierExactWindowFilterFrag) is not a no-op belt: a tier row
+//     whose retained sample timestamp sits outside its own BucketEnd's
+//     canonical interval (the shape a backfill bug or a manual data
+//     correction could produce) is correctly excluded from the merged
+//     answer rather than silently corrupting it — see
+//     TestDownsampleTier_ChdbCorruptedBucketPostMergeFilter.
+//
+// This file shares downsampleTierChdbSetup / insertDownsampleTierSamples /
+// downsampleTierHostSample / downsampleTierLowererTable / hostFromJSON with
+// range_window_downsample_tier_chdb_test.go (same package, same DDL, same
+// seed/query plumbing) — only the grid-shaped query runner is new
+// (runDownsampleTierPromQLGrid), since the single-bucket file's own
+// runDownsampleTierPromQL hard-codes a single-anchor grid and discards the
+// per-row timestamp, both of which a multi-anchor test needs.
+package chsql_test
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"testing"
+	"time"
+
+	promparser "github.com/prometheus/prometheus/promql/parser"
+
+	"github.com/tsouza/cerberus/internal/chsql"
+	"github.com/tsouza/cerberus/internal/chsqltest"
+	"github.com/tsouza/cerberus/internal/optimizer"
+	"github.com/tsouza/cerberus/internal/promql"
+	"github.com/tsouza/cerberus/internal/schema"
+)
+
+// downsampleTierGridResult is one output row's (timestamp, value) pair,
+// keyed by host — the shape a multi-anchor grid query needs that the
+// single-bucket file's host-only map cannot represent (two anchors for the
+// SAME host are two different map entries here).
+type downsampleTierGridResult struct {
+	ts    time.Time
+	value float64
+}
+
+// runDownsampleTierPromQLGrid mirrors runDownsampleTierPromQL
+// (range_window_downsample_tier_chdb_test.go) but takes an arbitrary
+// [start, end] / step grid instead of a single fixed anchor, and keeps each
+// row's own timestamp instead of discarding it — required to tell two
+// different anchors' answers for the SAME host apart.
+func runDownsampleTierPromQLGrid(
+	t *testing.T, db *sql.DB, query string, start, end time.Time, step time.Duration, tierRouted bool,
+) map[string]downsampleTierGridResult {
+	t.Helper()
+	p := promparser.NewParser(promparser.Options{EnableExperimentalFunctions: true})
+	expr, err := p.ParseExpr(query)
+	if err != nil {
+		t.Fatalf("parse %q: %v", query, err)
+	}
+	var lowerers promql.RangeLowerers
+	if tierRouted {
+		lowerers = downsampleTierLowererTable()
+	}
+	plan, err := promql.LowerAtRangeOpts(context.Background(), expr, schema.DefaultOTelMetrics(),
+		start, end, step, promql.LowerOpts{Lowerers: lowerers})
+	if err != nil {
+		t.Fatalf("lower %q (tierRouted=%v): %v", query, tierRouted, err)
+	}
+	plan = optimizer.Default().Run(context.Background(), plan)
+	sqlText, args, err := chsql.Emit(context.Background(), plan)
+	if err != nil {
+		t.Fatalf("emit %q (tierRouted=%v): %v", query, tierRouted, err)
+	}
+	wrapped := "SELECT toJSONString(`Attributes`) AS host_json, `TimeUnix`, `Value` FROM (" + sqlText + ")"
+	rows, err := db.Query(wrapped, args...)
+	if err != nil {
+		t.Fatalf("query %q (tierRouted=%v): %v\nSQL: %s", query, tierRouted, err, wrapped)
+	}
+	defer func() { _ = rows.Close() }()
+	out := make(map[string]downsampleTierGridResult)
+	for rows.Next() {
+		var hostJSON string
+		var ts time.Time
+		var value float64
+		if err := rows.Scan(&hostJSON, &ts, &value); err != nil {
+			t.Fatalf("scan: %v", err)
+		}
+		host := hostFromJSON(t, hostJSON)
+		key := fmt.Sprintf("%s@%s", host, ts.UTC().Format(time.RFC3339))
+		out[key] = downsampleTierGridResult{ts: ts, value: value}
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatalf("rows: %v", err)
+	}
+	return out
+}
+
+// runDownsampleTierPromQLSingleAnchor mirrors runDownsampleTierPromQL
+// (range_window_downsample_tier_chdb_test.go) — a single fixed anchor,
+// host-keyed Value map, no per-row timestamp — but takes an arbitrary
+// anchor instead of that file's hardcoded downsampleTierBucketAnchor
+// global. Used wherever a test needs dual-emit parity against the fan-out
+// oracle: the fan-out emitter's own outer SELECT carries no timestamp
+// column at all (only Attributes + Value — matching the original file's
+// own host-only wrapper), so a single-anchor comparison is the only shape
+// both sides can answer.
+func runDownsampleTierPromQLSingleAnchor(t *testing.T, db *sql.DB, query string, anchor time.Time, tierRouted bool) map[string]float64 {
+	t.Helper()
+	p := promparser.NewParser(promparser.Options{EnableExperimentalFunctions: true})
+	expr, err := p.ParseExpr(query)
+	if err != nil {
+		t.Fatalf("parse %q: %v", query, err)
+	}
+	var lowerers promql.RangeLowerers
+	if tierRouted {
+		lowerers = downsampleTierLowererTable()
+	}
+	plan, err := promql.LowerAtRangeOpts(context.Background(), expr, schema.DefaultOTelMetrics(),
+		anchor, anchor, schema.DownsampleTierBucket, promql.LowerOpts{Lowerers: lowerers})
+	if err != nil {
+		t.Fatalf("lower %q (tierRouted=%v): %v", query, tierRouted, err)
+	}
+	plan = optimizer.Default().Run(context.Background(), plan)
+	sqlText, args, err := chsql.Emit(context.Background(), plan)
+	if err != nil {
+		t.Fatalf("emit %q (tierRouted=%v): %v", query, tierRouted, err)
+	}
+	wrapped := "SELECT toJSONString(`Attributes`) AS host_json, `Value` FROM (" + sqlText + ")"
+	rows, err := db.Query(wrapped, args...)
+	if err != nil {
+		t.Fatalf("query %q (tierRouted=%v): %v\nSQL: %s", query, tierRouted, err, wrapped)
+	}
+	defer func() { _ = rows.Close() }()
+	out := make(map[string]float64)
+	for rows.Next() {
+		var hostJSON string
+		var value float64
+		if err := rows.Scan(&hostJSON, &value); err != nil {
+			t.Fatalf("scan: %v", err)
+		}
+		out[hostFromJSON(t, hostJSON)] = value
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatalf("rows: %v", err)
+	}
+	return out
+}
+
+// TestDownsampleTier_ChdbCrossBucketMerge proves the core #2857 mechanism:
+// a 15m range (3x the 5m bucket) merges THREE tier buckets via
+// timeSeriesLastTwoSamplesMerge, and the trailing pair the query actually
+// needs can span two DIFFERENT buckets rather than living entirely inside
+// the newest one.
+func TestDownsampleTier_ChdbCrossBucketMerge(t *testing.T) {
+	db := chsqltest.OpenIsolatedChDB(t)
+	downsampleTierChdbSetup(t, db)
+
+	anchor := time.Date(2024, 6, 1, 0, 15, 0, 0, time.UTC) // BucketEnd of the 3rd bucket
+	seed := []downsampleTierHostSample{
+		// "spanning": trailing pair (100@00:04:30, 200@00:07:00) spans the
+		// FIRST and SECOND bucket — the third bucket ([00:10,00:15]) holds no
+		// sample for this host at all, proving an empty covering bucket
+		// contributes nothing rather than erroring or defaulting to zero.
+		{"spanning", time.Date(2024, 6, 1, 0, 4, 30, 0, time.UTC), 100, 2},
+		{"spanning", time.Date(2024, 6, 1, 0, 7, 0, 0, time.UTC), 200, 2},
+		// "newest_only": every sample lives in the LAST bucket alone — the
+		// degenerate case where cross-bucket merging changes nothing,
+		// checked here for contrast against "spanning".
+		{"newest_only", time.Date(2024, 6, 1, 0, 11, 0, 0, time.UTC), 5, 2},
+		{"newest_only", time.Date(2024, 6, 1, 0, 12, 0, 0, time.UTC), 9, 2},
+		// "discarded_middle": THREE samples across all three buckets — the
+		// merge must keep only the trailing TWO (400@00:09, 500@00:13),
+		// discarding the earlier 300@00:02 even though it lives in a
+		// DIFFERENT (the oldest) bucket from the pair it's discarded in
+		// favour of.
+		{"discarded_middle", time.Date(2024, 6, 1, 0, 2, 0, 0, time.UTC), 300, 2},
+		{"discarded_middle", time.Date(2024, 6, 1, 0, 9, 0, 0, time.UTC), 400, 2},
+		{"discarded_middle", time.Date(2024, 6, 1, 0, 13, 0, 0, time.UTC), 500, 2},
+	}
+	insertDownsampleTierSamples(t, db, seed)
+
+	const ideltaQuery = `idelta(cpu_seconds_total[15m])`
+	const irateQuery = `irate(cpu_seconds_total[15m])`
+
+	ideltaTier := runDownsampleTierPromQLSingleAnchor(t, db, ideltaQuery, anchor, true)
+	ideltaFanout := runDownsampleTierPromQLSingleAnchor(t, db, ideltaQuery, anchor, false)
+	irateTier := runDownsampleTierPromQLSingleAnchor(t, db, irateQuery, anchor, true)
+	irateFanout := runDownsampleTierPromQLSingleAnchor(t, db, irateQuery, anchor, false)
+
+	wantIdelta := map[string]float64{
+		"spanning":         100, // 200 - 100
+		"newest_only":      4,   // 9 - 5
+		"discarded_middle": 100, // 500 - 400, NOT 500-300
+	}
+	for host, want := range wantIdelta {
+		got, ok := ideltaTier[host]
+		if !ok {
+			t.Errorf("idelta host=%s: expected present, got absent", host)
+			continue
+		}
+		if got != want {
+			t.Errorf("idelta host=%s: want %v, got %v", host, want, got)
+		}
+		fv, ok := ideltaFanout[host]
+		if !ok {
+			t.Errorf("idelta host=%s: absent from fan-out oracle (test bug?)", host)
+			continue
+		}
+		if fv != got {
+			t.Errorf("idelta host=%s: tier=%v fanout(oracle)=%v mismatch", host, got, fv)
+		}
+	}
+
+	wantIrate := map[string]float64{
+		"spanning":         100.0 / 150, // interval 00:04:30 -> 00:07:00 = 150s
+		"newest_only":      4.0 / 60,    // interval 00:11:00 -> 00:12:00 = 60s
+		"discarded_middle": 100.0 / 240, // interval 00:09:00 -> 00:13:00 = 240s
+	}
+	for host, want := range wantIrate {
+		got, ok := irateTier[host]
+		if !ok {
+			t.Errorf("irate host=%s: expected present, got absent", host)
+			continue
+		}
+		if diff := got - want; diff > 1e-9 || diff < -1e-9 {
+			t.Errorf("irate host=%s: want %v, got %v", host, want, got)
+		}
+		fv, ok := irateFanout[host]
+		if !ok {
+			t.Errorf("irate host=%s: absent from fan-out oracle (test bug?)", host)
+			continue
+		}
+		if diff := fv - got; diff > 1e-9 || diff < -1e-9 {
+			t.Errorf("irate host=%s: tier=%v fanout(oracle)=%v mismatch", host, got, fv)
+		}
+	}
+}
+
+// TestDownsampleTier_ChdbSlidingWindowMultiAnchor proves a SINGLE tier
+// bucket correctly feeds MULTIPLE overlapping query_range anchors (Step=5m
+// < Range=15m — three consecutive buckets slide across three anchors, each
+// anchor computing its own distinct trailing pair), not just the single
+// fixed anchor every other downsample-tier test exercises.
+func TestDownsampleTier_ChdbSlidingWindowMultiAnchor(t *testing.T) {
+	db := chsqltest.OpenIsolatedChDB(t)
+	downsampleTierChdbSetup(t, db)
+
+	// Powers of two so each anchor's idelta is unambiguous and a
+	// bucket-shifted-by-one bug would produce an easily distinguishable
+	// wrong answer (2, 4, or 8) rather than accidentally matching.
+	seed := []downsampleTierHostSample{
+		{"sliding", time.Date(2024, 6, 1, 0, 4, 0, 0, time.UTC), 1, 2},
+		{"sliding", time.Date(2024, 6, 1, 0, 9, 0, 0, time.UTC), 2, 2},
+		{"sliding", time.Date(2024, 6, 1, 0, 14, 0, 0, time.UTC), 4, 2},
+		{"sliding", time.Date(2024, 6, 1, 0, 19, 0, 0, time.UTC), 8, 2},
+		{"sliding", time.Date(2024, 6, 1, 0, 24, 0, 0, time.UTC), 16, 2},
+	}
+	insertDownsampleTierSamples(t, db, seed)
+
+	start := time.Date(2024, 6, 1, 0, 15, 0, 0, time.UTC)
+	end := time.Date(2024, 6, 1, 0, 25, 0, 0, time.UTC)
+	got := runDownsampleTierPromQLGrid(t, db, `idelta(cpu_seconds_total[15m])`, start, end, schema.DownsampleTierBucket, true)
+
+	want := map[time.Time]float64{
+		time.Date(2024, 6, 1, 0, 15, 0, 0, time.UTC): 2, // pair (2@00:09, 4@00:14)
+		time.Date(2024, 6, 1, 0, 20, 0, 0, time.UTC): 4, // pair (4@00:14, 8@00:19)
+		time.Date(2024, 6, 1, 0, 25, 0, 0, time.UTC): 8, // pair (8@00:19, 16@00:24)
+	}
+	for ts, wantVal := range want {
+		key := fmt.Sprintf("sliding@%s", ts.Format(time.RFC3339))
+		row, ok := got[key]
+		if !ok {
+			t.Errorf("anchor %s: expected present, got absent", ts)
+			continue
+		}
+		if row.value != wantVal {
+			t.Errorf("anchor %s: want %v, got %v", ts, wantVal, row.value)
+		}
+	}
+	if len(got) != len(want) {
+		t.Errorf("row-count mismatch: want %d rows, got %d (%v)", len(want), len(got), got)
+	}
+}
+
+// TestDownsampleTier_ChdbCorruptedBucketPostMergeFilter proves
+// downsampleTierExactWindowFilterFrag's post-merge re-filter is not a
+// redundant no-op: it manually writes a tier row (bypassing the MV
+// entirely, the same way a backfill bug or a manual data correction could)
+// whose retained sample timestamp sits OUTSIDE its own BucketEnd's
+// canonical interval — and outside the query's own window too — and
+// confirms the query correctly excludes that sample rather than treating it
+// as the newest one.
+func TestDownsampleTier_ChdbCorruptedBucketPostMergeFilter(t *testing.T) {
+	db := chsqltest.OpenIsolatedChDB(t)
+	downsampleTierChdbSetup(t, db)
+
+	// One legitimate sample, written the normal way (via otel_metrics_sum +
+	// the live MV), landing in the THIRD covering bucket.
+	insertDownsampleTierSamples(t, db, []downsampleTierHostSample{
+		{"corrupted", time.Date(2024, 6, 1, 0, 12, 0, 0, time.UTC), 500, 2},
+	})
+
+	// A hand-written tier row keyed BucketEnd=00:05:00 (the FIRST covering
+	// bucket) whose retained sample timestamp is 00:20:00 — outside its own
+	// bucket's (00:00,00:05] interval, and outside the query's own
+	// (00:00,00:15] window too. No real write path (the live MV or the
+	// backfill CLI) can produce this; it stands in for the data-corruption
+	// scenario the re-filter defends against.
+	const insertCorrupted = `
+INSERT INTO otel_metrics_sum_downsample_tier
+	(MetricName, Attributes, ResourceAttributes, ServiceName, BucketEnd, LastTwoSamples, Temporality)
+SELECT
+	'cpu_seconds_total',
+	map('host', 'corrupted'),
+	map(),
+	'',
+	toDateTime64('2024-06-01 00:05:00', 9),
+	state,
+	2
+FROM (
+	SELECT timeSeriesLastTwoSamplesState(t, v) AS state
+	FROM (SELECT toDateTime64('2024-06-01 00:20:00', 9) AS t, 9999.0 AS v)
+)`
+	if _, err := db.Exec(insertCorrupted); err != nil {
+		t.Fatalf("insert corrupted tier row: %v", err)
+	}
+
+	anchor := time.Date(2024, 6, 1, 0, 15, 0, 0, time.UTC)
+
+	lastOverTime := runDownsampleTierPromQLGrid(t, db, `last_over_time(cpu_seconds_total[15m])`, anchor, anchor, schema.DownsampleTierBucket, true)
+	idelta := runDownsampleTierPromQLGrid(t, db, `idelta(cpu_seconds_total[15m])`, anchor, anchor, schema.DownsampleTierBucket, true)
+	irate := runDownsampleTierPromQLGrid(t, db, `irate(cpu_seconds_total[15m])`, anchor, anchor, schema.DownsampleTierBucket, true)
+
+	key := fmt.Sprintf("corrupted@%s", anchor.Format(time.RFC3339))
+
+	// last_over_time needs only 1 sample: with the corrupted 9999@00:20
+	// correctly filtered out, the single legitimate sample (500@00:12) is
+	// what remains — NOT 9999, which is what an unfiltered merge would
+	// wrongly report as "most recent".
+	if row, ok := lastOverTime[key]; !ok || row.value != 500 {
+		t.Errorf("last_over_time host=corrupted: want 500 (the legitimate sample), got %v (present=%v)", row.value, ok)
+	}
+
+	// idelta / irate need >= 2 samples in-window. With the corrupted sample
+	// filtered out, only 1 legitimate sample remains, so both must be
+	// ABSENT — NOT a value computed from (500@00:12, 9999@00:20).
+	if row, ok := idelta[key]; ok {
+		t.Errorf("idelta host=corrupted: expected absent (only 1 legitimate sample after filtering), got %v", row.value)
+	}
+	if row, ok := irate[key]; ok {
+		t.Errorf("irate host=corrupted: expected absent (only 1 legitimate sample after filtering), got %v", row.value)
+	}
+}

--- a/internal/promql/downsample_tier_strategy_test.go
+++ b/internal/promql/downsample_tier_strategy_test.go
@@ -138,18 +138,43 @@ func TestDownsampleTierIneligible_StepNotMultipleOfBucket(t *testing.T) {
 	}
 }
 
-func TestDownsampleTierIneligible_RangeNotEqualToBucket(t *testing.T) {
-	// range (15m) != the tier's fixed 5m bucket — even though step is a
-	// clean bucket multiple, v1 scope requires Range == bucket exactly (see
-	// downsampleTierEligible's own doc on why multi-bucket merge is out of
-	// scope).
+// TestDownsampleTierEligible_RangeMultipleOfBucket proves cerberus issue
+// #2857's headline extension: a range spanning several tier buckets (15m ==
+// 3x the 5m bucket) now routes, not just the exact-bucket N==1 case #2751
+// shipped.
+func TestDownsampleTierEligible_RangeMultipleOfBucket(t *testing.T) {
 	rw, ok := lowerDownsampleTierQuery(t, `irate(cpu_seconds_total[15m])`,
 		bucketAlignedStart, bucketAlignedStart.Add(20*time.Minute), schema.DownsampleTierBucket)
 	if !ok {
 		t.Fatal("expected a RangeWindow in the plan")
 	}
+	if !rw.DownsampleTier {
+		t.Error("a range that is an integer multiple of the bucket (15m == 3x5m) must route to the tier")
+	}
+}
+
+func TestDownsampleTierIneligible_RangeNotMultipleOfBucket(t *testing.T) {
+	// range (7m) is coarser than the 5m bucket but NOT an integer multiple
+	// of it, so it cannot be covered by a whole run of tier buckets.
+	rw, ok := lowerDownsampleTierQuery(t, `irate(cpu_seconds_total[7m])`,
+		bucketAlignedStart, bucketAlignedStart.Add(20*time.Minute), schema.DownsampleTierBucket)
+	if !ok {
+		t.Fatal("expected a RangeWindow in the plan")
+	}
 	if rw.DownsampleTier {
-		t.Error("range != the tier's fixed bucket must never route to the tier")
+		t.Error("range that is not an integer multiple of the bucket must never route to the tier")
+	}
+}
+
+func TestDownsampleTierIneligible_RangeNarrowerThanBucket(t *testing.T) {
+	// range (1m) is narrower than a single 5m bucket.
+	rw, ok := lowerDownsampleTierQuery(t, `irate(cpu_seconds_total[1m])`,
+		bucketAlignedStart, bucketAlignedStart.Add(20*time.Minute), schema.DownsampleTierBucket)
+	if !ok {
+		t.Fatal("expected a RangeWindow in the plan")
+	}
+	if rw.DownsampleTier {
+		t.Error("range narrower than one bucket must never route to the tier")
 	}
 }
 

--- a/internal/promql/lower_strategy.go
+++ b/internal/promql/lower_strategy.go
@@ -1520,15 +1520,19 @@ func (n NativeLastOverTimeLowerer) LowerLastOverTime(rw *chplan.RangeWindow, s s
 //     PromQL subquery `[range:step]` — so it carries no subquery-specific
 //     signal at this layer to exclude on.
 //   - rw.Offset must be zero — an offset shifts the window off the tier's
-//     own bucket grid; v1 does not attempt to re-derive an offset-shifted
-//     alignment.
-//   - rw.Range must equal EXACTLY schema.DownsampleTierBucket. A wider
-//     range spanning multiple buckets would need merging several tier rows
-//     (timeSeriesLastTwoSamplesMerge across buckets) PLUS an exact
-//     timestamp re-filter at the union's edges to stay byte-correct at
-//     bucket boundaries — deliberately out of v1 scope (see the PR
-//     description's follow-up note); a narrower range cannot be answered
-//     from one bucket-granularity row at all.
+//     own bucket grid; this mechanism does not attempt to re-derive an
+//     offset-shifted alignment.
+//   - rw.Range must be a POSITIVE INTEGER MULTIPLE of
+//     schema.DownsampleTierBucket (cerberus issue #2857 — the single-bucket
+//     rw.Range == bucket case #2751 shipped is the N==1 degenerate case of
+//     this same check). Every wider multiple merges the N covering tier
+//     rows via timeSeriesLastTwoSamplesMerge and re-filters the merged
+//     result to the exact `(anchor-range, anchor]` window — see
+//     internal/chsql's emitRangeWindowDownsampleTier, mirroring the
+//     reasoning internal/schema/ddl's downsampleTierBucketEndExpr doc
+//     comment lays out for the single-bucket case. A range narrower than
+//     one bucket, or not an integer multiple of it, cannot be answered from
+//     whole bucket-granularity rows at all.
 //   - rw.Step must be a POSITIVE INTEGER MULTIPLE of the bucket — this is
 //     the "step >= bucket" resolution-awareness the issue requires (a step
 //     smaller than the bucket can never divide it evenly, so the modulo
@@ -1553,10 +1557,10 @@ func downsampleTierEligible(rw *chplan.RangeWindow) bool {
 	if len(rw.Variants) > 0 {
 		return false
 	}
-	if rw.Range != schema.DownsampleTierBucket {
+	bucketNS := schema.DownsampleTierBucket.Nanoseconds()
+	if rw.Range <= 0 || rw.Range.Nanoseconds()%bucketNS != 0 {
 		return false
 	}
-	bucketNS := schema.DownsampleTierBucket.Nanoseconds()
 	if rw.Step.Nanoseconds()%bucketNS != 0 {
 		return false
 	}

--- a/internal/schema/ddl/ddl.go
+++ b/internal/schema/ddl/ddl.go
@@ -1399,11 +1399,19 @@ func renderDeltaPrefixView(cfg Config) string {
 // off-by-one at BOTH edges against that PromQL window; the ceiling
 // convention here reproduces PromQL's half-open-left/closed-right window
 // exactly (verified empirically against a real ClickHouse boundary-exact
-// sample — see internal/chsql's downsample-tier chDB test), so the read
-// side (internal/chsql's emitRangeWindowDownsampleTier) can look up a
-// SINGLE bucket row per grid anchor with no multi-bucket merge or
-// arrayFilter re-narrowing — every raw sample in `(anchor-bucket, anchor]`
-// is guaranteed to land in exactly the row keyed `BucketEnd = anchor`.
+// sample — see internal/chsql's downsample-tier chDB test): every raw
+// sample is guaranteed to land in exactly the ONE bucket row whose
+// `(BucketStart, BucketEnd]` interval contains its timestamp, never split
+// or duplicated across two rows. That unambiguous per-sample assignment is
+// what makes the read side's bucket-to-anchor mapping exact — a query whose
+// range equals the bucket (internal/chsql's emitRangeWindowDownsampleTier,
+// cerberus issue #2751) looks up a SINGLE bucket row per grid anchor with
+// no merge or re-filter at all; a query spanning N buckets (the same
+// function, extended by issue #2857) merges exactly the N bucket rows whose
+// BucketEnd falls in the anchor's own window, with no gap or overlap
+// between them, and re-filters the merged result as a defensive check
+// against malformed data rather than a correctness requirement of this
+// boundary expression.
 //
 // Computed as `toStartOfInterval(t - toIntervalNanosecond(1), bucket) +
 // bucket`: subtracting one nanosecond (TimeUnix's own DateTime64(9)


### PR DESCRIPTION
## Summary

- Extends the downsample tier (#2751) so `irate()` / `idelta()` / `last_over_time()` route to it for a `[range]` that is any positive integer multiple of `schema.DownsampleTierBucket`, not just the exact-bucket `N==1` case.
- `downsampleTierEligible` (`internal/promql/lower_strategy.go`) now checks `rw.Range % bucket == 0` instead of `rw.Range == bucket`.
- `emitRangeWindowDownsampleTier` (`internal/chsql/range_window_downsample_tier.go`) fans each tier row across every covering grid anchor (reusing the existing `sampleAnchorFanoutFrag` sample-side fan-out, treating a bucket's `BucketEnd` as the "sample timestamp"), merges the covering buckets' states per anchor via `timeSeriesLastTwoSamplesMerge`, and re-filters the merged pairs to the exact `(anchor-range, anchor]` window (`downsampleTierExactWindowFilterFrag`) before computing the per-`Func` value.
- The re-filter is a defensive backstop, not a correctness requirement of the fan-out itself (which is exact by construction over well-formed data) — it protects against a tier row whose retained sample timestamp sits outside its own bucket's canonical interval (a backfill bug or manual data correction). Proven to matter: disabling it locally made the new corrupted-row test fail with the wrong values.

## Test plan

- [x] `just lint` clean (ran `golangci-lint run` untagged + `--build-tags cerberus_untagged_build` on `internal/chsql`, `internal/promql` — 0 issues; CI's own `lint` job is still authoritative per repo policy)
- [x] `just test` passes (race): `go test -race ./internal/promql/... ./internal/chsql/... ./internal/schema/...`
- [x] chDB tests (`-tags chdb`): existing `TestDownsampleTier_ChdbCorrectness` (single-bucket, #2751) passes unchanged — confirms the `N==1` case stays byte-identical.
- [x] New chDB tests in `internal/chsql/range_window_downsample_tier_multibucket_chdb_test.go`:
  - `TestDownsampleTier_ChdbCrossBucketMerge` — a trailing pair spanning two different tier buckets, an empty covering bucket contributing nothing, and a third sample correctly discarded across a bucket boundary; dual-emit parity against the raw fan-out oracle.
  - `TestDownsampleTier_ChdbSlidingWindowMultiAnchor` — one bucket correctly feeding multiple overlapping anchors on a `Step < Range` grid, each anchor computing its own distinct trailing pair.
  - `TestDownsampleTier_ChdbCorruptedBucketPostMergeFilter` — a hand-written tier row (bypassing the MV) whose retained sample timestamp sits outside its own bucket's interval; verified the query correctly excludes it. Verified this test is not tautological by temporarily bypassing the re-filter and confirming the test fails.
- [x] `node .github/scripts/forbid-sql-raw.mjs` clean (invariant 10 self-check)
- [x] `go test -run TestEveryTaggedTestHasAnExecutingLane ./test/regression/...` passes — the new `_chdb_test.go` file is enrolled in an executing CI lane
- [x] `markdownlint-cli2` clean on the touched docs
- [x] No golden/spec fixtures reference the downsample tier (it's gated behind a boot-time chopt feature never exercised by the pre-optimizer spec lane), so no `just update-golden` run was needed
- [ ] CI green

## Notes for reviewers

- No new `internal/**` package, so no `.go-arch-lint.yml` entry needed.
- Updated stale doc comments that described the old exact-bucket-only shape as if it were the only one: `internal/chopt/registry.go`'s `FeatureDownsampleTier`, `internal/schema/ddl/ddl.go`'s `downsampleTierBucketEndExpr`, and `docs/operations.md`.
- Did not add a dedicated fan-out row-cap guard (the kind `internal/chsql/lwr_fanout_bound.go` adds for `RangeBucketFanout`/`RangeLWR`): the merge accumulator here (`timeSeriesLastTwoSamplesMerge`) is fixed-size like `RangeLWR`'s `argMax`, and the underlying tier is already downsampled to 5-minute buckets, so cardinality is much lower than the raw-row fan-outs that shipped without a dedicated guard. Flagging this reasoning explicitly in case a reviewer wants a follow-up perf guard.
