### PR TITLE
feat(tempo): route auto-scope tag_values to materialized attr columns

### DIFF
--- a/docs/operations.md
+++ b/docs/operations.md
@@ -1533,8 +1533,10 @@ Every TraceQL predicate on a span/resource attribute (`http.status_code`,
 (`SchemaProvisioning.TraceMaterializedAttrsEnabled`, `AutoCreateSchema`
 must ALSO be `true`) provisions a curated default set of dedicated
 top-level `LowCardinality(String)` columns for three high-value keys and
-routes TraceQL reads (`FieldAccess`, structural filters, `tag_values`
-inventories for the single-scope `resource.x` / `span.x` forms) to them —
+routes TraceQL reads (`FieldAccess`, structural filters, and `tag_values`
+inventories for every scope form — `resource.x` / `span.x` read the
+narrow column directly, and the auto-scope `.x` form unions each side's
+materialized-or-map read, cerberus issue #2870) to them —
 `internal/schema/traces.go`'s `DefaultMaterializedSpanAttributeColumns` /
 `DefaultMaterializedResourceAttributeColumns`:
 

--- a/internal/api/tempo/search_tag_values.go
+++ b/internal/api/tempo/search_tag_values.go
@@ -265,12 +265,14 @@ func buildIntrinsicValuesSQL(s schema.Traces, col string, filter chsql.Frag, sta
 // For the single-scope forms, a materialized attribute column (cerberus
 // issue #2776) short-circuits both the projection and the pre-filter to a
 // direct DISTINCT read of the narrow column instead of the map subscript —
-// see buildMaterializedAttributeValuesSQL. The auto-scope (both-maps) form
-// stays on the map-only path in this version: routing it would mean
-// unioning a materialized column with the OTHER scope's still-map-backed
-// arm, which is more machinery than the common case (Grafana's
-// scope-qualified value dropdown) justifies today — tracked as cerberus
-// issue #2870.
+// see buildMaterializedAttributeValuesSQL.
+//
+// For the auto-scope (both-maps) form, a materialized key in EITHER map
+// (cerberus issue #2870) routes to buildAutoScopeUnionAttributeValuesSQL,
+// which reads whichever side has a materialized column directly and falls
+// back to the map subscript for the other side — see that function's doc
+// for the four routing cases. A key materialized in neither map keeps
+// today's single arrayJoin-over-both-maps shape, unchanged, below.
 func buildAttributeValuesSQL(s schema.Traces, name string, scope attrMapScope, filter chsql.Frag, start, end time.Time) (string, []any) {
 	switch scope {
 	case attrMapScopeResource:
@@ -280,6 +282,17 @@ func buildAttributeValuesSQL(s schema.Traces, name string, scope attrMapScope, f
 	case attrMapScopeSpan:
 		if col, ok := s.MaterializedSpanAttributeColumns[name]; ok {
 			return buildMaterializedAttributeValuesSQL(s, col, filter, start, end)
+		}
+	case attrMapScopeAny:
+		spanCol, spanMaterialized := s.MaterializedSpanAttributeColumns[name]
+		resCol, resMaterialized := s.MaterializedResourceAttributeColumns[name]
+		if spanMaterialized || resMaterialized {
+			return buildAutoScopeUnionAttributeValuesSQL(
+				s, name,
+				spanCol, spanMaterialized,
+				resCol, resMaterialized,
+				filter, start, end,
+			)
 		}
 	}
 	var (
@@ -347,6 +360,95 @@ func buildMaterializedAttributeValuesSQL(s schema.Traces, col string, filter chs
 		sb.Where(filter)
 	}
 	return sb.Build()
+}
+
+// buildAutoScopeUnionAttributeValuesSQL builds the SELECT for an
+// auto-scope (`.x` leading-dot, or the bare-key V1 fallback) dynamic-
+// attribute values lookup whose key is materialized in the span map, the
+// resource map, or both (cerberus issue #2870).
+//
+// Each side reads via its OWN narrow materialized column when one exists
+// for that side, or falls back to the map subscript otherwise — exactly
+// the same per-side shape buildAttributeValuesSQL already uses for the
+// single-scope (`span.x` / `resource.x`) forms, just built once per side
+// here instead of chosen once for the whole query:
+//
+//	SELECT DISTINCT v FROM (
+//	    (SELECT `<spanCol>`   AS v FROM `otel_traces` WHERE `<spanCol>` != ''            [AND time bounds] [AND filter])
+//	    UNION ALL
+//	    (SELECT `SpanAttributes`[?] AS v FROM `otel_traces` WHERE mapContains(`SpanAttributes`, ?) [AND time bounds] [AND filter])
+//	    -- (whichever of the two SpanAttributes lines applies)
+//	    UNION ALL
+//	    -- the matching ResourceAttributes line, materialized or map-backed
+//	) WHERE v != ''
+//
+// UNION ALL (not the arrayJoin-over-array-literal shape the map-only path
+// uses) is the composition that reuses the existing per-side Frag
+// builders as-is: attrValueArmFrag emits one complete arm — projection,
+// its own row-level pre-filter, time bounds, the optional `?q=` filter —
+// with no change needed to either mapAtFrag/mapContainsFrag (the map arm)
+// or the plain-column read (the materialized arm). Mixing a
+// LowCardinality(String) column and a Map subscript inside ONE arrayJoin
+// array literal would need both slots coerced to a common element type
+// up front; two independently-typed SELECT arms merged by UNION ALL let
+// ClickHouse resolve that per-column, the same way the map-only path's
+// own two-map arrayJoin already tolerates any per-key value-type drift
+// between the two source maps.
+//
+// The outer DISTINCT + `v != ”` wrapper is identical to every other
+// branch of buildAttributeValuesSQL: a materialized arm's own `<col> !=
+// ”` filter and a map arm's `mapContains` filter both admit only
+// non-empty values already, so the outer filter is redundant on any
+// single arm — but it is exactly what dedupes the two arms' results
+// against EACH OTHER (a key present with the same value in both maps
+// contributes one row here, not two), which no single arm can do alone.
+func buildAutoScopeUnionAttributeValuesSQL(
+	s schema.Traces, name string,
+	spanCol string, spanMaterialized bool,
+	resCol string, resMaterialized bool,
+	filter chsql.Frag, start, end time.Time,
+) (string, []any) {
+	spanArm := attrValueArmFrag(s, s.AttributesColumn, spanCol, spanMaterialized, name, filter, start, end)
+	resArm := attrValueArmFrag(s, s.ResourceAttributesColumn, resCol, resMaterialized, name, filter, start, end)
+
+	outer := chsql.NewQuery().
+		Select(chsql.Distinct(chsql.Col("v"))).
+		From(chsql.Paren(chsql.UnionAll(spanArm, resArm))).
+		Where(nonEmptyFrag("v"))
+	return outer.Build()
+}
+
+// attrValueArmFrag builds one UNION ALL arm of
+// buildAutoScopeUnionAttributeValuesSQL: a complete parenthesised SELECT
+// projecting the requested key's value (aliased `v`) from one attribute
+// map/column, with that key's own row-level pre-filter plus the shared
+// time-bounds and `?q=` conjuncts.
+//
+// materialized selects between the two per-arm shapes: true reads
+// materializedCol directly (mirrors buildMaterializedAttributeValuesSQL's
+// projection/filter pair); false reads the map subscript mapCol[name]
+// gated by mapContains(mapCol, name) (mirrors buildAttributeValuesSQL's
+// single-scope map-backed branch). materializedCol is ignored when
+// materialized is false.
+func attrValueArmFrag(s schema.Traces, mapCol, materializedCol string, materialized bool, name string, filter chsql.Frag, start, end time.Time) chsql.Frag {
+	arm := chsql.NewQuery().From(chsql.Col(s.SpansTable))
+	if materialized {
+		arm.Select(chsql.As(chsql.Col(materializedCol), "v")).
+			Where(nonEmptyFrag(materializedCol))
+	} else {
+		arm.Select(chsql.As(mapAtFrag(mapCol, name), "v")).
+			Where(mapContainsFrag(mapCol, name))
+	}
+	if !start.IsZero() {
+		arm.Where(tempoTimeGteFrag(s.TimestampColumn, start))
+	}
+	if !end.IsZero() {
+		arm.Where(tempoTimeLteFrag(s.TimestampColumn, end))
+	}
+	if filter != nil {
+		arm.Where(filter)
+	}
+	return arm.Frag()
 }
 
 // attrMapScope expresses which attribute map(s) a tag-values lookup

--- a/internal/api/tempo/search_tag_values_autoscope_chdb_test.go
+++ b/internal/api/tempo/search_tag_values_autoscope_chdb_test.go
@@ -1,0 +1,211 @@
+//go:build chdb
+
+// chDB-backed correctness roundtrip for cerberus issue #2870's auto-scope
+// materialized-column routing (buildAutoScopeUnionAttributeValuesSQL). The
+// SQL-shape test in search_tag_values_autoscope_materialized_test.go pins
+// which Frags the routed query is built from; this file proves the
+// EXECUTED result of the routed (UNION ALL) query is byte-identical, as a
+// set, to the executed result of the unrouted (arrayJoin-over-both-maps)
+// query the auto-scope form used before this feature — the same evidence
+// bar cerberus issue #2776 set for the single-scope routing (see that
+// issue's PR body / docs/operations.md).
+//
+// Every materialized column here is declared DEFAULT <map>[<key>], the
+// exact DDL shape internal/schema/ddl.renderTraceMaterializedAttrColumns
+// issues in production (cerberus issue #2776's schema.Traces doc): the
+// column is therefore, by construction, value-identical to what the
+// map-only path reads for that key on every row, seeded or not — so a
+// divergence between the routed and unrouted result sets below can only
+// come from buildAutoScopeUnionAttributeValuesSQL's own union/dedup shape,
+// never from the seed data disagreeing with itself.
+
+package tempo_test
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"testing"
+	"time"
+
+	"github.com/tsouza/cerberus/internal/api/tempo"
+	"github.com/tsouza/cerberus/internal/chclienttest"
+	"github.com/tsouza/cerberus/internal/schema"
+)
+
+// autoScopeWindowBase anchors every seeded row well away from wall-clock
+// drift, mirroring internal/api/loki's chdb test convention (see
+// map_key_order_chdb_test.go's keyOrderWindowBase).
+var autoScopeWindowBase = time.Date(2026, 5, 20, 0, 0, 0, 0, time.UTC)
+
+// autoScopeSeedTable is the minimal otel_traces projection
+// buildAutoScopeUnionAttributeValuesSQL and its unrouted arrayJoin
+// predecessor both read: the two source Maps, plus one materialized
+// column per (scope, key) pair this file's four cases exercise. Engine =
+// Memory mirrors the loki chdb tests — none of these queries depends on
+// MergeTree ordering.
+const autoScopeSeedTable = "CREATE TABLE otel_traces (\n" +
+	"    Timestamp DateTime64(9),\n" +
+	"    SpanAttributes Map(String, String),\n" +
+	"    ResourceAttributes Map(String, String),\n" +
+	"    `__cerberus_materialized_http.status_code` LowCardinality(String) DEFAULT SpanAttributes['http.status_code'],\n" +
+	"    `__cerberus_materialized_k8s.namespace.name` LowCardinality(String) DEFAULT ResourceAttributes['k8s.namespace.name'],\n" +
+	"    `__cerberus_materialized_span_both.key` LowCardinality(String) DEFAULT SpanAttributes['both.key'],\n" +
+	"    `__cerberus_materialized_resource_both.key` LowCardinality(String) DEFAULT ResourceAttributes['both.key']\n" +
+	") ENGINE = Memory;"
+
+// autoScopeSeedRow is one seeded span: the literal CH map() expressions
+// for both attribute maps. Writing them out longhand (rather than
+// building from a Go map) keeps each row's exact key/value set legible
+// next to the case it exercises.
+type autoScopeSeedRow struct {
+	spanMapSQL, resourceMapSQL string
+}
+
+// autoScopeSeedRows covers all four buildAttributeValuesSQL routing cases
+// (cerberus issue #2870) plus, within the two single-side cases, a row
+// where the OTHER (unmaterialized-for-that-key) map ALSO happens to carry
+// the key — an unusual but valid shape that specifically exercises the
+// map-subscript fallback arm merging with the materialized-column arm,
+// not just the materialized arm alone:
+//
+//   - both.key: materialized in BOTH maps. r0/r1 give the same value
+//     ("v1") from two DIFFERENT rows/scopes — proving the union DEDUPES
+//     across scopes, not just within one. r2 gives two DISTINCT values
+//     ("v2" span, "v3" resource) on the SAME row.
+//   - http.status_code: materialized in SPAN only. r3 is span-only
+//     ("200"); r4 carries a span value ("500") AND a resource value
+//     ("999") for the SAME key name — the resource side has no
+//     materialized column for this key, so it must fall back to the map
+//     subscript and still contribute "999" to the union.
+//   - k8s.namespace.name: materialized in RESOURCE only, mirrored: r5 is
+//     resource-only ("ns-a"); r6 carries a resource value ("ns-b") AND a
+//     span value ("ns-from-span") for the same key name.
+//   - rpc.method: materialized in NEITHER map (r7/r8) — the routing miss
+//     that keeps buildAttributeValuesSQL on its unrouted arrayJoin path;
+//     included so the "routed vs unrouted" comparison below also covers
+//     the trivial case where routed IS unrouted, byte for byte.
+func autoScopeSeedRows() []autoScopeSeedRow {
+	return []autoScopeSeedRow{
+		{spanMapSQL: "map('both.key','v1')", resourceMapSQL: "map()"},
+		{spanMapSQL: "map()", resourceMapSQL: "map('both.key','v1')"},
+		{spanMapSQL: "map('both.key','v2')", resourceMapSQL: "map('both.key','v3')"},
+		{spanMapSQL: "map('http.status_code','200')", resourceMapSQL: "map()"},
+		{spanMapSQL: "map('http.status_code','500')", resourceMapSQL: "map('http.status_code','999')"},
+		{spanMapSQL: "map()", resourceMapSQL: "map('k8s.namespace.name','ns-a')"},
+		{spanMapSQL: "map('k8s.namespace.name','ns-from-span')", resourceMapSQL: "map('k8s.namespace.name','ns-b')"},
+		{spanMapSQL: "map('rpc.method','GetUser')", resourceMapSQL: "map()"},
+		{spanMapSQL: "map()", resourceMapSQL: "map('rpc.method','ResourceRPC')"},
+	}
+}
+
+// autoScopeMaterializedSchema is the routed schema: the curated set of
+// (scope, key) -> column entries an operator opted into (cerberus issue
+// #2776's CERBERUS_SCHEMA_TRACES_MATERIALIZED_ATTRS_ENABLED), covering
+// three of autoScopeSeedRows's four keys. `rpc.method` is deliberately
+// absent from both maps — the fourth case, materialized-in-neither.
+func autoScopeMaterializedSchema() schema.Traces {
+	s := schema.DefaultOTelTraces()
+	s.MaterializedSpanAttributeColumns = map[string]string{
+		"http.status_code": "__cerberus_materialized_http.status_code",
+		"both.key":         "__cerberus_materialized_span_both.key",
+	}
+	s.MaterializedResourceAttributeColumns = map[string]string{
+		"k8s.namespace.name": "__cerberus_materialized_k8s.namespace.name",
+		"both.key":           "__cerberus_materialized_resource_both.key",
+	}
+	return s
+}
+
+// seedAutoScopeClient seeds otel_traces with autoScopeSeedRows, one row
+// per second from autoScopeWindowBase, and returns the chDB client plus
+// the [start, end) window bracketing every seeded row.
+func seedAutoScopeClient(t *testing.T) (*chclienttest.Client, time.Time, time.Time) {
+	t.Helper()
+	const tsFmt = "2006-01-02 15:04:05.000"
+
+	rows := autoScopeSeedRows()
+	seed := autoScopeSeedTable
+	for i, r := range rows {
+		ts := autoScopeWindowBase.Add(time.Duration(i) * time.Second).Format(tsFmt)
+		seed += fmt.Sprintf(
+			"\nINSERT INTO otel_traces (Timestamp, SpanAttributes, ResourceAttributes) VALUES"+
+				" (toDateTime64('%s', 9), %s, %s);",
+			ts, r.spanMapSQL, r.resourceMapSQL,
+		)
+	}
+
+	c := chclienttest.NewChDB(t)
+	c.Seed(t, seed)
+	start := autoScopeWindowBase.Add(-time.Minute)
+	end := autoScopeWindowBase.Add(time.Duration(len(rows))*time.Second + time.Minute)
+	return c, start, end
+}
+
+// sortedCopy returns a sorted copy of vs, leaving the input untouched.
+func sortedCopy(vs []string) []string {
+	out := make([]string, len(vs))
+	copy(out, vs)
+	sort.Strings(out)
+	return out
+}
+
+// TestBuildAutoScopeUnionAttributeValuesSQL_ChDB_MatchesUnroutedMapOnlyResult
+// is the correctness roundtrip cerberus issue #2870 requires: for each of
+// the four materialized-routing cases, the ROUTED query (materialized
+// schema) and the UNROUTED query (schema.DefaultOTelTraces(), which for
+// every key here has nil registries and so always takes the unchanged
+// arrayJoin-over-both-maps path) run against the SAME seeded rows must
+// return the exact same set of distinct values.
+func TestBuildAutoScopeUnionAttributeValuesSQL_ChDB_MatchesUnroutedMapOnlyResult(t *testing.T) {
+	c, start, end := seedAutoScopeClient(t)
+	ctx := context.Background()
+	unroutedSchema := schema.DefaultOTelTraces()
+	routedSchema := autoScopeMaterializedSchema()
+
+	cases := []struct {
+		name string
+		key  string
+		want []string
+	}{
+		{"materialized_in_both", "both.key", []string{"v1", "v2", "v3"}},
+		{"materialized_in_span_only", "http.status_code", []string{"200", "500", "999"}},
+		{"materialized_in_resource_only", "k8s.namespace.name", []string{"ns-a", "ns-b", "ns-from-span"}},
+		{"materialized_in_neither", "rpc.method", []string{"GetUser", "ResourceRPC"}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			unroutedSQL, unroutedArgs := tempo.BuildAttributeValuesSQLForTest(
+				unroutedSchema, tc.key, tempo.AttrMapScopeAnyForTest, nil, start, end,
+			)
+			routedSQL, routedArgs := tempo.BuildAttributeValuesSQLForTest(
+				routedSchema, tc.key, tempo.AttrMapScopeAnyForTest, nil, start, end,
+			)
+
+			unroutedGot, err := c.QueryStrings(ctx, unroutedSQL, unroutedArgs...)
+			if err != nil {
+				t.Fatalf("unrouted query failed: %v\nSQL: %s", err, unroutedSQL)
+			}
+			routedGot, err := c.QueryStrings(ctx, routedSQL, routedArgs...)
+			if err != nil {
+				t.Fatalf("routed query failed: %v\nSQL: %s", err, routedSQL)
+			}
+
+			unroutedSorted := sortedCopy(unroutedGot)
+			routedSorted := sortedCopy(routedGot)
+
+			// First pin the routed result against the case's own known-good
+			// expectation, so a failure names the actual wrong VALUES...
+			if fmt.Sprint(routedSorted) != fmt.Sprint(sortedCopy(tc.want)) {
+				t.Errorf("routed result = %v, want %v", routedSorted, tc.want)
+			}
+			// ...then the load-bearing #2870 assertion: routed and
+			// unrouted must agree exactly, proving the union/dedup shape
+			// changes nothing about the ANSWER, only how it is computed.
+			if fmt.Sprint(routedSorted) != fmt.Sprint(unroutedSorted) {
+				t.Errorf("routed result diverges from unrouted map-only result:\nrouted:   %v\nunrouted: %v",
+					routedSorted, unroutedSorted)
+			}
+		})
+	}
+}

--- a/internal/api/tempo/search_tag_values_autoscope_materialized_test.go
+++ b/internal/api/tempo/search_tag_values_autoscope_materialized_test.go
@@ -1,0 +1,132 @@
+package tempo_test
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/tsouza/cerberus/internal/api/tempo"
+	"github.com/tsouza/cerberus/internal/schema"
+)
+
+// TestBuildAttributeValuesSQL_AutoScopeMaterializedColumnRouting pins
+// cerberus issue #2870's tag-values routing contract: the auto-scope
+// (`.x` leading-dot, or the bare-key V1 fallback) form unions each side's
+// best available read — a materialized column's narrow, arrayJoin-free
+// read where the key is materialized in that map, a map subscript
+// (mapContains-gated) where it isn't — and drops the map-only
+// arrayJoin-over-both-maps shape entirely once EITHER side is
+// materialized. A key materialized in neither map keeps today's single
+// arrayJoin shape unchanged.
+func TestBuildAttributeValuesSQL_AutoScopeMaterializedColumnRouting(t *testing.T) {
+	s := schema.DefaultOTelTraces()
+	s.MaterializedSpanAttributeColumns = map[string]string{
+		"http.status_code": "__cerberus_materialized_http.status_code",
+		"both.key":         "__cerberus_materialized_span_both.key",
+	}
+	s.MaterializedResourceAttributeColumns = map[string]string{
+		"k8s.namespace.name": "__cerberus_materialized_k8s.namespace.name",
+		"both.key":           "__cerberus_materialized_resource_both.key",
+	}
+
+	start := time.Unix(1000, 0).UTC()
+	end := time.Unix(2000, 0).UTC()
+
+	cases := []struct {
+		name string
+		key  string
+		// wantMaterializedMarkers are __cerberus_materialized_* substrings
+		// the rendered SQL must contain — one per materialized side.
+		wantMaterializedMarkers []string
+		// wantUnionAll is true whenever at least one side is materialized:
+		// the query switches from the single arrayJoin shape to a UNION
+		// ALL of per-side arms.
+		wantUnionAll bool
+		// wantMapBacked is true whenever at least one side still needs the
+		// map subscript / mapContains fallback (unconfigured side, or
+		// neither side materialized).
+		wantMapBacked bool
+	}{
+		{
+			name:                    "materialized_in_both",
+			key:                     "both.key",
+			wantMaterializedMarkers: []string{"__cerberus_materialized_span_both.key", "__cerberus_materialized_resource_both.key"},
+			wantUnionAll:            true,
+			wantMapBacked:           false,
+		},
+		{
+			name:                    "materialized_in_span_only",
+			key:                     "http.status_code",
+			wantMaterializedMarkers: []string{"__cerberus_materialized_http.status_code"},
+			wantUnionAll:            true,
+			wantMapBacked:           true,
+		},
+		{
+			name:                    "materialized_in_resource_only",
+			key:                     "k8s.namespace.name",
+			wantMaterializedMarkers: []string{"__cerberus_materialized_k8s.namespace.name"},
+			wantUnionAll:            true,
+			wantMapBacked:           true,
+		},
+		{
+			name:                    "materialized_in_neither",
+			key:                     "rpc.method",
+			wantMaterializedMarkers: nil,
+			wantUnionAll:            false,
+			wantMapBacked:           true,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			sqlStr, _ := tempo.BuildAttributeValuesSQLForTest(s, tc.key, tempo.AttrMapScopeAnyForTest, nil, start, end)
+
+			for _, marker := range tc.wantMaterializedMarkers {
+				if !strings.Contains(sqlStr, marker) {
+					t.Errorf("SQL missing expected materialized column %q: %s", marker, sqlStr)
+				}
+			}
+			gotUnionAll := strings.Contains(sqlStr, "UNION ALL")
+			if gotUnionAll != tc.wantUnionAll {
+				t.Errorf("UNION ALL present = %v, want %v; SQL: %s", gotUnionAll, tc.wantUnionAll, sqlStr)
+			}
+			gotMapBacked := strings.Contains(sqlStr, "mapContains") || strings.Contains(sqlStr, "arrayJoin")
+			if gotMapBacked != tc.wantMapBacked {
+				t.Errorf("map-backed arm present = %v, want %v; SQL: %s", gotMapBacked, tc.wantMapBacked, sqlStr)
+			}
+			if tc.wantUnionAll {
+				// Once routed to the union shape, the arrayJoin-over-array
+				// idiom the map-only path uses must be entirely gone —
+				// each arm is either a plain column read or a map
+				// subscript, never an arrayJoin fan-out.
+				if strings.Contains(sqlStr, "arrayJoin") {
+					t.Errorf("union-routed SQL unexpectedly contains arrayJoin: %s", sqlStr)
+				}
+			} else {
+				if !strings.Contains(sqlStr, "arrayJoin") {
+					t.Errorf("materialized-in-neither SQL should keep the unchanged arrayJoin shape: %s", sqlStr)
+				}
+			}
+		})
+	}
+}
+
+// TestBuildAttributeValuesSQL_AutoScopeMaterializedUnchangedForConfiguredOtherKey
+// confirms that a key NOT present in either registry renders identically
+// whether or not the schema carries materialized registries for OTHER
+// keys — mirroring
+// TestBuildAttributeValuesSQL_UnmaterializedSchemaUnchanged's single-scope
+// coverage for the auto-scope form.
+func TestBuildAttributeValuesSQL_AutoScopeMaterializedUnchangedForConfiguredOtherKey(t *testing.T) {
+	withRegistry := schema.DefaultOTelTraces()
+	withRegistry.MaterializedSpanAttributeColumns = map[string]string{"http.status_code": "__cerberus_materialized_http.status_code"}
+	without := schema.DefaultOTelTraces()
+
+	start := time.Unix(1000, 0).UTC()
+	end := time.Unix(2000, 0).UTC()
+
+	gotWith, _ := tempo.BuildAttributeValuesSQLForTest(withRegistry, "rpc.method", tempo.AttrMapScopeAnyForTest, nil, start, end)
+	gotWithout, _ := tempo.BuildAttributeValuesSQLForTest(without, "rpc.method", tempo.AttrMapScopeAnyForTest, nil, start, end)
+	if gotWith != gotWithout {
+		t.Errorf("unconfigured key's auto-scope SQL differs based on registry presence:\nwith registry:    %s\nwithout registry: %s", gotWith, gotWithout)
+	}
+}

--- a/internal/api/tempo/search_tag_values_materialized_test.go
+++ b/internal/api/tempo/search_tag_values_materialized_test.go
@@ -13,8 +13,15 @@ import (
 // issue #2776's tag-values routing contract: a single-scope (resource.x /
 // span.x) lookup whose key is materialized reads the narrow column
 // directly — no arrayJoin, no mapContains, no map subscript — while an
-// unconfigured key (or the auto-scope `.x` form, out of scope for this
-// version) keeps today's map-backed shape unchanged.
+// unconfigured key keeps today's map-backed shape unchanged. The
+// auto-scope (`.x`) form's OWN materialized routing (cerberus issue
+// #2870, which unions a per-side materialized/map-backed read rather than
+// short-circuiting the whole query to one column) is pinned separately in
+// TestBuildAttributeValuesSQL_AutoScopeMaterializedColumnRouting
+// (search_tag_values_autoscope_materialized_test.go) — the all-or-nothing
+// "materialized ⇒ no arrayJoin/mapContains anywhere" assertion below
+// doesn't fit its union shape, which can legitimately keep mapContains on
+// whichever side has no materialized entry for the key.
 func TestBuildAttributeValuesSQL_MaterializedColumnRouting(t *testing.T) {
 	s := schema.DefaultOTelTraces()
 	s.MaterializedSpanAttributeColumns = map[string]string{"http.status_code": "__cerberus_materialized_http.status_code"}
@@ -32,7 +39,6 @@ func TestBuildAttributeValuesSQL_MaterializedColumnRouting(t *testing.T) {
 		{"span_materialized", "http.status_code", tempo.AttrMapScopeSpanForTest, true},
 		{"resource_materialized", "k8s.namespace.name", tempo.AttrMapScopeResourceForTest, true},
 		{"span_unconfigured_key_stays_on_map", "rpc.method", tempo.AttrMapScopeSpanForTest, false},
-		{"auto_scope_stays_on_map_even_when_materialized", "http.status_code", tempo.AttrMapScopeAnyForTest, false},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {


### PR DESCRIPTION
## Summary

- Closes #2870, a follow-up to #2776 (materialized trace attribute columns, #2872).
- Extends `buildAttributeValuesSQL`'s `attrMapScopeAny` branch (the auto-scope `.x` / bare-key V1 fallback): when a key is materialized in the span map, the resource map, or both, the query now unions each side's best available read via `UNION ALL` — a materialized column's narrow read where that side has one, the existing map subscript otherwise — instead of staying on the map-only `arrayJoin` path #2776 deliberately left it on.
- A key materialized in neither map is unaffected: the routing check falls through and the original `arrayJoin`-over-both-maps SQL is emitted unchanged.

## What changed

- **`internal/api/tempo/search_tag_values.go`** — new `buildAutoScopeUnionAttributeValuesSQL` + `attrValueArmFrag` helper. Each scope arm is built independently (materialized column read + `!= ''` filter, or map subscript + `mapContains` filter — the same per-side shapes the single-scope routing already uses), unioned via `chsql.UnionAll`, and wrapped in the same outer `SELECT DISTINCT v ... WHERE v != ''` every branch of `buildAttributeValuesSQL` already uses. `buildAttributeValuesSQL`'s doc comment updated to describe the new routing; the old "tracked as #2870" note is gone since this PR is that follow-up.
- **`internal/api/tempo/search_tag_values_materialized_test.go`** — removed the `auto_scope_stays_on_map_even_when_materialized` case, which pinned the *previous* limitation this PR removes; added a doc-comment pointer to the new dedicated test file.
- **`internal/api/tempo/search_tag_values_autoscope_materialized_test.go`** (new) — SQL-shape test mirroring `TestBuildAttributeValuesSQL_MaterializedColumnRouting`, covering all four cases: materialized-in-both, -span-only, -resource-only, -neither.
- **`internal/api/tempo/search_tag_values_autoscope_chdb_test.go`** (new, `chdb`-tagged) — real chDB correctness roundtrip: for each of the four cases, the routed (union) query and the unrouted (map-only `arrayJoin`) query run against the same seeded `otel_traces` rows and must return the identical value set. See evidence below.
- **`docs/operations.md`** — updated the materialized-attribute-columns section to note the auto-scope form is now routed too (was previously documented as single-scope-only).

## Design choice: `UNION ALL` of per-side arms, not a mixed-type `arrayJoin` array

The issue proposed either shape. I went with `UNION ALL` because it reuses the existing per-scope Frag builders (`mapAtFrag`/`mapContainsFrag` for the map arm, the plain-column read for the materialized arm) completely unchanged — each arm is exactly the shape `buildAttributeValuesSQL` already builds for a single scope, just built twice instead of chosen once. A single `arrayJoin([...])` array literal would need CH to resolve a common element type between a `LowCardinality(String)` column reference and a `Map` subscript expression inside one array constructor up front; `UNION ALL` lets each arm's projection carry its own type and only unifies them positionally, the way ClickHouse's `UNION ALL` already does elsewhere in this codebase (`internal/chsql/set_op.go`'s `emitSetOperation`, `nested_set_annotate.go`, `structural_join.go`).

## Four-case correctness verification (chDB roundtrip)

`TestBuildAutoScopeUnionAttributeValuesSQL_ChDB_MatchesUnroutedMapOnlyResult` (`internal/api/tempo/search_tag_values_autoscope_chdb_test.go`, `go test -tags=chdb`) seeds one `otel_traces` table with real `DEFAULT <map>[<key>]` materialized columns (the same DDL shape #2776 provisions in production) and, for each case, runs both the routed and unrouted SQL and diffs the sorted result sets:

| Case | Key | Routed result | Matches unrouted? |
|---|---|---|---|
| materialized-in-both | `both.key` | `[v1 v2 v3]` | yes |
| materialized-in-span-only | `http.status_code` | `[200 500 999]` (999 comes from the resource map's fallback arm — same key name, unmaterialized on that side) | yes |
| materialized-in-resource-only | `k8s.namespace.name` | `[ns-a ns-b ns-from-span]` (`ns-from-span` from the span map's fallback arm) | yes |
| materialized-in-neither | `rpc.method` | `[GetUser ResourceRPC]` | yes (trivially — routed IS unrouted here) |

All four `PASS`. I also verified the test isn't tautological: temporarily collapsing the union to `UnionAll(spanArm, spanArm)` (dropping the resource arm) made 3 of the 4 subtests fail with the exact expected wrong values (e.g. `both.key` case: got `[v1 v2]`, want `[v1 v2 v3]`), then reverted.

## Performance

No dedicated `perf-smoke`/`perf-nightly` baseline exists for Tempo tag-values routing (the only checked-in LFS sample data in `test/perf/{smoke,nightly}` is PromQL metrics fixtures, unrelated to traces), so I ran an ad hoc chDB comparison instead (2M-row synthetic `otel_traces`, MergeTree, single optimized part), mirroring `test/perf/materialized_k8s_col_chdb_test.go`'s methodology:

- Old (`arrayJoin` over both maps): 134.9 ms wall, reads the full `SpanAttributes` Map (compressed 5,770,390 B).
- New (`UNION ALL` union): 16.1 ms wall — the materialized-column arm reads 11,938 B compressed (~480x less than the Map) for the materialized side, and the other arm still reads only the smaller `ResourceAttributes` Map.

No regression; the routed path is substantially faster whenever it fires, consistent with #2776's own "MB-not-GB" read-cost win. Not added as a committed perf-nightly entry — the issue's own verification bar names the SQL-shape test and the chDB/real-CH roundtrip, not a new baseline, and this is a pure read-cost win with no new failure mode to guard a regression floor against.

## Test plan

- [x] `go build ./internal/api/tempo/...`, `go vet ./internal/api/tempo/...` (default + `chdb` tags) — clean.
- [x] `go test -race ./internal/api/tempo/...` (default + `-tags=chdb`) — green.
- [x] `TestBuildAttributeValuesSQL_AutoScopeMaterializedColumnRouting` — all four cases, SQL-shape.
- [x] `TestBuildAutoScopeUnionAttributeValuesSQL_ChDB_MatchesUnroutedMapOnlyResult` — all four cases, real chDB roundtrip against the unrouted answer.
- [x] `node .github/scripts/forbid-sql-raw.mjs` — clean.
- [x] `scripts/test-forbid-skip.sh`, `just lint-actions` — clean.
- [x] `markdownlint-cli2 docs/operations.md` — clean.
- [x] `gofumpt`/`goimports` on touched files — clean (lefthook `pre-commit` also ran these).
- [ ] CI (lint, full test matrix) — watching.

## Notes for reviewers

`lint` cannot be meaningfully verified locally in an agent worktree (CLAUDE.md invariant 5) — watching CI for it.
