### PR TITLE
fix(spec): close the parity-enrolled duplicate-timestamp class and gate a fourth

### DIFF
--- a/.github/scripts/README.md
+++ b/.github/scripts/README.md
@@ -261,6 +261,25 @@ what actually runs.
   `internal/chsql/fnresolution.go`. The companion Node test pins tracked,
   untracked, dynamic-conversion, and boundary behavior.
   - Exit: `0` clean, `1` on any raw literal construction.
+- **`forbid-parity-duplicate-samples.mjs`** — `ci.yml`, the `forbid-skip` job
+  step "Reject parity-enrolled fixtures seeding differing-value duplicate
+  timestamps", and the matching pre-push lefthook. Walks `test/spec/promql`,
+  `test/spec/logql` and `test/spec/traceql`, and fails when a fixture carrying
+  `-- parity --` also seeds two metric samples at one `(MetricName, labels,
+  TimeUnix)` carrying different payloads. Which of two samples at a timestamp
+  survives is implementation-defined on both sides — Prometheus's TSDB appender
+  keeps the first ingested, ClickHouse keeps both — so such a fixture asserts
+  what neither engine promises (#2905). Identical-value duplicates are allowed:
+  they have a right answer to converge on, and
+  `increase_duplicate_timestamp_dedup.txtar` deliberately seeds one to pin the
+  rate family's dedup contract against the reference. Metric tables are
+  recognised structurally (a DDL declaring both `MetricName` and `TimeUnix`),
+  and a classic-histogram table is grouped apart because its rows reach the
+  reference as `_bucket`/`_count`/`_sum` series. A scan that finds no
+  metric-shaped seed at all fails as a broken scan.
+  - Env: `REPO_ROOT` (default `process.cwd()`), `SPEC_DIRS` (default
+    `test/spec/promql,test/spec/logql,test/spec/traceql`).
+  - Exit: `0` clean, `1` on any violation or a vacuous scan.
 - **`crawl-surface-inventory-guard.mjs`** — `ci.yml`, the `forbid-skip` job
   step "Crawl surface inventory canonical-form ratchet (#1674)". The PR-time
   content ratchet over

--- a/.github/scripts/forbid-parity-duplicate-samples.mjs
+++ b/.github/scripts/forbid-parity-duplicate-samples.mjs
@@ -326,11 +326,22 @@ export function seriesNamespace(columns) {
 export function duplicateSamples(seed) {
   const tables = parseTables(seed);
   const groups = new Map();
+  const misaligned = [];
   let metricRows = 0;
 
   for (const row of parseInserts(seed, tables)) {
     const declared = tables.get(row.table);
     if (!declared || !isMetricTable(declared)) continue;
+
+    // A tuple whose arity does not match its column list cannot be read
+    // column-wise at all, and ClickHouse would reject the statement, so this
+    // means the DDL or VALUES parse above went wrong. Reported rather than
+    // truncated silently: a misaligned row would be compared against the
+    // wrong columns and could hide a duplicate or invent one.
+    if (row.cells.length !== row.columns.length) {
+      misaligned.push(`${row.table}: ${row.columns.length} column(s), ${row.cells.length} value(s)`);
+      continue;
+    }
     const typeOf = new Map(declared.map((c) => [c.name, c.type]));
 
     const identity = [];
@@ -371,7 +382,7 @@ export function duplicateSamples(seed) {
       payloads: [...payloads].sort(),
     });
   }
-  return { duplicates, metricRows, opaqueInserts: opaqueMetricInserts(seed, tables) };
+  return { duplicates, metricRows, misaligned, opaqueInserts: opaqueMetricInserts(seed, tables) };
 }
 
 /**
@@ -400,6 +411,7 @@ export function scan({ root = process.cwd(), dirs = DEFAULT_SPEC_DIRS } = {}) {
   let metricSeeded = 0;
   let opaqueInserts = 0;
   const violations = [];
+  const misaligned = [];
   for (const dir of dirs) {
     for (const path of fixturesIn(root, dir)) {
       const report = scanFixture(readFileSync(join(root, path), 'utf8'));
@@ -407,10 +419,11 @@ export function scan({ root = process.cwd(), dirs = DEFAULT_SPEC_DIRS } = {}) {
       enrolled++;
       if (report.metricRows > 0) metricSeeded++;
       opaqueInserts += report.opaqueInserts;
+      for (const problem of report.misaligned) misaligned.push({ path, problem });
       for (const duplicate of report.duplicates) violations.push({ path, ...duplicate });
     }
   }
-  return { enrolled, metricSeeded, opaqueInserts, violations };
+  return { enrolled, metricSeeded, opaqueInserts, misaligned, violations };
 }
 
 function main() {
@@ -420,7 +433,21 @@ function main() {
     .map((d) => d.trim())
     .filter(Boolean);
 
-  const { enrolled, metricSeeded, opaqueInserts, violations } = scan({ root, dirs });
+  const { enrolled, metricSeeded, opaqueInserts, misaligned, violations } = scan({ root, dirs });
+
+  // Fail closed on a row this scan could not read column-wise: it would be
+  // compared against the wrong columns, which can hide a duplicate as easily
+  // as invent one. Zero such rows today across the whole corpus, so a hit
+  // means the parser stopped understanding a seed shape.
+  for (const m of misaligned) {
+    error(
+      `${m.path}: a seeded metric row could not be aligned to its column list (${m.problem}). ` +
+        'ClickHouse would reject such a statement, so this is a parse failure in ' +
+        'forbid-parity-duplicate-samples.mjs, not a fixture defect — fix parseTables/parseInserts.',
+      { file: m.path },
+    );
+  }
+  if (misaligned.length > 0) return 1;
 
   // A gate that passes because it parsed nothing reports the same green as a
   // satisfied one. Metric-shaped seeds are what this scan is ABOUT, so finding

--- a/.github/scripts/forbid-parity-duplicate-samples.mjs
+++ b/.github/scripts/forbid-parity-duplicate-samples.mjs
@@ -1,0 +1,469 @@
+// forbid-parity-duplicate-samples.mjs — a parity-enrolled TXTAR fixture must
+// not seed two metric samples that share one (series, timestamp) and carry
+// DIFFERENT payloads.
+//
+// # WHY THIS EXISTS
+//
+// A fixture carrying `-- parity --` is answered twice: once by cerberus's own
+// emitted SQL against chDB, and once by the real upstream engine over the same
+// seeded data (test/spec/parity.go). The two answers must agree. That contract
+// is only meaningful where both engines PROMISE an answer.
+//
+// Duplicate metric samples are where the promise runs out. Prometheus's TSDB
+// appender (test/spec/parityoracle/promql/oracle.go feeds a real
+// `teststorage` head) stores at most ONE sample per (series, timestamp): a
+// second sample at an already-occupied timestamp is dropped at commit, and
+// WHICH one survives is the ingestion order — a fact about the appender, not
+// about PromQL. ClickHouse stores both rows, and which one a cerberus lowering
+// surfaces depends on the emitted shape: the array-fold path's
+// `arraySort(groupArray((ts, value)))` orders ties by VALUE, the sorted-slab
+// over_time path sums both, and the rate family deduplicates by design.
+//
+// So a fixture that both enrols for parity AND seeds a differing-value
+// duplicate asserts two things that cannot both hold: "every sample counts
+// individually" (cerberus) and "matches the reference" (which kept one,
+// chosen by ingestion order). The parity assertion is not testing cerberus, it
+// is testing an accident — and it goes red the moment either side's tie-break
+// shifts. Three such fixtures reached main and one of them was a live red lane
+// (cerberus issue #2905); a fourth had already been fixed in passing without
+// the class ever being closed.
+//
+// # WHY IDENTICAL-VALUE DUPLICATES ARE NOT A VIOLATION
+//
+// A duplicate whose rows carry the SAME payload still means Prometheus keeps
+// one row and ClickHouse keeps two, so a counting reducer can still diverge —
+// but that divergence has a RIGHT answer (the reference's), and cerberus can
+// be made to match it by deduplicating. That is an ordinary bug to fix at the
+// source, which is exactly what `increase_duplicate_timestamp_dedup.txtar`
+// pins: it seeds an identical-value duplicate, stays enrolled, and passes
+// because the rate family deduplicates. Failing it here would delete the only
+// fixture proving that contract against a real reference engine.
+//
+// A DIFFERING-value duplicate has no right answer to converge on. That is the
+// line this gate draws, and it is a line about the seed, not about the
+// operator: it is checkable without knowing which lowering the fixture selects.
+//
+// # SCOPE
+//
+// The hazard is metric-shaped, and the gate says so structurally rather than
+// by naming tables: a seeded table participates when its own DDL declares BOTH
+// a `MetricName` and a `TimeUnix` column — the OTel-CH metric contract
+// internal/schema/otel.go fixes. Log lines (otel_logs) and spans (otel_traces)
+// are not samples keyed by (series, timestamp): Loki keeps every line at a
+// timestamp and Tempo keys spans by span id, so neither reference store
+// collapses them and neither can produce this divergence. All three head
+// corpora are scanned regardless, so the day a LogQL or TraceQL fixture seeds
+// a metric table it is covered without a change here.
+//
+// Rows are grouped ACROSS the seed's metric tables, not per table, because a
+// `merge(otel_metrics_gauge|otel_metrics_sum)` scan reads them as one series
+// universe and the reference oracle folds them into one label set — as does a
+// native-histogram row, which reaches Prometheus under the BARE metric name
+// carrying a histogram-valued sample.
+//
+// The one split is the CLASSIC histogram, and it is read off the DDL rather
+// than off a table name: a table declaring `ExplicitBounds` is expanded by
+// test/spec/parity_chdb.go's readSeededClassicHistograms into `<name>_bucket`,
+// `<name>_count` and `<name>_sum` series, a namespace of its own that can
+// never collide with a bare-named sample. `pinned_name_selector_no_histogram_
+// fanout.txtar` is exactly that shape — a `up` gauge row and a decoy `up`
+// classic-histogram row at one timestamp — and it is correct, enrolled and
+// green, so conflating the two families would fail a good fixture.
+//
+// # KNOWN BLIND SPOT
+//
+// A seed may fill a metric table from a generated `INSERT INTO ... SELECT`
+// rather than a literal `VALUES` list (`quantile_over_time_p95_exact_interp
+// .txtar` seeds 10 000 rows from `numbers()`). Those rows exist only once the
+// statement runs, so no static scan can group them. The gate counts such
+// statements and reports the count in its pass notice rather than pretending
+// the corpus was fully inspected — a divergence there still surfaces as a red
+// round-trip lane, which is how this class was found in the first place.
+//
+// # ENV CONTRACT
+//   REPO_ROOT — repository root the fixture directories resolve against.
+//               Default `process.cwd()`.
+//   SPEC_DIRS — comma-separated, repo-relative fixture directories to scan.
+//               Default `test/spec/promql,test/spec/logql,test/spec/traceql`.
+//
+// Exit codes: 0 = clean; 1 = at least one violation, or a vacuous scan.
+
+import { readFileSync, readdirSync } from 'node:fs';
+import { isAbsolute, join, relative } from 'node:path';
+import process from 'node:process';
+
+import { error, log, notice } from './lib/gh.mjs';
+
+/** The TXTAR section that enrols a fixture against a real reference engine. */
+const PARITY_SECTION = 'parity';
+
+/** The TXTAR section holding the fixture's DDL + INSERT statements. */
+const SEED_SECTION = 'seed';
+
+/** The metric-identity column of the OTel-CH metric tables. */
+const METRIC_NAME_COLUMN = 'MetricName';
+
+/** The sample-timestamp column of the OTel-CH metric tables. */
+const TIMESTAMP_COLUMN = 'TimeUnix';
+
+/**
+ * The column whose presence makes a metric table a CLASSIC histogram, whose
+ * rows the reference engine expands into a `_bucket`/`_count`/`_sum` series
+ * namespace instead of a bare-named sample. See this file's SCOPE note.
+ */
+const CLASSIC_HISTOGRAM_COLUMN = 'ExplicitBounds';
+
+/** Fixture directories scanned when SPEC_DIRS is unset. */
+const DEFAULT_SPEC_DIRS = ['test/spec/promql', 'test/spec/logql', 'test/spec/traceql'];
+
+/**
+ * A declared column type that carries part of the SERIES IDENTITY rather than
+ * the sample payload: the label maps (`Attributes`, `ResourceAttributes`) and
+ * the string-valued identity columns (`MetricName`, `ServiceName`). Everything
+ * else a metric table declares — `Value`, `Count`, `Sum`, `BucketCounts`,
+ * `ExplicitBounds`, `Scale`, the exponential-histogram bucket arrays,
+ * `AggregationTemporality` — is payload, and two rows differing in any of them
+ * at one (series, timestamp) is the violation.
+ */
+const IDENTITY_TYPE = /^(?:Map\s*\(|String\b|LowCardinality\s*\(\s*String)/i;
+
+/** A ClickHouse datetime constructor whose first argument is the instant. */
+const DATETIME_CALL = /^toDateTime(?:64)?\s*\(/i;
+
+/**
+ * Splits TXTAR text into its named sections. The leading comment block before
+ * the first `-- name --` marker is not a section and is dropped.
+ */
+export function splitSections(text) {
+  const sections = new Map();
+  let current = null;
+  const buffer = [];
+  const flush = () => {
+    if (current !== null) sections.set(current, buffer.join('\n'));
+    buffer.length = 0;
+  };
+  for (const line of text.split('\n')) {
+    const marker = /^--\s+(.+?)\s+--\s*$/.exec(line);
+    if (marker) {
+      flush();
+      current = marker[1];
+      continue;
+    }
+    if (current !== null) buffer.push(line);
+  }
+  flush();
+  return sections;
+}
+
+/**
+ * Splits `text` on top-level `separator`, ignoring separators nested inside
+ * parentheses, brackets or single-quoted literals. ClickHouse escapes a quote
+ * inside a literal as `\'`; `''` never appears in this corpus but is handled
+ * for free because the closing quote simply reopens.
+ */
+export function splitTopLevel(text, separator = ',') {
+  const parts = [];
+  let depth = 0;
+  let quoted = false;
+  let start = 0;
+  for (let i = 0; i < text.length; i++) {
+    const ch = text[i];
+    if (quoted) {
+      if (ch === '\\') i++;
+      else if (ch === "'") quoted = false;
+      continue;
+    }
+    if (ch === "'") quoted = true;
+    else if (ch === '(' || ch === '[') depth++;
+    else if (ch === ')' || ch === ']') depth--;
+    else if (ch === separator && depth === 0) {
+      parts.push(text.slice(start, i));
+      start = i + 1;
+    }
+  }
+  parts.push(text.slice(start));
+  return parts;
+}
+
+/**
+ * Returns the index just past the `(` ... `)` group that opens at `open`,
+ * or -1 when the group is unterminated.
+ */
+function matchParen(text, open) {
+  let depth = 0;
+  let quoted = false;
+  for (let i = open; i < text.length; i++) {
+    const ch = text[i];
+    if (quoted) {
+      if (ch === '\\') i++;
+      else if (ch === "'") quoted = false;
+      continue;
+    }
+    if (ch === "'") quoted = true;
+    else if (ch === '(') depth++;
+    else if (ch === ')') {
+      depth--;
+      if (depth === 0) return i + 1;
+    }
+  }
+  return -1;
+}
+
+/**
+ * Every `CREATE TABLE` in `seed`, as table name -> declared columns. A column
+ * is `{ name, type }`, with `DEFAULT`/`CODEC`/`MATERIALIZED` tails trimmed off
+ * the type so the identity/payload classification reads the declared type
+ * alone. Non-column body entries (index and constraint clauses) carry no
+ * recognisable `<name> <type>` pair and are dropped.
+ */
+export function parseTables(seed) {
+  const tables = new Map();
+  const head = /CREATE\s+(?:OR\s+REPLACE\s+)?TABLE\s+(?:IF\s+NOT\s+EXISTS\s+)?([A-Za-z_][A-Za-z_0-9]*)\s*\(/gi;
+  for (const m of seed.matchAll(head)) {
+    const open = m.index + m[0].length - 1;
+    const close = matchParen(seed, open);
+    if (close < 0) continue;
+    const columns = [];
+    for (const entry of splitTopLevel(seed.slice(open + 1, close - 1))) {
+      const decl = entry.trim();
+      if (decl === '') continue;
+      const parts = /^([A-Za-z_][A-Za-z_0-9]*)\s+(.+)$/s.exec(decl);
+      if (!parts) continue;
+      if (/^(?:INDEX|CONSTRAINT|PRIMARY|PROJECTION)$/i.test(parts[1])) continue;
+      const type = parts[2].split(/\s+(?:DEFAULT|CODEC|MATERIALIZED|ALIAS|TTL)\b/i)[0].trim();
+      columns.push({ name: parts[1], type });
+    }
+    tables.set(m[1], columns);
+  }
+  return tables;
+}
+
+/**
+ * Every `INSERT INTO ... VALUES` row in `seed`, as
+ * `{ table, columns, cells }` where `columns` is the effective column list
+ * (explicit when the statement names one, the table's DDL order otherwise)
+ * and `cells` are the raw literal texts, positionally aligned.
+ */
+export function parseInserts(seed, tables) {
+  const rows = [];
+  const head = /INSERT\s+INTO\s+([A-Za-z_][A-Za-z_0-9]*)\s*(\([^)]*\))?\s*VALUES/gi;
+  for (const m of seed.matchAll(head)) {
+    const table = m[1];
+    const declared = tables.get(table);
+    const columns = m[2]
+      ? splitTopLevel(m[2].slice(1, -1)).map((c) => c.trim())
+      : (declared ?? []).map((c) => c.name);
+    let cursor = m.index + m[0].length;
+    // Consume the comma-separated tuple list up to the statement terminator.
+    for (;;) {
+      while (cursor < seed.length && /[\s,]/.test(seed[cursor])) cursor++;
+      if (seed[cursor] !== '(') break;
+      const close = matchParen(seed, cursor);
+      if (close < 0) break;
+      const cells = splitTopLevel(seed.slice(cursor + 1, close - 1)).map((c) => c.trim());
+      rows.push({ table, columns, cells });
+      cursor = close;
+    }
+  }
+  return rows;
+}
+
+/**
+ * How many statements fill a metric-shaped table from something other than a
+ * literal `VALUES` list — an `INSERT ... SELECT`, whose rows do not exist
+ * until the statement runs. See this file's KNOWN BLIND SPOT note.
+ */
+export function opaqueMetricInserts(seed, tables) {
+  let count = 0;
+  const head = /INSERT\s+INTO\s+([A-Za-z_][A-Za-z_0-9]*)\s*(?:\([^)]*\))?\s*([A-Za-z]+)/gi;
+  for (const m of seed.matchAll(head)) {
+    const declared = tables.get(m[1]);
+    if (!declared || !isMetricTable(declared)) continue;
+    if (!/^VALUES$/i.test(m[2])) count++;
+  }
+  return count;
+}
+
+/**
+ * Canonical text for one seeded literal, so two spellings of one value are one
+ * value. Numeric literals compare NUMERICALLY (`40` and `40.0` are the same
+ * sample), and a `toDateTime64('...', 9)` compares on the instant it names
+ * rather than on the call's own punctuation.
+ */
+export function normalizeCell(raw, { timestamp = false } = {}) {
+  const text = raw.trim().replace(/\s+/g, ' ');
+  if (timestamp && DATETIME_CALL.test(text)) {
+    const literal = /'((?:[^'\\]|\\.)*)'/.exec(text);
+    if (literal) return `@${literal[1]}`;
+  }
+  if (text !== '' && Number.isFinite(Number(text))) return `#${Number(text)}`;
+  return text;
+}
+
+/** Reports whether a table's DDL declares the OTel-CH metric-sample shape. */
+export function isMetricTable(columns) {
+  const names = new Set(columns.map((c) => c.name));
+  return names.has(METRIC_NAME_COLUMN) && names.has(TIMESTAMP_COLUMN);
+}
+
+/**
+ * The reference-side SERIES NAMESPACE a metric table's rows land in. Rows in
+ * different namespaces never describe one series, so they are grouped apart.
+ */
+export function seriesNamespace(columns) {
+  return columns.some((c) => c.name === CLASSIC_HISTOGRAM_COLUMN) ? 'classic-histogram' : 'sample';
+}
+
+/**
+ * Every differing-value duplicate a seed carries, as
+ * `{ series, timestamp, payloads }`. `payloads` holds the distinct payload
+ * renderings found at that one (series, timestamp).
+ *
+ * Returns `{ duplicates, metricRows, opaqueInserts }`; `metricRows` is how many
+ * metric-shaped rows the seed contributed, which the caller uses to tell
+ * "clean" apart from "nothing was looked at".
+ */
+export function duplicateSamples(seed) {
+  const tables = parseTables(seed);
+  const groups = new Map();
+  let metricRows = 0;
+
+  for (const row of parseInserts(seed, tables)) {
+    const declared = tables.get(row.table);
+    if (!declared || !isMetricTable(declared)) continue;
+    const typeOf = new Map(declared.map((c) => [c.name, c.type]));
+
+    const identity = [];
+    const payload = [];
+    for (let i = 0; i < row.columns.length && i < row.cells.length; i++) {
+      const name = row.columns[i];
+      const type = typeOf.get(name);
+      if (type === undefined) continue;
+      if (name === TIMESTAMP_COLUMN) {
+        identity.push([name, normalizeCell(row.cells[i], { timestamp: true })]);
+      } else if (IDENTITY_TYPE.test(type)) {
+        identity.push([name, normalizeCell(row.cells[i])]);
+      } else {
+        payload.push([name, normalizeCell(row.cells[i])]);
+      }
+    }
+    if (identity.length === 0) continue;
+    metricRows++;
+
+    identity.sort(([a], [b]) => (a < b ? -1 : a > b ? 1 : 0));
+    payload.sort(([a], [b]) => (a < b ? -1 : a > b ? 1 : 0));
+    const key = JSON.stringify([seriesNamespace(declared), identity]);
+    const rendered = payload.map(([n, v]) => `${n}=${v}`).join(' ');
+    if (!groups.has(key)) groups.set(key, { identity, payloads: new Set() });
+    groups.get(key).payloads.add(rendered);
+  }
+
+  const duplicates = [];
+  for (const { identity, payloads } of groups.values()) {
+    if (payloads.size < 2) continue;
+    const fields = new Map(identity);
+    duplicates.push({
+      series: identity
+        .filter(([n]) => n !== TIMESTAMP_COLUMN)
+        .map(([n, v]) => `${n}=${v}`)
+        .join(' '),
+      timestamp: (fields.get(TIMESTAMP_COLUMN) ?? '').replace(/^@/, ''),
+      payloads: [...payloads].sort(),
+    });
+  }
+  return { duplicates, metricRows, opaqueInserts: opaqueMetricInserts(seed, tables) };
+}
+
+/**
+ * Scans one fixture's text. Returns null when the fixture is not in scope
+ * (unenrolled, or carrying no seed), and a report otherwise.
+ */
+export function scanFixture(text) {
+  const sections = splitSections(text);
+  if (!sections.has(PARITY_SECTION)) return null;
+  const seed = sections.get(SEED_SECTION);
+  if (seed === undefined) return null;
+  return duplicateSamples(seed);
+}
+
+/** Every `*.txtar` directly under `dir`, as repo-relative paths, sorted. */
+function fixturesIn(root, dir) {
+  const abs = isAbsolute(dir) ? dir : join(root, dir);
+  return readdirSync(abs, { withFileTypes: true })
+    .filter((e) => e.isFile() && e.name.endsWith('.txtar'))
+    .map((e) => relative(root, join(abs, e.name)))
+    .sort();
+}
+
+export function scan({ root = process.cwd(), dirs = DEFAULT_SPEC_DIRS } = {}) {
+  let enrolled = 0;
+  let metricSeeded = 0;
+  let opaqueInserts = 0;
+  const violations = [];
+  for (const dir of dirs) {
+    for (const path of fixturesIn(root, dir)) {
+      const report = scanFixture(readFileSync(join(root, path), 'utf8'));
+      if (report === null) continue;
+      enrolled++;
+      if (report.metricRows > 0) metricSeeded++;
+      opaqueInserts += report.opaqueInserts;
+      for (const duplicate of report.duplicates) violations.push({ path, ...duplicate });
+    }
+  }
+  return { enrolled, metricSeeded, opaqueInserts, violations };
+}
+
+function main() {
+  const root = process.env.REPO_ROOT || process.cwd();
+  const dirs = (process.env.SPEC_DIRS || DEFAULT_SPEC_DIRS.join(','))
+    .split(',')
+    .map((d) => d.trim())
+    .filter(Boolean);
+
+  const { enrolled, metricSeeded, opaqueInserts, violations } = scan({ root, dirs });
+
+  // A gate that passes because it parsed nothing reports the same green as a
+  // satisfied one. Metric-shaped seeds are what this scan is ABOUT, so finding
+  // none means the parser stopped understanding the corpus, not that the
+  // corpus became clean.
+  if (metricSeeded === 0) {
+    error(
+      'forbid-parity-duplicate-samples: scanned ' +
+        `${enrolled} parity-enrolled fixture(s) and found no metric-shaped seed at all. ` +
+        'The scan is broken, not the corpus — check parseTables/parseInserts against ' +
+        `${dirs.join(', ')}.`,
+    );
+    return 1;
+  }
+
+  for (const v of violations) {
+    error(
+      `${v.path}: seeds ${v.series} twice at ${v.timestamp} with differing payloads ` +
+        `(${v.payloads.join(' vs ')}), while enrolling for parity against a reference engine. ` +
+        'Which of two samples at one (series, timestamp) survives is implementation-defined on ' +
+        'both sides — Prometheus keeps the first ingested, ClickHouse keeps both — so the two ' +
+        'claims cannot both hold. Either drop the duplicate and stay enrolled, or keep the ' +
+        'duplicate and replace `-- parity --` with a `-- parity_exempt --` section carrying ' +
+        'reason `duplicate-timestamp-seed` (test/spec/parity_exempt.go), pinning the contract ' +
+        'with a cerberus-vs-cerberus differential instead.',
+      { file: v.path },
+    );
+  }
+
+  if (violations.length > 0) {
+    log(`forbid-parity-duplicate-samples: ${violations.length} violation(s) across ${metricSeeded} metric-seeded fixture(s).`);
+    return 1;
+  }
+
+  notice(
+    `forbid-parity-duplicate-samples: ${enrolled} parity-enrolled fixture(s) scanned, ` +
+      `${metricSeeded} carrying a metric-shaped seed; no differing-value duplicate timestamps. ` +
+      `${opaqueInserts} generated INSERT ... SELECT statement(s) were not statically inspectable ` +
+      '(see this script\'s KNOWN BLIND SPOT note).',
+  );
+  return 0;
+}
+
+if (process.argv[1] && import.meta.url === `file://${process.argv[1]}`) {
+  process.exit(main());
+}

