### PR TITLE
test(traceql): kill six phase4-traceql-ast survivors and prove the other six equivalent

### DIFF
--- a/docs/test-strategy.md
+++ b/docs/test-strategy.md
@@ -1276,6 +1276,38 @@ Prior PRs #504 and #664 carry pattern-#3 refactors. They are not
 reverted (their diffs are now load-bearing for the published
 thresholds), but new violations should follow remedy #1 or #2.
 
+### Non-terminating mutants and a leg's irreducible ceiling
+
+A hand-written scanner — a lexer, a regex source walk, a replacement
+template parser — advances an induction variable by hand. Every mutation
+that stops that variable advancing (`i++` -> `i--`, `i += n` -> `i = n`,
+`break` -> `continue`, a loop guard negated, an offset arithmetic flipped)
+turns the loop into a non-terminating one. The mutated program does not
+compute a wrong answer; it computes no answer. Some spin on the CPU, and
+some append to a buffer inside the loop and grow without bound, which the
+per-mutant memory ceiling stops as a TIMED OUT verdict rather than a
+detection.
+
+Such a mutant is a PERMANENT cost with the same shape as a proven
+equivalent, and for the arithmetic it is worse: an equivalent is at least
+diluted by a bigger leg, and a timeout is too, but neither can ever be
+converted into a kill by writing a test. No assertion runs against a
+program that never returns. The consequence is a hard ceiling, and it is
+arithmetic rather than judgement: a leg whose TIMED OUT count plus its
+documented-equivalent count exceeds 5% of its own attempted total cannot
+reach the 95% floor however strong its assertions are. The remedy is the
+same dilution lever the surviving-mutant policy names — re-partition the
+leg wider against `gremlins unleash --dry-run` — applied to the package's
+scanner-bearing files, and it works only while the combined permanent cost
+stays under the margin.
+
+Recognising the class matters because it is easy to misread as budget
+starvation and answer with a bigger `--timeout-max`. It is not: the
+mutants below are non-terminating against any finite budget. The tell is
+the per-mutant memory notice the lane emits — a mutant that reaches the
+1GiB ceiling in a package whose whole test binary peaks near 100MiB is
+running away, not running slowly.
+
 ## Grafana surface crawler (Layer 9 extension)
 
 `test/e2e/playwright/crawl/` extends Layer 9 from *enumerated* UX

