### PR TITLE
fix(ci): stop paying every mutation leg for mutants the compiler rejected

### DIFF
--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -181,6 +181,17 @@ jobs:
       #     exit status, because `go test` reports a failing test, a package
       #     that does not build and a test that ran past its -timeout all as
       #     exit 1 (#2910).
+      #
+      #   prefix operators read as prefix operators
+      #     gremlins' token table describes the INFIX meaning of each operator,
+      #     and it was applied to `*ast.UnaryExpr` too. On this tree, whose
+      #     plan-building code is mostly `&chplan.Foo{...}` composite literals,
+      #     INVERT_BITWISE turned every one of them into `|chplan.Foo{...}` —
+      #     source that does not parse. Those mutants were then booked KILLED
+      #     off the same exit status 1, so each leg was paid efficacy for work
+      #     the compiler did: `Not viable: 0` on every leg was the tell that the
+      #     status had never once been reported. The fork no longer generates
+      #     them (#2930).
       # Routed through go-module-fetch.mjs because gremlins is NOT in go.mod, so
       # the warm step in ./.github/actions/setup-go — which runs
       # `go mod download` over the main module's own requirements — does not
@@ -193,7 +204,7 @@ jobs:
       - name: install gremlins
         run: >
           node .github/scripts/go-module-fetch.mjs --
-          go install github.com/tsouza/gremlins/cmd/gremlins@v0.6.0-cerberus-run-leash-consume
+          go install github.com/tsouza/gremlins/cmd/gremlins@v0.6.0-cerberus-unary-operators-consume
       # `workers: 0` keeps gremlins' default (runtime.NumCPU()); a
       # non-zero value caps the parallel `go test` fan-out per the
       # comment above the matrix entry.

--- a/docs/toolchain.md
+++ b/docs/toolchain.md
@@ -49,7 +49,7 @@ because that rule has no auto-fixer of its own.
 `mutation.yml` installs the `tsouza/gremlins` fork rather than upstream `go-gremlins/gremlins@v0.6.0`:
 
 ```bash
-go install github.com/tsouza/gremlins/cmd/gremlins@v0.6.0-cerberus-run-leash-consume
+go install github.com/tsouza/gremlins/cmd/gremlins@v0.6.0-cerberus-unary-operators-consume
 ```
 
 The fixes it carries defend one thing between them: that the number a run reports is a number the
@@ -103,13 +103,29 @@ status. `TIMED OUT` stays in the efficacy denominator and credits nobody, so a s
 a score. The scan is streaming and retains only enough bytes to recognise a marker split across two
 writes, so a mutant that prints without bound cannot exhaust memory.
 
+**Prefix operators read as prefix operators.** gremlins maps each `token.Token` to the mutations
+that make sense for it, and that table describes the operator's *infix* meaning — but the same walk
+reads `*ast.UnaryExpr` too. Go spells four operators identically in both positions and means
+something different by each, so two of them were mutated against the wrong meaning: `&x` is
+address-of rather than bitwise AND, and `INVERT_BITWISE` rewrote it to `|x`, which does not parse;
+`^x` is bitwise complement rather than XOR, and the same rule rewrote it to `&x`, which no longer has
+the operand's type. On this tree, whose plan-building code is largely `&chplan.Foo{...}` composite
+literals, that was most of a package's mutants — and every one of them arrived as exit status 1 and
+was booked `KILLED`, so each leg was paid efficacy for work the compiler did. The fork consults the
+table only for the prefix operators whose infix mutations carry over unchanged, `+x` and `-x`.
+
+Removing those mutants rather than reclassifying them is what makes a mutant set mean something: a
+leg's honest score is identical either way, since `NOT VIABLE` leaves both sides of the ratio, but a
+set padded with entries no compiler accepts measures nothing. The `NOT VIABLE` classification stays
+for a genuine build failure from any other source.
+
 `.gremlins.yaml`'s `exclude-files` paths are interpreted relative to the run's scope, not the repo
 root, and the matcher is RE2 with no lookahead. A path in the wrong form silently excludes nothing.
 
