### PR TITLE
fix(ci): stop generating the mutants no compiler accepts, and stop vet judging the rest

### DIFF
--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -164,7 +164,7 @@ jobs:
       # opaque `gremlins exited N` with no artifact and no measured-vs-threshold
       # numbers.
       #
-      # We consume gremlins via the tsouza/gremlins fork, which carries three
+      # We consume gremlins via the tsouza/gremlins fork, which carries five
       # fixes cerberus needs:
       #
       #   --on-shutdown-status=not-run   in-flight mutants killed by the
@@ -192,6 +192,37 @@ jobs:
       #     the compiler did: `Not viable: 0` on every leg was the tell that the
       #     status had never once been reported. The fork no longer generates
       #     them (#2930).
+      #
+      #   a candidate mutant is type-checked before it is emitted
+      #     The line above is one instance of a wider gap: a token table says
+      #     what a rewrite MEANS for a token read on its own, and whether the
+      #     result is a program depends on the operand types, the constant
+      #     values around it, and what statements the enclosing function
+      #     admits. `a + "-" + b` has no `-` on this tree either; `const week
+      #     = 7 * 24 * time.Hour` mutates into a legal constant expression
+      #     whose `d / week` further down is a division by zero; and
+      #     INVERT_LOOPCTRL turns the `continue` that keeps a `for {}` from
+      #     terminating into a `break` that leaves the function missing a
+      #     return. The fork type-checks the candidate's whole PACKAGE — the
+      #     package, because the error need not appear where the mutation is —
+      #     and does not emit it if that fails (#2933). A package it cannot
+      #     load and type-check as it stands is not used as an oracle at all:
+      #     its mutants are generated and left to the compiler, as before.
+      #
+      #   the mutated tests run with `-vet=off`
+      #     `go test` runs a subset of `go vet` before it builds anything and
+      #     reports a finding as `FAIL pkg [build failed]`, which from the
+      #     outside is source that does not compile. Its bools analyzer rejects
+      #     exactly what INVERT_LOGICAL produces from `name == a || name == b`
+      #     — a conjunction of equalities against distinct constants, "suspect
+      #     and". Those mutants are legal Go and a real change of behaviour, so
+      #     the fix is not to stop generating them (that would drop mutants the
+      #     suite ought to be asked about) but to stop letting a style analyzer
+      #     decide whether a mutant may be adjudicated. This is the one entry
+      #     in this list that can MOVE a leg's number rather than only correct
+      #     its meaning: 78 mutants that used to leave the ratio as NOT VIABLE
+      #     now get a real verdict, and one that nothing kills is a genuine gap
+      #     in the suite (#2933).
       # Routed through go-module-fetch.mjs because gremlins is NOT in go.mod, so
       # the warm step in ./.github/actions/setup-go — which runs
       # `go mod download` over the main module's own requirements — does not
@@ -204,7 +235,7 @@ jobs:
       - name: install gremlins
         run: >
           node .github/scripts/go-module-fetch.mjs --
-          go install github.com/tsouza/gremlins/cmd/gremlins@v0.6.0-cerberus-unary-operators-consume
+          go install github.com/tsouza/gremlins/cmd/gremlins@v0.6.0-cerberus-viable-mutants-consume
       # `workers: 0` keeps gremlins' default (runtime.NumCPU()); a
       # non-zero value caps the parallel `go test` fan-out per the
       # comment above the matrix entry.

--- a/docs/toolchain.md
+++ b/docs/toolchain.md
@@ -49,7 +49,7 @@ because that rule has no auto-fixer of its own.
 `mutation.yml` installs the `tsouza/gremlins` fork rather than upstream `go-gremlins/gremlins@v0.6.0`:
 
 ```bash
-go install github.com/tsouza/gremlins/cmd/gremlins@v0.6.0-cerberus-unary-operators-consume
+go install github.com/tsouza/gremlins/cmd/gremlins@v0.6.0-cerberus-viable-mutants-consume
 ```
 
 The fixes it carries defend one thing between them: that the number a run reports is a number the
@@ -119,13 +119,44 @@ leg's honest score is identical either way, since `NOT VIABLE` leaves both sides
 set padded with entries no compiler accepts measures nothing. The `NOT VIABLE` classification stays
 for a genuine build failure from any other source.
 
