### PR TITLE
test(mutation): kill the survivors on four legs the honest scoring exposed

### DIFF
--- a/internal/logql/gremlins_kill_drop_keep_fold_test.go
+++ b/internal/logql/gremlins_kill_drop_keep_fold_test.go
@@ -1,0 +1,117 @@
+package logql
+
+import (
+	"testing"
+
+	"github.com/prometheus/prometheus/model/labels"
+
+	"github.com/tsouza/cerberus/internal/chplan"
+	syntax "github.com/tsouza/cerberus/internal/logql/lsyntax"
+)
+
+// Both fold loops in drop_keep.go accumulate ACROSS entries: `| keep` ORs one
+// value predicate per entry naming the key, and the projection predicate ORs
+// one key predicate per entry. Each loop's `continue` therefore carries the
+// whole accumulation — abandoning the loop instead of skipping one entry
+// silently narrows the predicate to whatever had been folded so far, which
+// drops labels the query asked to keep (or keeps labels it asked to drop).
+//
+// Both `continue`s survived mutation on `phase4-logql-other-b` (cerberus issue
+// #2913): every fixture that reaches these loops carries a SINGLE entry, and a
+// one-entry loop cannot tell "skip this entry" from "stop here". The cases
+// below are the multi-entry shapes that can, and each asserts the exact folded
+// expression rather than merely that something non-nil came back — a truncated
+// fold is non-nil too.
+
+// dropKeepValueColumn is the stand-in for the synthetic key's value
+// expression, which the production callers supply as a closure.
+const dropKeepValueColumn = "SyntheticValue"
+
+// dropKeepNewValue is the newValue closure the folds call once per entry.
+func dropKeepNewValue() chplan.Expr { return &chplan.ColumnRef{Name: dropKeepValueColumn} }
+
+// dropKeepMatcherEntry builds a `| keep foo="bar"`-shaped entry.
+func dropKeepMatcherEntry(t *testing.T, name, value string) syntax.NamedLabelMatcher {
+	t.Helper()
+	m, err := labels.NewMatcher(labels.MatchEqual, name, value)
+	if err != nil {
+		t.Fatalf("labels.NewMatcher(%q, %q): %v", name, value, err)
+	}
+	return syntax.NewNamedLabelMatcher(m, "")
+}
+
+// TestKeepPredicateForKey_FoldsEveryEntryNamingTheKey pins that an entry for a
+// DIFFERENT label is skipped rather than ending the scan. `| keep other="x",
+// app="a"` must still constrain `app`; stopping at the first non-matching
+// entry would return no predicate at all, and the caller reads "no predicate"
+// as "this stage does not condition the key" — so the label would survive the
+// keep unconditionally.
+func TestKeepPredicateForKey_FoldsEveryEntryNamingTheKey(t *testing.T) {
+	t.Parallel()
+	const key = "app"
+	entries := []syntax.NamedLabelMatcher{
+		dropKeepMatcherEntry(t, "other", "x"),
+		dropKeepMatcherEntry(t, key, "a"),
+	}
+
+	pred, unconditional := keepPredicateForKey(entries, key, dropKeepNewValue)
+	if unconditional {
+		t.Fatalf("keepPredicateForKey(%q) reported unconditional; want a value predicate", key)
+	}
+	want := syntheticValueMatches(entries[1], dropKeepNewValue())
+	if pred == nil || !pred.Equal(want) {
+		t.Errorf("keepPredicateForKey(%q) = %#v; want %#v — the entry for %q must be skipped, not treated as the end of the list", key, pred, want, "other")
+	}
+}
+
+// TestKeepPredicateForKey_OrsEveryMatcherOnTheSameKey is the same loop's
+// accumulating half: two `| keep` entries on ONE key are alternatives, so the
+// key survives if EITHER value matches.
+func TestKeepPredicateForKey_OrsEveryMatcherOnTheSameKey(t *testing.T) {
+	t.Parallel()
+	const key = "app"
+	entries := []syntax.NamedLabelMatcher{
+		dropKeepMatcherEntry(t, key, "a"),
+		dropKeepMatcherEntry(t, key, "b"),
+	}
+
+	pred, unconditional := keepPredicateForKey(entries, key, dropKeepNewValue)
+	if unconditional {
+		t.Fatalf("keepPredicateForKey(%q) reported unconditional; want a value predicate", key)
+	}
+	want := &chplan.Binary{
+		Op:    chplan.OpOr,
+		Left:  syntheticValueMatches(entries[0], dropKeepNewValue()),
+		Right: syntheticValueMatches(entries[1], dropKeepNewValue()),
+	}
+	if pred == nil || !pred.Equal(want) {
+		t.Errorf("keepPredicateForKey(%q) = %#v; want the OR of both entries (%#v)", key, pred, want)
+	}
+}
+
+// TestAnyProjectionEntryMatches_OrsEveryEntry pins the projection fold. Three
+// bare-name entries must produce the OR of all three key predicates: the
+// expression selects the map entries the stage targets, so a fold that stops
+// after the first one targets only the first label.
+func TestAnyProjectionEntryMatches_OrsEveryEntry(t *testing.T) {
+	t.Parallel()
+	entries := []syntax.NamedLabelMatcher{
+		syntax.NewNamedLabelMatcher(nil, "a"),
+		syntax.NewNamedLabelMatcher(nil, "b"),
+		syntax.NewNamedLabelMatcher(nil, "c"),
+	}
+
+	got := anyProjectionEntryMatches(entries)
+	want := &chplan.Binary{
+		Op: chplan.OpOr,
+		Left: &chplan.Binary{
+			Op:    chplan.OpOr,
+			Left:  keyEquals("a"),
+			Right: keyEquals("b"),
+		},
+		Right: keyEquals("c"),
+	}
+	if got == nil || !got.Equal(want) {
+		t.Errorf("anyProjectionEntryMatches = %#v; want the left-folded OR of all three entries (%#v)", got, want)
+	}
+}

