### PR TITLE
fix(ci): scope the perf-sentinel obligation by mechanism, and gate what a green PR misses

### DIFF
--- a/.github/scripts/merge-risk.mjs
+++ b/.github/scripts/merge-risk.mjs
@@ -1,0 +1,304 @@
+// merge-risk.mjs — what this pull request's green does NOT cover.
+//
+// # The class (#2899)
+//
+// A pull request can be green on all seventeen required checks and still turn
+// `main` red the moment it merges. Two independent mechanisms produce that one
+// outcome, and both have already fired in this repository:
+//
+//   1. LANE SKIPPING. Several lanes that gate `main` or a release declare
+//      `merge_posture: never` in `.github/ci-lanes.json` — `compatibility/*`,
+//      the chDB round-trip and perf-guard shards, `perf-nightly`, the e2e
+//      family. They run on push-to-main, on a schedule, or on a release PR,
+//      never on an ordinary one. GitHub renders a lane that did not run as
+//      nothing at all, so a skipped lane and a passing lane look identical on
+//      the checks list. #2895 is what that costs: a 144-case Loki parity
+//      regression merged green and sat on `main` for 32 hours and 31 red runs
+//      before anyone read the run history.
+//
+//   2. STALE BASE. Branch protection deliberately does NOT require a branch to
+//      be up to date before merging (`required_status_checks.strict: false`),
+//      because forcing every one of ~20 PRs a day through an update-branch and
+//      a full ~40-minute re-run serialises merges and spends the most CI
+//      exactly when the repo is busiest. The cost of that trade is that a
+//      regenerate-and-diff ratchet runs against the tree AS THE PR SAW IT, and
+//      two PRs that each regenerate the same whole-tree artefact against
+//      different bases can both be green and still leave `main` drifted.
+//      `post-merge-golden-drift.mjs` caught exactly that with 8 drifted
+//      cardinality artefacts and diagnosed it in those terms.
+//
+// # What this gate does about each, and why they differ
+//
+// STALE BASE is BLOCKING here, because it is precisely decidable from two git
+// ranges and it fires only on a real collision. A golden artefact is a pure
+// function of (its fixture corpus, its generator code). When neither side of
+// the race moved generator code, each side's golden writes are determined by
+// its own fixtures and the merged tree is simply their union — no drift. When
+// EITHER side moved Go code, the function itself changed, and any golden the
+// other side wrote was produced by the old one. So: a collision is both sides
+// writing under the same shard's golden root while at least one side also
+// changes Go. Same-FILE races need no help from this gate — git already
+// reports those as merge conflicts and GitHub blocks them; the residual hole
+// this closes is the different-files-same-artefact race, which merges clean.
+//
+// This is the targeted form of `strict: true`: it forces an update-branch on
+// the handful of PRs that actually race a generated artefact, and leaves every
+// other PR unserialised. It is not a policy change to branch protection and
+// does not need one.
+//
+// LANE SKIPPING is REPORTED, not blocked, and that is a deliberate limit
+// rather than a soft landing. Blocking it would fail nearly every code PR —
+// an ordinary `internal/promql` change is unvalidated by `compatibility/
+// prometheus`, three chDB shards, `quality.property` and `performance.profile`
+// simultaneously, and the only escape from such a gate would be a per-PR
+// waiver citation, which is the receipt-issue pattern #2893 exists to delete.
+// What this gate does instead is make the skip legible: the lanes that gate
+// `main` and will not run before this merges are named on the PR, with the
+// local command that runs each one, so "green" is never silently read as
+// "validated". Attribution is by the lane's own declared `package_globs`; that
+// declaration is known to under-cover shared plumbing (see issue #2902), and
+// the summary says so rather than implying the list is exhaustive.
+//
+// # Env
+//
+//   BASE_SHA            start of the change's range (PR base, merge-group base,
+//                       or push `before`). Falls back to HEAD^.
+//   HEAD_SHA            end of the range. Falls back to HEAD.
+//   MERGE_TARGET_REF    the ref this change will land on, for the stale-base
+//                       comparison. Default `origin/main`. A ref that does not
+//                       resolve (a push to main, where it is the same commit)
+//                       disables the stale-base half rather than failing it.
+//   CI_LANE_REGISTRY    lane registry path. Default `.github/ci-lanes.json`.
+//   GITHUB_STEP_SUMMARY optional summary destination (written via lib/gh.mjs).
+//
+// Node builtins only. `process.exit(1)` on a stale-base collision or an
+// unreadable registry; the lane inventory never exits non-zero on its own.
+//
+// The pure halves are exported and pinned by merge-risk.test.mjs.
+
+import { readFileSync } from 'node:fs';
+import process from 'node:process';
+import { pathToFileURL } from 'node:url';
+
+import { matchesGlob } from './ci-lane-contract.mjs';
+import { appendStepSummary, assertSafeArg, error, git, log, notice, warning } from './lib/gh.mjs';
+import { SHARDS } from './lib/golden-shards.mjs';
+
+export const DEFAULT_REGISTRY_PATH = '.github/ci-lanes.json';
+export const DEFAULT_MERGE_TARGET_REF = 'origin/main';
+
+/** The extension that marks a generator-code change, as opposed to a data one. */
+const GO_EXT = '.go';
+
+// MAX_LISTED_FILES caps how many colliding paths each side of a stale-base
+// report names. The reader needs enough to recognise the artefact, not the
+// whole regeneration; a cardinality race can touch hundreds of shard files.
+const MAX_LISTED_FILES = 6;
+
+/** revExists — does `ref` name a commit in this checkout? */
+export function revExists(ref, { run = git } = {}) {
+  if (!ref) return false;
+  return run(['rev-parse', '--verify', '--quiet', `${ref}^{commit}`]).status === 0;
+}
+
+/** changedFiles — the paths a git range touches, newest-name form. */
+export function changedFiles(range, { run = git } = {}) {
+  const res = run(['diff', '--name-only', range]);
+  if (res.status !== 0) throw new Error(`git diff --name-only ${range} failed: ${res.stderr.trim()}`);
+  return res.stdout.split('\n').filter(Boolean);
+}
+
+/** revParse — one revision resolved to a sha, or a thrown explanation. */
+function revParse(args, { run = git } = {}) {
+  const res = run(args);
+  if (res.status !== 0) throw new Error(`git ${args.join(' ')} failed: ${res.stderr.trim()}`);
+  return res.stdout.trim();
+}
+
+/**
+ * goldenRootsOf — every path prefix a shard WRITES, as declared by
+ * lib/golden-shards.mjs. Read from the shard table rather than restated, so a
+ * shard that repoints its goldens moves this gate with it.
+ */
+export function goldenRootsOf(shards = SHARDS) {
+  return Object.fromEntries(Object.entries(shards).map(([name, s]) => [name, s.goldens ?? []]));
+}
+
+/** underGoldenRoot — is `file` written by a shard whose golden root is `root`? */
+export function underGoldenRoot(file, root) {
+  return matchesGlob(file, root) || matchesGlob(file, `${root}/**`);
+}
+
+/** shardsWritten — which shards' golden roots this file set writes under. */
+export function shardsWritten(files, roots = goldenRootsOf()) {
+  const hit = new Map();
+  for (const [name, prefixes] of Object.entries(roots)) {
+    const written = (files ?? []).filter((f) => prefixes.some((p) => underGoldenRoot(f, p)));
+    if (written.length > 0) hit.set(name, written);
+  }
+  return hit;
+}
+
+/**
+ * staleBaseCollisions — the shards this change and its merge target BOTH
+ * regenerate, where at least one side also moves generator code.
+ *
+ * Returns `[{ shard, ours, theirs }]`, ours/theirs being the written paths on
+ * each side. Empty is the overwhelmingly common answer.
+ */
+export function staleBaseCollisions({ ours, theirs, roots = goldenRootsOf() }) {
+  const codeMoved = [...(ours ?? []), ...(theirs ?? [])].some((f) => f.endsWith(GO_EXT));
+  if (!codeMoved) return [];
+
+  const mine = shardsWritten(ours, roots);
+  const yours = shardsWritten(theirs, roots);
+  const out = [];
+  for (const [shard, written] of mine) {
+    if (!yours.has(shard)) continue;
+    out.push({ shard, ours: written, theirs: yours.get(shard) });
+  }
+  return out.sort((a, b) => a.shard.localeCompare(b.shard));
+}
+
+/**
+ * gatingLanesThatSkipPRs — lanes that gate `main` or a release yet never run
+ * on a pull request. `merge_posture: never` is the skip; a lane that also runs
+ * nowhere afterwards (`main_posture: never` and no release requirement) gates
+ * nothing and is not a risk, so it is excluded.
+ */
+export function gatingLanesThatSkipPRs(registry) {
+  return (registry?.lanes ?? []).filter(
+    (l) => l.merge_posture === 'never'
+      && (l.main_posture !== 'never' || l.release_posture === 'required'),
+  );
+}
+
+/**
+ * unvalidatedLanes — of those, the ones whose declared `package_globs` this
+ * change actually touches. Attribution is only as good as the declaration:
+ * see this file's header and issue #2902.
+ */
+export function unvalidatedLanes(registry, files) {
+  const out = [];
+  for (const lane of gatingLanesThatSkipPRs(registry)) {
+    const matched = (files ?? []).filter((f) => (lane.package_globs ?? []).some((g) => matchesGlob(f, g)));
+    if (matched.length > 0) out.push({ lane, matched });
+  }
+  return out.sort((a, b) => a.lane.id.localeCompare(b.lane.id));
+}
+
+/** collisionReport — the printable failure for one stale-base collision. */
+export function collisionReport({ shard, ours, theirs }, targetRef = DEFAULT_MERGE_TARGET_REF) {
+  return (
+    `stale base: this change and ${targetRef} both regenerate the \`${shard}\` golden shard against `
+    + `different bases. Here: ${ours.slice(0, MAX_LISTED_FILES).join(', ')}`
+    + `${ours.length > MAX_LISTED_FILES ? ` (+${ours.length - MAX_LISTED_FILES} more)` : ''}. `
+    + `On ${targetRef} since this branch forked: ${theirs.slice(0, MAX_LISTED_FILES).join(', ')}`
+    + `${theirs.length > MAX_LISTED_FILES ? ` (+${theirs.length - MAX_LISTED_FILES} more)` : ''}. `
+    + 'A golden is a function of its corpus AND its generator code, and one side of this race moved '
+    + `code, so whichever artefact lands second was written by the other's generator. Merge `
+    + `${targetRef} into this branch and regenerate — \`just update-golden ${shard}\` locally, or `
+    + `\`gh workflow run update-golden.yml -f shards=${shard} -f branch=<this branch>\` when the `
+    + 'shard needs libchdb — then push. That makes the ratchet check the tree that actually lands.'
+  );
+}
+
+async function main() {
+  const targetRef = assertSafeArg(process.env.MERGE_TARGET_REF || DEFAULT_MERGE_TARGET_REF, 'MERGE_TARGET_REF');
+  const registryPath = process.env.CI_LANE_REGISTRY || DEFAULT_REGISTRY_PATH;
+
+  const head = assertSafeArg(process.env.HEAD_SHA || 'HEAD', 'HEAD_SHA');
+  const baseSha = assertSafeArg(process.env.BASE_SHA || '', 'BASE_SHA');
+  const base = revExists(baseSha) ? baseSha : `${head}^`;
+  const ours = changedFiles(`${base}...${head}`);
+
+  const summary = ['## merge-risk', ''];
+
+  // --- stale base (blocking) -------------------------------------------------
+  let collisions = [];
+  if (!revExists(targetRef)) {
+    summary.push(
+      `Stale-base check skipped: \`${targetRef}\` does not resolve in this checkout, which is what a`
+        + ' push to that same branch looks like — there is no other base to race.',
+      '',
+    );
+  } else {
+    const mergeBase = revParse(['merge-base', head, targetRef]);
+    const theirs = changedFiles(`${mergeBase}..${targetRef}`);
+    collisions = staleBaseCollisions({ ours, theirs });
+    summary.push(
+      collisions.length === 0
+        ? `Stale base: no golden shard is regenerated by both this change and \`${targetRef}\`.`
+        : `Stale base: **${collisions.length} colliding golden shard(s)** — see the error annotations.`,
+      '',
+    );
+  }
+
+  // --- unvalidated lanes (reported) -----------------------------------------
+  let registry;
+  try {
+    registry = JSON.parse(readFileSync(registryPath, 'utf8'));
+  } catch (e) {
+    error(
+      `merge-risk: ${registryPath} could not be read (${String(e?.message ?? e)}), so the lanes this `
+        + 'change leaves unvalidated cannot be enumerated at all.',
+      { title: 'merge-risk' },
+    );
+    process.exit(1);
+  }
+
+  const skipping = gatingLanesThatSkipPRs(registry);
+  const unvalidated = unvalidatedLanes(registry, ours);
+  summary.push(
+    `### Lanes that gate \`main\` but do not run on this PR (${unvalidated.length} of ${skipping.length} touched)`,
+    '',
+  );
+  if (unvalidated.length === 0) {
+    summary.push(
+      'None of the declared path globs for those lanes match this change. That is an argument, not a',
+      'proof: attribution uses each lane\'s own `package_globs`, which under-cover shared plumbing',
+      '(issue #2902).',
+      '',
+    );
+  } else {
+    summary.push('| lane | validates | run it with |', '| --- | --- | --- |');
+    for (const { lane } of unvalidated) {
+      summary.push(`| \`${lane.id}\` | ${lane.description} | \`${lane.command ?? lane.recipes?.join(', ') ?? '—'}\` |`);
+    }
+    summary.push(
+      '',
+      'These run on push-to-main, a schedule, or a release PR — never on this one. A green PR is not',
+      'evidence they pass. Attribution is by each lane\'s declared `package_globs`, which under-cover',
+      'shared plumbing (issue #2902), so this table is a floor rather than the whole risk.',
+      '',
+    );
+  }
+  appendStepSummary(summary.join('\n'));
+
+  if (unvalidated.length > 0) {
+    warning(
+      `merge-risk: ${unvalidated.length} lane(s) that gate main will not run before this merges — `
+        + `${unvalidated.map((u) => u.lane.id).join(', ')}. A green PR does not mean they pass.`,
+      { title: 'merge-risk' },
+    );
+  }
+  for (const { lane } of unvalidated) log(`unvalidated lane: ${lane.id} (${lane.command ?? lane.id})`);
+
+  if (collisions.length > 0) {
+    for (const c of collisions) error(`merge-risk: ${collisionReport(c, targetRef)}`, { title: 'merge-risk' });
+    process.exit(1);
+  }
+
+  notice(
+    `merge-risk: no golden shard collides with ${targetRef}; `
+      + `${unvalidated.length} gating lane(s) will not run before this merges.`,
+    { title: 'merge-risk' },
+  );
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main().catch((e) => {
+    error(`merge-risk: ${String(e?.message ?? e)}`, { title: 'merge-risk' });
+    process.exit(1);
+  });
+}

