### PR TITLE
test(mutation): kill the four -vet=off survivors and prove the fifth equivalent

### DIFF
--- a/internal/chsql/exemplars_misc_mutation_test.go
+++ b/internal/chsql/exemplars_misc_mutation_test.go
@@ -162,6 +162,87 @@ func TestMetricsCompareScanBoundRequiresBothEnds(t *testing.T) {
 	}
 }
 
+// TestExemplarsRateAndCountIgnoreAttr pins the two-site agreement that
+// makes the exemplar Value column well-formed for the counting ops:
+// EmitMetricsExemplars projects the metric operand as `metric_arg` ONLY
+// when the op is neither rate nor count_over_time (exemplars.go:179), so
+// the Value expression must reach for `argMax(1, ts)` — never
+// `argMax(metric_arg, ts)` — for exactly those two ops
+// (exemplars.go:275). Whether the caller left Attr set is irrelevant:
+// rate and count_over_time count rows, and the operand a caller may have
+// attached is deliberately ignored.
+//
+// Inverting the `||` at exemplars.go:275 makes that guard unsatisfiable.
+// A rate/count_over_time node carrying an Attr then falls into the
+// `else if m.Attr != nil` arm and emits `argMax(metric_arg, ts)` against
+// a column the inner SELECT never projected — SQL ClickHouse rejects at
+// parse time. Nothing in the suite asked, because every test built the
+// counting ops with a nil Attr, where both forms collapse onto the same
+// `argMax(1, ts)` else-arm (cerberus issue #2943; the mutant reached a
+// verdict for the first time once #2940 stopped `go vet`'s bools
+// analyzer rejecting it as "suspect and").
+//
+// EmitMetricsExemplars is an exported emitter entrypoint whose input is
+// a *chplan.MetricsAggregate, so "no lowering builds that combination
+// today" is not a property of this package and cannot be what keeps the
+// emitted SQL well-formed. The guard is.
+func TestExemplarsRateAndCountIgnoreAttr(t *testing.T) {
+	t.Parallel()
+
+	start := time.Date(2026, 5, 13, 12, 0, 0, 0, time.UTC)
+	end := time.Date(2026, 5, 13, 12, 5, 0, 0, time.UTC)
+
+	emit := func(t *testing.T, op chplan.MetricsOp, attr chplan.Expr) string {
+		t.Helper()
+		m := &chplan.MetricsAggregate{
+			Op:             op,
+			Attr:           attr,
+			GroupBy:        []chplan.Expr{&chplan.ColumnRef{Name: "resource.service.name"}},
+			GroupByAliases: []string{"resource.service.name"},
+			ValueAlias:     "Value",
+			Inner:          &chplan.Scan{Table: "otel_traces"},
+		}
+		rw := &chplan.RangeWindow{
+			Input:           m,
+			Step:            time.Minute,
+			Range:           time.Minute,
+			Start:           start,
+			End:             end,
+			TimestampColumn: "Timestamp",
+		}
+		sql, _, err := chsql.EmitMetricsExemplars(context.Background(), rw, m, "TraceId", "SpanId", 0, "")
+		if err != nil {
+			t.Fatalf("EmitMetricsExemplars(op=%v): %v", op, err)
+		}
+		return sql
+	}
+
+	for _, op := range []chplan.MetricsOp{chplan.MetricsOpRate, chplan.MetricsOpCountOverTime} {
+		op := op
+		t.Run(op.String(), func(t *testing.T) {
+			t.Parallel()
+			sql := emit(t, op, &chplan.ColumnRef{Name: "Duration"})
+			if !strings.Contains(sql, "toFloat64(argMax(1, `ts`))") {
+				t.Errorf("%v with an Attr must still count rows via argMax(1, ts):\n%s", op, sql)
+			}
+			if strings.Contains(sql, "metric_arg") {
+				t.Errorf("%v must never reference metric_arg — the inner SELECT does not project it:\n%s", op, sql)
+			}
+		})
+	}
+
+	// Counter-case: an op that DOES read the operand projects metric_arg
+	// and reduces over it, so the two assertions above are discriminating
+	// rather than true of every emitted exemplar statement.
+	t.Run("sum_over_time reads the operand", func(t *testing.T) {
+		t.Parallel()
+		sql := emit(t, chplan.MetricsOpSumOverTime, &chplan.ColumnRef{Name: "Duration"})
+		if !strings.Contains(sql, "toFloat64(argMax(`metric_arg`, `ts`))") {
+			t.Errorf("sum_over_time must reduce over the projected metric_arg:\n%s", sql)
+		}
+	})
+}
+
 // NOT KILLABLE — documented, not defended by a test.
 //
 // exemplars.go:292:18 (CONDITIONALS_BOUNDARY, `if maxPerSeries > 0` ->