--- a/.github/scripts/forbid-parity-duplicate-samples.test.mjs
+++ b/.github/scripts/forbid-parity-duplicate-samples.test.mjs
@@ -1,0 +1,263 @@
+// Unit + integration tests for forbid-parity-duplicate-samples.mjs.
+//
+// The integration cases drive the REAL script as a subprocess over a temp
+// fixture tree, because the gate's whole value is in what it does to a corpus
+// on disk: it must go RED on the shape it exists to forbid and stay GREEN on
+// the three neighbouring shapes that look similar and are legitimate — an
+// identical-value duplicate (increase_duplicate_timestamp_dedup.txtar's real
+// shape), a differing-value duplicate in an UNENROLLED fixture, and a gauge
+// row sharing a (name, labels, timestamp) with a classic-histogram decoy
+// (pinned_name_selector_no_histogram_fanout.txtar's real shape). A gate that
+// fires on any of those would delete good coverage, so each is a pinned
+// negative control rather than an afterthought.
+//
+// The vacuity case is pinned too: a scan that parses no metric-shaped seed at
+// all must FAIL rather than report the green a satisfied scan reports.
+
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { spawnSync } from 'node:child_process';
+import { mkdirSync, mkdtempSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import {
+  duplicateSamples,
+  isMetricTable,
+  normalizeCell,
+  opaqueMetricInserts,
+  parseInserts,
+  parseTables,
+  seriesNamespace,
+  splitSections,
+  splitTopLevel,
+} from './forbid-parity-duplicate-samples.mjs';
+
+const SCRIPT = join(dirname(fileURLToPath(import.meta.url)), 'forbid-parity-duplicate-samples.mjs');
+
+const GAUGE_DDL = `CREATE TABLE otel_metrics_gauge (
+    MetricName String,
+    Attributes Map(String, String),
+    TimeUnix DateTime64(9),
+    Value Float64
+) ENGINE = MergeTree ORDER BY (MetricName, Attributes, TimeUnix);
+`;
+
+const HISTOGRAM_DDL = `CREATE TABLE otel_metrics_histogram (
+    MetricName String,
+    Attributes Map(String, String),
+    TimeUnix DateTime64(9),
+    Count UInt64,
+    Sum Float64,
+    ExplicitBounds Array(Float64),
+    BucketCounts Array(UInt64)
+) ENGINE = MergeTree ORDER BY (MetricName, Attributes, TimeUnix);
+`;
+
+const PARITY = '-- parity --\noracle: prometheus\nendpoint: /api/v1/query\nscope: full\n';
+
+function fixture({ parity = true, seed }) {
+  return `# header comment\n${parity ? PARITY : ''}-- query.promql --\nup\n-- seed --\n${seed}`;
+}
+
+function row(name, labels, ts, value) {
+  return `    ('${name}', map(${labels}), toDateTime64('${ts}', 9), ${value})`;
+}
+
+function gaugeSeed(rows) {
+  return `${GAUGE_DDL}INSERT INTO otel_metrics_gauge VALUES\n${rows.join(',\n')};\n`;
+}
+
+// newCorpus() writes a throwaway spec tree of `name -> fixture text` under
+// test/spec/promql and returns its root.
+function newCorpus(fixtures) {
+  const dir = mkdtempSync(join(tmpdir(), 'forbid-parity-dup-samples-'));
+  mkdirSync(join(dir, 'test', 'spec', 'promql'), { recursive: true });
+  for (const [name, text] of Object.entries(fixtures)) {
+    writeFileSync(join(dir, 'test', 'spec', 'promql', name), text);
+  }
+  return dir;
+}
+
+function runGate(root) {
+  return spawnSync('node', [SCRIPT], {
+    cwd: root,
+    encoding: 'utf8',
+    env: { ...process.env, REPO_ROOT: root, SPEC_DIRS: 'test/spec/promql' },
+  });
+}
+
+test('splitSections keys each TXTAR section and drops the leading comment', () => {
+  const sections = splitSections('# note\n-- parity --\noracle: prometheus\n-- seed --\nSELECT 1;\n');
+  assert.deepEqual([...sections.keys()], ['parity', 'seed']);
+  assert.equal(sections.get('parity'), 'oracle: prometheus');
+  assert.equal(sections.get('seed'), 'SELECT 1;\n'.trimEnd() + '\n');
+});
+
+test('splitTopLevel ignores separators nested in calls, arrays and quotes', () => {
+  const parts = splitTopLevel("'a,b', map('x', 'y'), [1, 2], 3");
+  assert.deepEqual(
+    parts.map((p) => p.trim()),
+    ["'a,b'", "map('x', 'y')", '[1, 2]', '3'],
+  );
+});
+
+test('parseTables reads column names and trims DEFAULT tails off the type', () => {
+  const tables = parseTables(
+    'CREATE TABLE t (\n  MetricName String,\n  ResourceAttributes Map(String, String) DEFAULT map(),\n' +
+      '  TimeUnix DateTime64(9),\n  Value Float64\n) ENGINE = Memory;\n',
+  );
+  assert.deepEqual(tables.get('t'), [
+    { name: 'MetricName', type: 'String' },
+    { name: 'ResourceAttributes', type: 'Map(String, String)' },
+    { name: 'TimeUnix', type: 'DateTime64(9)' },
+    { name: 'Value', type: 'Float64' },
+  ]);
+});
+
+test('parseInserts aligns a positional VALUES list against the DDL column order', () => {
+  const seed = gaugeSeed([row('m', "'job', 'api'", '2026-01-01 00:00:00', '1.0')]);
+  const rows = parseInserts(seed, parseTables(seed));
+  assert.equal(rows.length, 1);
+  assert.deepEqual(rows[0].columns, ['MetricName', 'Attributes', 'TimeUnix', 'Value']);
+  assert.equal(rows[0].cells[3], '1.0');
+});
+
+test('parseInserts honours an explicit column list', () => {
+  const seed = `${GAUGE_DDL}INSERT INTO otel_metrics_gauge (MetricName, TimeUnix, Value) VALUES\n` +
+    "    ('m', toDateTime64('2026-01-01 00:00:00', 9), 1.0);\n";
+  const rows = parseInserts(seed, parseTables(seed));
+  assert.deepEqual(rows[0].columns, ['MetricName', 'TimeUnix', 'Value']);
+  assert.equal(rows[0].cells.length, 3);
+});
+
+test('normalizeCell compares numbers numerically and datetimes by instant', () => {
+  assert.equal(normalizeCell('40'), normalizeCell('40.0'));
+  assert.notEqual(normalizeCell('40'), normalizeCell('41'));
+  assert.equal(
+    normalizeCell("toDateTime64('2026-01-01 00:00:00', 9)", { timestamp: true }),
+    normalizeCell("toDateTime64( '2026-01-01 00:00:00' ,9)", { timestamp: true }),
+  );
+  assert.equal(normalizeCell("map('job',  'api')"), "map('job', 'api')");
+});
+
+test('isMetricTable and seriesNamespace read the shape off the DDL', () => {
+  const gauge = parseTables(GAUGE_DDL).get('otel_metrics_gauge');
+  const histogram = parseTables(HISTOGRAM_DDL).get('otel_metrics_histogram');
+  const logs = parseTables(
+    'CREATE TABLE otel_logs (Timestamp DateTime64(9), Body String) ENGINE = Memory;',
+  ).get('otel_logs');
+
+  assert.equal(isMetricTable(gauge), true);
+  assert.equal(isMetricTable(histogram), true);
+  assert.equal(isMetricTable(logs), false);
+  assert.equal(seriesNamespace(gauge), 'sample');
+  assert.equal(seriesNamespace(histogram), 'classic-histogram');
+});
+
+test('duplicateSamples reports a differing-value duplicate and its two payloads', () => {
+  const seed = gaugeSeed([
+    row('m', "'job', 'api'", '2026-01-01 00:02:00', '2.0'),
+    row('m', "'job', 'api'", '2026-01-01 00:02:00', '3.0'),
+  ]);
+  const { duplicates, metricRows } = duplicateSamples(seed);
+  assert.equal(metricRows, 2);
+  assert.equal(duplicates.length, 1);
+  assert.equal(duplicates[0].timestamp, '2026-01-01 00:02:00');
+  assert.deepEqual(duplicates[0].payloads, ['Value=#2', 'Value=#3']);
+});
+
+test('duplicateSamples ignores an identical-value duplicate however it is spelled', () => {
+  const seed = gaugeSeed([
+    row('m', "'job', 'api'", '2026-01-01 00:02:00', '40.0'),
+    row('m', "'job',  'api'", '2026-01-01 00:02:00', '40'),
+  ]);
+  assert.deepEqual(duplicateSamples(seed).duplicates, []);
+});
+
+test('duplicateSamples separates a gauge row from a classic-histogram row at the same series', () => {
+  const seed =
+    `${GAUGE_DDL}INSERT INTO otel_metrics_gauge VALUES\n` +
+    `${row('up', "'job', 'api'", '2026-01-01 00:00:00', '1.0')};\n` +
+    `${HISTOGRAM_DDL}INSERT INTO otel_metrics_histogram VALUES\n` +
+    "    ('up', map('job', 'api'), toDateTime64('2026-01-01 00:00:00', 9), 3, 6.0, [1.0], [1, 2]);\n";
+  assert.deepEqual(duplicateSamples(seed).duplicates, []);
+});
+
+test('duplicateSamples groups rows ACROSS bare-named metric tables', () => {
+  const sumDDL = GAUGE_DDL.replace(/otel_metrics_gauge/g, 'otel_metrics_sum');
+  const seed =
+    `${GAUGE_DDL}INSERT INTO otel_metrics_gauge VALUES\n` +
+    `${row('m', "'job', 'api'", '2026-01-01 00:00:00', '1.0')};\n` +
+    `${sumDDL}INSERT INTO otel_metrics_sum VALUES\n` +
+    `${row('m', "'job', 'api'", '2026-01-01 00:00:00', '9.0')};\n`;
+  assert.equal(duplicateSamples(seed).duplicates.length, 1);
+});
+
+test('opaqueMetricInserts counts generated INSERT ... SELECT seeds', () => {
+  const seed = `${GAUGE_DDL}INSERT INTO otel_metrics_gauge\n    SELECT 'm', map(), now64(), 1.0 FROM numbers(10);\n`;
+  const tables = parseTables(seed);
+  assert.equal(opaqueMetricInserts(seed, tables), 1);
+  assert.equal(duplicateSamples(seed).metricRows, 0);
+});
+
+test('the gate FAILS on a parity-enrolled differing-value duplicate', () => {
+  const root = newCorpus({
+    'clean.txtar': fixture({ seed: gaugeSeed([row('m', "'job', 'api'", '2026-01-01 00:00:00', '1.0')]) }),
+    'bad.txtar': fixture({
+      seed: gaugeSeed([
+        row('m', "'job', 'api'", '2026-01-01 00:02:00', '2.0'),
+        row('m', "'job', 'api'", '2026-01-01 00:02:00', '3.0'),
+      ]),
+    }),
+  });
+  const res = runGate(root);
+  assert.equal(res.status, 1, res.stdout + res.stderr);
+  assert.match(res.stdout, /bad\.txtar/);
+  assert.doesNotMatch(res.stdout, /clean\.txtar/);
+  assert.match(res.stdout, /1 violation\(s\)/);
+});
+
+test('the gate PASSES an identical-value duplicate, the dedup-contract fixture shape', () => {
+  const root = newCorpus({
+    'dedup.txtar': fixture({
+      seed: gaugeSeed([
+        row('m', "'job', 'api'", '1970-01-01 00:04:00', '40.0'),
+        row('m', "'job', 'api'", '1970-01-01 00:04:00', '40.0'),
+      ]),
+    }),
+  });
+  const res = runGate(root);
+  assert.equal(res.status, 0, res.stdout + res.stderr);
+  assert.match(res.stdout, /::notice::/);
+});
+
+test('the gate PASSES a differing-value duplicate in an UNENROLLED fixture', () => {
+  const root = newCorpus({
+    'exempt.txtar': fixture({
+      parity: false,
+      seed: gaugeSeed([
+        row('m', "'job', 'api'", '2026-01-01 00:02:00', '2.0'),
+        row('m', "'job', 'api'", '2026-01-01 00:02:00', '3.0'),
+      ]),
+    }),
+    'enrolled.txtar': fixture({ seed: gaugeSeed([row('m', "'job', 'api'", '2026-01-01 00:00:00', '1.0')]) }),
+  });
+  const res = runGate(root);
+  assert.equal(res.status, 0, res.stdout + res.stderr);
+});
+
+test('the gate FAILS a scan that parsed no metric-shaped seed at all', () => {
+  const root = newCorpus({
+    'logs.txtar': fixture({
+      seed:
+        'CREATE TABLE otel_logs (Timestamp DateTime64(9), Body String) ENGINE = Memory;\n' +
+        "INSERT INTO otel_logs VALUES (toDateTime64('2026-01-01 00:00:00', 9), 'a'),\n" +
+        "    (toDateTime64('2026-01-01 00:00:00', 9), 'b');\n",
+    }),
+  });
+  const res = runGate(root);
+  assert.equal(res.status, 1, res.stdout + res.stderr);
+  assert.match(res.stdout, /no metric-shaped seed at all/);
+});

--- a/.github/scripts/forbid-parity-duplicate-samples.test.mjs
+++ b/.github/scripts/forbid-parity-duplicate-samples.test.mjs
@@ -248,6 +248,21 @@ test('the gate PASSES a differing-value duplicate in an UNENROLLED fixture', () 
   assert.equal(res.status, 0, res.stdout + res.stderr);
 });
 
