### PR TITLE
fix(perf): clamp the smoke sentinels' committed ceiling to the absolute one

### DIFF
--- a/docs/performance.md
+++ b/docs/performance.md
@@ -227,7 +227,14 @@ every PR) to *broad* (corpus-wide, nightly).
    reconciler uses. Two independent bounds per sentinel: an absolute,
    cap-relative ceiling, and a committed per-sentinel ceiling
    (`test/perf/perf-smoke-baseline.json`, max-of-N repeats with headroom,
-   `just update-perf-smoke-baseline` to regenerate). A sentinel whose
+   `just update-perf-smoke-baseline` to regenerate). The committed ceiling is
+   clamped to the absolute one, in this corpus and in `test/perf/nightly`
+   alike: a per-sentinel ceiling above the absolute ceiling can never fire,
+   because the absolute prong rejects any measurement that would have reached
+   it, so an unclamped "tighter" bound is a gate that silently never gates.
+   `test/perf/smoke`'s own unit lane asserts that invariant over the committed
+   file on every PR, so a ceiling that gates nothing fails without needing
+   Docker. A sentinel whose
    mechanism is a per-query ClickHouse SETTING carries a third bound, and it
    is the load-bearing one: `Sentinel.RequiredQuerySettings` names the
    settings that must appear in `system.query_log`'s `Settings` map on every

--- a/test/perf/nightly/baseline.go
+++ b/test/perf/nightly/baseline.go
@@ -67,6 +67,24 @@ func committedCeilingBytes(maxBytes uint64, headroom float64) uint64 {
 	return min(uint64(float64(maxBytes)*headroom), nightlyCapCeilingBytes)
 }
 
+// exceedsCapCeiling reports whether a measured peak trips PRONG (a), the
+// absolute cap-relative ceiling.
+//
+// The harness's PRONG (a) IS this call, so the unit lane drives the real
+// decision rather than a restatement of it: a prong that started comparing the
+// wrong quantity, or flipped its boundary, fails in baseline_test.go instead of
+// waiting for a real regression to go unreported.
+func exceedsCapCeiling(maxBytes uint64) bool {
+	return maxBytes > nightlyCapCeilingBytes
+}
+
+// exceedsCommittedCeiling reports whether a measured peak trips PRONG (b), the
+// committed per-sentinel ceiling. The harness's PRONG (b) IS this call — see
+// exceedsCapCeiling for why that matters.
+func exceedsCommittedCeiling(maxBytes uint64, bound nightlyBound) bool {
+	return maxBytes > bound.CeilingBytes
+}
+
 // --- baseline load/write (invariant 9: never hand-edited) -----------------
 
 // nightlyBaselinePath is the committed bound file, a sibling of

--- a/test/perf/nightly/baseline.go
+++ b/test/perf/nightly/baseline.go
@@ -1,0 +1,132 @@
+// baseline.go — the perf-nightly corpus's committed memory bounds and the
+// arithmetic that derives them.
+//
+// Untagged, while the harness that consumes it
+// (realch_perfnightly_integration_test.go) is behind `integration`, for the
+// same reason test/perf/smoke's baseline.go is: the two ceilings a sentinel is
+// asserted against are pure arithmetic over committed numbers, and the
+// invariant that keeps the tighter of them honest — PRONG (b) must never be
+// looser than PRONG (a) — is a property of the committed file, not of a
+// ClickHouse container. Keeping the derivation here lets baseline_test.go
+// assert it through the ordinary unit lane instead of only when somebody
+// regenerates with Docker present.
+package nightly
+
+import (
+	"encoding/json"
+	"fmt"
+	"math"
+	"os"
+)
+
+// perfNightlyMemoryCapBytes matches CERBERUS_CH_QUERY_MAX_MEMORY's default —
+// see test/perf/smoke's sentinelMemoryCapBytes for why this is the value a
+// real deployment runs under, not a value tuned for this test.
+const perfNightlyMemoryCapBytes int64 = 1 << 30 // 1 GiB
+
+// nightlyMemoryCapFraction is PRONG (a)'s absolute ceiling. Same rationale
+// as test/perf/smoke's sentinelMemoryCapFraction (above
+// spillThreshold(cap)'s implied 0.5, below 1.0's OOM boundary), but NOT the
+// same value — 0.75 (smoke's own midpoint pick) does not fit this lane's
+// real measured data. Calibrated against this lane's own real
+// post-#2429-fix, max-of-5 numbers: the two ExpectedStatus=200 sentinels
+// measured 0.9% and 76.2% of cap; the two ExpectedStatus=422 sentinels
+// (rejected BEFORE the expensive stage runs, by design) measured 25.9% and
+// 27.6% at rejection. pod_status_reason_gauge's 76.2% already exceeds
+// 0.75x — a plain `sum by (reason) (...)` gauge aggregation over this
+// sample's real 7,024-series cardinality (855 distinct pods, only 8
+// distinct `reason` values it collapses to) genuinely costs this much;
+// filed as issue #2435 for its own investigation rather than silently
+// absorbed into a looser fraction picked to avoid looking at it. 0.85
+// keeps real, verified margin (~8 points) above that measured cost while
+// staying meaningfully below ClickHouse's own 1.0 OOM boundary.
+const nightlyMemoryCapFraction = 0.85
+
+// nightlyCapCeilingBytes is PRONG (a): the ABSOLUTE, cap-relative ceiling
+// every sentinel's peak memory must stay under, independent of any committed
+// number.
+//
+// A var rather than a const, and math.Round rather than a truncating
+// conversion: (1<<30)*0.85 is not itself an exact integer, so it has to go
+// through runtime float64 arithmetic — Go's exact-rational constant folding
+// refuses the conversion outright. (test/perf/smoke's 0.75 happens to divide
+// 2^30 evenly, which is why its equivalent IS a const.)
+var nightlyCapCeilingBytes = uint64(math.Round(float64(perfNightlyMemoryCapBytes) * nightlyMemoryCapFraction))
+
+// committedCeilingBytes derives one sentinel's PRONG (b) ceiling — the number
+// written into nightly-baseline.json — from its calibration-time max-of-N
+// measurement and its own per-sentinel headroom multiplier.
+//
+// The min() is the load-bearing part: for a sentinel already close to the
+// absolute ceiling (pod_status_reason_gauge measured 76.6% against a 1.5x
+// headroom — 1.5x of THAT already exceeds the 1 GiB cap outright), an
+// unclamped committed ceiling would sit above PRONG (a)'s own bound, making
+// PRONG (b) permanently unable to fire — a looser "tighter" check is a gate
+// that silently never gates. PRONG (b) must never be looser than PRONG (a).
+func committedCeilingBytes(maxBytes uint64, headroom float64) uint64 {
+	return min(uint64(float64(maxBytes)*headroom), nightlyCapCeilingBytes)
+}
+
+// --- baseline load/write (invariant 9: never hand-edited) -----------------
+
+// nightlyBaselinePath is the committed bound file, a sibling of
+// perf-smoke-baseline.json one level up from this package.
+const nightlyBaselinePath = "../nightly-baseline.json"
+
+// nightlyBound is one sentinel's committed bound: the calibration-time
+// max-of-N measurement (kept for the diff/failure message), the
+// headroom-multiplied, cap-clamped ceiling the gate actually asserts against,
+// and the HTTP status the sentinel was calibrated to expect (PRONG (b) itself
+// re-checks this against the sentinel's CURRENT ExpectedStatus, catching a
+// baseline gone stale relative to sentinels.go rather than silently
+// comparing memory across two different outcome classes).
+type nightlyBound struct {
+	Name           string `json:"name"`
+	ExpectedStatus int    `json:"expected_status"`
+	MaxOfNBytes    uint64 `json:"max_of_n_bytes"`
+	CeilingBytes   uint64 `json:"ceiling_bytes"`
+}
+
+type nightlyBaseline struct {
+	Sentinels []nightlyBound `json:"sentinels"`
+}
+
+func baselineFor(b nightlyBaseline, name string) (nightlyBound, bool) {
+	for _, s := range b.Sentinels {
+		if s.Name == name {
+			return s, true
+		}
+	}
+	return nightlyBound{}, false
+}
+
+// readNightlyBaseline parses the committed bound file. It returns the read and
+// the parse error separately from any test plumbing so both the integration
+// harness and the unit lane can consume the same loader.
+func readNightlyBaseline() (nightlyBaseline, error) {
+	buf, err := os.ReadFile(nightlyBaselinePath)
+	if err != nil {
+		return nightlyBaseline{}, fmt.Errorf("read baseline %s: %w", nightlyBaselinePath, err)
+	}
+	var b nightlyBaseline
+	if err := json.Unmarshal(buf, &b); err != nil {
+		return nightlyBaseline{}, fmt.Errorf("parse baseline %s: %w", nightlyBaselinePath, err)
+	}
+	return b, nil
+}
+
+// writeNightlyBaselineFile serialises bounds (in Sentinels order) as pretty
+// JSON with a trailing newline, so the committed file diffs cleanly and is
+// never hand-edited (invariant 9). Its only caller is the
+// UPDATE_NIGHTLY_PERF_BASELINE=1 calibration path.
+func writeNightlyBaselineFile(bounds []nightlyBound) error {
+	buf, err := json.MarshalIndent(nightlyBaseline{Sentinels: bounds}, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal baseline: %w", err)
+	}
+	buf = append(buf, '\n')
+	if err := os.WriteFile(nightlyBaselinePath, buf, 0o644); err != nil {
+		return fmt.Errorf("write baseline: %w", err)
+	}
+	return nil
+}