+**A candidate mutant is type-checked before it is emitted.** Reading a prefix operator as a prefix
+operator is one instance of a wider gap: the mutation table describes what a rewrite *means* for a
+token read on its own, and whether the result is a program depends on the operand types, on the
+constant values around it, and on what statements the enclosing function admits — none of which is
+in the token. Three shapes of that survived on this tree. `hint.Name + "=" + hint.Value.String()`
+became `operator - not defined on ... (variable of type string)`, since Go defines `+` on strings
+and nothing else; `const week = 7 * 24 * time.Hour` became a legal constant expression whose `d /
+week` three lines down is a division by zero; and `INVERT_LOOPCTRL` turned the `continue` that keeps
+a `for {}` from terminating into a `break` (`missing return`), and a `break` inside a `switch` no
+loop encloses into a `continue` that is not in a loop.
+
+The fork type-checks the candidate's whole **package** before emitting it — the package, because the
+error a mutation causes need not appear where the mutation is, as the constant case shows. One
+type-check (~100ms on `internal/promql`) buys back a whole recompile-link-run cycle (~10s) whenever
+it rejects, and generation runs on its own goroutine behind the executor pool, so the lane pays
+nothing for it. A package that cannot be loaded and type-checked as it stands is not used as an
+oracle at all: its mutants are generated and left to the compiler exactly as before, and a log line
+names the package. Dropping a mutant nobody proved illegal would shrink the set a score is measured
+against, which is the one direction a mutation tool must not move in.
+
+**`go vet` does not decide whether a mutant may be adjudicated.** `go test` runs a subset of `go
+vet` before it builds anything and reports a finding as `FAIL pkg [build failed]` — from the outside
+indistinguishable from source that does not compile. Its `bools` analyzer rejects exactly what
+`INVERT_LOGICAL` produces from `name == a || name == b`: a conjunction of equalities against
+distinct constants, which it calls "suspect and". Those mutants are legal Go and a real change of
+behaviour — the predicate becomes unsatisfiable, and any test exercising either operand kills it —
+so the fork keeps generating them and runs the mutated tests with `-vet=off`. This is the one fix in
+this list that can MOVE a leg's number rather than only correct its meaning: mutants that used to
+leave the ratio as `NOT VIABLE` now get a real verdict, and one that nothing kills is a genuine gap
+in the suite rather than an artefact.
+
 `.gremlins.yaml`'s `exclude-files` paths are interpreted relative to the run's scope, not the repo
 root, and the matcher is RE2 with no lookahead. A path in the wrong form silently excludes nothing.
 
 The fork ships two branches on purpose. `cerberus-sigterm-fix` at tag
-`v0.6.0-cerberus-unary-operators` is the branch the upstream pull request is built from, and keeps
+`v0.6.0-cerberus-viable-mutants` is the branch the upstream pull request is built from, and keeps
 the upstream module path `github.com/go-gremlins/gremlins` so the diff stays reviewable.
-`cerberus-sigterm-fix-consume` at tag `v0.6.0-cerberus-unary-operators-consume` is the branch
+`cerberus-sigterm-fix-consume` at tag `v0.6.0-cerberus-viable-mutants-consume` is the branch
 `mutation.yml` installs; it adds one commit renaming the `go.mod` module path to
 `github.com/tsouza/gremlins` and rewriting the internal imports, because `go install` otherwise
 rejects the module with `module declares its path as: github.com/go-gremlins/gremlins`. The fixes

