### PR TITLE
feat(promql): extend exp-histogram sumMap merge eligibility to avg()

### DIFF
--- a/internal/promql/exp_histogram_merge_summap.go
+++ b/internal/promql/exp_histogram_merge_summap.go
@@ -18,11 +18,14 @@ import (
 // # Scope (deliberately narrow — see "Why single-group only" below)
 //
 // Only the INSTANT, SINGLE-GROUP shape — `sum(<native-histogram
-// selector>)` with no `by(...)`/`without(...)` clause — is eligible.
-// avg(), any `by`/`without` grouping, and range/query_range mode all stay
-// on the existing fold unconditionally; see NativeExpHistogramMergeLowerer
-// and cerberus issue #2834 for why those need a genuinely different
-// (per-group JOIN) mechanism this file does not build.
+// selector>)` or its `avg()` twin, with no `by(...)`/`without(...)` clause
+// — is eligible (cerberus issue #2866 widened the original SUM-only v1,
+// #2757, to include AVG: identical merge, plus the same division
+// histogram_native_avg.go's fold path already applies). Any `by`/`without`
+// grouping and range/query_range mode still stay on the existing fold
+// unconditionally; see NativeExpHistogramMergeLowerer and cerberus issue
+// #2834 for why those need a genuinely different (per-group JOIN)
+// mechanism this file does not build.
 //
 // # The two-pass restructure (issue #2757's own "known hard part",
 // # verified here)
@@ -293,9 +296,9 @@ func expHistogramGroupMergeProjectionsSumMap(s schema.Metrics) []chplan.Projecti
 }
 
 // expHistogramGroupMergeSumMap builds the full two-pass merge node for the
-// eligible shape (instant, single-group, SUM fold — see this file's
-// header): pass 1's ScalarSubquery, pass 2's Aggregate (wrapped in this
-// design's OWN rows-independent budget guard,
+// eligible shape (instant, single-group, SUM or AVG fold — see this
+// file's header): pass 1's ScalarSubquery, pass 2's Aggregate (wrapped in
+// this design's OWN rows-independent budget guard,
 // [wrapExpHistogramMergeSumMapBudgetGuard] — see this file's header and
 // exp_histogram_merge_summap_bound.go for the calibration behind it), and
 // the reshape Project. No [expHistogramMergeSortStage] call: that stage
@@ -308,17 +311,32 @@ func expHistogramGroupMergeProjectionsSumMap(s schema.Metrics) []chplan.Projecti
 // — this file touches only the bucket-ladder scale/offset/counts fields,
 // mirroring how PR #2826's classic-bucket sumMap change left every
 // non-bucket field alone.
-func expHistogramGroupMergeSumMap(perSeries chplan.Node, s schema.Metrics, maxCostUnits int64) chplan.Node {
+//
+// avg() reuses this SAME merge — its own division is a projection rewrite
+// on top, mirroring how [expHistogramGroupMergeFanout] applies
+// [expHistogramAvgScaleProjections] to the fold path's output (cerberus
+// issue #2866): when agg is avg, this function also collects the group's
+// series count ([expHistogramGroupSeriesCountAgg], the divisor) and
+// divides the five count-bearing fields of projs by it before capping the
+// Project. Both steps are conditional on expHistogramGroupIsAvg(agg)
+// exactly like the fold path's own, so sum() emits byte-identical SQL to
+// before this file learned about avg.
+func expHistogramGroupMergeSumMap(perSeries chplan.Node, agg *parser.AggregateExpr, s schema.Metrics, maxCostUnits int64) chplan.Node {
 	mergedScale := expHistogramMergeScaleScalarSubquery(perSeries, s)
+	aggFuncs := append(
+		[]chplan.AggFunc{
+			{Fn: chplan.FnGroupArray, Args: []chplan.Expr{&chplan.ColumnRef{Name: s.CountColumn}}, Alias: hqMergeCountsArrayAlias},
+			{Fn: chplan.FnGroupArray, Args: []chplan.Expr{&chplan.ColumnRef{Name: s.SumColumn}}, Alias: hqMergeSumsArrayAlias},
+		},
+		expHistogramGroupMergeAggsSumMap(mergedScale, s)...,
+	)
+	isAvg := expHistogramGroupIsAvg(agg)
+	if isAvg {
+		aggFuncs = append(aggFuncs, expHistogramGroupSeriesCountAgg())
+	}
 	merged := &chplan.Aggregate{
-		Input: perSeries,
-		AggFuncs: append(
-			[]chplan.AggFunc{
-				{Fn: chplan.FnGroupArray, Args: []chplan.Expr{&chplan.ColumnRef{Name: s.CountColumn}}, Alias: hqMergeCountsArrayAlias},
-				{Fn: chplan.FnGroupArray, Args: []chplan.Expr{&chplan.ColumnRef{Name: s.SumColumn}}, Alias: hqMergeSumsArrayAlias},
-			},
-			expHistogramGroupMergeAggsSumMap(mergedScale, s)...,
-		),
+		Input:              perSeries,
+		AggFuncs:           aggFuncs,
 		DropEmptyOnNoGroup: true,
 	}
 	guarded := wrapExpHistogramMergeSumMapBudgetGuard(merged, maxCostUnits)
@@ -330,6 +348,9 @@ func expHistogramGroupMergeSumMap(perSeries chplan.Node, s schema.Metrics, maxCo
 		},
 		expHistogramGroupMergeProjectionsSumMap(s)...,
 	)
+	if isAvg {
+		projs = expHistogramAvgScaleProjections(projs, s)
+	}
 	return &chplan.Project{Input: guarded, Projections: projs}
 }
 
