### PR TITLE
fix(perf): read nightly sample tuple fields by name, not prefix-collapsing dot access

### DIFF
--- a/test/perf/nightly/loader.go
+++ b/test/perf/nightly/loader.go
@@ -10,11 +10,10 @@
 // ClickHouse exporter's own templates, see internal/schema/ddl) declares
 // both as Map(LowCardinality(String), String) — so loading is not a bare
 // `INSERT ... SELECT * FROM file(...)`; each named tuple field is read back
-// via dot access (backtick-quoted for the dotted ResourceAttributes keys)
-// and re-packed with mapFromArrays. This file is test-only data-loading
-// code, not the chsql emitter, so invariant 10 (typed Frags only) does not
-// apply here — the same carve-out scale_wall_pin_chdb_test.go's own seeding
-// already uses.
+// by name (see mapArraysExpr) and re-packed with mapFromArrays. This file
+// is test-only data-loading code, not the chsql emitter, so invariant 10
+// (typed Frags only) does not apply here — the same carve-out
+// scale_wall_pin_chdb_test.go's own seeding already uses.
 package nightly
 
 import (
@@ -41,6 +40,15 @@ var sampleAttributeKeys = map[string][]string{
 // sampleResourceAttributeKeys names the ResourceAttributes struct fields
 // every sample metric carries identically (the extraction pipeline flattens
 // the same resource-level key set regardless of metric type).
+//
+// Two of these are a PREFIX PAIR: "deployment.environment" (the OTel
+// semantic-convention name the captured production workload emitted) and
+// "deployment.environment.name" (its successor, emitted alongside it during
+// the convention's own migration window). Both are real, both carry
+// distinct values in the captured sample, and both stay listed — dropping
+// either would silently narrow what the nightly lane loads and measures.
+// Their coexistence is exactly what mapArraysExpr's field access has to
+// survive; see that function's comment.
 var sampleResourceAttributeKeys = []string{
 	"container.image.name", "container.image.tag", "deployment.environment", "deployment.environment.name",
 	"host.name", "k8s.cluster.name", "k8s.cluster.uid", "k8s.container.name", "k8s.deployment.name",
@@ -55,10 +63,38 @@ var sampleResourceAttributeKeys = []string{
 // configuration choice.
 const clickhouseUserFilesDir = "/var/lib/clickhouse/user_files"
 
-// mapArraysExpr renders `mapFromArrays([...keys...], [col.key1, col.key2, ...])`
-// for a struct column's named fields, backtick-quoting each key for the dot
-// access (required for ResourceAttributes' dotted field names, harmless for
-// Attributes' plain ones).
+// mapArraysExpr renders
+// `mapFromArrays([...keys...], [tupleElement(col, 'key1'), ...])` for a
+// struct column's named fields.
+//
+// The field access is deliberately the tupleElement(...) FUNCTION rather
+// than dot access — not a style choice, and specifically not the
+// backtick-quoted dot access this rendered before, which broke the lane
+// (#2875).
+//
+// Dot access is ambiguous whenever one tuple field name is a dotted prefix
+// of another, and sampleResourceAttributeKeys carries exactly such a pair
+// ("deployment.environment" / "deployment.environment.name"). Backticks do
+// not disambiguate it: reading from the file() table function, ClickHouse
+// pushes the requested column paths down into the format reader, and from
+// 26.x that pushdown splits the requested
+// ResourceAttributes.deployment.environment.name at the longest matching
+// column prefix — it asks Parquet for
+// ResourceAttributes.deployment.environment (a String), then fails to find
+// the ".name" remainder inside it:
+//
+//	Code: 10. Not found column or subcolumn
+//	ResourceAttributes.deployment.environment.name in block. There are only
+//	columns: ResourceAttributes.deployment.environment
+//
+// ClickHouse 25.9 (perfNightlyCHImage) resolved the same dot access
+// correctly, which is why only the 26.6 leg — the ts_grid_instant memory
+// measurement, whose floor sits above 25.9 — went red.
+//
+// tupleElement takes the field name as a string LITERAL, so no path
+// splitting happens at all and every field, prefix-colliding or not,
+// resolves to its own column. Verified against both engine versions;
+// pinned behaviourally by loader_prefix_collision_chdb_test.go.
 func mapArraysExpr(column string, keys []string) string {
 	keyList, valueList := "", ""
 	for i, k := range keys {
@@ -67,7 +103,7 @@ func mapArraysExpr(column string, keys []string) string {
 			valueList += ", "
 		}
 		keyList += fmt.Sprintf("'%s'", k)
-		valueList += fmt.Sprintf("%s.`%s`", column, k)
+		valueList += fmt.Sprintf("tupleElement(%s, '%s')", column, k)
 	}
 	return fmt.Sprintf("mapFromArrays([%s], [%s])", keyList, valueList)
 }

--- a/test/perf/nightly/loader_prefix_collision_chdb_test.go
+++ b/test/perf/nightly/loader_prefix_collision_chdb_test.go
@@ -1,0 +1,122 @@
+//go:build chdb
+
+// The PREFIX-COLLISION pin for the nightly loader's tuple-field access
+// (#2875).
+//
+// # What broke
+//
+// testdata/samples/*.parquet's ResourceAttributes tuple carries BOTH
+// "deployment.environment" and "deployment.environment.name" — the OTel
+// semantic-convention name the captured production workload emitted and its
+// successor, emitted side by side during the convention's migration window
+// (see sampleResourceAttributeKeys). loader.go read every tuple field by
+// backtick-quoted dot access, which is ambiguous for exactly that pair:
+// reading from the file() table function, ClickHouse pushes the requested
+// column paths down into the format reader, and from 26.x that pushdown
+// splits the requested ResourceAttributes.deployment.environment.name at
+// the longest matching column prefix, asks Parquet for
+// ResourceAttributes.deployment.environment (a String), and raises
+//
+//	Code: 10. Not found column or subcolumn
+//	ResourceAttributes.deployment.environment.name in block.
+//
+// perf-nightly's own harness pins ClickHouse 25.9, which resolved that dot
+// access correctly — so only the ts_grid_instant memory measurement, whose
+// feature floor sits above 25.9 and which therefore boots its own 26.6
+// container, went red. The lane's merge_posture is "never"
+// (.github/ci-lanes.json), so no PR ran it and the break landed on main.
+//
+// # Why this pin, on this substrate
+//
+// The break is a fact about how a real engine resolves the loader's real
+// SELECT list against a real Parquet source — not something a string
+// assertion can settle. chDB (26.5) reproduces the collapse exactly, so
+// this test rebuilds the hazard from first principles on it: write a
+// Parquet whose ResourceAttributes tuple carries sampleResourceAttributeKeys
+// verbatim (prefix pair and all), read it back through the SELECT list
+// mapArraysExpr itself renders, and require every key to come back with its
+// OWN distinct value. Restore dot access in mapArraysExpr and this fails
+// with the CI error above; delete either half of the prefix pair and
+// TestSampleResourceAttributeKeys_KeepPrefixCollision fails instead.
+//
+// It lives in this package rather than test/regression because the
+// behaviour under test is the unexported renderer's own output, and because
+// test/perf/** is already enrolled in the chdb.perf-guards lane
+// (.github/ci-lanes.json) that `just perf-chdb` drives.
+package nightly
+
+import (
+	"database/sql"
+	"fmt"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	_ "github.com/chdb-io/chdb-go/chdb/driver"
+)
+
+// prefixCollisionSeedPrefix marks each seeded field value so a value read
+// back under the wrong key is identifiable on sight rather than merely
+// unequal. The suffix is the key itself, which makes every field's value
+// unique by construction — that uniqueness is what turns "each key resolved
+// to its own column" into a checkable assertion.
+const prefixCollisionSeedPrefix = "seed:"
+
+func prefixCollisionSeedValue(key string) string { return prefixCollisionSeedPrefix + key }
+
+// TestMapArraysExpr_ResolvesPrefixCollidingParquetFields is the #2875 pin.
+func TestMapArraysExpr_ResolvesPrefixCollidingParquetFields(t *testing.T) {
+	keys := sampleResourceAttributeKeys
+
+	db, err := sql.Open("chdb", "")
+	if err != nil {
+		t.Fatalf("open chdb: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	if err := db.Ping(); err != nil {
+		t.Fatalf("ping chdb: %v", err)
+	}
+
+	fields := make([]string, len(keys))
+	values := make([]string, len(keys))
+	for i, k := range keys {
+		fields[i] = fmt.Sprintf("`%s` String", k)
+		values[i] = fmt.Sprintf("'%s'", prefixCollisionSeedValue(k))
+	}
+	tupleType := "Tuple(" + strings.Join(fields, ", ") + ")"
+
+	parquetPath := filepath.Join(t.TempDir(), "resource_attributes.parquet")
+	writeSQL := fmt.Sprintf(
+		"INSERT INTO FUNCTION file('%s', Parquet, 'ResourceAttributes %s') SELECT CAST((%s), '%s')",
+		parquetPath, tupleType, strings.Join(values, ", "), tupleType,
+	)
+	if _, err := db.Exec(writeSQL); err != nil {
+		t.Fatalf("write parquet fixture: %v", err)
+	}
+
+	// Read every key back through the loader's OWN map expression, one
+	// element access per key, so a collapsed pair shows up as the wrong
+	// value rather than as a silently missing map entry.
+	mapExpr := mapArraysExpr("ResourceAttributes", keys)
+	projections := make([]string, len(keys))
+	for i, k := range keys {
+		projections[i] = fmt.Sprintf("(%s)['%s']", mapExpr, k)
+	}
+	readSQL := fmt.Sprintf("SELECT %s FROM file('%s', Parquet)",
+		strings.Join(projections, ", "), parquetPath)
+
+	got := make([]string, len(keys))
+	dest := make([]any, len(keys))
+	for i := range got {
+		dest[i] = &got[i]
+	}
+	if err := db.QueryRow(readSQL).Scan(dest...); err != nil {
+		t.Fatalf("read parquet fixture back through mapArraysExpr: %v\nSQL: %s", err, readSQL)
+	}
+
+	for i, k := range keys {
+		if want := prefixCollisionSeedValue(k); got[i] != want {
+			t.Errorf("key %q resolved to %q, want %q — a tuple field read the wrong column", k, got[i], want)
+		}
+	}
+}

--- a/test/perf/nightly/loader_test.go
+++ b/test/perf/nightly/loader_test.go
@@ -8,7 +8,7 @@ import (
 
 func TestMapArraysExpr_PlainKeys(t *testing.T) {
 	got := mapArraysExpr("Attributes", []string{"app_id", "method"})
-	want := "mapFromArrays(['app_id', 'method'], [Attributes.`app_id`, Attributes.`method`])"
+	want := "mapFromArrays(['app_id', 'method'], [tupleElement(Attributes, 'app_id'), tupleElement(Attributes, 'method')])"
 	if got != want {
 		t.Errorf("mapArraysExpr =\n%s\nwant\n%s", got, want)
 	}
@@ -16,14 +16,10 @@ func TestMapArraysExpr_PlainKeys(t *testing.T) {
 
 func TestMapArraysExpr_DottedKeys(t *testing.T) {
 	got := mapArraysExpr("ResourceAttributes", []string{"service.name", "k8s.namespace.name"})
-	// Dotted field names need backtick-quoted dot access — ClickHouse would
-	// otherwise try to parse the dot as nested member access on an
-	// intermediate identifier that doesn't exist.
-	if !strings.Contains(got, "ResourceAttributes.`service.name`") {
-		t.Errorf("mapArraysExpr must backtick-quote dotted keys, got: %s", got)
-	}
-	if !strings.Contains(got, "ResourceAttributes.`k8s.namespace.name`") {
-		t.Errorf("mapArraysExpr must backtick-quote dotted keys, got: %s", got)
+	want := "mapFromArrays(['service.name', 'k8s.namespace.name'], " +
+		"[tupleElement(ResourceAttributes, 'service.name'), tupleElement(ResourceAttributes, 'k8s.namespace.name')])"
+	if got != want {
+		t.Errorf("mapArraysExpr =\n%s\nwant\n%s", got, want)
 	}
 }
 
@@ -33,6 +29,58 @@ func TestMapArraysExpr_EmptyKeys(t *testing.T) {
 	if got != want {
 		t.Errorf("mapArraysExpr(no keys) = %q, want %q", got, want)
 	}
+}
+
+// TestMapArraysExpr_NeverUsesDotAccess pins the SHAPE the #2875 fix turns
+// on, over the loader's real key sets rather than a hand-picked pair: no
+// rendered field access may be dot access. Dot access is what ClickHouse
+// 26.x's file()-reader column pushdown resolves by longest matching column
+// prefix, and so what collapses "deployment.environment.name" onto
+// "deployment.environment" — see mapArraysExpr's own comment. Reverting to
+// `Col.` + "`key`" reddens this without needing an engine.
+func TestMapArraysExpr_NeverUsesDotAccess(t *testing.T) {
+	sets := map[string][]string{"ResourceAttributes": sampleResourceAttributeKeys}
+	for metric, keys := range sampleAttributeKeys {
+		sets["Attributes/"+metric] = keys
+	}
+	for name, keys := range sets {
+		column := "ResourceAttributes"
+		if strings.HasPrefix(name, "Attributes/") {
+			column = "Attributes"
+		}
+		got := mapArraysExpr(column, keys)
+		if strings.Contains(got, column+".") {
+			t.Errorf("%s: mapArraysExpr must not render dot access on %s, got: %s", name, column, got)
+		}
+		for _, k := range keys {
+			if !strings.Contains(got, fmt.Sprintf("tupleElement(%s, '%s')", column, k)) {
+				t.Errorf("%s: mapArraysExpr must read %q via tupleElement, got: %s", name, k, got)
+			}
+		}
+	}
+}
+
+// TestSampleResourceAttributeKeys_KeepPrefixCollision keeps
+// TestMapArraysExpr_NeverUsesDotAccess and the chDB pin honest. The whole
+// hazard exists only because the captured sample really does carry a key
+// that is a dotted prefix of another key; deleting one of the pair would
+// make the nightly lane pass while measuring strictly less real production
+// shape than it did before — the hollow green invariant 6 forbids. This
+// fails the moment such a pair stops being present.
+func TestSampleResourceAttributeKeys_KeepPrefixCollision(t *testing.T) {
+	var pairs []string
+	for _, a := range sampleResourceAttributeKeys {
+		for _, b := range sampleResourceAttributeKeys {
+			if a != b && strings.HasPrefix(b, a+".") {
+				pairs = append(pairs, fmt.Sprintf("%q is a dotted prefix of %q", a, b))
+			}
+		}
+	}
+	if len(pairs) == 0 {
+		t.Fatalf("sampleResourceAttributeKeys no longer carries a dotted-prefix key pair, so the #2875 "+
+			"regression pins cannot fail; the captured sample's real key set is %v", sampleResourceAttributeKeys)
+	}
+	t.Logf("prefix-colliding key pairs still loaded: %s", strings.Join(pairs, "; "))
 }
 
 func TestSampleAttributeKeys_CoverEveryMetric(t *testing.T) {

--- a/test/perf/nightly/testmain_test.go
+++ b/test/perf/nightly/testmain_test.go
@@ -1,0 +1,19 @@
+package nightly
+
+import (
+	"os"
+	"testing"
+
+	"github.com/tsouza/cerberus/internal/chdbsession"
+)
+
+// TestMain shuts the process-wide chDB session down before this binary
+// exits. Under `-race`, os.Exit runs runtime.racefini, which runs libchdb's
+// C++ static destructors against a still-live embedded ClickHouse and
+// segfaults AFTER every test has already passed (#1971).
+// chdbsession.CloseForExit is a no-op in the default, non-chdb build.
+func TestMain(m *testing.M) {
+	code := m.Run()
+	chdbsession.CloseForExit()
+	os.Exit(code)
+}


### PR DESCRIPTION
## The break

`perf-nightly` is a `RELEASE_REQUIRED_CHECKS` entry (`.github/workflows/release.yml:267`) and had
concluded `failure` on every recent push to `main`, including the tip. One step failed: **Run the
ts_grid_instant real-data memory measurement (real ClickHouse)**, on its 26.6-alpine container.

```
insert into otel_metrics_sum from svc_http_requests_total.parquet: code: 10,
message: Not found column or subcolumn ResourceAttributes.deployment.environment.name in block.
There are only columns: ... ResourceAttributes.deployment.environment, ...
```

## Root cause

`test/perf/nightly/loader.go:70` (pre-fix) rendered each Parquet tuple field as backtick-quoted **dot
access**:

```go
valueList += fmt.Sprintf("%s.`%s`", column, k)
```

`sampleResourceAttributeKeys` (`loader.go:44-50`) lists both `deployment.environment` and
`deployment.environment.name` — the OTel semantic-convention name the captured production workload
emitted and its successor, emitted side by side during that convention's migration window.

### The fixture really does carry both keys

The error's `There are only columns: ...` list is the **pruned requested column set for that query**,
not the file's schema. The same repro with only two projections reports
`There are only columns: ResourceAttributes.deployment.environment` — a one-entry list. So that list
is not evidence the fixture lacks the key.

The fixture's own schema, read by **26.6 itself**:

```
$ clickhouse-local (26.6-alpine)
  "SELECT field FROM (SELECT arrayJoin(tupleNames(ResourceAttributes)) AS field
                      FROM file('svc_http_requests_total.parquet', Parquet) LIMIT 24)
   WHERE field LIKE 'deployment%'"
deployment.environment
deployment.environment.name
```

`DESCRIBE TABLE file(...)` agrees and reports the identical 23-field tuple under 25.9 and 26.6 — the
two engines read the same schema out of the same bytes.

Both fields carry real, non-null data, and the longer one carries strictly more of it, so dropping it
would be a genuine reduction in what the lane loads and measures:

```
$ clickhouse-local (26.6-alpine), over all rows of the fixture
  uniqExact(deployment.environment)            = 1
  uniqExact(deployment.environment.name)       = 3
  countIf(deployment.environment.name IS NULL) = 0
  count()                                      = 1338836
```

### Why dot access breaks on 26.6 and not 25.9

Reading through the `file()` table function, ClickHouse pushes the requested column paths down into
the format reader, and from 26.x that pushdown splits the requested path at the longest matching
**column** prefix: it asks Parquet for `ResourceAttributes.deployment.environment` (a `String`) and
then cannot find the `.name` remainder inside it. Backticks do not disambiguate it — the split
happens after identifier parsing.

Reproduced directly, outside Go, against both pinned engines on the real fixture:

```
$ clickhouse-local (25.9-alpine) "SELECT ResourceAttributes.`deployment.environment`,
                                         ResourceAttributes.`deployment.environment.name`
                                  FROM file('svc_http_requests_total.parquet', Parquet) LIMIT 1"
scrubbed-26f195d4a6b3   scrubbed-cb08d24f7f62

$ clickhouse-local (26.6-alpine) — same query
Code: 10. DB::Exception: Not found column or subcolumn
ResourceAttributes.deployment.environment.name in block. (NOT_FOUND_COLUMN_IN_BLOCK)
```

The same query against an **in-memory** tuple works on both versions, which places the change in the
table-function column pushdown, not in general expression resolution.

That version split is why this went unnoticed: the `#2370` nightly harness pins `perfNightlyCHImage`
= 25.9-alpine and still loads all three samples fine. Only the ts_grid_instant measurement, whose
feature floor sits above 25.9 and which therefore boots its own 26.6 container, went red. And the
lane's `merge_posture` is `never` (`.github/ci-lanes.json`), so no PR ran it — it merged broken and
reddened only on the schedule.

## The fix

Render `tupleElement(col, 'key')` instead. The field name is a string **literal**, so no path
splitting happens at all and every field — prefix-colliding or not — resolves to its own column.
Verified to work on both 25.9 and 26.6 over the real fixture.

Both keys stay in `sampleResourceAttributeKeys`.

The second commit adds the `TestMain` calling `chdbsession.CloseForExit` that
`TestChDBTaggedPackagesCloseSessionOnExit` requires of any package with a chdb-tagged test file
(#1971) — `test/perf/nightly` gained its first one here.

## Validation

Both perf-nightly steps were run end to end against real ClickHouse containers, not inferred from
green neighbours:

- **`perf-nightly` itself, dispatched on this branch** (`workflow_dispatch`, since the lane never
  runs on a PR): green on this exact tip (`5744f11`) —
  https://github.com/tsouza/cerberus/actions/runs/33560938675. Both steps measured for real:
  `loaded counter sample: 1338836 rows` / `PASS: TestPerfNightlyRealCH (137.76s)` on 25.9, and
  `lookback=1d: fan-out peak memory_usage = 167239118 bytes; native peak memory_usage = 114727538 bytes (native is 68.6% of fan-out)`
  on 26.6. (An earlier dispatch on the pre-rebase commit was green the same way:
  https://github.com/tsouza/cerberus/actions/runs/33559235273.)
- **Locally, 26.6 leg** (`just ts-grid-instant-memory-integration`, the step that was failing) — PASS
  in 80s, 1,338,836 real rows loaded, `fan-out 209352204 bytes / native 177736449 bytes (84.9%)`.
- **Locally, 25.9 leg** (`just perf-nightly-integration`, already passing) — PASS in 697s, all five
  sentinels, identical row counts (1317183 / 1338836 / 1676160 / 1317183 derived) and in-band memory
  readings. No regression from the changed rendering.

## Regression pins

`test/perf/nightly/loader_prefix_collision_chdb_test.go` (new, `chdb`-tagged, enrolled via the
`chdb.perf-guards` lane's `test/perf/**` globs) writes a Parquet whose `ResourceAttributes` tuple
carries `sampleResourceAttributeKeys` verbatim, then reads every key back through the SELECT list
`mapArraysExpr` itself renders, requiring each to return its own distinct seeded value. chDB is 26.5
and reproduces the collapse exactly.

Non-vacuity was checked, not assumed: with dot access temporarily restored in `mapArraysExpr`, the
new test fails with the identical `NOT_FOUND_COLUMN_IN_BLOCK` message seen in CI.

Two unit pins back it up, covering the two ways this could silently come back:

- `TestMapArraysExpr_NeverUsesDotAccess` — no rendered field access may be dot access, checked over
  the loader's real key sets.
- `TestSampleResourceAttributeKeys_KeepPrefixCollision` — fails if the sample key set ever stops
  carrying a dotted-prefix pair, which is the shape "fix it by deleting a key" would take.

Closes #2875

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E6EwMr2g22x8oT3kk7eTtR
