### PR TITLE
fix(ci): convert the promql, logql and traceql mutation legs to include_files

### DIFF
--- a/.github/scripts/README.md
+++ b/.github/scripts/README.md
@@ -920,8 +920,10 @@ what actually runs.
   - Exit: `0` when efficacy is `>=` threshold, `1` when below.
 - **`mutation-phases.mjs`** — data, imported by `mutation-matrix.mjs`. The single
   source of truth for the `mutation` lane's phase partition: each entry is one
-  gremlins run (`scope` package, optional scope-relative `exclude_files` RE2
-  alternation, `workers` cap, `--threshold-efficacy` bar), rendered straight into
+  gremlins run (`scope` package, optional scope-relative RE2 alternation naming
+  either the files the leg owns (`include_files`, used by every curated leg) or
+  the files it skips (`exclude_files`, used by the one catch-all leg per scope),
+  `workers` cap, `--threshold-efficacy` bar), rendered straight into
   `mutation.yml`'s `strategy.matrix`. It carries the per-leg rationale — the
   logql/traceql OOM splits, the equivalent-mutant analysis behind each bar — that
   used to live in the workflow. Also exports `HARNESS_PATHS`: the paths that
@@ -932,11 +934,13 @@ what actually runs.
   schedule / dispatch and on a `release/*` PR it selects every phase; on an
   ordinary PR — and on a merge-queue entry, off its own `base_sha..head_sha` —
   it selects only the legs whose scope the diff touches, applying each leg's
-  `exclude_files` to the SCOPE-RELATIVE path exactly as gremlins does.
+  file pattern to the SCOPE-RELATIVE path exactly as gremlins does.
   A changed path that lies inside a phase scope while claiming no leg is a
   coverage gap and fails the job rather than being dropped. `verify` mode asserts
   the table alone (every scope an existing directory, every pattern legal under
-  Go's RE2 — no lookaround, no backreferences); `emit` re-runs verify first, so
+  Go's RE2 — no lookaround, no backreferences — and every `include_files`
+  allowlist re-deriving from the real tree, so a name left behind by a deleted or
+  renamed file cannot shrink a leg silently); `emit` re-runs verify first, so
   it cannot ship a matrix built from a table that would have failed. `dump`
   validates and then writes the table to stdout as JSON and nothing else —
   that is the stream `test/regression/mutation_leg_partition_test.go` parses to

--- a/.github/scripts/mutation-matrix.mjs
+++ b/.github/scripts/mutation-matrix.mjs
@@ -22,11 +22,13 @@
 //
 // Three modes (env MODE, or argv[2]; default `verify`):
 //   - verify : assert the PHASES table is internally sound — unique phase names,
-//              every `scope` an existing directory, every `exclude_files`
-//              pattern compiling AND staying inside RE2 (no lookaround, no
-//              backreferences: Go's regexp rejects them, and round 11 of the
-//              traceql split burned a full CI cycle discovering that mid-run).
-//              Runs in milliseconds, installs nothing.
+//              every `scope` an existing directory, every `exclude_files` /
+//              `include_files` pattern compiling AND staying inside RE2 (no
+//              lookaround, no backreferences: Go's regexp rejects them, and
+//              round 11 of the traceql split burned a full CI cycle discovering
+//              that mid-run), and every `include_files` allowlist still matching
+//              exactly the files it names in the real tree. Runs in
+//              milliseconds, installs nothing.
 //   - emit   : run the same assertions, select the phases this event needs, and
 //              write `matrix=<json>` + `has_phases=true|false` to $GITHUB_OUTPUT.
 //              emit re-runs verify internally, so it can never ship a matrix
@@ -77,8 +79,54 @@ const NON_RE2_CONSTRUCTS = [
   { re: /\\[1-9]/, what: 'a backreference `\\1`' },
 ];
 
+// canonicalFilePattern — the ONE RE2 alternation this table uses to name a set
+// of scope-relative mutable files: `^(stem|stem|…)\.go$`, stems sorted and
+// regex-escaped. Both directions of the include/exclude translation go through
+// it, so a hand-written `include_files` and the `exclude_files` resolvePhases
+// derives from it are the same shape by construction rather than by review.
+// Returns null for an empty set — "names nothing" has no honest pattern.
+export function canonicalFilePattern(rels) {
+  const stems = [];
+  for (const rel of rels) {
+    if (!rel.endsWith('.go')) return null;
+    stems.push(rel.slice(0, -3).replace(/[.*+?^${}()|[\]\\]/g, '\\$&'));
+  }
+  if (stems.length === 0) return null;
+  return `^(${stems.sort().join('|')})\\.go$`;
+}
+
+// includeTightnessViolations — an `include_files` allowlist must be exactly the
+// canonical pattern for the files it actually claims, no more and no less.
+//
+// An allowlist fails differently from a denylist, and silently. A denylist that
+// names a since-deleted file over-excludes nothing (the name matches no path);
+// an allowlist that names one just claims fewer files than its doc comment
+// promises. Worse, a RENAME moves that file's whole mutant population out of
+// the curated leg and into the scope's catch-all with no signal at all — the
+// leg's efficacy denominator shifts underneath it while every check stays
+// green, because the exactly-one-owner invariant is still satisfied. Requiring
+// the pattern to re-derive from the real directory makes the drift a PR-time
+// failure that prints the pattern to paste. Caught `late_mat` in phase2-range
+// on its first run — deleted by cerberus #2830, still named in the allowlist.
+function includeTightnessViolations(name, phase, root) {
+  const directory = normalise(phase.scope);
+  const walkProblems = [];
+  const files = walkMutableGoFiles(root, directory, walkProblems);
+  if (walkProblems.length > 0) return walkProblems;
+  const includeRe = new RegExp(phase.include_files);
+  const claimed = files.map((file) => file.slice(directory.length + 1)).filter((rel) => includeRe.test(rel));
+  const canonical = canonicalFilePattern(claimed);
+  if (canonical === phase.include_files) return [];
+  return [
+    `phase "${name}" \`include_files\` is not the canonical allowlist of the files it actually claims in ` +
+      `${phase.scope} — it names a file that no longer exists, or is written in a non-canonical shape. ` +
+      `An allowlist that has drifted from the tree shrinks a leg silently. Expected: ` +
+      (canonical === null ? '(it claims no mutable Go file at all)' : `'${canonical}'`),
+  ];
+}
+
 // tableViolations — everything wrong with the PHASES table, as strings.
-export function tableViolations(phases) {
+export function tableViolations(phases, root = process.cwd()) {
   const problems = [];
   const seen = new Set();
 
@@ -126,7 +174,13 @@ export function tableViolations(phases) {
       problems.push(...filePatternViolations(name, 'exclude_files', p.exclude_files));
     }
     if (p.include_files !== undefined) {
-      problems.push(...filePatternViolations(name, 'include_files', p.include_files));
+      const patternProblems = filePatternViolations(name, 'include_files', p.include_files);
+      problems.push(...patternProblems);
+      // Tightness needs a compiled pattern and a real directory to walk. When
+      // either is already broken the message above is the actionable one.
+      if (patternProblems.length === 0 && p.scope && isDirectory(normalise(p.scope))) {
+        problems.push(...includeTightnessViolations(name, p, root));
+      }
     }
   }
 
@@ -423,7 +477,7 @@ export function resolvePhases(phases, root = process.cwd(), problems = []) {
     if (!phase.include_files) return phase;
     const directory = normalise(phase.scope);
     const includeRe = new RegExp(phase.include_files);
-    const excludedStems = [];
+    const excluded = [];
     for (const file of walkMutableGoFiles(root, directory, problems)) {
       const rel = file.slice(directory.length + 1);
       if (includeRe.test(rel)) continue;
@@ -431,11 +485,12 @@ export function resolvePhases(phases, root = process.cwd(), problems = []) {
         problems.push(`phase "${phase.phase}": derived exclude cannot express non-.go mutable file "${rel}"`);
         continue;
       }
-      excludedStems.push(rel.slice(0, -3).replace(/[.*+?^${}()|[\]\\]/g, '\\$&'));
+      excluded.push(rel);
     }
     const { include_files: _includeFiles, ...rest } = phase;
-    if (excludedStems.length === 0) return rest; // this leg's include already claims everything in scope
-    return { ...rest, exclude_files: `^(${excludedStems.sort().join('|')})\\.go$` };
+    const derived = canonicalFilePattern(excluded);
+    if (derived === null) return rest; // this leg's include already claims everything in scope
+    return { ...rest, exclude_files: derived };
   });
 }
 

--- a/.github/scripts/mutation-matrix.test.mjs
+++ b/.github/scripts/mutation-matrix.test.mjs
@@ -461,6 +461,43 @@ test('resolvePhases derives an include_files leg\'s real exclude_files from a di
   }
 });
 
