### PR TITLE
ci: repoint the release-gate drift lane at the ruleset API and make it able to run

### DIFF
--- a/.github/scripts/README.md
+++ b/.github/scripts/README.md
@@ -1116,35 +1116,57 @@ what actually runs.
   `RELEASE_REQUIRED_CHECKS` + `RELEASE_INFORMATIONAL_CHECKS` out of release.yml
   itself (one copy of the data, one parser; an empty parse throws rather than
   comparing against nothing) and checks two directions the preflight structurally
-  cannot see from the inside. PROTECTION DRIFT: a live branch-protection required
-  context in neither list is a lane every PR must pass and the release does not
-  wait for — the dangerous direction, and invisible to an allow-list of names to
-  wait for. LANE DRIFT: a required name that posted no check-run anywhere in the
-  scanned commit window no longer matches a lane, so the next release waits out
-  its full window and aborts mid-publish. The window spans many commits because a
-  single commit's check-runs are a subset of the lane inventory (a docs-only push
-  skips `check`); absent from every commit means dead, not skipped. PIN DRIFT:
-  set equality between the live contexts and `branchProtectionContexts`, the
-  repo's own pin of them in `test/regression/release_required_checks_test.go`.
-  Every in-tree gate reasons off that pin because the endpoint needs repo-admin
-  rights no test token has, so a pinned-but-unenforced context is a lane that
-  posts green on every PR while contributing nothing to the merge decision — and
-  nothing else in the tree can tell. Pure exported `parseBlockScalar` /
-  `parseCheckLists` / `parsePinnedContexts` / `protectionDrift` / `laneDrift` /
-  `pinnedProtectionDrift` / `readBranchProtection` plus a `--self-test` the job
-  runs first. The self-test rejects missing credentials, HTTP 403, empty, and
-  malformed protection data rather than treating any as a clean empty set.
-  - Env: `GITHUB_TOKEN` (least-privilege commit/check/status reads),
-    `BRANCH_PROTECTION_TOKEN` (dedicated repository-administration read
-    credential, confined to the protection request), `GITHUB_REPOSITORY`,
-    `GITHUB_API_URL` (default
+  cannot see from the inside. PROTECTION DRIFT: a live required context in
+  neither list is a lane every PR must pass and the release does not wait for —
+  the dangerous direction, and invisible to an allow-list of names to wait for.
+  LANE DRIFT: a required name that posted no check-run anywhere in the scanned
+  commit window no longer matches a lane, so the next release waits out its full
+  window and aborts mid-publish. The window spans many commits because a single
+  commit's check-runs are a subset of the lane inventory (a docs-only push skips
+  `check`); absent from every commit means dead, not skipped. It also spans every
+  PAGE of each commit's check-runs — a busy `main` commit carries ~150 across
+  ~26 check suites, and a first-page-only read reported the healthy
+  `forbid-deferral` lane as dead. PIN DRIFT: set equality between the live
+  contexts and `branchProtectionContexts`, the repo's own pin of them in
+  `test/regression/release_required_checks_test.go`. Every in-tree gate reasons
+  off that pin because a Go test does not reach the network, so a
+  pinned-but-unenforced context is a lane that posts green on every PR while
+  contributing nothing to the merge decision — and nothing else in the tree can
+  tell.
+  The live set is read from `GET /repos/{owner}/{repo}/rules/branches/{branch}`,
+  the RULESET API: this repository's legacy branch-protection object was replaced
+  by a ruleset and deleted, so `branches/{branch}/protection` answers `404`. That
+  endpoint returns the flattened rules in force, each tagged with the
+  `ruleset_id` that contributed it, and more than one ruleset can match a branch
+  (a second one governs `refs/heads/release/*.x`) — so the governing set is the
+  UNION across every `required_status_checks` rule, and rule types the script
+  does not model (`deletion`, `non_fast_forward`, `pull_request`, `merge_queue`)
+  are ignored by type rather than by position. It needs no elevated credential:
+  the read is served to `${{ github.token }}`, so the lane depends on NO secret.
+  It used to depend on a `BRANCH_PROTECTION_TOKEN` that was never provisioned,
+  which left the pin comparison without a single verdict from 2026-08-04 to
+  2026-09-01; `TestReleaseGateDriftDetectorRunsLiveAndNotSelfTestOnly` now
+  rejects any secret reference or `if:` guard in the workflow for that reason.
+  Pure exported `parseBlockScalar` / `parseCheckLists` / `parsePinnedContexts` /
+  `protectionDrift` / `laneDrift` / `pinnedProtectionDrift` / `describeRulesets`
+  / `rulesetContexts` / `apiPaged` / `readRequiredContexts` plus a `--self-test`
+  the job runs first, and `ci.yml` runs on every PR. The self-test pins a
+  RECORDED rules-endpoint response so a further shape change fails a test rather
+  than a Monday cron nobody reads, and rejects a missing token, HTTP 403, a
+  non-list payload, a branch with no `required_status_checks` rule, malformed
+  parameters, a non-string context and a zero-context rule rather than treating
+  any of them as a clean empty set.
+  - Env: `GITHUB_TOKEN` (the only credential — least-privilege workflow token,
+    used for the ruleset read as well as the commit/check/status reads),
+    `GITHUB_REPOSITORY`, `GITHUB_API_URL` (default
     `https://api.github.com`), `DRIFT_BRANCH` (default `main`), `DRIFT_HISTORY`
     (default 20 commits), `RELEASE_WORKFLOW` (default
     `.github/workflows/release.yml`), `PROTECTION_PIN_FILE` (default
     `test/regression/release_required_checks_test.go`).
   - Exit: `0` when all three directions are clean; `1` on any drift, an API read
-    failure, an unparseable release.yml, or protection reporting zero contexts
-    (fails closed — unreadable protection is not a clean bill of health).
+    failure, an unparseable release.yml, or the rules endpoint reporting no
+    `required_status_checks` rule or zero contexts (fails closed — an unreadable
+    live set is not a clean bill of health).
 - **`release-preflight.mjs`** — `release.yml`, the `preflight` job. The
   green-check guard for BOTH release paths, gated on the publish decision rather
   than on the branch: it runs whenever `app_publish` or `chart_publish` is true,

--- a/.github/scripts/generated-baseline-structural-guard.mjs
+++ b/.github/scripts/generated-baseline-structural-guard.mjs
@@ -51,10 +51,10 @@
 // the merge commit and diffs it against the committed file") — they were
 // already there for most of the list.
 //
-// The residual gap is procedural, not a missing validator: with branch
-// protection's "require branches to be up to date before merging" OFF
-// (`strict: false` as of this writing — confirmed via
-// `gh api repos/tsouza/cerberus/branches/main/protection`), a stale PR's
+// The residual gap is procedural, not a missing validator: with "require
+// branches to be up to date before merging" OFF on the ruleset governing `main`
+// (`strict_required_status_checks_policy: false` as of this writing — confirmed
+// via `gh api repos/tsouza/cerberus/rules/branches/main`), a stale PR's
 // squash-merge computes its diff against a `main` that has since moved
 // WITHOUT ever re-running the checks above against the resulting content —
 // so a corrupted blend of one of these files can land on `main` with no CI

--- a/.github/scripts/post-merge-golden-drift.mjs
+++ b/.github/scripts/post-merge-golden-drift.mjs
@@ -9,10 +9,12 @@
 // the inventory). Those ratchets are strong, and they all share one blind spot:
 // they run against the tree AS THE PR SAW IT.
 //
-// Branch protection has `require branches to be up to date before merging` OFF:
+// The ruleset governing `main` has `require branches to be up to date before
+// merging` OFF:
 //
-//   $ gh api repos/tsouza/cerberus/branches/main/protection \
-//       --jq '.required_status_checks.strict'
+//   $ gh api repos/tsouza/cerberus/rules/branches/main \
+//       --jq '.[] | select(.type == "required_status_checks")
+//                 | .parameters.strict_required_status_checks_policy'
 //   false
 //
 // so a PR's squash-merge computes its diff against a `main` that has since