--- a/test/perf/nightly/baseline.go
+++ b/test/perf/nightly/baseline.go
@@ -125,7 +125,7 @@ func writeNightlyBaselineFile(bounds []nightlyBound) error {
 		return fmt.Errorf("marshal baseline: %w", err)
 	}
 	buf = append(buf, '\n')
-	if err := os.WriteFile(nightlyBaselinePath, buf, 0o644); err != nil {
+	if err := os.WriteFile(nightlyBaselinePath, buf, 0o600); err != nil {
 		return fmt.Errorf("write baseline: %w", err)
 	}
 	return nil

--- a/test/perf/nightly/baseline_test.go
+++ b/test/perf/nightly/baseline_test.go
@@ -1,0 +1,108 @@
+package nightly
+
+import "testing"
+
+// TestCommittedCeilingBytes_ClampsToTheAbsoluteCeiling pins the clamp itself.
+// Without it the calibration path is free to write a PRONG (b) ceiling that
+// PRONG (a) makes unreachable — a per-sentinel bound that gates nothing, which
+// is what test/perf/smoke shipped with until issue #2906.
+func TestCommittedCeilingBytes_ClampsToTheAbsoluteCeiling(t *testing.T) {
+	// pod_status_reason_gauge's own calibration measurement: the sentinel whose
+	// existence forced the clamp here in the first place, since 1.5x of it
+	// overshoots the 1 GiB cap outright.
+	var overshoot uint64 = 751_191_629
+	const headroom = 1.5
+
+	cases := []struct {
+		name     string
+		maxBytes uint64
+		want     uint64
+	}{
+		{"well under the ceiling", 100_000_000, 150_000_000},
+		{"overshoots the ceiling", overshoot, nightlyCapCeilingBytes},
+		{"already over the ceiling", nightlyCapCeilingBytes + 1, nightlyCapCeilingBytes},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := committedCeilingBytes(tc.maxBytes, headroom); got != tc.want {
+				t.Fatalf("committedCeilingBytes(%d, %v) = %d, want %d", tc.maxBytes, headroom, got, tc.want)
+			}
+		})
+	}
+
+	// The overshoot case is only meaningful if the UNCLAMPED arithmetic really
+	// would have produced a ceiling above the absolute one — otherwise the
+	// assertion above would hold with the clamp deleted.
+	unclamped := uint64(float64(overshoot) * headroom)
+	if unclamped <= nightlyCapCeilingBytes {
+		t.Fatalf("unclamped ceiling for %d is %d, which does not exceed the absolute ceiling %d — "+
+			"the clamp case above proves nothing; pick a larger measurement",
+			overshoot, unclamped, nightlyCapCeilingBytes)
+	}
+}
+
+// TestNightlyBaseline_ProngBIsNeverLooserThanProngA asserts, over the COMMITTED
+// baseline rather than over arithmetic alone, that every sentinel's PRONG (b)
+// ceiling is one PRONG (a) can actually let a measurement reach — and that the
+// committed number is exactly what committedCeilingBytes derives from the
+// committed measurement and the sentinel's own headroom, so a hand-edited or
+// half-regenerated baseline (invariant 9) fails here rather than silently
+// gating less than it claims.
+//
+// test/perf/smoke's baseline_test.go carries the same assertion over its own
+// corpus. Both lanes clamp, so both are held to it: an invariant enforced in
+// one of two sibling corpora is one the other is free to drift away from.
+func TestNightlyBaseline_ProngBIsNeverLooserThanProngA(t *testing.T) {
+	baseline := mustReadBaseline(t)
+	for _, sentinel := range Sentinels {
+		bound, ok := baselineFor(baseline, sentinel.Name)
+		if !ok {
+			t.Errorf("%s: no committed bound in %s — the sentinel runs with PRONG (b) missing entirely",
+				sentinel.Name, nightlyBaselinePath)
+			continue
+		}
+		if bound.CeilingBytes > nightlyCapCeilingBytes {
+			t.Errorf("%s: committed ceiling %d exceeds the absolute cap-relative ceiling %d — "+
+				"PRONG (a) rejects first, so PRONG (b) can never fire and this sentinel gates "+
+				"with one of its two guards dead",
+				sentinel.Name, bound.CeilingBytes, nightlyCapCeilingBytes)
+		}
+		if want := committedCeilingBytes(bound.MaxOfNBytes, sentinel.BaselineHeadroom); bound.CeilingBytes != want {
+			t.Errorf("%s: committed ceiling %d is not committedCeilingBytes(%d, %v) = %d — regenerate with "+
+				"`just update-nightly-perf-baseline` rather than editing the file",
+				sentinel.Name, bound.CeilingBytes, bound.MaxOfNBytes, sentinel.BaselineHeadroom, want)
+		}
+	}
+}
+
+// TestNightlyBaseline_CalibrationMeasurementPassesBothProngs is the other
+// direction: a clamped PRONG (b) is only correct if a legitimate measurement
+// still passes. The calibration-time max-of-N committed alongside each ceiling
+// is the most legitimate measurement there is, so it must clear both prongs.
+func TestNightlyBaseline_CalibrationMeasurementPassesBothProngs(t *testing.T) {
+	baseline := mustReadBaseline(t)
+	for _, bound := range baseline.Sentinels {
+		if bound.MaxOfNBytes > nightlyCapCeilingBytes {
+			t.Errorf("%s: calibration measurement %d already exceeds the absolute ceiling %d — "+
+				"the committed baseline records a PRONG (a) failure",
+				bound.Name, bound.MaxOfNBytes, nightlyCapCeilingBytes)
+		}
+		if bound.MaxOfNBytes > bound.CeilingBytes {
+			t.Errorf("%s: calibration measurement %d already exceeds its own committed ceiling %d — "+
+				"the gate is red on the very run that produced it",
+				bound.Name, bound.MaxOfNBytes, bound.CeilingBytes)
+		}
+	}
+}
+
+func mustReadBaseline(t *testing.T) nightlyBaseline {
+	t.Helper()
+	baseline, err := readNightlyBaseline()
+	if err != nil {
+		t.Fatalf("%v", err)
+	}
+	if len(baseline.Sentinels) == 0 {
+		t.Fatalf("%s carries no sentinel bounds", nightlyBaselinePath)
+	}
+	return baseline
+}