+test('the gate FAILS a metric row whose tuple arity does not match its column list', () => {
+  // A shape ClickHouse itself would reject, so reaching it means the DDL or
+  // VALUES parse went wrong; a truncated comparison could hide a duplicate as
+  // easily as invent one, so this fails closed rather than silently aligning.
+  const root = newCorpus({
+    'ragged.txtar': fixture({
+      seed: `${GAUGE_DDL}INSERT INTO otel_metrics_gauge VALUES\n` +
+        "    ('m', map('job', 'api'), toDateTime64('2026-01-01 00:00:00', 9));\n",
+    }),
+  });
+  const res = runGate(root);
+  assert.equal(res.status, 1, res.stdout + res.stderr);
+  assert.match(res.stdout, /could not be aligned to its column list/);
+});
+
 test('the gate FAILS a scan that parsed no metric-shaped seed at all', () => {
   const root = newCorpus({
     'logs.txtar': fixture({

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1096,6 +1096,20 @@ jobs:
       - name: Reject raw chplan Fn literal construction
         run: node .github/scripts/forbid-chplan-fn-literal.mjs
 
+      # #2905: a parity-enrolled fixture that also seeds a differing-value
+      # duplicate (series, timestamp) asserts two things that cannot both
+      # hold — "every sample counts" (cerberus) and "matches the reference"
+      # (whose TSDB appender keeps one, chosen by ingestion order). Three
+      # such fixtures reached main and one was a live red `roundtrip-promql`
+      # lane. The suite runs first because the gate's negative controls (an
+      # identical-value duplicate, a classic-histogram decoy) are what keep
+      # it from failing good fixtures.
+      - name: Assert the parity duplicate-sample gate fires and spares its controls
+        run: node --test .github/scripts/forbid-parity-duplicate-samples.test.mjs
+
+      - name: Reject parity-enrolled fixtures seeding differing-value duplicate timestamps
+        run: node .github/scripts/forbid-parity-duplicate-samples.mjs
+
       # #1568: GitHub's server-side merge does NOT honour the `-merge`
       # .gitattributes driver (verified empirically — see the script's own
       # doc comment for the experiment). Most `-merge`-marked generated

--- a/docs/test-strategy.md
+++ b/docs/test-strategy.md
@@ -405,6 +405,24 @@ and a fixture change cannot pass its shard-coverage check without naming it.
 The generated files refuse line merging so unrelated additions cannot blend
 with a stale removal.
 
+Enrolment is a closed set rather than an aspiration. A PromQL fixture carries
+either a `-- parity --` section or a `-- parity_exempt --` one declaring, from a
+closed vocabulary of structural reasons (`test/spec/parity_exempt.go`), why it
+cannot be compared against a reference engine; `test/regression/
+parity_coverage_test.go` makes "neither" and "both" failures. One of those
+reasons, `duplicate-timestamp-seed`, covers a seed that deliberately carries two
+metric samples at one `(series, timestamp)` with different values: Prometheus's
+TSDB appender keeps a single sample per timestamp and drops the rest at commit,
+so the reference answers over rows cerberus never saw, with a survivor decided
+by ingestion order. Such a fixture pins its contract with a cerberus-vs-cerberus
+differential instead — the strategy under test against the fan-out strategy it
+must agree with, over the identical rows. `.github/scripts/
+forbid-parity-duplicate-samples.mjs`, a step of the required `forbid-skip` job
+and of the pre-push hook, is what keeps the two claims from being made at once:
+it walks all three head corpora and fails a `-- parity --` fixture whose seed
+carries such a duplicate. Identical-value duplicates stay enrollable, because
+that divergence has a reference answer for cerberus to converge on.
+
 Both sections are load-bearing: a fixture with a `-- seed --` but no
 `-- expected_rows --` is **inert** — the runner returns before it touches
 chDB, and the `GOLDEN_UPDATE=1` rewrite sits downstream of that return, so

--- a/internal/promql/duplicate_timestamp_seed_chdb_test.go
+++ b/internal/promql/duplicate_timestamp_seed_chdb_test.go
@@ -1,0 +1,357 @@
+//go:build chdb
+
+// chDB-backed differential proof of cerberus's duplicate-timestamp contract
+// (cerberus issue #2905): over a seed carrying two samples at ONE
+// (series, timestamp) with DIFFERENT values, a ClickHouse-native range
+// strategy must answer exactly what the fan-out array-fold strategy answers.
+//
+// # Why this is the right oracle, and a reference engine is not
+//
+// Three TXTAR fixtures seed such a duplicate on purpose, to pin how their
+// strategy treats the pair: sorted_slab_sum_over_time_range_step.txtar,
+// sorted_slab_avg_over_time_range_step.txtar and
+// lag_adjacency_idelta_duplicate_ts.txtar. All three used to also enrol for
+// parity against the upstream Prometheus engine, and that enrolment was
+// self-contradictory: Prometheus's TSDB appender stores at most one sample per
+// (series, timestamp) — parityoracle/promql/oracle.go feeds a real teststorage
+// head, whose commit drops the second — so the reference answers over a seed
+// cerberus never saw, with a survivor chosen by ingestion order. Agreement
+// would have been an accident, and disagreement was: the `roundtrip-promql`
+// lane went red on a divergence that was exactly the discarded sample.
+//
+// The three fixtures are parity-EXEMPT now (reason `duplicate-timestamp-seed`,
+// test/spec/parity_exempt.go), and this file is where the contract they exist
+// for is actually tested. It is a sharper oracle than a reference backend for
+// this one question: it compares the strategy under test against the fan-out
+// strategy it must agree with, over the identical rows, rather than against an
+// engine that discarded one of them before evaluating anything.
+//
+// # Why each case also pins a hand-derived value
+//
+// Two strategies agreeing proves they agree, not that they are right — and the
+// specific way they could BOTH be wrong here is by both deduplicating, which
+// is what the rate family does by design (increase_duplicate_timestamp_dedup
+// .txtar pins that). So every case additionally asserts the no-dedup answer it
+// must produce AND asserts that this differs from the deduplicated answer the
+// reference engine computes. Without that second assertion the differential
+// would keep passing the day the contract silently inverted.
+package promql_test
+
+import (
+	"context"
+	"math"
+	"strconv"
+	"testing"
+	"time"
+
+	promparser "github.com/prometheus/prometheus/promql/parser"
+
+	"github.com/tsouza/cerberus/internal/chsql"
+	"github.com/tsouza/cerberus/internal/promql"
+	"github.com/tsouza/cerberus/internal/schema"
+)
+
+// dupTSMetricsDDL creates both arms of the metrics fan-out a bare selector
+// resolves to, so the emitted `merge(...)` reads a complete catalog whichever
+// arm a given metric name routes to. `CREATE OR REPLACE` because the chDB
+// session outlives any one test — see chdbFixture's own doc.
+const dupTSMetricsDDL = `
+CREATE OR REPLACE TABLE otel_metrics_sum (
+    MetricName String,
+    Attributes Map(String, String),
+    ResourceAttributes Map(String, String) DEFAULT map(),
+    ServiceName LowCardinality(String) DEFAULT '',
+    TimeUnix DateTime64(9),
+    Value Float64
+) ENGINE = MergeTree ORDER BY (MetricName, Attributes, TimeUnix);
+CREATE OR REPLACE TABLE otel_metrics_gauge (
+    MetricName String,
+    Attributes Map(String, String),
+    ResourceAttributes Map(String, String) DEFAULT map(),
+    ServiceName LowCardinality(String) DEFAULT '',
+    TimeUnix DateTime64(9),
+    Value Float64
+) ENGINE = MergeTree ORDER BY (MetricName, Attributes, TimeUnix);
+`
+
+// The metric names the cases query. Distinct from every other fixture sharing
+// this package's chDB session (fixture_chdb_test.go), and distinct from the
+// TXTAR fixtures' own names for the same reason.
+const (
+	dupTSOverTimeMetric = "duplicate_ts_over_time_test_metric"
+	dupTSIdeltaMetric   = "duplicate_ts_idelta_test_metric"
+)
+
+// dupTSOverTimeSeed is sorted_slab_{sum,avg}_over_time_range_step.txtar's own
+// seed: job 'api' carries 00:02:00 twice with 2.0 and 3.0, job 'web' is a
+// plain monotonic control that no duplicate touches.
+const dupTSOverTimeSeed = dupTSMetricsDDL + `
+INSERT INTO otel_metrics_sum (MetricName, Attributes, TimeUnix, Value) VALUES
+    ('` + dupTSOverTimeMetric + `', map('job', 'api'), toDateTime64('2026-01-01 00:00:00', 9), 1.0),
+    ('` + dupTSOverTimeMetric + `', map('job', 'api'), toDateTime64('2026-01-01 00:01:00', 9), 5.0),
+    ('` + dupTSOverTimeMetric + `', map('job', 'api'), toDateTime64('2026-01-01 00:02:00', 9), 2.0),
+    ('` + dupTSOverTimeMetric + `', map('job', 'api'), toDateTime64('2026-01-01 00:02:00', 9), 3.0),
+    ('` + dupTSOverTimeMetric + `', map('job', 'api'), toDateTime64('2026-01-01 00:03:00', 9), 8.0),
+    ('` + dupTSOverTimeMetric + `', map('job', 'api'), toDateTime64('2026-01-01 00:04:00', 9), 1.0),
+    ('` + dupTSOverTimeMetric + `', map('job', 'api'), toDateTime64('2026-01-01 00:05:00', 9), 6.0),
+    ('` + dupTSOverTimeMetric + `', map('job', 'web'), toDateTime64('2026-01-01 00:00:00', 9), 10.0),
+    ('` + dupTSOverTimeMetric + `', map('job', 'web'), toDateTime64('2026-01-01 00:01:00', 9), 20.0),
+    ('` + dupTSOverTimeMetric + `', map('job', 'web'), toDateTime64('2026-01-01 00:02:00', 9), 30.0),
+    ('` + dupTSOverTimeMetric + `', map('job', 'web'), toDateTime64('2026-01-01 00:03:00', 9), 40.0),
+    ('` + dupTSOverTimeMetric + `', map('job', 'web'), toDateTime64('2026-01-01 00:04:00', 9), 50.0),
+    ('` + dupTSOverTimeMetric + `', map('job', 'web'), toDateTime64('2026-01-01 00:05:00', 9), 60.0);
+`
+
+// dupTSIdeltaSeed is lag_adjacency_idelta_duplicate_ts.txtar's own seed:
+// host 'a' carries 00:02:00 twice with 2.0 and 5.0.
+const dupTSIdeltaSeed = dupTSMetricsDDL + `
+INSERT INTO otel_metrics_gauge (MetricName, Attributes, TimeUnix, Value) VALUES
+    ('` + dupTSIdeltaMetric + `', map('host', 'a'), toDateTime64('2026-01-01 00:01:00', 9), 1.0),
+    ('` + dupTSIdeltaMetric + `', map('host', 'a'), toDateTime64('2026-01-01 00:02:00', 9), 2.0),
+    ('` + dupTSIdeltaMetric + `', map('host', 'a'), toDateTime64('2026-01-01 00:02:00', 9), 5.0),
+    ('` + dupTSIdeltaMetric + `', map('host', 'a'), toDateTime64('2026-01-01 00:04:00', 9), 10.0);
+`
+
+// The evaluation window every case shares, matching the TXTAR fixtures'
+// deterministic range anchor (internal/promql/lower_test.go).
+var (
+	dupTSRangeStart = time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	dupTSRangeEnd   = dupTSRangeStart.Add(5 * time.Minute)
+)
+
+// The two range steps the fixtures use: 30s for the over_time pair, 5m for
+// idelta (whose single anchor is the range end).
+const (
+	dupTSOverTimeStep = 30 * time.Second
+	dupTSIdeltaStep   = 5 * time.Minute
+)
+
+// dupTSFloatTolerance absorbs ordinary float64 representation error between
+// two constructions that sum the same values in a different order (arrayAvg
+// over a slab versus the fan-out fold). It is many orders above nothing and
+// many orders below every gap this file asserts on: the smallest is
+// avg_over_time's 25/6 vs 22/5, a gap of ~0.23.
+const dupTSFloatTolerance = 1e-9
+
+// dupTSSample is one output row, keyed for cross-strategy comparison.
+type dupTSSample struct {
+	attributes string
+	timestamp  string
+	value      float64
+}
+
+// dupTSAnswer is one strategy's whole answer plus the SQL that produced it.
+// The SQL is carried so the differential can prove the two strategies were
+// actually DIFFERENT — see [assertDupTSStrategiesAgree].
+type dupTSAnswer struct {
+	samples []dupTSSample
+	sql     string
+}
+
+// runDupTSQuery lowers query under lowerers, executes the emitted SQL against
+// fixture and returns every output row in the emitted order.
+func runDupTSQuery(
+	t *testing.T, fixture *chdbFixture, query string, step time.Duration, lowerers promql.RangeLowerers,
+) dupTSAnswer {
+	t.Helper()
+	p := promparser.NewParser(promparser.Options{})
+	expr, err := p.ParseExpr(query)
+	if err != nil {
+		t.Fatalf("ParseExpr(%q): %v", query, err)
+	}
+	plan, err := promql.LowerAtRangeOpts(
+		context.Background(), expr, schema.DefaultOTelMetrics(),
+		dupTSRangeStart, dupTSRangeEnd, step, promql.LowerOpts{Lowerers: lowerers},
+	)
+	if err != nil {
+		t.Fatalf("LowerAtRangeOpts(%q): %v", query, err)
+	}
+	sqlText, args, err := chsql.Emit(context.Background(), plan)
+	if err != nil {
+		t.Fatalf("Emit(%q): %v", query, err)
+	}
+
+	// Projected to plain strings: chdb-go's parquet driver cannot decode a
+	// Map(String, String) cell into a Go destination — see
+	// chdbFixture.queryOverEmitted's own doc.
+	rows := fixture.queryOverEmitted(t,
+		"toString(Attributes), toString(TimeUnix), toString(Value)", sqlText, args)
+	defer func() { _ = rows.Close() }()
+
+	var out []dupTSSample
+	for rows.Next() {
+		var attributes, timestamp, value string
+		if err := rows.Scan(&attributes, &timestamp, &value); err != nil {
+			t.Fatalf("scan(%q): %v", query, err)
+		}
+		parsed, err := strconv.ParseFloat(value, 64)
+		if err != nil {
+			t.Fatalf("parse Value %q (%q): %v", value, query, err)
+		}
+		out = append(out, dupTSSample{attributes: attributes, timestamp: timestamp, value: parsed})
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatalf("rows.Err(%q): %v", query, err)
+	}
+	if len(out) == 0 {
+		t.Fatalf("query %q returned no rows; the differential would compare two empty answers", query)
+	}
+	return dupTSAnswer{samples: out, sql: sqlText}
+}
+
+// assertDupTSStrategiesAgree pins the differential itself: the native strategy
+// and the fan-out strategy answer identically, row for row, over a seed whose
+// duplicate is the only thing that could separate them.
+//
+// It first asserts the two EMITTED STATEMENTS differ. Without that, a native
+// strategy that silently declined this shape and chained to its own Fallback
+// would make both legs run the identical SQL, and the comparison would pass by
+// comparing an answer with itself — the hollow green a differential is
+// supposed to be immune to.
+func assertDupTSStrategiesAgree(t *testing.T, nativeAnswer, fanoutAnswer dupTSAnswer) {
+	t.Helper()
+	if nativeAnswer.sql == fanoutAnswer.sql {
+		t.Fatalf("both strategies emitted the SAME SQL, so this compares an answer with itself; "+
+			"the native strategy declined this shape and fell back:\n%s", nativeAnswer.sql)
+	}
+	native, fanout := nativeAnswer.samples, fanoutAnswer.samples
+	if len(native) != len(fanout) {
+		t.Fatalf("native returned %d row(s), fan-out returned %d", len(native), len(fanout))
+	}
+	for i := range native {
+		n, f := native[i], fanout[i]
+		if n.attributes != f.attributes || n.timestamp != f.timestamp {
+			t.Fatalf("row %d: native is (%s, %s), fan-out is (%s, %s)",
+				i, n.attributes, n.timestamp, f.attributes, f.timestamp)
+		}
+		if math.Abs(n.value-f.value) > dupTSFloatTolerance {
+			t.Errorf("row %d (%s @ %s): native = %v, fan-out = %v; the two strategies must treat a "+
+				"duplicate (series, timestamp) identically", i, n.attributes, n.timestamp, n.value, f.value)
+		}
+	}
+}
+
+// dupTSValueAt returns the value of the single row matching attributes at the
+// LAST timestamp both strategies produced for it.
+func dupTSValueAt(t *testing.T, answer dupTSAnswer, attributes, timestamp string) float64 {
+	t.Helper()
+	for _, s := range answer.samples {
+		if s.attributes == attributes && s.timestamp == timestamp {
+			return s.value
+		}
+	}
+	t.Fatalf("no row for %s @ %s in %v", attributes, timestamp, answer.samples)
+	return 0
+}
+
+// assertNoDedup pins the CONTRACT rather than the agreement: the answer is the
+// one that counts every seeded sample, and it is NOT the one a deduplicating
+// path (or the reference engine's appender, which keeps a single sample per
+// timestamp) would produce.
+func assertNoDedup(t *testing.T, got, wantNoDedup, dedupedWouldBe float64, what string) {
+	t.Helper()
+	if math.Abs(got-wantNoDedup) > dupTSFloatTolerance {
+		t.Errorf("%s = %v, want %v (every seeded sample counted)", what, got, wantNoDedup)
+	}
+	if math.Abs(wantNoDedup-dedupedWouldBe) <= dupTSFloatTolerance {
+		t.Fatalf("%s: the no-dedup answer %v and the deduplicated answer %v are indistinguishable, "+
+			"so this case pins nothing about the contract", what, wantNoDedup, dedupedWouldBe)
+	}
+	if math.Abs(got-dedupedWouldBe) <= dupTSFloatTolerance {
+		t.Errorf("%s = %v, which is the DEDUPLICATED answer — the duplicate at 00:02:00 was dropped, "+
+			"inverting the contract this seed exists to pin", what, got)
+	}
+}
+
+// The window (00:00:00, 00:05:00] over job 'api' holds 5.0, 2.0, 3.0, 8.0,
+// 1.0, 6.0 with every sample counted, and loses 3.0 under deduplication.
+const (
+	dupTSAPISumNoDedup   = 25.0
+	dupTSAPISumDeduped   = 22.0
+	dupTSAPICountNoDedup = 6.0
+	dupTSAPICountDeduped = 5.0
+)
+
+// dupTSAPIAttributes is how the emitted `sum by(job)` / `avg by(job)`
+// projection renders job 'api', and dupTSHostAAttributes how the ungrouped
+// idelta projection renders host 'a'.
+const (
+	dupTSAPIAttributes   = `{'job':'api'}`
+	dupTSHostAAttributes = `{'host':'a'}`
+)
+
+// dupTSFinalAnchor is the range end, the anchor whose 5m window covers every
+// seeded sample including the duplicate.
+const dupTSFinalAnchor = "2026-01-01 00:05:00.000000000"
+
+// TestDuplicateTimestampSeed_SumOverTimeSortedSlabMatchesFanout is
+// sorted_slab_sum_over_time_range_step.txtar's contract, executed: the
+// sorted-slab reducer and the fan-out array fold must sum the SAME six
+// samples, duplicate included.
+func TestDuplicateTimestampSeed_SumOverTimeSortedSlabMatchesFanout(t *testing.T) {
+	fixture := newChDBFixture(t, dupTSOverTimeSeed)
+	query := "sum by(job) (sum_over_time(" + dupTSOverTimeMetric + "[5m]))"
+
+	native := runDupTSQuery(t, fixture, query, dupTSOverTimeStep, promql.RangeLowerers{
+		OverTime: promql.SortedSlabOverTimeLowerer{Fallback: promql.FanoutOverTimeLowerer{}},
+	})
+	fanout := runDupTSQuery(t, fixture, query, dupTSOverTimeStep, promql.RangeLowerers{})
+
+	assertDupTSStrategiesAgree(t, native, fanout)
+	assertNoDedup(t,
+		dupTSValueAt(t, native, dupTSAPIAttributes, dupTSFinalAnchor),
+		dupTSAPISumNoDedup, dupTSAPISumDeduped,
+		"sorted-slab sum_over_time at the final anchor")
+}
+
+// TestDuplicateTimestampSeed_AvgOverTimeSortedSlabMatchesFanout is
+// sorted_slab_avg_over_time_range_step.txtar's contract: the duplicate counts
+// in the DIVISOR too, so the answer is 25/6 rather than the reference
+// engine's 22/5.
+func TestDuplicateTimestampSeed_AvgOverTimeSortedSlabMatchesFanout(t *testing.T) {
+	fixture := newChDBFixture(t, dupTSOverTimeSeed)
+	query := "avg by(job) (avg_over_time(" + dupTSOverTimeMetric + "[5m]))"
+
+	native := runDupTSQuery(t, fixture, query, dupTSOverTimeStep, promql.RangeLowerers{
+		OverTime: promql.SortedSlabOverTimeLowerer{Fallback: promql.FanoutOverTimeLowerer{}},
+	})
+	fanout := runDupTSQuery(t, fixture, query, dupTSOverTimeStep, promql.RangeLowerers{})
+
+	assertDupTSStrategiesAgree(t, native, fanout)
+	assertNoDedup(t,
+		dupTSValueAt(t, native, dupTSAPIAttributes, dupTSFinalAnchor),
+		dupTSAPISumNoDedup/dupTSAPICountNoDedup, dupTSAPISumDeduped/dupTSAPICountDeduped,
+		"sorted-slab avg_over_time at the final anchor")
+}
+
+// TestDuplicateTimestampSeed_IdeltaLagAdjacencyMatchesFanout is
+// lag_adjacency_idelta_duplicate_ts.txtar's contract: the lagInFrame survivor
+// flag must select the SAME duplicate the array-fold path's
+// arraySort(groupArray((ts, value))) tuple order selects — the max-valued one
+// — so idelta is 10.0 - 5.0 and not the reference engine's 10.0 - 2.0.
+func TestDuplicateTimestampSeed_IdeltaLagAdjacencyMatchesFanout(t *testing.T) {
+	fixture := newChDBFixture(t, dupTSIdeltaSeed)
+	query := "idelta(" + dupTSIdeltaMetric + "[5m])"
+
+	native := runDupTSQuery(t, fixture, query, dupTSIdeltaStep, promql.RangeLowerers{
+		Idelta: promql.LagAdjacencyIdeltaLowerer{Fallback: promql.FanoutIdeltaLowerer{}},
+	})
+	fanout := runDupTSQuery(t, fixture, query, dupTSIdeltaStep, promql.RangeLowerers{})
+
+	assertDupTSStrategiesAgree(t, native, fanout)
+
+	// The last two samples in the window are 5.0 (the max-valued duplicate at
+	// 00:02:00) and 10.0 at 00:04:00. Deduplicating to the first-ingested 2.0
+	// makes the pair (2.0, 10.0) instead.
+	const (
+		lastSample               = 10.0
+		survivingDuplicate       = 5.0
+		firstIngestedDuplicate   = 2.0
+		ideltaNoDedup            = lastSample - survivingDuplicate
+		ideltaIfDuplicateDeduped = lastSample - firstIngestedDuplicate
+	)
+	assertNoDedup(t,
+		dupTSValueAt(t, native, dupTSHostAAttributes, dupTSFinalAnchor),
+		ideltaNoDedup, ideltaIfDuplicateDeduped,
+		"lag-adjacency idelta at the final anchor")
+}

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -194,6 +194,14 @@ pre-push:
     forbid-chplan-fn-literal:
       tags: discipline
       run: node .github/scripts/forbid-chplan-fn-literal.mjs
+    # Mirrors the CI gate of the same name: a `-- parity --` fixture must not
+    # seed two metric samples at one (series, timestamp) carrying different
+    # payloads. A pure-JS walk of the three spec corpora, comparable in cost
+    # to the chplan gate above, and it catches the mistake while the fixture
+    # is still being written rather than a CI round trip later. See #2905.
+    forbid-parity-duplicate-samples:
+      tags: discipline
+      run: node .github/scripts/forbid-parity-duplicate-samples.mjs
     # Mirrors the CI `repo-hygiene` gate's two checks:
     #   - binary:         rejects committed ELF/Mach-O/PE executables and
     #                     other binary artefacts tracked in git

--- a/test/regression/parity-enrolment-baselines/promql/baseline.txt
+++ b/test/regression/parity-enrolment-baselines/promql/baseline.txt
@@ -401,7 +401,6 @@ label_replace_regex_capture.txtar
 label_replace_shared_capture_name.txtar
 label_replace_truncated_shared_capture_name.txtar
 lag_adjacency_changes_nan_run.txtar
-lag_adjacency_idelta_duplicate_ts.txtar
 lag_adjacency_irate_delta_temporality_range.txtar
 lag_adjacency_resets_range_step.txtar
 last_over_time_exp_histogram_preserves.txtar
@@ -575,8 +574,6 @@ sort_by_label_natural_order.txtar
 sort_by_label_no_label.txtar
 sort_desc_descending.txtar
 sort_of_dropping_binop_exp_histogram.txtar
-sorted_slab_avg_over_time_range_step.txtar
-sorted_slab_sum_over_time_range_step.txtar
 sqrt_metric.txtar
 stddev_by_job.txtar
 stddev_over_time_window.txtar

--- a/test/spec/parity_exempt.go
+++ b/test/spec/parity_exempt.go
@@ -114,6 +114,43 @@ const (
 	// subquery_inner_anchor_synthesised.txtar, all enrolled with a real
 	// `parity:` section for exactly that reason).
 	ReasonVacuousEmptyInput = "vacuous-empty-input"
+
+	// ReasonDuplicateTimestampSeed covers a fixture whose seed
+	// DELIBERATELY carries two metric samples at one (series, timestamp)
+	// with DIFFERENT values, in order to pin how cerberus's own emitted
+	// shape treats that pair. Like [ReasonVacuousEmptyInput] this is a
+	// fact about the SEED rather than about the operator.
+	//
+	// Which of the two survives is implementation-defined on both sides.
+	// Prometheus's TSDB appender stores at most one sample per (series,
+	// timestamp): parityoracle/promql/oracle.go's appendSeries feeds a
+	// real teststorage head, and the second sample is dropped at commit,
+	// so the survivor is whichever arrived first — a fact about the
+	// appender and about ingestion order, not about PromQL. ClickHouse
+	// keeps both rows, and which one a lowering surfaces depends on the
+	// emitted shape: the sorted-slab over_time path sums both, the
+	// array-fold path's arraySort(groupArray((ts, value))) breaks the tie
+	// by VALUE, and the rate family deduplicates by design. So the
+	// reference has no answer for cerberus to agree with, however
+	// faithfully it reimplements the operator.
+	//
+	// The contract such a fixture pins is not lost with the enrolment: it
+	// is pinned by a cerberus-vs-cerberus differential over the same seed
+	// (internal/promql/duplicate_timestamp_seed_chdb_test.go), a sharper
+	// oracle than a reference backend for this question — it compares the
+	// strategy under test against the fan-out strategy it must agree
+	// with, rather than against an engine that discarded one of the
+	// samples before evaluating anything.
+	//
+	// This is NOT the reason for a duplicate whose rows carry IDENTICAL
+	// values. Prometheus still keeps one row there and ClickHouse still
+	// keeps two, so a counting reducer can still diverge — but that
+	// divergence has a RIGHT answer (the reference's) and cerberus can be
+	// made to match it, which is an ordinary bug to fix at the source
+	// rather than a structural claim.
+	// increase_duplicate_timestamp_dedup.txtar seeds exactly that, stays
+	// ENROLLED, and passes because the rate family deduplicates.
+	ReasonDuplicateTimestampSeed = "duplicate-timestamp-seed"
 )
 
 // parityExemptReasons is the single source of truth for the `reason`
@@ -125,6 +162,7 @@ var parityExemptReasons = []string{
 	ReasonNoComparableOracle,
 	ReasonRejectionOnly,
 	ReasonVacuousEmptyInput,
+	ReasonDuplicateTimestampSeed,
 }
 
 // ParityExemptReasons returns the accepted `reason` values, sorted.

--- a/test/spec/promql/lag_adjacency_idelta_duplicate_ts.txtar
+++ b/test/spec/promql/lag_adjacency_idelta_duplicate_ts.txtar
@@ -11,14 +11,22 @@
 # identical row (see range_window_lag_adjacency.go's doc). Window for the
 # 00:05:00 anchor is (00:00:00, 00:05:00]: samples 1.0, 2.0, 5.0, 10.0
 # sorted — idelta is the last two: 10.0 - 5.0 = 5.0 (NOT 10.0 - 2.0).
+#
+# That survivor selection is the whole subject of this fixture, and it is
+# also why it is parity-EXEMPT rather than enrolled (cerberus issue #2905):
+# Prometheus's TSDB appender keeps one sample per (series, timestamp), drops
+# 5.0 at commit and answers 10.0 - 2.0 = 8.0. Neither engine promises which
+# of the two survives, so agreement between them would be an accident. The
+# contract this fixture exists for is pinned instead, over this very seed, by
+# internal/promql/duplicate_timestamp_seed_chdb_test.go, which holds the
+# lag-adjacency answer against the fan-out array-fold answer it must equal.
 -- query.promql --
 idelta(temperature[5m])
 -- range_step --
 5m
--- parity --
-oracle: prometheus
-endpoint: /api/v1/query_range
-scope: full
+-- parity_exempt --
+reason: duplicate-timestamp-seed
+detail: host 'a' seeds 00:02:00 twice with 2.0 and 5.0 so the lagInFrame survivor flag must pick the same duplicate the array-fold path's arraySort tuple order picks; the reference engine's appender keeps only the first-ingested one and answers 8.0, a survivor neither engine promises.
 -- experimental_lag_adjacency_idelta --
 -- seed --
 CREATE TABLE otel_metrics_gauge (

--- a/test/spec/promql/sorted_slab_avg_over_time_range_step.txtar
+++ b/test/spec/promql/sorted_slab_avg_over_time_range_step.txtar
@@ -3,16 +3,23 @@
 # sorted_slab_sum_over_time_range_step.txtar, pinning avg_over_time's
 # nonEmptyWindowOrNaNFrag(arrayAvg(...)) reducer over the same sliced window.
 #
-# job 'api' carries a duplicate-timestamp pair (00:02:00 appears twice) to
-# pin the no-dedup contract (every sample counts individually, matching the
-# array-fold path, including in the divisor); job 'web' is a plain monotonic
-# series.
+# job 'api' carries a duplicate-timestamp pair (00:02:00 appears twice, with
+# DIFFERENT values 2.0 and 3.0) to pin the no-dedup contract (every sample
+# counts individually, matching the array-fold path, including in the
+# divisor); job 'web' is a plain monotonic series.
+#
+# That duplicate is why this fixture is parity-EXEMPT rather than enrolled
+# (cerberus issue #2905): Prometheus's TSDB appender keeps one sample per
+# (series, timestamp) and drops 3.0 at commit, so a reference comparison here
+# would assert that cerberus agrees with a survivor chosen by ingestion order.
+# The no-dedup contract is pinned instead, over this very seed, by
+# internal/promql/duplicate_timestamp_seed_chdb_test.go, which holds the
+# sorted-slab answer against the fan-out array-fold answer it must equal.
 -- query.promql --
 avg by(job) (avg_over_time(http_requests_total[5m]))
--- parity --
-oracle: prometheus
-endpoint: /api/v1/query_range
-scope: full
+-- parity_exempt --
+reason: duplicate-timestamp-seed
+detail: job 'api' seeds 00:02:00 twice with 2.0 and 3.0 to pin that avg_over_time's sorted-slab reducer counts both samples in numerator and divisor; the reference engine's appender keeps only the first-ingested one, so it has no answer to compare against.
 -- range_step --
 30s
 -- experimental_sorted_slab_over_time --

--- a/test/spec/promql/sorted_slab_sum_over_time_range_step.txtar
+++ b/test/spec/promql/sorted_slab_sum_over_time_range_step.txtar
@@ -4,15 +4,23 @@
 # RangeLowerers.OverTime = SortedSlabOverTimeLowerer, pinning the sorted-slab
 # SQL shape itself.
 #
-# job 'api' carries a duplicate-timestamp pair (00:02:00 appears twice) to
-# pin the no-dedup contract (every sample counts individually, matching the
-# array-fold path); job 'web' is a plain monotonic series.
+# job 'api' carries a duplicate-timestamp pair (00:02:00 appears twice, with
+# DIFFERENT values 2.0 and 3.0) to pin the no-dedup contract (every sample
+# counts individually, matching the array-fold path); job 'web' is a plain
+# monotonic series.
+#
+# That duplicate is why this fixture is parity-EXEMPT rather than enrolled
+# (cerberus issue #2905): Prometheus's TSDB appender keeps one sample per
+# (series, timestamp) and drops 3.0 at commit, so a reference comparison here
+# would assert that cerberus agrees with a survivor chosen by ingestion order.
+# The no-dedup contract is pinned instead, over this very seed, by
+# internal/promql/duplicate_timestamp_seed_chdb_test.go, which holds the
+# sorted-slab answer against the fan-out array-fold answer it must equal.
 -- query.promql --
 sum by(job) (sum_over_time(http_requests_total[5m]))
--- parity --
-oracle: prometheus
-endpoint: /api/v1/query_range
-scope: full
+-- parity_exempt --
+reason: duplicate-timestamp-seed
+detail: job 'api' seeds 00:02:00 twice with 2.0 and 3.0 to pin that sum_over_time's sorted-slab reducer counts both samples; the reference engine's appender keeps only the first-ingested one, so it has no answer to compare against.
 -- range_step --
 30s
 -- experimental_sorted_slab_over_time --


### PR DESCRIPTION
## The contradiction

A TXTAR fixture carrying `-- parity --` is answered twice: once by cerberus's own emitted SQL over
chDB, once by the real upstream Prometheus engine over the same seed. That contract only means
something where both engines promise an answer, and a duplicate metric sample is where the promise
runs out.

Prometheus's TSDB appender stores at most one sample per `(series, timestamp)` — `test/spec/
parityoracle/promql/oracle.go` feeds a real `teststorage` head, whose commit drops the second — so
the survivor is whichever arrived first, a fact about the appender and about ingestion order rather
than about PromQL. ClickHouse keeps both rows, and which one a lowering surfaces depends on the
emitted shape: the sorted-slab `over_time` path sums both, the array-fold path's
`arraySort(groupArray((ts, value)))` breaks the tie by VALUE, and the rate family deduplicates by
design.

So a fixture that both enrols for parity and seeds a differing-value duplicate asserts two claims
that cannot both hold. The class was exactly three fixtures, and one of them was a live red
`chdb / roundtrip-promql-shard` on `main`.

## Which intent each fixture serves

All three, read against their own header comments, exist to pin cerberus's contract — not to prove
parity. So in every case the duplicate stays and the enrolment goes.

| fixture | what its own comment says it pins |
|---|---|
| `sorted_slab_sum_over_time_range_step` | "the no-dedup contract (every sample counts individually, matching the array-fold path)" |
| `sorted_slab_avg_over_time_range_step` | the same, "including in the divisor" |
| `lag_adjacency_idelta_duplicate_ts` | the `leadInFrame` survivor flag must pick the *identical* duplicate the array-fold path's `arraySort` tuple order picks |

`lag_adjacency_idelta_duplicate_ts` is named for the duplicate and needed the most care. Its subject
IS the survivor selection — which is precisely the thing neither engine promises, so it is the least
enrollable of the three, not the most.

Dropping `-- parity --` alone would have failed `TestPromQLParityCoverageIsComplete`, which requires
every PromQL fixture to be either enrolled or exempt, never neither. So this adds a fifth
closed-vocabulary reason to `test/spec/parity_exempt.go`:

```
-- parity_exempt --
reason: duplicate-timestamp-seed
detail: <fixture-specific explanation>
```

It is a claim about the SEED, like the existing `vacuous-empty-input`, and it is deliberately narrow:
it does **not** cover a duplicate whose rows carry identical values. That divergence still exists
(Prometheus keeps one row, ClickHouse keeps two) but it has a RIGHT answer to converge on, so it is
an ordinary bug to fix at the source. `increase_duplicate_timestamp_dedup.txtar` seeds exactly such a
duplicate, stays enrolled, and passes because the rate family deduplicates — failing it would have
deleted the only fixture proving that contract against a real reference engine.

No `expected_rows` were regenerated, no skip list was added, and no tolerance file exists to add one
to.

## The contract is still pinned, harder than before

`internal/promql/duplicate_timestamp_seed_chdb_test.go` executes what the three fixtures existed for,
over the same seeds, as a cerberus-vs-cerberus differential: each strategy under test against the
fan-out strategy it must agree with. For this question that is a sharper oracle than a reference
backend, which discarded one of the samples before evaluating anything.

Two strategies agreeing proves they agree, not that they are right, so each case carries two more
assertions:

- the hand-derived **no-dedup** answer, plus an assertion that it **differs from the deduplicated
  answer** — so two strategies that both started deduplicating fail rather than quietly agree;
- that the two legs emitted **different SQL** — so a native strategy that declined the shape and
  chained to its own `Fallback` cannot pass by comparing an answer with itself.

Both were verified to actually fire, by mutating the expected constants and watching the test go red:

```
--- FAIL: TestDuplicateTimestampSeed_SumOverTimeSortedSlabMatchesFanout
    sorted-slab sum_over_time at the final anchor = 25, want 22 (every seeded sample counted)
    sorted-slab sum_over_time at the final anchor: the no-dedup answer 22 and the deduplicated
    answer 22 are indistinguishable, so this case pins nothing about the contract
--- FAIL: TestDuplicateTimestampSeed_IdeltaLagAdjacencyMatchesFanout
    lag-adjacency idelta at the final anchor = 5, want 8 (every seeded sample counted)
```

## The gate, shown failing before the fixtures were fixed

`.github/scripts/forbid-parity-duplicate-samples.mjs` fails when a fixture carrying `-- parity --`
also seeds two metric samples at one `(MetricName, labels, TimeUnix)` with different payloads. It
walks all three head corpora (`test/spec/promql`, `test/spec/logql`, `test/spec/traceql`), and it is
wired into the required `forbid-skip` job plus the pre-push lefthook.

Run against the tree **before** the fixtures were touched — this is the commit-1 state, and it is
exactly the three:

```
::error file=test/spec/promql/lag_adjacency_idelta_duplicate_ts.txtar::… seeds
  Attributes=map('host', 'a') MetricName='temperature' twice at 2026-01-01 00:02:00
  with differing payloads (Value=#2 vs Value=#5) …
::error file=test/spec/promql/sorted_slab_avg_over_time_range_step.txtar::… seeds
  Attributes=map('job', 'api') MetricName='http_requests_total' twice at 2026-01-01 00:02:00
  with differing payloads (Value=#2 vs Value=#3) …
::error file=test/spec/promql/sorted_slab_sum_over_time_range_step.txtar::… seeds
  Attributes=map('job', 'api') MetricName='http_requests_total' twice at 2026-01-01 00:02:00
  with differing payloads (Value=#2 vs Value=#3) …
forbid-parity-duplicate-samples: 3 violation(s) across 716 metric-seeded fixture(s).
```

**After**, on this branch:

```
::notice::forbid-parity-duplicate-samples: 803 parity-enrolled fixture(s) scanned, 713 carrying a
metric-shaped seed; no differing-value duplicate timestamps. 1 generated INSERT ... SELECT
statement(s) were not statically inspectable.
```

### How the gate decides what to look at

Structurally, never by a table-name list. A seeded table participates when its own DDL declares both
`MetricName` and `TimeUnix` — the OTel-CH metric contract `internal/schema/otel.go` fixes. Rows are
grouped **across** metric tables, because a `merge(otel_metrics_gauge|otel_metrics_sum)` scan reads
them as one series universe.

The one split is the classic histogram, read off the DDL too (a table declaring `ExplicitBounds`):
its rows reach the reference as `_bucket`/`_count`/`_sum` series, a namespace that cannot collide
with a bare-named sample. Writing the gate without that split produced a **fourth** hit —
`pinned_name_selector_no_histogram_fanout.txtar`, which seeds an `up` gauge row and a decoy `up`
classic-histogram row at one timestamp, and which is correct, enrolled and green. That false positive
is now a pinned negative control rather than a lesson someone re-learns.

`otel_logs` and `otel_traces` are scanned and never match, correctly: Loki keeps every line at a
timestamp and Tempo keys spans by span id, so neither reference store collapses them and neither can
produce this divergence. The day a LogQL or TraceQL fixture seeds a metric table, it is covered with
no change here.

A scan that parses **no** metric-shaped seed at all fails as a broken scan rather than reporting the
green a satisfied scan reports.

### Known blind spot, stated rather than hidden

A seed may fill a metric table from a generated `INSERT INTO ... SELECT` instead of a literal
`VALUES` list (`quantile_over_time_p95_exact_interp.txtar` seeds 10 000 rows from `numbers()`). Those
rows do not exist until the statement runs, so no static scan can group them. The gate counts such
statements and reports the count in its pass notice instead of pretending the corpus was fully
inspected.

### The gate's own suite

`forbid-parity-duplicate-samples.test.mjs` (17 cases, wired into `forbid-skip` so
`assert-gate-suites-wired` is satisfied) pins that the gate goes RED on the forbidden shape and stays
GREEN on the three neighbouring shapes that look similar and are legitimate — an identical-value
duplicate, a differing-value duplicate in an unenrolled fixture, and a gauge row sharing a series and
timestamp with a classic-histogram decoy. It also pins the two fail-closed paths: a vacuous scan
(no metric-shaped seed parsed at all) and a seeded row whose tuple arity does not match its column
list, which would mean the parser stopped understanding a seed shape rather than that the fixture is
odd. All 2562 metric rows across the three corpora align today.

## Verification, and what this PR's own CI cannot show

`roundtrip-promql-shard` is release-gated and SKIPS on pull requests (issue #2899), so **this PR's own
CI will not prove the red lane is fixed.** The evidence is a narrowed local reproduction of the exact
failure, before and after.

Before, on `origin/main` (`go test -tags chdb -run 'TestLower/(sorted_slab_sum_over_time_range_step|sorted_slab_avg_over_time_range_step|lag_adjacency_idelta_duplicate_ts)$' ./internal/promql/`):

```
--- FAIL: TestLower/lag_adjacency_idelta_duplicate_ts
    value differs   reference: 8    cerberus: 5
--- FAIL: TestLower/sorted_slab_avg_over_time_range_step
    value differs   reference: 2.6666666666666665   cerberus: 2.75      (and 6 more)
--- FAIL: TestLower/sorted_slab_sum_over_time_range_step
    value differs   reference: 8    cerberus: 11                        (and 6 more)
FAIL
```

Every gap is exactly the discarded sample: sum 25 vs 22, avg 25/6 vs 22/5, idelta 10−5 vs 10−2.

After, same command on this branch:

```
ok  github.com/tsouza/cerberus/internal/promql  2.057s
```

Also run locally: the new differential (3/3 pass, and red under mutation), the gate suite (17/17),
`assert-gate-suites-wired`, `ci-lane-contract`, `actionlint`, `forbid-skip` (all five checks), and
`TestParitySectionsParse` / `TestParityExemptSectionsParse` / `TestPromQLParityCoverageIsComplete` /
`TestParityExemptVocabulariesAreClosed`.

`TestParityEnrolmentBaseline` drifts by exactly the three de-enrolled fixtures, as it should;
`test/regression/parity-enrolment-baselines/promql/baseline.txt` is regenerated through
`update-golden.yml` (shard `parity`), since `just update-golden` is blocked in agent worktrees.

Closes #2905

🤖 Generated with [Claude Code](https://claude.com/claude-code)
