### PR TITLE
fix(ci): bound a mutant's run, not its compile, and read the verdict from the output

### DIFF
--- a/.github/scripts/README.md
+++ b/.github/scripts/README.md
@@ -1013,7 +1013,11 @@ what actually runs.
   scales the result by the concurrent-mutant count and a named headroom. The
   flat budget it replaced bounded a `go test` child that is 80-98%
   COMPILATION, so a contended runner starved ordinary mutants into `TIMED OUT`
-  (#2903).
+  (#2903). The measured cycle is passed as BOTH of the fork's bounds — the
+  `--timeout-max` run leash and the `--compile-allowance` the compile is charged
+  to — because the probe cannot separate the run from the compile inside it and
+  the cycle is an upper bound on each (#2910). Their sum is the deadline
+  gremlins gives up at, which is what the memory guard's hold is sized from.
   - Env: `SCOPE`, `REPORT`, `MUTANT_TIMEOUT_MIN`, `MUTANT_TIMEOUT_MAX`
     (required); `WORKERS`, `EXCLUDE_FILES`, `DIFF_REF` (optional).
     `MUTANT_TIMEOUT_MIN` is the floor the measurement may raise but never

--- a/.github/scripts/mutation-run.mjs
+++ b/.github/scripts/mutation-run.mjs
@@ -1,6 +1,6 @@
 // mutation-run.mjs — run one mutation phase with safe changed-line fallback,
-// under a per-mutant budget MEASURED from this leg's own recompile+link+run
-// cycle on this runner.
+// under per-mutant bounds MEASURED from this leg's own recompile+link+run cycle
+// on this runner.
 //
 // Required env: SCOPE, REPORT, MUTANT_TIMEOUT_MIN, MUTANT_TIMEOUT_MAX.
 // Optional env: WORKERS, EXCLUDE_FILES, DIFF_REF.
@@ -22,12 +22,15 @@ import { fileURLToPath } from 'node:url';
 
 import { error, notice } from './lib/gh.mjs';
 
-// gremlins derives each mutant's deadline as
-// `min(timeout-coefficient * max(coverage_elapsed, 1s), timeout-max)`, and that
-// deadline wraps the WHOLE `go test` child — recompile, link and run. But
-// `coverage_elapsed` is the wall time of gremlins' own coverage pass, which is
-// dominated by COMPILATION, not by test time. So the derived budget tracks how
-// warm the Go build cache happened to be rather than anything about the tests:
+// gremlins derives each mutant's RUN bound as
+// `min(timeout-coefficient * max(coverage_elapsed, 1s), timeout-max)` and hands
+// it to `go test -timeout`, which the Go toolchain starts when the test binary
+// starts; the compile is charged to --compile-allowance instead, and the two
+// together are the context deadline that also bounds a hung compile (#2910).
+// But `coverage_elapsed` is the wall time of gremlins' own coverage pass, which
+// is dominated by COMPILATION, not by test time. So the derived budget tracks
+// how warm the Go build cache happened to be rather than anything about the
+// tests:
 // the zero-mutant fallback below re-invokes gremlins in the same job with the
 // cache already warmed by the first invocation, the coverage pass collapses
 // from ~50s to ~0.4s, `baseTime` clamps to gremlins' own 1s floor, and the
@@ -54,19 +57,37 @@ const gremlinsCoverageBaselineFloorSeconds = 1;
 // the honest direction.
 const perMutantRunnerVarianceHeadroom = 2;
 
+// perMutantBounds turns the one measured cycle into the two bounds gremlins
+// takes, and the deadline they add up to.
+//
+// The probe times a whole recompile+link+run cycle and cannot separate the run
+// from the compile inside it, so the same number serves both roles. That is
+// sound in both directions rather than merely convenient: the cycle is an UPPER
+// bound on the run it contains, so no honest mutant can be starved by the run
+// bound, and it is an upper bound on the compile too, so no honest compile can
+// reach the deadline. Erring high costs wall clock only on a mutant that has
+// already stopped being adjudicable.
+//
+// deadlineSeconds is what the guard's hold has to outlast, which is why it is
+// derived here rather than recomputed at each use.
+function perMutantBounds(budgetSeconds) {
+  const runSeconds = budgetSeconds;
+  const compileSeconds = budgetSeconds;
+  return { runSeconds, compileSeconds, deadlineSeconds: runSeconds + compileSeconds };
+}
+
 // perMutantResidentMemoryMax is the ceiling on ONE mutant's test binary,
 // enforced by .github/scripts/mutant-memory-guard.mjs (which see for the
 // mechanism and for why the breach is recorded as TIMED OUT rather than as a
 // kill).
 //
-// The wall-clock budget above bounds TIME and nothing else, and the two bounds
-// cannot be collapsed into one: `internal/logql/logpattern`'s
-// REMOVE_SELF_ASSIGNMENTS mutant at pattern.go:129 allocates at ~1.5 GiB/s
-// (measured: 5 GiB of RSS in 3.3s), so it exhausts a 16 GB runner in about ten
-// seconds — under MUTANT_TIMEOUT_MIN, and far under the ~63s its own compile
-// cycle makes the derivation ask for. Lowering the leash until it is memory-safe
-// would starve every honest mutant on the leg, which is the failure #2903 fixed
-// (#2919).
+// The wall-clock bounds above bound TIME and nothing else, and time cannot
+// stand in for memory: `internal/logql/logpattern`'s REMOVE_SELF_ASSIGNMENTS
+// mutant at pattern.go:129 allocates at ~1.5 GiB/s (measured: 5 GiB of RSS in
+// 3.3s), so it exhausts a 16 GB runner in about ten seconds — under
+// MUTANT_TIMEOUT_MIN, and far under the ~63s its own compile cycle makes the
+// derivation ask for. Lowering the leash until it is memory-safe would starve
+// every honest mutant on the leg, which is the failure #2903 fixed (#2919).
 //
 // The value is measured, not guessed. Peak RSS of an UNMUTATED test binary,
 // per mutation-phases.mjs scope, on an 8-core machine:
@@ -85,6 +106,12 @@ const perMutantResidentMemoryMax = '1GiB';
 // process group when its deadline fires, so the guard is normally reaped well
 // inside this; the grace exists only so a breach on a path with no deadline
 // behind it (gremlins' unmutated coverage run) cannot wedge the job.
+//
+// The deadline it is added to is the RUN bound plus the COMPILE allowance, not
+// the run bound alone. Adding the grace to only one of the two would leave the
+// hold expiring first, and a guard that gives up before gremlins does exits 0 —
+// booking a memory runaway as LIVED, a survivor nobody detected, instead of
+// TIMED OUT.
 const perMutantMemoryHoldGraceSeconds = 30;
 
 const goDurationUnitSeconds = { ns: 1e-9, us: 1e-6, ms: 1e-3, s: 1, m: 60, h: 3600 };
@@ -187,7 +214,8 @@ function measurePerMutantCycleSeconds(scope, capSeconds) {
   return Number(process.hrtime.bigint() - started) / 1e9;
 }
 
-// perMutantBudgetSeconds is the deadline handed to gremlins, in seconds.
+// perMutantBudgetSeconds is the measured per-mutant cycle, in seconds, from
+// which perMutantBounds derives both of gremlins' bounds.
 //
 // It is measured rather than declared because the thing it has to cover is a
 // COMPILE, and a compile's cost is a property of the package and the runner,
@@ -248,7 +276,7 @@ function reportTotal(path) {
 // enforce the bound. That is a hard failure rather than a silent unguarded run:
 // an unenforced memory ceiling is exactly the state #2919 describes, and it is
 // worse than no ceiling because it looks like one.
-function memoryGuardedEnv(budgetSeconds, ledger) {
+function memoryGuardedEnv(deadlineSeconds, ledger) {
   const guard = resolve(dirname(fileURLToPath(import.meta.url)), 'mutant-memory-guard.mjs');
   if (/\s/.test(guard)) {
     throw new Error(`the memory guard's path contains whitespace, which GOFLAGS cannot express: ${guard}`);
@@ -261,7 +289,7 @@ function memoryGuardedEnv(budgetSeconds, ledger) {
     ...process.env,
     GOFLAGS: `${goFlags === '' ? '' : `${goFlags} `}-exec=${guard}`,
     MUTANT_MEMORY_MAX: perMutantResidentMemoryMax,
-    MUTANT_MEMORY_HOLD: `${budgetSeconds + perMutantMemoryHoldGraceSeconds}s`,
+    MUTANT_MEMORY_HOLD: `${deadlineSeconds + perMutantMemoryHoldGraceSeconds}s`,
     MUTANT_MEMORY_LEDGER: ledger,
   };
 }
@@ -287,15 +315,18 @@ function reportMemoryBreaches(ledger) {
 }
 
 function runGremlins({ report, budgetSeconds, ledger, diffRef = '' }) {
+  const bounds = perMutantBounds(budgetSeconds);
   const args = [
     'unleash',
     '--output',
     report,
     '--on-shutdown-status=not-run',
     '--timeout-max',
-    `${budgetSeconds}s`,
+    `${bounds.runSeconds}s`,
+    '--compile-allowance',
+    `${bounds.compileSeconds}s`,
     '--timeout-coefficient',
-    perMutantBudgetIsTheCeilingCoefficient(budgetSeconds),
+    perMutantBudgetIsTheCeilingCoefficient(bounds.runSeconds),
   ];
   const workers = String(process.env.WORKERS ?? '').trim();
   if (workers !== '' && workers !== '0') {
@@ -309,7 +340,7 @@ function runGremlins({ report, budgetSeconds, ledger, diffRef = '' }) {
 
   const result = spawnSync('gremlins', args, {
     stdio: 'inherit',
-    env: memoryGuardedEnv(budgetSeconds, ledger),
+    env: memoryGuardedEnv(bounds.deadlineSeconds, ledger),
   });
   if (result.error) throw new Error(`cannot execute gremlins: ${result.error.message}`);
   if (result.status !== 0) throw new Error(`gremlins exited ${result.status}`);

--- a/.github/scripts/mutation-run.test.mjs
+++ b/.github/scripts/mutation-run.test.mjs
@@ -105,6 +105,17 @@ function budgetOf(args) {
   return args[args.indexOf('--timeout-max') + 1];
 }
 
+function allowanceOf(args) {
+  return args[args.indexOf('--compile-allowance') + 1];
+}
+
+// The deadline gremlins actually gives up at: the run bound plus the compile
+// allowance. Read from the argv rather than recomputed, so a change to how the
+// two are derived is reflected here instead of being duplicated.
+function deadlineSecondsOf(args) {
+  return Number(budgetOf(args).replace('s', '')) + Number(allowanceOf(args).replace('s', ''));
+}
+
 function environments(f) {
   const raw = readFileSync(f.envCalls, 'utf8').trim();
   return raw === '' ? [] : raw.split('\n').map(JSON.parse);
@@ -221,6 +232,10 @@ test('both invocations pin the per-mutant budget to the derived value', (t) => {
   assert.equal(calls.length, 2);
   for (const args of calls) {
     assert.equal(budgetOf(args), '15s');
+    // The compile allowance must be pinned on BOTH invocations for the same
+    // reason the run bound is: the fallback invocation runs against the cache
+    // the first one warmed, and a bound that silently shrinks there is #2692.
+    assert.equal(allowanceOf(args), '15s');
     const at = args.indexOf('--timeout-coefficient');
     assert.notEqual(at, -1, `--timeout-coefficient missing from ${JSON.stringify(args)}`);
     // gremlins clamps its measured coverage time up to a 1s floor, so
@@ -302,12 +317,29 @@ test('every gremlins invocation runs its mutants under the memory guard', (t) =>
 // The hold has to outlast the deadline it defers to. If it expired FIRST the
 // guard would exit 0 while gremlins was still waiting, and a memory-runaway
 // mutant would be booked LIVED-by-accident instead of TIMED OUT-on-purpose.
-test('the guard holds strictly longer than the per-mutant budget', (t) => {
-  const f = fixture(t, [4], { probeSeconds: 0 });
-  assert.equal(run(f, { DIFF_REF: '' }).status, 0);
-  const budget = Number(budgetOf(invocations(f)[0]).replace('s', ''));
-  const hold = Number(environments(f)[0].MUTANT_MEMORY_HOLD.replace('s', ''));
-  assert.ok(hold > budget, `the hold (${hold}s) must outlast the budget (${budget}s)`);
+//
+// The deadline is the run bound PLUS the compile allowance (#2910), not the run
+// bound alone. Sizing the hold from the run bound was correct only while one
+// number bounded compile and run together; against the split it expires an
+// allowance early, on exactly the mutants this guard exists for.
+//
+// Exercised at the lane's ceiling as well as its floor, because the two regimes
+// fail differently. At a 15s floor the grace alone is wider than the compile
+// allowance, so a hold that forgot the allowance still clears the deadline by
+// accident; at a 120s ceiling it does not, and the accident becomes the bug.
+test('the guard holds strictly longer than the deadline gremlins gives up at', (t) => {
+  for (const floor of ['15s', '120s']) {
+    const f = fixture(t, [4], { probeSeconds: 0 });
+    assert.equal(run(f, { DIFF_REF: '', MUTANT_TIMEOUT_MIN: floor }).status, 0);
+    const args = invocations(f)[0];
+    const deadline = deadlineSecondsOf(args);
+    const hold = Number(environments(f)[0].MUTANT_MEMORY_HOLD.replace('s', ''));
+    assert.ok(
+      deadline > Number(budgetOf(args).replace('s', '')),
+      `at a ${floor} floor the deadline must exceed the run bound, or the compile allowance is not reaching gremlins`,
+    );
+    assert.ok(hold > deadline, `at a ${floor} floor the hold (${hold}s) must outlast the deadline (${deadline}s)`);
+  }
 });
 
 // An existing GOFLAGS belongs to the toolchain setup, not to us. Replacing it

--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -164,7 +164,7 @@ jobs:
       # opaque `gremlins exited N` with no artifact and no measured-vs-threshold
       # numbers.
       #
-      # We consume gremlins via the tsouza/gremlins fork, which carries two
+      # We consume gremlins via the tsouza/gremlins fork, which carries three
       # fixes cerberus needs:
       #
       #   --on-shutdown-status=not-run   in-flight mutants killed by the
@@ -174,6 +174,13 @@ jobs:
       #
       #   --timeout-max                  an absolute ceiling on a single
       #     mutant's test run. See the `gremlins unleash` step below.
+      #
+      #   --compile-allowance            the run bound above now bounds only the
+      #     RUN, and this is what compiling the mutant is charged to. The fork
+      #     also reads a mutant's verdict from the child's output instead of its
+      #     exit status, because `go test` reports a failing test, a package
+      #     that does not build and a test that ran past its -timeout all as
+      #     exit 1 (#2910).
       # Routed through go-module-fetch.mjs because gremlins is NOT in go.mod, so
       # the warm step in ./.github/actions/setup-go — which runs
       # `go mod download` over the main module's own requirements — does not
@@ -186,7 +193,7 @@ jobs:
       - name: install gremlins
         run: >
           node .github/scripts/go-module-fetch.mjs --
-          go install github.com/tsouza/gremlins/cmd/gremlins@v0.6.0-cerberus-timeout-max-consume
+          go install github.com/tsouza/gremlins/cmd/gremlins@v0.6.0-cerberus-run-leash-consume
       # `workers: 0` keeps gremlins' default (runtime.NumCPU()); a
       # non-zero value caps the parallel `go test` fan-out per the
       # comment above the matrix entry.
@@ -198,20 +205,29 @@ jobs:
       # measured. MUTANT_TIMEOUT_MIN and MUTANT_TIMEOUT_MAX are the bounds that
       # measurement is clamped into, not the budget itself.
       #
-      # Measuring is the fix for #2903. A flat declared budget bounds a
-      # quantity it does not describe: it wraps the WHOLE `go test` child, which
-      # is a recompile, a link, and only then a run. Per mutant on an 8-core
-      # machine, against the flat 15s that used to be declared here:
+      # A mutant is bounded TWICE, and the measured cycle serves both. Per
+      # mutant on an 8-core machine, against the flat 15s that used to be
+      # declared here:
       #
       #   internal/chsql   compile+link 12.7-14.4s   test run 0.31s
       #   internal/promql  compile+link  8.4-8.7s    test run 2.07s
       #
-      # So the compiler was 80-98% of the budget, every contended runner pushed
-      # mutants over it, and gremlins recorded that as TIMED OUT — which the
-      # gate then scored as a detection, paying the leg efficacy points for
-      # being starved. gremlins-threshold.mjs no longer scores it that way, so
-      # an undersized budget is now visibly RED; this step is what keeps an
-      # honest leg from being red for the compiler's sake.
+      # One number could not bound both. The compiler was 80-98% of it, every
+      # contended runner pushed mutants over, and gremlins recorded that as
+      # TIMED OUT — which the gate then scored as a detection, paying the leg
+      # efficacy points for being starved (#2903). Measuring the cycle sized the
+      # number to what it was really bounding; the fork then stopped asking one
+      # number to bound two quantities at all (#2910). `--timeout-max` is now
+      # the RUN bound, handed to `go test -timeout`, which the Go toolchain
+      # starts when the test binary starts; `--compile-allowance` is what the
+      # compile is charged to; and their sum is the context deadline, which is
+      # all that can bound a compile that has hung.
+      #
+      # mutation-run.mjs passes the measured cycle as both, because the probe
+      # cannot separate the run from the compile inside it and the cycle is an
+      # upper bound on each — so neither bound can starve an honest mutant. An
+      # undersized budget is visibly RED rather than quietly scored as a
+      # detection, so erring high here is the cheap direction.
       #
       # MIN is the floor: a probe that cannot measure anything (no `go` on
       # PATH, a build error) leaves the lane on exactly the 15s it ran on

--- a/docs/test-strategy.md
+++ b/docs/test-strategy.md
@@ -1099,11 +1099,32 @@ spent its checkout and toolchain setup.
 
 ### Per-mutant time budget
 
-Each mutant's `go test` child runs under a deadline, because a mutant that
-inverts a loop advance never terminates and allocates per iteration; without a
-deadline the OOM killer reaps the runner and the leg reports no verdict at all.
+Each mutant is bounded twice, because there are two things to bound and they
+scale with unrelated quantities.
 
-That deadline is MEASURED, per leg, per run. `.github/scripts/mutation-run.mjs`
+`go test -timeout` bounds the test RUN. The Go toolchain starts that clock when
+the test binary starts, so compiling the mutated package cannot consume it. This
+is the leash that matters: a mutant that inverts a loop advance never terminates
+and allocates per iteration, and this is what stops it.
+
+A context deadline — the run bound plus a compile allowance — bounds compilation
+and the run together, as a backstop. No `-timeout` can bound a compile that has
+hung, because there is no test binary yet to enforce one.
+
+The split is the fix for #2910. Before it the fork had only the context
+deadline, and it was set BELOW the run leash, so the run leash could never fire
+and compile time was charged to the budget meant to bound execution. On a leg
+compiling in 12.7-15.8s against a 15s budget, a mutant whose test reached a
+verdict in 0.3s was recorded `TIMED OUT` having never run a line of test code.
+
+The other half of that fix is how a verdict is read. `go test` reports a failing
+test, a package that does not build and a test that ran past its `-timeout` all
+as exit status 1 — only the test *binary* exits 2, and gremlins spawns `go` — so
+the fork scans the child's output to tell them apart. Taking the exit status at
+face value credits a timeout as a detection and books a mutant that never
+compiled as one too.
+
+Both bounds are MEASURED, per leg, per run. `.github/scripts/mutation-run.mjs`
 times one mutant's worth of work before gremlins starts — it appends a byte to
 the largest production file in the leg's scope, runs the scope's tests exactly
 as gremlins runs them for a mutant (`-count=1 -failfast`), and restores the file
@@ -1114,10 +1135,17 @@ concurrently and by a named headroom multiple. The result is clamped into
 keyed on content, so timing an unedited package times a cache hit and measures
 nothing a mutant will ever pay.
 
-It is measured because the thing the deadline has to cover is a COMPILE, and a
-compile's cost is a property of the package and the runner rather than of the
-test suite. Measured per mutant on an 8-core machine, against the flat 15s the
-lane used to declare:
+The measured cycle is passed as BOTH bounds: as `--timeout-max` (the run leash)
+and as `--compile-allowance`. The probe times a whole recompile+link+run and
+cannot separate the run from the compile inside it, and the cycle is an upper
+bound on each of them, so neither bound can starve an honest mutant. Their sum
+is the deadline gremlins gives up at, and it is what the memory guard's hold is
+sized from — a hold that expired first would exit 0 and book a memory runaway as
+`LIVED` rather than `TIMED OUT`.
+
+It is measured because the dominant cost is a COMPILE, and a compile's cost is a
+property of the package and the runner rather than of the test suite. Measured
+per mutant on an 8-core machine, against the flat 15s the lane used to declare:
 
 | scope             | compile + link | test run |
 | ----------------- | -------------- | -------- |
@@ -1127,7 +1155,8 @@ lane used to declare:
 80-98% of the budget went to the compiler, so every contended runner pushed
 ordinary mutants over it and gremlins recorded them as `TIMED OUT` — which the
 gate then scored as detections (#2903, and the "Timed-out mutants" section
-below).
+below). Measuring sized the number to what it was really bounding; splitting the
+bounds stopped it having to bound both.
 
 `MUTANT_TIMEOUT_MIN` is the floor a measurement may raise but never lower, so a
 probe that cannot measure anything leaves the lane exactly where it was.
@@ -1135,7 +1164,7 @@ probe that cannot measure anything leaves the lane exactly where it was.
 spend the job's whole `timeout-minutes` on hung mutants — and a leg that hits
 that job timeout reports `cancelled`, which the `mutation` aggregator fails.
 
-gremlins itself computes the deadline as
+gremlins itself computes the run bound as
 `min(timeout-coefficient x max(coverage_elapsed, 1s), timeout-max)`, where
 `coverage_elapsed` is the wall time of its own coverage pass — the same
 compile-dominated quantity, but taken on whatever build-cache warmth the

--- a/docs/toolchain.md
+++ b/docs/toolchain.md
@@ -49,11 +49,12 @@ because that rule has no auto-fixer of its own.
 `mutation.yml` installs the `tsouza/gremlins` fork rather than upstream `go-gremlins/gremlins@v0.6.0`:
 
 ```bash
-go install github.com/tsouza/gremlins/cmd/gremlins@v0.6.0-cerberus-timeout-max-consume
+go install github.com/tsouza/gremlins/cmd/gremlins@v0.6.0-cerberus-run-leash-consume
 ```
 
-Both fixes it carries exist because a mutation run that dies mid-flight is worse than one that
-reports a bad number: it reports nothing at all.
+The fixes it carries defend one thing between them: that the number a run reports is a number the
+tests earned. A run that dies mid-flight reports nothing at all; a run that credits the compiler
+reports something worse than nothing.
 
 **`--on-shutdown-status`, for mutants cancelled in flight.** Upstream's signal handler closes the
 channel that `os/signal` still writes to, so a second signal — the typical CI runner sequence of
@@ -74,20 +75,41 @@ time. A mutant that inverts a scanner's loop advance (`i++` to `i--`) never term
 per iteration, so on a slow-baseline package it gets minutes to exhaust the runner's memory; the OOM
 killer then reaps the runner and the job ends with no verdict. Measured across 91 heavy runs, all 55
 runner deaths were stalled on a lexer or scanner mutant. `--timeout-max` bounds exposure absolutely,
-independent of the baseline; cerberus passes `--timeout-max 15s`.
+independent of the baseline; cerberus derives its value per leg and clamps it into
+`[MUTANT_TIMEOUT_MIN, MUTANT_TIMEOUT_MAX]`, declared in `mutation.yml`.
 
 A recurrence is not fixed by excluding the file the log names. Excluding a file relocates its runaway
 mutants into whichever leg still owns it and burns real mutation coverage at the same time.
 `test/regression/mutation_timeout_max_test.go` pins the flag and the fork tag together, because the
 failure mode it prevents presents as flake rather than as a missing bound.
 
+**`--compile-allowance`, and verdicts read from the output rather than the exit status.** Upstream
+bounds a mutant with one number, a context deadline wrapping the whole `go test` child, and sets
+`go test`'s own run-only `-timeout` two seconds ABOVE it — so the run leash is structurally
+unreachable and compile time is charged to the budget meant to bound execution. Measured on cerberus:
+12.7-15.8s of compile against a 15s budget while the test itself reaches a verdict in 0.3-2.1s, so
+mutants were recorded `TIMED OUT` having never run. The fork hands the bound to `go test -timeout`,
+whose clock starts when the test binary starts, and keeps the context deadline — widened by
+`--compile-allowance` — as the backstop for a compile that has hung, since no `-timeout` can bound
+one.
+
+Letting Go's `-timeout` win that race is only safe with the second half. `go test` collapses a
+failing test, a package that does not build and a test that ran past its `-timeout` into its own exit
+status 1; only the test *binary* exits 2, and what gremlins spawns is `go`. Reading that 1 at face
+value credits a timeout as a KILL and books a mutant that never compiled as one too. The fork scans
+the child's output instead — the `panic: test timed out after` line maps to `TIMED OUT`,
+`[build failed]` and `[setup failed]` map to `NOT VIABLE`, and anything else is left to the exit
+status. `TIMED OUT` stays in the efficacy denominator and credits nobody, so a slow test cannot buy
+a score. The scan is streaming and retains only enough bytes to recognise a marker split across two
+writes, so a mutant that prints without bound cannot exhaust memory.
+
 `.gremlins.yaml`'s `exclude-files` paths are interpreted relative to the run's scope, not the repo
 root, and the matcher is RE2 with no lookahead. A path in the wrong form silently excludes nothing.
 
-The fork ships two branches on purpose. `cerberus-sigterm-fix` at tag `v0.6.0-cerberus-timeout-max`
+The fork ships two branches on purpose. `cerberus-sigterm-fix` at tag `v0.6.0-cerberus-run-leash`
 is the branch the upstream pull request is built from, and keeps the upstream module path
 `github.com/go-gremlins/gremlins` so the diff stays reviewable.
-`cerberus-sigterm-fix-consume` at tag `v0.6.0-cerberus-timeout-max-consume` is the branch
+`cerberus-sigterm-fix-consume` at tag `v0.6.0-cerberus-run-leash-consume` is the branch
 `mutation.yml` installs; it adds one commit renaming the `go.mod` module path to
 `github.com/tsouza/gremlins` and rewriting the internal imports, because `go install` otherwise
 rejects the module with `module declares its path as: github.com/go-gremlins/gremlins`. The fixes

--- a/test/regression/mutation_timeout_max_test.go
+++ b/test/regression/mutation_timeout_max_test.go
@@ -40,10 +40,18 @@ const (
 	timeoutMinDeclaration    = "MUTANT_TIMEOUT_MIN:"
 )
 
-// gremlinsForkTagPrefix is the fork tag family that supports timeoutMaxFlag.
-// The flag landed in the fork; a tag from before it makes gremlins reject the
-// argument outright.
-const gremlinsForkTagPrefix = "github.com/tsouza/gremlins/cmd/gremlins@v0.6.0-cerberus-timeout-max"
+// gremlinsForkTagPrefix is the fork tag family that supports timeoutMaxFlag AND
+// spends it on the right quantity. A tag from before the flag landed makes
+// gremlins reject the argument outright; a tag from the `timeout-max` family
+// accepts it but charges compilation to it, which is #2910: the deadline wrapped
+// the whole `go test` child, so on a package that takes 13-16s to compile
+// against a 15s budget a mutant whose test decides in 0.3s was recorded TIMED
+// OUT having never run. The `run-leash` family passes the bound to
+// `go test -timeout`, which the Go toolchain starts when the test binary starts,
+// and reads the verdict from the child's output rather than its exit status --
+// `go test` reports a failing test, a build failure and a test timeout all as
+// exit 1, so taking that at face value credits a timeout as a detection.
+const gremlinsForkTagPrefix = "github.com/tsouza/gremlins/cmd/gremlins@v0.6.0-cerberus-run-leash"
 
 // TestMutationLaneCapsPerMutantTimeout (#1294) pins the one bound that keeps the
 // mutation lane from killing its own runner.
@@ -107,8 +115,10 @@ func TestMutationLaneCapsPerMutantTimeout(t *testing.T) {
 	}
 
 	if !strings.Contains(body, gremlinsForkTagPrefix) {
-		t.Errorf("%s does not install a %s* build of gremlins. Earlier fork tags reject %s as an "+
-			"unknown flag, so the lane would fail on every leg rather than run unbounded — loud, but "+
-			"still broken.", mutationWorkflowPath, gremlinsForkTagPrefix, timeoutMaxFlag)
+		t.Errorf("%s does not install a %s* build of gremlins. Fork tags older than the flag reject %s "+
+			"outright, so the lane fails on every leg — loud, but still broken. Tags between the flag "+
+			"and the run-only leash are worse than loud: they accept the bound and then spend it on the "+
+			"compiler, so a mutant times out having never run a line of test code and the leg loses "+
+			"efficacy points it earned (#2910).", mutationWorkflowPath, gremlinsForkTagPrefix, timeoutMaxFlag)
 	}
 }


### PR DESCRIPTION
Closes #2910

## The defect

`tsouza/gremlins` bounded a mutant with one number. `internal/engine/executor.go:274` wrapped the
whole `go test` child — resolve, compile, link, and only then run — in a context deadline, and
`executor.go:330` set Go's own run-only `-timeout` two seconds **above** it:

```go
ctx, cancel := context.WithTimeout(m.runCtx, m.testExecutionTime)
args = append(args, "-timeout", (2*time.Second + m.testExecutionTime).String())
```

So the run-only leash was structurally unreachable, and compile time was charged to the budget meant
to bound execution. Measured on cerberus: 12.7–15.8s of compile against a 15s budget while the test
itself reaches a verdict in 0.3–2.1s. Mutants were recorded `TIMED OUT` having never run a line of
test code, and #2917 measured two legs as arithmetically unable to reach the 95% floor because of it.

## The exit-code correction, verified independently

The issue's original diagnosis said a Go test timeout exits 2 and would land in
`getTestFailedStatus`'s `case 2: NotViable`. That is wrong, and the correction on the issue is right.
Measured here on Go 1.26.2, against three throwaway packages:

| case | `go test` exit | distinguishing output |
| ---------------- | -------------- | ---------------------------------------- |
| failing test | 1 | `--- FAIL: TestF` |
| build error | 1 | `FAIL pkg [build failed]` |
| test timeout | 1 | `panic: test timed out after 2s` |

Only the test **binary** exits 2, and gremlins spawns `go`. So `case 2: NotViable` is unreachable
through `go test`, a build failure has been recorded as **KILLED** all along, and naively letting
Go's `-timeout` fire first would have put every timeout into KILLED — inside the efficacy denominator
and credited. That is #2903's defect returning by another route.

## The fork change

`tsouza/gremlins`, on `cerberus-sigterm-fix` and carried to `cerberus-sigterm-fix-consume`:

- **`go test -timeout` carries the run bound verbatim.** The Go toolchain starts that clock when the
  test binary starts, so a slow compile cannot eat it.
- **The context deadline becomes `run bound + --compile-allowance`** (default `2m`) and stays as the
  backstop. No `-timeout` can bound a compile that has hung — there is no test binary yet to enforce
  one. It is still rooted in the engine's `runCtx`, so SIGTERM still reports the shutdown status.
- **The verdict is read from the child's output, not the exit status.** `panic: test timed out
  after ` → `TimedOut`; `[build failed]` / `[setup failed]` → `NotViable`; anything else left to the
  exit code. The scan is streaming and retains only enough bytes to recognise a marker split across
  two writes, so a mutant that prints without bound cannot exhaust memory; `cmd.WaitDelay` bounds the
  pipe drain.

New tags: `v0.6.0-cerberus-run-leash` and `v0.6.0-cerberus-run-leash-consume`.

### The four directions, proven independently

Against the **real** toolchain in a throwaway module rather than a stubbed exec, because a stub
asserting exit codes would be asserting a fiction:

| direction | verdict |
| ------------------------------------ | ------------ |
| a test that does not terminate | `TIMED OUT` |
| a mutant that does not compile | `NOT VIABLE` |
| a failing test | `KILLED` |
| a passing suite | `LIVED` |

Plus a fifth pair that states the fix as behaviour: the same package compiled with an **empty build
cache**, once with a compile allowance (→ `LIVED`) and once with none (→ `TIMED OUT` from the
backstop). The first half fails if the cold compile did not actually outlast the run bound, so it
cannot pass vacuously on a machine where the two were never in tension.

Each gate was checked by breaking the mechanism:

| mutation | result |
| ------------------------------------------------- | ------------------------------------------ |
| drop the timeout-marker branch | timeout → `KILLED` — the correction, live |
| drop the build-failure branch | uncompilable → `KILLED` |
| revert `-timeout` to the `+2s` form | 31 argv/deadline assertions fail |
| context deadline back to the run bound alone | `expected LIVED after a 2.01s compile against a 2s run bound, got TIMED OUT` |
| scanner keeps no tail between writes | split-marker case fails |

## The cerberus change

- `mutation.yml` installs `@v0.6.0-cerberus-run-leash-consume`.
- `mutation-run.mjs` passes the measured cycle as **both** bounds — `--timeout-max` and
  `--compile-allowance`. The probe times a whole recompile+link+run and cannot separate the run from
  the compile inside it; the cycle is an upper bound on each, so neither bound can starve an honest
  mutant.
- **The memory guard's hold is resized.** `MUTANT_MEMORY_HOLD` was `budget + grace`, sized to
  gremlins' deadline back when the budget *was* the deadline. Against the split it would expire a
  compile allowance early, and a guard that gives up before gremlins does exits 0 — booking a memory
  runaway from #2921 as `LIVED`, a survivor nobody detected, instead of `TIMED OUT`. It is now sized
  from `run bound + compile allowance + grace`, and its test runs at the lane's ceiling as well as
  its floor: at a 15s floor the grace alone is wider than the allowance, so a hold that forgot the
  allowance still cleared the deadline by accident and the old assertion passed.
- `test/regression/mutation_timeout_max_test.go` pins the new tag family, and says why a tag between
  the flag and the run-only leash is worse than one from before the flag: it accepts the bound and
  then spends it on the compiler.
- `docs/toolchain.md`, `docs/test-strategy.md` and `.github/scripts/README.md` describe the two
  bounds and the output-derived verdicts.

## Expected effect on #2917

Timeouts are the entire remaining gap on two legs. Killing every remaining survivor left
`logql-lsyntax` at 94.87% and `qlcommon` at 94.85% — each one mutant short of the 95.00% floor,
because `killed / (killed + lived + timedOut)` counts a starved mutant in the denominator and credits
nobody for it. A compile no longer spends the run leash, so a mutant that reaches a verdict in
milliseconds now reaches it; each timeout that becomes a real verdict moves a unit out of the
denominator-only column. Both legs clear the floor if their timeouts were starvation rather than
non-termination, which is what the 0.3–2.1s run costs against 12.7–15.8s compiles say they were. The
lane run on this PR is the measurement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
