### PR TITLE
fix(chsql,chopt): pin the timeSeries*ToGrid NaN-duplicate survivor, and delete the claims it refutes

### DIFF
--- a/.github/ci-lanes.json
+++ b/.github/ci-lanes.json
@@ -414,7 +414,8 @@
         "traces-scan-bound-integration",
         "traces-scan-window-integration",
         "ts-grid-group-array-integration",
-        "ts-grid-last-over-time-integration"
+        "ts-grid-last-over-time-integration",
+        "ts-grid-nan-duplicate-integration"
       ],
       "command": "strict-scan and real-ClickHouse integration recipes",
       "build_tags": ["integration"],

--- a/.github/workflows/strict-scan.yml
+++ b/.github/workflows/strict-scan.yml
@@ -374,3 +374,17 @@ jobs:
       # internal/chsql/range_window_group_array_realch_integration_test.go.
       - name: Run ts_grid_group_array duplicate-timestamp + DateTime64 preconditions (real ClickHouse)
         run: just ts-grid-group-array-integration
+
+      # The timeSeries*ToGrid duplicate-timestamp survivor pins (#2798): for
+      # every member of the emitter's own nativeTSGridFn registry, which
+      # sample survives a NaN-bearing duplicate (series, timestamp) under each
+      # encounter order — including the split where the whole-window members
+      # keep a FIRST-visited NaN and the instant members (irate / idelta) keep
+      # a LAST-visited one; that the production dedupWindowPairsByTsFrag Frag
+      # elects the same survivor under both orders; and the divergence end to
+      # end through cerberus's own lowering + emitter. The family's own 25.9
+      # floor, so this boots its own container at CH_TEST_IMAGE rather than
+      # this job's higher CH_STRICT_SCAN_IMAGE pin. See internal/chsql/
+      # range_window_grid_native_nan_duplicate_realch_integration_test.go.
+      - name: Run timeSeries*ToGrid NaN-duplicate survivor pins (real ClickHouse)
+        run: just ts-grid-nan-duplicate-integration

--- a/Justfile
+++ b/Justfile
@@ -616,6 +616,21 @@ ts-grid-group-array-integration:
     @just _pull-retry {{CH_TEST_IMAGE}}
     go test -timeout 15m -tags=integration -count=1 -run '^(TestTimeSeriesGroupArray_|TestRate_NativeGroupArray_)' ./internal/chsql/...
 
+# Run the timeSeries*ToGrid duplicate-timestamp survivor pins (#2798): measures,
+# for every member of the emitter's own nativeTSGridFn registry, which sample
+# survives a NaN-bearing duplicate (series, timestamp) under each encounter
+# order; asserts the production dedupWindowPairsByTsFrag Frag elects the same
+# survivor under both; and reproduces the divergence end to end through
+# cerberus's own lowering + emitter over one MergeTree table holding two series
+# with the identical sample multiset. The family's own floor (25.9) is the
+# usual one, so this pins CH_TEST_IMAGE directly rather than reusing
+# CH_STRICT_SCAN_IMAGE's higher 26.6 pin. Requires Docker; gated behind the
+# `integration` build tag. See
+# internal/chsql/range_window_grid_native_nan_duplicate_realch_integration_test.go.
+ts-grid-nan-duplicate-integration:
+    @just _pull-retry {{CH_TEST_IMAGE}}
+    go test -timeout 15m -tags=integration -count=1 -run '^(TestTSGridFamily_NaNDuplicate|TestFanoutDedup_NaNDuplicate|TestRate_NativeGrid_NaNDuplicate)' ./internal/chsql/...
+
 # Run the FuzzParse target for one parser head for a bounded duration.
 # Usage: `just fuzz QL=promql DURATION=60s` (defaults).
 fuzz QL="promql" DURATION="60s":

