### PR TITLE
ci(mutation): derive the lane's harness paths instead of hand-listing them

### DIFF
--- a/.github/scripts/README.md
+++ b/.github/scripts/README.md
@@ -146,6 +146,30 @@ changed"), and segment-wise `underPrefix` / `matchesAny`.
 It exists so the two dangerous parts — the always-full event set and the
 uncomputable-diff fallback — cannot drift between the lanes that use it.
 
+`lib/lane-harness.mjs` answers the other half of that question: "which files
+does the lane ITSELF execute?" — the set that must force the FULL matrix,
+because a change to any of them reaches every leg. `laneHarnessClosure()`
+derives it from the workflow rather than from a hand-written array: the
+workflow's own `node …` steps and `uses: ./.github/actions/…` manifests are the
+entry points, and the transitive `.mjs` graph reachable from those — static
+`import` specifiers and equally the bare module literals a script resolves
+against its own directory to spawn — is the closure. Anchoring on the `node`
+verb is what keeps a script that a comment merely NAMES out of the graph, and
+whole-literal matching is what keeps prose that mentions a `.mjs` filename out
+of it. A hand-written list was the previous answer and it rotted exactly as
+lists do: `mutant-memory-guard.mjs` sat in front of every mutation leg's test
+binary deciding each mutant's fate and was never added, so a PR editing only the
+guard moved every leg's numbers while selecting no leg at all (cerberus #2948).
+Deriving makes "the runner gained a file" and "the harness set gained a path"
+one event instead of two. Only what the lane READS rather than executes — a
+tool's config, `go.mod` — is still declared by the caller, since no source scan
+can find it; `*.test.mjs` suites are reachable from no entry point and stay out,
+because a test-only edit cannot change a verdict and must not spend the matrix.
+An entry point in a form the walk does not model — a checked-in script run
+through a shell, which has no module graph — throws rather than being dropped,
+so the first one to appear extends the model instead of quietly shrinking the
+harness set.
+
 `lib/crawl-budget.mjs` owns the two nested time budgets the Grafana surface
 crawl runs under — the SPEC budget `crawl.spec.ts` sets on itself
 (`testInfo.setTimeout`) and the JOB cap the shard planners put on the runner —
@@ -978,8 +1002,14 @@ what actually runs.
   `mutation.yml`'s `strategy.matrix`. It carries the per-leg rationale — the
   logql/traceql OOM splits, the equivalent-mutant analysis behind each bar — that
   used to live in the workflow. Also exports `HARNESS_PATHS`: the paths that
-  change the lane itself and therefore force the FULL matrix.
-  - Env: none (pure data module).
+  change the lane itself and therefore force the FULL matrix. That set is
+  DERIVED, not listed — `lib/lane-harness.mjs` walks `mutation.yml`'s own `node`
+  steps and composite actions into the module graph reachable from them, and
+  only the read-only inputs no scan can find (`MUTATION_DATA_PATHS`:
+  `.gremlins.yaml`, `go.mod`, `go.sum`) are declared here.
+  - Env: none (the phase table is pure data; the harness closure reads the
+    workflow and script sources at import time, relative to this module's own
+    location rather than to `process.cwd()`).
 - **`mutation-matrix.mjs`** — `mutation.yml`, the `select` job. Decides WHICH
   phases run and emits them as the `mutate` `strategy.matrix`. On push /
   schedule / dispatch and on a `release/*` PR it selects every phase; on an