--- a/test/regression/mutation_timeout_max_test.go
+++ b/test/regression/mutation_timeout_max_test.go
@@ -67,7 +67,18 @@ const (
 //     the exit-status collapse above then booked each one KILLED. `Not viable:
 //     0` on every leg was the tell: the status had never once been reported,
 //     and three legs measured 52, 57 and 88 lost kills apiece once it was.
-const gremlinsForkTag = "github.com/tsouza/gremlins/cmd/gremlins@v0.6.0-cerberus-unary-operators-consume"
+//   - the `viable-mutants` family (#2933): type-checks a candidate mutant's
+//     whole package before emitting it, closing the 156 remaining mutants no
+//     compiler accepts — string concatenation mutated to subtraction, a
+//     constant mutated to zero and then divided by, a loop-control statement
+//     moved somewhere it is not legal. It also runs the mutated tests with
+//     `-vet=off`, which is the only entry in this list that MOVES a leg's
+//     number rather than correcting its meaning: 78 INVERT_LOGICAL mutants
+//     that `go vet` used to reject as "suspect and" — legal Go, and a real
+//     change of behaviour — now reach a test binary and are adjudicated.
+//     Reverting to an earlier tag puts them back outside the denominator,
+//     which reads as a leg getting easier when it has only stopped asking.
+const gremlinsForkTag = "github.com/tsouza/gremlins/cmd/gremlins@v0.6.0-cerberus-viable-mutants-consume"
 
 // TestMutationLaneCapsPerMutantTimeout (#1294) pins the one bound that keeps the
 // mutation lane from killing its own runner.
@@ -134,9 +145,12 @@ func TestMutationLaneCapsPerMutantTimeout(t *testing.T) {
 		t.Errorf("%s does not install %s. Fork tags older than the flag reject %s outright, so the lane "+
 			"fails on every leg — loud, but still broken. Every tag after it is worse than loud: the "+
 			"`timeout-max` family spends the bound on the compiler, so a mutant times out having never "+
-			"run a line of test code (#2910), and everything before `unary-operators` mutates a prefix "+
+			"run a line of test code (#2910); everything before `unary-operators` mutates a prefix "+
 			"`&` as if it were bitwise AND, so mutants that cannot parse are booked as detections and "+
-			"the leg is paid efficacy for the compiler's work (#2930).",
+			"the leg is paid efficacy for the compiler's work (#2930); and everything before "+
+			"`viable-mutants` emits 156 more mutants no compiler accepts and lets `go vet` withhold a "+
+			"verdict from 78 that are legal Go, shrinking the denominator a leg is measured against "+
+			"(#2933).",
 			mutationWorkflowPath, gremlinsForkTag, timeoutMaxFlag)
 	}
 }


### PR DESCRIPTION
The tail of #2891's three-part cleanup. #2903/#2911 stopped scoring a starved runner as a
detection, #2919/#2921 gave a memory-reaped runner a verdict, #2930/#2932 stopped crediting
uncompilable mutants as kills. This is the 234 that #2932 left — the control in its own
measurement, unchanged before and after, so a bounded set rather than an estimate.

## What the 234 were

| mutator | records | mechanism |
| --- | ---: | --- |
| `ARITHMETIC_BASE` | 150 | the operand's type, or a constant's value, forbids the mutated operator |
| `INVERT_ASSIGNMENTS` | 5 | the same, through `s += x` on a string |
| `INVERT_LOOPCTRL` | 1 | the statement is not legal where it sits |
| `INVERT_LOGICAL` | 78 | `go test`'s own vet pass rejects it — **not** a compile question |

One root under the first three: gremlins' table says what a rewrite *means* for a token read in
isolation, which is all a table can say. Whether the result is a program depends on the operand
types, on the constant values around it, and on what statements the enclosing function admits —
none of which is in the token. #2930's prefix-versus-infix case was the positional instance of the
same thing.

## Mechanism 1 and 3: type-check the candidate's whole package before emitting it

Both are decided exactly by `go/types`, and the same check decides both, so there is one mechanism
rather than two rules. Reproduced against the real toolchain, each of them:

```
./zoo.go:30:41: invalid operation: operator - not defined on a (variable of type string)
./zoo.go:39:44: invalid operation: division by zero
./zoo.go:54:1:  missing return
./zoo.go:61:3:  continue is not in a loop
```

The unit is the **package**, not the expression, and that is not incidental. `const week = 7 * 24 *
time.Hour` mutated `MUL -> QUO` is a perfectly legal constant expression on its own line; it is the
`d / week` three lines down that becomes a division by zero. Anything narrower cannot see it. The
issue offered "restrict by operand shape without types" as the cheap alternative, and the corpus
rules it out on its own evidence: `internal/traceql/ast/attribute.go:96` is `return prefix + name`
and `internal/promql/histogram_native_range_fn.go:613` is `return hqWindowAllArrayAliasPrefix +
alias`. No string literal anywhere in either `+` chain. A shape heuristic misses both, and it would
have missed the constant case entirely.