--- a/internal/logql/gremlins_kill_shared_value_index_test.go
+++ b/internal/logql/gremlins_kill_shared_value_index_test.go
@@ -1,0 +1,149 @@
+package logql
+
+import (
+	"testing"
+
+	"github.com/tsouza/cerberus/internal/chplan"
+)
+
+// [sharedValueProjectionIndex] decides which projection slot the multi-variant
+// range-aggregation fusion may unpivot. Getting it wrong is not a slow query:
+// picking a slot the arms differ at somewhere OTHER than the value column
+// folds two arms that describe DIFFERENT series onto one grouped pass, and the
+// result reports one arm's grouping for both.
+//
+// Three of its decisions survived mutation on `phase4-logql-other-b` (cerberus
+// issue #2913): the `continue` that walks past an agreeing position, the
+// duplicate-alias rejection inside the fallback alias search, and the
+// "found nothing" rejection after it. The corpus only ever reaches this
+// function through well-formed fused fixtures — arms that agree everywhere
+// except one properly-aliased value slot — so the loop only ever had one
+// answer to give and none of the three rejections was ever the reason for a
+// verdict.
+//
+// Each case below is therefore a shape the function must REJECT (or, for the
+// index-zero case, accept) that no fixture produces, asserted against an
+// accepted baseline of the same shape so a broken accept path cannot make a
+// rejection look correct.
+
+// sharedValueOtherAlias is a projection alias that is deliberately NOT
+// [rangeAggSynthValueColumn], so a slot carrying it can never be chosen as the
+// value slot.
+const sharedValueOtherAlias = "Attributes"
+
+// sharedValueProj builds one arm's Project from (alias, column-name) pairs.
+// The column name is what makes two arms differ at a position: projectionEqual
+// compares the alias first, then the expression.
+func sharedValueProj(pairs ...[2]string) *chplan.Project {
+	projections := make([]chplan.Projection, 0, len(pairs))
+	for _, p := range pairs {
+		projections = append(projections, chplan.Projection{
+			Expr:  &chplan.ColumnRef{Name: p[1]},
+			Alias: p[0],
+		})
+	}
+	return &chplan.Project{Projections: projections}
+}
+
+func TestSharedValueProjectionIndex_PicksTheSoleDifferingValueSlot(t *testing.T) {
+	t.Parallel()
+	// The baseline every rejection below is a perturbation of: the arms agree
+	// on their identity projection and differ only at the value slot.
+	projects := []*chplan.Project{
+		sharedValueProj([2]string{sharedValueOtherAlias, "labels"}, [2]string{rangeAggSynthValueColumn, "a"}),
+		sharedValueProj([2]string{sharedValueOtherAlias, "labels"}, [2]string{rangeAggSynthValueColumn, "b"}),
+	}
+	idx, ok := sharedValueProjectionIndex(projects)
+	if !ok || idx != 1 {
+		t.Fatalf("sharedValueProjectionIndex = (%d, %v); want (1, true)", idx, ok)
+	}
+}
+
+// TestSharedValueProjectionIndex_RejectsTwoDifferingPositions pins that the
+// scan does not stop at the first position the arms AGREE at. Two differing
+// positions is the "arms diverge somewhere the fused pass cannot represent"
+// case, and it is only reachable by continuing past position 0.
+//
+// Abandoning the scan there instead would silently fall through to the
+// every-position-agrees fallback, which finds the value alias by name and
+// reports the arms fusable — exactly the unsound fold the function exists to
+// refuse.
+func TestSharedValueProjectionIndex_RejectsTwoDifferingPositions(t *testing.T) {
+	t.Parallel()
+	projects := []*chplan.Project{
+		sharedValueProj(
+			[2]string{sharedValueOtherAlias, "labels"}, // position 0: the arms agree here
+			[2]string{rangeAggSynthValueColumn, "a"},   // position 1: differs
+			[2]string{sharedValueOtherAlias, "x"},      // position 2: differs too
+		),
+		sharedValueProj(
+			[2]string{sharedValueOtherAlias, "labels"},
+			[2]string{rangeAggSynthValueColumn, "b"},
+			[2]string{sharedValueOtherAlias, "y"},
+		),
+	}
+	if idx, ok := sharedValueProjectionIndex(projects); ok {
+		t.Errorf("sharedValueProjectionIndex = (%d, true); want ok=false — the arms differ at positions 1 AND 2, so no single slot describes the divergence", idx)
+	}
+}
+
+// TestSharedValueProjectionIndex_RejectsADuplicateValueAlias covers the
+// fallback path taken when every arm projects the same thing everywhere: the
+// value slot is then located by ALIAS, and two slots carrying that alias make
+// the choice ambiguous. Picking either one leaves the other unpivoted under
+// the same output name.
+//
+// The duplicate is placed at positions 0 and 1 deliberately: the ambiguity is
+// only detectable if the already-found index 0 counts as "already found", and
+// index 0 is the one value a `>= 0` guard and a `> 0` one disagree about.
+func TestSharedValueProjectionIndex_RejectsADuplicateValueAlias(t *testing.T) {
+	t.Parallel()
+	arm := func() *chplan.Project {
+		return sharedValueProj(
+			[2]string{rangeAggSynthValueColumn, "a"},
+			[2]string{rangeAggSynthValueColumn, "b"},
+		)
+	}
+	projects := []*chplan.Project{arm(), arm()}
+	if idx, ok := sharedValueProjectionIndex(projects); ok {
+		t.Errorf("sharedValueProjectionIndex = (%d, true); want ok=false — two slots carry %q, so the value slot is ambiguous", idx, rangeAggSynthValueColumn)
+	}
+}
+
+// TestSharedValueProjectionIndex_AcceptsTheValueAliasAtPositionZero is the
+// other half of the same boundary. When every arm agrees everywhere, the
+// fallback alias search legitimately answers "slot 0" — and slot 0 is a real
+// answer, not the "found nothing" sentinel the search starts from. Treating it
+// as a miss would refuse to fuse every shared-value query whose value column
+// happens to be projected first.
+func TestSharedValueProjectionIndex_AcceptsTheValueAliasAtPositionZero(t *testing.T) {
+	t.Parallel()
+	arm := func() *chplan.Project {
+		return sharedValueProj(
+			[2]string{rangeAggSynthValueColumn, "a"},
+			[2]string{sharedValueOtherAlias, "labels"},
+		)
+	}
+	projects := []*chplan.Project{arm(), arm()}
+	idx, ok := sharedValueProjectionIndex(projects)
+	if !ok || idx != 0 {
+		t.Errorf("sharedValueProjectionIndex = (%d, %v); want (0, true) — the value alias sits at slot 0, which is a found index, not a miss", idx, ok)
+	}
+}
+
+// TestSharedValueProjectionIndex_RejectsWhenNoSlotCarriesTheValueAlias is the
+// case the "found nothing" rejection actually exists for: arms that agree
+// everywhere but project no value column at all cannot be unpivoted.
+func TestSharedValueProjectionIndex_RejectsWhenNoSlotCarriesTheValueAlias(t *testing.T) {
+	t.Parallel()
+	arm := func() *chplan.Project {
+		return sharedValueProj(
+			[2]string{sharedValueOtherAlias, "labels"},
+			[2]string{"TimeUnix", "ts"},
+		)
+	}
+	projects := []*chplan.Project{arm(), arm()}
+	if idx, ok := sharedValueProjectionIndex(projects); ok {
+		t.Errorf("sharedValueProjectionIndex = (%d, true); want ok=false — no slot carries %q", idx, rangeAggSynthValueColumn)
+	}
+}