--- a/.github/scripts/lib/lane-harness.mjs
+++ b/.github/scripts/lib/lane-harness.mjs
@@ -1,0 +1,159 @@
+// lane-harness.mjs — the set of repository files a workflow lane EXECUTES,
+// DERIVED from the workflow rather than hand-listed.
+//
+// Why this exists
+// ---------------
+// A diff-scoped lane (see `lib/scope-gate.mjs`) selects the legs whose scope a
+// change touches. That is only sound while changes to the lane's OWN machinery
+// select everything: a file the runner executes has matrix-wide reach, so a PR
+// editing it must run the whole matrix or the lane reports green over work its
+// selection never covered.
+//
+// `mutation-phases.mjs` expressed that set as a hand-written `HARNESS_PATHS`
+// array, and it rotted exactly the way a hand-written list of paths rots. When
+// `mutant-memory-guard.mjs` landed (cerberus #2919 / #2921) it was wired into
+// every leg's `go test -exec`, where it decides each mutant's fate — and it was
+// never added to the array. A PR editing only the guard, including the one that
+// resized its hold (#2947), therefore moved every leg's numbers while selecting
+// NO leg (cerberus #2948). `lib/gh.mjs`, `go-module-fetch.mjs`,
+// `lib/registry.mjs` and the `setup-go` composite action were missing for the
+// same reason: nobody remembered to append them.
+//
+// So the array stops being written. The closure below is computed from the
+// artefacts that already state what the lane runs — the workflow's own `node`
+// invocations and `uses: ./.github/actions/…` steps, then the module graph
+// reachable from those entry points. Adding a step, an import, or a spawned
+// helper extends the harness set in the same commit that adds it, with nothing
+// to remember.
+//
+// What it deliberately does NOT cover
+// -----------------------------------
+//   - Data the lane READS rather than executes (a tool's config file, `go.mod`).
+//     No source scan can find those; the caller declares them alongside this
+//     closure, and that short list is reviewable precisely because it is short.
+//   - `*.test.mjs` suites. A unit test of a harness script is not run by the
+//     lane and cannot change a single mutant's verdict; it is reachable from no
+//     entry point, so it never enters the closure. Selecting the full matrix on
+//     a test-only edit would spend every leg to prove nothing.
+//
+// This module is pure: every input is a file path under `root`, and the result
+// is a sorted array of repo-relative paths.
+//
+// node: builtins only — no npm deps, no setup-node needed.
+
+import { existsSync, readFileSync } from 'node:fs';
+import { posix } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+// `node <script>` as a workflow actually spells it: bare, quoted, or rooted at
+// `$GITHUB_WORKSPACE` — the form a COMPOSITE action must use, because its own
+// `run:` steps inherit the caller's working directory rather than the repo
+// root. Anchoring on the `node` verb is what keeps a script a comment merely
+// NAMES out of the closure: `mutation.yml`'s header points at
+// `compose-smoke-matrix.mjs` as a shape to compare against, and that file is
+// not part of this lane.
+const NODE_INVOCATION =
+  /\bnode\s+["']?(?:\$\{?GITHUB_WORKSPACE\}?\/|\$\{\{\s*github\.workspace\s*\}\}\/)?(\.github\/scripts\/[A-Za-z0-9._/-]+\.mjs)/g;
+
+// A local composite action step: `uses: ./.github/actions/<name>`. Its manifest
+// is `<name>/action.yml`, and the manifest's own `node` invocations are entry
+// points of the lane exactly as the workflow's are.
+const LOCAL_ACTION_USE = /\buses:\s*(\.\/\.github\/actions\/[A-Za-z0-9._/-]+)/g;
+
+// An entry point this module does NOT model: a checked-in script run through an
+// interpreter other than `node`, which has no `.mjs` graph to walk. Nothing in
+// any lane wired to this module uses one today, and a derivation that quietly
+// ignored the first one would be back to under-reporting the harness — the
+// failure that made the hand-written list wrong. So it FAILS instead, naming
+// the file, and whoever adds the step extends the model in the same commit.
+// `shell: bash` and friends do not match: a path under a scripts directory must
+// follow the interpreter.
+const UNMODELLED_INVOCATION =
+  /\b(?:ba|z)?sh\s+["']?(?:\$\{?GITHUB_WORKSPACE\}?\/|\$\{\{\s*github\.workspace\s*\}\}\/)?((?:\.github\/)?scripts\/[A-Za-z0-9._/-]+)/g;
+
+// A module reference whose ENTIRE string literal is a path ending in `.mjs`.
+// That covers both edge kinds a script uses to reach another script: the
+// `import … from './lib/gh.mjs'` specifier, and the bare
+// `'mutant-memory-guard.mjs'` that `mutation-run.mjs` resolves against its own
+// directory to hand to `go test -exec`. Requiring the whole literal to be the
+// path is what excludes prose that merely names a script — an `::error::`
+// message or a thrown `Error` string — from the graph.
+const MODULE_LITERAL = /(['"`])([A-Za-z0-9._/-]+\.mjs)\1/g;
+
+// The repository root, derived from this module's own location
+// (`<root>/.github/scripts/lib/lane-harness.mjs`) rather than from
+// `process.cwd()`, so the closure is the same whichever directory a caller,
+// a test, or a workflow step happens to run from.
+export const REPO_ROOT = fileURLToPath(new URL('../../../', import.meta.url));
+
+function stripDotSlash(p) {
+  return String(p ?? '').replace(/^\.\//, '');
+}
+
+// resolveReference — where a `.mjs` literal found inside `fromPath` points.
+// A literal that already starts at `.github/` is repo-relative (that is how a
+// workflow names a script); anything else is resolved against the referring
+// file's own directory, which is how both ESM specifiers and the guard's
+// `dirname(import.meta.url)`-relative spawn path behave.
+export function resolveReference(fromPath, reference) {
+  if (reference.startsWith('.github/')) return reference;
+  return posix.normalize(posix.join(posix.dirname(fromPath), reference));
+}
+
+// laneHarnessClosure — every repo file the lane at `workflow` executes.
+//
+// The workflow itself, each local composite action manifest it uses, every
+// script those invoke with `node`, and the transitive `.mjs` graph reachable
+// from them. Sorted, so two callers reading the same tree get byte-identical
+// answers.
+//
+// A `node`-invoked script that does not exist is a broken workflow and throws:
+// silently dropping an entry point would put this module back in the business
+// of under-reporting the harness. A transitive literal that resolves to no file
+// is simply not an edge and is skipped.
+export function laneHarnessClosure({
+  workflow,
+  root = REPO_ROOT,
+  readFile = (p) => readFileSync(posix.join(root, p), 'utf8'),
+  fileExists = (p) => existsSync(posix.join(root, p)),
+}) {
+  const harness = new Set();
+  const manifests = [stripDotSlash(workflow)];
+  const roots = [];
+
+  for (const manifest of manifests) {
+    if (harness.has(manifest)) continue;
+    harness.add(manifest);
+    const text = readFile(manifest);
+    for (const [, action] of text.matchAll(LOCAL_ACTION_USE)) {
+      const actionManifest = posix.join(stripDotSlash(action), 'action.yml');
+      if (!harness.has(actionManifest) && fileExists(actionManifest)) manifests.push(actionManifest);
+    }
+    for (const [, script] of text.matchAll(NODE_INVOCATION)) {
+      if (!fileExists(script)) {
+        throw new Error(`lane-harness: ${manifest} runs "${script}", which does not exist`);
+      }
+      roots.push(script);
+    }
+    for (const [, script] of text.matchAll(UNMODELLED_INVOCATION)) {
+      throw new Error(
+        `lane-harness: ${manifest} runs "${script}" through a shell, an entry-point form this module ` +
+          'does not model — teach lane-harness.mjs to walk it rather than leaving it out of the harness set',
+      );
+    }
+  }
+
+  const queue = [...roots];
+  while (queue.length > 0) {
+    const script = queue.shift();
+    if (harness.has(script)) continue;
+    harness.add(script);
+    const source = readFile(script);
+    for (const [, , reference] of source.matchAll(MODULE_LITERAL)) {
+      const target = resolveReference(script, reference);
+      if (!harness.has(target) && fileExists(target)) queue.push(target);
+    }
+  }
+
+  return [...harness].sort();
+}

--- a/.github/scripts/mutation-matrix.test.mjs
+++ b/.github/scripts/mutation-matrix.test.mjs
@@ -39,7 +39,14 @@ import {
   selectPhases,
   tableViolations,
 } from './mutation-matrix.mjs';
-import { HARNESS_PATHS, MUTATION_PRODUCTION_GLOBS, PHASES } from './mutation-phases.mjs';
+import {
+  HARNESS_PATHS,
+  MUTATION_DATA_PATHS,
+  MUTATION_LANE_WORKFLOW,
+  MUTATION_PRODUCTION_GLOBS,
+  PHASES,
+} from './mutation-phases.mjs';
+import { laneHarnessClosure, resolveReference } from './lib/lane-harness.mjs';
 import { underPrefix } from './lib/scope-gate.mjs';
 
 const REGISTRY_SOURCE = readFileSync('.github/ci-lanes.json', 'utf8');
@@ -365,6 +372,159 @@ test('a change to the lane harness runs the full matrix', () => {
   for (const path of HARNESS_PATHS) {
     assert.equal(select([path]).phases.length, PHASES.length, path);
   }
+});
+
+// The derivation is only worth having if it reaches every kind of edge the lane
+// actually uses to get from mutation.yml to a file that decides a mutant's
+// fate. Each assertion below names ONE edge kind and one file that is reachable
+// ONLY through it, so losing that traversal fails here rather than showing up
+// as a matrix that silently selects nothing.
+//
+// `mutant-memory-guard.mjs` is the case that motivated all of this: a
+// `go test -exec` supervisor in front of every leg's test binary, absent from
+// the hand-written array for its whole life (cerberus #2948).
+test('HARNESS_PATHS is derived from what the lane executes, one entry per edge kind', () => {
+  const derived = new Set(laneHarnessClosure({ workflow: MUTATION_LANE_WORKFLOW }));
+
+  // the lane's own workflow — the single entry point everything else hangs off
+  assert.equal(derived.has('.github/workflows/mutation.yml'), true);
+  // a `run: node …` step in the workflow
+  assert.equal(derived.has('.github/scripts/mutation-matrix.mjs'), true);
+  assert.equal(derived.has('.github/scripts/mutation-run.mjs'), true);
+  assert.equal(derived.has('.github/scripts/gremlins-threshold.mjs'), true);
+  // a static `import … from` inside one of those scripts
+  assert.equal(derived.has('.github/scripts/mutation-phases.mjs'), true);
+  assert.equal(derived.has('.github/scripts/lib/scope-gate.mjs'), true);
+  assert.equal(derived.has('.github/scripts/lib/gh.mjs'), true);
+  // a spawn path: a bare literal resolved against the referring script's own
+  // directory and handed to `go test -exec`, reachable through no import
+  assert.equal(derived.has('.github/scripts/mutant-memory-guard.mjs'), true);
+  // a local composite action step, and the script ITS `run:` invokes through
+  // $GITHUB_WORKSPACE, plus that script's own transitive import
+  assert.equal(derived.has('.github/actions/setup-go/action.yml'), true);
+  assert.equal(derived.has('.github/scripts/go-module-fetch.mjs'), true);
+  assert.equal(derived.has('.github/scripts/lib/registry.mjs'), true);
+  // the derivation itself is reachable from mutation-phases.mjs, so a change to
+  // how the harness set is computed also sweeps the matrix
+  assert.equal(derived.has('.github/scripts/lib/lane-harness.mjs'), true);
+
+  // the shipped constant is exactly the closure plus the declared data inputs,
+  // with nothing appended by hand in between
+  assert.deepEqual(HARNESS_PATHS, [...derived, ...MUTATION_DATA_PATHS]);
+});
+
+// Before #2948 this exact diff selected 0 of 30 legs: the guard changed every
+// leg's adjudication and the matrix was skipped, so `mutation` reported green
+// over work that never ran. Asserted against the shipped constant rather than
+// against the closure, because it is the constant the selector reads.
+test('a diff touching only the per-mutant memory guard selects the FULL matrix', () => {
+  const result = select(['.github/scripts/mutant-memory-guard.mjs']);
+  assert.equal(result.phases.length, PHASES.length);
+  assert.equal(result.reason, "the lane's own harness changed (.github/scripts/mutant-memory-guard.mjs)");
+});
+
+// The other half of the bar: deriving must not degenerate into "every script in
+// the repository is harness". Each path below is a real file that the lane does
+// NOT execute, and one of them — compose-smoke-matrix.mjs — is named inside
+// mutation.yml's own header comment, which is precisely the reference a looser
+// scan would mistake for an edge.
+test('the derived harness set does not over-select scripts the lane never runs', () => {
+  for (const path of [
+    '.github/scripts/compose-smoke-matrix.mjs',
+    '.github/scripts/forbid-skip.mjs',
+    '.github/scripts/coverage-aggregate.mjs',
+    '.github/scripts/lib/golden-shards.mjs',
+  ]) {
+    assert.equal(HARNESS_PATHS.includes(path), false, path);
+    assert.deepEqual(select([path]).phases, [], path);
+  }
+
+  // A `*.test.mjs` suite is reachable from no entry point: it cannot change a
+  // mutant's verdict, so it must not spend all thirty legs proving that.
+  for (const path of HARNESS_PATHS) assert.equal(path.endsWith('.test.mjs'), false, path);
+  assert.deepEqual(select(['.github/scripts/mutant-memory-guard.test.mjs']).phases, []);
+  assert.deepEqual(select(['.github/scripts/mutation-matrix.test.mjs']).phases, []);
+
+  // and an ordinary production file still selects exactly its own leg
+  assert.deepEqual(names(select(['internal/chplan/plan.go'])), ['phase1']);
+});
+
+// The closure's own units, on a synthetic tree, so its edge rules are pinned
+// independently of whatever mutation.yml happens to contain today.
+test('laneHarnessClosure walks node steps, composite actions and module literals', () => {
+  const files = {
+    'wf.yml': [
+      '# a comment naming .github/scripts/unrelated.mjs proves prose is not an edge',
+      '      - uses: ./.github/actions/setup',
+      '      - run: node .github/scripts/entry.mjs',
+    ].join('\n'),
+    '.github/actions/setup/action.yml': 'run: node "$GITHUB_WORKSPACE/.github/scripts/warm.mjs"',
+    '.github/scripts/entry.mjs': [
+      "import { x } from './lib/shared.mjs';",
+      "const spawned = resolve(here, 'sidecar.mjs');",
+      "throw new Error('entry.mjs cannot reach unrelated.mjs from here');",
+    ].join('\n'),
+    '.github/scripts/lib/shared.mjs': '',
+    '.github/scripts/sidecar.mjs': '',
+    '.github/scripts/warm.mjs': '',
+    '.github/scripts/unrelated.mjs': '',
+  };
+  const closure = laneHarnessClosure({
+    workflow: 'wf.yml',
+    readFile: (p) => {
+      if (!(p in files)) throw new Error(`missing ${p}`);
+      return files[p];
+    },
+    fileExists: (p) => p in files,
+  });
+  assert.deepEqual(closure, [
+    '.github/actions/setup/action.yml',
+    '.github/scripts/entry.mjs',
+    '.github/scripts/lib/shared.mjs',
+    '.github/scripts/sidecar.mjs',
+    '.github/scripts/warm.mjs',
+    'wf.yml',
+  ]);
+
+  // A `node` step naming a script that is not there is a broken workflow, and
+  // saying so beats quietly shrinking the harness set — the failure mode this
+  // whole module exists to remove.
+  assert.throws(
+    () =>
+      laneHarnessClosure({
+        workflow: 'wf.yml',
+        readFile: () => '- run: node .github/scripts/gone.mjs',
+        fileExists: (p) => p === 'wf.yml',
+      }),
+    /runs ".github\/scripts\/gone\.mjs", which does not exist/,
+  );
+
+  // An entry point in a form the walk does not model must fail rather than be
+  // dropped: a shell script has no `.mjs` graph, and silently omitting it would
+  // reinstate exactly the under-reporting #2948 is about. `shell: bash`, which
+  // every composite `run:` step carries, is not an invocation and must not trip
+  // it.
+  assert.throws(
+    () =>
+      laneHarnessClosure({
+        workflow: 'wf.yml',
+        readFile: () => '- run: bash scripts/seed.sh',
+        fileExists: () => true,
+      }),
+    /runs "scripts\/seed\.sh" through a shell/,
+  );
+  assert.doesNotThrow(() =>
+    laneHarnessClosure({
+      workflow: 'wf.yml',
+      readFile: () => '      shell: bash\n      run: echo hello\n',
+      fileExists: () => true,
+    }),
+  );
+
+  assert.equal(resolveReference('.github/scripts/a.mjs', './lib/b.mjs'), '.github/scripts/lib/b.mjs');
+  assert.equal(resolveReference('.github/scripts/a.mjs', 'b.mjs'), '.github/scripts/b.mjs');
+  assert.equal(resolveReference('.github/scripts/lib/a.mjs', '../b.mjs'), '.github/scripts/b.mjs');
+  assert.equal(resolveReference('.github/workflows/w.yml', '.github/scripts/b.mjs'), '.github/scripts/b.mjs');
 });
 
 test('only the registry uses a semantic harness projection', () => {

--- a/.github/scripts/mutation-phases.mjs
+++ b/.github/scripts/mutation-phases.mjs
@@ -50,6 +50,8 @@
 //
 // node: builtins only — no npm deps, no setup-node needed.
 
+import { laneHarnessClosure } from './lib/lane-harness.mjs';
+
 // Every leg clears the same bar, and this is the only place a bar is declared.
 // `.gremlins.yaml` carries none: its former top-level `threshold-efficacy` was
 // a key gremlins never read, so the whole-repo floor it advertised for `just
@@ -619,20 +621,35 @@ export const PHASES = [
   },
 ];
 
-// Paths that change the LANE ITSELF rather than a single scope: the phase table,
-// the selector, the threshold gate, the workflow, gremlins' own config, and the
-// module graph every leg's `go test` links. Registry changes use a semantic
-// projection in mutation-matrix.mjs, so unrelated metadata does not spend a
-// full matrix while mutation-relevant edits still do. Just recipes are local
-// entry points and do not select CI mutation work.
+// The workflow this lane IS. Everything the lane executes is reachable from it,
+// so it is the one entry point the derivation below needs.
+export const MUTATION_LANE_WORKFLOW = '.github/workflows/mutation.yml';
+
+// Inputs the lane READS rather than executes, and which therefore appear in no
+// source graph: gremlins' own configuration, and the module graph every leg's
+// `go test` links and mutates. Declared, because nothing can derive them — and
+// short enough to review, which is the property the old hand-written harness
+// list lost the moment it grew past what a reader could hold.
+//
+// `.github/ci-lanes.json` is deliberately NOT here: registry changes go through
+// the semantic projection in mutation-matrix.mjs, so unrelated metadata does not
+// spend a full matrix while mutation-relevant edits still do. Just recipes are
+// local entry points and do not select CI mutation work.
+export const MUTATION_DATA_PATHS = ['.gremlins.yaml', 'go.mod', 'go.sum'];
+
+// Paths that change the LANE ITSELF rather than a single scope, and therefore
+// force the FULL matrix.
+//
+// DERIVED, not listed. The executed half comes from lane-harness.mjs walking
+// mutation.yml's own `node` steps and composite actions into the module graph
+// reachable from them; only the read-only data inputs above are declared. A
+// hand-written array is the shape that rots: `mutant-memory-guard.mjs` sat in
+// front of every leg's test binary, deciding each mutant's fate, and was absent
+// from the array for its whole life (cerberus #2948) — as were `lib/gh.mjs`,
+// `go-module-fetch.mjs`, `lib/registry.mjs` and the `setup-go` action. Deriving
+// makes "the runner gained a file" and "the harness set gained a path" the same
+// event instead of two, the second of which nobody performs.
 export const HARNESS_PATHS = [
-  '.github/workflows/mutation.yml',
-  '.github/scripts/mutation-phases.mjs',
-  '.github/scripts/mutation-matrix.mjs',
-  '.github/scripts/mutation-run.mjs',
-  '.github/scripts/gremlins-threshold.mjs',
-  '.github/scripts/lib/scope-gate.mjs',
-  '.gremlins.yaml',
-  'go.mod',
-  'go.sum',
+  ...laneHarnessClosure({ workflow: MUTATION_LANE_WORKFLOW }),
+  ...MUTATION_DATA_PATHS,
 ];


### PR DESCRIPTION
## The omission is real, and it is not alone

`mutation-phases.mjs` exported `HARNESS_PATHS` — "the paths that change the LANE ITSELF" — as a
hand-written array of nine entries. `mutation-matrix.mjs` runs the FULL 30-leg matrix when a PR's
diff hits one.

`.github/scripts/mutant-memory-guard.mjs` was not among them. It is the `go test -exec` supervisor
`mutation-run.mjs` interposes in front of **every** leg's test binary (`GOFLAGS=… -exec=<guard>`),
where it decides each mutant's fate: a mutant that breaches the per-mutant RSS ceiling is killed and
held so the compile+run backstop books it `TIMED OUT` — unadjudicated, in the denominator, credited
to nobody. Change the ceiling, the sampling interval, the hold (#2947 did exactly that) or the exit
path and every leg's numbers move.

Measured on this tree, against the pre-change array:

```
0/30   .github/scripts/mutant-memory-guard.mjs   — no changed path falls in any phase scope
0/30   .github/scripts/lib/gh.mjs                — no changed path falls in any phase scope
0/30   .github/scripts/go-module-fetch.mjs       — no changed path falls in any phase scope
0/30   .github/scripts/lib/registry.mjs          — no changed path falls in any phase scope
0/30   .github/actions/setup-go/action.yml       — no changed path falls in any phase scope
30/30  .github/scripts/mutation-run.mjs          — the lane's own harness changed
1/30   internal/chplan/plan.go                   — 1 of 30 phases scope a changed path
```

A PR editing only the guard selected nothing, `mutate` was skipped, and the `mutation` aggregator
reported green over work that never ran — the hollow green `mutation.yml`'s own header describes,
in the one file whose blast radius is the entire matrix.

## The audit: every file the lane executes, and why it is in or out

Walked from `mutation.yml` itself rather than from the array, because the array is what was wrong.

**In (all now selected; five of these were missing):**

| Path | Reached by | Why it changes every leg |
| --- | --- | --- |
| `.github/workflows/mutation.yml` | the lane | already listed |
| `.github/scripts/mutation-matrix.mjs` | `run: node …` | selection itself |
| `.github/scripts/mutation-phases.mjs` | import | the leg table and every floor |
| `.github/scripts/lib/scope-gate.mjs` | import | the diff → scope decision |
| **`.github/scripts/lib/gh.mjs`** | import (all four entry points) | the `git` diff selection reads, and the runner's own output path |
| **`.github/scripts/lib/lane-harness.mjs`** | import | the derivation below; a change to it changes the harness set |
| `.github/scripts/mutation-run.mjs` | `run: node …` | already listed |
| **`.github/scripts/mutant-memory-guard.mjs`** | spawned via `go test -exec` | per-mutant adjudication — the #2948 gap |
| `.github/scripts/gremlins-threshold.mjs` | `run: node …` | the efficacy verdict |
| **`.github/scripts/go-module-fetch.mjs`** | `run: node …` (and the `setup-go` warm step) | installs the binary every leg runs |
| **`.github/scripts/lib/registry.mjs`**, `lib/mirror.mjs` | import | that install's retry/mirror policy; a starved fetch is the #2903 accounting class |
| **`.github/actions/setup-go/action.yml`** | `uses: ./…` | pins the toolchain every mutant compiles under, same class as `go.mod` |
| `.gremlins.yaml`, `go.mod`, `go.sum` | declared | read, not executed — no scan can find them |

**Out, deliberately:**

- `.github/ci-lanes.json` — already covered by the semantic projection in `mutation-matrix.mjs`, so
  unrelated metadata does not spend a matrix while mutation-relevant edits still do. Unchanged, and
  still pinned by `only the registry uses a semantic harness projection`.
- **Every `*.test.mjs`, including the guard's own.** #2948's acceptance asks for the guard's test
  too; it is left out, and this is the one place this PR argues with the issue. A unit suite is not
  run by the lane and cannot change a single mutant's verdict, it is reachable from no entry point,
  and no existing harness entry's test selects either — so including it would not be "the same
  mechanism the other harness paths use", it would be a hand-added exception to a derived set, and
  it would spend all thirty legs to prove nothing on a test-only edit. The issue's real complaint —
  "a unit test of the supervisor is not a mutation run" — is answered by the guard *itself* now
  selecting the full matrix, which is what makes the lane re-adjudicate under it.
- `Justfile` / `just mutate` — a local entry point; it selects no CI work.
- Every other `.github/scripts/**` module (`compose-smoke-matrix.mjs`, `forbid-skip.mjs`,
  `coverage-aggregate.mjs`, `lib/golden-shards.mjs`, …) — the lane does not execute them.

## Derived, not gated

A hand-written list of paths is the shape that rots; adding the guard by hand would have fixed the
leaf and left the class. So the array stops being written. `lib/lane-harness.mjs` computes the set
from the artefacts that already state what the lane runs:

- entry points: the workflow's `node …` steps and its `uses: ./.github/actions/…` manifests, plus
  those manifests' own `node` steps (the `$GITHUB_WORKSPACE/…` spelling a composite action must use);
- edges: every string literal that is *entirely* a path ending in `.mjs` — the `import … from
  './lib/gh.mjs'` specifier, and equally the bare `'mutant-memory-guard.mjs'` the runner resolves
  against its own directory to hand to `go test -exec`.

Two precision choices carry their own tests. Anchoring on the `node` verb is what keeps a script a
comment merely **names** out of the graph — `mutation.yml`'s header points at
`compose-smoke-matrix.mjs` as a shape to compare against, and a looser scan would have adopted it.
Requiring the whole literal to be a path is what keeps prose (`throw new Error('… foo.mjs …')`) out.

Two things it refuses to guess at rather than getting quietly wrong: a `node` step naming a file that
does not exist throws, and an entry point in a form it does not model — a checked-in script run
through a shell, which has no module graph — throws too, naming the file, so the first one to appear
extends the model instead of silently shrinking the harness set.

`MUTATION_DATA_PATHS` (`.gremlins.yaml`, `go.mod`, `go.sum`) stays declared because nothing can
derive it, and stays reviewable because it is three lines.

## Proof it fires, and does not over-select

`node --test .github/scripts/mutation-matrix.test.mjs` — 45 tests, 45 pass. Four are new:

- **`HARNESS_PATHS is derived from what the lane executes, one entry per edge kind`** — one assertion
  per traversal (workflow root, `run: node` step, static import, `-exec` spawn literal, composite
  action + its `$GITHUB_WORKSPACE` script + that script's transitive import, and the derivation
  module itself), each naming a file reachable *only* through that edge, plus
  `HARNESS_PATHS === [...closure, ...MUTATION_DATA_PATHS]` so nothing can be appended by hand
  between them.
- **`a diff touching only the per-mutant memory guard selects the FULL matrix`** — 30/30 with the
  exact reason string.
- **`the derived harness set does not over-select scripts the lane never runs`** — four real scripts
  the lane does not execute select 0 legs (one of them the comment-named `compose-smoke-matrix.mjs`),
  no `*.test.mjs` is in the set, two named test suites select 0, and `internal/chplan/plan.go` still
  selects exactly `['phase1']`.
- **`laneHarnessClosure walks node steps, composite actions and module literals`** — the walk's own
  units on a synthetic tree, including the negative cases (a script named only in a comment, a `.mjs`
  filename inside a prose string), the missing-file throw, the shell-entry-point throw, and
  `shell: bash` not tripping it.

**Both directions of the bar, run here:**

- *Fires now, did not before.* Reverting `HARNESS_PATHS` to the pre-change nine-entry array and
  re-running the suite gives `tests 45 / pass 43 / fail 2` — the two failures being
  `HARNESS_PATHS is derived from what the lane executes` and
  `a diff touching only the per-mutant memory guard selects the FULL matrix`. Restored: 45/45.
- *Does not over-select.* `internal/chplan/plan.go` → `['phase1']`, docs-only → 0,
  `mutant-memory-guard.test.mjs` → 0, `compose-smoke-matrix.mjs` → 0.

Also run clean: `mutation-matrix.mjs verify` (30 phases, table sound), `doc-refs.mjs`,
`assert-gate-suites-wired.mjs` (76 suites, all invoked — no new suite file, the tests live in the
already-wired `mutation-matrix.test.mjs`), `ci-lane-contract.mjs`, `CHECK=all forbid-skip.mjs`,
markdownlint on the README. No workflow YAML changed, so no `actionlint` delta beyond the pre-push
hook's own clean run.

Closes #2948

🤖 Generated with [Claude Code](https://claude.com/claude-code)