--- a/test/perf/nightly/baseline_test.go
+++ b/test/perf/nightly/baseline_test.go
@@ -82,12 +82,12 @@ func TestNightlyBaseline_ProngBIsNeverLooserThanProngA(t *testing.T) {
 func TestNightlyBaseline_CalibrationMeasurementPassesBothProngs(t *testing.T) {
 	baseline := mustReadBaseline(t)
 	for _, bound := range baseline.Sentinels {
-		if bound.MaxOfNBytes > nightlyCapCeilingBytes {
+		if exceedsCapCeiling(bound.MaxOfNBytes) {
 			t.Errorf("%s: calibration measurement %d already exceeds the absolute ceiling %d — "+
 				"the committed baseline records a PRONG (a) failure",
 				bound.Name, bound.MaxOfNBytes, nightlyCapCeilingBytes)
 		}
-		if bound.MaxOfNBytes > bound.CeilingBytes {
+		if exceedsCommittedCeiling(bound.MaxOfNBytes, bound) {
 			t.Errorf("%s: calibration measurement %d already exceeds its own committed ceiling %d — "+
 				"the gate is red on the very run that produced it",
 				bound.Name, bound.MaxOfNBytes, bound.CeilingBytes)

--- a/test/perf/nightly/realch_perfnightly_integration_test.go
+++ b/test/perf/nightly/realch_perfnightly_integration_test.go
@@ -88,9 +88,9 @@ package nightly
 
 import (
 	"context"
-	"encoding/json"
+	"errors"
 	"fmt"
-	"math"
+	"io/fs"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -117,28 +117,10 @@ const perfNightlyCHImage = "clickhouse/clickhouse-server:25.9-alpine"
 
 const perfNightlyDB = "default"
 
-// perfNightlyMemoryCapBytes matches CERBERUS_CH_QUERY_MAX_MEMORY's default —
-// see test/perf/smoke's sentinelMemoryCapBytes for why this is the value a
-// real deployment runs under, not a value tuned for this test.
-const perfNightlyMemoryCapBytes int64 = 1 << 30 // 1 GiB
-
-// nightlyMemoryCapFraction is PRONG (a)'s absolute ceiling. Same rationale
-// as test/perf/smoke's sentinelMemoryCapFraction (above
-// spillThreshold(cap)'s implied 0.5, below 1.0's OOM boundary), but NOT the
-// same value — 0.75 (smoke's own midpoint pick) does not fit this lane's
-// real measured data. Calibrated against this lane's own real
-// post-#2429-fix, max-of-5 numbers: the two ExpectedStatus=200 sentinels
-// measured 0.9% and 76.2% of cap; the two ExpectedStatus=422 sentinels
-// (rejected BEFORE the expensive stage runs, by design) measured 25.9% and
-// 27.6% at rejection. pod_status_reason_gauge's 76.2% already exceeds
-// 0.75x — a plain `sum by (reason) (...)` gauge aggregation over this
-// sample's real 7,024-series cardinality (855 distinct pods, only 8
-// distinct `reason` values it collapses to) genuinely costs this much;
-// filed as issue #2435 for its own investigation rather than silently
-// absorbed into a looser fraction picked to avoid looking at it. 0.85
-// keeps real, verified margin (~8 points) above that measured cost while
-// staying meaningfully below ClickHouse's own 1.0 OOM boundary.
-const nightlyMemoryCapFraction = 0.85
+// perfNightlyMemoryCapBytes, nightlyMemoryCapFraction and the
+// nightlyCapCeilingBytes / committedCeilingBytes derivation they feed live in
+// the untagged baseline.go, so the unit lane can assert the derived bounds
+// without Docker.
 
 // Per-sentinel committed-ceiling headroom multipliers used to be one
 // package-wide nightlyBaselineHeadroom constant (1.5x, mirroring
@@ -331,12 +313,7 @@ func TestPerfNightlyRealCH(t *testing.T) {
 			// this point is never reached (a mismatch is fatal).
 			result.StatusOK = true
 
-			// math.Round forces this through runtime float64 arithmetic rather
-			// than Go's exact-rational constant folding — (1<<30)*0.85 is not
-			// itself an exact integer, unlike smoke's own 0.75 (which happens
-			// to divide 2^30 evenly), so a bare uint64(...) conversion of the
-			// constant expression fails to compile.
-			capCeiling := uint64(math.Round(float64(perfNightlyMemoryCapBytes) * nightlyMemoryCapFraction))
+			capCeiling := nightlyCapCeilingBytes
 			t.Logf("%s (%s): max-of-%d peak memory_usage = %d bytes (%.1f%% of %d-byte cap; absolute ceiling %d), expected status %d",
 				sentinel.Name, sentinel.Family, nightlySentinelRepeats, maxBytes,
 				100*float64(maxBytes)/float64(perfNightlyMemoryCapBytes), perfNightlyMemoryCapBytes, capCeiling, sentinel.ExpectedStatus)
@@ -347,15 +324,9 @@ func TestPerfNightlyRealCH(t *testing.T) {
 			result.CapOK = maxBytes <= capCeiling
 
 			if update {
-				// Clamp to capCeiling: for a sentinel already close to the
-				// absolute ceiling (pod_status_reason_gauge measured 76.6%
-				// against a 1.5x headroom — 1.5x of THAT already exceeds the
-				// 1 GiB cap outright), an unclamped committed ceiling would
-				// sit above PRONG (a)'s own bound, making PRONG (b)
-				// permanently unable to fire — a looser "tighter" check is a
-				// gate that silently never gates. PRONG (b) must never be
-				// looser than PRONG (a).
-				ceiling := min(uint64(float64(maxBytes)*sentinel.BaselineHeadroom), capCeiling)
+				// committedCeilingBytes clamps to capCeiling — see its own
+				// comment for why an unclamped PRONG (b) ceiling gates nothing.
+				ceiling := committedCeilingBytes(maxBytes, sentinel.BaselineHeadroom)
 				updated[sentinel.Name] = nightlyBound{
 					Name: sentinel.Name, ExpectedStatus: sentinel.ExpectedStatus,
 					MaxOfNBytes: maxBytes, CeilingBytes: ceiling,
@@ -505,75 +476,37 @@ func startPerfNightlyCH(ctx context.Context, t *testing.T) (*tcclickhouse.ClickH
 }
 
 // --- baseline load/write (invariant 9: never hand-edited) -----------------
-
-// nightlyBaselinePath is the committed bound file, a sibling of
-// perf-smoke-baseline.json one level up from this package.
-const nightlyBaselinePath = "../nightly-baseline.json"
-
-// nightlyBound is one sentinel's committed bound: the calibration-time
-// max-of-N measurement (kept for the diff/failure message), the
-// headroom-multiplied ceiling the gate actually asserts against, and the
-// HTTP status the sentinel was calibrated to expect (PRONG (b) itself
-// re-checks this against the sentinel's CURRENT ExpectedStatus, catching a
-// baseline gone stale relative to sentinels.go rather than silently
-// comparing memory across two different outcome classes).
-type nightlyBound struct {
-	Name           string `json:"name"`
-	ExpectedStatus int    `json:"expected_status"`
-	MaxOfNBytes    uint64 `json:"max_of_n_bytes"`
-	CeilingBytes   uint64 `json:"ceiling_bytes"`
-}
-
-type nightlyBaseline struct {
-	Sentinels []nightlyBound `json:"sentinels"`
-}
-
-func baselineFor(b nightlyBaseline, name string) (nightlyBound, bool) {
-	for _, s := range b.Sentinels {
-		if s.Name == name {
-			return s, true
-		}
-	}
-	return nightlyBound{}, false
-}
+//
+// The file format, the loader and the writer live in the untagged baseline.go;
+// these two wrappers add only this lane's test plumbing (t.Fatalf, and the
+// calibration path's tolerance for a not-yet-created file).
 
 func loadNightlyBaseline(t *testing.T) nightlyBaseline {
 	t.Helper()
-	buf, err := os.ReadFile(nightlyBaselinePath)
+	b, err := readNightlyBaseline()
 	if err != nil {
-		if os.Getenv("UPDATE_NIGHTLY_PERF_BASELINE") == "1" {
+		if os.Getenv("UPDATE_NIGHTLY_PERF_BASELINE") == "1" && errors.Is(err, fs.ErrNotExist) {
 			return nightlyBaseline{}
 		}
-		t.Fatalf("read baseline %s: %v — run `just update-nightly-perf-baseline` to create it", nightlyBaselinePath, err)
-	}
-	var b nightlyBaseline
-	if err := json.Unmarshal(buf, &b); err != nil {
-		t.Fatalf("parse baseline %s: %v", nightlyBaselinePath, err)
+		t.Fatalf("%v — run `just update-nightly-perf-baseline` to create it", err)
 	}
 	return b
 }
 
-// writeNightlyBaseline serialises updated (keyed by sentinel name, in
-// Sentinels order) as pretty JSON with a trailing newline, so the committed
-// file diffs cleanly and is never hand-edited (invariant 9) — this is the
-// ONLY code path that writes nightly-baseline.json, gated on
-// UPDATE_NIGHTLY_PERF_BASELINE=1.
+// writeNightlyBaseline orders updated (keyed by sentinel name) by Sentinels and
+// hands it to writeNightlyBaselineFile — this is the ONLY code path that
+// writes nightly-baseline.json, gated on UPDATE_NIGHTLY_PERF_BASELINE=1.
 func writeNightlyBaseline(t *testing.T, updated map[string]nightlyBound) {
 	t.Helper()
-	out := nightlyBaseline{Sentinels: make([]nightlyBound, 0, len(Sentinels))}
+	bounds := make([]nightlyBound, 0, len(Sentinels))
 	for _, s := range Sentinels {
 		bound, ok := updated[s.Name]
 		if !ok {
 			t.Fatalf("writeNightlyBaseline: no measurement for sentinel %q", s.Name)
 		}
-		out.Sentinels = append(out.Sentinels, bound)
+		bounds = append(bounds, bound)
 	}
-	buf, err := json.MarshalIndent(out, "", "  ")
-	if err != nil {
-		t.Fatalf("marshal baseline: %v", err)
-	}
-	buf = append(buf, '\n')
-	if err := os.WriteFile(nightlyBaselinePath, buf, 0o644); err != nil {
+	if err := writeNightlyBaselineFile(bounds); err != nil {
 		t.Fatalf("write baseline: %v", err)
 	}
 	t.Logf("wrote %s", nightlyBaselinePath)

--- a/test/perf/nightly/realch_perfnightly_integration_test.go
+++ b/test/perf/nightly/realch_perfnightly_integration_test.go
@@ -355,10 +355,15 @@ func TestPerfNightlyRealCH(t *testing.T) {
 			result.BaselineCeilingBytes = bound.CeilingBytes
 			result.BaselineOK = maxBytes <= bound.CeilingBytes
 			if maxBytes > bound.CeilingBytes {
+				// The committed ceiling's ACTUAL ratio to the calibration
+				// measurement, not sentinel.BaselineHeadroom: a sentinel whose
+				// ceiling committedCeilingBytes clamped to the absolute one
+				// carries less than its nominal multiple.
+				headroom := float64(bound.CeilingBytes) / float64(bound.MaxOfNBytes)
 				t.Errorf("%s: peak memory %d bytes exceeds the committed ceiling %d bytes (measured max-of-N was "+
 					"%d at calibration time, %.2fx headroom) — %s may have regressed; only run "+
 					"`just update-nightly-perf-baseline` if the increase is genuinely intended",
-					sentinel.Name, maxBytes, bound.CeilingBytes, bound.MaxOfNBytes, sentinel.BaselineHeadroom, sentinel.Family)
+					sentinel.Name, maxBytes, bound.CeilingBytes, bound.MaxOfNBytes, headroom, sentinel.Family)
 			}
 
 			// Every check above passed — this is the ONLY place Pass is set

--- a/test/perf/nightly/realch_perfnightly_integration_test.go
+++ b/test/perf/nightly/realch_perfnightly_integration_test.go
@@ -321,7 +321,7 @@ func TestPerfNightlyRealCH(t *testing.T) {
 			result.MaxOfNBytes = maxBytes
 			result.CapCeilingBytes = capCeiling
 			result.CapFractionPct = 100 * float64(maxBytes) / float64(perfNightlyMemoryCapBytes)
-			result.CapOK = maxBytes <= capCeiling
+			result.CapOK = !exceedsCapCeiling(maxBytes)
 
 			if update {
 				// committedCeilingBytes clamps to capCeiling — see its own
@@ -335,7 +335,7 @@ func TestPerfNightlyRealCH(t *testing.T) {
 			}
 
 			// PRONG (a): absolute, cap-relative ceiling.
-			if maxBytes > capCeiling {
+			if exceedsCapCeiling(maxBytes) {
 				t.Errorf("%s: peak memory %d bytes exceeds the absolute cap-relative ceiling %d bytes "+
 					"(%.0f%% of the %d-byte cap) — %s may have regressed",
 					sentinel.Name, maxBytes, capCeiling, 100*nightlyMemoryCapFraction, perfNightlyMemoryCapBytes, sentinel.Family)
@@ -353,8 +353,8 @@ func TestPerfNightlyRealCH(t *testing.T) {
 					sentinel.Name, bound.ExpectedStatus, sentinel.ExpectedStatus)
 			}
 			result.BaselineCeilingBytes = bound.CeilingBytes
-			result.BaselineOK = maxBytes <= bound.CeilingBytes
-			if maxBytes > bound.CeilingBytes {
+			result.BaselineOK = !exceedsCommittedCeiling(maxBytes, bound)
+			if exceedsCommittedCeiling(maxBytes, bound) {
 				// The committed ceiling's ACTUAL ratio to the calibration
 				// measurement, not sentinel.BaselineHeadroom: a sentinel whose
 				// ceiling committedCeilingBytes clamped to the absolute one

--- a/test/perf/nightly/sentinels.go
+++ b/test/perf/nightly/sentinels.go
@@ -136,7 +136,9 @@ type Sentinel struct {
 	WindowEnd   time.Time
 	Step        time.Duration
 	// BaselineHeadroom is this sentinel's own committed-ceiling multiplier
-	// against the max-of-N calibration measurement — see the
+	// against the max-of-N calibration measurement — the NOMINAL multiple,
+	// before committedCeilingBytes clamps it to nightlyCapCeilingBytes; a
+	// sentinel close to the absolute ceiling ends up with less. See the
 	// *BaselineHeadroom constants above for the real, independent-process
 	// noise data each value is calibrated against, and why a single
 	// package-wide multiplier does not fit all four sentinels.

--- a/test/perf/perf-smoke-baseline.json
+++ b/test/perf/perf-smoke-baseline.json
@@ -2,23 +2,23 @@
   "sentinels": [
     {
       "name": "native_histogram_quantile",
-      "max_of_n_bytes": 206521225,
-      "ceiling_bytes": 309781837
+      "max_of_n_bytes": 206521201,
+      "ceiling_bytes": 309781801
     },
     {
       "name": "spill_high_cardinality_groupby",
-      "max_of_n_bytes": 651518401,
-      "ceiling_bytes": 977277601
+      "max_of_n_bytes": 667298209,
+      "ceiling_bytes": 805306368
     },
     {
       "name": "compare_memory_bound",
-      "max_of_n_bytes": 682416449,
-      "ceiling_bytes": 1023624673
+      "max_of_n_bytes": 682442721,
+      "ceiling_bytes": 805306368
     },
     {
       "name": "join_spill_vector_join",
-      "max_of_n_bytes": 449714998,
-      "ceiling_bytes": 674572497
+      "max_of_n_bytes": 449714870,
+      "ceiling_bytes": 674572305
     }
   ]
 }

--- a/test/perf/smoke/baseline.go
+++ b/test/perf/smoke/baseline.go
@@ -52,7 +52,10 @@ const sentinelMemoryCapFraction = 0.75
 
 // sentinelBaselineHeadroom multiplies each sentinel's calibrated max-of-N
 // measurement to derive its committed per-sentinel ceiling in
-// perf-smoke-baseline.json. 1.5x mirrors scale_wall_pin_chdb_test.go's
+// perf-smoke-baseline.json — the NOMINAL multiple, before
+// committedCeilingBytes clamps it to sentinelCapCeilingBytes; a sentinel close
+// to the absolute ceiling ends up with less. 1.5x mirrors
+// scale_wall_pin_chdb_test.go's
 // scanAmplificationHeadroom (its low-variance prong): real-CH memory_usage
 // across the calibration repeats varied by well under 2% run-to-run for
 // every sentinel (e.g. Sentinel 3's five repeats at its calibrated scale all

--- a/test/perf/smoke/baseline.go
+++ b/test/perf/smoke/baseline.go
@@ -92,6 +92,24 @@ func committedCeilingBytes(maxBytes uint64) uint64 {
 	return min(uint64(float64(maxBytes)*sentinelBaselineHeadroom), sentinelCapCeilingBytes)
 }
 
+// exceedsCapCeiling reports whether a measured peak trips PRONG (a), the
+// absolute cap-relative ceiling.
+//
+// The harness's PRONG (a) IS this call, so the unit lane drives the real
+// decision rather than a restatement of it: a prong that started comparing the
+// wrong quantity, or flipped its boundary, fails in baseline_test.go instead of
+// waiting for a real regression to go unreported.
+func exceedsCapCeiling(maxBytes uint64) bool {
+	return maxBytes > sentinelCapCeilingBytes
+}
+
+// exceedsCommittedCeiling reports whether a measured peak trips PRONG (b), the
+// committed per-sentinel ceiling. The harness's PRONG (b) IS this call — see
+// exceedsCapCeiling for why that matters.
+func exceedsCommittedCeiling(maxBytes uint64, bound sentinelBound) bool {
+	return maxBytes > bound.CeilingBytes
+}
+
 // --- baseline load/write (invariant 9: never hand-edited) -----------------
 
 // perfSmokeBaselinePath is the committed bound file, a sibling of

--- a/test/perf/smoke/baseline.go
+++ b/test/perf/smoke/baseline.go
@@ -145,7 +145,7 @@ func writePerfSmokeBaselineFile(bounds []sentinelBound) error {
 		return fmt.Errorf("marshal baseline: %w", err)
 	}
 	buf = append(buf, '\n')
-	if err := os.WriteFile(perfSmokeBaselinePath, buf, 0o644); err != nil {
+	if err := os.WriteFile(perfSmokeBaselinePath, buf, 0o600); err != nil {
 		return fmt.Errorf("write baseline: %w", err)
 	}
 	return nil

--- a/test/perf/smoke/baseline.go
+++ b/test/perf/smoke/baseline.go
@@ -1,0 +1,149 @@
+// baseline.go — the perf-smoke corpus's committed memory bounds and the
+// arithmetic that derives them.
+//
+// This file is deliberately UNTAGGED while the harness that consumes it
+// (realch_perfsmoke_integration_test.go) is behind `integration`. The two
+// ceilings a sentinel is asserted against are pure arithmetic over committed
+// numbers, and the invariant that keeps the tighter of them honest — PRONG (b)
+// must never be looser than PRONG (a) — is a property of the committed file,
+// not of a ClickHouse container. Keeping the derivation here lets
+// sentinels_test.go assert it on every PR through the ordinary unit lane,
+// instead of only when somebody happens to regenerate the baseline with Docker
+// present. Issue #2906 is exactly the failure that costs: the clamp below was
+// missing for the whole life of this corpus and nothing could observe it.
+package smoke
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+)
+
+// --- calibrated constants -------------------------------------------------
+//
+// Every number below was measured, not guessed, against a real
+// testcontainers ClickHouse on this branch. See each constant's own comment
+// for the specific run that produced it; the PR description carries the full
+// calibration log.
+
+// sentinelMemoryCapBytes is the max_memory_usage cap the whole test session
+// runs under. 1 GiB matches config's default CERBERUS_CH_QUERY_MAX_MEMORY —
+// the cap a real deployment runs under by default — so
+// spillThreshold(cap) (spill.go) resolves to the exact 512 MiB the #2364
+// incident's own postmortem cites, and Sentinel 2's seed cardinality is
+// calibrated to reliably cross it at this specific cap.
+const sentinelMemoryCapBytes int64 = 1 << 30 // 1 GiB
+
+// sentinelMemoryCapFraction bounds the ABSOLUTE, cap-relative ceiling every
+// sentinel's peak memory must stay under: strictly above spillCapDenominator's
+// implied 0.5 (spill.go — below that fraction spill should already have
+// engaged and kept every query comfortably under half the cap) and strictly
+// below 1.0 (ClickHouse's own MEMORY_LIMIT_EXCEEDED boundary). 0.75 sits at
+// the midpoint of that (0.5, 1.0) admissible band. Calibration against a real
+// testcontainers ClickHouse measured every sentinel comfortably under this
+// line: Sentinel 1 (native histogram) ~205 MiB (19% of the 1 GiB cap),
+// Sentinel 2 (spill) ~650 MiB (61%) at its calibrated 10,000-series
+// cardinality, Sentinel 3 (compare) ~682 MiB (64%) at its calibrated
+// 40,000-trace cardinality — every one comfortably under the 0.75x/805 MiB
+// line with real margin, so 0.75 is not tuned tight to the measured data; it
+// is the band midpoint the task asked for, validated rather than picked
+// blind.
+const sentinelMemoryCapFraction = 0.75
+
+// sentinelBaselineHeadroom multiplies each sentinel's calibrated max-of-N
+// measurement to derive its committed per-sentinel ceiling in
+// perf-smoke-baseline.json. 1.5x mirrors scale_wall_pin_chdb_test.go's
+// scanAmplificationHeadroom (its low-variance prong): real-CH memory_usage
+// across the calibration repeats varied by well under 2% run-to-run for
+// every sentinel (e.g. Sentinel 3's five repeats at its calibrated scale all
+// landed within 4 bytes of each other, 682,475,556-682,475,660), far tighter
+// than scale-wall's WALL-clock prong (which uses 2.5x precisely because wall
+// is noisier), so the tighter 1.5x is the deliberate choice for a memory
+// metric.
+const sentinelBaselineHeadroom = 1.5
+
+// sentinelCapCeilingBytes is PRONG (a): the ABSOLUTE, cap-relative ceiling
+// every sentinel's peak memory must stay under, independent of any committed
+// number. 0.75 divides 2^30 evenly, so this constant expression is exact and
+// needs none of the math.Round test/perf/nightly's 0.85 fraction does.
+const sentinelCapCeilingBytes = uint64(float64(sentinelMemoryCapBytes) * sentinelMemoryCapFraction)
+
+// committedCeilingBytes derives one sentinel's PRONG (b) ceiling — the number
+// written into perf-smoke-baseline.json — from its calibration-time max-of-N
+// measurement.
+//
+// The min() is the load-bearing part, and it mirrors test/perf/nightly's own
+// calibration path rather than inventing a second mechanism: for a sentinel
+// already close to the absolute ceiling, an unclamped
+// maxBytes*sentinelBaselineHeadroom sits ABOVE PRONG (a)'s own bound, and a
+// ceiling above PRONG (a)'s can never fire — PRONG (a) rejects first, every
+// time. A looser "tighter" check is a gate that silently never gates. PRONG
+// (b) must never be looser than PRONG (a).
+//
+// Issue #2906: the smoke lane shipped without this clamp, so
+// spill_high_cardinality_groupby (committed 977,277,601) and
+// compare_memory_bound (committed 1,023,624,673) both carried ceilings above
+// the 805,306,368-byte absolute one and gated nothing at all — on the lane
+// that runs on every PR through the required strict-scan job.
+func committedCeilingBytes(maxBytes uint64) uint64 {
+	return min(uint64(float64(maxBytes)*sentinelBaselineHeadroom), sentinelCapCeilingBytes)
+}
+
+// --- baseline load/write (invariant 9: never hand-edited) -----------------
+
+// perfSmokeBaselinePath is the committed bound file, a sibling of
+// scale-wall-baseline.json one level up from this package.
+const perfSmokeBaselinePath = "../perf-smoke-baseline.json"
+
+// sentinelBound is one sentinel's committed bound: the calibration-time
+// max-of-N measurement (kept for the diff/failure message) and the
+// headroom-multiplied, cap-clamped ceiling the gate actually asserts against.
+type sentinelBound struct {
+	Name         string `json:"name"`
+	MaxOfNBytes  uint64 `json:"max_of_n_bytes"`
+	CeilingBytes uint64 `json:"ceiling_bytes"`
+}
+
+type perfSmokeBaseline struct {
+	Sentinels []sentinelBound `json:"sentinels"`
+}
+
+func baselineFor(b perfSmokeBaseline, name string) (sentinelBound, bool) {
+	for _, s := range b.Sentinels {
+		if s.Name == name {
+			return s, true
+		}
+	}
+	return sentinelBound{}, false
+}
+
+// readPerfSmokeBaseline parses the committed bound file. It returns the read
+// and the parse error separately from any test plumbing so both the
+// integration harness and the unit lane can consume the same loader.
+func readPerfSmokeBaseline() (perfSmokeBaseline, error) {
+	buf, err := os.ReadFile(perfSmokeBaselinePath)
+	if err != nil {
+		return perfSmokeBaseline{}, fmt.Errorf("read baseline %s: %w", perfSmokeBaselinePath, err)
+	}
+	var b perfSmokeBaseline
+	if err := json.Unmarshal(buf, &b); err != nil {
+		return perfSmokeBaseline{}, fmt.Errorf("parse baseline %s: %w", perfSmokeBaselinePath, err)
+	}
+	return b, nil
+}
+
+// writePerfSmokeBaselineFile serialises bounds (in Sentinels order) as pretty
+// JSON with a trailing newline, so the committed file diffs cleanly and is
+// never hand-edited (invariant 9). Its only caller is the
+// UPDATE_PERF_SMOKE_BASELINE=1 calibration path.
+func writePerfSmokeBaselineFile(bounds []sentinelBound) error {
+	buf, err := json.MarshalIndent(perfSmokeBaseline{Sentinels: bounds}, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal baseline: %w", err)
+	}
+	buf = append(buf, '\n')
+	if err := os.WriteFile(perfSmokeBaselinePath, buf, 0o644); err != nil {
+		return fmt.Errorf("write baseline: %w", err)
+	}
+	return nil
+}

--- a/test/perf/smoke/baseline_test.go
+++ b/test/perf/smoke/baseline_test.go
@@ -105,12 +105,12 @@ func TestPerfSmokeBaseline_ProngBIsNeverLooserThanProngA(t *testing.T) {
 func TestPerfSmokeBaseline_CalibrationMeasurementPassesBothProngs(t *testing.T) {
 	baseline := mustReadBaseline(t)
 	for _, bound := range baseline.Sentinels {
-		if bound.MaxOfNBytes > sentinelCapCeilingBytes {
+		if exceedsCapCeiling(bound.MaxOfNBytes) {
 			t.Errorf("%s: calibration measurement %d already exceeds the absolute ceiling %d — "+
 				"the committed baseline records a PRONG (a) failure",
 				bound.Name, bound.MaxOfNBytes, sentinelCapCeilingBytes)
 		}
-		if bound.MaxOfNBytes > bound.CeilingBytes {
+		if exceedsCommittedCeiling(bound.MaxOfNBytes, bound) {
 			t.Errorf("%s: calibration measurement %d already exceeds its own committed ceiling %d — "+
 				"the gate is red on the very run that produced it",
 				bound.Name, bound.MaxOfNBytes, bound.CeilingBytes)
@@ -144,11 +144,29 @@ func TestPerfSmokeBaseline_ProngBFiresWhereItPreviouslyCouldNot(t *testing.T) {
 		if probe >= preClamp {
 			t.Fatalf("%s: probe %d is not strictly below the pre-clamp ceiling %d", name, probe, preClamp)
 		}
-		if probe <= bound.CeilingBytes {
-			t.Errorf("%s: a peak memory of %d bytes is still within the committed ceiling %d — "+
+
+		// The probe is a peak the PRE-CLAMP ceiling accepted. Stated against
+		// the real prong predicate, not a restatement of it: this is the exact
+		// call the integration harness makes.
+		if exceedsCommittedCeiling(probe, sentinelBound{Name: name, CeilingBytes: preClamp}) {
+			t.Fatalf("%s: probe %d already tripped the pre-clamp ceiling %d — it is not in the "+
+				"interval the clamp is supposed to have reclaimed", name, probe, preClamp)
+		}
+		if !exceedsCommittedCeiling(probe, bound) {
+			t.Errorf("%s: PRONG (b) accepts a peak memory of %d bytes against the committed ceiling %d — "+
 				"the pre-clamp ceiling %d accepted it too, so PRONG (b) has not actually been "+
 				"restored for this sentinel (#2906)",
 				name, probe, bound.CeilingBytes, preClamp)
+		}
+
+		// The other direction, on the same predicate: the calibration
+		// measurement this ceiling was derived from must still pass both
+		// prongs. A clamp that fired hard enough to reject a legitimate
+		// measurement would be a different bug, not a fix.
+		if exceedsCommittedCeiling(bound.MaxOfNBytes, bound) || exceedsCapCeiling(bound.MaxOfNBytes) {
+			t.Errorf("%s: the calibration measurement %d no longer passes both prongs against "+
+				"committed ceiling %d / absolute ceiling %d",
+				name, bound.MaxOfNBytes, bound.CeilingBytes, sentinelCapCeilingBytes)
 		}
 	}
 }

--- a/test/perf/smoke/baseline_test.go
+++ b/test/perf/smoke/baseline_test.go
@@ -1,0 +1,166 @@
+package smoke
+
+import "testing"
+
+// preClampCeilingBytes records, per sentinel, the ceiling
+// perf-smoke-baseline.json carried before issue #2906 clamped the calibration
+// path — the numbers produced by an unclamped
+// max-of-N * sentinelBaselineHeadroom.
+//
+// Both are ABOVE sentinelCapCeilingBytes, which is precisely the defect: a
+// PRONG (b) ceiling above PRONG (a)'s can never fire, because PRONG (a)
+// rejects any measurement that would have reached it. These two sentinels ran
+// with one of their two guards silently dead for the whole life of the corpus,
+// on the lane that gates every PR through the required strict-scan job.
+//
+// They are kept here, rather than deleted with the baseline they came from,
+// because they are what makes
+// TestPerfSmokeBaseline_ProngBFiresWhereItPreviouslyCouldNot a real
+// before/after: the probe it rejects is a value the OLD ceiling demonstrably
+// accepted, not an arbitrary large number.
+var preClampCeilingBytes = map[string]uint64{
+	"spill_high_cardinality_groupby": 977_277_601,
+	"compare_memory_bound":           1_023_624_673,
+}
+
+// TestCommittedCeilingBytes_ClampsToTheAbsoluteCeiling pins the clamp itself.
+// Without it the calibration path is free to write a PRONG (b) ceiling that
+// PRONG (a) makes unreachable, which is issue #2906 exactly.
+func TestCommittedCeilingBytes_ClampsToTheAbsoluteCeiling(t *testing.T) {
+	// A measurement whose headroom multiple still fits under the absolute
+	// ceiling keeps the full multiple; one whose multiple overshoots is
+	// clamped to the absolute ceiling. The boundary case (a measurement whose
+	// multiple lands exactly on the ceiling) must NOT be clamped away from the
+	// value the unclamped arithmetic produces.
+	// A var, not a const: 651,518,401 * 1.5 is not an integer, so the
+	// unclamped cross-check below has to go through runtime float64 arithmetic
+	// rather than Go's exact-rational constant folding.
+	var overshoot uint64 = 651_518_401 // spill_high_cardinality_groupby's calibration measurement
+	const boundary = uint64(float64(sentinelCapCeilingBytes) / sentinelBaselineHeadroom)
+
+	cases := []struct {
+		name     string
+		maxBytes uint64
+		want     uint64
+	}{
+		{"well under the ceiling", 100_000_000, 150_000_000},
+		{"exactly on the ceiling", boundary, sentinelCapCeilingBytes},
+		{"overshoots the ceiling", overshoot, sentinelCapCeilingBytes},
+		{"already over the ceiling", sentinelCapCeilingBytes + 1, sentinelCapCeilingBytes},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := committedCeilingBytes(tc.maxBytes); got != tc.want {
+				t.Fatalf("committedCeilingBytes(%d) = %d, want %d", tc.maxBytes, got, tc.want)
+			}
+		})
+	}
+
+	// The overshoot case is only meaningful if the UNCLAMPED arithmetic really
+	// would have produced a ceiling above the absolute one — otherwise the
+	// assertion above would hold with the clamp deleted.
+	unclamped := uint64(float64(overshoot) * sentinelBaselineHeadroom)
+	if unclamped <= sentinelCapCeilingBytes {
+		t.Fatalf("unclamped ceiling for %d is %d, which does not exceed the absolute ceiling %d — "+
+			"the clamp case above proves nothing; pick a larger measurement",
+			overshoot, unclamped, sentinelCapCeilingBytes)
+	}
+}
+
+// TestPerfSmokeBaseline_ProngBIsNeverLooserThanProngA is the gate issue #2906
+// exists for. It asserts, over the COMMITTED baseline rather than over
+// arithmetic alone, that every sentinel's PRONG (b) ceiling is one PRONG (a)
+// can actually let a measurement reach — and that the committed number is
+// exactly what committedCeilingBytes derives from the committed measurement,
+// so a hand-edited or half-regenerated baseline (invariant 9) fails here
+// rather than silently gating less than it claims.
+func TestPerfSmokeBaseline_ProngBIsNeverLooserThanProngA(t *testing.T) {
+	baseline := mustReadBaseline(t)
+	for _, sentinel := range Sentinels {
+		bound, ok := baselineFor(baseline, sentinel.Name)
+		if !ok {
+			t.Errorf("%s: no committed bound in %s — the sentinel runs with PRONG (b) missing entirely",
+				sentinel.Name, perfSmokeBaselinePath)
+			continue
+		}
+		if bound.CeilingBytes > sentinelCapCeilingBytes {
+			t.Errorf("%s: committed ceiling %d exceeds the absolute cap-relative ceiling %d — "+
+				"PRONG (a) rejects first, so PRONG (b) can never fire and this sentinel gates "+
+				"with one of its two guards dead (#2906)",
+				sentinel.Name, bound.CeilingBytes, sentinelCapCeilingBytes)
+		}
+		if want := committedCeilingBytes(bound.MaxOfNBytes); bound.CeilingBytes != want {
+			t.Errorf("%s: committed ceiling %d is not committedCeilingBytes(%d) = %d — regenerate with "+
+				"`just update-perf-smoke-baseline` rather than editing the file",
+				sentinel.Name, bound.CeilingBytes, bound.MaxOfNBytes, want)
+		}
+	}
+}
+
+// TestPerfSmokeBaseline_CalibrationMeasurementPassesBothProngs is the other
+// direction: tightening PRONG (b) is only correct if a legitimate measurement
+// still passes. The calibration-time max-of-N committed alongside each ceiling
+// is the most legitimate measurement there is, so it must clear both prongs
+// with the documented headroom still intact.
+func TestPerfSmokeBaseline_CalibrationMeasurementPassesBothProngs(t *testing.T) {
+	baseline := mustReadBaseline(t)
+	for _, bound := range baseline.Sentinels {
+		if bound.MaxOfNBytes > sentinelCapCeilingBytes {
+			t.Errorf("%s: calibration measurement %d already exceeds the absolute ceiling %d — "+
+				"the committed baseline records a PRONG (a) failure",
+				bound.Name, bound.MaxOfNBytes, sentinelCapCeilingBytes)
+		}
+		if bound.MaxOfNBytes > bound.CeilingBytes {
+			t.Errorf("%s: calibration measurement %d already exceeds its own committed ceiling %d — "+
+				"the gate is red on the very run that produced it",
+				bound.Name, bound.MaxOfNBytes, bound.CeilingBytes)
+		}
+	}
+}
+
+// TestPerfSmokeBaseline_ProngBFiresWhereItPreviouslyCouldNot is the
+// red-before-green half of the #2906 fix, expressed as a standing assertion:
+// for each sentinel whose ceiling was above the absolute one, a peak-memory
+// value the OLD ceiling accepted must now be rejected by the committed one.
+//
+// The probe is derived, not picked: the midpoint of the interval
+// (sentinelCapCeilingBytes, preClampCeilingBytes) — every value in which the
+// pre-clamp ceiling let through and the clamped ceiling must not.
+func TestPerfSmokeBaseline_ProngBFiresWhereItPreviouslyCouldNot(t *testing.T) {
+	baseline := mustReadBaseline(t)
+	for name, preClamp := range preClampCeilingBytes {
+		bound, ok := baselineFor(baseline, name)
+		if !ok {
+			t.Errorf("%s: no committed bound in %s", name, perfSmokeBaselinePath)
+			continue
+		}
+		if preClamp <= sentinelCapCeilingBytes {
+			t.Errorf("%s: recorded pre-clamp ceiling %d does not exceed the absolute ceiling %d — "+
+				"this sentinel was never one of the inert ones and does not belong in "+
+				"preClampCeilingBytes", name, preClamp, sentinelCapCeilingBytes)
+			continue
+		}
+		probe := sentinelCapCeilingBytes + (preClamp-sentinelCapCeilingBytes)/2
+		if probe >= preClamp {
+			t.Fatalf("%s: probe %d is not strictly below the pre-clamp ceiling %d", name, probe, preClamp)
+		}
+		if probe <= bound.CeilingBytes {
+			t.Errorf("%s: a peak memory of %d bytes is still within the committed ceiling %d — "+
+				"the pre-clamp ceiling %d accepted it too, so PRONG (b) has not actually been "+
+				"restored for this sentinel (#2906)",
+				name, probe, bound.CeilingBytes, preClamp)
+		}
+	}
+}
+
+func mustReadBaseline(t *testing.T) perfSmokeBaseline {
+	t.Helper()
+	baseline, err := readPerfSmokeBaseline()
+	if err != nil {
+		t.Fatalf("%v", err)
+	}
+	if len(baseline.Sentinels) == 0 {
+		t.Fatalf("%s carries no sentinel bounds", perfSmokeBaselinePath)
+	}
+	return baseline
+}

--- a/test/perf/smoke/realch_perfsmoke_integration_test.go
+++ b/test/perf/smoke/realch_perfsmoke_integration_test.go
@@ -49,8 +49,9 @@ package smoke
 
 import (
 	"context"
-	"encoding/json"
+	"errors"
 	"fmt"
+	"io/fs"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -106,45 +107,12 @@ const perfSmokeDB = "default"
 // --- calibrated constants (task 4) ----------------------------------------
 //
 // Every number below was measured, not guessed, against a real
-// testcontainers ClickHouse 25.8-alpine on this branch. See each constant's
-// own comment for the specific run that produced it; the PR description
-// carries the full calibration log.
-
-// sentinelMemoryCapBytes is the max_memory_usage cap the whole test session
-// runs under. 1 GiB matches config's default CERBERUS_CH_QUERY_MAX_MEMORY —
-// the cap a real deployment runs under by default — so
-// spillThreshold(cap) (spill.go) resolves to the exact 512 MiB the #2364
-// incident's own postmortem cites, and Sentinel 2's seed cardinality is
-// calibrated to reliably cross it at this specific cap.
-const sentinelMemoryCapBytes int64 = 1 << 30 // 1 GiB
-
-// sentinelMemoryCapFraction bounds the ABSOLUTE, cap-relative ceiling every
-// sentinel's peak memory must stay under: strictly above spillCapDenominator's
-// implied 0.5 (spill.go — below that fraction spill should already have
-// engaged and kept every query comfortably under half the cap) and strictly
-// below 1.0 (ClickHouse's own MEMORY_LIMIT_EXCEEDED boundary). 0.75 sits at
-// the midpoint of that (0.5, 1.0) admissible band. Calibration against a real
-// testcontainers ClickHouse 25.8-alpine measured every sentinel comfortably
-// under this line: Sentinel 1 (native histogram) ~205 MiB (19% of the 1 GiB
-// cap), Sentinel 2 (spill) ~650 MiB (61%) at its calibrated 10,000-series
-// cardinality, Sentinel 3 (compare) ~682 MiB (64%) at its calibrated
-// 40,000-trace cardinality — every one comfortably under the 0.75x/805 MiB
-// line with real margin, so 0.75 is not tuned tight to the measured data; it
-// is the band midpoint the task asked for, validated rather than picked
-// blind.
-const sentinelMemoryCapFraction = 0.75
-
-// sentinelBaselineHeadroom multiplies each sentinel's calibrated max-of-N
-// measurement to derive its committed per-sentinel ceiling in
-// perf-smoke-baseline.json. 1.5x mirrors scale_wall_pin_chdb_test.go's
-// scanAmplificationHeadroom (its low-variance prong): real-CH memory_usage
-// across the calibration repeats varied by well under 2% run-to-run for
-// every sentinel (e.g. Sentinel 3's five repeats at its calibrated scale all
-// landed within 4 bytes of each other, 682,475,556-682,475,660), far tighter
-// than scale-wall's WALL-clock prong (which uses 2.5x precisely because wall
-// is noisier), so the tighter 1.5x is the deliberate choice for a memory
-// metric.
-const sentinelBaselineHeadroom = 1.5
+// testcontainers ClickHouse on this branch. See each constant's own comment
+// for the specific run that produced it; the PR description carries the full
+// calibration log. The memory-cap fraction and the baseline headroom — the
+// two numbers the ceilings themselves are derived from — live in the untagged
+// baseline.go alongside that derivation, so the unit lane can assert the
+// derived bounds without Docker.
 
 // sentinelRepeats (N) is the max-of-N repeat count each sentinel's memory
 // measurement is taken over — a CEILING gate wants the worst observed case,
@@ -307,13 +275,16 @@ func runSentinelFloor(
 				}
 			}
 
-			capCeiling := uint64(float64(sentinelMemoryCapBytes) * sentinelMemoryCapFraction)
+			const capCeiling = sentinelCapCeilingBytes
 			t.Logf("%s (%s): max-of-%d peak memory_usage = %d bytes (%.1f%% of %d-byte cap; absolute ceiling %d)",
 				sentinel.Name, sentinel.Mechanism, sentinelRepeats, maxBytes,
 				100*float64(maxBytes)/float64(sentinelMemoryCapBytes), sentinelMemoryCapBytes, capCeiling)
 
 			if update {
-				ceiling := uint64(float64(maxBytes) * sentinelBaselineHeadroom)
+				// committedCeilingBytes clamps to capCeiling — see its own
+				// comment for why an unclamped PRONG (b) ceiling gates
+				// nothing (#2906).
+				ceiling := committedCeilingBytes(maxBytes)
 				updated[sentinel.Name] = sentinelBound{Name: sentinel.Name, MaxOfNBytes: maxBytes, CeilingBytes: ceiling}
 				return
 			}
@@ -534,70 +505,37 @@ func startPerfSmokeCH(ctx context.Context, t *testing.T, image string) *chclient
 }
 
 // --- baseline load/write (invariant 9: never hand-edited) -----------------
-
-// perfSmokeBaselinePath is the committed bound file, a sibling of
-// scale-wall-baseline.json one level up from this package.
-const perfSmokeBaselinePath = "../perf-smoke-baseline.json"
-
-// sentinelBound is one sentinel's committed bound: the calibration-time
-// max-of-N measurement (kept for the diff/failure message) and the
-// headroom-multiplied ceiling the gate actually asserts against.
-type sentinelBound struct {
-	Name         string `json:"name"`
-	MaxOfNBytes  uint64 `json:"max_of_n_bytes"`
-	CeilingBytes uint64 `json:"ceiling_bytes"`
-}
-
-type perfSmokeBaseline struct {
-	Sentinels []sentinelBound `json:"sentinels"`
-}
-
-func baselineFor(b perfSmokeBaseline, name string) (sentinelBound, bool) {
-	for _, s := range b.Sentinels {
-		if s.Name == name {
-			return s, true
-		}
-	}
-	return sentinelBound{}, false
-}
+//
+// The file format, the loader and the writer live in the untagged baseline.go;
+// these two wrappers add only this lane's test plumbing (t.Fatalf, and the
+// calibration path's tolerance for a not-yet-created file).
 
 func loadPerfSmokeBaseline(t *testing.T) perfSmokeBaseline {
 	t.Helper()
-	buf, err := os.ReadFile(perfSmokeBaselinePath)
+	b, err := readPerfSmokeBaseline()
 	if err != nil {
-		if os.Getenv("UPDATE_PERF_SMOKE_BASELINE") == "1" {
+		if os.Getenv("UPDATE_PERF_SMOKE_BASELINE") == "1" && errors.Is(err, fs.ErrNotExist) {
 			return perfSmokeBaseline{}
 		}
-		t.Fatalf("read baseline %s: %v — run `just update-perf-smoke-baseline` to create it", perfSmokeBaselinePath, err)
-	}
-	var b perfSmokeBaseline
-	if err := json.Unmarshal(buf, &b); err != nil {
-		t.Fatalf("parse baseline %s: %v", perfSmokeBaselinePath, err)
+		t.Fatalf("%v — run `just update-perf-smoke-baseline` to create it", err)
 	}
 	return b
 }
 
-// writePerfSmokeBaseline serialises updated (keyed by sentinel name, in
-// Sentinels order) as pretty JSON with a trailing newline, so the committed
-// file diffs cleanly and is never hand-edited (invariant 9) — this is the
-// ONLY code path that writes perf-smoke-baseline.json, gated on
-// UPDATE_PERF_SMOKE_BASELINE=1.
+// writePerfSmokeBaseline orders updated (keyed by sentinel name) by Sentinels
+// and hands it to writePerfSmokeBaselineFile — this is the ONLY code path that
+// writes perf-smoke-baseline.json, gated on UPDATE_PERF_SMOKE_BASELINE=1.
 func writePerfSmokeBaseline(t *testing.T, updated map[string]sentinelBound) {
 	t.Helper()
-	out := perfSmokeBaseline{Sentinels: make([]sentinelBound, 0, len(Sentinels))}
+	bounds := make([]sentinelBound, 0, len(Sentinels))
 	for _, s := range Sentinels {
 		bound, ok := updated[s.Name]
 		if !ok {
 			t.Fatalf("writePerfSmokeBaseline: no measurement for sentinel %q", s.Name)
 		}
-		out.Sentinels = append(out.Sentinels, bound)
+		bounds = append(bounds, bound)
 	}
-	buf, err := json.MarshalIndent(out, "", "  ")
-	if err != nil {
-		t.Fatalf("marshal baseline: %v", err)
-	}
-	buf = append(buf, '\n')
-	if err := os.WriteFile(perfSmokeBaselinePath, buf, 0o644); err != nil {
+	if err := writePerfSmokeBaselineFile(bounds); err != nil {
 		t.Fatalf("write baseline: %v", err)
 	}
 	t.Logf("wrote %s", perfSmokeBaselinePath)

--- a/test/perf/smoke/realch_perfsmoke_integration_test.go
+++ b/test/perf/smoke/realch_perfsmoke_integration_test.go
@@ -109,10 +109,10 @@ const perfSmokeDB = "default"
 // Every number below was measured, not guessed, against a real
 // testcontainers ClickHouse on this branch. See each constant's own comment
 // for the specific run that produced it; the PR description carries the full
-// calibration log. The memory-cap fraction and the baseline headroom — the
-// two numbers the ceilings themselves are derived from — live in the untagged
-// baseline.go alongside that derivation, so the unit lane can assert the
-// derived bounds without Docker.
+// calibration log. The memory cap, its ceiling fraction and the baseline
+// headroom — the numbers the ceilings themselves are derived from — live in
+// the untagged baseline.go alongside that derivation, so the unit lane can
+// assert the derived bounds without Docker.
 
 // sentinelRepeats (N) is the max-of-N repeat count each sentinel's memory
 // measurement is taken over — a CEILING gate wants the worst observed case,

--- a/test/perf/smoke/realch_perfsmoke_integration_test.go
+++ b/test/perf/smoke/realch_perfsmoke_integration_test.go
@@ -302,10 +302,18 @@ func runSentinelFloor(
 				t.Fatalf("%s: no committed bound in perf-smoke-baseline.json — run `just update-perf-smoke-baseline`", sentinel.Name)
 			}
 			if maxBytes > bound.CeilingBytes {
+				// The headroom reported is the committed ceiling's ACTUAL
+				// ratio to the calibration measurement, not
+				// sentinelBaselineHeadroom: a sentinel whose ceiling
+				// committedCeilingBytes clamped to the absolute one carries
+				// less than the nominal multiple, and printing the nominal
+				// figure would misreport how much margin the sentinel really
+				// had.
+				headroom := float64(bound.CeilingBytes) / float64(bound.MaxOfNBytes)
 				t.Errorf("%s: peak memory %d bytes exceeds the committed ceiling %d bytes (measured max-of-N was "+
 					"%d at calibration time, %.2fx headroom) — %s may have regressed; only run "+
 					"`just update-perf-smoke-baseline` if the increase is genuinely intended",
-					sentinel.Name, maxBytes, bound.CeilingBytes, bound.MaxOfNBytes, sentinelBaselineHeadroom, sentinel.Mechanism)
+					sentinel.Name, maxBytes, bound.CeilingBytes, bound.MaxOfNBytes, headroom, sentinel.Mechanism)
 			}
 		})
 	}


### PR DESCRIPTION
## The defect

`test/perf/smoke` derives each sentinel's committed PRONG (b) ceiling as an
unclamped `max-of-N * sentinelBaselineHeadroom`. PRONG (a)'s absolute,
cap-relative ceiling is `1 GiB * 0.75` = **805,306,368** bytes. Two of the four
sentinels carried committed ceilings above that line:

| sentinel | committed ceiling | PRONG (a) ceiling | PRONG (b) could fire? |
|---|---|---|---|
| `native_histogram_quantile` | 309,781,837 | 805,306,368 | yes |
| `spill_high_cardinality_groupby` | 977,277,601 | 805,306,368 | **no** |
| `compare_memory_bound` | 1,023,624,673 | 805,306,368 | **no** |
| `join_spill_vector_join` | 674,572,497 | 805,306,368 | yes |

A PRONG (b) ceiling above PRONG (a)'s can never fire — PRONG (a) rejects any
measurement that would have reached it. Half of this corpus was gating with one
of its two guards dead, on the lane that runs on every PR through the required
`strict-scan` job.

## How nightly clamps, and how this mirrors it

`test/perf/nightly`'s calibration path already clamps, and its comment names
this exact failure mode:

```go
ceiling := min(uint64(float64(maxBytes)*sentinel.BaselineHeadroom), capCeiling)
```

The smoke lane now derives its ceiling through the same expression, not a
second mechanism:

```go
return min(uint64(float64(maxBytes)*sentinelBaselineHeadroom), sentinelCapCeilingBytes)
```

The two corpora differ only where they genuinely differ — smoke's fraction is
0.75 and its headroom a single package constant; nightly's is 0.85 with a
per-sentinel headroom, and its absolute ceiling needs `math.Round` because
`(1<<30)*0.85` is not an integer while smoke's `*0.75` is. Both now express the
clamp as one named function, `committedCeilingBytes`, sitting next to the
constants it reads.

To stop the two drifting, nightly gets the same structure and the same standing
assertion: it already clamped, but nothing observed that it kept clamping, and
an invariant enforced in one of two sibling corpora is one the other is free to
drift away from.

## The structural half

The clamp, the constants it derives from, the baseline format/loader, and both
prong predicates move out of the `integration`-tagged harness into an untagged
`baseline.go` in each corpus. That is load-bearing, not tidying: the invariant
is a property of the committed file, not of a ClickHouse container, so it now
fails in the ordinary unit lane on every PR instead of only when somebody
regenerates the baseline with Docker present. The absence of any such assertion
is exactly why this went unobserved for the life of the corpus.

The harness's PRONG (a) and PRONG (b) *are* `exceedsCapCeiling` and
`exceedsCommittedCeiling`, so the unit lane drives the real decision rather than
a restatement of it — a prong that started comparing the wrong quantity, or
flipped its boundary, fails in `baseline_test.go`.

## Corrected ceilings, and whether anything was masked

Regenerated through `just update-perf-smoke-baseline` against real
testcontainers ClickHouse (25.9-alpine base floor, 26.6-alpine join-spill
floor), max-of-5 per sentinel:

| sentinel | max-of-5 (was) | max-of-5 (now) | drift | ceiling (was) | ceiling (now) | headroom |
|---|---|---|---|---|---|---|
| `native_histogram_quantile` | 206,521,225 | 206,521,201 | -24 B | 309,781,837 | 309,781,801 | 1.50x |
| `spill_high_cardinality_groupby` | 651,518,401 | 667,298,209 | +2.42% | 977,277,601 | **805,306,368** | 1.21x |
| `compare_memory_bound` | 682,416,449 | 682,442,721 | +0.004% | 1,023,624,673 | **805,306,368** | 1.18x |
| `join_spill_vector_join` | 449,714,998 | 449,714,870 | -128 B | 674,572,497 | 674,572,305 | 1.50x |

**Both sentinels still pass, and nothing was masked.** Both re-measure within a
few percent of the numbers the pre-clamp baseline recorded, so the tightened
prong is a live guard over an unchanged workload rather than a regression being
papered over. No ceiling was raised anywhere in this change.

Three further independent measurements, two local and one on CI, agree:

| run | `spill_high_cardinality_groupby` | `compare_memory_bound` | verdict |
|---|---|---|---|
| calibration | 667,298,209 | 682,442,721 | — |
| local gate run 1 | (green) | (green) | PASS |
| local gate run 2 | 655,543,977 | 685,404,978 | PASS |
| local gate run 3 | 655,172,717 | 682,295,113 | PASS |
| CI `strict-scan` | — | — | PASS |

Spread across those runs is 1.8% for the spill sentinel and 0.45% for compare,
against 21% and 18% of remaining headroom under the clamped ceiling.

**Flake risk on CI is nil by construction**, not by argument: for those two
sentinels the clamped PRONG (b) ceiling is now *exactly* PRONG (a)'s, and
PRONG (a) has been enforced at 805,306,368 on every PR since the corpus shipped
and is green. A measurement that trips the new PRONG (b) is one that already
trips the guard CI runs today. The other two sentinels' ceilings move by 36 and
192 bytes, against measurements that reproduce to within 900 bytes across four
independent calibrations.

## Verification: PRONG (b) actually fires

The standing assertion is
`TestPerfSmokeBaseline_ProngBFiresWhereItPreviouslyCouldNot`. It derives a probe
at the midpoint of `(absolute ceiling, pre-clamp ceiling)` — every value in that
interval is one the old ceiling accepted and the clamped one must reject — and
puts it through the harness's own PRONG (b) predicate. Against the pre-clamp
baseline it is red:

```
--- FAIL: TestPerfSmokeBaseline_ProngBIsNeverLooserThanProngA
    spill_high_cardinality_groupby: committed ceiling 977277601 exceeds the absolute cap-relative ceiling 805306368 — PRONG (a) rejects first, so PRONG (b) can never fire and this sentinel gates with one of its two guards dead (#2906)
    compare_memory_bound: committed ceiling 1023624673 exceeds the absolute cap-relative ceiling 805306368 — ...
--- FAIL: TestPerfSmokeBaseline_ProngBFiresWhereItPreviouslyCouldNot
    spill_high_cardinality_groupby: PRONG (b) accepts a peak memory of 891291984 bytes against the committed ceiling 977277601 — the pre-clamp ceiling 977277601 accepted it too, so PRONG (b) has not actually been restored for this sentinel (#2906)
    compare_memory_bound: PRONG (b) accepts a peak memory of 914465520 bytes against the committed ceiling 1023624673 — ...
```

That is a unit-level statement, so it was also confirmed end to end. Feeding
those same probes into the real harness in place of the measured peak — a
temporary edit, the way #2908 temporarily removed a settings stamp — makes the
live gate fail on both sentinels, against a real ClickHouse:

```
DEMO: overriding measured 655172717 with pre-clamp-accepted probe 891291984
spill_high_cardinality_groupby: peak memory 891291984 bytes exceeds the committed ceiling 805306368 bytes (measured max-of-N was 667298209 at calibration time, 1.21x headroom) — applySpillSettings (internal/engine/spill.go) may have regressed

DEMO: overriding measured 682295113 with pre-clamp-accepted probe 914465520
compare_memory_bound: peak memory 914465520 bytes exceeds the committed ceiling 805306368 bytes (measured max-of-N was 682442721 at calibration time, 1.18x headroom) — applyCompareMemoryBound (internal/engine/query_settings_rules.go) may have regressed

--- FAIL: TestPerfSmokeRealCH/spill_high_cardinality_groupby (63.32s)
--- FAIL: TestPerfSmokeRealCH/compare_memory_bound (89.33s)
--- PASS: TestPerfSmokeRealCH/native_histogram_quantile (311.77s)
--- PASS: TestPerfSmokeRealCH/join_spill_vector_join (11.96s)
```

Before this change both of those peaks sat *under* the committed ceiling and
the gate stayed green. The same run's untouched sentinels stayed green, so the
failure is the prong firing rather than the harness breaking.

The clamp arithmetic itself is pinned separately by
`TestCommittedCeilingBytes_ClampsToTheAbsoluteCeiling`, which cross-checks that
its clamped case would genuinely have overshot unclamped — so the case cannot
pass with the `min()` deleted.

**The nightly mirror is not a vacuous green either.** Rewriting
`pod_status_reason_gauge`'s ceiling to what an unclamped calibration would have
written turns it red, and reverting turns it green:

```
--- FAIL: TestNightlyBaseline_ProngBIsNeverLooserThanProngA
    pod_status_reason_gauge: committed ceiling 1126787443 exceeds the absolute cap-relative ceiling 912680550 — PRONG (a) rejects first, so PRONG (b) can never fire and this sentinel gates with one of its two guards dead
```

Closes #2906

🤖 Generated with [Claude Code](https://claude.com/claude-code)