--- a/internal/logql/lsyntax/gremlins_kill_sort_grouping_test.go
+++ b/internal/logql/lsyntax/gremlins_kill_sort_grouping_test.go
@@ -1,0 +1,95 @@
+package lsyntax
+
+import (
+	"strings"
+	"testing"
+)
+
+// LogQL's `sort` / `sort_desc` are the two vector-aggregation operators that
+// accept NO grouping clause at all: `sort by (x) (…)` is a query the reference
+// parser rejects outright, because the operator sorts the whole instant vector
+// and has no per-group meaning. validateSortGrouping is the one place that
+// rule lives, and validateSampleExpr's *VectorAggregationExpr arm is the only
+// place it is consulted.
+//
+// Both of those sites survived mutation on `phase4-logql-parser` (cerberus
+// issue #2913) — the leg's only two survivors. Nothing in the corpus ever
+// wrote a grouping clause onto a sort, so:
+//
+//   - negating validateSortGrouping's `g != nil` nil-guard was invisible: with
+//     no case that reaches it carrying a grouping, the function returned nil
+//     either way; and
+//   - negating the `err != nil` check on its result in validateSampleExpr was
+//     invisible for the same reason — an always-nil error is indistinguishable
+//     from an always-ignored one.
+//
+// The rejection is therefore asserted directly, in all three surface forms the
+// grammar admits (`by`, `without`, and `sort_desc`'s own), alongside the
+// accepted no-grouping baseline that proves the operator itself parses. The
+// accepted case is what makes the rejections specific: it is the same query
+// with the grouping clause removed, so nothing but the clause can explain the
+// difference.
+
+// sortGroupingRejection is the reference wording validateSortGrouping raises.
+// Matching on it (not merely on "some error") is what pins the rejection to
+// THIS rule rather than to an unrelated parse failure elsewhere in the query.
+const sortGroupingRejection = "sort and sort_desc doesn't allow grouping by"
+
+// sortableInner is the range aggregation every case below sorts. It is a
+// well-formed selector, so it contributes no error of its own.
+const sortableInner = `rate({app="a"}[1m])`
+
+func TestParseExpr_SortAcceptsNoGroupingClause(t *testing.T) {
+	t.Parallel()
+	for _, q := range []string{
+		"sort(" + sortableInner + ")",
+		"sort_desc(" + sortableInner + ")",
+	} {
+		expr, err := ParseExpr(q)
+		if err != nil {
+			t.Fatalf("ParseExpr(%q) = %v; want the query to parse — the rejection cases below are this same query plus a grouping clause, and prove nothing if the baseline is already broken", q, err)
+		}
+		agg, ok := expr.(*VectorAggregationExpr)
+		if !ok {
+			t.Fatalf("ParseExpr(%q) = %T; want *VectorAggregationExpr", q, expr)
+		}
+		if agg.Grouping != nil && len(agg.Grouping.Groups) != 0 {
+			t.Errorf("ParseExpr(%q) produced grouping %#v; want none", q, agg.Grouping)
+		}
+	}
+}
+
+func TestParseExpr_SortRejectsEveryGroupingClause(t *testing.T) {
+	t.Parallel()
+	for _, q := range []string{
+		"sort by (app) (" + sortableInner + ")",
+		"sort without (app) (" + sortableInner + ")",
+		"sort_desc by (app) (" + sortableInner + ")",
+		"sort_desc without (app) (" + sortableInner + ")",
+	} {
+		_, err := ParseExpr(q)
+		if err == nil {
+			t.Errorf("ParseExpr(%q) = nil error; want the grouping clause rejected", q)
+			continue
+		}
+		if !strings.Contains(err.Error(), sortGroupingRejection) {
+			t.Errorf("ParseExpr(%q) = %v; want an error containing %q", q, err, sortGroupingRejection)
+		}
+	}
+}
+
+// TestParseExpr_SortStillValidatesItsOperand pins the OTHER half of the
+// *VectorAggregationExpr arm: the grouping check is a guard placed BEFORE the
+// recursive descent into the sorted expression, not a replacement for it. A
+// sort over an operand that is itself invalid must still be rejected on the
+// operand's own grounds — which is what stops the grouping check from being
+// wired as an early `return` on the sort arm.
+func TestParseExpr_SortStillValidatesItsOperand(t *testing.T) {
+	t.Parallel()
+	// `app=~".*"` is empty-compatible: it matches every stream, which
+	// validateMatchers rejects. The sort wrapper must not mask it.
+	const q = `sort(rate({app=~".*"}[1m]))`
+	if _, err := ParseExpr(q); err == nil {
+		t.Fatalf("ParseExpr(%q) = nil error; want the empty-compatible matcher inside the sort rejected", q)
+	}
+}