-The fork ships two branches on purpose. `cerberus-sigterm-fix` at tag `v0.6.0-cerberus-run-leash`
-is the branch the upstream pull request is built from, and keeps the upstream module path
-`github.com/go-gremlins/gremlins` so the diff stays reviewable.
-`cerberus-sigterm-fix-consume` at tag `v0.6.0-cerberus-run-leash-consume` is the branch
+The fork ships two branches on purpose. `cerberus-sigterm-fix` at tag
+`v0.6.0-cerberus-unary-operators` is the branch the upstream pull request is built from, and keeps
+the upstream module path `github.com/go-gremlins/gremlins` so the diff stays reviewable.
+`cerberus-sigterm-fix-consume` at tag `v0.6.0-cerberus-unary-operators-consume` is the branch
 `mutation.yml` installs; it adds one commit renaming the `go.mod` module path to
 `github.com/tsouza/gremlins` and rewriting the internal imports, because `go install` otherwise
 rejects the module with `module declares its path as: github.com/go-gremlins/gremlins`. The fixes

--- a/test/regression/mutation_timeout_max_test.go
+++ b/test/regression/mutation_timeout_max_test.go
@@ -40,18 +40,34 @@ const (
 	timeoutMinDeclaration    = "MUTANT_TIMEOUT_MIN:"
 )
 
-// gremlinsForkTagPrefix is the fork tag family that supports timeoutMaxFlag AND
-// spends it on the right quantity. A tag from before the flag landed makes
-// gremlins reject the argument outright; a tag from the `timeout-max` family
-// accepts it but charges compilation to it, which is #2910: the deadline wrapped
-// the whole `go test` child, so on a package that takes 13-16s to compile
-// against a 15s budget a mutant whose test decides in 0.3s was recorded TIMED
-// OUT having never run. The `run-leash` family passes the bound to
-// `go test -timeout`, which the Go toolchain starts when the test binary starts,
-// and reads the verdict from the child's output rather than its exit status --
-// `go test` reports a failing test, a build failure and a test timeout all as
-// exit 1, so taking that at face value credits a timeout as a detection.
-const gremlinsForkTagPrefix = "github.com/tsouza/gremlins/cmd/gremlins@v0.6.0-cerberus-run-leash"
+// gremlinsForkTag is the exact fork build this lane has been verified against.
+// It is pinned whole rather than by family prefix because a tag name carries no
+// ordering: "which tags are new enough" is not something a prefix can express,
+// and every fork family so far has changed a verdict semantic this lane's
+// numbers depend on. Bumping the fork therefore has to touch this line, which
+// is the point -- the bump gets read against the list below rather than sliding
+// through on a matching prefix.
+//
+// What each family in that history fixed, oldest first:
+//
+//   - before --timeout-max: gremlins rejects the argument outright, so the lane
+//     fails on every leg. Loud, but still broken.
+//   - the `timeout-max` family: accepts the bound and then charges compilation
+//     to it (#2910). The deadline wrapped the whole `go test` child, so on a
+//     package taking 13-16s to compile against a 15s budget, a mutant whose
+//     test decides in 0.3s was recorded TIMED OUT having never run.
+//   - the `run-leash` family: passes the bound to `go test -timeout`, which the
+//     Go toolchain starts when the test BINARY starts, and reads the verdict
+//     from the child's output rather than its exit status. `go test` reports a
+//     failing test, a build failure and a test timeout all as exit 1, so taking
+//     that at face value credits both of the latter as detections.
+//   - the `unary-operators` family (#2930): stops mutating a prefix operator
+//     against the infix meaning of its token. INVERT_BITWISE was rewriting
+//     every `&chplan.Foo{...}` to `|chplan.Foo{...}`, which does not parse, and
+//     the exit-status collapse above then booked each one KILLED. `Not viable:
+//     0` on every leg was the tell: the status had never once been reported,
+//     and three legs measured 52, 57 and 88 lost kills apiece once it was.
+const gremlinsForkTag = "github.com/tsouza/gremlins/cmd/gremlins@v0.6.0-cerberus-unary-operators-consume"
 
 // TestMutationLaneCapsPerMutantTimeout (#1294) pins the one bound that keeps the
 // mutation lane from killing its own runner.