--- a/.github/scripts/release-gate-drift.mjs
+++ b/.github/scripts/release-gate-drift.mjs
@@ -6,7 +6,7 @@
 // mid-publish, and it can rot in two independent directions that the preflight
 // itself structurally cannot see:
 //
-//   A. PROTECTION DRIFT — branch protection gains a required context that is in
+//   A. PROTECTION DRIFT — the branch gains a required context that is in
 //      neither `RELEASE_REQUIRED_CHECKS` nor `RELEASE_INFORMATIONAL_CHECKS`.
 //      Every PR now has to pass it, but the release does not wait for it, so it
 //      publishes past a lane the repo considers gating. The preflight cannot
@@ -23,12 +23,31 @@
 //      LogQL + TraceQL, rapid N=500)` is the standing reminder that these names
 //      are display strings, not identifiers.
 //
-//   C. PIN DRIFT — the live branch-protection set and the repo's own pin of it
+//   C. PIN DRIFT — the live required-context set and the repo's own pin of it
 //      (`branchProtectionContexts`, in the protection-pin file below) disagree.
-//      Every in-tree gate reasons off that pin, because reading the live
-//      setting needs repo-admin rights a Go test does not have — so a
-//      disagreement leaves those gates authoritative about a configuration
-//      that is not in force. See `pinnedProtectionDrift` for both halves.
+//      Every in-tree gate reasons off that pin, because a Go test has no
+//      network — so a disagreement leaves those gates authoritative about a
+//      configuration that is not in force. See `pinnedProtectionDrift` for
+//      both halves.
+//
+// WHERE THE LIVE SET COMES FROM. GitHub replaced this repository's legacy
+// branch-protection object with RULESETS, and deleted the legacy object:
+// `GET /repos/{owner}/{repo}/branches/{branch}/protection` now answers
+// `404 Branch not protected`. The live read is therefore
+// `GET /repos/{owner}/{repo}/rules/branches/{branch}`, which returns the
+// FLATTENED list of rules in force on that branch — every ruleset that matches
+// it contributes, tagged with its `ruleset_id`. More than one can carry a
+// `required_status_checks` rule (this repo already runs a second ruleset over
+// `refs/heads/release/*.x`), so the governing set is the UNION across them,
+// not the first one found. Rule types this script does not model — `deletion`,
+// `non_fast_forward`, `pull_request`, `merge_queue` — are ignored by type
+// rather than by position, so a new rule appearing alongside them is inert
+// here instead of shifting an index.
+//
+// The names `protectionDrift` / `pinnedProtectionDrift` /
+// `branchProtectionContexts` are kept: what they mean — the set of contexts a
+// merge into the branch must pass — did not change, only the endpoint that
+// reports it.
 //
 // So: run all three checks on a schedule, off the release critical path, where
 // the fix is a one-line PR instead of a broken publish.
@@ -38,16 +57,28 @@
 // yields an empty required set is a hard failure, not an empty comparison,
 // because a silently-empty set makes BOTH checks vacuously green.
 //
+// NO DEDICATED CREDENTIAL, ON PURPOSE. The legacy protection endpoint needed
+// repository `administration:read`, which the workflow token cannot receive, so
+// this lane carried a `BRANCH_PROTECTION_TOKEN` secret. That secret was never
+// provisioned: every scheduled run from 2026-08-04 to 2026-09-01 aborted on
+// `BRANCH_PROTECTION_TOKEN is unset` before reaching the API, so the only
+// automated comparison between the pin and reality had never once produced a
+// verdict — which is how `update-golden-guard` became a required context and
+// stayed unpinned. The rules endpoint carries no such requirement: it is served
+// to any credential that can read the repository, so the ordinary
+// `${{ github.token }}` is sufficient and there is no secret left to be absent.
+// Do not reintroduce one; a credential this lane cannot verify it has is
+// indistinguishable, on a Monday, from a lane nobody reads.
+//
 // Env:
-//   GITHUB_TOKEN       REQUIRED. Least-privilege workflow token used for
-//                      commits, check-runs, and commit statuses.
-//   BRANCH_PROTECTION_TOKEN
-//                      REQUIRED. Dedicated credential with repository
-//                      administration:read, used only for the live protection
-//                      request. Missing/denied/malformed data fails closed.
+//   GITHUB_TOKEN       REQUIRED. Least-privilege workflow token, used for the
+//                      live rules read as well as for commits, check-runs and
+//                      commit statuses. Missing/denied/malformed data fails
+//                      closed — never into an empty, vacuously green set.
 //   GITHUB_REPOSITORY  owner/repo (runner-provided).
 //   GITHUB_API_URL     API base (default https://api.github.com).
-//   DRIFT_BRANCH       Branch whose protection is compared (default `main`).
+//   DRIFT_BRANCH       Branch whose governing rulesets are read (default
+//                      `main`).
 //   DRIFT_HISTORY      How many recent commits on that branch are scanned for
 //                      posted check-run names (default 20).
 //   RELEASE_WORKFLOW   Path to the workflow holding the lists
@@ -73,8 +104,20 @@ import { error, notice, log, appendStepSummary } from './lib/gh.mjs';
 // of it. A name absent from EVERY commit in this window is dead, not skipped.
 const defaultHistoryCommits = 20;
 
-// GitHub caps `per_page` at 100 for both the commit list and the check-run list.
+// GitHub caps `per_page` at 100 for the commit list, the check-run list and the
+// combined-status list.
 const maxPerPage = 100;
+
+// A busy commit on `main` carries far more than one page of check-runs — 146 on
+// 2733b38c7, across 26 check suites — so a single-page read is a TRUNCATED
+// observation, and direction B reports every name that landed past the cut as a
+// dead lane. `forbid-deferral` sat on page 2 of that commit while its
+// push-triggered run was green: the first real verdict this detector ever
+// produced would have been a false accusation against a healthy required lane,
+// which is how a rot detector gets dismissed as noise a second time. Pages are
+// therefore walked to exhaustion, with a bound so a runaway pagination loop
+// fails loudly instead of spinning.
+const maxObservationPages = 10;
 
 // A block scalar's content is indented deeper than its key; the first line at or
 // below the key's indentation ends it. Comment lines sit at the key's own
@@ -132,54 +175,57 @@ export function protectionDrift({ liveContexts, required, informational }) {
     .filter((ctx) => !req.has(ctx) && !isInformational(ctx, informational))
     .map(
       (ctx) =>
-        `${ctx}: branch-protection REQUIRED context in neither RELEASE_REQUIRED_CHECKS nor ` +
+        `${ctx}: ruleset-REQUIRED context in neither RELEASE_REQUIRED_CHECKS nor ` +
         `RELEASE_INFORMATIONAL_CHECKS — the release publishes without waiting for it. ` +
         `Add it to the required set, or de-gate it explicitly with a reason.`,
     );
 }
 
-// Direction C. The repo pins its own expected protection set in
+// Direction C. The repo pins its own expected required-context set in
 // `branchProtectionContexts` (test/regression/release_required_checks_test.go),
 // and every in-tree gate that reasons about "what a PR must pass" reads that
-// pin rather than the live setting — because a Go test cannot call an endpoint
-// that needs repo-admin rights. So the pin is authoritative in the tree and
-// powerless over the repo, which leaves the two apart with nothing watching:
+// pin rather than the live setting — because a Go test does not reach the
+// network. So the pin is authoritative in the tree and powerless over the repo,
+// which leaves the two apart with nothing watching:
 //
 //   - LIVE MISSING. A context the pin names is not enforced. Every in-tree gate
 //     still reasons as though it were, and the check keeps posting green on
 //     every PR, so the lane looks gating from every angle except the only one
 //     that decides a merge. This is not hypothetical: `pr-body` sat in the pin
-//     while branch protection enforced 19 contexts, and the release preflight —
+//     while the live setting enforced 19 contexts, and the release preflight —
 //     which DOES require it on the maintenance path — never disagreed, because
 //     it reads the pin too.
-//   - LIVE EXTRA. Protection enforces a context the pin does not name. That is
+//   - LIVE EXTRA. The ruleset enforces a context the pin does not name. That is
 //     the drift the pin's own doc comment calls "the one drift this file cannot
 //     see", and it lands on the maintenance path as a lane certified by
