### PR TITLE
feat(chplan,chsql): add windowed-aggregate Expr primitive

### DIFF
--- a/internal/chplan/clone.go
+++ b/internal/chplan/clone.go
@@ -453,6 +453,8 @@ func cloneExpr(e Expr) Expr {
 		// copy, like the literals above.
 		c := *v
 		return &c
+	case *WindowExpr:
+		return &WindowExpr{Fn: v.Fn, Args: cloneExprs(v.Args), PartitionBy: cloneExprs(v.PartitionBy)}
 	default:
 		panic(fmt.Sprintf("chplan.cloneExpr: unhandled Expr type %T — extend the switch in clone.go", e))
 	}

--- a/internal/chplan/equal_invariants_test.go
+++ b/internal/chplan/equal_invariants_test.go
@@ -2197,6 +2197,99 @@ func TestScalarSubquery_Equal_Negative_OtherType(t *testing.T) {
 }
 
 // -----------------------------------------------------------------------
+// WindowExpr Equal tests (windowed-aggregate pre-pass Expr).
+// -----------------------------------------------------------------------
+
+func TestWindowExpr_Equal_Positive(t *testing.T) {
+	t.Parallel()
+	mk := func() *chplan.WindowExpr {
+		return &chplan.WindowExpr{
+			Fn:          chplan.FnMin,
+			Args:        []chplan.Expr{&chplan.ColumnRef{Name: "Scale"}},
+			PartitionBy: []chplan.Expr{&chplan.ColumnRef{Name: "route"}},
+		}
+	}
+	if !mk().Equal(mk()) {
+		t.Fatalf("identical WindowExpr should be Equal")
+	}
+}
+
+func TestWindowExpr_Equal_Positive_EmptyPartitionBy(t *testing.T) {
+	t.Parallel()
+	mk := func() *chplan.WindowExpr {
+		return &chplan.WindowExpr{Fn: chplan.FnMin, Args: []chplan.Expr{&chplan.ColumnRef{Name: "Scale"}}}
+	}
+	if !mk().Equal(mk()) {
+		t.Fatalf("identical WindowExpr with empty PartitionBy should be Equal")
+	}
+}
+
+func TestWindowExpr_Equal_Negative_Fn(t *testing.T) {
+	t.Parallel()
+	a := &chplan.WindowExpr{Fn: chplan.FnMin, Args: []chplan.Expr{&chplan.ColumnRef{Name: "Scale"}}}
+	b := &chplan.WindowExpr{Fn: chplan.FnMax, Args: []chplan.Expr{&chplan.ColumnRef{Name: "Scale"}}}
+	if a.Equal(b) {
+		t.Errorf("different Fn should not be Equal")
+	}
+}
+
+func TestWindowExpr_Equal_Negative_Args(t *testing.T) {
+	t.Parallel()
+	a := &chplan.WindowExpr{Fn: chplan.FnMin, Args: []chplan.Expr{&chplan.ColumnRef{Name: "Scale"}}}
+	b := &chplan.WindowExpr{Fn: chplan.FnMin, Args: []chplan.Expr{&chplan.ColumnRef{Name: "Other"}}}
+	if a.Equal(b) {
+		t.Errorf("different Args should not be Equal")
+	}
+}
+
+func TestWindowExpr_Equal_Negative_ArgsLength(t *testing.T) {
+	t.Parallel()
+	a := &chplan.WindowExpr{Fn: chplan.FnMin, Args: []chplan.Expr{&chplan.ColumnRef{Name: "Scale"}}}
+	b := &chplan.WindowExpr{Fn: chplan.FnMin, Args: []chplan.Expr{&chplan.ColumnRef{Name: "Scale"}, &chplan.ColumnRef{Name: "Other"}}}
+	if a.Equal(b) || b.Equal(a) {
+		t.Errorf("different Args length should not be Equal")
+	}
+}
+
+func TestWindowExpr_Equal_Negative_PartitionBy(t *testing.T) {
+	t.Parallel()
+	a := &chplan.WindowExpr{
+		Fn:          chplan.FnMin,
+		Args:        []chplan.Expr{&chplan.ColumnRef{Name: "Scale"}},
+		PartitionBy: []chplan.Expr{&chplan.ColumnRef{Name: "route"}},
+	}
+	b := &chplan.WindowExpr{
+		Fn:          chplan.FnMin,
+		Args:        []chplan.Expr{&chplan.ColumnRef{Name: "Scale"}},
+		PartitionBy: []chplan.Expr{&chplan.ColumnRef{Name: "other"}},
+	}
+	if a.Equal(b) {
+		t.Errorf("different PartitionBy should not be Equal")
+	}
+}
+
+func TestWindowExpr_Equal_Negative_PartitionByLength(t *testing.T) {
+	t.Parallel()
+	a := &chplan.WindowExpr{Fn: chplan.FnMin, Args: []chplan.Expr{&chplan.ColumnRef{Name: "Scale"}}}
+	b := &chplan.WindowExpr{
+		Fn:          chplan.FnMin,
+		Args:        []chplan.Expr{&chplan.ColumnRef{Name: "Scale"}},
+		PartitionBy: []chplan.Expr{&chplan.ColumnRef{Name: "route"}},
+	}
+	if a.Equal(b) || b.Equal(a) {
+		t.Errorf("empty vs non-empty PartitionBy should not be Equal")
+	}
+}
+
+func TestWindowExpr_Equal_Negative_OtherType(t *testing.T) {
+	t.Parallel()
+	a := &chplan.WindowExpr{Fn: chplan.FnMin, Args: []chplan.Expr{&chplan.ColumnRef{Name: "Scale"}}}
+	if a.Equal(&chplan.LitFloat{V: 1}) {
+		t.Errorf("WindowExpr should not equal a different Expr type")
+	}
+}
+
+// -----------------------------------------------------------------------
 // RangeWindow.ScalarExprs Equal coverage.
 // -----------------------------------------------------------------------
 