--- a/internal/traceql/ast/expr_mutation_test.go
+++ b/internal/traceql/ast/expr_mutation_test.go
@@ -1,0 +1,84 @@
+package ast
+
+import "testing"
+
+// Mutation-coverage tests for expr.go: the type-inference contract of the
+// composite field/scalar expression nodes.
+
+// TestBinaryOperationImpliedTypePrefersConcreteLHS pins BinaryOperation's
+// inference rule: a non-boolean operator takes its type from the LHS whenever
+// the LHS resolves to something concrete, and only falls through to the RHS
+// when the LHS is an unresolved attribute reference. Negating that guard
+// (`t != TypeAttribute` -> `t == TypeAttribute`) swaps the two arms, so each
+// case below is asserted with an LHS and an RHS of DIFFERENT types.
+func TestBinaryOperationImpliedTypePrefersConcreteLHS(t *testing.T) {
+	t.Parallel()
+	attr := NewScopedAttribute(AttributeScopeSpan, false, "http.status_code")
+	tests := []struct {
+		name string
+		op   *BinaryOperation
+		want StaticType
+	}{
+		{
+			name: "concrete LHS wins over a differently typed RHS",
+			op:   &BinaryOperation{Op: OpAdd, LHS: NewStaticInt(1), RHS: NewStaticString("a")},
+			want: TypeInt,
+		},
+		{
+			name: "attribute LHS falls through to the RHS",
+			op:   &BinaryOperation{Op: OpAdd, LHS: attr, RHS: NewStaticString("a")},
+			want: TypeString,
+		},
+		{
+			name: "boolean operator short-circuits both operands",
+			op:   &BinaryOperation{Op: OpEqual, LHS: NewStaticInt(1), RHS: NewStaticInt(2)},
+			want: TypeBoolean,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if got := tc.op.impliedType(); got != tc.want {
+				t.Fatalf("(%s).impliedType() = %v; want %v", tc.op.String(), got, tc.want)
+			}
+		})
+	}
+}
+
+// TestScalarOperationImpliedTypePrefersConcreteLHS is the ScalarOperation
+// twin of the test above. The two nodes carry the same inference rule in
+// duplicated code, and each copy is its own mutation site.
+func TestScalarOperationImpliedTypePrefersConcreteLHS(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name string
+		op   ScalarOperation
+		want StaticType
+	}{
+		{
+			name: "concrete LHS wins over a differently typed RHS",
+			op:   ScalarOperation{Op: OpAdd, LHS: NewStaticInt(1), RHS: NewStaticString("a")},
+			want: TypeInt,
+		},
+		{
+			name: "attribute-typed LHS falls through to the RHS",
+			// An Aggregate over a bare attribute is the reachable scalar
+			// whose implied type is TypeAttribute.
+			op:   ScalarOperation{Op: OpAdd, LHS: newAggregate(AggregateMax, NewScopedAttribute(AttributeScopeSpan, false, "x")), RHS: NewStaticString("a")},
+			want: TypeString,
+		},
+		{
+			name: "boolean operator short-circuits both operands",
+			op:   ScalarOperation{Op: OpGreater, LHS: NewStaticInt(1), RHS: NewStaticInt(2)},
+			want: TypeBoolean,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if got := tc.op.impliedType(); got != tc.want {
+				t.Fatalf("(%s).impliedType() = %v; want %v", tc.op.String(), got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/traceql/ast/lexer.go
+++ b/internal/traceql/ast/lexer.go
@@ -514,6 +514,12 @@ func (l *lexer) tryScopeAttribute() (tokenKind, bool) {
 		if !isAttributeRune(r) {
 			break
 		}
+		// `>=` here would be indistinguishable from `>`: the '.' arm above
+		// fires first, so sb holds at most len(prefix)-1 bytes while a
+		// dot-terminated prefix is being scanned, and the only two prefixes
+		// this function acts on are 5 and 9 bytes long. Both forms build
+		// them, and every longer run ends on a string no keyword matches.
+		// See lexer_mutation_test.go's NOT KILLABLE footer.
 		if sb.Len() > longestScopePrefix {
 			break
 		}
@@ -540,6 +546,11 @@ func (l *lexer) tryScanDuration(number string) (time.Duration, bool) {
 	consumed := 0
 	for {
 		r := probe.Peek()
+		// The EOF/space arm is a readability shortcut, not a distinct exit:
+		// the character test below rejects every rune this arm catches, since
+		// no rune is at once a space and a digit, a duration rune or '.'. An
+		// `&&` here leaves the loop on the same input, one line later. See
+		// lexer_mutation_test.go's NOT KILLABLE footer.
 		if r == scanner.EOF || unicode.IsSpace(r) {
 			break
 		}

--- a/internal/traceql/ast/lexer_mutation_test.go
+++ b/internal/traceql/ast/lexer_mutation_test.go
@@ -135,3 +135,27 @@ func TestParentScopedAttribute(t *testing.T) {
 		t.Errorf("Name = %q; want service.name", attr.Name)
 	}
 }
+
+// NOT KILLABLE — documented, not defended by a test.
+//
+// lexer.go:523:15 (CONDITIONALS_BOUNDARY, `if sb.Len() > longestScopePrefix`
+// -> `>=`). tryScopeAttribute only ever ACTS on the two keywords that map to
+// tokSpanDot / tokResourceDot — "span." (5 bytes) and "resource." (9) — and
+// the '.' arm two branches above fires before this length check, so sb holds
+// at most 4 and 8 bytes respectively when the check runs. Both forms build
+// both prefixes. For every other input the two forms differ only in whether
+// the probe stops at 9 or 10 bytes, and neither 9- nor 10-byte truncation of
+// a non-scope identifier is a key of keywordTokens, so both return
+// `0, false` having advanced nothing (the scanner is a value copy). An
+// exhaustive check of keywordTokens confirms no key mapping to tokSpanDot or
+// tokResourceDot exceeds longestScopePrefix.
+//
+// lexer.go:554:23 (INVERT_LOGICAL, `if r == scanner.EOF ||
+// unicode.IsSpace(r)` -> `&&`). This arm is subsumed by the character test on
+// the next branch: `!unicode.IsNumber(r) && !isDurationRune(r) && r != '.'`
+// breaks for every rune the EOF/space arm catches, because no rune is at once
+// a space and a digit, one of isDurationRune's nine letters, or '.'. Under
+// `&&` the loop leaves one branch later having consumed nothing extra, so
+// `consumed`, `sb` and the scanner are identical. Enumerating every rune in
+// [-1, 0x10FFFF] and comparing the composite break decision of the two forms
+// yields zero distinguishing inputs.

--- a/internal/traceql/ast/parse.go
+++ b/internal/traceql/ast/parse.go
@@ -188,6 +188,12 @@ func ParseIdentifier(s string) (Attribute, error) {
 	if err != nil {
 		return Attribute{}, fmt.Errorf("failed to parse identifier %s: %w", s, err)
 	}
+	// A post-condition check on an internal contract, not a branch: parseTree
+	// either fails or returns a non-nil RootExpr whose Pipeline holds at
+	// least one element, because parseRoot builds through newRootExpr* and
+	// asPipeline wraps a bare element in a one-element Pipeline. Both
+	// operands are therefore always false together, which makes an `&&` here
+	// indistinguishable. See parse_lenient_test.go's NOT KILLABLE footer.
 	if expr == nil || len(expr.Pipeline.Elements) == 0 {
 		return Attribute{}, fmt.Errorf("failed to parse identifier %s: no pipeline elements found", s)
 	}

--- a/internal/traceql/ast/parse_lenient_test.go
+++ b/internal/traceql/ast/parse_lenient_test.go
@@ -110,3 +110,36 @@ func TestReplaceIncompleteMatchersRequiresOperandAndRightBoundary(t *testing.T) 
 		})
 	}
 }
+
+// TestReplaceIncompleteMatchersScansPastAnUnrepairableComparison pins that a
+// comparison with no operand to its left — one that sits directly on a matcher
+// start boundary, so the backward scan lands on the comparison itself — is
+// SKIPPED rather than ending the scan. Turning that `continue` into a `break`
+// abandons every later token, so the genuinely incomplete matcher after it is
+// left in place and the lenient parse reports no change at all.
+func TestReplaceIncompleteMatchersScansPastAnUnrepairableComparison(t *testing.T) {
+	t.Parallel()
+	// `{ = && .x = }`: the first `=` has no left operand; the second one has.
+	toks := []token{
+		{kind: tokOpenBrace},
+		{kind: tokEq},
+		{kind: tokAnd},
+		{kind: tokName},
+		{kind: tokEq},
+		{kind: tokCloseBrace},
+	}
+	want := []tokenKind{tokOpenBrace, tokEq, tokAnd, tokTrue, tokCloseBrace}
+
+	got, changed := replaceIncompleteMatchers(toks)
+	if !changed {
+		t.Fatalf("replaceIncompleteMatchers changed = false, want true: the second matcher is repairable")
+	}
+	if len(got) != len(want) {
+		t.Fatalf("replaceIncompleteMatchers returned %d tokens, want %d: %+v", len(got), len(want), got)
+	}
+	for i, w := range want {
+		if got[i].kind != w {
+			t.Fatalf("replaceIncompleteMatchers token %d = %v, want %v", i, got[i].kind, w)
+		}
+	}
+}

--- a/internal/traceql/ast/parse_lenient_test.go
+++ b/internal/traceql/ast/parse_lenient_test.go
@@ -143,3 +143,17 @@ func TestReplaceIncompleteMatchersScansPastAnUnrepairableComparison(t *testing.T
 		}
 	}
 }
+
+// NOT KILLABLE — documented, not defended by a test.
+//
+// parse.go:197:17 (INVERT_LOGICAL, `if expr == nil ||
+// len(expr.Pipeline.Elements) == 0` -> `&&`). Both operands are always false
+// together, so neither form ever enters the branch. parseTokens returns a nil
+// expr only alongside a non-nil error, which ParseIdentifier has already
+// returned on; on the success path parseRoot returns the result of
+// newRootExpr, newRootExprWithMetrics or newRootExprWithMetricsTwoStage,
+// each of which is non-nil and sets Pipeline through asPipeline. asPipeline
+// either wraps a bare element in a one-element Pipeline or passes through a
+// Pipeline built from a slice seeded with a parsed first stage — non-empty in
+// both cases, and inductively so for nested parenthesised pipelines. The
+// guard is a post-condition check on that internal contract.

--- a/internal/traceql/ast/pipeline_mutation_test.go
+++ b/internal/traceql/ast/pipeline_mutation_test.go
@@ -139,3 +139,30 @@ func TestTopKBottomKString(t *testing.T) {
 		t.Errorf("TopKBottomK.String() = %q; want bottomk(9)", got)
 	}
 }