--- a/internal/promql/gremlins_kill_lower_structural_test.go
+++ b/internal/promql/gremlins_kill_lower_structural_test.go
@@ -1,0 +1,177 @@
+package promql
+
+import (
+	"testing"
+
+	"github.com/prometheus/common/model"
+	"github.com/prometheus/prometheus/model/labels"
+	promparser "github.com/prometheus/prometheus/promql/parser"
+
+	"github.com/tsouza/cerberus/internal/chplan"
+	"github.com/tsouza/cerberus/internal/schema"
+)
+
+// Structural recognisers and shape guards in lower.go that survived mutation
+// on `phase4-promql-lower` (cerberus issues #2883 / #2913). Each is a pure
+// function whose wrong answer is a wrong PLAN, not a slow one, and each
+// survived for the same reason: the golden corpus only ever reaches it down
+// the arm it accepts, so the rejections were never the reason for any pinned
+// SQL.
+
+// unionArmWindow is a range window standing in for the DELTA-temporality
+// fan-out arm. Its contents are irrelevant to the structural recogniser under
+// test — only its Go type is.
+func unionArmWindow() *chplan.RangeWindow { return &chplan.RangeWindow{Func: "rate"} }
+
+// unionArmNative is the CUMULATIVE native-grid arm's stand-in, for the same
+// reason.
+func unionArmNative() *chplan.RangeWindowGridNative { return &chplan.RangeWindowGridNative{} }
+
+// temporalityUnion wraps arms in the Project-over-UnionAll shape
+// [rateIncreaseTemporalityUnionArms] recognises.
+func temporalityUnion(arms ...chplan.Node) chplan.Node {
+	return &chplan.Project{Input: &chplan.UnionAll{Inputs: arms}}
+}
+
+// TestRateIncreaseTemporalityUnionArms_RecognisesOnlyTheExactTwoArmShape pins
+// every structural clause of the recogniser independently.
+//
+// The recogniser's whole contract is that it identifies ONE construction
+// site's output. Its caller folds an outer sum/min/max into the native arm and
+// leaves the delta arm alone, so a false positive rewrites a plan the fold was
+// never proven against: a third arm would be silently dropped, and a
+// mis-typed arm would be folded as if it were the native grid. Both are
+// answered here by the arm count and the two type assertions, and both
+// survived because the corpus only ever hands this function the exact shape
+// [derivedRateArm] builds.
+func TestRateIncreaseTemporalityUnionArms_RecognisesOnlyTheExactTwoArmShape(t *testing.T) {
+	t.Parallel()
+
+	// The baseline every rejection below is a perturbation of.
+	native, delta, ok := rateIncreaseTemporalityUnionArms(temporalityUnion(unionArmNative(), unionArmWindow()))
+	if !ok || native == nil || delta == nil {
+		t.Fatalf("rateIncreaseTemporalityUnionArms(native, window) = (%v, %v, %v); want both arms and ok=true — the rejections below prove nothing against a broken accept path", native, delta, ok)
+	}
+
+	cases := []struct {
+		name  string
+		input chplan.Node
+		why   string
+	}{
+		{
+			name:  "not a Project",
+			input: &chplan.UnionAll{Inputs: []chplan.Node{unionArmNative(), unionArmWindow()}},
+			why:   "the recognised shape is the attributes Project over the union, not a bare union",
+		},
+		{
+			name:  "Project over something other than a union",
+			input: &chplan.Project{Input: unionArmWindow()},
+			why:   "there are no arms to split without a UnionAll",
+		},
+		{
+			name:  "three arms",
+			input: temporalityUnion(unionArmNative(), unionArmWindow(), unionArmWindow()),
+			why:   "the fold rewrites arm 0 and passes arm 1 through, so a third arm would be silently dropped",
+		},
+		{
+			name:  "one arm",
+			input: temporalityUnion(unionArmNative()),
+			why:   "there is no delta arm to pass through",
+		},
+		{
+			name:  "first arm is not the native grid",
+			input: temporalityUnion(unionArmWindow(), unionArmWindow()),
+			why:   "the fold folds the outer aggregation INTO the native grid arm; a fan-out window there is a different plan",
+		},
+		{
+			name:  "second arm is not a fan-out window",
+			input: temporalityUnion(unionArmNative(), unionArmNative()),
+			why:   "the delta arm is the raw fan-out; a second native arm is not the shape derivedRateArm builds",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if n, d, got := rateIncreaseTemporalityUnionArms(tc.input); got {
+				t.Errorf("rateIncreaseTemporalityUnionArms(%s) = (%v, %v, true); want ok=false — %s", tc.name, n, d, tc.why)
+			}
+		})
+	}
+}
+
+// TestResolveUnambiguousScanTable_RejectsAnUnpinnedNameOverAHistogramSchema
+// pins the regex-name exclusion. An unpinned `__name__` matcher fans out to
+// the multi-arm regex-histogram union, so there is no single table for the
+// temporality read (or the downsample tier) to attach to — and answering with
+// one anyway would route a union-shaped query onto a single-scan strategy.
+//
+// The exclusion is only OBSERVABLE on a schema whose unknown-name table set is
+// already a singleton, because a schema with distinct Gauge and Sum tables
+// hands the routing two candidates and the later `len(route.tables) != 1`
+// check answers "" for its own reasons. Collapsing Sum onto Gauge — the shape
+// [schema.Metrics.TablesForUnknownName] carries an explicit branch for — is
+// what isolates this clause as the ONLY thing standing between a regex
+// selector and a single-scan answer. The default schema's two-table case is
+// asserted alongside it: the exclusion must hold there too.
+func TestResolveUnambiguousScanTable_RejectsAnUnpinnedNameOverAHistogramSchema(t *testing.T) {
+	t.Parallel()
+	base := schema.DefaultOTelMetrics()
+	if base.HistogramTable == "" {
+		t.Fatalf("schema.DefaultOTelMetrics() has no HistogramTable; this test asserts the clause that reads it")
+	}
+	// A deployment whose plain-Sample gauges and sums share one physical
+	// table: TablesForUnknownName then yields exactly one candidate.
+	collapsed := base
+	collapsed.SumTable = base.GaugeTable
+
+	pinned := &promparser.VectorSelector{LabelMatchers: []*labels.Matcher{
+		mustMatcher(t, labels.MatchEqual, model.MetricNameLabel, "http_requests_total"),
+	}}
+	if got := resolveUnambiguousScanTable(pinned, collapsed, lowerCtx{}); got != collapsed.GaugeTable {
+		t.Fatalf("resolveUnambiguousScanTable(pinned name) = %q; want %q — the rejections below prove nothing if the accept path is already broken", got, collapsed.GaugeTable)
+	}
+
+	for _, tc := range []struct {
+		name string
+		s    schema.Metrics
+	}{
+		{"gauge and sum collapsed onto one table", collapsed},
+		{"distinct gauge and sum tables", base},
+	} {
+		unpinned := &promparser.VectorSelector{LabelMatchers: []*labels.Matcher{
+			mustMatcher(t, labels.MatchRegexp, model.MetricNameLabel, "http_.*"),
+		}}
+		if got := resolveUnambiguousScanTable(unpinned, tc.s, lowerCtx{}); got != "" {
+			t.Errorf("resolveUnambiguousScanTable(regex name, %s) = %q; want \"\" — a regex name fans out to the multi-arm histogram union, which is not a single unambiguous scan", tc.name, got)
+		}
+	}
+}
+
+// TestAppendNameGroupKey_AppendsToAWindowGroupingOnNothing covers the
+// degenerate grouping the corpus never produces: every fixture that reaches
+// [appendNameGroupKey] already groups on the attributes column, so the
+// append's own sizing was only ever exercised with a non-empty key list.
+//
+// The emitter projects EXACTLY the group keys, so the post-condition that
+// matters is that the name key is present afterwards and appears once —
+// asserted here for both the empty starting grouping and the idempotent
+// re-application.
+func TestAppendNameGroupKey_AppendsToAWindowGroupingOnNothing(t *testing.T) {
+	t.Parallel()
+	s := schema.DefaultOTelMetrics()
+
+	rw := &chplan.RangeWindow{Func: "rate"}
+	ref := appendNameGroupKey(rw, s)
+	if ref == nil || ref.Name != s.MetricNameColumn {
+		t.Fatalf("appendNameGroupKey returned %#v; want a ColumnRef for %q", ref, s.MetricNameColumn)
+	}
+	if len(rw.GroupBy) != 1 || !isIdentityColumnRef(rw.GroupBy[0], s.MetricNameColumn) {
+		t.Fatalf("GroupBy after appending to an empty grouping = %#v; want exactly the name key", rw.GroupBy)
+	}
+
+	// Idempotent: a window that already groups on the name keeps one key.
+	appendNameGroupKey(rw, s)
+	if len(rw.GroupBy) != 1 {
+		t.Errorf("GroupBy after a second append = %#v; want the single name key, not a duplicate", rw.GroupBy)
+	}
+}