@@ -339,7 +360,7 @@ func expHistogramGroupMergeSumMap(perSeries chplan.Node, s schema.Metrics, maxCo
 // lowerExpHistogramSumOrAvgRange) collects and merges every contributing
 // row's distribution: the existing groupArray + arrayReduce/arraySlice
 // picker fold (every shape), or this file's two-pass sumMap reshape
-// (instant + single-group + SUM fold only,
+// (instant + single-group, SUM or AVG fold only,
 // chopt.FeatureExpHistogramMergeSumMap). It never returns nil.
 type ExpHistogramMergeLowerer interface {
 	// LowerExpHistogramMerge returns the merged chplan.Node. anchor is nil
@@ -362,10 +383,10 @@ func (FanoutExpHistogramMergeLowerer) LowerExpHistogramMerge(
 
 // NativeExpHistogramMergeLowerer is the boot-wired ExpHistogramMergeLowerer
 // that routes the eligible shape (anchor == nil, no by()/without()
-// grouping, SUM fold — never avg) onto expHistogramGroupMergeSumMap.
-// cmd/cerberus wires it ONLY when chopt resolved
-// exp_histogram_merge_summap at boot. Every other shape delegates to the
-// embedded Fallback, unconditionally.
+// grouping — SUM or AVG fold, cerberus issue #2866) onto
+// expHistogramGroupMergeSumMap. cmd/cerberus wires it ONLY when chopt
+// resolved exp_histogram_merge_summap at boot. Every other shape delegates
+// to the embedded Fallback, unconditionally.
 type NativeExpHistogramMergeLowerer struct {
 	// Fallback is the concrete lowerer for every ineligible shape. Boot
 	// wires it to FanoutExpHistogramMergeLowerer{}.
@@ -377,10 +398,10 @@ type NativeExpHistogramMergeLowerer struct {
 func (n NativeExpHistogramMergeLowerer) LowerExpHistogramMerge(
 	perSeries chplan.Node, anchor *chplan.ColumnRef, agg *parser.AggregateExpr, s schema.Metrics, maxCostUnits int64,
 ) chplan.Node {
-	if anchor == nil && !expHistogramGroupIsAvg(agg) {
+	if anchor == nil {
 		groupBy, _, _ := histogramAggGroupBy(agg, &chplan.ColumnRef{Name: s.AttributesColumn}, s)
 		if len(groupBy) == 0 {
-			return expHistogramGroupMergeSumMap(perSeries, s, maxCostUnits)
+			return expHistogramGroupMergeSumMap(perSeries, agg, s, maxCostUnits)
 		}
 	}
 	return n.Fallback.LowerExpHistogramMerge(perSeries, anchor, agg, s, maxCostUnits)

--- a/internal/promql/exp_histogram_merge_summap_bound.go
+++ b/internal/promql/exp_histogram_merge_summap_bound.go
@@ -122,6 +122,25 @@ import (
 // sumMapMergeCostMultiplier is chosen so this SAME width ceiling falls out
 // of the SHARED maxCostUnits default (60,000,000, unchanged) without
 // introducing a second operator knob — see that constant's own doc.
+//
+// # avg() confirmation (cerberus issue #2866)
+//
+// This guard's cost formula reads only the groupArray columns
+// [expHistogramGroupMergeAggsSumMap] collects — unaffected by whether the
+// caller is sum() or avg(), since avg()'s own extra work
+// (expHistogramGroupSeriesCountAgg's plain count() aggregate, plus
+// expHistogramAvgScaleProjections' division of the ALREADY-reconstructed
+// dense arrays) touches neither. A real ClickHouse 26.6 measurement (same
+// methodology as this file's own table above: a throwaway harness, deleted
+// before #2866 merged, `sum()` and `avg()` run back-to-back over the SAME
+// seed through [NativeExpHistogramMergeLowerer], real peak memory read from
+// `system.query_log`) at four shapes spanning both cost axes — {1, 160}
+// (parity baseline), {3741, 160} (rows-dominated, issue #2490's own repro),
+// {1, 3000} (width-dominated, a single wide series), {4096, 1280} (both
+// axes near their admitted limits) — measured avg()'s real peak memory at
+// 1.00x-1.02x sum()'s at every point (max divergence 2.37%, at {3741,
+// 160}), confirming this issue's own expectation empirically rather than by
+// assumption: no guard recalibration for avg() is needed.
 const (
 	// sumMapMergeCostMultiplier converts [maxHistogramMergeCostUnits]'s
 	// existing 60,000,000-unit default into this design's OWN, higher,

--- a/internal/promql/exp_histogram_merge_summap_chdb_test.go
+++ b/internal/promql/exp_histogram_merge_summap_chdb_test.go
@@ -32,6 +32,16 @@
 //     real, measured memory regression only shows up for a single series
 //     with an unusually WIDE individual layout, not exercised by this
 //     fixture).
+//
+// The five `TestExpHistogramMergeSumMapDifferential_Avg_*` cases below
+// mirror the five above, seed-for-seed, over `avg()` instead of `sum()` —
+// cerberus issue #2866's own differential proof that
+// [expHistogramGroupMergeSumMap]'s series-count collection and division
+// (added for avg() by that issue) reconciles bucket ladders identically to
+// the fold path's own [expHistogramAvgScaleProjections], not just that the
+// SUM-only shape still works. Each Avg case reuses its Sum sibling's exact
+// seed builder — same rows, same fixture — so a divergence in either
+// aggregation's arithmetic shows up against a shared baseline.
 package promql_test
 
 import (
@@ -83,9 +93,25 @@ type expHistSumMapDiffRow struct {
 // strategy and returns the single resulting merged-histogram row.
 func runExpHistSumMapDiffQuery(t *testing.T, fixture *chdbFixture, native bool) expHistSumMapDiffRow {
 	t.Helper()
+	return runExpHistSumMapDiffQueryAgg(t, fixture, native, "sum")
+}
+
+// runExpHistSumMapDiffQueryAvg is [runExpHistSumMapDiffQuery]'s `avg()`
+// twin — cerberus issue #2866's own eligibility widening.
+func runExpHistSumMapDiffQueryAvg(t *testing.T, fixture *chdbFixture, native bool) expHistSumMapDiffRow {
+	t.Helper()
+	return runExpHistSumMapDiffQueryAgg(t, fixture, native, "avg")
+}
+
+// runExpHistSumMapDiffQueryAgg lowers `<aggFn>(<metric>)` under the given
+// strategy and returns the single resulting merged-histogram row. aggFn is
+// "sum" or "avg" — the two shapes [NativeExpHistogramMergeLowerer] routes
+// onto [expHistogramGroupMergeSumMap].
+func runExpHistSumMapDiffQueryAgg(t *testing.T, fixture *chdbFixture, native bool, aggFn string) expHistSumMapDiffRow {
+	t.Helper()
 	s := schema.DefaultOTelMetrics()
 	p := promparser.NewParser(promparser.Options{})
-	query := fmt.Sprintf("sum(%s)", expHistSumMapDiffMetric)
+	query := fmt.Sprintf("%s(%s)", aggFn, expHistSumMapDiffMetric)
 	expr, err := p.ParseExpr(query)
 	if err != nil {
 		t.Fatalf("ParseExpr(%q): %v", query, err)
@@ -156,12 +182,13 @@ const expHistSumMapDiffSeedDDL = "" +
 	"`NegativeOffset` Int32, `NegativeBucketCounts` Array(UInt64)" +
 	") ENGINE = MergeTree ORDER BY (`MetricName`, `Attributes`, `TimeUnix`);\n"
 
-// TestExpHistogramMergeSumMapDifferential_Homogeneous seeds three series
-// sharing one Scale(0)/Offset(0) layout, each a plain 1-bucket-wide
-// positive-only histogram — the realistic OTel-SDK-default shape this
-// issue's own measured 13-43x win (at hundreds to thousands of rows) is
-// calibrated on.
-func TestExpHistogramMergeSumMapDifferential_Homogeneous(t *testing.T) {
+// newExpHistSumMapDiffFixtureHomogeneous seeds three series sharing one
+// Scale(0)/Offset(0) layout, each a plain 1-bucket-wide positive-only
+// histogram — the realistic OTel-SDK-default shape this issue's own
+// measured 13-43x win (at hundreds to thousands of rows) is calibrated on.
+// Shared by the Sum and Avg differential tests below.
+func newExpHistSumMapDiffFixtureHomogeneous(t *testing.T) *chdbFixture {
+	t.Helper()
 	var b strings.Builder
 	b.WriteString(expHistSumMapDiffSeedDDL)
 	b.WriteString("INSERT INTO otel_metrics_exponential_histogram (MetricName, Attributes, TimeUnix, Count, Sum, Scale, ZeroCount, PositiveOffset, PositiveBucketCounts, NegativeOffset, NegativeBucketCounts) VALUES\n")
@@ -171,19 +198,37 @@ func TestExpHistogramMergeSumMapDifferential_Homogeneous(t *testing.T) {
 		fmt.Sprintf("('%s', map('series', 's3'), toDateTime64('2026-01-01 00:00:00', 9), 3, 6.0, 0, 0, 0, [1,1,1], 0, [])", expHistSumMapDiffMetric),
 	}
 	b.WriteString("    " + strings.Join(rows, ",\n    ") + ";\n")
-	fixture := newChDBFixture(t, b.String())
+	return newChDBFixture(t, b.String())
+}
 
+// TestExpHistogramMergeSumMapDifferential_Homogeneous is the `sum()` case
+// over [newExpHistSumMapDiffFixtureHomogeneous].
+func TestExpHistogramMergeSumMapDifferential_Homogeneous(t *testing.T) {
+	fixture := newExpHistSumMapDiffFixtureHomogeneous(t)
 	fanout := runExpHistSumMapDiffQuery(t, fixture, false)
 	native := runExpHistSumMapDiffQuery(t, fixture, true)
 	assertExpHistSumMapDiffEqual(t, fanout, native)
 }
 
-// TestExpHistogramMergeSumMapDifferential_ScaleNegotiation seeds three
-// series with genuinely different Scale (0, 2, 1) and different
-// PositiveOffset — mirrors histogram_merge_scatter_chdb_test.go's own
-// scatter fixture, exercising both the no-collapse (ratio=1, s1) and
-// collapse (ratio>1, s2 and s3) downscale paths in the SAME merge.
-func TestExpHistogramMergeSumMapDifferential_ScaleNegotiation(t *testing.T) {
+// TestExpHistogramMergeSumMapDifferential_Avg_Homogeneous is
+// [TestExpHistogramMergeSumMapDifferential_Homogeneous]'s `avg()` twin
+// (cerberus issue #2866): the SAME seed, both strategies now dividing by
+// the group's 3-series member count.
+func TestExpHistogramMergeSumMapDifferential_Avg_Homogeneous(t *testing.T) {
+	fixture := newExpHistSumMapDiffFixtureHomogeneous(t)
+	fanout := runExpHistSumMapDiffQueryAvg(t, fixture, false)
+	native := runExpHistSumMapDiffQueryAvg(t, fixture, true)
+	assertExpHistSumMapDiffEqual(t, fanout, native)
+}
+
+// newExpHistSumMapDiffFixtureScaleNegotiation seeds three series with
+// genuinely different Scale (0, 2, 1) and different PositiveOffset —
+// mirrors histogram_merge_scatter_chdb_test.go's own scatter fixture,
+// exercising both the no-collapse (ratio=1, s1) and collapse (ratio>1, s2
+// and s3) downscale paths in the SAME merge. Shared by the Sum and Avg
+// differential tests below.
+func newExpHistSumMapDiffFixtureScaleNegotiation(t *testing.T) *chdbFixture {
+	t.Helper()
 	var b strings.Builder
 	b.WriteString(expHistSumMapDiffSeedDDL)
 	b.WriteString("INSERT INTO otel_metrics_exponential_histogram (MetricName, Attributes, TimeUnix, Count, Sum, Scale, ZeroCount, PositiveOffset, PositiveBucketCounts, NegativeOffset, NegativeBucketCounts) VALUES\n")
@@ -193,35 +238,70 @@ func TestExpHistogramMergeSumMapDifferential_ScaleNegotiation(t *testing.T) {
 		fmt.Sprintf("('%s', map('series', 's3'), toDateTime64('2026-01-01 00:00:00', 9), 630, 1.0, 1, 0, 9, [100,200,300], 0, [])", expHistSumMapDiffMetric),
 	}
 	b.WriteString("    " + strings.Join(rows, ",\n    ") + ";\n")
-	fixture := newChDBFixture(t, b.String())
+	return newChDBFixture(t, b.String())
+}
 
+// TestExpHistogramMergeSumMapDifferential_ScaleNegotiation is the `sum()`
+// case over [newExpHistSumMapDiffFixtureScaleNegotiation].
+func TestExpHistogramMergeSumMapDifferential_ScaleNegotiation(t *testing.T) {
+	fixture := newExpHistSumMapDiffFixtureScaleNegotiation(t)
 	fanout := runExpHistSumMapDiffQuery(t, fixture, false)
 	native := runExpHistSumMapDiffQuery(t, fixture, true)
 	assertExpHistSumMapDiffEqual(t, fanout, native)
 }
 
-// TestExpHistogramMergeSumMapDifferential_ZeroBucket seeds a SINGLE series
-// whose middle bucket count is exactly zero — sumMap([idx0,idx1,idx2],
-// [5,0,3]) drops the zero-valued key entirely (the same quirk
+// TestExpHistogramMergeSumMapDifferential_Avg_ScaleNegotiation is
+// [TestExpHistogramMergeSumMapDifferential_ScaleNegotiation]'s `avg()`
+// twin (cerberus issue #2866): the downscale-collapse case must still
+// merge identically to the fold BEFORE the division, then divide
+// identically.
+func TestExpHistogramMergeSumMapDifferential_Avg_ScaleNegotiation(t *testing.T) {
+	fixture := newExpHistSumMapDiffFixtureScaleNegotiation(t)
+	fanout := runExpHistSumMapDiffQueryAvg(t, fixture, false)
+	native := runExpHistSumMapDiffQueryAvg(t, fixture, true)
+	assertExpHistSumMapDiffEqual(t, fanout, native)
+}
+
+// newExpHistSumMapDiffFixtureZeroBucket seeds a SINGLE series whose middle
+// bucket count is exactly zero — sumMap([idx0,idx1,idx2], [5,0,3]) drops
+// the zero-valued key entirely (the same quirk
 // classic_bucket_merge_summap.go's header documents for the classic
-// path). Both strategies must still answer identically:
-// expHistogramSumMapLadderExpr's indexOf-based reconstruction restores
-// the dropped zero explicitly.
-func TestExpHistogramMergeSumMapDifferential_ZeroBucket(t *testing.T) {
-	fixture := newChDBFixture(t, expHistSumMapDiffSeedDDL+
+// path). Shared by the Sum and Avg differential tests below.
+func newExpHistSumMapDiffFixtureZeroBucket(t *testing.T) *chdbFixture {
+	t.Helper()
+	return newChDBFixture(t, expHistSumMapDiffSeedDDL+
 		"INSERT INTO otel_metrics_exponential_histogram (MetricName, Attributes, TimeUnix, Count, Sum, Scale, ZeroCount, PositiveOffset, PositiveBucketCounts, NegativeOffset, NegativeBucketCounts) VALUES\n"+
 		fmt.Sprintf("    ('%s', map('series', 's1'), toDateTime64('2026-01-01 00:00:00', 9), 8, 4.0, 0, 0, 0, [5,0,3], 0, []);\n", expHistSumMapDiffMetric))
+}
 
+// TestExpHistogramMergeSumMapDifferential_ZeroBucket is the `sum()` case
+// over [newExpHistSumMapDiffFixtureZeroBucket]. Both strategies must
+// answer identically: expHistogramSumMapLadderExpr's indexOf-based
+// reconstruction restores the dropped zero explicitly.
+func TestExpHistogramMergeSumMapDifferential_ZeroBucket(t *testing.T) {
+	fixture := newExpHistSumMapDiffFixtureZeroBucket(t)
 	fanout := runExpHistSumMapDiffQuery(t, fixture, false)
 	native := runExpHistSumMapDiffQuery(t, fixture, true)
 	assertExpHistSumMapDiffEqual(t, fanout, native)
 }
 
-// TestExpHistogramMergeSumMapDifferential_SignBuckets seeds two series
-// each carrying BOTH real positive and real negative bucket data —
-// exercising expHistogramGroupMergeAggsSumMap's independent pos/neg
-// sumMap pair together.
-func TestExpHistogramMergeSumMapDifferential_SignBuckets(t *testing.T) {
+// TestExpHistogramMergeSumMapDifferential_Avg_ZeroBucket is
+// [TestExpHistogramMergeSumMapDifferential_ZeroBucket]'s `avg()` twin
+// (cerberus issue #2866): the dropped-zero-key reconstruction must survive
+// the division on top unchanged.
+func TestExpHistogramMergeSumMapDifferential_Avg_ZeroBucket(t *testing.T) {
+	fixture := newExpHistSumMapDiffFixtureZeroBucket(t)
+	fanout := runExpHistSumMapDiffQueryAvg(t, fixture, false)
+	native := runExpHistSumMapDiffQueryAvg(t, fixture, true)
+	assertExpHistSumMapDiffEqual(t, fanout, native)
+}
+
+// newExpHistSumMapDiffFixtureSignBuckets seeds two series each carrying
+// BOTH real positive and real negative bucket data — exercising
+// expHistogramGroupMergeAggsSumMap's independent pos/neg sumMap pair
+// together. Shared by the Sum and Avg differential tests below.
+func newExpHistSumMapDiffFixtureSignBuckets(t *testing.T) *chdbFixture {
+	t.Helper()
 	var b strings.Builder
 	b.WriteString(expHistSumMapDiffSeedDDL)
 	b.WriteString("INSERT INTO otel_metrics_exponential_histogram (MetricName, Attributes, TimeUnix, Count, Sum, Scale, ZeroCount, PositiveOffset, PositiveBucketCounts, NegativeOffset, NegativeBucketCounts) VALUES\n")
@@ -230,28 +310,62 @@ func TestExpHistogramMergeSumMapDifferential_SignBuckets(t *testing.T) {
 		fmt.Sprintf("('%s', map('series', 's2'), toDateTime64('2026-01-01 00:00:00', 9), 15, -1.0, 0, 1, 0, [3,2,1], -3, [1,1,1])", expHistSumMapDiffMetric),
 	}
 	b.WriteString("    " + strings.Join(rows, ",\n    ") + ";\n")
-	fixture := newChDBFixture(t, b.String())
+	return newChDBFixture(t, b.String())
+}
 
+// TestExpHistogramMergeSumMapDifferential_SignBuckets is the `sum()` case
+// over [newExpHistSumMapDiffFixtureSignBuckets].
+func TestExpHistogramMergeSumMapDifferential_SignBuckets(t *testing.T) {
+	fixture := newExpHistSumMapDiffFixtureSignBuckets(t)
 	fanout := runExpHistSumMapDiffQuery(t, fixture, false)
 	native := runExpHistSumMapDiffQuery(t, fixture, true)
 	assertExpHistSumMapDiffEqual(t, fanout, native)
 }
 
-// TestExpHistogramMergeSumMapDifferential_SingleSeries seeds exactly ONE
-// series — no real cross-series merge — the "must not regress the simple
-// case" check: at this issue's own measured realistic OTel-default width
-// (~160 buckets and below), the two-pass design stays roughly PARITY with
-// the fold even here despite paying its own double-scan-of-perSeries
-// overhead; see this file's header and cerberus issue #2757 for the full
-// measured table (the documented memory regression only appears for a
-// SINGLE series with an unusually WIDE individual layout, not exercised
-// by this fixture).
-func TestExpHistogramMergeSumMapDifferential_SingleSeries(t *testing.T) {
-	fixture := newChDBFixture(t, expHistSumMapDiffSeedDDL+
+// TestExpHistogramMergeSumMapDifferential_Avg_SignBuckets is
+// [TestExpHistogramMergeSumMapDifferential_SignBuckets]'s `avg()` twin
+// (cerberus issue #2866): both ladders' merge, ZeroCount included, must
+// divide identically to the fold path.
+func TestExpHistogramMergeSumMapDifferential_Avg_SignBuckets(t *testing.T) {
+	fixture := newExpHistSumMapDiffFixtureSignBuckets(t)
+	fanout := runExpHistSumMapDiffQueryAvg(t, fixture, false)
+	native := runExpHistSumMapDiffQueryAvg(t, fixture, true)
+	assertExpHistSumMapDiffEqual(t, fanout, native)
+}
+
+// newExpHistSumMapDiffFixtureSingleSeries seeds exactly ONE series — no
+// real cross-series merge — the "must not regress the simple case" check:
+// at this issue's own measured realistic OTel-default width (~160 buckets
+// and below), the two-pass design stays roughly PARITY with the fold even
+// here despite paying its own double-scan-of-perSeries overhead; see this
+// file's header and cerberus issue #2757 for the full measured table (the
+// documented memory regression only appears for a SINGLE series with an
+// unusually WIDE individual layout, not exercised by this fixture). Shared
+// by the Sum and Avg differential tests below.
+func newExpHistSumMapDiffFixtureSingleSeries(t *testing.T) *chdbFixture {
+	t.Helper()
+	return newChDBFixture(t, expHistSumMapDiffSeedDDL+
 		"INSERT INTO otel_metrics_exponential_histogram (MetricName, Attributes, TimeUnix, Count, Sum, Scale, ZeroCount, PositiveOffset, PositiveBucketCounts, NegativeOffset, NegativeBucketCounts) VALUES\n"+
 		fmt.Sprintf("    ('%s', map('series', 's1'), toDateTime64('2026-01-01 00:00:00', 9), 6, 3.0, 3, 0, -2, [1,2,3], 0, []);\n", expHistSumMapDiffMetric))
+}
 
+// TestExpHistogramMergeSumMapDifferential_SingleSeries is the `sum()` case
+// over [newExpHistSumMapDiffFixtureSingleSeries].
+func TestExpHistogramMergeSumMapDifferential_SingleSeries(t *testing.T) {
+	fixture := newExpHistSumMapDiffFixtureSingleSeries(t)
 	fanout := runExpHistSumMapDiffQuery(t, fixture, false)
 	native := runExpHistSumMapDiffQuery(t, fixture, true)
+	assertExpHistSumMapDiffEqual(t, fanout, native)
+}
+
+// TestExpHistogramMergeSumMapDifferential_Avg_SingleSeries is
+// [TestExpHistogramMergeSumMapDifferential_SingleSeries]'s `avg()` twin
+// (cerberus issue #2866): a single-member group's avg() divides by 1 —
+// the degenerate case a divide-by-member-count implementation is likeliest
+// to get wrong (e.g. dividing by row count from the wrong stage).
+func TestExpHistogramMergeSumMapDifferential_Avg_SingleSeries(t *testing.T) {
+	fixture := newExpHistSumMapDiffFixtureSingleSeries(t)
+	fanout := runExpHistSumMapDiffQueryAvg(t, fixture, false)
+	native := runExpHistSumMapDiffQueryAvg(t, fixture, true)
 	assertExpHistSumMapDiffEqual(t, fanout, native)
 }

--- a/internal/promql/histogram_native_avg.go
+++ b/internal/promql/histogram_native_avg.go
@@ -23,10 +23,12 @@ import (
 // only that division: [sumOrAvgOverExpHistogram] recognises both
 // aggregations and both route through the SAME
 // [ExpHistogramMergeLowerer.LowerExpHistogramMerge] call, so the two can
-// never drift apart in the arithmetic that reconciles bucket ladders. avg
-// is never eligible for the sumMap alternate shape
-// (exp_histogram_merge_summap.go) — it always resolves to
-// [expHistogramGroupMergeFanout] — but sharing the ONE dispatch call is
+// never drift apart in the arithmetic that reconciles bucket ladders.
+// Eligible for the SAME instant, single-group shape sum() is (cerberus
+// issue #2866), avg() resolves through
+// [expHistogramGroupMergeSumMap]'s own division
+// (exp_histogram_merge_summap.go); every other shape still resolves to
+// [expHistogramGroupMergeFanout]'s. Sharing the ONE dispatch call is
 // still the whole point of the split: a second, parallel merge call site
 // would be a second place for the scale-fold to go wrong.
 //
@@ -74,8 +76,10 @@ const expHistogramGroupSeriesCountAlias = "_hq_group_series_count"
 // across-series merge, i.e. the number of series contributing a sample
 // to the group.
 //
-// It is collected for `avg()` only — see [expHistogramGroupMergeAggs].
-// `sum()` never reads it, and emitting it there would change a shipped
+// It is collected for `avg()` only, by both merge shapes — the fold path's
+// [expHistogramGroupMergeAggs] and the sumMap path's
+// [expHistogramGroupMergeSumMap] (cerberus issue #2866). `sum()` never
+// reads it in either shape, and emitting it there would change a shipped
 // lowering's SQL to carry a column nothing consumes.
 func expHistogramGroupSeriesCountAgg() chplan.AggFunc {
 	return chplan.AggFunc{

--- a/test/perf/solver-decision-baseline/exp_histogram_avg_merge_summap/fanout.json
+++ b/test/perf/solver-decision-baseline/exp_histogram_avg_merge_summap/fanout.json
@@ -1,0 +1,11 @@
+{
+  "query": "exp_histogram_avg_merge_summap/fanout",
+  "lowering": "fanout",
+  "routed": false,
+  "k": 0,
+  "reason": "not-sliceable",
+  "n_anchors": 241,
+  "fanout": 20,
+  "cumulative_d": "5m0s",
+  "outer_range": "1h0m0s"
+}

--- a/test/perf/solver-decision-baseline/exp_histogram_avg_merge_summap/native.json
+++ b/test/perf/solver-decision-baseline/exp_histogram_avg_merge_summap/native.json
@@ -1,0 +1,11 @@
+{
+  "query": "exp_histogram_avg_merge_summap/native",
+  "lowering": "native",
+  "routed": false,
+  "k": 0,
+  "reason": "not-sliceable",
+  "n_anchors": 241,
+  "fanout": 20,
+  "cumulative_d": "5m0s",
+  "outer_range": "1h0m0s"
+}

--- a/test/regression/parity-enrolment-baselines/promql/baseline.txt
+++ b/test/regression/parity-enrolment-baselines/promql/baseline.txt
@@ -135,6 +135,7 @@ exp_histogram_absent_missing.txtar
 exp_histogram_absent_present.txtar
 exp_histogram_avg.txtar
 exp_histogram_avg_by.txtar
+exp_histogram_avg_merge_summap.txtar
 exp_histogram_avg_over_avg_over_time.txtar
 exp_histogram_avg_over_time.txtar
 exp_histogram_bare_selector.txtar

--- a/test/spec/promql/exp_histogram_avg_merge_summap.txtar
+++ b/test/spec/promql/exp_histogram_avg_merge_summap.txtar
@@ -1,0 +1,263 @@
+-- query.promql --
+avg(http_server_duration_exp_hist)
+-- parity --
+oracle: prometheus
+endpoint: /api/v1/query
+scope: full
+-- experimental_exp_histogram_merge_summap --
+-- seed --
+CREATE TABLE otel_metrics_exponential_histogram (
+    MetricName String,
+    Attributes Map(String, String),
+    TimeUnix DateTime64(9),
+    Count UInt64,
+    Sum Float64,
+    Scale Int32,
+    ZeroCount UInt64,
+    PositiveOffset Int32,
+    PositiveBucketCounts Array(UInt64),
+    NegativeOffset Int32,
+    NegativeBucketCounts Array(UInt64)
+) ENGINE = MergeTree ORDER BY (MetricName, Attributes, TimeUnix);
+-- The `avg()` sibling of exp_histogram_merge_summap.txtar — cerberus issue
+-- #2866's own eligibility widening: BYTE-IDENTICAL query and seed to that
+-- fixture except for the aggregation, so the two fixtures' emitted SQL
+-- differs by exactly [expHistogramGroupSeriesCountAgg]'s extra count()
+-- aggregate and [expHistogramAvgScaleProjections]'s division on top — the
+-- reconciled bucket ladder underneath (the downscale COLLAPSE case, `fine`'s
+-- Scale-1 buckets folding pairwise onto `coarse`'s Scale-0 layout) is
+-- otherwise the SAME two-pass sumMap-keyed reshape
+-- (exp_histogram_merge_summap.go), not a second, parallel merge.
+--
+-- expected_rows below is exp_histogram_merge_summap.txtar's own merged row
+-- divided by 2 (the two contributing series) on the five count-bearing
+-- fields only — Scale and both offsets are untouched, matching
+-- [TestLower_ExpHistogram_AvgDividesOnlyTheCountFields]'s own assertion —
+-- pinned directly against chDB in exp_histogram_merge_summap_chdb_test.go's
+-- TestExpHistogramMergeSumMapDifferential_Avg_ScaleNegotiation.
+INSERT INTO otel_metrics_exponential_histogram VALUES
+    ('http_server_duration_exp_hist', map('series', 'fine'),   toDateTime64('2026-01-01 00:00:00', 9), 10, 1.0, 1, 0, 0, [1, 2, 3, 4], 0, []),
+    ('http_server_duration_exp_hist', map('series', 'coarse'), toDateTime64('2026-01-01 00:00:00', 9), 15, 2.0, 0, 0, 0, [5, 10],      0, []);
+-- expected_rows --
+[
+  ["", {}, "2026-01-01T00:00:01Z", 0, 12.5, 1.5, 0, 0, 0, 0, [4,8.5], 0, []]
+]
+-- args --
+[0] string = ""
+[1] int64 = 9
+[2] float64 = 0
+[3] string = "Map(String,String)"
+[4] int64 = 1
+[5] int64 = 2
+[6] float64 = 0
+[7] int64 = 2
+[8] int64 = 1
+[9] int64 = 1
+[10] int64 = 1
+[11] int64 = 1
+[12] int64 = 1
+[13] float64 = 0
+[14] float64 = 0
+[15] int64 = 1
+[16] int64 = 1
+[17] int64 = 2
+[18] float64 = 0
+[19] int64 = 2
+[20] int64 = 1
+[21] int64 = 1
+[22] int64 = 1
+[23] int64 = 1
+[24] int64 = 1
+[25] float64 = 0
+[26] float64 = 0
+[27] int64 = 1
+[28] int64 = 1
+[29] int64 = 2
+[30] float64 = 0
+[31] int64 = 2
+[32] int64 = 1
+[33] int64 = 1
+[34] int64 = 1
+[35] int64 = 1
+[36] int64 = 1
+[37] float64 = 0
+[38] float64 = 0
+[39] int64 = 1
+[40] int64 = 1
+[41] int64 = 0
+[42] int64 = 0
+[43] int64 = 1
+[44] int64 = 1
+[45] int64 = 0
+[46] float64 = 0
+[47] int64 = 2
+[48] int64 = 1
+[49] int64 = 1
+[50] int64 = 1
+[51] int64 = 1
+[52] int64 = 1
+[53] int64 = 1
+[54] int64 = 1
+[55] int64 = 0
+[56] int64 = 0
+[57] int64 = 1
+[58] int64 = 1
+[59] int64 = 0
+[60] float64 = 0
+[61] int64 = 2
+[62] int64 = 1
+[63] int64 = 1
+[64] int64 = 1
+[65] int64 = 1
+[66] int64 = 1
+[67] int64 = 1
+[68] int64 = 1
+[69] string = "service_name"
+[70] string = "service.name"
+[71] string = "service_name"
+[72] string = "service.name"
+[73] string = "service_name"
+[74] string = ""
+[75] string = "service_name"
+[76] string = "http_server_duration_exp_hist"
+[77] string = "http.server.duration.exp.hist"
+[78] string = "http.server.duration.exp/hist"
+[79] string = "http.server.duration.exp_hist"
+[80] string = "http.server.duration/exp/hist"
+[81] string = "http.server.duration/exp_hist"
+[82] string = "http.server.duration_exp.hist"
+[83] string = "http.server.duration_exp_hist"
+[84] string = "http.server/duration/exp/hist"
+[85] string = "http.server/duration/exp_hist"
+[86] string = "http.server/duration_exp_hist"
+[87] string = "http.server_duration.exp.hist"
+[88] string = "http.server_duration.exp_hist"
+[89] string = "http.server_duration_exp.hist"
+[90] string = "http.server_duration_exp_hist"
+[91] string = "http/server/duration/exp/hist"
+[92] string = "http/server/duration/exp_hist"
+[93] string = "http/server/duration_exp_hist"
+[94] string = "http/server_duration_exp_hist"
+[95] string = "http_server.duration.exp.hist"
+[96] string = "http_server.duration.exp_hist"
+[97] string = "http_server.duration_exp.hist"
+[98] string = "http_server.duration_exp_hist"
+[99] string = "http_server_duration.exp.hist"
+[100] string = "http_server_duration.exp_hist"
+[101] string = "http_server_duration_exp.hist"
+[102] string = "2026-01-01 00:00:01.000000000"
+[103] int64 = 9
+[104] string = "2026-01-01 00:00:01.000000000"
+[105] int64 = 9
+[106] int64 = 300000000000
+[107] int64 = 1
+[108] string = "service_name"
+[109] string = "service.name"
+[110] string = "service_name"
+[111] string = "service.name"
+[112] string = "service_name"
+[113] string = ""
+[114] string = "service_name"
+[115] string = "http_server_duration_exp_hist"
+[116] string = "http.server.duration.exp.hist"
+[117] string = "http.server.duration.exp/hist"
+[118] string = "http.server.duration.exp_hist"
+[119] string = "http.server.duration/exp/hist"
+[120] string = "http.server.duration/exp_hist"
+[121] string = "http.server.duration_exp.hist"
+[122] string = "http.server.duration_exp_hist"
+[123] string = "http.server/duration/exp/hist"
+[124] string = "http.server/duration/exp_hist"
+[125] string = "http.server/duration_exp_hist"
+[126] string = "http.server_duration.exp.hist"
+[127] string = "http.server_duration.exp_hist"
+[128] string = "http.server_duration_exp.hist"
+[129] string = "http.server_duration_exp_hist"
+[130] string = "http/server/duration/exp/hist"
+[131] string = "http/server/duration/exp_hist"
+[132] string = "http/server/duration_exp_hist"
+[133] string = "http/server_duration_exp_hist"
+[134] string = "http_server.duration.exp.hist"
+[135] string = "http_server.duration.exp_hist"
+[136] string = "http_server.duration_exp.hist"
+[137] string = "http_server.duration_exp_hist"
+[138] string = "http_server_duration.exp.hist"
+[139] string = "http_server_duration.exp_hist"
+[140] string = "http_server_duration_exp.hist"
+[141] string = "2026-01-01 00:00:01.000000000"
+[142] int64 = 9
+[143] string = "2026-01-01 00:00:01.000000000"
+[144] int64 = 9
+[145] int64 = 300000000000
+[146] string = "service_name"
+[147] string = "service.name"
+[148] string = "service_name"
+[149] string = "service.name"
+[150] string = "service_name"
+[151] string = ""
+[152] string = "service_name"
+[153] string = "http_server_duration_exp_hist"
+[154] string = "http.server.duration.exp.hist"
+[155] string = "http.server.duration.exp/hist"
+[156] string = "http.server.duration.exp_hist"
+[157] string = "http.server.duration/exp/hist"
+[158] string = "http.server.duration/exp_hist"
+[159] string = "http.server.duration_exp.hist"
+[160] string = "http.server.duration_exp_hist"
+[161] string = "http.server/duration/exp/hist"
+[162] string = "http.server/duration/exp_hist"
+[163] string = "http.server/duration_exp_hist"
+[164] string = "http.server_duration.exp.hist"
+[165] string = "http.server_duration.exp_hist"
+[166] string = "http.server_duration_exp.hist"
+[167] string = "http.server_duration_exp_hist"
+[168] string = "http/server/duration/exp/hist"
+[169] string = "http/server/duration/exp_hist"
+[170] string = "http/server/duration_exp_hist"
+[171] string = "http/server_duration_exp_hist"
+[172] string = "http_server.duration.exp.hist"
+[173] string = "http_server.duration.exp_hist"
+[174] string = "http_server.duration_exp.hist"
+[175] string = "http_server.duration_exp_hist"
+[176] string = "http_server_duration.exp.hist"
+[177] string = "http_server_duration.exp_hist"
+[178] string = "http_server_duration_exp.hist"
+[179] string = "2026-01-01 00:00:01.000000000"
+[180] int64 = 9
+[181] string = "2026-01-01 00:00:01.000000000"
+[182] int64 = 9
+[183] int64 = 300000000000
+[184] int64 = 4096
+[185] int64 = 4
+[186] int64 = 0
+[187] int64 = 1
+[188] int64 = 1
+[189] int64 = 1
+[190] int64 = 100000
+[191] int64 = 0
+[192] int64 = 1
+[193] int64 = 1
+[194] int64 = 1
+[195] int64 = 100000
+[196] int64 = 0
+[197] int64 = 1
+[198] int64 = 1
+[199] int64 = 1
+[200] int64 = 100000
+[201] int64 = 0
+[202] int64 = 1
+[203] int64 = 1
+[204] int64 = 1
+[205] int64 = 100000
+[206] int64 = 60000000
+[207] int64 = 0
+-- chplan --
+HistogramProjection project=["" AS MetricName, Attributes AS Attributes, FnNow64(9) AS TimeUnix, 0 AS Value]
+  Project [FnCast(FnMap(), "Map(String,String)") AS Attributes, (FnArrayMap(kh_final -> (FnTupleElement(kh_final, 1) + FnTupleElement(kh_final, 2)), FnArray(FnArrayFold((kh_acc, kh_x) -> FnArrayMap(kh_total -> FnTuple(kh_total, FnIf(FnIsInfinite(kh_total), 0, (FnTupleElement(kh_acc, 2) + FnIf((FnAbs(FnTupleElement(kh_acc, 1)) >= FnAbs(kh_x)), ((FnTupleElement(kh_acc, 1) - kh_total) + kh_x), ((kh_x - kh_total) + FnTupleElement(kh_acc, 1)))))), FnArray((FnTupleElement(kh_acc, 1) + kh_x)))[1], _hq_merge_counts, FnTuple(0, 0))))[1] / _hq_group_series_count) AS Count, (FnArrayMap(kh_final -> (FnTupleElement(kh_final, 1) + FnTupleElement(kh_final, 2)), FnArray(FnArrayFold((kh_acc, kh_x) -> FnArrayMap(kh_total -> FnTuple(kh_total, FnIf(FnIsInfinite(kh_total), 0, (FnTupleElement(kh_acc, 2) + FnIf((FnAbs(FnTupleElement(kh_acc, 1)) >= FnAbs(kh_x)), ((FnTupleElement(kh_acc, 1) - kh_total) + kh_x), ((kh_x - kh_total) + FnTupleElement(kh_acc, 1)))))), FnArray((FnTupleElement(kh_acc, 1) + kh_x)))[1], _hq_merge_sums, FnTuple(0, 0))))[1] / _hq_group_series_count) AS Sum, _hq_merged_scale AS Scale, (FnArrayMap(kh_final -> (FnTupleElement(kh_final, 1) + FnTupleElement(kh_final, 2)), FnArray(FnArrayFold((kh_acc, kh_x) -> FnArrayMap(kh_total -> FnTuple(kh_total, FnIf(FnIsInfinite(kh_total), 0, (FnTupleElement(kh_acc, 2) + FnIf((FnAbs(FnTupleElement(kh_acc, 1)) >= FnAbs(kh_x)), ((FnTupleElement(kh_acc, 1) - kh_total) + kh_x), ((kh_x - kh_total) + FnTupleElement(kh_acc, 1)))))), FnArray((FnTupleElement(kh_acc, 1) + kh_x)))[1], _hq_merge_zero_counts, FnTuple(0, 0))))[1] / _hq_group_series_count) AS ZeroCount, FnIf((FnLength(FnTupleElement(_hq_pos_summap, 1)) = 0), 0, FnArrayMin(FnTupleElement(_hq_pos_summap, 1))) AS PositiveOffset, FnArrayMap(b -> (b / _hq_group_series_count), FnIf((FnLength(FnTupleElement(_hq_pos_summap, 1)) = 0), FnEmptyArrayFloat64(), FnArrayMap(t -> FnArrayConcat(FnArray(0), FnTupleElement(_hq_pos_summap, 2))[(FnIndexOf(FnTupleElement(_hq_pos_summap, 1), (FnArrayMin(FnTupleElement(_hq_pos_summap, 1)) + t)) + 1)], FnRange(FnToUInt64(((FnArrayMax(FnTupleElement(_hq_pos_summap, 1)) - FnArrayMin(FnTupleElement(_hq_pos_summap, 1))) + 1)))))) AS PositiveBucketCounts, FnIf((FnLength(FnTupleElement(_hq_neg_summap, 1)) = 0), 0, FnArrayMin(FnTupleElement(_hq_neg_summap, 1))) AS NegativeOffset, FnArrayMap(b -> (b / _hq_group_series_count), FnIf((FnLength(FnTupleElement(_hq_neg_summap, 1)) = 0), FnEmptyArrayFloat64(), FnArrayMap(t -> FnArrayConcat(FnArray(0), FnTupleElement(_hq_neg_summap, 2))[(FnIndexOf(FnTupleElement(_hq_neg_summap, 1), (FnArrayMin(FnTupleElement(_hq_neg_summap, 1)) + t)) + 1)], FnRange(FnToUInt64(((FnArrayMax(FnTupleElement(_hq_neg_summap, 1)) - FnArrayMin(FnTupleElement(_hq_neg_summap, 1))) + 1)))))) AS NegativeBucketCounts]
+    Filter predicate=(FnThrowIf(((FnLength(_hq_scales) > 4096) OR ((4 * ((FnLeast(FnArrayMap(mst -> FnGreatest(0, ((FnArrayMax(FnArrayMap((sm, om, am) -> FnBitShiftRight((om + (FnLength(am) - 1)), (sm - _hq_merged_scale)), _hq_scales, _hq_pos_offsets, _hq_pos_buckets)) - mst) + 1)), FnArray(FnArrayMin(FnArrayMap((sm, om) -> FnBitShiftRight(om, (sm - _hq_merged_scale)), _hq_scales, _hq_pos_offsets))))[1], 100000) * FnLeast(FnArrayMap(mst -> FnGreatest(0, ((FnArrayMax(FnArrayMap((sm, om, am) -> FnBitShiftRight((om + (FnLength(am) - 1)), (sm - _hq_merged_scale)), _hq_scales, _hq_pos_offsets, _hq_pos_buckets)) - mst) + 1)), FnArray(FnArrayMin(FnArrayMap((sm, om) -> FnBitShiftRight(om, (sm - _hq_merged_scale)), _hq_scales, _hq_pos_offsets))))[1], 100000)) + (FnLeast(FnArrayMap(mst -> FnGreatest(0, ((FnArrayMax(FnArrayMap((sm, om, am) -> FnBitShiftRight((om + (FnLength(am) - 1)), (sm - _hq_merged_scale)), _hq_scales, _hq_neg_offsets, _hq_neg_buckets)) - mst) + 1)), FnArray(FnArrayMin(FnArrayMap((sm, om) -> FnBitShiftRight(om, (sm - _hq_merged_scale)), _hq_scales, _hq_neg_offsets))))[1], 100000) * FnLeast(FnArrayMap(mst -> FnGreatest(0, ((FnArrayMax(FnArrayMap((sm, om, am) -> FnBitShiftRight((om + (FnLength(am) - 1)), (sm - _hq_merged_scale)), _hq_scales, _hq_neg_offsets, _hq_neg_buckets)) - mst) + 1)), FnArray(FnArrayMin(FnArrayMap((sm, om) -> FnBitShiftRight(om, (sm - _hq_merged_scale)), _hq_scales, _hq_neg_offsets))))[1], 100000)))) > 60000000)), "native histogram merge exceeds the series-per-group or merged-bucket-width resource bound") = 0)
+      Aggregate groupBy=[] funcs=[FnGroupArray(Count) AS _hq_merge_counts, FnGroupArray(Sum) AS _hq_merge_sums, FnMin(Scale) AS _hq_merged_scale, FnGroupArray(ZeroCount) AS _hq_merge_zero_counts, FnGroupArray(Scale) AS _hq_scales, FnGroupArray(PositiveOffset) AS _hq_pos_offsets, FnGroupArray(PositiveBucketCounts) AS _hq_pos_buckets, FnGroupArray(NegativeOffset) AS _hq_neg_offsets, FnGroupArray(NegativeBucketCounts) AS _hq_neg_buckets, FnSumMap(FnArrayMap(j -> FnBitShiftRight(((PositiveOffset + j) - 1), (Scale - scalarSubquery{Project [_hq_pass1_merged_scale AS _hq_pass1_merged_scale] ; Aggregate groupBy=[] funcs=[FnMin(Scale) AS _hq_pass1_merged_scale] ; Aggregate groupBy=[FnMapSort(FnMapMerge(FnMapFilter((k, v) -> (k NOT IN ("service_name")), FnMapUpdate(FnMapFromArrays(FnArrayMap(k -> FnRegexReplaceAll(k, "[^a-zA-Z0-9_]", "_"), FnMapKeys(FnMapFilter((k, v) -> (k NOT IN ("service.name", "service_name")), ResourceAttributes))), FnMapValues(FnMapFilter((k, v) -> (k NOT IN ("service.name", "service_name")), ResourceAttributes))), FnMapFromArrays(FnArrayMap(k -> FnRegexReplaceAll(k, "[^a-zA-Z0-9_]", "_"), FnMapKeys(Attributes)), FnMapValues(Attributes)))), FnMapFilter((k, v) -> (v != ""), FnMap("service_name", FnToString(ServiceName))))) AS Attributes] funcs=[FnArgMax(Count, TimeUnix) AS Count, FnArgMax(Sum, TimeUnix) AS Sum, FnArgMax(Scale, TimeUnix) AS Scale, FnArgMax(ZeroCount, TimeUnix) AS ZeroCount, FnArgMax(PositiveOffset, TimeUnix) AS PositiveOffset, FnArgMax(PositiveBucketCounts, TimeUnix) AS PositiveBucketCounts, FnArgMax(NegativeOffset, TimeUnix) AS NegativeOffset, FnArgMax(NegativeBucketCounts, TimeUnix) AS NegativeBucketCounts] ; Filter predicate=(((MetricName IN ("http_server_duration_exp_hist", "http.server.duration.exp.hist", "http.server.duration.exp/hist", "http.server.duration.exp_hist", "http.server.duration/exp/hist", "http.server.duration/exp_hist", "http.server.duration_exp.hist", "http.server.duration_exp_hist", "http.server/duration/exp/hist", "http.server/duration/exp_hist", "http.server/duration_exp_hist", "http.server_duration.exp.hist", "http.server_duration.exp_hist", "http.server_duration_exp.hist", "http.server_duration_exp_hist", "http/server/duration/exp/hist", "http/server/duration/exp_hist", "http/server/duration_exp_hist", "http/server_duration_exp_hist", "http_server.duration.exp.hist", "http_server.duration.exp_hist", "http_server.duration_exp.hist", "http_server.duration_exp_hist", "http_server_duration.exp.hist", "http_server_duration.exp_hist", "http_server_duration_exp.hist")) AND (TimeUnix <= FnToDateTime64("2026-01-01 00:00:01.000000000", 9))) AND (TimeUnix > (FnToDateTime64("2026-01-01 00:00:01.000000000", 9) - FnToIntervalNanosecond(300000000000)))) ; Scan(otel_metrics_exponential_histogram)})), FnArrayEnumerate(PositiveBucketCounts)), FnArrayMap(x -> FnToFloat64(x), PositiveBucketCounts)) AS _hq_pos_summap, FnSumMap(FnArrayMap(j -> FnBitShiftRight(((NegativeOffset + j) - 1), (Scale - scalarSubquery{Project [_hq_pass1_merged_scale AS _hq_pass1_merged_scale] ; Aggregate groupBy=[] funcs=[FnMin(Scale) AS _hq_pass1_merged_scale] ; Aggregate groupBy=[FnMapSort(FnMapMerge(FnMapFilter((k, v) -> (k NOT IN ("service_name")), FnMapUpdate(FnMapFromArrays(FnArrayMap(k -> FnRegexReplaceAll(k, "[^a-zA-Z0-9_]", "_"), FnMapKeys(FnMapFilter((k, v) -> (k NOT IN ("service.name", "service_name")), ResourceAttributes))), FnMapValues(FnMapFilter((k, v) -> (k NOT IN ("service.name", "service_name")), ResourceAttributes))), FnMapFromArrays(FnArrayMap(k -> FnRegexReplaceAll(k, "[^a-zA-Z0-9_]", "_"), FnMapKeys(Attributes)), FnMapValues(Attributes)))), FnMapFilter((k, v) -> (v != ""), FnMap("service_name", FnToString(ServiceName))))) AS Attributes] funcs=[FnArgMax(Count, TimeUnix) AS Count, FnArgMax(Sum, TimeUnix) AS Sum, FnArgMax(Scale, TimeUnix) AS Scale, FnArgMax(ZeroCount, TimeUnix) AS ZeroCount, FnArgMax(PositiveOffset, TimeUnix) AS PositiveOffset, FnArgMax(PositiveBucketCounts, TimeUnix) AS PositiveBucketCounts, FnArgMax(NegativeOffset, TimeUnix) AS NegativeOffset, FnArgMax(NegativeBucketCounts, TimeUnix) AS NegativeBucketCounts] ; Filter predicate=(((MetricName IN ("http_server_duration_exp_hist", "http.server.duration.exp.hist", "http.server.duration.exp/hist", "http.server.duration.exp_hist", "http.server.duration/exp/hist", "http.server.duration/exp_hist", "http.server.duration_exp.hist", "http.server.duration_exp_hist", "http.server/duration/exp/hist", "http.server/duration/exp_hist", "http.server/duration_exp_hist", "http.server_duration.exp.hist", "http.server_duration.exp_hist", "http.server_duration_exp.hist", "http.server_duration_exp_hist", "http/server/duration/exp/hist", "http/server/duration/exp_hist", "http/server/duration_exp_hist", "http/server_duration_exp_hist", "http_server.duration.exp.hist", "http_server.duration.exp_hist", "http_server.duration_exp.hist", "http_server.duration_exp_hist", "http_server_duration.exp.hist", "http_server_duration.exp_hist", "http_server_duration_exp.hist")) AND (TimeUnix <= FnToDateTime64("2026-01-01 00:00:01.000000000", 9))) AND (TimeUnix > (FnToDateTime64("2026-01-01 00:00:01.000000000", 9) - FnToIntervalNanosecond(300000000000)))) ; Scan(otel_metrics_exponential_histogram)})), FnArrayEnumerate(NegativeBucketCounts)), FnArrayMap(x -> FnToFloat64(x), NegativeBucketCounts)) AS _hq_neg_summap, FnCount() AS _hq_group_series_count]
+        Aggregate groupBy=[FnMapSort(FnMapMerge(FnMapFilter((k, v) -> (k NOT IN ("service_name")), FnMapUpdate(FnMapFromArrays(FnArrayMap(k -> FnRegexReplaceAll(k, "[^a-zA-Z0-9_]", "_"), FnMapKeys(FnMapFilter((k, v) -> (k NOT IN ("service.name", "service_name")), ResourceAttributes))), FnMapValues(FnMapFilter((k, v) -> (k NOT IN ("service.name", "service_name")), ResourceAttributes))), FnMapFromArrays(FnArrayMap(k -> FnRegexReplaceAll(k, "[^a-zA-Z0-9_]", "_"), FnMapKeys(Attributes)), FnMapValues(Attributes)))), FnMapFilter((k, v) -> (v != ""), FnMap("service_name", FnToString(ServiceName))))) AS Attributes] funcs=[FnArgMax(Count, TimeUnix) AS Count, FnArgMax(Sum, TimeUnix) AS Sum, FnArgMax(Scale, TimeUnix) AS Scale, FnArgMax(ZeroCount, TimeUnix) AS ZeroCount, FnArgMax(PositiveOffset, TimeUnix) AS PositiveOffset, FnArgMax(PositiveBucketCounts, TimeUnix) AS PositiveBucketCounts, FnArgMax(NegativeOffset, TimeUnix) AS NegativeOffset, FnArgMax(NegativeBucketCounts, TimeUnix) AS NegativeBucketCounts]
+          Filter predicate=(((MetricName IN ("http_server_duration_exp_hist", "http.server.duration.exp.hist", "http.server.duration.exp/hist", "http.server.duration.exp_hist", "http.server.duration/exp/hist", "http.server.duration/exp_hist", "http.server.duration_exp.hist", "http.server.duration_exp_hist", "http.server/duration/exp/hist", "http.server/duration/exp_hist", "http.server/duration_exp_hist", "http.server_duration.exp.hist", "http.server_duration.exp_hist", "http.server_duration_exp.hist", "http.server_duration_exp_hist", "http/server/duration/exp/hist", "http/server/duration/exp_hist", "http/server/duration_exp_hist", "http/server_duration_exp_hist", "http_server.duration.exp.hist", "http_server.duration.exp_hist", "http_server.duration_exp.hist", "http_server.duration_exp_hist", "http_server_duration.exp.hist", "http_server_duration.exp_hist", "http_server_duration_exp.hist")) AND (TimeUnix <= FnToDateTime64("2026-01-01 00:00:01.000000000", 9))) AND (TimeUnix > (FnToDateTime64("2026-01-01 00:00:01.000000000", 9) - FnToIntervalNanosecond(300000000000))))
+            Scan(otel_metrics_exponential_histogram)
+-- sql --
+SELECT ? AS `MetricName`, `Attributes` AS `Attributes`, now64(?) AS `TimeUnix`, toFloat64(?) AS `Value`, toFloat64(`Count`) AS `HistogramCount`, toFloat64(`Sum`) AS `HistogramSum`, toInt32(`Scale`) AS `HistogramScale`, toFloat64(0.) AS `HistogramZeroThreshold`, toFloat64(`ZeroCount`) AS `HistogramZeroCount`, toInt32(`PositiveOffset`) AS `HistogramPositiveOffset`, arrayMap(x -> toFloat64(x), `PositiveBucketCounts`) AS `HistogramPositiveBucketCounts`, toInt32(`NegativeOffset`) AS `HistogramNegativeOffset`, arrayMap(x -> toFloat64(x), `NegativeBucketCounts`) AS `HistogramNegativeBucketCounts` FROM (SELECT CAST(map(), ?) AS `Attributes`, (arrayMap(kh_final -> (tupleElement(kh_final, ?) + tupleElement(kh_final, ?)), array(arrayFold((kh_acc, kh_x) -> arrayMap(kh_total -> tuple(kh_total, if(isInfinite(kh_total), toFloat64(?), (tupleElement(kh_acc, ?) + if((abs(tupleElement(kh_acc, ?)) >= abs(kh_x)), ((tupleElement(kh_acc, ?) - kh_total) + kh_x), ((kh_x - kh_total) + tupleElement(kh_acc, ?)))))), array((tupleElement(kh_acc, ?) + kh_x)))[?], `_hq_merge_counts`, tuple(toFloat64(?), toFloat64(?)))))[?] / `_hq_group_series_count`) AS `Count`, (arrayMap(kh_final -> (tupleElement(kh_final, ?) + tupleElement(kh_final, ?)), array(arrayFold((kh_acc, kh_x) -> arrayMap(kh_total -> tuple(kh_total, if(isInfinite(kh_total), toFloat64(?), (tupleElement(kh_acc, ?) + if((abs(tupleElement(kh_acc, ?)) >= abs(kh_x)), ((tupleElement(kh_acc, ?) - kh_total) + kh_x), ((kh_x - kh_total) + tupleElement(kh_acc, ?)))))), array((tupleElement(kh_acc, ?) + kh_x)))[?], `_hq_merge_sums`, tuple(toFloat64(?), toFloat64(?)))))[?] / `_hq_group_series_count`) AS `Sum`, `_hq_merged_scale` AS `Scale`, (arrayMap(kh_final -> (tupleElement(kh_final, ?) + tupleElement(kh_final, ?)), array(arrayFold((kh_acc, kh_x) -> arrayMap(kh_total -> tuple(kh_total, if(isInfinite(kh_total), toFloat64(?), (tupleElement(kh_acc, ?) + if((abs(tupleElement(kh_acc, ?)) >= abs(kh_x)), ((tupleElement(kh_acc, ?) - kh_total) + kh_x), ((kh_x - kh_total) + tupleElement(kh_acc, ?)))))), array((tupleElement(kh_acc, ?) + kh_x)))[?], `_hq_merge_zero_counts`, tuple(toFloat64(?), toFloat64(?)))))[?] / `_hq_group_series_count`) AS `ZeroCount`, if((length(tupleElement(`_hq_pos_summap`, ?)) = ?), ?, arrayMin(tupleElement(`_hq_pos_summap`, ?))) AS `PositiveOffset`, arrayMap(b -> (b / `_hq_group_series_count`), if((length(tupleElement(`_hq_pos_summap`, ?)) = ?), emptyArrayFloat64(), arrayMap(t -> arrayConcat(array(toFloat64(?)), tupleElement(`_hq_pos_summap`, ?))[(indexOf(tupleElement(`_hq_pos_summap`, ?), (arrayMin(tupleElement(`_hq_pos_summap`, ?)) + t)) + ?)], range(toUInt64(((arrayMax(tupleElement(`_hq_pos_summap`, ?)) - arrayMin(tupleElement(`_hq_pos_summap`, ?))) + ?)))))) AS `PositiveBucketCounts`, if((length(tupleElement(`_hq_neg_summap`, ?)) = ?), ?, arrayMin(tupleElement(`_hq_neg_summap`, ?))) AS `NegativeOffset`, arrayMap(b -> (b / `_hq_group_series_count`), if((length(tupleElement(`_hq_neg_summap`, ?)) = ?), emptyArrayFloat64(), arrayMap(t -> arrayConcat(array(toFloat64(?)), tupleElement(`_hq_neg_summap`, ?))[(indexOf(tupleElement(`_hq_neg_summap`, ?), (arrayMin(tupleElement(`_hq_neg_summap`, ?)) + t)) + ?)], range(toUInt64(((arrayMax(tupleElement(`_hq_neg_summap`, ?)) - arrayMin(tupleElement(`_hq_neg_summap`, ?))) + ?)))))) AS `NegativeBucketCounts` FROM (SELECT * FROM (SELECT `_hq_merge_counts`, `_hq_merge_sums`, `_hq_merged_scale`, `_hq_merge_zero_counts`, `_hq_scales`, `_hq_pos_offsets`, `_hq_pos_buckets`, `_hq_neg_offsets`, `_hq_neg_buckets`, `_hq_pos_summap`, `_hq_neg_summap`, `_hq_group_series_count` FROM (SELECT groupArray(`Count`) AS `_hq_merge_counts`, groupArray(`Sum`) AS `_hq_merge_sums`, min(`Scale`) AS `_hq_merged_scale`, groupArray(`ZeroCount`) AS `_hq_merge_zero_counts`, groupArray(`Scale`) AS `_hq_scales`, groupArray(`PositiveOffset`) AS `_hq_pos_offsets`, groupArray(`PositiveBucketCounts`) AS `_hq_pos_buckets`, groupArray(`NegativeOffset`) AS `_hq_neg_offsets`, groupArray(`NegativeBucketCounts`) AS `_hq_neg_buckets`, sumMap(arrayMap(j -> bitShiftRight(((`PositiveOffset` + j) - ?), (`Scale` - (SELECT `_hq_pass1_merged_scale` AS `_hq_pass1_merged_scale` FROM (SELECT min(`Scale`) AS `_hq_pass1_merged_scale` FROM (SELECT mapSort(mapConcat(mapFilter((k, v) -> (k NOT IN (?)), mapUpdate(mapFromArrays(arrayMap(k -> replaceRegexpAll(k, '[^a-zA-Z0-9_]', '_'), mapKeys(mapFilter((k, v) -> (k NOT IN (?, ?)), `ResourceAttributes`))), mapValues(mapFilter((k, v) -> (k NOT IN (?, ?)), `ResourceAttributes`))), mapFromArrays(arrayMap(k -> replaceRegexpAll(k, '[^a-zA-Z0-9_]', '_'), mapKeys(`Attributes`)), mapValues(`Attributes`)))), mapFilter((k, v) -> (v != ?), map(?, toString(`ServiceName`))))) AS `Attributes`, argMax(`Count`, `TimeUnix`) AS `Count`, argMax(`Sum`, `TimeUnix`) AS `Sum`, argMax(`Scale`, `TimeUnix`) AS `Scale`, argMax(`ZeroCount`, `TimeUnix`) AS `ZeroCount`, argMax(`PositiveOffset`, `TimeUnix`) AS `PositiveOffset`, argMax(`PositiveBucketCounts`, `TimeUnix`) AS `PositiveBucketCounts`, argMax(`NegativeOffset`, `TimeUnix`) AS `NegativeOffset`, argMax(`NegativeBucketCounts`, `TimeUnix`) AS `NegativeBucketCounts` FROM (SELECT * FROM `otel_metrics_exponential_histogram` PREWHERE (`MetricName` IN (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)) WHERE (`TimeUnix` <= toDateTime64(?, ?)) AND (`TimeUnix` > (toDateTime64(?, ?) - toIntervalNanosecond(?)))) GROUP BY `Attributes`))))), arrayEnumerate(`PositiveBucketCounts`)), arrayMap(x -> toFloat64(x), `PositiveBucketCounts`)) AS `_hq_pos_summap`, sumMap(arrayMap(j -> bitShiftRight(((`NegativeOffset` + j) - ?), (`Scale` - (SELECT `_hq_pass1_merged_scale` AS `_hq_pass1_merged_scale` FROM (SELECT min(`Scale`) AS `_hq_pass1_merged_scale` FROM (SELECT mapSort(mapConcat(mapFilter((k, v) -> (k NOT IN (?)), mapUpdate(mapFromArrays(arrayMap(k -> replaceRegexpAll(k, '[^a-zA-Z0-9_]', '_'), mapKeys(mapFilter((k, v) -> (k NOT IN (?, ?)), `ResourceAttributes`))), mapValues(mapFilter((k, v) -> (k NOT IN (?, ?)), `ResourceAttributes`))), mapFromArrays(arrayMap(k -> replaceRegexpAll(k, '[^a-zA-Z0-9_]', '_'), mapKeys(`Attributes`)), mapValues(`Attributes`)))), mapFilter((k, v) -> (v != ?), map(?, toString(`ServiceName`))))) AS `Attributes`, argMax(`Count`, `TimeUnix`) AS `Count`, argMax(`Sum`, `TimeUnix`) AS `Sum`, argMax(`Scale`, `TimeUnix`) AS `Scale`, argMax(`ZeroCount`, `TimeUnix`) AS `ZeroCount`, argMax(`PositiveOffset`, `TimeUnix`) AS `PositiveOffset`, argMax(`PositiveBucketCounts`, `TimeUnix`) AS `PositiveBucketCounts`, argMax(`NegativeOffset`, `TimeUnix`) AS `NegativeOffset`, argMax(`NegativeBucketCounts`, `TimeUnix`) AS `NegativeBucketCounts` FROM (SELECT * FROM `otel_metrics_exponential_histogram` PREWHERE (`MetricName` IN (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)) WHERE (`TimeUnix` <= toDateTime64(?, ?)) AND (`TimeUnix` > (toDateTime64(?, ?) - toIntervalNanosecond(?)))) GROUP BY `Attributes`))))), arrayEnumerate(`NegativeBucketCounts`)), arrayMap(x -> toFloat64(x), `NegativeBucketCounts`)) AS `_hq_neg_summap`, toFloat64(count()) AS `_hq_group_series_count`, count() AS `_cerb_n` FROM (SELECT mapSort(mapConcat(mapFilter((k, v) -> (k NOT IN (?)), mapUpdate(mapFromArrays(arrayMap(k -> replaceRegexpAll(k, '[^a-zA-Z0-9_]', '_'), mapKeys(mapFilter((k, v) -> (k NOT IN (?, ?)), `ResourceAttributes`))), mapValues(mapFilter((k, v) -> (k NOT IN (?, ?)), `ResourceAttributes`))), mapFromArrays(arrayMap(k -> replaceRegexpAll(k, '[^a-zA-Z0-9_]', '_'), mapKeys(`Attributes`)), mapValues(`Attributes`)))), mapFilter((k, v) -> (v != ?), map(?, toString(`ServiceName`))))) AS `Attributes`, argMax(`Count`, `TimeUnix`) AS `Count`, argMax(`Sum`, `TimeUnix`) AS `Sum`, argMax(`Scale`, `TimeUnix`) AS `Scale`, argMax(`ZeroCount`, `TimeUnix`) AS `ZeroCount`, argMax(`PositiveOffset`, `TimeUnix`) AS `PositiveOffset`, argMax(`PositiveBucketCounts`, `TimeUnix`) AS `PositiveBucketCounts`, argMax(`NegativeOffset`, `TimeUnix`) AS `NegativeOffset`, argMax(`NegativeBucketCounts`, `TimeUnix`) AS `NegativeBucketCounts` FROM (SELECT * FROM `otel_metrics_exponential_histogram` PREWHERE (`MetricName` IN (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)) WHERE (`TimeUnix` <= toDateTime64(?, ?)) AND (`TimeUnix` > (toDateTime64(?, ?) - toIntervalNanosecond(?)))) GROUP BY `Attributes`)) WHERE `_cerb_n` > 0) WHERE (throwIf(((length(`_hq_scales`) > ?) OR ((? * ((least(arrayMap(mst -> greatest(?, ((arrayMax(arrayMap((sm, om, am) -> bitShiftRight((om + (length(am) - ?)), (sm - `_hq_merged_scale`)), `_hq_scales`, `_hq_pos_offsets`, `_hq_pos_buckets`)) - mst) + ?)), array(arrayMin(arrayMap((sm, om) -> bitShiftRight(om, (sm - `_hq_merged_scale`)), `_hq_scales`, `_hq_pos_offsets`))))[?], ?) * least(arrayMap(mst -> greatest(?, ((arrayMax(arrayMap((sm, om, am) -> bitShiftRight((om + (length(am) - ?)), (sm - `_hq_merged_scale`)), `_hq_scales`, `_hq_pos_offsets`, `_hq_pos_buckets`)) - mst) + ?)), array(arrayMin(arrayMap((sm, om) -> bitShiftRight(om, (sm - `_hq_merged_scale`)), `_hq_scales`, `_hq_pos_offsets`))))[?], ?)) + (least(arrayMap(mst -> greatest(?, ((arrayMax(arrayMap((sm, om, am) -> bitShiftRight((om + (length(am) - ?)), (sm - `_hq_merged_scale`)), `_hq_scales`, `_hq_neg_offsets`, `_hq_neg_buckets`)) - mst) + ?)), array(arrayMin(arrayMap((sm, om) -> bitShiftRight(om, (sm - `_hq_merged_scale`)), `_hq_scales`, `_hq_neg_offsets`))))[?], ?) * least(arrayMap(mst -> greatest(?, ((arrayMax(arrayMap((sm, om, am) -> bitShiftRight((om + (length(am) - ?)), (sm - `_hq_merged_scale`)), `_hq_scales`, `_hq_neg_offsets`, `_hq_neg_buckets`)) - mst) + ?)), array(arrayMin(arrayMap((sm, om) -> bitShiftRight(om, (sm - `_hq_merged_scale`)), `_hq_scales`, `_hq_neg_offsets`))))[?], ?)))) > ?)), 'native histogram merge exceeds the series-per-group or merged-bucket-width resource bound') = ?)))


### PR DESCRIPTION
## Summary

Closes #2866 (item 4 of #2834's split; item 3 shipped in #2864).

`avg()` is `sum()` plus one division and shares `NativeExpHistogramMergeLowerer`'s
dispatch, but `LowerExpHistogramMerge` explicitly excluded it from the sumMap
cross-series merge (#2757) regardless of shape. This drops that exclusion for
the same instant, single-group shape `sum()` is already eligible for — no
`by()`/`without()` clause, no range/query_range mode (still tracked by #2834).

## The merge needed real changes — not just the eligibility gate

The issue's own text flagged this as the thing to confirm rather than assume,
and it was right to: `expHistogramGroupMergeSumMap` built its own `AggFuncs`
and projections directly, rather than routing through the fold path's
avg-aware `expHistogramGroupMergeAggs`. So it collected no series count and
applied no division — dropping just the eligibility check would have silently
made `avg()` answer `sum()`'s value through the sumMap path.

I verified this empirically before shipping the real fix: temporarily
reverting the merge-side change alone (keeping only the eligibility-gate
drop) and re-running the new differential tests below reproduces exactly
that bug — native's output comes back at fanout's count/sum × the group's
member count (2x/3x depending on fixture), not divided at all. See the
`Homogeneous`/`ScaleNegotiation`/`SignBuckets` failures this produces.

The fix: `expHistogramGroupMergeSumMap` now also collects
`expHistogramGroupSeriesCountAgg()` (the divisor) and applies
`expHistogramAvgScaleProjections()` to its own reshape projections when
`agg` is `avg()` — mirroring `expHistogramGroupMergeFanout`'s own split
exactly, both gated on `expHistogramGroupIsAvg(agg)`. `sum()` is
byte-unaffected: `isAvg` is false, so the two new steps are no-ops for it.

## Budget guard — confirmed unchanged, with real measurements

The #2864 guard's cost formula reads only the groupArray columns
(`expHistogramGroupMergeAggsSumMap`'s Scale/Offset/BucketCounts arrays),
untouched by avg()'s extra `count()` aggregate or its division of the
already-reconstructed dense arrays. Confirmed this with a real ClickHouse
26.6 measurement (testcontainers, same methodology as the guard's own
calibration: `sum()`/`avg()` run back-to-back over the same seed, real peak
memory read from `system.query_log` after `SYSTEM FLUSH LOGS`) at four
shapes spanning both cost axes:

| rows | width | sum() peak | avg() peak | ratio |
|-----:|------:|-----------:|-----------:|------:|
| 1    | 160   | 3,896,585  | 3,904,996  | 1.0022 |
| 3741 | 160   | 43,248,972 | 44,272,619 | 1.0237 |
| 1    | 3000  | 3,874,524  | 3,904,996  | 1.0079 |
| 4096 | 1280  | 312,587,310| 312,603,078| 1.0001 |

Max divergence 2.37%, well inside the guard's own margin discipline. No
recalibration needed — documented in `exp_histogram_merge_summap_bound.go`'s
header. (The throwaway harness that produced this table was deleted before
this PR, same precedent that file's own header cites for the original
calibration.)

## Tests

- `exp_histogram_merge_summap_chdb_test.go`: five new `avg()` differential
  cases (`Avg_Homogeneous`, `Avg_ScaleNegotiation`, `Avg_ZeroBucket`,
  `Avg_SignBuckets`, `Avg_SingleSeries`), mirroring the five existing `sum()`
  cases seed-for-seed via shared fixture builders, each comparing native's
  `avg()` output against the fold path's.
- `test/spec/promql/exp_histogram_avg_merge_summap.txtar`: new TXTAR
  fixture, the `avg()` sibling of `exp_histogram_merge_summap.txtar` (same
  query/seed, mixed-Scale downscale-collapse case), regenerated via
  `just update-golden`.
- Regenerated `parity`, `solver`, `promql`, `chsql`, `codegen`, `migration`
  golden shards for the new fixture.

## Known gap

The `cardinality` baseline shard (`test/perf/cardinality-baseline/promql/`)
for the new fixture was **not** regenerated — this dev sandbox's shared host
is at 99% disk (`Cannot reserve 1.00 MiB, not enough space` from chDB,
confirmed via `df`) and severely CPU-oversubscribed (load average 45 on 8
cores) from many unrelated concurrent workloads, and the full-corpus
profiling pass couldn't complete under those conditions. This is a
release-gate-only check (`perf-guards`, no-ops on ordinary PRs per
`docs/performance.md`) — it does not block this PR's CI — but it should be
backfilled with `just update-golden cardinality` before or shortly after
this merges, so `main`'s next push/nightly cardinality ratchet run doesn't
flag the new fixture as missing a baseline.

## Test plan

- [x] `go build ./...` and `go build -tags chdb ./...`
- [x] `go test -tags chdb -race -run TestExpHistogramMergeSumMap ./internal/promql/...` (all sum + new avg cases green)
- [x] Confirmed (by temporarily reverting the merge-side fix) that the new avg differential tests fail without it
- [x] Real ClickHouse 26.6 avg-vs-sum memory calibration (table above)
- [x] `just update-golden migration parity solver promql chsql codegen` (cardinality pending — see Known gap)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)