@@ -114,11 +130,13 @@ func TestMutationLaneCapsPerMutantTimeout(t *testing.T) {
 		}
 	}
 
-	if !strings.Contains(body, gremlinsForkTagPrefix) {
-		t.Errorf("%s does not install a %s* build of gremlins. Fork tags older than the flag reject %s "+
-			"outright, so the lane fails on every leg — loud, but still broken. Tags between the flag "+
-			"and the run-only leash are worse than loud: they accept the bound and then spend it on the "+
-			"compiler, so a mutant times out having never run a line of test code and the leg loses "+
-			"efficacy points it earned (#2910).", mutationWorkflowPath, gremlinsForkTagPrefix, timeoutMaxFlag)
+	if !strings.Contains(body, gremlinsForkTag) {
+		t.Errorf("%s does not install %s. Fork tags older than the flag reject %s outright, so the lane "+
+			"fails on every leg — loud, but still broken. Every tag after it is worse than loud: the "+
+			"`timeout-max` family spends the bound on the compiler, so a mutant times out having never "+
+			"run a line of test code (#2910), and everything before `unary-operators` mutates a prefix "+
+			"`&` as if it were bitwise AND, so mutants that cannot parse are booked as detections and "+
+			"the leg is paid efficacy for the compiler's work (#2930).",
+			mutationWorkflowPath, gremlinsForkTag, timeoutMaxFlag)
 	}
 }


### PR DESCRIPTION
## The bug

gremlins maps each `token.Token` to the mutations that make sense for it, and that table describes
the operator's **infix** meaning. The same AST walk reads `*ast.UnaryExpr` too. Go spells four
operators identically in prefix and infix position and means something different by each, so two of
them were being mutated against the wrong meaning:

| prefix form | what it means | `INVERT_BITWISE` rewrites it to | what the compiler says |
| ----------- | ------------- | ------------------------------- | ---------------------- |
| `&x` | address-of | `\|x` | `syntax error: unexpected \|, expected expression` |
| `^x` | bitwise complement | `&x` | `cannot use &u (value of type *uint) as uint value` |

On this tree the first is not an edge case. The plan-building code across all three heads is largely
`&chplan.Foo{...}` composite literals, so a large share of a package's mutants could not compile at
all.

`go test` folds a build failure into the same exit status **1** as a failing test — only the test
*binary* exits 2, and gremlins spawns `go`. So every one of those mutants was booked `KILLED`: the
suite credited with a detection against source that a compiler rejected. `Not viable: 0` on every
leg was the tell that the status had never once been reported.

## Why classifying was necessary and is not the fix

PR #2929 taught the fork to read `[build failed]` from the child's output and record `NOT VIABLE`.
Measured on the same corpus, three legs lost exactly as many kills as they gained `NOT VIABLE`
records: `97 − 45 = 52`, `265 − 208 = 57`, `449 − 361 = 88`.

But `NOT VIABLE` leaves **both** sides of the efficacy ratio, so a leg's honest score is identical
whether those mutants are classified or never generated — `45 / 49` either way. What differs is
whether the leg's mutant set means anything. A set padded with entries no compiler accepts measures
nothing.

So the root fix is at the mutator. `NodeToken` now records the position it read a token in, and
`MutantTypesFor` consults the table only for the prefix operators whose infix mutations carry over
unchanged: `+x` and `-x`, which are the same sign arithmetic in both positions. The `NOT VIABLE`
classification stays, for a genuine build failure arriving from any other source.

## The gate

The fork's new `TestEveryGeneratedMutantCompiles` is a gate on the **whole** mutation table, not on
these two operators. It builds a package exercising every operator gremlins maps — prefix and infix
spelling of each where Go admits both — applies every generated mutant to it and hands the result to
the real compiler.

Reverting `MutantTypesFor` fails it with exactly the two diagnostics above, named at their source
positions:

