### PR TITLE
fix(ci): derive lane path attribution from the Go import graph

### DIFF
--- a/.github/ci-lanes.json
+++ b/.github/ci-lanes.json
@@ -800,7 +800,12 @@
       "recipes": ["compat-promql"],
       "command": "Prometheus compatibility with CERBERUS_EVAL_ROUTE=sharded and FAIL_ON_DIFF=1",
       "build_tags": [],
-      "package_globs": ["compatibility/prometheus/**", "internal/solver/**"],
+      "package_globs": [
+        "compatibility/prometheus/**",
+        "internal/api/prom/**",
+        "internal/promql/**",
+        "internal/solver/**"
+      ],
       "substrate": "reference-stack",
       "risk_domains": ["promql", "solver", "sql"],
       "merge_posture": "never",

--- a/.github/scripts/README.md
+++ b/.github/scripts/README.md
@@ -194,10 +194,31 @@ above 20 minutes, a release-required SLO above 120 minutes, and observational
 lanes marked release-required. It also enforces each query head's oracle
 floor: PromQL Layer 6a, LogQL Layer 6b, and TraceQL Layer 6c must each retain
 source-applicable `execution`, `property`, and `reference` oracle providers
-that run on `main` and are required before a release.
+that run on `main` and are required before a release. Every `reference`
+provider must additionally name its own head's query-path packages
+(`internal/<ql>` and `internal/api/<head>`) in `package_globs`, because those
+are the seeds the affected-path derivation below starts from.
 `GITHUB_STEP_SUMMARY`, when set, receives a short registry summary. Direct
 execution emits a GitHub `::error::` and exits non-zero on any contract
 failure.
+
+`lib/lane-closure.mjs` derives what a lane actually validates, rather than
+reading it off `package_globs` (#2902). Those globs name a lane's own
+directories, which cannot express the fact that every head's SQL flows through
+one shared pipeline: PR #2824 moved `internal/chclient`, `internal/chopt`,
+`internal/engine`, `internal/config` and `cmd/cerberus`, matched none of
+`compatibility.loki`'s three globs, and produced #2895's 144-case LogQL parity
+regression on the lane that had just declared itself unaffected. The module
+treats the declared globs as SEEDS and unions them with the first-party
+dependency closure `go list` reports for those seeds — the same derivation
+`lib/golden-shards.mjs` applies to the golden shards, at the scale a 27-lane
+sweep needs: one `go list -json ./...` per distinct build-tag set (~20s)
+rather than one `go list -deps -test` per lane (~82s). Non-Go inputs — a
+compose file, a workflow, a reference-stack config — stay in `package_globs`,
+which is why the derived set is a union rather than a replacement.
+`merge-risk.mjs` is the live consumer; it exits non-zero rather than falling
+back to the raw declaration if the graph cannot be loaded, because a silent
+fallback would report the pre-#2902 answer under the post-#2902 name.
 
 `test/regression/ci_lane_registry_test.go`'s `TestCILaneRegistry` binds the
 registry to the workflow graph itself — total job ownership, the exact check

--- a/.github/scripts/ci-lane-contract.mjs
+++ b/.github/scripts/ci-lane-contract.mjs
@@ -81,6 +81,27 @@ const CANONICAL_HEAD_ORACLE_SOURCE_ROOTS = Object.freeze({
   }),
 });
 
+// The head packages a REFERENCE lane must name in its own `package_globs`
+// (#2902). A reference lane drives the real HTTP head against the reference
+// backend, so its query path starts at that head's API package and its query
+// language, and `lib/lane-closure.mjs` derives everything downstream — the
+// shared `chplan`/`optimizer`/`chsql`/`chclient`/`engine` pipeline — from
+// exactly these two roots. That is why they are a contract rather than a
+// convention: the closure is only as wide as the seeds it starts from, so a
+// lane that stops naming its own head silently narrows back to the pre-#2902
+// attribution, which is what let PR #2824 merge without `compatibility.loki`
+// considering itself touched.
+//
+// EXECUTION lanes are deliberately outside this rule rather than exempted from
+// it: a round-trip lane lowers and executes SQL without ever entering the HTTP
+// head, so requiring the API package of one would assert a dependency it does
+// not have.
+export const CANONICAL_HEAD_QUERY_PATH_ROOTS = Object.freeze({
+  promql: Object.freeze(["internal/promql", "internal/api/prom"]),
+  logql: Object.freeze(["internal/logql", "internal/api/loki"]),
+  traceql: Object.freeze(["internal/traceql", "internal/api/tempo"]),
+});
+
 const TOP_KEYS = new Set([
   "schema_version",
   "impact_selection",
@@ -599,6 +620,15 @@ function validateCanonicalHeadOracleFloors(lanes, root, recipeCommands, problems
           problems.push(
             `canonical head ${head} ${oracleClass} provider ${provider.id} has no real ` +
               `oracle/test source under ${sourceRoot} covered by package_globs`,
+          );
+        }
+        if (oracleClass !== "reference") continue;
+        for (const queryPathRoot of CANONICAL_HEAD_QUERY_PATH_ROOTS[head]) {
+          if (providerHasCanonicalSource(provider, root, queryPathRoot)) continue;
+          problems.push(
+            `canonical head ${head} reference provider ${provider.id} does not cover ` +
+              `${queryPathRoot} in package_globs, so the affected-path set derived from those ` +
+              `globs never reaches the shared query pipeline this lane runs through (#2902)`,
           );
         }
       }

--- a/.github/scripts/ci-lane-contract.test.mjs
+++ b/.github/scripts/ci-lane-contract.test.mjs
@@ -133,6 +133,16 @@ const canonicalSourceFiles = [
   ["compatibility", "prometheus", "oracle.test"],
   ["compatibility", "loki", "oracle.test"],
   ["compatibility", "tempo", "oracle.test"],
+  // The head query-path packages a reference lane must seed on, so the
+  // affected-path set derived from its globs reaches the shared pipeline
+  // (#2902). These are real files because the coverage check asks whether any
+  // file under the root matches a glob, not whether the directory exists.
+  ["internal", "promql", "lower.go"],
+  ["internal", "logql", "lower.go"],
+  ["internal", "traceql", "lower.go"],
+  ["internal", "api", "prom", "handler.go"],
+  ["internal", "api", "loki", "handler.go"],
+  ["internal", "api", "tempo", "handler.go"],
 ];
 for (const parts of canonicalSourceFiles) {
   mkdirSync(join(root, ...parts.slice(0, -1)), { recursive: true });
@@ -265,6 +275,12 @@ function registryFixture() {
           "compatibility/loki/**",
           "compatibility/prometheus/**",
           "compatibility/tempo/**",
+          "internal/api/loki/**",
+          "internal/api/prom/**",
+          "internal/api/tempo/**",
+          "internal/logql/**",
+          "internal/promql/**",
+          "internal/traceql/**",
         ],
         riskDomains: ["logql", "promql", "traceql"],
       }),
@@ -433,6 +449,41 @@ test("canonical providers fail when their workflow command is removed", () => {
       writeFileSync(workflow, original);
     }
   }
