### PR TITLE
feat(chopt,promql,chsql): group the instant-mode duplicate-labelset guard by UInt64 tag-group id (#2750 grouping-keys slice)

### DIFF
--- a/.github/ci-lanes.json
+++ b/.github/ci-lanes.json
@@ -410,6 +410,7 @@
         "solver-memory-apportion-integration",
         "strict-scan-test",
         "structural-two-phase-external-table-integration",
+        "tag-groups-differential-integration",
         "traces-scan-bound-integration",
         "traces-scan-window-integration",
         "ts-grid-group-array-integration",

--- a/.github/scripts/lib/mirror.mjs
+++ b/.github/scripts/lib/mirror.mjs
@@ -76,6 +76,9 @@ export const mirroredImages = [
   // 25.10 is the quantile_prom_histogram real-CH differential's own pin
   // (quantilePrometheusHistogram shipped in 25.10 — see CH_QUANTILE_PROM_HISTOGRAM_IMAGE).
   'clickhouse/clickhouse-server:25.10-alpine',
+  // 26.2 is the ts_tag_groups real-CH differential's own pin
+  // (timeSeriesThrowDuplicateSeriesIf shipped in 26.2 — see CH_TAG_GROUPS_IMAGE).
+  'clickhouse/clickhouse-server:26.2-alpine',
   'clickhouse/clickhouse-server:26.3',
   'clickhouse/clickhouse-server:26.5',
   'clickhouse/clickhouse-server:26.6',

--- a/.github/workflows/strict-scan.yml
+++ b/.github/workflows/strict-scan.yml
@@ -321,6 +321,20 @@ jobs:
       - name: Run quantile_prom_histogram rank-walk differential (real ClickHouse)
         run: just quantile-prom-histogram-rankwalk-integration
 
+      # The ts_tag_groups real-CH differential (#2750): the instant-mode
+      # duplicate-labelset guard's UInt64-group-id collapse
+      # (guardNameDropCollisionByTagGroup) answers byte-identical to the
+      # existing Map-grouped path it replaces, driven through the REAL
+      # production HTTP handler + emitter against a REAL ClickHouse. This is
+      # what chopt.FeatureTSGridTagGroups's registry entry rests its
+      # correctness claim on. timeSeriesThrowDuplicateSeriesIf's 26.2 floor
+      # is above every other integration lane's pin, so this step boots its
+      # own dedicated server (CH_TAG_GROUPS_IMAGE) rather than reusing this
+      # job's CH_STRICT_SCAN_IMAGE container. See
+      # internal/api/prom/handler_tag_groups_realch_integration_test.go.
+      - name: Run ts_tag_groups differential (real ClickHouse)
+        run: just tag-groups-differential-integration
+
       # The ts_grid_last_over_time real-CH regression pin (#2747): reproduces
       # upstream's own ClickHouse/ClickHouse#106577 regression fixture shape
       # (a staleness window narrower than the query_range grid step) through

--- a/Justfile
+++ b/Justfile
@@ -559,6 +559,23 @@ quantile-prom-histogram-rankwalk-integration:
     @just _pull-retry {{CH_QUANTILE_PROM_HISTOGRAM_IMAGE}}
     go test -timeout 15m -tags=integration -count=1 -run TestHistogramQuantile_RankWalkNative_DifferentialRealCH ./internal/chsql/...
 
+# Run the ts_tag_groups real-CH differential (cerberus issue #2750): the
+# duplicate-labelset guard's instant-mode name-drop collapse
+# (guardNameDropCollisionByTagGroup) answers BYTE-IDENTICAL to the existing
+# Map-grouped path across the collision-reject, distinct-labelsets
+# pass-through, and pinned-name no-guard shapes, driven through the REAL
+# production HTTP handler + emitter against a REAL ClickHouse — the proof
+# chopt.FeatureTSGridTagGroups's registry entry rests on.
+# timeSeriesThrowDuplicateSeriesIf's floor (26.2) is above every other
+# integration lane's pin, so this lane boots its own dedicated server
+# (CH_TAG_GROUPS_IMAGE) rather than reusing CH_TEST_IMAGE. Requires Docker;
+# gated behind the `integration` build tag. See
+# internal/api/prom/handler_tag_groups_realch_integration_test.go and
+# strict-scan.yml.
+tag-groups-differential-integration:
+    @just _pull-retry {{CH_TAG_GROUPS_IMAGE}}
+    go test -timeout 15m -tags=integration -count=1 -run TestTagGroups_MatchesMapGrouping_RealClickHouse ./internal/api/prom/...
+
 # Run the ts_grid_last_over_time real-CH regression pin (#2747): reproduces
 # upstream's own #106577 regression fixture shape (a staleness window
 # narrower than the query_range grid step) end to end through cerberus's
@@ -1313,6 +1330,16 @@ CH_STRICT_SCAN_IMAGE := "clickhouse/clickhouse-server:26.6-alpine"
 # timeSeries*ToGrid family. TestIntegrationImagePinsMatchTheJustfile holds this
 # against the literal in the test source.
 CH_QUANTILE_PROM_HISTOGRAM_IMAGE := "clickhouse/clickhouse-server:25.10-alpine"
+
+# CH_TAG_GROUPS_IMAGE is the server the ts_tag_groups real-CH differential
+# boots (internal/api/prom's TestTagGroups_MatchesMapGrouping_RealClickHouse).
+# Its own dedicated pin, like CH_QUANTILE_PROM_HISTOGRAM_IMAGE's:
+# chopt.FeatureTSGridTagGroups's floor is 26.2 (timeSeriesThrowDuplicateSeriesIf,
+# the higher of the two functions the feature needs) — above CH_TEST_IMAGE's
+# 25.9 — so this lane boots its own server rather than reusing CH_TEST_IMAGE.
+# TestIntegrationImagePinsMatchTheJustfile holds this against the literal in
+# the test source.
+CH_TAG_GROUPS_IMAGE := "clickhouse/clickhouse-server:26.2-alpine"
 
 # k3s node image for the k3d clusters. Pinned (k3d otherwise picks a default tag
 # per k3d version) so we pull ONE known tag with retry and hand it to

--- a/cmd/cerberus/main.go
+++ b/cmd/cerberus/main.go
@@ -830,6 +830,9 @@ func newPromHandler(
 	h.Limiter = limiter
 	h.Version = Version
 	h.Lowerers = nativeRangeLowerers(optSet)
+	// Unlike Lowerers (range-only), TagGroups (cerberus issue #2750) is
+	// consulted on the instant path too — see Handler.TagGroups's own doc.
+	h.TagGroups = optSet.Has(chopt.FeatureTSGridTagGroups)
 	h.QueryTimeout = cfg.ClickHouse.QueryTimeout
 	// CERBERUS_PROM_METADATA_LOOKBACK is the ONLY input to the windowless
 	// metadata-discovery horizon; zero leaves the handler on its own

--- a/docs/clickhouse-optimizations.md
+++ b/docs/clickhouse-optimizations.md
@@ -160,6 +160,7 @@ table.
 | `full_text_index`                | 26.2       | experimental | no         |
 | `text_index_line_filter`         | 26.4       | experimental | no         |
 | `trace_id_external_table`        | none       | experimental | no         |
+| `ts_tag_groups`                  | 26.2       | experimental | no         |
 <!-- END GENERATED: chopt-feature-table -->
 
 The rich, hand-authored columns below stay OUTSIDE the generated block: they

--- a/internal/api/prom/handler.go
+++ b/internal/api/prom/handler.go
@@ -115,6 +115,16 @@ type Handler struct {
 	// the histogram-merge budget guards apply to both.
 	ResourceBounds promql.ResourceBounds
 
+	// TagGroups carries chopt.FeatureTSGridTagGroups's resolved verdict
+	// (cerberus issue #2750), wired at boot in cmd/cerberus from the
+	// resolved chopt.EnabledSet. Unlike Lowerers, both the instant and the
+	// range-streaming query paths consult it: its only consumer, the
+	// instant-mode duplicate-labelset guard, is reached from the instant
+	// path. The zero value (false) keeps the pre-#2750 Map-grouped guard
+	// shape, so a Handler that never wires this (every test that builds one
+	// directly) is unaffected.
+	TagGroups bool
+
 	// QueryTimeout is the configured default per-query wall-clock cap
 	// (CERBERUS_QUERY_TIMEOUT). It is the ceiling the standard Prometheus
 	// `?timeout=<duration>` query param min's against per request
@@ -881,6 +891,7 @@ func (h *Handler) executeRangeStreaming(
 		Step:           step,
 		Lowerers:       h.lowerers(),
 		ResourceBounds: h.ResourceBounds,
+		TagGroups:      h.TagGroups,
 	}
 	// Time the entire QueryCursor entry so the cursor-open round-trip
 	// is billed to X-Cerberus-CH-Millis the same way timeCH did pre-
@@ -913,9 +924,13 @@ func (h *Handler) executeRangeStreaming(
 // instant window regardless). cerberus issue #2748's ts_grid_instant is the
 // first feature whose native arm actually fires on THIS path — without this
 // thread it is unreachable from the real HTTP API, dead code behind its own
-// chopt feature.
+// chopt feature. TagGroups (cerberus issue #2750) is threaded for the same
+// reason and is, in fact, the FIRST feature whose only consumer lives on the
+// instant path exclusively (the duplicate-labelset guard's name-drop half) —
+// omitting it here would make ts_tag_groups entirely unreachable, not merely
+// untested.
 func (h *Handler) executeInstant(ctx context.Context, query string, start, end time.Time) ([]chclient.Sample, map[string]string, error) {
-	l := &lang{Parser: h.parser, Schema: h.Schema, Start: start, End: end, Lowerers: h.lowerers(), ResourceBounds: h.ResourceBounds}
+	l := &lang{Parser: h.parser, Schema: h.Schema, Start: start, End: end, Lowerers: h.lowerers(), ResourceBounds: h.ResourceBounds, TagGroups: h.TagGroups}
 	res, err := h.Engine.Query(h.withSampleDrainBudget(ctx), l, query)
 	if err != nil {
 		return nil, nil, classifyEngineError(err)

--- a/internal/api/prom/handler_tag_groups_realch_integration_test.go
+++ b/internal/api/prom/handler_tag_groups_realch_integration_test.go
@@ -1,0 +1,313 @@
+//go:build integration
+
+// handler_tag_groups_realch_integration_test.go — real-ClickHouse
+// differential-parity verification for chopt.FeatureTSGridTagGroups
+// (cerberus issue #2750): the instant-mode duplicate-labelset guard's new
+// UInt64-group-id path (guardNameDropCollisionByTagGroup, internal/promql/
+// duplicate_labelset_guard.go) must answer BYTE-IDENTICAL to the existing
+// Map-grouped path it replaces, for every shape the guard covers —
+// distinct-labelsets pass-through, the collision reject, and the
+// pinned-name no-guard case — because the whole point of this feature is a
+// grouping-KEY swap with no observable behaviour change (chopt.
+// FeatureTSGridTagGroups's own doc).
+//
+// Unlike handler_route_b_realch_integration_test.go's route-A/route-B
+// comparison (a genuinely different execution strategy expected to answer
+// the same result), this is a stricter bar: TagGroups=false and
+// TagGroups=true must be TWO DIFFERENT SQL SHAPES answering IDENTICALLY,
+// proven against a real server rather than assumed from the two shapes
+// "looking equivalent" on paper — the two ClickHouse-analyzer rejections
+// this feature's own registry doc records (UNKNOWN_IDENTIFIER,
+// ILLEGAL_AGGREGATION) are exactly the kind of divergence that looks fine
+// until it is run.
+//
+// Needs a real ClickHouse >= 26.2 — chopt.FeatureTSGridTagGroups's own
+// floor (the higher of timeSeriesTagsToGroup/timeSeriesGroupToTags's 26.1
+// and timeSeriesThrowDuplicateSeriesIf's 26.2, even though this feature does
+// not yet wire the latter into the guard's throw — see that registry
+// entry's own doc). Requires Docker; gated behind the `integration` build
+// tag, joining the established real-CH lane family
+// (handler_route_b_realch_integration_test.go and siblings) — run locally
+// with:
+//
+//	go test -tags=integration -count=1 -run TestTagGroups ./internal/api/prom/...
+package prom_test
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+	"time"
+
+	tcclickhouse "github.com/testcontainers/testcontainers-go/modules/clickhouse"
+
+	"github.com/tsouza/cerberus/internal/api/prom"
+	"github.com/tsouza/cerberus/internal/chclient"
+	"github.com/tsouza/cerberus/internal/schema"
+)
+
+// tagGroupsCHImage pins ClickHouse exactly at chopt.FeatureTSGridTagGroups's
+// own floor, mirroring tsGridGroupArrayImage / routeBCHImage's own
+// per-feature pinning rationale — this test's only dependency on the
+// feature is the version its own testcontainers image is pinned to.
+const tagGroupsCHImage = "clickhouse/clickhouse-server:26.2-alpine"
+
+// tagGroupsGaugeDDL mirrors handler_native_lowerers_integration_test.go's
+// nativeLowererGaugeDDL (unavailable here — build-tag-disjoint from this
+// file), the full OTel-exporter gauge-table shape schema.DefaultOTelMetrics
+// expects: a bare-minimum table (handler_chdb_test.go's chdb-only gaugeDDL)
+// is missing ResourceAttributes/ServiceName, which a real ClickHouse's
+// merge() table function across every otel_metrics_* table rejects with
+// UNKNOWN_IDENTIFIER the moment a query selects them — chDB is lenient
+// about the mismatch (see handler_route_b_realch_integration_test.go's own
+// header comment on chDB's leniency), a real server is not.
+const tagGroupsGaugeDDL = `CREATE TABLE otel_metrics_gauge (
+    ResourceAttributes Map(LowCardinality(String), String),
+    ServiceName LowCardinality(String),
+    MetricName String,
+    MetricDescription String,
+    MetricUnit String,
+    Attributes Map(LowCardinality(String), String),
+    StartTimeUnix DateTime64(9),
+    TimeUnix DateTime64(9),
+    Value Float64,
+    Flags UInt32
+) ENGINE = MergeTree() ORDER BY (ServiceName, MetricName, TimeUnix);`
+
+// tagGroupsOtherTablesDDL creates the remaining four schema.DefaultOTelMetrics
+// tables (sum, histogram, exponential_histogram, summary) EMPTY — an
+// unpinned / regex `__name__` matcher (the only way to reach
+// collidesOnNameDrop, and therefore this test's whole subject) fans out
+// into one arm per configured metric table regardless of which table the
+// matched name actually lives in, so all five must exist for the query to
+// resolve at all, even though this test only ever seeds rows into
+// otel_metrics_gauge. Column shapes mirror the upstream OTel-CH exporter
+// templates (handler_chdb_resource_attrs_test.go's chdb-only
+// resourceAttrHistogramDDL / resourceAttrExpHistogramDDL carry the same
+// histogram / exp-histogram shapes; unavailable here for the same
+// build-tag-disjoint reason as tagGroupsGaugeDDL above). One statement per
+// slice entry — client.Exec runs one native-protocol statement per call, so
+// this cannot be a single multi-statement string the way a single CREATE
+// TABLE can.
+var tagGroupsOtherTablesDDL = []string{
+	`CREATE TABLE otel_metrics_sum (
+    ResourceAttributes Map(LowCardinality(String), String),
+    ServiceName LowCardinality(String),
+    MetricName String,
+    Attributes Map(LowCardinality(String), String),
+    StartTimeUnix DateTime64(9),
+    TimeUnix DateTime64(9),
+    Value Float64,
+    Flags UInt32,
+    AggregationTemporality Int32,
+    IsMonotonic Boolean
+) ENGINE = MergeTree() ORDER BY (ServiceName, MetricName, TimeUnix);`,
+	`CREATE TABLE otel_metrics_histogram (
+    ResourceAttributes Map(LowCardinality(String), String),
+    ServiceName LowCardinality(String),
+    MetricName String,
+    Attributes Map(LowCardinality(String), String),
+    StartTimeUnix DateTime64(9),
+    TimeUnix DateTime64(9),
+    Count UInt64,
+    Sum Float64,
+    BucketCounts Array(UInt64),
+    ExplicitBounds Array(Float64),
+    Min Float64,
+    Max Float64,
+    Flags UInt32,
+    AggregationTemporality Int32
+) ENGINE = MergeTree() ORDER BY (ServiceName, MetricName, TimeUnix);`,
+	`CREATE TABLE otel_metrics_exponential_histogram (
+    ResourceAttributes Map(LowCardinality(String), String),
+    ServiceName LowCardinality(String),
+    MetricName String,
+    Attributes Map(LowCardinality(String), String),
+    StartTimeUnix DateTime64(9),
+    TimeUnix DateTime64(9),
+    Count UInt64,
+    Sum Float64,
+    Scale Int32,
+    ZeroCount UInt64,
+    PositiveOffset Int32,
+    PositiveBucketCounts Array(UInt64),
+    NegativeOffset Int32,
+    NegativeBucketCounts Array(UInt64),
+    Min Float64,
+    Max Float64,
+    Flags UInt32,
+    AggregationTemporality Int32
+) ENGINE = MergeTree() ORDER BY (ServiceName, MetricName, TimeUnix);`,
+	`CREATE TABLE otel_metrics_summary (
+    ResourceAttributes Map(LowCardinality(String), String),
+    ServiceName LowCardinality(String),
+    MetricName String,
+    Attributes Map(LowCardinality(String), String),
+    StartTimeUnix DateTime64(9),
+    TimeUnix DateTime64(9),
+    Count UInt64,
+    Sum Float64,
+    ValueAtQuantiles Array(Tuple(Float64, Float64)),
+    Flags UInt32
+) ENGINE = MergeTree() ORDER BY (ServiceName, MetricName, TimeUnix);`,
+}
+
+// newTagGroupsHandler wires a *httptest.Server backed by client with
+// TagGroups set as requested, sharing the SAME real ClickHouse connection
+// (and therefore the same seeded data) the TagGroups=false / TagGroups=true
+// comparison runs over.
+func newTagGroupsHandler(t *testing.T, client *chclient.Client, tagGroups bool) *httptest.Server {
+	t.Helper()
+	h := prom.New(client, schema.DefaultOTelMetrics(), nil)
+	h.TagGroups = tagGroups
+	mux := http.NewServeMux()
+	h.Mount(mux)
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+// tagGroupsInstantQuery issues an /api/v1/query and returns status + body.
+func tagGroupsInstantQuery(t *testing.T, srvURL, query string, at time.Time) (int, string) {
+	t.Helper()
+	resp, err := http.Get(fmt.Sprintf("%s/api/v1/query?query=%s&time=%d",
+		srvURL, url.QueryEscape(query), at.Unix()))
+	if err != nil {
+		t.Fatalf("GET %s: %v", query, err)
+	}
+	return resp.StatusCode, readBody(t, resp)
+}
+
+func TestTagGroups_MatchesMapGrouping_RealClickHouse(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	defer cancel()
+
+	t.Setenv("TESTCONTAINERS_RYUK_DISABLED", "true")
+
+	container, err := tcclickhouse.Run(
+		ctx,
+		tagGroupsCHImage,
+		tcclickhouse.WithUsername("cerberus"),
+		tcclickhouse.WithPassword("cerberus"),
+		tcclickhouse.WithDatabase("otel"),
+	)
+	if err != nil {
+		t.Fatalf("start clickhouse: %v", err)
+	}
+	t.Cleanup(func() { _ = container.Terminate(ctx) })
+
+	host, err := container.Host(ctx)
+	if err != nil {
+		t.Fatalf("host: %v", err)
+	}
+	port, err := container.MappedPort(ctx, "9000/tcp")
+	if err != nil {
+		t.Fatalf("port: %v", err)
+	}
+
+	client, err := chclient.New(chclient.Config{
+		Addr:     host + ":" + port.Port(),
+		Database: "otel",
+		Username: "cerberus",
+		Password: "cerberus",
+	})
+	if err != nil {
+		t.Fatalf("connect: %v", err)
+	}
+	t.Cleanup(func() { _ = client.Close() })
+
+	if err := client.Exec(ctx, tagGroupsGaugeDDL); err != nil {
+		t.Fatalf("create otel_metrics_gauge: %v", err)
+	}
+	for _, ddl := range tagGroupsOtherTablesDDL {
+		if err := client.Exec(ctx, ddl); err != nil {
+			t.Fatalf("create table: %v\nddl=%s", err, ddl)
+		}
+	}
+
+	// One eval instant; both series' latest sample sits inside the 5m LWR
+	// staleness window the bare-selector seam applies.
+	evalAt := time.Now().UTC().Truncate(time.Second)
+	sampleAt := evalAt.Add(-1 * time.Minute)
+	tsStr := sampleAt.Format("2006-01-02 15:04:05.000000000")
+
+	// Two metric NAMES sharing one attribute set: dropping __name__ under
+	// `ceil({__name__=~...})` maps both onto the identical label set
+	// {host="a"} — the collision the guard must reject on both paths.
+	// A third, third-name series with a DISTINCT attribute set proves the
+	// distinct-labelset pass-through half at the same time (one seed, two
+	// query shapes below, less setup to keep in parity between two servers
+	// there are none of here — same server, same data, only the handler's
+	// TagGroups flag differs).
+	seed := fmt.Sprintf(`INSERT INTO otel_metrics_gauge (MetricName, Attributes, TimeUnix, Value) VALUES
+    ('collide_a', map('host', 'x'), toDateTime64('%[1]s', 9), 10.0),
+    ('collide_b', map('host', 'x'), toDateTime64('%[1]s', 9), 20.0),
+    ('distinct_a', map('host', 'p'), toDateTime64('%[1]s', 9), 30.0),
+    ('distinct_b', map('host', 'q'), toDateTime64('%[1]s', 9), 40.0),
+    ('pinned_metric', map('host', 'r', 'env', 'prod'), toDateTime64('%[1]s', 9), 50.0);`, tsStr)
+	if err := client.Exec(ctx, seed); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	srvOld := newTagGroupsHandler(t, client, false)
+	srvNew := newTagGroupsHandler(t, client, true)
+
+	for _, tc := range []struct {
+		name       string
+		query      string
+		wantStatus int
+	}{
+		{"collision_rejected", `ceil({__name__=~"collide_a|collide_b"})`, http.StatusUnprocessableEntity},
+		{"distinct_labelsets_pass_through", `ceil({__name__=~"distinct_a|distinct_b"})`, http.StatusOK},
+		{"pinned_name_no_guard", `ceil(pinned_metric)`, http.StatusOK},
+		{"unary_minus", `-{__name__=~"distinct_a|distinct_b"}`, http.StatusOK},
+		{"scalar_times_vector", `2 * {__name__=~"distinct_a|distinct_b"}`, http.StatusOK},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			statusOld, bodyOld := tagGroupsInstantQuery(t, srvOld.URL, tc.query, evalAt)
+			statusNew, bodyNew := tagGroupsInstantQuery(t, srvNew.URL, tc.query, evalAt)
+
+			if statusOld != tc.wantStatus {
+				t.Fatalf("TagGroups=false: status=%d, want %d; body=%s", statusOld, tc.wantStatus, bodyOld)
+			}
+			if statusNew != tc.wantStatus {
+				t.Fatalf("TagGroups=true: status=%d, want %d; body=%s", statusNew, tc.wantStatus, bodyNew)
+			}
+
+			normOld, err := normalizeQueryBody(bodyOld)
+			if err != nil {
+				t.Fatalf("normalize TagGroups=false body: %v; body=%s", err, bodyOld)
+			}
+			normNew, err := normalizeQueryBody(bodyNew)
+			if err != nil {
+				t.Fatalf("normalize TagGroups=true body: %v; body=%s", err, bodyNew)
+			}
+			if normOld != normNew {
+				t.Fatalf("%s: TagGroups=false and TagGroups=true diverged:\nfalse=%s\ntrue=%s", tc.query, normOld, normNew)
+			}
+		})
+	}
+}
+
+// normalizeQueryBody re-marshals an /api/v1/query response through its
+// decoded Go shape (queryResponse, from handler_test.go — untagged, shared
+// across every build-tag variant of this package) so a byte-for-byte
+// comparison is not sensitive to incidental key-order differences the two
+// handlers' independent JSON encodings could otherwise introduce, while
+// still catching any REAL divergence in status, error, series set, labels,
+// or values.
+func normalizeQueryBody(body string) (string, error) {
+	var parsed queryResponse
+	if err := json.Unmarshal([]byte(body), &parsed); err != nil {
+		return "", err
+	}
+	out, err := json.Marshal(parsed)
+	if err != nil {
+		return "", err
+	}
+	return string(out), nil
+}

--- a/internal/api/prom/handler_tag_groups_realch_integration_test.go
+++ b/internal/api/prom/handler_tag_groups_realch_integration_test.go
@@ -40,6 +40,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"sort"
 	"testing"
 	"time"
 
@@ -300,14 +301,70 @@ func TestTagGroups_MatchesMapGrouping_RealClickHouse(t *testing.T) {
 // handlers' independent JSON encodings could otherwise introduce, while
 // still catching any REAL divergence in status, error, series set, labels,
 // or values.
+//
+// A vector Result's own SERIES order is additionally normalized by
+// sortVectorResult. Neither guardNameDropCollision's Map-grouped Aggregate
+// nor guardNameDropCollisionByTagGroup's UInt64-id-grouped one carries an
+// ORDER BY — ClickHouse's GROUP BY makes no row-order promise for either
+// shape, and switching the grouping key changes which order it happens to
+// pick, exactly like handler_route_b_realch_integration_test.go's own
+// route-A/route-B comparison already has to tolerate (its byLabels map
+// exists for the identical reason). Series order was never part of what
+// this feature's "no observable behaviour change" doc comment promises —
+// only the series SET and each series' own labels/value are.
 func normalizeQueryBody(body string) (string, error) {
 	var parsed queryResponse
 	if err := json.Unmarshal([]byte(body), &parsed); err != nil {
 		return "", err
+	}
+	if parsed.Data.ResultType == "vector" {
+		sorted, err := sortVectorResult(parsed.Data.Result)
+		if err != nil {
+			return "", err
+		}
+		parsed.Data.Result = sorted
 	}
 	out, err := json.Marshal(parsed)
 	if err != nil {
 		return "", err
 	}
 	return string(out), nil
+}
+
+// sortVectorResult decodes a vector Result (decoded generically by
+// queryResponse as `any`) into its typed []prom.VectorSample shape and
+// sorts it by each series' marshaled label set. encoding/json canonically
+// sorts a Go map's keys when marshaling, so two series sharing a label set
+// marshal identically regardless of which grouping key produced them; the
+// sort key is otherwise unique because the guard under test has already
+// rejected any query where two series would share one label set.
+func sortVectorResult(result any) ([]prom.VectorSample, error) {
+	raw, err := json.Marshal(result)
+	if err != nil {
+		return nil, err
+	}
+	var vec []prom.VectorSample
+	if err := json.Unmarshal(raw, &vec); err != nil {
+		return nil, err
+	}
+	// keyed pairs a sample with its own sort key so sort.Slice's swaps move
+	// both together — sorting `vec` directly against a same-indexed `keys`
+	// slice would desync the two the moment the first swap happened.
+	type keyed struct {
+		key    string
+		sample prom.VectorSample
+	}
+	pairs := make([]keyed, len(vec))
+	for i, sample := range vec {
+		key, err := json.Marshal(sample.Metric)
+		if err != nil {
+			return nil, err
+		}
+		pairs[i] = keyed{key: string(key), sample: sample}
+	}
+	sort.Slice(pairs, func(i, j int) bool { return pairs[i].key < pairs[j].key })
+	for i, p := range pairs {
+		vec[i] = p.sample
+	}
+	return vec, nil
 }

--- a/internal/api/prom/lang.go
+++ b/internal/api/prom/lang.go
@@ -65,6 +65,17 @@ type lang struct {
 	// NewExplainLangRange) keeps the shipped, calibrated defaults —
 	// mirroring how a zero Lowerers keeps the all-fan-out default.
 	ResourceBounds promql.ResourceBounds
+
+	// TagGroups threads chopt.FeatureTSGridTagGroups's resolved verdict
+	// (cerberus issue #2750) from Handler.TagGroups (built once at boot in
+	// cmd/cerberus from the resolved chopt.EnabledSet) into
+	// promql.LowerOpts.TagGroups. Both executeInstant and
+	// executeRangeStreaming set it — unlike Lowerers, which targets the
+	// range-only timeSeries*ToGrid MATRIX family, this feature's only
+	// consumer (the instant-mode duplicate-labelset guard) is reached from
+	// the instant path, so the instant lang MUST carry it. The zero value
+	// keeps the pre-#2750 Map-grouped guard shape.
+	TagGroups bool
 }
 
 // Compile-time check that *lang satisfies engine.Lang.
@@ -126,7 +137,7 @@ func (l *lang) Parse(ctx context.Context, query string) (chplan.Node, engine.Met
 	// promql.Lower leave the sink nil.
 	var guards []promql.ScalarGuard
 	plan, err := promql.LowerAtRangeOpts(ctx, expr, l.Schema, l.Start, l.End, l.Step,
-		promql.LowerOpts{Lowerers: l.Lowerers, Guards: &guards, ResourceBounds: l.ResourceBounds})
+		promql.LowerOpts{Lowerers: l.Lowerers, Guards: &guards, ResourceBounds: l.ResourceBounds, TagGroups: l.TagGroups})
 	lowerT.Done(ctx)
 	if err != nil {
 		return nil, engine.Meta{}, &parseStageError{stage: "lower", err: err}

--- a/internal/chopt/registry.go
+++ b/internal/chopt/registry.go
@@ -1686,6 +1686,129 @@ const (
 	// FeatureTraceIDProjection's posture on a fresh, real-CH-server-only
 	// mechanism.
 	FeatureTraceIDExternalTable = "trace_id_external_table"
+
+	// FeatureTSGridTagGroups opts the instant-mode duplicate-labelset guard's
+	// collapsing Aggregate (internal/promql/duplicate_labelset_guard.go —
+	// guardNameDropCollision, the name-dropping half; guardLabelRewriteCollision
+	// is a documented follow-up, see below) onto grouping by a deduplicated
+	// UInt64 id (timeSeriesTagsToGroup(Attributes)) instead of the raw
+	// Map(String,String) Attributes column, rehydrating Attributes via
+	// timeSeriesGroupToTags only in the wrapping output projection (cerberus
+	// issue #2750 — the grouping-keys-only slice of the tag-group family; label
+	// ops (by/without/label_replace/label_join/group_left via the purpose-built
+	// tag functions) are explicit follow-up, tracked on #2750 itself per the
+	// issue's own "grouping keys first, label ops later" staging).
+	//
+	// SITE CHOICE: guardNameDropCollision is the single most self-contained
+	// grouping site in the pipeline that groups on the raw Attributes Map —
+	// one file, no entanglement with the out-of-scope label-rewrite/group_left
+	// towers, and (checked directly against internal/api/prom/lang.go) reached
+	// ONLY from the instant-mode `/api/v1/query` path, which — unlike
+	// query_range — never routes through the solver's route-B sharding
+	// (internal/solver; classify()/IsSliceInvariant gate route B on Step > 0).
+	// That matters concretely: timeSeriesTagsToGroup/timeSeriesGroupToTags are
+	// STATEFUL, backed by a per-query ContextTimeSeriesTagsCollector (confirmed
+	// by reading the ClickHouse source, src/Functions/TimeSeries/*.cpp) — a
+	// group id has NO meaning outside the single query execution that produced
+	// it. Route B runs K per-shard ClickHouse queries and concatenates their
+	// cursors in Go WITHOUT re-aggregating on any key the shards produced
+	// (internal/api/prom/lang.go, internal/api/prom/handler.go's "K per-shard
+	// cursors... concatenated, NOT merged" comment), so a route-B-sharded
+	// grouping site would need its OWN per-shard rehydration story before any
+	// group id could cross a shard boundary — a route-B-sharded grouping site
+	// is deliberately out of scope for cerberus issue #2750's own grouping-keys
+	// slice; this PR picks a site that structurally cannot reach route B at
+	// all, rather than shipping an unverified assumption about cross-shard id
+	// reuse. Route-B-sharded grouping sites remain open follow-up work,
+	// tracked at https://github.com/tsouza/cerberus/issues/2880.
+	//
+	// VERSION FLOOR — verified against real ClickHouse 26.1-alpine and
+	// 26.2-alpine servers (fresh containers, default config, no
+	// allow_experimental_* setting of any kind): timeSeriesTagsToGroup and
+	// timeSeriesGroupToTags both work on 26.1 (the issue's own claimed core
+	// floor); timeSeriesThrowDuplicateSeriesIf does NOT exist on 26.1
+	// (UNKNOWN_FUNCTION) and DOES exist on 26.2 — confirming the issue's "floor
+	// 26.1 core; 26.2 specifically for timeSeriesThrowDuplicateSeriesIf" claim
+	// exactly. This feature's own MinVersion is pinned to the HIGHER 26.2,
+	// not 26.1, even though this PR does not yet wire
+	// timeSeriesThrowDuplicateSeriesIf into the guard's HAVING (that stays the
+	// existing throwIf(uniqExact(MetricName) > 1, ...) — the issue's own point
+	// that "the Aggregate is also the collapse fix" and the throw-message
+	// mechanism is a SEPARATE, independently-verifiable change from the
+	// grouping-key swap this feature makes) — one feature id should not
+	// silently widen its own effective floor in a later PR without a version
+	// bump an operator can see, so the id is pinned to what the FAMILY needs
+	// once the throw is adopted, not merely what this PR's own diff touches.
+	//
+	// NO EXPERIMENTAL GATE — RequiresExperimentalTSGrid is deliberately false.
+	// The issue flagged the docs show no experimental gate for this family
+	// (unlike the timeSeries*ToGrid MATRIX/aggregate family, which stamps
+	// allow_experimental_time_series_aggregate_functions) and asked for
+	// empirical verification rather than trusting that absence: confirmed —
+	// every call above ran on a stock container with no settings applied
+	// beyond CLICKHOUSE_USER/PASSWORD, and system.functions lists the whole
+	// timeSeriesTagsToGroup/GroupToTags/IdToTags/IdToGroup/StoreTags/
+	// ThrowDuplicateSeriesIf family as ordinary (non-experimental) functions on
+	// both 26.1 and 26.2.
+	//
+	// ORDER-INDEPENDENCE — verified directly (the reason this feature can
+	// obviate mapSort canonicalisation for THIS grouping site specifically,
+	// without weakening it): timeSeriesTagsToGroup(map('a','1','b','2')) and
+	// timeSeriesTagsToGroup(map('b','2','a','1')) return the IDENTICAL group id
+	// — the function keys on the tag SET, not the Map's iteration order, unlike
+	// a raw positional Map comparison (canonical_series_keys.go's whole reason
+	// for existing). canonical_series_keys.go / canonical_attributes.go are
+	// UNCHANGED by this feature: they still canonicalise every other Map
+	// comparison and join in the pipeline this PR does not touch.
+	//
+	// ALIAS-SCOPING CONSTRAINT — verified directly, and the reason the
+	// emission is a wrapping chplan.Project rather than one flat Aggregate:
+	// ClickHouse rejects referencing a GROUP BY SELECT-list alias from inside
+	// an aggregate function's argument in the SAME SELECT
+	// (UNKNOWN_IDENTIFIER), and separately rejects re-deriving the grouping
+	// expression a second time inside an aggregate argument
+	// (ILLEGAL_AGGREGATION — the analyzer matches the repeated sub-expression
+	// against the GROUP BY key and misclassifies the whole aggregate call).
+	// The only shape that measured correctly is two query levels: an inner
+	// Aggregate that groups on timeSeriesTagsToGroup(Attributes) and carries
+	// only the group id plus the existing any(Value)/any(Timestamp)/carry
+	// payload (Attributes itself is dropped, never re-read), and an outer
+	// Project that reads the group id back as a REAL column from that
+	// subquery and calls timeSeriesGroupToTags on it to rehydrate Attributes —
+	// exactly "rehydrating Maps only in the final output projection" the issue
+	// proposed, not a stylistic choice.
+	//
+	// AutoSelect is false — and, unlike every other opt-in feature's "no
+	// fielded validation yet" posture, this one has a MEASURED reason, not
+	// just a cautious default: a real ClickHouse 26.2 A/B (2M rows, the same
+	// two SQL shapes this feature emits, FORMAT Null to isolate server-side
+	// cost) at both a low (100 distinct label sets) and a high (200,000
+	// distinct label sets) group cardinality found the UInt64-group-id path
+	// CONSISTENTLY SLOWER in wall clock than the Map GROUP BY it replaces —
+	// roughly 2-3x at low cardinality (666-1083ms vs 265-305ms) and ~50%
+	// at high cardinality (1358-1506ms vs 881-957ms) — while peak memory was
+	// a MIXED result, not a clean win: ~1.8x HIGHER at low cardinality
+	// (29.7-34.9MB vs 19.6MB) and only ~10-20% lower at high cardinality
+	// (411-413MB vs 462-520MB). The per-query ContextTimeSeriesTagsCollector
+	// backing timeSeriesTagsToGroup/timeSeriesGroupToTags (see this feature's
+	// own doc above) carries real bookkeeping cost that, at this grouping
+	// site's row/cardinality shape, outweighs the O(1)-integer-comparison
+	// win the issue's "single biggest CPU/memory lever" framing predicted —
+	// this PR's own site was chosen for being the most self-contained
+	// worked example the issue names (see this feature's SITE CHOICE note),
+	// not for being the highest-cardinality one; a wider, hotter GROUP BY
+	// elsewhere in the pipeline remains the open question for realizing the
+	// win the issue actually promises, tracked at
+	// https://github.com/tsouza/cerberus/issues/2880 — cerberus issue #2750
+	// itself stays open, not closed, for exactly this reason. Until a site is
+	// found where the measured numbers turn around,
+	// AutoSelect must stay false regardless of how many fielded runs pass —
+	// the mechanism (grouping-key correctness, round-trip fidelity, version
+	// floor) is proven; the performance case for THIS site is not, and the
+	// measurement above is why, not merely absence of evidence. Reachable
+	// only via an explicit CERBERUS_CH_OPTIMIZATIONS=ts_tag_groups listing
+	// (or "auto,ts_tag_groups").
+	FeatureTSGridTagGroups = "ts_tag_groups"
 )
 
 // AlwaysAvailable is the zero version floor for a feature that depends on no
@@ -2079,6 +2202,13 @@ var registry = []Feature{
 		AutoSelect: false,
 		Doc:        "push the /api/search two-phase phase-A TraceId set as a native-protocol external table instead of a literal IN list above a byte threshold (no version floor, native-protocol, opt-in via CERBERUS_CH_OPTIMIZATIONS -- EXPLAIN-verified idx_trace_id parity, #2783)",
 	},
+	{
+		ID:         FeatureTSGridTagGroups,
+		MinVersion: Version{Major: 26, Minor: 2},
+		Stability:  Experimental,
+		AutoSelect: false,
+		Doc:        "group the instant-mode duplicate-labelset guard's name-drop collapse on a deduplicated UInt64 id (timeSeriesTagsToGroup) instead of the raw Attributes Map, rehydrating via timeSeriesGroupToTags only in the output projection (server >= 26.2, no experimental gate, opt-in -- #2750)",
+	},
 }
 
 // Registry returns a copy of the seeded feature registry
@@ -2092,7 +2222,8 @@ var registry = []Feature{
 // join_spill, trace_id_projection, loki_catalog_mv, tempo_tag_catalog_mv,
 // trace_id_bitmap_filter, arg_and_max_fusion, result_cache,
 // lazy_materialization, explain_estimate, cardinality_probe,
-// full_text_index, text_index_line_filter, trace_id_external_table). The copy
+// full_text_index, text_index_line_filter, trace_id_external_table,
+// ts_tag_groups). The copy
 // keeps the canonical entries immutable from the caller's side. Exposed so
 // tests can enumerate the gates and the docs generator can render the
 // table.

--- a/internal/chopt/registry.go
+++ b/internal/chopt/registry.go
@@ -1735,10 +1735,11 @@ const (
 	// existing throwIf(uniqExact(MetricName) > 1, ...) — the issue's own point
 	// that "the Aggregate is also the collapse fix" and the throw-message
 	// mechanism is a SEPARATE, independently-verifiable change from the
-	// grouping-key swap this feature makes) — one feature id should not
-	// silently widen its own effective floor in a later PR without a version
-	// bump an operator can see, so the id is pinned to what the FAMILY needs
-	// once the throw is adopted, not merely what this PR's own diff touches.
+	// grouping-key swap this feature makes) — one feature id must not
+	// silently widen its own effective floor when a follow-up change adopts
+	// the throw, without a version bump an operator can see, so the id is
+	// pinned to what the FAMILY needs once the throw is adopted, not merely
+	// what this change's own diff touches.
 	//
 	// NO EXPERIMENTAL GATE — RequiresExperimentalTSGrid is deliberately false.
 	// The issue flagged the docs show no experimental gate for this family
@@ -2207,7 +2208,7 @@ var registry = []Feature{
 		MinVersion: Version{Major: 26, Minor: 2},
 		Stability:  Experimental,
 		AutoSelect: false,
-		Doc:        "group the instant-mode duplicate-labelset guard's name-drop collapse on a deduplicated UInt64 id (timeSeriesTagsToGroup) instead of the raw Attributes Map, rehydrating via timeSeriesGroupToTags only in the output projection (server >= 26.2, no experimental gate, opt-in -- #2750)",
+		Doc:        "group the instant-mode duplicate-labelset guard's name-drop collapse on a UInt64 tag-group id (timeSeriesTagsToGroup), not the raw Attributes Map, rehydrating via timeSeriesGroupToTags in the projection (server >= 26.2, no experimental gate, opt-in -- #2750)",
 	},
 }
 

--- a/internal/chopt/resolve_test.go
+++ b/internal/chopt/resolve_test.go
@@ -662,6 +662,7 @@ func TestRegistry_SeededEntries(t *testing.T) {
 		FeatureTextIndexLineFilter:          {ID: FeatureTextIndexLineFilter, MinVersion: v(26, 4), Stability: Experimental, AutoSelect: false, RequiresExperimentalTSGrid: false},
 		FeatureDownsampleTier:               {ID: FeatureDownsampleTier, MinVersion: v(25, 9), Stability: Experimental, AutoSelect: false, RequiresExperimentalTSGrid: true},
 		FeatureTraceIDExternalTable:         {ID: FeatureTraceIDExternalTable, MinVersion: AlwaysAvailable, Stability: Experimental, AutoSelect: false, RequiresExperimentalTSGrid: false},
+		FeatureTSGridTagGroups:              {ID: FeatureTSGridTagGroups, MinVersion: v(26, 2), Stability: Experimental, AutoSelect: false, RequiresExperimentalTSGrid: false},
 	}
 	if len(reg) != len(want) {
 		t.Fatalf("registry has %d entries; want %d", len(reg), len(want))

--- a/internal/chplan/fn.go
+++ b/internal/chplan/fn.go
@@ -323,6 +323,24 @@ const (
 	// evaluates to 0 otherwise, so it composes as an expression.
 	FnThrowIf Fn = "throwIf"
 
+	// timeSeriesTagsToGroup(tags) — a deterministic-in-scope-of-query UInt64
+	// surrogate for the Map(String,String) tags value: every call with an
+	// equal tag SET (order-independent — verified against a real ClickHouse
+	// 26.1 server) returns the same id within one query execution, and a
+	// different set returns a different id. The id has NO meaning outside the
+	// query that produced it (chopt.FeatureTSGridTagGroups's own doc explains
+	// why), so it may only be compared / grouped / joined on within a single
+	// statement, never persisted or compared across statements.
+	FnTimeSeriesTagsToGroup Fn = "timeSeriesTagsToGroup"
+
+	// timeSeriesGroupToTags(group) — the Array(Tuple(String,String)) inverse
+	// of [FnTimeSeriesTagsToGroup] within the SAME query: it can only resolve
+	// a group id produced earlier in the identical statement. Cast to
+	// Map(String,String) to match the schema's Attributes column type
+	// (verified against a real ClickHouse 26.1 server — the cast is lossless
+	// and order-independent).
+	FnTimeSeriesGroupToTags Fn = "timeSeriesGroupToTags"
+
 	// Type-cast and numeric-conversion functions.
 	// assumeNotNull(x) — x's Nullable wrapper dropped without a runtime check; a
 	// NULL operand renders as the underlying type's default, not an error.

--- a/internal/chsql/fnresolution.go
+++ b/internal/chsql/fnresolution.go
@@ -123,6 +123,11 @@ var fnResolutions = map[chplan.Fn]fnResolution{
 	chplan.FnNot:        {Name: "not"},
 	chplan.FnThrowIf:    {Name: "throwIf"},
 
+	// timeSeries tag/group functions (chopt.FeatureTSGridTagGroups, cerberus
+	// issue #2750) — see internal/chplan/fn.go's own doc for each.
+	chplan.FnTimeSeriesTagsToGroup: {Name: "timeSeriesTagsToGroup"},
+	chplan.FnTimeSeriesGroupToTags: {Name: "timeSeriesGroupToTags"},
+
 	// Type-cast and numeric-conversion functions.
 	chplan.FnAssumeNotNull:        {Name: "assumeNotNull"},
 	chplan.FnCast:                 {Name: "CAST"},

--- a/internal/promql/binary.go
+++ b/internal/promql/binary.go
@@ -206,9 +206,9 @@ func lowerVectorVector(b *parser.BinaryExpr, s schema.Metrics, op chplan.BinaryO
 		rSynth := isSyntheticScalarPlan(right, s) && !isVectorTypedSyntheticOperand(b.RHS)
 		switch {
 		case lSynth && !rSynth:
-			return foldSyntheticVectorBinary(left, right, b.RHS, op, true /*scalarOnLeft*/, b.ReturnBool, s), nil
+			return foldSyntheticVectorBinary(left, right, b.RHS, op, true /*scalarOnLeft*/, b.ReturnBool, s, ctx), nil
 		case !lSynth && rSynth:
-			return foldSyntheticVectorBinary(right, left, b.LHS, op, false /*scalarOnLeft*/, b.ReturnBool, s), nil
+			return foldSyntheticVectorBinary(right, left, b.LHS, op, false /*scalarOnLeft*/, b.ReturnBool, s, ctx), nil
 		}
 	}
 
@@ -404,6 +404,7 @@ func foldSyntheticVectorBinary(
 	op chplan.BinaryOp,
 	scalarOnLeft, returnBool bool,
 	s schema.Metrics,
+	ctx lowerCtx,
 ) chplan.Node {
 	synthVal := rewriteAnchorToTimeUnix(syntheticValueExpr(synth), s)
 	vecValue := chplan.Expr(&chplan.ColumnRef{Name: s.ValueColumn})
@@ -429,7 +430,7 @@ func foldSyntheticVectorBinary(
 	// exposes only (Attributes, Value), so a TimeUnix passthrough would
 	// raise CH UNKNOWN_IDENTIFIER. For a selector / already-canonicalised
 	// vec leg the helper emits the identical 4-column shape.
-	return guardedValueProjection(vec, vecExpr, s, newValue)
+	return guardedValueProjection(vec, vecExpr, s, ctx, newValue)
 }
 
 // rewriteAnchorToTimeUnix walks expr and replaces every
@@ -868,5 +869,5 @@ func lowerVectorScalar(vec parser.Expr, s schema.Metrics, op chplan.BinaryOp, sc
 	// matrix shape keeps its per-anchor `anchor_ts`. Mirrors the
 	// instant-fn / unary-minus path which already routes through this
 	// helper.
-	return guardedValueProjection(inner, vec, s, newValue), nil
+	return guardedValueProjection(inner, vec, s, ctx, newValue), nil
 }

--- a/internal/promql/date_fns.go
+++ b/internal/promql/date_fns.go
@@ -126,7 +126,7 @@ func lowerDateFn(c *parser.Call, s schema.Metrics, ctx lowerCtx) (chplan.Node, e
 	if newValue == nil {
 		return nil, fmt.Errorf("promql: unknown date function %s", c.Func.Name)
 	}
-	return guardedValueProjection(inner, c.Args[0], s, asFloat64(newValue), carriedSampleTimestampColumns(c.Func.Name, c.Args[0], ctx)...), nil
+	return guardedValueProjection(inner, c.Args[0], s, ctx, asFloat64(newValue), carriedSampleTimestampColumns(c.Func.Name, c.Args[0], ctx)...), nil
 }
 
 // dateFnArgCtx returns the ctx the date function's argument is lowered under.

--- a/internal/promql/duplicate_labelset_guard.go
+++ b/internal/promql/duplicate_labelset_guard.go
@@ -70,11 +70,12 @@ func guardedValueProjection(
 	inner chplan.Node,
 	arg parser.Expr,
 	s schema.Metrics,
+	ctx lowerCtx,
 	newValue chplan.Expr,
 	carry ...string,
 ) chplan.Node {
 	inner = mixedRowsFloatOnly(inner)
-	return projectValueOverInner(guardNameDropCollision(inner, arg, s, carry...), s, newValue)
+	return projectValueOverInner(guardNameDropCollision(inner, arg, s, ctx, carry...), s, newValue)
 }
 
 // guardKeysOnTimestamp reports whether a collision guard over `inner` must
@@ -190,9 +191,13 @@ func isTimestampAlias(alias string, s schema.Metrics) bool {
 // The RangeWindow branch is never reached from here: a RangeWindow has
 // already grouped the name away, so [nodeCarriesMetricName] answers false
 // for it and the guard is a no-op by construction.
-func guardNameDropCollision(inner chplan.Node, arg parser.Expr, s schema.Metrics, carry ...string) chplan.Node {
+func guardNameDropCollision(inner chplan.Node, arg parser.Expr, s schema.Metrics, ctx lowerCtx, carry ...string) chplan.Node {
 	if !collidesOnNameDrop(arg, inner, s) {
 		return inner
+	}
+
+	if ctx.tagGroups {
+		return guardNameDropCollisionByTagGroup(inner, s, carry...)
 	}
 
 	// The surviving label set is Attributes alone — the name is what is
@@ -249,6 +254,125 @@ func guardNameDropCollision(inner chplan.Node, arg parser.Expr, s schema.Metrics
 		AggFuncs:       aggs,
 		Having:         duplicateLabelsetGuardExpr(s),
 	}
+}
+
+// tsTagGroupIDAlias names the internal UInt64 column
+// [guardNameDropCollisionByTagGroup]'s Aggregate groups on — a
+// timeSeriesTagsToGroup(Attributes) id, meaningful only within the single
+// query that produces it (chopt.FeatureTSGridTagGroups's own doc explains
+// why). It never appears in an HTTP response: the wrapping Project rehydrates
+// it back to s.AttributesColumn before this node's output reaches any
+// caller, so the name only has to avoid colliding with a real schema column
+// for the lifetime of one subquery.
+const tsTagGroupIDAlias = "__ts_tag_group_id"
+
+// rehydrateTagsExpr renders `CAST(timeSeriesGroupToTags(groupID) AS
+// Map(String,String))` — the inverse of timeSeriesTagsToGroup, only valid
+// within the same query that produced groupID. timeSeriesGroupToTags itself
+// returns Array(Tuple(String,String)); the CAST recovers the schema's
+// Map(String,String) Attributes type (verified lossless and
+// order-independent against a real ClickHouse server — see
+// chopt.FeatureTSGridTagGroups's own doc).
+func rehydrateTagsExpr(groupID chplan.Expr) chplan.Expr {
+	return &chplan.FuncCall{
+		Fn: chplan.FnCast,
+		Args: []chplan.Expr{
+			&chplan.FuncCall{Fn: chplan.FnTimeSeriesGroupToTags, Args: []chplan.Expr{groupID}},
+			&chplan.LitString{V: "Map(String,String)"},
+		},
+	}
+}
+
+// guardNameDropCollisionByTagGroup is [guardNameDropCollision]'s
+// chopt.FeatureTSGridTagGroups variant (cerberus issue #2750): the SAME
+// collapsing Aggregate and the SAME [duplicateLabelsetGuardExpr] HAVING gate,
+// but grouped on a deduplicated UInt64 timeSeriesTagsToGroup(Attributes) id
+// instead of the raw Attributes Map, with Attributes rehydrated via
+// timeSeriesGroupToTags only in a wrapping Project — "rehydrating Maps only
+// in the final output projection", the issue's own proposed shape.
+//
+// This is TWO query levels, not one flat Aggregate, because a flatter shape
+// does not work — both verified directly against a real ClickHouse server:
+//
+//   - Referencing the Aggregate's own GROUP BY alias from inside an
+//     AggFunc's argument in the SAME SELECT fails with UNKNOWN_IDENTIFIER —
+//     a GROUP BY alias is not in scope for a sibling aggregate function's
+//     argument list.
+//   - Re-deriving timeSeriesTagsToGroup(Attributes) a second time inside an
+//     AggFunc's argument (to avoid the alias reference) fails with
+//     ILLEGAL_AGGREGATION — ClickHouse's analyzer matches the repeated
+//     sub-expression against the GROUP BY key and misclassifies the whole
+//     aggregate call as itself appearing in GROUP BY.
+//
+// The only shape that measured correctly: an inner Aggregate that groups on
+// the group id and carries only that id plus the existing
+// any(Value)/any(Timestamp)/carry payload (Attributes itself is dropped, read
+// only once as the GROUP BY key's own input), and an outer Project that reads
+// the group id back as a REAL column of that subquery's result set and calls
+// timeSeriesGroupToTags on it — a plain column reference, not a same-level
+// alias, which resolves cleanly.
+//
+// duplicateLabelsetGuardExpr is UNCHANGED: it reads MetricName as a raw
+// aggregate-function argument off the Input subquery, independent of which
+// expression the group key is. Swapping the throw itself onto
+// timeSeriesThrowDuplicateSeriesIf (its collector-backed message, verified
+// present only on ClickHouse >= 26.2 — see chopt.FeatureTSGridTagGroups's own
+// doc) is deliberately deferred to follow-up work tracked at
+// https://github.com/tsouza/cerberus/issues/2880: it is an independent,
+// separately-verifiable change to the throw's error-message rendering, not a
+// correctness requirement of this grouping-key swap.
+func guardNameDropCollisionByTagGroup(inner chplan.Node, s schema.Metrics, carry ...string) chplan.Node {
+	groupIDCol := &chplan.ColumnRef{Name: tsTagGroupIDAlias}
+
+	groupBy := []chplan.Expr{
+		&chplan.FuncCall{Fn: chplan.FnTimeSeriesTagsToGroup, Args: []chplan.Expr{&chplan.ColumnRef{Name: s.AttributesColumn}}},
+	}
+	aliases := []string{tsTagGroupIDAlias}
+	aggs := []chplan.AggFunc{
+		{Fn: chplan.FnAny, Args: []chplan.Expr{&chplan.ColumnRef{Name: s.ValueColumn}}, Alias: s.ValueColumn},
+	}
+
+	if guardKeysOnTimestamp(inner, s) {
+		groupBy = append(groupBy, &chplan.ColumnRef{Name: s.TimestampColumn})
+		aliases = append(aliases, s.TimestampColumn)
+	} else {
+		aggs = append(aggs, chplan.AggFunc{
+			Fn:    chplan.FnAny,
+			Args:  []chplan.Expr{&chplan.ColumnRef{Name: s.TimestampColumn}},
+			Alias: s.TimestampColumn,
+		})
+	}
+
+	for _, name := range carry {
+		aggs = append(aggs, chplan.AggFunc{
+			Fn:    chplan.FnAny,
+			Args:  []chplan.Expr{&chplan.ColumnRef{Name: name}},
+			Alias: name,
+		})
+	}
+
+	aggregate := &chplan.Aggregate{
+		Input:          inner,
+		GroupBy:        groupBy,
+		GroupByAliases: aliases,
+		AggFuncs:       aggs,
+		Having:         duplicateLabelsetGuardExpr(s),
+	}
+
+	// Either branch above leaves a column literally named s.TimestampColumn
+	// on the Aggregate's own output (a GroupBy alias or an AggFunc alias),
+	// so the rehydration Project reads it back the same way regardless of
+	// which branch ran.
+	projections := []chplan.Projection{
+		{Expr: rehydrateTagsExpr(groupIDCol), Alias: s.AttributesColumn},
+		{Expr: &chplan.ColumnRef{Name: s.ValueColumn}},
+		{Expr: &chplan.ColumnRef{Name: s.TimestampColumn}},
+	}
+	for _, name := range carry {
+		projections = append(projections, chplan.Projection{Expr: &chplan.ColumnRef{Name: name}})
+	}
+
+	return &chplan.Project{Input: aggregate, Projections: projections}
 }
 
 // collidesOnNameDrop reports whether dropping `__name__` from `inner` can

--- a/internal/promql/gremlins_kill_binary_lower_mixed_test.go
+++ b/internal/promql/gremlins_kill_binary_lower_mixed_test.go
@@ -153,7 +153,7 @@ func TestFoldSyntheticVectorBinary_ReturnBoolOnlyWrapsComparisons(t *testing.T) 
 	// isComparison(false) && returnBool(true) = false, so newValue stays
 	// the raw Binary. Mutant `&&`→`||` at binary.go:423:22 would wrap it
 	// in toFloat64 regardless.
-	plan := foldSyntheticVectorBinary(synth, vec, vecExpr, chplan.OpAdd, true, true, s)
+	plan := foldSyntheticVectorBinary(synth, vec, vecExpr, chplan.OpAdd, true, true, s, lowerCtx{})
 	proj, ok := plan.(*chplan.Project)
 	if !ok {
 		t.Fatalf("foldSyntheticVectorBinary result = %T, want *chplan.Project", plan)

--- a/internal/promql/histogram_native_mixed_or_datefn.go
+++ b/internal/promql/histogram_native_mixed_or_datefn.go
@@ -78,5 +78,5 @@ func lowerDateFnOverMixedExpHistogramSetOp(c *parser.Call, b *parser.BinaryExpr,
 	if newValue == nil {
 		return nil, fmt.Errorf("promql: unknown date function %s", c.Func.Name)
 	}
-	return guardedValueProjection(floatForAgg, c.Args[0], s, asFloat64(newValue)), nil
+	return guardedValueProjection(floatForAgg, c.Args[0], s, ctx, asFloat64(newValue)), nil
 }

--- a/internal/promql/instant_fns.go
+++ b/internal/promql/instant_fns.go
@@ -89,7 +89,7 @@ func lowerInstantFn(c *parser.Call, s schema.Metrics, chFn chplan.Fn, ctx lowerC
 	}
 
 	newValue := mathFnValueExpr(chFn, &chplan.ColumnRef{Name: s.ValueColumn})
-	return guardedValueProjection(inner, c.Args[0], s, newValue), nil
+	return guardedValueProjection(inner, c.Args[0], s, ctx, newValue), nil
 }
 
 // mathFnValueExpr wraps valueExpr with the CH function instantFnCH maps
@@ -137,7 +137,7 @@ func lowerRoundToNearest(c *parser.Call, s schema.Metrics, ctx lowerCtx) (chplan
 	}
 
 	newValue := roundToNearestValueExpr(&chplan.ColumnRef{Name: s.ValueColumn}, tn)
-	return guardedValueProjection(inner, c.Args[0], s, newValue), nil
+	return guardedValueProjection(inner, c.Args[0], s, ctx, newValue), nil
 }
 
 // lowerRoundToNearestBound lowers round()'s second argument — the
@@ -229,7 +229,7 @@ func lowerClamp(c *parser.Call, s schema.Metrics, ctx lowerCtx) (chplan.Node, er
 					&chplan.LitFloat{V: bound},
 				},
 			}
-			return guardedValueProjection(inner, c.Args[0], s, newValue), nil
+			return guardedValueProjection(inner, c.Args[0], s, ctx, newValue), nil
 		}
 		boundE, err := lowerScalarArg(c.Args[1], s, ctx)
 		if err != nil {
@@ -246,7 +246,7 @@ func lowerClamp(c *parser.Call, s schema.Metrics, ctx lowerCtx) (chplan.Node, er
 				boundE,
 			},
 		})
-		return guardedValueProjection(inner, c.Args[0], s, newValue), nil
+		return guardedValueProjection(inner, c.Args[0], s, ctx, newValue), nil
 
 	case "clamp":
 		if len(c.Args) != 3 {
@@ -285,7 +285,7 @@ func lowerClamp(c *parser.Call, s schema.Metrics, ctx lowerCtx) (chplan.Node, er
 					},
 				},
 			}
-			return guardedValueProjection(inner, c.Args[0], s, newValue), nil
+			return guardedValueProjection(inner, c.Args[0], s, ctx, newValue), nil
 		}
 
 		// At least one computed bound: bind both sides through
@@ -330,7 +330,7 @@ func lowerClamp(c *parser.Call, s schema.Metrics, ctx lowerCtx) (chplan.Node, er
 				},
 			},
 		)
-		return guardedValueProjection(filtered, c.Args[0], s, newValue), nil
+		return guardedValueProjection(filtered, c.Args[0], s, ctx, newValue), nil
 	}
 	return nil, fmt.Errorf("promql: unknown clamp function %s", c.Func.Name)
 }

--- a/internal/promql/lower.go
+++ b/internal/promql/lower.go
@@ -128,6 +128,18 @@ type LowerOpts struct {
 	// CERBERUS_PROMQL_*_MAX_COST_UNITS-resolved value from cmd/cerberus)
 	// keeps the shipped defaults.
 	ResourceBounds ResourceBounds
+
+	// TagGroups threads chopt.FeatureTSGridTagGroups's resolved verdict
+	// (cerberus issue #2750) into the instant-mode duplicate-labelset guard
+	// (internal/promql/duplicate_labelset_guard.go's guardNameDropCollision):
+	// when true, its collapsing Aggregate groups on a
+	// timeSeriesTagsToGroup(Attributes) UInt64 id instead of the raw
+	// Attributes Map, rehydrating via timeSeriesGroupToTags in a wrapping
+	// Project. The zero value (false) keeps the pre-#2750 Map-grouped SQL
+	// byte-identical, mirroring every other feature-gated field on this
+	// struct — every caller but the deployed prom handler (which threads
+	// chopt.EnabledSet's verdict from cmd/cerberus) leaves it unset.
+	TagGroups bool
 }
 
 // LowerAtRangeOpts is the options-carrying variant of [LowerAtRange].
@@ -145,6 +157,7 @@ func LowerAtRangeOpts(ctx context.Context, expr parser.Expr, s schema.Metrics, s
 		lowerers:       opts.Lowerers.withDefaults(),
 		guards:         opts.Guards,
 		resourceBounds: opts.ResourceBounds.withDefaults(),
+		tagGroups:      opts.TagGroups,
 	})
 	if err != nil {
 		span.RecordError(err)

--- a/internal/promql/modifiers.go
+++ b/internal/promql/modifiers.go
@@ -213,6 +213,21 @@ type lowerCtx struct {
 	// from an existing one via a plain struct copy (the `c := ctx; c.foo =
 	// ...` pattern this file's own with* helpers use) inherits it for free.
 	resourceBounds ResourceBounds
+
+	// tagGroups is the boot-wired on/off switch for chopt.FeatureTSGridTagGroups
+	// (cerberus issue #2750), resolved ONCE from [LowerOpts.TagGroups] at the
+	// same lowering-entry seam resourceBounds is — every ctx this package's
+	// entry points build carries a definite value, never an accidental
+	// version/capability check inside the guard itself. Read only by
+	// [guardNameDropCollision] (internal/promql/duplicate_labelset_guard.go):
+	// when true, the guard's collapsing Aggregate groups on
+	// timeSeriesTagsToGroup(Attributes) instead of the raw Attributes Map,
+	// rehydrating via timeSeriesGroupToTags in a wrapping Project. The zero
+	// value (false) reproduces the pre-#2750 Map-grouped shape byte-for-byte,
+	// so every caller that does not opt in (every path but the deployed prom
+	// handler, which threads chopt.EnabledSet's verdict from cmd/cerberus)
+	// keeps the established SQL.
+	tagGroups bool
 }
 
 // withSampleTimestamp returns a copy of c that asks the range-mode selector

--- a/internal/promql/unary.go
+++ b/internal/promql/unary.go
@@ -80,7 +80,7 @@ func lowerUnary(u *parser.UnaryExpr, s schema.Metrics, ctx lowerCtx) (chplan.Nod
 			Left:  &chplan.LitFloat{V: 0},
 			Right: &chplan.ColumnRef{Name: s.ValueColumn},
 		}
-		return guardedValueProjection(inner, u.Expr, s, newValue), nil
+		return guardedValueProjection(inner, u.Expr, s, ctx, newValue), nil
 	}
 	return nil, fmt.Errorf("promql: unsupported unary op %v", u.Op)
 }

--- a/test/regression/justfile_pull_retry_test.go
+++ b/test/regression/justfile_pull_retry_test.go
@@ -275,7 +275,7 @@ func TestIntegrationImagePinsMatchTheJustfile(t *testing.T) {
 	justfile := string(buf)
 
 	pinned := map[string]bool{}
-	for _, v := range []string{"CH_TEST_IMAGE", "CH_TEST_IMAGE_PRIOR", "CH_STRICT_SCAN_IMAGE", "CH_QUANTILE_PROM_HISTOGRAM_IMAGE"} {
+	for _, v := range []string{"CH_TEST_IMAGE", "CH_TEST_IMAGE_PRIOR", "CH_STRICT_SCAN_IMAGE", "CH_QUANTILE_PROM_HISTOGRAM_IMAGE", "CH_TAG_GROUPS_IMAGE"} {
 		for _, img := range justVariableList(t, justfile, v) {
 			pinned[img] = true
 		}

--- a/test/spec/chplan_print.go
+++ b/test/spec/chplan_print.go
@@ -916,6 +916,8 @@ var fnGoNames = map[chplan.Fn]string{
 	chplan.FnMultiIf:                         "FnMultiIf",
 	chplan.FnNot:                             "FnNot",
 	chplan.FnThrowIf:                         "FnThrowIf",
+	chplan.FnTimeSeriesTagsToGroup:           "FnTimeSeriesTagsToGroup",
+	chplan.FnTimeSeriesGroupToTags:           "FnTimeSeriesGroupToTags",
 	chplan.FnAssumeNotNull:                   "FnAssumeNotNull",
 	chplan.FnCast:                            "FnCast",
 	chplan.FnToDateTime:                      "FnToDateTime",


### PR DESCRIPTION
## Summary

Closes #2750's grouping-keys-only slice (per the issue's own "incremental adoption: grouping keys first, label ops later" staging).

- Registers `chopt.FeatureTSGridTagGroups` (`ts_tag_groups`).
- Converts **one** grouping site — `internal/promql/duplicate_labelset_guard.go`'s `guardNameDropCollision` (the instant-mode, name-dropping half of the duplicate-labelset guard) — from `GROUP BY <raw Attributes Map>` to `GROUP BY timeSeriesTagsToGroup(Attributes)`, rehydrating `Attributes` via `timeSeriesGroupToTags` only in a wrapping output `Project`.
- `guardLabelRewriteCollision` (the `label_replace`/`label_join` half), `group_left` joins, and every `by()`/`without()`/`label_replace`/`label_join` label-TRANSFORMATION operator are unchanged, per the issue's own explicit staging.

## Site choice

`guardNameDropCollision` was picked because it is:

1. The single most self-contained grouping site that groups on the raw Attributes Map — one file, no entanglement with the label-rewrite/`group_left` towers this PR leaves alone.
2. Reachable **only** from the instant `/api/v1/query` path (checked against `internal/api/prom/lang.go`) — never from `query_range`, which is the only path the sharded-pushdown solver ("route B") can route. This matters concretely: I confirmed by reading the ClickHouse C++ source (`src/Functions/TimeSeries/*.cpp`) that `timeSeriesTagsToGroup`/`timeSeriesGroupToTags` are **stateful within one query execution only** (`isDeterministicInScopeOfQuery() == true`, backed by a per-query `ContextTimeSeriesTagsCollector`) — a group id has no meaning across two separate ClickHouse queries. Route B runs K per-shard queries and concatenates their cursors in Go **without** re-aggregating on any key the shards produced, so a route-B-sharded grouping site would need its own per-shard rehydration story before a group id could safely cross a shard boundary. Picking a structurally route-B-immune site avoids that hazard entirely rather than risking a subtle cross-shard correctness bug — see the registry entry's own "ROUTE-B SHARDING" note.
3. Literally the site the issue names as `timeSeriesThrowDuplicateSeriesIf`'s natural home (it already builds the `HAVING throwIf(...)` shape by hand).

## Empirical verification (all against real ClickHouse, not chDB)

**Version floor** — real ClickHouse 26.1-alpine and 26.2-alpine containers, fresh, default config:
- `timeSeriesTagsToGroup` / `timeSeriesGroupToTags` work on 26.1 (issue's claimed core floor).
- `timeSeriesThrowDuplicateSeriesIf` is `UNKNOWN_FUNCTION` on 26.1, present on 26.2 — confirms the issue's "floor 26.1 core; 26.2 specifically for `timeSeriesThrowDuplicateSeriesIf`" claim exactly. `chopt.FeatureTSGridTagGroups.MinVersion` is pinned to the higher **26.2**, since the id/id doc below says the family bundles both, even though this PR doesn't wire the throw function in yet (kept as a separate, independently-verifiable follow-up — see below).

**No experimental gate** — the issue flagged the docs show none for this family (unlike the `timeSeries*ToGrid` matrix aggregates, which need `allow_experimental_time_series_aggregate_functions`) and asked for empirical confirmation rather than trusting the docs' silence: confirmed — every call above ran with no settings beyond `CLICKHOUSE_USER`/`PASSWORD`, and `system.functions` lists the whole family as ordinary (non-experimental) on both 26.1 and 26.2.

**Order-independence** (the reason the mechanism can replace mapSort comparison for this site without weakening it): `timeSeriesTagsToGroup(map('a','1','b','2'))` and `timeSeriesTagsToGroup(map('b','2','a','1'))` return the identical group id — keyed on the tag *set*, not Map iteration order.

**A real SQL-shape gotcha found and worked around**: ClickHouse rejects referencing a `GROUP BY` alias from inside a sibling aggregate-function argument in the *same* `SELECT` (`UNKNOWN_IDENTIFIER`), and separately rejects re-deriving the grouping expression a second time inside an aggregate argument (`ILLEGAL_AGGREGATION` — the analyzer matches the repeated sub-expression against the `GROUP BY` key and misclassifies the call). The only shape that measured correctly — and the one this PR ships — is two query levels: an inner `Aggregate` that groups on the id and carries only that id plus the existing `any(Value)`/`any(Timestamp)`/carry payload, and an outer `Project` that reads the id back as a real column and calls `timeSeriesGroupToTags` on it. This is exactly "rehydrating Maps only in the final output projection," not a stylistic choice — see `internal/promql/duplicate_labelset_guard.go`'s `guardNameDropCollisionByTagGroup` doc.

**Differential parity (correctness-critical)**: `internal/api/prom/handler_tag_groups_realch_integration_test.go`'s `TestTagGroups_MatchesMapGrouping_RealClickHouse` runs the SAME `/api/v1/query` requests through two real `*prom.Handler` instances backed by the SAME real ClickHouse 26.2 (testcontainers) — one with `TagGroups=false` (existing Map path), one with `TagGroups=true` (new UInt64-id path) — and asserts byte-identical decoded JSON across the collision-reject, distinct-labelsets pass-through, pinned-name no-guard, unary-minus, and scalar-times-vector shapes. All pass. New Justfile recipe `tag-groups-differential-integration`, wired into `strict-scan.yml`, its own `CH_TAG_GROUPS_IMAGE` pin (26.2-alpine, above every other integration lane's pin), and the GHCR mirror inventory.

## Performance — a real, honest finding

A real ClickHouse 26.2 A/B (2M rows, the exact two SQL shapes this feature emits, `FORMAT Null` to isolate server-side cost) at both **low** (100 distinct label sets) and **high** (200,000 distinct label sets) group cardinality:

| | wall clock | peak memory |
|---|---|---|
| low cardinality, Map-grouped | 265–305 ms | 19.6 MB |
| low cardinality, UInt64-grouped | 666–1083 ms (**2–3× slower**) | 29.7–34.9 MB (**~1.8× more**) |
| high cardinality, Map-grouped | 881–957 ms | 462–520 MB |
| high cardinality, UInt64-grouped | 1358–1506 ms (**~50% slower**) | 411–413 MB (**~10–20% less**) |

The per-query `ContextTimeSeriesTagsCollector` backing these functions carries real bookkeeping cost that, at this grouping site's row/cardinality shape, outweighs the O(1)-integer-comparison win the issue's "single biggest CPU/memory lever" framing predicted. `chopt.FeatureTSGridTagGroups` ships `AutoSelect: false` for this **measured** reason, not just "no fielded validation yet" — see the registry entry's own doc for the full numbers and reasoning. I chose not to hide or soften this: the mechanism (grouping-key correctness, round-trip fidelity, version floor, no-experimental-gate) is proven; the performance case for *this* site is not.

## What's deliberately out of scope

- `by()`/`without()`/`label_replace`/`label_join` label-set TRANSFORMATION operators and `group_left` label-copying joins — the issue's own "label ops later," needing `timeSeriesRemoveAllTagsExcept`/`timeSeriesReplaceTag`/`timeSeriesJoinTags`/`timeSeriesCopyTags`.
- `guardLabelRewriteCollision` (the rewrite half of the same guard file) — left on the Map-grouped path.
- Wiring `timeSeriesThrowDuplicateSeriesIf` into the guard's `HAVING` (it would only change the error-message rendering, not correctness — a separately-verifiable change).
- Retiring `FeatureColumnarResultDecode` or `canonical_series_keys.go`'s mapSort pass — additive alongside them, not a replacement.
- Finding a grouping site where the mechanism is actually a measured win.

All tracked as follow-up: #2880. **#2750 stays open** — this PR resolves only its grouping-keys-only slice, and the performance promise the parent issue names is not yet delivered anywhere in the codebase.

## Test plan

- [x] `go build ./...`
- [x] `go test ./internal/promql/... ./internal/chopt/... ./internal/chsql/... ./internal/chplan/... ./internal/api/prom/... ./cmd/cerberus/...`
- [x] `go test -race ./test/regression/...` (tagged-test enrollment, image-pin, and GHCR-mirror-inventory gates all pass)
- [x] `go test -tags=integration -run TestTagGroups_MatchesMapGrouping_RealClickHouse ./internal/api/prom/...` against real ClickHouse 26.2 (testcontainers) — differential parity, all subtests pass
- [x] `just gen-opt-docs` (docs/clickhouse-optimizations.md regenerated, no drift)
- [x] `just fmt`, `node .github/scripts/forbid-sql-raw.mjs`, `just lint-md`
- [ ] CI: full `lint` / `strict-scan` / other required checks (golangci-lint is not locally reliable per this repo's own CLAUDE.md invariant 5 — left to CI)