--- a/internal/promql/gremlins_kill_strategy_eligibility_test.go
+++ b/internal/promql/gremlins_kill_strategy_eligibility_test.go
@@ -1,0 +1,248 @@
+package promql
+
+// The four boot-wired range-strategy eligibility predicates in
+// lower_strategy.go — fixedAccumulatorEligible, sortedSlabOverTimeEligible,
+// lagAdjacencyEligible and downsampleTierEligible — each open with one
+// multi-clause `||` guard that decides whether a query takes the
+// ClickHouse-native path or the unchanged fan-out. Every clause of every one
+// of those guards survived mutation on `phase4-promql-g` (cerberus issue
+// #2913): the corpus that reaches these strategies only ever carries a fully
+// materialised matrix grid, so nothing distinguished `<= 0` from `< 0` on the
+// window bounds, and nothing distinguished `||` from `&&` between the clauses.
+//
+// A `||` chain is only pinned by a case where the clauses DISAGREE: flipping
+// one `||` to `&&` is invisible whenever every clause agrees, and invisible
+// whenever the guard is never reached. So each table below starts from a
+// baseline the test first proves IS routed to the native path, then perturbs
+// exactly ONE clause of the guard and requires the strategy to decline. That
+// makes the case impossible to satisfy vacuously: a broken baseline fails the
+// accept assertion, and a guard that stopped guarding fails the decline
+// assertion.
+//
+// The bounds clauses are asserted at their exact `== 0` boundary rather than
+// with a negative duration, because `<= 0` and `< 0` differ ONLY at zero — a
+// negative-duration case would pass against either operator and prove nothing.
+
+import (
+	"testing"
+	"time"
+
+	"github.com/tsouza/cerberus/internal/chplan"
+	"github.com/tsouza/cerberus/internal/schema"
+)
+
+// The baseline window every case below perturbs: a materialised query_range
+// matrix grid over a whole number of downsample-tier buckets, anchored on a
+// bucket boundary so the tier guard's alignment clauses are satisfied too.
+const (
+	// eligibilityBaselineRange is the window duration — one tier bucket, so
+	// the same baseline satisfies downsampleTierEligible's
+	// integer-multiple-of-bucket clause.
+	eligibilityBaselineRange = schema.DownsampleTierBucket
+
+	// eligibilityBaselineStep is the eval step — also one tier bucket, for
+	// the same reason.
+	eligibilityBaselineStep = schema.DownsampleTierBucket
+
+	// eligibilityBaselineOuterRange is the fan-out span the three
+	// non-tier guards require to be positive.
+	eligibilityBaselineOuterRange = time.Hour
+
+	// eligibilityBaselineStartUnix is the grid start, an exact multiple of
+	// schema.DownsampleTierBucket in absolute Unix-epoch seconds
+	// (1700000100 = 5666667 * 300) so downsampleTierEligible's
+	// bucket-boundary clause holds.
+	eligibilityBaselineStartUnix = 1700000100
+)
+
+// eligibilityBaseline returns the range window every case perturbs: eligible
+// for all four strategies as written.
+func eligibilityBaseline() *chplan.RangeWindow {
+	start := time.Unix(eligibilityBaselineStartUnix, 0).UTC()
+	return &chplan.RangeWindow{
+		Func:                "rate",
+		Range:               eligibilityBaselineRange,
+		Step:                eligibilityBaselineStep,
+		OuterRange:          eligibilityBaselineOuterRange,
+		Start:               start,
+		End:                 start.Add(eligibilityBaselineOuterRange),
+		DownsampleTierInput: &chplan.Scan{Table: schema.DownsampleTierTable},
+	}
+}
+
+// eligibilityCase is one perturbation of the baseline window plus the reason
+// the guard under test must decline it.
+type eligibilityCase struct {
+	name string
+	// perturb mutates exactly one clause's input on a fresh baseline.
+	perturb func(rw *chplan.RangeWindow)
+	// why explains, in the failure message, what the guard is for.
+	why string
+}
+
+// boundsPerturbations are the four clauses fixedAccumulatorEligible,
+// sortedSlabOverTimeEligible and lagAdjacencyEligible share verbatim:
+//
+//	if rw.OuterRange <= 0 || rw.Step <= 0 || rw.Start.IsZero() || rw.End.IsZero()
+//
+// Every one of them must independently send the query to the fan-out
+// fallback.
+var boundsPerturbations = []eligibilityCase{
+	{
+		name:    "OuterRange is exactly zero",
+		perturb: func(rw *chplan.RangeWindow) { rw.OuterRange = 0 },
+		why:     "a window with no fan-out span is not the materialised matrix grid these emitters need",
+	},
+	{
+		name:    "Step is exactly zero",
+		perturb: func(rw *chplan.RangeWindow) { rw.Step = 0 },
+		why:     "a zero step is the instant shape, which has no anchor grid to decompose",
+	},
+	{
+		name:    "Start is unset",
+		perturb: func(rw *chplan.RangeWindow) { rw.Start = time.Time{} },
+		why:     "an unpinned Start leaves the scan-prune bound these emitters rely on unbounded",
+	},
+	{
+		name:    "End is unset",
+		perturb: func(rw *chplan.RangeWindow) { rw.End = time.Time{} },
+		why:     "an unpinned End leaves the scan-prune bound these emitters rely on unbounded",
+	},
+}
+
+func TestFixedAccumulatorRateLowerer_DeclinesEveryUnboundedWindowClause(t *testing.T) {
+	t.Parallel()
+	s := schema.DefaultOTelMetrics()
+	l := FixedAccumulatorRateLowerer{Fallback: FanoutRateLowerer{}}
+
+	routed, ok := l.LowerRate(eligibilityBaseline(), s).(*chplan.RangeWindow)
+	if !ok || !routed.FixedAccumulatorExtrapolated {
+		t.Fatalf("baseline window was not routed to the fixed-accumulator path (%#v); every decline case below would then prove nothing", routed)
+	}
+
+	for _, tc := range boundsPerturbations {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			rw := eligibilityBaseline()
+			tc.perturb(rw)
+			got, isWindow := l.LowerRate(rw, s).(*chplan.RangeWindow)
+			if !isWindow {
+				t.Fatalf("LowerRate returned %#v; want a *chplan.RangeWindow", got)
+			}
+			if got.FixedAccumulatorExtrapolated {
+				t.Errorf("LowerRate routed to the fixed-accumulator path with %s; want the fan-out fallback — %s", tc.name, tc.why)
+			}
+		})
+	}
+}
+
+func TestSortedSlabOverTimeLowerer_DeclinesEveryUnboundedWindowClause(t *testing.T) {
+	t.Parallel()
+	s := schema.DefaultOTelMetrics()
+	l := SortedSlabOverTimeLowerer{Fallback: FanoutOverTimeLowerer{}}
+
+	routed, ok := l.LowerOverTime(eligibilityBaseline(), s).(*chplan.RangeWindow)
+	if !ok || !routed.SortedSlabOverTime {
+		t.Fatalf("baseline window was not routed to the sorted-slab path (%#v); every decline case below would then prove nothing", routed)
+	}
+
+	for _, tc := range boundsPerturbations {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			rw := eligibilityBaseline()
+			tc.perturb(rw)
+			got, isWindow := l.LowerOverTime(rw, s).(*chplan.RangeWindow)
+			if !isWindow {
+				t.Fatalf("LowerOverTime returned %#v; want a *chplan.RangeWindow", got)
+			}
+			if got.SortedSlabOverTime {
+				t.Errorf("LowerOverTime routed to the sorted-slab path with %s; want the fan-out fallback — %s", tc.name, tc.why)
+			}
+		})
+	}
+}
+
+func TestLagAdjacencyIrateLowerer_DeclinesEveryUnboundedWindowClause(t *testing.T) {
+	t.Parallel()
+	s := schema.DefaultOTelMetrics()
+	l := LagAdjacencyIrateLowerer{Fallback: FanoutIrateLowerer{}}
+
+	routed, ok := l.LowerIrate(eligibilityBaseline(), s).(*chplan.RangeWindow)
+	if !ok || !routed.LagAdjacency {
+		t.Fatalf("baseline window was not routed to the lag-adjacency path (%#v); every decline case below would then prove nothing", routed)
+	}
+
+	for _, tc := range boundsPerturbations {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			rw := eligibilityBaseline()
+			tc.perturb(rw)
+			got, isWindow := l.LowerIrate(rw, s).(*chplan.RangeWindow)
+			if !isWindow {
+				t.Fatalf("LowerIrate returned %#v; want a *chplan.RangeWindow", got)
+			}
+			if got.LagAdjacency {
+				t.Errorf("LowerIrate routed to the lag-adjacency path with %s; want the fan-out fallback — %s", tc.name, tc.why)
+			}
+		})
+	}
+}
+
+// downsampleTierEligible's own opening guard differs from the three above: it
+// leads with rw.Identity instead of an OuterRange bound (OuterRange carries no
+// subquery-specific signal at this layer, per the predicate's doc), and its
+// range clause lives on a separate line. Each clause gets its own case for the
+// same reason.
+var downsampleTierPerturbations = []eligibilityCase{
+	{
+		name:    "Identity window",
+		perturb: func(rw *chplan.RangeWindow) { rw.Identity = true },
+		why:     "the bare-vector subquery no-op path is not one of the tier's three owning functions",
+	},
+	{
+		name:    "Step is exactly zero",
+		perturb: func(rw *chplan.RangeWindow) { rw.Step = 0 },
+		why:     "a zero step is the instant shape, which the tier's materialised grid cannot answer",
+	},
+	{
+		name:    "Start is unset",
+		perturb: func(rw *chplan.RangeWindow) { rw.Start = time.Time{} },
+		why:     "an unpinned Start cannot be checked against the tier's absolute bucket boundaries",
+	},
+	{
+		name:    "End is unset",
+		perturb: func(rw *chplan.RangeWindow) { rw.End = time.Time{} },
+		why:     "an unpinned End leaves the tier read unbounded",
+	},
+	{
+		name:    "Range is exactly zero",
+		perturb: func(rw *chplan.RangeWindow) { rw.Range = 0 },
+		why:     "a zero-width window covers no whole tier bucket, and 0 % bucket == 0 makes the multiple check alone accept it",
+	},
+}
+
+func TestDownsampleTierIrateLowerer_DeclinesEveryShapeClause(t *testing.T) {
+	t.Parallel()
+	s := schema.DefaultOTelMetrics()
+	l := DownsampleTierIrateLowerer{Fallback: FanoutIrateLowerer{}}
+
+	routed, ok := l.LowerIrate(eligibilityBaseline(), s).(*chplan.RangeWindow)
+	if !ok || !routed.DownsampleTier {
+		t.Fatalf("baseline window was not routed to the downsampled tier (%#v); every decline case below would then prove nothing", routed)
+	}
+
+	for _, tc := range downsampleTierPerturbations {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			rw := eligibilityBaseline()
+			tc.perturb(rw)
+			got, isWindow := l.LowerIrate(rw, s).(*chplan.RangeWindow)
+			if !isWindow {
+				t.Fatalf("LowerIrate returned %#v; want a *chplan.RangeWindow", got)
+			}
+			if got.DownsampleTier {
+				t.Errorf("LowerIrate routed to the downsampled tier with %s; want the raw-scan fallback — %s", tc.name, tc.why)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Closes #2913

Closes #2883

Kills mutants on four of the seven legs #2913 lists, by adding real
assertions. No `exclude_files` widened, no `include_files` narrowed, no bar
lowered, and nothing added that lets a timeout pay for efficacy —
`.github/scripts/mutation-phases.mjs` and `mutation-matrix.mjs` are untouched
by this diff, so every denominator below is the same denominator the honest
run measured.

## A correction to #2913's table, measured

Run [33572151680](https://github.com/tsouza/cerberus/actions/runs/33572151680)
ran on `30d6c940`, the head of #2911's branch — which never picked up #2901.
So the 33 survivors it reports for `phase4-promql-lower` are the standing
BEFORE #2901's kills, not after.

I re-measured all 33 against `main`'s tree by hand-applying each mutation at
its exact `line:col` and running the `internal/promql` suite. **20 of the 33
are already dead**; only 13 genuinely survive. The denominator is a property
of the production code, which #2901 did not touch, so the leg's true standing
on `main` before this PR is 524/537 = **97.58%**, not 93.85%. That is why
`Closes #2883` is on this PR: #2901 did most of the work, and the four kills
here finish it.

## Per-leg standing

| leg | before (run 33572151680) | measured on `main` | this PR's own mutation run | denominator |
| --- | ---: | ---: | --- | ---: |
| `phase4-promql-lower` | 93.85% | 97.58% | **98.33% — green** (529 killed, 9 lived, 0 timed out) | 538, unchanged |
| `phase4-promql-g` | 94.88% | 94.88% | **green** | 410, unchanged |
| `phase4-logql-parser` | 94.87% | 94.87% | **green** | 78, unchanged |
| `phase4-logql-other-b` | 94.48% | 94.48% | did not finish — see below | 525, unchanged |
| `phase4-traceql-ast` | 92.98% | — | 92.98%, untouched | 285, unchanged |
| `phase4-logql-lsyntax` | 92.20% | — | 92.20%, untouched (reported exactly) | 487, unchanged |
| `phase5-qlcommon` | 90.61% | — | 90.61%, untouched | 330, unchanged |

Three legs are green on this PR's own run. Three are untouched here and are
inventoried in #2917 with the reason each is where it is: `traceql-ast` needs
six real kills, and `logql-lsyntax` / `qlcommon` are short by one mutant even
at a perfect survivor sweep because of their timeouts, which #2910 is what
settles.

`phase4-logql-other-b`'s two attempts both ended with the runner agent reaped
mid-run rather than with an efficacy line, so its number is unverified on CI.
The cause is measured and filed as #2919: the leg's per-mutant leash is derived
from its compile cycle, this PR's two new test files moved that cycle from
25.7s to 31.2s, and the longer leash lets
`logpattern/pattern.go:129:5` — an allocating non-terminating mutant that
`TIMED OUT` safely at the old 52s bound — run long enough to exhaust the
runner's memory. Both attempts stop at exactly that mutant. That is the
failure mode `mutation.yml`'s own comment above the budget derivation
describes, and it is a property of the leash, not of these tests: any edit
that lengthens the package's compile cycle would do it. The five kills
themselves are individually verified locally, and the leg's partial log
confirms all five are gone from its survivor list.

## What was killed, and by which assertion

### `phase4-promql-g` — 20 of 21 survivors

`lower_strategy.go`'s four boot-wired range-strategy eligibility predicates
each open with one multi-clause `||` guard, and **every clause of every guard**
survived. The corpus only reaches them with a fully materialised matrix grid,
so no case ever made two clauses of a guard disagree — which is the only thing
a `||`→`&&` collapse is visible in — and no case sat on the `== 0` boundary
where `<= 0` and `< 0` differ.

| site | mutants killed |
| --- | --- |
| `fixedAccumulatorEligible` (834) | `<=`→`<` at :19, :35; `\|\|`→`&&` at :24, :40, :61 |
| `sortedSlabOverTimeEligible` (891) | same five |
| `lagAdjacencyEligible` (1381) | same five |
| `downsampleTierEligible` (1566, 1576) | `<=`→`<` at 1566:28 and 1576:14; `\|\|`→`&&` at 1566:17, :33, :54 |

Each table starts from a baseline the test first proves IS routed to the
native path, then perturbs exactly one clause and requires the strategy to
decline — so a broken baseline fails the accept assertion and a guard that
stopped guarding fails the decline assertion.

### `phase4-logql-parser` — both survivors

`sort` / `sort_desc` accept no grouping clause. Both the rule
(`validateSortGrouping`'s `g != nil`) and its only consultation
(`validateSampleExpr`'s `err != nil`) survived: nothing in the corpus ever
wrote a grouping onto a sort, and an always-nil error is indistinguishable
from an always-ignored one. All four surface forms are now asserted against
the no-grouping baseline they are the perturbation of, plus the operand still
being validated underneath.

### `phase4-logql-other-b` — 5 of 23 survivors

Five loop decisions that only a shape no fixture writes can distinguish.

- `variants.go:406:4` (`continue`→`break`), `:422:16` (`>=`→`>`), `:427:15`
  (`<`→`<=`) — `sharedValueProjectionIndex` decides which projection slot the
  multi-variant fusion may unpivot; a wrong slot folds arms describing
  DIFFERENT series onto one grouped pass. Now pinned on the two-differing-
  positions rejection, the duplicate alias, the value alias at slot 0 (a found
  index, not the miss sentinel) and the no-value-alias rejection.
- `drop_keep.go:165:4`, `:223:4` (`continue`→`break`) — both fold loops
  accumulate ACROSS entries, so abandoning either instead of skipping one
  entry silently narrows the predicate. Asserted on the exact folded
  expression: a truncated fold is non-nil too.

### `phase4-promql-lower` — 4 of the 13 real survivors

- `4522:14`, `4527:15` (`||`→`&&`) — `rateIncreaseTemporalityUnionArms`
  identifies exactly one construction site's `Project{UnionAll{…}}` output,
  and its caller folds an outer sum/min/max into arm 0. A false positive drops
  a third arm silently or folds a mis-typed arm as if it were the native grid.
  Both the arm-count clause and the two arm-type assertions are perturbed one
  at a time against an accepted baseline.
- `3887:72` (`!=`→`==`) — `resolveUnambiguousScanTable` must answer `""` for an
  unpinned `__name__` matcher over a schema that has a histogram table. The
  clause is only OBSERVABLE on a schema whose unknown-name table set is already
  a singleton, because a two-table schema's later `len(route.tables) != 1`
  check answers `""` for its own reasons — so the test collapses Sum onto
  Gauge, the shape `TablesForUnknownName` carries an explicit branch for, and
  asserts the default two-table schema alongside it.
- `4174:67` (`+`→`-`) — `appendNameGroupKey`'s sizing was only ever exercised
  from a window that already groups on the attributes column. The degenerate
  empty grouping is now covered, asserted on the post-condition the emitter
  reads: the name key present exactly once.

## Proven equivalent mutants

Five of `phase4-promql-lower`'s 13 remaining survivors are equivalent, with
the proof rather than the claim — the same treatment #2901 gave its three
`CONDITIONALS_BOUNDARY` mutants on an unreachable `== 1` branch.

- `lower.go:5073:56` and `lower.go:6018:49`, `ARITHMETIC_BASE` `*`→`/`. Both
  mutate the CAPACITY argument of a `make([]chplan.Expr, 0, …)` whose length is
  zero. Capacity is an allocation hint with no observable behaviour, and
  `(n+1)*2` / `n*2` and their `/2` mutants are all non-negative for every `n`,
  so neither can panic either. Nothing downstream can see the difference.
- `lower.go:2709:21`, `:2775:21`, `:2796:21`, `CONDITIONALS_BOUNDARY`
  `<= 1`→`< 1`. All three sit immediately after
  `if !format.PromLabelNeedsDottedFallback(x) { return … }`. That guard
  returning true means `x` carries at least one internal underscore
  (`otelname.go:220`), and `computePromLabelCandidates` then returns `s` plus
  at least one dotted rewrite — so `len(candidates) >= 2` at all three sites,
  always. `<= 1` and `< 1` differ only at exactly 1, which is unreachable.

The other four (`5291:31`, `5882:15`, `737:54`, `797:25`) are real survivors
I did not reach; they are inventoried in #2917 with the rest.

## Verification

Every kill was verified individually and mechanically: apply the mutation at
its exact `line:col`, run the new test, confirm it FAILS; restore the file,
confirm it PASSES. 31 of 31 targeted mutants flip. The measurement of
`phase4-promql-lower`'s true standing used the same harness against the whole
33-mutant list and the full `internal/promql` suite.

`mutation` is informational on a PR. Its run here independently confirms
`phase4-promql-lower` at 98.33% with exactly the nine survivors this
description predicts — the five proven equivalents plus the four named as
unreached — and confirms `phase4-promql-g` and `phase4-logql-parser` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
