### PR TITLE
feat(chsql): extend fixed-accumulator rate/increase to temporality-bearing counters

### DIFF
--- a/internal/chopt/registry.go
+++ b/internal/chopt/registry.go
@@ -635,11 +635,11 @@ const (
 	// zero-clamp are both decomposed into fixed accumulators, reusing
 	// range_window.go's deltaMatrixLevelSource / deltaFirstValFrag
 	// UNCHANGED (see internal/chsql/range_window_fixed_accumulator.go's own
-	// doc, "Temporality-bearing counters"). What stays excluded is the
-	// EXACT, retention-independent DELTA-prefix aggregate mechanism (issue
-	// #2389, RangeWindow.DeltaPrefixAggregateInput != nil) — a narrower
-	// opt-in-only population needing its own separate re-plumbing, tracked
-	// at https://github.com/tsouza/cerberus/issues/2797.
+	// doc, "Temporality-bearing counters"). This includes the EXACT,
+	// retention-independent DELTA-prefix aggregate mechanism (issue #2389,
+	// RangeWindow.DeltaPrefixAggregateInput != nil) — cerberus issue #2797
+	// closed the gap that used to exclude that narrower, opt-in-only
+	// population.
 	FeatureFixedAccumulatorExtrapolated = "fixed_accumulator_extrapolated"
 
 	// FeatureSortedSlabOverTime opts eligible query_range sum_over_time() /

--- a/internal/chsql/range_window.go
+++ b/internal/chsql/range_window.go
@@ -4075,9 +4075,16 @@ func deltaMatrixLevelSource(regroupSource Frag, groupFrags []Frag) Frag {
 // emitting exactly the SQL it emits today.
 //
 // Produces the SAME output shape as deltaMatrixLevelSource (groupFrags,
-// anchor_ts, windowTemporalityAlias, window_pairs, deltaAnchorLevelsAlias)
-// so the caller's downstream mid / extrap / outer layers need no changes —
-// only how deltaAnchorLevelsAlias is computed differs.
+// anchor_ts, windowTemporalityAlias, passthroughCols, deltaAnchorLevelsAlias)
+// so the caller's downstream layers need no changes — only how
+// deltaAnchorLevelsAlias is computed differs. passthroughCols carries
+// whatever per-(series, anchor) columns the caller's own regroupSource holds
+// besides the group/anchor/temporality keys — the array-fold matrix emitter
+// passes ["window_pairs"], while the fixed-accumulator sibling
+// (range_window_fixed_accumulator.go's fixedAccumRegroupLayer) passes its own
+// scalar accumulator alias list — this function never reads the columns'
+// CONTENTS, only relays them, so genericising over the name list needs no
+// behavioural change to the two DELTA-prefix streams themselves.
 //
 // Two DISJOINT, per-anchor cumulative streams are summed, mirroring
 // deltaPrefixAggregateSource's own two-term split:
@@ -4205,12 +4212,23 @@ func (e *emitter) deltaMatrixLevelSourceAggregate(
 	r *chplan.RangeWindow,
 	regroupSource Frag,
 	groupFrags []Frag,
+	passthroughCols []string,
 	end Frag,
 	stepNS, rangeNS, numAnchors int64,
 ) (Frag, error) {
 	groupColumns, err := plainGroupColumnNames(r.GroupBy)
 	if err != nil {
 		return nil, err
+	}
+	selectPassthrough := func(q *QueryBuilder) {
+		for _, col := range passthroughCols {
+			q.Select(Col(col))
+		}
+	}
+	selectPassthroughQualified := func(q *QueryBuilder, qualifier string) {
+		for _, col := range passthroughCols {
+			q.Select(As(Qual(qualifier, col), col))
+		}
 	}
 
 	// Raw stream — deltaMatrixLevelSource's own shape, but the cumulative
@@ -4219,7 +4237,7 @@ func (e *emitter) deltaMatrixLevelSourceAggregate(
 	increments.Select(groupFrags...)
 	increments.Select(Col("anchor_ts"))
 	increments.Select(Col(windowTemporalityAlias))
-	increments.Select(Col("window_pairs"))
+	selectPassthrough(increments)
 	increments.Select(As(deltaPrefixSumFrag(Col(deltaPrefixPairsAlias)), deltaPrefixStepAlias))
 	increments.Select(As(
 		deltaPrefixBucketStartFrag(rangeStartFrag(Col("anchor_ts"), rangeNS)),
@@ -4233,7 +4251,7 @@ func (e *emitter) deltaMatrixLevelSourceAggregate(
 	rawLevels.Select(groupFrags...)
 	rawLevels.Select(Col("anchor_ts"))
 	rawLevels.Select(Col(windowTemporalityAlias))
-	rawLevels.Select(Col("window_pairs"))
+	selectPassthrough(rawLevels)
 	rawLevels.Select(As(
 		Window(
 			Call("sum", Col(deltaPrefixStepAlias)),
@@ -4267,7 +4285,7 @@ func (e *emitter) deltaMatrixLevelSourceAggregate(
 	}
 	preJoin.Select(As(Qual("w", "anchor_ts"), "anchor_ts"))
 	preJoin.Select(As(Qual("w", windowTemporalityAlias), windowTemporalityAlias))
-	preJoin.Select(As(Qual("w", "window_pairs"), "window_pairs"))
+	selectPassthroughQualified(preJoin, "w")
 	preJoin.Select(As(Qual("w", deltaPrefixRawDayLevelAlias), deltaPrefixRawDayLevelAlias))
 	preJoin.Select(As(
 		Call("ifNull", Qual("af", deltaPrefixAggregateMatrixStepAlias), InlineLit(0)),
@@ -4286,7 +4304,7 @@ func (e *emitter) deltaMatrixLevelSourceAggregate(
 	}
 	aggLevels.Select(Col("anchor_ts"))
 	aggLevels.Select(Col(windowTemporalityAlias))
-	aggLevels.Select(Col("window_pairs"))
+	selectPassthrough(aggLevels)
 	aggLevels.Select(Col(deltaPrefixRawDayLevelAlias))
 	partition := make([]Frag, 0, len(groupColumns))
 	for _, col := range groupColumns {
@@ -4314,7 +4332,7 @@ func (e *emitter) deltaMatrixLevelSourceAggregate(
 	}
 	final.Select(Col("anchor_ts"))
 	final.Select(Col(windowTemporalityAlias))
-	final.Select(Col("window_pairs"))
+	selectPassthrough(final)
 	final.Select(As(
 		Add(
 			Call("ifNull", Col(deltaPrefixRawDayLevelAlias), InlineLit(0)),
@@ -4578,7 +4596,7 @@ func (e *emitter) emitWindowedArrayExtrapolatedMatrix(r *chplan.RangeWindow, kin
 	)
 	if needsDeltaFirstLevel {
 		if useAggregateDeltaPrefix {
-			regroupSource, err = e.deltaMatrixLevelSourceAggregate(r, regroupSource, groupFrags, end, stepNS, rangeNS, numAnchors)
+			regroupSource, err = e.deltaMatrixLevelSourceAggregate(r, regroupSource, groupFrags, []string{"window_pairs"}, end, stepNS, rangeNS, numAnchors)
 			if err != nil {
 				return err
 			}

--- a/internal/chsql/range_window_fixed_accumulator.go
+++ b/internal/chsql/range_window_fixed_accumulator.go
@@ -75,20 +75,28 @@ import (
 // RECONSTRUCTED first_val for a DELTA series: a single DELTA sample is an
 // increment, not a running total, so feeding it directly into "did the
 // counter start inside this window" arithmetic answers the wrong question.
-// That reconstruction — the running per-anchor level built from
-// deltaPrefixPairsAlias / deltaPrefixSumFrag, range_window.go's own
-// deltaMatrixLevelSource / deltaFirstValFrag — is REUSED UNCHANGED here
-// (fixedAccumDeltaLevelSource is its pass-through sibling, carrying this
-// file's own scalar accumulator columns instead of a window_pairs array).
-// The reconstruction's OWN prefix array (deltaPrefixPairsAlias) is a
-// genuinely separate, already-small array (bounded by
-// e.deltaPrefixLookbackNS, not the window itself) — issue #2760's proposal
-// itself calls this piece "anchor-grid level and unaffected", so it is not
-// part of what this rewrite targets.
+// That reconstruction is one of two, mutually exclusive mechanisms — both
+// REUSED UNCHANGED from range_window.go, carrying this file's own scalar
+// accumulator columns as their passthrough instead of a window_pairs array
+// (fixedAccumDeltaLevelSource / the deltaMatrixLevelSourceAggregate call in
+// fixedAccumRegroupLayer are the pass-through siblings that wire this in):
+//
+//   - the default, BOUNDED-LOOKBACK approximation: a running per-anchor level
+//     built from deltaPrefixPairsAlias / deltaPrefixSumFrag,
+//     deltaMatrixLevelSource / deltaFirstValFrag (bounded by
+//     e.deltaPrefixLookbackNS, not the window itself).
+//   - cerberus issue #2389's EXACT, retention-independent DELTA-prefix
+//     aggregate mechanism, selected only when both
+//     r.DeltaPrefixAggregateInput != nil AND e.deltaPrefixReadEnabled
+//     (useAggregateDeltaPrefix, mirroring
+//     emitWindowedArrayExtrapolatedMatrix's own gate exactly):
+//     deltaMatrixLevelSourceAggregate reads a schema-provisioned
+//     DeltaPrefixTable instead of an unbounded/lookback-bounded raw scan.
 //
 // Getting there needs the array-fold's OWN sample-anchor fan-out
 // (windowedMatrixFanoutAnchorTsFrag) and scan bound
-// (applyMatrixFanoutScanBound), reused UNCHANGED: a temporality-bearing
+// (applyMatrixFanoutScanBound / applyMatrixFanoutScanBoundAggregate for the
+// useAggregateDeltaPrefix arm), reused UNCHANGED: a temporality-bearing
 // fan-out assigns a raw sample to EITHER its covering anchors' actual
 // windows OR (for a DELTA sample outside every window) a "prefix" anchor
 // supplying history for the reconstruction — the two are mutually exclusive
@@ -103,17 +111,12 @@ import (
 //
 // # Scope (this cut)
 //
-// Eligibility (fixedAccumulatorEligible, internal/promql/lower_strategy.go)
-// still requires DeltaPrefixAggregateInput == nil — the EXACT,
-// retention-independent DELTA-prefix aggregate mechanism (cerberus issue
-// #2389, deltaMatrixLevelSourceAggregate / deltaPrefixAggregateRawAnchorArrayFrag)
-// is a narrower, opt-in-only population (gated behind
-// config.Config.DeltaPrefixReadEnabled AND a schema-provisioned
-// DeltaPrefixTable) with its own separate re-plumbing needed; see
-// https://github.com/tsouza/cerberus/issues/2797. Every window using that
-// mechanism keeps the unchanged array-fold emission — a strict fallback
-// narrowing, never a regression (the plain fan-out remains the permanent,
-// fully-functional path for anything this feature does not claim).
+// Every RangeWindow shape the array-fold path supports for the EXTRAPOLATED
+// matrix family is now eligible (fixedAccumulatorEligible,
+// internal/promql/lower_strategy.go), including both DELTA-prefix
+// reconstruction mechanisms above (cerberus issue #2797). The plain fan-out
+// remains the permanent, fully-functional fallback for the excluded shapes
+// (rw.Identity, the INSTANT single-anchor shape, rw.Variants != nil).
 const (
 	// fixedAccumFirstTsAlias / fixedAccumLastTsAlias / fixedAccumFirstValAlias
 	// deliberately match the array-fold path's own "first_ts" / "last_ts" /
@@ -138,13 +141,13 @@ const (
 )
 
 // fixedAccumulatorMatrixShapeCheck validates the RangeWindow fields this
-// emitter needs, mirroring lagAdjacencyMatrixShapeCheck. The
-// DeltaPrefixAggregateInput guard is defense-in-depth:
-// promql.fixedAccumulatorEligible already excludes it at lowering time, so a
-// plan reaching here with it set means FixedAccumulatorExtrapolated was set
-// by something other than the boot-wired strategies — fail loudly rather
-// than silently ignore the side-scan (the same hazard
-// nativeTSGridMatrixNode's own guards name).
+// emitter needs, mirroring lagAdjacencyMatrixShapeCheck. r.DeltaPrefixAggregateInput
+// is intentionally NOT rejected here (cerberus issue #2797) — a set value is
+// a valid, eligible shape now; emitFixedAccumulatorExtrapolatedMatrix reads
+// it (gated behind e.deltaPrefixReadEnabled, the same runtime knob
+// emitWindowedArrayExtrapolatedMatrix consults) to select
+// deltaMatrixLevelSourceAggregate instead of the bounded-lookback
+// approximation.
 func fixedAccumulatorMatrixShapeCheck(r *chplan.RangeWindow) error {
 	if r.TimestampColumn == "" {
 		return fmt.Errorf("%w: RangeWindow.TimestampColumn unset", ErrUnsupported)
@@ -154,9 +157,6 @@ func fixedAccumulatorMatrixShapeCheck(r *chplan.RangeWindow) error {
 	}
 	if r.OuterRange <= 0 || r.Step <= 0 {
 		return fmt.Errorf("%w: RangeWindow.FixedAccumulatorExtrapolated requires a matrix (OuterRange > 0, Step > 0) window", ErrUnsupported)
-	}
-	if r.DeltaPrefixAggregateInput != nil {
-		return fmt.Errorf("%w: RangeWindow.FixedAccumulatorExtrapolated does not support DeltaPrefixAggregateInput (issue #2797)", ErrUnsupported)
 	}
 	return nil
 }
@@ -173,16 +173,16 @@ func fixedAccumulatorMatrixShapeCheck(r *chplan.RangeWindow) error {
 // The scan is bounded here, at the EARLIEST point over raw innerSub —
 // mirroring lagAdjacencyAnnotateLayer's own pushdown, so ClickHouse prunes
 // granules before any window function runs. A temporality-bearing window
-// (needsDeltaFirstLevel) needs the WIDER bound applyMatrixFanoutScanBound
-// already computes (admitting DELTA-temporality rows arbitrarily far back,
-// up to e.deltaPrefixLookbackNS, for the level reconstruction); that bound is
-// a pure function of the raw row's own srcTs (never of which anchor it will
-// later be assigned to), so applying it here rather than after the fan-out
-// is equivalent and prunes earlier.
+// (needsDeltaFirstLevel) needs the WIDER bound applyMatrixFanoutScanBound (or,
+// when useAggregateDeltaPrefix selects the exact #2389 mechanism,
+// applyMatrixFanoutScanBoundAggregate) already computes; that bound is a pure
+// function of the raw row's own srcTs (never of which anchor it will later be
+// assigned to), so applying it here rather than after the fan-out is
+// equivalent and prunes earlier.
 func (e *emitter) fixedAccumDedupLayer(
 	r *chplan.RangeWindow, innerSub Frag, groupFrags []Frag, srcTs string,
-	end Frag, stepNS, rangeNS, numAnchors int64, needsDeltaFirstLevel bool,
-) *QueryBuilder {
+	end Frag, stepNS, rangeNS, numAnchors int64, needsDeltaFirstLevel, useAggregateDeltaPrefix bool,
+) (*QueryBuilder, error) {
 	orderBy := []OrderKey{{Expr: Col(srcTs)}, {Expr: Col(r.ValueColumn)}}
 	leadFrame := RowsCurrentRowToUnboundedFollowing()
 	hasTemporality := windowTemporalityProjected(r)
@@ -198,7 +198,13 @@ func (e *emitter) fixedAccumDedupLayer(
 		Neq(WindowFrame(Call("leadInFrame", Col(srcTs)), groupFrags, orderBy, leadFrame), Col(srcTs)),
 		lagAdjIsLastOfRunAlias,
 	))
-	e.applyMatrixFanoutScanBound(tag, r, srcTs, end, stepNS, rangeNS, numAnchors, needsDeltaFirstLevel)
+	if useAggregateDeltaPrefix {
+		if err := e.applyMatrixFanoutScanBoundAggregate(tag, r, srcTs, end, stepNS, rangeNS, numAnchors); err != nil {
+			return nil, err
+		}
+	} else {
+		e.applyMatrixFanoutScanBound(tag, r, srcTs, end, stepNS, rangeNS, numAnchors, needsDeltaFirstLevel)
+	}
 
 	dedup := NewQuery().From(tag.Frag())
 	dedup.Select(groupFrags...)
@@ -208,7 +214,7 @@ func (e *emitter) fixedAccumDedupLayer(
 		dedup.Select(Col(r.TemporalityColumn))
 	}
 	dedup.Where(Col(lagAdjIsLastOfRunAlias))
-	return dedup
+	return dedup, nil
 }
 
 // fixedAccumLagLayer tags each ALREADY-DEDUPED row (fixedAccumDedupLayer's
@@ -369,9 +375,13 @@ func fixedAccumDeltaLevelSource(regroupSource Frag, groupFrags []Frag, passthrou
 // windowedMatrixFanoutAnchorTsFrag split for the identical reason.
 func (e *emitter) fixedAccumRegroupLayer(
 	r *chplan.RangeWindow, innerSub Frag, groupFrags []Frag, srcTs string, end Frag,
-	stepNS, rangeNS, numAnchors int64, hasTemporality, needsResetTerm, needsDeltaFirstLevel bool,
-) Frag {
-	dedupSource := e.fixedAccumDedupLayer(r, innerSub, groupFrags, srcTs, end, stepNS, rangeNS, numAnchors, needsDeltaFirstLevel).Frag()
+	stepNS, rangeNS, numAnchors int64, hasTemporality, needsResetTerm, needsDeltaFirstLevel, useAggregateDeltaPrefix bool,
+) (Frag, error) {
+	dedupQuery, err := e.fixedAccumDedupLayer(r, innerSub, groupFrags, srcTs, end, stepNS, rangeNS, numAnchors, needsDeltaFirstLevel, useAggregateDeltaPrefix)
+	if err != nil {
+		return nil, err
+	}
+	dedupSource := dedupQuery.Frag()
 
 	preFanoutSource := dedupSource
 	if needsResetTerm {
@@ -390,7 +400,7 @@ func (e *emitter) fixedAccumRegroupLayer(
 		fanout.Select(Col(r.TemporalityColumn))
 	}
 	fanout.Select(RawAs(
-		windowedMatrixFanoutAnchorTsFrag(r, end, srcTs, stepNS, rangeNS, numAnchors, needsDeltaFirstLevel, false),
+		windowedMatrixFanoutAnchorTsFrag(r, end, srcTs, stepNS, rangeNS, numAnchors, needsDeltaFirstLevel, useAggregateDeltaPrefix),
 		RangeWindowAnchorAlias,
 	))
 
@@ -455,9 +465,16 @@ func (e *emitter) fixedAccumRegroupLayer(
 		if needsResetTerm {
 			passthrough = append(passthrough, fixedAccumResetSumAlias)
 		}
-		regroupSource = fixedAccumDeltaLevelSource(regroupSource, groupFrags, passthrough)
+		if useAggregateDeltaPrefix {
+			regroupSource, err = e.deltaMatrixLevelSourceAggregate(r, regroupSource, groupFrags, passthrough, end, stepNS, rangeNS, numAnchors)
+			if err != nil {
+				return nil, err
+			}
+		} else {
+			regroupSource = fixedAccumDeltaLevelSource(regroupSource, groupFrags, passthrough)
+		}
 	}
-	return regroupSource
+	return regroupSource, nil
 }
 
 // emitFixedAccumulatorExtrapolatedMatrix is the fixed-accumulator sibling of
@@ -510,9 +527,16 @@ func (e *emitter) emitFixedAccumulatorExtrapolatedMatrix(r *chplan.RangeWindow, 
 	// flag exactly: a temporality-bearing counter window (delta() never
 	// carries TemporalityColumn, so this is always false for that kind).
 	needsDeltaFirstLevel := hasTemporality && kind.isCounter()
+	// useAggregateDeltaPrefix mirrors emitWindowedArrayExtrapolatedMatrix's own
+	// gate exactly (cerberus issue #2389's exact, retention-independent
+	// DELTA-prefix aggregate mechanism) — see this file's own doc comment.
+	useAggregateDeltaPrefix := needsDeltaFirstLevel && r.DeltaPrefixAggregateInput != nil && e.deltaPrefixReadEnabled
 
-	regroupSource := e.fixedAccumRegroupLayer(r, innerSub, groupFrags, srcTs, end,
-		stepNS, rangeNS, numAnchors, hasTemporality, needsResetTerm, needsDeltaFirstLevel)
+	regroupSource, err := e.fixedAccumRegroupLayer(r, innerSub, groupFrags, srcTs, end,
+		stepNS, rangeNS, numAnchors, hasTemporality, needsResetTerm, needsDeltaFirstLevel, useAggregateDeltaPrefix)
+	if err != nil {
+		return err
+	}
 
 	extrap := NewQuery().From(regroupSource)
 	extrap.Select(groupFrags...)

--- a/internal/chsql/range_window_fixed_accumulator_delta_prefix_aggregate_chdb_test.go
+++ b/internal/chsql/range_window_fixed_accumulator_delta_prefix_aggregate_chdb_test.go
@@ -1,0 +1,200 @@
+//go:build chdb
+
+package chsql
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"math"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/tsouza/cerberus/internal/chplan"
+	"github.com/tsouza/cerberus/internal/chsqltest"
+	"github.com/tsouza/cerberus/internal/schema"
+)
+
+// This file is range_window_fixed_accumulator_chdb_test.go's own sibling for
+// cerberus issue #2797's third proposal item: the useAggregateDeltaPrefix
+// variant (issue #2389's exact, retention-independent DELTA-prefix aggregate
+// mechanism) of the fixed-accumulator decomposition. It lives in package
+// chsql, like range_window_delta_prefix_aggregate_matrix_chdb_test.go, rather
+// than package chsql_test like range_window_fixed_accumulator_chdb_test.go:
+// it needs deltaPrefixCanonicalizedMatrixWindow's direct RangeWindow
+// construction (setting DeltaPrefixAggregateInput), which only a
+// promql-level DELTA-prefix-aware lowering pass would otherwise reach —
+// no such pass exists yet, mirroring why the OTHER #2389 dual-mechanism
+// tests (TestDeltaMatrixAggregateSource_*) also bypass promql lowering.
+//
+// The comparison discipline mirrors TestFixedAccumulatorRateIncrease_DualEmitParity
+// (range_window_fixed_accumulator_chdb_test.go): the SAME RangeWindow shape
+// (DeltaPrefixAggregateInput set, deltaPrefixReadEnabled=true, so BOTH arms
+// resolve useAggregateDeltaPrefix=true) is emitted TWICE — once with
+// FixedAccumulatorExtrapolated=false (array-fold,
+// deltaMatrixLevelSourceAggregate fed "window_pairs") and once with it true
+// (this cut's own emitFixedAccumulatorExtrapolatedMatrix, feeding the SAME
+// deltaMatrixLevelSourceAggregate its own scalar accumulator columns
+// instead) — proving fixedAccumRegroupLayer's useAggregateDeltaPrefix wiring
+// reconstructs the identical DELTA level and rate() value. The fixture's
+// window samples are a monotonic (no counter-reset) walk, so reset_sum is
+// exactly 0 on both arms and this assertion can stay a tight absolute
+// tolerance — mirroring TestDeltaMatrixAggregateSource_UniformLayout's own
+// 1e-9 convention in this same package — rather than needing an
+// engine-measured ULP budget the way the reset-correction-bearing path in
+// range_window_fixed_accumulator_chdb_test.go does.
+func TestFixedAccumulatorDeltaPrefixAggregate_DualEmitParity(t *testing.T) {
+	db := chsqltest.OpenIsolatedChDB(t)
+	deltaPrefixAggregateSeedDDL(t, db)
+
+	insertDeltaMatrixWindowSamples(t, db, `map('job', 'fx-agg')`, "fx-agg")
+	// History strictly before the grid's own day, backfilled into BOTH the
+	// base table (the oracle/never-backfilled tests' own raw-remainder
+	// source) and the aggregate table (deltaMatrixLevelSourceAggregate's
+	// own day-bucket source) — the uniform-layout shape
+	// TestDeltaMatrixAggregateSource_UniformLayout already proves matches
+	// the unbounded-raw-scan oracle exactly, so it is large enough here to
+	// move the reconstructed level (and therefore the counter zero-clamp)
+	// away from the window's own tiny raw first sample.
+	if _, err := db.Exec(`INSERT INTO otel_metrics_sum VALUES
+		(1, map('job', 'fx-agg'), toDateTime64('2026-01-10 00:00:00', 9), 100)`); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.Exec(`INSERT INTO otel_metrics_sum_delta_prefix VALUES
+		(map('job', 'fx-agg'), toDateTime64('2026-01-10 00:00:00', 9), 100)`); err != nil {
+		t.Fatal(err)
+	}
+
+	fanoutWindow := deltaPrefixCanonicalizedMatrixWindow(
+		deltaMatrixTestStart, deltaMatrixTestEnd, deltaMatrixTestStep, deltaMatrixTestRange,
+		"otel_metrics_sum_delta_prefix",
+	)
+	fixedWindow := deltaPrefixCanonicalizedMatrixWindow(
+		deltaMatrixTestStart, deltaMatrixTestEnd, deltaMatrixTestStep, deltaMatrixTestRange,
+		"otel_metrics_sum_delta_prefix",
+	)
+	fixedWindow.FixedAccumulatorExtrapolated = true
+
+	fanout := runDeltaMatrixPrefixQuery(t, db, fanoutWindow, 0, true)["fx-agg"]
+	fixed := runDeltaMatrixPrefixQuery(t, db, fixedWindow, 0, true)["fx-agg"]
+
+	if len(fanout) == 0 {
+		t.Fatal("array-fold (useAggregateDeltaPrefix) produced zero rows — fixture must yield a populated grid")
+	}
+	if len(fixed) != len(fanout) {
+		t.Fatalf("row-count divergence: fanout=%d fixed=%d\nfanout=%v\nfixed=%v", len(fanout), len(fixed), fanout, fixed)
+	}
+	for anchorMs, fv := range fanout {
+		xv, ok := fixed[anchorMs]
+		if !ok {
+			t.Errorf("anchor %d: present in array-fold but absent in fixed-accumulator", anchorMs)
+			continue
+		}
+		if math.IsNaN(fv) || math.IsNaN(xv) {
+			t.Errorf("anchor %d: non-finite value: fanout=%v fixed=%v", anchorMs, fv, xv)
+			continue
+		}
+		if math.Abs(fv-xv) > 1e-9 {
+			t.Errorf("anchor %d: array-fold=%v, fixed-accumulator=%v — useAggregateDeltaPrefix reconstruction must match exactly", anchorMs, fv, xv)
+		}
+	}
+
+	// Belt-and-suspenders: the reconstructed level itself (first_val), not
+	// just the post-clamp rate() value — see runDeltaMatrixPrefixLevelQuery's
+	// own doc on why a Value-only match alone can coincidentally agree
+	// despite a genuinely different reconstruction (clamp saturation).
+	//
+	// The array-fold arm reads runDeltaMatrixPrefixLevelQuery unchanged — its
+	// own "extrap" layer's first_val IS the fully DELTA-reconstructed value
+	// (range_window.go's mid-layer deltaFirstValFrag already folds
+	// delta_anchor_levels into it). The fixed-accumulator arm needs its own
+	// reader (runFixedAccumMatrixPrefixLevelQuery below): its "extrap" layer
+	// deliberately keeps first_val RAW — fixedAccumCounterDeltaFrag's
+	// CUMULATIVE telescoping term (last_val - first_val) needs the raw value
+	// too, so the reconstruction is folded into the final Value expression
+	// inline (fixedAccumClampFirstValFrag) rather than materialized as its
+	// own first_val column. Reading raw first_val here would silently strip
+	// the reconstruction back out and defeat this exact check.
+	fanoutLevel := runDeltaMatrixPrefixLevelQuery(t, db, fanoutWindow, 0, true)["fx-agg"]
+	fixedLevel := runFixedAccumMatrixPrefixLevelQuery(t, db, fixedWindow, 0, true)["fx-agg"]
+	if len(fixedLevel) != len(fanoutLevel) {
+		t.Fatalf("level row-count divergence: fanout=%d fixed=%d\nfanout=%v\nfixed=%v", len(fanoutLevel), len(fixedLevel), fanoutLevel, fixedLevel)
+	}
+	for anchorMs, fv := range fanoutLevel {
+		xv, ok := fixedLevel[anchorMs]
+		if !ok {
+			t.Errorf("anchor %d: level present in array-fold but absent in fixed-accumulator", anchorMs)
+			continue
+		}
+		if math.Abs(fv-xv) > 1e-9 {
+			t.Errorf("anchor %d: array-fold first_val=%v, fixed-accumulator first_val=%v — reconstructed DELTA level must match exactly", anchorMs, fv, xv)
+		}
+	}
+	t.Logf("useAggregateDeltaPrefix dual-emit parity: %d/%d anchors match (array-fold == fixed-accumulator, both Value and reconstructed first_val)", len(fanout), len(fanout))
+}
+
+// runFixedAccumMatrixPrefixLevelQuery is runDeltaMatrixPrefixLevelQuery's
+// fixed-accumulator sibling. It cannot reuse that helper unchanged: the
+// array-fold emitter's own "extrap" layer already carries the fully
+// DELTA-reconstructed value under the name first_val (range_window.go's
+// mid-layer deltaFirstValFrag folds delta_anchor_levels into it before
+// extrap ever sees it), but the fixed-accumulator emitter's "extrap" layer
+// (range_window_fixed_accumulator.go's emitFixedAccumulatorExtrapolatedMatrix)
+// deliberately keeps first_val RAW — fixedAccumCounterDeltaFrag's own
+// CUMULATIVE telescoping term (last_val - first_val) reads that same column
+// and needs the RAW window-first value, not the reconstructed level — so the
+// reconstruction is instead folded into the final Value expression inline,
+// via fixedAccumClampFirstValFrag, and never materialized as its own column.
+// This helper reproduces that exact fold (temporality, delta_anchor_levels,
+// first_val — all three already pass through extrap, see
+// emitFixedAccumulatorExtrapolatedMatrix's needsDeltaFirstLevel branch) in
+// the wrapping SQL so it reads the SAME reconstructed quantity
+// runDeltaMatrixPrefixLevelQuery reads off the array-fold arm.
+func runFixedAccumMatrixPrefixLevelQuery(
+	t *testing.T, db *sql.DB, r *chplan.RangeWindow, lookback time.Duration, readEnabled bool,
+) map[string]map[int64]float64 {
+	t.Helper()
+	ctx := WithDeltaPrefixLookback(context.Background(), lookback)
+	ctx = WithDeltaPrefixReadEnabled(ctx, readEnabled)
+	sqlText, args, err := Emit(ctx, r)
+	if err != nil {
+		t.Fatalf("Emit(lookback=%s, readEnabled=%v): %v", lookback, readEnabled, err)
+	}
+	inner := strings.TrimSuffix(strings.TrimSpace(sqlText), ";")
+	const outerFromMarker = " FROM ("
+	idx := strings.Index(inner, outerFromMarker)
+	if idx == -1 {
+		t.Fatalf("runFixedAccumMatrixPrefixLevelQuery: no outer FROM found in:\n%s", inner)
+	}
+	rest := inner[idx+len(outerFromMarker):]
+	wrapped := fmt.Sprintf(
+		"SELECT Attributes['job'] AS job, toUnixTimestamp64Milli(anchor_ts) AS anchor_ms, "+
+			"if(%s = %d, %s + %s, %s) AS first_val FROM (%s",
+		windowTemporalityAlias, schema.AggregationTemporalityDelta,
+		deltaAnchorLevelsAlias, fixedAccumFirstValAlias, fixedAccumFirstValAlias,
+		rest,
+	)
+	rows, err := db.Query(wrapped, args...)
+	if err != nil {
+		t.Fatalf("level query(lookback=%s, readEnabled=%v): %v\n%s", lookback, readEnabled, err, wrapped)
+	}
+	defer func() { _ = rows.Close() }()
+	out := map[string]map[int64]float64{}
+	for rows.Next() {
+		var job string
+		var anchorMs int64
+		var firstVal float64
+		if err := rows.Scan(&job, &anchorMs, &firstVal); err != nil {
+			t.Fatalf("level scan(lookback=%s, readEnabled=%v): %v", lookback, readEnabled, err)
+		}
+		if out[job] == nil {
+			out[job] = map[int64]float64{}
+		}
+		out[job][anchorMs] = firstVal
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatalf("level rows(lookback=%s, readEnabled=%v): %v", lookback, readEnabled, err)
+	}
+	return out
+}

--- a/internal/chsql/range_window_matrix_delta_prefix_guard_test.go
+++ b/internal/chsql/range_window_matrix_delta_prefix_guard_test.go
@@ -285,7 +285,7 @@ func TestDeltaMatrixLevelSourceAggregate_EmptyGroupFragsDoesNotPanic(t *testing.
 	// numAnchors=3, stepNS/rangeNS arbitrary but nonzero — only
 	// groupFrags'/groupColumns' emptiness matters for the capacity hints
 	// under test (4133, 4180).
-	frag, err := e.deltaMatrixLevelSourceAggregate(r, regroupSource, nil, end, 10_000_000_000, 60_000_000_000, 3)
+	frag, err := e.deltaMatrixLevelSourceAggregate(r, regroupSource, nil, []string{"window_pairs"}, end, 10_000_000_000, 60_000_000_000, 3)
 	if err != nil {
 		t.Fatalf("deltaMatrixLevelSourceAggregate with empty groupFrags/GroupBy: %v", err)
 	}

--- a/internal/promql/lower_strategy.go
+++ b/internal/promql/lower_strategy.go
@@ -727,12 +727,10 @@ func (n NativeIncreaseLowerer) LowerIncrease(rw *chplan.RangeWindow, s schema.Me
 // Scope: a temporality-bearing rate()/increase() window IS eligible — see
 // chsql/range_window_fixed_accumulator.go's own doc comment
 // ("Temporality-bearing counters") for the DELTA/CUMULATIVE runtime branch
-// and the reconstructed counter zero-clamp this needs and reuses UNCHANGED
-// from the array-fold path. What stays excluded is the EXACT,
-// retention-independent DELTA-prefix aggregate mechanism (issue #2389,
-// rw.DeltaPrefixAggregateInput != nil) — a narrower opt-in-only population
-// needing its own separate re-plumbing; see
-// https://github.com/tsouza/cerberus/issues/2797.
+// and the reconstructed counter zero-clamp this needs, including BOTH the
+// bounded-lookback approximation and issue #2389's EXACT, retention-independent
+// DELTA-prefix aggregate mechanism (rw.DeltaPrefixAggregateInput != nil) —
+// cerberus issue #2797 closed the gap that used to exclude the latter.
 
 // FixedAccumulatorRateLowerer is the boot-wired RateLowerer that emits
 // RangeWindow{FixedAccumulatorExtrapolated: true} for a shape-eligible rate
@@ -816,11 +814,6 @@ func (l FixedAccumulatorDeltaLowerer) LowerDelta(rw *chplan.RangeWindow, s schem
 //     Step > 0, and both Start and End pinned — the fixed-accumulator
 //     emitter's own dedup/lag passes need the same scan-prune bound
 //     lagAdjacencyEligible's identical clause exists for.
-//   - rw.DeltaPrefixAggregateInput must be nil: the issue #2389 exact
-//     DELTA-prefix aggregate mechanism is out of scope for this cut (see
-//     chsql/range_window_fixed_accumulator.go's doc and
-//     https://github.com/tsouza/cerberus/issues/2797) — a populated side-scan
-//     declines rather than silently ignoring it.
 //   - rw.Variants must be empty: the fused multi-arm shape has its own
 //     emitter and does not participate in this decomposition.
 //
@@ -829,15 +822,16 @@ func (l FixedAccumulatorDeltaLowerer) LowerDelta(rw *chplan.RangeWindow, s schem
 // and chsql/range_window_fixed_accumulator.go's own "Temporality-bearing
 // counters" section) — the DELTA/CUMULATIVE runtime branch and the
 // reconstructed counter zero-clamp are both decomposed into fixed
-// accumulators too, not merely the no-temporality case.
+// accumulators too, not merely the no-temporality case. rw.DeltaPrefixAggregateInput
+// is likewise NOT excluded (cerberus issue #2797): the emitter reads it
+// (gated behind e.deltaPrefixReadEnabled, resolved from the runtime context,
+// not this shape predicate) to select issue #2389's exact reconstruction
+// mechanism instead of the bounded-lookback approximation.
 func fixedAccumulatorEligible(rw *chplan.RangeWindow) bool {
 	if rw.Identity {
 		return false
 	}
 	if rw.OuterRange <= 0 || rw.Step <= 0 || rw.Start.IsZero() || rw.End.IsZero() {
-		return false
-	}
-	if rw.DeltaPrefixAggregateInput != nil {
 		return false
 	}
 	return len(rw.Variants) == 0


### PR DESCRIPTION
## Summary

- Decompose `CounterOrDeltaSum`'s DELTA arm (`sum(value) - first_val`) as fixed accumulators, and re-plumb `deltaMatrixLevelSource`/`deltaMatrixLevelSourceAggregate` to consume the fixed-accumulator `first_val` instead of `window_pairs`, extending #2760's fixed-accumulator `rate()`/`increase()`/`delta()` decomposition to temporality-bearing (DELTA/CUMULATIVE) OTel Sum counters.
- Covers both the bounded-lookback approximation and issue #2389's exact, retention-independent DELTA-prefix aggregate mechanism (`useAggregateDeltaPrefix`) — `fixedAccumulatorEligible` no longer excludes `RangeWindow.DeltaPrefixAggregateInput`.
- Adds `TestFixedAccumulatorDeltaPrefixAggregate_DualEmitParity`, a differential proof (dual-emit against the array-fold) that the `useAggregateDeltaPrefix` variant reconstructs the identical DELTA level and `rate()` value.

## Test plan

- [x] Targeted `go test -tags chdb -race -run 'TestFixedAccumulator|TestDeltaMatrix|TestDeltaPrefix' ./internal/chsql/...` — all pass, including the new dual-emit parity test.
- [x] `go test -race ./internal/promql/...` and `go test -race ./internal/chsql/...` (non-chdb) — pass.
- [x] `node .github/scripts/forbid-sql-raw.mjs`, `forbid-verbatim-concat.mjs`, `forbid-chplan-fn-literal.mjs` — clean.
- [x] `gofumpt -extra` / `goimports -local` on touched files — clean.
- [ ] CI green

## Notes for reviewers

The new differential test initially failed: its "belt-and-suspenders" level check (comparing the reconstructed DELTA `first_val`, not just the post-clamp `Value`) read the wrong column for the fixed-accumulator arm. That emitter deliberately keeps `first_val` RAW in its `extrap` layer — `fixedAccumCounterDeltaFrag`'s CUMULATIVE telescoping term (`last_val - first_val`) needs the raw value too — and folds the DELTA reconstruction into the final `Value` expression inline (`fixedAccumClampFirstValFrag`) instead of materializing it as its own column, unlike the array-fold emitter. Added `runFixedAccumMatrixPrefixLevelQuery`, a dedicated reader that reproduces that same fold in the wrapping test SQL. The production emitter itself was already correct — verified by tracing `fixedAccumValueFrag` → `extrapolatedValueExpr`.

`internal/chopt/registry.go`'s `FeatureFixedAccumulatorExtrapolated` doc comment updated — it previously said the `DeltaPrefixAggregateInput` population "stays excluded", tracked at #2797; that gap is now closed.

All 3 items from #2797's proposal are addressed, so this closes the issue.