+test('an include_files allowlist that has drifted from the tree is rejected', () => {
+  // The failure mode an allowlist introduces that a denylist does not. A
+  // denylist naming a since-deleted file over-excludes nothing; an allowlist
+  // naming one silently claims fewer files than its doc comment promises, and
+  // on a RENAME hands that file's whole mutant population to the scope's
+  // catch-all with every other check still green — the exactly-one-owner
+  // invariant is satisfied either way, so nothing else in this file would
+  // notice. Found `late_mat` (deleted by cerberus #2830) still named in
+  // phase2-range the first time it ran.
+  const real = PHASES.find((p) => p.phase === 'phase2-range');
+  assert.ok(real.include_files, 'phase2-range must still be an include_files leg for this test to mean anything');
+
+  // A name that no longer exists: rejected, and the message hands over the
+  // exact pattern to paste.
+  const stale = tableViolations([{ ...real, include_files: real.include_files.replace('^(', '^(late_mat|') }]);
+  assert.equal(stale.length, 1);
+  assert.match(stale[0], /is not the canonical allowlist/);
+  assert.ok(stale[0].includes(`Expected: '${real.include_files}'`), stale[0]);
+
+  // A pattern that claims the right files but is written loosely — here with
+  // the `$` anchor dropped, which is how `range_window` would silently swallow
+  // `range_window_fused.go` if that file ever moved into this scope's orbit.
+  const loose = tableViolations([{ ...real, include_files: '^(range_window)' }]);
+  assert.equal(loose.length, 1);
+  assert.match(loose[0], /is not the canonical allowlist/);
+
+  // An allowlist matching nothing at all is rejected too, rather than
+  // reporting a vacuous "canonical" agreement.
+  const empty = tableViolations([{ ...real, include_files: '^(no_such_emitter)\\.go$' }]);
+  assert.equal(empty.length, 1);
+  assert.match(empty[0], /claims no mutable Go file at all/);
+
+  // And the shipped table passes it — the same assertion the `verify` mode
+  // makes, pinned here so a drifted allowlist fails in the unit suite too.
+  assert.deepEqual(tableViolations(PHASES), []);
+});
+
 test('resolvePhases leaves an exclude_files (or bare) leg completely untouched', () => {
   const [rangeLeg] = PHASES.filter((p) => p.phase === 'phase3-optimizer');
   const [resolved] = resolvePhases([rangeLeg], process.cwd());

--- a/.github/scripts/mutation-matrix.test.mjs
+++ b/.github/scripts/mutation-matrix.test.mjs
@@ -3,15 +3,17 @@
 // Two things are pinned here, and both are gates rather than documentation:
 //
 //   1. The REAL PHASES table is sound against the REAL tree — every scope is an
-//      existing directory, every exclude_files pattern is RE2-legal. This is the
-//      cheap in-process version of the check that otherwise costs a full
-//      checkout + toolchain setup per leg before failing.
+//      existing directory, every include_files / exclude_files pattern is
+//      RE2-legal, and every allowlist still names the files it actually claims.
+//      This is the cheap in-process version of the check that otherwise costs a
+//      full checkout + toolchain setup per leg before failing.
 //
 //   2. The selection is EXACT, not merely non-empty. Asserting "chplan.go
 //      selects at least one leg" would pass while quietly running all eighteen;
 //      asserting the precise leg set is what proves the scoping actually scopes,
-//      and that a file claimed by one leg's exclude alternation is not silently
-//      claimed by a sibling's too.
+//      and that a file claimed by one leg's alternation is not silently claimed
+//      by a sibling's too — including a file that did not exist when the legs
+//      were written, which is the case cerberus issue #2814 is about.
 //
 // Run: node --test .github/scripts/mutation-matrix.test.mjs (from the repo root).
 
@@ -394,7 +396,7 @@ test('a change under one scope selects exactly that scope’s leg', () => {
   assert.deepEqual(names(select(['internal/spansscan/match.go'])), ['phase6-spansscan']);
 });
 
-test('the chsql legs partition the package by exclude_files, one leg per file', () => {
+test('the chsql legs partition the package, one leg per file', () => {
   assert.deepEqual(names(select(['internal/chsql/metrics_compare.go'])), ['phase2-compare']);
   assert.deepEqual(names(select(['internal/chsql/emit_node.go'])), ['phase2-compare']);
   assert.deepEqual(names(select(['internal/chsql/emit.go'])), ['phase2-compare']);
@@ -498,13 +500,97 @@ test('an include_files allowlist that has drifted from the tree is rejected', ()
   assert.deepEqual(tableViolations(PHASES), []);
 });
 
+// The regression cerberus issue #2814 is actually about, checked on every
+// multi-leg scope rather than on the one that happened to get hit twice.
+//
+// Before the include_files conversion this was a live landmine in three of the
+// four groups: a brand-new file matches no curated leg's hand-written DENYLIST,
+// and an exclude-shaped leg claims everything it does not name — so the new
+// file was claimed by all twelve promql legs, all four logql legs, both
+// lsyntax legs and both traceql pairs at once. Each collision is a hard
+// `ownershipViolations` failure that surfaces only once CI runs the selector,
+// and clearing it means hand-patching every one of those regexes.
+//
+// Note what is NOT asserted: that some leg claims the file. Exactly one leg
+// must, and it must be the scope's catch-all — "at least one" would pass in
+// precisely the broken state this pins against.
+const CATCH_ALL_BY_SCOPE = [
+  ['./internal/chsql', 'phase2-other'],
+  ['./internal/promql', 'phase4-promql-other'],
+  ['./internal/logql', 'phase4-logql-other-b'],
+  ['./internal/logql/logpattern', 'phase4-logql-other-b'],
+  ['./internal/logql/lsyntax', 'phase4-logql-lsyntax'],
+  ['./internal/traceql', 'phase4-traceql-other'],
+  ['./internal/traceql/ast', 'phase4-traceql-ast'],
+];
+
+// The probe file is REAL, briefly, and that is the point. resolvePhases derives
+// an allowlist leg's exclude_files from a live directory walk, so a purely
+// hypothetical path would exercise only the declared table and leave the one
+// gremlins actually receives untested. Written, measured, and removed before a
+// single assertion runs, so a failure never leaves it behind.
+const PROBE_BASENAME = 'zz_mutation_partition_probe.go';
+
+function claimersForProbe(scope) {
+  const directory = scope.replace(/^\.\//, '');
+  const probe = `${directory}/${PROBE_BASENAME}`;
+  writeFileSync(probe, `package ${basename(directory)}\n`);
+  try {
+    const resolved = resolvePhases(PHASES, process.cwd());
+    return {
+      probe,
+      declared: PHASES.filter((phase) => phaseClaims(phase, probe)).map((phase) => phase.phase),
+      resolved: resolved.filter((phase) => phaseClaims(phase, probe)).map((phase) => phase.phase),
+      selected: names(select([probe], { phases: resolved })),
+      gaps: select([probe], { phases: resolved }).gaps,
+    };
+  } finally {
+    rmSync(probe, { force: true });
+  }
+}
+
+test('a brand-new file in any multi-leg scope is claimed by exactly one leg, the catch-all', () => {
+  const measured = CATCH_ALL_BY_SCOPE.map(([scope, catchAll]) => [catchAll, claimersForProbe(scope)]);
+  for (const [catchAll, m] of measured) {
+    assert.deepEqual(m.declared, [catchAll], `declared table: ${m.probe} must fall through to ${catchAll} alone`);
+    assert.deepEqual(m.resolved, [catchAll], `resolved table: ${m.probe} must fall through to ${catchAll} alone`);
+    // Not a selector gap either: the new file selects that one leg and is
+    // mutated on a PR that touches it, rather than being owned by nobody.
+    assert.deepEqual(m.selected, [catchAll]);
+    assert.deepEqual(m.gaps, []);
+  }
+});
+
+test('every scope with sibling legs has exactly one catch-all to absorb a new file', () => {
+  // The structural precondition the test above depends on. A scope whose legs
+  // are ALL allowlists has nowhere for a new file to land: it would be claimed
+  // by nobody, which `selectPhases` reports as a coverage gap and
+  // `ownershipViolations` as "claimed by no mutation phase" — the opposite
+  // failure to the one #2814 fixed, and just as silent until someone adds a
+  // file. Pinned here so converting the last denylist in a group fails at PR
+  // time instead.
+  const byScope = new Map();
+  for (const phase of PHASES) {
+    if (!byScope.has(phase.scope)) byScope.set(phase.scope, []);
+    byScope.get(phase.scope).push(phase);
+  }
+  for (const [scope, legs] of byScope) {
+    const catchAlls = legs.filter((leg) => leg.include_files === undefined).map((leg) => leg.phase);
+    assert.equal(catchAlls.length, 1, `scope ${scope} must have exactly one non-allowlist leg, got [${catchAlls}]`);
+  }
+  // Every scope in the table is covered, and the conversion actually happened:
+  // the allowlist legs are the majority now, not the chsql-only exception.
+  assert.equal(byScope.size, 10);
+  assert.equal(PHASES.filter((p) => p.include_files !== undefined).length, 20);
+});
+
 test('resolvePhases leaves an exclude_files (or bare) leg completely untouched', () => {
   const [rangeLeg] = PHASES.filter((p) => p.phase === 'phase3-optimizer');
   const [resolved] = resolvePhases([rangeLeg], process.cwd());
   assert.deepEqual(resolved, rangeLeg);
 });
 
-test('the promql legs partition the package by exclude_files, one leg per file', () => {
+test('the promql legs partition the package, one leg per file', () => {
   // The two oversized single files each get a dedicated leg.
   assert.deepEqual(names(select(['internal/promql/lower.go'])), ['phase4-promql-lower']);
   assert.deepEqual(names(select(['internal/promql/histogram_quantile.go'])), ['phase4-promql-quantile']);
@@ -519,7 +605,7 @@ test('the promql legs partition the package by exclude_files, one leg per file',
   assert.deepEqual(names(select(['internal/promql/doc.go'])), ['phase4-promql-other']);
 });
 
-test('the logql legs partition the package by exclude_files, one leg per file', () => {
+test('the logql legs partition the package, one leg per file', () => {
   assert.deepEqual(names(select(['internal/logql/lower.go'])), ['phase4-logql-lower']);
   assert.deepEqual(names(select(['internal/logql/range_aggregation.go'])), ['phase4-logql-aggregation']);
   assert.deepEqual(names(select(['internal/logql/dotted_labels.go'])), ['phase4-logql-other-a']);

--- a/.github/scripts/mutation-phases.mjs
+++ b/.github/scripts/mutation-phases.mjs
@@ -95,10 +95,12 @@ export const PHASES = [
     efficacy: EFFICACY,
     workers: DEFAULT_WORKERS,
     // range_window(228) + aggregate_range_lwr_fusion(29) +
-    // late_mat(25) + range_bucket_fanout(17) +
-    // range_window_stale_resample(11) + fnresolution(4) +
-    // lwr_fanout_bound(2). range_window.go alone is the package's single
-    // largest file; the rest of this leg is greedy-balance filler, not theme.
+    // range_bucket_fanout(17) + range_window_stale_resample(11) +
+    // fnresolution(4) + lwr_fanout_bound(2). range_window.go alone is the
+    // package's single largest file; the rest of this leg is greedy-balance
+    // filler, not theme. late_mat(25) was part of this balance until cerberus
+    // #2830 deleted late_mat.go outright; the allowlist kept naming it until
+    // the include-tightness check in mutation-matrix.mjs caught the dead name.
     //
     // `include_files` (an allowlist), not `exclude_files`: this leg owns a
     // small, curated set, and an exclude-shaped pattern would have to name
@@ -111,7 +113,7 @@ export const PHASES = [
     // gremlins runs against from this list plus a live directory walk, so a
     // new file falls straight through to phase2-other's catch-all, exactly
     // as an existing unclaimed file already does today.
-    include_files: '^(aggregate_range_lwr_fusion|fnresolution|late_mat|lwr_fanout_bound|range_bucket_fanout|range_window|range_window_stale_resample)\\.go$',
+    include_files: '^(aggregate_range_lwr_fusion|fnresolution|lwr_fanout_bound|range_bucket_fanout|range_window|range_window_stale_resample)\\.go$',
   },
   {
     phase: 'phase2-builder',
@@ -188,7 +190,7 @@ export const PHASES = [
     // tally the next time a mutant here gets a new "NOT KILLABLE" note, and
     // re-partition the leg wider if it ever approaches the margin.
     exclude_files:
-      '^(aggregate_range_lwr_fusion|builder|emit|emit_node|exemplars|fnresolution|histogram_over_time|histogram_projection|histogram_quantile_native|late_mat|lwr_fanout_bound|metrics_compare|metrics_second_stage|nary_vector_set_op|nested_set_annotate|range_bucket_fanout|range_lwr|range_window|range_window_fused|range_window_stale_resample|range_window_variants|rate_window_fanout_bound|vector_join|vector_set_op)\\.go$',
+      '^(aggregate_range_lwr_fusion|builder|emit|emit_node|exemplars|fnresolution|histogram_over_time|histogram_projection|histogram_quantile_native|lwr_fanout_bound|metrics_compare|metrics_second_stage|nary_vector_set_op|nested_set_annotate|range_bucket_fanout|range_lwr|range_window|range_window_fused|range_window_stale_resample|range_window_variants|rate_window_fanout_bound|vector_join|vector_set_op)\\.go$',
   },
   {
     phase: 'phase3-optimizer',

--- a/.github/scripts/mutation-phases.mjs
+++ b/.github/scripts/mutation-phases.mjs
@@ -2,16 +2,51 @@
 // phase partition (mutation.yml's `mutate` strategy.matrix).
 //
 // Each entry is one gremlins run: a `scope` package (walked recursively), an
-// optional scope-relative `exclude_files` RE2 alternation carving that scope
-// into sibling legs, a `workers` cap, and the `--threshold-efficacy` bar the
-// leg must clear. The keys are the matrix keys mutation.yml interpolates as
-// `matrix.scope` / `matrix.workers` / `matrix.exclude_files` / `matrix.efficacy`
-// / `matrix.phase`, so this table renders straight into `strategy.matrix.include`.
+// optional scope-relative RE2 alternation carving that scope into sibling legs,
+// a `workers` cap, and the `--threshold-efficacy` bar the leg must clear. The
+// keys are the matrix keys mutation.yml interpolates as `matrix.scope` /
+// `matrix.workers` / `matrix.exclude_files` / `matrix.efficacy` /
+// `matrix.phase`, so this table renders straight into `strategy.matrix.include`.
 //
 // It lives in JS rather than inline YAML because mutation-matrix.mjs has to
 // REASON about it — selecting the legs an ordinary PR's diff actually touches,
-// and asserting the exclude regexes stay RE2-safe — and a workflow `include:`
+// and asserting the file regexes stay RE2-safe — and a workflow `include:`
 // block is data the workflow cannot read back.
+//
+// include_files vs exclude_files (cerberus issue #2814)
+// ----------------------------------------------------
+// A leg names its file set one way or the other, never both, and which one it
+// picks is decided by its ROLE in the scope, not by taste:
+//
+//   - A CURATED leg — one of several siblings sharing a scope, owning a small
+//     hand-balanced set — uses `include_files`, an allowlist. Expressing the
+//     same ownership as a denylist means naming every OTHER file in the
+//     package, including files that do not exist yet, and that is precisely
+//     what broke: a brand-new file matched none of its siblings' hand-written
+//     denylists, so EVERY curated leg claimed it at once, a hard
+//     `ownershipViolations` failure that surfaced only once CI ran and needed
+//     N separate regexes hand-patched to clear. It happened twice in one
+//     evening on two different new internal/chsql emitters. An allowlist
+//     cannot make that mistake: a new file simply is not in it.
+//
+//   - The scope's CATCH-ALL leg — exactly one per scope — uses `exclude_files`,
+//     naming its siblings' files and claiming everything else. That is what
+//     makes a new file land somewhere by default instead of nowhere, and why
+//     the catch-all is the one leg that must keep no positive file list to
+//     fall out of sync.
+//
+// gremlins itself only understands `--exclude-files`, so resolvePhases
+// (mutation-matrix.mjs) translates every allowlist into the equivalent denylist
+// at emit/dump time by walking the scope's real files. That walk is where a new
+// file gets classified for free: it matches no allowlist, lands in every
+// curated leg's DERIVED denylist, and falls through to the catch-all. No hand
+// edit anywhere.
+//
+// The cost of an allowlist is that it goes stale silently — a name left behind
+// by a deleted or renamed file shrinks the leg without tripping the
+// exactly-one-owner invariant. `tableViolations` therefore re-derives each
+// allowlist from the tree and fails when the two disagree, so the staleness is
+// a PR-time error rather than a drifting efficacy denominator.
 //
 // node: builtins only — no npm deps, no setup-node needed.
 
@@ -101,18 +136,6 @@ export const PHASES = [
     // filler, not theme. late_mat(25) was part of this balance until cerberus
     // #2830 deleted late_mat.go outright; the allowlist kept naming it until
     // the include-tightness check in mutation-matrix.mjs caught the dead name.
-    //
-    // `include_files` (an allowlist), not `exclude_files`: this leg owns a
-    // small, curated set, and an exclude-shaped pattern would have to name
-    // every OTHER file in the package to express that — including files that
-    // do not exist yet. cerberus issue #2814: a new chsql file matched none of
-    // the four legs' hand-written exclude lists and was claimed by all of
-    // them until three separate regexes were hand-patched. An allowlist leg
-    // cannot make that mistake — a new file simply isn't in it — and
-    // resolvePhases (mutation-matrix.mjs) derives the real `exclude_files`
-    // gremlins runs against from this list plus a live directory walk, so a
-    // new file falls straight through to phase2-other's catch-all, exactly
-    // as an existing unclaimed file already does today.
     include_files: '^(aggregate_range_lwr_fusion|fnresolution|lwr_fanout_bound|range_bucket_fanout|range_window|range_window_stale_resample)\\.go$',
   },
   {
@@ -124,9 +147,6 @@ export const PHASES = [
     // range_window_variants(31) + vector_join(27) +
     // range_lwr(24) + vector_set_op(10) +
     // nary_vector_set_op(6) + rate_window_fanout_bound(2).
-    //
-    // `include_files`, not `exclude_files` — see phase2-range's own comment
-    // for why (cerberus issue #2814).
     include_files: '^(builder|nary_vector_set_op|nested_set_annotate|range_lwr|range_window_variants|rate_window_fanout_bound|vector_join|vector_set_op)\\.go$',
   },
   {
@@ -139,9 +159,6 @@ export const PHASES = [
     // range_window_fused(29) + histogram_over_time(25) +
     // histogram_projection(21) + emit(12) +
     // metrics_second_stage(10).
-    //
-    // `include_files`, not `exclude_files` — see phase2-range's own comment
-    // for why (cerberus issue #2814).
     include_files: '^(emit|emit_node|exemplars|histogram_over_time|histogram_projection|histogram_quantile_native|metrics_compare|metrics_second_stage|range_window_fused)\\.go$',
   },
   {
@@ -245,8 +262,8 @@ export const PHASES = [
     // lower.go only (485 mutants, the package's single largest file,
     // same reason phase4-traceql-lower and phase4-logql-lower each get a
     // dedicated leg for their own oversized file).
-    exclude_files:
-      '^(absent|binary|classic_bucket_merge_bound|classic_bucket_merge_summap|date_fns|doc|duplicate_labelset_guard|exp_histogram_merge_summap|exp_histogram_merge_summap_bound|histogram_bucket|histogram_merge_bound|histogram_native_avg|histogram_native_bare|histogram_native_binop|histogram_native_binop_card|histogram_native_binop_eq|histogram_native_binop_match|histogram_native_count|histogram_native_count_present_over_time|histogram_native_count_values|histogram_native_drop_aggregation|histogram_native_dropping_shape|histogram_native_float_fn|histogram_native_float_vector_binop|histogram_native_float_vector_scaling_binop|histogram_native_label_replace|histogram_native_last_first_over_time|histogram_native_mixed_or|histogram_native_mixed_or_aggregate|histogram_native_mixed_or_aggregate_count_values|histogram_native_mixed_or_aggregate_float_only|histogram_native_mixed_or_aggregate_presence|histogram_native_mixed_or_aggregate_topk|histogram_native_mixed_or_arithmetic|histogram_native_mixed_or_comparison|histogram_native_mixed_or_datefn|histogram_native_mixed_or_info|histogram_native_mixed_or_label|histogram_native_mixed_or_math_fn|histogram_native_mixed_or_scalar|histogram_native_mixed_or_scale|histogram_native_mixed_or_sort|histogram_native_mixed_or_sort_by_label|histogram_native_mixed_or_subquery_aggregate_range_fn|histogram_native_mixed_or_subquery_further_setop_range_fn|histogram_native_mixed_or_subquery_last_first|histogram_native_mixed_or_subquery_range_fn|histogram_native_mixed_or_subquery_resets_changes|histogram_native_mixed_or_timestamp|histogram_native_mixed_or_value_fn|histogram_native_mixed_or_vector_arithmetic|histogram_native_mixed_or_vector_comparison|histogram_native_mixed_or_vector_plain_arithmetic|histogram_native_mixed_or_vector_plain_comparison|histogram_native_over_time|histogram_native_range_fn|histogram_native_reset|histogram_native_resets|histogram_native_scalar_binop|histogram_native_set_op|histogram_native_subquery_call_subquery|histogram_native_subquery_call_subquery_outer_fn|histogram_native_subquery_select|histogram_native_sum|histogram_native_timestamp|histogram_native_ts_of_first_last_over_time|histogram_native_unary|histogram_native_value_producing_call|histogram_quantile|histogram_quantile_classic_native|histogram_quantile_float|histogram_quantile_le|histogram_quantile_native_window|histogram_quantile_range|histogram_quantile_window|histogram_shape_guard|histogram_synthetic_names|histogram_value_fns|histogram_wire_arms|info_fn|instant_fns|label_fns|lower_strategy|metadata_catalog|modifiers|parser_shape|range_fns|regex_histogram_lower|resource_attributes|resource_bounds_env|scalar|scalar_args|scalar_domain|scalar_guard|schema_lookup|sort|subquery|synthetic|unary)\\.go$',
+    include_files:
+      '^(lower)\\.go$',
   },
   {
     phase: 'phase4-promql-quantile',
@@ -256,8 +273,8 @@ export const PHASES = [
     // histogram_quantile.go only (359 mutants, the second largest — also
     // too big to fold into a balanced filler leg without recreating the
     // imbalance this split exists to fix).
-    exclude_files:
-      '^(absent|binary|classic_bucket_merge_bound|classic_bucket_merge_summap|date_fns|doc|duplicate_labelset_guard|exp_histogram_merge_summap|exp_histogram_merge_summap_bound|histogram_bucket|histogram_merge_bound|histogram_native_avg|histogram_native_bare|histogram_native_binop|histogram_native_binop_card|histogram_native_binop_eq|histogram_native_binop_match|histogram_native_count|histogram_native_count_present_over_time|histogram_native_count_values|histogram_native_drop_aggregation|histogram_native_dropping_shape|histogram_native_float_fn|histogram_native_float_vector_binop|histogram_native_float_vector_scaling_binop|histogram_native_label_replace|histogram_native_last_first_over_time|histogram_native_mixed_or|histogram_native_mixed_or_aggregate|histogram_native_mixed_or_aggregate_count_values|histogram_native_mixed_or_aggregate_float_only|histogram_native_mixed_or_aggregate_presence|histogram_native_mixed_or_aggregate_topk|histogram_native_mixed_or_arithmetic|histogram_native_mixed_or_comparison|histogram_native_mixed_or_datefn|histogram_native_mixed_or_info|histogram_native_mixed_or_label|histogram_native_mixed_or_math_fn|histogram_native_mixed_or_scalar|histogram_native_mixed_or_scale|histogram_native_mixed_or_sort|histogram_native_mixed_or_sort_by_label|histogram_native_mixed_or_subquery_aggregate_range_fn|histogram_native_mixed_or_subquery_further_setop_range_fn|histogram_native_mixed_or_subquery_last_first|histogram_native_mixed_or_subquery_range_fn|histogram_native_mixed_or_subquery_resets_changes|histogram_native_mixed_or_timestamp|histogram_native_mixed_or_value_fn|histogram_native_mixed_or_vector_arithmetic|histogram_native_mixed_or_vector_comparison|histogram_native_mixed_or_vector_plain_arithmetic|histogram_native_mixed_or_vector_plain_comparison|histogram_native_over_time|histogram_native_range_fn|histogram_native_reset|histogram_native_resets|histogram_native_scalar_binop|histogram_native_set_op|histogram_native_subquery_call_subquery|histogram_native_subquery_call_subquery_outer_fn|histogram_native_subquery_select|histogram_native_sum|histogram_native_timestamp|histogram_native_ts_of_first_last_over_time|histogram_native_unary|histogram_native_value_producing_call|histogram_quantile_classic_native|histogram_quantile_float|histogram_quantile_le|histogram_quantile_native_window|histogram_quantile_range|histogram_quantile_window|histogram_shape_guard|histogram_synthetic_names|histogram_value_fns|histogram_wire_arms|info_fn|instant_fns|label_fns|lower|lower_strategy|metadata_catalog|modifiers|parser_shape|range_fns|regex_histogram_lower|resource_attributes|resource_bounds_env|scalar|scalar_args|scalar_domain|scalar_guard|schema_lookup|sort|subquery|synthetic|unary)\\.go$',
+    include_files:
+      '^(histogram_quantile)\\.go$',
   },
   {
     phase: 'phase4-promql-a',
@@ -266,8 +283,8 @@ export const PHASES = [
     workers: DEFAULT_WORKERS,
     // subquery(268) + histogram_native_mixed_or_arithmetic(12) +
     // histogram_native_drop_aggregation(9) + histogram_native_mixed_or_datefn(3).
-    exclude_files:
-      '^(absent|binary|classic_bucket_merge_bound|classic_bucket_merge_summap|date_fns|doc|duplicate_labelset_guard|exp_histogram_merge_summap|exp_histogram_merge_summap_bound|histogram_bucket|histogram_merge_bound|histogram_native_avg|histogram_native_bare|histogram_native_binop|histogram_native_binop_card|histogram_native_binop_eq|histogram_native_binop_match|histogram_native_count|histogram_native_count_present_over_time|histogram_native_count_values|histogram_native_dropping_shape|histogram_native_float_fn|histogram_native_float_vector_binop|histogram_native_float_vector_scaling_binop|histogram_native_label_replace|histogram_native_last_first_over_time|histogram_native_mixed_or|histogram_native_mixed_or_aggregate|histogram_native_mixed_or_aggregate_count_values|histogram_native_mixed_or_aggregate_float_only|histogram_native_mixed_or_aggregate_presence|histogram_native_mixed_or_aggregate_topk|histogram_native_mixed_or_comparison|histogram_native_mixed_or_info|histogram_native_mixed_or_label|histogram_native_mixed_or_math_fn|histogram_native_mixed_or_scalar|histogram_native_mixed_or_scale|histogram_native_mixed_or_sort|histogram_native_mixed_or_sort_by_label|histogram_native_mixed_or_subquery_aggregate_range_fn|histogram_native_mixed_or_subquery_further_setop_range_fn|histogram_native_mixed_or_subquery_last_first|histogram_native_mixed_or_subquery_range_fn|histogram_native_mixed_or_subquery_resets_changes|histogram_native_mixed_or_timestamp|histogram_native_mixed_or_value_fn|histogram_native_mixed_or_vector_arithmetic|histogram_native_mixed_or_vector_comparison|histogram_native_mixed_or_vector_plain_arithmetic|histogram_native_mixed_or_vector_plain_comparison|histogram_native_over_time|histogram_native_range_fn|histogram_native_reset|histogram_native_resets|histogram_native_scalar_binop|histogram_native_set_op|histogram_native_subquery_call_subquery|histogram_native_subquery_call_subquery_outer_fn|histogram_native_subquery_select|histogram_native_sum|histogram_native_timestamp|histogram_native_ts_of_first_last_over_time|histogram_native_unary|histogram_native_value_producing_call|histogram_quantile|histogram_quantile_classic_native|histogram_quantile_float|histogram_quantile_le|histogram_quantile_native_window|histogram_quantile_range|histogram_quantile_window|histogram_shape_guard|histogram_synthetic_names|histogram_value_fns|histogram_wire_arms|info_fn|instant_fns|label_fns|lower|lower_strategy|metadata_catalog|modifiers|parser_shape|range_fns|regex_histogram_lower|resource_attributes|resource_bounds_env|scalar|scalar_args|scalar_domain|scalar_guard|schema_lookup|sort|synthetic|unary)\\.go$',
+    include_files:
+      '^(histogram_native_drop_aggregation|histogram_native_mixed_or_arithmetic|histogram_native_mixed_or_datefn|subquery)\\.go$',
   },
   {
     phase: 'phase4-promql-b',
@@ -278,8 +295,8 @@ export const PHASES = [
     // histogram_native_last_first_over_time(29) + schema_lookup(19) +
     // histogram_native_float_vector_scaling_binop(16) + histogram_synthetic_names(8) +
     // histogram_native_mixed_or_aggregate_float_only(4).
-    exclude_files:
-      '^(absent|binary|classic_bucket_merge_bound|classic_bucket_merge_summap|date_fns|doc|duplicate_labelset_guard|exp_histogram_merge_summap|exp_histogram_merge_summap_bound|histogram_bucket|histogram_merge_bound|histogram_native_avg|histogram_native_bare|histogram_native_binop|histogram_native_binop_card|histogram_native_binop_eq|histogram_native_binop_match|histogram_native_count|histogram_native_count_present_over_time|histogram_native_count_values|histogram_native_drop_aggregation|histogram_native_dropping_shape|histogram_native_float_fn|histogram_native_float_vector_binop|histogram_native_label_replace|histogram_native_mixed_or|histogram_native_mixed_or_aggregate|histogram_native_mixed_or_aggregate_count_values|histogram_native_mixed_or_aggregate_presence|histogram_native_mixed_or_aggregate_topk|histogram_native_mixed_or_arithmetic|histogram_native_mixed_or_comparison|histogram_native_mixed_or_datefn|histogram_native_mixed_or_info|histogram_native_mixed_or_label|histogram_native_mixed_or_math_fn|histogram_native_mixed_or_scalar|histogram_native_mixed_or_scale|histogram_native_mixed_or_sort|histogram_native_mixed_or_sort_by_label|histogram_native_mixed_or_subquery_aggregate_range_fn|histogram_native_mixed_or_subquery_further_setop_range_fn|histogram_native_mixed_or_subquery_last_first|histogram_native_mixed_or_subquery_range_fn|histogram_native_mixed_or_subquery_resets_changes|histogram_native_mixed_or_timestamp|histogram_native_mixed_or_value_fn|histogram_native_mixed_or_vector_arithmetic|histogram_native_mixed_or_vector_comparison|histogram_native_mixed_or_vector_plain_arithmetic|histogram_native_mixed_or_vector_plain_comparison|histogram_native_over_time|histogram_native_range_fn|histogram_native_reset|histogram_native_resets|histogram_native_scalar_binop|histogram_native_set_op|histogram_native_subquery_call_subquery|histogram_native_subquery_call_subquery_outer_fn|histogram_native_subquery_select|histogram_native_sum|histogram_native_timestamp|histogram_native_ts_of_first_last_over_time|histogram_native_unary|histogram_native_value_producing_call|histogram_quantile|histogram_quantile_classic_native|histogram_quantile_float|histogram_quantile_le|histogram_quantile_native_window|histogram_quantile_range|histogram_shape_guard|histogram_value_fns|histogram_wire_arms|info_fn|instant_fns|label_fns|lower|lower_strategy|modifiers|parser_shape|range_fns|regex_histogram_lower|resource_attributes|resource_bounds_env|scalar|scalar_args|scalar_domain|scalar_guard|sort|subquery|synthetic|unary)\\.go$',
+    include_files:
+      '^(histogram_native_float_vector_scaling_binop|histogram_native_last_first_over_time|histogram_native_mixed_or_aggregate_float_only|histogram_quantile_window|histogram_synthetic_names|metadata_catalog|schema_lookup)\\.go$',
   },
   {
     phase: 'phase4-promql-c',
@@ -290,8 +307,8 @@ export const PHASES = [
     // histogram_native_binop_card(39) + histogram_native_reset(33) + scalar(27) +
     // histogram_native_dropping_shape(19) + histogram_native_mixed_or_subquery_range_fn(13) +
     // histogram_native_mixed_or_vector_plain_comparison(11) + scalar_guard(3).
-    exclude_files:
-      '^(absent|binary|classic_bucket_merge_bound|classic_bucket_merge_summap|date_fns|doc|duplicate_labelset_guard|exp_histogram_merge_summap|exp_histogram_merge_summap_bound|histogram_bucket|histogram_merge_bound|histogram_native_avg|histogram_native_bare|histogram_native_binop|histogram_native_binop_eq|histogram_native_binop_match|histogram_native_count|histogram_native_count_present_over_time|histogram_native_count_values|histogram_native_drop_aggregation|histogram_native_float_fn|histogram_native_float_vector_binop|histogram_native_float_vector_scaling_binop|histogram_native_label_replace|histogram_native_last_first_over_time|histogram_native_mixed_or|histogram_native_mixed_or_aggregate|histogram_native_mixed_or_aggregate_count_values|histogram_native_mixed_or_aggregate_float_only|histogram_native_mixed_or_aggregate_presence|histogram_native_mixed_or_aggregate_topk|histogram_native_mixed_or_arithmetic|histogram_native_mixed_or_comparison|histogram_native_mixed_or_datefn|histogram_native_mixed_or_info|histogram_native_mixed_or_label|histogram_native_mixed_or_math_fn|histogram_native_mixed_or_scalar|histogram_native_mixed_or_scale|histogram_native_mixed_or_sort|histogram_native_mixed_or_sort_by_label|histogram_native_mixed_or_subquery_aggregate_range_fn|histogram_native_mixed_or_subquery_further_setop_range_fn|histogram_native_mixed_or_subquery_last_first|histogram_native_mixed_or_subquery_resets_changes|histogram_native_mixed_or_timestamp|histogram_native_mixed_or_value_fn|histogram_native_mixed_or_vector_arithmetic|histogram_native_mixed_or_vector_comparison|histogram_native_mixed_or_vector_plain_arithmetic|histogram_native_over_time|histogram_native_resets|histogram_native_scalar_binop|histogram_native_set_op|histogram_native_subquery_call_subquery|histogram_native_subquery_call_subquery_outer_fn|histogram_native_subquery_select|histogram_native_sum|histogram_native_timestamp|histogram_native_ts_of_first_last_over_time|histogram_native_unary|histogram_native_value_producing_call|histogram_quantile|histogram_quantile_classic_native|histogram_quantile_float|histogram_quantile_le|histogram_quantile_native_window|histogram_quantile_range|histogram_quantile_window|histogram_shape_guard|histogram_synthetic_names|histogram_wire_arms|info_fn|instant_fns|label_fns|lower|lower_strategy|metadata_catalog|modifiers|parser_shape|range_fns|regex_histogram_lower|resource_attributes|resource_bounds_env|scalar_args|scalar_domain|schema_lookup|sort|subquery|synthetic|unary)\\.go$',
+    include_files:
+      '^(histogram_native_binop_card|histogram_native_dropping_shape|histogram_native_mixed_or_subquery_range_fn|histogram_native_mixed_or_vector_plain_comparison|histogram_native_range_fn|histogram_native_reset|histogram_value_fns|scalar|scalar_guard)\\.go$',
   },
   {
     phase: 'phase4-promql-d',
@@ -301,8 +318,8 @@ export const PHASES = [
     // scalar_args(77) + resource_attributes(55) + date_fns(40) + regex_histogram_lower(37) +
     // histogram_native_over_time(31) + histogram_native_timestamp(23) +
     // histogram_native_mixed_or_comparison(18) + histogram_native_mixed_or_info(7) + unary(4).
-    exclude_files:
-      '^(absent|binary|classic_bucket_merge_bound|classic_bucket_merge_summap|doc|duplicate_labelset_guard|exp_histogram_merge_summap|exp_histogram_merge_summap_bound|histogram_bucket|histogram_merge_bound|histogram_native_avg|histogram_native_bare|histogram_native_binop|histogram_native_binop_card|histogram_native_binop_eq|histogram_native_binop_match|histogram_native_count|histogram_native_count_present_over_time|histogram_native_count_values|histogram_native_drop_aggregation|histogram_native_dropping_shape|histogram_native_float_fn|histogram_native_float_vector_binop|histogram_native_float_vector_scaling_binop|histogram_native_label_replace|histogram_native_last_first_over_time|histogram_native_mixed_or|histogram_native_mixed_or_aggregate|histogram_native_mixed_or_aggregate_count_values|histogram_native_mixed_or_aggregate_float_only|histogram_native_mixed_or_aggregate_presence|histogram_native_mixed_or_aggregate_topk|histogram_native_mixed_or_arithmetic|histogram_native_mixed_or_datefn|histogram_native_mixed_or_label|histogram_native_mixed_or_math_fn|histogram_native_mixed_or_scalar|histogram_native_mixed_or_scale|histogram_native_mixed_or_sort|histogram_native_mixed_or_sort_by_label|histogram_native_mixed_or_subquery_aggregate_range_fn|histogram_native_mixed_or_subquery_further_setop_range_fn|histogram_native_mixed_or_subquery_last_first|histogram_native_mixed_or_subquery_range_fn|histogram_native_mixed_or_subquery_resets_changes|histogram_native_mixed_or_timestamp|histogram_native_mixed_or_value_fn|histogram_native_mixed_or_vector_arithmetic|histogram_native_mixed_or_vector_comparison|histogram_native_mixed_or_vector_plain_arithmetic|histogram_native_mixed_or_vector_plain_comparison|histogram_native_range_fn|histogram_native_reset|histogram_native_resets|histogram_native_scalar_binop|histogram_native_set_op|histogram_native_subquery_call_subquery|histogram_native_subquery_call_subquery_outer_fn|histogram_native_subquery_select|histogram_native_sum|histogram_native_ts_of_first_last_over_time|histogram_native_unary|histogram_native_value_producing_call|histogram_quantile|histogram_quantile_classic_native|histogram_quantile_float|histogram_quantile_le|histogram_quantile_native_window|histogram_quantile_range|histogram_quantile_window|histogram_shape_guard|histogram_synthetic_names|histogram_value_fns|histogram_wire_arms|info_fn|instant_fns|label_fns|lower|lower_strategy|metadata_catalog|modifiers|parser_shape|range_fns|resource_bounds_env|scalar|scalar_domain|scalar_guard|schema_lookup|sort|subquery|synthetic)\\.go$',
+    include_files:
+      '^(date_fns|histogram_native_mixed_or_comparison|histogram_native_mixed_or_info|histogram_native_over_time|histogram_native_timestamp|regex_histogram_lower|resource_attributes|scalar_args|unary)\\.go$',
   },
   {
     phase: 'phase4-promql-e',
@@ -313,8 +330,8 @@ export const PHASES = [
     // duplicate_labelset_guard(36) + histogram_bucket(29) +
     // histogram_native_mixed_or_vector_plain_arithmetic(22) + histogram_merge_bound(18) +
     // histogram_native_mixed_or_aggregate_presence(6) + histogram_native_unary(6).
-    exclude_files:
-      '^(binary|classic_bucket_merge_bound|classic_bucket_merge_summap|date_fns|doc|exp_histogram_merge_summap|exp_histogram_merge_summap_bound|histogram_native_avg|histogram_native_bare|histogram_native_binop|histogram_native_binop_card|histogram_native_binop_eq|histogram_native_binop_match|histogram_native_count|histogram_native_count_present_over_time|histogram_native_count_values|histogram_native_drop_aggregation|histogram_native_dropping_shape|histogram_native_float_fn|histogram_native_float_vector_binop|histogram_native_float_vector_scaling_binop|histogram_native_label_replace|histogram_native_last_first_over_time|histogram_native_mixed_or|histogram_native_mixed_or_aggregate|histogram_native_mixed_or_aggregate_count_values|histogram_native_mixed_or_aggregate_float_only|histogram_native_mixed_or_aggregate_topk|histogram_native_mixed_or_arithmetic|histogram_native_mixed_or_comparison|histogram_native_mixed_or_datefn|histogram_native_mixed_or_info|histogram_native_mixed_or_label|histogram_native_mixed_or_math_fn|histogram_native_mixed_or_scalar|histogram_native_mixed_or_scale|histogram_native_mixed_or_sort|histogram_native_mixed_or_sort_by_label|histogram_native_mixed_or_subquery_aggregate_range_fn|histogram_native_mixed_or_subquery_further_setop_range_fn|histogram_native_mixed_or_subquery_last_first|histogram_native_mixed_or_subquery_range_fn|histogram_native_mixed_or_subquery_resets_changes|histogram_native_mixed_or_timestamp|histogram_native_mixed_or_value_fn|histogram_native_mixed_or_vector_comparison|histogram_native_mixed_or_vector_plain_comparison|histogram_native_over_time|histogram_native_range_fn|histogram_native_reset|histogram_native_resets|histogram_native_scalar_binop|histogram_native_set_op|histogram_native_subquery_call_subquery|histogram_native_subquery_call_subquery_outer_fn|histogram_native_subquery_select|histogram_native_sum|histogram_native_timestamp|histogram_native_ts_of_first_last_over_time|histogram_native_value_producing_call|histogram_quantile|histogram_quantile_classic_native|histogram_quantile_float|histogram_quantile_le|histogram_quantile_native_window|histogram_quantile_range|histogram_quantile_window|histogram_shape_guard|histogram_synthetic_names|histogram_value_fns|histogram_wire_arms|info_fn|label_fns|lower|lower_strategy|metadata_catalog|modifiers|parser_shape|range_fns|regex_histogram_lower|resource_attributes|resource_bounds_env|scalar|scalar_args|scalar_domain|scalar_guard|schema_lookup|sort|subquery|synthetic|unary)\\.go$',
+    include_files:
+      '^(absent|duplicate_labelset_guard|histogram_bucket|histogram_merge_bound|histogram_native_mixed_or_aggregate_presence|histogram_native_mixed_or_vector_arithmetic|histogram_native_mixed_or_vector_plain_arithmetic|histogram_native_unary|instant_fns)\\.go$',
   },
   {
     phase: 'phase4-promql-f',
@@ -325,8 +342,8 @@ export const PHASES = [
     // synthetic(37) + modifiers(31) + histogram_native_binop_match(23) +
     // histogram_native_mixed_or_scale(17) + scalar_domain(8) + histogram_native_avg(3) +
     // histogram_native_mixed_or_sort(1).
-    exclude_files:
-      '^(absent|binary|classic_bucket_merge_bound|classic_bucket_merge_summap|date_fns|doc|duplicate_labelset_guard|exp_histogram_merge_summap|exp_histogram_merge_summap_bound|histogram_bucket|histogram_merge_bound|histogram_native_bare|histogram_native_binop|histogram_native_binop_card|histogram_native_binop_eq|histogram_native_count|histogram_native_count_present_over_time|histogram_native_count_values|histogram_native_drop_aggregation|histogram_native_dropping_shape|histogram_native_float_fn|histogram_native_float_vector_binop|histogram_native_float_vector_scaling_binop|histogram_native_label_replace|histogram_native_last_first_over_time|histogram_native_mixed_or|histogram_native_mixed_or_aggregate|histogram_native_mixed_or_aggregate_count_values|histogram_native_mixed_or_aggregate_float_only|histogram_native_mixed_or_aggregate_presence|histogram_native_mixed_or_aggregate_topk|histogram_native_mixed_or_arithmetic|histogram_native_mixed_or_comparison|histogram_native_mixed_or_datefn|histogram_native_mixed_or_info|histogram_native_mixed_or_label|histogram_native_mixed_or_math_fn|histogram_native_mixed_or_scalar|histogram_native_mixed_or_sort_by_label|histogram_native_mixed_or_subquery_aggregate_range_fn|histogram_native_mixed_or_subquery_further_setop_range_fn|histogram_native_mixed_or_subquery_last_first|histogram_native_mixed_or_subquery_range_fn|histogram_native_mixed_or_subquery_resets_changes|histogram_native_mixed_or_timestamp|histogram_native_mixed_or_value_fn|histogram_native_mixed_or_vector_arithmetic|histogram_native_mixed_or_vector_comparison|histogram_native_mixed_or_vector_plain_arithmetic|histogram_native_mixed_or_vector_plain_comparison|histogram_native_over_time|histogram_native_range_fn|histogram_native_reset|histogram_native_scalar_binop|histogram_native_set_op|histogram_native_subquery_call_subquery|histogram_native_subquery_call_subquery_outer_fn|histogram_native_subquery_select|histogram_native_sum|histogram_native_timestamp|histogram_native_ts_of_first_last_over_time|histogram_native_unary|histogram_native_value_producing_call|histogram_quantile|histogram_quantile_classic_native|histogram_quantile_float|histogram_quantile_le|histogram_quantile_range|histogram_quantile_window|histogram_shape_guard|histogram_synthetic_names|histogram_value_fns|histogram_wire_arms|info_fn|instant_fns|lower|lower_strategy|metadata_catalog|parser_shape|range_fns|regex_histogram_lower|resource_attributes|resource_bounds_env|scalar|scalar_args|scalar_guard|schema_lookup|sort|subquery|unary)\\.go$',
+    include_files:
+      '^(histogram_native_avg|histogram_native_binop_match|histogram_native_mixed_or_scale|histogram_native_mixed_or_sort|histogram_native_resets|histogram_quantile_native_window|label_fns|modifiers|scalar_domain|synthetic)\\.go$',
   },
   {
     phase: 'phase4-promql-g',
@@ -336,8 +353,8 @@ export const PHASES = [
     // binary(70) + info_fn(59) + lower_strategy(42) + histogram_native_mixed_or_math_fn(38) +
     // histogram_native_count_present_over_time(31) + histogram_quantile_classic_native(23) +
     // classic_bucket_merge_bound(16) + histogram_native_float_fn(10) + histogram_wire_arms(3).
-    exclude_files:
-      '^(absent|date_fns|doc|duplicate_labelset_guard|exp_histogram_merge_summap|exp_histogram_merge_summap_bound|histogram_bucket|histogram_merge_bound|histogram_native_avg|histogram_native_bare|histogram_native_binop|histogram_native_binop_card|histogram_native_binop_eq|histogram_native_binop_match|histogram_native_count|histogram_native_count_values|histogram_native_drop_aggregation|histogram_native_dropping_shape|histogram_native_float_vector_binop|histogram_native_float_vector_scaling_binop|histogram_native_label_replace|histogram_native_last_first_over_time|histogram_native_mixed_or|histogram_native_mixed_or_aggregate|histogram_native_mixed_or_aggregate_count_values|histogram_native_mixed_or_aggregate_float_only|histogram_native_mixed_or_aggregate_presence|histogram_native_mixed_or_aggregate_topk|histogram_native_mixed_or_arithmetic|histogram_native_mixed_or_comparison|histogram_native_mixed_or_datefn|histogram_native_mixed_or_info|histogram_native_mixed_or_label|histogram_native_mixed_or_scalar|histogram_native_mixed_or_scale|histogram_native_mixed_or_sort|histogram_native_mixed_or_sort_by_label|histogram_native_mixed_or_subquery_aggregate_range_fn|histogram_native_mixed_or_subquery_further_setop_range_fn|histogram_native_mixed_or_subquery_last_first|histogram_native_mixed_or_subquery_range_fn|histogram_native_mixed_or_subquery_resets_changes|histogram_native_mixed_or_timestamp|histogram_native_mixed_or_value_fn|histogram_native_mixed_or_vector_arithmetic|histogram_native_mixed_or_vector_comparison|histogram_native_mixed_or_vector_plain_arithmetic|histogram_native_mixed_or_vector_plain_comparison|histogram_native_over_time|histogram_native_range_fn|histogram_native_reset|histogram_native_resets|histogram_native_scalar_binop|histogram_native_set_op|histogram_native_subquery_call_subquery|histogram_native_subquery_call_subquery_outer_fn|histogram_native_subquery_select|histogram_native_sum|histogram_native_timestamp|histogram_native_ts_of_first_last_over_time|histogram_native_unary|histogram_native_value_producing_call|histogram_quantile|histogram_quantile_float|histogram_quantile_le|histogram_quantile_native_window|histogram_quantile_range|histogram_quantile_window|histogram_shape_guard|histogram_synthetic_names|histogram_value_fns|instant_fns|label_fns|lower|metadata_catalog|modifiers|parser_shape|range_fns|regex_histogram_lower|resource_attributes|resource_bounds_env|scalar|scalar_args|scalar_domain|scalar_guard|schema_lookup|sort|subquery|synthetic|unary)\\.go$',
+    include_files:
+      '^(binary|classic_bucket_merge_bound|classic_bucket_merge_summap|histogram_native_count_present_over_time|histogram_native_float_fn|histogram_native_mixed_or_math_fn|histogram_quantile_classic_native|histogram_wire_arms|info_fn|lower_strategy)\\.go$',
   },
   {
     phase: 'phase4-promql-h',
@@ -353,8 +370,8 @@ export const PHASES = [
     // #2724 — same family, joins this leg too) +
     // histogram_native_mixed_or_aggregate(27) + histogram_native_mixed_or(12) +
     // histogram_shape_guard(12) + histogram_native_mixed_or_aggregate_count_values(2).
-    exclude_files:
-      '^(absent|binary|classic_bucket_merge_bound|classic_bucket_merge_summap|date_fns|doc|duplicate_labelset_guard|exp_histogram_merge_summap|exp_histogram_merge_summap_bound|histogram_bucket|histogram_merge_bound|histogram_native_avg|histogram_native_bare|histogram_native_binop_card|histogram_native_binop_eq|histogram_native_binop_match|histogram_native_count|histogram_native_count_present_over_time|histogram_native_count_values|histogram_native_drop_aggregation|histogram_native_dropping_shape|histogram_native_float_fn|histogram_native_float_vector_binop|histogram_native_float_vector_scaling_binop|histogram_native_label_replace|histogram_native_last_first_over_time|histogram_native_mixed_or_aggregate_float_only|histogram_native_mixed_or_aggregate_presence|histogram_native_mixed_or_aggregate_topk|histogram_native_mixed_or_arithmetic|histogram_native_mixed_or_comparison|histogram_native_mixed_or_datefn|histogram_native_mixed_or_info|histogram_native_mixed_or_label|histogram_native_mixed_or_math_fn|histogram_native_mixed_or_scalar|histogram_native_mixed_or_scale|histogram_native_mixed_or_sort|histogram_native_mixed_or_sort_by_label|histogram_native_mixed_or_subquery_range_fn|histogram_native_mixed_or_timestamp|histogram_native_mixed_or_value_fn|histogram_native_mixed_or_vector_arithmetic|histogram_native_mixed_or_vector_comparison|histogram_native_mixed_or_vector_plain_arithmetic|histogram_native_mixed_or_vector_plain_comparison|histogram_native_over_time|histogram_native_range_fn|histogram_native_reset|histogram_native_resets|histogram_native_scalar_binop|histogram_native_set_op|histogram_native_subquery_call_subquery|histogram_native_subquery_call_subquery_outer_fn|histogram_native_subquery_select|histogram_native_sum|histogram_native_timestamp|histogram_native_ts_of_first_last_over_time|histogram_native_unary|histogram_native_value_producing_call|histogram_quantile|histogram_quantile_classic_native|histogram_quantile_le|histogram_quantile_native_window|histogram_quantile_range|histogram_quantile_window|histogram_synthetic_names|histogram_value_fns|histogram_wire_arms|info_fn|instant_fns|label_fns|lower|lower_strategy|metadata_catalog|modifiers|parser_shape|regex_histogram_lower|resource_attributes|resource_bounds_env|scalar|scalar_args|scalar_domain|scalar_guard|schema_lookup|subquery|synthetic|unary)\\.go$',
+    include_files:
+      '^(histogram_native_binop|histogram_native_mixed_or|histogram_native_mixed_or_aggregate|histogram_native_mixed_or_aggregate_count_values|histogram_native_mixed_or_subquery_aggregate_range_fn|histogram_native_mixed_or_subquery_further_setop_range_fn|histogram_native_mixed_or_subquery_last_first|histogram_native_mixed_or_subquery_resets_changes|histogram_quantile_float|histogram_shape_guard|range_fns|sort)\\.go$',
   },
   {
     phase: 'phase4-promql-i',
@@ -378,8 +395,8 @@ export const PHASES = [
     // rather than incidental coverage from a sweep, which is what cerberus
     // issue #2730 showed a shared leg needs to stay honest on a
     // CPU-constrained runner).
-    exclude_files:
-      '^(absent|binary|classic_bucket_merge_bound|classic_bucket_merge_summap|date_fns|doc|duplicate_labelset_guard|exp_histogram_merge_summap|exp_histogram_merge_summap_bound|histogram_bucket|histogram_merge_bound|histogram_native_avg|histogram_native_binop|histogram_native_binop_card|histogram_native_binop_match|histogram_native_count_present_over_time|histogram_native_drop_aggregation|histogram_native_dropping_shape|histogram_native_float_fn|histogram_native_float_vector_binop|histogram_native_float_vector_scaling_binop|histogram_native_label_replace|histogram_native_last_first_over_time|histogram_native_mixed_or|histogram_native_mixed_or_aggregate|histogram_native_mixed_or_aggregate_count_values|histogram_native_mixed_or_aggregate_float_only|histogram_native_mixed_or_aggregate_presence|histogram_native_mixed_or_aggregate_topk|histogram_native_mixed_or_arithmetic|histogram_native_mixed_or_comparison|histogram_native_mixed_or_datefn|histogram_native_mixed_or_info|histogram_native_mixed_or_math_fn|histogram_native_mixed_or_scalar|histogram_native_mixed_or_scale|histogram_native_mixed_or_sort|histogram_native_mixed_or_sort_by_label|histogram_native_mixed_or_subquery_aggregate_range_fn|histogram_native_mixed_or_subquery_further_setop_range_fn|histogram_native_mixed_or_subquery_last_first|histogram_native_mixed_or_subquery_range_fn|histogram_native_mixed_or_subquery_resets_changes|histogram_native_mixed_or_timestamp|histogram_native_mixed_or_vector_arithmetic|histogram_native_mixed_or_vector_plain_arithmetic|histogram_native_mixed_or_vector_plain_comparison|histogram_native_over_time|histogram_native_range_fn|histogram_native_reset|histogram_native_resets|histogram_native_scalar_binop|histogram_native_set_op|histogram_native_sum|histogram_native_timestamp|histogram_native_ts_of_first_last_over_time|histogram_native_unary|histogram_quantile|histogram_quantile_classic_native|histogram_quantile_float|histogram_quantile_le|histogram_quantile_native_window|histogram_quantile_range|histogram_quantile_window|histogram_shape_guard|histogram_synthetic_names|histogram_value_fns|histogram_wire_arms|info_fn|instant_fns|label_fns|lower|lower_strategy|metadata_catalog|modifiers|parser_shape|range_fns|regex_histogram_lower|resource_attributes|resource_bounds_env|scalar|scalar_args|scalar_domain|scalar_guard|schema_lookup|sort|subquery|synthetic|unary)\\.go$',
+    include_files:
+      '^(histogram_native_bare|histogram_native_binop_eq|histogram_native_count|histogram_native_count_values|histogram_native_mixed_or_label|histogram_native_mixed_or_value_fn|histogram_native_mixed_or_vector_comparison|histogram_native_subquery_call_subquery|histogram_native_subquery_call_subquery_outer_fn|histogram_native_subquery_select|histogram_native_value_producing_call)\\.go$',
   },
   {
     phase: 'phase4-promql-other',
@@ -419,8 +436,8 @@ export const PHASES = [
   // admits ~80 of ~300+ mutants in the package.
   //
   // Round 7 split phase4-logql into three sibling entries (lower / aggregation /
-  // other), each scoped to ./internal/logql but with --exclude-files regexes
-  // carving the source set into roughly equal slices. Round 8 split `other` into
+  // other), each scoped to ./internal/logql but with file regexes carving the
+  // source set into roughly equal slices. Round 8 split `other` into
   // `other-a` + `other-b`. Round 9 peeled dotted_labels.go into its own slice,
   // and round 10 (job 77211633492) proved even a single-file slice of that
   // surface SIGTERM'd at ~3 min — the runner-budget ceiling sat below it. That
@@ -455,10 +472,14 @@ export const PHASES = [
   // of directory). Once dotted_labels_test.go relocated into package lsyntax,
   // every covered mutant anywhere in lsyntax forced
   // `go test .../internal/logql/lsyntax` to link and run that heavier test
-  // binary, on every one of the four legs. Fix: exclude the whole lsyntax
-  // subtree (scope-relative '^lsyntax/', mirroring the phase4-traceql-lower
-  // '^ast/' precedent) from all four legs, and give lsyntax its own dedicated
-  // legs so the package keeps its mutation coverage instead of losing it.
+  // binary, on every one of the four legs. Fix: keep the whole lsyntax subtree
+  // out of all four legs, and give lsyntax its own dedicated legs so the
+  // package keeps its mutation coverage instead of losing it. The three curated
+  // legs do that by construction now — an `include_files` allowlist of bare
+  // filenames can never match a `lsyntax/…` scope-relative path — and the
+  // catch-all still names the subtree explicitly ('^lsyntax/', mirroring
+  // phase4-traceql-other's '^ast/' precedent), which is what an
+  // everything-else leg has to do to keep the subtree out.
   // ---------------------------------------------------------------------------
   {
     phase: 'phase4-logql-lower',
@@ -466,9 +487,8 @@ export const PHASES = [
     efficacy: EFFICACY,
     workers: SERIAL_WORKERS,
     // Mutate only lower.go (~50 KB, the package's largest source file).
-    // Excludes every other logql source plus the lsyntax subtree.
-    exclude_files:
-      '^lsyntax/|^(binary|detected_level|dotted_labels|drop_keep|literal|label_fns|top_level_columns|range_aggregation|vector_aggregation|lang)\\.go$|^logpattern/|^(doc|duration|ip|jsonpath|numbytes|pattern_filter|variants)\\.go$',
+    include_files:
+      '^(lower)\\.go$',
   },
   {
     phase: 'phase4-logql-aggregation',
@@ -476,8 +496,8 @@ export const PHASES = [
     efficacy: EFFICACY,
     workers: SERIAL_WORKERS,
     // Mutate range_aggregation.go + vector_aggregation.go + lang.go (~54 KB).
-    exclude_files:
-      '^lsyntax/|^(binary|detected_level|dotted_labels|drop_keep|literal|label_fns|top_level_columns|lower)\\.go$|^logpattern/|^(doc|duration|ip|jsonpath|numbytes|pattern_filter|variants)\\.go$',
+    include_files:
+      '^(lang|range_aggregation|vector_aggregation)\\.go$',
   },
   {
     phase: 'phase4-logql-other-a',
@@ -485,8 +505,8 @@ export const PHASES = [
     efficacy: EFFICACY,
     workers: SERIAL_WORKERS,
     // Mutate binary.go + detected_level.go + dotted_labels.go (~21 KB).
-    exclude_files:
-      '^lsyntax/|^(lower|range_aggregation|vector_aggregation|lang|drop_keep|literal|label_fns|top_level_columns)\\.go$|^logpattern/|^(doc|duration|ip|jsonpath|numbytes|pattern_filter|variants)\\.go$',
+    include_files:
+      '^(binary|detected_level|dotted_labels)\\.go$',
   },
   {
     phase: 'phase4-logql-other-b',
@@ -510,7 +530,8 @@ export const PHASES = [
     // Mutate parser.go only (~27 KB, the recursive-descent LogQL parser — the
     // densest control-flow surface in the package, same shape as
     // phase4-traceql-parser). dotted_labels.go belongs to the lsyntax leg.
-    exclude_files: '^(ast|binop|dotted_labels|errors|labelfilter|lexer|ops|string)\\.go$',
+    include_files:
+      '^(parser)\\.go$',
   },
   {
     phase: 'phase4-logql-lsyntax',
@@ -532,8 +553,9 @@ export const PHASES = [
   // errored before running: their exclude regexes used negative lookahead
   // `(?!…)`, which Go's RE2 engine rejects — pinned now by mutation-matrix.mjs's
   // RE2-safety assertion, so that mistake fails at PR time instead of mid-run.
-  // Round 12 splits into four legs, each an RE2-safe alternation of the files to
-  // exclude.
+  // Round 12 splits into four legs, each an RE2-safe alternation naming the
+  // files it owns (the two curated legs) or the files its siblings own (the two
+  // catch-alls).
   //
   // Efficacy is preserved by scoping rather than lost: gremlins runs the mutated
   // file's own package tests per mutant, so scoping the ast legs to
@@ -545,9 +567,10 @@ export const PHASES = [
     efficacy: EFFICACY,
     workers: SERIAL_WORKERS,
     // ast/parser.go only — where the ~109 timeout-inducing loop-control mutants
-    // live. exclude-files matches SCOPE-RELATIVE paths (here, relative to
+    // live. Both file patterns match SCOPE-RELATIVE paths (here, relative to
     // ./internal/traceql/ast), so entries are bare filenames.
-    exclude_files: '^(assert|attribute|doc|enum|expr|lexer|metrics|parse|pipeline|references|rewrite|static|validate)\\.go$',
+    include_files:
+      '^(parser)\\.go$',
   },
   {
     phase: 'phase4-traceql-ast',
@@ -562,9 +585,11 @@ export const PHASES = [
     scope: './internal/traceql',
     efficacy: EFFICACY,
     workers: SERIAL_WORKERS,
-    // lower.go only (~84 KB). scope ./internal/traceql recurses into ast/, so
-    // exclude the whole ast subtree plus the other top-level files.
-    exclude_files: '^ast/|^(aggregate|doc|group_coalesce|metrics_compare|metrics_pipeline|search_limit|select|spanset_operand)\\.go$',
+    // lower.go only (~84 KB). scope ./internal/traceql recurses into ast/; the
+    // allowlist keeps that subtree out by construction, since a bare-filename
+    // pattern can never match an `ast/…` scope-relative path.
+    include_files:
+      '^(lower)\\.go$',
   },
   {
     phase: 'phase4-traceql-other',

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -939,9 +939,9 @@ jobs:
       # its selector decides which legs an ordinary PR runs, so a bug there is
       # not a slow release but a SILENT one — legs quietly deselected while the
       # required `mutation` context still reports green. The tests pin the phase
-      # table against this tree (every scope a real directory, every
-      # exclude_files pattern legal under Go's RE2) and pin the selection
-      # EXACTLY, not merely non-empty.
+      # table against this tree (every scope a real directory, every file
+      # pattern legal under Go's RE2, every allowlist still naming files that
+      # exist) and pin the selection EXACTLY, not merely non-empty.
       - name: Assert the mutation phase selector scopes correctly
         run: node --test .github/scripts/mutation-matrix.test.mjs
 

--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -72,8 +72,10 @@ jobs:
   #
   # The phase table itself lives in .github/scripts/mutation-phases.mjs, not
   # inline here, because the selector has to REASON about it (match each leg's
-  # scope + scope-relative exclude_files against the PR diff, and assert the
-  # exclude patterns stay inside Go's RE2 dialect) — and a workflow `include:`
+  # scope + scope-relative file pattern against the PR diff, assert those
+  # patterns stay inside Go's RE2 dialect, and translate every `include_files`
+  # allowlist into the `exclude_files` gremlins understands) — and a workflow
+  # `include:`
   # block is data the workflow cannot read back. Same single-source-of-truth
   # shape as compose-smoke-setup / .github/scripts/compose-smoke-matrix.mjs.
   #

--- a/docs/test-strategy.md
+++ b/docs/test-strategy.md
@@ -1019,7 +1019,7 @@ with the packages they cover, and a table duplicated into prose drifts
 out of step without anything going red. Read the module.
 
 `internal/logql` is split into four sibling matrix entries (each scoped
-to `./internal/logql` but with disjoint `--exclude-files` regexes) to
+to `./internal/logql` but with disjoint file regexes) to
 keep the `go test ./internal/logql` cycle under the ubuntu-latest memory
 ceiling. Its `internal/logql/lsyntax` parser
 subpackage gets its own pair of dedicated legs (`phase4-logql-parser` /

--- a/internal/logql/jsonpath_mutation_test.go
+++ b/internal/logql/jsonpath_mutation_test.go
@@ -13,11 +13,14 @@ import (
 // the plain `go test ./internal/logql` invocation gremlins drives — so
 // every predicate / boundary / control-flow mutant in the file survived.
 //
-// jsonpath.go is matched by NO phase's exclude_files regex in
-// mutation.yml, so it is mutated by ALL FOUR phase4-logql-* phases
-// (aggregation, lower, other-a, other-b). The same 18 LIVED mutants
-// therefore deflated every one of those phases below the 95% efficacy
-// bar; killing them here lifts all four back over the bar at once.
+// When these 18 mutants were found, jsonpath.go was named by no
+// phase4-logql-* leg's file pattern at all, so ALL FOUR legs mutated it
+// and the same 18 survivors deflated every one of them below the 95%
+// efficacy bar at once. The leg partition now claims it exactly once
+// (phase4-logql-other-b, its scope's catch-all — see
+// .github/scripts/mutation-phases.mjs), so a survivor here deflates that
+// one leg rather than four. Killing them is what put the file over the
+// bar either way.
 //
 // Each case below depends on the exact value or branch a cited mutation
 // alters, so the mutation breaks the assertion. Mutants pinned:


### PR DESCRIPTION
Extends the `include_files` conversion from `internal/chsql`'s phase2 group to the three groups the issue names: `internal/promql`, `internal/logql` (plus its `lsyntax` subpackage) and `internal/traceql` (plus its `ast` subpackage).

Closes #2814

## What the chsql-only fix did

`mutation-phases.mjs` partitions each mutated package into sibling legs with a scope-relative RE2 alternation. Every leg used `exclude_files`, a denylist — so a leg claims everything it does not name. That makes a brand-new file in a shared scope match *no* sibling's hand-written denylist and therefore be claimed by **all** of them at once, a hard `ownershipViolations` / `mutation-select` failure that surfaces only once CI runs and needs N separate regexes hand-patched to clear. It happened twice in one evening on two different new `internal/chsql` emitters.

The fix inverted the three *curated* chsql legs to `include_files`, an allowlist, and left the one *catch-all* leg on a denylist so a new file still has somewhere to land. Since gremlins only understands `--exclude-files`, `resolvePhases()` in `mutation-matrix.mjs` translates each allowlist into the equivalent denylist at `emit`/`dump` time by walking the scope's real files — and that live walk is where a new file gets classified for free: it matches no allowlist, lands in every curated leg's *derived* denylist, and falls through to the catch-all.

## What this PR extends

Seventeen curated legs swap denylist for allowlist:

| group | scope | converted | catch-all kept on `exclude_files` |
| --- | --- | --- | --- |
| promql | `./internal/promql` | `-lower`, `-quantile`, `-a`…`-i` (11) | `phase4-promql-other` |
| logql | `./internal/logql` | `-lower`, `-aggregation`, `-other-a` (3) | `phase4-logql-other-b` |
| logql | `./internal/logql/lsyntax` | `-parser` (1) | `phase4-logql-lsyntax` |
| traceql | `./internal/traceql` | `-lower` (1) | `phase4-traceql-other` |
| traceql | `./internal/traceql/ast` | `-parser` (1) | `phase4-traceql-ast` |

Twenty of thirty legs are allowlists now, so the per-leg "why an allowlist" rationale is hoisted out of the three chsql legs into the file header rather than repeated twenty times.

## Proof that ownership did not move

The allowlists were **derived, not typed**: for each leg, walk the scope's real mutable `.go` files, keep those its current denylist does not exclude, and emit the canonical `^(stem|stem)\.go$` for exactly that set. Three independent checks:

1. **Verdict equivalence, per file.** For every real file in each scope, `!exclude.test(rel)` and `include.test(rel)` agree — 0 mismatches across all 17 legs (100 promql files, 28 logql, 9 lsyntax, 23 traceql, 14 ast).
2. **Resolved-table equivalence, end to end.** Dumping the table (`node .github/scripts/mutation-matrix.mjs dump` — the exact JSON gremlins' matrix and `test/regression/mutation_leg_partition_test.go` consume) and expanding each leg's `exclude_files` against the real tree gives a **byte-identical** owned-file list for **all 30 legs**, before and after.
3. **Corroboration against the comments.** Each derived allowlist matches its own leg's doc-comment file list exactly — e.g. `phase4-promql-h`'s comment names 12 files and the allowlist derives 12, `phase4-logql-aggregation`'s names `range_aggregation` + `vector_aggregation` + `lang` and the allowlist derives those three.

## Effect on efficacy denominators, and #2883

**None.** A leg's denominator is the executed-mutant population of the files it owns, and by proof 2 above no leg's file set changed. `phase4-promql-lower` still owns `lower.go` and nothing else, so the ~485-mutant denominator behind #2883 is untouched.

The `mutation` lane's oscillation on main is real and independent of this branch — the last eight runs on `main` are success / failure / failure / cancelled / success / failure / failure / cancelled, and the failing leg in each of the three failures inspected (runs 33542904091, 33529616787, 33509695248) is `phase4-promql-lower`, with `phase4-promql-g` joining it once. This branch is based on `8f5d189de`, whose own `main` run was a **success**, so a red `phase4-promql-lower` here would be the #2883 flip, not this change. Nothing here makes it worse: no file moves between legs, so no leg's mutant population is diluted or concentrated.

Going forward the change *reduces* denominator drift. Before, the only way a file changed legs was the collision above — a loud failure. Now a rename is the risk, and it is gated (below).

## Verification — the gates can still fail

**The new-file regression, pinned on all seven multi-leg scopes.** A real probe `.go` file is written into each scope, the table resolved against it, the probe removed, and only then asserted: it must be claimed by **exactly one** leg, the scope's catch-all — in the declared table *and* in the resolved one gremlins receives. The probe has to be real, because `resolvePhases` walks live; a hypothetical path would have exercised only the declared table. Reverting `mutation-phases.mjs` to `8f5d189de` and re-running the test fails exactly as the issue describes:

```
AssertionError: declared table: internal/promql/zz_mutation_partition_probe.go
  must fall through to phase4-promql-other alone
  actual: [ 'phase4-promql-lower', 'phase4-promql-quantile', 'phase4-promql-a',
            'phase4-promql-b', 'phase4-promql-c', 'phase4-promql-d',
            'phase4-promql-e', 'phase4-promql-f', 'phase4-promql-g',
            'phase4-promql-h', 'phase4-promql-i', 'phase4-promql-other' ]
  expected: [ 'phase4-promql-other' ]
```

**The structural precondition.** Every scope must keep exactly one non-allowlist leg. Converting the last denylist in a group would leave a new file owned by *nobody* — the opposite failure, equally silent until someone adds a file — so it now fails at PR time. Also fails on the pre-conversion table (`scope ./internal/promql must have exactly one non-allowlist leg, got [12 legs]`).

**A new failure mode an allowlist introduces, and its gate.** A denylist naming a since-deleted file over-excludes nothing. An allowlist naming one quietly claims fewer files, and on a *rename* hands that file's whole mutant population to the catch-all with the exactly-one-owner invariant still satisfied — a denominator moving with nothing red. `tableViolations` now re-derives each allowlist from the tree and fails when the two disagree, printing the pattern to paste. `resolvePhases` and the check share one `canonicalFilePattern` helper, so the hand-written allowlist and the derived denylist are the same shape by construction.

That check caught a real one on its first run: `phase2-range` still named `late_mat`, deleted outright by #2830. Removed from both `phase2-range`'s allowlist and `phase2-other`'s denylist — no ownership change, the file does not exist. It was the only stale name in the whole table (all 30 legs' patterns were swept for names with no matching file).

**Also run locally:** `node --test .github/scripts/mutation-matrix.test.mjs` (41/41), `mutation-run.test.mjs` (6/6), `node .github/scripts/mutation-matrix.mjs verify`, `go test -run 'Mutation' ./test/regression/` (the partition test that parses `dump`), `just lint-actions`, `markdownlint-cli2` on the two touched docs, `go vet ./internal/logql/`.

## Prose realigned with the code

`mutation.yml`, `ci.yml`, `.github/scripts/README.md` and `docs/test-strategy.md` all described the partition as a set of `exclude_files` denylists. Each is reworded to say which pattern a leg carries and why.

`internal/logql/jsonpath_mutation_test.go`'s header claimed `jsonpath.go` "is matched by NO phase's exclude_files regex … so it is mutated by ALL FOUR phase4-logql-* phases". That was already untrue before this branch — it is claimed exactly once, by `phase4-logql-other-b`, verified against the resolved table both before and after this change. Rewritten to put the four-leg deflation in the past tense where it belongs.

## Not verified here

`mutation` is not one of the required checks, so merge does not wait on it; the lane's own behaviour on a full `push`-to-main matrix is the one thing that cannot be reproduced locally. The equivalence proof is against the resolved table gremlins is handed, not against a live gremlins run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E6EwMr2g22x8oT3kk7eTtR
