### PR TITLE
fix(ci): stop scoring a starved mutation runner as a strong test suite

### DIFF
--- a/.github/scripts/README.md
+++ b/.github/scripts/README.md
@@ -915,7 +915,12 @@ what actually runs.
     `run_heavy=true`, logged via `::notice::`, never a hard failure); `1` on an
     unrecognised `MODE`.
 - **`gremlins-threshold.mjs`** — `mutation.yml`, the
-  `enforce efficacy threshold` step.
+  `enforce efficacy threshold` step. Gates on `killed / (killed + lived +
+  timedOut)`, the kill rate over every mutant the runner ATTEMPTED to
+  adjudicate, rather than on gremlins' own `killed / (killed + lived)`. A
+  timed-out mutant is unadjudicated, not detected, so moving one into
+  `TIMED OUT` can never raise the score and a starved runner reads as red
+  rather than as a flattering green (#2903).
   - Env: `REPORT` (default `gremlins.json`), `THRESHOLD` (a number).
   - Exit: `0` when efficacy is `>=` threshold, `1` when below.
 - **`mutation-phases.mjs`** — data, imported by `mutation-matrix.mjs`. The single
@@ -961,9 +966,20 @@ what actually runs.
   phase. A non-empty `DIFF_REF` first invokes gremlins' native merge-base
   `--diff` filter; if that report executed zero mutants (a comment-only or
   otherwise mutation-free edit), it deletes the report and reruns the phase in
-  full rather than letting a hollow incremental run report green.
-  - Env: `SCOPE`, `REPORT`, `MUTANT_TIMEOUT_MAX` (required); `WORKERS`,
-    `EXCLUDE_FILES`, `DIFF_REF` (optional).
+  full rather than letting a hollow incremental run report green. Also derives
+  the per-mutant budget by MEASURING this leg's own recompile+link+run cycle on
+  this runner — it edits a byte of the scope's largest production file, times
+  the scope's tests as gremlins runs them for a mutant, restores the file, and
+  scales the result by the concurrent-mutant count and a named headroom. The
+  flat budget it replaced bounded a `go test` child that is 80-98%
+  COMPILATION, so a contended runner starved ordinary mutants into `TIMED OUT`
+  (#2903).
+  - Env: `SCOPE`, `REPORT`, `MUTANT_TIMEOUT_MIN`, `MUTANT_TIMEOUT_MAX`
+    (required); `WORKERS`, `EXCLUDE_FILES`, `DIFF_REF` (optional).
+    `MUTANT_TIMEOUT_MIN` is the floor the measurement may raise but never
+    lower, so an unmeasurable cycle leaves the lane where it was;
+    `MUTANT_TIMEOUT_MAX` is the ceiling, so one pathological measurement
+    cannot spend the job's whole wall clock on hung mutants.
   - Exit: `0` when the final report executed at least one mutant; `1` on a bad
     env value, a pre-existing report at `REPORT`, a gremlins invocation
     failure, or zero mutants surviving the full fallback.

--- a/.github/scripts/gremlins-threshold.mjs
+++ b/.github/scripts/gremlins-threshold.mjs
@@ -12,42 +12,72 @@
 // no measured-vs-threshold numbers. Gating after the report is written keeps
 // both. Do not "simplify" this by passing --threshold-efficacy.
 //
-// Reproduces the original bash exactly:
+// A TIMED-OUT MUTANT IS AN UNADJUDICATED MUTANT, AND COUNTS AGAINST THE SCORE.
 //
-//   measured=$(jq -r '.test_efficacy' gremlins.json)
-//   if awk 'BEGIN { exit (m < t) ? 1 : 0 }'; then  # m < t  -> fail
-//     ::notice:: measured >= threshold
-//   else
-//     ::error::  measured <  threshold ; exit 1
-//
-// The comparison is `measured < threshold` -> FAIL (strict less-than),
-// i.e. `measured >= threshold` passes. Matches the awk `m < t` semantics.
-//
-// A TIMED-OUT MUTANT IS A DETECTED MUTANT, and gremlins counts it as neither
-// killed nor lived.
+// This is the property the whole gate rests on, so it is worth stating as a
+// rule rather than as a formula: THE SCORE MUST BE MONOTONE NON-INCREASING IN
+// THE TIMEOUT COUNT. Moving one mutant from any other status into TIMED OUT may
+// never raise the number this gate reads. A gate that violates that rule pays a
+// slower runner in efficacy points, and a green run then proves that the
+// machine was busy rather than that the tests are strong.
 //
 // gremlins excludes TIMED_OUT from BOTH sides of its own verdict
 // (internal/report/report.go: `tEfficacy = killed / (killed + lived)` and
-// `MutantsTotal = lived + killed + notViable`), so a leg where most mutants time
-// out reports a confident-looking ratio computed over the few that did not. Run
-// 33156989462's `phase2-builder` reported 97.50% over 40 of 399 mutants; 279
-// timed out and appear in no number the gate could previously read.
+// `MutantsTotal = lived + killed + notViable`), so its ratio VIOLATES that rule
+// in the worst way — a timeout leaves the denominator entirely, so starving the
+// runner raises the score. This gate therefore recomputes efficacy over every
+// mutant the runner ATTEMPTED to adjudicate, timeouts included:
 //
-// The orthodox reading, and the one the measurements support, is that those 279
-// were KILLED. `internal/chsql` recompiles, links and runs in 1.04s at eight
-// cores and 2.42s at one, against a 15s budget — a 6x-15x margin — so a mutant
-// that exhausts it did not do so because the machine was slow. It did so because
-// the mutation broke termination, which is exactly what negating a conditional
-// in a RECURSIVE renderer does: the mutator statistics put the timeouts in
-// CONDITIONALS_NEGATION (75%) and CONDITIONALS_BOUNDARY (93%), not in
-// INVERT_LOOPCTRL (4 mutants in the whole leg). The suite caught each one by
-// hanging on it.
+//   efficacy = killed / (killed + lived + timedOut)
 //
-// Efficacy is therefore recomputed here with timeouts counted as detections.
-// That is MORE permissive than gremlins' own ratio, which is why it is paired
-// with minCompletedMutants: the one thing this must never wave through is
-// #2692's budget collapse, where nothing completed and the timeouts prove
-// nothing about the tests.
+// which is monotone by construction, and is never above the ratio gremlins
+// reported.
+//
+// Why the opposite reading was wrong (cerberus issue #2903)
+// --------------------------------------------------------
+// This gate previously counted a timeout as a DETECTION, on the premise that a
+// mutant which exhausts the per-mutant budget "did not do so because the
+// machine was slow — it did so because the mutation broke termination". The
+// premise was checked against `internal/chsql`'s recursive renderer and looked
+// sound there. It is false, and it is false on that very leg.
+//
+// The budget wraps the whole `go test` child, which is a RECOMPILE, a LINK and
+// then a run. Measured per mutant, on an 8-core machine, against the 15s budget
+// those legs ran under:
+//
+//   internal/chsql   compile+link 12.7-14.4s   test run 0.31s
+//   internal/promql  compile+link  8.4-8.7s    test run 2.07s
+//
+// The compiler is 80-98% of the budget and the mutant's own execution is a
+// rounding error, so TIMED OUT records "the compiler was slow today", not
+// "this mutation stopped the suite terminating".
+//
+// Two signatures in the real reports confirm it:
+//
+//   - Runs 33542904091 (red) and 33551271099 (green) on `phase4-promql-lower`
+//     recorded the SAME 486 kills. The whole 94.00% -> 97.01% swing was 16
+//     mutants moving LIVED -> TIMED OUT, and the green runner was the SLOWER
+//     one (coverage 53.2s vs 36.8s). Matching mutants across the two revisions
+//     by source text, 18 of the red run's 31 survivors — short-circuit boolean
+//     guards and slice-capacity arithmetic, none of which can unbound a loop —
+//     were booked as detections on the green run.
+//
+//   - gremlins runs each mutant with `-failfast`, so a KILLED mutant exits at
+//     its first failing test while a LIVED mutant must run the suite to the
+//     end. Budget starvation therefore converts SURVIVORS preferentially. Run
+//     33522074818 shows the endpoint of that bias: all four `internal/chsql`
+//     legs reported 100.00% with `lived: 0`, over 1266 mutants of which 1230
+//     timed out.
+//
+// Counting timeouts as detections scored that last case — a leg that
+// adjudicated 3% of its mutants and found no survivor because it never ran long
+// enough to see one — as a perfect leg.
+//
+// The paired defence is the per-mutant budget itself: .github/scripts/
+// mutation-run.mjs now MEASURES the leg's own recompile+link+run cycle and
+// sizes the budget from it, so an honest leg has few timeouts to spend. This
+// gate is what makes that safe to get wrong in the tight direction — an
+// undersized budget now shows up as a RED leg rather than as a flattering one.
 //
 // Counts come from `files[].mutations[].status`, the per-mutant record, because
 // no aggregate field in the report exposes the timed-out total.
@@ -56,9 +86,8 @@
 //   REPORT     path to the gremlins JSON report   (default: gremlins.json)
 //   THRESHOLD  efficacy floor as a number, e.g. 95
 //
-// Exit codes: 0 = efficacy >= threshold both as gremlins reports it and with
-// timeouts counted as detections, 1 = below either / nothing completed / bad
-// input.
+// Exit codes: 0 = efficacy over the attempted mutants >= threshold, 1 = below
+// it / nothing completed / bad input.
 
 import { readFileSync } from 'node:fs';
 import process from 'node:process';
@@ -68,12 +97,11 @@ import { error, notice } from './lib/gh.mjs';
 // minCompletedMutants is how many mutants must reach a NORMAL verdict (KILLED
 // or LIVED) before this leg's numbers describe anything.
 //
-// This guards the BUDGET-COLLAPSE signature, not pathological mutants. When the
-// per-mutant budget collapsed (#2692) the leg reported Killed 0 / Lived 0 /
-// Timed out 295: nothing ran, so the timeouts are evidence about the budget
-// rather than about the tests. Counting them as detections — which is what this
-// gate otherwise does — would score that 295/295 = 100%, so the collapse needs
-// its own floor and cannot be caught by a ratio.
+// This guards the BUDGET-COLLAPSE signature (#2692), where the leg reported
+// Killed 0 / Lived 0 / Timed out 295. The ratio above already fails that case —
+// 0/295 is 0% — but it fails it with the message of a weak test suite, and the
+// remedy for a collapsed budget is not "write more tests". The floor exists to
+// name the right cause.
 //
 // One is the honest minimum: it separates "nothing completed" from "something
 // did". Any larger figure would be a guess about how many mutants a leg ought
@@ -105,16 +133,18 @@ export function countMutationStatuses(report) {
   return { total, timedOut, killed, lived };
 }
 
-// detectedEfficacy is the kill rate with timeouts counted as detections, or
-// null when no mutant reached any verdict at all.
-export function detectedEfficacy({ killed, lived, timedOut }) {
-  const detected = killed + timedOut;
-  if (detected + lived === 0) return null;
-  return (detected / (detected + lived)) * 100;
+// attemptedEfficacy is the kill rate over every mutant the runner ATTEMPTED to
+// adjudicate — killed, survived, or ran out of budget — or null when it
+// attempted none. A timeout is an unknown, and an unknown is not a kill, so it
+// sits in the denominator only.
+export function attemptedEfficacy({ killed, lived, timedOut }) {
+  const attempted = killed + lived + timedOut;
+  if (attempted === 0) return null;
+  return (killed / attempted) * 100;
 }
 
-// main runs the gate. Guarded below so a test can import
-// countMutationStatuses without the import running the gate as a side effect.
+// main runs the gate. Guarded below so a test can import the helpers without
+// the import running the gate as a side effect.
 function main() {
   const reportPath = process.env.REPORT || 'gremlins.json';
   const thresholdRaw = process.env.THRESHOLD;
@@ -138,24 +168,27 @@ function main() {
     process.exit(1);
   }
 
-  const measured = Number(report.test_efficacy);
-  if (!Number.isFinite(measured)) {
+  // Read but do not gate on gremlins' own ratio. It is killed/(killed+lived),
+  // which is always >= the ratio gated below, so a comparison against it could
+  // never fire where the one below passed. It is still parsed so that a rename
+  // or a malformed report fails loudly instead of being scored as zero
+  // timeouts, and it is reported so the log shows both numbers.
+  const reported = Number(report.test_efficacy);
+  if (!Number.isFinite(reported)) {
     // jq -r '.test_efficacy' on a missing key yields "null"; surface that.
     error(`gremlins-threshold.mjs: .test_efficacy missing or non-numeric in ${reportPath}`);
     process.exit(1);
   }
 
-  // awk `m < t` -> exit 1 (fail). So measured < threshold fails the gate.
-  if (measured < threshold) {
-    error(`gremlins efficacy ${measured}% < threshold ${threshold}%`);
-    process.exit(1);
-  }
-
   const counts = countMutationStatuses(report);
   if (counts.total === 0) {
-    // No per-mutation records to recompute from; gremlins' own ratio already
-    // cleared the bar above.
-    notice(`gremlins efficacy ${measured}% >= threshold ${threshold}%`);
+    // No per-mutation records to recompute from. There is nothing to say about
+    // timeouts, so gremlins' own ratio is the only number available.
+    if (reported < threshold) {
+      error(`gremlins efficacy ${reported}% < threshold ${threshold}%`);
+      process.exit(1);
+    }
+    notice(`gremlins efficacy ${reported}% >= threshold ${threshold}%`);
     process.exit(0);
   }
 
@@ -164,26 +197,32 @@ function main() {
     error(
       `gremlins completed ${completed} mutant(s) — killed ${counts.killed}, lived ${counts.lived}, ` +
         `with ${counts.timedOut} timed out of ${counts.total}. Nothing ran to a verdict, so neither ` +
-        `the reported ${measured}% nor the timeouts say anything about this package: this is the ` +
+        `the reported ${reported}% nor the timeouts say anything about this package: this is the ` +
         `per-mutant budget collapsing, not the tests failing (#2692).`,
     );
     process.exit(1);
   }
 
-  // No second threshold comparison here, deliberately. Counting timeouts into
-  // both the numerator and the denominator moves the ratio TOWARD 100%, so the
-  // detected rate is always >= the rate gremlins reported: a leg that cleared
-  // the bar above clears it again by construction. Gating on it would be dead
-  // code that reads like a second opinion.
-  const detected = detectedEfficacy(counts);
+  const measured = attemptedEfficacy(counts);
+  const attempted = counts.killed + counts.lived + counts.timedOut;
+
+  if (measured < threshold) {
+    error(
+      `gremlins efficacy ${measured.toFixed(2)}% < threshold ${threshold}% — ` +
+        `killed ${counts.killed} of ${attempted} attempted (lived ${counts.lived}, ` +
+        `timed out ${counts.timedOut}). A timed-out mutant is unadjudicated, not detected: ` +
+        `it counts against this ratio (#2903). gremlins reported ${reported}% over killed+lived only.`,
+    );
+    process.exit(1);
+  }
 
   if (counts.timedOut > 0) {
     notice(
-      `gremlins timed out ${counts.timedOut}/${counts.total} mutants, counted as detected: ` +
-        `efficacy ${detected.toFixed(2)}% (gremlins reported ${measured}% over killed+lived only)`,
+      `gremlins timed out ${counts.timedOut}/${counts.total} mutants, counted as unadjudicated: ` +
+        `efficacy ${measured.toFixed(2)}% (gremlins reported ${reported}% over killed+lived only)`,
     );
   }
-  notice(`gremlins efficacy ${measured}% >= threshold ${threshold}%`);
+  notice(`gremlins efficacy ${measured.toFixed(2)}% >= threshold ${threshold}%`);
   process.exit(0);
 }
 

--- a/.github/scripts/gremlins-threshold.test.mjs
+++ b/.github/scripts/gremlins-threshold.test.mjs
@@ -4,6 +4,12 @@
 // reason. A gate that only ever sees healthy reports is indistinguishable from
 // one that reads nothing — and this script guards a number that gremlins
 // computes over a subset of the mutants it ran.
+//
+// The load-bearing case is the pair taken from runs 33542904091 /
+// 33551271099: the same commit range, the same 486 kills, and the SLOWER
+// runner scoring three points higher under the old reading (#2903). It is
+// pinned here as a regression test because it is the shape a gate cannot be
+// allowed to reward.
 
 import assert from 'node:assert/strict';
 import { execFileSync } from 'node:child_process';
@@ -12,7 +18,7 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import test from 'node:test';
 
-import { countMutationStatuses, detectedEfficacy } from './gremlins-threshold.mjs';
+import { attemptedEfficacy, countMutationStatuses } from './gremlins-threshold.mjs';
 
 const script = new URL('./gremlins-threshold.mjs', import.meta.url).pathname;
 
@@ -25,84 +31,196 @@ function mutations({ killed = 0, lived = 0, timedOut = 0 }) {
   return [{ file_name: 'a.go', mutations: out }];
 }
 
-function run(report, threshold) {
+// gremlinsReported is gremlins' own ratio, killed/(killed+lived), which the
+// report carries as `test_efficacy`. Computed rather than hand-written so a
+// case cannot accidentally pair counts with an inconsistent report field.
+function gremlinsReported({ killed, lived }) {
+  return (killed / (killed + lived)) * 100;
+}
+
+function run(counts, threshold) {
   const dir = mkdtempSync(join(tmpdir(), 'gremlins-threshold-'));
   const path = join(dir, 'gremlins.json');
-  writeFileSync(path, JSON.stringify(report));
+  writeFileSync(
+    path,
+    JSON.stringify({ test_efficacy: gremlinsReported(counts), files: mutations(counts) }),
+  );
   try {
-    return { code: 0, out: execFileSync('node', [script], {
-      env: { ...process.env, REPORT: path, THRESHOLD: String(threshold) },
-      encoding: 'utf8',
-    }) };
+    return {
+      code: 0,
+      out: execFileSync('node', [script], {
+        env: { ...process.env, REPORT: path, THRESHOLD: String(threshold) },
+        encoding: 'utf8',
+      }),
+    };
   } catch (e) {
     return { code: e.status, out: `${e.stdout ?? ''}${e.stderr ?? ''}` };
   }
 }
 
+// The two runs the gate was rewritten for. Same leg, same 486 kills; the green
+// run's machine was 44% slower (coverage 53.2s vs 36.8s) and 16 of the red
+// run's survivors were booked as timeouts on it.
+const promqlLowerRed = { killed: 486, lived: 31, timedOut: 4 };
+const promqlLowerStarved = { killed: 486, lived: 15, timedOut: 36 };
+
 test('a healthy leg passes', () => {
   // Real phase4-promql-g numbers.
-  const r = run({ test_efficacy: 99.65, files: mutations({ killed: 286, lived: 1, timedOut: 8 }) }, 95);
+  assert.equal(run({ killed: 286, lived: 1, timedOut: 8 }, 95).code, 0);
+});
+
+test('a leg that genuinely killed its mutants passes with no timeouts at all', () => {
+  // The shape a correctly-budgeted leg produces: every mutant adjudicated.
+  const r = run({ killed: 990, lived: 32, timedOut: 0 }, 95);
   assert.equal(r.code, 0, r.out);
+  assert.doesNotMatch(r.out, /timed out/);
 });
 
 test('efficacy below the threshold still fails', () => {
-  const r = run({ test_efficacy: 90, files: mutations({ killed: 90, lived: 10 }) }, 95);
+  const r = run({ killed: 90, lived: 10 }, 95);
   assert.equal(r.code, 1);
   // gh.mjs percent-encodes `%` into the workflow command, so match around it.
   assert.match(r.out, /efficacy 90\S* < threshold 95/);
 });
 
-// A mutant that exhausts a 15s budget against a 1-2.4s baseline broke
-// termination — the suite caught it by hanging. Real phase2-builder numbers,
-// which gremlins itself scored 97.50% over 40 of 399.
-test('timed-out mutants count as detected', () => {
-  const r = run({ test_efficacy: 97.5, files: mutations({ killed: 39, lived: 1, timedOut: 279 }) }, 95);
-  assert.equal(r.code, 0, r.out);
-  assert.match(r.out, /timed out 279\/319 mutants, counted as detected/);
+// #2903. The starved run of a leg must not outscore the honest one, and must
+// not pass a bar the honest one failed.
+test('the starved run of a leg scores BELOW the run it was compared against', () => {
+  const red = attemptedEfficacy(promqlLowerRed);
+  const starved = attemptedEfficacy(promqlLowerStarved);
+  assert.ok(
+    starved < red,
+    `the slower runner scored ${starved} against ${red}: a timeout is still paying efficacy`,
+  );
+  // And the gate agrees with the arithmetic, in both directions.
+  assert.equal(run(promqlLowerRed, 95).code, 1, 'the red run must stay red');
+  const r = run(promqlLowerStarved, 95);
+  assert.equal(r.code, 1, `the starved run must not pass where the red one failed: ${r.out}`);
+  assert.match(r.out, /timed out 36/);
 });
 
-// The case counting-as-detected must never wave through: nothing completed, so
-// the timeouts describe the budget rather than the tests (#2692).
-test('a leg where nothing completed fails, even though every mutant timed out', () => {
-  const r = run({ test_efficacy: 0, files: mutations({ timedOut: 295 }) }, 0);
-  assert.equal(r.code, 1, 'a total budget collapse must not score 295/295 = 100%');
-  assert.match(r.out, /completed 0 mutant/);
+// The endpoint of the same bias, from run 33522074818's phase2-builder: a leg
+// that adjudicated 22 of 345 mutants, found no survivor because it never ran
+// long enough to see one, and reported a perfect score.
+test('a leg that adjudicated 6% of its mutants cannot report 100%', () => {
+  const counts = { killed: 22, lived: 0, timedOut: 323 };
+  assert.equal(gremlinsReported(counts), 100);
+  const r = run(counts, 95);
+  assert.equal(r.code, 1, `100% over 22 of 345 mutants must not pass: ${r.out}`);
+  assert.match(r.out, /killed 22 of 345 attempted/);
 });
 
-test('the detected rate is never below the rate gremlins reported', () => {
-  // Counting timeouts into numerator AND denominator moves the ratio toward
-  // 100%, so there is no report on which a second threshold comparison could
-  // fire. Pinned so nobody re-adds one as a "second opinion" — it would be
-  // dead code, and dead code in a gate reads as coverage.
+// The rule the whole gate rests on, checked as a property rather than on one
+// report: moving a mutant into TIMED OUT may never raise the score. Under the
+// reading this replaced — timeouts as detections — every one of these pairs
+// moved the wrong way.
+test('moving any mutant into TIMED OUT never raises the score', () => {
   for (const [killed, lived, timedOut] of [
+    [486, 31, 4],
+    [39, 1, 279],
+    [5, 40, 5],
+    [1, 1, 0],
+    [0, 7, 3],
+    [990, 32, 0],
+  ]) {
+    const base = attemptedEfficacy({ killed, lived, timedOut });
+    if (lived > 0) {
+      const fromLived = attemptedEfficacy({ killed, lived: lived - 1, timedOut: timedOut + 1 });
+      assert.ok(fromLived <= base, `LIVED -> TIMED OUT raised ${base} to ${fromLived}`);
+    }
+    if (killed > 0) {
+      const fromKilled = attemptedEfficacy({ killed: killed - 1, lived, timedOut: timedOut + 1 });
+      assert.ok(fromKilled <= base, `KILLED -> TIMED OUT raised ${base} to ${fromKilled}`);
+    }
+  }
+});
+
+test('the gated rate is never above the rate gremlins reported', () => {
+  // gremlins drops timeouts from both sides; this gate keeps them in the
+  // denominator. So this gate is strictly the stricter of the two, which is
+  // why gremlins' own ratio is reported here but not compared against.
+  for (const [killed, lived, timedOut] of [
+    [486, 15, 36],
     [39, 1, 279],
     [5, 40, 5],
     [1, 1, 0],
     [0, 7, 3],
   ]) {
-    const reported = (killed / (killed + lived)) * 100;
-    const detected = detectedEfficacy({ killed, lived, timedOut });
-    assert.ok(
-      detected >= reported - Number.EPSILON,
-      `detected ${detected} < reported ${reported} for ${killed}/${lived}/${timedOut}`,
-    );
+    const reported = gremlinsReported({ killed, lived });
+    const gated = attemptedEfficacy({ killed, lived, timedOut });
+    assert.ok(gated <= reported + Number.EPSILON, `gated ${gated} > reported ${reported}`);
   }
+});
+
+// The budget-collapse signature keeps its own message: 0/295 already fails the
+// ratio, but "your tests are weak" is the wrong diagnosis for a broken budget.
+test('a leg where nothing completed fails, and names the budget rather than the tests', () => {
+  const r = run({ timedOut: 295 }, 0);
+  assert.equal(r.code, 1, 'a total budget collapse must not pass even at a zero threshold');
+  assert.match(r.out, /completed 0 mutant/);
+  assert.match(r.out, /budget collapsing/);
 });
 
 test('countMutationStatuses matches only the exact status strings', () => {
   const c = countMutationStatuses({
-    files: [{ mutations: [{ status: 'TIMED OUT' }, { status: 'TIMEDOUT' }, { status: 'KILLED' }, { status: 'LIVED' }] }],
+    files: [
+      {
+        mutations: [
+          { status: 'TIMED OUT' },
+          { status: 'TIMEDOUT' },
+          { status: 'KILLED' },
+          { status: 'LIVED' },
+        ],
+      },
+    ],
   });
   assert.deepEqual(c, { total: 4, timedOut: 1, killed: 1, lived: 1 });
 });
 
-test('detectedEfficacy reports null when no mutant reached a verdict', () => {
-  assert.equal(detectedEfficacy({ killed: 0, lived: 0, timedOut: 0 }), null);
-  assert.equal(detectedEfficacy({ killed: 1, lived: 1, timedOut: 2 }), 75);
+test('attemptedEfficacy reports null when the runner attempted nothing', () => {
+  assert.equal(attemptedEfficacy({ killed: 0, lived: 0, timedOut: 0 }), null);
+  assert.equal(attemptedEfficacy({ killed: 1, lived: 1, timedOut: 2 }), 25);
 });
 
 test('a report with no per-mutation records falls back to the reported ratio', () => {
-  const r = run({ test_efficacy: 99, files: [] }, 95);
-  assert.equal(r.code, 0);
-  assert.doesNotMatch(r.out, /timed out/);
+  const dir = mkdtempSync(join(tmpdir(), 'gremlins-threshold-'));
+  const path = join(dir, 'gremlins.json');
+  writeFileSync(path, JSON.stringify({ test_efficacy: 99, files: [] }));
+  const out = execFileSync('node', [script], {
+    env: { ...process.env, REPORT: path, THRESHOLD: '95' },
+    encoding: 'utf8',
+  });
+  assert.doesNotMatch(out, /timed out/);
+});
+
+test('a report with no per-mutation records still fails below the threshold', () => {
+  const dir = mkdtempSync(join(tmpdir(), 'gremlins-threshold-'));
+  const path = join(dir, 'gremlins.json');
+  writeFileSync(path, JSON.stringify({ test_efficacy: 90, files: [] }));
+  assert.throws(
+    () =>
+      execFileSync('node', [script], {
+        env: { ...process.env, REPORT: path, THRESHOLD: '95' },
+        encoding: 'utf8',
+        stdio: 'pipe',
+      }),
+    /./,
+  );
+});
+
+test('a missing test_efficacy fails rather than being scored as zero timeouts', () => {
+  const dir = mkdtempSync(join(tmpdir(), 'gremlins-threshold-'));
+  const path = join(dir, 'gremlins.json');
+  writeFileSync(path, JSON.stringify({ files: mutations({ killed: 100 }) }));
+  let out = '';
+  try {
+    execFileSync('node', [script], {
+      env: { ...process.env, REPORT: path, THRESHOLD: '95' },
+      encoding: 'utf8',
+    });
+    assert.fail('a report with no test_efficacy must not pass');
+  } catch (e) {
+    out = `${e.stdout ?? ''}${e.stderr ?? ''}`;
+  }
+  assert.match(out, /test_efficacy missing or non-numeric/);
 });

--- a/.github/scripts/mutation-run.mjs
+++ b/.github/scripts/mutation-run.mjs
@@ -1,6 +1,8 @@
-// mutation-run.mjs — run one mutation phase with safe changed-line fallback.
+// mutation-run.mjs — run one mutation phase with safe changed-line fallback,
+// under a per-mutant budget MEASURED from this leg's own recompile+link+run
+// cycle on this runner.
 //
-// Required env: SCOPE, REPORT, MUTANT_TIMEOUT_MAX.
+// Required env: SCOPE, REPORT, MUTANT_TIMEOUT_MIN, MUTANT_TIMEOUT_MAX.
 // Optional env: WORKERS, EXCLUDE_FILES, DIFF_REF.
 //
 // A non-empty DIFF_REF first invokes gremlins' native merge-base line filter.
@@ -8,11 +10,13 @@
 // reruns the phase without --diff. This makes comment-only or otherwise
 // mutation-free edits conservative full checks instead of hollow greens.
 //
-// Both invocations pin --timeout-coefficient so MUTANT_TIMEOUT_MAX is the sole
+// Both invocations pin --timeout-coefficient so the derived budget is the sole
 // per-mutant budget; see perMutantBudgetIsTheCeilingCoefficient below.
 
 import { spawnSync } from 'node:child_process';
-import { existsSync, readFileSync, unlinkSync } from 'node:fs';
+import { existsSync, readdirSync, readFileSync, statSync, unlinkSync, writeFileSync } from 'node:fs';
+import { availableParallelism } from 'node:os';
+import { join, resolve } from 'node:path';
 import process from 'node:process';
 
 import { error, notice } from './lib/gh.mjs';
@@ -26,12 +30,28 @@ import { error, notice } from './lib/gh.mjs';
 // the zero-mutant fallback below re-invokes gremlins in the same job with the
 // cache already warmed by the first invocation, the coverage pass collapses
 // from ~50s to ~0.4s, `baseTime` clamps to gremlins' own 1s floor, and the
-// budget silently drops to 5s — under `internal/promql`'s real ~6.6s
+// budget silently drops to 5s — under `internal/promql`'s real per-mutant
 // recompile+link+run cost, so every mutant times out and the leg reports 0.00%
-// efficacy. Declaring the coefficient as `ceil(ceiling / 1s floor)` makes
-// `coefficient * max(elapsed, 1s)` at least the ceiling for any elapsed time,
-// so the budget is exactly MUTANT_TIMEOUT_MAX on every invocation.
+// efficacy (#2692). Declaring the coefficient as `ceil(budget / 1s floor)`
+// makes `coefficient * max(elapsed, 1s)` at least the budget for any elapsed
+// time, so the budget is exactly the value derived below on every invocation.
 const gremlinsCoverageBaselineFloorSeconds = 1;
+
+// perMutantRunnerVarianceHeadroom is the multiple applied over the measured
+// cycle to absorb how much slower this runner may get AFTER the probe ran.
+//
+// Not a guess: runs 33542904091 and 33551271099 are the same leg an hour apart,
+// and the second runner took 53.2s to gather coverage where the first took
+// 36.8s — 44% slower on identical work. Doubling clears that with margin.
+//
+// Erring high is the cheap direction. A budget larger than a mutant needs costs
+// wall clock only on a mutant that genuinely never terminates, and the job's own
+// `timeout-minutes` is the backstop for that (a leg that hits it reports
+// cancelled, which the `mutation` aggregator already fails). A budget SMALLER
+// than a mutant needs used to cost efficacy points in cerberus's favour, which
+// is what #2903 fixed in gremlins-threshold.mjs — and still costs them, now in
+// the honest direction.
+const perMutantRunnerVarianceHeadroom = 2;
 
 const goDurationUnitSeconds = { ns: 1e-9, us: 1e-6, ms: 1e-3, s: 1, m: 60, h: 3600 };
 
@@ -41,7 +61,7 @@ function required(name) {
   return value;
 }
 
-// Parses the subset of Go's duration grammar a timeout ceiling can use: one or
+// Parses the subset of Go's duration grammar a timeout bound can use: one or
 // more unsigned `<number><unit>` terms, e.g. `15s` or `1m30s`.
 function goDurationSeconds(name, spec) {
   const terms = spec.match(/[0-9]+(?:\.[0-9]+)?(?:ns|us|ms|s|m|h)/g);
@@ -54,10 +74,118 @@ function goDurationSeconds(name, spec) {
   }, 0);
 }
 
-function perMutantBudgetIsTheCeilingCoefficient(name, ceiling) {
-  const seconds = goDurationSeconds(name, ceiling);
-  if (!(seconds > 0)) throw new Error(`${name} must be a positive duration: ${ceiling}`);
+function positiveDurationSeconds(name) {
+  const spec = required(name);
+  const seconds = goDurationSeconds(name, spec);
+  if (!(seconds > 0)) throw new Error(`${name} must be a positive duration: ${spec}`);
+  return seconds;
+}
+
+function perMutantBudgetIsTheCeilingCoefficient(seconds) {
   return String(Math.ceil(seconds / gremlinsCoverageBaselineFloorSeconds));
+}
+
+// concurrentMutants is how many `go test` children gremlins runs at once, which
+// is what each one's own compile has to share the machine with. `workers: 0`
+// (the phase table's DEFAULT_WORKERS) means gremlins' own default of
+// runtime.NumCPU().
+function concurrentMutants() {
+  const workers = String(process.env.WORKERS ?? '').trim();
+  if (workers !== '' && workers !== '0') return Number(workers);
+  return availableParallelism();
+}
+
+// probeFile picks the file the probe below edits: the largest non-test .go file
+// directly in the scope directory. Largest because it is the closest stand-in
+// for the worst mutant this leg can draw, and deterministic so two runs of the
+// same leg measure the same thing.
+function probeFile(scope) {
+  const dir = resolve(scope);
+  let chosen = null;
+  for (const name of readdirSync(dir).sort()) {
+    if (!name.endsWith('.go') || name.endsWith('_test.go')) continue;
+    const path = join(dir, name);
+    const { size } = statSync(path);
+    if (chosen === null || size > chosen.size) chosen = { path, size };
+  }
+  return chosen?.path ?? null;
+}
+
+// measurePerMutantCycleSeconds times ONE mutant's worth of work: change a byte
+// of production source in the scope, then run the scope's tests exactly as
+// gremlins runs them for a mutant (`-count=1` to defeat the test result cache,
+// `-failfast` because that is what gremlins passes). The edit is what makes the
+// measurement honest — Go's build cache is keyed on content, so timing an
+// unchanged package measures nothing a mutant will ever pay.
+//
+// The source file is restored in a finally, so the tree gremlins then copies is
+// byte-identical to the checkout.
+//
+// Any failure to measure — no probe file, a build error, a `go` that is not
+// there — yields null, and the caller falls back to MUTANT_TIMEOUT_MIN, which
+// is the value the lane ran on before this measurement existed.
+function measurePerMutantCycleSeconds(scope, capSeconds) {
+  const path = probeFile(scope);
+  if (path === null) {
+    notice(`no non-test .go file directly in ${scope}: cannot measure the per-mutant cycle`);
+    return null;
+  }
+  const original = readFileSync(path);
+  const started = process.hrtime.bigint();
+  try {
+    writeFileSync(path, Buffer.concat([original, Buffer.from('\n// per-mutant budget probe\n')]));
+    const result = spawnSync(
+      'go',
+      ['test', '-count=1', '-failfast', '-timeout', `${capSeconds}s`, scope],
+      { stdio: 'inherit', timeout: capSeconds * 1000 * perMutantRunnerVarianceHeadroom },
+    );
+    // A probe killed by its own watchdog still measured something real — a
+    // cycle longer than any budget this script may hand out — so its elapsed
+    // time is kept and clamps to MUTANT_TIMEOUT_MAX below. Only a `go` that
+    // could not be launched at all measured nothing.
+    if (result.error && result.error.code !== 'ETIMEDOUT') {
+      notice(`cannot measure the per-mutant cycle: ${result.error.message}`);
+      return null;
+    }
+  } finally {
+    writeFileSync(path, original);
+  }
+  return Number(process.hrtime.bigint() - started) / 1e9;
+}
+
+// perMutantBudgetSeconds is the deadline handed to gremlins, in seconds.
+//
+// It is measured rather than declared because the thing it has to cover is a
+// COMPILE, and a compile's cost is a property of the package and the runner,
+// not of the test suite. The flat 15s this replaced was picked, and measurement
+// says it was under the cost it was meant to bound: `internal/chsql` recompiles
+// and links in 12.7-14.4s per mutant on an 8-core machine and runs its tests in
+// 0.31s, so nearly the whole budget went to the compiler and every contended
+// runner pushed mutants over (#2903).
+//
+// MIN is the floor a measurement may not lower the budget below, so a probe
+// that fails to measure anything leaves the lane exactly where it was. MAX is
+// the ceiling a measurement may not raise it above, so one pathological probe
+// cannot spend the job's whole wall-clock allowance on hung mutants.
+function perMutantBudgetSeconds(scope) {
+  const min = positiveDurationSeconds('MUTANT_TIMEOUT_MIN');
+  const max = positiveDurationSeconds('MUTANT_TIMEOUT_MAX');
+  if (max < min) throw new Error(`MUTANT_TIMEOUT_MAX is below MUTANT_TIMEOUT_MIN: ${max}s < ${min}s`);
+
+  const cycle = measurePerMutantCycleSeconds(scope, max);
+  if (cycle === null) {
+    notice(`per-mutant budget ${min}s (the floor; the cycle could not be measured)`);
+    return min;
+  }
+  const fanOut = concurrentMutants();
+  const derived = Math.ceil(cycle * fanOut * perMutantRunnerVarianceHeadroom);
+  const budget = Math.min(max, Math.max(min, derived));
+  notice(
+    `measured per-mutant cycle ${cycle.toFixed(1)}s for ${scope}; ` +
+      `x${fanOut} concurrent mutants x${perMutantRunnerVarianceHeadroom} headroom = ${derived}s, ` +
+      `clamped to [${min}s, ${max}s] -> per-mutant budget ${budget}s`,
+  );
+  return budget;
 }
 
 function reportTotal(path) {
@@ -73,17 +201,16 @@ function reportTotal(path) {
   return document.mutants_total;
 }
 
-function runGremlins({ report, diffRef = '' }) {
-  const ceiling = required('MUTANT_TIMEOUT_MAX');
+function runGremlins({ report, budgetSeconds, diffRef = '' }) {
   const args = [
     'unleash',
     '--output',
     report,
     '--on-shutdown-status=not-run',
     '--timeout-max',
-    ceiling,
+    `${budgetSeconds}s`,
     '--timeout-coefficient',
-    perMutantBudgetIsTheCeilingCoefficient('MUTANT_TIMEOUT_MAX', ceiling),
+    perMutantBudgetIsTheCeilingCoefficient(budgetSeconds),
   ];
   const workers = String(process.env.WORKERS ?? '').trim();
   if (workers !== '' && workers !== '0') {
@@ -103,17 +230,24 @@ function runGremlins({ report, diffRef = '' }) {
 
 function main() {
   const report = required('REPORT');
+  const scope = required('SCOPE');
   const diffRef = String(process.env.DIFF_REF ?? '').trim();
   if (diffRef !== '' && !/^[0-9a-f]{40,64}$/i.test(diffRef)) {
     throw new Error(`DIFF_REF is invalid: ${diffRef}`);
   }
   if (existsSync(report)) throw new Error(`refusing stale gremlins report ${report}`);
 
-  runGremlins({ report, diffRef });
+  // Measured once, before either invocation, and reused. Both invocations run
+  // the same mutants on the same runner, so a second measurement would only add
+  // a second compile — and would take it against a cache the first invocation
+  // warmed, which is the exact mismeasurement #2692 was.
+  const budgetSeconds = perMutantBudgetSeconds(scope);
+
+  runGremlins({ report, budgetSeconds, diffRef });
   if (diffRef !== '' && reportTotal(report) === 0) {
     notice('changed-line mutation found zero executable mutants; rerunning the full phase');
     unlinkSync(report);
-    runGremlins({ report });
+    runGremlins({ report, budgetSeconds });
   }
   const total = reportTotal(report);
   if (total <= 0) throw new Error('mutation phase executed zero mutants after full fallback');

--- a/.github/scripts/mutation-run.test.mjs
+++ b/.github/scripts/mutation-run.test.mjs
@@ -1,5 +1,5 @@
 import assert from 'node:assert/strict';
-import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { test } from 'node:test';
@@ -8,15 +8,33 @@ import { test } from 'node:test';
 // contract and two-invocation fallback, not a helper that bypasses main().
 import { spawnSync } from 'node:child_process';
 
-function fixture(t, totals) {
+// fixture builds a self-contained leg: a fake `gremlins` that records its argv
+// and writes the report totals it is told to, a fake `go` that records its argv
+// and burns `probeSeconds` of wall clock, and a scope directory holding the
+// production source the budget probe edits.
+//
+// `go` is faked rather than skipped because the probe is the thing under test:
+// a probe that silently measured nothing would fall back to the floor and every
+// budget assertion below would still pass against a script that never probed.
+function fixture(t, totals, { probeSeconds = 0, goExits = 0, goMissing = false } = {}) {
   const root = mkdtempSync(join(tmpdir(), 'mutation-run-'));
   t.after(() => rmSync(root, { recursive: true, force: true }));
   const calls = join(root, 'calls.jsonl');
-  const fake = join(root, 'gremlins');
+  const goCalls = join(root, 'go-calls.jsonl');
+  const bin = join(root, 'bin');
+  const scope = join(root, 'scope');
+  mkdirSync(bin);
+  mkdirSync(scope);
+  // Two files, so "largest non-test .go, ties broken by name" has something to
+  // choose between, and a _test.go the probe must not touch.
+  writeFileSync(join(scope, 'a_small.go'), 'package scope\n');
+  writeFileSync(join(scope, 'b_large.go'), `package scope\n\n// ${'x'.repeat(200)}\n`);
+  writeFileSync(join(scope, 'z_test.go'), `package scope\n\n// ${'y'.repeat(4000)}\n`);
   writeFileSync(calls, '');
+  writeFileSync(goCalls, '');
   writeFileSync(
-    fake,
-    `#!/usr/bin/env node
+    join(bin, 'gremlins'),
+    `#!${process.execPath}
 const fs = require('node:fs');
 const args = process.argv.slice(2);
 fs.appendFileSync(${JSON.stringify(calls)}, JSON.stringify(args) + '\\n');
@@ -27,99 +45,215 @@ fs.writeFileSync(report, JSON.stringify({ mutants_total: totals[call] }));
 `,
     { mode: 0o755 },
   );
-  return { root, calls, fake };
+  if (!goMissing) {
+    writeFileSync(
+      join(bin, 'go'),
+      `#!${process.execPath}
+const fs = require('node:fs');
+const args = process.argv.slice(2);
+// Record what the tree looked like WHILE the probe was running, so the test can
+// prove the probe actually edited the source rather than timing a cache hit.
+const seen = {};
+for (const f of fs.readdirSync(${JSON.stringify(scope)})) {
+  seen[f] = fs.readFileSync(require('node:path').join(${JSON.stringify(scope)}, f), 'utf8');
+}
+fs.appendFileSync(${JSON.stringify(goCalls)}, JSON.stringify({ args, seen }) + '\\n');
+Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, ${probeSeconds} * 1000);
+process.exit(${goExits});
+`,
+      { mode: 0o755 },
+    );
+  }
+  return { root, bin, scope, calls, goCalls };
 }
 
-function run(root, env = {}) {
+function run(f, env = {}) {
   return spawnSync(process.execPath, ['.github/scripts/mutation-run.mjs'], {
     cwd: process.cwd(),
     encoding: 'utf8',
     env: {
       ...process.env,
-      PATH: `${root}:${process.env.PATH}`,
-      SCOPE: './internal/chplan',
-      REPORT: join(root, 'gremlins.json'),
-      MUTANT_TIMEOUT_MAX: '15s',
-      WORKERS: '0',
+      PATH: f.bin,
+      SCOPE: f.scope,
+      REPORT: join(f.root, 'gremlins.json'),
+      MUTANT_TIMEOUT_MIN: '15s',
+      MUTANT_TIMEOUT_MAX: '120s',
+      WORKERS: '1',
       EXCLUDE_FILES: '',
       ...env,
     },
   });
 }
 
+function invocations(f) {
+  const raw = readFileSync(f.calls, 'utf8').trim();
+  return raw === '' ? [] : raw.split('\n').map(JSON.parse);
+}
+
+function budgetOf(args) {
+  return args[args.indexOf('--timeout-max') + 1];
+}
+
 test('changed-line execution stays incremental when it executes mutants', (t) => {
-  const { root, calls } = fixture(t, [3]);
-  const result = run(root, { DIFF_REF: 'a'.repeat(40) });
+  const f = fixture(t, [3]);
+  const result = run(f, { DIFF_REF: 'a'.repeat(40) });
   assert.equal(result.status, 0, result.stderr);
-  const invocations = readFileSync(calls, 'utf8').trim().split('\n').map(JSON.parse);
-  assert.equal(invocations.length, 1);
-  assert.deepEqual(invocations[0].slice(-3), ['--diff', 'a'.repeat(40), './internal/chplan']);
+  const calls = invocations(f);
+  assert.equal(calls.length, 1);
+  assert.deepEqual(calls[0].slice(-3), ['--diff', 'a'.repeat(40), f.scope]);
 });
 
 test('zero changed-line mutants trigger one full fallback', (t) => {
-  const { root, calls } = fixture(t, [0, 7]);
-  const result = run(root, { DIFF_REF: 'a'.repeat(40) });
+  const f = fixture(t, [0, 7]);
+  const result = run(f, { DIFF_REF: 'a'.repeat(40) });
   assert.equal(result.status, 0, result.stderr);
-  const invocations = readFileSync(calls, 'utf8').trim().split('\n').map(JSON.parse);
-  assert.equal(invocations.length, 2);
-  assert.equal(invocations[0].includes('--diff'), true);
-  assert.equal(invocations[1].includes('--diff'), false);
+  const calls = invocations(f);
+  assert.equal(calls.length, 2);
+  assert.equal(calls[0].includes('--diff'), true);
+  assert.equal(calls[1].includes('--diff'), false);
 });
 
 test('zero mutants after full fallback fail closed', (t) => {
-  const { root } = fixture(t, [0, 0]);
-  const result = run(root, { DIFF_REF: 'a'.repeat(40) });
+  const f = fixture(t, [0, 0]);
+  const result = run(f, { DIFF_REF: 'a'.repeat(40) });
   assert.equal(result.status, 1);
   assert.match(`${result.stdout}\n${result.stderr}`, /executed zero mutants after full fallback/);
 });
 
-// The per-mutant budget must be a DECLARED value, not an accident of build-cache
-// warmth. gremlins computes `min(coefficient * max(coverage_elapsed, 1s),
-// timeout-max)`, so unless the coefficient alone carries the whole ceiling
-// across gremlins' own 1s floor, the hot-cache fallback invocation silently gets
-// a smaller budget than the cold-cache first one.
-test('both invocations pin the per-mutant budget to the declared ceiling', (t) => {
-  const { root, calls } = fixture(t, [0, 7]);
-  const result = run(root, { DIFF_REF: 'a'.repeat(40), MUTANT_TIMEOUT_MAX: '15s' });
+// The probe has to force the recompile a mutant forces. Go's build cache is
+// keyed on CONTENT, so timing an unedited package times a cache hit and
+// measures nothing — which is the mismeasurement this whole change exists to
+// remove. Proven from inside the probe's own `go` child.
+test('the probe edits the largest production file, and restores it exactly', (t) => {
+  const f = fixture(t, [4]);
+  const before = readFileSync(join(f.scope, 'b_large.go'), 'utf8');
+  assert.equal(run(f, { DIFF_REF: '' }).status, 0);
+
+  const [probe] = readFileSync(f.goCalls, 'utf8').trim().split('\n').map(JSON.parse);
+  assert.deepEqual(probe.args, ['test', '-count=1', '-failfast', '-timeout', '120s', f.scope]);
+  assert.notEqual(probe.seen['b_large.go'], before, 'the probe timed an unedited package');
+  assert.ok(probe.seen['b_large.go'].startsWith(before), 'the probe rewrote the file wholesale');
+  assert.equal(probe.seen['a_small.go'], 'package scope\n', 'the probe edited more than one file');
+  assert.match(probe.seen['z_test.go'], /^package scope\n\n\/\/ y+\n$/, 'the probe edited a test file');
+
+  // Restored before gremlins ever sees the tree.
+  assert.equal(readFileSync(join(f.scope, 'b_large.go'), 'utf8'), before);
+});
+
+// The measurement is the point: a slower cycle must buy a bigger budget.
+test('the budget scales with the measured cycle and the concurrent-mutant count', (t) => {
+  const slow = fixture(t, [4], { probeSeconds: 2 });
+  assert.equal(run(slow, { DIFF_REF: '', WORKERS: '1', MUTANT_TIMEOUT_MIN: '1s' }).status, 0);
+  const serial = Number(budgetOf(invocations(slow)[0]).replace('s', ''));
+  assert.ok(serial >= 4, `a 2s cycle at 1 worker must buy at least 2x2s, got ${serial}s`);
+
+  const fanned = fixture(t, [4], { probeSeconds: 2 });
+  assert.equal(run(fanned, { DIFF_REF: '', WORKERS: '4', MUTANT_TIMEOUT_MIN: '1s' }).status, 0);
+  const parallel = Number(budgetOf(invocations(fanned)[0]).replace('s', ''));
+  assert.ok(
+    parallel >= serial * 3,
+    `4 concurrent mutants must buy ~4x the budget 1 does, got ${parallel}s vs ${serial}s`,
+  );
+});
+
+// The starved case, in the direction that matters: MIN is a floor the
+// measurement may raise but never lower, so a leg whose cycle measures as
+// nearly free still gets the budget the lane ran on before it was measured.
+test('a fast cycle floors at MUTANT_TIMEOUT_MIN rather than shrinking the budget', (t) => {
+  const f = fixture(t, [4], { probeSeconds: 0 });
+  assert.equal(run(f, { DIFF_REF: '' }).status, 0);
+  assert.equal(budgetOf(invocations(f)[0]), '15s');
+});
+
+test('a cycle larger than the ceiling clamps to MUTANT_TIMEOUT_MAX', (t) => {
+  const f = fixture(t, [4], { probeSeconds: 1 });
+  const env = { DIFF_REF: '', WORKERS: '2', MUTANT_TIMEOUT_MIN: '1s', MUTANT_TIMEOUT_MAX: '3s' };
+  assert.equal(run(f, env).status, 0);
+  assert.equal(budgetOf(invocations(f)[0]), '3s');
+});
+
+// Degrading safely is a requirement, not a nicety: an unmeasurable probe must
+// leave the lane exactly where it was, never at some accidental smaller number.
+test('an unmeasurable cycle falls back to the floor instead of guessing', (t) => {
+  const f = fixture(t, [4], { goMissing: true });
+  const result = run(f, { DIFF_REF: '' });
   assert.equal(result.status, 0, result.stderr);
-  const invocations = readFileSync(calls, 'utf8').trim().split('\n').map(JSON.parse);
-  assert.equal(invocations.length, 2);
-  for (const args of invocations) {
-    assert.deepEqual(args.slice(args.indexOf('--timeout-max'), args.indexOf('--timeout-max') + 2), [
-      '--timeout-max',
-      '15s',
-    ]);
+  assert.equal(budgetOf(invocations(f)[0]), '15s');
+  assert.match(`${result.stdout}\n${result.stderr}`, /cannot measure the per-mutant cycle/);
+});
+
+test('a scope with no production source falls back to the floor', (t) => {
+  const f = fixture(t, [4]);
+  rmSync(join(f.scope, 'a_small.go'));
+  rmSync(join(f.scope, 'b_large.go'));
+  const result = run(f, { DIFF_REF: '' });
+  assert.equal(result.status, 0, result.stderr);
+  assert.equal(budgetOf(invocations(f)[0]), '15s');
+  assert.equal(readFileSync(f.goCalls, 'utf8'), '', 'nothing to edit, so nothing to time');
+});
+
+// The per-mutant budget must be the value this script derived, not an accident
+// of build-cache warmth. gremlins computes `min(coefficient * max(coverage
+// _elapsed, 1s), timeout-max)`, so unless the coefficient alone carries the
+// whole budget across gremlins' own 1s floor, the hot-cache fallback invocation
+// silently gets a smaller budget than the cold-cache first one (#2692).
+test('both invocations pin the per-mutant budget to the derived value', (t) => {
+  const f = fixture(t, [0, 7]);
+  const result = run(f, { DIFF_REF: 'a'.repeat(40) });
+  assert.equal(result.status, 0, result.stderr);
+  const calls = invocations(f);
+  assert.equal(calls.length, 2);
+  for (const args of calls) {
+    assert.equal(budgetOf(args), '15s');
     const at = args.indexOf('--timeout-coefficient');
     assert.notEqual(at, -1, `--timeout-coefficient missing from ${JSON.stringify(args)}`);
     // gremlins clamps its measured coverage time up to a 1s floor, so
     // `coefficient * 1s` is the smallest budget the coefficient can yield; it
-    // must already reach the ceiling for the ceiling to be the sole budget.
-    assert.ok(Number(args[at + 1]) * 1 >= 15, `coefficient ${args[at + 1]} is below the ceiling`);
+    // must already reach the derived budget for that to be the sole budget.
+    assert.ok(Number(args[at + 1]) * 1 >= 15, `coefficient ${args[at + 1]} is below the budget`);
   }
 });
 
-test('the declared coefficient rounds a compound ceiling up, and rejects a bad one', (t) => {
-  const { root, calls } = fixture(t, [4]);
-  let result = run(root, { DIFF_REF: '', MUTANT_TIMEOUT_MAX: '1m30s' });
+test('the probe is timed once and reused across the fallback invocation', (t) => {
+  const f = fixture(t, [0, 7]);
+  assert.equal(run(f, { DIFF_REF: 'a'.repeat(40) }).status, 0);
+  assert.equal(
+    readFileSync(f.goCalls, 'utf8').trim().split('\n').length,
+    1,
+    'a second measurement would be taken against the cache the first invocation warmed',
+  );
+});
+
+test('the derived coefficient rounds a compound bound up, and rejects a bad one', (t) => {
+  const f = fixture(t, [4]);
+  let result = run(f, { DIFF_REF: '', MUTANT_TIMEOUT_MIN: '1m30s' });
   assert.equal(result.status, 0, result.stderr);
-  const args = readFileSync(calls, 'utf8').trim().split('\n').map(JSON.parse)[0];
+  const args = invocations(f)[0];
   assert.equal(args[args.indexOf('--timeout-coefficient') + 1], '90');
 
   const bad = fixture(t, [4]);
-  result = run(bad.root, { DIFF_REF: '', MUTANT_TIMEOUT_MAX: '15 seconds' });
+  result = run(bad, { DIFF_REF: '', MUTANT_TIMEOUT_MAX: '15 seconds' });
   assert.equal(result.status, 1);
   assert.equal(readFileSync(bad.calls, 'utf8'), '');
   assert.match(`${result.stdout}\n${result.stderr}`, /MUTANT_TIMEOUT_MAX is not a Go duration/);
 });
 
-test('invalid diff refs and stale reports fail before gremlins runs', (t) => {
-  const { root, calls } = fixture(t, [3]);
-  let result = run(root, { DIFF_REF: 'main' });
+test('a ceiling below the floor is rejected rather than silently inverted', (t) => {
+  const f = fixture(t, [4]);
+  const result = run(f, { DIFF_REF: '', MUTANT_TIMEOUT_MIN: '30s', MUTANT_TIMEOUT_MAX: '15s' });
   assert.equal(result.status, 1);
-  assert.equal(readFileSync(calls, 'utf8'), '');
+  assert.equal(readFileSync(f.calls, 'utf8'), '');
+  assert.match(`${result.stdout}\n${result.stderr}`, /MUTANT_TIMEOUT_MAX is below MUTANT_TIMEOUT_MIN/);
+});
 
-  writeFileSync(join(root, 'gremlins.json'), '{}');
-  result = run(root, { DIFF_REF: '' });
+test('invalid diff refs and stale reports fail before gremlins runs', (t) => {
+  const f = fixture(t, [3]);
+  let result = run(f, { DIFF_REF: 'main' });
+  assert.equal(result.status, 1);
+  assert.equal(readFileSync(f.calls, 'utf8'), '');
+
+  writeFileSync(join(f.root, 'gremlins.json'), '{}');
+  result = run(f, { DIFF_REF: '' });
   assert.equal(result.status, 1);
   assert.match(`${result.stdout}\n${result.stderr}`, /refusing stale gremlins report/);
 });

--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -191,50 +191,65 @@ jobs:
       # non-zero value caps the parallel `go test` fan-out per the
       # comment above the matrix entry.
       #
-      # MUTANT_TIMEOUT_MAX is the per-mutant budget, and — because
-      # mutation-run.mjs pins --timeout-coefficient to match it — it is the
-      # WHOLE budget, not merely a ceiling over some smaller derived value.
-      # That distinction is load-bearing. gremlins derives the timeout as
+      # The per-mutant budget is MEASURED, not declared. mutation-run.mjs times
+      # this leg's own recompile+link+run cycle on this runner — it edits a byte
+      # of the scope's production source and runs the scope's tests exactly as
+      # gremlins runs them for a mutant — and sizes the budget from what it
+      # measured. MUTANT_TIMEOUT_MIN and MUTANT_TIMEOUT_MAX are the bounds that
+      # measurement is clamped into, not the budget itself.
+      #
+      # Measuring is the fix for #2903. A flat declared budget bounds a
+      # quantity it does not describe: it wraps the WHOLE `go test` child, which
+      # is a recompile, a link, and only then a run. Per mutant on an 8-core
+      # machine, against the flat 15s that used to be declared here:
+      #
+      #   internal/chsql   compile+link 12.7-14.4s   test run 0.31s
+      #   internal/promql  compile+link  8.4-8.7s    test run 2.07s
+      #
+      # So the compiler was 80-98% of the budget, every contended runner pushed
+      # mutants over it, and gremlins recorded that as TIMED OUT — which the
+      # gate then scored as a detection, paying the leg efficacy points for
+      # being starved. gremlins-threshold.mjs no longer scores it that way, so
+      # an undersized budget is now visibly RED; this step is what keeps an
+      # honest leg from being red for the compiler's sake.
+      #
+      # MIN is the floor: a probe that cannot measure anything (no `go` on
+      # PATH, a build error) leaves the lane on exactly the 15s it ran on
+      # before. MAX is the ceiling: one pathological measurement cannot spend
+      # the job's whole wall-clock allowance on hung mutants. 120s is roughly
+      # the largest budget the derivation can ask for (internal/chsql's ~14.4s
+      # cycle x 4 concurrent mutants x2 headroom), so it bounds the outlier
+      # without clipping the legs it is sized for. The job's own
+      # `timeout-minutes` below is the backstop beyond it, and a leg that hits
+      # that reports cancelled, which the `mutation` aggregator fails.
+      #
+      # The coefficient is still pinned by mutation-run.mjs, for the reason it
+      # always was: gremlins derives the deadline as
       # `min(timeout-coefficient x the coverage run's wall time, timeout-max)`,
-      # which scales the leash by how long the package took to COMPILE for
-      # coverage — a quantity unrelated to how much damage a runaway mutant
-      # does in that time, and one that collapses to gremlins' 1s floor
+      # and the coverage run's wall time collapses to gremlins' 1s floor
       # whenever the Go build cache is already warm (as it is for
       # mutation-run.mjs's second, full-fallback invocation). Left alone, the
-      # ceiling therefore silently lowered itself to 5s on exactly the path a
-      # pull request takes, under internal/promql's real ~6.6s per-mutant
-      # recompile+link+run, and the leg reported 0.00% efficacy (#2692). With
-      # the coefficient pinned, both invocations get this declared value.
+      # budget silently lowered itself to 5s on exactly the path a pull request
+      # takes, under internal/promql's real per-mutant recompile+link+run, and
+      # the leg reported 0.00% efficacy (#2692).
       #
-      # This is deliberately NOT budget-neutral on the single-invocation path
-      # that was already green. Any leg whose COLD coverage pass ran under
-      # 3s was silently below this ceiling on every event too, and now gets the
-      # full declared value: phase6-spansscan 1.19s -> 5.97s becomes 15s,
-      # phase5-qlcommon 2.82s -> 14.1s becomes 15s. That is the point — the
-      # budget is now the number written here rather than an artefact of
-      # compile time — but it does lengthen the OOM leash the paragraph below
-      # governs, by up to 2.5x on the fastest-compiling legs. 15s is the
-      # analysed value and those legs report `Timed out: 0`, so the exposure is
-      # bounded; deriving the ceiling from measurement behind a memory cap is
-      # tracked in #2694.
-      #
-      # The budget bounds the whole `go test` child, and a bound is needed at
-      # all because a mutant that inverts a scanner's loop-advance
-      # (i++ -> i--) never terminates and allocates per iteration, so an
-      # unbounded leash lets it exhaust the runner's memory. The OOM killer
-      # then reaps the runner agent and the job dies with no verdict at all,
-      # which reads as flake rather than as a missing bound.
+      # A bound is needed at all because a mutant that inverts a scanner's
+      # loop-advance (i++ -> i--) never terminates and allocates per iteration,
+      # so an unbounded leash lets it exhaust the runner's memory. The OOM
+      # killer then reaps the runner agent and the job dies with no verdict at
+      # all, which reads as flake rather than as a missing bound.
       #
       # Do NOT "fix" a recurrence by excluding whichever file the log names:
       # that relocates the file's runaway mutants into whichever leg still owns
-      # it, and burns real mutation coverage. The ceiling is the fix.
+      # it, and burns real mutation coverage. The budget is the fix.
       # mutation-run.mjs owns the changed-line/full decision and validates that
       # the final report executed at least one mutant. Keeping the zero-mutant
       # fallback out of shell prevents a missing or malformed JSON field from
       # being read as a cheap successful phase.
       - name: gremlins unleash
         env:
-          MUTANT_TIMEOUT_MAX: 15s
+          MUTANT_TIMEOUT_MIN: 15s
+          MUTANT_TIMEOUT_MAX: 120s
           SCOPE: ${{ matrix.scope }}
           WORKERS: ${{ matrix.workers }}
           EXCLUDE_FILES: ${{ matrix.exclude_files }}

--- a/docs/test-strategy.md
+++ b/docs/test-strategy.md
@@ -1076,15 +1076,46 @@ Each mutant's `go test` child runs under a deadline, because a mutant that
 inverts a loop advance never terminates and allocates per iteration; without a
 deadline the OOM killer reaps the runner and the leg reports no verdict at all.
 
-That deadline is a declared value, not a measured one. gremlins computes it as
+That deadline is MEASURED, per leg, per run. `.github/scripts/mutation-run.mjs`
+times one mutant's worth of work before gremlins starts — it appends a byte to
+the largest production file in the leg's scope, runs the scope's tests exactly
+as gremlins runs them for a mutant (`-count=1 -failfast`), and restores the file
+— then scales what it measured by the number of mutants gremlins will run
+concurrently and by a named headroom multiple. The result is clamped into
+`[MUTANT_TIMEOUT_MIN, MUTANT_TIMEOUT_MAX]`, both declared in
+`.github/workflows/mutation.yml`. The edit is load-bearing: Go's build cache is
+keyed on content, so timing an unedited package times a cache hit and measures
+nothing a mutant will ever pay.
+
+It is measured because the thing the deadline has to cover is a COMPILE, and a
+compile's cost is a property of the package and the runner rather than of the
+test suite. Measured per mutant on an 8-core machine, against the flat 15s the
+lane used to declare:
+
+| scope             | compile + link | test run |
+| ----------------- | -------------- | -------- |
+| `internal/chsql`  | 12.7-14.4s     | 0.31s    |
+| `internal/promql` | 8.4-8.7s       | 2.07s    |
+
+80-98% of the budget went to the compiler, so every contended runner pushed
+ordinary mutants over it and gremlins recorded them as `TIMED OUT` — which the
+gate then scored as detections (#2903, and the "Timed-out mutants" section
+below).
+
+`MUTANT_TIMEOUT_MIN` is the floor a measurement may raise but never lower, so a
+probe that cannot measure anything leaves the lane exactly where it was.
+`MUTANT_TIMEOUT_MAX` is the ceiling, so one pathological measurement cannot
+spend the job's whole `timeout-minutes` on hung mutants — and a leg that hits
+that job timeout reports `cancelled`, which the `mutation` aggregator fails.
+
+gremlins itself computes the deadline as
 `min(timeout-coefficient x max(coverage_elapsed, 1s), timeout-max)`, where
-`coverage_elapsed` is the wall time of its own coverage pass — a number
-dominated by COMPILATION, not by test time, and therefore a function of how warm
-the Go build cache happened to be. `.github/scripts/mutation-run.mjs` neutralises
-that input: it derives `--timeout-coefficient` from `MUTANT_TIMEOUT_MAX` as
-`ceil(ceiling / 1s)`, so `coefficient x max(elapsed, 1s)` is at least the ceiling
-for any elapsed time and the budget is exactly `MUTANT_TIMEOUT_MAX` on every
-invocation. `.github/workflows/mutation.yml` declares that ceiling.
+`coverage_elapsed` is the wall time of its own coverage pass — the same
+compile-dominated quantity, but taken on whatever build-cache warmth the
+invocation happened to inherit. `mutation-run.mjs` neutralises that input: it
+derives `--timeout-coefficient` as `ceil(budget / 1s)`, so
+`coefficient x max(elapsed, 1s)` is at least the budget for any elapsed time and
+the measured budget is the sole budget on every invocation.
 
 The coefficient is passed on BOTH of `mutation-run.mjs`'s invocations, and the
 second is why this matters. When the changed-line run finds zero executable
@@ -1096,6 +1127,44 @@ times out, and because gremlins counts a timed-out mutant in neither the efficac
 ratio nor `mutants_total`, the leg reported `Timed out: 295 / Test efficacy:
 0.00%` on pull requests while the identical leg on push-to-main — one
 cold-cache invocation, the intended budget — reported 99.65% (#2692).
+
+### Timed-out mutants are unadjudicated, and count against the leg
+
+`.github/scripts/gremlins-threshold.mjs` scores a leg as
+`killed / (killed + lived + timedOut)` — the kill rate over every mutant the
+runner ATTEMPTED to adjudicate. gremlins' own `test_efficacy` is
+`killed / (killed + lived)`, which drops a timeout from BOTH sides, so this gate
+is strictly the stricter of the two and gremlins' number is reported rather than
+compared against.
+
+The rule that formula encodes: **the score must be monotone non-increasing in
+the timeout count.** Moving a mutant into `TIMED OUT` may never raise the number
+the gate reads. A gate that breaks that rule pays a slower runner in efficacy
+points, and a green run then proves the machine was busy rather than that the
+tests are strong.
+
+The gate used to break it — it counted a timeout as a DETECTION, on the premise
+that a mutant exhausting the budget broke termination rather than lost a race
+with the compiler. The per-mutant costs in "Per-mutant time budget" above
+falsify that premise, and two signatures in the reports confirm it:
+
+- Runs 33542904091 (red) and 33551271099 (green) recorded the SAME 486 kills on
+  `phase4-promql-lower`. The whole 94.00% -> 97.01% swing was 16 mutants moving
+  `LIVED` -> `TIMED OUT`, on a runner that was 44% slower (coverage 53.2s vs
+  36.8s). Matching mutants across the two revisions by source text, 18 of the
+  red run's 31 survivors — short-circuit boolean guards and slice-capacity
+  arithmetic, none of which can unbound a loop — were booked as detections.
+- gremlins runs each mutant with `-failfast`, so a killed mutant exits at its
+  first failing test while a survivor must run the suite to the end. Starvation
+  therefore converts SURVIVORS preferentially, which makes the bias monotone
+  rather than noisy. Run 33522074818 is the endpoint: all four `internal/chsql`
+  legs reported 100.00% with `lived: 0`, over 1266 mutants of which 1230 timed
+  out.
+
+The two halves are paired. The measured budget keeps an honest leg from timing
+out for the compiler's sake; this formula is what makes it safe to get that
+measurement wrong in the tight direction, because an undersized budget now shows
+up as a RED leg instead of a flattering one.
 
 A surviving mutant is either (a) a legitimately weak assertion that
 needs strengthening, (b) a functionally-equivalent mutation (`<` vs

--- a/test/regression/mutation_timeout_max_test.go
+++ b/test/regression/mutation_timeout_max_test.go
@@ -17,17 +17,27 @@ const mutationRunnerPath = "../../.github/scripts/mutation-run.mjs"
 // mutated package's own tests are.
 const timeoutMaxFlag = "--timeout-max"
 
-// The runner must pass the flag AND source its value from the env var. Pinned
-// as two independent substrings rather than as one adjacent `'--timeout-max',
-// required('MUTANT_TIMEOUT_MAX'),` phrase: that spelling broke the moment the
-// value was hoisted into a local to be reused by --timeout-coefficient, which
-// is a refactor this pin has no business rejecting. What it must still catch is
-// the flag disappearing, or its value coming from somewhere other than the
-// declared ceiling.
+// The runner must pass the flag AND bound its value by the declared ceiling.
+// Pinned as independent substrings rather than as one adjacent phrase: the
+// spelling of how the value reaches the argv has already changed twice — once
+// when it was hoisted into a local to be reused by --timeout-coefficient, and
+// again when cerberus issue #2903 made the budget MEASURED, so the argv now
+// carries a derived number that the ceiling clamps rather than the ceiling
+// itself. Neither is a refactor this pin has any business rejecting. What it
+// must still catch is the flag disappearing, or the bounds it is clamped into
+// no longer coming from the workflow's declared envelope.
+//
+// Both bounds are pinned because they fail in opposite directions and only one
+// of them is this test's own subject. Losing the ceiling removes the OOM bound
+// this test exists for. Losing the floor lets a mismeasured cycle hand out a
+// budget SMALLER than the lane's analysed value, which is #2692's collapse.
 const (
 	mutationRunnerInvocation = "run: node .github/scripts/mutation-run.mjs"
 	timeoutMaxArg            = "'--timeout-max',"
-	timeoutMaxValue          = "required('MUTANT_TIMEOUT_MAX')"
+	timeoutMaxValue          = "'MUTANT_TIMEOUT_MAX'"
+	timeoutMinValue          = "'MUTANT_TIMEOUT_MIN'"
+	timeoutMaxDeclaration    = "MUTANT_TIMEOUT_MAX:"
+	timeoutMinDeclaration    = "MUTANT_TIMEOUT_MIN:"
 )
 
 // gremlinsForkTagPrefix is the fork tag family that supports timeoutMaxFlag.
@@ -76,10 +86,24 @@ func TestMutationLaneCapsPerMutantTimeout(t *testing.T) {
 	}
 	runnerBody := string(runner)
 	if !strings.Contains(runnerBody, timeoutMaxArg) || !strings.Contains(runnerBody, timeoutMaxValue) {
-		t.Errorf("%s does not pass %s from MUTANT_TIMEOUT_MAX to gremlins unleash. Without an absolute "+
-			"ceiling a mutant that inverts a scanner loop-advance runs until the runner is out of memory, "+
-			"and the job dies with no verdict — which reads as flake, not as a missing bound.",
+		t.Errorf("%s does not pass %s bounded by MUTANT_TIMEOUT_MAX to gremlins unleash. Without an "+
+			"absolute ceiling a mutant that inverts a scanner loop-advance runs until the runner is out "+
+			"of memory, and the job dies with no verdict — which reads as flake, not as a missing bound.",
 			mutationRunnerPath, timeoutMaxFlag)
+	}
+	if !strings.Contains(runnerBody, timeoutMinValue) {
+		t.Errorf("%s does not floor the measured per-mutant budget at MUTANT_TIMEOUT_MIN. The budget is "+
+			"derived from a timed probe (#2903), and a probe that measures nothing must fall back to the "+
+			"lane's analysed value rather than to whatever small number it happened to record — that is "+
+			"#2692's budget collapse, where every mutant times out and the leg reports 0.00%%.",
+			mutationRunnerPath)
+	}
+	for _, declaration := range []string{timeoutMinDeclaration, timeoutMaxDeclaration} {
+		if !strings.Contains(body, declaration) {
+			t.Errorf("%s does not declare %s for the gremlins unleash step. Both bounds are required env, "+
+				"so a missing one fails every leg rather than running unbounded — loud, but still broken.",
+				mutationWorkflowPath, declaration)
+		}
 	}
 
 	if !strings.Contains(body, gremlinsForkTagPrefix) {


### PR DESCRIPTION
## The defect

The mutation lane's per-mutant budget wraps the whole `go test` child — a
recompile, a link, and only then a run. On this repo's legs the compile is most
of that. Measured per mutant on an 8-core machine, against the flat 15s budget
the lane declared:

| scope             | compile + link | test run |
| ----------------- | -------------- | -------- |
| `internal/chsql`  | 12.7-14.4s     | 0.31s    |
| `internal/promql` | 8.4-8.7s       | 2.07s    |

So `TIMED OUT` recorded "the compiler was slow today", not "this mutation broke
termination" — and `gremlins-threshold.mjs` scored it as a detection. Because
gremlins drops a timeout from BOTH sides of its own ratio, starving the runner
*removed survivors from the denominator*, and the score went UP as the machine
got busier.

## Independent verification

Re-derived from the two runs' own `gremlins.json` artifacts rather than from the
issue's tables.

**The denominator arithmetic.** Same leg, same 486 kills:

| | red [33542904091](https://github.com/tsouza/cerberus/actions/runs/33542904091) | green [33551271099](https://github.com/tsouza/cerberus/actions/runs/33551271099) |
| --- | ---: | ---: |
| KILLED | 486 | 486 |
| LIVED | 31 | 15 |
| TIMED OUT | 4 | 36 |
| `test_efficacy` (gated on) | 94.00% | 97.01% |
| verdict | FAIL | **PASS** |
| with timeouts in the denominator | 93.28% | **90.50%** |

The whole three-point swing is 16 mutants moving `LIVED` -> `TIMED OUT`, on the
runner that gathered coverage in 53.2s where the other took 36.8s.

**The 18 survivors.** Matching the two revisions' per-mutant records by
`(mutator, column, trimmed source line)` — `lower.go` grew 190 lines between
them, so line numbers do not match — the red run's 31 survivors resolve as 18
`TIMED OUT` / 11 `LIVED` / 1 `KILLED` on the green run. Independently
reproduced; the 18 are short-circuit boolean guards and `make([]T, 0, n*2)`
capacity arithmetic, none of which can unbound a loop.

**The compile-vs-execution split.** With the `lower.go:3574` `||` -> `&&`
mutation applied and the leg's own cycle run:

```
MUTANT_COMPILE wall=15.77       # exceeds the entire 15s budget on its own
native_rate_temporality_test.go:125: instant native rate shape = ...
FAIL
MUTANT_RUN wall=1.62            # a KILL verdict, in 1.6s
```

The mutant is killed in 1.6s of test execution. The budget was spent by the
compiler before the test binary started. Repeated with a content change (not
`touch` — Go's build cache is content-keyed, so `touch` measures nothing):
`internal/promql` 8.4/8.6/8.7s, `internal/chsql` 12.7/14.4/12.9s.

**A second, stronger signature the issue does not name.** gremlins runs each
mutant with `-failfast`, so a KILLED mutant exits at its first failing test
while a survivor must run the suite to the end. Starvation therefore converts
*survivors* preferentially — the bias is monotone, not noise. Its endpoint, on
the green run [33522074818](https://github.com/tsouza/cerberus/actions/runs/33522074818):

| leg | killed | lived | timed out | reported | timeouts as non-kills |
| --- | ---: | ---: | ---: | ---: | ---: |
| `phase2-other` | 37 | 0 | 339 | **100.00%** | 9.84% |
| `phase2-builder` | 22 | 0 | 323 | **100.00%** | 6.38% |
| `phase2-compare` | 36 | 0 | 284 | **100.00%** | 11.25% |
| `phase2-range` | 16 | 0 | 284 | **100.00%** | 5.33% |

All four `internal/chsql` legs reported a perfect score with **zero survivors**,
over 1266 mutants of which 1230 were never adjudicated. `lived: 0` across four
independent legs is not a strong test suite; it is a runner that never ran long
enough to see a survivor.

## The direction chosen, and why

Two changes, one commit each. Both are needed: the second is the correctness
fix, the first is what keeps an honest leg from paying for it.

**1. Measure the budget instead of declaring it** (`mutation-run.mjs`). The
script times one mutant's worth of work before gremlins starts — appends a byte
to the largest production file in the leg's scope, runs the scope's tests
exactly as gremlins runs them for a mutant (`-count=1 -failfast`), restores the
file — and scales the result by the concurrent-mutant count and a named
headroom (2, against the 44% runner-to-runner swing measured above). The edit is
load-bearing: Go's build cache is keyed on content, so timing an unedited
package times a cache hit.

`MUTANT_TIMEOUT_MIN` (15s, the value the lane already ran on) is the floor a
measurement may raise but never lower, so an unmeasurable cycle leaves the lane
exactly where it was. `MUTANT_TIMEOUT_MAX` (120s) is the ceiling, so one
pathological measurement cannot spend the job's whole wall clock on hung
mutants.

**2. Score a timeout as unadjudicated** (`gremlins-threshold.mjs`). Efficacy
becomes `killed / (killed + lived + timedOut)` — the kill rate over every mutant
the runner *attempted* to adjudicate. The rule it encodes: **the score must be
monotone non-increasing in the timeout count.** Moving a mutant into `TIMED OUT`
can never raise the number the gate reads.

### The failure direction, stated plainly

**This change biases toward RED under starvation.** A runner too slow to
adjudicate its mutants now fails the leg instead of scoring it higher. That is
the safe direction because the two errors are not symmetric: a false red costs
one investigation and names its own cause in the error message, while the false
green it replaces was *indistinguishable from a strong test suite* and had
already let `phase2-*` report 100.00% on 3% of its mutants for weeks. It is also
what makes measurement-derived budgets safe to get wrong in the tight direction
— an undersized budget is now visible.

## Verification

**The gate fails where it used to pass, on the real artifacts:**

```
red/gremlins.json     FAIL  efficacy 93.28% < 95% (killed 486 of 521, lived 31, timed out 4)
green/gremlins.json   FAIL  efficacy 90.50% < 95% (killed 486 of 537, lived 15, timed out 36)
phase2-builder        FAIL  efficacy  6.38% < 95% (killed 22 of 345, lived 0, timed out 323)
```

The starved run now scores **below** the run it beat, and the leg that reported
100.00% reports 6.38%.

**It still passes a genuinely-killing run:** a leg with 990 killed / 32 lived /
0 timed out passes, and emits no timeout notice at all.

**Both directions are pinned by tests that fail if the behaviour regresses**, and
each was proven to fail rather than assumed to:

- reverting the formula to timeouts-as-detections: **5 of 13** gate tests fail,
  including `the starved run of a leg scores BELOW the run it was compared
  against` and the `moving any mutant into TIMED OUT never raises the score`
  property;
- making the probe stop editing the source (so it times a cache hit): `the probe
  edits the largest production file, and restores it exactly` fails;
- dropping the concurrent-mutant factor: `the budget scales with the measured
  cycle and the concurrent-mutant count` fails.

The `mutation-run` fixture fakes `go` as well as `gremlins`, because a probe
that silently measured nothing would fall back to the floor and every budget
assertion would still pass against a script that never probed.

**End-to-end against real packages**, with a stub gremlins recording its argv:

```
::notice::measured per-mutant cycle 1.3s for ./internal/spansscan; x8 x2 = 22s -> budget 22s
::notice::measured per-mutant cycle 18.3s for ./internal/chsql; x8 x2 = 294s, clamped -> budget 120s
```

The working tree is byte-identical afterwards.

## Does #2694 / #2695's rejected rationale still hold?

**#2694 (`NOT_PLANNED`) does not.** It was closed on the measurement
"`internal/chsql` recompiles, links and runs in 1.04s at eight cores", giving a
6x-15x margin under 15s. That figure does not reproduce: forcing the recompile a
mutant forces, `internal/chsql` costs 12.7-14.4s of compile+link and 0.31s of
test run. The closing argument — "those mutants do not terminate at any finite
budget" — is therefore false on the very leg it was measured on. Its *other*
concerns survive and are honoured here: worst-case wall clock is why
`MUTANT_TIMEOUT_MAX` exists, and this PR does not raise the budget blindly, it
measures it.

**#2695 is half-vindicated.** Its title — "gate the timed-out share" — is what
this PR implements. Its shipped implementation went the other way, and the
detections reading is what #2903 refutes. Its sequencing warning is the sharpest
thing in it: "the timeout-share gate and the ceiling work should land together,
or the gate is red for however long the ceiling work takes." That is exactly why
both halves are in this PR.

The memory cap #2694 also proposed remains unimplemented and unclaimed here; the
budget still carries the OOM bound alone, now bounded by `MUTANT_TIMEOUT_MAX`
rather than by 15s.

## What this makes visible

Legs whose reported efficacy was carried by timeouts will now report what they
actually adjudicated. On the last full green run that is every `phase2-*` leg
and several `phase4-promql-*` legs. The measured budget is what those legs get
in exchange; where a leg still lands under its bar with a healthy timeout count,
the remedy is the one `docs/test-strategy.md` already prescribes — kill the
survivors — never a wider `exclude_files` and never a lower bar. `mutation` is
informational on PRs and in `RELEASE_INFORMATIONAL_CHECKS`, so nothing is
blocked while that work happens.

#2883's exit criterion is two consecutive green push-to-main `mutation` runs
precisely because one green proves nothing today. This is the change that makes
a single green mean mutants were killed.

The remaining root — gremlins collapsing an overall deadline and a run-only one
into a single number, so `TIMED OUT` still cannot distinguish a hang from a slow
compile — is #2910, filed under epic #2891 with the same milestone. That work is
in the `tsouza/gremlins` fork and needs its own authorization.

Closes #2903

🤖 Generated with [Claude Code](https://claude.com/claude-code)