+});
+
+test("a reference lane that stops naming its own head query path is rejected", () => {
+  // #2902's seed rule. The derived affected-path set is the dependency closure
+  // of the packages a lane's globs name, so dropping the head's API package or
+  // its query language narrows the lane back to seeing only its own harness —
+  // which is exactly how PR #2824 moved the shared pipeline with no reference
+  // lane considering itself touched. Both roots are controlled independently:
+  // covering one must not excuse the other.
+  for (const dropped of ["internal/api/loki/**", "internal/logql/**"]) {
+    const narrowed = registryFixture();
+    const provider = narrowed.lanes.find(
+      (candidate) => candidate.id === "oracle-reference",
+    );
+    provider.package_globs = provider.package_globs.filter(
+      (glob) => glob !== dropped,
+    );
+    expectContractError(
+      () => validateRegistry(narrowed, { root }),
+      new RegExp(
+        `canonical head logql reference provider oracle-reference does not cover ` +
+          `${dropped.replace("/**", "").replace(/\//g, "\\/")} in package_globs`,
+      ),
+    );
+  }
+});
+
+test("the head query-path rule does not apply to an execution provider", () => {
+  // An execution lane lowers and executes SQL without entering the HTTP head,
+  // so requiring the API package of one would assert a dependency it has not
+  // got. The `always` lane declares only `test/spec/<head>/**` and stays valid.
+  const document = registryFixture();
+  const execution = document.lanes.find((candidate) => candidate.id === "always");
+  assert.ok(!execution.package_globs.some((glob) => glob.startsWith("internal/api/")));
+  assert.equal(validateRegistry(document, { root }), document);
 });
 
 test("canonical providers fail when their real oracle source is removed", () => {

--- a/.github/scripts/ci-lane-contract.test.mjs
+++ b/.github/scripts/ci-lane-contract.test.mjs
@@ -17,6 +17,7 @@ import { join } from "node:path";
 
 import {
   CANONICAL_HEAD_ORACLE_FLOORS,
+  CANONICAL_HEAD_QUERY_PATH_ROOTS,
   ContractError,
   MERGE_P95_SLO_MINUTES,
   RELEASE_QUALIFICATION_SLO_MINUTES,
@@ -456,22 +457,33 @@ test("a reference lane that stops naming its own head query path is rejected", (
   // of the packages a lane's globs name, so dropping the head's API package or
   // its query language narrows the lane back to seeing only its own harness —
   // which is exactly how PR #2824 moved the shared pipeline with no reference
-  // lane considering itself touched. Both roots are controlled independently:
-  // covering one must not excuse the other.
-  for (const dropped of ["internal/api/loki/**", "internal/logql/**"]) {
+  // lane considering itself touched. The roots are driven from the exported
+  // constant, and controlled one at a time: covering one must not excuse the
+  // other.
+  assert.ok(
+    CANONICAL_HEAD_QUERY_PATH_ROOTS.logql.length > 1,
+    "a single-root head would let this loop pass without testing independence",
+  );
+  for (const queryPathRoot of CANONICAL_HEAD_QUERY_PATH_ROOTS.logql) {
     const narrowed = registryFixture();
     const provider = narrowed.lanes.find(
       (candidate) => candidate.id === "oracle-reference",
     );
     provider.package_globs = provider.package_globs.filter(
-      (glob) => glob !== dropped,
+      (glob) => glob !== `${queryPathRoot}/**`,
     );
-    expectContractError(
-      () => validateRegistry(narrowed, { root }),
-      new RegExp(
-        `canonical head logql reference provider oracle-reference does not cover ` +
-          `${dropped.replace("/**", "").replace(/\//g, "\\/")} in package_globs`,
-      ),
+    // Matched as an exact substring rather than through a RegExp built by
+    // hand-escaping a path: the escaping is unnecessary here and reads as a
+    // real sanitizer, which is what CodeQL's js/incomplete-sanitization saw.
+    const caught = expectContractError(() =>
+      validateRegistry(narrowed, { root }),
+    );
+    const expected =
+      `canonical head logql reference provider oracle-reference does not cover ` +
+      `${queryPathRoot} in package_globs`;
+    assert.ok(
+      caught.message.includes(expected),
+      `expected the contract to name ${queryPathRoot}; got:\n${caught.message}`,
     );
   }
 });

--- a/.github/scripts/lib/golden-shards.mjs
+++ b/.github/scripts/lib/golden-shards.mjs
@@ -52,8 +52,12 @@ import { execFileSync, spawnSync } from 'node:child_process';
 import { existsSync, readdirSync, statSync } from 'node:fs';
 import path from 'node:path';
 
-/** The Go module path every first-party package import starts with. */
-const MODULE_PATH = 'github.com/tsouza/cerberus';
+/**
+ * The Go module path every first-party package import starts with. Exported
+ * because `lib/lane-closure.mjs` reads the same import graph for the CI lane
+ * registry and must draw the first-party boundary at exactly the same place.
+ */
+export const MODULE_PATH = 'github.com/tsouza/cerberus';
 
 function gitLines(repoRoot, args) {
   const r = spawnSync('git', args, { cwd: repoRoot, encoding: 'utf8' });

--- a/.github/scripts/lib/lane-closure.mjs
+++ b/.github/scripts/lib/lane-closure.mjs
@@ -1,0 +1,291 @@
+// lane-closure.mjs — which repository paths can move what a CI lane validates,
+// DERIVED from the Go import graph rather than declared.
+//
+// # THE BLIND SPOT THIS CLOSES (#2902, from the #2895 outage)
+//
+// `.github/ci-lanes.json` gives every lane a `package_globs` list, and gates
+// that attribute a change to a lane read it as "the paths this lane validates".
+// For the reference lanes that list names the lane's OWN directories and
+// nothing else. `compatibility.loki` declares
+//
+//     compatibility/loki/**, internal/logql/**, internal/api/loki/**
+//
+// and PR #2824 (`0d32cc96d`) — the change that produced #2895's 144-case LogQL
+// parity regression — moved `internal/chclient`, `internal/chopt`,
+// `internal/engine`, `internal/config` and `cmd/cerberus`. It matched none of
+// those three globs, so the one lane that would have caught the regression did
+// not consider itself affected by the change that caused it.
+//
+// That is not a typo in one list. cerberus is a SHARED pipeline (`chplan` →
+// `optimizer` → `chsql` → `chclient`, driven by `engine`) under three thin
+// heads, so a per-head glob list structurally cannot express "this lane also
+// depends on the shared pipeline". Any hand-written list of that dependency is
+// the drift, not the fix: the import graph moves every week and the list does
+// not.
+//
+// So the list is not extended. Each lane's declared globs are treated as SEEDS
+// — the packages the lane is about — and the paths it validates are the
+// first-party dependency closure of those seeds, read out of the import graph
+// `go list` reports. `lib/golden-shards.mjs` already solved the identical
+// problem for the golden shards this way (`impliedShards`, derivation 2), and
+// its own header says why a hand table was not acceptable there either.
+//
+// # WHY THIS LOADS THE GRAPH INSTEAD OF CALLING generatorPackageDirs
+//
+// `golden-shards.mjs`'s `generatorPackageDirs` runs `go list -deps -test` once
+// per shard: ten shards, and every one of them worth its own process. The lane
+// registry has 27 lanes that gate `main` while skipping pull requests, and
+// several of them seed on `internal` or `test` — measured on this tree, one
+// `go list -deps -test` per lane costs 82 seconds of wall clock and 58 seconds
+// of CPU for the registry. Loading the module's import EDGES once per build-tag
+// set (`go list -json`, 2.7s for the whole module) and walking the closure here
+// costs about 20 seconds for the same answer, on a required check that also
+// fires on every pull-request description edit. Same authority — `go list`
+// reading the real graph — at the scale this caller works at.
+//
+// # NON-GO INPUTS
+//
+// `go list` sees Go packages, and a lane can also be moved by a compose file, a
+// workflow, a reference-stack config or a fixture corpus. Those stay in
+// `package_globs`, and the derived closure is UNIONED with it rather than
+// replacing it. That division is stable in a way the old one was not: what is
+// left declared is the lane's own artefacts, which move when the lane moves,
+// while the transitive dependency — the half that drifted — is now derived.
+//
+// # ENV / INPUTS
+//
+// Pure module: no env of its own. Callers pass `repoRoot` and may inject
+// `runGoList(repoRoot, args) -> string` to test without a toolchain.
+
+import { existsSync, readdirSync, statSync } from 'node:fs';
+import { execFileSync } from 'node:child_process';
+import path from 'node:path';
+
+import { MODULE_PATH } from './golden-shards.mjs';
+
+/** The extension that makes a directory a Go package directory. */
+const GO_EXT = '.go';
+
+/** Directories `go list` itself never treats as packages. */
+const IGNORED_DIRS = new Set(['node_modules', 'testdata', '.git']);
+
+/** The `go list -json` fields the closure needs, and nothing else. */
+const GO_LIST_FIELDS = 'ImportPath,Dir,Imports,TestImports,XTestImports';
+
+function toSlash(p) {
+  return p.split(path.sep).join('/');
+}
+
+function isDirectory(absolute) {
+  try {
+    return statSync(absolute).isDirectory();
+  } catch {
+    return false;
+  }
+}
+
+/** Does this directory hold Go source anywhere beneath it? */
+export function holdsGoSource(repoRoot, dir) {
+  const stack = [path.join(repoRoot, dir)];
+  while (stack.length > 0) {
+    const current = stack.pop();
+    let entries;
+    try {
+      entries = readdirSync(current, { withFileTypes: true });
+    } catch {
+      continue;
+    }
+    for (const entry of entries) {
+      if (entry.isDirectory()) {
+        if (IGNORED_DIRS.has(entry.name) || entry.name.startsWith('.')) continue;
+        stack.push(path.join(current, entry.name));
+      } else if (entry.name.endsWith(GO_EXT)) {
+        return true;
+      }
+    }
+  }
+  return false;
+}
+
+/** The literal directory prefix of a glob — everything before its first `*`. */
+export function staticPrefix(glob) {
+  const segments = String(glob ?? '').split('/');
+  const wildcard = segments.findIndex((segment) => segment.includes('*'));
+  return wildcard === -1 ? String(glob ?? '') : segments.slice(0, wildcard).join('/');
+}
+
+/**
+ * The Go package directories a lane's own `package_globs` name.
+ *
+ * A glob anchored at a directory that holds Go source seeds that directory. A
+ * glob anchored at a single `.go` FILE seeds the package that file belongs to —
+ * a file is a member of its package, and its behaviour depends on everything
+ * that package depends on, so naming one file is not a way to claim a narrower
+ * dependency than the package has. A glob whose first segment is already a
+ * wildcard seeds nothing: it matches every path in the repository, so no
+ * closure could widen it.
+ */
+export function laneSeedDirs(lane, { repoRoot }) {
+  const seeds = new Set();
+  for (const glob of lane?.package_globs ?? []) {
+    const prefix = staticPrefix(glob);
+    if (prefix === '') continue;
+    const absolute = path.join(repoRoot, prefix);
+    if (!existsSync(absolute)) continue;
+    if (isDirectory(absolute)) {
+      if (holdsGoSource(repoRoot, prefix)) seeds.add(prefix);
+      continue;
+    }
+    if (!prefix.endsWith(GO_EXT)) continue;
+    const owner = path.posix.dirname(prefix);
+    if (owner !== '' && owner !== '.') seeds.add(owner);
+  }
+  return [...seeds].sort();
+}
+
+function defaultGoList(repoRoot, args) {
+  return execFileSync('go', args, {
+    cwd: repoRoot,
+    encoding: 'utf8',
+    maxBuffer: 64 * 1024 * 1024,
+  });
+}
+
+/**
+ * Split `go list -json`'s concatenated objects. The command pretty-prints one
+ * object per package with its closing brace in column zero, which is the only
+ * place a `}` can start a line, so that is the record separator.
+ */
+export function splitGoListJSON(text) {
+  const records = [];
+  let buffer = [];
+  for (const line of String(text ?? '').split('\n')) {
+    buffer.push(line);
+    if (line === '}') {
+      records.push(JSON.parse(buffer.join('\n')));
+      buffer = [];
+    }
+  }
+  return records;
+}
+
+/** A first-party import path reduced to its repo-relative package directory. */
+function firstPartyDir(importPath) {
+  if (importPath === MODULE_PATH) return '';
+  if (!importPath.startsWith(`${MODULE_PATH}/`)) return null;
+  return importPath.slice(MODULE_PATH.length + 1);
+}
+
+/**
+ * The first-party import graph, keyed by repo-relative package directory:
+ * `Map<dir, { imports, testImports }>`.
+ *
+ * The two edge sets are kept apart because `go list -deps -test <pattern>`
+ * keeps them apart: a package NAMED by the pattern contributes its test
+ * binaries' imports, while a package merely reached through the graph
+ * contributes only what it imports in production. Folding them into one set
+ * would make every transitive dependency drag in its own test fixtures, and a
+ * head's test helpers would then reach the other heads — the
+ * everything-depends-on-everything failure, which is the same blindness this
+ * module exists to remove, pointed the other way.
+ *
+ * `-e` keeps a package that does not build (a nested module's directory, a tag
+ * combination that leaves a package empty) from failing the whole load; such a
+ * package simply contributes no edges.
+ */
+export function loadPackageGraph({ repoRoot, tags = [], runGoList = defaultGoList }) {
+  const args = ['list', '-e', `-json=${GO_LIST_FIELDS}`];
+  if (tags.length > 0) args.push('-tags', [...tags].join(','));
+  args.push('./...');
+
+  const graph = new Map();
+  for (const pkg of splitGoListJSON(runGoList(repoRoot, args))) {
+    const dir = pkg.Dir ? toSlash(path.relative(repoRoot, pkg.Dir)) : firstPartyDir(pkg.ImportPath ?? '');
+    if (dir === null || dir === '' || dir.startsWith('..')) continue;
+    const node = graph.get(dir) ?? { imports: new Set(), testImports: new Set() };
+    for (const [list, into] of [
+      [pkg.Imports, node.imports],
+      [pkg.TestImports, node.testImports],
+      [pkg.XTestImports, node.testImports],
+    ]) {
+      for (const importPath of list ?? []) {
+        const target = firstPartyDir(importPath);
+        if (target) into.add(target);
+      }
+    }
+    graph.set(dir, node);
+  }
+  return graph;
+}
+
+function isUnder(dir, root) {
+  return dir === root || dir.startsWith(`${root}/`);
+}
+
+/**
+ * Every package directory reachable from `seeds` in `graph`, seeds included.
+ * A seed directory stands for every package at or beneath it, which is what
+ * `./<dir>/...` means to `go list`.
+ */
+export function closureFrom(graph, seeds) {
+  const reached = new Set();
+  for (const dir of graph.keys()) {
+    if (seeds.some((seed) => isUnder(dir, seed))) reached.add(dir);
+  }
+
+  // Seeds first, with their test edges; everything reached from there follows
+  // production imports only. See loadPackageGraph's note on why.
+  const frontier = [];
+  for (const seed of [...reached]) {
+    const node = graph.get(seed);
+    for (const next of [...node.imports, ...node.testImports]) {
+      if (reached.has(next)) continue;
+      reached.add(next);
+      frontier.push(next);
+    }
+  }
+  while (frontier.length > 0) {
+    for (const next of graph.get(frontier.pop())?.imports ?? []) {
+      if (reached.has(next)) continue;
+      reached.add(next);
+      frontier.push(next);
+    }
+  }
+  return reached;
+}
+
+/**
+ * The affected-path globs of one lane: its declared `package_globs` unioned
+ * with `<dir>/**` for every package in its seeds' dependency closure.
+ */
+export function affectedGlobsFor(lane, closureDirs) {
+  const globs = new Set(lane?.package_globs ?? []);
+  for (const dir of closureDirs) globs.add(`${dir}/**`);
+  return [...globs].sort();
+}
+
+/**
+ * `Map<laneID, string[]>` of affected-path globs for the given lanes.
+ *
+ * The import graph is loaded once per distinct build-tag set — build tags
+ * select which files, and so which imports, a package has, so a chdb-tagged
+ * lane and an untagged one do not see the same graph.
+ */
+export function laneAffectedGlobs(lanes, { repoRoot, runGoList = defaultGoList }) {
+  const graphs = new Map();
+  const out = new Map();
+  for (const lane of lanes) {
+    const tags = [...(lane.build_tags ?? [])].sort();
+    const key = tags.join(',');
+    if (!graphs.has(key)) graphs.set(key, loadPackageGraph({ repoRoot, tags, runGoList }));
+    const seeds = laneSeedDirs(lane, { repoRoot });
+    const closure = seeds.length === 0 ? new Set() : closureFrom(graphs.get(key), seeds);
+    out.set(lane.id, affectedGlobsFor(lane, closure));
+  }
+  return out;
+}
+
+/** `Map<laneID, string[]>` holding each lane's DECLARED globs and nothing else. */
+export function declaredGlobs(lanes) {
+  return new Map(lanes.map((lane) => [lane.id, [...(lane.package_globs ?? [])]]));
+}

--- a/.github/scripts/lib/lane-closure.test.mjs
+++ b/.github/scripts/lib/lane-closure.test.mjs
@@ -1,0 +1,236 @@
+// lane-closure.test.mjs — node:test guard for the lane affected-path
+// derivation (#2902).
+//
+// The derivation has two failure directions and both are pinned here. Too
+// NARROW is the bug it exists to fix: a lane that does not see the shared query
+// pipeline it runs through, which is how #2824 merged without
+// `compatibility.loki` considering itself touched. Too WIDE is the same
+// blindness pointed the other way: if every package drags in its own test
+// fixtures, every head reaches every other head and every lane is reported on
+// every pull request, which is a list nobody reads. The seed-only test-edge rule
+// is what separates them, so it is asserted directly rather than inferred from
+// a lane's totals.
+//
+// The graph is supplied by a stubbed `runGoList` throughout: this suite pins
+// the derivation, not the toolchain. `merge-risk.test.mjs` is where the real
+// import graph of this repository is read, against PR #2824's real file set.
+
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  affectedGlobsFor,
+  closureFrom,
+  declaredGlobs,
+  holdsGoSource,
+  laneAffectedGlobs,
+  laneSeedDirs,
+  loadPackageGraph,
+  splitGoListJSON,
+  staticPrefix,
+} from './lane-closure.mjs';
+
+const ROOT = process.cwd();
+const MODULE = 'github.com/tsouza/cerberus';
+
+/** One `go list -json` record, rendered the way the command renders it. */
+function record({ dir, imports = [], testImports = [], xtestImports = [] }) {
+  return JSON.stringify(
+    {
+      ImportPath: `${MODULE}/${dir}`,
+      Dir: `/repo/${dir}`,
+      Imports: imports.map((d) => `${MODULE}/${d}`),
+      TestImports: testImports.map((d) => `${MODULE}/${d}`),
+      XTestImports: xtestImports.map((d) => `${MODULE}/${d}`),
+    },
+    null,
+    2,
+  );
+}
+
+function stubGoList(records) {
+  const calls = [];
+  const run = (repoRoot, args) => {
+    calls.push(args);
+    return records.map(record).join('\n');
+  };
+  return { run, calls };
+}
+
+// --- glob anchoring ------------------------------------------------------------
+
+test('staticPrefix stops at the first wildcard segment', () => {
+  assert.equal(staticPrefix('internal/logql/**'), 'internal/logql');
+  assert.equal(staticPrefix('internal/chsql/rate_window_fanout_bound.go'), 'internal/chsql/rate_window_fanout_bound.go');
+  assert.equal(staticPrefix('**/*.go'), '');
+  assert.equal(staticPrefix('**'), '');
+});
+
+// --- seed derivation -----------------------------------------------------------
+
+test('a directory glob over Go source seeds that directory', () => {
+  assert.deepEqual(
+    laneSeedDirs({ package_globs: ['internal/logql/**', 'internal/api/loki/**'] }, { repoRoot: ROOT }),
+    ['internal/api/loki', 'internal/logql'],
+  );
+});
+
+test('a glob naming ONE Go file seeds the package that file belongs to', () => {
+  // Declaring a single file is a claim about which file matters, never a claim
+  // that the file depends on less than its package does. Without this, a lane
+  // could opt out of the closure by listing files instead of a directory.
+  assert.deepEqual(
+    laneSeedDirs({ package_globs: ['internal/chsql/rate_window_fanout_bound.go'] }, { repoRoot: ROOT }),
+    ['internal/chsql'],
+  );
+});
+
+test('an unanchored glob seeds nothing — it already matches every path', () => {
+  assert.deepEqual(laneSeedDirs({ package_globs: ['**', '**/*.go', '**/*.md'] }, { repoRoot: ROOT }), []);
+});
+
+test('a directory holding no Go source is not a seed', () => {
+  assert.deepEqual(laneSeedDirs({ package_globs: ['deploy/helm/**', 'docs/**'] }, { repoRoot: ROOT }), []);
+  assert.equal(holdsGoSource(ROOT, 'internal/chsql'), true);
+  assert.equal(holdsGoSource(ROOT, 'docs'), false);
+});
+
+test('a glob whose prefix does not exist is not a seed', () => {
+  assert.deepEqual(laneSeedDirs({ package_globs: ['internal/not-a-package/**'] }, { repoRoot: ROOT }), []);
+});
+
+test('a lane with no globs at all seeds nothing rather than throwing', () => {
+  assert.deepEqual(laneSeedDirs({}, { repoRoot: ROOT }), []);
+});
+
+// --- graph loading -------------------------------------------------------------
+
+test('splitGoListJSON reads the concatenated objects go list emits', () => {
+  const parsed = splitGoListJSON([record({ dir: 'a' }), record({ dir: 'b', imports: ['a'] })].join('\n'));
+  assert.deepEqual(parsed.map((p) => p.ImportPath), [`${MODULE}/a`, `${MODULE}/b`]);
+});
+
+test('loadPackageGraph keeps first-party edges and drops everything else', () => {
+  const run = (repoRoot, args) => [
+    JSON.stringify(
+      {
+        ImportPath: `${MODULE}/internal/api/loki`,
+        Dir: '/repo/internal/api/loki',
+        Imports: [`${MODULE}/internal/engine`, 'net/http', 'github.com/ClickHouse/clickhouse-go/v2'],
+        TestImports: [`${MODULE}/test/spec`],
+      },
+      null,
+      2,
+    ),
+  ].join('\n');
+  const graph = loadPackageGraph({ repoRoot: '/repo', runGoList: run });
+  assert.deepEqual([...graph.get('internal/api/loki').imports], ['internal/engine']);
+  assert.deepEqual([...graph.get('internal/api/loki').testImports], ['test/spec']);
+});
+
+test('loadPackageGraph passes the lane build tags through to go list', () => {
+  const stub = stubGoList([]);
+  loadPackageGraph({ repoRoot: '/repo', tags: ['chdb', 'agpl_oracle'], runGoList: stub.run });
+  assert.deepEqual(stub.calls[0].slice(-3), ['-tags', 'chdb,agpl_oracle', './...']);
+});
+
+// --- the closure itself ---------------------------------------------------------
+
+const PIPELINE = [
+  { dir: 'internal/api/loki', imports: ['internal/logql', 'internal/engine'], xtestImports: ['test/spec'] },
+  { dir: 'internal/logql', imports: ['internal/chplan'] },
+  { dir: 'internal/api/prom', imports: ['internal/promql', 'internal/engine'] },
+  { dir: 'internal/promql', imports: ['internal/chplan'] },
+  { dir: 'internal/engine', imports: ['internal/chclient'] },
+  { dir: 'internal/chclient', imports: ['internal/chopt'] },
+  { dir: 'internal/chopt', imports: [] },
+  { dir: 'internal/chplan', imports: [] },
+  { dir: 'test/spec', imports: ['internal/promql'], testImports: ['internal/traceql'] },
+  { dir: 'internal/traceql', imports: [] },
+];
+
+function pipelineGraph() {
+  const stub = stubGoList(PIPELINE);
+  return loadPackageGraph({ repoRoot: '/repo', runGoList: stub.run });
+}
+
+test('NARROW DIRECTION: the closure reaches the shared pipeline the seed runs through', () => {
+  // The #2902 shape: a Loki-seeded lane must see chclient/chopt/engine, which
+  // is what PR #2824 moved and what the declared globs never named.
+  const reached = closureFrom(pipelineGraph(), ['internal/api/loki', 'internal/logql']);
+  for (const want of ['internal/engine', 'internal/chclient', 'internal/chopt', 'internal/chplan']) {
+    assert.ok(reached.has(want), `${want} is on the LogQL query path and must be reachable`);
+  }
+});
+
+test('WIDE DIRECTION: a seed does not reach a sibling head it never imports', () => {
+  const reached = closureFrom(pipelineGraph(), ['internal/api/loki', 'internal/logql']);
+  assert.equal(reached.has('internal/api/prom'), false);
+});
+
+test('a seed contributes its TEST imports; a package merely reached does not', () => {
+  // This one rule is what keeps the closure from collapsing into "everything".
+  // `test/spec` is an external test import of `internal/api/loki`, so a Loki
+  // seed reaches it and then follows its PRODUCTION import to internal/promql —
+  // but never its test import of internal/traceql, because test/spec is a
+  // transitive dependency here, not a package the lane runs the tests of.
+  const reached = closureFrom(pipelineGraph(), ['internal/api/loki']);
+  assert.equal(reached.has('test/spec'), true, 'a seed links what its own tests import');
+  assert.equal(reached.has('internal/promql'), true, 'production imports are followed transitively');
+  assert.equal(reached.has('internal/traceql'), false, 'a dependency does not drag in its own test imports');
+
+  // Seeded directly, the same package DOES contribute its test imports.
+  assert.equal(closureFrom(pipelineGraph(), ['test/spec']).has('internal/traceql'), true);
+});
+
+test('a seed directory stands for every package beneath it', () => {
+  const graph = loadPackageGraph({
+    repoRoot: '/repo',
+    runGoList: stubGoList([
+      { dir: 'internal/logql', imports: [] },
+      { dir: 'internal/logql/lsyntax', imports: ['internal/chplan'] },
+      { dir: 'internal/chplan', imports: [] },
+    ]).run,
+  });
+  assert.equal(closureFrom(graph, ['internal/logql']).has('internal/chplan'), true);
+});
+
+// --- assembly -------------------------------------------------------------------
+
+test('affectedGlobsFor unions the declared globs with the derived packages', () => {
+  const globs = affectedGlobsFor(
+    { package_globs: ['compatibility/loki/**', 'internal/api/loki/**'] },
+    new Set(['internal/api/loki', 'internal/chclient']),
+  );
+  // The declared non-Go path survives — go list never sees a compose file or a
+  // reference-stack config, so the declaration is still what carries them.
+  assert.ok(globs.includes('compatibility/loki/**'));
+  assert.ok(globs.includes('internal/chclient/**'));
+});
+
+test('laneAffectedGlobs loads ONE graph per distinct build-tag set', () => {
+  const stub = stubGoList(PIPELINE);
+  const lanes = [
+    { id: 'a', package_globs: ['internal/logql/**'], build_tags: [] },
+    { id: 'b', package_globs: ['internal/promql/**'], build_tags: [] },
+    { id: 'c', package_globs: ['internal/promql/**'], build_tags: ['chdb'] },
+    { id: 'd', package_globs: ['internal/promql/**'], build_tags: ['chdb'] },
+  ];
+  const out = laneAffectedGlobs(lanes, { repoRoot: ROOT, runGoList: stub.run });
+  assert.equal(stub.calls.length, 2, 'tag sets, not lanes, decide how often go list runs');
+  assert.deepEqual([...out.keys()], ['a', 'b', 'c', 'd']);
+});
+
+test('laneAffectedGlobs falls back to nothing extra for a lane with no Go seed', () => {
+  const stub = stubGoList(PIPELINE);
+  const out = laneAffectedGlobs([{ id: 'docs', package_globs: ['docs/**'], build_tags: [] }], {
+    repoRoot: ROOT,
+    runGoList: stub.run,
+  });
+  assert.deepEqual(out.get('docs'), ['docs/**']);
+});
+
+test('declaredGlobs returns the raw declaration — the pre-#2902 attribution', () => {
+  const lanes = [{ id: 'x', package_globs: ['internal/logql/**'] }];
+  assert.deepEqual(declaredGlobs(lanes).get('x'), ['internal/logql/**']);
+});

--- a/.github/scripts/merge-risk.mjs
+++ b/.github/scripts/merge-risk.mjs
@@ -55,9 +55,21 @@
 // What this gate does instead is make the skip legible: the lanes that gate
 // `main` and will not run before this merges are named on the PR, with the
 // local command that runs each one, so "green" is never silently read as
-// "validated". Attribution is by the lane's own declared `package_globs`; that
-// declaration is known to under-cover shared plumbing (see issue #2902), and
-// the summary says so rather than implying the list is exhaustive.
+// "validated".
+//
+// # Attribution (#2902)
+//
+// Which lanes a change touches is DERIVED from the Go import graph, not read
+// off each lane's declared `package_globs`. Those globs name a lane's own
+// directories, and #2824 — the change that caused #2895, the very outage above
+// — moved `internal/chclient`, `internal/chopt`, `internal/engine`,
+// `internal/config` and `cmd/cerberus`, matching none of `compatibility.loki`'s
+// three globs. The lane that would have caught the regression did not consider
+// itself touched by the change that caused it. `lib/lane-closure.mjs` treats
+// the declared globs as SEEDS and unions them with the dependency closure `go
+// list` reports for those seeds, so the shared pipeline every head runs through
+// is attributed to every head's lane, and a sibling head's change still is not.
+// That module's header carries the full reasoning and the measured cost.
 //
 // # Env
 //
@@ -71,8 +83,12 @@
 //   CI_LANE_REGISTRY    lane registry path. Default `.github/ci-lanes.json`.
 //   GITHUB_STEP_SUMMARY optional summary destination (written via lib/gh.mjs).
 //
-// Node builtins only. `process.exit(1)` on a stale-base collision or an
-// unreadable registry; the lane inventory never exits non-zero on its own.
+// Node builtins only, plus the Go toolchain the attribution derivation reads
+// the import graph with. `process.exit(1)` on a stale-base collision, an
+// unreadable registry, or an import graph that cannot be loaded — a derivation
+// that silently degrades to the declared globs would report the pre-#2902
+// answer while claiming the post-#2902 one. The lane inventory itself never
+// exits non-zero.
 //
 // The pure halves are exported and pinned by merge-risk.test.mjs.
 
@@ -83,6 +99,7 @@ import { pathToFileURL } from 'node:url';
 import { matchesGlob } from './ci-lane-contract.mjs';
 import { appendStepSummary, assertSafeArg, error, git, log, notice, warning } from './lib/gh.mjs';
 import { SHARDS } from './lib/golden-shards.mjs';
+import { laneAffectedGlobs } from './lib/lane-closure.mjs';
 
 export const DEFAULT_REGISTRY_PATH = '.github/ci-lanes.json';
 export const DEFAULT_MERGE_TARGET_REF = 'origin/main';
@@ -174,14 +191,22 @@ export function gatingLanesThatSkipPRs(registry) {
 }
 
 /**
- * unvalidatedLanes — of those, the ones whose declared `package_globs` this
- * change actually touches. Attribution is only as good as the declaration:
- * see this file's header and issue #2902.
+ * unvalidatedLanes — of those, the ones whose AFFECTED paths this change
+ * actually touches.
+ *
+ * `affectedGlobs` is `Map<laneID, string[]>`, normally the derived set from
+ * `lib/lane-closure.mjs`'s `laneAffectedGlobs`. It is a required argument
+ * rather than a fallback to `lane.package_globs`: attributing by the raw
+ * declaration is exactly the #2902 blind spot, and a default that quietly
+ * restored it would be indistinguishable from the fix at every call site. A
+ * lane the map does not cover throws for the same reason.
  */
-export function unvalidatedLanes(registry, files) {
+export function unvalidatedLanes(registry, files, affectedGlobs) {
   const out = [];
   for (const lane of gatingLanesThatSkipPRs(registry)) {
-    const matched = (files ?? []).filter((f) => (lane.package_globs ?? []).some((g) => matchesGlob(f, g)));
+    const globs = affectedGlobs?.get(lane.id);
+    if (!globs) throw new Error(`merge-risk: no affected-path set was derived for lane ${lane.id}`);
+    const matched = (files ?? []).filter((f) => globs.some((g) => matchesGlob(f, g)));
     if (matched.length > 0) out.push({ lane, matched });
   }
   return out.sort((a, b) => a.lane.id.localeCompare(b.lane.id));
@@ -248,16 +273,28 @@ async function main() {
   }
 
   const skipping = gatingLanesThatSkipPRs(registry);
-  const unvalidated = unvalidatedLanes(registry, ours);
+  let affected;
+  try {
+    affected = laneAffectedGlobs(skipping, { repoRoot: process.cwd() });
+  } catch (e) {
+    error(
+      `merge-risk: the Go import graph could not be loaded (${String(e?.message ?? e)}), so which lanes `
+        + 'this change leaves unvalidated cannot be derived. Attributing by the declared `package_globs` '
+        + 'instead would silently report the pre-#2902 answer, so this fails rather than degrades.',
+      { title: 'merge-risk' },
+    );
+    process.exit(1);
+  }
+  const unvalidated = unvalidatedLanes(registry, ours, affected);
   summary.push(
     `### Lanes that gate \`main\` but do not run on this PR (${unvalidated.length} of ${skipping.length} touched)`,
     '',
   );
   if (unvalidated.length === 0) {
     summary.push(
-      'None of the declared path globs for those lanes match this change. That is an argument, not a',
-      'proof: attribution uses each lane\'s own `package_globs`, which under-cover shared plumbing',
-      '(issue #2902).',
+      'No lane\'s affected paths match this change. Attribution is the dependency closure `go list`',
+      'reports for each lane\'s own packages, so a change to the shared query pipeline counts against',
+      'every head\'s lane, not only against the head it was filed under.',
       '',
     );
   } else {
@@ -268,8 +305,8 @@ async function main() {
     summary.push(
       '',
       'These run on push-to-main, a schedule, or a release PR — never on this one. A green PR is not',
-      'evidence they pass. Attribution is by each lane\'s declared `package_globs`, which under-cover',
-      'shared plumbing (issue #2902), so this table is a floor rather than the whole risk.',
+      'evidence they pass. Attribution is the dependency closure `go list` reports for each lane\'s own',
+      'packages, unioned with the non-Go paths it declares.',
       '',
     );
   }

--- a/.github/scripts/merge-risk.test.mjs
+++ b/.github/scripts/merge-risk.test.mjs
@@ -8,6 +8,13 @@
 // are asserted below, and so is the ONE case the blocking half deliberately
 // stays quiet on — two PRs adding independent fixtures with no generator-code
 // change between them, where the merged tree really is the union.
+//
+// The reporting half's ATTRIBUTION carries its own acceptance case (#2902),
+// read against this repository's real import graph rather than a fixture: PR
+// #2824's real changed-file set — the change that caused the #2895 outage — is
+// replayed through the derivation and must name `compatibility.loki`, and the
+// same file set replayed through the raw `package_globs` must NOT, because that
+// contrast is the whole evidence that the derivation is what closed the hole.
 
 import assert from 'node:assert/strict';
 import test from 'node:test';
@@ -27,8 +34,57 @@ import {
   underGoldenRoot,
   unvalidatedLanes,
 } from './merge-risk.mjs';
+import { declaredGlobs, laneAffectedGlobs } from './lib/lane-closure.mjs';
 
 const REGISTRY = JSON.parse(readFileSync(resolve(DEFAULT_REGISTRY_PATH), 'utf8'));
+
+// The three reference harnesses plus their variants: the lanes #2895 was red on
+// for 31 runs, and the only lanes whose attribution these tests interrogate.
+// Restricting the registry keeps the real `go list` load to the ONE untagged
+// import graph they share — the production gate loads one per build-tag set.
+const COMPAT_REGISTRY = { lanes: REGISTRY.lanes.filter((l) => l.id.startsWith('compatibility.')) };
+const COMPAT_LANES = gatingLanesThatSkipPRs(COMPAT_REGISTRY);
+
+/** Derived attribution: the declared globs plus their real dependency closure. */
+const DERIVED = laneAffectedGlobs(COMPAT_LANES, { repoRoot: process.cwd() });
+/** The pre-#2902 attribution, kept only so the contrast below can be asserted. */
+const DECLARED = declaredGlobs(COMPAT_LANES);
+
+const laneIDs = (registry, files, globs) => unvalidatedLanes(registry, files, globs).map((u) => u.lane.id);
+
+// PR #2824 `0d32cc96d` ("gate the ClickHouse query result cache on closed
+// windows"), verbatim from `gh pr view 2824 --json files`. It stamped
+// `use_query_cache=1` without `query_cache_nondeterministic_function_handling`,
+// whose ClickHouse default fails any query containing `arrayJoin` — which is
+// how every non-native range lowering fans samples across the step grid. 144
+// LogQL and 871 PromQL cases diverged and `compatibility` was red on `main` for
+// 31 consecutive runs (#2895).
+const PR_2824_FILES = [
+  'cmd/cerberus/bootstrap_config_test.go',
+  'cmd/cerberus/chopt_reprobe.go',
+  'cmd/cerberus/main.go',
+  'docs/clickhouse-optimizations.md',
+  'docs/configuration.md',
+  'internal/api/info/info.go',
+  'internal/api/info/info_test.go',
+  'internal/chclient/client.go',
+  'internal/chclient/result_cache.go',
+  'internal/chclient/result_cache_hit_integration_test.go',
+  'internal/chclient/result_cache_metrics.go',
+  'internal/chclient/result_cache_probe.go',
+  'internal/chclient/result_cache_probe_integration_test.go',
+  'internal/chclient/result_cache_probe_test.go',
+  'internal/chclient/ts_grid_probe.go',
+  'internal/chopt/capability.go',
+  'internal/chopt/registry.go',
+  'internal/chopt/resolve.go',
+  'internal/chopt/resolve_test.go',
+  'internal/config/config.go',
+  'internal/config/envdocs.go',
+  'internal/engine/query_settings_rules.go',
+  'internal/engine/result_cache_test.go',
+  'test/perf/solver_decision_ratchet_test.go',
+];
 
 // The two sides of the real #2895 / post-merge-drift races, as file sets.
 const CARDINALITY_A = ['internal/chsql/emit.go', 'test/perf/cardinality-baseline/promql/rate_5m.json'];
@@ -167,17 +223,88 @@ test('the real compatibility lanes ARE in the skipping set — that is the #2895
 });
 
 test('unvalidatedLanes names the LogQL reference lane for a LogQL change', () => {
-  const found = unvalidatedLanes(REGISTRY, ['internal/logql/lsyntax/parser.go']).map((u) => u.lane.id);
-  assert.ok(found.includes('compatibility.loki'));
+  assert.ok(laneIDs(COMPAT_REGISTRY, ['internal/logql/lsyntax/parser.go'], DERIVED).includes('compatibility.loki'));
 });
 
-test('unvalidatedLanes is silent on a change no gating-but-skipping lane declares', () => {
-  assert.deepEqual(unvalidatedLanes(REGISTRY, ['.github/scripts/merge-risk.mjs']), []);
+test('unvalidatedLanes is silent on a change that reaches no lane at all', () => {
+  assert.deepEqual(laneIDs(COMPAT_REGISTRY, ['.github/scripts/merge-risk.mjs'], DERIVED), []);
+  assert.deepEqual(laneIDs(COMPAT_REGISTRY, ['docs/engine.md'], DERIVED), []);
 });
 
 test('unvalidatedLanes is silent on an empty or missing file set', () => {
-  assert.deepEqual(unvalidatedLanes(REGISTRY, []), []);
-  assert.deepEqual(unvalidatedLanes(REGISTRY, undefined), []);
+  assert.deepEqual(unvalidatedLanes(COMPAT_REGISTRY, [], DERIVED), []);
+  assert.deepEqual(unvalidatedLanes(COMPAT_REGISTRY, undefined, DERIVED), []);
+});
+
+test('unvalidatedLanes refuses to attribute a lane it was given no derived set for', () => {
+  // A default back to `lane.package_globs` would be the pre-#2902 answer wearing
+  // the post-#2902 name, so the missing case throws instead of degrading.
+  assert.throws(
+    () => unvalidatedLanes(COMPAT_REGISTRY, ['internal/chclient/client.go'], new Map()),
+    /no affected-path set was derived for lane/,
+  );
+});
+
+// --- #2902: attribution across the shared query pipeline -------------------------
+
+test('ACCEPTANCE: PR #2824 — the change that caused #2895 — now attributes compatibility.loki', () => {
+  assert.ok(
+    laneIDs(COMPAT_REGISTRY, PR_2824_FILES, DERIVED).includes('compatibility.loki'),
+    'the LogQL reference lane must consider itself touched by the change it would have caught',
+  );
+});
+
+test('CONTRAST: the same file set attributes NOTHING to compatibility.loki by declared globs', () => {
+  // If this ever passes for compatibility.loki, the contrast has stopped
+  // proving anything and the acceptance test above has become a tautology.
+  assert.ok(
+    !laneIDs(COMPAT_REGISTRY, PR_2824_FILES, DECLARED).includes('compatibility.loki'),
+    'compatibility.loki declares no glob that PR #2824 matches — that is the hole #2902 names',
+  );
+});
+
+test('compatibility.loki inherits the shared pipeline, and not the sibling heads', () => {
+  const globs = DERIVED.get('compatibility.loki');
+  for (const want of [
+    'internal/chclient/**',
+    'internal/chopt/**',
+    'internal/engine/**',
+    'internal/chplan/**',
+    'internal/chsql/**',
+    'internal/optimizer/**',
+  ]) {
+    assert.ok(globs.includes(want), `${want} is on the LogQL query path and must be attributed`);
+  }
+  for (const notWant of ['internal/promql/**', 'internal/traceql/**', 'internal/api/prom/**', 'internal/api/tempo/**']) {
+    assert.ok(!globs.includes(notWant), `${notWant} cannot move a LogQL parity verdict; attributing it is noise`);
+  }
+});
+
+test('NOT everything depends on everything: a single-head change stays on its own head', () => {
+  const promql = laneIDs(COMPAT_REGISTRY, ['internal/promql/lower.go'], DERIVED);
+  assert.ok(promql.includes('compatibility.prometheus'));
+  assert.ok(!promql.includes('compatibility.loki'));
+  assert.ok(!promql.includes('compatibility.tempo'));
+
+  const traceql = laneIDs(COMPAT_REGISTRY, ['internal/traceql/ast/parser.go'], DERIVED);
+  assert.ok(traceql.includes('compatibility.tempo'));
+  assert.ok(!traceql.includes('compatibility.loki'));
+  assert.ok(!traceql.includes('compatibility.prometheus'));
+});
+
+test('every lane the gate reports on has a derived affected-path set', () => {
+  // The production run derives over EVERY gating-but-skipping lane, tag sets
+  // included; a lane the derivation cannot answer for would throw at run time.
+  const all = laneAffectedGlobs(gatingLanesThatSkipPRs(REGISTRY), {
+    repoRoot: process.cwd(),
+    // Structural check only: an empty graph leaves each lane with its declared
+    // globs, which is enough to prove every lane gets an entry without paying
+    // for one `go list` per build-tag set here.
+    runGoList: () => '',
+  });
+  for (const lane of gatingLanesThatSkipPRs(REGISTRY)) {
+    assert.ok(all.has(lane.id), `${lane.id} would throw at run time with no derived set`);
+  }
 });
 
 // --- git plumbing ---------------------------------------------------------------
@@ -204,4 +331,10 @@ const forbidDeferralWorkflow = readFileSync(resolve('.github/workflows/forbid-de
 test('the merge-risk gate rides forbid-deferral.yml and invokes the script', () => {
   assert.match(forbidDeferralWorkflow, /run: node \.github\/scripts\/merge-risk\.mjs/);
   assert.match(forbidDeferralWorkflow, /run: node --test \.github\/scripts\/merge-risk\.test\.mjs/);
+});
+
+test('the job sets Go up through the hardened wrapper, which the attribution needs', () => {
+  // Without a toolchain in this job the derivation cannot read the import graph
+  // and merge-risk.mjs exits 1 rather than falling back to the declared globs.
+  assert.match(forbidDeferralWorkflow, /uses: \.\/\.github\/actions\/setup-go/);
 });

--- a/.github/workflows/forbid-deferral.yml
+++ b/.github/workflows/forbid-deferral.yml
@@ -134,13 +134,29 @@ jobs:
           HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
       # #2899's merge-risk gate: what this PR's green does NOT cover. It rides
       # this job for the same reason the obligation gate above does — it needs
-      # the full history a `fetch-depth: 0` checkout gives and nothing else,
-      # and it is a required context on every PR without adding a new one to
-      # branch protection. `origin/main` is fetched explicitly first: a
-      # `pull_request` checkout populates the PR refs, not the target branch's
-      # remote-tracking ref, and the stale-base half compares against it.
+      # the full history a `fetch-depth: 0` checkout gives, and it is a required
+      # context on every PR without adding a new one to branch protection.
+      # `origin/main` is fetched explicitly first: a `pull_request` checkout
+      # populates the PR refs, not the target branch's remote-tracking ref, and
+      # the stale-base half compares against it.
+      #
+      # WHY THIS JOB NOW SETS GO UP. Since #2902 the gate attributes a change to
+      # a lane through the Go import graph rather than through the lane's
+      # declared `package_globs`, because those globs name only each head's own
+      # directories and so missed PR #2824 — the change that caused #2895 —
+      # entirely. Reading the graph needs `go list`. Measured against this
+      # repository: the wrapper costs ~16s on a warm module cache, and the
+      # derivation ~20s (one `go list -json ./...` per distinct build-tag set,
+      # not one per lane, which would be ~80s). That is the price of the
+      # attribution being right; a Go-less job could only have kept the wrong
+      # one. The wrapper — never `actions/setup-go` directly — is what
+      # `assert-go-setup-hardened.mjs` requires, and it also keeps this job from
+      # archiving an empty module cache.
+      - uses: ./.github/actions/setup-go
       - name: Fetch the merge target for the stale-base comparison
         run: git fetch --no-tags --quiet origin +refs/heads/main:refs/remotes/origin/main
+      - name: Assert the lane affected-path derivation matches, and does not over-match
+        run: node --test .github/scripts/lib/lane-closure.test.mjs
       - name: Assert the merge-risk scanner matches, and does not over-match
         run: node --test .github/scripts/merge-risk.test.mjs
       - name: Reject a golden shard regenerated against a base main has moved past

--- a/docs/test-strategy.md
+++ b/docs/test-strategy.md
@@ -202,8 +202,17 @@ The gate also REPORTS, without blocking, the lanes that gate `main` yet declare
 `merge_posture: never` and so never run on a pull request — the compatibility
 harnesses, the chDB round-trip and perf-guard shards, `perf-nightly`, the e2e
 family — naming each one and the command that runs it, so a skipped lane is
-never read as a passing one. Attribution uses each lane's declared
-`package_globs` and is a floor rather than the whole risk.
+never read as a passing one. Attribution is the first-party dependency closure
+`go list` reports for the packages each lane's `package_globs` name, unioned
+with those globs so the non-Go inputs a lane also has stay covered
+(`.github/scripts/lib/lane-closure.mjs`). Reading the declaration alone was
+issue #2902's blind spot: a lane's globs name its own directories, so the shared
+`chplan` → `optimizer` → `chsql` → `chclient` pipeline every head runs through
+belonged to none of them, and PR #2824 moved exactly that pipeline without
+`compatibility.loki` considering itself touched — the lane #2895 then left red
+on `main` for 31 runs. The contract keeps the seeds honest: a `reference` lane
+must name its own head's `internal/<ql>` and `internal/api/<head>` packages,
+because the closure is only as wide as what it starts from.
 
 ### Test-fence enrollment contracts
 


### PR DESCRIPTION
## The blind spot

`.github/ci-lanes.json` gives every lane a `package_globs` list, and the gates that attribute a
change to a lane read it as "the paths this lane validates". For the reference lanes that list names
the lane's own directories and nothing else:

```json
"compatibility.loki": { "package_globs": ["compatibility/loki/**", "internal/logql/**", "internal/api/loki/**"] }
```

PR #2824 (`0d32cc96d`) — the change that produced #2895's 144-case LogQL parity regression and left
`compatibility` red on `main` for 31 consecutive runs — moved `internal/chclient`, `internal/chopt`,
`internal/engine`, `internal/config` and `cmd/cerberus`. It matched **none** of those three globs.
The lane that would have caught the regression did not consider itself touched by the change that
caused it.

That is not a typo in one list. cerberus is a shared pipeline (`chplan` → `optimizer` → `chsql` →
`chclient`, driven by `engine`) under three thin heads, so a per-head glob list structurally cannot
express "this lane also depends on the shared pipeline". Any hand-written statement of that
dependency is the drift, not the fix.

## What this does

`.github/scripts/lib/lane-closure.mjs` treats each lane's declared globs as **seeds** and derives its
affected-path set as the first-party dependency closure of those seeds, read out of the import graph
`go list` reports — the same derivation `lib/golden-shards.mjs` already applies to the golden shards
(`impliedShards`, derivation 2), whose own header explains why a hand table was not acceptable there
either. `merge-risk.mjs` attributes through the derived set.

There is deliberately **no fallback** to the raw declaration: `unvalidatedLanes` throws on a lane it
was given no derived set for, and `merge-risk.mjs` exits 1 if the graph cannot be loaded. A default
back to `package_globs` would report the pre-#2902 answer under the post-#2902 name, and would be
invisible at every call site.

Two semantics are load-bearing and both are pinned:

- **Seeds include a file-level glob's package.** A glob naming one `.go` file seeds that file's
  package. Otherwise a lane could opt out of the closure by listing files instead of a directory.
- **Test imports are edges of the seed only.** `go list -deps -test <pattern>` counts a *named*
  package's test imports and a *reached* package's production imports. Folding them together makes
  every transitive dependency drag in its own test fixtures, every head reaches every other head, and
  the report becomes a list nobody reads. That is the same blindness pointed the other way.

`ci-lane-contract.mjs` gains the one rule that keeps the seeds honest: a `reference` lane must name
its own head's `internal/<ql>` and `internal/api/<head>` packages, because the closure is only as
wide as what it starts from. `compatibility.prometheus-forced-route` — which drives the full PromQL
harness with `CERBERUS_EVAL_ROUTE=sharded` yet declared only `compatibility/prometheus/**` and
`internal/solver/**` — gains the two globs it was missing. Execution lanes are outside that rule
rather than exempted from it: a round-trip lane lowers and executes SQL without entering the HTTP
head, so requiring its API package would assert a dependency it has not got.

## Acceptance: PR #2824 replayed through the derivation

Real file set, `gh pr view 2824 --json files`, replayed against the real registry and the real import
graph over all 27 gating-but-PR-skipping lanes:

| attribution | lanes named |
| --- | --- |
| **derived** (this PR) | 26 lanes, **including `compatibility.loki`, `compatibility.prometheus`, `compatibility.tempo`** |
| **declared** (before) | 10 lanes, **none of the three reference harnesses** |

Narrowed to the six `compatibility.*` lanes, so the contrast is legible:

```
PR2824 derived   : compatibility.loki, compatibility.prometheus, compatibility.prometheus-floor,
                   compatibility.prometheus-forced-route, compatibility.promql-surface, compatibility.tempo
PR2824 declared  : compatibility.prometheus-floor
```

Only `prometheus-floor` ever saw it, and only because it happens to declare `internal/chopt/**`.

26 of 27 is the correct answer *for this change*: #2824 moved the ClickHouse client, the capability
registry, the engine's query settings and the binary entrypoint, so it really did put every head at
risk — which is exactly what #2895 then demonstrated. The lane it does not name is
`e2e.dashboard-crawl`, which seeds only `test/e2e/playwright/**` and has no Go surface.

## The other direction: this has not become "every lane on every PR"

`compatibility.loki`'s derived set contains `internal/chclient/**`, `internal/chopt/**`,
`internal/engine/**`, `internal/chplan/**`, `internal/chsql/**`, `internal/optimizer/**` — and does
**not** contain `internal/promql/**`, `internal/traceql/**`, `internal/api/prom/**` or
`internal/api/tempo/**`.

```
promql-only  (internal/promql/lower.go)      -> compatibility.prometheus{,-floor,-forced-route}, promql-surface
traceql-only (internal/traceql/ast/parser.go)-> compatibility.tempo, compatibility.promql-surface
logql-only   (internal/logql/lsyntax/...)    -> compatibility.loki, compatibility.promql-surface
docs-only    (docs/engine.md)                -> (none)
this PR's own diff                           -> 0 of 27 gating lanes
```

(`compatibility.promql-surface` seeds `test/surface-parity`, which really does read all three heads.)

## Both directions pinned by tests that fail on regression

Verified by breaking the mechanism and watching the suites reject, not by reading them:

| deliberate break | rejected by |
| --- | --- |
| test edges followed from every package, not only seeds | `a seed contributes its TEST imports; a package merely reached does not`; `compatibility.loki inherits the shared pipeline, and not the sibling heads`; `NOT everything depends on everything` (3 failures across 2 suites) |
| `unvalidatedLanes` falls back to `lane.package_globs` | `unvalidatedLanes refuses to attribute a lane it was given no derived set for` |
| `compatibility.loki` drops `internal/api/loki/**` | `ci-lane-contract` fails: *"does not cover internal/api/loki in package_globs, so the affected-path set derived from those globs never reaches the shared query pipeline this lane runs through"*; plus `a reference lane that stops naming its own head query path is rejected` |

`merge-risk.test.mjs` carries PR #2824's real 24-path file set verbatim, with both the derived
assertion and the declared-globs contrast, so if the contrast ever passes the acceptance test has
become a tautology and says so.

## The Go toolchain cost, measured

The reason this was not done in #2904 is that `merge-risk.mjs` rides the `forbid-deferral` job, which
had no Go. Measured from this PR's own `forbid-deferral` run (job `100118666719`), not estimated:

| step | cost |
| --- | --- |
| `./.github/actions/setup-go` (toolchain + cache restore + retry-hardened warm) | **17s** |
| `merge-risk.mjs`, including the whole derivation over all 27 lanes | **3.6s** |
| `lane-closure.test.mjs` + `merge-risk.test.mjs` | 0s + 1s |
| **whole job, end to end** | **34s** — inside the 20–90s band it already occupied |

So the honest answer is: adding Go to this job is cheap, and the derivation itself is nearly free.
The one-off `setup-go` is the whole cost, and it is the same cost every other Go job in the repo
already pays; cold, after a `go.sum` bump, it is that same shared cold cost and not a new one.

The 3.6s is why the module loads the graph rather than calling `generatorPackageDirs` once per lane.
Measured locally (on a contended box, so read the *ratio*, not the absolutes): one `go list -deps
-test` per lane costs **82s wall / 58s CPU** for the identical answer, while one `go list -json
./...` per distinct **build-tag set** — 7 of them, not 27 lanes — costs ~20s, about 4x less work.
Same authority (`go list` reading the real graph) at the scale this caller works at. The graph-walk
result was cross-checked against `go list -deps -test` per lane on four lanes: identical package
sets, no additions and no omissions once synthetic `.test` / `_test` package variants are discounted.

The wrapper — never `actions/setup-go` directly — is what `assert-go-setup-hardened.mjs` requires,
and it also stops this job archiving an empty module cache.

### The gate is not vacuously green here

Its first run on this PR produced a real verdict rather than an empty one:

```
merge-risk: 2 lane(s) that gate main will not run before this merges — e2e.compose-crawl, e2e.compose-smoke.
```

Both declare `.github/ci-lanes.json`, which this PR edits. The derivation ran, loaded the graph,
attributed lanes and reported them.

## Non-Go inputs

`go list` sees Go packages. A lane is also moved by a compose file, a workflow, a reference-stack
config or a fixture corpus, and those stay in `package_globs` — the derived closure is **unioned**
with the declaration, never a replacement. That division is stable in a way the old one was not:
what remains declared is the lane's own artefacts, which move when the lane moves, while the
transitive dependency — the half that actually drifted — is now derived. No second list is
introduced, and no list grew: `package_globs` is *smaller* in meaning than it was, because it no
longer has to guess at the import graph.

`quality.mutation` and `e2e.quickstart` keep reading `package_globs` directly and are unchanged.
Those two ask a different question of the same field — the mutation *surface* gremlins operates on
(pinned to `MUTATION_PRODUCTION_GLOBS`), and whether a diff can skip the published quickstart
artefact whose globs already span `cmd/**` and `internal/**`. Widening either through the closure
would change what they do, not fix what they say.

Closes #2902

🤖 Generated with [Claude Code](https://claude.com/claude-code)
