### PR TITLE
feat(tempo): push structural two-phase trace-id sets as external tables (#2783)

### DIFF
--- a/.github/ci-lanes.json
+++ b/.github/ci-lanes.json
@@ -409,6 +409,7 @@
         "router-corpus-integration",
         "solver-memory-apportion-integration",
         "strict-scan-test",
+        "structural-two-phase-external-table-integration",
         "traces-scan-bound-integration",
         "traces-scan-window-integration",
         "ts-grid-last-over-time-integration"

--- a/.github/workflows/strict-scan.yml
+++ b/.github/workflows/strict-scan.yml
@@ -166,6 +166,19 @@ jobs:
       - name: Run Tempo traces-scan WINDOW differential (real ClickHouse)
         run: just traces-scan-window-integration
 
+      # Issue #2783: the structural two-phase phase-B restriction may push its
+      # TraceId set as a native-protocol external table instead of a spliced
+      # literal IN list once the literal's estimated size crosses a byte
+      # budget. This step proves, against a real ClickHouse: (i) the
+      # external-table form returns byte-identical results to the literal
+      # form; (ii) EXPLAIN indexes=1 shows idx_trace_id drops the SAME
+      # granule count for both forms; and (iii) a chclient.WithExternalTraceIDs
+      # context is safe to dispatch more than once (a transport retry, or a
+      # route-B shard). See
+      # internal/api/tempo/structural_two_phase_external_table_integration_test.go.
+      - name: Run structural two-phase external-trace-id-table verification (real ClickHouse)
+        run: just structural-two-phase-external-table-integration
+
       # The failure-driven route memo's mandatory per-shard memory
       # apportionment (Executor.runShard) stamps a max_memory_usage override
       # via chclient.WithQuerySetting. chDB is known-lenient about settings

--- a/Justfile
+++ b/Justfile
@@ -346,6 +346,29 @@ traces-scan-window-integration:
     @just _pull-retry {{CH_TEST_IMAGE}}
     go test -timeout 15m -tags=integration -count=1 -run TestTracesScanWindowRealCH ./internal/api/tempo/...
 
+# Run the structural two-phase external-trace-id-table real-CH verification
+# (issue #2783): the phase-B literal `TraceId IN (...)` splice vs. the
+# native-protocol external-table push restrictStructural switches to on wide
+# closures. Three tests share this lane (they all seed the same otel_traces
+# shape at real-server scale, so one recipe/CI step covers them without
+# tripling the container-boot overhead each pays independently):
+#   - TestStructuralTwoPhase_ExternalTraceIDTable_RealCH — drives the real
+#     /api/search handler with h.ExternalTraceIDPush toggled and asserts the
+#     external-table run returns the EXACT same ordered traces as the literal
+#     run, with a comparable (not blown-up) read_rows count.
+#   - TestStructuralTwoPhase_ExternalTraceIDTable_ExplainIndexes — the
+#     issue's own EXPLAIN indexes=1 mandate: asserts idx_trace_id drops the
+#     SAME granule count for both forms.
+#   - TestExternalTraceIDs_ReusableAcrossDispatches — proves a
+#     chclient.WithExternalTraceIDs ctx is safe to dispatch more than once
+#     (the shape both a transport retry and a route-B shard take).
+# Requires Docker; gated behind the `integration` build tag. See
+# internal/api/tempo/structural_two_phase_external_table_integration_test.go
+# and strict-scan.yml.
+structural-two-phase-external-table-integration:
+    @just _pull-retry {{CH_TEST_IMAGE}}
+    go test -timeout 15m -tags=integration -count=1 -run 'TestStructuralTwoPhase_ExternalTraceIDTable|TestExternalTraceIDs_ReusableAcrossDispatches' ./internal/api/tempo/...
+
 # Run the perf-smoke real-ClickHouse sentinel differential (#2370 PR 1): the
 # real-CH memory-bounding guard for the #2364 incident class. PR #2358
 # disabled ClickHouse's query analyzer for native-histogram plan shapes,

--- a/cmd/cerberus/main.go
+++ b/cmd/cerberus/main.go
@@ -18,6 +18,7 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/ClickHouse/clickhouse-go/v2"
 	"go.opentelemetry.io/otel"
 	"golang.org/x/sync/semaphore"
 	"google.golang.org/grpc"
@@ -231,6 +232,7 @@ func mountAPIHeads(
 		tempoHandler := tempo.New(tempoClient, cfg.Traces, Version, logger.With("api", "tempo"))
 		tempoHandler.Limiter = limiters.tempo
 		tempoHandler.StructuralTwoPhase = cfg.TempoStructuralTwoPhase
+		tempoHandler.ExternalTraceIDPush = buildExternalTraceIDPush(optSet, cfg.ClickHouse.Protocol)
 		// Same knob + wiring shape as the prom and loki heads (see
 		// newPromHandler / newLokiHandler above): the Go-side context-deadline
 		// backstop that unblocks a hung handler and releases its admit slot +
@@ -937,6 +939,29 @@ func buildScanEstimateAdvisor(
 // buildPerRungAdmission constructed and buildScanEstimateAdvisor also
 // threads, never a third one, so all three mechanisms' state cannot
 // diverge.
+// buildExternalTraceIDPush resolves internal/api/tempo.Handler.ExternalTraceIDPush
+// (cerberus issue #2783): whether the structural two-phase phase-B
+// restriction (structural_two_phase.go's restrictStructural) may push a wide
+// closure's TraceId set as a native-protocol external table instead of a
+// spliced literal. Gated on TWO independent axes ANDed together —
+//
+//   - the chopt trace_id_external_table feature (an operator opt-in via
+//     CERBERUS_CH_OPTIMIZATIONS: AlwaysAvailable + AutoSelect=false, pending
+//     production calibration beyond this issue's own synthetic corpus — see
+//     the registry entry's doc); and
+//   - protocol == clickhouse.Native, because the mechanism itself
+//     (clickhouse-go/v2's WithExternalTable) is the native-protocol wire
+//     feature #2783 scoped this PR to — the chopt resolver has no visibility
+//     into Config.Protocol, so this function is the single place both axes
+//     combine.
+//
+// false (the default when the feature is unlisted, or when the deployment
+// runs Protocol=http) keeps every phase-B restriction on the pre-#2783
+// literal-splice path, byte-identical.
+func buildExternalTraceIDPush(optSet chopt.EnabledSet, protocol clickhouse.Protocol) bool {
+	return optSet.Has(chopt.FeatureTraceIDExternalTable) && protocol == clickhouse.Native
+}
+
 func buildCardinalityProbeAdvisor(
 	client *chclient.Client,
 	optSet chopt.EnabledSet,

--- a/docs/clickhouse-optimizations.md
+++ b/docs/clickhouse-optimizations.md
@@ -158,6 +158,7 @@ table.
 | `cardinality_probe`              | none       | experimental | no         |
 | `full_text_index`                | 26.2       | experimental | no         |
 | `text_index_line_filter`         | 26.4       | experimental | no         |
+| `trace_id_external_table`        | none       | experimental | no         |
 <!-- END GENERATED: chopt-feature-table -->
 
 The rich, hand-authored columns below stay OUTSIDE the generated block: they

--- a/internal/api/tempo/handler.go
+++ b/internal/api/tempo/handler.go
@@ -154,6 +154,17 @@ type Handler struct {
 	// it true; cmd/ overrides from config.
 	StructuralTwoPhase bool
 
+	// ExternalTraceIDPush is the resolved chopt trace_id_external_table
+	// verdict, ANDed with Config.ClickHouse.Protocol==clickhouse.Native
+	// (cmd/cerberus's buildExternalTraceIDPush) — cerberus issue #2783. When
+	// true, runStructuralTwoPhase's phase-B restriction may push the phase-A
+	// TraceId set as a native-protocol external table instead of splicing it
+	// as a literal IN list once the literal's estimated size crosses
+	// traceIDLiteralByteBudget; see restrictStructural. false (New()'s
+	// default, matching every un-wired Handler in tests) keeps every phase-B
+	// restriction on the pre-#2783 literal path, byte-identical.
+	ExternalTraceIDPush bool
+
 	// QueryTimeout is the default per-request wall-clock budget every query
 	// entrypoint installs via applyQueryTimeout, wired from
 	// Config.ClickHouse.QueryTimeout — the same knob prom and loki draw

--- a/internal/api/tempo/structural_two_phase.go
+++ b/internal/api/tempo/structural_two_phase.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/tsouza/cerberus/internal/chclient"
 	"github.com/tsouza/cerberus/internal/chplan"
 	"github.com/tsouza/cerberus/internal/chsql"
 	"github.com/tsouza/cerberus/internal/engine"
@@ -15,6 +16,65 @@ import (
 // uses as a trace's startTimeUnixNano. It is only ever referenced by the
 // ORDER BY of the phase-A plan and never surfaces on the wire.
 const phaseARankTsAlias = "rankTs"
+
+// externalTraceIDTableName is the fixed name restrictStructural stamps onto
+// chplan.StructuralJoin.TraceIDExternalTable and runStructuralTwoPhase passes
+// to chclient.WithExternalTraceIDs (issue #2783). A single fixed name is safe
+// even across concurrent phase-B dispatches (route-B sharding, or two
+// unrelated requests in flight at once): ClickHouse scopes a native-protocol
+// external table to the ONE query dispatch that declares it and tears the
+// backing storage down when that query finishes (see
+// chclient.WithExternalTraceIDs's doc), so there is no server-side registry
+// for two dispatches sharing this name to collide in.
+const externalTraceIDTableName = "cerberus_phase_b_trace_ids"
+
+// traceIDRestrictionSiteCount is the number of independent closure scan
+// sites chsql/structural_join.go's traceIDRestrictionFrag call sites splice
+// TraceIDRestriction onto (the anchor seed, the recursive step, the R leaf on
+// both the anti-join and direct-join arms, and the inverse-closure anchor).
+// Not every phase-B shape reaches every site simultaneously, but
+// useExternalTraceIDTable sizes its budget for the worst case — assuming
+// every site fires — so the byte-size decision never under-shoots and lets a
+// too-large literal splice through.
+const traceIDRestrictionSiteCount = 5
+
+// traceIDLiteralByteBudget bounds the TOTAL literal bytes
+// useExternalTraceIDTable is willing to let restrictStructural splice across
+// every closure scan site (traceIDRestrictionSiteCount of them) before
+// switching to the external-table form. chsql's own emitted-SQL bound
+// (internal/chsql/emit_size_bound.go's maxEmittedSQLBytes) is 262144 bytes —
+// ClickHouse's own max_query_size default — and this budget reserves the
+// majority of that for the REST of the query text (the recursive CTE
+// structure, window predicates, projected columns), rather than letting the
+// restriction alone consume it.
+const traceIDLiteralByteBudget = 64 * 1024
+
+// estimatedLiteralBytes returns the SQL-text weight of splicing ids as a
+// single `IN ('id0','id1',...)` literal list — each id wrapped in one quote
+// on either side plus a separator — matching what chsql's
+// inStringLiteralsFrag / InlineLit render (a 1-byte overcount for the list's
+// final id, which has no trailing separator, is irrelevant at threshold
+// scale).
+func estimatedLiteralBytes(ids []string) int {
+	total := 0
+	for _, id := range ids {
+		total += len(id) + len(`'',`)
+	}
+	return total
+}
+
+// useExternalTraceIDTable reports whether restrictStructural should push ids
+// as a native-protocol external table (chclient.WithExternalTraceIDs) rather
+// than splice them as literals: external is only ever worth its round trip
+// once the literal form's estimated total bytes — across every closure scan
+// site the restriction reaches — crosses traceIDLiteralByteBudget. Below the
+// budget the literal splice is cheaper and, per issue #2783's EXPLAIN
+// indexes=1 verification against a real ClickHouse server, prunes
+// idx_trace_id identically to the external-table form at every size tested —
+// so the choice is purely about SQL-text-size risk, never pruning parity.
+func useExternalTraceIDTable(ids []string) bool {
+	return estimatedLiteralBytes(ids)*traceIDRestrictionSiteCount > traceIDLiteralByteBudget
+}
 
 // structuralTwoPhaseTarget reports whether the lowered search plan is the
 // positive recursive structural join (`A >> B` / `A << B`) the two-phase
@@ -121,10 +181,13 @@ func (h *Handler) SearchResult(ctx context.Context, query string, limit int) (en
 // TraceId ASC LIMIT N — the exact ranking sortSummariesStartDesc +
 // TruncateSummaries apply downstream — yielding the top-N on-disk TraceIds.
 // Phase B re-runs the closure projecting WIDE but with those N TraceIds
-// spliced as literals onto every physical spans scan, so idx_trace_id
-// granule-prunes the wide fetch to just the response traces. toTraceSummaries
-// over phase B's rows recomputes the identical summaries; TruncateSummaries is
-// then a no-op safety net (≤ N traces already).
+// restricted onto every physical spans scan, so idx_trace_id granule-prunes
+// the wide fetch to just the response traces — spliced as literals below
+// useExternalTraceIDTable's threshold, or pushed as a native-protocol
+// external table above it when h.ExternalTraceIDPush is set (issue #2783;
+// see restrictStructural). toTraceSummaries over phase B's rows recomputes
+// the identical summaries; TruncateSummaries is then a no-op safety net (≤ N
+// traces already).
 func (h *Handler) runStructuralTwoPhase(ctx context.Context, sj *chplan.StructuralJoin, fullPlan chplan.Node, meta engine.Meta, limit int) (engine.Result, error) {
 	topN, err := h.runStructuralPhaseA(ctx, sj, limit)
 	if err != nil {
@@ -140,7 +203,13 @@ func (h *Handler) runStructuralTwoPhase(ctx context.Context, sj *chplan.Structur
 	// top-N traces, then run the normal wide pipeline (wrap-projection +
 	// optimizer + emit + execute) so res.Samples arrive in the exact shape
 	// toTraceSummaries already consumes.
-	restricted := restrictStructural(fullPlan, topN)
+	restricted, ids, external := restrictStructural(fullPlan, topN, h.ExternalTraceIDPush)
+	if external {
+		ctx, err = chclient.WithExternalTraceIDs(ctx, externalTraceIDTableName, h.Schema.TraceIDColumn, ids)
+		if err != nil {
+			return engine.Result{}, fmt.Errorf("engine: execute: structural phase B external trace-id table: %w", err)
+		}
+	}
 	return h.Engine.QueryPlan(ctx, h.lang, restricted, meta)
 }
 
@@ -220,19 +289,30 @@ func buildStructuralPhaseAPlan(sj *chplan.StructuralJoin, s schema.Traces, limit
 }
 
 // restrictStructural clones the lowered structural-join plan and stamps the
-// phase-A top-N TraceIds onto it as the closure's TraceIDRestriction, so phase
-// B's wide fetch reads only those traces. The ids are routed through
+// phase-A top-N TraceIds onto it as the closure's restriction, so phase B's
+// wide fetch reads only those traces. The ids are routed through
 // padTraceIDs (the root-lookup literal-splice helper) — idempotent for the
 // on-disk 32-char form phase A returns, and a defensive left-pad for any short
-// id — so the spliced literals match otel_traces.TraceId exactly.
-func restrictStructural(plan chplan.Node, topN []string) chplan.Node {
+// id — so the restriction matches otel_traces.TraceId exactly whichever form
+// it takes.
+//
+// externalEligible is h.ExternalTraceIDPush: when false (the pre-#2783
+// default) every restriction is the literal splice, byte-identical to
+// before. When true, restrictStructural ALSO checks useExternalTraceIDTable —
+// only once BOTH hold does it stamp TraceIDExternalTable instead of
+// TraceIDRestriction, and reports external=true so the caller
+// (runStructuralTwoPhase) knows to attach the actual id rows via
+// chclient.WithExternalTraceIDs. Returns the padded ids alongside the clone
+// either way, since the caller needs them again for that attach.
+func restrictStructural(plan chplan.Node, topN []string, externalEligible bool) (restricted chplan.Node, ids []string, external bool) {
 	// Clone as a plain Node (not *StructuralJoin): the plan may be a pure-select
 	// Project wrapped over the join (`… >> … | select(...)`), in which case the
 	// root is the Project and the join sits beneath it. eachStructuralJoin walks
 	// into it either way, so the restriction is stamped whether the root is the
 	// join or a wrapper over it.
 	clone := chplan.CloneNode(plan)
-	ids := padTraceIDs(topN)
+	ids = padTraceIDs(topN)
+	external = externalEligible && useExternalTraceIDTable(ids)
 	// Stamp EVERY structural join in the plan, not just the root: a chain
 	// `A >> B >> C` is left-associative, so the root's Left is itself a
 	// StructuralJoin (the inner `A >> B` closure). Restricting only the root
@@ -240,9 +320,13 @@ func restrictStructural(plan chplan.Node, topN []string) chplan.Node {
 	// phases (the exact OOM this fix removes). Every result trace is in the
 	// top-N set, so confining an inner closure to those trace-ids is loss-free.
 	eachStructuralJoin(clone, func(sj *chplan.StructuralJoin) {
-		sj.TraceIDRestriction = ids
+		if external {
+			sj.TraceIDExternalTable = externalTraceIDTableName
+		} else {
+			sj.TraceIDRestriction = ids
+		}
 	})
-	return clone
+	return clone, ids, external
 }
 
 // eachStructuralJoin visits every StructuralJoin in n (root-first), so a

--- a/internal/api/tempo/structural_two_phase_external_table_integration_test.go
+++ b/internal/api/tempo/structural_two_phase_external_table_integration_test.go
@@ -1,0 +1,447 @@
+//go:build integration
+
+// structural_two_phase_external_table_integration_test.go — real-ClickHouse
+// verification for cerberus issue #2783: the native-protocol external-table
+// push that replaces restrictStructural's literal TraceId IN-list splice on
+// wide closures.
+//
+// # WHY THIS LANE EXISTS
+//
+// chDB (search_structural_two_phase_chdb_test.go's own parity lane) proves
+// the two-phase split is result-correct, but it never goes through
+// clickhouse-go/v2's native-protocol Conn — chDB is an embedded engine driven
+// by SQL text, with no WithExternalTable wire feature to exercise. Everything
+// this file checks — that the external-table form (a) returns the exact same
+// traces as the literal form, (b) engages ClickHouse's idx_trace_id skip
+// index the same way the literal form does (issue #2783's own EXPLAIN
+// indexes=1 mandate), and (c) is safe to attach fresh across more than one
+// dispatch of the SAME context (the shape both a retry and a route-B shard
+// take) — needs a real server.
+//
+// Gated behind the `integration` build tag (Docker required), mirroring
+// traces_scan_window_integration_test.go.
+package tempo
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"regexp"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/ClickHouse/clickhouse-go/v2/lib/driver"
+
+	"github.com/tsouza/cerberus/internal/chclient"
+	"github.com/tsouza/cerberus/internal/schema"
+	"github.com/tsouza/cerberus/internal/schema/ddl"
+)
+
+// extTblTraceCount is the number of distinct root/leaf trace pairs seeded —
+// large enough that its literal IN-list estimate crosses
+// traceIDLiteralByteBudget (a 32-hex-char id costs 35 bytes per
+// estimatedLiteralBytes; extTblTraceCount*35*traceIDRestrictionSiteCount must
+// exceed 64KiB), so a request for ALL of them genuinely exercises the
+// external-table path rather than falling back to the literal one anyway.
+const extTblTraceCount = 700
+
+// extTblExplainIDCount is the id-set size the EXPLAIN indexes=1 sub-test
+// splices/pushes — small enough (per issue #2783's own manual verification)
+// that idx_trace_id still meaningfully prunes granules for BOTH forms, so a
+// pruning-parity regression shows up as a granule-count difference rather
+// than both forms degrading to a full scan alike.
+const extTblExplainIDCount = 200
+
+func TestStructuralTwoPhase_ExternalTraceIDTable_RealCH(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Minute)
+	defer cancel()
+
+	client := startScanWinCH(ctx, t)
+	conn := client.Conn()
+	if err := ddl.Apply(ctx, conn, []ddl.Signal{ddl.Traces}); err != nil {
+		t.Fatalf("apply traces DDL: %v", err)
+	}
+	seedExtTblTraces(ctx, t, conn)
+
+	s := schema.DefaultOTelTraces()
+	q := &loggedCappedQuerier{inner: client}
+	h := New(q, s, "v-test", nil)
+	mux := http.NewServeMux()
+	h.Mount(mux)
+
+	query := `{ resource.service.name = "ext-root" } >> { resource.service.name = "ext-leaf" }`
+	params := url.Values{
+		"q":     {query},
+		"limit": {strconv.Itoa(extTblTraceCount)},
+		"start": {"1777593600"},
+		"end":   {"1777680000"},
+	}
+
+	// --- Run 1: h.ExternalTraceIDPush=false forces the pre-#2783 literal
+	// splice even though the closure is wide enough to qualify. ---
+	h.ExternalTraceIDPush = false
+	literalMarker := "ext2783_literal"
+	literal := extTblDoSearch(t, mux, q, literalMarker, params)
+	if len(literal.Traces) != extTblTraceCount {
+		t.Fatalf("literal-path search returned %d traces, want all %d — seed or closure misconfigured",
+			len(literal.Traces), extTblTraceCount)
+	}
+	literalReadRows := scanWinRequestReadRows(ctx, t, conn, literalMarker)
+
+	// --- Run 2: h.ExternalTraceIDPush=true, same request. useExternalTraceIDTable
+	// must actually pick the external form here (extTblTraceCount is sized for
+	// that above), which the granule-parity assertion below indirectly proves —
+	// a run that silently fell back to the literal form would read the exact
+	// same rows, not merely similar ones. ---
+	h.ExternalTraceIDPush = true
+	externalMarker := "ext2783_external"
+	external := extTblDoSearch(t, mux, q, externalMarker, params)
+	externalReadRows := scanWinRequestReadRows(ctx, t, conn, externalMarker)
+
+	// ★ Correctness parity: the external-table form must return the EXACT
+	// same ordered trace set as the literal form — the whole point of #2783
+	// is a wire-format change with no observable difference in results.
+	if len(external.Traces) != len(literal.Traces) {
+		t.Fatalf("external-table search returned %d traces, want %d (literal-path count)",
+			len(external.Traces), len(literal.Traces))
+	}
+	for i := range literal.Traces {
+		if external.Traces[i].TraceID != literal.Traces[i].TraceID {
+			t.Errorf("trace %d: external=%q literal=%q — external-table form diverged from the literal reference",
+				i, external.Traces[i].TraceID, literal.Traces[i].TraceID)
+		}
+		if external.Traces[i].StartTimeUnixNano != literal.Traces[i].StartTimeUnixNano {
+			t.Errorf("trace %d (%s): external StartTimeUnixNano=%s literal=%s",
+				i, external.Traces[i].TraceID, external.Traces[i].StartTimeUnixNano, literal.Traces[i].StartTimeUnixNano)
+		}
+	}
+
+	// ★ Read-row parity: the external-table form must read a COMPARABLE
+	// number of rows to the literal form — not dramatically more, which
+	// would mean it lost granule pruning idx_trace_id gives the literal
+	// splice (issue #2783's EXPLAIN indexes=1 risk). A generous 2x band
+	// (rather than requiring near-equality) absorbs the external table's own
+	// small extra read (its own extTblTraceCount rows) plus ordinary
+	// part-layout noise between the two runs.
+	if externalReadRows > literalReadRows*2 {
+		t.Errorf("external-table read_rows=%d, literal read_rows=%d — external form reads more than 2x the literal form, suggesting it lost idx_trace_id pruning",
+			externalReadRows, literalReadRows)
+	}
+	t.Logf("read_rows: literal=%d external=%d (closure=%d traces)", literalReadRows, externalReadRows, extTblTraceCount)
+}
+
+// TestStructuralTwoPhase_ExternalTraceIDTable_ExplainIndexes is issue #2783's
+// own mandated check: EXPLAIN indexes=1 against a real server, comparing the
+// literal IN-list form against the external-table form at a size
+// (extTblExplainIDCount) where idx_trace_id still meaningfully prunes for
+// both. It asserts the two forms drop the SAME number of granules — not
+// merely "some" — so a future ClickHouse version that stops treating an
+// external-table IN-subquery as a prepared set for index analysis would fail
+// this test loudly rather than silently regressing production.
+func TestStructuralTwoPhase_ExternalTraceIDTable_ExplainIndexes(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Minute)
+	defer cancel()
+
+	client := startScanWinCH(ctx, t)
+	conn := client.Conn()
+	if err := ddl.Apply(ctx, conn, []ddl.Signal{ddl.Traces}); err != nil {
+		t.Fatalf("apply traces DDL: %v", err)
+	}
+	seedExtTblTraces(ctx, t, conn)
+	seedExtTblGranuleNoise(ctx, t, conn)
+
+	ids := extTblRootTraceIDs(ctx, t, conn, extTblExplainIDCount)
+	if len(ids) != extTblExplainIDCount {
+		t.Fatalf("seeded %d root trace ids, want %d", len(ids), extTblExplainIDCount)
+	}
+
+	literalDropped, literalTotal := extTblExplainGranules(ctx, t, conn, extTblLiteralExplainSQL(ids))
+
+	const extTable = "ext2783_explain_ids"
+	extCtx, err := chclient.WithExternalTraceIDs(ctx, extTable, "TraceId", ids)
+	if err != nil {
+		t.Fatalf("WithExternalTraceIDs: %v", err)
+	}
+	externalDropped, externalTotal := extTblExplainGranules(extCtx, t, conn, fmt.Sprintf(
+		"EXPLAIN indexes=1 SELECT count() FROM otel_traces WHERE TraceId IN (SELECT TraceId FROM %s)", extTable,
+	))
+
+	if literalTotal != externalTotal {
+		t.Fatalf("literal and external EXPLAIN plans scanned different total granule counts (%d vs %d) — not a comparable pair",
+			literalTotal, externalTotal)
+	}
+	if literalDropped == 0 {
+		t.Fatalf("literal form's idx_trace_id dropped 0 granules — the seed is not selective enough to prove anything")
+	}
+	if externalDropped != literalDropped {
+		t.Errorf("idx_trace_id dropped %d/%d granules for the external-table form, %d/%d for the literal form — external-table pruning is NOT at parity",
+			externalDropped, externalTotal, literalDropped, literalTotal)
+	}
+	t.Logf("idx_trace_id granules dropped: literal=%d/%d external=%d/%d", literalDropped, literalTotal, externalDropped, externalTotal)
+}
+
+// TestExternalTraceIDs_ReusableAcrossDispatches proves the retry / route-B
+// sharding safety issue #2783 calls out: a *ext.Table-carrying context built
+// ONCE by chclient.WithExternalTraceIDs is safe to hand to more than one
+// Client.Query dispatch — the exact shape BOTH a transport retry
+// (chclient/retry.go's withTransportRetry, which reuses the SAME derived ctx
+// across attempts) and a route-B shard (each shard issuing its own Query call
+// under the shared ctx) take. If attaching the table drained or mutated
+// shared state on first use, the second dispatch below would return an empty
+// or short result instead of the full, identical set.
+func TestExternalTraceIDs_ReusableAcrossDispatches(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	defer cancel()
+
+	client := startScanWinCH(ctx, t)
+	conn := client.Conn()
+	if err := ddl.Apply(ctx, conn, []ddl.Signal{ddl.Traces}); err != nil {
+		t.Fatalf("apply traces DDL: %v", err)
+	}
+	seedExtTblTraces(ctx, t, conn)
+
+	ids := extTblRootTraceIDs(ctx, t, conn, extTblExplainIDCount)
+	extCtx, err := chclient.WithExternalTraceIDs(ctx, "ext2783_retry_ids", "TraceId", ids)
+	if err != nil {
+		t.Fatalf("WithExternalTraceIDs: %v", err)
+	}
+	// Filtered to root spans only: each seeded trace carries a root AND a leaf
+	// row (seedExtTblTraces), so counting bare TraceId membership would count
+	// both per trace — restricting to ServiceName='ext-root' keeps the
+	// expected count exactly extTblExplainIDCount, one row per pushed id.
+	const sql = "SELECT toString(count()) FROM otel_traces WHERE ServiceName = 'ext-root' AND TraceId IN (SELECT TraceId FROM ext2783_retry_ids)"
+
+	first, err := client.QueryStrings(extCtx, sql)
+	if err != nil {
+		t.Fatalf("first dispatch: %v", err)
+	}
+	second, err := client.QueryStrings(extCtx, sql)
+	if err != nil {
+		t.Fatalf("second dispatch (simulated retry / second shard) over the SAME ctx: %v", err)
+	}
+	if len(first) != 1 || len(second) != 1 {
+		t.Fatalf("want exactly one count() row per dispatch, got %d then %d", len(first), len(second))
+	}
+	if first[0] != second[0] {
+		t.Fatalf("second dispatch over the same external-table ctx returned %q, want %q (first dispatch) — the table was drained or mutated by the first use",
+			second[0], first[0])
+	}
+	wantCount := strconv.Itoa(extTblExplainIDCount)
+	if first[0] != wantCount {
+		t.Fatalf("count()=%q, want %q (%d seeded root ids all present)", first[0], wantCount, extTblExplainIDCount)
+	}
+}
+
+// extTblSearchResult is the decoded /api/search envelope this file needs —
+// just the trace list, unlike search_trace_limit_chdb_test.go's searchResult
+// (which also tracks the span-drain header this file's assertions don't use).
+type extTblSearchResult struct {
+	SearchResponse
+}
+
+// extTblDoSearch points q's log_comment at marker, issues ONE GET for
+// path+params through mux, and decodes the /api/search response body.
+func extTblDoSearch(t *testing.T, mux *http.ServeMux, q *loggedCappedQuerier, marker string, params url.Values) extTblSearchResult {
+	t.Helper()
+	q.marker = marker
+	req := httptest.NewRequest(http.MethodGet, "/api/search?"+params.Encode(), nil)
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("marker=%s: /api/search returned HTTP %d, want 200: %s", marker, rec.Code, rec.Body.String())
+	}
+	var sr extTblSearchResult
+	if err := json.Unmarshal(rec.Body.Bytes(), &sr.SearchResponse); err != nil {
+		t.Fatalf("marker=%s: decode /api/search body: %v\nbody: %s", marker, err, rec.Body.String())
+	}
+	return sr
+}
+
+// seedExtTblTraces inserts extTblTraceCount root/leaf trace pairs server-side
+// via INSERT … SELECT FROM numbers(), matching seedScanWinTraces's style. Root
+// spans carry ResourceAttributes.service.name="ext-root" (ParentSpanId=""),
+// leaf spans "ext-leaf" parented at the root — the same shape
+// search_structural_two_phase_chdb_test.go's structuralTwoPhaseSeed builds by
+// hand, generated here at real-server scale. Every pair sits inside the same
+// single partition/window (2026-05-01, matching the params start/end used
+// above) so partition pruning is not a confound for the granule-count
+// assertions — only idx_trace_id is under test.
+//
+// traceid is left-padded to the canonical 32-char TraceId hex width
+// (handler.go's traceIDHexLen / normaliseTraceID): padTraceIDs left-pads any
+// SHORTER id with leading zeros before splicing/pushing it as the phase-B
+// restriction, so an unpadded (here, 16-char) synthetic id would restrict on
+// a value that never matches what otel_traces actually stores — phase B
+// would silently return zero rows even though phase A found the trace.
+func seedExtTblTraces(ctx context.Context, t *testing.T, conn driver.Conn) {
+	t.Helper()
+	insert := fmt.Sprintf(`
+INSERT INTO otel_traces
+    (Timestamp, TraceId, SpanId, ParentSpanId, SpanName, SpanKind, ServiceName,
+     ResourceAttributes, SpanAttributes, Duration, StatusCode, StatusMessage,
+     ScopeName, ScopeVersion, TraceState)
+SELECT
+    base_ts + toIntervalSecond(if(leaf, 1, 0)) AS Timestamp,
+    traceid AS TraceId,
+    concat(traceid, if(leaf, '_1', '_0')) AS SpanId,
+    if(leaf, concat(traceid, '_0'), '') AS ParentSpanId,
+    if(leaf, 'leaf-op', 'root-op') AS SpanName,
+    if(leaf, 'Internal', 'Server') AS SpanKind,
+    if(leaf, 'ext-leaf', 'ext-root') AS ServiceName,
+    map('service.name', if(leaf, 'ext-leaf', 'ext-root')) AS ResourceAttributes,
+    map() AS SpanAttributes,
+    1000 AS Duration, 'Unset' AS StatusCode, '' AS StatusMessage,
+    '' AS ScopeName, '' AS ScopeVersion, '' AS TraceState
+FROM (
+    SELECT
+        number AS n,
+        leftPad(lower(hex(reinterpretAsFixedString(number))), 32, '0') AS traceid,
+        toDateTime64('2026-05-01 10:00:00', 9) + toIntervalSecond(number %% 60) AS base_ts
+    FROM numbers(%d)
+) AS tr
+ARRAY JOIN [false, true] AS leaf`, extTblTraceCount)
+	if err := conn.Exec(ctx, insert); err != nil {
+		t.Fatalf("seed insert: %v", err)
+	}
+}
+
+// extTblGranuleNoiseRows is the row count seedExtTblGranuleNoise inserts.
+// idx_trace_id is a bloom_filter skip index over 8192-row granules
+// (index_granularity, ddl's traces DDL default); 4,000,000 noise rows sharing
+// seedExtTblTraces' SAME date partition gives ~488 granules for it to prune
+// against — comparable to the manual scale (20M rows / 2458 granules, 200-id
+// lookup dropping ~2000 of them) issue #2783's own EXPLAIN verification used
+// while implementing this feature, scaled down to keep this test's runtime
+// reasonable for CI.
+const extTblGranuleNoiseRows = 4_000_000
+
+// seedExtTblGranuleNoise inserts extTblGranuleNoiseRows unrelated spans into
+// the SAME date partition seedExtTblTraces uses (2026-05-01), so
+// TestStructuralTwoPhase_ExternalTraceIDTable_ExplainIndexes's EXPLAIN
+// indexes=1 has enough granules for idx_trace_id to meaningfully prune —
+// without this, seedExtTblTraces' own 1,400 rows fit inside a single 8192-row
+// granule and the index has nothing to drop either way. TraceIds are
+// generated from a number range disjoint from seedExtTblTraces' (starting at
+// 10,000,000) so no noise row can collide with a real root/leaf TraceId.
+func seedExtTblGranuleNoise(ctx context.Context, t *testing.T, conn driver.Conn) {
+	t.Helper()
+	insert := fmt.Sprintf(`
+INSERT INTO otel_traces
+    (Timestamp, TraceId, SpanId, ParentSpanId, SpanName, SpanKind, ServiceName,
+     ResourceAttributes, SpanAttributes, Duration, StatusCode, StatusMessage,
+     ScopeName, ScopeVersion, TraceState)
+SELECT
+    toDateTime64('2026-05-01 10:00:00', 9) + toIntervalSecond(number %% 86400) AS Timestamp,
+    leftPad(lower(hex(reinterpretAsFixedString(number + 10000000))), 32, '0') AS TraceId,
+    lower(hex(reinterpretAsFixedString(number + 10000000))) AS SpanId,
+    '' AS ParentSpanId, 'noise-op' AS SpanName, 'Server' AS SpanKind, 'ext-noise' AS ServiceName,
+    map('service.name', 'ext-noise') AS ResourceAttributes, map() AS SpanAttributes,
+    1000 AS Duration, 'Unset' AS StatusCode, '' AS StatusMessage,
+    '' AS ScopeName, '' AS ScopeVersion, '' AS TraceState
+FROM numbers(%d)`, extTblGranuleNoiseRows)
+	if err := conn.Exec(ctx, insert); err != nil {
+		t.Fatalf("seed granule-noise insert: %v", err)
+	}
+	if err := conn.Exec(ctx, "OPTIMIZE TABLE otel_traces FINAL"); err != nil {
+		t.Fatalf("optimize table final: %v", err)
+	}
+}
+
+// extTblRootTraceIDs returns n distinct on-disk TraceId values read directly
+// off the seeded root spans — the exact bytes otel_traces stores, whatever
+// their length, so the literal and external-table forms compare the SAME
+// values either way. extTblLiteralExplainSQL and chclient.WithExternalTraceIDs
+// both consume this slice.
+func extTblRootTraceIDs(ctx context.Context, t *testing.T, conn driver.Conn, n int) []string {
+	t.Helper()
+	rows, err := conn.Query(ctx, fmt.Sprintf(
+		"SELECT TraceId FROM otel_traces WHERE ServiceName = 'ext-root' ORDER BY TraceId LIMIT %d", n,
+	))
+	if err != nil {
+		t.Fatalf("select root trace ids: %v", err)
+	}
+	defer func() { _ = rows.Close() }()
+	var out []string
+	for rows.Next() {
+		var id string
+		if err := rows.Scan(&id); err != nil {
+			t.Fatalf("scan trace id: %v", err)
+		}
+		out = append(out, id)
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatalf("root trace ids rows: %v", err)
+	}
+	return out
+}
+
+// extTblLiteralExplainSQL renders the literal IN-list EXPLAIN statement
+// extTblExplainGranules parses, using chsql's own quoting convention (single
+// quotes) so the rendered predicate matches what inStringLiteralsFrag emits.
+func extTblLiteralExplainSQL(ids []string) string {
+	sql := "EXPLAIN indexes=1 SELECT count() FROM otel_traces WHERE TraceId IN ("
+	for i, id := range ids {
+		if i > 0 {
+			sql += ", "
+		}
+		sql += "'" + id + "'"
+	}
+	return sql + ")"
+}
+
+// extTblExplainGranuleLine matches EXPLAIN indexes=1's per-index summary line,
+// e.g. "Granules: 456/2458" under the "Skip" / "Name: idx_trace_id" block.
+var extTblExplainGranuleLine = regexp.MustCompile(`^\s*Granules: (\d+)/(\d+)\s*$`)
+
+// extTblExplainGranules runs an EXPLAIN indexes=1 statement and returns the
+// idx_trace_id skip index's (dropped, total) granule counts — dropped =
+// total - readGranules, parsed off the "Granules: <read>/<total>" line that
+// immediately follows the "Name: idx_trace_id" line in the plan text
+// (ClickHouse's own EXPLAIN indexes=1 output shape, verified manually against
+// a real 26.6 server while implementing #2783).
+func extTblExplainGranules(ctx context.Context, t *testing.T, conn driver.Conn, sql string) (dropped, total int) {
+	t.Helper()
+	rows, err := conn.Query(ctx, sql)
+	if err != nil {
+		t.Fatalf("EXPLAIN: %v\n%s", err, sql)
+	}
+	defer func() { _ = rows.Close() }()
+	sawIdxTraceID := false
+	for rows.Next() {
+		var line string
+		if err := rows.Scan(&line); err != nil {
+			t.Fatalf("scan EXPLAIN line: %v", err)
+		}
+		if line == "    Name: idx_trace_id" || line == "Name: idx_trace_id" ||
+			(len(line) > 0 && lastField(line) == "idx_trace_id") {
+			sawIdxTraceID = true
+			continue
+		}
+		if sawIdxTraceID {
+			if m := extTblExplainGranuleLine.FindStringSubmatch(line); m != nil {
+				read, _ := strconv.Atoi(m[1])
+				tot, _ := strconv.Atoi(m[2])
+				return tot - read, tot
+			}
+		}
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatalf("EXPLAIN rows: %v", err)
+	}
+	t.Fatalf("EXPLAIN output carried no idx_trace_id Granules line:\n%s", sql)
+	return 0, 0
+}
+
+// lastField returns the last whitespace-separated field of line, used to
+// match "Name: idx_trace_id" regardless of leading-space indentation depth.
+func lastField(line string) string {
+	fields := regexp.MustCompile(`\s+`).Split(line, -1)
+	if len(fields) == 0 {
+		return ""
+	}
+	return fields[len(fields)-1]
+}

--- a/internal/api/tempo/structural_two_phase_external_table_test.go
+++ b/internal/api/tempo/structural_two_phase_external_table_test.go
@@ -1,0 +1,150 @@
+package tempo
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/tsouza/cerberus/internal/chplan"
+)
+
+// TestUseExternalTraceIDTable_Threshold pins the byte-size crossover
+// useExternalTraceIDTable computes: below traceIDLiteralByteBudget (once
+// multiplied by traceIDRestrictionSiteCount) the literal splice wins, at and
+// above it the external table wins. A 32-hex-char TraceId costs
+// len(id)+3 = 35 bytes per estimatedLiteralBytes (the two quotes plus the
+// separator), so the crossover
+// count is traceIDLiteralByteBudget / (35 * traceIDRestrictionSiteCount).
+func TestUseExternalTraceIDTable_Threshold(t *testing.T) {
+	const idBytes = 32 + 3 // one 32-hex-char TraceId plus estimatedLiteralBytes' quote/comma overhead
+	crossover := traceIDLiteralByteBudget / (idBytes * traceIDRestrictionSiteCount)
+
+	below := make([]string, crossover)
+	for i := range below {
+		below[i] = strings.Repeat("a", 32)
+	}
+	if useExternalTraceIDTable(below) {
+		t.Fatalf("useExternalTraceIDTable(%d ids) = true, want false (still under budget)", len(below))
+	}
+
+	above := make([]string, crossover+1)
+	copy(above, below)
+	above[len(above)-1] = strings.Repeat("a", 32)
+	if !useExternalTraceIDTable(above) {
+		t.Fatalf("useExternalTraceIDTable(%d ids) = false, want true (over budget)", len(above))
+	}
+}
+
+// TestUseExternalTraceIDTable_EmptyIsLiteral pins the vacuous case: zero ids
+// never trips the external-table path (runStructuralTwoPhase already returns
+// early on an empty phase-A result before restrictStructural is even called,
+// but the pure function itself must not be the one relying on that).
+func TestUseExternalTraceIDTable_EmptyIsLiteral(t *testing.T) {
+	if useExternalTraceIDTable(nil) {
+		t.Fatalf("useExternalTraceIDTable(nil) = true, want false")
+	}
+}
+
+// TestRestrictStructural_LiteralWhenIneligible pins that restrictStructural
+// never takes the external-table path when externalEligible is false
+// (h.ExternalTraceIDPush unset — the default for every un-wired Handler),
+// even for a closure whose literal splice would cross the byte budget. This
+// is the byte-identical-by-default guarantee: the feature is inert until
+// BOTH the chopt gate and the byte threshold agree.
+func TestRestrictStructural_LiteralWhenIneligible(t *testing.T) {
+	wide := make([]string, 2000)
+	for i := range wide {
+		wide[i] = strings.Repeat("a", 32)
+	}
+	plan := structuralClosurePlanForTest()
+
+	restricted, ids, external := restrictStructural(plan, wide, false)
+	if external {
+		t.Fatalf("restrictStructural chose external with externalEligible=false")
+	}
+	if len(ids) != len(wide) {
+		t.Fatalf("restrictStructural returned %d ids, want %d", len(ids), len(wide))
+	}
+	joins := 0
+	eachStructuralJoin(restricted, func(sj *chplan.StructuralJoin) {
+		joins++
+		if sj.TraceIDExternalTable != "" {
+			t.Errorf("join carries TraceIDExternalTable %q though externalEligible=false", sj.TraceIDExternalTable)
+		}
+		if len(sj.TraceIDRestriction) != len(wide) {
+			t.Errorf("join TraceIDRestriction has %d ids, want %d", len(sj.TraceIDRestriction), len(wide))
+		}
+	})
+	if joins == 0 {
+		t.Fatalf("eachStructuralJoin visited no join")
+	}
+}
+
+// TestRestrictStructural_ExternalWhenEligibleAndWide pins the positive case:
+// externalEligible=true plus a wide closure switches every structural join in
+// the plan to the external-table form, and the returned ids are the padded
+// values runStructuralTwoPhase threads to chclient.WithExternalTraceIDs.
+func TestRestrictStructural_ExternalWhenEligibleAndWide(t *testing.T) {
+	wide := make([]string, 2000)
+	for i := range wide {
+		wide[i] = strings.Repeat("a", 32)
+	}
+	plan := structuralClosurePlanForTest()
+
+	restricted, ids, external := restrictStructural(plan, wide, true)
+	if !external {
+		t.Fatalf("restrictStructural chose literal though externalEligible=true and the closure is wide")
+	}
+	if len(ids) != len(wide) {
+		t.Fatalf("restrictStructural returned %d ids, want %d", len(ids), len(wide))
+	}
+	joins := 0
+	eachStructuralJoin(restricted, func(sj *chplan.StructuralJoin) {
+		joins++
+		if sj.TraceIDExternalTable != externalTraceIDTableName {
+			t.Errorf("join TraceIDExternalTable = %q, want %q", sj.TraceIDExternalTable, externalTraceIDTableName)
+		}
+		if len(sj.TraceIDRestriction) != 0 {
+			t.Errorf("join TraceIDRestriction = %v, want empty when external is chosen", sj.TraceIDRestriction)
+		}
+	})
+	if joins == 0 {
+		t.Fatalf("eachStructuralJoin visited no join")
+	}
+}
+
+// TestRestrictStructural_LiteralWhenEligibleButNarrow pins that a narrow
+// closure stays on the literal path even with externalEligible=true — the
+// external-table round trip is only worth it once the byte budget is
+// actually crossed.
+func TestRestrictStructural_LiteralWhenEligibleButNarrow(t *testing.T) {
+	narrow := []string{strings.Repeat("a", 32), strings.Repeat("b", 32)}
+	plan := structuralClosurePlanForTest()
+
+	restricted, _, external := restrictStructural(plan, narrow, true)
+	if external {
+		t.Fatalf("restrictStructural chose external for a narrow (%d-id) closure", len(narrow))
+	}
+	eachStructuralJoin(restricted, func(sj *chplan.StructuralJoin) {
+		if sj.TraceIDExternalTable != "" {
+			t.Errorf("join carries TraceIDExternalTable %q for a narrow closure", sj.TraceIDExternalTable)
+		}
+	})
+}
+
+// structuralClosurePlanForTest returns a minimal chained `A >> B` closure
+// (root over an inner StructuralJoin) so restrictStructural's
+// eachStructuralJoin walk has more than one node to visit — mirroring
+// phase_a_narrow_test.go's own TestPhaseAStaysNarrow fixture shape.
+func structuralClosurePlanForTest() chplan.Node {
+	scan := func() chplan.Node { return &chplan.Scan{Table: "otel_traces"} }
+	mkJoin := func(l, r chplan.Node) *chplan.StructuralJoin {
+		return &chplan.StructuralJoin{
+			Left: l, Right: r, Op: chplan.StructuralDescendant,
+			TraceIDColumn:      "TraceId",
+			SpanIDColumn:       "SpanId",
+			ParentSpanIDColumn: "ParentSpanId",
+		}
+	}
+	inner := mkJoin(scan(), scan())
+	return mkJoin(inner, scan())
+}

--- a/internal/chclient/external_trace_ids.go
+++ b/internal/chclient/external_trace_ids.go
@@ -1,0 +1,73 @@
+package chclient
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/ClickHouse/clickhouse-go/v2"
+	"github.com/ClickHouse/clickhouse-go/v2/ext"
+)
+
+// external_trace_ids.go closes the chclient half of cerberus issue #2783: the
+// native-protocol external-table push that replaces the phase-B literal
+// TraceId IN-list splice (internal/api/tempo/structural_two_phase.go's
+// restrictStructural) on wide closures. internal/api/tempo is the other
+// half — it decides WHEN to switch (the literal splice's estimated byte cost
+// against a threshold) and names the table on the emitted plan
+// (chplan.StructuralJoin.TraceIDExternalTable); this file only carries the
+// VALUES onto the wire.
+//
+// externalTraceIDColumnType is String because every on-disk TraceId column
+// cerberus reads (schema.Traces.TraceIDColumn) is String — the external
+// table's single column matches it exactly so the `IN (SELECT … FROM …)`
+// comparison chsql.inExternalTraceIDsFrag emits needs no cast.
+const externalTraceIDColumnType = "String"
+
+// WithExternalTraceIDs returns ctx carrying a native-protocol external
+// (temporary) table named table, with one column named column of type
+// String, holding ids — the values a chplan.StructuralJoin.TraceIDExternalTable
+// reference resolves against. Every Client method that derives its dispatch
+// context through queryContext (Query, QueryStrings, and the rest) picks it
+// up automatically: clickhouse.Context/queryOptions merge with whatever is
+// already on ctx (clickhouse-go/v2's own contract — see context.go's
+// Context()), so stacking this ahead of a Client call composes with the
+// settings/query-id options queryContext adds on top, in either order.
+//
+// Lifetime and safety:
+//
+//   - Per-query, like a bound parameter. The driver serialises the table's
+//     rows onto the wire as part of the ONE query dispatch that carries this
+//     ctx (conn_send_query.go's sendQuery: the external tables ride the same
+//     packet as the query body, before the empty end-of-data block). Building
+//     the *ext.Table below never mutates ids, and encoding a table's block does
+//     not drain it — clickhouse-go's own external-table example queries the
+//     same *ext.Table more than once off one build — so calling this again on
+//     a fresh ctx for a retry, or reusing the returned ctx across several
+//     route-B shard dispatches, resends the SAME complete row set every time;
+//     nothing carries over silently and nothing is short a row.
+//   - Query-scoped on the SERVER side too: ClickHouse tears the backing
+//     temporary storage down once the declaring query finishes, so two
+//     concurrent dispatches attaching the SAME table name (this package
+//     always uses one fixed name, tempo.externalTraceIDTableName) never
+//     collide — there is no cross-request registry to clash in.
+//   - Native-protocol only. The caller (internal/api/tempo) gates this on
+//     Config.Protocol == clickhouse.Native at boot (cmd/cerberus/main.go),
+//     mirroring the issue's own scope: HTTP-protocol external data support is
+//     out of scope for #2783 and untested here.
+//
+// ids are sent as-is with no further validation — the caller is responsible
+// for handing the exact on-disk TraceId values a literal splice would
+// otherwise carry (internal/api/tempo.padTraceIDs is cerberus's canonical
+// normalizer for that).
+func WithExternalTraceIDs(ctx context.Context, table, column string, ids []string) (context.Context, error) {
+	t, err := ext.NewTable(table, ext.Column(column, externalTraceIDColumnType))
+	if err != nil {
+		return ctx, fmt.Errorf("chclient: external trace-id table %q: %w", table, err)
+	}
+	for _, id := range ids {
+		if err := t.Append(id); err != nil {
+			return ctx, fmt.Errorf("chclient: external trace-id table %q: append: %w", table, err)
+		}
+	}
+	return clickhouse.Context(ctx, clickhouse.WithExternalTable(t)), nil
+}

--- a/internal/chclient/external_trace_ids_test.go
+++ b/internal/chclient/external_trace_ids_test.go
@@ -1,0 +1,43 @@
+package chclient
+
+import (
+	"context"
+	"testing"
+)
+
+// TestWithExternalTraceIDs_ReturnsDerivedContext pins the pure client-side
+// half of issue #2783's helper: given a normal id set it returns a nil error
+// and a ctx that carries clickhouse-go's QueryOptions value (added by
+// clickhouse.Context/WithExternalTable) — a DIFFERENT context.Context value
+// than the one passed in, since context.WithValue always wraps into a new
+// concrete type. The wire-level behaviour (the driver actually serialising
+// the table onto a live query, a real server accepting it, idx_trace_id
+// pruning through it) is verified against a real ClickHouse in
+// internal/api/tempo's integration lane — chclient has no live connection to
+// assert against here, only that this function builds and attaches the
+// table without error.
+func TestWithExternalTraceIDs_ReturnsDerivedContext(t *testing.T) {
+	t.Parallel()
+
+	base := context.Background()
+	ctx, err := WithExternalTraceIDs(base, "ext_trace_ids", "TraceId", []string{"aabb", "ccdd"})
+	if err != nil {
+		t.Fatalf("WithExternalTraceIDs: %v", err)
+	}
+	if ctx == base {
+		t.Fatalf("WithExternalTraceIDs returned the SAME context.Context as base — clickhouse.Context should always derive a new value")
+	}
+}
+
+// TestWithExternalTraceIDs_EmptyIDsStillSucceeds pins the vacuous case: an
+// empty id slice still builds a valid (zero-row) external table rather than
+// erroring — runStructuralTwoPhase never calls this with zero ids in
+// practice (it returns before reaching restrictStructural when phase A found
+// nothing), but the helper itself should not assume that invariant.
+func TestWithExternalTraceIDs_EmptyIDsStillSucceeds(t *testing.T) {
+	t.Parallel()
+
+	if _, err := WithExternalTraceIDs(context.Background(), "ext_trace_ids", "TraceId", nil); err != nil {
+		t.Fatalf("WithExternalTraceIDs(nil ids): %v", err)
+	}
+}

--- a/internal/chopt/registry.go
+++ b/internal/chopt/registry.go
@@ -1984,7 +1984,7 @@ var registry = []Feature{
 		MinVersion: AlwaysAvailable,
 		Stability:  Experimental,
 		AutoSelect: false,
-		Doc:        "push the /api/search structural two-phase phase-A TraceId set as a native-protocol external table instead of a spliced literal IN list once the estimated literal bytes cross a threshold (no version floor, native-protocol only, opt-in via CERBERUS_CH_OPTIMIZATIONS — EXPLAIN-verified idx_trace_id parity with the literal form, #2783)",
+		Doc:        "push the /api/search two-phase phase-A TraceId set as a native-protocol external table instead of a literal IN list above a byte threshold (no version floor, native-protocol, opt-in via CERBERUS_CH_OPTIMIZATIONS -- EXPLAIN-verified idx_trace_id parity, #2783)",
 	},
 }
 

--- a/internal/chopt/registry.go
+++ b/internal/chopt/registry.go
@@ -1565,6 +1565,42 @@ const (
 	// predicate already pays for, a pure (if small) per-row LIKE-evaluation
 	// tax with no pruning to offset it.
 	FeatureTextIndexLineFilter = "text_index_line_filter"
+
+	// FeatureTraceIDExternalTable pushes the /api/search structural
+	// two-phase orchestrator's phase-A TraceId result set onto phase B as a
+	// native-protocol external (temporary) table instead of splicing it as a
+	// literal `TraceId IN (...)` list (restrictStructural, issue #2783).
+	// CLIENT-SIDE and version-independent (AlwaysAvailable): clickhouse-go/v2
+	// external tables are ordinary native-protocol functionality with no CH
+	// version floor, so — like FeatureColumnarResultDecode — this carries no
+	// MinVersion gate, only the boot-wired chopt on/off switch the "register
+	// as chopt feature, resolve at boot, one lifecycle" rule requires even
+	// for a floor-less optimization.
+	//
+	// The switch is BYTE-SIZE-gated, not width-gated: restrictStructural only
+	// takes this path once the literal splice's estimated total bytes (summed
+	// across every closure scan site the restriction reaches) crosses a
+	// threshold sized against chsql's own emitted-SQL bound
+	// (internal/chsql/emit_size_bound.go's 262144-byte maxEmittedSQLBytes,
+	// itself ClickHouse's max_query_size default). Below the threshold the
+	// literal splice is cheaper (no external-table round trip) and, per this
+	// issue's own EXPLAIN indexes=1 verification against a real ClickHouse
+	// server, prunes idx_trace_id IDENTICALLY to the external-table form at
+	// every closure size tested — the switch exists purely to avoid the
+	// literal splice's SQL-text-size failure axis (megabyte-scale statements,
+	// chsql's ErrEmittedSQLTooLarge, or a bare max_query_size SYNTAX_ERROR),
+	// never to fix a pruning gap.
+	//
+	// NOT auto-selected (AutoSelect=false): native-protocol-only (the
+	// resolver has no way to see Config.Protocol, so cmd/cerberus's own
+	// wiring additionally requires Protocol==clickhouse.Native — see
+	// buildExternalTraceIDPush), and the production win at today's
+	// MaxSearchLimit=1000 is real but unmeasured at scale beyond this issue's
+	// own synthetic corpus — an operator opt-in via
+	// CERBERUS_CH_OPTIMIZATIONS=trace_id_external_table, mirroring
+	// FeatureTraceIDProjection's posture on a fresh, real-CH-server-only
+	// mechanism.
+	FeatureTraceIDExternalTable = "trace_id_external_table"
 )
 
 // AlwaysAvailable is the zero version floor for a feature that depends on no
@@ -1943,6 +1979,13 @@ var registry = []Feature{
 		AutoSelect: false,
 		Doc:        "prepend an ANDed per-token LIKE strict-superset prefilter ahead of the unchanged row predicate for non-negated LogQL line filters (server >= 26.4 — verified LIKE-via-text-index floor, opt-in via CERBERUS_CH_OPTIMIZATIONS, inert without full_text_index)",
 	},
+	{
+		ID:         FeatureTraceIDExternalTable,
+		MinVersion: AlwaysAvailable,
+		Stability:  Experimental,
+		AutoSelect: false,
+		Doc:        "push the /api/search structural two-phase phase-A TraceId set as a native-protocol external table instead of a spliced literal IN list once the estimated literal bytes cross a threshold (no version floor, native-protocol only, opt-in via CERBERUS_CH_OPTIMIZATIONS — EXPLAIN-verified idx_trace_id parity with the literal form, #2783)",
+	},
 }
 
 // Registry returns a copy of the seeded feature registry
@@ -1956,7 +1999,7 @@ var registry = []Feature{
 // join_spill, trace_id_projection, loki_catalog_mv, tempo_tag_catalog_mv,
 // trace_id_bitmap_filter, arg_and_max_fusion, result_cache,
 // lazy_materialization, explain_estimate, cardinality_probe,
-// full_text_index, text_index_line_filter). The copy
+// full_text_index, text_index_line_filter, trace_id_external_table). The copy
 // keeps the canonical entries immutable from the caller's side. Exposed so
 // tests can enumerate the gates and the docs generator can render the
 // table.

--- a/internal/chopt/resolve_test.go
+++ b/internal/chopt/resolve_test.go
@@ -660,6 +660,7 @@ func TestRegistry_SeededEntries(t *testing.T) {
 		FeatureFullTextIndex:                {ID: FeatureFullTextIndex, MinVersion: v(26, 2), Stability: Experimental, AutoSelect: false, RequiresExperimentalTSGrid: false},
 		FeatureTextIndexLineFilter:          {ID: FeatureTextIndexLineFilter, MinVersion: v(26, 4), Stability: Experimental, AutoSelect: false, RequiresExperimentalTSGrid: false},
 		FeatureDownsampleTier:               {ID: FeatureDownsampleTier, MinVersion: v(25, 9), Stability: Experimental, AutoSelect: false, RequiresExperimentalTSGrid: true},
+		FeatureTraceIDExternalTable:         {ID: FeatureTraceIDExternalTable, MinVersion: AlwaysAvailable, Stability: Experimental, AutoSelect: false, RequiresExperimentalTSGrid: false},
 	}
 	if len(reg) != len(want) {
 		t.Fatalf("registry has %d entries; want %d", len(reg), len(want))

--- a/internal/chplan/structural_join.go
+++ b/internal/chplan/structural_join.go
@@ -190,7 +190,27 @@ type StructuralJoin struct {
 	// byte-identical off the two-phase path. The restriction is a pure
 	// pruning bound: correctness comes from the closure, so restricting to a
 	// subset of traces only shrinks reads, never changes the per-trace rows.
+	//
+	// Mutually exclusive with TraceIDExternalTable — restrictStructural
+	// (issue #2783) sets exactly one of the two per plan, never both.
 	TraceIDRestriction []string
+
+	// TraceIDExternalTable, when non-empty, names a native-protocol external
+	// (temporary) table carrying the SAME phase-A TraceId set
+	// TraceIDRestriction would otherwise splice as literals: every closure
+	// scan site emits `<col> IN (SELECT <TraceIDColumn> FROM
+	// <TraceIDExternalTable>)` instead. restrictStructural chooses this form
+	// over TraceIDRestriction once the literal splice's estimated byte cost
+	// crosses a threshold (wide closures risk chsql's own emitted-SQL bound,
+	// internal/chsql/emit_size_bound.go, or ClickHouse's max_query_size) —
+	// EXPLAIN indexes=1 against a real server confirmed both forms engage
+	// idx_trace_id identically at every closure size tested, so the switch is
+	// purely about statement-size risk, never pruning parity (issue #2783).
+	// The actual id rows are attached to the query's context separately, by
+	// chclient.WithExternalTraceIDs — this field only names the table the
+	// emitted SQL references; empty means "no external table for this join",
+	// the pre-#2783 path.
+	TraceIDExternalTable string
 
 	// CandidatePrefilter, when true, restricts the recursive anchor seed to
 	// traces that appear on BOTH sides of the relation (the L-intersect-R
@@ -248,6 +268,9 @@ func (j *StructuralJoin) Equal(other Node) bool {
 		if j.TraceIDRestriction[i] != o.TraceIDRestriction[i] {
 			return false
 		}
+	}
+	if j.TraceIDExternalTable != o.TraceIDExternalTable {
+		return false
 	}
 	return j.Left.Equal(o.Left) && j.Right.Equal(o.Right)
 }

--- a/internal/chsql/structural_join.go
+++ b/internal/chsql/structural_join.go
@@ -376,8 +376,8 @@ func (e *emitter) rootedStructuralLeftSub(j *chplan.StructuralJoin, leftSub Frag
 	}
 	winLo, winHi := spansScanWindowFrags(j.TimestampColumn, j.WindowStartNano, j.WindowEndNano)
 	anchorConds = appendNonNilFrags(anchorConds, winLo, winHi)
-	if len(j.TraceIDRestriction) > 0 {
-		anchorConds = append(anchorConds, inStringLiteralsFrag(Col(j.TraceIDColumn), j.TraceIDRestriction))
+	if f, ok := traceIDRestrictionFrag(j, Col(j.TraceIDColumn)); ok {
+		anchorConds = append(anchorConds, f)
 	}
 	cteName := "_struct_rooted_" + strconv.Itoa(e.nextCTESeq())
 	anchor := NewQuery().
@@ -802,8 +802,8 @@ func (e *emitter) emitStructuralRecursive(j *chplan.StructuralJoin) error {
 		// would not return. Restricting both sides keeps phase B a faithful
 		// top-N subset of the single-query result (A≡B). Nil off the two-phase
 		// path, so every other caller's SQL is byte-identical.
-		if len(j.TraceIDRestriction) > 0 {
-			sb = sb.Where(inStringLiteralsFrag(qualColFrag("R", j.TraceIDColumn), j.TraceIDRestriction))
+		if f, ok := traceIDRestrictionFrag(j, qualColFrag("R", j.TraceIDColumn)); ok {
+			sb = sb.Where(f)
 		}
 		return e.emitSelect(sb)
 	case j.Op.IsUnion():
@@ -842,8 +842,8 @@ func (e *emitter) emitStructuralRecursive(j *chplan.StructuralJoin) error {
 		// Phase B: granule-prune the wide R scan to the top-N traces. The
 		// closure already restricts L to those traces (anchor seed WHERE), so
 		// this only shrinks the R side's reads — the result rows are unchanged.
-		if len(j.TraceIDRestriction) > 0 {
-			sb = sb.Where(inStringLiteralsFrag(qualColFrag("R", j.TraceIDColumn), j.TraceIDRestriction))
+		if f, ok := traceIDRestrictionFrag(j, qualColFrag("R", j.TraceIDColumn)); ok {
+			sb = sb.Where(f)
 		}
 		return e.emitSelect(sb)
 	}
@@ -961,8 +961,8 @@ func structuralStepWhere(j *chplan.StructuralJoin) []Frag {
 	conds = appendNonNilFrags(conds, winLo, winHi)
 	// Phase B: granule-prune the step scan to the top-N traces so idx_trace_id
 	// prunes each recursion level's read. Empty off the two-phase path.
-	if len(j.TraceIDRestriction) > 0 {
-		conds = append(conds, inStringLiteralsFrag(qualColFrag("t", j.TraceIDColumn), j.TraceIDRestriction))
+	if f, ok := traceIDRestrictionFrag(j, qualColFrag("t", j.TraceIDColumn)); ok {
+		conds = append(conds, f)
 	}
 	return conds
 }
@@ -1001,8 +1001,8 @@ func structuralAnchorWhere(j *chplan.StructuralJoin, otherSideSub Frag) []Frag {
 // the top-N literals, exactly the read amplification phase B exists to avoid.
 func structuralAnchorNodeBounds(j *chplan.StructuralJoin) []Frag {
 	var conds []Frag
-	if len(j.TraceIDRestriction) > 0 {
-		conds = append(conds, inStringLiteralsFrag(Col(j.TraceIDColumn), j.TraceIDRestriction))
+	if f, ok := traceIDRestrictionFrag(j, Col(j.TraceIDColumn)); ok {
+		conds = append(conds, f)
 	}
 	return append(conds, structuralAnchorWindowFrags(j)...)
 }
@@ -1062,6 +1062,47 @@ func inStringLiteralsFrag(col Frag, ids []string) Frag {
 		lits = append(lits, InlineLit(id))
 	}
 	return In(col, lits...)
+}
+
+// inExternalTraceIDsFrag renders `<col> IN (SELECT <traceIDColumn> FROM
+// <table>)` — the native-protocol external-table form of
+// inStringLiteralsFrag. table is a bare identifier naming a temporary table
+// chclient.WithExternalTraceIDs attaches to the query's context (issue
+// #2783); it carries no user data itself, so it is rendered as a plain
+// identifier via Col, exactly like scanTableFrag renders a physical table
+// name. traceIDColumn names that external table's single column, which the
+// caller builds with the SAME name as the physical TraceId column
+// (StructuralJoin.TraceIDColumn) so the two sides need no separate naming
+// contract.
+//
+// Unlike inStringLiteralsFrag's literal list, this is a genuine subquery —
+// but EXPLAIN indexes=1 against a real ClickHouse server (issue #2783)
+// confirmed idx_trace_id prunes an `IN (SELECT … FROM <external table>)`
+// exactly as it prunes the literal list at every closure size tested, so the
+// swap costs no pruning.
+func inExternalTraceIDsFrag(col Frag, table, traceIDColumn string) Frag {
+	sub := NewQuery().Select(Col(traceIDColumn)).From(Col(table))
+	return InSubquery(col, Subquery(sub))
+}
+
+// traceIDRestrictionFrag renders the phase-B closure restriction for col and
+// reports whether j carries one at all: the literal IN-list form
+// (inStringLiteralsFrag) when TraceIDRestriction is set, or the external-table
+// form (inExternalTraceIDsFrag) when TraceIDExternalTable is set. The two
+// fields are mutually exclusive by construction (restrictStructural, issue
+// #2783, sets exactly one per plan), so at most one branch fires; every other
+// caller leaves both unset and gets (nil, false), which every call site below
+// reads as "leave this scan unrestricted" — byte-identical to the pre-#2783
+// behaviour.
+func traceIDRestrictionFrag(j *chplan.StructuralJoin, col Frag) (Frag, bool) {
+	switch {
+	case len(j.TraceIDRestriction) > 0:
+		return inStringLiteralsFrag(col, j.TraceIDRestriction), true
+	case j.TraceIDExternalTable != "":
+		return inExternalTraceIDsFrag(col, j.TraceIDExternalTable, j.TraceIDColumn), true
+	default:
+		return nil, false
+	}
 }
 
 // structuralDepthBoundFrag renders the recursive-CTE iteration cap

--- a/internal/chsql/structural_join_external_trace_ids_test.go
+++ b/internal/chsql/structural_join_external_trace_ids_test.go
@@ -1,0 +1,82 @@
+package chsql_test
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/tsouza/cerberus/internal/chsql"
+)
+
+// TestEmitStructuralRecursive_AnchorCarriesExternalTraceIDTable pins the
+// external-table sibling of TestEmitStructuralRecursive_AnchorCarriesTraceIDRestriction
+// (structural_join_anchor_mutation_test.go): once TraceIDExternalTable is set
+// instead of TraceIDRestriction, the closure's anchor seed WHERE renders the
+// subquery form `IN (SELECT ... FROM ...)` — chclient.WithExternalTraceIDs's
+// counterpart on the query's context — never the literal list (issue #2783).
+func TestEmitStructuralRecursive_AnchorCarriesExternalTraceIDTable(t *testing.T) {
+	t.Parallel()
+
+	plan := structuralClosurePlan()
+	plan.TraceIDExternalTable = "cerberus_phase_b_trace_ids"
+
+	sql, _, err := chsql.Emit(context.Background(), plan)
+	if err != nil {
+		t.Fatalf("Emit: %v", err)
+	}
+	if !strings.Contains(sql, "AS _seed WHERE `TraceId` IN (SELECT `TraceId` FROM `cerberus_phase_b_trace_ids`)") {
+		t.Fatalf("external trace-id table reference missing from the anchor seed:\n%s", sql)
+	}
+	if strings.Contains(sql, "IN ('") {
+		t.Fatalf("external-table plan must not ALSO splice a literal IN list:\n%s", sql)
+	}
+}
+
+// TestEmitStructuralRecursive_TraceIDRestrictionWinsOverExternalTable pins
+// traceIDRestrictionFrag's documented precedence: TraceIDRestriction, when
+// non-empty, renders the literal form even if TraceIDExternalTable is ALSO
+// set. restrictStructural never actually sets both (they are mutually
+// exclusive by construction), but the emitter's own precedence is worth
+// pinning directly rather than trusting the one caller to never violate it.
+func TestEmitStructuralRecursive_TraceIDRestrictionWinsOverExternalTable(t *testing.T) {
+	t.Parallel()
+
+	plan := structuralClosurePlan()
+	plan.TraceIDRestriction = []string{"aabb"}
+	plan.TraceIDExternalTable = "cerberus_phase_b_trace_ids"
+
+	sql, _, err := chsql.Emit(context.Background(), plan)
+	if err != nil {
+		t.Fatalf("Emit: %v", err)
+	}
+	if !strings.Contains(sql, "AS _seed WHERE `TraceId` IN ('aabb')") {
+		t.Fatalf("literal restriction should win when both fields are set:\n%s", sql)
+	}
+	if strings.Contains(sql, "cerberus_phase_b_trace_ids") {
+		t.Fatalf("external table must not ALSO be referenced when TraceIDRestriction wins:\n%s", sql)
+	}
+}
+
+// TestEmitStructuralRecursive_InverseAnchorCarriesExternalTraceIDTable mirrors
+// TestEmitStructuralRecursive_InverseAnchorCarriesTraceIDRestriction for the
+// external-table form: the union op's INVERSE closure anchor
+// (buildStructuralInverseClosure) must fold TraceIDExternalTable exactly as
+// it folds TraceIDRestriction, so a wide union search gets the same
+// SQL-text-size relief on both arms.
+func TestEmitStructuralRecursive_InverseAnchorCarriesExternalTraceIDTable(t *testing.T) {
+	t.Parallel()
+
+	plan := structuralUnionClosurePlan()
+	plan.TraceIDExternalTable = "cerberus_phase_b_trace_ids"
+
+	sql, _, err := chsql.Emit(context.Background(), plan)
+	if err != nil {
+		t.Fatalf("Emit: %v", err)
+	}
+	if !strings.Contains(sql, "_struct_closure_inv_") {
+		t.Fatalf("union recursive op did not render an inverse closure CTE:\n%s", sql)
+	}
+	if !strings.Contains(sql, "AS _seed WHERE `TraceId` IN (SELECT `TraceId` FROM `cerberus_phase_b_trace_ids`)") {
+		t.Fatalf("external trace-id table reference missing from the inverse closure's anchor seed:\n%s", sql)
+	}
+}


### PR DESCRIPTION
## Summary

Closes #2783. `restrictStructural` (the `/api/search` structural two-phase
orchestrator's phase-B step) spliced the phase-A `TraceId` result set onto
every closure scan as a literal `TraceId IN ('id0', 'id1', ...)` list. On a
wide closure this risks megabyte-scale SQL text, server parse time, and
chsql's own emitted-SQL bound (`internal/chsql/emit_size_bound.go`'s
262144-byte `maxEmittedSQLBytes`, itself ClickHouse's `max_query_size`
default) — a genuine `SYNTAX_ERROR` reproduced manually while implementing
this PR (see below).

This PR adds `chclient.WithExternalTraceIDs`, a native-protocol
external-table push (`clickhouse-go/v2`'s `ext.Table` /
`clickhouse.WithExternalTable`), and switches `restrictStructural` to it once
the literal splice's estimated byte cost — summed across every closure scan
site the restriction reaches — crosses a threshold. Below the threshold the
literal splice is unchanged (byte-identical SQL, matching every existing
golden fixture).

Scoped narrowly per the issue's own guidance: only
`restrictStructural`'s phase-B swap. The anchor-grid generation candidate the
issue names as a possible second target is **not** attempted here.

## Skip-index pruning verification (EXPLAIN indexes=1, real ClickHouse)

Per the issue's own mandate, I verified empirically — first manually against
a scratch ClickHouse 26.6 container, then in-repo against the pinned
25.9-alpine test image
(`TestStructuralTwoPhase_ExternalTraceIDTable_ExplainIndexes`) — whether the
external-table form still engages `idx_trace_id` the way the literal splice
does:

| id-set size | literal granules dropped | external-table granules dropped |
|---|---|---|
| 200 (in-repo test, 490 total granules) | 396 | 396 |
| 200 (manual, 2458 total granules) | 2002 | 2002 |
| 1000–8000 (manual sweep) | identical at every size tested | identical at every size tested |

**Result: exact parity at every size tested.** `IN (SELECT ... FROM
<external table>)` is treated as a prepared set the same way a literal list
is, so the switch is purely about SQL-text-size risk — never a pruning
trade-off. I also measured the **JOIN** form the issue names as an
alternative and rejected it: `INNER JOIN <external table>` read the full 20M
row table with **zero** index engagement (`read_rows` = table size), while
`IN (SELECT ...)` read only the pruned subset. `IN (SELECT ...)` is the
correct shape; a JOIN would have been a silent regression.

I also reproduced the literal splice's own failure mode directly: a
50,000-id closure (~950KB of literal text) hit ClickHouse's
`max_query_size` (`SYNTAX_ERROR`, code 62) outright, while the same set
pushed as an external table succeeded in under a second — the exact failure
axis this PR removes.

## Route-B sharding / retry safety

`chclient.WithExternalTraceIDs` is a pure `ctx` transform
(`clickhouse.Context(ctx, clickhouse.WithExternalTable(t))`); `clickhouse-go/v2`'s
own `Context()` merges with whatever `QueryOptions` are already on the
incoming `ctx` rather than overwriting them, so it composes for free with
`chclient`'s existing `queryContext` settings/query-id stamping. Because the
attach happens once per `Query()` dispatch (not once per request), it is
naturally safe under:

- **Retry** (`chclient/retry.go`'s `withTransportRetry`): the same derived
  `ctx` is reused across attempts, and `clickhouse-go/v2`'s `sendData` reads
  the table's backing block without draining it, so a retry resends the
  identical rows — proven directly in
  `TestExternalTraceIDs_ReusableAcrossDispatches` (two sequential dispatches
  over the same `ctx` return identical, correct counts).
- **Route-B sharding**: each shard's own `Query()` call derives its own
  dispatch context from the same base `ctx`, so each shard gets its own full
  attach — the same mechanism the retry test exercises.
- **Server-side scoping**: ClickHouse ties an external table's backing
  storage to the one query that declares it, so a fixed table name
  (`cerberus_phase_b_trace_ids`) never collides across concurrent
  dispatches.

## chopt wiring

Ships behind a new `trace_id_external_table` chopt feature
(`AlwaysAvailable`, `Experimental`, `AutoSelect: false` — opt-in via
`CERBERUS_CH_OPTIMIZATIONS=trace_id_external_table`), additionally gated on
`Config.ClickHouse.Protocol == clickhouse.Native` in
`cmd/cerberus.buildExternalTraceIDPush` (the resolver has no visibility into
the connection protocol, so this is the one place both axes combine) — the
mechanism is native-protocol-only per the issue's own scope; HTTP-protocol
external data is untested here.

## Testing

- `internal/chsql/structural_join_external_trace_ids_test.go` — emitter unit
  tests pinning the exact SQL shape (anchor + inverse-closure anchor) for
  both forms, and the literal-wins-over-external precedence.
- `internal/api/tempo/structural_two_phase_external_table_test.go` — unit
  tests for the byte-threshold decision and `restrictStructural`'s
  literal/external branching.
- `internal/chclient/external_trace_ids_test.go` — unit test for the
  client-side `WithExternalTraceIDs` helper.
- `internal/api/tempo/structural_two_phase_external_table_integration_test.go`
  (new `structural-two-phase-external-table-integration` Justfile recipe,
  wired into `strict-scan.yml` + `.github/ci-lanes.json`) — real ClickHouse
  (testcontainers), three tests: correctness parity via the real
  `/api/search` handler, the EXPLAIN indexes=1 granule-parity proof above,
  and the retry/shard reusability proof above.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...` / `go vet -tags=integration ./...`
- [x] `just fmt` (no diff)
- [x] `just test-unit` (full `-race ./...`, including
      `test/regression.TestEveryTaggedTestHasAnExecutingLane`)
- [x] `just vet-tagged`
- [x] `just structural-two-phase-external-table-integration` (real
      ClickHouse via testcontainers)
- [x] `node .github/scripts/forbid-sql-raw.mjs`
- [ ] CI green (watching)