--- a/internal/chsql/exemplars_misc_mutation_test.go
+++ b/internal/chsql/exemplars_misc_mutation_test.go
@@ -164,16 +164,17 @@ func TestMetricsCompareScanBoundRequiresBothEnds(t *testing.T) {
 
 // TestExemplarsRateAndCountIgnoreAttr pins the two-site agreement that
 // makes the exemplar Value column well-formed for the counting ops:
-// EmitMetricsExemplars projects the metric operand as `metric_arg` ONLY
-// when the op is neither rate nor count_over_time (exemplars.go:179), so
-// the Value expression must reach for `argMax(1, ts)` — never
-// `argMax(metric_arg, ts)` — for exactly those two ops
-// (exemplars.go:275). Whether the caller left Attr set is irrelevant:
+// EmitMetricsExemplars's inner SELECT projects the metric operand as
+// `metric_arg` ONLY when the op is neither rate nor count_over_time, so
+// its Value expression must reach for `argMax(1, ts)` — never
+// `argMax(metric_arg, ts)` — for exactly those two ops. The two guards
+// are a pair: whichever one moves, the other has to move with it.
+// Whether the caller left Attr set is irrelevant:
 // rate and count_over_time count rows, and the operand a caller may have
 // attached is deliberately ignored.
 //
-// Inverting the `||` at exemplars.go:275 makes that guard unsatisfiable.
-// A rate/count_over_time node carrying an Attr then falls into the
+// Inverting the `||` on the Value-expression guard makes it
+// unsatisfiable. A rate/count_over_time node carrying an Attr then falls into the
 // `else if m.Attr != nil` arm and emits `argMax(metric_arg, ts)` against
 // a column the inner SELECT never projected — SQL ClickHouse rejects at
 // parse time. Nothing in the suite asked, because every test built the

--- a/internal/chsql/range_window_grid_native_ts_axis_test.go
+++ b/internal/chsql/range_window_grid_native_ts_axis_test.go
@@ -4,6 +4,9 @@ import (
 	"context"
 	"strings"
 	"testing"
+	"time"
+
+	"github.com/tsouza/cerberus/internal/chplan"
 )
 
 // The native ts-grid aggregates take their timestamp axis as the FIRST
@@ -31,12 +34,12 @@ import (
 // the first time once #2940 stopped `go vet`'s bools analyzer rejecting it as
 // "suspect and").
 //
-// The assertion below is a class-level ratchet driven by the emitter's OWN
-// registry, in the same shape as TestNativeTSGrid_ScanBound_EveryRegisteredFunc
-// in range_window_grid_native_scan_bound_test.go: every registered native
-// function must have its axis choice recorded here, so a function added later
-// cannot ship without one, and the two axis forms are mutually exclusive so
-// neither expectation can be satisfied vacuously.
+// nativeGridTsAxisFrag has TWO callers — the range emitter
+// (range_window_grid_native.go) and the instant one
+// (range_window_grid_native_instant.go), which build different node types and
+// so cannot share one driver. Both are covered below, mirroring the way
+// range_window_grid_native_scan_bound_test.go pairs its registry loop with
+// TestNativeTSGrid_ScanBound_Resample for the node type that loop cannot reach.
 
 // nativeWholeSecondTsAxis records, per registered native function, whether its
 // timestamp axis is the whole-second `toDateTime(<ts>)` form (true) or the raw
@@ -55,44 +58,86 @@ var nativeWholeSecondTsAxis = map[string]bool{
 }
 
 // nativeTsAxisRaw / nativeTsAxisWholeSecond are the two renderings of the axis
-// argument as it appears at the head of the aggregate's argument group.
+// argument as it appears at the head of the aggregate's argument group. Under
+// strings.HasPrefix over the argument group they are mutually exclusive in both
+// directions, so asserting the expected one is enough — no negative half is
+// needed to tell them apart.
 const (
-	nativeTsAxisRaw          = "`" + nativeScanBoundTSCol + "`"
-	nativeTsAxisWholeSecond  = "toDateTime(`" + nativeScanBoundTSCol + "`)"
-	errNativeAggNotRendered  = "emitted SQL contains no %q call — the expression did not reach the native emitter"
-	errNativeAggUnterminated = "emitted SQL's %q call is unterminated — cannot read its argument group"
+	nativeTsAxisRaw         = "`" + nativeScanBoundTSCol + "`"
+	nativeTsAxisWholeSecond = "toDateTime(`" + nativeScanBoundTSCol + "`)"
 )
 
-// nativeGridArgGroup returns the text of the argument (second) paren group of
-// the first `fn(params...)(args...)` parametric call in sql. The params group
-// nests parens of its own (`toDateTime(…, 'UTC')`), so the scan matches them
-// rather than searching for the first `)`.
+// nativeGridArgGroup returns the text INSIDE the argument (second) paren group
+// of the first `fn(params...)(args...)` parametric call in sql. Both groups
+// nest parens of their own (`toDateTime(…, 'UTC')` in the params,
+// `toDateTime(<ts>)` in the args), so each is found by matching parens rather
+// than by searching for the next `)`.
+//
+// It reads the FIRST such call. Every caller below emits exactly one native
+// node — the range cases are guarded by requireNativeNodeCount(t, plan, 1) and
+// the instant case builds a single node by hand — which matters because `rate`
+// and `increase` share the aggregate name `timeSeriesRateToGrid`, so a plan
+// carrying two native nodes would silently be asserted on its first one only.
+// The `fn+"("` match also keeps the `…ToGridState(` / `…ToGridMerge(`
+// combinators from being mistaken for the aggregate itself.
 func nativeGridArgGroup(sql, fn string) (string, bool) {
-	i := strings.Index(sql, fn+"(")
-	if i < 0 {
+	open := strings.Index(sql, fn+"(")
+	if open < 0 {
 		return "", false
 	}
+	paramsEnd, ok := matchParen(sql, open+len(fn))
+	if !ok || paramsEnd+1 >= len(sql) || sql[paramsEnd+1] != '(' {
+		return "", false
+	}
+	argsEnd, ok := matchParen(sql, paramsEnd+1)
+	if !ok {
+		return "", false
+	}
+	return sql[paramsEnd+2 : argsEnd], true
+}
+
+// matchParen returns the index of the `)` closing the `(` at position open, or
+// false when the group is unterminated.
+func matchParen(s string, open int) (int, bool) {
 	depth := 0
-	for j := i + len(fn); j < len(sql); j++ {
-		switch sql[j] {
+	for i := open; i < len(s); i++ {
+		switch s[i] {
 		case '(':
 			depth++
 		case ')':
 			depth--
 			if depth == 0 {
-				// End of the params group; the args group opens next.
-				if j+1 >= len(sql) || sql[j+1] != '(' {
-					return "", false
-				}
-				return sql[j+2:], true
+				return i, true
 			}
 		}
 	}
-	return "", false
+	return 0, false
+}
+
+// assertNativeTsAxis fails unless the aggregate's argument group leads with the
+// axis form recorded for fn.
+func assertNativeTsAxis(t *testing.T, fn, aggFn, sql string, wholeSecond bool) {
+	t.Helper()
+
+	args, ok := nativeGridArgGroup(sql, aggFn)
+	if !ok {
+		t.Fatalf("%s: emitted SQL contains no complete %q parametric call — the expression did not reach the native emitter\nSQL: %s",
+			fn, aggFn, sql)
+	}
+	want := nativeTsAxisRaw
+	if wholeSecond {
+		want = nativeTsAxisWholeSecond
+	}
+	if !strings.HasPrefix(args, want+",") {
+		t.Errorf("%s: %s's timestamp axis is not %s — the emitted grid would be computed on the wrong x-axis\nargument group: %s",
+			fn, aggFn, want, args)
+	}
 }
 
 // TestNativeTSGrid_TsAxis_EveryRegisteredFunc pins the per-function timestamp
-// axis for every member of the emitter's native registry.
+// axis for every member of the emitter's native registry, through the RANGE
+// emitter. Driven by the registry itself, so a native aggregate registered
+// later cannot ship without recording an axis choice here.
 func TestNativeTSGrid_TsAxis_EveryRegisteredFunc(t *testing.T) {
 	t.Parallel()
 
@@ -121,28 +166,100 @@ func TestNativeTSGrid_TsAxis_EveryRegisteredFunc(t *testing.T) {
 			if err != nil {
 				t.Fatalf("emit %q: %v", tc.query, err)
 			}
-			args, ok := nativeGridArgGroup(sql, agg.Fn)
-			if !ok {
-				if !strings.Contains(sql, agg.Fn+"(") {
-					t.Fatalf(errNativeAggNotRendered+"\nSQL: %s", agg.Fn, sql)
-				}
-				t.Fatalf(errNativeAggUnterminated+"\nSQL: %s", agg.Fn, sql)
-			}
+			assertNativeTsAxis(t, fn, agg.Fn, sql, wholeSecond)
+		})
+	}
+}
 
-			want, unwanted := nativeTsAxisRaw, nativeTsAxisWholeSecond
-			if wholeSecond {
-				want, unwanted = nativeTsAxisWholeSecond, nativeTsAxisRaw
+// nativeTsAxisInstantWindow / nativeTsAxisInstantHorizon are the instant
+// fixture's lookback window and predict_linear's whole-second horizon t.
+const (
+	nativeTsAxisInstantWindow  = 5 * time.Minute
+	nativeTsAxisInstantHorizon = 3600
+)
+
+// nativeTsAxisInstantOutOfScope names the two registry members the INSTANT
+// emitter rejects outright rather than emitting: the lowering never builds an
+// instant node for them, and the emitter fails loudly instead of accepting a
+// shape nothing has differentially proven (cerberus issue #2748). They are
+// therefore skipped by the loop below rather than left silently uncovered.
+var nativeTsAxisInstantOutOfScope = map[string]bool{"increase": true, "delta": true}
+
+// TestNativeTSGrid_TsAxis_InstantEmitter covers nativeGridTsAxisFrag's OTHER
+// caller. RangeWindowGridNativeInstant is a distinct node type with its own
+// emitter, so the registry loop above cannot reach it — the same gap
+// TestNativeTSGrid_ScanBound_Resample closes for the scan bound.
+//
+// The node is built directly rather than lowered: instant native routing is
+// per-function opt-in at the lowering seam, and this test is about the
+// emitter's axis choice, not about which queries reach it.
+func TestNativeTSGrid_TsAxis_InstantEmitter(t *testing.T) {
+	t.Parallel()
+
+	anchor := time.Date(2029, 2, 3, 4, 0, 0, 0, time.UTC)
+
+	for fn, agg := range nativeTSGridFn {
+		if nativeTsAxisInstantOutOfScope[fn] {
+			continue
+		}
+		wholeSecond, recorded := nativeWholeSecondTsAxis[fn]
+		if !recorded {
+			t.Errorf("nativeTSGridFn registers %q but nativeWholeSecondTsAxis records no timestamp-axis choice for it", fn)
+			continue
+		}
+		t.Run(fn, func(t *testing.T) {
+			t.Parallel()
+
+			node := &chplan.RangeWindowGridNativeInstant{
+				Input:           &chplan.Scan{Table: "otel_metrics_gauge"},
+				Func:            fn,
+				Range:           nativeTsAxisInstantWindow,
+				Anchor:          anchor,
+				TimestampColumn: nativeScanBoundTSCol,
+				ValueColumn:     "Value",
+				GroupBy:         []chplan.Expr{&chplan.ColumnRef{Name: "Attributes"}},
 			}
-			if !strings.HasPrefix(args, want+",") {
-				t.Errorf("%s: %s's timestamp axis is not %s — the emitted grid would be computed on the "+
-					"wrong x-axis\nargument group: %s", fn, agg.Fn, want, args)
+			if fn == "predict_linear" {
+				node.Scalars = []float64{nativeTsAxisInstantHorizon}
 			}
-			// Mutually exclusive by construction: the whole-second form
-			// CONTAINS the raw form, so the negative half is asserted only
-			// for the raw expectation, where it is discriminating.
-			if !wholeSecond && strings.HasPrefix(args, unwanted+",") {
-				t.Errorf("%s: %s's timestamp axis is %s, but this function reads the raw column\n"+
-					"argument group: %s", fn, agg.Fn, unwanted, args)
+			sql, _, err := Emit(context.Background(), node)
+			if err != nil {
+				t.Fatalf("emit instant %q: %v", fn, err)
+			}
+			assertNativeTsAxis(t, fn, agg.Fn, sql, wholeSecond)
+		})
+	}
+}
+
+// TestNativeTSGrid_TsAxis_InstantOutOfScopeStillRejected keeps the skip list
+// above honest: the two functions it excludes are excluded because the instant
+// emitter REFUSES them, not because covering them was inconvenient. If either
+// ever starts emitting, this fails and the skip has to be reconsidered rather
+// than quietly hiding an uncovered axis choice.
+func TestNativeTSGrid_TsAxis_InstantOutOfScopeStillRejected(t *testing.T) {
+	t.Parallel()
+
+	anchor := time.Date(2029, 2, 3, 4, 0, 0, 0, time.UTC)
+
+	if len(nativeTsAxisInstantOutOfScope) == 0 {
+		t.Fatal("nativeTsAxisInstantOutOfScope is empty — this test would vacuously pass")
+	}
+	for fn := range nativeTsAxisInstantOutOfScope {
+		t.Run(fn, func(t *testing.T) {
+			t.Parallel()
+
+			node := &chplan.RangeWindowGridNativeInstant{
+				Input:           &chplan.Scan{Table: "otel_metrics_gauge"},
+				Func:            fn,
+				Range:           nativeTsAxisInstantWindow,
+				Anchor:          anchor,
+				TimestampColumn: nativeScanBoundTSCol,
+				ValueColumn:     "Value",
+				GroupBy:         []chplan.Expr{&chplan.ColumnRef{Name: "Attributes"}},
+			}
+			if _, _, err := Emit(context.Background(), node); err == nil {
+				t.Fatalf("instant emitter accepted %q — it is listed as out of scope, so either the "+
+					"exclusion in nativeTsAxisInstantOutOfScope is stale or the axis choice is now uncovered", fn)
 			}
 		})
 	}

--- a/internal/chsql/range_window_grid_native_ts_axis_test.go
+++ b/internal/chsql/range_window_grid_native_ts_axis_test.go
@@ -1,0 +1,149 @@
+package chsql
+
+import (
+	"context"
+	"strings"
+	"testing"
+)
+
+// The native ts-grid aggregates take their timestamp axis as the FIRST
+// argument of the second (argument) paren group:
+//
+//	timeSeriesRateToGrid(start, end, step_s, window_s)(<ts axis>, value)
+//
+// nativeGridTsAxisFrag decides what that axis is per function, and the choice
+// is NOT cosmetic. The regression pair (deriv, predict_linear) is handed a
+// whole-second `toDateTime(<ts>)` axis so the emitted values stay BIT-IDENTICAL
+// to the fan-out lowering, whose own x-axis is the floored
+// `dateDiff('second', anchor, ts)`; the rest of the family reads the raw
+// DateTime64 column. See nativeGridTsAxisFrag's own doc for the numerical
+// argument behind each half.
+//
+// Inverting the `||` in
+//
+//	if fn == "deriv" || fn == "predict_linear" {
+//
+// makes the test unsatisfiable, so the regression pair silently drops to the
+// raw axis. That is a change of emitted SQL — and of the values ClickHouse
+// computes — that nothing failed on: the existing deriv / predict_linear
+// activation tests assert the aggregate NAME and its parametric prefix, both of
+// which are unchanged (cerberus issue #2943; the mutant reached a verdict for
+// the first time once #2940 stopped `go vet`'s bools analyzer rejecting it as
+// "suspect and").
+//
+// The assertion below is a class-level ratchet driven by the emitter's OWN
+// registry, in the same shape as TestNativeTSGrid_ScanBound_EveryRegisteredFunc
+// in range_window_grid_native_scan_bound_test.go: every registered native
+// function must have its axis choice recorded here, so a function added later
+// cannot ship without one, and the two axis forms are mutually exclusive so
+// neither expectation can be satisfied vacuously.
+
+// nativeWholeSecondTsAxis records, per registered native function, whether its
+// timestamp axis is the whole-second `toDateTime(<ts>)` form (true) or the raw
+// timestamp column (false). Only the least-squares regression pair takes the
+// whole-second axis; see the file header.
+var nativeWholeSecondTsAxis = map[string]bool{
+	"rate":           false,
+	"increase":       false,
+	"changes":        false,
+	"resets":         false,
+	"deriv":          true,
+	"predict_linear": true,
+	"delta":          false,
+	"irate":          false,
+	"idelta":         false,
+}
+
+// nativeTsAxisRaw / nativeTsAxisWholeSecond are the two renderings of the axis
+// argument as it appears at the head of the aggregate's argument group.
+const (
+	nativeTsAxisRaw          = "`" + nativeScanBoundTSCol + "`"
+	nativeTsAxisWholeSecond  = "toDateTime(`" + nativeScanBoundTSCol + "`)"
+	errNativeAggNotRendered  = "emitted SQL contains no %q call — the expression did not reach the native emitter"
+	errNativeAggUnterminated = "emitted SQL's %q call is unterminated — cannot read its argument group"
+)
+
+// nativeGridArgGroup returns the text of the argument (second) paren group of
+// the first `fn(params...)(args...)` parametric call in sql. The params group
+// nests parens of its own (`toDateTime(…, 'UTC')`), so the scan matches them
+// rather than searching for the first `)`.
+func nativeGridArgGroup(sql, fn string) (string, bool) {
+	i := strings.Index(sql, fn+"(")
+	if i < 0 {
+		return "", false
+	}
+	depth := 0
+	for j := i + len(fn); j < len(sql); j++ {
+		switch sql[j] {
+		case '(':
+			depth++
+		case ')':
+			depth--
+			if depth == 0 {
+				// End of the params group; the args group opens next.
+				if j+1 >= len(sql) || sql[j+1] != '(' {
+					return "", false
+				}
+				return sql[j+2:], true
+			}
+		}
+	}
+	return "", false
+}
+
+// TestNativeTSGrid_TsAxis_EveryRegisteredFunc pins the per-function timestamp
+// axis for every member of the emitter's native registry.
+func TestNativeTSGrid_TsAxis_EveryRegisteredFunc(t *testing.T) {
+	t.Parallel()
+
+	if len(nativeTSGridFn) == 0 {
+		t.Fatal("nativeTSGridFn is empty — the ratchet below would vacuously pass")
+	}
+
+	for fn, agg := range nativeTSGridFn {
+		wholeSecond, recorded := nativeWholeSecondTsAxis[fn]
+		if !recorded {
+			t.Errorf("nativeTSGridFn registers %q but nativeWholeSecondTsAxis records no timestamp-axis "+
+				"choice for it — record one, or the new native aggregate ships with no axis coverage", fn)
+			continue
+		}
+		tc, ok := nativeScanBoundCases[fn]
+		if !ok {
+			t.Errorf("nativeTSGridFn registers %q but nativeScanBoundCases has no expression for it", fn)
+			continue
+		}
+		t.Run(fn, func(t *testing.T) {
+			t.Parallel()
+
+			plan := lowerNativeScanBound(t, tc.query, tc.lowerers)
+			requireNativeNodeCount(t, plan, 1)
+			sql, _, err := Emit(context.Background(), plan)
+			if err != nil {
+				t.Fatalf("emit %q: %v", tc.query, err)
+			}
+			args, ok := nativeGridArgGroup(sql, agg.Fn)
+			if !ok {
+				if !strings.Contains(sql, agg.Fn+"(") {
+					t.Fatalf(errNativeAggNotRendered+"\nSQL: %s", agg.Fn, sql)
+				}
+				t.Fatalf(errNativeAggUnterminated+"\nSQL: %s", agg.Fn, sql)
+			}
+
+			want, unwanted := nativeTsAxisRaw, nativeTsAxisWholeSecond
+			if wholeSecond {
+				want, unwanted = nativeTsAxisWholeSecond, nativeTsAxisRaw
+			}
+			if !strings.HasPrefix(args, want+",") {
+				t.Errorf("%s: %s's timestamp axis is not %s — the emitted grid would be computed on the "+
+					"wrong x-axis\nargument group: %s", fn, agg.Fn, want, args)
+			}
+			// Mutually exclusive by construction: the whole-second form
+			// CONTAINS the raw form, so the negative half is asserted only
+			// for the raw expectation, where it is discriminating.
+			if !wholeSecond && strings.HasPrefix(args, unwanted+",") {
+				t.Errorf("%s: %s's timestamp axis is %s, but this function reads the raw column\n"+
+					"argument group: %s", fn, agg.Fn, unwanted, args)
+			}
+		})
+	}
+}

--- a/internal/chsql/range_window_metrics_reducer_mutation_test.go
+++ b/internal/chsql/range_window_metrics_reducer_mutation_test.go
@@ -14,6 +14,10 @@ import (
 // the expected divisor a readable literal.
 const metricsReducerRouteStep = time.Minute
 
+// metricsReducerRouteSpanSteps is the grid span in steps, so the fixture
+// covers several anchors rather than the instant-fallback single one.
+const metricsReducerRouteSpanSteps = 5
+
 // metricsReducerRouteZeroFillReducer is the reducer emitRangeWindowMetrics
 // renders for the ops that zero-fill empty buckets: the sample arm tags every
 // real row `1 AS in_window` and the generator arm tags every (group, anchor)
@@ -25,6 +29,25 @@ const (
 	metricsReducerRouteRateDivisor     = " / 60"
 	metricsReducerRouteOperandReducer  = "toFloat64(sum(`metric_arg`))"
 )
+
+// metricsOpZeroFillExpectation records, for EVERY chplan.MetricsOp, whether
+// the matrix path zero-fills its empty buckets. rate and count_over_time do
+// because Tempo's aggregators emit 0 for an empty bucket; quantile_over_time
+// does too (and is additionally routed to the bucket-shape emitter before the
+// reducer choice is made); the observed-only ops do not, because Tempo
+// initialises their aggregators to NaN and skips empty buckets on the wire.
+// MetricsOpInvalid is the zero value and reaches no reducer at all.
+var metricsOpZeroFillExpectation = map[chplan.MetricsOp]bool{
+	chplan.MetricsOpInvalid:           false,
+	chplan.MetricsOpRate:              true,
+	chplan.MetricsOpCountOverTime:     true,
+	chplan.MetricsOpQuantileOverTime:  true,
+	chplan.MetricsOpSumOverTime:       false,
+	chplan.MetricsOpAvgOverTime:       false,
+	chplan.MetricsOpMinOverTime:       false,
+	chplan.MetricsOpMaxOverTime:       false,
+	chplan.MetricsOpHistogramOverTime: false,
+}
 
 // metricsReducerRoutePlan builds the matrix-path RangeWindow the emitter walks
 // for op, over a spans inner with a bounded request window.
@@ -45,7 +68,7 @@ func metricsReducerRoutePlan(op chplan.MetricsOp) *chplan.RangeWindow {
 		Step:            metricsReducerRouteStep,
 		Range:           metricsReducerRouteStep,
 		Start:           start,
-		End:             start.Add(5 * metricsReducerRouteStep),
+		End:             start.Add(metricsReducerRouteSpanSteps * metricsReducerRouteStep),
 		TimestampColumn: "Timestamp",
 	}
 }
@@ -113,31 +136,22 @@ func TestMetricsMatrixCountingOpsTakeTheZeroFillReducer(t *testing.T) {
 	})
 
 	// The predicate that routes the two counting ops away from
-	// metricsReducerFrag, asserted directly. quantile_over_time is listed
-	// because it zero-fills too, and is additionally routed to the
-	// bucket-shape emitter before the reducer choice is even made.
+	// metricsReducerFrag, asserted directly and over the WHOLE enum rather
+	// than a hand-picked sample: an op added to chplan.MetricsOp later must
+	// have its zero-fill answer recorded here, or this fails. That is what
+	// keeps the equivalence note at the foot of this file from quietly going
+	// stale behind a new op.
 	t.Run("zero-fill op set", func(t *testing.T) {
 		t.Parallel()
-		zeroFilling := []chplan.MetricsOp{
-			chplan.MetricsOpRate,
-			chplan.MetricsOpCountOverTime,
-			chplan.MetricsOpQuantileOverTime,
-		}
-		for _, op := range zeroFilling {
-			if !metricsOpZeroFillsEmptyBuckets(op) {
-				t.Errorf("metricsOpZeroFillsEmptyBuckets(%v) = false, want true", op)
+		for op := chplan.MetricsOpInvalid; op <= chplan.MetricsOpHistogramOverTime; op++ {
+			want, recorded := metricsOpZeroFillExpectation[op]
+			if !recorded {
+				t.Errorf("chplan.MetricsOp %v (%d) has no recorded zero-fill expectation — record one, "+
+					"or the new op ships with no coverage of the predicate this file's equivalence note depends on", op, op)
+				continue
 			}
-		}
-		observedOnly := []chplan.MetricsOp{
-			chplan.MetricsOpSumOverTime,
-			chplan.MetricsOpAvgOverTime,
-			chplan.MetricsOpMinOverTime,
-			chplan.MetricsOpMaxOverTime,
-			chplan.MetricsOpHistogramOverTime,
-		}
-		for _, op := range observedOnly {
-			if metricsOpZeroFillsEmptyBuckets(op) {
-				t.Errorf("metricsOpZeroFillsEmptyBuckets(%v) = true, want false", op)
+			if got := metricsOpZeroFillsEmptyBuckets(op); got != want {
+				t.Errorf("metricsOpZeroFillsEmptyBuckets(%v) = %v, want %v", op, got, want)
 			}
 		}
 	})

--- a/internal/chsql/range_window_metrics_reducer_mutation_test.go
+++ b/internal/chsql/range_window_metrics_reducer_mutation_test.go
@@ -1,0 +1,177 @@
+package chsql
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/tsouza/cerberus/internal/chplan"
+)
+
+// metricsReducerRouteStep is the matrix grid step these fixtures use; the
+// rate reducer divides by the window seconds, so a whole-minute step keeps
+// the expected divisor a readable literal.
+const metricsReducerRouteStep = time.Minute
+
+// metricsReducerRouteZeroFillReducer is the reducer emitRangeWindowMetrics
+// renders for the ops that zero-fill empty buckets: the sample arm tags every
+// real row `1 AS in_window` and the generator arm tags every (group, anchor)
+// `0`, so summing the tag counts observed samples and answers 0 for an anchor
+// with none. metricsReducerRouteRateDivisor is the extra `/ <window seconds>`
+// rate applies on top.
+const (
+	metricsReducerRouteZeroFillReducer = "toFloat64(sum(in_window))"
+	metricsReducerRouteRateDivisor     = " / 60"
+	metricsReducerRouteOperandReducer  = "toFloat64(sum(`metric_arg`))"
+)
+
+// metricsReducerRoutePlan builds the matrix-path RangeWindow the emitter walks
+// for op, over a spans inner with a bounded request window.
+func metricsReducerRoutePlan(op chplan.MetricsOp) *chplan.RangeWindow {
+	start := time.Date(2026, 5, 13, 12, 0, 0, 0, time.UTC)
+	m := &chplan.MetricsAggregate{
+		Op:             op,
+		GroupBy:        []chplan.Expr{&chplan.ColumnRef{Name: "resource.service.name"}},
+		GroupByAliases: []string{"resource.service.name"},
+		ValueAlias:     "Value",
+		Inner:          &chplan.Scan{Table: "otel_traces"},
+	}
+	if op != chplan.MetricsOpRate && op != chplan.MetricsOpCountOverTime {
+		m.Attr = &chplan.ColumnRef{Name: "Duration"}
+	}
+	return &chplan.RangeWindow{
+		Input:           m,
+		Step:            metricsReducerRouteStep,
+		Range:           metricsReducerRouteStep,
+		Start:           start,
+		End:             start.Add(5 * metricsReducerRouteStep),
+		TimestampColumn: "Timestamp",
+	}
+}
+
+// TestMetricsMatrixCountingOpsTakeTheZeroFillReducer pins the routing fact the
+// NOT KILLABLE note at the foot of this file depends on: in the matrix path,
+// rate and count_over_time are answered by the zero-fill reducer
+// (metricsSumWeightReducerFrag) and never reach metricsReducerFrag at all.
+//
+// The two are not interchangeable. metricsSumWeightReducerFrag sums the
+// per-row `in_window` weight, which is what makes an anchor with no samples
+// answer 0 — Tempo's rate/count_over_time aggregators emit 0 for an empty
+// bucket, and dropping the row instead would answer with a hole. So this is a
+// wire-visible contract in its own right, not merely bookkeeping about which
+// helper runs.
+//
+// The observed-only counter-case keeps the assertion discriminating: sum_over_time
+// takes the OTHER branch and reduces over the projected operand, so a change
+// that routed everything through one reducer fails here.
+func TestMetricsMatrixCountingOpsTakeTheZeroFillReducer(t *testing.T) {
+	t.Parallel()
+
+	emit := func(t *testing.T, op chplan.MetricsOp) string {
+		t.Helper()
+		sql, _, err := Emit(WithSpansTable(context.Background(), "otel_traces"), metricsReducerRoutePlan(op))
+		if err != nil {
+			t.Fatalf("Emit(op=%v): %v", op, err)
+		}
+		return sql
+	}
+
+	t.Run("rate", func(t *testing.T) {
+		t.Parallel()
+		sql := emit(t, chplan.MetricsOpRate)
+		if !strings.Contains(sql, metricsReducerRouteZeroFillReducer+metricsReducerRouteRateDivisor) {
+			t.Errorf("rate must reduce with %s%s so an empty anchor answers 0:\n%s",
+				metricsReducerRouteZeroFillReducer, metricsReducerRouteRateDivisor, sql)
+		}
+		if strings.Contains(sql, metricsReducerRouteOperandReducer) {
+			t.Errorf("rate must not reduce over metric_arg:\n%s", sql)
+		}
+	})
+
+	t.Run("count_over_time", func(t *testing.T) {
+		t.Parallel()
+		sql := emit(t, chplan.MetricsOpCountOverTime)
+		if !strings.Contains(sql, metricsReducerRouteZeroFillReducer) {
+			t.Errorf("count_over_time must reduce with %s so an empty anchor answers 0:\n%s",
+				metricsReducerRouteZeroFillReducer, sql)
+		}
+		if strings.Contains(sql, metricsReducerRouteZeroFillReducer+metricsReducerRouteRateDivisor) {
+			t.Errorf("count_over_time must NOT divide by the window seconds — that is rate's normalisation:\n%s", sql)
+		}
+	})
+
+	t.Run("sum_over_time stays observed-only", func(t *testing.T) {
+		t.Parallel()
+		sql := emit(t, chplan.MetricsOpSumOverTime)
+		if !strings.Contains(sql, metricsReducerRouteOperandReducer) {
+			t.Errorf("sum_over_time must reduce over the projected metric_arg:\n%s", sql)
+		}
+		if strings.Contains(sql, metricsReducerRouteZeroFillReducer) {
+			t.Errorf("sum_over_time must not take the zero-fill reducer — Tempo skips its empty buckets:\n%s", sql)
+		}
+	})
+
+	// The predicate that routes the two counting ops away from
+	// metricsReducerFrag, asserted directly. quantile_over_time is listed
+	// because it zero-fills too, and is additionally routed to the
+	// bucket-shape emitter before the reducer choice is even made.
+	t.Run("zero-fill op set", func(t *testing.T) {
+		t.Parallel()
+		zeroFilling := []chplan.MetricsOp{
+			chplan.MetricsOpRate,
+			chplan.MetricsOpCountOverTime,
+			chplan.MetricsOpQuantileOverTime,
+		}
+		for _, op := range zeroFilling {
+			if !metricsOpZeroFillsEmptyBuckets(op) {
+				t.Errorf("metricsOpZeroFillsEmptyBuckets(%v) = false, want true", op)
+			}
+		}
+		observedOnly := []chplan.MetricsOp{
+			chplan.MetricsOpSumOverTime,
+			chplan.MetricsOpAvgOverTime,
+			chplan.MetricsOpMinOverTime,
+			chplan.MetricsOpMaxOverTime,
+			chplan.MetricsOpHistogramOverTime,
+		}
+		for _, op := range observedOnly {
+			if metricsOpZeroFillsEmptyBuckets(op) {
+				t.Errorf("metricsOpZeroFillsEmptyBuckets(%v) = true, want false", op)
+			}
+		}
+	})
+}
+
+// NOT KILLABLE — documented, not defended by a test.
+//
+// range_window.go:2646:32 (INVERT_LOGICAL, `if op == chplan.MetricsOpRate ||
+// op == chplan.MetricsOpCountOverTime` -> `&&`, inside metricsReducerFrag).
+// The mutated conjunction is unsatisfiable, so the block never runs — but
+// neither does the original disjunction, because metricsReducerFrag is never
+// called with either of those two ops.
+//
+// metricsReducerFrag has exactly ONE caller in the tree
+// (emitRangeWindowMetrics, range_window.go:1280), and that call sits in the
+// `else` of `if zeroFill`, where `zeroFill :=
+// metricsOpZeroFillsEmptyBuckets(m.Op)` was computed from the SAME m.Op a few
+// lines above. metricsOpZeroFillsEmptyBuckets returns true for exactly
+// count_over_time, rate and quantile_over_time, so the reachable op set at
+// line 1280 excludes rate and count_over_time outright. (quantile_over_time is
+// excluded twice over: emitRangeWindowMetrics routes it to
+// emitRangeWindowMetricsQuantileBuckets before the reducer choice is made.)
+// TestMetricsMatrixCountingOpsTakeTheZeroFillReducer above pins both halves of
+// that routing, so this equivalence claim fails loudly if it ever stops
+// holding — and the mutant becomes killable again at the same moment.
+//
+// Verified empirically as well as by construction: emitting every one of the
+// nine chplan.MetricsOp values through the matrix path, crossed with
+// Attr-set/Attr-nil and grouped/ungrouped (36 statements), produces
+// byte-identical SQL and identical argument slices with the mutation applied
+// and reverted.
+//
+// The same reachability makes the `case chplan.MetricsOpRate` arm of
+// metricsReducerFrag's own switch, and the rate half of its doc comment,
+// stale — tracked as a separate cleanup in cerberus issue #2945, because
+// deleting reachable-looking production code belongs in a change that is about
+// that code rather than in a mutation-coverage one.

--- a/internal/promql/histogram_native_mixed_or_aggregate_topk_test.go
+++ b/internal/promql/histogram_native_mixed_or_aggregate_topk_test.go
@@ -1,0 +1,185 @@
+package promql_test
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/prometheus/prometheus/promql/parser"
+
+	"github.com/tsouza/cerberus/internal/chplan"
+	"github.com/tsouza/cerberus/internal/promql"
+	"github.com/tsouza/cerberus/internal/schema"
+)
+
+// TestLower_ExpHistogram_MixedSetOpOr_TopKWrapped is the untagged
+// ACCEPTANCE pin for [topKOverMixedExpHistogramSetOp]
+// (histogram_native_mixed_or_aggregate_topk.go, cerberus issue #2600):
+// `topk`/`bottomk` [by/without] directly wrapping a mixed float/histogram
+// `or` lowers to a chplan.TopK over the shadow-resolved float arm instead
+// of falling through to internal/promql/binary.go's lowerVectorSetOp
+// rejection.
+//
+// The shape already had a chDB execution proof
+// (histogram_native_mixed_or_aggregate_topk_chdb_test.go), but that file
+// is behind the `chdb` build tag, so nothing in the untagged build ever
+// asked the recognizer to ACCEPT. Inverting the `&&` in its guard
+//
+//	if !ok || (agg.Op != parser.TOPK && agg.Op != parser.BOTTOMK) {
+//
+// to `||` makes the parenthesised clause a tautology for every agg.Op —
+// the recognizer then reports "not mine" for every input and the whole
+// lowering is dead — and the untagged suite did not notice
+// (cerberus issue #2943; the mutant reached a verdict for the first time
+// once #2940 stopped `go vet`'s bools analyzer rejecting it as
+// "suspect and" before it could be adjudicated).
+//
+// The rejection counter-case below is what makes the acceptance
+// assertions discriminating: `sum` over the identical `or` must NOT take
+// this route, so the test cannot pass by the recognizer accepting
+// everything either.
+func TestLower_ExpHistogram_MixedSetOpOr_TopKWrapped(t *testing.T) {
+	t.Parallel()
+
+	s := schema.DefaultOTelMetrics()
+	p := parser.NewParser(parser.Options{EnableExperimentalFunctions: true})
+	at := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+
+	cases := []struct {
+		name  string
+		query string
+		k     int64
+		desc  bool
+		byLen int
+	}{
+		{
+			name:  "topk, histogram on left",
+			query: `topk(2, latency_exp_hist or histogram_quantile(0.5, latency_exp_hist))`,
+			k:     2,
+			desc:  true,
+		},
+		{
+			name:  "topk, float on left",
+			query: `topk(3, histogram_quantile(0.5, latency_exp_hist) or latency_exp_hist)`,
+			k:     3,
+			desc:  true,
+		},
+		{
+			name:  "bottomk, histogram on left",
+			query: `bottomk(2, latency_exp_hist or histogram_quantile(0.5, latency_exp_hist))`,
+			k:     2,
+			desc:  false,
+		},
+		{
+			name:  "topk by (...)",
+			query: `topk by (service) (2, latency_exp_hist or histogram_quantile(0.5, latency_exp_hist))`,
+			k:     2,
+			desc:  true,
+			byLen: 1,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			expr, err := p.ParseExpr(tc.query)
+			if err != nil {
+				t.Fatalf("ParseExpr(%q): %v", tc.query, err)
+			}
+			plan, err := promql.LowerAt(context.Background(), expr, s, at, at)
+			if err != nil {
+				t.Fatalf("LowerAt(%q): unexpected error: %v", tc.query, err)
+			}
+			topK, ok := plan.(*chplan.TopK)
+			if !ok {
+				t.Fatalf("lower(%q): plan root is %T, want *chplan.TopK — the topk-over-mixed-`or` recognizer did not accept the shape it exists to accept",
+					tc.query, plan)
+			}
+			if topK.K != tc.k {
+				t.Errorf("lower(%q): TopK.K = %d, want %d", tc.query, topK.K, tc.k)
+			}
+			if topK.Desc != tc.desc {
+				t.Errorf("lower(%q): TopK.Desc = %v, want %v", tc.query, topK.Desc, tc.desc)
+			}
+			if len(topK.By) != tc.byLen {
+				t.Errorf("lower(%q): len(TopK.By) = %d, want %d", tc.query, len(topK.By), tc.byLen)
+			}
+			// Reference's aggregationK drops every histogram sample from
+			// K-selection, so the ranked input is the FLOAT arm alone and
+			// the result rows are float-shaped.
+			if shape := chplan.RowShapeOf(plan); shape != chplan.SampleRowShape {
+				t.Errorf("lower(%q): plan root publishes %s, want %s — topk/bottomk rank float rows only",
+					tc.query, shape, chplan.SampleRowShape)
+			}
+		})
+	}
+}
+
+// TestLower_ExpHistogram_MixedSetOpOr_NonTopKAggregateNotRouted is the
+// counter-case for TestLower_ExpHistogram_MixedSetOpOr_TopKWrapped: an
+// aggregate that is NEITHER topk NOR bottomk over the identical mixed
+// `or` must not take the topk route. It keeps that test honest — a
+// recognizer that accepted every aggregate would satisfy the acceptance
+// assertions but fail here.
+func TestLower_ExpHistogram_MixedSetOpOr_NonTopKAggregateNotRouted(t *testing.T) {
+	t.Parallel()
+
+	s := schema.DefaultOTelMetrics()
+	p := parser.NewParser(parser.Options{EnableExperimentalFunctions: true})
+	at := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+
+	const query = `sum(latency_exp_hist or histogram_quantile(0.5, latency_exp_hist))`
+	expr, err := p.ParseExpr(query)
+	if err != nil {
+		t.Fatalf("ParseExpr(%q): %v", query, err)
+	}
+	plan, err := promql.LowerAt(context.Background(), expr, s, at, at)
+	if err != nil {
+		t.Fatalf("LowerAt(%q): unexpected error: %v", query, err)
+	}
+	if _, ok := plan.(*chplan.TopK); ok {
+		t.Fatalf("lower(%q): plan root is a *chplan.TopK — sum() must not be routed through the topk/bottomk recognizer", query)
+	}
+	if _, ok := plan.(*chplan.VectorSetOp); !ok {
+		t.Fatalf("lower(%q): plan root is %T, want *chplan.VectorSetOp", query, plan)
+	}
+}
+
+// TestLower_ExpHistogram_MixedSetOpOr_TopKBoolModifierRejected pins the
+// `bool` guard [lowerTopKOverMixedExpHistogramSetOp] carries: `bool` is
+// only legal on a comparison binary op, never on the `or` this
+// composition lowers, so the shape is rejected with that message rather
+// than silently lowering.
+func TestLower_ExpHistogram_MixedSetOpOr_TopKBoolModifierRejected(t *testing.T) {
+	t.Parallel()
+
+	s := schema.DefaultOTelMetrics()
+	p := parser.NewParser(parser.Options{EnableExperimentalFunctions: true})
+	at := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+
+	// `bool` on a set op is rejected by the upstream parser itself, so
+	// the guard is reached only via a hand-built AST with ReturnBool set.
+	const query = `topk(2, latency_exp_hist or histogram_quantile(0.5, latency_exp_hist))`
+	expr, err := p.ParseExpr(query)
+	if err != nil {
+		t.Fatalf("ParseExpr(%q): %v", query, err)
+	}
+	agg, ok := expr.(*parser.AggregateExpr)
+	if !ok {
+		t.Fatalf("ParseExpr(%q) produced %T, want *parser.AggregateExpr", query, expr)
+	}
+	bin, ok := agg.Expr.(*parser.BinaryExpr)
+	if !ok {
+		t.Fatalf("topk operand is %T, want *parser.BinaryExpr", agg.Expr)
+	}
+	bin.ReturnBool = true
+
+	_, err = promql.LowerAt(context.Background(), expr, s, at, at)
+	if err == nil {
+		t.Fatalf("LowerAt(%q) with ReturnBool set: expected an error, got none", query)
+	}
+	if !strings.Contains(err.Error(), "'bool' modifier") {
+		t.Fatalf("LowerAt(%q) with ReturnBool set: error = %v, want the 'bool' modifier rejection", query, err)
+	}
+}

--- a/internal/promql/histogram_native_mixed_or_aggregate_topk_test.go
+++ b/internal/promql/histogram_native_mixed_or_aggregate_topk_test.go
@@ -149,8 +149,18 @@ func TestLower_ExpHistogram_MixedSetOpOr_NonTopKAggregateNotRouted(t *testing.T)
 // TestLower_ExpHistogram_MixedSetOpOr_TopKBoolModifierRejected pins the
 // `bool` guard [lowerTopKOverMixedExpHistogramSetOp] carries: `bool` is
 // only legal on a comparison binary op, never on the `or` this
-// composition lowers, so the shape is rejected with that message rather
-// than silently lowering.
+// composition lowers, so the shape is rejected rather than silently
+// lowered.
+//
+// The rejection message is NOT unique — thirteen sites in this package
+// emit the same "'bool' modifier is only allowed on comparison binary
+// ops" text, so matching it alone would pass even with this recognizer
+// disabled entirely and the rejection coming from some other route. The
+// test therefore establishes the route FIRST: the identical AST with
+// ReturnBool cleared must lower to a *chplan.TopK, which is reachable
+// only through this file's recognizer. Only then is ReturnBool set and
+// the rejection asserted, so the second half is known to be this guard's
+// answer and not a stranger's.
 func TestLower_ExpHistogram_MixedSetOpOr_TopKBoolModifierRejected(t *testing.T) {
 	t.Parallel()
 
@@ -173,8 +183,20 @@ func TestLower_ExpHistogram_MixedSetOpOr_TopKBoolModifierRejected(t *testing.T) 
 	if !ok {
 		t.Fatalf("topk operand is %T, want *parser.BinaryExpr", agg.Expr)
 	}
-	bin.ReturnBool = true
 
+	// Route control: without ReturnBool this AST reaches
+	// lowerTopKOverMixedExpHistogramSetOp and lowers. If this fails, the
+	// rejection below proves nothing about that function.
+	plan, err := promql.LowerAt(context.Background(), expr, s, at, at)
+	if err != nil {
+		t.Fatalf("LowerAt(%q) without ReturnBool: unexpected error: %v — the rejection assertion below would not be about this recognizer", query, err)
+	}
+	if _, isTopK := plan.(*chplan.TopK); !isTopK {
+		t.Fatalf("LowerAt(%q) without ReturnBool: plan root is %T, want *chplan.TopK — this AST is not on the topk-over-mixed-`or` route, so the rejection below would be some other site's",
+			query, plan)
+	}
+
+	bin.ReturnBool = true
 	_, err = promql.LowerAt(context.Background(), expr, s, at, at)
 	if err == nil {
 		t.Fatalf("LowerAt(%q) with ReturnBool set: expected an error, got none", query)

--- a/internal/promql/histogram_native_scalar_binop_test.go
+++ b/internal/promql/histogram_native_scalar_binop_test.go
@@ -431,3 +431,95 @@ func TestLower_ExpHistogram_ScalarBinopScalesOnlyTheCountFields(t *testing.T) {
 		})
 	}
 }
+
+// TestLower_ExpHistogram_ScaledOperandIsHistogramValuedToWrappers pins
+// the MUL/DIV arm of [isExpHistogramValuedShape]
+// (histogram_native_scalar_binop.go):
+//
+//	if (b.Op == parser.MUL || b.Op == parser.DIV) && isExpHistogramValuedShape(b.LHS, s, ctx) {
+//	    _, scalar := tryScalarLiteral(b.RHS)
+//	    return scalar
+//	}
+//
+// That arm is what tells every OTHER recognizer in this package that
+// `<exp-hist> * <scalar>` and `<exp-hist> / <scalar>` are themselves
+// histogram-valued, so a wrapper around one keeps the histogram
+// lowering instead of falling through to the float path. It is reached
+// only through a WRAPPER: the bare `<exp-hist> * 2` root goes through
+// [expHistogramScalarBinop]'s own scalar-on-the-right arm, which is
+// what the tests above cover, and which is why inverting this arm's
+// `||` to `&&` — making the operator test unsatisfiable and the whole
+// arm dead — left the package's untagged suite green (cerberus issue
+// #2943; the mutant reached a verdict for the first time once #2940
+// stopped `go vet`'s bools analyzer rejecting it as "suspect and").
+//
+// Each case below silently degraded to a float/sample-shaped plan with
+// the arm dead — no error, just the wrong lowering — so the assertion
+// is on the published row shape, not on an error string. The bare
+// `<exp-hist> * <scalar>` control at the end does NOT depend on this
+// arm and stays histogram-valued either way; it is included so a
+// wholesale regression of exp-histogram scaling is distinguishable from
+// the wrapper-only gap this test exists for.
+func TestLower_ExpHistogram_ScaledOperandIsHistogramValuedToWrappers(t *testing.T) {
+	t.Parallel()
+
+	s := schema.DefaultOTelMetrics()
+	p := parser.NewParser(parser.Options{EnableExperimentalFunctions: true})
+	at := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+
+	cases := []struct {
+		name  string
+		query string
+	}{
+		// Unary minus over a scaled operand — the widening
+		// histogram_native_unary.go's own doc comment names.
+		{name: "unary minus over scaled", query: `-(latency_exp_hist * 2)`},
+		{name: "unary minus over divided", query: `-(latency_exp_hist / 4)`},
+		// label_replace forwards the histogram shape of its first arg.
+		{name: "label_replace over scaled", query: `label_replace(latency_exp_hist * 2, "svc", "$1", "service", "(.*)")`},
+		{name: "label_replace over divided", query: `label_replace(latency_exp_hist / 4, "svc", "$1", "service", "(.*)")`},
+		// <exp-hist>+<exp-hist> merge with a scaled operand on one side.
+		{name: "scaled plus histogram", query: `(latency_exp_hist * 2) + other_exp_hist`},
+		{name: "divided plus histogram", query: `(latency_exp_hist / 4) + other_exp_hist`},
+		// Set ops over a scaled operand.
+		{name: "scaled and histogram", query: `(latency_exp_hist * 2) and other_exp_hist`},
+		{name: "divided unless histogram", query: `(latency_exp_hist / 4) unless other_exp_hist`},
+		// A second scaling applied to an already-scaled operand.
+		{name: "scaled times scalar again", query: `(latency_exp_hist * 2) * 3`},
+		{name: "divided by scalar again", query: `(latency_exp_hist / 4) / 5`},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			expr, err := p.ParseExpr(tc.query)
+			if err != nil {
+				t.Fatalf("ParseExpr(%q): %v", tc.query, err)
+			}
+			plan, err := promql.LowerAt(context.Background(), expr, s, at, at)
+			if err != nil {
+				t.Fatalf("LowerAt(%q): unexpected error: %v", tc.query, err)
+			}
+			if shape := chplan.RowShapeOf(plan); shape != chplan.HistogramRowShape {
+				t.Fatalf("lower(%q): plan root publishes %s, want %s — the wrapper stopped seeing the scaled operand as histogram-valued",
+					tc.query, shape, chplan.HistogramRowShape)
+			}
+		})
+	}
+
+	t.Run("control: bare scaled operand does not depend on this arm", func(t *testing.T) {
+		t.Parallel()
+		const query = `latency_exp_hist * 2`
+		expr, err := p.ParseExpr(query)
+		if err != nil {
+			t.Fatalf("ParseExpr(%q): %v", query, err)
+		}
+		plan, err := promql.LowerAt(context.Background(), expr, s, at, at)
+		if err != nil {
+			t.Fatalf("LowerAt(%q): unexpected error: %v", query, err)
+		}
+		if shape := chplan.RowShapeOf(plan); shape != chplan.HistogramRowShape {
+			t.Fatalf("lower(%q): plan root publishes %s, want %s", query, shape, chplan.HistogramRowShape)
+		}
+	})
+}

--- a/internal/promql/histogram_native_unary_lower_test.go
+++ b/internal/promql/histogram_native_unary_lower_test.go
@@ -1,0 +1,140 @@
+package promql_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/prometheus/prometheus/promql/parser"
+
+	"github.com/tsouza/cerberus/internal/chplan"
+	"github.com/tsouza/cerberus/internal/promql"
+	"github.com/tsouza/cerberus/internal/schema"
+)
+
+// expHistogramUnaryNegationFactor is the scalar `-hist` folds into: unary
+// minus over a histogram-valued operand IS "multiply by the compile-time
+// literal -1", which is what negates
+// Count/Sum/ZeroCount/PositiveBucketCounts/NegativeBucketCounts while
+// leaving Scale/ZeroThreshold/both offsets untouched. See
+// histogram_native_unary.go's own doc for the reference-semantics citation.
+const expHistogramUnaryNegationFactor = -1.0
+
+// TestLower_ExpHistogram_UnaryFoldsToTheLiteralNegation pins what
+// [lowerUnaryOverExpHistogram] actually produces for the two unary
+// operators, which is a strictly stronger statement than "it lowers":
+//
+//   - `-<exp-hist>` reshapes through a *chplan.Project whose count-bearing
+//     projections are `<col> * -1`. The factor is asserted by VALUE: a fold
+//     that multiplied by +1 (or by anything else) would still publish
+//     thirteen well-typed columns and still decode, and would answer every
+//     query with the wrong sign.
+//   - `+<exp-hist>` is reference's identity case and must add NO scaling
+//     reshape at all — it defers to the operand's own histogram-valued
+//     lowering unchanged.
+//
+// The two halves are what make each other discriminating: swapping the
+// operator arms (so `+` negated and `-` did not) satisfies neither.
+//
+// Until the scaled-operand wrapper cases in
+// histogram_native_scalar_binop_test.go were added, this lowering was
+// reached by no untagged test at all — its mutants sat in gremlins'
+// NOT COVERED bucket, outside both sides of the efficacy ratio, so the gap
+// was invisible rather than merely unmeasured (cerberus issue #2943).
+func TestLower_ExpHistogram_UnaryFoldsToTheLiteralNegation(t *testing.T) {
+	t.Parallel()
+
+	s := schema.DefaultOTelMetrics()
+	p := parser.NewParser(parser.Options{EnableExperimentalFunctions: true})
+	at := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+
+	lower := func(t *testing.T, query string) chplan.Node {
+		t.Helper()
+		expr, err := p.ParseExpr(query)
+		if err != nil {
+			t.Fatalf("ParseExpr(%q): %v", query, err)
+		}
+		plan, err := promql.LowerAt(context.Background(), expr, s, at, at)
+		if err != nil {
+			t.Fatalf("LowerAt(%q): unexpected error: %v", query, err)
+		}
+		return plan
+	}
+
+	// The count-bearing scalar fields the negation must reach. The two
+	// bucket ladders are arrayMap-shaped rather than a plain Binary and are
+	// already pinned field-by-field by
+	// TestLower_ExpHistogram_ScalarBinopScalesOnlyTheCountFields; this test
+	// is about the FACTOR, so it asserts on the three scalar carriers.
+	scalarFields := []string{
+		chplan.HistogramCountColumn,
+		chplan.HistogramSumColumn,
+		chplan.HistogramZeroCountColumn,
+	}
+
+	t.Run("unary minus scales by -1", func(t *testing.T) {
+		t.Parallel()
+		const query = `-latency_exp_hist`
+		plan := lower(t, query)
+		hp, ok := plan.(*chplan.HistogramProjection)
+		if !ok {
+			t.Fatalf("lower(%q): plan root is %T, want *chplan.HistogramProjection", query, plan)
+		}
+		reshape, ok := hp.Input.(*chplan.Project)
+		if !ok {
+			t.Fatalf("lower(%q): HistogramProjection.Input is %T, want the scaling *chplan.Project", query, hp.Input)
+		}
+		byAlias := make(map[string]chplan.Expr, len(reshape.Projections))
+		for _, proj := range reshape.Projections {
+			byAlias[proj.Alias] = proj.Expr
+		}
+		for _, alias := range scalarFields {
+			e, ok := byAlias[alias]
+			if !ok {
+				t.Errorf("lower(%q): no projection for %q", query, alias)
+				continue
+			}
+			bin, ok := e.(*chplan.Binary)
+			if !ok || bin.Op != chplan.OpMul {
+				t.Errorf("lower(%q): projection for %q = %#v, want a %s Binary", query, alias, e, chplan.OpMul)
+				continue
+			}
+			lit, ok := bin.Right.(*chplan.LitFloat)
+			if !ok {
+				t.Errorf("lower(%q): projection for %q scales by %#v, want a *chplan.LitFloat", query, alias, bin.Right)
+				continue
+			}
+			if lit.V != expHistogramUnaryNegationFactor {
+				t.Errorf("lower(%q): projection for %q scales by %v, want %v — unary minus must NEGATE, not rescale",
+					query, alias, lit.V, expHistogramUnaryNegationFactor)
+			}
+		}
+		// Scale is position-bearing and must survive untouched, so the
+		// negation is proven to be selective rather than blanket.
+		if e, ok := byAlias[chplan.HistogramScaleColumn]; !ok {
+			t.Errorf("lower(%q): no projection for %q", query, chplan.HistogramScaleColumn)
+		} else if _, isBinary := e.(*chplan.Binary); isBinary {
+			t.Errorf("lower(%q): position-bearing column %q was scaled: %#v", query, chplan.HistogramScaleColumn, e)
+		}
+	})
+
+	t.Run("unary plus is the identity", func(t *testing.T) {
+		t.Parallel()
+		const query = `+latency_exp_hist`
+		plan := lower(t, query)
+		hp, ok := plan.(*chplan.HistogramProjection)
+		if !ok {
+			t.Fatalf("lower(%q): plan root is %T, want *chplan.HistogramProjection", query, plan)
+		}
+		if reshape, isProject := hp.Input.(*chplan.Project); isProject {
+			t.Fatalf("lower(%q): unary + added a scaling reshape (%d projections) — reference's `+` is the identity, so the operand's own lowering must pass through unchanged",
+				query, len(reshape.Projections))
+		}
+		// Byte-for-byte the bare operand's own plan: `+hist` and `hist`
+		// differ only in the AST, never in the IR.
+		bare := lower(t, `latency_exp_hist`)
+		if !plan.Equal(bare) {
+			t.Errorf("lower(%q) differs from lower(`latency_exp_hist`) — unary + must be a no-op on the plan", query)
+		}
+	})
+}


### PR DESCRIPTION
## What this is

#2940 stopped `go test`'s vet pass deciding whether a mutant may be adjudicated at all. Its `bools`
analyzer rejects exactly what `INVERT_LOGICAL` produces from `name == constA || name == constB` — a
conjunction of equalities against distinct constants, "suspect and" — and `go test` reports that as
`FAIL pkg [build failed]`, which gremlins reads as `NOT VIABLE`. **78 mutants across the matrix**
therefore left both sides of the efficacy ratio without ever reaching a test binary.

Enumerating them from CI artifacts — run
[33643658437](https://github.com/tsouza/cerberus/actions/runs/33643658437) (all 30 legs, `-vet=off`)
against main's own pre-#2940 full matrix
[33635018460](https://github.com/tsouza/cerberus/actions/runs/33635018460) — gives the exact set:
**78 newly adjudicated, 73 killed on the spot, 5 survivors.** This change closes all five.

## The five survivors

| Leg | Site | Verdict here |
| --- | --- | --- |
| `phase4-promql-other` | `internal/promql/histogram_native_mixed_or_aggregate_topk.go:73` | killed |
| `phase4-promql-other` | `internal/promql/histogram_native_scalar_binop.go:240` | killed |
| `phase2-compare` | `internal/chsql/exemplars.go:275` | killed |
| `phase2-other` | `internal/chsql/range_window_grid_native.go:308` | killed |
| `phase2-range` | `internal/chsql/range_window.go:2646` | equivalent, proven |

All five are `INVERT_LOGICAL` on a `||` (or the `&&` inside a negated pair), and none of the four
killed ones errors — each silently disables a path and answers with the wrong shape.

Killing the second of them exposed three more, in a place the suite had never reached at all; they
are killed here too. See **The gap the wrapper cases uncovered** below.

### `topKOverMixedExpHistogramSetOp` — `histogram_native_mixed_or_aggregate_topk.go:73`

```go
if !ok || (agg.Op != parser.TOPK && agg.Op != parser.BOTTOMK) {
```

Inverting the inner `&&` makes the parenthesised clause a tautology for every `agg.Op`, so the
recognizer reports "not mine" for every input and the whole `topk`/`bottomk`-over-mixed-`or`
lowering is dead. The shape had a chDB execution proof, but that file is behind the `chdb` build
tag, so nothing in the untagged build ever asked the recognizer to **accept**. New untagged test
asserts the plan root is a `*chplan.TopK` with the right `K`/`Desc`/`By`, in four shapes.

### `isExpHistogramValuedShape` — `histogram_native_scalar_binop.go:240`

```go
if (b.Op == parser.MUL || b.Op == parser.DIV) && isExpHistogramValuedShape(b.LHS, s, ctx) {
```

Inverting the `||` makes the operator test unsatisfiable, so `<exp-hist> * <scalar>` and
`<exp-hist> / <scalar>` stop being histogram-valued to every **wrapper** that gates on this
predicate. The bare root form goes through `expHistogramScalarBinop`'s own arm instead, which is why
the existing tests never reached this line. New test covers ten wrapper shapes (unary minus,
`label_replace`, `+` merge, `and`/`unless` set ops, a second scaling), each of which silently
degraded to a sample-shaped plan.

### exemplars — `exemplars.go:275`

`exemplars.go:179` projects the metric operand as `metric_arg` only when the op is neither `rate`
nor `count_over_time`. Line 275 is the mirror: those two ops must reduce with `argMax(1, ts)`
whatever `Attr` holds. Inverting the `||` makes that guard unsatisfiable, so a counting op carrying
an `Attr` falls into the `else if m.Attr != nil` arm and emits `argMax(metric_arg, ts)` against a
column the inner SELECT never projected. Every existing test built the counting ops with a nil
`Attr`, where both forms collapse onto the same `argMax(1, ts)` else-arm. `EmitMetricsExemplars` is
an exported entrypoint over a `*chplan.MetricsAggregate`, so what keeps its SQL well-formed for that
input is the guard, not any lowering's habits.

### native ts axis — `range_window_grid_native.go:308`

```go
if fn == "deriv" || fn == "predict_linear" {
    return Call("toDateTime", Col(tsColumn))
}
```

Inverting the `||` drops the regression pair from the whole-second axis onto the raw `DateTime64`
column — a change of emitted SQL and of the values ClickHouse computes. The existing activation
tests assert the aggregate name and its parametric prefix, neither of which moves. The new test is a
class-level ratchet driven by the emitter's own `nativeTSGridFn` registry, in the same shape as the
scan-bound ratchet beside it: all nine registered functions are checked, and one added later without
a recorded axis choice fails.

### `metricsReducerFrag` — `range_window.go:2646` — equivalent

`metricsReducerFrag` has exactly one caller (`emitRangeWindowMetrics`, `range_window.go:1280`), and
that call sits in the `else` of `if zeroFill`, where `zeroFill :=
metricsOpZeroFillsEmptyBuckets(m.Op)` came from the same `m.Op`. That predicate is true for exactly
`count_over_time`, `rate` and `quantile_over_time`, so the reachable op set at line 1280 excludes
both ops the mutated guard names. (`quantile_over_time` is excluded twice: it is routed to
`emitRangeWindowMetricsQuantileBuckets` before the reducer choice is made.)

Verified empirically as well as by construction: emitting all nine `chplan.MetricsOp` values crossed
with `Attr`-set/nil and grouped/ungrouped — 36 statements — gives byte-identical SQL and identical
argument slices with the mutation applied and reverted.

The equivalence is not left as an assertion in a comment. `TestMetricsMatrixCountingOpsTakeTheZeroFillReducer`
pins both halves of the routing the argument rests on, at the emitted-SQL surface: `rate` and
`count_over_time` reduce with `toFloat64(sum(in_window))` (`/ 60` for rate) so an empty anchor
answers 0, and `sum_over_time` reduces over the projected operand instead. If that routing ever
changes, the claim fails loudly and the mutant becomes killable in the same moment.

### The gap the wrapper cases uncovered — `histogram_native_unary.go`

`-(<exp-hist> * 2)` is the first untagged test in the tree to reach
`lowerUnaryOverExpHistogram`. That moved three of `histogram_native_unary.go`'s mutants out of
gremlins' `NOT COVERED` bucket — where they sat outside **both** sides of the efficacy ratio — and
into `LIVED`, taking `phase4-promql-e` from 95.37% to 92.79% on the PR's first run. That is the gap
becoming visible, not appearing: the code was always unasserted, and `NOT COVERED` is the status that
hid it.

The three are killed rather than left named. The new test pins what the fold actually produces:
`-<exp-hist>` reshapes through a `*chplan.Project` whose count-bearing projections are `<col> * -1`
— asserted by VALUE, because a fold by `+1` still publishes thirteen well-typed columns and still
decodes, and answers every query with the wrong sign — while `+<exp-hist>` is reference's identity
case and must add no reshape at all, staying plan-`Equal` to the bare operand. Each half makes the
other discriminating: swapping the operator arms satisfies neither.

## Arithmetic

Efficacy below is the **gate's** formula — `killed / (killed + lived + timedOut)`, what
`.github/scripts/gremlins-threshold.mjs` recomputes — not gremlins' own `test_efficacy`, which drops
timed-out mutants from the denominator.

| Leg | pre-#2940 | post-#2940 (`-vet=off`) | after this change |
| --- | --- | --- | --- |
| `phase2-compare` | 98.94% (k280 l3) | 98.60% (k281 l4) | **98.95%** (k282 l3) |
| `phase2-other` | 96.15% (k325 l12 t1) | 95.88% (k326 l13 t1) | **96.18%** (k327 l12 t1) |
| `phase2-range` | 97.90% (k280 l6) | 97.57% (k281 l7) | 97.57% (k281 l7) — equivalent, unchanged |
| `phase4-promql-other` | 88.46% (k92 l12) | 87.16% (k95 l14) | **88.99%** (k97 l12) |
| `phase4-promql-e` | 95.28% (k101 l5) | 95.37% (k103 l5) | **95.50%** (k106 l5) — see below |

`phase4-promql-e` is not a `-vet=off` leg at all — it holds none of the five survivors. It moves
because the new `-(<exp-hist> * 2)` wrapper case gives `histogram_native_unary.go` its first untagged
coverage, converting 3 `NOT COVERED` mutants into adjudicated ones (k103 l5 → k103 l8, 92.79%, on the
PR's first run) which the unary test then kills (k106 l5). Net +0.13 points against main, and the leg
is green either side of the honest dip.

Untouched control legs, pre-#2940 → post-#2940, none of which this change goes near:
`phase1` 96.43 → 96.43, `phase2-builder` 97.89 → 97.90, `phase3-optimizer` 98.17 → 98.18,
`phase4-promql-a` 97.41 → 97.45, `phase5-qlcommon` 90.03 → 90.06, `phase6-spansscan` 96.23 → 96.23.
Their movement is only the 73 mutants `-vet=off` adjudicated and killed elsewhere in the matrix;
nothing in this diff touches them, so the numbers above are attributable.

The other legs red on this PR — `phase4-promql-b/c/d/f/i/other/quantile` — are red on main's own
full-matrix run at this PR's base SHA (56e2c1add, run
[33649479052](https://github.com/tsouza/cerberus/actions/runs/33649479052)), with identical
conclusions. `mutation` is not a required context (#2230); it is informational on a pull request.

**Floors.** Three of the four legs were above their 95% floor before and stay above it. The fourth,
`phase4-promql-other`, was already below the floor before #2940 (88.46%) and remains below it at
88.99%: the two kills here recover the 1.30 points #2940's honest re-scoring exposed and add 0.53
more, but they do not close a gap this change was never about. Its remaining twelve survivors are
separate work.

## Verification

- Every kill proven individually: apply the mutation by hand → the new test **FAILS**; revert → it
  **PASSES**. Confirmed for all seven (the five survivors' four kills plus the three unary ones),
  running the whole owning package each time, and re-run after the review fixes below.
- Adversarially reviewed. The review found that
  `TestLower_ExpHistogram_MixedSetOpOr_TopKBoolModifierRejected` was **not discriminating** —
  thirteen sites in `internal/promql` emit the same `'bool' modifier` text, and the test passed with
  the topk recognizer disabled entirely. It now establishes the route first (the identical AST with
  `ReturnBool` cleared must lower to a `*chplan.TopK`) before asserting the rejection, and fails
  under the mutation. Also from that review: the ts-axis test now covers `nativeGridTsAxisFrag`'s
  other caller (the instant emitter, which the range-driven registry loop cannot reach, with a
  companion test proving the two functions it refuses really are refused);
  `nativeGridArgGroup` now returns the argument group it claims to rather than the whole SQL suffix;
  the zero-fill expectation is a whole-enum ratchet rather than a hand-picked list; and two
  `exemplars.go` line citations that were off by one now name the guards instead.
- The equivalent one confirmed the other way: with the mutation applied, `internal/chsql`'s suite is
  green and the 36-statement emit sweep is byte-identical.
- `.github/scripts/mutation-phases.mjs` and `mutation-matrix.mjs` are untouched. No floor moved, no
  `exclude_files`/`include_files` changed, no denominator shrunk.
- Non-vacuity: every new test carries a discriminating counter-case — a non-topk aggregate over the
  identical `or`; the bare scaled operand that does not depend on the mutated arm; `sum_over_time`
  reading `metric_arg` where the counting ops must not; the seven native functions that must read
  the raw axis where deriv/predict_linear must not.

## Out of scope, filed

The reachability that makes `range_window.go:2646` equivalent also makes the `case
chplan.MetricsOpRate` arm of `metricsReducerFrag`'s switch, and the rate half of its doc comment,
stale. Separately, the "these two ops count rows rather than reading an operand" predicate is spelled
out inline at three sites with no shared helper (`metricsOpZeroFillsEmptyBuckets` is a different set
— it also carries `quantile_over_time`). Both are #2945 (M1, under epic #2891): deleting production
code that still reads as reachable, and naming a predicate two load-bearing guards must agree on,
belong in a change where the reviewer is looking at the emitter rather than at test coverage.

Closes #2943

🤖 Generated with [Claude Code](https://claude.com/claude-code)