+
+// TestAggregateImpliedTypeCountIsInt pins Aggregate's two-step inference:
+// count() is an integer regardless of its (absent) inner expression, and every
+// other aggregate takes the inner expression's type. Negating the count guard
+// (`a.op == AggregateCount` -> `!=`) swaps the arms, which makes count() type
+// as TypeAttribute (its inner expression is nil) and max(<float>) type as
+// TypeInt.
+func TestAggregateImpliedTypeCountIsInt(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name string
+		agg  Aggregate
+		want StaticType
+	}{
+		{"count has no inner expression and is an integer", newAggregate(AggregateCount, nil), TypeInt},
+		{"max takes the inner expression's type", newAggregate(AggregateMax, NewStaticFloat(1.5)), TypeFloat},
+		{"a nil inner expression on a non-count aggregate is unresolved", newAggregate(AggregateMax, nil), TypeAttribute},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if got := tc.agg.impliedType(); got != tc.want {
+				t.Fatalf("(%s).impliedType() = %v; want %v", tc.agg.String(), got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/traceql/ast/rewrite.go
+++ b/internal/traceql/ast/rewrite.go
@@ -108,9 +108,17 @@ func foldArrayComparison(op *BinaryOperation) (FieldExpression, bool) {
 			continue
 		}
 		attrR, valR, ok := attrLiteralOperands(op.RHS, rule.scalar, rule.array)
+		// Reaching here means op.LHS carries one of THIS rule's two
+		// operators, and no later rule sharing this rule's outer operator
+		// shares either of them, so a `break` in place of the `continue`
+		// below would end the loop at the same `return nil, false`.
 		if !ok || attrL != attrR {
 			continue
 		}
+		// `restrict` is exactly the string family, which is also the only
+		// family staticMerge merges a string with, so the two operands are
+		// either both allowed or unmergeable. An `&&` on the inner condition
+		// reaches the same `continue` by way of staticMerge's rejection.
 		if len(rule.restrict) > 0 {
 			if !staticTypeAllowed(valL.Type, rule.restrict) || !staticTypeAllowed(valR.Type, rule.restrict) {
 				continue

--- a/internal/traceql/ast/rewrite_mutation_test.go
+++ b/internal/traceql/ast/rewrite_mutation_test.go
@@ -130,3 +130,34 @@ func TestArrayFoldNotAppliedAcrossOperators(t *testing.T) {
 		t.Errorf("Op = %v; want OpOr (no fold for mixed =/!=)", bin.Op)
 	}
 }
+
+// TestStaticTypeAllowedMatchesExactly pins staticTypeAllowed's membership
+// test. It is the gate on the two regex fold rules' `restrict` lists, and a
+// negated comparison (`t == a` -> `t != a`) turns it inside out: the loop then
+// returns true on the FIRST entry that does not match, so a single-entry
+// allow-list reports the opposite answer for both a member and a non-member.
+func TestStaticTypeAllowedMatchesExactly(t *testing.T) {
+	t.Parallel()
+	stringFamily := []StaticType{TypeString, TypeStringArray}
+	tests := []struct {
+		name    string
+		t       StaticType
+		allowed []StaticType
+		want    bool
+	}{
+		{"first entry matches", TypeString, stringFamily, true},
+		{"later entry matches", TypeStringArray, stringFamily, true},
+		{"no entry matches", TypeInt, stringFamily, false},
+		{"single-entry allow-list, member", TypeString, []StaticType{TypeString}, true},
+		{"single-entry allow-list, non-member", TypeInt, []StaticType{TypeString}, false},
+		{"empty allow-list admits nothing", TypeString, nil, false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if got := staticTypeAllowed(tc.t, tc.allowed); got != tc.want {
+				t.Fatalf("staticTypeAllowed(%v, %v) = %v; want %v", tc.t, tc.allowed, got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/traceql/ast/rewrite_mutation_test.go
+++ b/internal/traceql/ast/rewrite_mutation_test.go
@@ -161,3 +161,26 @@ func TestStaticTypeAllowedMatchesExactly(t *testing.T) {
 		})
 	}
 }
+
+// NOT KILLABLE — documented, not defended by a test.
+//
+// rewrite.go:115:4 (INVERT_LOOPCTRL, the `continue` under `if !ok || attrL !=
+// attrR`). Reaching that branch means attrLiteralOperands accepted op.LHS
+// against the CURRENT rule, so op.LHS's operator is that rule's `scalar` or
+// `array`. arrayFoldRules pairs the only two rules that share an outer
+// operator as {OpEqual, OpIn} with {OpRegex, OpRegexMatchAny} under `||`, and
+// {OpNotEqual, OpNotIn} with {OpNotRegex, OpRegexMatchNone} under `&&` — two
+// disjoint operand sets each time. Every later rule therefore fails at the
+// EARLIER `continue` (the op.LHS extraction) or at the outer-operator match,
+// so a `break` here reaches the same `return nil, false`.
+//
+// rewrite.go:123:52 (INVERT_LOGICAL, `if !staticTypeAllowed(valL.Type,
+// rule.restrict) || !staticTypeAllowed(valR.Type, rule.restrict)` -> `&&`).
+// Both rules that carry a `restrict` list carry the same one — the string
+// family, {TypeString, TypeStringArray} — and that family is exactly the set
+// staticMerge will merge a string with. So the two operands are either both
+// allowed (the mutant and the original both fall through to staticMerge and
+// fold) or at least one is outside the string family, in which case
+// staticMerge's own family check rejects the pair and the mutant reaches the
+// `continue` two branches later. There is no static type that is disallowed
+// by `restrict` yet mergeable with an allowed one.

--- a/internal/traceql/ast/static.go
+++ b/internal/traceql/ast/static.go
@@ -213,6 +213,11 @@ func (s Static) Elements() iter.Seq2[int, Static] {
 // line with the language's loose numeric comparison rules. A nil operand
 // on either side is never equal.
 func (s Static) Equals(o *Static) bool {
+	// An `&&` in place of this `||` is not observable. With exactly one nil
+	// operand the function falls through to the `s.Type != o.Type` check
+	// below, which is true for every mixed-nil pair and returns the same
+	// false; with two nil operands the `&&` is true anyway. See
+	// static_mutation_test.go's NOT KILLABLE footer.
 	if s.Type == TypeNil || o.Type == TypeNil {
 		return false
 	}

--- a/internal/traceql/ast/static_mutation_test.go
+++ b/internal/traceql/ast/static_mutation_test.go
@@ -211,3 +211,16 @@ func TestStaticEncodeToString(t *testing.T) {
 		t.Errorf("unquoted string = %q; want hi", got)
 	}
 }
+
+// NOT KILLABLE — documented, not defended by a test.
+//
+// static.go:221:23 (INVERT_LOGICAL, `if s.Type == TypeNil || o.Type ==
+// TypeNil` -> `&&`). The guard is a fast path for a result the rest of the
+// function already produces. With both operands nil the `&&` is true and both
+// forms return false. With exactly one nil operand the mutant falls through:
+// isNumeric is false for TypeNil, so the numeric arm is skipped; TypeNil is
+// neither TypeInt nor TypeStatus/TypeKind, so the cross-type switch is
+// skipped; and `s.Type != o.Type` is true for every mixed-nil pair, so the
+// mutant returns the same false one branch later. Comparing the two forms
+// over all 21 x 21 pairs of a corpus covering every StaticType yields zero
+// distinguishing pairs.

--- a/internal/traceql/ast/validate_test.go
+++ b/internal/traceql/ast/validate_test.go
@@ -394,3 +394,32 @@ func TestUnaryTypesValidSymmetryWithAttribute(t *testing.T) {
 		t.Error("OpNot.unaryTypesValid(TypeAttribute) = false, want true")
 	}
 }
+
+// TestValidateRegexPatternSkipsNonStringLiterals pins the type half of
+// validateRegexPattern's guard. The compile-time regex check is defined only
+// for a literal String pattern: every other static encodes to text that was
+// never written as a pattern, so feeding it to regexp.Compile would reject
+// queries on the strength of an encoding artefact.
+//
+// The array-valued node below is built directly rather than parsed, because
+// the grammar never puts an array literal on a scalar regex operator — which
+// is the point. The guard is what keeps such a node (from a future rewrite, a
+// lenient-parse path, or an in-package caller) out of regexp.Compile, and an
+// empty array encodes to "[]", which is not a valid regular expression. A
+// mutation that turns the guard's `||` into `&&` lets it through and turns
+// this valid-by-construction node into a validation error.
+func TestValidateRegexPatternSkipsNonStringLiterals(t *testing.T) {
+	t.Parallel()
+	attr := NewScopedAttribute(AttributeScopeSpan, false, "http.route")
+	for _, op := range []Operator{OpRegex, OpNotRegex} {
+		bin := &BinaryOperation{Op: op, LHS: attr, RHS: NewStaticStringArray(nil)}
+		if err := validateRegexPattern(bin); err != nil {
+			t.Errorf("validateRegexPattern(%s) = %v; want nil (a non-String static is not a pattern)", bin.String(), err)
+		}
+	}
+	// The String half of the guard still reaches the compiler.
+	bad := &BinaryOperation{Op: OpRegex, LHS: attr, RHS: NewStaticString("[")}
+	if err := validateRegexPattern(bad); err == nil {
+		t.Error("validateRegexPattern({ span.http.route =~ `[` }) = nil; want an invalid-regex rejection")
+	}
+}


### PR DESCRIPTION
Addresses the tractable half of #2917 and answers the other half with evidence.
It does **not** close #2917: two of its three acceptance criteria are met, and the
first one — `phase4-traceql-ast` clears 95% — is shown to be unreachable as
written. #2944 carries what remains.

## What this changes

**Six `phase4-traceql-ast` survivors become assertions.** Each one was proven
individually: the mutation applied by hand to the production source, the new test
observed to FAIL, the mutation reverted, the test observed to PASS.

| site | mutation | what distinguishes it |
| --- | --- | --- |
| `expr.go:56` | `t != TypeAttribute` -> `==` | a `BinaryOperation` whose LHS and RHS type differently, so the fall-through arm is observable |
| `expr.go:100` | `t != TypeAttribute` -> `==` | the `ScalarOperation` twin of the same rule, its own mutation site |
| `pipeline.go:190` | `a.op == AggregateCount` -> `!=` | `count()` types as `TypeInt`; the mutant reads its nil inner expression and answers `TypeAttribute` |
| `rewrite.go:164` | `t == a` -> `!=` | a single-entry allow-list, which the mutant answers the opposite way for both a member and a non-member |
| `validate.go:422` | `!ok \|\| Type != TypeString` -> `&&` | an array-valued RHS, which the mutant hands to `regexp.Compile` |
| `parse.go:99` | the `start >= i` `continue` -> `break` | a repairable incomplete matcher standing AFTER an unrepairable comparison |

**The other six are proven equivalent**, per `docs/test-strategy.md`'s
surviving-mutant policy remedy #1: a comment at the site plus an entry in that
file's `NOT KILLABLE — documented, not defended by a test.` footer. Each was
re-applied and confirmed to survive the full package suite, so none is a weak
assertion in disguise, and two carry exhaustive evidence rather than an argument
alone — every rune in `[-1, 0x10FFFF]` for `lexer.go:543`, all 21x21 `StaticType`
pairs for `static.go:216`.

| site | mutation | why it is not observable |
| --- | --- | --- |
| `lexer.go:517` | `sb.Len() > longestScopePrefix` -> `>=` | the `'.'` arm fires before the length check, so it sees at most 4 and 8 bytes for the only two prefixes the function acts on |
| `lexer.go:543` | `r == EOF \|\| IsSpace(r)` -> `&&` | subsumed by the character test on the next branch; no rune is at once a space and a digit, a duration rune or `'.'` |
| `parse.go:191` | `expr == nil \|\| len(...) == 0` -> `&&` | a post-condition on an internal contract; both operands are always false together |
| `rewrite.go:112` | `continue` -> `break` | no later fold rule sharing this rule's outer operator shares either of its operand operators |
| `rewrite.go:115` | `!allowed(L) \|\| !allowed(R)` -> `&&` | `restrict` is exactly the family `staticMerge` merges a string with, so the operands are both allowed or unmergeable |
| `static.go:216` | `s.Type == TypeNil \|\| o.Type == TypeNil` -> `&&` | mixed-nil falls through to `s.Type != o.Type` and returns the same false |

Six documented equivalents against 228 attempted mutants is 2.6%, inside the 5%
dilution margin the policy sets.

**`docs/test-strategy.md` gains a section naming the non-terminating-mutant
class** — what it is, why a bigger `--timeout-max` does not convert it, and the
ceiling it sets on a leg that carries one.

## The arithmetic, measured

This PR's own mutation run
[33646427445](https://github.com/tsouza/cerberus/actions/runs/33646427445)
confirms the change exactly: the six survivors are gone, and the six that remain
`LIVED` are precisely the six documented equivalents, at their post-comment line
numbers.

```
before   208 killed / 12 lived /  8 timed out / 228 attempted = 91.23%
after    221 killed /  6 lived /  8 timed out / 235 attempted = 94.04%
needed   224 killed                            / 235          = 95.32%
```

Killed rose by 13 rather than 6 because the new tests also cover seven mutants
that were previously `NOT COVERED` and kill all seven; mutator coverage went
82.71% -> 89.02% and `NOT COVERED` fell 46 -> 28. Neither sibling leg regressed:
`phase4-traceql-parser` 95.00% -> 95.16%, `phase4-traceql-lower` 94.48% -> 94.77%.

94.04% is the leg's ceiling, not a step towards the bar. Six proven equivalents
plus eight timeouts is 14 of 235 — a 5.96% permanent cost against the 5% margin
`docs/test-strategy.md` sets — and neither is convertible by writing a test.
Taking the most optimistic remaining lever, covering AND killing all 28 of the
leg's uncovered mutants, reaches 249/263 = 94.68%, one mutant short of the 250 the
floor asks for.

## What the other two legs' timeouts are

Every one of the 42 timeouts on `phase4-logql-lsyntax` (25) and `phase5-qlcommon`
(17) is a mutation of a hand-written scanner's induction variable, in a loop the
scanner advances by hand: `i++` -> `i--`, `i += n` -> `i = n`, `break` ->
`continue`, a scan guard negated, an offset return flipped, a sentinel parent
index made real. Eleven were applied by hand and run against their own package's
suite under a 2GiB cgroup cap and the Go test watchdog. **None of the eleven
terminated** — six were killed at the memory cap in 3-14s, five ran until the
watchdog fired. For scale, the unmutated `internal/logql/lsyntax` suite runs in
0.07s at 117MiB peak and `internal/qlcommon` in 6.7s at 87MiB.

They are not compile starvation. #2903's measured budget and #2929's run-only
leash had already removed that, which is why the counts did not move across either
change, and a non-terminating program does not terminate on a bigger budget.

## What this deliberately does not do

No `exclude_files` widening, no `include_files` narrowing, no bar lowered, no
denominator shrunk. `.github/scripts/mutation-phases.mjs` and
`.github/scripts/mutation-matrix.mjs` are untouched. A leg that reports green
because its scanner was excluded is the lie #2903, #2919 and #2930 exist to
remove, and an honest red is worth more than that.

## What remains

#2944 — the three legs' ceilings, the per-mutant evidence, and the two levers that
would actually move them: adjudicating a run-phase timeout as a detection (the
compile-starvation cause #2903 was answering is gone), and a per-mutant
suppression flag in the `tsouza/gremlins` fork so a documented equivalent stops
being paid on every future run. Neither is a change a survivor-killing PR should
make on its own judgement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
