### PR TITLE
fix(solver): give downsample-tier RangeWindows a bounded K-clipping signal

### DIFF
--- a/docs/solver.md
+++ b/docs/solver.md
@@ -139,7 +139,16 @@ whether slicing is worthwhile:
 - `D` = cumulative spine lookback (Σ `Range` down nested matrix windows + leaf
   `RangeLWR.Lookback`). Unlike `F`, `D` is unaffected by which emitter reads the
   window: it measures per-slice SCAN redundancy, and a native carrier's shard
-  widens its input by `Offset + Range` exactly as a fan-out carrier's does.
+  widens its input by `Offset + Range` exactly as a fan-out carrier's does. The
+  one exception is a `RangeWindow` with `DownsampleTier` set (issue #2751):
+  `DownsampleTierInput` reads a table bounded to one row per
+  `schema.DownsampleTierBucket` per series regardless of `Range`, a different
+  and sparser SOURCE than the raw scan `D`'s invariance assumes, so that
+  carrier's `D` contribution is capped at the bucket width instead of growing
+  with `Range` (issue #2859). `F` is untouched by the same case — the tier
+  emitter still arrayJoins each tier row across its covering anchors exactly
+  like the raw fan-out, so the materialised-rows-per-row ratio is still
+  `Range/Step`.
 - `K = clamp(floor(N / MinAnchorsPerSlice), 2, min(MaxK, floor(OuterRange /
   max(D, Step))))`.
 

--- a/internal/solver/planner.go
+++ b/internal/solver/planner.go
@@ -4,6 +4,7 @@ import (
 	"time"
 
 	"github.com/tsouza/cerberus/internal/chplan"
+	"github.com/tsouza/cerberus/internal/schema"
 )
 
 // Planner is pure, read-only classification of a post-optimize plan into a
@@ -762,6 +763,31 @@ type carrierGeometry struct {
 	// offset-bearing carrier kind at once.
 	lookback time.Duration
 
+	// redundancyLookback overrides lookback for the D (Σ lookback) term
+	// alone, when a carrier's SOURCE TABLE — not merely its emitter
+	// strategy — makes per-slice re-scan redundancy cheaper than the raw
+	// window span implies. Zero (the default for every carrier kind but
+	// one) means "use lookback for D too", which is what singlePass's own
+	// doc above already establishes as correct for a carrier reading the
+	// SAME raw table as the fan-out family: redundancy is unaffected by
+	// emitter strategy when the density of what is re-scanned is unchanged.
+	//
+	// The one exception is a [chplan.RangeWindow] with DownsampleTier set
+	// (cerberus issue #2751): DownsampleTierInput reads
+	// schema.DownsampleTierTable, which holds at most one row per
+	// schema.DownsampleTierBucket per series REGARDLESS of Range — a
+	// different, bounded-density source table, not just a different
+	// emitter over the same one. Re-scanning a Range-wide span of that
+	// table costs proportionally to the bucket width, not to Range, so D's
+	// contribution is capped there instead of growing with Range — see
+	// issue #2859. F is deliberately left untouched by this override: the
+	// tier emitter (chsql's emitRangeWindowDownsampleTier) still arrayJoins
+	// each tier row across its covering anchors exactly like the raw
+	// fan-out does, so the MATERIALISED-rows-per-row ratio genuinely is
+	// still lookback/Step — only the redundant RE-SCAN cost per slice
+	// changes, because the table underneath is sparser.
+	redundancyLookback time.Duration
+
 	// singlePass reports that the carrier's emitter reduces each raw sample
 	// EXACTLY ONCE, in one streaming aggregate pass, and never materialises the
 	// (sample, anchor) matrix. It is the native timeSeries*ToGrid family: the
@@ -886,7 +912,16 @@ func carrierGeometryOf(gc chplan.GridCarrier) (carrierGeometry, bool) {
 		// than derived from End-Start because a subquery-inner window leaves
 		// both bounds zero for ReanchorRange to fill, and the span must stay
 		// measurable there.
-		return carrierGeometry{outerRange: v.OuterRange, lookback: v.Range, reanchorable: true}, true
+		geom := carrierGeometry{outerRange: v.OuterRange, lookback: v.Range, reanchorable: true}
+		if v.DownsampleTier {
+			// See redundancyLookback's own doc: this node answers from
+			// schema.DownsampleTierTable's bounded, bucket-granularity rows
+			// (cerberus issue #2751) rather than Input's raw per-sample
+			// scan, so its per-slice re-scan redundancy is capped at the
+			// tier's fixed bucket width instead of growing with Range.
+			geom.redundancyLookback = schema.DownsampleTierBucket
+		}
+		return geom, true
 
 	case *chplan.RangeLWR:
 		// The bare-selector last-with-respect-to leaf: one sample per anchor,
@@ -1056,8 +1091,15 @@ func (p *Planner) recordGridCarrier(gc chplan.GridCarrier, depth int, sig *signa
 	// D is per-slice SCAN redundancy, which is the window SPAN regardless of
 	// which emitter reads it — a single-pass carrier's shard widens its input
 	// by Offset+Range exactly as a fan-out carrier's does, so singlePass does
-	// not enter here.
-	sig.cumulativeD += geom.lookback
+	// not enter here. redundancyLookback is the one exception: a carrier
+	// whose SOURCE TABLE (not just its emitter) is bounded-density —
+	// currently only a DownsampleTier RangeWindow — substitutes its capped
+	// value; see that field's own doc.
+	dLookback := geom.lookback
+	if geom.redundancyLookback > 0 {
+		dLookback = geom.redundancyLookback
+	}
+	sig.cumulativeD += dLookback
 
 	if depth == 0 && geom.outerRange > 0 && step > 0 {
 		sig.hasWindow = true

--- a/internal/solver/planner_downsample_tier_test.go
+++ b/internal/solver/planner_downsample_tier_test.go
@@ -1,0 +1,173 @@
+package solver
+
+import (
+	"testing"
+
+	"github.com/tsouza/cerberus/internal/chplan"
+	"github.com/tsouza/cerberus/internal/schema"
+)
+
+// downsampleTierGuardStep / Range / OuterRange define the synthetic
+// K-clipping-guard fixture for issue #2859: a tier-eligible idelta() shape
+// whose Range and Step are both positive multiples of
+// schema.DownsampleTierBucket and whose Start is bucket-aligned —
+// downsampleTierEligible's own contract (internal/promql/lower_strategy.go).
+//
+// OuterRange is chosen at exactly 800m / 240m = 3.33x its own Range, so the
+// PRE-#2859 D=Range ceiling (floor(OuterRange/Range) = floor(800m/240m) = 3)
+// sits BELOW the structural MaxK=8 backstop and is therefore the BINDING
+// constraint, while the shape's own N/MinAnchorsPerSlice-derived K
+// (floor(161/16) = 10) clears both ceilings — so which ceiling binds is what
+// this fixture isolates.
+//
+// Step == schema.DownsampleTierBucket (the smallest step downsampleTierEligible
+// ever admits, since it requires Step to be a positive integer multiple of the
+// bucket) is also why the POST-fix ceiling lands on Step rather than on the
+// bucket width itself: denom = max(D, Step) always resolves to Step for a real
+// tier-eligible plan, because D can never be narrower than the bucket it is
+// now capped at, and Step can never be narrower than that same bucket either.
+var (
+	downsampleTierGuardStep       = schema.DownsampleTierBucket      // 5m — the minimum tier-eligible step
+	downsampleTierGuardRange      = 48 * schema.DownsampleTierBucket // 4h
+	downsampleTierGuardOuterRange = 160 * downsampleTierGuardStep    // 13h20m, N = 161
+	downsampleTierGuardStart      = gridStart.Truncate(schema.DownsampleTierBucket)
+	downsampleTierGuardEnd        = downsampleTierGuardStart.Add(downsampleTierGuardOuterRange)
+)
+
+// downsampleTierGuardWindow builds the fixture's RangeWindow node.
+// tierEligible controls DownsampleTier alone: with it false, the node is
+// BYTE-IDENTICAL to what carrierGeometryOf saw before issue #2859's fix
+// (which never branched on the flag, so a DownsampleTierInput-populated node
+// got the same D=Range treatment as a plain raw-scan one) — the exact
+// pre-fix cost model, reproduced by construction rather than by reverting
+// code. With it true, the node is what internal/promql/lower_strategy.go's
+// downsampleTierNode actually emits for this shape once the boot-wired
+// DownsampleTier*Lowerer routes it (idelta / irate / last_over_time only).
+func downsampleTierGuardWindow(tierEligible bool) chplan.Node {
+	return &chplan.RangeWindow{
+		Input:               leafScan(),
+		Func:                "idelta",
+		Range:               downsampleTierGuardRange,
+		Step:                downsampleTierGuardStep,
+		OuterRange:          downsampleTierGuardOuterRange,
+		Start:               downsampleTierGuardStart,
+		End:                 downsampleTierGuardEnd,
+		TimestampColumn:     "TimeUnix",
+		ValueColumn:         "Value",
+		GroupBy:             []chplan.Expr{&chplan.ColumnRef{Name: "Attributes"}},
+		DownsampleTierInput: leafScan(),
+		DownsampleTier:      tierEligible,
+	}
+}
+
+func downsampleTierGuardMeta() RequestMeta {
+	return RequestMeta{
+		Lang:  "promql",
+		Start: downsampleTierGuardStart,
+		End:   downsampleTierGuardEnd,
+		Step:  downsampleTierGuardStep,
+	}
+}
+
+// TestPlan_DownsampleTierRelievesKClippingGuard is issue #2859's required
+// proof: the SAME tier-eligible shape's K-clipping-guard decision (the
+// floor(OuterRange/max(D,Step)) ceiling tied to issue #2685's MaxK clamp)
+// actually changes once the solver's cost model is told DownsampleTier is
+// set, and does not merely stay routed at the same K.
+func TestPlan_DownsampleTierRelievesKClippingGuard(t *testing.T) {
+	t.Parallel()
+	p := &Planner{Cfg: autoCfg()}
+	meta := downsampleTierGuardMeta()
+
+	before, routedBefore := p.Plan(downsampleTierGuardWindow(false), meta)
+	if !routedBefore {
+		t.Fatalf("pre-fix (raw-scan cost model) shape must route; reason=%q", before.Reason)
+	}
+	if before.Reason != ReasonRouted {
+		t.Fatalf("pre-fix reason = %q, want %q", before.Reason, ReasonRouted)
+	}
+	if before.K != 3 {
+		t.Fatalf("pre-fix K = %d, want 3 (D=Range=4h clips floor(OuterRange/Range)=floor(800m/240m)=3, below MaxK=8)", before.K)
+	}
+
+	after, routedAfter := p.Plan(downsampleTierGuardWindow(true), meta)
+	if !routedAfter {
+		t.Fatalf("tier-aware shape must route; reason=%q", after.Reason)
+	}
+	if after.Reason != ReasonRouted {
+		t.Fatalf("tier-aware reason = %q, want %q", after.Reason, ReasonRouted)
+	}
+	if after.K != 8 {
+		t.Fatalf("tier-aware K = %d, want 8 (D capped at schema.DownsampleTierBucket=5m <= Step, so Step binds "+
+			"the ceiling and the structural MaxK=8 backstop decides instead)", after.K)
+	}
+
+	if after.K <= before.K {
+		t.Fatalf("DownsampleTier awareness must raise K above the pre-fix value: before=%d after=%d", before.K, after.K)
+	}
+}
+
+// TestPlan_DownsampleTierLeavesFanoutUnchanged pins the OTHER half of the
+// same fix: F (the ModeAuto fan-out/MinFanout memory proxy) is deliberately
+// LEFT ALONE by the DownsampleTier override — the tier emitter
+// (chsql.emitRangeWindowDownsampleTier) still arrayJoins each tier row across
+// its covering anchors exactly like the raw fan-out does, so F stays
+// Range/Step regardless of the flag. Only D (the redundancy/K-ceiling term)
+// changes — see carrierGeometry.redundancyLookback's own doc for why the two
+// answer different questions here.
+func TestPlan_DownsampleTierLeavesFanoutUnchanged(t *testing.T) {
+	t.Parallel()
+	p := &Planner{Cfg: autoCfg()}
+	meta := downsampleTierGuardMeta()
+
+	before, routedBefore := p.Plan(downsampleTierGuardWindow(false), meta)
+	if !routedBefore {
+		t.Fatalf("pre-fix shape must route; reason=%q", before.Reason)
+	}
+	after, routedAfter := p.Plan(downsampleTierGuardWindow(true), meta)
+	if !routedAfter {
+		t.Fatalf("tier-aware shape must route; reason=%q", after.Reason)
+	}
+
+	wantFanout := int64(downsampleTierGuardRange / downsampleTierGuardStep) // 240m/5m = 48
+	if before.Fanout != wantFanout {
+		t.Fatalf("pre-fix Fanout = %d, want %d", before.Fanout, wantFanout)
+	}
+	if after.Fanout != before.Fanout {
+		t.Fatalf("DownsampleTier must not change Fanout: before=%d after=%d", before.Fanout, after.Fanout)
+	}
+}
+
+// TestPlan_DownsampleTierIneligible_ByteIdenticalToNoSignal pins the
+// default-off contract at the STRUCT level rather than the flag level: a
+// RangeWindow whose DownsampleTierInput is nil and DownsampleTier is false —
+// every deployment that has not wired cerberus issue #2751's feature at
+// all — reproduces the ORIGINAL (pre-#2859) K decision for the identical
+// grid geometry, confirming the new redundancyLookback branch is truly
+// unreachable off this one flag.
+func TestPlan_DownsampleTierIneligible_ByteIdenticalToNoSignal(t *testing.T) {
+	t.Parallel()
+	p := &Planner{Cfg: autoCfg()}
+	meta := downsampleTierGuardMeta()
+
+	rw := &chplan.RangeWindow{
+		Input:           leafScan(),
+		Func:            "idelta",
+		Range:           downsampleTierGuardRange,
+		Step:            downsampleTierGuardStep,
+		OuterRange:      downsampleTierGuardOuterRange,
+		Start:           downsampleTierGuardStart,
+		End:             downsampleTierGuardEnd,
+		TimestampColumn: "TimeUnix",
+		ValueColumn:     "Value",
+		GroupBy:         []chplan.Expr{&chplan.ColumnRef{Name: "Attributes"}},
+		// DownsampleTierInput and DownsampleTier both left zero-valued.
+	}
+	d, routed := p.Plan(rw, meta)
+	if !routed {
+		t.Fatalf("shape must route; reason=%q", d.Reason)
+	}
+	if d.K != 3 {
+		t.Fatalf("K = %d, want 3 (unchanged from the raw-scan cost model; DownsampleTierInput is nil)", d.K)
+	}
+}


### PR DESCRIPTION
## Summary

- `RangeWindow.DownsampleTier` (#2751) tells the emitter to answer from the bucketed tier table instead of raw-scanning `Input`, but the solver's cost model (`carrierGeometryOf` / `recordGridCarrier`) kept measuring the raw-scan shape — `D`, the per-slice scan-redundancy term the K-clipping ceiling (`floor(OuterRange/max(D,Step))`, tied to #2685's `MaxK` clamp) is built from, stayed `Range`-scaled regardless of the flag.
- Add `carrierGeometry.redundancyLookback`: a `D`-only override that caps a `DownsampleTier` `RangeWindow`'s contribution at `schema.DownsampleTierBucket` (the tier's fixed bucket width) instead of `Range`, since the tier table holds at most one row per bucket per series no matter how wide `Range` is. `F` (the `ModeAuto` fan-out/`MinFanout` proxy) is deliberately left untouched — the tier emitter still `arrayJoin`s each tier row across its covering anchors exactly like the raw fan-out, so that ratio is genuinely unchanged.
- Off the flag (the default, and every deployment that hasn't wired #2751), `redundancyLookback` stays zero and the cost grid is byte-identical to pre-#2859 — no correctness or emission changes anywhere; this is purely a planning-quality fix.

## Verification

- **Required synthetic proof** (`TestPlan_DownsampleTierRelievesKClippingGuard`): the identical tier-eligible `idelta()` shape (`Range=4h`, `Step=5m`, `OuterRange=13h20m`) goes from **K=3** (pre-fix: `D=Range=4h` binds the ceiling below the structural `MaxK=8` backstop) to **K=8** (post-fix: `D` capped at the 5m bucket, so `Step` binds the ceiling instead and `MaxK` decides) — purely from flipping `DownsampleTier` from `false` to `true` on an otherwise-identical node. `false` reproduces the exact pre-#2859 cost model by construction, since `carrierGeometryOf` never branched on the flag before this change.
- `TestPlan_DownsampleTierLeavesFanoutUnchanged` pins that `F` is untouched by the same flip.
- `TestPlan_DownsampleTierIneligible_ByteIdenticalToNoSignal` pins the struct-level default-off contract (`DownsampleTierInput == nil`).
- **No regression on non-tier-eligible queries**: the override is gated strictly on `DownsampleTier == true`, defaulting to the pre-existing `lookback`-based `D` otherwise — a structural no-op elsewhere. `TestSolverDecisionRatchet` (the full `test/spec/promql/**` corpus, 745 fixtures) shows **zero drift** — expected, since its fixed eval grid's 15s step is never a multiple of the 5-minute tier bucket, so no corpus fixture is (or ever was) tier-eligible either way.
- Emission is unaffected: `chsql.emitRangeWindowDownsampleTier` is untouched by this change; `internal/chsql` and `internal/chplan` package tests pass unmodified.
- `perf-nightly`/`perf-smoke` (real-ClickHouse execution baselines) are not required checks on this PR and are structurally out of scope — this change touches only `internal/solver`'s planning signal, never emitted SQL.

## Test plan

- [x] `just fmt` clean (gofumpt / goimports)
- [x] `go build ./...`
- [x] `go test -race ./internal/solver/...`
- [x] `go test -race ./internal/chplan/... ./internal/chsql/...`
- [x] `go test -count=1 -run TestSolverDecisionRatchet ./test/perf/` — zero drift
- [ ] CI green

## Notes for reviewers

- Scoped deliberately to `D` only, not `F`: `F` is a structurally accurate matrix-amplification ratio (`Range/Step`) for the tier emitter too — the row-density win lives in the *absolute* row count (bucket-bounded vs. raw-scrape-bounded), which neither `F` nor `D` tracks as an absolute count. `D`, however, is exactly the term the K-clipping ceiling reads, and the tier's bounded, fixed-density source table genuinely changes what it should represent — see `redundancyLookback`'s doc in `internal/solver/planner.go` for the full reasoning, including why this doesn't contradict the pre-existing "`D` is unaffected by emitter strategy" invariant (that invariant is about the SAME source table read by two emitter strategies; the tier reads a categorically different, sparser table).

Closes #2859