**Cost.** One type-check per candidate mutant, measured at ~100ms for `internal/promql` (101 files,
93k lines) against a ~10s per-mutant recompile-link-run. It *removes* cycles rather than adding
them, and generation runs on its own goroutine behind the executor pool, so it is hidden entirely
behind execution. Package load is ~3.5s per package directory, once. Peak RSS of the loaded graph
for `internal/promql` is 366 MB.

**Degradation.** A package that cannot be loaded and type-checked *as it stands* is not used as an
oracle at all: its mutants are generated and left to the compiler exactly as before, and a log line
names the package. That falls out of a single baseline check rather than an enumeration of failure
modes — wrong build tags, an unresolved dependency, a language version `go/types` cannot express all
land there. The direction matters: silently dropping a mutant nobody proved illegal would shrink the
set a score is measured against.

One bug worth naming, because it made the first version of this a silent no-op: gremlins'
`GoModule.Root` is `"."` whenever the scope is given as a relative path, which is how every
documented invocation gives it, while `go list` reports absolute paths. The index never matched and
the checker suppressed nothing while looking like it worked. It is fixed, and a file the checker
cannot answer for now says so out loud rather than answering "viable".

## Mechanism 2: `-vet=off`, not a refusal to generate

This one is argued rather than assumed, because it is the one place where "do not generate it" is
the *wrong* answer.

`go test` runs a subset of `go vet` before it builds anything and reports a finding as
`FAIL pkg [build failed]` — from the outside, indistinguishable from source that does not compile.
Its `bools` analyzer rejects exactly what `INVERT_LOGICAL` produces from `name == a || name == b`: a
conjunction of equalities against two distinct **constants**, "suspect and". (It ignores the same
shape over variables, whose values it cannot compare — worth knowing, because a fixture built from
parameters does not reproduce the bug.)

Every one of those 78 is legal Go and a real change of behaviour. `go build` accepts them without a
word; the mutated predicate is unsatisfiable where the original was not; a suite exercising either
operand kills it. Refusing to generate them would drop from the corpus mutants the suite *ought to
be asked about* — the one direction a mutation tool must never shrink in, and the same argument this
repo makes against tolerance files. What is wrong is not the mutant; it is that a style analyzer
gets to decide whether a mutant may be adjudicated at all. So the analyzer leaves the loop. It also
takes a vet pass off every mutant's build, on a tool whose cost is dominated by builds.

**This is the one half of this change that can move a leg's number.** 78 mutants that used to leave
both sides of `killed / (killed + lived + timedOut)` now get a real verdict. If all are killed a leg
rises slightly; if one lives, that is a gap in the suite that was never being asked about, and it
gets fixed at the test rather than absorbed or floored away. The full matrix on this PR is what
measures it.

## The gates, and that they can fail

Four tests in the fork, all behavioural:

- **`TestEveryGeneratedMutantCompiles`** — builds a package exercising every operator the table maps
  plus every shape above, applies each generated mutant, hands it to the real compiler. The fixture
  is widened, and the engine now runs over a real directory rather than an `fstest.MapFS`, because a
  map in memory is not something a compiler can be asked about.
- **`TestTheViabilityCheckIsWhatKeepsTheZooCompiling`** — the break-proof. Identical generation with
  the check removed, and the compiler must reject **exactly** the sites the fixture marks
  `// illegal:`. Neither a fixture that quietly stopped exercising a shape (missing rejection) nor a
  check that suppresses more than the compiler would (extra rejection) leaves the first test
  passing. Verified in both directions by deliberately mis-marking the fixture.
- **`TestViabilityKeepsTheLegalMutationsAtTheSameSites`** — the over-suppression guard, since
  removing mutants is precisely how a score gets inflated. Every mutation marked `// legal:` at
  those same sites must survive.
- **`TestMutantsAreRunWithVetDisabled`** — runs the suspect conjunction through `go test` twice,
  with the flag and without, and requires the second to fail on `suspect and`. Both halves, because
  only the pair is evidence: one shows the mutant now builds and runs, the other shows it is the
  flag that makes it. Verified to fail when `-vet=off` is removed from `getTestArgs`.

Break-proof for the compile gate, with the check sabotaged — all four diagnostics, at their sources:

