### PR TITLE
feat(chsql): adopt timeSeriesGroupArrayIf for the split-window groupArrayIf sites (#2862)

### DIFF
--- a/internal/chsql/range_window.go
+++ b/internal/chsql/range_window.go
@@ -2245,11 +2245,8 @@ func nativeGroupArrayPairFrag(tsCol, valCol string) Frag {
 // for a per-series (timestamp, value) sample-array assembly site, based on
 // r.NativeGroupArray (chopt.FeatureTSGridGroupArray, cerberus issue #2749).
 // Every caller of this helper is a plain, non-split-window assembly — the
-// needsDeltaFirstLevel groupArrayIf split-window sites never call it (see
-// chopt.FeatureTSGridGroupArray's doc for why they stay hand-rolled) — so
-// the choice is a pure emission-detail swap: the two idioms produce the same
-// element type, the same ascending-by-timestamp order, and (outside the NaN
-// edge case) the same deduplicated membership.
+// two idioms produce the same element type, the same ascending-by-timestamp
+// order, and (outside the NaN edge case) the same deduplicated membership.
 func seriesArrayPairFrag(r *chplan.RangeWindow, tsCol, valCol string) Frag {
 	if r.NativeGroupArray {
 		return nativeGroupArrayPairFrag(tsCol, valCol)
@@ -2257,18 +2254,63 @@ func seriesArrayPairFrag(r *chplan.RangeWindow, tsCol, valCol string) Frag {
 	return groupArrayPairFrag(tsCol, valCol)
 }
 
+// groupArrayPairIfFrag returns a Frag rendering
+// `arraySort(groupArrayIf((<ts>, <val>), <cond>))` — groupArrayPairFrag's
+// split-window sibling, used where a single fan-out row must land in one of
+// two complementary (ts, value) arrays (needsDeltaFirstLevel's window_pairs /
+// delta_prefix_pairs split in emitWindowedArrayExtrapolatedMatrix, and the
+// fixed-accumulator's own delta_prefix_pairs term).
+func groupArrayPairIfFrag(tsCol, valCol string, cond Frag) Frag {
+	return Call("arraySort",
+		Call("groupArrayIf", Tuple(Col(tsCol), Col(valCol)), cond))
+}
+
+// nativeGroupArrayPairIfFrag returns a Frag rendering
+// `timeSeriesGroupArrayIf(<tsCol>, <valCol>, <cond>)` — the native
+// ClickHouse aggregate replacement for groupArrayPairIfFrag
+// (chopt.FeatureTSGridGroupArray, cerberus issue #2862). ClickHouse's
+// generic `-If` aggregate-function combinator applies to timeSeriesGroupArray
+// like any other aggregate: measured against a real ClickHouse 25.9 server,
+// timeSeriesGroupArrayIf carries the SAME three preconditions
+// nativeGroupArrayPairFrag's own doc pins for the plain form — DateTime64(9)
+// accepted directly and losslessly, duplicate-timestamp collapse to the
+// max-valued sample among rows PASSING cond (insertion-order independent for
+// finite values), and insertion-order DEPENDENT survival on a NaN-bearing
+// duplicate — re-verified independently for the combinator form rather than
+// assumed to carry over. Callers that swap to this Frag must skip the
+// subsequent dedup step for THIS array — see seriesArrayPairIfFrag and
+// deltaPrefixSumFrag's alreadyDeduped parameter.
+func nativeGroupArrayPairIfFrag(tsCol, valCol string, cond Frag) Frag {
+	return Call("timeSeriesGroupArrayIf", Col(tsCol), Col(valCol), cond)
+}
+
+// seriesArrayPairIfFrag picks groupArrayPairIfFrag or
+// nativeGroupArrayPairIfFrag for a split-window (timestamp, value)
+// sample-array assembly site, based on r.NativeGroupArray
+// (chopt.FeatureTSGridGroupArray, cerberus issue #2862). Only
+// emitWindowedArrayExtrapolatedMatrix's needsDeltaFirstLevel branch calls
+// this — the fixed-accumulator's own delta_prefix_pairs term
+// (range_window_fixed_accumulator.go) stays on groupArrayPairIfFrag
+// unconditionally, since it never reads r.NativeGroupArray (see that file's
+// own call site).
+func seriesArrayPairIfFrag(r *chplan.RangeWindow, tsCol, valCol string, cond Frag) Frag {
+	if r.NativeGroupArray {
+		return nativeGroupArrayPairIfFrag(tsCol, valCol, cond)
+	}
+	return groupArrayPairIfFrag(tsCol, valCol, cond)
+}
+
 // matrixWindowPairsAlreadyDeduped reports whether
 // emitWindowedArrayExtrapolatedMatrix's regroup already assembled
-// `window_pairs` via the native, self-deduping timeSeriesGroupArray
+// `window_pairs` via the native, self-deduping timeSeriesGroupArray(If)
 // aggregate (r.NativeGroupArray), so its caller's dedupWindowPairsLayer step
-// can skip the arrayReverse/arrayCompact/arrayReverse triple. The
-// needsDeltaFirstLevel branch always assembles window_pairs via the
-// hand-rolled groupArrayIf split instead (chopt.FeatureTSGridGroupArray's doc
-// explains why that stays hand-rolled), so it always still needs the dedup
-// pass regardless of r.NativeGroupArray — only the plain (non-split-window)
-// assembly seriesArrayPairFrag renders is ever already deduped.
-func matrixWindowPairsAlreadyDeduped(r *chplan.RangeWindow, needsDeltaFirstLevel bool) bool {
-	return r.NativeGroupArray && !needsDeltaFirstLevel
+// can skip the arrayReverse/arrayCompact/arrayReverse triple. True
+// unconditionally whenever r.NativeGroupArray is set: the plain
+// (non-split-window) assembly reads it via seriesArrayPairFrag, and (since
+// cerberus issue #2862) the needsDeltaFirstLevel split-window assembly reads
+// it via seriesArrayPairIfFrag — both native paths self-dedup identically.
+func matrixWindowPairsAlreadyDeduped(r *chplan.RangeWindow) bool {
+	return r.NativeGroupArray
 }
 
 // dedupWindowPairsByTsFrag collapses a `arraySort`-ordered
@@ -4039,14 +4081,18 @@ func (e *emitter) emitWindowedArrayExtrapolated(r *chplan.RangeWindow, kind extr
 // deltaMatrixLevelSource attaches the reconstructed DELTA level before each
 // anchor window. The input is already one row per (series, anchor); an ordered
 // window sum avoids packing those rows into nested arrays only to expand them
-// again before extrapolation.
-func deltaMatrixLevelSource(regroupSource Frag, groupFrags []Frag) Frag {
+// again before extrapolation. deltaPrefixAlreadyDeduped is this caller's own
+// r.NativeGroupArray verdict (cerberus issue #2862): true only when
+// deltaPrefixPairsAlias was itself assembled via the native
+// timeSeriesGroupArrayIf combinator (seriesArrayPairIfFrag), which already
+// collapses duplicate timestamps — see deltaPrefixSumFrag.
+func deltaMatrixLevelSource(regroupSource Frag, groupFrags []Frag, deltaPrefixAlreadyDeduped bool) Frag {
 	increments := NewQuery().From(regroupSource)
 	increments.Select(groupFrags...)
 	increments.Select(Col("anchor_ts"))
 	increments.Select(Col(windowTemporalityAlias))
 	increments.Select(Col("window_pairs"))
-	increments.Select(As(deltaPrefixSumFrag(Col(deltaPrefixPairsAlias)), deltaPrefixStepAlias))
+	increments.Select(As(deltaPrefixSumFrag(Col(deltaPrefixPairsAlias), deltaPrefixAlreadyDeduped), deltaPrefixStepAlias))
 
 	levels := NewQuery().From(increments.Frag())
 	levels.Select(groupFrags...)
@@ -4208,11 +4254,23 @@ func (e *emitter) deltaMatrixLevelSourceAggregateDailyFanout(
 	return aggFanoutSummed, aggDailyKeys, nil
 }
 
+// deltaPrefixAlreadyDeduped is EXPLICIT, not derived from r.NativeGroupArray
+// inside this function: this function is shared between
+// emitWindowedArrayExtrapolatedMatrix's array-fold regroup (whose
+// deltaPrefixPairsAlias is built by seriesArrayPairIfFrag, natively deduped
+// exactly when r.NativeGroupArray) and
+// range_window_fixed_accumulator.go's fixedAccumRegroupLayer (whose own
+// deltaPrefixPairsAlias is ALWAYS built via the hand-rolled groupArrayIf —
+// cerberus issue #2862 only adopted the native combinator at the array-fold
+// site). Deriving the flag from r.NativeGroupArray here would wrongly skip
+// the dedup pass for the fixed-accumulator caller whenever that boot-resolved
+// flag happens to be on.
 func (e *emitter) deltaMatrixLevelSourceAggregate(
 	r *chplan.RangeWindow,
 	regroupSource Frag,
 	groupFrags []Frag,
 	passthroughCols []string,
+	deltaPrefixAlreadyDeduped bool,
 	end Frag,
 	stepNS, rangeNS, numAnchors int64,
 ) (Frag, error) {
@@ -4238,7 +4296,7 @@ func (e *emitter) deltaMatrixLevelSourceAggregate(
 	increments.Select(Col("anchor_ts"))
 	increments.Select(Col(windowTemporalityAlias))
 	selectPassthrough(increments)
-	increments.Select(As(deltaPrefixSumFrag(Col(deltaPrefixPairsAlias)), deltaPrefixStepAlias))
+	increments.Select(As(deltaPrefixSumFrag(Col(deltaPrefixPairsAlias), deltaPrefixAlreadyDeduped), deltaPrefixStepAlias))
 	increments.Select(As(
 		deltaPrefixBucketStartFrag(rangeStartFrag(Col("anchor_ts"), rangeNS)),
 		deltaPrefixAnchorDayAlias,
@@ -4558,25 +4616,11 @@ func (e *emitter) emitWindowedArrayExtrapolatedMatrix(r *chplan.RangeWindow, kin
 	if needsDeltaFirstLevel {
 		windowStart := rangeStartFrag(Col("anchor_ts"), rangeNS)
 		regroup.Select(As(
-			Call(
-				"arraySort",
-				Call(
-					"groupArrayIf",
-					Tuple(Col(srcTs), Col(r.ValueColumn)),
-					Gt(Col(srcTs), windowStart),
-				),
-			),
+			seriesArrayPairIfFrag(r, srcTs, r.ValueColumn, Gt(Col(srcTs), windowStart)),
 			"window_pairs",
 		))
 		regroup.Select(As(
-			Call(
-				"arraySort",
-				Call(
-					"groupArrayIf",
-					Tuple(Col(srcTs), Col(r.ValueColumn)),
-					Lte(Col(srcTs), windowStart),
-				),
-			),
+			seriesArrayPairIfFrag(r, srcTs, r.ValueColumn, Lte(Col(srcTs), windowStart)),
 			deltaPrefixPairsAlias,
 		))
 	} else {
@@ -4592,16 +4636,18 @@ func (e *emitter) emitWindowedArrayExtrapolatedMatrix(r *chplan.RangeWindow, kin
 	}
 	regroupSource := dedupWindowPairsLayer(
 		regroup.Frag(), groupFrags, true, hasTemporality,
-		matrixWindowPairsAlreadyDeduped(r, needsDeltaFirstLevel), extraColumns...,
+		matrixWindowPairsAlreadyDeduped(r), extraColumns...,
 	)
 	if needsDeltaFirstLevel {
 		if useAggregateDeltaPrefix {
-			regroupSource, err = e.deltaMatrixLevelSourceAggregate(r, regroupSource, groupFrags, []string{"window_pairs"}, end, stepNS, rangeNS, numAnchors)
+			regroupSource, err = e.deltaMatrixLevelSourceAggregate(
+				r, regroupSource, groupFrags, []string{"window_pairs"}, r.NativeGroupArray, end, stepNS, rangeNS, numAnchors,
+			)
 			if err != nil {
 				return err
 			}
 		} else {
-			regroupSource = deltaMatrixLevelSource(regroupSource, groupFrags)
+			regroupSource = deltaMatrixLevelSource(regroupSource, groupFrags, r.NativeGroupArray)
 		}
 	}
 
@@ -4725,11 +4771,19 @@ func firstValFrag() Frag {
 	return tupleElemFrag(Subscript(BareIdent("window_pairs"), InlineLit(int64(1))), 2)
 }
 
-func deltaPrefixSumFrag(pairs Frag) Frag {
-	deduped := dedupWindowPairsByTsFrag(pairs)
+// deltaPrefixSumFrag sums the values of a `delta_prefix_pairs`-shaped
+// (timestamp, value) array. alreadyDeduped skips the dedupWindowPairsByTsFrag
+// wrap: set only when pairs was itself assembled via a native, self-deduping
+// timeSeriesGroupArray(If) aggregate (cerberus issues #2749 / #2862) — see
+// each caller's own doc for why the flag is threaded explicitly rather than
+// read off r.NativeGroupArray inside this shared helper.
+func deltaPrefixSumFrag(pairs Frag, alreadyDeduped bool) Frag {
+	if !alreadyDeduped {
+		pairs = dedupWindowPairsByTsFrag(pairs)
+	}
 	return Call(
 		"arraySum",
-		Call("arrayMap", Lambda1("p", tupleElemFrag(BareIdent("p"), 2)), deduped),
+		Call("arrayMap", Lambda1("p", tupleElemFrag(BareIdent("p"), 2)), pairs),
 	)
 }
 

--- a/internal/chsql/range_window.go
+++ b/internal/chsql/range_window.go
@@ -2270,16 +2270,21 @@ func groupArrayPairIfFrag(tsCol, valCol string, cond Frag) Frag {
 // ClickHouse aggregate replacement for groupArrayPairIfFrag
 // (chopt.FeatureTSGridGroupArray, cerberus issue #2862). ClickHouse's
 // generic `-If` aggregate-function combinator applies to timeSeriesGroupArray
-// like any other aggregate: measured against a real ClickHouse 25.9 server,
-// timeSeriesGroupArrayIf carries the SAME three preconditions
-// nativeGroupArrayPairFrag's own doc pins for the plain form — DateTime64(9)
-// accepted directly and losslessly, duplicate-timestamp collapse to the
-// max-valued sample among rows PASSING cond (insertion-order independent for
-// finite values), and insertion-order DEPENDENT survival on a NaN-bearing
-// duplicate — re-verified independently for the combinator form rather than
-// assumed to carry over. Callers that swap to this Frag must skip the
-// subsequent dedup step for THIS array — see seriesArrayPairIfFrag and
-// deltaPrefixSumFrag's alreadyDeduped parameter.
+// like any other aggregate. timeSeriesGroupArrayIf carries the SAME three
+// preconditions nativeGroupArrayPairFrag's own doc pins for the plain form —
+// DateTime64(9) accepted directly and losslessly, duplicate-timestamp
+// collapse to the max-valued sample (insertion-order independent for finite
+// values), and insertion-order DEPENDENT survival on a NaN-bearing duplicate
+// — plus the one only the combinator form can pose: cond gates whether a row
+// reaches the fold at ALL, so the collapse runs over the rows PASSING cond
+// and a cond-failing row can never take a timestamp from a passing one. All
+// four are RE-RUN for this form rather than assumed to carry over from the
+// plain one, against a real ClickHouse at chopt.FeatureTSGridGroupArray's own
+// 25.9 floor — see range_window_group_array_realch_integration_test.go's
+// TestTimeSeriesGroupArray_IfCombinator* trio (the strict-scan lane's
+// `just ts-grid-group-array-integration` recipe). Callers that swap to this
+// Frag must skip the subsequent dedup step for THIS array — see
+// seriesArrayPairIfFrag and deltaPrefixSumFrag's alreadyDeduped parameter.
 func nativeGroupArrayPairIfFrag(tsCol, valCol string, cond Frag) Frag {
 	return Call("timeSeriesGroupArrayIf", Col(tsCol), Col(valCol), cond)
 }

--- a/internal/chsql/range_window_delta_prefix_test.go
+++ b/internal/chsql/range_window_delta_prefix_test.go
@@ -69,7 +69,7 @@ func TestDeltaPrefixAggregateRawAnchorArrayRequiresDeltaTemporality(t *testing.T
 func TestDeltaPrefixSumDeduplicatesTimestampBeforeSumming(t *testing.T) {
 	t.Parallel()
 
-	got := renderFragToSQL(deltaPrefixSumFrag(Col("prefix_pairs")))
+	got := renderFragToSQL(deltaPrefixSumFrag(Col("prefix_pairs"), false))
 	for _, want := range []string{
 		"arraySum(arrayMap(p -> tupleElement(p, 2)",
 		"arrayReverse(arrayCompact(p -> tupleElement(p, 1), arrayReverse(`prefix_pairs`)))",
@@ -77,6 +77,24 @@ func TestDeltaPrefixSumDeduplicatesTimestampBeforeSumming(t *testing.T) {
 		if !strings.Contains(got, want) {
 			t.Errorf("DELTA prefix sum missing %q\nSQL: %s", want, got)
 		}
+	}
+}
+
+// TestDeltaPrefixSumSkipsDedupeWhenAlreadyDeduped pins deltaPrefixSumFrag's
+// alreadyDeduped parameter (cerberus issue #2862): when the caller's own
+// pairs input was already assembled via a native, self-deduping
+// timeSeriesGroupArrayIf combinator, the redundant
+// arrayReverse/arrayCompact/arrayReverse dedup triple is skipped entirely —
+// only the arraySum(arrayMap(...)) reduction remains.
+func TestDeltaPrefixSumSkipsDedupeWhenAlreadyDeduped(t *testing.T) {
+	t.Parallel()
+
+	got := renderFragToSQL(deltaPrefixSumFrag(Col("prefix_pairs"), true))
+	if !strings.Contains(got, "arraySum(arrayMap(p -> tupleElement(p, 2), `prefix_pairs`))") {
+		t.Errorf("DELTA prefix sum (alreadyDeduped) should reduce `prefix_pairs` directly\nSQL: %s", got)
+	}
+	if strings.Contains(got, "arrayCompact") {
+		t.Errorf("DELTA prefix sum (alreadyDeduped) should skip the dedup triple\nSQL: %s", got)
 	}
 }
 

--- a/internal/chsql/range_window_fixed_accumulator.go
+++ b/internal/chsql/range_window_fixed_accumulator.go
@@ -456,8 +456,11 @@ func (e *emitter) fixedAccumRegroupLayer(
 	}
 	if needsDeltaFirstLevel {
 		regroup.Select(As(Call("sumIf", Col(r.ValueColumn), Gt(Col(srcTs), windowStart)), fixedAccumSumValAlias))
+		// groupArrayPairIfFrag, not seriesArrayPairIfFrag: this term stays
+		// on the hand-rolled idiom unconditionally — see
+		// fixedAccumDeltaLevelSource's own doc.
 		regroup.Select(As(
-			Call("arraySort", Call("groupArrayIf", Tuple(Col(srcTs), Col(r.ValueColumn)), Lte(Col(srcTs), windowStart))),
+			groupArrayPairIfFrag(srcTs, r.ValueColumn, Lte(Col(srcTs), windowStart)),
 			deltaPrefixPairsAlias,
 		))
 	}

--- a/internal/chsql/range_window_fixed_accumulator.go
+++ b/internal/chsql/range_window_fixed_accumulator.go
@@ -344,6 +344,13 @@ func fixedAccumValueFrag(kind extrapolationKind, rangeSeconds float64, temporali
 // this file's own doc comment. The only difference from deltaMatrixLevelSource
 // is WHICH columns pass through: this emitter carries its own scalar
 // accumulators (passthroughCols) instead of a window_pairs array.
+// deltaPrefixSumFrag is called with alreadyDeduped=false unconditionally: this
+// file's own delta_prefix_pairs term (fixedAccumRegroupLayer, above) is
+// always built via the hand-rolled groupArrayIf, never the native
+// timeSeriesGroupArrayIf combinator range_window.go's array-fold site
+// adopted for cerberus issue #2862 — see that issue and
+// deltaMatrixLevelSourceAggregate's own doc for why the flag can't be
+// derived from r.NativeGroupArray in a function this shared.
 func fixedAccumDeltaLevelSource(regroupSource Frag, groupFrags []Frag, passthroughCols []string) Frag {
 	selectPassthrough := func(q *QueryBuilder) {
 		q.Select(groupFrags...)
@@ -356,7 +363,7 @@ func fixedAccumDeltaLevelSource(regroupSource Frag, groupFrags []Frag, passthrou
 
 	increments := NewQuery().From(regroupSource)
 	selectPassthrough(increments)
-	increments.Select(As(deltaPrefixSumFrag(Col(deltaPrefixPairsAlias)), deltaPrefixStepAlias))
+	increments.Select(As(deltaPrefixSumFrag(Col(deltaPrefixPairsAlias), false), deltaPrefixStepAlias))
 
 	levels := NewQuery().From(increments.Frag())
 	selectPassthrough(levels)
@@ -466,7 +473,9 @@ func (e *emitter) fixedAccumRegroupLayer(
 			passthrough = append(passthrough, fixedAccumResetSumAlias)
 		}
 		if useAggregateDeltaPrefix {
-			regroupSource, err = e.deltaMatrixLevelSourceAggregate(r, regroupSource, groupFrags, passthrough, end, stepNS, rangeNS, numAnchors)
+			// false: see fixedAccumDeltaLevelSource's own doc — this file's
+			// delta_prefix_pairs term never adopts the native combinator.
+			regroupSource, err = e.deltaMatrixLevelSourceAggregate(r, regroupSource, groupFrags, passthrough, false, end, stepNS, rangeNS, numAnchors)
 			if err != nil {
 				return nil, err
 			}

--- a/internal/chsql/range_window_group_array_if_chdb_test.go
+++ b/internal/chsql/range_window_group_array_if_chdb_test.go
@@ -1,0 +1,218 @@
+//go:build chdb
+
+package chsql
+
+import (
+	"context"
+	"database/sql"
+	"math"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/tsouza/cerberus/internal/chclient"
+	"github.com/tsouza/cerberus/internal/chplan"
+	"github.com/tsouza/cerberus/internal/chsqltest"
+)
+
+// Differential coverage for the split-window native array assembly
+// (chopt.FeatureTSGridGroupArray, cerberus issue #2862):
+// emitWindowedArrayExtrapolatedMatrix's needsDeltaFirstLevel branch builds
+// `window_pairs` and `delta_prefix_pairs` from two complementary
+// predicates, and under r.NativeGroupArray both become
+// timeSeriesGroupArrayIf — whose own duplicate-timestamp collapse is what
+// lets seriesArrayPairIfFrag's callers drop the
+// arrayReverse/arrayCompact/arrayReverse triple at BOTH sites
+// (matrixWindowPairsAlreadyDeduped for the window arm, deltaPrefixSumFrag's
+// alreadyDeduped parameter for the prefix arm).
+//
+// # Why the assertion lives here and not in the TXTAR corpus
+//
+// native_group_array_if_rate_delta_temporality_range.txtar pins the SQL
+// SHAPE and its answer against the real Prometheus engine, but it cannot
+// seed a duplicate timestamp: the parity harness's DELTA-temporality
+// adapter (cumulativeDeltaSeries, test/spec/parity_chdb.go) running-sums
+// every seeded row into the cumulative series Prometheus accepts, so two
+// rows sharing a timestamp are two additive increments there while
+// cerberus collapses them to one sample. That is a disagreement about what
+// a duplicate OTel DELTA observation MEANS, not about this feature. Here
+// BOTH sides of the comparison are cerberus's own two lowerings, so the
+// duplicate is exactly the interesting input.
+//
+// The survivor choice among DIFFERENT values at one timestamp (max-valued
+// for finite samples, insertion-order dependent for a NaN — the reason
+// chopt.FeatureTSGridGroupArray ships AutoSelect: false) is a property of
+// the ClickHouse aggregate itself and is pinned against a real server by
+// range_window_group_array_realch_integration_test.go, not here.
+
+// groupArrayIfDupEnd / groupArrayIfDupStep / groupArrayIfDupRange anchor the
+// query_range evaluation every scenario below shares: two anchors
+// (00:00:00, 00:00:30) over a 1m window, with the seed's earliest sample
+// sitting at or before the first anchor's window start so it lands in
+// `delta_prefix_pairs` rather than `window_pairs`.
+var (
+	groupArrayIfDupStart = time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	groupArrayIfDupEnd   = time.Date(2026, 1, 1, 0, 0, 30, 0, time.UTC)
+)
+
+const (
+	groupArrayIfDupStep  = 30 * time.Second
+	groupArrayIfDupRange = time.Minute
+)
+
+// groupArrayIfDupWindow builds the DELTA-temporality rate() window both
+// lowerings are emitted from. Only NativeGroupArray differs between the
+// two runs, so any divergence in the answer is attributable to the array
+// assembly and nothing else.
+func groupArrayIfDupWindow(native bool) *chplan.RangeWindow {
+	return &chplan.RangeWindow{
+		Input: shapedDeltaPrefixInput(
+			&chplan.Scan{Table: "otel_metrics_sum"},
+			chplan.Projection{Expr: &chplan.ColumnRef{Name: "TimeUnix"}, Alias: "TimeUnix"},
+			chplan.Projection{Expr: &chplan.ColumnRef{Name: "Value"}, Alias: "Value"},
+			chplan.Projection{Expr: &chplan.ColumnRef{Name: "AggregationTemporality"}, Alias: "AggregationTemporality"},
+		),
+		Func:              "rate",
+		Range:             groupArrayIfDupRange,
+		Start:             groupArrayIfDupStart,
+		End:               groupArrayIfDupEnd,
+		Step:              groupArrayIfDupStep,
+		OuterRange:        groupArrayIfDupEnd.Sub(groupArrayIfDupStart),
+		TimestampColumn:   "TimeUnix",
+		ValueColumn:       "Value",
+		TemporalityColumn: "AggregationTemporality",
+		GroupBy:           []chplan.Expr{&chplan.ColumnRef{Name: "Attributes"}},
+		NativeGroupArray:  native,
+	}
+}
+
+// runGroupArrayIfDupQuery emits r and returns job -> (anchor unix millis ->
+// rate() value). The experimental ts-grid aggregate setting is applied to
+// the session by the caller, since chDB's session is process-global.
+func runGroupArrayIfDupQuery(t *testing.T, db *sql.DB, r *chplan.RangeWindow) map[string]map[int64]float64 {
+	t.Helper()
+	sqlText, args, err := Emit(context.Background(), r)
+	if err != nil {
+		t.Fatalf("Emit(native=%v): %v", r.NativeGroupArray, err)
+	}
+	inner := strings.TrimSuffix(strings.TrimSpace(sqlText), ";")
+	wrapped := "SELECT Attributes['job'] AS job, toUnixTimestamp64Milli(anchor_ts) AS anchor_ms, Value FROM (" + inner + ")"
+	rows, err := db.Query(wrapped, args...)
+	if err != nil {
+		t.Fatalf("query(native=%v): %v\n%s", r.NativeGroupArray, err, sqlText)
+	}
+	defer func() { _ = rows.Close() }()
+	out := map[string]map[int64]float64{}
+	for rows.Next() {
+		var job string
+		var anchorMs int64
+		var value float64
+		if err := rows.Scan(&job, &anchorMs, &value); err != nil {
+			t.Fatalf("scan(native=%v): %v", r.NativeGroupArray, err)
+		}
+		if out[job] == nil {
+			out[job] = map[int64]float64{}
+		}
+		out[job][anchorMs] = value
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatalf("rows(native=%v): %v", r.NativeGroupArray, err)
+	}
+	return out
+}
+
+// TestGroupArrayIf_NativeSplitWindow_DuplicateTimestampMatchesFanout is the
+// assertion cerberus issue #2862 turns on: swapping the needsDeltaFirstLevel
+// branch's two groupArrayIf calls for timeSeriesGroupArrayIf — and dropping
+// the dedup pass on BOTH resulting arrays — must not change the answer,
+// including on a series whose duplicate timestamps land in the prefix arm
+// and in the window arm.
+//
+// Series "dup" duplicates a sample at 23:59:30 (which the 00:00:30 anchor
+// reads through `delta_prefix_pairs`) and another at 00:00:00 (which both
+// anchors read through `window_pairs`). Series "plain" seeds the SAME three
+// distinct (timestamp, value) samples with no duplicates, so the two series
+// must answer identically at every anchor: the fan-out's dedup triple and
+// the native aggregate's own collapse both reduce "dup" to "plain". Without
+// that collapse the DELTA reconstruction would double-count — the window arm
+// sums window values minus the first, the prefix arm sums the whole prefix
+// array — so "dup" would drift away from "plain" and this test would fail
+// rather than pass on a no-op.
+//
+// The duplicate pairs carry EQUAL values, which is what makes "dup must
+// equal plain" a well-defined claim about the collapse rather than about
+// which of two competing samples survives it.
+func TestGroupArrayIf_NativeSplitWindow_DuplicateTimestampMatchesFanout(t *testing.T) {
+	db := chsqltest.OpenIsolatedChDB(t)
+	deltaPrefixAggregateSeedDDL(t, db)
+	if _, err := db.Exec("SET " + chclient.SettingExperimentalTSGridAggregate + " = 1"); err != nil {
+		t.Fatalf("enable %s: %v", chclient.SettingExperimentalTSGridAggregate, err)
+	}
+
+	if _, err := db.Exec(`INSERT INTO otel_metrics_sum VALUES
+		(1, map('job', 'dup'), toDateTime64('2025-12-31 23:59:30', 9), 90),
+		(1, map('job', 'dup'), toDateTime64('2025-12-31 23:59:30', 9), 90),
+		(1, map('job', 'dup'), toDateTime64('2026-01-01 00:00:00', 9), 10),
+		(1, map('job', 'dup'), toDateTime64('2026-01-01 00:00:00', 9), 10),
+		(1, map('job', 'dup'), toDateTime64('2026-01-01 00:00:30', 9), 40),
+		(1, map('job', 'plain'), toDateTime64('2025-12-31 23:59:30', 9), 90),
+		(1, map('job', 'plain'), toDateTime64('2026-01-01 00:00:00', 9), 10),
+		(1, map('job', 'plain'), toDateTime64('2026-01-01 00:00:30', 9), 40)`); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	fanout := runGroupArrayIfDupQuery(t, db, groupArrayIfDupWindow(false))
+	native := runGroupArrayIfDupQuery(t, db, groupArrayIfDupWindow(true))
+
+	for _, job := range []string{"dup", "plain"} {
+		if len(fanout[job]) == 0 {
+			t.Fatalf("job=%s: fan-out returned zero anchors — the fixture is not exercising the branch", job)
+		}
+		if len(native[job]) != len(fanout[job]) {
+			t.Fatalf("job=%s: anchor-count divergence: native=%d fanout=%d", job, len(native[job]), len(fanout[job]))
+		}
+	}
+
+	// The native and fan-out assemblies must agree, per series and per
+	// anchor: the emission swap this issue makes is meant to be answer-
+	// preserving.
+	for job, anchors := range fanout {
+		for anchorMs, want := range anchors {
+			got, ok := native[job][anchorMs]
+			if !ok {
+				t.Errorf("job=%s anchor=%d present in fan-out but absent in native", job, anchorMs)
+				continue
+			}
+			if math.Abs(got-want) > 1e-9 {
+				t.Errorf("job=%s anchor=%d: native=%v fanout=%v NOT equal", job, anchorMs, got, want)
+			}
+		}
+	}
+
+	// The collapse itself: "dup" and "plain" describe the same deduplicated
+	// series, so both lowerings must reduce them to the same answer. This is
+	// what would fail if either dedup pass were dropped without the native
+	// aggregate replacing it.
+	for _, side := range []struct {
+		name    string
+		answers map[string]map[int64]float64
+	}{
+		{"fanout", fanout},
+		{"native", native},
+	} {
+		for anchorMs, plain := range side.answers["plain"] {
+			dup, ok := side.answers["dup"][anchorMs]
+			if !ok {
+				t.Errorf("%s: anchor=%d answered for job=plain but not for job=dup", side.name, anchorMs)
+				continue
+			}
+			if math.Abs(dup-plain) > 1e-9 {
+				t.Errorf(
+					"%s anchor=%d: duplicate-timestamp series answered %v, its deduplicated twin answered %v — "+
+						"the duplicate-timestamp collapse did not happen",
+					side.name, anchorMs, dup, plain,
+				)
+			}
+		}
+	}
+}

--- a/internal/chsql/range_window_group_array_realch_integration_test.go
+++ b/internal/chsql/range_window_group_array_realch_integration_test.go
@@ -18,6 +18,15 @@
 //     chopt.FeatureTSGridGroupArray ships AutoSelect: false
 //     (TestTimeSeriesGroupArray_NaNDuplicateIsInsertionOrderDependent_RealCH).
 //
+// Cerberus issue #2862 extends the same feature to the split-window
+// assembly sites via ClickHouse's generic `-If` aggregate combinator
+// (timeSeriesGroupArrayIf, nativeGroupArrayPairIfFrag). Combinator wrapping
+// could plausibly change any of the three, so each is RE-RUN for that form
+// rather than assumed to carry over — TestTimeSeriesGroupArray_IfCombinator*
+// below, one per precondition, plus the combinator's own additional
+// question (does the predicate filter BEFORE or AFTER the
+// duplicate-timestamp collapse?) which the plain form cannot pose.
+//
 // Needs a real ClickHouse >= 25.9 (chopt.FeatureTSGridGroupArray's own
 // floor, shared with the rest of the timeSeries*ToGrid family) — this lane
 // pins CH_TEST_IMAGE (see the ts-grid-group-array-integration Justfile
@@ -189,6 +198,178 @@ func TestTimeSeriesGroupArray_NaNDuplicateIsInsertionOrderDependent_RealCH(t *te
 	}
 	if strings.Contains(strings.ToLower(nanSecond), "nan") {
 		t.Errorf("NaN-second duplicate: got %q, want the surviving sample to be 3 (nan never displaces a finite current-best)", nanSecond)
+	}
+}
+
+// TestTimeSeriesGroupArray_IfCombinatorAcceptsDateTime64Losslessly_RealCH
+// re-runs precondition 1 for the `-If` combinator form (cerberus issue
+// #2862): wrapping the aggregate in `-If` must not change which timestamp
+// types it accepts, nor cost sub-second precision. UInt64 is asserted
+// REJECTED for the same contrast the plain form's probe draws — a
+// combinator that RELAXED the argument types would be a different function
+// than the one nativeGroupArrayPairIfFrag's doc describes.
+func TestTimeSeriesGroupArray_IfCombinatorAcceptsDateTime64Losslessly_RealCH(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	defer cancel()
+	db := realCHConnect(ctx, t)
+
+	const settings = " SETTINGS " + chclient.SettingExperimentalTSGridAggregate + " = 1"
+
+	var typeName string
+	if err := db.QueryRowContext(
+		ctx,
+		"SELECT toTypeName(timeSeriesGroupArrayIf(t, v, v > 0)) FROM "+
+			"(SELECT toDateTime64('2026-01-01 00:00:01.123456789', 9) AS t, 1.0 AS v)"+settings,
+	).Scan(&typeName); err != nil {
+		t.Fatalf("DateTime64(9) -If probe: %v", err)
+	}
+	const wantType = "Array(Tuple(DateTime64(9), Float64))"
+	if typeName != wantType {
+		t.Errorf("timeSeriesGroupArrayIf(DateTime64(9), Float64, UInt8) result type = %q, want %q", typeName, wantType)
+	}
+
+	var roundTripped string
+	if err := db.QueryRowContext(
+		ctx,
+		"SELECT toString(timeSeriesGroupArrayIf(t, v, v > 0)) FROM "+
+			"(SELECT toDateTime64('2026-01-01 00:00:01.123456789', 9) AS t, 1.0 AS v)"+settings,
+	).Scan(&roundTripped); err != nil {
+		t.Fatalf("precision round-trip -If probe: %v", err)
+	}
+	if !strings.Contains(roundTripped, "00:00:01.123456789") {
+		t.Errorf("sub-second precision lost under -If: got %q, want it to contain 00:00:01.123456789", roundTripped)
+	}
+
+	var uint64Err error
+	err := db.QueryRowContext(
+		ctx,
+		"SELECT timeSeriesGroupArrayIf(t, v, v > 0) FROM "+
+			"(SELECT toUInt64(1767225601123456789) AS t, 1.0 AS v)"+settings,
+	).Scan(&uint64Err)
+	if err == nil {
+		t.Fatal("timeSeriesGroupArrayIf(UInt64, Float64, UInt8) unexpectedly succeeded — the documented UInt64 " +
+			"alternative was expected to be rejected (ILLEGAL_TYPE_OF_ARGUMENT) on this server, exactly as for " +
+			"the plain form")
+	}
+}
+
+// TestTimeSeriesGroupArray_IfCombinatorFiltersBeforeCollapse_RealCH re-runs
+// precondition 2 for the `-If` combinator form (cerberus issue #2862), and
+// asks the one question only the combinator form can pose: WHERE in the fold
+// the predicate is applied.
+//
+// The two orderings are behaviourally different and both are a priori
+// plausible. Filter-then-collapse (what an `-If` combinator is documented to
+// do: it gates whether a row is fed to the aggregate at all) means a row
+// failing cond is invisible, so the survivor at a duplicate timestamp is the
+// max among PASSING rows. Collapse-then-filter would let a larger, EXCLUDED
+// row win the timestamp and then be dropped, silently deleting the passing
+// sample from the array. seriesArrayPairIfFrag's two complementary
+// predicates split one scan into `window_pairs` and `delta_prefix_pairs`, so
+// the second ordering would lose real samples from both arms wherever a
+// timestamp is duplicated across the split boundary.
+//
+// The probe seeds a duplicate timestamp whose LARGER value fails cond and
+// whose smaller value passes: filter-then-collapse yields the smaller,
+// passing value; collapse-then-filter would yield an empty array. A second
+// probe pins the max-collapse among two PASSING rows, so the first probe
+// cannot pass merely because the aggregate ignores values entirely.
+func TestTimeSeriesGroupArray_IfCombinatorFiltersBeforeCollapse_RealCH(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	defer cancel()
+	db := realCHConnect(ctx, t)
+
+	const settings = " SETTINGS " + chclient.SettingExperimentalTSGridAggregate + " = 1"
+
+	// The excluded row carries the LARGER value, so a collapse that ran
+	// before the filter would elect it and then drop it.
+	var excludedLoses string
+	if err := db.QueryRowContext(
+		ctx,
+		"SELECT toString(timeSeriesGroupArrayIf(t, v, keep)) FROM "+
+			"(SELECT toDateTime64('2026-01-01 00:00:01', 9) AS t, 99.0 AS v, 0 AS keep "+
+			"UNION ALL SELECT toDateTime64('2026-01-01 00:00:01', 9), 3.0, 1)"+settings,
+	).Scan(&excludedLoses); err != nil {
+		t.Fatalf("filter-before-collapse probe: %v", err)
+	}
+	if !strings.Contains(excludedLoses, "3") || strings.Contains(excludedLoses, "99") {
+		t.Errorf(
+			"timeSeriesGroupArrayIf collapsed a duplicate timestamp across the predicate: got %q, want the "+
+				"single passing sample (value 3). A cond-failing row must never take the timestamp from a "+
+				"cond-passing one — seriesArrayPairIfFrag's two complementary predicates would lose samples "+
+				"from both split arms.",
+			excludedLoses,
+		)
+	}
+
+	// Among rows that DO pass, the collapse is the same max-valued fold the
+	// plain form performs — which is what makes dropping
+	// dedupWindowPairsByTsFrag downstream of this aggregate answer-preserving.
+	var maxAmongPassing string
+	if err := db.QueryRowContext(
+		ctx,
+		"SELECT toString(timeSeriesGroupArrayIf(t, v, keep)) FROM "+
+			"(SELECT toDateTime64('2026-01-01 00:00:01', 9) AS t, 3.0 AS v, 1 AS keep "+
+			"UNION ALL SELECT toDateTime64('2026-01-01 00:00:01', 9), 7.0, 1)"+settings,
+	).Scan(&maxAmongPassing); err != nil {
+		t.Fatalf("max-among-passing probe: %v", err)
+	}
+	if !strings.Contains(maxAmongPassing, "7") || strings.Contains(maxAmongPassing, "3") {
+		t.Errorf(
+			"timeSeriesGroupArrayIf duplicate collapse among passing rows: got %q, want the max-valued "+
+				"sample (value 7), matching the plain form's own fold",
+			maxAmongPassing,
+		)
+	}
+}
+
+// TestTimeSeriesGroupArray_IfCombinatorNaNDuplicateIsInsertionOrderDependent_RealCH
+// re-runs precondition 3 for the `-If` combinator form (cerberus issue
+// #2862). The finding is the plain form's, unchanged: because every IEEE754
+// comparison against NaN is false, the running "replace only when candidate
+// > current-best" fold keeps whichever NaN it visits FIRST and never lets a
+// NaN visited SECOND dislodge a finite current-best. Pinning it here is what
+// makes chopt.FeatureTSGridGroupArray's AutoSelect: false posture cover the
+// split-window sites too, rather than resting on the assumption that a
+// combinator cannot change a fold's comparison.
+func TestTimeSeriesGroupArray_IfCombinatorNaNDuplicateIsInsertionOrderDependent_RealCH(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	defer cancel()
+	db := realCHConnect(ctx, t)
+
+	const settings = " SETTINGS " + chclient.SettingExperimentalTSGridAggregate + " = 1"
+
+	// NaN listed FIRST survives — nothing compares greater than NaN. Both
+	// rows pass cond, so the predicate is not what decides the outcome.
+	var nanFirst string
+	if err := db.QueryRowContext(
+		ctx,
+		"SELECT toString(timeSeriesGroupArrayIf(t, v, keep)) FROM "+
+			"(SELECT toDateTime64('2026-01-01 00:00:01', 9) AS t, nan AS v, 1 AS keep "+
+			"UNION ALL SELECT toDateTime64('2026-01-01 00:00:01', 9), 3.0, 1)"+settings,
+	).Scan(&nanFirst); err != nil {
+		t.Fatalf("nan-first -If probe: %v", err)
+	}
+	if !strings.Contains(strings.ToLower(nanFirst), "nan") {
+		t.Errorf("NaN-first duplicate under -If: got %q, want the surviving sample to be nan", nanFirst)
+	}
+
+	// The SAME two candidates, NaN listed SECOND: the finite value survives.
+	var nanSecond string
+	if err := db.QueryRowContext(
+		ctx,
+		"SELECT toString(timeSeriesGroupArrayIf(t, v, keep)) FROM "+
+			"(SELECT toDateTime64('2026-01-01 00:00:01', 9) AS t, 3.0 AS v, 1 AS keep "+
+			"UNION ALL SELECT toDateTime64('2026-01-01 00:00:01', 9), nan, 1)"+settings,
+	).Scan(&nanSecond); err != nil {
+		t.Fatalf("nan-second -If probe: %v", err)
+	}
+	if strings.Contains(strings.ToLower(nanSecond), "nan") {
+		t.Errorf(
+			"NaN-second duplicate under -If: got %q, want the surviving sample to be 3 (nan never displaces "+
+				"a finite current-best)",
+			nanSecond,
+		)
 	}
 }
 

--- a/internal/chsql/range_window_matrix_delta_prefix_guard_test.go
+++ b/internal/chsql/range_window_matrix_delta_prefix_guard_test.go
@@ -285,7 +285,7 @@ func TestDeltaMatrixLevelSourceAggregate_EmptyGroupFragsDoesNotPanic(t *testing.
 	// numAnchors=3, stepNS/rangeNS arbitrary but nonzero — only
 	// groupFrags'/groupColumns' emptiness matters for the capacity hints
 	// under test (4133, 4180).
-	frag, err := e.deltaMatrixLevelSourceAggregate(r, regroupSource, nil, []string{"window_pairs"}, end, 10_000_000_000, 60_000_000_000, 3)
+	frag, err := e.deltaMatrixLevelSourceAggregate(r, regroupSource, nil, []string{"window_pairs"}, false, end, 10_000_000_000, 60_000_000_000, 3)
 	if err != nil {
 		t.Fatalf("deltaMatrixLevelSourceAggregate with empty groupFrags/GroupBy: %v", err)
 	}

--- a/test/perf/cardinality-baseline/promql/exp_histogram_avg_merge_summap.json
+++ b/test/perf/cardinality-baseline/promql/exp_histogram_avg_merge_summap.json
@@ -1,0 +1,11 @@
+{
+  "fixture": "promql/exp_histogram_avg_merge_summap",
+  "fan_factor": 1,
+  "scan_rows": 2,
+  "peak_intermediate": 2,
+  "has_cross_join": false,
+  "has_array_join": false,
+  "has_recursive_cte": false,
+  "max_recursion_depth": 0,
+  "uncountable_levels": 0
+}

--- a/test/perf/cardinality-baseline/promql/native_delta_vector_agg_range_step.json
+++ b/test/perf/cardinality-baseline/promql/native_delta_vector_agg_range_step.json
@@ -1,0 +1,11 @@
+{
+  "fixture": "promql/native_delta_vector_agg_range_step",
+  "fan_factor": 1,
+  "scan_rows": 10,
+  "peak_intermediate": 10,
+  "has_cross_join": false,
+  "has_array_join": true,
+  "has_recursive_cte": false,
+  "max_recursion_depth": 0,
+  "uncountable_levels": 0
+}

--- a/test/perf/cardinality-baseline/promql/native_group_array_if_rate_delta_temporality_range.json
+++ b/test/perf/cardinality-baseline/promql/native_group_array_if_rate_delta_temporality_range.json
@@ -1,0 +1,11 @@
+{
+  "fixture": "promql/native_group_array_if_rate_delta_temporality_range",
+  "fan_factor": 2.6666666666666665,
+  "scan_rows": 6,
+  "peak_intermediate": 16,
+  "has_cross_join": false,
+  "has_array_join": true,
+  "has_recursive_cte": false,
+  "max_recursion_depth": 0,
+  "uncountable_levels": 0
+}

--- a/test/perf/cardinality-baseline/promql/native_increase_vector_agg_temporality_union.json
+++ b/test/perf/cardinality-baseline/promql/native_increase_vector_agg_temporality_union.json
@@ -1,0 +1,11 @@
+{
+  "fixture": "promql/native_increase_vector_agg_temporality_union",
+  "fan_factor": 3,
+  "scan_rows": 12,
+  "peak_intermediate": 36,
+  "has_cross_join": false,
+  "has_array_join": true,
+  "has_recursive_cte": false,
+  "max_recursion_depth": 0,
+  "uncountable_levels": 0
+}

--- a/test/perf/cardinality-baseline/promql/native_rate_avg_vector_agg_temporality_union_excluded.json
+++ b/test/perf/cardinality-baseline/promql/native_rate_avg_vector_agg_temporality_union_excluded.json
@@ -1,0 +1,11 @@
+{
+  "fixture": "promql/native_rate_avg_vector_agg_temporality_union_excluded",
+  "fan_factor": 3,
+  "scan_rows": 12,
+  "peak_intermediate": 36,
+  "has_cross_join": false,
+  "has_array_join": true,
+  "has_recursive_cte": false,
+  "max_recursion_depth": 0,
+  "uncountable_levels": 0
+}

--- a/test/perf/cardinality-baseline/promql/native_rate_max_vector_agg_temporality_union.json
+++ b/test/perf/cardinality-baseline/promql/native_rate_max_vector_agg_temporality_union.json
@@ -1,0 +1,11 @@
+{
+  "fixture": "promql/native_rate_max_vector_agg_temporality_union",
+  "fan_factor": 3,
+  "scan_rows": 12,
+  "peak_intermediate": 36,
+  "has_cross_join": false,
+  "has_array_join": true,
+  "has_recursive_cte": false,
+  "max_recursion_depth": 0,
+  "uncountable_levels": 0
+}

--- a/test/perf/cardinality-baseline/promql/native_rate_recollapse_vector_agg_temporality_union_excluded.json
+++ b/test/perf/cardinality-baseline/promql/native_rate_recollapse_vector_agg_temporality_union_excluded.json
@@ -1,0 +1,11 @@
+{
+  "fixture": "promql/native_rate_recollapse_vector_agg_temporality_union_excluded",
+  "fan_factor": 1.5,
+  "scan_rows": 12,
+  "peak_intermediate": 18,
+  "has_cross_join": false,
+  "has_array_join": true,
+  "has_recursive_cte": false,
+  "max_recursion_depth": 0,
+  "uncountable_levels": 0
+}

--- a/test/perf/cardinality-baseline/promql/native_rate_vector_agg_temporality_union.json
+++ b/test/perf/cardinality-baseline/promql/native_rate_vector_agg_temporality_union.json
@@ -1,0 +1,11 @@
+{
+  "fixture": "promql/native_rate_vector_agg_temporality_union",
+  "fan_factor": 2,
+  "scan_rows": 18,
+  "peak_intermediate": 36,
+  "has_cross_join": false,
+  "has_array_join": true,
+  "has_recursive_cte": false,
+  "max_recursion_depth": 0,
+  "uncountable_levels": 0
+}

--- a/test/perf/cardinality-baseline/promql/native_rate_vector_agg_temporality_union_nogroup.json
+++ b/test/perf/cardinality-baseline/promql/native_rate_vector_agg_temporality_union_nogroup.json
@@ -1,0 +1,11 @@
+{
+  "fixture": "promql/native_rate_vector_agg_temporality_union_nogroup",
+  "fan_factor": 3,
+  "scan_rows": 12,
+  "peak_intermediate": 36,
+  "has_cross_join": false,
+  "has_array_join": true,
+  "has_recursive_cte": false,
+  "max_recursion_depth": 0,
+  "uncountable_levels": 0
+}

--- a/test/perf/solver-decision-baseline/native_group_array_if_rate_delta_temporality_range/fanout.json
+++ b/test/perf/solver-decision-baseline/native_group_array_if_rate_delta_temporality_range/fanout.json
@@ -1,0 +1,11 @@
+{
+  "query": "native_group_array_if_rate_delta_temporality_range/fanout",
+  "lowering": "fanout",
+  "routed": false,
+  "k": 0,
+  "reason": "below-threshold",
+  "n_anchors": 241,
+  "fanout": 4,
+  "cumulative_d": "1m0s",
+  "outer_range": "1h0m0s"
+}

--- a/test/perf/solver-decision-baseline/native_group_array_if_rate_delta_temporality_range/native.json
+++ b/test/perf/solver-decision-baseline/native_group_array_if_rate_delta_temporality_range/native.json
@@ -1,0 +1,11 @@
+{
+  "query": "native_group_array_if_rate_delta_temporality_range/native",
+  "lowering": "native",
+  "routed": false,
+  "k": 0,
+  "reason": "below-threshold",
+  "n_anchors": 241,
+  "fanout": 4,
+  "cumulative_d": "2m0s",
+  "outer_range": "1h0m0s"
+}

--- a/test/regression/parity-enrolment-baselines/promql/baseline.txt
+++ b/test/regression/parity-enrolment-baselines/promql/baseline.txt
@@ -453,6 +453,7 @@ native_delta_range_step.txtar
 native_delta_vector_agg_range_step.txtar
 native_deriv_range_step.txtar
 native_group_array_delta_range_step.txtar
+native_group_array_if_rate_delta_temporality_range.txtar
 native_idelta_range_step.txtar
 native_increase_range_step.txtar
 native_increase_vector_agg_temporality_union.txtar

--- a/test/spec/promql/native_group_array_delta_range_step.txtar
+++ b/test/spec/promql/native_group_array_delta_range_step.txtar
@@ -14,6 +14,21 @@
 # to exercise the native aggregate's own duplicate-timestamp collapse in
 # place of the arrayReverse/arrayCompact/arrayReverse triple; job 'flat' has
 # no duplicates.
+#
+# The duplicate pair carries the SAME value. WHICH of two DIFFERENT values
+# survives a duplicate timestamp is implementation-defined on both sides —
+# ClickHouse's timeSeriesGroupArray keeps the max-valued row (and, for a
+# NaN, whichever the scan visits first: the reason
+# chopt.FeatureTSGridGroupArray ships AutoSelect: false), while the
+# reference engine's TSDB appender keeps whichever sample it ingested
+# first. That disagreement is a fact about the two storage layers, not
+# about this feature, so seeding it here would make the `parity:`
+# enrolment below assert something neither engine promises. Equal values
+# keep the collapse itself fully under test — dropping it would leave
+# delta()'s window carrying an extra element, changing the extrapolation's
+# own length(window_vals) divisor — while leaving the survivor choice out
+# of the comparison; the survivor choice is pinned separately, against a
+# real ClickHouse, by range_window_group_array_realch_integration_test.go.
 -- query.promql --
 sum by(job) (delta(cpu_temp_celsius[5m]))
 -- parity --
@@ -33,7 +48,7 @@ CREATE TABLE otel_metrics_gauge (
 INSERT INTO otel_metrics_gauge VALUES
     ('cpu_temp_celsius', map('job', 'dup'), toDateTime64('2026-01-01 00:00:00', 9), 40.0),
     ('cpu_temp_celsius', map('job', 'dup'), toDateTime64('2026-01-01 00:01:00', 9), 45.0),
-    ('cpu_temp_celsius', map('job', 'dup'), toDateTime64('2026-01-01 00:01:00', 9), 55.0),
+    ('cpu_temp_celsius', map('job', 'dup'), toDateTime64('2026-01-01 00:01:00', 9), 45.0),
     ('cpu_temp_celsius', map('job', 'dup'), toDateTime64('2026-01-01 00:02:00', 9), 45.0),
     ('cpu_temp_celsius', map('job', 'dup'), toDateTime64('2026-01-01 00:03:00', 9), 60.0),
     ('cpu_temp_celsius', map('job', 'dup'), toDateTime64('2026-01-01 00:04:00', 9), 50.0),
@@ -46,15 +61,15 @@ INSERT INTO otel_metrics_gauge VALUES
     ('cpu_temp_celsius', map('job', 'flat'), toDateTime64('2026-01-01 00:05:00', 9), 20.0);
 -- expected_rows --
 [
-  ["", {"job": "dup"}, "2026-01-01T00:01:00Z", 22.5],
-  ["", {"job": "dup"}, "2026-01-01T00:01:30Z", 30],
+  ["", {"job": "dup"}, "2026-01-01T00:01:00Z", 7.5],
+  ["", {"job": "dup"}, "2026-01-01T00:01:30Z", 10],
   ["", {"job": "dup"}, "2026-01-01T00:02:00Z", 6.25],
   ["", {"job": "dup"}, "2026-01-01T00:02:30Z", 7.5],
   ["", {"job": "dup"}, "2026-01-01T00:03:00Z", 23.333333333333336],
   ["", {"job": "dup"}, "2026-01-01T00:03:30Z", 26.666666666666664],
   ["", {"job": "dup"}, "2026-01-01T00:04:00Z", 12.5],
   ["", {"job": "dup"}, "2026-01-01T00:04:30Z", 12.5],
-  ["", {"job": "dup"}, "2026-01-01T00:05:00Z", 12.5],
+  ["", {"job": "dup"}, "2026-01-01T00:05:00Z", 25],
   ["", {"job": "flat"}, "2026-01-01T00:01:00Z", 0],
   ["", {"job": "flat"}, "2026-01-01T00:01:30Z", 0],
   ["", {"job": "flat"}, "2026-01-01T00:02:00Z", 0],

--- a/test/spec/promql/native_group_array_if_rate_delta_temporality_range.txtar
+++ b/test/spec/promql/native_group_array_if_rate_delta_temporality_range.txtar
@@ -10,13 +10,27 @@
 # arrayReverse dedup triple on both `window_pairs` and `delta_prefix_pairs`
 # (deltaPrefixSumFrag's alreadyDeduped parameter).
 #
-# job 'dup' carries a duplicate-timestamp pair landing in the PREFIX array
-# (23:59:30, at or before the first anchor's window start) and a
-# duplicate-timestamp pair landing in the WINDOW array (00:00:00, inside the
-# first anchor's window) — exercising the native aggregate's own
-# duplicate-timestamp collapse in place of the dedup triple at BOTH sites.
-# job 'plain' has no duplicates, so the test cannot pass merely because the
-# dedup happened to be a no-op everywhere.
+# Both series' earliest sample (23:59:30) is at or before the first anchor's
+# own window start, so it lands in `delta_prefix_pairs` for anchor 00:00:30
+# while the later two land in `window_pairs` — both arms of the split carry
+# real data at both anchors, and each series reconstructs a different DELTA
+# level, so a per-series mix-up in either arm changes the answer.
+#
+# The seed carries NO duplicate timestamps, deliberately. The parity
+# enrolment below answers the same query with the real Prometheus engine,
+# and evaluatePrometheusParity's DELTA-temporality adapter
+# (cumulativeDeltaSeries, test/spec/parity_chdb.go) running-sums EVERY
+# seeded row into the cumulative series Prometheus accepts — so two rows
+# sharing a timestamp become two additive increments there, while cerberus
+# collapses them to one sample. That disagreement is about what a duplicate
+# OTel DELTA observation MEANS, not about this feature, and seeding it here
+# would make the enrolment assert something neither engine promises. The
+# duplicate-timestamp collapse this feature does depend on is pinned
+# instead where both sides of the comparison are cerberus's own two
+# lowerings: internal/chsql/range_window_group_array_if_chdb_test.go
+# (native vs fan-out over a duplicate-bearing DELTA seed, at both split
+# arms), with the survivor choice among DIFFERENT values pinned against a
+# real ClickHouse by range_window_group_array_realch_integration_test.go.
 -- query.promql --
 rate(http_requests_delta_total[1m])
 -- range_step --
@@ -35,20 +49,18 @@ CREATE TABLE otel_metrics_sum (
     Value Float64
 ) ENGINE = MergeTree ORDER BY (MetricName, Attributes, TimeUnix);
 INSERT INTO otel_metrics_sum VALUES
-    (1, 'http_requests_delta_total', map('job', 'dup'), toDateTime64('2025-12-31 23:59:30', 9), 90.0),
-    (1, 'http_requests_delta_total', map('job', 'dup'), toDateTime64('2025-12-31 23:59:30', 9), 70.0),
-    (1, 'http_requests_delta_total', map('job', 'dup'), toDateTime64('2026-01-01 00:00:00', 9), 10.0),
-    (1, 'http_requests_delta_total', map('job', 'dup'), toDateTime64('2026-01-01 00:00:00', 9), 25.0),
-    (1, 'http_requests_delta_total', map('job', 'dup'), toDateTime64('2026-01-01 00:00:30', 9), 40.0),
-    (1, 'http_requests_delta_total', map('job', 'plain'), toDateTime64('2025-12-31 23:59:30', 9), 90.0),
-    (1, 'http_requests_delta_total', map('job', 'plain'), toDateTime64('2026-01-01 00:00:00', 9), 10.0),
-    (1, 'http_requests_delta_total', map('job', 'plain'), toDateTime64('2026-01-01 00:00:30', 9), 40.0);
+    (1, 'http_requests_delta_total', map('job', 'a'), toDateTime64('2025-12-31 23:59:30', 9), 90.0),
+    (1, 'http_requests_delta_total', map('job', 'a'), toDateTime64('2026-01-01 00:00:00', 9), 10.0),
+    (1, 'http_requests_delta_total', map('job', 'a'), toDateTime64('2026-01-01 00:00:30', 9), 40.0),
+    (1, 'http_requests_delta_total', map('job', 'b'), toDateTime64('2025-12-31 23:59:30', 9), 30.0),
+    (1, 'http_requests_delta_total', map('job', 'b'), toDateTime64('2026-01-01 00:00:00', 9), 5.0),
+    (1, 'http_requests_delta_total', map('job', 'b'), toDateTime64('2026-01-01 00:00:30', 9), 60.0);
 -- expected_rows --
 [
-  [{"job": "dup"}, "2026-01-01T00:00:00Z", "2026-01-01T00:00:00Z", 0.8333333333333334],
-  [{"job": "dup"}, "2026-01-01T00:00:30Z", "2026-01-01T00:00:30Z", 1.3333333333333333],
-  [{"job": "plain"}, "2026-01-01T00:00:00Z", "2026-01-01T00:00:00Z", 0.3333333333333333],
-  [{"job": "plain"}, "2026-01-01T00:00:30Z", "2026-01-01T00:00:30Z", 1.3333333333333333]
+  [{"job": "a"}, "2026-01-01T00:00:00Z", "2026-01-01T00:00:00Z", 0.3333333333333333],
+  [{"job": "a"}, "2026-01-01T00:00:30Z", "2026-01-01T00:00:30Z", 1.3333333333333333],
+  [{"job": "b"}, "2026-01-01T00:00:00Z", "2026-01-01T00:00:00Z", 0.16666666666666666],
+  [{"job": "b"}, "2026-01-01T00:00:30Z", "2026-01-01T00:00:30Z", 1.5833333333333333]
 ]
 -- args --
 [0] string = "service_name"

--- a/test/spec/promql/native_group_array_if_rate_delta_temporality_range.txtar
+++ b/test/spec/promql/native_group_array_if_rate_delta_temporality_range.txtar
@@ -1,0 +1,102 @@
+# Native array assembly (cerberus issue #2862) for the needsDeltaFirstLevel
+# split-window branch: rate() over a DELTA-temporality Sum table in RANGE
+# mode routes emitWindowedArrayExtrapolatedMatrix through the two
+# groupArrayIf calls that build `window_pairs` / `delta_prefix_pairs`
+# (unlike native_group_array_delta_range_step.txtar's delta(), which never
+# sets needsDeltaFirstLevel and so never reaches this branch). The
+# `experimental_ts_grid_group_array` section opts the fixture into
+# RangeLowerers.NativeGroupArray = true, swapping both groupArrayIf calls for
+# timeSeriesGroupArrayIf and skipping the arrayReverse/arrayCompact/
+# arrayReverse dedup triple on both `window_pairs` and `delta_prefix_pairs`
+# (deltaPrefixSumFrag's alreadyDeduped parameter).
+#
+# job 'dup' carries a duplicate-timestamp pair landing in the PREFIX array
+# (23:59:30, at or before the first anchor's window start) and a
+# duplicate-timestamp pair landing in the WINDOW array (00:00:00, inside the
+# first anchor's window) — exercising the native aggregate's own
+# duplicate-timestamp collapse in place of the dedup triple at BOTH sites.
+# job 'plain' has no duplicates, so the test cannot pass merely because the
+# dedup happened to be a no-op everywhere.
+-- query.promql --
+rate(http_requests_delta_total[1m])
+-- range_step --
+30s
+-- parity --
+oracle: prometheus
+endpoint: /api/v1/query_range
+scope: full
+-- experimental_ts_grid_group_array --
+-- seed --
+CREATE TABLE otel_metrics_sum (
+    AggregationTemporality Int32,
+    MetricName String,
+    Attributes Map(String, String),
+    TimeUnix DateTime64(9),
+    Value Float64
+) ENGINE = MergeTree ORDER BY (MetricName, Attributes, TimeUnix);
+INSERT INTO otel_metrics_sum VALUES
+    (1, 'http_requests_delta_total', map('job', 'dup'), toDateTime64('2025-12-31 23:59:30', 9), 90.0),
+    (1, 'http_requests_delta_total', map('job', 'dup'), toDateTime64('2025-12-31 23:59:30', 9), 70.0),
+    (1, 'http_requests_delta_total', map('job', 'dup'), toDateTime64('2026-01-01 00:00:00', 9), 10.0),
+    (1, 'http_requests_delta_total', map('job', 'dup'), toDateTime64('2026-01-01 00:00:00', 9), 25.0),
+    (1, 'http_requests_delta_total', map('job', 'dup'), toDateTime64('2026-01-01 00:00:30', 9), 40.0),
+    (1, 'http_requests_delta_total', map('job', 'plain'), toDateTime64('2025-12-31 23:59:30', 9), 90.0),
+    (1, 'http_requests_delta_total', map('job', 'plain'), toDateTime64('2026-01-01 00:00:00', 9), 10.0),
+    (1, 'http_requests_delta_total', map('job', 'plain'), toDateTime64('2026-01-01 00:00:30', 9), 40.0);
+-- expected_rows --
+[
+  [{"job": "dup"}, "2026-01-01T00:00:00Z", "2026-01-01T00:00:00Z", 0.8333333333333334],
+  [{"job": "dup"}, "2026-01-01T00:00:30Z", "2026-01-01T00:00:30Z", 1.3333333333333333],
+  [{"job": "plain"}, "2026-01-01T00:00:00Z", "2026-01-01T00:00:00Z", 0.3333333333333333],
+  [{"job": "plain"}, "2026-01-01T00:00:30Z", "2026-01-01T00:00:30Z", 1.3333333333333333]
+]
+-- args --
+[0] string = "service_name"
+[1] string = "service.name"
+[2] string = "service_name"
+[3] string = "service.name"
+[4] string = "service_name"
+[5] string = ""
+[6] string = "service_name"
+[7] string = "http_requests_delta_total"
+[8] string = "http.requests.delta.total"
+[9] string = "http.requests.delta/total"
+[10] string = "http.requests.delta_total"
+[11] string = "http.requests/delta/total"
+[12] string = "http.requests/delta_total"
+[13] string = "http.requests_delta.total"
+[14] string = "http.requests_delta_total"
+[15] string = "http/requests/delta/total"
+[16] string = "http/requests/delta_total"
+[17] string = "http/requests_delta_total"
+[18] string = "http_requests.delta.total"
+[19] string = "http_requests.delta_total"
+[20] string = "http_requests_delta.total"
+[21] string = "service_name"
+[22] string = "service.name"
+[23] string = "service_name"
+[24] string = "service.name"
+[25] string = "service_name"
+[26] string = ""
+[27] string = "service_name"
+[28] string = "http_requests_delta_total"
+[29] string = "http.requests.delta.total"
+[30] string = "http.requests.delta/total"
+[31] string = "http.requests.delta_total"
+[32] string = "http.requests/delta/total"
+[33] string = "http.requests/delta_total"
+[34] string = "http.requests_delta.total"
+[35] string = "http.requests_delta_total"
+[36] string = "http/requests/delta/total"
+[37] string = "http/requests/delta_total"
+[38] string = "http/requests_delta_total"
+[39] string = "http_requests.delta.total"
+[40] string = "http_requests.delta_total"
+[41] string = "http_requests_delta.total"
+-- chplan --
+RangeWindow func=rate range=1m0s step=30s outerRange=5m0s ts=TimeUnix value=Value temporality=AggregationTemporality groupBy=[Attributes] start=2026-01-01T00:00:00Z end=2026-01-01T00:05:00Z
+  Project [MetricName AS MetricName, FnMapSort(FnMapMerge(FnMapFilter((k, v) -> (k NOT IN ("service_name")), FnMapUpdate(FnMapFromArrays(FnArrayMap(k -> FnRegexReplaceAll(k, "[^a-zA-Z0-9_]", "_"), FnMapKeys(FnMapFilter((k, v) -> (k NOT IN ("service.name", "service_name")), ResourceAttributes))), FnMapValues(FnMapFilter((k, v) -> (k NOT IN ("service.name", "service_name")), ResourceAttributes))), FnMapFromArrays(FnArrayMap(k -> FnRegexReplaceAll(k, "[^a-zA-Z0-9_]", "_"), FnMapKeys(Attributes)), FnMapValues(Attributes)))), FnMapFilter((k, v) -> (v != ""), FnMap("service_name", FnToString(ServiceName))))) AS Attributes, TimeUnix AS TimeUnix, Value AS Value, AggregationTemporality AS AggregationTemporality]
+    Filter predicate=(MetricName IN ("http_requests_delta_total", "http.requests.delta.total", "http.requests.delta/total", "http.requests.delta_total", "http.requests/delta/total", "http.requests/delta_total", "http.requests_delta.total", "http.requests_delta_total", "http/requests/delta/total", "http/requests/delta_total", "http/requests_delta_total", "http_requests.delta.total", "http_requests.delta_total", "http_requests_delta.total"))
+      Scan(otel_metrics_sum)
+-- sql --
+SELECT `Attributes`, `anchor_ts`, anchor_ts AS `TimeUnix`, if(sampled_interval > 0, counter_delta * ((sampled_interval + if(counter_delta > 0 AND first_val >= 0, least(duration_to_start, sampled_interval * first_val / counter_delta), duration_to_start) + duration_to_end) / sampled_interval / 60), nan) AS `Value` FROM (SELECT `Attributes`, `anchor_ts`, `window_vals`, `counter_delta`, `first_val`, toFloat64(dateDiff('nanosecond', first_ts, last_ts)) / 1e9 AS `sampled_interval`, if(toFloat64(dateDiff('nanosecond', anchor_ts - toIntervalNanosecond(60000000000), first_ts)) / 1e9 >= 1.1 * sampled_interval / (length(window_vals) - 1), sampled_interval / (length(window_vals) - 1) / 2, toFloat64(dateDiff('nanosecond', anchor_ts - toIntervalNanosecond(60000000000), first_ts)) / 1e9) AS `duration_to_start`, if(toFloat64(dateDiff('nanosecond', last_ts, anchor_ts)) / 1e9 >= 1.1 * sampled_interval / (length(window_vals) - 1), sampled_interval / (length(window_vals) - 1) / 2, toFloat64(dateDiff('nanosecond', last_ts, anchor_ts)) / 1e9) AS `duration_to_end` FROM (SELECT `Attributes`, `anchor_ts`, arrayMap(p -> tupleElement(p, 2), window_pairs) AS `window_vals`, if(temporality = 1, arraySum(arrayMap(x -> tupleElement(x, 2), window_pairs)) - tupleElement(window_pairs[1], 2), arraySum(arrayMap((p, c) -> if(c < p, c, c - p), arrayPopBack(arrayMap(x -> tupleElement(x, 2), window_pairs)), arrayPopFront(arrayMap(x -> tupleElement(x, 2), window_pairs))))) AS `counter_delta`, tupleElement(window_pairs[1], 1) AS `first_ts`, tupleElement(window_pairs[length(window_pairs)], 1) AS `last_ts`, if(temporality = 1, `delta_anchor_levels` + tupleElement(window_pairs[1], 2), tupleElement(window_pairs[1], 2)) AS `first_val` FROM (SELECT `Attributes`, `anchor_ts`, `temporality`, `window_pairs`, sum(`delta_prefix_step`) OVER (PARTITION BY `Attributes` ORDER BY `anchor_ts`) AS `delta_anchor_levels` FROM (SELECT `Attributes`, `anchor_ts`, `temporality`, `window_pairs`, arraySum(arrayMap(p -> tupleElement(p, 2), `delta_prefix_pairs`)) AS `delta_prefix_step` FROM (SELECT `Attributes`, `anchor_ts`, `temporality`, `delta_prefix_pairs`, window_pairs AS `window_pairs` FROM (SELECT `Attributes`, `anchor_ts`, any(`AggregationTemporality`) AS `temporality`, timeSeriesGroupArrayIf(`TimeUnix`, `Value`, `TimeUnix` > `anchor_ts` - toIntervalNanosecond(60000000000)) AS `window_pairs`, timeSeriesGroupArrayIf(`TimeUnix`, `Value`, `TimeUnix` <= `anchor_ts` - toIntervalNanosecond(60000000000)) AS `delta_prefix_pairs` FROM (SELECT `Attributes`, `TimeUnix`, `Value`, `AggregationTemporality`, `anchor_ts` FROM (SELECT `Attributes`, `TimeUnix`, `Value`, `AggregationTemporality`, `anchor_ts` FROM (SELECT `Attributes`, `TimeUnix`, `Value`, `AggregationTemporality`, arrayJoin(arrayConcat(arrayMap(i -> toDateTime64('2026-01-01 00:05:00.000000000', 9) - toIntervalNanosecond(i * 30000000000), range(greatest(0, intDiv(dateDiff('nanosecond', `TimeUnix`, toDateTime64('2026-01-01 00:05:00.000000000', 9)) - 60000000000, toInt64(30000000000)) - (modulo(dateDiff('nanosecond', `TimeUnix`, toDateTime64('2026-01-01 00:05:00.000000000', 9)) - 60000000000, toInt64(30000000000)) < 0) + 1), least(11, intDiv(dateDiff('nanosecond', `TimeUnix`, toDateTime64('2026-01-01 00:05:00.000000000', 9)), toInt64(30000000000)) - (modulo(dateDiff('nanosecond', `TimeUnix`, toDateTime64('2026-01-01 00:05:00.000000000', 9)), toInt64(30000000000)) < 0) + 1))), arrayMap(i -> toDateTime64('2026-01-01 00:05:00.000000000', 9) - toIntervalNanosecond(i * 30000000000), range(least(10, greatest(0, intDiv(dateDiff('nanosecond', `TimeUnix`, toDateTime64('2026-01-01 00:05:00.000000000', 9)) - 60000000000, toInt64(30000000000)) - (modulo(dateDiff('nanosecond', `TimeUnix`, toDateTime64('2026-01-01 00:05:00.000000000', 9)) - 60000000000, toInt64(30000000000)) < 0) + 1 - 1)), least(10, greatest(0, intDiv(dateDiff('nanosecond', `TimeUnix`, toDateTime64('2026-01-01 00:05:00.000000000', 9)) - 60000000000, toInt64(30000000000)) - (modulo(dateDiff('nanosecond', `TimeUnix`, toDateTime64('2026-01-01 00:05:00.000000000', 9)) - 60000000000, toInt64(30000000000)) < 0) + 1 - 1)) + if(`AggregationTemporality` = 1 AND `TimeUnix` <= toDateTime64('2026-01-01 00:05:00.000000000', 9) - toIntervalNanosecond(60000000000), 1, 0))))) AS `anchor_ts` FROM (SELECT `MetricName` AS `MetricName`, mapSort(mapConcat(mapFilter((k, v) -> (k NOT IN (?)), mapUpdate(mapFromArrays(arrayMap(k -> replaceRegexpAll(k, '[^a-zA-Z0-9_]', '_'), mapKeys(mapFilter((k, v) -> (k NOT IN (?, ?)), `ResourceAttributes`))), mapValues(mapFilter((k, v) -> (k NOT IN (?, ?)), `ResourceAttributes`))), mapFromArrays(arrayMap(k -> replaceRegexpAll(k, '[^a-zA-Z0-9_]', '_'), mapKeys(`Attributes`)), mapValues(`Attributes`)))), mapFilter((k, v) -> (v != ?), map(?, toString(`ServiceName`))))) AS `Attributes`, `TimeUnix` AS `TimeUnix`, `Value` AS `Value`, `AggregationTemporality` AS `AggregationTemporality` FROM (SELECT * FROM `otel_metrics_sum` WHERE (`MetricName` IN (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)))) WHERE `TimeUnix` <= toDateTime64('2026-01-01 00:05:00.000000000', 9) AND (`AggregationTemporality` = 1 AND `TimeUnix` > toDateTime64('2026-01-01 00:05:00.000000000', 9) - toIntervalNanosecond(300000000000) - toIntervalNanosecond(60000000000) - toIntervalNanosecond(86400000000000) OR `TimeUnix` > toDateTime64('2026-01-01 00:05:00.000000000', 9) - toIntervalNanosecond(300000000000) - toIntervalNanosecond(60000000000))) LIMIT 2800001) WHERE throwIf((SELECT count() AS `n` FROM (SELECT `TimeUnix` FROM (SELECT `Attributes`, `TimeUnix`, `Value`, `AggregationTemporality`, arrayJoin(arrayConcat(arrayMap(i -> toDateTime64('2026-01-01 00:05:00.000000000', 9) - toIntervalNanosecond(i * 30000000000), range(greatest(0, intDiv(dateDiff('nanosecond', `TimeUnix`, toDateTime64('2026-01-01 00:05:00.000000000', 9)) - 60000000000, toInt64(30000000000)) - (modulo(dateDiff('nanosecond', `TimeUnix`, toDateTime64('2026-01-01 00:05:00.000000000', 9)) - 60000000000, toInt64(30000000000)) < 0) + 1), least(11, intDiv(dateDiff('nanosecond', `TimeUnix`, toDateTime64('2026-01-01 00:05:00.000000000', 9)), toInt64(30000000000)) - (modulo(dateDiff('nanosecond', `TimeUnix`, toDateTime64('2026-01-01 00:05:00.000000000', 9)), toInt64(30000000000)) < 0) + 1))), arrayMap(i -> toDateTime64('2026-01-01 00:05:00.000000000', 9) - toIntervalNanosecond(i * 30000000000), range(least(10, greatest(0, intDiv(dateDiff('nanosecond', `TimeUnix`, toDateTime64('2026-01-01 00:05:00.000000000', 9)) - 60000000000, toInt64(30000000000)) - (modulo(dateDiff('nanosecond', `TimeUnix`, toDateTime64('2026-01-01 00:05:00.000000000', 9)) - 60000000000, toInt64(30000000000)) < 0) + 1 - 1)), least(10, greatest(0, intDiv(dateDiff('nanosecond', `TimeUnix`, toDateTime64('2026-01-01 00:05:00.000000000', 9)) - 60000000000, toInt64(30000000000)) - (modulo(dateDiff('nanosecond', `TimeUnix`, toDateTime64('2026-01-01 00:05:00.000000000', 9)) - 60000000000, toInt64(30000000000)) < 0) + 1 - 1)) + if(`AggregationTemporality` = 1 AND `TimeUnix` <= toDateTime64('2026-01-01 00:05:00.000000000', 9) - toIntervalNanosecond(60000000000), 1, 0))))) AS `anchor_ts` FROM (SELECT `MetricName` AS `MetricName`, mapSort(mapConcat(mapFilter((k, v) -> (k NOT IN (?)), mapUpdate(mapFromArrays(arrayMap(k -> replaceRegexpAll(k, '[^a-zA-Z0-9_]', '_'), mapKeys(mapFilter((k, v) -> (k NOT IN (?, ?)), `ResourceAttributes`))), mapValues(mapFilter((k, v) -> (k NOT IN (?, ?)), `ResourceAttributes`))), mapFromArrays(arrayMap(k -> replaceRegexpAll(k, '[^a-zA-Z0-9_]', '_'), mapKeys(`Attributes`)), mapValues(`Attributes`)))), mapFilter((k, v) -> (v != ?), map(?, toString(`ServiceName`))))) AS `Attributes`, `TimeUnix` AS `TimeUnix`, `Value` AS `Value`, `AggregationTemporality` AS `AggregationTemporality` FROM (SELECT * FROM `otel_metrics_sum` WHERE (`MetricName` IN (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)))) WHERE `TimeUnix` <= toDateTime64('2026-01-01 00:05:00.000000000', 9) AND (`AggregationTemporality` = 1 AND `TimeUnix` > toDateTime64('2026-01-01 00:05:00.000000000', 9) - toIntervalNanosecond(300000000000) - toIntervalNanosecond(60000000000) - toIntervalNanosecond(86400000000000) OR `TimeUnix` > toDateTime64('2026-01-01 00:05:00.000000000', 9) - toIntervalNanosecond(300000000000) - toIntervalNanosecond(60000000000))) LIMIT 2800001)) > 2800000, 'range window sample fanout exceeds the series-times-anchors resource bound') = 0) GROUP BY `Attributes`, `anchor_ts`)))))) WHERE length(`window_vals`) >= 2


### PR DESCRIPTION
## What

Adopts ClickHouse's `timeSeriesGroupArrayIf` at the split-window assembly sites, the follow-up scoped out of #2749 (`chopt.FeatureTSGridGroupArray`).

`emitWindowedArrayExtrapolatedMatrix`'s `needsDeltaFirstLevel` branch builds `window_pairs` and `delta_prefix_pairs` from two complementary `groupArrayIf` calls. ClickHouse's generic `-If` aggregate combinator applies to `timeSeriesGroupArray` like any other aggregate, so both now route through `seriesArrayPairIfFrag`, which picks the native combinator under the feature flag and the hand-rolled `arraySort(groupArrayIf(...))` otherwise.

Because the native combinator self-dedups by timestamp, two dedup passes downstream of it become redundant and are skipped:

- `matrixWindowPairsAlreadyDeduped` no longer excludes the split-window branch, so `dedupWindowPairsLayer` drops the `arrayReverse`/`arrayCompact`/`arrayReverse` triple on `window_pairs`.
- `deltaPrefixSumFrag` gains an `alreadyDeduped` parameter, threaded through `deltaMatrixLevelSource` and `deltaMatrixLevelSourceAggregate`, dropping the same triple on `delta_prefix_pairs`.

The flag is threaded **explicitly** rather than read off `r.NativeGroupArray` inside the shared helpers: `range_window_fixed_accumulator.go`'s own `delta_prefix_pairs` term is still built by the hand-rolled `groupArrayIf`, so deriving the verdict from the plan node would wrongly drop its dedup pass whenever the boot-resolved feature flag happens to be on. Both files' doc comments carry that reasoning.

Emitted SQL is unchanged wherever `NativeGroupArray` is off, and the feature ships `AutoSelect: false`.

## The empirical re-verification (issue point 3)

The issue is explicit that the three preconditions #2749 established must be **re-run** for the combinator form, not assumed to carry over. They now are, as real-ClickHouse probes sitting alongside the plain form's own in `range_window_group_array_realch_integration_test.go`, at `chopt.FeatureTSGridGroupArray`'s own 25.9 floor. They need no recipe change: `just ts-grid-group-array-integration` (the `strict-scan` lane) already selects them through its `^TestTimeSeriesGroupArray_` `-run` pattern.

- `DateTime64(9)` is accepted directly and losslessly under `-If`, with `UInt64` still rejected for contrast.
- The NaN duplicate remains insertion-order dependent under `-If` — which is what extends the `AutoSelect: false` posture to these sites rather than leaving it resting on the plain form.
- Plus the question only the combinator form can pose: `cond` gates whether a row reaches the fold **at all**, so the duplicate-timestamp collapse runs over the rows *passing* `cond`, and a cond-failing row can never take a timestamp from a passing one. The probe seeds a duplicate whose **larger** value fails `cond`, so a collapse-before-filter ordering would return an empty array — which, given `seriesArrayPairIfFrag`'s two complementary predicates, would silently lose samples from **both** arms of the split.

`internal/chsql/range_window_group_array_if_chdb_test.go` adds the differential: the same window emitted with `NativeGroupArray` false and true over a duplicate-bearing DELTA seed, asserting native equals fan-out per series and per anchor, and that a duplicate-timestamp series answers identically to its already-deduplicated twin. I mutation-checked it — forcing both dedup passes off makes it fail on four assertions rather than pass on a no-op.

## A red `main` this change had to fix

`test/spec/promql/native_group_array_delta_range_step.txtar`, the #2749 sibling, has been failing the required `roundtrip-promql-shard` lane on `main` since it landed (run `33542904102`, job `roundtrip-promql-shard (2)`: `reference: 7.5`, `cerberus: 22.5`). The first draft of this PR's own fixture reproduced it exactly, which is how it surfaced.

The cause is not the feature either fixture covers. **Which** of two *different* values survives a duplicate timestamp is implementation-defined on both sides: ClickHouse's `timeSeriesGroupArray` keeps the max-valued row, the reference engine's TSDB appender keeps whichever sample it ingested first. Seeding that made the `parity:` enrolment assert something neither engine promises. The duplicate pair now carries the same value, which leaves the collapse fully under test — dropping it would leave `delta()`'s window carrying an extra element and change the extrapolation's own `length(window_vals)` divisor — while taking the survivor choice out of the comparison.

This PR's own fixture hit a second, DELTA-specific form of the same problem that equal values do **not** fix: the parity harness's DELTA-to-cumulative adapter (`cumulativeDeltaSeries`) running-sums *every* seeded row, so two rows sharing a timestamp are two additive increments there while cerberus collapses them to one sample. That is a disagreement about what a duplicate OTel DELTA observation *means*. It therefore seeds two duplicate-free series with distinct DELTA patterns and keeps its enrolment; its earliest sample still lands in `delta_prefix_pairs` while the later two land in `window_pairs`, so both arms of the split still carry real data. The collapse coverage both fixtures were reaching for moved to the chDB differential above, where both sides of the comparison are cerberus's own two lowerings.

## Also

`range_window_fixed_accumulator.go`'s `delta_prefix_pairs` term now calls `groupArrayPairIfFrag` instead of re-inlining the identical `arraySort(groupArrayIf(...))` shape, so that helper's doc no longer names a call site that does not exist. Emitted SQL unchanged.

## Verification

- `go test -race -tags chdb ./internal/chsql/` — green, including the new differential.
- `TestLower/native_group_array_delta_range_step` and `TestLower/native_group_array_if_rate_delta_temporality_range` — both green through the full round-trip **and** the Prometheus parity comparison.
- Mutation check on the new differential: both dedup passes forced off ⇒ 4 failing assertions.
- `node .github/scripts/forbid-sql-raw.mjs` — clean. Every new expression is a typed Frag; no new token writes.
- Goldens regenerated with the update-golden mechanism, never hand-edited.

The `-If` probes themselves need a real ClickHouse server, so `strict-scan` is where they report — that is the lane they were written for.

Closes #2862

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E6EwMr2g22x8oT3kk7eTtR