```text
INVERT_BITWISE at zoo.go:5:40 produced a mutant the compiler rejects:
  ./zoo.go:5:35: syntax error: unexpected |, expected expression
  func Address(i int) *int { return |i }
INVERT_BITWISE at zoo.go:7:40 produced a mutant the compiler rejects:
  ./zoo.go:7:39: cannot use &u (value of type *uint) as uint value in return statement
  func Complement(u uint) uint { return &u }
```

The four-direction verdict proof from PR #2929 still holds on the new tag, and each direction was
re-verified by breaking its mechanism:

| direction | verdict | breaking the mechanism gives |
| --------- | ------- | ---------------------------- |
| a passing test | `LIVED` | — |
| a failing test | `KILLED` | `expected KILLED, got LIVED` |
| a mutant that does not compile | `NOT VIABLE` | `expected NOT VIABLE, got KILLED` |
| a test that does not terminate | `TIMED OUT` | `expected TIMED OUT, got KILLED` |

The two `got KILLED` rows are the exit-1 collapse itself, reproduced on demand.

## What lands here

- `.github/workflows/mutation.yml` installs `v0.6.0-cerberus-unary-operators-consume`.
- `test/regression/mutation_timeout_max_test.go` pins the fork build **whole** rather than by family
  prefix. A tag name carries no ordering, so "new enough" is not something a prefix can express, and
  every fork family so far has changed a verdict semantic this lane's numbers depend on. Bumping the
  fork now has to touch that line, which is the point.
- `docs/toolchain.md` records the fix alongside the other three the fork carries.

Fork branches, both tagged: `cerberus-sigterm-fix` at `v0.6.0-cerberus-unary-operators` (upstream
module path, reviewable diff) and `cerberus-sigterm-fix-consume` at
`v0.6.0-cerberus-unary-operators-consume` (the build `mutation.yml` installs).

## Measured on the lane, not only in the fork

Full matrix on this PR, run
[33627189201](https://github.com/tsouza/cerberus/actions/runs/33627189201), against the honest
baseline that PR #2929 established, run
[33611413378](https://github.com/tsouza/cerberus/actions/runs/33611413378). Counted out of the
uploaded `gremlins.json` reports across all 30 legs:

| | before | after |
| --- | ---: | ---: |
| mutants generated | 10728 | 7063 |
| `NOT VIABLE` — `INVERT_BITWISE` | 3511 | **0** |
| `NOT VIABLE` — every other mutator | 234 | 234 |
| `KILLED` | 5614 | 5619 |
| `LIVED` | 242 | 241 |
| `TIMED OUT` | 65 | 62 |

3511 mutants no compiler accepts are gone; the four other non-viable mutators are unchanged to the
record, which is the control that says nothing else moved; and the adjudicated columns shift by 5, 1
and 3 — main advancing past the baseline by #2926 and #2928, plus timeout jitter.

**No leg's score moved**, which is the whole argument: classifying a non-viable mutant and never
generating it produce the same ratio. `phase4-logql-other-a` is the leg the issue measured, and it
reads the same 45 killed, 4 lived, 91.84% as it did under classification alone — over 51 mutants
now rather than 103.

The 234 that remain are three further mechanisms with one root — a type-illegal operator, a mutant
`go test`'s own vet pass rejects, and `break` becoming `continue` outside a loop. Each was
reproduced against the real toolchain and the finding is measured in issue #2933. They sit outside
both sides of the ratio, so they change no leg's number.

The corrected per-leg arithmetic — 15 legs below the floor, 57 kills to clear the 13 that are
reachable, and the two that are not — is posted to #2917, whose own tables were read off the
credited corpus.

## The floor is not touched

Legs that were green on the credited numbers are red on the honest ones. That is the correct
outcome: the green was paid for by the compiler, not earned by the tests. No threshold is lowered,
no denominator shrunk, no file excluded. Closing the gaps the honest corpus exposes is the work
tracked by issue #2917, against a corpus several points below where that issue measured it.

Closes #2930

🤖 Generated with [Claude Code](https://claude.com/claude-code)
