### PR TITLE
test(logql): re-measure the three sub-floor mutation legs and kill seven lsyntax survivors

### DIFF
--- a/internal/logql/lsyntax/ast.go
+++ b/internal/logql/lsyntax/ast.go
@@ -212,6 +212,9 @@ func validateRegexpParser(re string) error {
 			return fmt.Errorf("duplicate extracted label name '%s'", n)
 		}
 		seen[n] = struct{}{}
+		// `named--` here is indistinguishable from `named++`: the only
+		// read is the `named == 0` post-condition below, and +k and -k
+		// are zero for the same k. See ast_test.go's NOT KILLABLE footer.
 		named++
 	}
 	if named == 0 {

--- a/internal/logql/lsyntax/ast_test.go
+++ b/internal/logql/lsyntax/ast_test.go
@@ -537,3 +537,14 @@ func TestMustNewVectorAggregationExpr_UnparseableTopKParameter(t *testing.T) {
 		t.Fatal("Selector() = nil error, want an invalid-parameter error")
 	}
 }
+
+// NOT KILLABLE — documented, not defended by a test.
+//
+// ast.go:218:8 (INCREMENT_DECREMENT, validateExtractedLabels' `named++` ->
+// `named--`). `named` is initialised to 0, is written only by this statement,
+// and is read only by the `if named == 0` post-condition three lines later.
+// The original leaves it at +k and the mutant at -k, where k is the number of
+// non-empty entries in regex.SubexpNames(); both are zero exactly when k is
+// zero, so the post-condition returns errMissingCapture for the same inputs.
+// k is bounded by regex.NumSubexp()+1, so the mutant cannot wrap into 0
+// either. Re-applied and confirmed to survive the whole package suite.

--- a/internal/logql/lsyntax/dotted_labels_test.go
+++ b/internal/logql/lsyntax/dotted_labels_test.go
@@ -352,6 +352,58 @@ func TestNormalizeLokiDottedLabels(t *testing.T) {
 			in:   `{a='b.c', d.e="f"}`,
 			want: `{a='b.c', d_e="f"}`,
 		},
