### PR TITLE
test(promql): kill the native-grid eligibility-guard mutants on phase4-promql-lower

### DIFF
--- a/internal/promql/gremlins_kill_companion_union_test.go
+++ b/internal/promql/gremlins_kill_companion_union_test.go
@@ -3,6 +3,7 @@ package promql
 import (
 	"testing"
 
+	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/model/labels"
 
 	"github.com/tsouza/cerberus/internal/schema"
@@ -149,7 +150,7 @@ func TestResolveSelectorRouting_RewritesToTheBareNameOnlyForTheSingleArmFallback
 	matchers := func(t *testing.T) []*labels.Matcher {
 		t.Helper()
 		return []*labels.Matcher{
-			mustMatcher(t, labels.MatchEqual, labels.MetricName, companionSuffixedName),
+			mustMatcher(t, labels.MatchEqual, model.MetricNameLabel, companionSuffixedName),
 		}
 	}
 
@@ -207,9 +208,9 @@ func TestResolveSelectorRouting_RewritesToTheBareNameOnlyForTheSingleArmFallback
 func TestRewriteMetricName_TouchesOnlyThePinnedNameMatcher(t *testing.T) {
 	t.Parallel()
 
-	name := mustMatcher(t, labels.MatchEqual, labels.MetricName, companionSuffixedName)
+	name := mustMatcher(t, labels.MatchEqual, model.MetricNameLabel, companionSuffixedName)
 	job := mustMatcher(t, labels.MatchEqual, "job", "api")
-	nameRegex := mustMatcher(t, labels.MatchRegexp, labels.MetricName, "http_.*")
+	nameRegex := mustMatcher(t, labels.MatchRegexp, model.MetricNameLabel, "http_.*")
 	in := []*labels.Matcher{name, job, nameRegex}
 
 	out := rewriteMetricName(in, companionBareName)

--- a/internal/promql/gremlins_kill_companion_union_test.go
+++ b/internal/promql/gremlins_kill_companion_union_test.go
@@ -30,9 +30,6 @@ const (
 	companionBareName     = "http_request_duration_seconds"
 )
 
-// companionValueCol is the histogram-table column a `_sum` companion reads.
-const companionValueCol = "Sum"
-
 // TestNeedCompanionUnion_RejectsEachMissingNameIndependently pins that all
 // three name inputs are required, one at a time.
 //
@@ -49,7 +46,7 @@ func TestNeedCompanionUnion_RejectsEachMissingNameIndependently(t *testing.T) {
 	t.Parallel()
 	s := schema.DefaultOTelMetrics()
 
-	if !needCompanionUnion(s, companionValueCol, companionSuffixedName, companionBareName) {
+	if !needCompanionUnion(s, s.SumColumn, companionSuffixedName, companionBareName) {
 		t.Fatal("the fully-named default-schema companion was refused; the rejection cases below would be vacuous")
 	}
 
@@ -60,8 +57,8 @@ func TestNeedCompanionUnion_RejectsEachMissingNameIndependently(t *testing.T) {
 		bare        string
 	}{
 		{"no companion value column", "", companionSuffixedName, companionBareName},
-		{"no suffixed name", companionValueCol, "", companionBareName},
-		{"no bare name", companionValueCol, companionSuffixedName, ""},
+		{"no suffixed name", s.SumColumn, "", companionBareName},
+		{"no bare name", s.SumColumn, companionSuffixedName, ""},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
@@ -91,7 +88,7 @@ func TestNeedCompanionUnion_RequiresADistinctLiteralValueTable(t *testing.T) {
 	if got := literalCompanionValueTables(s); len(got) != 0 {
 		t.Fatalf("literalCompanionValueTables = %v; want empty once Sum and Gauge collapse onto Histogram", got)
 	}
-	if needCompanionUnion(s, companionValueCol, companionSuffixedName, companionBareName) {
+	if needCompanionUnion(s, s.SumColumn, companionSuffixedName, companionBareName) {
 		t.Error("needCompanionUnion requested a union with no distinct literal value table; want the single-arm histogram emit")
 	}
 }

--- a/internal/promql/gremlins_kill_companion_union_test.go
+++ b/internal/promql/gremlins_kill_companion_union_test.go
@@ -133,6 +133,67 @@ func TestLiteralCompanionValueTables_SkipsEmptyAndHistogramTables(t *testing.T) 
 	})
 }
 
+// TestResolveSelectorRouting_RewritesToTheBareNameOnlyForTheSingleArmFallback
+// pins the consequence of the decision above on the matchers the selector
+// actually scans with.
+//
+// The bare-name rewrite exists so the single-arm histogram fallback filters on
+// the name the histogram row is stored under. It is correct ONLY on that
+// fallback: when a distinct literal value table exists the union path owns the
+// rewrite per-arm, and rewriting here as well would make the Sum/Gauge arm
+// filter on the bare name — which is not in those tables — and return nothing.
+//
+// So the two configurations must disagree, and this asserts both. Testing only
+// the default schema would leave the negation of the guard indistinguishable
+// from the guard.
+func TestResolveSelectorRouting_RewritesToTheBareNameOnlyForTheSingleArmFallback(t *testing.T) {
+	t.Parallel()
+
+	matchers := func(t *testing.T) []*labels.Matcher {
+		t.Helper()
+		return []*labels.Matcher{
+			mustMatcher(t, labels.MatchEqual, labels.MetricName, companionSuffixedName),
+		}
+	}
+
+	t.Run("union path leaves the suffixed name alone", func(t *testing.T) {
+		t.Parallel()
+		s := schema.DefaultOTelMetrics()
+		if got := literalCompanionValueTables(s); len(got) == 0 {
+			t.Fatalf("default schema has no distinct literal value table (%v); this case would test the fallback instead", got)
+		}
+
+		route, err := resolveSelectorRouting(
+			companionSuffixedName, s, lowerCtx{}, s.TablesFor(companionSuffixedName), matchers(t),
+		)
+		if err != nil {
+			t.Fatalf("resolveSelectorRouting: %v", err)
+		}
+		if got := route.matchers[0].Value; got != companionSuffixedName {
+			t.Errorf("routed matcher = %q; want the suffixed name %q left intact — the union path rewrites per-arm",
+				got, companionSuffixedName)
+		}
+	})
+
+	t.Run("single-arm fallback rewrites to the bare name", func(t *testing.T) {
+		t.Parallel()
+		s := schema.DefaultOTelMetrics()
+		s.SumTable = s.HistogramTable
+		s.GaugeTable = s.HistogramTable
+
+		route, err := resolveSelectorRouting(
+			companionSuffixedName, s, lowerCtx{}, s.TablesFor(companionSuffixedName), matchers(t),
+		)
+		if err != nil {
+			t.Fatalf("resolveSelectorRouting: %v", err)
+		}
+		if got := route.matchers[0].Value; got != companionBareName {
+			t.Errorf("routed matcher = %q; want the bare name %q — the histogram row is stored under it",
+				got, companionBareName)
+		}
+	})
+}
+
 // TestRewriteMetricName_TouchesOnlyThePinnedNameMatcher pins both halves of
 // rewriteMetricName's per-matcher predicate and its copy-on-write contract.
 //

--- a/internal/promql/gremlins_kill_companion_union_test.go
+++ b/internal/promql/gremlins_kill_companion_union_test.go
@@ -1,0 +1,178 @@
+package promql
+
+import (
+	"testing"
+
+	"github.com/prometheus/prometheus/model/labels"
+
+	"github.com/tsouza/cerberus/internal/schema"
+)
+
+// The classic-histogram-companion fan-out decides how a `<x>_sum` / `<x>_count`
+// selector is READ: as the single bare-name arm inside the histogram table, or
+// as a UnionAll that also scans the Sum / Gauge tables under the literal
+// suffixed name. Choosing the single arm when a distinct value table exists
+// drops whichever rows live there — a silently short answer, not an error — and
+// choosing the union when there is no such table adds an arm that scans the
+// histogram table twice under two different names.
+//
+// [needCompanionUnion] and [literalCompanionValueTables] are the two pure
+// functions that decision funnels through, and both were carrying unkilled
+// mutants on `phase4-promql-lower` (issue #2883): the lowering fixtures pin the
+// SQL of a fully-configured default schema, which satisfies every clause at
+// once and so distinguishes none of them.
+
+// companionSuffixedName / companionBareName are a matched `<x>_sum` pair: the
+// user-visible suffixed name and the histogram-companion bare name it reduces
+// to.
+const (
+	companionSuffixedName = "http_request_duration_seconds_sum"
+	companionBareName     = "http_request_duration_seconds"
+)
+
+// companionValueCol is the histogram-table column a `_sum` companion reads.
+const companionValueCol = "Sum"
+
+// TestNeedCompanionUnion_RejectsEachMissingNameIndependently pins that all
+// three name inputs are required, one at a time.
+//
+// Each is load-bearing for a DIFFERENT part of the union: the value column is
+// what the histogram arm reduces, the suffixed name is the literal the
+// Sum/Gauge arm filters on, and the bare name is the literal the histogram arm
+// filters on. A union built with any of them empty emits an arm matching the
+// empty string, which returns no rows rather than failing.
+//
+// The schema is the fully-configured default, so [literalCompanionValueTables]
+// is non-empty for every case — the union would be requested if and only if the
+// name guard let it through. That isolates the guard.
+func TestNeedCompanionUnion_RejectsEachMissingNameIndependently(t *testing.T) {
+	t.Parallel()
+	s := schema.DefaultOTelMetrics()
+
+	if !needCompanionUnion(s, companionValueCol, companionSuffixedName, companionBareName) {
+		t.Fatal("the fully-named default-schema companion was refused; the rejection cases below would be vacuous")
+	}
+
+	for _, tc := range []struct {
+		name        string
+		valueColumn string
+		suffixed    string
+		bare        string
+	}{
+		{"no companion value column", "", companionSuffixedName, companionBareName},
+		{"no suffixed name", companionValueCol, "", companionBareName},
+		{"no bare name", companionValueCol, companionSuffixedName, ""},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if needCompanionUnion(s, tc.valueColumn, tc.suffixed, tc.bare) {
+				t.Errorf("needCompanionUnion requested a union with %s; want the single-arm histogram emit", tc.name)
+			}
+		})
+	}
+}
+
+// TestNeedCompanionUnion_RequiresADistinctLiteralValueTable pins the other half
+// of the decision: with all three names present, the union is requested if and
+// only if there is somewhere OTHER than the histogram table for the literal
+// suffixed name to live.
+//
+// The `> 0` is a strict comparison for a reason: a zero-length table list means
+// every configured value table collapsed onto the histogram table, so the
+// second arm would scan the same physical layout the first arm already reads,
+// under a name that is not in it.
+func TestNeedCompanionUnion_RequiresADistinctLiteralValueTable(t *testing.T) {
+	t.Parallel()
+
+	s := schema.DefaultOTelMetrics()
+	s.SumTable = s.HistogramTable
+	s.GaugeTable = s.HistogramTable
+
+	if got := literalCompanionValueTables(s); len(got) != 0 {
+		t.Fatalf("literalCompanionValueTables = %v; want empty once Sum and Gauge collapse onto Histogram", got)
+	}
+	if needCompanionUnion(s, companionValueCol, companionSuffixedName, companionBareName) {
+		t.Error("needCompanionUnion requested a union with no distinct literal value table; want the single-arm histogram emit")
+	}
+}
+
+// TestLiteralCompanionValueTables_SkipsEmptyAndHistogramTables pins the two
+// independent reasons a configured table is dropped from the literal-name arm
+// list, and that both are checked for every candidate.
+//
+// An unconfigured (empty) table name must not become an arm scanning ""; the
+// histogram table must not become one either, because it is already the bare-
+// name arm and re-scanning it under the suffixed name matches nothing. The two
+// cases below make exactly one of those reasons apply per candidate, so
+// collapsing the pair into a conjunction admits whichever one is not shared.
+func TestLiteralCompanionValueTables_SkipsEmptyAndHistogramTables(t *testing.T) {
+	t.Parallel()
+
+	t.Run("unconfigured sum table with a distinct histogram table", func(t *testing.T) {
+		t.Parallel()
+		s := schema.DefaultOTelMetrics()
+		s.SumTable = ""
+
+		got := literalCompanionValueTables(s)
+		if len(got) != 1 || got[0] != s.GaugeTable {
+			t.Errorf("literalCompanionValueTables = %v; want only the Gauge table %q — an empty name is not an arm",
+				got, s.GaugeTable)
+		}
+	})
+
+	t.Run("sum table configured as the histogram table", func(t *testing.T) {
+		t.Parallel()
+		s := schema.DefaultOTelMetrics()
+		s.SumTable = s.HistogramTable
+
+		got := literalCompanionValueTables(s)
+		if len(got) != 1 || got[0] != s.GaugeTable {
+			t.Errorf("literalCompanionValueTables = %v; want only the Gauge table %q — the histogram table is the bare-name arm",
+				got, s.GaugeTable)
+		}
+	})
+}
+
+// TestRewriteMetricName_TouchesOnlyThePinnedNameMatcher pins both halves of
+// rewriteMetricName's per-matcher predicate and its copy-on-write contract.
+//
+// The rewrite substitutes the caller's target name into a pinned `__name__=`
+// matcher so the single-arm histogram fallback reads the bare companion name.
+// Two failure modes it must not have: rewriting a matcher that is not the
+// pinned name (which would silently retarget a label filter — `job="api"`
+// becoming `job="<metric>"` matches nothing), and stopping the sweep at the
+// first rewritten matcher (which would leave the rest of the slice nil and
+// panic or drop filters downstream).
+//
+// The pinned matcher is deliberately NOT last, so a sweep that terminates early
+// instead of continuing leaves an observable hole behind it.
+func TestRewriteMetricName_TouchesOnlyThePinnedNameMatcher(t *testing.T) {
+	t.Parallel()
+
+	name := mustMatcher(t, labels.MatchEqual, labels.MetricName, companionSuffixedName)
+	job := mustMatcher(t, labels.MatchEqual, "job", "api")
+	nameRegex := mustMatcher(t, labels.MatchRegexp, labels.MetricName, "http_.*")
+	in := []*labels.Matcher{name, job, nameRegex}
+
+	out := rewriteMetricName(in, companionBareName)
+
+	if len(out) != len(in) {
+		t.Fatalf("rewriteMetricName returned %d matchers; want %d", len(out), len(in))
+	}
+	if out[0] == nil || out[0].Value != companionBareName {
+		t.Errorf("out[0] = %v; want the pinned __name__ matcher rewritten to %q", out[0], companionBareName)
+	}
+	// Every matcher after the rewritten one must still be there: a sweep
+	// that broke out of the loop leaves these nil.
+	if out[1] != job {
+		t.Errorf("out[1] = %v; want the untouched job matcher %v — only the pinned __name__ matcher is rewritten", out[1], job)
+	}
+	if out[2] != nameRegex {
+		t.Errorf("out[2] = %v; want the untouched __name__ regex matcher %v — the rewrite is equality-only", out[2], nameRegex)
+	}
+	// Copy-on-write: the caller's slice and its matchers are never mutated,
+	// because the parser reuses them across lowering passes.
+	if in[0].Value != companionSuffixedName {
+		t.Errorf("input matcher was mutated to %q; want the original %q", in[0].Value, companionSuffixedName)
+	}
+}

--- a/internal/promql/gremlins_kill_downsample_tier_test.go
+++ b/internal/promql/gremlins_kill_downsample_tier_test.go
@@ -1,0 +1,80 @@
+package promql
+
+import (
+	"testing"
+
+	"github.com/prometheus/prometheus/model/labels"
+
+	"github.com/tsouza/cerberus/internal/chplan"
+	"github.com/tsouza/cerberus/internal/schema"
+)
+
+// [buildDownsampleTierArm] builds the pre-aggregated tier relation a range
+// window reads INSTEAD OF the raw samples when the tier covers the request. Its
+// doc is explicit that the arm filters by "the SAME full label-matcher set the
+// primary selector arm applies", because the tier table carries the whole
+// series identity and there is no later join step to defer the rest of the
+// matchers to.
+//
+// That makes the Filter load-bearing for correctness, not for cost: an
+// unfiltered tier arm reads every series in the tier table and answers a
+// window over the wrong rows. The `pred != nil` test guarding it survived as a
+// mutant on `phase4-promql-lower` (issue #2883) — the fixtures that reach this
+// arm all pass a non-empty matcher set and pin the emitted SQL, so nothing
+// distinguished "wrap when there is a predicate" from its negation.
+//
+// Both directions are asserted, since the negation flips both: a matcher set
+// must produce a Filter, and an empty one must NOT produce a Filter carrying a
+// nil predicate.
+
+// downsampleTierMetric is the series the tier arm below selects.
+const downsampleTierMetric = "http_requests_total"
+
+// tierArmProject unwraps the attributes Project every tier arm is wrapped in
+// and returns the relation underneath it.
+func tierArmProject(t *testing.T, n chplan.Node) chplan.Node {
+	t.Helper()
+	p, ok := n.(*chplan.Project)
+	if !ok {
+		t.Fatalf("buildDownsampleTierArm returned %#v; want the attributes *chplan.Project", n)
+	}
+	return p.Input
+}
+
+func TestBuildDownsampleTierArm_FiltersByTheFullMatcherSet(t *testing.T) {
+	t.Parallel()
+	s := schema.DefaultOTelMetrics()
+	matchers := []*labels.Matcher{
+		mustMatcher(t, labels.MatchEqual, labels.MetricName, downsampleTierMetric),
+		mustMatcher(t, labels.MatchEqual, "job", "api"),
+	}
+
+	under := tierArmProject(t, buildDownsampleTierArm(matchers, s, lowerCtx{}))
+
+	filter, ok := under.(*chplan.Filter)
+	if !ok {
+		t.Fatalf("tier arm relation = %#v; want a *chplan.Filter — an unfiltered tier scan reads every series in the tier table", under)
+	}
+	if want := buildPredicate(matchers, s); !filter.Predicate.Equal(want) {
+		t.Errorf("tier arm predicate = %#v; want the same predicate the primary selector arm applies (%#v)", filter.Predicate, want)
+	}
+	scan, ok := filter.Input.(*chplan.Scan)
+	if !ok || scan.Table != schema.DownsampleTierTable {
+		t.Errorf("tier arm scans %#v; want a Scan of %q", filter.Input, schema.DownsampleTierTable)
+	}
+}
+
+func TestBuildDownsampleTierArm_SkipsTheFilterWithNoMatchers(t *testing.T) {
+	t.Parallel()
+	s := schema.DefaultOTelMetrics()
+
+	under := tierArmProject(t, buildDownsampleTierArm(nil, s, lowerCtx{}))
+
+	scan, ok := under.(*chplan.Scan)
+	if !ok {
+		t.Fatalf("tier arm relation = %#v; want the bare *chplan.Scan — there is no predicate to filter on", under)
+	}
+	if scan.Table != schema.DownsampleTierTable {
+		t.Errorf("tier arm scans %q; want %q", scan.Table, schema.DownsampleTierTable)
+	}
+}

--- a/internal/promql/gremlins_kill_downsample_tier_test.go
+++ b/internal/promql/gremlins_kill_downsample_tier_test.go
@@ -3,6 +3,7 @@ package promql
 import (
 	"testing"
 
+	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/model/labels"
 
 	"github.com/tsouza/cerberus/internal/chplan"
@@ -45,7 +46,7 @@ func TestBuildDownsampleTierArm_FiltersByTheFullMatcherSet(t *testing.T) {
 	t.Parallel()
 	s := schema.DefaultOTelMetrics()
 	matchers := []*labels.Matcher{
-		mustMatcher(t, labels.MatchEqual, labels.MetricName, downsampleTierMetric),
+		mustMatcher(t, labels.MatchEqual, model.MetricNameLabel, downsampleTierMetric),
 		mustMatcher(t, labels.MatchEqual, "job", "api"),
 	}
 

--- a/internal/promql/gremlins_kill_native_grid_guard_test.go
+++ b/internal/promql/gremlins_kill_native_grid_guard_test.go
@@ -1,0 +1,309 @@
+package promql
+
+import (
+	"testing"
+	"time"
+
+	"github.com/tsouza/cerberus/internal/chplan"
+	"github.com/tsouza/cerberus/internal/schema"
+)
+
+// The two native-grid eligibility funnels — [nativeTSGridMatrixNode] (the
+// timeSeries*ToGrid family) and [nativeLastOverTimeNode] (the stale-resample
+// sibling) — are pure classifiers: every clause they check decides whether a
+// window is handed to a ClickHouse aggregate that has NO equivalent of the
+// fan-out path's per-anchor arrayJoin. A clause that stops firing does not make
+// a query slower, it makes it WRONG — the native aggregate would be asked to
+// materialise a grid it cannot express (an unpinned or zero-step window), or to
+// read a series identity it does not group on.
+//
+// The lowering-level fixtures reach both funnels, but only ever down the
+// accepting arm: they pin the SQL a well-shaped window emits, so a guard that
+// was deleted outright still produces the same golden text for every input the
+// corpus happens to contain. That is exactly the gap mutation testing reports —
+// each `||` in the two guards below survived as an unkilled mutant on
+// `phase4-promql-lower` (issue #2883).
+//
+// The rejections are therefore asserted one clause at a time, each case
+// perturbing EXACTLY ONE field of a window the same test proves is otherwise
+// accepted. Holding every other field at an accepted value is what makes each
+// assertion specific: a nil result can only be attributed to the field under
+// test, so short-circuiting one disjunct into a conjunction (`||` -> `&&`)
+// flips that single case and nothing else.
+
+// nativeGuardStep is the eval-grid resolution the accepted baseline windows
+// carry — any strictly positive duration clears the `Step > 0` clause.
+const nativeGuardStep = 30 * time.Second
+
+// nativeGuardRange is the PromQL matrix `[range]` the baseline windows read.
+const nativeGuardRange = 5 * time.Minute
+
+// nativeGuardWindowSpan is the distance between the baseline Start and End
+// anchors, i.e. the eval grid the native aggregate materialises.
+const nativeGuardWindowSpan = time.Hour
+
+// nativeGuardScalarHorizon is the literal `t` a predict_linear-shaped window
+// would carry in Scalars; here it is only a non-empty marker value.
+const nativeGuardScalarHorizon = 60.0
+
+// nativeGuardStart / nativeGuardEnd are the pinned grid endpoints. They are
+// wall-clock-independent so the classifier's verdict is deterministic.
+func nativeGuardStart() time.Time {
+	return time.Date(2026, time.September, 1, 0, 0, 0, 0, time.UTC)
+}
+
+func nativeGuardEnd() time.Time {
+	return nativeGuardStart().Add(nativeGuardWindowSpan)
+}
+
+// nativeGuardInput is the row-shape relation both funnels accept: a plain
+// Filter-over-Scan chain ([isPlainScanFilter]).
+func nativeGuardInput(s schema.Metrics) chplan.Node {
+	return &chplan.Filter{
+		Input: &chplan.Scan{Database: "otel", Table: "otel_metrics_sum"},
+		Predicate: &chplan.Binary{
+			Op:    chplan.OpEq,
+			Left:  &chplan.ColumnRef{Name: s.MetricNameColumn},
+			Right: &chplan.LitString{V: "http_requests_total"},
+		},
+	}
+}
+
+// acceptedGridWindow is a window [nativeTSGridMatrixNode] accepts for `rate`.
+func acceptedGridWindow(s schema.Metrics) *chplan.RangeWindow {
+	return &chplan.RangeWindow{
+		Input:           nativeGuardInput(s),
+		Func:            "rate",
+		Range:           nativeGuardRange,
+		Step:            nativeGuardStep,
+		Start:           nativeGuardStart(),
+		End:             nativeGuardEnd(),
+		TimestampColumn: s.TimestampColumn,
+		ValueColumn:     s.ValueColumn,
+		GroupBy:         []chplan.Expr{&chplan.ColumnRef{Name: s.AttributesColumn}},
+	}
+}
+
+// acceptedLastOverTimeWindow is a window [nativeLastOverTimeNode] accepts.
+func acceptedLastOverTimeWindow(s schema.Metrics) *chplan.RangeWindow {
+	rw := acceptedGridWindow(s)
+	rw.Func = "last_over_time"
+	return rw
+}
+
+// TestNativeTSGridMatrixNode_GridGuardRejectsEachUnpinnedClause pins that the
+// materialised-grid precondition rejects on EVERY one of its four clauses
+// independently: an identity (bare-vector subquery) window, a window with no
+// eval step, and a window with either endpoint unpinned.
+//
+// The native emitter renders `timeSeries*ToGrid(start, end, step, …)`, whose
+// three grid parameters have no fan-out fallback inside the aggregate. A window
+// that reaches it with Step == 0 asks ClickHouse to divide the span by zero
+// buckets; one with a zero Start or End substitutes the emitter's `now64()`
+// anchor, which silently answers a DIFFERENT time range than the request. Each
+// case below is the only one of the four that a single short-circuit collapse
+// of this guard would let through.
+func TestNativeTSGridMatrixNode_GridGuardRejectsEachUnpinnedClause(t *testing.T) {
+	t.Parallel()
+	s := schema.DefaultOTelMetrics()
+
+	if got := nativeTSGridMatrixNode(acceptedGridWindow(s), "rate", s, false); got == nil {
+		t.Fatal("baseline pinned-grid rate window was refused; the rejection cases below would be vacuous")
+	}
+
+	for _, tc := range []struct {
+		name    string
+		perturb func(*chplan.RangeWindow)
+	}{
+		{
+			// Identity is the bare-vector subquery no-op path: the
+			// emitter must read the last sample in the window, not
+			// apply `rate`'s per-second reduction.
+			name:    "identity window",
+			perturb: func(rw *chplan.RangeWindow) { rw.Identity = true },
+		},
+		{
+			// Step == 0 is the instant shape, owned by
+			// nativeTSGridInstantNode. It is also the exact boundary
+			// the `<= 0` comparison exists for: `< 0` would admit it.
+			name:    "zero step",
+			perturb: func(rw *chplan.RangeWindow) { rw.Step = 0 },
+		},
+		{
+			name:    "unpinned start",
+			perturb: func(rw *chplan.RangeWindow) { rw.Start = time.Time{} },
+		},
+		{
+			name:    "unpinned end",
+			perturb: func(rw *chplan.RangeWindow) { rw.End = time.Time{} },
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			rw := acceptedGridWindow(s)
+			tc.perturb(rw)
+			if got := nativeTSGridMatrixNode(rw, "rate", s, false); got != nil {
+				t.Errorf("nativeTSGridMatrixNode accepted a %s: %#v; want nil so the fan-out path emits it", tc.name, got)
+			}
+		})
+	}
+}
+
+// TestNativeLastOverTimeNode_GridGuardRejectsEachUnpinnedClause is the
+// stale-resample sibling of the case above. chplan.RangeWindowStaleResample
+// carries Start / End / Step straight into the emitted resample grid, so the
+// same four clauses guard the same wrong answer.
+func TestNativeLastOverTimeNode_GridGuardRejectsEachUnpinnedClause(t *testing.T) {
+	t.Parallel()
+	s := schema.DefaultOTelMetrics()
+
+	if got := nativeLastOverTimeNode(acceptedLastOverTimeWindow(s), s); got == nil {
+		t.Fatal("baseline pinned-grid last_over_time window was refused; the rejection cases below would be vacuous")
+	}
+
+	for _, tc := range []struct {
+		name    string
+		perturb func(*chplan.RangeWindow)
+	}{
+		{
+			name:    "identity window",
+			perturb: func(rw *chplan.RangeWindow) { rw.Identity = true },
+		},
+		{
+			name:    "zero step",
+			perturb: func(rw *chplan.RangeWindow) { rw.Step = 0 },
+		},
+		{
+			name:    "unpinned start",
+			perturb: func(rw *chplan.RangeWindow) { rw.Start = time.Time{} },
+		},
+		{
+			name:    "unpinned end",
+			perturb: func(rw *chplan.RangeWindow) { rw.End = time.Time{} },
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			rw := acceptedLastOverTimeWindow(s)
+			tc.perturb(rw)
+			if got := nativeLastOverTimeNode(rw, s); got != nil {
+				t.Errorf("nativeLastOverTimeNode accepted a %s: %#v; want nil so the fan-out path emits it", tc.name, got)
+			}
+		})
+	}
+}
+
+// TestNativeLastOverTimeNode_RequiresSoleIdentityGroupKey pins BOTH halves of
+// the series-identity precondition, which is a disjunction of two independently
+// sufficient rejections.
+//
+// chplan.RangeWindowStaleResample has no GroupBy field at all: it hard-codes its
+// grouping to (MetricName, Attributes) in the emitter. Handing it a window that
+// grouped on anything else — a second key, or a single key that is not the
+// schema's attributes column — would therefore silently DISCARD that key and
+// collapse distinct output series into one. Neither half can be dropped:
+// "exactly one key" without "and it is the identity one" admits a lone wrong
+// key, and the converse admits a wrong key alongside the right one.
+func TestNativeLastOverTimeNode_RequiresSoleIdentityGroupKey(t *testing.T) {
+	t.Parallel()
+	s := schema.DefaultOTelMetrics()
+
+	for _, tc := range []struct {
+		name    string
+		groupBy []chplan.Expr
+	}{
+		{
+			// Arity fails, identity holds for element 0.
+			name: "identity key plus a second key",
+			groupBy: []chplan.Expr{
+				&chplan.ColumnRef{Name: s.AttributesColumn},
+				&chplan.ColumnRef{Name: s.MetricNameColumn},
+			},
+		},
+		{
+			// Arity holds, identity fails.
+			name:    "sole non-identity key",
+			groupBy: []chplan.Expr{&chplan.ColumnRef{Name: s.MetricNameColumn}},
+		},
+		{
+			// Arity holds, identity fails on the expression SHAPE
+			// rather than the name: a computed key is not a bare
+			// column reference the emitter can drop.
+			name: "sole computed key",
+			groupBy: []chplan.Expr{&chplan.MapAccess{
+				Map: &chplan.ColumnRef{Name: s.AttributesColumn},
+				Key: &chplan.LitString{V: "job"},
+			}},
+		},
+		{
+			// Both halves fail at once.
+			name:    "no group keys",
+			groupBy: nil,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			rw := acceptedLastOverTimeWindow(s)
+			rw.GroupBy = tc.groupBy
+			if got := nativeLastOverTimeNode(rw, s); got != nil {
+				t.Errorf("nativeLastOverTimeNode accepted %s: %#v; want nil so the fan-out path keeps the grouping", tc.name, got)
+			}
+		})
+	}
+}
+
+// TestNativeLastOverTimeNode_RejectsEachFusedWindowCarrier pins the four-clause
+// "this window carries more than one plain reduction" guard.
+//
+// chplan.RangeWindowStaleResample emits ONE resampled value column. Each of the
+// four fields below is a carrier for extra per-window outputs that the node has
+// nowhere to put: DeltaPrefixAggregateInput is the delta-temporality prefix
+// relation, Variants is the fused multi-arm shape, and ScalarExprs / Scalars are
+// the parametric arguments a function like predict_linear threads through.
+// Accepting any of them would emit a query that silently answers only the first
+// arm. Each field is set alone, so no case leans on another's rejection.
+func TestNativeLastOverTimeNode_RejectsEachFusedWindowCarrier(t *testing.T) {
+	t.Parallel()
+	s := schema.DefaultOTelMetrics()
+
+	for _, tc := range []struct {
+		name    string
+		perturb func(*chplan.RangeWindow)
+	}{
+		{
+			name: "delta-temporality prefix relation",
+			perturb: func(rw *chplan.RangeWindow) {
+				rw.DeltaPrefixAggregateInput = nativeGuardInput(s)
+			},
+		},
+		{
+			name: "fused multi-arm variants",
+			perturb: func(rw *chplan.RangeWindow) {
+				rw.Variants = []chplan.RangeWindowVariant{
+					{Func: "last_over_time", ValueColumn: s.ValueColumn},
+				}
+			},
+		},
+		{
+			name: "parametric scalar expressions",
+			perturb: func(rw *chplan.RangeWindow) {
+				rw.ScalarExprs = []chplan.Expr{&chplan.LitFloat{V: nativeGuardScalarHorizon}}
+			},
+		},
+		{
+			name: "parametric scalar literals",
+			perturb: func(rw *chplan.RangeWindow) {
+				rw.Scalars = []float64{nativeGuardScalarHorizon}
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			rw := acceptedLastOverTimeWindow(s)
+			tc.perturb(rw)
+			if got := nativeLastOverTimeNode(rw, s); got != nil {
+				t.Errorf("nativeLastOverTimeNode accepted a window carrying %s: %#v; want nil so every arm is emitted", tc.name, got)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

The `gremlins phase4-promql-lower (./internal/promql @ 95%)` leg has been
oscillating red on push-to-main, sitting just under its floor. This raises it by
killing 20 surviving mutants with real assertions. **No production code changes,
and the leg's file set is untouched** — `include_files` still reads
`^(lower)\.go$`, so the denominator is exactly what it was.

## The measurement, refreshed

The issue body's inventory was stale. Re-read from the job log of run
[33542904091](https://github.com/tsouza/cerberus/actions/runs/33542904091)
(`phase4-promql-lower`, job 99973344955):

| status | count |
| --- | ---: |
| KILLED | 486 |
| LIVED | 31 |
| NOT COVERED | 48 |
| TIMED OUT | 4 |

`Test efficacy: 94.00%` = 486 / (486 + 31) = 486/517, and `Mutator coverage:
91.50%` = 517/565. Both reproduce exactly, which pins the arithmetic the floor
is computed over — `gremlins-threshold.mjs` gates on `report.test_efficacy`,
which is `killed / (killed + lived)`:

- **NOT COVERED is outside the denominator.** A test that merely *reaches* an
  uncovered line moves that mutant into the denominator and makes the score
  WORSE unless it also kills it. The 48 uncovered mutants are therefore not a
  shortcut, and this change deliberately does not chase them.
- **TIMED OUT is outside it too**, and is separately recomputed into the kill
  side by `detectedEfficacy`. So a timeout cannot lower the score and may raise
  it. Had the red run's four timeouts all completed and been killed, the score
  would be 490/521 = 94.05% — still under the floor. They are not the shortfall.

That leaves the 31 LIVED mutants as the only honest lever. Clearing 95% needs at
least six of them killed: (486 + n)/517 >= 0.95 requires n >= 6.

## What is killed here

Twenty — 506/517 = **97.87%** on that inventory. Each was verified individually
by applying the mutation to `lower.go` by hand and re-running the new tests: all
20 report the suite failing under the mutation and passing without it.

### The two native-grid eligibility funnels (12)

`nativeTSGridMatrixNode` and `nativeLastOverTimeNode` are pure classifiers: they
decide whether a `chplan.RangeWindow` is handed to a ClickHouse
`timeSeries*ToGrid` aggregate, which has no per-anchor fan-out fallback inside
it. Every clause guards a wrong answer — a window reaching the native emitter
with `Step == 0` asks it to divide a span by zero buckets, and one with an
unpinned `Start`/`End` substitutes the emitter's `now64()` anchor and silently
answers a different time range than the request.

The existing lowering fixtures reach both funnels only down the *accepting* arm.
They pin the SQL a well-shaped window emits, so a guard deleted outright still
produces identical golden text for every input the corpus contains. That is
precisely the gap the mutation score was reporting.

| site | mutants | killed by |
| --- | ---: | --- |
| `lower.go:3574` pinned-grid guard | 3 `INVERT_LOGICAL` + 1 `CONDITIONALS_BOUNDARY` | identity / zero-step / unpinned-start / unpinned-end windows |
| `lower.go:3753` same guard, stale-resample sibling | 3 `INVERT_LOGICAL` + 1 `CONDITIONALS_BOUNDARY` | as above |
| `lower.go:3762` sole-identity-group-key guard | 1 `INVERT_LOGICAL` | second key present / lone non-identity key / computed key / no keys |
| `lower.go:3765-3766` fused-window-carrier guard | 3 `INVERT_LOGICAL` | delta prefix / variants / scalar exprs / scalar literals, each set alone |

### The classic-histogram-companion routing (7)

`needCompanionUnion` and `literalCompanionValueTables` decide how a `<x>_sum` /
`<x>_count` selector is READ: as the single bare-name arm inside the histogram
table, or as a UnionAll that also scans the Sum / Gauge tables under the literal
suffixed name. Picking the single arm when a distinct value table exists drops
whichever rows live there — a silently short answer, not an error. The bare-name
rewrite in `resolveSelectorRouting` is the same decision's consequence, and is
correct only on the fallback: on the union path the arms own their own rewrite,
and rewriting here too makes the Sum/Gauge arm filter on a name those tables do
not carry. The fixtures only exercise the fully-configured default schema, which
satisfies every clause at once and so distinguishes none of them.

| site | mutants | killed by |
| --- | ---: | --- |
| `lower.go:1344` three-name precondition | 2 `INVERT_LOGICAL` | one name dropped per case |
| `lower.go:1351` distinct-value-table count | 1 `CONDITIONALS_BOUNDARY` | Sum and Gauge both collapsed onto Histogram |
| `lower.go:1364` per-candidate skip | 1 `INVERT_LOGICAL` | unconfigured table / table equal to the histogram table |
| `lower.go:1069` bare-name rewrite guard | 1 `CONDITIONALS_NEGATION` | union schema and fallback schema asserted to disagree |
| `lower.go:1911` pinned-name-matcher predicate | 1 `INVERT_LOGICAL` | a `job=` matcher that must pass through untouched |
| `lower.go:1918` sweep past the rewritten matcher | 1 `INVERT_LOOPCTRL` | the pinned matcher placed before two others |

### The downsample-tier arm (1)

`buildDownsampleTierArm`'s doc is explicit that the tier relation filters by the
same full matcher set the primary selector arm applies, because the tier table
carries the whole series identity and there is no later join to defer the rest
of the matchers to. An unfiltered tier arm answers a window over the wrong rows
rather than merely reading too many. `lower.go:1803`'s `pred != nil` is now
pinned in both directions — a matcher set produces the Filter, an empty one
produces the bare Scan rather than a Filter carrying a nil predicate.

### What makes the assertions specific

Every case perturbs **exactly one** field or input of a value the same test
first proves is accepted, with a `t.Fatal` on that baseline so the rejection
cases cannot go vacuous. A nil result is therefore attributable to the field
under test alone, so collapsing one disjunct into a conjunction flips that one
case and nothing else. The zero-step case is what kills the `<= 0` -> `< 0`
boundary mutants: `0 <= 0` fires the guard and `0 < 0` does not, so it is the
one input that distinguishes them.

## The denominator is unchanged

- `.github/scripts/mutation-phases.mjs` is not touched; `phase4-promql-lower`
  still declares `include_files: '^(lower)\.go$'`. `mutation-matrix.mjs`'s
  `includeTightnessViolations` would fail the table if that allowlist stopped
  being the canonical set of files it claims.
- `git diff origin/main -- internal/promql/lower.go` is empty. Every mutable
  line gremlins can reach is the same line it reached before.
- The change is four new `_test.go` files and nothing else, so the whole
  efficacy gain is new kills.

## Survivors deliberately left, because they cannot be killed

Three `CONDITIONALS_BOUNDARY` mutants on `if len(candidates) <= 1` (in
`matcherToExpr`, `attributeLookupKeys` and `attributeLookupExpr`) are equivalent
mutants. Each sits behind `format.PromLabelNeedsDottedFallback`, which returns
true only when the label carries a rewritable underscore — and
`PromLabelToOTelCandidates` then returns the powerset of dotted re-expansions,
which has at least two elements. `len(candidates) == 1` is unreachable, exactly
as the third site's own comment says ("Belt-and-braces … we expect >= 2
candidates"). `< 1` and `<= 1` cannot be distinguished by any input, so no test
can kill them without changing production code to make a dead branch live.

`args := make([]chplan.Expr, 0, len(a.Grouping)*2)` is equivalent for the same
kind of reason: `ARITHMETIC_BASE` turns `*` into `/`, and a capacity hint of
`len/2` rather than `len*2` changes only how often the slice regrows. Invariant
13 exempts slice-capacity hints from the named-constant rule on exactly this
ground — they carry no meaning a test could observe.

## Why the leg oscillates, which this does not fix

Worth recording, because it means a single green run on this leg is not
evidence. The green run
[33551271099](https://github.com/tsouza/cerberus/actions/runs/33551271099)
reported 97.01% on the **same 486 kills** as the red one — the difference is
entirely 16 mutants moving from LIVED into TIMED OUT, and its runner was 44%
SLOWER (coverage 53.2s vs 36.8s, mutation phase 16m43s vs 11m38s). Matching the
two runs' per-mutant records by source text, 18 of the red run's 31 LIVED
mutants appear as TIMED OUT in the green one, including most of the guards this
PR now asserts. Measured directly, the `lower.go:3574` mutant runs to a verdict
in 2.0s and takes 22s of wall clock to COMPILE under load, against a 15s ceiling
that wraps the whole `go test` child.

Scoring that as a detection is its own defect, and it is filed as #2903 with the
full evidence; it is a property of the lane rather than of this file, it affects
the reading of every leg, and its fix is a change to the gate rather than to
`internal/promql`. This PR is orthogonal to it: killing a mutant makes the leg
green on a fast runner and a slow one alike.

## What this does not settle

The exit criterion for #2883 is two consecutive completed push-to-main
`mutation` runs green, which only merging can produce. The leg's line numbers
also drift between revisions — the inventory above was measured against a
6023-line `lower.go` while `main` now carries 6213 — so the surviving set on the
merge commit will be close to, not identical to, the one tabulated here.

Closes #2883

🤖 Generated with [Claude Code](https://claude.com/claude-code)