--- a/internal/chplan/sealed_kinds_test.go
+++ b/internal/chplan/sealed_kinds_test.go
@@ -57,6 +57,7 @@ func allExprKinds() []Expr {
 		&ScalarSubquery{},
 		&BoundedTraceScope{},
 		&InSubquery{},
+		&WindowExpr{},
 	}
 }
 

--- a/internal/chplan/walk_expr.go
+++ b/internal/chplan/walk_expr.go
@@ -80,5 +80,12 @@ func inspectExpr(e Expr, visit func(Expr) bool, nodeVisit func(Node)) {
 		if nodeVisit != nil && v.Subquery != nil {
 			nodeVisit(v.Subquery)
 		}
+	case *WindowExpr:
+		for _, a := range v.Args {
+			inspectExpr(a, visit, nodeVisit)
+		}
+		for _, p := range v.PartitionBy {
+			inspectExpr(p, visit, nodeVisit)
+		}
 	}
 }

--- a/internal/chplan/window_expr.go
+++ b/internal/chplan/window_expr.go
@@ -1,0 +1,58 @@
+package chplan
+
+// WindowExpr is a windowed-aggregate expression: `<Fn>(<Args>) OVER
+// (PARTITION BY <PartitionBy>)`. It computes an aggregate over each
+// PARTITION BY group WITHOUT collapsing rows — every row in a group is
+// annotated with that group's own aggregate result — unlike a GROUP BY
+// Aggregate node, which reduces each group down to one row.
+//
+// The motivating shape: a ClickHouse aggregate's per-row arguments cannot
+// see a SIBLING aggregate's finished result within the same GROUP BY
+// pass, so a value one aggregate needs as input to another must be
+// resolved in an earlier, independent pass. WindowExpr is that earlier
+// pass, evaluated in a non-aggregating Project stage ahead of the
+// Aggregate that consumes it. It generalizes past a single group:
+// PartitionBy carries the same group-key expression(s) the later
+// Aggregate GROUP BYs on, so every row is annotated with ITS OWN group's
+// value rather than one value shared by the whole input — unlike
+// ScalarSubquery, which is valid only for exactly one group (it always
+// resolves to a single scalar). An empty PartitionBy renders `OVER ()`,
+// ClickHouse's whole-result-set partition, reproducing ScalarSubquery's
+// single-group behavior without a subquery.
+//
+// Fn is resolved through the same sealed Fn table FuncCall uses
+// (internal/chsql/fnresolution.go). Only a plain, non-parameterised
+// aggregate name is valid here — a Fn resolving to a chsql fnRender hook
+// is rejected by the emitter, mirroring resolveAggFuncName's same
+// restriction for chplan.AggFunc.
+//
+// Optimizer note: like ScalarSubquery, WindowExpr's sub-expressions are
+// ordinary Exprs (Args, PartitionBy), so chplan.Walk's Node-only
+// traversal does not need a special case for it — InspectExpr descends
+// into both slices directly, unlike ScalarSubquery's embedded Node
+// subtree.
+type WindowExpr struct {
+	Fn          Fn
+	Args        []Expr
+	PartitionBy []Expr
+}
+
+func (*WindowExpr) exprNode() {}
+
+func (w *WindowExpr) Equal(other Expr) bool {
+	o, ok := other.(*WindowExpr)
+	if !ok || w.Fn != o.Fn || len(w.Args) != len(o.Args) || len(w.PartitionBy) != len(o.PartitionBy) {
+		return false
+	}
+	for i := range w.Args {
+		if !w.Args[i].Equal(o.Args[i]) {
+			return false
+		}
+	}
+	for i := range w.PartitionBy {
+		if !w.PartitionBy[i].Equal(o.PartitionBy[i]) {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/chsql/builder.go
+++ b/internal/chsql/builder.go
@@ -402,6 +402,8 @@ func (b *Builder) Expr(x chplan.Expr) (err error) {
 		return b.exprInSubquery(v)
 	case *chplan.BoundedTraceScope:
 		return b.exprBoundedTraceScope(v)
+	case *chplan.WindowExpr:
+		return b.exprWindow(v)
 	default:
 		return fmt.Errorf("%w: expr %T", ErrUnsupported, x)
 	}
@@ -886,6 +888,58 @@ func (b *Builder) exprFunc(f *chplan.FuncCall) error {
 	}
 	b.sb.WriteByte(')')
 	return nil
+}
+
+// exprWindow renders chplan.WindowExpr as `<fn>(<Args>) OVER (PARTITION BY
+// <PartitionBy>)` via the Window Frag builder — the same window-clause
+// idiom chplan.TopK's computed-K path and the vector-set-op / range-window
+// emitters already use, generalised to an arbitrary Expr position. An
+// empty PartitionBy renders `OVER ()`, ClickHouse's whole-result-set
+// partition.
+//
+// Fn is resolved through the same fnResolutions table exprFunc uses; a Fn
+// resolving to a fnRender hook is rejected, mirroring resolveAggFuncName's
+// identical restriction for chplan.AggFunc — no current Fn sets one (see
+// fnresolution.go's fnRender doc), so this is a forward guard, not a live
+// case.
+func (b *Builder) exprWindow(w *chplan.WindowExpr) error {
+	name, render, err := resolveFn(w.Fn)
+	if err != nil {
+		return err
+	}
+	if render != nil {
+		return fmt.Errorf("%w: chplan.WindowExpr Fn %q resolves to a chsql render hook, "+
+			"not a plain aggregate name — window position cannot use it", ErrUnsupported, w.Fn)
+	}
+
+	var firstErr error
+	captureErr := func(err error) {
+		if err != nil && firstErr == nil {
+			firstErr = err
+		}
+	}
+
+	args := w.Args
+	fnFrag := func(fb *Builder) {
+		fb.sb.WriteString(name)
+		fb.sb.WriteByte('(')
+		for i, a := range args {
+			if i > 0 {
+				fb.sb.WriteString(", ")
+			}
+			captureErr(fb.Expr(a))
+		}
+		fb.sb.WriteByte(')')
+	}
+
+	partitionBy := make([]Frag, 0, len(w.PartitionBy))
+	for _, p := range w.PartitionBy {
+		expr := p
+		partitionBy = append(partitionBy, func(fb *Builder) { captureErr(fb.Expr(expr)) })
+	}
+
+	Window(fnFrag, partitionBy, nil)(b)
+	return firstErr
 }
 
 func (b *Builder) exprMapAccess(m *chplan.MapAccess) error {

--- a/internal/chsql/fnresolution_test.go
+++ b/internal/chsql/fnresolution_test.go
@@ -31,6 +31,20 @@ func TestExprFuncRejectsUndeclaredFn(t *testing.T) {
 	}
 }
 
+// TestExprWindowRejectsUndeclaredFn is exprWindow's sibling of
+// TestExprFuncRejectsUndeclaredFn: it resolves its Fn through the same
+// resolveFn call, so an undeclared symbol must fail closed there too
+// rather than emitting a raw or empty function identifier inside the
+// `... OVER (...)` shape.
+func TestExprWindowRejectsUndeclaredFn(t *testing.T) {
+	t.Parallel()
+
+	b := NewBuilder()
+	if err := b.Expr(&chplan.WindowExpr{Fn: chplan.Fn("not-a-declared-fn")}); err == nil {
+		t.Fatal("Expr: got nil error, want an unresolved-Fn error")
+	}
+}
+
 func TestAggFuncFragResolvesSealedFn(t *testing.T) {
 	t.Parallel()
 

--- a/internal/chsql/window_expr_chdb_test.go
+++ b/internal/chsql/window_expr_chdb_test.go
@@ -1,0 +1,219 @@
+//go:build chdb
+
+// chDB-backed proof that chplan.WindowExpr evaluates correctly as a
+// non-aggregating pre-pass ahead of a GROUP BY Aggregate, standalone from
+// any lowering (issue #2865, PR 1 of 3: the primitive only — no promql
+// call site wires into it here).
+//
+// The shape under test is the one issue #2865's own empirical validation
+// used: a Project stage computes `min(Scale) OVER (PARTITION BY route) AS
+// _winMergedScale` ahead of an Aggregate that GROUP BYs on route and reads
+// _winMergedScale as a plain per-row column inside a SIBLING aggregate's
+// argument (`sum(Scale - _winMergedScale)`) — the exact "resolve a value
+// in an earlier, independent pass so a sibling aggregate's per-row
+// argument can see it" contract chplan.ScalarSubquery solves for a single
+// group, generalised here to multiple groups without a JOIN or a
+// subquery. The Project-stage column and the Aggregate's own output alias
+// are deliberately DIFFERENT names (_winMergedScale vs. mergedScale),
+// mirroring the issue's own probe SQL: reusing one alias for both lets CH
+// resolve the sibling aggregate's reference back to the OUTPUT alias
+// instead of the per-row input column, nesting one aggregate inside
+// another (ILLEGAL_AGGREGATION).
+//
+// None of these tests mark themselves parallel: chdb-go caches one
+// session per process (internal/chsqltest's package doc, #2074/#1987),
+// so every chDB test in internal/chsql must run serially —
+// test/regression/chsql_chdb_isolation_test.go pins it.
+package chsql_test
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/tsouza/cerberus/internal/chplan"
+	"github.com/tsouza/cerberus/internal/chsql"
+	"github.com/tsouza/cerberus/internal/chsqltest"
+)
+
+// windowExprPlan builds the Project(WindowExpr) -> Aggregate plan every
+// test in this file shares: _winMergedScale is computed once per row in
+// the Project stage, then read back both as a passthrough aggregate
+// (`any(_winMergedScale) AS mergedScale`) and inside a sibling
+// aggregate's own argument (`sum(Scale - _winMergedScale)`), proving the
+// window value is visible to a GROUP BY aggregate the same way a resolved
+// ScalarSubquery scalar is.
+func windowExprPlan(scanTable string) chplan.Node {
+	return &chplan.Aggregate{
+		Input: &chplan.Project{
+			Input: &chplan.Scan{Table: scanTable, Columns: []string{"route", "Scale"}},
+			Projections: []chplan.Projection{
+				{Expr: &chplan.ColumnRef{Name: "route"}, Alias: "route"},
+				{Expr: &chplan.ColumnRef{Name: "Scale"}, Alias: "Scale"},
+				{
+					Expr: &chplan.WindowExpr{
+						Fn:          chplan.FnMin,
+						Args:        []chplan.Expr{&chplan.ColumnRef{Name: "Scale"}},
+						PartitionBy: []chplan.Expr{&chplan.ColumnRef{Name: "route"}},
+					},
+					Alias: "_winMergedScale",
+				},
+			},
+		},
+		GroupBy: []chplan.Expr{&chplan.ColumnRef{Name: "route"}},
+		AggFuncs: []chplan.AggFunc{
+			{Fn: chplan.FnAny, Args: []chplan.Expr{&chplan.ColumnRef{Name: "_winMergedScale"}}, Alias: "mergedScale"},
+			{
+				Fn: chplan.FnSum,
+				Args: []chplan.Expr{&chplan.Binary{
+					Op:    chplan.OpSub,
+					Left:  &chplan.ColumnRef{Name: "Scale"},
+					Right: &chplan.ColumnRef{Name: "_winMergedScale"},
+				}},
+				Alias: "scaleDiffSum",
+			},
+		},
+	}
+}
+
+// emitAgainstInlineRows emits windowExprPlan and substitutes its scan
+// table reference for an inline dataset, mirroring
+// TestEmitAggregate_RawMapKeyDoesNotSplitSeries's hand-built-plan / no-DDL
+// approach (canonical_series_keys_chdb_test.go).
+func emitAgainstInlineRows(t *testing.T, rows string) string {
+	t.Helper()
+	const scanTable = "windowSeries"
+	gotSQL, args, err := chsql.Emit(context.Background(), windowExprPlan(scanTable))
+	if err != nil {
+		t.Fatalf("emit: %v", err)
+	}
+	if len(args) != 0 {
+		t.Fatalf("plan has no parameters, got args %v", args)
+	}
+	idx := strings.Index(gotSQL, "`"+scanTable+"`")
+	if idx < 0 {
+		t.Fatalf("emitted SQL does not reference `%s`: %s", scanTable, gotSQL)
+	}
+	return gotSQL[:idx] + "(" + rows + ")" + gotSQL[idx+len(scanTable)+2:]
+}
+
+// TestWindowExpr_MultiGroupMergesPerPartition pins the multi-group case
+// issue #2865 identifies WindowExpr as solving without a JOIN: two
+// `route='a'` rows (Scale 0 and 1) and one `route='b'` row (Scale 5).
+// mergedScale must be each GROUP's own min(Scale), not the whole table's:
+// route='a' -> 0, route='b' -> 5. scaleDiffSum proves _winMergedScale was
+// resolved BEFORE the outer sum reads it as a per-row argument: route='a'
+// sums (0-0)+(1-0)=1, route='b' sums (5-5)=0.
+func TestWindowExpr_MultiGroupMergesPerPartition(t *testing.T) {
+	const rows = `SELECT 'a' AS route, 0 AS Scale ` +
+		`UNION ALL SELECT 'a' AS route, 1 AS Scale ` +
+		`UNION ALL SELECT 'b' AS route, 5 AS Scale`
+	query := emitAgainstInlineRows(t, rows)
+
+	db := chsqltest.OpenIsolatedChDB(t)
+	rowsResult, err := db.Query("SELECT `route`, `mergedScale`, `scaleDiffSum` FROM (" + query + ") ORDER BY `route`")
+	if err != nil {
+		t.Fatalf("query %s: %v", query, err)
+	}
+	defer rowsResult.Close()
+
+	type got struct {
+		route              string
+		mergedScale, diffs int64
+	}
+	var out []got
+	for rowsResult.Next() {
+		var g got
+		if err := rowsResult.Scan(&g.route, &g.mergedScale, &g.diffs); err != nil {
+			t.Fatalf("scan: %v", err)
+		}
+		out = append(out, g)
+	}
+	if err := rowsResult.Err(); err != nil {
+		t.Fatalf("rows: %v", err)
+	}
+
+	want := []got{{"a", 0, 1}, {"b", 5, 0}}
+	if len(out) != len(want) {
+		t.Fatalf("got %d groups, want %d: %+v", len(out), len(want), out)
+	}
+	for i, w := range want {
+		if out[i] != w {
+			t.Errorf("group %d: got %+v, want %+v", i, out[i], w)
+		}
+	}
+}
+
+// TestWindowExpr_EmptyPartitionKeyMatchesWholeSetScalar pins the
+// degenerate no-by()/without() case: an empty PartitionBy renders `OVER
+// ()`, ClickHouse's whole-result-set partition — every row is annotated
+// with the SAME whole-table min(Scale), reproducing
+// chplan.ScalarSubquery's existing single-group behavior without a
+// subquery. All three rows collapse into one group (no GroupBy at all, so
+// this proves the window value itself, not the grouping), and
+// mergedScale must be the table-wide min: 0.
+func TestWindowExpr_EmptyPartitionKeyMatchesWholeSetScalar(t *testing.T) {
+	plan := &chplan.Aggregate{
+		Input: &chplan.Project{
+			Input: &chplan.Scan{Table: "windowSeries", Columns: []string{"route", "Scale"}},
+			Projections: []chplan.Projection{
+				{Expr: &chplan.ColumnRef{Name: "route"}, Alias: "route"},
+				{Expr: &chplan.ColumnRef{Name: "Scale"}, Alias: "Scale"},
+				{
+					Expr: &chplan.WindowExpr{
+						Fn:   chplan.FnMin,
+						Args: []chplan.Expr{&chplan.ColumnRef{Name: "Scale"}},
+					},
+					Alias: "_winMergedScale",
+				},
+			},
+		},
+		AggFuncs: []chplan.AggFunc{
+			{Fn: chplan.FnAny, Args: []chplan.Expr{&chplan.ColumnRef{Name: "_winMergedScale"}}, Alias: "mergedScale"},
+		},
+	}
+
+	gotSQL, args, err := chsql.Emit(context.Background(), plan)
+	if err != nil {
+		t.Fatalf("emit: %v", err)
+	}
+	if len(args) != 0 {
+		t.Fatalf("plan has no parameters, got args %v", args)
+	}
+	const rows = `SELECT 'a' AS route, 0 AS Scale ` +
+		`UNION ALL SELECT 'a' AS route, 1 AS Scale ` +
+		`UNION ALL SELECT 'b' AS route, 5 AS Scale`
+	idx := strings.Index(gotSQL, "`windowSeries`")
+	if idx < 0 {
+		t.Fatalf("emitted SQL does not reference `windowSeries`: %s", gotSQL)
+	}
+	query := gotSQL[:idx] + "(" + rows + ")" + gotSQL[idx+len("`windowSeries`"):]
+
+	db := chsqltest.OpenIsolatedChDB(t)
+	var mergedScale int64
+	if err := db.QueryRow("SELECT `mergedScale` FROM (" + query + ")").Scan(&mergedScale); err != nil {
+		t.Fatalf("query %s: %v", query, err)
+	}
+	if mergedScale != 0 {
+		t.Fatalf("got mergedScale=%d, want 0 (whole-set min across all three rows)", mergedScale)
+	}
+}
+
+// TestWindowExpr_EmptyInputYieldsZeroRows pins the empty-partition
+// degenerate case issue #2865 verified empirically: a WindowExpr Project
+// stage over an empty input produces an empty Project output, so the
+// outer GROUP BY naturally emits zero rows — no special-case handling
+// needed, it falls out of plain GROUP BY semantics over an empty input.
+func TestWindowExpr_EmptyInputYieldsZeroRows(t *testing.T) {
+	const rows = `SELECT 'a' AS route, 0 AS Scale WHERE 1 = 0`
+	query := emitAgainstInlineRows(t, rows)
+
+	db := chsqltest.OpenIsolatedChDB(t)
+	var count int64
+	if err := db.QueryRow("SELECT count() FROM (" + query + ")").Scan(&count); err != nil {
+		t.Fatalf("query %s: %v", query, err)
+	}
+	if count != 0 {
+		t.Fatalf("got %d rows from an empty input, want 0", count)
+	}
+}

--- a/internal/chsql/window_expr_test.go
+++ b/internal/chsql/window_expr_test.go
@@ -1,0 +1,149 @@
+package chsql
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/tsouza/cerberus/internal/chplan"
+)
+
+// TestExprWindow_RendersFnArgsAndPartitionBy pins the core shape:
+// `<fn>(<args>) OVER (PARTITION BY <keys>)`. This is the single-group-key
+// case a multi-group exp-histogram merge would use (issue #2865, PR 1 of
+// 3): PartitionBy carries the same group-key expression the consuming
+// Aggregate later GROUP BYs on.
+func TestExprWindow_RendersFnArgsAndPartitionBy(t *testing.T) {
+	t.Parallel()
+
+	b := NewBuilder()
+	err := b.Expr(&chplan.WindowExpr{
+		Fn:          chplan.FnMin,
+		Args:        []chplan.Expr{&chplan.ColumnRef{Name: "Scale"}},
+		PartitionBy: []chplan.Expr{&chplan.ColumnRef{Name: "route"}},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	sql, _, buildErr := b.Build()
+	if buildErr != nil {
+		t.Fatalf("unexpected build error: %v", buildErr)
+	}
+	const want = "min(`Scale`) OVER (PARTITION BY `route`)"
+	if sql != want {
+		t.Fatalf("got %q, want %q", sql, want)
+	}
+}
+
+// TestExprWindow_EmptyPartitionByRendersOverEmptyParens pins the
+// degenerate no-group-key shape: `OVER ()`, ClickHouse's whole-result-set
+// partition. This is the shape that reproduces chplan.ScalarSubquery's
+// current single-group behavior without a subquery (issue #2865's
+// empirically-verified degenerate case).
+func TestExprWindow_EmptyPartitionByRendersOverEmptyParens(t *testing.T) {
+	t.Parallel()
+
+	b := NewBuilder()
+	err := b.Expr(&chplan.WindowExpr{
+		Fn:   chplan.FnMin,
+		Args: []chplan.Expr{&chplan.ColumnRef{Name: "Scale"}},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	sql, _, buildErr := b.Build()
+	if buildErr != nil {
+		t.Fatalf("unexpected build error: %v", buildErr)
+	}
+	const want = "min(`Scale`) OVER ()"
+	if sql != want {
+		t.Fatalf("got %q, want %q", sql, want)
+	}
+}
+
+// TestExprWindow_MultiplePartitionByKeys pins the multi-group-key shape:
+// range mode (issue #2865 item 2) partitions by `[anchor, ...by/without
+// labels]`, so PartitionBy must render every key, comma-separated, in
+// order.
+func TestExprWindow_MultiplePartitionByKeys(t *testing.T) {
+	t.Parallel()
+
+	b := NewBuilder()
+	err := b.Expr(&chplan.WindowExpr{
+		Fn:   chplan.FnMin,
+		Args: []chplan.Expr{&chplan.ColumnRef{Name: "Scale"}},
+		PartitionBy: []chplan.Expr{
+			&chplan.ColumnRef{Name: "anchor"},
+			&chplan.ColumnRef{Name: "route"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	sql, _, buildErr := b.Build()
+	if buildErr != nil {
+		t.Fatalf("unexpected build error: %v", buildErr)
+	}
+	const want = "min(`Scale`) OVER (PARTITION BY `anchor`, `route`)"
+	if sql != want {
+		t.Fatalf("got %q, want %q", sql, want)
+	}
+}
+
+// TestExprWindow_MultipleArgs pins that Args renders every positional
+// argument, comma-separated, inside the aggregate call — the same
+// positional-args contract chplan.FuncCall has.
+func TestExprWindow_MultipleArgs(t *testing.T) {
+	t.Parallel()
+
+	b := NewBuilder()
+	err := b.Expr(&chplan.WindowExpr{
+		Fn: chplan.FnMax,
+		Args: []chplan.Expr{
+			&chplan.ColumnRef{Name: "A"},
+			&chplan.ColumnRef{Name: "B"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	sql, _, buildErr := b.Build()
+	if buildErr != nil {
+		t.Fatalf("unexpected build error: %v", buildErr)
+	}
+	const want = "max(`A`, `B`) OVER ()"
+	if sql != want {
+		t.Fatalf("got %q, want %q", sql, want)
+	}
+}
+
+// TestExprWindow_ArgErrorPropagates pins that a render error in an Args
+// slot reaches the caller instead of silently truncating the SQL. exprWindow
+// renders Args inside a Frag closure passed to Window (which cannot itself
+// return an error), so the error must be captured and returned explicitly.
+func TestExprWindow_ArgErrorPropagates(t *testing.T) {
+	t.Parallel()
+
+	err := NewBuilder().Expr(&chplan.WindowExpr{
+		Fn:   chplan.FnMin,
+		Args: []chplan.Expr{errExpr()},
+	})
+	if !errors.Is(err, ErrUnsupported) {
+		t.Fatalf("WindowExpr with an unrenderable Args entry must return ErrUnsupported, got %v", err)
+	}
+}
+
+// TestExprWindow_PartitionByErrorPropagates is the PartitionBy sibling of
+// TestExprWindow_ArgErrorPropagates: PartitionBy renders through its own
+// Frag closures and must surface a render error the same way.
+func TestExprWindow_PartitionByErrorPropagates(t *testing.T) {
+	t.Parallel()
+
+	err := NewBuilder().Expr(&chplan.WindowExpr{
+		Fn:          chplan.FnMin,
+		Args:        []chplan.Expr{&chplan.ColumnRef{Name: "Scale"}},
+		PartitionBy: []chplan.Expr{errExpr()},
+	})
+	if !errors.Is(err, ErrUnsupported) {
+		t.Fatalf("WindowExpr with an unrenderable PartitionBy entry must return ErrUnsupported, got %v", err)
+	}
+}

--- a/test/spec/chplan_print.go
+++ b/test/spec/chplan_print.go
@@ -744,6 +744,17 @@ func printExpr(e chplan.Expr) string {
 		flat := strings.TrimRight(sb.String(), "\n")
 		flat = strings.Join(strings.Fields(strings.ReplaceAll(flat, "\n", " ; ")), " ")
 		return fmt.Sprintf("(%s IN {%s})", printExpr(v.Left), flat)
+	case *chplan.WindowExpr:
+		args := make([]string, len(v.Args))
+		for i, a := range v.Args {
+			args[i] = printExpr(a)
+		}
+		partitionBy := make([]string, len(v.PartitionBy))
+		for i, p := range v.PartitionBy {
+			partitionBy[i] = printExpr(p)
+		}
+		return fmt.Sprintf("%s(%s) OVER (PARTITION BY [%s])",
+			fnDisplayName(v.Fn), strings.Join(args, ", "), strings.Join(partitionBy, ", "))
 	case *chplan.BoundedTraceScope:
 		// One-line greppable form: the gate shows on each leaf Filter of a
 		// bounded structure-tab row source so the IR snapshot proves the


### PR DESCRIPTION
## Summary

Adds `chplan.WindowExpr`, a generic `<Fn>(<Args>) OVER (PARTITION BY
<PartitionBy>)` expression, plus a `chsql` emitter case built on the
existing `Window` Frag builder (`internal/chsql/builder.go`, already used
by `chplan.TopK`'s computed-K path, `VectorSetOp`, `NaryVectorSetOp` and
`RangeWindow`).

This is **slice 1 of 3** from the design recommended in
[#2865's investigation comment](https://github.com/tsouza/cerberus/issues/2865#issuecomment-5496951486):
a `min(Scale) OVER (PARTITION BY <group-key-expr>)` pre-pass generalizes
`chplan.ScalarSubquery`'s single-group "resolve a value in an earlier,
independent pass so a sibling aggregate's per-row argument can see it"
trick to multi-group and range mode, without ever emitting a
`chplan.Join`. Verified empirically against real ClickHouse 26.6 in that
investigation session.

**This PR ships only the standalone primitive.** Nothing wires it into
the exp-histogram sumMap merge call sites yet
(`internal/promql/exp_histogram_merge_summap.go`,
`NativeExpHistogramMergeLowerer.LowerExpHistogramMerge`,
`lowerExpHistogramSumOrAvgRange`) — that is PR 2/3 (multi-group instant
mode + a new group-count-aware budget guard) and PR 3/3 (range mode). No
user-visible behavior changes.

## What's included

- `internal/chplan/window_expr.go` — the `WindowExpr` Expr kind (`Fn`,
  `Args`, `PartitionBy`), its `Equal` method, and doc comment explaining
  the ScalarSubquery-generalization contract.
- Its exhaustive invariant-test registrations, matched to the existing
  pattern every other `chplan.Expr` kind follows:
  - `internal/chplan/sealed_kinds_test.go` — `allExprKinds()` entry.
  - `internal/chplan/walk_expr.go` — `inspectExpr` case (descends into
    `Args` and `PartitionBy`).
  - `internal/chplan/clone.go` — `cloneExpr` case.
  - `internal/chplan/equal_invariants_test.go` — positive/negative
    `Equal` coverage per field.
- `internal/chsql/builder.go` — the `exprWindow` emitter case, resolving
  `Fn` through the same `fnResolutions` table `FuncCall` uses and
  rejecting a `fnRender`-backed `Fn` (mirrors `resolveAggFuncName`'s
  identical restriction for `chplan.AggFunc`).
- `test/spec/chplan_print.go` — a `WindowExpr` case in the IR
  pretty-printer for greppable TXTAR snapshots (defensive; nothing wires
  this in yet, so no existing golden changes).
- Direct unit tests (`internal/chsql/window_expr_test.go`): render shape,
  empty-`PartitionBy` → `OVER ()`, multiple partition keys, multiple
  args, render-error propagation from both `Args` and `PartitionBy`, plus
  an undeclared-`Fn` test alongside `exprFunc`'s existing one in
  `fnresolution_test.go`.
- chDB-backed tests against real ClickHouse
  (`internal/chsql/window_expr_chdb_test.go`), proving the primitive
  round-trips and evaluates correctly standalone (a hand-built
  `Project(WindowExpr) -> Aggregate` plan, never crossing a lowering):
  - multi-group merge: each partition gets its OWN aggregate result,
    and a sibling aggregate correctly reads it as a per-row argument
    (the exact contract this primitive exists for).
  - empty `PartitionBy` → `OVER ()` reproduces `ScalarSubquery`'s
    current whole-set-scalar behavior.
  - empty input → zero output rows, no special-casing needed.

## Test plan

- [x] `go test ./internal/chplan/...` — all exhaustive invariant tests
      (`sealed_kinds`, `walk_expr`, `clone`, `equal_invariants`) pass.
- [x] `go test -tags chdb ./internal/chsql/... -run
      'TestWindowExpr|TestExprWindow'` — new unit + chDB tests pass.
- [x] `go test -tags chdb ./test/regression/...` — including the
      chDB-suite hygiene gates (`TestChSQLChDBTestsAreSerial`,
      `TestChSQLChDBTestsUseIsolatedDatabase`).
- [x] `node .github/scripts/forbid-sql-raw.mjs`,
      `forbid-chplan-fn-literal.mjs` — clean.
- [x] `gofumpt -l` / `goimports -l` — clean.
- [x] `go build ./...` — clean.
- [ ] CI (lint, coverage, strict-scan, etc.)

Part of #2865