--- a/internal/chopt/registry.go
+++ b/internal/chopt/registry.go
@@ -535,24 +535,41 @@ const (
 	//     trailing edge (anchor - staleness) is excluded, matching
 	//     FeatureTSGridRange's own left-open fix.
 	//   - The doc's duplicate-timestamp "highest value wins, NaN loses"
-	//     rule reproduces the SAME order-dependence for a real-vs-NaN
-	//     duplicate pair that cerberus issue #2798 already tracks as
-	//     family-wide (NaN loses when inserted before the real sample, wins
-	//     when inserted after). Unlike rate/delta, irate reduces every
-	//     window to its trailing pair, so a duplicate-timestamp trailing
-	//     pair is not a rare edge of a summed window but the whole answer —
-	//     but the fan-out has no dedup layer of its own for this shape
-	//     either (a duplicate-ts trailing pair there resolves by whatever
-	//     order arraySort's stable tie-break happens to produce, itself
-	//     unspecified), so this is not a regression against a well-defined
-	//     fan-out contract, just the same #2798 gap surfacing through a
-	//     different function.
+	//     rule is order-dependent for a real-vs-NaN duplicate pair, the
+	//     family-wide gap cerberus tracks at
+	//     https://github.com/tsouza/cerberus/issues/2798. Re-measured
+	//     against a real ClickHouse at this feature's own 25.9 floor
+	//     (internal/chsql's
+	//     TestTSGridFamily_NaNDuplicateSurvivorIsOrderDependent_RealCH),
+	//     irate INVERTS the whole-window members' direction: the finite
+	//     sample survives when the NaN reaches the fold first, the NaN
+	//     survives when it reaches the fold second. Unlike rate/delta,
+	//     irate reduces every window to its trailing pair, so a
+	//     duplicate-timestamp trailing pair is not a rare edge of a summed
+	//     window but the whole answer.
+	//   - The array-fold fan-out this feature displaces does NOT share that
+	//     exposure, and the asymmetry is real rather than a wash: the
+	//     pairs-shaped fan-out carries no dedup layer for a duplicate-ts
+	//     trailing pair, but arraySort orders Float64 totally with NaN
+	//     ranked greatest, so the pair it selects is a function of the
+	//     sample multiset alone. Switching irate to the native aggregate
+	//     therefore trades a deterministic answer for a scan-order-dependent
+	//     one on that shape. internal/chsql.dedupWindowPairsByTsFrag's doc
+	//     states the rule and names the tests that execute both sides.
 	//
-	// AutoSelect is true: the sweep found no irate-specific divergence from
-	// PromQL — the one real gap it surfaced is the same pre-existing,
-	// family-wide ClickHouse tie-break bug already accepted for the
-	// auto-selected rate/increase/resets/deriv/predict_linear/delta
-	// siblings, not a reason to treat irate differently from them.
+	// AutoSelect is true, and the reason is exposure rather than harmlessness.
+	// The shape needed to reach the divergence is doubly degenerate — two
+	// samples at one series' exact timestamp, one of them NaN — and it is
+	// the FAMILY's shape, shared verbatim by the already-auto-selected
+	// rate/increase/resets/deriv/predict_linear/delta siblings; nothing about
+	// irate makes it likelier or worse there. The two family members that DO
+	// carry AutoSelect: false carry it for divergences ordinary data reaches:
+	// FeatureTSGridChanges diverges on any NaN-adjacent window with no
+	// duplicate involved at all (#1721), and FeatureTSGridGroupArray is a
+	// pure SQL-shape swap whose only effect would be to import this same
+	// nondeterminism into paths that today do not have it (#2749). Treating
+	// irate differently from its siblings would single out the member whose
+	// evidence is strongest, not the risk.
 	FeatureTSGridIrate = "ts_grid_irate"
 
 	// FeatureTSGridIdelta is FeatureTSGridIrate's sibling for

--- a/internal/chsql/range_window.go
+++ b/internal/chsql/range_window.go
@@ -2320,12 +2320,62 @@ func matrixWindowPairsAlreadyDeduped(r *chplan.RangeWindow) bool {
 
 // dedupWindowPairsByTsFrag collapses a `arraySort`-ordered
 // `Array(Tuple(ts, value))` down to one tuple per distinct timestamp,
-// keeping the LAST tuple of each equal-ts run. Because the input is
-// sorted ascending by (ts, value), that last-of-run tuple is the
-// max-valued sample at the timestamp — byte-for-byte the choice the
-// ClickHouse-native `timeSeries*ToGrid` aggregates make (verified
-// insertion-order-independent against `timeSeriesRateToGrid`), and the
-// single-sample-per-timestamp invariant Prometheus assumes.
+// keeping the LAST tuple of each equal-ts run. It implements cerberus's
+// single duplicate-timestamp rule, and this comment is where that rule is
+// stated in full.
+//
+// # The rule
+//
+// One sample per distinct (series, timestamp), tie-broken to the max value.
+// That is the rule PR #1092 gave the rate family, and the rule cerberus
+// issue #2914 / PR #2920 pinned for the *_over_time family's identical-value
+// duplicate (see internal/promql's duplicate_timestamp_seed_chdb_test.go,
+// which is the authority on which shapes each family's lowerings collapse —
+// this comment states the rule, not its reach).
+//
+// "Max" is ClickHouse's TOTAL order over Float64 — the one arraySort imposes,
+// in which NaN ranks GREATEST. That clause is load-bearing rather than
+// pedantic: IEEE754 leaves `max` undefined the moment a NaN is involved
+// (every comparison against a NaN is false in both directions), so a rule
+// naming only "the max value" would say nothing about the one case where the
+// answer is actually in doubt — which is exactly the case this Frag and the
+// native family answer differently.
+//
+// The rule has two halves, and separating them is what makes it checkable:
+//
+//   - CARDINALITY — exactly one sample survives each distinct timestamp.
+//   - REPRESENTATIVE — the survivor is the greatest-ranked sample under that
+//     total order, and is therefore a function of the sample multiset alone,
+//     never of the order the rows arrived in.
+//
+// This Frag delivers both, measured rather than assumed: the input is sorted
+// ascending by (ts, value), so the last-of-run tuple is the greatest-ranked
+// sample at the timestamp, and arraySort's ordering does not depend on
+// insertion order. This is executed against a real ClickHouse over both
+// encounter orders of a NaN-bearing duplicate, asserting an identical
+// survivor, by
+// TestFanoutDedup_NaNDuplicateSurvivorIsOrderIndependent_RealCH.
+//
+// # Where the rule cannot be kept
+//
+// The ClickHouse-native `timeSeries*ToGrid` family keeps the cardinality half
+// and cannot keep the representative half. Its own documented rule is the
+// opposite one ("a NaN value loses to any other value"), and it delivers
+// NEITHER rule deterministically: the collapse is a running "replace the
+// current best only when the candidate compares greater" fold, so on a
+// NaN-bearing duplicate the survivor is whichever row the (multi-threaded,
+// multi-part) scan visits first. Measured family-wide against a real server
+// at the family's own 25.9 floor — including the split where the whole-window
+// members keep a FIRST-visited NaN while the instant members (irate / idelta)
+// keep a LAST-visited one — by
+// TestTSGridFamily_NaNDuplicateSurvivorIsOrderDependent_RealCH, and end to
+// end through cerberus's own lowering by
+// TestRate_NativeGrid_NaNDuplicate_DivergesFromFanout_RealCH.
+//
+// The fold lives inside a ClickHouse builtin, so no emitted SQL can reorder
+// it; nativeTSGridFn's own doc records the emitter-side gate that was
+// measured and ruled out, and cerberus tracks the gap at
+// https://github.com/tsouza/cerberus/issues/2798.
 //
 // OTel/ClickHouse ingestion can write two rows with the same
 // (Attributes, TimeUnix); without this collapse `length(window_vals)`

--- a/internal/chsql/range_window_grid_native.go
+++ b/internal/chsql/range_window_grid_native.go
@@ -101,6 +101,36 @@ type nativeTSGridAgg struct {
 // one uniform capability verdict. The emitter is version-agnostic and only
 // needs the name (plus predict_linear's offset scalar).
 //
+// # The duplicate-timestamp survivor, and why the emitter does not repair it
+//
+// Every member collapses a duplicate (series, timestamp) inside the ClickHouse
+// builtin, with a fold whose survivor follows scan order once a NaN is
+// involved. dedupWindowPairsByTsFrag's doc states cerberus's rule and where
+// this family departs from it; the gap is tracked at
+// https://github.com/tsouza/cerberus/issues/2798.
+//
+// The obvious emitter-side repair is available mechanically and unsound
+// numerically, and it is recorded here so it is not re-proposed as new. Its
+// shape: compute the grid over NaN-free rows with the `-If` combinator and
+// substitute NaN wherever a companion per-grid-point detector says the window
+// held a NaN sample. All three moving parts exist on a real 25.9 server —
+// `-If` applies to the parametric family (timeSeriesResetsToGridIf answers
+// over a predicate), a `-StateIf` form exists for the Recollapse tower, and
+// timeSeriesResetsToGrid's NULL-on-empty-window behaviour already serves as a
+// per-grid-point presence detector elsewhere (see range_bucket_grid_native.go's
+// bucketGridSeenFn).
+//
+// It is ruled out because its premise is false, measured rather than argued:
+// "a window holding a NaN sample answers NaN" does not hold. rate() over a
+// window whose NaN sits strictly between the first and last sample returns an
+// ordinary finite rate (0.829… for the probe seed), because the extrapolation
+// reads the window's endpoints and its sample count, and a NaN interior to
+// that never enters the arithmetic. The substitution would therefore NaN out
+// windows that today answer correctly on both paths — trading a rare
+// nondeterminism for a common wrong answer. changes/resets (integer counts,
+// which no NaN propagates into) and irate/idelta (trailing-pair folds, blind
+// to an interior NaN) break the premise a second and third way.
+//
 // StateFn / MergeFn name the aggregate's partial-state combinator pair, which
 // the deferred label-shaping shape (chplan.RangeWindowGridNative.Recollapse)
 // needs: the inner level emits <fn>ToGridState per RAW series and the middle
@@ -177,18 +207,32 @@ var nativeTSGridFn = map[string]nativeTSGridAgg{
 	// window-membership fix (the shared 25.9 floor) applies identically — a
 	// sample sitting exactly on the window's trailing edge is excluded.
 	//
-	// Both carry the SAME duplicate-timestamp "greatest value wins, NaN
-	// loses" dedup layer as the rest of the family, including the same
-	// order-dependent violation of that contract for a real-vs-NaN
-	// duplicate pair that cerberus issue #2798 already tracks as
-	// family-wide (confirmed to reproduce identically for irate/idelta).
-	// The fan-out has no dedup layer of its own for a duplicate-timestamp
-	// trailing pair either — it resolves by whatever order arraySort's
-	// stable tie-break happens to produce, itself unspecified — so the
-	// native path's deterministic-but-order-dependent dedup is not a
-	// regression against a well-defined fan-out contract, just the same
-	// #2798 gap surfacing through a different function. StateFn/MergeFn are
-	// deliberately left empty for the same reason delta's are: neither
+	// Both carry the family's duplicate-timestamp dedup layer, and both
+	// INVERT it relative to the whole-window members. Measured against a
+	// real ClickHouse at the family's own 25.9 floor
+	// (TestTSGridFamily_NaNDuplicateSurvivorIsOrderDependent_RealCH): on a
+	// NaN-bearing duplicate timestamp, irate/idelta leave the FINITE sample
+	// standing when the NaN reaches the fold first and the NaN standing when
+	// it reaches the fold second — the exact opposite of
+	// rate/increase/delta/deriv/predict_linear/changes, because a
+	// trailing-pair fold lands the same always-false IEEE754 comparison on
+	// the other side. Either way the survivor follows scan order rather than
+	// the sample multiset: the family-wide gap cerberus tracks at
+	// https://github.com/tsouza/cerberus/issues/2798.
+	//
+	// The fan-out is NOT equally unspecified on this shape, and that
+	// asymmetry is why the gap is a real divergence rather than a wash. The
+	// pairs-shaped fan-out has no dedup layer of its own for a
+	// duplicate-timestamp trailing pair, but arraySort still imposes a total
+	// order in which NaN ranks greatest, and that order is a function of the
+	// sample multiset alone — so the trailing pair it selects is the same
+	// one whatever order the rows arrived in. dedupWindowPairsByTsFrag's doc
+	// states the rule in full and names the tests that execute it. What
+	// keeps irate/idelta on the same AutoSelect posture as their siblings is
+	// that the exposure is the family's rather than theirs — see
+	// chopt.FeatureTSGridIrate.
+	//
+	// StateFn/MergeFn are empty for the same reason delta's are: neither
 	// Native*Lowerer sets Recollapse for irate/idelta.
 	"irate":  {Fn: "timeSeriesInstantRateToGrid"},
 	"idelta": {Fn: "timeSeriesInstantDeltaToGrid"},

--- a/internal/chsql/range_window_grid_native_nan_duplicate_realch_integration_test.go
+++ b/internal/chsql/range_window_grid_native_nan_duplicate_realch_integration_test.go
@@ -1,0 +1,697 @@
+//go:build integration
+
+// Real-ClickHouse characterisation of the duplicate-timestamp SURVIVOR the
+// native timeSeries*ToGrid family actually elects, and of the survivor the
+// array-fold fan-out elects for the same rows (cerberus issue #2798).
+//
+// # What this pins, and why it is a class-level suite rather than one probe
+//
+// Cerberus states ONE duplicate-timestamp rule for every range function
+// (cerberus issue #2914, PR #2920), implemented by dedupWindowPairsByTsFrag
+// and stated in full on that function's doc: one sample per distinct
+// (series, timestamp), tie-broken to the max value under ClickHouse's total
+// order over Float64 — the order in which NaN ranks GREATEST.
+//
+// The native family cannot keep the second half of that rule. Its own
+// documented rule is the opposite one ("a NaN value loses to any other
+// value"), and it delivers NEITHER deterministically: the collapse is a
+// running "replace the current best only when the candidate compares
+// greater" fold, and IEEE754 makes every comparison against a NaN false, so
+// the survivor is decided by which row the scan happens to visit first.
+//
+// Three properties are therefore pinned here, all against a real server at
+// the family's own 25.9 registry floor (chopt.FeatureTSGridRange and
+// siblings), because the finding is a property of the ClickHouse builtin and
+// no amount of cerberus-side reasoning can establish it:
+//
+//  1. TestTSGridFamily_NaNDuplicateSurvivorIsOrderDependent_RealCH — for
+//     EVERY member of the emitter's own nativeTSGridFn registry, which
+//     sample survives a NaN-bearing duplicate under each of the two
+//     encounter orders. The case list is ratcheted against that registry, so
+//     a family member added later cannot ship unprobed.
+//  2. TestFanoutDedup_NaNDuplicateSurvivorIsOrderIndependent_RealCH — the
+//     production dedupWindowPairsByTsFrag Frag itself, rendered and executed,
+//     elects the SAME survivor under both encounter orders. This is the half
+//     of the contract cerberus does deliver, and it is what makes the
+//     divergence a divergence rather than two equally unspecified paths.
+//  3. TestRate_NativeGrid_NaNDuplicate_DivergesFromFanout_RealCH — the gap
+//     end to end through cerberus's own lowering and emitter, over one
+//     MergeTree table holding two series with the IDENTICAL sample multiset
+//     and opposite physical row order.
+//
+// These tests are a characterisation of third-party behaviour, so their
+// direction of failure is the point: they go red when ClickHouse's fold
+// changes. A red here is the signal to re-derive nativeTSGridFn's and
+// chopt.FeatureTSGrid*'s posture docs against the new behaviour — and, if
+// the fold became order-independent, to close #2798.
+//
+// Needs a real ClickHouse >= 25.9 and Docker; gated behind the `integration`
+// build tag, run by the `ts-grid-nan-duplicate-integration` Justfile recipe.
+// In-package (`package chsql`, unlike its `chsql_test` sibling
+// range_window_group_array_realch_integration_test.go) precisely so the
+// family sweep can be driven by the unexported nativeTSGridFn registry and
+// the fan-out probe can execute the unexported dedupWindowPairsByTsFrag Frag
+// itself rather than a hand-copied transcription of either.
+package chsql
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"math"
+	"sort"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/ClickHouse/clickhouse-go/v2"
+	promparser "github.com/prometheus/prometheus/promql/parser"
+	tcclickhouse "github.com/testcontainers/testcontainers-go/modules/clickhouse"
+
+	"github.com/tsouza/cerberus/internal/chclient"
+	"github.com/tsouza/cerberus/internal/promql"
+	"github.com/tsouza/cerberus/internal/schema"
+)
+
+// nanDupImage pins a ClickHouse at the timeSeries*ToGrid family's own 25.9
+// registry floor (chopt.FeatureTSGridRange and siblings). A plain literal
+// rather than an import of internal/chopt, mirroring tsGridGroupArrayImage's
+// rationale in the sibling integration file: this suite's only dependency on
+// the family's floor is the image tag its container runs.
+const nanDupImage = "clickhouse/clickhouse-server:25.9-alpine"
+
+// The one grid point every probe evaluates, and the two samples that share a
+// timestamp inside its window. nanDupDupTS carries BOTH nanDupFiniteValue and
+// a NaN; nanDupLaterTS carries a single unambiguous sample, so every
+// aggregate has the >= 2 samples it needs to return non-NULL.
+const (
+	nanDupAnchor    = "2026-01-01 00:01:00"
+	nanDupDupTS     = "2026-01-01 00:00:20"
+	nanDupLaterTS   = "2026-01-01 00:00:50"
+	nanDupStepSec   = 60
+	nanDupWindowSec = 60
+
+	nanDupFiniteValue = 25.0
+	nanDupLaterValue  = 40.0
+
+	// nanDupPredictOffsetSec is predict_linear's fifth parametric argument
+	// (the forecast horizon). Any whole-second horizon works; 600 matches
+	// the horizon the native predict_linear fixtures already use.
+	nanDupPredictOffsetSec = 600
+)
+
+// nanDupSurvivor names which of the two samples sharing nanDupDupTS won the
+// collapse. It is derived from the aggregate's answer by comparing it against
+// the two duplicate-free baselines the same aggregate returns over the same
+// window — so a case declares a statement about the DEDUP CONTRACT ("the NaN
+// survived") rather than transcribing whatever float the arithmetic happens
+// to produce.
+type nanDupSurvivor int
+
+const (
+	// survivorUnobservable marks an aggregate whose two duplicate-free
+	// baselines are equal, so its answer cannot reveal which sample won.
+	survivorUnobservable nanDupSurvivor = iota
+	survivorNaN
+	survivorFinite
+)
+
+func (s nanDupSurvivor) String() string {
+	switch s {
+	case survivorNaN:
+		return "NaN"
+	case survivorFinite:
+		return "finite"
+	default:
+		return "unobservable"
+	}
+}
+
+// nanDupCase declares, for one nativeTSGridFn member, the extra parametric
+// arguments its aggregate takes and the survivor it elects under each of the
+// two encounter orders.
+type nanDupCase struct {
+	// extraParams is appended to the shared
+	// `(start, end, step_s, window_s)` parameter list. Empty for every
+	// member except predict_linear, whose fifth argument is its horizon.
+	extraParams string
+	// nanFirstSurvivor / nanSecondSurvivor are the samples that win when the
+	// NaN row is fed to the aggregate before / after the finite row.
+	nanFirstSurvivor  nanDupSurvivor
+	nanSecondSurvivor nanDupSurvivor
+	// why records what makes this member's outcome what it is, so a future
+	// red carries its own diagnosis.
+	why string
+}
+
+// orderDependent reports whether the two encounter orders elect different
+// samples. Derived rather than declared: a case that declared BOTH the two
+// survivors and a redundant "is it order dependent" flag could disagree with
+// itself.
+func (c nanDupCase) orderDependent() bool {
+	return c.nanFirstSurvivor != c.nanSecondSurvivor
+}
+
+// nanDupCases covers every nativeTSGridFn member. The sweep below fails when
+// the registry holds a function this map does not, which is what makes the
+// coverage a ratchet rather than a snapshot.
+//
+// Two sub-groups fall out of the measurements, and the split is the
+// substantive finding — the family does NOT fold uniformly:
+//
+//   - The whole-window members (rate / increase / delta / changes / resets /
+//     deriv / predict_linear) keep the FIRST-visited sample when it is a NaN:
+//     nothing compares greater than a NaN, so a NaN that is already the
+//     current best can never be replaced, and a NaN arriving later can never
+//     replace a finite current best.
+//   - The instant members (irate / idelta) invert it: they keep the
+//     LAST-visited sample when it is a NaN. Their fold reduces the window to
+//     its trailing pair rather than sweeping a running maximum, so the same
+//     false comparison lands on the opposite side.
+//
+// Neither sub-group matches the family's own documented "a NaN value loses to
+// any other value" rule, which would require survivorFinite in BOTH columns
+// for every member.
+var nanDupCases = map[string]nanDupCase{
+	"rate": {
+		nanFirstSurvivor:  survivorNaN,
+		nanSecondSurvivor: survivorFinite,
+		why:               "running max fold; a NaN current best is never replaced and never replaces",
+	},
+	"increase": {
+		nanFirstSurvivor:  survivorNaN,
+		nanSecondSurvivor: survivorFinite,
+		why:               "shares timeSeriesRateToGrid with rate, so it shares rate's fold exactly",
+	},
+	"changes": {
+		nanFirstSurvivor:  survivorNaN,
+		nanSecondSurvivor: survivorFinite,
+		why:               "running max fold; the surviving sample shifts the transition count",
+	},
+	"resets": {
+		nanFirstSurvivor:  survivorUnobservable,
+		nanSecondSurvivor: survivorUnobservable,
+		why: "a counter reset needs curr < prev, and every comparison against a NaN is false, " +
+			"so both survivors yield the same zero count and the fold is not observable through the answer",
+	},
+	"deriv": {
+		nanFirstSurvivor:  survivorNaN,
+		nanSecondSurvivor: survivorFinite,
+		why:               "running max fold; the surviving sample enters the least-squares fit",
+	},
+	"predict_linear": {
+		extraParams:       fmt.Sprintf(", %d", nanDupPredictOffsetSec),
+		nanFirstSurvivor:  survivorNaN,
+		nanSecondSurvivor: survivorFinite,
+		why:               "running max fold; the surviving sample enters the same least-squares fit deriv uses",
+	},
+	"delta": {
+		nanFirstSurvivor:  survivorNaN,
+		nanSecondSurvivor: survivorFinite,
+		why:               "running max fold; the surviving sample is one end of the differenced pair",
+	},
+	"irate": {
+		nanFirstSurvivor:  survivorFinite,
+		nanSecondSurvivor: survivorNaN,
+		why:               "trailing-pair fold, INVERTED against the whole-window members: the LAST-visited NaN wins",
+	},
+	"idelta": {
+		nanFirstSurvivor:  survivorFinite,
+		nanSecondSurvivor: survivorNaN,
+		why:               "trailing-pair fold, inverted for the same reason irate's is",
+	},
+}
+
+// nanDupConnect boots a ClickHouse at nanDupImage and returns a pooled
+// handle. A local copy of the sibling file's realCHConnect rather than a
+// shared helper: that one lives in `package chsql_test` and this suite must
+// be in-package to reach nativeTSGridFn and dedupWindowPairsByTsFrag.
+func nanDupConnect(ctx context.Context, t *testing.T) *sql.DB {
+	t.Helper()
+	container, err := tcclickhouse.Run(
+		ctx,
+		nanDupImage,
+		tcclickhouse.WithUsername("cerberus"),
+		tcclickhouse.WithPassword("cerberus"),
+		tcclickhouse.WithDatabase("otel"),
+	)
+	if err != nil {
+		t.Fatalf("start clickhouse: %v", err)
+	}
+	t.Cleanup(func() { _ = container.Terminate(ctx) })
+
+	host, err := container.Host(ctx)
+	if err != nil {
+		t.Fatalf("host: %v", err)
+	}
+	port, err := container.MappedPort(ctx, "9000/tcp")
+	if err != nil {
+		t.Fatalf("port: %v", err)
+	}
+
+	db := clickhouse.OpenDB(&clickhouse.Options{
+		Addr: []string{host + ":" + port.Port()},
+		Auth: clickhouse.Auth{
+			Database: "otel",
+			Username: "cerberus",
+			Password: "cerberus",
+		},
+	})
+	t.Cleanup(func() { _ = db.Close() })
+	if err := db.PingContext(ctx); err != nil {
+		t.Fatalf("ping: %v", err)
+	}
+	return db
+}
+
+// nanDupFloatLit renders a Float64 SQL literal. A bare `%v` renders 25.0 as
+// `25`, which ClickHouse types UInt8 — and the timeSeries*ToGrid family
+// rejects a non-Float64 value argument outright (ILLEGAL_TYPE_OF_ARGUMENT),
+// so the fractional digit is load-bearing rather than cosmetic.
+func nanDupFloatLit(v float64) string {
+	return strconv.FormatFloat(v, 'f', 1, 64)
+}
+
+// nanDupSampleRows renders the UNION ALL row source the sweep feeds one
+// aggregate. valuesAtDupTS are the samples sharing nanDupDupTS, IN ENCOUNTER
+// ORDER — the whole point of the probe — followed by the unambiguous
+// nanDupLaterTS sample.
+func nanDupSampleRows(valuesAtDupTS ...string) string {
+	parts := make([]string, 0, len(valuesAtDupTS)+1)
+	for i, v := range valuesAtDupTS {
+		if i == 0 {
+			parts = append(parts, fmt.Sprintf(
+				"SELECT toDateTime('%s') AS ts, %s AS val", nanDupDupTS, v,
+			))
+			continue
+		}
+		parts = append(parts, fmt.Sprintf(
+			"SELECT toDateTime('%s'), %s", nanDupDupTS, v,
+		))
+	}
+	parts = append(parts, fmt.Sprintf(
+		"SELECT toDateTime('%s'), %s", nanDupLaterTS, nanDupFloatLit(nanDupLaterValue),
+	))
+	return "(" + strings.Join(parts, " UNION ALL ") + ")"
+}
+
+// nanDupGrid runs one family member over rows and returns its grid as a
+// string. The experimental setting is scoped to the statement rather than the
+// session: a pooled *sql.DB gives no guarantee a later query reuses the
+// connection a session-level SET landed on.
+func nanDupGrid(ctx context.Context, t *testing.T, db *sql.DB, agg, extraParams, rows string) string {
+	t.Helper()
+	query := fmt.Sprintf(
+		"SELECT toString(%s(toDateTime('%s'), toDateTime('%s'), %d, %d%s)(ts, val)) FROM %s SETTINGS %s = 1",
+		agg, nanDupAnchor, nanDupAnchor, nanDupStepSec, nanDupWindowSec, extraParams, rows,
+		chclient.SettingExperimentalTSGridAggregate,
+	)
+	var got string
+	if err := db.QueryRowContext(ctx, query).Scan(&got); err != nil {
+		t.Fatalf("%s: %v\nSQL: %s", agg, err, query)
+	}
+	return got
+}
+
+// TestTSGridFamily_NaNDuplicateSurvivorIsOrderDependent_RealCH measures, for
+// every nativeTSGridFn member, which sample survives a NaN-bearing duplicate
+// timestamp under each encounter order — the finding cerberus issue #2798
+// tracks, established here family-wide rather than inferred from the two
+// members #2746's chDB sweep happened to probe.
+//
+// The survivor is DERIVED, not transcribed: each member is first run over the
+// two duplicate-free windows (the NaN alone at the shared timestamp, then the
+// finite sample alone), and the duplicate answer is matched against those two
+// baselines. A member whose baselines coincide is declared unobservable and
+// asserted to be so, which is what stops `resets` from silently counting as
+// evidence of order-independence.
+func TestTSGridFamily_NaNDuplicateSurvivorIsOrderDependent_RealCH(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Minute)
+	defer cancel()
+	db := nanDupConnect(ctx, t)
+
+	if len(nativeTSGridFn) == 0 {
+		t.Fatal("nativeTSGridFn is empty — the ratchet below would vacuously pass")
+	}
+	for fn := range nativeTSGridFn {
+		if _, ok := nanDupCases[fn]; !ok {
+			t.Errorf("nativeTSGridFn registers %q but nanDupCases has no case for it — every native "+
+				"family member must have its duplicate-timestamp survivor measured (cerberus issue #2798)", fn)
+		}
+	}
+	for fn := range nanDupCases {
+		if _, ok := nativeTSGridFn[fn]; !ok {
+			t.Errorf("nanDupCases declares %q, which nativeTSGridFn does not register — a stale case "+
+				"would keep asserting against an aggregate cerberus no longer emits", fn)
+		}
+	}
+
+	names := make([]string, 0, len(nanDupCases))
+	for fn := range nanDupCases {
+		names = append(names, fn)
+	}
+	sort.Strings(names)
+
+	orderDependentMembers := 0
+	for _, fn := range names {
+		c := nanDupCases[fn]
+		agg, ok := nativeTSGridFn[fn]
+		if !ok {
+			continue // already reported above
+		}
+		t.Run(fn, func(t *testing.T) {
+			nanOnly := nanDupGrid(ctx, t, db, agg.Fn, c.extraParams,
+				nanDupSampleRows("nan"))
+			finiteOnly := nanDupGrid(ctx, t, db, agg.Fn, c.extraParams,
+				nanDupSampleRows(nanDupFloatLit(nanDupFiniteValue)))
+
+			classify := func(got string) nanDupSurvivor {
+				if nanOnly == finiteOnly {
+					return survivorUnobservable
+				}
+				switch got {
+				case nanOnly:
+					return survivorNaN
+				case finiteOnly:
+					return survivorFinite
+				default:
+					t.Fatalf("%s: duplicate answer %q matches NEITHER duplicate-free baseline "+
+						"(nan-only=%q, finite-only=%q) — the collapse kept something other than one of "+
+						"the two samples, which no reading of the documented rule allows",
+						agg.Fn, got, nanOnly, finiteOnly)
+					return survivorUnobservable
+				}
+			}
+
+			if c.nanFirstSurvivor == survivorUnobservable || c.nanSecondSurvivor == survivorUnobservable {
+				if nanOnly != finiteOnly {
+					t.Fatalf("%s: case declares the survivor unobservable (%s), but the two "+
+						"duplicate-free baselines DIFFER (nan-only=%q, finite-only=%q) — the answer "+
+						"does reveal the survivor, so the case must declare which one it is",
+						agg.Fn, c.why, nanOnly, finiteOnly)
+				}
+			} else if nanOnly == finiteOnly {
+				t.Fatalf("%s: case declares survivors (%s / %s) the answer cannot distinguish — both "+
+					"duplicate-free baselines are %q",
+					agg.Fn, c.nanFirstSurvivor, c.nanSecondSurvivor, nanOnly)
+			}
+
+			nanFirst := classify(nanDupGrid(ctx, t, db, agg.Fn, c.extraParams,
+				nanDupSampleRows("nan", nanDupFloatLit(nanDupFiniteValue))))
+			nanSecond := classify(nanDupGrid(ctx, t, db, agg.Fn, c.extraParams,
+				nanDupSampleRows(nanDupFloatLit(nanDupFiniteValue), "nan")))
+
+			if nanFirst != c.nanFirstSurvivor {
+				t.Errorf("%s: NaN fed FIRST — survivor is %s, case declares %s (%s)",
+					agg.Fn, nanFirst, c.nanFirstSurvivor, c.why)
+			}
+			if nanSecond != c.nanSecondSurvivor {
+				t.Errorf("%s: NaN fed SECOND — survivor is %s, case declares %s (%s)",
+					agg.Fn, nanSecond, c.nanSecondSurvivor, c.why)
+			}
+			if got, want := nanFirst != nanSecond, c.orderDependent(); got != want {
+				t.Errorf("%s: order dependence = %v, case implies %v — if ClickHouse's fold became "+
+					"order-independent, cerberus issue #2798 can close and every doc citing it must be "+
+					"re-derived", agg.Fn, got, want)
+			}
+		})
+		if c.orderDependent() {
+			orderDependentMembers++
+		}
+	}
+
+	if orderDependentMembers == 0 {
+		t.Fatal("no nativeTSGridFn member is declared order dependent — this suite exists to pin " +
+			"cerberus issue #2798's finding, and would be vacuous with every case declared insensitive")
+	}
+}
+
+// TestFanoutDedup_NaNDuplicateSurvivorIsOrderIndependent_RealCH executes the
+// PRODUCTION dedupWindowPairsByTsFrag Frag — rendered from the emitter's own
+// constructor, not transcribed — over the same two encounter orders, and
+// asserts it elects the same survivor either way.
+//
+// This is the half of cerberus's duplicate-timestamp contract that IS
+// deliverable, and it is what makes the native family's behaviour a
+// divergence rather than two equally unspecified paths: `arraySort` orders
+// Float64 under a total order in which NaN ranks greatest, so the
+// last-of-run keep is a function of the sample multiset alone.
+//
+// It fails if dedupWindowPairsByTsFrag is ever swapped for a fold that
+// inherits ClickHouse's IEEE754 comparison — including the self-deduping
+// native timeSeriesGroupArray aggregate (chopt.FeatureTSGridGroupArray),
+// whose AutoSelect: false posture rests on exactly this difference.
+func TestFanoutDedup_NaNDuplicateSurvivorIsOrderIndependent_RealCH(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Minute)
+	defer cancel()
+	db := nanDupConnect(ctx, t)
+
+	dedupSQL, err := Render(dedupWindowPairsByTsFrag(
+		Call("arraySort", Call("groupArray", Tuple(Col("ts"), Col("val")))),
+	))
+	if err != nil {
+		t.Fatalf("render dedupWindowPairsByTsFrag: %v", err)
+	}
+
+	run := func(rows string) string {
+		var got string
+		query := fmt.Sprintf("SELECT toString(%s) FROM %s", dedupSQL, rows)
+		if err := db.QueryRowContext(ctx, query).Scan(&got); err != nil {
+			t.Fatalf("dedup probe: %v\nSQL: %s", err, query)
+		}
+		return got
+	}
+
+	finite := nanDupFloatLit(nanDupFiniteValue)
+	nanFirst := run(nanDupSampleRows("nan", finite))
+	nanSecond := run(nanDupSampleRows(finite, "nan"))
+
+	if nanFirst != nanSecond {
+		t.Fatalf("dedupWindowPairsByTsFrag is insertion-order DEPENDENT: nan-first=%q nan-second=%q. "+
+			"Cerberus's duplicate-timestamp contract (see the Frag's own doc) promises a survivor that "+
+			"is a function of the sample multiset alone", nanFirst, nanSecond)
+		return
+	}
+	if strings.Count(nanFirst, "(") != 2 {
+		t.Fatalf("dedupWindowPairsByTsFrag kept %q — want exactly two tuples, one per distinct "+
+			"timestamp (the cardinality half of the contract)", nanFirst)
+	}
+	if !strings.Contains(strings.ToLower(nanFirst), "nan") {
+		t.Fatalf("dedupWindowPairsByTsFrag kept %q — want the NaN to survive: arraySort ranks NaN "+
+			"greatest, so the last-of-run keep elects it, and that is the representative half of the "+
+			"contract cerberus commits to", nanFirst)
+	}
+	if strings.Contains(nanFirst, finite) {
+		t.Fatalf("dedupWindowPairsByTsFrag kept %q — the finite duplicate must NOT survive alongside "+
+			"the NaN; both rows surviving is the over-count dedupWindowPairsByTsFrag exists to prevent",
+			nanFirst)
+	}
+}
+
+// nanDupMetricsDDL is the OTel-CH sum table the end-to-end case seeds. Only
+// the columns the default schema's rate() lowering reads.
+const nanDupMetricsDDL = `
+CREATE TABLE otel_metrics_sum (
+    MetricName String,
+    Attributes Map(String, String),
+    ResourceAttributes Map(String, String) DEFAULT map(),
+    ServiceName LowCardinality(String) DEFAULT '',
+    TimeUnix DateTime64(9),
+    Value Float64,
+    AggregationTemporality Int32 DEFAULT 2
+) ENGINE = MergeTree ORDER BY (MetricName, Attributes, TimeUnix)
+`
+
+// The three series the end-to-end case seeds. nanFirst and nanSecond hold the
+// IDENTICAL sample multiset and differ only in the physical order of the two
+// rows sharing one timestamp; plain has no duplicate at all, so a lowering
+// that silently stopped producing rows cannot pass this test vacuously.
+const (
+	nanDupJobNaNFirst  = "nanfirst"
+	nanDupJobNaNSecond = "nansecond"
+	nanDupJobPlain     = "plain"
+)
+
+// TestRate_NativeGrid_NaNDuplicate_DivergesFromFanout_RealCH runs cerberus's
+// OWN emitted SQL for `rate(requests_total[1m])` down both lowerings over one
+// table holding two series with the identical sample multiset, and pins the
+// gap cerberus issue #2798 tracks:
+//
+//   - the fan-out answers the two series IDENTICALLY (its survivor is a
+//     function of the multiset), and
+//   - the native grid path does NOT (its survivor is a function of physical
+//     row order), so one of the two series gets an answer the contract does
+//     not sanction.
+//
+// The control series pins that both lowerings agree where no duplicate
+// timestamp exists at all, so the divergence cannot be an artefact of the two
+// paths disagreeing generally.
+func TestRate_NativeGrid_NaNDuplicate_DivergesFromFanout_RealCH(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Minute)
+	defer cancel()
+	db := nanDupConnect(ctx, t)
+
+	if _, err := db.ExecContext(ctx, nanDupMetricsDDL); err != nil {
+		t.Fatalf("create table: %v", err)
+	}
+	seed := fmt.Sprintf(`
+INSERT INTO otel_metrics_sum (MetricName, Attributes, TimeUnix, Value) VALUES
+    ('requests_total', map('job', '%[1]s'), toDateTime64('%[4]s', 9), nan),
+    ('requests_total', map('job', '%[1]s'), toDateTime64('%[4]s', 9), %[6]s),
+    ('requests_total', map('job', '%[1]s'), toDateTime64('%[5]s', 9), %[7]s),
+    ('requests_total', map('job', '%[2]s'), toDateTime64('%[4]s', 9), %[6]s),
+    ('requests_total', map('job', '%[2]s'), toDateTime64('%[4]s', 9), nan),
+    ('requests_total', map('job', '%[2]s'), toDateTime64('%[5]s', 9), %[7]s),
+    ('requests_total', map('job', '%[3]s'), toDateTime64('%[4]s', 9), %[6]s),
+    ('requests_total', map('job', '%[3]s'), toDateTime64('%[5]s', 9), %[7]s)
+`, nanDupJobNaNFirst, nanDupJobNaNSecond, nanDupJobPlain,
+		nanDupDupTS, nanDupLaterTS, nanDupFloatLit(nanDupFiniteValue), nanDupFloatLit(nanDupLaterValue))
+	if _, err := db.ExecContext(ctx, seed); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	anchor, err := time.Parse("2006-01-02 15:04:05", nanDupAnchor)
+	if err != nil {
+		t.Fatalf("parse anchor: %v", err)
+	}
+
+	fanout := nanDupRunRate(ctx, t, db, anchor, false)
+	native := nanDupRunRate(ctx, t, db, anchor, true)
+
+	for _, job := range []string{nanDupJobNaNFirst, nanDupJobNaNSecond, nanDupJobPlain} {
+		if _, ok := fanout[job]; !ok {
+			t.Fatalf("fan-out returned no row for job=%s — the fixture is broken", job)
+		}
+		if _, ok := native[job]; !ok {
+			t.Fatalf("native returned no row for job=%s — the fixture is broken", job)
+		}
+	}
+
+	// The control: no duplicate timestamp, so both lowerings must agree.
+	if f, n := fanout[nanDupJobPlain], native[nanDupJobPlain]; math.Abs(f-n) > 1e-9 {
+		t.Fatalf("job=%s carries no duplicate timestamp yet native=%v and fan-out=%v disagree — the "+
+			"divergence asserted below would not be attributable to the duplicate",
+			nanDupJobPlain, n, f)
+	}
+
+	// The contract half cerberus delivers: the two duplicate-bearing series
+	// hold the same sample multiset, so the fan-out must answer them the same.
+	fFirst, fSecond := fanout[nanDupJobNaNFirst], fanout[nanDupJobNaNSecond]
+	if !math.IsNaN(fFirst) || !math.IsNaN(fSecond) {
+		t.Fatalf("fan-out answered job=%s %v and job=%s %v — cerberus's duplicate-timestamp contract "+
+			"elects the NaN (arraySort ranks NaN greatest), so rate() over the surviving window is NaN "+
+			"for both", nanDupJobNaNFirst, fFirst, nanDupJobNaNSecond, fSecond)
+	}
+
+	// The gap #2798 tracks: the native family's survivor follows physical row
+	// order, so the two series answer differently.
+	nFirst, nSecond := native[nanDupJobNaNFirst], native[nanDupJobNaNSecond]
+	if math.IsNaN(nFirst) && math.IsNaN(nSecond) {
+		t.Fatalf("the native timeSeries*ToGrid path answered both duplicate-bearing series NaN — "+
+			"if ClickHouse's collapse became order-independent, cerberus issue #2798 can close and "+
+			"every doc citing it must be re-derived (native: %s=%v %s=%v)",
+			nanDupJobNaNFirst, nFirst, nanDupJobNaNSecond, nSecond)
+	}
+	if !math.IsNaN(nFirst) {
+		t.Errorf("native job=%s = %v, want NaN: with the NaN row physically first, nothing compares "+
+			"greater than it, so it survives the collapse", nanDupJobNaNFirst, nFirst)
+	}
+	if math.IsNaN(nSecond) {
+		t.Errorf("native job=%s = NaN, want the finite-survivor answer: with the NaN row physically "+
+			"second it can never displace the finite current best", nanDupJobNaNSecond)
+	}
+}
+
+// nanDupRunRate lowers and emits `rate(requests_total[1m])` as an instant
+// query at anchor, down the native timeSeries*ToGrid lowering or the fan-out,
+// and returns the per-job value.
+//
+// An instant query rather than a range query: it evaluates exactly one grid
+// point, so the answer is the survivor's contribution and nothing else, and
+// the assertions above need no anchor bookkeeping.
+func nanDupRunRate(ctx context.Context, t *testing.T, db *sql.DB, anchor time.Time, native bool) map[string]float64 {
+	t.Helper()
+	p := promparser.NewParser(promparser.Options{})
+	expr, err := p.ParseExpr(fmt.Sprintf("rate(requests_total[%ds])", nanDupWindowSec))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+
+	var lowerers promql.RangeLowerers
+	if native {
+		lowerers.Rate = promql.NativeRateLowerer{Fallback: promql.FanoutRateLowerer{}}
+	}
+	// A single-point range query rather than the instant shape: the native
+	// timeSeries*ToGrid lowering is a query_range strategy, so an instant
+	// query would silently fall back to the fan-out and compare the fan-out
+	// with itself.
+	plan, err := promql.LowerAtRangeOpts(ctx, expr, nanDupSchema(),
+		anchor, anchor, time.Duration(nanDupStepSec)*time.Second,
+		promql.LowerOpts{Lowerers: lowerers})
+	if err != nil {
+		t.Fatalf("lower (native=%v): %v", native, err)
+	}
+	sqlStr, args, err := Emit(ctx, plan)
+	if err != nil {
+		t.Fatalf("emit (native=%v): %v", native, err)
+	}
+	if native && !strings.Contains(sqlStr, nativeTSGridFn["rate"].Fn) {
+		t.Fatalf("native=true did not emit %s — the differential would compare the fan-out with "+
+			"itself:\n%s", nativeTSGridFn["rate"].Fn, sqlStr)
+	}
+	if !native && strings.Contains(sqlStr, nativeTSGridFn["rate"].Fn) {
+		t.Fatalf("native=false emitted %s — the fan-out arm is not the fan-out:\n%s",
+			nativeTSGridFn["rate"].Fn, sqlStr)
+	}
+
+	wrapped := fmt.Sprintf(
+		"SELECT toJSONString(`Attributes`) AS job_json, `Value` FROM (%s) SETTINGS %s = 1",
+		sqlStr, chclient.SettingExperimentalTSGridAggregate,
+	)
+	rows, err := db.QueryContext(ctx, wrapped, args...)
+	if err != nil {
+		t.Fatalf("query (native=%v): %v\nSQL: %s", native, err, wrapped)
+	}
+	defer func() { _ = rows.Close() }()
+
+	out := map[string]float64{}
+	for rows.Next() {
+		var jobJSON string
+		var v float64
+		if err := rows.Scan(&jobJSON, &v); err != nil {
+			t.Fatalf("scan (native=%v): %v", native, err)
+		}
+		out[nanDupJobLabel(jobJSON)] = v
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatalf("rows.Err (native=%v): %v", native, err)
+	}
+	return out
+}
+
+// nanDupSchema is the default OTel-CH metrics schema with the
+// AggregationTemporality column cleared: a schema that declares it forces
+// every rate() window off the native path (see nativeTSGridMatrixNode), which
+// would make the native arm above silently the fan-out.
+func nanDupSchema() schema.Metrics {
+	s := schema.DefaultOTelMetrics()
+	s.AggregationTemporalityColumn = ""
+	return s
+}
+
+// nanDupJobLabel pulls the job value out of the JSON-encoded Attributes map
+// (`{"job":"a"}`). A local copy for the same reason nanDupConnect is one.
+func nanDupJobLabel(jsonStr string) string {
+	const key = `"job":"`
+	i := strings.Index(jsonStr, key)
+	if i < 0 {
+		return ""
+	}
+	rest := jsonStr[i+len(key):]
+	j := strings.Index(rest, `"`)
+	if j < 0 {
+		return rest
+	}
+	return rest[:j]
+}