```
--- FAIL: TestEveryGeneratedMutantCompiles
    ./zoo.go:30:41: invalid operation: operator - not defined on a (variable of type string)
    ./zoo.go:30:41: invalid operation: operator - not defined on a + "-" (value of type string)
    ./zoo.go:31:37: invalid operation: operator - not defined on a (variable of type string)
    ./zoo.go:39:44: invalid operation: division by zero
    ./zoo.go:54:1:  missing return
    ./zoo.go:61:3:  continue is not in a loop
```

## Before / after on this tree

`--dry-run` with the shipped binary against one built with the check disabled, over every scope the
lane's 30 legs use. The unchecked column is the control:

| scope | candidates before | after | removed |
| --- | ---: | ---: | ---: |
| `internal/chplan` | 1034 | 1022 | 12 |
| `internal/chsql` | 1687 | 1607 | 80 |
| `internal/logql` | 1152 | 1117 | 35 |
| `internal/optimizer` | 119 | 110 | 9 |
| `internal/promql` | 1948 | 1913 | 35 |
| `internal/qlcommon` | 328 | 319 | 9 |
| `internal/spansscan` | 112 | 107 | 5 |
| `internal/traceql` | 688 | 632 | 56 |
| **total** | **7068** | **6827** | **241** |

**Added: 0, everywhere.** By mutator: 230 `ARITHMETIC_BASE`, 6 `INVERT_ASSIGNMENTS`, 4
`INVERT_LOOPCTRL`, 1 `INVERT_BITWISE`. Every removal was read back against its source line and is
string concatenation, a constant that becomes zero and is then divided by, or a loop-control
statement moved somewhere it is not legal.

241 exceeds the issue's 234 because a dry run enumerates every candidate including the `NOT COVERED`
ones, which never reached a verdict there was a `NOT VIABLE` to report; and because the 78
`INVERT_LOGICAL` are not in this column at all — they are still generated, and are now run.

Two things the corpus said that the issue did not predict:

- **The single `INVERT_LOOPCTRL` record is the mirror image of the one #2933 describes.** The issue
  predicted `break` inside a `switch` becoming `continue is not in a loop`. The actual record,
  `internal/logql/jsonpath.go:168`, is a `continue` — and it is what keeps `next()`'s `for {}` from
  terminating, so `break` leaves the function `missing return`. Both shapes are in the fixture; only
  the second was ever generated here. The other three the sweep found are the predicted shape, in
  `case` arms of type switches that no loop encloses.
- **A fifth shape nobody predicted.** `internal/optimizer/constant_fold.go:367` is
  `func foldNumeric[T int64 | float64]`, and the `|` of a type-parameter constraint is an
  `*ast.BinaryExpr` like any other, so `INVERT_BITWISE` still reached it after #2930:
  `int64 & float64 is not a type`. Nothing about it resembles the four shapes that were catalogued.
  That is the argument for a type-check over a rule per shape, made by the corpus rather than by me.

## Fork

New tags on both branches, fetched and installed from the module proxy before this PR was opened:

- `v0.6.0-cerberus-viable-mutants` (`cerberus-sigterm-fix`, upstream module path, reviewable diff)
- `v0.6.0-cerberus-viable-mutants-consume` (`cerberus-sigterm-fix-consume`, the one the lane
  installs)

The two branches differ only by module path — verified by normalising the import prefix out of the
inter-branch diff and confirming every remaining line pairs. `test/regression/mutation_timeout_max_test.go`
pins the tag whole, with the family history extended; `docs/toolchain.md`'s fork section gains both
fixes. The fork's own suite is green and `golangci-lint` is at its pre-change baseline of 39
findings, none in the new files.

## Not verified here

- **Efficacy movement.** Nothing local can measure it; the full matrix runs on this PR because
  `.github/workflows/mutation.yml` is a `HARNESS_PATHS` entry. Any leg that moves gets explained
  against these numbers, not absorbed, and no floor moves either way.
- **The dry runs above ran against this branch's tree**, which has drifted from the SHA the issue's
  artifacts were read from (`2c347cf`). Per-site correspondence was checked by source text rather
  than by line number, and every site the issue named is in the removed set.

Closes #2933

🤖 Generated with [Claude Code](https://claude.com/claude-code)