+		// The four cases below pin the two ASCII class predicates the
+		// walker delegates to — lokiIsIdentStart and lokiIsIdentCont —
+		// at each of their range ENDPOINTS. Every other test in this
+		// file starts its label keys with a mid-range letter, so a
+		// CONDITIONALS_BOUNDARY mutant narrowing a class by exactly
+		// one character changed nothing any assertion could see.
+		//
+		// A byte excluded from lokiIsIdentStart cannot open a label
+		// key, so the walker's default arm writes it verbatim and
+		// clears keyStart — the whole dotted token then survives
+		// unrewritten, which is the observable difference below.
+		{
+			// lokiIsIdentStart's `b <= 'z'`. A boundary mutant `b <
+			// 'z'` drops the last lower-case letter from the class,
+			// so `z.a` stops being a rewritable key.
+			name: "ident_start_lowercase_upper_endpoint",
+			in:   `{z.a="1"}`,
+			want: `{z_a="1"}`,
+		},
+		{
+			// lokiIsIdentStart's `b >= 'A'`. A boundary mutant `b >
+			// 'A'` drops the first upper-case letter.
+			name: "ident_start_uppercase_lower_endpoint",
+			in:   `{A.b="1"}`,
+			want: `{A_b="1"}`,
+		},
+		{
+			// lokiIsIdentStart's `b <= 'Z'`, which carries TWO
+			// survivors: the boundary mutant `b < 'Z'` and the
+			// negation mutant `b > 'Z'`. Both make `Z` fail the
+			// upper-case arm, and `Z != '_'` finishes the predicate
+			// false either way.
+			name: "ident_start_uppercase_upper_endpoint",
+			in:   `{Z.b="1"}`,
+			want: `{Z_b="1"}`,
+		},
+		{
+			// lokiIsIdentCont's `b >= '0'`. A boundary mutant `b >
+			// '0'` stops the token scan at the digit, so
+			// lokiConsumeIdentToken emits the bare `a` and the
+			// rest of the dotted token falls through verbatim.
+			name: "ident_cont_digit_lower_endpoint",
+			in:   `{a0.b="1"}`,
+			want: `{a0_b="1"}`,
+		},
+		{
+			// lokiIsIdentCont's `b <= '9'`, the other digit
+			// endpoint, mutated to `b < '9'`.
+			name: "ident_cont_digit_upper_endpoint",
+			in:   `{a9.b="1"}`,
+			want: `{a9_b="1"}`,
+		},
 	}
 
 	for _, tc := range cases {

--- a/internal/logql/lsyntax/lexer.go
+++ b/internal/logql/lsyntax/lexer.go
@@ -548,6 +548,11 @@ func (l *lexer) trySuffix(num string, runeOK func(rune) bool, parse func(string)
 	j := l.pos
 	for j < len(l.src) {
 		b := l.src[j]
+		// `>` here would be indistinguishable from `>=`: the forms differ
+		// only at b == 0x80, and durationRune — the only runeOK this
+		// function is ever passed — rejects both the U+FFFD that byte
+		// decodes to and U+0080 itself. See lexer_test.go's NOT KILLABLE
+		// footer.
 		if b >= utf8.RuneSelf {
 			rr, sz := utf8.DecodeRuneInString(l.src[j:])
 			if runeOK(rr) {
@@ -595,6 +600,9 @@ func (l *lexer) tryBytesSuffix(num string) (uint64, int, bool) {
 func (l *lexer) scanIdent() {
 	start := l.pos
 	j := l.pos
+	// `<=` here would be indistinguishable from `<`: the extra iteration
+	// decodes the empty string to utf8.RuneError, which isIdentPart
+	// rejects. See lexer_test.go's NOT KILLABLE footer.
 	for j < len(l.src) {
 		r, sz := utf8.DecodeRuneInString(l.src[j:])
 		if isIdentPart(r) {
@@ -688,6 +696,13 @@ func (l *lexer) isFunction() bool {
 		if strings.HasPrefix(strings.ToLower(l.src[i:]), kw) {
 			end := i + len(kw)
 			// Ensure it's a whole word.
+			//
+			// Neither `<=` nor `>=` here is distinguishable from `<`, and
+			// neither is `break` in place of the `continue` below: "by" and
+			// "without" share no prefix, so a source matching one cannot
+			// match the other and the `continue` only ever reaches the
+			// trailing `return false`. See lexer_test.go's NOT KILLABLE
+			// footer.
 			if end < len(l.src) {
 				r, _ := utf8.DecodeRuneInString(l.src[end:])
 				if isIdentPart(r) {

--- a/internal/logql/lsyntax/lexer_test.go
+++ b/internal/logql/lsyntax/lexer_test.go
@@ -479,3 +479,54 @@ func TestLexScanIdentToEOF(t *testing.T) {
 		t.Errorf("final token kind = %v, want tkEOF", toks[1].kind)
 	}
 }
+
+// NOT KILLABLE — documented, not defended by a test.
+//
+// Five surviving mutants in lexer.go for which no input distinguishes the
+// mutated form from the original. Each was re-applied and the whole package
+// suite re-run to confirm it survives rather than merely lacking a test.
+//
+// lexer.go:556:8 (CONDITIONALS_BOUNDARY, `if b >= utf8.RuneSelf` -> `>`). The
+// two forms differ on exactly one byte value, b == 0x80, which is not a legal
+// UTF-8 start byte. The original decodes it to (utf8.RuneError, 1) and asks
+// runeOK; the mutant falls through to the ASCII arm and asks
+// runeOK(rune(0x80)). trySuffix has ONE call site (scanNumber) and it passes
+// durationRune, whose nine accepted runes are 'n', 'u', 'µ', 'm', 's', 'h',
+// 'd', 'w' and 'y' — neither U+FFFD nor U+0080 is among them, so both forms
+// take their break with j unchanged, and the ASCII arm's other two tests
+// (isDigit, `b == '.'`) are false for 0x80 as well.
+//
+// lexer.go:606:8 (CONDITIONALS_BOUNDARY, scanIdent's `for j < len(l.src)` ->
+// `<=`). The extra iteration the mutant admits runs at j == len(l.src), where
+// `l.src[j:]` is the empty string — a legal slice, not a panic — and
+// utf8.DecodeRuneInString("") returns (utf8.RuneError, 0). isIdentPart
+// rejects U+FFFD (it is neither ASCII alphanumeric nor `_`, it is not below
+// utf8.RuneSelf, and unicode.IsLetter and unicode.IsDigit are both false for
+// it), so the mutant breaks at the same j the original's loop condition
+// stopped at.
+//
+// lexer.go:706:11 (CONDITIONALS_BOUNDARY `if end < len(l.src)` -> `<=`, and
+// CONDITIONALS_NEGATION -> `>=`). `end` is `i + len(kw)` guarded by a
+// HasPrefix on `l.src[i:]`, so end > len(l.src) is unreachable and both
+// mutants differ from the original only over end <= len(l.src).
+//   - At end == len(l.src) the `<=` and `>=` forms enter the whole-word
+//     check, which decodes the empty string to (utf8.RuneError, 0) and finds
+//     it is not an identPart, so no `continue` fires and control reaches the
+//     same trailing scan the original reached by skipping the block.
+//   - At end < len(l.src) the `>=` form skips the whole-word check. When
+//     l.src[end] does not begin an identPart the original skips it too. When
+//     it does, the original `continue`s (see the entry below, which shows
+//     that is indistinguishable from returning false) while the mutant runs
+//     the trailing scan — but that scan advances only over ' ', '\t', '\n'
+//     and '\r', none of which is an identPart, so it stops at end and returns
+//     `l.src[end] == '('`. '(' is not an identPart either, so the mutant
+//     returns false as well.
+//
+// lexer.go:709:6 (INVERT_LOOPCTRL, isFunction's whole-word `continue` ->
+// `break`). The `continue` advances to the next keyword in
+// []string{"by", "without"}, and reaching it means HasPrefix already matched
+// the current one. "by" and "without" share no prefix, so a source that
+// matched one cannot match the other; and a `continue` out of the last
+// element ends the loop outright. The `continue` is therefore equivalent to
+// `break` for every input, both falling through to the function's trailing
+// `return false`.

--- a/internal/logql/lsyntax/string_test.go
+++ b/internal/logql/lsyntax/string_test.go
@@ -230,8 +230,29 @@ func TestGroupingString(t *testing.T) {
 func TestBinOpExprString_IncompleteNodeRendersEmpty(t *testing.T) {
 	// An errored BinOpExpr carries nil legs (mustNewBinOpExpr stashes the
 	// error instead of the operands); String must not dereference them.
-	if got := (&BinOpExpr{Op: OpTypeAdd}).String(); got != "" {
-		t.Errorf("String() on a leg-less BinOpExpr = %q, want %q", got, "")
+	//
+	// The guard is a DISJUNCTION over the two legs, so it has to be
+	// exercised with each leg nil ON ITS OWN as well as with both. A
+	// both-nil case alone leaves `SampleExpr == nil || RHS == nil`
+	// indistinguishable from `&&`: with the conjunction the guard still
+	// fires when both are nil, and String still returns "". A half-built
+	// node is the shape that separates them — under `&&` the guard is
+	// false and String dereferences the nil leg.
+	present := mustNewLiteralExpr("1", false)
+	cases := []struct {
+		name string
+		expr *BinOpExpr
+	}{
+		{"both legs nil", &BinOpExpr{Op: OpTypeAdd}},
+		{"left leg nil", &BinOpExpr{Op: OpTypeAdd, RHS: present}},
+		{"right leg nil", &BinOpExpr{Op: OpTypeAdd, SampleExpr: present}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := tc.expr.String(); got != "" {
+				t.Errorf("String() on a leg-less BinOpExpr = %q, want %q", got, "")
+			}
+		})
 	}
 }
 

--- a/internal/qlcommon/capture_participation_test.go
+++ b/internal/qlcommon/capture_participation_test.go
@@ -513,3 +513,25 @@ func firstNonEmptyDisagreement(re *regexp.Regexp, inputs []string) string {
 	}
 	return ""
 }
+
+// NOT KILLABLE — documented, not defended by a test.
+//
+// capture_participation.go:181:38 (CONDITIONALS_BOUNDARY, the SECOND `>=` in
+// mutuallyExclusive's `if shared >= len(a.spine) || shared >= len(b.spine)`
+// -> `>`). The loop above increments `shared` only while it is below BOTH
+// lengths, so shared <= min(len(a.spine), len(b.spine)) on exit and
+// `shared > len(b.spine)` is unsatisfiable: the mutant simply deletes that
+// half of the guard.
+//
+// The case it deletes is shared == len(b.spine) < len(a.spine) — b's spine is
+// a strict prefix of a's. Both spines are root-down paths through one parse
+// tree that agreed at every step, so a.spine[shared] is the node reached by
+// walking the WHOLE of b's spine, which is b's own capture. Its Op is
+// syntax.OpCapture, never syntax.OpAlternate, so the `fork.node.Op !=
+// syntax.OpAlternate` disjunct on the next line is true and `||` short-
+// circuits before `b.spine[shared]` is ever indexed. The mutant returns
+// false without panicking, which is the answer the deleted guard gave.
+//
+// Killing it would need a captureShape whose spine puts an OpAlternate one
+// step past a prefix of another shape's spine — a value captureShapes cannot
+// build, since the spine is that node's own ancestry.

--- a/internal/qlcommon/capture_probe_boundary_test.go
+++ b/internal/qlcommon/capture_probe_boundary_test.go
@@ -372,6 +372,52 @@ func TestReadBackPlanAcceptsCarrierZero(t *testing.T) {
 	}
 }
 
+// negativeCarrierWalks is how many times the walk below is repeated. The
+// defect it pins is a control-flow one over a Go map, whose iteration order
+// is randomised per range statement, so a single call observes the wrong
+// order only about half the time. Each repeat is an independent draw, which
+// puts a false pass below 2^-64 — small enough that a green run is evidence
+// rather than luck, and cheap enough (one Compile per repeat) to sit in the
+// unit lane.
+const negativeCarrierWalks = 64
+
+// TestReadBackPlanSkipsNegativeCarriersWithoutStopping pins that the
+// synthetic negative-sibling requests planCaptureProbes mints — the
+// descending -1, -2, … keys at capture_probe.go:151 — are SKIPPED by the
+// positive-probe walk rather than ending it.
+//
+// probeNames is keyed by carrier and mixes both kinds, so a walk that
+// stopped at the first negative key would drop every positive carrier the
+// map happened to order after it. Nothing about that is deterministic: the
+// resulting plan would be correct or silently missing a probe depending on
+// Go's per-range map seed, which is why the assertion is a repeated one.
+func TestReadBackPlanSkipsNegativeCarriersWithoutStopping(t *testing.T) {
+	t.Parallel()
+
+	original, err := regexp.Compile(`(?P<orig>x)`)
+	if err != nil {
+		t.Fatalf("regexp.Compile: %v", err)
+	}
+	positive := probeNamePrefix + "0"
+	negative := probeNamePrefix + "1"
+	probed := `(?P<` + positive + `>(?P<orig>x))(?P<` + negative + `>y)?`
+	// Carrier 1 is a real capture group; -1 is a synthetic negative-sibling
+	// request, whose probe index reaches the plan through negativeNames.
+	probeNames := map[int]string{1: positive, -1: negative}
+
+	for i := range negativeCarrierWalks {
+		plan, ok := readBackPlan(original, probed, probeNames, nil)
+		if !ok {
+			t.Fatalf("walk %d: readBackPlan declined a plan mixing positive and negative carriers", i)
+		}
+		if at, planned := plan.probeOf[1]; !planned || compileNames(t, probed)[at] != positive {
+			t.Fatalf("walk %d: probeOf = %v, want carrier 1 mapped to the %q group — a walk that "+
+				"stops at a negative carrier drops whatever the map ordered after it",
+				i, plan.probeOf, positive)
+		}
+	}
+}
+
 // TestReadBackPlanRejectsInvalidRewriteMetadata pins each part of the
 // compiler-backed proof that turns inserted source spans into capture indexes.
 // Every case is a rewrite that looks plausible to one weaker check but cannot
@@ -467,6 +513,20 @@ func TestCaptureGroupsRejectMissingShapes(t *testing.T) {
 	_, _, _, ambiguous, ok := groups.expressibleCarriers([]int{1})
 	if ok || ambiguous != 1 {
 		t.Fatalf("expressibleCarriers with no shape = ambiguous %d, ok %v; want 1, false", ambiguous, ok)
+	}
+
+	// An unclassified carrier must be SKIPPED, not treated as the end of
+	// the search: the carriers after it are still classifiable and still
+	// have to be reported. With a single unknown carrier the two readings
+	// are indistinguishable — both end the loop — so the mixed list below
+	// is what separates them.
+	mixed := captureGroups{shapes: map[int]captureShape{
+		2: {nullable: true},
+		3: {nullable: true},
+	}}
+	cleared := mixed.unclearedCarriers([]int{1, 2, 3})
+	if len(cleared) != 1 || cleared[0] != 2 {
+		t.Fatalf("unclearedCarriers past an unknown carrier = %v, want [2]", cleared)
 	}
 }
 
@@ -671,3 +731,72 @@ func TestCarriersNeedingProbesIgnoresUnsharedNames(t *testing.T) {
 		t.Error("no rewrite was planned, so the unshared name ended the walk early")
 	}
 }
+
+// NOT KILLABLE — documented, not defended by a test.
+//
+// Seven surviving mutants in capture_probe.go. Each was re-applied and the
+// whole package suite re-run to confirm it survives rather than merely
+// lacking a test.
+//
+// capture_probe.go:293:4 (INVERT_LOOPCTRL, `break` after `fork = i` ->
+// `continue`). The loop descends the spine, so `break` leaves `fork` at the
+// DEEPEST syntax.OpAlternate and `continue` leaves it at the SHALLOWEST. With
+// zero or one alternation on the spine the two agree outright. With k >= 2 at
+// depths i1 < … < ik, the original's fork is ik and `shape.spine[:ik]` still
+// contains i1; the mutant's fork is i1 and `shape.spine[i1+1:]` still
+// contains i2. skippable reports true for syntax.OpAlternate
+// (capture_participation.go:126), so whichever way round it lands, one of the
+// two spine scans below rejects the carrier and the function returns
+// (nil, false). Both loops are side-effect-free and run before anything else.
+//
+// capture_probe.go:310:13 (CONDITIONALS_BOUNDARY, `for parent >= 0 && …` ->
+// `parent > 0`). Index 0 is the virtual whole-pattern group, minted with
+// parent -1 at regex_source_scan.go:57, so the two forms differ only at
+// parent == 0 with no alternations on that group: the original steps to -1
+// and returns at the `parent < 0` check, while the mutant leaves the loop
+// holding 0. It then reaches branchContaining(groups[0], …), which returns
+// (sourceSpan{}, false) for a group with no alternations; the ignored bool
+// leaves `branch` the zero span, captureShapes(src[0:0]) parses the empty
+// pattern into an empty map, `known` is false, and the next guard returns
+// (nil, false) — the answer the original returned one branch earlier.
+//
+// capture_probe.go:319:12 (INVERT_LOGICAL, `if !known ||
+// !branchShape.unconditional` -> `&&`). When `known` is false branchShape is
+// the zero captureShape, so `!branchShape.unconditional` is true and the
+// conjunction is true as well: the mutant declines exactly where the original
+// does. The only state that separates them is known && !unconditional, and it
+// is not reachable through this package's own producers. A conditional
+// ancestor of the carrier INSIDE the branch text is also an ancestor of the
+// carrier below the fork in the whole-pattern parse, and the spine scan four
+// branches above already returned (nil, false) for any skippable node in
+// `shape.spine[fork+1:]`. Go's parser can lift a common prefix out of the
+// branches, but two syntax.OpCapture nodes never compare equal (their Cap
+// differs), so the carrier is never inside the factored prefix, and removing
+// a prefix cannot introduce a skippable ancestor.
+//
+// capture_probe.go:336:33 (CONDITIONALS_BOUNDARY, `return siblings,
+// len(siblings) > 0` -> `>= 0`). Reaching this line requires
+// groups[parent].alternations to be non-empty, so appending bodyEnd to it
+// yields at least two spans. They are consecutive disjoint ranges over the
+// parent's body, so at most one of them equals `branch` and is skipped, and
+// every other span either appends a sibling or returns (nil, false) at the
+// parse / matchesEmpty check above. len(siblings) is therefore never 0 here
+// and the two comparisons agree.
+//
+// capture_probe.go:376:28 (CONDITIONALS_BOUNDARY, the sort's
+// `ordered[i].start < ordered[j].start` -> `<=`). The line is guarded by
+// `if ordered[i].start != ordered[j].start`, and on unequal operands `<` and
+// `<=` are the same function.
+//
+// capture_probe.go:378:25 (CONDITIONALS_BOUNDARY, `ordered[i].end >
+// ordered[j].end` -> `>=`). Reached only when the two starts are equal.
+// `ordered` is filled through the `named map[sourceSpan]string` seen-check
+// above, so its elements are pairwise distinct spans; equal starts therefore
+// force unequal ends, where `>` and `>=` agree. sort.SliceStable never calls
+// less(i, i).
+//
+// capture_probe.go:496:13 (CONDITIONALS_BOUNDARY, branchContaining's
+// `if offset < bar` -> `<=`). `offset` is always a group's `open`, the byte
+// index of a '(', and `bar` is the byte index of a '|'. One byte cannot be
+// both, so offset == bar is unreachable and the two comparisons agree on
+// every offset a caller can supply.

--- a/internal/qlcommon/label_replace_test.go
+++ b/internal/qlcommon/label_replace_test.go
@@ -355,3 +355,15 @@ func TestEmptyCapturesReplacement(t *testing.T) {
 		})
 	}
 }
+
+// NOT KILLABLE — documented, not defended by a test.
+//
+// label_replace.go:770:10 (CONDITIONALS_BOUNDARY, extractRef's
+// `for end < len(rest)` -> `<=`). The extra iteration the mutant admits runs
+// at end == len(rest), where `rest[end:]` is the empty string — a legal
+// slice — and utf8.DecodeRuneInString("") returns (utf8.RuneError, 0).
+// utf8.RuneError is U+FFFD, category So: unicode.IsLetter and unicode.IsDigit
+// are both false for it and it is not '_', so the body breaks before reaching
+// `end += size`. The mutant therefore leaves `end` where the original's loop
+// condition stopped it, and every read below — the empty-name check, `name`,
+// `width`, the closing-brace check — sees the same value.

--- a/internal/qlcommon/regex_source_scan_test.go
+++ b/internal/qlcommon/regex_source_scan_test.go
@@ -185,3 +185,28 @@ func TestPlanCaptureProbesDeclines(t *testing.T) {
 		})
 	}
 }
+
+// NOT KILLABLE — documented, not defended by a test.
+//
+// Four surviving mutants in regex_source_scan.go, all of them in a `switch`
+// that is the ENTIRE body of its enclosing `for`.
+//
+// regex_source_scan.go:77:5 (INVERT_LOOPCTRL, scanSourceGroups' `\Q` arm) and
+// regex_source_scan.go:155:5 (INVERT_LOOPCTRL, skipCharClass' POSIX-name arm)
+// are the same shape. `break` inside a `switch` leaves the SWITCH, not the
+// loop. In both functions the switch is the whole loop body and the `for` has
+// an empty post statement, so the byte after the switch is the loop's closing
+// brace: `break` re-evaluates the loop condition exactly as `continue` does,
+// and it skips the `i += 2` / `j++` that follows in the same case arm for the
+// same reason. The two forms have identical control flow on every input.
+//
+// regex_source_scan.go:142:11 (CONDITIONALS_BOUNDARY, skipCharClass'
+// `if j+1 >= len(src)` -> `>`) and regex_source_scan.go:142:8
+// (ARITHMETIC_BASE, the same line's `j+1` -> `j-1`). The guard sits inside
+// `for j < len(src)`, so j+1 <= len(src) and j-1 <= len(src)-2: neither
+// `j+1 > len(src)` nor `j-1 >= len(src)` can hold, and both mutants delete
+// the guard rather than move it. The deleted case is a trailing `\` at
+// j == len(src)-1, where the original returns (0, false) directly. The
+// mutants instead run `j += 2`, which puts j past len(src), ends the loop,
+// and falls through to the function's own `return 0, false` — the identical
+// pair of values, with no character-class terminator found either way.


### PR DESCRIPTION
## What this is

#2917's arithmetic has been restated three times, each time against a tree that had moved
under it, so this branch **measures first and writes code second**. #2947 is the reason it
had to be redone again: the gate now reads

```
efficacy = (killed + runTimedOut) / (killed + lived + timedOut + runTimedOut)
```

A run-phase timeout — the test binary's own `-timeout` watchdog firing, printed by the binary
itself — is a detection. The context-deadline backstop, which covers compile as well as run and
which is also where a memory-reaped mutant lands, is not.

## Measured, not computed from an older table

Push-to-main run [33657879957](https://github.com/tsouza/cerberus/actions/runs/33657879957) at
`d1ea58549`, plus this PR's own run for `phase4-logql-lsyntax`, whose leg on that main run was
cancelled by the next push to `main`.

| leg | killed | lived | TIMED OUT | RUN TIMED OUT | attempted | efficacy | floor |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | --- |
| `phase4-traceql-ast` | 221 | 6 | 2 | 6 | 235 | **96.60%** | clears |
| `phase4-logql-lsyntax` (before) | 369 | 13 | 17 | 8 | 407 | 92.63% | below |
| `phase4-logql-lsyntax` (this PR) | 376 | 6 | 17 | 8 | 407 | **94.35%** | below |
| `phase5-qlcommon` (before) | 281 | 14 | 9 | 8 | 312 | 92.63% | below |
| `phase5-qlcommon` (this PR) | 282 | 13 | 9 | 8 | 312 | **92.95%** | below |

`phase4-traceql-ast` clears with no new test at all, and its job is green on that run.
#2942 took it to 221/235 = 94.04% under the old formula; six of its eight timeouts are
run-phase, and crediting them is the whole difference. Its six remaining survivors are exactly
the six equivalents #2942 proved at the site — nothing else survives the leg.

## The load-bearing check: the 42 timeouts are NOT all run-phase

#2944 proved all 42 timeouts on `lsyntax` / `qlcommon` are genuine non-termination — eleven were
applied by hand under a 2 GiB cgroup cap and none terminated; **six died at the memory cap in
3–14s, five ran to the watchdog**. The tempting reading was that #2947 moves all 42 into the
numerator. It does not, and the measured split is the same shape as that hand-run 6:5:

| leg | TIMED OUT (backstop, credited to nobody) | RUN TIMED OUT (credited) |
| --- | ---: | ---: |
| `phase4-logql-lsyntax` | 17 | 8 |
| `phase5-qlcommon` | 9 | 8 |
| total | **26** | **16** |

That is the design working, not a misclassification. `mutant-memory-guard.mjs` reaps a mutant
that breaches the per-mutant RSS ceiling and then HOLDS, precisely so no exit status of its own
can be read as a verdict — so it reaches the compile+run backstop and is credited to nobody.
Thirteen of `lsyntax`'s seventeen backstop timeouts are `INCREMENT_DECREMENT` mutants of
`l.pos++` in the token loop and its four operator scanners, which append to `l.toks` every
iteration: memory runaways by construction. Raising that ceiling so the watchdog fires first
would convert them, which is exactly why it is not touched here.

## What this branch lands

### Nine kills, each proven individually

Apply the mutation → the new assertion FAILS; revert → it PASSES.

| leg | site | mutation | what distinguishes it |
| --- | --- | --- | --- |
| lsyntax | `dotted_labels.go:217:24` | `b <= 'z'` → `b < 'z'` | `{z.a="1"}` — `z` stops opening a label key |
| lsyntax | `dotted_labels.go:217:38` | `b >= 'A'` → `b > 'A'` | `{A.b="1"}` |
| lsyntax | `dotted_labels.go:217:50` | `b <= 'Z'` → `b < 'Z'` | `{Z.b="1"}` |
| lsyntax | `dotted_labels.go:217:50` | `b <= 'Z'` → `b > 'Z'` | `{Z.b="1"}`, same input |
| lsyntax | `dotted_labels.go:221:35` | `b >= '0'` → `b > '0'` | `{a0.b="1"}` — the token scan truncates at the digit |
| lsyntax | `dotted_labels.go:221:47` | `b <= '9'` → `b < '9'` | `{a9.b="1"}` |
| lsyntax | `string.go:239:25` | `\|\|` → `&&` | a `BinOpExpr` with exactly ONE nil leg |
| qlcommon | `label_replace.go:385:4` | `continue` → `break` | an unknown carrier FOLLOWED by classifiable ones |
| qlcommon | `capture_probe.go:259:4` | `continue` → `break` | a `probeNames` map holding both a negative and a positive carrier |

Every existing case in `dotted_labels_test.go` opens its label keys with a mid-range letter, so
a character class missing one endpoint was invisible to all of them. The `BinOpExpr` guard is a
disjunction and the only test on it built a node with BOTH legs nil, which `&&` also renders as
`""`. Both qlcommon mutants turn a SKIP into a STOP, and both existing tests passed a list with
a single skippable element, where `continue` and `break` do the same thing.

`capture_probe.go:259:4` is a map walk, so `break` drops whatever Go's randomised iteration
order put after the negative carrier — correct or silently wrong depending on the per-range
seed. Its assertion is repeated 64 times, which also stops it being a survivor a later run kills
by luck (it was LIVED on run 33653736094 and KILLED on 33657879957, with no code change
between them).

### Nineteen equivalents, proven and documented

Six on `lsyntax` and thirteen on `qlcommon`. Each was re-applied and the whole package suite
re-run to confirm it SURVIVES rather than merely lacking a test, and each is written down with
its argument in a `NOT KILLABLE` footer beside the code it belongs to, following the convention
PR #2942 established for `internal/traceql/ast`. The `lsyntax` six are also pointed at from the
source sites.

The measurement confirms the reading exactly. On this PR's own run
[33663429982](https://github.com/tsouza/cerberus/actions/runs/33663429982), `phase4-logql-lsyntax`
reports six survivors and `phase5-qlcommon` reports thirteen — in both cases the documented
equivalents, at the line and column their footers cite, and nothing else.

## The ceilings, and what would move them

With every survivor that is not a proven equivalent killed — which this branch has now done —
the two remaining legs are AT their ceilings:

| leg | detected | attempted | ceiling | needs | short by |
| --- | ---: | ---: | ---: | ---: | ---: |
| `phase4-logql-lsyntax` | 384 | 407 | **94.35%** | 387 | 3 |
| `phase5-qlcommon` | 290 | 312 | **92.95%** | 297 | 7 |

Their permanent cost is 5.65% and 7.05% of the leg respectively — equivalents plus the backstop
timeouts — against a 5% margin. Covering the remaining `NOT COVERED` mutants does not close
either gap: `lsyntax` would need 53 of them both covered and killed to move 94.35% to 95%, and
most of its 68 are `case` expressions in a `switch`, which Go's cover profile attributes to a
block starting after the clause's colon (`lexer.go:269` opens its block at column 56), so no
test can reach them.

This leaves #2917 open on its two capped legs, with the ceilings now measured rather than
projected.

## Constraints

No threshold lowered, no denominator shrunk, no file excluded, no `include_files` narrowed.
Four scoring-inflation mechanisms were removed from this lane so the numbers stop lying;
reaching the bar by narrowing what is measured would undo all of it. An honest red is the better
outcome.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