### PR DESCRIPTION
## What was measured

Against a **real ClickHouse 25.9.7.56** — the `timeSeries*ToGrid` family's own
registry floor — not chDB and not the documentation.

For a duplicate `(series, timestamp)` carrying one NaN and one finite sample,
which sample survives the family's internal collapse:

| aggregate | NaN reaches the fold first | NaN reaches it second |
|---|---|---|
| `timeSeriesRateToGrid` (rate, increase) | NaN | finite |
| `timeSeriesDeltaToGrid` | NaN | finite |
| `timeSeriesChangesToGrid` | NaN | finite |
| `timeSeriesDerivToGrid` | NaN | finite |
| `timeSeriesPredictLinearToGrid` | NaN | finite |
| `timeSeriesResetsToGrid` | not observable through the answer | |
| `timeSeriesInstantRateToGrid` (irate) | **finite** | **NaN** |
| `timeSeriesInstantDeltaToGrid` (idelta) | **finite** | **NaN** |

Two findings the issue did not have. The gap is **family-wide**, not confined
to the two members #2746's chDB sweep probed. And the family does **not fold
uniformly**: the instant members invert the whole-window members, because a
trailing-pair fold lands the same always-false IEEE754 comparison on the other
side. Any single-member reasoning about this shape is unsound.

