### PR TITLE
fix(ci): bound a mutant's memory so a runaway is recorded, not fatal

### DIFF
--- a/.github/scripts/mutant-memory-guard.mjs
+++ b/.github/scripts/mutant-memory-guard.mjs
@@ -1,0 +1,218 @@
+#!/usr/bin/env node
+// mutant-memory-guard.mjs — a `go test -exec` supervisor that bounds ONE
+// mutant's resident memory, so an allocating non-terminating mutant is RECORDED
+// instead of reaping the runner.
+//
+// Required env: MUTANT_MEMORY_MAX (a Go-style byte size, e.g. `1GiB`),
+//               MUTANT_MEMORY_HOLD (a Go duration, e.g. `150s`),
+//               MUTANT_MEMORY_LEDGER (a path this script APPENDS one JSON line
+//               to per breach).
+// argv: the test binary and its arguments, exactly as `go test -exec` passes
+//       them.
+//
+// The ledger is how a breach becomes visible. `go test` buffers a test binary's
+// output and prints it only when the package FAILS, so a ::notice:: written to
+// stdout from here is discarded on exactly the path this guard creates — the
+// child is killed, the package is never reported as failing, and the annotation
+// would vanish. mutation-run.mjs reads the ledger after gremlins exits and
+// reports every breach itself.
+//
+// WHY A SEPARATE BOUND EXISTS AT ALL
+// ----------------------------------
+// gremlins leashes each mutant with ONE number — a context deadline wrapping
+// the whole `go test` child (resolve, compile, link, then run). That deadline
+// is the lane's only bound, and .github/scripts/mutation-run.mjs derives it
+// from the leg's measured recompile+link+run cycle, because the compile is what
+// dominates it (#2903).
+//
+// A wall-clock bound does not bound ALLOCATION. Measured on
+// `internal/logql/logpattern`'s REMOVE_SELF_ASSIGNMENTS mutant at
+// pattern.go:129 (`i += size` -> `i = size`, which pins the scanner index and
+// appends a rune per iteration for ever), the mutated test binary reaches
+// 5 GiB of RSS in 3.3 s — about 1.5 GiB/s. So on a 16 GB runner the mutant
+// exhausts the machine in roughly ten seconds, BELOW the lane's 15 s budget
+// floor and far below the ~63 s its compile cycle requires. There is no leash
+// value that is both long enough for the compile and short enough for the
+// memory: the window is empty, not merely narrow (#2919).
+//
+// GOMEMLIMIT does not close it either. It is a soft limit, and Go's GC CPU
+// limiter guarantees the mutator at least half the CPU, so a mutant whose heap
+// is LIVE keeps growing. Measured on the same binary: 5 GiB in 8.5 s at
+// GOMEMLIMIT=512MiB against 3.3 s unbounded — a 2.6x slowdown, not a bound.
+//
+// So the bound has to be memory itself, applied to the process that allocates.
+//
+// WHAT HAPPENS WHEN THE BOUND IS BREACHED
+// ---------------------------------------
+// The child is killed immediately, which returns its pages to the runner, and
+// the guard then HOLDS — it does not exit. That is deliberate, and it is the
+// only honest verdict this script can produce:
+//
+//   - gremlins reads a mutant's outcome from the `go test` EXIT CODE (1 ->
+//     KILLED, 2 -> NOT VIABLE, anything else -> LIVED) or from its own deadline
+//     firing (-> TIMED OUT). `go test` collapses every test-binary failure to
+//     its own exit 1, so ANY exit the guard forces after killing the child
+//     would be recorded as a KILL — crediting the suite for a mutant it never
+//     adjudicated, which is exactly the accounting #2903 removed.
+//   - Exiting 0 would record LIVED, which gremlins' own --on-shutdown-status
+//     work rejected for unadjudicated mutants: "reporting these as LIVED
+//     misrepresents the data — they were never tested".
+//   - Holding lets gremlins' existing deadline fire and record TIMED OUT, which
+//     .github/scripts/gremlins-threshold.mjs already scores as UNADJUDICATED:
+//     counted in the denominator, credited to nobody.
+//
+// The hold costs no wall clock the lane was not already paying: the mutants
+// that trip this bound are the mutants that were already burning their whole
+// budget before dying. What changes is the peak RSS while they do it.
+//
+// MUTANT_MEMORY_HOLD is a backstop for the one path with no deadline behind it
+// — gremlins' initial coverage run, which is UNMUTATED and so cannot trip the
+// bound, but must not be able to wedge the job if that ever stops being true.
+// On expiry the guard exits 0 (LIVED, a survivor). The ordering is deliberate:
+// prefer TIMED OUT, fall back to LIVED, never KILLED.
+
+import { spawn } from 'node:child_process';
+import { appendFileSync, readFileSync } from 'node:fs';
+import process from 'node:process';
+
+import { error, notice } from './lib/gh.mjs';
+
+// residentSampleIntervalMs is how often the child's RSS is read from
+// /proc/<pid>/status. It bounds the OVERSHOOT past MUTANT_MEMORY_MAX: at the
+// 1.5 GiB/s allocation rate measured above, a 50 ms gap lets a runaway add at
+// most ~77 MiB after crossing the line. Reading one small procfs file twenty
+// times a second is not measurable against a `go test` child.
+const residentSampleIntervalMs = 50;
+
+// holdPollIntervalMs is how often the hold loop re-checks its own deadline.
+// Nothing observes it but the deadline itself, so it is coarse on purpose.
+const holdPollIntervalMs = 250;
+
+const byteUnitMultipliers = {
+  B: 1,
+  KiB: 1024,
+  MiB: 1024 ** 2,
+  GiB: 1024 ** 3,
+  KB: 1000,
+  MB: 1000 ** 2,
+  GB: 1000 ** 3,
+};
+
+const goDurationUnitSeconds = { ns: 1e-9, us: 1e-6, ms: 1e-3, s: 1, m: 60, h: 3600 };
+
+function required(name) {
+  const value = String(process.env[name] ?? '').trim();
+  if (value === '') throw new Error(`${name} is required`);
+  return value;
+}
+
+// Parses `<number><unit>` with an explicit unit — no bare byte counts, because
+// a limit whose unit has to be guessed is a limit nobody can review.
+export function byteSize(name, spec) {
+  const match = /^([0-9]+(?:\.[0-9]+)?)(B|KiB|MiB|GiB|KB|MB|GB)$/.exec(spec);
+  if (match === null) {
+    throw new Error(`${name} is not a byte size (e.g. 1GiB): ${spec}`);
+  }
+  const bytes = Number(match[1]) * byteUnitMultipliers[match[2]];
+  if (!(bytes > 0)) throw new Error(`${name} must be positive: ${spec}`);
+  return bytes;
+}
+
+// Parses the subset of Go's duration grammar a hold bound can use: one or more
+// unsigned `<number><unit>` terms, e.g. `150s` or `2m30s`.
+export function goDurationSeconds(name, spec) {
+  const terms = spec.match(/[0-9]+(?:\.[0-9]+)?(?:ns|us|ms|s|m|h)/g);
+  if (terms === null || terms.join('') !== spec) {
+    throw new Error(`${name} is not a Go duration: ${spec}`);
+  }
+  const seconds = terms.reduce((total, term) => {
+    const [, value, unit] = /^([0-9]+(?:\.[0-9]+)?)([a-z]+)$/.exec(term);
+    return total + Number(value) * goDurationUnitSeconds[unit];
+  }, 0);
+  if (!(seconds > 0)) throw new Error(`${name} must be a positive duration: ${spec}`);
+  return seconds;
+}
+
+// residentBytes reads VmRSS for a live pid. A pid whose procfs entry is gone
+// has exited — a race with the exit handler, not a failure — so it reports 0
+// rather than throwing.
+export function residentBytes(pid, readStatus = (p) => readFileSync(`/proc/${p}/status`, 'utf8')) {
+  let status;
+  try {
+    status = readStatus(pid);
+  } catch {
+    return 0;
+  }
+  const match = /^VmRSS:\s+([0-9]+)\s+kB$/m.exec(status);
+  return match === null ? 0 : Number(match[1]) * 1024;
+}
+
+function formatMiB(bytes) {
+  return `${(bytes / 1024 ** 2).toFixed(0)}MiB`;
+}
+
+function main() {
+  const limitBytes = byteSize('MUTANT_MEMORY_MAX', required('MUTANT_MEMORY_MAX'));
+  const holdSeconds = goDurationSeconds('MUTANT_MEMORY_HOLD', required('MUTANT_MEMORY_HOLD'));
+  const ledger = required('MUTANT_MEMORY_LEDGER');
+  const [binary, ...args] = process.argv.slice(2);
+  if (binary === undefined) throw new Error('no test binary to run: this script is a `go test -exec` wrapper');
+
+  const child = spawn(binary, args, { stdio: 'inherit' });
+  let breached = false;
+
+  const sampler = setInterval(() => {
+    if (child.pid === undefined) return;
+    const rss = residentBytes(child.pid);
+    if (rss <= limitBytes) return;
+    breached = true;
+    clearInterval(sampler);
+    child.kill('SIGKILL');
+    // Recorded BEFORE the hold, because the hold normally ends in this process
+    // being killed by gremlins' deadline and never running another line.
+    appendFileSync(
+      ledger,
+      `${JSON.stringify({ binary, resident_bytes: rss, limit_bytes: limitBytes })}\n`,
+    );
+    notice(
+      `mutant memory bound breached: ${binary} reached ${formatMiB(rss)} against a ` +
+        `${formatMiB(limitBytes)} ceiling; killed, and holding so gremlins' own deadline records it ` +
+        'as TIMED OUT (unadjudicated) rather than as a kill',
+    );
+  }, residentSampleIntervalMs);
+
+  child.on('error', (cause) => {
+    clearInterval(sampler);
+    error(`cannot execute ${binary}: ${cause.message}`);
+    process.exit(1);
+  });
+
+  child.on('exit', (code, signal) => {
+    clearInterval(sampler);
+    if (!breached) {
+      // Faithful passthrough: an unbreached mutant must reach gremlins exactly
+      // as it would have without this wrapper in the path.
+      process.exit(code === null ? 128 + (signal === null ? 0 : 1) : code);
+    }
+    const deadline = Date.now() + holdSeconds * 1000;
+    const holder = setInterval(() => {
+      if (Date.now() < deadline) return;
+      clearInterval(holder);
+      notice(
+        `held ${holdSeconds}s after the memory bound was breached and no deadline reaped this ` +
+          'process; exiting 0, which records the mutant as LIVED (a survivor, never a kill)',
+      );
+      process.exit(0);
+    }, holdPollIntervalMs);
+  });
+}
+
+// Importing this module for its parsers must not run a supervisor.
+if (process.argv[1] !== undefined && process.argv[1].endsWith('mutant-memory-guard.mjs')) {
+  try {
+    main();
+  } catch (cause) {
+    error(cause instanceof Error ? cause.message : String(cause));
+    process.exit(1);
+  }
+}

