### PR TITLE
fix(ci): count a run-phase timeout as a detection, and only a run-phase one

### DIFF
--- a/.github/scripts/README.md
+++ b/.github/scripts/README.md
@@ -955,12 +955,18 @@ what actually runs.
     `run_heavy=true`, logged via `::notice::`, never a hard failure); `1` on an
     unrecognised `MODE`.
 - **`gremlins-threshold.mjs`** — `mutation.yml`, the
-  `enforce efficacy threshold` step. Gates on `killed / (killed + lived +
-  timedOut)`, the kill rate over every mutant the runner ATTEMPTED to
-  adjudicate, rather than on gremlins' own `killed / (killed + lived)`. A
-  timed-out mutant is unadjudicated, not detected, so moving one into
-  `TIMED OUT` can never raise the score and a starved runner reads as red
-  rather than as a flattering green (#2903).
+  `enforce efficacy threshold` step. Gates on `(killed + runTimedOut) /
+  (killed + lived + timedOut + runTimedOut)`, the detection rate over every
+  mutant the runner ATTEMPTED to adjudicate, rather than on gremlins' own
+  `killed / (killed + lived)`. The two timeout statuses mean opposite
+  things: `RUN TIMED OUT` is the test binary's own watchdog firing on a
+  clock no compile can spend, so the mutant stopped its suite terminating
+  and is a detection (#2944); `TIMED OUT` is the compile+run backstop,
+  which cannot say which phase spent it, so it is unadjudicated and moving
+  a mutant into it can never raise the score — a starved runner reads as
+  red rather than as a flattering green (#2903). The recognised status set
+  is CLOSED: an unknown status fails the gate rather than dropping those
+  mutants out of both sides of the ratio.
   - Env: `REPORT` (default `gremlins.json`), `THRESHOLD` (a number).
   - Exit: `0` when efficacy is `>=` threshold, `1` when below.
 - **`mutation-phases.mjs`** — data, imported by `mutation-matrix.mjs`. The single

--- a/.github/scripts/gremlins-threshold.mjs
+++ b/.github/scripts/gremlins-threshold.mjs
@@ -48,10 +48,11 @@
 //   TIMED OUT      the context deadline covering compile AND run expired. Which
 //                  phase spent it is unknown: a compile that hung reaches this
 //                  status identically to a run that did, and so does a mutant
-//                  killed by .github/scripts/mutant-memory-guard.mjs, which reaps a memory runaway and
-//                  then HOLDS precisely so that no exit status of its own can be
-//                  read as a verdict (#2919, #2921). Unadjudicated. Denominator
-//                  only, credited to nobody.
+//                  killed by the per-mutant memory guard, which reaps a memory
+//                  runaway and then HOLDS precisely so that no exit status of
+//                  its own can be read as a verdict — see
+//                  .github/scripts/mutant-memory-guard.mjs (#2919, #2921).
+//                  Unadjudicated. Denominator only, credited to nobody.
 //
 // Collapsing those two back into one number re-creates #2903 in a new place, so
 // an unrecognised status string is a hard failure below rather than a silent
@@ -108,10 +109,11 @@
 //     handed to `go test -timeout`, so compilation cannot spend it, and the
 //     verdict comes from the child's own output rather than from an exit status
 //     `go test` shares between a timeout, a build failure and a real failure.
-//   - the MEASURED budget in .github/scripts/mutation-run.mjs: the run bound is this leg's own
-//     recompile+link+run cycle, times the mutant fan-out, times 2 for runner
-//     variance, floored at MUTANT_TIMEOUT_MIN. It is an upper bound on the
-//     honest run several times over, so an honest suite cannot reach it.
+//   - the MEASURED budget in the lane's own runner script: the run bound is this
+//     leg's recompile+link+run cycle as measured on this runner, times the
+//     mutant fan-out, times 2 for runner variance, floored at
+//     MUTANT_TIMEOUT_MIN. It is an upper bound on the honest run several times
+//     over, so an honest suite cannot reach it.
 //     test/regression/mutation_timeout_max_test.go pins both bounds and the fork
 //     tag together for exactly this reason.
 //
@@ -123,7 +125,7 @@
 // its budget works, whatever its run timeouts say.
 //
 // Counts come from `files[].mutations[].status`, the per-mutant record, because
-// no aggregate field in the report exposes the timed-out total.
+// no aggregate field in the report exposes either timeout total.
 //
 // Env contract:
 //   REPORT     path to the gremlins JSON report   (default: gremlins.json)
@@ -250,9 +252,13 @@ function main() {
   }
 
   // Read but do not gate on gremlins' own ratio. It is killed/(killed+lived),
-  // which is always >= the ratio gated below, so a comparison against it could
-  // never fire where the one below passed. It is still parsed so that a rename
-  // or a malformed report fails loudly instead of being scored as zero
+  // computed over a DIFFERENT mutant set: it drops both timeout kinds from both
+  // sides. With no run-phase timeouts it is always >= the ratio gated below, so
+  // a comparison against it could never fire where the one below passed; with
+  // them it can be lower, because a mutant it discards entirely is one this gate
+  // counts as a detection. Neither direction is a bound on the other, which is
+  // why it is REPORTED and never compared against. It is still parsed so that a
+  // rename or a malformed report fails loudly instead of being scored as zero
   // timeouts, and it is reported so the log shows both numbers.
   const reported = Number(report.test_efficacy);
   if (!Number.isFinite(reported)) {

--- a/.github/scripts/gremlins-threshold.mjs
+++ b/.github/scripts/gremlins-threshold.mjs
@@ -12,47 +12,71 @@
 // no measured-vs-threshold numbers. Gating after the report is written keeps
 // both. Do not "simplify" this by passing --threshold-efficacy.
 //
-// A TIMED-OUT MUTANT IS AN UNADJUDICATED MUTANT, AND COUNTS AGAINST THE SCORE.
+// AN UNADJUDICATED MUTANT COUNTS AGAINST THE SCORE. A MUTANT THAT STOPPED ITS
+// OWN SUITE TERMINATING IS ADJUDICATED.
 //
-// This is the property the whole gate rests on, so it is worth stating as a
+// The whole gate rests on telling those two apart, so it is worth stating as a
 // rule rather than as a formula: THE SCORE MUST BE MONOTONE NON-INCREASING IN
-// THE TIMEOUT COUNT. Moving one mutant from any other status into TIMED OUT may
-// never raise the number this gate reads. A gate that violates that rule pays a
-// slower runner in efficacy points, and a green run then proves that the
-// machine was busy rather than that the tests are strong.
+// THE UNADJUDICATED COUNT. Moving one mutant from any other status into an
+// unadjudicated one may never raise the number this gate reads. A gate that
+// violates that rule pays a slower runner in efficacy points, and a green run
+// then proves that the machine was busy rather than that the tests are strong.
 //
-// gremlins excludes TIMED_OUT from BOTH sides of its own verdict
+// gremlins excludes both timeout statuses from BOTH sides of its own verdict
 // (internal/report/report.go: `tEfficacy = killed / (killed + lived)` and
 // `MutantsTotal = lived + killed + notViable`), so its ratio VIOLATES that rule
 // in the worst way — a timeout leaves the denominator entirely, so starving the
 // runner raises the score. This gate therefore recomputes efficacy over every
-// mutant the runner ATTEMPTED to adjudicate, timeouts included:
+// mutant the runner ATTEMPTED to adjudicate, both timeout kinds included:
 //
-//   efficacy = killed / (killed + lived + timedOut)
+//   efficacy = (killed + runTimedOut) / (killed + lived + timedOut + runTimedOut)
 //
-// which is monotone by construction, and is never above the ratio gremlins
-// reported.
+// WHICH TIMEOUT IS WHICH
+// ----------------------
+// A mutant is leashed twice, and the pinned fork reports which leash claimed it
+// (#2910/#2929 split the two bounds; #2944 made the report say which fired):
 //
-// Why the opposite reading was wrong (cerberus issue #2903)
-// --------------------------------------------------------
-// This gate previously counted a timeout as a DETECTION, on the premise that a
-// mutant which exhausts the per-mutant budget "did not do so because the
-// machine was slow — it did so because the mutation broke termination". The
-// premise was checked against `internal/chsql`'s recursive renderer and looked
-// sound there. It is false, and it is false on that very leg.
+//   RUN TIMED OUT  the test BINARY's own `-timeout` watchdog fired and printed
+//                  `panic: test timed out after `. The Go toolchain starts that
+//                  clock when the binary starts, so no compile can consume it.
+//                  This is a positive observation produced by the mutant's own
+//                  suite: the suite did not finish. Against an original that
+//                  finishes in a fraction of the bound that is a change in
+//                  observable behaviour, caught by the suite's own runtime
+//                  bound — which is what a detection is. Numerator.
 //
-// The budget wraps the whole `go test` child, which is a RECOMPILE, a LINK and
-// then a run. Measured per mutant, on an 8-core machine, against the 15s budget
-// those legs ran under:
+//   TIMED OUT      the context deadline covering compile AND run expired. Which
+//                  phase spent it is unknown: a compile that hung reaches this
+//                  status identically to a run that did, and so does a mutant
+//                  killed by .github/scripts/mutant-memory-guard.mjs, which reaps a memory runaway and
+//                  then HOLDS precisely so that no exit status of its own can be
+//                  read as a verdict (#2919, #2921). Unadjudicated. Denominator
+//                  only, credited to nobody.
+//
+// Collapsing those two back into one number re-creates #2903 in a new place, so
+// an unrecognised status string is a hard failure below rather than a silent
+// zero.
+//
+// Why the FLAT reading — every timeout a detection — was wrong (#2903)
+// -------------------------------------------------------------------
+// This gate once counted every timeout as a detection, on the premise that a
+// mutant which exhausts the per-mutant budget "did not do so because the machine
+// was slow — it did so because the mutation broke termination". The premise was
+// checked against `internal/chsql`'s recursive renderer and looked sound there.
+// It was false, and it was false on that very leg.
+//
+// The budget then wrapped the whole `go test` child, which is a RECOMPILE, a
+// LINK and then a run. Measured per mutant, on an 8-core machine, against the
+// 15s budget those legs ran under:
 //
 //   internal/chsql   compile+link 12.7-14.4s   test run 0.31s
 //   internal/promql  compile+link  8.4-8.7s    test run 2.07s
 //
-// The compiler is 80-98% of the budget and the mutant's own execution is a
-// rounding error, so TIMED OUT records "the compiler was slow today", not
+// The compiler was 80-98% of the budget and the mutant's own execution was a
+// rounding error, so TIMED OUT recorded "the compiler was slow today", not
 // "this mutation stopped the suite terminating".
 //
-// Two signatures in the real reports confirm it:
+// Two signatures in the real reports confirmed it:
 //
 //   - Runs 33542904091 (red) and 33551271099 (green) on `phase4-promql-lower`
 //     recorded the SAME 486 kills. The whole 94.00% -> 97.01% swing was 16
@@ -69,15 +93,34 @@
 //     legs reported 100.00% with `lived: 0`, over 1266 mutants of which 1230
 //     timed out.
 //
-// Counting timeouts as detections scored that last case — a leg that
-// adjudicated 3% of its mutants and found no survivor because it never ran long
-// enough to see one — as a perfect leg.
+// Every one of those mutants is a TIMED OUT today — the compile is what consumed
+// the budget, and the compile is what the backstop covers — so none of them
+// would be credited by the reading below. The narrow reading is not the flat one
+// coming back.
 //
-// The paired defence is the per-mutant budget itself: .github/scripts/
-// mutation-run.mjs now MEASURES the leg's own recompile+link+run cycle and
-// sizes the budget from it, so an honest leg has few timeouts to spend. This
-// gate is what makes that safe to get wrong in the tight direction — an
-// undersized budget now shows up as a RED leg rather than as a flattering one.
+// WHAT MAKES CREDITING SAFE, AND WHERE IT LIVES
+// ---------------------------------------------
+// Not this file. Two mechanisms elsewhere are what stop a RUN TIMED OUT from
+// being manufactured by a starved runner, and reverting either turns the credit
+// below into a lie:
+//
+//   - the fork's split (#2929) and its output-read verdict: the run bound is
+//     handed to `go test -timeout`, so compilation cannot spend it, and the
+//     verdict comes from the child's own output rather than from an exit status
+//     `go test` shares between a timeout, a build failure and a real failure.
+//   - the MEASURED budget in .github/scripts/mutation-run.mjs: the run bound is this leg's own
+//     recompile+link+run cycle, times the mutant fan-out, times 2 for runner
+//     variance, floored at MUTANT_TIMEOUT_MIN. It is an upper bound on the
+//     honest run several times over, so an honest suite cannot reach it.
+//     test/regression/mutation_timeout_max_test.go pins both bounds and the fork
+//     tag together for exactly this reason.
+//
+// The residual asymmetry is deliberate, and is stated rather than hidden: moving
+// a mutant LIVED -> RUN TIMED OUT DOES raise the score, because a survivor that
+// stops terminating has stopped surviving. Moving one into TIMED OUT never
+// does. The budget-collapse floor below is therefore computed over NORMAL
+// verdicts only — a leg that killed nothing and survived nothing has not shown
+// its budget works, whatever its run timeouts say.
 //
 // Counts come from `files[].mutations[].status`, the per-mutant record, because
 // no aggregate field in the report exposes the timed-out total.
@@ -109,38 +152,76 @@ import { error, notice } from './lib/gh.mjs';
 const minCompletedMutants = 1;
 
 // The per-mutation status strings gremlins writes (internal/mutator/mutator.go).
-// Matched exactly: a rename upstream must fail this gate loudly rather than
-// silently count zero of everything forever.
+// Matched exactly, and the set is CLOSED: a status this gate does not recognise
+// is a hard failure, not a mutant quietly dropped from both sides of the ratio.
+//
+// That closure is what makes the two timeout kinds safe to score differently. A
+// fork that renames a status, or adds one — as it DID when RUN TIMED OUT was
+// split out of TIMED OUT — would otherwise leave the new status uncounted,
+// which takes mutants out of the denominator and raises every leg's score.
+// Failing loudly costs one red run; counting zero of them costs the number its
+// meaning.
 const timedOutStatus = 'TIMED OUT';
+const runTimedOutStatus = 'RUN TIMED OUT';
 const killedStatus = 'KILLED';
 const livedStatus = 'LIVED';
 
+// The statuses that carry no verdict about the test suite: a mutant no test
+// reaches, one no compiler accepts, one the run never got to. They are outside
+// both sides of the ratio, and they are enumerated so that they are outside it
+// DELIBERATELY rather than by falling through an unrecognised branch.
+const unscoredStatuses = ['NOT COVERED', 'NOT VIABLE', 'SKIPPED', 'RUNNABLE'];
+
+const knownStatuses = new Set([
+  timedOutStatus,
+  runTimedOutStatus,
+  killedStatus,
+  livedStatus,
+  ...unscoredStatuses,
+]);
+
 // countMutationStatuses walks the per-file mutation records and returns the
 // mutant total plus the per-status counts the verdict is computed from.
+// `unknown` collects every status string outside the closed set above, keyed by
+// the string, so the caller can fail on a report it does not understand instead
+// of scoring one.
 export function countMutationStatuses(report) {
   let total = 0;
   let timedOut = 0;
+  let runTimedOut = 0;
   let killed = 0;
   let lived = 0;
+  const unknown = new Map();
   for (const file of report?.files ?? []) {
     for (const m of file?.mutations ?? []) {
       total++;
-      if (m?.status === timedOutStatus) timedOut++;
-      else if (m?.status === killedStatus) killed++;
-      else if (m?.status === livedStatus) lived++;
+      const status = m?.status;
+      if (status === timedOutStatus) timedOut++;
+      else if (status === runTimedOutStatus) runTimedOut++;
+      else if (status === killedStatus) killed++;
+      else if (status === livedStatus) lived++;
+      else if (!knownStatuses.has(status)) {
+        const key = String(status);
+        unknown.set(key, (unknown.get(key) ?? 0) + 1);
+      }
     }
   }
-  return { total, timedOut, killed, lived };
+  return { total, timedOut, runTimedOut, killed, lived, unknown };
 }
 
-// attemptedEfficacy is the kill rate over every mutant the runner ATTEMPTED to
-// adjudicate — killed, survived, or ran out of budget — or null when it
-// attempted none. A timeout is an unknown, and an unknown is not a kill, so it
-// sits in the denominator only.
-export function attemptedEfficacy({ killed, lived, timedOut }) {
-  const attempted = killed + lived + timedOut;
+// attemptedEfficacy is the detection rate over every mutant the runner
+// ATTEMPTED to adjudicate, or null when it attempted none.
+//
+// Two things are detections. A KILLED mutant made a test fail. A RUN TIMED OUT
+// mutant made the suite stop finishing, reported by the test binary itself
+// against a bound no compile can spend — a change in observable behaviour that
+// the suite's own runtime bound caught. A TIMED OUT mutant is neither: the
+// compile+run backstop cannot say which phase spent it, so it is an unknown,
+// and an unknown is not a detection. It sits in the denominator only.
+export function attemptedEfficacy({ killed, lived, timedOut, runTimedOut = 0 }) {
+  const attempted = killed + lived + timedOut + runTimedOut;
   if (attempted === 0) return null;
-  return (killed / attempted) * 100;
+  return ((killed + runTimedOut) / attempted) * 100;
 }
 
 // main runs the gate. Guarded below so a test can import the helpers without
@@ -181,6 +262,24 @@ function main() {
   }
 
   const counts = countMutationStatuses(report);
+
+  // A status this gate has no branch for is a report it cannot score. Silently
+  // ignoring one removes those mutants from the denominator, which raises the
+  // leg's number for a reason that has nothing to do with its tests — the exact
+  // shape of every defect this gate exists to stop. It is also the concrete
+  // failure mode of the fork bump that introduced RUN TIMED OUT: an older gate
+  // paired with a newer fork would have scored those mutants out of existence.
+  if (counts.unknown.size > 0) {
+    const listed = [...counts.unknown.entries()].map(([s, n]) => `${JSON.stringify(s)} x${n}`).join(', ');
+    error(
+      `gremlins-threshold.mjs: ${reportPath} carries mutation status(es) this gate does not know: ` +
+        `${listed}. A status with no branch here would leave those mutants out of BOTH sides of the ` +
+        `ratio and raise this leg's score for free, so it fails instead. Add the status to this ` +
+        `script's closed set and decide, explicitly, which side of the ratio it belongs on.`,
+    );
+    process.exit(1);
+  }
+
   if (counts.total === 0) {
     // No per-mutation records to recompute from. There is nothing to say about
     // timeouts, so gremlins' own ratio is the only number available.
@@ -192,34 +291,60 @@ function main() {
     process.exit(0);
   }
 
+  // NORMAL verdicts only — killed or lived. A run-phase timeout is adjudicated
+  // and is credited below, but it is NOT evidence that the budget worked: a
+  // collapsed run bound manufactures exactly that status, so counting one here
+  // would let the collapse signature this floor exists to name pass as a leg
+  // that adjudicated something.
   const completed = counts.killed + counts.lived;
   if (completed < minCompletedMutants) {
     error(
       `gremlins completed ${completed} mutant(s) — killed ${counts.killed}, lived ${counts.lived}, ` +
-        `with ${counts.timedOut} timed out of ${counts.total}. Nothing ran to a verdict, so neither ` +
-        `the reported ${reported}% nor the timeouts say anything about this package: this is the ` +
-        `per-mutant budget collapsing, not the tests failing (#2692).`,
+        `with ${counts.timedOut} timed out and ${counts.runTimedOut} run-timed-out of ${counts.total}. ` +
+        `Nothing ran to a normal verdict, so neither the reported ${reported}% nor the timeouts say ` +
+        `anything about this package: this is the per-mutant budget collapsing, not the tests ` +
+        `failing (#2692).`,
     );
     process.exit(1);
   }
 
   const measured = attemptedEfficacy(counts);
-  const attempted = counts.killed + counts.lived + counts.timedOut;
+  const attempted = counts.killed + counts.lived + counts.timedOut + counts.runTimedOut;
+  const detected = counts.killed + counts.runTimedOut;
 
   if (measured < threshold) {
     error(
       `gremlins efficacy ${measured.toFixed(2)}% < threshold ${threshold}% — ` +
-        `killed ${counts.killed} of ${attempted} attempted (lived ${counts.lived}, ` +
-        `timed out ${counts.timedOut}). A timed-out mutant is unadjudicated, not detected: ` +
-        `it counts against this ratio (#2903). gremlins reported ${reported}% over killed+lived only.`,
+        `detected ${detected} of ${attempted} attempted (killed ${counts.killed}, run timed out ` +
+        `${counts.runTimedOut}, lived ${counts.lived}, timed out ${counts.timedOut}). A mutant the ` +
+        `compile+run backstop claimed is unadjudicated, not detected: it counts against this ratio ` +
+        `(#2903). gremlins reported ${reported}% over killed+lived only.`,
     );
     process.exit(1);
   }
 
+  if (counts.runTimedOut > 0) {
+    // Both numbers, always. The delta between them is how much of this leg's
+    // score rests on the run-phase credit, which is the one thing a reader
+    // reviewing #2944's decision needs and cannot recompute from the log.
+    const uncredited = attemptedEfficacy({
+      killed: counts.killed,
+      lived: counts.lived,
+      timedOut: counts.timedOut + counts.runTimedOut,
+      runTimedOut: 0,
+    });
+    notice(
+      `gremlins run-timed-out ${counts.runTimedOut}/${counts.total} mutants, counted as DETECTIONS: ` +
+        `the test binary's own -timeout watchdog fired, which no compile can consume (#2944). ` +
+        `efficacy ${measured.toFixed(2)}%; without that credit it would be ` +
+        `${uncredited.toFixed(2)}% over the same ${attempted} attempted`,
+    );
+  }
   if (counts.timedOut > 0) {
     notice(
-      `gremlins timed out ${counts.timedOut}/${counts.total} mutants, counted as unadjudicated: ` +
-        `efficacy ${measured.toFixed(2)}% (gremlins reported ${reported}% over killed+lived only)`,
+      `gremlins timed out ${counts.timedOut}/${counts.total} mutants on the compile+run backstop, ` +
+        `counted as unadjudicated: efficacy ${measured.toFixed(2)}% ` +
+        `(gremlins reported ${reported}% over killed+lived only)`,
     );
   }
   notice(`gremlins efficacy ${measured.toFixed(2)}% >= threshold ${threshold}%`);

--- a/.github/scripts/gremlins-threshold.test.mjs
+++ b/.github/scripts/gremlins-threshold.test.mjs
@@ -23,11 +23,15 @@ import { attemptedEfficacy, countMutationStatuses } from './gremlins-threshold.m
 const script = new URL('./gremlins-threshold.mjs', import.meta.url).pathname;
 
 // mutations builds a files[] block with the given per-status counts.
-function mutations({ killed = 0, lived = 0, timedOut = 0 }) {
+function mutations({ killed = 0, lived = 0, timedOut = 0, runTimedOut = 0, unknown = 0 }) {
   const out = [];
   for (let i = 0; i < killed; i++) out.push({ type: 'X', status: 'KILLED', line: i, column: 1 });
   for (let i = 0; i < lived; i++) out.push({ type: 'X', status: 'LIVED', line: i, column: 1 });
   for (let i = 0; i < timedOut; i++) out.push({ type: 'X', status: 'TIMED OUT', line: i, column: 1 });
+  for (let i = 0; i < runTimedOut; i++) {
+    out.push({ type: 'X', status: 'RUN TIMED OUT', line: i, column: 1 });
+  }
+  for (let i = 0; i < unknown; i++) out.push({ type: 'X', status: 'SOMETHING NEW', line: i, column: 1 });
   return [{ file_name: 'a.go', mutations: out }];
 }
 
@@ -107,32 +111,125 @@ test('a leg that adjudicated 6% of its mutants cannot report 100%', () => {
   assert.equal(gremlinsReported(counts), 100);
   const r = run(counts, 95);
   assert.equal(r.code, 1, `100% over 22 of 345 mutants must not pass: ${r.out}`);
-  assert.match(r.out, /killed 22 of 345 attempted/);
+  assert.match(r.out, /detected 22 of 345 attempted/);
 });
 
 // The rule the whole gate rests on, checked as a property rather than on one
-// report: moving a mutant into TIMED OUT may never raise the score. Under the
-// reading this replaced — timeouts as detections — every one of these pairs
-// moved the wrong way.
-test('moving any mutant into TIMED OUT never raises the score', () => {
-  for (const [killed, lived, timedOut] of [
-    [486, 31, 4],
-    [39, 1, 279],
-    [5, 40, 5],
-    [1, 1, 0],
-    [0, 7, 3],
-    [990, 32, 0],
+// report: moving a mutant into the UNADJUDICATED status may never raise the
+// score. Under the reading #2903 replaced — every timeout a detection — each of
+// these pairs moved the wrong way, and that reading is what a starved runner
+// exploits. It stays closed: the backstop status is the one a starved compile,
+// a hung compile and a memory reap all land in.
+test('moving any mutant into the backstop TIMED OUT never raises the score', () => {
+  for (const [killed, lived, timedOut, runTimedOut] of [
+    [486, 31, 4, 0],
+    [39, 1, 279, 0],
+    [5, 40, 5, 0],
+    [1, 1, 0, 0],
+    [0, 7, 3, 0],
+    [990, 32, 0, 0],
+    [361, 13, 11, 14],
+    [280, 14, 9, 8],
   ]) {
-    const base = attemptedEfficacy({ killed, lived, timedOut });
+    const base = attemptedEfficacy({ killed, lived, timedOut, runTimedOut });
     if (lived > 0) {
-      const fromLived = attemptedEfficacy({ killed, lived: lived - 1, timedOut: timedOut + 1 });
+      const fromLived = attemptedEfficacy({ killed, lived: lived - 1, timedOut: timedOut + 1, runTimedOut });
       assert.ok(fromLived <= base, `LIVED -> TIMED OUT raised ${base} to ${fromLived}`);
     }
     if (killed > 0) {
-      const fromKilled = attemptedEfficacy({ killed: killed - 1, lived, timedOut: timedOut + 1 });
+      const fromKilled = attemptedEfficacy({ killed: killed - 1, lived, timedOut: timedOut + 1, runTimedOut });
       assert.ok(fromKilled <= base, `KILLED -> TIMED OUT raised ${base} to ${fromKilled}`);
     }
+    if (runTimedOut > 0) {
+      const fromRun = attemptedEfficacy({ killed, lived, timedOut: timedOut + 1, runTimedOut: runTimedOut - 1 });
+      assert.ok(fromRun <= base, `RUN TIMED OUT -> TIMED OUT raised ${base} to ${fromRun}`);
+    }
   }
+});
+
+// #2944. The one asymmetry the narrow reading introduces, pinned so it is a
+// decision rather than an accident: a survivor that stops terminating stops
+// being a survivor, so LIVED -> RUN TIMED OUT DOES raise the score. Nothing
+// else does, which is why the two timeout kinds may not be collapsed.
+test('LIVED -> RUN TIMED OUT raises the score, and KILLED -> RUN TIMED OUT leaves it alone', () => {
+  for (const [killed, lived, timedOut, runTimedOut] of [
+    [361, 13, 11, 14],
+    [280, 14, 9, 8],
+    [221, 6, 5, 3],
+  ]) {
+    const base = attemptedEfficacy({ killed, lived, timedOut, runTimedOut });
+    const fromLived = attemptedEfficacy({ killed, lived: lived - 1, timedOut, runTimedOut: runTimedOut + 1 });
+    assert.ok(fromLived > base, `LIVED -> RUN TIMED OUT did not raise ${base} (got ${fromLived})`);
+    const fromKilled = attemptedEfficacy({
+      killed: killed - 1,
+      lived,
+      timedOut,
+      runTimedOut: runTimedOut + 1,
+    });
+    assert.equal(fromKilled, base, 'KILLED and RUN TIMED OUT are both detections, so the ratio is unchanged');
+  }
+});
+
+// The distinction stated at the level the gate actually reads: two reports with
+// the same total timeout count score differently only because of WHICH bound
+// claimed them, and the backstop one is the lower.
+test('a leg whose timeouts are all backstop scores below one whose timeouts all ran', () => {
+  const backstop = { killed: 361, lived: 13, timedOut: 25, runTimedOut: 0 };
+  const ranOut = { killed: 361, lived: 13, timedOut: 0, runTimedOut: 25 };
+  assert.ok(attemptedEfficacy(backstop) < attemptedEfficacy(ranOut));
+  assert.equal(run(backstop, 95).code, 1, 'backstop timeouts must not carry a leg over the floor');
+  assert.equal(run(ranOut, 95).code, 0, 'run-phase timeouts are detections (#2944)');
+});
+
+// A memory reap reaches the gate as a BACKSTOP timeout, because the guard kills
+// the child and then holds so that no exit status of its own can be read as a
+// verdict, and gremlins' compile+run deadline is what finally claims it. #2921
+// must not regress through the run-phase credit: the arithmetic below is the
+// same leg with the same 25 unadjudicated mutants either way.
+test('a memory-reaped mutant is still not a kill', () => {
+  const reaped = { killed: 361, lived: 13, timedOut: 25, runTimedOut: 0 };
+  const r = run(reaped, 95);
+  assert.equal(r.code, 1, `a leg carried over the floor by reaped mutants: ${r.out}`);
+  assert.match(r.out, /timed out 25/);
+});
+
+// The closed status set. A fork that adds or renames a status must fail loudly:
+// an unrecognised status counted as nothing leaves those mutants out of BOTH
+// sides of the ratio, which raises the leg's score for free. This is the exact
+// failure an older gate would have hit against the fork that introduced RUN
+// TIMED OUT.
+test('an unrecognised status fails the gate instead of vanishing from the ratio', () => {
+  const r = run({ killed: 100, lived: 0, unknown: 40 }, 95);
+  assert.equal(r.code, 1, `a report with an unknown status must not pass: ${r.out}`);
+  assert.match(r.out, /does not know/);
+  assert.match(r.out, /SOMETHING NEW/);
+});
+
+test('the statuses that carry no verdict stay outside both sides of the ratio', () => {
+  const c = countMutationStatuses({
+    files: [
+      {
+        mutations: [
+          { status: 'NOT COVERED' },
+          { status: 'NOT VIABLE' },
+          { status: 'SKIPPED' },
+          { status: 'RUNNABLE' },
+          { status: 'KILLED' },
+        ],
+      },
+    ],
+  });
+  assert.equal(c.unknown.size, 0, 'the unscored statuses are known, just not counted');
+  assert.equal(attemptedEfficacy(c), 100);
+});
+
+// A run bound that collapsed manufactures RUN TIMED OUT specifically, so the
+// budget-collapse floor is computed over NORMAL verdicts only. Crediting run
+// timeouts must not turn that signature into a perfect leg.
+test('a leg whose every mutant run-timed-out is a collapsed budget, not a perfect suite', () => {
+  const r = run({ killed: 0, lived: 0, runTimedOut: 295 }, 95);
+  assert.equal(r.code, 1, `295 run timeouts and no normal verdict must not report 100%: ${r.out}`);
+  assert.match(r.out, /budget collapsing/);
 });
 
 test('the gated rate is never above the rate gremlins reported', () => {
@@ -168,18 +265,28 @@ test('countMutationStatuses matches only the exact status strings', () => {
         mutations: [
           { status: 'TIMED OUT' },
           { status: 'TIMEDOUT' },
+          { status: 'RUN TIMED OUT' },
           { status: 'KILLED' },
           { status: 'LIVED' },
         ],
       },
     ],
   });
-  assert.deepEqual(c, { total: 4, timedOut: 1, killed: 1, lived: 1 });
+  assert.equal(c.total, 5);
+  assert.equal(c.timedOut, 1);
+  assert.equal(c.runTimedOut, 1);
+  assert.equal(c.killed, 1);
+  assert.equal(c.lived, 1);
+  // A near-miss spelling is not silently folded into the status it resembles;
+  // it is collected as unknown, and main() fails on it.
+  assert.deepEqual([...c.unknown.entries()], [['TIMEDOUT', 1]]);
 });
 
 test('attemptedEfficacy reports null when the runner attempted nothing', () => {
   assert.equal(attemptedEfficacy({ killed: 0, lived: 0, timedOut: 0 }), null);
+  assert.equal(attemptedEfficacy({ killed: 0, lived: 0, timedOut: 0, runTimedOut: 0 }), null);
   assert.equal(attemptedEfficacy({ killed: 1, lived: 1, timedOut: 2 }), 25);
+  assert.equal(attemptedEfficacy({ killed: 1, lived: 1, timedOut: 1, runTimedOut: 1 }), 50);
 });
 
 test('a report with no per-mutation records falls back to the reported ratio', () => {

--- a/.github/scripts/gremlins-threshold.test.mjs
+++ b/.github/scripts/gremlins-threshold.test.mjs
@@ -232,10 +232,10 @@ test('a leg whose every mutant run-timed-out is a collapsed budget, not a perfec
   assert.match(r.out, /budget collapsing/);
 });
 
-test('the gated rate is never above the rate gremlins reported', () => {
-  // gremlins drops timeouts from both sides; this gate keeps them in the
-  // denominator. So this gate is strictly the stricter of the two, which is
-  // why gremlins' own ratio is reported here but not compared against.
+test('with no run-phase timeouts the gated rate is never above gremlins own', () => {
+  // gremlins drops both timeout kinds from both sides; this gate keeps the
+  // backstop ones in the denominator. Over a report with no RUN TIMED OUT
+  // mutants this gate is therefore strictly the stricter of the two.
   for (const [killed, lived, timedOut] of [
     [486, 15, 36],
     [39, 1, 279],
@@ -247,6 +247,21 @@ test('the gated rate is never above the rate gremlins reported', () => {
     const gated = attemptedEfficacy({ killed, lived, timedOut });
     assert.ok(gated <= reported + Number.EPSILON, `gated ${gated} > reported ${reported}`);
   }
+});
+
+// …and the ordering does NOT hold once run-phase timeouts exist, which is why
+// gremlins' number is reported and never compared against. A mutant gremlins
+// discards from both sides is one this gate counts as a detection, so the two
+// ratios are computed over different mutant sets and neither bounds the other.
+// Pinned so the removed "always >= " claim cannot creep back as an assertion.
+test('the two ratios are computed over different mutant sets, so neither bounds the other', () => {
+  const runHeavy = { killed: 0, lived: 1, timedOut: 0, runTimedOut: 99 };
+  assert.equal(gremlinsReported(runHeavy), 0);
+  assert.equal(attemptedEfficacy(runHeavy), 99);
+
+  const backstopHeavy = { killed: 90, lived: 10, timedOut: 100, runTimedOut: 0 };
+  assert.equal(gremlinsReported(backstopHeavy), 90);
+  assert.equal(attemptedEfficacy(backstopHeavy), 45);
 });
 
 // The budget-collapse signature keeps its own message: 0/295 already fails the

--- a/.github/scripts/mutant-memory-guard.mjs
+++ b/.github/scripts/mutant-memory-guard.mjs
@@ -57,9 +57,14 @@
 //   - Exiting 0 would record LIVED, which gremlins' own --on-shutdown-status
 //     work rejected for unadjudicated mutants: "reporting these as LIVED
 //     misrepresents the data — they were never tested".
-//   - Holding lets gremlins' existing deadline fire and record TIMED OUT, which
-//     .github/scripts/gremlins-threshold.mjs already scores as UNADJUDICATED:
-//     counted in the denominator, credited to nobody.
+//   - Holding lets gremlins' existing deadline fire. The deadline that fires is
+//     the compile+run BACKSTOP, not the run-phase watchdog: the test binary is
+//     already dead, so it never prints the `panic: test timed out after ` the
+//     run-phase verdict is read from. The status is therefore TIMED OUT, which
+//     .github/scripts/gremlins-threshold.mjs scores as UNADJUDICATED — counted
+//     in the denominator, credited to nobody. That is what keeps a reaped mutant
+//     out of the numerator now that a run-phase timeout IS credited (#2944):
+//     killing the child destroys the very evidence the credit requires (#2921).
 //
 // The hold costs no wall clock the lane was not already paying: the mutants
 // that trip this bound are the mutants that were already burning their whole

--- a/.github/scripts/mutation-run.mjs
+++ b/.github/scripts/mutation-run.mjs
@@ -78,8 +78,8 @@ function perMutantBounds(budgetSeconds) {
 
 // perMutantResidentMemoryMax is the ceiling on ONE mutant's test binary,
 // enforced by .github/scripts/mutant-memory-guard.mjs (which see for the
-// mechanism and for why the breach is recorded as TIMED OUT rather than as a
-// kill).
+// mechanism, and for why the breach is recorded as a BACKSTOP TIMED OUT rather
+// than as a kill or as the run-phase timeout that IS credited).
 //
 // The wall-clock bounds above bound TIME and nothing else, and time cannot
 // stand in for memory: `internal/logql/logpattern`'s REMOVE_SELF_ASSIGNMENTS
@@ -310,7 +310,8 @@ function reportMemoryBreaches(ledger) {
   notice(
     `${breaches.length} mutant(s) hit the ${perMutantResidentMemoryMax} per-mutant memory ceiling and ` +
       `were stopped there (worst observed ${(worst / 1024 ** 2).toFixed(0)}MiB); each is recorded as ` +
-      'TIMED OUT — unadjudicated, counted in the denominator, credited to nobody',
+      'TIMED OUT on the compile+run backstop — unadjudicated, counted in the denominator, ' +
+      'credited to nobody, and specifically NOT the run-phase timeout the gate credits (#2944)',
   );
 }
 

--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -209,6 +209,18 @@ jobs:
       #     load and type-check as it stands is not used as an oracle at all:
       #     its mutants are generated and left to the compiler, as before.
       #
+      #   the two per-mutant bounds report which of them claimed a mutant
+      #     A mutant is leashed twice — `go test -timeout` bounds the RUN, and a
+      #     context deadline covering compile+run is the backstop no -timeout can
+      #     be — but both produced one verdict, TIMED OUT. So a mutant that
+      #     genuinely does not terminate was indistinguishable from a compile
+      #     that hung and from one the memory guard below reaped. The fork now
+      #     reports RUN TIMED OUT when the test BINARY's own watchdog fired and
+      #     said so in its output, and keeps TIMED OUT for the backstop. It takes
+      #     no position on which is a detection — neither appears in
+      #     `test_efficacy` — so the policy stays in gremlins-threshold.mjs,
+      #     which credits the run-phase one and not the backstop (#2944).
+      #
       #   the mutated tests run with `-vet=off`
       #     `go test` runs a subset of `go vet` before it builds anything and
       #     reports a finding as `FAIL pkg [build failed]`, which from the
@@ -235,7 +247,7 @@ jobs:
       - name: install gremlins
         run: >
           node .github/scripts/go-module-fetch.mjs --
-          go install github.com/tsouza/gremlins/cmd/gremlins@v0.6.0-cerberus-viable-mutants-consume
+          go install github.com/tsouza/gremlins/cmd/gremlins@v0.6.0-cerberus-run-phase-timeout-consume
       # `workers: 0` keeps gremlins' default (runtime.NumCPU()); a
       # non-zero value caps the parallel `go test` fan-out per the
       # comment above the matrix entry.
@@ -307,12 +319,16 @@ jobs:
       # mutation-run.mjs therefore wires .github/scripts/mutant-memory-guard.mjs
       # in front of every test binary gremlins launches, as a `go test -exec`
       # supervisor, and gives it a per-mutant RSS ceiling. A mutant that breaches
-      # it is killed and then HELD, so gremlins' own deadline records it as
-      # TIMED OUT — unadjudicated, counted in the denominator, credited to
-      # nobody. It is deliberately not allowed to reach gremlins as an exit
-      # code: `go test` collapses every test-binary failure into its own exit 1,
-      # which gremlins reads as a KILL, and paying a leg efficacy for a mutant
-      # nobody adjudicated is the accounting #2903 removed.
+      # it is killed and then HELD, so the deadline that records it is the
+      # compile+run BACKSTOP — status TIMED OUT, unadjudicated, counted in the
+      # denominator, credited to nobody. It is deliberately not allowed to reach
+      # gremlins as an exit code: `go test` collapses every test-binary failure
+      # into its own exit 1, which gremlins reads as a KILL, and paying a leg
+      # efficacy for a mutant nobody adjudicated is the accounting #2903 removed.
+      # It stays uncredited now that a RUN-phase timeout is credited (#2944),
+      # and not by a second rule: killing the child destroys the only evidence
+      # that credit is read from — the test binary's own timeout panic — so a
+      # reaped mutant cannot be scored as a detection (#2921).
       #
       # The clean fix is upstream of all of this: #2910 splits gremlins' single
       # deadline into an overall one and a run-only one, and a run-only leash is

--- a/docs/test-strategy.md
+++ b/docs/test-strategy.md
@@ -1184,25 +1184,67 @@ ratio nor `mutants_total`, the leg reported `Timed out: 295 / Test efficacy:
 0.00%` on pull requests while the identical leg on push-to-main — one
 cold-cache invocation, the intended budget — reported 99.65% (#2692).
 
-### Timed-out mutants are unadjudicated, and count against the leg
+### Which timeout is which, and which one counts
 
-`.github/scripts/gremlins-threshold.mjs` scores a leg as
-`killed / (killed + lived + timedOut)` — the kill rate over every mutant the
-runner ATTEMPTED to adjudicate. gremlins' own `test_efficacy` is
-`killed / (killed + lived)`, which drops a timeout from BOTH sides, so this gate
-is strictly the stricter of the two and gremlins' number is reported rather than
-compared against.
+A mutant is leashed twice. `go test -timeout` bounds the RUN, on a clock the Go
+toolchain starts when the test binary starts; a context deadline covering
+compile AND run is the backstop, because no `-timeout` can bound a compile that
+has hung. The pinned fork reports which of the two claimed a mutant, and the two
+answers mean opposite things:
 
-The rule that formula encodes: **the score must be monotone non-increasing in
-the timeout count.** Moving a mutant into `TIMED OUT` may never raise the number
-the gate reads. A gate that breaks that rule pays a slower runner in efficacy
-points, and a green run then proves the machine was busy rather than that the
-tests are strong.
+| status          | what fired                                                                         | what it proves                                               | side of the ratio |
+| --------------- | ---------------------------------------------------------------------------------- | ------------------------------------------------------------ | ----------------- |
+| `RUN TIMED OUT` | the test binary's own watchdog, which printed a `panic: test timed out after` line | the suite did not finish inside a bound no compile can spend | numerator         |
+| `TIMED OUT`     | the compile+run backstop                                                           | nothing about which phase spent it                           | denominator only  |
 
-The gate used to break it — it counted a timeout as a DETECTION, on the premise
-that a mutant exhausting the budget broke termination rather than lost a race
-with the compiler. The per-mutant costs in "Per-mutant time budget" above
-falsify that premise, and two signatures in the reports confirm it:
+`.github/scripts/gremlins-threshold.mjs` therefore scores a leg as
+
+```text
+efficacy = (killed + runTimedOut) / (killed + lived + timedOut + runTimedOut)
+```
+
+over every mutant the runner ATTEMPTED to adjudicate. gremlins' own
+`test_efficacy` is `killed / (killed + lived)`, which drops both timeout kinds
+from BOTH sides; the gate is the stricter of the two, and gremlins' number is
+reported rather than compared against.
+
+**A `RUN TIMED OUT` mutant is a detection because it changed observable
+behaviour.** The original suite finishes in a fraction of the bound — the bound
+is this leg's own measured recompile+link+run cycle, times the mutant fan-out,
+times 2 for runner variance — and the mutated one does not finish at all. The
+test binary itself reports that, in its own output. Nothing about the machine
+can manufacture it: compilation is charged to the allowance, not to this clock.
+That is the mutation-testing convention of counting a timeout as killed, applied
+only where the evidence supports it.
+
+**A `TIMED OUT` mutant is unadjudicated and credits nobody.** The backstop
+cannot say which phase spent it: a hung compile reaches it identically to a hung
+run, and so does a mutant `.github/scripts/mutant-memory-guard.mjs` reaped for
+breaching the per-mutant RSS ceiling — the guard kills the child and then HOLDS,
+precisely so that no exit status of its own can be read as a verdict, which also
+destroys the only evidence the run-phase credit is read from.
+
+The rule the formula encodes: **the score must be monotone non-increasing in
+the UNADJUDICATED count.** Moving a mutant into `TIMED OUT` may never raise the
+number the gate reads. A gate that breaks that rule pays a slower runner in
+efficacy points, and a green run then proves the machine was busy rather than
+that the tests are strong.
+
+The one asymmetry is deliberate and is pinned as its own test: moving a mutant
+`LIVED` -> `RUN TIMED OUT` DOES raise the score, because a survivor that stops
+terminating has stopped surviving. That is why the two statuses may not be
+collapsed, and why the gate's status set is CLOSED — a status it does not
+recognise fails the run rather than being dropped from both sides of the ratio,
+which would raise a leg's score for free.
+
+The gate used to break it — it counted EVERY timeout as a detection, on the
+premise that a mutant exhausting the budget broke termination rather than lost a
+race with the compiler. Under one undifferentiated budget that premise was
+false, and the per-mutant costs in "Per-mutant time budget" above falsify it.
+Two signatures in the reports confirm it, and every mutant in both would be a
+backstop `TIMED OUT` today — the compile is what consumed the budget, and the
+compile is what the backstop covers — so the narrow reading above credits none
+of them:
 
 - Runs 33542904091 (red) and 33551271099 (green) recorded the SAME 486 kills on
   `phase4-promql-lower`. The whole 94.00% -> 97.01% swing was 16 mutants moving
@@ -1217,10 +1259,14 @@ falsify that premise, and two signatures in the reports confirm it:
   legs reported 100.00% with `lived: 0`, over 1266 mutants of which 1230 timed
   out.
 
-The two halves are paired. The measured budget keeps an honest leg from timing
-out for the compiler's sake; this formula is what makes it safe to get that
-measurement wrong in the tight direction, because an undersized budget now shows
-up as a RED leg instead of a flattering one.
+The three halves are paired, and none of them is optional. The split leash
+(#2929) is what makes the run bound mean the run. The measured budget keeps an
+honest leg from timing out for the compiler's sake. The backstop's place in the
+denominator is what makes it safe to get that measurement wrong in the tight
+direction, because an undersized budget shows up as a RED leg instead of a
+flattering one — a collapsed run bound manufactures `RUN TIMED OUT`
+specifically, which is why the budget-collapse floor is computed over NORMAL
+verdicts (killed or lived) only.
 
 A surviving mutant is either (a) a legitimately weak assertion that
 needs strengthening, (b) a functionally-equivalent mutation (`<` vs
@@ -1283,30 +1329,43 @@ template parser — advances an induction variable by hand. Every mutation
 that stops that variable advancing (`i++` -> `i--`, `i += n` -> `i = n`,
 `break` -> `continue`, a loop guard negated, an offset arithmetic flipped)
 turns the loop into a non-terminating one. The mutated program does not
-compute a wrong answer; it computes no answer. Some spin on the CPU, and
-some append to a buffer inside the loop and grow without bound, which the
-per-mutant memory ceiling stops as a TIMED OUT verdict rather than a
-detection.
+compute a wrong answer; it computes no answer.
 
-Such a mutant is a PERMANENT cost with the same shape as a proven
-equivalent, and for the arithmetic it is worse: an equivalent is at least
-diluted by a bigger leg, and a timeout is too, but neither can ever be
-converted into a kill by writing a test. No assertion runs against a
-program that never returns. The consequence is a hard ceiling, and it is
-arithmetic rather than judgement: a leg whose TIMED OUT count plus its
-documented-equivalent count exceeds 5% of its own attempted total cannot
-reach the 95% floor however strong its assertions are. The remedy is the
-same dilution lever the surviving-mutant policy names — re-partition the
-leg wider against `gremlins unleash --dry-run` — applied to the package's
-scanner-bearing files, and it works only while the combined permanent cost
-stays under the margin.
+Which is a detection. The suite cannot finish, the test binary's own
+watchdog says so, and `RUN TIMED OUT` records it — see "Which timeout is
+which" above. No assertion will ever run against a program that never
+returns, and none needs to: the mutant already changed observable
+behaviour, and the suite's own runtime bound is what observed it.
+
+The class splits on HOW the mutant runs away, and only one half is a
+permanent cost:
+
+- **spins on the CPU** — reaches the run watchdog, prints the panic, and
+  is credited. Nothing to do.
+- **allocates inside the loop** — reaches the 1GiB per-mutant RSS ceiling
+  first, and `mutant-memory-guard.mjs` kills it there. The kill destroys
+  the evidence the credit is read from, so the mutant is claimed by the
+  compile+run backstop as `TIMED OUT`: unadjudicated, in the denominator,
+  credited to nobody. This half IS a permanent cost with the same shape as
+  a proven equivalent, and for the arithmetic it is worse, because neither
+  can be converted into a kill by writing a test.
+
+So a leg's ceiling is arithmetic rather than judgement: a leg whose
+BACKSTOP `TIMED OUT` count plus its documented-equivalent count exceeds 5%
+of its own attempted total cannot reach the 95% floor however strong its
+assertions are. `RUN TIMED OUT` no longer enters that sum. The remedy for
+what remains is the same dilution lever the surviving-mutant policy names
+— re-partition the leg wider against `gremlins unleash --dry-run` —
+applied to the package's scanner-bearing files, and it works only while
+the combined permanent cost stays under the margin.
 
 Recognising the class matters because it is easy to misread as budget
-starvation and answer with a bigger `--timeout-max`. It is not: the
-mutants below are non-terminating against any finite budget. The tell is
-the per-mutant memory notice the lane emits — a mutant that reaches the
-1GiB ceiling in a package whose whole test binary peaks near 100MiB is
-running away, not running slowly.
+starvation and answer with a bigger `--timeout-max`. It is not: these
+mutants are non-terminating against any finite budget, so a larger bound
+converts none of them — it only makes the leg slower. The tells are the
+status itself and the per-mutant memory notice the lane emits: a mutant
+that reaches the 1GiB ceiling in a package whose whole test binary peaks
+near 100MiB is running away, not running slowly.
 
 ## Grafana surface crawler (Layer 9 extension)
 

--- a/docs/test-strategy.md
+++ b/docs/test-strategy.md
@@ -1205,8 +1205,11 @@ efficacy = (killed + runTimedOut) / (killed + lived + timedOut + runTimedOut)
 
 over every mutant the runner ATTEMPTED to adjudicate. gremlins' own
 `test_efficacy` is `killed / (killed + lived)`, which drops both timeout kinds
-from BOTH sides; the gate is the stricter of the two, and gremlins' number is
-reported rather than compared against.
+from BOTH sides. The two are computed over different mutant sets, so neither
+bounds the other — with no run-phase timeouts the gate is the stricter, and with
+them it can read higher, because a mutant gremlins discards entirely is one the
+gate counts as a detection. gremlins' number is therefore reported alongside,
+never compared against.
 
 **A `RUN TIMED OUT` mutant is a detection because it changed observable
 behaviour.** The original suite finishes in a fraction of the bound — the bound

--- a/docs/toolchain.md
+++ b/docs/toolchain.md
@@ -49,7 +49,7 @@ because that rule has no auto-fixer of its own.
 `mutation.yml` installs the `tsouza/gremlins` fork rather than upstream `go-gremlins/gremlins@v0.6.0`:
 
 ```bash
-go install github.com/tsouza/gremlins/cmd/gremlins@v0.6.0-cerberus-viable-mutants-consume
+go install github.com/tsouza/gremlins/cmd/gremlins@v0.6.0-cerberus-run-phase-timeout-consume
 ```
 
 The fixes it carries defend one thing between them: that the number a run reports is a number the
@@ -97,11 +97,26 @@ Letting Go's `-timeout` win that race is only safe with the second half. `go tes
 failing test, a package that does not build and a test that ran past its `-timeout` into its own exit
 status 1; only the test *binary* exits 2, and what gremlins spawns is `go`. Reading that 1 at face
 value credits a timeout as a KILL and books a mutant that never compiled as one too. The fork scans
-the child's output instead — the `panic: test timed out after` line maps to `TIMED OUT`,
+the child's output instead — the `panic: test timed out after` line maps to `RUN TIMED OUT`,
 `[build failed]` and `[setup failed]` map to `NOT VIABLE`, and anything else is left to the exit
-status. `TIMED OUT` stays in the efficacy denominator and credits nobody, so a slow test cannot buy
-a score. The scan is streaming and retains only enough bytes to recognise a marker split across two
+status. The scan is streaming and retains only enough bytes to recognise a marker split across two
 writes, so a mutant that prints without bound cannot exhaust memory.
+
+**The two bounds report which of them claimed a mutant.** Splitting the leash gave the run bound and
+the backstop different meanings, but both still produced one status, so a mutant that genuinely does
+not terminate stayed indistinguishable from a compile that hung. The fork now reports them apart:
+
+| status          | what fired                                                         | what it proves                                               |
+| --------------- | ------------------------------------------------------------------ | ------------------------------------------------------------ |
+| `RUN TIMED OUT` | the test binary's own `-timeout` watchdog, which printed the panic | the suite did not finish inside a bound no compile can spend |
+| `TIMED OUT`     | the context deadline over compile **and** run                      | nothing — a hung compile and a hung run reach it identically |
+
+The marker is read before either deadline, because a large goroutine dump can still be draining when
+the backstop expires, and it is guarded on the child having failed, so a suite that passes while
+printing those bytes stays `LIVED`. gremlins takes no position on which status is a detection —
+neither appears in its own `test_efficacy` — so the policy lives one layer up, in
+`.github/scripts/gremlins-threshold.mjs`, which counts `RUN TIMED OUT` as a detection and leaves
+`TIMED OUT` in the denominator crediting nobody. A slow compiler still cannot buy a score.
 
 **Prefix operators read as prefix operators.** gremlins maps each `token.Token` to the mutations
 that make sense for it, and that table describes the operator's *infix* meaning — but the same walk
@@ -154,9 +169,9 @@ in the suite rather than an artefact.
 root, and the matcher is RE2 with no lookahead. A path in the wrong form silently excludes nothing.
 
 The fork ships two branches on purpose. `cerberus-sigterm-fix` at tag
-`v0.6.0-cerberus-viable-mutants` is the branch the upstream pull request is built from, and keeps
+`v0.6.0-cerberus-run-phase-timeout` is the branch the upstream pull request is built from, and keeps
 the upstream module path `github.com/go-gremlins/gremlins` so the diff stays reviewable.
-`cerberus-sigterm-fix-consume` at tag `v0.6.0-cerberus-viable-mutants-consume` is the branch
+`cerberus-sigterm-fix-consume` at tag `v0.6.0-cerberus-run-phase-timeout-consume` is the branch
 `mutation.yml` installs; it adds one commit renaming the `go.mod` module path to
 `github.com/tsouza/gremlins` and rewriting the internal imports, because `go install` otherwise
 rejects the module with `module declares its path as: github.com/go-gremlins/gremlins`. The fixes

--- a/test/regression/mutation_timeout_max_test.go
+++ b/test/regression/mutation_timeout_max_test.go
@@ -78,7 +78,17 @@ const (
 //     change of behaviour — now reach a test binary and are adjudicated.
 //     Reverting to an earlier tag puts them back outside the denominator,
 //     which reads as a leg getting easier when it has only stopped asking.
-const gremlinsForkTag = "github.com/tsouza/gremlins/cmd/gremlins@v0.6.0-cerberus-viable-mutants-consume"
+//   - the `run-phase-timeout` family (#2944): reports WHICH of the two bounds
+//     claimed a timed-out mutant. `go test -timeout` bounds the run and the
+//     context deadline bounds compile+run, but both used to produce one status,
+//     so a mutant that genuinely does not terminate was indistinguishable from a
+//     compile that hung and from one the memory guard reaped. The fork now emits
+//     RUN TIMED OUT when the test BINARY's own watchdog fired and printed so,
+//     and .github/scripts/gremlins-threshold.mjs credits that and only that.
+//     Reverting to an earlier tag makes every report carry the undifferentiated
+//     status, and the gate FAILS on it rather than silently scoring the union:
+//     the closed status set there refuses to score a report it cannot read.
+const gremlinsForkTag = "github.com/tsouza/gremlins/cmd/gremlins@v0.6.0-cerberus-run-phase-timeout-consume"
 
 // TestMutationLaneCapsPerMutantTimeout (#1294) pins the one bound that keeps the
 // mutation lane from killing its own runner.
@@ -150,7 +160,9 @@ func TestMutationLaneCapsPerMutantTimeout(t *testing.T) {
 			"the leg is paid efficacy for the compiler's work (#2930); and everything before "+
 			"`viable-mutants` emits 156 more mutants no compiler accepts and lets `go vet` withhold a "+
 			"verdict from 78 that are legal Go, shrinking the denominator a leg is measured against "+
-			"(#2933).",
+			"(#2933); and everything before `run-phase-timeout` reports one undifferentiated TIMED "+
+			"OUT for both of the two bounds, so a mutant that genuinely does not terminate cannot be "+
+			"told from a compile that hung or from one the memory guard reaped (#2944).",
 			mutationWorkflowPath, gremlinsForkTag, timeoutMaxFlag)
 	}
 }


### PR DESCRIPTION
A mutant is leashed twice. `go test -timeout` bounds the RUN, on a clock the Go toolchain starts
when the test binary starts. A context deadline covering compile AND run is the backstop, because no
`-timeout` can bound a compile that has hung. #2929 split the two bounds; both still reported one
status, `TIMED OUT`, so nothing downstream could tell a mutant that genuinely does not terminate
from a compile that lost a race with the runner.

This makes the report say which bound fired, and credits only one of them.

## The formula

```text
efficacy = (killed + runTimedOut) / (killed + lived + timedOut + runTimedOut)
```

Nothing leaves the denominator. No floor moves. No file is excluded.

| status | what fired | what it proves | side |
| --- | --- | --- | --- |
| `KILLED` | a test failed | the suite distinguishes the mutant | numerator |
| `RUN TIMED OUT` | the test binary's own watchdog, which printed the `panic: test timed out after` line | the suite did not finish inside a bound no compile can spend | numerator |
| `LIVED` | the suite passed | the mutant survived | denominator |
| `TIMED OUT` | the compile+run backstop | nothing about which phase spent it | denominator |

## Why this is not #2903 coming back

#2903 removed the flat credit because the budget then wrapped the whole `go test` child, the
compiler was 80-98% of it, and `TIMED OUT` recorded "the machine was busy". Both signatures it was
built from — the `phase4-promql-lower` pair 33542904091/33551271099 where the SLOWER runner scored
three points higher off the same 486 kills, and run 33522074818 where four `internal/chsql` legs
reported 100.00% having adjudicated 3% of their mutants — are compile starvation. Every mutant in
both is a backstop `TIMED OUT` today, and this change credits none of them.

What a `RUN TIMED OUT` mutant overran is a leash sized from its own leg's measured
recompile+link+run cycle, times the mutant fan-out, times 2 for runner variance, floored at
`MUTANT_TIMEOUT_MIN` — an upper bound on the honest run several times over — and the test binary
itself reported the overrun in its output. Against an original that finishes in a fraction of that
bound, not finishing is a change in observable behaviour, caught by the suite's own runtime bound.
That is what a detection is.

#2917's investigation is what makes this safe to assert rather than assume: all 42 timeouts on
`phase4-logql-lsyntax`/`phase5-qlcommon` are mutations of a hand-written scanner's induction
variable, eleven were applied by hand under a 2 GiB cap, and **none terminated**.

## Where each half lives, and why

**The fork records the evidence.** Only the executor knows whether a verdict came from the output
marker or from `ctx.Err()`, and that fact is unrecoverable from today's JSON. So the fork emits two
statuses and takes **no** position on what they mean: neither appears in gremlins' own
`test_efficacy`, exactly as before.

**The gate sets the policy.** What counts as a detection is cerberus's decision about what its own
number means, not gremlins'. `gremlins-threshold.mjs` already deliberately ignores gremlins' ratio
and recomputes; this is the same layer, and putting the credit in the fork would have hidden a
cerberus policy inside a shared tool.

Ordering detail in the fork: the marker is read **before** either deadline. A large goroutine dump
can still be draining when the backstop expires, and reading the backstop first would relabel the one
mutant that did report a verdict as one that did not. It is guarded on the child having failed, so a
suite that passes while printing those bytes stays `LIVED`.

## What did not change

- **A memory-reaped mutant is still not a kill (#2921).** Not by a second rule — by construction.
  `mutant-memory-guard.mjs` kills the child and then HOLDS, so the deadline that claims the mutant is
  the compile+run backstop, and the kill destroys the only evidence the run-phase credit is read
  from. The guard cannot manufacture a detection even in principle.
- **A hung compile is still not a kill (#2910).** The backstop cannot say which phase spent it.
- **The budget-collapse floor (#2692)** stays computed over NORMAL verdicts — killed or lived —
  because a collapsed run bound manufactures `RUN TIMED OUT` specifically. A leg that killed nothing
  and survived nothing has not shown its budget works, whatever its run timeouts say.
- **The monotonicity rule**, restated over the unadjudicated count: moving a mutant into `TIMED OUT`
  may never raise the score. The one asymmetry is deliberate and pinned as its own test — `LIVED` ->
  `RUN TIMED OUT` DOES raise it, because a survivor that stops terminating has stopped surviving.

## The gate's status set is now closed

An unrecognised status fails the run instead of being dropped from both sides of the ratio. That is
not decoration: it is the concrete failure mode of this very fork bump. An older gate paired with the
new fork would have scored every `RUN TIMED OUT` mutant out of the denominator and raised every leg
for free.

## Four-direction proof, each verified by breaking the mechanism

Against the real `go` toolchain, not stubs — `internal/engine/executor_verdict_test.go` drives real
`go test` children because `go test` gives a failing test, a build failure and a test timeout the
same exit status 1.

| direction | verdict | break applied | observed failure |
| --- | --- | --- | --- |
| a mutant that does not terminate in its RUN | `RUN TIMED OUT` | marker branch returns `TimedOut` | `expected RUN TIMED OUT, got TIMED OUT` |
| a mutant whose COMPILE hangs | `TIMED OUT` | backstop branch returns `RunTimedOut` | `expected TIMED OUT from the compile backstop, got RUN TIMED OUT` |
| a mutant reaped by a `go test -exec` supervisor that then holds | `TIMED OUT` | same | `a mutant killed by an external memory supervisor was credited as a run-phase timeout` |
| a child that prints the marker and still exits 0 | `LIVED` | drop the `err != nil` guard | `expected mutation to be LIVED, but got: RUN TIMED OUT` |
| failing test / passing test / uncompilable mutant | `KILLED` / `LIVED` / `NOT VIABLE` | unchanged, still pinned | — |

The reap case shares one fixture with the unsupervised case and differs only in whether the
supervisor is interposed, so the contrast is the mechanism itself: without it the run watchdog fires
and the mutant is credited; with it, the same mutant is not.

Gate-side, four more breaks, each producing its specific failure:

| break | failing test |
| --- | --- |
| do not credit a run-phase timeout | `LIVED -> RUN TIMED OUT raises the score…`, `a leg whose timeouts are all backstop scores below one whose timeouts all ran` |
| credit the backstop too (#2903 restored) | `the starved run of a leg scores BELOW the run it was compared against`, `a leg that adjudicated 6% of its mutants cannot report 100%`, `a memory-reaped mutant is still not a kill`, + 4 more |
| drop the closed-status guard | `an unrecognised status fails the gate instead of vanishing from the ratio` |
| count a run timeout toward the collapse floor | `a leg whose every mutant run-timed-out is a collapsed budget, not a perfect suite` |

## Per-leg arithmetic

This diff touches `HARNESS_PATHS`, so the selector sweeps the FULL matrix and this PR's own
`mutation` run measures every leg. The before/after table lands in this description as soon as that
run completes, against the full-matrix baseline
[33635018460](https://github.com/tsouza/cerberus/actions/runs/33635018460) plus #2942's own run
[33646427445](https://github.com/tsouza/cerberus/actions/runs/33646427445) for `phase4-traceql-ast`.

## Fork

New tags on both branches, identical fixes:

- `v0.6.0-cerberus-run-phase-timeout` on `cerberus-sigterm-fix` (upstream module path, reviewable
  diff)
- `v0.6.0-cerberus-run-phase-timeout-consume` on `cerberus-sigterm-fix-consume` (the tag
  `mutation.yml` installs)

`test/regression/mutation_timeout_max_test.go` pins the new tag whole, with the family history
extended; `docs/toolchain.md` and `docs/test-strategy.md` carry the two-status table and the revised
ceiling arithmetic.

Closes #2944

🤖 Generated with [Claude Code](https://claude.com/claude-code)