The seat of it is exactly where the coordinator predicted: the collapse is a
running "replace the current best only when the candidate compares greater"
fold, and every comparison against a NaN is false in both directions, so a NaN
already holding the slot can never be displaced and a NaN arriving later can
never take it.

## Red before green

One query, one MergeTree table, two series carrying the **identical sample
multiset** and differing only in the physical order of the two rows that share
a timestamp:

```
job=nanfirst   -> [nan]
job=nansecond  -> [0.5]
```

The array-fold fan-out answers **both** series identically over the same rows
(`[(00:00:20, nan), (00:00:50, 40)]`), because `arraySort` orders Float64
totally with NaN ranked greatest and that order is a function of the multiset
alone. Reproduced through cerberus's own lowering and emitter, with a
duplicate-free control series proving the two paths agree where no duplicate
exists.

## The contract, and where it cannot be kept

Stated once, on `dedupWindowPairsByTsFrag` — the Frag that implements it:

> One sample per distinct `(series, timestamp)`, tie-broken to the max value,
> where **"max" is ClickHouse's total order over Float64, in which NaN ranks
> greatest**.

The NaN clause is not decoration. IEEE754 leaves `max` undefined the moment a
NaN is involved, so a rule naming only "the max value" says nothing about the
one case where the answer is in doubt — which is why the old comment could
claim byte-identity with the native family and be wrong without anyone
noticing.