--- a/.github/scripts/mutant-memory-guard.test.mjs
+++ b/.github/scripts/mutant-memory-guard.test.mjs
@@ -9,12 +9,25 @@ import { byteSize, goDurationSeconds, residentBytes } from './mutant-memory-guar
 
 const guard = '.github/scripts/mutant-memory-guard.mjs';
 
-// A child that allocates far past any ceiling the tests set, retaining every
-// buffer so the growth is LIVE — the shape of the mutant this guard exists for
+// A child that allocates past the ceiling the tests set, retaining every buffer
+// so the growth is LIVE — the shape of the mutant this guard exists for
 // (`i += size` -> `i = size` pins a scanner index and appends per iteration).
+//
+// It stops at 4x the ceiling under test rather than running away for real. That
+// self-limit is not decoration: this suite runs on a shared CI runner, and a
+// child that allocated without bound would take the runner down whenever the
+// guard is BROKEN — turning a test failure into the very outage the guard
+// exists to prevent, with no assertion to read afterwards. A working guard kills
+// it at the 256MiB ceiling long before the self-limit; a broken one lets the
+// child stop on its own and leaves the ledger empty, which is what the
+// assertions below read.
+const runawayChildCeilingBytes = 4 * 256 * 1024 * 1024;
 const runawayChild = `
 const held = [];
-for (;;) held.push(Buffer.alloc(8 * 1024 * 1024, 1));
+while (held.length * 8 * 1024 * 1024 < ${runawayChildCeilingBytes}) {
+  held.push(Buffer.alloc(8 * 1024 * 1024, 1));
+}
+setTimeout(() => process.exit(0), 30_000);
 `;
 
 function workspace(t) {

--- a/.github/scripts/mutant-memory-guard.test.mjs
+++ b/.github/scripts/mutant-memory-guard.test.mjs
@@ -1,0 +1,203 @@
+import assert from 'node:assert/strict';
+import { spawn, spawnSync } from 'node:child_process';
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { test } from 'node:test';
+
+import { byteSize, goDurationSeconds, residentBytes } from './mutant-memory-guard.mjs';
+
+const guard = '.github/scripts/mutant-memory-guard.mjs';
+
+// A child that allocates far past any ceiling the tests set, retaining every
+// buffer so the growth is LIVE — the shape of the mutant this guard exists for
+// (`i += size` -> `i = size` pins a scanner index and appends per iteration).
+const runawayChild = `
+const held = [];
+for (;;) held.push(Buffer.alloc(8 * 1024 * 1024, 1));
+`;
+
+function workspace(t) {
+  const root = mkdtempSync(join(tmpdir(), 'mutant-memory-guard-'));
+  t.after(() => rmSync(root, { recursive: true, force: true }));
+  return root;
+}
+
+function child(root, source) {
+  const path = join(root, 'child.cjs');
+  writeFileSync(path, source);
+  return path;
+}
+
+function guardEnv(root, overrides = {}) {
+  return {
+    ...process.env,
+    MUTANT_MEMORY_MAX: '256MiB',
+    MUTANT_MEMORY_HOLD: '2s',
+    MUTANT_MEMORY_LEDGER: join(root, 'ledger.jsonl'),
+    ...overrides,
+  };
+}
+
+function ledgerLines(root) {
+  const path = join(root, 'ledger.jsonl');
+  if (!existsSync(path)) return [];
+  return readFileSync(path, 'utf8')
+    .split('\n')
+    .filter((line) => line.trim() !== '')
+    .map(JSON.parse);
+}
+
+test('byteSize demands an explicit unit and a positive value', () => {
+  assert.equal(byteSize('X', '1GiB'), 1024 ** 3);
+  assert.equal(byteSize('X', '256MiB'), 256 * 1024 ** 2);
+  assert.equal(byteSize('X', '1GB'), 1000 ** 3);
+  assert.throws(() => byteSize('X', '1024'), /not a byte size/);
+  assert.throws(() => byteSize('X', '1gib'), /not a byte size/);
+  assert.throws(() => byteSize('X', '0GiB'), /must be positive/);
+});
+
+test('goDurationSeconds parses the bound the runner writes', () => {
+  assert.equal(goDurationSeconds('X', '150s'), 150);
+  assert.equal(goDurationSeconds('X', '2m30s'), 150);
+  assert.throws(() => goDurationSeconds('X', '150'), /not a Go duration/);
+  assert.throws(() => goDurationSeconds('X', '0s'), /must be a positive duration/);
+});
+
+// A pid that has already exited is a RACE with the exit handler, not a failure.
+// Reporting it as 0 rather than throwing is what keeps the sampler from turning
+// a finished mutant into a breach.
+test('residentBytes reads VmRSS and reports a vanished pid as zero', () => {
+  assert.equal(
+    residentBytes(1, () => 'Name:\tx\nVmRSS:\t   4096 kB\nThreads:\t1\n'),
+    4096 * 1024,
+  );
+  assert.equal(
+    residentBytes(1, () => {
+      throw new Error('ENOENT');
+    }),
+    0,
+  );
+  assert.equal(residentBytes(1, () => 'Name:\tx\n'), 0);
+  assert.ok(residentBytes(process.pid) > 0, 'the guard cannot read its own RSS from /proc');
+});
+
+// The passthrough contract. A mutant that stays inside the ceiling must reach
+// gremlins with the verdict it earned — the guard is in the path for EVERY
+// mutant on every leg, so a wrapper that perturbed an ordinary exit code would
+// silently rewrite every leg's efficacy.
+for (const code of [0, 1, 2, 3]) {
+  test(`an unbreached child's exit ${code} is forwarded verbatim`, (t) => {
+    const root = workspace(t);
+    const result = spawnSync(
+      process.execPath,
+      [guard, process.execPath, child(root, `process.stdout.write('hello\\n'); process.exit(${code});`)],
+      { cwd: process.cwd(), encoding: 'utf8', env: guardEnv(root) },
+    );
+    assert.equal(result.status, code, result.stderr);
+    assert.match(result.stdout, /hello/, 'the child was not given the guard’s stdio');
+    assert.deepEqual(ledgerLines(root), [], 'an unbreached mutant was recorded as a breach');
+  });
+}
+
+test('the child receives the arguments go test handed the wrapper', (t) => {
+  const root = workspace(t);
+  const result = spawnSync(
+    process.execPath,
+    [guard, process.execPath, child(root, 'console.log(JSON.stringify(process.argv.slice(2)));'), '-test.v=true', '-test.count=1'],
+    { cwd: process.cwd(), encoding: 'utf8', env: guardEnv(root) },
+  );
+  assert.equal(result.status, 0, result.stderr);
+  assert.deepEqual(JSON.parse(result.stdout.trim()), ['-test.v=true', '-test.count=1']);
+});
+
+// THE load-bearing test. A breach must produce, in this order: the child dead,
+// the breach on the ledger, and the guard STILL RUNNING — because holding is
+// what routes the verdict to gremlins' deadline (TIMED OUT, unadjudicated)
+// instead of to an exit code. `go test` collapses every test-binary failure to
+// its own exit 1, so any non-zero exit here would be recorded as a KILL: the
+// suite credited for a mutant it never adjudicated.
+test('a runaway child is killed, recorded, and then HELD rather than exited', async (t) => {
+  const root = workspace(t);
+  const proc = spawn(process.execPath, [guard, process.execPath, child(root, runawayChild)], {
+    cwd: process.cwd(),
+    stdio: 'ignore',
+    env: guardEnv(root, { MUTANT_MEMORY_HOLD: '3600s' }),
+  });
+  t.after(() => proc.kill('SIGKILL'));
+
+  const exited = new Promise((resolve) => proc.on('exit', (code, signal) => resolve({ code, signal })));
+  const deadline = Date.now() + 60_000;
+  while (ledgerLines(root).length === 0 && Date.now() < deadline) {
+    await new Promise((resolve) => setTimeout(resolve, 50));
+  }
+
+  const [breach] = ledgerLines(root);
+  assert.ok(breach !== undefined, 'the runaway child was never recorded as a breach');
+  assert.equal(breach.limit_bytes, 256 * 1024 ** 2);
+  assert.ok(
+    breach.resident_bytes > breach.limit_bytes,
+    `a breach must record the RSS that crossed the line, got ${breach.resident_bytes}`,
+  );
+  // The sampling interval bounds the overshoot; a guard that only noticed the
+  // runaway after it had taken the machine would pass the line above and still
+  // be useless.
+  assert.ok(
+    breach.resident_bytes < 2 * breach.limit_bytes,
+    `overshoot past the ceiling must stay small, got ${breach.resident_bytes} over ${breach.limit_bytes}`,
+  );
+
+  const raced = await Promise.race([
+    exited,
+    new Promise((resolve) => setTimeout(() => resolve('still-holding'), 1500)),
+  ]);
+  assert.equal(raced, 'still-holding', `the guard exited after a breach instead of holding: ${JSON.stringify(raced)}`);
+});
+
+// The hold is bounded, and its expiry is the ONE remaining exit — 0, which
+// gremlins records as LIVED. A survivor is not a kill: it stays in the
+// denominator and credits nobody, so the fallback can only ever lower a leg's
+// efficacy. Preferring TIMED OUT and falling back to LIVED is the whole
+// ordering; KILLED is not in it.
+test('the hold expires into exit 0, never a non-zero exit', async (t) => {
+  const root = workspace(t);
+  const proc = spawn(process.execPath, [guard, process.execPath, child(root, runawayChild)], {
+    cwd: process.cwd(),
+    stdio: 'ignore',
+    env: guardEnv(root, { MUTANT_MEMORY_HOLD: '2s' }),
+  });
+  t.after(() => proc.kill('SIGKILL'));
+  const { code } = await new Promise((resolve) =>
+    proc.on('exit', (code, signal) => resolve({ code, signal })),
+  );
+  assert.equal(code, 0, 'a breached mutant must never leave this guard with a non-zero status');
+  assert.equal(ledgerLines(root).length, 1);
+});
+
+for (const [name, env] of [
+  ['MUTANT_MEMORY_MAX', { MUTANT_MEMORY_MAX: '' }],
+  ['MUTANT_MEMORY_HOLD', { MUTANT_MEMORY_HOLD: '' }],
+  ['MUTANT_MEMORY_LEDGER', { MUTANT_MEMORY_LEDGER: '' }],
+]) {
+  test(`a missing ${name} fails closed rather than running unguarded`, (t) => {
+    const root = workspace(t);
+    const result = spawnSync(
+      process.execPath,
+      [guard, process.execPath, child(root, 'process.exit(0);')],
+      { cwd: process.cwd(), encoding: 'utf8', env: guardEnv(root, env) },
+    );
+    assert.equal(result.status, 1);
+    assert.match(result.stdout, new RegExp(`::error::${name} is required`));
+  });
+}
+
+test('a malformed ceiling fails closed rather than defaulting', (t) => {
+  const root = workspace(t);
+  const result = spawnSync(
+    process.execPath,
+    [guard, process.execPath, child(root, 'process.exit(0);')],
+    { cwd: process.cwd(), encoding: 'utf8', env: guardEnv(root, { MUTANT_MEMORY_MAX: 'lots' }) },
+  );
+  assert.equal(result.status, 1);
+  assert.match(result.stdout, /::error::MUTANT_MEMORY_MAX is not a byte size/);
+});

--- a/.github/scripts/mutation-run.mjs
+++ b/.github/scripts/mutation-run.mjs
@@ -16,8 +16,9 @@
 import { spawnSync } from 'node:child_process';
 import { existsSync, readdirSync, readFileSync, statSync, unlinkSync, writeFileSync } from 'node:fs';
 import { availableParallelism } from 'node:os';
-import { join, resolve } from 'node:path';
+import { dirname, join, resolve } from 'node:path';
 import process from 'node:process';
+import { fileURLToPath } from 'node:url';
 
 import { error, notice } from './lib/gh.mjs';
 
@@ -52,6 +53,39 @@ const gremlinsCoverageBaselineFloorSeconds = 1;
 // is what #2903 fixed in gremlins-threshold.mjs — and still costs them, now in
 // the honest direction.
 const perMutantRunnerVarianceHeadroom = 2;
+
+// perMutantResidentMemoryMax is the ceiling on ONE mutant's test binary,
+// enforced by .github/scripts/mutant-memory-guard.mjs (which see for the
+// mechanism and for why the breach is recorded as TIMED OUT rather than as a
+// kill).
+//
+// The wall-clock budget above bounds TIME and nothing else, and the two bounds
+// cannot be collapsed into one: `internal/logql/logpattern`'s
+// REMOVE_SELF_ASSIGNMENTS mutant at pattern.go:129 allocates at ~1.5 GiB/s
+// (measured: 5 GiB of RSS in 3.3s), so it exhausts a 16 GB runner in about ten
+// seconds — under MUTANT_TIMEOUT_MIN, and far under the ~63s its own compile
+// cycle makes the derivation ask for. Lowering the leash until it is memory-safe
+// would starve every honest mutant on the leg, which is the failure #2903 fixed
+// (#2919).
+//
+// The value is measured, not guessed. Peak RSS of an UNMUTATED test binary,
+// per mutation-phases.mjs scope, on an 8-core machine:
+//
+//   internal/promql 112MiB   internal/chsql 44MiB   internal/engine 43MiB
+//   internal/logql   35MiB   internal/qlcommon 30MiB   internal/traceql 28MiB
+//   internal/optimizer 23MiB   internal/chplan 22MiB   internal/logql/lsyntax 10MiB
+//
+// 1 GiB is ~9x the heaviest of those, so no honest mutant can approach it, and
+// it is small enough that even gremlins' default fan-out (runtime.NumCPU()
+// concurrent mutants) cannot add up to the runner's ceiling.
+const perMutantResidentMemoryMax = '1GiB';
+
+// perMutantMemoryHoldGraceSeconds is how long the guard holds PAST the mutant's
+// own deadline before giving up and exiting. gremlins kills the whole `go test`
+// process group when its deadline fires, so the guard is normally reaped well
+// inside this; the grace exists only so a breach on a path with no deadline
+// behind it (gremlins' unmutated coverage run) cannot wedge the job.
+const perMutantMemoryHoldGraceSeconds = 30;
 
 const goDurationUnitSeconds = { ns: 1e-9, us: 1e-6, ms: 1e-3, s: 1, m: 60, h: 3600 };
 
@@ -201,7 +235,58 @@ function reportTotal(path) {
   return document.mutants_total;
 }
 
-function runGremlins({ report, budgetSeconds, diffRef = '' }) {
+// memoryGuardedEnv returns the environment gremlins runs under: this process's
+// own, plus the `go test -exec` hook that puts mutant-memory-guard.mjs in front
+// of every test binary gremlins launches, plus the two bounds the guard reads.
+//
+// -exec is reached through GOFLAGS because gremlins builds the `go test` argv
+// itself and takes no pass-through for extra flags. GOFLAGS is SPACE-separated
+// with no quoting, so the guard's path may not contain whitespace, and an
+// existing GOFLAGS is appended to rather than replaced.
+//
+// The guard reads the child's RSS from /proc, so a platform without it cannot
+// enforce the bound. That is a hard failure rather than a silent unguarded run:
+// an unenforced memory ceiling is exactly the state #2919 describes, and it is
+// worse than no ceiling because it looks like one.
+function memoryGuardedEnv(budgetSeconds, ledger) {
+  const guard = resolve(dirname(fileURLToPath(import.meta.url)), 'mutant-memory-guard.mjs');
+  if (/\s/.test(guard)) {
+    throw new Error(`the memory guard's path contains whitespace, which GOFLAGS cannot express: ${guard}`);
+  }
+  if (!existsSync('/proc/self/status')) {
+    throw new Error('no /proc: mutant-memory-guard.mjs cannot bound a mutant\'s memory on this platform');
+  }
+  const goFlags = String(process.env.GOFLAGS ?? '').trim();
+  return {
+    ...process.env,
+    GOFLAGS: `${goFlags === '' ? '' : `${goFlags} `}-exec=${guard}`,
+    MUTANT_MEMORY_MAX: perMutantResidentMemoryMax,
+    MUTANT_MEMORY_HOLD: `${budgetSeconds + perMutantMemoryHoldGraceSeconds}s`,
+    MUTANT_MEMORY_LEDGER: ledger,
+  };
+}
+
+// reportMemoryBreaches turns the guard's ledger into the one log line a reader
+// needs: how many mutants hit the ceiling, and how far past it they got before
+// they were stopped. Reported as a ::notice::, not an error — a breach is the
+// bound WORKING, and the mutant it stopped is already counted against the leg's
+// efficacy as TIMED OUT.
+function reportMemoryBreaches(ledger) {
+  if (!existsSync(ledger)) return;
+  const breaches = readFileSync(ledger, 'utf8')
+    .split('\n')
+    .filter((line) => line.trim() !== '')
+    .map((line) => JSON.parse(line));
+  if (breaches.length === 0) return;
+  const worst = Math.max(...breaches.map((b) => b.resident_bytes));
+  notice(
+    `${breaches.length} mutant(s) hit the ${perMutantResidentMemoryMax} per-mutant memory ceiling and ` +
+      `were stopped there (worst observed ${(worst / 1024 ** 2).toFixed(0)}MiB); each is recorded as ` +
+      'TIMED OUT — unadjudicated, counted in the denominator, credited to nobody',
+  );
+}
+
+function runGremlins({ report, budgetSeconds, ledger, diffRef = '' }) {
   const args = [
     'unleash',
     '--output',
@@ -222,7 +307,10 @@ function runGremlins({ report, budgetSeconds, diffRef = '' }) {
   if (diffRef !== '') args.push('--diff', diffRef);
   args.push(required('SCOPE'));
 
-  const result = spawnSync('gremlins', args, { stdio: 'inherit' });
+  const result = spawnSync('gremlins', args, {
+    stdio: 'inherit',
+    env: memoryGuardedEnv(budgetSeconds, ledger),
+  });
   if (result.error) throw new Error(`cannot execute gremlins: ${result.error.message}`);
   if (result.status !== 0) throw new Error(`gremlins exited ${result.status}`);
   if (!existsSync(report)) throw new Error(`gremlins produced no report at ${report}`);
@@ -242,13 +330,18 @@ function main() {
   // a second compile — and would take it against a cache the first invocation
   // warmed, which is the exact mismeasurement #2692 was.
   const budgetSeconds = perMutantBudgetSeconds(scope);
+  // One ledger for both invocations: a breach is a property of the leg, not of
+  // which of the two gremlins runs happened to draw the mutant.
+  const ledger = resolve(`${report}.memory-breaches.jsonl`);
+  if (existsSync(ledger)) unlinkSync(ledger);
 
-  runGremlins({ report, budgetSeconds, diffRef });
+  runGremlins({ report, budgetSeconds, ledger, diffRef });
   if (diffRef !== '' && reportTotal(report) === 0) {
     notice('changed-line mutation found zero executable mutants; rerunning the full phase');
     unlinkSync(report);
-    runGremlins({ report, budgetSeconds });
+    runGremlins({ report, budgetSeconds, ledger });
   }
+  reportMemoryBreaches(ledger);
   const total = reportTotal(report);
   if (total <= 0) throw new Error('mutation phase executed zero mutants after full fallback');
   notice(`mutation phase executed ${total} mutant(s)${diffRef === '' ? ' in full' : ''}`);

--- a/.github/scripts/mutation-run.test.mjs
+++ b/.github/scripts/mutation-run.test.mjs
@@ -1,5 +1,5 @@
 import assert from 'node:assert/strict';
-import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { test } from 'node:test';
@@ -20,6 +20,7 @@ function fixture(t, totals, { probeSeconds = 0, goExits = 0, goMissing = false }
   const root = mkdtempSync(join(tmpdir(), 'mutation-run-'));
   t.after(() => rmSync(root, { recursive: true, force: true }));
   const calls = join(root, 'calls.jsonl');
+  const envCalls = join(root, 'env-calls.jsonl');
   const goCalls = join(root, 'go-calls.jsonl');
   const bin = join(root, 'bin');
   const scope = join(root, 'scope');
@@ -31,6 +32,7 @@ function fixture(t, totals, { probeSeconds = 0, goExits = 0, goMissing = false }
   writeFileSync(join(scope, 'b_large.go'), `package scope\n\n// ${'x'.repeat(200)}\n`);
   writeFileSync(join(scope, 'z_test.go'), `package scope\n\n// ${'y'.repeat(4000)}\n`);
   writeFileSync(calls, '');
+  writeFileSync(envCalls, '');
   writeFileSync(goCalls, '');
   writeFileSync(
     join(bin, 'gremlins'),
@@ -38,6 +40,15 @@ function fixture(t, totals, { probeSeconds = 0, goExits = 0, goMissing = false }
 const fs = require('node:fs');
 const args = process.argv.slice(2);
 fs.appendFileSync(${JSON.stringify(calls)}, JSON.stringify(args) + '\\n');
+// The env gremlins actually receives is half the contract: the memory guard is
+// wired ONLY through it, so an argv-only assertion would pass over a leg whose
+// mutants run unbounded.
+fs.appendFileSync(${JSON.stringify(envCalls)}, JSON.stringify({
+  GOFLAGS: process.env.GOFLAGS,
+  MUTANT_MEMORY_MAX: process.env.MUTANT_MEMORY_MAX,
+  MUTANT_MEMORY_HOLD: process.env.MUTANT_MEMORY_HOLD,
+  MUTANT_MEMORY_LEDGER: process.env.MUTANT_MEMORY_LEDGER,
+}) + '\\n');
 const report = args[args.indexOf('--output') + 1];
 const totals = ${JSON.stringify(totals)};
 const call = fs.readFileSync(${JSON.stringify(calls)}, 'utf8').trim().split('\\n').length - 1;
@@ -64,7 +75,7 @@ process.exit(${goExits});
       { mode: 0o755 },
     );
   }
-  return { root, bin, scope, calls, goCalls };
+  return { root, bin, scope, calls, envCalls, goCalls };
 }
 
 function run(f, env = {}) {
@@ -92,6 +103,11 @@ function invocations(f) {
 
 function budgetOf(args) {
   return args[args.indexOf('--timeout-max') + 1];
+}
+
+function environments(f) {
+  const raw = readFileSync(f.envCalls, 'utf8').trim();
+  return raw === '' ? [] : raw.split('\n').map(JSON.parse);
 }
 
 test('changed-line execution stays incremental when it executes mutants', (t) => {
@@ -256,4 +272,84 @@ test('invalid diff refs and stale reports fail before gremlins runs', (t) => {
   result = run(f, { DIFF_REF: '' });
   assert.equal(result.status, 1);
   assert.match(`${result.stdout}\n${result.stderr}`, /refusing stale gremlins report/);
+});
+
+// The memory bound reaches gremlins ONLY through the environment, and only as a
+// `go test -exec` hook. A leg that ran without it would look exactly like a leg
+// that ran with it — same argv, same report — right up to the run where a
+// runaway mutant takes the runner down with no verdict at all (#2919). So the
+// env contract is pinned as tightly as the argv one.
+test('every gremlins invocation runs its mutants under the memory guard', (t) => {
+  const f = fixture(t, [0, 7]);
+  assert.equal(run(f, { DIFF_REF: 'a'.repeat(40) }).status, 0);
+  const envs = environments(f);
+  assert.equal(envs.length, 2, 'the fallback invocation must be guarded too');
+  for (const env of envs) {
+    assert.match(
+      env.GOFLAGS,
+      /(^| )-exec=\/.*\/\.github\/scripts\/mutant-memory-guard\.mjs$/,
+      `GOFLAGS must put the guard in front of every test binary, got ${env.GOFLAGS}`,
+    );
+    assert.equal(env.MUTANT_MEMORY_MAX, '1GiB');
+    assert.ok(
+      env.MUTANT_MEMORY_LEDGER.endsWith('gremlins.json.memory-breaches.jsonl'),
+      `the ledger must sit beside the report, got ${env.MUTANT_MEMORY_LEDGER}`,
+    );
+  }
+  assert.equal(envs[0].MUTANT_MEMORY_LEDGER, envs[1].MUTANT_MEMORY_LEDGER, 'a leg keeps one ledger');
+});
+
+// The hold has to outlast the deadline it defers to. If it expired FIRST the
+// guard would exit 0 while gremlins was still waiting, and a memory-runaway
+// mutant would be booked LIVED-by-accident instead of TIMED OUT-on-purpose.
+test('the guard holds strictly longer than the per-mutant budget', (t) => {
+  const f = fixture(t, [4], { probeSeconds: 0 });
+  assert.equal(run(f, { DIFF_REF: '' }).status, 0);
+  const budget = Number(budgetOf(invocations(f)[0]).replace('s', ''));
+  const hold = Number(environments(f)[0].MUTANT_MEMORY_HOLD.replace('s', ''));
+  assert.ok(hold > budget, `the hold (${hold}s) must outlast the budget (${budget}s)`);
+});
+
+// An existing GOFLAGS belongs to the toolchain setup, not to us. Replacing it
+// would silently drop whatever the composite setup-go action put there.
+test('an existing GOFLAGS is appended to, not replaced', (t) => {
+  const f = fixture(t, [4]);
+  assert.equal(run(f, { DIFF_REF: '', GOFLAGS: '-mod=mod' }).status, 0);
+  assert.match(environments(f)[0].GOFLAGS, /^-mod=mod -exec=\//);
+});
+
+// A breach is the bound WORKING, so it is reported rather than fatal — but it
+// must be reported, because `go test` discards a passing binary's output and
+// the guard's own annotation dies with it.
+test('memory breaches recorded by the guard are surfaced by the runner', (t) => {
+  const f = fixture(t, [4]);
+  const ledger = join(f.root, 'gremlins.json.memory-breaches.jsonl');
+  writeFileSync(
+    join(f.bin, 'gremlins'),
+    `#!${process.execPath}
+const fs = require('node:fs');
+const args = process.argv.slice(2);
+fs.appendFileSync(${JSON.stringify(f.calls)}, JSON.stringify(args) + '\\n');
+fs.appendFileSync(process.env.MUTANT_MEMORY_LEDGER,
+  JSON.stringify({ binary: '/tmp/x.test', resident_bytes: 1181116006, limit_bytes: 1073741824 }) + '\\n');
+fs.writeFileSync(args[args.indexOf('--output') + 1], JSON.stringify({ mutants_total: 4 }));
+`,
+    { mode: 0o755 },
+  );
+  const result = run(f, { DIFF_REF: '' });
+  assert.equal(result.status, 0, result.stderr);
+  assert.match(result.stdout, /::notice::1 mutant\(s\) hit the 1GiB per-mutant memory ceiling/);
+  assert.match(result.stdout, /recorded as TIMED OUT/);
+  assert.ok(existsSync(ledger), 'the ledger the runner read must be the one the guard wrote');
+});
+
+// A stale ledger from a previous leg in the same workspace would report
+// breaches this run never had.
+test('a stale breach ledger is discarded before the run', (t) => {
+  const f = fixture(t, [4]);
+  const ledger = join(f.root, 'gremlins.json.memory-breaches.jsonl');
+  writeFileSync(ledger, JSON.stringify({ binary: '/stale', resident_bytes: 1, limit_bytes: 1 }) + '\n');
+  const result = run(f, { DIFF_REF: '' });
+  assert.equal(result.status, 0, result.stderr);
+  assert.doesNotMatch(result.stdout, /hit the 1GiB per-mutant memory ceiling/);
 });

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -953,6 +953,20 @@ jobs:
       - name: Assert the mutation runner's env contract and fallback
         run: node --test .github/scripts/mutation-run.test.mjs
 
+      # The third half of the same lane: the per-mutant MEMORY bound. The leash
+      # gremlins enforces bounds time and nothing else, and a mutant that
+      # allocates without terminating exhausts the runner in about ten seconds
+      # — under the lane's own budget floor (#2919). The guard is what stops
+      # that, and its failure mode is the quiet one: a wrapper that let a
+      # breached mutant EXIT would have `go test` collapse the kill into its own
+      # exit 1, and gremlins would book a mutant nobody adjudicated as a KILL.
+      # These tests pin that it holds instead, and that an unbreached mutant's
+      # exit code reaches gremlins byte-for-byte — the guard sits in front of
+      # every test binary on every leg, so a perturbed exit code would rewrite
+      # every leg's efficacy at once.
+      - name: Assert the per-mutant memory guard records rather than kills
+        run: node --test .github/scripts/mutant-memory-guard.test.mjs
+
       # Whether a job that pulls an image logged in first. An anonymous pull is
       # not an error: it succeeds until the shared per-runner-IP quota happens to
       # be spent, and then reads as flake — which is how #1572 fixed the class by

--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -233,15 +233,36 @@ jobs:
       # takes, under internal/promql's real per-mutant recompile+link+run, and
       # the leg reported 0.00% efficacy (#2692).
       #
-      # A bound is needed at all because a mutant that inverts a scanner's
-      # loop-advance (i++ -> i--) never terminates and allocates per iteration,
-      # so an unbounded leash lets it exhaust the runner's memory. The OOM
-      # killer then reaps the runner agent and the job dies with no verdict at
-      # all, which reads as flake rather than as a missing bound.
+      # The budget bounds TIME. It does not, and cannot, bound ALLOCATION, and
+      # the lane needs both. A mutant that inverts or removes a scanner's
+      # loop-advance never terminates and allocates per iteration:
+      # internal/logql/logpattern's `i += size` -> `i = size` mutant reaches
+      # 5 GiB of RSS in 3.3s, so it exhausts a 16 GB runner in about ten seconds
+      # — UNDER the 15s floor above, and far under the ~63s that leg's own
+      # compile cycle makes the derivation ask for. There is no leash value that
+      # is both long enough for the compile and short enough for the memory; the
+      # window is empty, not narrow, so capping MUTANT_TIMEOUT_MAX cannot be the
+      # fix (#2919). GOMEMLIMIT cannot either — it is soft, and Go's GC CPU
+      # limiter guarantees the mutator half the CPU, so a live heap still grows
+      # (measured: 2.6x slower, not bounded).
+      #
+      # mutation-run.mjs therefore wires .github/scripts/mutant-memory-guard.mjs
+      # in front of every test binary gremlins launches, as a `go test -exec`
+      # supervisor, and gives it a per-mutant RSS ceiling. A mutant that breaches
+      # it is killed and then HELD, so gremlins' own deadline records it as
+      # TIMED OUT — unadjudicated, counted in the denominator, credited to
+      # nobody. It is deliberately not allowed to reach gremlins as an exit
+      # code: `go test` collapses every test-binary failure into its own exit 1,
+      # which gremlins reads as a KILL, and paying a leg efficacy for a mutant
+      # nobody adjudicated is the accounting #2903 removed.
+      #
+      # The clean fix is upstream of all of this: #2910 splits gremlins' single
+      # deadline into an overall one and a run-only one, and a run-only leash is
+      # tight enough to bound allocation without starving an honest mutant.
       #
       # Do NOT "fix" a recurrence by excluding whichever file the log names:
       # that relocates the file's runaway mutants into whichever leg still owns
-      # it, and burns real mutation coverage. The budget is the fix.
+      # it, and burns real mutation coverage. The two bounds are the fix.
       # mutation-run.mjs owns the changed-line/full decision and validates that
       # the final report executed at least one mutant. Keeping the zero-mutant
       # fallback out of shell prevents a missing or malformed JSON field from


### PR DESCRIPTION
## The gap

`#2911` replaced the mutation lane's flat 15s per-mutant leash with one measured
from the leg's own recompile+link+run cycle. That was right, and this change
does not touch it. What it exposed is that the lane has **one** bound where it
needs **two**: gremlins leashes each mutant with a single context deadline
wrapping the whole `go test` child, and a deadline bounds TIME, not ALLOCATION.

`phase4-logql-other-b` then died with no verdict at all — the runner reaped,
every remaining mutant `NOT COVERED`, no efficacy line, which the aggregator
cannot tell apart from a flake.

## Why capping the leash cannot work — measured, not argued

The obvious fix is to cap the derived leash at a memory-safe value. It is
arithmetically impossible on this leg.

`internal/logql/logpattern`'s `REMOVE_SELF_ASSIGNMENTS` mutant at
`pattern.go:129` (`i += size` -> `i = size`) pins the scanner index and appends
a rune per iteration for ever. Measured directly on the mutated test binary:

| bound | 1 GiB RSS | 5 GiB RSS |
| --- | ---: | ---: |
| unbounded | 0.8s | 3.3s |
| `GOMEMLIMIT=512MiB` | 1.9s | 8.5s |
| `GOMEMLIMIT=1GiB` | 1.3s | 6.8s |

~1.5 GiB/s unbounded. A 16 GB runner is gone in about ten seconds — **below**
`MUTANT_TIMEOUT_MIN` (15s), and far below the ~63s the leg's own compile cycle
makes the derivation ask for. The window in which a leash is both long enough
for the compile and short enough for the memory is EMPTY, not merely narrow.

`GOMEMLIMIT` does not open it either. It is a soft limit and Go's GC CPU limiter
guarantees the mutator at least half the CPU, so a mutant whose heap is LIVE
keeps growing: 2.6x slower, not bounded.

So the bound has to be memory itself, applied to the process that allocates.

## The kernel's own account of the two regimes

The same mutant, the same binary, reproduced twice — once unbounded, once inside
a memory cgroup. `journalctl -k`:

```
05:01:05 oom-kill:constraint=CONSTRAINT_NONE,...,global_oom,task=logpattern.test
         Killed process 1518318 (logpattern.test) anon-rss:26398156kB

07:31:08 oom-kill:constraint=CONSTRAINT_MEMCG,...,oom_memcg=/user.slice/...
         Killed process 1671583 (logpattern.test) anon-rss:6253116kB
```

25 GiB and a **global** OOM in the first case: the kernel picks victims
machine-wide, and the processes it takes are unrelated to the mutant. That is
precisely what happens on a runner — the victim is the runner agent, and the job
dies with no verdict. In the second the kill is `CONSTRAINT_MEMCG`, confined to
the cgroup, and nothing outside it is touched.

A per-mutant bound is what turns the first regime into the second. This guard
goes one better than a cgroup would: it caps at 1 GiB before the kernel ever has
to choose a victim, so there is no OOM kill at all and no guessing which process
the runaway was.

## What this adds

`.github/scripts/mutant-memory-guard.mjs`, a `go test -exec` supervisor wired in
through `GOFLAGS` by `mutation-run.mjs`, so it sits in front of every test binary
gremlins launches. It samples the child's RSS from `/proc` every 50ms; past
`MUTANT_MEMORY_MAX` it kills the child, records the breach on a ledger, and then
**holds**.

The hold is the whole design, and it is what keeps `#2911`'s door shut:

- gremlins reads a verdict from the `go test` exit code (1 -> KILLED, 2 -> NOT
  VIABLE, anything else -> LIVED) or from its own deadline (-> TIMED OUT).
- `go test` collapses every test-binary failure to its own exit 1 (measured — a
  failing test, a build error and a test timeout all exit 1), so **any** exit the
  guard forces after killing the child would be recorded as a KILL, crediting
  the suite for a mutant it never adjudicated. That is the accounting `#2903`
  removed.
- Exiting 0 would record LIVED, which gremlins' own `--on-shutdown-status` work
  rejected for unadjudicated mutants.
- Holding lets gremlins' existing deadline fire and record **TIMED OUT**, which
  `gremlins-threshold.mjs` already scores as unadjudicated: in the denominator,
  credited to nobody.

The hold costs no wall clock the lane was not already paying — these mutants
were already burning their whole budget before dying. What changes is the peak
RSS while they do it.

`MUTANT_MEMORY_MAX` is `1GiB`: ~9x the heaviest measured peak RSS of an
UNMUTATED test binary across every `mutation-phases.mjs` scope
(`internal/promql` 112MiB, `internal/chsql` 44MiB, `internal/logql` 35MiB,
`internal/qlcommon` 30MiB, `internal/traceql` 28MiB, `internal/optimizer` 23MiB,
`internal/chplan` 22MiB, `internal/logql/lsyntax` 10MiB), and small enough that
even gremlins' default `runtime.NumCPU()` fan-out cannot add up to the runner's
ceiling.

## Evidence: the same leg, before and after, in CI

`main` at `57383f969` (this branch's base) against this PR, `mutation` lane:

| leg | main @ 57383f969 | this PR |
| --- | --- | --- |
| `phase4-logql-other-b` | `unleash` step **cancelled**; threshold + report upload **skipped** | every step **success**, 96.54% vs a 95% bar |
| `phase4-logql-lsyntax` | failed at `enforce efficacy threshold` | failed at `enforce efficacy threshold` |
| `phase5-qlcommon` | failed at `enforce efficacy threshold` | failed at `enforce efficacy threshold` |
| `phase4-traceql-ast` | failed at `enforce efficacy threshold` | failed at `enforce efficacy threshold` |

The first row is the fix: on `main` the leg burns nine minutes and emits no
efficacy line at all, because the step that would write one never completes.
Here it completes and reports.

The other three rows are the control. They are the `#2917` shortfall legs, they
fail at the same step for the same reason on both sides, and their step-level
outcome is identical — a normal leg is unaffected.

The leg's own report:

```
KILLED 502   LIVED 18   TIMED OUT 6   NOT COVERED 30   test_efficacy 96.54%
```

526 adjudicated against the 525 of `#2911`'s own pre-regression run, and six
timeouts on a leg that used to end with none because it ended early. The five
mutants at the heart of `#2919`:

| mutant | main | this PR |
| --- | --- | --- |
| `123:7 INVERT_ASSIGNMENTS` | LIVED (the OOM killer took the `go test` driver, `ExitCode()` -1, gremlins' `default` branch) | TIMED OUT |
| `123:7 REMOVE_SELF_ASSIGNMENTS` | NOT COVERED (run dead) | TIMED OUT |
| `124:5 INVERT_LOOPCTRL` | NOT COVERED (run dead) | KILLED |
| `129:5 INVERT_ASSIGNMENTS` | NOT COVERED (run dead) | KILLED |
| `129:5 REMOVE_SELF_ASSIGNMENTS` | NOT COVERED (run dead) | **TIMED OUT** |

No verdict moves in a direction that credits the suite: LIVED and TIMED OUT are
arithmetically identical under `killed / (killed + lived + timedOut)`, so the
relabelling is score-neutral and the gain is the mutants the leg can now reach.
The guard's ledger shows the bound holding to a 1.5-3% overshoot:

```
resident_bytes 1090179072 / limit_bytes 1073741824
resident_bytes 1105272832 / limit_bytes 1073741824
resident_bytes 1085272064 / limit_bytes 1073741824
```

## The tests fail when the behaviour regresses

Each was run against a deliberately broken guard before being trusted:

| injected regression | outcome |
| --- | --- |
| a breach exits 1 instead of holding (the fake-kill door) | 2 failures: `...HELD rather than exited`, `the hold expires into exit 0` |
| the RSS sampler never trips (the bug itself) | the same 2 failures |
| an unbreached child's exit code is clamped | 2 failures: `exit 2 is forwarded verbatim`, `exit 3` |

The suite's own runaway fixture stops at 4x the ceiling under test, so a broken
guard fails an assertion instead of taking the runner down — the outage this
guard exists to prevent must not be the way its own tests report.

## On #2910 — the clean fix does require the fork

Stated plainly, because it is the answer to the question and not a hedge: **yes.**
This PR is a compensation and says so in its own comments.

gremlins exposes exactly one per-mutant bound, and everything else it learns
about a mutant arrives as the `go test` exit code. A second bound therefore has
to be enforced outside gremlins and its result smuggled back through one of
those two channels. The exit code cannot carry it (`go test` collapses
everything to 1), so the only channel left is the deadline — reachable only by
deliberately burning wall clock until gremlins' own timer fires. That is what
the hold is. It is correct, and it spends up to a full budget per runaway mutant
purely to select a label.

`#2910`'s split removes the need entirely: the run-only cost on these packages
is ~0.1-2.1s against a ~31s compile, so a run-only leash of a few seconds bounds
allocation to a few GiB-seconds without touching one honest mutant — no guard,
no hold, no ledger.

One measured correction for whoever picks `#2910` up. The trap is real but it is
not `NotViable`:

```
go test ./failing-test   -> exit 1
go test ./build-error    -> exit 1
go test ./test-timeout   -> exit 1      (the test BINARY exits 2; go test does not)
```

gremlins spawns `go`, not the test binary, so `getTestFailedStatus`'s `case 2:
NotViable` branch is unreachable through modern `go test`. Letting Go's own
`-timeout` fire first therefore lands a timeout in **KILLED**, not `NotViable` —
in the denominator, but credited as a detection, which is exactly the `#2903`
accounting again for any honest test that overruns. So `#2910` cannot simply
pass a tighter `-timeout` and let Go win the race: the fork has to keep catching
the run-only overrun with a timer of its own and map it to `TimedOut`. That is
fork-side by construction; cerberus cannot reach it.

No fork work is started here.

Closes #2919

🤖 Generated with [Claude Code](https://claude.com/claude-code)