--- a/.github/scripts/merge-risk.test.mjs
+++ b/.github/scripts/merge-risk.test.mjs
@@ -1,0 +1,207 @@
+// merge-risk.test.mjs — node:test guard for #2899's merge-risk gate.
+//
+// The gate has one BLOCKING half (the stale-base golden collision) and one
+// REPORTING half (the lanes that gate `main` and do not run on this PR), and
+// each needs both directions pinned. A stale-base check that only ever finds a
+// collision would block every PR; one that can never find a collision is the
+// invisible-skip posture this exists to end, wearing a green tick. Both shapes
+// are asserted below, and so is the ONE case the blocking half deliberately
+// stays quiet on — two PRs adding independent fixtures with no generator-code
+// change between them, where the merged tree really is the union.
+
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+import {
+  DEFAULT_MERGE_TARGET_REF,
+  DEFAULT_REGISTRY_PATH,
+  changedFiles,
+  collisionReport,
+  gatingLanesThatSkipPRs,
+  goldenRootsOf,
+  revExists,
+  shardsWritten,
+  staleBaseCollisions,
+  underGoldenRoot,
+  unvalidatedLanes,
+} from './merge-risk.mjs';
+
+const REGISTRY = JSON.parse(readFileSync(resolve(DEFAULT_REGISTRY_PATH), 'utf8'));
+
+// The two sides of the real #2895 / post-merge-drift races, as file sets.
+const CARDINALITY_A = ['internal/chsql/emit.go', 'test/perf/cardinality-baseline/promql/rate_5m.json'];
+const CARDINALITY_B = ['internal/promql/lower.go', 'test/perf/cardinality-baseline/promql/sum_by.json'];
+
+// --- golden-root resolution ---------------------------------------------------
+
+test('goldenRootsOf reads the shard table rather than restating it', () => {
+  const roots = goldenRootsOf();
+  assert.ok(Object.keys(roots).length > 0, 'an empty shard table makes the stale-base half vacuous');
+  assert.ok(roots.cardinality.includes('test/perf/cardinality-baseline'));
+  assert.ok(roots.promql.includes('test/spec/promql'));
+});
+
+test('underGoldenRoot matches inside a root and the root itself, not a sibling', () => {
+  assert.equal(underGoldenRoot('test/perf/cardinality-baseline/promql/a.json', 'test/perf/cardinality-baseline'), true);
+  assert.equal(underGoldenRoot('test/perf/cardinality-baseline', 'test/perf/cardinality-baseline'), true);
+  assert.equal(underGoldenRoot('test/perf/cardinality-baseline-notes.md', 'test/perf/cardinality-baseline'), false);
+});
+
+test('underGoldenRoot honours a globbed golden root', () => {
+  assert.equal(
+    underGoldenRoot('test/e2e/migration/archetypes/kube/expected/plan.sql', 'test/e2e/migration/archetypes/*/expected'),
+    true,
+  );
+});
+
+test('shardsWritten attributes a written artefact to its shard', () => {
+  const hit = shardsWritten(CARDINALITY_A);
+  assert.deepEqual([...hit.keys()], ['cardinality']);
+  assert.deepEqual(hit.get('cardinality'), ['test/perf/cardinality-baseline/promql/rate_5m.json']);
+});
+
+test('shardsWritten ignores a change that writes no golden at all', () => {
+  assert.equal(shardsWritten(['internal/chsql/emit.go', 'docs/engine.md']).size, 0);
+});
+
+// --- the blocking half: FIRES -------------------------------------------------
+
+test('FIRES: two code changes regenerating the same shard against different bases collide', () => {
+  const c = staleBaseCollisions({ ours: CARDINALITY_A, theirs: CARDINALITY_B });
+  assert.equal(c.length, 1);
+  assert.equal(c[0].shard, 'cardinality');
+  assert.deepEqual(c[0].ours, ['test/perf/cardinality-baseline/promql/rate_5m.json']);
+  assert.deepEqual(c[0].theirs, ['test/perf/cardinality-baseline/promql/sum_by.json']);
+});
+
+test('FIRES even when only ONE side moved generator code — the other golden is stale under it', () => {
+  const c = staleBaseCollisions({
+    ours: ['test/spec/promql/new_case.txtar', 'test/perf/cardinality-baseline/promql/new_case.json'],
+    theirs: ['internal/chsql/emit.go', 'test/perf/cardinality-baseline/promql/rate_5m.json'],
+  });
+  assert.equal(c.length, 1);
+  assert.equal(c[0].shard, 'cardinality');
+});
+
+test('FIRES on every colliding shard, not just the first', () => {
+  const c = staleBaseCollisions({
+    ours: ['internal/chsql/emit.go', 'test/spec/promql/a.txtar', 'test/perf/solver-decision-baseline/a.json'],
+    theirs: ['test/spec/promql/b.txtar', 'test/perf/solver-decision-baseline/b.json'],
+  });
+  assert.deepEqual(c.map((x) => x.shard), ['promql', 'solver']);
+});
+
+test('the collision report names the shard, both sides, and the exact remedy command', () => {
+  const [c] = staleBaseCollisions({ ours: CARDINALITY_A, theirs: CARDINALITY_B });
+  const text = collisionReport(c, DEFAULT_MERGE_TARGET_REF);
+  assert.match(text, /cardinality/);
+  assert.match(text, /rate_5m\.json/);
+  assert.match(text, /sum_by\.json/);
+  assert.match(text, /just update-golden cardinality/);
+});
+
+// --- the blocking half: DOES NOT FIRE -----------------------------------------
+
+test('DOES NOT FIRE: two independent fixture additions with no generator change', () => {
+  // The union really is correct here: a golden is a function of its corpus and
+  // its generator code, and neither side moved the code.
+  assert.deepEqual(
+    staleBaseCollisions({
+      ours: ['test/spec/promql/a.txtar', 'test/perf/cardinality-baseline/promql/a.json'],
+      theirs: ['test/spec/promql/b.txtar', 'test/perf/cardinality-baseline/promql/b.json'],
+    }),
+    [],
+  );
+});
+
+test('DOES NOT FIRE: the target moved code but regenerated no shard this change writes', () => {
+  assert.deepEqual(
+    staleBaseCollisions({ ours: CARDINALITY_A, theirs: ['internal/api/loki/handler.go', 'docs/engine.md'] }),
+    [],
+  );
+});
+
+test('DOES NOT FIRE: different shards on each side', () => {
+  assert.deepEqual(
+    staleBaseCollisions({
+      ours: ['internal/chsql/emit.go', 'test/perf/cardinality-baseline/promql/a.json'],
+      theirs: ['internal/promql/lower.go', 'test/surface-parity/promql.json'],
+    }),
+    [],
+  );
+});
+
+test('DOES NOT FIRE on an empty or missing file set', () => {
+  assert.deepEqual(staleBaseCollisions({ ours: [], theirs: [] }), []);
+  assert.deepEqual(staleBaseCollisions({}), []);
+});
+
+// --- the reporting half --------------------------------------------------------
+
+test('the gating-but-skipping lane set is non-empty and every member really skips PRs', () => {
+  const lanes = gatingLanesThatSkipPRs(REGISTRY);
+  assert.ok(lanes.length > 0, 'an empty set would make the disclosure permanently silent');
+  for (const l of lanes) {
+    assert.equal(l.merge_posture, 'never', `${l.id} runs on PRs and is not an unvalidated-skip risk`);
+    assert.ok(
+      l.main_posture !== 'never' || l.release_posture === 'required',
+      `${l.id} gates nothing after merge and must not be reported as a merge risk`,
+    );
+  }
+});
+
+test('a lane that gates nothing after merge is NOT reported as a risk', () => {
+  const ids = gatingLanesThatSkipPRs(REGISTRY).map((l) => l.id);
+  // `governance.release-gate-drift` never runs on a PR and never gates main or
+  // a release; reporting it would be noise with no remedy.
+  assert.ok(!ids.includes('governance.release-gate-drift'));
+});
+
+test('the real compatibility lanes ARE in the skipping set — that is the #2895 shape', () => {
+  const ids = gatingLanesThatSkipPRs(REGISTRY).map((l) => l.id);
+  for (const want of ['compatibility.loki', 'compatibility.prometheus', 'compatibility.tempo']) {
+    assert.ok(ids.includes(want), `${want} gates main and does not run on PRs`);
+  }
+});
+
+test('unvalidatedLanes names the LogQL reference lane for a LogQL change', () => {
+  const found = unvalidatedLanes(REGISTRY, ['internal/logql/lsyntax/parser.go']).map((u) => u.lane.id);
+  assert.ok(found.includes('compatibility.loki'));
+});
+
+test('unvalidatedLanes is silent on a change no gating-but-skipping lane declares', () => {
+  assert.deepEqual(unvalidatedLanes(REGISTRY, ['.github/scripts/merge-risk.mjs']), []);
+});
+
+test('unvalidatedLanes is silent on an empty or missing file set', () => {
+  assert.deepEqual(unvalidatedLanes(REGISTRY, []), []);
+  assert.deepEqual(unvalidatedLanes(REGISTRY, undefined), []);
+});
+
+// --- git plumbing ---------------------------------------------------------------
+
+test('revExists is false for a ref that names nothing, true for HEAD', () => {
+  assert.equal(revExists('definitely-not-a-ref-in-this-repo'), false);
+  assert.equal(revExists(''), false);
+  assert.equal(revExists('HEAD'), true);
+});
+
+test('changedFiles reads a real range out of this checkout', () => {
+  const files = changedFiles('HEAD~1...HEAD');
+  assert.ok(Array.isArray(files));
+});
+
+test('changedFiles surfaces a bad range instead of returning an empty set', () => {
+  assert.throws(() => changedFiles('not-a-ref...also-not-a-ref'), /git diff --name-only/);
+});
+
+// --- wiring pin ------------------------------------------------------------------
+
+const forbidDeferralWorkflow = readFileSync(resolve('.github/workflows/forbid-deferral.yml'), 'utf8');
+
+test('the merge-risk gate rides forbid-deferral.yml and invokes the script', () => {
+  assert.match(forbidDeferralWorkflow, /run: node \.github\/scripts\/merge-risk\.mjs/);
+  assert.match(forbidDeferralWorkflow, /run: node --test \.github\/scripts\/merge-risk\.test\.mjs/);
+});