Splitting the rule in two is what makes it checkable:

- **cardinality** — exactly one sample survives each distinct timestamp;
- **representative** — the survivor is a function of the sample multiset
  alone, never of the order the rows arrived in.

The array-fold path delivers both, and the test executes the production Frag
to prove it. The native family delivers the cardinality half and **cannot**
deliver the representative half: the fold lives inside a ClickHouse builtin,
so no emitted SQL can reorder it.

## Three claims this deletes

Each was load-bearing, not colour:

1. `dedupWindowPairsByTsFrag` claimed its collapse was "byte-for-byte the
   choice the ClickHouse-native `timeSeries*ToGrid` aggregates make (verified
   insertion-order-independent against `timeSeriesRateToGrid`)". It is not,
   for a NaN-bearing duplicate.
2. `nativeTSGridFn`'s irate/idelta entry called the native fold
   "deterministic-but-order-dependent" — a contradiction in terms over an
   unordered scan — and called the fan-out's own trailing-pair selection
   "itself unspecified". `arraySort` is fully specified and insertion-order
   independent; measured both ways.
3. `chopt.FeatureTSGridIrate` used claim 2 to argue the native path "is not a
   regression against a well-defined fan-out contract". It is one. The posture
   is re-derived on the true premise: what keeps irate on its siblings'
   `AutoSelect` setting is that the exposure is the **family's** shape, not
   irate's, and that the two members which do carry `AutoSelect: false` carry
   it for divergences ordinary data reaches — `ts_grid_changes` diverges on any
   NaN-adjacent window with no duplicate at all (#1721), and
   `ts_grid_group_array` is a pure SQL-shape swap whose only effect would be to
   import this nondeterminism into paths that today do not have it (#2749).

## Was order-independence achievable?

No, and the repair that looks obvious is recorded on `nativeTSGridFn` so it is
not re-proposed as new. Its shape: compute the grid over NaN-free rows with the
`-If` combinator and substitute NaN wherever a companion per-grid-point
detector says the window held a NaN sample. Every moving part exists on a real
25.9 server — `-If` applies to the parametric family, a `-StateIf` form exists
for the `Recollapse` tower, and `timeSeriesResetsToGrid`'s NULL-on-empty-window
behaviour already serves as a per-grid-point presence detector in
`range_bucket_grid_native.go`.

It is ruled out because its premise is false, measured rather than argued:
`rate()` over a window whose NaN sits strictly between the first and last
sample returns an ordinary finite rate (`0.829…` for the probe seed) — the
extrapolation reads the window's endpoints and its sample count, and an
interior NaN never enters the arithmetic. The substitution would NaN out
windows that today answer correctly on **both** paths, trading a rare
nondeterminism for a common wrong answer. `changes`/`resets` (integer counts no
NaN propagates into) and `irate`/`idelta` (trailing-pair folds blind to an
interior NaN) break the premise a second and third way.

An exact gate does exist — drop a finite row iff some row shares its
`(series, timestamp)` and is NaN, via
`max(isNaN(Value)) OVER (PARTITION BY <series>, TimeUnix)` — and it is sound.
It also forces a full sort of the scan on the flagship native path for every
query, to reach a doubly degenerate shape. That is a performance decision with
a measured cost, not a correctness cleanup, so it is filed rather than smuggled
in here: #2924.

## Non-vacuity

The family sweep is ratcheted against the emitter's own `nativeTSGridFn`
registry in both directions — a registered function with no case fails, and a
case for an unregistered function fails — so a member added later cannot ship
unprobed and a stale case cannot keep asserting against an aggregate cerberus
no longer emits. Survivors are **derived** from each aggregate's own two
duplicate-free baselines rather than transcribed, so a case declares a
statement about the dedup contract rather than a float; a member whose
baselines coincide (`resets`) must declare itself unobservable and is asserted
to be so, which stops it counting as evidence of order-independence. The
end-to-end case asserts each arm actually emitted its own strategy before
comparing answers.

Direction of failure is the point: these go red when ClickHouse's fold changes.
A red is the signal to re-derive the posture docs — and, if the fold became
order-independent, to close the upstream tracking.

Closes #2798

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ca2Fmjd48cPzhyHKT41XDQ
