### PR TITLE
feat(promql,schema,downsampletier): route last_over_time() gauges onto the downsample tier

### DIFF
--- a/cmd/cerberus/cmd_schema.go
+++ b/cmd/cerberus/cmd_schema.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"strings"
 	"text/tabwriter"
 	"time"
 
@@ -427,11 +428,13 @@ func newSchemaDownsampleTierBackfillCmd() *cobra.Command {
 		Use:   "downsample-tier-backfill",
 		Short: "One-time historical backfill into the downsampled long-range tier",
 		Long: "Backfill the downsampled long-range tier (CERBERUS_CH_OPTIMIZATIONS=\n" +
-			"downsample_tier, cerberus issue #2751) for history that predates its\n" +
-			"materialized view: the MV only captures INSERTs into the base sum table\n" +
-			"from the moment it was created onward, so existing history needs this\n" +
-			"one-time INSERT ... SELECT pass. --before MUST be the MV's own creation\n" +
-			"timestamp (system.tables.metadata_modification_time, or an\n" +
+			"downsample_tier, cerberus issues #2751 and #2858) for history that\n" +
+			"predates its materialized view(s): the MV(s) only capture INSERTs into\n" +
+			"the base Sum table (and, unless it is configured identically to Sum,\n" +
+			"the base Gauge table) from the moment each was created onward, so\n" +
+			"existing history needs this one-time INSERT ... SELECT pass PER SOURCE.\n" +
+			"--before MUST be the LATER of the two MVs' own creation timestamps\n" +
+			"(system.tables.metadata_modification_time, or an\n" +
 			"operator-recorded timestamp from the moment CREATE MATERIALIZED VIEW\n" +
 			"ran) — the SAME exact-instant bound discipline\n" +
 			"`cerberus schema delta-prefix-backfill` uses, and for the identical\n" +
@@ -474,9 +477,10 @@ func runDownsampleTierBackfill(cmd *cobra.Command, in downsampleTierBackfillInpu
 	cols := downsampleTierColumns(cfg)
 
 	if in.dryRun {
-		sql, args := downsampletier.BackfillSQL(cols, before)
-		fmt.Fprintln(cmd.OutOrStdout(), sql)
-		fmt.Fprintf(cmd.OutOrStdout(), "-- args: %v\n", args)
+		for _, stmt := range downsampletier.BackfillSQL(cols, before) {
+			fmt.Fprintln(cmd.OutOrStdout(), stmt.SQL)
+			fmt.Fprintf(cmd.OutOrStdout(), "-- args: %v\n", stmt.Args)
+		}
 		return nil
 	}
 
@@ -493,7 +497,7 @@ func runDownsampleTierBackfill(cmd *cobra.Command, in downsampleTierBackfillInpu
 		return err
 	}
 	fmt.Fprintf(cmd.OutOrStdout(), "backfilled the downsample tier from %s (rows strictly before %s)\n",
-		cols.SumTable, before.Format(time.RFC3339))
+		strings.Join(downsampletier.SourceTables(cols), ", "), before.Format(time.RFC3339))
 	if len(result.OutsideRetentionDays) > 0 {
 		writeOutsideRetentionWarning(cmd.OutOrStdout(), "the downsample tier", result.OutsideRetentionDays)
 	}
@@ -521,9 +525,10 @@ func newSchemaDownsampleTierRebuildCmd() *cobra.Command {
 		Use:   "downsample-tier-rebuild",
 		Short: "TRUNCATE and fully re-populate the downsampled long-range tier",
 		Long: "TRUNCATEs the downsampled long-range tier (CERBERUS_CH_OPTIMIZATIONS=\n" +
-			"downsample_tier, cerberus issue #2751) and re-populates it in FULL, from\n" +
-			"the base sum table's entire currently-retained history — no --before\n" +
-			"bound. DESTRUCTIVE: every row currently in the tier is dropped first.\n" +
+			"downsample_tier, cerberus issues #2751 and #2858) and re-populates it in\n" +
+			"FULL, from every configured source table's (Sum, and Gauge unless it is\n" +
+			"configured identically to Sum) entire currently-retained history — no\n" +
+			"--before bound. DESTRUCTIVE: every row currently in the tier is dropped first.\n" +
 			"Use this, not downsample-tier-backfill, when the persisted\n" +
 			"AggregateFunction(timeSeriesLastTwoSamples, ...) state is suspected\n" +
 			"stranded or format-incompatible (a ClickHouse changelog entry naming\n" +
@@ -555,9 +560,10 @@ func runDownsampleTierRebuild(cmd *cobra.Command, in downsampleTierRebuildInputs
 
 	if in.dryRun {
 		fmt.Fprintln(cmd.OutOrStdout(), downsampletier.TruncateSQL(cols))
-		sql, args := downsampletier.RebuildSQL(cols)
-		fmt.Fprintln(cmd.OutOrStdout(), sql)
-		fmt.Fprintf(cmd.OutOrStdout(), "-- args: %v\n", args)
+		for _, stmt := range downsampletier.RebuildSQL(cols) {
+			fmt.Fprintln(cmd.OutOrStdout(), stmt.SQL)
+			fmt.Fprintf(cmd.OutOrStdout(), "-- args: %v\n", stmt.Args)
+		}
 		return nil
 	}
 
@@ -573,7 +579,8 @@ func runDownsampleTierRebuild(cmd *cobra.Command, in downsampleTierRebuildInputs
 	if err != nil {
 		return err
 	}
-	fmt.Fprintf(cmd.OutOrStdout(), "rebuilt the downsample tier from %s (full history)\n", cols.SumTable)
+	fmt.Fprintf(cmd.OutOrStdout(), "rebuilt the downsample tier from %s (full history)\n",
+		strings.Join(downsampletier.SourceTables(cols), ", "))
 	if len(result.OutsideRetentionDays) > 0 {
 		writeOutsideRetentionWarning(cmd.OutOrStdout(), "the downsample tier", result.OutsideRetentionDays)
 	}
@@ -599,8 +606,9 @@ func newSchemaDownsampleTierVerifyCmd() *cobra.Command {
 		Use:   "downsample-tier-verify",
 		Short: "Verify downsample-tier backfill completeness before relying on it",
 		Long: "Compare the downsampled long-range tier's per-metric-name DISTINCT\n" +
-			"bucket count against the base sum table's own, over the same\n" +
-			"backfilled/rebuilt history (--before, the tier MV's creation timestamp\n" +
+			"bucket count against the SUM of every configured source table's own\n" +
+			"(Sum, and Gauge unless it is configured identically to Sum), over the same\n" +
+			"backfilled/rebuilt history (--before, the later of the MVs' creation timestamps\n" +
 			"— see `cerberus schema downsample-tier-backfill --help`). A clean pass\n" +
 			"is the recommended confirmation before an operator sets\n" +
 			"CERBERUS_CH_OPTIMIZATIONS=downsample_tier for long-range queries over\n" +

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -2316,22 +2316,40 @@ high-cardinality DELTA metric — not `date-range × 1` — and belongs in
 capacity planning for any deployment enabling
 `CERBERUS_DELTA_PREFIX_READ_ENABLED` against such a metric.
 
-### Downsampled long-range tier (cerberus issue #2751, #2857)
+### Downsampled long-range tier (cerberus issue #2751, #2857, #2858)
 
-Auto-create can also provision an **opt-in, cerberus-owned** table + materialized
-view folding raw Sum-table samples into a persisted `timeSeriesLastTwoSamples`
-aggregate state per 5-minute bucket (`internal/schema/ddl`, table
-`otel_metrics_sum_downsample_tier`), read back by `irate()` / `idelta()` /
-`last_over_time()` `query_range` shapes whose window is a positive integer
-multiple of the bucket (one bucket exactly, or several merged via
-`timeSeriesLastTwoSamplesMerge` and re-filtered to the exact window, per
-issue #2857). Unlike the DELTA-prefix table above, provisioning and query routing
-share a **single** flag: `CERBERUS_CH_OPTIMIZATIONS=downsample_tier` (a chopt
-feature, floor ClickHouse >= 25.9, `AutoSelect=false` — never picked by
-`auto`). A not-yet-backfilled or missing bucket degrades to an ABSENT series
-point at query time, never a wrong value — see the scope note below — so
-this mechanism does not need DELTA-prefix's separate, later
-`*_READ_ENABLED` declaration.
+Auto-create can also provision an **opt-in, cerberus-owned** table fed by
+**two independent materialized views**, folding raw samples into a persisted
+`timeSeriesLastTwoSamples` aggregate state per 5-minute bucket
+(`internal/schema/ddl`, table `otel_metrics_sum_downsample_tier`): one MV
+from the Sum table (`otel_metrics_sum_downsample_tier_mv`, issue #2751,
+feeding `irate()` / `idelta()` / `last_over_time()`), one from the Gauge
+table (`otel_metrics_sum_downsample_tier_gauge_mv`, issue #2858, feeding
+`last_over_time()` only — a gauge has no counter-reset semantics for
+`irate()`/`idelta()`). Read back by `query_range` shapes whose window is a
+positive integer multiple of the bucket (one bucket exactly, or several
+merged via `timeSeriesLastTwoSamplesMerge` and re-filtered to the exact
+window, per issue #2857). Unlike the DELTA-prefix table above, provisioning
+and query routing share a **single** flag:
+`CERBERUS_CH_OPTIMIZATIONS=downsample_tier` (a chopt feature, floor
+ClickHouse >= 25.9, `AutoSelect=false` — never picked by `auto`). A
+not-yet-backfilled or missing bucket degrades to an ABSENT series point at
+query time, never a wrong value — see the scope note below — so this
+mechanism does not need DELTA-prefix's separate, later `*_READ_ENABLED`
+declaration.
+
+The Gauge-sourced MV is skipped when `CERBERUS_SCHEMA_METRICS_GAUGE_TABLE`
+is configured identically to the Sum table — in that configuration the
+Sum-sourced MV already folds every row either name would otherwise read
+twice. Because an UNSUFFIXED metric name is otherwise ambiguous between
+Gauge and Sum (the same routing fan-out `/api/v1/series` etc. rely on to
+find hostmetrics-style cumulative sums under bare names), `last_over_time()`
+only routes a Gauge-table metric to the tier when its name resolves
+UNAMBIGUOUSLY to Gauge alone — realistically, a deployment with no Sum table
+configured at all. This mirrors the pre-existing restriction
+`irate()`/`idelta()` already have for an unsuffixed COUNTER metric (only a
+`_total`-suffixed name resolves unambiguously to Sum), applied symmetrically
+rather than newly introduced.
 
 **Hard scope boundary — `rate()` / `increase()` / `delta()` never route
 here, and never will.** Retaining only the two newest raw samples per bucket
@@ -2376,7 +2394,28 @@ SELECT MetricName, Attributes, ResourceAttributes, ServiceName,
        any(AggregationTemporality) AS Temporality
 FROM <db>.otel_metrics_sum
 GROUP BY MetricName, Attributes, ResourceAttributes, ServiceName, BucketEnd;
+
+CREATE MATERIALIZED VIEW IF NOT EXISTS <db>.otel_metrics_sum_downsample_tier_gauge_mv
+TO <db>.otel_metrics_sum_downsample_tier AS
+SELECT MetricName, Attributes, ResourceAttributes, ServiceName,
+       toStartOfInterval(TimeUnix - toIntervalNanosecond(1), toIntervalSecond(300))
+           + toIntervalSecond(300) AS BucketEnd,
+       timeSeriesLastTwoSamplesState(TimeUnix, Value) AS LastTwoSamples,
+       -1 AS Temporality
+FROM <db>.otel_metrics_gauge
+GROUP BY MetricName, Attributes, ResourceAttributes, ServiceName, BucketEnd;
 ```
+
+The Gauge-sourced MV writes the fixed sentinel `-1` in place of a real
+`AggregationTemporality` reading — a Gauge series carries no such column at
+all. `-1` is chosen outside the OTLP `AggregationTemporality` wire enum's
+valid `{0, 1, 2}` range so it can never be misread as a genuine reading; the
+only reader of `Temporality` is `irate()` (`idelta()` and `last_over_time()`
+ignore it), and `irate()`'s own eligibility already requires an unambiguous
+Sum/Histogram-table resolution, so a sentinel-valued row from this MV is
+never reachable from an `irate()` query in the first place — this is
+verified empirically (a real ClickHouse engine, not just reasoned about)
+against a manually-seeded sentinel row.
 
 `BucketEnd` is a **ceiling**, not ClickHouse's native `toStartOfInterval`
 floor: PromQL's range-vector window is half-open-left / closed-right
@@ -2407,8 +2446,11 @@ cerberus schema downsample-tier-verify   --before 2026-08-20T14:32:10Z
 `downsample-tier-backfill` is the SAME non-retroactive, exact-instant
 `--before` bound `delta-prefix-backfill` uses, and the SAME
 already-outside-retention-TTL detection (reported as a `WARNING`, not an
-error). `downsample-tier-verify` is a per-metric **completeness** check —
-distinct `(MetricName, BucketEnd)` counts, base table vs. tier — not a
+error) — checked and applied once PER configured source (Sum, and Gauge
+unless it is configured identically to Sum), so `--before` must be the
+LATER of the two MVs' own creation timestamps. `downsample-tier-verify` is a
+per-metric **completeness** check — distinct `(MetricName, BucketEnd)`
+counts, summed across every configured source, base tables vs. tier — not a
 value-parity check like `delta-prefix-verify`'s sum comparison: this
 mechanism has no aggregate total to parity-check against in the first
 place, only samples to be present or absent.
@@ -2418,14 +2460,15 @@ cerberus schema downsample-tier-rebuild
 ```
 
 `downsample-tier-rebuild` `TRUNCATE`s the tier table and re-populates it in
-full, from the base table's entire currently-retained history — no
+full, from every configured source's entire currently-retained history — no
 `--before` bound. This is the recovery path for a suspected stranded or
 format-incompatible persisted state: `timeSeriesLastTwoSamples` is an
 EXPERIMENTAL ClickHouse aggregate function, and a future ClickHouse upgrade
 changing its on-disk state format could strand every already-written row.
 An incremental `downsample-tier-backfill` cannot repair rows that are
 already unreadable — `downsample-tier-rebuild` starts clean instead. All
-three verbs accept `--dry-run` to print the statement(s) without executing.
+three verbs accept `--dry-run` to print the statement(s) — one per
+configured source for backfill/rebuild — without executing.
 
 ### Startup requirements preflight
 

--- a/internal/chopt/registry.go
+++ b/internal/chopt/registry.go
@@ -825,12 +825,20 @@ const (
 	// bucket, grid aligned to the bucket boundary — see
 	// internal/promql/lower_strategy.go's eligibility check) onto the
 	// operator-provisioned downsampled long-range tier
-	// (schema.DownsampleTierTable): a materialized view folding raw Sum-
-	// table samples into a persisted timeSeriesLastTwoSamples aggregate
-	// state per bucket, read back via timeSeriesLastTwoSamplesMerge +
-	// finalizeAggregation instead of scanning full-resolution raw rows
-	// (cerberus issue #2751; a range spanning several buckets merges them
-	// and re-filters to the exact window — issue #2857).
+	// (schema.DownsampleTierTable): TWO independent materialized views
+	// (internal/schema/ddl's renderDownsampleTierView from the Sum table,
+	// renderDownsampleTierGaugeView from the Gauge table — cerberus issue
+	// #2858) folding raw samples into a SHARED persisted
+	// timeSeriesLastTwoSamples aggregate state per bucket, read back via
+	// timeSeriesLastTwoSamplesMerge + finalizeAggregation instead of
+	// scanning full-resolution raw rows (cerberus issue #2751; a range
+	// spanning several buckets merges them and re-filters to the exact
+	// window — issue #2857). The Gauge-sourced MV feeds last_over_time()
+	// ONLY — a gauge has no counter-reset semantics for irate()/idelta(),
+	// see internal/promql/lower.go's attachDownsampleTierArm — and is
+	// eligible only over an UNAMBIGUOUS Gauge-table metric-name resolution,
+	// the same restriction an unsuffixed COUNTER metric already has for
+	// irate()/idelta() (schema.Metrics.TablesForUnknownName's own doc).
 	//
 	// THIS IS A FUNDAMENTALLY DIFFERENT MECHANISM from the rest of the
 	// timeSeries*ToGrid family above: those are stateless read-time

--- a/internal/chsql/downsample_tier_gauge_sentinel_chdb_test.go
+++ b/internal/chsql/downsample_tier_gauge_sentinel_chdb_test.go
@@ -1,0 +1,154 @@
+//go:build chdb
+
+// TestDownsampleTierGaugeSentinelTemporality_TakesSafeBranch is the sentinel
+// safety proof cerberus issue #2858 requires: if the Go-level eligibility
+// gate (internal/promql's attachDownsampleTierArm) ever had a bug and routed
+// an irate() call onto a Gauge-sourced tier row anyway, the
+// schema.DownsampleTierGaugeTemporalitySentinel value that row's Temporality
+// column carries must NOT be misread as schema.AggregationTemporalityDelta —
+// it must take the SAME "not DELTA" (counter-reset-aware) branch
+// chsql.CounterOrDeltaPairDelta already takes for a nil temporality (a
+// Gauge-table scan with no TemporalityColumn at all).
+//
+// This bypasses the normal PromQL lowering entirely (which structurally
+// never produces this shape for a real query — see
+// range_window_downsample_tier_gauge_chdb_test.go's
+// TestDownsampleTierGauge_IrateIdeltaNeverRouteToTier for that proof) and
+// hand-builds the chplan.RangeWindow the emitter itself would receive if
+// eligibility had failed open, to prove the EMITTER's own branch selection
+// is safe independent of the Go-level gate — defense in depth, not a
+// substitute for it.
+package chsql
+
+import (
+	"context"
+	"database/sql"
+	"math"
+	"testing"
+	"time"
+
+	"github.com/tsouza/cerberus/internal/chclient"
+	"github.com/tsouza/cerberus/internal/chplan"
+	"github.com/tsouza/cerberus/internal/chsqltest"
+	"github.com/tsouza/cerberus/internal/schema"
+)
+
+// downsampleTierGaugeSentinelDDL hand-writes the tier table's real column
+// shape (schema.DownsampleTierTable's own doc: MetricName, Attributes,
+// ResourceAttributes, ServiceName, BucketEnd, LastTwoSamples, Temporality) —
+// mirroring range_window_delta_prefix_aggregate_chdb_test.go's own
+// hand-written-DDL precedent for an internal-package chDB test (importing
+// internal/schema/ddl here would cycle back into this package).
+func downsampleTierGaugeSentinelDDL(t *testing.T, db *sql.DB) {
+	t.Helper()
+	if _, err := db.Exec("SET " + chclient.SettingExperimentalTSGridAggregate + " = 1"); err != nil {
+		t.Fatalf("enable experimental ts-grid: %v", err)
+	}
+	if _, err := db.Exec(`CREATE TABLE otel_metrics_sum_downsample_tier (
+		MetricName LowCardinality(String),
+		Attributes Map(LowCardinality(String), String),
+		ResourceAttributes Map(LowCardinality(String), String),
+		ServiceName LowCardinality(String),
+		BucketEnd DateTime64(9),
+		LastTwoSamples AggregateFunction(timeSeriesLastTwoSamples, DateTime64(9), Float64),
+		Temporality SimpleAggregateFunction(any, Int32)
+	) ENGINE = AggregatingMergeTree ORDER BY (MetricName, BucketEnd, Attributes, ResourceAttributes, ServiceName)`); err != nil {
+		t.Fatalf("create otel_metrics_sum_downsample_tier: %v", err)
+	}
+}
+
+// downsampleTierGaugeSentinelAnchor is the bucket this hand-seeded row
+// belongs to and the single grid anchor the test evaluates at.
+var downsampleTierGaugeSentinelAnchor = time.Date(2024, 6, 1, 0, 5, 0, 0, time.UTC)
+
+// seedDownsampleTierGaugeSentinelRow writes ONE tier row directly (bypassing
+// any MV) whose LastTwoSamples state holds an INCREASING pair — prev=30 at
+// 00:01:00, curr=45 at 00:03:00 — chosen so the DELTA branch (raw curr
+// alone, 45) and the "not DELTA" branch (curr-prev, 15) disagree; a test
+// that instead used a decreasing ("reset") pair could not distinguish the
+// two branches, since Prometheus's reset-heuristic collapses them both to
+// the raw curr value in that case. Temporality carries the fixed
+// schema.DownsampleTierGaugeTemporalitySentinel literal — exactly what
+// renderDownsampleTierGaugeView would have written for a real Gauge sample.
+func seedDownsampleTierGaugeSentinelRow(t *testing.T, db *sql.DB) {
+	t.Helper()
+	_, err := db.Exec(`INSERT INTO otel_metrics_sum_downsample_tier
+		SELECT 'gauge_metric', map('host', 'h1'), map(), '',
+		       toDateTime64('2024-06-01 00:05:00', 9),
+		       timeSeriesLastTwoSamplesState(t, v),
+		       ?
+		FROM (
+			SELECT toDateTime64('2024-06-01 00:01:00', 9) AS t, 30.0 AS v
+			UNION ALL
+			SELECT toDateTime64('2024-06-01 00:03:00', 9) AS t, 45.0 AS v
+		)`, schema.DownsampleTierGaugeTemporalitySentinel)
+	if err != nil {
+		t.Fatalf("seed sentinel tier row: %v", err)
+	}
+}
+
+// downsampleTierGaugeSentinelWindow hand-builds the SAME chplan.RangeWindow
+// shape attachDownsampleTierArm/buildDownsampleTierArm would produce for an
+// irate() call — DownsampleTier: true, DownsampleTierInput scanning the
+// tier table directly (the isolated chDB database holds exactly the one row
+// seedDownsampleTierGaugeSentinelRow wrote, so no MetricName filter is
+// needed to isolate it).
+func downsampleTierGaugeSentinelWindow() *chplan.RangeWindow {
+	return &chplan.RangeWindow{
+		DownsampleTier:      true,
+		DownsampleTierInput: &chplan.Scan{Table: schema.DownsampleTierTable},
+		Func:                "irate",
+		Range:               schema.DownsampleTierBucket,
+		Step:                schema.DownsampleTierBucket,
+		Start:               downsampleTierGaugeSentinelAnchor,
+		End:                 downsampleTierGaugeSentinelAnchor,
+		TimestampColumn:     "TimeUnix",
+		ValueColumn:         "Value",
+		GroupBy:             []chplan.Expr{&chplan.ColumnRef{Name: "Attributes"}},
+	}
+}
+
+func TestDownsampleTierGaugeSentinelTemporality_TakesSafeBranch(t *testing.T) {
+	db := chsqltest.OpenIsolatedChDB(t)
+	downsampleTierGaugeSentinelDDL(t, db)
+	seedDownsampleTierGaugeSentinelRow(t, db)
+
+	sqlText, args, err := Emit(context.Background(), downsampleTierGaugeSentinelWindow())
+	if err != nil {
+		t.Fatalf("Emit: %v", err)
+	}
+	wrapped := "SELECT `Value` FROM (" + sqlText + ")"
+	rows, err := db.Query(wrapped, args...)
+	if err != nil {
+		t.Fatalf("query: %v\nSQL: %s", err, wrapped)
+	}
+	defer func() { _ = rows.Close() }()
+	var value float64
+	got := false
+	for rows.Next() {
+		if got {
+			t.Fatal("expected exactly one row")
+		}
+		if err := rows.Scan(&value); err != nil {
+			t.Fatalf("scan: %v", err)
+		}
+		got = true
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatalf("rows: %v", err)
+	}
+	if !got {
+		t.Fatal("expected exactly one row, got none")
+	}
+
+	const interval = 120.0 // seconds between 00:01:00 and 00:03:00
+	wantNotDelta := 15.0 / interval
+	wantDelta := 45.0 / interval
+	if math.Abs(value-wantDelta) < 1e-12 {
+		t.Fatalf("value=%v took the DELTA branch (raw curr alone) — the sentinel %d was misread as "+
+			"schema.AggregationTemporalityDelta (%d)", value, schema.DownsampleTierGaugeTemporalitySentinel, schema.AggregationTemporalityDelta)
+	}
+	if math.Abs(value-wantNotDelta) > 1e-12 {
+		t.Fatalf("value=%v; want %v (the counter-reset-aware curr-prev branch, matching a nil-temporality Gauge read)", value, wantNotDelta)
+	}
+}

--- a/internal/chsql/range_window_downsample_tier_gauge_chdb_test.go
+++ b/internal/chsql/range_window_downsample_tier_gauge_chdb_test.go
@@ -1,0 +1,316 @@
+//go:build chdb
+
+// chDB-backed correctness proof for the Gauge-sourced extension of the
+// downsampled long-range tier (cerberus issue #2858, following #2751 /
+// #2857): internal/schema/ddl's real renderDownsampleTierGaugeView DDL,
+// folding otel_metrics_gauge into the SAME schema.DownsampleTierTable
+// #2751's Sum-sourced MV already feeds, run end to end against a real
+// ClickHouse engine (chDB) — mirroring range_window_downsample_tier_chdb_test.go's
+// own approach for the Sum-only v1.
+//
+// Three properties this file proves empirically:
+//
+//  1. last_over_time() over a Gauge-table metric routes to the tier and
+//     agrees EXACTLY with the ordinary fan-out reading the SAME raw
+//     otel_metrics_gauge rows — see TestDownsampleTierGauge_ChdbCorrectness.
+//  2. irate() / idelta() over the SAME Gauge-table metric, with the SAME
+//     tier lowerers wired, do NOT route to the tier at all: the emitted SQL
+//     never references schema.DownsampleTierTable, and the query still
+//     executes correctly via the ordinary fan-out — see
+//     TestDownsampleTierGauge_IrateIdeltaNeverRouteToTier.
+//  3. The chosen design (a shared tier table fed by two independent MVs,
+//     rather than two physical tier tables) leaves the pre-existing
+//     Sum-table irate()/idelta()/last_over_time() behaviour completely
+//     unaffected — see TestDownsampleTierGauge_SumPathUnaffected.
+package chsql_test
+
+import (
+	"context"
+	"database/sql"
+	"math"
+	"strings"
+	"testing"
+	"time"
+
+	promparser "github.com/prometheus/prometheus/promql/parser"
+
+	"github.com/tsouza/cerberus/internal/chclient"
+	"github.com/tsouza/cerberus/internal/chsql"
+	"github.com/tsouza/cerberus/internal/chsqltest"
+	"github.com/tsouza/cerberus/internal/optimizer"
+	"github.com/tsouza/cerberus/internal/promql"
+	"github.com/tsouza/cerberus/internal/schema"
+	"github.com/tsouza/cerberus/internal/schema/ddl"
+)
+
+// downsampleTierGaugeBucketAnchor mirrors downsampleTierBucketAnchor
+// (range_window_downsample_tier_chdb_test.go) — the single query_range
+// anchor every scenario below evaluates at.
+var downsampleTierGaugeBucketAnchor = time.Date(2024, 6, 1, 0, 5, 0, 0, time.UTC)
+
+// downsampleTierGaugeChdbSetup mirrors downsampleTierChdbSetup, provisioning
+// the REAL DDL (both the Sum-sourced and Gauge-sourced MVs, since
+// DownsampleTierEnabled gates the whole feature — internal/schema/ddl's
+// RenderAll) inside db's isolated database.
+func downsampleTierGaugeChdbSetup(t *testing.T, db *sql.DB) {
+	t.Helper()
+	if _, err := db.Exec("SET " + chclient.SettingExperimentalTSGridAggregate + " = 1"); err != nil {
+		t.Fatalf("enable experimental ts-grid: %v", err)
+	}
+	var currentDB string
+	if err := db.QueryRow("SELECT currentDatabase()").Scan(&currentDB); err != nil {
+		t.Fatalf("read currentDatabase(): %v", err)
+	}
+	cfg := ddl.Config{Database: currentDB, SkipDatabaseCreate: true, DownsampleTierEnabled: true}
+	stmts, err := ddl.RenderAll(cfg, []ddl.Signal{ddl.Metrics})
+	if err != nil {
+		t.Fatalf("ddl.RenderAll: %v", err)
+	}
+	for _, stmt := range stmts {
+		if _, err := db.Exec(stmt); err != nil {
+			t.Fatalf("exec DDL: %v\n--- stmt ---\n%s", err, stmt)
+		}
+	}
+}
+
+// downsampleTierGaugeSample is one raw (host, ts, value) row
+// downsampleTierGaugeSeed inserts into otel_metrics_gauge — no temporality
+// field: a Gauge sample has no AggregationTemporality column at all.
+type downsampleTierGaugeSample struct {
+	host  string
+	ts    time.Time
+	value float64
+}
+
+// downsampleTierGaugeSeed mirrors downsampleTierSeed's shape for a Gauge
+// metric: a normal two-sample pair, a single-sample host, a bucket gap, and
+// a boundary-exact sample proving the Gauge MV shares the SAME
+// downsampleTierBucketEndExpr ceiling-bucket convention the Sum MV uses.
+var downsampleTierGaugeSeed = []downsampleTierGaugeSample{
+	// "normal": two samples in [00:00,00:05], last_over_time must report
+	// the LATER one (150).
+	{"normal", time.Date(2024, 6, 1, 0, 1, 0, 0, time.UTC), 100},
+	{"normal", time.Date(2024, 6, 1, 0, 3, 0, 0, time.UTC), 150},
+	// "boundary": a boundary-exact sample AT 00:05:00 itself must join
+	// THIS bucket (ending at 00:05:00), not the next one.
+	{"boundary", downsampleTierGaugeBucketAnchor, 42},
+	// "single": exactly one raw sample — last_over_time must still answer.
+	{"single", time.Date(2024, 6, 1, 0, 2, 0, 0, time.UTC), 77},
+	// "gap": no rows in THIS bucket, present in the next one only.
+	{"gap", time.Date(2024, 6, 1, 0, 6, 0, 0, time.UTC), 999},
+}
+
+func insertDownsampleTierGaugeSamples(t *testing.T, db *sql.DB, samples []downsampleTierGaugeSample) {
+	t.Helper()
+	for _, s := range samples {
+		_, err := db.Exec(
+			`INSERT INTO otel_metrics_gauge (MetricName, Attributes, TimeUnix, Value) VALUES (?, map('host', ?), ?, ?)`,
+			"cpu_temperature", s.host, s.ts, s.value,
+		)
+		if err != nil {
+			t.Fatalf("insert host=%s ts=%s: %v", s.host, s.ts, err)
+		}
+	}
+}
+
+// downsampleTierGaugeOnlySchema returns schema.DefaultOTelMetrics() with
+// SumTable cleared. An UNSUFFIXED metric name like "cpu_temperature" is
+// otherwise ambiguous (schema.Metrics.TablesForUnknownName's own doc: it
+// deliberately fans across BOTH Gauge and Sum, so the hostmetrics-style
+// cumulative-sum-under-a-bare-name shape isn't silently dropped) — the SAME
+// pre-existing restriction that already keeps an unsuffixed COUNTER metric
+// out of irate()/idelta()'s own tier eligibility (#2751/#1628: only a
+// `_total`-suffixed name resolves unambiguously to Sum). Clearing SumTable
+// collapses TablesForUnknownName to [GaugeTable] alone, giving
+// rangeVectorSingleGaugeTable (internal/promql/lower.go, cerberus issue
+// #2858) the unambiguous resolution its eligibility check requires — the
+// realistic deployment shape this proves against is a Gauge-only (no Sum
+// table) metrics source, mirroring the Sum-only restriction's own precedent
+// rather than introducing a new one.
+func downsampleTierGaugeOnlySchema() schema.Metrics {
+	m := schema.DefaultOTelMetrics()
+	m.SumTable = ""
+	return m
+}
+
+// runDownsampleTierGaugeQuery mirrors runDownsampleTierPromQL: lowers query
+// against s at the single downsampleTierGaugeBucketAnchor grid point, emits
+// it, runs it against db, and returns (host -> value, emitted SQL text).
+func runDownsampleTierGaugeQuery(t *testing.T, db *sql.DB, s schema.Metrics, query string, tierRouted bool) (map[string]float64, string) {
+	t.Helper()
+	p := promparser.NewParser(promparser.Options{EnableExperimentalFunctions: true})
+	expr, err := p.ParseExpr(query)
+	if err != nil {
+		t.Fatalf("parse %q: %v", query, err)
+	}
+	var lowerers promql.RangeLowerers
+	if tierRouted {
+		lowerers = downsampleTierLowererTable()
+	}
+	plan, err := promql.LowerAtRangeOpts(context.Background(), expr, s,
+		downsampleTierGaugeBucketAnchor, downsampleTierGaugeBucketAnchor, schema.DownsampleTierBucket,
+		promql.LowerOpts{Lowerers: lowerers})
+	if err != nil {
+		t.Fatalf("lower %q (tierRouted=%v): %v", query, tierRouted, err)
+	}
+	plan = optimizer.Default().Run(context.Background(), plan)
+	sqlText, args, err := chsql.Emit(context.Background(), plan)
+	if err != nil {
+		t.Fatalf("emit %q (tierRouted=%v): %v", query, tierRouted, err)
+	}
+	wrapped := "SELECT toJSONString(`Attributes`) AS host_json, `Value` FROM (" + sqlText + ")"
+	rows, err := db.Query(wrapped, args...)
+	if err != nil {
+		t.Fatalf("query %q (tierRouted=%v): %v\nSQL: %s", query, tierRouted, err, wrapped)
+	}
+	defer func() { _ = rows.Close() }()
+	out := make(map[string]float64)
+	for rows.Next() {
+		var hostJSON string
+		var value float64
+		if err := rows.Scan(&hostJSON, &value); err != nil {
+			t.Fatalf("scan: %v", err)
+		}
+		out[hostFromJSON(t, hostJSON)] = value
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatalf("rows: %v", err)
+	}
+	return out, sqlText
+}
+
+// TestDownsampleTierGauge_ChdbCorrectness proves last_over_time() over a
+// Gauge-table metric routes to the tier (via renderDownsampleTierGaugeView's
+// real MV) and agrees exactly with the ordinary fan-out over the SAME raw
+// rows — the Gauge-sourced counterpart of TestDownsampleTier_ChdbCorrectness.
+func TestDownsampleTierGauge_ChdbCorrectness(t *testing.T) {
+	db := chsqltest.OpenIsolatedChDB(t)
+	downsampleTierGaugeChdbSetup(t, db)
+	insertDownsampleTierGaugeSamples(t, db, downsampleTierGaugeSeed)
+
+	s := downsampleTierGaugeOnlySchema()
+	const lastQuery = `last_over_time(cpu_temperature[5m])`
+	tier, tierSQL := runDownsampleTierGaugeQuery(t, db, s, lastQuery, true)
+	fanout, _ := runDownsampleTierGaugeQuery(t, db, s, lastQuery, false)
+
+	if !strings.Contains(tierSQL, schema.DownsampleTierTable) {
+		t.Fatalf("last_over_time() over a Gauge metric did not route to the tier — SQL:\n%s", tierSQL)
+	}
+
+	for host, fv := range fanout {
+		tv, ok := tier[host]
+		if !ok {
+			t.Errorf("host=%s: present in fan-out (%v) but ABSENT from tier route", host, fv)
+			continue
+		}
+		if math.Float64bits(tv) != math.Float64bits(fv) {
+			t.Errorf("host=%s: tier=%.20g fanout=%.20g NOT bit-identical", host, tv, fv)
+		}
+	}
+	if len(tier) != len(fanout) {
+		t.Errorf("row-count divergence: tier=%d fanout=%d\ntier=%v\nfanout=%v", len(tier), len(fanout), tier, fanout)
+	}
+
+	wantLast := map[string]float64{
+		"normal":   150, // the LATER of the two in-window samples
+		"boundary": 42,  // boundary-exact sample joins THIS bucket
+		"single":   77,  // a single sample is enough for last_over_time
+	}
+	for host, want := range wantLast {
+		got, ok := tier[host]
+		if !ok {
+			t.Errorf("host=%s: expected present, got absent", host)
+			continue
+		}
+		if got != want {
+			t.Errorf("host=%s: want %v, got %v", host, want, got)
+		}
+	}
+	if _, ok := tier["gap"]; ok {
+		t.Error("host=gap: expected absent (no data in this bucket), got a value")
+	}
+}
+
+// TestDownsampleTierGauge_IrateIdeltaNeverRouteToTier is the negative test
+// cerberus issue #2858 explicitly calls for: irate()/idelta() over a
+// Gauge-table metric — a gauge has no counter-reset semantics for either —
+// must NOT route to the tier even with the SAME tier lowerers wired that
+// correctly route last_over_time() for the identical metric above. Checked
+// structurally (the emitted SQL never references schema.DownsampleTierTable)
+// AND empirically (the query still executes correctly via the ordinary
+// fan-out, matching a baseline run with NO tier lowerers wired at all).
+func TestDownsampleTierGauge_IrateIdeltaNeverRouteToTier(t *testing.T) {
+	db := chsqltest.OpenIsolatedChDB(t)
+	downsampleTierGaugeChdbSetup(t, db)
+	insertDownsampleTierGaugeSamples(t, db, downsampleTierGaugeSeed)
+
+	s := downsampleTierGaugeOnlySchema()
+	for _, query := range []string{`irate(cpu_temperature[5m])`, `idelta(cpu_temperature[5m])`} {
+		tierWired, sqlText := runDownsampleTierGaugeQuery(t, db, s, query, true)
+		if strings.Contains(sqlText, schema.DownsampleTierTable) {
+			t.Errorf("%s: SQL references %s even though a gauge must never route to it:\n%s", query, schema.DownsampleTierTable, sqlText)
+		}
+		noLowerers, _ := runDownsampleTierGaugeQuery(t, db, s, query, false)
+		if len(tierWired) != len(noLowerers) {
+			t.Errorf("%s: row-count differs between tier-lowerers-wired (%d) and no-lowerers (%d) runs — "+
+				"a gauge metric's routing must be identical either way", query, len(tierWired), len(noLowerers))
+		}
+		for host, want := range noLowerers {
+			got, ok := tierWired[host]
+			if !ok {
+				t.Errorf("%s host=%s: present without tier lowerers (%v) but absent with them wired", query, host, want)
+				continue
+			}
+			if math.Float64bits(got) != math.Float64bits(want) {
+				t.Errorf("%s host=%s: tier-lowerers-wired=%.20g no-lowerers=%.20g NOT bit-identical", query, host, got, want)
+			}
+		}
+	}
+}
+
+// TestDownsampleTierGauge_SumPathUnaffected confirms the Gauge-sourced MV
+// addition (cerberus issue #2858) leaves the pre-existing Sum-table
+// irate()/idelta()/last_over_time() tier routing (#2751/#2857) completely
+// unaffected: a counter metric, seeded ALONGSIDE the gauge metric in the
+// SAME database (both MVs live), still answers exactly as
+// TestDownsampleTier_ChdbCorrectness proves it does in isolation.
+func TestDownsampleTierGauge_SumPathUnaffected(t *testing.T) {
+	db := chsqltest.OpenIsolatedChDB(t)
+	downsampleTierGaugeChdbSetup(t, db)
+
+	// A counter metric (Sum table) alongside the gauge fixtures above —
+	// proving the two MVs coexist without cross-contamination.
+	insertDownsampleTierGaugeSamples(t, db, downsampleTierGaugeSeed)
+	if _, err := db.Exec(
+		`INSERT INTO otel_metrics_sum (MetricName, Attributes, TimeUnix, Value, AggregationTemporality) VALUES
+		 ('cpu_seconds_total', map('host', 'counter'), ?, 100, 2),
+		 ('cpu_seconds_total', map('host', 'counter'), ?, 150, 2)`,
+		time.Date(2024, 6, 1, 0, 1, 0, 0, time.UTC), time.Date(2024, 6, 1, 0, 3, 0, 0, time.UTC),
+	); err != nil {
+		t.Fatalf("insert counter samples: %v", err)
+	}
+
+	const irateQuery = `irate(cpu_seconds_total[5m])`
+	s := schema.DefaultOTelMetrics()
+	tier, sqlText := runDownsampleTierGaugeQuery(t, db, s, irateQuery, true)
+	fanout, _ := runDownsampleTierGaugeQuery(t, db, s, irateQuery, false)
+
+	if !strings.Contains(sqlText, schema.DownsampleTierTable) {
+		t.Fatalf("irate() over the Sum-table counter did not route to the tier — SQL:\n%s", sqlText)
+	}
+	tv, ok := tier["counter"]
+	if !ok {
+		t.Fatal("host=counter: expected present in tier route, got absent")
+	}
+	fv, ok := fanout["counter"]
+	if !ok {
+		t.Fatal("host=counter: expected present in fan-out, got absent")
+	}
+	if math.Float64bits(tv) != math.Float64bits(fv) {
+		t.Errorf("host=counter: tier=%.20g fanout=%.20g NOT bit-identical", tv, fv)
+	}
+	const want = 50.0 / 120 // (150-100)/120s, no reset
+	if math.Abs(tv-want) > 1e-12 {
+		t.Errorf("host=counter: want %v, got %v", want, tv)
+	}
+}

--- a/internal/downsampletier/doc.go
+++ b/internal/downsampletier/doc.go
@@ -7,6 +7,17 @@
 // composition + result diffing is unit testable without a live ClickHouse
 // connection (see Conn).
 //
+// # Two source tables, one target table
+//
+// The tier folds TWO raw source tables (cerberus issue #2858 added the
+// Gauge table alongside #2751's original Sum table — see downsampleTierSources)
+// into the SAME schema.DownsampleTierTable, mirroring internal/schema/ddl's
+// two independent materialized views into that one AggregatingMergeTree.
+// Every function in this package that reads or writes "the base table" —
+// Backfill, Rebuild, Verify — actually does so once per configured source,
+// via downsampleTierSources; BackfillSQL / RebuildSQL return one Statement
+// per source for the same reason.
+//
 // # Why a backfill is needed at all
 //
 // Exactly the same reason as internal/deltaprefix's own doc: `CREATE

--- a/internal/downsampletier/downsampletier.go
+++ b/internal/downsampletier/downsampletier.go
@@ -81,10 +81,18 @@ func withCaps(ctx context.Context) context.Context {
 // backfill + rebuild + verify queries reference. Unlike
 // internal/deltaprefix.Columns, the tier table/column names are FIXED
 // schema.DownsampleTier* constants (see that package's doc for why), so
-// only the database + base Sum table name vary by deployment.
+// only the database + base source table names vary by deployment.
+//
+// GaugeTable is the second source this package folds into the tier
+// (cerberus issue #2858), alongside SumTable — mirroring
+// internal/schema/ddl's two-MV shape (renderDownsampleTierView +
+// renderDownsampleTierGaugeView). See downsampleTierSources for how the two
+// combine, and for why a deployment where GaugeTable equals SumTable folds
+// only once.
 type Columns struct {
 	Database                     string
 	SumTable                     string
+	GaugeTable                   string
 	MetricNameColumn             string
 	AttributesColumn             string
 	ResourceAttributesColumn     string
@@ -101,6 +109,7 @@ func FromSchema(database string, m schema.Metrics) Columns {
 	return Columns{
 		Database:                     database,
 		SumTable:                     m.SumTable,
+		GaugeTable:                   m.GaugeTable,
 		MetricNameColumn:             m.MetricNameColumn,
 		AttributesColumn:             m.AttributesColumn,
 		ResourceAttributesColumn:     m.ResourceAttributesColumn,
@@ -109,6 +118,52 @@ func FromSchema(database string, m schema.Metrics) Columns {
 		ValueColumn:                  m.ValueColumn,
 		AggregationTemporalityColumn: m.AggregationTemporalityColumn,
 	}
+}
+
+// downsampleTierSource is one physical raw table this package folds into the
+// shared tier table, paired with the Temporality expression its own
+// backfillSelectSQL projects for it — the SAME (table, temporality-expr)
+// pairing internal/schema/ddl's renderDownsampleTierView /
+// renderDownsampleTierGaugeView use on the live-MV side, reproduced here for
+// the SAME "leaf packages can't share one helper" reason bucketEndExpr's own
+// doc gives.
+type downsampleTierSource struct {
+	table       string
+	temporality chsql.Frag
+}
+
+// downsampleTierSources returns the source(s) Backfill/Rebuild/Verify fold
+// into (or read completeness counts against): the Sum table always, and the
+// Gauge table too (cerberus issue #2858) UNLESS it is configured identically
+// to the Sum table. In that configuration the Sum source's own scan already
+// covers every row the Gauge source would otherwise re-read from the SAME
+// physical table — re-scanning it a second time would double-write every
+// bucket, mirroring the identical guard renderDownsampleTierGaugeView's own
+// doc explains on the live-MV side.
+func downsampleTierSources(c Columns) []downsampleTierSource {
+	sources := []downsampleTierSource{
+		{table: c.SumTable, temporality: chsql.Call("any", chsql.Col(c.AggregationTemporalityColumn))},
+	}
+	if c.GaugeTable != "" && c.GaugeTable != c.SumTable {
+		sources = append(sources, downsampleTierSource{
+			table:       c.GaugeTable,
+			temporality: chsql.InlineLit(schema.DownsampleTierGaugeTemporalitySentinel),
+		})
+	}
+	return sources
+}
+
+// SourceTables returns the base table name(s) Backfill/Rebuild/Verify fold
+// into or read completeness counts against — cmd/cerberus's own
+// user-facing messages name these rather than hard-coding "the Sum table"
+// (cerberus issue #2858: that used to be the only source).
+func SourceTables(c Columns) []string {
+	srcs := downsampleTierSources(c)
+	names := make([]string, len(srcs))
+	for i, src := range srcs {
+		names[i] = src.table
+	}
+	return names
 }
 
 // bucketEndExpr renders the SAME ceiling bucket-boundary expression
@@ -130,8 +185,12 @@ func bucketSeconds() int64 { return int64(schema.DownsampleTierBucket / time.Sec
 
 // backfillSelectSQL renders the SELECT half shared by BackfillSQL (bounded
 // by `before`) and RebuildSQL (unbounded, the full history) — factored out
-// so the two statements cannot drift on the GROUP BY / projection shape.
-func backfillSelectSQL(c Columns, before *time.Time) *chsql.QueryBuilder {
+// so the statements for every source (downsampleTierSources) cannot drift
+// on the GROUP BY / projection shape. src picks the FROM table and the
+// Temporality expression (a real any(AggregationTemporality) for the Sum
+// source, the fixed sentinel literal for the Gauge source — see
+// downsampleTierSources).
+func backfillSelectSQL(c Columns, src downsampleTierSource, before *time.Time) *chsql.QueryBuilder {
 	bucket := bucketEndExpr(c.TimestampColumn)
 	q := chsql.NewQuery().
 		Select(
@@ -141,9 +200,9 @@ func backfillSelectSQL(c Columns, before *time.Time) *chsql.QueryBuilder {
 			chsql.Col(c.ServiceNameColumn),
 			chsql.As(bucket, schema.DownsampleTierBucketColumn),
 			chsql.As(chsql.Call("timeSeriesLastTwoSamplesState", chsql.Col(c.TimestampColumn), chsql.Col(c.ValueColumn)), schema.DownsampleTierSamplesColumn),
-			chsql.As(chsql.Call("any", chsql.Col(c.AggregationTemporalityColumn)), schema.DownsampleTierTemporalityColumn),
+			chsql.As(src.temporality, schema.DownsampleTierTemporalityColumn),
 		).
-		From(chsql.Qual(c.Database, c.SumTable))
+		From(chsql.Qual(c.Database, src.table))
 	if before != nil {
 		q = q.Where(chsql.Lt(chsql.Col(c.TimestampColumn), chsql.Lit(*before)))
 	}
@@ -165,21 +224,47 @@ func tierColumns(c Columns) []string {
 	}
 }
 
-// BackfillSQL renders the one-time `INSERT INTO ... SELECT` that populates
-// the tier table for c.SumTable history strictly older than before — the
-// MV's own exact creation instant (see internal/deltaprefix's package doc
-// for why an exact instant, never a calendar-day-rounded one). Mirrors
-// internal/deltaprefix.BackfillSQL's own bound discipline exactly.
-func BackfillSQL(c Columns, before time.Time) (string, []any) {
-	return chsql.InsertSelect(c.Database, schema.DownsampleTierTable, tierColumns(c), backfillSelectSQL(c, &before)).Build()
+// Statement is one rendered SQL text plus its positional args — BackfillSQL
+// / RebuildSQL return one per downsampleTierSources(c) entry (cerberus issue
+// #2858: previously always exactly one, the Sum table; now also the Gauge
+// table unless it collapses onto the Sum table). Two straightforward
+// single-source INSERT statements, rather than one UNION ALL statement,
+// mirror the two-independent-MV shape internal/schema/ddl provisions
+// (renderDownsampleTierView + renderDownsampleTierGaugeView) 1:1 — an
+// operator inspecting --dry-run output sees exactly the two statements the
+// live MVs themselves logically perform.
+type Statement struct {
+	SQL  string
+	Args []any
 }
 
-// RebuildSQL renders the FULL, unbounded `INSERT INTO ... SELECT` a Rebuild
-// issues after truncating the tier table (see this package's doc for why a
-// full rebuild — not just an incremental backfill — is the recovery path
-// for a suspected stranded/incompatible persisted state).
-func RebuildSQL(c Columns) (string, []any) {
-	return chsql.InsertSelect(c.Database, schema.DownsampleTierTable, tierColumns(c), backfillSelectSQL(c, nil)).Build()
+// BackfillSQL renders the one-time `INSERT INTO ... SELECT` statement(s)
+// that populate the tier table for history strictly older than before — the
+// relevant MV's own exact creation instant (see internal/deltaprefix's
+// package doc for why an exact instant, never a calendar-day-rounded one).
+// Mirrors internal/deltaprefix.BackfillSQL's own bound discipline exactly,
+// once per downsampleTierSources(c) entry.
+func BackfillSQL(c Columns, before time.Time) []Statement {
+	var stmts []Statement
+	for _, src := range downsampleTierSources(c) {
+		sql, args := chsql.InsertSelect(c.Database, schema.DownsampleTierTable, tierColumns(c), backfillSelectSQL(c, src, &before)).Build()
+		stmts = append(stmts, Statement{SQL: sql, Args: args})
+	}
+	return stmts
+}
+
+// RebuildSQL renders the FULL, unbounded `INSERT INTO ... SELECT`
+// statement(s) a Rebuild issues after truncating the tier table (see this
+// package's doc for why a full rebuild — not just an incremental backfill —
+// is the recovery path for a suspected stranded/incompatible persisted
+// state), once per downsampleTierSources(c) entry.
+func RebuildSQL(c Columns) []Statement {
+	var stmts []Statement
+	for _, src := range downsampleTierSources(c) {
+		sql, args := chsql.InsertSelect(c.Database, schema.DownsampleTierTable, tierColumns(c), backfillSelectSQL(c, src, nil)).Build()
+		stmts = append(stmts, Statement{SQL: sql, Args: args})
+	}
+	return stmts
 }
 
 // TruncateSQL renders the `TRUNCATE TABLE` Rebuild issues before its full
@@ -202,17 +287,19 @@ func retentionBoundary(now time.Time, retention time.Duration) (boundary time.Ti
 }
 
 // outsideRetentionDaysSQL renders the DISTINCT bucket-boundary read against
-// the base table's own history, restricted to Backfill's own `[-inf,
+// one source table's own history, restricted to Backfill's own `[-inf,
 // before)` scope AND already past the tier table's retention as of
 // boundary — the tier's analogue of internal/deltaprefix's own
 // outsideRetentionDaysSQL (cerberus issue #2652's finding, reproduced here
-// rather than re-derived: this table shares the base Sum table's TTL, see
-// internal/schema/ddl's renderDownsampleTierTable).
-func outsideRetentionDaysSQL(c Columns, before, boundary time.Time) (string, []any) {
+// rather than re-derived: this table shares the base table's TTL, see
+// internal/schema/ddl's renderDownsampleTierTable). source is a
+// downsampleTierSources(c) entry's table (cerberus issue #2858: previously
+// always c.SumTable).
+func outsideRetentionDaysSQL(c Columns, source string, before, boundary time.Time) (string, []any) {
 	bucket := bucketEndExpr(c.TimestampColumn)
 	q := chsql.NewQuery().
 		Select(bucket).
-		From(chsql.Qual(c.Database, c.SumTable)).
+		From(chsql.Qual(c.Database, source)).
 		Where(
 			chsql.Lt(chsql.Col(c.TimestampColumn), chsql.Lit(before)),
 			chsql.Lt(bucket, chsql.Lit(boundary)),
@@ -222,24 +309,40 @@ func outsideRetentionDaysSQL(c Columns, before, boundary time.Time) (string, []a
 	return q.Build()
 }
 
+// queryOutsideRetentionDays unions the outside-retention bucket days across
+// EVERY configured source (cerberus issue #2858: previously just the Sum
+// table) — a day reported by either source's own history is worth warning
+// the operator about, so the result is the set union, de-duplicated and
+// sorted ascending exactly like the single-source result used to come back
+// from ClickHouse's own ORDER BY.
 func queryOutsideRetentionDays(ctx context.Context, conn Conn, c Columns, before, boundary time.Time) ([]time.Time, error) {
-	sql, args := outsideRetentionDaysSQL(c, before, boundary)
-	rows, err := conn.Query(withCaps(ctx), sql, args...)
-	if err != nil {
-		return nil, err
-	}
-	defer func() { _ = rows.Close() }()
-	var days []time.Time
-	for rows.Next() {
-		var day time.Time
-		if err := rows.Scan(&day); err != nil {
-			return nil, err
+	seen := map[time.Time]struct{}{}
+	for _, src := range downsampleTierSources(c) {
+		sql, args := outsideRetentionDaysSQL(c, src.table, before, boundary)
+		rows, err := conn.Query(withCaps(ctx), sql, args...)
+		if err != nil {
+			return nil, fmt.Errorf("downsampletier: check retention window against %s: %w", src.table, err)
 		}
-		days = append(days, day)
+		scanErr := func() error {
+			defer func() { _ = rows.Close() }()
+			for rows.Next() {
+				var day time.Time
+				if err := rows.Scan(&day); err != nil {
+					return err
+				}
+				seen[day] = struct{}{}
+			}
+			return rows.Err()
+		}()
+		if scanErr != nil {
+			return nil, fmt.Errorf("downsampletier: check retention window against %s: %w", src.table, scanErr)
+		}
 	}
-	if err := rows.Err(); err != nil {
-		return nil, err
+	days := make([]time.Time, 0, len(seen))
+	for d := range seen {
+		days = append(days, d)
 	}
+	sort.Slice(days, func(i, j int) bool { return days[i].Before(days[j]) })
 	return days, nil
 }
 
@@ -260,12 +363,13 @@ func Backfill(ctx context.Context, conn Conn, c Columns, before time.Time, reten
 		var err error
 		outsideDays, err = queryOutsideRetentionDays(ctx, conn, c, before, boundary)
 		if err != nil {
-			return Result{}, fmt.Errorf("downsampletier: check retention window against %s: %w", c.SumTable, err)
+			return Result{}, err
 		}
 	}
-	sql, args := BackfillSQL(c, before)
-	if err := conn.Exec(withCaps(ctx), sql, args...); err != nil {
-		return Result{}, fmt.Errorf("downsampletier: backfill %s: %w", schema.DownsampleTierTable, err)
+	for _, stmt := range BackfillSQL(c, before) {
+		if err := conn.Exec(withCaps(ctx), stmt.SQL, stmt.Args...); err != nil {
+			return Result{}, fmt.Errorf("downsampletier: backfill %s: %w", schema.DownsampleTierTable, err)
+		}
 	}
 	return Result{OutsideRetentionDays: outsideDays}, nil
 }
@@ -287,15 +391,16 @@ func Rebuild(ctx context.Context, conn Conn, c Columns, retention time.Duration)
 		// entire currently-retained history.
 		outsideDays, err = queryOutsideRetentionDays(ctx, conn, c, nowFunc(), boundary)
 		if err != nil {
-			return Result{}, fmt.Errorf("downsampletier: check retention window against %s: %w", c.SumTable, err)
+			return Result{}, err
 		}
 	}
 	if err := conn.Exec(withCaps(ctx), TruncateSQL(c)); err != nil {
 		return Result{}, fmt.Errorf("downsampletier: truncate %s: %w", schema.DownsampleTierTable, err)
 	}
-	sql, args := RebuildSQL(c)
-	if err := conn.Exec(withCaps(ctx), sql, args...); err != nil {
-		return Result{}, fmt.Errorf("downsampletier: rebuild %s: %w", schema.DownsampleTierTable, err)
+	for _, stmt := range RebuildSQL(c) {
+		if err := conn.Exec(withCaps(ctx), stmt.SQL, stmt.Args...); err != nil {
+			return Result{}, fmt.Errorf("downsampletier: rebuild %s: %w", schema.DownsampleTierTable, err)
+		}
 	}
 	return Result{OutsideRetentionDays: outsideDays}, nil
 }
@@ -306,8 +411,9 @@ func Rebuild(ctx context.Context, conn Conn, c Columns, retention time.Duration)
 // like internal/deltaprefix.Verify's sum comparison. See this package's doc
 // for why: the tier's read-side failure mode for a missing bucket is a safe
 // absent series point, never a wrong number, so there is no aggregate total
-// to parity-check in the first place.
-func baseBucketsSQL(c Columns, before, boundary time.Time, retentionActive bool) (string, []any) {
+// to parity-check in the first place. source is a downsampleTierSources(c)
+// entry's table (cerberus issue #2858: previously always c.SumTable).
+func baseBucketsSQL(c Columns, source string, before, boundary time.Time, retentionActive bool) (string, []any) {
 	bucket := bucketEndExpr(c.TimestampColumn)
 	conds := []chsql.Frag{chsql.Lt(chsql.Col(c.TimestampColumn), chsql.Lit(before))}
 	if retentionActive {
@@ -315,10 +421,36 @@ func baseBucketsSQL(c Columns, before, boundary time.Time, retentionActive bool)
 	}
 	q := chsql.NewQuery().
 		Select(chsql.Col(c.MetricNameColumn), chsql.As(chsql.Call("uniqExact", bucket), "n")).
-		From(chsql.Qual(c.Database, c.SumTable)).
+		From(chsql.Qual(c.Database, source)).
 		Where(conds...).
 		GroupBy(chsql.Col(c.MetricNameColumn))
 	return q.Build()
+}
+
+// baseBucketCounts merges per-metric-name DISTINCT bucket counts across
+// EVERY configured source (cerberus issue #2858: previously always just the
+// Sum table) — summed rather than deduped, since a metric name is expected
+// to live in exactly one source table (the same "one name -> one table"
+// invariant internal/promql's tier-routing eligibility relies on, via
+// resolveUnambiguousScanTable's single-table requirement). A name that
+// somehow existed in both would double count here, but such a name could
+// never route to the tier for either irate()/idelta() (Sum-only) or
+// last_over_time() (its own unambiguous-Gauge-table gate) in the first
+// place, so this completeness check does not need to defend against it any
+// harder than the read path already does.
+func baseBucketCounts(ctx context.Context, conn Conn, c Columns, before, boundary time.Time, retentionActive bool) (map[string]int64, error) {
+	out := map[string]int64{}
+	for _, src := range downsampleTierSources(c) {
+		sql, args := baseBucketsSQL(c, src.table, before, boundary, retentionActive)
+		counts, err := scanCounts(ctx, conn, sql, args)
+		if err != nil {
+			return nil, fmt.Errorf("downsampletier: read %s bucket counts: %w", src.table, err)
+		}
+		for name, n := range counts {
+			out[name] += n
+		}
+	}
+	return out, nil
 }
 
 func tierBucketsSQL(c Columns, before, boundary time.Time, retentionActive bool) (string, []any) {
@@ -383,14 +515,13 @@ func Verify(ctx context.Context, conn Conn, c Columns, before time.Time, retenti
 		var err error
 		outsideDays, err = queryOutsideRetentionDays(ctx, conn, c, before, boundary)
 		if err != nil {
-			return Report{}, fmt.Errorf("downsampletier: check retention window against %s: %w", c.SumTable, err)
+			return Report{}, err
 		}
 	}
 
-	baseSQL, baseArgs := baseBucketsSQL(c, before, boundary, active)
-	base, err := scanCounts(ctx, conn, baseSQL, baseArgs)
+	base, err := baseBucketCounts(ctx, conn, c, before, boundary, active)
 	if err != nil {
-		return Report{}, fmt.Errorf("downsampletier: read %s bucket counts: %w", c.SumTable, err)
+		return Report{}, err
 	}
 	tierSQL, tierArgs := tierBucketsSQL(c, before, boundary, active)
 	tier, err := scanCounts(ctx, conn, tierSQL, tierArgs)

--- a/internal/downsampletier/downsampletier_test.go
+++ b/internal/downsampletier/downsampletier_test.go
@@ -21,13 +21,20 @@ func testColumns() Columns {
 
 var testBefore = time.Date(2026, 8, 20, 12, 30, 0, 0, time.UTC)
 
-// TestBackfillSQL pins the rendered INSERT ... SELECT shape: the target
-// column list, the exact-instant-before WHERE bound (no temporality
-// filter, unlike internal/deltaprefix — see this package's doc), and the
-// ceiling-bucket GROUP BY matching internal/schema/ddl's MV exactly.
+// TestBackfillSQL pins the rendered INSERT ... SELECT shape: ONE statement
+// per downsampleTierSources(c) entry (Sum, then Gauge — cerberus issue
+// #2858), the target column list, the exact-instant-before WHERE bound (no
+// temporality filter, unlike internal/deltaprefix — see this package's
+// doc), and the ceiling-bucket GROUP BY matching internal/schema/ddl's MVs
+// exactly. The Sum statement carries a real any(AggregationTemporality);
+// the Gauge statement carries the fixed sentinel literal in its place —
+// see schema.DownsampleTierGaugeTemporalitySentinel's own doc.
 func TestBackfillSQL(t *testing.T) {
-	sql, args := BackfillSQL(testColumns(), testBefore)
-	want := "INSERT INTO otel.otel_metrics_sum_downsample_tier " +
+	stmts := BackfillSQL(testColumns(), testBefore)
+	if len(stmts) != 2 {
+		t.Fatalf("BackfillSQL returned %d statements; want 2 (Sum, Gauge)", len(stmts))
+	}
+	wantSum := "INSERT INTO otel.otel_metrics_sum_downsample_tier " +
 		"(`MetricName`, `Attributes`, `ResourceAttributes`, `ServiceName`, `BucketEnd`, `LastTwoSamples`, `Temporality`) " +
 		"SELECT `MetricName`, `Attributes`, `ResourceAttributes`, `ServiceName`, " +
 		"toStartOfInterval(`TimeUnix` - toIntervalNanosecond(1), toIntervalSecond(300)) + toIntervalSecond(300) AS `BucketEnd`, " +
@@ -36,11 +43,59 @@ func TestBackfillSQL(t *testing.T) {
 		"FROM `otel`.`otel_metrics_sum` WHERE `TimeUnix` < ? " +
 		"GROUP BY `MetricName`, `Attributes`, `ResourceAttributes`, `ServiceName`, " +
 		"toStartOfInterval(`TimeUnix` - toIntervalNanosecond(1), toIntervalSecond(300)) + toIntervalSecond(300)"
-	if sql != want {
-		t.Errorf("BackfillSQL sql =\n%s\nwant\n%s", sql, want)
+	if stmts[0].SQL != wantSum {
+		t.Errorf("BackfillSQL[0] sql =\n%s\nwant\n%s", stmts[0].SQL, wantSum)
 	}
-	if len(args) != 1 || args[0] != testBefore {
-		t.Errorf("BackfillSQL args = %v; want [%v]", args, testBefore)
+	if len(stmts[0].Args) != 1 || stmts[0].Args[0] != testBefore {
+		t.Errorf("BackfillSQL[0] args = %v; want [%v]", stmts[0].Args, testBefore)
+	}
+	wantGauge := "INSERT INTO otel.otel_metrics_sum_downsample_tier " +
+		"(`MetricName`, `Attributes`, `ResourceAttributes`, `ServiceName`, `BucketEnd`, `LastTwoSamples`, `Temporality`) " +
+		"SELECT `MetricName`, `Attributes`, `ResourceAttributes`, `ServiceName`, " +
+		"toStartOfInterval(`TimeUnix` - toIntervalNanosecond(1), toIntervalSecond(300)) + toIntervalSecond(300) AS `BucketEnd`, " +
+		"timeSeriesLastTwoSamplesState(`TimeUnix`, `Value`) AS `LastTwoSamples`, " +
+		"-1 AS `Temporality` " +
+		"FROM `otel`.`otel_metrics_gauge` WHERE `TimeUnix` < ? " +
+		"GROUP BY `MetricName`, `Attributes`, `ResourceAttributes`, `ServiceName`, " +
+		"toStartOfInterval(`TimeUnix` - toIntervalNanosecond(1), toIntervalSecond(300)) + toIntervalSecond(300)"
+	if stmts[1].SQL != wantGauge {
+		t.Errorf("BackfillSQL[1] sql =\n%s\nwant\n%s", stmts[1].SQL, wantGauge)
+	}
+	if len(stmts[1].Args) != 1 || stmts[1].Args[0] != testBefore {
+		t.Errorf("BackfillSQL[1] args = %v; want [%v]", stmts[1].Args, testBefore)
+	}
+}
+
+// TestBackfillSQL_GaugeEqualsSumSkipsSecondStatement pins
+// downsampleTierSources' collapse guard (cerberus issue #2858's own doc): a
+// deployment schema pointing GaugeTable at the SAME physical table as
+// SumTable gets exactly ONE statement, not two — a second MV/backfill over
+// the identical source would double-write every bucket.
+func TestBackfillSQL_GaugeEqualsSumSkipsSecondStatement(t *testing.T) {
+	c := testColumns()
+	c.GaugeTable = c.SumTable
+	stmts := BackfillSQL(c, testBefore)
+	if len(stmts) != 1 {
+		t.Fatalf("BackfillSQL with GaugeTable==SumTable returned %d statements; want 1", len(stmts))
+	}
+}
+
+// TestSourceTables pins the cmd/cerberus-facing helper: both configured
+// sources by default, collapsing to just the Sum table when Gauge is
+// configured identically to it (mirroring downsampleTierSources' own
+// collapse guard).
+func TestSourceTables(t *testing.T) {
+	c := testColumns()
+	got := SourceTables(c)
+	want := []string{c.SumTable, c.GaugeTable}
+	if len(got) != len(want) || got[0] != want[0] || got[1] != want[1] {
+		t.Errorf("SourceTables = %v; want %v", got, want)
+	}
+
+	c.GaugeTable = c.SumTable
+	got = SourceTables(c)
+	if len(got) != 1 || got[0] != c.SumTable {
+		t.Errorf("SourceTables with GaugeTable==SumTable = %v; want [%s]", got, c.SumTable)
 	}
 }
 
@@ -48,20 +103,27 @@ func TestBackfillSQL(t *testing.T) {
 // bound at all — the full-history rebuild this package's doc explains is
 // the recovery path for a suspected stranded persisted state.
 func TestRebuildSQL(t *testing.T) {
-	sql, args := RebuildSQL(testColumns())
-	if len(args) != 0 {
-		t.Errorf("RebuildSQL args = %v; want none (no --before bound)", args)
+	stmts := RebuildSQL(testColumns())
+	if len(stmts) != 2 {
+		t.Fatalf("RebuildSQL returned %d statements; want 2 (Sum, Gauge)", len(stmts))
 	}
-	backfillSQL, _ := BackfillSQL(testColumns(), testBefore)
-	if sql == backfillSQL {
-		t.Fatal("RebuildSQL rendered identically to a bounded BackfillSQL — the WHERE clause is missing")
+	for i, stmt := range stmts {
+		if len(stmt.Args) != 0 {
+			t.Errorf("RebuildSQL[%d] args = %v; want none (no --before bound)", i, stmt.Args)
+		}
+		if containsSubstr(stmt.SQL, "WHERE") {
+			t.Errorf("RebuildSQL[%d] sql = %q; want no WHERE clause at all", i, stmt.SQL)
+		}
+	}
+	backfillStmts := BackfillSQL(testColumns(), testBefore)
+	if stmts[0].SQL == backfillStmts[0].SQL {
+		t.Fatal("RebuildSQL[0] rendered identically to a bounded BackfillSQL[0] — the WHERE clause is missing")
 	}
 	wantPrefix := "INSERT INTO otel.otel_metrics_sum_downsample_tier "
-	if len(sql) < len(wantPrefix) || sql[:len(wantPrefix)] != wantPrefix {
-		t.Errorf("RebuildSQL sql = %q; want prefix %q", sql, wantPrefix)
-	}
-	if containsSubstr(sql, "WHERE") {
-		t.Errorf("RebuildSQL sql = %q; want no WHERE clause at all", sql)
+	for i, stmt := range stmts {
+		if len(stmt.SQL) < len(wantPrefix) || stmt.SQL[:len(wantPrefix)] != wantPrefix {
+			t.Errorf("RebuildSQL[%d] sql = %q; want prefix %q", i, stmt.SQL, wantPrefix)
+		}
 	}
 }
 
@@ -81,17 +143,26 @@ func TestTruncateSQL(t *testing.T) {
 // to this package's ceiling bucket expression and lack of a temporality
 // filter.
 func TestOutsideRetentionDaysSQL(t *testing.T) {
+	c := testColumns()
 	boundary := time.Date(2026, 8, 10, 0, 0, 0, 0, time.UTC)
-	sql, args := outsideRetentionDaysSQL(testColumns(), testBefore, boundary)
 	bucketExpr := "toStartOfInterval(`TimeUnix` - toIntervalNanosecond(1), toIntervalSecond(300)) + toIntervalSecond(300)"
-	want := "SELECT " + bucketExpr + " FROM `otel`.`otel_metrics_sum` " +
-		"WHERE `TimeUnix` < ? AND " + bucketExpr + " < ? " +
-		"GROUP BY " + bucketExpr + " ORDER BY " + bucketExpr
-	if sql != want {
-		t.Errorf("outsideRetentionDaysSQL sql =\n%s\nwant\n%s", sql, want)
-	}
-	if len(args) != 2 || args[0] != testBefore || args[1] != boundary {
-		t.Errorf("outsideRetentionDaysSQL args = %v; want [%v %v]", args, testBefore, boundary)
+	for _, tc := range []struct {
+		source string
+		table  string
+	}{
+		{c.SumTable, "otel_metrics_sum"},
+		{c.GaugeTable, "otel_metrics_gauge"},
+	} {
+		sql, args := outsideRetentionDaysSQL(c, tc.source, testBefore, boundary)
+		want := "SELECT " + bucketExpr + " FROM `otel`.`" + tc.table + "` " +
+			"WHERE `TimeUnix` < ? AND " + bucketExpr + " < ? " +
+			"GROUP BY " + bucketExpr + " ORDER BY " + bucketExpr
+		if sql != want {
+			t.Errorf("outsideRetentionDaysSQL(%s) sql =\n%s\nwant\n%s", tc.table, sql, want)
+		}
+		if len(args) != 2 || args[0] != testBefore || args[1] != boundary {
+			t.Errorf("outsideRetentionDaysSQL(%s) args = %v; want [%v %v]", tc.table, args, testBefore, boundary)
+		}
 	}
 }
 
@@ -101,7 +172,7 @@ func TestOutsideRetentionDaysSQL(t *testing.T) {
 func TestBaseAndTierBucketsSQL(t *testing.T) {
 	c := testColumns()
 
-	baseSQL, baseArgs := baseBucketsSQL(c, testBefore, time.Time{}, false)
+	baseSQL, baseArgs := baseBucketsSQL(c, c.SumTable, testBefore, time.Time{}, false)
 	bucketExpr := "toStartOfInterval(`TimeUnix` - toIntervalNanosecond(1), toIntervalSecond(300)) + toIntervalSecond(300)"
 	wantBase := "SELECT `MetricName`, uniqExact(" + bucketExpr + ") AS `n` " +
 		"FROM `otel`.`otel_metrics_sum` WHERE `TimeUnix` < ? GROUP BY `MetricName`"
@@ -110,6 +181,13 @@ func TestBaseAndTierBucketsSQL(t *testing.T) {
 	}
 	if len(baseArgs) != 1 || baseArgs[0] != testBefore {
 		t.Errorf("baseBucketsSQL args = %v; want [%v]", baseArgs, testBefore)
+	}
+
+	gaugeSQL, _ := baseBucketsSQL(c, c.GaugeTable, testBefore, time.Time{}, false)
+	wantGauge := "SELECT `MetricName`, uniqExact(" + bucketExpr + ") AS `n` " +
+		"FROM `otel`.`otel_metrics_gauge` WHERE `TimeUnix` < ? GROUP BY `MetricName`"
+	if gaugeSQL != wantGauge {
+		t.Errorf("baseBucketsSQL(gauge) sql =\n%s\nwant\n%s", gaugeSQL, wantGauge)
 	}
 
 	tierSQL, tierArgs := tierBucketsSQL(c, testBefore, time.Time{}, false)
@@ -130,7 +208,7 @@ func TestBaseAndTierBucketsSQL_RetentionActive(t *testing.T) {
 	c := testColumns()
 	boundary := time.Date(2026, 8, 10, 0, 0, 0, 0, time.UTC)
 
-	baseSQL, baseArgs := baseBucketsSQL(c, testBefore, boundary, true)
+	baseSQL, baseArgs := baseBucketsSQL(c, c.SumTable, testBefore, boundary, true)
 	bucketExpr := "toStartOfInterval(`TimeUnix` - toIntervalNanosecond(1), toIntervalSecond(300)) + toIntervalSecond(300)"
 	wantBase := "SELECT `MetricName`, uniqExact(" + bucketExpr + ") AS `n` " +
 		"FROM `otel`.`otel_metrics_sum` WHERE `TimeUnix` < ? AND " + bucketExpr + " >= ? GROUP BY `MetricName`"
@@ -265,6 +343,11 @@ type fakeConn struct {
 	execSQL  []string
 	execArgs [][]any
 	execErr  error
+	// execErrOn, when non-zero, fails only the execErrOn-th Exec call
+	// (1-indexed) rather than every one — used to reach a LATER statement's
+	// own error-wrap branch (e.g. Rebuild's second, Gauge-sourced INSERT)
+	// without also failing every earlier one.
+	execErrOn int
 
 	queries []string
 	respond map[string][][2]any
@@ -274,6 +357,12 @@ type fakeConn struct {
 func (c *fakeConn) Exec(_ context.Context, query string, args ...any) error {
 	c.execSQL = append(c.execSQL, query)
 	c.execArgs = append(c.execArgs, args)
+	if c.execErrOn != 0 {
+		if len(c.execSQL) == c.execErrOn {
+			return c.execErr
+		}
+		return nil
+	}
 	return c.execErr
 }
 
@@ -302,19 +391,22 @@ func containsSubstr(s, substr string) bool {
 	return false
 }
 
-// twoCallConn succeeds on its first Query and fails on its second — the
-// shape Verify's own two reads (base table, then tier table) need to reach
-// its second error-wrap branch.
-type twoCallConn struct {
-	calls int
-	err   error
+// nthCallConn succeeds on every Query call except the failOn-th (1-indexed),
+// which fails — used to reach a specific error-wrap branch among Verify's
+// several sequential reads (retention check x2 sources, base-bucket reads x2
+// sources, tier-bucket read x1 — cerberus issue #2858 widened the base read
+// from one call to one per downsampleTierSources(c) entry).
+type nthCallConn struct {
+	calls  int
+	failOn int
+	err    error
 }
 
-func (c *twoCallConn) Exec(context.Context, string, ...any) error { return nil }
+func (c *nthCallConn) Exec(context.Context, string, ...any) error { return nil }
 
-func (c *twoCallConn) Query(context.Context, string, ...any) (driver.Rows, error) {
+func (c *nthCallConn) Query(context.Context, string, ...any) (driver.Rows, error) {
 	c.calls++
-	if c.calls == 2 {
+	if c.calls == c.failOn {
 		return nil, c.err
 	}
 	return &fakeRows{}, nil
@@ -328,8 +420,9 @@ func withFrozenNow(t *testing.T, now time.Time) {
 }
 
 // TestBackfill_ExecutesRenderedSQL confirms Backfill hands conn EXACTLY the
-// statement + args BackfillSQL renders, and wraps a real Exec failure with
-// enough context to identify the target table.
+// statements + args BackfillSQL renders — one per downsampleTierSources(c)
+// entry (Sum, then Gauge — cerberus issue #2858) — and wraps a real Exec
+// failure with enough context to identify the target table.
 func TestBackfill_ExecutesRenderedSQL(t *testing.T) {
 	c := testColumns()
 	conn := &fakeConn{}
@@ -340,14 +433,21 @@ func TestBackfill_ExecutesRenderedSQL(t *testing.T) {
 	if len(result.OutsideRetentionDays) != 0 {
 		t.Errorf("OutsideRetentionDays = %v; want none with retention=0", result.OutsideRetentionDays)
 	}
-	wantSQL, wantArgs := BackfillSQL(c, testBefore)
-	if len(conn.execSQL) != 1 || conn.execSQL[0] != wantSQL {
-		t.Errorf("Exec sql = %v; want [%q]", conn.execSQL, wantSQL)
+	wantStmts := BackfillSQL(c, testBefore)
+	if len(conn.execSQL) != len(wantStmts) {
+		t.Fatalf("Exec calls = %d; want %d (one per source)", len(conn.execSQL), len(wantStmts))
 	}
-	if len(conn.execArgs) != 1 || len(conn.execArgs[0]) != len(wantArgs) {
-		t.Errorf("Exec args = %v; want %v", conn.execArgs, wantArgs)
+	for i, want := range wantStmts {
+		if conn.execSQL[i] != want.SQL {
+			t.Errorf("Exec[%d] sql = %q; want %q", i, conn.execSQL[i], want.SQL)
+		}
+		if len(conn.execArgs[i]) != len(want.Args) {
+			t.Errorf("Exec[%d] args = %v; want %v", i, conn.execArgs[i], want.Args)
+		}
 	}
 
+	// A failing FIRST (Sum) Exec must stop before ever attempting the
+	// second (Gauge) statement.
 	failing := &fakeConn{execErr: errors.New("boom")}
 	_, err = Backfill(context.Background(), failing, c, testBefore, 0)
 	if err == nil {
@@ -355,6 +455,9 @@ func TestBackfill_ExecutesRenderedSQL(t *testing.T) {
 	}
 	if got := err.Error(); !containsSubstr(got, schema.DownsampleTierTable) {
 		t.Errorf("Backfill error %q does not name the target table %q", got, schema.DownsampleTierTable)
+	}
+	if len(failing.execSQL) != 1 {
+		t.Errorf("expected Backfill to stop after the first failing Exec; got %d Exec calls", len(failing.execSQL))
 	}
 }
 
@@ -373,15 +476,17 @@ func TestBackfill_DetectsOutsideRetentionDays(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Backfill: %v", err)
 	}
-	// The outside-retention check must run BEFORE the INSERT.
-	if len(conn.queries) != 1 {
-		t.Fatalf("expected exactly 1 Query (the retention check); got %d", len(conn.queries))
+	// The outside-retention check must run BEFORE the INSERT — one Query
+	// per source (Sum, Gauge), both matching "GROUP BY" and both reporting
+	// the SAME outsideDay, deduplicated by queryOutsideRetentionDays.
+	if len(conn.queries) != 2 {
+		t.Fatalf("expected exactly 2 Query calls (the retention check, one per source); got %d", len(conn.queries))
 	}
-	if len(conn.execSQL) != 1 {
-		t.Fatalf("expected exactly 1 Exec (the INSERT); got %d", len(conn.execSQL))
+	if len(conn.execSQL) != 2 {
+		t.Fatalf("expected exactly 2 Exec calls (the INSERTs, one per source); got %d", len(conn.execSQL))
 	}
 	if len(result.OutsideRetentionDays) != 1 || !result.OutsideRetentionDays[0].Equal(outsideDay) {
-		t.Errorf("OutsideRetentionDays = %v; want [%v]", result.OutsideRetentionDays, outsideDay)
+		t.Errorf("OutsideRetentionDays = %v; want [%v] (deduplicated across both sources)", result.OutsideRetentionDays, outsideDay)
 	}
 }
 
@@ -395,10 +500,43 @@ func TestBackfill_PropagatesRetentionCheckQueryError(t *testing.T) {
 	}
 }
 
+// TestQueryOutsideRetentionDays_PropagatesSecondSourceQueryError confirms
+// the per-source loop (cerberus issue #2858) surfaces a failure from the
+// SECOND source's own Query call — not just the first, which every other
+// retention-check test above already covers via a conn that fails
+// unconditionally.
+func TestQueryOutsideRetentionDays_PropagatesSecondSourceQueryError(t *testing.T) {
+	c := testColumns()
+	conn := &nthCallConn{failOn: 2, err: errors.New("gauge retention query failed")}
+	_, err := queryOutsideRetentionDays(context.Background(), conn, c, testBefore, time.Time{})
+	if err == nil {
+		t.Fatal("expected an error from the second (Gauge) source's Query")
+	}
+	if !containsSubstr(err.Error(), c.GaugeTable) {
+		t.Errorf("error %q does not name the Gauge source table", err.Error())
+	}
+}
+
+// TestQueryOutsideRetentionDays_PropagatesScanError confirms a Scan failure
+// on the retention-day read is wrapped with the failing source's table name,
+// mirroring scanCounts' own PropagatesScanError coverage for the sibling
+// bucket-count reads.
+func TestQueryOutsideRetentionDays_PropagatesScanError(t *testing.T) {
+	c := testColumns()
+	conn := &singleRowsConn{rows: &erroringRows{hasRow: true, scanErr: errors.New("scan failed")}}
+	_, err := queryOutsideRetentionDays(context.Background(), conn, c, testBefore, time.Time{})
+	if err == nil {
+		t.Fatal("expected an error from a failing Scan")
+	}
+	if !containsSubstr(err.Error(), c.SumTable) {
+		t.Errorf("error %q does not name the source table", err.Error())
+	}
+}
+
 // TestRebuild_TruncatesThenInserts confirms Rebuild issues TRUNCATE before
-// the unbounded INSERT ... SELECT, in that order, and surfaces
-// outside-retention days computed against `now` rather than any --before
-// bound.
+// the unbounded INSERT ... SELECT statements (one per source — cerberus
+// issue #2858), in that order, and surfaces outside-retention days computed
+// against `now` rather than any --before bound.
 func TestRebuild_TruncatesThenInserts(t *testing.T) {
 	c := testColumns()
 	conn := &fakeConn{}
@@ -409,15 +547,17 @@ func TestRebuild_TruncatesThenInserts(t *testing.T) {
 	if len(result.OutsideRetentionDays) != 0 {
 		t.Errorf("OutsideRetentionDays = %v; want none with retention=0", result.OutsideRetentionDays)
 	}
-	if len(conn.execSQL) != 2 {
-		t.Fatalf("Exec calls = %d; want 2 (TRUNCATE then INSERT)", len(conn.execSQL))
+	wantInserts := RebuildSQL(c)
+	if len(conn.execSQL) != 1+len(wantInserts) {
+		t.Fatalf("Exec calls = %d; want %d (TRUNCATE then one INSERT per source)", len(conn.execSQL), 1+len(wantInserts))
 	}
 	if conn.execSQL[0] != TruncateSQL(c) {
 		t.Errorf("first Exec = %q; want TRUNCATE %q", conn.execSQL[0], TruncateSQL(c))
 	}
-	wantInsert, _ := RebuildSQL(c)
-	if conn.execSQL[1] != wantInsert {
-		t.Errorf("second Exec = %q; want %q", conn.execSQL[1], wantInsert)
+	for i, want := range wantInserts {
+		if conn.execSQL[1+i] != want.SQL {
+			t.Errorf("Exec[%d] = %q; want %q", 1+i, conn.execSQL[1+i], want.SQL)
+		}
 	}
 
 	failingTruncate := &fakeConn{execErr: errors.New("truncate failed")}
@@ -426,7 +566,28 @@ func TestRebuild_TruncatesThenInserts(t *testing.T) {
 		t.Fatal("expected error from a failing TRUNCATE")
 	}
 	if len(failingTruncate.execSQL) != 1 {
-		t.Errorf("expected Rebuild to stop after a failing TRUNCATE, not attempt the INSERT; got %d Exec calls", len(failingTruncate.execSQL))
+		t.Errorf("expected Rebuild to stop after a failing TRUNCATE, not attempt any INSERT; got %d Exec calls", len(failingTruncate.execSQL))
+	}
+}
+
+// TestRebuild_StopsAfterFirstFailingInsert confirms Rebuild stops issuing
+// further INSERT statements (cerberus issue #2858: now one per source) as
+// soon as one fails, rather than attempting every remaining source's own
+// statement regardless. execErrOn=3 fails the SECOND insert (Exec call 3:
+// TRUNCATE, Sum insert, Gauge insert).
+func TestRebuild_StopsAfterFirstFailingInsert(t *testing.T) {
+	c := testColumns()
+	conn := &fakeConn{execErrOn: 3, execErr: errors.New("gauge insert failed")}
+	_, err := Rebuild(context.Background(), conn, c, 0)
+	if err == nil {
+		t.Fatal("expected error from the second (Gauge) INSERT failing")
+	}
+	if !containsSubstr(err.Error(), schema.DownsampleTierTable) {
+		t.Errorf("Rebuild error %q does not name the target table", err.Error())
+	}
+	if len(conn.execSQL) != 3 {
+		t.Errorf("Exec calls = %d; want 3 (TRUNCATE, Sum insert, the failing Gauge insert) — "+
+			"no statement past the failure should run", len(conn.execSQL))
 	}
 }
 
@@ -443,6 +604,11 @@ func TestRebuild_PropagatesRetentionCheckQueryError(t *testing.T) {
 	}
 }
 
+// TestVerify_ReadsBothBucketCountsAndDiffs confirms baseBucketCounts SUMS
+// per-metric-name counts across BOTH sources (cerberus issue #2858: "m2"
+// only exists in the Gauge table's response here, proving its count is not
+// silently dropped just because it's absent from the Sum table's read) and
+// still diffs correctly against the tier's own combined count.
 func TestVerify_ReadsBothBucketCountsAndDiffs(t *testing.T) {
 	c := testColumns()
 	// Match keys must be MUTUALLY EXCLUSIVE substrings — a bare
@@ -451,12 +617,13 @@ func TestVerify_ReadsBothBucketCountsAndDiffs(t *testing.T) {
 	// containsSubstr would match BOTH queries against whichever key map
 	// iteration (random order) happens to check first. The closing
 	// backtick right after the table name disambiguates: it appears in
-	// the base table's own quoted reference but not inside the tier
+	// the base tables' own quoted references but not inside the tier
 	// table's (longer) one.
 	conn := &fakeConn{
 		respond: map[string][][2]any{
-			"`" + schema.DownsampleTierTable + "`": {{"m1", int64(4)}},
+			"`" + schema.DownsampleTierTable + "`": {{"m1", int64(4)}, {"m2", int64(2)}},
 			"`" + c.SumTable + "`":                 {{"m1", int64(5)}},
+			"`" + c.GaugeTable + "`":               {{"m2", int64(2)}},
 		},
 	}
 	rep, err := Verify(context.Background(), conn, c, testBefore, 0)
@@ -464,25 +631,41 @@ func TestVerify_ReadsBothBucketCountsAndDiffs(t *testing.T) {
 		t.Fatalf("Verify: %v", err)
 	}
 	if rep.Pass() {
-		t.Fatal("expected a mismatch (base=5, tier=4)")
+		t.Fatal("expected a mismatch (base=5, tier=4 for m1)")
 	}
 	if len(rep.Mismatches) != 1 || rep.Mismatches[0].MetricName != "m1" {
-		t.Errorf("Mismatches = %v; want one entry for m1", rep.Mismatches)
+		t.Errorf("Mismatches = %v; want one entry for m1 (m2's Gauge-sourced base/tier counts agree at 2)", rep.Mismatches)
 	}
 }
 
 func TestVerify_PropagatesBaseTableQueryError(t *testing.T) {
 	c := testColumns()
-	conn := &twoCallConn{err: errors.New("boom")}
-	// twoCallConn fails on its SECOND call. Verify's own read order is
-	// base table first, then tier table — see Verify's own doc — so the
-	// second call belongs to the TIER table read.
+	// retention=0 skips the retention-day check entirely, so Verify's own
+	// read order is: base-Sum (call 1), base-Gauge (call 2), tier (call 3).
+	// failOn=3 reaches the tier read's own error-wrap branch.
+	conn := &nthCallConn{failOn: 3, err: errors.New("boom")}
 	_, err := Verify(context.Background(), conn, c, testBefore, 0)
 	if err == nil {
-		t.Fatal("expected an error from the second (tier table) Query")
+		t.Fatal("expected an error from the third (tier table) Query")
 	}
 	if !containsSubstr(err.Error(), schema.DownsampleTierTable) {
 		t.Errorf("Verify error %q does not name the tier table", err.Error())
+	}
+}
+
+// TestVerify_PropagatesGaugeBaseTableQueryError mirrors
+// TestVerify_PropagatesBaseTableQueryError for the SECOND base read (the
+// Gauge source, cerberus issue #2858) — proving baseBucketCounts surfaces a
+// failure from either configured source, not just the first.
+func TestVerify_PropagatesGaugeBaseTableQueryError(t *testing.T) {
+	c := testColumns()
+	conn := &nthCallConn{failOn: 2, err: errors.New("boom")}
+	_, err := Verify(context.Background(), conn, c, testBefore, 0)
+	if err == nil {
+		t.Fatal("expected an error from the second (Gauge base) Query")
+	}
+	if !containsSubstr(err.Error(), c.GaugeTable) {
+		t.Errorf("Verify error %q does not name the Gauge source table", err.Error())
 	}
 }
 
@@ -503,12 +686,14 @@ func TestVerify_ExcludesOutsideRetentionDaysFromReport(t *testing.T) {
 	retention := 30 * 24 * time.Hour
 	outsideDay := time.Date(2026, 7, 1, 0, 0, 0, 0, time.UTC)
 	boundary, _ := retentionBoundary(now, retention)
-	// Three distinct queries land on this one conn (the retention-day
-	// check, baseBucketsSQL, tierBucketsSQL) — key each response by its
-	// OWN exact rendered SQL (derived from the real renderers, not a
-	// hand-guessed substring) so none can accidentally match another.
-	dayQuery, _ := outsideRetentionDaysSQL(c, testBefore, boundary)
-	baseQuery, _ := baseBucketsSQL(c, testBefore, boundary, true)
+	// Five distinct queries land on this one conn (the retention-day check
+	// and the base-bucket read, each once per source, plus tierBucketsSQL)
+	// — key the Sum source's two responses by their OWN exact rendered SQL
+	// (derived from the real renderers, not a hand-guessed substring) so
+	// none can accidentally match another; the Gauge source's two queries
+	// fall through to the default empty response, contributing nothing.
+	dayQuery, _ := outsideRetentionDaysSQL(c, c.SumTable, testBefore, boundary)
+	baseQuery, _ := baseBucketsSQL(c, c.SumTable, testBefore, boundary, true)
 	conn := &fakeConn{
 		respond: map[string][][2]any{
 			dayQuery:  {{outsideDay, int64(0)}},

--- a/internal/promql/downsample_tier_strategy_test.go
+++ b/internal/promql/downsample_tier_strategy_test.go
@@ -313,3 +313,133 @@ func TestDownsampleTierDisabled_FallsThroughToFanout(t *testing.T) {
 		t.Error("DownsampleTier must stay false when no DownsampleTier*Lowerer was wired")
 	}
 }
+
+// --- Gauge-table eligibility for last_over_time() (cerberus issue #2858) ---
+//
+// These are the plain lowering-shape counterparts of the Sum-table tests
+// above, using rangeVectorSingleGaugeTable's own unambiguous-resolution
+// requirement (internal/promql/lower.go) instead of
+// rangeVectorCounterTemporalityColumn's. An UNSUFFIXED metric name is
+// otherwise ambiguous between Gauge and Sum (schema.Metrics.TablesForUnknownName's
+// own doc — the SAME pre-existing restriction #1628/#2751 already impose on
+// an unsuffixed COUNTER metric's own irate()/idelta() eligibility), so every
+// test below clears SumTable to give the fixture metric name an unambiguous
+// Gauge-only resolution — see
+// internal/chsql's range_window_downsample_tier_gauge_chdb_test.go
+// (downsampleTierGaugeOnlySchema) for the identical reasoning against a real
+// ClickHouse engine.
+
+// lowerDownsampleTierQueryWithSchema mirrors lowerDownsampleTierQuery but
+// takes an explicit schema.Metrics rather than hard-coding
+// schema.DefaultOTelMetrics() — needed so a test can clear SumTable to make
+// an unsuffixed metric name resolve unambiguously to Gauge.
+func lowerDownsampleTierQueryWithSchema(t *testing.T, s schema.Metrics, query string, start, end time.Time, step time.Duration) (*chplan.RangeWindow, bool) {
+	t.Helper()
+	p := promparser.NewParser(promparser.Options{EnableExperimentalFunctions: true})
+	expr, err := p.ParseExpr(query)
+	if err != nil {
+		t.Fatalf("parse %q: %v", query, err)
+	}
+	plan, err := promql.LowerAtRangeOpts(context.Background(), expr, s,
+		start, end, step, promql.LowerOpts{Lowerers: downsampleTierLowerers()})
+	if err != nil {
+		t.Fatalf("lower %q: %v", query, err)
+	}
+	var found *chplan.RangeWindow
+	chplan.WalkDeep(plan, func(n chplan.Node) bool {
+		if rw, ok := n.(*chplan.RangeWindow); ok && found == nil {
+			found = rw
+			return false
+		}
+		return true
+	})
+	return found, found != nil
+}
+
+// gaugeOnlySchema returns schema.DefaultOTelMetrics() with SumTable cleared
+// — see this section's own doc for why an unambiguous Gauge resolution
+// needs it.
+func gaugeOnlySchema() schema.Metrics {
+	m := schema.DefaultOTelMetrics()
+	m.SumTable = ""
+	return m
+}
+
+func TestDownsampleTierEligible_LastOverTimeGaugeTable(t *testing.T) {
+	rw, ok := lowerDownsampleTierQueryWithSchema(t, gaugeOnlySchema(), `last_over_time(cpu_temperature[5m])`,
+		bucketAlignedStart, bucketAlignedStart.Add(20*time.Minute), schema.DownsampleTierBucket)
+	if !ok {
+		t.Fatal("expected a RangeWindow in the plan")
+	}
+	if !rw.DownsampleTier {
+		t.Error("expected DownsampleTier=true for a bucket-aligned last_over_time() query over an unambiguous Gauge-table metric")
+	}
+	if rw.DownsampleTierInput == nil {
+		t.Error("expected DownsampleTierInput to be populated")
+	}
+}
+
+// TestDownsampleTierIneligible_IrateGaugeTable proves irate() stays
+// Sum/Histogram-only even over an UNAMBIGUOUS Gauge-table resolution — a
+// gauge has no counter-reset semantics for irate() to apply.
+// TestDownsampleTierIneligible_IdeltaGaugeTable mirrors it for idelta().
+func TestDownsampleTierIneligible_IrateGaugeTable(t *testing.T) {
+	rw, ok := lowerDownsampleTierQueryWithSchema(t, gaugeOnlySchema(), `irate(cpu_temperature[5m])`,
+		bucketAlignedStart, bucketAlignedStart.Add(20*time.Minute), schema.DownsampleTierBucket)
+	if !ok {
+		t.Fatal("expected a RangeWindow in the plan")
+	}
+	if rw.DownsampleTier || rw.DownsampleTierInput != nil {
+		t.Error("irate() must never route to the tier for a Gauge-table metric, even unambiguously resolved")
+	}
+}
+
+func TestDownsampleTierIneligible_IdeltaGaugeTable(t *testing.T) {
+	rw, ok := lowerDownsampleTierQueryWithSchema(t, gaugeOnlySchema(), `idelta(cpu_temperature[5m])`,
+		bucketAlignedStart, bucketAlignedStart.Add(20*time.Minute), schema.DownsampleTierBucket)
+	if !ok {
+		t.Fatal("expected a RangeWindow in the plan")
+	}
+	if rw.DownsampleTier || rw.DownsampleTierInput != nil {
+		t.Error("idelta() must never route to the tier for a Gauge-table metric, even unambiguously resolved")
+	}
+}
+
+// TestDownsampleTierIneligible_LastOverTimeNoGaugeTableConfigured proves
+// rangeVectorSingleGaugeTable's own s.GaugeTable == "" guard: a deployment
+// with no Gauge table configured at all can never have an "unambiguous
+// Gauge-table resolution", so last_over_time() stays off the tier for it —
+// as opposed to falling through to resolveUnambiguousScanTable and
+// (incorrectly) matching an empty string against an equally-empty
+// s.GaugeTable. SumTable stays configured (unlike gaugeOnlySchema's own
+// Sum-disabled shape) so `_total`-suffixed selectors elsewhere in this
+// schema still resolve normally — only the Gauge arm is disabled.
+func TestDownsampleTierIneligible_LastOverTimeNoGaugeTableConfigured(t *testing.T) {
+	s := schema.DefaultOTelMetrics()
+	s.GaugeTable = ""
+	rw, ok := lowerDownsampleTierQueryWithSchema(t, s, `last_over_time(cpu_temperature[5m])`,
+		bucketAlignedStart, bucketAlignedStart.Add(20*time.Minute), schema.DownsampleTierBucket)
+	if !ok {
+		t.Fatal("expected a RangeWindow in the plan")
+	}
+	if rw.DownsampleTier || rw.DownsampleTierInput != nil {
+		t.Error("last_over_time() must not route to the tier when no Gauge table is configured at all")
+	}
+}
+
+// TestDownsampleTierIneligible_LastOverTimeAmbiguousGaugeSum proves the
+// pre-existing (Gauge, Sum) ambiguity fan-out for an unsuffixed metric name
+// (schema.Metrics.TablesForUnknownName, both tables configured) keeps
+// last_over_time() OUT of the tier — the same restriction #1628/#2751
+// already impose on irate()/idelta() for an unsuffixed counter metric,
+// applied symmetrically here rather than newly introduced.
+func TestDownsampleTierIneligible_LastOverTimeAmbiguousGaugeSum(t *testing.T) {
+	rw, ok := lowerDownsampleTierQuery(t, `last_over_time(cpu_temperature[5m])`,
+		bucketAlignedStart, bucketAlignedStart.Add(20*time.Minute), schema.DownsampleTierBucket)
+	if !ok {
+		t.Fatal("expected a RangeWindow in the plan")
+	}
+	if rw.DownsampleTier || rw.DownsampleTierInput != nil {
+		t.Error("last_over_time() must not route to the tier for an unsuffixed name ambiguous between Gauge and Sum")
+	}
+}

--- a/internal/promql/lower.go
+++ b/internal/promql/lower.go
@@ -1720,26 +1720,35 @@ func downsampleTierEligibleFunc(funcName string) bool {
 }
 
 // attachDownsampleTierArm side-feeds the downsampled long-range tier
-// (cerberus issue #2751) onto rw whenever funcName is eligible for it
-// (downsampleTierEligibleFunc) over an unambiguous Sum/Histogram-table scan.
-// Unlike attachDeltaPrefixAggregateArm this does NOT gate on
-// counterTemporalityRangeFn(funcName) first — idelta() and last_over_time()
-// are not counterTemporalityRangeFn members (neither ever needs
-// rw.TemporalityColumn populated: idelta never counter-corrects and
-// last_over_time is temporality-agnostic), so this resolves its own "is
-// this a Sum/Histogram-table scan" verdict directly via
-// rangeVectorCounterTemporalityColumn, purely as an eligibility oracle —
-// the resolved column is discarded, never assigned to rw.TemporalityColumn.
+// (cerberus issue #2751, extended by #2858) onto rw whenever funcName is
+// eligible for it (downsampleTierEligibleFunc) over an unambiguous scan of a
+// table the tier is actually fed from. Unlike attachDeltaPrefixAggregateArm
+// this does NOT gate on counterTemporalityRangeFn(funcName) first — idelta()
+// and last_over_time() are not counterTemporalityRangeFn members (neither
+// ever needs rw.TemporalityColumn populated: idelta never counter-corrects
+// and last_over_time is temporality-agnostic), so this resolves its own
+// eligibility verdict directly via rangeVectorCounterTemporalityColumn /
+// rangeVectorSingleGaugeTable, purely as eligibility oracles — neither
+// resolved value is ever assigned to rw.TemporalityColumn.
 //
-// A Histogram-table verdict slipping through (the tier's own MV reads only
-// the Sum table — see internal/schema/ddl's renderDownsampleTierView) is
-// safe, not silently wrong: the arm's Scan filters on MetricName, and a
-// histogram metric's rows simply never exist in the tier table, so the
-// query reads back empty and the boot-wired DownsampleTier*Lowerer's own
-// row-count guard (chsql's emitRangeWindowDownsampleTier) drops the series
-// exactly as PromQL would for missing data — see
-// schema.DownsampleTierTable's doc for why this whole mechanism degrades
-// safely rather than silently.
+// irate() and idelta() accept only an unambiguous Sum/Histogram-table
+// resolution (rangeVectorCounterTemporalityColumn != "") — a gauge has no
+// counter-reset semantics for either. last_over_time() additionally accepts
+// an unambiguous GAUGE-table resolution (rangeVectorSingleGaugeTable,
+// cerberus issue #2858): it is temporality-agnostic by definition, so the
+// tier's Gauge-sourced rows (internal/schema/ddl's
+// renderDownsampleTierGaugeView) answer it exactly as its Sum-sourced rows
+// do.
+//
+// A Histogram-table verdict slipping through irate()/idelta()'s check (the
+// tier's Sum-sourced MV reads only the Sum table — see internal/schema/ddl's
+// renderDownsampleTierView) is safe, not silently wrong: the arm's Scan
+// filters on MetricName, and a histogram metric's rows simply never exist in
+// the tier table, so the query reads back empty and the boot-wired
+// DownsampleTier*Lowerer's own row-count guard (chsql's
+// emitRangeWindowDownsampleTier) drops the series exactly as PromQL would
+// for missing data — see schema.DownsampleTierTable's doc for why this whole
+// mechanism degrades safely rather than silently.
 //
 // This populates the FIELD unconditionally under those conditions; whether
 // the emitter actually CONSUMES it is the separate, boot-wired
@@ -1757,10 +1766,13 @@ func attachDownsampleTierArm(
 	if !downsampleTierEligibleFunc(funcName) {
 		return
 	}
-	if rangeVectorCounterTemporalityColumn(vs, s, rangeCtx) == "" {
+	if rangeVectorCounterTemporalityColumn(vs, s, rangeCtx) != "" {
+		rw.DownsampleTierInput = buildDownsampleTierArm(vs.LabelMatchers, s, rangeCtx)
 		return
 	}
-	rw.DownsampleTierInput = buildDownsampleTierArm(vs.LabelMatchers, s, rangeCtx)
+	if funcName == "last_over_time" && rangeVectorSingleGaugeTable(vs, s, rangeCtx) {
+		rw.DownsampleTierInput = buildDownsampleTierArm(vs.LabelMatchers, s, rangeCtx)
+	}
 }
 
 // buildDownsampleTierArm builds chplan.RangeWindow.DownsampleTierInput
@@ -3834,36 +3846,28 @@ func counterTemporalityRangeFn(name string) bool {
 	return false
 }
 
-// rangeVectorCounterTemporalityColumn reports which column
-// chplan.RangeWindow.TemporalityColumn should carry for a
-// counterTemporalityRangeFn call over vs, or "" when none applies. It
-// calls the SAME resolveSelectorRouting the inner lowerVectorSelector is
-// about to call for this exact selector, so the two never disagree about
-// which table(s) the selector resolves to — see
-// rangeCtx.wantsTemporalityColumn's doc for why this has to run BEFORE
-// lowerVectorSelector rather than inspect its output.
+// resolveUnambiguousScanTable resolves vs to the single physical table its
+// selector routing collapses to, or "" when it doesn't collapse to exactly
+// one. It calls the SAME resolveSelectorRouting the inner lowerVectorSelector
+// is about to call for this exact selector, so no caller of this function
+// ever disagrees with the real lowering about which table(s) the selector
+// resolves to — see rangeCtx.wantsTemporalityColumn's doc for why this has
+// to run BEFORE lowerVectorSelector rather than inspect its output.
 //
-// The column only applies when the selector resolves to EXACTLY ONE
-// table, and that table is the Sum or (classic) Histogram table: a
-// Gauge-table scan carries no AggregationTemporality column in production,
-// the exp-histogram / companion-union arms stay out of #1628's scope (see
-// the nil-temporality call sites in histogram_quantile_range.go /
-// histogram_quantile_native_window.go), and the (Gauge, Sum)
-// Scan.UnionTables ambiguous-routing shape (an unsuffixed metric name that
-// could live in either table) deliberately drops the Sum-only column from
-// its projection so the union's column list still matches. A
-// resolveSelectorRouting error here is not this function's to report —
-// the real lowerVectorSelector call right after it will hit the identical
-// error and report it through the normal path — so an error conservatively
-// answers "no column" instead.
-func rangeVectorCounterTemporalityColumn(vs *parser.VectorSelector, s schema.Metrics, ctx lowerCtx) string {
-	if s.AggregationTemporalityColumn == "" {
-		return ""
-	}
+// Shared by rangeVectorCounterTemporalityColumn (accepts Sum/Histogram, for
+// irate()/idelta()/rate()/increase()'s temporality-aware reads) and
+// rangeVectorSingleGaugeTable (accepts Gauge, for last_over_time()'s
+// downsample-tier eligibility — cerberus issue #2858) so the two callers can
+// never disagree about what "an unambiguous scan" means. A caller-visible
+// resolveSelectorRouting error is not this function's to report — the real
+// lowerVectorSelector call right after it will hit the identical error and
+// report it through the normal path — so an error conservatively answers ""
+// instead.
+func resolveUnambiguousScanTable(vs *parser.VectorSelector, s schema.Metrics, ctx lowerCtx) string {
 	metricName := metricNameFromMatchers(vs.LabelMatchers)
 	if hasUnpinnedMetricNameMatcher(vs.LabelMatchers) && s.HistogramTable != "" {
 		// The regex-histogram fan-out (lowerRegexHistogramSelector) unions
-		// several arms — never a single unambiguous Sum/Histogram scan.
+		// several arms — never a single unambiguous scan.
 		return ""
 	}
 	tables := s.TablesForUnknownName()
@@ -3874,27 +3878,63 @@ func rangeVectorCounterTemporalityColumn(vs *parser.VectorSelector, s schema.Met
 	if err != nil || len(route.tables) != 1 {
 		return ""
 	}
-	if route.tables[0] != s.SumTable && route.tables[0] != s.HistogramTable {
-		return ""
-	}
 	// The `_bucket` fan-out (wrapHistogramBucketFanout) and the `_count` /
 	// `_sum` / exp-histogram companion routing (buildHistogramCompanionArm,
 	// lowerCompanionUnion, expHistogramSelectorRouting) all pre-merge
 	// resource attributes themselves and pass augmentSelectorAttributes a
 	// ctx with attributesPreMerged set — which makes selectorAttributesExpr
 	// return the bare Attributes ColumnRef, taking augmentSelectorAttributes'
-	// EARLY RETURN before it ever reaches the temporality-widening branch.
-	// route.tables reporting a single Sum/Histogram table doesn't rule any
-	// of these out (the companion-union case still reports
-	// route.tables == [HistogramTable] even though its real output is a
-	// 4-column UnionAll with the Sum-table arm, which cannot carry
-	// AggregationTemporality through at all). Restricting eligibility to a
-	// route with NONE of these set is what keeps this to the plain-selector
-	// path augmentSelectorAttributes actually widens.
+	// EARLY RETURN before it ever reaches a column-widening branch.
+	// route.tables reporting a single table doesn't rule any of these out
+	// (the companion-union case still reports route.tables == [HistogramTable]
+	// even though its real output is a multi-column UnionAll with a second
+	// arm). Restricting eligibility to a route with NONE of these set is what
+	// keeps this to the plain-selector path augmentSelectorAttributes
+	// actually widens.
 	if route.bucketSuffixed != "" || route.companionValueColumn != "" || route.expHistogramCompanion {
 		return ""
 	}
+	return route.tables[0]
+}
+
+// rangeVectorCounterTemporalityColumn reports which column
+// chplan.RangeWindow.TemporalityColumn should carry for a
+// counterTemporalityRangeFn call over vs, or "" when none applies.
+//
+// The column only applies when resolveUnambiguousScanTable resolves to the
+// Sum or (classic) Histogram table: a Gauge-table scan carries no
+// AggregationTemporality column in production, the exp-histogram /
+// companion-union arms stay out of #1628's scope (see the nil-temporality
+// call sites in histogram_quantile_range.go / histogram_quantile_native_window.go),
+// and the (Gauge, Sum) Scan.UnionTables ambiguous-routing shape (an
+// unsuffixed metric name that could live in either table) deliberately drops
+// the Sum-only column from its projection so the union's column list still
+// matches — resolveUnambiguousScanTable's own len(route.tables) != 1 check
+// answers "" for exactly that shape.
+func rangeVectorCounterTemporalityColumn(vs *parser.VectorSelector, s schema.Metrics, ctx lowerCtx) string {
+	if s.AggregationTemporalityColumn == "" {
+		return ""
+	}
+	table := resolveUnambiguousScanTable(vs, s, ctx)
+	if table != s.SumTable && table != s.HistogramTable {
+		return ""
+	}
 	return s.AggregationTemporalityColumn
+}
+
+// rangeVectorSingleGaugeTable reports whether vs resolves to an unambiguous
+// Gauge-table scan — last_over_time()'s downsample-tier eligibility
+// counterpart of rangeVectorCounterTemporalityColumn's Sum/Histogram check
+// (cerberus issue #2858). last_over_time() is temporality-agnostic by
+// definition (schema.DownsampleTierTemporalityColumn's own doc), so unlike
+// irate()/idelta() — which stay Sum/Histogram-only, since a gauge has no
+// counter-reset rule for either — it is ALSO eligible for the tier over a
+// Gauge-table resolution.
+func rangeVectorSingleGaugeTable(vs *parser.VectorSelector, s schema.Metrics, ctx lowerCtx) bool {
+	if s.GaugeTable == "" {
+		return false
+	}
+	return resolveUnambiguousScanTable(vs, s, ctx) == s.GaugeTable
 }
 
 // noRecollapse spells out the [nativeTSGridMatrixNode] recollapse argument for

--- a/internal/schema/ddl/ddl.go
+++ b/internal/schema/ddl/ddl.go
@@ -875,13 +875,20 @@ func renderSignal(cfg Config, s Signal) ([]string, error) {
 		// The downsampled long-range tier (cerberus issue #2751) is entirely
 		// opt-in and entirely cerberus-authored, the same shape as the
 		// DELTA-prefix pair immediately above — CREATE precedes the MV
-		// (which references it in its TO clause).
+		// (which references it in its TO clause). The Gauge-sourced MV
+		// (cerberus issue #2858) is a SECOND, independent MV into the SAME
+		// table, added only when Gauge and Sum are configured as distinct
+		// physical tables — see renderDownsampleTierGaugeView's own doc for
+		// why an identically-configured pair skips it.
 		if cfg.DownsampleTierEnabled {
 			stmts = append(
 				stmts,
 				renderDownsampleTierTable(cfg),
 				renderDownsampleTierView(cfg),
 			)
+			if cfg.Tables.MetricsGauge != cfg.Tables.MetricsSum {
+				stmts = append(stmts, renderDownsampleTierGaugeView(cfg))
+			}
 		}
 		// Column statistics (issue #2766) trail every other metrics
 		// statement — CREATE, then projections, then the temporality index,
@@ -1491,11 +1498,12 @@ func renderDownsampleTierTable(cfg Config) string {
 // renderDownsampleTierView renders the CREATE MATERIALIZED VIEW feeding
 // renderDownsampleTierTable from the Sum table (cerberus issue #2751): every
 // raw sample, bucketed to its downsampleTierBucketEndExpr boundary, folded
-// through timeSeriesLastTwoSamplesState. Scoped to the Sum table only
-// (counters) — v1's deliberate scope decision, matching
-// renderDeltaPrefixView's own single-source-table shape; a gauge metric's
-// last_over_time() never routes to this tier (see
-// internal/promql/lower_strategy.go's eligibility check).
+// through timeSeriesLastTwoSamplesState. Scoped to the Sum table alone —
+// counters, feeding irate()/idelta()/last_over_time() — with
+// renderDownsampleTierGaugeView below as its Gauge-sourced sibling (cerberus
+// issue #2858), feeding the SAME target table for last_over_time() only (a
+// gauge has no counter-reset semantics for irate()/idelta() — see
+// internal/promql/lower.go's attachDownsampleTierArm).
 //
 // any(AggregationTemporality) also rides along, feeding
 // schema.DownsampleTierTemporalityColumn — exact per bucket because a
@@ -1531,6 +1539,68 @@ func renderDownsampleTierView(cfg Config) string {
 			bucketEnd,
 		)
 	stmt := chsql.CreateMaterializedView(schema.DownsampleTierTable+cerberusOwnedViewSuffix).
+		Database(cfg.Database).
+		IfNotExists().
+		To(cfg.Database, schema.DownsampleTierTable).
+		As(body)
+	if cfg.Cluster != "" {
+		stmt.OnCluster(cfg.Cluster)
+	}
+	return stmt.SQL()
+}
+
+// renderDownsampleTierGaugeView renders the CREATE MATERIALIZED VIEW feeding
+// renderDownsampleTierTable from the Gauge table (cerberus issue #2858):
+// renderDownsampleTierView's sibling, folding every raw Gauge sample through
+// the SAME timeSeriesLastTwoSamplesState bucketing into the SAME physical
+// tier table via a SECOND, independent MV — the same "two MVs, one
+// AggregatingMergeTree target" shape renderDeltaPrefixView's own doc
+// establishes as this codebase's precedent, not a new pattern.
+//
+// A Gauge series carries no AggregationTemporality column at all — the
+// column does not exist on the Gauge table's schema, unlike a merely-empty
+// value in a column that does exist. In place of `any(AggregationTemporality)`
+// this projects the fixed schema.DownsampleTierGaugeTemporalitySentinel
+// literal — see that constant's own doc for why a sentinel outside the
+// OTLP-enum range, rather than a second physical tier table, is the correct
+// choice here: the read side (internal/chsql's emitRangeWindowDownsampleTier)
+// already scans schema.DownsampleTierTable by MetricName + label matchers
+// alone, with no notion of "which MV wrote this row" anywhere in its own
+// query shape — adding a second physical table would mean TEACHING the read
+// side that distinction for the first time, whereas the sentinel keeps it
+// exactly as agnostic as it already is for the Sum-only v1 shipped by
+// #2751.
+//
+// Skipped by RenderAll when cfg.Tables.MetricsGauge equals cfg.Tables.MetricsSum
+// (a deployment schema is allowed to point both at the same physical table —
+// see schema.Metrics.TablesForUnknownName's own doc): in that configuration
+// renderDownsampleTierView's Sum-sourced MV above already fires on every row
+// this one would otherwise re-read from the identical table, and adding a
+// second MV over the same source would double-fold every sample into the
+// tier table AND make the merged Temporality column's any() pick
+// nondeterministically between a real reading and the sentinel for what is
+// actually the same underlying row.
+func renderDownsampleTierGaugeView(cfg Config) string {
+	bucketEnd := downsampleTierBucketEndExpr(metricTimeColumn, schema.DownsampleTierBucket)
+	body := chsql.NewQuery().
+		Select(
+			chsql.Col(metricNameColumn),
+			chsql.Col(metricAttributesColumn),
+			chsql.Col(metricResourceAttributesColumn),
+			chsql.Col(metricServiceNameColumn),
+			chsql.As(bucketEnd, schema.DownsampleTierBucketColumn),
+			chsql.As(chsql.Call("timeSeriesLastTwoSamplesState", chsql.Col(metricTimeColumn), chsql.Col(metricValueColumn)), schema.DownsampleTierSamplesColumn),
+			chsql.As(chsql.InlineLit(schema.DownsampleTierGaugeTemporalitySentinel), schema.DownsampleTierTemporalityColumn),
+		).
+		From(chsql.Qual(cfg.Database, cfg.Tables.MetricsGauge)).
+		GroupBy(
+			chsql.Col(metricNameColumn),
+			chsql.Col(metricAttributesColumn),
+			chsql.Col(metricResourceAttributesColumn),
+			chsql.Col(metricServiceNameColumn),
+			bucketEnd,
+		)
+	stmt := chsql.CreateMaterializedView(schema.DownsampleTierTable+"_gauge"+cerberusOwnedViewSuffix).
 		Database(cfg.Database).
 		IfNotExists().
 		To(cfg.Database, schema.DownsampleTierTable).

--- a/internal/schema/downsample_tier.go
+++ b/internal/schema/downsample_tier.go
@@ -58,6 +58,33 @@ const (
 	DownsampleTierTemporalityColumn = "Temporality"
 )
 
+// DownsampleTierGaugeTemporalitySentinel is the Temporality value the
+// Gauge-sourced materialized view (internal/schema/ddl's
+// renderDownsampleTierGaugeView, cerberus issue #2858) writes in place of a
+// real AggregationTemporality reading — a Gauge series has no such column at
+// all, unlike a merely-absent value in one that exists. Chosen OUTSIDE the
+// OTLP AggregationTemporality wire enum's valid {0, 1, 2} range
+// (AggregationTemporalityUnspecified / Delta / Cumulative below) specifically
+// so it can never be misread as a genuine reading by any code that branches
+// on this column.
+//
+// The only reader of DownsampleTierTemporalityColumn is irate() (see that
+// constant's own doc: idelta() and last_over_time() never branch on it), and
+// irate()'s own tier eligibility (internal/promql/lower.go's
+// attachDownsampleTierArm, via rangeVectorCounterTemporalityColumn) requires
+// an UNAMBIGUOUS Sum/Histogram-table resolution — which a Gauge-table metric
+// never satisfies, and which an AMBIGUOUS name (one [Metrics.TablesFor] could
+// resolve to either Gauge or Sum) never satisfies either, since that check
+// requires the routed table set to have exactly one member. So an irate()
+// query can only ever read tier rows THIS view wrote when its own metric name
+// is also somehow routable to Sum/Histogram — which the same single-table
+// check rules out by construction. See internal/chsql's downsample-tier
+// gauge chDB test for the empirical proof that this sentinel, if it were
+// ever read by CounterOrDeltaPairDelta, would take the safe "not DELTA"
+// branch rather than being confused for a genuine Delta or Cumulative
+// reading.
+const DownsampleTierGaugeTemporalitySentinel int64 = -1
+
 // DownsampleTierBucket is the tier's single supported aggregation bucket —
 // fixed, not operator-configurable (cerberus issue #2751's deliberate v1
 // scope decision). It mirrors the retired otel_metrics_sum_5m rollup's own


### PR DESCRIPTION
## Summary

Extends the downsampled long-range tier (#2751, #2857) to cover Gauge-table
metrics: `last_over_time(<gauge_metric>[5m])` now routes onto the tier when
the query shape is otherwise eligible, closing #2858.

## Design decision: shared table + sentinel, not a second physical table

The issue named two options. I picked **a second, independent materialized
view feeding the SAME `otel_metrics_sum_downsample_tier` table**, with a
fixed sentinel `Temporality` value for Gauge-sourced rows, over a dedicated
second physical tier table. Empirical reasoning:

- **The read side is already fully source-agnostic.** `internal/chsql`'s
  `emitRangeWindowDownsampleTier` scans the tier table by `MetricName` +
  label matchers alone — it has no notion anywhere in its own SQL shape of
  "which MV wrote this row". A second physical table would require teaching
  the read side that distinction for the first time; the shared-table design
  needs **zero changes** to that emitter.
- **The routing-ambiguity guard that already exists structurally prevents
  cross-table confusion**, independent of the sentinel's specific spelling.
  `irate()`/`idelta()` eligibility (`rangeVectorCounterTemporalityColumn`)
  requires the selector to resolve to an UNAMBIGUOUS Sum/Histogram table;
  I extended the same machinery (refactored into a shared
  `resolveUnambiguousScanTable` helper) for `last_over_time()`'s Gauge-side
  check (`rangeVectorSingleGaugeTable`). A metric name ambiguous between
  Gauge and Sum (the pre-existing `(Gauge, Sum)` fan-out for unsuffixed
  names) is excluded from BOTH checks, so an `irate()` query can only ever
  read tier rows the Sum-sourced MV wrote.
- **Sentinel value**: `schema.DownsampleTierGaugeTemporalitySentinel = -1`,
  outside the OTLP `AggregationTemporality` wire enum's valid `{0, 1, 2}`
  range. The only reader of the `Temporality` column is `irate()`
  (`idelta()`/`last_over_time()` never branch on it) via
  `chsql.CounterOrDeltaPairDelta`, and `irate()`'s own eligibility
  structurally prevents it from ever reading a Gauge-sourced row. Verified
  empirically anyway (defense in depth): a hand-built plan that bypasses the
  Go-level eligibility gate and forces an `irate()` read over a
  sentinel-valued tier row (`TestDownsampleTierGaugeSentinelTemporality_TakesSafeBranch`)
  proves the sentinel takes the same "not DELTA" branch a nil-temporality
  Gauge read already takes — never the DELTA branch.
- **Backfill CLI complexity** is comparable either way (both designs need to
  fold two source tables), but the shared-table design keeps `Verify`
  managing ONE tier table's completeness/TTL/retention logic instead of two.

Both MVs are gated by the SAME `CERBERUS_CH_OPTIMIZATIONS=downsample_tier`
verdict — no new chopt feature or config knob. The Gauge-sourced MV is
skipped when `GaugeTable` is configured identically to `SumTable` (both
DDL-side and CLI-side), avoiding double-processing and the resulting
Temporality `any()`-merge nondeterminism that configuration would otherwise
create.

## Honest scope note

An UNSUFFIXED metric name (the shape a real Gauge metric has) is ambiguous
between Gauge and Sum under the standard two-table schema
(`schema.Metrics.TablesForUnknownName`) — this is a **pre-existing**
restriction, the exact same one that already keeps an unsuffixed COUNTER
metric out of `irate()`/`idelta()`'s own tier eligibility (only a
`_total`-suffixed name resolves unambiguously to Sum). I extended
`last_over_time()`'s Gauge eligibility symmetrically rather than special-
casing around it. The realistic deployment shape where this fires is one
with no Sum table configured (a Gauge-only metrics source) — every chDB test
below uses that fixture to prove the routing empirically. No follow-up issue
filed: this mirrors existing, intentional behavior rather than introducing a
new gap.

## What's covered by tests

Real ClickHouse (chDB) verification, mirroring the existing
`range_window_downsample_tier_chdb_test.go`'s approach:

- `TestDownsampleTierGauge_ChdbCorrectness` — `last_over_time()` over a
  Gauge-table metric routes to the tier and is bit-identical to the ordinary
  fan-out over the same raw rows (normal pair, boundary-exact bucketing,
  single-sample, gap).
- `TestDownsampleTierGauge_IrateIdeltaNeverRouteToTier` — the required
  negative test: `irate()`/`idelta()` over the same Gauge metric, with the
  same tier lowerers wired, never route (checked both structurally — no
  `schema.DownsampleTierTable` reference in the emitted SQL — and
  empirically, matching a no-lowerers baseline).
- `TestDownsampleTierGauge_SumPathUnaffected` — a counter metric alongside
  the gauge fixtures, in the SAME database (both MVs live), still answers
  `irate()` exactly as the pre-existing Sum-only path does — additive
  extension, not a rewrite.
- `TestDownsampleTierGaugeSentinelTemporality_TakesSafeBranch` — the
  sentinel-safety proof described above.
- `TestDownsampleTier_ChdbCorrectness` / `_ChdbCrossBucketMerge` /
  `_ChdbSlidingWindowMultiAnchor` / `_ChdbCorruptedBucketPostMergeFilter`
  (pre-existing #2751/#2857 tests) all still pass unmodified — the Sum path
  is unaffected.

Plus fast, non-chDB `internal/promql` unit tests pinning the eligibility
shape (`downsample_tier_strategy_test.go`): eligible Gauge resolution,
ineligible `irate()`/`idelta()` over the same unambiguous Gauge metric,
ineligible when no Gauge table is configured, ineligible for the ambiguous
`(Gauge, Sum)` case.

`internal/downsampletier`'s backfill/rebuild/verify CLI is extended to fold
and verify against both sources (`BackfillSQL`/`RebuildSQL` now return one
`Statement` per source; `Verify`'s completeness check sums per-metric bucket
counts across both). Coverage: `internal/downsampletier` 99.4%,
`internal/promql`'s new/changed functions 100%, `internal/schema/ddl`
(merged default+chdb) 96.1% — all above their respective
`test/coverage-floor/` entries.

## Verified locally

- `just test-unit` (full `go test -race ./...`) — green.
- `golangci-lint run ./...` and `golangci-lint run --build-tags cerberus_untagged_build ./...` — 0 issues.
- `just vet-tagged` — clean.
- `just build` — clean.
- Full `go test -tags chdb ./internal/chsql/...` (~365s) — green, including
  every downsample-tier test (Sum and Gauge).
- `node .github/scripts/forbid-sql-raw.mjs`, `forbid-skip.mjs` (all checks),
  `forbid-chplan-fn-literal.mjs`, `forbid-verbatim-concat.mjs` — clean.
- `just lint-md` — clean.

## Test plan

- [x] Real ClickHouse (chDB) correctness for gauge-sourced `last_over_time()`
- [x] Real ClickHouse (chDB) negative test: `irate()`/`idelta()` never route a gauge metric
- [x] Real ClickHouse (chDB) sentinel-safety proof
- [x] Sum-table path (#2751/#2857) unaffected — same chDB tests pass unmodified, plus a coexistence test
- [x] CI green (lint, check-test, check-build, chdb)