--- a/.github/scripts/perf-sentinel-obligation.mjs
+++ b/.github/scripts/perf-sentinel-obligation.mjs
@@ -2,25 +2,65 @@
 // perf sentinel corpora.
 //
 // Repo policy, one level more specific than forbid-deferral.mjs's own
-// "work becomes an issue, filed before merge" discipline: a change to
-// `internal/engine/query_settings_rules.go` or `internal/engine/spill.go`
-// — the two files defining which per-query settings the engine's memory-
-// bounding mechanisms apply, and how — is exactly the shape of change
-// #2364 traced back to. #2358 silently removed a CSE fold those settings
-// relied on; production hit MEMORY_LIMIT_EXCEEDED 6h8m later (#2364),
-// because nothing in CI measured real memory at real scale. test/perf/
-// smoke's sentinel corpus (sentinels.go) and #2370's nightly one
+// "work becomes an issue, filed before merge" discipline: a change to the
+// engine's MEMORY-BOUNDING MECHANISM — the settings whose stamped value
+// caps how much RAM a query may build before it spills or how many
+// buffered read lanes it may open — is exactly the shape of change #2364
+// traced back to. #2358 silently removed a CSE fold those settings relied
+// on; production hit MEMORY_LIMIT_EXCEEDED 6h8m later (#2364), because
+// nothing in CI measured real memory at real scale. test/perf/smoke's
+// sentinel corpus (sentinels.go) and #2370's nightly one
 // (test/perf/nightly/sentinels.go) exist specifically to catch this class
-// before it reaches production — a change to the settings machinery that
-// adds no new sentinel coverage risks shipping in exactly the state #2364
-// did.
+// before it reaches production — a change to that machinery that adds no
+// new sentinel coverage risks shipping in exactly the state #2364 did.
 //
-// So: a diff touching either settings file must ALSO touch one of the two
-// sentinel files, or cite a waiver — `PERF-SENTINEL-WAIVER: #<issue>` —
-// naming an OPEN issue tracking why new coverage genuinely isn't owed by
-// this change (a pure refactor with no behavioural change, verified by a
-// human reviewer, is the shape this exists for; this gate cannot make
-// that judgement itself, only require someone did).
+// So: a diff that adds or alters a memory-bounding mechanism must ALSO
+// touch one of the two sentinel files, or cite a waiver —
+// `PERF-SENTINEL-WAIVER: #<issue>` — naming an OPEN issue tracking why
+// new coverage genuinely isn't owed by this change (a pure refactor with
+// no behavioural change, verified by a human reviewer, is the shape this
+// exists for; this gate cannot make that judgement itself, only require
+// someone did).
+//
+// WHAT "A MEMORY-BOUNDING MECHANISM" MEANS, and why it is not a filename
+// (#2893). This gate originally obligated on whole-FILE membership: any
+// edit to internal/engine/query_settings_rules.go or spill.go owed a
+// sentinel or a waiver. Those two files also carry every RESULT-EQUIVALENT
+// optimizer knob the engine stamps — the condition cache, lazy
+// materialisation, the projection-index threshold, the log_comment shape
+// id, the workload tag — none of which can move a query's peak memory at
+// all. A comment fix, a rename, or a new query-tag setting therefore owed
+// a waiver it could never honestly earn, and the only way to clear the
+// gate was to open an issue whose entire content was the receipt. Three
+// such issues were minted in one week (#2832, #2833, #2849) for zero
+// engineering content, which is the per-leg pattern this repository's own
+// discipline forbids.
+//
+// The obligation is now scoped by MECHANISM CLASS, derived from the trigger
+// files' own source rather than declared in this script:
+//
+//   1. Every ClickHouse setting the engine stamps from those files is a
+//      `setting<Name>` const, and each carries a `perf-sentinel:` doc-comment
+//      classification — `memory-bounding` or `neutral` — stating which class
+//      it belongs to and why. That comment is the single source of truth; a
+//      const with no classification FAILS this gate rather than being assumed
+//      harmless, so a new setting cannot slip in unclassified.
+//   2. `memoryBoundingSurface` closes over the file's own reference graph
+//      from those memory-bounding consts: a declaration that STAMPS one is
+//      part of the mechanism, and so is every declaration it reaches to
+//      compute or gate that stamp (`spillThreshold`, its two byte constants,
+//      the plan predicates). Nothing here is a hand-maintained list — repoint
+//      the code and the surface follows it.
+//   3. A change obligates when one of its own changed lines — added OR
+//      removed, code only, comments stripped — names something in that
+//      surface. A comment-only edit, a neutral-setting edit and a rename of
+//      unrelated machinery all leave the surface untouched and owe nothing.
+//
+// Two structural guards keep that derivation from going quietly vacuous:
+// the gate fails if the surface resolves to nothing at all, and it fails if
+// a `WithQuerySetting` call in a trigger file passes a bare string literal
+// instead of a classified `setting<Name>` const — which would otherwise be
+// a memory bound the classification never saw.
 //
 // WHAT IS SCANNED for the waiver citation — the same two surfaces
 // forbid-deferral.mjs reads for a marker's citation, minus the diff
@@ -39,16 +79,19 @@
 //
 // Env contract: identical to forbid-deferral.mjs's (see its header) —
 // GITHUB_REPOSITORY, GITHUB_TOKEN, GITHUB_EVENT_NAME, PR_BODY,
-// GITHUB_EVENT_PATH, BASE_SHA, HEAD_SHA, GITHUB_API_URL.
+// GITHUB_EVENT_PATH, BASE_SHA, HEAD_SHA, GITHUB_API_URL. The trigger files
+// themselves are read from the checkout at HEAD, which is the tree the
+// classification must be judged against.
 //
 // The pure halves of this module are exported and pinned by
 // perf-sentinel-obligation.test.mjs; the scan itself runs only when this
 // file is invoked as the program.
 //
-// Exit codes: 0 = the trigger files were not touched, or were touched
-// alongside sentinel coverage or a valid open-issue waiver; 1 = touched
-// with neither, or a malformed input.
+// Exit codes: 0 = no memory-bounding mechanism was added or altered, or it
+// was alongside sentinel coverage or a valid open-issue waiver; 1 = altered
+// with neither, or a malformed/unclassifiable input.
 
+import { readFileSync } from 'node:fs';
 import process from 'node:process';
 import { pathToFileURL } from 'node:url';
 
@@ -63,9 +106,10 @@ import {
   stripFencedBlocks,
 } from './forbid-deferral.mjs';
 