-//     absence.
+//     absence. `update-golden-guard` spent a week in exactly that state, while
+//     this very comparison was inert for want of a credential.
 //
 // Set EQUALITY is the assertion, in both directions, because either half alone
 // is a gate that reports on something other than what it claims to gate.
-export function pinnedProtectionDrift({ liveContexts, pinned }) {
+export function pinnedProtectionDrift({ liveContexts, pinned, branch = 'main', rulesetIds = [] }) {
   const live = new Set(liveContexts ?? []);
   const pin = new Set(pinned ?? []);
+  const where = describeRulesets(rulesetIds);
 
   const missing = [...pin]
     .filter((ctx) => !live.has(ctx))
     .map(
       (ctx) =>
-        `${ctx}: pinned in branchProtectionContexts but NOT enforced by branch protection on ` +
-        `\`main\`. The lane still posts green on every PR, so nothing in the tree can tell the ` +
-        `difference — the check is advisory while every gate that reads the pin treats it as ` +
-        `binding. Restore it with: gh api -X POST repos/<owner>/<repo>/branches/main/protection/` +
-        `required_status_checks/contexts -f 'contexts[]=${ctx}' — or, if it is meant to be ` +
-        `advisory, drop it from the pin and from RELEASE_REQUIRED_CHECKS in the same change.`,
+        `${ctx}: pinned in branchProtectionContexts but NOT required by ${where} on ` +
+        `\`${branch}\`. The lane still posts green on every PR, so nothing in the tree can tell ` +
+        `the difference — the check is advisory while every gate that reads the pin treats it as ` +
+        `binding. Restore it by adding the context to that ruleset's required_status_checks rule ` +
+        `(Settings -> Rules -> Rulesets, or gh api -X PUT repos/<owner>/<repo>/rulesets/<id> ` +
+        `--input <edited-ruleset>.json) — or, if it is meant to be advisory, drop it from the pin ` +
+        `and from RELEASE_REQUIRED_CHECKS in the same change.`,
     );
 
   const extra = [...live]
     .filter((ctx) => !pin.has(ctx))
     .map(
       (ctx) =>
-        `${ctx}: enforced by branch protection on \`main\` but absent from ` +
+        `${ctx}: required by ${where} on \`${branch}\` but absent from ` +
         `branchProtectionContexts. The release-preflight totality assertion runs OVER that pin, ` +
         `so an unpinned context is certified by absence on the maintenance path. Add it to the ` +
         `pin, which forces it into RELEASE_REQUIRED_CHECKS or an explicit de-gating.`,
@@ -227,6 +273,27 @@ export async function apiJson(url, headers, what, fetchImpl = globalThis.fetch) 
   return res.json();
 }
 
+// apiPaged — every item across every page, not just the first. `pick` pulls the
+// item array out of a page body, because the check-run and combined-status
+// endpoints wrap theirs under different keys. A short page ends the walk; a
+// walk that never shortens throws rather than silently returning a prefix,
+// since a prefix is exactly the truncation this function exists to remove.
+export async function apiPaged({ url, headers, what, pick, fetchImpl = globalThis.fetch }) {
+  const join = url.includes('?') ? '&' : '?';
+  const items = [];
+  for (let page = 1; page <= maxObservationPages; page++) {
+    const body = await apiJson(`${url}${join}per_page=${maxPerPage}&page=${page}`, headers, what, fetchImpl);
+    const batch = pick(body) ?? [];
+    items.push(...batch);
+    if (batch.length < maxPerPage) return items;
+  }
+  throw new Error(
+    `${what}: still returning full pages after ${maxObservationPages} of them ` +
+      `(${maxObservationPages * maxPerPage} items) — the observation set would be truncated, ` +
+      `which reports healthy lanes as dead`,
+  );
+}
+
 function tokenHeaders(token) {
   return {
     Accept: 'application/vnd.github+json',
@@ -235,26 +302,94 @@ function tokenHeaders(token) {
   };
 }
 
-export function protectionContexts(protection, branch = 'main') {
-  const contexts = protection?.required_status_checks?.contexts;
-  if (!Array.isArray(contexts)) {
-    throw new Error(
-      `branch protection on ${branch} returned malformed required-status-check data`,
-    );
-  }
-  if (
-    contexts.length === 0 ||
-    contexts.some((context) => typeof context !== 'string' || context.trim() === '')
-  ) {
-    throw new Error(
-      `branch protection on ${branch} reports invalid or zero required contexts — either protection was ` +
-        `removed or the credential cannot see it; both make this check vacuous`,
-    );
-  }
-  return contexts;
+// The one rule type this script models. Everything else the rules endpoint
+// reports for a branch — `deletion`, `non_fast_forward`, `pull_request`,
+// `merge_queue` — is ignored BY TYPE, so a rule added beside them changes
+// nothing here rather than shifting a position.
+const requiredStatusChecksRuleType = 'required_status_checks';
+
+// describeRulesets — how a drift message names the thing that enforces a
+// context. Plural because the union below can genuinely span rulesets, and a
+// message that says "the ruleset" when two are in force sends the reader to
+// edit the wrong one.
+export function describeRulesets(rulesetIds = []) {
+  const ids = [...new Set((rulesetIds ?? []).filter((id) => id !== undefined && id !== null))];
+  if (ids.length === 0) return 'the ruleset(s) in force';
+  if (ids.length === 1) return `ruleset #${ids[0]}`;
+  return `rulesets ${ids.map((id) => `#${id}`).join(' + ')}`;
 }
 
-export async function readBranchProtection({
+// rulesetContexts — the required contexts a merge into `branch` must pass,
+// read out of the FLATTENED rule list `GET /repos/{o}/{r}/rules/branches/{b}`
+// returns.
+//
+// The endpoint answers with one array covering EVERY active ruleset that
+// matches the branch, each entry tagged `ruleset_id`. So there can be more than
+// one `required_status_checks` rule and the governing set is their UNION — this
+// repository already runs a second ruleset over `refs/heads/release/*.x`, and
+// reading only the first match would under-report the moment a branch falls
+// under two. Contexts are `{context, integration_id}` objects here, not the
+// bare strings the legacy protection object carried.
+//
+// Every degenerate shape throws rather than returning an empty list: an empty
+// live set makes directions A and C vacuously green, which is the failure mode
+// this whole lane exists to prevent.
+export function rulesetContexts(rules, branch = 'main') {
+  if (!Array.isArray(rules)) {
+    throw new Error(
+      `the rules endpoint for ${branch} returned a non-list payload — the branch-rules read is ` +
+        `broken or the response shape changed; either way the comparison has nothing to compare`,
+    );
+  }
+
+  const checkRules = rules.filter((rule) => rule?.type === requiredStatusChecksRuleType);
+  if (checkRules.length === 0) {
+    throw new Error(
+      `no ${requiredStatusChecksRuleType} rule is in force on ${branch} — every ruleset carrying ` +
+        `one was deleted, disabled or set to evaluate-only, or the credential cannot see them; ` +
+        `all of those make this check vacuous`,
+    );
+  }
+
+  const contexts = [];
+  const seen = new Set();
+  const rulesetIds = [];
+  for (const rule of checkRules) {
+    const entries = rule?.parameters?.required_status_checks;
+    if (!Array.isArray(entries)) {
+      throw new Error(
+        `a ${requiredStatusChecksRuleType} rule on ${branch} carries malformed ` +
+          `parameters.required_status_checks`,
+      );
+    }
+    if (rule.ruleset_id !== undefined && !rulesetIds.includes(rule.ruleset_id)) {
+      rulesetIds.push(rule.ruleset_id);
+    }
+    for (const entry of entries) {
+      const context = entry?.context;
+      if (typeof context !== 'string' || context.trim() === '') {
+        throw new Error(
+          `a ${requiredStatusChecksRuleType} rule on ${branch} names a non-string or empty ` +
+            `context — the live set cannot be trusted`,
+        );
+      }
+      if (seen.has(context)) continue;
+      seen.add(context);
+      contexts.push(context);
+    }
+  }
+
+  if (contexts.length === 0) {
+    throw new Error(
+      `the ${requiredStatusChecksRuleType} rule(s) on ${branch} require zero contexts — nothing ` +
+        `gates a merge, and comparing against an empty set would report a clean bill of health`,
+    );
+  }
+
+  return { contexts, rulesetIds };
+}
+
+export async function readRequiredContexts({
   apiBase,
   repo,
   branch,
@@ -263,16 +398,16 @@ export async function readBranchProtection({
 }) {
   if (!token) {
     throw new Error(
-      'BRANCH_PROTECTION_TOKEN is unset — the live required-context comparison cannot run',
+      'GITHUB_TOKEN is unset — the live required-context comparison cannot run',
     );
   }
-  const protection = await apiJson(
-    `${apiBase}/repos/${repo}/branches/${encodeURIComponent(branch)}/protection`,
+  const rules = await apiJson(
+    `${apiBase}/repos/${repo}/rules/branches/${encodeURIComponent(branch)}`,
     tokenHeaders(token),
-    'read branch protection',
+    'read branch rules',
     fetchImpl,
   );
-  return protectionContexts(protection, branch);
+  return rulesetContexts(rules, branch);
 }
 
 async function main() {
@@ -282,7 +417,6 @@ async function main() {
   const history = Number(process.env.DRIFT_HISTORY || defaultHistoryCommits);
   const repo = process.env.GITHUB_REPOSITORY;
   const token = process.env.GITHUB_TOKEN;
-  const protectionToken = process.env.BRANCH_PROTECTION_TOKEN;
   const apiBase = process.env.GITHUB_API_URL || 'https://api.github.com';
 
   if (!repo) throw new Error('GITHUB_REPOSITORY is unset');
@@ -296,11 +430,11 @@ async function main() {
   const pinned = parsePinnedContexts(readFileSync(pinPath, 'utf8'));
 
   const headers = tokenHeaders(token);
-  const liveContexts = await readBranchProtection({
+  const { contexts: liveContexts, rulesetIds } = await readRequiredContexts({
     apiBase,
     repo,
     branch,
-    token: protectionToken,
+    token,
   });
 
   const commits = await apiJson(
@@ -311,29 +445,36 @@ async function main() {
 
   const observed = new Set();
   for (const c of commits) {
-    const runs = await apiJson(
-      `${apiBase}/repos/${repo}/commits/${c.sha}/check-runs?per_page=${maxPerPage}`,
+    for (const run of await apiPaged({
+      url: `${apiBase}/repos/${repo}/commits/${c.sha}/check-runs`,
       headers,
-      `read check-runs for ${c.sha}`,
-    );
-    for (const run of runs?.check_runs ?? []) observed.add(run.name);
-    for (const s of (await apiJson(`${apiBase}/repos/${repo}/commits/${c.sha}/status`, headers, 'read statuses'))
-      ?.statuses ?? []) {
-      observed.add(s.context);
+      what: `read check-runs for ${c.sha}`,
+      pick: (body) => body?.check_runs,
+    })) {
+      observed.add(run.name);
+    }
+    for (const status of await apiPaged({
+      url: `${apiBase}/repos/${repo}/commits/${c.sha}/status`,
+      headers,
+      what: `read statuses for ${c.sha}`,
+      pick: (body) => body?.statuses,
+    })) {
+      observed.add(status.context);
     }
   }
 
   const problems = [
     ...protectionDrift({ liveContexts, required, informational }),
     ...laneDrift({ required, observed: [...observed] }),
-    ...pinnedProtectionDrift({ liveContexts, pinned }),
+    ...pinnedProtectionDrift({ liveContexts, pinned, branch, rulesetIds }),
   ];
 
   appendStepSummary(
     [
       `## release gate drift — \`${branch}\``,
       '',
-      `- branch-protection required contexts: **${liveContexts.length}** (pinned: **${pinned.length}**)`,
+      `- required contexts in force via ${describeRulesets(rulesetIds)}: **${liveContexts.length}** ` +
+        `(pinned: **${pinned.length}**)`,
       `- \`RELEASE_REQUIRED_CHECKS\`: **${required.length}**`,
       `- \`RELEASE_INFORMATIONAL_CHECKS\`: **${informational.length}**`,
       `- commits scanned for posted lane names: **${commits.length}**`,
@@ -348,9 +489,10 @@ async function main() {
   }
 
   notice(
-    `release gate is in sync: ${liveContexts.length} protected context(s) all accounted for and ` +
-      `matching the ${pinned.length}-name in-tree pin exactly, ${required.length} required lane(s) ` +
-      `all still posting across ${commits.length} commit(s)`,
+    `release gate is in sync: ${liveContexts.length} context(s) required by ` +
+      `${describeRulesets(rulesetIds)} on \`${branch}\` all accounted for and matching the ` +
+      `${pinned.length}-name in-tree pin exactly, ${required.length} required lane(s) all still ` +
+      `posting across ${commits.length} commit(s)`,
     { title: 'release gate drift' },
   );
 }
@@ -388,7 +530,7 @@ async function selfTest() {
   );
   const aDrift = protectionDrift({ liveContexts: ['check', 'brand-new-gate'], required, informational });
   assert.equal(aDrift.length, 1, `expected exactly one problem, got: ${aDrift.join('; ')}`);
-  assert.match(aDrift[0], /^brand-new-gate: branch-protection REQUIRED context in neither/);
+  assert.match(aDrift[0], /^brand-new-gate: ruleset-REQUIRED context in neither/);
 
   // Direction B: a name nothing posts, versus a full set that everything posts.
   assert.deepEqual(laneDrift({ required, observed: required }), []);
@@ -433,11 +575,11 @@ async function selfTest() {
     pinned,
   });
   assert.equal(cMissing.length, 1, `expected exactly one problem, got: ${cMissing.join('; ')}`);
-  assert.match(cMissing[0], /^pr-body: pinned in branchProtectionContexts but NOT enforced/);
+  assert.match(cMissing[0], /^pr-body: pinned in branchProtectionContexts but NOT required by/);
 
   const cExtra = pinnedProtectionDrift({ liveContexts: [...pinned, 'brand-new-gate'], pinned });
   assert.equal(cExtra.length, 1, `expected exactly one problem, got: ${cExtra.join('; ')}`);
-  assert.match(cExtra[0], /^brand-new-gate: enforced by branch protection on `main` but absent/);
+  assert.match(cExtra[0], /^brand-new-gate: required by the ruleset\(s\) in force on `main` but absent/);
 
   // Both halves at once are reported together, not short-circuited: a rename
   // presents as exactly this pair, and seeing only one end of it hides which.
@@ -447,12 +589,209 @@ async function selfTest() {
   assert.throws(() => parsePinnedContexts('var other = []string{"check"}'), /slice literal not found/);
   assert.throws(() => parsePinnedContexts('var branchProtectionContexts = []string{}'), /parsed as empty/);
 
-  // Authorization and payload failures must never degrade into an empty, green
-  // comparison. The dedicated credential is also proven to be the one placed
-  // on the protection request rather than the ordinary workflow token.
+  // Pagination. The regression this exists for is exact: a required lane whose
+  // check-run lands past the first page of a busy commit must still count as
+  // observed, or direction B accuses a healthy lane of being dead.
+  const pageOf = (n, start) => Array.from({ length: n }, (_, i) => ({ name: `run-${start + i}` }));
+  const twoPageCommit = [
+    { check_runs: pageOf(maxPerPage, 0) },
+    { check_runs: [...pageOf(45, maxPerPage), { name: 'forbid-deferral' }] },
+  ];
+  const requestedPages = [];
+  const walked = await apiPaged({
+    url: 'https://api.invalid/repos/example/project/commits/deadbeef/check-runs',
+    headers: {},
+    what: 'read check-runs',
+    pick: (body) => body?.check_runs,
+    fetchImpl: async (url) => {
+      requestedPages.push(url);
+      return { ok: true, json: async () => twoPageCommit[requestedPages.length - 1] };
+    },
+  });
+  assert.equal(requestedPages.length, 2, 'a full first page must be followed by a second request');
+  assert.match(requestedPages[0], /\?per_page=100&page=1$/);
+  assert.match(requestedPages[1], /\?per_page=100&page=2$/);
+  assert.equal(walked.length, maxPerPage + 46);
+  assert.ok(
+    walked.some((r) => r.name === 'forbid-deferral'),
+    'a name on page 2 must survive into the observation set',
+  );
+  assert.deepEqual(
+    laneDrift({ required: ['forbid-deferral'], observed: walked.map((r) => r.name) }),
+    [],
+    'the page-2 name must not be reported as a dead lane',
+  );
+  // A single short page still costs exactly one request.
+  requestedPages.length = 0;
+  assert.deepEqual(
+    await apiPaged({
+      url: 'https://api.invalid/x',
+      headers: {},
+      what: 'read statuses',
+      pick: (body) => body?.statuses,
+      fetchImpl: async (url) => {
+        requestedPages.push(url);
+        return { ok: true, json: async () => ({ statuses: [{ context: 'legacy' }] }) };
+      },
+    }),
+    [{ context: 'legacy' }],
+  );
+  assert.equal(requestedPages.length, 1);
+  // Endless full pages must fail loudly rather than return a silent prefix.
   await assert.rejects(
     () =>
-      readBranchProtection({
+      apiPaged({
+        url: 'https://api.invalid/x',
+        headers: {},
+        what: 'read check-runs',
+        pick: (body) => body?.check_runs,
+        fetchImpl: async () => ({ ok: true, json: async () => ({ check_runs: pageOf(maxPerPage, 0) }) }),
+      }),
+    /still returning full pages after 10 of them/,
+  );
+
+  // A drift message must send the reader to the right ruleset, and say so in
+  // the plural when more than one is in force — an id-less "the ruleset" would
+  // have them editing whichever they happened to open.
+  assert.equal(describeRulesets([]), 'the ruleset(s) in force');
+  assert.equal(describeRulesets([22113683]), 'ruleset #22113683');
+  assert.equal(describeRulesets([22113683, 22113683, 18472142]), 'rulesets #22113683 + #18472142');
+  assert.match(
+    pinnedProtectionDrift({ liveContexts: [], pinned: ['check'], rulesetIds: [22113683] })[0],
+    /NOT required by ruleset #22113683 on `main`/,
+  );
+
+  // A RECORDED response from GET /repos/tsouza/cerberus/rules/branches/main,
+  // captured 2026-09-02, trimmed to the fields this parser reads. Its job is to
+  // fail loudly if the endpoint's shape moves again — the previous shape change
+  // (branch protection deleted in favour of rulesets) was found by a human
+  // reading a red cron, not by a test.
+  const recordedMainRules = [
+    { type: 'deletion', ruleset_id: 22113683 },
+    { type: 'non_fast_forward', ruleset_id: 22113683 },
+    {
+      type: 'pull_request',
+      parameters: {
+        required_approving_review_count: 0,
+        required_review_thread_resolution: true,
+        allowed_merge_methods: ['squash'],
+      },
+      ruleset_id: 22113683,
+    },
+    {
+      type: 'required_status_checks',
+      parameters: {
+        strict_required_status_checks_policy: false,
+        do_not_enforce_on_create: false,
+        required_status_checks: [
+          { context: 'check' },
+          { context: 'lint' },
+          { context: 'forbid-skip' },
+          { context: 'probe' },
+          { context: 'chart-validate' },
+          { context: 'coverage' },
+          { context: 'property (PromQL + LogQL + TraceQL, rapid N=500)' },
+          { context: 'strict-scan' },
+          { context: 'CodeQL' },
+          { context: 'forbid-deferral' },
+          { context: 'pr-body' },
+          { context: 'quickstart' },
+          { context: 'agpl-clean' },
+          { context: 'schema-ddl' },
+          { context: 'config-docs' },
+          { context: 'link-check' },
+          { context: 'update-golden-guard' },
+        ],
+      },
+      ruleset_id: 22113683,
+    },
+  ];
+
+  const recorded = rulesetContexts(recordedMainRules, 'main');
+  assert.equal(recorded.contexts.length, 17);
+  assert.deepEqual(recorded.rulesetIds, [22113683]);
+  // The matrix name survives as ONE context, exactly as it must for direction A
+  // to match it against the release list.
+  assert.ok(recorded.contexts.includes('property (PromQL + LogQL + TraceQL, rapid N=500)'));
+  // Non-status-check rules contribute nothing and cost nothing.
+  assert.ok(!recorded.contexts.some((c) => c === undefined));
+
+  // A branch under TWO rulesets: the governing set is the union, deduplicated,
+  // and both ids are reported so the remediation hint can name them. Reading
+  // only the first matching rule would silently under-report the live set,
+  // which lands as a direction-C "pinned but not required" on a context that IS
+  // required.
+  const twoRulesets = rulesetContexts(
+    [
+      {
+        type: 'required_status_checks',
+        parameters: { required_status_checks: [{ context: 'check' }, { context: 'lint' }] },
+        ruleset_id: 1,
+      },
+      { type: 'merge_queue', parameters: { grouping_strategy: 'ALLGREEN' }, ruleset_id: 1 },
+      {
+        type: 'required_status_checks',
+        parameters: { required_status_checks: [{ context: 'lint' }, { context: 'quickstart' }] },
+        ruleset_id: 2,
+      },
+    ],
+    'release/9.9.x',
+  );
+  assert.deepEqual(twoRulesets.contexts, ['check', 'lint', 'quickstart']);
+  assert.deepEqual(twoRulesets.rulesetIds, [1, 2]);
+
+  // Every degenerate live payload must throw rather than become an empty set:
+  // an empty live set makes directions A and C report "no drift" over nothing.
+  for (const [rules, pattern] of [
+    [null, /non-list payload/],
+    [{ type: 'required_status_checks' }, /non-list payload/],
+    [[], /no required_status_checks rule is in force/],
+    [[{ type: 'deletion' }, { type: 'pull_request' }], /no required_status_checks rule is in force/],
+    [[{ type: 'required_status_checks', parameters: {} }], /malformed parameters/],
+    [
+      [{ type: 'required_status_checks', parameters: { required_status_checks: {} } }],
+      /malformed parameters/,
+    ],
+    [
+      [{ type: 'required_status_checks', parameters: { required_status_checks: [] } }],
+      /require zero contexts/,
+    ],
+    [
+      [
+        {
+          type: 'required_status_checks',
+          parameters: { required_status_checks: [{ context: 'check' }, { context: '' }] },
+        },
+      ],
+      /non-string or empty context/,
+    ],
+    [
+      [
+        {
+          type: 'required_status_checks',
+          parameters: { required_status_checks: [{ context: 'check' }, { context: 7 }] },
+        },
+      ],
+      /non-string or empty context/,
+    ],
+    [
+      [
+        {
+          type: 'required_status_checks',
+          parameters: { required_status_checks: [{ context: 'check' }, 'lint'] },
+        },
+      ],
+      /non-string or empty context/,
+    ],
+  ]) {
+    assert.throws(() => rulesetContexts(rules, 'main'), pattern, `expected a throw for ${JSON.stringify(rules)}`);
+  }
+
+  // Credential and transport failures must never degrade into an empty, green
+  // comparison either.
+  await assert.rejects(
+    () =>
+      readRequiredContexts({
         apiBase: 'https://api.invalid',
         repo: 'example/project',
         branch: 'main',
@@ -461,73 +800,42 @@ async function selfTest() {
           throw new Error('network should not be reached without a credential');
         },
       }),
-    /BRANCH_PROTECTION_TOKEN is unset/,
+    /GITHUB_TOKEN is unset/,
   );
 
   await assert.rejects(
     () =>
-      readBranchProtection({
+      readRequiredContexts({
         apiBase: 'https://api.invalid',
         repo: 'example/project',
         branch: 'main',
-        token: 'protection-read-token',
-        fetchImpl: async () => ({
-          ok: false,
-          status: 403,
-          statusText: 'Forbidden',
-        }),
+        token: 'workflow-token',
+        fetchImpl: async () => ({ ok: false, status: 403, statusText: 'Forbidden' }),
       }),
-    /read branch protection: HTTP 403 Forbidden/,
+    /read branch rules: HTTP 403 Forbidden/,
   );
 
-  for (const payload of [
-    {},
-    { required_status_checks: {} },
-    { required_status_checks: { contexts: null } },
-    { required_status_checks: { contexts: [] } },
-    { required_status_checks: { contexts: ['check', ''] } },
-    { required_status_checks: { contexts: ['check', 7] } },
-  ]) {
-    await assert.rejects(
-      () =>
-        readBranchProtection({
-          apiBase: 'https://api.invalid',
-          repo: 'example/project',
-          branch: 'main',
-          token: 'protection-read-token',
-          fetchImpl: async (_url, options) => {
-            assert.equal(
-              options.headers.Authorization,
-              'Bearer protection-read-token',
-            );
-            return { ok: true, json: async () => payload };
-          },
-        }),
-      /malformed|required contexts/,
-    );
-  }
-
-  assert.deepEqual(
-    await readBranchProtection({
-      apiBase: 'https://api.invalid',
-      repo: 'example/project',
-      branch: 'main',
-      token: 'protection-read-token',
-      fetchImpl: async (_url, options) => {
-        assert.equal(
-          options.headers.Authorization,
-          'Bearer protection-read-token',
-        );
-        return {
-          ok: true,
-          json: async () => ({
-            required_status_checks: { contexts: ['check', 'quickstart'] },
-          }),
-        };
-      },
-    }),
-    ['check', 'quickstart'],
+  // The URL is the endpoint that still exists, the branch is path-escaped so a
+  // maintenance line reads its own rules rather than 404ing, and the ordinary
+  // workflow token is what carries the request — there is no second credential
+  // to be absent.
+  let requestedUrl = null;
+  const live = await readRequiredContexts({
+    apiBase: 'https://api.invalid',
+    repo: 'example/project',
+    branch: 'release/1.2.x',
+    token: 'workflow-token',
+    fetchImpl: async (url, options) => {
+      requestedUrl = url;
+      assert.equal(options.headers.Authorization, 'Bearer workflow-token');
+      return { ok: true, json: async () => recordedMainRules };
+    },
+  });
+  assert.equal(
+    requestedUrl,
+    'https://api.invalid/repos/example/project/rules/branches/release%2F1.2.x',
   );
+  assert.equal(live.contexts.length, 17);
 
   log('release-gate-drift self-test: OK');
 }

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -20,9 +20,9 @@ name: CodeQL
 # of the umbrella job below), so no branch-protection edit is needed.
 #
 # REQUIRED CONTEXT: `CodeQL` — produced by the umbrella job below, which
-# depends on all per-language analyze jobs. Branch protection requires this
-# name; any rename here must be accompanied by an update to the required-checks
-# list (`gh api repos/tsouza/cerberus/branches/main/protection`).
+# depends on all per-language analyze jobs. The ruleset governing `main`
+# requires this name; any rename here must be accompanied by an update to the
+# required-checks list (`gh api repos/tsouza/cerberus/rules/branches/main`).
 #
 # LANGUAGES: the same set default setup was scanning:
 #   go, javascript-typescript, actions, python

--- a/.github/workflows/release-gate-drift.yml
+++ b/.github/workflows/release-gate-drift.yml
@@ -7,8 +7,8 @@ name: release-gate-drift
 # hand-maintained and only ever exercised mid-publish, so it rots in two
 # directions the preflight cannot see from the inside:
 #
-#   - branch protection gains a required context nobody added to the list, and
-#     the release publishes past a lane every PR has to pass;
+#   - the ruleset governing `main` gains a required context nobody added to the
+#     list, and the release publishes past a lane every PR has to pass;
 #   - a required name stops matching any lane that posts (a job renamed, a
 #     matrix leg reworded), and the next release waits out its full window on a
 #     check-run that never arrives, then aborts with the tag already cut.
@@ -43,13 +43,22 @@ jobs:
       - name: drift self-test
         run: node .github/scripts/release-gate-drift.mjs --self-test
 
-      # Branch protection needs repository-administration read permission,
-      # which the workflow token cannot receive. Keep that dedicated credential
-      # confined to this trusted scheduled/manual job and to that one API read;
-      # ordinary history/check reads use the least-privilege workflow token.
-      - name: Compare the release gate against live branch protection
+      # NO SECRET, AND NO `if:` GUARD ON ONE. This step used to carry a
+      # `BRANCH_PROTECTION_TOKEN` because the legacy branch-protection endpoint
+      # needed repository `administration:read`, which the workflow token cannot
+      # receive. That secret was never provisioned, so every scheduled run from
+      # 2026-08-04 to 2026-09-01 aborted before the API call and the only
+      # automated check that the repo's pinned required-context list matches
+      # reality never once produced a verdict.
+      #
+      # The read is now `GET /repos/{owner}/{repo}/rules/branches/{branch}`,
+      # which any credential that can read the repository may call, so
+      # `${{ github.token }}` is sufficient and there is nothing left to
+      # provision. Do not reintroduce a secret here, and never guard this step
+      # on one — a step that skips itself when a credential is absent reports
+      # the same green as a step that compared and agreed.
+      - name: Compare the release gate against the live branch ruleset
         env:
           GITHUB_TOKEN: ${{ github.token }}
-          BRANCH_PROTECTION_TOKEN: ${{ secrets.BRANCH_PROTECTION_TOKEN }}
           GITHUB_REPOSITORY: ${{ github.repository }}
         run: node .github/scripts/release-gate-drift.mjs

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -81,10 +81,18 @@ per-layer "catches X / misses Y" guidance.
 
 ## Hard invariants (non-negotiable)
 
-1. **PR-per-change.** Branch protection rejects direct pushes to `main` and requires a large set of
-   status checks. The source of truth for that set is
-   `gh api repos/tsouza/cerberus/branches/main/protection --jq '.required_status_checks.contexts[]'`;
-   `docs/test-strategy.md` is the per-gate reference. **Never `gh pr merge --admin`** — if a required
+1. **PR-per-change.** A repository ruleset rejects direct pushes to `main` and requires a large set
+   of status checks. The source of truth for that set is the ruleset API — the legacy
+   `branches/main/protection` endpoint was deleted with the object and now answers `404`:
+
+   ```bash
+   gh api repos/tsouza/cerberus/rules/branches/main \
+     --jq '[.[] | select(.type == "required_status_checks")
+                | .parameters.required_status_checks[].context] | unique[]'
+   ```
+
+   More than one ruleset can govern a branch, so the union across every `required_status_checks`
+   rule is what a merge must pass. `docs/test-strategy.md` is the per-gate reference. **Never `gh pr merge --admin`** — if a required
    check is red, fix the code or fix the workflow. Ship with
    `gh pr merge --squash --delete-branch`.
 2. **A pushed branch gets a PR in the same breath.** The push and the `gh pr create` are one step. A

--- a/docs/agent-workflow.md
+++ b/docs/agent-workflow.md
@@ -68,11 +68,21 @@ A one-commit PR squashes the **commit** subject, not the PR title, so a `chore:`
 
 ## Required checks and the gate posture
 
-The authoritative list of required contexts is the API, not any document:
+The authoritative list of required contexts is the API, not any document. `main` is governed by a
+repository **ruleset**; the legacy `branches/main/protection` endpoint was deleted along with the
+object it described and now answers `404 Branch not protected`:
 
 ```bash
-gh api repos/tsouza/cerberus/branches/main/protection --jq '.required_status_checks.contexts[]'
+gh api repos/tsouza/cerberus/rules/branches/main \
+  --jq '[.[] | select(.type == "required_status_checks")
+             | .parameters.required_status_checks[].context] | unique[]'
 ```
+
+That endpoint returns the flattened rules in force on the branch, one entry per rule, each tagged
+with the `ruleset_id` that contributed it. More than one ruleset can match a branch — this
+repository runs a second one over `refs/heads/release/*.x` — so the union across every
+`required_status_checks` rule is the set a merge must pass, which is why the `jq` above collects
+rather than picks.
 
 `docs/test-strategy.md` carries the per-gate reference: what each context proves, what it cannot see,
 and which layer covers the residue. Three postures are worth knowing:

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -382,8 +382,10 @@ orphan `compat-scores` branch so the README badges refresh.
 `compatibility/<head>` checks (the three per-language legs plus
 `compatibility/prometheus-forced-route`) are **release-gate** lanes (#2230,
 the merge/release two-tier test fence), not required PR status checks —
-`gh api repos/tsouza/cerberus/branches/main/protection --jq
-'.required_status_checks.contexts[]'` does not list any of them. Instead,
+`gh api repos/tsouza/cerberus/rules/branches/main --jq '[.[] |
+select(.type == "required_status_checks") |
+.parameters.required_status_checks[].context] | unique[]'` does not list any
+of them. Instead,
 `release.yml`'s `RELEASE_REQUIRED_CHECKS` names each one and its preflight
 blocks a publish until every one has posted a green check-run on the commit
 being shipped: the gate moved from the PR to the release, it did not

--- a/test/regression/release_gate_test.go
+++ b/test/regression/release_gate_test.go
@@ -443,9 +443,18 @@ func TestEOLRetireUsesTheTokenThatBypassesTheReleaseRuleset(t *testing.T) {
 //
 //   - the live comparison step dropped, leaving only `--self-test`: the weekly
 //     run goes green every week while comparing nothing;
-//   - the dedicated administration-read credential swapped for the default
-//     workflow token: branch protection is unreadable at any `permissions:`
-//     level, so the job reds every week until someone deletes it as noise;
+//   - the comparison made conditional on a secret. This is not hypothetical: it
+//     is what the lane DID. The legacy branch-protection endpoint needed
+//     repository administration:read, so the step carried a
+//     `BRANCH_PROTECTION_TOKEN` that was never provisioned, and every scheduled
+//     run from 2026-08-04 to 2026-09-01 aborted before reaching the API. The
+//     only automated check that the pin below matches reality had never once
+//     produced a verdict — which is exactly how `update-golden-guard` became a
+//     required context and stayed unpinned for a week. The ruleset endpoint the
+//     detector reads today needs no elevated credential, so the fix is
+//     structural: this lane must depend on NO secret at all, and must never
+//     guard its comparison on one, because a step that skips itself when a
+//     credential is absent posts the same green as a step that compared;
 //   - the schedule removed: the detector survives as a manual-dispatch button
 //     nobody presses.
 func TestReleaseGateDriftDetectorRunsLiveAndNotSelfTestOnly(t *testing.T) {
@@ -479,15 +488,59 @@ func TestReleaseGateDriftDetectorRunsLiveAndNotSelfTestOnly(t *testing.T) {
 			driftWorkflowPath, driftScript, selfTestFlag)
 	}
 
-	if !strings.Contains(body, "BRANCH_PROTECTION_TOKEN: ${{ secrets.BRANCH_PROTECTION_TOKEN }}") {
-		t.Fatalf("%s no longer passes the dedicated branch-protection read credential. The default "+
-			"workflow token cannot receive repository-administration permission, so the live "+
-			"comparison would fail every scheduled run", driftWorkflowPath)
-	}
 	if !strings.Contains(body, "GITHUB_TOKEN: ${{ github.token }}") {
-		t.Fatalf("%s does not keep ordinary commit/check/status reads on the least-privilege workflow "+
-			"token; the administration-read credential must be confined to the protection request",
+		t.Fatalf("%s does not pass the least-privilege workflow token to the live comparison; every "+
+			"read it makes — the branch ruleset, the commit list, the check-runs — is served to it",
 			driftWorkflowPath)
+	}
+
+	// The inertness pin. A secret this repository has never provisioned is what
+	// kept the comparison from ever running, so the lane must reference no
+	// secret at all — and must not condition any step on one, which is how
+	// "no token, skip" is spelled in workflow YAML.
+	if strings.Contains(body, "secrets.") {
+		t.Fatalf("%s references a repository secret again. The ruleset read the detector performs is "+
+			"served to ${{ github.token }}, so a secret here can only be a credential that is absent "+
+			"on the runner — the state that left this lane without a single verdict between "+
+			"2026-08-04 and 2026-09-01", driftWorkflowPath)
+	}
+	for _, line := range strings.Split(body, "\n") {
+		trimmed := strings.TrimSpace(line)
+		if strings.HasPrefix(trimmed, "if:") {
+			t.Fatalf("%s conditions a step on %q. The comparison must run unconditionally: a step "+
+				"that skips itself reports the same green as a step that compared and agreed",
+				driftWorkflowPath, trimmed)
+		}
+	}
+
+	// The endpoint pin. `/branches/{branch}/protection` answers 404 for this
+	// repository — the legacy protection object was replaced by rulesets and
+	// deleted — so a detector that reads it compares against nothing at all.
+	//
+	// Judged on the URLs the script BUILDS — every request it makes is
+	// interpolated off `${apiBase}` — rather than on prose, so the header
+	// comment may go on explaining which endpoint died and why.
+	script := readFileString(t, "../../.github/scripts/"+driftScript)
+	const apiBaseInterpolation = "${apiBase}"
+	rulesRead := false
+	for _, line := range strings.Split(script, "\n") {
+		if !strings.Contains(line, apiBaseInterpolation) {
+			continue
+		}
+		if strings.Contains(line, "/rules/branches/") {
+			rulesRead = true
+		}
+		if strings.Contains(line, "/protection") {
+			t.Fatalf("%s builds a branch-protection request again (%q). `gh api "+
+				"repos/tsouza/cerberus/branches/main/protection` returns 404 Branch not protected: "+
+				"the legacy protection object was replaced by a ruleset and deleted, so that read "+
+				"compares the pin against nothing", driftScript, strings.TrimSpace(line))
+		}
+	}
+	if !rulesRead {
+		t.Fatalf("%s builds no request to /repos/{owner}/{repo}/rules/branches/{branch}. That is "+
+			"where the required-context set lives now, and it is the only endpoint that can tell "+
+			"branchProtectionContexts from reality", driftScript)
 	}
 
 	// The pure half has to stay on a PR lane, for the same reason

--- a/test/regression/release_required_checks_test.go
+++ b/test/regression/release_required_checks_test.go
@@ -38,21 +38,26 @@ import (
 // These pins close both: totality against a checked-in copy of the branch
 // protection contexts, and trigger-coverage against the workflow files.
 
-// branchProtectionContexts is the required status-check set on `main`. The
-// live source of truth is
+// branchProtectionContexts is the required status-check set on `main`. It is
+// enforced by a repository RULESET — the legacy branch-protection object was
+// replaced by one and deleted, so `branches/main/protection` answers
+// `404 Branch not protected` — and the live source of truth is
 //
-//	gh api repos/tsouza/cerberus/branches/main/protection \
-//	  --jq '.required_status_checks.contexts[]'
+//	gh api repos/tsouza/cerberus/rules/branches/main \
+//	  --jq '[.[] | select(.type == "required_status_checks")
+//	             | .parameters.required_status_checks[].context] | unique[]'
 //
-// and this copy exists so the totality assertion below has something to be
-// total OVER. Adding it here without wiring it into release.yml fails
-// immediately.
+// The name is unchanged because what it denotes is: the set of contexts a merge
+// into `main` must pass. Only the endpoint that reports it moved.
 //
-// This copy and the live setting cannot be compared from here — that endpoint
-// needs repo-admin rights, which no test token carries — so the comparison
-// runs where a token that does exist: `pinnedProtectionDrift` in
-// .github/scripts/release-gate-drift.mjs asserts set EQUALITY between this
-// slice and the live contexts, on the scheduled drift lane. Both halves matter
+// This copy exists so the totality assertion below has something to be total
+// OVER. Adding it here without wiring it into release.yml fails immediately.
+//
+// This copy and the live setting cannot be compared from here — a Go test does
+// not reach the network — so the comparison runs where the API does:
+// `pinnedProtectionDrift` in .github/scripts/release-gate-drift.mjs asserts set
+// EQUALITY between this slice and the live contexts, on the scheduled drift
+// lane. Both halves matter
 // and both have bitten. A context enforced live but missing here is certified
 // by absence on the maintenance path. A context named here but not enforced
 // live is worse, because nothing in the tree can see it: the lane keeps posting


### PR DESCRIPTION
## What broke

`main`'s legacy branch protection was replaced by repository ruleset **#22113683** and the legacy
object deleted, so

```console
$ gh api repos/tsouza/cerberus/branches/main/protection
gh: Branch not protected (HTTP 404)
```

`release-gate-drift.mjs` read exactly that endpoint, which killed the two directions that need a
live set: **A** (a required context in neither `RELEASE_REQUIRED_CHECKS` nor
`RELEASE_INFORMATIONAL_CHECKS`) and **C** (set equality between the live set and
`branchProtectionContexts`).

## The worse half: the comparison had never once run

The protection endpoint needed repository `administration:read`, which the workflow token cannot
receive, so the step carried a `BRANCH_PROTECTION_TOKEN` secret. That secret was never provisioned.
Every scheduled run from 2026-08-04 to 2026-09-01 aborted on `BRANCH_PROTECTION_TOKEN is unset`
before reaching the API, so the only automated check that the repo's pin matches reality had never
produced a verdict — which is how `update-golden-guard` became a required context on 2026-08-24 and
stayed absent from `branchProtectionContexts` for a week.

Repointing the URL alone would have left the lane exactly as silent.

## What this changes

**Repointed at the ruleset API.** The live read is now
`GET /repos/{owner}/{repo}/rules/branches/{branch}`. The shape is different in three ways and all
three are handled rather than assumed away:

- the response is a flat **list of rules**, not one protection object, so rules are selected by
  `type === 'required_status_checks'` — `deletion`, `non_fast_forward`, `pull_request` and the
  `merge_queue` rule about to appear alongside them are ignored **by type**, never by position;
- a context is `{context, integration_id}`, not a bare string;
- **more than one ruleset can govern one branch.** This repo already runs a second ruleset over
  `refs/heads/release/*.x`, so the endpoint can return two `required_status_checks` rules with
  different `ruleset_id`s. The governing set is the **union** across all of them, deduplicated;
  reading only the first match would under-report the live set and land as a bogus direction-C
  "pinned but not required" on a context that *is* required. The contributing ids are carried
  through into the drift messages and the step summary, so a remediation hint names the ruleset to
  edit — in the plural when two are in force.

Every degenerate payload throws rather than degrading to an empty set: a non-list body, a branch
with no `required_status_checks` rule at all, malformed `parameters`, a non-string or empty context,
and a rule requiring zero contexts. An empty live set makes directions A and C vacuously green,
which is the failure this lane exists to prevent.

**No token, because none is needed.** `rules/branches/{branch}` carries no `administration:read`
requirement — it is served to any credential that can read the repository, and on this public repo
to no credential at all:

```console
$ curl -s -o /dev/null -w '%{http_code}\n' \
    https://api.github.com/repos/tsouza/cerberus/rules/branches/main
200
```

So the secret is **deleted, not re-provisioned**, and the lane now runs on `${{ github.token }}`.
There is no absent-secret path left to fail or skip, which is the strongest available answer to
"how does it fail loudly when the credential is missing": there is no credential to be missing. The
regression pin enforces that structurally — `TestReleaseGateDriftDetectorRunsLiveAndNotSelfTestOnly`
now fails on **any** `secrets.` reference in `release-gate-drift.yml` and on **any** `if:` guard on
any step, because `if:` on a secret is how "no token, skip" is spelled in workflow YAML.

**A second real bug the repointing exposed.** With the read fixed, direction B immediately accused
`forbid-deferral` — a healthy required lane with a green push-to-main run — of being dead. The scan
read only the first page of each commit's check-runs. `2733b38c7` carries 146 check-runs across 26
check suites, and `forbid-deferral` sits on page 2. The detector's first real verdict in a month
would have been a false accusation against a working gate, which is how a rot detector gets
dismissed as noise a second time. `apiPaged()` now walks check-runs and combined statuses to
exhaustion, bounded, throwing rather than silently returning a prefix.

**Shape pinned.** The self-test carries a **recorded** `rules/branches/main` response (captured
2026-09-02, trimmed to the fields the parser reads) and asserts it yields the real 17 contexts from
ruleset #22113683 with the matrix name intact. A further endpoint change now fails a test on a PR,
not a Monday cron nobody reads. `TestReleaseGateDriftDetectorRunsLiveAndNotSelfTestOnly` also pins
the endpoint itself, judged on the URLs the script *builds* (every request is interpolated off
`${apiBase}`) so the header comment may go on explaining which endpoint died.

**Eight stale sites repointed**, `CLAUDE.md` invariant 1 included — it named the 404ing command as
*the* source of truth for the required-check set. The replacement everywhere is:

```bash
gh api repos/tsouza/cerberus/rules/branches/main \
  --jq '[.[] | select(.type == "required_status_checks")
             | .parameters.required_status_checks[].context] | unique[]'
```

`CLAUDE.md`, `docs/agent-workflow.md`, `docs/compatibility.md`, `.github/workflows/codeql.yml`,
`.github/scripts/release-gate-drift.mjs` (the remediation hint, which pointed at the
protection-contexts `POST` — under a ruleset the edit is a whole-ruleset `PUT`),
`.github/scripts/generated-baseline-structural-guard.mjs` and
`.github/scripts/post-merge-golden-drift.mjs` (both cite `strict: false`, now
`strict_required_status_checks_policy: false`), and
`test/regression/release_required_checks_test.go`. The `.github/scripts/README.md` entry is rewritten
to match.

`branchProtectionContexts`, `protectionDrift` and `pinnedProtectionDrift` keep their names: what
they denote — the set of contexts a merge into `main` must pass — did not change, only the endpoint
that reports it. Each doc comment now says so explicitly.

## Evidence

**It detects a real drift, unprompted.** The lane's first working run finds the drift #2938 is
independently fixing, from both directions and nothing else:

```console
$ GITHUB_TOKEN=… GITHUB_REPOSITORY=tsouza/cerberus node .github/scripts/release-gate-drift.mjs
- required contexts in force via ruleset #22113683: **17** (pinned: **16**)
- commits scanned for posted lane names: **20**
- ❌ update-golden-guard: ruleset-REQUIRED context in neither RELEASE_REQUIRED_CHECKS nor
  RELEASE_INFORMATIONAL_CHECKS — the release publishes without waiting for it. …
- ❌ update-golden-guard: required by ruleset #22113683 on `main` but absent from
  branchProtectionContexts. …
```

Direction B is clean in the same run — the pagination fix is what makes that true. Once #2938 lands
(it adds `update-golden-guard` to both `RELEASE_REQUIRED_CHECKS` and the pin) all three directions
go clean; this PR deliberately does not touch the pin, so the drift stays visible and belongs to the
PR that caused it.

**Each new assertion fails when violated**, checked by mutating the tree and re-running
`TestReleaseGateDriftDetectorRunsLiveAndNotSelfTestOnly`:

| mutation | result |
| --- | --- |
| re-add `BRANCH_PROTECTION_TOKEN: ${{ secrets.… }}` to the step | FAIL — "references a repository secret again" |
| add `if: env.SOME_TOKEN != ''` to the live step | FAIL — "conditions a step on …" |
| point the read back at `…/branches/${…}/protection` | FAIL — "builds a branch-protection request again" |
| none | pass |

**It runs in the workflow, not just in a shell with a human's `gh` token.** Verified by dispatching
`release-gate-drift.yml` on this branch — see the run linked in the comment below, which reaches the
API on `${{ github.token }}` and reports the drift above.

**Local, targeted:** `node .github/scripts/release-gate-drift.mjs --self-test` (green),
`go test ./test/regression/ -count=1` (green), `just lint-actions`, `markdownlint-cli2` on the four
touched docs, `CHECK=all node .github/scripts/forbid-skip.mjs`,
`node .github/scripts/assert-gate-suites-wired.mjs`, `node .github/scripts/ci-lane-contract.mjs`.

Closes #2937

🤖 Generated with [Claude Code](https://claude.com/claude-code)