-// TRIGGER_FILES — touching any of these is what obligates new sentinel
-// coverage (or a waiver). Repo-root-relative paths, exactly as `git diff`
-// reports them.
+// TRIGGER_FILES — the files the memory-bounding surface is derived FROM.
+// Touching one is necessary but no longer sufficient (#2893): the changed
+// lines must also name something in the surface those files declare.
+// Repo-root-relative paths, exactly as `git diff` reports them.
 export const TRIGGER_FILES = Object.freeze([
   'internal/engine/query_settings_rules.go',
   'internal/engine/spill.go',
@@ -102,9 +146,325 @@ export function waiverRefs(text) {
   return [...numbers].sort((a, b) => a - b);
 }
 
-// needsObligation — does this changed-file set touch a trigger file?
-export function needsObligation(files) {
+// touchesTriggerFile — does this changed-file set touch a trigger file at
+// all? The cheap pre-filter: when it is false there is nothing to parse and
+// nothing to classify, which is the overwhelmingly common case.
+export function touchesTriggerFile(files) {
   return (files ?? []).some((f) => TRIGGER_FILES.includes(f));
+}
+
+// --- the memory-bounding surface --------------------------------------------
+
+// SETTING_CONST_PATTERN — the identifier shape every ClickHouse setting name
+// in the trigger files is bound to. The `setting` prefix is the convention
+// those files already follow for all eleven of them; requiring it is what
+// makes "did anyone add a setting without classifying it?" answerable.
+export const SETTING_CONST_PATTERN = /^setting[A-Z]/;
+
+// CLASSIFICATION_PATTERN — the doc-comment tag that classifies a setting
+// const. Written on its own comment line immediately above (or inside) the
+// const's doc block, e.g.
+//
+//   // perf-sentinel: memory-bounding — caps the aggregator's in-RAM hash
+//   // table so it spills instead of aborting at max_memory_usage.
+//
+// The prose after the class is for the human reader; only the class word is
+// read here.
+export const CLASSIFICATION_PATTERN = /^\s*\/\/\s*perf-sentinel:\s*(memory-bounding|neutral)\b/;
+
+export const CLASS_MEMORY_BOUNDING = 'memory-bounding';
+export const CLASS_NEUTRAL = 'neutral';
+
+// TOP_LEVEL_DECL_PATTERN — a Go top-level declaration opener at column 0.
+// The tree is gofumpt-formatted (`just fmt`), so every top-level decl starts
+// flush left and every block-form decl closes with a flush-left `}` or `)`;
+// that is the whole grammar this needs.
+const TOP_LEVEL_DECL_PATTERN = /^(?:func|type|const|var)\b/;
+
+// GROUPED_DECL_OPEN_PATTERN — `const (` / `var (`, whose members are each a
+// declaration in their own right.
+const GROUPED_DECL_OPEN_PATTERN = /^(?:const|var)\s*\($/;
+
+// A Go identifier, for the reference scan. Package-qualified names such as
+// `chplan.WalkDeep` still yield `chplan` and `WalkDeep` as separate words;
+// neither is a local declaration, so neither joins the graph.
+const IDENTIFIER_PATTERN = /[A-Za-z_][A-Za-z0-9_]*/g;
+
+// stripComments — the code half of a Go line. Everything from `//` onward is
+// prose: it can mention `spillThreshold` all it likes without being part of
+// the mechanism, which is precisely the misfire #2893 is about.
+export function stripComments(line) {
+  const at = String(line ?? '').indexOf('//');
+  return at === -1 ? String(line ?? '') : String(line).slice(0, at);
+}
+
+function declName(header) {
+  // `func (r SettingsRules) apply(` -> apply; `func spillThreshold(` -> spillThreshold
+  const method = /^func\s*\([^)]*\)\s*([A-Za-z_][A-Za-z0-9_]*)/.exec(header);
+  if (method) return method[1];
+  const fn = /^func\s+([A-Za-z_][A-Za-z0-9_]*)/.exec(header);
+  if (fn) return fn[1];
+  const other = /^(?:type|const|var)\s+([A-Za-z_][A-Za-z0-9_]*)/.exec(header);
+  if (other) return other[1];
+  return null;
+}
+
+/**
+ * parseGoDecls — every top-level declaration in one gofumpt-formatted Go
+ * source, as `{ name, doc, body }`. `doc` is the contiguous run of `//` lines
+ * immediately above the declaration; `body` is its code text with comments
+ * stripped. Members of a `const (` / `var (` group are returned individually,
+ * each with the doc comment written directly above it inside the group.
+ *
+ * This is deliberately a line grammar rather than a Go parser: the two files
+ * it reads are formatted by `just fmt` on every commit, and a full parser
+ * would be a dependency this gate's "node: builtins only" contract does not
+ * allow. `memoryBoundingSurface` fails loudly rather than silently narrowing
+ * if the grammar ever stops matching (see `surfaceViolations`).
+ */
+export function parseGoDecls(src) {
+  const lines = String(src ?? '').split('\n');
+  const decls = [];
+  let doc = [];
+  let i = 0;
+
+  const flushDoc = () => {
+    const d = doc;
+    doc = [];
+    return d;
+  };
+
+  while (i < lines.length) {
+    const line = lines[i];
+
+    if (/^\s*\/\//.test(line)) {
+      doc.push(line);
+      i += 1;
+      continue;
+    }
+    if (line.trim() === '') {
+      doc = [];
+      i += 1;
+      continue;
+    }
+
+    if (GROUPED_DECL_OPEN_PATTERN.test(line)) {
+      // The doc above `const (` documents every member that carries no doc of
+      // its own — the Go convention the two trigger files already follow for
+      // the group-by/sort spill pair, which shares one paragraph.
+      const groupDoc = flushDoc();
+      i += 1;
+      let memberDoc = [];
+      while (i < lines.length && lines[i] !== ')') {
+        const member = lines[i];
+        if (/^\s*\/\//.test(member)) {
+          memberDoc.push(member);
+        } else if (member.trim() === '') {
+          memberDoc = [];
+        } else {
+          const name = /^\s*([A-Za-z_][A-Za-z0-9_]*)/.exec(member)?.[1] ?? null;
+          if (name) {
+            decls.push({
+              name,
+              doc: memberDoc.length > 0 ? memberDoc : groupDoc,
+              body: stripComments(member),
+            });
+          }
+          memberDoc = [];
+        }
+        i += 1;
+      }
+      i += 1;
+      continue;
+    }
+
+    if (TOP_LEVEL_DECL_PATTERN.test(line)) {
+      const header = line;
+      const declDoc = flushDoc();
+      const body = [stripComments(header)];
+      // A block-form declaration closes at the next flush-left `}` or `)`.
+      if (/[{(]\s*$/.test(header)) {
+        i += 1;
+        while (i < lines.length && lines[i] !== '}' && lines[i] !== ')') {
+          body.push(stripComments(lines[i]));
+          i += 1;
+        }
+      }
+      i += 1;
+      const name = declName(header);
+      if (name) decls.push({ name, doc: declDoc, body: body.join('\n') });
+      continue;
+    }
+
+    flushDoc();
+    i += 1;
+  }
+
+  return decls;
+}
+
+/** classificationOf — the `perf-sentinel:` class a declaration's doc declares, or null. */
+export function classificationOf(decl) {
+  for (const line of decl?.doc ?? []) {
+    const m = CLASSIFICATION_PATTERN.exec(line);
+    if (m) return m[1];
+  }
+  return null;
+}
+
+/**
+ * surfaceViolations — the structural defects that would make the derived
+ * surface a lie, as printable strings. Any one of these fails the gate
+ * outright: a surface that resolves to nothing, or a classification that was
+ * never made, is a gate that passes everything.
+ *
+ * `sources` is `{ [path]: contents }` for the trigger files at HEAD.
+ */
+export function surfaceViolations(sources) {
+  const problems = [];
+  for (const path of TRIGGER_FILES) {
+    const src = sources?.[path];
+    if (typeof src !== 'string' || src.trim() === '') {
+      problems.push(`${path} could not be read at HEAD, so its memory-bounding surface is unknown`);
+      continue;
+    }
+    for (const decl of parseGoDecls(src)) {
+      if (!SETTING_CONST_PATTERN.test(decl.name)) continue;
+      if (classificationOf(decl) === null) {
+        problems.push(
+          `${path}: const ${decl.name} carries no \`// perf-sentinel: memory-bounding|neutral\` `
+            + 'classification, so this gate cannot tell whether changing it bounds memory',
+        );
+      }
+    }
+    // A memory bound stamped through a bare string literal would never reach
+    // the classification at all, so the literal form is rejected outright.
+    for (const [, literal] of src.matchAll(/WithQuerySetting\([^,]+,\s*"([^"]+)"/g)) {
+      problems.push(
+        `${path}: WithQuerySetting stamps the bare literal "${literal}" — bind it to a classified `
+          + '`setting<Name>` const so its memory class is declared',
+      );
+    }
+  }
+  return problems;
+}
+
+/**
+ * memoryBoundingSurface — the set of identifiers that ARE the memory-bounding
+ * mechanism, derived from the trigger files' own reference graph.
+ *
+ * Seeded with the setting consts classified `memory-bounding`, then closed in
+ * BOTH directions until it stops growing:
+ *
+ *   - upward: a declaration whose body names something already in the surface
+ *     STAMPS a memory bound, so it is part of the mechanism (`applySpillSettings`
+ *     naming `settingMaxBytesBeforeExternalGroupBy`);
+ *   - downward: a declaration named BY something in the surface computes or
+ *     gates that bound, so it is part of the mechanism too (`spillThreshold`,
+ *     reached from `applySpillSettings`, then `spillCapDenominator` and
+ *     `spillThresholdBytes` reached from it).
+ *
+ * Both directions are needed and neither over-reaches: the neutral rules stamp
+ * neutral consts and share no helper with the bounding ones, so the closure
+ * terminates well short of the whole file. `surfaceIsNeutralOf` in the test
+ * suite pins exactly that.
+ */
+export function memoryBoundingSurface(sources) {
+  const decls = [];
+  for (const path of TRIGGER_FILES) {
+    for (const d of parseGoDecls(sources?.[path] ?? '')) decls.push(d);
+  }
+  const byName = new Map(decls.map((d) => [d.name, d]));
+  const refs = new Map(
+    decls.map((d) => [
+      d.name,
+      new Set([...String(d.body).matchAll(IDENTIFIER_PATTERN)]
+        .map((m) => m[0])
+        .filter((w) => w !== d.name && byName.has(w))),
+    ]),
+  );
+
+  const surface = new Set(
+    decls
+      .filter((d) => SETTING_CONST_PATTERN.test(d.name) && classificationOf(d) === CLASS_MEMORY_BOUNDING)
+      .map((d) => d.name),
+  );
+
+  for (let grew = true; grew; ) {
+    grew = false;
+    for (const d of decls) {
+      if (surface.has(d.name)) {
+        for (const r of refs.get(d.name)) {
+          if (!surface.has(r)) {
+            surface.add(r);
+            grew = true;
+          }
+        }
+        continue;
+      }
+      for (const r of refs.get(d.name)) {
+        if (surface.has(r)) {
+          surface.add(d.name);
+          grew = true;
+          break;
+        }
+      }
+    }
+  }
+
+  return surface;
+}
+
+/**
+ * changedCodeLines — every line a unified diff ADDS or REMOVES in one of
+ * `paths`, with comments stripped.
+ *
+ * forbid-deferral.mjs's `parseDiff` deliberately drops removed lines (a
+ * deletion cannot introduce a deferral marker) and is shared by that gate's
+ * citation-window scan, so widening it there would weaken a different gate.
+ * Here a DELETION is the most dangerous edit there is — #2364's postmortem is
+ * a removal — so this walks the diff on its own terms.
+ */
+export function changedCodeLines(diffText, paths) {
+  const want = new Set(paths ?? []);
+  const out = [];
+  let file = null;
+  for (const raw of String(diffText ?? '').split('\n')) {
+    if (raw.startsWith('diff --git ')) {
+      file = null;
+      continue;
+    }
+    if (raw.startsWith('+++ ')) {
+      const p = raw.slice(4).trim();
+      file = p === '/dev/null' ? null : p.replace(/^b\//, '');
+      continue;
+    }
+    if (raw.startsWith('--- ') || raw.startsWith('@@') || raw.startsWith('\\')) continue;
+    if (file === null || !want.has(file)) continue;
+    if (raw.startsWith('+') || raw.startsWith('-')) {
+      const code = stripComments(raw.slice(1)).trim();
+      if (code !== '') out.push({ file, code, added: raw.startsWith('+') });
+    }
+  }
+  return out;
+}
+
+/**
+ * mechanismEdits — the changed lines that name something in the surface,
+ * i.e. the evidence that this change actually touched a memory bound.
+ */
+export function mechanismEdits(changed, surface) {
+  return (changed ?? []).filter((l) =>
+    [...String(l.code).matchAll(IDENTIFIER_PATTERN)].some((m) => surface.has(m[0])),
+  );
+}
+
+// needsObligation — does this change add or alter a memory-bounding
+// mechanism? `files` is the changed-file set, `edits` the surface-naming
+// changed lines within the trigger files.
+export function needsObligation(files, edits) {
+  if (!touchesTriggerFile(files)) return false;
+  return (edits ?? []).length > 0;
 }
 
 // satisfiesViaSentinel — did the SAME changed-file set also touch a
@@ -118,8 +478,8 @@ export function satisfiesViaSentinel(files) {
 // kind/state via the SAME resolution forbid-deferral.mjs uses.
 // `resolved` maps number -> { kind: 'missing' | 'pull-request' | 'issue',
 // state }, exactly resolveRefs's own return shape.
-export function verdict({ files, waiverNumbers, resolved }) {
-  if (!needsObligation(files)) {
+export function verdict({ files, edits, waiverNumbers, resolved }) {
+  if (!needsObligation(files, edits)) {
     return { obligated: false };
   }
   if (satisfiesViaSentinel(files)) {
@@ -153,15 +513,23 @@ export function verdict({ files, waiverNumbers, resolved }) {
 }
 
 const REMEDY =
-  'This change touches a memory-bounding settings file '
-  + `(${TRIGGER_FILES.join(' or ')}) without touching either sentinel corpus `
+  'This change adds or alters a memory-bounding mechanism in '
+  + `${TRIGGER_FILES.join(' or ')} without touching either sentinel corpus `
   + `(${SENTINEL_FILES.join(' or ')}). Remedy, whichever is true: (1) add a `
   + 'sentinel that would have caught this class of change (see test/perf/smoke/'
-  + 'sentinels.go or test/perf/nightly/sentinels.go for the shape); or (2) if '
-  + 'new coverage is genuinely not owed here — a pure refactor with no '
-  + 'behavioural change, verified by review — open an issue saying so and cite '
-  + 'it as `PERF-SENTINEL-WAIVER: #<issue>` in the PR description or a commit '
-  + 'message.';
+  + 'sentinels.go or test/perf/nightly/sentinels.go for the shape); (2) if the '
+  + 'setting the changed lines name does NOT bound memory, say so on its const '
+  + 'as `// perf-sentinel: neutral — <why>` and the obligation disappears at '
+  + 'the root instead of needing a receipt; or (3) if new coverage is genuinely '
+  + 'not owed for a real memory bound — a pure refactor with no behavioural '
+  + 'change, verified by review — open an issue saying so and cite it as '
+  + '`PERF-SENTINEL-WAIVER: #<issue>` in the PR description or a commit message.';
+
+// MAX_REPORTED_EDITS caps how many surface-naming lines the step summary
+// quotes back. The list is evidence for the reader ("this is why you were
+// obligated"), not a transcript of the diff, and a wholesale rewrite of
+// spill.go would otherwise bury the verdict under its own body.
+const MAX_REPORTED_EDITS = 5;
 
 async function main() {
   const repo = process.env.GITHUB_REPOSITORY;
@@ -194,9 +562,49 @@ async function main() {
     );
   }
 
-  if (!needsObligation(files)) {
+  if (!touchesTriggerFile(files)) {
     notice(
       `perf-sentinel-obligation: neither ${TRIGGER_FILES.join(' nor ')} was touched — no obligation.`,
+      { title: 'perf-sentinel-obligation' },
+    );
+    return;
+  }
+
+  // From here the classification is load-bearing, so it is validated before
+  // it is trusted: an unclassified setting or an unreadable trigger file
+  // makes the surface a guess, and a guessing gate is worse than none.
+  const sources = Object.fromEntries(
+    TRIGGER_FILES.map((p) => {
+      try {
+        return [p, readFileSync(p, 'utf8')];
+      } catch {
+        return [p, null];
+      }
+    }),
+  );
+  const problems = surfaceViolations(sources);
+  if (problems.length > 0) {
+    for (const p of problems) error(`perf-sentinel-obligation: ${p}`, { title: 'perf-sentinel-obligation' });
+    process.exit(1);
+  }
+
+  const surface = memoryBoundingSurface(sources);
+  if (surface.size === 0) {
+    error(
+      'perf-sentinel-obligation: the memory-bounding surface derived from '
+        + `${TRIGGER_FILES.join(' and ')} is EMPTY, so nothing could ever obligate a sentinel. `
+        + 'Either every setting is now classified neutral (say so deliberately) or the derivation '
+        + 'stopped matching the source.',
+      { title: 'perf-sentinel-obligation' },
+    );
+    process.exit(1);
+  }
+
+  const edits = mechanismEdits(changedCodeLines(diffText, TRIGGER_FILES), surface);
+  if (edits.length === 0) {
+    notice(
+      `perf-sentinel-obligation: ${TRIGGER_FILES.filter((f) => files.includes(f)).join(', ')} changed, `
+        + 'but no changed line names the memory-bounding surface — no obligation.',
       { title: 'perf-sentinel-obligation' },
     );
     return;
@@ -212,10 +620,15 @@ async function main() {
     ? await resolveRefs(waiverNumbers, { repo, token, apiBase })
     : new Map();
 
-  const v = verdict({ files, waiverNumbers, resolved });
+  const v = verdict({ files, edits, waiverNumbers, resolved });
 
   const inspected = [
     `- trigger files touched: ${TRIGGER_FILES.filter((f) => files.includes(f)).join(', ')}`,
+    `- memory-bounding surface: ${[...surface].sort().join(', ')}`,
+    `- changed lines naming it: ${edits.length} (${edits
+      .slice(0, MAX_REPORTED_EDITS)
+      .map((e) => `${e.added ? '+' : '-'}${e.code}`)
+      .join(' | ')})`,
     `- sentinel files touched: ${SENTINEL_FILES.filter((f) => files.includes(f)).join(', ') || '(none)'}`,
     `- waiver citations found: ${waiverNumbers.length > 0 ? waiverNumbers.map((n) => `#${n}`).join(', ') : '(none)'}`,
   ];

--- a/.github/scripts/perf-sentinel-obligation.test.mjs
+++ b/.github/scripts/perf-sentinel-obligation.test.mjs
@@ -15,13 +15,23 @@ import { readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
 
 import {
-  TRIGGER_FILES,
+  CLASS_MEMORY_BOUNDING,
+  CLASS_NEUTRAL,
   SENTINEL_FILES,
+  SETTING_CONST_PATTERN,
+  TRIGGER_FILES,
   WAIVER_PATTERN,
-  waiverRefs,
+  changedCodeLines,
+  classificationOf,
+  memoryBoundingSurface,
+  mechanismEdits,
   needsObligation,
+  parseGoDecls,
   satisfiesViaSentinel,
+  surfaceViolations,
+  touchesTriggerFile,
   verdict,
+  waiverRefs,
 } from './perf-sentinel-obligation.mjs';
 
 // The three real fixtures forbid-deferral.test.mjs already established for
@@ -90,19 +100,249 @@ test('waiverRefs still finds a real citation sitting outside a fenced block in t
   assert.deepEqual(waiverRefs(text), [1486]);
 });
 
-// --- needsObligation / satisfiesViaSentinel -----------------------------------
+// --- the memory-bounding surface (#2893) --------------------------------------
 
-test('needsObligation is true when a trigger file is in the changed set', () => {
-  assert.equal(needsObligation(['internal/engine/spill.go', 'docs/README.md']), true);
+// A miniature stand-in for the two trigger files, carrying one setting of each
+// class plus the derivation chain a real memory bound has: the stamp, the value
+// arithmetic behind it, and a plan predicate gating it. Synthetic rather than a
+// slice of the real file so the two DIRECTIONS below stay readable, and so a
+// future edit to the real source cannot silently make a test vacuous — the
+// "real source" pins further down cover that half.
+const FAKE_SPILL = [
+  '// settingCap makes the aggregator spill.',
+  '//',
+  '// perf-sentinel: memory-bounding — caps in-RAM state before it spills.',
+  'const settingCap = "max_bytes_before_external_group_by"',
+  '',
+  '// capDenominator halves the cap.',
+  'const capDenominator int64 = 2',
+  '',
+  '// threshold derives the byte threshold from the live cap.',
+  'func threshold(maxMemory int64) int64 {',
+  '\treturn maxMemory / capDenominator',
+  '}',
+  '',
+  '// applyCap stamps the spill threshold.',
+  'func applyCap(ctx context.Context, maxMemory int64) context.Context {',
+  '\treturn chclient.WithQuerySetting(ctx, settingCap, threshold(maxMemory))',
+  '}',
+  '',
+].join('\n');
+
+const FAKE_RULES = [
+  '// settingTag annotates a query.',
+  '//',
+  '// perf-sentinel: neutral — a free-form annotation, never a budget.',
+  'const settingTag = "log_comment"',
+  '',
+  '// shapeID computes the annotation value.',
+  'func shapeID(plan chplan.Node) string {',
+  '\treturn plan.Kind()',
+  '}',
+  '',
+  '// applyTag stamps the annotation.',
+  'func applyTag(ctx context.Context, plan chplan.Node) context.Context {',
+  '\treturn chclient.WithQuerySetting(ctx, settingTag, shapeID(plan))',
+  '}',
+  '',
+].join('\n');
+
+const FAKE = { [TRIGGER_FILES[0]]: FAKE_RULES, [TRIGGER_FILES[1]]: FAKE_SPILL };
+
+function unifiedDiff(file, lines) {
+  return [`diff --git a/${file} b/${file}`, `--- a/${file}`, `+++ b/${file}`, '@@ -1,1 +1,1 @@', ...lines].join('\n');
+}
+
+test('parseGoDecls finds every top-level declaration, grouped consts included', () => {
+  const names = parseGoDecls(
+    ['// perf-sentinel: neutral — group doc.', 'const (', '\talpha = "a"', '\tbeta  = "b"', ')', '',
+      'func gamma() {', '\treturn', '}'].join('\n'),
+  ).map((d) => d.name);
+  assert.deepEqual(names, ['alpha', 'beta', 'gamma']);
 });
 
-test('needsObligation is false when no trigger file is touched', () => {
-  assert.equal(needsObligation(['internal/engine/other.go', 'docs/README.md']), false);
+test('a grouped const member inherits the group doc when it has none of its own', () => {
+  const decls = parseGoDecls(
+    ['// perf-sentinel: memory-bounding — shared paragraph.', 'const (', '\talpha = "a"', ')'].join('\n'),
+  );
+  assert.equal(classificationOf(decls[0]), CLASS_MEMORY_BOUNDING);
+});
+
+test('the surface is the bounding const AND everything deriving or stamping it', () => {
+  const surface = memoryBoundingSurface(FAKE);
+  for (const want of ['settingCap', 'applyCap', 'threshold', 'capDenominator']) {
+    assert.ok(surface.has(want), `${want} is part of the memory-bounding mechanism`);
+  }
+});
+
+test('the surface does NOT leak into the neutral rules sharing the same files', () => {
+  const surface = memoryBoundingSurface(FAKE);
+  for (const nope of ['settingTag', 'applyTag', 'shapeID']) {
+    assert.ok(!surface.has(nope), `${nope} bounds nothing and must stay outside the surface`);
+  }
+});
+
+test('an unclassified setting const FAILS the gate rather than being assumed harmless', () => {
+  const problems = surfaceViolations({
+    [TRIGGER_FILES[0]]: 'const settingMystery = "some_knob"\n',
+    [TRIGGER_FILES[1]]: FAKE_SPILL,
+  });
+  assert.equal(problems.length, 1);
+  assert.match(problems[0], /settingMystery carries no .*perf-sentinel/);
+});
+
+test('a memory bound stamped through a bare string literal FAILS the gate', () => {
+  const problems = surfaceViolations({
+    [TRIGGER_FILES[0]]: [
+      '// perf-sentinel: neutral — classified, but the stamp below dodges it.',
+      'const settingTag = "log_comment"',
+      'func sneak(ctx context.Context) context.Context {',
+      '\treturn chclient.WithQuerySetting(ctx, "max_memory_usage", 1)',
+      '}',
+    ].join('\n'),
+    [TRIGGER_FILES[1]]: FAKE_SPILL,
+  });
+  assert.equal(problems.length, 1);
+  assert.match(problems[0], /bare literal "max_memory_usage"/);
+});
+
+test('an unreadable trigger file FAILS the gate instead of narrowing the surface', () => {
+  const problems = surfaceViolations({ [TRIGGER_FILES[0]]: FAKE_RULES, [TRIGGER_FILES[1]]: null });
+  assert.equal(problems.length, 1);
+  assert.match(problems[0], /could not be read at HEAD/);
+});
+
+test('changedCodeLines reads REMOVALS as well as additions — #2364 was a deletion', () => {
+  const diff = unifiedDiff(TRIGGER_FILES[1], ['-\tctx = applyCap(ctx, maxMemory)', '+\treturn ctx']);
+  const changed = changedCodeLines(diff, TRIGGER_FILES);
+  assert.deepEqual(changed.map((c) => [c.added, c.code]), [
+    [false, 'ctx = applyCap(ctx, maxMemory)'],
+    [true, 'return ctx'],
+  ]);
+});
+
+test('changedCodeLines ignores files outside the trigger set', () => {
+  const diff = unifiedDiff('internal/engine/engine.go', ['+\tctx = applyCap(ctx, maxMemory)']);
+  assert.deepEqual(changedCodeLines(diff, TRIGGER_FILES), []);
+});
+
+// --- needsObligation: the two directions #2893 is about -----------------------
+
+test('FIRES: deleting the spill stamp still obligates a sentinel', () => {
+  const diff = unifiedDiff(TRIGGER_FILES[1], ['-\treturn chclient.WithQuerySetting(ctx, settingCap, threshold(maxMemory))']);
+  const edits = mechanismEdits(changedCodeLines(diff, TRIGGER_FILES), memoryBoundingSurface(FAKE));
+  assert.equal(edits.length, 1);
+  assert.equal(needsObligation([TRIGGER_FILES[1]], edits), true);
+});
+
+test('FIRES: re-deriving the threshold arithmetic still obligates a sentinel', () => {
+  const diff = unifiedDiff(TRIGGER_FILES[1], ['-\treturn maxMemory / capDenominator', '+\treturn maxMemory']);
+  const edits = mechanismEdits(changedCodeLines(diff, TRIGGER_FILES), memoryBoundingSurface(FAKE));
+  assert.ok(edits.length > 0);
+  assert.equal(needsObligation([TRIGGER_FILES[1]], edits), true);
+});
+
+test('DOES NOT FIRE: a comment-only edit naming the surface in prose owes nothing', () => {
+  const diff = unifiedDiff(TRIGGER_FILES[1], [
+    '-// threshold derives the byte threshold from the live cap.',
+    '+// threshold derives the byte threshold from the live per-query cap.',
+  ]);
+  const edits = mechanismEdits(changedCodeLines(diff, TRIGGER_FILES), memoryBoundingSurface(FAKE));
+  assert.deepEqual(edits, []);
+  assert.equal(needsObligation([TRIGGER_FILES[1]], edits), false);
+});
+
+test('DOES NOT FIRE: adding a NEUTRAL setting to the same file owes nothing', () => {
+  // The exact shape of #2832 / #2833 / #2849 — three issues whose entire
+  // content was a waiver receipt. Under mechanism-class scoping there is
+  // nothing left to receipt.
+  const diff = unifiedDiff(TRIGGER_FILES[0], [
+    '+// perf-sentinel: neutral — an index-selection threshold, never a budget.',
+    '+const settingProjectionIndex = "min_table_rows_to_use_projection_index"',
+    '+\tctx = chclient.WithQuerySetting(ctx, settingProjectionIndex, 0)',
+  ]);
+  const edits = mechanismEdits(changedCodeLines(diff, TRIGGER_FILES), memoryBoundingSurface(FAKE));
+  assert.deepEqual(edits, []);
+  assert.equal(needsObligation([TRIGGER_FILES[0]], edits), false);
+});
+
+test('DOES NOT FIRE: renaming a neutral helper owes nothing', () => {
+  const diff = unifiedDiff(TRIGGER_FILES[0], ['-\treturn chclient.WithQuerySetting(ctx, settingTag, shapeID(plan))', '+\treturn chclient.WithQuerySetting(ctx, settingTag, planShapeID(plan))']);
+  const edits = mechanismEdits(changedCodeLines(diff, TRIGGER_FILES), memoryBoundingSurface(FAKE));
+  assert.deepEqual(edits, []);
+});
+
+// --- the REAL trigger files, so the synthetic fixtures cannot drift away ------
+
+const REAL = Object.fromEntries(TRIGGER_FILES.map((p) => [p, readFileSync(resolve(p), 'utf8')]));
+
+test('every setting const in the real trigger files carries a classification', () => {
+  assert.deepEqual(surfaceViolations(REAL), []);
+});
+
+test('the real surface is non-empty — an empty one would pass every change', () => {
+  assert.ok(memoryBoundingSurface(REAL).size > 0);
+});
+
+test('the real surface holds every spill/thread bound and none of the neutral knobs', () => {
+  const surface = memoryBoundingSurface(REAL);
+  for (const want of [
+    'settingMaxBytesBeforeExternalGroupBy',
+    'settingMaxBytesBeforeExternalSort',
+    'settingMaxBytesBeforeExternalJoin',
+    'settingMaxThreads',
+    'spillThreshold',
+    'spillThresholdBytes',
+    'spillCapDenominator',
+    'applySpillSettings',
+    'applyJoinSpillSettings',
+    'applyCompareMemoryBound',
+  ]) {
+    assert.ok(surface.has(want), `${want} must stay inside the memory-bounding surface`);
+  }
+  for (const nope of [
+    'settingOptimizeAggregationInOrder',
+    'settingUseQueryConditionCache',
+    'settingEnableAnalyzer',
+    'settingLogComment',
+    'settingQueryPlanOptimizeLazyMaterialization',
+    'settingMinTableRowsToUseProjectionIndex',
+    'apply',
+    'eligibleForResultCache',
+  ]) {
+    assert.ok(!surface.has(nope), `${nope} bounds no memory and must stay outside the surface`);
+  }
+});
+
+test('every real setting const is classified exactly one of the two classes', () => {
+  for (const path of TRIGGER_FILES) {
+    for (const decl of parseGoDecls(REAL[path])) {
+      if (!SETTING_CONST_PATTERN.test(decl.name)) continue;
+      assert.ok(
+        [CLASS_MEMORY_BOUNDING, CLASS_NEUTRAL].includes(classificationOf(decl)),
+        `${path}: ${decl.name} is unclassified`,
+      );
+    }
+  }
+});
+
+// --- touchesTriggerFile / satisfiesViaSentinel --------------------------------
+
+test('touchesTriggerFile is true when a trigger file is in the changed set', () => {
+  assert.equal(touchesTriggerFile(['internal/engine/spill.go', 'docs/README.md']), true);
+});
+
+test('touchesTriggerFile is false when no trigger file is touched', () => {
+  assert.equal(touchesTriggerFile(['internal/engine/other.go', 'docs/README.md']), false);
 });
 
 test('needsObligation is false on an empty or missing file list', () => {
-  assert.equal(needsObligation([]), false);
-  assert.equal(needsObligation(undefined), false);
+  assert.equal(needsObligation([], []), false);
+  assert.equal(needsObligation(undefined, undefined), false);
+});
+
+test('needsObligation is false when a trigger file moved but the surface did not', () => {
+  assert.equal(needsObligation(['internal/engine/spill.go'], []), false);
 });
 
 test('satisfiesViaSentinel is true when either sentinel file is touched', () => {
@@ -116,14 +356,21 @@ test('satisfiesViaSentinel is false when neither is touched', () => {
 
 // --- verdict -------------------------------------------------------------------
 
+// The surface-naming changed line every obligated verdict below stands on:
+// mechanism-class scoping means `verdict` is handed the EVIDENCE that a memory
+// bound moved, not merely the filename it moved in.
+const BOUND_EDIT = [{ file: 'internal/engine/spill.go', code: 'ctx = applySpillSettings(ctx, maxMemory)', added: true }];
+
+
 test('verdict: no trigger file touched -> not obligated at all', () => {
-  const v = verdict({ files: ['docs/README.md'], waiverNumbers: [], resolved: new Map() });
+  const v = verdict({ files: ['docs/README.md'], edits: [], waiverNumbers: [], resolved: new Map() });
   assert.deepEqual(v, { obligated: false });
 });
 
 test('verdict: trigger file touched alongside smoke sentinel -> satisfied', () => {
   const v = verdict({
     files: ['internal/engine/spill.go', 'test/perf/smoke/sentinels.go'],
+    edits: BOUND_EDIT,
     waiverNumbers: [],
     resolved: new Map(),
   });
@@ -135,6 +382,7 @@ test('verdict: trigger file touched alongside smoke sentinel -> satisfied', () =
 test('verdict: trigger file touched alongside nightly sentinel -> satisfied', () => {
   const v = verdict({
     files: ['internal/engine/query_settings_rules.go', 'test/perf/nightly/sentinels.go'],
+    edits: BOUND_EDIT,
     waiverNumbers: [],
     resolved: new Map(),
   });
@@ -146,6 +394,7 @@ test('verdict: trigger file touched alongside nightly sentinel -> satisfied', ()
 test('verdict: trigger file touched, no sentinel, an OPEN waiver -> satisfied', () => {
   const v = verdict({
     files: ['internal/engine/spill.go'],
+    edits: BOUND_EDIT,
     waiverNumbers: [1535],
     resolved: RESOLVED,
   });
@@ -156,26 +405,26 @@ test('verdict: trigger file touched, no sentinel, an OPEN waiver -> satisfied', 
 });
 
 test('verdict: trigger file touched, no sentinel, no waiver at all -> unsatisfied', () => {
-  const v = verdict({ files: ['internal/engine/spill.go'], waiverNumbers: [], resolved: new Map() });
+  const v = verdict({ files: ['internal/engine/spill.go'], edits: BOUND_EDIT, waiverNumbers: [], resolved: new Map() });
   assert.equal(v.obligated, true);
   assert.equal(v.satisfied, false);
   assert.match(v.reason, /no PERF-SENTINEL-WAIVER/);
 });
 
 test('verdict: waiver cites a CLOSED issue -> unsatisfied, named as such', () => {
-  const v = verdict({ files: ['internal/engine/spill.go'], waiverNumbers: [1486], resolved: RESOLVED });
+  const v = verdict({ files: ['internal/engine/spill.go'], edits: BOUND_EDIT, waiverNumbers: [1486], resolved: RESOLVED });
   assert.equal(v.satisfied, false);
   assert.match(v.reason, /#1486 is a closed issue/);
 });
 
 test('verdict: waiver cites a PULL REQUEST, not an issue -> unsatisfied, named as such', () => {
-  const v = verdict({ files: ['internal/engine/spill.go'], waiverNumbers: [1143], resolved: RESOLVED });
+  const v = verdict({ files: ['internal/engine/spill.go'], edits: BOUND_EDIT, waiverNumbers: [1143], resolved: RESOLVED });
   assert.equal(v.satisfied, false);
   assert.match(v.reason, /#1143 is a pull request/);
 });
 
 test('verdict: waiver cites a number that names nothing -> unsatisfied, named as such', () => {
-  const v = verdict({ files: ['internal/engine/spill.go'], waiverNumbers: [999999], resolved: new Map() });
+  const v = verdict({ files: ['internal/engine/spill.go'], edits: BOUND_EDIT, waiverNumbers: [999999], resolved: new Map() });
   assert.equal(v.satisfied, false);
   assert.match(v.reason, /#999999 names nothing/);
 });
@@ -183,6 +432,7 @@ test('verdict: waiver cites a number that names nothing -> unsatisfied, named as
 test('verdict: multiple waiver citations — the first VALID one satisfies, even if cited after an invalid one', () => {
   const v = verdict({
     files: ['internal/engine/spill.go'],
+    edits: BOUND_EDIT,
     waiverNumbers: [1486, 1535],
     resolved: RESOLVED,
   });
@@ -193,6 +443,7 @@ test('verdict: multiple waiver citations — the first VALID one satisfies, even
 test('verdict: sentinel coverage wins even when an invalid waiver is also present', () => {
   const v = verdict({
     files: ['internal/engine/spill.go', 'test/perf/smoke/sentinels.go'],
+    edits: BOUND_EDIT,
     waiverNumbers: [999999],
     resolved: new Map(),
   });

--- a/.github/workflows/forbid-deferral.yml
+++ b/.github/workflows/forbid-deferral.yml
@@ -125,10 +125,26 @@ jobs:
       # waiver-in-the-body fix as it is for a deferral-marker one).
       - name: Assert the perf-sentinel obligation scanner matches
         run: node --test .github/scripts/perf-sentinel-obligation.test.mjs
-      - name: Reject a settings-file change with no sentinel coverage or waiver
+      - name: Reject a memory-bounding change with no sentinel coverage or waiver
         run: node .github/scripts/perf-sentinel-obligation.mjs
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_BODY: ${{ github.event.pull_request.body }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.merge_group.base_sha || github.event.before }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+      # #2899's merge-risk gate: what this PR's green does NOT cover. It rides
+      # this job for the same reason the obligation gate above does — it needs
+      # the full history a `fetch-depth: 0` checkout gives and nothing else,
+      # and it is a required context on every PR without adding a new one to
+      # branch protection. `origin/main` is fetched explicitly first: a
+      # `pull_request` checkout populates the PR refs, not the target branch's
+      # remote-tracking ref, and the stale-base half compares against it.
+      - name: Fetch the merge target for the stale-base comparison
+        run: git fetch --no-tags --quiet origin +refs/heads/main:refs/remotes/origin/main
+      - name: Assert the merge-risk scanner matches, and does not over-match
+        run: node --test .github/scripts/merge-risk.test.mjs
+      - name: Reject a golden shard regenerated against a base main has moved past
+        run: node .github/scripts/merge-risk.mjs
+        env:
           BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.merge_group.base_sha || github.event.before }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}

--- a/docs/test-strategy.md
+++ b/docs/test-strategy.md
@@ -169,6 +169,42 @@ for the rosters themselves and the procedure for moving one.
 | `link-check`                            | `ci.yml` (`link-check`)                                                                                                          | PR + queue + push                   | Required  | `lychee --offline --include-fragments`: every relative `[text](./other.md#anchor)` link resolves to a file that exists, and every `#fragment` resolves to a real heading/anchor. No network, so it cannot flake on a slow/blocked host; external `http(s)://` links are checked separately by the schedule-only `link-check-external.yml`                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    |
 | `schema-ddl`                            | `schema-integration.yml` (`schema-ddl`)                                                                                          | PR + queue + push + nightly         | Required  | `internal/schema/ddl`'s `integration`-tagged tests against a real ClickHouse (testcontainers-go): the `AUTO_CREATE_SCHEMA` DDL actually accepted by a live server, including that a Replicated database really replicates (`system.replicas`) — a class of bug the rendered-SQL unit tests and the chDB lanes cannot see (three production incidents shipped through that blind spot)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        |
 
+### What a green pull request does not cover
+
+Three gates ride the `forbid-deferral` job and share its required context,
+because each needs the same two things that workflow already provides: the
+`edited` trigger, so a fix made in the description re-runs the check, and a
+`fetch-depth: 0` checkout.
+
+`perf-sentinel-obligation.mjs` obligates new perf-sentinel coverage — or an
+open-issue `PERF-SENTINEL-WAIVER:` citation — when a change adds or alters a
+memory-bounding mechanism. The mechanism is derived, not declared here: every
+ClickHouse setting const in `internal/engine/query_settings_rules.go` and
+`internal/engine/spill.go` carries a `perf-sentinel:` doc classification of
+`memory-bounding` or `neutral`, and the gate closes over those files' own
+reference graph from the memory-bounding ones in both directions — what stamps
+a bound, and what computes or gates it. A change obligates only when one of its
+own changed lines, added or removed and with comments stripped, names something
+in that closure. A comment fix, a rename, or a result-equivalent optimizer knob
+living in the same file therefore owes nothing. An unclassified setting const,
+or a `WithQuerySetting` stamping a bare string literal, fails the gate rather
+than being assumed harmless.
+
+`merge-risk.mjs` answers the other half: what this pull request's green does not
+prove. It REJECTS a stale-base golden race — both the change and `main` writing
+under one shard's golden root while either side moves Go code — because a golden
+is a function of its corpus and its generator code, so whichever artefact lands
+second was written by the other side's generator. That is the targeted form of
+branch protection's `strict: true`, which stays off: it forces an update-branch
+only on the PRs that actually race a generated artefact instead of on all of
+them. Same-file races need no help here; git already reports those as conflicts.
+The gate also REPORTS, without blocking, the lanes that gate `main` yet declare
+`merge_posture: never` and so never run on a pull request — the compatibility
+harnesses, the chDB round-trip and perf-guard shards, `perf-nightly`, the e2e
+family — naming each one and the command that runs it, so a skipped lane is
+never read as a passing one. Attribution uses each lane's declared
+`package_globs` and is a floor rather than the whole risk.
+
 ### Test-fence enrollment contracts
 
 The lane registry describes ownership and policy, but registry metadata alone

--- a/internal/engine/query_settings_rules.go
+++ b/internal/engine/query_settings_rules.go
@@ -15,6 +15,10 @@ import (
 // RESULT-EQUIVALENT: it changes only the execution strategy, never the rows.
 // It has existed since well before cerberus's CH 24.8 floor, so stamping it
 // is version-safe.
+//
+// perf-sentinel: neutral — an execution-strategy choice. Consuming rows in sort
+// order REDUCES the aggregator's live state; it can never raise peak memory
+// versus the hash-table plan it replaces.
 const settingOptimizeAggregationInOrder = "optimize_aggregation_in_order"
 
 // settingUseQueryConditionCache is the ClickHouse setting that turns on the
@@ -26,6 +30,9 @@ const settingOptimizeAggregationInOrder = "optimize_aggregation_in_order"
 // in (server >= 25.3) AND the read path is predicate-stable; below 25.3 the
 // feature is absent from the resolved set, so ConditionCache is false and this
 // is never stamped (version-safe fallback to no-op).
+//
+// perf-sentinel: neutral — a server-side granule cache. It changes how much of
+// a predicate is re-evaluated, never how much state the query builds.
 const settingUseQueryConditionCache = "use_query_condition_cache"
 
 // settingEnableAnalyzer turns on ClickHouse's new query analyzer. The query
@@ -35,12 +42,18 @@ const settingUseQueryConditionCache = "use_query_condition_cache"
 // server/profile level. It is RESULT-EQUIVALENT (an execution-planner choice,
 // not a result rewrite) and the analyzer is GA on every server the
 // condition_cache feature resolves on (>= 25.3), so co-stamping is version-safe.
+//
+// perf-sentinel: neutral — selects which query planner runs. Its measured cost
+// (applyNativeHistogramAnalyzerFix) is CPU time before execution, not memory.
 const settingEnableAnalyzer = "enable_analyzer"
 
 // settingLogComment is ClickHouse's free-form per-query annotation. When set
 // it is copied verbatim into system.query_log.log_comment, letting operators
 // GROUP BY a cerberus-assigned shape id. Free-form and ignored by execution,
 // so stamping it is version-safe and result-neutral.
+//
+// perf-sentinel: neutral — a free-form annotation ClickHouse copies into
+// query_log and never reads during execution.
 const settingLogComment = "log_comment"
 
 // settingQueryPlanOptimizeLazyMaterialization is the ClickHouse setting that
@@ -48,6 +61,9 @@ const settingLogComment = "log_comment"
 // has picked the surviving rows, instead of reading them for the whole
 // scanned window and discarding most of it. It is RESULT-EQUIVALENT (only
 // the read order changes, never the rows) and ships in ClickHouse 25.11.
+//
+// perf-sentinel: neutral — deferring column reads until after ORDER BY + LIMIT
+// strictly REDUCES bytes read and held; it cannot raise peak memory.
 const settingQueryPlanOptimizeLazyMaterialization = "query_plan_optimize_lazy_materialization"
 
 // settingQueryPlanMaxLimitForLazyMaterialization caps the LIMIT a query may
@@ -56,6 +72,9 @@ const settingQueryPlanOptimizeLazyMaterialization = "query_plan_optimize_lazy_ma
 // exceeds this knob silently falls back to eager reads, so
 // eligibleForLazyMaterialization sizes it to the query's OWN LIMIT rather
 // than a fixed ceiling, guaranteeing it never under-shoots.
+//
+// perf-sentinel: neutral — an eligibility threshold for the lazy-materialisation
+// plan above. It gates which plan is picked, never a memory budget.
 const settingQueryPlanMaxLimitForLazyMaterialization = "query_plan_max_limit_for_lazy_materialization"
 
 // settingMinTableRowsToUseProjectionIndex is the ClickHouse setting (>= 25.11,
@@ -65,6 +84,10 @@ const settingQueryPlanMaxLimitForLazyMaterialization = "query_plan_max_limit_for
 // estimated row count clears this threshold. It is RESULT-EQUIVALENT — it
 // only widens which physical plan the optimizer is allowed to pick, never
 // which rows a query returns.
+//
+// perf-sentinel: neutral — an index-SELECTION threshold. It only widens which
+// physical plan the optimizer may pick, and the plan it unlocks reads strictly
+// fewer rows (this is the classification issue #2832 was minted to record).
 const settingMinTableRowsToUseProjectionIndex = "min_table_rows_to_use_projection_index"
 
 // traceIDBitmapFilterMinTableRows is the value cerberus stamps for
@@ -310,6 +333,11 @@ func (r SettingsRules) apply(ctx context.Context, plan chplan.Node) context.Cont
 // storage (large buffers) uncapped parallelism multiplies buffer RAM. It is
 // RESULT-EQUIVALENT: it changes only how many lanes run concurrently, never the
 // rows produced.
+//
+// perf-sentinel: memory-bounding — every read thread holds its own column read
+// buffer, so this caps how many of those buffers can be live at once. Raising
+// it multiplies buffer RAM; that is why compare() needs it (see
+// applyCompareMemoryBound).
 const settingMaxThreads = "max_threads"
 
 // compareMaxThreads bounds the read parallelism of a TraceQL compare() query to

--- a/internal/engine/spill.go
+++ b/internal/engine/spill.go
@@ -13,6 +13,10 @@ import (
 // whole GROUP BY hash table / sort buffer in RAM. Both are RESULT-EQUIVALENT —
 // only the execution strategy changes, never the rows — and have existed since
 // long before cerberus's CH floor, so stamping them is version-safe.
+//
+// perf-sentinel: memory-bounding — each caps the bytes an aggregation or sort
+// may hold in RAM before it spills, so changing either moves the peak memory a
+// query reaches. This is the #2364 class.
 const (
 	settingMaxBytesBeforeExternalGroupBy = "max_bytes_before_external_group_by"
 	settingMaxBytesBeforeExternalSort    = "max_bytes_before_external_sort"
@@ -26,6 +30,9 @@ const (
 // ClickHouse 26.4 — so stamping it is gated on the chopt.FeatureJoinSpill
 // boot-resolved verdict (see applyJoinSpillSettings) rather than being
 // unconditional like its two siblings.
+//
+// perf-sentinel: memory-bounding — caps the bytes a hash join's build side may
+// hold in RAM before it spills, exactly as its group-by/sort siblings do.
 const settingMaxBytesBeforeExternalJoin = "max_bytes_before_external_join"
 
 // spillThresholdBytes is the byte threshold at which a GROUP BY / sort begins


### PR DESCRIPTION
Both issues in this pair are the same defect wearing two faces: a CI gate whose
signal is not the thing it claims to measure. #2893 is a gate that fires on
changes it has no business judging; #2899 is a gate that does not fire on
changes it exists to judge. Neither is fixable by patching a leg.

## #2893 — the perf-sentinel obligation was scoped by filename

`perf-sentinel-obligation.mjs` decided whether a change owed new sentinel
coverage by testing whole-file membership:

```js
export const TRIGGER_FILES = Object.freeze([
  'internal/engine/query_settings_rules.go',
  'internal/engine/spill.go',
]);
return (files ?? []).some((f) => TRIGGER_FILES.includes(f));
```

Those two files also carry every result-equivalent optimizer knob the engine
stamps — the condition cache, lazy materialisation, the projection-index
threshold, the `log_comment` shape id, the workload tag. None of those can move
a query's peak memory, so a comment fix or a new query-tag setting owed a waiver
it could never honestly earn, and the only way to clear the gate was an issue
whose entire content was the receipt. #2832, #2833 and #2849 were all minted
that way in one week.

**The fix scopes the obligation by mechanism class, derived from the trigger
files' own source rather than declared in the gate.**

1. Every ClickHouse setting const in those two files now carries a
   `// perf-sentinel: memory-bounding` or `// perf-sentinel: neutral`
   classification saying which class it belongs to and why. That comment is the
   single source of truth. An unclassified const **fails** the gate rather than
   being assumed harmless, and a `WithQuerySetting` stamping a bare string
   literal fails too — so no memory bound can reach production without a
   declared class.
2. `memoryBoundingSurface` closes over the files' own reference graph from the
   memory-bounding consts, in both directions: a declaration that *stamps* one
   is part of the mechanism, and so is everything it *reaches* to compute or
   gate that stamp. Today that resolves to exactly thirteen identifiers — the
   three `max_bytes_before_external_*` consts, `max_threads`, `spillThreshold`
   and its two byte constants, the three `apply*` stamps, `compareMaxThreads`,
   `planHasJoin`, `planHasMetricsCompare` — and to nothing else in either file.
   Nothing is a hand-maintained list; repoint the code and the surface follows.
3. A change obligates when one of its own changed lines — added **or removed**,
   code only, comments stripped — names something in that surface. Removals
   matter most: #2364's postmortem is a deletion. `parseDiff` in
   `forbid-deferral.mjs` deliberately drops removed lines and is shared by that
   gate's citation-window scan, so this walks the diff on its own terms rather
   than weakening a different gate.

### Proof it no longer misfires, and still fires

Replayed against this repository's real history, using each commit's actual
diff of the two trigger files:

| PR | what it did | before | now |
| --- | --- | --- | --- |
| #2831 | `trace_id_bitmap_filter` | obligated → minted #2832 | **no obligation** |
| #2830 | `lazy_materialization` | obligated → minted #2833 | **no obligation** |
| #2848 | workload query tag | obligated → minted #2849 | **no obligation** |
| #2824 | result cache | obligated | **no obligation** |
| #1112 | unconditional GROUP BY/sort spill | obligated | **obligated** |
| #1163 | compare() memory bound | obligated | **obligated** |
| #1400 | half-the-cap spill threshold | obligated | **obligated** |
| #2819 | `max_bytes_before_external_join` | obligated | **obligated** |

This pull request is itself the live case: it edits both trigger files (adding
the classification comments) and owes nothing, because comments are stripped
before the surface is matched.

Four mutations, each confirming a test that can fail:

| mutation | result |
| --- | --- |
| drop one setting's classification | 2 tests fail |
| reclassify every memory-bounding const as neutral | 2 tests fail |
| stop reading removed lines | 3 tests fail |
| stop stripping comments (restore the #2893 misfire) | 3 tests fail |

## #2899 — a green PR that reds `main`

Two mechanisms, one outcome, and they need different answers.

**Stale base — BLOCKING.** A golden artefact is a function of its fixture corpus
*and* its generator code. When neither side of a race moves code, each side's
golden writes are determined by its own fixtures and the merged tree is simply
their union. When **either** side moves Go, the function itself changed, and any
golden the other side wrote was produced by the old one. So a collision is: both
sides writing under the same shard's golden root while at least one side changes
Go. Same-file races need no help — git already reports those as conflicts and
GitHub blocks them; what this closes is the different-files-same-artefact race
that merges clean, which is exactly the 8 drifted cardinality artefacts
`post-merge-drift` diagnosed.

This is the targeted form of `strict: true`, which stays **off**. It forces an
update-branch on the PRs that actually race a generated artefact instead of on
all ~20 a day. Golden roots come from `lib/golden-shards.mjs`'s own shard table,
so nothing is restated.

**Lane skipping — REPORTED.** `merge-risk` names the lanes that gate `main` yet
declare `merge_posture: never`, together with the command that runs each, so a
skipped lane is never read as a passing one. It does not block, and that is
argued rather than conceded: an ordinary `internal/promql` change is unvalidated
by `compatibility/prometheus`, three chDB shards, `quality.property` and
`performance.profile` at once, so blocking would fail nearly every code PR and
the only escape would be a per-PR waiver citation — the receipt-issue pattern
the first half of this PR exists to delete.

Both gates ride the existing `forbid-deferral` job, which is already a protected
required context on every PR, so **no branch-protection change is needed** and
none is made.

### Proof it fires, and what it will cost

Replayed on real history: PR #2887 as if still in flight while `main` gained
#2890 is **rejected across three shards** — `parity`, `promql` and `solver`.
`parity` wrote the same file on both sides (git would have conflicted), but
`promql` and `solver` wrote disjoint files and would have merged clean into a
tree no ratchet ever checked.

Measured over the last 60 commits on `main` (23 of which write a golden shard):

| PR in flight while `main` gains… | blocked |
| --- | --- |
| 1 commit | 11.9% |
| 3 commits | 22.8% |
| 5 commits | 30.9% |

Every one of those is a true positive with a mechanical remedy (merge `main`,
`just update-golden <shard>`, push) — and it is the same work `post-merge-drift`
currently discovers *after* the fact, moved to the author who caused it. For
comparison, `strict: true` would block 100% of PRs whenever `main` moves at all.
If 31% at a five-commit window reads as too much of a merge tax, say so and I
will demote the stale-base half to reporting; the shape is one boolean.

Four mutations, each confirming a test that can fail:

| mutation | result |
| --- | --- |
| drop the generator-code guard (over-fire) | 1 test fails |
| make a collision unfindable (hollow green) | 4 tests fail |
| report every skipping lane, gating or not | 2 tests fail |
| stop matching paths under a golden root | 7 tests fail |

## What I did not do

`strict: true` and linear history are both untouched, deliberately.

While building the disclosure I verified a finding that limits it and filed it
rather than working around it: **`compatibility.loki` declares
`package_globs: ["compatibility/loki/**", "internal/logql/**",
"internal/api/loki/**"]`, and PR #2824 — the one that caused #2895 — touched
`internal/chclient`, `internal/chopt`, `internal/engine`, `internal/config` and
`cmd/cerberus`, matching none of them.** The lane that would have caught the
regression does not, by its own declaration, consider itself affected by the
change that caused it. Path attribution built on these globs inherits that blind
spot, and `merge-risk`'s summary says so in the output rather than implying the
list is exhaustive. `lib/golden-shards.mjs` already solved the identical problem
for shards by reading `go list -deps` instead of a hand table; issue #2902 tracks
applying that derivation to lane globs.

## Verification

- `node --test .github/scripts/perf-sentinel-obligation.test.mjs` — 44 pass
- `node --test .github/scripts/merge-risk.test.mjs` — 23 pass
- `node .github/scripts/assert-gate-suites-wired.mjs`, `ci-lane-contract.mjs`,
  `doc-refs.mjs`, `doc-counts.mjs`, `assert-go-setup-hardened.mjs` — clean
- `actionlint .github/workflows/forbid-deferral.yml`, `markdownlint-cli2
  docs/test-strategy.md`, `gofumpt -extra -l` on both engine files — clean
- Live run of `merge-risk.mjs` on this branch: no collision, 5 gating lanes
  disclosed

Closes #2893

Closes #2899

🤖 Generated with [Claude Code](https://claude.com/claude-code)
